### PR TITLE
word_pack: generic word-explanation schema + builder + canonical sample (#472, #474)

### DIFF
--- a/corpan/dja/cor/utils/test_word_pack.py
+++ b/corpan/dja/cor/utils/test_word_pack.py
@@ -1,0 +1,176 @@
+# tests/test_word_pack.py
+#
+# Tests for the word-explanation pack pipeline (dja/word_pack). They run under
+# plain pytest with only the stdlib + pydantic available -- exactly the deps
+# the CI `dja` gate installs. The pipeline modules live in dja/word_pack/ and
+# import each other as top-level modules (mirroring dja/hanzi_pack), so we add
+# that directory to sys.path here. The LLM provider is imported lazily inside
+# generate_word_explanations.main(), so importing the module for its parsing
+# helpers never touches corpora_ai.
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# dja/word_pack lives two levels up from cor/utils/.
+WORD_PACK = Path(__file__).resolve().parents[2] / "word_pack"
+if str(WORD_PACK) not in sys.path:
+    sys.path.insert(0, str(WORD_PACK))
+
+import build_word_pack  # noqa: E402
+import extract_words  # noqa: E402
+import generate_word_explanations as gen  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Tokenization: the word universe must be stable and predictable.
+# ---------------------------------------------------------------------------
+def test_tokenize_lowercases_and_keeps_apostrophes():
+    assert extract_words.tokenize("Don't STOP running!") == [
+        "don't",
+        "stop",
+        "running",
+    ]
+
+
+def test_tokenize_drops_numbers_and_punctuation():
+    assert extract_words.tokenize("Room 101 -- the x-ray, 3.5kg.") == [
+        "room",
+        "the",
+        "x",
+        "ray",
+        "kg",
+    ]
+
+
+def test_tokenize_empty():
+    assert extract_words.tokenize("12345 !!! ???") == []
+
+
+# ---------------------------------------------------------------------------
+# Seed parsing: the builder must ignore malformed records, never crash.
+# ---------------------------------------------------------------------------
+def test_load_explanations_filters_bad_records(tmp_path):
+    seed = tmp_path / "seed.json"
+    seed.write_text(
+        json.dumps(
+            [
+                {"word": "running", "explanation": {"en": "to move fast", "es": "correr"}},
+                {"word": "bad", "explanation": "not a dict"},  # dropped
+                {"explanation": {"en": "no word key"}},  # dropped
+                {"word": "blank", "explanation": {"en": "   ", "zh-Hans": "解释"}},
+                "totally wrong",  # dropped
+            ]
+        ),
+        encoding="utf-8",
+    )
+    out = build_word_pack.load_explanations(seed)
+    assert set(out) == {"running", "blank"}
+    assert out["running"] == {"en": "to move fast", "es": "correr"}
+    # empty/whitespace paragraphs are stripped out per-language
+    assert out["blank"] == {"zh-Hans": "解释"}
+
+
+def test_load_explanations_missing_file(tmp_path):
+    assert build_word_pack.load_explanations(tmp_path / "nope.json") == {}
+
+
+# ---------------------------------------------------------------------------
+# Checked-in canonical sample: structural contract the pack relies on.
+# ---------------------------------------------------------------------------
+SEED_PATH = WORD_PACK / "seed" / "explanations_seed.json"
+SAMPLE_LANGS = {"en", "zh-Hans", "ar", "hi", "es"}
+
+
+def _load_seed_records():
+    return json.loads(SEED_PATH.read_text(encoding="utf-8"))
+
+
+def test_sample_seed_is_valid_and_complete():
+    records = _load_seed_records()
+    assert len(records) >= 15, "sample should be ~15-20 words"
+    words = {r["word"] for r in records}
+    assert "running" in words, "the locked exemplar must be present"
+    for r in records:
+        # every word carries all four sample targets + English
+        assert SAMPLE_LANGS.issubset(set(r["explanation"])), r["word"]
+        for lang in SAMPLE_LANGS:
+            assert r["explanation"][lang].strip(), f"{r['word']}/{lang} empty"
+        # origin confidence is recorded and from the allowed set
+        assert r["origin_confidence"] in {"high", "medium", "low"}, r["word"]
+
+
+def test_sample_paragraphs_are_roughly_fifty_words():
+    for r in _load_seed_records():
+        n = len(r["explanation"]["en"].split())
+        assert 35 <= n <= 70, f"{r['word']} English paragraph is {n} words"
+
+
+def test_sample_scripts_match_languages():
+    def has(text, lo, hi):
+        return any(lo <= ord(c) <= hi for c in text)
+
+    for r in _load_seed_records():
+        e = r["explanation"]
+        assert has(e["zh-Hans"], 0x4E00, 0x9FFF), f"{r['word']} zh missing Han"
+        assert has(e["ar"], 0x0600, 0x06FF), f"{r['word']} ar missing Arabic"
+        assert has(e["hi"], 0x0900, 0x097F), f"{r['word']} hi missing Devanagari"
+
+
+# ---------------------------------------------------------------------------
+# Build: the seed -> SQLite emit must produce the generic schema + rows.
+# ---------------------------------------------------------------------------
+def test_build_emits_generic_schema(tmp_path, monkeypatch):
+    # Avoid scanning the real corpus: stub the word scan to the seed's words.
+    records = _load_seed_records()
+    words = sorted(r["word"] for r in records)
+    monkeypatch.setattr(build_word_pack, "collect_words", lambda *a, **k: words)
+
+    out = tmp_path / "word.sqlite3"
+    # release.sqlite3 must exist for the core-db guard; point at any real file.
+    monkeypatch.setattr(
+        sys, "argv", ["build", "--core-db", str(SEED_PATH), "--out", str(out)]
+    )
+    build_word_pack.main()
+
+    conn = sqlite3.connect(out)
+    try:
+        cols = [r[1] for r in conn.execute("PRAGMA table_info(word_explanation)")]
+        assert cols == ["word", "language_code", "paragraph"]
+        meta = dict(conn.execute("SELECT key, value FROM pack_meta"))
+        assert meta["schema_version"] == build_word_pack.SCHEMA_VERSION
+        assert int(meta["word_count"]) == len(words)
+        rows = conn.execute("SELECT COUNT(*) FROM word_explanation").fetchone()[0]
+        assert rows == len(words) * len(SAMPLE_LANGS)
+        para = conn.execute(
+            "SELECT paragraph FROM word_explanation "
+            "WHERE word='running' AND language_code='en'"
+        ).fetchone()[0]
+        assert "Old English" in para
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Generator schemas: confidence field + import safety (no corpora_ai needed).
+# ---------------------------------------------------------------------------
+def test_verify_item_defaults():
+    item = gen.VerifyItem(word="egg", confidence="high")
+    assert item.note == "" and item.corrected == ""
+
+
+def test_save_and_load_seed_roundtrips_metadata(tmp_path):
+    path = tmp_path / "full.json"
+    data = {
+        "egg": {
+            "explanation": {"en": "An egg.", "es": "Un huevo."},
+            "origin_confidence": "high",
+        }
+    }
+    gen.save_seed(path, data)
+    back = gen.load_seed(path)
+    assert back["egg"]["explanation"]["es"] == "Un huevo."
+    assert back["egg"]["origin_confidence"] == "high"

--- a/corpan/dja/word_pack/README.md
+++ b/corpan/dja/word_pack/README.md
@@ -1,0 +1,122 @@
+# Word-explanation pack data pipeline
+
+Builds the SQLite database for the **word-explanation pack** ("Phrase Flip"
+word explanations). It generalizes the Hanzi pack (`dja/hanzi_pack`) from
+per-character etymologies to per-word explanations.
+
+## What a word explanation is
+
+For each unique English word in the corpus, ONE flowing paragraph of about 50
+words that captures:
+
+1. the word's **range of common senses** (its polysemy) and how they relate,
+2. where the word **came from** (origin/etymology), and
+3. how that original idea **branched** into the modern senses.
+
+Exemplar (the quality bar):
+
+> Running means moving rapidly on foot, but can also describe something
+> operating, continuing, or flowing, such as a running engine, program, or
+> stream. It comes from Old English rinnan and irnan, to flow or move swiftly,
+> from Proto-Germanic \*rinnaną. The original idea of continuous movement later
+> branched into these modern uses.
+
+The paragraph is authored in English, then written **in each target language**
+(so a Chinese speaker reads the explanation in Chinese), across the corpus's 54
+languages (English + 53 targets).
+
+## Word universe
+
+The set of words to explain = unique English words from BOTH:
+
+- the core corpus (`release.sqlite3`, the English side of `cor_translation`), and
+- every phrase pack under `corpan/tools/phrase-packs/phrase-*/phrases.json`.
+
+```bash
+python3 extract_words.py                 # prints the unique word list
+python3 extract_words.py --out words.txt # or write to a file
+```
+
+As of this writing that is **11,757 unique surface words** across ~25,269
+English phrases (10,000 core + 15,269 in 33 phrase packs).
+
+## Schema
+
+One generic table (mirrors `hanzi_etymology`):
+
+```sql
+CREATE TABLE word_explanation(
+  word TEXT NOT NULL,
+  language_code TEXT NOT NULL,
+  paragraph TEXT NOT NULL,
+  PRIMARY KEY(word, language_code)
+);
+```
+
+`pack_meta` carries `schema_version` (currently `1` for this pack family),
+`generated_at`, `core_db`, and `word_count`.
+
+## Generate explanations (LLM)
+
+`generate_word_explanations.py` runs three stages:
+
+1. **English authoring** — one ~50-word multi-sense paragraph per word.
+2. **Origin verification** — an adversarial critic pass over ONLY the
+   etymology clause (definitions/senses are low-risk; origins are
+   hallucination-prone). Each word gets an `origin_confidence` of
+   `high` / `medium` / `low`; overstated or wrong roots are softened or
+   rewritten. **Never confabulate a root** — hedge when unsure.
+3. **Translation** — faithfully render the verified English into each target
+   language; no added facts.
+
+```bash
+# small sample, 4 representative targets
+python3 generate_word_explanations.py \
+  --words running set light the of robot egg deadline freedom \
+  --langs en zh-Hans ar hi es
+
+# full universe, all corpus languages
+python3 generate_word_explanations.py --all-langs
+```
+
+Output writes to `seed/explanations_full.json`. Pass that file into the builder
+with `--explanations`.
+
+## Build
+
+```bash
+python3 build_word_pack.py \
+  --explanations seed/explanations_seed.json \
+  --out ../../packs/wordpan/data/word.sqlite3
+```
+
+Options: `--core-db`, `--packs-dir`, `--limit N`, `--include-seed-words`.
+
+## Seed format
+
+`seed/explanations_seed.json` is a list of records:
+
+```json
+{
+  "word": "running",
+  "explanation": {
+    "en": "Running means moving rapidly on foot, but ...",
+    "zh-Hans": "Running 指快速用脚奔跑 ...",
+    "ar": "...",
+    "hi": "...",
+    "es": "..."
+  },
+  "origin_confidence": "high",
+  "origin_note": "optional: present only when the origin needed hedging"
+}
+```
+
+The checked-in seed is the operator-approved **canonical sample** (17 words),
+not the full set. Replace/extend it with the full generated output once the
+quality bar is approved.
+
+## Consumer lookup (native-first + English fallback)
+
+The pack app should look up `word_explanation` by `(word, ui_language_code)`
+first, then fall back to `language_code = 'en'` when the UI language is absent —
+the same native-first-with-English-fallback pattern used by Hanzipan.

--- a/corpan/dja/word_pack/build_word_pack.py
+++ b/corpan/dja/word_pack/build_word_pack.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Build the SQLite database shipped with the word-explanation pack.
+
+This generalizes the Hanzi pack pipeline (`dja/hanzi_pack`) from per-character
+etymologies to per-word explanations. Each word gets ONE ~50-word paragraph in
+each of the corpus languages, capturing the word's range of common senses
+(polysemy), how those senses relate, where the word came from, and how the
+origin branched into the modern senses.
+
+Schema (one generic table, mirrors `hanzi_etymology`):
+
+    word_explanation(word, language_code, paragraph)
+
+The pack DB is standalone: it uses the core DB only to discover the word
+universe (via extract_words.py), and reads explanation text from the seed JSON.
+
+    seed/explanations_seed.json := [
+        {"word": "running", "explanation": {"en": "...", "zh-Hans": "...", ...}},
+        ...
+    ]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List
+
+from extract_words import collect_words
+
+# Bumped from the Hanzi pack's schema_version=2: the word-explanation pack is a
+# new pack family with its own schema. Kept as a string for parity with the
+# Hanzi pack_meta convention.
+SCHEMA_VERSION = "1"
+
+SCHEMA_SQL = """
+CREATE TABLE pack_meta(
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+
+CREATE TABLE word_explanation(
+  word TEXT NOT NULL,
+  language_code TEXT NOT NULL,
+  paragraph TEXT NOT NULL,
+  PRIMARY KEY(word, language_code)
+);
+
+CREATE INDEX word_explanation_language ON word_explanation(language_code);
+"""
+
+
+def load_explanations(path: Path) -> Dict[str, Dict[str, str]]:
+    """Parse seed JSON into {word: {lang_code: paragraph}}."""
+    if not path.exists():
+        return {}
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    out: Dict[str, Dict[str, str]] = {}
+    if not isinstance(raw, list):
+        return out
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        word = item.get("word")
+        explanation = item.get("explanation")
+        if not isinstance(word, str) or not isinstance(explanation, dict):
+            continue
+        clean = {
+            lang: text
+            for lang, text in explanation.items()
+            if isinstance(lang, str) and isinstance(text, str) and text.strip()
+        }
+        if clean:
+            out[word] = clean
+    return out
+
+
+def main() -> None:
+    here = Path(__file__).resolve()
+    dja = here.parents[1]
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--core-db", type=Path, default=dja / "release.sqlite3")
+    ap.add_argument(
+        "--packs-dir",
+        type=Path,
+        default=dja.parent / "tools" / "phrase-packs",
+    )
+    ap.add_argument(
+        "--explanations",
+        type=Path,
+        default=here.parent / "seed" / "explanations_seed.json",
+    )
+    ap.add_argument(
+        "--out",
+        type=Path,
+        default=dja.parent / "packs" / "wordpan" / "data" / "word.sqlite3",
+    )
+    ap.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Limit number of words (0 = all). For quick iteration.",
+    )
+    ap.add_argument(
+        "--include-seed-words",
+        action="store_true",
+        help=(
+            "Union the live corpus word scan with words already present in "
+            "the explanations seed. Keeps the pack's word universe stable "
+            "across corpus slims (mirrors the Hanzi pack's "
+            "--include-etymology-chars)."
+        ),
+    )
+    args = ap.parse_args()
+
+    core_db = args.core_db.resolve()
+    if not core_db.exists():
+        print(f"Core DB not found: {core_db}", file=sys.stderr)
+        sys.exit(1)
+
+    words: List[str] = collect_words(core_db, args.packs_dir.resolve())
+    explanations = load_explanations(args.explanations.resolve())
+
+    if args.include_seed_words and explanations:
+        seed_words = set(explanations.keys())
+        scan = set(words)
+        added = len(seed_words - scan)
+        if added:
+            print(
+                f"[words] include-seed-words: scan={len(scan)} "
+                f"+ seed-only={added} = {len(scan | seed_words)} total",
+            )
+        words = sorted(scan | seed_words)
+
+    if args.limit:
+        words = words[: args.limit]
+
+    out = args.out.resolve()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    if out.exists():
+        out.unlink()
+
+    conn = sqlite3.connect(str(out))
+    conn.isolation_level = None
+    conn.execute("PRAGMA journal_mode=OFF;")
+    conn.execute("PRAGMA synchronous=OFF;")
+    conn.execute("PRAGMA temp_store=MEMORY;")
+    conn.execute("PRAGMA foreign_keys=OFF;")
+    conn.executescript(SCHEMA_SQL)
+
+    now = datetime.now(timezone.utc).isoformat()
+    conn.executemany(
+        "INSERT INTO pack_meta(key, value) VALUES(?, ?)",
+        [
+            ("schema_version", SCHEMA_VERSION),
+            ("generated_at", now),
+            ("core_db", str(core_db)),
+            ("word_count", str(len(words))),
+        ],
+    )
+
+    rows = 0
+    with_explanation = 0
+    conn.execute("BEGIN")
+    for word in words:
+        by_lang = explanations.get(word, {})
+        if by_lang:
+            with_explanation += 1
+        for lang, paragraph in by_lang.items():
+            conn.execute(
+                "INSERT INTO word_explanation(word, language_code, paragraph) "
+                "VALUES(?, ?, ?)",
+                (word, lang, paragraph),
+            )
+            rows += 1
+    conn.execute("COMMIT")
+
+    conn.execute("ANALYZE;")
+    conn.execute("PRAGMA optimize;")
+    conn.execute("VACUUM;")
+    conn.close()
+
+    print("== Word-explanation pack DB built ==")
+    print(f"Words (universe): {len(words)}")
+    print(f"Words with >=1 explanation: {with_explanation}")
+    print(f"Explanation rows: {rows}")
+    print(f"Output: {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/corpan/dja/word_pack/extract_words.py
+++ b/corpan/dja/word_pack/extract_words.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Extract the unique English word list for the word-explanation pack.
+
+Source = the English side of the core corpus (`release.sqlite3`) PLUS every
+phrase pack under `corpan/tools/phrase-packs/phrase-*/phrases.json`. This is
+the canonical universe of words the pack must explain.
+
+Tokenization keeps it deliberately simple and stable: lowercase, then take
+runs of ASCII letters with internal apostrophes (so "don't" stays one token,
+"x-ray" splits into "x" and "ray"). Numbers and pure punctuation are dropped.
+The result is the set of surface words; lemmatization is intentionally NOT done
+here so the pack can explain words exactly as a learner meets them in a phrase.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Iterable, List, Set
+
+
+WORD_RE = re.compile(r"[a-z]+(?:'[a-z]+)*")
+
+
+def tokenize(text: str) -> Iterable[str]:
+    return WORD_RE.findall(text.lower())
+
+
+def core_english(core_db: Path) -> List[str]:
+    conn = sqlite3.connect(f"file:{core_db}?mode=ro&immutable=1", uri=True)
+    try:
+        row = conn.execute(
+            "SELECT id FROM cor_language WHERE code = 'en'"
+        ).fetchone()
+        if not row:
+            return []
+        (en_id,) = row
+        return [
+            text
+            for (text,) in conn.execute(
+                "SELECT text FROM cor_translation WHERE language_id = ?",
+                (en_id,),
+            )
+            if text
+        ]
+    finally:
+        conn.close()
+
+
+def phrase_pack_english(packs_dir: Path) -> List[str]:
+    out: List[str] = []
+    for phrases_json in sorted(packs_dir.glob("phrase-*/phrases.json")):
+        try:
+            data = json.loads(phrases_json.read_text(encoding="utf-8"))
+        except Exception as exc:  # noqa: BLE001
+            print(f"[warn] skipping {phrases_json}: {exc}", file=sys.stderr)
+            continue
+        if not isinstance(data, list):
+            continue
+        for item in data:
+            if isinstance(item, dict) and isinstance(item.get("english"), str):
+                out.append(item["english"])
+    return out
+
+
+def collect_words(core_db: Path, packs_dir: Path) -> List[str]:
+    texts: List[str] = []
+    texts.extend(core_english(core_db))
+    texts.extend(phrase_pack_english(packs_dir))
+    words: Set[str] = set()
+    for text in texts:
+        words.update(tokenize(text))
+    return sorted(words)
+
+
+def main() -> None:
+    here = Path(__file__).resolve()
+    dja = here.parents[1]
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--core-db", type=Path, default=dja / "release.sqlite3")
+    ap.add_argument(
+        "--packs-dir",
+        type=Path,
+        default=dja.parent / "tools" / "phrase-packs",
+    )
+    ap.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Write the word list (one per line) here. Default: stdout.",
+    )
+    args = ap.parse_args()
+
+    core_db = args.core_db.resolve()
+    if not core_db.exists():
+        print(f"Core DB not found: {core_db}", file=sys.stderr)
+        sys.exit(1)
+
+    words = collect_words(core_db, args.packs_dir.resolve())
+    print(f"[words] unique English words: {len(words)}", file=sys.stderr)
+
+    if args.out:
+        args.out.write_text("\n".join(words) + "\n", encoding="utf-8")
+        print(f"[words] wrote {args.out}", file=sys.stderr)
+    else:
+        for w in words:
+            print(w)
+
+
+if __name__ == "__main__":
+    main()

