### PR TITLE
further polish + tutomaton packaging

### DIFF
--- a/corpan/corpan-app/CHANGELOG.md
+++ b/corpan/corpan-app/CHANGELOG.md
@@ -7,6 +7,16 @@ Conventions: `corpan/CHANGELOGS.md`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Text-to-Speech setup: newly installed voices now appear on their own.** The
+  redesigned setup screen only refreshed its voice list on mount and on
+  `visibilitychange`, so a voice you just installed wouldn't show up until you
+  backed out of the screen and returned. The screen now lightly polls the
+  installed voices (every 3s while it's open) and refreshes the list only when
+  the voice set actually changed — so freshly installed voices surface
+  automatically, with zero re-renders in steady state.
+
 ### Changed
 
 - **Tighter, consistent top bar.** The home top bar (logo + gear) was puffier

--- a/corpan/corpan-app/src/components/OnboardingFinish.tsx
+++ b/corpan/corpan-app/src/components/OnboardingFinish.tsx
@@ -9,7 +9,7 @@ import { useSettingsStore } from "@/store/settings";
 import { useTranslation } from "react-i18next";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useState } from "react";
-import { Github, Youtube, Newspaper, Globe, Instagram, ExternalLink, Sparkles, Share2 } from "lucide-react";
+import { Github, Youtube, Newspaper, Globe, Instagram, ExternalLink, Sparkles, Share2, Heart } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { OnboardingShell } from "@/onboarding/OnboardingShell";
 import { usePaywallStore } from "@/store/paywall";
