### PR TITLE
fix(dja): translate_entry_batch fails loud on incomplete/failed LLM batch (#486)

### DIFF
--- a/corpan/dja/cor/utils/llm.py
+++ b/corpan/dja/cor/utils/llm.py
@@ -660,16 +660,45 @@ def translate_entry_batch(
     ]
 
     print(f"{messages}")
+    # Do NOT swallow the LLM error: a failed call must propagate, never fall
+    # through to an unbound/partial `result` (that masked the real failure with
+    # an UnboundLocalError and could persist garbage). Fail loud.
     try:
         result = llm.get_data_completion(messages, TranslationResponse)
     except Exception as e:
-        print(f"LLM translation error: {e}")
-        import traceback
-
-        traceback.print_exc()
+        raise RuntimeError(
+            f"LLM translation failed for language {lang_code} "
+            f"({len(entries)} entries): {e}"
+        ) from e
 
     print("RESULT:")
     print(result.translations)
+
+    # Reconcile-and-raise: the LLM must return exactly one translation per
+    # requested entry id (correct count AND correct ids). A short / garbled /
+    # misaligned response must fail loud, never silently bulk_create a partial
+    # or wrong-id set into the shipped DB. Mirrors the guard in
+    # cor/utils/llm_source.py:translate_source_to_english_batch.
+    requested_ids = [entry_id for entry_id, _ in entries]
+    requested_set = set(requested_ids)
+    returned_ids = [item.entry_id for item in result.translations]
+    returned_set = set(returned_ids)
+
+    missing = sorted(i for i in requested_set if i not in returned_set)
+    unknown = sorted(
+        i for i in returned_set if i is not None and i not in requested_set
+    )
+    has_null = any(i is None for i in returned_ids)
+    has_dupes = len(returned_ids) != len(returned_set)
+
+    if missing or unknown or has_null or has_dupes:
+        raise ValueError(
+            "Incomplete/misaligned translation batch for language "
+            f"{lang_code}: requested {len(requested_set)} entries, "
+            f"got {len(result.translations)} translations. "
+            f"missing_ids={missing} unknown_ids={unknown} "
+            f"null_ids={has_null} duplicate_ids={has_dupes}"
+        )
 
     objs = [
         Translation(

--- a/corpan/dja/cor/utils/test_translate_entry_batch.py
+++ b/corpan/dja/cor/utils/test_translate_entry_batch.py
@@ -1,0 +1,211 @@
+# tests/test_translate_entry_batch.py
+#
+# Regression tests for the #486 data-corruption bug in
+# cor.utils.llm.translate_entry_batch:
+#   1. A failed LLM call used to be swallowed (printed) and then fall through
+#      to an UNBOUND `result` -> UnboundLocalError masked the real failure.
+#   2. There was NO completeness/alignment check before bulk_create, so a
+#      short / garbled / misaligned LLM response silently persisted FEWER (or
+#      wrong-id) translations than requested -> languages quietly missing
+#      content in the shipped DB while the build "succeeded".
+#
+# These tests run under plain pytest. `cor.utils.llm` imports Django models
+# and a corpora_ai provider at module load, neither of which is needed to
+# exercise the reconcile-and-raise logic, so we install lightweight stubs in
+# sys.modules BEFORE importing the module under test. The LLM call itself is
+# mocked (never hits a real API).
+
+import sys
+import types
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Stub the external dependencies that cor.utils.llm imports at module load.
+# ---------------------------------------------------------------------------
+def _install_stubs():
+    # corpora_ai.llm_interface.ChatCompletionTextMessage
+    llm_interface = types.ModuleType("corpora_ai.llm_interface")
+
+    class ChatCompletionTextMessage:  # minimal stand-in
+        def __init__(self, role=None, text=None):
+            self.role = role
+            self.text = text
+
+        def __repr__(self):
+            return f"Msg({self.role!r})"
+
+    llm_interface.ChatCompletionTextMessage = ChatCompletionTextMessage
+
+    # corpora_ai.provider_loader.load_llm_provider
+    provider_loader = types.ModuleType("corpora_ai.provider_loader")
+
+    def load_llm_provider(_name):
+        # Default module-level provider; tests pass their own mock `llm=`.
+        return object()
+
+    provider_loader.load_llm_provider = load_llm_provider
+
+    corpora_ai = types.ModuleType("corpora_ai")
+    corpora_ai.llm_interface = llm_interface
+    corpora_ai.provider_loader = provider_loader
+
+    # cor.models: Domain, Entry, Language, Translation
+    cor_models = types.ModuleType("cor.models")
+
+    class _CapturingManager:
+        """Records bulk_create calls so tests can assert nothing persisted."""
+
+        def __init__(self):
+            self.bulk_created = []
+
+        def get(self, **kwargs):
+            # Language.objects.get(code=...) -> object exposing .code/.name.
+            ns = types.SimpleNamespace(**kwargs)
+            if not hasattr(ns, "name"):
+                ns.name = kwargs.get("code", "Test")
+            return ns
+
+        def bulk_create(self, objs, ignore_conflicts=False):
+            self.bulk_created.append(list(objs))
+            return objs
+
+    class Translation:
+        objects = _CapturingManager()
+
+        def __init__(self, entry_id=None, language=None, text=None):
+            self.entry_id = entry_id
+            self.language = language
+            self.text = text
+
+    class Language:
+        objects = _CapturingManager()
+
+    class Domain:
+        pass
+
+    class Entry:
+        pass
+
+    cor_models.Domain = Domain
+    cor_models.Entry = Entry
+    cor_models.Language = Language
+    cor_models.Translation = Translation
+
+    sys.modules.setdefault("corpora_ai", corpora_ai)
+    sys.modules["corpora_ai.llm_interface"] = llm_interface
+    sys.modules["corpora_ai.provider_loader"] = provider_loader
+    sys.modules["cor.models"] = cor_models
+
+
+_install_stubs()
+
+from cor.utils import llm as llm_mod  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Mock LLM provider
+# ---------------------------------------------------------------------------
+class _Item:
+    def __init__(self, entry_id, translated_text):
+        self.entry_id = entry_id
+        self.translated_text = translated_text
+
+
+class _Resp:
+    def __init__(self, items):
+        self.translations = items
+
+
+class MockLLM:
+    """Returns a canned TranslationResponse-shaped object, or raises."""
+
+    def __init__(self, items=None, raises=None):
+        self._items = items
+        self._raises = raises
+        self.calls = 0
+
+    def get_data_completion(self, messages, schema):
+        self.calls += 1
+        if self._raises is not None:
+            raise self._raises
+        return _Resp(self._items)
+
+
+@pytest.fixture(autouse=True)
+def _reset_capture():
+    # Clear any persisted state between tests.
+    llm_mod.Translation.objects.bulk_created.clear()
+    yield
+    llm_mod.Translation.objects.bulk_created.clear()
+
+
+ENTRIES = [(1, "Hello"), (2, "Goodbye"), (3, "Thanks")]
+
+
+# ---------------------------------------------------------------------------
+# Happy path: full, aligned response -> persists all, identical behavior.
+# ---------------------------------------------------------------------------
+def test_full_aligned_response_persists_all():
+    mock = MockLLM(items=[_Item(1, "Hola"), _Item(2, "Adiós"), _Item(3, "Gracias")])
+    result = llm_mod.translate_entry_batch("es", ENTRIES, llm=mock, dry_run=False)
+    assert {t.entry_id for t in result.translations} == {1, 2, 3}
+    # Exactly one bulk_create with all three rows.
+    assert len(llm_mod.Translation.objects.bulk_created) == 1
+    persisted = llm_mod.Translation.objects.bulk_created[0]
+    assert {o.entry_id for o in persisted} == {1, 2, 3}
+    assert {o.text for o in persisted} == {"Hola", "Adiós", "Gracias"}
+
+
+def test_dry_run_does_not_persist():
+    mock = MockLLM(items=[_Item(1, "Hola"), _Item(2, "Adiós"), _Item(3, "Gracias")])
+    llm_mod.translate_entry_batch("es", ENTRIES, llm=mock, dry_run=True)
+    assert llm_mod.Translation.objects.bulk_created == []
+
+
+# ---------------------------------------------------------------------------
+# Bug #1: LLM exception must propagate, NOT fall through to unbound result.
+# ---------------------------------------------------------------------------
+def test_llm_exception_raises_and_does_not_persist():
+    mock = MockLLM(raises=RuntimeError("boom: rate limited"))
+    with pytest.raises(Exception) as exc:
+        llm_mod.translate_entry_batch("es", ENTRIES, llm=mock, dry_run=False)
+    # Not an UnboundLocalError (the old masking failure).
+    assert not isinstance(exc.value, UnboundLocalError)
+    assert llm_mod.Translation.objects.bulk_created == []
+
+
+# ---------------------------------------------------------------------------
+# Bug #2: incomplete / misaligned responses must RAISE, never bulk_create.
+# ---------------------------------------------------------------------------
+def test_short_response_raises_and_does_not_persist():
+    # Missing entry id 3.
+    mock = MockLLM(items=[_Item(1, "Hola"), _Item(2, "Adiós")])
+    with pytest.raises(ValueError) as exc:
+        llm_mod.translate_entry_batch("es", ENTRIES, llm=mock, dry_run=False)
+    assert "3" in str(exc.value)
+    assert llm_mod.Translation.objects.bulk_created == []
+
+
+def test_unknown_id_raises_and_does_not_persist():
+    # Returns an id (99) that was never requested -> misalignment.
+    mock = MockLLM(items=[_Item(1, "Hola"), _Item(2, "Adiós"), _Item(99, "???")])
+    with pytest.raises(ValueError):
+        llm_mod.translate_entry_batch("es", ENTRIES, llm=mock, dry_run=False)
+    assert llm_mod.Translation.objects.bulk_created == []
+
+
+def test_null_id_raises_and_does_not_persist():
+    mock = MockLLM(items=[_Item(1, "Hola"), _Item(2, "Adiós"), _Item(None, "Gracias")])
+    with pytest.raises(ValueError):
+        llm_mod.translate_entry_batch("es", ENTRIES, llm=mock, dry_run=False)
+    assert llm_mod.Translation.objects.bulk_created == []
+
+
+def test_duplicate_id_raises_and_does_not_persist():
+    # Two rows for id 1, none for id 3 -> wrong count + dupe.
+    mock = MockLLM(items=[_Item(1, "Hola"), _Item(1, "Hola2"), _Item(2, "Adiós")])
+    with pytest.raises(ValueError):
+        llm_mod.translate_entry_batch("es", ENTRIES, llm=mock, dry_run=False)
+    assert llm_mod.Translation.objects.bulk_created == []


### PR DESCRIPTION
### **User description**
Fixes #486 (from the #484 hunt, B1 — the real find).

## The bug
`corpan/dja/cor/utils/llm.py` `translate_entry_batch`:

1. **Swallowed error.** It `catch`-and-`print`-ed the LLM exception, then fell through to an **unbound** `result` → `UnboundLocalError` masked the real failure.
2. **No completeness/alignment check** before `bulk_create(..., ignore_conflicts=True)`. A short / garbled / misaligned LLM response silently persisted **fewer (or wrong-id)** translations than requested entries — so languages quietly shipped missing content in the app DB while the build "succeeded". This is the `dry_run=False` write path (`cor/packs/service.py`, `translate_missing.py`).

## The fix — copy the guard the sibling already has
Mirrors the reconcile-and-raise in `cor/utils/llm_source.py:translate_source_to_english_batch` (the `Missing items … raise ValueError` pattern):

1. On the LLM exception, **RAISE** (`RuntimeError`) instead of falling through to an unbound/partial `result`.
2. Before persisting, **validate the response covers every requested entry id exactly once** — no missing, unknown, null, or duplicate ids. On any mismatch, **RAISE** a `ValueError` naming what's wrong. Fail loud; never `bulk_create` a partial/misaligned set into the shipped DB.
3. **Happy path unchanged**: a full, aligned response → the same `bulk_create` as before.

This is a strictly-better correctness fix: a loud failure replaces silent corpus corruption.

## Test
Adds `corpan/dja/cor/utils/test_translate_entry_batch.py` (plain-pytest style, mirroring `cor/utils/test_split.py`). The LLM is **mocked** (never hits a real API); Django models + the corpora_ai provider are stubbed in `sys.modules` so the reconcile logic is exercised in isolation:

- short response (missing id) → RAISES, **no** `bulk_create`
- unknown / extra id → RAISES, no persist
- null id → RAISES, no persist
- duplicate id (wrong count) → RAISES, no persist
- LLM raises → propagates (not `UnboundLocalError`), no persist
- full aligned response → persists all 3 (happy path)
- `dry_run=True` → persists nothing

**Verified locally:** with the pre-fix code the 5 bug-targeting tests FAIL and the 2 happy-path tests pass; with the fix all 7 pass. (Run with a throwaway venv: `pydantic` + `pytest`. Note: dja's full deps — Django, corpora_ai — are not installed on this box, so I could not run `manage.py test`; the test is self-contained via stubs and will run in CI / any dja env.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fail loud on LLM translation errors

- Validate returned translation entry alignment

- Prevent partial translation persistence

- Add mocked regression coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Requested entry batch"] --> B["LLM translation response"]
  B -- "validate ids" --> C["Completeness and alignment guard"]
  C -- "valid" --> D["bulk_create translations"]
  C -- "invalid or failed" --> E["raise exception"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>llm.py</strong><dd><code>Validate translation batches before persistence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/dja/cor/utils/llm.py

<ul><li>Converts swallowed LLM exceptions into <code>RuntimeError</code>.<br> <li> Adds requested-versus-returned entry id reconciliation.<br> <li> Rejects missing, unknown, null, or duplicate ids.<br> <li> Prevents <code>bulk_create</code> on invalid translation batches.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/488/files#diff-898b9ba1260fb31954b44b6a60a8f146047b4fc9cda0fb5c53e02b320397dd5a">+33/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_translate_entry_batch.py</strong><dd><code>Add regression tests for translation reconciliation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/dja/cor/utils/test_translate_entry_batch.py

<ul><li>Adds plain pytest regression tests with dependency stubs.<br> <li> Verifies full aligned responses still persist.<br> <li> Covers dry-run behavior without persistence.<br> <li> Ensures failed, short, misaligned, null, and duplicate responses <br>raise.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/488/files#diff-4cdde24a32e94572fc677ad764e33e504f9e15ff2dd88f328a6139fae1540150">+211/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

