### PR TITLE
Fix catalog deploy: tutomaton /0.5.4/ URL + gate Teletron/Corpan City to preview

### DIFF
--- a/web/data/packs.json
+++ b/web/data/packs.json
@@ -127,7 +127,7 @@
     "minAppVersion": "0.17.0",
     "v1Listed": false,
     "requireCompleteLocalization": true,
-    "channel": "stable",
+    "channel": "preview",
     "packType": "game",
     "purchase": {
       "type": "free"
@@ -167,7 +167,7 @@
     "github": "https://github.com/corpora-inc/encorpora/tree/main/corpan/packs/teletron",
     "minAppVersion": "0.17.0",
     "v1Listed": false,
-    "channel": "stable",
+    "channel": "preview",
     "packType": "social",
     "purchase": {
       "type": "free",

--- a/web/data/packs.json
+++ b/web/data/packs.json
@@ -6,7 +6,7 @@
     "status": "active",
     "listed": true,
     "manifestUrl": "/corpan/packs/tutomaton/manifest.json",
-    "zipUrl": "/corpan/packs/tutomaton/0.5.1/tutomaton.zip",
+    "zipUrl": "/corpan/packs/tutomaton/0.5.4/tutomaton.zip",
     "landingUrl": "/corpan/packs/tutomaton/",
     "avatarSource": "corpan/packs/tutomaton/tutomaton-avatar.png",
     "github": "https://github.com/corpora-inc/encorpora/tree/main/corpan/packs/tutomaton",


### PR DESCRIPTION
### **User description**
## Fix the catalog deploy (broken on `main` after #287) + actually gate the deferred packs

Two fixes the `deploy-pages` build needs:

1. **Unblock the build.** `web/pages/build.js` asserts a `requireVersionedArtifact` pack's `zipUrl` contains the manifest version. Tutomaton bumped to **0.5.4** in #287 but `packs.json` still pinned the current entry's `zipUrl` to `/0.5.1/` → build threw. Bumped it to `/0.5.4/` (the deploy workflow publishes that immutable path from the manifest version). The `/0.3.2/` compat entry (app 0.16.x, its own manifest) is untouched.

2. **Actually gate Teletron + Corpan City.** The catalog reads `channel` from `web/data/packs.json` (`build.js → pack.channel`), **not** the pack manifest — so the `channel:"preview"` edits made to the *manifests* in #287 were silently ignored and both packs still resolved to `stable` (publicly recommendable). Set `channel:"preview"` in `packs.json` so `filterCatalogForApp` drops them for non-dev users; testers reveal them via the Settings 7-tap unlock.

Verified locally: `node web/pages/build.js` exits 0; generated `catalog-v3.json` shows `tutomaton → /0.5.4/` (+ `/0.3.2/` compat) and `corpan_city`/`teletron → channel: preview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix Tutomaton catalog artifact URL

- Gate deferred packs as preview-only


___

### Diagram Walkthrough


```mermaid
flowchart LR
  catalog["Pack catalog"]
  tutomaton["Tutomaton 0.5.4 artifact"]
  deferred["Deferred packs"]
  preview["Preview channel"]
  catalog -- "points to" --> tutomaton
  catalog -- "gates" --> deferred
  deferred -- "uses" --> preview
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>packs.json</strong><dd><code>Update pack catalog URL and channels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/data/packs.json

<ul><li>Updates <code>tutomaton</code> <code>zipUrl</code> to <code>/0.5.4/</code>.<br> <li> Changes <code>corpan_city</code> channel from <code>stable</code> to <code>preview</code>.<br> <li> Changes <code>teletron</code> channel from <code>stable</code> to <code>preview</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/288/files#diff-defdf869a8f7904a0a2512d21a53b704d507d5649d6cca6c866e2242a799087c">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

