### PR TITLE
Teletron: don't auto-end the chat on unmount; bind handlers before publishProfile

### DIFF
--- a/corpan/packs/teletron/CHANGELOG.md
+++ b/corpan/packs/teletron/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+- Fix async-penpal delivery losing messages when the recipient steps away by
+  exiting Teletron (Back / pack switch). The pack's `unmount` was sending
+  `chat-control { action: "ended" }` whenever the chat was active and the
+  partner was online — the server treated that as a deliberate end-of-chat
+  and ran `forgetAcceptedPair`, which also calls `outbox.removeForPair` and
+  drops every still-buffered envelope between the two players. Any later
+  message from the partner was then rejected at the accepted-pair guard.
+  Only the explicit End button and Block actions should send `ended`.
+- Bind room message handlers (especially `chatDeliver`) before calling
+  `publishProfile()` on every (re)join. The server's `profilePublish`
+  handler synchronously drains the outbox and sends each buffered
+  `chatDeliver` to the client; if `publishProfile()` ran before the
+  handler was bound, a hot reconnect could land the flushed messages
+  before the listener existed and silently drop them. Now matches the
+  server-side comment's stated invariant.
 - Fix the gray-square that rendered on the right side of speakable message
   bubbles: the speaker-icon CSS was using `polygon()` as a mask layer, which is
   a `clip-path` value and not a valid mask source — every browser dropped the

--- a/corpan/packs/teletron/src/main.ts
+++ b/corpan/packs/teletron/src/main.ts
@@ -1306,7 +1306,15 @@ async function mountTeletron(
     players.clear()
     profiles.clear()
     renderPeople()
-    publishProfile()
+    // Bind room message handlers BEFORE publishProfile(). The server's
+    // profilePublish handler synchronously drains the outbox and `client.send`s
+    // each buffered chatDeliver — the comment at PlazaRoom.ts profilePublish
+    // explicitly relies on "the client publishes its profile right after
+    // binding its message handlers." Publishing first leaves a window where
+    // the round-trip is the only thing protecting freshly-buffered messages
+    // from arriving before chatDeliver is registered; on a hot reconnect the
+    // server response can land in the same microtask and the message is
+    // dropped on the floor.
     const callbacks = getStateCallbacks(joined) as unknown as (
       target: unknown,
     ) => { players: { onAdd: (cb: (p: WirePlayer, key: string) => void) => () => void; onRemove: (cb: (p: WirePlayer, key: string) => void) => () => void } }
@@ -1388,6 +1396,9 @@ async function mountTeletron(
         if (parsed.success && !isBlocked(parsed.data.from)) enqueueReceive(parsed.data)
       }),
     )
