### PR TITLE
Lingo Hero: make it playable — slower, easier, bigger words

### DIFF
--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- **Playability overhaul — much slower and easier.** Notes now fall over ~7s
+  (was ~1.3–2.7s) and movement is delta-timed, so it no longer runs 2× faster on
+  90/120Hz phones. Words and note cards are substantially larger and more
+  readable, the hit window is far more forgiving, and BLITZ wave cadence eased
+  from ~1.2s to 3.5–5.5s between waves. Tunable via `NOTE_TRAVEL_SECONDS`.
+
 ### Fixed
 - Install no longer fails with "Pack id mismatch": the pack id is now the
   underscore form `lingo_hero` (manifest, catalog, and game registration) to

--- a/corpan/packs/lingo-hero/manifest.json
+++ b/corpan/packs/lingo-hero/manifest.json
@@ -11,5 +11,5 @@
   "entryType": "script",
   "sdkVersion": "0.1.0",
   "minAppVersion": "0.17.0",
-  "devRevision": "2026-06-22T00:00:00.000Z"
+  "devRevision": "2026-06-23T00:00:00.000Z"
 }

--- a/corpan/packs/lingo-hero/src/Game.ts
+++ b/corpan/packs/lingo-hero/src/Game.ts
@@ -37,7 +37,14 @@ export class Game {
   private notes: Note[] = [];
   private score: number = 0;
   private combo: number = 0;
-  private speed: number = 3;
+  // Seconds a note takes to fall from spawn to the strum line. Higher = slower &
+  // easier — THE primary playability knob. (Was effectively ~1.3–2.7s AND
+  // frame-rate-dependent, which made it unplayable on high-refresh phones.)
+  private readonly NOTE_TRAVEL_SECONDS = 7;
+  // Note fall speed in PIXELS PER SECOND, derived from NOTE_TRAVEL_SECONDS on
+  // resize and applied with delta-time in the loop (frame-rate independent).
+  private speed: number = 200;
+  private lastTimestamp: number = 0;
 
   private isRunning: boolean = false;
   private fontsReady: boolean = false;
@@ -166,7 +173,9 @@ export class Game {
     if (ctx) ctx.scale(dpr, dpr);
 
     this.laneSystem.resize(width, height);
-    this.speed = Math.max(2, height * 0.005);
+    // px/sec so a note covers spawn(-100)→strum(0.8·H) in NOTE_TRAVEL_SECONDS,
+    // independent of canvas size and device refresh rate.
+    this.speed = (height * 0.8 + 100) / this.NOTE_TRAVEL_SECONDS;
   }
 
   private showMenu() {
@@ -382,6 +391,13 @@ export class Game {
   private loop(timestamp: number) {
     if (!this.isRunning) return;
 
+    // Frame-rate-independent timestep (clamped so a backgrounded tab resuming
+    // can't teleport notes through the strum line).
+    const dt = this.lastTimestamp
+      ? Math.min(0.05, (timestamp - this.lastTimestamp) / 1000)
+      : 0;
+    this.lastTimestamp = timestamp;
+
     if (this.state === GameState.PLAYING) {
       // 1. Spawning
       if (this.mode === GameMode.PRACTICE) {
@@ -390,11 +406,11 @@ export class Game {
         }
       } else {
         if (timestamp > this.nextWaveTime) {
-          const minTimeGap = 150 / this.speed;
           this.spawnWave();
-          const dynamicInterval = Math.max(1200, 2500 - this.score * 5);
-          const finalInterval = Math.max(dynamicInterval, minTimeGap * 16);
-          this.nextWaveTime = timestamp + finalInterval;
+          // Calm, confidence-building cadence: a fresh wave every 5.5s, easing to
+          // a 3.5s floor as the score climbs. (Was as low as ~1.2s.)
+          const interval = Math.max(3500, 5500 - this.score * 3);
+          this.nextWaveTime = timestamp + interval;
         }
       }
 
@@ -403,7 +419,7 @@ export class Game {
       const strumY = this.laneSystem.getStrumLineY();
 
       this.notes.forEach((note) => {
-        note.y += this.speed;
+        note.y += this.speed * dt;
 
         if (note.y > boundsHeight + 100) {
           note.missed = true;
@@ -411,7 +427,7 @@ export class Game {
 
         if (
           note.isTarget &&
-          note.y > strumY + 50 &&
+          note.y > strumY + this.laneSystem.getNoteRadius() * 2.2 &&
           !note.hit &&
           !note.missed
         ) {

--- a/corpan/packs/lingo-hero/src/LaneSystem.ts
+++ b/corpan/packs/lingo-hero/src/LaneSystem.ts
@@ -27,8 +27,9 @@ export class LaneSystem {
     this.laneWidth = actualTotalWidth / 3;
     this.startX = (width - actualTotalWidth) / 2;
     
-    // Scale note radius based on lane width
-    this.noteRadius = Math.min(40, this.laneWidth * 0.35);
+    // Scale note radius based on lane width — bigger cards so the words are
+    // readable while they fall.
+    this.noteRadius = Math.min(72, this.laneWidth * 0.5);
   }
 
   getLaneX(index: LaneIndex): number {
@@ -53,7 +54,7 @@ export class LaneSystem {
   // Hit detection logic
   checkHit(lane: LaneIndex, notes: Note[]): Note | null {
     const hitY = this.getStrumLineY();
-    const hitZoneRadius = this.noteRadius * 1.5; // Scale hit zone with note size
+    const hitZoneRadius = this.noteRadius * 2.4; // Generous, forgiving timing window
 
     // Find the note in this lane that is closest to the strum line
     // and hasn't been hit yet

--- a/corpan/packs/lingo-hero/src/Renderer.ts
+++ b/corpan/packs/lingo-hero/src/Renderer.ts
@@ -243,7 +243,9 @@ export class Renderer {
       // Text Rendering
       if (note.text) {
         this.ctx.fillStyle = "white";
-        let fontSize = 20; 
+        // Scale the word with the (now larger) note so it's legible at a glance;
+        // it still auto-shrinks below to fit narrow cards / long words.
+        let fontSize = Math.max(30, r * 0.62);
         this.ctx.font = `bold ${fontSize}px 'Russo One', sans-serif`;
         
         // Fit text


### PR DESCRIPTION
### **User description**
Lingo Hero in production was **unplayably fast and hard** — words tiny, notes impossible to catch. This retunes it for a calm, accomplishable, confidence-building feel (premium, still juicy — only pacing/sizing changed).

## Root causes
- **Frame-rate-dependent movement**: notes moved a fixed amount *per frame* (`note.y += speed`), so on 90/120Hz phones the game ran ~1.5–2× faster than designed.
- **Travel time far too short**: a note reached the strum line in ~1.3–2.7s — not enough to read a foreign word, hear the TTS, and choose among 3 English answers.
- **Tiny words** (fixed 20px) and **small note cards**.
- **BLITZ flooded**: waves could spawn as often as ~1.2s apart.

## Changes
- **Delta-timed movement** — frame-rate independent (the same on 60/90/120/144Hz). Clamped so a backgrounded tab can't teleport notes.
- **`NOTE_TRAVEL_SECONDS = 7`** — notes now fall over ~7s; one clearly-labeled knob for future tuning.
- **Bigger, readable words + cards** — font scales with note size (min 30px, auto-shrinks to fit); note radius cap 40 → 72.
- **Forgiving hit window** — 1.5× → 2.4× note radius; the "passed" miss now fires at the edge of the hit zone instead of early.
- **Calmer BLITZ** — wave cadence eased to 3.5–5.5s.
- Bumped `devRevision` so installed clients re-fetch.

Built green (`tsc` + vite). Live preview of the retuned bundle (offline, mock host) for a feel-check: **http://spark-f62c:5219/**


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Delta-timed note movement

- Slower, calmer gameplay pacing

- Larger, more readable note text

- More forgiving hit detection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  timing["Delta-timed movement"] 
  pacing["7s note travel"]
  visuals["Larger cards and text"]
  hits["Forgiving hit window"]
  blitz["Calmer BLITZ waves"]
  timing -- "stabilizes" --> pacing
  pacing -- "improves readability" --> visuals
  visuals -- "supports" --> hits
  hits -- "pairs with" --> blitz
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Game.ts</strong><dd><code>Frame-independent slower note movement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/src/Game.ts

<ul><li>Adds <code>NOTE_TRAVEL_SECONDS</code> as the main pacing knob.<br> <li> Converts note movement to delta-time-based pixels-per-second.<br> <li> Recalculates fall speed from canvas height on resize.<br> <li> Slows BLITZ wave cadence and delays misses past the larger hit zone.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/365/files#diff-6c075e8c51d32e4e5452a4c738f6cc530345361455286e0f7d1af37f46fedde7">+24/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LaneSystem.ts</strong><dd><code>Larger notes with forgiving hits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/src/LaneSystem.ts

<ul><li>Increases maximum note radius from <code>40</code> to <code>72</code>.<br> <li> Scales notes larger within each lane.<br> <li> Expands hit detection from <code>1.5x</code> to <code>2.4x</code> note radius.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/365/files#diff-49208e8c6b4d3a2cbe84d78c7e15bd2cf92174f83b0eeb9992687c59a0375125">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Renderer.ts</strong><dd><code>More readable falling word labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/src/Renderer.ts

<ul><li>Scales note word font size from note radius.<br> <li> Raises minimum visible word size to <code>30px</code>.<br> <li> Preserves auto-shrink behavior for narrow cards and long words.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/365/files#diff-a8ca1f488ce07a5bfdd1fbb0851ce6f79a8731c3dacfe7d692d733838b839a53">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document Lingo Hero playability overhaul</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/CHANGELOG.md

<ul><li>Documents the playability overhaul under <code>Unreleased</code>.<br> <li> Notes delta-timed movement, larger notes, easier hits, and slower <br>BLITZ waves.<br> <li> Mentions <code>NOTE_TRAVEL_SECONDS</code> as the tuning control.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/365/files#diff-dd09bf20e11864991961b7ef6d2fc6687a66d9a9de2d246f765d9d6891e646c2">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump preview pack revision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/manifest.json

<ul><li>Updates <code>devRevision</code> to <code>2026-06-23T00:00:00.000Z</code>.<br> <li> Forces preview clients to refresh the updated pack bundle.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/365/files#diff-38411e79d50eee7f8ad439a29518dcddf16cdc9cd03739fc81ea212f18519b15">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

