### PR TITLE
ci: gate dja content-generation tests (#491)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       corpan_app: ${{ steps.filter.outputs.corpan_app }}
+      dja: ${{ steps.filter.outputs.dja }}
       lambda: ${{ steps.filter.outputs.lambda }}
       packs: ${{ steps.filter.outputs.packs }}
       terraform: ${{ steps.filter.outputs.terraform }}
@@ -74,6 +75,7 @@ jobs:
           }
 
           set_output corpan_app '^(corpan/corpan-app/|\.github/workflows/ci\.yml$)'
+          set_output dja '^(corpan/dja/|\.github/workflows/ci\.yml$)'
           set_output lambda '^(corpan/infra/terraform/lambda/|\.github/workflows/ci\.yml$)'
           set_output packs '^(corpan/packs/|\.github/workflows/(ci|deploy-pages)\.yml$)'
           set_output terraform '^(corpan/infra/terraform/.*(\.tf|\.tfvars|\.tf\.json)$|corpan/infra/terraform/\.terraform\.lock\.hcl$|\.github/workflows/ci\.yml$)'
@@ -103,6 +105,36 @@ jobs:
       - name: Build
         working-directory: corpan/corpan-app
         run: npm run build
+
+  # Django content-generation tests (corpan/dja). The shipped SQLite content
+  # bundle is built from this code; a regression here (e.g. the #486 silent
+  # translation-corruption bug) would otherwise ship unnoticed. The two test
+  # modules under cor/utils are plain-pytest and stub out Django + corpora_ai
+  # in sys.modules, so the only runtime deps are pytest + pydantic — no Django
+  # install, no DB, no API access. Fast (<1s) and self-contained, so it cannot
+  # jam the merge queue. Skips cleanly when no corpan/dja/** files changed,
+  # exactly like the sibling area jobs; ci-gate treats a skip as a pass.
+  dja:
+    name: dja · tests
+    needs: changes
+    if: needs.changes.outputs.dja == 'true'
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install test deps (pinned)
+        run: python -m pip install --disable-pip-version-check "pytest==8.3.4" "pydantic==2.12.5"
+      - name: Run dja tests
+        working-directory: corpan/dja
+        # Scope to cor/utils: the plain-pytest modules live here and stub their
+        # Django/corpora_ai deps. This auto-collects future test_*.py added in
+        # this dir, while NOT collecting cor/tests.py (a Django TestCase
+        # placeholder that would need a full Django install + DB) — keeping the
+        # gate fast and unable to jam the queue.
+        run: python -m pytest cor/utils -q
 
   lambda:
     name: lambda · tests
@@ -255,7 +287,7 @@ jobs:
   # Skipped needs are fine; any failure or cancellation fails the gate.
   ci-gate:
     name: ci-gate
-    needs: [changes, corpan-app, lambda, web-io, changed-packs, terraform, pack-catalog]
+    needs: [changes, corpan-app, dja, lambda, web-io, changed-packs, terraform, pack-catalog]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### **User description**
Closes #491.

## What

Adds a path-filtered **`dja · tests`** job to CI that runs the plain-pytest tests under `corpan/dja/cor/utils`:
- `cor/utils/test_translate_entry_batch.py` — the #486 regression tests (silent translation-corruption / UnboundLocalError masking).
- `cor/utils/test_split.py` — utterance-splitting tests.

Before this, **no workflow ran the dja tests at all**, so a content-generation regression (the dja code builds the shipped `release.sqlite3` content bundle) could pass CI and ship unnoticed.

## Design (mirrors the existing area jobs exactly)

- **Path-filtered**: a new `dja` output on the `changes` job (`^(corpan/dja/|\.github/workflows/ci\.yml$)`), and the job is `needs: changes` + `if: needs.changes.outputs.dja == 'true'` — identical to `corpan-app` / `lambda` / `web-io`.
- **Wired into `ci-gate`**: added to `ci-gate.needs`. The aggregator already treats `skipped` as pass (only `failure`/`cancelled` fail it), so on non-dja PRs the dja job skips cleanly and the gate stays green. No change to the aggregator logic.
- **Cannot jam the merge queue**:
  - Deps are tiny + pinned: `pytest==8.3.4` + `pydantic==2.12.5` only. The tests stub `django` and `corpora_ai` in `sys.modules`, so there is **no Django install, no DB, no API/network access**.
  - Run scoped to `cor/utils` so it auto-collects future plain-pytest files there but does **not** collect `cor/tests.py` (a Django `TestCase` placeholder that would need a full Django + DB stack).
  - `timeout-minutes: 10` (tests run in <1s locally).

## Constraints respected

Purely **additive** — does not weaken or modify any existing gate job, nor the adversarial-review / hygiene scripts (the #393 line). 33 insertions, 1 deletion (the `ci-gate` needs list).

## Verification

- 23 tests pass locally in a clean venv with only `pytest` + `pydantic` installed (0.05s).
- Because this PR touches `.github/workflows/ci.yml`, the `dja` filter matches and the **dja job runs on this very PR** (it does not skip) — so CI on this PR exercises the job end-to-end.

Not enqueued / not auto-merged — this is a queue-affecting CI change for human sanity-check of the `.github` diff first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Adds path-filtered `dja` CI tests

- Runs scoped pytest content-generation coverage

- Wires `dja` into `ci-gate`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  changes["changes job"] -- "detects corpan/dja changes" --> dja["dja · tests"]
  dja -- "runs pytest cor/utils" --> gate["ci-gate"]
  changes -- "aggregates with other jobs" --> gate
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Ci configuration</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Gate dja tests in CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Adds a <code>dja</code> path-filter output for <code>corpan/dja/**</code> and CI workflow <br>changes.<br> <li> Introduces a <code>dja · tests</code> job using Python 3.12 with pinned <code>pytest</code> and <br><code>pydantic</code>.<br> <li> Runs <code>python -m pytest cor/utils -q</code> from <code>corpan/dja</code>, scoped to <br>plain-pytest utility tests.<br> <li> Adds <code>dja</code> to <code>ci-gate.needs</code> so failures block the required aggregate <br>check.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/494/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+33/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

