### PR TITLE
Fix Lingo Hero install (pack id mismatch) + artwork; add catalog-integrity gate

### DIFF
--- a/.github/scripts/pack_catalog_check.js
+++ b/.github/scripts/pack_catalog_check.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// Pack catalog integrity gate.
+//
+// Catches the production-embarrassment class of bugs before they ship:
+//   1) Pack-id mismatch — the installer derives a pack's id from its ZIP
+//      filename and normalizes hyphens to underscores for non-`phrase-` packs
+//      (see corpan-app/src/contentPacks/install.ts). If the catalog/manifest id
+//      doesn't equal that derived id, install fails with "Pack id mismatch".
+//      (Lingo Hero shipped to preview broken exactly this way.)
+//   2) Missing artwork — a catalog entry that declares an `avatarSource` whose
+//      file doesn't exist ships with no image (catalog `imageUrl` becomes null).
+//
+// Validates EVERY entry in web/data/packs.json so a catalog-only edit is covered
+// too, not just changes under corpan/packs/.
+
+const fs = require("fs");
+const path = require("path");
+
+const CATALOG = "web/data/packs.json";
+const raw = JSON.parse(fs.readFileSync(CATALOG, "utf8"));
+const packs = Array.isArray(raw) ? raw : raw.packs || [];
+const errors = [];
+
+for (const p of packs) {
+  if (!p || !p.id) continue;
+
+  // Local pack dir from manifestUrl: /corpan/packs/<dir>/manifest.json
+  const mu = p.manifestUrl || "";
+  const dm = mu.match(/\/corpan\/packs\/([^/]+)\/manifest\.json$/);
+  const dir = dm ? path.join("corpan", "packs", dm[1]) : null;
+
+  // (1) id convention — only for zip-installable packs (manifest-url-only
+  // installs use manifest.id verbatim and are exempt). Legacy version-routed
+  // aliases (entries pinned with `maxAppVersion`) intentionally encode a
+  // version/legacy suffix in their frozen zip name and are exempt.
+  if (p.zipUrl && !p.maxAppVersion) {
+    const zipName = (p.zipUrl.match(/\/([^/]+)\.zip$/) || [])[1] || "";
+    if (zipName) {
+      const expected = zipName.startsWith("phrase-")
+        ? zipName
+        : zipName.replace(/-/g, "_");
+      if (p.id !== expected) {
+        errors.push(
+          `${p.id}: catalog id must equal the installer-derived id "${expected}" ` +
+            `(from zip "${zipName}.zip", hyphens→underscores) or install fails with "Pack id mismatch".`
+        );
+      }
+      if (dir) {
+        const mp = path.join(dir, "manifest.json");
+        if (fs.existsSync(mp)) {
+          const m = JSON.parse(fs.readFileSync(mp, "utf8"));
+          if (m.id !== p.id) {
+            errors.push(`${p.id}: manifest.json id "${m.id}" != catalog id "${p.id}" (${mp}).`);
+          }
+        }
+      }
+    }
+  }
+
+  // (2) artwork — a declared avatarSource must resolve to a real file.
+  if (p.avatarSource && !fs.existsSync(p.avatarSource)) {
+    errors.push(
+      `${p.id}: avatarSource "${p.avatarSource}" does not exist — pack would ship with no artwork.`
+    );
+  }
+}
+
+if (errors.length) {
+  console.error(`Pack catalog integrity FAILED (${errors.length} issue(s)):`);
+  for (const e of errors) console.error("  - " + e);
+  process.exit(1);
+}
+console.log(`Pack catalog integrity OK (${packs.length} catalog entries checked).`);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,13 +232,30 @@ jobs:
         working-directory: corpan/infra/terraform
         run: terraform validate
 
