### PR TITLE
hover-runner 0.3.6: delta-timed, stackable screen shake (#438 PR-6)

### DIFF
--- a/corpan/packs/hover-runner/CHANGELOG.md
+++ b/corpan/packs/hover-runner/CHANGELOG.md
@@ -10,6 +10,28 @@ Conventions: `corpan/CHANGELOGS.md`.
 
 ## [Unreleased]
 
+## [0.3.6] - 2026-06-24 — delta-timed, stackable screen shake (#438 PR-6)
+
+### Changed
+- **Screen shake is now frame-rate independent and stacks on rapid hits
+  (#438 PR-6).** The fail/wrong-answer camera shake was driven by a separate
+  `setInterval(16ms)` and early-returned while a shake was already running.
+  Two problems on a premium bar:
+  - *Not frame-rate independent.* On a 120Hz iPad the timer still ticked every
+    ~16ms while the frame rendered every ~8ms, so the camera only jittered on
+    alternate frames; on a janky frame the offset overshot. The shake now
+    advances on the render loop's clamped `dt` (`updateScreenShake(dt)` in the
+    `runRenderLoop` callback), so it reads identically at 60/90/120fps.
+  - *Dropped stacked hits.* `if (shakeActive) return` meant a second fail in
+    quick succession produced no extra feedback. Shake is now an `energy`
+    scalar that decays exponentially (`exp(dt)`, ~90ms half-life); each trigger
+    ADDS energy (capped at 2× the single-hit kick) so consecutive fails
+    compound the jolt instead of being ignored.
+  Decays cleanly to exact rest even while paused. Pure render-side change — no
+  gameplay, audio, translation, or paywall-contract impact. Covered by a new
+  `particles.test.ts` regression suite (frame-rate independence + stacking,
+  both asserted via Monte-Carlo energy proxies, run green 3×).
+
 ## [0.3.5] - 2026-06-23 — iOS audio unlock + premium post-process re-tune + revived velocity effects + paywall pause
 
 ### Fixed

--- a/corpan/packs/hover-runner/manifest.json
+++ b/corpan/packs/hover-runner/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "hover_runner",
   "name": "Hover Runner",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "3D fun in Hover Runner: lock in correct translations with the All-Hearing Ear and avoid wrong ones",
   "entry": "dist/app.js",
   "styles": [
@@ -9,7 +9,7 @@
   ],
   "entryType": "script",
   "sdkVersion": "0.1.0",
-  "devRevision": "2026-06-23T12:00:00.000Z",
+  "devRevision": "2026-06-24T15:00:00.000Z",
   "nameLocalized": {
     "ar": "هوفر رانر",
     "bg": "Ховър Рънър",

--- a/corpan/packs/hover-runner/src/game.ts
+++ b/corpan/packs/hover-runner/src/game.ts
@@ -1262,7 +1262,7 @@ export const createHoverRunner = (
   }
 
   // Initialize screen shake system
-  const { shakeOffset, trigger: triggerScreenShake } = createScreenShake()
+  const { shakeOffset, trigger: triggerScreenShake, update: updateScreenShake } = createScreenShake()
 
   const createPhraseMesh = (spec: PhraseSpec) => {
     const scale = getTextScale() * 1.45 * getSettings().textScaleFactor
@@ -2583,6 +2583,10 @@ export const createHoverRunner = (
       )
       updateSpeedLines(speedLines, speedMultiplier)
     }
+    // #438 PR-6: advance the screen shake on the render clock so it is
+    // frame-rate independent and decays cleanly even while paused (was a
+    // separate setInterval that drifted on high-refresh displays).
+    updateScreenShake(dt)
     const farX = road.getFarCenterX()
     cameraTarget.set(
       farX * 0.2 + shakeOffset.x,

--- a/corpan/packs/hover-runner/src/systems/particles.test.ts
+++ b/corpan/packs/hover-runner/src/systems/particles.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest"
+import { createScreenShake } from "./particles"
+
+// Regression coverage for the #438 PR-6 screen-shake rework. The old impl used
+// a separate setInterval(16ms): it was not frame-rate independent and it
+// dropped a second trigger while a shake was already running. The new impl is
+// driven by the render loop's dt and stacks energy on each trigger.
+describe("createScreenShake (delta-timed, stackable)", () => {
+  it("starts at rest with a zero offset", () => {
+    const { shakeOffset } = createScreenShake()
+    expect(shakeOffset.x).toBe(0)
+    expect(shakeOffset.y).toBe(0)
+    expect(shakeOffset.z).toBe(0)
+  })
+
+  it("produces a non-zero offset after a trigger + update", () => {
+    const { shakeOffset, trigger, update } = createScreenShake()
+    trigger()
+    update(0.016)
+    const magnitude =
+      Math.abs(shakeOffset.x) + Math.abs(shakeOffset.y) + Math.abs(shakeOffset.z)
+    expect(magnitude).toBeGreaterThan(0)
+  })
+
+  it("decays back to exactly rest after enough time", () => {
+    const { shakeOffset, trigger, update } = createScreenShake()
+    trigger()
+    // Advance ~1s in 16ms steps; energy half-life is 90ms, so this is many
+    // half-lives and must reach the rest snap-to-zero branch.
+    for (let i = 0; i < 60; i++) update(0.016)
+    expect(shakeOffset.x).toBe(0)
+    expect(shakeOffset.y).toBe(0)
+    expect(shakeOffset.z).toBe(0)
+  })
+
+  it("is frame-rate independent: same wall-clock decay regardless of step size", () => {
+    // Decay one shake to the SAME total elapsed time (~96ms ≈ one half-life)
+    // at 16ms steps (~60fps) vs 8ms steps (~120fps), then measure the residual
+    // energy via mean |x| over many micro-steps. exp(dt) decay is exact under
+    // step subdivision, so both rates must land on the same residual energy.
+    // The old setInterval impl could not — it only ticked every ~16ms wall
+    // time, so a 120Hz frame saw a stale offset on alternate frames.
+    const residualEnergy = (step: number) => {
+      const s = createScreenShake()
+      s.trigger()
+      const elapsed = 0.096
+      const steps = Math.round(elapsed / step)
+      for (let i = 0; i < steps; i++) s.update(step)
+      // Sample residual energy: E[|x|] = energy/2 over many ~0-dt frames.
+      let sum = 0
+      const N = 4000
+      for (let i = 0; i < N; i++) {
+        s.update(1e-6)
+        sum += Math.abs(s.shakeOffset.x)
+      }
+      return (sum / N) * 2 // back out energy from mean|x|
+    }
+
+    const e60 = residualEnergy(0.016)
+    const e120 = residualEnergy(0.008)
+    expect(e60).toBeGreaterThan(0)
+    expect(e120).toBeGreaterThan(0)
+    // Within ~12% of each other (Monte-Carlo noise on 4000 samples + the tiny
+    // residual decay of the sampling loop). Frame-rate independence proven.
+    const ratio = e60 / e120
+    expect(ratio).toBeGreaterThan(0.88)
+    expect(ratio).toBeLessThan(1.12)
+  })
+
+  it("stacks: a second trigger while shaking adds energy (does not drop it)", () => {
+    // Drive each shake with near-zero dt so decay is negligible, then sample
+    // the mean |x| over many frames. With dt≈0 the offset is uniform on
+    // [-energy, +energy], so E[|x|] = energy/2 — a stable, deterministic-ish
+    // proxy for the underlying energy (law of large numbers over 4000 samples).
+    const meanAbsX = (kicks: number) => {
+      const s = createScreenShake()
+      for (let k = 0; k < kicks; k++) s.trigger()
+      let sum = 0
+      const N = 4000
+      for (let i = 0; i < N; i++) {
+        s.update(1e-6) // negligible decay
+        sum += Math.abs(s.shakeOffset.x)
+      }
+      return sum / N
+    }
+
+    const single = meanAbsX(1) // energy ~0.08  → mean|x| ~0.04
+    const stacked = meanAbsX(2) // energy ~0.16  → mean|x| ~0.08
+
+    // The two-trigger shake is meaningfully stronger. Under the old
+    // `if (shakeActive) return` early-out the second trigger was a no-op, so
+    // these would have been equal. We assert a clear separation (≥40% larger)
+    // with generous margin for the small remaining Monte-Carlo noise.
+    expect(stacked).toBeGreaterThan(single * 1.4)
+  })
+})

--- a/corpan/packs/hover-runner/src/systems/particles.ts
+++ b/corpan/packs/hover-runner/src/systems/particles.ts
@@ -101,37 +101,55 @@ export const createFailParticles = (scene: Scene, position: Vector3) => {
   activeParticleTimeouts.add(timeoutId)
 }
 
+// Screen shake — delta-timed and stackable (#438 PR-6).
+//
+// The old impl drove the offset from a separate `setInterval(16ms)`, which is
+// NOT frame-rate independent (on a 120Hz iPad the timer still ticks every
+// ~16ms while the frame renders every ~8ms, so the camera only jitters on
+// alternate frames; on a janky frame it overshoots) and it early-returned
+// (`if (shakeActive) return`) so two fails in quick succession produced only
+// one shake — the second hit gave no extra feedback.
+//
+// New model: a single `energy` scalar that decays exponentially every frame.
+// `trigger()` ADDS energy (capped) so consecutive hits compound instead of
+// being dropped. `update(dt)` is driven by the existing render loop (which
+// already computes a clamped `dt`), so the shake is frame-rate independent and
+// in lockstep with `scene.render()`.
 export const createScreenShake = () => {
   const shakeOffset = new Vector3(0, 0, 0)
-  let shakeActive = false
+  let energy = 0
+
+  // Per-trigger energy injection. Tuned so a single hit reads like the old
+  // 0.08 peak; the cap keeps a burst of fails from going seasick.
+  const KICK = 0.08
+  const MAX_ENERGY = 0.16
+  // Exponential decay: energy halves roughly every ~90ms (matches the old
+  // ~260ms visible-shake window where the linear ramp fell below perceptible).
+  const HALF_LIFE_MS = 90
 
   const trigger = () => {
-    if (shakeActive) return
-    shakeActive = true
-
-    const startTime = performance.now()
-    const duration = 260
-    const intensity = 0.08
-
-    const shakeInterval = setInterval(() => {
-      const elapsed = performance.now() - startTime
-      if (elapsed >= duration) {
-        clearInterval(shakeInterval)
-        shakeOffset.set(0, 0, 0)
-        shakeActive = false
-        return
-      }
-
-      const decay = 1 - elapsed / duration
-      const amount = intensity * decay
-
-      shakeOffset.x = (Math.random() - 0.5) * amount * 2
-      shakeOffset.y = (Math.random() - 0.5) * amount * 2
-      shakeOffset.z = (Math.random() - 0.5) * amount
-    }, 16)
+    energy = Math.min(MAX_ENERGY, energy + KICK)
   }
 
-  return { shakeOffset, trigger }
+  const update = (dt: number) => {
+    if (energy <= 0.0001) {
+      if (shakeOffset.x !== 0 || shakeOffset.y !== 0 || shakeOffset.z !== 0) {
+        shakeOffset.set(0, 0, 0)
+      }
+      energy = 0
+      return
+    }
+
+    // Frame-rate-independent exponential decay.
+    const dtMs = dt * 1000
+    energy *= Math.pow(0.5, dtMs / HALF_LIFE_MS)
+
+    shakeOffset.x = (Math.random() - 0.5) * energy * 2
+    shakeOffset.y = (Math.random() - 0.5) * energy * 2
+    shakeOffset.z = (Math.random() - 0.5) * energy
+  }
+
+  return { shakeOffset, trigger, update }
 }
 
 // ============================================================================


### PR DESCRIPTION
### **User description**
## Hover Runner premium pass — final piece (#438 PR-6)

Worker pass on the Hover Runner premium EPIC. **PROFILE-FIRST outcome: most of
the EPIC already landed.** The operator's own audit (issue #438) laid out a
PR-1..PR-6 plan, and a sweep of merged PRs shows PR-1 through PR-5 are already
on `main` at v0.3.5:

| Plan item | Status | PR |
|---|---|---|
| PR-1 dead-code + post-process config-truth | ✅ merged | #458 |
| PR-2 native haptics + 8 trigger points | ✅ merged | #453 |
| PR-3 iPad/tablet scorecard HUD scale-up (#435) | ✅ merged | #451 |
| PR-4 post-process re-tune (bloom/aberration/sharpen/grain) | ✅ merged | #459 |
| PR-5 revived velocity effects (`updateSpeedLines` wired) + iOS audio unlock | ✅ merged | #459 |
| **PR-6 delta-timed screen shake** | **this PR** | — |

I re-audited the current `main` source to confirm and to avoid re-churning
shipped work: `updateSpeedLines` is now called in the render loop, the dead
`createAvatarAura`/`updateAvatarAura` exports are gone, `POST_PROCESSING` is the
live source of truth, and haptics fire on hits/milestones/fails. **The one
genuinely-still-open Babylon best-practices gap was the screen shake.**

### What this PR changes (the one real remaining win)

The fail/wrong-answer camera shake (`createScreenShake` in `systems/particles.ts`)
ran on a separate `setInterval(16ms)`:

1. **Not frame-rate independent.** On a 120Hz iPad the timer still ticked every
   ~16ms while the frame rendered every ~8ms — the camera only jittered on
   alternate frames; on a janky frame the offset overshot. Below our premium bar.
2. **Dropped stacked hits.** `if (shakeActive) return` meant a second fail in
   quick succession produced *no* extra feedback — two mistakes felt like one.

**Reworked** to an `energy` scalar that decays exponentially (`exp(dt)`, ~90ms
half-life) and is advanced by the render loop's already-clamped `dt`
(`updateScreenShake(dt)` in `runRenderLoop`). Each `trigger()` **adds** energy
(capped at 2× the single-hit kick), so consecutive fails compound the jolt.
Decays cleanly to exact rest, including while the host paywall pause is active.

Pure render-side change — **no gameplay, audio, i18n, or paywall-contract
(`corpan:host-pause`/`-resume`) impact** (verified those listeners untouched;
shake decays behind the overlay rather than freezing mid-jolt).

### Reproduction / regression coverage

New `src/systems/particles.test.ts` (vitest, no WebGL needed — shake math is
pure) asserts both flagged behaviors through the real code path:
- **Frame-rate independence:** decaying to the same elapsed time at 16ms vs 8ms
  steps lands on the same residual energy (within Monte-Carlo noise).
- **Stacking:** a second trigger while shaking yields meaningfully higher energy
  (≥40%) — impossible under the old early-out.
- plus rest/zero, non-zero-after-trigger, decay-to-exact-rest.

Run green 3× consecutively, no flake.

### What I deliberately left

- **PR-1..PR-5 work** — already merged; not touched.
- **The deeper PR-6 perf track** (thin-instances / GPU particles for road ribbon,
  props, electric tubes) — the audit rated this "optional, profile on device
  first." It is a perf optimization with no correctness/feel bug; not worth the
  risk/churn without on-device profiling. Honest call: the current per-frame CPU
  geometry rebuilds *land* correctly, they're just not optimal. Left as a tracked
  follow-up, not shipped.
- **Taste-dependent visual polish** (star twinkle, background-particle density)
  — already addressed or non-blocking; needs the device/CDP frame review the
  issue's `needs-human` flag already carries.

### Gate status (Node 20, in worktree off `origin/main`)
- `npx tsc --noEmit` — clean
- `npm run test:run` — **21 passed** (16 prior + 5 new), green 3×
- `npm run build` — succeeds (vite 8 + rolldown)
- `node .github/scripts/pack_catalog_check.js` — OK (17 entries)
- Version bumped 0.3.5 → **0.3.6**; CHANGELOG entry added.

### Notes
- No headless WebGL design-critic frame pass on this box (no GPU browser /
  playwright installed in the pack). The change is motion/feel only — a static
  vision critic can't assess camera-shake feel — and is fully covered by the
  deterministic regression suite. The post-process/particle visuals were already
  reviewed on device in #459.
- `.github` untouched (additive-only rule honored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Makes screen shake frame-rate independent

- Allows rapid fail shakes to stack

- Adds screen-shake regression tests

- Releases Hover Runner `0.3.6`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  triggers["Fail and wrong-answer triggers"]
  energy["Capped shake energy"]
  renderLoop["Render-loop dt update"]
  cameraOffset["Camera shake offset"]
  tests["Regression tests"]
  triggers -- "adds kick" --> energy
  renderLoop -- "decays energy" --> energy
  energy -- "updates" --> cameraOffset
  tests -- "verifies stacking and timing" --> energy
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>game.ts</strong><dd><code>Drive screen shake from render loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/src/game.ts

<ul><li>Destructures <code>update</code> from <code>createScreenShake()</code>.<br> <li> Calls <code>updateScreenShake(dt)</code> inside the render loop.<br> <li> Documents render-clock-driven shake behavior.<br> <li> Keeps camera target using <code>shakeOffset</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/496/files#diff-f83d51b602f2289081ca7b8cf96c0802c8a1973b6c5a1562f375a85af8de7176">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>particles.ts</strong><dd><code>Rework screen shake energy model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/src/systems/particles.ts

<ul><li>Replaces timer-based shake with energy decay.<br> <li> Adds capped stacking via repeated <code>trigger()</code> calls.<br> <li> Adds <code>update(dt)</code> for frame-rate-independent progression.<br> <li> Snaps <code>shakeOffset</code> exactly to rest at low energy.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/496/files#diff-db5b1c532600c71604cf0ec1a4bc8d3e736aa53ac9018b4a53998d4312829b06">+38/-20</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>particles.test.ts</strong><dd><code>Add screen shake regression tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/src/systems/particles.test.ts

<ul><li>Adds <code>createScreenShake</code> regression coverage.<br> <li> Verifies initial rest and triggered offsets.<br> <li> Tests decay back to exact rest.<br> <li> Checks frame-rate independence and stacked triggers.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/496/files#diff-300528dd73427909f4a0668c2536557d31e88108d4b5945ae8e058e51169c12d">+96/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document screen shake release changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/CHANGELOG.md

<ul><li>Adds <code>0.3.6</code> release notes.<br> <li> Documents render-loop <code>dt</code> screen-shake update.<br> <li> Explains stacked energy behavior.<br> <li> Notes behavior scope and test coverage.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/496/files#diff-554a78adaeab8d73031f6062c33ea3602d4b86eb9cb1030d92b39d0c79619e50">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump Hover Runner release metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/hover-runner/manifest.json

<ul><li>Bumps Hover Runner version to <code>0.3.6</code>.<br> <li> Updates <code>devRevision</code> timestamp.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/496/files#diff-949b680907b5b15b50e097f1542e0d4cf96ebe0be42c567a533ae84639d25d5e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

