### PR TITLE
beatlounge 0.2.1: ship the RTL fixes (version bump)

### DIFF
--- a/corpan/corpan-app/src/contentPacks/catalog.ts
+++ b/corpan/corpan-app/src/contentPacks/catalog.ts
@@ -205,7 +205,7 @@ const DEFAULT_CATALOG: CatalogGame[] = [
   {
     id: "beatlounge",
     name: "beatlounge",
-    version: "0.2.0",
+    version: "0.2.1",
     minAppVersion: "0.18.0",
     manifestUrl: "https://encorpora.io/corpan/packs/beatlounge.zip",
     description:
@@ -258,7 +258,7 @@ const DEV_CATALOG: CatalogGame[] = [
   {
     id: "beatlounge",
     name: "beatlounge",
-    version: "0.2.0",
+    version: "0.2.1",
     minAppVersion: "0.18.0",
     manifestUrl: "/packs/beatlounge/manifest.json",
     description:

--- a/corpan/packs/beatlounge/CHANGELOG.md
+++ b/corpan/packs/beatlounge/CHANGELOG.md
@@ -5,6 +5,37 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-06-13
+
+_The right-to-left release: beatlounge now flips for Arabic, Hebrew, Persian and
+Urdu, plus two phone fixes._
+
+### Added
+- **Right-to-left layout (Arabic, Hebrew, Persian, Urdu).** The interface now
+  flips properly under an RTL language, not just translates. Panel copy
+  right-aligns (the rhythmic-cycle "Teental · 4/4 · 96 bpm" line, the instrument
+  name box, the phrase picker); the performance ribbon mirrors so high pitches
+  sit on the left and low on the right, with its octave arrows and expand button
+  following suit; and directional glyphs flip — the play button points left, the
+  exit chevron points right. Built on CSS logical properties so left-to-right
+  stays pixel-identical. Script subtags decide direction independently of region,
+  so an Arabic-script regional tag (e.g. `pa-Arab-PK`) reads RTL while Gurmukhi
+  stays LTR. (The piano-roll and track timeline keep their physical left-to-right
+  orientation on purpose.)
+
+### Fixed
+- **The drums "−" now actually thins the beat.** On the drums home widget, "−"
+  was wired to the additive generator, so it layered a new beat on top and could
+  *add* hits. It now removes hits with a weighted-random thinning that plucks
+  off-beat and quieter notes first and spares the downbeat — surprising each
+  press, but always strictly fewer hits, never more. (The displayed density level
+  only drops when hits were actually removed.)
+- **The mixer pan slider is grabbable again.** On the phone drawer mixer the
+  per-track pan had collapsed to a ~5px nub with no track (its wrapper was never
+  stretched, only the inner track), so it was almost impossible to use. It now
+  spans the row like the level fader above it. (The level fader and the iPad
+  console were unaffected.)
+
 ## [0.2.0] - 2026-06-13
 
 _GA + the calling card: beatlounge goes stable and the entire interface ships in
@@ -17,16 +48,6 @@ _GA + the calling card: beatlounge goes stable and the entire interface ships in
   `tools/gen_i18n.py` (codex-cli, one call per locale). Music loan-words stay
   international on purpose — Reverb/Delay/EQ, BPM, note/mode/raga names, the proper
   names of kits and world rhythms. A freshness-gate test keeps every locale in sync.
-- **Right-to-left layout (Arabic, Hebrew, Persian, Urdu).** The interface now
-  flips properly under an RTL language, not just translates. Panel copy
-  right-aligns (the rhythmic-cycle "Teental · 4/4 · 96 bpm" line, the instrument
-  name box, the phrase picker); the performance ribbon mirrors so high pitches
-  sit on the left and low on the right, with its octave arrows and expand button
-  following suit; and directional glyphs flip — the play button points left, the
-  exit chevron points right. Built on CSS logical properties so left-to-right
-  stays pixel-identical. (The piano-roll and track timeline keep their physical
-  left-to-right orientation on purpose.)
-
 - **Auto melody expansion — per-track, persisted, always-on.** The Score editor's
   Auto is now a per-track generative conductor that keeps re-walking a flowing
   line each loop wrap, and keeps going after you leave the Instruments screen
@@ -65,18 +86,6 @@ _GA + the calling card: beatlounge goes stable and the entire interface ships in
   the Mix page…" paragraph under the drawer mixer, a dev-status note on the
   Rhythmic Cycle accent map, and trimmed empty-state / home-tile copy to terse
   fragments. The UI shows what to do by how it looks, not by a sentence to read.
-
-### Fixed
-- **The drums "−" now actually thins the beat.** On the drums home widget, "−"
-  was wired to the additive generator, so it layered a new beat on top and could
-  *add* hits. It now removes hits with a weighted-random thinning that plucks
-  off-beat and quieter notes first and spares the downbeat — surprising each
-  press, but always strictly fewer hits, never more.
-- **The mixer pan slider is grabbable again.** On the phone drawer mixer the
-  per-track pan had collapsed to a ~5px nub with no track (its wrapper was never
-  stretched, only the inner track), so it was almost impossible to use. It now
-  spans the row like the level fader above it. (The level fader and the iPad
-  console were unaffected.)
 
 ### Performance
 - **No more first-entry scratch hitch.** The scratch AudioWorklet compiles once per

--- a/corpan/packs/beatlounge/manifest.json
+++ b/corpan/packs/beatlounge/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "beatlounge",
   "name": "beatlounge",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "You never forget a song. beatlounge is a real music studio where your samples are the language you're learning — pull real phrases across 50+ languages and scratch them on the deck, over ten million to play with, all offline. No music theory needed; it teaches you as you go.",
   "descriptionLocalized": {
     "en": "You never forget a song. beatlounge is a real music studio where your samples are the language you're learning — pull real phrases across 50+ languages and scratch them on the deck, over ten million to play with, all offline. No music theory needed; it teaches you as you go.",
@@ -63,5 +63,5 @@
   "entryType": "script",
   "minAppVersion": "0.18.0",
   "sdkVersion": "0.1.0",
-  "devRevision": "2026-06-13T05:47:35.235Z"
+  "devRevision": "2026-06-14T00:06:17.000Z"
 }


### PR DESCRIPTION
### **User description**
## Why

The real RTL support (Arabic/Hebrew/Persian/Urdu) plus the drums "−" thinning fix and the phone pan-slider fix shipped in #294 — but they were folded into the `[0.2.0]` CHANGELOG section **without a version bump**. Since the live `catalog-v3.json` version is sourced from the manifest, clients already on beatlounge `0.2.0` never got an update prompt for these. :eyeroll:

## What

- **Bump `0.2.0` → `0.2.1`** in `manifest.json` (+ fresh `devRevision`) and the built-in `catalog.ts` (both `DEFAULT_CATALOG` and `DEV_CATALOG` entries).
- **Carve the #294 follow-ups out of `[0.2.0]` into a new `[0.2.1]` CHANGELOG section** — the RTL bullet (with the scripted-RTL `pa-Arab-PK` note) and the two Fixed items (drums "−", pan slider). The `0.2.0` section keeps what actually shipped as `0.2.0` (GA + localization + Auto melody + perf + scratch-rack fix).

`getUpdateType()` now surfaces a **patch** update badge for installed users.

## Test

No code/logic change — version strings + CHANGELOG prose only.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Bumps beatlounge to `0.2.1`

- Restores patch update visibility

- Splits `0.2.1` changelog follow-ups

- Refreshes manifest development revision


___

### Diagram Walkthrough


```mermaid
flowchart LR
  manifest["manifest version 0.2.1"]
  catalog["catalog version 0.2.1"]
  changelog["0.2.1 release notes"]
  clients["patch update prompt"]
  manifest -- "sources pack version" --> clients
  catalog -- "mirrors pack metadata" --> clients
  changelog -- "documents shipped fixes" --> clients
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>catalog.ts</strong><dd><code>Align catalog beatlounge version metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/corpan-app/src/contentPacks/catalog.ts

<ul><li>Updates <code>DEFAULT_CATALOG</code> beatlounge version to <code>0.2.1</code><br> <li> Updates <code>DEV_CATALOG</code> beatlounge version to <code>0.2.1</code><br> <li> Keeps catalog metadata aligned with pack manifest</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/295/files#diff-b1d586396a5417b99d466942ec932eae1c6d3aef39b050fe11d48158190901c3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump beatlounge manifest release version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/manifest.json

<ul><li>Bumps beatlounge manifest version to <code>0.2.1</code><br> <li> Refreshes <code>devRevision</code> timestamp for the release<br> <li> Enables clients to detect the patch update</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/295/files#diff-6a948fc57a1bf98cbb2ab48c20d11500638af318e8c10638a3dd411ae48de63f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document beatlounge 0.2.1 follow-up release</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/CHANGELOG.md

<ul><li>Adds a new <code>0.2.1</code> changelog section<br> <li> Documents RTL layout support and phone fixes<br> <li> Moves follow-up fixes out of <code>0.2.0</code><br> <li> Adds RTL script subtag behavior details</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/295/files#diff-83e97c4e36caca34711c70ef258b21b23e7362bf0f79b312a22fb2679ced8def">+31/-22</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