+  # Pack catalog integrity: every catalog entry's id matches the installer's
+  # zip-derived id (else "Pack id mismatch" on install) and every declared
+  # avatarSource resolves to a real file (else the pack ships with no artwork).
+  # Runs whenever packs OR the catalog (web/data) change. Cheap, no npm.
+  pack-catalog:
+    name: pack-catalog · integrity
+    needs: changes
+    if: needs.changes.outputs.packs == 'true' || needs.changes.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Validate pack ids + artwork against the catalog
+        run: node .github/scripts/pack_catalog_check.js
+
   # Single summary status that aggregates every job above. THIS is the context to
   # mark as a required check on `main` — it always runs (if: always()) and always
   # reports, so path-skipped sub-jobs never deadlock the branch protection / queue.
   # Skipped needs are fine; any failure or cancellation fails the gate.
   ci-gate:
     name: ci-gate
-    needs: [changes, corpan-app, lambda, web-io, changed-packs, terraform]
+    needs: [changes, corpan-app, lambda, web-io, changed-packs, terraform, pack-catalog]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:

--- a/corpan/packs/juice-squeeze/CHANGELOG.md
+++ b/corpan/packs/juice-squeeze/CHANGELOG.md
@@ -10,6 +10,8 @@ preview-gated alongside the original `juice_squeeze` until promoted.
 ## [Unreleased]
 
 ### Fixed
