### PR TITLE
corpan-city: backfill jv/su/tl localization — unblocks the Pages deploy

### DIFF
--- a/corpan/packs/README.md
+++ b/corpan/packs/README.md
@@ -27,6 +27,40 @@ Feature flags:
 - Store-based purchase flow (Apple/Google) + verify endpoint.
 - Hidden in the UI for now until billing setup is released.
 
+## Publishing — how a pack reaches encorpora.io (READ THIS)
+
+**A merge to `main` IS the deploy. Nobody builds or uploads pack zips by hand —
+there is no SSH/rsync/manual-upload step, and an agent cannot push to the host.**
+Do not ask whether you should "build the zip and put it on encorpora.io"; that
+is not a thing.
+
+- **Code / game packs** (beatlounge, corpan-city, hover-runner, hanzipan,
+  juice-squeeze, world-radio, the readers, …) ship via GitHub Actions →
+  GitHub Pages. On every push to `main` that touches `corpan/packs/**`,
+  [`.github/workflows/deploy-pages.yml`](../../.github/workflows/deploy-pages.yml)
+  installs deps, `npm run build`s each pack, zips it, and publishes it to
+  `https://encorpora.io/corpan/packs/<id>.zip` (the `manifestUrl`/`zipUrl` the
+  catalog points at). **To ship a new version: bump the manifest `version`
+  (and the matching `catalog.ts` entry), merge to `main`. Done.** The next
+  Pages run rebuilds and publishes the zip automatically.
+- **Catalog metadata is OTA, no app release.** `catalog-v3.json` (including each
+  pack's localized name/description) is *regenerated from the manifests* on every
+  Pages build and served from the same Pages host, so metadata/translation
+  changes reach clients without an app store release.
+- **Hard localization gate.** The Pages build runs
+  `assertCompleteCatalogLocalization` (`web/pages/build.js`): any catalog pack
+  with `requireCompleteLocalization: true` (currently only **`corpan_city`**)
+  MUST carry `nameLocalized` + `descriptionLocalized` for **every** locale under
+  `corpan-app/public/locales/`. One missing locale throws and fails the WHOLE
+  deploy (so a stale gate can silently block unrelated pack releases). When you
+  add a new app language, backfill that pack's manifest in the same change.
+
+> Narration packs (books) and phrase packs are the exception — those do NOT go
+> through GitHub Pages. They publish to S3 / CloudFront via
+> `corpan/infra/patch-catalog.py` and the phrase-pack `publish.py`. That S3/CDN
+> path is the only place "pushing content" is a real step, and it's for book
+> audio / phrase data, not code packs.
+
 ## Reference pack
 - `hover-runner` is the reference implementation.
 - `hanzipan` is the Mandarin character pack (pack-owned DB + handwriting surface).

--- a/corpan/packs/corpan-city/CHANGELOG.md
+++ b/corpan/packs/corpan-city/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Catalog listing: add the Javanese (jv), Sundanese (su) and Tagalog (tl)
+  `nameLocalized` + `descriptionLocalized` strings introduced as supported
+  languages in 0.18.1. Corpan City is the only catalog pack with
+  `requireCompleteLocalization`, so these three gaps were failing the
+  GitHub Pages build (`assertCompleteCatalogLocalization`) and blocking every
+  deploy since #294 — including the beatlounge 0.2.1 publish.
+
 ## [0.1.7] - 2026-06-09
 
 - Adopt Teletron's two-step mediated-chat moderation (binary safety classifier +

--- a/corpan/packs/corpan-city/manifest.json
+++ b/corpan/packs/corpan-city/manifest.json
@@ -61,7 +61,10 @@
     "vi": "Corpan City",
     "yue-Hant-HK": "Corpan City",
     "zh-Hans": "Corpan City",
-    "zh-Hant": "Corpan City"
+    "zh-Hant": "Corpan City",
+    "jv": "Corpan City",
+    "su": "Corpan City",
+    "tl": "Corpan City"
   },
   "descriptionLocalized": {
     "en": "A living city where you meet AI characters and real players, follow a personal journey, and turn every encounter into a language lesson.",
@@ -114,7 +117,10 @@
     "vi": "Corpan City là nơi bạn gặp gỡ nhân vật AI và người chơi thực, theo đuổi hành trình cá nhân và biến mọi cuộc gặp gỡ thành bài học ngôn ngữ.",
     "yue-Hant-HK": "在這座活城市中，你會遇見AI角色和真實玩家，跟隨個人旅程，將每次相遇化作語言課堂。",
     "zh-Hans": "在Corpan City，你会遇到AI角色和真实玩家，展开个人旅程，将每次相遇转化为语言课程。",
-    "zh-Hant": "在這座活城市中，您將遇見AI角色和真實玩家，開展個人旅程，將每次邂逅轉化為語言課程。"
+    "zh-Hant": "在這座活城市中，您將遇見AI角色和真實玩家，開展個人旅程，將每次邂逅轉化為語言課程。",
+    "jv": "Ing Corpan City, ketemu karakter AI lan pemain asli, ngetutake lelakon pribadi, lan ngowahi saben pepanggihan dadi pelajaran basa.",
+    "su": "Di Corpan City, papanggih jeung karakter AI sareng pamaén nyata, nuturkeun lalampahan pribadi, sarta ngarobah unggal papanggihan janten pelajaran basa.",
+    "tl": "Sa Corpan City, makilala ang mga karakter na AI at totoong manlalaro, sundan ang isang personal na paglalakbay, at gawing aralin sa wika ang bawat pakikipagtagpo."
   },
   "devRevision": "2026-06-09T06:40:00.765Z"
 }


