### PR TITLE
beatlounge: per-facet reroll dice in the "New…" world form

### DIFF
--- a/corpan/packs/beatlounge/CHANGELOG.md
+++ b/corpan/packs/beatlounge/CHANGELOG.md
@@ -25,6 +25,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   randomizer is refactored to build from an explicit `DraftWorld`
   (`rollDraftWorld` / `buildSnapshotFromDraft`); `buildRandomSnapshot` is now a
   thin all-random wrapper. (Beat-Lounge-Plus; closes #326.)
+- Per-facet reroll in the "New…" form: a dice beside each row rerolls just that
+  facet and keeps the rest; disabled while the facet is locked. (Beat-Lounge-Plus;
+  closes #327.)
 
 ## [0.3.2] - 2026-06-19
 

--- a/corpan/packs/beatlounge/src/i18n/strings.ts
+++ b/corpan/packs/beatlounge/src/i18n/strings.ts
@@ -397,6 +397,7 @@ const en: Record<string, string> = {
   "scenes.newTitle": "New world",
   "scenes.randomize": "Randomize",
   "scenes.randomizedToast": "Randomized",
+  "scenes.rerollFacet": "Reroll {facet}",
   "scenes.saveCurrent": "Save current as Scene",
   "scenes.savedCount": "{n} saved",
   "scenes.savedNamed": "Saved scene \"{name}\"",

--- a/corpan/packs/beatlounge/src/modules/scenes/NewWorldForm.test.tsx
+++ b/corpan/packs/beatlounge/src/modules/scenes/NewWorldForm.test.tsx
@@ -69,6 +69,31 @@ describe("NewWorldForm", () => {
     })
   })
 
+  it("per-facet dice rerolls only that facet (locks every other one)", () => {
+    const ctrl = makeCtrl()
+    render({ ctrl, onCreate: () => {}, onCancel: () => {} })
+    ;(ctrl.rollWorld as ReturnType<typeof vi.fn>).mockClear()
+    const dice = container!.querySelector<HTMLButtonElement>('button[aria-label="Reroll Kit"]')!
+    act(() => dice.click())
+    expect(ctrl.rollWorld).toHaveBeenCalledTimes(1)
+    const arg = (ctrl.rollWorld as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    expect(arg.from).toBe(draft)
+    // every facet but "kit" is locked, so only kit can move
+    const locked = arg.lock as ReadonlySet<string>
+    expect(locked.has("kit")).toBe(false)
+    expect(locked.has("meter")).toBe(true)
+    expect(locked.size).toBe(7)
+  })
+
+  it("disables a facet's dice while that facet is locked", () => {
+    render({ ctrl: makeCtrl(), onCreate: () => {}, onCancel: () => {} })
+    const dice = () =>
+      container!.querySelector<HTMLButtonElement>('button[aria-label="Reroll Meter"]')!
+    expect(dice().disabled).toBe(false)
+    act(() => container!.querySelector<HTMLButtonElement>('button[aria-label="Lock Meter"]')!.click())
+    expect(dice().disabled).toBe(true)
+  })
+
   it("Create applies the draft and notifies the caller", () => {
     const ctrl = makeCtrl()
     const onCreate = vi.fn()

--- a/corpan/packs/beatlounge/src/modules/scenes/NewWorldForm.tsx
+++ b/corpan/packs/beatlounge/src/modules/scenes/NewWorldForm.tsx
@@ -73,6 +73,12 @@ export const NewWorldForm = ({ ctrl, onCreate, onCancel }: Props) => {
     })
 
   const reroll = () => setDraft(ctrl.rollWorld({ from: draft, lock: locks }))
+  // Per-facet reroll: roll just this facet, keep every other one (lock = all but f).
+  // The dice is disabled while its facet is locked, so a locked facet never moves.
+  const rerollFacet = (f: DraftFacet) =>
+    setDraft(
+      ctrl.rollWorld({ from: draft, lock: new Set(ROWS.map((r) => r.facet).filter((x) => x !== f)) })
+    )
   const create = () => {
     ctrl.applyWorld(draft)
     onCreate()
@@ -90,6 +96,15 @@ export const NewWorldForm = ({ ctrl, onCreate, onCancel }: Props) => {
               <span className="bl-newworld-value" title={r.value(draft)}>
                 {r.value(draft)}
               </span>
+              <button
+                type="button"
+                className="bl-icon-btn bl-newworld-dice"
+                aria-label={ct("scenes.rerollFacet", { facet: label })}
+                disabled={locked}
+                onClick={() => rerollFacet(r.facet)}
+              >
+                <Glyph name="dice" size={15} />
+              </button>
               <button
                 type="button"
                 className={`bl-icon-btn bl-newworld-lock${locked ? " is-locked" : ""}`}

--- a/corpan/packs/beatlounge/src/modules/scenes/scenes.css
+++ b/corpan/packs/beatlounge/src/modules/scenes/scenes.css
@@ -286,9 +286,12 @@
 }
 .bl-newworld-row {
   display: grid;
-  grid-template-columns: 5.5rem 1fr auto;
+  grid-template-columns: 5.5rem 1fr auto auto;
   align-items: center;
   gap: var(--bl-s3);
+}
+.bl-newworld-dice {
+  color: var(--bl-text-dim);
 }
 .bl-newworld-facet {
   font-size: var(--bl-fs-label);


### PR DESCRIPTION
### **User description**
## What
A **dice** button beside each facet row in the "New…" world form rerolls **just that facet**, keeping every other one. It's **disabled while the facet is locked**, so a locked facet never moves.

## How
Reuses the `rollDraftWorld({ from, lock })` engine — per-facet reroll is simply `lock = all facets except this one`. No model changes; pure UI on top of #326.

## Gates
- `npm run typecheck` — clean
- `npm run test` — **1309 passed**; +per-facet reroll and locked-dice-disabled cases
- `npm run build` — clean

## Scope
Pack-only (`corpan/packs/beatlounge`). No `model/` spine change, no manifest/version change.

Closes #327.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add per-facet dice rerolls

- Preserve locked and unrelated facets

- Cover reroll and lock behavior

- Document Beat Lounge changelog entry


___

### Diagram Walkthrough


```mermaid
flowchart LR
  form["New world form"]
  row["Facet row"]
  dice["Dice button"]
  locks["Lock set"]
  roll["rollWorld with other facets locked"]
  draft["Updated draft preview"]
  form -- "renders" --> row
  row -- "adds" --> dice
  dice -- "disabled by" --> locks
  dice -- "rerolls one facet" --> roll
  roll -- "updates" --> draft
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>strings.ts</strong><dd><code>Add reroll facet i18n string</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/i18n/strings.ts

<ul><li>Adds <code>scenes.rerollFacet</code> UI string.<br> <li> Supports accessible per-facet dice labels.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/382/files#diff-87074fa850643147c97378c9a4527253ed05850ba3de2c04991c53bfdb2f6e91">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NewWorldForm.tsx</strong><dd><code>Add per-facet dice reroll controls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/modules/scenes/NewWorldForm.tsx

<ul><li>Adds <code>rerollFacet</code> helper using existing <code>rollWorld</code>.<br> <li> Locks every facet except the selected one.<br> <li> Renders dice button beside each facet row.<br> <li> Disables dice when that facet is locked.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/382/files#diff-5a4edc59254b52b02b5baf99e5c4754c1e2a9726d51a60bb0e7246cfd3cf5b51">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>scenes.css</strong><dd><code>Style New world dice column</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/modules/scenes/scenes.css

<ul><li>Expands New world row grid for dice button.<br> <li> Adds dimmed styling for reroll dice.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/382/files#diff-dd8b4d9c8b8e9ac52fc70e5fd5b2906d49b3b068fd58e8fe1e17e2a25d0657c2">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NewWorldForm.test.tsx</strong><dd><code>Test per-facet reroll behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/modules/scenes/NewWorldForm.test.tsx

<ul><li>Tests per-facet dice calls <code>rollWorld</code>.<br> <li> Verifies all other facets are locked.<br> <li> Verifies locked facets disable their dice.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/382/files#diff-bc50601320be31fdc040fc841a24d8fb90dfba897e5d47ab39de77ef71228ae8">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document per-facet reroll feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/CHANGELOG.md

<ul><li>Documents per-facet reroll in New form.<br> <li> Notes locked facets disable reroll.<br> <li> References Beat-Lounge-Plus and closes <code>#327</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/382/files#diff-83e97c4e36caca34711c70ef258b21b23e7362bf0f79b312a22fb2679ced8def">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