+- Added the pack avatar (`juice-squeeze-avatar.png`); the catalog entry pointed
+  at a non-existent image, so the pack shipped with no artwork.
 - **Audio in the INSTALLED pack (0.1.1)** — `fetch()`/XHR is blocked against the
   `corpan-pack://` scheme on iOS WebKit, so the slimmed fetch+decode engine loaded
   no SFX in the sideloaded pack (it worked over the http dev server, which is why

--- a/corpan/packs/juice-squeeze/juice-squeeze-avatar.png
+++ b/corpan/packs/juice-squeeze/juice-squeeze-avatar.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:985b12c85c5db73ba07304b94a487352b80cf9fd8e42fae0cc1a60e7812a92b3
+size 55443

--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
+- Install no longer fails with "Pack id mismatch": the pack id is now the
+  underscore form `lingo_hero` (manifest, catalog, and game registration) to
+  match the id the installer derives from the `lingo-hero.zip` filename. Paths
+  and the zip stay hyphenated.
+- Added the pack avatar (`lingo-hero-avatar.png`); the catalog entry previously
+  pointed at a non-existent image, so the pack shipped with no artwork.
 - TTS now speaks the raw entry text instead of the display-cleaned label;
   display labels are cleaned separately and title-casing is restricted to
   Latin/ASCII text (foreign scripts are left intact).

--- a/corpan/packs/lingo-hero/lingo-hero-avatar.png
+++ b/corpan/packs/lingo-hero/lingo-hero-avatar.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e56d02b7500384c69fd37d2ccde97983f640044f953c6dd782404286200d1273
+size 74313

--- a/corpan/packs/lingo-hero/manifest.json
+++ b/corpan/packs/lingo-hero/manifest.json
@@ -1,5 +1,5 @@
 {
-  "id": "lingo-hero",
+  "id": "lingo_hero",
   "channel": "preview",
   "name": "Lingo Hero",
   "version": "0.1.0",

--- a/corpan/packs/lingo-hero/src/main.ts
+++ b/corpan/packs/lingo-hero/src/main.ts
@@ -9,7 +9,11 @@ type GlobalScope = typeof globalThis & {
   __corpanHostActive?: boolean
 }
 
-const GAME_ID = "lingo-hero"
+// Pack id MUST be the underscore form. The installer derives the pack id from
+// the zip filename and normalizes hyphens to underscores (see install.ts), so
+// the game must register under — and the manifest id must be — `lingo_hero`,
+// else install fails with "Pack id mismatch". Paths/zip stay hyphenated.
+const GAME_ID = "lingo_hero"
 
 const registerGame = () => {
   const scope = globalThis as GlobalScope

--- a/web/data/packs.json
+++ b/web/data/packs.json
@@ -155,7 +155,7 @@
     "tagline": "A living city that turns every encounter into a lesson."
   },
   {
-    "id": "lingo-hero",
+    "id": "lingo_hero",
     "name": "Lingo Hero",
     "description": "A three-lane rhythm game: hear a word in the language you're learning, then strum the lane with the right English answer as the notes fall. Combos, score multipliers, Practice and Blitz modes.",
     "status": "prototype",


### PR DESCRIPTION
### **User description**
Lingo Hero shipped to the preview channel but **failed to install in production** with "Pack id mismatch", and had **no artwork**. This fails forward both, and adds a CI gate so this class of bug can't reach production again.

## Root causes
- **Install / id mismatch** — the installer (`contentPacks/install.ts`) derives a pack id from the **zip filename** and normalizes hyphens to underscores for non-`phrase-` packs: `lingo-hero.zip` → `lingo_hero`. But the manifest/catalog id was `lingo-hero`, so the post-download id check threw **"Pack id mismatch"**. Reference game packs (`hover_runner`, `corpan_city`, …) already follow the convention: **paths/zip hyphenated, id underscored.**
  - Fix: id → `lingo_hero` in `manifest.json`, `web/data/packs.json`, and `GAME_ID` (the key the game registers under and the app mounts by). Paths/zip unchanged.
- **No artwork** — the catalog declared `avatarSource: .../lingo-hero-avatar.png` but the file didn't exist, so `web/pages/build.js` emits a null `imageUrl`. Added a real avatar. Found and fixed the **same live bug on `juice_squeeze`** (also shipping with no art) while here.

## Guardrail (the part that prevents recurrence)
New required check **`pack-catalog · integrity`** (`.github/scripts/pack_catalog_check.js`), runs on any pack/catalog change and folds into `ci-gate`:
- every catalog entry's id must equal the installer-derived id from its zip name (or it would fail install);
- every declared `avatarSource` must resolve to a real file (or the pack ships with no art).
- Legacy version-routed aliases (`maxAppVersion`-pinned compat zips) are exempt from the id rule by design.

Verified locally: the gate **catches the original bug** (both the catalog-id and manifest-id mismatch) and now passes clean across all 17 catalog entries. Pack builds green (`tsc` + vite), `lingo_hero` confirmed in the bundle.


___

### **PR Type**
Bug fix, Enhancement, Documentation


___

### **Description**
- Fix Lingo Hero pack identity mismatch

- Add pack catalog integrity CI gate

- Validate catalog ids, manifests, avatars

- Document Lingo/Juice artwork fixes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  zip["Zip filename"] -- "derives" --> id["Installer pack id"]
  id["Installer pack id"] -- "must match" --> metadata["Catalog and manifest ids"]
  metadata["Catalog and manifest ids"] -- "validated by" --> gate["Pack catalog integrity CI"]
  avatars["Avatar sources"] -- "existence checked" --> gate["Pack catalog integrity CI"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>main.ts</strong><dd><code>Register Lingo Hero with underscore pack id</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/363/files#diff-4e371b8f9cfb0cc90249e49221a2b1824e5c244afc875fc87fd1d3ec37317bdf">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>manifest.json</strong><dd><code>Update Lingo Hero manifest pack id</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/363/files#diff-38411e79d50eee7f8ad439a29518dcddf16cdc9cd03739fc81ea212f18519b15">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>packs.json</strong><dd><code>Align Lingo Hero catalog pack id</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/363/files#diff-defdf869a8f7904a0a2512d21a53b704d507d5649d6cca6c866e2242a799087c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>pack_catalog_check.js</strong><dd><code>Add pack catalog integrity validation script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/363/files#diff-34b9aec0126a8b98d5734523f48b64cfe22cbb4e28c447dc87b9a5ec7c2b98f6">+73/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ci.yml</strong><dd><code>Wire pack catalog validation into CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/363/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+18/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document Juice Squeeze avatar artwork fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/363/files#diff-2371c0ea8407bbc94d8d67467237cc40d35ba08d58ab98a8d0f794b5bff64a99">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document Lingo Hero id and artwork fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/363/files#diff-dd09bf20e11864991961b7ef6d2fc6687a66d9a9de2d246f765d9d6891e646c2">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

