### PR TITLE
Fix Android whisper SIGILL on older arm64 CPUs

### DIFF
--- a/corpan/plugins/tauri-plugin-asr-native/android/build.gradle.kts
+++ b/corpan/plugins/tauri-plugin-asr-native/android/build.gradle.kts
@@ -40,4 +40,5 @@ android {
 dependencies {
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
+    implementation(project(":tauri-android"))
 }

--- a/corpan/plugins/tauri-plugin-stt/android/src/main/cpp/CMakeLists.txt
+++ b/corpan/plugins/tauri-plugin-stt/android/src/main/cpp/CMakeLists.txt
@@ -52,43 +52,17 @@ set(GGML_VULKAN            OFF CACHE BOOL "" FORCE)
 set(GGML_BLAS              OFF CACHE BOOL "" FORCE)
 set(GGML_CCACHE            OFF CACHE BOOL "" FORCE)
 
-# Match whisper.cpp's own `examples/whisper.android/lib/src/main/jni/whisper/CMakeLists.txt`
-# config for arm64-v8a: target ARMv8.2-A with two optional extensions:
-#
-#   +fp16     — hardware fp16 NEON ops. Without this the compiler
-#               defaults to armv8-a (no FP16) and ggml's fp16 vec_dot
-#               path emits NEON intrinsics that don't have a real
-#               instruction on the target — the root cause of the
-#               SIGSEGV in `ggml_vec_dot_f16` we saw on Snapdragon 8
-#               Elite during early Phase 1. With `+fp16` the kernels
-#               compile to the real fp16 NEON ops and run fast + stable
-#               across all cores.
-#
-#   +dotprod  — int8 dot-product (UDOT/SDOT) NEON ops. Gates the
-#               dotprod-accelerated `vec_dot_q4_0_q8_0`,
-#               `vec_dot_q5_0_q8_0`, `vec_dot_q8_0_q8_0` kernels in
-#               `ggml-cpu/arch/arm/quants.c` behind
-#               `__ARM_FEATURE_DOTPROD`. Without the flag those
-#               kernels #ifdef out and the scalar fallback runs ~2-4×
-#               slower per matmul. ARMv8.2-A extension, supported on
-#               every phone our `+fp16` target already covers
-#               (Cortex-A75+, all Snapdragon 8-series, etc. — ~2018+).
-#
-# Pair this with reading the high-performance CPU count on the Kotlin
-# side (see `WhisperCpuConfig.kt`) and passing it as `n_threads` so
-# workers stay pinned to perf cores. Workers spread across perf +
-# efficiency cores are the *other* part of the same crash family —
-# torn reads from memory that's been updated by a different cluster's
-# cache.
-#
-# Not enabled here: `+i8mm` (ARMv8.6-A int8 matrix multiply). Bigger
-# perf win for quantized models but only on Snapdragon 8 Gen 1+
-# (~2022 phones); enabling it in a single-variant build would SIGILL
-# on older devices. Defer until we either bump minSdk or wire ggml's
-# multi-variant runtime selection.
+# Keep the shipped arm64-v8a library on the ABI baseline. A previous
+# build used `-march=armv8.2-a+fp16+dotprod` globally to get faster ggml
+# kernels. That made generic code legal to compile with ARMv8.1+ LSE
+# atomics too; the release .so emitted `ldadd` inside
+# `ggml_graph_next_uid`, and older arm64 devices SIGILL before Kotlin can
+# catch or route around anything. arm64-v8a only guarantees ARMv8.0, so a
+# single packaged .so must stay at armv8-a. Fast fp16/dotprod/i8mm paths
+# need runtime-dispatched ggml CPU backend variants or a separately
+# gated library, not one high-ISA binary.
 if(ANDROID_ABI STREQUAL "arm64-v8a")
-    add_definitions(-DGGML_USE_CPU_AARCH64)
-    add_compile_options(-march=armv8.2-a+fp16+dotprod)
+    add_compile_options(-march=armv8-a)
 endif()
 
 # Pull in whisper.cpp source. Vendored under whisper.cpp/, gitignored.


### PR DESCRIPTION
### **User description**
## Summary
- build Android whisper JNI at the arm64-v8a ABI baseline instead of globally targeting armv8.2-a+fp16+dotprod
- document why fast fp16/dotprod paths need runtime dispatch rather than one high-ISA shipped binary
- add the missing tauri-android dependency to tauri-plugin-asr-native so release Kotlin compilation succeeds

## Verification
- ./gradlew :tauri-plugin-stt:externalNativeBuildDebug
- ./gradlew :tauri-plugin-stt:externalNativeBuildRelease
- ./gradlew :tauri-plugin-asr-native:compileReleaseKotlin
- npm run tauri -- android build --target aarch64 --apk --ci
- llvm-objdump confirmed release ggml_graph_next_uid now calls __aarch64_ldadd8_relax instead of executing ldadd directly; helper falls back to ldxr/stxr when LSE atomics are unavailable


___

### **PR Type**
Bug fix


___

### **Description**
- Target Android arm64 baseline for whisper

- Prevent older-device SIGILL from LSE atomics

- Add missing Tauri Android dependency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Android STT CMake"] --> B["Use armv8-a baseline"]
  B --> C["Avoid unsupported high-ISA instructions"]
  D["ASR Native Gradle"] --> E["Depend on tauri-android"]
  E --> F["Release Kotlin compilation succeeds"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.gradle.kts</strong><dd><code>Add missing Tauri Android dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/plugins/tauri-plugin-asr-native/android/build.gradle.kts

<ul><li>Adds <code>project(":tauri-android")</code> as an implementation dependency.<br> <li> Ensures the native ASR Android plugin can compile against Tauri <br>Android APIs.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/279/files#diff-5ec40628740c6368e10e16a8410464aed2a195f143ac3d892c2e82c8fdde1afc">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Target baseline arm64 for whisper JNI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/plugins/tauri-plugin-stt/android/src/main/cpp/CMakeLists.txt

<ul><li>Replaces high-ISA arm64 build targeting with <code>-march=armv8-a</code>.<br> <li> Keeps the packaged <code>arm64-v8a</code> whisper library on the Android ABI <br>baseline.<br> <li> Documents why fp16, dotprod, and i8mm paths need runtime dispatch or <br>gated libraries.<br> <li> Avoids release binaries emitting unsupported instructions such as <br><code>ldadd</code> on older CPUs.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/279/files#diff-f35fb36d414b786a71736a0c3d511c15e9c315f5e018c1eb1d3e7d69e2091d65">+10/-36</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

