### PR TITLE
teletron 0.1.10: stop silently chopping mediated chat to 280 chars (#487)

### DIFF
--- a/corpan/packs/teletron/CHANGELOG.md
+++ b/corpan/packs/teletron/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+## 0.1.10 - 2026-06-24
+
+- **Stop silently chopping mediated messages.** The recipient-side mediator
+  re-sliced every translated message to 280 characters (`MAX_TEXT`) before
+  showing it in the bubble AND speaking it aloud — a silent mid-word cut with no
+  ellipsis, no log, and no rationale (the chat contract has no length cap). A
+  longer message (verbose A1 register, long German/Finnish compounds, RTL) lost
+  its tail in both the displayed text and the spoken audio. The cap on
+  displayed/spoken/stored text is removed; the safe-relay pipeline's own length
+  guard is raised to a generous defense-in-depth bound so a full message is never
+  chopped mid-word. The only remaining trim is on suggested-reply *chip labels*
+  (tap targets), which are display affordances, never message content. Regression
+  test added: a >280-char mediated message survives whole through the real
+  mediator path. (Part of #484; fixes #487.)
+
 ## 0.1.9 - 2026-06-09
 
 - **Reliable chat delivery (live, offline, and rejoin).** The accepted-pair link

--- a/corpan/packs/teletron/manifest.json
+++ b/corpan/packs/teletron/manifest.json
@@ -2,7 +2,7 @@
   "id": "teletron",
   "channel": "preview",
   "name": "Teletron",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "entry": "dist/app.js",
   "entryType": "script",
   "styles": [

--- a/corpan/packs/teletron/src/mediator.test.ts
+++ b/corpan/packs/teletron/src/mediator.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import { MediatedChatInput, type LanguageCode } from "@corpan-city/contracts"
+import { createChatMediator } from "./mediator.js"
+import type {
+  HostApi,
+  LlmApi,
+  LlmChatHandlers,
+  LlmChatMessage,
+  LlmChatOptions,
+} from "../../corpan-city/src/npc/hostTypes"
+
+// A long, benign translated message — well past the old 280-char MAX_TEXT cap,
+// with no PII/links/places so the safe-relay pipeline keeps it verbatim. The
+// distinctive tail is what a silent mid-word `.slice(0, 280)` would drop.
+const LONG_TAIL = "and that is the very last clause the recipient must still read and hear."
+const LONG_MESSAGE = [
+  "I spent the whole afternoon describing how I learned to cook with my grandmother,",
+  "how she taught me to taste the broth before adding salt, to chop the onions slowly,",
+  "to let the stew rest so the flavors settle, and to always share the first bowl with a",
+  "neighbor because a warm meal feels better when someone else is at the table too,",
+  LONG_TAIL,
+].join(" ")
+
+// Build a host whose on-device LLM always streams the same long benign line, so
+// every safe-relay stage (re-clean, translate-target, translate-native) yields
+// the full text. We drive the REAL mediator/pipeline, not a reimplementation.
+function hostReturning(text: string): HostApi {
+  const llm = {
+    chat: async (
+      _args: { messages: LlmChatMessage[]; options?: LlmChatOptions },
+      handlers: LlmChatHandlers,
+    ) => {
+      // Stream a couple of tokens then finish, mirroring the real runtime.
+      handlers.onToken(text.slice(0, 10))
+      handlers.onDone(text)
+      return { sessionId: "s1", cancel: async () => {} }
+    },
+  } as unknown as LlmApi
+  return { llm } as unknown as HostApi
+}
+
+describe("teletron mediator — no silent truncation of mediated chat", () => {
+  it("keeps a long mediated message intact in visibleText (displayed + spoken)", async () => {
+    const mediator = createChatMediator(hostReturning(LONG_MESSAGE))
+    const input = MediatedChatInput.parse({
+      from: "p1",
+      to: "p2",
+      interactionId: "i1",
+      source: { kind: "text", text: LONG_MESSAGE },
+      sourceLanguage: "en",
+      targetLanguage: "de",
+      mode: "advanced",
+    })
+    const artifact = await mediator.lessonify(input, {
+      native: "en" as LanguageCode,
+      target: "de" as LanguageCode,
+    })
+    mediator.dispose()
+
+    // The whole message survives — both the bytes AND the final clause. A
+    // `.slice(0, 280)` would have chopped the message mid-word and dropped the
+    // tail; visibleText feeds both the bubble and speakNow().
+    expect(artifact.visibleText.length).toBeGreaterThan(280)
+    expect(artifact.visibleText).toContain(LONG_TAIL)
+    expect(artifact.visibleText).toBe(LONG_MESSAGE)
+    // The native gloss (shown as the small "detail" line) is likewise intact.
+    expect(artifact.naturalTranslation).toBe(LONG_MESSAGE)
+  })
+})

--- a/corpan/packs/teletron/src/mediator.ts
+++ b/corpan/packs/teletron/src/mediator.ts
@@ -15,7 +15,14 @@ import {
 } from "@shared/moderation"
 import type { HostApi, LlmChatMessage, LlmChatOptions } from "../../corpan-city/src/npc/hostTypes"
 
-const MAX_TEXT = 280
+// Reply-chip labels are tap targets in the composer; a hard cap keeps them
+// button-sized. This is a *display affordance* on short suggestions, never a
+// cap on the message the recipient reads or hears.
+const MAX_REPLY_LABEL = 80
+// Defense-in-depth length guard for the safe-relay pipeline's on-device LLM
+// output. Generous enough to hold a full chat message plus the expansion a
+// translation can add, so the recipient never gets a mid-word chop.
+const MAX_RELAY_TEXT = 1000
 const INBOUND_FALLBACK = "Let's talk about something friendly."
 
 export type PrepareOutboundArgs = {
@@ -48,8 +55,19 @@ export type ChatMediatorEvents = {
   onDone?: (label: string, fullText: string) => void
 }
 
-function bounded(value: unknown, max = MAX_TEXT): string {
-  return typeof value === "string" ? value.trim().slice(0, max) : ""
+// Normalize an LLM/string value WITHOUT dropping content: trim whitespace only.
+// The recipient must read and hear the whole translated message — never a
+// silent mid-word chop. (The safe-relay pipeline already bounds on-device LLM
+// output upstream; teletron must not re-truncate the result it displays/speaks.)
+function clean(value: unknown): string {
+  return typeof value === "string" ? value.trim() : ""
+}
+
+// Trim a short *display label* to a fixed width. Only for reply-chip buttons —
+// never for displayed or spoken message text.
+function boundedLabel(value: unknown, max = MAX_REPLY_LABEL): string {
+  const text = clean(value)
+  return text.length > max ? text.slice(0, max).trimEnd() : text
 }
 
 function mint(prefix: string): string {
@@ -72,7 +90,7 @@ function composeSafeRelayInput(
     interactionId: args.interactionId,
     source: {
       kind: "text",
-      text: bounded(outbound.relayText) || INBOUND_FALLBACK,
+      text: clean(outbound.relayText) || INBOUND_FALLBACK,
     },
     sourceLanguage: "en" as LanguageCode,
     targetLanguage: args.targetLanguage,
@@ -113,10 +131,10 @@ function artifactFromLesson(
     targetPlayerId: input.to,
     sourceLanguage: input.sourceLanguage,
     targetLanguage: recipient.target,
-    visibleText: bounded(lesson.targetText) || INBOUND_FALLBACK,
-    naturalTranslation: bounded(lesson.nativeText) || undefined,
+    visibleText: clean(lesson.targetText) || INBOUND_FALLBACK,
+    naturalTranslation: clean(lesson.nativeText) || undefined,
     suggestedReplies: lesson.suggestedReplies
-      .map((label, index) => ({ id: `r${index}`, label: bounded(label, 80) }))
+      .map((label, index) => ({ id: `r${index}`, label: boundedLabel(label) }))
       .filter((reply) => reply.label),
     lessonNotes: [],
     moderation: {
@@ -180,6 +198,13 @@ export function createChatMediator(hostApi: HostApi, events: ChatMediatorEvents 
   const pipeline = createSafeRelayPipeline({
     runLlm: (messages, options, label) => run(messages, options, label),
     sampleSafePhrase: createHostSafePhraseSampler(hostApi),
+    // A chat message plus its translation expansion (verbose A1 register, long
+    // compounds in de/fi, RTL, etc.) routinely runs past the relay's default
+    // 280-char guard. The pipeline's own translate pass already allows ~180
+    // tokens; this lifts the post-hoc char clamp to match so a full message is
+    // never silently chopped mid-word before the recipient reads or hears it.
+    // Still a generous defense-in-depth bound, not unbounded.
+    maxText: MAX_RELAY_TEXT,
   })
 
   return {


### PR DESCRIPTION
### **User description**
## What

Fixes #487 (the last cleanPrompt-class truncation from the #484 hunt).

`corpan/packs/teletron/src/mediator.ts` `bounded()` re-sliced every mediated-chat translation to `MAX_TEXT = 280`. That `visibleText` is **both displayed** (`main.ts:1416`) **and spoken** (`speakNow`, `main.ts:1418`) — a silent mid-word chop with no ellipsis, no log, and no rationale. The chat contract (`chat.ts:60`) has no length cap, so this was a magic number inventing a limit the data model never asked for. Same anti-pattern class as the cleanPrompt comma-chop (#460).

## The fix

- **Remove the lossy slice on displayed/spoken/stored text.** A new `clean()` trims whitespace only — it never drops content. Applied to `visibleText`, `naturalTranslation`, and the outbound relay text.
- **Raise the safe-relay pipeline's char guard.** Even with the teletron-side cap gone, the shared moderation pipeline defaults its own `maxText` to 280. Passing `maxText: 1000` via the pipeline's existing knob (teletron-only; no change to the shared default) lets a full translated message survive upstream too. The translate pass already permits ~180 tokens, so 280 chars was the real bottleneck — this is a generous defense-in-depth bound, not unbounded.
- **Keep the one legitimate trim:** suggested-reply *chip labels* are tap-target buttons. `boundedLabel()` (80 chars) is explicitly a display affordance, never message content.
- **No display change needed:** the bubble CSS already wraps and scrolls (`white-space: pre-wrap; overflow-wrap: anywhere; max-width: 88%`), so the full message renders cleanly.

## Test

`corpan/packs/teletron/src/mediator.test.ts` — drives the **real** `createChatMediator(...).lessonify(...)` path (not a reimplementation of `bounded`) with a >280-char benign message and asserts `visibleText` + `naturalTranslation` survive whole.

Verified out-of-band against the real pipeline graph (Node-20 toolchain unavailable locally per #450, so vitest runs in CI):
- **Old slice path:** `visibleText.length` = 280, final clause dropped → FAIL.
- **Fixed path:** `visibleText.length` = 405 (full), final clause present → PASS.

## Versioning

Preview pack. Bumped `manifest.json` 0.1.9 → 0.1.10 + CHANGELOG entry.

Part of #484.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Stop mediated-chat message truncation

- Preserve displayed and spoken text

- Add long-message regression coverage

- Bump Teletron to `0.1.10`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  input["Long mediated chat"] 
  relay["Safe relay pipeline"]
  artifact["Mediator artifact"]
  ui["Displayed and spoken text"]
  test["Regression test"]
  input -- "allows up to 1000 chars" --> relay
  relay -- "trims whitespace only" --> artifact
  artifact -- "preserves full message" --> ui
  test -- "verifies tail survives" --> artifact
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mediator.ts</strong><dd><code>Preserve full mediated chat content</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/teletron/src/mediator.ts

<ul><li>Replaces lossy <code>bounded()</code> message slicing with <code>clean()</code>.<br> <li> Keeps truncation only for reply-chip labels via <code>boundedLabel()</code>.<br> <li> Raises safe-relay <code>maxText</code> to <code>1000</code>.<br> <li> Documents why message content must not be chopped.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/493/files#diff-9cde7383bd684d764b9b125dd487d7a4e623f5439d09e32740070be03a663ebc">+32/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mediator.test.ts</strong><dd><code>Add long-message mediator regression test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/teletron/src/mediator.test.ts

<ul><li>Adds Vitest coverage for <code>createChatMediator().lessonify()</code>.<br> <li> Uses a mocked host LLM returning a >280-character message.<br> <li> Asserts <code>visibleText</code> and <code>naturalTranslation</code> remain intact.<br> <li> Verifies the distinctive long tail is preserved.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/493/files#diff-28bdff34f09c03d1c9fa5bb3958fe39bc5a8b3a971a838cdc40fae6829c23af0">+69/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document Teletron truncation fix release</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/teletron/CHANGELOG.md

<ul><li>Adds <code>0.1.10</code> changelog entry.<br> <li> Explains removal of the <code>MAX_TEXT</code> message cap.<br> <li> Notes remaining reply-chip-only label trimming.<br> <li> Mentions regression coverage and related tickets.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/493/files#diff-d1060f3eb9617be15bd90f19e0d33f2b8a3eb98cff539fe4cf246e5aa72cd49e">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump Teletron preview pack version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/teletron/manifest.json

- Updates Teletron manifest version from `0.1.9` to `0.1.10`.


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/493/files#diff-8a9f7867b07ed9f2512f789a507af6d55aa3e826e1415f19bc08e850e2d4a56a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

