### PR TITLE
Lingo Hero 0.4.2: fix language selection — rotate target across learning langs + single-language reading mode (#407)

### DIFF
--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -6,6 +6,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-06-24
+
+A language-selection correctness fix (issue #407): the falling/spoken TARGET
+language now rotates randomly across ALL of your learning languages, and a
+single-language stack becomes a same-language reading exercise instead of
+silently substituting a foreign language.
+
+### Fixed
+- **Target now rotates across ALL learning languages.** With a multi-language
+  stack the game previously always used `languages[1]` as the target, so a
+  player studying several languages only ever practiced the first one. The
+  TARGET is now chosen RANDOMLY among `languages[1..]` each round (prompt stays
+  in `languages[0]`, the language you know), so over a session you practice
+  every language in your stack with random phrases. The active target language —
+  the one whose words fall and get spoken — re-syncs per round.
+  (`ContentManager.resolveLanguages` / `getRound`, `Game.startRound`.)
+- **Single-language stacks are now a READING exercise, not a wrong foreign
+  substitute.** With only one language in the stack (e.g. a kid learning to READ
+  in their native language) the game used to default the target to a wrong
+  foreign language (Arabic/Spanish were seen). It now NEVER substitutes a
+  foreign language: the prompt AND the catchable falling words are both in that
+  single language (catch the phrase's own tokens, in order). (`resolveLanguages`
+  reading-mode branch.)
+
+### Tests
+- `test/e2e/gameplay.spec.mjs` now asserts, via `window.__lingoHero`, that a
+  ≥3-language stack varies its target across rounds (not pinned to
+  `languages[1]`) and that a 1-language stack keeps target === primary with the
+  stack language's own tokens as the catchable words. New harnesses
+  `harness-multi.html` + `harness-reading.html`.
+
 ## [0.4.1] - 2026-06-24
 
 A learning-beat + anti-brick + chrome pass: the phrase-complete result now

--- a/corpan/packs/lingo-hero/manifest.json
+++ b/corpan/packs/lingo-hero/manifest.json
@@ -2,7 +2,7 @@
   "id": "lingo_hero",
   "channel": "preview",
   "name": "Lingo Hero",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Catch the translation. The phrase you know falls as a chart of timed notes in the language you're learning — catch each word in rhythm, in order, and hear it spoken.",
   "entry": "dist/app.js",
   "styles": [
@@ -11,5 +11,5 @@
   "entryType": "script",
   "sdkVersion": "0.1.0",
   "minAppVersion": "0.17.0",
-  "devRevision": "2026-06-24T00:00:00.000Z"
+  "devRevision": "2026-06-24T01:00:00.000Z"
 }

--- a/corpan/packs/lingo-hero/src/ContentManager.ts
+++ b/corpan/packs/lingo-hero/src/ContentManager.ts
@@ -128,33 +128,43 @@ export class ContentManager {
   }
 
   /**
-   * Resolve the TARGET (learning) language for a round given the host stack.
-   *  - primary = languages[0] (the language the player already knows)
-   *  - target  = the first stack language that is NOT the primary
-   *  - if the stack has only one language, target = "en" when primary != en,
-   *    else fall back to a sensible second language present on the entry.
-   * `entry` is consulted only for the single-language fallback.
+   * Resolve the PROMPT (known/UI) language + the TARGET (learning) language for a
+   * round, given the host stack. The stack convention is
+   * `languages[0]` = the language the player already KNOWS (prompt / UI) and
+   * `languages[1..]` = the learning TARGET languages.
+   *
+   * Two first-class modes (issue #407):
+   *
+   *  - **≥2 languages — translation mode**: prompt in `languages[0]`; the TARGET
+   *    is chosen RANDOMLY among `languages[1..]` so over many rounds the player
+   *    practices EVERY learning language in the stack, not just `languages[1]`.
+   *    `reading` is false.
+   *
+   *  - **exactly 1 language — READING mode**: there is no foreign language to
+   *    translate INTO, so we NEVER substitute one. Instead the round is a reading
+   *    exercise in that single language: the prompt and the catchable words are
+   *    BOTH that language (`primary === target`). `reading` is true.
+   *
+   * Pass `rng` to make the random target choice deterministic in tests. `entry`
+   * is no longer consulted — single-language stacks resolve purely to reading
+   * mode in their own language (no cross-language guessing from the pool).
    */
   resolveLanguages(
     languages: string[],
-    entry?: EntryOut
-  ): { primary: string; target: string } {
+    rng: () => number = Math.random
+  ): { primary: string; target: string; reading: boolean } {
     const langs = (languages ?? []).filter(Boolean);
     const primary = langs[0] ?? "en";
-    let target = langs.find((l) => l !== primary) ?? "";
-    if (!target) {
-      if (primary !== "en") {
-        target = "en";
-      } else if (entry) {
-        // Single-language stack of "en": pick any non-en translation present.
-        target =
-          entry.translations.find((t) => t.language_code !== "en")
-            ?.language_code || "en";
-      } else {
-        target = "es";
-      }
+    // The learning targets are everything after the known/UI language.
+    const targets = langs.slice(1).filter((l) => l && l !== primary);
+    if (targets.length === 0) {
+      // Single-language stack → READING mode in that one language. Never pick a
+      // foreign substitute (the old "default to en/es" behavior — issue #407).
+      return { primary, target: primary, reading: true };
     }
-    return { primary, target };
+    // Translation mode: rotate the target RANDOMLY across all learning langs.
+    const target = targets[Math.floor(rng() * targets.length) % targets.length];
+    return { primary, target, reading: false };
   }
 
   /**
@@ -174,27 +184,30 @@ export class ContentManager {
     const pool = [...byId.values()];
     if (pool.length === 0) throw new Error("No content available");
 
-    // Provisional language resolution (may be refined once we know the entry,
-    // for the single-language fallback case).
-    let { primary, target } = this.resolveLanguages(languages, pool[0]);
+    // Per-round language resolution. In TRANSLATION mode the target rotates
+    // randomly across languages[1..] each round; in READING mode (1-lang stack)
+    // primary === target and the round is read in that single language.
+    const { primary, target, reading } = this.resolveLanguages(languages);
 
-    // A valid target entry must carry BOTH the prompt (primary) AND the target
-    // translation. If none does (e.g. mock pool only has en+es and primary is
-    // something else), relax: require just the target-language translation and
-    // use the entry's primary OR any other translation as the prompt.
-    let valid = pool.filter(
-      (e) => this.hasLang(e, primary) && this.hasLang(e, target)
-    );
-    if (valid.length === 0) {
-      const re = this.resolveLanguages(languages, pool[0]);
-      primary = re.primary;
-      target = re.target;
+    // A valid round entry must carry the TARGET translation; in translation mode
+    // it must ALSO carry the prompt (primary). In reading mode primary === target
+    // so this collapses to "has the one language" — exactly what we want (the
+    // prompt and catchable tokens are the same single-language text).
+    let valid = reading
+      ? pool.filter((e) => this.hasLang(e, target))
+      : pool.filter((e) => this.hasLang(e, primary) && this.hasLang(e, target));
+    if (valid.length === 0 && !reading) {
+      // No entry carries both prompt+target (e.g. mock pool lacks the chosen
+      // target lang). Relax: require just the target-language translation and use
+      // any other translation as the prompt. Never silently leave reading mode.
       valid = pool.filter(
         (e) => this.hasLang(e, target) && e.translations.length >= 2
       );
     }
-    if (valid.length === 0) {
-      // Last resort: anything with two translations; treat the first as prompt.
+    if (valid.length === 0 && !reading) {
+      // Last resort (translation mode only): anything with two translations;
+      // treat the first as prompt. Reading mode never falls through to a foreign
+      // language — if the single language is absent we error rather than guess.
       valid = pool.filter((e) => e.translations.length >= 2);
     }
     if (valid.length === 0) throw new Error("No usable round content");

--- a/corpan/packs/lingo-hero/src/Game.ts
+++ b/corpan/packs/lingo-hero/src/Game.ts
@@ -293,11 +293,13 @@ export class Game {
   }
 
   /**
-   * Resolve the resolved active TARGET (learning) language + the player's
-   * primary (known/UI) language from the host stack. primary = languages[0];
-   * target = the first non-primary language (with the single-language
-   * fallbacks the ContentManager uses). `code` is the TARGET language — the one
-   * whose words fall and get spoken.
+   * Resolve the INITIAL active TARGET (learning) language + the player's primary
+   * (known/UI) language from the host stack, for HUD/RTL setup before the first
+   * round loads. `code` is the TARGET language — the one whose words fall and get
+   * spoken. With a ≥2-language stack the TARGET actually ROTATES per round
+   * (chosen in ContentManager.getRound); `startRound` re-syncs `activeLanguage`
+   * to the round's real target each round. With a 1-language stack this resolves
+   * to READING mode (target === primary). This method only seeds sane defaults.
    */
   private resolveActiveLanguage(cfg: StackConfig): ActiveLanguage {
     const { primary, target } = this.contentManager.resolveLanguages(
@@ -438,6 +440,20 @@ export class Game {
     this.roundResolved = false;
     this.roundAllCaught = true;
     this.chartClean = true;
+
+    // Re-sync the active TARGET language to THIS round's actual target. In a
+    // ≥2-language stack the target rotates randomly per round (issue #407), so
+    // the language whose words fall + get spoken must follow the round, not the
+    // one-time mount-time resolution. RTL + the HUD direction follow too. (In
+    // reading mode round.targetLang === primary, so this is a no-op.)
+    if (round.targetLang && round.targetLang !== this.activeLanguage.code) {
+      this.activeLanguage = {
+        ...this.activeLanguage,
+        code: round.targetLang,
+        isRTL: RTL_LANGS.has(round.targetLang),
+      };
+      this.hud.applyLanguage(this.activeLanguage);
+    }
 
     this.currentWord = {
       entryId: round.entryId,

--- a/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
+++ b/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
@@ -163,6 +163,105 @@ if (catches === 0 && failures === 0) fail("no target word reached the strum line
 }
 
 await page.screenshot({ path: join(outDir, "gameplay-final.png") });
+
+// =============================================================================
+// Issue #407 — language-selection correctness.
+// These run on dedicated harnesses with non-default stacks so we exercise the
+// resolution policy directly via window.__lingoHero introspection.
+// =============================================================================
+const harnessMulti = "file://" + join(here, "harness-multi.html");
+const harnessReading = "file://" + join(here, "harness-reading.html");
+
+// Drive several rounds and collect the TARGET language seen at the start of each
+// fresh round. Returns the ordered list of observed targetLangs (one per round).
+async function collectRoundTargets(p, wantRounds) {
+  await p.evaluate(() => {
+    const b = [...document.querySelectorAll("button")].find((x) => /practice/i.test(x.textContent || ""));
+    if (b) b.click(); else window.__lingoHero.startGame("PRACTICE");
+  });
+  await p.waitForFunction(() => (window.__lingoHero.notes || []).length > 0, { timeout: 10000 });
+  const seen = [];
+  let lastEntryId = -1;
+  const deadline = Date.now() + 60000;
+  while (seen.length < wantRounds && Date.now() < deadline) {
+    const s = await p.evaluate(() => {
+      const g = window.__lingoHero, r = g.round;
+      return r ? { entryId: r.entryId, targetLang: r.targetLang, primaryLang: g.activeLanguage.primary, words: r.targetWords } : null;
+    });
+    if (s && s.entryId !== lastEntryId) { lastEntryId = s.entryId; seen.push(s); }
+    // Advance rounds without manual play: catch the next correct word if it is
+    // on the strum line; otherwise let the no-input watchdog resolve the chart.
+    const st = await p.evaluate(() => {
+      const g = window.__lingoHero, ls = g.laneSystem, rr = g.canvas.getBoundingClientRect();
+      const t = (g.notes || []).find((n) => n.isTarget && n.seqIndex === g.caughtCount && !n.hit && !n.missed);
+      const strumY = ls.getStrumLineY();
+      if (t && t.y >= strumY - 44 && t.y <= strumY + 44) {
+        return { click: { x: rr.left + ls.getLaneX(t.lane), y: rr.top + strumY } };
+      }
+      return { click: null };
+    });
+    if (st.click) await p.mouse.click(st.click.x, st.click.y);
+    await p.waitForTimeout(120);
+  }
+  return seen;
+}
+
+// --- Bug A: ≥3-language stack → TARGET rotates randomly (not pinned to [1]). --
+{
+  const mp = await browser.newPage({ viewport: { width: 390, height: 844 }, deviceScaleFactor: 2 });
+  mp.on("pageerror", (e) => fail("pageerror(multi): " + e.message));
+  await mp.goto(harnessMulti);
+  await mp.waitForFunction(() => !!window.__lingoHero, { timeout: 10000 });
+  const rounds = await collectRoundTargets(mp, 12);
+  const targets = rounds.map((r) => r.targetLang);
+  const primaries = new Set(rounds.map((r) => r.primaryLang));
+  const distinct = new Set(targets);
+  console.log(`multi-stack targets over ${rounds.length} rounds: ${JSON.stringify(targets)}`);
+  if (rounds.length < 4) fail(`only saw ${rounds.length} rounds on multi-stack (need >=4 to judge rotation)`);
+  if (primaries.size !== 1 || ![...primaries][0] || [...primaries][0] !== "en") {
+    fail(`multi-stack prompt language not pinned to known lang 'en': ${JSON.stringify([...primaries])}`);
+  }
+  // The learning langs are {es, fr, de}. The target MUST vary across rounds —
+  // the old bug pinned it to languages[1] (es) forever.
+  if (distinct.size < 2) fail(`multi-stack target did NOT rotate (always ${[...distinct][0]}); Bug A not fixed`);
+  else console.log(`OK: multi-stack target rotated across ${distinct.size} learning langs ${JSON.stringify([...distinct])}`);
+  // And every observed target must be one of the learning langs, never the known lang.
+  const bad = targets.filter((t) => t === "en" || !["es", "fr", "de"].includes(t));
+  if (bad.length) fail(`multi-stack target leaked outside learning langs: ${JSON.stringify(bad)}`);
+  await mp.screenshot({ path: join(outDir, "multi-stack.png") });
+  await mp.close();
+}
+
+// --- Bug B: 1-language stack → READING mode (target === primary === lang). ----
+{
+  const rp = await browser.newPage({ viewport: { width: 390, height: 844 }, deviceScaleFactor: 2 });
+  rp.on("pageerror", (e) => fail("pageerror(reading): " + e.message));
+  await rp.goto(harnessReading);
+  await rp.waitForFunction(() => !!window.__lingoHero, { timeout: 10000 });
+  const rounds = await collectRoundTargets(rp, 4);
+  console.log(`reading-stack rounds: ${JSON.stringify(rounds.map((r) => ({ t: r.targetLang, p: r.primaryLang })))}`);
+  if (rounds.length < 1) fail("reading-stack never produced a round");
+  for (const r of rounds) {
+    // The single stack language is "en". Target MUST be that same language —
+    // NEVER a foreign substitute (the old bug grabbed es/ar). And the catchable
+    // words must be that language's own tokens (a real, non-empty sequence).
+    if (r.targetLang !== "en") fail(`reading-stack target was '${r.targetLang}', expected 'en' (no foreign substitute)`);
+    if (r.primaryLang !== "en") fail(`reading-stack primary was '${r.primaryLang}', expected 'en'`);
+    if (!Array.isArray(r.words) || r.words.length < 1) fail(`reading-stack had no catchable tokens: ${JSON.stringify(r.words)}`);
+    // Catchable tokens must be ENGLISH (the stack lang), not Spanish. Heuristic:
+    // the joined token string must NOT contain the entry's Spanish-only markers.
+    const joined = (r.words || []).join(" ").toLowerCase();
+    if (/dónde|está|gato|días|gracias|cuesta|perro|gusta|leer/.test(joined)) {
+      fail(`reading-stack catchable words look like a foreign substitute: ${JSON.stringify(r.words)}`);
+    }
+  }
+  if (rounds.every((r) => r.targetLang === "en" && r.primaryLang === "en" && (r.words || []).length >= 1)) {
+    console.log(`OK: reading-stack stayed in 'en' (prompt + catchable tokens), no foreign substitute`);
+  }
+  await rp.screenshot({ path: join(outDir, "reading-stack.png") });
+  await rp.close();
+}
+
 await browser.close();
 console.log(failures === 0 ? "\nGAMEPLAY E2E: PASS" : `\nGAMEPLAY E2E: ${failures} FAILURE(S)`);
 process.exit(failures === 0 ? 0 : 1);

--- a/corpan/packs/lingo-hero/test/e2e/harness-multi.html
+++ b/corpan/packs/lingo-hero/test/e2e/harness-multi.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<!--
+  Multi-language stack harness for issue #407 (Bug A — random target rotation).
+  Stack = ["en","es","fr","de"]: prompt in en (known), TARGET rotates randomly
+  across {es, fr, de} every round. Each entry carries all four languages so any
+  target is always catchable. Run `npm run build` first.
+-->
+<html>
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../../dist/app.css" />
+<style>
+  html, body { margin: 0; padding: 0; height: 100%; background: #07060f; }
+  #host { position: static; margin: 90px 0 0 70px; width: 360px; height: 720px; }
+</style>
+</head>
+<body>
+<div id="host"></div>
+<script>window.__corpanHostActive = true;</script>
+<script src="../../dist/app.js"></script>
+<script>
+  // [en, es, fr, de] for each entry — every learning language is always present.
+  const ROWS = [
+    ["the cat", "el gato", "le chat", "die Katze"],
+    ["good morning", "buenos días", "bonjour", "guten Morgen"],
+    ["thank you very much", "muchas gracias", "merci beaucoup", "danke schön"],
+    ["see you tomorrow", "hasta mañana", "à demain", "bis morgen"],
+    ["where is the station", "dónde está la estación", "où est la gare", "wo ist der Bahnhof"],
+    ["how much is this", "cuánto cuesta esto", "combien ça coûte", "wie viel kostet das"],
+    ["the weather is nice", "hace buen tiempo", "il fait beau", "das Wetter ist schön"],
+    ["I would like coffee", "quisiera un café", "je voudrais un café", "ich möchte einen Kaffee"],
+  ];
+  const ENTRIES = ROWS.map(([en, es, fr, de], i) => ({
+    entry_id: i + 1, level: "A1", domains: ["travel"],
+    translations: [
+      { language_code: "en", text: en },
+      { language_code: "es", text: es },
+      { language_code: "fr", text: fr },
+      { language_code: "de", text: de },
+    ],
+  }));
+  let k = 0;
+  const host = {
+    speak() {}, stopSpeech() {},
+    getStackConfig() { return { languages: ["en", "es", "fr", "de"], domains: [], levels: [], rate: 1, textSize: "m", showRomanization: false }; },
+    onStackConfigChange() { return () => {}; },
+    getRandomEntries(n) { const o = []; for (let i = 0; i < n; i++) o.push(ENTRIES[(k++) % ENTRIES.length]); return Promise.resolve(o); },
+    getRandomEntry() { return Promise.resolve(ENTRIES[(k++) % ENTRIES.length]); },
+    isMock: true,
+  };
+  window.CorpanGames.lingo_hero.mount(document.getElementById("host"), host);
+</script>
+</body>
+</html>

--- a/corpan/packs/lingo-hero/test/e2e/harness-reading.html
+++ b/corpan/packs/lingo-hero/test/e2e/harness-reading.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<!--
+  Single-language stack harness for issue #407 (Bug B — READING mode).
+  Stack = ["en"] only: there is NO foreign language to translate into, so the
+  round is a READING exercise — prompt AND catchable words are BOTH "en" (the
+  phrase's own tokens, in order). The game must NEVER substitute a foreign
+  language here. Run `npm run build` first.
+-->
+<html>
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../../dist/app.css" />
+<style>
+  html, body { margin: 0; padding: 0; height: 100%; background: #07060f; }
+  #host { position: static; margin: 90px 0 0 70px; width: 360px; height: 720px; }
+</style>
+</head>
+<body>
+<div id="host"></div>
+<script>window.__corpanHostActive = true;</script>
+<script src="../../dist/app.js"></script>
+<script>
+  // Entries carry en (the only stack language) PLUS a foreign translation, to
+  // prove the game does NOT grab the foreign one when the stack is single-lang.
+  const ROWS = [
+    ["the cat sleeps", "el gato duerme"],
+    ["good morning everyone", "buenos días a todos"],
+    ["thank you very much", "muchas gracias"],
+    ["see you tomorrow friend", "hasta mañana amigo"],
+    ["where is the station", "dónde está la estación"],
+    ["how much is this", "cuánto cuesta esto"],
+    ["the big red dog", "el gran perro rojo"],
+    ["I like to read books", "me gusta leer libros"],
+  ];
+  const ENTRIES = ROWS.map(([en, es], i) => ({
+    entry_id: i + 1, level: "A1", domains: ["travel"],
+    translations: [
+      { language_code: "en", text: en },
+      { language_code: "es", text: es },
+    ],
+  }));
+  let k = 0;
+  const host = {
+    speak() {}, stopSpeech() {},
+    getStackConfig() { return { languages: ["en"], domains: [], levels: [], rate: 1, textSize: "m", showRomanization: false }; },
+    onStackConfigChange() { return () => {}; },
+    getRandomEntries(n) { const o = []; for (let i = 0; i < n; i++) o.push(ENTRIES[(k++) % ENTRIES.length]); return Promise.resolve(o); },
+    getRandomEntry() { return Promise.resolve(ENTRIES[(k++) % ENTRIES.length]); },
+    isMock: true,
+  };
+  window.CorpanGames.lingo_hero.mount(document.getElementById("host"), host);
+</script>
+</body>
+</html>


### PR DESCRIPTION
### **User description**
## Summary

Fixes the two language-selection correctness bugs in the **Lingo Hero** pack (preview channel) reported in #407. Pure gameplay-logic fix — no visual change.

### Bug A — target always pinned to `languages[1]`
With a multi-language stack the game always used `languages[1]` as the learning target, so a player studying several languages only ever practiced the first one.

**Fix:** the TARGET is now chosen **randomly among `languages[1..]` each round**. The prompt stays in `languages[0]` (the language the player knows). The active target language — the one whose words fall and get spoken — **re-syncs per round** (`Game.startRound` follows `round.targetLang`, so RTL/HUD direction and TTS track the rotating target). Over a session you practice every language in your stack with random phrases.

### Bug B — single-language stack substituted a wrong foreign language
With only one language in the stack (e.g. a kid learning to **read** in their native language) the target defaulted to a wrong foreign language (Arabic/Spanish were seen).

**Fix:** a one-language stack is now a first-class **READING exercise** — the prompt AND the catchable falling words are **both** in that single language (catch the phrase's own tokens, in order). `resolveLanguages` never picks a foreign fallback; reading mode resolves `target === primary`.

### Resolution rule (implemented exactly)
- **≥2 languages:** prompt in `languages[0]`; TARGET = random choice among `languages[1..]`, rotating across all of them each round.
- **exactly 1 language:** READING mode — prompt + catchable words both in that single language; no cross-language target.

## Tests
`test/e2e/gameplay.spec.mjs` (exit-code gated) now asserts via `window.__lingoHero`:
- **(Bug A)** with a 3-language mock stack (`en, es, fr, de`) the target varies across rounds — observed rotation across all of `{es, fr, de}`, never pinned to `[1]`, never the known lang.
- **(Bug B)** with a 1-language stack (`en`) target === primary === `en` and the catchable words are that language's own tokens (not a foreign substitute).
- Existing contracts preserved: falling note y increases; catching the correct word scores; tapping Exit does **not** score; no-input round resolves (no brick).

New harnesses: `harness-multi.html`, `harness-reading.html`.

## Gates run locally
- `npm run build` — clean (tsc + vite, 0 errors).
- `node test/e2e/gameplay.spec.mjs` — **PASS** (exit 0), all old + new assertions.
- Design-critic GO/NO-GO (frontend-design skill, 9 captured frames): **GO — zero blockers**, playable + coherent + no regression. Three minor polish items filed as follow-ups, not gating.

## Contracts preserved
Answer dedup, offline-first (no network/remote fonts), TTS speaks RAW foreign text, pack id `lingo_hero` everywhere, canvas-relative input, delta-timed movement, `window.__lingoHero` introspectable.

Version: 0.4.1 → **0.4.2** (+ devRevision), CHANGELOG `[0.4.2]` added. Preview channel.

Closes #407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Rotate targets across learning languages

- Add single-language reading mode

- Re-sync HUD language per round

- Cover selection rules with e2e tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  stack["Host language stack"]
  resolver["Per-round language resolver"]
  multi["Random learning target"]
  reading["Same-language reading mode"]
  game["Game round HUD/TTS sync"]
  tests["E2E harness coverage"]
  stack -- "languages[1..]" --> resolver
  resolver -- "multi-language" --> multi
  resolver -- "single-language" --> reading
  multi -- "targetLang" --> game
  reading -- "targetLang = primary" --> game
  game -- "validated by" --> tests
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>ContentManager.ts</strong><dd><code>Resolve rotating targets and reading mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/424/files#diff-7f7f66aa0a0ab0785ba8e14b6eec2a3c527ed1175293a5030a3dcadd1575ed52">+50/-37</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Game.ts</strong><dd><code>Re-sync active language per round</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/424/files#diff-6c075e8c51d32e4e5452a4c738f6cc530345361455286e0f7d1af37f46fedde7">+21/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>harness-multi.html</strong><dd><code>Add multi-language rotation test harness</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/424/files#diff-583939b1e493c7b5b98504fe2e15395d98a28ee7f558600b895c8c9590686e1e">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>harness-reading.html</strong><dd><code>Add single-language reading test harness</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/424/files#diff-00135f5396fd5dbd5935b9b18090b9a14693a2f0bb150f6090b96979de839817">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gameplay.spec.mjs</strong><dd><code>Assert language rotation and reading behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/424/files#diff-5ee22f0c6a817c0427478004e2238facf99cd3c18591eda51d590170655a3c57">+99/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document 0.4.2 language-selection fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/424/files#diff-dd09bf20e11864991961b7ef6d2fc6687a66d9a9de2d246f765d9d6891e646c2">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>manifest.json</strong><dd><code>Bump pack version and revision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/424/files#diff-38411e79d50eee7f8ad439a29518dcddf16cdc9cd03739fc81ea212f18519b15">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

