### PR TITLE
hover-runner: native haptics + 8 trigger points (#452, premium pass #438)

### DIFF
--- a/corpan/packs/hover-runner/CHANGELOG.md
+++ b/corpan/packs/hover-runner/CHANGELOG.md
@@ -10,6 +10,22 @@ Conventions: `corpan/CHANGELOGS.md`.
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-06-23 — Native haptics
+
+### Added
+- **Native haptics across 8 gameplay events.** Adds `src/haptics.ts`, a small
+  singleton (`triggerHaptic(style)`) that copies the juice-squeeze pattern —
+  direct `plugin:haptics|impact` IPC into the host's Tauri webview (no host
+  rebuild needed on Corpán 0.19.0+) with a `navigator.vibrate` fallback. Off
+  device / desktop / mock → silent no-op. Wired triggers: correct hit →
+  `success`; wrong hit → `heavy`; missed correct phrase → `warning`; dodged a
+  wrong answer → `light`; combo milestone (every 5) / level-up → `medium`;
+  daily-cap lock → `heavy`; lane/row change (touch + keyboard) → `selection`
+  (debounced, gated); settings/menu drawer open → `light`. New
+  `hapticsEnabled` setting in `tuningStore` (defaults ON for touch/coarse-pointer
+  devices, OFF on desktop) gates all of it, ready for a future settings toggle.
+  No gameplay, scoring, audio, or translation changes.
+
 ## [0.3.2] - 2026-06-23 — Scorecard scales up on tablet/large viewports
 
 ### Changed

--- a/corpan/packs/hover-runner/manifest.json
+++ b/corpan/packs/hover-runner/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "hover_runner",
   "name": "Hover Runner",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "3D fun in Hover Runner: lock in correct translations with the All-Hearing Ear and avoid wrong ones",
   "entry": "dist/app.js",
   "styles": [
@@ -9,7 +9,7 @@
   ],
   "entryType": "script",
   "sdkVersion": "0.1.0",