+    // All handlers (especially chatDeliver) are bound — now signal readiness so
+    // the server flushes anything the outbox was holding for us.
+    publishProfile()
     // After the first successful join, return the user to a recent conversation.
     if (!restoredConversation) {
       restoredConversation = true
@@ -1466,7 +1477,14 @@ async function mountTeletron(
   return {
     unmount: () => {
       mounted = false
-      if (chatState === "active" && partnerOnline) sendControl("ended")
+      // Unmount fires when the user steps away (Back arrow → corpan:exit, pack
+      // switch, app background that tears the pack down) — NOT a deliberate
+      // end-of-chat. Sending `ended` here would forget the accepted pair on the
+      // server, which also drops every still-buffered envelope between this
+      // pair (forgetAcceptedPair → outbox.removeForPair) and rejects any future
+      // chat-send from the partner because the pair guard fails. That defeats
+      // the whole 24h living-link / async outbox design. Only the explicit End
+      // button and Block actions tear the link down.
       for (const dispose of roomDisposers.splice(0)) {
         try {
           dispose()


### PR DESCRIPTION
### **User description**
## Summary

Fixes the bug where User A's message to a stepped-away User B never
arrives even after B returns to Teletron, contradicting the 24h outbox
design just shipped in #281.

**Repro:** A and B are mid-chat (`chatState === "active"`, both online).
B taps the Back arrow → `corpan:exit` event → host unmounts the pack.
A sends another message. B comes back. A's message never shows up.

**Root cause #1 (the actual bug):** `main.ts` `unmount()` was sending
`chat-control { action: "ended" }` whenever the chat was active and the
partner was online. The server (`PlazaRoom.ts:490-493`) treats `ended`
as a deliberate end-of-chat and runs `forgetAcceptedPair`, which both
deletes the accepted pair **and** calls `outbox.removeForPair(a, b)`
(`PlazaRoom.ts:731`) — so every still-buffered envelope between A and B
is dropped on the spot. A's later `chat-send` is then rejected at the
accepted-pair guard (`PlazaRoom.ts:489`: `"rejected chat without
accepted invite"`) and never reaches the enqueue path. From A's side
the message looks sent; from B's side there's nothing to deliver on
return.

Fixed by removing the unmount-time `sendControl("ended")` entirely.
Unmount is "stepping away," not "ending the chat." Only the explicit
**End** button (`endOrDismissThread`) and **Block** actions tear the
link down — those callsites are unchanged.

**Root cause #2 (belt-and-braces):** In `bindRoom`, `publishProfile()`
was being called BEFORE the room message handlers were registered. The
server's `profilePublish` handler synchronously drains the outbox and
`client.send`s each buffered `chatDeliver`; the server-side comment at
that handler explicitly relies on _"the client publishes its profile
right after binding its message handlers."_ The pre-fix order worked
only because the network round-trip happened to land after handler
registration. On a hot reconnect that's not guaranteed, and a flushed
`chatDeliver` could arrive before its listener existed and get silently
dropped. Moved `publishProfile()` to after the handler block.

## How to confirm in production

Tail the EC2 container while reproducing:

```bash
aws ssm send-command --instance-ids i-03643bd4d40f07cae \
  --document-name AWS-RunShellScript \
  --parameters 'commands=["docker logs --tail=200 --since=10m corpan-presence-server | grep -E \"rejected chat|forgot|flushed\""]'
```

The smoking gun is `[plaza] rejected chat without accepted invite from <session>`
from A's send with no preceding `[plaza] flushed N buffered message(s)` on B's return.

## Test plan
- [ ] On two devices, A and B start a chat
- [ ] B taps Back (leaves Teletron via Back arrow, NOT the End button)
- [ ] A sends one or more new messages
- [ ] B reopens Teletron — the conversation auto-restores and the
      messages A sent while B was away land in B's transcript
- [ ] Cross-check the server log shows a `flushed N buffered message(s)`
      line on B's return, and NO `rejected chat without accepted invite`
      line during A's send
- [ ] Regression: tapping the explicit **End** button still tears down
      the conversation for both sides as before
- [ ] Regression: Block still drops the partner and clears the link


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Preserve async penpal links on unmount

- Register handlers before outbox flush

- Document delivery-loss fixes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Teletron unmount"] -- "keeps link alive" --> B["Server accepted pair"]
  C["Room rejoin"] -- "binds handlers first" --> D["chatDeliver listener"]
  D -- "then publishes profile" --> E["Outbox flush"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.ts</strong><dd><code>Preserve async chat delivery lifecycle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/teletron/src/main.ts

<ul><li>Moves <code>publishProfile()</code> after room message handler registration.<br> <li> Ensures <code>chatDeliver</code> is bound before server outbox flushing.<br> <li> Stops sending <code>chat-control</code> <code>ended</code> during pack unmount.<br> <li> Clarifies unmount as stepping away, not ending chat.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/282/files#diff-1ddb9bfc899117427b2971976bcd39dd8458b931c59a2b77d6a23691f991071b">+20/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document Teletron delivery loss fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/teletron/CHANGELOG.md

<ul><li>Documents the unmount-triggered message loss fix.<br> <li> Explains why only explicit End and Block send <code>ended</code>.<br> <li> Notes handler binding before <code>publishProfile()</code> on reconnect.<br> <li> Describes prevention of hot-reconnect dropped messages.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/282/files#diff-d1060f3eb9617be15bd90f19e0d33f2b8a3eb98cff539fe4cf246e5aa72cd49e">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

