### PR TITLE
Lingo Hero 0.4.3 — prompt auto-fit, compact bottom HUD row, accessible pause/exit (#426)

### DIFF
--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -6,6 +6,50 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-06-24
+
+A HUD / layout pass (issue #426): the prompt always shows in full, the bottom
+stats collapse into one compact row clear of the rings, and the top-left exit
+becomes an accessible auto-hiding pause control with an Android-back path.
+
+### Fixed
+- **Prompt never truncates.** The top primary-language prompt used to clip on
+  longer phrases. It now auto-fits: the font shrinks (to a readable floor) and
+  the phrase wraps so the ENTIRE prompt is visible at any length, and it re-fits
+  on resize/rotation. The prompt also centers across the full width below the
+  top-left chrome so it never crowds the edge or collides with the controls.
+  (`Hud.setQuestion` / `Hud.fitPrompt`, `.question-box` / `.top-bar` styles,
+  `Game.handleResize` → `Hud.onResize`.)
+- **Bottom HUD is one compact row, clear of the rings.** The level meter, SCORE,
+  and STREAK now sit in a SINGLE fixed compact row pinned across the very bottom,
+  UNDER the hit-ring circles (the strum line / rings were nudged UP from 0.74
+  height so the rings are fully visible and never clipped at the screen edge).
+  The row is a centered, content-width cluster so it never flanks or overlaps the
+  falling-note lanes (preserves the 0.4.0 layout fix); the bottom inset respects
+  the Android safe area. (`Hud` stats markup, `.lh-stats` styles,
+  `LaneSystem.STRUM_LINE_Y_RATIO` + `getStrumRatio`.)
+
+### Changed
+- **Exit is now an accessible auto-hiding pause control.** The bare top-left exit
+  arrow is replaced by a small PAUSE control that opens a Resume/Exit sheet, so an
+  accidental tap can't dump a run mid-combo. It AUTO-FADES during active play and
+  reappears on any tap / when paused. The Android hardware/gesture BACK button
+  (`popstate`) is wired to the same pause→exit path, so Android users get both a
+  visible control and the back gesture (iOS keeps the visible affordance). Exactly
+  ONE mute toggle sits beside it; both are canvas-input-safe (`stopPropagation`,
+  above the canvas) so taps never leak through into a lane. On the menu /
+  game-over screens the in-game chrome is hidden (those own their own navigation).
+  (`Hud` pause/mute/back wiring, `Game` pause/resume/mute callbacks, `muteChange`
+  event applied live in `audio/index.ts`.)
+
+### Tests
+- `test/e2e/gameplay.spec.mjs` now asserts a deliberately LONG prompt renders in
+  full (no horizontal overflow; wraps within the header band), that tapping the
+  pause control / its Exit / the single mute toggle does NOT score or register a
+  lane hit (no tap-through), that the pause control opens the Resume/Exit sheet,
+  and that exactly one mute control exists. Existing motion / catch / no-brick /
+  #407 language-rule assertions are unchanged.
+
 ## [0.4.2] - 2026-06-24
 
 A language-selection correctness fix (issue #407): the falling/spoken TARGET

--- a/corpan/packs/lingo-hero/manifest.json
+++ b/corpan/packs/lingo-hero/manifest.json
@@ -2,7 +2,7 @@
   "id": "lingo_hero",
   "channel": "preview",
   "name": "Lingo Hero",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Catch the translation. The phrase you know falls as a chart of timed notes in the language you're learning — catch each word in rhythm, in order, and hear it spoken.",
   "entry": "dist/app.js",
   "styles": [
@@ -11,5 +11,5 @@
   "entryType": "script",
   "sdkVersion": "0.1.0",
   "minAppVersion": "0.17.0",
-  "devRevision": "2026-06-24T01:00:00.000Z"
+  "devRevision": "2026-06-24T02:00:00.000Z"
 }

--- a/corpan/packs/lingo-hero/src/Game.ts
+++ b/corpan/packs/lingo-hero/src/Game.ts
@@ -188,6 +188,12 @@ export class Game {
         onShowMenu: () => this.showMenu(),
         // Result-linger tap-to-continue: advance immediately past the dwell.
         onContinue: () => this.continueFromResult(),
+        // Pause sheet (issue #426): pause/resume the loop + audio together.
+        onPause: () => this.pause("manual"),
+        onResume: () => this.resume(),
+        // Single mute control → flip the audio stream live (+ already persisted
+        // by the Hud). Game is the only bus emitter, so it forwards the toggle.
+        onSetMuted: (muted) => this.bus.emit("muteChange", { muted }),
       },
       this.progression
     );
@@ -337,7 +343,12 @@ export class Game {
     if (ctx) ctx.scale(dpr, dpr);
 
     this.laneSystem.resize(width, height);
-    this.speed = (height * 0.8 + 100) / this.NOTE_TRAVEL_SECONDS;
+    this.speed = (height * this.laneSystem.getStrumRatio() + 100) / this.NOTE_TRAVEL_SECONDS;
+
+    // Re-fit the prompt to the new viewport so a long phrase stays fully visible
+    // after rotation / resize (issue #426). Hud may not exist yet on the very
+    // first constructor-time resize; guard for that.
+    this.hud?.onResize();
 
     // The lane now runs FULL HEIGHT to the very top edge: notes spawn at the top
     // and are seen THROUGH the translucent header as they enter (the header is a
@@ -763,6 +774,9 @@ export class Game {
 
   private handleInput(lane: LaneIndex) {
     this.lanePressTimes[lane] = performance.now();
+    // Any lane interaction briefly resurfaces the auto-faded top-left chrome
+    // (pause/mute) so the player always has a reliable way to reach the exit.
+    this.hud?.notifyInteraction();
     if (this.state !== GameState.PLAYING) return;
     // While backgrounded-paused or holding the result linger, lane taps don't
     // play (a tap during the linger is consumed by tap-to-continue instead).

--- a/corpan/packs/lingo-hero/src/LaneSystem.ts
+++ b/corpan/packs/lingo-hero/src/LaneSystem.ts
@@ -17,7 +17,12 @@ export class LaneSystem {
   // Visual config
   // Now relative to screen size instead of fixed pixels
   private noteRadius: number = 40;
-  private readonly STRUM_LINE_Y_RATIO = 0.8;
+  // The strum line (hit-ring circles) sits at this fraction of the canvas
+  // height. Pulled UP from the old 0.8 (issue #426) so the rings are FULLY
+  // visible (never clipped by the bottom edge) and leave a clear band below for
+  // the single compact stats row (level · score · combo). The rings' bottom is
+  // strumY + noteRadius; at 0.74 that clears the bottom band on a tall phone.
+  private readonly STRUM_LINE_Y_RATIO = 0.74;
 
   constructor(width: number, height: number) {
     this.resize(width, height);
@@ -52,6 +57,11 @@ export class LaneSystem {
 
   getStrumLineY(): number {
     return this.canvasHeight * this.STRUM_LINE_Y_RATIO;
+  }
+
+  /** The strum-line height fraction (so the fall-speed math stays in sync). */
+  getStrumRatio(): number {
+    return this.STRUM_LINE_Y_RATIO;
   }
 
   /**

--- a/corpan/packs/lingo-hero/src/audio/index.ts
+++ b/corpan/packs/lingo-hero/src/audio/index.ts
@@ -97,10 +97,27 @@ export function initAudioHaptics(bus: GameEventBus): AudioHandle {
   const haptics = new Haptics();
   const unsubs: Array<() => void> = [];
 
-  // Honor a stored mute preference (no in-game button anymore; a future pause
-  // menu can write this key). Default = unmuted.
+  // Honor a stored mute preference. The in-game MUTE control (one, in the HUD)
+  // flips this live via the `muteChange` event below; the preference also
+  // persists so it carries across runs. Default = unmuted.
   let muted = readStoredMuted();
   const applyMute = () => synth.setMuted(muted);
+
+  // --- muteChange: the single in-game mute toggle, applied LIVE -------------
+  unsubs.push(
+    bus.on("muteChange", (e) => {
+      muted = e.muted;
+      applyMute();
+      // Stop or (re)start the bed to match, so muting actually silences the
+      // running music bed and unmuting brings it back during play.
+      if (muted) {
+        music.stop(0.2);
+      } else if (synth.ready) {
+        music.resync();
+        music.start();
+      }
+    })
+  );
 
   // --- gameStart: unlock audio (first gesture) + swell + start the bed -----
   unsubs.push(

--- a/corpan/packs/lingo-hero/src/styles.css
+++ b/corpan/packs/lingo-hero/src/styles.css
@@ -557,30 +557,35 @@ canvas {
   align-items: center;
   justify-content: center;
   width: 100%;
-  /* Clear the top-left Exit button; nothing on the right anymore. A hair of
-     side gutter keeps text off the very edge while still reading full-width. */
-  padding-left: calc(52px + env(safe-area-inset-left, 0px));
-  padding-right: calc(12px + env(safe-area-inset-right, 0px));
+  /* The prompt centers across the FULL width and starts BELOW the top-left
+     chrome band (pause + mute pills are ~40px tall in the corner), so a long
+     phrase can use the whole width + wrap without ever colliding with the
+     controls or crowding the right edge. Symmetric side gutters keep text off
+     the very edges. */
+  padding-left: calc(14px + env(safe-area-inset-left, 0px));
+  padding-right: calc(14px + env(safe-area-inset-right, 0px));
+  padding-top: 46px;
   box-sizing: border-box;
 }
 
-/* Exit control — top-left corner, mirroring the audio mute toggle (top-right).
-   In the .ui-layer overlay (pointer-events:none) but itself interactive. */
-.lh-exit-btn {
+/* TOP-LEFT CHROME (issue #426): the small PAUSE control + a single MUTE toggle.
+   Both live in the .ui-layer overlay (pointer-events:none) but opt back IN, and
+   their JS handlers stopPropagation, so taps never leak through to the canvas
+   lanes. Compact 40px pills; the pair tucks into the top-left corner. */
+.lh-chrome-btn {
   position: absolute;
   top: calc(var(--na-space-3) + env(safe-area-inset-top, 0px));
-  left: calc(var(--na-space-3) + env(safe-area-inset-left, 0px));
   z-index: var(--na-z-overlay, 40);
-  width: 44px;
-  height: 44px;
+  width: 40px;
+  height: 40px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.4rem;
+  font-size: 1.1rem;
   line-height: 1;
   padding: 0;
   border-radius: var(--na-radius-pill);
-  border: 1px solid color-mix(in srgb, var(--na-text) 35%, transparent);
+  border: 1px solid color-mix(in srgb, var(--na-text) 32%, transparent);
   background: var(--na-glass-bg);
   color: var(--na-text);
   cursor: pointer;
@@ -590,14 +595,111 @@ canvas {
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
   transition: transform var(--na-dur-fast) var(--na-ease-snap),
-    border-color var(--na-dur-base) var(--na-ease-out);
+    border-color var(--na-dur-base) var(--na-ease-out),
+    opacity var(--na-dur-base) var(--na-ease-out);
 }
-.lh-exit-btn:hover,
-.lh-exit-btn:focus-visible {
+.lh-pause-btn {
+  left: calc(var(--na-space-3) + env(safe-area-inset-left, 0px));
+  font-size: 0.9rem;
+  letter-spacing: -1px;
+}
+.lh-mute-btn {
+  left: calc(var(--na-space-3) + 48px + env(safe-area-inset-left, 0px));
+}
+.lh-chrome-btn:hover,
+.lh-chrome-btn:focus-visible {
   border-color: var(--na-text);
 }
-.lh-exit-btn:active {
+.lh-chrome-btn:active {
   transform: scale(0.92);
+}
+/* Mute toggle: show the speaker-on glyph by default; swap to muted when pressed. */
+.lh-mute-btn .lh-mute-off {
+  display: none;
+}
+.lh-mute-btn.is-muted .lh-mute-on {
+  display: none;
+}
+.lh-mute-btn.is-muted .lh-mute-off {
+  display: inline;
+}
+.lh-mute-btn.is-muted {
+  color: var(--ink-dim);
+  border-color: color-mix(in srgb, var(--na-text) 20%, transparent);
+}
+
+/* AUTO-FADE: during active play the top-left chrome tucks away (unobtrusive). It
+   stays clickable for a moment as it fades, then drops pointer-events so a faded
+   control can't eat a lane tap. It reappears on any lane tap (Game re-shows it)
+   or whenever the pause sheet is open. */
+.ui-layer.chrome-hidden .lh-chrome-btn {
+  opacity: 0;
+  pointer-events: none;
+}
+/* OFF the playfield (menu / game-over): pause + mute have no meaning, so the
+   in-game chrome is fully removed (those screens own their own navigation). */
+.ui-layer.chrome-off .lh-chrome-btn {
+  display: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  .lh-chrome-btn {
+    transition: none;
+  }
+}
+
+/* PAUSE SHEET — a small modal (Resume / Exit) so an accidental tap on the pause
+   control can't dump a run mid-combo. Covers the screen with a dimmed scrim;
+   the card is centered. pointer-events:auto so it captures all taps (the loop is
+   frozen underneath anyway). */
+.lh-pause-sheet {
+  position: absolute;
+  inset: 0;
+  z-index: calc(var(--na-z-overlay, 40) + 5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6vmin;
+  background: rgba(7, 6, 15, 0.66);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  pointer-events: auto;
+  animation: lh-sheet-in var(--na-dur-base, 240ms) var(--na-ease-out, ease);
+}
+.lh-pause-sheet[hidden] {
+  display: none;
+}
+.lh-pause-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: min(86vw, 340px);
+  padding: clamp(1.1rem, 4vmin, 1.8rem);
+  border-radius: var(--radius-lg);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-stroke);
+  box-shadow: 0 24px 60px -20px rgba(0, 0, 0, 0.85);
+}
+.lh-pause-title {
+  margin: 0 0 4px;
+  text-align: center;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: clamp(1.2rem, 5vmin, 1.6rem);
+  color: var(--ink);
+  letter-spacing: 0.02em;
+}
+@keyframes lh-sheet-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .lh-pause-sheet {
+    animation: none;
+  }
 }
 
 /* Prompt stack: foreign prompt + romanization line, vertically grouped so the
@@ -747,84 +849,80 @@ canvas {
   }
 }
 
-/* STATS STRIP — pulled OUT of the central play area. Default (tall screens):
-   docked just BELOW the hit-ring circles (the strum line sits at 80% height;
-   the rings have up to ~72px radius, so we anchor the strip in the bottom band
-   under them). It spans only a centered, content-width cluster so it never
-   flanks the falling-note lanes. pointer-events stay off for the strip itself;
-   the stat plates don't need interaction. */
+/* BOTTOM STATS ROW (issue #426) — ONE fixed, compact row across the very
+   bottom: level meter · SCORE · STREAK. It is pinned UNDER the hit-ring circles
+   (the strum line was pulled up to 0.74 height; the rings clear this band) and
+   is a centered, content-width cluster so it NEVER flanks the falling-note
+   lanes (preserves the 0.4.0 fix). The bottom inset RESPECTS the Android safe
+   area (gesture/nav bar) so nothing is clipped or overlapped by system chrome.
+   pointer-events stay off the row (the plates don't need interaction). */
 .lh-stats {
   position: absolute;
   left: 50%;
+  bottom: calc(8px + var(--safe-bottom));
   transform: translateX(-50%);
-  /* Below the rings: strum line at 80% of height, ring radius up to ~72px → sit
-     the strip a touch under that, with a floor so it never hugs the very edge.
-     The floor RESPECTS the Android bottom SAFE AREA (gesture/nav bar) via
-     env(safe-area-inset-bottom) so the SCORE/COMBO strip is never clipped or
-     overlapped by system chrome; the bottom padding reserves the band too. */
-  top: min(calc(80% + 86px), calc(100% - 92px - var(--safe-bottom)));
-  padding-bottom: var(--safe-bottom);
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
+  flex-direction: row;
+  align-items: stretch;
+  justify-content: center;
+  gap: 8px;
   width: max-content;
-  max-width: min(94vw, 460px);
+  max-width: calc(100vw - 24px);
   pointer-events: none;
 }
 
-/* Compact the moved-out stat plates so the strip stays a tidy cluster below the
-   rings instead of the old full-width banner. */
+/* Compact the plates so the whole row reads as one tidy bottom HUD bar (smaller
+   than the old stacked banner) and fits a narrow phone without flanking lanes. */
 .lh-stats .mastery-readout {
-  width: min(90vw, 320px);
   align-self: center;
-  padding: 4px 12px;
+  width: auto;
+  max-width: 44vw;
+  margin: 0;
+  gap: 8px;
+  padding: 4px 10px;
+  font-size: clamp(0.62rem, 2.6vmin, 0.8rem);
+}
+/* Keep the meter's progress bar from collapsing in the compact row. */
+.lh-stats .mastery-bar {
+  min-width: 34px;
 }
 .lh-stats .stat {
-  padding: 0.3rem 0.7rem;
+  padding: 0.28rem 0.7rem;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+/* In the bottom row the combo plate is centered (not right-flushed). */
+.lh-stats .combo-box {
+  align-items: center;
+  text-align: center;
 }
 .lh-stats .score-box .stat-value {
-  font-size: clamp(1.15rem, 5vmin, 1.7rem);
+  font-size: clamp(1.05rem, 4.6vmin, 1.5rem);
 }
 .lh-stats .combo-value #combo {
-  font-size: clamp(1.4rem, 6.5vmin, 2.3rem);
+  font-size: clamp(1.25rem, 5.4vmin, 1.9rem);
 }
 .lh-stats .combo-value .x {
-  font-size: clamp(0.85rem, 3.5vmin, 1.2rem);
+  font-size: clamp(0.8rem, 3.2vmin, 1.05rem);
 }
 
-/* Score + combo strip */
-.score-container {
-  display: flex;
-  align-items: stretch;
-  justify-content: center;
-  gap: 10px;
-}
-
-/* Short / landscape screens: there isn't room below the rings, so collapse the
-   stats to a slim row pinned at the very TOP (above the prompt), still out of
-   the falling-note lanes' way. */
+/* Very short / landscape screens: keep the same single compact bottom row, just
+   trim the padding so it never grows tall. (No longer relocated to the top — the
+   rings already cleared the bottom band, so the row stays put.) */
 @media (max-height: 560px) {
   .lh-stats {
-    top: calc(var(--safe-top) + 6px);
-    flex-direction: row;
-    align-items: center;
-    gap: 8px;
-    max-width: min(96vw, 560px);
+    bottom: calc(6px + var(--safe-bottom));
+    gap: 6px;
+    max-width: calc(100vw - 16px);
   }
   .lh-stats .mastery-readout {
-    width: auto;
-    max-width: 46vw;
-  }
-  .lh-stats .score-container {
-    gap: 8px;
+    max-width: 40vw;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .lh-stats .stat {
-    padding: 0.25rem 0.6rem;
-  }
-  /* Nudge the prompt stack down so the slim top stats row doesn't collide. */
-  .hud .top-bar {
-    margin-top: 40px;
+    padding: 0.22rem 0.55rem;
   }
 }
 

--- a/corpan/packs/lingo-hero/src/types.ts
+++ b/corpan/packs/lingo-hero/src/types.ts
@@ -256,6 +256,15 @@ export interface ResultCelebrateEvent {
 }
 
 /**
+ * Emitted when the player toggles the in-game MUTE control. The audio stream
+ * applies it live (and the preference is also persisted so it carries across
+ * runs). One mute control owns this — there is exactly one in the HUD.
+ */
+export interface MuteChangeEvent {
+  muted: boolean;
+}
+
+/**
  * The full event map. Keys are event names, values are payload types.
  * `GameEventBus` (src/events.ts) is typed against this map.
  */
@@ -272,6 +281,7 @@ export interface GameEventMap {
   gameResumed: GameResumedEvent;
   roundAdvance: RoundAdvanceEvent;
   "result-celebrate": ResultCelebrateEvent;
+  muteChange: MuteChangeEvent;
 }
 
 export type GameEventName = keyof GameEventMap;

--- a/corpan/packs/lingo-hero/src/ui/Hud.ts
+++ b/corpan/packs/lingo-hero/src/ui/Hud.ts
@@ -2,6 +2,11 @@ import type { GameEventBus } from "../events";
 import type { ProgressionApi } from "../progression";
 import { GameMode, type ActiveLanguage } from "../types";
 
+/** Shared with the audio stream — the single persisted mute preference key. */
+const MUTE_STORAGE_KEY = "lingoHero.audio.muted";
+/** Idle delay before the top-left chrome auto-fades during active play. */
+const CHROME_IDLE_MS = 2600;
+
 /**
  * Payload for the post-answer FEEDBACK card (slot c). The shell-ui stream fills
  * this from `wave-resolved`. Foundation only renders the surface + exposes the
@@ -49,6 +54,15 @@ export interface HudCallbacks {
    * older call sites still compile.
    */
   onContinue?: () => void;
+  /**
+   * User opened the PAUSE sheet (or pressed the OS/gesture back). Game pauses
+   * the loop + audio. Optional for older call sites.
+   */
+  onPause?: () => void;
+  /** User dismissed the pause sheet (Resume). Game resumes the loop + audio. */
+  onResume?: () => void;
+  /** User toggled the single MUTE control. Game emits `muteChange` on the bus. */
+  onSetMuted?: (muted: boolean) => void;
 }
 
 export class Hud {
@@ -71,11 +85,23 @@ export class Hud {
   private goLevelEl: HTMLElement;
   private goHighEl: HTMLElement;
 
+  private pauseBtn: HTMLElement;
+  private muteBtn: HTMLElement;
+  private pauseSheet: HTMLElement;
+
   private offFns: Array<() => void> = [];
   private lastMode: GameMode = GameMode.PRACTICE;
   private comboPulseTimer = 0;
   private flyoutTimer = 0;
   private feedbackTimer = 0;
+  /** Auto-fade timer for the top-left chrome (pause/mute) during active play. */
+  private chromeIdleTimer = 0;
+  /** True while the pause sheet is open (chrome must stay visible). */
+  private pauseOpen = false;
+  /** Persisted mute preference, mirrored into the toggle's pressed state. */
+  private muted = false;
+  /** Detach handle for the Android/gesture back (popstate) listener. */
+  private offPopState?: () => void;
   /** Words seen this run + correct count (drive the in-run mastery readout). */
   private runSeen = 0;
   private runCorrect = 0;
@@ -87,11 +113,41 @@ export class Hud {
     private progression?: ProgressionApi
   ) {
     this.root = document.createElement("div");
-    this.root.className = "ui-layer";
+    // Start on the menu: the in-game pause/mute chrome is hidden until a run
+    // begins (gameStart removes `chrome-off`).
+    this.root.className = "ui-layer chrome-off";
     this.root.innerHTML = `
-      <button class="lh-exit-btn" id="lh-exit" type="button" aria-label="Exit Lingo Hero" title="Exit">
-        <span aria-hidden="true">&#8592;</span>
+      <!-- TOP-LEFT chrome (issue #426): a single PAUSE control that opens a small
+           sheet (Resume / Exit) so an accidental tap can't dump a run mid-combo.
+           It AUTO-FADES during active play and reappears on tap / when paused.
+           Plus ONE mute toggle. Both are pointer-events:auto and stopPropagation,
+           so taps never leak through to the canvas lanes. The legacy #lh-exit id
+           is kept (inside the sheet) so the host/tests still resolve "exit". -->
+      <button class="lh-chrome-btn lh-pause-btn" id="lh-pause" type="button"
+              aria-label="Pause" title="Pause" aria-haspopup="dialog" aria-expanded="false">
+        <span aria-hidden="true">&#10073;&#10073;</span>
       </button>
+      <button class="lh-chrome-btn lh-mute-btn" id="lh-mute" type="button"
+              aria-label="Mute audio" aria-pressed="false" title="Mute">
+        <span class="lh-mute-on" aria-hidden="true">&#128266;</span>
+        <span class="lh-mute-off" aria-hidden="true">&#128263;</span>
+      </button>
+      <div class="lh-pause-sheet" id="lh-pause-sheet" role="dialog"
+           aria-label="Paused" aria-modal="true" hidden>
+        <div class="lh-pause-card">
+          <p class="lh-pause-title">Paused</p>
+          <button class="menu-btn blitz" id="lh-resume" type="button">
+            <span class="btn-icon" aria-hidden="true">&#9654;</span>
+            <span class="btn-labels"><span class="btn-title">Resume</span></span>
+            <span class="btn-chevron" aria-hidden="true">&#10095;</span>
+          </button>
+          <button class="menu-btn secondary" id="lh-exit" type="button" aria-label="Exit Lingo Hero">
+            <span class="btn-icon" aria-hidden="true">&#8592;</span>
+            <span class="btn-labels"><span class="btn-title">Exit</span></span>
+            <span class="btn-chevron" aria-hidden="true">&#10095;</span>
+          </button>
+        </div>
+      </div>
       <div class="menu-screen" id="menu" role="dialog" aria-label="Lingo Hero main menu">
         <div class="brand">
           <p class="brand-kicker">Rhythm · Language</p>
@@ -134,23 +190,22 @@ export class Hud {
             <div class="lh-assemble" id="lh-assemble" aria-live="polite" hidden></div>
           </div>
         </div>
-        <!-- STATS STRIP — moved OUT of the central play area so SCORE / COMBO /
-             progress never flank the falling-note lanes. On tall screens it
-             docks BELOW the hit-ring circles (near the bottom); on short
-             screens it collapses to a slim row at the very top. -->
+        <!-- BOTTOM STATS ROW — a SINGLE fixed, compact row pinned across the very
+             bottom (issue #426): level meter · SCORE · STREAK/COMBO. It sits
+             UNDER the hit-ring circles (which were nudged up) and is a centered,
+             content-width cluster so it NEVER flanks/overlaps the falling-note
+             lanes (preserves the 0.4.0 fix). pointer-events stay off the row. -->
         <div class="lh-stats" id="lh-stats">
-          <!-- (d) progress / mastery readout slot -->
+          <!-- (d) level / mastery meter slot (left of the row) -->
           <div class="mastery-readout" id="mastery-readout" aria-live="polite" hidden></div>
-          <div class="score-container">
-            <div class="stat score-box">
-              <span class="stat-label">Score</span>
-              <span class="stat-value" id="score">0</span>
-              <span class="score-flyout" id="score-flyout" aria-hidden="true"></span>
-            </div>
-            <div class="stat combo-box zero" id="combo-box">
-              <span class="stat-label">Combo</span>
-              <span class="combo-value"><span class="x">x</span><span id="combo">0</span></span>
-            </div>
+          <div class="stat score-box">
+            <span class="stat-label">Score</span>
+            <span class="stat-value" id="score">0</span>
+            <span class="score-flyout" id="score-flyout" aria-hidden="true"></span>
+          </div>
+          <div class="stat combo-box zero" id="combo-box">
+            <span class="stat-label">Streak</span>
+            <span class="combo-value"><span class="x">x</span><span id="combo">0</span></span>
           </div>
         </div>
         <!-- (c) post-answer FEEDBACK card surface (foreign <-> english + state) -->
@@ -188,6 +243,9 @@ export class Hud {
     `;
     container.appendChild(this.root);
 
+    this.pauseBtn = this.root.querySelector("#lh-pause")!;
+    this.muteBtn = this.root.querySelector("#lh-mute")!;
+    this.pauseSheet = this.root.querySelector("#lh-pause-sheet")!;
     this.menuScreen = this.root.querySelector("#menu")!;
     this.hudPanel = this.root.querySelector("#hud")!;
     this.gameOverScreen = this.root.querySelector("#game-over")!;
@@ -217,12 +275,30 @@ export class Hud {
     );
     this.bindButton("#btn-menu", () => this.callbacks.onShowMenu());
 
-    // Exit the pack entirely: the Corpán host listens for `corpan:exit` (App.tsx)
-    // and dismisses the game. Persistent (menu + gameplay) so there's always a
-    // way out besides the OS back button.
-    this.bindButton("#lh-exit", () =>
-      window.dispatchEvent(new CustomEvent("corpan:exit"))
-    );
+    // PAUSE control (top-left) → opens the small Resume/Exit sheet. Consolidating
+    // the top-left into a pause (not a bare exit) means an accidental tap can't
+    // dump a run mid-combo (issue #426). The sheet's Exit dispatches the host
+    // `corpan:exit` (App.tsx dismisses the game); Resume closes the sheet.
+    this.bindButton("#lh-pause", () => this.openPause());
+    this.bindButton("#lh-resume", () => this.closePause(true));
+    this.bindButton("#lh-exit", () => this.doExit());
+    // Tapping the sheet backdrop (outside the card) resumes — same as Resume.
+    this.bindButton("#lh-pause-sheet", (e) => {
+      if (e && e.target === this.pauseSheet) this.closePause(true);
+    });
+
+    // The single MUTE toggle. Reads the persisted preference for its initial
+    // pressed state, then flips it live + persists on each tap.
+    this.muted = this.readStoredMuted();
+    this.reflectMute();
+    this.bindButton("#lh-mute", () => this.toggleMute());
+
+    // ANDROID hardware/gesture BACK: wire window 'popstate' to the SAME exit
+    // path so Android users get a back-gesture exit in addition to the visible
+    // pause control (iOS has no system back button → the visible control is the
+    // accessible affordance). We push one history entry when the run starts so
+    // the first back press lands here instead of leaving the SPA.
+    this.installBackHandler();
 
     // The held result card is itself a tap-to-continue surface (it sits in the
     // pointer-events:none overlay but takes pointer-events:auto while held).
@@ -244,6 +320,48 @@ export class Hud {
     // force reflow so the animation restarts
     void this.questionBox.offsetWidth;
     this.questionBox.style.animation = "";
+    // AUTO-FIT: the prompt must ALWAYS show in full (issue #426). The phrase may
+    // be a long sentence; CSS wraps it, but a big base font on a narrow phone can
+    // still overflow the reserved header band. Shrink the font (down to a sane
+    // floor) until the FULL text fits within the band at up to ~2 lines, so it is
+    // never clipped at any length.
+    this.fitPrompt();
+  }
+
+  /**
+   * Shrink the prompt font until the entire phrase fits inside the header band
+   * (up to ~2 wrapped lines), floored so short phrases stay big and long ones
+   * stay legible. Measured against the element's own scroll size so it works for
+   * any phrase length / script. Idempotent + cheap (a handful of reflows). The
+   * upper bound is the CSS-resolved size so short prompts keep their full scale.
+   */
+  private fitPrompt(): void {
+    const el = this.questionBox;
+    if (!el.textContent) return;
+    // Reset to the CSS-driven size, then read it as our ceiling.
+    el.style.fontSize = "";
+    const ceiling = parseFloat(getComputedStyle(el).fontSize) || 24;
+    const FLOOR = 13; // px — never shrink below this (still readable)
+    // Two passes: first cap the height to ~2 lines, then ensure no horizontal
+    // overflow. Bisect-ish linear step keeps it bounded (<= ~12 iterations).
+    let size = ceiling;
+    el.style.fontSize = `${size}px`;
+    const lineH = 1.16;
+    // Budget: at most 2 lines tall. maxH derives from the current font (2 lines
+    // + the box's vertical padding, already in offsetHeight via clientHeight).
+    const fits = (): boolean => {
+      const maxLines = 2;
+      const maxH = size * lineH * maxLines + 2;
+      return (
+        el.scrollHeight <= maxH + 1 && el.scrollWidth <= el.clientWidth + 1
+      );
+    };
+    let guard = 0;
+    while (size > FLOOR && !fits() && guard < 24) {
+      size = Math.max(FLOOR, size - 1);
+      el.style.fontSize = `${size}px`;
+      guard++;
+    }
   }
 
   /**
@@ -423,12 +541,152 @@ export class Hud {
     this.root.setAttribute("data-text-size", lang.textSize);
   }
 
+  /** Re-fit the prompt to the current viewport (Game calls this on resize). */
+  onResize(): void {
+    this.fitPrompt();
+  }
+
+  // -------------------------------------------------------------------------
+  // TOP-LEFT CHROME: pause sheet, mute, auto-fade, Android back. (Issue #426)
+  // -------------------------------------------------------------------------
+
+  /** Open the pause sheet (Resume / Exit) and pause the game. */
+  private openPause(): void {
+    if (this.pauseOpen) return;
+    this.pauseOpen = true;
+    this.pauseSheet.hidden = false;
+    this.pauseBtn.setAttribute("aria-expanded", "true");
+    this.showChrome(); // keep chrome visible while paused
+    this.callbacks.onPause?.();
+    // Move focus into the sheet for keyboard/AT users.
+    const resume = this.pauseSheet.querySelector<HTMLElement>("#lh-resume");
+    resume?.focus?.();
+  }
+
+  /** Close the pause sheet. `resume` true → resume gameplay (vs. on exit). */
+  private closePause(resume: boolean): void {
+    if (!this.pauseOpen) return;
+    this.pauseOpen = false;
+    this.pauseSheet.hidden = true;
+    this.pauseBtn.setAttribute("aria-expanded", "false");
+    if (resume) {
+      this.callbacks.onResume?.();
+      this.showChrome(); // re-arm the auto-fade after resuming
+    }
+  }
+
+  /** Exit the pack: close the sheet, then ask the host to dismiss the game. */
+  private doExit(): void {
+    this.closePause(false);
+    window.dispatchEvent(new CustomEvent("corpan:exit"));
+  }
+
+  /** Toggle the single mute control: flip, persist, reflect, notify Game. */
+  private toggleMute(): void {
+    this.muted = !this.muted;
+    try {
+      localStorage.setItem(MUTE_STORAGE_KEY, this.muted ? "1" : "0");
+    } catch {
+      /* storage may be unavailable; the live toggle still works this session */
+    }
+    this.reflectMute();
+    this.callbacks.onSetMuted?.(this.muted);
+    this.showChrome();
+  }
+
+  private readStoredMuted(): boolean {
+    try {
+      return localStorage.getItem(MUTE_STORAGE_KEY) === "1";
+    } catch {
+      return false;
+    }
+  }
+
+  /** Sync the mute button's pressed state + label to `this.muted`. */
+  private reflectMute(): void {
+    this.muteBtn.setAttribute("aria-pressed", this.muted ? "true" : "false");
+    this.muteBtn.setAttribute(
+      "aria-label",
+      this.muted ? "Unmute audio" : "Mute audio"
+    );
+    this.muteBtn.classList.toggle("is-muted", this.muted);
+  }
+
+  /**
+   * Reveal the top-left chrome (pause + mute) and arm an auto-fade so it tucks
+   * away during active play (issue #426 — unobtrusive). It reappears on any tap
+   * (handled by Game forwarding interaction) or whenever the sheet is open.
+   */
+  private showChrome(): void {
+    this.root.classList.remove("chrome-hidden");
+    if (this.chromeIdleTimer) clearTimeout(this.chromeIdleTimer);
+    // Never fade while paused (the user needs the sheet + controls visible).
+    if (this.pauseOpen) return;
+    this.chromeIdleTimer = window.setTimeout(() => {
+      // Only fade during active gameplay (not on the menu / game-over).
+      if (!this.hudPanel.classList.contains("hidden") && !this.pauseOpen) {
+        this.root.classList.add("chrome-hidden");
+      }
+    }, CHROME_IDLE_MS);
+  }
+
+  /**
+   * Game calls this on any lane interaction so the chrome briefly reappears
+   * (then re-fades), giving the player a reliable way to surface the exit/pause
+   * without leaving it permanently on screen.
+   */
+  notifyInteraction(): void {
+    this.showChrome();
+  }
+
+  /** True while the pause sheet is open (Game gates its own input on this). */
+  isPaused(): boolean {
+    return this.pauseOpen;
+  }
+
+  /**
+   * Wire the Android hardware/gesture BACK button (and desktop browser back) to
+   * the pause/exit path via History + popstate. We push a sentinel state on
+   * gameStart; the first back press fires popstate (consumed here) instead of
+   * navigating away. If a run is active we open the pause sheet (so back doesn't
+   * instantly dump the run); a second back from the open sheet exits.
+   */
+  private installBackHandler(): void {
+    if (typeof window === "undefined") return;
+    const onPop = () => {
+      // Only meaningful during gameplay; ignore on menu/game-over.
+      if (this.hudPanel.classList.contains("hidden")) return;
+      // Re-arm a sentinel so a subsequent back is caught again.
+      this.armHistorySentinel();
+      if (this.pauseOpen) {
+        // Already paused → back means EXIT.
+        this.doExit();
+      } else {
+        this.openPause();
+      }
+    };
+    window.addEventListener("popstate", onPop);
+    this.offPopState = () => window.removeEventListener("popstate", onPop);
+  }
+
+  /** Push one sentinel history entry so the next back press hits popstate. */
+  private armHistorySentinel(): void {
+    try {
+      window.history.pushState({ lingoHero: true }, "");
+    } catch {
+      /* history may be unavailable (e.g. file:// sandboxes); degrade silently */
+    }
+  }
+
   dispose(): void {
     for (const off of this.offFns) off();
     this.offFns = [];
     if (this.comboPulseTimer) clearTimeout(this.comboPulseTimer);
     if (this.flyoutTimer) clearTimeout(this.flyoutTimer);
     if (this.feedbackTimer) clearTimeout(this.feedbackTimer);
+    if (this.chromeIdleTimer) clearTimeout(this.chromeIdleTimer);
+    this.offPopState?.();
+    this.offPopState = undefined;
     this.root.remove();
   }
 
@@ -451,6 +709,13 @@ export class Hud {
         this.runSeen = 0;
         this.runCorrect = 0;
         this.refreshMastery();
+        // A run begins: reveal the in-game chrome (pause + mute), close any
+        // pause sheet, surface the chrome (it then auto-fades), and arm the
+        // Android-back sentinel for this run.
+        this.root.classList.remove("chrome-off");
+        this.closePause(false);
+        this.showChrome();
+        this.armHistorySentinel();
       }),
       this.bus.on("menuShown", () => {
         this.menuScreen.classList.remove("hidden");
@@ -458,6 +723,12 @@ export class Hud {
         this.gameOverScreen.classList.add("hidden");
         this.hideFeedback();
         this.setMastery(null);
+        // Off the playfield (menu): pause/mute have no meaning here — hide the
+        // in-game chrome entirely (the menu has its own affordances).
+        this.closePause(false);
+        this.root.classList.add("chrome-off");
+        this.root.classList.remove("chrome-hidden");
+        if (this.chromeIdleTimer) clearTimeout(this.chromeIdleTimer);
       }),
       this.bus.on("scoreChange", (e) => {
         this.scoreEl.textContent = e.value.toLocaleString();
@@ -473,6 +744,12 @@ export class Hud {
         this.gameOverScreen.classList.remove("hidden");
         this.finalScoreEl.textContent = e.finalScore.toLocaleString();
         this.populateGameOverStats(e.finalScore);
+        // Run ended: the game-over panel owns navigation (Retry / Main Menu),
+        // so hide the in-game pause/mute chrome here too.
+        this.closePause(false);
+        this.root.classList.add("chrome-off");
+        this.root.classList.remove("chrome-hidden");
+        if (this.chromeIdleTimer) clearTimeout(this.chromeIdleTimer);
       }),
       // (c) LEARNING SURFACE — the single, reliable per-wave verdict hook.
       // Raise the meaning-reveal feedback card and advance the run mastery
@@ -566,7 +843,7 @@ export class Hud {
     this.newBestEl.classList.toggle("hidden", !isNewBest);
   }
 
-  private bindButton(selector: string, action: () => void): void {
+  private bindButton(selector: string, action: (e?: Event) => void): void {
     const btn = this.root.querySelector(selector);
     if (!btn) return;
 
@@ -574,11 +851,13 @@ export class Hud {
     const handleEvent = (e: Event) => {
       if (handled) return;
       e.preventDefault();
+      // stopPropagation is CRITICAL: these controls live in the ui overlay above
+      // the canvas; without it a tap could bubble/leak into a lane (tap-through).
       e.stopPropagation();
       handled = true;
       setTimeout(() => (handled = false), 300);
       try {
-        action();
+        action(e);
       } catch (err) {
         console.error(`[Hud] Error in button action:`, err);
       }

--- a/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
+++ b/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
@@ -12,9 +12,12 @@
  *   (b) CATCH SCORES — tapping the lane of the correct NEXT target word (the
  *       one with seqIndex === caughtCount), at its visual position on the strum
  *       line, INCREASES the score. (input coords + catch-in-sequence)
- *   (c) NO TAP-THROUGH — tapping the on-screen Exit control does NOT score
- *       (the in-game mute button was removed; Exit is the only top chrome and
- *       must capture its own taps rather than leaking into a lane).
+ *   (c) NO TAP-THROUGH — tapping the on-screen chrome (the Pause control + its
+ *       Resume/Exit sheet, and the single Mute toggle) does NOT score; the
+ *       controls must capture their own taps rather than leaking into a lane.
+ *   (e) PROMPT FULLY VISIBLE — a deliberately LONG primary-language prompt
+ *       renders without truncation (no horizontal overflow; wraps within the
+ *       header band). The #426 prompt auto-fit/wrap contract.
  *   (d) NO BRICK — a round left with NO INPUT eventually RESOLVES (the chart
  *       exhausts and the phrase resolves into the result linger / next round)
  *       rather than leaving the player stuck with empty lanes + half strip.
@@ -87,25 +90,111 @@ await page.waitForFunction(() => (window.__lingoHero.notes || []).length > 0, { 
   }
 }
 
-// --- Contract (c): control tap (Exit) must NOT score (no tap-through). -------
-// The Exit button is the only top chrome now. It sits in the pointer-events:none
-// overlay but opts back in, so a tap on it must NOT reach the lane input. We
-// stub corpan:exit so the click doesn't actually tear the game down mid-test.
+// --- Contract (c): control tap (Pause) must NOT score (no tap-through). ------
+// The top-left chrome is now a PAUSE control that opens a Resume/Exit sheet, plus
+// a single MUTE toggle. Both sit in the pointer-events:none overlay but opt back
+// in + stopPropagation, so a tap on them must NOT reach the lane input. We stub
+// corpan:exit so the eventual Exit doesn't tear the game down mid-test, and
+// force the chrome visible (it auto-fades during play) before measuring.
 await page.evaluate(() => {
   window.__exitFired = 0;
   window.addEventListener("corpan:exit", () => { window.__exitFired++; }, true);
+  // Surface the auto-fading chrome so the control is hittable in this frame.
+  document.querySelector(".ui-layer")?.classList.remove("chrome-hidden");
 });
-const exit = await page.evaluate(() => {
-  const b = document.querySelector("#lh-exit"); if (!b) return null;
+const pauseCtl = await page.evaluate(() => {
+  const b = document.querySelector("#lh-pause"); if (!b) return null;
   const r = b.getBoundingClientRect(); return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
 });
-if (!exit) fail("no #lh-exit control found");
+if (!pauseCtl) fail("no #lh-pause control found");
 else {
   const before = (await read()).score;
-  await page.mouse.click(exit.x, exit.y);
+  await page.mouse.click(pauseCtl.x, pauseCtl.y);
   await page.waitForTimeout(140);
-  if ((await read()).score !== before) fail("tap-through: Exit tap changed the score");
-  else console.log("OK: Exit tap did not leak into a lane");
+  if ((await read()).score !== before) fail("tap-through: Pause tap changed the score");
+  else console.log("OK: Pause tap did not leak into a lane");
+  // The pause sheet must now be open (Resume / Exit) and the run paused.
+  const sheetOpen = await page.evaluate(() => {
+    const s = document.querySelector("#lh-pause-sheet");
+    return !!s && !s.hidden && !!document.querySelector("#lh-exit") && !!document.querySelector("#lh-resume");
+  });
+  if (!sheetOpen) fail("pause control did not open the Resume/Exit sheet");
+  else console.log("OK: pause control opened the Resume/Exit sheet");
+  // Tapping Exit inside the sheet must NOT score either, and must fire corpan:exit.
+  const exit = await page.evaluate(() => {
+    const b = document.querySelector("#lh-exit"); if (!b) return null;
+    const r = b.getBoundingClientRect(); return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+  });
+  if (!exit) fail("no #lh-exit control found inside the pause sheet");
+  else {
+    const before = (await read()).score;
+    await page.mouse.click(exit.x, exit.y);
+    await page.waitForTimeout(120);
+    if ((await read()).score !== before) fail("tap-through: Exit tap changed the score");
+    else if (!(await page.evaluate(() => window.__exitFired > 0))) fail("Exit tap did not dispatch corpan:exit");
+    else console.log("OK: Exit tap fired corpan:exit and did not leak into a lane");
+  }
+  // Resume so the rest of the test plays normally (Exit was stubbed, run is live).
+  await page.evaluate(() => window.__lingoHero.resume && window.__lingoHero.resume());
+}
+
+// --- Contract (c2): MUTE control tap must NOT score (no tap-through). --------
+await page.evaluate(() => document.querySelector(".ui-layer")?.classList.remove("chrome-hidden"));
+const muteCtl = await page.evaluate(() => {
+  const b = document.querySelector("#lh-mute"); if (!b) return null;
+  // Exactly ONE mute control must exist.
+  if (document.querySelectorAll("#lh-mute, .lh-mute-btn").length !== 1) return { dupe: true };
+  const r = b.getBoundingClientRect(); return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+});
+if (!muteCtl) fail("no #lh-mute control found");
+else if (muteCtl.dupe) fail("more than one mute control present");
+else {
+  const before = (await read()).score;
+  await page.mouse.click(muteCtl.x, muteCtl.y);
+  await page.waitForTimeout(120);
+  if ((await read()).score !== before) fail("tap-through: Mute tap changed the score");
+  else console.log("OK: Mute tap did not leak into a lane");
+  // Unmute again so audio state is neutral for later phases.
+  await page.mouse.click(muteCtl.x, muteCtl.y);
+}
+
+// --- Contract (e): the PROMPT shows the FULL phrase (no truncation). ---------
+// Inject a deliberately LONG primary-language prompt and assert the question box
+// renders it WITHOUT clipping: scrollWidth must fit clientWidth (no horizontal
+// overflow) and scrollHeight must fit within the wrapped-line budget. This is the
+// #426 prompt auto-fit/wrap contract — long phrases must never be cut off.
+{
+  const LONG = "When my passport disappeared at the hostel in the middle of the night";
+  const probe = await page.evaluate((text) => {
+    const g = window.__lingoHero;
+    g.hud.setQuestion(text);
+    const el = document.querySelector("#question-box");
+    if (!el) return null;
+    const cs = getComputedStyle(el);
+    return {
+      text: el.textContent,
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+      scrollHeight: el.scrollHeight,
+      fontPx: parseFloat(cs.fontSize),
+      lineHeightPx: parseFloat(cs.lineHeight) || parseFloat(cs.fontSize) * 1.16,
+    };
+  }, LONG);
+  if (!probe) fail("no #question-box element to check prompt fit");
+  else {
+    if (probe.text !== LONG) fail(`prompt text was altered/truncated: ${JSON.stringify(probe.text)}`);
+    if (probe.scrollWidth > probe.clientWidth + 1) {
+      fail(`prompt overflows horizontally (scrollWidth ${probe.scrollWidth} > clientWidth ${probe.clientWidth})`);
+    }
+    // Allow up to ~3 lines of slack (the box wraps to 2; padding adds a little).
+    const maxH = probe.lineHeightPx * 3 + 8;
+    if (probe.scrollHeight > maxH) {
+      fail(`prompt overflows vertically (scrollHeight ${probe.scrollHeight} > budget ${maxH.toFixed(0)})`);
+    }
+    if (failures === 0 || probe.scrollWidth <= probe.clientWidth + 1) {
+      console.log(`OK: long prompt fully visible (font ${probe.fontPx.toFixed(0)}px, ${probe.scrollWidth}<=${probe.clientWidth}w, ${probe.scrollHeight}px tall)`);
+    }
+  }
 }
 
 // --- Contract (b): catching the correct NEXT target word scores. -------------


### PR DESCRIPTION
### **User description**
Closes #426. **Pack:** `lingo_hero` (preview channel) · **0.4.2 → 0.4.3**.

A single coherent HUD/layout pass addressing all three parts of #426.

## 1. Prompt never truncates
The top primary-language prompt clipped on longer phrases. It now **auto-fits**: the font shrinks to a readable floor and the phrase wraps so the **entire** prompt is visible at any length, re-fitting on resize/rotation. The prompt centers across the full width **below** the top-left chrome, so it never crowds the right edge or collides with the controls — and it does not collide with the notes spawning at the top (the header stays a transparent overlay; notes show through behind the scrim).

`Hud.setQuestion` → new `Hud.fitPrompt`; `.question-box`/`.top-bar` styles; `Game.handleResize` → `Hud.onResize`.

## 2. One compact bottom HUD row, clear of the rings
Level meter · **SCORE** · **STREAK** now sit in a **single fixed compact row** pinned across the very bottom, **under** the hit-ring circles. The rings were **nudged up** (strum line `0.8 → 0.74` of height) so they are **fully visible and never clipped** at the screen edge. The row is a centered, content-width cluster, so it never flanks/overlaps the falling-note lanes (preserves the 0.4.0 fix); bottom inset respects the Android safe area. Works on small/narrow phone screens.

`Hud` stats markup; `.lh-stats` styles; `LaneSystem.STRUM_LINE_Y_RATIO` + `getStrumRatio`.

## 3. Accessible auto-hiding pause/exit + Android back
The bare top-left exit is replaced by a small **PAUSE** control that opens a **Resume / Exit** sheet (so an accidental tap can't dump a run mid-combo). It **auto-fades** during active play and reappears on any tap / when paused. The **Android hardware/gesture back** (`popstate`) is wired to the same pause→exit path, so Android gets both a visible control and the back gesture (iOS keeps the visible affordance — no system back button). Exactly **one mute** toggle sits beside it; both controls are **canvas-input-safe** (`stopPropagation`, layered above the canvas) so taps never leak through into a lane. Chrome is hidden on the menu / game-over screens (those own their own navigation).

`Hud` pause/mute/back wiring; `Game` pause/resume/mute callbacks; new `muteChange` event applied live in `audio/index.ts`.

## Preserved contracts
Answer dedup; offline-first (no network/remote fonts); TTS speaks raw foreign text; pack id `lingo_hero`; canvas-relative input (`InputManager.canvasX` unchanged); delta-timed motion (`NOTE_TRAVEL_SECONDS`); the #407 language rule (target rotates across learning langs; 1-lang stack = reading mode); `window.__lingoHero` introspectable.

## Verification
- **Build + tsc:** clean (`npm run build`, `tsc --noEmit`).
- **e2e** (`test/e2e/gameplay.spec.mjs`, headless Chromium, app-like offset container): **PASS**. Existing assertions kept (note y increases; catching the correct next target word scores; mute/control taps don't score). Added: long-prompt full-visibility (no horizontal overflow / wraps), pause control opens the Resume/Exit sheet, tapping pause / Exit / mute does not score or register a lane hit, exactly one mute control.
- **Design-critic gate** (senior product/visual designer, `frontend-design` skill, reviewed menu + 8 gameplay frames + worst-case full-HUD + pause-sheet frames): **VERDICT: PLAYABLE — zero blockers.** Prompt full and unclipped at worst-case length; bottom HUD one compact row under fully-visible rings, clear of lanes; single pause + single mute with working Resume/Exit sheet. Polish notes (e.g. tighten the ring↔row gap) filed as follow-ups, not gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement, Tests, Documentation


___

### **Description**
- Auto-fit long prompts on resize

- Compact bottom stats below rings

- Add pause sheet, back, mute controls

- Expand e2e coverage and release metadata


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Long prompts"] -- "auto-fit" --> B["Visible header text"]
  C["Bottom HUD"] -- "compact row" --> D["Clear hit rings"]
  E["Top chrome"] -- "pause/mute/back" --> F["Safer controls"]
  F -- "covered by" --> G["E2E tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>Game.ts</strong><dd><code>Wire HUD pause, mute, resize, interaction callbacks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/431/files#diff-6c075e8c51d32e4e5452a4c738f6cc530345361455286e0f7d1af37f46fedde7">+15/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Apply live mute changes to audio bed</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/431/files#diff-2184219bcd7d4e7e52fed856f6c7e9983d9b3372de1de66e7fc1aac52cdb241f">+19/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Add typed mute change event payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/431/files#diff-90db924f79313d23c6eada5092c9adb12ccb7ceb3a47dcd832071a22448af88b">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Hud.ts</strong><dd><code>Add auto-fit prompt and pause chrome</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/431/files#diff-145e656a10e1e233418a8c559a94e938bf0e0c922802aa2f87d69b0498a38c02">+305/-26</a></td>

</tr>

<tr>
  <td><strong>styles.css</strong><dd><code>Restyle prompt, chrome, and bottom stats</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/431/files#diff-b9b9a82cd5a6b2fe32239b2b4b2f069c2c4853d63db1736b575103a5d1daf226">+165/-67</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>LaneSystem.ts</strong><dd><code>Raise strum line and expose ratio</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/431/files#diff-49208e8c6b4d3a2cbe84d78c7e15bd2cf92174f83b0eeb9992687c59a0375125">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document Lingo Hero 0.4.3 HUD fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/431/files#diff-dd09bf20e11864991961b7ef6d2fc6687a66d9a9de2d246f765d9d6891e646c2">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>manifest.json</strong><dd><code>Bump pack version and development revision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/431/files#diff-38411e79d50eee7f8ad439a29518dcddf16cdc9cd03739fc81ea212f18519b15">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>gameplay.spec.mjs</strong><dd><code>Cover pause, mute, and prompt visibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/431/files#diff-5ee22f0c6a817c0427478004e2238facf99cd3c18591eda51d590170655a3c57">+102/-13</a></td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

