### PR TITLE
hover-runner: premium v2 — iOS audio unlock + post-process re-tune + revived velocity effects + paywall pause (#437, #438, #436)

### DIFF
--- a/corpan/packs/hover-runner/CHANGELOG.md
+++ b/corpan/packs/hover-runner/CHANGELOG.md
@@ -10,6 +10,57 @@ Conventions: `corpan/CHANGELOGS.md`.
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-06-23 — iOS audio unlock + premium post-process re-tune + revived velocity effects + paywall pause
+
+### Fixed
+- **iOS/iPad music & SFX no longer stuck silent (#437).** On iOS the
+  `AudioContext` is created `suspended` and re-suspended whenever the app/tab is
+  backgrounded — even when the game itself was never paused — so audio could
+  sit silent forever. We now resume it on the first user gesture (already wired
+  via `sfx.unlock()` on the wake-lock pointerdown) **and** on every
+  `visibilitychange → visible` (new `sfx.resume()` in `audio.ts`, called from
+  `onVisibilityChange` in `game.ts`). Resuming a running context is a no-op, so
+  Android/desktop are unaffected. Same root-cause fix that shipped for Lingo
+  Hero (#439). Stays fully offline. (iPad has no haptics but does have audio.)
+
+### Changed
+- **Post-process re-tune for premium glow + legible glyphs (#438 PR-4).** Now
+  that `game.ts` reads `POST_PROCESSING` from `core/visualConfig.ts` (the live
+  source of truth since #458), tuned the values there:
+  - **Bloom:** threshold `0.9 → 0.7`, weight `0.99 → 0.45`. The old pairing let
+    almost nothing cross the threshold, so the visible glow was entirely the
+    GlowLayer; bloom now actually halos the bright neon emissives (road center
+    line, avatar ring, electric arcs) without blowing out.
+  - **Chromatic aberration:** amount `15 → 5`. 15 smeared red/blue fringes onto
+    every glyph edge — bad in a text game. 5 keeps a tasteful peripheral lens
+    tint while restoring glyph legibility.
+  - **Sharpen:** edgeAmount `0.2 → 0.3` (crisp glyph edges).
+  - **Film grain:** intensity `3 → 2` (subtle filmic texture, doesn't fight the
+    text).
+  These are taste calls — operator reviews on device.
+- **Particle visibility bumped to a tasteful, profile-minded level (#438 PR-5).**
+  Emit rates that had been slashed near-invisible are restored: ambient dust
+  `8 → 16`, starfield `10 → 18`, energy-field wisps `8 → 14`.
+
+### Added
+- **Revived speed-lines velocity-feel (#438 PR-5).** `updateSpeedLines()` was
+  exported but never called, so the effect was dead. It's now driven every
+  frame from the render loop, keyed to the live phrase speed
+  (`getPhraseSpeed()` normalized over baseline..max into a 0..1 multiplier), so
+  streaks stay calm at slow speed and ramp up as the game speeds up. Emit-rate
+  floor raised so the streaks read even at the slow end.
+- **Host pause/resume listeners for the paywall (#436).** Added `window`
+  listeners for `corpan:host-pause` (stop the RAF update advance via the
+  existing `paused` gate + suspend the `AudioContext`) and `corpan:host-resume`
+  (resume audio + restart the update advance), dispatched by core-app when it
+  overlays the paywall. Reuses the same `setPaused` path the settings drawer
+  uses; both listeners are torn down on dispose.
+
+### Preserved
+- Gameplay, scoring, translations, i18n, offline behavior, native haptics
+  (0.3.3), the #458 dead-code/config-truth cleanup, and frame-rate-independent
+  motion are all unchanged.
+
 ## [0.3.4] - 2026-06-24 — Dead-code removal + post-process config is the single source of truth
 
 ### Removed

--- a/corpan/packs/hover-runner/manifest.json
+++ b/corpan/packs/hover-runner/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "hover_runner",
   "name": "Hover Runner",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "3D fun in Hover Runner: lock in correct translations with the All-Hearing Ear and avoid wrong ones",
   "entry": "dist/app.js",
   "styles": [
@@ -9,7 +9,7 @@
   ],
   "entryType": "script",
   "sdkVersion": "0.1.0",
-  "devRevision": "2026-06-24T12:00:00.000Z",
+  "devRevision": "2026-06-23T12:00:00.000Z",
   "nameLocalized": {
     "ar": "هوفر رانر",
     "bg": "Ховър Рънър",

--- a/corpan/packs/hover-runner/src/audio.ts
+++ b/corpan/packs/hover-runner/src/audio.ts
@@ -17,6 +17,8 @@ const pickRandom = <T>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length
 
 type SfxHandle = {
   unlock: () => void
+  resume: () => void
+  suspend: () => void
   setVolume: (volume: number) => void
   setSfxVolume: (volume: number) => void
   setMusicVolume: (volume: number) => void
@@ -259,6 +261,31 @@ const createSfxHandle = (): SfxHandle => {
     ensureMusicBuffer()
   }
 
+  // iOS (#437): the AudioContext is created `suspended` and iOS re-suspends it
+  // whenever the app/tab is backgrounded — even when the game itself was never
+  // paused. Resume it on every user gesture and on visibilitychange->visible so
+  // music/SFX don't get stuck silent. Resuming a running context is a no-op, so
+  // this is safe on Android/desktop and never regresses them. Same root-cause
+  // fix that shipped for Lingo Hero (#439). Stays fully offline.
+  const resume = () => {
+    if (ctx && ctx.state === "suspended") {
+      void ctx.resume().catch((err) => {
+        console.warn("[hover-runner] AudioContext resume failed:", err)
+      })
+    }
+  }
+
+  // Paywall/host-pause (#436): suspend the context so music/SFX go quiet while
+  // paused. resume() (above) restores it. Guarded so it never runs on a closed
+  // or absent context.
+  const suspend = () => {
+    if (ctx && ctx.state === "running") {
+      void ctx.suspend().catch((err) => {
+        console.warn("[hover-runner] AudioContext suspend failed:", err)
+      })
+    }
+  }
+
   const setSfxVolume = (next: number) => {
     sfxVolume = clamp(next, 0, 1)
     if (sfxGain) {
@@ -313,6 +340,8 @@ const createSfxHandle = (): SfxHandle => {
 
   return {
     unlock,
+    resume,
+    suspend,
     setVolume,
     setSfxVolume,
     setMusicVolume,

--- a/corpan/packs/hover-runner/src/core/visualConfig.ts
+++ b/corpan/packs/hover-runner/src/core/visualConfig.ts
@@ -113,9 +113,15 @@ export const SSAO = {
 // ============================================================
 export const POST_PROCESSING = {
   // Chromatic Aberration (color fringing at edges)
+  //
+  // #438 PR-4: dropped 15 -> 5. This is a TEXT game — the player reads glyphs
+  // on the phrase surfaces, and amount:15 smeared visible red/blue fringes onto
+  // every glyph edge, hurting legibility. 5 keeps a tasteful "premium lens"
+  // edge tint at the screen periphery without mauling the text. (Tasteful call,
+  // device review.)
   chromaticAberration: {
     enabled: true,
-    amount: 15,         // Aberration strength
+    amount: 5,          // Aberration strength (was 15 — fringed glyphs)
     radialIntensity: 0.8,
   },
 
@@ -127,24 +133,37 @@ export const POST_PROCESSING = {
   },
 
   // Bloom (glow on bright areas)
+  //
+  // #438 PR-4: threshold 0.9 / weight 0.99 meant almost nothing crossed the
+  // threshold, so the DefaultRenderingPipeline bloom did essentially nothing —
+  // the visible "glow" was entirely the GlowLayer. Lowered threshold to 0.7 so
+  // the bright neon emissives (road center line, avatar ring, electric arcs)
+  // actually bloom, and set weight to 0.45 so it's a tasteful halo, not a
+  // blown-out wash. kernel/scale unchanged. (Tasteful call, device review.)
   bloom: {
     enabled: true,
-    threshold: 0.9,     // Only pixels brighter than this bloom (0-1)
-    weight: 0.99,       // Bloom intensity
+    threshold: 0.7,     // bloom the bright neon emissives (was 0.9 = ~nothing)
+    weight: 0.45,       // visible but tasteful halo (was 0.99, paired w/ 0.9 thr)
     kernel: 32,         // Blur radius (8 = sharp, 64 = soft)
     scale: 0.3,         // Bloom texture resolution
   },
 
   // Sharpen
+  //
+  // #438 PR-4: nudged 0.2 -> 0.3 to keep glyph edges crisp now that bloom is
+  // actually contributing softness. Kept modest to avoid ringing artifacts.
   sharpen: {
     enabled: true,
-    edgeAmount: 0.2,    // Sharpening strength
+    edgeAmount: 0.3,    // Sharpening strength (was 0.2)
   },
 
   // Film Grain
+  //
+  // #438 PR-4: intensity 3 was a touch coarse over text; eased to 2 for a
+  // subtle filmic texture that doesn't compete with glyph legibility.
   grain: {
     enabled: true,
-    intensity: 3,       // Grain amount (0 = off, 8 = heavy)
+    intensity: 2,       // Grain amount (was 3) — 0 = off, 8 = heavy
     animated: true,
   },
 }

--- a/corpan/packs/hover-runner/src/game.ts
+++ b/corpan/packs/hover-runner/src/game.ts
@@ -88,7 +88,7 @@ import { createHoverboard } from "./rendering/hoverboard"
 import { createPhraseSurfaceEffects } from "./rendering/phraseSurfaceEffects"
 
 // Systems
-import { createSuccessParticles, createFailParticles, createScreenShake, clearAllParticleTimeouts, createAmbientParticles, createStarfieldParticles, createEnergyFieldParticles, createSpeedLines } from "./systems/particles"
+import { createSuccessParticles, createFailParticles, createScreenShake, clearAllParticleTimeouts, createAmbientParticles, createStarfieldParticles, createEnergyFieldParticles, createSpeedLines, updateSpeedLines } from "./systems/particles"
 import { createScoreAnimator } from "./ui/scoreAnimation"
 import { initInput } from "./systems/input"
 import { createDailyQuota, getQuota } from "@shared/monetization"
@@ -161,8 +161,14 @@ export const createHoverRunner = (
     }
   }
   const onVisibilityChange = () => {
-    if (document.visibilityState === "visible" && !wakeLock) {
-      void requestWakeLock()
+    if (document.visibilityState === "visible") {
+      if (!wakeLock) {
+        void requestWakeLock()
+      }
+      // iOS (#437): the AudioContext is re-suspended on background; resume it
+      // when we return to the foreground so music/SFX aren't stuck silent.
+      // No-op on a running context (Android/desktop) — safe, no regression.
+      sfx.resume()
     }
   }
 
@@ -367,6 +373,26 @@ export const createHoverRunner = (
     dispose()
   }
   window.addEventListener("corpan:host-dispose", onHostDispose as EventListener)
+
+  // Paywall / host pause (#436). The core-app dispatches `corpan:host-pause`
+  // when it overlays the paywall (or any host-level modal) and
+  // `corpan:host-resume` when it dismisses it. Pause = stop the RAF update
+  // advance (via the existing `paused` gate, which also halts speech repeats)
+  // AND suspend the AudioContext so music/SFX go quiet. Resume = un-suspend
+  // audio + restart the update advance. We reuse the same `setPaused` path the
+  // settings drawer uses, so gameplay/speech state stays consistent.
+  const onHostPause = () => {
+    setPaused(true)
+    sfx.suspend()
+  }
+  const onHostResume = () => {
+    // Resume audio first so the context is `running` before the loop ticks
+    // again. No-op if it was never suspended (safe on Android/desktop).
+    sfx.resume()
+    setPaused(false)
+  }
+  window.addEventListener("corpan:host-pause", onHostPause)
+  window.addEventListener("corpan:host-resume", onHostResume)
 
   // --- Settings drawer ---
   //
@@ -2511,6 +2537,17 @@ export const createHoverRunner = (
   let perfTimer = 0
   let lastLongFrameLog = 0
 
+  // #438 PR-5: speed-line normalization bounds. getPhraseSpeed() returns the
+  // raw phrase speed (baselineSpeed .. maxSpeed, defaults ~12 .. ~22). We map
+  // that span onto the 0..1 multiplier updateSpeedLines() expects so slow play
+  // shows calm streaks and fast play ramps them up. Read from tuning so a user
+  // who widens the speed range still gets a sensible mapping.
+  const SPEED_LINE_MIN = tuningStore.getState().settings.baselineSpeed
+  const SPEED_LINE_MAX = Math.max(
+    SPEED_LINE_MIN + 1,
+    tuningStore.getState().settings.maxSpeed
+  )
+
   engine.runRenderLoop(() => {
     const dt = Math.min(engine.getDeltaTime() / 1000, 0.05)
     const dtMs = dt * 1000
@@ -2534,6 +2571,17 @@ export const createHoverRunner = (
           cachedProgression.electricIntensity
         )
       }
+
+      // #438 PR-5: drive the speed-lines off the live phrase speed so the
+      // velocity-feel reacts to the game. updateSpeedLines() was exported but
+      // never called, so this effect was dead. Normalize phrase speed (baseline
+      // ~12 .. max ~22) into a 0..1 multiplier the effect expects.
+      const phraseSpeed = getPhraseSpeed()
+      const speedMultiplier = Math.max(
+        0,
+        Math.min(1, (phraseSpeed - SPEED_LINE_MIN) / (SPEED_LINE_MAX - SPEED_LINE_MIN))
+      )
+      updateSpeedLines(speedLines, speedMultiplier)
     }
     const farX = road.getFarCenterX()
     cameraTarget.set(
@@ -2688,6 +2736,8 @@ export const createHoverRunner = (
       "corpan:host-dispose",
       onHostDispose as EventListener
     )
+    window.removeEventListener("corpan:host-pause", onHostPause)
+    window.removeEventListener("corpan:host-resume", onHostResume)
     settingsDrawer.dispose()
     unsubUiLang()
     unsubHostLang?.()

--- a/corpan/packs/hover-runner/src/systems/particles.ts
+++ b/corpan/packs/hover-runner/src/systems/particles.ts
@@ -167,7 +167,7 @@ export const createAmbientParticles = (
   particleSystem.minLifeTime = 2.0
   particleSystem.maxLifeTime = 4.0
 
-  particleSystem.emitRate = 8  // Reduced from 20
+  particleSystem.emitRate = 16  // #438 PR-5: 8 was near-invisible; bumped to 16
 
   // Gentle drift
   particleSystem.minEmitPower = 0.5
@@ -215,7 +215,7 @@ export const createStarfieldParticles = (
   particleSystem.minLifeTime = 1.0
   particleSystem.maxLifeTime = 2.0
 
-  particleSystem.emitRate = 10  // Reduced from 25
+  particleSystem.emitRate = 18  // #438 PR-5: 10 was near-invisible; bumped to 18
 
   // Fast toward camera
   particleSystem.minEmitPower = 15
@@ -265,7 +265,7 @@ export const createEnergyFieldParticles = (
   particleSystem.minLifeTime = 1.2
   particleSystem.maxLifeTime = 2.5
 
-  particleSystem.emitRate = 8  // Reduced from 25
+  particleSystem.emitRate = 14  // #438 PR-5: 8 was near-invisible; bumped to 14
 
   // Rising motion
   particleSystem.minEmitPower = 1.5
@@ -339,12 +339,16 @@ export const createSpeedLines = (
   return particleSystem
 }
 
-// Update speed lines intensity based on game speed (kept subtle)
+// Update speed lines intensity based on game speed.
+// #438 PR-5: this is now CALLED every frame from the render loop (it was dead
+// before — exported but never invoked), so the velocity-feel reacts to the live
+// phrase speed. Floor bumped 10 -> 18 so streaks read even at the slow end;
+// scales with the 0..1 speedMultiplier toward a brisk-but-tasteful top.
 export const updateSpeedLines = (
   particleSystem: ParticleSystem,
   speedMultiplier: number
 ) => {
-  particleSystem.emitRate = 10 + speedMultiplier * 10  // Reduced base and multiplier
+  particleSystem.emitRate = 18 + speedMultiplier * 22
   particleSystem.minEmitPower = 40 + speedMultiplier * 20
   particleSystem.maxEmitPower = 70 + speedMultiplier * 30
 }


### PR DESCRIPTION
### **User description**
## Hover Runner premium v2 — 0.3.4 → 0.3.5

One PR bundling the iOS audio fix, the post-process re-tune, the revived velocity
effects, and the paywall pause listener. **Hover Runner is STABLE / prod-on-merge
→ this is human-reviewed (`needs-human`); please do NOT auto-merge.** Several
changes are VISIBLE and need an operator device review (the vision design-critic
can't run locally).

Refs #437, #438, #436.

### 1. #437 — iOS/iPad audio unlock
Same proven root-cause + fix as Lingo Hero #439. On iOS the `AudioContext` is
created `suspended` and re-suspended on background, so music/SFX can sit silent
forever. We now resume it:
- on the **first user gesture** — already wired via `sfx.unlock()` on the
  wake-lock `pointerdown`;
- on every **`visibilitychange → visible`** — new `sfx.resume()` in `audio.ts`,
  called from `onVisibilityChange` in `game.ts`.

Resuming a running context is a no-op, so Android/desktop are unaffected. Stays
fully offline. (iPad has no haptics but does have audio.)

### 2. #438 PR-4 — post-process re-tune (VISIBLE — device review)
Tuned in `core/visualConfig.ts` (the live `POST_PROCESSING` source of truth
since #458). **Values I chose, with rationale:**

| Effect | Field | Was | Now | Why |
|---|---|---|---|---|
| Bloom | threshold | 0.9 | **0.7** | At 0.9 almost nothing crossed → bloom did ~nothing (the glow was all GlowLayer). 0.7 lets the bright neon emissives (road center line, avatar ring, electric arcs) actually halo. |
| Bloom | weight | 0.99 | **0.45** | 0.99 paired with a low threshold would blow out; 0.45 is a tasteful halo, not a wash. |
| Chromatic aberration | amount | 15 | **5** | 15 smeared red/blue fringes on every glyph edge — bad in a text game. 5 keeps a premium peripheral lens tint while restoring legibility. |
| Sharpen | edgeAmount | 0.2 | **0.3** | Keep glyph edges crisp now that bloom adds softness; modest to avoid ringing. |
| Film grain | intensity | 3 | **2** | Subtle filmic texture that doesn't fight the text. |

These are taste calls — **flagging for the operator's device review.** kernel/scale
(bloom) and vignette were left as-is.

### 3. #438 PR-5 — revive dead/invisible effects (VISIBLE — device review)
- **Speed-lines:** `updateSpeedLines()` was exported but **never called** → the
  velocity-feel was dead. Now driven every frame from the render loop, keyed to
  the live phrase speed: `getPhraseSpeed()` normalized over baseline..max
  (read from tuning, defaults ~12..22) into the 0..1 multiplier the effect
  expects. Slow play = calm streaks; fast play ramps up. Emit-rate floor raised
  (`10 → 18 + 22·mult`) so streaks read at the slow end.
- **Particle visibility:** emit rates restored to visible-but-tasteful,
  profile-minded (mobile unified memory): ambient dust `8 → 16`, starfield
  `10 → 18`, energy-field wisps `8 → 14`.
- **Did NOT** revive `createAvatarAura` (deleted in #458).
- **Skipped (flagging):** sky-dome star twinkle. The stars are baked into a
  canvas DynamicTexture; per-frame re-draw to twinkle would be a real mobile
  perf cost. Left out to stay conservative — can revisit with a cheaper approach
  if the operator wants it.

### 4. Paywall pause listener (#436 contract)
Added `window` listeners (exact event names):
- **`corpan:host-pause`** → `setPaused(true)` (stops the RAF update advance via
  the existing `paused` gate, which also halts speech repeats) + `sfx.suspend()`.
- **`corpan:host-resume`** → `sfx.resume()` then `setPaused(false)`.

Reuses the same `setPaused` path the settings drawer uses; both listeners are
removed on dispose.

### Preserved
Gameplay, scoring, translations, i18n, offline, native haptics (0.3.3), the #458
dead-code/config-truth cleanup, and frame-rate-independent motion — all unchanged.

### Build / safety net
- `npx tsc --noEmit` — **clean** (TypeScript installed locally just to run it).
- `npm run build` fails locally on the Node 18 box (`Vite requires Node 20.19+`,
  per #450) — **expected; CI builds on Node 20.**

### Device-verify (for @skyl)
1. **iOS/iPad audio:** open Hover Runner on iPhone (and iPad) → music plays after
   first tap; background the app and return → music/SFX resume (not stuck silent).
2. **Bloom/aberration:** bright neon edges glow tastefully (not blown out); glyphs
   on the phrase surfaces are crisp & legible (no red/blue fringing on text).
3. **Speed-lines:** streaks are visible and ramp up as the game speeds up.
4. **Particles:** ambient dust / starfield / edge wisps are visible but not busy;
   no frame-rate regression on device.
5. **Paywall pause:** when the paywall overlays, the game loop freezes and audio
   goes quiet; dismissing it resumes both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement, Documentation


___

### **Description**
- Fixes iOS audio and paywall pause

- Retunes post-processing for legible premium visuals

- Revives speed-line and particle effects

- Documents and publishes version 0.3.5


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["iOS resume hooks"]
  B["Paywall pause events"]
  C["Visual tuning"]
  D["Particle velocity effects"]
  E["Hover Runner 0.3.5"]
  A -- "restore audio" --> E
  B -- "pause gameplay and sound" --> E
  C -- "improve legibility and glow" --> E
  D -- "restore motion feedback" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio.ts</strong><dd><code>Add resumable and suspendable audio controls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/src/audio.ts

<ul><li>Adds <code>resume()</code> to restart suspended <code>AudioContext</code> instances.<br> <li> Adds <code>suspend()</code> to quiet audio during host pauses.<br> <li> Logs resume/suspend failures without interrupting gameplay.<br> <li> Exposes the new methods through <code>SfxHandle</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/459/files#diff-c5500b7343c35a3f65983126bf32269ff96dc487cb5598483c7f6719ab249a66">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>game.ts</strong><dd><code>Wire audio resume, paywall pause, speed lines</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/src/game.ts

<ul><li>Resumes audio on <code>visibilitychange</code> when returning visible.<br> <li> Adds <code>corpan:host-pause</code> and <code>corpan:host-resume</code> listeners.<br> <li> Suspends audio and pauses gameplay behind host overlays.<br> <li> Calls <code>updateSpeedLines()</code> each frame using normalized phrase speed.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/459/files#diff-f83d51b602f2289081ca7b8cf96c0802c8a1973b6c5a1562f375a85af8de7176">+53/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>visualConfig.ts</strong><dd><code>Retune post-processing for readable premium visuals</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/src/core/visualConfig.ts

<ul><li>Reduces chromatic aberration from <code>15</code> to <code>5</code> for glyph legibility.<br> <li> Lowers bloom threshold and weight for visible but restrained halos.<br> <li> Increases sharpen amount to preserve crisp text edges.<br> <li> Reduces film grain intensity for subtler texture.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/459/files#diff-e0b581b02b9f7440fdfcaaf1fef97f54992ea06ee9692df4933dab323071b6f4">+24/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>particles.ts</strong><dd><code>Increase particle visibility and velocity feedback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/src/systems/particles.ts

<ul><li>Raises ambient particle emit rate from <code>8</code> to <code>16</code>.<br> <li> Raises starfield emit rate from <code>10</code> to <code>18</code>.<br> <li> Raises energy-field emit rate from <code>8</code> to <code>14</code>.<br> <li> Increases speed-line emit-rate scaling for visible velocity feedback.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/459/files#diff-db5b1c532600c71604cf0ec1a4bc8d3e736aa53ac9018b4a53998d4312829b06">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document Hover Runner 0.3.5 changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/CHANGELOG.md

<ul><li>Adds <code>0.3.5</code> release notes.<br> <li> Documents the iOS audio unlock fix.<br> <li> Describes post-processing and particle visibility changes.<br> <li> Notes paywall pause/resume behavior and preserved contracts.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/459/files#diff-554a78adaeab8d73031f6062c33ea3602d4b86eb9cb1030d92b39d0c79619e50">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump Hover Runner manifest version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/manifest.json

<ul><li>Bumps Hover Runner version from <code>0.3.4</code> to <code>0.3.5</code>.<br> <li> Updates <code>devRevision</code> metadata for the new build.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/459/files#diff-949b680907b5b15b50e097f1542e0d4cf96ebe0be42c567a533ae84639d25d5e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

