### PR TITLE
lingo-hero: script-aware tokenization + offline glyph rendering — zh/ja/th playable (#463)

### DIFF
--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -6,6 +6,49 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.9] - 2026-06-24
+
+Script-aware tokenization + offline glyph rendering — the correctness fix that
+makes whole non-Latin language classes actually PLAYABLE (#463). Preview channel.
+
+### Fixed
+- **Chinese (zh), Japanese (ja), and Thai (th) now genuinely play (#463).**
+  Operator-confirmed completely broken: the phrase→catchable-notes split was
+  whitespace-only, so a no-space script (CJK, Thai) produced ZERO playable
+  units and the round bricked. Replaced the whitespace `tokenize` with a new
+  reusable, OFFLINE, script-aware `segmentPhrase(text, lang)` (built on the
+  built-in `Intl.Segmenter`) in `src/segment.ts`:
+  - Space-delimited (Latin/Cyrillic/Greek): word granularity filtered to
+    word-like segments (≈ prior behavior; punctuation stays attached).
+  - CJK no-space (zh/ja): word granularity → meaningful multi-char units, with
+    a per-character fall back when the segmenter returns one giant run, so the
+    phrase is always playable as a hanzi/kana sequence (reading mode).
+  - Thai + SE Asian no-space (th/lo/km/my): word granularity, grapheme-cluster
+    safe — a Thai combining vowel/tone mark is never split off its base.
+  - Indic (hi/bn/…): space-split words, conjuncts/matras kept as intact
+    grapheme clusters.
+  - Fallback when `Intl.Segmenter` is missing: space-split if spaces present,
+    else per grapheme-cluster.
+  Distractor-word collection is segmented the same script-aware way, so foils
+  are real target-language units (answer dedup preserved).
+- **Non-Latin scripts no longer render as TOFU (#463).** The neon display face
+  (Russo One / Lato) is Latin-only, so zh/ja/th/ar/he/Devanagari showed as
+  boxes on the canvas note cards and the DOM prompt/strip. Added a per-script
+  OFFLINE system-font fallback stack (`scriptFontStack` in `src/segment.ts`):
+  the Renderer now picks the active target language's stack for canvas glyph
+  rendering (`Renderer.setActiveLang`), and the CSS adds matching `[data-lang]`
+  fallbacks on `.question-box` + `.lh-chip`. No large CJK/Thai fonts vendored —
+  device system fonts carry these scripts.
+- **RTL assembling strip (ar/he/fa/ur).** The caught-word strip follows logical
+  (RTL) reading order with `dir=rtl`, matching the already-RTL prompt.
+
+### Tests
+- `test/e2e/gameplay.spec.mjs` grows the #463 regression teeth: for
+  zh/ja/th/ar/hi it drives the real game with REAL phrases and asserts the
+  phrase segments into >= 2 units, the note glyphs render with real ink (not
+  tofu), catching the correct unit SCORES (genuinely playable), and the strip
+  is RTL for Arabic. New `harness-script.html` mounts an `?lang=` stack.
+
 ## [0.4.8] - 2026-06-24
 
 The prompt-truncation fix that the 0.4.3 and 0.4.6 "fixes" only *appeared* to

--- a/corpan/packs/lingo-hero/manifest.json
+++ b/corpan/packs/lingo-hero/manifest.json
@@ -2,7 +2,7 @@
   "id": "lingo_hero",
   "channel": "preview",
   "name": "Lingo Hero",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Catch the translation. The phrase you know falls as a chart of timed notes in the language you're learning — catch each word in rhythm, in order, and hear it spoken.",
   "entry": "dist/app.js",
   "styles": [
@@ -11,5 +11,5 @@
   "entryType": "script",
   "sdkVersion": "0.1.0",
   "minAppVersion": "0.17.0",
-  "devRevision": "2026-06-24T00:00:00.000Z"
+  "devRevision": "2026-06-24T02:00:00.000Z"
 }

--- a/corpan/packs/lingo-hero/src/ContentManager.ts
+++ b/corpan/packs/lingo-hero/src/ContentManager.ts
@@ -1,4 +1,5 @@
 import { HostApi, EntryOut } from "./sdk/types";
+import { segmentPhrase } from "./segment";
 
 /**
  * WordSelector — the injection point that lets the learning stream bias round
@@ -74,14 +75,19 @@ export interface Round {
   distractorWords: string[];
 }
 
-/** Split a phrase into display tokens. Splits on whitespace; keeps punctuation
- *  attached to the word it trails (so "café," stays one catchable token). */
-function tokenize(text: string): string[] {
-  return text
-    .trim()
-    .split(/\s+/)
-    .map((w) => w.trim())
-    .filter(Boolean);
+/**
+ * Split a phrase into ORDERED catchable units, SCRIPT-AWARE (issue #463).
+ *
+ * `lang` is the TARGET language: a whitespace split only works for space-
+ * delimited scripts and yields ZERO units for no-space scripts (zh/ja/th),
+ * which is why those were completely unplayable. `segmentPhrase` uses the
+ * built-in offline `Intl.Segmenter` to produce meaningful units per script
+ * (CJK words / per-hanzi, Thai words, Indic words, space-split for Latin),
+ * keeping punctuation attached for Latin and never splitting grapheme
+ * clusters. See src/segment.ts (shared with beatlounge #465).
+ */
+function tokenize(text: string, lang: string): string[] {
+  return segmentPhrase(text, lang);
 }
 
 /** Strip surrounding punctuation for dedup/comparison (keeps inner apostrophes). */
@@ -234,7 +240,7 @@ export class ContentManager {
       .find((t) => t.language_code === target)
       ?.romanization?.trim();
 
-    const targetWords = tokenize(targetText);
+    const targetWords = tokenize(targetText, target);
 
     // Distractor pool: real target-language words from OTHER entries, not in the
     // sequence. Order biased by the optional selector weight.
@@ -252,7 +258,7 @@ export class ContentManager {
     for (const e of distractorSources) {
       const t = this.transIn(e, target);
       if (!t) continue;
-      for (const w of tokenize(t)) {
+      for (const w of tokenize(t, target)) {
         const key = normWord(w);
         if (!key || seqNorms.has(key) || seenDistractor.has(key)) continue;
         seenDistractor.add(key);

--- a/corpan/packs/lingo-hero/src/Game.ts
+++ b/corpan/packs/lingo-hero/src/Game.ts
@@ -175,6 +175,7 @@ export class Game {
         this.stackConfig = next;
         this.activeLanguage = this.resolveActiveLanguage(next);
         this.hud?.applyLanguage(this.activeLanguage);
+        this.renderer.setActiveLang(this.activeLanguage.code);
       });
     }
 
@@ -204,6 +205,7 @@ export class Game {
       this.progression
     );
     this.hud.applyLanguage(this.activeLanguage);
+    this.renderer.setActiveLang(this.activeLanguage.code);
     // #460 — whenever the prompt (re-)fits (per round, on resize, and crucially
     // when the heavy display font swaps in and reflows the phrase taller), keep
     // the spawn play-top in sync so falling tiles never cover the prompt's last
@@ -539,6 +541,7 @@ export class Game {
         isRTL: RTL_LANGS.has(round.targetLang),
       };
       this.hud.applyLanguage(this.activeLanguage);
+      this.renderer.setActiveLang(this.activeLanguage.code);
     }
 
     this.currentWord = {

--- a/corpan/packs/lingo-hero/src/Renderer.ts
+++ b/corpan/packs/lingo-hero/src/Renderer.ts
@@ -1,5 +1,6 @@
 import { LaneIndex, Note } from "./types";
 import { LaneSystem } from "./LaneSystem";
+import { scriptFontStack } from "./segment";
 import {
   getBoardState,
   tickBoardState,
@@ -66,6 +67,12 @@ export class Renderer {
   // Scrolling phase for the synthwave floor grid (advances with energy).
   private gridScroll = 0;
 
+  // Per-script canvas font stack for the falling note cards (#463). Defaults to
+  // the Latin display face; Game calls setActiveLang() so CJK/Thai/Arabic/etc.
+  // get an on-device system font that actually carries the script (no tofu),
+  // fully offline. See src/segment.ts (scriptFontStack).
+  private wordFontStack = "'Russo One', 'Lingo Sans', system-ui, sans-serif";
+
   constructor(private canvas: HTMLCanvasElement, private laneSystem: LaneSystem) {
     this.ctx = canvas.getContext("2d")!;
     this.ctx.textAlign = "center";
@@ -93,6 +100,17 @@ export class Renderer {
     const width = parseFloat(this.canvas.style.width);
     const height = parseFloat(this.canvas.style.height);
     this.ctx.clearRect(0, 0, width, height);
+  }
+
+  /**
+   * Set the active TARGET language so the note cards use a font stack that
+   * carries that language's script (#463). Latin keeps the branded display
+   * face; non-Latin scripts append on-device system fonts so glyphs render
+   * instead of tofu — all offline. Game calls this whenever the round's target
+   * language changes.
+   */
+  setActiveLang(lang: string): void {
+    this.wordFontStack = scriptFontStack(lang);
   }
 
   // -------------------------------------------------------------------------
@@ -621,7 +639,7 @@ export class Renderer {
       const laneW = this.laneSystem.getLaneBounds(0).width;
       const cardW = laneW * 0.88;
       const cardH = r * 1.5;
-      const wordFont = "'Russo One', 'Lingo Sans', system-ui, sans-serif";
+      const wordFont = this.wordFontStack;
       const fontSize = note.text
         ? fitOneLine(ctx, note.text, cardW - 26, Math.round(r * 0.6), 17, wordFont)
         : 0;

--- a/corpan/packs/lingo-hero/src/segment.ts
+++ b/corpan/packs/lingo-hero/src/segment.ts
@@ -1,0 +1,266 @@
+/**
+ * segment.ts — script-aware phrase segmentation + per-script font fallbacks.
+ *
+ * The single source of truth for turning a target-language phrase into the
+ * ORDERED catchable units Lingo Hero drops as notes. A whitespace split only
+ * works for space-delimited scripts (Latin/Cyrillic/Greek); it yields ZERO
+ * playable units for no-space scripts (CJK, Thai, …), which is why Chinese,
+ * Japanese and Thai were completely broken (issue #463).
+ *
+ * Strategy (all OFFLINE, built-in `Intl.Segmenter`, iOS 14.5+ / all modern
+ * engines):
+ *   - Space-delimited (Latin/Cyrillic/Greek): word granularity, filtered to
+ *     word-like segments (≈ the old whitespace behavior, but punctuation-aware).
+ *   - CJK no-space (zh, ja): word granularity → meaningful multi-char units;
+ *     a segment that is one giant run (the segmenter occasionally returns the
+ *     whole phrase) falls back to per-CHARACTER so it's always playable.
+ *   - Thai + SE Asian no-space (th, lo, km, my): word granularity, and the
+ *     per-character fallback is GRAPHEME-cluster-safe so a Thai combining
+ *     vowel/tone mark is never split off its base consonant.
+ *   - Indic (hi, bn, ta, …): space-delimited, so word granularity works; any
+ *     fallback slicing is grapheme-cluster-safe (conjuncts/matras stay intact).
+ *   - Fallback when Intl.Segmenter is unavailable: split on spaces if present,
+ *     else per grapheme-cluster.
+ *
+ * This module is intentionally dependency-free and side-effect-free so
+ * beatlounge (#465) can reuse `segmentPhrase` / `scriptFontStack` verbatim.
+ */
+
+/** Languages whose script writes WITHOUT inter-word spaces. */
+const NO_SPACE_LANGS = new Set([
+  // CJK
+  "zh",
+  "zh-hans",
+  "zh-hant",
+  "ja",
+  // Thai + mainland SE Asian Brahmic (no word spaces)
+  "th",
+  "lo",
+  "km",
+  "my",
+]);
+
+/** CJK languages where a one-character fallback unit is meaningful (a hanzi /
+ *  kana is itself a catchable token when the segmenter returns a giant run). */
+const CJK_LANGS = new Set(["zh", "zh-hans", "zh-hant", "ja"]);
+
+/** RTL scripts — exported so callers share ONE source of truth. */
+export const RTL_LANGS = new Set(["ar", "he", "fa", "ur", "ps", "sd", "ug"]);
+
+/** Normalize a BCP-47-ish code to its lowercase base + full lowercase form. */
+function langKeys(lang: string): { base: string; full: string } {
+  const full = (lang || "").toLowerCase();
+  const base = full.split(/[-_]/)[0] || full;
+  return { base, full };
+}
+
+export function isRTL(lang: string): boolean {
+  const { base, full } = langKeys(lang);
+  return RTL_LANGS.has(base) || RTL_LANGS.has(full);
+}
+
+function isNoSpace(lang: string): boolean {
+  const { base, full } = langKeys(lang);
+  return NO_SPACE_LANGS.has(base) || NO_SPACE_LANGS.has(full);
+}
+
+function isCJK(lang: string): boolean {
+  const { base, full } = langKeys(lang);
+  return CJK_LANGS.has(base) || CJK_LANGS.has(full);
+}
+
+/** Whether the runtime has a usable Intl.Segmenter. */
+function hasSegmenter(): boolean {
+  return (
+    typeof Intl !== "undefined" &&
+    typeof (Intl as any).Segmenter === "function"
+  );
+}
+
+/** Build an Intl.Segmenter, tolerant of an unknown locale (falls back to
+ *  undefined locale, which still segments by Unicode script properties). */
+function makeSegmenter(
+  lang: string,
+  granularity: "word" | "grapheme"
+): any | null {
+  if (!hasSegmenter()) return null;
+  const { base } = langKeys(lang);
+  try {
+    return new (Intl as any).Segmenter(base || undefined, { granularity });
+  } catch {
+    try {
+      return new (Intl as any).Segmenter(undefined, { granularity });
+    } catch {
+      return null;
+    }
+  }
+}
+
+/** Split into grapheme clusters (combining marks stay attached to their base).
+ *  Uses Intl.Segmenter grapheme granularity when present; otherwise a
+ *  best-effort code-POINT split (still better than UTF-16 unit splitting). */
+export function graphemeClusters(text: string): string[] {
+  const seg = makeSegmenter("und", "grapheme");
+  if (seg) {
+    return [...seg.segment(text)].map((s: any) => s.segment).filter(Boolean);
+  }
+  // Code-point fallback: Array.from respects surrogate pairs (not combining
+  // marks, but far safer than text.split("")).
+  return Array.from(text);
+}
+
+/** True if a segment carries at least one letter/number (script-agnostic).
+ *  Used as the word-like filter for space-delimited scripts so pure-punctuation
+ *  segments ("," "—" "…") don't become catchable notes. */
+function looksWordLike(s: string): boolean {
+  // \p{L} letters, \p{N} numbers — across ALL scripts.
+  return /[\p{L}\p{N}]/u.test(s);
+}
+
+/**
+ * Segment a phrase into the ORDERED catchable units for `lang`.
+ *
+ * Always returns at least the trimmed whole phrase as one unit when it cannot
+ * do better (never returns []), so a round is never silently empty — but for
+ * every supported script it returns the natural multi-unit split.
+ */
+export function segmentPhrase(text: string, lang: string): string[] {
+  const raw = (text || "").trim();
+  if (!raw) return [];
+
+  const seg = makeSegmenter(lang, "word");
+
+  // ---- Path A: Intl.Segmenter available -------------------------------------
+  if (seg) {
+    const segments = [...seg.segment(raw)];
+    const noSpace = isNoSpace(lang);
+
+    // For no-space scripts the segmenter doesn't mark CJK runs as isWordLike
+    // reliably, so we keep every non-blank segment; for space-delimited scripts
+    // we filter to word-like segments (drops standalone punctuation/space).
+    const units = segments
+      .map((s: any) => s.segment as string)
+      .map((u) => u.trim())
+      .filter(Boolean)
+      .filter((u) => (noSpace ? true : looksWordLike(u)));
+
+    // CJK safety net: if word-segmentation collapsed to ONE giant run (some
+    // engines return the whole phrase for short CJK), fall back to per-char so
+    // the phrase is still playable as a hanzi/kana sequence (reading mode).
+    if (isCJK(lang) && units.length <= 1 && [...raw].length > 1) {
+      return cjkCharUnits(raw);
+    }
+
+    // Thai/SE-Asian safety net: same collapse guard, grapheme-cluster-safe.
+    if (noSpace && units.length <= 1 && graphemeClusters(raw).length > 1) {
+      return graphemeClusters(raw).filter((g) => g.trim());
+    }
+
+    if (units.length) return units;
+    // Fall through to the no-Segmenter heuristics if filtering emptied it.
+  }
+
+  // ---- Path B: no Intl.Segmenter (or it produced nothing usable) ------------
+  // Space-delimited phrase → split on whitespace.
+  if (/\s/.test(raw)) {
+    return raw
+      .split(/\s+/)
+      .map((w) => w.trim())
+      .filter(Boolean);
+  }
+  // No spaces → CJK gets per-character, everything else per grapheme cluster.
+  if (isCJK(lang)) return cjkCharUnits(raw);
+  const clusters = graphemeClusters(raw).filter((g) => g.trim());
+  return clusters.length ? clusters : [raw];
+}
+
+/** Per-character CJK units (each hanzi/kana is one catchable note), built on
+ *  grapheme clusters so a rare combining mark stays attached. Drops blanks. */
+function cjkCharUnits(text: string): string[] {
+  return graphemeClusters(text).filter((g) => g.trim());
+}
+
+// ---------------------------------------------------------------------------
+// Per-script FONT fallback stacks.
+// ---------------------------------------------------------------------------
+//
+// The neon display face (Russo One / Lato) is Latin-only, so CJK / Thai /
+// Arabic / Hebrew / Devanagari render as TOFU (□□□) on the canvas AND in the
+// DOM strip. Lingo Hero is fully offline (no remote fonts), so we lean on the
+// platform's OWN system fonts, which DO carry these scripts on every shipping
+// device (iOS/Android/macOS/Windows). We never vendor large CJK/Thai files.
+//
+// Each stack starts with the Latin display face (so Latin text still gets the
+// branded look) then appends the most likely on-device system fonts for that
+// script, ending in `sans-serif` so the OS picks something with coverage.
+
+const FONT_LATIN = "'Russo One', 'Lingo Sans', system-ui, sans-serif";
+
+/** System fonts that ship with the relevant script, per platform. */
+const SCRIPT_FALLBACKS: Record<string, string> = {
+  // CJK — Apple (PingFang/Hiragino), Android/Linux (Noto CJK), Windows (MS/Yu).
+  cjk:
+    "'PingFang SC', 'PingFang TC', 'Hiragino Sans', 'Hiragino Kaku Gothic ProN', " +
+    "'Noto Sans CJK SC', 'Noto Sans CJK JP', 'Noto Sans SC', 'Noto Sans JP', " +
+    "'Microsoft YaHei', 'Yu Gothic', 'Source Han Sans', sans-serif",
+  // Thai / Lao / Khmer / Burmese. ('Noto Looped Thai/Lao' is the common Linux
+  // package name; Apple ships 'Thonburi', Windows 'Leelawadee UI'.)
+  thai:
+    "'Thonburi', 'Noto Sans Thai', 'Noto Looped Thai', 'Leelawadee UI', " +
+    "'Noto Sans Lao', 'Noto Looped Lao', 'Noto Sans Khmer', 'Noto Sans Myanmar', " +
+    "sans-serif",
+  // Arabic / Persian / Urdu.
+  arabic:
+    "'Geeza Pro', 'SF Arabic', 'Noto Sans Arabic', 'Noto Naskh Arabic', " +
+    "'Noto Kufi Arabic', 'Segoe UI', 'Tahoma', sans-serif",
+  // Hebrew.
+  hebrew:
+    "'Arial Hebrew', 'SF Hebrew', 'Noto Sans Hebrew', 'Noto Rashi Hebrew', " +
+    "'Segoe UI', 'Tahoma', sans-serif",
+  // Devanagari + common Indic (Hindi, Marathi, …).
+  devanagari:
+    "'Kohinoor Devanagari', 'Devanagari Sangam MN', 'Noto Sans Devanagari', " +
+    "'Lohit Devanagari', 'Nirmala UI', sans-serif",
+  // Bengali, Tamil, Telugu, etc. — broad Noto Indic net.
+  indic:
+    "'Noto Sans Bengali', 'Noto Sans Tamil', 'Noto Sans Telugu', " +
+    "'Noto Sans Kannada', 'Noto Sans Malayalam', 'Noto Sans Gujarati', " +
+    "'Nirmala UI', sans-serif",
+};
+
+/** Map a language code to its script-fallback bucket key (or null = Latin). */
+function scriptBucket(lang: string): keyof typeof SCRIPT_FALLBACKS | null {
+  const { base } = langKeys(lang);
+  if (CJK_LANGS.has(base) || base === "ko") return "cjk";
+  if (base === "th" || base === "lo" || base === "km" || base === "my")
+    return "thai";
+  if (base === "ar" || base === "fa" || base === "ur" || base === "ps")
+    return "arabic";
+  if (base === "he" || base === "yi") return "hebrew";
+  if (base === "hi" || base === "mr" || base === "ne" || base === "sa")
+    return "devanagari";
+  if (
+    base === "bn" ||
+    base === "ta" ||
+    base === "te" ||
+    base === "kn" ||
+    base === "ml" ||
+    base === "gu" ||
+    base === "pa" ||
+    base === "si" ||
+    base === "or"
+  )
+    return "indic";
+  return null;
+}
+
+/**
+ * The canvas/DOM font stack for `lang`: the Latin display face first (branded
+ * look preserved for Latin), then the on-device system fonts that actually
+ * carry the script — so non-Latin glyphs render instead of tofu, fully offline.
+ */
+export function scriptFontStack(lang: string): string {
+  const bucket = scriptBucket(lang);
+  if (!bucket) return FONT_LATIN;
+  return `${FONT_LATIN}, ${SCRIPT_FALLBACKS[bucket]}`;
+}

--- a/corpan/packs/lingo-hero/src/styles.css
+++ b/corpan/packs/lingo-hero/src/styles.css
@@ -800,6 +800,117 @@ canvas {
   font-weight: 900;
 }
 
+/* =========================================================================
+   PER-SCRIPT FONT FALLBACKS (issue #463)
+   The branded display/body faces (Lato) are Latin-only, so non-Latin target
+   scripts render as TOFU (□□□) on the prompt AND the assembling strip. Lingo
+   Hero is fully OFFLINE (no remote fonts), so we lean on the platform's OWN
+   system fonts, which carry these scripts on every shipping device. We never
+   vendor large CJK/Thai files. The canvas note cards get the same treatment in
+   Renderer.ts via scriptFontStack() — single-sourced intent in src/segment.ts.
+   Each stack keeps the Latin display face FIRST (branded Latin), then the
+   on-device system fonts that actually carry the script.
+   ========================================================================= */
+
+/* --- CJK (Chinese, Japanese, Korean) --- */
+[data-lang="zh"] .question-box,
+[data-lang="zh"] .lh-chip,
+[data-lang="ja"] .question-box,
+[data-lang="ja"] .lh-chip,
+[data-lang="ko"] .question-box,
+[data-lang="ko"] .lh-chip {
+  font-family:
+    "Russo One", "Lingo Sans", "PingFang SC", "PingFang TC", "Hiragino Sans",
+    "Hiragino Kaku Gothic ProN", "Noto Sans CJK SC", "Noto Sans CJK JP",
+    "Noto Sans SC", "Noto Sans JP", "Microsoft YaHei", "Yu Gothic",
+    "Source Han Sans", system-ui, sans-serif;
+}
+
+/* --- Thai + SE Asian no-space (Lao, Khmer, Burmese) --- */
+[data-lang="th"] .question-box,
+[data-lang="th"] .lh-chip,
+[data-lang="lo"] .question-box,
+[data-lang="lo"] .lh-chip,
+[data-lang="km"] .question-box,
+[data-lang="km"] .lh-chip,
+[data-lang="my"] .question-box,
+[data-lang="my"] .lh-chip {
+  font-family:
+    "Russo One", "Lingo Sans", "Thonburi", "Noto Sans Thai", "Noto Looped Thai",
+    "Leelawadee UI", "Noto Sans Lao", "Noto Looped Lao", "Noto Sans Khmer",
+    "Noto Sans Myanmar", system-ui, sans-serif;
+  /* Thai stacks combining vowels/tones above + below — give them headroom. */
+  line-height: 1.5;
+}
+
+/* --- Arabic / Persian / Urdu (RTL) --- */
+[data-lang="ar"] .lh-chip,
+[data-lang="fa"] .lh-chip,
+[data-lang="ur"] .lh-chip,
+[data-lang="fa"] .question-box,
+[data-lang="ur"] .question-box {
+  font-family:
+    "Lingo Sans", "Geeza Pro", "SF Arabic", "Noto Sans Arabic",
+    "Noto Naskh Arabic", "Segoe UI", "Tahoma", system-ui, sans-serif;
+}
+/* ar already sets font-body above; ensure the strip chip matches it. */
+[data-lang="ar"] .lh-chip {
+  font-family:
+    "Lingo Sans", "Geeza Pro", "SF Arabic", "Noto Sans Arabic",
+    "Noto Naskh Arabic", "Segoe UI", "Tahoma", system-ui, sans-serif;
+}
+
+/* --- Hebrew (RTL) --- */
+[data-lang="he"] .lh-chip,
+[data-lang="he"] .question-box {
+  font-family:
+    "Lingo Sans", "Arial Hebrew", "SF Hebrew", "Noto Sans Hebrew", "Segoe UI",
+    "Tahoma", system-ui, sans-serif;
+}
+
+/* --- Devanagari (Hindi, Marathi, …) --- */
+[data-lang="hi"] .question-box,
+[data-lang="hi"] .lh-chip,
+[data-lang="mr"] .question-box,
+[data-lang="mr"] .lh-chip {
+  font-family:
+    "Russo One", "Lingo Sans", "Kohinoor Devanagari", "Devanagari Sangam MN",
+    "Noto Sans Devanagari", "Lohit Devanagari", "Nirmala UI", system-ui,
+    sans-serif;
+  /* Devanagari matras/conjuncts stack — a touch more leading reads cleaner. */
+  line-height: 1.45;
+}
+
+/* --- Other Indic (Bengali, Tamil, Telugu, …) — broad Noto Indic net --- */
+[data-lang="bn"] .question-box,
+[data-lang="bn"] .lh-chip,
+[data-lang="ta"] .question-box,
+[data-lang="ta"] .lh-chip,
+[data-lang="te"] .question-box,
+[data-lang="te"] .lh-chip,
+[data-lang="kn"] .question-box,
+[data-lang="kn"] .lh-chip,
+[data-lang="ml"] .question-box,
+[data-lang="ml"] .lh-chip,
+[data-lang="gu"] .question-box,
+[data-lang="gu"] .lh-chip {
+  font-family:
+    "Russo One", "Lingo Sans", "Noto Sans Bengali", "Noto Sans Tamil",
+    "Noto Sans Telugu", "Noto Sans Kannada", "Noto Sans Malayalam",
+    "Noto Sans Gujarati", "Nirmala UI", system-ui, sans-serif;
+  line-height: 1.45;
+}
+
+/* The assembling strip must follow RTL reading order for RTL targets. The Hud
+   sets dir="rtl" on the container, and flex honors it (right-to-left visual
+   order = logical caught order). Make that explicit + keep chips upright. */
+[data-lang="ar"] .lh-assemble,
+[data-lang="he"] .lh-assemble,
+[data-lang="fa"] .lh-assemble,
+[data-lang="ur"] .lh-assemble {
+  direction: rtl;
+}
+
 /* (in-game audio replay / "tap to hear" control removed — the prompt is now a
    plain display label; the TARGET word is still spoken on catch.) */
 

--- a/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
+++ b/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
@@ -756,6 +756,109 @@ async function collectRoundTargets(p, wantRounds) {
   await rp.close();
 }
 
+// =============================================================================
+// Issue #463 — SCRIPT-AWARE tokenization + offline glyph rendering.
+// These are the REGRESSION TEETH for the languages the old whitespace-only
+// split left completely UNPLAYABLE. For each target script we drive the real
+// game with REAL phrases and prove: (1) the phrase SEGMENTS into >= 2 catchable
+// units (the old code yielded ZERO units for no-space scripts → bricked round),
+// (2) catching the correct next unit at the strum line SCORES (genuinely
+// playable, not just non-crashing), (3) the note glyphs RENDER (an offscreen
+// script-font render of a unit has real ink — guards the per-script offline
+// font fallback against tofu), and for RTL (ar) the assembling strip is dir=rtl.
+// =============================================================================
+const harnessScript = (lang) => "file://" + join(here, `harness-script.html?lang=${lang}`);
+
+// Offscreen ink count of `text` in `font` — 0 ≈ tofu/blank; >12 = real glyphs.
+async function unitInk(p, text, font) {
+  return p.evaluate(([text, font]) => {
+    const c = document.createElement("canvas");
+    c.width = 256; c.height = 64;
+    const x = c.getContext("2d");
+    x.clearRect(0, 0, c.width, c.height);
+    x.fillStyle = "#fff"; x.textBaseline = "middle"; x.font = `bold 34px ${font}`;
+    x.fillText(text, 4, 32);
+    const d = x.getImageData(0, 0, c.width, c.height).data;
+    let ink = 0;
+    for (let i = 3; i < d.length; i += 4) if (d[i] > 24) ink++;
+    return ink;
+  }, [text, font]);
+}
+
+// Acceptance gate (zh/ja/th) + RTL/Indic must-also-work (ar/hi).
+const SCRIPT_CASES = [
+  { lang: "zh", font: "'Noto Sans CJK SC', sans-serif", rtl: false },
+  { lang: "ja", font: "'Noto Sans CJK JP', sans-serif", rtl: false },
+  { lang: "th", font: "'Noto Sans Thai', 'Noto Looped Thai', sans-serif", rtl: false },
+  { lang: "ar", font: "'Noto Sans Arabic', sans-serif", rtl: true },
+  { lang: "hi", font: "'Noto Sans Devanagari', 'Lohit Devanagari', sans-serif", rtl: false },
+];
+
+for (const tc of SCRIPT_CASES) {
+  const sp = await browser.newPage({ viewport: { width: 390, height: 844 }, deviceScaleFactor: 2 });
+  sp.on("pageerror", (e) => fail(`pageerror(${tc.lang}): ${e.message}`));
+  await sp.goto(harnessScript(tc.lang));
+  await sp.waitForFunction(() => !!window.__lingoHero, { timeout: 10000 });
+  await sp.evaluate(() => document.fonts && document.fonts.ready);
+  await sp.evaluate(() => {
+    const b = [...document.querySelectorAll("button")].find((x) => /practice/i.test(x.textContent || ""));
+    if (b) b.click(); else window.__lingoHero.startGame("PRACTICE");
+  });
+  await sp.waitForFunction(() => (window.__lingoHero.notes || []).length > 0, { timeout: 10000 });
+
+  // (1) SEGMENT — >= 2 units for a multi-word phrase (the core #463 fix).
+  const r = await sp.evaluate(() => {
+    const rd = window.__lingoHero.round;
+    return rd ? { lang: rd.targetLang, text: rd.targetText, words: rd.targetWords } : null;
+  });
+  if (!r) fail(`#463[${tc.lang}]: no round produced`);
+  else {
+    if (r.lang !== tc.lang) fail(`#463[${tc.lang}]: target lang was '${r.lang}'`);
+    if (!Array.isArray(r.words) || r.words.length < 2)
+      fail(`#463[${tc.lang}]: phrase did NOT segment into >=2 catchable units (got ${JSON.stringify(r.words)} for "${r.text}") — the old whitespace split bricked this script`);
+    else console.log(`OK: #463[${tc.lang}] segmented "${r.text}" into ${r.words.length} units ${JSON.stringify(r.words)}`);
+
+    // (3) RENDER — the first unit has real script ink (not tofu/blank).
+    const ink = await unitInk(sp, r.words[0], tc.font);
+    if (!(ink > 12)) fail(`#463[${tc.lang}]: unit "${r.words[0]}" rendered with ~no ink in its script font (tofu): ink=${ink}`);
+    else console.log(`OK: #463[${tc.lang}] unit "${r.words[0]}" renders real glyphs (${ink}px ink)`);
+
+    // RTL strip direction (ar).
+    if (tc.rtl) {
+      const dir = await sp.evaluate(() => {
+        const s = document.querySelector(".lh-assemble");
+        return s ? (s.getAttribute("dir") || getComputedStyle(s).direction) : null;
+      });
+      if (dir !== "rtl") fail(`#463[${tc.lang}]: assembling strip not RTL (dir=${dir})`);
+      else console.log(`OK: #463[${tc.lang}] assembling strip dir=rtl`);
+    }
+
+    // (2) PLAY — catching the correct next unit at the strum line SCORES.
+    let scored = false;
+    const before = await sp.evaluate(() => window.__lingoHero.score);
+    const dl = Date.now() + 12000;
+    while (Date.now() < dl && !scored) {
+      const st = await sp.evaluate(() => {
+        const g = window.__lingoHero, ls = g.laneSystem, rr = g.canvas.getBoundingClientRect();
+        const strumY = ls.getStrumLineY();
+        const t = (g.notes || []).find((n) => n.isTarget && n.seqIndex === g.caughtCount && !n.hit && !n.missed);
+        return t && t.y >= strumY - 46 && t.y <= strumY + 46
+          ? { click: { x: rr.left + ls.getLaneX(t.lane), y: rr.top + strumY } } : { click: null };
+      });
+      if (st.click) {
+        await sp.mouse.click(st.click.x, st.click.y);
+        await sp.waitForTimeout(90);
+        if ((await sp.evaluate(() => window.__lingoHero.score)) > before) scored = true;
+      }
+      await sp.waitForTimeout(70);
+    }
+    if (!scored) fail(`#463[${tc.lang}]: could NOT catch a unit to score — script is not playable`);
+    else console.log(`OK: #463[${tc.lang}] catching the correct unit SCORED (playable)`);
+  }
+  await sp.screenshot({ path: join(outDir, `script-${tc.lang}.png`) });
+  await sp.close();
+}
+
 // --- iOS AUDIO UNLOCK WIRING (issue #428). -----------------------------------
 // We CANNOT verify real iOS audio OUTPUT headlessly, so we verify the WIRING:
 // the AudioContext must NOT be running before any user gesture (it is lazy — no

--- a/corpan/packs/lingo-hero/test/e2e/harness-script.html
+++ b/corpan/packs/lingo-hero/test/e2e/harness-script.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<!--
+  Script-aware target-language harness (issue #463). The stack is
+  ["en", TARGET] where TARGET is taken from ?lang=zh|ja|th|ar|he|hi (default zh),
+  so the prompt is English (known) and the catchable TARGET is a real no-space /
+  RTL / Indic phrase. Every entry carries en + the target language, with REAL
+  phrases in each script. `host.speak` records the (lang, text) it is asked to
+  speak so the test can prove TTS gets the RAW target unit. Run `npm run build`.
+-->
+<html>
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="../../dist/app.css" />
+<style>
+  html, body { margin: 0; padding: 0; height: 100%; background: #07060f; }
+  #host { position: static; margin: 90px 0 0 70px; width: 360px; height: 720px; }
+</style>
+</head>
+<body>
+<div id="host"></div>
+<script>window.__corpanHostActive = true;</script>
+<script src="../../dist/app.js"></script>
+<script>
+  const params = new URLSearchParams(location.search);
+  const LANG = params.get("lang") || "zh";
+
+  // REAL phrases per script. [en, target]. Multiple rows so the distractor pool
+  // is populated and we can sample several rounds.
+  const BANK = {
+    zh: [
+      ["I love learning Chinese", "我爱学习中文"],
+      ["good morning", "早上好"],
+      ["thank you very much", "非常感谢你"],
+      ["where is the station", "车站在哪里"],
+      ["the weather is nice today", "今天天气很好"],
+      ["I would like a coffee", "我想要一杯咖啡"],
+    ],
+    ja: [
+      ["I study Japanese", "私は日本語を勉強します"],
+      ["good morning", "おはようございます"],
+      ["thank you very much", "どうもありがとうございます"],
+      ["where is the station", "駅はどこですか"],
+      ["the weather is nice today", "今日はいい天気です"],
+      ["I would like a coffee", "コーヒーをください"],
+    ],
+    th: [
+      ["I love learning Thai", "ฉันรักการเรียนภาษาไทย"],
+      ["good morning", "สวัสดีตอนเช้า"],
+      ["thank you very much", "ขอบคุณมากครับ"],
+      ["where is the station", "สถานีอยู่ที่ไหน"],
+      ["the weather is nice today", "วันนี้อากาศดี"],
+      ["I would like a coffee", "ฉันอยากได้กาแฟ"],
+    ],
+    ar: [
+      ["I love learning Arabic", "أنا أحب تعلم اللغة العربية"],
+      ["good morning", "صباح الخير"],
+      ["thank you very much", "شكرا جزيلا لك"],
+      ["where is the station", "أين المحطة"],
+      ["the weather is nice today", "الطقس جميل اليوم"],
+      ["I would like a coffee", "أريد فنجان قهوة"],
+    ],
+    he: [
+      ["I love learning Hebrew", "אני אוהב ללמוד עברית"],
+      ["good morning", "בוקר טוב"],
+      ["thank you very much", "תודה רבה לך"],
+      ["where is the station", "איפה התחנה"],
+      ["the weather is nice today", "מזג האוויר נחמד היום"],
+      ["I would like a coffee", "אני רוצה כוס קפה"],
+    ],
+    hi: [
+      ["I love learning Hindi", "मुझे हिंदी सीखना पसंद है"],
+      ["good morning", "सुप्रभात मित्र"],
+      ["thank you very much", "आपका बहुत बहुत धन्यवाद"],
+      ["where is the station", "स्टेशन कहाँ है"],
+      ["the weather is nice today", "आज मौसम अच्छा है"],
+      ["I would like a coffee", "मुझे एक कॉफ़ी चाहिए"],
+    ],
+  };
+
+  const ROWS = BANK[LANG] || BANK.zh;
+  const ENTRIES = ROWS.map(([en, tgt], i) => ({
+    entry_id: i + 1, level: "A1", domains: ["travel"],
+    translations: [
+      { language_code: "en", text: en },
+      { language_code: LANG, text: tgt },
+    ],
+  }));
+
+  let k = 0;
+  window.__spoken = []; // {lang, text} log so the test can verify RAW target TTS.
+  const host = {
+    speak(lang, text) { window.__spoken.push({ lang, text }); },
+    stopSpeech() {},
+    getStackConfig() {
+      return { languages: ["en", LANG], domains: [], levels: [], rate: 1, textSize: "m", showRomanization: false };
+    },
+    onStackConfigChange() { return () => {}; },
+    getRandomEntries(n) { const o = []; for (let i = 0; i < n; i++) o.push(ENTRIES[(k++) % ENTRIES.length]); return Promise.resolve(o); },
+    getRandomEntry() { return Promise.resolve(ENTRIES[(k++) % ENTRIES.length]); },
+    isMock: true,
+  };
+  window.CorpanGames.lingo_hero.mount(document.getElementById("host"), host);
+</script>
+</body>
+</html>


### PR DESCRIPTION
### **User description**
Closes #463.

Chinese (zh), Japanese (ja), and Thai (th) were **operator-confirmed completely unplayable**. Two root causes, both fixed:

1. **Tokenization was whitespace-only** → a no-space script (CJK, Thai) produced ZERO catchable units and the round bricked.
2. **The neon display face (Russo One / Lato) is Latin-only** → zh/ja/th/ar/he/Devanagari rendered as TOFU on the canvas note cards + DOM strip.

## What changed
- **New reusable OFFLINE segmenter `src/segment.ts`** — `segmentPhrase(text, lang)` + `scriptFontStack(lang)`, built on the built-in `Intl.Segmenter`. Shared with beatlounge (#465).
  - Space-delimited (Latin/Cyrillic/Greek): word granularity, word-like filtered (≈ prior behavior, punctuation-aware).
  - CJK no-space (zh/ja): word granularity → meaningful multi-char units; per-character fallback when the segmenter returns one giant run (so a phrase is always playable as a hanzi/kana sequence — reading mode).
  - Thai + SE Asian no-space (th/lo/km/my): word granularity, **grapheme-cluster-safe** — a combining vowel/tone mark is never split off its base.
  - Indic (hi/bn/…): space-split words, conjuncts/matras kept intact.
  - Fallback if `Intl.Segmenter` missing: space-split if spaces present, else per grapheme-cluster.
- **`ContentManager`** uses `segmentPhrase` for both target units and distractor pool (answer dedup preserved; RAW target unit still spoken by TTS).
- **`Renderer.setActiveLang`** selects the per-script canvas font stack; **Game** syncs it on mount + each per-round target change. CSS adds matching `[data-lang]` system-font fallbacks on `.question-box` + `.lh-chip`. No large CJK/Thai fonts vendored — on-device system fonts carry these scripts.
- **RTL** assembling strip (ar/he/fa/ur) follows logical reading order with `dir=rtl`.

## Faithful verification (acceptance gate zh/ja/th + must-also-work ar/he/hi)
Drove the **real built game** in headless Chromium with REAL phrases in each script and proved, per language: segments into ≥2 sensible units · catching the correct unit at the strum line SCORES (genuinely playable) · note glyphs render with real ink (not tofu) · two distinct units render distinct glyphs · TTS speaks the RAW target-script unit · ar/he strip `dir=rtl` · Thai combining marks intact (no orphan-mark unit).

| lang | segments | plays (scores) | renders (no tofu) | RTL | TTS raw unit |
|------|----------|----------------|-------------------|-----|--------------|
| zh | ✅ e.g. `车站在哪里` → `车站 / 在 / 哪里` | ✅ | ✅ | — | ✅ |
| ja | ✅ e.g. `私は日本語を勉強します` → 7 units | ✅ | ✅ | — | ✅ |
| th | ✅ e.g. `สถานีอยู่ที่ไหน` → `สถานี / อยู่ / ที่ไหน` | ✅ | ✅ (marks intact) | — | ✅ |
| ar | ✅ e.g. `شكرا جزيلا لك` → 3 units | ✅ | ✅ | ✅ | ✅ |
| he | ✅ e.g. `אני רוצה כוס קפה` → 4 units | ✅ | ✅ | ✅ | ✅ |
| hi | ✅ e.g. `सुप्रभात मित्र` → 2 units | ✅ | ✅ | — | ✅ |

Real-game screenshots (worktree) confirm real glyphs on multiple distinct note cards for all six — no tofu, no one-giant-unit, RTL HUD mirrored for ar/he. A tailscale repro that mounts the live game with a per-script switcher is staged for the operator at `/tmp/lh-script-repro/`.

## Gates
- `npm run typecheck` ✅ · `npm run build` ✅
- e2e `test/e2e/gameplay.spec.mjs` **PASS** (exit 0), including the new #463 zh/ja/th/ar/hi regression teeth + all pre-existing contracts.

## Preserved contracts
Answer dedup (distractors are distinct real target units) · TTS speaks the raw target unit · #407 language rule incl. 1-language READING mode (catch hanzi in sequence) · canvas-relative input · delta-timed · 0.4.8 prompt-fit + HUD · `window.__lingoHero`.

Preview channel. Bumps manifest 0.4.8 → 0.4.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Adds script-aware target segmentation

- Fixes offline non-Latin glyph rendering

- Applies RTL strip direction handling

- Adds multilingual regression coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  input["Target phrase and language"]
  segmenter["Intl.Segmenter script-aware units"]
  content["Round targets and distractors"]
  fonts["Per-script font stack"]
  render["Canvas notes and DOM strip"]
  tests["Multilingual e2e verification"]
  input -- "segment" --> segmenter
  segmenter -- "feeds" --> content
  fonts -- "renders" --> render
  content -- "plays" --> render
  render -- "verified by" --> tests
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>ContentManager.ts</strong><dd><code>Uses script-aware target and distractor tokenization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/482/files#diff-7f7f66aa0a0ab0785ba8e14b6eec2a3c527ed1175293a5030a3dcadd1575ed52">+16/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Game.ts</strong><dd><code>Syncs renderer font with active language</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/482/files#diff-6c075e8c51d32e4e5452a4c738f6cc530345361455286e0f7d1af37f46fedde7">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>styles.css</strong><dd><code>Adds non-Latin DOM font fallbacks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/482/files#diff-b9b9a82cd5a6b2fe32239b2b4b2f069c2c4853d63db1736b575103a5d1daf226">+111/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>Renderer.ts</strong><dd><code>Adds per-language canvas note font stacks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/482/files#diff-a8ca1f488ce07a5bfdd1fbb0851ce6f79a8731c3dacfe7d692d733838b839a53">+19/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>segment.ts</strong><dd><code>Introduces reusable multilingual segmentation utilities</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/482/files#diff-2453a9e0c4df00d2b53a78d0050e4a9cb83950775e03f7370dfdb7ac0b074b06">+266/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>harness-script.html</strong><dd><code>Adds multilingual script regression harness page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/482/files#diff-b36dd85481dda5c9df463bbde1f999e19e20610e7d79b5d555724393c844a3bb">+105/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>gameplay.spec.mjs</strong><dd><code>Adds e2e checks for script support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/482/files#diff-5ee22f0c6a817c0427478004e2238facf99cd3c18591eda51d590170655a3c57">+103/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Documents version 0.4.9 script fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/482/files#diff-dd09bf20e11864991961b7ef6d2fc6687a66d9a9de2d246f765d9d6891e646c2">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>manifest.json</strong><dd><code>Bumps preview manifest version and revision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/482/files#diff-38411e79d50eee7f8ad439a29518dcddf16cdc9cd03739fc81ea212f18519b15">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

