### PR TITLE
Lingo Hero 0.4.9: fix the REAL comma truncation (cleanPrompt) — #460

### DIFF
--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.10] - 2026-06-24
+
+THE actual comma-truncation fix (#460). The prompt was being chopped at the
+first comma by `Game.cleanPrompt()` — `if (len > 28 && includes(",")) clean =
+clean.split(",")[0]` — so "I dropped an egg, and the floor got slippery" rendered
+as "I dropped an egg". It was a CONTENT truncation, not CSS/layout: 0.4.3/0.4.6/
+0.4.8 all chased the wrong layer, and the repro harness injected the full phrase
+straight into `setQuestion` (bypassing `cleanPrompt`), so it never reproduced.
+Removed the truncation — the prompt always keeps the full phrase and wraps/auto-
+fits. Added an e2e assertion against the real `cleanPrompt` path. Preview channel.
+
 ## [0.4.9] - 2026-06-24
 
 Script-aware tokenization + offline glyph rendering — the correctness fix that

--- a/corpan/packs/lingo-hero/manifest.json
+++ b/corpan/packs/lingo-hero/manifest.json
@@ -2,7 +2,7 @@
   "id": "lingo_hero",
   "channel": "preview",
   "name": "Lingo Hero",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Catch the translation. The phrase you know falls as a chart of timed notes in the language you're learning — catch each word in rhythm, in order, and hear it spoken.",
   "entry": "dist/app.js",
   "styles": [

--- a/corpan/packs/lingo-hero/src/Game.ts
+++ b/corpan/packs/lingo-hero/src/Game.ts
@@ -477,18 +477,22 @@ export class Game {
   }
 
   /**
-   * Clean a phrase for DISPLAY at the prompt. Strips parenthetical glosses and,
-   * for long comma-listed glosses, keeps the first sense. The TARGET words are
-   * NOT cleaned this way (they fall verbatim so the assembled translation is
-   * faithful), only the primary-language prompt label.
+   * Clean a phrase for DISPLAY at the prompt. Strips parenthetical glosses and
+   * capitalizes — and ALWAYS keeps the FULL phrase. The prompt wraps + auto-fits
+   * (Hud.fitPrompt), so a long, comma-containing sentence shows in full.
+   *
+   * We used to chop everything after the first comma on phrases >28 chars
+   * (`clean.split(",")[0]`). That silently dropped half of any real sentence —
+   * e.g. "I dropped an egg, and the floor got slippery" rendered as just
+   * "I dropped an egg". That was the operator's recurring "comma truncation"
+   * (mis-diagnosed as a CSS/layout clip three times; it was here all along).
+   * NEVER truncate the prompt. The TARGET words are NOT cleaned this way (they
+   * fall verbatim so the assembled translation is faithful).
    */
   private cleanPrompt(text: string): string {
-    let clean = text.replace(/\s*\(.*?\)\s*/g, "").trim();
-    if (clean.length > 28 && clean.includes(",")) {
-      clean = clean.split(",")[0].trim();
-    }
+    const clean = text.replace(/\s*\(.*?\)\s*/g, "").trim();
     if (clean.length > 0 && /^[a-z]/.test(clean)) {
-      clean = clean.charAt(0).toUpperCase() + clean.slice(1);
+      return clean.charAt(0).toUpperCase() + clean.slice(1);
     }
     return clean;
   }

--- a/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
+++ b/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
@@ -49,6 +49,27 @@ await page.waitForFunction(() => !!window.__lingoHero, { timeout: 10000 });
 await page.waitForTimeout(300);
 await page.screenshot({ path: join(outDir, "menu.png") });
 
+// #460/#467 — REGRESSION: the prompt MUST NOT be truncated at a comma. The real
+// game runs the primary-language phrase through cleanPrompt() before setQuestion;
+// it used to chop everything after the first comma on phrases >28 chars, dropping
+// half of any real sentence (the operator's recurring "comma truncation" that
+// three CSS "fixes" + a setQuestion-injecting harness all missed). Test the
+// ACTUAL cleanPrompt path, not an injected string.
+{
+  const longComma = "I dropped an egg, and the floor got slippery on the kitchen tiles";
+  const cleaned = await page.evaluate(
+    (p) => window.__lingoHero.cleanPrompt(p),
+    longComma
+  );
+  if (!cleaned.includes("slippery") || !cleaned.includes("floor")) {
+    fail(`cleanPrompt TRUNCATED a comma phrase — got "${cleaned}" (the post-comma clause is missing)`);
+  }
+  if (!cleaned.includes(",")) {
+    fail(`cleanPrompt dropped the comma/second clause — got "${cleaned}"`);
+  }
+  console.log("OK cleanPrompt keeps the full comma phrase");
+}
+
 const read = () => page.evaluate(() => {
   const g = window.__lingoHero, ls = g.laneSystem, r = g.canvas.getBoundingClientRect();
   return {


### PR DESCRIPTION
### **User description**
**The actual root cause of the recurring prompt truncation (#460), found after 5 reports.**

`Game.cleanPrompt()` chopped the prompt at the first comma for phrases >28 chars:
```js
if (clean.length > 28 && clean.includes(",")) clean = clean.split(",")[0].trim();
```
So "I dropped an egg, and the floor got slippery" → "I dropped an egg". It was a **content** truncation, not CSS — 0.4.3/0.4.6/0.4.8 all fixed the wrong layer, and the repro harness injected the full phrase directly into `setQuestion` (bypassing `cleanPrompt`), so it never reproduced.

**Fix:** removed the truncation; the prompt always keeps the full phrase (it already wraps/auto-fits). Added an e2e assertion against the real `cleanPrompt` path. Preview channel, 0.4.9. e2e exit 0; build clean.


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Preserve full comma-containing prompts

- Add regression coverage for `cleanPrompt`

- Document 0.4.9 comma fix

- Bump Lingo Hero preview version


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Input phrase with comma"] -- "cleanPrompt removes glosses only" --> B["Full prompt preserved"]
  B -- "Hud wraps and auto-fits" --> C["Complete sentence displayed"]
  D["E2E regression"] -- "asserts real cleanPrompt path" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Game.ts</strong><dd><code>Preserve full comma prompts in cleanPrompt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/src/Game.ts

<ul><li>Updates <code>cleanPrompt</code> documentation to clarify full prompt preservation.<br> <li> Removes the long-phrase comma split that discarded post-comma text.<br> <li> Keeps parenthetical-gloss stripping and first-letter capitalization <br>behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/483/files#diff-6c075e8c51d32e4e5452a4c738f6cc530345361455286e0f7d1af37f46fedde7">+13/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document 0.4.9 comma truncation fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/CHANGELOG.md

<ul><li>Adds the <code>0.4.9</code> changelog entry.<br> <li> Documents the <code>Game.cleanPrompt()</code> comma truncation root cause.<br> <li> Notes removal of truncation and added regression coverage.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/483/files#diff-dd09bf20e11864991961b7ef6d2fc6687a66d9a9de2d246f765d9d6891e646c2">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump preview package to 0.4.9</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/manifest.json

- Bumps Lingo Hero preview package version from `0.4.8` to `0.4.9`.


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/483/files#diff-38411e79d50eee7f8ad439a29518dcddf16cdc9cd03739fc81ea212f18519b15">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gameplay.spec.mjs</strong><dd><code>Add cleanPrompt comma regression test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs

<ul><li>Adds an e2e regression check for long comma-containing prompts.<br> <li> Calls the real <code>window.__lingoHero.cleanPrompt</code> path instead of <br>injecting prompt text.<br> <li> Fails if the post-comma clause or comma is removed.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/483/files#diff-5ee22f0c6a817c0427478004e2238facf99cd3c18591eda51d590170655a3c57">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

