### PR TITLE
Lingo Hero 0.4.7: persistent level meter, streak-0 visibility, ring↔HUD gap, spawn clearance (#432, #433, #445)

### DIFF
--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -6,6 +6,46 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.7] - 2026-06-23
+
+Bottom-HUD + top-prompt polish follow-ups from the 0.4.6 design-critic pass
+(#432, #433, #445) — preview channel, non-gating cosmetics. No gameplay,
+scoring, audio, or layout-contract changes; the 0.4.6 prompt full-visibility,
+lane-tap isolation, and iOS audio-unlock contracts are all preserved.
+
+### Changed
+- **Persistent level meter (#432).** The bottom row's center level meter now
+  shows at ALL times during play — including the zero state ("Lv 1 · 0%") before
+  the first wave resolves — so the row always reads as the intended 3-part HUD
+  (Score | meter | Streak) instead of collapsing to a lone centered SCORE plate.
+  The zero-state readout is a quiet placeholder (standing level + its progress
+  bar), brightening into the live caught/seen accuracy readout once waves land.
+- **STREAK plate visible at streak 0 (#432 / #445).** The streak plate was fully
+  invisible (`opacity: 0`) until the first catch, leaving the right side of the
+  row empty. It is now a dimmed, legible PLACEHOLDER ("Streak x0", desaturated,
+  no neon glow) at streak 0 — the inactive twin of the SCORE plate — and
+  brightens to the full juicy amber as soon as the player has a streak.
+- **Tighter ring↔HUD gap (#432).** Raised the bottom stats row (a clamped,
+  viewport-proportional inset) so it tucks up closer beneath the hit-ring
+  circles instead of hugging the very bottom edge with a large empty band above
+  it. Short/landscape screens keep their low inset (the tighten is for tall
+  phones, where the gap was largest).
+- **Compact phone meter label (#445).** At narrow phone widths the center meter
+  now uses a compact "Lv N · pp%" label (drops the caught/seen fraction) so it
+  isn't cramped between the two plates; roomier widths still show the full
+  "Lv N · c/s · pp%". Also stopped force-uppercasing the in-stats meter label so
+  it reads as designed ("Lv 1 · 0%", mixed case + middot) rather than "LV 1...".
+
+### Fixed
+- **Spawn clearance from the prompt (#433 / #445).** A freshly-spawned falling
+  tile could near/graze the top prompt label as it entered — most visible on a
+  narrow phone where a 2-line wrapped prompt sits closer to the spawn zone. The
+  play-area top now holds a SMALL clearance just below the printed prompt block
+  (measured per phrase + per resize, nudged down a touch more when the prompt
+  wraps to 2+ lines), so tiles fade in clear of the prompt text. The translucent
+  show-through header (#426) is preserved — notes still appear within the header
+  band below the text, they just no longer touch the glyphs.
+
 ## [0.4.6] - 2026-06-23
 
 Prompt full-visibility fix (#441), lane-tap isolation (#442), and a big-screen

--- a/corpan/packs/lingo-hero/manifest.json
+++ b/corpan/packs/lingo-hero/manifest.json
@@ -2,7 +2,7 @@
   "id": "lingo_hero",
   "channel": "preview",
   "name": "Lingo Hero",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Catch the translation. The phrase you know falls as a chart of timed notes in the language you're learning — catch each word in rhythm, in order, and hear it spoken.",
   "entry": "dist/app.js",
   "styles": [
@@ -11,5 +11,5 @@
   "entryType": "script",
   "sdkVersion": "0.1.0",
   "minAppVersion": "0.17.0",
-  "devRevision": "2026-06-23T20:15:00.000Z"
+  "devRevision": "2026-06-23T22:30:00.000Z"
 }

--- a/corpan/packs/lingo-hero/src/Game.ts
+++ b/corpan/packs/lingo-hero/src/Game.ts
@@ -377,12 +377,39 @@ export class Game {
     // first constructor-time resize; guard for that.
     this.hud?.onResize();
 
-    // The lane now runs FULL HEIGHT to the very top edge: notes spawn at the top
-    // and are seen THROUGH the translucent header as they enter (the header is a
-    // transparent overlay, not a reserved band). So the play-area top is 0 — no
-    // HUD-band reservation, no clip. The header text stays readable above the
-    // notes and never blocks taps on the lanes behind it (pointer-events:none).
-    this.laneSystem.setPlayTop(0);
+    // The lane runs essentially full height: notes are seen THROUGH the
+    // translucent header as they enter (the header is a transparent overlay, not
+    // a reserved band) — the #426 show-through look. We do NOT reserve the whole
+    // header band. We DO hold a SMALL spawn-clearance just under the printed
+    // prompt lines (#433 / #445.1) so a freshly-spawned tile fades in clear of
+    // the prompt text instead of grazing it — nudged down a touch more when the
+    // prompt wraps to 2+ lines (the case the operator hit on a narrow phone).
+    this.applySpawnClearance();
+  }
+
+  /**
+   * Hold a small play-area top so spawning tiles clear the prompt text
+   * (#433 / #445.1). This is intentionally SMALL — a few px below the printed
+   * prompt block, not a full HUD-band reservation — so the translucent
+   * show-through header look (#426) is preserved: notes still appear within the
+   * header band, just clear of the glyphs. Re-applied on resize AND on each new
+   * phrase (wrap count changes per phrase). Falls back to 0 if the Hud/measure
+   * isn't ready yet.
+   */
+  private applySpawnClearance(): void {
+    if (!this.hud) {
+      this.laneSystem.setPlayTop(0);
+      return;
+    }
+    const containerTop = this.canvas.getBoundingClientRect().top;
+    const { bottom, wrapped } = this.hud.getPromptClearance(containerTop);
+    if (bottom <= 0) {
+      this.laneSystem.setPlayTop(0);
+      return;
+    }
+    // A small gap below the prompt block; a bit more when wrapped to 2+ lines.
+    const gap = wrapped ? 18 : 10;
+    this.laneSystem.setPlayTop(bottom + gap);
   }
 
   private showMenu() {
@@ -505,6 +532,15 @@ export class Game {
     this.hud.setQuestion(this.cleanPrompt(round.promptText));
     this.hud.setRomanization(round.romanization ?? "");
     this.hud.setAssembled([], this.roundWords.length, this.activeLanguage.isRTL);
+
+    // Re-measure spawn clearance for THIS phrase: a longer phrase wraps to more
+    // lines, so the clearance band below the prompt must track it (#433/#445.1).
+    // Run now (synchronous fitPrompt has applied) and again next frame so the
+    // measure reflects the settled wrapped layout.
+    this.applySpawnClearance();
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(() => this.applySpawnClearance());
+    }
 
     this.buildChart();
   }

--- a/corpan/packs/lingo-hero/src/styles.css
+++ b/corpan/packs/lingo-hero/src/styles.css
@@ -872,7 +872,12 @@ canvas {
 .lh-stats {
   position: absolute;
   left: 50%;
-  bottom: calc(10px + var(--safe-bottom));
+  /* TIGHTER ring↔HUD gap (#432): raise the stats row so it sits closer beneath
+     the hit-ring circles (rings' bottom ≈ 0.74·h + noteRadius) instead of
+     hugging the very bottom edge with a big empty band above it. Uses a
+     viewport-proportional inset (clamped) so the row tucks up under the rings on
+     tall phones yet keeps a comfortable bottom margin + safe area. */
+  bottom: calc(clamp(20px, 4.5vh, 56px) + var(--safe-bottom));
   transform: translateX(-50%);
   display: flex;
   flex-direction: row;
@@ -922,6 +927,50 @@ canvas {
 .lh-stats .mastery-bar {
   min-width: 34px;
 }
+/* The in-stats meter label is a mixed-case readout ("Lv 1 · 0%") — keep its
+   intended casing + middot separator (#445.3); do NOT uppercase it like the
+   plate eyebrow labels (that turned "Lv" into "LV"). */
+.lh-stats .mastery-label {
+  text-transform: none;
+}
+/* LABEL DENSITY (#445.3): show the FULL "Lv N · c/s · pp%" label on roomy
+   widths; on a narrow phone show the COMPACT "Lv N · pp%" variant so the center
+   meter never reads cramped. Default = full visible / compact hidden; the phone
+   media query below flips it. The hidden twin is removed from layout (not just
+   transparent) so only one label ever takes width. */
+.lh-stats .mastery-label-full {
+  display: inline;
+}
+.lh-stats .mastery-label-compact {
+  display: none;
+}
+/* The persistent ZERO-state placeholder (#432) reads a touch quieter than the
+   earned live readout — it shows the standing level, not progress just made. */
+.lh-stats .mastery-readout.is-placeholder {
+  opacity: 0.82;
+}
+.lh-stats .mastery-readout.is-placeholder .mastery-fill {
+  opacity: 0.7;
+}
+/* Phone widths: swap to the compact label + tighten the meter so its single
+   line ("Lv 1 · 0%") sits comfortably between the two plates. */
+@media (max-width: 460px) {
+  .lh-stats .mastery-label-full {
+    display: none;
+  }
+  .lh-stats .mastery-label-compact {
+    display: inline;
+  }
+  .lh-stats .mastery-readout {
+    min-width: clamp(64px, 26vw, 120px);
+    gap: 6px;
+    padding: clamp(3px, 1vmin, 5px) clamp(6px, 2.4vw, 10px);
+    white-space: nowrap;
+  }
+  .lh-stats .mastery-label {
+    font-variant-numeric: tabular-nums;
+  }
+}
 .lh-stats .score-box .stat-value {
   font-size: clamp(1.2rem, 5.2vmin, 2rem);
 }
@@ -937,7 +986,10 @@ canvas {
    rings already cleared the bottom band, so the row stays put.) */
 @media (max-height: 560px) {
   .lh-stats {
-    bottom: calc(6px + var(--safe-bottom));
+    /* Short/landscape: less vertical room below the rings, so keep the row low
+       (just clear of the bottom safe area) — the proportional tighten above is
+       for tall phones, not these. */
+    bottom: calc(8px + var(--safe-bottom));
     gap: clamp(6px, 1.6vw, 14px);
     width: min(calc(100vw - 16px), 640px);
   }
@@ -1023,16 +1075,29 @@ canvas {
     transform: scale(1);
   }
 }
-/* Combo is HIDDEN until the player actually has a streak (>0), so the HUD reads
-   calm at the start of a round; it fades in on the first catch. */
+/* STREAK plate stays VISIBLE at zero (#432 / #445.2) — for left/right symmetry
+   with the SCORE plate the row never reads as a lone centered SCORE. At streak 0
+   it's a quiet, dimmed PLACEHOLDER (legible "Streak x0", desaturated, no glow);
+   it brightens to the full juicy amber as soon as the player has a streak. */
 .combo-box {
   transition: opacity var(--na-dur-base, 240ms) var(--na-ease-out, ease),
     filter var(--na-dur-base, 240ms) var(--na-ease-out, ease);
 }
 .combo-box.zero {
-  opacity: 0;
-  filter: saturate(0.4);
+  /* Visible but calm: dimmed (not invisible), softened color + no neon glow, so
+     it reads as the inactive twin of the SCORE plate rather than disappearing. */
+  opacity: 0.62;
+  filter: saturate(0.55);
   pointer-events: none;
+  border-color: color-mix(in srgb, var(--neon-amber) 18%, transparent);
+  background: linear-gradient(160deg, rgba(255, 194, 61, 0.05), rgba(10, 8, 22, 0.5));
+}
+.combo-box.zero .stat-label {
+  color: color-mix(in srgb, var(--neon-amber) 45%, var(--ink-faint));
+}
+.combo-box.zero .combo-value {
+  color: color-mix(in srgb, var(--neon-amber) 60%, var(--ink-dim));
+  text-shadow: 0 2px 0 rgba(0, 0, 0, 0.4);
 }
 
 /* Score delta flyout */

--- a/corpan/packs/lingo-hero/src/ui/Hud.ts
+++ b/corpan/packs/lingo-hero/src/ui/Hud.ts
@@ -28,6 +28,12 @@ export interface MasteryReadout {
   label: string;
   /** Optional 0..1 progress for a bar fill; omit to hide the bar. */
   progress?: number;
+  /**
+   * #432 — true for the persistent ZERO-state placeholder (level shown before
+   * any wave resolves). Styled slightly quieter than the earned live readout so
+   * the row stays composed without overclaiming progress that hasn't happened.
+   */
+  placeholder?: boolean;
 }
 
 /**
@@ -534,6 +540,7 @@ export class Hud {
     if (!readout || !readout.label.trim()) {
       this.masteryEl.hidden = true;
       this.masteryEl.innerHTML = "";
+      this.masteryEl.classList.remove("is-placeholder");
       return;
     }
     const bar =
@@ -543,10 +550,31 @@ export class Hud {
             Math.min(1, readout.progress)
           ) * 100}%"></span></span>`
         : "";
-    this.masteryEl.innerHTML = `<span class="mastery-label">${this.escape(
-      readout.label
-    )}</span>${bar}`;
+    // PHONE LABEL DENSITY (#445.3): the full "Lv N · c/s · pp%" label is cramped
+    // at the narrowest widths. Carry BOTH the full label and a compact variant
+    // (drop the c/s fraction → "Lv N · pp%"); CSS shows the compact one on a
+    // phone and the full one on roomier widths. Both stay non-overlapping.
+    const full = this.escape(readout.label);
+    const compact = this.escape(this.compactMasteryLabel(readout.label));
+    this.masteryEl.innerHTML =
+      `<span class="mastery-label mastery-label-full">${full}</span>` +
+      `<span class="mastery-label mastery-label-compact" aria-hidden="true">${compact}</span>` +
+      bar;
+    this.masteryEl.classList.toggle("is-placeholder", readout.placeholder === true);
     this.masteryEl.hidden = false;
+  }
+
+  /**
+   * Compact a "Lv N · c/s · pp%" mastery label for narrow widths by dropping the
+   * middle caught/seen fraction → "Lv N · pp%" (#445.3). Labels without that
+   * shape pass through unchanged.
+   */
+  private compactMasteryLabel(label: string): string {
+    const parts = label.split("·").map((p) => p.trim());
+    if (parts.length === 3 && /^\d+\s*\/\s*\d+$/.test(parts[1])) {
+      return `${parts[0]} · ${parts[2]}`;
+    }
+    return label;
   }
 
   /** Minimal HTML-escape for text fed into slot innerHTML. */
@@ -570,6 +598,33 @@ export class Hud {
   /** Re-fit the prompt to the current viewport (Game calls this on resize). */
   onResize(): void {
     this.fitPrompt();
+  }
+
+  /**
+   * SPAWN CLEARANCE (#433 / #445.1): report the prompt block's bottom edge in
+   * VIEWPORT px (relative to `containerTop`), and whether the prompt has wrapped
+   * to 2+ lines, so Game can hold a SMALL clearance band below it — falling
+   * tiles fade in just under the prompt instead of grazing/touching it. We
+   * measure the whole prompt stack (foreign prompt + romanization + the
+   * assembling strip) so the clearance tracks every line the header actually
+   * shows. Returns 0/false when the prompt is empty (no clearance needed).
+   *
+   * The header stays a TRANSLUCENT overlay (#426 contract preserved): notes
+   * still appear BEHIND/within the header band below the text — we only push
+   * their entry a few px clear of the printed lines so the top reads cleanly.
+   */
+  getPromptClearance(containerTop: number): { bottom: number; wrapped: boolean } {
+    const stack = this.root.querySelector<HTMLElement>(".prompt-stack");
+    const qb = this.questionBox;
+    if (!stack || !qb.textContent) return { bottom: 0, wrapped: false };
+    const rect = stack.getBoundingClientRect();
+    const bottom = Math.max(0, rect.bottom - containerTop);
+    // Wrapped to 2+ lines when the question box is taller than ~1.6 line-heights.
+    const cs = getComputedStyle(qb);
+    const fontPx = parseFloat(cs.fontSize) || 20;
+    const lineH = parseFloat(cs.lineHeight) || fontPx * 1.18;
+    const wrapped = qb.getBoundingClientRect().height > lineH * 1.6;
+    return { bottom, wrapped };
   }
 
   // -------------------------------------------------------------------------
@@ -805,14 +860,34 @@ export class Hud {
   /**
    * (d) Recompute + push the in-run mastery readout. Blends this run's live
    * accuracy with the persisted level progress so the player always feels
-   * forward motion. Hidden on the very first wave (nothing to show yet).
+   * forward motion.
+   *
+   * PERSISTENT (#432): the level meter is shown at ALL times during play —
+   * including the zero state, BEFORE the first wave resolves — so the bottom
+   * row always reads as the intended 3-part HUD (Score | meter | Streak) and
+   * never collapses to a lone centered SCORE plate. On the first wave (nothing
+   * caught yet) we render the persisted LEVEL only, with the level-progress bar
+   * fill, and no run fraction; once waves resolve we fold in this run's
+   * accuracy + caught/seen tally.
    */
   private refreshMastery(): void {
+    const snap = this.progression?.getSnapshot();
+    const lvl = snap?.level ?? 1;
+    const levelProgress =
+      typeof snap?.levelProgress === "number" ? snap.levelProgress : 0;
+
     if (this.runSeen === 0) {
-      this.setMastery(null);
+      // Zero state: persistent placeholder so the row is never sparse. Shows the
+      // standing LEVEL + its progress bar; the compact phone format drops the
+      // run fraction (there is none yet). Marked `placeholder` so styling can
+      // read it slightly quieter than the live, earned readout.
+      this.setMastery({
+        label: `Lv ${lvl} · 0%`,
+        progress: levelProgress,
+        placeholder: true,
+      });
       return;
     }
-    const snap = this.progression?.getSnapshot();
     const acc = Math.round((this.runCorrect / this.runSeen) * 100);
     // Prefer the persisted level bar for the fill (a true sense of progress);
     // fall back to this run's accuracy when progression isn't wired.
@@ -820,7 +895,6 @@ export class Hud {
       typeof snap?.levelProgress === "number"
         ? snap.levelProgress
         : this.runCorrect / this.runSeen;
-    const lvl = snap?.level ?? 1;
     this.setMastery({
       label: `Lv ${lvl} · ${this.runCorrect}/${this.runSeen} · ${acc}%`,
       progress,

--- a/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
+++ b/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
@@ -91,6 +91,45 @@ await page.waitForFunction(() => (window.__lingoHero.notes || []).length > 0, { 
   }
 }
 
+// --- Contract (f): #432 — LEVEL METER is PERSISTENT during play. -------------
+// The bottom HUD's center level meter must be present + visible from the START
+// of a run (the ZERO state, before any wave resolves), so the row reads as the
+// intended 3-part HUD (Score | meter | Streak) and never collapses to a lone
+// centered SCORE. We assert the #mastery-readout exists, is not [hidden], has a
+// non-empty label, has real layout size, AND carries a streak-0 placeholder
+// (the STREAK plate must also stay visible — non-zero opacity — at streak 0).
+{
+  const meter = await page.evaluate(() => {
+    const m = document.querySelector("#mastery-readout");
+    if (!m) return { present: false };
+    const r = m.getBoundingClientRect();
+    const cs = getComputedStyle(m);
+    const combo = document.querySelector("#combo-box");
+    const cr = combo ? combo.getBoundingClientRect() : null;
+    const ccs = combo ? getComputedStyle(combo) : null;
+    return {
+      present: true,
+      hidden: m.hidden,
+      label: (m.textContent || "").trim(),
+      w: r.width,
+      h: r.height,
+      visible: cs.display !== "none" && parseFloat(cs.opacity || "1") > 0.05,
+      placeholder: m.classList.contains("is-placeholder"),
+      // Streak plate (zero state) must stay visible — non-zero opacity.
+      comboVisible:
+        !!combo && cr.width > 0 && parseFloat(ccs.opacity || "1") > 0.05,
+      comboLabel: combo ? (combo.textContent || "").trim() : "",
+    };
+  });
+  if (!meter.present) fail("#432: no #mastery-readout (level meter) element present during play");
+  else if (meter.hidden) fail("#432: level meter is [hidden] during play (should be persistent)");
+  else if (!meter.label) fail("#432: level meter has no label text during play");
+  else if (!(meter.w > 0 && meter.h > 0)) fail(`#432: level meter has no layout size (w=${meter.w}, h=${meter.h})`);
+  else if (!meter.visible) fail("#432: level meter present but not visible (display:none / opacity ~0)");
+  else if (!meter.comboVisible) fail(`#432: STREAK plate not visible at streak 0 (should be a dimmed placeholder, not invisible): ${JSON.stringify(meter)}`);
+  else console.log(`OK: level meter persistent during play (label "${meter.label}", placeholder=${meter.placeholder}) + STREAK plate visible at 0 ("${meter.comboLabel}")`);
+}
+
 // --- Contract (c): control tap (Pause) must NOT score (no tap-through). ------
 // The top-left chrome is now a PAUSE control that opens a Resume/Exit sheet, plus
 // a single MUTE toggle. Both sit in the pointer-events:none overlay but opt back


### PR DESCRIPTION
### **User description**
Preview-channel polish pass for **Lingo Hero** → **0.4.7**, deduping three design-critic follow-ups from the 0.4.6 gate into one coherent change. Cosmetic only — no gameplay/scoring/audio/layout-contract changes.

Closes #432. Closes #433. Closes #445.

## What changed
**Bottom HUD (#432 + #445 streak/meter)**
- **Persistent center level meter** — shown at all times during play, including the zero state (`Lv 1 · 0%`) before the first wave resolves, so the bottom row always reads as the intended 3-part HUD (Score | meter | Streak) instead of collapsing to a lone centered SCORE plate. Zero state is a quiet placeholder (standing level + progress bar); brightens into the live caught/seen accuracy readout once waves land.
- **STREAK plate visible at streak 0** — was fully invisible (`opacity:0`) until the first catch. Now a dimmed, legible placeholder (`Streak x0`, desaturated, no glow) — the inactive twin of the SCORE plate — brightening to full amber on the first streak.
- **Tighter ring↔HUD gap** — raised the stats row (clamped viewport-proportional inset) so it tucks up under the hit-ring circles on tall phones instead of hugging the bottom edge with a large empty band. Short/landscape keep their low inset.
- **Compact phone meter label** — `Lv N · pp%` (drops the caught/seen fraction) at narrow phone widths; full `Lv N · c/s · pp%` on roomier widths. Stopped force-uppercasing the meter label so it reads `Lv 1 · 0%` (mixed case + middot) rather than `LV 1 ...`.

**Top prompt (#433 + #445 phone clearance)**
- **Spawn clearance from the prompt** — the play-area top now holds a small clearance just below the printed prompt block (measured per phrase + per resize, nudged down a touch more when the prompt wraps to 2+ lines), so a freshly-spawned falling tile fades in clear of the prompt text instead of grazing it. The translucent show-through header (#426) is preserved — notes still appear within the header band below the text.

## Preserved contracts (verified)
- Prompt **full-visibility** (#441) — long+comma phrase renders fully at phone + iPad portrait + iPad landscape (e2e, all words, spill ≤1.5px).
- **Lane-tap isolation** (#442), iOS **audio unlock** (#428), answer dedup, offline-first, raw-text TTS, canvas-relative input, delta-timed motion, `window.__lingoHero`.

## Verification
- `npm run build` — clean (tsc green).
- `node test/e2e/gameplay.spec.mjs` — exit 0. Added a persistent level-meter assertion (present + visible + non-`[hidden]` + streak-0 plate visible during normal play); all existing assertions (prompt full-visibility ×3 viewports, lane-tap isolation, catch/dodge/miss, no-brick, multi-stack lang rule, audio unlock) stay green.
- Design-critic GO/NO-GO on captured frames (phone 2-line prompt + streak-0, phone gameplay, iPad portrait + landscape, menu): **GO, zero blockers.** Residual polish filed as a follow-up, non-gating.

Channel: **preview**. Bar: playable + clearly better than 0.4.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Bug fix, Tests, Documentation


___

### **Description**
- Persistent three-part bottom HUD

- Improved prompt-to-spawn clearance

- Responsive meter and streak styling

- Version, changelog, e2e coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Prompt layout"] 
  B["Spawn clearance"] 
  C["Persistent level meter"] 
  D["Visible zero streak"] 
  E["Responsive HUD styling"] 
  F["E2E validation"]
  A -- "measures wrapped prompt" --> B
  C -- "keeps center HUD filled" --> E
  D -- "keeps right plate visible" --> E
  E -- "covered by" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Game.ts</strong><dd><code>Add prompt-aware spawn clearance handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/src/Game.ts

<ul><li>Replaces fixed <code>playTop</code> reset with <code>applySpawnClearance()</code>.<br> <li> Measures HUD prompt clearance on resize.<br> <li> Re-applies clearance after each new phrase.<br> <li> Adds wrapped-prompt extra spawn gap handling.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/448/files#diff-6c075e8c51d32e4e5452a4c738f6cc530345361455286e0f7d1af37f46fedde7">+42/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Hud.ts</strong><dd><code>Make mastery meter persistent and measurable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/src/ui/Hud.ts

<ul><li>Adds <code>placeholder</code> support to <code>MasteryReadout</code>.<br> <li> Keeps mastery meter visible at zero state.<br> <li> Emits full and compact mastery labels.<br> <li> Adds <code>getPromptClearance()</code> prompt stack measurement.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/448/files#diff-145e656a10e1e233418a8c559a94e938bf0e0c922802aa2f87d69b0498a38c02">+81/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Styling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>styles.css</strong><dd><code>Refine bottom HUD responsive styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/src/styles.css

<ul><li>Raises bottom stats row with clamped viewport inset.<br> <li> Adds compact phone mastery label styles.<br> <li> Preserves mixed-case <code>Lv</code> meter text.<br> <li> Makes zero-streak plate dim but visible.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/448/files#diff-b9b9a82cd5a6b2fe32239b2b4b2f069c2c4853d63db1736b575103a5d1daf226">+71/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document Lingo Hero 0.4.7 polish</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/CHANGELOG.md

<ul><li>Adds <code>0.4.7</code> release notes.<br> <li> Documents persistent meter and zero-streak visibility.<br> <li> Documents tighter ring-to-HUD spacing.<br> <li> Documents prompt spawn-clearance polish.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/448/files#diff-dd09bf20e11864991961b7ef6d2fc6687a66d9a9de2d246f765d9d6891e646c2">+40/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump Lingo Hero preview version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/manifest.json

<ul><li>Bumps pack version from <code>0.4.6</code> to <code>0.4.7</code>.<br> <li> Updates <code>devRevision</code> timestamp for the release.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/448/files#diff-38411e79d50eee7f8ad439a29518dcddf16cdc9cd03739fc81ea212f18519b15">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gameplay.spec.mjs</strong><dd><code>Test persistent HUD meter contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs

<ul><li>Adds persistent level meter gameplay contract.<br> <li> Verifies <code>#mastery-readout</code> is visible during play.<br> <li> Checks meter label and layout dimensions.<br> <li> Asserts zero-streak plate remains visible.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/448/files#diff-5ee22f0c6a817c0427478004e2238facf99cd3c18591eda51d590170655a3c57">+39/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