-  "devRevision": "2026-06-23T00:00:00.000Z",
+  "devRevision": "2026-06-24T00:02:01.921Z",
   "nameLocalized": {
     "ar": "هوفر رانر",
     "bg": "Ховър Рънър",

--- a/corpan/packs/hover-runner/src/game.ts
+++ b/corpan/packs/hover-runner/src/game.ts
@@ -22,6 +22,7 @@ import {
 } from "@babylonjs/core"
 import "@babylonjs/loaders/glTF"
 import { getSfx } from "./audio"
+import { triggerHaptic } from "./haptics"
 import { tuningStore } from "./tuningStore"
 import type { EntryOut, HostApi, StackConfig } from "./sdk/types"
 import { t, setLanguage as setUiLanguage, onChange as onUiLangChange } from "./i18n"
@@ -433,7 +434,11 @@ export const createHoverRunner = (
     sfx,
     motion: motionControl,
     extraSections: [displaySection],
-    onOpen: () => setPaused(true),
+    onOpen: () => {
+      // Haptic: settings/menu drawer opened → light.
+      triggerHaptic("light")
+      setPaused(true)
+    },
     onClose: () => setPaused(false),
     onExit: () => requestExit(),
     onResetExtras: () => {
@@ -1641,6 +1646,8 @@ export const createHoverRunner = (
     // (mount + next-round) is covered — show the accomplishment lock instead.
     // Subscribers never block (isBlocked() is always false for them).
     if (paywallGate.isBlocked()) {
+      // Haptic: daily-cap lock reached → heavy.
+      triggerHaptic("heavy")
       paywallGate.requestDailyLock()
       return
     }
@@ -2026,6 +2033,8 @@ export const createHoverRunner = (
       // round — re-show the accomplishment-lock overlay instead. Subscribers
       // never block. They got EXACTLY the daily cap (QUOTAS.hover_phrases).
       if (paywallGate.isBlocked()) {
+        // Haptic: daily-cap lock reached (post-celebration) → heavy.
+        triggerHaptic("heavy")
         paywallGate.requestDailyLock()
         return
       }
@@ -2283,8 +2292,22 @@ export const createHoverRunner = (
             draft.incorrectStreak = 0
           })
           if (tuningStore.getState().settings.sfxEnabled) sfx.playSuccess()
+          // Haptic: correct hit → success. Capture streak/level around the
+          // record so we can fire a distinct "milestone" buzz on a combo
+          // threshold (every 5) or a level-up, layered on top of success.
+          const beforeStats = tuningStore.getState().stats
           const points = getPhraseScore(round.answer, round.answerLang)
           tuningStore.getState().recordCorrect(points)
+          triggerHaptic("success")
+          const afterStats = tuningStore.getState().stats
+          const crossedComboMilestone =
+            afterStats.streak > 0 &&
+            afterStats.streak % 5 === 0 &&
+            afterStats.streak !== beforeStats.streak
+          const leveledUp = afterStats.level > beforeStats.level
+          if (crossedComboMilestone || leveledUp) {
+            triggerHaptic("medium")
+          }
           hoverboard.adjustParticleIntensity?.(true)
           tuningStore.getState().recordPhraseResult(
             current.spec.id,
@@ -2315,6 +2338,8 @@ export const createHoverRunner = (
             )
           }
           if (tuningStore.getState().settings.sfxEnabled) sfx.playFail()
+          // Haptic: wrong hit → heavy (strongest negative).
+          triggerHaptic("heavy")
           createFailParticles(scene, phrasePosition)
           triggerScreenShake()
           setPromptStatus(t("phrase.wrong"), true)
@@ -2340,6 +2365,8 @@ export const createHoverRunner = (
           tuningStore.getState().recordWrong()
           hoverboard.adjustParticleIntensity?.(false)
           if (tuningStore.getState().settings.sfxEnabled) sfx.playFail()
+          // Haptic: missed a correct phrase (passed the hit window) → warning.
+          triggerHaptic("warning")
           createFailParticles(scene, passedPosition)
           triggerScreenShake()
           setPromptStatus(t("phrase.missed"), true)
@@ -2349,6 +2376,8 @@ export const createHoverRunner = (
         } else {
           // Successfully dodged a wrong answer - no miss increment!
           tuningStore.getState().recordDodge()
+          // Haptic: dodged a wrong answer → light (gentle positive).
+          triggerHaptic("light")
           scoreAnimator.showScorePopup(1)
           if (tuningStore.getState().settings.sfxEnabled) sfx.playSuccess()
         }
@@ -2373,6 +2402,8 @@ export const createHoverRunner = (
           tuningStore.getState().recordWrong()
           hoverboard.adjustParticleIntensity?.(false)
           if (tuningStore.getState().settings.sfxEnabled) sfx.playFail()
+          // Haptic: missed a correct phrase (fell off the end) → warning.
+          triggerHaptic("warning")
           createFailParticles(scene, endPosition)
           triggerScreenShake()
           setPromptStatus(t("phrase.missed"), true)
@@ -2382,6 +2413,8 @@ export const createHoverRunner = (
         } else {
           // Successfully dodged a wrong answer - no miss increment!
           tuningStore.getState().recordDodge()
+          // Haptic: dodged a wrong answer → light (gentle positive).
+          triggerHaptic("light")
           scoreAnimator.showScorePopup(1)
           if (tuningStore.getState().settings.sfxEnabled) sfx.playSuccess()
         }

--- a/corpan/packs/hover-runner/src/haptics.ts
+++ b/corpan/packs/hover-runner/src/haptics.ts
@@ -1,0 +1,97 @@
+/**
+ * Haptics — fires native iOS/Android haptics via the `tauri-plugin-haptics`
+ * plugin that shipped in Corpán 0.19.0 (native `plugin:haptics|impact`, granted
+ * to the webview by the `haptics:default` capability).
+ *
+ * Adapted from `juice-squeeze/src/hooks/useHaptics.ts`. Hover Runner is NOT a
+ * React app and its `HostApi` exposes no `haptic` seam, so this is a plain
+ * singleton — `triggerHaptic(style)` — rather than a hook. It reaches the host's
+ * Tauri IPC directly (no host rebuild needed on 0.19.0+, because the pack runs
+ * inside the host's webview) and falls back to `navigator.vibrate`.
+ *
+ * Everything here is best-effort and SILENT on failure:
+ *   - Off-device / desktop / mock (no Tauri IPC, no Vibration API) → no-op.
+ *   - `hapticsEnabled` setting OFF → no-op.
+ *
+ * The plugin's native `style` is one of light/medium/heavy/success/warning, so we
+ * map our richer HapticStyle onto those.
+ */
+import { tuningStore } from "./tuningStore"
+
+export type HapticStyle =
+  | "selection"
+  | "light"
+  | "medium"
+  | "heavy"
+  | "success"
+  | "warning"
+
+// HapticStyle → the plugin's accepted native style.
+const NATIVE_STYLE: Record<HapticStyle, string> = {
+  selection: "light",
+  light: "light",
+  medium: "medium",
+  heavy: "heavy",
+  success: "success",
+  warning: "warning",
+}
+
+// HapticStyle → `navigator.vibrate` pattern (ms), used only when the native
+// plugin IPC is unavailable but the Vibration API is (e.g. Android Chrome).
+const VIBRATE_MS: Record<HapticStyle, number | number[]> = {
+  selection: 8,
+  light: 12,
+  medium: 20,
+  heavy: 32,
+  success: [12, 40, 18],
+  warning: [22, 50, 22],
+}
+
+type TauriInvoke = (cmd: string, payload?: unknown) => Promise<unknown>
+
+/** Reach the Tauri IPC from inside the host webview, without bundling the SDK. */
+function getInvoke(): TauriInvoke | null {
+  if (typeof window === "undefined") return null
+  const w = window as unknown as {
+    __TAURI_INTERNALS__?: { invoke?: TauriInvoke }
+    __TAURI__?: { core?: { invoke?: TauriInvoke }; invoke?: TauriInvoke }
+  }
+  return (
+    w.__TAURI_INTERNALS__?.invoke ??
+    w.__TAURI__?.core?.invoke ??
+    w.__TAURI__?.invoke ??
+    null
+  )
+}
+
+/**
+ * Fire a haptic of the given style. Respects the `hapticsEnabled` setting and is
+ * a silent no-op everywhere it can't run. Never throws.
+ */
+export function triggerHaptic(style: HapticStyle): void {
+  try {
+    if (!tuningStore.getState().settings.hapticsEnabled) return
+
+    // Preferred: native plugin (no host rebuild needed on 0.19.0+).
+    const invoke = getInvoke()
+    if (invoke) {
+      void Promise.resolve(
+        invoke("plugin:haptics|impact", {
+          args: { style: NATIVE_STYLE[style] ?? "medium" },
+        })
+      ).catch(() => undefined)
+      return
+    }
+
+    // Fallback: Web Vibration API (Android browsers / some WebViews).
+    const nav =
+      typeof navigator !== "undefined"
+        ? (navigator as Navigator & { vibrate?: (p: number | number[]) => boolean })
+        : undefined
+    if (nav && typeof nav.vibrate === "function") {
+      nav.vibrate(VIBRATE_MS[style])
+    }
+  } catch {
+    // swallow — haptics are best-effort
+  }
+}

--- a/corpan/packs/hover-runner/src/systems/input.ts
+++ b/corpan/packs/hover-runner/src/systems/input.ts
@@ -1,4 +1,5 @@
 import { getSfx } from "../audio"
+import { triggerHaptic } from "../haptics"
 import { tuningStore } from "../tuningStore"
 import { clamp } from "../core/utils"
 import type { InputState } from "../core/types"
@@ -34,6 +35,22 @@ export const initInput = (
     tiltActive: false,
     tiltX: 0,
     tiltY: 0,
+  }
+
+  // Lane/row change haptic. Fired only when the discrete lane (col) or row
+  // actually changes, and DEBOUNCED so rapid input (or repeated key events)
+  // can't machine-gun the vibration motor. `triggerHaptic` itself is gated by
+  // the `hapticsEnabled` setting and is a silent no-op off-device.
+  const LANE_HAPTIC_DEBOUNCE_MS = 60
+  let lastLaneHapticAt = 0
+  const fireLaneChangeHaptic = () => {
+    const now =
+      typeof performance !== "undefined" && typeof performance.now === "function"
+        ? performance.now()
+        : Date.now()
+    if (now - lastLaneHapticAt < LANE_HAPTIC_DEBOUNCE_MS) return
+    lastLaneHapticAt = now
+    triggerHaptic("selection")
   }
 
   let tiltState: TiltState = "off"
@@ -117,6 +134,9 @@ export const initInput = (
       audio.playMusic()
     }
 
+    const prevRow = state.row
+    const prevCol = state.col
+
     if (event.key === "ArrowUp" || event.key === "w") {
       state.row = clamp(state.row - 1, 0, 2)
     }
@@ -128,6 +148,10 @@ export const initInput = (
     }
     if (event.key === "ArrowRight" || event.key === "d") {
       state.col = 1
+    }
+
+    if (state.row !== prevRow || state.col !== prevCol) {
+      fireLaneChangeHaptic()
     }
   }
 
@@ -147,6 +171,9 @@ export const initInput = (
       audio.playMusic()
     }
 
+    const prevRow = state.row
+    const prevCol = state.col
+
     const x = event.clientX - rect.left
     const y = event.clientY - rect.top
     state.col = x < rect.width / 2 ? 0 : 1
@@ -156,6 +183,10 @@ export const initInput = (
       state.row = 1
     } else {
       state.row = 2
+    }
+
+    if (state.row !== prevRow || state.col !== prevCol) {
+      fireLaneChangeHaptic()
     }
   }
 

--- a/corpan/packs/hover-runner/src/tuningStore.ts
+++ b/corpan/packs/hover-runner/src/tuningStore.ts
@@ -3,6 +3,14 @@ import { createJSONStorage, persist } from "zustand/middleware"
 
 // iOS detection removed - no longer needed for performance tuning
 
+// Touch / coarse-pointer devices are where native haptics exist and are
+// expected; default the haptics setting ON there and OFF on desktop. Guarded
+// for non-browser (SSR/test) environments.
+const isTouchDevice =
+  typeof window !== "undefined" &&
+  typeof window.matchMedia === "function" &&
+  window.matchMedia("(pointer: coarse)").matches
+
 export type TuningSettings = {
   // Core gameplay
   autoAdjustDifficulty: boolean
@@ -13,6 +21,10 @@ export type TuningSettings = {
   sfxEnabled: boolean
   musicVolume: number
   sfxVolume: number
+  // Haptics (native iOS/Android via tauri-plugin-haptics; no-op off-device).
+  // Default ON for touch/coarse-pointer devices, OFF elsewhere. A settings UI
+  // can toggle this later via setSetting("hapticsEnabled", ...).
+  hapticsEnabled: boolean
   // Advanced gameplay (baseline values for auto-adjustment)
   baselineSpeed: number // Starting speed before auto-adjustment
   baselineCorrectProb: number // Starting probability of correct answer (0-1, default 0.5)
@@ -85,6 +97,7 @@ const DEFAULT_SETTINGS: TuningSettings = {
   sfxEnabled: true,
   musicVolume: 0.3,
   sfxVolume: 0.5,
+  hapticsEnabled: isTouchDevice, // ON for touch/mobile, OFF on desktop
   // Advanced gameplay baselines
   baselineSpeed: 12,
   baselineCorrectProb: 0.5, // 50% correct at start (1 in 2)


### PR DESCRIPTION
### **User description**
## Hover Runner: native haptics (PR-2 of the #438 premium pass)

Closes part of #438. Implements #452.

Hover Runner fired **zero** haptics. This adds native iOS/Android haptics across 8 gameplay events, copying the proven `juice-squeeze/src/hooks/useHaptics.ts` pattern.

### What was added
- **`src/haptics.ts`** — a small plain-TS singleton `triggerHaptic(style)` (hover-runner is not React, so this is a function/singleton, not a hook). It fires `plugin:haptics|impact` via **direct Tauri IPC** into the host webview (no host rebuild needed on Corpán 0.19.0+) with a **`navigator.vibrate` fallback**. Off-device / desktop / mock (no IPC, no Vibration API) → **silent no-op**. Never throws. Respects the `hapticsEnabled` flag.
- **`hapticsEnabled` setting** in `tuningStore.ts` — defaults **ON for touch / coarse-pointer devices, OFF on desktop**. Persisted under `settings`, so old saved profiles migrate to the default via the existing `merge`. Exposed through `setSetting` so a future settings UI can toggle it (no settings panel built here — minimal).

### The 8 trigger points (wired alongside the existing audio/particle calls, no logic changed)
| Event | Style | Site |
|---|---|---|
| Correct hit | `success` | `game.ts` correct-hit branch (after `recordCorrect`) |
| Wrong hit | `heavy` | `game.ts` wrong-hit branch (with `playFail`) |
| Missed correct phrase (passed hit window) | `warning` | `game.ts` `hasPassed` / isCorrect branch |
| Missed correct phrase (fell off end) | `warning` | `game.ts` `PHRASE_END_Z` / isCorrect branch |
| Dodged a wrong answer | `light` | both dodge branches (`recordDodge`) |
| Combo milestone (streak %5) / level-up | `medium` | layered after correct-hit `success`, detected via streak/level before vs after `recordCorrect` |
| Daily-cap lock | `heavy` | both `requestDailyLock()` sites (`startNewRound` + post-celebration) |
| Lane/row change (touch + keyboard) | `selection` | `input.ts` `onPointer` + `onKey`, fired only on an actual row/col change, **debounced (60ms)** and gated behind `hapticsEnabled` to avoid buzz spam |
| Settings/menu drawer open | `light` | `game.ts` drawer `onOpen` callback |

Note on "tilt": tilt steering is analog (continuous `tiltX/tiltY` lerp, no discrete lane), so there is no discrete lane-change event to hook without inventing a threshold — buzzing it would be exactly the spam #452 warns against. Discrete lane/row haptics therefore fire on touch + keyboard only.

### Off-device no-op safety
Every path is best-effort and wrapped: no Tauri IPC and no `navigator.vibrate` → does nothing; `hapticsEnabled` false → does nothing; any throw is swallowed. Fully offline, no new network, no new contracts, no SDK type changes (hover-runner's `HostApi` has no `haptic` seam, so this reaches IPC directly).

### Build / verification
- **Could NOT build locally** — this box runs Node 18.19 but hover-runner needs Node ≥20.19 (Vite 8 + rolldown), per #450. `npm run build` and `vitest` fail purely on the toolchain (`CustomEvent is not defined`, `node:util` `styleText`), not on this code. **CI (Node 20) builds it.**
- **`tsc --noEmit` (`npm run typecheck`) passes clean** locally (Node-version-independent), validating all types and imports.
- The vision design-critic can't run locally either → **operator on-device verification required before merge.**

### Sequencing
Version **0.3.3**. This **sequences after #451** (HUD = 0.3.2). The existing `[Unreleased]` HUD changelog entry on `main` is left untouched for #451 to promote to `[0.3.2]`; this PR adds a `[0.3.3]` entry above it. **If this merges out of order relative to #451, rebase and re-bump** (0.3.3 stays correct as long as #451 takes 0.3.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Adds native Hover Runner haptics

- Wires eight gameplay trigger points

- Adds mobile-default haptics setting

- Documents release as version 0.3.3


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Gameplay and UI events"] --> B["triggerHaptic(style)"]
  B --> C["hapticsEnabled gate"]
  C --> D["Tauri haptics IPC"]
  C --> E["navigator.vibrate fallback"]
  D --> F["Native device feedback"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>game.ts</strong><dd><code>Wire gameplay and menu haptic triggers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/src/game.ts

<ul><li>Imports <code>triggerHaptic</code> for gameplay feedback.<br> <li> Fires haptics on settings drawer open.<br> <li> Adds heavy haptics for daily-cap locks.<br> <li> Adds success, warning, heavy, light, and medium haptics for hits, <br>misses, dodges, combo milestones, and level-ups.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/453/files#diff-f83d51b602f2289081ca7b8cf96c0802c8a1973b6c5a1562f375a85af8de7176">+34/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>haptics.ts</strong><dd><code>Add reusable native haptics helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/src/haptics.ts

<ul><li>Adds a plain TypeScript <code>triggerHaptic(style)</code> singleton.<br> <li> Uses direct <code>plugin:haptics|impact</code> Tauri IPC when available.<br> <li> Falls back to <code>navigator.vibrate</code> patterns.<br> <li> Respects <code>hapticsEnabled</code> and silently no-ops on failure.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/453/files#diff-3f20cd4648316a005077139ff639488c680eae10f9e40e5d854ebdc78741fb30">+97/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>input.ts</strong><dd><code>Add debounced movement haptic feedback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/src/systems/input.ts

<ul><li>Imports <code>triggerHaptic</code> into input handling.<br> <li> Tracks previous row and column values.<br> <li> Fires debounced selection haptics only on actual lane or row changes.<br> <li> Applies feedback for keyboard and pointer movement.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/453/files#diff-1d8dd75b5d616e01de2dfcf30bc1986ae4981bdf163248cabdb60ffd08dde285">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tuningStore.ts</strong><dd><code>Add persisted haptics setting default</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/src/tuningStore.ts

<ul><li>Adds coarse-pointer detection for haptics defaults.<br> <li> Extends <code>TuningSettings</code> with <code>hapticsEnabled</code>.<br> <li> Defaults haptics on for touch devices and off elsewhere.<br> <li> Leaves setting available for a future UI toggle.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/453/files#diff-08612524f1e88b5842a7175e88918b37d20a0cb7fff1eddf6239af3e574e8033">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump Hover Runner pack version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/manifest.json

<ul><li>Bumps Hover Runner version from <code>0.3.1</code> to <code>0.3.3</code>.<br> <li> Updates <code>devRevision</code> timestamp for the new release.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/453/files#diff-949b680907b5b15b50e097f1542e0d4cf96ebe0be42c567a533ae84639d25d5e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document native haptics release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/CHANGELOG.md

<ul><li>Adds <code>0.3.3</code> release notes.<br> <li> Documents native haptics helper and fallback behavior.<br> <li> Lists the eight wired haptic trigger groups.<br> <li> Notes no gameplay, scoring, audio, or translation changes.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/453/files#diff-554a78adaeab8d73031f6062c33ea3602d4b86eb9cb1030d92b39d0c79619e50">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

