### PR TITLE
Corpán post 0.12.0 assets artifacts

### DIFF
--- a/corpan/APP_STORE_DESCRIPTION_0_12_0.md
+++ b/corpan/APP_STORE_DESCRIPTION_0_12_0.md
@@ -1,0 +1,34 @@
+**Pure Learning.** Quiet, private, ad-free language study from a small independent team.
+
+Corpán is the continuous evolution of language learning.
+
+Our principles:
+
+• **Private.** No accounts, no tracking, no data collection. Your study stays on your device.
+• **Offline.** Your sentence library works without a network. Audio works offline too if you have offline voices installed. Travel, fly, study off-grid.
+• **Quiet.** No ads, ever. No streaks, no badges, no nagging notifications.
+• **Curated.** Every sentence is hand-picked. Phrases real people actually say, weighted A1–B2 for daily life, travel, and work.
+• **Yours.** Set your native language and study from your perspective, not "from English."
+
+Many ways to study, all in one app:
+
+• **Phrase book.** Tap any sentence to hear it spoken in clear native voices. Filter by topic and CEFR level.
+• **Audiobooks.** Read full books in your target language with sentence-by-sentence narration and instant translation. Free and premium titles.
+• **World Radio.** Tune in to live stations from anywhere on the planet — true native streaming, lock-screen controls, background playback.
+• **Games.** Recognize Chinese characters with **Hanzipan**. Run, jump, and learn in 3D with **Hover Runner**.
+• **And new experiences ship all the time** — delivered through Packs, our modular system for adding games, books, readers, and learning modes without bloating the core app.
+
+Learn many languages at once, or focus on just one. Switch your primary language any time. Currently practiced in:
+
+Arabic, Bengali, Chinese (Simplified), Chinese (Traditional), Danish, Dutch, English, Finnish, French, German, Greek, Gujarati, Hebrew, Hindi, Hungarian, Indonesian, Italian, Japanese, Kannada, Korean, Malay, Marathi, Norwegian, Persian, Polish, Portuguese (Brazil), Punjabi (Gurmukhi), Punjabi (Shahmukhi), Russian, Spanish, Swahili, Swedish, Tamil, Telugu, Thai, Turkish, Urdu, and Vietnamese.
+
+The interface, onboarding, and settings are fully localized in every supported language.
+
+Build with us:
+
+Corpán is open at the edges. Our Packs SDK lets creators build their own language-learning experiences — powered by the same curated corpus, native TTS, and native streaming — and ship them inside Corpán. Join the small team building the language-learning app we always wanted.
+
+Start learning with Corpán today.
+
+- Terms of Use (EULA): https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+- Privacy Policy: https://encorpora.io/privacy

--- a/corpan/APP_STORE_WHATS_NEW_0_12_0.md
+++ b/corpan/APP_STORE_WHATS_NEW_0_12_0.md
@@ -1,0 +1,37 @@
+**Corpán 0.12.0 — a big one.**
+
+A whole new way to study, nine new languages, and the kind of polish that turns a good app into the one you open every day.
+
+**World Radio: native streaming.**
+
+Tune in to live radio in your target language from anywhere on the planet. The stream now plays outside the browser, with lock-screen and Control Center transport, true background playback, and live station metadata. Plays through your headphones, your car, your AirPlay speakers, your kitchen.
+
+**Nine new languages.**
+
+Welcome to Corpán: Hebrew (with nikkud), Greek, Swahili, Swedish, Finnish, Dutch, Norwegian, Danish, and Malay. The interface is fully localized in each one, the corpus is translated end-to-end, and Hebrew and Greek now support romanization.
+
+**Discover Packs.**
+
+A curated first-run panel after onboarding gets you straight into the things that make Corpán shine: our two flagship audiobook readers (Earthgate Reader, Stargate Reader), a 3D learning game (Hover Runner), and our Chinese character studio (Hanzipan). One tap to install.
+
+**A tighter corpus.**
+
+We re-curated every sentence in the bundled library. The corpus is leaner and more useful — weighted toward the A1–B2 phrases you'll actually say. Less noise, more signal.
+
+**A better first impression.**
+
+Onboarding polish across the board: RTL-aware arrows, language names shown in their own scripts on the primary-language picker, a cleaner welcome animation, and fixes to subtle spacing nits we've wanted to address for months.
+
+**Genuinely random.**
+
+Rapid taps used to cluster on the same handful of phrases. Fixed at the root. Every tap now gives you a truly random sentence from the matching pool.
+
+**Also in this release:**
+
+• A contextual intro tip the first time you open Settings → Stacks.
+• Localized language names throughout — no more raw codes in the picker.
+• Smoother handling of edge cases in your study history.
+
+Corpán keeps evolving. Thank you for studying with us — more coming soon.
+
+— The Corpán team

