### PR TITLE
Lingo Hero 0.2.2 — usable controls + exit + readable words (+ gameplay e2e test)

### DIFF
--- a/corpan/packs/lingo-hero/.gitignore
+++ b/corpan/packs/lingo-hero/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 # Editor/OS cruft
 .DS_Store
 *.log
+test/e2e/out/

--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-06-23
+
+### Fixed
+- **Taps on the on-screen buttons (mute / replay) leaked through into a lane**,
+  making the controls impossible to use. Input now listens on the canvas itself,
+  so taps on the HUD controls never reach the lanes. (Verified in a headless
+  browser: a mute-button tap no longer scores; a lane tap still does.)
+- **Mute and replay buttons overlapped in the top-right.** The top bar now
+  reserves both corners; replay and mute sit side by side without overlapping.
+- **Long phrases were shrunk to an unreadable size.** Note text now wraps to two
+  balanced lines at a readable minimum size, and the card grows to fit.
+
+### Added
+- **Exit button** (top-left) that leaves the pack via the host's `corpan:exit`
+  event — no longer dependent on the OS back button.
+- Headless-browser **gameplay test + screenshot capture** (`test/e2e/`) that
+  asserts the interaction contracts (correct tap scores; button taps don't leak)
+  and produces visual proof — the basis for an automated CI gate.
+
 ## [0.2.1] - 2026-06-23
 
 ### Fixed

--- a/corpan/packs/lingo-hero/manifest.json
+++ b/corpan/packs/lingo-hero/manifest.json
@@ -2,7 +2,7 @@
   "id": "lingo_hero",
   "channel": "preview",
   "name": "Lingo Hero",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Rhythm-based language learning. Feel the beat, learn the words.",
   "entry": "dist/app.js",
   "styles": [
@@ -11,5 +11,5 @@
   "entryType": "script",
   "sdkVersion": "0.1.0",
   "minAppVersion": "0.17.0",
-  "devRevision": "2026-06-23T18:00:00.000Z"
+  "devRevision": "2026-06-23T21:00:00.000Z"
 }

--- a/corpan/packs/lingo-hero/src/InputManager.ts
+++ b/corpan/packs/lingo-hero/src/InputManager.ts
@@ -70,7 +70,13 @@ export class InputManager {
    * the lane against the CANVAS rect.
    */
   private setupPointer() {
-    this.container.addEventListener(
+    // Listen on the CANVAS (z-index 1), NOT the container. The HUD/controls live
+    // in a separate `pointer-events:none` overlay ABOVE the canvas; only the
+    // buttons are `pointer-events:auto`. So a tap on a button (mute / replay /
+    // exit) is handled by that button and NEVER reaches the canvas — no
+    // tap-through into a lane — while a tap on the play area passes through the
+    // transparent overlay to the canvas and fires a lane.
+    this.canvas.addEventListener(
       "pointerdown",
       (e: PointerEvent) => {
         e.preventDefault();

--- a/corpan/packs/lingo-hero/src/Renderer.ts
+++ b/corpan/packs/lingo-hero/src/Renderer.ts
@@ -559,7 +559,13 @@ export class Renderer {
 
       const laneW = this.laneSystem.getLaneBounds(0).width;
       const cardW = laneW * 0.9;
-      const cardH = r * 1.5;
+      // Lay the word out FIRST (wrap to <=2 lines at a readable size) so the card
+      // can grow to fit two lines instead of shrinking text to an unreadable size.
+      const wordFont = "'Russo One', 'Lingo Sans', system-ui, sans-serif";
+      const layout = note.text
+        ? layoutWord(ctx, note.text, cardW - 24, Math.max(30, r * 0.62), 21, wordFont)
+        : null;
+      const cardH = (layout && layout.lines.length >= 2 ? 2.15 : 1.5) * r;
       const x = cx - cardW / 2;
       const cardY = y - cardH / 2;
       const radius = Math.min(16, cardH * 0.32);
@@ -616,24 +622,20 @@ export class Renderer {
       ctx.fill();
       ctx.restore();
 
-      // --- WORD ---
-      if (note.text) {
+      // --- WORD (wrapped, readable) ---
+      if (layout) {
         ctx.save();
         ctx.textAlign = "center";
         ctx.textBaseline = "middle";
-        let fontSize = Math.max(26, r * 0.6);
-        ctx.font = `bold ${fontSize}px 'Russo One', 'Lingo Sans', system-ui, sans-serif`;
-        const maxTextW = cardW - 24;
-        const metrics = ctx.measureText(note.text);
-        if (metrics.width > maxTextW) {
-          fontSize = fontSize * (maxTextW / metrics.width);
-          ctx.font = `bold ${fontSize}px 'Russo One', 'Lingo Sans', system-ui, sans-serif`;
-        }
-        // Soft contrast shadow so the word stays legible over the glow.
+        ctx.font = `bold ${layout.fontSize}px ${wordFont}`;
         ctx.shadowColor = "rgba(0,0,0,0.55)";
         ctx.shadowBlur = 4;
         ctx.fillStyle = rgbStr(this.textColor);
-        ctx.fillText(note.text, cx + 3, y);
+        const lineH = layout.fontSize * 1.14;
+        const startY = y - (lineH * (layout.lines.length - 1)) / 2;
+        for (let li = 0; li < layout.lines.length; li++) {
+          ctx.fillText(layout.lines[li], cx + 3, startY + li * lineH);
+        }
         ctx.restore();
       }
     }
@@ -643,6 +645,47 @@ export class Renderer {
 // ---------------------------------------------------------------------------
 // Color + path helpers (module-scope, allocation-light).
 // ---------------------------------------------------------------------------
+
+/**
+ * Lay a word/phrase out to fit a card: keep it on one line at `baseFont` if it
+ * fits; otherwise wrap to TWO balanced lines and only shrink the font as far as
+ * `minFont` (so phrases stay readable on mobile instead of shrinking to nothing
+ * on a single line — the old behavior). A single un-splittable long token falls
+ * back to a shrink-to-fit single line. Returns the lines + the font size to use.
+ */
+function layoutWord(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxW: number,
+  baseFont: number,
+  minFont: number,
+  family: string
+): { lines: string[]; fontSize: number } {
+  const widthAt = (s: string, px: number) => {
+    ctx.font = `bold ${px}px ${family}`;
+    return ctx.measureText(s).width;
+  };
+
+  if (widthAt(text, baseFont) <= maxW) return { lines: [text], fontSize: baseFont };
+
+  const words = text.split(/\s+/).filter(Boolean);
+  if (words.length < 2) {
+    // Un-splittable: shrink single line to fit, floored at minFont.
+    const fit = (maxW / widthAt(text, baseFont)) * baseFont;
+    return { lines: [text], fontSize: Math.max(minFont, Math.min(baseFont, fit)) };
+  }
+
+  // Choose the split that minimizes the WIDER of the two lines (balanced wrap).
+  let best = { a: words.slice(0, 1).join(" "), b: words.slice(1).join(" "), wide: Infinity };
+  for (let i = 1; i < words.length; i++) {
+    const a = words.slice(0, i).join(" ");
+    const b = words.slice(i).join(" ");
+    const wide = Math.max(widthAt(a, baseFont), widthAt(b, baseFont));
+    if (wide < best.wide) best = { a, b, wide };
+  }
+  const fit = best.wide <= maxW ? baseFont : (maxW / best.wide) * baseFont;
+  return { lines: [best.a, best.b], fontSize: Math.max(minFont, Math.min(baseFont, fit)) };
+}
 
 function cssVar(root: HTMLElement | null, name: string): string {
   if (!root || typeof getComputedStyle !== "function") return "";

--- a/corpan/packs/lingo-hero/src/styles.css
+++ b/corpan/packs/lingo-hero/src/styles.css
@@ -549,6 +549,47 @@ canvas {
   justify-content: center;
   gap: var(--na-space-3);
   width: 100%;
+  /* Reserve the top corners for the Exit (left) and Mute (right) controls so the
+     centered prompt + replay never sit underneath them. */
+  padding-left: calc(56px + env(safe-area-inset-left, 0px));
+  padding-right: calc(56px + env(safe-area-inset-right, 0px));
+  box-sizing: border-box;
+}
+
+/* Exit control — top-left corner, mirroring the audio mute toggle (top-right).
+   In the .ui-layer overlay (pointer-events:none) but itself interactive. */
+.lh-exit-btn {
+  position: absolute;
+  top: calc(var(--na-space-3) + env(safe-area-inset-top, 0px));
+  left: calc(var(--na-space-3) + env(safe-area-inset-left, 0px));
+  z-index: var(--na-z-overlay, 40);
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  line-height: 1;
+  padding: 0;
+  border-radius: var(--na-radius-pill);
+  border: 1px solid color-mix(in srgb, var(--na-text) 35%, transparent);
+  background: var(--na-glass-bg);
+  color: var(--na-text);
+  cursor: pointer;
+  pointer-events: auto;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+  transition: transform var(--na-dur-fast) var(--na-ease-snap),
+    border-color var(--na-dur-base) var(--na-ease-out);
+}
+.lh-exit-btn:hover,
+.lh-exit-btn:focus-visible {
+  border-color: var(--na-text);
+}
+.lh-exit-btn:active {
+  transform: scale(0.92);
 }
 
 /* Prompt stack: foreign prompt + romanization line, vertically grouped so the

--- a/corpan/packs/lingo-hero/src/ui/Hud.ts
+++ b/corpan/packs/lingo-hero/src/ui/Hud.ts
@@ -89,6 +89,9 @@ export class Hud {
     this.root = document.createElement("div");
     this.root.className = "ui-layer";
     this.root.innerHTML = `
+      <button class="lh-exit-btn" id="lh-exit" type="button" aria-label="Exit Lingo Hero" title="Exit">
+        <span aria-hidden="true">&#8592;</span>
+      </button>
       <div class="menu-screen" id="menu" role="dialog" aria-label="Lingo Hero main menu">
         <div class="brand">
           <p class="brand-kicker">Rhythm · Language</p>
@@ -203,6 +206,13 @@ export class Hud {
       this.callbacks.onStartGame(this.lastMode)
     );
     this.bindButton("#btn-menu", () => this.callbacks.onShowMenu());
+
+    // Exit the pack entirely: the Corpán host listens for `corpan:exit` (App.tsx)
+    // and dismisses the game. Persistent (menu + gameplay) so there's always a
+    // way out besides the OS back button.
+    this.bindButton("#lh-exit", () =>
+      window.dispatchEvent(new CustomEvent("corpan:exit"))
+    );
 
     // (b) Wire the audio-replay button only if the host provided a callback.
     if (this.callbacks.onReplayPrompt) {

--- a/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
+++ b/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
@@ -1,0 +1,88 @@
+/**
+ * Headless gameplay test for Lingo Hero — the kind of test that catches
+ * interaction/UI bugs the build/typecheck/adversarial gates cannot "see"
+ * because nothing else actually PLAYS the game. It drives the built bundle in a
+ * real (headless) browser, in an app-like offset container, and asserts the core
+ * interaction contracts that humans kept having to catch by hand:
+ *
+ *   1. Tapping the correct lane at a card's visual position SCORES.        (input coords)
+ *   2. Tapping an on-screen control (mute) does NOT leak into a lane.      (tap-through)
+ *
+ * It also captures menu + gameplay screenshots (visual proof) into test/e2e/out/.
+ *
+ * Run:  npm run build  (produces ../../dist)
+ *       node test/e2e/gameplay.spec.mjs   (needs `playwright` + chromium available)
+ * Exits non-zero on any failed assertion so it can gate in CI.
+ */
+import { chromium } from "playwright";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { mkdirSync } from "node:fs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const harness = "file://" + join(here, "harness.html");
+const outDir = join(here, "out");
+mkdirSync(outDir, { recursive: true });
+
+const fail = (m) => { console.error("FAIL:", m); failures++; };
+let failures = 0;
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 390, height: 844 }, deviceScaleFactor: 2 });
+page.on("pageerror", (e) => fail("pageerror: " + e.message));
+await page.goto(harness);
+await page.waitForFunction(() => !!window.__lingoHero, { timeout: 10000 });
+await page.waitForTimeout(300);
+await page.screenshot({ path: join(outDir, "menu.png") });
+
+const read = () => page.evaluate(() => {
+  const g = window.__lingoHero, ls = g.laneSystem, r = g.canvas.getBoundingClientRect();
+  return {
+    score: g.score, strumY: ls.getStrumLineY(),
+    laneX: [ls.getLaneX(0), ls.getLaneX(1), ls.getLaneX(2)],
+    canvas: { left: r.left, top: r.top },
+    notes: (g.notes || []).map((n) => ({ lane: n.lane, y: n.y, isTarget: n.isTarget, hit: n.hit, missed: n.missed })),
+  };
+});
+
+await page.evaluate(() => {
+  const p = [...document.querySelectorAll("button")].find((b) => /practice/i.test(b.textContent || ""));
+  if (p) p.click(); else window.__lingoHero.startGame("PRACTICE");
+});
+
+// Contract 2: control tap must NOT score.
+const mute = await page.evaluate(() => {
+  const b = document.querySelector(".na-mute-toggle"); if (!b) return null;
+  const r = b.getBoundingClientRect(); return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+});
+if (!mute) fail("no .na-mute-toggle control found");
+else {
+  const before = (await read()).score;
+  await page.mouse.click(mute.x, mute.y);
+  await page.waitForTimeout(120);
+  if ((await read()).score !== before) fail("tap-through: mute tap changed the score");
+  else console.log("OK: mute tap did not leak into a lane");
+}
+
+// Contract 1: correct lane tap at the card's visual position must score.
+let scored = false;
+const deadline = Date.now() + 15000;
+while (Date.now() < deadline && !scored) {
+  const s = await read();
+  const t = s.notes.find((n) => n.isTarget && !n.hit && !n.missed);
+  if (t && t.y >= s.strumY - 40 && t.y <= s.strumY + 40) {
+    const before = s.score;
+    await page.screenshot({ path: join(outDir, "gameplay.png") });
+    await page.mouse.click(s.canvas.left + s.laneX[t.lane], s.canvas.top + s.strumY);
+    await page.waitForTimeout(120);
+    if ((await read()).score > before) { scored = true; console.log("OK: correct lane tap scored"); }
+    else fail("correct lane tap at visual position did not score");
+    break;
+  }
+  await page.waitForTimeout(60);
+}
+if (!scored && failures === 0) fail("no target note reached the strum line in time");
+
+await browser.close();
+console.log(failures === 0 ? "\nGAMEPLAY E2E: PASS" : `\nGAMEPLAY E2E: ${failures} FAILURE(S)`);
+process.exit(failures === 0 ? 0 : 1);

--- a/corpan/packs/lingo-hero/test/e2e/harness.html
+++ b/corpan/packs/lingo-hero/test/e2e/harness.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<!--
+  Standalone harness for the headless gameplay test (test/e2e/gameplay.spec.mjs).
+  Loads the BUILT bundle and mounts the game into an OFFSET, unpositioned
+  container — deliberately reproducing the app's layout (where the host passes
+  its own container that the absolutely-positioned canvas is not anchored to).
+  Run `npm run build` first so ../../dist exists.
+-->
+<html>
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../../dist/app.css" />
+<style>
+  html, body { margin: 0; padding: 0; height: 100%; background: #07060f; }
+  /* Offset + STATIC on purpose — see note above. */
+  #host { position: static; margin: 90px 0 0 70px; width: 360px; height: 720px; }
+</style>
+</head>
+<body>
+<div id="host"></div>
+<script>window.__corpanHostActive = true;</script>
+<script src="../../dist/app.js"></script>
+<script>
+  const PAIRS = [
+    ["cat", "el gato"],
+    ["I would like a cup of coffee, please", "quisiera una taza de café, por favor"],
+    ["good morning everyone", "buenos días a todos"],
+    ["where is the train station", "dónde está la estación de tren"],
+    ["thank you very much", "muchas gracias"],
+    ["how much does this cost", "cuánto cuesta esto"],
+    ["see you tomorrow", "hasta mañana"],
+    ["the weather is nice today", "hace buen tiempo hoy"],
+  ];
+  const ENTRIES = PAIRS.map(([en, es], i) => ({
+    entry_id: i + 1, level: "A1", domains: ["travel"],
+    translations: [{ language_code: "es", text: es }, { language_code: "en", text: en }],
+  }));
+  let k = 0;
+  const host = {
+    speak() {}, stopSpeech() {},
+    getStackConfig() { return { languages: ["es"], domains: [], levels: [], rate: 1, textSize: "m", showRomanization: true }; },
+    onStackConfigChange() { return () => {}; },
+    getRandomEntries(n) { const o = []; for (let i = 0; i < n; i++) o.push(ENTRIES[(k++) % ENTRIES.length]); return Promise.resolve(o); },
+    getRandomEntry() { return Promise.resolve(ENTRIES[(k++) % ENTRIES.length]); },
+    isMock: true,
+  };
+  window.CorpanGames.lingo_hero.mount(document.getElementById("host"), host);
+</script>
+</body>
+</html>


### PR DESCRIPTION
### **User description**
Fixes found by playing on a phone, all verified in a headless browser:

- **Tap-through:** on-screen buttons (mute/replay) leaked taps into the lane behind them. Input now listens on the **canvas** (controls live in a separate overlay), so a button tap can't trigger a lane. Headless-verified: mute tap → no score; lane tap → scores.
- **Overlapping controls:** mute + replay stacked in the top-right. The top bar now reserves both corners; they sit side-by-side (geometry-asserted: no overlap).
- **Unreadable words:** long phrases shrank to nothing. Note text now **wraps to two readable lines** and the card grows to fit.
- **No exit:** added an **Exit** button (top-left) that leaves the pack via the host's `corpan:exit` event.

### Building the testing muscle (the point)
This PR also commits a **headless-browser gameplay test** (`test/e2e/`) that drives the built bundle in an app-like offset container and asserts the interaction contracts that humans kept catching by hand, plus captures **screenshot proof**. This is the class of test our gates couldn't see (nothing else plays the game). Next step: wire it as a CI gate on pack changes so agents catch this automatically.

Screenshots (menu + gameplay, phone viewport) attached in chat.


___

### **PR Type**
Bug fix, Enhancement, Tests, Documentation


___

### **Description**
- Prevent HUD control tap-through scoring

- Add persistent host exit control

- Wrap long note phrases readably

- Add headless gameplay regression test


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HUD controls"]
  B["Canvas-only input"]
  C["Lane scoring"]
  D["Readable note layout"]
  E["Headless gameplay test"]
  A -- "no tap-through" --> B
  B -- "preserves" --> C
  D -- "wraps phrases" --> C
  E -- "verifies interactions" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>InputManager.ts</strong><dd><code>Route pointer input through canvas only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/370/files#diff-0197c1179d3e88e235f695277b616fc2951de9d3b23e39d65ed3e1c6022044a1">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>Renderer.ts</strong><dd><code>Wrap long note text readably</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/370/files#diff-a8ca1f488ce07a5bfdd1fbb0851ce6f79a8731c3dacfe7d692d733838b839a53">+56/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Hud.ts</strong><dd><code>Add persistent host exit button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/370/files#diff-145e656a10e1e233418a8c559a94e938bf0e0c922802aa2f87d69b0498a38c02">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>styles.css</strong><dd><code>Style exit button and reserve corners</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/370/files#diff-b9b9a82cd5a6b2fe32239b2b4b2f069c2c4853d63db1736b575103a5d1daf226">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>harness.html</strong><dd><code>Add browser harness for gameplay tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/370/files#diff-8ee2dd317f309986882bf709a5d4c019eef9d67566a123801874380c26a7d95f">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gameplay.spec.mjs</strong><dd><code>Add Playwright gameplay interaction regression test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/370/files#diff-5ee22f0c6a817c0427478004e2238facf99cd3c18591eda51d590170655a3c57">+88/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document Lingo Hero 0.2.2 changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/370/files#diff-dd09bf20e11864991961b7ef6d2fc6687a66d9a9de2d246f765d9d6891e646c2">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>manifest.json</strong><dd><code>Bump version and development revision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/370/files#diff-38411e79d50eee7f8ad439a29518dcddf16cdc9cd03739fc81ea212f18519b15">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

