### PR TITLE
Hover Runner 0.3.2: scorecard HUD scales up on tablet/large viewports (#435)

### DIFF
--- a/corpan/packs/hover-runner/CHANGELOG.md
+++ b/corpan/packs/hover-runner/CHANGELOG.md
@@ -10,6 +10,21 @@ Conventions: `corpan/CHANGELOGS.md`.
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-06-23 — Scorecard scales up on tablet/large viewports
+
+### Changed
+- **Scorecard HUD (top-left) now scales up on bigger screens.** Card height,
+  score font, stat font, and stat-icon sizes are now `clamp()`-keyed to `vmin`
+  instead of fixed pixels, so the card grows smoothly across phone → tablet →
+  desktop. Previously the card was pinned at phone size (48px / score 22px /
+  stat 12px) with media queries that only ever shrank it for small/landscape
+  screens — on iPad it stayed tiny while the scene had room to spare (#435,
+  #438 row #22). The phone floor is unchanged and the existing small-screen
+  shrink breakpoints still pin it tight on cramped/landscape phones; on
+  tablet/desktop the card now reads premium-sized (height up to 76px, score up
+  to 38px). CSS-only — no layout/JS change. The hamburger stays a shared 48px,
+  so the scorecard intentionally grows a touch more on big screens.
+
 ### Added
 - **Status HUD shows today's phrase quota + days-in-a-row streak.** The top-left
   readout now lays out four numbers in a compact 2-column grid: 🔥 visit streak

--- a/corpan/packs/hover-runner/manifest.json
+++ b/corpan/packs/hover-runner/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "hover_runner",
   "name": "Hover Runner",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "3D fun in Hover Runner: lock in correct translations with the All-Hearing Ear and avoid wrong ones",
   "entry": "dist/app.js",
   "styles": [
@@ -9,7 +9,7 @@
   ],
   "entryType": "script",
   "sdkVersion": "0.1.0",
-  "devRevision": "2026-06-05T06:15:07.949Z",
+  "devRevision": "2026-06-23T00:00:00.000Z",
   "nameLocalized": {
     "ar": "هوفر رانر",
     "bg": "Ховър Рънър",

--- a/corpan/packs/hover-runner/src/styles.css
+++ b/corpan/packs/hover-runner/src/styles.css
@@ -153,22 +153,31 @@ body {
 
 /* --- Status HUD (score/streak top-left) --- */
 
-/* ── Scorecard: a compact glass card, top-left — the exact mirror of the
+/* ── Scorecard: a compact glass card, top-left — the mirror of the
       command-drawer hamburger (top-right). Big SCORE on the left, a 2×2 grid of
-      mini-stats on the right (combo·best / 🔥 days / ⚡ quota / ✓ net). Card
-      height is LOCKED to the hamburger across the same breakpoints. ────────── */
+      mini-stats on the right (combo·best / 🔥 days / ⚡ quota / ✓ net).
+
+      Sizing is RESPONSIVE via clamp() keyed to vmin: the phone floor matches the
+      previous fixed sizes, and every dimension grows smoothly as the viewport
+      gets bigger so the card reads premium at iPad/desktop size (where the scene
+      has room to spare) instead of staying phone-sized. The hamburger is a shared
+      component that stays 48px, so on big screens the scorecard intentionally
+      grows a touch MORE — per #435 it should scale "at least as much as the
+      hamburger, arguably more". The small-screen media queries below still pin it
+      tight on cramped/landscape phones. ────────── */
 .scorecard {
   position: absolute;
   left: calc(16px + var(--safe-left));
   top: calc(15px + var(--safe-top));
-  height: 48px;
+  /* phone floor 48px → grows on tablet/desktop, capped so it never dominates */
+  height: clamp(48px, 5.6vmin + 30px, 76px);
   box-sizing: border-box;
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: clamp(12px, 1.4vmin + 8px, 20px);
   width: max-content;
-  padding: 0 13px;
-  border-radius: 12px;
+  padding: 0 clamp(13px, 1.4vmin + 9px, 22px);
+  border-radius: clamp(12px, 1vmin + 8px, 18px);
   background: linear-gradient(180deg, rgba(14, 20, 36, 0.82), rgba(8, 11, 22, 0.8));
   border: 1px solid rgba(170, 200, 255, 0.16);
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.06);
@@ -178,9 +187,9 @@ body {
   font-variant-numeric: tabular-nums;
   z-index: 10;
 }
-/* Match the hamburger's responsive heights (see commandDrawer.css). */
+/* Cramped / landscape phones: pin tight (these override the clamp floor). */
 @media (max-width: 480px) {
-  .scorecard { height: 42px; padding: 0 12px; gap: 10px; }
+  .scorecard { height: 42px; padding: 0 12px; gap: 10px; border-radius: 12px; }
 }
 @media (max-height: 520px) {
   .scorecard { height: 38px; top: calc(10px + var(--safe-top)); padding: 0 11px; }
@@ -190,7 +199,7 @@ body {
 }
 
 .sc-score {
-  font: 800 22px/1 "Trebuchet MS", "Helvetica Neue", sans-serif;
+  font: 800 clamp(22px, 2.8vmin + 12px, 38px)/1 "Trebuchet MS", "Helvetica Neue", sans-serif;
   letter-spacing: 0.01em;
   text-shadow: 0 1px 10px rgba(120, 180, 255, 0.25);
 }
@@ -200,7 +209,7 @@ body {
 .sc-grid {
   display: grid;
   grid-template-columns: auto auto;
-  column-gap: 11px;
+  column-gap: clamp(11px, 1.2vmin + 7px, 18px);
   row-gap: 1px;
   align-content: center;
 }
@@ -209,7 +218,7 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 3px;
-  font-size: 12px;
+  font-size: clamp(12px, 1.1vmin + 8px, 18px);
   font-weight: 600;
   line-height: 1.3;
 }
@@ -217,7 +226,7 @@ body {
 .sc-stat.is-hidden { visibility: hidden; }
 
 .sc-ic { display: inline-flex; }
-.sc-ic svg { width: 12px; height: 12px; display: block; }
+.sc-ic svg { width: clamp(12px, 1.1vmin + 8px, 18px); height: clamp(12px, 1.1vmin + 8px, 18px); display: block; }
 .sc-stat.is-combo .sc-ic { color: #7fd6ff; }
 .sc-stat.is-days .sc-ic { color: #ffb27a; }
 .sc-stat.is-quota .sc-ic { color: #c0a9ff; }
@@ -231,7 +240,7 @@ body {
 .sc-sub {
   color: #aebbd6;
   opacity: 0.65;
-  font-size: 10px;
+  font-size: clamp(10px, 0.9vmin + 7px, 15px);
   font-weight: 500;
 }
 .sc-stat.is-combo .sc-sub::before { content: "·"; margin-right: 1px; }


### PR DESCRIPTION
### **User description**
Closes #435 (parked on human verify — see below).

## What
The Hover Runner scorecard HUD (top-left) was pinned at phone size — card 48px / score 22px / stat 12px — with media queries that **only ever shrank** it for small/landscape screens. There was no scale-up branch, so on iPad/large viewports the card stayed phone-sized while the scene had room to spare (per the #438 audit, findings row #22).

## Fix (CSS-only, `corpan/packs/hover-runner/src/styles.css`)
Switched the scorecard's size-driving properties from fixed px to `clamp()` keyed to `vmin`, so the card grows smoothly across phone → tablet → desktop:

| property | before | clamp (floor → cap) |
|---|---|---|
| card height | 48px | `clamp(48px, 5.6vmin + 30px, 76px)` |
| score font | 22px | `clamp(22px, 2.8vmin + 12px, 38px)` |
| stat font | 12px | `clamp(12px, 1.1vmin + 8px, 18px)` |
| stat-icon | 12px | `clamp(12px, 1.1vmin + 8px, 18px)` |
| sub font | 10px | `clamp(10px, 0.9vmin + 7px, 15px)` |
| gap / padding / radius | fixed | clamped |

- **Phone floor unchanged** — clamp minimums equal the previous fixed values, and the existing `max-width:480px` / `max-height` shrink breakpoints are retained (they override the clamp floor to keep cramped/landscape phones tight). No phone regression.
- On iPad (vmin ≈ 8.3) the card reads premium: height ≈ 76px, score ≈ 35px.
- The hamburger is a **shared** component (`packs/shared/ui/commandDrawer.css`) that stays 48px — untouched — so on big screens the scorecard intentionally grows a touch more, per the issue ("at least as much as the hamburger, arguably more").
- `width: max-content` so the card never overflows; `tabular-nums` keeps numbers aligned.

No layout/structure/JS change. No other packs or `.github` files touched.

## Build / verify
Could **not build or screenshot locally** — this box is Node 18.19 and hover-runner pins Vite 8 + rolldown (need Node ≥20.19), see #450. `npm install` succeeds; `npm run build` fails with the known `CustomEvent is not defined` Node-18 error. **CI (Node 20) builds the changed pack.** The vision design-critic also can't run locally.

**@skyl** — needs-human: please confirm on-device that the scorecard now reads premium-sized on iPad (and stays tidy on phone) before merging. Stable pack, not auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Scales scorecard HUD on large viewports.

- Preserves cramped phone sizing overrides.

- Documents release and bumps pack version.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Phone-sized scorecard HUD"]
  B["Responsive clamp sizing"]
  C["Tablet and desktop readability"]
  D["Version and changelog update"]
  A -- "replace fixed pixels" --> B
  B -- "scales with vmin" --> C
  B -- "released as" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>styles.css</strong><dd><code>Make scorecard HUD responsive on larger screens</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/src/styles.css

<ul><li>Updates <code>.scorecard</code> dimensions to use <code>clamp()</code> and <code>vmin</code>.<br> <li> Scales score, stat text, icons, gaps, padding, and radius.<br> <li> Keeps small-screen media queries to preserve compact phone layouts.<br> <li> Adds explanatory comments for responsive HUD behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/451/files#diff-efeb02c42615b1487a1224980023672af380973f70abd077938926ee89d55fba">+23/-14</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document responsive scorecard HUD release changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/CHANGELOG.md

<ul><li>Adds <code>0.3.2</code> changelog entry.<br> <li> Documents responsive scorecard HUD scaling.<br> <li> Notes unchanged phone floor and retained shrink breakpoints.<br> <li> Clarifies this is a CSS-only update.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/451/files#diff-554a78adaeab8d73031f6062c33ea3602d4b86eb9cb1030d92b39d0c79619e50">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump Hover Runner pack release metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/manifest.json

<ul><li>Bumps Hover Runner version from <code>0.3.1</code> to <code>0.3.2</code>.<br> <li> Updates <code>devRevision</code> timestamp for the release.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/451/files#diff-949b680907b5b15b50e097f1542e0d4cf96ebe0be42c567a533ae84639d25d5e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