--- a/corpan/infra/MARKETING_ASSETS.md
+++ b/corpan/infra/MARKETING_ASSETS.md
@@ -1,0 +1,93 @@
+# Marketing assets — layout and workflow
+
+App Store / Play Store screenshots and App Previews live in S3, not git, so
+binaries don't bloat the repo and multiple agents/workstations can share them.
+
+- **Bucket**: `s3://corpan-assets/marketing/`  (region `us-east-2`)
+- **Local mirror**: `~/encorpora/marketing/`
+- **Sync up**:    `infra/sync-marketing-to-s3.sh`
+- **Sync down**:  `infra/hydrate-marketing.sh`
+
+Both scripts auto-source `~/Code/corpora/encorpora/.env` for AWS creds; you can
+also export `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` or set `AWS_PROFILE`.
+
+## Directory layout
+
+```
+marketing/
+  <platform>/                  # ios | android
+    <device>/                  # ipad-13 | iphone-6.9 | phone | tablet-10 | ...
+      <app-version>/           # 0.12.1, 0.13.0, ...
+        screenshots/
+          raw/                 # everything captured, archived by date
+            YYYY-MM-DD/
+              IMG_xxxx.PNG     # native filename from device
+              ...
+          final/               # curated set actually uploaded to the store
+            01-home.png
+            02-stargate-narration.png
+            ...
+        app-previews/
+          raw/
+            YYYY-MM-DD/
+              recording-N.mov
+          final/
+            01-stargate-reader.mov
+            02-world-radio.mov
+            03-pack-discovery.mov
+```
+
+## Axis conventions
+
+| Axis | Allowed values | Notes |
+|------|----------------|-------|
+| `platform` | `ios`, `android` | One per app store. |
+| `device` | `iphone-6.9`, `iphone-6.5`, `ipad-13`, `phone`, `tablet-7`, `tablet-10` | Matches the upload slot in App Store Connect / Play Console. iPhone 6.9" is now Apple's required baseline (replaced 6.5"); 6.5" only needed if shipping a fallback set. iPad 13" covers iPad Pro 12.9" (2732×2048) and 13" M4 (2752×2064). |
+| `app-version` | dotted semver from `corpan-app/src-tauri/tauri.conf.json` | Bump when the captured UI no longer reflects what's shipping. |
+| asset type | `screenshots`, `app-previews` | Both stores accept both kinds. |
+| `raw/` | full capture sessions, by date | Keep everything; cheap and traceable. |
+| `final/` | curated upload set, ordered names | `NN-slug.ext` so the order matches what the store displays. |
+
+## Capture sources by platform
+
+- **iOS, real device over USB** (preferred for App Store — uses real production
+  rendering): pull screenshots and screen-recordings from the Camera Roll via
+  `afcclient` (libimobiledevice). Example:
+  ```
+  UDID=$(idevice_id -l | head -1)
+  afcclient -u "$UDID" ls DCIM/100APPLE/
+  afcclient -u "$UDID" get DCIM/100APPLE/IMG_0051.PNG ./IMG_0051.PNG
+  ```
+  Stash under `marketing/ios/<device>/<version>/screenshots/raw/<YYYY-MM-DD>/`.
+- **iOS Simulator** (fallback when the right hardware isn't available, e.g. for
+  the iPad 13" slot when only an iPhone is to hand): `xcrun simctl io booted
+  screenshot out.png` and `xcrun simctl io booted recordVideo out.mov`.
+- **Android device over ADB**: `adb shell screencap -p > out.png` and
+  `adb shell screenrecord /sdcard/out.mp4`.
+
+## Capture specs (current as of 2026-05)
+
+- **iPad 13" screenshots**: 2064×2752 (M4) or 2048×2732 (12.9" Pro), portrait
+  or landscape. App Store Connect accepts either resolution for the 13" slot.
+- **iPhone 6.9" screenshots**: 1290×2796 (e.g. iPhone 16 Pro Max, native).
+- **App Previews**: 15–30 s, `.mov` or `.mp4` (H.264), no overlays/hands/
+  third-party content beyond what the user controls. Up to 3 per locale per
+  device size. Up to 10 screenshots per locale per device size.
+
+## Workflow
+
+1. Capture on device → screenshots land in Camera Roll, recordings in Photos.
+2. Pull to `marketing/<platform>/<device>/<version>/<asset-type>/raw/<YYYY-MM-DD>/`.
+3. Run `./infra/sync-marketing-to-s3.sh` to back up to S3.
+4. When ready to submit: curate the chosen set into the sibling `final/`
+   directory with `NN-slug.ext` names, re-run the sync, then upload `final/`
+   files to App Store Connect / Play Console.
+5. On a new workstation, run `./infra/hydrate-marketing.sh` to pull everything
+   back down.
+
+## Notes for the iPhone agent
+
+To add iPhone assets, mirror this exact layout under
+`marketing/ios/iphone-6.9/<app-version>/`. No changes to scripts or bucket
+needed — just create the directories and sync. If you also capture a 6.5"
+fallback set, use `marketing/ios/iphone-6.5/<app-version>/`.

--- a/corpan/infra/hydrate-marketing.sh
+++ b/corpan/infra/hydrate-marketing.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Download App Store / Play Store marketing assets from s3://corpan-assets/marketing/
+# to local disk. Use after a fresh clone or on a different workstation when
+# re-uploading to App Store Connect / Play Console.
+#
+# See `infra/MARKETING_ASSETS.md` for the directory layout convention.
+#
+# Prerequisites:
+#   - AWS CLI installed
+#   - AWS credentials available via one of:
+#       (a) ~/Code/corpora/encorpora/.env  containing AWS_ACCESS_KEY + AWS_SECRET_ACCESS_KEY
+#       (b) AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY exported in the shell
+#       (c) An aws-cli profile with access to corpan-assets (then call with AWS_PROFILE=...)
+#
+# Usage:
+#   ./corpan/infra/hydrate-marketing.sh
+
+set -euo pipefail
+
+MARKETING_DIR="${MARKETING_DIR:-${HOME}/encorpora/marketing}"
+S3_SRC="s3://corpan-assets/marketing/"
+S3_REGION="us-east-2"
+
+ENV_FILE="${ENV_FILE:-${HOME}/Code/corpora/encorpora/.env}"
+if [ -f "$ENV_FILE" ] && [ -z "${AWS_ACCESS_KEY_ID:-}" ]; then
+  set -a; . "$ENV_FILE"; set +a
+  export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-${AWS_ACCESS_KEY:-}}"
+fi
+
+mkdir -p "$MARKETING_DIR"
+
+echo "Downloading marketing assets from $S3_SRC ..."
+aws s3 sync "$S3_SRC" "$MARKETING_DIR" \
+  --region "$S3_REGION" \
+  --exclude '*' \
+  --include '*.png' --include '*.PNG' \
+  --include '*.jpg' --include '*.JPG' \
+  --include '*.jpeg' --include '*.JPEG' \
+  --include '*.heic' --include '*.HEIC' \
+  --include '*.mov' --include '*.MOV' \
+  --include '*.mp4' --include '*.MP4'
+
+echo "Done. Marketing assets in: $MARKETING_DIR"

--- a/corpan/infra/sync-marketing-to-s3.sh
+++ b/corpan/infra/sync-marketing-to-s3.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Upload App Store / Play Store marketing assets (screenshots + App Previews)
+# from local disk to s3://corpan-assets/marketing/.
+#
+# See `infra/MARKETING_ASSETS.md` for the directory layout convention.
+#
+# Prerequisites:
+#   - AWS CLI installed
+#   - AWS credentials available via one of:
+#       (a) ~/Code/corpora/encorpora/.env  containing AWS_ACCESS_KEY + AWS_SECRET_ACCESS_KEY
+#       (b) AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY exported in the shell
+#       (c) An aws-cli profile with access to corpan-assets (then call with AWS_PROFILE=...)
+#
+# Usage:
+#   ./corpan/infra/sync-marketing-to-s3.sh
+
+set -euo pipefail
+
+MARKETING_DIR="${MARKETING_DIR:-${HOME}/encorpora/marketing}"
+S3_DEST="s3://corpan-assets/marketing/"
+S3_REGION="us-east-2"
+
+ENV_FILE="${ENV_FILE:-${HOME}/Code/corpora/encorpora/.env}"
+if [ -f "$ENV_FILE" ] && [ -z "${AWS_ACCESS_KEY_ID:-}" ]; then
+  set -a; . "$ENV_FILE"; set +a
+  export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-${AWS_ACCESS_KEY:-}}"
+fi
+
+if [ ! -d "$MARKETING_DIR" ]; then
+  echo "Error: marketing directory not found: $MARKETING_DIR" >&2
+  exit 1
+fi
+
+echo "Syncing marketing assets to $S3_DEST ..."
+aws s3 sync "$MARKETING_DIR" "$S3_DEST" \
+  --region "$S3_REGION" \
+  --exclude '*' \
+  --include '*.png' --include '*.PNG' \
+  --include '*.jpg' --include '*.JPG' \
+  --include '*.jpeg' --include '*.JPEG' \
+  --include '*.heic' --include '*.HEIC' \
+  --include '*.mov' --include '*.MOV' \
+  --include '*.mp4' --include '*.MP4'
+
+echo "Done."


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add S3 marketing asset sync scripts

- Document asset layout and workflow

- Add App Store 0.12.0 description

- Add App Store 0.12.0 release notes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  local["Local marketing/ directory"]
  sync["sync-marketing-to-s3.sh"]
  s3["S3 corpan-assets/marketing/"]
  hydrate["hydrate-marketing.sh"]
  docs["MARKETING_ASSETS.md workflow"]
  store["App Store submission metadata"]

  local -- "upload assets" --> sync
  sync -- "syncs to" --> s3
  s3 -- "downloads from" --> hydrate
  hydrate -- "restores into" --> local
  docs -- "documents process for" --> local
  docs -- "supports" --> store
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hydrate-marketing.sh</strong><dd><code>Add S3 marketing asset download helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/infra/hydrate-marketing.sh

<ul><li>Adds a shell script to download marketing assets<br> <li> Syncs from <code>s3://corpan-assets/marketing/</code><br> <li> Auto-loads AWS credentials from <code>.env</code><br> <li> Filters downloads to image and video files</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/240/files#diff-aa0ec5604ff1353eb4e623e8bd8ae5775c0f494a5ba45cf4544fe31484229a05">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sync-marketing-to-s3.sh</strong><dd><code>Add S3 marketing asset upload helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/infra/sync-marketing-to-s3.sh

<ul><li>Adds a shell script to upload marketing assets<br> <li> Validates the local marketing directory exists<br> <li> Auto-loads AWS credentials from <code>.env</code><br> <li> Syncs only supported screenshot and preview formats</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/240/files#diff-cc7019cec005709b3060c76d8aac1d18c048dd4980c06bda0a9f89dd25a201a7">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>APP_STORE_DESCRIPTION_0_12_0.md</strong><dd><code>Add App Store description for 0.12.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/APP_STORE_DESCRIPTION_0_12_0.md

<ul><li>Adds App Store marketing description for <code>0.12.0</code><br> <li> Highlights privacy, offline, and ad-free principles<br> <li> Describes core study modes and Packs platform<br> <li> Includes supported languages and policy links</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/240/files#diff-13f7ee1da58df4c607bcd46ac8d25ed92af79fd8e8cda2bb415795ad3143bd7f">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>APP_STORE_WHATS_NEW_0_12_0.md</strong><dd><code>Add release notes for version 0.12.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/APP_STORE_WHATS_NEW_0_12_0.md

<ul><li>Adds App Store <code>What's New</code> copy<br> <li> Highlights World Radio and Packs discovery<br> <li> Lists nine new languages and onboarding polish<br> <li> Summarizes corpus and randomness improvements</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/240/files#diff-98f5ce9bf9341efdf8354cff438adb47a22006de162384d3155f5e19ed0f58a1">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MARKETING_ASSETS.md</strong><dd><code>Document marketing asset layout and workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/infra/MARKETING_ASSETS.md

<ul><li>Documents S3-backed marketing asset storage workflow<br> <li> Defines directory structure for platforms and devices<br> <li> Lists capture methods and current store specs<br> <li> Explains sync, curation, and workstation hydration steps</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/240/files#diff-27721e0cfee7d8cfedc760226db0cc46f07cc0d318c4ac15cda2bb1af8b8d166">+93/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

