### PR TITLE
fix(pages): tutomaton catalog zipUrl → 0.6.0 (unbreak main deploy)

### DIFF
--- a/web/data/packs.json
+++ b/web/data/packs.json
@@ -6,7 +6,7 @@
     "status": "active",
     "listed": true,
     "manifestUrl": "/corpan/packs/tutomaton/manifest.json",
-    "zipUrl": "/corpan/packs/tutomaton/0.5.4/tutomaton.zip",
+    "zipUrl": "/corpan/packs/tutomaton/0.6.0/tutomaton.zip",
     "landingUrl": "/corpan/packs/tutomaton/",
     "avatarSource": "corpan/packs/tutomaton/tutomaton-avatar.png",
     "github": "https://github.com/corpora-inc/encorpora/tree/main/corpan/packs/tutomaton",


### PR DESCRIPTION
### **User description**
Main's **Deploy Encorpora to GitHub Pages** is failing:

```
Error: [pages] tutomaton requires an immutable artifact URL containing /0.6.0/
```

**Cause:** tutomaton's live manifest was bumped `0.5.4 → 0.6.0`, but the current catalog entry (app ≥ 0.17.0) in `web/data/packs.json` still pointed `zipUrl` at `/corpan/packs/tutomaton/0.5.4/tutomaton.zip`. With `requireVersionedArtifact: true`, the build gate requires the zipUrl's version segment to match the manifest version. The deploy publishes the zip at `/<manifest.version>/` (`deploy-pages.yml` → `jq .version` = `0.6.0`), so `/0.6.0/` is the real path and `/0.5.4/` is no longer published.

**Fix:** bump the current entry's `zipUrl` to `/0.6.0/`. The legacy entry (app 0.16.x → `tutomaton-0.3.2`, `/0.3.2/`) is already consistent and left untouched. **No tutomaton pack changes.**

Verified locally: `node web/pages/build.js` completes cleanly (was throwing before).


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Tutomaton artifact URL version

- Restore Pages catalog build consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  catalog["Tutomaton catalog entry"]
  zip["Versioned zipUrl"]
  pages["GitHub Pages deploy"]
  catalog -- "points to 0.6.0" --> zip
  zip -- "matches manifest version" --> pages
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>packs.json</strong><dd><code>Update Tutomaton versioned artifact URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/data/packs.json

<ul><li>Updates Tutomaton <code>zipUrl</code> from <code>0.5.4</code> to <code>0.6.0</code>.<br> <li> Aligns the catalog artifact path with the current manifest version.<br> <li> Preserves the existing active pack metadata and app version <br>requirements.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/301/files#diff-defdf869a8f7904a0a2512d21a53b704d507d5649d6cca6c866e2242a799087c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

