### PR TITLE
beatlounge 0.2.0 — version bump so users get the update

### DIFF
--- a/corpan/corpan-app/src/contentPacks/catalog.ts
+++ b/corpan/corpan-app/src/contentPacks/catalog.ts
@@ -205,7 +205,7 @@ const DEFAULT_CATALOG: CatalogGame[] = [
   {
     id: "beatlounge",
     name: "beatlounge",
-    version: "0.1.0",
+    version: "0.2.0",
     minAppVersion: "0.18.0",
     manifestUrl: "https://encorpora.io/corpan/packs/beatlounge.zip",
     description:
@@ -258,7 +258,7 @@ const DEV_CATALOG: CatalogGame[] = [
   {
     id: "beatlounge",
     name: "beatlounge",
-    version: "0.1.0",
+    version: "0.2.0",
     minAppVersion: "0.18.0",
     manifestUrl: "/packs/beatlounge/manifest.json",
     description:

--- a/corpan/packs/beatlounge/CHANGELOG.md
+++ b/corpan/packs/beatlounge/CHANGELOG.md
@@ -5,6 +5,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-13
+
+_GA + the calling card: beatlounge goes stable and the entire interface ships in
+50+ languages, with a localized catalog listing to match._
+
 ### Added
 - **The whole interface speaks your language — 50+ of them.** Every chrome string
   (buttons, labels, hints, empty states, toasts) is now localized into the user's

--- a/corpan/packs/beatlounge/manifest.json
+++ b/corpan/packs/beatlounge/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "beatlounge",
   "name": "beatlounge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "You never forget a song. beatlounge is a real music studio where your samples are the language you're learning — pull real phrases across 50+ languages and scratch them on the deck, over ten million to play with, all offline. No music theory needed; it teaches you as you go.",
   "descriptionLocalized": {
     "en": "You never forget a song. beatlounge is a real music studio where your samples are the language you're learning — pull real phrases across 50+ languages and scratch them on the deck, over ten million to play with, all offline. No music theory needed; it teaches you as you go.",
@@ -63,5 +63,5 @@
   "entryType": "script",
   "minAppVersion": "0.18.0",
   "sdkVersion": "0.1.0",
-  "devRevision": "2026-06-12T20:40:57.717Z"
+  "devRevision": "2026-06-13T05:47:35.235Z"
 }


### PR DESCRIPTION
### **User description**
The 50-language UI localization, GA flip, and catalog-copy localization all shipped via the catalog — but **without a pack version bump**, so clients already on 0.1.0 don't see an update prompt.

Bumps beatlounge **0.1.0 → 0.2.0**:
- `manifest.json` (the live `catalog-v3.json` version is read from here by build.js)
- built-in `catalog.ts` fallback (beatlounge only — reverted an accidental sed hit on hover_runner / corpan_city)
- Promoted CHANGELOG `[Unreleased]` → `[0.2.0] - 2026-06-13`

`getUpdateType()` surfaces this as a **minor** update; `usePackUpdates` then badges it in Packs/Recents. `requireVersionedArtifact` isn't set on beatlounge, so the unversioned `beatlounge.zip` URL is fine (deploy overwrites it with the latest build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Bump beatlounge catalog version to 0.2.0

- Update manifest version and dev revision

- Publish changelog release heading


___

### Diagram Walkthrough


```mermaid
flowchart LR
  manifest["beatlounge manifest"]
  catalog["Built-in catalogs"]
  users["Installed users"]
  changelog["Release notes"]
  manifest -- "sets version 0.2.0" --> catalog
  catalog -- "surfaces update" --> users
  manifest -- "documented by" --> changelog
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>catalog.ts</strong><dd><code>Bump beatlounge catalog entries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/corpan-app/src/contentPacks/catalog.ts

<ul><li>Updates <code>beatlounge</code> version to <code>0.2.0</code>.<br> <li> Applies the bump in both default and development catalogs.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/293/files#diff-b1d586396a5417b99d466942ec932eae1c6d3aef39b050fe11d48158190901c3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Update beatlounge manifest version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/manifest.json

<ul><li>Bumps pack <code>version</code> from <code>0.1.0</code> to <code>0.2.0</code>.<br> <li> Refreshes <code>devRevision</code> timestamp for the release.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/293/files#diff-6a948fc57a1bf98cbb2ab48c20d11500638af318e8c10638a3dd411ae48de63f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add beatlounge 0.2.0 release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/CHANGELOG.md

<ul><li>Adds <code>0.2.0</code> release heading dated <code>2026-06-13</code>.<br> <li> Notes stable GA and 50+ language localization.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/293/files#diff-83e97c4e36caca34711c70ef258b21b23e7362bf0f79b312a22fb2679ced8def">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

