### PR TITLE
Lingo Hero 0.4.12: type the __lingoHero debug surface + pause-sheet polish (#485, #490)

### DIFF
--- a/corpan/packs/lingo-hero/CHANGELOG.md
+++ b/corpan/packs/lingo-hero/CHANGELOG.md
@@ -6,6 +6,48 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.12] - 2026-06-24
+
+Hardening + chrome polish (#485, #490). A structural type fix that closes the
+cleanPrompt saga, plus the follow-up pause-sheet polish the #462 design-critic
+called out. No gameplay/contract changes.
+
+### Changed
+- **Pause-sheet rows lose the drill-in chevron (#490).** Resume / Mute / Exit are
+  TERMINAL actions, but they carried a trailing `›` that reads as "drill into a
+  submenu." Dropped the chevron on those three rows (new `terminal-action` class)
+  and centered the icon+label so they read as flat, tappable actions. The chevron
+  stays on the menu's real drill-in buttons (Practice / Blitz / Retry / Main Menu).
+- **Corner pause pill: visible pressed state + comfortable touch target (#490).**
+  The small (intentionally unobtrusive 36px) corner pill now shows a clear pressed
+  state (accent ring + lifted fill, driven by an `is-pressed` class so it is
+  reliable on touch where `:active` is flaky), and its hit area is expanded to
+  ~44px via an invisible inset overflow — the glyph stays small, the finger gets
+  room (WCAG 2.5.5 / Apple HIG).
+
+### Internal / tests
+- **Typed the `window.__lingoHero` debug surface (#485).** It was typed as
+  `{ dispose }` but is the full `Game` instance at runtime, so the e2e harness
+  reached past the type into untyped internals — exactly how the #460 cleanPrompt
+  comma-truncation hid from tests for five rounds. Declared an explicit
+  `LingoHeroDebug` introspection contract (dispose, startGame, resume, cleanPrompt,
+  score, combo, notes, caughtCount, decoyDodges, round, activeLanguage, laneSystem,
+  canvas, hud.setQuestion, audioContextState, audioUnlocked) and typed
+  `window.__lingoHero` as it, so tests call real methods (incl. `cleanPrompt`)
+  through a typed contract a future content-mangler can't hide behind. Clearly a
+  debug/introspection contract, not a public API.
+- Removed three dead exports flagged by the #484 audit (`cumulativeXpForLevel`,
+  `getDefaultWordSelector`, `laneHex`) — grep-confirmed zero importers.
+- e2e: added a **4-line worst-case prompt clearance** check on the narrowest phone
+  column (the #462 gutters can push a long phrase to one more wrap line — confirms
+  the falling-note spawn zone still clears a 4-line prompt), and assertions that
+  terminal sheet rows have no chevron while menu drill-in buttons keep theirs.
+
+### Preserved
+- #460 prompt full-visibility (long comma phrase still renders fully, e2e
+  enforced), #462 persistent-pause + no-tap-through + mute-in-sheet, #463 script
+  rendering, canvas-relative input, delta-timed motion, the typed `__lingoHero`.
+
 ## [0.4.11] - 2026-06-24
 
 Slim mobile chrome (#462). The top-left in-game chrome wasted vertical space and

--- a/corpan/packs/lingo-hero/manifest.json
+++ b/corpan/packs/lingo-hero/manifest.json
@@ -2,7 +2,7 @@
   "id": "lingo_hero",
   "channel": "preview",
   "name": "Lingo Hero",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Catch the translation. The phrase you know falls as a chart of timed notes in the language you're learning — catch each word in rhythm, in order, and hear it spoken.",
   "entry": "dist/app.js",
   "styles": [

--- a/corpan/packs/lingo-hero/src/ContentManager.ts
+++ b/corpan/packs/lingo-hero/src/ContentManager.ts
@@ -38,11 +38,6 @@ export function setDefaultWordSelector(selector: WordSelector | null): void {
   defaultSelector = selector;
 }
 
-/** Read the current default selector (mostly for tests / introspection). */
-export function getDefaultWordSelector(): WordSelector | null {
-  return defaultSelector;
-}
-
 /**
  * A single "Catch the Translation" round.
  *

--- a/corpan/packs/lingo-hero/src/effects/palette.ts
+++ b/corpan/packs/lingo-hero/src/effects/palette.ts
@@ -31,11 +31,6 @@ export function laneRgb(lane: LaneIndex | number): Rgb {
   return LANE_RGB[lane] ?? WHITE;
 }
 
-export function laneHex(lane: LaneIndex | number): string {
-  const c = laneRgb(lane);
-  return rgbToHex(c);
-}
-
 export function rgbToHex(c: Rgb): string {
   return `rgb(${c.r | 0},${c.g | 0},${c.b | 0})`;
 }

--- a/corpan/packs/lingo-hero/src/main.ts
+++ b/corpan/packs/lingo-hero/src/main.ts
@@ -2,10 +2,60 @@ import "./styles.css"
 import type { GameModule, HostApi } from "./sdk/types"
 import { createMockHostApi } from "./sdk/mockHostApi"
 import { Game } from "./Game"
+import type { Note, ActiveLanguage, GameMode } from "./types"
+import type { LaneSystem } from "./LaneSystem"
+import type { Round } from "./ContentManager"
+import type { Hud } from "./ui/Hud"
+
+/**
+ * DEBUG / INTROSPECTION CONTRACT — not a public API.
+ *
+ * At runtime `window.__lingoHero` is the FULL `Game` instance, but the e2e
+ * harness (`test/e2e/gameplay.spec.mjs`) only ever pokes at a known subset of
+ * its members — including several that are `private` on `Game` (TS `private`
+ * is erased at runtime, so JS can still read them). This interface is the
+ * EXPLICIT, TYPED list of exactly what the harness is allowed to touch, so a
+ * future content-mangler can't hide behind a too-loose `{ dispose }` type
+ * (which is precisely how the #460 cleanPrompt comma-truncation slipped past
+ * five rounds of tests — they reached past `{dispose}` into untyped internals).
+ *
+ * Members are pulled from `Game` via index access so the contract stays in
+ * lock-step with the real implementation: if a method's signature changes, the
+ * harness call typechecks against the real thing, not a hand-copied shadow.
+ * Keep this in sync with what the harness reads off `window.__lingoHero`.
+ */
+export interface LingoHeroDebug {
+  // Lifecycle
+  dispose: Game["dispose"]
+  /** GameMode is a string enum; the harness passes string-literal modes. */
+  startGame: (mode: GameMode | `${GameMode}`) => void
+  resume: Game["resume"]
+
+  // The real prompt-cleaning path (#460 comma-truncation regression surface).
+  cleanPrompt: (text: string) => string
+
+  // Live gameplay state the harness asserts on.
+  readonly score: number
+  readonly combo: number
+  readonly notes: Note[]
+  readonly caughtCount: number
+  readonly decoyDodges: number
+  readonly round: Round | null
+  readonly activeLanguage: ActiveLanguage
+
+  // Subsystems the harness introspects (lane geometry, canvas rect, HUD).
+  readonly laneSystem: LaneSystem
+  readonly canvas: HTMLCanvasElement
+  readonly hud: Pick<Hud, "setQuestion">
+
+  // iOS audio-unlock diagnostics (#428).
+  audioContextState: Game["audioContextState"]
+  audioUnlocked: Game["audioUnlocked"]
+}
 
 type GlobalScope = typeof globalThis & {
   CorpanGames?: Record<string, GameModule>
-  __lingoHero?: { dispose: () => void }
+  __lingoHero?: LingoHeroDebug
   __corpanHostActive?: boolean
 }
 
@@ -14,6 +64,15 @@ type GlobalScope = typeof globalThis & {
 // the game must register under — and the manifest id must be — `lingo_hero`,
 // else install fails with "Pack id mismatch". Paths/zip stay hyphenated.
 const GAME_ID = "lingo_hero"
+
+/**
+ * Expose a `Game` as the debug surface. `LingoHeroDebug` intentionally names
+ * `private` members of `Game` (which TS won't accept as a structural
+ * assignment), so this is the ONE sanctioned cast — narrowing the full
+ * instance to the typed introspection contract above.
+ */
+const asDebug = (game: Game): LingoHeroDebug =>
+  game as unknown as LingoHeroDebug
 
 const registerGame = () => {
   const scope = globalThis as GlobalScope
@@ -29,7 +88,7 @@ const registerGame = () => {
       
       const instance = new Game(container, hostApi, initialState)
 
-      scope.__lingoHero = instance
+      scope.__lingoHero = asDebug(instance)
       return {
         unmount: () => {
           instance.dispose()
@@ -61,7 +120,7 @@ const mountForDev = () => {
   }
 
   const instance = new Game(root, hostApi)
-  scope.__lingoHero = instance
+  scope.__lingoHero = asDebug(instance)
 }
 
 registerGame()

--- a/corpan/packs/lingo-hero/src/scoring/curve.ts
+++ b/corpan/packs/lingo-hero/src/scoring/curve.ts
@@ -126,13 +126,6 @@ export function xpToCompleteLevel(level: number): number {
   return Math.floor(LEVEL_BASE * Math.pow(L, LEVEL_EXP));
 }
 
-/** Cumulative XP needed to be sitting *at the start of* `level`. */
-export function cumulativeXpForLevel(level: number): number {
-  let total = 0;
-  for (let l = 1; l < level; l++) total += xpToCompleteLevel(l);
-  return total;
-}
-
 export interface LevelState {
   level: number;
   /** XP accrued within the current level. */

--- a/corpan/packs/lingo-hero/src/styles.css
+++ b/corpan/packs/lingo-hero/src/styles.css
@@ -623,14 +623,32 @@ canvas {
   font-size: 0.8rem;
   letter-spacing: -1px;
 }
+/* #490: the visible pill stays a small/unobtrusive 36px, but the TOUCH target is
+   expanded to ~44px (Apple HIG / WCAG 2.5.5 comfortable minimum) via an
+   invisible inset-overflowing hit area so the glyph doesn't grow but the finger
+   has room. pointer-events flow through it to the button. */
+.lh-chrome-btn::before {
+  content: "";
+  position: absolute;
+  /* (44 - 36) / 2 = 4px of grab room on every side. */
+  inset: -4px;
+  border-radius: inherit;
+}
 .lh-chrome-btn:hover,
 .lh-chrome-btn:focus-visible {
   opacity: 1;
   border-color: var(--na-text);
 }
-.lh-chrome-btn:active {
+/* #490: a clearly visible PRESSED/active state — the corner pill was previously
+   only scaling on :active, which is easy to miss on a small low-opacity glyph.
+   Add an accent ring + lift the fill so a tap reads as registered. */
+.lh-chrome-btn:active,
+.lh-chrome-btn.is-pressed {
   opacity: 1;
   transform: scale(0.92);
+  border-color: var(--na-accent, var(--na-text));
+  background: color-mix(in srgb, var(--na-accent, var(--na-text)) 28%, var(--na-glass-bg));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--na-accent, var(--na-text)) 45%, transparent);
 }
 /* OFF the playfield (menu / game-over): the pause control has no meaning, so it
    is fully removed (those screens own their own navigation). */
@@ -697,6 +715,21 @@ canvas {
   font-size: clamp(1.2rem, 5vmin, 1.6rem);
   color: var(--ink);
   letter-spacing: 0.02em;
+}
+
+/* #490: TERMINAL-ACTION sheet rows (Resume / Mute / Exit). These ACT in place
+   rather than drilling into a submenu, so they carry NO trailing `›` chevron
+   (the chevron is the menu's "go deeper" affordance). With the chevron gone, the
+   icon + label center as a balanced, obviously-tappable action instead of
+   hanging left with an empty right gutter where the chevron used to push them. */
+.menu-btn.terminal-action {
+  justify-content: center;
+}
+.menu-btn.terminal-action .btn-icon {
+  flex: 0 0 auto;
+}
+.menu-btn.terminal-action .btn-labels {
+  flex: 0 1 auto;
 }
 @keyframes lh-sheet-in {
   from {

--- a/corpan/packs/lingo-hero/src/ui/Hud.ts
+++ b/corpan/packs/lingo-hero/src/ui/Hud.ts
@@ -149,24 +149,27 @@ export class Hud {
            aria-label="Paused" aria-modal="true" hidden>
         <div class="lh-pause-card">
           <p class="lh-pause-title">Paused</p>
-          <button class="menu-btn blitz" id="lh-resume" type="button">
+          <!-- #490: pause-sheet rows are TERMINAL actions (they act, they don't
+               drill into a submenu), so they carry NO trailing drill-in chevron.
+               That chevron glyph is reserved for the menu's drill-in buttons
+               (Practice / Blitz / Retry / Main Menu). The terminal-action class
+               drops the chevron affordance and keeps the row a flat, tappable
+               action. -->
+          <button class="menu-btn blitz terminal-action" id="lh-resume" type="button">
             <span class="btn-icon" aria-hidden="true">&#9654;</span>
             <span class="btn-labels"><span class="btn-title">Resume</span></span>
-            <span class="btn-chevron" aria-hidden="true">&#10095;</span>
           </button>
-          <button class="menu-btn secondary lh-mute-btn" id="lh-mute" type="button"
+          <button class="menu-btn secondary terminal-action lh-mute-btn" id="lh-mute" type="button"
                   aria-label="Mute audio" aria-pressed="false">
             <span class="btn-icon" aria-hidden="true">
               <span class="lh-mute-on">&#128266;</span>
               <span class="lh-mute-off">&#128263;</span>
             </span>
             <span class="btn-labels"><span class="btn-title lh-mute-label">Mute</span></span>
-            <span class="btn-chevron" aria-hidden="true">&#10095;</span>
           </button>
-          <button class="menu-btn secondary" id="lh-exit" type="button" aria-label="Exit Lingo Hero">
+          <button class="menu-btn secondary terminal-action" id="lh-exit" type="button" aria-label="Exit Lingo Hero">
             <span class="btn-icon" aria-hidden="true">&#8592;</span>
             <span class="btn-labels"><span class="btn-title">Exit</span></span>
-            <span class="btn-chevron" aria-hidden="true">&#10095;</span>
           </button>
         </div>
       </div>
@@ -303,6 +306,11 @@ export class Hud {
     // dump a run mid-combo (issue #426). The sheet's Exit dispatches the host
     // `corpan:exit` (App.tsx dismisses the game); Resume closes the sheet.
     this.bindButton("#lh-pause", () => this.openPause());
+    // #490: explicit pressed-state on the small corner pill. `:active` can be
+    // unreliable for a low-opacity glyph inside the pointer-events overlay, so
+    // toggle `.is-pressed` directly on press/release for a guaranteed-visible
+    // tap acknowledgement (the CSS gives it an accent ring + lifted fill).
+    this.bindPressedState("#lh-pause");
     this.bindButton("#lh-resume", () => this.closePause(true));
     this.bindButton("#lh-exit", () => this.doExit());
     // Tapping the sheet backdrop (outside the card) resumes — same as Resume.
@@ -983,5 +991,22 @@ export class Hud {
 
     btn.addEventListener("touchstart", handleEvent, { passive: false });
     btn.addEventListener("click", handleEvent);
+  }
+
+  /**
+   * #490: toggle a `.is-pressed` class on press / release so a small control has
+   * a reliable visible pressed state on touch (where CSS `:active` is flaky).
+   * Pure visual feedback — the actual action stays wired via {@link bindButton}.
+   */
+  private bindPressedState(selector: string): void {
+    const btn = this.root.querySelector(selector);
+    if (!btn) return;
+    const on = () => btn.classList.add("is-pressed");
+    const off = () => btn.classList.remove("is-pressed");
+    btn.addEventListener("touchstart", on, { passive: true });
+    btn.addEventListener("pointerdown", on);
+    for (const ev of ["touchend", "touchcancel", "pointerup", "pointercancel", "pointerleave"]) {
+      btn.addEventListener(ev, off);
+    }
   }
 }

--- a/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
+++ b/corpan/packs/lingo-hero/test/e2e/gameplay.spec.mjs
@@ -213,6 +213,25 @@ else {
   if (!sheetOpen) fail("pause control did not open the Resume/Mute/Exit sheet");
   else console.log("OK: pause control opened the Resume/Mute/Exit sheet");
 
+  // --- #490: pause-sheet rows are TERMINAL actions → NO drill-in `›` chevron.
+  // The chevron stays reserved for the menu's drill-in buttons (Practice/Blitz/
+  // Retry/Main Menu) so the affordance reads honestly (chevron = "go deeper").
+  const chevrons = await page.evaluate(() => {
+    const has = (sel) => !!document.querySelector(`${sel} .btn-chevron`);
+    return {
+      resume: has("#lh-resume"),
+      mute: has("#lh-mute"),
+      exit: has("#lh-exit"),
+      practice: has("#btn-practice"),
+      retry: has("#btn-retry"),
+    };
+  });
+  if (chevrons.resume || chevrons.mute || chevrons.exit)
+    fail(`#490: terminal pause-sheet rows must NOT carry a drill-in chevron (resume=${chevrons.resume} mute=${chevrons.mute} exit=${chevrons.exit})`);
+  else if (!chevrons.practice || !chevrons.retry)
+    fail(`#490: menu drill-in buttons should KEEP their chevron (practice=${chevrons.practice} retry=${chevrons.retry})`);
+  else console.log("OK: #490 terminal sheet rows drop the chevron; menu drill-in buttons keep it");
+
   // --- Contract (c2): the MUTE control now lives INSIDE the open sheet (#462).
   // Exactly ONE mute control must exist, and it must be within the pause sheet.
   // Tapping it must NOT leak a tap into a lane (score unchanged).
@@ -437,6 +456,11 @@ else {
     { name: "ipad-portrait-col", vw: 834, vh: 1112, hw: 430, hh: 980, phrase: LONG },
     { name: "ipad11-landscape-col", vw: 1194, vh: 834, hw: 390, hh: 780, phrase: EXTRA },
     { name: "phone-portrait", vw: 390, vh: 844, hw: 0, hh: 0, phrase: LONG },
+    // #490: 4-line WORST CASE on the NARROWEST phone column. The #462 gutters
+    // narrowed the prompt band, so the 20-word EXTRA phrase wraps to ~4 lines at
+    // 390px-wide full-bleed — the most wrap lines the smallest device produces.
+    // The spawn play-top must STILL clear that tallest prompt (coverPx > 0).
+    { name: "phone-portrait-4line", vw: 390, vh: 844, hw: 0, hh: 0, phrase: EXTRA },
   ];
   for (const sz of SIZES) {
     const words = sz.phrase.replace(/[.,]/g, "").split(/\s+/).filter(Boolean);
@@ -512,6 +536,16 @@ else {
       rng.selectNodeContents(el);
       const t = rng.getBoundingClientRect();
       const txt = el.textContent || "";
+      // Count wrapped lines by clustering the range's client rects on their top
+      // edge (each visual line is one band) — lets us assert the worst case
+      // really stresses the 4-line wrap, not just any wrap.
+      const rects = [...rng.getClientRects()];
+      const tops = [];
+      for (const r of rects) {
+        if (r.height < 1) continue;
+        if (!tops.some((y) => Math.abs(y - r.top) <= 2)) tops.push(r.top);
+      }
+      const lineCount = tops.length;
       // (3) Walk the ancestor chain — find the FIRST clipper (overflow != visible
       // that cuts the wrapped text) or a viewport cut.
       const desc = (n) => {
@@ -555,6 +589,7 @@ else {
         promptBottomLocal,
         playTopY,
         coverPx: promptBottomLocal - playTopY,
+        lineCount,
       };
     }, [sz.phrase, words]);
     if (!m) {
@@ -567,9 +602,14 @@ else {
       // The prompt's last line must clear the spawn play-top (tiles must not
       // spawn over it). A small tolerance for sub-pixel rounding.
       if (m.coverPx > 2.0)
-        fail(`#460 ${sz.name}: prompt last line COVERED by spawn area by ${m.coverPx.toFixed(1)}px (promptBottom ${m.promptBottomLocal.toFixed(0)} > playTop ${m.playTopY.toFixed(0)}, col ${m.qbWidth}px)`);
+        fail(`#460 ${sz.name}: prompt last line COVERED by spawn area by ${m.coverPx.toFixed(1)}px (promptBottom ${m.promptBottomLocal.toFixed(0)} > playTop ${m.playTopY.toFixed(0)}, col ${m.qbWidth}px, ${m.lineCount} lines)`);
+      // #490: the dedicated worst-case must actually reach the 4-line wrap it is
+      // designed to stress (else a future layout change could silently shrink it
+      // back to an easy 2-liner and the clearance check would lose its teeth).
+      if (sz.name === "phone-portrait-4line" && m.lineCount < 4)
+        fail(`#490 ${sz.name}: expected a 4-line worst-case wrap but got ${m.lineCount} lines (col ${m.qbWidth}px, font ${m.fontPx.toFixed(0)}px) — worst-case no longer exercised`);
       if (m.allPresent && !m.clipper && m.coverPx <= 2.0)
-        console.log(`OK: #460 long+comma prompt fully visible at ${sz.name} (col ${m.qbWidth}px, font ${m.fontPx.toFixed(0)}px, all ${words.length} words, no ancestor clip, clears spawn by ${(-m.coverPx).toFixed(0)}px)`);
+        console.log(`OK: #460 long+comma prompt fully visible at ${sz.name} (col ${m.qbWidth}px, font ${m.fontPx.toFixed(0)}px, ${m.lineCount} lines, all ${words.length} words, no ancestor clip, clears spawn by ${(-m.coverPx).toFixed(0)}px)`);
     }
     await vp.screenshot({ path: join(outDir, `prompt-460-${sz.name}.png`) });
     await vp.close();


### PR DESCRIPTION
### **User description**
Hardening + chrome polish pass for Lingo Hero (PREVIEW pack). Closes #485 and #490. Version 0.4.11 → 0.4.12.

## #485 — type the `__lingoHero` debug surface (closes the cleanPrompt saga)
`src/main.ts` typed `window.__lingoHero` as `{ dispose: () => void }`, but at runtime it is the **full `Game` instance** — so the e2e harness reached past the typed `{dispose}` into untyped internals. That mistyping is exactly how the #460 `cleanPrompt` comma-truncation hid from tests for five rounds (tests injected via `setQuestion` instead of exercising the real `cleanPrompt` path through a typed contract).

- Declared an explicit **`LingoHeroDebug`** introspection contract and typed `window.__lingoHero` as it. Members (everything the e2e/repro harness reads): `dispose`, `startGame`, `resume`, **`cleanPrompt`**, `score`, `combo`, `notes`, `caughtCount`, `decoyDodges`, `round`, `activeLanguage`, `laneSystem`, `canvas`, `hud.setQuestion`, `audioContextState`, `audioUnlocked`. Public methods pull their type from `Game[...]`; the `private`-on-`Game` members (`cleanPrompt`, gameplay state) are explicitly declared. One sanctioned `asDebug()` cast at the two assignment sites.
- Clearly commented as a **debug/introspection contract, not a public API**.
- Removed 3 dead exports flagged by the #484 audit — **grep-confirmed zero importers**: `cumulativeXpForLevel` (scoring/curve.ts), `getDefaultWordSelector` (ContentManager.ts), `laneHex` (effects/palette.ts). The other functions they touched (`xpToCompleteLevel`, `setDefaultWordSelector`/`defaultSelector`, `rgbToHex`) remain in use and are kept.

## #490 — chrome polish (from the #462/#489 design-critic)
- **Terminal-action chevrons:** the pause-sheet rows (Resume / Mute / Exit) are terminal actions, but carried a trailing `›` that reads as "drill into a submenu." Dropped the chevron on those three rows (new `terminal-action` class; icon+label centered) — the chevron stays on the menu's real drill-in buttons (Practice / Blitz / Retry / Main Menu). *(Note: this is the direction the issue specifies — drop, not add.)*
- **4-line worst-case prompt clearance:** added an e2e case (`phone-portrait-4line`, the 20-word phrase at full narrow 390px phone width) — confirms the falling-note spawn zone still clears a true 4-line prompt. Result: **4 lines, all words present, no ancestor clip, clears spawn by 63px.**
- **Corner pause pill:** visible pressed/active state (accent ring + lifted fill via an `is-pressed` class — reliable on touch where `:active` is flaky) + ~44px touch target (36px glyph + 4px inset-overflow hit area), keeping the glyph small/unobtrusive.

## Verification
- `npm run typecheck` (tsc --noEmit): **clean** — the typed surface compiles and the harness's `__lingoHero.cleanPrompt(...)` typechecks.
- `npm run build` (vite): **clean**.
- `node test/e2e/gameplay.spec.mjs`: **PASS, 0 failures** — incl. `cleanPrompt keeps the full comma phrase`, all five #460 prompt cases + the new 4-line worst-case, #463 script rendering (zh/ja/th/ar/hi), #462 persistent-pause + mute-in-sheet + no-tap-through, #490 chevron affordance, #428 audio-unlock.
- Design-critic: **GO** on the pause-sheet polish (terminal rows read as flat actions; corner pill pressed state is clear + on-brand cyan; touch target adequate).

## Preserved contracts
#460 prompt full-visibility, #462 persistent-pause/no-tap-through/mute-in-sheet, #463 script rendering, canvas-relative input, delta-timed motion, the typed `window.__lingoHero`.

Closes #485
Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Types `__lingoHero` debug introspection

- Polishes pause sheet interactions

- Expands prompt and chevron e2e coverage

- Documents `0.4.12` release changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  debug["Typed debug contract"] 
  tests["E2E harness coverage"]
  ui["Pause sheet polish"]
  release["0.4.12 release notes"]
  debug -- "exposes cleanPrompt safely" --> tests
  ui -- "chevrons and pressed state" --> tests
  tests -- "validated behavior" --> release
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>ContentManager.ts</strong><dd><code>Remove unused default selector getter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/492/files#diff-7f7f66aa0a0ab0785ba8e14b6eec2a3c527ed1175293a5030a3dcadd1575ed52">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>palette.ts</strong><dd><code>Remove unused lane hex helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/492/files#diff-df8f43bff975bbd86028c081e792777c54ebb77e21a99a24ba6692429e4928ea">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>curve.ts</strong><dd><code>Remove unused cumulative XP export</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/492/files#diff-dc7ecdf0628f26e58c595fc736fe70fa30266d400390b71a1b38ed4ffbc018f4">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>main.ts</strong><dd><code>Add typed Lingo Hero debug surface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/492/files#diff-4e371b8f9cfb0cc90249e49221a2b1824e5c244afc875fc87fd1d3ec37317bdf">+62/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Hud.ts</strong><dd><code>Polish pause sheet actions and pressed state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/492/files#diff-145e656a10e1e233418a8c559a94e938bf0e0c922802aa2f87d69b0498a38c02">+31/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>styles.css</strong><dd><code>Style pause touch target and terminal rows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/492/files#diff-b9b9a82cd5a6b2fe32239b2b4b2f069c2c4853d63db1736b575103a5d1daf226">+34/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document Lingo Hero 0.4.12 changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/492/files#diff-dd09bf20e11864991961b7ef6d2fc6687a66d9a9de2d246f765d9d6891e646c2">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>manifest.json</strong><dd><code>Bump preview pack version to 0.4.12</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/492/files#diff-38411e79d50eee7f8ad439a29518dcddf16cdc9cd03739fc81ea212f18519b15">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>gameplay.spec.mjs</strong><dd><code>Add chevron and prompt clearance assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/492/files#diff-5ee22f0c6a817c0427478004e2238facf99cd3c18591eda51d590170655a3c57">+42/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

