### PR TITLE
Lingo Hero 0.4.6: prompt full-visibility (#441), lane-tap isolation (#442), big-screen HUD row (#443)

### DIFF
--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -6,6 +6,44 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-06-23
+
+Prompt full-visibility fix (#441), lane-tap isolation (#442), and a big-screen
+bottom HUD row (#443) — shipped together.
+
+### Fixed
+- **The prompt phrase is now ALWAYS fully visible (#441).** On iPad many phrases
+  (e.g. "They built a fort, then argued about what to defend it from") clipped —
+  cut at the comma / forced to one line that ran off the band. Root cause: the
+  0.4.3 `fitPrompt()` tried to JAM every phrase into ≤2 lines and bottomed out at
+  a font floor, so a long sentence wrapped to a 3rd line that overflowed the
+  reserved header band (its `scrollHeight` exceeded the flex-squeezed box height).
+  Inverted the model: the phrase now WRAPS freely to as many lines as it needs
+  within a generous height budget, and the font only SHRINKS (floored, never
+  past a readable size) when the wrapped text genuinely exceeds that budget. The
+  `.question-box` is `flex: 0 0 auto` / `height: auto` so the flex column can no
+  longer squeeze it below its own content, and the fit re-runs on the next frame
+  (rAF) so it never measures against a pre-layout width. Re-fits on resize /
+  orientation. Verified by a headless harness against a long comma phrase at
+  phone, iPad-portrait, and iPad-landscape: every word present, zero glyph clip
+  (Range-measured), at all three widths.
+- **Lane taps are isolated to the lane columns (#442).** Hit-testing spanned the
+  whole screen width, so a tap on the top-left pause/mute chrome or in the dead
+  side margins (where the lanes cap at 600px and center on a wide screen) could
+  register a lane hit/miss. Added `LaneSystem.laneAtXStrict()` — it returns the
+  lane only when the tap lands within the drawn 3-lane band (with a small
+  forgiving edge slack), and `null` outside it, so chrome / margin taps neither
+  score nor register a miss. The 0.4.3 chrome `stopPropagation` (no tap-through)
+  and canvas-relative input are preserved.
+
+### Changed
+- **Big-screen bottom HUD row (#443):** SCORE | thin level meter | STREAK — two
+  equal "fat" plates flanking a slim center meter, the row now spanning the full
+  width of the 3 lanes (capped to the 600px lane band and centered on wide
+  screens). Comfortable and premium at iPad / landscape width instead of a
+  cramped center cluster, still tidy on a phone. Responsive; respects the bottom
+  safe area; never flanks/overlaps the falling-note lanes.
+
 ## [0.4.5] - 2026-06-23
 
 iOS/iPad audio fix (issue #428): music was silent on iPad/iOS Safari while

--- a/corpan/packs/lingo-hero/manifest.json
+++ b/corpan/packs/lingo-hero/manifest.json
@@ -2,7 +2,7 @@
   "id": "lingo_hero",
   "channel": "preview",
   "name": "Lingo Hero",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Catch the translation. The phrase you know falls as a chart of timed notes in the language you're learning — catch each word in rhythm, in order, and hear it spoken.",
   "entry": "dist/app.js",
   "styles": [
@@ -11,5 +11,5 @@
   "entryType": "script",
   "sdkVersion": "0.1.0",
   "minAppVersion": "0.17.0",
-  "devRevision": "2026-06-23T19:30:00.000Z"
+  "devRevision": "2026-06-23T20:15:00.000Z"
 }

--- a/corpan/packs/lingo-hero/src/Game.ts
+++ b/corpan/packs/lingo-hero/src/Game.ts
@@ -347,7 +347,13 @@ export class Game {
   }
 
   private getLaneFromX(x: number): LaneIndex | null {
-    return this.laneSystem.laneAtX(x);
+    // #442: a tap only counts as a lane hit when it lands within the lane COLUMN
+    // band (around the hit-ring circles). Taps on the top-left chrome or out in
+    // the dead side margins resolve to null → no score, no miss. The overlay
+    // chrome buttons still stopPropagation when visible (0.4.3); this also covers
+    // the case where they've auto-faded to pointer-events:none and a tap there
+    // would otherwise pass through to the canvas.
+    return this.laneSystem.laneAtXStrict(x);
   }
 
   private handleResize(container: HTMLElement) {

--- a/corpan/packs/lingo-hero/src/LaneSystem.ts
+++ b/corpan/packs/lingo-hero/src/LaneSystem.ts
@@ -50,7 +50,32 @@ export class LaneSystem {
 
   // Inverse of getLaneX, honoring the centered/capped lane band. Taps in the
   // side margins clamp to the nearest edge lane. Keeps input lanes == drawn lanes.
+  // NOTE: this clamps everything to a lane; for hit-testing that must REJECT taps
+  // outside the lane columns (chrome / dead margins), use laneAtXStrict (#442).
   laneAtX(x: number): LaneIndex {
+    const idx = Math.floor((x - this.startX) / this.laneWidth);
+    return Math.max(0, Math.min(2, idx)) as LaneIndex;
+  }
+
+  /**
+   * #442 — lane hit-testing constrained to the lane COLUMN band. Returns the
+   * lane only when `x` falls within the drawn 3-lane band (the columns where the
+   * hit-ring circles + falling notes live), with a small forgiving edge margin.
+   * Taps OUTSIDE the band — the top-left pause/mute chrome, or the dead side
+   * gutters on a wide screen where the lanes cap at 600px and center — return
+   * `null`, so they neither score nor register a miss. The band is the same
+   * geometry the renderer draws, so input columns == visible columns.
+   */
+  laneAtXStrict(x: number): LaneIndex | null {
+    const bandWidth = this.laneWidth * 3;
+    // Forgive a SMALL amount past each outer edge (a fat thumb right on the edge
+    // lane) — a fraction of a lane, NOT the whole margin — so genuine edge taps
+    // still count but a tap out in the gutter / on the top-left chrome does not.
+    // Kept tight (≈quarter lane, capped) so the dead margins truly reject.
+    const edgeSlack = Math.min(this.laneWidth * 0.25, this.noteRadius * 0.5, 40);
+    const left = this.startX - edgeSlack;
+    const right = this.startX + bandWidth + edgeSlack;
+    if (x < left || x > right) return null;
     const idx = Math.floor((x - this.startX) / this.laneWidth);
     return Math.max(0, Math.min(2, idx)) as LaneIndex;
   }

--- a/corpan/packs/lingo-hero/src/styles.css
+++ b/corpan/packs/lingo-hero/src/styles.css
@@ -723,13 +723,23 @@ canvas {
   width: 100%;
   max-width: 100%;
   box-sizing: border-box;
-  padding: clamp(0.25rem, 1.2vmin, 0.5rem) clamp(0.5rem, 2.5vmin, 1rem);
+  /* NEVER let the flex column squeeze the prompt below its own wrapped content
+     height — that was the #441 clip (box rendered 2px shorter than its 3-line
+     text). flex-shrink:0 + height:auto means the box always grows to fit every
+     wrapped line; fitPrompt() shrinks the FONT (not the box) when a phrase is
+     genuinely huge, so the full phrase is visible at any length. */
+  flex: 0 0 auto;
+  height: auto;
+  /* A touch of vertical padding fully contains each line box's leading so the
+     wrapped phrase never grazes the band edge (the residual iPad ~1px the strict
+     #441 clip check saw is line-leading, not glyph ink — this absorbs it). */
+  padding: clamp(0.4rem, 1.4vmin, 0.6rem) clamp(0.5rem, 2.5vmin, 1rem);
   font-family: var(--font-display);
   font-weight: 800;
   /* Auto-fit: scale with viewport but cap so long phrases shrink to fit the
-     full width and wrap to at most a couple of lines rather than clipping. */
+     full width and wrap across a few lines rather than clipping. */
   font-size: clamp(1.05rem, 5vw, 2rem);
-  line-height: 1.12;
+  line-height: 1.18;
   text-align: center;
   color: var(--ink);
   letter-spacing: 0.01em;
@@ -738,7 +748,9 @@ canvas {
   text-shadow:
     0 1px 2px rgba(0, 0, 0, 0.85),
     0 0 14px rgba(0, 0, 0, 0.7);
-  /* Wrap rules: break long words/sentences, never truncate. */
+  /* Wrap rules: break long words/sentences, never truncate. The phrase wraps to
+     as many lines as it needs; no nowrap, no ellipsis, no fixed-height clip. */
+  overflow: visible;
   overflow-wrap: anywhere;
   word-break: normal;
   white-space: normal;
@@ -849,62 +861,75 @@ canvas {
   }
 }
 
-/* BOTTOM STATS ROW (issue #426) — ONE fixed, compact row across the very
-   bottom: level meter · SCORE · STREAK. It is pinned UNDER the hit-ring circles
-   (the strum line was pulled up to 0.74 height; the rings clear this band) and
-   is a centered, content-width cluster so it NEVER flanks the falling-note
-   lanes (preserves the 0.4.0 fix). The bottom inset RESPECTS the Android safe
-   area (gesture/nav bar) so nothing is clipped or overlapped by system chrome.
-   pointer-events stay off the row (the plates don't need interaction). */
+/* BOTTOM STATS ROW (issue #443, evolves #426) — SCORE | thin level meter |
+   STREAK. Two EQUAL "fat" plates flank a THIN center meter, and the whole row
+   spans the FULL WIDTH of the 3 lanes (the lanes cap at 600px and center, so
+   the row matches that band: min(100vw − gutters, 600px), centered). On a phone
+   the lanes fill the width so the row does too; on iPad/landscape it stays the
+   premium 600px band — comfortable, never a cramped center cluster, never wider
+   than the lanes (preserves the 0.4.0 no-flank rule). Pinned UNDER the hit-ring
+   circles (strum at 0.74h) and RESPECTS the bottom safe area. pointer-events off. */
 .lh-stats {
   position: absolute;
   left: 50%;
-  bottom: calc(8px + var(--safe-bottom));
+  bottom: calc(10px + var(--safe-bottom));
   transform: translateX(-50%);
   display: flex;
   flex-direction: row;
   align-items: stretch;
   justify-content: center;
-  gap: 8px;
-  width: max-content;
-  max-width: calc(100vw - 24px);
+  gap: clamp(8px, 2.2vw, 18px);
+  /* Span the full lane band: full phone width, capped to the 600px lane cap on
+     wide screens, with symmetric side gutters so it never touches the edges. */
+  width: min(calc(100vw - 28px), 600px);
   pointer-events: none;
 }
 
-/* Compact the plates so the whole row reads as one tidy bottom HUD bar (smaller
-   than the old stacked banner) and fits a narrow phone without flanking lanes. */
-.lh-stats .mastery-readout {
-  align-self: center;
-  width: auto;
-  max-width: 44vw;
-  margin: 0;
-  gap: 8px;
-  padding: 4px 10px;
-  font-size: clamp(0.62rem, 2.6vmin, 0.8rem);
-}
-/* Keep the meter's progress bar from collapsing in the compact row. */
-.lh-stats .mastery-bar {
-  min-width: 34px;
-}
+/* The two outer plates are EQUAL and FAT — they share the row evenly and grow
+   to fill the lane-band width comfortably at iPad size. */
 .lh-stats .stat {
-  padding: 0.28rem 0.7rem;
+  flex: 1 1 0;
+  min-width: 0;
+  padding: clamp(0.4rem, 1.4vmin, 0.7rem) clamp(0.7rem, 2.4vw, 1.3rem);
   align-items: center;
   justify-content: center;
   text-align: center;
+}
+.lh-stats .score-box {
+  align-items: center;
 }
 /* In the bottom row the combo plate is centered (not right-flushed). */
 .lh-stats .combo-box {
   align-items: center;
   text-align: center;
 }
+
+/* The CENTER meter is THIN: it does NOT grow like the fat plates — it takes a
+   modest fixed-ish slice between them, so the two score/streak plates dominate
+   and the meter reads as a slim progress strip. */
+.lh-stats .mastery-readout {
+  flex: 0 1 auto;
+  align-self: center;
+  width: auto;
+  min-width: clamp(72px, 22vw, 150px);
+  max-width: 32%;
+  margin: 0;
+  gap: 8px;
+  padding: clamp(3px, 1vmin, 6px) clamp(8px, 1.6vw, 14px);
+  font-size: clamp(0.6rem, 2.4vmin, 0.78rem);
+}
+/* Keep the meter's progress bar from collapsing in the compact row. */
+.lh-stats .mastery-bar {
+  min-width: 34px;
+}
 .lh-stats .score-box .stat-value {
-  font-size: clamp(1.05rem, 4.6vmin, 1.5rem);
+  font-size: clamp(1.2rem, 5.2vmin, 2rem);
 }
 .lh-stats .combo-value #combo {
-  font-size: clamp(1.25rem, 5.4vmin, 1.9rem);
+  font-size: clamp(1.35rem, 5.8vmin, 2.2rem);
 }
 .lh-stats .combo-value .x {
-  font-size: clamp(0.8rem, 3.2vmin, 1.05rem);
+  font-size: clamp(0.85rem, 3.4vmin, 1.2rem);
 }
 
 /* Very short / landscape screens: keep the same single compact bottom row, just
@@ -913,16 +938,16 @@ canvas {
 @media (max-height: 560px) {
   .lh-stats {
     bottom: calc(6px + var(--safe-bottom));
-    gap: 6px;
-    max-width: calc(100vw - 16px);
+    gap: clamp(6px, 1.6vw, 14px);
+    width: min(calc(100vw - 16px), 640px);
   }
   .lh-stats .mastery-readout {
-    max-width: 40vw;
+    max-width: 28%;
     overflow: hidden;
     text-overflow: ellipsis;
   }
   .lh-stats .stat {
-    padding: 0.22rem 0.55rem;
+    padding: 0.3rem 0.7rem;
   }
 }
 

--- a/corpan/packs/lingo-hero/src/ui/Hud.ts
+++ b/corpan/packs/lingo-hero/src/ui/Hud.ts
@@ -190,19 +190,20 @@ export class Hud {
             <div class="lh-assemble" id="lh-assemble" aria-live="polite" hidden></div>
           </div>
         </div>
-        <!-- BOTTOM STATS ROW — a SINGLE fixed, compact row pinned across the very
-             bottom (issue #426): level meter · SCORE · STREAK/COMBO. It sits
-             UNDER the hit-ring circles (which were nudged up) and is a centered,
-             content-width cluster so it NEVER flanks/overlaps the falling-note
-             lanes (preserves the 0.4.0 fix). pointer-events stay off the row. -->
+        <!-- BOTTOM STATS ROW (issue #443, evolves #426): SCORE | thin level meter |
+             STREAK — two equal "fat" plates flanking a THIN center meter, the row
+             spanning the FULL WIDTH of the 3 lanes. Premium + comfortable at
+             iPad/landscape width (not a cramped center cluster), still tidy on a
+             phone. It sits UNDER the hit-ring circles and respects the bottom safe
+             area. pointer-events stay off the row. DOM order == visual order. -->
         <div class="lh-stats" id="lh-stats">
-          <!-- (d) level / mastery meter slot (left of the row) -->
-          <div class="mastery-readout" id="mastery-readout" aria-live="polite" hidden></div>
           <div class="stat score-box">
             <span class="stat-label">Score</span>
             <span class="stat-value" id="score">0</span>
             <span class="score-flyout" id="score-flyout" aria-hidden="true"></span>
           </div>
+          <!-- (d) thin CENTER level / mastery meter (between the two plates) -->
+          <div class="mastery-readout" id="mastery-readout" aria-live="polite" hidden></div>
           <div class="stat combo-box zero" id="combo-box">
             <span class="stat-label">Streak</span>
             <span class="combo-value"><span class="x">x</span><span id="combo">0</span></span>
@@ -329,37 +330,62 @@ export class Hud {
   }
 
   /**
-   * Shrink the prompt font until the entire phrase fits inside the header band
-   * (up to ~2 wrapped lines), floored so short phrases stay big and long ones
-   * stay legible. Measured against the element's own scroll size so it works for
-   * any phrase length / script. Idempotent + cheap (a handful of reflows). The
-   * upper bound is the CSS-resolved size so short prompts keep their full scale.
+   * Auto-fit the prompt so the ENTIRE phrase is always visible — #441.
+   *
+   * The 0.4.3 version tried to JAM every phrase into <=2 lines and bottomed out
+   * at a font floor; a long sentence then wrapped to a 3rd line that overflowed
+   * the band (scrollHeight > clientHeight) — the exact iPad clip the operator
+   * kept hitting. The model here is inverted and correct:
+   *
+   *   - The phrase WRAPS freely (CSS: white-space:normal / overflow-wrap:anywhere).
+   *   - We give it a GENEROUS height budget (a fraction of the viewport, capped
+   *     to a max line count that is large enough to never clip a real phrase).
+   *   - We START at the CSS ceiling and only SHRINK the font when the wrapped
+   *     text exceeds that budget OR a single unbreakable token overflows width,
+   *     floored so it stays readable.
+   *
+   * Because layout must be settled to measure, we run once now and again on the
+   * next frame (rAF) — the first call can fire before flex layout resolves
+   * (which made the old fit silently no-op against a stale/zero width).
    */
   private fitPrompt(): void {
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(() => this.fitPromptNow());
+    }
+    // Also run synchronously so callers/tests that measure immediately see a fit.
+    this.fitPromptNow();
+  }
+
+  private fitPromptNow(): void {
     const el = this.questionBox;
     if (!el.textContent) return;
     // Reset to the CSS-driven size, then read it as our ceiling.
     el.style.fontSize = "";
+    el.style.lineHeight = "";
     const ceiling = parseFloat(getComputedStyle(el).fontSize) || 24;
+    const cssLineH = parseFloat(getComputedStyle(el).lineHeight) || ceiling * 1.16;
+    const lineRatio = cssLineH / ceiling || 1.16;
     const FLOOR = 13; // px — never shrink below this (still readable)
-    // Two passes: first cap the height to ~2 lines, then ensure no horizontal
-    // overflow. Bisect-ish linear step keeps it bounded (<= ~12 iterations).
+    // Generous height budget: up to MAX_LINES of text, but never taller than a
+    // fraction of the viewport. MAX_LINES is high enough that a normal sentence
+    // never clips; the font only shrinks if a phrase is genuinely huge.
+    const MAX_LINES = 4;
+    const vh = window.innerHeight || 800;
+    const budget = Math.min(MAX_LINES * ceiling * lineRatio, vh * 0.3);
+
     let size = ceiling;
-    el.style.fontSize = `${size}px`;
-    const lineH = 1.16;
-    // Budget: at most 2 lines tall. maxH derives from the current font (2 lines
-    // + the box's vertical padding, already in offsetHeight via clientHeight).
-    const fits = (): boolean => {
-      const maxLines = 2;
-      const maxH = size * lineH * maxLines + 2;
-      return (
-        el.scrollHeight <= maxH + 1 && el.scrollWidth <= el.clientWidth + 1
-      );
+    const apply = (s: number) => {
+      el.style.fontSize = `${s}px`;
     };
+    apply(size);
+    // scrollHeight is the wrapped content height; scrollWidth>clientWidth means a
+    // single token can't break (rare). Shrink until BOTH fit the budget/width.
+    const fits = (): boolean =>
+      el.scrollHeight <= budget + 1 && el.scrollWidth <= el.clientWidth + 1;
     let guard = 0;
-    while (size > FLOOR && !fits() && guard < 24) {
+    while (size > FLOOR && !fits() && guard < 40) {
       size = Math.max(FLOOR, size - 1);
-      el.style.fontSize = `${size}px`;
+      apply(size);
       guard++;
     }
   }

--- a/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
+++ b/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
@@ -159,6 +159,104 @@ else {
   await page.mouse.click(muteCtl.x, muteCtl.y);
 }
 
+// --- Contract (c3): #442 — lane hit-testing is ISOLATED to the lane COLUMNS. ---
+// A tap OUTSIDE the lane band (the dead side margins where the lanes cap+center
+// on a wide screen, or the top-left chrome region) must NOT resolve to a lane —
+// no score, no miss. A tap INSIDE a lane column DOES resolve. We verify the
+// geometry contract directly (laneAtXStrict) AND prove a real margin tap doesn't
+// score, on a WIDE viewport where the lanes cap at 600px so true dead margins
+// exist. Uses window.__lingoHero introspection — no private internals leaked.
+{
+  const wide = await browser.newPage({ viewport: { width: 1180, height: 820 }, deviceScaleFactor: 2 });
+  wide.on("pageerror", (e) => fail("pageerror(442): " + e.message));
+  await wide.goto(harness);
+  await wide.waitForFunction(() => !!window.__lingoHero, { timeout: 10000 });
+  await wide.evaluate(() => {
+    const h = document.getElementById("host");
+    if (h) { h.style.margin = "0"; h.style.width = "100vw"; h.style.height = "100vh"; }
+  });
+  await wide.evaluate(() => {
+    const p = [...document.querySelectorAll("button")].find((b) => /practice/i.test(b.textContent || ""));
+    if (p) p.click(); else window.__lingoHero.startGame("PRACTICE");
+  });
+  await wide.waitForFunction(() => (window.__lingoHero.notes || []).length > 0, { timeout: 10000 });
+
+  // Geometry contract: laneAtXStrict rejects the dead margins, accepts the lanes.
+  const geo = await wide.evaluate(() => {
+    const ls = window.__lingoHero.laneSystem;
+    const lb0 = ls.getLaneBounds(0), lb2 = ls.getLaneBounds(2);
+    const bandLeft = lb0.x, bandRight = lb2.x + lb2.width;
+    return {
+      // Far-left and far-right margins (well outside the band) must be null.
+      farLeft: ls.laneAtXStrict(bandLeft - 60),
+      farRight: ls.laneAtXStrict(bandRight + 60),
+      // Centers of each lane column must resolve to that lane.
+      lane0: ls.laneAtXStrict(ls.getLaneX(0)),
+      lane1: ls.laneAtXStrict(ls.getLaneX(1)),
+      lane2: ls.laneAtXStrict(ls.getLaneX(2)),
+      bandLeft, bandRight,
+    };
+  });
+  if (geo.farLeft !== null) fail(`#442: a tap in the LEFT dead margin resolved to lane ${geo.farLeft} (must be null)`);
+  if (geo.farRight !== null) fail(`#442: a tap in the RIGHT dead margin resolved to lane ${geo.farRight} (must be null)`);
+  if (geo.lane0 !== 0 || geo.lane1 !== 1 || geo.lane2 !== 2) {
+    fail(`#442: lane-column centers did not resolve to their lanes (got ${geo.lane0}/${geo.lane1}/${geo.lane2})`);
+  } else if (geo.farLeft === null && geo.farRight === null) {
+    console.log(`OK: #442 lane hit-testing isolated to columns (margins→null, lanes 0/1/2 resolve; band ${geo.bandLeft.toFixed(0)}–${geo.bandRight.toFixed(0)})`);
+  }
+
+  // Behavioral: a REAL tap out in the dead side margin must not change the score
+  // (no lane hit, no miss). Tap at the canvas top-left margin, far from any lane.
+  const wread = () => wide.evaluate(() => ({ score: window.__lingoHero.score, combo: window.__lingoHero.combo }));
+  {
+    const before = await wread();
+    const pt = await wide.evaluate(() => {
+      const g = window.__lingoHero, ls = g.laneSystem, r = g.canvas.getBoundingClientRect();
+      const lb0 = ls.getLaneBounds(0);
+      // A point in the dead left margin (canvas-left edge), at the strum height.
+      const marginX = Math.max(8, lb0.x * 0.4);
+      return { x: r.left + marginX, y: r.top + ls.getStrumLineY() };
+    });
+    await wide.mouse.click(pt.x, pt.y);
+    await wide.waitForTimeout(140);
+    const after = await wread();
+    if (after.score !== before.score || after.combo > before.combo) {
+      fail(`#442: a tap in the dead side margin changed score/combo (${before.score}/${before.combo} -> ${after.score}/${after.combo})`);
+    } else {
+      console.log("OK: #442 a real tap in the dead side margin did not score or register a lane hit");
+    }
+  }
+
+  // And prove a tap IN a lane column at the strum DOES score (positive control).
+  {
+    let scored = false;
+    const dl = Date.now() + 20000;
+    while (Date.now() < dl && !scored) {
+      const s = await wide.evaluate(() => {
+        const g = window.__lingoHero, ls = g.laneSystem, r = g.canvas.getBoundingClientRect();
+        const strumY = ls.getStrumLineY();
+        const t = (g.notes || []).find((n) => n.isTarget && n.seqIndex === g.caughtCount && !n.hit && !n.missed);
+        return {
+          score: g.score,
+          ready: !!t && t.y >= strumY - 44 && t.y <= strumY + 44,
+          click: t ? { x: r.left + ls.getLaneX(t.lane), y: r.top + strumY } : null,
+        };
+      });
+      if (s.ready && s.click) {
+        const before = s.score;
+        await wide.mouse.click(s.click.x, s.click.y);
+        await wide.waitForTimeout(140);
+        const ns = await wread();
+        if (ns.score > before) { scored = true; console.log("OK: #442 a tap in a lane column at the strum DID score (positive control)"); }
+      }
+      await wide.waitForTimeout(50);
+    }
+    if (!scored) fail("#442: could not land an in-column lane catch to confirm lanes still score");
+  }
+  await wide.screenshot({ path: join(outDir, "lane-isolation-442.png") });
+  await wide.close();
+}
+
 // --- Contract (e): the PROMPT shows the FULL phrase (no truncation). ---------
 // Inject a deliberately LONG primary-language prompt and assert the question box
 // renders it WITHOUT clipping: scrollWidth must fit clientWidth (no horizontal
@@ -195,6 +293,75 @@ else {
     if (failures === 0 || probe.scrollWidth <= probe.clientWidth + 1) {
       console.log(`OK: long prompt fully visible (font ${probe.fontPx.toFixed(0)}px, ${probe.scrollWidth}<=${probe.clientWidth}w, ${probe.scrollHeight}px tall)`);
     }
+  }
+}
+
+// --- Contract (e2): #441 — LONG + COMMA prompt FULLY VISIBLE at PHONE *and*
+// IPAD widths (portrait + landscape). The 0.4.3 fitPrompt() jammed phrases into
+// <=2 lines, hit a font floor, and let the overflow spill the band on iPad — the
+// exact clip the operator kept hitting. This proves the FULL phrase (every word)
+// renders without any glyph clipped, measured with a Range over the rendered text
+// (immune to scrollHeight/clientHeight integer rounding), across viewport widths.
+{
+  const LONG = "They built a fort, then argued about what to defend it from";
+  const WORDS = LONG.replace(/[.,]/g, "").split(/\s+/).filter(Boolean);
+  const SIZES = [
+    { name: "phone-portrait", w: 390, h: 844 },
+    { name: "ipad-portrait", w: 834, h: 1112 },
+    { name: "ipad-landscape", w: 1180, h: 820 },
+  ];
+  for (const sz of SIZES) {
+    const vp = await browser.newPage({ viewport: { width: sz.w, height: sz.h }, deviceScaleFactor: 2 });
+    vp.on("pageerror", (e) => fail(`pageerror(441-${sz.name}): ` + e.message));
+    await vp.goto(harness);
+    await vp.waitForFunction(() => !!window.__lingoHero, { timeout: 10000 });
+    // Give the pack the FULL viewport (the app hands the pack the whole screen).
+    await vp.evaluate(() => {
+      const h = document.getElementById("host");
+      if (h) { h.style.margin = "0"; h.style.width = "100vw"; h.style.height = "100vh"; }
+    });
+    await vp.evaluate(() => {
+      const p = [...document.querySelectorAll("button")].find((b) => /practice/i.test(b.textContent || ""));
+      if (p) p.click(); else window.__lingoHero.startGame("PRACTICE");
+    });
+    await vp.waitForTimeout(350);
+    const m = await vp.evaluate((args) => {
+      const [text, words] = args;
+      window.__lingoHero.hud.setQuestion(text);
+      const el = document.querySelector("#question-box");
+      if (!el) return null;
+      const cs = getComputedStyle(el);
+      const eb = el.getBoundingClientRect();
+      const padT = parseFloat(cs.paddingTop) || 0, padB = parseFloat(cs.paddingBottom) || 0;
+      const padL = parseFloat(cs.paddingLeft) || 0, padR = parseFloat(cs.paddingRight) || 0;
+      const rng = document.createRange(); rng.selectNodeContents(el);
+      const tb = rng.getBoundingClientRect();
+      const txt = el.textContent || "";
+      return {
+        fontPx: parseFloat(cs.fontSize),
+        allPresent: words.every((w) => txt.includes(w)),
+        missing: words.filter((w) => !txt.includes(w)),
+        // glyph spill past the content box (Range measures the line box, which
+        // includes ~1px font leading — so 1.5px is the real-clip threshold).
+        spillBottom: Math.max(0, tb.bottom - (eb.bottom - padB)),
+        spillTop: Math.max(0, (eb.top + padT) - tb.top),
+        spillRight: Math.max(0, tb.right - (eb.right - padR)),
+        spillLeft: Math.max(0, (eb.left + padL) - tb.left),
+      };
+    }, [LONG, WORDS]);
+    if (!m) { fail(`#441 ${sz.name}: no #question-box`); }
+    else {
+      const SPILL = 1.5;
+      if (!m.allPresent) fail(`#441 ${sz.name}: prompt missing words ${JSON.stringify(m.missing)}`);
+      if (m.spillBottom > SPILL || m.spillTop > SPILL || m.spillRight > SPILL || m.spillLeft > SPILL) {
+        fail(`#441 ${sz.name}: prompt CLIPPED — spill(t/b/l/r)=${m.spillTop.toFixed(1)}/${m.spillBottom.toFixed(1)}/${m.spillLeft.toFixed(1)}/${m.spillRight.toFixed(1)} (font ${m.fontPx}px)`);
+      }
+      if (m.allPresent && m.spillBottom <= SPILL && m.spillTop <= SPILL && m.spillRight <= SPILL && m.spillLeft <= SPILL) {
+        console.log(`OK: #441 long+comma prompt fully visible at ${sz.name} ${sz.w}x${sz.h} (font ${m.fontPx}px, all ${WORDS.length} words, spill<=${SPILL}px)`);
+      }
+    }
+    await vp.screenshot({ path: join(outDir, `prompt-441-${sz.name}.png`) });
+    await vp.close();
   }
 }
 


### PR DESCRIPTION
### **User description**
Ships **#441, #442, #443** as one coherent Lingo Hero fix → **v0.4.6** (preview channel).

## #441 — Prompt phrase STILL truncated (reproduction-gated)

The 0.4.3 `fitPrompt()` shipped "fixed" once and was still broken on iPad: long, comma-containing phrases like *"They built a fort, then argued about what to defend it from"* clipped — cut at the comma / forced onto one line that ran off the band.

**Reproduced first (on the 0.4.5 build):** a headless harness set that long phrase into `#question-box` and measured the rendered text with a `Range` (immune to `scrollHeight`/`clientHeight` integer rounding). Result — the phrase **clipped** on iPad:

| viewport | 0.4.5 OLD | 0.4.6 FIXED |
|---|---|---|
| phone-portrait 390×844 | font jammed to 13px floor, glyph spill | font 19.5px, 2 lines, **0px spill** |
| iPad-portrait 834×1112 | 1 line @28px, **spillTop 2.0px (clipped)** | 2 lines @32px, spill ≤1px |
| iPad-landscape 1180×820 | 1 line @32px, **spillTop 2.0px (clipped)** | 1 line @32px, spill ≤1px |

All 12 words present in every case; the OLD failure was vertical band overflow, not missing text.

**Root cause:** `fitPrompt()` tried to JAM every phrase into ≤2 lines and bottomed out at a font floor, so a long sentence wrapped to a 3rd line that overflowed the reserved header band — and the `.question-box` was `flex: 0 1 auto` inside a flex column, which squeezed the box ~2px below its own content height.

**Fix:** inverted the model — the phrase WRAPS freely to as many lines as it needs within a generous height budget, and the font only SHRINKS (floored to a readable size) when the wrapped text genuinely exceeds that budget. `.question-box` is now `flex: 0 0 auto` / `height: auto` so the flex column can no longer squeeze it, and the fit re-runs on the next animation frame (rAF) so it never measures against a pre-layout width. Re-fits on resize / orientation.

**Proof of fix (mandatory):** the same long+comma phrase now renders FULLY — every word, ≤1px glyph spill (line leading only), no clip — at phone, iPad-portrait, AND iPad-landscape. Asserted in e2e and confirmed by the design-critic across all captured frames.

## #442 — Lane tap isolated to the circle columns

Hit-testing spanned the full screen width, so taps on the top-left pause/mute chrome or in the dead side margins (lanes cap at 600px and center on wide screens) registered a lane hit/miss. Added `LaneSystem.laneAtXStrict()`: returns a lane only within the drawn 3-lane band (small forgiving edge slack), `null` outside it. Chrome `stopPropagation` (no tap-through) and canvas-relative input preserved. e2e proves a margin tap doesn't score while an in-column strum tap does.

## #443 — Big-screen bottom HUD row

`SCORE | thin level meter | STREAK` — two equal "fat" plates flanking a slim center meter, the row now spanning the full width of the 3 lanes (capped to the 600px lane band, centered on wide screens). Premium/comfortable at iPad-landscape, still tidy on phone, never flanks the lanes; respects the bottom safe area. Verified at 290–890px (full lane band): SCORE 200px | meter 164px | STREAK 200px.

## Verification
- `tsc` clean, `npm run build` passes.
- e2e (`test/e2e/gameplay.spec.mjs`) **PASS** — added #441 (full long+comma prompt at phone + iPad-portrait + iPad-landscape) and #442 (margin/chrome tap no-score, in-column tap scores) assertions; ALL prior assertions kept (motion, catch-scores, no-tap-through pause/mute/exit, decoy-dodge reward, missed-correct miss, no-brick, #407 language rules, iOS audio unlock) and green.
- Design-critic gate: **GO, zero blockers** — #441 full-visibility confirmed across all frames; HUD row premium with no lane/ring overlap; no menu/gameplay regression. 3 minor polish follow-ups noted (non-blocking, preview channel).

Preserves all contracts: answer dedup, offline-first, raw-text TTS, pack id `lingo_hero`, canvas-relative input, delta-timed motion, #407 language rule, the 0.4.5 iOS audio unlock, prior HUD/visual gains. `window.__lingoHero` still introspectable.

Closes #441
Closes #442
Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement, Tests, Documentation


___

### **Description**
- Fix prompt clipping for long phrases

- Restrict lane taps to columns

- Improve wide-screen bottom HUD layout

- Add regression coverage and release notes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  prompt["Long prompt text"] -- "wraps and refits" --> visible["Fully visible phrase"]
  input["Canvas tap input"] -- "strict lane hit-test" --> lanes["Lane columns only"]
  hud["Bottom HUD"] -- "responsive row" --> layout["Score | meter | streak"]
  tests["E2E harness"] -- "validates" --> regressions["Prompt and tap regressions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>Game.ts</strong><dd><code>Use strict lane-column hit testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/444/files#diff-6c075e8c51d32e4e5452a4c738f6cc530345361455286e0f7d1af37f46fedde7">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LaneSystem.ts</strong><dd><code>Add strict lane band resolver</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/444/files#diff-49208e8c6b4d3a2cbe84d78c7e15bd2cf92174f83b0eeb9992687c59a0375125">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>Hud.ts</strong><dd><code>Refit prompts and reorder stats</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/444/files#diff-145e656a10e1e233418a8c559a94e938bf0e0c922802aa2f87d69b0498a38c02">+52/-26</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>styles.css</strong><dd><code>Prevent prompt clipping and widen HUD</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/444/files#diff-b9b9a82cd5a6b2fe32239b2b4b2f069c2c4853d63db1736b575103a5d1daf226">+63/-38</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document Lingo Hero 0.4.6 release</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/444/files#diff-dd09bf20e11864991961b7ef6d2fc6687a66d9a9de2d246f765d9d6891e646c2">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>manifest.json</strong><dd><code>Bump preview pack version metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/444/files#diff-38411e79d50eee7f8ad439a29518dcddf16cdc9cd03739fc81ea212f18519b15">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>gameplay.spec.mjs</strong><dd><code>Add prompt and lane regression tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/444/files#diff-5ee22f0c6a817c0427478004e2238facf99cd3c18591eda51d590170655a3c57">+167/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

