### PR TITLE
beatlounge: on-device fixes — scratch empty-state + voice-switcher overflow

### DIFF
--- a/corpan/packs/beatlounge/CHANGELOG.md
+++ b/corpan/packs/beatlounge/CHANGELOG.md
@@ -26,6 +26,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (`rollDraftWorld` / `buildSnapshotFromDraft`); `buildRandomSnapshot` is now a
   thin all-random wrapper. (Beat-Lounge-Plus; closes #326.)
 
+### Fixed
+- Scratch empty-state no longer looks broken: with an empty bank the idle
+  turntable always renders (instead of a "nothing here" screen), the Effects /
+  Phrases toggle is no longer stuck, and tapping "Pick snippet" opens the Phrases
+  loader instead of an empty dropdown. (Beat-Lounge-Plus)
+- Home voice switcher: a long instrument name no longer pushes the next arrow off
+  the safe screen zone — the name truncates in a stable-width slot and the arrows
+  hold their position. (Beat-Lounge-Plus)
+
 ## [0.3.2] - 2026-06-19
 
 ### Changed

--- a/corpan/packs/beatlounge/src/modules/phrase-scratch/PhraseScratchImmersive.tsx
+++ b/corpan/packs/beatlounge/src/modules/phrase-scratch/PhraseScratchImmersive.tsx
@@ -159,8 +159,11 @@ export const PhraseScratchImmersive = ({ host, store, audioSource }: Props) => {
   // The master chain is persisted (localStorage) so a rack you dial in survives
   // leaving the pack and coming back — restored on mount, saved on every change.
   const [fxChain, setFxChain] = useState<EffectNode[]>(() => loadScratchChain())
-  const [drawerTab, setDrawerTab] = useState("fx")
-  const [drawer, setDrawer] = useState<DrawerState>("peek")
+  // Empty bank ⇒ open the drawer on Phrases so the first phrase is one tap away.
+  // The idle turntable still renders above (the deck is never hidden), so the
+  // surface never looks "broken/gone" — you just have nothing on the platter yet.
+  const [drawerTab, setDrawerTab] = useState(() => (bank.length === 0 ? "phrases" : "fx"))
+  const [drawer, setDrawer] = useState<DrawerState>(() => (bank.length === 0 ? "open" : "peek"))
   // Which deck a discovered phrase lands on (A unless the user aims B).
   const [aimDeck, setAimDeck] = useState<DeckId>("a")
   const fxBusRef = useRef<ScratchFxBus | null>(null)
@@ -630,30 +633,10 @@ export const PhraseScratchImmersive = ({ host, store, audioSource }: Props) => {
     },
   ]
 
-  // ---- empty state: no snippet yet. Keep the shared drawer mounted (open on
-  // Phrases) so the user can DISCOVER + load their first phrase right here. -----
-  if (bank.length === 0) {
-    return (
-      <div className="bl-scr">
-        <div className="bl-scr-empty">
-          <Glyph name="wave" size={28} />
-          <p className="bl-scr-empty-title">{ct("scratch.nothingOnDeck")}</p>
-          <p className="bl-scr-empty-sub">
-            {ct("scratch.openPhrasesToLoad")}
-          </p>
-        </div>
-        <TrackDrawer
-          label={ct("scratch.tools")}
-          tabsLabel={ct("scratch.tools")}
-          tabs={drawerTabs}
-          activeTab="phrases"
-          onTab={openDrawer}
-          state={drawer === "peek" ? "open" : drawer}
-          setState={setDrawer}
-        />
-      </div>
-    )
-  }
+  // NOTE: an empty bank is NOT a special early-return anymore — the deck below
+  // renders an idle turntable (loadDeck no-ops on a null selection) and the drawer
+  // opens on Phrases (see the drawerTab/drawer inits), so the turntable is ALWAYS
+  // visible and the Effects/Phrases toggle is never stuck.
 
   const renderDeck = (
     id: DeckId,
@@ -675,7 +658,13 @@ export const PhraseScratchImmersive = ({ host, store, audioSource }: Props) => {
             className="bl-scr-picker-btn"
             aria-haspopup="listbox"
             aria-expanded={pickerFor === id}
-            onClick={() => setPickerFor((v) => (v === id ? null : id))}
+            // Empty bank ⇒ there's nothing to pick; route the tap to the Phrases
+            // loader instead of opening an empty (useless) dropdown.
+            onClick={() =>
+              bank.length === 0
+                ? openDrawer("phrases")
+                : setPickerFor((v) => (v === id ? null : id))
+            }
             title={ct("scratch.chooseSnippet")}
           >
             <span className="bl-scr-picker-cur" lang={selected?.language}>
@@ -685,7 +674,7 @@ export const PhraseScratchImmersive = ({ host, store, audioSource }: Props) => {
           </button>
         </div>
 
-        {pickerFor === id && (
+        {pickerFor === id && bank.length > 0 && (
           <div
             className="bl-scr-picker"
             role="listbox"

--- a/corpan/packs/beatlounge/src/styles.css
+++ b/corpan/packs/beatlounge/src/styles.css
@@ -275,32 +275,49 @@
   align-items: baseline;
   gap: var(--bl-s4);
   margin-bottom: var(--bl-s5);
+  /* let children shrink instead of overflowing (the stage clips horizontal) */
+  min-width: 0;
 }
 .bl-song-name {
   font-family: var(--bl-font-mono);
   font-size: var(--bl-fs-label);
   color: var(--bl-text-dim);
   letter-spacing: 0.04em;
+  /* the song name absorbs tight space first (truncates) so it never pushes the
+     voice switcher's arrows off the safe zone */
+  min-width: 0;
+  flex: 0 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-/* Home voice switcher — prev / name / next, trailing edge of the Stage head */
+/* Home voice switcher — prev / name / next, trailing edge of the Stage head.
+   The switcher is a STABLE size and never shrinks, so the arrows hold their
+   position regardless of the voice name's length. */
 .bl-voice-switch {
   display: inline-flex;
   align-items: center;
   gap: 4px;
   margin-inline-start: auto;
   align-self: center;
+  flex: 0 0 auto;
+  max-width: 100%;
 }
 .bl-voice-arrow {
   min-width: calc(var(--bl-hit) * 0.72);
   min-height: calc(var(--bl-hit) * 0.72);
+  /* arrows never shrink or move — they are the fixed frame around the name */
+  flex: 0 0 auto;
 }
 .bl-voice-name {
   font-family: var(--bl-font-mono);
   font-size: var(--bl-fs-label);
   color: var(--bl-text);
   letter-spacing: 0.02em;
-  min-width: 7ch;
-  max-width: 16ch;
+  /* ONE stable width (not min/max) so the next arrow sits at a fixed x; long
+     names truncate with an ellipsis rather than pushing the arrow off-screen */
+  width: clamp(5ch, 20vw, 11ch);
+  flex: 0 0 auto;
   text-align: center;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
### **User description**
Two small polish fixes surfaced while testing the merged home/scratch work **on device** (Ian confirmed both on an iPhone 16 Pro Max).

## Scratch empty-state
With an **empty bank** the surface looked broken — no turntable, a dead "nothing here" screen, the Effects/Phrases toggle stuck, and the deck picker opening an empty dropdown. Now:
- the **idle turntable always renders** (`loadDeck` already no-ops on a null selection — no crash),
- the drawer **opens on Phrases** so the first phrase is one tap away,
- the Effects/Phrases toggle is **bound to state** (no longer hardcoded/stuck),
- **"Pick snippet"** routes to the **Phrases loader** instead of an empty dropdown.

## Voice-switcher overflow (fix to the merged #375)
A long instrument name pushed the **next arrow off the safe screen zone** (the Stage clips horizontal overflow). Now the voice name lives in a **stable-width, truncating** slot and the **arrows never shrink**, so they hold position; the **song name** absorbs tight space instead.

## Gates
- `npm run typecheck` — clean
- `npm run test` — **1307 passed**
- `npm run build` — clean

## Scope
Pack-only (`corpan/packs/beatlounge`). No `model/` spine change, no manifest/version change. Two files: `PhraseScratchImmersive.tsx`, `styles.css`.

_Relates to Sky's #396 (scratch perf is separate). Device-tested; leaving open for final human review._


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Keep idle scratch turntable visible

- Open phrases drawer for empty banks

- Prevent voice switcher overflow

- Document on-device fixes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  emptyBank["Empty scratch bank"]
  idleDeck["Idle turntable"]
  phrasesDrawer["Phrases drawer"]
  stageHead["Stage head"]
  voiceSwitcher["Stable voice switcher"]
  changelog["Changelog"]
  emptyBank -- "keeps visible" --> idleDeck
  emptyBank -- "opens" --> phrasesDrawer
  stageHead -- "contains" --> voiceSwitcher
  voiceSwitcher -- "truncates long names" --> stageHead
  idleDeck -- "documented in" --> changelog
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PhraseScratchImmersive.tsx</strong><dd><code>Keep scratch deck usable when empty</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/modules/phrase-scratch/PhraseScratchImmersive.tsx

<ul><li>Initializes empty banks with the drawer open on <code>phrases</code>.<br> <li> Removes the empty-bank early return so the idle turntable remains <br>visible.<br> <li> Routes <code>Pick snippet</code> clicks to the Phrases loader when no bank items <br>exist.<br> <li> Suppresses rendering an empty picker dropdown.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/414/files#diff-d99d0e0a7b507e7bdd422b2910e3f1a981db013bbdee747b0b8e247c177d0198">+17/-28</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>styles.css</strong><dd><code>Stabilize voice switcher Stage layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/styles.css

<ul><li>Allows Stage header children to shrink without horizontal overflow.<br> <li> Makes the song name truncate before affecting controls.<br> <li> Keeps voice switcher arrows fixed and non-shrinking.<br> <li> Uses a stable clamped width for truncating voice names.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/414/files#diff-582c6e13b0ed866e3e1441a6007e17cb088593ee8ae83e4a60725bf7e639878d">+20/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document scratch and voice switcher fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/CHANGELOG.md

<ul><li>Documents the fixed scratch empty-state behavior.<br> <li> Notes that long voice names now truncate safely.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/414/files#diff-83e97c4e36caca34711c70ef258b21b23e7362bf0f79b312a22fb2679ced8def">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

