### PR TITLE
Harden STT first-install model loading

### DIFF
--- a/corpan/corpan-app/package-lock.json
+++ b/corpan/corpan-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "corpan",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "corpan",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",

--- a/corpan/corpan-app/package.json
+++ b/corpan/corpan-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "corpan",
   "private": true,
-  "version": "0.17.1",
+  "version": "0.17.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/corpan/corpan-app/src-tauri/Cargo.lock
+++ b/corpan/corpan-app/src-tauri/Cargo.lock
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "corpan"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "futures-util",
  "reqwest 0.12.28",

--- a/corpan/corpan-app/src-tauri/Cargo.toml
+++ b/corpan/corpan-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corpan"
-version = "0.17.1"
+version = "0.17.2"
 description = "Language learning app"
 authors = ["you"]
 edition = "2021"

--- a/corpan/corpan-app/src-tauri/tauri.conf.json
+++ b/corpan/corpan-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "corpan",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "identifier": "com.corpora.corpan",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/corpan/corpan-app/src/contentPacks/types.ts
+++ b/corpan/corpan-app/src/contentPacks/types.ts
@@ -149,12 +149,12 @@ export type SttStatus = {
   availableMemoryMB?: number | null
   /** Total physical RAM on the device in MB. */
   physicalMemoryMB?: number | null
-  /** Set by the Android plugin on the first getStatus after a prior
+  /** Set by the native plugin on the first getStatus after a prior
    *  on-device whisper init crashed (uncatchable native SIGSEGV/abort in
    *  ggml model load). The native side wrote a breadcrumb before the crash
    *  and held it across the restart; the host's getStatus wrapper records
    *  it once into on-device analytics, then the field is cleared natively.
-   *  JSON string with `model`/`instanceOrdinal`/`instancesCreated`/`uptimeMs`. */
+   *  JSON string with native model-load context and timing fields. */
   priorInitCrash?: string | null
 }
 
