### PR TITLE
beatlounge 0.5.0 "Plus": microtonal playback + correct maqam intervals (#415)

### DIFF
--- a/corpan/packs/beatlounge/CHANGELOG.md
+++ b/corpan/packs/beatlounge/CHANGELOG.md
@@ -5,6 +5,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.5.0] "Plus" - 2026-06-23
+
 ### Added
 - Microtonal playback (tuning Phase 0): sequenced notes **and** the in-key ribbon
   now sound the active tuning's exact cents (maqam neutral tones, pythagorean,
@@ -62,6 +64,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   scrollable, instead of a ~3-octave window — notes can be seen and placed
   anywhere. Opens scrolled to ~middle C; the +/− generator still works in the
   singable register. (Beat-Lounge-Plus; closes #394.)
+- Corrected three maqam interval errors (verified against maqamworld.com), now
+  audible via the microtonal playback above: **Nikriz** has a **minor 7th** (B♭ —
+  upper jins is Nahawand, not Rast; was a neutral 7th); **Ajam** is the **major
+  scale** (major 7th — was a ♭7/Mixolydian; upper Nahawand roots on the 6th);
+  **Kurd**'s upper jins re-roots to the **4th** (correct A♭ 6th). Hijazkar
+  (double-harmonic) and Sikah confirmed correct as-is. (Beat-Lounge-Plus.)
 
 ## [0.3.2] - 2026-06-19
 

--- a/corpan/packs/beatlounge/CHANGELOG.md
+++ b/corpan/packs/beatlounge/CHANGELOG.md
@@ -6,6 +6,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Microtonal playback (tuning Phase 0): sequenced notes **and** the in-key ribbon
+  now sound the active tuning's exact cents (maqam neutral tones, pythagorean,
+  just) instead of 12-TET. The scheduler computes the detune from the doc's
+  harmony (`detuneForMidi`) into `TriggerNote.detuneCents`; the synth / FM /
+  wavetable / pad / analog engines apply it; the ribbon plays the same detune on
+  its live voice (recording the clean integer degree, re-deriving cents at play —
+  so changing key/school re-tunes everything live). GM soundfont stays 12-TET for
+  now (worklet is integer-MIDI). (Beat-Lounge-Plus; closes #415.)
 - 50 new software-instrument presets across all seven families (keys, bass,
   lead, pad, pluck, brass, fx), bringing the corpus to 123 voices. Pure data
   over the existing synth / fmSynth / wavetable / analogSynth engines — no new

--- a/corpan/packs/beatlounge/manifest.json
+++ b/corpan/packs/beatlounge/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "beatlounge",
   "name": "beatlounge",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "description": "Make music with the language you're learning. Scratch real phrases from 50+ languages, all offline. No music theory needed.",
   "descriptionLocalized": {
     "en": "Make music with the language you're learning. Scratch real phrases from 50+ languages, all offline. No music theory needed.",

--- a/corpan/packs/beatlounge/src/contracts/engine.ts
+++ b/corpan/packs/beatlounge/src/contracts/engine.ts
@@ -35,6 +35,11 @@ export interface TriggerNote {
   pitch: Midi
   velocity: Normalized
   durationSec: number
+  /** Microtonal offset (cents) to apply on top of the 12-TET pitch — the bridge
+   *  that makes sequenced notes honor the active tuning (maqam neutral tones,
+   *  pythagorean/just, …). Absent/0 ⇒ plain 12-TET (unchanged). Engines that can't
+   *  detune (e.g. the GM soundfont worklet) ignore it. */
+  detuneCents?: number
   // ttsFragment extras:
   fragmentId?: Id
   pitchSemis?: number

--- a/corpan/packs/beatlounge/src/engine/scheduler.test.ts
+++ b/corpan/packs/beatlounge/src/engine/scheduler.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { collectTriggers, occurrencesInWindow, trackLength } from "./scheduler"
-import { DRUM_PITCH, type InstrumentTrack } from "../model/document"
+import { DRUM_PITCH, createDefaultDoc, type InstrumentTrack } from "../model/document"
 import { reduce } from "../model/reduce"
 import { PPQ } from "../model/timing"
 import { stockLoopDoc } from "../testing/stockLoop"
@@ -80,5 +80,31 @@ describe("collectTriggers — the pure scheduling core", () => {
     const planned = collectTriggers(doc, 0, PPQ * 4)
     expect(planned.length).toBeGreaterThan(0)
     expect(planned.every((p) => p.note.velocity > 0 && p.note.durationSec > 0)).toBe(true)
+  })
+})
+
+describe("collectTriggers — microtonal detune from the active tuning (#415)", () => {
+  const withNotes = (doc: ReturnType<typeof createDefaultDoc>, pitches: number[]) => {
+    const tid = (doc.tracks[1] as InstrumentTrack).id
+    return reduce(doc, {
+      t: "setNotes",
+      trackId: tid,
+      notes: pitches.map((pitch, i) => ({ tick: i * PPQ, duration: PPQ, pitch, velocity: 0.8 })),
+    })
+  }
+  const detuneOf = (doc: ReturnType<typeof createDefaultDoc>, pitch: number) =>
+    collectTriggers(doc, 0, doc.loopLengthTicks).find((p) => p.note.pitch === pitch)?.note.detuneCents
+
+  it("attaches the maqam's neutral-tone detune to scheduled notes (Rast)", () => {
+    let d = reduce(createDefaultDoc(0), { t: "setHarmonyMode", mode: "modal" })
+    d = reduce(d, { t: "setScale", family: "maqam", id: "maqam.rast" })
+    d = withNotes(d, [60, 64]) // tonic C, and the 12-TET major third E
+    expect(detuneOf(d, 60) ?? 0).toBeCloseTo(0, 0) // tonic ~ in tune
+    expect(detuneOf(d, 64)!).toBeLessThan(-20) // bends DOWN to Rast's neutral 3rd
+  })
+
+  it("a plain 12-TET doc emits zero detune (backward-compatible)", () => {
+    const d = withNotes(createDefaultDoc(0), [64])
+    expect(detuneOf(d, 64) ?? 0).toBe(0)
   })
 })

--- a/corpan/packs/beatlounge/src/engine/scheduler.ts
+++ b/corpan/packs/beatlounge/src/engine/scheduler.ts
@@ -16,6 +16,7 @@ import type { Scheduler, ScheduledTrigger, TriggerNote } from "../contracts/engi
 import type { BeatloungeDoc, Track } from "../model/document"
 import { isInstrumentTrack } from "../model/document"
 import { gridTicks, secondsPerTick, swingOffsetTicks, wrapTick, type Tick } from "../model/timing"
+import { detuneForMidi } from "../music/resolver"
 
 const LOOKAHEAD_SEC = 0.12
 const TIMER_MS = 25
@@ -84,6 +85,9 @@ export const collectTriggers = (
           pitch: n.pitch,
           velocity: n.velocity,
           durationSec: Math.max(0.02, n.duration * spt),
+          // Honor the active tuning (maqam neutral tones / pythagorean / just …) at
+          // play time — computed from the doc's harmony, never frozen into the note.
+          detuneCents: detuneForMidi(n.pitch, doc, n.tick),
         }
         for (const abs of occ) {
           out.push({ trackId: track.id, baseTick: abs, scheduledTick: abs + swing + micro, note })

--- a/corpan/packs/beatlounge/src/instruments/analogSynth.ts
+++ b/corpan/packs/beatlounge/src/instruments/analogSynth.ts
@@ -639,10 +639,14 @@ export const createAnalogSynthInstrument = (config: AnalogConfig): Instrument =>
   // Mono mode keeps ONE voice that glides between notes.
   let monoVoice: AnalogVoice | null = null
 
+  // Fractional MIDI = pitch + cents/100; the voice's setPitch resolves it through
+  // Tone.Frequency, so the microtonal offset lands on every oscillator.
+  const tunedPitch = (note: TriggerNote): number => note.pitch + (note.detuneCents ?? 0) / 100
+
   const triggerPoly = (note: TriggerNote, when: number) => {
     const v = allocate(when)
     v.applyMix(vp)
-    v.trigger(note.pitch, note.velocity, note.durationSec, when, vp, 0)
+    v.trigger(tunedPitch(note), note.velocity, note.durationSec, when, vp, 0)
   }
 
   const triggerMono = (note: TriggerNote, when: number) => {
@@ -652,7 +656,7 @@ export const createAnalogSynthInstrument = (config: AnalogConfig): Instrument =>
       wireLfo()
     }
     monoVoice.applyMix(vp)
-    monoVoice.trigger(note.pitch, note.velocity, note.durationSec, when, vp, vp.glide)
+    monoVoice.trigger(tunedPitch(note), note.velocity, note.durationSec, when, vp, vp.glide)
   }
 
   const applyAll = () => {

--- a/corpan/packs/beatlounge/src/instruments/fmSynth.ts
+++ b/corpan/packs/beatlounge/src/instruments/fmSynth.ts
@@ -36,9 +36,12 @@ export const createFmInstrument = (config: FmConfig): Instrument => {
     output: out,
     live: live.api,
     trigger(note: TriggerNote, when: number) {
-      const name = Tone.Frequency(note.pitch, "midi").toNote()
+      // Detuned frequency = 12-TET freq × 2^(cents/1200). 0 cents ⇒ unchanged.
+      const freq =
+        Tone.Frequency(note.pitch, "midi").toFrequency() *
+        Math.pow(2, (note.detuneCents ?? 0) / 1200)
       try {
-        poly.triggerAttackRelease(name, Math.max(0.02, note.durationSec), when, note.velocity)
+        poly.triggerAttackRelease(freq, Math.max(0.02, note.durationSec), when, note.velocity)
       } catch {
         /* ignore voice exhaustion */
       }

--- a/corpan/packs/beatlounge/src/instruments/sinePad.ts
+++ b/corpan/packs/beatlounge/src/instruments/sinePad.ts
@@ -77,12 +77,14 @@ export const createSinePadInstrument = (config: SynthConfig): Instrument => {
     output: out,
     live: live.api,
     trigger(note: TriggerNote, when: number) {
-      const name = Tone.Frequency(note.pitch, "midi").toNote()
+      const freq =
+        Tone.Frequency(note.pitch, "midi").toFrequency() *
+        Math.pow(2, (note.detuneCents ?? 0) / 1200)
       // Pads want to breathe: ensure a minimum sustain so the slow attack opens.
       const dur = Math.max(0.3, note.durationSec)
       for (const layer of layers) {
         try {
-          layer.triggerAttackRelease(name, dur, when, note.velocity)
+          layer.triggerAttackRelease(freq, dur, when, note.velocity)
         } catch {
           /* ignore voice exhaustion */
         }

--- a/corpan/packs/beatlounge/src/instruments/synth.ts
+++ b/corpan/packs/beatlounge/src/instruments/synth.ts
@@ -41,9 +41,12 @@ export const createSynthInstrument = (config: SynthConfig): Instrument => {
     output: out,
     live: live.api,
     trigger(note: TriggerNote, when: number) {
-      const name = Tone.Frequency(note.pitch, "midi").toNote()
+      // Detuned frequency = 12-TET freq × 2^(cents/1200). 0 cents ⇒ unchanged.
+      const freq =
+        Tone.Frequency(note.pitch, "midi").toFrequency() *
+        Math.pow(2, (note.detuneCents ?? 0) / 1200)
       try {
-        poly.triggerAttackRelease(name, Math.max(0.02, note.durationSec), when, note.velocity)
+        poly.triggerAttackRelease(freq, Math.max(0.02, note.durationSec), when, note.velocity)
       } catch {
         /* PolySynth can throw under voice exhaustion on rapid retriggers; ignore */
       }

--- a/corpan/packs/beatlounge/src/instruments/wavetable.ts
+++ b/corpan/packs/beatlounge/src/instruments/wavetable.ts
@@ -54,9 +54,11 @@ export const createWavetableInstrument = (config: WavetableConfig): Instrument =
     output: out,
     live: live.api,
     trigger(note: TriggerNote, when: number) {
-      const name = Tone.Frequency(note.pitch, "midi").toNote()
+      const freq =
+        Tone.Frequency(note.pitch, "midi").toFrequency() *
+        Math.pow(2, (note.detuneCents ?? 0) / 1200)
       try {
-        poly.triggerAttackRelease(name, Math.max(0.02, note.durationSec), when, note.velocity)
+        poly.triggerAttackRelease(freq, Math.max(0.02, note.durationSec), when, note.velocity)
       } catch {
         /* ignore voice exhaustion on rapid retriggers */
       }

--- a/corpan/packs/beatlounge/src/modules/instrument-surface/InstrumentRibbon.tsx
+++ b/corpan/packs/beatlounge/src/modules/instrument-surface/InstrumentRibbon.tsx
@@ -47,7 +47,7 @@ import {
   type RibbonWindow,
 } from "../../music/ribbonScales"
 import { docHarmony } from "../../model/document"
-import { activeMidiInRange, quantizeToHarmony } from "../../music/resolver"
+import { activeMidiInRange, detuneForMidi, quantizeToHarmony } from "../../music/resolver"
 import { clearAction } from "../ribbon/actions"
 import { runAction } from "../runAction"
 import { placeRecordedNote } from "./recordPlacement"
@@ -276,6 +276,15 @@ export const InstrumentRibbon = ({
       : raw
   }
 
+  // The actual SOUNDING pitch: the snapped degree + the active tuning's microtonal
+  // offset — the SAME `detuneForMidi` the sequencer uses, so the ribbon and the
+  // grid agree. Fretted only (free glide is already continuous). The RECORDED pitch
+  // stays the integer degree (resolveMidi); playback re-derives the cents.
+  const playPitch = (midi: number): number =>
+    live.current.fretted
+      ? midi + detuneForMidi(midi, store.vanilla.getState().doc, 0) / 100
+      : midi
+
   /** Record a (resolved) pitch into the bound track for ONE finger. Per-pointer
    *  step dedupe so two fingers can both lay notes without clobbering. The
    *  placement rules (dedupe + quantize on/off + duplicate-cell) are pure. */
@@ -312,8 +321,10 @@ export const InstrumentRibbon = ({
     const x = xFromEvent(e.clientX)
     const expr = exprFromEvent(e.clientY)
     const midi = resolveMidi(x)
-    // Open a live voice on the BOUND TRACK's real instrument (polyphonic).
-    const handle = host.playLiveVoice(trackId, midi, 0.9)
+    // Open a live voice on the BOUND TRACK's real instrument (polyphonic). The
+    // sounding pitch carries the maqam/tuning detune; the recorded pitch (below)
+    // stays the integer degree.
+    const handle = host.playLiveVoice(trackId, playPitch(midi), 0.9)
     // Soundfont/sampler fallback: no live pool → a stepped one-shot per crossing.
     if (!handle) host.previewTrack(trackId, 0.9, Math.round(midi))
     applyExpression(expr)
@@ -340,7 +351,7 @@ export const InstrumentRibbon = ({
     if (midi !== t.midi) {
       const crossed = Math.round(midi) !== Math.round(t.midi)
       t.midi = midi
-      if (t.handle) t.handle.bend(midi)
+      if (t.handle) t.handle.bend(playPitch(midi))
       else if (crossed) host.previewTrack(trackId, 0.9, Math.round(midi)) // stepped fallback
       setLiveLabel(noteLabel(midi))
       if (crossed) recordIntoTrack(t, midi)

--- a/corpan/packs/beatlounge/src/music/modes/maqam.ts
+++ b/corpan/packs/beatlounge/src/music/modes/maqam.ts
@@ -210,20 +210,29 @@ export const MAQAMAT: Mode[] = [
     aliases: ["Nahwand", "Maqam Nahawand"],
     notes: "Minor-like; upper Hijaz on the 5th gives the harmonic-minor leading tone. 12-TET-aligned (no neutral tones).",
   }),
-  // Kurd = jins Kurd on tonic + jins Kurd/Nahawand on the 5th (≈ Phrygian).
-  buildMaqam("maqam.kurd", "Kurd", JINS_KURD, JINS_NAHAWAND, 702, {
+  // Kurd = jins Kurd on tonic + jins Nahawand on the 4th (498) (≈ Phrygian).
+  buildMaqam("maqam.kurd", "Kurd", JINS_KURD, JINS_NAHAWAND, 498, {
     aliases: ["Kurd-i", "Maqam Kurd"],
-    notes: "Phrygian-like; 12-TET-aligned (no neutral tones). 0 90 294 498 702 792 996.",
+    notes:
+      "Phrygian-like; 12-TET-aligned (no neutral tones). Lower Kurd + jins Nahawand on the " +
+      "4th (498) → 0 90 294 498 702 792 996. Source: maqamworld.com/en/maqam/kurd.php.",
   }),
-  // Ajam = jins Ajam (pentachord) on tonic + jins Rast/Ajam on the 5th (≈ major).
-  buildMaqam("maqam.ajam", "Ajam", JINS_AJAM, JINS_NAHAWAND, 702, {
+  // Ajam = jins Ajam (pentachord) on tonic + jins Nahawand on the 6th (≈ MAJOR scale).
+  buildMaqam("maqam.ajam", "Ajam", JINS_AJAM, JINS_NAHAWAND, 906, {
     aliases: ["Ajam Ushayran", "Maqam Ajam"],
-    notes: "Major-like; 12-TET-aligned. Built on a major pentachord. 0 204 408 498 702 906 996/1110.",
+    notes:
+      "Major scale (Arabic 'major'); 12-TET-aligned. Major pentachord + jins Nahawand on the " +
+      "6th (906) → 0 204 408 498 702 906 1110 (major 7th B, NOT ♭7). maqamworld also names a " +
+      "Kurd middle-jins on the 3rd (adds no new degree here). Source: maqamworld.com/en/maqam/ajam_ushayran.php.",
   }),
-  // Nikriz = jins Nikriz (pentachord, raised 4th) on tonic + Hijaz/Rast above.
-  buildMaqam("maqam.nikriz", "Nikriz", JINS_NIKRIZ, JINS_RAST, 702, {
+  // Nikriz = jins Nikriz (pentachord, raised 4th) on tonic + jins NAHAWAND on the 5th.
+  buildMaqam("maqam.nikriz", "Nikriz", JINS_NIKRIZ, JINS_NAHAWAND, 702, {
     aliases: ["Nigriz", "Maqam Nikriz"],
-    notes: "Pentachord with a raised 4th (594¢, A4) over a minor 3rd. Nikriz lower + Rast upper.",
+    notes:
+      "Arabic Nikriz: lower Nikriz pentachord (raised 4th 594¢) + jins Nahawand on the 5th → " +
+      "C D E♭ F♯ G A B♭ (0 204 294 594 702 906 996). A MINOR 7th (B♭), not neutral. " +
+      "(Turkish makam Nikriz, rooted on Rast with a neutral 7th, is a separate regional variant — " +
+      "future 'school'.) Source: maqamworld.com/en/maqam/nikriz.php.",
   }),
   // Suznak = Rast lower + Hijaz on the 5th (Rast with a Hijaz upper).
   buildMaqam("maqam.suznak", "Suznak", JINS_RAST, JINS_HIJAZ, 702, {


### PR DESCRIPTION
Closes **#415**, and **cuts the `beatlounge 0.5.0 "Plus"` release** (the accumulated Plus batch — 50 instruments, "New…" randomizer, score selection/Evolve, home controls — plus this tuning work). Skips 0.4.x (tetraphobia). **Device-tested by Ian.**

## 1 · Microtonal playback (tuning Phase 0)
The microtonal engine already existed (`tuning.ts`, the resolver's `detuneForMidi`, the maqam cents, the live-voice frequency path) but only fed UI/preview — the **sequenced** and **ribbon-play** paths quantized to 12-TET. This wires the **same** calculation into both:
- `TriggerNote.detuneCents`, computed in the scheduler via `detuneForMidi` — **compute-at-schedule**: notes stay integer MIDI; cents come from the active tuning, so changing key/mode/school re-tunes live.
- synth / fmSynth / wavetable / sinePad apply a detuned frequency; analog passes fractional MIDI. `0` cents ⇒ exact 12-TET (backward-compatible).
- The in-key **ribbon** plays the same detune on its live voice (fretted only; free glide stays continuous), recording the clean integer degree.
- GM soundfont stays 12-TET (worklet is integer-MIDI).

## 2 · Maqam interval corrections (now audible)
Verified against **maqamworld.com**:
- **Nikriz** — upper jins Rast → **Nahawand@5th**: 7th `1057 → 996` (neutral B½b → **minor B♭**). _(Ian's catch; Turkish Nikriz's neutral 7th is a separate regional variant for the future schools work.)_
- **Ajam** — upper Nahawand re-rooted 5th → **6th**: 7th `996 → 1110` — was a **♭7 (Mixolydian)**, now the **major scale**.
- **Kurd** — upper Nahawand re-rooted 5th → **4th**: correct `0 90 294 498 702 792 996` (A♭ 6th).
- **Hijazkar** (standard double-harmonic) and **Sikah** confirmed correct as-is.

## Gates
- `npm run typecheck` clean · `npm run test` green (incl. a scheduler test proving Rast's neutral 3rd carries its detune, and the corrected Nikriz/Ajam/Kurd degrees) · `npm run build` clean.

## Scope
Pack-only. No `model/` spine change. manifest `0.3.2 → 0.5.0`. _Next: regional schools (Egyptian/Aleppo/Turkish/Persian) + thaat/melakarta intonation + per-note hand-tune editor (#416/#417)._