### PR TITLE
Lingo Hero — premium Neon Arcade rebuild (board/shell/learning/audio)

### DIFF
--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -19,6 +19,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   optional injected `WordSelector` (or a process-wide default via
   `setDefaultWordSelector`) to bias wave content toward due/weak words while
   still guaranteeing distinct entries + distinct English answers.
+- **Neon Arcade shell + learning surfaces (UI).** Filled the foundation HUD
+  slots with a cohesive, token-driven UI: a romanization line tucked under the
+  foreign prompt, a glassy audio-**replay** button, a premium post-answer
+  **feedback card** (outcome-tinted verdict + foreign → romanization → English
+  meaning reveal, wired to the once-per-wave `wave-resolved` event), and an
+  in-run **mastery readout** (level · correct/seen · accuracy with a progress
+  bar fed from persisted level progress). Added a static synthwave perspective
+  grid backdrop behind the canvas. RTL-aware (bidi `dir="auto"` on revealed
+  text, mirrored chevrons/bars), contrast-checked, fully offline (no remote
+  assets), and reduced-motion safe.
 
 ### Fixed
 - **Correct answers were being scored as wrong (core logic).** Wave content had

--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -62,6 +62,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (`mastery` / `difficulty`). Wired with **no Game.ts edits** — the learning
   layer initialises from the progression module (which already receives the bus
   + hostApi) and injects via `setDefaultWordSelector`.
+- **Synthwave audio palette (fully offline, procedural).** The WebAudio layer
+  splits the master into independent SFX + music sub-buses with a synthesized
+  convolution reverb (procedural impulse, no IR files). A new evolving
+  **MusicBed** — Cm pad + pulsing sub-bass + a combo-faded arp sparkle layer —
+  is driven by a lookahead scheduler; combo swells the music level, lifts tempo
+  (84→104 BPM), and cools on streak break (reduced-motion = lower steady level,
+  arp suppressed). Every SFX cue was elevated with reverb sends + sub-body, tuned
+  to the Cm tonic, plus a subtle per-wave verdict accent. A self-contained neon
+  **mute toggle** (token-styled, 44px touch target, safe-area insets,
+  localStorage-persisted) mutes the whole bus and pauses/resumes the bed. All
+  procedurally synthesized — zero binary assets, no network/fonts.
+- **Premium integration.** Merged the four disjoint premium streams (board /
+  shell / learning / audio) onto the foundation; verified the non-negotiable
+  contracts hold post-merge (distinct-entry + distinct-English wave dedup, TTS
+  speaks raw foreign text, `lingo_hero` pack id, delta-timed ~7s note travel,
+  fully offline — no remote URLs/fonts/fetch) and that the pack builds to
+  `dist/app.js` + `dist/app.css` and registers `window.CorpanGames["lingo_hero"]`.
 
 ### Fixed
 - **Correct answers were being scored as wrong (core logic).** Wave content had

--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **Neon Arcade premium foundation.** A cohesive design-token layer (`--na-*`
+  palette / glow + bloom shadows / type scale / spacing / radii / motion) at the
+  top of `styles.css` that everything downstream styles from. The event bus now
+  carries the target **word identity** (`{ entryId, foreign, english,
+  romanization?, lang }`) on `noteHit` / `noteMiss` plus a new once-per-wave
+  `wave-resolved` event, so the learning stream can do spaced difficulty and the
+  UI can do meaning-reveal. New HUD slots: a romanization line under the prompt,
+  an audio-replay button, a post-answer feedback card, and a mastery readout
+  (minimal no-ops that keep the game playable). `ContentManager` accepts an
+  optional injected `WordSelector` (or a process-wide default via
+  `setDefaultWordSelector`) to bias wave content toward due/weak words while
+  still guaranteeing distinct entries + distinct English answers.
+
 ### Fixed
 - **Correct answers were being scored as wrong (core logic).** Wave content had
   no dedup, so on a small per-language pool the *correct* English could appear on

--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -19,6 +19,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   optional injected `WordSelector` (or a process-wide default via
   `setDefaultWordSelector`) to bias wave content toward due/weak words while
   still guaranteeing distinct entries + distinct English answers.
+- **Spaced difficulty + mastery (learning depth).** A new `src/learning/*`
+  layer gives the loop a memory: per-word correctness is tracked over time in a
+  Leitner/SM-2-lite scheduler (`wordStats.ts`), keyed by host entry id and
+  scoped per (stack, language), persisted offline-first to localStorage with an
+  in-memory fallback. The spaced-difficulty `WordSelector` (`selector.ts`)
+  resurfaces **due / weak** words as the quiz target and orders believable foils
+  as distractors — biasing choice only, never breaking the distinct-entries +
+  distinct-English dedup contract (selected target is validated within the pool;
+  distractor weighting is re-deduped after). A **gentle, hysteretic adaptive
+  difficulty** (`difficulty.ts`) reads rolling accuracy to lean harder into
+  resurfacing when the learner is hot and ease off when they struggle — it
+  tunes *content* pressure only and never touches note speed/spawn timing, so
+  the calibrated ~7s travel feel is preserved. A live **mastery readout**
+  (mastered · learning · due, with a mean-strength progress bar) is surfaced via
+  the foundation's `#mastery-readout` HUD slot and on the progression snapshot
+  (`mastery` / `difficulty`). Wired with **no Game.ts edits** — the learning
+  layer initialises from the progression module (which already receives the bus
+  + hostApi) and injects via `setDefaultWordSelector`.
 
 ### Fixed
 - **Correct answers were being scored as wrong (core logic).** Wave content had

--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -19,6 +19,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   optional injected `WordSelector` (or a process-wide default via
   `setDefaultWordSelector`) to bias wave content toward due/weak words while
   still guaranteeing distinct entries + distinct English answers.
+- **Neon Arcade board visuals.** The canvas (`Renderer`) is rebuilt to the
+  Neon Arcade bar: a scrolling synthwave perspective grid floor converging to a
+  horizon, volumetric glowing lane shafts + neon edge rails in the `--na-lane-*`
+  colors (cyan / magenta / lime, single-sourced from the design tokens), premium
+  glass note cards with a top specular sheen, lane-color spine, and an approach
+  bloom that swells as a note nears the strum line, plus a glass strum bar that
+  leans toward the hottest lane. Hits fire a lane-flash light column + white-hot
+  pop ring; misses flush the floor red; the whole board escalates intensity with
+  the combo (grid speed, lane glow, strum bloom). The VFX particle / shockwave /
+  screen-shake layer now reads the same elevated palette so the board reads as
+  one instrument. The Renderer reacts to gameplay through a shared
+  `effects/boardState` seam written by the bus-subscribed effects layer, so none
+  of this touches `Game.ts`. All Canvas2D, additive-bloom, 60fps-targeted, and
+  fully offline (palette resolves from `:root` tokens with matching hardcoded
+  fallbacks).
 
 ### Fixed
 - **Correct answers were being scored as wrong (core logic).** Wave content had

--- a/corpan/packs/lingo-hero/manifest.json
+++ b/corpan/packs/lingo-hero/manifest.json
@@ -11,5 +11,5 @@
   "entryType": "script",
   "sdkVersion": "0.1.0",
   "minAppVersion": "0.17.0",
-  "devRevision": "2026-06-23T05:00:00.000Z"
+  "devRevision": "2026-06-23T12:00:00.000Z"
 }

--- a/corpan/packs/lingo-hero/src/ContentManager.ts
+++ b/corpan/packs/lingo-hero/src/ContentManager.ts
@@ -1,7 +1,74 @@
 import { HostApi, EntryOut } from "./sdk/types";
 
