### PR TITLE
Lingo Hero 0.2.1 — fix: correct taps scored as 'missed' (input coordinate origin)

### DIFF
--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-06-23
+
+### Fixed
+- **Correct taps were scored as "missed" in the app — every time.** Input x was
+  measured against the *container*, but notes are drawn in the absolutely-
+  positioned *canvas*. In the app the host passes its own (unpositioned)
+  container, so the canvas and container don't share an origin — every tap
+  resolved to the wrong lane. Pointer x is now measured against the **canvas's**
+  bounding rect (with scale normalization), and input uses unified Pointer
+  Events. Added a `ResizeObserver` so lane geometry tracks the container even
+  when the game mounts before it's sized. Reproduced + verified fixed in a
+  headless browser with an offset container (correct tap: old = no score,
+  fixed = scores).
+
 ## [0.2.0] - 2026-06-23
 
 The premium **Neon Arcade** release: a billion-dollar-bar rebuild of the single

--- a/corpan/packs/lingo-hero/manifest.json
+++ b/corpan/packs/lingo-hero/manifest.json
@@ -2,7 +2,7 @@
   "id": "lingo_hero",
   "channel": "preview",
   "name": "Lingo Hero",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Rhythm-based language learning. Feel the beat, learn the words.",
   "entry": "dist/app.js",
   "styles": [
@@ -11,5 +11,5 @@
   "entryType": "script",
   "sdkVersion": "0.1.0",
   "minAppVersion": "0.17.0",
-  "devRevision": "2026-06-23T12:00:00.000Z"
+  "devRevision": "2026-06-23T18:00:00.000Z"
 }

