### PR TITLE
Corpan World Radio - try native implementation over browser

### DIFF
--- a/corpan/corpan-app/src-tauri/ios/project.yml
+++ b/corpan/corpan-app/src-tauri/ios/project.yml
@@ -55,6 +55,18 @@ targets:
           - UIInterfaceOrientationLandscapeRight
         UIBackgroundModes:
           - audio
+        # ATS exception for media playback. The World Radio pack streams
+        # public Icecast/Shoutcast radio, which is overwhelmingly delivered
+        # over plain HTTP — WKWebView's `<audio>` element refuses HTTP under
+        # default ATS. `NSAllowsArbitraryLoadsForMedia` is Apple's blessed
+        # opt-out for streaming-media apps; `NSAllowsArbitraryLoadsInWebContent`
+        # belt-and-braces for `<audio>` HLS playlists fetched through web
+        # content. We do NOT enable the global `NSAllowsArbitraryLoads`
+        # because no other corpan code path needs cleartext HTTP — keeping
+        # it scoped to media is friendlier to App Review.
+        NSAppTransportSecurity:
+          NSAllowsArbitraryLoadsForMedia: true
+          NSAllowsArbitraryLoadsInWebContent: true
         # CFBundleShortVersionString + CFBundleVersion are auto-injected by
         # Tauri from tauri.conf.json's `version` field. Don't hardcode them
         # here or they'll drift.

--- a/corpan/packs/world-radio/CHANGELOG.md
+++ b/corpan/packs/world-radio/CHANGELOG.md
@@ -8,6 +8,16 @@ Conventions: `corpan/CHANGELOGS.md`.
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-04-30
+### Fixed
+- Drop stations the current platform can't decode before they reach the list:
+  AAC+/AACP on Android Chromium WebView, OGG/Vorbis on Apple, and plain-HTTP
+  streams on iOS / iPadOS (ATS).
+
+## [0.3.0] - 2026-04-30
+### Changed
+- Radio next follow-up (#235): version bump for the post-Narrators polish.
+
 ## [0.2.2] - 2026-04
 ### Changed
 - Bundled with the readers + radio polish pass.

--- a/corpan/packs/world-radio/manifest.json
+++ b/corpan/packs/world-radio/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "world_radio",
   "name": "World Radio",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Tune into live internet radio in any of Corpan's languages — your stack first, the world right after",
   "entry": "dist/app.js",
   "styles": [
@@ -9,5 +9,5 @@
   ],
   "entryType": "script",
   "sdkVersion": "0.1.0",
-  "devRevision": "2026-04-30T23:40:43.118Z"
+  "devRevision": "2026-05-01T00:33:49.888Z"
 }

--- a/corpan/packs/world-radio/src/api/radioBrowser.ts
+++ b/corpan/packs/world-radio/src/api/radioBrowser.ts
@@ -244,6 +244,64 @@ function isPlayable(s: RadioStation): boolean {
 }
 
 /**
+ * Per-platform playability filter, applied at display time (not cache time)
+ * so the same cache works across devices. Returns false for stations whose
+ * codec or URL scheme is known-broken on the current platform.
+ *
+ * Today's known gaps:
+ *   - **Android Chromium WebView** fails to decode HE-AAC v2 / `audio/aacp`
+ *     (raw AAC v1 still works). Codec strings to drop: "AAC+", "AACP".
+ *   - **iOS / iPadOS WKWebView** enforces App Transport Security: plain
+ *     HTTP streams fail unless the host app declares an ATS exception.
+ *     Many Icecast/Shoutcast servers run over HTTP; until the host's
+ *     `NSAllowsArbitraryLoadsForMedia` ships in a new app version, drop
+ *     stations whose only URL is HTTP. Once the host change ships, this
+ *     filter line is a no-op for HTTPS-only stations and only the codec
+ *     filter remains.
+ *   - **iOS / Safari** doesn't decode Vorbis (commonly labelled "OGG" in
+ *     the Radio Browser codec field). iOS 17.4+ added Opus-in-WebM but
+ *     not Vorbis-in-Ogg. Drop "OGG"/"VORBIS" on Apple platforms.
+ *
+ * Once the native streaming plugin (PR 2 — ExoPlayer/AVPlayer) lands, this
+ * filter narrows further or goes away entirely.
+ */
+const ANDROID_UNPLAYABLE_CODECS = new Set(["AAC+", "AACP"])
+const APPLE_UNPLAYABLE_CODECS = new Set(["OGG", "VORBIS"])
+
+function isHttpOnly(s: RadioStation): boolean {
+  const a = (s.url_resolved || "").toLowerCase()
+  const b = (s.url || "").toLowerCase()
+  // True only if every URL we know is plain HTTP (not https, not file, etc.).
+  // If either URL is HTTPS we'll happily try that one.
+  if (a && a.startsWith("https://")) return false
+  if (b && b.startsWith("https://")) return false
+  return Boolean(a || b)
+}
+
+export function isPlayableOnPlatform(s: RadioStation): boolean {
+  if (typeof navigator === "undefined") return true
+  const ua = navigator.userAgent
+  const codec = s.codec.toUpperCase()
+
+  if (/Android/i.test(ua)) {
+    if (ANDROID_UNPLAYABLE_CODECS.has(codec)) return false
+  }
+
+  // Apple: covers iPhone, iPad, iPod (WKWebView in the app) and macOS Safari
+  // when running in the bundled app shell. Browser-dev mode on macOS also
+  // matches; that's fine — Mac Safari has the same Vorbis gap, and HTTP
+  // streams work in dev mode anyway since browsers don't enforce ATS.
+  if (/iPhone|iPad|iPod|Macintosh/i.test(ua)) {
+    if (APPLE_UNPLAYABLE_CODECS.has(codec)) return false
+    // ATS gate — only block on iOS-family devices. macOS's bundled Safari
+    // permits HTTP for legacy reasons; iOS WKWebView blocks it by default.
+    if (/iPhone|iPad|iPod/i.test(ua) && isHttpOnly(s)) return false
+  }
+
+  return true
+}
+
+/**
  * Split the comma-separated `tags` field into clean lowercase tokens.
  * Drops empties, dedupes, and trims whitespace.
  */