### PR DESCRIPTION
### **User description**
## Why

The GitHub Pages deploy has been **failing on every merge to `main` since #294** (the last green deploy was #293). It's not visible unless you check Actions:

\`\`\`
Error: [pages] corpan_city requires complete descriptionLocalized; missing: jv, su, tl
  at assertCompleteCatalogLocalization (web/pages/build.js:278)
\`\`\`

#294 added Javanese/Sundanese/Tagalog (`jv`/`su`/`tl`) as supported app languages but didn't backfill **corpan-city**'s manifest marketing copy. `corpan_city` is the *only* catalog pack with `requireCompleteLocalization: true`, so its three missing `descriptionLocalized` keys throw and fail the **whole** Pages job — which means **beatlounge 0.2.1 (#295) never actually published either**. The live zips are still whatever #293 produced.

## What

- **Backfill `jv`/`su`/`tl`** in `corpan-city/manifest.json`:
  - `nameLocalized` → `"Corpan City"` (proper noun, matching `en`/`id`/`ms`).
  - `descriptionLocalized` → real translations matching the `id`/`ms` house style and the existing jv/su/tl experience blurbs in `common.json`.
- **Document the real publish mechanism** in `packs/README.md` (new "Publishing" section): a merge to `main` *is* the deploy via `deploy-pages.yml` → GitHub Pages; nobody hand-builds/uploads zips; only book-narration and phrase packs use the S3/CDN path. Plus a note that the `requireCompleteLocalization` gate fails the whole deploy, so new app languages must backfill the gated pack in the same change.
- corpan-city `CHANGELOG` `[Unreleased]` note.

No version bump: catalog metadata (incl. localized strings) is regenerated from manifests and served OTA on every Pages build, so this reaches clients without a corpan_city version change.

## Test

\`node web/pages/build.js web/io/out\` now **exits 0** (was exit 1) and emits `catalog-v3.json` with `corpan_city` at **54/54** locales for both `nameLocalized` and `descriptionLocalized`. Merging this should turn the next Pages run green and finally publish both #294's content and beatlounge 0.2.1.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Backfills missing Corpan City locales

- Unblocks GitHub Pages pack deploys

- Documents pack publishing workflow

- Records localization gate fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["New app languages"]
  B["Corpan City manifest"]
  C["Localization gate"]
  D["GitHub Pages deploy"]
  E["Pack publishing docs"]
  A -- "requires jv/su/tl" --> B
  B -- "satisfies" --> C
  C -- "unblocks" --> D
  E -- "explains" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document pack publishing and localization gate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/README.md

<ul><li>Adds a dedicated pack publishing section.<br> <li> Clarifies merges to <code>main</code> trigger GitHub Pages deployment.<br> <li> Documents <code>requireCompleteLocalization</code> gate requirements.<br> <li> Distinguishes code packs from S3/CDN narration and phrase packs.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/296/files#diff-7fbc117c1f71d70ca96de3fe5afb8356b59b40c73332b7fd131339bf609022dd">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Record Corpan City localization deploy fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/corpan-city/CHANGELOG.md

<ul><li>Adds an <code>Unreleased</code> note for new catalog localization.<br> <li> Explains missing <code>jv</code>, <code>su</code>, and <code>tl</code> strings.<br> <li> Notes the Pages build failure and blocked deploys.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/296/files#diff-0538f88c05785d425b8ac91d0b9e503858e5a5c36b13ac2e54fe69854de24c91">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Add missing Southeast Asian catalog localizations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/corpan-city/manifest.json

<ul><li>Adds <code>jv</code>, <code>su</code>, and <code>tl</code> <code>nameLocalized</code> entries.<br> <li> Adds matching localized <code>descriptionLocalized</code> catalog copy.<br> <li> Completes Corpan City localization for gated catalog builds.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/296/files#diff-1bd4cebfc10fd19bf8e999279c46f56fc12f2fba2604611e39b15a9c8bf77a87">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

