### PR TITLE
lingo-hero: fix prompt truncation on iPad long comma phrase (FAITHFUL repro) + level-meter height (#460, #461)

### DIFF
--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -6,6 +6,58 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.8] - 2026-06-24
+
+The prompt-truncation fix that the 0.4.3 and 0.4.6 "fixes" only *appeared* to
+make — both passed a NON-faithful harness and still truncated on the operator's
+iPad (#460) — plus the level-meter HUD height match (#461). Preview channel.
+
+### Fixed
+- **Prompt no longer truncates on a long comma phrase on iPad (#460).** Root
+  cause, found with a FAITHFUL reproduction (the real game mounted at the real
+  narrow PLAY-COLUMN width — not the full landscape viewport the old harness
+  used — with the iOS font-swap timing reproduced): the heavy display face
+  ("Russo One" / Lato-Heavy) swaps in a beat AFTER the first prompt fit (the
+  normal iOS WKWebView sequence). Its wider glyphs reflow the phrase to MORE
+  lines, but nothing re-fit the prompt or recomputed the spawn play-top, so the
+  stale, too-high play-top let falling tiles spawn OVER the prompt's last line —
+  the operator's "doesn't show the whole prompt." At the narrow play column a
+  long comma phrase wraps to 3+ lines, which is why it only showed there.
+  The fix:
+  - Re-fit the prompt AND recompute the spawn clearance on
+    `document.fonts.ready` (the heavy face landing), so the layout settles
+    against the REAL glyph metrics.
+  - A second deferred (rAF) re-fit pass catches a late font swap even without
+    the fonts.ready signal.
+  - The Hud now fires an `onPromptFit` callback after every fit settles; Game
+    recomputes the spawn play-top from it, so the prompt→playfield clearance
+    stays in sync no matter WHO changed the prompt (round load, resize, direct
+    setQuestion, or a font reflow). Falling tiles now always clear the prompt's
+    last line.
+  - Defensive `overflow: visible` pinned all the way up the prompt's ancestor
+    chain (`.hud`, `.top-bar`, `.prompt-stack`) so no ancestor band can ever
+    clip the wrapped lines.
+  - **The e2e was the real reason this shipped broken twice.** The old #441
+    assertion measured the `.question-box`'s OWN metrics — but that box is
+    `overflow:visible` + `height:auto`, so its rect always grows to contain the
+    text and can NEVER report clipping itself; it also rendered at full viewport
+    width where a long phrase fits on 1–2 lines. The new #460 assertion is
+    faithful: it constrains the host to the real portrait play-column width on
+    portrait + landscape iPad, reproduces the iOS font-swap race, walks the
+    prompt's ANCESTOR chain (failing on any ancestor/viewport clip), and asserts
+    the prompt's last line clears the lane spawn play-top. It FAILS on 0.4.7 and
+    passes on 0.4.8 — a real regression guard, proven before shipping.
+
+### Changed
+- **Level meter matches the SCORE/STREAK plate height (#461).** The bottom row's
+  center level meter was a thin single-row pill (label + bar side by side), much
+  shorter than the two flanking plates. It now STACKS its two rows vertically —
+  the "Lv N · pp%" label/percent on top, the progress bar below — so all three
+  bottom-row elements read at the SAME height and the row is balanced. It stays
+  the slim center element (narrower than the fat plates); it grows in height to
+  match, not in width. Verified equal-height on big iPad (portrait + landscape)
+  and phone.
+
 ## [0.4.7] - 2026-06-23
 
 Bottom-HUD + top-prompt polish follow-ups from the 0.4.6 design-critic pass

--- a/corpan/packs/lingo-hero/manifest.json
+++ b/corpan/packs/lingo-hero/manifest.json
@@ -2,7 +2,7 @@
   "id": "lingo_hero",
   "channel": "preview",
   "name": "Lingo Hero",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Catch the translation. The phrase you know falls as a chart of timed notes in the language you're learning — catch each word in rhythm, in order, and hear it spoken.",
   "entry": "dist/app.js",
   "styles": [
@@ -11,5 +11,5 @@
   "entryType": "script",
   "sdkVersion": "0.1.0",
   "minAppVersion": "0.17.0",
-  "devRevision": "2026-06-23T22:30:00.000Z"
+  "devRevision": "2026-06-24T00:00:00.000Z"
 }

--- a/corpan/packs/lingo-hero/src/Game.ts
+++ b/corpan/packs/lingo-hero/src/Game.ts
@@ -204,6 +204,12 @@ export class Game {
       this.progression
     );
     this.hud.applyLanguage(this.activeLanguage);
+    // #460 — whenever the prompt (re-)fits (per round, on resize, and crucially
+    // when the heavy display font swaps in and reflows the phrase taller), keep
+    // the spawn play-top in sync so falling tiles never cover the prompt's last
+    // line. This makes the prompt→playfield clearance automatic regardless of
+    // who changed the prompt, closing the iOS font-swap gap the operator hit.
+    this.hud.setOnPromptFit(() => this.applySpawnClearance());
     this.effects = initEffects(
       this.canvas.getContext("2d")!,
       this.bus,
@@ -224,6 +230,20 @@ export class Game {
     if (document.fonts && document.fonts.ready) {
       document.fonts.ready.then(() => {
         this.fontsReady = true;
+        // #460 — RE-FIT THE PROMPT once the heavy display face has swapped in.
+        // The first fitPrompt() during setQuestion() can run against the FALLBACK
+        // metrics (system-ui), then the vendored Lato-Heavy ("Russo One") lands a
+        // moment later (notably on iOS WKWebView, where the woff2 swaps in after
+        // first paint) with WIDER glyphs → the phrase reflows to MORE lines than
+        // the fallback measured. Without a re-fit the prompt keeps the stale
+        // fallback font size, the extra wrapped line spills below the reserved
+        // header band, and the playfield clearance (computed from the stale
+        // height) lets falling tiles / the assemble strip cover that last line —
+        // the operator's "doesn't show the whole prompt" on a long comma phrase.
+        // Re-fitting + recomputing the play-area top on font-ready closes that
+        // gap so the FULL phrase is laid out against the real glyph metrics.
+        this.hud?.onResize();
+        this.applySpawnClearance();
       });
     } else {
       this.fontsReady = true;

--- a/corpan/packs/lingo-hero/src/styles.css
+++ b/corpan/packs/lingo-hero/src/styles.css
@@ -547,6 +547,14 @@ canvas {
   padding: calc(var(--safe-top) + 4px) 0 0;
   gap: 4px;
   pointer-events: none;
+  /* #460 — the prompt header must NEVER be clipped by an ancestor. The HUD and
+     every container ABOVE the prompt explicitly keep overflow visible so a long
+     comma phrase that wraps to 3+ lines spills past the translucent band into
+     the (transparent) playfield instead of being cut off. This is a hard
+     contract: the operator hit truncation when an ancestor band clipped the
+     wrapped lines, so we pin overflow:visible all the way up the prompt chain. */
+  overflow: visible;
+  min-height: 0;
 }
 
 /* Full-width, edge-to-edge top header — just prompt + building pills, minimum
@@ -566,6 +574,9 @@ canvas {
   padding-right: calc(14px + env(safe-area-inset-right, 0px));
   padding-top: 46px;
   box-sizing: border-box;
+  /* #460 — never clip the wrapped prompt (see .hud note). */
+  overflow: visible;
+  min-height: 0;
 }
 
 /* TOP-LEFT CHROME (issue #426): the small PAUSE control + a single MUTE toggle.
@@ -712,6 +723,9 @@ canvas {
   gap: var(--na-space-1);
   min-width: 0;
   width: 100%;
+  /* #460 — never clip the wrapped prompt (see .hud note). */
+  overflow: visible;
+  min-height: 0;
 }
 
 /* The prompt is a TRANSLUCENT overlay label — no solid card, so the falling
@@ -909,23 +923,36 @@ canvas {
   text-align: center;
 }
 
-/* The CENTER meter is THIN: it does NOT grow like the fat plates — it takes a
-   modest fixed-ish slice between them, so the two score/streak plates dominate
-   and the meter reads as a slim progress strip. */
+/* #461 — the CENTER level meter now matches the SCORE/STREAK plate HEIGHT.
+   Instead of a thin single-row pill (label + bar side by side, much shorter than
+   the two flanking plates), the meter cell STACKS its two rows VERTICALLY — the
+   "Lv N · pp%" label/percent ON TOP, the progress bar BELOW — so all three
+   bottom-row elements read at the SAME height and the row is visually balanced.
+   It still stays the SLIM center element (narrower than the fat plates) — it
+   grows in height to match, not in width. `align-items: stretch` lets the bar
+   span the cell width; `justify-content: center` vertically centers the 2 rows
+   so they sit level with the plates' label+value. */
 .lh-stats .mastery-readout {
   flex: 0 1 auto;
-  align-self: center;
+  align-self: stretch;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   width: auto;
   min-width: clamp(72px, 22vw, 150px);
   max-width: 32%;
   margin: 0;
-  gap: 8px;
-  padding: clamp(3px, 1vmin, 6px) clamp(8px, 1.6vw, 14px);
+  gap: clamp(4px, 1.2vmin, 8px);
+  padding: clamp(0.4rem, 1.4vmin, 0.7rem) clamp(0.7rem, 2vw, 1.2rem);
   font-size: clamp(0.6rem, 2.4vmin, 0.78rem);
 }
-/* Keep the meter's progress bar from collapsing in the compact row. */
+/* The progress bar now sits on its OWN row beneath the label and spans the
+   meter cell width (capped) so the 2-row meter reads as a proper plate. */
 .lh-stats .mastery-bar {
-  min-width: 34px;
+  flex: 0 0 auto;
+  width: 100%;
+  min-width: 48px;
+  max-width: 160px;
 }
 /* The in-stats meter label is a mixed-case readout ("Lv 1 · 0%") — keep its
    intended casing + middot separator (#445.3); do NOT uppercase it like the

--- a/corpan/packs/lingo-hero/src/ui/Hud.ts
+++ b/corpan/packs/lingo-hero/src/ui/Hud.ts
@@ -111,6 +111,16 @@ export class Hud {
   /** Words seen this run + correct count (drive the in-run mastery readout). */
   private runSeen = 0;
   private runCorrect = 0;
+  /**
+   * #460 — fired AFTER the prompt has (re-)fitted to a final wrapped layout,
+   * including the deferred rAF / font-swap re-fits. Game subscribes to recompute
+   * the spawn play-top so falling tiles always clear the prompt's LAST line — no
+   * matter WHO changed the prompt (loadRound, a direct setQuestion, resize, or
+   * the font-ready reflow). Without this, a re-fit that grew the prompt taller
+   * left the play-top stale and tiles spawned over the last line (the operator's
+   * "doesn't show the whole prompt" at a narrow play column on iPad).
+   */
+  private onPromptFitCb?: () => void;
 
   constructor(
     container: HTMLElement,
@@ -357,6 +367,17 @@ export class Hud {
   private fitPrompt(): void {
     if (typeof requestAnimationFrame === "function") {
       requestAnimationFrame(() => this.fitPromptNow());
+      // #460 — a SECOND deferred re-fit one more frame out. The vendored heavy
+      // display face ("Russo One"/Lato-Heavy) can swap in AFTER the first fit
+      // (notably on iOS WKWebView, where the woff2 lands a beat after first
+      // paint). Its wider glyphs reflow the phrase to more lines than the
+      // fallback measured; without re-measuring, the prompt keeps the stale
+      // fallback size and the extra line spills the band. The extra frame
+      // re-fits against the real glyph metrics so the FULL phrase stays visible.
+      // (Game.ts also re-fits on document.fonts.ready for the definitive swap.)
+      requestAnimationFrame(() =>
+        requestAnimationFrame(() => this.fitPromptNow())
+      );
     }
     // Also run synchronously so callers/tests that measure immediately see a fit.
     this.fitPromptNow();
@@ -394,6 +415,19 @@ export class Hud {
       apply(size);
       guard++;
     }
+    // #460 — the wrapped layout is now final for this fit pass. Tell Game so it
+    // recomputes the spawn play-top against the prompt's settled height (the
+    // prompt may have just grown taller from a font swap / narrower column).
+    this.onPromptFitCb?.();
+  }
+
+  /**
+   * #460 — register a callback fired after every prompt (re-)fit settles, so the
+   * owner (Game) can recompute the spawn-clearance play-top against the prompt's
+   * final wrapped height. Idempotent + cheap; called on each fit pass.
+   */
+  setOnPromptFit(cb: () => void): void {
+    this.onPromptFitCb = cb;
   }
 
   /**

--- a/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
+++ b/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
@@ -335,71 +335,179 @@ else {
   }
 }
 
-// --- Contract (e2): #441 — LONG + COMMA prompt FULLY VISIBLE at PHONE *and*
-// IPAD widths (portrait + landscape). The 0.4.3 fitPrompt() jammed phrases into
-// <=2 lines, hit a font floor, and let the overflow spill the band on iPad — the
-// exact clip the operator kept hitting. This proves the FULL phrase (every word)
-// renders without any glyph clipped, measured with a Range over the rendered text
-// (immune to scrollHeight/clientHeight integer rounding), across viewport widths.
+// --- Contract (e2): #460 — LONG + COMMA prompt FULLY VISIBLE at the REAL
+// PLAY-COLUMN WIDTH on portrait *and* landscape iPad, under the iOS font-swap
+// race. This REPLACES the old #441 assertion, which was MEANINGLESS: it measured
+// the `.question-box`'s OWN getBoundingClientRect, but that box is
+// `overflow:visible` + `height:auto`, so its rect ALWAYS grows to contain the
+// text → spill was always ~0 (it can never report clipping itself). It also
+// rendered the prompt at FULL viewport width, where a long phrase fits on 1–2
+// lines and never stresses the wrap. Both gaps let two "fixes" (0.4.3, 0.4.6)
+// pass a non-faithful harness while the operator's iPad still truncated.
+//
+// This version is FAITHFUL to the device:
+//   1. NARROW PLAY-COLUMN WIDTH — the host is constrained to a portrait play
+//      column (360–430px) so the comma phrase wraps to 3+ lines (the stress the
+//      full-width harness never applied), on both portrait and landscape iPad.
+//   2. iOS FONT-SWAP RACE — the heavy display face (Russo One / Lato-Heavy) is
+//      held back until AFTER the prompt is set, then released, reproducing the
+//      WKWebView sequence where the woff2 swaps in a beat after first paint and
+//      the phrase reflows WIDER/taller than the fallback fit measured.
+//   3. ANCESTOR / VISUAL clip — we walk the prompt's ANCESTOR chain and fail if
+//      any ancestor that establishes a clip (overflow != visible) or the
+//      VIEWPORT cuts the wrapped text, instead of trusting the question-box's
+//      own metrics.
+//   4. SPAWN-COVER — the prompt's wrapped text bottom must NOT fall below the
+//      lane spawn play-top (else falling tiles render OVER the last line — the
+//      operator's "doesn't show the whole prompt"). This is the real, width- and
+//      font-timing-dependent failure the prior harness could not see.
 {
   const LONG = "They built a fort, then argued about what to defend it from";
-  const WORDS = LONG.replace(/[.,]/g, "").split(/\s+/).filter(Boolean);
+  const EXTRA =
+    "The committee, having deliberated for hours, finally agreed that the proposal, though ambitious, deserved a cautious and measured trial run";
+  // Real iPad sizes, with the host constrained to a portrait PLAY-COLUMN width
+  // (not the full landscape viewport) — the dimension the old harness got wrong.
   const SIZES = [
-    { name: "phone-portrait", w: 390, h: 844 },
-    { name: "ipad-portrait", w: 834, h: 1112 },
-    { name: "ipad-landscape", w: 1180, h: 820 },
+    { name: "ipad-landscape-col", vw: 1080, vh: 810, hw: 360, hh: 760, phrase: LONG },
+    { name: "ipad-landscape-col-extralong", vw: 1080, vh: 810, hw: 360, hh: 760, phrase: EXTRA },
+    { name: "ipad-portrait-col", vw: 834, vh: 1112, hw: 430, hh: 980, phrase: LONG },
+    { name: "ipad11-landscape-col", vw: 1194, vh: 834, hw: 390, hh: 780, phrase: EXTRA },
+    { name: "phone-portrait", vw: 390, vh: 844, hw: 0, hh: 0, phrase: LONG },
   ];
   for (const sz of SIZES) {
-    const vp = await browser.newPage({ viewport: { width: sz.w, height: sz.h }, deviceScaleFactor: 2 });
-    vp.on("pageerror", (e) => fail(`pageerror(441-${sz.name}): ` + e.message));
+    const words = sz.phrase.replace(/[.,]/g, "").split(/\s+/).filter(Boolean);
+    const vp = await browser.newPage({
+      viewport: { width: sz.vw, height: sz.vh },
+      deviceScaleFactor: 2,
+    });
+    vp.on("pageerror", (e) => fail(`pageerror(460-${sz.name}): ` + e.message));
+    // iOS font-swap race: hold the heavy display face until after the fit.
+    let releaseFont = null;
+    const fontGate = new Promise((r) => (releaseFont = r));
+    await vp.route("**/lato-heavy.woff2", async (route) => {
+      await fontGate;
+      route.continue();
+    });
     await vp.goto(harness);
     await vp.waitForFunction(() => !!window.__lingoHero, { timeout: 10000 });
-    // Give the pack the FULL viewport (the app hands the pack the whole screen).
-    await vp.evaluate(() => {
+    // Constrain the host to the real play-column box (centered), so the pack
+    // measures container.clientWidth == that narrow width — not the full vp.
+    await vp.evaluate((sz) => {
       const h = document.getElementById("host");
-      if (h) { h.style.margin = "0"; h.style.width = "100vw"; h.style.height = "100vh"; }
-    });
-    await vp.evaluate(() => {
-      const p = [...document.querySelectorAll("button")].find((b) => /practice/i.test(b.textContent || ""));
-      if (p) p.click(); else window.__lingoHero.startGame("PRACTICE");
-    });
-    await vp.waitForTimeout(350);
+      if (!h) return;
+      h.style.margin = "0";
+      if (sz.hw) {
+        // Anchor the narrow play column at the TOP-center (top:0), exactly like
+        // the real app where the pack header sits at the top of a full-height
+        // container — only the WIDTH is the play column. Centering it vertically
+        // would move the prompt to mid-viewport and distort the clip geometry.
+        h.style.position = "fixed";
+        h.style.width = sz.hw + "px";
+        h.style.height = sz.hh + "px";
+        h.style.left = "50%";
+        h.style.top = "0";
+        h.style.transform = "translateX(-50%)";
+        h.style.inset = "auto";
+      } else {
+        h.style.width = "100vw";
+        h.style.height = "100vh";
+      }
+      window.dispatchEvent(new Event("resize"));
+    }, sz);
+    await vp.waitForTimeout(120);
+    // Enter play + set the long phrase WHILE the heavy font is still blocked
+    // (fit happens at fallback metrics, exactly like iOS first paint).
+    await vp.evaluate((phrase) => {
+      const p = [...document.querySelectorAll("button")].find((b) =>
+        /practice/i.test(b.textContent || "")
+      );
+      if (p) p.click();
+      else window.__lingoHero.startGame("PRACTICE");
+      window.__lingoHero.hud.setQuestion(phrase);
+    }, sz.phrase);
+    await vp.waitForTimeout(150);
+    // Release the heavy font → it swaps in, glyphs widen, the phrase reflows.
+    releaseFont();
+    await vp.waitForTimeout(650); // fonts.ready re-fit + re-clearance settles
+    // Re-assert the phrase (the round loop may auto-advance), then measure.
     const m = await vp.evaluate((args) => {
-      const [text, words] = args;
-      window.__lingoHero.hud.setQuestion(text);
+      const [phrase, wordsIn] = args;
+      const lh = window.__lingoHero;
+      lh.hud.setQuestion(phrase);
+      // NOTE: we deliberately do NOT dispatch a synthetic resize here. The whole
+      // point of #460 is the iOS FONT-SWAP race: the heavy display face lands
+      // AFTER the initial fit and the phrase reflows taller. The fix re-fits the
+      // prompt AND recomputes the spawn play-top on document.fonts.ready (which
+      // fired during the wait above once we released the woff2). A resize tick
+      // would MASK the regression by recomputing the clearance the broken build
+      // never did on font-ready — so this test relies solely on the font-ready
+      // path, giving it real teeth against the exact bug that shipped twice.
       const el = document.querySelector("#question-box");
       if (!el) return null;
-      const cs = getComputedStyle(el);
-      const eb = el.getBoundingClientRect();
-      const padT = parseFloat(cs.paddingTop) || 0, padB = parseFloat(cs.paddingBottom) || 0;
-      const padL = parseFloat(cs.paddingLeft) || 0, padR = parseFloat(cs.paddingRight) || 0;
-      const rng = document.createRange(); rng.selectNodeContents(el);
-      const tb = rng.getBoundingClientRect();
+      const rng = document.createRange();
+      rng.selectNodeContents(el);
+      const t = rng.getBoundingClientRect();
       const txt = el.textContent || "";
-      return {
-        fontPx: parseFloat(cs.fontSize),
-        allPresent: words.every((w) => txt.includes(w)),
-        missing: words.filter((w) => !txt.includes(w)),
-        // glyph spill past the content box (Range measures the line box, which
-        // includes ~1px font leading — so 1.5px is the real-clip threshold).
-        spillBottom: Math.max(0, tb.bottom - (eb.bottom - padB)),
-        spillTop: Math.max(0, (eb.top + padT) - tb.top),
-        spillRight: Math.max(0, tb.right - (eb.right - padR)),
-        spillLeft: Math.max(0, (eb.left + padL) - tb.left),
+      // (3) Walk the ancestor chain — find the FIRST clipper (overflow != visible
+      // that cuts the wrapped text) or a viewport cut.
+      const desc = (n) => {
+        const id = n.id ? "#" + n.id : "";
+        const c =
+          n.className && typeof n.className === "string"
+            ? "." + n.className.trim().split(/\s+/).join(".")
+            : "";
+        return n.tagName.toLowerCase() + id + (id ? "" : c);
       };
-    }, [LONG, WORDS]);
-    if (!m) { fail(`#441 ${sz.name}: no #question-box`); }
-    else {
-      const SPILL = 1.5;
-      if (!m.allPresent) fail(`#441 ${sz.name}: prompt missing words ${JSON.stringify(m.missing)}`);
-      if (m.spillBottom > SPILL || m.spillTop > SPILL || m.spillRight > SPILL || m.spillLeft > SPILL) {
-        fail(`#441 ${sz.name}: prompt CLIPPED — spill(t/b/l/r)=${m.spillTop.toFixed(1)}/${m.spillBottom.toFixed(1)}/${m.spillLeft.toFixed(1)}/${m.spillRight.toFixed(1)} (font ${m.fontPx}px)`);
+      let clipper = null;
+      let node = el;
+      const vh = window.innerHeight;
+      while (node && node !== document.documentElement) {
+        const cs = getComputedStyle(node);
+        const r = node.getBoundingClientRect();
+        if (cs.overflowY !== "visible") {
+          const overB = t.bottom - r.bottom;
+          const overT = r.top - t.top;
+          if ((overB > 1.5 || overT > 1.5) && !clipper) {
+            clipper = `${desc(node)} (overflow ${cs.overflowX}/${cs.overflowY}) cuts ↓${overB.toFixed(1)}/↑${overT.toFixed(1)}`;
+          }
+        }
+        node = node.parentElement;
       }
-      if (m.allPresent && m.spillBottom <= SPILL && m.spillTop <= SPILL && m.spillRight <= SPILL && m.spillLeft <= SPILL) {
-        console.log(`OK: #441 long+comma prompt fully visible at ${sz.name} ${sz.w}x${sz.h} (font ${m.fontPx}px, all ${WORDS.length} words, spill<=${SPILL}px)`);
-      }
+      if (!clipper && t.bottom - vh > 1.5)
+        clipper = `VIEWPORT cuts ↓${(t.bottom - vh).toFixed(1)}`;
+      if (!clipper && -t.top > 1.5)
+        clipper = `VIEWPORT cuts ↑${(-t.top).toFixed(1)}`;
+      // (4) Spawn-cover: prompt text bottom vs lane spawn play-top (canvas-local).
+      const canvas = document.querySelector("canvas");
+      const ctop = canvas.getBoundingClientRect().top;
+      const playTopY = lh.laneSystem.getPlayTopY();
+      const promptBottomLocal = t.bottom - ctop;
+      return {
+        fontPx: parseFloat(getComputedStyle(el).fontSize),
+        qbWidth: el.clientWidth,
+        allPresent: wordsIn.every((w) => txt.includes(w)),
+        missing: wordsIn.filter((w) => !txt.includes(w)),
+        clipper,
+        promptBottomLocal,
+        playTopY,
+        coverPx: promptBottomLocal - playTopY,
+      };
+    }, [sz.phrase, words]);
+    if (!m) {
+      fail(`#460 ${sz.name}: no #question-box`);
+    } else {
+      if (!m.allPresent)
+        fail(`#460 ${sz.name}: prompt missing words ${JSON.stringify(m.missing)}`);
+      if (m.clipper)
+        fail(`#460 ${sz.name}: prompt CLIPPED by ANCESTOR/viewport — ${m.clipper} (col ${m.qbWidth}px, font ${m.fontPx.toFixed(0)}px)`);
+      // The prompt's last line must clear the spawn play-top (tiles must not
+      // spawn over it). A small tolerance for sub-pixel rounding.
+      if (m.coverPx > 2.0)
+        fail(`#460 ${sz.name}: prompt last line COVERED by spawn area by ${m.coverPx.toFixed(1)}px (promptBottom ${m.promptBottomLocal.toFixed(0)} > playTop ${m.playTopY.toFixed(0)}, col ${m.qbWidth}px)`);
+      if (m.allPresent && !m.clipper && m.coverPx <= 2.0)
+        console.log(`OK: #460 long+comma prompt fully visible at ${sz.name} (col ${m.qbWidth}px, font ${m.fontPx.toFixed(0)}px, all ${words.length} words, no ancestor clip, clears spawn by ${(-m.coverPx).toFixed(0)}px)`);
     }
-    await vp.screenshot({ path: join(outDir, `prompt-441-${sz.name}.png`) });
+    await vp.screenshot({ path: join(outDir, `prompt-460-${sz.name}.png`) });
     await vp.close();
   }
 }


### PR DESCRIPTION
### **User description**
Fixes #460. Fixes #461. **Preview channel. Target 0.4.8. DO NOT auto-merge / DO NOT enqueue** — given the two prior false fixes, the operator verifies on their iPad via the repro page FIRST.

## #460 — why it shipped broken TWICE, and the actual root cause

The 0.4.3 and 0.4.6 "fixes" both passed e2e + design-critic and still truncated on the operator's iPad. **The e2e was meaningless**: the old #441 assertion measured the `.question-box`'s OWN `getBoundingClientRect`, but that box is `overflow:visible` + `height:auto`, so its rect ALWAYS grows to contain the text → it can never report clipping itself. It also rendered the prompt at the FULL viewport width, where a long phrase fits on 1–2 lines and never stresses the wrap.

### Faithful reproduction (built first, before any fix)
A repro page mounts the REAL built game at the REAL narrow **play-column width** (not the full landscape viewport) and reproduces the iOS **font-swap timing**. It walks the prompt's ANCESTOR chain and reports each ancestor's clientHeight/scrollHeight/overflow + whether the wrapped text is clipped, and whether the prompt's last line clears the lane spawn play-top.

### Root-cause EVIDENCE
- At **full viewport width** (what the old harness used): no clip at any size — exactly why the prior fixes "passed." The landscape iPad gives the prompt ~1080px, so the phrase fits on ~1 line.
- **No CSS ancestor has `overflow:hidden`** except `body`, and the prompt sits at the top, far from the viewport bottom — so pure vertical ancestor clipping does NOT reproduce in headless Chromium. (Reported honestly; the prior fixes were not wrong about that mechanism.)
- **The real defect is the iOS font-swap race**, reproduced deterministically: the heavy display face (`Russo One` / Lato-Heavy) swaps in a beat AFTER the first prompt fit (normal WKWebView sequence). Its wider glyphs reflow the phrase to MORE lines, but nothing re-fit the prompt or recomputed the spawn play-top, so the stale, too-high play-top let **falling tiles spawn OVER the prompt's last line** — the operator's "doesn't show the whole prompt." It only shows at the **narrow play column**, where a long comma phrase wraps to 3+ lines.

**Before/after at the narrow 360px play column, extra-long comma phrase, font held until after the fit then released:**

| build | prompt bottom vs spawn play-top | result |
|---|---|---|
| OLD 0.4.7 | promptBottom 177 > playTop **152** → covered by **24.6px** | last line covered by spawn area |
| NEW 0.4.8 | promptBottom 177 < playTop **198** → clears by **21.2px** | full phrase clears the playfield |

## The fix
- Re-fit the prompt AND recompute the spawn clearance on `document.fonts.ready` (the heavy face landing) so layout settles against the REAL glyph metrics.
- A second deferred (rAF) re-fit pass catches a late font swap even without the fonts.ready signal.
- `Hud` now fires an `onPromptFit` callback after every fit settles; `Game` recomputes the spawn play-top from it, so the prompt→playfield clearance stays in sync no matter WHO changed the prompt (round load, resize, direct setQuestion, font reflow).
- Defensive `overflow: visible` pinned up the prompt ancestor chain (`.hud`, `.top-bar`, `.prompt-stack`).

## The new e2e has TEETH (proven)
The #441 assertion is REPLACED by a faithful #460 assertion: constrains the host to the real portrait play-column width on **portrait + landscape iPad**, reproduces the iOS font-swap race, walks the prompt ANCESTOR chain (fails on any ancestor/viewport clip), and asserts the prompt's last line clears the lane spawn play-top.
- **OLD build (0.4.7): e2e exit 1** — FAILS `ipad-portrait-col` "prompt last line COVERED by spawn area by 10.4px".
- **NEW build (0.4.8): e2e exit 0** — all 5 #460 cases pass (prompt clears spawn by 62–74px), full suite 24 OK / 0 FAIL.

## #461 — level meter matches plate height
The center level meter was a thin single-row pill, much shorter than the SCORE/STREAK plates. It now STACKS its two rows vertically (`Lv N · pp%` label/percent on top, progress bar below), so all three bottom-row elements read at the SAME height. Verified equal-height: iPad 71.4px / 71.4px / 71.4px, phone 48.1px / 48.1px / 48.1px (score/meter/streak). Stays the slim center element (narrower than the fat plates); grows in height, not width.

## Operator verification page (serve to their iPad)
Repro page at `/tmp/lh-prompt-repro/index.html` (built 0.4.8 `app.js` + `app.css` + fonts). Served on `0.0.0.0:8745`:
- **http://spark-f62c:8745/** (short, MagicDNS) or **http://100.99.83.64:8745/** (IPv4 fallback)
- Tap a phrase (defaults to the operator's `They built a fort, then argued about what to defend it from`; also an extra-long-commas option) and a size (iPad portrait 810×1080 / landscape 1080×810 / native device). The top diagnostic banner reports the ancestor-chain clip verdict live; tap **diag** to hide it and see the bare prompt.

## Contracts preserved
answer dedup, offline, raw-text TTS, canvas-relative input, delta-timed motion, #407 language rule, iOS audio 0.4.5, lane-tap isolation, bottom HUD row, `window.__lingoHero`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement, Tests, Documentation


___

### **Description**
- Fix iPad prompt font-swap clipping

- Recompute spawn clearance after prompt fits

- Equalize level-meter HUD plate height

- Add faithful regression coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Long comma prompt"] 
  B["Font-ready and rAF re-fit"]
  C["Prompt-fit callback"]
  D["Spawn clearance recomputed"]
  E["No ancestor or tile cover"]
  F["Stacked level meter"]

  A -- "wraps at real column width" --> B
  B -- "settled layout" --> C
  C -- "notifies Game" --> D
  D -- "keeps playfield below prompt" --> E
  A -- "HUD polish" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Game.ts</strong><dd><code>Synchronize prompt fitting with spawn clearance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/src/Game.ts

<ul><li>Registers <code>Hud</code> prompt-fit callback.<br> <li> Recomputes spawn clearance after prompt fits.<br> <li> Re-fits HUD on <code>document.fonts.ready</code>.<br> <li> Applies clearance after heavy font swap.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/467/files#diff-6c075e8c51d32e4e5452a4c738f6cc530345361455286e0f7d1af37f46fedde7">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Hud.ts</strong><dd><code>Notify game after prompt layout settles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/src/ui/Hud.ts

<ul><li>Adds <code>onPromptFitCb</code> notification hook.<br> <li> Runs an extra deferred <code>requestAnimationFrame</code> fit.<br> <li> Fires callback after each settled prompt fit.<br> <li> Exposes <code>setOnPromptFit</code> for <code>Game</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/467/files#diff-145e656a10e1e233418a8c559a94e938bf0e0c922802aa2f87d69b0498a38c02">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>styles.css</strong><dd><code>Prevent prompt clipping and balance HUD meter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/src/styles.css

<ul><li>Pins prompt ancestor overflow to visible.<br> <li> Prevents prompt-chain height clipping.<br> <li> Stacks level label above progress bar.<br> <li> Stretches level meter to plate height.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/467/files#diff-b9b9a82cd5a6b2fe32239b2b4b2f069c2c4853d63db1736b575103a5d1daf226">+35/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document prompt fix and HUD refinement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/CHANGELOG.md

<ul><li>Adds <code>0.4.8</code> release notes.<br> <li> Documents iPad prompt truncation root cause.<br> <li> Summarizes font-ready re-fit fix.<br> <li> Notes level-meter height refinement.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/467/files#diff-dd09bf20e11864991961b7ef6d2fc6687a66d9a9de2d246f765d9d6891e646c2">+52/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump Lingo Hero preview version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/manifest.json

<ul><li>Bumps package version to <code>0.4.8</code>.<br> <li> Updates <code>devRevision</code> timestamp.<br> <li> Keeps preview channel metadata unchanged.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/467/files#diff-38411e79d50eee7f8ad439a29518dcddf16cdc9cd03739fc81ea212f18519b15">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gameplay.spec.mjs</strong><dd><code>Add faithful prompt visibility regression test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs

<ul><li>Replaces non-faithful prompt visibility assertion.<br> <li> Constrains host to real play-column widths.<br> <li> Simulates delayed heavy-font loading.<br> <li> Asserts ancestor clipping and spawn-cover clearance.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/467/files#diff-5ee22f0c6a817c0427478004e2238facf99cd3c18591eda51d590170655a3c57">+158/-50</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

