### PR TITLE
Fix playback click/pop on seek & language switch (stargate + earthgate readers)

### DIFF
--- a/corpan/packs/earthgate-reader/CHANGELOG.md
+++ b/corpan/packs/earthgate-reader/CHANGELOG.md
@@ -10,6 +10,8 @@ Conventions: `corpan/CHANGELOGS.md`.
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-06-23
+
 ### Fixed
 - **No more click/pop when scrubbing or switching narration language.**
   Seeking and language switches cut the playing source off mid-waveform and

--- a/corpan/packs/earthgate-reader/CHANGELOG.md
+++ b/corpan/packs/earthgate-reader/CHANGELOG.md
@@ -11,6 +11,12 @@ Conventions: `corpan/CHANGELOGS.md`.
 ## [Unreleased]
 
 ### Fixed
+- **No more click/pop when scrubbing or switching narration language.**
+  Seeking and language switches cut the playing source off mid-waveform and
+  started the new one at full amplitude, producing an audible click. The audio
+  engine now gives each source its own gain envelope: the outgoing source fades
+  to silence before it stops and the incoming source ramps up from zero, so
+  there is never a hard discontinuity on seek or language switch.
 - **Book owners now download the full narration, not the preview.** Two-ZIP
   premium entries signed the full ZIP only for Corpán Plus subscribers; a
   one-time book owner without Plus got the truncated preview and the upgrade