@@ -400,8 +400,10 @@ export type SttApi = {
     problems: string[]
   }>
   /**
-   * Downloads a model from Hugging Face into the app's data dir, then
-   * verifies file integrity. Calls `onProgress` with `phase` ∈
+   * Downloads a model into the app's data dir, fsyncs/moves it into place,
+   * and verifies the ggml header plus tail readback. The expensive native
+   * init happens later in `prepare()`, under the runtime memory gate.
+   * Calls `onProgress` with `phase` in
    * `downloading | verifying | verified | failed`. Throws on failure.
    */
   installModel?: (

--- a/corpan/packs/pronunciation-coach/src/game.ts
+++ b/corpan/packs/pronunciation-coach/src/game.ts
@@ -76,6 +76,8 @@ type SttStatus = {
   availableMemoryMB?: number | null
   /** Total physical RAM on the device in MB. */
   physicalMemoryMB?: number | null
+  /** One-shot native-init crash breadcrumb from the previous process. */
+  priorInitCrash?: string | null
 }
 export type SttWordTiming = {
   word: string
@@ -260,17 +262,26 @@ const folderForMode = (mode: ModelMode): string => {
 const labelForMode = (mode: ModelMode): string => {
   return modelById(mode)?.label ?? mode
 }
-// prepare() is local-only — never downloads. First load on a fresh
-// device is dominated by CoreML compiling each .mlmodelc into an ANE
-// execution plan: on M-series iPad large-v3-turbo this is typically
-// 30–90 s the first time, 3–5 s after the ANE cache is warm. Bigger
-// models get a longer deadline; default 60 s for sub-300 MB variants.
+// prepare() is local-only — never downloads. Bigger whisper.cpp ggml
+// models can take a long time to map and initialize on-device, so they
+// get a longer deadline; default 60 s for smaller variants.
 const prepareTimeoutMs = (mode: ModelMode): number => {
   const m = modelById(mode)
   if (m && m.approxSizeMB >= 1000) return 180_000
   return 60_000
 }
 const TRANSCRIBE_TIMEOUT_MS = 90_000
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => window.setTimeout(resolve, ms))
+
+const postInstallSettleMs = (mode: ModelMode): number => {
+  const size = modelById(mode)?.approxSizeMB ?? 0
+  if (size >= 1200) return 5000
+  if (size >= 800) return 4000
+  if (size >= 500) return 2500
+  if (size >= 250) return 1250
+  return 400
+}
 
 const withTimeout = async <T>(
   p: Promise<T>,
@@ -886,7 +897,7 @@ export const mountGame = (
       </div>
 
       <div class="pc-footer">
-        Powered by WhisperKit · <span id="pc-footer-model">Standard</span> · on-device, iOS
+        Powered by whisper.cpp · <span id="pc-footer-model">Standard</span> · on-device
       </div>
     </div>
   `
@@ -1990,14 +2001,11 @@ export const mountGame = (
     else dispatchExit()
   })
 
-  // Re-prepare the saved-mode kit if it isn't currently loaded.
-  // Idempotent: if Swift's prepare hits its in-memory cache, returns
-  // immediately. The plugin's install path drops the previously-loaded
-  // kit before running its load test for a different model; if that
-  // install fails (or the user cancels mid-flight), the previous
-  // model's kit ends up nil'd in memory while its files and marker
-  // are still on disk. Calling this after any setup interaction
-  // restores the working state without requiring a JS-side guess
+  // Re-prepare the saved-mode native context if it isn't currently
+  // loaded. Idempotent: if prepare hits its in-memory cache, returns
+  // immediately. Install and unload paths can drop the previous native
+  // context while leaving its files and marker on disk; calling this
+  // after setup restores the working state without a JS-side guess
   // about what the plugin did internally.
   const ensureLoaded = async (mode: ModelMode): Promise<boolean> => {
     if (!stt?.prepare) return false
@@ -2166,7 +2174,7 @@ export const mountGame = (
       persist()
       renderModeButton()
       console.log(
-        `[pronunciation-coach] WhisperKit prepared: ${r.model} (${targetLabel})`
+        `[pronunciation-coach] Whisper prepared: ${r.model} (${targetLabel})`
       )
       hideOverlay()
       micBtn.disabled = false
@@ -2894,8 +2902,8 @@ export const mountGame = (
         // round-trip count.
         if (!stt?.validateModel) return
         for (const m of MODELS) {
-          // The currently-active model is installed by definition —
-          // WhisperKit has it loaded. Skip validateModel for it; the
+          // The currently-active model is installed by definition:
+          // the native context has it loaded. Skip validateModel for it; the
           // heuristic has been observed reporting "<model dir missing>"
           // for models that prepare() then loads successfully (the
           // fundamental bug that motivated this whole rebuild). We trust
@@ -2982,7 +2990,7 @@ export const mountGame = (
         setProgress(mode, 0, "Starting…")
 
         try {
-          await stt.installModel(
+          const installResult = await stt.installModel(
             {
               model: folderForMode(mode),
               downloadUrl: modelById(mode)?.downloadUrl,
@@ -3002,7 +3010,7 @@ export const mountGame = (
                 }
                 setProgress(mode, event.fraction ?? 0, label)
               } else if (event.phase === "verifying") {
-                setProgress(mode, 1, "Verifying files…")
+                setProgress(mode, 1, "Verifying download…")
               } else if (event.phase === "verified") {
                 setProgress(mode, 1, "Verified ✓")
               } else if (event.phase === "failed") {
@@ -3013,11 +3021,18 @@ export const mountGame = (
           if (disposed) return
           installed[mode] = true
           installing = null
-          setProgress(mode, 1, "Verified ✓")
-          setTimeout(() => {
-            cleanup()
-            resolve({ kind: "selected", mode })
-          }, 300)
+          const settleMs =
+            installResult.alreadyInstalled ? 0 : postInstallSettleMs(mode)
+          if (settleMs > 0) {
+            setProgress(mode, 1, "Finalizing…")
+            await delay(settleMs)
+            if (disposed) return
+          }
+          setProgress(mode, 1, "Verified")
+          await delay(300)
+          if (disposed) return
+          cleanup()
+          resolve({ kind: "selected", mode })
         } catch (err) {
           installing = null
           setProgressVisible(mode, false)
@@ -3039,13 +3054,11 @@ export const mountGame = (
             errorEl.textContent = `Install failed: ${msg}`
           }
           errorEl.hidden = false
-          // Critical: the plugin's install path drops the previously
-          // loaded kit before its load test. If install fails here,
-          // the previously-active model's kit is nil'd in memory
-          // even though its files and marker are intact on disk.
-          // Re-prepare the previously-active model so the user can
-          // keep using it. Without this, the user records, taps stop,
-          // and stopSession reports "WhisperKit not prepared".
+          // Critical: install can drop the previously loaded native
+          // context while replacing files. If install fails here, the
+          // previously-active model may be nil'd in memory even though
+          // its files and marker are intact on disk. Re-prepare it so
+          // the user can keep using it.
           if (currentActive && currentActive !== mode && stt?.prepare) {
             try {
               const r = await stt.prepare({
@@ -3053,7 +3066,7 @@ export const mountGame = (
               })
               if (r.ready) {
                 console.log(
-                  `[pronunciation-coach] restored ${currentActive} kit after ${mode} install failed`
+                  `[pronunciation-coach] restored ${currentActive} model after ${mode} install failed`
                 )
               }
             } catch (restoreErr) {
@@ -3151,7 +3164,7 @@ export const mountGame = (
     // directory layout we don't fully control, and we've seen it
     // report "missing" on models that prepare() then loads
     // successfully. The only definition of "installed" that matters
-    // is "WhisperKit can load it right now".
+    // is "the native runtime can load it right now".
     const savedEarly = loadSavedState(storage)
     if (savedEarly?.mode && modelById(savedEarly.mode)) {
       modelMode = savedEarly.mode
@@ -3180,10 +3193,10 @@ export const mountGame = (
     }
 
     renderModeButton()
-    // Larger models pay a one-time CoreML compile cost on first
-    // launch. Surface the wait honestly so users don't think the
-    // app froze. Threshold (~300 MB) chosen so Standard / Small
-    // skip the warning but Medium / Large / Advanced get it.
+    // Larger models can spend real time on first native initialization.
+    // Surface the wait honestly so users don't think the app froze.
+    // Threshold (~300 MB) chosen so Standard / Small skip the warning
+    // but Medium / Large / Advanced get it.
     const bootModelLabel = labelForMode(modelMode)
     const bootIsLargeModel = (modelById(modelMode)?.approxSizeMB ?? 0) >= 300
     showOverlay(
@@ -3213,7 +3226,7 @@ export const mountGame = (
         prepareWithRecovery(bootTargetMode).then((r) => {
           modelReady = true
           console.log(
-            `[pronunciation-coach] WhisperKit prepared: ${r.model} (${labelForMode(bootTargetMode)})`
+            `[pronunciation-coach] Whisper prepared: ${r.model} (${labelForMode(bootTargetMode)})`
           )
         }),
         loadFirstPhrase(),

--- a/corpan/plugins/tauri-plugin-stt/CHANGELOG.md
+++ b/corpan/plugins/tauri-plugin-stt/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Android + iOS: model install now verifies bytes on disk instead of
+  immediately running a native load test.** Download completion now does
+  a durable write/readback barrier, validates ggml magic plus tail
+  readability, writes a `ggml-probe-v2` install marker, and leaves native
+  initialization to `prepare()`, where memory headroom, fresh-install
+  settle timing, and crash breadcrumbs all run in one guarded path. This
+  avoids stacking large-model download finalization and whisper.cpp init
+  in the same memory-pressure window on first install.
+
+### Added
+- **iOS: native-init crash breadcrumbs now match Android's analytics
+  path.** A failed previous process load is surfaced once via
+  `getStatus().priorInitCrash`.
+
 ## [0.5.3] - 2026-06-04 — Truncated-download guard + crash-breadcrumb harvest
 
 ### Fixed

--- a/corpan/plugins/tauri-plugin-stt/android/src/main/java/com/corpora/stt/SttPlugin.kt
+++ b/corpan/plugins/tauri-plugin-stt/android/src/main/java/com/corpora/stt/SttPlugin.kt
@@ -29,8 +29,11 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONArray
 import java.io.File
+import java.io.FileOutputStream
 import java.io.IOException
+import java.io.RandomAccessFile
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
 // Android implementation of tauri-plugin-stt — Phase 1.
@@ -50,6 +53,9 @@ private const val MODELS_SUBDIR = "whisper-cpp/models"
 private const val MARKER_SUBDIR = ".pronunciation-coach/installed"
 private const val SAMPLE_RATE = 16_000
 private const val LEADING_PAD_SAMPLES = 4_800   // 300 ms
+private const val GGML_FILE_MAGIC = 0x67676d6c
+private const val MIN_PLAUSIBLE_MODEL_BYTES = 1_000_000L
+private const val MODEL_PROBE_BYTES = 4096
 
 // Matches the `[_BEG_]`, `[_END_]`, `[_TT_50]`, `[_PT_*]` markers
 // whisper.cpp emits when token_timestamps is on. Stripped from token
@@ -221,6 +227,7 @@ class SttPlugin(private val activity: Activity) : Plugin(activity) {
      *  compression threshold). nil = use the native ramps unchanged. */
     @Volatile private var activeScoringParams: ScoringParamsArg? = null
     @Volatile private var sessionStartedAt: Long = 0L
+    private val freshInstallReadyAt = ConcurrentHashMap<String, Long>()
 
     init {
         if (instanceOrdinal > 1) {
@@ -265,7 +272,7 @@ class SttPlugin(private val activity: Activity) : Plugin(activity) {
     private fun writeInstallMarker(name: String) {
         try {
             markerFile(name).writeText(
-                """{"installed":true,"model":"$name","writtenAt":"${System.currentTimeMillis()}"}"""
+                """{"installed":true,"model":"$name","verifiedBy":"ggml-probe-v2","writtenAt":"${System.currentTimeMillis()}"}"""
             )
         } catch (e: Exception) {
             Log.w(TAG, "failed to write install marker: ${e.message}")
@@ -279,15 +286,10 @@ class SttPlugin(private val activity: Activity) : Plugin(activity) {
     private fun installMarkerExists(name: String) = markerFile(name).exists()
 
     private fun validateModelInternal(name: String): List<String> {
-        val f = modelFile(name)
-        if (!f.exists()) {
+        val problems = validateGgmlModelFile(modelFile(name))
+        if (problems.isNotEmpty()) {
             if (installMarkerExists(name)) removeInstallMarker(name)
-            return listOf("<model file missing>")
-        }
-        val size = f.length()
-        if (size < 1_000_000) {
-            if (installMarkerExists(name)) removeInstallMarker(name)
-            return listOf("<model file too small: $size bytes>")
+            return problems
         }
         if (!installMarkerExists(name)) writeInstallMarker(name)
         return emptyList()
@@ -344,32 +346,42 @@ class SttPlugin(private val activity: Activity) : Plugin(activity) {
         try { f.delete() } catch (_: Exception) {}
     }
 
-    /** True if [f] starts with the ggml file magic. A truncated/empty
-     *  download or an HTML error page saved as the model has no magic;
-     *  catching it here returns a clean LOAD_FAILED instead of handing
-     *  garbage to native init. Fails CLOSED on a read error: the file is
-     *  about to be fed to native whisper init, which cannot defend itself
-     *  against a bad file, and a SIGSEGV there is uncatchable and kills the
-     *  app. If we can't read even its first 4 bytes, refusing is strictly
-     *  safer than guessing — and reading 4 bytes of a local file that
-     *  exists and is >= 1 MB does not fail transiently, so this costs no
-     *  legitimate loads. */
-    private fun looksLikeGgmlModel(f: File): Boolean {
-        if (!f.exists() || f.length() < 1_000_000L) return false
+    /** Cheap model-file sanity check before native whisper.cpp sees the file.
+     *  Reads only the first and last 4 KiB: enough to reject HTML error pages,
+     *  empty/truncated artifacts, unreadable files, and storage-layer readback
+     *  failures without buffering a giant model in memory. */
+    private fun validateGgmlModelFile(f: File, expectedBytes: Long? = null): List<String> {
+        if (!f.exists()) return listOf("<model file missing>")
+        if (!f.canRead()) return listOf("<model file unreadable>")
+        val size = f.length()
+        if (size < MIN_PLAUSIBLE_MODEL_BYTES) {
+            return listOf("<model file too small: $size bytes>")
+        }
+        if (expectedBytes != null && expectedBytes > 0 && size != expectedBytes) {
+            return listOf("<model file size mismatch: got $size of $expectedBytes bytes>")
+        }
         return try {
-            f.inputStream().use { s ->
+            RandomAccessFile(f, "r").use { raf ->
                 val b = ByteArray(4)
-                if (s.read(b) != 4) return@use false
+                if (raf.read(b) != 4) return@use listOf("<model file header unreadable>")
                 // GGML_FILE_MAGIC 0x67676d6c, stored little-endian on disk.
                 val magic = (b[0].toInt() and 0xff) or
                     ((b[1].toInt() and 0xff) shl 8) or
                     ((b[2].toInt() and 0xff) shl 16) or
                     ((b[3].toInt() and 0xff) shl 24)
-                magic == 0x67676d6c
+                if (magic != GGML_FILE_MAGIC) {
+                    return@use listOf("<bad ggml magic: ${String.format("0x%08x", magic)}>")
+                }
+                if (size > MODEL_PROBE_BYTES.toLong()) {
+                    raf.seek(maxOf(0L, size - MODEL_PROBE_BYTES.toLong()))
+                    val tail = ByteArray(MODEL_PROBE_BYTES)
+                    val n = raf.read(tail)
+                    if (n <= 0) return@use listOf("<model file tail unreadable>")
+                }
+                emptyList()
             }
         } catch (e: Exception) {
-            Log.e(TAG, "ggml magic check could not read ${f.name}, refusing load: ${e.message}")
-            false
+            listOf("<model file readback failed: ${e.message}>")
         }
     }
 
@@ -377,8 +389,9 @@ class SttPlugin(private val activity: Activity) : Plugin(activity) {
      *  holding [nativeMutex]. Rejects a non-ggml file before native code
      *  sees it, then brackets the native call with the crash breadcrumb. */
     private fun loadGuarded(name: String, path: String): WhisperContext? {
-        if (!looksLikeGgmlModel(File(path))) {
-            Log.e(TAG, "refusing to load $name: not a valid ggml model (bad magic / too small)")
+        val problems = validateGgmlModelFile(File(path))
+        if (problems.isNotEmpty()) {
+            Log.e(TAG, "refusing to load $name: ${problems.joinToString(", ")}")
             return null
         }
         writeInitBreadcrumb(name)
@@ -387,6 +400,33 @@ class SttPlugin(private val activity: Activity) : Plugin(activity) {
         } finally {
             clearInitBreadcrumb()
         }
+    }
+
+    private fun postInstallSettleMs(name: String): Long {
+        val size = modelFile(name).length()
+        return when {
+            size >= 1_200_000_000L -> 5_000L
+            size >= 800_000_000L -> 4_000L
+            size >= 500_000_000L -> 2_500L
+            size >= 250_000_000L -> 1_250L
+            else -> 400L
+        }
+    }
+
+    private fun markFreshInstall(name: String) {
+        val delayMs = postInstallSettleMs(name)
+        freshInstallReadyAt[name] = SystemClock.elapsedRealtime() + delayMs
+        Log.i(TAG, "fresh install cooldown: $name delayMs=$delayMs")
+    }
+
+    private fun waitForFreshInstallSettleIfNeeded(name: String) {
+        val readyAt = freshInstallReadyAt[name] ?: return
+        val remaining = readyAt - SystemClock.elapsedRealtime()
+        if (remaining > 0L) {
+            Log.i(TAG, "waiting for fresh install to settle: $name remainingMs=$remaining")
+            Thread.sleep(remaining)
+        }
+        freshInstallReadyAt.remove(name)
     }
 
     private fun hasMicPermission(): Boolean {
@@ -516,8 +556,7 @@ class SttPlugin(private val activity: Activity) : Plugin(activity) {
 
         // Bail BEFORE touching WhisperContext when the native lib
         // failed to load (e.g. x86_64 Chromebook with no matching
-        // .so). Any reference to WhisperContext (including the
-        // post-download verify load test below) would otherwise
+        // .so). Any reference to WhisperContext during prepare would otherwise
         // re-throw UnsatisfiedLinkError from the companion's
         // <clinit> — only fatal because Kotlin coroutines have no
         // default uncaught-exception handler that survives. We
@@ -560,34 +599,19 @@ class SttPlugin(private val activity: Activity) : Plugin(activity) {
                     channel?.send(installEvent(name, "downloading", fraction, completed, total, null, null))
                     Log.i(TAG, "install progress $name bytes: $completed / $total fraction: ${"%.3f".format(fraction)}")
                 }
-                Log.i(TAG, "download finished: ${dest.absolutePath}")
+                Log.i(TAG, "download finished + file barrier passed: ${dest.absolutePath}")
                 channel?.send(installEvent(name, "verifying", 1.0, null, null, null, null))
-                Log.i(TAG, "running whisper.cpp load test: $name")
-                // Release + load + adopt the new ctx under ONE lock. Doing
-                // the ctx/loadedModel assignment outside the lock would
-                // re-open the check-then-act race the mutex exists to close:
-                // a concurrent prepare()/install could load a second context
-                // and leak one. Also drops any ctx another flow loaded while
-                // we were downloading.
-                val loaded = nativeMutex.withLock {
-                    if (ctx != null) {
-                        Log.i(TAG, "dropping current ctx before install load test: $loadedModel")
-                        ctx?.release(); ctx = null; loadedModel = null
-                    }
-                    loadGuarded(name, dest.absolutePath)?.also { newCtx ->
-                        ctx = newCtx
-                        loadedModel = name
-                    }
-                }
-                if (loaded != null) {
+                val problems = validateModelInternal(name)
+                if (problems.isEmpty()) {
+                    markFreshInstall(name)
                     writeInstallMarker(name)
-                    Log.i(TAG, "install + load test ok: $name")
+                    Log.i(TAG, "install verified on disk: $name")
                     channel?.send(installEvent(name, "verified", 1.0, null, null, null, null))
                     val ret = JSObject()
                     ret.put("installed", true); ret.put("model", name); ret.put("alreadyInstalled", false)
                     invoke.resolve(ret)
                 } else {
-                    val msg = "Model file downloaded but failed to load. The download was probably truncated."
+                    val msg = "Model file downloaded but failed verification: ${problems.joinToString(", ")}"
                     Log.e(TAG, msg)
                     dest.delete(); removeInstallMarker(name)
                     channel?.send(installEvent(name, "failed", null, null, null, msg, "LOAD_FAILED"))
@@ -669,11 +693,17 @@ class SttPlugin(private val activity: Activity) : Plugin(activity) {
                     Thread.sleep(150)
                     memSnapshot("swap-after-settle")
                 }
+                System.gc()
+                Thread.sleep(150)
+                memSnapshot("prepare-after-settle: $name")
+                waitForFreshInstallSettleIfNeeded(name)
+                memSnapshot("prepare-after-fresh-install-barrier: $name")
                 val dest = modelFile(name)
-                if (!dest.exists()) {
+                val problems = validateModelInternal(name)
+                if (problems.isNotEmpty()) {
                     val ret = JSObject()
                     ret.put("ready", false); ret.put("model", name)
-                    ret.put("message", "Model not installed")
+                    ret.put("message", "Model not installed: ${problems.joinToString(", ")}")
                     ret.put("code", "MODEL_NOT_INSTALLED")
                     invoke.resolve(ret); return@launch
                 }
@@ -1185,8 +1215,9 @@ class SttPlugin(private val activity: Activity) : Plugin(activity) {
             val body = resp.body ?: throw IOException("empty body from $url")
             val total = body.contentLength()
             val tmp = File(dest.parentFile, "${dest.name}.part")
+            tmp.delete()
             var completed = 0L
-            tmp.outputStream().use { out ->
+            FileOutputStream(tmp).use { out ->
                 body.byteStream().use { input ->
                     val buf = ByteArray(64 * 1024)
                     var lastReport = 0L
@@ -1203,6 +1234,7 @@ class SttPlugin(private val activity: Activity) : Plugin(activity) {
                         }
                     }
                 }
+                out.fd.sync()
             }
             // Completeness gate. When the server advertised a Content-Length
             // (total > 0), a clean end-of-stream before we've read that many
@@ -1215,15 +1247,24 @@ class SttPlugin(private val activity: Activity) : Plugin(activity) {
             // real end of file. Fail loudly here instead; installModel's catch
             // surfaces a clean, retryable DOWNLOAD_FAILED. (total <= 0 means
             // the server sent no Content-Length — nothing to compare against,
-            // so we fall through and let the post-download load test catch a
-            // bad file.)
+            // so we fall through and let the post-download ggml probe catch a
+            // bad file before native init sees it.)
             if (total > 0 && completed != total) {
                 tmp.delete()
                 throw IOException("truncated download from $url: got $completed of $total bytes")
             }
+            if (dest.exists() && !dest.delete()) {
+                tmp.delete()
+                throw IOException("failed to replace existing ${dest.absolutePath}")
+            }
             if (!tmp.renameTo(dest)) {
                 tmp.delete()
                 throw IOException("failed to move temp file to ${dest.absolutePath}")
+            }
+            val problems = validateGgmlModelFile(dest, expectedBytes = total.takeIf { it > 0 })
+            if (problems.isNotEmpty()) {
+                dest.delete()
+                throw IOException("downloaded model failed file verification: ${problems.joinToString(", ")}")
             }
         }
     }

--- a/corpan/plugins/tauri-plugin-stt/ios/Sources/STTPlugin.swift
+++ b/corpan/plugins/tauri-plugin-stt/ios/Sources/STTPlugin.swift
@@ -239,6 +239,7 @@ struct StatusPayload: Encodable {
     let message: String?
     let availableMemoryMB: Int?
     let physicalMemoryMB: Int?
+    let priorInitCrash: String?
 }
 
 struct InstallProgressPayload: Encodable {
@@ -342,6 +343,99 @@ private func classifyLoadError(_ error: Error) -> SttErrorCode {
         return .modelNotInstalled
     }
     return .loadFailed
+}
+
+private let ggmlFileMagic: UInt32 = 0x67676d6c
+private let minPlausibleModelBytes: Int64 = 1_000_000
+private let modelProbeBytes = 4096
+
+private func sttFileSizeBytes(_ url: URL) -> Int64 {
+    let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
+    return Int64((attrs?[.size] as? NSNumber)?.int64Value ?? 0)
+}
+
+private func sttPosixError(_ operation: String, _ path: String) -> NSError {
+    return NSError(
+        domain: NSPOSIXErrorDomain,
+        code: Int(errno),
+        userInfo: [
+            NSLocalizedDescriptionKey:
+                "\(operation) failed for \(path): \(String(cString: strerror(errno)))"
+        ])
+}
+
+/// Best-effort durability barrier after URLSession moves a multi-GB model
+/// into place. APFS rename semantics are already strong, but fsync + readback
+/// removes two avoidable sources of "download finished, native init touched it
+/// immediately" risk on first install.
+private func syncModelFileToDisk(_ url: URL) throws {
+    let fd = url.path.withCString { pathPtr in Darwin.open(pathPtr, O_RDONLY) }
+    if fd < 0 { throw sttPosixError("open", url.path) }
+    defer { Darwin.close(fd) }
+    if Darwin.fsync(fd) != 0 { throw sttPosixError("fsync", url.path) }
+
+    // Directory fsync is not available on every iOS filesystem view. Treat it
+    // as a bonus barrier, not an install failure.
+    let parent = url.deletingLastPathComponent()
+    let dirFd = parent.path.withCString { pathPtr in Darwin.open(pathPtr, O_RDONLY) }
+    if dirFd >= 0 {
+        _ = Darwin.fsync(dirFd)
+        Darwin.close(dirFd)
+    }
+}
+
+/// Cheap model-file sanity check before native whisper.cpp sees the file.
+/// Reads only the first and last 4 KiB: enough to reject HTML error pages,
+/// empty/truncated artifacts, unreadable files, and storage-layer readback
+/// failures without buffering a giant model in memory.
+private func validateGgmlModelFile(_ url: URL, expectedBytes: Int64? = nil) -> [String] {
+    let fm = FileManager.default
+    guard fm.fileExists(atPath: url.path) else { return ["<model file missing>"] }
+    guard fm.isReadableFile(atPath: url.path) else { return ["<model file unreadable>"] }
+
+    let size = sttFileSizeBytes(url)
+    if size < minPlausibleModelBytes {
+        return ["<model file too small: \(size) bytes>"]
+    }
+    if let expectedBytes, expectedBytes > 0, size != expectedBytes {
+        return ["<model file size mismatch: got \(size) of \(expectedBytes) bytes>"]
+    }
+
+    do {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+
+        guard let head = try handle.read(upToCount: modelProbeBytes),
+            head.count >= 4
+        else {
+            return ["<model file header unreadable>"]
+        }
+        let b = Array(head.prefix(4))
+        let magic =
+            UInt32(b[0])
+            | (UInt32(b[1]) << 8)
+            | (UInt32(b[2]) << 16)
+            | (UInt32(b[3]) << 24)
+        if magic != ggmlFileMagic {
+            return [
+                String(
+                    format: "<bad ggml magic: 0x%08x>",
+                    Int(magic))
+            ]
+        }
+
+        if size > Int64(modelProbeBytes) {
+            try handle.seek(toOffset: UInt64(max(0, size - Int64(modelProbeBytes))))
+            guard let tail = try handle.read(upToCount: modelProbeBytes),
+                !tail.isEmpty
+            else {
+                return ["<model file tail unreadable>"]
+            }
+        }
+    } catch {
+        return ["<model file readback failed: \(error.localizedDescription)>"]
+    }
+    return []
 }
 
 // -----------------------------------------------------------------------------
@@ -753,9 +847,26 @@ private final class WhisperDownloadDelegate: NSObject, URLSessionDownloadDelegat
                     return
                 }
             }
-            sttLog("Whisper | download finished:", dest.path)
+            try syncModelFileToDisk(dest)
+            let problems = validateGgmlModelFile(
+                dest,
+                expectedBytes: expected > 0 ? expected : nil)
+            if !problems.isEmpty {
+                try? fm.removeItem(at: dest)
+                onComplete(
+                    .failure(
+                        NSError(
+                            domain: "stt", code: -1002,
+                            userInfo: [
+                                NSLocalizedDescriptionKey:
+                                    "downloaded model failed file verification: \(problems.joined(separator: ", "))"
+                            ])))
+                return
+            }
+            sttLog("Whisper | download finished + file barrier passed:", dest.path)
             onComplete(.success(dest))
         } catch {
+            try? fm.removeItem(at: dest)
             onComplete(.failure(error))
         }
     }
@@ -797,6 +908,16 @@ private final class WhisperManager {
     /// running one.
     private var loadInFlightFor: String?
 
+    /// Per-process post-install cooling window. The file is already moved,
+    /// fsynced, and header/tail-probed before install resolves; this just
+    /// avoids immediately asking ggml/Metal to map a fresh multi-GB artifact
+    /// in the same allocator pressure window as the download finalization.
+    private var freshInstallReadyAt: [String: Date] = [:]
+
+    /// One-shot native-init crash breadcrumb captured from the previous
+    /// process. `status()` hands it to JS analytics once, then clears it.
+    private var pendingInitCrash: String?
+
     // Audio capture
     private var audioEngine: AVAudioEngine?
     private var converter: AVAudioConverter?
@@ -826,6 +947,11 @@ private final class WhisperManager {
     /// the only entry. Phase 2 replaces this with the real Small.
     private static let defaultModel = "ggml-tiny.bin"
     private static let targetSampleRate: Double = 16000.0
+
+    private init() {
+        pendingInitCrash = nil
+        pendingInitCrash = reportPriorInitCrash()
+    }
 
     // ---------------------------------------------------------------------
     // Model storage layout (whisper.cpp era)
@@ -861,6 +987,13 @@ private final class WhisperManager {
             .appendingPathComponent("\(name).marker")
     }
 
+    private func initBreadcrumbURL() -> URL {
+        return documentsDir()
+            .appendingPathComponent(".pronunciation-coach")
+            .appendingPathComponent("installed")
+            .appendingPathComponent("stt-init-inflight.json")
+    }
+
     private func writeInstallMarker(_ name: String) {
         let url = installMarkerURL(name)
         let fm = FileManager.default
@@ -869,7 +1002,7 @@ private final class WhisperManager {
             try fm.createDirectory(
                 at: dir, withIntermediateDirectories: true)
             let payload = """
-                {"installed":true,"model":"\(name)","writtenAt":"\(Date())"}
+                {"installed":true,"model":"\(name)","verifiedBy":"ggml-probe-v2","writtenAt":"\(Date())"}
                 """
             try payload.write(to: url, atomically: true, encoding: .utf8)
             sttLog("Whisper | wrote install marker:", url.path)
@@ -891,8 +1024,87 @@ private final class WhisperManager {
 
     /// File size in bytes, or 0 if the file is missing.
     private func fileSizeBytes(_ url: URL) -> Int64 {
-        let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
-        return Int64((attrs?[.size] as? NSNumber)?.intValue ?? 0)
+        return sttFileSizeBytes(url)
+    }
+
+    private func writeInitBreadcrumb(_ modelName: String) {
+        let url = initBreadcrumbURL()
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true)
+            let payload = """
+                {"model":"\(modelName)","phase":"native-init","uptimeMs":\(Int(ProcessInfo.processInfo.systemUptime * 1000)),"ts":"\(Date())"}
+                """
+            try payload.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            sttErr(
+                "Whisper | failed to write init breadcrumb for",
+                modelName, "—", error.localizedDescription)
+        }
+    }
+
+    private func clearInitBreadcrumb() {
+        try? FileManager.default.removeItem(at: initBreadcrumbURL())
+    }
+
+    private func reportPriorInitCrash() -> String? {
+        let url = initBreadcrumbURL()
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        let payload =
+            (try? String(contentsOf: url, encoding: .utf8))
+            ?? "<unreadable init breadcrumb>"
+        sttErr(
+            "STT_INIT_CRASH previous on-device whisper init did not complete",
+            "context=\(payload)")
+        try? FileManager.default.removeItem(at: url)
+        return payload
+    }
+
+    private func loadGuarded(modelName: String, path: String) -> WhisperCppContext? {
+        let file = URL(fileURLWithPath: path)
+        let problems = validateGgmlModelFile(file)
+        if !problems.isEmpty {
+            sttErr(
+                "Whisper | refusing native load for",
+                modelName, "—", problems.joined(separator: ", "))
+            return nil
+        }
+        writeInitBreadcrumb(modelName)
+        defer { clearInitBreadcrumb() }
+        return WhisperCppContext.load(path: path)
+    }
+
+    private func postInstallSettleSeconds(for modelName: String) -> TimeInterval {
+        let size = fileSizeBytes(modelFile(modelName))
+        if size >= 1_200_000_000 { return 5.0 }
+        if size >= 800_000_000 { return 4.0 }
+        if size >= 500_000_000 { return 2.5 }
+        if size >= 250_000_000 { return 1.25 }
+        return 0.4
+    }
+
+    private func markFreshInstall(_ modelName: String) {
+        let seconds = postInstallSettleSeconds(for: modelName)
+        let readyAt = Date().addingTimeInterval(seconds)
+        queue.sync { self.freshInstallReadyAt[modelName] = readyAt }
+        sttLog(
+            "Whisper | fresh install cooldown:",
+            modelName, "seconds=\(String(format: "%.2f", seconds))")
+    }
+
+    private func waitForFreshInstallSettleIfNeeded(_ modelName: String) async {
+        let readyAt = queue.sync { self.freshInstallReadyAt[modelName] }
+        guard let readyAt else { return }
+        let remaining = readyAt.timeIntervalSinceNow
+        if remaining > 0 {
+            sttLog(
+                "Whisper | waiting for fresh install to settle:",
+                modelName, "seconds=\(String(format: "%.2f", remaining))")
+            try? await Task.sleep(
+                nanoseconds: UInt64(max(0.0, remaining) * 1_000_000_000.0))
+        }
+        queue.sync { _ = self.freshInstallReadyAt.removeValue(forKey: modelName) }
     }
 
     /// Authoritative "is this model installed?" answer.
@@ -903,29 +1115,15 @@ private final class WhisperManager {
     /// with the marker, we trust disk and rewrite the marker.
     private func validateModel(_ name: String) -> [String] {
         let file = modelFile(name)
-        let fm = FileManager.default
-        guard fm.fileExists(atPath: file.path) else {
-            sttLog(
-                "Whisper | validateModel: file missing —",
-                "name=", name, "path=", file.path)
+        let problems = validateGgmlModelFile(file)
+        if !problems.isEmpty {
             if installMarkerExists(name) {
                 sttLog(
-                    "Whisper | clearing stale marker (file missing):", name)
+                    "Whisper | clearing stale marker (validation failed):",
+                    name, problems.joined(separator: ", "))
                 self.removeInstallMarker(name)
             }
-            return ["<model file missing>"]
-        }
-        let size = fileSizeBytes(file)
-        // 1 MB floor catches truncated downloads. Real models are tens
-        // to hundreds of MB; tiny is the smallest at ~75 MB.
-        if size < 1_000_000 {
-            if installMarkerExists(name) {
-                sttLog(
-                    "Whisper | clearing stale marker (file too small \(size) bytes):",
-                    name)
-                self.removeInstallMarker(name)
-            }
-            return ["<model file too small: \(size) bytes>"]
+            return problems
         }
         if !installMarkerExists(name) {
             self.writeInstallMarker(name)
@@ -979,14 +1177,17 @@ private final class WhisperManager {
         sttLog(
             "Whisper | status() returning availableMemoryMB=\(availMB.map { String($0) } ?? "nil") physicalMemoryMB=\(physMB)")
         return queue.sync {
-            StatusPayload(
+            let prior = self.pendingInitCrash
+            self.pendingInitCrash = nil
+            return StatusPayload(
                 available: true,
                 prepared: ctx != nil,
                 model: loadedModel,
                 recording: isRecording,
                 message: nil,
                 availableMemoryMB: availMB,
-                physicalMemoryMB: physMB
+                physicalMemoryMB: physMB,
+                priorInitCrash: prior
             )
         }
     }
@@ -994,12 +1195,14 @@ private final class WhisperManager {
     func isAvailable() -> Bool { true }
 
     // ---------------------------------------------------------------------
-    // Install — single-file URLSession download, then load test.
+    // Install — single-file URLSession download, then disk verification.
     //
     // The pack passes the model id as the .bin filename (e.g.
     // "ggml-tiny.bin"). We resolve it to the canonical Hugging Face
     // download URL on `ggml-org/whisper.cpp` and stream to our private
-    // model dir.
+    // model dir. Native model init is intentionally left to prepare(),
+    // where the memory gate, fresh-install cooldown, and crash breadcrumb
+    // all run in one place.
     // ---------------------------------------------------------------------
 
     // Use ggerganov/whisper.cpp (not ggml-org/whisper.cpp) — the
@@ -1077,7 +1280,7 @@ private final class WhisperManager {
         let previouslyLoaded: String? = self.queue.sync { self.loadedModel }
         if let prev = previouslyLoaded, prev != modelName {
             sttLog(
-                "Whisper | dropping previous kit before install load test:",
+                "Whisper | dropping previous kit before model download:",
                 prev)
             self.queue.sync {
                 self.ctx = nil
@@ -1096,7 +1299,13 @@ private final class WhisperManager {
             sttLog(
                 "Whisper | install failed; restoring previously-loaded model:",
                 prev)
-            if let prevCtx = WhisperCppContext.load(path: prevPath) {
+            if let headroomError = self.checkMemoryHeadroom(for: prev) {
+                sttErr(
+                    "Whisper | skip restore after install failure (INSUFFICIENT_MEMORY):",
+                    headroomError)
+                return
+            }
+            if let prevCtx = self.loadGuarded(modelName: prev, path: prevPath) {
                 self.queue.sync {
                     self.ctx = prevCtx
                     self.loadedModel = prev
@@ -1122,21 +1331,19 @@ private final class WhisperManager {
             case .success(let downloadedURL):
                 Task {
                     sttLog(
-                        "Whisper | running whisper.cpp load test:", modelName)
+                        "Whisper | finalizing verified model install:",
+                        modelName, downloadedURL.path)
                     onProgress(
                         InstallProgressPayload(
                             model: modelName, phase: "verifying",
                             fraction: 1.0, completed: nil, total: nil,
                             error: nil, code: nil))
-                    let loaded = WhisperCppContext.load(path: downloadedURL.path)
-                    if let loaded {
-                        self.queue.sync {
-                            self.ctx = loaded
-                            self.loadedModel = modelName
-                        }
+                    let problems = self.validateModel(modelName)
+                    if problems.isEmpty {
+                        self.markFreshInstall(modelName)
                         self.writeInstallMarker(modelName)
                         sttLog(
-                            "Whisper | install + load test ok:", modelName)
+                            "Whisper | install verified on disk:", modelName)
                         onProgress(
                             InstallProgressPayload(
                                 model: modelName, phase: "verified",
@@ -1148,10 +1355,8 @@ private final class WhisperManager {
                                     installed: true, model: modelName,
                                     alreadyInstalled: false)))
                     } else {
-                        // Load test failed — wipe the bytes so we don't
-                        // serve a half-broken install on next boot.
                         let msg =
-                            "Model file downloaded but failed to load. The download was probably truncated."
+                            "Model file downloaded but failed verification: \(problems.joined(separator: ", "))"
                         sttErr("Whisper |", msg)
                         try? FileManager.default.removeItem(at: dest)
                         self.removeInstallMarker(modelName)
@@ -1279,8 +1484,10 @@ private final class WhisperManager {
             // schedule even when malloc doesn't return them eagerly.
             _ = malloc_zone_pressure_relief(nil, 0)
             sttMemSnapshot("prepare-after-pressure-relief: \(modelName)")
-            Thread.sleep(forTimeInterval: 0.15)
+            try? await Task.sleep(nanoseconds: 150_000_000)
             sttMemSnapshot("prepare-after-settle: \(modelName)")
+            await self.waitForFreshInstallSettleIfNeeded(modelName)
+            sttMemSnapshot("prepare-after-fresh-install-barrier: \(modelName)")
 
             // File present?
             let problems = self.validateModel(modelName)
@@ -1322,7 +1529,7 @@ private final class WhisperManager {
 
             sttLog("Whisper | loading model from disk:", modelName)
             let path = self.modelFile(modelName).path
-            guard let loaded = WhisperCppContext.load(path: path) else {
+            guard let loaded = self.loadGuarded(modelName: modelName, path: path) else {
                 let msg = "Failed to load \(modelName) (whisper_init returned nil)"
                 sttErr("Whisper | load failed (LOAD_FAILED):", msg)
                 completion(
@@ -2573,6 +2780,10 @@ final class STTPlugin: Plugin {
         if let model = s.model { dict["model"] = model }
         if let message = s.message { dict["message"] = message }
         if let availMB { dict["availableMemoryMB"] = availMB }
+        if let prior = s.priorInitCrash {
+            dict["priorInitCrash"] = prior
+            sttErr("Whisper | delivering prior STT init-crash breadcrumb to analytics")
+        }
         invoke.resolve(dict)
     }
 

--- a/corpan/plugins/tauri-plugin-stt/src/desktop.rs
+++ b/corpan/plugins/tauri-plugin-stt/src/desktop.rs
@@ -66,6 +66,7 @@ impl<R: Runtime> Stt<R> {
             message: Some("STT not supported on desktop in this build".to_string()),
             available_memory_mb: None,
             physical_memory_mb: None,
+            prior_init_crash: None,
         })
     }
 }

--- a/corpan/plugins/tauri-plugin-stt/src/models.rs
+++ b/corpan/plugins/tauri-plugin-stt/src/models.rs
@@ -213,4 +213,9 @@ pub struct StatusResult {
     /// `available_memory_mb`.
     #[serde(default, rename = "physicalMemoryMB")]
     pub physical_memory_mb: Option<i64>,
+    /// One-shot native-init crash breadcrumb delivered by iOS/Android after
+    /// the previous process died inside whisper.cpp model load. The host
+    /// records this into on-device analytics, then native clears it.
+    #[serde(default, rename = "priorInitCrash")]
+    pub prior_init_crash: Option<String>,
 }


### PR DESCRIPTION
### **User description**
## Summary
- harden iOS/Android STT install so model downloads are fsynced/readback-verified instead of immediately native-loaded
- move first native whisper init into guarded prepare() with fresh-install settle timing, memory checks, and crash breadcrumbs
- surface iOS priorInitCrash through the Rust/TS bridge and bump Corpan app metadata to 0.17.2

## Validation
- git diff --check && git diff --cached --check
- npm run build
- cargo check (plugins/tauri-plugin-stt)
- ./gradlew :app:compileUniversalDebugKotlin
- cargo tauri ios build --debug --target aarch64 --ci


___

### **PR Type**
Bug fix, Enhancement, Documentation


___

### **Description**
- Verify model downloads before native initialization

- Delay prepare after fresh installs

- Surface init-crash breadcrumbs cross-platform

- Bump app metadata to 0.17.2


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Model download"] 
  B["Fsync and ggml readback"]
  C["Verified install marker"]
  D["Fresh-install settle window"]
  E["Guarded prepare load"]
  F["One-shot crash breadcrumb"]
  A -- "complete" --> B
  B -- "valid" --> C
  C -- "prepare later" --> D
  D -- "memory gated" --> E
  E -- "prior crash" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>types.ts</strong><dd><code>Update STT API install and crash docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/286/files#diff-b39d14abf9f79a37693cdadf8e753684f54608e58c90242d90332e8c2ba5d479">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document STT install hardening changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/286/files#diff-cd5b7db793725330d0bf4330af108fb44f3eba931f7d401c07ce17e77770fc5f">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>game.ts</strong><dd><code>Add post-install settling and wording updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/286/files#diff-0cd759298faa23b179ab8534e79f1932f7a250132e3cd7a991f715fd10c1dee4">+51/-38</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>models.rs</strong><dd><code>Add prior init crash status model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/286/files#diff-d6048db1fcf771ac14882cd45f8cb98b35ac709473d4ef700a2951329817cab9">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>desktop.rs</strong><dd><code>Populate desktop prior crash status field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/286/files#diff-d892d9d08f4efc7a6b6f7a8db867b6d18f960937596c728d9ff9302e1534baad">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>STTPlugin.swift</strong><dd><code>Harden iOS STT install and prepare</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/286/files#diff-a7c227f34d01ba9e73799a6e42a1712b2751cc71c23a2a0a31dc89f918379aef">+253/-42</a></td>

</tr>

<tr>
  <td><strong>SttPlugin.kt</strong><dd><code>Harden Android STT install and prepare</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/286/files#diff-753ed78abd42baab731f5673c0397502e8fa86a2b258dce0f91e483d1f564389">+97/-56</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>package.json</strong><dd><code>Bump web app package version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/286/files#diff-6f3835061316357e8d8d2db1c1be20a177080546158dd0c5f79c6a916b484c74">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong><dd><code>Bump Tauri package version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/286/files#diff-9ef6389f1df3c4b4d85e794fe98cd4483e38e4bb188e0c7a608c28e262389dfa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tauri.conf.json</strong><dd><code>Bump Tauri app configuration version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/286/files#diff-c63059cb2f0219fa2102fa1693da4fdf0aac37f378e1d2596598d0864430e0db">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

