### PR TITLE
Lingo Hero 0.4.0 — batch-timed chart spawn + freed-center HUD

### DIFF
--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **Notes no longer spawn behind the HUD.** The top HUD band (source-sentence
+  chip + exit/mute controls) was sharing pixels with the top of the falling-note
+  lanes, so notes spawned clipped/occluded behind the prompt chip and audio
+  button — shortening read-time and hiding which word/lane was incoming. The
+  game now measures the HUD band each resize / round and reserves a clear play
+  area below it (`LaneSystem.setPlayTop`); the Renderer clips both note passes to
+  that play area and fades each card in over a short ramp just below the band, so
+  every note is fully visible from the moment it appears. Gameplay timing, hit
+  detection, input, and the e2e contracts are unchanged.
+
 ## [0.4.0] - 2026-06-23
 
 Rebuilt the spawn into a true **Guitar-Hero chart** and pulled the stats out of

--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -6,6 +6,42 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-23
+
+Rebuilt the spawn into a true **Guitar-Hero chart** and pulled the stats out of
+the play area.
+
+### Changed
+- **Batch-timed CHART spawn (replaces one-word-at-a-time).** At round start the
+  ENTIRE target translation is now laid out as a single falling chart: every word
+  becomes a note, **in order**, spaced in **time** (vertical gap = the gap
+  between their strum beats, timed to a phrase tempo). The notes fall
+  continuously and the player catches each correct word at the strum line in
+  rhythm — a phrase of notes, not a trickle. Notes derive their position from
+  their strum beat (`y = strumY − (strumTime − now) · speed`), so the whole
+  phrase rides one pre-laid timeline; the proven delta-timed motion, forgiving
+  hit window, canvas-relative input, scoring/combo, and event/effects/audio
+  streams are unchanged.
+- **Streak-driven difficulty (resets on fail).** A relaxed start: at streak 0 the
+  words are spaced **far apart** in time and **zero decoys** fall (only the
+  correct words, in order). As the clean-chart streak builds, the inter-word
+  spacing **compresses** toward a natural-speech tempo **and decoys ramp**
+  `0 → 1 → 2` per sentence — wrong target-language words placed in OTHER lanes,
+  interleaved between the correct beats, to dodge. Whiffing or missing a correct
+  word, or catching a decoy, **resets** spacing to relaxed and decoys to 0 for
+  the next chart.
+- **Stats moved OUT of the center.** The level/progress readout + SCORE + COMBO
+  plates no longer flank the falling-note lanes. On tall screens they dock in a
+  compact strip **below the hit-ring circles**; on short/landscape screens they
+  collapse to a slim row at the very top. The prompt + assembling-phrase strip
+  stay at the top (gameplay-relevant).
+
+### Fixed
+- **Card accent spine now follows the rounded corners.** The lane-color spine on
+  each word card's leading edge is clipped to the card's rounded-rect, so its
+  top/bottom follow the corner radius exactly instead of poking past it as a
+  straight bar.
+
 ## [0.3.0] - 2026-06-23
 
 New mechanic: **Catch the Translation**. The game now teaches by having you

--- a/corpan/packs/lingo-hero/manifest.json
+++ b/corpan/packs/lingo-hero/manifest.json
@@ -2,8 +2,8 @@
   "id": "lingo_hero",
   "channel": "preview",
   "name": "Lingo Hero",
-  "version": "0.3.0",
-  "description": "Catch the translation. The phrase you know falls word-by-word in the language you're learning — catch it in order and hear it spoken.",
+  "version": "0.4.0",
+  "description": "Catch the translation. The phrase you know falls as a chart of timed notes in the language you're learning — catch each word in rhythm, in order, and hear it spoken.",
   "entry": "dist/app.js",
   "styles": [
     "dist/app.css"
@@ -11,5 +11,5 @@
   "entryType": "script",
   "sdkVersion": "0.1.0",
   "minAppVersion": "0.17.0",
-  "devRevision": "2026-06-23T18:05:05.000Z"
+  "devRevision": "2026-06-23T22:40:00.000Z"
 }

--- a/corpan/packs/lingo-hero/src/Game.ts
+++ b/corpan/packs/lingo-hero/src/Game.ts
@@ -23,26 +23,32 @@ const RTL_LANGS = new Set(["ar", "he", "fa", "ur"]);
  * Game — "CATCH THE TRANSLATION".
  *
  * The player sees a phrase in the language they ALREADY KNOW (primary =
- * stack.languages[0], also the UI language). Its translation in the TARGET
- * (learning) language falls down the three lanes WORD BY WORD, IN ORDER. The
- * player catches each correct next word as it crosses the strum line; on catch
- * the target word is SPOKEN (so they hear the pronunciation) and revealed in an
- * assembling target-phrase strip. Reconstructing + hearing the translation,
- * prompted by the known phrase, IS the learning.
+ * stack.languages[0], also the UI language). At round start its translation in
+ * the TARGET (learning) language is laid out as a FALLING CHART: every word of
+ * the translation becomes a note, IN ORDER, spaced in TIME (vertical gap = the
+ * gap between their strum beats) — like a phrase of guitar-hero notes. They
+ * fall continuously; the player catches each correct word at the strum line in
+ * rhythm. Catching in order assembles the phrase + speaks each target word (the
+ * learning).
  *
- * Difficulty ramps with the combo: at first ONLY correct words fall (pure
- * rhythm catch); as the player heats up, DISTRACTOR target words fall in the
- * OTHER lanes and must be dodged.
+ * STREAK-DRIVEN DIFFICULTY (reset to relaxed on any fail):
+ *   - Streak 0: words spaced FAR apart in time (generous) and ZERO decoys.
+ *   - As the streak builds: COMPRESS the inter-word spacing toward natural
+ *     speech tempo AND add DECOYS (wrong target-language words in OTHER lanes,
+ *     interleaved with the correct sequence) — 0 -> 1 -> 2 decoys per sentence.
+ *   - On FAIL (whiff / miss a correct word / catch a decoy → combo break):
+ *     spacing resets to relaxed and decoys to 0 for the NEXT chart.
  *
- * COHERENCE CONTRACT: at any instant exactly ONE catchable card carries the
- * next correct token of the target translation. Catching it advances the
- * sequence; tapping a distractor or letting the correct word pass is a miss.
+ * COHERENCE CONTRACT: the correct words are a strict ordered sequence; the
+ * player must catch the NEXT one (seqIndex === caughtCount). Catching it
+ * advances the sequence; catching a decoy or letting the next correct word
+ * sail past the strum is a miss.
  *
  * This file keeps the proven engine intact — delta-timed falling motion,
  * canvas-relative input (InputManager), forgiving hit detection (LaneSystem),
  * the typed event bus, and the effects/audio/hud/progression streams. Only the
