### PR TITLE
Juice Squeeze 0.1.4: fix pack failing to register in production

### DIFF
--- a/corpan/packs/juice-squeeze/CHANGELOG.md
+++ b/corpan/packs/juice-squeeze/CHANGELOG.md
@@ -9,6 +9,18 @@ Conventions: `corpan/CHANGELOGS.md`.
 
 ## [Unreleased]
 
+## [0.1.4] - 2026-06-16 — Fix: pack never registered (blank/failed load)
+
+### Fixed
+- **Pack now registers in production.** The store imported `create` from the
+  root `zustand` entry, which pulls in `react`. This pack declares no React, so
+  the IIFE build emitted a bundle that *threw* `Could not resolve "react"
+  imported by "zustand"` at module-init — before `registerGame()` ran — so the
+  host's `waitForGameModule` timed out with "Content pack did not register:
+  juice_squeeze". Switched to `zustand/vanilla`'s `createStore` (the pack is a
+  vanilla DOM game; all call sites use `.getState()`/`.subscribe()`). Rebuilt
+  bundle contains the registry and no resolve-throw.
+
 ### Changed
 - Upgraded Babylon.js **6.48 → 9.11** (latest stable). No source changes
   required; typecheck + build clean.

--- a/corpan/packs/juice-squeeze/manifest.json
+++ b/corpan/packs/juice-squeeze/manifest.json
@@ -1,14 +1,14 @@
 {
   "id": "juice_squeeze",
   "name": "Juice Squeeze",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "entry": "dist/app.js",
   "styles": [
     "dist/app.css"
   ],
   "entryType": "script",
   "sdkVersion": "0.1.0",
-  "devRevision": "2026-06-05T06:19:04.251Z",
+  "devRevision": "2026-06-16T15:59:44.508Z",
   "nameLocalized": {
     "ar": "عصر العصير",
     "bg": "Изстискай сока",

--- a/corpan/packs/juice-squeeze/src/store/gameState.ts
+++ b/corpan/packs/juice-squeeze/src/store/gameState.ts
@@ -1,4 +1,9 @@
-import { create } from "zustand"
+// This pack is a vanilla DOM game (no React). Import from `zustand/vanilla`
+// so the bundle never pulls in `react` — the root `zustand` entry's React
+// binding made the IIFE build throw "Could not resolve 'react'" at init,
+// which silently prevented registerGame() from ever running (the host then
+// reported "Content pack did not register: juice_squeeze").
+import { createStore as create } from "zustand/vanilla"
 import { persist, createJSONStorage } from "zustand/middleware"
 
 // Fruit definition type


### PR DESCRIPTION
### **User description**
## Problem
Juice Squeeze fails to load/register in production ("Content pack did not register: juice_squeeze").

## Root cause
`src/store/gameState.ts` imported `{ create }` from the **root `zustand`** entry, which imports `react`. This pack is a vanilla DOM game and declares no React dependency. In the Vite `lib`/`iife` build, the unresolved `react` doesn't fail the build — Rollup bakes a **runtime throw** into the bundle:
```
throw … Error(`Could not resolve "react" imported by "zustand". Is it installed?`)
```
That throw fires at module-init, **before `registerGame()` runs**, so `globalThis.CorpanGames["juice_squeeze"]` is never populated → the host's `waitForGameModule` (500ms) times out → "Content pack did not register". Confirmed in the live prod bundle and a fresh build: `grep -c CorpanGames dist/app.js` = **0**, bundle tail ends in the resolve-throw.

## Fix
Import from the React-free entry: `import { createStore as create } from "zustand/vanilla"`. Drop-in — every call site uses `.getState()`/`.subscribe()`, never the hook form; `persist`/`createJSONStorage` from `zustand/middleware` are already React-free.

After the fix, a clean build off `main` produces: **`CorpanGames` present, zero resolve-throws**, typecheck clean.

Bumped **0.1.3 → 0.1.4** so OTA clients refetch (never change a pack in place at the same version).

## Scope
Minimal — only the three Juice Squeeze files (`gameState.ts`, `manifest.json`, `CHANGELOG.md`). `dist/` is gitignored; the Pages deploy rebuilds it. Merging republishes the catalog and the working pack.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fix production pack registration failure

- Use React-free Zustand vanilla store

- Document `0.1.4` registration fix

- Bump manifest version and revision


___

### Diagram Walkthrough


```mermaid
flowchart LR
  store["Game state store"] 
  vanilla["zustand/vanilla createStore"]
  bundle["IIFE production bundle"]
  register["registerGame runs"]
  host["Host loads juice_squeeze"]

  store -- "imports" --> vanilla
  vanilla -- "avoids React dependency" --> bundle
  bundle -- "no init throw" --> register
  register -- "populates registry" --> host
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gameState.ts</strong><dd><code>Switch store to Zustand vanilla entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/juice-squeeze/src/store/gameState.ts

<ul><li>Replaces root <code>zustand</code> import with <code>zustand/vanilla</code>.<br> <li> Aliases <code>createStore</code> as <code>create</code> for compatibility.<br> <li> Adds comments explaining the production init failure.<br> <li> Prevents React dependency from entering the IIFE bundle.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/299/files#diff-cc14c563299c74e7bee6981f25b2348d9fa13e53f65a4286aaeb91e7e039089a">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document Juice Squeeze registration fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/juice-squeeze/CHANGELOG.md

<ul><li>Adds <code>0.1.4</code> release notes.<br> <li> Documents the production registration failure.<br> <li> Explains the <code>react</code> resolution throw root cause.<br> <li> Notes the switch to <code>zustand/vanilla</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/299/files#diff-2371c0ea8407bbc94d8d67467237cc40d35ba08d58ab98a8d0f794b5bff64a99">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump pack version for fixed release</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/juice-squeeze/manifest.json

<ul><li>Bumps pack version from <code>0.1.3</code> to <code>0.1.4</code>.<br> <li> Updates <code>devRevision</code> timestamp.<br> <li> Ensures OTA clients refetch the fixed pack.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/299/files#diff-a03b84df0f00fff76e6279e0bcab24c7c50cf0324c8756c457b17a9616e7b010">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

