### PR TITLE
catalog: PREVIEW badge on dev-mode-revealed phrase packs (#468)

### DIFF
--- a/corpan/corpan-app/CHANGELOG.md
+++ b/corpan/corpan-app/CHANGELOG.md
@@ -18,6 +18,10 @@ Conventions: `corpan/CHANGELOGS.md`.
   already shipped: hover-runner (#459) pauses its game loop; the shared reader
   shell pauses narration audio (stargate/earthgate); lingo-hero's listener is a
   separate follow-up. No user-facing strings; no locale keys added.
+- **PREVIEW badge on dev-mode-only phrase packs.** Phrase-pack cards now show a
+  small amber **PREVIEW** pill when `pack.channel === "preview"` — the packs
+  revealed only in developer mode. Stable packs stay unbadged. The label is an
+  intentional literal (not localized) since it's a technical/dev marker (#468).
 - **New "Semi large" text-size option.** Adds a size between Medium and Large
   (`1.1rem`, CSS class `text-semi-large`) to the text-size picker, and makes it
   the default for new profiles so default reading text is a touch larger. New

--- a/corpan/corpan-app/src/components/packs/PhrasePackCard.tsx
+++ b/corpan/corpan-app/src/components/packs/PhrasePackCard.tsx
@@ -180,14 +180,26 @@ export function PhrasePackCard({
             {/* Header */}
             <div className="flex items-start justify-between gap-2">
                 <div className="flex-1 min-w-0">
-                    <h3
-                        className={[
-                            "font-semibold leading-tight",
-                            compact ? "text-sm" : "text-base",
-                        ].join(" ")}
-                    >
-                        {pack.name}
-                    </h3>
+                    <div className="flex items-center gap-1.5 flex-wrap">
+                        <h3
+                            className={[
+                                "font-semibold leading-tight",
+                                compact ? "text-sm" : "text-base",
+                            ].join(" ")}
+                        >
+                            {pack.name}
+                        </h3>
+                        {/* Dev-mode-only "preview" packs (channel === "preview")
+                            carry an amber PREVIEW marker so it's unmistakable
+                            they're not part of the stable catalog. Stable packs
+                            stay unbadged. Literal string — a technical/dev
+                            marker, deliberately not run through i18n. */}
+                        {pack.channel === "preview" && (
+                            <span className="shrink-0 inline-flex items-center px-1.5 py-0.5 rounded-full border border-amber-400/70 bg-amber-500/[0.12] text-amber-600 text-[9px] font-semibold uppercase tracking-wider">
+                                PREVIEW
+                            </span>
+                        )}
+                    </div>
                     {pack.topic && pack.topic !== pack.name && (
                         <p className="text-[11px] text-muted-foreground/80 mt-0.5">
                             {pack.topic}


### PR DESCRIPTION
### **User description**
Closes #468.

## What

Phrase-pack cards now show a small **amber "PREVIEW" pill** on packs that are
revealed only in developer mode — exactly `pack.channel === "preview"` (the same
predicate the devMode reveal gate uses in `phrasePackCatalog.ts:310`). Stable
packs stay unbadged.

## Where

Single surgical change in `corpan-app/src/components/packs/PhrasePackCard.tsx` —
the one component that renders pack cards from the visible catalog list
(`usePhrasePackCatalog` → `PhrasePackBrowser` grid + full card). The badge sits
in the card header next to the title, so it appears in **both** the compact
browser grid and the full (detail) card with no extra render site.

The pack model already exposes `channel` at the render site via the parsed
catalog (`parseChannel`), so no catalog/build/parse change is needed.

## i18n

The label is an intentional **literal `"PREVIEW"` string — no new `t()` key**.
It is a technical/dev marker, and adding a key would force a ~54-locale fanout to
pass `check:i18n`. `check:i18n` confirmed still green (687 keys × 54 locales).

## Scope guardrails

- No app version bump — ships in the next operator-controlled app-store release.
- Did not touch `store/paywall.ts` (parked PR #464) or any pack.
- Onboarding has its own card component and preview packs are a devMode edge
  case there; left untouched to keep this small.

## Gates (local)

- `npm run tsc` — clean ✅
- `npm run check:i18n` — pass ✅
- `npm run check:recommendations` — pass ✅
- `vite build` deferred to CI (local Node 18 < vite's Node 20+ requirement; not a
  code issue).

## Verify (for @skyl)

Enable developer mode → open the Packs tab / phrase-pack browser. The
preview-channel packs that appear should carry the amber **PREVIEW** badge next
to their name; stable packs show no badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Badge preview-channel phrase packs

- Keep stable packs unbadged

- Document unreleased catalog UI change


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Phrase pack card"]
  B["pack.channel check"]
  C["Amber PREVIEW badge"]
  D["Unreleased changelog"]
  A -- "renders" --> B
  B -- "preview only" --> C
  C -- "documented in" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PhrasePackCard.tsx</strong><dd><code>Render preview badge on phrase pack cards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/corpan-app/src/components/packs/PhrasePackCard.tsx

<ul><li>Wraps the pack title in a flexible header row.<br> <li> Shows an amber <code>PREVIEW</code> pill when <code>pack.channel === "preview"</code>.<br> <li> Uses a literal <code>PREVIEW</code> label without adding i18n keys.<br> <li> Leaves stable phrase packs unbadged.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/469/files#diff-600c8c644ddb21c4cb849ddffab146f53e0dca6e20056d309bfa1383110216aa">+20/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document preview badge catalog update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/corpan-app/CHANGELOG.md

<ul><li>Adds an <code>[Unreleased]</code> entry for preview pack badging.<br> <li> Notes that preview badges appear only for developer-mode packs.<br> <li> Documents the intentional non-localized <code>PREVIEW</code> label.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/469/files#diff-fcd2aeaa88f0735613dd8b9388c69c41b43b9eec554f31f82c902937b33b9940">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

