### PR TITLE
Lingo Hero 0.4.5: iOS/iPad audio unlock (#428)

### DIFF
--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-06-23
+
+iOS/iPad audio fix (issue #428): music was silent on iPad/iOS Safari while
+working on Android/desktop — the canonical iOS Web Audio gotcha.
+
+### Fixed
+- **Music now unlocks on iPad/iOS Safari (#428).** iOS creates the AudioContext
+  in the `suspended` state and only lets it start when `resume()` is called from
+  inside a real user-gesture handler; if the first tap isn't spent on the
+  unlock, audio stays suspended and silent. The context was previously unlocked
+  only on the menu Start button, so a first tap landing elsewhere (a canvas lane
+  tap, tap-to-begin) left iOS audio dead. We now unlock from the FIRST
+  window-level user gesture (`pointerdown` / `touchend` / `click`) and detach
+  after — covering the InputManager canvas taps and any tap-to-begin. We also
+  `resume()` the context on every `visibilitychange`→visible (iOS suspends the
+  context when the app backgrounds even on the menu, where the loop pause/resume
+  gate never fires). Resuming an already-running context is a no-op, so Android
+  and desktop are unaffected; the music content/feel is unchanged. The unlock
+  wiring is now e2e-verified: the context is not running before any gesture and
+  flips to `running` after a simulated tap. (`audio/index.ts`,
+  `audio/SynthEngine.ts`; `window.__lingoHero.audioContextState()` /
+  `audioUnlocked()` introspection.)
+
 ## [0.4.4] - 2026-06-23
 
 A juice / visual pass (issues #427 and #429): the lane tracks now read as

--- a/corpan/packs/lingo-hero/manifest.json
+++ b/corpan/packs/lingo-hero/manifest.json
@@ -2,7 +2,7 @@
   "id": "lingo_hero",
   "channel": "preview",
   "name": "Lingo Hero",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Catch the translation. The phrase you know falls as a chart of timed notes in the language you're learning — catch each word in rhythm, in order, and hear it spoken.",
   "entry": "dist/app.js",
   "styles": [
@@ -11,5 +11,5 @@
   "entryType": "script",
   "sdkVersion": "0.1.0",
   "minAppVersion": "0.17.0",
-  "devRevision": "2026-06-23T18:00:00.000Z"
+  "devRevision": "2026-06-23T19:30:00.000Z"
 }

--- a/corpan/packs/lingo-hero/src/Game.ts
+++ b/corpan/packs/lingo-hero/src/Game.ts
@@ -331,6 +331,21 @@ export class Game {
     return this.activeLanguage;
   }
 
+  /**
+   * Test/diagnostic introspection for the iOS audio-unlock wiring (issue #428).
+   * The e2e harness asserts the AudioContext is NOT running before any gesture
+   * and flips to "running" after a simulated tap — proving the unlock wiring
+   * fires on a gesture (real iOS audio OUTPUT cannot be verified headlessly).
+   */
+  audioContextState(): AudioContextState | null {
+    return this.audio.contextState();
+  }
+
+  /** True once a user gesture has unlocked the AudioContext (issue #428). */
+  audioUnlocked(): boolean {
+    return this.audio.isUnlocked();
+  }
+
   private getLaneFromX(x: number): LaneIndex | null {
     return this.laneSystem.laneAtX(x);
   }

--- a/corpan/packs/lingo-hero/src/audio/SynthEngine.ts
+++ b/corpan/packs/lingo-hero/src/audio/SynthEngine.ts
@@ -111,6 +111,19 @@ export class SynthEngine {
     return this.unlocked && this.ctx !== null && this.ctx.state === "running";
   }
 
+  /** Whether a user gesture has unlocked (created/resumed) the context. */
+  get isUnlocked(): boolean {
+    return this.unlocked;
+  }
+
+  /**
+   * The live AudioContext.state, or null if no context has been created yet.
+   * Used by the e2e harness to prove the iOS unlock wiring fires on a gesture.
+   */
+  get state(): AudioContextState | null {
+    return this.ctx ? this.ctx.state : null;
+  }
+
   /** Raw context accessor for advanced subsystems (music bed). Null until unlocked. */
   get context(): AudioContext | null {
     return this.ctx;

--- a/corpan/packs/lingo-hero/src/audio/index.ts
+++ b/corpan/packs/lingo-hero/src/audio/index.ts
@@ -43,6 +43,14 @@ import {
 export interface AudioHandle {
   /** Close the AudioContext and detach listeners. */
   dispose: () => void;
+  /**
+   * Introspection for the e2e harness (iOS unlock-wiring proof). Reports the
+   * live AudioContext.state ("suspended" | "running" | "closed") or null if no
+   * context exists yet. NOT used by gameplay — purely a test/diagnostic hook.
+   */
+  contextState: () => AudioContextState | null;
+  /** True once a real user gesture has unlocked (created/resumed) the context. */
+  isUnlocked: () => boolean;
 }
 
 /** Combo milestone every N hits triggers the celebratory riser. */
@@ -119,6 +127,58 @@ export function initAudioHaptics(bus: GameEventBus): AudioHandle {
       }
     })
   );
+
+  // --- iOS FIRST-GESTURE UNLOCK (issue #428) -------------------------------
+  // On iOS/iPadOS Safari the AudioContext is born `suspended` and Safari will
+  // ONLY transition it to `running` if resume()/the first sound is initiated
+  // from INSIDE a real user-gesture handler (pointerdown/touchend/click). The
+  // menu Practice button already drives `gameStart` -> synth.unlock(), but a
+  // player's FIRST tap may land elsewhere (a canvas lane tap, a tap-to-begin),
+  // and on iOS that first tap is the one gesture we must spend on the unlock.
+  // So we also unlock from the very first window-level gesture, then detach.
+  // unlock() creates-then-resumes; resuming an already-running context is a
+  // harmless no-op, so this never regresses Android/desktop (where the context
+  // is already permitted) and never double-creates (unlock() is idempotent).
+  let gestureUnlockDetach: (() => void) | null = null;
+  if (typeof window !== "undefined") {
+    const onFirstGesture = () => {
+      synth.unlock();
+      gestureUnlockDetach?.();
+    };
+    // touchend + click cover iOS Safari's accepted gesture set; pointerdown
+    // covers the canvas InputManager taps and mouse/desktop. `once` lets the
+    // browser auto-remove, and we also detach explicitly after the first fire.
+    const opts = { capture: true, passive: true } as AddEventListenerOptions;
+    const events: Array<keyof WindowEventMap> = [
+      "pointerdown",
+      "touchend",
+      "click",
+    ];
+    for (const ev of events) window.addEventListener(ev, onFirstGesture, opts);
+    gestureUnlockDetach = () => {
+      for (const ev of events)
+        window.removeEventListener(ev, onFirstGesture, opts);
+      gestureUnlockDetach = null;
+    };
+    unsubs.push(() => gestureUnlockDetach?.());
+  }
+
+  // --- iOS RESUME-FROM-BACKGROUND (issue #428) -----------------------------
+  // iOS suspends the AudioContext whenever the app/tab is backgrounded — even
+  // when the game itself was not paused (e.g. sitting on the menu). The Game's
+  // own pause/resume gate (`gameResumed`) only fires if the LOOP was paused, so
+  // a menu-time background->foreground would leave audio stuck `suspended` and
+  // silent. Resume on every visibilitychange->visible directly, independent of
+  // the loop pause gate. Resuming a running context is a no-op (no regression).
+  if (typeof document !== "undefined") {
+    const onVisible = () => {
+      if (!document.hidden) synth.resume();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    unsubs.push(() =>
+      document.removeEventListener("visibilitychange", onVisible)
+    );
+  }
 
   // --- gameStart: unlock audio (first gesture) + swell + start the bed -----
   unsubs.push(
@@ -258,6 +318,8 @@ export function initAudioHaptics(bus: GameEventBus): AudioHandle {
   );
 
   return {
+    contextState: () => synth.state,
+    isUnlocked: () => synth.isUnlocked,
     dispose: () => {
       for (const off of unsubs) {
         try {

--- a/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
+++ b/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
@@ -442,6 +442,56 @@ async function collectRoundTargets(p, wantRounds) {
   await rp.close();
 }
 
+// --- iOS AUDIO UNLOCK WIRING (issue #428). -----------------------------------
+// We CANNOT verify real iOS audio OUTPUT headlessly, so we verify the WIRING:
+// the AudioContext must NOT be running before any user gesture (it is lazy — no
+// context exists yet), and the FIRST real gesture (a pointerdown, like a canvas
+// lane tap or tap-to-begin on iOS) must unlock it -> state "running" + unlocked
+// flag true. This proves the canonical iOS gesture-unlock path is wired without
+// requiring the menu Start button specifically, and (resuming a running context
+// being a no-op) guarantees it does not regress Android/desktop.
+{
+  const ap = await browser.newPage({ viewport: { width: 390, height: 844 }, deviceScaleFactor: 2 });
+  ap.on("pageerror", (e) => fail("pageerror(audio): " + e.message));
+  await ap.goto(harness);
+  await ap.waitForFunction(() => !!window.__lingoHero, { timeout: 10000 });
+
+  // BEFORE any gesture: the engine is lazy, so no context exists and it is not
+  // unlocked. (On iOS a pre-gesture context would be stuck `suspended` + silent;
+  // we never create one before the gesture, which is the correct iOS behavior.)
+  const pre = await ap.evaluate(() => ({
+    state: window.__lingoHero.audioContextState(),
+    unlocked: window.__lingoHero.audioUnlocked(),
+  }));
+  if (pre.unlocked) fail(`audio reported unlocked BEFORE any gesture: ${JSON.stringify(pre)}`);
+  if (pre.state === "running") fail(`AudioContext was RUNNING before any gesture (iOS would never allow this): ${JSON.stringify(pre)}`);
+  else console.log(`OK: audio not unlocked pre-gesture (state=${pre.state}, unlocked=${pre.unlocked})`);
+
+  // Dispatch a REAL pointerdown on the canvas (a lane tap) — the InputManager
+  // gesture path, NOT the menu Start button — to prove the window-level
+  // first-gesture unlock fires regardless of WHERE the first tap lands.
+  const box = await ap.evaluate(() => {
+    const r = window.__lingoHero.canvas.getBoundingClientRect();
+    return { x: r.left + r.width / 2, y: r.top + r.height * 0.6 };
+  });
+  await ap.mouse.click(box.x, box.y);
+  // The context.resume() promise resolves async; give it a beat to flip.
+  await ap.waitForFunction(
+    () => window.__lingoHero.audioContextState() === "running",
+    { timeout: 5000 }
+  ).catch(() => {});
+
+  const post = await ap.evaluate(() => ({
+    state: window.__lingoHero.audioContextState(),
+    unlocked: window.__lingoHero.audioUnlocked(),
+  }));
+  if (!post.unlocked) fail(`audio did NOT unlock after a gesture: ${JSON.stringify(post)}`);
+  else if (post.state !== "running") fail(`AudioContext did not reach "running" after a gesture (unlock wiring): ${JSON.stringify(post)}`);
+  else console.log(`OK: first gesture unlocked AudioContext (state=${post.state}, unlocked=${post.unlocked})`);
+
+  await ap.close();
+}
+
 await browser.close();
 console.log(failures === 0 ? "\nGAMEPLAY E2E: PASS" : `\nGAMEPLAY E2E: ${failures} FAILURE(S)`);
 process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
### **User description**
Fixes #428 — no music on iPad/iOS Safari (works on Android).

## Cause
The canonical iOS Web Audio gotcha. iOS/iPadOS Safari creates the `AudioContext` in the `suspended` state and will only transition it to `running` when `resume()` (or the first sound) is initiated **inside a real user-gesture handler**. Lingo Hero previously unlocked the context **only** on the menu Start button (`gameStart` → `synth.unlock()`). If the player's first tap landed elsewhere — a canvas lane tap, a tap-to-begin — that single permitted gesture was spent without unlocking, and audio stayed suspended and silent. Additionally, iOS suspends the context whenever the app backgrounds (even sitting on the menu), where the game's own loop pause/resume gate never fires, so it could never recover.

## What changed (unlock/resume WIRING only — music content/feel unchanged)
- **First-gesture unlock** (`src/audio/index.ts`): attach window-level `pointerdown` / `touchend` / `click` listeners that call `synth.unlock()` on the first real gesture, then detach. Covers the InputManager canvas taps and any tap-to-begin, independent of the menu Start button. `unlock()` is idempotent (creates-then-resumes; resuming a running context is a harmless no-op).
- **Resume-from-background** (`src/audio/index.ts`): `synth.resume()` on every `visibilitychange`→visible, independent of the loop pause gate, so a menu-time background→foreground recovers audio.
- **Introspection** for the e2e harness: `SynthEngine.state` / `.isUnlocked`, surfaced as `window.__lingoHero.audioContextState()` / `audioUnlocked()`.
- Manifest 0.4.4 → 0.4.5 + devRevision; CHANGELOG `[0.4.5]`.

Kept fully offline (no assets, no network). No changes to the music synthesis. Preserved contracts: answer dedup, raw-text TTS, canvas-relative input, delta-timed motion, #407 language rule, the 0.4.3 HUD + 0.4.4 visuals.

## Verification (headless)
`npm run build` (tsc clean) + `node test/e2e/gameplay.spec.mjs` → **exit 0, GAMEPLAY E2E: PASS**. This proves:
- **Android/desktop non-regression**: all prior gameplay contracts (motion, catch-scores, no-tap-through, prompt-fit, decoy-dodge reward, no-brick, multi-stack rotation, reading-stack) still pass.
- **Unlock wiring fires on a gesture**: a fresh page reports `audioContextState()===null` / `audioUnlocked()===false` **before** any gesture, and after a simulated canvas `pointerdown` (the InputManager path, not the Start button) the context flips to `state="running"` / `audioUnlocked()===true`.

Real iOS audio **output** cannot be verified headlessly — only the wiring.

## iPad verification needed
**Open Lingo Hero on iPad, tap to start, and confirm music now plays.** (Also nice-to-check: background the app mid-game and return — music should resume.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Unlock audio on first gesture

- Resume audio after foregrounding

- Expose audio diagnostics for e2e

- Add changelog and version bump


___

### Diagram Walkthrough


```mermaid
flowchart LR
  gesture["First user gesture"] -- "calls" --> unlock["synth.unlock()"]
  unlock["synth.unlock()"] -- "resumes" --> audio["AudioContext running"]
  visible["App becomes visible"] -- "calls" --> resume["synth.resume()"]
  resume["synth.resume()"] -- "recovers" --> audio["AudioContext running"]
  audio["AudioContext running"] -- "verified by" --> e2e["E2E diagnostics"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Game.ts</strong><dd><code>Expose game-level audio diagnostics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/src/Game.ts

<ul><li>Adds <code>audioContextState()</code> diagnostic accessor.<br> <li> Adds <code>audioUnlocked()</code> diagnostic accessor.<br> <li> Exposes audio unlock state through game API.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/439/files#diff-6c075e8c51d32e4e5452a4c738f6cc530345361455286e0f7d1af37f46fedde7">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gameplay.spec.mjs</strong><dd><code>Test first-gesture audio unlock wiring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs

<ul><li>Adds e2e coverage for audio unlock wiring.<br> <li> Verifies audio is not unlocked pre-gesture.<br> <li> Simulates a canvas gesture to trigger unlock.<br> <li> Asserts <code>AudioContext</code> reaches <code>running</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/439/files#diff-5ee22f0c6a817c0427478004e2238facf99cd3c18591eda51d590170655a3c57">+50/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SynthEngine.ts</strong><dd><code>Add SynthEngine unlock state introspection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/src/audio/SynthEngine.ts

<ul><li>Adds <code>isUnlocked</code> getter for unlock tracking.<br> <li> Adds <code>state</code> getter for <code>AudioContext.state</code>.<br> <li> Supports external validation of audio readiness.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/439/files#diff-bc8854c3f7e746dbf1d4ea82da7bb3b38eab30e8ee83da44e973ff5e65d3e881">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Fix iOS first-gesture audio unlock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/src/audio/index.ts

<ul><li>Extends <code>AudioHandle</code> with diagnostic accessors.<br> <li> Unlocks <code>AudioContext</code> on first window gesture.<br> <li> Resumes audio on <code>visibilitychange</code> when visible.<br> <li> Detaches first-gesture listeners after use.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/439/files#diff-2184219bcd7d4e7e52fed856f6c7e9983d9b3372de1de66e7fc1aac52cdb241f">+62/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document Lingo Hero 0.4.5 audio fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/CHANGELOG.md

<ul><li>Adds <code>0.4.5</code> release notes.<br> <li> Documents the iOS/iPad Safari audio fix.<br> <li> Notes first-gesture unlock and foreground resume behavior.<br> <li> Mentions e2e diagnostics for unlock verification.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/439/files#diff-dd09bf20e11864991961b7ef6d2fc6687a66d9a9de2d246f765d9d6891e646c2">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump Lingo Hero preview version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/manifest.json

<ul><li>Bumps Lingo Hero version to <code>0.4.5</code>.<br> <li> Updates <code>devRevision</code> timestamp.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/439/files#diff-38411e79d50eee7f8ad439a29518dcddf16cdc9cd03739fc81ea212f18519b15">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