--- a/corpan/packs/earthgate-reader/manifest.json
+++ b/corpan/packs/earthgate-reader/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "earthgate_reader",
   "name": "Earthgate Reader",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Calm, earth-toned audiobook reader with word-level highlighting synced to narrated audio",
   "entry": "dist/app.js",
   "styles": [

--- a/corpan/packs/shared/audio/audioEngine.ts
+++ b/corpan/packs/shared/audio/audioEngine.ts
@@ -62,7 +62,18 @@ export function createAudioEngine(
   let analyser: AnalyserNode | null = null
   let gainNode: GainNode | null = null
   let currentSource: AudioBufferSourceNode | null = null
+  // Per-source gain node, inserted between each source and the master gainNode.
+  // Gives every source an independent fade envelope so a seek/switch can fade
+  // the outgoing source to 0 while the incoming source ramps up from 0 —
+  // without the two ramps fighting over one shared gain param.
+  let currentSourceGain: GainNode | null = null
   let playing = false
+  // When set, the next source `playSegment` starts is a discontinuity (seek,
+  // resume, language switch) rather than a smooth segment-to-segment handoff,
+  // so it must ramp gain up from ~0 to avoid a click. Cleared once consumed.
+  // Normal segment handoffs leave this false: gain stays pinned at 1.0 so we
+  // don't chop a dip into the start of every segment.
+  let fadeInNextStart = false
   let waitingForNextSegment = false
   let waitingOwnerGeneration: number | null = null
   let nextSegmentTimer: ReturnType<typeof setTimeout> | null = null
@@ -140,6 +151,8 @@ export function createAudioEngine(
     // Invalidate stale source/state from dead context
     outputLatencyLoggedOnce = false
     currentSource = null
+    currentSourceGain = null
+    fadeInNextStart = false
 
     waitingForNextSegment = false
     waitingOwnerGeneration = null
@@ -269,34 +282,43 @@ export function createAudioEngine(
 
     if (!currentSource) return
     const source = currentSource
+    const sourceGain = currentSourceGain
     currentSource = null  // release the reference immediately so callers see "not playing"
+    currentSourceGain = null
 
-    if (fadeMs > 0 && ctx && gainNode) {
+    if (fadeMs > 0 && ctx && sourceGain) {
       const now = ctx.currentTime
       const end = now + fadeMs / 1000
       try {
-        gainNode.gain.cancelScheduledValues(now)
-        // Pin the current value so the ramp starts from wherever we actually are.
-        gainNode.gain.setValueAtTime(gainNode.gain.value, now)
+        // Ramp this source's OWN gain to silence — independent of the master
+        // gain and of any incoming source's fade-in, so a seek/switch can
+        // overlap the two without one ramp clobbering the other.
+        sourceGain.gain.cancelScheduledValues(now)
+        sourceGain.gain.setValueAtTime(sourceGain.gain.value, now)
         // linearRampToValueAtTime requires a non-zero target.
-        gainNode.gain.linearRampToValueAtTime(0.0001, end)
+        sourceGain.gain.linearRampToValueAtTime(0.0001, end)
         source.stop(end)
         // Don't disconnect yet — disconnect would cut the source off from the
         // graph before the ramp finishes. Let the source play through to `end`,
         // then detach it. setTimeout uses ms, Web Audio uses seconds.
         setTimeout(() => {
           try { source.disconnect() } catch { /* already gone */ }
+          try { sourceGain.disconnect() } catch { /* already gone */ }
         }, fadeMs + 5)
       } catch (e) {
         console.warn("[audio] fade-stop failed, hard-stopping:", e)
         try { source.stop() } catch { /* already stopped */ }
         try { source.disconnect() } catch { /* already disconnected */ }
+        try { sourceGain.disconnect() } catch { /* already disconnected */ }
       }
       return
     }
 
     try { source.stop() } catch (e) { console.warn("[audio] source.stop():", e) }
     try { source.disconnect() } catch (e) { console.warn("[audio] source.disconnect():", e) }
+    if (sourceGain) {
+      try { sourceGain.disconnect() } catch (e) { console.warn("[audio] sourceGain.disconnect():", e) }
+    }
   }
 
   /**
@@ -468,15 +490,38 @@ export function createAudioEngine(
 
     const source = context.createBufferSource()
     source.buffer = buffer
-    source.connect(gainNode)
+
+    // Each source gets its own gain node so its fade envelope is independent of
+    // any outgoing source still fading out (seek / switch overlap).
+    const sourceGain = context.createGain()
+    source.connect(sourceGain)
+    sourceGain.connect(gainNode)
+
+    // If this start follows a discontinuity (seek / resume / narration switch),
+    // ramp this source up from near-silence so it doesn't pop in at full
+    // amplitude mid-waveform. Smooth segment handoffs skip this (gain starts at
+    // 1.0) so continuous playback isn't notched at every segment boundary.
+    if (fadeInNextStart) {
+      fadeInNextStart = false
+      const now = context.currentTime
+      try {
+        sourceGain.gain.setValueAtTime(0.0001, now)
+        sourceGain.gain.linearRampToValueAtTime(1.0, now + FADE_MS / 1000)
+      } catch (e) { console.warn("[audio] seek/switch fade-in failed:", e) }
+    } else {
+      sourceGain.gain.value = 1.0
+    }
 
     segmentStartedAtCtxTime = context.currentTime
     segmentPlaybackOffset = clampedOffset
     accumulatedTimeMs = segmentAbsoluteStartMs[index]
 
     source.onended = () => {
+      // Detach this source's gain node from the graph so it doesn't leak.
+      try { sourceGain.disconnect() } catch { /* already gone */ }
       if (currentSource === source) {
         currentSource = null
+        currentSourceGain = null
       }
       if (disposed || !playing || gen !== playbackGeneration) return
 
@@ -488,6 +533,7 @@ export function createAudioEngine(
 
     source.start(0, clampedOffset / 1000)
     currentSource = source
+    currentSourceGain = sourceGain
 
     waitingForNextSegment = false
     waitingOwnerGeneration = null
@@ -526,17 +572,11 @@ export function createAudioEngine(
 
       // Symmetric fade-in to match the out-fade in stopSource — avoids the
       // click on resume/narration-switch that would otherwise pair with the
-      // fade-out click we just eliminated.
-      if (context && gainNode) {
-        const now = context.currentTime
-        try {
-          gainNode.gain.cancelScheduledValues(now)
-          gainNode.gain.setValueAtTime(0.0001, now)
-          gainNode.gain.linearRampToValueAtTime(1.0, now + FADE_MS / 1000)
-        } catch (e) { console.warn("[audio] fade-in failed:", e) }
-      }
-
+      // fade-out click we just eliminated. The per-source gain (set in
+      // playSegment when fadeInNextStart is armed) carries the ramp; the master
+      // gainNode stays pinned at 1.0.
       playing = true
+      fadeInNextStart = true
       playSegment(currentSegmentIndex, segmentPlaybackOffset)
     },
 
@@ -572,7 +612,10 @@ export function createAudioEngine(
       playing = false
       playbackGeneration++
 
-      stopSource()
+      // Fade the outgoing source to silence before stopping (anti-click on the
+      // old position) and ramp the new one up from 0 (anti-click on the new
+      // position). Without the fades a scrub cuts/starts mid-waveform → pop.
+      stopSource(wasPlaying ? FADE_MS : 0)
 
       currentSegmentIndex = Math.max(0, Math.min(index, segments.length - 1))
       segmentPlaybackOffset = 0
@@ -580,6 +623,7 @@ export function createAudioEngine(
 
       if (wasPlaying) {
         playing = true
+        fadeInNextStart = true
         playSegment(currentSegmentIndex)
       }
     },
@@ -590,7 +634,8 @@ export function createAudioEngine(
       playing = false
       playbackGeneration++
 
-      stopSource()
+      // See seekToSegment — fade out the old source, ramp in the new one.
+      stopSource(wasPlaying ? FADE_MS : 0)
 
       const { index: segIdx, offsetMs: offsetWithinSegment } = resolveSeekTarget(targetMs)
 
@@ -600,6 +645,7 @@ export function createAudioEngine(
 
       if (wasPlaying) {
         playing = true
+        fadeInNextStart = true
         playSegment(segIdx, offsetWithinSegment)
       }
     },
@@ -608,7 +654,9 @@ export function createAudioEngine(
       // Invalidate any pending async playback
       playbackGeneration++
 
-      stopSource()
+      // Paused-scrub preview: no audio is playing so a hard stop won't click,
+      // but if a source is somehow live (race), fade it.
+      stopSource(currentSource ? FADE_MS : 0)
 
       const { index: segIdx, offsetMs: offsetWithinSegment } = resolveSeekTarget(targetMs)
 

--- a/corpan/packs/stargate-reader/CHANGELOG.md
+++ b/corpan/packs/stargate-reader/CHANGELOG.md
@@ -10,6 +10,8 @@ Conventions: `corpan/CHANGELOGS.md`.
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-06-23
+
 ### Fixed
 - **No more click/pop when scrubbing or switching narration language.**
   Seeking and language switches cut the playing source off mid-waveform and

--- a/corpan/packs/stargate-reader/CHANGELOG.md
+++ b/corpan/packs/stargate-reader/CHANGELOG.md
@@ -11,6 +11,12 @@ Conventions: `corpan/CHANGELOGS.md`.
 ## [Unreleased]
 
 ### Fixed
+- **No more click/pop when scrubbing or switching narration language.**
+  Seeking and language switches cut the playing source off mid-waveform and
+  started the new one at full amplitude, producing an audible click. The audio
+  engine now gives each source its own gain envelope: the outgoing source fades
+  to silence before it stops and the incoming source ramps up from zero, so
+  there is never a hard discontinuity on seek or language switch.
 - **Book owners now download the full narration, not the preview.** Two-ZIP
   premium entries signed the full ZIP only for Corpán Plus subscribers; a
   one-time book owner without Plus got the truncated preview and the upgrade

--- a/corpan/packs/stargate-reader/manifest.json
+++ b/corpan/packs/stargate-reader/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "stargate_reader",
   "name": "Stargate Reader",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Immersive 3D audiobook: words stream through space in sync with narrated audio",
   "entry": "dist/app.js",
   "styles": [


### PR DESCRIPTION
### **User description**
## What

Fixes audible click/pop in **both reader packs** (`stargate-reader`, `earthgate-reader`) when:
- **scrubbing/seeking** the timeline, and
- **switching narration language**

This is a **playback-time** anti-click fix in the shared Web Audio engine (`corpan/packs/shared/audio/audioEngine.ts`), distinct from the generation-time Chatterbox declick.

## Root cause

The engine cut the playing `AudioBufferSourceNode` off mid-waveform on seek (`stopSource()` with no fade) and started the new source at full amplitude (the fade-in lived only in the public `play()` method, not in the seek-restart path). Both endpoints produced a hard discontinuity → click. Language-switch was already faded out via `dispose()` + faded back in via the new engine's `play()`, but resume/restart fade-in was inconsistent.

## Fix

Give **each source its own gain node** (`source → sourceGain → master gain → analyser → destination`) so every source has an independent fade envelope and an outgoing fade can overlap an incoming fade without the two ramps fighting over one shared param:

- `stopSource(fadeMs)` ramps the **per-source** gain to silence before `stop()` (was ramping the shared master gain).
- `seekToMs` / `seekToSegment` fade the outgoing source out (when playing) and arm a fade-in on the next source start.
- `playSegment` ramps a source up from ~0 **only when the start follows a discontinuity** (seek / resume / switch) via a `fadeInNextStart` flag; smooth segment-to-segment handoffs keep gain pinned at 1.0 so continuous playback isn't notched at every segment boundary.
- `play()` routes its resume fade-in through the same per-source path.

Fade length unchanged (`FADE_MS = 15`, imperceptible as a fade).

## Build / verification

- Both packs rebuilt (`dist/` + `manifest.devRevision` updated, per repo convention for pack changes).
- `vite build` clean for both packs (Node 20).
- No new TypeScript errors introduced in `audioEngine.ts`. (Pre-existing `npm run typecheck` errors live in unrelated `shared/**` test files missing devDep type decls; CI's changed-packs gate runs `tsc --if-present`, and these packs have no `tsc` script, so it is not gated.)

## Needs human

These are **stable, shipped packs**. The click is an audio-perception issue — **please ear-check seek + language-switch on a real device** before merging. Do **not** auto-merge.

Refs #372


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Use per-source gain envelopes

- Fade outgoing audio on seeks

- Fade incoming discontinuity starts

- Update reader changelogs and revisions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Seek or language switch"]
  B["Outgoing source gain"]
  C["Incoming source gain"]
  D["Smooth playback"]
  A -- "fade out" --> B
  A -- "fade in" --> C
  B -- "avoids hard stop" --> D
  C -- "avoids full-volume start" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>audioEngine.ts</strong><dd><code>Add per-source fades for playback discontinuities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/408/files#diff-d7416617fa2a6899b2f0dd965d379cd0635d28f04e151ed682e28405ccebdffc">+67/-19</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>manifest.json</strong><dd><code>Bump Stargate reader development revision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/408/files#diff-e5de46972a41d2007641306956b6a25b0562ce91f2b8a5cd708b99c89b9163f9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>manifest.json</strong><dd><code>Bump Earthgate reader development revision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/408/files#diff-29cbfe06038df2bf292991b2f9588591012ebd43747c82242b6ce4f6bb33fd24">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document Earthgate audio click fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/408/files#diff-35c4f143ae27a4fed1c4ecb6e131162e40d1631c1355c328accfe09521f50f71">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document Stargate audio click fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/408/files#diff-7306fca8553bd01e7a3589a0cfdcea30f52b676f181b8ea9db054f96d7093dd1">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Build artifacts</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>app.js</strong><dd><code>Rebuild Earthgate bundled application script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/408/files#diff-889a3bcbd51beb93cef05a4a4d5bf6eda3d0309c345c8fa88277c183fe25d72c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app.css</strong><dd><code>Rebuild Earthgate bundled stylesheet asset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/408/files#diff-e8be06f277e283134084dc88ee5a93e6fe24bc6361f11c1684998d020f824e72">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app.css</strong><dd><code>Rebuild Stargate bundled stylesheet asset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/408/files#diff-6c4cb456445c01c1e176acbfcfd994a8c1a56002c0bebed7c3043fa674a3d7df">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>app.js</strong></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/408/files#diff-06adb6a28842d1f0e37a5b5ae64fc39f5d188484c8d6eeee53bd8e439cccb51f">+897/-897</a></td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

