### PR TITLE
Lingo Hero: fix core scoring — correct answers were marked wrong

### DIFF
--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **Correct answers were being scored as wrong (core logic).** Wave content had
+  no dedup, so on a small per-language pool the *correct* English could appear on
+  both the target and a distractor — tapping the right answer hit the duplicate
+  and was penalized. Wave content now guarantees one target + distractors with
+  **distinct entries and distinct English answers**.
+- **Tap-lane vs shown-lane mismatch.** Input split the full width into thirds
+  while the board is centered/capped at 600px, so on wide layouts the lane you
+  tapped wasn't the lane you saw. Input now uses the exact board geometry.
+- Hit detection now selects the note *closest* to the strum line (was first in
+  array order).
+
 ### Changed
 - **Playability overhaul — much slower and easier.** Notes now fall over ~7s
   (was ~1.3–2.7s) and movement is delta-timed, so it no longer runs 2× faster on

--- a/corpan/packs/lingo-hero/manifest.json
+++ b/corpan/packs/lingo-hero/manifest.json
@@ -11,5 +11,5 @@
   "entryType": "script",
   "sdkVersion": "0.1.0",
   "minAppVersion": "0.17.0",
-  "devRevision": "2026-06-23T00:00:00.000Z"
+  "devRevision": "2026-06-23T05:00:00.000Z"
 }