+/**
+ * WordSelector — the injection point that lets the learning stream bias wave
+ * content toward DUE / WEAK words WITHOUT any further Game.ts edits. Pass one
+ * into the ContentManager constructor; omit it for the default (random) feel.
+ *
+ * CRITICAL: the selector only *biases ordering/choice*. ContentManager ALWAYS
+ * re-applies the distinct-entries + distinct-English-answers dedup AFTER the
+ * selector runs, so the core correctness contract (correct English appears on
+ * exactly one note) can never be broken by a selector. A selector cannot
+ * fabricate entries — it only reorders / scores the candidates it is handed.
+ */
+export interface WordSelector {
+  /**
+   * Choose the TARGET entry from the valid candidate pool (entries that have a
+   * foreign prompt AND an English answer). Return one of `candidates`, or
+   * undefined/null to fall back to default behavior. Must NOT return an entry
+   * outside `candidates`.
+   */
+  chooseTarget?(
+    candidates: EntryOut[],
+    activeLang: string
+  ): EntryOut | undefined | null;
+  /**
+   * Score an entry's *desirability as a distractor* (higher = sooner). Used to
+   * order distractor candidates so e.g. confusable / due words surface. Dedup
+   * still runs after; ties keep pool order. Pure + cheap, please.
+   */
+  weight?(entry: EntryOut, activeLang: string): number;
+  /**
+   * Optional observation hook so a stateful selector can prime itself when a
+   * wave's candidate pool is known (before target/distractor pick). Side-effect
+   * only; return value ignored.
+   */
+  observePool?(candidates: EntryOut[], activeLang: string): void;
+}
+
+/**
+ * Module-level default selector registry. This is how the learning stream
+ * injects spaced-difficulty biasing WITHOUT editing Game.ts: the stream calls
+ * `setDefaultWordSelector(mySelector)` from its own init module (e.g. imported
+ * for side-effects in main.ts), and any ContentManager constructed without an
+ * explicit selector arg picks it up. Set to null to clear.
+ */
+let defaultSelector: WordSelector | null = null;
+
+/** Register the process-wide default WordSelector (learning stream entry). */
+export function setDefaultWordSelector(selector: WordSelector | null): void {
+  defaultSelector = selector;
+}
+
+/** Read the current default selector (mostly for tests / introspection). */
+export function getDefaultWordSelector(): WordSelector | null {
+  return defaultSelector;
+}
+
 export class ContentManager {
-  constructor(private hostApi: HostApi) {}
+  private selector?: WordSelector;
+
+  constructor(
+    private hostApi: HostApi,
+    /**
+     * Optional learning-stream selector. If omitted, falls back to the
+     * module-level default (set via setDefaultWordSelector); if that's also
+     * unset, behavior is the original random feel.
+     */
+    selector?: WordSelector
+  ) {
+    this.selector = selector ?? defaultSelector ?? undefined;
+  }
 
   private englishOf(e: EntryOut): string {
     return (
@@ -50,7 +117,17 @@ export class ContentManager {
     // Target must have a foreign prompt AND an English answer; prefer one whose
     // prompt is in the user's active language.
     const valid = pool.filter((e) => this.hasForeign(e) && this.englishOf(e));
+
+    // Let an injected learning-stream selector observe + bias the pick. It can
+    // ONLY choose from `valid`; anything else is ignored and we fall back to
+    // the original (random) behavior. Dedup below is unconditional.
+    this.selector?.observePool?.(valid, activeLang);
+    const inValid = (e: EntryOut | undefined | null): e is EntryOut =>
+      !!e && valid.some((v) => v.entry_id === e.entry_id);
+    const chosen = this.selector?.chooseTarget?.(valid, activeLang);
+
     const target =
+      (inValid(chosen) ? chosen : undefined) ??
       valid.find((e) =>
         e.translations.some(
           (t) => t.language_code === activeLang && t.text.trim()
@@ -59,10 +136,21 @@ export class ContentManager {
       valid[0] ??
       pool[0];
 
+    // Optional weighting biases the ORDER distractors are considered in. Stable:
+    // higher weight first, ties keep original pool order. Dedup still gates.
+    let distractorOrder = pool;
+    if (this.selector?.weight) {
+      const w = this.selector.weight.bind(this.selector);
+      distractorOrder = pool
+        .map((e, i) => ({ e, i, s: w(e, activeLang) }))
+        .sort((a, b) => b.s - a.s || a.i - b.i)
+        .map((x) => x.e);
+    }
+
     // Distinct answers only: never repeat the target's English on a distractor.
     const seenEnglish = new Set<string>([this.englishOf(target).toLowerCase()]);
     const distractors: EntryOut[] = [];
-    for (const e of pool) {
+    for (const e of distractorOrder) {
       if (e.entry_id === target.entry_id) continue;
       const en = this.englishOf(e);
       const key = en.toLowerCase();

--- a/corpan/packs/lingo-hero/src/Game.ts
+++ b/corpan/packs/lingo-hero/src/Game.ts
@@ -5,6 +5,7 @@ import {
   Note,
   LaneIndex,
   type ActiveLanguage,
+  type WordIdentity,
 } from "./types";
 import { LaneSystem } from "./LaneSystem";
 import { Renderer } from "./Renderer";
@@ -60,6 +61,17 @@ export class Game {
   // Current active question (foreign prompt, display label)
   private currentQuestionText: string = "";
 
+  // Identity of the target word for the CURRENT wave. Carried on
+  // noteHit/noteMiss/wave-resolved so the learning stream + UI can react.
+  // Null between waves. RAW foreign text + entryId is the stable spacing key.
+  private currentWord: WordIdentity | null = null;
+  // Guards "wave-resolved" so it fires exactly once per wave even though
+  // noteMiss can fire on distractor taps before the wave truly resolves.
+  private waveResolved: boolean = false;
+  // The RAW foreign text + lang for the current prompt (for audio replay).
+  private currentSpeakText: string = "";
+  private currentSpeakLang: string = "";
+
   // Track lane activation for visuals
   private lanePressTimes: number[] = [0, 0, 0];
 
@@ -102,6 +114,7 @@ export class Game {
       {
         onStartGame: (mode) => this.startGame(mode),
         onShowMenu: () => this.showMenu(),
+        onReplayPrompt: () => this.replayPrompt(),
       },
       this.progression
     );
@@ -149,6 +162,20 @@ export class Game {
   /** The resolved active target language (for the UI stream). */
   getActiveLanguage(): ActiveLanguage {
     return this.activeLanguage;
+  }
+
+  /**
+   * Re-speak the CURRENT prompt's RAW foreign text at the host rate. Wired to
+   * the Hud audio-replay button (callback). No-op if no wave is active yet.
+   * Speaks RAW text (not display-cleaned) per the TTS contract.
+   */
+  replayPrompt(): void {
+    if (!this.currentSpeakText) return;
+    this.contentManager.speak(
+      this.currentSpeakText,
+      this.currentSpeakLang || this.activeLanguage.code,
+      this.activeLanguage.rate
+    );
   }
 
   private getLaneFromX(x: number): LaneIndex | null {
@@ -243,6 +270,7 @@ export class Game {
 
   private async spawnWave() {
     this.isWaveActive = true;
+    this.waveResolved = false;
 
     try {
       const { target, distractors } = await this.contentManager.getWaveContent(
@@ -255,6 +283,7 @@ export class Game {
       let speakText = ""; // RAW text fed to TTS
       let speakLang = "";
       let visualText = ""; // English answer shown on the target note
+      let romanization: string | undefined; // optional, host-provided
 
       // Prefer the user's resolved active language; fall back to any non-English.
       const foreign =
@@ -267,6 +296,7 @@ export class Game {
         this.currentQuestionText = this.cleanDisplay(foreign.text);
         speakText = foreign.text;
         speakLang = foreign.language_code;
+        romanization = foreign.romanization?.trim() || undefined;
 
         const enTrans =
           target.translations.find((t) => t.language_code === "en")?.text ||
@@ -276,10 +306,23 @@ export class Game {
         this.currentQuestionText = this.cleanDisplay(t0?.text || "?");
         speakText = t0?.text || "";
         speakLang = t0?.language_code || "en";
+        romanization = t0?.romanization?.trim() || undefined;
         visualText = this.cleanDisplay(t0?.text || "");
       }
 
+      // Establish the target word identity for this wave (learning ABI).
+      this.currentWord = {
+        entryId: target.entry_id,
+        foreign: speakText,
+        english: visualText,
+        romanization,
+        lang: speakLang,
+      };
+      this.currentSpeakText = speakText;
+      this.currentSpeakLang = speakLang;
+
       this.hud.setQuestion(this.currentQuestionText);
+      this.hud.setRomanization(romanization ?? "");
 
       const targetNote: Note = {
         id: `note-${Date.now()}-t`,
@@ -333,6 +376,25 @@ export class Game {
     this.bus.emit("comboChange", { value, previous });
   }
 
+  /**
+   * Emit the single, authoritative "wave-resolved" event for the current wave.
+   * Fires at most once per wave (guarded by `waveResolved`) so the learning
+   * stream records exactly one outcome and the UI raises one feedback card.
+   * Distractor taps before resolution don't resolve the wave (the player can
+   * still hit the target), so only target-hit / target-passed call this.
+   */
+  private resolveWave(outcome: "correct" | "wrong" | "passed") {
+    if (this.waveResolved || !this.currentWord) return;
+    this.waveResolved = true;
+    this.bus.emit("wave-resolved", {
+      word: this.currentWord,
+      outcome,
+      correct: outcome === "correct",
+      combo: this.combo,
+      mode: this.mode,
+    });
+  }
+
   private handleInput(lane: LaneIndex) {
     this.lanePressTimes[lane] = performance.now();
 
@@ -341,6 +403,15 @@ export class Game {
     const hitNote = this.laneSystem.checkHit(lane, this.notes);
     const strumY = this.laneSystem.getStrumLineY();
     const laneX = this.laneSystem.getLaneX(lane);
+
+    // The wave's target identity (always set during an active wave). Fall back
+    // to a synthetic identity so the strongly-typed event always carries a word.
+    const word: WordIdentity = this.currentWord ?? {
+      entryId: -1,
+      foreign: this.currentSpeakText,
+      english: "",
+      lang: this.currentSpeakLang || this.activeLanguage.code,
+    };
 
     if (hitNote) {
       if (hitNote.isTarget) {
@@ -356,7 +427,9 @@ export class Game {
           combo: this.combo,
           points,
           mode: this.mode,
+          word,
         });
+        this.resolveWave("correct");
 
         if (this.mode === GameMode.PRACTICE) {
           this.notes.forEach((n) => {
@@ -375,7 +448,12 @@ export class Game {
           y: strumY,
           reason: "wrong",
           mode: this.mode,
+          word,
         });
+        // A wrong distractor tap does NOT end the wave (preserves prior feel):
+        // the target keeps falling and the player can still hit it. The wave
+        // resolves only when the target is hit ("correct") or passes
+        // ("passed", emitted from the loop). So no resolveWave() here.
       }
     } else {
       this.setCombo(0);
@@ -385,6 +463,7 @@ export class Game {
         y: strumY,
         reason: "wrong",
         mode: this.mode,
+        word,
       });
     }
   }
@@ -433,13 +512,21 @@ export class Game {
           !note.missed
         ) {
           this.setCombo(0);
+          const passedWord: WordIdentity = this.currentWord ?? {
+            entryId: -1,
+            foreign: this.currentSpeakText,
+            english: note.text,
+            lang: this.currentSpeakLang || this.activeLanguage.code,
+          };
           this.bus.emit("noteMiss", {
             lane: note.lane,
             x: this.laneSystem.getLaneX(note.lane),
             y: strumY,
             reason: "passed",
             mode: this.mode,
+            word: passedWord,
           });
+          this.resolveWave("passed");
 
           if (this.mode === GameMode.PRACTICE) {
             this.isWaveActive = false;

--- a/corpan/packs/lingo-hero/src/Renderer.ts
+++ b/corpan/packs/lingo-hero/src/Renderer.ts
@@ -1,13 +1,92 @@
 import { LaneIndex, Note } from "./types";
 import { LaneSystem } from "./LaneSystem";
+import {
+  getBoardState,
+  tickBoardState,
+  type LaneFlash,
+} from "./effects/boardState";
+
+/**
+ * Renderer — the Neon Arcade canvas floor. STREAM: board.
+ *
+ * Draws (back→front) each frame, inside Game's loop, BEFORE the VFX layer:
+ *   1. clear()
+ *   2. drawLanes()  — synthwave perspective grid floor + volumetric neon lane
+ *                     shafts + glass strum bar + fret pads (combo-escalated).
+ *   3. drawNotes()  — glass note cards with the foreign/answer word, approach
+ *                     bloom, motion trails, and the per-note hit pop.
+ * The particle/shake/shockwave/transition juice is layered on top by
+ * effects/index.ts (a bus subscriber). This file never imports the bus and
+ * never touches Game.ts; it reads gameplay escalation through the shared
+ * `effects/boardState` seam that the effects stream writes to.
+ *
+ * Palette is single-sourced from the `--na-*` design tokens, resolved once from
+ * :root at construction (with hardcoded fallbacks that MATCH the tokens, so the
+ * board is correct fully offline even if getComputedStyle is unavailable).
+ *
+ * Performance: pure Canvas2D, allocation-light per frame (gradients are the only
+ * per-frame allocs — unavoidable in 2D and cheap at this count), one additive
+ * pass for trails/glow. Grid lines are bounded and depth-culled. Targets 60fps
+ * on mobile; all motion is wall-clock driven so it's refresh-rate independent.
+ */
+
+interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+// Fallbacks MATCH the --na-* tokens (offline-safe if :root can't be read).
+const FALLBACK = {
+  bg0: { r: 7, g: 6, b: 15 }, // --na-bg  #07060f
+  bg1: { r: 13, g: 11, b: 26 }, // --na-bg-elev #0d0b1a
+  bg2: { r: 20, g: 17, b: 42 }, // --na-surface #14112a
+  lane1: { r: 47, g: 243, b: 255 }, // --na-lane-1 cyan
+  lane2: { r: 255, g: 0, b: 212 }, // --na-lane-2 magenta
+  lane3: { r: 123, g: 255, b: 123 }, // --na-lane-3 lime
+  accent: { r: 154, g: 130, b: 255 }, // grid horizon violet (--neon-violet-ish)
+  text: { r: 244, g: 241, b: 255 }, // --na-text
+  wrong: { r: 255, g: 62, b: 165 }, // --na-wrong neon pink
+};
 
 export class Renderer {
   private ctx: CanvasRenderingContext2D;
+
+  // Resolved lane colors (from tokens, with fallback). Index = LaneIndex.
+  private laneColors: [Rgb, Rgb, Rgb];
+  private bgTop: Rgb;
+  private bgMid: Rgb;
+  private bgBot: Rgb;
+  private horizonColor: Rgb;
+  private textColor: Rgb;
+  private wrongColor: Rgb;
+
+  // Frame clock for the board-state easing + scrolling grid (wall-clock).
+  private lastFrame = performance.now();
+  // Scrolling phase for the synthwave floor grid (advances with energy).
+  private gridScroll = 0;
 
   constructor(private canvas: HTMLCanvasElement, private laneSystem: LaneSystem) {
     this.ctx = canvas.getContext("2d")!;
     this.ctx.textAlign = "center";
     this.ctx.textBaseline = "middle";
+
+    const root =
+      typeof document !== "undefined" ? document.documentElement : null;
+    const read = (name: string, fb: Rgb): Rgb =>
+      parseColor(cssVar(root, name)) ?? fb;
+
+    this.laneColors = [
+      read("--na-lane-1", FALLBACK.lane1),
+      read("--na-lane-2", FALLBACK.lane2),
+      read("--na-lane-3", FALLBACK.lane3),
+    ];
+    this.bgTop = read("--na-bg", FALLBACK.bg0);
+    this.bgMid = read("--na-bg-elev", FALLBACK.bg1);
+    this.bgBot = read("--na-surface", FALLBACK.bg2);
+    this.horizonColor = read("--na-accent", FALLBACK.accent);
+    this.textColor = read("--na-text", FALLBACK.text);
+    this.wrongColor = read("--na-wrong", FALLBACK.wrong);
   }
 
   clear() {
@@ -16,283 +95,640 @@ export class Renderer {
     this.ctx.clearRect(0, 0, width, height);
   }
 
+  // -------------------------------------------------------------------------
+  // LANES — perspective grid floor + volumetric neon lane shafts + strum/pads.
+  // -------------------------------------------------------------------------
   drawLanes(activeLanes: number[] = []) {
+    const ctx = this.ctx;
+    const now = performance.now();
+
+    // Advance shared board easing once per frame (Renderer is the first paint).
+    let dt = (now - this.lastFrame) / 1000;
+    this.lastFrame = now;
+    if (!(dt > 0)) dt = 1 / 60;
+    if (dt > 0.1) dt = 0.1;
+    tickBoardState(dt);
+    const board = getBoardState();
+    const energy = board.energy; // 0..1 combo-driven escalation
+    const heat = board.heat;
+
     const height = parseFloat(this.canvas.style.height);
+    const width = parseFloat(this.canvas.style.width);
     const strumY = this.laneSystem.getStrumLineY();
 
-    // 1. Draw Linear Highway Background
-    // Dark background for the track
     const lane0 = this.laneSystem.getLaneBounds(0);
     const lane2 = this.laneSystem.getLaneBounds(2);
     const trackX = lane0.x;
-    const trackWidth = (lane2.x + lane2.width) - lane0.x;
-    
-    // Fretboard gradient
-    const grad = this.ctx.createLinearGradient(trackX, 0, trackX + trackWidth, 0);
-    grad.addColorStop(0, "#080808");
-    grad.addColorStop(0.5, "#151515");
-    grad.addColorStop(1, "#080808");
-    
-    this.ctx.fillStyle = grad;
-    this.ctx.fillRect(trackX, 0, trackWidth, height);
-    
-    // Side borders
-    this.ctx.strokeStyle = "#333";
-    this.ctx.lineWidth = 4;
-    this.ctx.beginPath();
-    this.ctx.moveTo(trackX, 0);
-    this.ctx.lineTo(trackX, height);
-    this.ctx.moveTo(trackX + trackWidth, 0);
-    this.ctx.lineTo(trackX + trackWidth, height);
-    this.ctx.stroke();
+    const trackWidth = lane2.x + lane2.width - trackX;
+    const trackRight = trackX + trackWidth;
 
-    // 2. Vertical Lane Dividers
-    this.ctx.strokeStyle = "rgba(255, 255, 255, 0.1)";
-    this.ctx.lineWidth = 2;
-    for (let i = 1; i < 3; i++) {
-        const x = this.laneSystem.getLaneBounds(i).x;
-        this.ctx.beginPath();
-        this.ctx.moveTo(x, 0);
-        this.ctx.lineTo(x, height);
-        this.ctx.stroke();
-    }
-    
-    // 3. Strum Line (Target Area) — breathing energy bar.
-    const tNow = performance.now();
-    const breathe = 0.5 + 0.5 * Math.sin(tNow * 0.004);
-    const barGrad = this.ctx.createLinearGradient(trackX, 0, trackX + trackWidth, 0);
-    barGrad.addColorStop(0, "rgba(0,255,255,0.05)");
-    barGrad.addColorStop(0.5, `rgba(255,255,255,${0.1 + breathe * 0.06})`);
-    barGrad.addColorStop(1, "rgba(0,255,0,0.05)");
-    this.ctx.fillStyle = barGrad;
-    this.ctx.fillRect(trackX, strumY - 12, trackWidth, 24);
+    // 1) FULL-SCREEN SYNTHWAVE BACKDROP — deep vertical wash so the gutters and
+    //    the track share one cohesive night sky (the VFX starfield sits in the
+    //    gutters on top of this). Drawn opaque so clear() leaves no host bleed.
+    const sky = ctx.createLinearGradient(0, 0, 0, height);
+    sky.addColorStop(0, rgbStr(this.bgTop));
+    sky.addColorStop(0.55, rgbStr(this.bgMid));
+    sky.addColorStop(1, rgbStr(mix(this.bgBot, this.horizonColor, 0.12)));
+    ctx.fillStyle = sky;
+    ctx.fillRect(0, 0, width, height);
 
-    this.ctx.save();
-    this.ctx.shadowBlur = 8 + breathe * 8;
-    this.ctx.shadowColor = "rgba(255,255,255,0.8)";
-    this.ctx.strokeStyle = `rgba(255, 255, 255, ${0.45 + breathe * 0.3})`;
-    this.ctx.lineWidth = 2;
-    this.ctx.beginPath();
-    this.ctx.moveTo(trackX, strumY);
-    this.ctx.lineTo(trackX + trackWidth, strumY);
-    this.ctx.stroke();
-    this.ctx.restore();
+    // 2) TRACK FLOOR — the perspective grid lives between the horizon (a little
+    //    above the top of the visible track band) and the strum line, then a
+    //    near-field continues below the strum toward the bottom edge.
+    //    We give the track a subtly brighter, glassier base than the sky.
+    const floorGrad = ctx.createLinearGradient(trackX, 0, trackRight, 0);
+    floorGrad.addColorStop(0, rgba(this.bgMid, 0.0));
+    floorGrad.addColorStop(0.5, rgba(mix(this.bgMid, this.horizonColor, 0.1), 0.55));
+    floorGrad.addColorStop(1, rgba(this.bgMid, 0.0));
+    ctx.fillStyle = floorGrad;
+    ctx.fillRect(trackX, 0, trackWidth, height);
 
-    // 4. Hit Targets (Fret Buttons)
+    this.drawPerspectiveGrid(
+      trackX,
+      trackRight,
+      height,
+      strumY,
+      energy,
+      dt
+    );
+
+    // 3) VOLUMETRIC NEON LANE SHAFTS — a soft column of lane-colored light per
+    //    lane, brightest at the strum line, fading up the track. Additive.
+    ctx.save();
+    ctx.globalCompositeOperation = "lighter";
     for (let i = 0; i < 3; i++) {
-        const centerX = this.laneSystem.getLaneX(i);
-        const color = this.getNeonColor(i);
-        const isActive = activeLanes.includes(i);
-        
-        // Fret Button Logic
-        const r = this.laneSystem.getNoteRadius();
-        
-        this.ctx.beginPath();
-        this.ctx.arc(centerX, strumY, r, 0, Math.PI * 2);
-        
-        if (isActive) {
-            // "Pressed" Animation State — bright slam with an expanding halo.
-            this.ctx.save();
-            this.ctx.shadowBlur = 32;
-            this.ctx.shadowColor = color;
-            this.ctx.fillStyle = color;
-            this.ctx.fill();
-            this.ctx.fillStyle = "rgba(255,255,255,0.85)";
-            this.ctx.fill();
-            // Halo ring around the pressed button.
-            this.ctx.beginPath();
-            this.ctx.arc(centerX, strumY, r * 1.35, 0, Math.PI * 2);
-            this.ctx.strokeStyle = color;
-            this.ctx.lineWidth = 3;
-            this.ctx.stroke();
-            this.ctx.restore();
-        } else {
-            // Resting State (Hollow Ring) with a gentle idle breathe.
-            const idle = 0.5 + 0.5 * Math.sin(performance.now() * 0.003 + i * 1.3);
-            this.ctx.save();
-            this.ctx.shadowBlur = 6 + idle * 8;
-            this.ctx.shadowColor = color;
-            this.ctx.strokeStyle = color;
-            this.ctx.lineWidth = 4;
-            this.ctx.stroke();
-            this.ctx.restore();
+      const c = this.laneColors[i];
+      const cx = this.laneSystem.getLaneX(i as LaneIndex);
+      const halfW = lane0.width * 0.5;
+      // Vertical shaft: brightest band hugging the strum line.
+      const shaft = ctx.createLinearGradient(0, strumY - height * 0.62, 0, strumY + 12);
+      const baseA = 0.05 + energy * 0.06;
+      shaft.addColorStop(0, rgba(c, 0));
+      shaft.addColorStop(0.78, rgba(c, baseA));
+      shaft.addColorStop(1, rgba(c, baseA + 0.1 + energy * 0.08));
+      ctx.fillStyle = shaft;
+      ctx.fillRect(cx - halfW, strumY - height * 0.62, halfW * 2, height * 0.62 + 12);
 
-            this.ctx.fillStyle = "rgba(0,0,0,0.5)";
-            this.ctx.fill();
-        }
-        this.ctx.shadowBlur = 0;
+      // A tighter, brighter central glow line down each lane.
+      const core = ctx.createLinearGradient(cx - halfW * 0.12, 0, cx + halfW * 0.12, 0);
+      core.addColorStop(0, rgba(c, 0));
+      core.addColorStop(0.5, rgba(c, 0.08 + energy * 0.07));
+      core.addColorStop(1, rgba(c, 0));
+      ctx.fillStyle = core;
+      ctx.fillRect(cx - halfW * 0.12, strumY - height * 0.55, halfW * 0.24, height * 0.55);
+    }
+    ctx.restore();
+
+    // 4) LANE EDGE RAILS — glowing neon dividers framing the three lanes. The
+    //    outer rails blend the two adjacent lane colors; inner dividers too.
+    this.drawLaneRails(trackX, trackRight, lane0.width, height, energy);
+
+    // 5) STRUM LINE — a premium glass energy bar with a bright neon edge and a
+    //    breathing bloom. Color leans toward the hottest recent lane.
+    this.drawStrumBar(trackX, trackWidth, strumY, now, energy, heat, board);
+
+    // 6) FRET PADS — glassy hit targets per lane with idle breathe + press slam.
+    for (let i = 0; i < 3; i++) {
+      this.drawFretPad(i as LaneIndex, strumY, now, activeLanes.includes(i), energy, board.laneFlash[i]);
+    }
+
+    // 7) MISS WASH — a brief red flood across the floor when the player whiffs
+    //    or lets the target sail past (read from the board seam).
+    const missAge = (now - board.lastMissAt) / 1000;
+    if (missAge >= 0 && missAge < 0.45) {
+      const k = 1 - missAge / 0.45;
+      ctx.save();
+      const g = ctx.createLinearGradient(0, strumY - 120, 0, strumY + 40);
+      g.addColorStop(0, rgba(this.wrongColor, 0));
+      g.addColorStop(1, rgba(this.wrongColor, 0.16 * k * board.lastMissPower));
+      ctx.fillStyle = g;
+      ctx.fillRect(trackX, strumY - 120, trackWidth, 160);
+      ctx.restore();
     }
   }
 
+  /**
+   * Synthwave perspective grid: horizontal rails marching up toward a vanishing
+   * horizon (spacing compresses with depth) + converging verticals that fan out
+   * from the horizon to the lane edges at the strum line. Scrolls toward the
+   * player; speed ramps with combo energy. Depth-faded so the horizon dissolves
+   * into the sky and the near field reads crisp.
+   */
+  private drawPerspectiveGrid(
+    trackX: number,
+    trackRight: number,
+    height: number,
+    strumY: number,
+    energy: number,
+    dt: number
+  ): void {
+    const ctx = this.ctx;
+    const cx = (trackX + trackRight) / 2;
+    const trackW = trackRight - trackX;
+
+    // Horizon sits above the playfield (off the top of the lane band) so lines
+    // converge into the distance. Near plane = strum line.
+    const horizonY = strumY - height * 0.92;
+    const span = strumY - horizonY;
+    if (span <= 1) return;
+
+    // Scroll the grid toward the player; faster as the combo heats up.
+    this.gridScroll += dt * (0.18 + energy * 0.42);
+    if (this.gridScroll > 1) this.gridScroll -= Math.floor(this.gridScroll);
+
+    ctx.save();
+    ctx.globalCompositeOperation = "lighter";
+
+    // --- Horizontal depth rails ---
+    // Param u in [0,1): 0 = horizon, 1 = near (strum). Perspective: y grows
+    // non-linearly. We march N rails and offset by scroll so they appear to
+    // flow toward us; each rail's screen y = horizon + span * pow(u, p).
+    const RAILS = 18;
+    const p = 2.2; // perspective exponent (compresses near the horizon)
+    for (let i = 0; i < RAILS; i++) {
+      let u = (i + this.gridScroll) / RAILS;
+      if (u <= 0 || u >= 1) continue;
+      const y = horizonY + span * Math.pow(u, p);
+      if (y < horizonY || y > strumY + 1) continue;
+      // Lines widen toward the viewer (track edges fan from cx at horizon to
+      // full width at strum). Width fraction follows the same perspective.
+      const wf = Math.pow(u, p * 0.5);
+      const halfSpan = (trackW / 2) * (0.04 + 0.96 * wf);
+      // Depth fade: dim near horizon, brighter near player, then the very
+      // nearest few fade as they pass off the bottom.
+      const depthA = Math.pow(u, 1.4) * (1 - u * 0.15);
+      const a = depthA * (0.16 + energy * 0.16);
+      ctx.strokeStyle = rgba(mix(this.horizonColor, this.laneColors[1], 0.25), a);
+      ctx.lineWidth = 0.6 + wf * 1.6;
+      ctx.beginPath();
+      ctx.moveTo(cx - halfSpan, y);
+      ctx.lineTo(cx + halfSpan, y);
+      ctx.stroke();
+    }
+
+    // --- Converging verticals: fan from the horizon point to evenly spaced
+    //     near-plane positions across the track. 7 lines for a clean weave. ---
+    const VERTS = 7;
+    for (let i = 0; i <= VERTS; i++) {
+      const f = i / VERTS; // 0..1 across the track at the near plane
+      const nearX = trackX + f * trackW;
+      // All verticals originate near the horizon center (vanishing point) with
+      // a slight spread so they don't pinch to a single pixel.
+      const farX = cx + (f - 0.5) * trackW * 0.06;
+      const grad = ctx.createLinearGradient(0, horizonY, 0, strumY);
+      grad.addColorStop(0, rgba(this.horizonColor, 0));
+      grad.addColorStop(1, rgba(mix(this.horizonColor, this.laneColors[1], 0.3), 0.12 + energy * 0.12));
+      ctx.strokeStyle = grad;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(farX, horizonY);
+      ctx.lineTo(nearX, strumY);
+      ctx.stroke();
+    }
+
+    // --- Horizon glow bar: a soft bloom where the grid dissolves into sky. ---
+    const hg = ctx.createLinearGradient(0, horizonY - 24, 0, horizonY + 40);
+    hg.addColorStop(0, rgba(this.horizonColor, 0));
+    hg.addColorStop(0.5, rgba(this.horizonColor, 0.1 + energy * 0.1));
+    hg.addColorStop(1, rgba(this.horizonColor, 0));
+    ctx.fillStyle = hg;
+    ctx.fillRect(trackX, horizonY - 24, trackW, 64);
+
+    ctx.restore();
+  }
+
+  /** Glowing neon rails framing the lanes (outer track edges + inner dividers). */
+  private drawLaneRails(
+    trackX: number,
+    trackRight: number,
+    laneW: number,
+    height: number,
+    energy: number
+  ): void {
+    const ctx = this.ctx;
+    ctx.save();
+    ctx.globalCompositeOperation = "lighter";
+
+    // Four rail positions: left edge, two dividers, right edge.
+    const rails: Array<{ x: number; c: Rgb }> = [
+      { x: trackX, c: this.laneColors[0] },
+      { x: trackX + laneW, c: mix(this.laneColors[0], this.laneColors[1], 0.5) },
+      { x: trackX + laneW * 2, c: mix(this.laneColors[1], this.laneColors[2], 0.5) },
+      { x: trackRight, c: this.laneColors[2] },
+    ];
+
+    for (const rail of rails) {
+      // Soft halo column around the rail.
+      const halo = ctx.createLinearGradient(rail.x - 6, 0, rail.x + 6, 0);
+      halo.addColorStop(0, rgba(rail.c, 0));
+      halo.addColorStop(0.5, rgba(rail.c, 0.18 + energy * 0.14));
+      halo.addColorStop(1, rgba(rail.c, 0));
+      ctx.fillStyle = halo;
+      ctx.fillRect(rail.x - 6, 0, 12, height);
+      // Crisp 1px neon core.
+      ctx.strokeStyle = rgba(rail.c, 0.5 + energy * 0.3);
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      ctx.moveTo(rail.x, 0);
+      ctx.lineTo(rail.x, height);
+      ctx.stroke();
+    }
+    ctx.restore();
+  }
+
+  /** Premium glass strum bar with neon edge + breathing bloom, color-led by heat. */
+  private drawStrumBar(
+    trackX: number,
+    trackWidth: number,
+    strumY: number,
+    now: number,
+    energy: number,
+    heat: number,
+    board: Readonly<ReturnType<typeof getBoardState>>
+  ): void {
+    const ctx = this.ctx;
+    const breathe = 0.5 + 0.5 * Math.sin(now * 0.004);
+
+    // Lead color: blend toward the lane of the most recent flash.
+    let lead: Rgb = mix(this.laneColors[0], this.laneColors[2], 0.5);
+    let freshest = -Infinity;
+    for (let i = 0; i < 3; i++) {
+      const f = board.laneFlash[i];
+      if (f.at > freshest) {
+        freshest = f.at;
+        const age = (now - f.at) / 1000;
+        if (age < 0.5) lead = mix(lead, this.laneColors[i], 1 - age / 0.5);
+      }
+    }
+
+    // Glass slab behind the line.
+    ctx.save();
+    const barH = 26;
+    const slab = ctx.createLinearGradient(0, strumY - barH / 2, 0, strumY + barH / 2);
+    slab.addColorStop(0, rgba(lead, 0.02));
+    slab.addColorStop(0.5, rgba(lead, 0.14 + heat * 0.12 + breathe * 0.04));
+    slab.addColorStop(1, rgba(lead, 0.02));
+    ctx.fillStyle = slab;
+    ctx.fillRect(trackX, strumY - barH / 2, trackWidth, barH);
+
+    // Top glass highlight hairline.
+    ctx.fillStyle = rgba({ r: 255, g: 255, b: 255 }, 0.08 + breathe * 0.05);
+    ctx.fillRect(trackX, strumY - barH / 2, trackWidth, 1);
+
+    // The neon line itself — additive, blooming.
+    ctx.globalCompositeOperation = "lighter";
+    ctx.shadowBlur = 10 + breathe * 10 + heat * 14 + energy * 8;
+    ctx.shadowColor = rgbStr(lead);
+    ctx.strokeStyle = rgba(lead, 0.6 + breathe * 0.3 + heat * 0.1 + energy * 0.08);
+    ctx.lineWidth = 2.5 + energy * 1;
+    ctx.beginPath();
+    ctx.moveTo(trackX, strumY);
+    ctx.lineTo(trackX + trackWidth, strumY);
+    ctx.stroke();
+    // Bright white inner core for that "hot wire" pop.
+    ctx.shadowBlur = 0;
+    ctx.strokeStyle = rgba({ r: 255, g: 255, b: 255 }, 0.25 + breathe * 0.2);
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(trackX, strumY);
+    ctx.lineTo(trackX + trackWidth, strumY);
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  /** Glass fret pad with idle breathe, press slam, and a hit-flash column. */
+  private drawFretPad(
+    lane: LaneIndex,
+    strumY: number,
+    now: number,
+    isActive: boolean,
+    energy: number,
+    flash: LaneFlash
+  ): void {
+    const ctx = this.ctx;
+    const cx = this.laneSystem.getLaneX(lane);
+    const c = this.laneColors[lane];
+    const r = this.laneSystem.getNoteRadius();
+
+    // --- Hit flash column: a bright lane-colored beam shooting up from the pad
+    //     the instant a note lands here (decays over ~360ms). The particles
+    //     come from the VFX layer; this is the lane's own light response. ---
+    const flashAge = (now - flash.at) / 1000;
+    if (flashAge >= 0 && flashAge < 0.36) {
+      const k = 1 - flashAge / 0.36;
+      ctx.save();
+      ctx.globalCompositeOperation = "lighter";
+      const beamW = r * (0.9 + (1 - k) * 0.5);
+      const beam = ctx.createLinearGradient(0, strumY - r * 7, 0, strumY);
+      beam.addColorStop(0, rgba(c, 0));
+      beam.addColorStop(1, rgba(c, 0.5 * k * flash.power));
+      ctx.fillStyle = beam;
+      ctx.fillRect(cx - beamW, strumY - r * 7, beamW * 2, r * 7);
+      ctx.restore();
+    }
+
+    const idle = 0.5 + 0.5 * Math.sin(now * 0.003 + lane * 1.3);
+
+    ctx.save();
+    if (isActive) {
+      // PRESSED — bright slam: filled neon core, white-hot center, expanding halo.
+      ctx.globalCompositeOperation = "lighter";
+      ctx.shadowBlur = 30;
+      ctx.shadowColor = rgbStr(c);
+      // Filled disc.
+      ctx.beginPath();
+      ctx.arc(cx, strumY, r, 0, Math.PI * 2);
+      ctx.fillStyle = rgba(c, 0.85);
+      ctx.fill();
+      // White core.
+      ctx.beginPath();
+      ctx.arc(cx, strumY, r * 0.55, 0, Math.PI * 2);
+      ctx.fillStyle = rgba({ r: 255, g: 255, b: 255 }, 0.9);
+      ctx.fill();
+      // Expanding halo ring.
+      ctx.shadowBlur = 0;
+      ctx.beginPath();
+      ctx.arc(cx, strumY, r * 1.4, 0, Math.PI * 2);
+      ctx.strokeStyle = rgba(c, 0.7);
+      ctx.lineWidth = 3;
+      ctx.stroke();
+    } else {
+      // RESTING — glassy hollow ring with a soft inner well + idle breathe glow.
+      // Glass well (subtle dark dish so the pad reads as a physical button).
+      const well = ctx.createRadialGradient(cx, strumY, 0, cx, strumY, r);
+      well.addColorStop(0, rgba(this.bgBot, 0.55));
+      well.addColorStop(0.7, rgba(this.bgTop, 0.5));
+      well.addColorStop(1, rgba(this.bgTop, 0.0));
+      ctx.fillStyle = well;
+      ctx.beginPath();
+      ctx.arc(cx, strumY, r, 0, Math.PI * 2);
+      ctx.fill();
+
+      // Neon ring (additive glow).
+      ctx.globalCompositeOperation = "lighter";
+      ctx.shadowBlur = 6 + idle * 8 + energy * 8;
+      ctx.shadowColor = rgbStr(c);
+      ctx.strokeStyle = rgba(c, 0.55 + idle * 0.25 + energy * 0.15);
+      ctx.lineWidth = 3.5;
+      ctx.beginPath();
+      ctx.arc(cx, strumY, r, 0, Math.PI * 2);
+      ctx.stroke();
+      // Thin bright inner rim highlight (glass edge).
+      ctx.shadowBlur = 0;
+      ctx.strokeStyle = rgba({ r: 255, g: 255, b: 255 }, 0.12 + idle * 0.08);
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.arc(cx, strumY, r * 0.86, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+    ctx.restore();
+  }
+
+  // -------------------------------------------------------------------------
+  // NOTES — motion trails, glass cards w/ approach bloom, hit pop.
+  // -------------------------------------------------------------------------
   drawNotes(notes: Note[]) {
+    const ctx = this.ctx;
     const now = performance.now();
     const strumY = this.laneSystem.getStrumLineY();
+    const r = this.laneSystem.getNoteRadius();
 
-    // PASS 1 — motion trails behind every falling note (drawn additively so
-    // overlaps bloom). Cheap vertical gradient comet-tail; reads as speed/juice.
-    this.ctx.save();
-    this.ctx.globalCompositeOperation = "lighter";
+    // PASS 1 — additive motion trails behind every live note (comet tails that
+    // brighten as they approach the strum line). One additive pass = cheap bloom.
+    ctx.save();
+    ctx.globalCompositeOperation = "lighter";
     for (const note of notes) {
       if (note.missed || note.hit || note.y < -50) continue;
-      const centerX = this.laneSystem.getLaneX(note.lane);
+      const cx = this.laneSystem.getLaneX(note.lane);
       const y = note.y;
-      const r = this.laneSystem.getNoteRadius();
-      // Brighten as the note nears the strum line (anticipation).
-      const proximity = Math.max(0, 1 - Math.abs(y - strumY) / (strumY + 1));
-      const trailLen = r * (2.2 + proximity * 2.4);
-      const grad = this.ctx.createLinearGradient(0, y - trailLen, 0, y);
-      grad.addColorStop(0, this.rgbaColor(note.lane, 0));
-      grad.addColorStop(1, this.rgbaColor(note.lane, 0.32 + proximity * 0.35));
-      this.ctx.fillStyle = grad;
-      const tw = r * (0.5 + proximity * 0.25);
-      this.ctx.beginPath();
-      this.ctx.moveTo(centerX - tw, y);
-      this.ctx.lineTo(centerX + tw, y);
-      this.ctx.lineTo(centerX + tw * 0.25, y - trailLen);
-      this.ctx.lineTo(centerX - tw * 0.25, y - trailLen);
-      this.ctx.closePath();
-      this.ctx.fill();
+      const c = this.laneColors[note.lane];
+      const proximity = clamp01(1 - Math.abs(y - strumY) / (strumY + 1));
+      const trailLen = r * (2.0 + proximity * 2.8);
+      const grad = ctx.createLinearGradient(0, y - trailLen, 0, y);
+      grad.addColorStop(0, rgba(c, 0));
+      grad.addColorStop(1, rgba(c, 0.28 + proximity * 0.34));
+      ctx.fillStyle = grad;
+      const tw = r * (0.42 + proximity * 0.24);
+      ctx.beginPath();
+      ctx.moveTo(cx - tw, y);
+      ctx.lineTo(cx + tw, y);
+      ctx.lineTo(cx + tw * 0.22, y - trailLen);
+      ctx.lineTo(cx - tw * 0.22, y - trailLen);
+      ctx.closePath();
+      ctx.fill();
     }
-    this.ctx.restore();
+    ctx.restore();
 
-    // PASS 2 — the notes themselves.
+    // PASS 2 — glass cards (+ hit pop).
     for (const note of notes) {
       if (note.missed) continue;
-
-      const centerX = this.laneSystem.getLaneX(note.lane);
+      const cx = this.laneSystem.getLaneX(note.lane);
       const y = note.y;
+      const c = this.laneColors[note.lane];
 
-      // Hit Effect (Explosion)
+      // HIT POP — quick expanding white core + lane ring, owned by Renderer so
+      // the note's own light response reads instantly even before particles.
       if (note.hit) {
-         if (note.hitTime && (now - note.hitTime < 300)) {
-             const progress = (now - note.hitTime) / 300;
-             const alpha = 1 - progress;
-             const r = this.laneSystem.getNoteRadius() * (1 + progress * 0.5);
-
-             this.ctx.save();
-             this.ctx.globalAlpha = alpha;
-             this.ctx.translate(centerX, y);
-
-             // Flash
-             this.ctx.beginPath();
-             this.ctx.arc(0, 0, r, 0, Math.PI * 2);
-             this.ctx.fillStyle = "white";
-             this.ctx.fill();
-
-             // Ring
-             this.ctx.beginPath();
-             this.ctx.arc(0, 0, r * 1.5, 0, Math.PI * 2);
-             this.ctx.strokeStyle = this.getNeonColor(note.lane);
-             this.ctx.lineWidth = 5;
-             this.ctx.stroke();
-
-             this.ctx.restore();
-         }
-         continue;
+        if (note.hitTime && now - note.hitTime < 320) {
+          const t = (now - note.hitTime) / 320;
+          const a = 1 - t;
+          const rr = r * (1 + t * 0.8);
+          ctx.save();
+          ctx.globalCompositeOperation = "lighter";
+          ctx.translate(cx, y);
+          // White flash core.
+          ctx.beginPath();
+          ctx.arc(0, 0, rr * 0.6, 0, Math.PI * 2);
+          ctx.fillStyle = rgba({ r: 255, g: 255, b: 255 }, a * 0.85);
+          ctx.fill();
+          // Lane shockring.
+          ctx.beginPath();
+          ctx.arc(0, 0, rr * 1.4, 0, Math.PI * 2);
+          ctx.strokeStyle = rgba(c, a * 0.9);
+          ctx.lineWidth = 5 * a + 1;
+          ctx.stroke();
+          ctx.restore();
+        }
+        continue;
       }
 
-      // Don't draw if off screen (top)
       if (y < -50) continue;
 
-      const r = this.laneSystem.getNoteRadius();
-      const color = this.getNeonColor(note.lane);
+      const proximity = clamp01(1 - Math.abs(y - strumY) / (strumY + 1));
+      const pulse = 0.5 + 0.5 * Math.sin(now * 0.011 + note.lane * 1.7);
 
-      // Draw Note (Rectangular "Tape" / "Card" style for Linear view)
       const laneW = this.laneSystem.getLaneBounds(0).width;
       const cardW = laneW * 0.9;
       const cardH = r * 1.5;
-
-      const x = centerX - cardW / 2;
+      const x = cx - cardW / 2;
       const cardY = y - cardH / 2;
+      const radius = Math.min(16, cardH * 0.32);
 
-      // Pulsing approach glow as the note nears the strum line.
-      const proximity = Math.max(0, 1 - Math.abs(y - strumY) / (strumY + 1));
-      const pulse = 0.5 + 0.5 * Math.sin(now * 0.012 + note.lane * 1.7);
-
-      // Glow
-      this.ctx.shadowBlur = 15 + proximity * 18 + pulse * 6;
-      this.ctx.shadowColor = color;
-
-      // Body
-      this.ctx.fillStyle = "rgba(20, 20, 20, 0.95)";
-      this.ctx.beginPath();
-      if (this.ctx.roundRect) {
-          this.ctx.roundRect(x, cardY, cardW, cardH, 10);
-      } else {
-          this.ctx.rect(x, cardY, cardW, cardH);
+      // --- APPROACH BLOOM: a soft lane-colored glow pad behind the card that
+      //     swells as it nears the strum line (anticipation). Additive. ---
+      if (proximity > 0.02) {
+        ctx.save();
+        ctx.globalCompositeOperation = "lighter";
+        const bloomR = cardW * (0.7 + proximity * 0.5);
+        const bg = ctx.createRadialGradient(cx, y, 0, cx, y, bloomR);
+        bg.addColorStop(0, rgba(c, (0.18 + pulse * 0.06) * proximity));
+        bg.addColorStop(1, rgba(c, 0));
+        ctx.fillStyle = bg;
+        ctx.beginPath();
+        ctx.arc(cx, y, bloomR, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
       }
-      this.ctx.fill();
 
-      // Border / Color indicator
-      this.ctx.strokeStyle = color;
-      this.ctx.lineWidth = 3 + proximity * 1.5;
-      this.ctx.stroke();
+      // --- GLASS CARD BODY ---
+      ctx.save();
+      // Outer neon glow on the card edge (scales with proximity).
+      ctx.shadowBlur = 12 + proximity * 20 + pulse * 5;
+      ctx.shadowColor = rgbStr(c);
 
-      // Sidebar highlight (like a gem on the side?)
-      this.ctx.fillStyle = color;
-      this.ctx.beginPath();
-      if (this.ctx.roundRect) {
-          this.ctx.roundRect(x, cardY, 10, cardH, [10, 0, 0, 10]); // TopLeft, TopRight, BotRight, BotLeft
-      } else {
-          this.ctx.fillRect(x, cardY, 10, cardH);
-      }
-      this.ctx.fill();
+      // Frosted glass fill: vertical gradient from a lifted top to a darker base.
+      const glass = ctx.createLinearGradient(0, cardY, 0, cardY + cardH);
+      glass.addColorStop(0, rgba(mix(this.bgBot, c, 0.14), 0.94));
+      glass.addColorStop(0.5, rgba(mix(this.bgMid, c, 0.06), 0.96));
+      glass.addColorStop(1, rgba(this.bgTop, 0.95));
+      ctx.fillStyle = glass;
+      roundRectPath(ctx, x, cardY, cardW, cardH, radius);
+      ctx.fill();
+      ctx.shadowBlur = 0;
 
-      this.ctx.shadowBlur = 0;
+      // Top glass highlight sheen (the "Apple-grade" specular line).
+      const sheen = ctx.createLinearGradient(0, cardY, 0, cardY + cardH * 0.5);
+      sheen.addColorStop(0, rgba({ r: 255, g: 255, b: 255 }, 0.16));
+      sheen.addColorStop(1, rgba({ r: 255, g: 255, b: 255 }, 0));
+      ctx.fillStyle = sheen;
+      roundRectPath(ctx, x + 2, cardY + 2, cardW - 4, cardH * 0.5, radius * 0.8);
+      ctx.fill();
 
-      // Text Rendering
+      // Neon border.
+      ctx.strokeStyle = rgba(c, 0.85 + proximity * 0.15);
+      ctx.lineWidth = 2 + proximity * 1.5;
+      roundRectPath(ctx, x, cardY, cardW, cardH, radius);
+      ctx.stroke();
+
+      // Lane-color accent spine on the leading (left) edge.
+      ctx.fillStyle = rgba(c, 0.95);
+      roundRectPath(ctx, x, cardY, 6, cardH, [radius, 0, 0, radius]);
+      ctx.fill();
+      ctx.restore();
+
+      // --- WORD ---
       if (note.text) {
-        this.ctx.fillStyle = "white";
-        // Scale the word with the (now larger) note so it's legible at a glance;
-        // it still auto-shrinks below to fit narrow cards / long words.
-        let fontSize = Math.max(30, r * 0.62);
-        this.ctx.font = `bold ${fontSize}px 'Russo One', sans-serif`;
-        
-        // Fit text
-        const maxTextW = cardW - 20; // Padding
-        let metrics = this.ctx.measureText(note.text);
-        
+        ctx.save();
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        let fontSize = Math.max(26, r * 0.6);
+        ctx.font = `bold ${fontSize}px 'Russo One', 'Lingo Sans', system-ui, sans-serif`;
+        const maxTextW = cardW - 24;
+        const metrics = ctx.measureText(note.text);
         if (metrics.width > maxTextW) {
-             fontSize = fontSize * (maxTextW / metrics.width);
-             this.ctx.font = `bold ${fontSize}px 'Russo One', sans-serif`;
+          fontSize = fontSize * (maxTextW / metrics.width);
+          ctx.font = `bold ${fontSize}px 'Russo One', 'Lingo Sans', system-ui, sans-serif`;
         }
-        
-        // Offset text slightly to right because of the colored bar
-        // Update: Center text precisely in the remaining space or relative to card center?
-        // User requested "completly centered on the box".
-        // The "box" is the card.
-        // We have a 10px bar on the left.
-        // If we want visual centering on the card body (excluding bar), we should shift right.
-        // But if we want centering on the whole object, use centerX.
-        // Let's assume centering on the CARD BODY (white space) looks best.
-        // Card Body Width = cardW - 10.
-        // Center of Card Body relative to x: 10 + (cardW - 10)/2 = 10 + cardW/2 - 5 = cardW/2 + 5.
-        // Absolute X: x + cardW/2 + 5 = (centerX - cardW/2) + cardW/2 + 5 = centerX + 5.
-        // So centerX + 5 IS the center of the available space.
-        // I will keep centerX + 5 but make sure alignment is strictly center/middle.
-        
-        this.ctx.textAlign = "center";
-        this.ctx.textBaseline = "middle";
-        this.ctx.fillText(note.text, centerX + 5, y);
+        // Soft contrast shadow so the word stays legible over the glow.
+        ctx.shadowColor = "rgba(0,0,0,0.55)";
+        ctx.shadowBlur = 4;
+        ctx.fillStyle = rgbStr(this.textColor);
+        ctx.fillText(note.text, cx + 3, y);
+        ctx.restore();
       }
     }
   }
+}
 
-  private getNeonColor(lane: LaneIndex): string {
-    switch(lane) {
-      case 0: return "#00ffff"; // Cyan
-      case 1: return "#ff00ff"; // Pink
-      case 2: return "#00ff00"; // Green
-      default: return "white";
-    }
-  }
+// ---------------------------------------------------------------------------
+// Color + path helpers (module-scope, allocation-light).
+// ---------------------------------------------------------------------------
 
-  private rgbaColor(lane: LaneIndex, a: number): string {
-    switch (lane) {
-      case 0: return `rgba(0,255,255,${a})`;
-      case 1: return `rgba(255,0,255,${a})`;
-      case 2: return `rgba(0,255,0,${a})`;
-      default: return `rgba(255,255,255,${a})`;
-    }
+function cssVar(root: HTMLElement | null, name: string): string {
+  if (!root || typeof getComputedStyle !== "function") return "";
+  try {
+    return getComputedStyle(root).getPropertyValue(name).trim();
+  } catch {
+    return "";
   }
+}
+
+/** Parse #rgb / #rrggbb / rgb()/rgba() into an Rgb, else null. */
+function parseColor(v: string): Rgb | null {
+  if (!v) return null;
+  const s = v.trim();
+  if (s[0] === "#") {
+    let hex = s.slice(1);
+    if (hex.length === 3) {
+      hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+    }
+    if (hex.length >= 6) {
+      const n = parseInt(hex.slice(0, 6), 16);
+      if (!Number.isNaN(n)) {
+        return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+      }
+    }
+    return null;
+  }
+  const m = s.match(/rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)/i);
+  if (m) {
+    return { r: +m[1], g: +m[2], b: +m[3] };
+  }
+  return null;
+}
+
+function rgbStr(c: Rgb): string {
+  return `rgb(${c.r | 0},${c.g | 0},${c.b | 0})`;
+}
+
+function rgba(c: Rgb, a: number): string {
+  const aa = a < 0 ? 0 : a > 1 ? 1 : a;
+  return `rgba(${c.r | 0},${c.g | 0},${c.b | 0},${aa})`;
+}
+
+function mix(a: Rgb, b: Rgb, t: number): Rgb {
+  const k = t < 0 ? 0 : t > 1 ? 1 : t;
+  return {
+    r: a.r + (b.r - a.r) * k,
+    g: a.g + (b.g - a.g) * k,
+    b: a.b + (b.b - a.b) * k,
+  };
+}
+
+function clamp01(v: number): number {
+  return v < 0 ? 0 : v > 1 ? 1 : v;
+}
+
+/** roundRect with a per-corner radius array fallback for older engines. */
+function roundRectPath(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  radius: number | [number, number, number, number]
+): void {
+  ctx.beginPath();
+  const anyCtx = ctx as CanvasRenderingContext2D & {
+    roundRect?: (
+      x: number,
+      y: number,
+      w: number,
+      h: number,
+      r: number | number[]
+    ) => void;
+  };
+  if (typeof anyCtx.roundRect === "function") {
+    anyCtx.roundRect(x, y, w, h, radius as number | number[]);
+    return;
+  }
+  // Manual rounded rect (uniform radius fallback).
+  const r = Array.isArray(radius) ? radius[0] : radius;
+  const rr = Math.min(r, w / 2, h / 2);
+  ctx.moveTo(x + rr, y);
+  ctx.arcTo(x + w, y, x + w, y + h, rr);
+  ctx.arcTo(x + w, y + h, x, y + h, rr);
+  ctx.arcTo(x, y + h, x, y, rr);
+  ctx.arcTo(x, y, x + w, y, rr);
+  ctx.closePath();
 }

--- a/corpan/packs/lingo-hero/src/audio/MusicBed.ts
+++ b/corpan/packs/lingo-hero/src/audio/MusicBed.ts
@@ -1,0 +1,272 @@
+/**
+ * MusicBed — an evolving, fully-synthesized synthwave bed.
+ *
+ * No audio files. A self-scheduling lookahead sequencer (the standard WebAudio
+ * "clock" pattern) drives three sustained layers that all feed the engine's
+ * dedicated music sub-bus:
+ *
+ *   1. PAD     — slow, warm two-oscillator chords drifting through a minor
+ *                progression. Always present while the bed runs.
+ *   2. BASS     — a pulsing sub on the root, on every beat. The synthwave pulse.
+ *   3. ARP     — a bright plucky arpeggio that FADES IN with combo intensity,
+ *                so a hot streak literally adds sparkle to the music.
+ *
+ * Intensity (0..1, driven by combo) controls: music-bus level (swell), arp
+ * presence, bass drive, and a gentle tempo lift — so the track tightens as the
+ * player heats up and relaxes when they cool down. The whole thing is keyed to
+ * the same C-minor synthwave palette as the SFX so cues sit in the music.
+ *
+ * Honors prefers-reduced-motion (passed in): when reduced, the bed runs at a
+ * lower, steadier level with the arp suppressed — present but unobtrusive.
+ */
+
+import type { SynthEngine } from "./SynthEngine";
+
+/** One bar = 4 beats; tempo glides between these with intensity. */
+const TEMPO_MIN = 84; // BPM at idle
+const TEMPO_MAX = 104; // BPM at full heat
+
+/** Scheduler lookahead window (s) and tick cadence (ms). */
+const LOOKAHEAD_S = 0.18;
+const TICK_MS = 45;
+
+/**
+ * Cm synthwave progression: Cm – A♭ – E♭ – B♭ (i – VI – III – VII). Each entry
+ * is the chord's root (Hz, low octave) plus the third & fifth offsets in
+ * semitones that build the triad. Minor-leaning but not bleak — classic
+ * outrun harmony.
+ */
+interface ChordSpec {
+  root: number; // Hz (bass octave)
+  third: number; // semitones above root
+  fifth: number; // semitones above root
+}
+
+const SEMI = (hz: number, semis: number) => hz * Math.pow(2, semis / 12);
+
+const PROGRESSION: ChordSpec[] = [
+  { root: 130.81, third: 3, fifth: 7 }, // Cm   (C3, E♭, G)
+  { root: 103.83, third: 4, fifth: 7 }, // A♭   (A♭2, C,  E♭)
+  { root: 155.56, third: 4, fifth: 7 }, // E♭   (E♭3, G,  B♭)
+  { root: 116.54, third: 4, fifth: 7 }, // B♭   (B♭2, D,  F)
+];
+
+/** Pentatonic-ish arp degrees (semitones from chord root) for the sparkle layer. */
+const ARP_DEGREES = [12, 15, 19, 24, 19, 15]; // root, m3, 5, octave, 5, m3 (up & back)
+
+export class MusicBed {
+  private readonly synth: SynthEngine;
+  private readonly reduced: boolean;
+
+  private running = false;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  /** Next beat's scheduled context-time. */
+  private nextBeatTime = 0;
+  /** Global beat counter since start (drives bar/chord position). */
+  private beat = 0;
+
+  /** Smoothed 0..1 intensity that the bed reacts to. */
+  private intensity = 0;
+  /** Raw target intensity set from combo; `intensity` chases this. */
+  private targetIntensity = 0;
+
+  constructor(synth: SynthEngine, reducedMotion: boolean) {
+    this.synth = synth;
+    this.reduced = reducedMotion;
+  }
+
+  /** Begin the bed. Safe to call repeatedly; no-op if already running. */
+  start(): void {
+    if (this.running) return;
+    const ctx = this.synth.context;
+    if (!ctx || !this.synth.ready) return;
+    this.running = true;
+    this.beat = 0;
+    this.nextBeatTime = ctx.currentTime + 0.08;
+    // Swell the music bus up from silence to a calm idle level.
+    this.synth.setMusicLevel(this.reduced ? 0.18 : this.baseLevel(), 1.4);
+    this.timer = setInterval(() => this.tick(), TICK_MS);
+  }
+
+  /** Fade the bed out and stop scheduling. */
+  stop(fade = 0.8): void {
+    if (!this.running) return;
+    this.running = false;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.synth.setMusicLevel(0, fade);
+  }
+
+  /**
+   * Set how "hot" the music should feel from the current combo. Mapped to a
+   * 0..1 target intensity; the bed eases toward it so changes never jolt.
+   */
+  setCombo(combo: number): void {
+    // Saturating curve: first few hits lift quickly, then it plateaus.
+    const t = 1 - Math.exp(-combo / 9);
+    this.targetIntensity = Math.max(0, Math.min(1, t));
+  }
+
+  /** Drop intensity instantly on a streak break (music "cools"). */
+  cool(): void {
+    this.targetIntensity = 0;
+  }
+
+  /** Idle music-bus level before intensity is added in. */
+  private baseLevel(): number {
+    return 0.26;
+  }
+
+  /** Tear down. */
+  dispose(): void {
+    this.stop(0.2);
+  }
+
+  private currentTempo(): number {
+    const i = this.reduced ? 0 : this.intensity;
+    return TEMPO_MIN + (TEMPO_MAX - TEMPO_MIN) * i;
+  }
+
+  /** The scheduler: queue every beat that falls inside the lookahead window. */
+  private tick(): void {
+    const ctx = this.synth.context;
+    if (!this.running || !ctx || !this.synth.ready) return;
+
+    // Ease the smoothed intensity toward target (per-tick low-pass).
+    this.intensity += (this.targetIntensity - this.intensity) * 0.12;
+
+    // React: music level swells with intensity; arp/tempo follow inside notes.
+    if (!this.reduced) {
+      const level = this.baseLevel() + this.intensity * 0.34; // 0.26 .. 0.60
+      this.synth.setMusicLevel(level, 0.5);
+    }
+
+    const secPerBeat = 60 / this.currentTempo();
+    const horizon = ctx.currentTime + LOOKAHEAD_S;
+    while (this.nextBeatTime < horizon) {
+      this.scheduleBeat(this.beat, this.nextBeatTime);
+      this.nextBeatTime += secPerBeat;
+      this.beat++;
+    }
+  }
+
+  /** Lay down all layers for one beat at absolute context-time `when`. */
+  private scheduleBeat(beat: number, when: number): void {
+    const ctx = this.synth.context;
+    if (!ctx) return;
+    const now = ctx.currentTime;
+    const delay = Math.max(0, when - now);
+    const secPerBeat = 60 / this.currentTempo();
+
+    const beatInBar = beat % 4;
+    const bar = Math.floor(beat / 4);
+    const chord = PROGRESSION[bar % PROGRESSION.length];
+
+    // --- PAD: new chord swells at the top of each bar (long, soft) ----------
+    if (beatInBar === 0) {
+      this.schedulePad(chord, delay, secPerBeat * 4);
+    }
+
+    // --- BASS: a sub pulse on every beat; harder with intensity ------------
+    this.scheduleBass(chord, delay, secPerBeat, beatInBar);
+
+    // --- ARP: 16th sparkle that fades in with intensity --------------------
+    if (!this.reduced && this.intensity > 0.12) {
+      this.scheduleArp(chord, delay, secPerBeat, beat);
+    }
+  }
+
+  /** Two slightly-detuned saw oscillators + a sine sub = warm outrun pad. */
+  private schedulePad(chord: ChordSpec, delay: number, dur: number): void {
+    const tones = [
+      chord.root * 2, // up an octave for the body
+      SEMI(chord.root * 2, chord.third),
+      SEMI(chord.root * 2, chord.fifth),
+    ];
+    const gain = 0.05 + this.intensity * 0.03;
+    for (const f of tones) {
+      // Detuned unison for analog width.
+      this.synth.playVoice({
+        type: "sawtooth",
+        freq: f,
+        gain,
+        attack: dur * 0.32,
+        release: dur * 0.66,
+        delay,
+        detune: -7,
+        pan: -0.35,
+        reverb: 0.5,
+      });
+      this.synth.playVoice({
+        type: "sawtooth",
+        freq: f,
+        gain,
+        attack: dur * 0.32,
+        release: dur * 0.66,
+        delay,
+        detune: 7,
+        pan: 0.35,
+        reverb: 0.5,
+      });
+    }
+  }
+
+  /** Punchy sub on the root; downbeat is fuller than off-beats. */
+  private scheduleBass(
+    chord: ChordSpec,
+    delay: number,
+    secPerBeat: number,
+    beatInBar: number
+  ): void {
+    const accent = beatInBar === 0 ? 1 : 0.7;
+    const drive = 0.06 + this.intensity * 0.06;
+    this.synth.playVoice({
+      type: "sine",
+      freq: chord.root,
+      gain: drive * accent,
+      attack: 0.006,
+      release: secPerBeat * 0.7,
+      delay,
+    });
+    // A square layer an octave up adds presence as it heats up.
+    if (this.intensity > 0.3) {
+      this.synth.playVoice({
+        type: "square",
+        freq: chord.root * 2,
+        gain: 0.02 * this.intensity * accent,
+        attack: 0.005,
+        release: secPerBeat * 0.4,
+        delay,
+      });
+    }
+  }
+
+  /** A bright triangle pluck walking the arp pattern in 16ths. */
+  private scheduleArp(
+    chord: ChordSpec,
+    delay: number,
+    secPerBeat: number,
+    beat: number
+  ): void {
+    const sixteenth = secPerBeat / 4;
+    const base = chord.root * 2;
+    const presence = Math.min(1, (this.intensity - 0.12) / 0.6);
+    for (let s = 0; s < 4; s++) {
+      const stepIdx = (beat * 4 + s) % ARP_DEGREES.length;
+      const f = SEMI(base, ARP_DEGREES[stepIdx]);
+      this.synth.playVoice({
+        type: "triangle",
+        freq: f,
+        gain: 0.035 * presence,
+        attack: 0.004,
+        release: sixteenth * 1.6,
+        delay: delay + s * sixteenth,
+        pan: s % 2 === 0 ? -0.25 : 0.25,
+        reverb: 0.4,
+      });
+    }
+  }
+}

--- a/corpan/packs/lingo-hero/src/audio/MuteToggle.ts
+++ b/corpan/packs/lingo-hero/src/audio/MuteToggle.ts
@@ -1,0 +1,168 @@
+/**
+ * MuteToggle — a self-contained, neon-styled mute control for the audio stream.
+ *
+ * The audio stream owns ONLY src/audio/*, so rather than ask the HUD for a
+ * button this module builds and manages its own floating control. It is styled
+ * entirely from the shared Neon Arcade `--na-*` design tokens (via inline
+ * custom-property-referencing styles) so it reads as part of the same system
+ * without us editing styles.css. Fully offline — pure DOM + inline SVG, no
+ * fonts, no assets, no network.
+ *
+ * Behavior:
+ *   - Persists the on/off state to localStorage so the preference sticks.
+ *   - Calls back into the audio layer (which drives SynthEngine.setMuted +
+ *     MusicBed) on every change.
+ *   - Anchors itself to the HUD's `.ui-layer` overlay when present (so it sits
+ *     inside the game's safe-area-aware coordinate space); falls back to the
+ *     document body otherwise. Re-anchors lazily if the layer mounts later.
+ *   - Respects touch + small screens (44px hit target, safe-area insets).
+ */
+
+const STORAGE_KEY = "lingoHero.audio.muted";
+
+/** Speaker-on / speaker-off inline SVGs (no external icon font). */
+const ICON_ON = `<svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M4 9v6h4l5 4V5L8 9H4z"/><path d="M16.5 8.5a5 5 0 0 1 0 7"/><path d="M19 6a8 8 0 0 1 0 12"/></svg>`;
+const ICON_OFF = `<svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M4 9v6h4l5 4V5L8 9H4z"/><path d="M22 9l-6 6"/><path d="M16 9l6 6"/></svg>`;
+
+function readStoredMuted(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeStoredMuted(muted: boolean): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, muted ? "1" : "0");
+  } catch {
+    /* storage may be unavailable (private mode); state is still in-memory */
+  }
+}
+
+export class MuteToggle {
+  private readonly btn: HTMLButtonElement;
+  private readonly onChange: (muted: boolean) => void;
+  private muted: boolean;
+  private mounted = false;
+
+  constructor(onChange: (muted: boolean) => void) {
+    this.onChange = onChange;
+    this.muted = readStoredMuted();
+
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "na-mute-toggle";
+    this.applyBaseStyle(btn);
+    btn.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      this.toggle();
+    });
+    // Keep the canvas/lane input from also receiving the tap.
+    btn.addEventListener("pointerdown", (e) => e.stopPropagation());
+    btn.addEventListener("touchstart", (e) => e.stopPropagation(), {
+      passive: true,
+    });
+
+    this.btn = btn;
+    this.render();
+  }
+
+  /** The persisted/initial mute state, so the engine can sync at startup. */
+  get isMuted(): boolean {
+    return this.muted;
+  }
+
+  /** Attach to the HUD overlay (or body). Idempotent + lazily re-tries. */
+  attach(): void {
+    if (this.mounted && this.btn.isConnected) return;
+    const host =
+      (document.querySelector(".ui-layer") as HTMLElement | null) ??
+      document.body;
+    if (!host) return;
+    host.appendChild(this.btn);
+    this.mounted = true;
+  }
+
+  private toggle(): void {
+    this.muted = !this.muted;
+    writeStoredMuted(this.muted);
+    this.render();
+    this.onChange(this.muted);
+  }
+
+  private render(): void {
+    this.btn.innerHTML = this.muted ? ICON_OFF : ICON_ON;
+    this.btn.setAttribute("aria-pressed", this.muted ? "true" : "false");
+    this.btn.setAttribute(
+      "aria-label",
+      this.muted ? "Unmute sound" : "Mute sound"
+    );
+    this.btn.title = this.muted ? "Sound off" : "Sound on";
+    // Active = lime-glow on; muted = dimmed faint.
+    if (this.muted) {
+      this.btn.style.color = "var(--na-text-faint, #8a90b8)";
+      this.btn.style.borderColor = "var(--na-glass-stroke, rgba(255,255,255,.12))";
+      this.btn.style.boxShadow = "var(--na-shadow-panel, 0 8px 24px rgba(0,0,0,.5))";
+    } else {
+      this.btn.style.color = "var(--na-accent, #2ff3ff)";
+      this.btn.style.borderColor = "var(--na-accent, #2ff3ff)";
+      this.btn.style.boxShadow =
+        "var(--na-glow-cyan, 0 0 12px rgba(47,243,255,.55)), var(--na-shadow-panel, 0 8px 24px rgba(0,0,0,.5))";
+    }
+  }
+
+  private applyBaseStyle(btn: HTMLButtonElement): void {
+    const css: Record<string, string> = {
+      position: "absolute",
+      top: "calc(var(--na-space-3, 12px) + env(safe-area-inset-top, 0px))",
+      right: "calc(var(--na-space-3, 12px) + env(safe-area-inset-right, 0px))",
+      "z-index": "var(--na-z-overlay, 40)",
+      width: "44px",
+      height: "44px",
+      display: "inline-flex",
+      "align-items": "center",
+      "justify-content": "center",
+      padding: "0",
+      margin: "0",
+      "border-radius": "var(--na-radius-pill, 999px)",
+      border: "1px solid var(--na-accent, #2ff3ff)",
+      background: "var(--na-glass-bg, rgba(18,20,40,.55))",
+      "backdrop-filter": "blur(10px)",
+      "-webkit-backdrop-filter": "blur(10px)",
+      color: "var(--na-accent, #2ff3ff)",
+      cursor: "pointer",
+      transition:
+        "transform var(--na-dur-fast, 140ms) var(--na-ease-snap, ease), box-shadow var(--na-dur-base, 240ms) var(--na-ease-out, ease), color var(--na-dur-base, 240ms) var(--na-ease-out, ease), border-color var(--na-dur-base, 240ms) var(--na-ease-out, ease)",
+      "-webkit-tap-highlight-color": "transparent",
+      "touch-action": "manipulation",
+      "user-select": "none",
+    };
+    for (const [prop, value] of Object.entries(css)) {
+      btn.style.setProperty(prop, value);
+    }
+
+    btn.addEventListener("pointerenter", () => {
+      btn.style.transform = "scale(1.06)";
+    });
+    btn.addEventListener("pointerleave", () => {
+      btn.style.transform = "scale(1)";
+    });
+    btn.addEventListener("pointerdown", () => {
+      btn.style.transform = "scale(0.92)";
+    });
+    btn.addEventListener("pointerup", () => {
+      btn.style.transform = "scale(1.06)";
+    });
+  }
+
+  dispose(): void {
+    try {
+      this.btn.remove();
+    } catch {
+      /* already detached */
+    }
+    this.mounted = false;
+  }
+}

--- a/corpan/packs/lingo-hero/src/audio/SynthEngine.ts
+++ b/corpan/packs/lingo-hero/src/audio/SynthEngine.ts
@@ -2,14 +2,26 @@
  * SynthEngine — a tiny, fully-offline WebAudio synthesizer.
  *
  * Zero binary assets. Every sound is procedurally generated from oscillators,
- * noise buffers, and gain envelopes. Designed for low-latency rhythm-game SFX:
- * snappy attacks, short decays, and a shared master bus with a soft limiter so
- * stacked hits never clip on mobile speakers.
+ * noise buffers, gain envelopes, and a synthesized convolution reverb. Designed
+ * for low-latency rhythm-game SFX (snappy attacks, short decays) layered over a
+ * persistent synthwave music bed.
  *
- * The engine is intentionally lazy: the AudioContext is only created/resumed on
- * an explicit unlock() call (driven by the first user gesture) to satisfy
- * mobile autoplay policies. Every public method is a no-op until unlocked, and
- * nothing throws if WebAudio is unavailable.
+ * Routing topology:
+ *
+ *   voices/noise ──► [dry] ─────────────────────────────┐
+ *                └─► [reverbSend] ─► convolver ─► wet ───┤
+ *                                                        ▼
+ *   music bed ───────────────────► musicBus ───────►  master ─► limiter ─► out
+ *
+ * Two independent gain buses (`sfxBus`, `musicBus`) hang off the master so the
+ * evolving ambient bed can swell/duck on its own envelope while transient SFX
+ * stay punchy. A shared convolution reverb gives every cue a cohesive
+ * synthwave "room" without per-sound tails.
+ *
+ * The engine is lazy: the AudioContext is only created/resumed on an explicit
+ * unlock() call (driven by the first user gesture) to satisfy mobile autoplay
+ * policy. Every public method is a no-op until unlocked, and nothing throws if
+ * WebAudio is unavailable.
  */
 
 type Ctor = typeof AudioContext;
@@ -44,6 +56,8 @@ export interface VoiceSpec {
   pan?: number;
   /** Optional detune in cents for a fatter unison feel. */
   detune?: number;
+  /** Reverb send amount 0..1 (0 = bone dry). */
+  reverb?: number;
 }
 
 export interface NoiseSpec {
@@ -63,11 +77,20 @@ export interface NoiseSpec {
   delay?: number;
   /** Stereo placement -1..1. */
   pan?: number;
+  /** Reverb send amount 0..1. */
+  reverb?: number;
 }
 
 export class SynthEngine {
   private ctx: AudioContext | null = null;
   private master: GainNode | null = null;
+  /** Transient SFX sub-bus (hits, misses, risers, stings). */
+  private sfxBus: GainNode | null = null;
+  /** Sustained music/ambient sub-bus (the evolving bed). */
+  private musicBus: GainNode | null = null;
+  /** Wet return of the shared reverb. */
+  private reverbWet: GainNode | null = null;
+  private convolver: ConvolverNode | null = null;
   private noiseBuffer: AudioBuffer | null = null;
   private readonly Ctor: Ctor | null;
   private unlocked = false;
@@ -86,6 +109,16 @@ export class SynthEngine {
   /** Whether the context is live and ready to make sound. */
   get ready(): boolean {
     return this.unlocked && this.ctx !== null && this.ctx.state === "running";
+  }
+
+  /** Raw context accessor for advanced subsystems (music bed). Null until unlocked. */
+  get context(): AudioContext | null {
+    return this.ctx;
+  }
+
+  /** The music sub-bus node; subsystems connect their output here. */
+  get musicDestination(): AudioNode | null {
+    return this.musicBus;
   }
 
   /**
@@ -123,9 +156,27 @@ export class SynthEngine {
     }
   }
 
+  get isMuted(): boolean {
+    return this.muted;
+  }
+
   /** Current transport time; 0 if not yet unlocked. */
   now(): number {
     return this.ctx ? this.ctx.currentTime : 0;
+  }
+
+  /**
+   * Smoothly ramp the music sub-bus level (0..1). Used by the bed to swell with
+   * combo and duck on menus. Never throws.
+   */
+  setMusicLevel(level: number, ramp = 0.6): void {
+    if (!this.musicBus || !this.ctx) return;
+    const v = Math.max(0, Math.min(1, level));
+    try {
+      this.musicBus.gain.setTargetAtTime(v, this.ctx.currentTime, ramp);
+    } catch {
+      this.musicBus.gain.value = v;
+    }
   }
 
   private buildGraph(): void {
@@ -142,11 +193,31 @@ export class SynthEngine {
 
     const master = ctx.createGain();
     master.gain.value = this.muted ? 0 : this.masterGain;
-
     master.connect(limiter);
     limiter.connect(ctx.destination);
 
+    // Two sub-buses for independent SFX vs. music dynamics.
+    const sfxBus = ctx.createGain();
+    sfxBus.gain.value = 1;
+    sfxBus.connect(master);
+
+    const musicBus = ctx.createGain();
+    musicBus.gain.value = 0; // bed starts silent; the MusicBed ramps it in.
+    musicBus.connect(master);
+
+    // Shared synthwave reverb (procedural impulse → convolver → wet return).
+    const convolver = ctx.createConvolver();
+    convolver.buffer = this.makeImpulse(ctx, 1.9, 2.6);
+    const reverbWet = ctx.createGain();
+    reverbWet.gain.value = 0.85;
+    convolver.connect(reverbWet);
+    reverbWet.connect(master);
+
     this.master = master;
+    this.sfxBus = sfxBus;
+    this.musicBus = musicBus;
+    this.convolver = convolver;
+    this.reverbWet = reverbWet;
     this.noiseBuffer = this.makeNoiseBuffer(ctx);
   }
 
@@ -160,18 +231,56 @@ export class SynthEngine {
     return buf;
   }
 
-  /** Connect a node to the master bus through an optional stereo panner. */
-  private route(node: AudioNode, pan?: number): AudioNode {
-    if (!this.ctx || !this.master) return node;
-    if (pan !== undefined && pan !== 0 && typeof this.ctx.createStereoPanner === "function") {
+  /**
+   * Synthesize a stereo exponential-decay impulse response for the convolver —
+   * a "plate"-ish synthwave tail. Slightly decorrelated L/R for width. Fully
+   * generated, no IR files.
+   */
+  private makeImpulse(
+    ctx: AudioContext,
+    seconds: number,
+    decay: number
+  ): AudioBuffer {
+    const rate = ctx.sampleRate;
+    const len = Math.max(1, Math.floor(rate * seconds));
+    const buf = ctx.createBuffer(2, len, rate);
+    for (let ch = 0; ch < 2; ch++) {
+      const data = buf.getChannelData(ch);
+      for (let i = 0; i < len; i++) {
+        const t = i / len;
+        // Short pre-build (early reflections) then long exponential tail.
+        const env = Math.pow(1 - t, decay);
+        data[i] = (Math.random() * 2 - 1) * env;
+      }
+    }
+    return buf;
+  }
+
+  /**
+   * Connect a node to the SFX bus through an optional stereo panner, and add a
+   * parallel reverb send if requested. Returns the (panned) dry node.
+   */
+  private route(node: AudioNode, pan?: number, reverb?: number): AudioNode {
+    if (!this.ctx || !this.sfxBus) return node;
+    let out: AudioNode = node;
+    if (
+      pan !== undefined &&
+      pan !== 0 &&
+      typeof this.ctx.createStereoPanner === "function"
+    ) {
       const panner = this.ctx.createStereoPanner();
       panner.pan.value = Math.max(-1, Math.min(1, pan));
       node.connect(panner);
-      panner.connect(this.master);
-      return panner;
+      out = panner;
     }
-    node.connect(this.master);
-    return node;
+    out.connect(this.sfxBus);
+    if (reverb && reverb > 0 && this.convolver) {
+      const send = this.ctx.createGain();
+      send.gain.value = Math.min(1, reverb);
+      out.connect(send);
+      send.connect(this.convolver);
+    }
+    return out;
   }
 
   /** Play a single oscillator voice with an AD envelope. */
@@ -194,11 +303,14 @@ export class SynthEngine {
 
     const env = ctx.createGain();
     env.gain.setValueAtTime(0.0001, t0);
-    env.gain.exponentialRampToValueAtTime(Math.max(0.0002, spec.gain), t0 + spec.attack);
+    env.gain.exponentialRampToValueAtTime(
+      Math.max(0.0002, spec.gain),
+      t0 + spec.attack
+    );
     env.gain.exponentialRampToValueAtTime(0.0001, t0 + spec.attack + spec.release);
 
     osc.connect(env);
-    this.route(env, spec.pan);
+    this.route(env, spec.pan, spec.reverb);
 
     osc.start(t0);
     osc.stop(t0 + spec.attack + spec.release + 0.02);
@@ -241,7 +353,7 @@ export class SynthEngine {
 
     src.connect(filter);
     filter.connect(env);
-    this.route(env, spec.pan);
+    this.route(env, spec.pan, spec.reverb);
 
     src.start(t0);
     src.stop(t0 + spec.dur + 0.02);
@@ -260,8 +372,19 @@ export class SynthEngine {
   dispose(): void {
     this.unlocked = false;
     const ctx = this.ctx;
+    // Explicitly tear down the reverb return so the convolver tail is freed.
+    try {
+      this.reverbWet?.disconnect();
+      this.convolver?.disconnect();
+    } catch {
+      /* already torn down */
+    }
     this.ctx = null;
     this.master = null;
+    this.sfxBus = null;
+    this.musicBus = null;
+    this.convolver = null;
+    this.reverbWet = null;
     this.noiseBuffer = null;
     if (ctx) {
       try {

--- a/corpan/packs/lingo-hero/src/audio/index.ts
+++ b/corpan/packs/lingo-hero/src/audio/index.ts
@@ -1,6 +1,8 @@
 import type { GameEventBus } from "../events";
 import { LaneIndex } from "../types";
 import { SynthEngine } from "./SynthEngine";
+import { MusicBed } from "./MusicBed";
+import { MuteToggle } from "./MuteToggle";
 import { Haptics } from "./haptics";
 import {
   playHit,
@@ -11,11 +13,19 @@ import {
   playMenu,
   playStart,
   playGameOver,
+  playWaveVerdict,
 } from "./sounds";
 
 /**
- * SFX + haptics layer — UI clicks, hit chimes, miss thuds, combo risers,
- * game-over sting, and navigator.vibrate haptic taps.
+ * Audio + haptics layer — a fully-offline synthwave palette:
+ *   - combo-pitched hit chimes, milestone risers, a soft non-punitive miss,
+ *   - a per-wave verdict accent that reinforces the learning moment,
+ *   - a menu stinger + an energetic start swell + a dramatic game-over sting,
+ *   - an EVOLVING ambient/music BED that intensifies with the combo, and
+ *   - navigator.vibrate haptic taps.
+ *
+ * Plus a self-contained, neon-styled MUTE TOGGLE (persisted to localStorage)
+ * and full prefers-reduced-motion respect.
  *
  * STREAM: audio. Everything is wired off the bus; Game.ts is untouched. All
  * sound is synthesized at runtime (no bundled audio assets) so the pack stays
@@ -32,6 +42,19 @@ export interface AudioHandle {
 
 /** Combo milestone every N hits triggers the celebratory riser. */
 const MILESTONE_INTERVAL = 5;
+
+/** Read prefers-reduced-motion once; vibration + heavy motion-y layers respect it. */
+function prefersReducedMotion(): boolean {
+  try {
+    return (
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    );
+  } catch {
+    return false;
+  }
+}
 
 /** Map a lane to a gentle stereo pan so hits feel spatial. */
 function lanePan(lane: LaneIndex | null): number {
@@ -54,26 +77,63 @@ function milestoneCrossed(prev: number, value: number): number {
 }
 
 export function initAudioHaptics(bus: GameEventBus): AudioHandle {
+  const reduced = prefersReducedMotion();
   const synth = new SynthEngine();
+  const music = new MusicBed(synth, reduced);
   const haptics = new Haptics();
   const unsubs: Array<() => void> = [];
 
-  // --- gameStart: unlock audio (first gesture) + energetic swell ---------
+  // Self-contained neon mute control. Created up front; attached to the HUD
+  // overlay once it exists (first menu/start). Toggling mutes the whole bus
+  // (SFX + music) and the bed pauses/resumes its scheduler accordingly.
+  const mute = new MuteToggle((muted) => {
+    synth.setMuted(muted);
+    if (muted) {
+      // Stop scheduling so a muted run isn't quietly burning the clock.
+      music.stop(0.1);
+    } else if (synth.ready) {
+      music.start();
+    }
+  });
+
+  /** Sync engine + bed to the persisted mute preference once audio is live. */
+  const applyMute = () => {
+    synth.setMuted(mute.isMuted);
+  };
+
+  // --- gameStart: unlock audio (first gesture) + swell + start the bed -----
   unsubs.push(
     bus.on("gameStart", () => {
       // Critical: this fires from the menu click/touch handler, so it is a
       // valid user-gesture context to create/resume the AudioContext.
       synth.unlock();
+      applyMute();
+      mute.attach();
       playStart(synth);
+      if (!mute.isMuted) {
+        music.setCombo(0);
+        music.start();
+      }
     })
   );
 
-  // --- menuShown: gentle ambient chime -----------------------------------
+  // --- menuShown: gentle stinger + cool the bed back to menu ambience ------
   unsubs.push(
     bus.on("menuShown", () => {
       // The very first menu may show before any gesture; unlock() is a no-op
       // until then, so this simply stays silent until audio is permitted.
-      if (synth.ready) playMenu(synth);
+      mute.attach();
+      if (synth.ready) {
+        applyMute();
+        playMenu(synth);
+        // Keep a soft menu bed running if not muted, otherwise hush it.
+        if (!mute.isMuted) {
+          music.cool();
+          music.start();
+        } else {
+          music.stop(0.3);
+        }
+      }
     })
   );
 
@@ -98,9 +158,25 @@ export function initAudioHaptics(bus: GameEventBus): AudioHandle {
     })
   );
 
-  // --- comboChange: milestone riser OR streak-break deflate --------------
+  // --- wave-resolved: a subtle verdict accent for the learning moment ----
+  // Fires exactly once per wave with the FINAL verdict (correct/wrong/passed),
+  // layered quietly under the per-tap SFX to reinforce the meaning-reveal.
+  unsubs.push(
+    bus.on("wave-resolved", (e) => {
+      playWaveVerdict(synth, e.outcome);
+    })
+  );
+
+  // --- comboChange: milestone riser / break deflate + drive the music bed -
   unsubs.push(
     bus.on("comboChange", (e) => {
+      // The bed intensifies (or cools) with every combo change.
+      if (e.value === 0) {
+        music.cool();
+      } else {
+        music.setCombo(e.value);
+      }
+
       const tier = milestoneCrossed(e.previous, e.value);
       if (tier > 0) {
         playMilestone(synth, tier);
@@ -112,11 +188,13 @@ export function initAudioHaptics(bus: GameEventBus): AudioHandle {
     })
   );
 
-  // --- gameOver: dramatic sting + rumble ---------------------------------
+  // --- gameOver: dramatic sting + rumble + cool the bed out --------------
   unsubs.push(
     bus.on("gameOver", () => {
       playGameOver(synth);
       haptics.gameOver();
+      music.cool();
+      music.stop(1.2);
     })
   );
 
@@ -131,6 +209,8 @@ export function initAudioHaptics(bus: GameEventBus): AudioHandle {
       }
       unsubs.length = 0;
       haptics.cancel();
+      mute.dispose();
+      music.dispose();
       synth.dispose();
     },
   };

--- a/corpan/packs/lingo-hero/src/audio/sounds.ts
+++ b/corpan/packs/lingo-hero/src/audio/sounds.ts
@@ -2,16 +2,21 @@
  * sounds.ts — sound DESIGN. Maps high-level game cues to layered synth voices.
  *
  * All sounds are procedurally synthesized (no bundled audio files), keeping the
- * pack fully offline with zero binary weight. The hit chime walks up a
- * pentatonic scale as the combo grows, so a long streak literally sounds like a
- * rising melody — pure dopamine.
+ * pack fully offline with zero binary weight. Everything is tuned to the same
+ * C-minor synthwave palette as the MusicBed so SFX sit *inside* the track
+ * rather than fighting it, and each cue gets a touch of the engine's shared
+ * reverb for a cohesive, premium "room".
+ *
+ * The hit chime walks up a pentatonic scale as the combo grows, so a long
+ * streak literally sounds like a rising melody — pure dopamine.
  */
 
 import type { SynthEngine } from "./SynthEngine";
 
-// A major pentatonic scale (C, D, E, G, A) across a couple octaves. Pentatonic
-// means consecutive notes always sound consonant, so an ascending combo never
-// produces a sour interval no matter how high it climbs.
+// A major-pentatonic scale (C D E G A) across a few octaves. Pentatonic means
+// consecutive notes always sound consonant, so an ascending combo never
+// produces a sour interval no matter how high it climbs, and it sits happily
+// over the Cm bed (shared C tonic).
 const PENTATONIC_Hz: number[] = (() => {
   const root = 523.25; // C5
   const ratios = [1, 9 / 8, 5 / 4, 3 / 2, 5 / 3]; // C D E G A
@@ -32,11 +37,17 @@ function comboPitch(combo: number): number {
 }
 
 /**
- * Correct hit: a bright two-partial bell that rises with the combo, plus a
- * tiny noise "tick" transient for attack snap and a faint sub for body.
+ * Correct hit: a bright multi-partial bell that rises with the combo. Layers:
+ *   - a triangle fundamental (the note),
+ *   - a sine octave shimmer (the "ting"),
+ *   - a fifth sparkle on bigger combos (richness),
+ *   - a soft sine sub for body/weight,
+ *   - a bandpassed noise tick for attack snap.
+ * Each carries a light reverb send so hits bloom into the synthwave space.
  */
 export function playHit(synth: SynthEngine, combo: number, lanePan: number): void {
   const f = comboPitch(combo);
+  const pan = lanePan * 0.6;
 
   // Fundamental bell.
   synth.playVoice({
@@ -44,8 +55,9 @@ export function playHit(synth: SynthEngine, combo: number, lanePan: number): voi
     freq: f,
     gain: 0.32,
     attack: 0.004,
-    release: 0.16,
-    pan: lanePan * 0.6,
+    release: 0.17,
+    pan,
+    reverb: 0.22,
   });
   // Shimmer partial an octave up — gives the "ting".
   synth.playVoice({
@@ -53,8 +65,9 @@ export function playHit(synth: SynthEngine, combo: number, lanePan: number): voi
     freq: f * 2,
     gain: 0.16,
     attack: 0.003,
-    release: 0.12,
-    pan: lanePan * 0.6,
+    release: 0.13,
+    pan,
+    reverb: 0.3,
   });
   // Perfect-fifth sparkle for richness on bigger combos.
   if (combo >= 3) {
@@ -63,137 +76,202 @@ export function playHit(synth: SynthEngine, combo: number, lanePan: number): voi
       freq: f * 3,
       gain: 0.08,
       attack: 0.003,
-      release: 0.09,
-      pan: lanePan * 0.6,
+      release: 0.1,
+      pan,
+      reverb: 0.35,
     });
   }
-  // Attack transient.
+  // Soft sub gives the chime weight on phone speakers.
+  synth.playVoice({
+    type: "sine",
+    freq: f / 2,
+    gain: 0.07,
+    attack: 0.004,
+    release: 0.12,
+    pan: pan * 0.4,
+  });
+  // Attack transient — crisp pick of light.
   synth.playNoise({
     gain: 0.12,
     dur: 0.05,
-    cutoff: 7000,
+    cutoff: 7200,
     cutoffTo: 2500,
     filter: "bandpass",
     q: 0.7,
-    pan: lanePan * 0.6,
+    pan,
   });
 }
 
-/** Wrong tap: a detuned downward "thunk" + a short low noise thud. */
+/**
+ * Wrong tap: a detuned downward "thunk" + a short low noise thud. Kept soft and
+ * non-punitive (this is a learning game — a wrong tap shouldn't sting). Slight
+ * reverb so it doesn't sound disconnected from the polished hits.
+ */
 export function playMiss(synth: SynthEngine, lanePan: number): void {
+  const pan = lanePan * 0.5;
   synth.playVoice({
     type: "sawtooth",
     freq: 196,
-    freqTo: 110,
-    gain: 0.22,
+    freqTo: 104,
+    gain: 0.2,
     attack: 0.004,
-    release: 0.18,
-    pan: lanePan * 0.5,
+    release: 0.2,
+    pan,
     detune: -12,
+    reverb: 0.12,
   });
   synth.playNoise({
-    gain: 0.18,
-    dur: 0.14,
+    gain: 0.16,
+    dur: 0.15,
     cutoff: 900,
-    cutoffTo: 220,
+    cutoffTo: 200,
     filter: "lowpass",
     q: 0.6,
-    pan: lanePan * 0.5,
+    pan,
+    reverb: 0.1,
   });
 }
 
-/** Target slipped past unanswered: softer, sadder descending sine. */
+/**
+ * Target slipped past unanswered: softer, sadder descending sine pair — a
+ * gentle "you missed that one" without a hard buzz. More reverb for a wistful,
+ * receding feel.
+ */
 export function playPassed(synth: SynthEngine): void {
   synth.playVoice({
     type: "sine",
     freq: 330,
     freqTo: 247,
-    gain: 0.14,
+    gain: 0.13,
     attack: 0.01,
-    release: 0.28,
+    release: 0.3,
+    reverb: 0.4,
   });
   synth.playVoice({
     type: "sine",
     freq: 247,
-    freqTo: 185,
+    freqTo: 175,
     gain: 0.1,
     attack: 0.02,
-    release: 0.3,
-    delay: 0.04,
+    release: 0.32,
+    delay: 0.05,
+    reverb: 0.45,
   });
 }
 
 /**
  * Combo milestone (every N): an ascending arpeggio "riser" that scales its
- * brightness with the milestone tier. This is the celebratory ear-candy.
+ * brightness and octave with the milestone tier. This is the celebratory
+ * ear-candy — the moment a streak crosses 5/10/15… A bright whoosh underneath
+ * gives it lift, and a sub-thump lands the arrival.
  */
 export function playMilestone(synth: SynthEngine, tier: number): void {
   const base = 523.25; // C5
   const arp = [1, 5 / 4, 3 / 2, 2]; // C E G C — a major triad + octave
   const t = Math.min(tier, 5);
+  const octShift = Math.pow(2, Math.floor(t / 3)); // climbs an octave at big tiers
   arp.forEach((ratio, i) => {
     synth.playVoice({
       type: "triangle",
-      freq: base * ratio * Math.pow(2, Math.floor(t / 3)),
+      freq: base * ratio * octShift,
       gain: 0.2,
       attack: 0.005,
-      release: 0.22,
+      release: 0.24,
       delay: i * 0.06,
       pan: i % 2 === 0 ? -0.3 : 0.3,
+      reverb: 0.4,
     });
     // Octave shimmer on top.
     synth.playVoice({
       type: "sine",
-      freq: base * ratio * 2,
+      freq: base * ratio * 2 * octShift,
       gain: 0.08,
       attack: 0.004,
-      release: 0.16,
+      release: 0.18,
       delay: i * 0.06,
+      reverb: 0.5,
     });
   });
-  // A bright whoosh underneath for "lift".
+  // A bright rising whoosh underneath for "lift".
   synth.playNoise({
-    gain: 0.12,
-    dur: 0.3,
-    cutoff: 600,
-    cutoffTo: 6000,
+    gain: 0.13,
+    dur: 0.34,
+    cutoff: 500,
+    cutoffTo: 6500,
     filter: "bandpass",
     q: 0.8,
+    reverb: 0.3,
+  });
+  // Sub-thump on the arrival so the riser "lands".
+  synth.playVoice({
+    type: "sine",
+    freq: 130.81 * octShift, // C3
+    gain: 0.16,
+    attack: 0.006,
+    release: 0.4,
+    delay: arp.length * 0.06,
   });
 }
 
-/** Combo streak broken (was high, dropped to 0): a quick deflating glissando. */
+/**
+ * Combo streak broken (was high, dropped to 0): a quick deflating glissando —
+ * a tasteful "aww", not a punishment buzz.
+ */
 export function playComboBreak(synth: SynthEngine): void {
   synth.playVoice({
     type: "square",
     freq: 440,
-    freqTo: 130,
-    gain: 0.14,
+    freqTo: 123,
+    gain: 0.13,
     attack: 0.005,
-    release: 0.32,
+    release: 0.34,
+    reverb: 0.18,
+  });
+  synth.playVoice({
+    type: "sine",
+    freq: 220,
+    freqTo: 82,
+    gain: 0.1,
+    attack: 0.008,
+    release: 0.38,
+    reverb: 0.2,
   });
 }
 
-/** Menu shown / UI ready: a gentle welcoming two-note chime. */
+/**
+ * Menu shown / UI ready: a welcoming, glassy stinger — a rising minor-add9
+ * spread that announces the brand. Warm reverb, gentle, premium.
+ */
 export function playMenu(synth: SynthEngine): void {
-  synth.playVoice({
-    type: "sine",
-    freq: 587.33, // D5
-    gain: 0.14,
-    attack: 0.01,
-    release: 0.25,
+  // C E♭ G B♭ D — a lush Cm9 spread, arpeggiated upward.
+  const notes = [523.25, 622.25, 783.99, 932.33, 1174.66];
+  notes.forEach((f, i) => {
+    synth.playVoice({
+      type: "triangle",
+      freq: f,
+      gain: i === 0 ? 0.14 : 0.1,
+      attack: 0.012,
+      release: 0.34,
+      delay: i * 0.07,
+      pan: i % 2 === 0 ? -0.22 : 0.22,
+      reverb: 0.5,
+    });
   });
+  // A soft pad swell underneath grounds the chime.
   synth.playVoice({
     type: "sine",
-    freq: 880, // A5
-    gain: 0.12,
-    attack: 0.01,
-    release: 0.3,
-    delay: 0.11,
+    freq: 261.63, // C4
+    gain: 0.08,
+    attack: 0.1,
+    release: 0.6,
+    reverb: 0.45,
   });
 }
 
-/** Game start: an energetic upward "let's go" swell. */
+/**
+ * Game start: an energetic upward "let's go" swell that lifts straight into the
+ * music bed. Detuned saw stab + a filter-opening whoosh + a downbeat sub.
+ */
 export function playStart(synth: SynthEngine): void {
   synth.playVoice({
     type: "triangle",
@@ -201,21 +279,43 @@ export function playStart(synth: SynthEngine): void {
     freqTo: 784, // G5
     gain: 0.2,
     attack: 0.02,
+    release: 0.32,
+    reverb: 0.3,
+  });
+  // Detuned saw stab for synthwave grit.
+  synth.playVoice({
+    type: "sawtooth",
+    freq: 261.63,
+    gain: 0.1,
+    attack: 0.01,
     release: 0.3,
+    detune: 8,
+    reverb: 0.25,
   });
   synth.playNoise({
     gain: 0.14,
-    dur: 0.35,
+    dur: 0.36,
     cutoff: 400,
-    cutoffTo: 7000,
+    cutoffTo: 7200,
     filter: "bandpass",
     q: 0.7,
+    reverb: 0.3,
+  });
+  // Downbeat sub "boom" to kick off the run.
+  synth.playVoice({
+    type: "sine",
+    freq: 65.41, // C2
+    gain: 0.18,
+    attack: 0.008,
+    release: 0.45,
+    delay: 0.18,
   });
 }
 
 /**
- * Game over: a descending minor "sting" — three falling notes that resolve
- * with a low body tone. Dramatic without being harsh.
+ * Game over: a descending minor "sting" — three falling notes that resolve with
+ * a low body tone and a dark filtered fall. Dramatic without being harsh, and
+ * drenched in reverb so the run ends in a big synthwave room.
  */
 export function playGameOver(synth: SynthEngine): void {
   const notes = [659.25, 523.25, 415.3]; // E5 → C5 → G#4 (falling)
@@ -225,9 +325,10 @@ export function playGameOver(synth: SynthEngine): void {
       freq: f,
       gain: 0.2,
       attack: 0.008,
-      release: 0.4,
+      release: 0.42,
       delay: i * 0.16,
       pan: 0,
+      reverb: 0.5,
     });
   });
   // Low resolving body.
@@ -236,16 +337,52 @@ export function playGameOver(synth: SynthEngine): void {
     freq: 130.81, // C3
     gain: 0.16,
     attack: 0.02,
-    release: 0.9,
+    release: 0.95,
     delay: 0.48,
+    reverb: 0.4,
   });
   synth.playNoise({
     gain: 0.1,
     dur: 0.6,
     cutoff: 3000,
-    cutoffTo: 200,
+    cutoffTo: 180,
     filter: "lowpass",
     q: 0.5,
     delay: 0.48,
+    reverb: 0.35,
   });
+}
+
+/**
+ * Wave verdict accent (learning-feel): a tiny confirm/deny ping layered on top
+ * of the per-tap SFX when a whole wave resolves. Correct = a clean two-note
+ * "up" affirmation; wrong/passed = a soft single low note. Subtle by design so
+ * it reinforces the meaning-reveal moment without doubling the hit volume.
+ */
+export function playWaveVerdict(
+  synth: SynthEngine,
+  outcome: "correct" | "wrong" | "passed"
+): void {
+  if (outcome === "correct") {
+    synth.playVoice({
+      type: "sine",
+      freq: 783.99, // G5
+      freqTo: 1046.5, // C6
+      gain: 0.1,
+      attack: 0.006,
+      release: 0.18,
+      reverb: 0.45,
+    });
+  } else {
+    // wrong or passed — a gentle, low confirmation that the wave closed.
+    synth.playVoice({
+      type: "sine",
+      freq: 311.13, // E♭4
+      freqTo: 261.63, // C4
+      gain: 0.08,
+      attack: 0.01,
+      release: 0.24,
+      reverb: 0.4,
+    });
+  }
 }

--- a/corpan/packs/lingo-hero/src/effects/boardState.ts
+++ b/corpan/packs/lingo-hero/src/effects/boardState.ts
@@ -1,0 +1,107 @@
+import { LaneIndex } from "../types";
+
+/**
+ * Process-local "board signal" — the thin seam that lets the Renderer (which is
+ * constructed as `new Renderer(canvas, laneSystem)` and therefore never receives
+ * the event bus) react to gameplay WITHOUT editing Game.ts.
+ *
+ * The effects layer (`effects/index.ts`) is already a bus subscriber. It pushes
+ * combo / hit / miss signals into this singleton each time the bus fires; the
+ * Renderer reads them every frame to escalate lane intensity, fire lane-flash
+ * columns on a hit, and flush the playfield with red on a miss. Both modules
+ * live under `effects/*` + `Renderer.ts` (this stream's owned files), so the
+ * coupling stays inside the BOARD stream and never crosses into Game.ts.
+ *
+ * It is intentionally a module-level singleton: there is exactly one live Game /
+ * canvas at a time in the host, and `reset()` is called on gameStart/menuShown
+ * so a remount starts clean.
+ */
+
+export interface LaneFlash {
+  /** performance.now() timestamp the flash was triggered. */
+  at: number;
+  /** 0..1 intensity (scales with combo at trigger time). */
+  power: number;
+}
+
+interface BoardState {
+  /** Current combo (0 when broken). Drives escalation of grid + lane glow. */
+  combo: number;
+  /** Smoothed 0..1 "energy" the Renderer eases toward combo for buttery ramps. */
+  energy: number;
+  /** Per-lane hit flash (column slam + ring). Indexed by LaneIndex. */
+  laneFlash: [LaneFlash, LaneFlash, LaneFlash];
+  /** performance.now() of the last miss (drives a brief red wash on the floor). */
+  lastMissAt: number;
+  /** 0..1 power of the last miss (passed target > wrong tap). */
+  lastMissPower: number;
+  /** Global "heat" 0..1 used for bloom budget; eases with energy + recent hits. */
+  heat: number;
+}
+
+const NEVER = -1e9;
+
+const state: BoardState = {
+  combo: 0,
+  energy: 0,
+  laneFlash: [
+    { at: NEVER, power: 0 },
+    { at: NEVER, power: 0 },
+    { at: NEVER, power: 0 },
+  ],
+  lastMissAt: NEVER,
+  lastMissPower: 0,
+  heat: 0,
+};
+
+export function getBoardState(): Readonly<BoardState> {
+  return state;
+}
+
+/** Effects layer calls this on `noteHit`. */
+export function signalHit(lane: LaneIndex, combo: number, now: number): void {
+  state.combo = combo;
+  const f = state.laneFlash[lane] ?? state.laneFlash[1];
+  f.at = now;
+  f.power = 1;
+}
+
+/** Effects layer calls this on `noteMiss`. */
+export function signalMiss(power: number, now: number): void {
+  state.combo = 0;
+  state.lastMissAt = now;
+  state.lastMissPower = power < 0 ? 0 : power > 1 ? 1 : power;
+}
+
+/** Effects layer calls this on `comboChange` (covers non-hit decrements too). */
+export function signalCombo(value: number): void {
+  state.combo = value < 0 ? 0 : value;
+}
+
+/** Effects layer calls this on gameStart / menuShown / gameOver. */
+export function resetBoardState(): void {
+  state.combo = 0;
+  state.energy = 0;
+  state.heat = 0;
+  state.lastMissAt = NEVER;
+  state.lastMissPower = 0;
+  for (const f of state.laneFlash) {
+    f.at = NEVER;
+    f.power = 0;
+  }
+}
+
+/**
+ * Per-frame easing toward the current combo, called once from the Renderer.
+ * Keeps the smoothing single-sourced so escalation visuals stay in lockstep.
+ * `dt` is seconds; safe to call with the Renderer's own clamped delta.
+ */
+export function tickBoardState(dt: number): void {
+  const d = dt > 0.1 ? 0.1 : dt > 0 ? dt : 1 / 60;
+  // Map combo onto a 0..1 energy curve that saturates around a 24-combo run.
+  const target = state.combo <= 0 ? 0 : Math.min(1, state.combo / 24);
+  state.energy += (target - state.energy) * Math.min(1, d * 3.4);
+  // Heat tracks energy but spikes on a fresh hit and bleeds off slowly.
+  const heatTarget = Math.max(state.energy, target);
+  state.heat += (heatTarget - state.heat) * Math.min(1, d * 2.2);
+}

--- a/corpan/packs/lingo-hero/src/effects/index.ts
+++ b/corpan/packs/lingo-hero/src/effects/index.ts
@@ -7,6 +7,12 @@ import { Background } from "./background";
 import { Floaters } from "./floaters";
 import { Transitions } from "./transitions";
 import { laneRgb, COLORS, mix, type Rgb } from "./palette";
+import {
+  signalHit,
+  signalMiss,
+  signalCombo,
+  resetBoardState,
+} from "./boardState";
 
 /**
  * VFX layer — particles, screen shake, hit bursts, combo flares, transitions,
@@ -61,6 +67,8 @@ export function initEffects(
     bus.on("noteHit", (e) => {
       const color = laneRgb(e.lane);
       combo = e.combo;
+      // Feed the Renderer's escalation/lane-flash seam (no Game.ts coupling).
+      signalHit(e.lane, e.combo, performance.now());
 
       // Core burst: bright sparks + shards fanning up from the strum line.
       particles.burst(e.x, e.y, {
@@ -135,6 +143,7 @@ export function initEffects(
   offs.push(
     bus.on("noteMiss", (e) => {
       combo = 0;
+      signalMiss(e.reason === "passed" ? 1 : 0.55, performance.now());
       const x = e.x;
       const y = e.y;
       const red = COLORS.RED;
@@ -166,6 +175,7 @@ export function initEffects(
   offs.push(
     bus.on("comboChange", (e) => {
       combo = e.value;
+      signalCombo(e.value);
       // Detect milestone crossings (value rose past a threshold).
       if (e.value > e.previous) {
         for (const m of MILESTONES) {
@@ -180,6 +190,7 @@ export function initEffects(
   offs.push(
     bus.on("gameStart", (e) => {
       combo = 0;
+      resetBoardState();
       particles.clear();
       floaters.clear();
       shake.reset();
@@ -223,6 +234,7 @@ export function initEffects(
         }
       }
       combo = 0;
+      resetBoardState();
       background.reset();
     })
   );
@@ -230,6 +242,7 @@ export function initEffects(
   offs.push(
     bus.on("menuShown", () => {
       combo = 0;
+      resetBoardState();
       particles.clear();
       floaters.clear();
       shake.reset();

--- a/corpan/packs/lingo-hero/src/effects/palette.ts
+++ b/corpan/packs/lingo-hero/src/effects/palette.ts
@@ -12,15 +12,20 @@ export interface Rgb {
   b: number;
 }
 
+// Elevated "Neon Arcade" lane colors — single-sourced to the --na-lane-* design
+// tokens (cyan #2ff3ff / magenta #ff00d4 / lime #7bff7b) so particles, rings,
+// trails, and the Renderer's lanes/cards all read as ONE coherent instrument.
+// (The harsh pure #00ffff / #00ff00 of the bootstrap palette muddied the bloom.)
 const LANE_RGB: Record<number, Rgb> = {
-  0: { r: 0, g: 255, b: 255 }, // Cyan
-  1: { r: 255, g: 0, b: 255 }, // Pink/Magenta
-  2: { r: 0, g: 255, b: 0 }, // Green
+  0: { r: 47, g: 243, b: 255 }, // Cyan   — --na-lane-1
+  1: { r: 255, g: 0, b: 212 }, // Magenta — --na-lane-2
+  2: { r: 123, g: 255, b: 123 }, // Lime  — --na-lane-3
 };
 
 const WHITE: Rgb = { r: 255, g: 255, b: 255 };
-const GOLD: Rgb = { r: 255, g: 215, b: 90 };
-const RED: Rgb = { r: 255, g: 70, b: 70 };
+const GOLD: Rgb = { r: 255, g: 211, b: 92 }; // warm arcade gold (combo / milestones)
+const RED: Rgb = { r: 255, g: 62, b: 120 }; // --na-wrong-adjacent neon pink-red
+const PINK: Rgb = { r: 255, g: 62, b: 165 }; // --neon-pink, for miss washes
 
 export function laneRgb(lane: LaneIndex | number): Rgb {
   return LANE_RGB[lane] ?? WHITE;
@@ -53,4 +58,4 @@ export function clamp01(v: number): number {
   return v < 0 ? 0 : v > 1 ? 1 : v;
 }
 
-export const COLORS = { WHITE, GOLD, RED };
+export const COLORS = { WHITE, GOLD, RED, PINK };

--- a/corpan/packs/lingo-hero/src/learning/difficulty.ts
+++ b/corpan/packs/lingo-hero/src/learning/difficulty.ts
@@ -1,0 +1,94 @@
+/**
+ * learning/difficulty.ts — Gentle adaptive difficulty for Lingo Hero.
+ *
+ * STREAM: learning. Pure, side-effect-free math. Tracks a rolling window of
+ * recent wave outcomes and derives a 0..1 "difficulty" signal that the learning
+ * layer can use to bias content selection (e.g. how aggressively to resurface
+ * weak/due words vs. let fresh content flow).
+ *
+ * IMPORTANT — scope of "difficulty": the foundation owns NOTE_TRAVEL_SECONDS and
+ * we must NOT make the game impossible again (the calibrated ~7s travel feel is
+ * a hard non-regression). This module therefore does NOT touch note speed or
+ * spawn timing. "Difficulty" here means *content* difficulty: when the learner
+ * is hot, lean harder into due/weak resurfacing and more believable distractors;
+ * when they're struggling, ease off and let familiar/fresh words breathe. It is
+ * a comfort dial on the LEARNING curve, never on the playability curve.
+ *
+ * The curve is deliberately gentle and hysteretic: it ramps up slowly on
+ * success and backs off quickly on a rough patch, so the learner is challenged
+ * but never punished into a spiral. Defaults give a calm, encouraging ride.
+ */
+
+export interface DifficultyConfig {
+  /** How many recent outcomes feed the rolling accuracy. */
+  windowSize: number;
+  /** EWMA smoothing for the difficulty signal (0..1; lower = smoother). */
+  smoothing: number;
+  /** Accuracy at/above which difficulty ramps up. */
+  hotAccuracy: number;
+  /** Accuracy at/below which difficulty eases off (back off fast). */
+  coldAccuracy: number;
+}
+
+export const DEFAULT_DIFFICULTY: DifficultyConfig = {
+  windowSize: 8,
+  smoothing: 0.25,
+  hotAccuracy: 0.8,
+  coldAccuracy: 0.5,
+};
+
+export class AdaptiveDifficulty {
+  private readonly window: boolean[] = [];
+  /** 0 = easiest content bias, 1 = hardest. Starts neutral-low (encouraging). */
+  private signal = 0.3;
+
+  constructor(private readonly cfg: DifficultyConfig = DEFAULT_DIFFICULTY) {}
+
+  /** Reset to a fresh, encouraging baseline (call on run start). */
+  reset(): void {
+    this.window.length = 0;
+    this.signal = 0.3;
+  }
+
+  /** Feed one resolved wave outcome. Updates the rolling window + signal. */
+  record(correct: boolean): void {
+    this.window.push(correct);
+    if (this.window.length > this.cfg.windowSize) this.window.shift();
+
+    const acc = this.accuracy();
+    // Target difficulty derived from how far accuracy sits in the comfort band.
+    let target: number;
+    if (acc >= this.cfg.hotAccuracy) {
+      // Hot: ramp toward harder, scaled by how far above the threshold we are.
+      const span = 1 - this.cfg.hotAccuracy || 1;
+      target = 0.6 + 0.4 * ((acc - this.cfg.hotAccuracy) / span);
+    } else if (acc <= this.cfg.coldAccuracy) {
+      // Cold: ease toward easier, scaled by how far below we are.
+      const span = this.cfg.coldAccuracy || 1;
+      target = 0.15 * (acc / span);
+    } else {
+      // In-band: gently settle toward the middle.
+      target = 0.45;
+    }
+
+    // Asymmetric hysteresis: ease DOWN quickly (be kind), ramp UP slowly.
+    const k = target < this.signal ? Math.min(1, this.cfg.smoothing * 2) : this.cfg.smoothing;
+    this.signal = clamp01(this.signal + (target - this.signal) * k);
+  }
+
+  /** Rolling accuracy over the window (0..1). Neutral 0.7 before enough data. */
+  accuracy(): number {
+    if (this.window.length === 0) return 0.7;
+    const hits = this.window.reduce((n, ok) => n + (ok ? 1 : 0), 0);
+    return hits / this.window.length;
+  }
+
+  /** Current content-difficulty signal in [0,1]. */
+  get value(): number {
+    return this.signal;
+  }
+}
+
+function clamp01(v: number): number {
+  return v < 0 ? 0 : v > 1 ? 1 : v;
+}

--- a/corpan/packs/lingo-hero/src/learning/index.ts
+++ b/corpan/packs/lingo-hero/src/learning/index.ts
@@ -1,0 +1,263 @@
+/**
+ * learning/index.ts — Spaced-difficulty + mastery orchestrator.
+ *
+ * STREAM: learning. Wires the per-word memory (WordStatsStore), the gentle
+ * adaptive-difficulty signal, the content-selection bias (WordSelector via the
+ * foundation's setDefaultWordSelector hook), and the HUD mastery readout — all
+ * WITHOUT editing Game.ts or Hud.ts.
+ *
+ * HOW IT HOOKS IN (no Game.ts edits):
+ *   - The selector reaches ContentManager via the process-wide default registry
+ *     (`setDefaultWordSelector`). Game.ts's existing `new ContentManager(hostApi)`
+ *     transparently resolves it. We register it in `initLearning` AND, as a
+ *     belt-and-suspenders side effect, on module import (see bottom of file) so
+ *     the bias is live even if init ordering ever shifts.
+ *   - Outcomes flow from the typed bus's `wave-resolved` event (Game.ts is the
+ *     sole emitter; we only subscribe). One subscription updates the memory,
+ *     the difficulty signal, and the mastery readout.
+ *
+ * SCOPING: memory is keyed (stackId, lang). We derive the scope from each
+ * `wave-resolved` event's `word.lang` (most reliable) and lazily create a store
+ * per scope, so switching languages mid-session never cross-contaminates.
+ *
+ * OFFLINE-FIRST: all persistence is localStorage (guarded). No network.
+ */
+
+import type { GameEventBus } from "../events";
+import type { HostApi } from "../sdk/types";
+import { setDefaultWordSelector } from "../ContentManager";
+import { WordStatsStore } from "./wordStats";
+import { AdaptiveDifficulty } from "./difficulty";
+import { createWordSelector } from "./selector";
+import {
+  computeMastery,
+  formatReadout,
+  renderMasterySlot,
+  type MasterySummary,
+} from "./mastery";
+
+export interface LearningApi {
+  /** Structured mastery for the CURRENT (active) scope; null before any word. */
+  getMastery: () => MasterySummary | null;
+  /** Current gentle content-difficulty signal (0..1) for the active scope. */
+  getDifficulty: () => number;
+  /** Tear down subscriptions + flush all per-scope memory. */
+  dispose: () => void;
+}
+
+/** Resolve the active stack id defensively (scope namespacing). */
+function resolveStackId(hostApi: HostApi): string {
+  try {
+    return hostApi.getStackConfig?.().activeStackId || "default";
+  } catch {
+    return "default";
+  }
+}
+
+/**
+ * A shared, process-wide learning context so the selector registered at module
+ * import time and the bus-driven init agree on the SAME memory + difficulty.
+ * Lazily creates a store per (stackId, lang) scope.
+ */
+class LearningContext {
+  private stores = new Map<string, WordStatsStore>();
+  private difficulties = new Map<string, AdaptiveDifficulty>();
+  /** The scope the selector should read for the CURRENT wave. */
+  activeScope = "default::";
+
+  constructor(private stackIdProvider: () => string) {}
+
+  private scopeKey(lang: string): string {
+    return `${this.stackIdProvider()}::${lang || ""}`;
+  }
+
+  store(lang: string): WordStatsStore {
+    const key = this.scopeKey(lang);
+    let s = this.stores.get(key);
+    if (!s) {
+      s = new WordStatsStore(key);
+      this.stores.set(key, s);
+    }
+    return s;
+  }
+
+  difficulty(lang: string): AdaptiveDifficulty {
+    const key = this.scopeKey(lang);
+    let d = this.difficulties.get(key);
+    if (!d) {
+      d = new AdaptiveDifficulty();
+      this.difficulties.set(key, d);
+    }
+    return d;
+  }
+
+  /** The store/difficulty the selector should consult right now. */
+  activeStore(): WordStatsStore {
+    const lang = this.activeScope.split("::")[1] ?? "";
+    return this.store(lang);
+  }
+  activeDifficulty(): AdaptiveDifficulty {
+    const lang = this.activeScope.split("::")[1] ?? "";
+    return this.difficulty(lang);
+  }
+
+  setActiveLang(lang: string): void {
+    this.activeScope = this.scopeKey(lang);
+  }
+
+  disposeAll(): void {
+    for (const s of this.stores.values()) s.dispose();
+    this.stores.clear();
+    this.difficulties.clear();
+  }
+}
+
+// Process-wide singleton so the import-time selector and the runtime init share
+// state. Stack-id is read lazily (the host may not be ready at import time).
+let sharedCtx: LearningContext | null = null;
+let lastHostApi: HostApi | null = null;
+
+function ensureContext(): LearningContext {
+  if (!sharedCtx) {
+    sharedCtx = new LearningContext(() =>
+      lastHostApi ? resolveStackId(lastHostApi) : "default"
+    );
+  }
+  return sharedCtx;
+}
+
+/**
+ * Register the spaced-difficulty selector as the process-wide default. The
+ * selector reads whatever scope `ctx.activeScope` points at, which the bus init
+ * keeps in sync with the active language. Idempotent.
+ */
+function registerSelector(): void {
+  const ctx = ensureContext();
+  setDefaultWordSelector(
+    createWordSelector(
+      // Bind to a thin live-view so the selector always reads the ACTIVE scope's
+      // store/difficulty even as the active language changes mid-session.
+      new Proxy({} as WordStatsStore, {
+        get(_t, prop) {
+          const store = ctx.activeStore() as unknown as Record<string | symbol, unknown>;
+          const v = store[prop];
+          return typeof v === "function" ? (v as Function).bind(ctx.activeStore()) : v;
+        },
+      }),
+      new Proxy({} as AdaptiveDifficulty, {
+        get(_t, prop) {
+          const d = ctx.activeDifficulty() as unknown as Record<string | symbol, unknown>;
+          const v = d[prop];
+          return typeof v === "function" ? (v as Function).bind(ctx.activeDifficulty()) : v;
+        },
+      })
+    )
+  );
+}
+
+/**
+ * Initialise the learning layer against a bus + host. Called from the
+ * progression init (which Game.ts already constructs with bus + hostApi), so no
+ * Game.ts edit is needed. Returns a LearningApi for introspection + dispose.
+ */
+export function initLearning(bus: GameEventBus, hostApi: HostApi): LearningApi {
+  lastHostApi = hostApi;
+  const ctx = ensureContext();
+  registerSelector(); // ensure the selector is live for this run
+
+  // Default active scope from the current stack config (best-effort).
+  try {
+    const cfg = hostApi.getStackConfig?.();
+    const lang = cfg?.languages?.find((l) => l && l !== "en") ?? cfg?.languages?.[0] ?? "";
+    ctx.setActiveLang(lang);
+  } catch {
+    /* keep default scope */
+  }
+
+  const offFns: Array<() => void> = [];
+
+  // Refresh the readout for the active scope.
+  const refreshReadout = (): void => {
+    const summary = computeMastery(ctx.activeStore());
+    renderMasterySlot(formatReadout(summary));
+  };
+
+  offFns.push(
+    bus.on("gameStart", (e) => {
+      // The active-language context arrives on gameStart. Point the scope at it
+      // and reset the per-run difficulty ride to an encouraging baseline.
+      ctx.setActiveLang(e.language.code);
+      ctx.activeDifficulty().reset();
+      refreshReadout();
+    })
+  );
+
+  // Mark the target as SHOWN as soon as a wave begins. There is no dedicated
+  // "wave-spawned" event, so we lean on the FIRST signal we get for a wave —
+  // noteHit/noteMiss both carry the word — guarded so we stamp "shown" at most
+  // once per wave (the resolve handler clears the guard).
+  let shownThisWave = -1;
+  const markShownOnce = (entryId: number, foreign: string, english: string): void => {
+    if (shownThisWave === entryId) return;
+    shownThisWave = entryId;
+    ctx.activeStore().markShown(entryId, foreign, english);
+  };
+
+  offFns.push(
+    bus.on("noteHit", (e) => {
+      markShownOnce(e.word.entryId, e.word.foreign, e.word.english);
+    })
+  );
+  offFns.push(
+    bus.on("noteMiss", (e) => {
+      markShownOnce(e.word.entryId, e.word.foreign, e.word.english);
+    })
+  );
+
+  // The authoritative learning signal: one final verdict per wave.
+  offFns.push(
+    bus.on("wave-resolved", (e) => {
+      // Make sure the scope matches the word's language (defensive — the event
+      // is the source of truth for which language was actually quizzed).
+      if (e.word.lang) ctx.setActiveLang(e.word.lang);
+      const store = ctx.activeStore();
+      // Ensure it's been counted as shown even if the show-guard missed it.
+      markShownOnce(e.word.entryId, e.word.foreign, e.word.english);
+      store.recordOutcome(e.word.entryId, e.correct, e.word.foreign, e.word.english);
+      ctx.activeDifficulty().record(e.correct);
+      shownThisWave = -1; // arm for the next wave
+      refreshReadout();
+    })
+  );
+
+  // On return to menu, flush memory so progress is durable even mid-session.
+  offFns.push(
+    bus.on("menuShown", () => {
+      ctx.activeStore().flush();
+    })
+  );
+  offFns.push(
+    bus.on("gameOver", () => {
+      ctx.activeStore().flush();
+    })
+  );
+
+  return {
+    getMastery: () => {
+      const summary = computeMastery(ctx.activeStore());
+      return summary.seen > 0 ? summary : null;
+    },
+    getDifficulty: () => ctx.activeDifficulty().value,
+    dispose: () => {
+      for (const off of offFns) off();
+      offFns.length = 0;
+      ctx.disposeAll();
+    },
+  };
+}
+
+// --- import-time side effect ------------------------------------------------
+// Register the selector as the process-wide default the moment this module is
+// imported, so ContentManager picks up the spaced-difficulty bias even before
+// initLearning runs (belt-and-suspenders; initLearning re-registers harmlessly).
+registerSelector();

--- a/corpan/packs/lingo-hero/src/learning/mastery.ts
+++ b/corpan/packs/lingo-hero/src/learning/mastery.ts
@@ -1,0 +1,119 @@
+/**
+ * learning/mastery.ts — Mastery model + readout for Lingo Hero.
+ *
+ * STREAM: learning. Turns the per-word memory (WordStatsStore) into:
+ *   1. a structured MasterySummary the rest of the app can read, and
+ *   2. a MasteryReadout (label + 0..1 progress) for the HUD's slot (d).
+ *
+ * SURFACING TO THE HUD: the foundation added `Hud.setMastery(readout|null)` and
+ * a `#mastery-readout` element (`.mastery-label` + optional `.mastery-bar` >
+ * `.mastery-fill`) explicitly for "the ui/learning stream". The learning stream
+ * does not hold a Hud reference (we must not edit Game.ts/Hud.ts), so we render
+ * into that documented slot directly, matching the Hud's exact markup contract.
+ * The render is fully guarded: if the element isn't present (e.g. headless),
+ * it's a silent no-op. We also expose the structured summary on the progression
+ * snapshot so any consumer holding the ProgressionApi can read it.
+ *
+ * The progress bar reflects OVERALL mastery of the words the learner has met:
+ * the mean strength across seen words, which climbs as they nail words and dips
+ * when fresh/weak words enter — a calm, honest "how well do I know this set".
+ */
+
+import { MASTERED_BOX, type WordStatsStore } from "./wordStats";
+
+/** A structured snapshot of the learner's mastery for this (stack, lang) scope. */
+export interface MasterySummary {
+  /** Words the learner has encountered at least once. */
+  seen: number;
+  /** Words at/above the mastered Leitner box. */
+  mastered: number;
+  /** Seen-but-not-mastered words actively being learned. */
+  learning: number;
+  /** Words currently due to resurface (overdue or due now), among seen. */
+  due: number;
+  /** Mean strength across SEEN words, 0..1 (the readout bar fill). */
+  meanStrength: number;
+  /** A coarse mastery level (1+) derived from mastered count, for flavour. */
+  level: number;
+}
+
+/** The HUD readout shape (mirror of Hud.MasteryReadout to avoid a UI import). */
+export interface MasteryReadout {
+  label: string;
+  progress?: number;
+}
+
+/** Compute the structured mastery summary from the word store. */
+export function computeMastery(store: WordStatsStore): MasterySummary {
+  const words = store.all();
+  const wave = store.wave;
+  let mastered = 0;
+  let due = 0;
+  let strengthSum = 0;
+  for (const w of words) {
+    if (w.box >= MASTERED_BOX) mastered += 1;
+    if (wave >= w.dueWave) due += 1;
+    strengthSum += w.strength;
+  }
+  const seen = words.length;
+  const meanStrength = seen > 0 ? strengthSum / seen : 0;
+  return {
+    seen,
+    mastered,
+    learning: Math.max(0, seen - mastered),
+    due,
+    meanStrength,
+    // Gentle level curve: every 5 mastered words = +1 level, min 1.
+    level: 1 + Math.floor(mastered / 5),
+  };
+}
+
+/**
+ * Format a MasterySummary into a HUD readout. Kept short + glanceable so it
+ * never competes with the gameplay. Returns null (hide) before any word is met.
+ */
+export function formatReadout(m: MasterySummary): MasteryReadout | null {
+  if (m.seen === 0) return null;
+  const parts: string[] = [];
+  if (m.mastered > 0) parts.push(`${m.mastered} mastered`);
+  parts.push(`${m.learning} learning`);
+  if (m.due > 0) parts.push(`${m.due} due`);
+  return {
+    label: parts.join(" · "),
+    progress: m.meanStrength,
+  };
+}
+
+/**
+ * Render a readout into the foundation's `#mastery-readout` slot, mirroring the
+ * Hud's exact markup (`.mastery-label` + optional `.mastery-bar`/`.mastery-fill`)
+ * so existing CSS hooks apply. Null/empty hides the slot. Fully guarded for
+ * headless/no-DOM hosts. Input is escaped (label is our own composed string,
+ * but we stay defensive).
+ */
+export function renderMasterySlot(readout: MasteryReadout | null): void {
+  let el: HTMLElement | null = null;
+  try {
+    el = document.getElementById("mastery-readout");
+  } catch {
+    el = null;
+  }
+  if (!el) return;
+
+  if (!readout || !readout.label.trim()) {
+    el.hidden = true;
+    el.innerHTML = "";
+    return;
+  }
+  const pct = Math.max(0, Math.min(1, readout.progress ?? 0)) * 100;
+  const bar =
+    typeof readout.progress === "number"
+      ? `<span class="mastery-bar"><span class="mastery-fill" style="width:${pct}%"></span></span>`
+      : "";
+  el.innerHTML = `<span class="mastery-label">${escapeHtml(readout.label)}</span>${bar}`;
+  el.hidden = false;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/corpan/packs/lingo-hero/src/learning/selector.ts
+++ b/corpan/packs/lingo-hero/src/learning/selector.ts
@@ -1,0 +1,119 @@
+/**
+ * learning/selector.ts — The spaced-difficulty WordSelector.
+ *
+ * STREAM: learning. This implements the foundation's `WordSelector` hook
+ * (src/ContentManager.ts) to bias which word is QUIZZED (the target) and how
+ * distractors are ORDERED, using the per-word memory (WordStatsStore) and the
+ * gentle adaptive-difficulty signal.
+ *
+ * ╔══════════════════════════════════════════════════════════════════════════╗
+ * ║ CORRECTNESS CONTRACT (non-negotiable):                                    ║
+ * ║  - chooseTarget MUST return one of `candidates` (the valid pool) or       ║
+ * ║    undefined. ContentManager validates membership (inValid) and ignores   ║
+ * ║    anything else, so we can NEVER fabricate an entry.                      ║
+ * ║  - weight only REORDERS the distractor scan. ContentManager ALWAYS re-runs ║
+ * ║    the distinct-entries + distinct-English-answers dedup AFTER us, so the  ║
+ * ║    correct English still appears on EXACTLY ONE note. We can bias, never   ║
+ * ║    break.                                                                  ║
+ * ║  - observePool is side-effect only (priming the memory model).            ║
+ * ╚══════════════════════════════════════════════════════════════════════════╝
+ *
+ * Selection philosophy:
+ *  - Target: prefer DUE / WEAK words (spaced repetition), but mix in fresh and
+ *    keep it stochastic so the game never feels like a drill. The
+ *    adaptive-difficulty signal controls how hard we lean into resurfacing:
+ *    hot learner ⇒ more due/weak pressure; struggling ⇒ ease toward fresh and
+ *    already-comfortable words. Active-language prompts are strongly preferred
+ *    (matches the foundation's own fallback) so the spoken prompt is on-target.
+ *  - Distractors: bias toward believable foils (words the learner half-knows)
+ *    so discrimination is trained — but never at the cost of the dedup contract.
+ */
+
+import type { EntryOut } from "../sdk/types";
+import type { WordSelector } from "../ContentManager";
+import type { WordStatsStore } from "./wordStats";
+import type { AdaptiveDifficulty } from "./difficulty";
+
+/** Resolve the foreign/english for context stamping (cheap, best-effort). */
+function readContext(
+  e: EntryOut,
+  activeLang: string
+): { foreign?: string; english?: string } {
+  const english = e.translations.find((t) => t.language_code === "en")?.text?.trim();
+  const foreign =
+    e.translations.find((t) => t.language_code === activeLang && t.text.trim())?.text?.trim() ||
+    e.translations.find((t) => t.language_code !== "en" && t.text.trim())?.text?.trim();
+  return { foreign, english };
+}
+
+/** A small deterministic-but-jittered tiebreak so picks don't feel robotic. */
+function jitter(): number {
+  return Math.random() * 0.12;
+}
+
+/**
+ * Build the learning WordSelector bound to a memory store + difficulty signal.
+ * The store/difficulty are owned by the learning init and updated from the bus;
+ * the selector only READS them here (selection must be pure-ish + cheap).
+ */
+export function createWordSelector(
+  store: WordStatsStore,
+  difficulty: AdaptiveDifficulty
+): WordSelector {
+  return {
+    observePool(candidates: EntryOut[], activeLang: string): void {
+      // Prime context for any unseen words so the mastery readout + scheduler
+      // have human-readable labels available. Pure bookkeeping; no scheduling
+      // side effects (markShown happens when a target is actually chosen).
+      for (const e of candidates) {
+        if (!store.get(e.entry_id)) {
+          const { foreign, english } = readContext(e, activeLang);
+          // ensure-on-read via a no-op record path: we only stamp context.
+          // (We deliberately do NOT advance the wave clock here.)
+          store.primeContext(e.entry_id, foreign, english);
+        }
+      }
+    },
+
+    chooseTarget(candidates: EntryOut[], activeLang: string): EntryOut | undefined {
+      if (candidates.length === 0) return undefined;
+
+      // Prefer candidates whose prompt is actually in the active language — this
+      // mirrors the foundation's own fallback and keeps the spoken prompt on
+      // target. If none match, fall back to the full valid pool.
+      const inLang = candidates.filter((e) =>
+        e.translations.some((t) => t.language_code === activeLang && t.text.trim())
+      );
+      const pool = inLang.length > 0 ? inLang : candidates;
+
+      // How hard to lean into due/weak resurfacing, from the difficulty signal.
+      // Even at the gentle end we keep SOME spacing pressure (0.35 floor) so the
+      // learning value is always present; hot learners get the full push.
+      const pressure = 0.35 + 0.65 * difficulty.value;
+
+      // Score every candidate: urgency (spacing/weakness) blended with a small
+      // exploration term so fresh content still flows and it never feels rote.
+      let best: EntryOut | undefined;
+      let bestScore = -Infinity;
+      for (const e of pool) {
+        const urgency = store.targetUrgency(e.entry_id); // 0..1
+        const explore = jitter(); // 0..~0.12 stochastic freshness
+        const score = pressure * urgency + (1 - pressure) * 0.5 + explore;
+        if (score > bestScore) {
+          bestScore = score;
+          best = e;
+        }
+      }
+      // Returning a member of `candidates` (pool ⊆ candidates) — contract-safe.
+      // If for any reason nothing scored, return undefined to let CM fall back.
+      return best;
+    },
+
+    weight(entry: EntryOut, _activeLang: string): number {
+      // Higher = surface sooner as a distractor. Believable foils first. This
+      // ONLY reorders the distractor scan; dedup still guarantees the correct
+      // English appears on exactly one note.
+      return store.distractorAffinity(entry.entry_id);
+    },
+  };
+}

--- a/corpan/packs/lingo-hero/src/learning/wordStats.ts
+++ b/corpan/packs/lingo-hero/src/learning/wordStats.ts
@@ -1,0 +1,330 @@
+/**
+ * learning/wordStats.ts — Per-word spaced-repetition memory for Lingo Hero.
+ *
+ * STREAM: learning. This is the durable "what do you actually know" model that
+ * drives spaced difficulty, weak-word resurfacing, and the mastery readout. It
+ * is intentionally a small, well-understood Leitner/SM-2-lite scheduler rather
+ * than a heavyweight SRS — the game loop is fast and forgiving, so we optimise
+ * for "resurface what you fumbled, retire what you nail, keep it gentle".
+ *
+ * KEYING: a word is identified by its host `entryId` (stable across sessions),
+ * scoped by (stackId, lang) so a Spanish learner's memory never bleeds into a
+ * Korean stack. We also persist the foreign/english strings purely so the
+ * mastery model can show human-readable context if ever needed — scheduling
+ * keys on entryId only.
+ *
+ * PERSISTENCE: offline-first localStorage, fully guarded (private-mode / no-DOM
+ * hosts degrade to in-memory). Mirrors the progression/storage.ts pattern and
+ * shares the same host-storage migration TODO: when HostApi grows a durable
+ * key/value surface, route through it here and keep localStorage as fallback.
+ *
+ * NO NETWORK. NO REMOTE ASSETS. Pure local memory of the learner's progress.
+ */
+
+const SCHEMA_VERSION = 2;
+const KEY_PREFIX = "lingo-hero:wordstats";
+
+/**
+ * Leitner-style boxes. A word climbs a box on a correct answer and drops on a
+ * miss. Higher box ⇒ longer interval before it's "due" again ⇒ surfaced less.
+ * Box 0 = brand new / just fumbled (due immediately). Box 5 = mastered.
+ *
+ * Intervals are measured in WAVES (the game's natural tick), not wall-clock —
+ * the loop is the clock. Tuned so a fumbled word comes back within a few waves
+ * (re-exposure while it still stings) and a mastered word fades to the deep
+ * background but never fully disappears (occasional retention checks).
+ */
+export const BOX_INTERVALS_WAVES: readonly number[] = [0, 2, 5, 10, 20, 40] as const;
+export const MAX_BOX = BOX_INTERVALS_WAVES.length - 1; // 5
+/** A word at or above this box counts as "mastered" for the readout. */
+export const MASTERED_BOX = 4;
+
+/** The persisted record for a single word. */
+export interface WordStat {
+  /** Host entry id — the stable scheduling key. */
+  entryId: number;
+  /** Leitner box 0..MAX_BOX (higher = better known). */
+  box: number;
+  /** Lifetime correct answers for this word. */
+  correct: number;
+  /** Lifetime misses (wrong tap on its wave, or let it pass). */
+  wrong: number;
+  /** Wave index (global counter) when this word was last shown. */
+  lastSeenWave: number;
+  /** Wave index at/after which this word is "due" to resurface. */
+  dueWave: number;
+  /**
+   * Smoothed strength 0..1 (EWMA of correctness). Distinct from `box`: box is
+   * the discrete scheduler, strength is the continuous signal the mastery bar
+   * and the adaptive-difficulty model read. Starts at 0.5 (unknown).
+   */
+  strength: number;
+  /** Human context (not used for scheduling; handy for debugging/readouts). */
+  foreign?: string;
+  english?: string;
+}
+
+interface PersistedWordStats {
+  version: number;
+  /** Monotonic wave counter for this scope (the SRS "clock"). */
+  wave: number;
+  /** entryId → record. Stored as an object map for compact JSON. */
+  words: Record<string, WordStat>;
+}
+
+function emptyPersisted(): PersistedWordStats {
+  return { version: SCHEMA_VERSION, wave: 0, words: {} };
+}
+
+function storageKey(scope: string): string {
+  return `${KEY_PREFIX}:${scope || "default"}`;
+}
+
+/** Best-effort Storage access; null when blocked/unavailable (mirrors progression). */
+function safeLocalStorage(): Storage | null {
+  try {
+    const ls = globalThis.localStorage;
+    if (!ls) return null;
+    const probe = `${KEY_PREFIX}:__probe__`;
+    ls.setItem(probe, "1");
+    ls.removeItem(probe);
+    return ls;
+  } catch {
+    return null;
+  }
+}
+
+function clamp01(v: number): number {
+  return v < 0 ? 0 : v > 1 ? 1 : v;
+}
+
+function sanitizeStat(raw: Partial<WordStat>, entryId: number): WordStat {
+  const box = clampInt(raw.box, 0, MAX_BOX, 0);
+  return {
+    entryId,
+    box,
+    correct: clampInt(raw.correct, 0, Number.MAX_SAFE_INTEGER, 0),
+    wrong: clampInt(raw.wrong, 0, Number.MAX_SAFE_INTEGER, 0),
+    lastSeenWave: clampInt(raw.lastSeenWave, 0, Number.MAX_SAFE_INTEGER, 0),
+    dueWave: clampInt(raw.dueWave, 0, Number.MAX_SAFE_INTEGER, 0),
+    strength:
+      typeof raw.strength === "number" && Number.isFinite(raw.strength)
+        ? clamp01(raw.strength)
+        : 0.5,
+    foreign: typeof raw.foreign === "string" ? raw.foreign : undefined,
+    english: typeof raw.english === "string" ? raw.english : undefined,
+  };
+}
+
+function clampInt(v: unknown, lo: number, hi: number, dflt: number): number {
+  if (typeof v !== "number" || !Number.isFinite(v)) return dflt;
+  const i = Math.round(v);
+  return i < lo ? lo : i > hi ? hi : i;
+}
+
+/**
+ * The in-memory, persisted word-memory store. One instance per (stack, lang)
+ * scope; the learning init creates/swaps these as the active language changes.
+ */
+export class WordStatsStore {
+  private state: PersistedWordStats;
+  private dirty = false;
+  private flushHandle: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private readonly scope: string) {
+    this.state = this.load();
+  }
+
+  private load(): PersistedWordStats {
+    const ls = safeLocalStorage();
+    if (!ls) return emptyPersisted();
+    try {
+      const raw = ls.getItem(storageKey(this.scope));
+      if (!raw) return emptyPersisted();
+      const parsed = JSON.parse(raw) as Partial<PersistedWordStats>;
+      const words: Record<string, WordStat> = {};
+      const src = parsed.words && typeof parsed.words === "object" ? parsed.words : {};
+      for (const [k, v] of Object.entries(src)) {
+        const id = Number(k);
+        if (!Number.isFinite(id)) continue;
+        words[k] = sanitizeStat((v ?? {}) as Partial<WordStat>, id);
+      }
+      return {
+        version: SCHEMA_VERSION,
+        wave: clampInt(parsed.wave, 0, Number.MAX_SAFE_INTEGER, 0),
+        words,
+      };
+    } catch {
+      return emptyPersisted();
+    }
+  }
+
+  /** Debounced persist so a fast Blitz run doesn't thrash localStorage. */
+  private scheduleFlush(): void {
+    this.dirty = true;
+    if (this.flushHandle != null) return;
+    this.flushHandle = setTimeout(() => {
+      this.flushHandle = null;
+      this.flush();
+    }, 400);
+  }
+
+  /** Force-write now (call on run end / dispose). */
+  flush(): void {
+    if (!this.dirty) return;
+    const ls = safeLocalStorage();
+    if (!ls) {
+      this.dirty = false;
+      return;
+    }
+    try {
+      ls.setItem(storageKey(this.scope), JSON.stringify(this.state));
+      this.dirty = false;
+    } catch {
+      /* quota / blocked — in-memory remains source of truth */
+    }
+  }
+
+  /** Current global wave clock for this scope. */
+  get wave(): number {
+    return this.state.wave;
+  }
+
+  /** Read (never mutates) a word's record, or undefined if unseen. */
+  get(entryId: number): WordStat | undefined {
+    return this.state.words[String(entryId)];
+  }
+
+  /** Ensure a record exists (new words start in box 0, due now, strength 0.5). */
+  private ensure(entryId: number, foreign?: string, english?: string): WordStat {
+    const key = String(entryId);
+    let s = this.state.words[key];
+    if (!s) {
+      s = {
+        entryId,
+        box: 0,
+        correct: 0,
+        wrong: 0,
+        lastSeenWave: this.state.wave,
+        dueWave: this.state.wave,
+        strength: 0.5,
+        foreign,
+        english,
+      };
+      this.state.words[key] = s;
+    } else {
+      if (foreign && !s.foreign) s.foreign = foreign;
+      if (english && !s.english) s.english = english;
+    }
+    return s;
+  }
+
+  /**
+   * Note that a word was just SHOWN as the target of a wave. Advances the wave
+   * clock and stamps lastSeen, so "due-ness" is measured from exposures.
+   */
+  markShown(entryId: number, foreign?: string, english?: string): void {
+    this.state.wave += 1;
+    const s = this.ensure(entryId, foreign, english);
+    s.lastSeenWave = this.state.wave;
+    this.scheduleFlush();
+  }
+
+  /**
+   * Record the OUTCOME of a resolved wave for `entryId`. Climbs/drops the
+   * Leitner box, updates the EWMA strength, and reschedules the due wave.
+   *
+   * @param correct true iff the learner answered correctly.
+   */
+  recordOutcome(entryId: number, correct: boolean, foreign?: string, english?: string): WordStat {
+    const s = this.ensure(entryId, foreign, english);
+    // EWMA strength: weight recent performance, but don't whiplash on one tap.
+    const alpha = 0.4;
+    s.strength = clamp01(s.strength * (1 - alpha) + (correct ? 1 : 0) * alpha);
+    if (correct) {
+      s.correct += 1;
+      s.box = Math.min(MAX_BOX, s.box + 1);
+    } else {
+      s.wrong += 1;
+      // A miss drops two boxes (but not below 0) — fumbles should sting and
+      // resurface fast, which is the whole point of spaced difficulty.
+      s.box = Math.max(0, s.box - 2);
+    }
+    const interval = BOX_INTERVALS_WAVES[s.box] ?? 0;
+    s.dueWave = this.state.wave + interval;
+    this.scheduleFlush();
+    return s;
+  }
+
+  /**
+   * Stamp human-readable context (foreign/english) for a word WITHOUT advancing
+   * the scheduler — used by the selector's observePool priming pass so the
+   * mastery readout has labels even before a word is first quizzed. Creates the
+   * record in box 0 / due-now if unseen, but does NOT touch the wave clock.
+   */
+  primeContext(entryId: number, foreign?: string, english?: string): void {
+    const before = this.get(entryId);
+    const beforeForeign = before?.foreign;
+    const beforeEnglish = before?.english;
+    const s = this.ensure(entryId, foreign, english);
+    // Only mark dirty if something actually changed: a brand-new record, or
+    // context that was previously empty and is now filled.
+    if (!before || s.foreign !== beforeForeign || s.english !== beforeEnglish) {
+      this.scheduleFlush();
+    }
+  }
+
+  /** All records as an array (snapshot copy; cheap for our pool sizes). */
+  all(): WordStat[] {
+    return Object.values(this.state.words);
+  }
+
+  /**
+   * Urgency score for surfacing a word as the TARGET (higher = sooner). Combines:
+   *  - overdue-ness (how many waves past due), so the scheduler is respected;
+   *  - weakness (1 - strength), so fumbled words get priority;
+   *  - novelty (unseen words get a healthy baseline so new content still flows,
+   *    but below the ceiling a weak+overdue word can reach, so spaced
+   *    repetition can out-prioritise novelty for actively-fumbled words).
+   * Pure read; safe to call in tight loops.
+   */
+  targetUrgency(entryId: number): number {
+    const s = this.get(entryId);
+    const wave = this.state.wave;
+    // Unseen: a HEALTHY baseline so fresh content always flows, but below the
+    // ceiling a genuinely weak+overdue word can reach — spaced repetition must
+    // be able to out-prioritise novelty when something is actively fumbled.
+    if (!s) return 0.6;
+    const overdue = Math.max(0, wave - s.dueWave);
+    const overdueScore = 1 - 1 / (1 + overdue); // 0..1, saturating
+    const weakness = 1 - s.strength; // 0..1
+    const dueBonus = wave >= s.dueWave ? 0.2 : 0;
+    // Weak + overdue can reach ~1.0 (above the 0.6 unseen baseline); a strong,
+    // not-yet-due word sinks toward ~0, fading into the background.
+    return Math.min(1, 0.5 * weakness + 0.45 * overdueScore + dueBonus);
+  }
+
+  /**
+   * Desirability of a word as a DISTRACTOR (higher = surface sooner). We bias
+   * toward words the learner KNOWS reasonably well (so distractors are plausible
+   * but not cruel) and toward recently/often-seen words (familiar foils sharpen
+   * discrimination). Never affects correctness — only ordering before dedup.
+   */
+  distractorAffinity(entryId: number): number {
+    const s = this.get(entryId);
+    if (!s) return 0.3; // unseen distractors are fine but not preferred
+    // Mid-to-high strength makes a believable foil; very weak words as foils
+    // just add noise. Familiarity (exposure) adds a little.
+    const believability = s.strength; // 0..1
+    const familiarity = Math.min(1, (s.correct + s.wrong) / 6); // 0..1
+    return 0.7 * believability + 0.3 * familiarity;
+  }
+
+  dispose(): void {
+    if (this.flushHandle != null) {
+      clearTimeout(this.flushHandle);
+      this.flushHandle = null;
+    }
+    this.flush();
+  }
+}

--- a/corpan/packs/lingo-hero/src/progression/index.ts
+++ b/corpan/packs/lingo-hero/src/progression/index.ts
@@ -16,6 +16,8 @@ import {
   saveState,
   type PersistedProgression,
 } from "./storage";
+import { initLearning, type LearningApi } from "../learning";
+import type { MasterySummary } from "../learning/mastery";
 
 /**
  * Progression layer — XP, levels, combo multipliers, streaks, high scores,
@@ -116,6 +118,19 @@ export interface ProgressionSnapshot {
   runs: number;
   /** End-of-run summary (null until a run ends; reset on next start). */
   lastRun: RunStats | null;
+
+  // --- learning extensions (spaced difficulty + mastery) ---
+  /**
+   * Spaced-repetition mastery for the active (stack, lang) scope: seen /
+   * mastered / learning / due counts, mean strength, coarse mastery level.
+   * Null before any word has been encountered. Surfaced here so any consumer
+   * holding the ProgressionApi (e.g. the HUD/game-over panel) can read mastery
+   * without importing the learning module. The HUD's live mastery readout slot
+   * is driven directly by the learning layer.
+   */
+  mastery: MasterySummary | null;
+  /** Gentle content-difficulty signal (0..1) for the active scope. */
+  difficulty: number;
 }
 
 export interface ProgressionApi {
@@ -146,6 +161,22 @@ export function initProgression(
 
   // Durable lifetime state.
   const persisted: PersistedProgression = loadState(stackId);
+
+  // --- learning layer (spaced difficulty + mastery) ----------------------
+  // Initialised here because Game.ts already hands progression the bus +
+  // hostApi, so this is the no-Game.ts-edit hook. Importing the learning module
+  // also registers the spaced-difficulty WordSelector as ContentManager's
+  // process-wide default (see learning/index.ts import-time side effect), so
+  // Game.ts's existing `new ContentManager(hostApi)` transparently picks it up.
+  // Fully guarded: if anything in the learning layer throws, the core game and
+  // progression keep working.
+  let learning: LearningApi | null = null;
+  try {
+    learning = initLearning(bus, hostApi);
+  } catch (err) {
+    console.error("[progression] learning init failed; continuing without:", err);
+    learning = null;
+  }
 
   // Live per-run session state (reset on gameStart).
   let mode: GameMode = GameMode.PRACTICE;
@@ -309,6 +340,8 @@ export function initProgression(
       lifetimeHits: persisted.lifetimeHits,
       runs: persisted.runs,
       lastRun,
+      mastery: learning?.getMastery() ?? null,
+      difficulty: learning?.getDifficulty() ?? 0,
     };
   };
 
@@ -323,6 +356,13 @@ export function initProgression(
     for (const off of offFns) off();
     offFns.length = 0;
     milestoneHandlers.clear();
+    // Tear down the learning layer (flushes per-scope word memory).
+    try {
+      learning?.dispose();
+    } catch (err) {
+      console.error("[progression] learning dispose threw:", err);
+    }
+    learning = null;
     // Final flush in case a run was abandoned mid-flight.
     if (runActive) persist();
   };

--- a/corpan/packs/lingo-hero/src/styles.css
+++ b/corpan/packs/lingo-hero/src/styles.css
@@ -228,6 +228,29 @@ html {
     linear-gradient(180deg, var(--bg-1), var(--bg-0));
 }
 
+/* Synthwave perspective grid backdrop — a subtle, static horizon glow + grid
+   that lives BEHIND the canvas (z 0) so it never competes with gameplay. Pure
+   CSS, no assets. Honors reduced-motion (no animation here, it's static). */
+#lingo-hero-root::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(60% 40% at 50% 64%, color-mix(in srgb, var(--na-accent) 16%, transparent), transparent 70%),
+    repeating-linear-gradient(
+      90deg,
+      transparent 0,
+      transparent calc(11.11% - 1px),
+      color-mix(in srgb, var(--na-accent) 8%, transparent) calc(11.11% - 1px),
+      color-mix(in srgb, var(--na-accent) 8%, transparent) 11.11%
+    );
+  -webkit-mask-image: linear-gradient(180deg, transparent 52%, #000 100%);
+  mask-image: linear-gradient(180deg, transparent 52%, #000 100%);
+  opacity: 0.5;
+}
+
 canvas {
   position: absolute;
   top: 0;
@@ -522,8 +545,20 @@ canvas {
 
 .top-bar {
   display: flex;
+  align-items: center;
   justify-content: center;
+  gap: var(--na-space-3);
   width: 100%;
+}
+
+/* Prompt stack: foreign prompt + romanization line, vertically grouped so the
+   romanization tucks neatly under the question box. */
+.prompt-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--na-space-1);
+  min-width: 0;
 }
 
 .question-box {
@@ -813,6 +848,308 @@ canvas {
   100% {
     opacity: 1;
     transform: scale(1) rotate(0);
+  }
+}
+
+/* =========================================================================
+   LEARNING SURFACES (SHELL stream) — romanization · replay · feedback · mastery
+   All styled from the --na-* Neon Arcade tokens. RTL-aware, contrast-checked,
+   reduced-motion safe. These fill the foundation Hud slots.
+   ========================================================================= */
+
+/* ----- (a) Romanization line — sits under the foreign prompt ----- */
+.romanization-line {
+  max-width: min(92%, 640px);
+  font-family: var(--na-font-body);
+  font-weight: 700;
+  font-size: clamp(var(--na-fs-xs), 3.4vmin, var(--na-fs-md));
+  line-height: var(--na-lh-snug);
+  letter-spacing: var(--na-tracking-wide);
+  text-align: center;
+  color: var(--na-text-dim);
+  text-shadow: 0 1px 10px rgba(0, 0, 0, 0.6);
+  opacity: 0.92;
+  /* gentle entrance, re-keyed each wave by the hidden→shown toggle */
+  animation: roman-in var(--na-dur-base) var(--na-ease-out) both;
+}
+.romanization-line[hidden] {
+  display: none;
+}
+@keyframes roman-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 0.92;
+    transform: none;
+  }
+}
+
+/* ----- (b) Audio-replay button — re-speaks the current prompt ----- */
+.replay-btn {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: clamp(2.6rem, 11vmin, 3.2rem);
+  height: clamp(2.6rem, 11vmin, 3.2rem);
+  padding: 0;
+  border-radius: var(--na-radius-pill);
+  cursor: pointer;
+  pointer-events: auto;
+  color: var(--na-accent);
+  background:
+    radial-gradient(120% 120% at 50% 20%, color-mix(in srgb, var(--na-accent) 24%, transparent), transparent 65%),
+    var(--na-glass-bg);
+  border: 1px solid color-mix(in srgb, var(--na-accent) 45%, transparent);
+  box-shadow:
+    var(--na-glow-cyan),
+    0 8px 22px -12px rgba(0, 0, 0, 0.8),
+    0 1px 0 var(--na-glass-hi) inset;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  transition:
+    transform var(--na-dur-fast) var(--na-ease-snap),
+    box-shadow var(--na-dur-base) var(--na-ease-out),
+    border-color var(--na-dur-base) var(--na-ease-out),
+    background var(--na-dur-base) var(--na-ease-out);
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+.replay-btn[hidden] {
+  display: none;
+}
+.replay-icon {
+  font-size: clamp(1.05rem, 4.6vmin, 1.4rem);
+  line-height: 1;
+  filter: drop-shadow(0 0 6px color-mix(in srgb, var(--na-accent) 70%, transparent));
+}
+.replay-btn:hover,
+.replay-btn:focus-visible {
+  transform: translateY(-2px) scale(1.04);
+  border-color: var(--na-accent);
+  box-shadow:
+    var(--na-bloom-md),
+    0 12px 26px -12px rgba(0, 0, 0, 0.85),
+    0 1px 0 var(--na-glass-hi) inset;
+}
+.replay-btn:active {
+  transform: translateY(0) scale(0.94);
+}
+.replay-btn:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--na-accent) 80%, white);
+  outline-offset: 3px;
+}
+/* tiny ping ring on tap to confirm the re-speak fired */
+.replay-btn:active .replay-icon {
+  animation: replay-ping var(--na-dur-slow) var(--na-ease-out);
+}
+@keyframes replay-ping {
+  0% {
+    transform: scale(1);
+  }
+  45% {
+    transform: scale(0.82);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+/* ----- (d) Mastery readout — a real sense of progress, in-run ----- */
+.mastery-readout {
+  display: flex;
+  align-items: center;
+  gap: var(--na-space-3);
+  align-self: center;
+  width: min(86%, 420px);
+  padding: var(--na-space-2) var(--na-space-4);
+  border-radius: var(--na-radius-pill);
+  background: var(--na-glass-bg);
+  border: 1px solid var(--na-glass-stroke);
+  box-shadow: 0 1px 0 var(--na-glass-hi) inset, var(--na-glow-soft);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  animation: mastery-in var(--na-dur-base) var(--na-ease-out) both;
+}
+.mastery-readout[hidden] {
+  display: none;
+}
+@keyframes mastery-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+.mastery-label {
+  flex: 0 0 auto;
+  font-family: var(--na-font-body);
+  font-weight: 900;
+  font-size: var(--na-fs-2xs);
+  letter-spacing: var(--na-tracking-wide);
+  text-transform: uppercase;
+  color: var(--na-text-dim);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+.mastery-bar {
+  position: relative;
+  flex: 1 1 auto;
+  height: 6px;
+  min-width: 48px;
+  border-radius: var(--na-radius-pill);
+  background: color-mix(in srgb, var(--na-text-faint) 28%, transparent);
+  overflow: hidden;
+}
+.mastery-fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--na-accent), var(--na-accent-3));
+  box-shadow: var(--na-glow-lime);
+  transition: width var(--na-dur-slow) var(--na-ease-out);
+}
+/* RTL: the fill grows from the right edge to match reading direction. */
+[dir="rtl"] .mastery-fill {
+  margin-inline-start: auto;
+}
+
+/* ----- (c) Post-answer FEEDBACK card — meaning reveal ----- */
+.feedback-card {
+  position: absolute;
+  left: 50%;
+  bottom: clamp(16%, 26vh, 32%);
+  transform: translateX(-50%);
+  z-index: var(--na-z-feedback);
+  width: min(88vw, 440px);
+  padding: var(--na-space-5) var(--na-space-5) var(--na-space-4);
+  text-align: center;
+  pointer-events: none;
+  border-radius: var(--na-radius-lg);
+  background:
+    radial-gradient(120% 90% at 50% -10%, color-mix(in srgb, var(--na-accent) 14%, transparent), transparent 60%),
+    var(--na-glass-bg);
+  border: 1px solid var(--na-glass-stroke);
+  box-shadow: var(--na-shadow-panel), var(--na-bloom-md);
+  backdrop-filter: blur(16px) saturate(1.15);
+  -webkit-backdrop-filter: blur(16px) saturate(1.15);
+  overflow: hidden;
+}
+.feedback-card[hidden] {
+  display: none;
+}
+.feedback-card.is-in {
+  animation: fb-in var(--na-dur-slow) var(--na-ease-snap) both;
+}
+@keyframes fb-in {
+  0% {
+    opacity: 0;
+    transform: translateX(-50%) translateY(14px) scale(0.94);
+  }
+  100% {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+}
+/* Outcome-tinted top edge + accent. */
+.feedback-card::before {
+  content: "";
+  position: absolute;
+  inset-inline: 0;
+  top: 0;
+  height: 3px;
+  background: var(--fb-accent, var(--na-accent));
+  box-shadow: 0 0 16px var(--fb-accent, var(--na-accent));
+}
+.feedback-card.is-correct {
+  --fb-accent: var(--na-correct);
+  border-color: color-mix(in srgb, var(--na-correct) 50%, var(--na-glass-stroke));
+  box-shadow: var(--na-shadow-panel), var(--na-glow-lime);
+}
+.feedback-card.is-wrong {
+  --fb-accent: var(--na-wrong);
+  border-color: color-mix(in srgb, var(--na-wrong) 45%, var(--na-glass-stroke));
+  box-shadow: var(--na-shadow-panel), 0 0 22px rgba(255, 62, 165, 0.34);
+}
+
+.fb-verdict {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45em;
+  margin-bottom: var(--na-space-3);
+  padding: 0.28em 0.85em;
+  border-radius: var(--na-radius-pill);
+  font-family: var(--na-font-body);
+  font-weight: 900;
+  font-size: var(--na-fs-2xs);
+  letter-spacing: var(--na-tracking-wider);
+  text-transform: uppercase;
+  color: var(--fb-accent, var(--na-accent));
+  background: color-mix(in srgb, var(--fb-accent, var(--na-accent)) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--fb-accent, var(--na-accent)) 40%, transparent);
+}
+.fb-verdict-icon {
+  font-size: 1.1em;
+  line-height: 1;
+}
+.fb-pair {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--na-space-1);
+}
+.fb-foreign {
+  font-family: var(--na-font-display);
+  font-weight: 800;
+  font-size: clamp(var(--na-fs-lg), 6vmin, var(--na-fs-xl));
+  line-height: var(--na-lh-tight);
+  color: var(--na-text);
+  text-shadow: 0 2px 14px rgba(0, 0, 0, 0.5);
+  word-break: break-word;
+}
+.fb-roman {
+  font-family: var(--na-font-body);
+  font-weight: 700;
+  font-size: var(--na-fs-sm);
+  letter-spacing: var(--na-tracking-wide);
+  color: var(--na-text-dim);
+  opacity: 0.9;
+}
+.fb-arrow {
+  font-size: var(--na-fs-md);
+  line-height: 1;
+  color: var(--fb-accent, var(--na-accent));
+  opacity: 0.85;
+  margin: var(--na-space-1) 0;
+  filter: drop-shadow(0 0 8px var(--fb-accent, var(--na-accent)));
+}
+.fb-english {
+  font-family: var(--na-font-body);
+  font-weight: 900;
+  font-size: clamp(var(--na-fs-md), 4.6vmin, var(--na-fs-lg));
+  line-height: var(--na-lh-snug);
+  color: var(--na-text);
+  word-break: break-word;
+}
+
+/* RTL: mirror the feedback transform origin so the centered card stays put. */
+[dir="rtl"] .feedback-card {
+  /* translateX(-50%) is direction-agnostic; nothing to flip, but foreign
+     scripts get their own dir="auto" on the line for correct bidi shaping. */
+}
+
+/* Short / landscape phones: lift the card so it clears the strum line. */
+@media (max-height: 560px) {
+  .feedback-card {
+    bottom: 14%;
+    padding: var(--na-space-3) var(--na-space-4);
+  }
+  .fb-verdict {
+    margin-bottom: var(--na-space-2);
   }
 }
 

--- a/corpan/packs/lingo-hero/src/styles.css
+++ b/corpan/packs/lingo-hero/src/styles.css
@@ -85,6 +85,112 @@
   --radius-sm: 10px;
   --safe-top: env(safe-area-inset-top, 0px);
   --safe-bottom: env(safe-area-inset-bottom, 0px);
+
+  /* =====================================================================
+     NEON ARCADE — cohesive token layer (FOUNDATION).
+     Everything downstream (Hud slots, feedback card, replay button,
+     romanization, mastery readout) styles from THESE, never from raw
+     hex. Semantic aliases sit on top of the brand spectrum above so the
+     palette stays single-sourced.
+     ===================================================================== */
+
+  /* -- Semantic surface + glass aliases (single-sourced from above) -- */
+  --na-bg: var(--bg-0);
+  --na-bg-elev: var(--bg-1);
+  --na-surface: var(--bg-2);
+  --na-glass-bg: var(--glass-bg);
+  --na-glass-stroke: var(--glass-stroke);
+  --na-glass-hi: var(--glass-hi);
+
+  /* -- The three canonical LANE neons (cyan / magenta / lime) -- */
+  --na-lane-1: var(--neon-cyan);     /* left  lane  */
+  --na-lane-2: var(--neon-magenta);  /* center lane */
+  --na-lane-3: var(--neon-lime);     /* right lane  */
+
+  /* -- Semantic accents -- */
+  --na-accent: var(--neon-cyan);
+  --na-accent-2: var(--neon-magenta);
+  --na-accent-3: var(--neon-lime);
+  --na-correct: var(--neon-lime);    /* right-answer feedback */
+  --na-wrong: var(--neon-pink);      /* wrong-answer feedback */
+  --na-warn: var(--neon-amber);
+
+  /* -- Text -- */
+  --na-text: var(--ink);
+  --na-text-dim: var(--ink-dim);
+  --na-text-faint: var(--ink-faint);
+
+  /* -- Glow / bloom shadow ramp (drop-in box/text-shadow values) -- */
+  --na-glow-cyan: 0 0 12px rgba(47, 243, 255, 0.55), 0 0 28px rgba(47, 243, 255, 0.32);
+  --na-glow-magenta: 0 0 12px rgba(255, 0, 212, 0.55), 0 0 28px rgba(255, 0, 212, 0.30);
+  --na-glow-lime: 0 0 12px rgba(123, 255, 123, 0.50), 0 0 28px rgba(123, 255, 123, 0.28);
+  --na-glow-soft: 0 0 10px rgba(154, 130, 255, 0.30);
+  --na-bloom-sm: 0 0 8px rgba(47, 243, 255, 0.35);
+  --na-bloom-md: 0 0 18px rgba(47, 243, 255, 0.40), 0 0 44px rgba(154, 130, 255, 0.22);
+  --na-bloom-lg: 0 0 28px rgba(47, 243, 255, 0.45), 0 0 72px rgba(255, 0, 212, 0.22);
+  --na-shadow-panel: 0 24px 64px rgba(0, 0, 0, 0.55), inset 0 1px 0 var(--glass-hi);
+
+  /* -- Type scale (modular, ~1.25). Pair with --na-font-* families. -- */
+  --na-font-display: var(--font-display);
+  --na-font-body: var(--font-body);
+  --na-fs-2xs: 0.6875rem; /* 11px micro labels  */
+  --na-fs-xs: 0.8125rem;  /* 13px captions      */
+  --na-fs-sm: 0.9375rem;  /* 15px body          */
+  --na-fs-md: 1.125rem;   /* 18px               */
+  --na-fs-lg: 1.5rem;     /* 24px               */
+  --na-fs-xl: 2rem;       /* 32px               */
+  --na-fs-2xl: 2.75rem;   /* 44px prompt        */
+  --na-fs-3xl: 3.75rem;   /* 60px hero          */
+  --na-lh-tight: 1.08;
+  --na-lh-snug: 1.25;
+  --na-lh-body: 1.5;
+  --na-tracking-wide: 0.08em;
+  --na-tracking-wider: 0.16em;
+
+  /* -- Spacing scale (8pt-ish) -- */
+  --na-space-0: 0;
+  --na-space-1: 4px;
+  --na-space-2: 8px;
+  --na-space-3: 12px;
+  --na-space-4: 16px;
+  --na-space-5: 24px;
+  --na-space-6: 32px;
+  --na-space-7: 48px;
+  --na-space-8: 64px;
+
+  /* -- Radii (semantic aliases over the layout radii) -- */
+  --na-radius-xs: 8px;
+  --na-radius-sm: var(--radius-sm);
+  --na-radius-md: var(--radius-md);
+  --na-radius-lg: var(--radius-lg);
+  --na-radius-pill: 999px;
+
+  /* -- Motion durations + easings -- */
+  --na-dur-instant: 80ms;
+  --na-dur-fast: 140ms;
+  --na-dur-base: 240ms;
+  --na-dur-slow: 420ms;
+  --na-dur-slower: 680ms;
+  --na-ease-snap: var(--ease-snap);
+  --na-ease-out: var(--ease-out);
+  --na-ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+  --na-ease-linear: linear;
+
+  /* -- Z-index ladder for HUD slots -- */
+  --na-z-grid: 1;
+  --na-z-hud: 10;
+  --na-z-feedback: 30;
+  --na-z-overlay: 40;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --na-dur-instant: 0ms;
+    --na-dur-fast: 0ms;
+    --na-dur-base: 0ms;
+    --na-dur-slow: 0ms;
+    --na-dur-slower: 0ms;
+  }
 }
 
 * {

--- a/corpan/packs/lingo-hero/src/types.ts
+++ b/corpan/packs/lingo-hero/src/types.ts
@@ -72,6 +72,29 @@ export interface ActiveLanguage {
 // Game.ts emits; effects/audio/progression/ui subscribe. Do NOT widen these
 // without coordinating — they are the cross-stream ABI.
 
+/**
+ * The identity of the TARGET word a wave is quizzing. Carried on noteHit /
+ * noteMiss / wave-resolved so the learning stream can do spaced-difficulty
+ * bookkeeping and the UI can do meaning-reveal / feedback cards WITHOUT
+ * reaching into Game.ts or ContentManager. This is the learning ABI.
+ *
+ * `foreign` is the RAW (un-cleaned) foreign prompt text — the same string that
+ * is spoken — so the learning stream keys on stable identity, not the
+ * display-cleaned label. `english` is the display-cleaned correct answer.
+ */
+export interface WordIdentity {
+  /** Stable host entry id for the target word (dedup/spacing key). */
+  entryId: number;
+  /** RAW foreign prompt text (what TTS speaks), not the display-cleaned form. */
+  foreign: string;
+  /** The correct English answer (display-cleaned). */
+  english: string;
+  /** Optional romanization of the foreign prompt, if the host provided one. */
+  romanization?: string;
+  /** Language code of the foreign prompt (e.g. "es", "ar"). */
+  lang: string;
+}
+
 /** Emitted once per game start (Practice or Blitz). */
 export interface GameStartEvent {
   mode: GameMode;
@@ -97,6 +120,12 @@ export interface NoteHitEvent {
   /** Base points awarded for this hit (pre-progression-multiplier). */
   points: number;
   mode: GameMode;
+  /**
+   * Identity of the target word the player just answered correctly. Drives
+   * spaced-difficulty (mark word easier) and meaning-reveal. Always present
+   * on a correct hit.
+   */
+  word: WordIdentity;
 }
 
 /** Emitted when the player hits a WRONG note OR lets the target pass. */
@@ -107,6 +136,31 @@ export interface NoteMissEvent {
   y: number;
   /** "wrong" = tapped a distractor; "passed" = target fell past the line. */
   reason: "wrong" | "passed";
+  mode: GameMode;
+  /**
+   * Identity of the target word the player missed. Drives spaced-difficulty
+   * (mark word due-sooner / weaker) and the meaning-reveal feedback card.
+   * Always present.
+   */
+  word: WordIdentity;
+}
+
+/**
+ * Emitted exactly once when a wave concludes — whether the player got it right,
+ * tapped a distractor, or let the target pass. This is the single, reliable
+ * hook for the learning stream to record an outcome and for the UI to raise the
+ * post-answer feedback card. (noteHit/noteMiss can fire on distractor taps mid-
+ * wave; wave-resolved fires once with the FINAL verdict.)
+ */
+export interface WaveResolvedEvent {
+  /** Identity of the target word this wave quizzed. */
+  word: WordIdentity;
+  /** Final outcome of the wave. */
+  outcome: "correct" | "wrong" | "passed";
+  /** True iff outcome === "correct". Convenience for subscribers. */
+  correct: boolean;
+  /** Combo value at the moment the wave resolved. */
+  combo: number;
   mode: GameMode;
 }
 
@@ -139,6 +193,7 @@ export interface GameEventMap {
   menuShown: MenuShownEvent;
   noteHit: NoteHitEvent;
   noteMiss: NoteMissEvent;
+  "wave-resolved": WaveResolvedEvent;
   comboChange: ComboChangeEvent;
   scoreChange: ScoreChangeEvent;
   gameOver: GameOverEvent;

--- a/corpan/packs/lingo-hero/src/ui/Hud.ts
+++ b/corpan/packs/lingo-hero/src/ui/Hud.ts
@@ -76,6 +76,9 @@ export class Hud {
   private comboPulseTimer = 0;
   private flyoutTimer = 0;
   private feedbackTimer = 0;
+  /** Words seen this run + correct count (drive the in-run mastery readout). */
+  private runSeen = 0;
+  private runCorrect = 0;
 
   constructor(
     container: HTMLElement,
@@ -213,6 +216,9 @@ export class Hud {
   /** The prompt text shown in the in-game question box (foreign word). */
   setQuestion(text: string): void {
     this.questionBox.textContent = text;
+    // A new wave begins: clear any lingering meaning-reveal card so it never
+    // overlaps the fresh prompt (the auto-hide timer may still be pending).
+    this.hideFeedback();
     // re-trigger the pop animation each wave
     this.questionBox.style.animation = "none";
     // force reflow so the animation restarts
@@ -249,19 +255,41 @@ export class Hud {
    * may replace innerHTML entirely if it wants a richer card.
    */
   showFeedback(data: FeedbackCardData, autoHideMs = 0): void {
+    const outcome = data.outcome ?? (data.correct ? "correct" : "wrong");
     const roman = data.romanization?.trim()
       ? `<div class="fb-roman">${this.escape(data.romanization)}</div>`
       : "";
+
+    // RTL-aware, outcome-nuanced verdict copy. "passed" (the prompt fell by)
+    // reads differently from a tapped-wrong distractor — both reveal meaning.
+    const verdict =
+      outcome === "correct"
+        ? { icon: "&#10003;", label: "Nailed it" }
+        : outcome === "passed"
+          ? { icon: "&#8987;", label: "Missed it" }
+          : { icon: "&#10005;", label: "Not quite" };
+
     this.feedbackCard.className =
       "feedback-card " + (data.correct ? "is-correct" : "is-wrong");
-    this.feedbackCard.dataset.outcome = data.outcome ?? (data.correct ? "correct" : "wrong");
+    this.feedbackCard.dataset.outcome = outcome;
     this.feedbackCard.innerHTML = `
-      <div class="fb-foreign">${this.escape(data.foreign)}</div>
-      ${roman}
-      <div class="fb-arrow" aria-hidden="true">&#8595;</div>
-      <div class="fb-english">${this.escape(data.english)}</div>
+      <div class="fb-verdict">
+        <span class="fb-verdict-icon" aria-hidden="true">${verdict.icon}</span>
+        <span class="fb-verdict-label">${verdict.label}</span>
+      </div>
+      <div class="fb-pair">
+        <div class="fb-foreign" dir="auto">${this.escape(data.foreign)}</div>
+        ${roman}
+        <div class="fb-arrow" aria-hidden="true">&#8595;</div>
+        <div class="fb-english" dir="auto">${this.escape(data.english)}</div>
+      </div>
     `;
     this.feedbackCard.hidden = false;
+    // Restart the entrance animation each reveal.
+    this.feedbackCard.classList.remove("is-in");
+    void this.feedbackCard.offsetWidth;
+    this.feedbackCard.classList.add("is-in");
+
     if (this.feedbackTimer) clearTimeout(this.feedbackTimer);
     if (autoHideMs > 0) {
       this.feedbackTimer = window.setTimeout(
@@ -340,15 +368,19 @@ export class Hud {
         this.comboEl.textContent = "0";
         this.comboBox.classList.add("zero");
         this.comboBox.classList.remove("pulse");
-        // Reset transient learning slots for a fresh run.
+        // Reset transient learning slots + run tally for a fresh run.
         this.hideFeedback();
         this.setRomanization("");
+        this.runSeen = 0;
+        this.runCorrect = 0;
+        this.refreshMastery();
       }),
       this.bus.on("menuShown", () => {
         this.menuScreen.classList.remove("hidden");
         this.hudPanel.classList.add("hidden");
         this.gameOverScreen.classList.add("hidden");
         this.hideFeedback();
+        this.setMastery(null);
       }),
       this.bus.on("scoreChange", (e) => {
         this.scoreEl.textContent = e.value.toLocaleString();
@@ -364,8 +396,53 @@ export class Hud {
         this.gameOverScreen.classList.remove("hidden");
         this.finalScoreEl.textContent = e.finalScore.toLocaleString();
         this.populateGameOverStats(e.finalScore);
+      }),
+      // (c) LEARNING SURFACE — the single, reliable per-wave verdict hook.
+      // Raise the meaning-reveal feedback card and advance the run mastery
+      // tally. This is the ui-stream wiring the foundation deliberately left
+      // to us (Game.ts only emits; it never calls showFeedback/setMastery).
+      this.bus.on("wave-resolved", (e) => {
+        this.runSeen += 1;
+        if (e.correct) this.runCorrect += 1;
+        this.showFeedback(
+          {
+            foreign: e.word.foreign,
+            english: e.word.english,
+            romanization: e.word.romanization,
+            correct: e.correct,
+            outcome: e.outcome,
+          },
+          // Correct answers flash by; misses linger so the meaning sinks in.
+          e.correct ? 1400 : 2600
+        );
+        this.refreshMastery();
       })
     );
+  }
+
+  /**
+   * (d) Recompute + push the in-run mastery readout. Blends this run's live
+   * accuracy with the persisted level progress so the player always feels
+   * forward motion. Hidden on the very first wave (nothing to show yet).
+   */
+  private refreshMastery(): void {
+    if (this.runSeen === 0) {
+      this.setMastery(null);
+      return;
+    }
+    const snap = this.progression?.getSnapshot();
+    const acc = Math.round((this.runCorrect / this.runSeen) * 100);
+    // Prefer the persisted level bar for the fill (a true sense of progress);
+    // fall back to this run's accuracy when progression isn't wired.
+    const progress =
+      typeof snap?.levelProgress === "number"
+        ? snap.levelProgress
+        : this.runCorrect / this.runSeen;
+    const lvl = snap?.level ?? 1;
+    this.setMastery({
+      label: `Lv ${lvl} · ${this.runCorrect}/${this.runSeen} · ${acc}%`,
+      progress,
+    });
   }
 
   /** Brief scale-pulse on the combo number when it climbs. */

--- a/corpan/packs/lingo-hero/src/ui/Hud.ts
+++ b/corpan/packs/lingo-hero/src/ui/Hud.ts
@@ -3,6 +3,29 @@ import type { ProgressionApi } from "../progression";
 import { GameMode, type ActiveLanguage } from "../types";
 
 /**
+ * Payload for the post-answer FEEDBACK card (slot c). The shell-ui stream fills
+ * this from `wave-resolved`. Foundation only renders the surface + exposes the
+ * setter; the actual wiring (subscribe to wave-resolved → showFeedback) lives
+ * in the ui stream so Foundation stays minimal.
+ */
+export interface FeedbackCardData {
+  foreign: string;
+  english: string;
+  romanization?: string;
+  correct: boolean;
+  /** "correct" | "wrong" | "passed" — for nuanced copy/styling. */
+  outcome?: "correct" | "wrong" | "passed";
+}
+
+/** Payload for the progress / mastery readout (slot d). */
+export interface MasteryReadout {
+  /** Free-form short label, e.g. "12 mastered · 3 due". */
+  label: string;
+  /** Optional 0..1 progress for a bar fill; omit to hide the bar. */
+  progress?: number;
+}
+
+/**
  * Hud — OWNS the DOM overlay (menu / in-game HUD / game-over) for Lingo Hero.
  *
  * STREAM: ui. Foundation MOVED the original uiRoot.innerHTML + updateHUD +
@@ -20,6 +43,12 @@ export interface HudCallbacks {
   onStartGame: (mode: GameMode) => void;
   /** User asked to return to the main menu. */
   onShowMenu: () => void;
+  /**
+   * User tapped the audio-REPLAY button (slot b): re-speak the current prompt.
+   * Optional so older call sites that don't pass it still compile; the button
+   * is wired only when present.
+   */
+  onReplayPrompt?: () => void;
 }
 
 export class Hud {
@@ -28,6 +57,10 @@ export class Hud {
   private hudPanel: HTMLElement;
   private gameOverScreen: HTMLElement;
   private questionBox: HTMLElement;
+  private romanizationEl: HTMLElement;
+  private replayBtn: HTMLElement;
+  private feedbackCard: HTMLElement;
+  private masteryEl: HTMLElement;
   private scoreEl: HTMLElement;
   private comboEl: HTMLElement;
   private comboBox: HTMLElement;
@@ -42,6 +75,7 @@ export class Hud {
   private lastMode: GameMode = GameMode.PRACTICE;
   private comboPulseTimer = 0;
   private flyoutTimer = 0;
+  private feedbackTimer = 0;
 
   constructor(
     container: HTMLElement,
@@ -80,8 +114,18 @@ export class Hud {
 
       <div class="hud hidden" id="hud">
         <div class="top-bar">
-          <div class="question-box" id="question-box" aria-live="polite"></div>
+          <div class="prompt-stack">
+            <div class="question-box" id="question-box" aria-live="polite"></div>
+            <!-- (a) romanization line under the foreign prompt -->
+            <div class="romanization-line" id="romanization-line" aria-live="polite" hidden></div>
+          </div>
+          <!-- (b) audio-replay button: re-speaks the current prompt -->
+          <button class="replay-btn" id="replay-btn" type="button" aria-label="Replay audio" hidden>
+            <span class="replay-icon" aria-hidden="true">&#128266;</span>
+          </button>
         </div>
+        <!-- (d) progress / mastery readout slot -->
+        <div class="mastery-readout" id="mastery-readout" aria-live="polite" hidden></div>
         <div class="score-container">
           <div class="stat score-box">
             <span class="stat-label">Score</span>
@@ -93,6 +137,8 @@ export class Hud {
             <span class="combo-value"><span class="x">x</span><span id="combo">0</span></span>
           </div>
         </div>
+        <!-- (c) post-answer FEEDBACK card surface (foreign <-> english + state) -->
+        <div class="feedback-card" id="feedback-card" role="status" aria-live="polite" hidden></div>
       </div>
 
       <div class="game-over-screen hidden" id="game-over" role="dialog" aria-label="Game over">
@@ -130,6 +176,10 @@ export class Hud {
     this.hudPanel = this.root.querySelector("#hud")!;
     this.gameOverScreen = this.root.querySelector("#game-over")!;
     this.questionBox = this.root.querySelector("#question-box")!;
+    this.romanizationEl = this.root.querySelector("#romanization-line")!;
+    this.replayBtn = this.root.querySelector("#replay-btn")!;
+    this.feedbackCard = this.root.querySelector("#feedback-card")!;
+    this.masteryEl = this.root.querySelector("#mastery-readout")!;
     this.scoreEl = this.root.querySelector("#score")!;
     this.comboEl = this.root.querySelector("#combo")!;
     this.comboBox = this.root.querySelector("#combo-box")!;
@@ -151,6 +201,12 @@ export class Hud {
     );
     this.bindButton("#btn-menu", () => this.callbacks.onShowMenu());
 
+    // (b) Wire the audio-replay button only if the host provided a callback.
+    if (this.callbacks.onReplayPrompt) {
+      this.replayBtn.hidden = false;
+      this.bindButton("#replay-btn", () => this.callbacks.onReplayPrompt!());
+    }
+
     this.subscribe();
   }
 
@@ -162,6 +218,95 @@ export class Hud {
     // force reflow so the animation restarts
     void this.questionBox.offsetWidth;
     this.questionBox.style.animation = "";
+  }
+
+  /**
+   * (a) ROMANIZATION SLOT — set the line shown under the foreign prompt.
+   * Pass "" to clear/hide. Foundation no-op styling; the ui stream restyles.
+   * Game.ts calls this each wave with the host romanization (may be empty).
+   */
+  setRomanization(text: string): void {
+    const t = (text ?? "").trim();
+    this.romanizationEl.textContent = t;
+    this.romanizationEl.hidden = t.length === 0;
+  }
+
+  /**
+   * (b) Programmatic show/hide of the replay button (e.g. hide between waves).
+   * The button is auto-shown at construction iff an onReplayPrompt callback
+   * was provided; this lets the ui stream toggle it without re-wiring.
+   */
+  setReplayEnabled(enabled: boolean): void {
+    this.replayBtn.hidden = !enabled || !this.callbacks.onReplayPrompt;
+  }
+
+  /**
+   * (c) FEEDBACK CARD SLOT — raise the post-answer card showing the
+   * foreign↔english pairing, romanization, and correct/incorrect state. The
+   * ui stream calls this from a `wave-resolved` subscription. `autoHideMs`
+   * (default 0 = stay until next call / hideFeedback) auto-dismisses.
+   * Foundation default render is a minimal, correct surface; the ui stream
+   * may replace innerHTML entirely if it wants a richer card.
+   */
+  showFeedback(data: FeedbackCardData, autoHideMs = 0): void {
+    const roman = data.romanization?.trim()
+      ? `<div class="fb-roman">${this.escape(data.romanization)}</div>`
+      : "";
+    this.feedbackCard.className =
+      "feedback-card " + (data.correct ? "is-correct" : "is-wrong");
+    this.feedbackCard.dataset.outcome = data.outcome ?? (data.correct ? "correct" : "wrong");
+    this.feedbackCard.innerHTML = `
+      <div class="fb-foreign">${this.escape(data.foreign)}</div>
+      ${roman}
+      <div class="fb-arrow" aria-hidden="true">&#8595;</div>
+      <div class="fb-english">${this.escape(data.english)}</div>
+    `;
+    this.feedbackCard.hidden = false;
+    if (this.feedbackTimer) clearTimeout(this.feedbackTimer);
+    if (autoHideMs > 0) {
+      this.feedbackTimer = window.setTimeout(
+        () => this.hideFeedback(),
+        autoHideMs
+      );
+    }
+  }
+
+  /** (c) Hide/clear the feedback card. */
+  hideFeedback(): void {
+    this.feedbackCard.hidden = true;
+    this.feedbackCard.innerHTML = "";
+    if (this.feedbackTimer) clearTimeout(this.feedbackTimer);
+  }
+
+  /**
+   * (d) MASTERY READOUT SLOT — set the progress/mastery line. Pass null to
+   * hide. The ui/learning stream feeds this from spaced-difficulty state.
+   */
+  setMastery(readout: MasteryReadout | null): void {
+    if (!readout || !readout.label.trim()) {
+      this.masteryEl.hidden = true;
+      this.masteryEl.innerHTML = "";
+      return;
+    }
+    const bar =
+      typeof readout.progress === "number"
+        ? `<span class="mastery-bar"><span class="mastery-fill" style="width:${Math.max(
+            0,
+            Math.min(1, readout.progress)
+          ) * 100}%"></span></span>`
+        : "";
+    this.masteryEl.innerHTML = `<span class="mastery-label">${this.escape(
+      readout.label
+    )}</span>${bar}`;
+    this.masteryEl.hidden = false;
+  }
+
+  /** Minimal HTML-escape for text fed into slot innerHTML. */
+  private escape(s: string): string {
+    return s
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
   }
 
   /**
@@ -179,6 +324,7 @@ export class Hud {
     this.offFns = [];
     if (this.comboPulseTimer) clearTimeout(this.comboPulseTimer);
     if (this.flyoutTimer) clearTimeout(this.flyoutTimer);
+    if (this.feedbackTimer) clearTimeout(this.feedbackTimer);
     this.root.remove();
   }
 
@@ -194,11 +340,15 @@ export class Hud {
         this.comboEl.textContent = "0";
         this.comboBox.classList.add("zero");
         this.comboBox.classList.remove("pulse");
+        // Reset transient learning slots for a fresh run.
+        this.hideFeedback();
+        this.setRomanization("");
       }),
       this.bus.on("menuShown", () => {
         this.menuScreen.classList.remove("hidden");
         this.hudPanel.classList.add("hidden");
         this.gameOverScreen.classList.add("hidden");
+        this.hideFeedback();
       }),
       this.bus.on("scoreChange", (e) => {
         this.scoreEl.textContent = e.value.toLocaleString();


### PR DESCRIPTION
### **User description**
## Lingo Hero — Premium "Neon Arcade" rebuild

Integrates the premium rebuild of the **Lingo Hero** game pack
(`corpan/packs/lingo-hero/`) — a 3-lane rhythm/Guitar-Hero loop for
language learning. The HUD speaks a foreign prompt; three glass cards fall,
each showing an English option; the player taps the lane whose card is the
correct translation as it reaches the strum line (PRACTICE + BLITZ modes).

This PR merges four disjoint, independently-built streams onto the
`lingo-hero-premium` foundation and verifies every non-negotiable contract.

### What's in it

- **Board (canvas rewrite).** Scrolling synthwave perspective grid floor,
  volumetric glowing lane shafts + neon edge rails, premium glass note
  cards with specular sheen + approach bloom, a glass strum bar that leans
  toward the hottest lane, hit pops / lane-flash columns / red miss wash,
  and combo-escalating intensity. All Canvas2D, additive-bloom, 60fps /
  mobile-targeted, wall-clock (frame-rate independent). Reacts to gameplay
  via a new `effects/boardState` seam written by the bus-subscribed effects
  layer — **no `Game.ts` edits**.
- **Shell (glass HUD + learning surfaces).** Token-driven Neon Arcade HUD:
  romanization line, glassy replay button, post-answer feedback card
  (foreign → romanization → English meaning reveal, wired to the
  once-per-wave `wave-resolved` event), and an in-run mastery readout.
  RTL-aware, focus-visible, reduced-motion safe.
- **Learning depth (spaced difficulty + mastery).** A new `src/learning/*`
  Leitner/SM-2-lite per-word memory + spaced-difficulty `WordSelector` that
  resurfaces due/weak words and orders believable foils — **biasing choice
  only**; ContentManager re-runs the distinct-entries + distinct-English
  dedup AFTER, so the correctness contract is never broken. Adaptive
  difficulty tunes *content* pressure only (never note speed/spawn), so the
  calibrated ~7s travel feel is preserved. Offline-first localStorage.
- **Audio (synthwave palette).** Fully procedural WebAudio: SFX + music
  sub-buses, synthesized convolution reverb (no IR files), an evolving
  combo-reactive MusicBed (84→104 BPM), elevated Cm-tonic SFX, and a
  self-contained neon mute toggle. Zero binary assets, no network/fonts.

### Contracts verified post-merge

- **Correctness / dedup** — `getWaveContent` returns one target +
  distractors with **distinct entries AND distinct English answers**
  (`byId` map + `seenEnglish` Set seeded with the target's English). The
  injected selector is validated to stay within the candidate pool; dedup
  is unconditional and runs after selection.
- **Offline-first** — no remote URLs / fonts / fetch in `src/` or built
  `dist/` (fonts vendored as `assets/fonts/*.woff2`; audio synthesized).
- **TTS speaks RAW foreign text** — `foreign.text` is fed to TTS; display
  labels are cleaned separately (decoupled in `Game.ts`).
- **Pack id stays `lingo_hero`** (underscore) in manifest + game
  registration; paths/zip stay hyphenated.
- **Frame-rate-independent / playable** — `note.y += this.speed * dt`;
  `NOTE_TRAVEL_SECONDS = 7` calibrated feel preserved. `Game.ts`, `types.ts`,
  and `events.ts` were untouched by all four streams.

### Build

`npx tsc --noEmit` = 0 and `npx vite build` = 0 on Node 18 / vite 5
(`dist/app.js` 80.6 kB / 25.8 kB gz). dist/ + node_modules gitignored.
`devRevision` bumped; additive `[Unreleased]` CHANGELOG entries per the
corpan release-notes convention.

### How to judge it (devMode preview)

Pack is registered on the **`preview`** channel and is **devMode-gated** —
in a Corpán build with devMode/preview enabled, install Lingo Hero from the
catalog and play a PRACTICE + a BLITZ run on a phone-sized viewport: watch
the synthwave board + glass cards, confirm the spoken prompt matches the
foreign text, that exactly one falling card is the correct English, the
meaning-reveal feedback card, the mastery readout climbing, and the
combo-reactive music + mute toggle.

Premium rebuild credited to @0bkevin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Rebuilds Neon Arcade canvas board

- Adds synthwave music and SFX

- Introduces spaced word mastery

- Expands HUD learning feedback


___

### Diagram Walkthrough


```mermaid
flowchart LR
  bus["Event bus"] 
  boardState["Board state seam"]
  renderer["Neon canvas renderer"]
  audio["Synthwave audio engine"]
  learning["Spaced learning model"]
  hud["HUD feedback surfaces"]
  bus -- "drives effects" --> boardState
  boardState -- "animates lanes" --> renderer
  bus -- "scores outcomes" --> learning
  learning -- "updates mastery" --> hud
  bus -- "triggers cues" --> audio
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>20 files</summary><table>
<tr>
  <td><strong>Renderer.ts</strong><dd><code>Rebuild canvas board with neon arcade visuals</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-a8ca1f488ce07a5bfdd1fbb0851ce6f79a8731c3dacfe7d692d733838b839a53">+665/-229</a></td>

</tr>

<tr>
  <td><strong>sounds.ts</strong><dd><code>Retune procedural cues with reverb layers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-81a4c5686b15d89e3aa9d1bec3b9b5168f974821ac2e59f8e88b741b96eb6ccd">+203/-66</a></td>

</tr>

<tr>
  <td><strong>Hud.ts</strong><dd><code>Add romanization, replay, feedback, mastery slots</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-145e656a10e1e233418a8c559a94e938bf0e0c922802aa2f87d69b0498a38c02">+228/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>wordStats.ts</strong><dd><code>Add persisted per-word spaced repetition stats</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-29006adefa8077796694123909b2068c96c1d451447e19c5da6e171ea43a2527">+330/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SynthEngine.ts</strong><dd><code>Add music bus and convolution reverb</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-bc8854c3f7e746dbf1d4ea82da7bb3b38eab30e8ee83da44e973ff5e65d3e881">+142/-19</a></td>

</tr>

<tr>
  <td><strong>MusicBed.ts</strong><dd><code>Add evolving procedural synthwave music bed</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-a2aca9f10025f549d177c61e1fddca4f7ae25b5137ea209b8fa3e054056fb777">+272/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Wire learning stream into gameplay events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-6d549e41059372e63d058b83aa8d1758d8c4ad6ee74b479bb8b5a1ed7aba54b5">+263/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>MuteToggle.ts</strong><dd><code>Add neon audio mute toggle control</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-a80cc9f1f9a45fec271420ca843fd59c3415095bd5043e72c6283138a76beb67">+168/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>selector.ts</strong><dd><code>Add adaptive word and foil selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-d8b35fcc97a8c7d095f62322af3bf8ecba365288bb4532a77c95705c1dbc7a56">+119/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mastery.ts</strong><dd><code>Add mastery snapshot and progress calculations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-2322791cd8f7d177a1e334e76cbd04850debdfacc9de97c59ea80ab20c08427d">+119/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>boardState.ts</strong><dd><code>Add shared board animation state seam</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-12780b7b5961e7e626be8e3713ac652b5bb9711b48ecd20a9fd47487fd1c6180">+107/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>difficulty.ts</strong><dd><code>Add spaced difficulty scoring helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-43999288ad05bb1f0753e76786cfe6e4dde56f72b0437ed989b9c45be8456b45">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Game.ts</strong><dd><code>Emit wave outcomes and expose replay data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-6c075e8c51d32e4e5452a4c738f6cc530345361455286e0f7d1af37f46fedde7">+87/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Integrate music bed, verdict cues, mute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-2184219bcd7d4e7e52fed856f6c7e9983d9b3372de1de66e7fc1aac52cdb241f">+87/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ContentManager.ts</strong><dd><code>Apply adaptive selection before content deduping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-7f7f66aa0a0ab0785ba8e14b6eec2a3c527ed1175293a5030a3dcadd1575ed52">+90/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Extend game types for learning metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-90db924f79313d23c6eada5092c9adb12ccb7ceb3a47dcd832071a22448af88b">+55/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Expose progression snapshots for mastery UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-ced3690c00b381052c6c8181786c533b40330dfb3ebf4fa66f37e6215f0e10e9">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Feed board state from gameplay effects</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-9b5f998ad83be84b538e3d132b6d0b92d385eb5913681c574cbf16f6527d7aaa">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>palette.ts</strong><dd><code>Align effect palette with neon tokens</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-df8f43bff975bbd86028c081e792777c54ebb77e21a99a24ba6692429e4928ea">+11/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>styles.css</strong><dd><code>Style Neon Arcade HUD and learning surfaces</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-b9b9a82cd5a6b2fe32239b2b4b2f069c2c4853d63db1736b575103a5d1daf226">+443/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-dd09bf20e11864991961b7ef6d2fc6687a66d9a9de2d246f765d9d6891e646c2">+74/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>manifest.json</strong></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/367/files#diff-38411e79d50eee7f8ad439a29518dcddf16cdc9cd03739fc81ea212f18519b15">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

