### PR TITLE
Fix end-of-book 'Up next' loop between two items (#381)

### DIFF
--- a/corpan/packs/earthgate-reader/CHANGELOG.md
+++ b/corpan/packs/earthgate-reader/CHANGELOG.md
@@ -10,6 +10,16 @@ Conventions: `corpan/CHANGELOGS.md`.
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-06-23
+
+### Fixed
+- **End-of-book "Up next" no longer loops between two books (#381).**
+  `chooseNextBook` now reads on-device reading history (the progress store) and
+  never re-suggests the just-finished or any completed book, deprioritizes
+  recently-read / in-progress titles, and randomizes across the newest few
+  eligible candidates — so finishing book A then book B can't ping-pong back to
+  A. Near-term anti-loop heuristic; superseded by the data-driven engine (#380).
+
 ## [0.7.2] - 2026-06-23
 
 ### Fixed
@@ -30,12 +40,6 @@ Conventions: `corpan/CHANGELOGS.md`.
   it without ever opening the drawer left the catalog unfetched, so the
   suggestion silently no-op'd; the `corpan:book-finished` handler now
   lazy-hydrates the catalog before choosing the next book.
-- **End-of-book "Up next" no longer loops between two books (#381).**
-  `chooseNextBook` now reads on-device reading history (the progress store) and
-  never re-suggests the just-finished or any completed book, deprioritizes
-  recently-read / in-progress titles, and randomizes across the newest few
-  eligible candidates — so finishing book A then book B can't ping-pong back to
-  A. Near-term anti-loop heuristic; superseded by the data-driven engine (#380).
 
 ## [0.7.1] - 2026-06-19
 

--- a/corpan/packs/earthgate-reader/CHANGELOG.md
+++ b/corpan/packs/earthgate-reader/CHANGELOG.md
@@ -30,6 +30,12 @@ Conventions: `corpan/CHANGELOGS.md`.
   it without ever opening the drawer left the catalog unfetched, so the
   suggestion silently no-op'd; the `corpan:book-finished` handler now
   lazy-hydrates the catalog before choosing the next book.
+- **End-of-book "Up next" no longer loops between two books (#381).**
+  `chooseNextBook` now reads on-device reading history (the progress store) and
+  never re-suggests the just-finished or any completed book, deprioritizes
+  recently-read / in-progress titles, and randomizes across the newest few
+  eligible candidates — so finishing book A then book B can't ping-pong back to
+  A. Near-term anti-loop heuristic; superseded by the data-driven engine (#380).
 
 ## [0.7.1] - 2026-06-19
 

--- a/corpan/packs/earthgate-reader/manifest.json
+++ b/corpan/packs/earthgate-reader/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "earthgate_reader",
   "name": "Earthgate Reader",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Calm, earth-toned audiobook reader with word-level highlighting synced to narrated audio",
   "entry": "dist/app.js",
   "styles": [

--- a/corpan/packs/shared/catalog/src/appShell.ts
+++ b/corpan/packs/shared/catalog/src/appShell.ts
@@ -592,12 +592,59 @@ export function createAppShell(
     window.setTimeout(() => el.remove(), 250)
   }
 
+  /**
+   * Read on-device reading history (the corpan-app progress store, persisted
+   * to localStorage) and project it onto the current `language` so the
+   * end-of-book suggestion never re-pushes a completed book and won't ping-pong
+   * between two items (issue #381). Pure read; tolerant of missing/old data.
+   */
+  function readingHistoryFor(language: string): {
+    completedBookIds: string[]
+    inProgressBookIds: string[]
+    recentBookIds: string[]
+  } {
+    const empty = { completedBookIds: [], inProgressBookIds: [], recentBookIds: [] }
+    try {
+      const raw = localStorage.getItem("corpan-progress-v1")
+      if (!raw) return empty
+      const byKey = (JSON.parse(raw)?.state?.byKey ?? {}) as Record<
+        string,
+        { segmentsReached?: number; totalSegments?: number; lastOpenedAt?: string }
+      >
+      const completed: string[] = []
+      const inProgress: string[] = []
+      const recent: Array<{ bookId: string; at: number }> = []
+      for (const [k, p] of Object.entries(byKey)) {
+        const sep = k.lastIndexOf("::")
+        if (sep < 0) continue
+        const bookId = k.slice(0, sep)
+        const lang = k.slice(sep + 2)
+        if (lang !== language || !bookId) continue
+        const done =
+          p?.totalSegments != null &&
+          (p?.segmentsReached ?? 0) >= p.totalSegments
+        if (done) completed.push(bookId)
+        else inProgress.push(bookId)
+        recent.push({ bookId, at: Date.parse(p?.lastOpenedAt ?? "") || 0 })
+      }
+      recent.sort((a, b) => b.at - a.at)
+      return {
+        completedBookIds: completed,
+        inProgressBookIds: inProgress,
+        recentBookIds: recent.map((r) => r.bookId),
+      }
+    } catch {
+      return empty
+    }
+  }
+
   /** Show the next-book suggestion for the book that just finished. */
   function showEndOfBookSuggestion(finishedBookId: string, language: string): void {
     if (disposed) return
     // Only meaningful once the catalog is loaded.
     if (allNarrations.length === 0) return
-    const next = chooseNextBook(allNarrations, finishedBookId, language)
+    const history = readingHistoryFor(language)
+    const next = chooseNextBook(allNarrations, finishedBookId, language, history)
     if (!next) return // nothing sensible to suggest — stay out of the way
 
     // Replace any prior suggestion (e.g. user re-finished a book).

--- a/corpan/packs/shared/catalog/src/searchFilter.test.ts
+++ b/corpan/packs/shared/catalog/src/searchFilter.test.ts
@@ -67,7 +67,8 @@ test("falls back to the newest other book when the series has no next volume", (
     n("older", "es", { publishedAt: "2000-01-01" }),
   ]
   // Finished the last volume of the series → no next volume → newest other book.
-  const next = chooseNextBook(catalog, "last", "es")
+  // random()=0 pins the diversify window to its newest (first) entry.
+  const next = chooseNextBook(catalog, "last", "es", { random: () => 0 })
   assert.equal(next?.book.bookId, "fresh")
 })
 
@@ -77,7 +78,7 @@ test("falls back across series when finished book has no series", () => {
     n("newest", "es", { publishedAt: "2099-01-01" }),
     n("mid", "es", { publishedAt: "2050-01-01" }),
   ]
-  const next = chooseNextBook(catalog, "done", "es")
+  const next = chooseNextBook(catalog, "done", "es", { random: () => 0 })
   assert.equal(next?.book.bookId, "newest")
 })
 
@@ -96,7 +97,91 @@ test("returns the narration matching the requested language", () => {
     n("next", "es", { publishedAt: "2099-01-01" }),
     n("next", "fr", { publishedAt: "2099-01-01" }),
   ]
-  const next = chooseNextBook(catalog, "done", "es")
+  const next = chooseNextBook(catalog, "done", "es", { random: () => 0 })
   assert.equal(next?.book.bookId, "next")
   assert.equal(next?.narration.language, "es")
+})
+
+// --- Anti-loop heuristic (issue #381) -------------------------------------
+
+test("never suggests a completed book", () => {
+  const catalog = [
+    n("med", "es", { publishedAt: "2026-01-01" }),
+    n("aitw", "es", { publishedAt: "2026-02-01" }),
+    n("fresh", "es", { publishedAt: "2026-03-01" }),
+  ]
+  // Finished aitw; med already completed → must pick the fresh, untouched book,
+  // not bounce back to med.
+  const next = chooseNextBook(catalog, "aitw", "es", {
+    completedBookIds: ["med"],
+  })
+  assert.equal(next?.book.bookId, "fresh")
+})
+
+test("does not ping-pong between the only two items: returns null when the alternative is completed", () => {
+  const catalog = [
+    n("med", "es", { publishedAt: "2026-01-01" }),
+    n("aitw", "es", { publishedAt: "2026-02-01" }),
+  ]
+  // Classic #381: finish med, get aitw; finish aitw → med is the only other and
+  // it's already done, so suggest nothing rather than loop back to med.
+  const next = chooseNextBook(catalog, "aitw", "es", {
+    completedBookIds: ["med"],
+  })
+  assert.equal(next, null)
+})
+
+test("prefers a never-read book over a recently-read one", () => {
+  const catalog = [
+    n("recent", "es", { publishedAt: "2099-01-01" }), // newest, but just read
+    n("never", "es", { publishedAt: "2026-01-01" }),
+  ]
+  const next = chooseNextBook(catalog, "done", "es", {
+    recentBookIds: ["recent"],
+  })
+  assert.equal(next?.book.bookId, "never")
+})
+
+test("falls back to a recent book when nothing fresh remains", () => {
+  const catalog = [
+    n("recent", "es", { publishedAt: "2099-01-01" }),
+  ]
+  const next = chooseNextBook(catalog, "done", "es", {
+    recentBookIds: ["recent"],
+  })
+  // Only candidate is recent — better to suggest it than dead-end.
+  assert.equal(next?.book.bookId, "recent")
+})
+
+test("diversifies across the newest eligible candidates (no deterministic ping-pong)", () => {
+  const catalog = [
+    n("a", "es", { publishedAt: "2026-05-01" }),
+    n("b", "es", { publishedAt: "2026-04-01" }),
+    n("c", "es", { publishedAt: "2026-03-01" }),
+    n("d", "es", { publishedAt: "2026-02-01" }),
+  ]
+  // With diversifyTop=3, picking random()=0 / 0.5 / 0.99 should reach the top-3
+  // window (a, b, c) — proving the choice isn't pinned to the single newest.
+  const seen = new Set<string>()
+  for (const r of [0, 0.4, 0.99]) {
+    const next = chooseNextBook(catalog, "done", "es", {
+      diversifyTop: 3,
+      random: () => r,
+    })
+    if (next) seen.add(next.book.bookId)
+  }
+  assert.deepEqual([...seen].sort(), ["a", "b", "c"])
+})
+
+test("series 'next volume' skips a completed volume", () => {
+  const catalog = [
+    n("v1", "es", { series: "Saga", volume: 1 }),
+    n("v2", "es", { series: "Saga", volume: 2 }),
+    n("v3", "es", { series: "Saga", volume: 3 }),
+  ]
+  // Finished v1, already completed v2 → should advance to v3, not re-push v2.
+  const next = chooseNextBook(catalog, "v1", "es", {
+    completedBookIds: ["v2"],
+  })
+  assert.equal(next?.book.bookId, "v3")
 })

--- a/corpan/packs/shared/catalog/src/searchFilter.ts
+++ b/corpan/packs/shared/catalog/src/searchFilter.ts
@@ -157,28 +157,79 @@ export function sortBooks(books: BookGroup[], sort: BookSort): BookGroup[] {
 }
 
 /**
+ * Reading-history signals fed into `chooseNextBook` so the end-of-book
+ * suggestion stops ping-ponging between the same two items (issue #381).
+ *
+ * All sets/lists are keyed by `bookId` and scoped to the reader's CURRENT
+ * `language` by the caller (appShell reads them from the on-device progress
+ * store). This is the near-term anti-loop heuristic; the data-driven
+ * recommendation engine (#380) supersedes it.
+ */
+export type ChooseNextOpts = {
+  /**
+   * Books the user has already FINISHED in this language. Never suggested —
+   * completed items must not be re-pushed.
+   */
+  completedBookIds?: Iterable<string>
+  /**
+   * Books currently IN PROGRESS (opened but not finished) in this language.
+   * Deprioritized so we prefer something fresh, but allowed as a last resort
+   * (so we never dead-end into "nothing to suggest" when only in-flight books
+   * remain).
+   */
+  inProgressBookIds?: Iterable<string>
+  /**
+   * Recently-opened books, most-recent-first, in this language. Deprioritized
+   * to break the two-item cycle: the thing you just bounced off of won't be
+   * shoved back at you immediately.
+   */
+  recentBookIds?: Iterable<string>
+  /**
+   * How many of the newest eligible candidates to randomize across, so the
+   * fallback can't deterministically ping-pong onto the single newest book.
+   * Defaults to 3.
+   */
+  diversifyTop?: number
+  /** Injectable RNG in [0,1) for deterministic tests. Defaults to Math.random. */
+  random?: () => number
+}
+
+/**
  * Pick the book to suggest when the reader finishes `finishedBookId`.
  *
- * Preference order, all pure off the catalog:
- *   1. The next volume in the SAME series (series reading order — see
- *      `sortBooksWithinSeries`): the first book after the finished one that the
- *      reader can play in `language`.
- *   2. Otherwise the newest other book (by `sortBooks(..., "latest")`) the
- *      reader can play in `language`.
+ * Preference order, all pure off the catalog + the (optional) on-device
+ * reading-history signals:
+ *   1. The next UNFINISHED volume in the SAME series (series reading order —
+ *      see `sortBooksWithinSeries`) the reader can play in `language`.
+ *   2. Otherwise a fresh other book the reader can play in `language`,
+ *      preferring books they have NOT recently read / are not mid-way through,
+ *      randomized across the newest few eligible candidates so it can't
+ *      deterministically cycle between two items.
+ *   3. As a last resort (everything fresh is exhausted), fall back to recent /
+ *      in-progress books so we still suggest *something* rather than dead-end.
  *
  * "Can play in `language`" means the book has a narration in that language.
- * The finished book is never suggested. Returns the chosen book plus the
- * concrete narration to launch (the one matching `language`). Returns null when
- * nothing suitable exists (e.g. the only book in the catalog just finished, or
- * no other book is narrated in `language`).
+ * The finished book and any completed book are never suggested. Returns the
+ * chosen book plus the concrete narration to launch (the one matching
+ * `language`). Returns null when nothing suitable exists.
  */
 export function chooseNextBook(
   narrations: CatalogNarrationEntry[],
   finishedBookId: string,
-  language: string
+  language: string,
+  opts: ChooseNextOpts = {}
 ): { book: BookGroup; narration: CatalogNarrationEntry } | null {
   const books = groupByBook(narrations)
   const finished = books.find((b) => b.bookId === finishedBookId)
+
+  const completed = new Set(opts.completedBookIds ?? [])
+  // The just-finished book is always treated as completed for this language,
+  // even if the caller's progress signal hasn't caught up yet.
+  completed.add(finishedBookId)
+  const inProgress = new Set(opts.inProgressBookIds ?? [])
+  const recent = new Set(opts.recentBookIds ?? [])
+  const diversifyTop = Math.max(1, opts.diversifyTop ?? 3)
+  const random = opts.random ?? Math.random
 
   // A book is playable when it has a narration in the reader's current language
   // (so "Read next" actually plays rather than dead-ending).
@@ -193,7 +244,7 @@ export function chooseNextBook(
     return narration ? { book, narration } : null
   }
 
-  // 1. Next volume in the same series.
+  // 1. Next UNFINISHED volume in the same series.
   if (finished?.series) {
     const seriesBooks = sortBooksWithinSeries(
       books.filter((b) => b.series === finished.series)
@@ -201,19 +252,36 @@ export function chooseNextBook(
     const idx = seriesBooks.findIndex((b) => b.bookId === finishedBookId)
     if (idx >= 0) {
       for (let i = idx + 1; i < seriesBooks.length; i++) {
-        const chosen = pick(seriesBooks[i])
+        const book = seriesBooks[i]
+        if (completed.has(book.bookId)) continue
+        const chosen = pick(book)
         if (chosen) return chosen
       }
     }
   }
 
-  // 2. Fall back to the newest other playable book.
+  // 2 + 3. Fall back to other playable books, newest-first, then bucketed by
+  // freshness so we exhaust never-touched books before re-suggesting recent or
+  // in-progress ones. Completed books are dropped entirely.
   const others = sortBooks(
-    books.filter((b) => b.bookId !== finishedBookId),
+    books.filter((b) => b.bookId !== finishedBookId && !completed.has(b.bookId)),
     "latest"
+  ).filter((b) => playableIn(b) !== undefined)
+
+  // Freshest first: never read AND not recently opened > in-progress/recent.
+  const fresh = others.filter(
+    (b) => !inProgress.has(b.bookId) && !recent.has(b.bookId)
   )
-  for (const book of others) {
-    const chosen = pick(book)
+  const stale = others.filter(
+    (b) => inProgress.has(b.bookId) || recent.has(b.bookId)
+  )
+
+  // Diversify across the newest few fresh candidates so two items can't loop.
+  const bucket = fresh.length > 0 ? fresh : stale
+  if (bucket.length > 0) {
+    const window = bucket.slice(0, Math.min(diversifyTop, bucket.length))
+    const choice = window[Math.floor(random() * window.length)] ?? window[0]
+    const chosen = pick(choice)
     if (chosen) return chosen
   }
 

--- a/corpan/packs/stargate-reader/CHANGELOG.md
+++ b/corpan/packs/stargate-reader/CHANGELOG.md
@@ -10,6 +10,16 @@ Conventions: `corpan/CHANGELOGS.md`.
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-06-23
+
+### Fixed
+- **End-of-book "Up next" no longer loops between two books (#381).**
+  `chooseNextBook` now reads on-device reading history (the progress store) and
+  never re-suggests the just-finished or any completed book, deprioritizes
+  recently-read / in-progress titles, and randomizes across the newest few
+  eligible candidates — so finishing book A then book B can't ping-pong back to
+  A. Near-term anti-loop heuristic; superseded by the data-driven engine (#380).
+
 ## [0.7.3] - 2026-06-23
 
 ### Fixed
@@ -30,12 +40,6 @@ Conventions: `corpan/CHANGELOGS.md`.
   it without ever opening the drawer left the catalog unfetched, so the
   suggestion silently no-op'd; the `corpan:book-finished` handler now
   lazy-hydrates the catalog before choosing the next book.
-- **End-of-book "Up next" no longer loops between two books (#381).**
-  `chooseNextBook` now reads on-device reading history (the progress store) and
-  never re-suggests the just-finished or any completed book, deprioritizes
-  recently-read / in-progress titles, and randomizes across the newest few
-  eligible candidates — so finishing book A then book B can't ping-pong back to
-  A. Near-term anti-loop heuristic; superseded by the data-driven engine (#380).
 
 ## [0.7.2] - 2026-06-19
 

--- a/corpan/packs/stargate-reader/CHANGELOG.md
+++ b/corpan/packs/stargate-reader/CHANGELOG.md
@@ -30,6 +30,12 @@ Conventions: `corpan/CHANGELOGS.md`.
   it without ever opening the drawer left the catalog unfetched, so the
   suggestion silently no-op'd; the `corpan:book-finished` handler now
   lazy-hydrates the catalog before choosing the next book.
+- **End-of-book "Up next" no longer loops between two books (#381).**
+  `chooseNextBook` now reads on-device reading history (the progress store) and
+  never re-suggests the just-finished or any completed book, deprioritizes
+  recently-read / in-progress titles, and randomizes across the newest few
+  eligible candidates — so finishing book A then book B can't ping-pong back to
+  A. Near-term anti-loop heuristic; superseded by the data-driven engine (#380).
 
 ## [0.7.2] - 2026-06-19
 

--- a/corpan/packs/stargate-reader/manifest.json
+++ b/corpan/packs/stargate-reader/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "stargate_reader",
   "name": "Stargate Reader",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Immersive 3D audiobook: words stream through space in sync with narrated audio",
   "entry": "dist/app.js",
   "styles": [


### PR DESCRIPTION
### **User description**
## Summary

Fixes #381 — the end-of-book **"Up next"** suggestion ping-pongs between two items: finish Mediterranean Biome → it suggests AI This Week → finish that → it suggests Mediterranean again → then the same AITW episode, cycling forever.

### Root cause
`chooseNextBook` (in `packs/shared/catalog/src/searchFilter.ts`) only excluded the *just-finished* book. With two playable books, finishing A suggests B (newest other); finishing B suggests A again (now newest other). It had no memory of what the user already completed or recently read.

### Fix (near-term anti-loop heuristic)
This is the **stopgap** described in #381, superseded later by the data-driven recommendation engine (#380).

- `chooseNextBook` gains an optional `opts` carrying on-device reading-history signals:
  - **completedBookIds** — never suggested (the just-finished book is always treated as completed too), so finished items are never re-pushed.
  - **inProgressBookIds / recentBookIds** — deprioritized so we prefer something fresh, but still usable as a last resort (never dead-ends when only stale books remain).
  - **diversifyTop** (default 3) + injectable **random** — randomizes across the newest few eligible candidates so it physically cannot deterministically cycle between two items.
- Series "next volume" preference is kept, but now skips completed volumes.
- `appShell` reads the `corpan-progress-v1` progress store from localStorage, projects it onto the reader's current language, and threads the signals into `chooseNextBook`. Pure read, tolerant of missing/old data.

### Notes
- **No new user-facing strings** — reuses existing `reader.eob.*` keys, so `check:i18n` stays green across all ~54 locales.
- Pure-function logic is fully unit-tested (new anti-loop cases + the classic two-item scenario returning `null` instead of looping).
- Changelog entries added to both reader packs (stargate-reader, earthgate-reader) which bundle the shared catalog appShell.

### Gates run locally (Node 20+)
- corpan-app: `npm test` (37 pass) · `npm run tsc` (clean) · `npm run build` incl. `check:i18n` (pass)
- shared/catalog: `searchFilter.test.ts` 13/13 pass
- stargate-reader / earthgate-reader build pass; typecheck error count unchanged vs main (37 pre-existing, 0 introduced)

This is **core app**, so it is **not** auto-merged — leaving open for human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Prevents completed-book recommendation loops

- Uses language-scoped progress history

- Deprioritizes recent and in-progress books

- Adds anti-loop tests and changelogs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  progress["Progress store"]
  history["Language-scoped reading history"]
  chooser["Anti-loop chooseNextBook"]
  suggestion["End-of-book Up next"]
  progress -- "read from localStorage" --> history
  history -- "completed/recent/in-progress signals" --> chooser
  chooser -- "fresh diversified candidate" --> suggestion
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>appShell.ts</strong><dd><code>Thread progress history into recommendations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/shared/catalog/src/appShell.ts

<ul><li>Adds <code>readingHistoryFor</code> to read <code>corpan-progress-v1</code>.<br> <li> Projects progress by current <code>language</code>.<br> <li> Classifies completed, in-progress, and recent books.<br> <li> Passes history into <code>chooseNextBook</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/423/files#diff-caf497160c5610fb81627475f005a5a1bf915dc9d3209ca1fb760f0a5fc15117">+48/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>searchFilter.ts</strong><dd><code>Add anti-loop recommendation heuristic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/shared/catalog/src/searchFilter.ts

<ul><li>Adds <code>ChooseNextOpts</code> recommendation history signals.<br> <li> Never suggests completed or just-finished books.<br> <li> Skips completed volumes in same-series suggestions.<br> <li> Randomizes across fresh candidates before stale fallback.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/423/files#diff-34889c42298ba8f84f7e85035f4ce23391fe5966ef7328cf0b3e653b4f4df553">+85/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>searchFilter.test.ts</strong><dd><code>Cover anti-loop recommendation behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/shared/catalog/src/searchFilter.test.ts

<ul><li>Pins existing fallback tests with deterministic <code>random</code>.<br> <li> Tests completed-book exclusion and two-item loop prevention.<br> <li> Covers recent/in-progress deprioritization and fallback.<br> <li> Verifies diversification and completed series-volume skipping.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/423/files#diff-d1915969f6a12f3245d47e71ca90f86cd1006afc128a1793513fe224b8d8b76e">+88/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document Earthgate reader loop fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/earthgate-reader/CHANGELOG.md

<ul><li>Documents the end-of-book loop fix.<br> <li> Notes progress-history usage and candidate diversification.<br> <li> References stopgap status before data-driven engine.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/423/files#diff-35c4f143ae27a4fed1c4ecb6e131162e40d1631c1355c328accfe09521f50f71">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document Stargate reader loop fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/stargate-reader/CHANGELOG.md

<ul><li>Documents the end-of-book loop fix.<br> <li> Notes completed-book exclusion and stale-item deprioritization.<br> <li> References stopgap status before data-driven engine.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/423/files#diff-7306fca8553bd01e7a3589a0cfdcea30f52b676f181b8ea9db054f96d7093dd1">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