- * CONTENT MODEL (phrase → ordered words), spawn cadence, catch-in-sequence
- * input, and the assembling strip are new.
+ * CONTENT MODEL (phrase → time-spaced chart), the batch chart layout, the
+ * catch-in-sequence input, and the assembling strip are new.
  */
 export class Game {
   private canvas: HTMLCanvasElement;
@@ -87,11 +93,9 @@ export class Game {
   private caughtCount: number = 0;
   /** The words revealed in the assembling strip so far. */
   private assembled: string[] = [];
-  /** True while a correct-word card for the current step is in flight. */
-  private stepActive: boolean = false;
   /** True iff EVERY word this round has been caught cleanly (no pass / wrong). */
   private roundAllCaught: boolean = true;
-  /** performance.now() after which the next round/step may spawn. */
+  /** performance.now() after which the next round may load (post-resolve gap). */
   private nextSpawnTime: number = 0;
   /** Fires the round's once-per-round verdict exactly once. */
   private roundResolved: boolean = false;
@@ -101,6 +105,24 @@ export class Game {
   private currentWord: WordIdentity | null = null;
   /** Monotonic counter so note ids are unique even within the same ms. */
   private noteSeq: number = 0;
+
+  // ---- Streak-driven chart difficulty -------------------------------------
+  /**
+   * The "difficulty streak" — how many CHARTS in a row the player has caught
+   * cleanly (every correct word, no decoy taps). It drives spacing compression
+   * + the decoy ramp, and RESETS to 0 on any fail. Distinct from the scoring
+   * combo (which is per-word): a single whiffed word resets both, but the
+   * difficulty streak only climbs at the granularity of whole clean charts so
+   * the ramp feels deliberate.
+   */
+  private chartStreak: number = 0;
+  /** Tracks, within the current chart, whether the player has failed anything. */
+  private chartClean: boolean = true;
+  /**
+   * Seconds between consecutive correct-word strum beats for the CURRENT chart,
+   * chosen at layout time from the streak (relaxed -> natural-speech tempo).
+   */
+  private beatGap: number = 1.6;
 
   // Track lane activation for visuals.
   private lanePressTimes: number[] = [0, 0, 0];
@@ -255,8 +277,9 @@ export class Game {
     this.roundWords = [];
     this.caughtCount = 0;
     this.assembled = [];
-    this.stepActive = false;
     this.nextSpawnTime = 0;
+    this.chartStreak = 0;
+    this.chartClean = true;
 
     this.bus.emit("gameStart", { mode, language: this.activeLanguage });
     this.bus.emit("scoreChange", { value: 0, delta: 0 });
@@ -293,10 +316,12 @@ export class Game {
   }
 
   // -------------------------------------------------------------------------
-  // ROUND lifecycle: load a phrase, then spawn its words one step at a time.
+  // ROUND lifecycle: load a phrase, then lay out the WHOLE translation as a
+  // time-spaced falling CHART (true Guitar-Hero timing). Difficulty (spacing +
+  // decoys) is chosen from the streak at layout time and reset on any fail.
   // -------------------------------------------------------------------------
 
-  /** Load a fresh round from content + reset per-round state, then spawn step 0. */
+  /** Load a fresh round from content + reset per-round state, then build the chart. */
   private async startRound() {
     // Guard against the loop firing a second load while the first is in flight.
     if (this.loadingRound) return;
@@ -322,9 +347,9 @@ export class Game {
     this.roundWords = round.targetWords;
     this.caughtCount = 0;
     this.assembled = [];
-    this.stepActive = false;
     this.roundResolved = false;
     this.roundAllCaught = true;
+    this.chartClean = true;
 
     this.currentWord = {
       entryId: round.entryId,
@@ -338,85 +363,125 @@ export class Game {
     this.hud.setRomanization(round.romanization ?? "");
     this.hud.setAssembled([], this.roundWords.length, this.activeLanguage.isRTL);
 
-    this.spawnStep();
+    this.buildChart();
   }
 
   /**
-   * Number of DISTRACTOR cards to put in the OTHER lanes for the current step.
-   * Difficulty ramp tied to the combo (gentle, gradual):
-   *   combo < 3   → 0 (Level 1: only the correct word falls — pure rhythm)
-   *   combo 3..6  → 1 distractor (probabilistically, easing in)
-   *   combo >= 7  → up to 2 distractors (dodge to catch the right one)
-   * Never exceeds the 2 free lanes, and never exceeds the available pool.
+   * Inter-word beat spacing (seconds between consecutive CORRECT strum beats)
+   * for the given difficulty streak. Streak 0 is relaxed/generous; it compresses
+   * toward a natural-speech tempo floor as the streak climbs.
    */
-  private distractorCountForStep(): number {
+  private beatGapForStreak(streak: number): number {
+    const RELAXED = 1.7; // generous gap at streak 0
+    const TIGHT = 0.85; // natural-speech-ish floor
+    // Reach the floor by ~streak 6; smooth ramp in between.
+    const t = Math.min(1, streak / 6);
+    return RELAXED + (TIGHT - RELAXED) * t;
+  }
+
+  /**
+   * Number of DECOYS to interleave across the whole chart for the given streak:
+   *   streak 0    → 0 (only the correct words fall, in order — relaxed start)
+   *   streak 1..2 → 1 decoy in the sentence
+   *   streak >= 3 → 2 decoys in the sentence
+   * Capped by the available decoy pool.
+   */
+  private decoyCountForStreak(streak: number): number {
     const pool = this.round?.distractorWords.length ?? 0;
-    if (pool === 0) return 0;
-    const c = this.combo;
-    if (c < 3) return 0;
-    if (c < 7) {
-      // Ease in: ~60% chance of a single distractor in this band.
-      return Math.random() < 0.6 ? Math.min(1, pool) : 0;
-    }
-    // Hot: usually 1, sometimes 2 (fill both free lanes).
-    const want = Math.random() < 0.45 ? 2 : 1;
-    return Math.min(want, 2, pool);
+    if (pool === 0 || streak <= 0) return 0;
+    const want = streak >= 3 ? 2 : 1;
+    return Math.min(want, pool);
   }
 
   /**
-   * Spawn the next correct word (the catchable target) + 0..2 distractors in
-   * the OTHER lanes per the difficulty ramp. Exactly one catchable target card
-   * is in flight at a time (coherence contract).
+   * Lay out the ENTIRE target translation as a falling chart: each correct word
+   * is a note whose strum beat is `beatGap` after the previous one, in order.
+   * Decoys (per the streak ramp) are inserted at the midpoints BETWEEN correct
+   * beats, placed in a lane OTHER than the surrounding correct words so they
+   * read as dodge-me foils interleaved with the sequence. Notes derive their y
+   * each frame from (strumTime - now), so the whole chart is timed up front.
    */
-  private spawnStep() {
+  private buildChart() {
     if (!this.round) return;
-    if (this.caughtCount >= this.roundWords.length) return;
+    const words = this.roundWords;
+    if (!words.length) return;
 
-    const lanes = [0, 1, 2].sort(() => Math.random() - 0.5) as LaneIndex[];
-    const targetLane = lanes[0];
-    const seqIndex = this.caughtCount;
-    const targetWord = this.roundWords[seqIndex];
+    // Choose difficulty for THIS chart from the streak (reset on prior fail).
+    this.beatGap = this.beatGapForStreak(this.chartStreak);
+    const decoys = this.decoyCountForStreak(this.chartStreak);
 
-    const targetNote: Note = {
-      id: `note-${Date.now()}-${this.noteSeq++}-t`,
-      lane: targetLane,
-      y: -120,
-      text: targetWord,
-      isTarget: true,
-      seqIndex,
-      hit: false,
-      missed: false,
-      spawnTime: Date.now(),
-    };
+    const now = performance.now();
+    // Lead-in so the first word doesn't strum the instant the chart loads — give
+    // the player the full travel time plus a small beat to read the prompt.
+    const leadIn = now + this.NOTE_TRAVEL_SECONDS * 1000 + 450;
+    const gapMs = this.beatGap * 1000;
 
-    const notes: Note[] = [targetNote];
+    // Correct-word lanes: vary lane per word so the chart weaves across all
+    // three lanes (avoid a static single-lane column), never repeating the
+    // immediately previous lane.
+    const correctLanes: LaneIndex[] = [];
+    let prevLane = -1;
+    for (let i = 0; i < words.length; i++) {
+      let lane = Math.floor(Math.random() * 3);
+      if (lane === prevLane) lane = (lane + 1) % 3;
+      correctLanes.push(lane as LaneIndex);
+      prevLane = lane;
+    }
 
-    // Distractors: real target-language words NOT in this sequence, in the
-    // OTHER lanes. Drawn fresh each step so the foils vary.
-    const dCount = this.distractorCountForStep();
-    if (dCount > 0 && this.round.distractorWords.length) {
+    const notes: Note[] = [];
+    for (let i = 0; i < words.length; i++) {
+      const strumTime = leadIn + i * gapMs;
+      notes.push(
+        this.makeNote(words[i], correctLanes[i], true, i, strumTime)
+      );
+    }
+
+    // Interleave decoys: pick distinct gaps between correct beats, drop a foil
+    // at the midpoint of each chosen gap, in a lane different from BOTH adjacent
+    // correct words so it never collides with the catchable sequence.
+    if (decoys > 0 && words.length >= 2) {
       const pool = [...this.round.distractorWords].sort(
         () => Math.random() - 0.5
       );
-      for (let i = 0; i < dCount && i < lanes.length - 1; i++) {
-        const w = pool[i % pool.length];
-        if (!w) continue;
-        notes.push({
-          id: `note-${Date.now()}-${this.noteSeq++}-d${i}`,
-          lane: lanes[i + 1],
-          y: -120,
-          text: w,
-          isTarget: false,
-          seqIndex: -1,
-          hit: false,
-          missed: false,
-          spawnTime: Date.now(),
-        });
+      const gapIdx = Array.from({ length: words.length - 1 }, (_, k) => k).sort(
+        () => Math.random() - 0.5
+      );
+      const slots = Math.min(decoys, gapIdx.length, pool.length);
+      for (let s = 0; s < slots; s++) {
+        const g = gapIdx[s];
+        const word = pool[s];
+        if (!word) continue;
+        const strumTime = leadIn + (g + 0.5) * gapMs;
+        const taken = new Set([correctLanes[g], correctLanes[g + 1]]);
+        let lane = 0;
+        while (taken.has(lane as LaneIndex) && lane < 2) lane++;
+        notes.push(this.makeNote(word, lane as LaneIndex, false, -1, strumTime));
       }
     }
 
     this.notes.push(...notes);
-    this.stepActive = true;
+  }
+
+  /** Build a single chart note seeded above the screen; physics drives its y. */
+  private makeNote(
+    text: string,
+    lane: LaneIndex,
+    isTarget: boolean,
+    seqIndex: number,
+    strumTime: number
+  ): Note {
+    return {
+      id: `note-${Date.now()}-${this.noteSeq++}-${isTarget ? "t" : "d"}`,
+      lane,
+      y: -160,
+      text,
+      isTarget,
+      seqIndex,
+      hit: false,
+      missed: false,
+      spawnTime: Date.now(),
+      strumTime,
+    };
   }
 
   private setScore(value: number) {
@@ -434,27 +499,22 @@ export class Game {
   }
 
   /**
-   * Reveal the next word in the assembling target strip + advance the step.
-   * `caught` true = the player caught it (score/combo handled by the caller);
-   * false = it passed or the player missed it (we still reveal it so the phrase
-   * stays coherent and teaching continues). Spawns the next step or, when the
-   * sequence is complete, resolves the round.
+   * Advance the catch sequence by exactly one correct word: reveal it in the
+   * assembling strip and bump caughtCount. `caught` true = the player caught it
+   * (score/combo handled by the caller); false = the correct word sailed past
+   * (we still reveal it so the assembled phrase stays coherent and teaching
+   * continues). When the last correct word is consumed, resolves the round.
+   *
+   * Unlike the old one-at-a-time model this NEVER spawns — the whole chart is
+   * already in flight (buildChart). advanceStep only tracks SEQUENCE progress.
    */
   private advanceStep(caught: boolean) {
     if (!this.round) return;
-    // Strict per-step idempotency: a step is resolved exactly once. `stepActive`
-    // is set true only by spawnStep() and cleared here on the first call, so any
-    // re-entrant or delayed second call for the same step is a hard no-op. This
-    // closes every re-entrancy path into the caughtCount mutation below.
-    // (adversarial-review, PR #390)
-    if (!this.stepActive) return;
-    this.stepActive = false;
     // The sequence is already complete — never advance past the last word, so
     // caughtCount can't overshoot roundWords.length or corrupt the assembling
-    // strip / spawn state.
-    if (this.caughtCount >= this.roundWords.length) {
-      return;
-    }
+    // strip.
+    if (this.caughtCount >= this.roundWords.length) return;
+
     const idx = this.caughtCount;
     this.assembled.push(this.roundWords[idx]);
     this.hud.setAssembled(
@@ -462,19 +522,23 @@ export class Game {
       this.roundWords.length,
       this.activeLanguage.isRTL
     );
-    // Clamp the increment to the sequence length so caughtCount can never
-    // exceed roundWords.length even under a (guarded-against) re-entrant call.
     this.caughtCount = Math.min(this.caughtCount + 1, this.roundWords.length);
 
     if (this.caughtCount >= this.roundWords.length) {
       // Sequence complete — resolve the round and queue the next one.
       this.resolveRound(this.roundAllCaught ? "correct" : "wrong");
+      // STREAK: a fully-clean chart bumps the difficulty streak (tighter +
+      // more decoys next time); any fail this chart resets it to relaxed.
+      this.chartStreak = this.chartClean ? this.chartStreak + 1 : 0;
       this.nextSpawnTime = performance.now() + 1100;
       void caught;
-    } else {
-      // Brief beat between words so the catch reads as deliberate, not a stream.
-      this.nextSpawnTime = performance.now() + 320;
     }
+  }
+
+  /** Record a fail this chart: resets the difficulty streak for the next chart. */
+  private failChart() {
+    this.chartClean = false;
+    this.roundAllCaught = false;
   }
 
   /**
@@ -509,8 +573,8 @@ export class Game {
       lang: this.activeLanguage.code,
     };
 
-    if (hitNote && hitNote.isTarget) {
-      // CAUGHT the correct next word.
+    if (hitNote && hitNote.isTarget && hitNote.seqIndex === this.caughtCount) {
+      // CAUGHT the correct NEXT word in the sequence.
       hitNote.hit = true;
       hitNote.hitTime = performance.now();
       const points = 100 + this.combo * 10;
@@ -536,10 +600,10 @@ export class Game {
 
       this.advanceStep(true);
     } else if (hitNote && !hitNote.isTarget) {
-      // Tapped a DISTRACTOR — miss/penalty, combo breaks. The correct word
-      // keeps falling; the player can still catch it.
+      // Caught a DECOY — miss/penalty, combo breaks + difficulty streak resets.
+      // The correct words keep falling; the player can still catch them.
       hitNote.hit = true;
-      this.roundAllCaught = false;
+      this.failChart();
       this.setCombo(0);
       this.setScore(this.score - 40);
       this.bus.emit("noteMiss", {
@@ -551,15 +615,16 @@ export class Game {
         word,
       });
     } else {
-      // Empty lane tap. Only a *genuine* whiffed catch breaks the combo: there
-      // must be a live catchable target in flight (un-hit, un-missed) for the
-      // tap to count as a real gameplay error. Taps during the dead air between
-      // steps (no target on the board) are a no-op, so an accidental press in a
-      // gap doesn't punish the player. (adversarial-review, PR #390)
-      const liveTarget = this.notes.some(
-        (n) => n.isTarget && !n.hit && !n.missed
+      // Empty lane tap (or a tap that grabbed a not-yet-due correct note — we
+      // ignore those so the player isn't punished for tapping early on a future
+      // word). Only a *genuine* whiffed catch breaks the combo: the NEXT correct
+      // word must be live (un-hit, un-missed) for the tap to count as a real
+      // gameplay error. Taps during dead air are a no-op.
+      const liveNext = this.notes.some(
+        (n) => n.isTarget && n.seqIndex === this.caughtCount && !n.hit && !n.missed
       );
-      if (!liveTarget) return;
+      if (!liveNext) return;
+      this.failChart();
       this.setCombo(0);
       this.bus.emit("noteMiss", {
         lane,
@@ -581,7 +646,9 @@ export class Game {
     this.lastTimestamp = timestamp;
 
     if (this.state === GameState.PLAYING) {
-      // 1. SPAWNING — step / round cadence.
+      // 1. ROUND CADENCE — the whole chart is laid out by buildChart(); the loop
+      //    only gates loading the NEXT round after the current one resolves +
+      //    clears. No per-word spawning.
       if (!this.round) {
         // No active round (post-resolve gap): start the next one when due.
         if (timestamp > this.nextSpawnTime) {
@@ -596,51 +663,59 @@ export class Game {
           this.round = null;
           this.startRound();
         }
-      } else if (
-        !this.stepActive &&
-        !this.roundResolved &&
-        this.caughtCount < this.roundWords.length &&
-        timestamp > this.nextSpawnTime
-      ) {
-        this.spawnStep();
       }
 
-      // 2. PHYSICS — delta-timed falling motion (the hero).
+      // 2. PHYSICS — delta-timed falling motion (the hero). Chart notes derive
+      //    their y from their strum BEAT: y = strumY - (strumTime - now)*speed,
+      //    so the whole phrase falls on its pre-laid timeline. Notes without a
+      //    strumTime (legacy/defensive) fall by the old delta integration.
+      const now = performance.now();
       const boundsHeight = this.canvas.clientHeight;
       const strumY = this.laneSystem.getStrumLineY();
       const passLine = strumY + this.laneSystem.getNoteRadius() * 2.2;
 
       this.notes.forEach((note) => {
-        note.y += this.speed * dt;
+        if (note.hit) return;
+        if (typeof note.strumTime === "number") {
+          note.y = strumY - ((note.strumTime - now) / 1000) * this.speed;
+        } else {
+          note.y += this.speed * dt;
+        }
 
         if (note.y > boundsHeight + 120) note.missed = true;
 
-        if (note.isTarget && note.y > passLine && !note.hit && !note.missed) {
-          // The correct word sailed past the strum unhit → a miss. Combo
-          // breaks and the same point penalty as a wrong (distractor) catch
-          // applies, so missing the real answer is never lower-risk than
-          // whiffing a foil (symmetric miss contract). We reveal the word
-          // anyway (assembling strip) and advance so the phrase stays coherent
-          // and the player keeps learning. (adversarial-review, PR #390)
-          note.missed = true;
-          this.roundAllCaught = false;
-          this.setCombo(0);
-          this.setScore(this.score - 40);
-          this.bus.emit("noteMiss", {
-            lane: note.lane,
-            x: this.laneSystem.getLaneX(note.lane),
-            y: strumY,
-            reason: "passed",
-            mode: this.mode,
-            word:
-              this.currentWord ?? {
-                entryId: -1,
-                foreign: this.round?.targetText ?? "",
-                english: note.text,
-                lang: this.activeLanguage.code,
-              },
-          });
-          this.advanceStep(false);
+        if (note.y > passLine && !note.hit && !note.missed) {
+          if (note.isTarget && note.seqIndex === this.caughtCount) {
+            // The NEXT correct word sailed past the strum unhit → a miss. Combo
+            // breaks + difficulty streak resets, same penalty as catching a
+            // decoy (symmetric miss). We reveal the word anyway (assembling
+            // strip) and advance so the phrase stays coherent and the player
+            // keeps learning.
+            note.missed = true;
+            this.failChart();
+            this.setCombo(0);
+            this.setScore(this.score - 40);
+            this.bus.emit("noteMiss", {
+              lane: note.lane,
+              x: this.laneSystem.getLaneX(note.lane),
+              y: strumY,
+              reason: "passed",
+              mode: this.mode,
+              word:
+                this.currentWord ?? {
+                  entryId: -1,
+                  foreign: this.round?.targetText ?? "",
+                  english: note.text,
+                  lang: this.activeLanguage.code,
+                },
+            });
+            this.advanceStep(false);
+          } else {
+            // A decoy or an already-consumed/out-of-sequence note falling past
+            // the line is simply retired — no penalty (dodging a decoy is the
+            // correct play).
+            note.missed = true;
+          }
         }
       });
 

--- a/corpan/packs/lingo-hero/src/Game.ts
+++ b/corpan/packs/lingo-hero/src/Game.ts
@@ -257,6 +257,22 @@ export class Game {
 
     this.laneSystem.resize(width, height);
     this.speed = (height * 0.8 + 100) / this.NOTE_TRAVEL_SECONDS;
+
+    // Reserve a clear HUD band ABOVE the lanes: measure the bottom of the top
+    // HUD (prompt chip + exit/mute controls) and push it to the LaneSystem so
+    // the Renderer only draws notes BELOW it — notes emerge fully visible
+    // instead of spawning occluded behind the chip/audio button. Deferred to
+    // the next frame so the DOM HUD has laid out (fonts/safe-area applied).
+    this.measureHudBand();
+    requestAnimationFrame(() => this.measureHudBand());
+  }
+
+  /** Push the current DOM HUD band bottom into the LaneSystem (canvas-local). */
+  private measureHudBand() {
+    if (!this.hud) return;
+    const rect = this.canvas.getBoundingClientRect();
+    const bandBottom = this.hud.measureHudBandBottom({ top: rect.top });
+    this.laneSystem.setPlayTop(bandBottom);
   }
 
   private showMenu() {
@@ -284,6 +300,12 @@ export class Game {
     this.bus.emit("gameStart", { mode, language: this.activeLanguage });
     this.bus.emit("scoreChange", { value: 0, delta: 0 });
     this.bus.emit("comboChange", { value: 0, previous: 0 });
+
+    // The HUD is now visible (gameStart un-hides it). Re-measure the reserved
+    // HUD band so the play-area top reflects the real, laid-out prompt chip +
+    // controls before the first chart falls.
+    this.measureHudBand();
+    requestAnimationFrame(() => this.measureHudBand());
 
     try {
       await this.startRound();
@@ -362,6 +384,11 @@ export class Game {
     this.hud.setQuestion(this.cleanPrompt(round.promptText));
     this.hud.setRomanization(round.romanization ?? "");
     this.hud.setAssembled([], this.roundWords.length, this.activeLanguage.isRTL);
+
+    // The prompt chip + assembling strip just changed height for this round;
+    // re-measure the reserved HUD band next frame so the play-area top tracks
+    // the (possibly taller) prompt and notes still clear it.
+    requestAnimationFrame(() => this.measureHudBand());
 
     this.buildChart();
   }

--- a/corpan/packs/lingo-hero/src/LaneSystem.ts
+++ b/corpan/packs/lingo-hero/src/LaneSystem.ts
@@ -7,9 +7,16 @@ export class LaneSystem {
   // Logical scale (updated on resize)
   private canvasHeight: number = 0;
 
+  // Top of the clear PLAY AREA, in canvas-local px. The DOM HUD (prompt chip +
+  // exit/mute controls) occupies the band above this; falling notes are only
+  // drawn at/below it so they emerge fully visible BELOW the HUD instead of
+  // spawning occluded behind the chip/audio button. Game measures the HUD band
+  // each resize and pushes it here; 0 until then (no clip).
+  private playTopY: number = 0;
+
   // Visual config
   // Now relative to screen size instead of fixed pixels
-  private noteRadius: number = 40; 
+  private noteRadius: number = 40;
   private readonly STRUM_LINE_Y_RATIO = 0.8;
 
   constructor(width: number, height: number) {
@@ -46,7 +53,24 @@ export class LaneSystem {
   getStrumLineY(): number {
     return this.canvasHeight * this.STRUM_LINE_Y_RATIO;
   }
-  
+
+  /**
+   * Set the top of the clear play area (canvas-local px) — the baseline BELOW
+   * the DOM HUD band. Clamped to a sane range so a mis-measured HUD can never
+   * push the play-area top past the strum line (which would hide every note).
+   */
+  setPlayTop(y: number): void {
+    const strumY = this.getStrumLineY();
+    // Never eat more than the top ~55% of the track, and never go negative.
+    const cap = strumY > 0 ? strumY * 0.55 : this.canvasHeight * 0.44;
+    this.playTopY = Math.max(0, Math.min(y, cap));
+  }
+
+  /** Top of the clear play area (canvas-local px). Notes draw at/below this. */
+  getPlayTopY(): number {
+    return this.playTopY;
+  }
+
   getNoteRadius(): number {
     return this.noteRadius;
   }

--- a/corpan/packs/lingo-hero/src/Renderer.ts
+++ b/corpan/packs/lingo-hero/src/Renderer.ts
@@ -493,9 +493,33 @@ export class Renderer {
     const strumY = this.laneSystem.getStrumLineY();
     const r = this.laneSystem.getNoteRadius();
 
+    // PLAY-AREA CLIP — the DOM HUD (prompt chip + exit/mute controls) owns the
+    // band above `playTopY`; notes must NEVER draw into it (they'd render
+    // occluded behind the chip/audio button at spawn, shortening read-time).
+    // We clip BOTH note passes to [playTopY, height] and fade cards in over a
+    // short ramp just below the band so they emerge cleanly rather than popping.
+    const width = parseFloat(this.canvas.style.width);
+    const height = parseFloat(this.canvas.style.height);
+    const playTopY = this.laneSystem.getPlayTopY();
+    const fadeBand = Math.max(r * 1.1, 36); // soft entry ramp below the band
+    // Visibility of a card at screen-y `y`: 0 above the band, ramping to 1 over
+    // `fadeBand` px below it (so a note appears below the HUD, never inside it).
+    const bandAlpha = (y: number): number => {
+      if (playTopY <= 0) return 1;
+      if (y <= playTopY) return 0;
+      if (y >= playTopY + fadeBand) return 1;
+      return (y - playTopY) / fadeBand;
+    };
+
     // PASS 1 — additive motion trails behind every live note (comet tails that
     // brighten as they approach the strum line). One additive pass = cheap bloom.
+    // Clipped to the play area so trails never streak up behind the HUD.
     ctx.save();
+    if (playTopY > 0) {
+      ctx.beginPath();
+      ctx.rect(0, playTopY, width, height - playTopY);
+      ctx.clip();
+    }
     ctx.globalCompositeOperation = "lighter";
     for (const note of notes) {
       if (note.missed || note.hit || note.y < -50) continue;
@@ -519,12 +543,21 @@ export class Renderer {
     }
     ctx.restore();
 
-    // PASS 2 — glass cards (+ hit pop).
+    // PASS 2 — glass cards (+ hit pop). Clipped to the play area so a card's
+    // body/word can never bleed into the reserved HUD band.
+    ctx.save();
+    if (playTopY > 0) {
+      ctx.beginPath();
+      ctx.rect(0, playTopY, width, height - playTopY);
+      ctx.clip();
+    }
     for (const note of notes) {
       if (note.missed) continue;
       const cx = this.laneSystem.getLaneX(note.lane);
       const y = note.y;
       const c = this.laneColors[note.lane];
+      // Fade the card in as it crosses below the HUD band (0 inside the band).
+      const enter = bandAlpha(y);
 
       // HIT POP — quick expanding white core + lane ring, owned by Renderer so
       // the note's own light response reads instantly even before particles.
@@ -553,6 +586,9 @@ export class Renderer {
       }
 
       if (y < -50) continue;
+      // Fully inside the reserved HUD band — don't draw it at all (the clip
+      // would hide it anyway; this also skips the wasted gradient allocs).
+      if (enter <= 0) continue;
 
       const proximity = clamp01(1 - Math.abs(y - strumY) / (strumY + 1));
       const pulse = 0.5 + 0.5 * Math.sin(now * 0.011 + note.lane * 1.7);
@@ -586,7 +622,7 @@ export class Renderer {
         ctx.globalCompositeOperation = "lighter";
         const bloomR = cardW * (0.6 + proximity * 0.42);
         const bg = ctx.createRadialGradient(cx, y, 0, cx, y, bloomR);
-        bg.addColorStop(0, rgba(c, (0.13 + pulse * 0.04) * proximity));
+        bg.addColorStop(0, rgba(c, (0.13 + pulse * 0.04) * proximity * enter));
         bg.addColorStop(1, rgba(c, 0));
         ctx.fillStyle = bg;
         ctx.beginPath();
@@ -597,7 +633,7 @@ export class Renderer {
 
       // --- GLASS CARD BODY ---
       ctx.save();
-      ctx.globalAlpha = isTgt ? 1 : 0.9;
+      ctx.globalAlpha = (isTgt ? 1 : 0.9) * enter;
       // Outer neon glow on the card edge (scales with proximity, tightened so it
       // never bleeds over the word).
       ctx.shadowBlur = (8 + proximity * 12 + pulse * 3) * glowK;
@@ -642,6 +678,7 @@ export class Renderer {
       // --- WORD (single line, centered, always inside with padding) ---
       if (fontSize > 0) {
         ctx.save();
+        ctx.globalAlpha = enter;
         ctx.textAlign = "center";
         ctx.textBaseline = "middle";
         ctx.font = `bold ${fontSize}px ${wordFont}`;
@@ -654,6 +691,7 @@ export class Renderer {
         ctx.restore();
       }
     }
+    ctx.restore(); // close the PASS 2 play-area clip
   }
 }
 

--- a/corpan/packs/lingo-hero/src/Renderer.ts
+++ b/corpan/packs/lingo-hero/src/Renderer.ts
@@ -627,10 +627,16 @@ export class Renderer {
       roundRectPath(ctx, x, cardY, cardW, cardH, radius);
       ctx.stroke();
 
-      // Lane-color accent spine on the leading (left) edge.
+      // Lane-color accent spine on the leading (left) edge. CLIP to the card's
+      // rounded-rect so the spine's top/bottom follow the card's rounded corners
+      // EXACTLY (a plain bar would poke past the rounding). We clip to the full
+      // card path, then paint a left-edge band; the clip carves it to the curve.
+      ctx.save();
+      roundRectPath(ctx, x, cardY, cardW, cardH, radius);
+      ctx.clip();
       ctx.fillStyle = rgba(c, isTgt ? 0.95 : 0.6);
-      roundRectPath(ctx, x, cardY, 6, cardH, [radius, 0, 0, radius]);
-      ctx.fill();
+      ctx.fillRect(x, cardY, 6, cardH);
+      ctx.restore();
       ctx.restore();
 
       // --- WORD (single line, centered, always inside with padding) ---

--- a/corpan/packs/lingo-hero/src/styles.css
+++ b/corpan/packs/lingo-hero/src/styles.css
@@ -757,13 +757,81 @@ canvas {
   }
 }
 
+/* STATS STRIP — pulled OUT of the central play area. Default (tall screens):
+   docked just BELOW the hit-ring circles (the strum line sits at 80% height;
+   the rings have up to ~72px radius, so we anchor the strip in the bottom band
+   under them). It spans only a centered, content-width cluster so it never
+   flanks the falling-note lanes. pointer-events stay off for the strip itself;
+   the stat plates don't need interaction. */
+.lh-stats {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  /* Below the rings: strum line at 80% of height, ring radius up to ~72px → sit
+     the strip a touch under that, with a floor so it never hugs the very edge. */
+  top: min(calc(80% + 86px), calc(100% - 92px));
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  width: max-content;
+  max-width: min(94vw, 460px);
+  pointer-events: none;
+}
+
+/* Compact the moved-out stat plates so the strip stays a tidy cluster below the
+   rings instead of the old full-width banner. */
+.lh-stats .mastery-readout {
+  width: min(90vw, 320px);
+  align-self: center;
+  padding: 4px 12px;
+}
+.lh-stats .stat {
+  padding: 0.3rem 0.7rem;
+}
+.lh-stats .score-box .stat-value {
+  font-size: clamp(1.15rem, 5vmin, 1.7rem);
+}
+.lh-stats .combo-value #combo {
+  font-size: clamp(1.4rem, 6.5vmin, 2.3rem);
+}
+.lh-stats .combo-value .x {
+  font-size: clamp(0.85rem, 3.5vmin, 1.2rem);
+}
+
 /* Score + combo strip */
 .score-container {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-  width: 100%;
+  align-items: stretch;
+  justify-content: center;
+  gap: 10px;
+}
+
+/* Short / landscape screens: there isn't room below the rings, so collapse the
+   stats to a slim row pinned at the very TOP (above the prompt), still out of
+   the falling-note lanes' way. */
+@media (max-height: 560px) {
+  .lh-stats {
+    top: calc(var(--safe-top) + 6px);
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    max-width: min(96vw, 560px);
+  }
+  .lh-stats .mastery-readout {
+    width: auto;
+    max-width: 46vw;
+  }
+  .lh-stats .score-container {
+    gap: 8px;
+  }
+  .lh-stats .stat {
+    padding: 0.25rem 0.6rem;
+  }
+  /* Nudge the prompt stack down so the slim top stats row doesn't collide. */
+  .hud .top-bar {
+    margin-top: 40px;
+  }
 }
 
 .stat {

--- a/corpan/packs/lingo-hero/src/types.ts
+++ b/corpan/packs/lingo-hero/src/types.ts
@@ -38,6 +38,14 @@ export interface Note {
   missed: boolean; // Did it pass the line without a catch?
   spawnTime: number;
   hitTime?: number;
+  /**
+   * Wall-clock time (performance.now() ms) at which this note's center should
+   * cross the strum line — its "beat" in the falling chart. Physics derives the
+   * note's y each frame from (strumTime - now) and the fall speed, so the whole
+   * chart is laid out in TIME up front (true Guitar-Hero timing) rather than
+   * spawned one-at-a-time. Optional so any legacy/ad-hoc note still falls.
+   */
+  strumTime?: number;
 }
 
 export enum GameState {

--- a/corpan/packs/lingo-hero/src/ui/Hud.ts
+++ b/corpan/packs/lingo-hero/src/ui/Hud.ts
@@ -134,17 +134,23 @@ export class Hud {
             <div class="lh-assemble" id="lh-assemble" aria-live="polite" hidden></div>
           </div>
         </div>
-        <!-- (d) progress / mastery readout slot -->
-        <div class="mastery-readout" id="mastery-readout" aria-live="polite" hidden></div>
-        <div class="score-container">
-          <div class="stat score-box">
-            <span class="stat-label">Score</span>
-            <span class="stat-value" id="score">0</span>
-            <span class="score-flyout" id="score-flyout" aria-hidden="true"></span>
-          </div>
-          <div class="stat combo-box zero" id="combo-box">
-            <span class="stat-label">Combo</span>
-            <span class="combo-value"><span class="x">x</span><span id="combo">0</span></span>
+        <!-- STATS STRIP — moved OUT of the central play area so SCORE / COMBO /
+             progress never flank the falling-note lanes. On tall screens it
+             docks BELOW the hit-ring circles (near the bottom); on short
+             screens it collapses to a slim row at the very top. -->
+        <div class="lh-stats" id="lh-stats">
+          <!-- (d) progress / mastery readout slot -->
+          <div class="mastery-readout" id="mastery-readout" aria-live="polite" hidden></div>
+          <div class="score-container">
+            <div class="stat score-box">
+              <span class="stat-label">Score</span>
+              <span class="stat-value" id="score">0</span>
+              <span class="score-flyout" id="score-flyout" aria-hidden="true"></span>
+            </div>
+            <div class="stat combo-box zero" id="combo-box">
+              <span class="stat-label">Combo</span>
+              <span class="combo-value"><span class="x">x</span><span id="combo">0</span></span>
+            </div>
           </div>
         </div>
         <!-- (c) post-answer FEEDBACK card surface (foreign <-> english + state) -->

--- a/corpan/packs/lingo-hero/src/ui/Hud.ts
+++ b/corpan/packs/lingo-hero/src/ui/Hud.ts
@@ -55,6 +55,7 @@ export class Hud {
   private root: HTMLElement;
   private menuScreen: HTMLElement;
   private hudPanel: HTMLElement;
+  private topBar!: HTMLElement;
   private gameOverScreen: HTMLElement;
   private questionBox: HTMLElement;
   private romanizationEl: HTMLElement;
@@ -190,6 +191,7 @@ export class Hud {
 
     this.menuScreen = this.root.querySelector("#menu")!;
     this.hudPanel = this.root.querySelector("#hud")!;
+    this.topBar = this.root.querySelector(".top-bar")!;
     this.gameOverScreen = this.root.querySelector("#game-over")!;
     this.questionBox = this.root.querySelector("#question-box")!;
     this.romanizationEl = this.root.querySelector("#romanization-line")!;
@@ -399,6 +401,37 @@ export class Hud {
     this.root.setAttribute("dir", lang.isRTL ? "rtl" : "ltr");
     this.root.setAttribute("data-lang", lang.code);
     this.root.setAttribute("data-text-size", lang.textSize);
+  }
+
+  /**
+   * Measure the bottom of the HUD band — the y, in the canvas's LOCAL
+   * coordinate space, below which the falling-note play area is clear of every
+   * top HUD element. This reserves room for BOTH the centered prompt stack
+   * (instruction + question chip + romanization + assembling strip) AND the
+   * top-corner controls (exit / mute), so notes are never spawned occluded
+   * behind them. Returns a px offset from the canvas top (>= 0).
+   *
+   * `canvasRect` is the canvas's bounding rect; we subtract its top so the
+   * result is canvas-local (the canvas may be offset within the host
+   * container). The exit + mute controls live on `.ui-layer` at a fixed top
+   * inset; we read whichever live element sits lowest and add a small breathing
+   * gap so the first row of notes clears the HUD with margin.
+   */
+  measureHudBandBottom(canvasRect: { top: number }): number {
+    const gap = 14; // breathing room below the HUD before notes appear
+    let lowest = 0;
+    const consider = (el: Element | null) => {
+      if (!el) return;
+      const r = (el as HTMLElement).getBoundingClientRect();
+      if (r.height <= 0 && r.width <= 0) return; // hidden / not laid out
+      lowest = Math.max(lowest, r.bottom - canvasRect.top);
+    };
+    // Centered prompt stack (the source-sentence chip lives here).
+    consider(this.topBar);
+    // Top-corner controls: exit (in this.root) + mute (mounted on .ui-layer).
+    consider(this.root.querySelector("#lh-exit"));
+    consider(document.querySelector(".na-mute-toggle"));
+    return lowest > 0 ? lowest + gap : 0;
   }
 
   dispose(): void {

--- a/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
+++ b/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
@@ -1,5 +1,5 @@
 /**
- * Headless gameplay test for Lingo Hero — "CATCH THE TRANSLATION".
+ * Headless gameplay test for Lingo Hero — "CATCH THE TRANSLATION" (batch CHART).
  *
  * It drives the BUILT bundle in a real (headless) browser, in an app-like
  * OFFSET container, and asserts the core interaction contracts that humans kept
@@ -7,9 +7,11 @@
  * cannot "see" because nothing else actually PLAYS the game:
  *
  *   (a) MOTION IS REAL — a falling card's y INCREASES across sampled frames.
- *       (Catches the prior "frozen notes" no-ship bug head-on.)
- *   (b) CATCH SCORES — tapping the lane of the correct NEXT target word, at its
- *       visual position on the strum line, INCREASES the score. (input coords)
+ *       (Catches the prior "frozen notes" no-ship bug head-on; the chart now
+ *       times notes off their strum beat, so this guards that math too.)
+ *   (b) CATCH SCORES — tapping the lane of the correct NEXT target word (the
+ *       one with seqIndex === caughtCount), at its visual position on the strum
+ *       line, INCREASES the score. (input coords + catch-in-sequence)
  *   (c) NO TAP-THROUGH — tapping the on-screen mute control does NOT score.
  *
  * It also captures menu + gameplay screenshots (visual proof) into test/e2e/out/.
@@ -42,7 +44,7 @@ await page.screenshot({ path: join(outDir, "menu.png") });
 const read = () => page.evaluate(() => {
   const g = window.__lingoHero, ls = g.laneSystem, r = g.canvas.getBoundingClientRect();
   return {
-    score: g.score, strumY: ls.getStrumLineY(),
+    score: g.score, strumY: ls.getStrumLineY(), caughtCount: g.caughtCount,
     laneX: [ls.getLaneX(0), ls.getLaneX(1), ls.getLaneX(2)],
     canvas: { left: r.left, top: r.top },
     notes: (g.notes || []).map((n) => ({
@@ -93,14 +95,17 @@ else {
 }
 
 // --- Contract (b): catching the correct NEXT target word scores. -------------
-// Catch the catchable target card (isTarget) when it crosses the strum line, by
-// clicking ITS lane at the strum-line position. Do this for a couple of words so
-// we exercise the catch-in-sequence advance, asserting the score climbs.
+// The whole translation is laid out as a time-spaced chart; the catchable word
+// is the target note whose seqIndex === caughtCount. Click ITS lane at the
+// strum-line position when it arrives. Do this for a couple of words so we
+// exercise the catch-in-sequence advance, asserting the score climbs.
 let catches = 0;
-const deadline = Date.now() + 20000;
+const deadline = Date.now() + 25000;
 while (Date.now() < deadline && catches < 2) {
   const s = await read();
-  const t = s.notes.find((n) => n.isTarget && !n.hit && !n.missed);
+  const t = s.notes.find(
+    (n) => n.isTarget && n.seqIndex === s.caughtCount && !n.hit && !n.missed
+  );
   if (t && t.y >= s.strumY - 44 && t.y <= s.strumY + 44) {
     const before = s.score;
     if (catches === 0) await page.screenshot({ path: join(outDir, "gameplay.png") });


### PR DESCRIPTION
### **User description**
## Lingo Hero 0.4.0 — "Catch the Translation" matures into a true chart

Preview-channel pack release. Builds on the 0.3.0 "Catch the Translation" mechanic (#390), turning the one-word-at-a-time trickle into a proper Guitar-Hero-style falling chart and clearing the play field of stats. e2e passes; design-critic returned zero blockers; clearly better than 0.3.0 — shipping to the preview channel.

### What changed

**Batch-timed CHART spawn (replaces one-word-at-a-time).** At round start the entire target translation is laid out as a single falling chart: every word becomes a note, in order, spaced in *time* (vertical gap = the gap between strum beats, timed to a phrase tempo). Notes derive position from their strum beat (`y = strumY − (strumTime − now) · speed`), so the whole phrase rides one pre-laid timeline. The proven delta-timed motion, forgiving hit window, canvas-relative input, scoring/combo, and event/effects/audio streams are unchanged.

**Streak-driven difficulty (resets on fail).** Relaxed start: at streak 0 words are spaced far apart with zero decoys (only correct words, in order). As the clean-chart streak builds, inter-word spacing compresses toward a natural-speech tempo and decoys ramp `0 → 1 → 2` per sentence (wrong-target words in other lanes). Whiffing, missing a correct word, or catching a decoy resets spacing + decoys.

**Freed-center HUD — stats moved OUT of the play area.** The level/progress readout + SCORE + COMBO plates no longer flank the falling-note lanes. On tall screens they dock in a compact strip below the hit rings; on short/landscape they collapse to a slim top row. The prompt + assembling-phrase strip stay at top. Plus a follow-up fix so notes never spawn behind the prompt chip / mute button: the game measures the HUD band each resize/round and reserves a clear play area below it (`LaneSystem.setPlayTop`); the Renderer clips both note passes to that area and fades each card in just below the band.

**Accent-spine fix.** The lane-color spine on each word card's leading edge is now clipped to the card's rounded-rect, so its top/bottom follow the corner radius instead of poking past as a straight bar.

### Version
`manifest.json` 0.3.0 → 0.4.0. Scope is the lingo-hero pack only.

### Follow-up polish (filed, non-blocking)
Ship-review polish captured as tracked follow-ups rather than gating this release:
- #398 — relocate SCORE pill into player eyeline (surface streak/multiplier there)
- #399 — tighten note-tint == target-ring-tint so the catch lane is unambiguous
- #400 — give the assembled-words row its own band, separated from the source prompt capsule
- #401 — raise idle lane-line / funnel-guide contrast for bright outdoor screens
- #402 — add a count-in / first-note-incoming cue for the empty-field beat
- #403 — add a menu footer to balance the empty lower third
- #404 — unify caught-word chip styling with the falling-note visual language

### Credit
Mechanic + chart direction with @0bkevin.


___

### **PR Type**
Enhancement, Bug fix, Tests, Documentation


___

### **Description**
- Adds batch-timed falling translation charts

- Ramps difficulty through clean-chart streaks

- Moves stats outside play lanes

- Reserves HUD band for note visibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Round["Round translation"]
  Chart["Timed falling chart"]
  Player["Ordered catches"]
  Streak["Streak difficulty"]
  HUD["Clear HUD band"]
  Render["Clipped note rendering"]
  Round -- "lays out words" --> Chart
  Chart -- "requires next seqIndex" --> Player
  Player -- "clean or fail" --> Streak
  HUD -- "sets play top" --> Render
  Render -- "keeps notes visible" --> Player
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>Game.ts</strong><dd><code>Builds batch-timed chart gameplay flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/405/files#diff-6c075e8c51d32e4e5452a4c738f6cc530345361455286e0f7d1af37f46fedde7">+253/-151</a></td>

</tr>

<tr>
  <td><strong>LaneSystem.ts</strong><dd><code>Tracks reserved play-area top boundary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/405/files#diff-49208e8c6b4d3a2cbe84d78c7e15bd2cf92174f83b0eeb9992687c59a0375125">+26/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Adds timed strum beat metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/405/files#diff-90db924f79313d23c6eada5092c9adb12ccb7ceb3a47dcd832071a22448af88b">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Hud.ts</strong><dd><code>Relocates stats and measures HUD band</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/405/files#diff-145e656a10e1e233418a8c559a94e938bf0e0c922802aa2f87d69b0498a38c02">+50/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>styles.css</strong><dd><code>Styles docked stats strip layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/405/files#diff-b9b9a82cd5a6b2fe32239b2b4b2f069c2c4853d63db1736b575103a5d1daf226">+72/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Renderer.ts</strong><dd><code>Clips notes below HUD band</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/405/files#diff-a8ca1f488ce07a5bfdd1fbb0851ce6f79a8731c3dacfe7d692d733838b839a53">+50/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Documents 0.4.0 chart release fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/405/files#diff-dd09bf20e11864991961b7ef6d2fc6687a66d9a9de2d246f765d9d6891e646c2">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>manifest.json</strong><dd><code>Bumps preview pack to 0.4.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/405/files#diff-38411e79d50eee7f8ad439a29518dcddf16cdc9cd03739fc81ea212f18519b15">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>gameplay.spec.mjs</strong><dd><code>Tests chart scoring and tap-through</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/405/files#diff-5ee22f0c6a817c0427478004e2238facf99cd3c18591eda51d590170655a3c57">+15/-10</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