--- a/corpan/packs/lingo-hero/src/Game.ts
+++ b/corpan/packs/lingo-hero/src/Game.ts
@@ -24,6 +24,7 @@ export class Game {
   private renderer: Renderer;
   private laneSystem: LaneSystem;
   private inputManager: InputManager;
+  private resizeObserver?: ResizeObserver;
   private contentManager: ContentManager;
 
   private bus: GameEventBus;
@@ -101,7 +102,9 @@ export class Game {
     this.laneSystem = new LaneSystem(0, 0); // resized immediately below
     this.renderer = new Renderer(this.canvas, this.laneSystem);
     this.contentManager = new ContentManager(hostApi);
-    this.inputManager = new InputManager(container, (x) => this.getLaneFromX(x));
+    this.inputManager = new InputManager(container, this.canvas, (x) =>
+      this.getLaneFromX(x)
+    );
     this.inputManager.onInput((lane) => this.handleInput(lane));
 
     // Event bus + stream modules (no-op stubs the streams fill in).
@@ -125,9 +128,16 @@ export class Game {
       this.laneSystem
     );
 
-    // Initial resize (DPI) + responsive handler
+    // Initial resize (DPI) + responsive handler. A ResizeObserver tracks the
+    // ACTUAL container size — critical in the app, where the game can mount
+    // before the host's container has its final size (a window 'resize' may
+    // never fire), which would otherwise leave the lane geometry stale.
     this.handleResize(container);
     window.addEventListener("resize", () => this.handleResize(container));
+    if (typeof ResizeObserver !== "undefined") {
+      this.resizeObserver = new ResizeObserver(() => this.handleResize(container));
+      this.resizeObserver.observe(container);
+    }
 
     // Gate the first canvas draw on fonts so 'Russo One' is loaded before paint.
     if (document.fonts && document.fonts.ready) {
@@ -563,6 +573,7 @@ export class Game {
   dispose() {
     this.isRunning = false;
     this.offStackConfigChange?.();
+    this.resizeObserver?.disconnect();
     this.inputManager.dispose();
     this.effects.dispose();
     this.audio.dispose();

--- a/corpan/packs/lingo-hero/src/InputManager.ts
+++ b/corpan/packs/lingo-hero/src/InputManager.ts
@@ -2,25 +2,47 @@ import { LaneIndex } from "./types";
 
 type InputCallback = (lane: LaneIndex) => void;
 
+/**
+ * Maps player input to a lane. CRITICAL: pointer x is measured relative to the
+ * CANVAS's own bounding rect — the element the notes are actually drawn into —
+ * NOT the container. The canvas is absolutely positioned, so in the app (where
+ * the host passes its own, possibly unpositioned container) the canvas and the
+ * container do NOT share an origin; measuring against the container made every
+ * tap land in the wrong lane. Measuring against the canvas rect (with scale
+ * normalization for any CSS transform) is correct regardless of layout.
+ */
 export class InputManager {
   private listeners: InputCallback[] = [];
 
-  constructor(private container: HTMLElement, private getLaneFromX: (x: number) => LaneIndex | null) {
+  constructor(
+    private container: HTMLElement,
+    private canvas: HTMLCanvasElement,
+    private getLaneFromX: (x: number) => LaneIndex | null
+  ) {
     this.setupKeyboard();
-    this.setupTouch();
+    this.setupPointer();
   }
 
   onInput(callback: InputCallback) {
     this.listeners.push(callback);
   }
 
-  private trigger(lane: LaneIndex) {
-    this.listeners.forEach(cb => cb(lane));
+  private trigger(lane: LaneIndex | null) {
+    if (lane === null) return;
+    this.listeners.forEach((cb) => cb(lane));
+  }
+
+  /** Convert a viewport clientX to the canvas's internal CSS-pixel x. */
+  private canvasX(clientX: number): number {
+    const rect = this.canvas.getBoundingClientRect();
+    // Normalize for any CSS scaling/transform on the canvas or its ancestors so
+    // the value is in the same coordinate space the renderer/lanes use.
+    const scaleX = rect.width > 0 ? this.canvas.clientWidth / rect.width : 1;
+    return (clientX - rect.left) * scaleX;
   }
 
   private setupKeyboard() {
     window.addEventListener("keydown", (e) => {
-      // 1, 2, 3 or A, S, D or Left, Down, Right
       switch (e.key) {
         case "1":
         case "a":
@@ -41,29 +63,24 @@ export class InputManager {
     });
   }
 
-  private setupTouch() {
-    // Basic touch support - split screen into 3 columns
-    // Better way: use the LaneSystem coordinates. 
-    // We passed a helper `getLaneFromX` for this.
-    
-    this.container.addEventListener("touchstart", (e) => {
-      e.preventDefault(); // Prevent scrolling
-      for (let i = 0; i < e.changedTouches.length; i++) {
-        const touch = e.changedTouches[i];
-        // Get X relative to container
-        const rect = this.container.getBoundingClientRect();
-        const x = touch.clientX - rect.left;
-        
-        const lane = this.getLaneFromX(x);
-        if (lane !== null) {
-          this.trigger(lane);
-        }
-      }
-    }, { passive: false });
+  /**
+   * Pointer Events unify mouse + touch + pen and fire once per press (no
+   * touch→click double-trigger). Listen on the container so taps anywhere in the
+   * play area count (they bubble up from the canvas / HUD overlay), but resolve
+   * the lane against the CANVAS rect.
+   */
+  private setupPointer() {
+    this.container.addEventListener(
+      "pointerdown",
+      (e: PointerEvent) => {
+        e.preventDefault();
+        this.trigger(this.getLaneFromX(this.canvasX(e.clientX)));
+      },
+      { passive: false }
+    );
   }
 
   dispose() {
-    // Remove listeners if needed (mostly for HMR/cleanup)
-    // For now simple reload handles it
+    // Listeners are cleaned up when the container/canvas are removed on unmount.
   }
 }


### PR DESCRIPTION
### **User description**
**The real gameplay bug, found and verified.** Players picked the correct answer and it was scored *missed* — every time.

## Root cause
`InputManager` measured the tap x against the **container**, but notes are drawn in the **absolutely-positioned canvas**. In the app the host passes its own (unpositioned) container, so the canvas and container don't share an origin → every tap resolved to the wrong lane → correct answers read as misses, consistently.

It never reproduced in standalone/preview because there the container is a positioned full-screen `#lingo-hero-root` that the canvas pins to (origins coincide). That's why two prior fixes (dedup, lane-geometry) missed it — they weren't the bug.

## Fix
- Measure pointer x against the **canvas's** bounding rect (with scale normalization for any CSS transform).
- Unified **Pointer Events** (mouse/touch/pen, single-fire).
- Pass the canvas to `InputManager`; add a **`ResizeObserver`** so lane geometry tracks the container even if the game mounts before it's sized.

## Verified
Reproduced in **headless Chromium** with an offset, unpositioned container, tapping the correct lane at the card's visual position:
- **old build → score stays 0 (missed)** — reproduces the bug
- **fixed build → scores 100** ✅

Ships as 0.2.1 (devRevision bumped so installed clients re-fetch).


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fix tap lane detection origin

- Use unified pointer input

- Track container resizing reliably

- Document and bump 0.2.1 release


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Pointer input"]
  B["Canvas bounding rect"]
  C["Lane lookup"]
  D["Correct scoring"]
  E["ResizeObserver"]
  F["Updated lane geometry"]
  A -- "normalize clientX" --> B
  B -- "canvas-relative x" --> C
  C -- "matched lane" --> D
  E -- "container size changes" --> F
  F -- "keeps lanes aligned" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Game.ts</strong><dd><code>Wire canvas-based input and responsive lane resizing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/src/Game.ts

<ul><li>Adds an optional <code>ResizeObserver</code> field.<br> <li> Passes <code>this.canvas</code> into <code>InputManager</code>.<br> <li> Observes container size changes for lane resizing.<br> <li> Disconnects the observer during disposal.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/369/files#diff-6c075e8c51d32e4e5452a4c738f6cc530345361455286e0f7d1af37f46fedde7">+13/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>InputManager.ts</strong><dd><code>Resolve pointer input using canvas coordinates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/src/InputManager.ts

<ul><li>Accepts the game <code>canvas</code> for coordinate resolution.<br> <li> Converts <code>clientX</code> using the canvas bounding rect.<br> <li> Normalizes x coordinates for CSS scaling.<br> <li> Replaces touch handling with unified <code>pointerdown</code> input.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/369/files#diff-0197c1179d3e88e235f695277b616fc2951de9d3b23e39d65ed3e1c6022044a1">+43/-26</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document 0.2.1 input scoring fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/CHANGELOG.md

<ul><li>Adds the <code>0.2.1</code> release entry.<br> <li> Documents the incorrect missed-tap scoring fix.<br> <li> Notes Pointer Events and <code>ResizeObserver</code> improvements.<br> <li> Includes verification context for the offset-container bug.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/369/files#diff-dd09bf20e11864991961b7ef6d2fc6687a66d9a9de2d246f765d9d6891e646c2">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump Lingo Hero package revision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/manifest.json

<ul><li>Bumps package version from <code>0.2.0</code> to <code>0.2.1</code>.<br> <li> Updates <code>devRevision</code> to force client refresh.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/369/files#diff-38411e79d50eee7f8ad439a29518dcddf16cdc9cd03739fc81ea212f18519b15">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