--- a/corpan/dja/word_pack/generate_word_explanations.py
+++ b/corpan/dja/word_pack/generate_word_explanations.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Generate word explanations (LLM), EN-pivot then translate.
+
+Generalizes `dja/hanzi_pack/generate_hanzi_etymologies.py` from per-character
+etymologies to per-word explanations. Three stages:
+
+  1. ENGLISH authoring -- one ~50-word paragraph per word capturing the range
+     of common senses (polysemy), how they relate, where the word came from,
+     and how the origin branched into the modern senses.
+  2. ORIGIN VERIFICATION -- a separate critic pass over ONLY the etymology
+     clause of each English paragraph. Definitions/senses are low-risk; the
+     origin clause is hallucination-prone, so it is fact-checked and any
+     uncertain root is softened/hedged (never confabulated). Verdicts are
+     recorded so the build can surface low-confidence words.
+  3. TRANSLATION -- faithfully render the verified English paragraph into each
+     target language (written IN that language; no added facts).
+
+Output (seed JSON consumed by build_word_pack.py):
+
+    [{"word": "running",
+      "explanation": {"en": "...", "zh-Hans": "...", ...},
+      "origin_confidence": "high" | "medium" | "low",
+      "origin_note": "..."}, ...]
+
+This module is import-safe without the LLM provider installed: the heavy
+imports happen inside main(), so the schema/parsing helpers (and their tests)
+load with only the stdlib + pydantic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+from pydantic import BaseModel
+
+from extract_words import collect_words
+
+
+# --------------------------------------------------------------------------
+# LLM response schemas
+# --------------------------------------------------------------------------
+class ExplanationItem(BaseModel):
+    word: str
+    explanation: str
+
+
+class ExplanationBatch(BaseModel):
+    items: List[ExplanationItem]
+
+
+class VerifyItem(BaseModel):
+    word: str
+    # "high" = mainstream/well-attested; "medium" = directionally right, hedged;
+    # "low" = uncertain/contested -- the paragraph must hedge or omit the root.
+    confidence: str
+    note: str = ""
+    # Optional corrected paragraph when the critic rewrites a bad origin clause.
+    corrected: str = ""
+
+
+class VerifyBatch(BaseModel):
+    items: List[VerifyItem]
+
+
+class TranslationItem(BaseModel):
+    word: str
+    text: str
+
+
+class TranslationBatch(BaseModel):
+    items: List[TranslationItem]
+
+
+# --------------------------------------------------------------------------
+# Seed I/O (shape matches build_word_pack.load_explanations + extra metadata)
+# --------------------------------------------------------------------------
+def load_seed(path: Path) -> Dict[str, dict]:
+    if not path.exists():
+        return {}
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    out: Dict[str, dict] = {}
+    if isinstance(raw, list):
+        for item in raw:
+            if isinstance(item, dict) and isinstance(item.get("word"), str):
+                rec = dict(item)
+                rec.setdefault("explanation", {})
+                out[item["word"]] = rec
+    return out
+
+
+def save_seed(path: Path, data: Dict[str, dict]) -> None:
+    payload = [
+        {
+            "word": word,
+            "explanation": rec.get("explanation", {}),
+            **(
+                {"origin_confidence": rec["origin_confidence"]}
+                if rec.get("origin_confidence")
+                else {}
+            ),
+            **({"origin_note": rec["origin_note"]} if rec.get("origin_note") else {}),
+        }
+        for word, rec in sorted(data.items(), key=lambda kv: kv[0])
+    ]
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def chunk(items: List[str], size: int) -> List[List[str]]:
+    return [items[i : i + size] for i in range(0, len(items), size)]
+
+
+ENGLISH_SYSTEM = (
+    "You explain English words for language learners. For EACH word write ONE "
+    "flowing paragraph of about 50 words that captures: (1) the word's range of "
+    "common senses (its polysemy, where it has it) and how those senses relate; "
+    "(2) where the word came from (etymology/origin); and (3) how the original "
+    "idea branched into the modern senses. Friendly, accessible, accurate. Write "
+    "in English only. If you are unsure of the precise root, hedge with phrases "
+    "like 'is thought to come from' -- NEVER invent a root. Output JSON with "
+    "`items`: each item has `word` and `explanation`."
+)
+
+VERIFY_SYSTEM = (
+    "You are an adversarial historical-linguistics fact-checker. For each word "
+    "you are given its explanation paragraph. Evaluate ONLY the ORIGIN/etymology "
+    "clause (ignore the definitions/senses). Catch folk etymologies and "
+    "overstated roots. For each word return `confidence` = 'high' (mainstream, "
+    "well-attested), 'medium' (directionally right but should be hedged), or "
+    "'low' (uncertain/contested). Put a one-line `note` only when action is "
+    "needed. If the origin clause is wrong or overstated, return a `corrected` "
+    "paragraph that softens/fixes it (keep ~50 words, keep the senses). NEVER "
+    "confabulate a root; when unsure, hedge. Output JSON with `items`."
+)
+
+
+def main() -> None:
+    here = Path(__file__).resolve()
+    dja = here.parents[1]
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--core-db", type=Path, default=dja / "release.sqlite3")
+    ap.add_argument(
+        "--packs-dir", type=Path, default=dja.parent / "tools" / "phrase-packs"
+    )
+    ap.add_argument(
+        "--out", type=Path, default=here.parent / "seed" / "explanations_full.json"
+    )
+    ap.add_argument(
+        "--langs",
+        nargs="*",
+        default=["en"],
+        help="Language codes to generate (include 'en').",
+    )
+    ap.add_argument(
+        "--all-langs",
+        action="store_true",
+        help="Generate explanations for every language in the core DB.",
+    )
+    ap.add_argument("--words", nargs="*", default=None, help="Explicit word list.")
+    ap.add_argument("--limit", type=int, default=0)
+    ap.add_argument("--batch-size", type=int, default=8)
+    ap.add_argument("--provider", type=str, default="openai")
+    ap.add_argument("--completion-model", type=str, default=None)
+    ap.add_argument(
+        "--skip-verify",
+        action="store_true",
+        help="Skip the origin-verification pass (NOT recommended).",
+    )
+    args = ap.parse_args()
+
+    # Heavy imports deferred so parsing helpers stay import-safe for tests.
+    from corpora_ai.llm_interface import ChatCompletionTextMessage
+    from corpora_ai.provider_loader import load_llm_provider
+
+    core_db = args.core_db.resolve()
+    if not core_db.exists():
+        print(f"Core DB not found: {core_db}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.all_langs:
+        conn = __import__("sqlite3").connect(
+            f"file:{core_db}?mode=ro&immutable=1", uri=True
+        )
+        langs = [c for (c,) in conn.execute("SELECT code FROM cor_language")]
+        conn.close()
+    else:
+        langs = list(args.langs)
+    if "en" not in langs:
+        langs = ["en", *langs]
+
+    if args.words:
+        words = sorted(set(w.lower() for w in args.words))
+    else:
+        words = collect_words(core_db, args.packs_dir.resolve())
+    if args.limit:
+        words = words[: args.limit]
+
+    out = args.out.resolve()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    seed = load_seed(out)
+
+    llm_kwargs = {}
+    if args.completion_model:
+        llm_kwargs["completion_model"] = args.completion_model
+    llm = load_llm_provider(args.provider, **llm_kwargs)
+
+    def msg(role: str, text: str):
+        return ChatCompletionTextMessage(role=role, text=text)
+
+    # 1) English authoring.
+    missing_en = [w for w in words if "en" not in seed.get(w, {}).get("explanation", {})]
+    for i, batch in enumerate(chunk(missing_en, args.batch_size), start=1):
+        print(f"[english] batch {i} ({len(batch)} words)", flush=True)
+        res = llm.get_data_completion(
+            [msg("system", ENGLISH_SYSTEM), msg("user", "\n".join(batch))],
+            ExplanationBatch,
+        )
+        for item in res.items:
+            rec = seed.setdefault(item.word, {"explanation": {}})
+            rec["explanation"]["en"] = item.explanation.strip()
+        save_seed(out, seed)
+
+    # 2) Origin verification (English only).
+    if not args.skip_verify:
+        to_verify = [
+            w
+            for w in words
+            if "en" in seed.get(w, {}).get("explanation", {})
+            and not seed[w].get("origin_confidence")
+        ]
+        for i, batch in enumerate(chunk(to_verify, args.batch_size), start=1):
+            print(f"[verify] batch {i} ({len(batch)} words)", flush=True)
+            payload = "\n".join(
+                f"{w}: {seed[w]['explanation']['en']}" for w in batch
+            )
+            res = llm.get_data_completion(
+                [msg("system", VERIFY_SYSTEM), msg("user", payload)], VerifyBatch
+            )
+            for item in res.items:
+                rec = seed.get(item.word)
+                if not rec:
+                    continue
+                rec["origin_confidence"] = (item.confidence or "medium").lower()
+                if item.note:
+                    rec["origin_note"] = item.note.strip()
+                if item.corrected.strip():
+                    rec["explanation"]["en"] = item.corrected.strip()
+            save_seed(out, seed)
+
+    # 3) Translation of the verified English into each target language.
+    for lang in [c for c in langs if c != "en"]:
+        todo = [
+            w
+            for w in words
+            if "en" in seed.get(w, {}).get("explanation", {})
+            and lang not in seed[w]["explanation"]
+        ]
+        for i, batch in enumerate(chunk(todo, args.batch_size), start=1):
+            print(f"[translate {lang}] batch {i} ({len(batch)} words)", flush=True)
+            payload = "\n".join(
+                f"{w}: {seed[w]['explanation']['en']}" for w in batch
+            )
+            res = llm.get_data_completion(
+                [
+                    msg(
+                        "system",
+                        f"Translate each English word-explanation into language "
+                        f"code '{lang}', written naturally IN that language. "
+                        f"Preserve meaning, tone, hedges, and the ~50-word "
+                        f"length. Do NOT add facts. Output JSON `items` with "
+                        f"`word` and `text`.",
+                    ),
+                    msg("user", payload),
+                ],
+                TranslationBatch,
+            )
+            for item in res.items:
+                rec = seed.get(item.word)
+                if rec and item.text.strip():
+                    rec["explanation"][lang] = item.text.strip()
+            save_seed(out, seed)
+
+    print(f"Done. Wrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/corpan/dja/word_pack/seed/explanations_seed.json
+++ b/corpan/dja/word_pack/seed/explanations_seed.json
@@ -1,0 +1,196 @@
+[
+  {
+    "word": "bank",
+    "explanation": {
+      "en": "Bank has two main, separate senses: the raised edge of a river, and a place that holds money. The riverbank sense comes from Old Norse bakki, a ridge. The money sense comes through Italian banca, the bench or counter where medieval money-changers worked. Both ultimately trace to a Germanic root for a bench or raised surface.",
+      "zh-Hans": "Bank 有两个主要且彼此独立的义项：河流隆起的岸边，以及存放金钱的机构。河岸义来自古诺尔斯语 bakki，意为山脊。银行义则经由意大利语 banca 而来，指中世纪兑币商办公的长凳或柜台。两者最终都追溯到一个表示长凳或隆起面的日耳曼语词根。",
+      "ar": "لكلمة bank معنيان رئيسان منفصلان: الضفّة المرتفعة للنهر، والمؤسسة التي تحفظ المال. ومعنى ضفّة النهر من النوردية القديمة bakki أي تلّ أو حافة. أما معنى المصرف فجاء عبر الإيطالية banca، وهي المقعد أو الطاولة التي كان يعمل عليها صيارفة العصور الوسطى. وكلاهما يعود في النهاية إلى جذر جرماني معناه مقعد أو سطح مرتفع.",
+      "hi": "Bank के दो मुख्य और परस्पर अलग अर्थ हैं: नदी का उठा हुआ किनारा, और धन रखने वाली संस्था। नदी-तट वाला अर्थ पुरानी नॉर्स bakki से आया, अर्थात कगार। बैंक वाला अर्थ इतालवी banca से होकर आया, यानी वह बेंच या काउंटर जहाँ मध्यकालीन मुद्रा-विनिमयकर्ता बैठते थे। दोनों अंततः बेंच या उठी हुई सतह अर्थ वाले एक जर्मैनिक मूल तक जाते हैं।",
+      "es": "Bank tiene dos sentidos principales e independientes: la orilla elevada de un río y la institución que guarda el dinero. El sentido de orilla viene del nórdico antiguo bakki, una loma. El sentido de banco financiero llega a través del italiano banca, el banco o mostrador donde trabajaban los cambistas medievales. Ambos se remontan, en última instancia, a una raíz germánica de banco o superficie elevada."
+    },
+    "origin_confidence": "high"
+  },
+  {
+    "word": "book",
+    "explanation": {
+      "en": "A book is a set of written or printed pages bound together, and we also book a ticket or appointment by writing it down. It comes from Old English bōc, from Proto-Germanic *bōks. Many scholars connect it to the beech tree, whose wood or bark may have been an early writing surface, though this link is not certain.",
+      "zh-Hans": "Book 指装订在一起的一叠手写或印刷书页，我们也用它表示预订，如 book a ticket（订票），即把事情记下来。它源自古英语 bōc，来自原始日耳曼语 *bōks。许多学者把它与山毛榉（beech）相联系，认为其木材或树皮可能是早期的书写材料，但这一关联尚不确定。",
+      "ar": "كلمة book تعني مجموعة من الصفحات المكتوبة أو المطبوعة مجلّدة معًا، ونستعملها أيضًا بمعنى الحجز، كقولك book a ticket (تحجز تذكرة)، أي تدوّنه. وأصلها من الإنجليزية القديمة bōc، من الجرمانية البدائية *bōks. ويربطها كثير من الباحثين بشجرة الزان (beech)، إذ ربما كان خشبها أو لحاؤها سطح كتابة قديمًا، غير أن هذه الصلة غير مؤكّدة.",
+      "hi": "Book का अर्थ है एक साथ जिल्दबंद किए लिखे या छपे पन्नों का समूह, और हम book a ticket (टिकट बुक करना) यानी कुछ लिखकर आरक्षित करना भी कहते हैं। यह पुरानी अंग्रेज़ी के bōc से आया, आदि-जर्मैनिक *bōks से। बहुत-से विद्वान इसे बीच (beech) वृक्ष से जोड़ते हैं, यह मानते हुए कि उसकी लकड़ी या छाल आरंभिक लेखन-सतह रही होगी, पर यह संबंध निश्चित नहीं है।",
+      "es": "Book es un conjunto de páginas escritas o impresas encuadernadas juntas, y también usamos book a ticket (reservar un billete), es decir, anotarlo. Viene del inglés antiguo bōc, del protogermánico *bōks. Muchos estudiosos lo relacionan con el haya (beech), cuya madera o corteza pudo ser una superficie de escritura temprana, aunque esa conexión no es segura."
+    },
+    "origin_confidence": "medium",
+    "origin_note": "Beech-tree connection is contested; explicitly marked uncertain."
+  },
+  {
+    "word": "charge",
+    "explanation": {
+      "en": "To charge can mean to ask a price, to accuse, to rush forward, to fill with electricity, or to load. It comes through Old French charger from Late Latin carricare, to load a wagon, from carrus, a wheeled cart. The idea of loading or laying a burden on something spread into payment, accusation, attack, and electrical charging.",
+      "zh-Hans": "To charge 可以表示索价、指控、向前冲锋、充电，或装填。它经由古法语 charger，来自晚期拉丁语 carricare（给马车装载），再来自 carrus（轮车）。装载、把重负加于某物这一概念，扩展到了付款、指控、攻击以及充电等含义。",
+      "ar": "الفعل to charge قد يعني يطلب ثمنًا، أو يتّهم، أو يندفع للأمام، أو يشحن بالكهرباء، أو يُحمّل. وأصله عبر الفرنسية القديمة charger، من اللاتينية المتأخّرة carricare أي يُحمّل عربة، من carrus وهي عربة ذات عجلات. وفكرة التحميل أو وضع عبء على الشيء انتشرت إلى الدفع والاتهام والهجوم والشحن الكهربائي.",
+      "hi": "To charge का अर्थ हो सकता है दाम माँगना, आरोप लगाना, आगे धावा बोलना, बिजली से चार्ज करना, या भरना। यह पुरानी फ़्रेंच के charger होते हुए, उत्तर-लैटिन के carricare (गाड़ी लादना) से आया, जो carrus (पहियेदार गाड़ी) से है। लादने या किसी पर बोझ रखने का विचार फैलकर भुगतान, आरोप, आक्रमण और बिजली-चार्जिंग तक पहुँच गया।",
+      "es": "To charge puede significar cobrar un precio, acusar, lanzarse hacia delante, cargar de electricidad o cargar peso. Viene a través del francés antiguo charger, del latín tardío carricare, cargar un carro, de carrus, un carro de ruedas. La idea de cargar o poner una carga sobre algo se extendió hacia el pago, la acusación, el ataque y la carga eléctrica."
+    },
+    "origin_confidence": "high"
+  },
+  {
+    "word": "deadline",
+    "explanation": {
+      "en": "A deadline is the time by which something must be finished. The word is widely reported to come from the American Civil War, naming a line around a prison camp that prisoners were shot for crossing. It combines dead and line. The grim boundary-you-must-not-cross sense shifted, by the early twentieth century, into our familiar time limit.",
+      "zh-Hans": "Deadline 指某事必须完成的最后期限。该词普遍被认为源自美国南北战争，指战俘营周围的一条线，越过此线的战俘会遭枪击；它由 dead 和 line 组合而成。这种不可逾越的致命界线之义，在二十世纪初转变为我们熟悉的时间期限。",
+      "ar": "تعني كلمة deadline الموعد النهائي الذي يجب إنجاز الشيء قبله. ويُقال على نطاق واسع إنها من الحرب الأهلية الأمريكية، حيث تسمّي خطًا حول معسكر للأسرى كان من يتجاوزه يُطلق عليه الرصاص؛ وهي مركّبة من dead وline. ومعنى الحدّ المميت الذي لا يُتجاوز تحوّل في مطلع القرن العشرين إلى مهلتنا الزمنية المألوفة.",
+      "hi": "Deadline वह अंतिम समय है जिसके भीतर कोई काम पूरा होना चाहिए। यह शब्द व्यापक रूप से अमेरिकी गृहयुद्ध से आया माना जाता है, जो किसी बंदी-शिविर के चारों ओर खींची उस रेखा को कहता था जिसे पार करने पर बंदियों को गोली मार दी जाती थी; यह dead और line से बना है। जिसे पार न किया जाए ऐसी घातक सीमा का यह भाव बीसवीं सदी के आरंभ तक हमारी जानी-पहचानी समय-सीमा में बदल गया।",
+      "es": "Una deadline es el plazo en que algo debe terminarse. Se suele afirmar que viene de la Guerra Civil estadounidense, donde nombraba una línea alrededor de un campo de prisioneros que, al cruzarse, suponía recibir disparos; combina dead y line. Aquel sentido de frontera mortal que no se debe cruzar derivó, a comienzos del siglo XX, en nuestro conocido límite de tiempo."
+    },
+    "origin_confidence": "medium",
+    "origin_note": "Civil-War prison-line origin is widely reported but the line of descent to 'time limit' is not firmly established; kept hedged."
+  },
+  {
+    "word": "egg",
+    "explanation": {
+      "en": "An egg is the rounded object birds and other animals lay, and by extension we egg someone on or call a foolish person a bad egg. The word comes from Old Norse egg, brought by Scandinavian settlers, which replaced the native Old English ey. Both go back to a shared Proto-Germanic root *ajją for the same thing.",
+      "zh-Hans": "Egg 指鸟类及其他动物所产的圆形物，引申还有怂恿（egg someone on）以及把坏人称作 bad egg（坏蛋）等用法。该词来自古诺尔斯语 egg，由斯堪的纳维亚移民带入，取代了本土古英语词 ey。两者都上溯到共同的原始日耳曼语词根 *ajją，指的是同一样东西。",
+      "ar": "كلمة egg تعني الجسم المستدير الذي تضعه الطيور وغيرها من الحيوانات، ومجازًا نقول egg someone on (نحرّضه) ونصف الشخص الأحمق بأنه bad egg. وأصلها من النوردية القديمة egg، أدخله المستوطنون الإسكندناف، فحلّ محل الكلمة الإنجليزية القديمة الأصلية ey. وكلاهما يعود إلى جذر جرماني بدائي مشترك *ajją لنفس الشيء.",
+      "hi": "Egg वह गोल वस्तु है जिसे पक्षी और अन्य जीव देते हैं, और इससे आगे egg someone on (उकसाना) तथा मूर्ख व्यक्ति को bad egg कहने जैसे प्रयोग बने। यह शब्द पुरानी नॉर्स egg से आया, जिसे स्कैंडिनेवियाई बसने वालों ने लाया, और इसने मूल पुरानी अंग्रेज़ी शब्द ey की जगह ले ली। दोनों एक ही चीज़ के लिए साझा आदि-जर्मैनिक मूल *ajją तक जाते हैं।",
+      "es": "Egg es el objeto redondeado que ponen las aves y otros animales, y de ahí también egg someone on (incitar a alguien) o llamar bad egg a una persona deshonesta. La palabra viene del nórdico antiguo egg, traída por colonos escandinavos, que reemplazó a la voz nativa del inglés antiguo ey. Ambas se remontan a una misma raíz protogermánica *ajją para lo mismo."
+    },
+    "origin_confidence": "high"
+  },
+  {
+    "word": "freedom",
+    "explanation": {
+      "en": "Freedom is the state of being free, able to act, speak, or think without undue restraint, covering everything from political liberty to personal choice. It comes from Old English frēodōm, joining frēo (free) and the suffix -dōm, which marks a state or condition, as in kingdom or wisdom. The root frēo is ultimately related to an old word-family meaning dear or beloved.",
+      "zh-Hans": "Freedom 指自由的状态，即能够不受过度约束地行动、言说或思考，涵盖从政治自由到个人选择的一切。它源自古英语 frēodōm，由 frēo（自由的）与后缀 -dōm 构成，后者表示一种状态或情形，如 kingdom（王国）或 wisdom（智慧）。词根 frēo 最终还与一个意为亲爱、心爱的古老词族相关。",
+      "ar": "كلمة freedom تعني حال الحرية، أي القدرة على الفعل أو القول أو التفكير دون قيد مفرط، وتشمل كل شيء من الحرية السياسية إلى الاختيار الشخصي. وأصلها من الإنجليزية القديمة frēodōm، تجمع frēo (حر) واللاحقة -dōm التي تدل على حال أو وضع، كما في kingdom (مملكة) أو wisdom (حكمة). والجذر frēo يتصل في النهاية بعائلة كلمات قديمة معناها عزيز أو محبوب.",
+      "hi": "Freedom का अर्थ है स्वतंत्र होने की अवस्था, अर्थात अनुचित बंधन के बिना कार्य करने, बोलने या सोचने की क्षमता, जिसमें राजनीतिक स्वतंत्रता से लेकर व्यक्तिगत चयन तक सब शामिल है। यह पुरानी अंग्रेज़ी के frēodōm से आया, जो frēo (स्वतंत्र) और प्रत्यय -dōm से बना, जो अवस्था या दशा दर्शाता है, जैसे kingdom या wisdom। मूल frēo अंततः प्रिय या प्यारा अर्थ वाले एक प्राचीन शब्द-कुल से संबंधित है।",
+      "es": "Freedom es el estado de ser libre, poder actuar, hablar o pensar sin restricción indebida, y abarca desde la libertad política hasta la elección personal. Viene del inglés antiguo frēodōm, que une frēo (libre) y el sufijo -dōm, que marca un estado o condición, como en kingdom (reino) o wisdom (sabiduría). La raíz frēo se relaciona, en última instancia, con una vieja familia de palabras que significaban querido o amado."
+    },
+    "origin_confidence": "medium",
+    "origin_note": "Link of free to 'dear/beloved' framed as ultimate relation, not direct meaning."
+  },
+  {
+    "word": "light",
+    "explanation": {
+      "en": "Light names the brightness we see by, but also means not heavy, pale in colour, or to set something burning. The illumination sense comes from Old English lēoht, from a Proto-Germanic and Indo-European root meaning to shine. The not-heavy sense is an unrelated word from a different root; the two only came to share their modern spelling by coincidence.",
+      "zh-Hans": "Light 指我们赖以看见的光亮，但也表示不重、颜色浅，或点燃某物。表示光的义来自古英语 lēoht，源于一个意为照耀的原始日耳曼语和印欧语词根。表示轻的义则是另一个无关的词，来自不同词根；二者只是碰巧在现代拼写上变得相同。",
+      "ar": "تشير كلمة light إلى الضوء الذي نرى به، لكنها تعني أيضًا غير ثقيل، أو فاتح اللون، أو أن تُشعل شيئًا. معنى الإضاءة من الإنجليزية القديمة lēoht، من جذر جرماني بدائي وهندي-أوروبي معناه يضيء. أما معنى الخفيف فهو كلمة أخرى لا صلة لها من جذر مختلف؛ ولم يتطابق اللفظان في الكتابة الحديثة إلا مصادفةً.",
+      "hi": "Light का अर्थ है वह उजाला जिससे हम देखते हैं, पर इसका अर्थ हल्का, फीके रंग का, या किसी चीज़ को जलाना भी है। प्रकाश वाला अर्थ पुरानी अंग्रेज़ी के lēoht से आया, जो चमकना अर्थ वाले एक आदि-जर्मैनिक तथा भारोपीय मूल से है। हल्का वाला अर्थ एक असंबंधित शब्द है, भिन्न मूल से; दोनों केवल संयोगवश आधुनिक वर्तनी में एक जैसे हो गए।",
+      "es": "Light nombra la claridad con que vemos, pero también significa no pesado, de color pálido, o encender algo. El sentido de iluminación viene del inglés antiguo lēoht, de una raíz protogermánica e indoeuropea que significaba brillar. El sentido de poco peso es una palabra distinta y sin relación, de otra raíz; ambas solo coincidieron por azar en su grafía moderna."
+    },
+    "origin_confidence": "medium",
+    "origin_note": "Two unrelated roots (shine vs. not-heavy) that became homographs; framed as coincidence, not a merge."
+  },
+  {
+    "word": "nice",
+    "explanation": {
+      "en": "Nice today means pleasant or kind, but it once meant foolish or ignorant. It comes through Old French from Latin nescius, not knowing, from ne (not) and scire (to know). Over centuries its sense drifted from foolish, to precise or fussy, to fine and agreeable, finally settling on the warm everyday meaning we use now.",
+      "zh-Hans": "Nice 如今意为宜人或友善，但它曾经的意思是愚蠢、无知。它经由古法语来自拉丁语 nescius，意为不知道，由 ne（不）和 scire（知道）构成。数百年间，它的词义从愚蠢漂移到精确、挑剔，再到美好，最终定型为我们今天所用的温和日常含义。",
+      "ar": "كلمة nice تعني اليوم لطيفًا أو طيّبًا، لكنها كانت تعني سابقًا أحمق أو جاهلًا. وصلت عبر الفرنسية القديمة من اللاتينية nescius أي غير عارف، من ne (لا) وscire (يعرف). وعبر قرون انزاح معناها من الحماقة إلى الدقّة أو التزمّت، ثم إلى الجيّد، حتى استقرّ على المعنى اليومي الدافئ الذي نستعمله الآن.",
+      "hi": "Nice का आज अर्थ है सुखद या दयालु, पर कभी इसका अर्थ मूर्ख या अज्ञानी था। यह पुरानी फ़्रेंच होते हुए लैटिन के nescius से आया, अर्थात न जानने वाला, जो ne (नहीं) और scire (जानना) से बना। सदियों में इसका अर्थ मूर्ख से खिसककर सटीक या नकचढ़ा, फिर उत्तम, और अंततः उस गर्मजोश रोज़मर्रा अर्थ पर ठहरा जो हम अब प्रयोग करते हैं।",
+      "es": "Nice hoy significa agradable o amable, pero antaño significaba tonto o ignorante. Llegó a través del francés antiguo desde el latín nescius, que no sabe, de ne (no) y scire (saber). A lo largo de siglos su sentido se desplazó de necio a preciso o quisquilloso, luego a fino, hasta asentarse en el cálido significado cotidiano que usamos ahora."
+    },
+    "origin_confidence": "high"
+  },
+  {
+    "word": "of",
+    "explanation": {
+      "en": "Of links things to show belonging, origin, or material, as in the leg of the table or a cup of tea. It comes from Old English of, originally meaning away or from, the same word as off, from Proto-Germanic *aba. The early sense of moving away from a source softened into the general grammatical link of possession and relation.",
+      "zh-Hans": "Of 用来连接事物，表示从属、来源或材料，如 the leg of the table（桌子的腿）或 a cup of tea（一杯茶）。它源自古英语 of，本意为离开或从某处来，与 off 是同一个词，来自原始日耳曼语 *aba。早期从某来源离开的含义，软化成了表示所属和关系的通用语法连接词。",
+      "ar": "تربط كلمة of بين الأشياء لتدل على الانتماء أو الأصل أو المادة، كقولك the leg of the table (ساق الطاولة) أو a cup of tea (فنجان شاي). وأصلها من الإنجليزية القديمة of بمعنى بعيدًا أو مِن، وهي الكلمة نفسها off، من الجرمانية البدائية *aba. ومعناها المبكر الابتعاد عن مصدر تلطّف ليصير رابطًا نحويًا عامًا للملكية والعلاقة.",
+      "hi": "Of चीज़ों को जोड़कर अपनापन, उद्गम या सामग्री दर्शाता है, जैसे the leg of the table (मेज़ का पाया) या a cup of tea (एक कप चाय)। यह पुरानी अंग्रेज़ी के of से आया, जिसका मूल अर्थ था दूर या से, और यह off ही का रूप है, आदि-जर्मैनिक *aba से। स्रोत से दूर जाने का आरंभिक भाव नरम होकर संबंध और स्वामित्व का सामान्य व्याकरणिक संयोजक बन गया।",
+      "es": "Of une cosas para indicar pertenencia, origen o material, como the leg of the table (la pata de la mesa) o a cup of tea (una taza de té). Viene del inglés antiguo of, que originalmente significaba lejos o desde, la misma palabra que off, del protogermánico *aba. El sentido temprano de alejarse de un origen se suavizó hasta el enlace gramatical general de posesión y relación."
+    },
+    "origin_confidence": "high"
+  },
+  {
+    "word": "passport",
+    "explanation": {
+      "en": "A passport is the document allowing you to travel between countries, and figuratively anything that grants entry, as in a passport to success. It comes from French passeport, from passer (to pass) and port; the port likely meant a city gate or harbour, though sources differ on which. The original permission to pass broadened into the modern travel document.",
+      "zh-Hans": "Passport 是允许你在国家之间旅行的证件，引申还指任何获得准入的东西，如 a passport to success（通往成功的通行证）。它源自法语 passeport，由 passer（通过）和 port 组成；port 可能指城门或港口，但出处说法不一。最初准许通过的含义，扩展成了现代的旅行证件。",
+      "ar": "جواز السفر (passport) هو الوثيقة التي تتيح لك السفر بين البلدان، ومجازًا كل ما يمنح الدخول، كقولك passport to success (جواز إلى النجاح). وأصله من الفرنسية passeport، من passer (يمرّ) وport؛ وربما عنى port بوابة مدينة أو ميناءً، غير أن المصادر تختلف في ذلك. ومعنى الإذن بالمرور الأصلي اتسع ليصير وثيقة السفر الحديثة.",
+      "hi": "Passport वह दस्तावेज़ है जो आपको देशों के बीच यात्रा की अनुमति देता है, और लाक्षणिक रूप से वह कोई भी चीज़ जो प्रवेश दिलाए, जैसे a passport to success (सफलता का पासपोर्ट)। यह फ़्रेंच के passeport से आया, passer (पार करना) और port से; यहाँ port संभवतः नगर-द्वार या बंदरगाह था, पर स्रोत इस पर भिन्न हैं। पार होने की अनुमति का मूल भाव फैलकर आधुनिक यात्रा-दस्तावेज़ बना।",
+      "es": "Un passport es el documento que permite viajar entre países, y en sentido figurado cualquier cosa que franquea la entrada, como a passport to success (un pasaporte al éxito). Viene del francés passeport, de passer (pasar) y port; ese port quizá designaba una puerta de ciudad o un puerto, aunque las fuentes discrepan. El sentido original de permiso para pasar se amplió hasta el documento de viaje moderno."
+    },
+    "origin_confidence": "medium",
+    "origin_note": "Sense of 'port' (city gate vs. harbour) is contested; hedged."
+  },
+  {
+    "word": "robot",
+    "explanation": {
+      "en": "A robot is a machine that performs tasks automatically, and the word is now also used for software that runs without a person. It was introduced in 1920 in Karel Čapek's play R.U.R., though Čapek credited the actual coinage to his brother Josef, from Czech robota, forced labour or drudgery. The idea of compelled work gave us today's tireless mechanical worker.",
+      "zh-Hans": "Robot 指能自动完成任务的机器，如今也用来指无需人操作而运行的软件。该词于 1920 年出现在捷克作家卡雷尔·恰佩克的剧作 R.U.R. 中，不过恰佩克本人把造词归功于他的兄弟约瑟夫；它来自捷克语 robota，意为强制劳动或苦役。这种被迫劳作的本意，造就了今天不知疲倦的机械工人。",
+      "ar": "كلمة robot تعني آلة تؤدي المهام تلقائيًا، وتُستعمل اليوم أيضًا للبرامج التي تعمل دون إنسان. ظهرت عام 1920 في مسرحية الكاتب التشيكي كاريل تشابيك R.U.R.، غير أن تشابيك نسب صكّ الكلمة إلى أخيه يوزيف؛ وأصلها من التشيكية robota أي العمل القسري أو الكدح. ومن فكرة العمل المفروض هذه جاءنا عاملنا الآلي الدؤوب اليوم.",
+      "hi": "Robot का अर्थ है ऐसी मशीन जो कार्य स्वतः करती है, और अब यह शब्द बिना व्यक्ति के चलने वाले सॉफ़्टवेयर के लिए भी प्रयुक्त होता है। यह 1920 में चेक लेखक कारेल चापेक के नाटक R.U.R. में आया, हालाँकि चापेक ने शब्द-रचना का श्रेय अपने भाई योज़ेफ़ को दिया; यह चेक के robota से है, अर्थात बेगार या कठोर श्रम। इसी बाध्य श्रम के भाव से आज का अथक यांत्रिक कर्मी मिला।",
+      "es": "Robot designa una máquina que realiza tareas de forma automática, y hoy también el software que funciona sin una persona. Apareció en 1920 en la obra R.U.R. del escritor checo Karel Čapek, aunque él atribuyó la creación de la palabra a su hermano Josef; viene del checo robota, trabajo forzado o servidumbre. Esa idea de labor impuesta nos dio el incansable trabajador mecánico de hoy."
+    },
+    "origin_confidence": "medium",
+    "origin_note": "Coinage commonly credited to Josef Capek, not Karel; noted."
+  },
+  {
+    "word": "run",
+    "explanation": {
+      "en": "To run is to move fast on foot, but we also run a business, run late, run a tap, or watch a road run north. It comes from Old English rinnan, to flow, from Proto-Germanic *rinnaną, its modern form also shaped by Old Norse. The single idea of swift, continuous motion broadened to cover operating, flowing, and extending in space or time.",
+      "zh-Hans": "To run 是用脚快跑，但我们也说经营生意、迟到、开水龙头，或说一条路向北延伸。它源自古英语 rinnan，意为流动，来自原始日耳曼语 *rinnaną，其现代词形还受到古诺尔斯语的影响。迅速而持续运动这一单一概念，扩展到涵盖运转、流动以及在空间或时间上的延伸。",
+      "ar": "أن تَجري (run) هو أن تتحرك سريعًا على قدميك، لكننا أيضًا نُدير عملًا، ونتأخر، ونفتح صنبورًا، ونرى طريقًا يمتد شمالًا. وأصلها من الإنجليزية القديمة rinnan أي يتدفق، من الجرمانية البدائية *rinnaną، وقد تأثر شكلها الحديث أيضًا بالنوردية القديمة. ففكرة الحركة السريعة المتصلة الواحدة اتسعت لتشمل التشغيل والتدفق والامتداد في المكان أو الزمان.",
+      "hi": "Run का अर्थ है पैरों से तेज़ दौड़ना, पर हम व्यवसाय चलाना, देर से आना, नल खोलना, या किसी सड़क को उत्तर की ओर फैलते देखना भी कहते हैं। यह पुरानी अंग्रेज़ी के rinnan से आया, अर्थात बहना, आदि-जर्मैनिक *rinnaną से; इसके आधुनिक रूप पर पुरानी नॉर्स का भी प्रभाव पड़ा। तीव्र, निरंतर गति का एक ही विचार फैलकर चलने, बहने और स्थान या समय में विस्तार तक पहुँच गया।",
+      "es": "Correr (run) es moverse rápido a pie, pero también dirigimos un negocio, llegamos tarde, abrimos un grifo o vemos una carretera que se extiende al norte. Viene del inglés antiguo rinnan, fluir, del protogermánico *rinnaną, y su forma moderna fue además moldeada por el nórdico antiguo. La sola idea de movimiento veloz y continuo se amplió para abarcar funcionar, fluir y extenderse en el espacio o el tiempo."
+    },
+    "origin_confidence": "medium",
+    "origin_note": "Modern form shaped by Old Norse alongside Old English rinnan; noted."
+  },
+  {
+    "word": "running",
+    "explanation": {
+      "en": "Running means moving rapidly on foot, but can also describe something operating, continuing, or flowing, as in a running engine, a running program, or running water. It comes from Old English rinnan and irnan, to flow or move swiftly, from Proto-Germanic *rinnaną. The original idea of continuous movement later branched into these modern uses.",
+      "zh-Hans": "Running 指快速用脚奔跑，比走路更快，但也能表示某物正在运转、持续或流动，如运转的引擎、运行的程序或流动的水。该词源自古英语 rinnan 和 irnan，意为流动或迅速移动，再上溯到原始日耳曼语 *rinnaną。最初连续移动的概念后来分化出这些现代含义。",
+      "ar": "تعني كلمة running الجري السريع على القدمين، لكنها قد تصف أيضًا شيئًا يعمل أو يستمر أو يتدفق، كمحرّك يعمل أو برنامج يشتغل أو ماء يجري. وأصلها من الإنجليزية القديمة rinnan وirnan بمعنى يتدفق أو يتحرك بسرعة، من الجرمانية البدائية *rinnaną. وفكرة الحركة المستمرة الأصلية تفرّعت لاحقًا إلى هذه المعاني الحديثة.",
+      "hi": "Running का अर्थ है पैरों से तेज़ दौड़ना, पर यह किसी चीज़ के चलने, जारी रहने या बहने को भी बता सकता है, जैसे चलता इंजन, चलता प्रोग्राम या बहता पानी। यह पुरानी अंग्रेज़ी के rinnan और irnan से आया है, जिसका अर्थ है बहना या तेज़ी से बढ़ना, और आगे आदि-जर्मैनिक *rinnaną से। निरंतर गति का मूल विचार बाद में इन आधुनिक अर्थों में बँट गया।",
+      "es": "Running significa moverse rápidamente a pie, pero también puede describir algo que funciona, continúa o fluye, como un motor en marcha, un programa en ejecución o agua que corre. Procede del inglés antiguo rinnan e irnan, fluir o moverse con rapidez, del protogermánico *rinnaną. La idea original de movimiento continuo se ramificó luego en estos usos modernos."
+    },
+    "origin_confidence": "high"
+  },
+  {
+    "word": "set",
+    "explanation": {
+      "en": "Set is one of English's most versatile words: to place something, to harden (jelly sets), a group of things, a tennis division, or the scenery of a play. It comes from Old English settan, to cause to sit, from Proto-Germanic *satjaną, the causative of sit. The core sense of putting in place spread outward into its many meanings.",
+      "zh-Hans": "Set 是英语中用途最广的词之一：放置某物、凝固（果冻凝固）、一组东西、网球中的一盘，或一出戏的布景。它源自古英语 settan，意为使坐下，来自原始日耳曼语 *satjaną，是 sit（坐）的使役形式。把东西放置就位这一核心义向外扩展，衍生出众多含义。",
+      "ar": "تُعد كلمة set من أكثر الكلمات تنوعًا في الإنجليزية: أن تضع شيئًا، أن يتماسك (الهلام يتماسك)، مجموعة من الأشياء، شوط في التنس، أو ديكور مسرحية. وأصلها من الإنجليزية القديمة settan أي يجعله يجلس، من الجرمانية البدائية *satjaną، وهي الصيغة السببية للفعل sit (يجلس). فمن معنى وضع الشيء في مكانه انتشرت معانيها الكثيرة.",
+      "hi": "Set अंग्रेज़ी के सबसे बहुअर्थी शब्दों में से एक है: कुछ रखना, जमना (जेली जमती है), चीज़ों का समूह, टेनिस का एक सेट, या नाटक का मंच-सज्जा। यह पुरानी अंग्रेज़ी के settan से आया, अर्थात बैठाना, जो आदि-जर्मैनिक *satjaną से है, यानी sit (बैठना) का प्रेरणार्थक रूप। स्थान पर रखने का मूल भाव फैलकर इसके अनेक अर्थ बने।",
+      "es": "Set es una de las palabras más versátiles del inglés: colocar algo, cuajar (la gelatina cuaja), un conjunto de cosas, un set de tenis o el decorado de una obra. Viene del inglés antiguo settan, hacer sentar, del protogermánico *satjaną, la forma causativa de sit (sentarse). El sentido básico de poner en su lugar se extendió hacia sus muchos significados."
+    },
+    "origin_confidence": "high"
+  },
+  {
+    "word": "spirit",
+    "explanation": {
+      "en": "Spirit means the soul or animating force, but also liveliness, an attitude, the true intent of a rule, or distilled alcohol. It comes from Latin spiritus, breath or breathing, from spirare, to breathe. The ancient link between breath and life let the word branch from literal breathing into soul, mood, essence, and the volatile liquids called spirits.",
+      "zh-Hans": "Spirit 指灵魂或赋予生命的力量，但也表示活力、某种态度、规则的真正精神，以及蒸馏出的烈酒。它源自拉丁语 spiritus，意为呼吸，来自 spirare（呼吸）。古人把呼吸与生命相联系，使这个词从字面的呼吸分化出灵魂、情绪、本质，以及那些易挥发的液体，即烈酒。",
+      "ar": "كلمة spirit تعني الروح أو القوة المحيية، لكنها تعني أيضًا الحيوية، أو موقفًا، أو روح القاعدة الحقيقية، أو الكحول المقطَّر. وأصلها من اللاتينية spiritus أي النَّفَس، من spirare (يتنفّس). والربط القديم بين النَّفَس والحياة سمح للكلمة أن تتفرّع من التنفّس الحرفي إلى الروح والمزاج والجوهر، وإلى تلك السوائل المتطايرة المسمّاة أرواحًا.",
+      "hi": "Spirit का अर्थ है आत्मा या जीवनदायी शक्ति, पर यह उत्साह, कोई दृष्टिकोण, किसी नियम का असली भाव, और आसुत मद्य भी दर्शाता है। यह लैटिन के spiritus से आया, अर्थात साँस, spirare (साँस लेना) से। साँस और जीवन के बीच के प्राचीन संबंध ने इस शब्द को शाब्दिक साँस से आत्मा, मनोदशा, सार, और स्पिरिट्स कहलाने वाले वाष्पशील तरलों में बँटने दिया।",
+      "es": "Spirit significa el alma o la fuerza que anima, pero también vivacidad, una actitud, el verdadero sentido de una norma o el alcohol destilado. Viene del latín spiritus, aliento, de spirare, respirar. El antiguo vínculo entre respiración y vida permitió que la palabra se ramificara desde el respirar literal hacia el alma, el ánimo, la esencia y esos líquidos volátiles llamados spirits."
+    },
+    "origin_confidence": "high"
+  },
+  {
+    "word": "the",
+    "explanation": {
+      "en": "The is the most common word in English, a definite article pointing to something specific and already known, as in the door rather than a door. It descends from Old English demonstratives like se and þæt, from a Proto-Germanic and Indo-European pointing root that also gave us that and this. Over time these pointing words wore down into the neutral article.",
+      "zh-Hans": "The 是英语中最常用的词，是一个定冠词，指向具体且已知的事物，如 the door（那扇门）而非 a door（一扇门）。它源自古英语的指示词，如 se 和 þæt，来自一个表示指点的原始日耳曼语和印欧语词根，这词根也产生了 that 和 this。久而久之，这些指示词磨损成了中性的冠词。",
+      "ar": "كلمة the هي الأكثر شيوعًا في الإنجليزية، وهي أداة تعريف تشير إلى شيء محدّد ومعروف سلفًا، كقولك the door (الباب) بدل a door (باب ما). وتنحدر من أدوات إشارة في الإنجليزية القديمة مثل se وþæt، من جذر إشاري في الجرمانية البدائية والهندية-الأوروبية أعطى أيضًا that وthis. ومع الزمن تآكلت هذه الكلمات المشيرة لتصير أداة تعريف محايدة.",
+      "hi": "The अंग्रेज़ी का सबसे आम शब्द है, एक निश्चयवाचक उपपद जो किसी विशिष्ट और पहले से ज्ञात चीज़ की ओर इशारा करता है, जैसे the door (वही दरवाज़ा) न कि a door (कोई दरवाज़ा)। यह पुरानी अंग्रेज़ी के संकेतवाचक शब्दों se और þæt से उतरा है, एक आदि-जर्मैनिक तथा भारोपीय संकेत-मूल से, जिसने that और this भी दिए। समय के साथ ये संकेतवाची शब्द घिसकर एक तटस्थ उपपद बन गए।",
+      "es": "The es la palabra más frecuente del inglés, un artículo determinado que señala algo concreto y ya conocido, como the door (la puerta) frente a a door (una puerta). Desciende de demostrativos del inglés antiguo como se y þæt, de una raíz señaladora protogermánica e indoeuropea que también dio that y this. Con el tiempo, esas palabras señaladoras se desgastaron hasta el artículo neutro."
+    },
+    "origin_confidence": "high"
+  },
+  {
+    "word": "water",
+    "explanation": {
+      "en": "Water is the clear liquid that fills seas and rivers and that we drink, and figuratively we water plants, water down a drink, or test the waters. It comes from Old English wæter, from Proto-Germanic *watōr, going back to a very old Indo-European root *wódr̥ that gave water words across many related languages.",
+      "zh-Hans": "Water 指充满海洋与河流、供我们饮用的清澈液体，引申还有 water plants（浇灌植物）、water down（冲淡饮料）以及 test the waters（试探）等用法。它源自古英语 wæter，来自原始日耳曼语 *watōr，再上溯到一个非常古老的印欧语词根 *wódr̥，许多亲属语言中表示水的词都源于它。",
+      "ar": "كلمة water تعني السائل الصافي الذي يملأ البحار والأنهار ونشربه، ومجازًا نقول water plants (نسقي النبات) وwater down (نخفّف الشراب) وtest the waters (نجسّ النبض). وأصلها من الإنجليزية القديمة wæter، من الجرمانية البدائية *watōr، وتعود إلى جذر هندي-أوروبي عريق جدًّا *wódr̥ أعطى كلمات الماء في لغات قريبة كثيرة.",
+      "hi": "Water वह स्वच्छ तरल है जो समुद्रों और नदियों को भरता है और जिसे हम पीते हैं, और लाक्षणिक रूप से हम water plants (पौधों को सींचना), water down (पेय को पतला करना), या test the waters (आज़माइश करना) कहते हैं। यह पुरानी अंग्रेज़ी के wæter से आया, आदि-जर्मैनिक *watōr से, जो एक बहुत प्राचीन भारोपीय मूल *wódr̥ तक जाता है, जिसने अनेक संबंधी भाषाओं में जल के शब्द दिए।",
+      "es": "Water es el líquido claro que llena mares y ríos y que bebemos, y en sentido figurado decimos water plants (regar las plantas), water down (aguar una bebida) o test the waters (tantear el terreno). Viene del inglés antiguo wæter, del protogermánico *watōr, que se remonta a una raíz indoeuropea muy antigua, *wódr̥, origen de palabras para agua en muchas lenguas emparentadas."
+    },
+    "origin_confidence": "high"
+  }
+]


### PR DESCRIPTION
### **User description**
## What

Generalizes the Hanzi etymology pipeline (`dja/hanzi_pack`) into a **generic word-explanation pack** for Phrase Flip (epic #470, schema #472, pilot #474). Schema + builder + a small operator-review sample. **Does not scale generation.**

### Schema (one generic table, mirrors `hanzi_etymology`)
```sql
CREATE TABLE word_explanation(
  word TEXT NOT NULL,
  language_code TEXT NOT NULL,
  paragraph TEXT NOT NULL,
  PRIMARY KEY(word, language_code)
);
```
`pack_meta.schema_version = 1` (new pack family).

### Files
- `word_pack/extract_words.py` — unique English word universe from the core corpus (`release.sqlite3`) **+ ALL 33 phrase packs**. Real count: **11,757 unique surface words** across ~25,269 English phrases (10,000 core + 15,269 phrase-pack).
- `word_pack/build_word_pack.py` — emits standalone `word.sqlite3` (mirrors `build_hanzi_pack.py`; `--include-seed-words` parallels `--include-etymology-chars`).
- `word_pack/generate_word_explanations.py` — EN-pivot authoring → **adversarial ORIGIN-verification pass** (the etymology clause is hallucination-prone; never confabulate a root, hedge when unsure, record `origin_confidence`) → faithful translation.
- `word_pack/seed/explanations_seed.json` — operator-review **sample of 17 words** (incl. the locked `running` exemplar) in `en / zh-Hans / ar / hi / es`. Origins verified; 10 high / 7 medium confidence (medium ones carry an `origin_note`).
- `cor/utils/test_word_pack.py` — self-contained pytest (pytest + pydantic only, no Django/corpora_ai) so the `dja` CI gate stays green. 10 tests; full `cor/utils` suite: 34 passed.

### Per-word format (the bar)
One ~50-word paragraph = the word's **range of senses** (polysemy) + how they relate + **origin** + how the origin **branched** into the senses. Written natively in each language. Exemplar (`running`): "Running means moving rapidly on foot, but can also describe something operating, continuing, or flowing... It comes from Old English rinnan and irnan... The original idea of continuous movement later branched into these modern uses."

### Sizing (honest read)
Projected full English pack (11,757 words × 54 langs, ~50-word paragraphs): **~120–150 MB compressed** by two independent estimates (text-blob gzip and scaled SQLite gzip). This is **above** the spec's ~20–40 MB ballpark — flagged for the operator before any scale. The 5-lang sample over-weights byte-heavy hi/ar; the true 54-lang mix averages lighter, but the order of magnitude stands.

The canonical sample is posted for quality approval in #474. Builder verified end-to-end against the real corpus (scans 11,757 words, emits 85 sample rows).


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add generic word-explanation pack pipeline

- Build standalone SQLite word schema

- Generate verified multilingual explanation seeds

- Cover pipeline contracts with pytest


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["English corpus and phrase packs"]
  B["Word extractor"]
  C["LLM generation pipeline"]
  D["Verified multilingual seed JSON"]
  E["SQLite pack builder"]
  F["word.sqlite3 pack"]
  A -- "scan phrases" --> B
  B -- "word universe" --> C
  C -- "author, verify, translate" --> D
  B -- "word list" --> E
  D -- "explanation rows" --> E
  E -- "emit pack" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_word_pack.py</strong><dd><code>Add word-pack pipeline tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/dja/cor/utils/test_word_pack.py

<ul><li>Adds pytest coverage for word tokenization rules.<br> <li> Verifies malformed seed records are safely ignored.<br> <li> Checks canonical sample completeness and script coverage.<br> <li> Validates emitted SQLite schema and generator metadata round-trips.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/495/files#diff-5da469490622e17b868070d40a3decc1718d023e34e96ec4f349531395cd4a6c">+176/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_word_pack.py</strong><dd><code>Build generic word-explanation SQLite packs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/dja/word_pack/build_word_pack.py

<ul><li>Adds a CLI builder for standalone <code>word.sqlite3</code> packs.<br> <li> Defines <code>pack_meta</code> and <code>word_explanation</code> SQLite schema.<br> <li> Loads multilingual seed explanations into <code>(word, language_code)</code> rows.<br> <li> Supports corpus scanning, limits, and seed-word inclusion.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/495/files#diff-f4f4f2d5bea81af7cef2187318c9a5b3625f7319cb89954d0fafb5f960f20461">+195/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>extract_words.py</strong><dd><code>Extract canonical English word universe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/dja/word_pack/extract_words.py

<ul><li>Adds extraction of unique English surface words.<br> <li> Reads core <code>release.sqlite3</code> and phrase-pack <code>phrases.json</code> files.<br> <li> Implements stable lowercase tokenization with apostrophe handling.<br> <li> Provides CLI output to stdout or a word-list file.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/495/files#diff-add6bf3bc55129602c087aaa6544dc98a94efdd9ccef2ee39dca6d07924f1940">+115/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>generate_word_explanations.py</strong><dd><code>Generate verified multilingual word explanations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/dja/word_pack/generate_word_explanations.py

<ul><li>Adds LLM generation for English word explanations.<br> <li> Adds adversarial origin verification with confidence metadata.<br> <li> Adds translation into requested or all corpus languages.<br> <li> Keeps provider imports lazy for lightweight test imports.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/495/files#diff-fcba465348e7c07a9a2536f8cab4e90c1c4e7bfb1690ffeea40b3f3ecdb40def">+294/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>explanations_seed.json</strong><dd><code>Add canonical multilingual explanation seed</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/dja/word_pack/seed/explanations_seed.json

<ul><li>Adds canonical sample explanations for 17 English words.<br> <li> Includes <code>en</code>, <code>zh-Hans</code>, <code>ar</code>, <code>hi</code>, and <code>es</code> paragraphs.<br> <li> Records <code>origin_confidence</code> and notes for hedged origins.<br> <li> Provides seed data for builder and quality review.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/495/files#diff-d0b5046e17b391ef8947e1ce2ce9e0b884b0953f56e5109275d0c12c2be74ca6">+196/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document word-explanation pack pipeline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/dja/word_pack/README.md

<ul><li>Documents the word-explanation pack purpose and quality bar.<br> <li> Explains word-universe extraction and SQLite schema.<br> <li> Provides generation and build command examples.<br> <li> Describes native-language lookup with English fallback.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/495/files#diff-ba2c19a711f36cbc17594959c3acc0dac39ee23da7afdcd94f52c7918b3e2d3f">+122/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