@@ -34,6 +34,7 @@ export function OnboardingFinish({ onAdvance, onBack }: OnboardingStepProps = {}
     const setOnboarded = useSettingsStore((s) => s.setOnboarded);
     const openPaywall = usePaywallStore((s) => s.openPaywall);
     const iapAvailable = useEntitlementStore((s) => s.iapAvailable);
+    const subscribed = useEntitlementStore((s) => s.subscription.active);
     const { t } = useTranslation();
 
     async function openExternal(url: string) {
@@ -101,8 +102,10 @@ export function OnboardingFinish({ onAdvance, onBack }: OnboardingStepProps = {}
             </p>
 
             <ul className="mt-6 grid w-full grid-cols-1 gap-3 sm:grid-cols-2">
-                {/* Soft join/support — opens the Plus sheet, framed as optional. */}
-                {iapAvailable ? (
+                {/* Soft join/support. Subscribers get a gracious, non-interactive
+                    thank-you chip instead of a button that would no-op against the
+                    paywall's "never nag subscribers" guard. */}
+                {iapAvailable && !subscribed ? (
                     <li className="sm:col-span-2">
                         <button
                             type="button"
@@ -124,6 +127,24 @@ export function OnboardingFinish({ onAdvance, onBack }: OnboardingStepProps = {}
                                 <ExternalLink size={16} className="shrink-0 text-muted-foreground transition group-hover:text-foreground" aria-hidden />
                             </div>
                         </button>
+                    </li>
+                ) : iapAvailable && subscribed ? (
+                    <li className="sm:col-span-2">
+                        <div className="w-full rounded-xl border border-purple-400/50 bg-gradient-to-br from-purple-500/[0.12] to-purple-500/[0.03] p-4 text-left">
+                            <div className="flex items-center gap-3">
+                                <span className="grid h-10 w-10 place-items-center rounded-lg bg-purple-500/15 text-purple-400">
+                                    <Heart size={20} className="fill-current" />
+                                </span>
+                                <div className="min-w-0 flex-1">
+                                    <div className="text-sm font-semibold text-foreground">
+                                        {t("onboarding.engage.subscribedTitle", { defaultValue: "You're a Corpanista" })}
+                                    </div>
+                                    <div className="mt-0.5 text-xs text-muted-foreground">
+                                        {t("onboarding.engage.subscribedDesc", { defaultValue: "Thank you for keeping Corpán ad-free and growing." })}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </li>
                 ) : null}
 

--- a/corpan/corpan-app/src/components/OnboardingTTSInstructions.tsx
+++ b/corpan/corpan-app/src/components/OnboardingTTSInstructions.tsx
@@ -108,6 +108,15 @@ function uniqBy<T>(arr: T[], key: (x: T) => string): T[] {
     return out;
 }
 
+/** Stable signature of a voice set, order-independent, for change detection. */
+function voicesSignature(list: ExtendedVoiceInfo[] | null): string {
+    if (!list) return "";
+    return list
+        .map((v) => `${v.id}|${v.language}`)
+        .sort()
+        .join(",");
+}
+
 function baseLang(tag: string) {
     const t = tag.toLowerCase();
     const i = t.indexOf("-");
@@ -202,6 +211,12 @@ export function OnboardingTTSInstructions({ onAdvance, onBack }: OnboardingStepP
     phaseRef.current = phase;
     const inFlightRef = useRef(false);
     const pendingRunRef = useRef(false);
+    // Latest voices snapshot for the polling effect to diff against without
+    // re-subscribing on every change. A dedicated guard prevents overlapping
+    // polls (native list_voices can be slow on Android).
+    const voicesRef = useRef<ExtendedVoiceInfo[] | null>(voices);
+    voicesRef.current = voices;
+    const pollInFlightRef = useRef(false);
 
     /**
      * Refresh voices + engine status. Returns whether the voices list was
@@ -366,6 +381,47 @@ export function OnboardingTTSInstructions({ onAdvance, onBack }: OnboardingStepP
         return () => window.clearTimeout(timer);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [phase.kind, voices]);
+
+    // Lightly poll the installed voices while the setup screen is open so a
+    // voice the user just installed appears on its own — without backing out
+    // and re-entering the screen. visibilitychange covers the clean
+    // return-from-Settings case, but iOS often surfaces a freshly downloaded
+    // voice a beat later (and without a visibility flip when the download
+    // happens in-app), so a gentle poll closes the gap. We only setVoices when
+    // the voice SET actually changed, so steady state causes zero re-renders
+    // (no audio/preview churn).
+    useEffect(() => {
+        if (phase.kind !== "ready") return;
+        let cancelled = false;
+        const interval = window.setInterval(async () => {
+            // Don't fight an in-flight diagnose, and don't stack polls.
+            if (inFlightRef.current || pollInFlightRef.current) return;
+            pollInFlightRef.current = true;
+            try {
+                const raw = await getVoices({});
+                if (cancelled) return;
+                const list = uniqBy(
+                    raw as ExtendedVoiceInfo[],
+                    (v) => `${v.id}|${v.language}`,
+                );
+                if (voicesSignature(list) !== voicesSignature(voicesRef.current)) {
+                    console.info(
+                        "[onboardingTTS] voice set changed on poll — refreshing list",
+                    );
+                    setVoices(list);
+                }
+            } catch (e) {
+                console.warn("[onboardingTTS] voice poll failed", e);
+            } finally {
+                pollInFlightRef.current = false;
+            }
+        }, 3000);
+        return () => {
+            cancelled = true;
+            window.clearInterval(interval);
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [phase.kind]);
 
     /* ---------- Rescue actions ---------- */
 

--- a/corpan/corpan-app/src/contentPacks/llmTypes.ts
+++ b/corpan/corpan-app/src/contentPacks/llmTypes.ts
@@ -7,7 +7,7 @@
  *      One per supported runtime; downloaded once per device; reused by
  *      every LLM-consuming pack on that device.
  *
- *   2. **Regular content packs** (e.g. `tutomaton-v1`) that consume the
+ *   2. **Regular content packs** (e.g. `tutomaton`) that consume the
  *      base via `dependsOn: ["llm-base-..."]`. These are NOT special
  *      catalog entries — they're regular packs that happen to use the
  *      LLM runtime, and they ship their own internal content management
@@ -112,7 +112,7 @@ export type TutomatonLanguageModule = {
 export type CatalogLlmPersona = TwoZipDownloadable & {
   id: string
   packType: "llm-persona"
-  /** Which pack + language this overlays (e.g. "tutomaton-v1:es"). */
+  /** Which pack + language this overlays (e.g. "tutomaton:es"). */
   baseRef: string
   character: string
   displayName: Record<string, string>

--- a/corpan/packs/tutomaton/CHANGELOG.md
+++ b/corpan/packs/tutomaton/CHANGELOG.md
@@ -5,6 +5,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-06-01 — Fix on-device black screen (inline manifest + prompts)
+
 ### Fixed
 - **Black screen on launch (on-device).** `mount()` fetched the pack manifest
   (and per-language prompt files) at runtime over the `corpan-pack://` scheme.

--- a/corpan/packs/tutomaton/CHANGELOG.md
+++ b/corpan/packs/tutomaton/CHANGELOG.md
@@ -5,6 +5,23 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **Black screen on launch (on-device).** `mount()` fetched the pack manifest
+  (and per-language prompt files) at runtime over the `corpan-pack://` scheme.
+  On device the WebView origin is `tauri://localhost` while the installed pack
+  is served from `corpan-pack://localhost`, so WebKit CORS-blocked the
+  cross-origin `fetch` ("Origin tauri://localhost is not allowed by
+  Access-Control-Allow-Origin" → "Load failed"), `mount()` rejected, and the
+  pack rendered a black void. It worked in `npm run dev` only because the pack
+  is served same-origin over http there (and routed via `/game-proxy`). Fix:
+  the manifest and all language prompt files (`system_prompt.txt`,
+  `grounding_instruction.txt` — the only files `languageManager` reads at
+  runtime) are now **inlined into the bundle at build time** (vite `define`,
+  see `vite.config.ts`), mirroring how the pack already inlines its logo and
+  how the reader packs receive host-preloaded data. Zero runtime cross-origin
+  fetches; the pack is fully self-contained / offline. RAG sqlite databases are
+  unaffected — they still install via the native `installModuleZip`.
+
 ## [0.3.0] - 2026-05-31 — Multi-source RAG architecture + en/fr/de/ja republish + phrase-pack bridge
 
 ### Added

--- a/corpan/packs/tutomaton/manifest.json
+++ b/corpan/packs/tutomaton/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "tutomaton",
   "name": "Tutomaton",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "entry": "dist/chat.js",
   "entryType": "module",
   "styles": [
@@ -725,7 +725,7 @@
     "supportsLanguageDownload": true,
     "supportsVoiceMode": true
   },
-  "devRevision": "2026-06-01T20:29:55.506Z",
+  "devRevision": "2026-06-01T20:36:34.588Z",
   "databases": {
     "tutomaton-es": "languages/es/data/spanish.sqlite3",
     "tutomaton-zh": "languages/zh/data/mandarin.sqlite3"

--- a/corpan/packs/tutomaton/manifest.json
+++ b/corpan/packs/tutomaton/manifest.json
@@ -725,7 +725,7 @@
     "supportsLanguageDownload": true,
     "supportsVoiceMode": true
   },
-  "devRevision": "2026-06-01T16:57:57.917Z",
+  "devRevision": "2026-06-01T20:29:55.506Z",
   "databases": {
     "tutomaton-es": "languages/es/data/spanish.sqlite3",
     "tutomaton-zh": "languages/zh/data/mandarin.sqlite3"

--- a/corpan/packs/tutomaton/src/chat.ts
+++ b/corpan/packs/tutomaton/src/chat.ts
@@ -63,6 +63,17 @@ function readPackBaseUrl(): string {
   }
 }
 
+// Build-time-inlined pack data (see vite.config.ts `define`). These replace
+// the old runtime `fetch("corpan-pack://…")` reads, which WebKit CORS-blocks
+// on-device (the WebView origin is `tauri://`, the installed pack is served
+// from `corpan-pack://`). Inlining keeps the pack fully offline / self-
+// contained — the established pattern here (cf. the base64 logo).
+declare const __TUTOMATON_MANIFEST_JSON__: string
+declare const __TUTOMATON_PROMPTS_JSON__: string
+
+const INLINED_PROMPTS: Record<string, { system: string; grounding: string }> =
+  JSON.parse(__TUTOMATON_PROMPTS_JSON__)
+
 function joinUrl(base: string, rel: string): string {
   if (!base) return rel
   const b = base.endsWith("/") ? base.slice(0, -1) : base
@@ -223,7 +234,9 @@ const PackModule: ContentPackModule = {
     const baseUrl = readPackBaseUrl()
     const packFetch = (rel: string) => fetch(proxied(joinUrl(baseUrl, rel)), { cache: "no-store" })
 
-    const manifest = (await packFetch("manifest.json").then((r) => r.json())) as {
+    // Manifest is inlined at build time — NO runtime fetch (CORS-blocked on
+    // device for the cross-origin `corpan-pack://` scheme). See chat.ts header.
+    const manifest = JSON.parse(__TUTOMATON_MANIFEST_JSON__) as {
       languages: LanguageRegistryEntry[]
       databases?: Record<string, string>
       universalSources?: import("./languageManager").SourceManifestEntry[]
@@ -309,7 +322,17 @@ const PackModule: ContentPackModule = {
           onProgress
         )
       },
-      loadModuleFile: async (code, rel) => packFetch(`languages/${code}/${rel}`).then((r) => r.text()),
+      // Prompts are inlined at build time (the only files languageManager
+      // reads). Serve them from the bundle — no cross-origin fetch. Any other
+      // path falls back to packFetch (works in http dev; not hit on device).
+      loadModuleFile: async (code, rel) => {
+        const p = INLINED_PROMPTS[code]
+        if (p) {
+          if (rel === "prompts/system_prompt.txt") return p.system
+          if (rel === "prompts/grounding_instruction.txt") return p.grounding
+        }
+        return packFetch(`languages/${code}/${rel}`).then((r) => r.text())
+      },
       // Universal sources (§7) — bundled in this pack ZIP, apply to every
       // target language. Currently: the phrase-pack bridge. Each one receives
       // pattern-A `helpers` carrying phrasePacks + queryPackDb at retrieve time.

--- a/corpan/packs/tutomaton/vite.config.ts
+++ b/corpan/packs/tutomaton/vite.config.ts
@@ -1,6 +1,35 @@
 import { defineConfig } from "vite"
 import path from "node:path"
-import { readFileSync, writeFileSync } from "node:fs"
+import { readFileSync, writeFileSync, readdirSync, existsSync } from "node:fs"
+
+// Inline the pack manifest + every language's prompt files INTO the bundle at
+// build time. The pack used to `fetch("corpan-pack://…/manifest.json")` (and
+// the prompt files) at runtime, but on-device the WebView is on `tauri://`
+// while the installed pack is served from the `corpan-pack://` origin — so
+// WebKit CORS-blocks the cross-origin fetch and `mount()` throws (black
+// screen). Inlining mirrors how this pack already inlines its logo and how the
+// reader packs receive host-preloaded data: zero runtime cross-origin fetches,
+// fully offline. Prompts total ~65 KB, manifest ~20 KB — trivial bundle cost.
+function readInlinedManifest(): string {
+  return readFileSync(path.resolve(__dirname, "manifest.json"), "utf8")
+}
+
+function readInlinedPrompts(): Record<string, { system: string; grounding: string }> {
+  const langsDir = path.resolve(__dirname, "languages")
+  const out: Record<string, { system: string; grounding: string }> = {}
+  for (const code of readdirSync(langsDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && !d.name.startsWith("_"))
+    .map((d) => d.name)) {
+    const sys = path.join(langsDir, code, "prompts/system_prompt.txt")
+    const grd = path.join(langsDir, code, "prompts/grounding_instruction.txt")
+    if (!existsSync(sys) && !existsSync(grd)) continue
+    out[code] = {
+      system: existsSync(sys) ? readFileSync(sys, "utf8") : "",
+      grounding: existsSync(grd) ? readFileSync(grd, "utf8") : "",
+    }
+  }
+  return out
+}
 
 // Bump manifest.devRevision on production builds so corpan-app picks up the
 // new bundle. Dev:corpan does this via its own watcher (see scripts/dev-corpan.mjs).
@@ -28,6 +57,11 @@ const updateManifestPlugin = () => {
 
 export default defineConfig({
   plugins: [updateManifestPlugin()],
+  define: {
+    // Embedded as JS string literals; parsed once at runtime (see chat.ts).
+    __TUTOMATON_MANIFEST_JSON__: JSON.stringify(readInlinedManifest()),
+    __TUTOMATON_PROMPTS_JSON__: JSON.stringify(JSON.stringify(readInlinedPrompts())),
+  },
   build: {
     outDir: "dist",
     emptyOutDir: true,

--- a/corpan/tools/llm-packs/publish.py
+++ b/corpan/tools/llm-packs/publish.py
@@ -9,7 +9,7 @@ Three subcommands:
                catalog's `llmPacks[]` array.
 
   pack       — a regular content pack that consumes the LLM runtime
-               (e.g. `tutomaton-v1`). Two-ZIP: preview + full. Goes into the
+               (e.g. `tutomaton`). Two-ZIP: preview + full. Goes into the
                catalog's `entries[]` array (same place as phrase packs).
                For Tutomaton, the shell ZIP *excludes* per-language modules
                under `languages/` — those ship separately via `language`.


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement, Documentation


___

### **Description**
- Fix on-device Tutomaton launch CORS

- Inline Tutomaton manifest and prompts

- Auto-refresh newly installed TTS voices

- Thank subscribed users during onboarding


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Tutomaton build"] -- "inlines" --> B["Manifest and prompts"]
  B -- "avoids" --> C["Runtime corpan-pack fetches"]
  C -- "fixes" --> D["On-device launch"]
  E["TTS setup"] -- "polls" --> F["Installed voices"]
  F -- "updates" --> G["Voice list"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>OnboardingFinish.tsx</strong><dd><code>Show subscriber thank-you chip on finish screen</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/265/files#diff-6c093addd14a393e8897d49495d6a132804695b9ca708d8e3dca85b63b0c0726">+24/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>OnboardingTTSInstructions.tsx</strong><dd><code>Poll installed voices during TTS setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/265/files#diff-ae092c1e9cb207c4eac44567d2989d9af663f5f34f1763bd030c2ece643925bc">+56/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chat.ts</strong><dd><code>Load Tutomaton manifest and prompts from bundle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/265/files#diff-4d4a20d8f79c852055712a47674de580cda1759d3c845742d3888980459cdbdf">+25/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>vite.config.ts</strong><dd><code>Inline manifest and prompts at build time</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/265/files#diff-e53fd23950b53fb730c03808b883d67c9282fa7f610583b1d3ffc1f34828a715">+35/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>manifest.json</strong><dd><code>Bump Tutomaton development revision timestamp</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/265/files#diff-51a40560ce04abc3b96b74d68966730ded6198e2da7e656aa9df771f10a2739c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document automatic TTS voice refresh fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/265/files#diff-fcd2aeaa88f0735613dd8b9388c69c41b43b9eec554f31f82c902937b33b9940">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document Tutomaton on-device CORS launch fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/265/files#diff-2fdaad4e15c4e5222d961f524dcf83ca2bdbcd644e03532e1004a7a31e3d47fa">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

