### PR TITLE
Lingo Hero 0.4.4: full-height lane beams + decoy-dodge reward (#427, #429)

### DIFF
--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-06-23
+
+A juice / visual pass (issues #427 and #429): the lane tracks now read as
+continuous full-height beams, and correctly DODGING a decoy is celebrated
+instead of passing silently.
+
+### Added
+- **Dodging a decoy is now rewarded (#429).** When a DECOY (distractor) word
+  crosses the strum line UN-caught — the correct play — the player now earns
+  points, a combo boost, and a small celebration: a mint-green "DODGED +N"
+  popup, an upward sparkle burst with gold glints, a soft shockwave + lane
+  flash, and a bright airy "phew" SFX. Points are scaled below a correct catch
+  (`40 + combo*4` vs `100 + combo*10`) so dodging can never out-score catching
+  the real words, and a clean dodge keeps the difficulty streak climbing.
+  Catching a decoy is still a miss/combo-break; letting the CORRECT word pass is
+  still a miss (never a dodge reward). New `decoy-dodged` bus event +
+  `playDecoyDodged` SFX; `window.__lingoHero.decoyDodges` is introspectable.
+  (`Game.rewardDecoyDodge`, `effects/index.ts`, `audio/sounds.ts` + `audio/index.ts`.)
+
+### Changed
+- **Lane color beams now extend the full playfield height (#427).** Each lane's
+  colored beam previously started partway down the track; it now runs as one
+  continuous column from the top edge (where notes spawn), brightest hugging the
+  strum line, carried down to the bottom edge — so every lane reads as an
+  unbroken track from spawn past the strum. Tuned to stay restrained (Neon
+  Arcade): the beam concentrates its light at the action band and never
+  out-glows the falling word cards. (`Renderer.drawLanes` volumetric shafts.)
+
 ## [0.4.3] - 2026-06-24
 
 A HUD / layout pass (issue #426): the prompt always shows in full, the bottom

--- a/corpan/packs/lingo-hero/manifest.json
+++ b/corpan/packs/lingo-hero/manifest.json
@@ -2,7 +2,7 @@
   "id": "lingo_hero",
   "channel": "preview",
   "name": "Lingo Hero",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Catch the translation. The phrase you know falls as a chart of timed notes in the language you're learning — catch each word in rhythm, in order, and hear it spoken.",
   "entry": "dist/app.js",
   "styles": [
@@ -11,5 +11,5 @@
   "entryType": "script",
   "sdkVersion": "0.1.0",
   "minAppVersion": "0.17.0",
-  "devRevision": "2026-06-24T02:00:00.000Z"
+  "devRevision": "2026-06-23T18:00:00.000Z"
 }

--- a/corpan/packs/lingo-hero/src/Game.ts
+++ b/corpan/packs/lingo-hero/src/Game.ts
@@ -70,6 +70,12 @@ export class Game {
   private notes: Note[] = [];
   private score: number = 0;
   private combo: number = 0;
+  /**
+   * How many DECOYS the player has correctly DODGED this run (a wrong card
+   * crossed the strum line un-caught — the right play, issue #429). Introspected
+   * by the e2e harness via window.__lingoHero to prove the dodge reward fires.
+   */
+  private decoyDodges: number = 0;
   // Seconds a word takes to fall from spawn to the strum line. Higher = slower
   // & easier — THE primary playability knob, delta-timed so it is frame-rate
   // independent on high-refresh phones.
@@ -371,6 +377,7 @@ export class Game {
     this.mode = mode;
     this.score = 0;
     this.combo = 0;
+    this.decoyDodges = 0;
     this.notes = [];
     this.round = null;
     this.roundWords = [];
@@ -857,6 +864,39 @@ export class Game {
     }
   }
 
+  /**
+   * REWARD a correctly-dodged DECOY (issue #429): the player let a distractor
+   * card sail past the strum line un-caught — the right play. We award points
+   * (scaled BELOW a correct catch so dodging can never out-score catching the
+   * real words), KEEP and gently boost the combo (a clean dodge sustains the
+   * streak rather than just not breaking it), and fire a small celebration via
+   * the bus (effects burst + a positive SFX). A dodge does NOT mark the chart
+   * unclean — avoiding a foil is correct, so the difficulty streak keeps
+   * climbing. Only ever called for a genuine decoy note (isTarget === false).
+   */
+  private rewardDecoyDodge(lane: LaneIndex) {
+    if (this.state !== GameState.PLAYING) return;
+    this.decoyDodges++;
+    // Points: a catch is 100 + combo*10; a dodge is deliberately smaller so a
+    // run of dodges can't beat actually catching the translation.
+    const points = 40 + this.combo * 4;
+    this.setScore(this.score + points);
+    // A clean dodge sustains/boosts the streak (combo +1) — it should FEEL like
+    // a win, not merely a non-loss — but never breaks it.
+    this.setCombo(this.combo + 1);
+
+    const x = this.laneSystem.getLaneX(lane);
+    const y = this.laneSystem.getStrumLineY();
+    this.bus.emit("decoy-dodged", {
+      lane,
+      x,
+      y,
+      combo: this.combo,
+      points,
+      mode: this.mode,
+    });
+  }
+
   private loop(timestamp: number) {
     if (!this.isRunning) return;
 
@@ -966,10 +1006,19 @@ export class Game {
                 },
             });
             this.advanceStep(false);
+          } else if (!note.isTarget) {
+            // DECOY DODGED (issue #429): a distractor card crossed the strum
+            // line UN-caught — exactly the right play. Reward it: points, a
+            // combo boost, and a small celebration (juice). Distinct from a
+            // missed correct word (handled above, still a miss) and from a
+            // consumed/out-of-sequence target (retired silently below).
+            note.missed = true;
+            this.rewardDecoyDodge(note.lane);
           } else {
-            // A decoy or an already-consumed/out-of-sequence note falling past
-            // the line is simply retired — no penalty (dodging a decoy is the
-            // correct play).
+            // An already-consumed / out-of-sequence TARGET note falling past the
+            // line is simply retired — no penalty and no reward (it was already
+            // caught earlier in the sequence, or is a future word the player has
+            // not reached). Only a genuine decoy earns the dodge reward.
             note.missed = true;
           }
         }

--- a/corpan/packs/lingo-hero/src/Game.ts
+++ b/corpan/packs/lingo-hero/src/Game.ts
@@ -978,8 +978,10 @@ export class Game {
           note.y += this.speed * dt;
         }
 
-        if (note.y > boundsHeight + 120) note.missed = true;
-
+        // Handle the strum pass-line FIRST (catch / dodge / miss verdicts), then
+        // fall through to the off-screen retire. Ordering matters: if a fast
+        // frame jumped the note past both lines at once, the bottom-bounds retire
+        // must not pre-empt the dodge reward / miss for a note crossing the strum.
         if (note.y > passLine && !note.hit && !note.missed) {
           if (note.isTarget && note.seqIndex === this.caughtCount) {
             // The NEXT correct word sailed past the strum unhit → a miss. Combo
@@ -1022,6 +1024,11 @@ export class Game {
             note.missed = true;
           }
         }
+
+        // Off-screen retire fallback: anything that somehow fell well past the
+        // bottom edge without being resolved above is marked missed so it can be
+        // filtered out (defensive; the pass-line handling above is the norm).
+        if (note.y > boundsHeight + 120 && !note.hit) note.missed = true;
       });
 
       this.notes = this.notes.filter(

--- a/corpan/packs/lingo-hero/src/Renderer.ts
+++ b/corpan/packs/lingo-hero/src/Renderer.ts
@@ -152,30 +152,51 @@ export class Renderer {
       dt
     );
 
-    // 3) VOLUMETRIC NEON LANE SHAFTS — a soft column of lane-colored light per
-    //    lane, brightest at the strum line, fading up the track. Additive.
+    // 3) VOLUMETRIC NEON LANE SHAFTS — a CONTINUOUS lane-colored beam per lane,
+    //    running the FULL HEIGHT of the playfield (top edge → past the strum,
+    //    down to the bottom edge) so every lane reads as one unbroken track from
+    //    spawn to strum (issue #427). Brightness is shaped along the column:
+    //    softly present at the very top (notes spawn here), brightest hugging the
+    //    strum line (the action band), then carried — dimmer — all the way to the
+    //    bottom edge so the track never visually "stops short". Tastefully
+    //    restrained (Neon Arcade): the column never out-glows the falling word
+    //    cards; the strum band is where it concentrates its light. Additive.
     ctx.save();
     ctx.globalCompositeOperation = "lighter";
+    const strumStop = height > 0 ? clamp01(strumY / height) : 0.74;
     for (let i = 0; i < 3; i++) {
       const c = this.laneColors[i];
       const cx = this.laneSystem.getLaneX(i as LaneIndex);
       const halfW = lane0.width * 0.5;
-      // Vertical shaft: brightest band hugging the strum line.
-      const shaft = ctx.createLinearGradient(0, strumY - height * 0.62, 0, strumY + 12);
-      const baseA = 0.05 + energy * 0.06;
-      shaft.addColorStop(0, rgba(c, 0));
-      shaft.addColorStop(0.78, rgba(c, baseA));
-      shaft.addColorStop(1, rgba(c, baseA + 0.1 + energy * 0.08));
-      ctx.fillStyle = shaft;
-      ctx.fillRect(cx - halfW, strumY - height * 0.62, halfW * 2, height * 0.62 + 12);
 
-      // A tighter, brighter central glow line down each lane.
+      // Full-height beam: one gradient from the top edge to the bottom edge.
+      // Top: a gentle wash so the spawn zone reads as the same track. Strum:
+      // the brightest band. Bottom: a faded-but-present tail so the beam reaches
+      // the very edge (continuous), without competing with the bottom HUD row.
+      const shaft = ctx.createLinearGradient(0, 0, 0, height);
+      const topA = 0.035 + energy * 0.03; // subtle at spawn
+      const strumA = 0.13 + energy * 0.1; // brightest at the action band
+      const botA = 0.07 + energy * 0.05; // carried to the bottom edge (present, not dark)
+      shaft.addColorStop(0, rgba(c, topA));
+      // Ramp up toward the strum line (placed at its real screen fraction).
+      shaft.addColorStop(Math.max(0.02, strumStop - 0.18), rgba(c, topA + 0.035));
+      shaft.addColorStop(strumStop, rgba(c, strumA));
+      // Carry the beam below the strum to the bottom edge so it never stops short
+      // — a visible-but-restrained tail keeps the track continuous past the rings
+      // without competing with the bottom HUD stats row.
+      shaft.addColorStop(Math.min(0.999, strumStop + 0.05), rgba(c, strumA * 0.72));
+      shaft.addColorStop(1, rgba(c, botA));
+      ctx.fillStyle = shaft;
+      ctx.fillRect(cx - halfW, 0, halfW * 2, height);
+
+      // A tighter, brighter central glow line down each lane — also full height,
+      // so the lane's "spine" of light reads continuously top→bottom.
       const core = ctx.createLinearGradient(cx - halfW * 0.12, 0, cx + halfW * 0.12, 0);
       core.addColorStop(0, rgba(c, 0));
-      core.addColorStop(0.5, rgba(c, 0.08 + energy * 0.07));
+      core.addColorStop(0.5, rgba(c, 0.07 + energy * 0.06));
       core.addColorStop(1, rgba(c, 0));
       ctx.fillStyle = core;
-      ctx.fillRect(cx - halfW * 0.12, strumY - height * 0.55, halfW * 0.24, height * 0.55);
+      ctx.fillRect(cx - halfW * 0.12, 0, halfW * 0.24, height);
     }
     ctx.restore();
 

--- a/corpan/packs/lingo-hero/src/audio/index.ts
+++ b/corpan/packs/lingo-hero/src/audio/index.ts
@@ -13,6 +13,7 @@ import {
   playStart,
   playGameOver,
   playWaveVerdict,
+  playDecoyDodged,
 } from "./sounds";
 
 /**
@@ -203,6 +204,16 @@ export function initAudioHaptics(bus: GameEventBus): AudioHandle {
         playMiss(synth, lanePan(e.lane));
         haptics.miss();
       }
+    })
+  );
+
+  // --- decoy-dodged: bright "phew + sparkle" reward + a light haptic tick ---
+  // The player correctly dodged a distractor (issue #429). A positive, airy cue
+  // that celebrates the avoidance without competing with the catch bell.
+  unsubs.push(
+    bus.on("decoy-dodged", (e) => {
+      playDecoyDodged(synth, lanePan(e.lane));
+      haptics.hit(Math.max(1, e.combo));
     })
   );
 

--- a/corpan/packs/lingo-hero/src/audio/sounds.ts
+++ b/corpan/packs/lingo-hero/src/audio/sounds.ts
@@ -354,6 +354,50 @@ export function playGameOver(synth: SynthEngine): void {
 }
 
 /**
+ * Decoy DODGED (issue #429): the player correctly let a distractor sail past.
+ * A bright, airy "phew + sparkle" — a quick rising two-note chime over a soft
+ * upward noise swish (the foil whooshing harmlessly by). Positive and light:
+ * it celebrates the correct avoidance without competing with the fuller catch
+ * bell, so dodging FEELS rewarding but reads as secondary to a real catch.
+ */
+export function playDecoyDodged(synth: SynthEngine, lanePan: number): void {
+  const pan = lanePan * 0.5;
+  // Rising two-note sparkle (a confident little "nice").
+  synth.playVoice({
+    type: "triangle",
+    freq: 659.25, // E5
+    freqTo: 987.77, // B5
+    gain: 0.16,
+    attack: 0.004,
+    release: 0.16,
+    pan,
+    reverb: 0.32,
+  });
+  // Octave shimmer on top for a glint of "magic".
+  synth.playVoice({
+    type: "sine",
+    freq: 1318.51, // E6
+    gain: 0.07,
+    attack: 0.003,
+    release: 0.12,
+    delay: 0.05,
+    pan,
+    reverb: 0.4,
+  });
+  // Soft upward air swish — the foil whooshing harmlessly past.
+  synth.playNoise({
+    gain: 0.08,
+    dur: 0.22,
+    cutoff: 1200,
+    cutoffTo: 6000,
+    filter: "bandpass",
+    q: 0.9,
+    pan,
+    reverb: 0.3,
+  });
+}
+
+/**
  * Wave verdict accent (learning-feel): a tiny confirm/deny ping layered on top
  * of the per-tap SFX when a whole wave resolves. Correct = a clean two-note
  * "up" affirmation; wrong/passed = a soft single low note. Subtle by design so

--- a/corpan/packs/lingo-hero/src/effects/index.ts
+++ b/corpan/packs/lingo-hero/src/effects/index.ts
@@ -172,6 +172,66 @@ export function initEffects(
     })
   );
 
+  // DECOY DODGED — issue #429. The player correctly let a distractor sail past.
+  // A small, JUICY celebration that reads clearly as POSITIVE and distinct from
+  // both the catch burst (white/lane) and the miss puff (red): a tight mint/lime
+  // upward sparkle + a quick gold glint + a "DODGED +N" popup + a soft shockwave.
+  // Deliberately smaller + lower-trauma than a catch so it rewards without
+  // obscuring the falling cards or stealing the catch's thunder.
+  offs.push(
+    bus.on("decoy-dodged", (e) => {
+      combo = e.combo;
+      const mint: Rgb = { r: 120, g: 255, b: 180 }; // fresh "correct avoidance" green
+      // Feed the lane-flash seam so the lane the foil dropped down pulses too
+      // (a soft positive acknowledgement on the right lane).
+      signalHit(e.lane, e.combo, performance.now());
+
+      // Upward mint sparkle fan — the foil whooshing harmlessly by.
+      particles.burst(e.x, e.y, {
+        count: 12,
+        speedMin: 90,
+        speedMax: 300,
+        sizeMin: 1.4,
+        sizeMax: 3.6,
+        lifeMin: 0.3,
+        lifeMax: 0.7,
+        gravity: 360,
+        drag: 0.88,
+        spread: Math.PI * 1.1,
+        angle: -Math.PI / 2,
+        color: mint,
+        glow: 1.05,
+      });
+      // A few gold glints for that "nice!" pop.
+      particles.burst(e.x, e.y, {
+        count: 6,
+        speedMin: 60,
+        speedMax: 200,
+        sizeMin: 1.6,
+        sizeMax: 3.6,
+        lifeMin: 0.35,
+        lifeMax: 0.7,
+        drag: 0.85,
+        spread: Math.PI * 2,
+        shape: "star",
+        color: COLORS.GOLD,
+        glow: 1.15,
+      });
+      floaters.shockwave(e.x, e.y, mint, 0.85);
+      floaters.popup(
+        e.x,
+        e.y - laneSystem.getNoteRadius(),
+        `DODGED +${e.points}`,
+        mint,
+        22
+      );
+      // A light, happy kick — smaller than a catch so it stays secondary.
+      shake.add(0.1);
+      background.setHue(mix(mint, COLORS.WHITE, 0.2));
+      background.pulse(0.16);
+    })
+  );
+
   offs.push(
     bus.on("comboChange", (e) => {
       combo = e.value;

--- a/corpan/packs/lingo-hero/src/types.ts
+++ b/corpan/packs/lingo-hero/src/types.ts
@@ -265,6 +265,27 @@ export interface MuteChangeEvent {
 }
 
 /**
+ * Emitted when the player correctly DODGES a DECOY (distractor) word: a wrong
+ * target-language card crossed the strum line UN-caught (the right play). This
+ * is a REWARD, not a miss — it awards points, keeps/boosts the combo, and fires
+ * a small celebration (issue #429). Only decoy cards trigger it; a missed
+ * CORRECT word is still a miss (NoteMiss), never a dodge.
+ */
+export interface DecoyDodgedEvent {
+  /** The lane the dodged decoy fell down (for placing the VFX/sound pan). */
+  lane: LaneIndex;
+  /** Screen-space x of the reward (CSS px) — the dodged lane at the strum line. */
+  x: number;
+  /** Screen-space y of the reward (CSS px) — the strum line. */
+  y: number;
+  /** Combo value AFTER this dodge (dodging keeps/boosts the streak). */
+  combo: number;
+  /** Points awarded for the dodge (scaled below a correct catch). */
+  points: number;
+  mode: GameMode;
+}
+
+/**
  * The full event map. Keys are event names, values are payload types.
  * `GameEventBus` (src/events.ts) is typed against this map.
  */
@@ -282,6 +303,7 @@ export interface GameEventMap {
   roundAdvance: RoundAdvanceEvent;
   "result-celebrate": ResultCelebrateEvent;
   muteChange: MuteChangeEvent;
+  "decoy-dodged": DecoyDodgedEvent;
 }
 
 export type GameEventName = keyof GameEventMap;

--- a/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
+++ b/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
@@ -53,6 +53,7 @@ const read = () => page.evaluate(() => {
   const g = window.__lingoHero, ls = g.laneSystem, r = g.canvas.getBoundingClientRect();
   return {
     score: g.score, strumY: ls.getStrumLineY(), caughtCount: g.caughtCount,
+    combo: g.combo, decoyDodges: g.decoyDodges,
     laneX: [ls.getLaneX(0), ls.getLaneX(1), ls.getLaneX(2)],
     canvas: { left: r.left, top: r.top },
     // Anti-brick introspection.
@@ -220,6 +221,96 @@ while (Date.now() < deadline && catches < 2) {
   await page.waitForTimeout(50);
 }
 if (catches === 0 && failures === 0) fail("no target word reached the strum line in time");
+
+// --- Contract (f): DECOY DODGED is REWARDED (issue #429). --------------------
+// Letting a DECOY (distractor, isTarget=false) cross the strum line UN-caught is
+// the correct play and must REWARD the player: score climbs + the decoy-dodge
+// counter increments + the combo is kept/boosted (NOT broken). We inject a
+// controlled decoy into the live chart positioned just above the pass line so it
+// sails past on the next frames with no input, then assert the reward fired.
+// Drives the real Game loop physics + pass-line branch via window.__lingoHero.
+{
+  const before = await page.evaluate(() => {
+    const g = window.__lingoHero, ls = g.laneSystem;
+    const strumY = ls.getStrumLineY();
+    const speed = g.speed;
+    // Place a DECOY just ABOVE the pass line so it falls past within a few
+    // frames un-caught. strumTime is back-computed so physics carries it down:
+    //   y = strumY - ((strumTime - now)/1000)*speed  → seed y just under strumY.
+    const now = performance.now();
+    const startY = strumY + ls.getNoteRadius() * 1.5; // just above the pass line
+    const strumTime = now - ((startY - strumY) / speed) * 1000;
+    g.notes.push({
+      id: "test-decoy-" + now,
+      lane: 0,
+      y: startY,
+      text: "señuelo",
+      isTarget: false,
+      seqIndex: -1,
+      hit: false,
+      missed: false,
+      spawnTime: Date.now(),
+      strumTime,
+    });
+    return { score: g.score, decoyDodges: g.decoyDodges, combo: g.combo };
+  });
+  // Do NOTHING — let the injected decoy sail past the line un-caught.
+  let dodged = false;
+  const dodgeDeadline = Date.now() + 4000;
+  while (Date.now() < dodgeDeadline) {
+    const s = await read();
+    if (s.decoyDodges > before.decoyDodges) { dodged = true; break; }
+    await page.waitForTimeout(60);
+  }
+  if (!dodged) fail("decoy passed un-caught but the dodge reward never fired (decoyDodges did not increment)");
+  else {
+    const after = await read();
+    if (after.score <= before.score) fail(`dodging a decoy did not award points (score ${before.score} -> ${after.score})`);
+    else if (after.combo < before.combo) fail(`dodging a decoy broke the combo (${before.combo} -> ${after.combo})`);
+    else console.log(`OK: decoy dodged → rewarded (score ${before.score} -> ${after.score}, combo ${before.combo} -> ${after.combo}, dodges ${before.decoyDodges} -> ${after.decoyDodges})`);
+  }
+}
+
+// --- Contract (f2): a missed CORRECT target is a MISS, NOT a dodge reward. ----
+// Inject a TARGET note that is NOT the next-in-sequence word... actually the
+// pass-line reward path only ever fires for isTarget=false. To prove the CORRECT
+// word missing stays a miss (no dodge), we let the next-in-sequence target sail
+// past un-caught and assert: score does NOT rise (it falls / breaks combo) and
+// the dodge counter does NOT increment.
+{
+  // Find (or wait for) a live next-in-sequence target, then DON'T catch it.
+  const probe = await (async () => {
+    const dl = Date.now() + 8000;
+    while (Date.now() < dl) {
+      const s = await read();
+      const t = s.notes.find((n) => n.isTarget && n.seqIndex === s.caughtCount && !n.hit && !n.missed);
+      if (t) return { dodgesBefore: s.decoyDodges, caught: s.caughtCount };
+      await page.waitForTimeout(80);
+    }
+    return null;
+  })();
+  if (!probe) {
+    console.log("note: no live target to test the missed-correct case (round boundary); skipping f2");
+  } else {
+    // Let the correct word pass: wait until caughtCount advances (the pass-line
+    // miss path reveals + advances it) OR the round resolves.
+    let advanced = false;
+    const dl = Date.now() + 12000;
+    while (Date.now() < dl) {
+      const s = await read();
+      if (s.caughtCount > probe.caught || s.roundResolved || s.lingering) { advanced = true; break; }
+      await page.waitForTimeout(120);
+    }
+    const after = await read();
+    if (!advanced) {
+      console.log("note: missed-correct case did not advance within window; skipping f2 assertion");
+    } else if (after.decoyDodges > probe.dodgesBefore) {
+      fail("missing the CORRECT target word wrongly granted a decoy-dodge reward");
+    } else {
+      console.log("OK: missing the CORRECT target word was a miss, not a dodge reward (dodges unchanged)");
+    }
+  }
+}
 
 // --- Contract (d): NO-BRICK — a round with NO INPUT eventually resolves. -----
 // Wait for a fresh, unresolved round to be in flight, then do NOTHING and


### PR DESCRIPTION
### **User description**
Ships **#427** and **#429** as one coherent Lingo Hero juice / visual pass. PREVIEW channel pack (`lingo_hero`), bumped **0.4.3 → 0.4.4**.

## #427 — lane color beams extend full height
Each lane's colored beam previously started partway down the track (it only spanned from ~62% above the strum down to just past it). It now renders as one **continuous column from the top edge** (where notes spawn) — brightest hugging the strum line — **carried down to the bottom edge**, so every lane reads as an unbroken track from spawn past the strum. Tuned to stay restrained (Neon Arcade): the beam concentrates its light at the action band and never out-glows the falling word cards. `Renderer.drawLanes` volumetric shafts.

## #429 — reward correctly dodging a decoy
When a DECOY (distractor) word crosses the strum line **un-caught — the correct play** — the player now earns:
- **points** (`40 + combo*4`, scaled below a correct catch's `100 + combo*10` so dodging can never out-score catching the real words),
- a **combo boost** (a clean dodge keeps the difficulty streak climbing), and
- a **small celebration**: mint-green `DODGED +N` popup, upward sparkle burst with gold glints, soft shockwave + lane flash, and a bright airy "phew" SFX.

Catching a decoy is **still a miss / combo-break** (unchanged). Letting the **correct** word pass is **still a miss**, never a dodge reward. Only a genuine decoy (`isTarget === false`) crossing the line un-caught triggers it. New `decoy-dodged` bus event + `playDecoyDodged` SFX; `window.__lingoHero.decoyDodges` is introspectable.

## Contracts preserved
Answer dedup, offline-first (all SFX synthesized, no assets/fonts), TTS speaks raw foreign text, pack id `lingo_hero`, canvas-relative input, delta-timed movement, #407 language rotation, and the full 0.4.3 HUD (auto-fit prompt, compact bottom row, accessible pause/exit, one mute, no tap-through) — all unchanged and re-verified.

## Verification
- **e2e** (`test/e2e/gameplay.spec.mjs`, exit 0): all existing assertions pass (motion real, catch scores, no tap-through on pause/mute/exit, long prompt fully visible, no-brick, #407 rotation + reading mode). **Added**: letting a decoy pass un-caught increases score + increments `decoyDodges` + boosts combo; and missing the CORRECT target word does NOT grant the dodge reward (still a miss).
- **Design-critic gate** (frames captured from the built bundle): **PLAYABLE — zero blockers**. Beams full-height + continuous, tasteful (cards stay readable); `DODGED +N` reward reads clearly positive and distinct from the red MISS, doesn't obscure gameplay; 0.4.3 HUD intact (no regression, no text overlap).

Preview pack: this stays on `channel: "preview"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Bug fix, Tests, Documentation


___

### **Description**
- Reward decoy dodges with score, combo

- Add dodge VFX, SFX, haptics

- Extend lane beams full playfield height

- Bump version and e2e coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  decoy["Uncaught decoy crosses strum"]
  game["Game awards dodge reward"]
  event["decoy-dodged event"]
  juice["VFX, SFX, haptics"]
  renderer["Lane renderer"]
  beams["Full-height neon beams"]
  tests["E2E coverage"]
  decoy -- "triggers" --> game
  game -- "emits" --> event
  event -- "drives" --> juice
  renderer -- "draws" --> beams
  game -- "validated by" --> tests
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>Game.ts</strong><dd><code>Reward uncaught decoys during gameplay loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/434/files#diff-6c075e8c51d32e4e5452a4c738f6cc530345361455286e0f7d1af37f46fedde7">+52/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Wire decoy dodge audio and haptics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/434/files#diff-2184219bcd7d4e7e52fed856f6c7e9983d9b3372de1de66e7fc1aac52cdb241f">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sounds.ts</strong><dd><code>Add airy decoy dodge sound effect</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/434/files#diff-81a4c5686b15d89e3aa9d1bec3b9b5168f974821ac2e59f8e88b741b96eb6ccd">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Add decoy dodge celebration effects</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/434/files#diff-9b5f998ad83be84b538e3d132b6d0b92d385eb5913681c574cbf16f6527d7aaa">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.ts</strong><dd><code>Define typed decoy dodge event</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/434/files#diff-90db924f79313d23c6eada5092c9adb12ccb7ceb3a47dcd832071a22448af88b">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Renderer.ts</strong><dd><code>Render full-height lane color beams</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/434/files#diff-a8ca1f488ce07a5bfdd1fbb0851ce6f79a8731c3dacfe7d692d733838b839a53">+33/-12</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document Lingo Hero 0.4.4 changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/434/files#diff-dd09bf20e11864991961b7ef6d2fc6687a66d9a9de2d246f765d9d6891e646c2">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>manifest.json</strong><dd><code>Bump preview pack version metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/434/files#diff-38411e79d50eee7f8ad439a29518dcddf16cdc9cd03739fc81ea212f18519b15">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>gameplay.spec.mjs</strong><dd><code>Test decoy rewards and missed targets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/434/files#diff-5ee22f0c6a817c0427478004e2238facf99cd3c18591eda51d590170655a3c57">+91/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