--- a/corpan/packs/lingo-hero/src/ContentManager.ts
+++ b/corpan/packs/lingo-hero/src/ContentManager.ts
@@ -3,45 +3,82 @@ import { HostApi, EntryOut } from "./sdk/types";
 export class ContentManager {
   constructor(private hostApi: HostApi) {}
 
-  async getWaveContent(): Promise<{
-    target: EntryOut;
-    distractors: EntryOut[];
-  }> {
-    // We need 3 items: 1 target, 2 distractors
-    let entries: EntryOut[] = [];
-    
-    // Attempt to get random entries
+  private englishOf(e: EntryOut): string {
+    return (
+      e.translations.find((t) => t.language_code === "en")?.text || ""
+    ).trim();
+  }
+
+  private hasForeign(e: EntryOut): boolean {
+    return e.translations.some((t) => t.language_code !== "en" && t.text.trim());
+  }
+
+  private async fetchBatch(n: number): Promise<EntryOut[]> {
     if (this.hostApi.getRandomEntries) {
-      entries = await this.hostApi.getRandomEntries(3);
-    } else {
-      // Fallback if bulk fetch not available
-      const p1 = this.hostApi.getRandomEntry ? this.hostApi.getRandomEntry() : Promise.resolve(null);
-      const p2 = this.hostApi.getRandomEntry ? this.hostApi.getRandomEntry() : Promise.resolve(null);
-      const p3 = this.hostApi.getRandomEntry ? this.hostApi.getRandomEntry() : Promise.resolve(null);
-      
-      const results = await Promise.all([p1, p2, p3]);
-      entries = results.filter(e => e !== null) as EntryOut[];
+      return (await this.hostApi.getRandomEntries(n)) ?? [];
     }
-    
-    // Ensure unique entries if possible (simple dedup by ID)
-    // For a prototype, raw fetch is okay.
+    if (this.hostApi.getRandomEntry) {
+      const out = await Promise.all(
+        Array.from({ length: n }, () => this.hostApi.getRandomEntry!())
+      );
+      return out.filter(Boolean) as EntryOut[];
+    }
+    return [];
+  }
 
-    if (entries.length === 0) {
-        throw new Error("No content available");
+  /**
+   * Returns one target + up to two distractors that are GUARANTEED to be
+   * distinct entries with DISTINCT English answers. This is the core
+   * correctness contract: the correct English must appear on exactly ONE note,
+   * so tapping the right answer can never be scored wrong. We accumulate across
+   * a few random batches to dedup — which matters when a language's entry pool
+   * is small (the prior code did no dedup, so the correct answer often appeared
+   * on two notes and the "wrong" copy beat the player down).
+   */
+  async getWaveContent(
+    activeLang: string
+  ): Promise<{ target: EntryOut; distractors: EntryOut[] }> {
+    const byId = new Map<number, EntryOut>();
+    for (let attempt = 0; attempt < 4 && byId.size < 6; attempt++) {
+      for (const e of await this.fetchBatch(6)) {
+        if (e && !byId.has(e.entry_id)) byId.set(e.entry_id, e);
+      }
+    }
+    const pool = [...byId.values()];
+    if (pool.length === 0) throw new Error("No content available");
+
+    // Target must have a foreign prompt AND an English answer; prefer one whose
+    // prompt is in the user's active language.
+    const valid = pool.filter((e) => this.hasForeign(e) && this.englishOf(e));
+    const target =
+      valid.find((e) =>
+        e.translations.some(
+          (t) => t.language_code === activeLang && t.text.trim()
+        )
+      ) ??
+      valid[0] ??
+      pool[0];
+
+    // Distinct answers only: never repeat the target's English on a distractor.
+    const seenEnglish = new Set<string>([this.englishOf(target).toLowerCase()]);
+    const distractors: EntryOut[] = [];
+    for (const e of pool) {
+      if (e.entry_id === target.entry_id) continue;
+      const en = this.englishOf(e);
+      const key = en.toLowerCase();
+      if (!en || seenEnglish.has(key)) continue;
+      seenEnglish.add(key);
+      distractors.push(e);
+      if (distractors.length === 2) break;
     }
 
-    // Pick one as target
-    const target = entries[0];
-    const distractors = entries.slice(1);
-    
     return { target, distractors };
   }
 
   /**
-   * Speak RAW text in the given language. `rate` is accepted for signature
-   * symmetry with the host stack config; the current HostApi.speak takes
-   * (lang, text) and reads rate from its own stack config, so rate is a
-   * forward-compat hint here (host applies its configured rate).
+   * Speak RAW text in the given language. The current HostApi.speak takes
+   * (lang, text) and reads rate from its own stack config, so `rate` is a
+   * forward-compat hint the host already applies.
    */
   speak(text: string, lang: string, _rate?: number) {
     this.hostApi.speak(lang, text);

--- a/corpan/packs/lingo-hero/src/Game.ts
+++ b/corpan/packs/lingo-hero/src/Game.ts
@@ -152,11 +152,10 @@ export class Game {
   }
 
   private getLaneFromX(x: number): LaneIndex | null {
-    const width = this.canvas.clientWidth;
-    const third = width / 3;
-    if (x < third) return LaneIndex.Left;
-    else if (x < third * 2) return LaneIndex.Center;
-    else return LaneIndex.Right;
+    // Use the SAME lane geometry the renderer draws with (centered, capped at
+    // 600px). The old naive width/3 split didn't account for the side margins,
+    // so on wide layouts the lane you tapped wasn't the lane you saw.
+    return this.laneSystem.laneAtX(x);
   }
 
   private handleResize(container: HTMLElement) {
@@ -246,7 +245,9 @@ export class Game {
     this.isWaveActive = true;
 
     try {
-      const { target, distractors } = await this.contentManager.getWaveContent();
+      const { target, distractors } = await this.contentManager.getWaveContent(
+        this.activeLanguage.code
+      );
 
       const indices = [0, 1, 2].sort(() => Math.random() - 0.5);
       const t0 = target.translations[0];

--- a/corpan/packs/lingo-hero/src/LaneSystem.ts
+++ b/corpan/packs/lingo-hero/src/LaneSystem.ts
@@ -36,6 +36,13 @@ export class LaneSystem {
     return this.startX + (index * this.laneWidth) + (this.laneWidth / 2);
   }
 
+  // Inverse of getLaneX, honoring the centered/capped lane band. Taps in the
+  // side margins clamp to the nearest edge lane. Keeps input lanes == drawn lanes.
+  laneAtX(x: number): LaneIndex {
+    const idx = Math.floor((x - this.startX) / this.laneWidth);
+    return Math.max(0, Math.min(2, idx)) as LaneIndex;
+  }
+
   getStrumLineY(): number {
     return this.canvasHeight * this.STRUM_LINE_Y_RATIO;
   }
@@ -56,12 +63,19 @@ export class LaneSystem {
     const hitY = this.getStrumLineY();
     const hitZoneRadius = this.noteRadius * 2.4; // Generous, forgiving timing window
 
-    // Find the note in this lane that is closest to the strum line
-    // and hasn't been hit yet
-    const hittableNote = notes
-      .filter(n => n.lane === lane && !n.hit && !n.missed)
-      .find(n => Math.abs(n.y - hitY) < hitZoneRadius);
-
-    return hittableNote || null;
+    // The hittable note in this lane CLOSEST to the strum line (the prior code
+    // returned the first in array order, which could grab the wrong note when
+    // two were on screen).
+    let best: Note | null = null;
+    let bestDist = Infinity;
+    for (const n of notes) {
+      if (n.lane !== lane || n.hit || n.missed) continue;
+      const dist = Math.abs(n.y - hitY);
+      if (dist < hitZoneRadius && dist < bestDist) {
+        best = n;
+        bestDist = dist;
+      }
+    }
+    return best;
   }
 }


### PR DESCRIPTION
### **User description**
**Production was telling players they were wrong when they were right.** Root cause + two related correctness bugs, fixed.

## Root cause: duplicate correct answer
`getWaveContent` did **no dedup** ("raw fetch is okay" / prototype). `getRandomEntries(3)` on a small per-language pool frequently returned the **same entry — or the same English answer — as both the target and a distractor**. So the correct English appeared on *two* notes; only one was `isTarget`. Tapping the right answer hit the duplicate → penalty. That's the "I for sure have the right answer and it says no."

**Fix:** wave content now guarantees **one target + distractors with distinct entries AND distinct English answers**, accumulating across a few random batches to dedup. The active language is passed through so the prompt prefers it.

## Also fixed
- **Tap-lane ≠ shown-lane.** `getLaneFromX` split the *full width* into thirds, but the board is centered and capped at 600px — so on any layout wider than 600px the lane you tapped wasn't the lane you saw. Input now uses `LaneSystem.laneAtX` (the exact board geometry, clamped).
- **Hit selection** now picks the note *closest* to the strum line (was first-in-array order).

Built green (`tsc` + vite). This is the correctness hotfix; the premium A+ rework is the next, larger effort.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Prevent duplicate correct answers

- Align tap lanes with rendering

- Select closest hittable note

- Document scoring correctness fixes


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ContentManager.ts</strong><dd><code>Deduplicate wave content by answer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/src/ContentManager.ts

<ul><li>Adds helpers for English extraction and foreign prompt checks.<br> <li> Introduces batched random entry fetching with fallback support.<br> <li> Updates <code>getWaveContent</code> to require <code>activeLang</code>.<br> <li> Ensures target and distractors have distinct entries and English <br>answers.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/366/files#diff-7f7f66aa0a0ab0785ba8e14b6eec2a3c527ed1175293a5030a3dcadd1575ed52">+67/-30</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Game.ts</strong><dd><code>Use rendered lane geometry for input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/src/Game.ts

<ul><li>Replaces naive canvas-width lane splitting with <code>LaneSystem.laneAtX</code>.<br> <li> Passes the active language code into <code>getWaveContent</code>.<br> <li> Keeps tap detection aligned with centered, capped board geometry.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/366/files#diff-6c075e8c51d32e4e5452a4c738f6cc530345361455286e0f7d1af37f46fedde7">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LaneSystem.ts</strong><dd><code>Improve lane mapping and hit selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/src/LaneSystem.ts

<ul><li>Adds <code>laneAtX</code> as the inverse of rendered lane positioning.<br> <li> Clamps side-margin taps to the nearest lane.<br> <li> Updates hit detection to return the closest eligible note.<br> <li> Avoids array-order-dependent hit selection.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/366/files#diff-49208e8c6b4d3a2cbe84d78c7e15bd2cf92174f83b0eeb9992687c59a0375125">+21/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document Lingo Hero scoring fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/CHANGELOG.md

<ul><li>Documents the duplicate-answer scoring fix.<br> <li> Notes tap-lane versus shown-lane correction.<br> <li> Records closest-note hit detection behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/366/files#diff-dd09bf20e11864991961b7ef6d2fc6687a66d9a9de2d246f765d9d6891e646c2">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump Lingo Hero dev revision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/manifest.json

- Updates `devRevision` timestamp for the new preview build.


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/366/files#diff-38411e79d50eee7f8ad439a29518dcddf16cdc9cd03739fc81ea212f18519b15">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

