### PR TITLE
stargate-reader: pre-warm glyphs to kill inter-segment jerk (#455)

### DIFF
--- a/corpan/packs/stargate-reader/CHANGELOG.md
+++ b/corpan/packs/stargate-reader/CHANGELOG.md
@@ -10,6 +10,31 @@ Conventions: `corpan/CHANGELOGS.md`.
 
 ## [Unreleased]
 
+## [0.7.5] - 2026-06-24
+
+### Fixed
+- **No more micro-stutter at segment boundaries (#455).** Each time playback
+  crossed into a new segment, the first few words of that segment — which the
+  forced alignment often packs into a tight cluster after the inter-segment
+  pause — could reach the legibility threshold (`FADE_IN_Z`) in the same frame.
+  Glyphs that "must be legible this frame" bypassed the per-frame rasterization
+  budget, so several `DynamicTexture` draws + GPU uploads ran synchronously on
+  one frame: a one-frame hitch. The word stream now **pre-warms** upcoming
+  glyphs during their long invisible runway, rasterizing the words *nearest* to
+  crossing `FADE_IN_Z` first (priority-ordered within the existing per-frame
+  budget), so by the time a word becomes legible its texture is already drawn
+  and nothing has to be rasterized at the boundary. Output is visually
+  identical; the boundary just no longer hitches. Motion remains fully
+  audio-clock-driven (frame-rate independent); no audio timing, alignment, word
+  list, or sync changed.
+
+### Added
+- **Opt-in perf diagnostic for segment-boundary smoothness (#455).** Enable with
+  `?srperf=1` (or `localStorage.sr_perf = "1"`) to log and draw the worst frame
+  time in a ~0.5s window around each segment boundary plus the count of forced
+  (un-pre-warmed) glyph rasterizations — the metric the fix drives toward zero.
+  Off by default with no runtime cost when disabled.
+
 ## [0.7.4] - 2026-06-23
 
 ### Fixed

--- a/corpan/packs/stargate-reader/manifest.json
+++ b/corpan/packs/stargate-reader/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "stargate_reader",
   "name": "Stargate Reader",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Immersive 3D audiobook: words stream through space in sync with narrated audio",
   "entry": "dist/app.js",
   "styles": [
@@ -9,7 +9,7 @@
   ],
   "entryType": "script",
   "sdkVersion": "0.1.0",
-  "devRevision": "2026-06-16T23:12:50.890Z",
+  "devRevision": "2026-06-24T00:39:08.000Z",
   "nameLocalized": {
     "ar": "قارئ بوابة النجوم",
     "bg": "Stargate Reader",

--- a/corpan/packs/stargate-reader/src/game.ts
+++ b/corpan/packs/stargate-reader/src/game.ts
@@ -684,6 +684,31 @@ export function createStargateReader(
   let timelineWords: TimelineWord[] = []
   let currentWordHint = 0
 
+  // ── Perf diagnostic (segment-boundary smoothness; #455) ────────────────
+  // Off by default — it's free when disabled (one boolean test per frame).
+  // Enable with `?srperf=1` in the URL or `localStorage.sr_perf = "1"`, then
+  // watch the console / on-canvas HUD. It surfaces the max frame time inside a
+  // window around each segment boundary plus the forced (un-pre-warmed) glyph
+  // rasterizations that frame — the metric the #455 fix drives toward zero.
+  const perfHudEnabled = (() => {
+    try {
+      const q = new URLSearchParams(window.location.search)
+      if (q.get("srperf") === "1") return true
+      return window.localStorage?.getItem("sr_perf") === "1"
+    } catch {
+      return false
+    }
+  })()
+  let lastFrameAtMs = 0          // performance.now() of previous render frame
+  let perfLastSegIndex = -1      // last segment index seen by the perf probe
+  let perfBoundaryFramesLeft = 0 // frames remaining in the post-boundary window
+  let perfWindowMaxFrameMs = 0   // worst frame time in the current boundary window
+  let perfWindowForced = 0       // forced rasterizations summed over the window
+  let perfHud: HTMLDivElement | null = null
+  // Sample this many frames after each boundary (≈0.5s at 60fps) to capture the
+  // hitch even if it lands a frame or two after the index advances.
+  const PERF_BOUNDARY_WINDOW_FRAMES = 30
+
   // --- Swipe-to-navigate segment gesture ---
   let swipeStartY = 0
   let swipeStartX = 0
@@ -1463,8 +1488,44 @@ export function createStargateReader(
   }
 
   // --- Render loop ---
+  // Perf HUD: a tiny on-canvas readout of the last segment boundary's worst
+  // frame time + forced rasterizations. Created lazily, only when the probe is
+  // enabled, so it has zero footprint in normal builds.
+  function updatePerfHud(
+    seg: number,
+    maxFrameMs: number,
+    forced: number,
+    hitch: boolean
+  ) {
+    if (!perfHudEnabled) return
+    if (!perfHud) {
+      perfHud = document.createElement("div")
+      perfHud.style.cssText =
+        "position:absolute;top:8px;left:8px;z-index:9999;" +
+        "font:11px/1.4 monospace;padding:6px 8px;border-radius:6px;" +
+        "background:rgba(0,0,0,0.6);color:#9ff;pointer-events:none;white-space:pre"
+      const parent = canvas.parentElement ?? document.body
+      parent.appendChild(perfHud)
+    }
+    perfHud.style.color = hitch ? "#f99" : "#9ff"
+    perfHud.textContent =
+      `SR perf · seg ${seg}\n` +
+      `boundary maxFrame ${maxFrameMs.toFixed(1)}ms\n` +
+      `forced rasters ${forced}${hitch ? "  ⚠ HITCH" : ""}`
+  }
+
   function renderLoop() {
     if (disposed) return
+
+    // Perf probe: measure inter-frame time. Frame N's duration is the gap from
+    // the previous frame's start to this one's. A boundary hitch shows up as one
+    // long gap. Cost when disabled: a single boolean test.
+    let frameDeltaMs = 0
+    if (perfHudEnabled) {
+      const nowMs = performance.now()
+      if (lastFrameAtMs > 0) frameDeltaMs = nowMs - lastFrameAtMs
+      lastFrameAtMs = nowMs
+    }
 
     // Lockscreen controls can pause/resume WebAudio via WebKit without
     // delivering JS action handlers. Reconcile app state with engine state.
@@ -1596,6 +1657,41 @@ export function createStargateReader(
       wordStream.update(visualMs, timelineWords, currentWordHint, wordHoldEnabled)
     }
 
+    // Perf probe: open a sampling window at each segment boundary and report the
+    // worst frame time + forced rasterizations within it. This is how the
+    // operator confirms on a real device that the inter-segment jerk (#455) is
+    // gone: forced should be ~0 and maxFrame should stay near the frame budget.
+    if (perfHudEnabled && audioEngine) {
+      const segIdx = audioEngine.getCurrentSegmentIndex()
+      if (perfLastSegIndex !== -1 && segIdx !== perfLastSegIndex) {
+        // Boundary just crossed — start/refresh the sampling window.
+        perfBoundaryFramesLeft = PERF_BOUNDARY_WINDOW_FRAMES
+        perfWindowMaxFrameMs = 0
+        perfWindowForced = 0
+      }
+      perfLastSegIndex = segIdx
+
+      if (perfBoundaryFramesLeft > 0) {
+        if (frameDeltaMs > perfWindowMaxFrameMs) perfWindowMaxFrameMs = frameDeltaMs
+        perfWindowForced += wordStream?.getLastFrameStats().forced ?? 0
+        perfBoundaryFramesLeft--
+        if (perfBoundaryFramesLeft === 0) {
+          const hitch = perfWindowMaxFrameMs > 24 // >~1.5 frames @60fps
+          srTrace(
+            "perf:segment-boundary",
+            {
+              seg: segIdx,
+              maxFrameMs: Math.round(perfWindowMaxFrameMs * 10) / 10,
+              forcedRasterizations: perfWindowForced,
+              hitch,
+            },
+            { level: hitch ? "warn" : "log" }
+          )
+          updatePerfHud(segIdx, perfWindowMaxFrameMs, perfWindowForced, hitch)
+        }
+      }
+    }
+
     // Update waveform stream (visualMs for smooth swipe animation)
     if (waveformStream && waveformStream.mesh.isVisible && timelineWords.length > 0 && waveformCache) {
       waveformStream.update(visualMs, timelineWords, waveformCache, currentWordHint)
@@ -1682,6 +1778,8 @@ export function createStargateReader(
     pulseRing?.dispose()
     starfield?.dispose()
     glow.dispose()
+    perfHud?.remove()
+    perfHud = null
     engine.stopRenderLoop()
     scene.dispose()
     engine.dispose()

--- a/corpan/packs/stargate-reader/src/rendering/wordStream.ts
+++ b/corpan/packs/stargate-reader/src/rendering/wordStream.ts
@@ -36,10 +36,27 @@ type WordMesh = {
 
 export type WordHoldConfig = { holdY?: number; zPull?: number }
 
+/**
+ * Per-frame rasterization stats, surfaced for the perf diagnostic overlay.
+ *
+ * - `rasterized`: glyphs drawn to a DynamicTexture this frame (budgeted pre-warm
+ *   + any forced must-be-legible draws).
+ * - `forced`: glyphs that had to be drawn this frame because the word was already
+ *   at/inside the fade-in zone with no pre-warmed texture ready. This is the
+ *   metric that spikes on an unmitigated segment boundary; the pre-warm pass
+ *   aims to keep it at 0.
+ */
+export type WordStreamStats = {
+  rasterized: number
+  forced: number
+}
+
 export type WordStream = {
   root: TransformNode
   update: (currentMs: number, words: TimelineWord[], currentWordIndex: number, wordHold?: boolean) => void
   configure: (config: WordHoldConfig) => void
+  /** Stats from the most recent update() call (for the perf diagnostic). */
+  getLastFrameStats: () => WordStreamStats
   dispose: () => void
 }
 
@@ -151,22 +168,35 @@ export function createWordStream(scene: Scene): WordStream {
   // Per-frame rasterization budget. Drawing a glyph onto a DynamicTexture
   // (measureText + fillText + a 512x384 GPU upload) is the most expensive
   // synchronous step in this renderer. When several words cross into the
-  // look-ahead range in the same frame (dense phrase, post-seek, post-swipe),
-  // doing all of them at once is the source of the occasional hitch.
+  // legible zone in the same frame (dense phrase, post-seek, post-swipe, and —
+  // the case #455 targets — the first words of a new segment arriving as a
+  // cluster after the inter-segment pause), doing all of them at once is a
+  // one-frame hitch: the inter-segment jerk.
   //
   // Words are fully transparent (computeFade === 0) while z > FADE_IN_Z, and the
   // look-ahead range extends to LOOK_AHEAD_Z (well beyond FADE_IN_Z), so a word
-  // has a long runway of invisible frames before it must be legible. We rasterize
-  // immediately for any word that is at/inside the fade-in zone (must be ready),
-  // and cap rasterizations of still-invisible far words to this budget per frame.
+  // has a long runway of invisible frames before it must be legible. We use that
+  // runway to PRE-WARM textures: each frame we rasterize up to this many words,
+  // chosen NEAREST-to-fade-in first, so by the time any word crosses FADE_IN_Z
+  // its glyph is already drawn (renderWord() early-returns) and nothing has to be
+  // drawn at the boundary. The must-be-legible fallback below stays as a
+  // correctness backstop, but in normal playback it should fire ~0 times.
+  //
   // Deferred far words stay invisible (alpha 0) regardless, so output is identical.
   const MAX_RASTERIZE_PER_FRAME = 2
+
+  // Reused scratch buffer for the pre-warm priority pass (avoid per-frame alloc).
+  const prewarmCandidates: { idx: number; margin: number }[] = []
+
+  const lastFrameStats: WordStreamStats = { rasterized: 0, forced: 0 }
 
   return {
     root,
 
     update: (currentMs: number, words: TimelineWord[], currentWordIndex: number, wordHold = true) => {
       let rasterizeBudget = MAX_RASTERIZE_PER_FRAME
+      let rasterizedThisFrame = 0
+      let forcedThisFrame = 0
       const lookAheadMs = LOOK_AHEAD_Z * MS_PER_Z_UNIT
       const lookBehindMs = LOOK_BEHIND_Z * MS_PER_Z_UNIT
 
@@ -186,7 +216,44 @@ export function createWordStream(scene: Scene): WordStream {
         }
       }
 
-      // Assign/update meshes for visible words
+      // ── Pre-warm pass ──────────────────────────────────────────────────
+      // Before assigning/positioning, decide which still-invisible far words to
+      // rasterize this frame. We prioritise by how close each word is to crossing
+      // FADE_IN_Z (smallest positive margin first) so the budget is always spent
+      // on the words that will need to be legible soonest — never starved by
+      // words that are still far up the runway. This is what eliminates the
+      // boundary burst: the first words of the next segment get warmed during the
+      // current segment's invisible runway, frame by frame, ahead of the boundary.
+      prewarmCandidates.length = 0
+      for (let i = visStart; i < visEnd; i++) {
+        const word = words[i]
+        const midpointMs = (word.absoluteStartMs + word.absoluteEndMs) / 2
+        const z = wordToZ(midpointMs, currentMs)
+        // Only far (still-transparent) words that don't yet have their glyph.
+        if (z <= FADE_IN_Z || z > LOOK_AHEAD_Z) continue
+        const existing = assignedMeshes.get(i)
+        if (existing && existing.assignedWord === word.word) continue
+        prewarmCandidates.push({ idx: i, margin: z - FADE_IN_Z })
+      }
+      if (prewarmCandidates.length > 1) {
+        prewarmCandidates.sort((a, b) => a.margin - b.margin)
+      }
+      for (let k = 0; k < prewarmCandidates.length && rasterizeBudget > 0; k++) {
+        const i = prewarmCandidates[k].idx
+        let mesh = assignedMeshes.get(i)
+        if (!mesh) {
+          const acquired = acquireMesh()
+          if (!acquired) break // pool exhausted
+          mesh = acquired
+          assignedMeshes.set(i, mesh)
+          mesh.plane.isVisible = false // stays hidden (alpha 0) until it crosses FADE_IN_Z
+        }
+        renderWord(mesh, words[i].word)
+        rasterizeBudget--
+        rasterizedThisFrame++
+      }
+
+      // ── Assign/update/position visible words ───────────────────────────
       for (let i = visStart; i < visEnd; i++) {
         const word = words[i]
         const midpointMs = (word.absoluteStartMs + word.absoluteEndMs) / 2
@@ -204,19 +271,22 @@ export function createWordStream(scene: Scene): WordStream {
           assignedMeshes.set(i, mesh)
         }
 
-        // Render text (only on assignment change). Glyph rasterization is the
-        // heaviest synchronous step, so we spread it across frames for words
-        // that are still fully transparent (z > FADE_IN_Z): they are invisible
-        // until they reach the fade-in zone, giving a long runway to prepare
-        // the texture. Words at/inside the fade-in zone must be ready now.
+        // Render text (only on assignment change). The pre-warm pass above has
+        // already drawn most upcoming glyphs while they were still invisible.
         const needsRender = mesh.assignedWord !== word.word
         if (needsRender) {
           if (z <= FADE_IN_Z) {
-            // Must be legible this frame — always rasterize.
+            // Must be legible this frame and the pre-warm didn't reach it — draw
+            // now (correctness backstop). Each occurrence is a potential boundary
+            // hitch; the diagnostic counts these so smoothness is measurable.
             renderWord(mesh, word.word)
+            rasterizedThisFrame++
+            forcedThisFrame++
           } else if (rasterizeBudget > 0) {
+            // Far word the priority pass had budget left for.
             renderWord(mesh, word.word)
             rasterizeBudget--
+            rasterizedThisFrame++
           } else {
             // Defer: word is fully transparent at this z, so leaving the stale
             // texture for a frame is visually identical. Keep it hidden until
@@ -260,12 +330,17 @@ export function createWordStream(scene: Scene): WordStream {
           mesh.material.emissiveColor = approachColor
         }
       }
+
+      lastFrameStats.rasterized = rasterizedThisFrame
+      lastFrameStats.forced = forcedThisFrame
     },
 
     configure: (config: WordHoldConfig) => {
       if (config.holdY !== undefined) holdY = config.holdY
       if (config.zPull !== undefined) holdZPull = config.zPull
     },
+
+    getLastFrameStats: () => lastFrameStats,
 
     dispose: () => {
       for (const mesh of pool) {


### PR DESCRIPTION
### **User description**
Fixes the inter-segment micro-stutter in Stargate Reader (#455). Stable pack — **needs-human / device-verify; do not auto-merge.**

## Root-cause analysis (code evidence)

The reader streams **one flat `timelineWords` array** (built once in `buildTimeline`, `corpan/packs/shared/core/timeline.ts:16`) for the entire book. Word position is a pure function of the audio clock: `wordToZ(midpointMs, currentMs)` (`timeline.ts:84`). So there is **no per-segment re-layout, mesh/material alloc, or dispose at a boundary** — I traced `renderLoop` (`src/game.ts:1466`) and the only per-frame consumer of `getCurrentSegmentIndex()` is chapter-overlay detection; `onSegmentChange` (`src/game.ts:1330`) already avoids native-bridge work (a previously-fixed hitch). Motion is fully audio-clock-driven (`audioEngine.getCurrentTimeMs`, `corpan/packs/shared/audio/audioEngine.ts:676`) — **frame-rate independent**, so the jerk is a per-frame *work spike*, not a motion-coupling bug.

The spike is the **rasterization burst in `rendering/wordStream.ts`**, exactly as suspected:

- Drawing a glyph = `measureText` + `fillText` + a 512×384 `DynamicTexture` GPU upload — the heaviest synchronous step (`wordStream.ts:107` `renderWord`).
- Far, still-invisible words (`z > FADE_IN_Z`, `computeFade === 0`) are budgeted at `MAX_RASTERIZE_PER_FRAME = 2`. **But** words that crossed into the legible zone (`z <= FADE_IN_Z`) bypassed the budget and **always rasterized that frame** (old `wordStream.ts:214-216`).
- At a **segment boundary**, the first words of the next segment are clustered tightly in time by forced alignment, and the `pause_after_ms` gap (`timeline.ts:46`) means they arrive together as a "wall". Several of them cross `FADE_IN_Z` in the same 1–2 frames → a synchronous burst of must-rasterize draws + GPU uploads = **one-frame hitch**. The pre-existing 2/frame budget was spent in `visStart..visEnd` order, so it could be consumed by words still far up the runway while the about-to-be-legible cluster starved → forced to draw at the boundary.

Ruled out (by code): per-segment re-layout/anchor recompute (none — flat z-flow); mesh/material/texture alloc or dispose per segment (pool is created once at `wordStream.ts:68`, never per-boundary; no GC churn); audio seek/sync work (boundary handoff keeps the same continuous timeline; `getCurrentTimeMs` clamps across the gap, no rewind/seek).

## The fix

**Pre-warm upcoming glyphs during their long invisible runway.** The runway from `LOOK_AHEAD_Z=60` to `FADE_IN_Z=50` is `10 * MS_PER_Z_UNIT = 2000ms` (~120 frames @60fps) of fully-transparent frames before any word must be legible. New pre-warm pass in `wordStream.update`:

- Collect still-invisible far words (`FADE_IN_Z < z <= LOOK_AHEAD_Z`) lacking their glyph, **sort by smallest margin to `FADE_IN_Z` first**, and rasterize them within the existing per-frame budget — nearest-to-legible first, never starved by words still far up the runway.
- By the time any word crosses `FADE_IN_Z`, its texture is already drawn, so `renderWord` early-returns (`mesh.assignedWord === text`) and **nothing rasterizes at the boundary**.
- The must-be-legible branch stays as a **correctness backstop** (counted by the diagnostic); in normal playback it should fire ~0 times.

Output is **visually identical**: deferred/pre-warmed words are alpha-0 until they cross `FADE_IN_Z` regardless of when their glyph was drawn. No audio timing, alignment, word list, or sync touched. Scratch buffer reused (no per-frame alloc); pool unchanged (no per-boundary alloc/dispose). All motion remains delta-/clock-timed.

## Instrumentation (how to read it)

Opt-in, **off by default, zero cost when disabled** (one boolean test/frame). Enable with **`?srperf=1`** in the URL or **`localStorage.sr_perf = "1"`**, then play across a few segment boundaries:

- **Console**: `[SR:trace] ... event=perf:segment-boundary seg=<n> maxFrameMs=<x> forcedRasterizations=<k> hitch=<bool>` — logged once per boundary over a ~0.5s (30-frame) window; `warn` level if `maxFrameMs > 24` (~1.5 frames @60fps).
- **On-canvas HUD** (top-left): live `seg`, `boundary maxFrame Xms`, `forced rasters K`, turns red + `⚠ HITCH` if a boundary frame ran long.

**Smooth = `forced rasters` ≈ 0 and `maxFrame` near the frame budget (~16ms) across boundaries.** A non-zero `forced` count localizes any remaining burst.

## Build / typecheck status

- **tsc-clean**: the pack `src` tree typechecks with **zero errors** under the pack's own strict `tsconfig.json` (`noUnusedLocals`/`noUnusedParameters` on). (Remaining whole-tree `../shared/**` errors are pre-existing, from locally-missing dev deps — vitest/colyseus/node types — present in CI; unrelated to this change.)
- **Could not `npm run build` / profile / screenshot locally** per #450: this box runs Node 18.19 but Vite 8 + rolldown needs Node ≥20.19 (`vite build` aborts: *"Vite requires Node.js version 20.19+"*). **CI (Node 20) builds the changed pack.**

## @skyl — device verify

Because this is a stable pack and the perf change is unverifiable locally (no Node-20 build / no profiler here), please **verify on a real device that playback is 100% smooth between segments — the inter-segment jerk should be gone.** To measure it: open the reader with `?srperf=1` (or set `localStorage.sr_perf = "1"`), play across several segment boundaries, and check the frame-time diagnostic — **`forced rasters` should be ~0 and the boundary `maxFrame` should stay near the frame budget with no `⚠ HITCH`.** If you still feel a hitch with `forced` at 0, that points to a different (non-rasterization) boundary cost and I'll re-investigate from the diagnostic numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement, Documentation


___

### **Description**
- Pre-warms upcoming glyph textures

- Prevents boundary rasterization bursts

- Adds opt-in smoothness diagnostics

- Bumps Stargate Reader to 0.7.5


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Upcoming invisible words"]
  B["Priority pre-warm pass"]
  C["Budgeted glyph rasterization"]
  D["Legible boundary words"]
  E["Perf HUD and logs"]
  A -- "nearest to fade-in first" --> B
  B -- "spreads work across frames" --> C
  C -- "textures ready before boundary" --> D
  D -- "measured by" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>game.ts</strong><dd><code>Add segment-boundary performance diagnostics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/stargate-reader/src/game.ts

<ul><li>Adds opt-in <code>srperf</code> boundary performance probe.<br> <li> Tracks frame gaps around segment changes.<br> <li> Logs and displays max frame time and forced rasterizations.<br> <li> Removes the diagnostic HUD during disposal.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/456/files#diff-efca786f6a3f8c371149aa8fc1d942d3abb84bf20266d48a688340d6e16b43f6">+98/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wordStream.ts</strong><dd><code>Pre-warm word glyphs before fade-in</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/stargate-reader/src/rendering/wordStream.ts

<ul><li>Adds <code>WordStreamStats</code> and <code>getLastFrameStats()</code>.<br> <li> Pre-warms invisible upcoming word textures by priority.<br> <li> Preserves forced rasterization as a correctness fallback.<br> <li> Tracks rasterized and forced glyph counts per frame.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/456/files#diff-d05c1b7b7e2392173e0f71472d0a85726911313a34a70830f55c8c7e51078779">+87/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document Stargate Reader 0.7.5 changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/stargate-reader/CHANGELOG.md

<ul><li>Documents the <code>0.7.5</code> release.<br> <li> Explains the segment-boundary micro-stutter fix.<br> <li> Notes the opt-in <code>?srperf=1</code> diagnostic.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/456/files#diff-7306fca8553bd01e7a3589a0cfdcea30f52b676f181b8ea9db054f96d7093dd1">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump Stargate Reader pack version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/stargate-reader/manifest.json

<ul><li>Bumps pack version from <code>0.7.4</code> to <code>0.7.5</code>.<br> <li> Updates <code>devRevision</code> timestamp for the release.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/456/files#diff-e5de46972a41d2007641306956b6a25b0562ce91f2b8a5cd708b99c89b9163f9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

