### PR TITLE
paywall: pause active pack + reader narration behind the Plus paywall (#436)

### DIFF
--- a/corpan/corpan-app/CHANGELOG.md
+++ b/corpan/corpan-app/CHANGELOG.md
@@ -8,6 +8,16 @@ Conventions: `corpan/CHANGELOGS.md`.
 ## [Unreleased]
 
 ### Added
+- **Paywall pauses the active pack/reader (#436).** When the Corpán Plus
+  paywall opens over a running pack or reader, the host now dispatches a generic
+  `corpan:host-pause` window event (and `corpan:host-resume` when it closes),
+  following the `corpan:host-dispose` convention. This is fired once at the
+  paywall store's open/close chokepoint on a genuine closed↔open transition, so
+  it never double-fires regardless of which surface triggered it (reader
+  end-of-preview, Library "Unlock with Plus", engagement moments). Listeners
+  already shipped: hover-runner (#459) pauses its game loop; the shared reader
+  shell pauses narration audio (stargate/earthgate); lingo-hero's listener is a
+  separate follow-up. No user-facing strings; no locale keys added.
 - **New "Semi large" text-size option.** Adds a size between Medium and Large
   (`1.1rem`, CSS class `text-semi-large`) to the text-size picker, and makes it
   the default for new profiles so default reading text is a touch larger. New

--- a/corpan/corpan-app/src/store/paywall.ts
+++ b/corpan/corpan-app/src/store/paywall.ts
@@ -63,6 +63,29 @@ function stampEngagement(now: number) {
   }
 }
 
+/**
+ * Tell the active content pack / reader to pause (or resume) while a blocking
+ * overlay is up. The paywall is a full-screen modal — anything playing behind
+ * it (pack gameplay, reader narration audio) must stop so it doesn't compete
+ * for the user's attention/ears, then resume cleanly on dismiss.
+ *
+ * This is a GENERIC host signal (reusable by any future blocking overlay),
+ * following the `corpan:host-dispose` convention. Listeners already shipped:
+ *   - hover-runner (PR #459) pauses its game loop.
+ *   - the shared reader shell (stargate/earthgate) pauses narration audio.
+ *   - lingo-hero (follow-up) pauses its rhythm game.
+ * Listeners must only resume the pause THEY caused (track a `hostPaused` flag),
+ * so a host-resume never overrides a user's own manual pause.
+ */
+function dispatchHostBlock(type: "pause" | "resume"): void {
+  try {
+    window.dispatchEvent(new CustomEvent(`corpan:host-${type}`))
+  } catch (e) {
+    // Best-effort — host absent / SSR. Never let it break the paywall.
+    console.warn(`[paywall] corpan:host-${type} dispatch failed`, e)
+  }
+}
+
 /** Legacy per-reader skin hint. Readers still pass this on `request-unlock`,
  *  but the universal paywall IGNORES it — there is ONE dark, brand-defining
  *  paywall everywhere now (no per-pack theming). Kept only so existing callers
@@ -103,7 +126,12 @@ export const usePaywallStore = create<PaywallState>((set, get) => ({
       if (now - lastEngagementAt() < ENGAGEMENT_CAP_MS) return false
       stampEngagement(now)
     }
+    const wasOpen = get().open
     set({ open: true, context })
+    // Pause the active pack/reader the moment the blocking overlay appears, but
+    // only on a genuine closed→open transition (never re-fire if it was already
+    // up — e.g. a second surface racing the first), so resume stays balanced.
+    if (!wasOpen) dispatchHostBlock("pause")
     // Funnel: paywall_shown — fired at the single open chokepoint so it can
     // never drift from the visual component the paywall team owns.
     trackPaywallShownFunnel(context.surface, context.packId)
@@ -115,6 +143,7 @@ export const usePaywallStore = create<PaywallState>((set, get) => ({
     // paywall_converted; otherwise it was dismissed without converting. (The
     // store-level converted event is a backstop; the authoritative plan/code/
     // platform conversion is emitted from purchase.ts.)
+    const wasOpen = get().open
     const ctx = get().context
     if (ctx) {
       const sub = useEntitlementStore.getState().subscription
@@ -125,5 +154,8 @@ export const usePaywallStore = create<PaywallState>((set, get) => ({
       }
     }
     set({ open: false, context: null })
+    // Resume the active pack/reader once — and only when we were actually open,
+    // so an idempotent close (e.g. unmount after dismiss) can't double-resume.
+    if (wasOpen) dispatchHostBlock("resume")
   },
 }))

--- a/corpan/packs/earthgate-reader/CHANGELOG.md
+++ b/corpan/packs/earthgate-reader/CHANGELOG.md
@@ -10,6 +10,18 @@ Conventions: `corpan/CHANGELOGS.md`.
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-06-24
+
+### Fixed
+- **Narration now pauses behind the Corpán Plus paywall (#436).** When the Plus
+  paywall (or any host blocking overlay) opened — e.g. at the end of a free
+  preview — the reader kept streaming narration audio behind the modal. The
+  shared reader shell now listens for the host's generic `corpan:host-pause` /
+  `corpan:host-resume` window events and pauses/resumes playback. The reader
+  only auto-resumes the pause IT made for the host, so a manual pause taken
+  while the overlay is up is never overridden; an explicit user play/pause also
+  clears the host-pause flag. No audio, alignment, or sync changed.
+
 ## [0.7.3] - 2026-06-23
 
 ### Fixed

--- a/corpan/packs/earthgate-reader/manifest.json
+++ b/corpan/packs/earthgate-reader/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "earthgate_reader",
   "name": "Earthgate Reader",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Calm, earth-toned audiobook reader with word-level highlighting synced to narrated audio",
   "entry": "dist/app.js",
   "styles": [

--- a/corpan/packs/earthgate-reader/src/game.ts
+++ b/corpan/packs/earthgate-reader/src/game.ts
@@ -73,6 +73,10 @@ export function createEarthgateReader(
   let mediaAnchor: MediaSessionAnchor | null = null
   let playInFlight = false
   let desiredPlaying = false
+  // True while a host blocking overlay (e.g. the Plus paywall) has paused us.
+  // We only auto-resume if WE paused for the host, so a user's manual pause
+  // taken while the overlay is up is never overridden on host-resume.
+  let hostPaused = false
   let playRequestSeq = 0
   let lastNowPlayingToken = 0
   let lastMediaMetadataKey = ""
@@ -184,6 +188,9 @@ export function createEarthgateReader(
     if (lastRemotePlayPauseCmd === cmd && now - lastRemotePlayPauseAt < REMOTE_PLAY_PAUSE_DEDUPE_MS) return
     lastRemotePlayPauseCmd = cmd
     lastRemotePlayPauseAt = now
+    // Any explicit play/pause command means the host-overlay pause is no longer
+    // ours to manage — drop the flag so host-resume can't override the user.
+    hostPaused = false
     if (cmd === "play") { void doPlay(); return }
     doPause()
   }
@@ -381,6 +388,22 @@ export function createEarthgateReader(
     syncNativeNowPlaying()
     stopBackgroundTimers()
     if (document.hidden) backgroundedAt = 0
+  }
+
+  /** Pause/resume for a host blocking overlay (Plus paywall). On pause, only
+   *  act if we're actually playing, and remember that the host paused us. On
+   *  resume, only resume if WE paused for the host (never override the user's
+   *  own manual pause). */
+  function setPlaybackPaused(paused: boolean) {
+    if (paused) {
+      if (!isPlaying && !desiredPlaying) return
+      hostPaused = true
+      doPause()
+    } else {
+      if (!hostPaused) return
+      hostPaused = false
+      void doPlay()
+    }
   }
 
   // Module-level state
@@ -584,11 +607,14 @@ export function createEarthgateReader(
 
   // --- Transport callbacks ---
   transport.onPlay(() => {
+    // User-driven play overrides any host-overlay pause we were holding.
+    hostPaused = false
     endPreview(false)
     void doPlay()
   })
 
   transport.onPause(() => {
+    hostPaused = false
     doPause()
   })
 
@@ -1244,5 +1270,7 @@ export function createEarthgateReader(
     persistBookmark,
     /** Whether audio is currently playing */
     isPlaying: () => isPlaying,
+    /** Pause/resume for a host blocking overlay (e.g. Plus paywall) */
+    setPlaybackPaused,
   }
 }

--- a/corpan/packs/shared/catalog/src/appShell.ts
+++ b/corpan/packs/shared/catalog/src/appShell.ts
@@ -116,6 +116,10 @@ export type ReaderInstance = {
   /** Persist the current playback bookmark on demand. Used before an upgrade
    *  reload so the new (full) pack resumes exactly where the preview was. */
   persistBookmark?: () => void
+  /** Pause/resume narration audio in response to a host blocking overlay
+   *  (e.g. the Corpán Plus paywall). The reader resumes only the pause IT made
+   *  via this call, so it never overrides a user's manual pause. */
+  setPlaybackPaused?: (paused: boolean) => void
 }
 
 export type ReaderFactory = (
@@ -914,6 +918,21 @@ export function createAppShell(
     showEndOfBookSuggestion(bookId, language)
   }
   window.addEventListener("corpan:book-finished", onBookFinished)
+
+  // Host blocking overlay (e.g. the Corpán Plus paywall) → pause narration so
+  // it doesn't keep playing behind the modal, then resume on dismiss. The host
+  // (corpan-app store/paywall.ts) dispatches these generic `corpan:host-*`
+  // signals; the reader tracks its own `hostPaused` flag so resume only undoes
+  // the pause WE made here, never a user's manual pause. Both readers get this
+  // for free since the shell owns the reader instance.
+  const onHostPause = (): void => {
+    readerInstance?.setPlaybackPaused?.(true)
+  }
+  const onHostResume = (): void => {
+    readerInstance?.setPlaybackPaused?.(false)
+  }
+  window.addEventListener("corpan:host-pause", onHostPause)
+  window.addEventListener("corpan:host-resume", onHostResume)
 
   // -----------------------------------------------------------------------
   // Corpán Plus preview → full upgrade (3 layers).
@@ -3274,6 +3293,8 @@ export function createAppShell(
     window.removeEventListener("corpan:subscription-recorded", onPurchaseEvent)
     window.removeEventListener("corpan:restore-purchases-completed", onPurchaseEvent)
     window.removeEventListener("corpan:book-finished", onBookFinished)
+    window.removeEventListener("corpan:host-pause", onHostPause)
+    window.removeEventListener("corpan:host-resume", onHostResume)
     dismissEndOfBookSuggestion()
     window.removeEventListener(ENTITLEMENTS_CHANGED_EVENT, onEntitlementsChanged)
     window.removeEventListener(NARRATION_UPGRADED_EVENT, onNarrationUpgraded)

--- a/corpan/packs/stargate-reader/CHANGELOG.md
+++ b/corpan/packs/stargate-reader/CHANGELOG.md
@@ -10,6 +10,18 @@ Conventions: `corpan/CHANGELOGS.md`.
 
 ## [Unreleased]
 
+## [0.7.6] - 2026-06-24
+
+### Fixed
+- **Narration now pauses behind the Corpán Plus paywall (#436).** When the Plus
+  paywall (or any host blocking overlay) opened — e.g. at the end of a free
+  preview — the reader kept streaming narration audio behind the modal. The
+  shared reader shell now listens for the host's generic `corpan:host-pause` /
+  `corpan:host-resume` window events and pauses/resumes playback. The reader
+  only auto-resumes the pause IT made for the host, so a manual pause taken
+  while the overlay is up is never overridden; an explicit user play/pause also
+  clears the host-pause flag. No audio, alignment, or sync changed.
+
 ## [0.7.5] - 2026-06-24
 
 ### Fixed

--- a/corpan/packs/stargate-reader/manifest.json
+++ b/corpan/packs/stargate-reader/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "stargate_reader",
   "name": "Stargate Reader",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Immersive 3D audiobook: words stream through space in sync with narrated audio",
   "entry": "dist/app.js",
   "styles": [

--- a/corpan/packs/stargate-reader/src/game.ts
+++ b/corpan/packs/stargate-reader/src/game.ts
@@ -118,6 +118,10 @@ export function createStargateReader(
   let mediaAnchor: MediaSessionAnchor | null = null
   let playInFlight = false
   let desiredPlaying = false
+  // True while a host blocking overlay (e.g. the Plus paywall) has paused us.
+  // We only auto-resume if WE paused for the host, so a user's manual pause
+  // taken while the overlay is up is never overridden on host-resume.
+  let hostPaused = false
   let playRequestSeq = 0
   let mediaArtworkUrl: string | undefined
   let lastMediaSessionSyncAt = 0
@@ -477,6 +481,22 @@ export function createStargateReader(
     stopBackgroundTimers()
     if (document.hidden) backgroundedAt = 0
     tracePlayback("doPause:done", { requestId }, true)
+  }
+
+  /** Pause/resume for a host blocking overlay (Plus paywall). On pause, only
+   *  act if we're actually playing, and remember that the host paused us. On
+   *  resume, only resume if WE paused for the host (never override the user's
+   *  own manual pause). */
+  function setPlaybackPaused(paused: boolean) {
+    if (paused) {
+      if (!isPlaying && !desiredPlaying) return
+      hostPaused = true
+      doPause()
+    } else {
+      if (!hostPaused) return
+      hostPaused = false
+      void doPlay()
+    }
   }
 
   // Module-level state for language/book switching
@@ -858,6 +878,9 @@ export function createStargateReader(
     lastRemotePlayPauseCmd = cmd
     lastRemotePlayPauseAt = now
     tracePlayback("cmd:dispatch", { cmd, source }, true)
+    // Any explicit play/pause command means the host-overlay pause is no longer
+    // ours to manage — drop the flag so host-resume can't override the user.
+    hostPaused = false
     if (cmd === "play") {
       void doPlay()
       return
@@ -889,10 +912,13 @@ export function createStargateReader(
   }
 
   transport.onPlay(() => {
+    // User-driven play overrides any host-overlay pause we were holding.
+    hostPaused = false
     void doPlay()
   })
 
   transport.onPause(() => {
+    hostPaused = false
     doPause()
   })
 
@@ -1792,6 +1818,8 @@ export function createStargateReader(
     persistBookmark,
     /** Whether audio is currently playing */
     isPlaying: () => isPlaying,
+    /** Pause/resume for a host blocking overlay (e.g. Plus paywall) */
+    setPlaybackPaused,
     /** Get display settings DrawerSectionDef for injection into command drawer */
     getDisplaySection(): DrawerSectionDef {
       return {


### PR DESCRIPTION
### **User description**
Closes #436 (core-app + readers scope).

## Problem
When the Corpán Plus paywall (a full-screen blocking overlay) opened over a running pack or reader, the pack kept playing audio + running behind it. The paywall must pause the active pack and resume on close.

## Contract (pinned)
The host (paywall) dispatches generic `window` CustomEvents:
- **`corpan:host-pause`** when the blocking overlay opens
- **`corpan:host-resume`** when it closes

Generic + reusable for any future blocking overlay, following the existing `corpan:host-dispose` convention. This is the **emitter** that hover-runner's listener (already merged in #459) depends on. lingo-hero's listener is a separate follow-up owned elsewhere.

## 1. Core app — the emitter (`corpan-app/src/store/paywall.ts`)
- New `dispatchHostBlock("pause"|"resume")` helper dispatches the two events.
- Wired into the paywall store's single open/close chokepoint:
  - `openPaywall` fires `corpan:host-pause` **only on a genuine closed→open transition** (guards on prior `open` state, so a second surface racing the first can't double-fire).
  - `closePaywall` fires `corpan:host-resume` **only when it was actually open** (so an idempotent close can't double-resume).
- Because it's at the store chokepoint, every current/future trigger is covered automatically: reader end-of-preview (`corpan:request-unlock`), Library/PackActions "Unlock with Plus", onboarding/home/engagement surfaces.
- **No user-facing strings / no new locale keys** → `check:i18n` unaffected.

## 2. Readers — investigation + fix
**Investigated:** when a reader hit end-of-free-preview and dispatched `corpan:request-unlock`, its narration audio **KEPT PLAYING** behind the modal. The readers only called `audioEngine.pause()` on user pause / scrub / remote / iOS interruption — never around the paywall request. So both readers needed the listener. (Neither already stops at the paywall.)

**Fix (shared, both readers get it once):**
- Shared reader shell `@shared/catalog/src/appShell.ts` now adds `corpan:host-pause` / `corpan:host-resume` window listeners that call a new optional `ReaderInstance.setPlaybackPaused(paused)`. Listeners are torn down in `dispose()`. Since the shell owns the single `readerInstance`, **both stargate and earthgate are covered by one place.**
- Each reader (`stargate-reader`, `earthgate-reader`) implements `setPlaybackPaused` with a `hostPaused` flag:
  - On pause: act only if actually playing; remember the host paused us.
  - On resume: resume **only the pause we made** (never override a user's manual pause).
  - Any explicit user play/pause (transport buttons, remote/media-session command funnel) clears `hostPaused`, so a later host-resume can't fight the user.

## Why not host-only (no per-pack listeners)?
A host-only "duck/pause all audio" isn't reachable: the readers own their own Web Audio `AudioContext` and game packs own their loops — the host has no handle to pause them generically. The event contract is the decoupled seam (no analytics/host deps leak into packs), and it's exactly what hover-runner #459 already consumes. So the contract + readers-listener is the right shape.

## Version bumps + changelogs
- `corpan-app`: changelog `[Unreleased] → Added` entry (no app version bump — coordinated release).
- `stargate-reader`: manifest `0.7.5 → 0.7.6` + changelog entry.
- `earthgate-reader`: manifest `0.7.3 → 0.7.4` + changelog entry.

## Build / typecheck
- `corpan-app`: `npm run tsc` → **clean (exit 0)**.
- Readers: `npx tsc --noEmit` → **no errors in touched source** (stargate/earthgate `game.ts`, shared `appShell.ts`). Remaining tsc output is pre-existing `shared/*.test.ts` / `*.run.ts` harness files missing dev deps (vitest/@types/node/colyseus) under a minimal local install — out of the readers' Vite build graph; full reader build is CI-only (#450).

## Related
- Listener already merged: hover-runner **#459** (consumes `corpan:host-pause`/`resume`).
- lingo-hero pause listener: separate follow-up (parallel worker / not in scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Emit paywall host pause/resume events

- Pause reader narration behind overlays

- Preserve manual playback pause intent

- Document releases and bump reader versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Paywall open/close"]
  B["Host pause/resume events"]
  C["Shared reader shell"]
  D["Reader playback controls"]
  E["Active content paused"]
  A -- "dispatches" --> B
  B -- "listened by" --> C
  C -- "calls" --> D
  D -- "prevents background audio" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>paywall.ts</strong><dd><code>Dispatch host pause events from paywall</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/464/files#diff-51e7925096fbb179d744bf1e5a7bea10c99d30b9641a4ce69b47e82c8f68791d">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>game.ts</strong><dd><code>Add host-controlled narration pause handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/464/files#diff-cd0c8001c104ed4c0b3d31e09bf5ef2d692e0700e09c1586353351ac980985af">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>appShell.ts</strong><dd><code>Wire host pause events to readers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/464/files#diff-caf497160c5610fb81627475f005a5a1bf915dc9d3209ca1fb760f0a5fc15117">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>game.ts</strong><dd><code>Add host-controlled narration pause handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/464/files#diff-efca786f6a3f8c371149aa8fc1d942d3abb84bf20266d48a688340d6e16b43f6">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document generic paywall pause contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/464/files#diff-fcd2aeaa88f0735613dd8b9388c69c41b43b9eec554f31f82c902937b33b9940">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document Earthgate paywall narration fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/464/files#diff-35c4f143ae27a4fed1c4ecb6e131162e40d1631c1355c328accfe09521f50f71">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document Stargate paywall narration fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/464/files#diff-7306fca8553bd01e7a3589a0cfdcea30f52b676f181b8ea9db054f96d7093dd1">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>manifest.json</strong><dd><code>Bump Earthgate reader package version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/464/files#diff-29cbfe06038df2bf292991b2f9588591012ebd43747c82242b6ce4f6bb33fd24">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>manifest.json</strong><dd><code>Bump Stargate reader package version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/464/files#diff-e5de46972a41d2007641306956b6a25b0562ce91f2b8a5cd708b99c89b9163f9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

