### PR TITLE
beatlounge: instrument score shows the full octave range (scrollable)

### DIFF
--- a/corpan/packs/beatlounge/CHANGELOG.md
+++ b/corpan/packs/beatlounge/CHANGELOG.md
@@ -37,6 +37,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Home voice switcher: a long instrument name no longer pushes the next arrow off
   the safe screen zone — the name truncates in a stable-width slot and the arrows
   hold their position. (Beat-Lounge-Plus)
+- Instrument score now shows the **full instrument range** (88-key piano, A0–C8),
+  scrollable, instead of a ~3-octave window — notes can be seen and placed
+  anywhere. Opens scrolled to ~middle C; the +/− generator still works in the
+  singable register. (Beat-Lounge-Plus; closes #394.)
 
 ## [0.3.2] - 2026-06-19
 

--- a/corpan/packs/beatlounge/src/modules/score/Score.tsx
+++ b/corpan/packs/beatlounge/src/modules/score/Score.tsx
@@ -59,8 +59,13 @@ export interface ScoreProps {
   audio?: AudioFacade
 }
 
-/** ~2 octaves around the working tonic — singable, mostly-ascending register. */
+/** The register the +/- generator works in (singable, mostly-ascending). The
+ *  VIEW shows far more than this — see SCORE_RANGE. */
 const OCTAVES = 2
+
+/** The score VIEW shows the full instrument range (88-key piano, A0–C8),
+ *  scrollable — so notes can be seen and placed anywhere, not just ~3 octaves. */
+const SCORE_RANGE = { loMidi: 21, hiMidi: 108 } as const
 
 /** The Variation seed-policy values + their short, translatable labels. */
 const VARIATIONS: readonly AutoVariation[] = ["lock", "evolve", "new"]
@@ -92,11 +97,27 @@ export const Score = ({ host, store, trackId, audio }: ScoreProps) => {
     TRANSITION_TABLES.find((t) => t.id === tableId) ?? TRANSITION_TABLES[0]
 
   // The grid view (rows = degrees, columns = steps), cells filled from the track.
+  // Full instrument range (scrollable) so notes can be placed anywhere (#394).
   const view: ScoreView | null = useMemo(() => {
     if (!track || !isInstrumentTrack(track)) return null
-    const base = buildScoreView(doc, track.grid, { octaves: OCTAVES })
+    const base = buildScoreView(doc, track.grid, { range: SCORE_RANGE })
     return fillScoreCells(base, track.notes, track.grid)
   }, [doc, track])
+
+  // Open scrolled to ~middle C so the user starts in a useful register (the full
+  // range is tall; row 0 is the highest pitch). Center ONCE PER TRACK — re-center
+  // when you switch tracks, but never on note edits (which would yank the scroll
+  // back mid-placement). Keyed by trackId, not the view.
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const centeredFor = useRef<string | null>(null)
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el || !view || view.rows.length === 0) return
+    if (centeredFor.current === trackId) return
+    const frac = (SCORE_RANGE.hiMidi - 60) / (SCORE_RANGE.hiMidi - SCORE_RANGE.loMidi)
+    el.scrollTop = Math.max(0, frac * el.scrollHeight - el.clientHeight / 2)
+    centeredFor.current = trackId
+  }, [view, trackId])
 
   // Live playhead → current step on this track's grid. (Auto generation now runs
   // in the rig-level AutoConductor, not here, so it survives leaving the screen.)
@@ -319,7 +340,7 @@ export const Score = ({ host, store, trackId, audio }: ScoreProps) => {
       </div>
 
       {/* ---- the degree grid (rows = scale degrees, in key) ---- */}
-      <div className="bl-grid-scroll bl-score-scroll">
+      <div ref={scrollRef} className="bl-grid-scroll bl-score-scroll">
         <LaneGrid
           lanes={lanes}
           steps={view.steps}

--- a/corpan/packs/beatlounge/src/modules/score/scoreModel.test.ts
+++ b/corpan/packs/beatlounge/src/modules/score/scoreModel.test.ts
@@ -81,6 +81,37 @@ describe("degree rows resolve in key", () => {
   })
 })
 