--- a/corpan/packs/world-radio/src/views/stationList.ts
+++ b/corpan/packs/world-radio/src/views/stationList.ts
@@ -14,6 +14,7 @@
 import { displayName } from "../api/languageMap"
 import {
   getStationsByLanguage,
+  isPlayableOnPlatform,
   parseTags,
   type RadioStation,
 } from "../api/radioBrowser"
@@ -446,8 +447,13 @@ export function createStationListView(opts: {
   function loadStations() {
     void (async () => {
       try {
-        const stations = await getStationsByLanguage(opts.radioName)
+        const raw = await getStationsByLanguage(opts.radioName)
         if (disposed) return
+        // Drop stations whose codec is known-broken on the current platform
+        // (e.g., AAC+/AACP on Android Chromium WebView). Filter at display
+        // time, not cache time, so the same localStorage cache works across
+        // devices.
+        const stations = raw.filter(isPlayableOnPlatform)
         allStations = stations
 
         // Compute popular threshold (top-decile clickcount) for the badge.


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Filter unsupported stations per platform
  - Block `AAC+`/`AACP` on Android
  - Block `OGG`/`VORBIS` on Apple
  - Exclude HTTP-only streams on iOS

- Apply filtering at list render time
  - Preserve shared cached station data

- Enable iOS ATS media exceptions
  - Allow HTTP radio playback in WKWebView


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cache["Shared station cache"]
  filter["isPlayableOnPlatform filter"]
  list["Filtered station list"]
  ios["iOS ATS media exceptions"]
  playback["Improved in-app playback"]

  cache -- "loaded at display time" --> filter
  filter -- "keeps only supported streams" --> list
  ios -- "allows HTTP media requests" --> playback
  list -- "reduces broken playback attempts" --> playback
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>radioBrowser.ts</strong><dd><code>Add platform-specific station playability checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/world-radio/src/api/radioBrowser.ts

<ul><li>Added <code>isPlayableOnPlatform</code> for runtime platform filtering<br> <li> Defined Android codec exclusions: <code>AAC+</code> and <code>AACP</code><br> <li> Defined Apple codec exclusions: <code>OGG</code> and <code>VORBIS</code><br> <li> Added <code>isHttpOnly</code> helper to reject iOS HTTP-only streams</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/237/files#diff-80a52a8c4e23eae912f5113b367ed0bca9659396c716b7f94a152b8444a53cc6">+58/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stationList.ts</strong><dd><code>Filter station results before rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/world-radio/src/views/stationList.ts

<ul><li>Imported <code>isPlayableOnPlatform</code> into the station list view<br> <li> Filtered fetched stations before assigning <code>allStations</code><br> <li> Kept filtering at display time to preserve cross-device cache reuse</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/237/files#diff-53bd3d6113dc92d8897c4e5ad4e7e3e5f20dfce9d7916466d183ba6e22c3e7a1">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>project.yml</strong><dd><code>Allow iOS HTTP media playback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/corpan-app/src-tauri/ios/project.yml

<ul><li>Added <code>NSAppTransportSecurity</code> settings for media playback<br> <li> Enabled <code>NSAllowsArbitraryLoadsForMedia</code> for HTTP radio streams<br> <li> Enabled <code>NSAllowsArbitraryLoadsInWebContent</code> for web-fetched media<br> <li> Scoped ATS relaxation to media instead of global arbitrary loads</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/237/files#diff-039f3618cb555cd64a69e622261324fc786a40f8995c95e03b817b0e031483c2">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