+describe("degree rows — full instrument range (#394)", () => {
+  it("covers the whole MIDI window (A0–C8), high→low, all in range + in key", () => {
+    const d = doc()
+    const ap = activePitches(d, 0)
+    const rows = degreeRows(d, { range: { loMidi: 21, hiMidi: 108 } })
+    // Far more rows than the ~2-octave window, all within the window.
+    expect(rows.length).toBeGreaterThan(7 * 7) // > ~7 octaves of degrees
+    for (const r of rows) {
+      expect(r.midi).toBeGreaterThanOrEqual(21)
+      expect(r.midi).toBeLessThanOrEqual(108)
+    }
+    // High → low, strictly descending MIDI (distinct rows).
+    for (let i = 1; i < rows.length; i++) {
+      expect(rows[i].midi).toBeLessThan(rows[i - 1].midi)
+    }
+    // Every row's pitch class is in the active set (still in key).
+    const pcs = new Set(ap.pcs)
+    for (const r of rows) expect(pcs.has(((r.midi % 12) + 12) % 12)).toBe(true)
+    // Reaches near both ends of the window.
+    expect(rows[0].midi).toBeGreaterThan(100)
+    expect(rows[rows.length - 1].midi).toBeLessThan(30)
+  })
+
+  it("spans many more octaves than the fixed 2-octave window", () => {
+    const d = doc()
+    const windowed = degreeRows(d, { octaves: 2 }).length
+    const full = degreeRows(d, { range: { loMidi: 21, hiMidi: 108 } }).length
+    expect(full).toBeGreaterThan(windowed * 2)
+  })
+})
+
 describe("+ layer (add)", () => {
   it("is additive — keeps existing notes and adds more, in key", () => {
     const d = doc()

--- a/corpan/packs/beatlounge/src/modules/score/scoreModel.ts
+++ b/corpan/packs/beatlounge/src/modules/score/scoreModel.ts
@@ -121,12 +121,37 @@ export const workingTonicMidi = (ap: ActivePitches, centerMidi = 60): number => 
  */
 export const degreeRows = (
   doc: BeatloungeDoc,
-  opts: { tick?: Tick; octaves?: number; centerMidi?: number } = {}
+  opts: {
+    tick?: Tick
+    octaves?: number
+    centerMidi?: number
+    /** Full-range mode (#394): emit every in-scale row whose pitch lands in this
+     *  MIDI window (the instrument's range) instead of a fixed octave window. */
+    range?: { loMidi: number; hiMidi: number }
+  } = {}
 ): DegreeRow[] => {
   const ap = activePitches(doc, opts.tick ?? 0)
   const size = ap.cents.length > 0 ? ap.cents.length : 7
-  const octaves = Math.max(1, Math.floor(opts.octaves ?? 2))
   const tonicMidi = workingTonicMidi(ap, opts.centerMidi ?? 60)
+
+  // Full-range mode (#394): walk degrees outward from the tonic and keep every
+  // row whose resolved pitch lands in [loMidi, hiMidi], HIGH→LOW — so the score
+  // shows + scrolls the whole instrument range, not just a couple of octaves.
+  if (opts.range) {
+    const { loMidi, hiMidi } = opts.range
+    const stepSemis = 12 / size // ≈ semitones per scale degree
+    const dHi = Math.ceil((hiMidi - tonicMidi) / stepSemis) + size
+    const dLo = Math.floor((loMidi - tonicMidi) / stepSemis) - size
+    const rangeRows: DegreeRow[] = []
+    for (let d = dHi; d >= dLo; d--) {
+      const p = degreeToPitch(d, ap, tonicMidi)
+      if (p.midi < loMidi || p.midi > hiMidi) continue
+      rangeRows.push({ degree: d, midi: p.midi, detuneCents: p.detuneCents, key: String(d) })
+    }
+    return rangeRows
+  }
+
+  const octaves = Math.max(1, Math.floor(opts.octaves ?? 2))
   // Span: `octaves` above and (octaves-1) below the tonic, so the tonic sits a
   // little below center — a singable, mostly-ascending register.
   const lo = -((octaves - 1) * size)
@@ -173,7 +198,7 @@ const midiLabel = (midi: number): string => {
 export const buildScoreView = (
   doc: BeatloungeDoc,
   grid: Grid,
-  opts: { octaves?: number; centerMidi?: number } = {}
+  opts: { octaves?: number; centerMidi?: number; range?: { loMidi: number; hiMidi: number } } = {}
 ): ScoreView => {
   const steps = stepsInLoop(doc.loopLengthTicks, grid)
   const stepsPerBeat = Math.max(1, Math.round(grid.denominator / 4))


### PR DESCRIPTION
### **User description**
Closes **#394**. Device-tested by Ian on an iPhone 16 Pro Max (A0→B7 visible + scrollable, places notes across the range).

## What
The score editor was capped at a ~3-octave register window (`OCTAVES = 2`), so notes outside it couldn't be seen or placed. Now:
- the **view spans the full 88-key piano range (A0–C8)** and **scrolls**,
- it **opens scrolled to ~middle C** so you start in a useful register,
- the **+/− generator still works in the singable register** (unchanged) — only what you *see and can place on* expanded.

## How
- `degreeRows()` gains a **full-range mode**: walk degrees out from the tonic, keep every in-key row whose pitch lands in `[loMidi, hiMidi]`, high→low. (The fixed-octave-window path is untouched, so generation/auto-play behaviour is unchanged.)
- `Score.tsx` builds the **view** with range A0–C8; a one-shot effect centers the scroll near middle C on first render.

## Gates
- `npm run typecheck` — clean
- `npm run test` — **1311 passed** (+2 full-range `degreeRows` cases)
- `npm run build` — clean

## Scope
Pack-only (`corpan/packs/beatlounge`), 4 files. No `model/` spine change, no manifest/version change.


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Shows full score pitch range

- Centers initial scroll near middle C

- Adds full-range row model tests

- Documents score editor fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Score editor"] 
  B["Full A0-C8 range"]
  C["Scrollable piano-roll grid"]
  D["Middle C initial position"]
  E["Notes placeable across range"]
  A -- "builds view with" --> B
  B -- "renders as" --> C
  C -- "opens near" --> D
  C -- "enables" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Score.tsx</strong><dd><code>Enable full-range scrollable score view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/modules/score/Score.tsx

<ul><li>Adds <code>SCORE_RANGE</code> for A0-C8 view coverage.<br> <li> Builds the score view using <code>range</code> instead of <code>octaves</code>.<br> <li> Adds a scroll ref and one-time centering near middle C.<br> <li> Keeps <code>OCTAVES</code> for the existing +/- generator register.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/440/files#diff-288178d9a7e795bdf8f8f21386ec1173919147b9443fcbbe754492a5258356ab">+21/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>scoreModel.ts</strong><dd><code>Add full-range degree row generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/modules/score/scoreModel.ts

<ul><li>Extends <code>degreeRows</code> options with full MIDI <code>range</code>.<br> <li> Emits all in-key rows within the configured range.<br> <li> Preserves the existing fixed-octave behavior when no range is <br>provided.<br> <li> Passes range options through <code>buildScoreView</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/440/files#diff-fd2f5f980a3ff3a63b2fcd2fa5001b3bf347a1ed5ffc4b61ae8ec0be8d187ce7">+28/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scoreModel.test.ts</strong><dd><code>Test full instrument range rows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/modules/score/scoreModel.test.ts

<ul><li>Adds coverage for A0-C8 full-range degree rows.<br> <li> Verifies rows are in range, in key, and high-to-low.<br> <li> Compares full-range output against the fixed two-octave window.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/440/files#diff-c22d0f9d86d954eeb122e344fde580765a37bded6b77d88f678a5b4caa2ef846">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document full-range score editor fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/CHANGELOG.md

<ul><li>Documents the score editor full-range fix.<br> <li> Notes scrollable A0-C8 coverage and middle-C startup position.<br> <li> Mentions unchanged +/- generator register behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/440/files#diff-83e97c4e36caca34711c70ef258b21b23e7362bf0f79b312a22fb2679ced8def">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

