### PR TITLE
word_pack: free codex-cli generation backend (parallel, resumable)

### DIFF
--- a/corpan/dja/cor/utils/codex.py
+++ b/corpan/dja/cor/utils/codex.py
@@ -55,6 +55,10 @@ def run(prompt: str, *, reasoning: str = "low", timeout: float = 240.0,
         capture_output=True,
         text=True,
         timeout=timeout,
+        # CRITICAL: `codex exec` blocks on "Reading additional input from
+        # stdin..." unless stdin is closed. Without this it hangs forever in
+        # any non-interactive or threaded context.
+        stdin=subprocess.DEVNULL,
     )
     elapsed = time.monotonic() - t0
     if proc.returncode != 0:

--- a/corpan/dja/cor/utils/test_word_pack_codex.py
+++ b/corpan/dja/cor/utils/test_word_pack_codex.py
@@ -1,0 +1,301 @@
+# tests/test_word_pack_codex.py
+#
+# Tests for the CODEX backend of the word-explanation generator
+# (dja/word_pack/generate_word_explanations.py). They run under plain pytest
+# with only stdlib + pydantic -- the exact deps the CI `dja` gate installs.
+#
+# The real `codex exec` subprocess is NEVER called here: every test stubs
+# `cor.utils.codex.run_json` (the single seam the driver uses) with an
+# in-process fake. We cover the four behaviors the production run depends on:
+#
+#   1. compose_codex_prompt folds system+user into one JSON-only prompt.
+#   2. run_codex_batch validates against the pydantic schema, retries on
+#      parse/validation failure, and returns None (skip-and-log) when every
+#      attempt fails -- so one bad batch can never wedge the whole run.
+#   3. run_codex_stage applies results and checkpoints under a lock, with no
+#      two workers writing the seed concurrently.
+#   4. The seed selectors give resumable work-sets (a kill mid-run re-runs
+#      only the unfinished words/langs).
+
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+
+# dja/word_pack lives two levels up from cor/utils/.
+WORD_PACK = Path(__file__).resolve().parents[2] / "word_pack"
+if str(WORD_PACK) not in sys.path:
+    sys.path.insert(0, str(WORD_PACK))
+
+import generate_word_explanations as gen  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Prompt composition: system + user folded into one JSON-only codex prompt.
+# ---------------------------------------------------------------------------
+def test_compose_codex_prompt_includes_system_user_and_json_demand():
+    prompt = gen.compose_codex_prompt("SYS-RULES", "egg\nbank")
+    assert "SYS-RULES" in prompt
+    assert "egg\nbank" in prompt
+    # Must demand JSON-only output (no prose / no fences).
+    low = prompt.lower()
+    assert "json" in low
+    assert "only" in low
+
+
+def test_english_system_has_surprising_origin_rule():
+    # The origin-clarity instruction (operator guidance) must be present.
+    sysmsg = gen.ENGLISH_SYSTEM.lower()
+    assert "banca" in sysmsg or "bank" in sysmsg
+    assert "surprising" in sysmsg or "counterintuitive" in sysmsg
+
+
+# ---------------------------------------------------------------------------
+# A fake codex module: stub `run_json` so no subprocess ever runs.
+# ---------------------------------------------------------------------------
+class _FakeCodexError(RuntimeError):
+    pass
+
+
+class FakeCodex:
+    """Stand-in for `cor.utils.codex` injected into sys.modules."""
+
+    CodexError = _FakeCodexError
+
+    def __init__(self, responses):
+        # responses: list of either a dict (returned as JSON obj) or an
+        # Exception instance (raised). Consumed one per run_json() call.
+        self._responses = list(responses)
+        self.calls = []
+        self._lock = threading.Lock()
+
+    def run_json(self, prompt, **kwargs):
+        with self._lock:
+            self.calls.append((prompt, kwargs))
+            resp = self._responses.pop(0)
+        if isinstance(resp, Exception):
+            raise resp
+        return resp
+
+
+@pytest.fixture
+def install_fake_codex(monkeypatch):
+    """Install a FakeCodex as the `cor.utils.codex` module the driver imports."""
+
+    def _install(responses):
+        fake = FakeCodex(responses)
+        # The driver does `from cor.utils import codex`; intercept that import.
+        monkeypatch.setitem(sys.modules, "cor.utils.codex", fake)
+        return fake
+
+    return _install
+
+
+# ---------------------------------------------------------------------------
+# run_codex_batch: validation, retry, skip-and-log.
+# ---------------------------------------------------------------------------
+def _english_obj(words):
+    return {"items": [{"word": w, "explanation": f"about {w}"} for w in words]}
+
+
+def test_run_codex_batch_validates_and_returns_model(install_fake_codex):
+    install_fake_codex([_english_obj(["egg", "bank"])])
+    res = gen.run_codex_batch(
+        "SYS",
+        "egg\nbank",
+        gen.ExplanationBatch,
+        reasoning="low",
+        model=None,
+        timeout=10.0,
+        max_retries=2,
+        label="english batch 1",
+    )
+    assert isinstance(res, gen.ExplanationBatch)
+    assert {i.word for i in res.items} == {"egg", "bank"}
+
+
+def test_run_codex_batch_retries_then_succeeds(install_fake_codex):
+    # First call returns schema-invalid JSON, second is good -> 2 calls total.
+    fake = install_fake_codex(
+        [
+            {"wrong": "shape"},  # ValidationError
+            _english_obj(["egg"]),  # good
+        ]
+    )
+    res = gen.run_codex_batch(
+        "SYS", "egg", gen.ExplanationBatch,
+        reasoning="low", model=None, timeout=10.0, max_retries=2,
+        label="english batch 1",
+    )
+    assert res is not None and res.items[0].word == "egg"
+    assert len(fake.calls) == 2
+
+
+def test_run_codex_batch_skips_after_exhausting_retries(install_fake_codex):
+    # 1 try + 2 retries = 3 bad responses -> returns None (skip-and-log).
+    fake = install_fake_codex([ValueError("no json")] * 3)
+    res = gen.run_codex_batch(
+        "SYS", "egg", gen.ExplanationBatch,
+        reasoning="low", model=None, timeout=10.0, max_retries=2,
+        label="english batch 1",
+    )
+    assert res is None
+    assert len(fake.calls) == 3
+
+
+def test_run_codex_batch_handles_codex_error(install_fake_codex):
+    fake = install_fake_codex([_FakeCodexError("codex exited 1")] * 3)
+    res = gen.run_codex_batch(
+        "SYS", "egg", gen.ExplanationBatch,
+        reasoning="low", model=None, timeout=10.0, max_retries=2,
+        label="english batch 1",
+    )
+    assert res is None
+    assert len(fake.calls) == 3
+
+
+# ---------------------------------------------------------------------------
+# run_codex_stage: concurrent batches, results applied + checkpointed safely.
+# ---------------------------------------------------------------------------
+def test_run_codex_stage_applies_all_batches_and_checkpoints(install_fake_codex):
+    words = ["a", "b", "c", "d", "e"]
+    batches = gen.chunk(words, 2)  # [a,b],[c,d],[e]
+    # one response per batch
+    install_fake_codex([_english_obj(b) for b in batches])
+
+    seed = {}
+    saves = []
+    lock = threading.Lock()
+
+    def apply(res):
+        for item in res.items:
+            seed.setdefault(item.word, {"explanation": {}})["explanation"][
+                "en"
+            ] = item.explanation
+
+    def save():
+        # snapshot how many words are committed at each checkpoint
+        saves.append(len(seed))
+
+    gen.run_codex_stage(
+        batches,
+        lambda b: (gen.ENGLISH_SYSTEM, "\n".join(b)),
+        gen.ExplanationBatch,
+        apply,
+        concurrency=4,
+        reasoning="low",
+        model=None,
+        timeout=10.0,
+        max_retries=2,
+        save=save,
+        save_lock=lock,
+        stage="english",
+    )
+
+    assert set(seed) == set(words)
+    # save() called once per successful batch
+    assert len(saves) == len(batches)
+    # final checkpoint sees all words
+    assert max(saves) == len(words)
+
+
+def test_run_codex_stage_skips_bad_batch_keeps_rest(install_fake_codex):
+    batches = [["a", "b"], ["c", "d"]]
+    # first batch always fails (3 bad), second always succeeds.
+    install_fake_codex(
+        [ValueError("bad")] * 3 + [_english_obj(["c", "d"])]
+    )
+    seed = {}
+    lock = threading.Lock()
+
+    def apply(res):
+        for item in res.items:
+            seed.setdefault(item.word, {"explanation": {}})["explanation"][
+                "en"
+            ] = item.explanation
+
+    gen.run_codex_stage(
+        batches,
+        lambda b: ("SYS", "\n".join(b)),
+        gen.ExplanationBatch,
+        apply,
+        concurrency=1,  # deterministic ordering for the fake's response queue
+        reasoning="low",
+        model=None,
+        timeout=10.0,
+        max_retries=2,
+        save=lambda: None,
+        save_lock=lock,
+        stage="english",
+    )
+    # bad batch dropped, good batch survived -> run is never wedged.
+    assert set(seed) == {"c", "d"}
+
+
+def test_run_codex_stage_empty_is_noop(install_fake_codex):
+    fake = install_fake_codex([])
+    called = []
+    gen.run_codex_stage(
+        [],
+        lambda b: ("SYS", "x"),
+        gen.ExplanationBatch,
+        lambda r: called.append(r),
+        concurrency=4,
+        reasoning="low",
+        model=None,
+        timeout=10.0,
+        max_retries=2,
+        save=lambda: called.append("save"),
+        save_lock=threading.Lock(),
+        stage="english",
+    )
+    assert called == []
+    assert fake.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Resume semantics: save_seed/load_seed merge-by-word survives a "kill".
+# A re-run must only target words/langs not yet present in the seed.
+# ---------------------------------------------------------------------------
+def test_resume_roundtrip_only_targets_missing(tmp_path):
+    path = tmp_path / "full.json"
+    # Simulate a partial run: 'egg' done in en+es, 'bank' only en, 'cat' nothing.
+    data = {
+        "egg": {"explanation": {"en": "An egg.", "es": "Un huevo."},
+                "origin_confidence": "high"},
+        "bank": {"explanation": {"en": "A bank."}},
+    }
+    gen.save_seed(path, data)
+    seed = gen.load_seed(path)
+
+    words = ["egg", "bank", "cat"]
+
+    # English authoring must only target 'cat' (egg+bank already have en).
+    missing_en = [
+        w for w in words if "en" not in seed.get(w, {}).get("explanation", {})
+    ]
+    assert missing_en == ["cat"]
+
+    # Verify must only target 'bank' (egg has confidence, cat has no en yet).
+    to_verify = [
+        w
+        for w in words
+        if "en" in seed.get(w, {}).get("explanation", {})
+        and not seed[w].get("origin_confidence")
+    ]
+    assert to_verify == ["bank"]
+
+    # es-translation must only target 'bank' (egg already has es; cat has no en).
+    todo_es = [
+        w
+        for w in words
+        if "en" in seed.get(w, {}).get("explanation", {})
+        and "es" not in seed[w]["explanation"]
+    ]
+    assert todo_es == ["bank"]
+
+    # Metadata survives the roundtrip intact.
+    assert seed["egg"]["origin_confidence"] == "high"
+    assert seed["egg"]["explanation"]["es"] == "Un huevo."

--- a/corpan/dja/word_pack/README.md
+++ b/corpan/dja/word_pack/README.md
@@ -82,6 +82,33 @@ python3 generate_word_explanations.py --all-langs
 Output writes to `seed/explanations_full.json`. Pass that file into the builder
 with `--explanations`.
 
+### Backends: `--provider openai` (billed) vs `--provider codex` (free)
+
+The default `--provider openai` routes batches through `corpora_ai` (billed
+OpenAI API). For the full-corpus run, use the **subscription codex-cli**
+backend (`--provider codex`, FREE, gpt-5.5): it composes each stage's
+system+user prompt into one JSON-only `codex exec` call (via
+`cor/utils/codex.py`), validates the reply against the same
+`ExplanationBatch`/`VerifyBatch`/`TranslationBatch` schemas, retries a failed
+batch up to `--max-retries` (default 2) times, then **skip-and-logs** so one
+bad batch can't wedge the run. Batches run concurrently (`--concurrency`,
+default 8) and the seed checkpoint is written under a lock after each batch, so
+a kill mid-run is safe to resume (it re-targets only unfinished words/langs).
+
+```bash
+# free codex backend, concurrent, resumable
+python3 generate_word_explanations.py \
+  --provider codex --concurrency 12 --batch-size 12 \
+  --all-langs --out seed/explanations_full.json
+```
+
+Measured (gpt-5.5, ~50-word paragraphs): a batch of 12 words ≈ 20s; per-word
+cost drops with batch size (≈2.9s/word at 4 → ≈1.7s/word at 12). The ChatGPT
+subscription showed **no throttling at concurrency 8 or 16** on the probe.
+Recommended: `--batch-size 12 --concurrency 12`. Projected wall-time at that
+setting: EN authoring + verify of all 11,757 words ≈ **~1 h**; full ×53-language
+translation ≈ **~1 day** (≈18 h at concurrency 16).
+
 ## Build
 
 ```bash

--- a/corpan/dja/word_pack/generate_word_explanations.py
+++ b/corpan/dja/word_pack/generate_word_explanations.py
@@ -32,10 +32,12 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Dict, List
+from typing import Callable, Dict, List, Optional, Type, TypeVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from extract_words import collect_words
 
@@ -123,8 +125,13 @@ ENGLISH_SYSTEM = (
     "(2) where the word came from (etymology/origin); and (3) how the original "
     "idea branched into the modern senses. Friendly, accessible, accurate. Write "
     "in English only. If you are unsure of the precise root, hedge with phrases "
-    "like 'is thought to come from' -- NEVER invent a root. Output JSON with "
-    "`items`: each item has `word` and `explanation`."
+    "like 'is thought to come from' -- NEVER invent a root. When an origin is "
+    "SURPRISING or counterintuitive (e.g. a Romance word borrowed from a "
+    "Germanic root, like Italian 'banca' giving English 'bank', or an everyday "
+    "word with an unexpected lineage), state the borrowing path EXPLICITLY so a "
+    "sharp reader does not mistake a correct fact for an error. Still never "
+    "confabulate; hedge when unsure. Output JSON with `items`: each item has "
+    "`word` and `explanation`."
 )
 
 VERIFY_SYSTEM = (
@@ -138,6 +145,143 @@ VERIFY_SYSTEM = (
     "paragraph that softens/fixes it (keep ~50 words, keep the senses). NEVER "
     "confabulate a root; when unsure, hedge. Output JSON with `items`."
 )
+
+
+def translate_system(lang: str) -> str:
+    return (
+        f"Translate each English word-explanation into language code '{lang}', "
+        f"written naturally IN that language. Preserve meaning, tone, hedges, "
+        f"and the ~50-word length. Do NOT add facts. Output JSON `items` with "
+        f"`word` and `text`."
+    )
+
+
+# --------------------------------------------------------------------------
+# Codex backend (subscription codex-cli, FREE) -- ADDITIVE alongside openai.
+#
+# Codex has no separate system role, so we compose system+user into one
+# prompt string and demand JSON-only output. Each batch is validated against
+# its pydantic schema; on parse/validation failure we retry up to
+# `max_retries` times, then skip-and-log so one bad batch can't wedge the run.
+# Batches run concurrently via a thread pool of `codex exec` subprocesses
+# (network-bound, not CPU-bound). Seed writes are serialized under a lock so
+# two workers never clobber the checkpoint file.
+# --------------------------------------------------------------------------
+TBatch = TypeVar("TBatch", bound=BaseModel)
+
+
+def compose_codex_prompt(system: str, user: str) -> str:
+    """Fold a system+user pair into one JSON-only codex prompt."""
+    return (
+        f"{system}\n\n"
+        "Respond with ONLY a single JSON object and nothing else -- no prose, "
+        "no markdown fences, no commentary. The JSON must match the described "
+        "`items` shape exactly.\n\n"
+        "INPUT:\n"
+        f"{user}"
+    )
+
+
+def run_codex_batch(
+    system: str,
+    user: str,
+    schema: Type[TBatch],
+    *,
+    reasoning: str,
+    model: Optional[str],
+    timeout: float,
+    max_retries: int,
+    label: str,
+) -> Optional[TBatch]:
+    """Run one codex batch, validate against `schema`, retry, then give up.
+
+    Returns the validated model, or None if every attempt failed (the caller
+    logs and skips so the overall run keeps making progress).
+    """
+    # Imported lazily so the module stays import-safe for the CI gate (which
+    # has only stdlib + pydantic and never executes a real codex call). Ensure
+    # the dja root is importable so `cor.utils.codex` resolves regardless of
+    # how this script was launched (the script dir is word_pack/, not dja/).
+    dja_root = str(Path(__file__).resolve().parents[1])
+    if dja_root not in sys.path:
+        sys.path.insert(0, dja_root)
+    from cor.utils import codex
+
+    prompt = compose_codex_prompt(system, user)
+    last_err = ""
+    for attempt in range(1, max_retries + 2):  # 1 try + max_retries retries
+        try:
+            obj = codex.run_json(
+                prompt, reasoning=reasoning, model=model, timeout=timeout
+            )
+            return schema.model_validate(obj)
+        except (ValidationError, ValueError, json.JSONDecodeError) as exc:
+            last_err = f"{type(exc).__name__}: {str(exc)[:200]}"
+        except codex.CodexError as exc:
+            last_err = f"CodexError: {str(exc)[:200]}"
+        except Exception as exc:  # noqa: BLE001 -- never let a batch wedge the pool
+            last_err = f"{type(exc).__name__}: {str(exc)[:200]}"
+        if attempt <= max_retries:
+            print(
+                f"[{label}] attempt {attempt} failed ({last_err}); retrying",
+                file=sys.stderr,
+                flush=True,
+            )
+    print(
+        f"[{label}] SKIPPED after {max_retries + 1} attempts: {last_err}",
+        file=sys.stderr,
+        flush=True,
+    )
+    return None
+
+
+def run_codex_stage(
+    batches: List[List[str]],
+    build_prompt: Callable[[List[str]], "tuple[str, str]"],
+    schema: Type[TBatch],
+    apply_result: Callable[[TBatch], None],
+    *,
+    concurrency: int,
+    reasoning: str,
+    model: Optional[str],
+    timeout: float,
+    max_retries: int,
+    save: Callable[[], None],
+    save_lock: threading.Lock,
+    stage: str,
+) -> None:
+    """Run a stage's batches concurrently, applying results + checkpointing
+    under a lock so the seed file is never written by two workers at once."""
+    if not batches:
+        return
+
+    def work(idx_batch):
+        idx, batch = idx_batch
+        system, user = build_prompt(batch)
+        label = f"{stage} batch {idx}/{len(batches)} ({len(batch)} words)"
+        print(f"[{label}] dispatch", flush=True)
+        return idx, run_codex_batch(
+            system,
+            user,
+            schema,
+            reasoning=reasoning,
+            model=model,
+            timeout=timeout,
+            max_retries=max_retries,
+            label=label,
+        )
+
+    indexed = list(enumerate(batches, start=1))
+    with ThreadPoolExecutor(max_workers=max(1, concurrency)) as pool:
+        futures = [pool.submit(work, ib) for ib in indexed]
+        for fut in as_completed(futures):
+            idx, res = fut.result()
+            if res is None:
+                continue
+            # Mutating the shared seed + writing it must be serialized.
+            with save_lock:
+                apply_result(res)
+                save()
 
 
 def main() -> None:
@@ -166,8 +310,37 @@ def main() -> None:
     ap.add_argument("--words", nargs="*", default=None, help="Explicit word list.")
     ap.add_argument("--limit", type=int, default=0)
     ap.add_argument("--batch-size", type=int, default=8)
-    ap.add_argument("--provider", type=str, default="openai")
+    ap.add_argument(
+        "--provider",
+        type=str,
+        default="openai",
+        help="LLM backend: 'openai' (billed corpora_ai) or 'codex' "
+        "(FREE subscription codex-cli).",
+    )
     ap.add_argument("--completion-model", type=str, default=None)
+    # Codex-only knobs (ignored by the openai path).
+    ap.add_argument(
+        "--concurrency",
+        type=int,
+        default=8,
+        help="codex: max concurrent `codex exec` batches.",
+    )
+    ap.add_argument(
+        "--reasoning",
+        type=str,
+        default="low",
+        help="codex: model_reasoning_effort (low keeps latency down).",
+    )
+    ap.add_argument(
+        "--timeout", type=float, default=240.0, help="codex: per-batch timeout (s)."
+    )
+    ap.add_argument(
+        "--max-retries",
+        type=int,
+        default=2,
+        help="codex: retries per batch on parse/validation failure before "
+        "skip-and-log.",
+    )
     ap.add_argument(
         "--skip-verify",
         action="store_true",
@@ -175,9 +348,13 @@ def main() -> None:
     )
     args = ap.parse_args()
 
+    use_codex = args.provider == "codex"
+
     # Heavy imports deferred so parsing helpers stay import-safe for tests.
-    from corpora_ai.llm_interface import ChatCompletionTextMessage
-    from corpora_ai.provider_loader import load_llm_provider
+    # The codex path needs neither corpora_ai nor a billed key.
+    if not use_codex:
+        from corpora_ai.llm_interface import ChatCompletionTextMessage
+        from corpora_ai.provider_loader import load_llm_provider
 
     core_db = args.core_db.resolve()
     if not core_db.exists():
@@ -206,6 +383,113 @@ def main() -> None:
     out.parent.mkdir(parents=True, exist_ok=True)
     seed = load_seed(out)
 
+    # --- Shared, backend-agnostic merge logic (same for openai + codex) ---
+    save_lock = threading.Lock()
+
+    def save():
+        save_seed(out, seed)
+
+    def apply_english(res: ExplanationBatch) -> None:
+        for item in res.items:
+            rec = seed.setdefault(item.word, {"explanation": {}})
+            rec["explanation"]["en"] = item.explanation.strip()
+
+    def apply_verify(res: VerifyBatch) -> None:
+        for item in res.items:
+            rec = seed.get(item.word)
+            if not rec:
+                continue
+            rec["origin_confidence"] = (item.confidence or "medium").lower()
+            if item.note:
+                rec["origin_note"] = item.note.strip()
+            if item.corrected.strip():
+                rec["explanation"]["en"] = item.corrected.strip()
+
+    def make_apply_translation(lang: str):
+        def apply_translation(res: TranslationBatch) -> None:
+            for item in res.items:
+                rec = seed.get(item.word)
+                if rec and item.text.strip():
+                    rec["explanation"][lang] = item.text.strip()
+
+        return apply_translation
+
+    def english_payload(batch: List[str]) -> str:
+        return "\n".join(batch)
+
+    def en_para_payload(batch: List[str]) -> str:
+        return "\n".join(f"{w}: {seed[w]['explanation']['en']}" for w in batch)
+
+    # --- Work-set selectors (identical resume semantics for both backends) ---
+    def missing_en_words() -> List[str]:
+        return [
+            w for w in words if "en" not in seed.get(w, {}).get("explanation", {})
+        ]
+
+    def to_verify_words() -> List[str]:
+        return [
+            w
+            for w in words
+            if "en" in seed.get(w, {}).get("explanation", {})
+            and not seed[w].get("origin_confidence")
+        ]
+
+    def to_translate_words(lang: str) -> List[str]:
+        return [
+            w
+            for w in words
+            if "en" in seed.get(w, {}).get("explanation", {})
+            and lang not in seed[w]["explanation"]
+        ]
+
+    if use_codex:
+        # --- Codex backend: validated, retried, concurrent, lock-checkpointed.
+        codex_kwargs = dict(
+            concurrency=args.concurrency,
+            reasoning=args.reasoning,
+            model=args.completion_model,
+            timeout=args.timeout,
+            max_retries=args.max_retries,
+            save=save,
+            save_lock=save_lock,
+        )
+
+        # 1) English authoring.
+        run_codex_stage(
+            chunk(missing_en_words(), args.batch_size),
+            lambda b: (ENGLISH_SYSTEM, english_payload(b)),
+            ExplanationBatch,
+            apply_english,
+            stage="english",
+            **codex_kwargs,
+        )
+
+        # 2) Origin verification (English only).
+        if not args.skip_verify:
+            run_codex_stage(
+                chunk(to_verify_words(), args.batch_size),
+                lambda b: (VERIFY_SYSTEM, en_para_payload(b)),
+                VerifyBatch,
+                apply_verify,
+                stage="verify",
+                **codex_kwargs,
+            )
+
+        # 3) Translation into each target language.
+        for lang in [c for c in langs if c != "en"]:
+            run_codex_stage(
+                chunk(to_translate_words(lang), args.batch_size),
+                lambda b, lang=lang: (translate_system(lang), en_para_payload(b)),
+                TranslationBatch,
+                make_apply_translation(lang),
+                stage=f"translate {lang}",
+                **codex_kwargs,
+            )
+
+        print(f"Done. Wrote {out}")
+        return
+
+    # --- OpenAI backend (billed corpora_ai) -- unchanged behavior. ---
     llm_kwargs = {}
     if args.completion_model:
         llm_kwargs["completion_model"] = args.completion_model
@@ -215,77 +499,42 @@ def main() -> None:
         return ChatCompletionTextMessage(role=role, text=text)
 
     # 1) English authoring.
-    missing_en = [w for w in words if "en" not in seed.get(w, {}).get("explanation", {})]
-    for i, batch in enumerate(chunk(missing_en, args.batch_size), start=1):
+    for i, batch in enumerate(chunk(missing_en_words(), args.batch_size), start=1):
         print(f"[english] batch {i} ({len(batch)} words)", flush=True)
         res = llm.get_data_completion(
-            [msg("system", ENGLISH_SYSTEM), msg("user", "\n".join(batch))],
+            [msg("system", ENGLISH_SYSTEM), msg("user", english_payload(batch))],
             ExplanationBatch,
         )
-        for item in res.items:
-            rec = seed.setdefault(item.word, {"explanation": {}})
-            rec["explanation"]["en"] = item.explanation.strip()
-        save_seed(out, seed)
+        apply_english(res)
+        save()
 
     # 2) Origin verification (English only).
     if not args.skip_verify:
-        to_verify = [
-            w
-            for w in words
-            if "en" in seed.get(w, {}).get("explanation", {})
-            and not seed[w].get("origin_confidence")
-        ]
-        for i, batch in enumerate(chunk(to_verify, args.batch_size), start=1):
+        for i, batch in enumerate(chunk(to_verify_words(), args.batch_size), start=1):
             print(f"[verify] batch {i} ({len(batch)} words)", flush=True)
-            payload = "\n".join(
-                f"{w}: {seed[w]['explanation']['en']}" for w in batch
-            )
             res = llm.get_data_completion(
-                [msg("system", VERIFY_SYSTEM), msg("user", payload)], VerifyBatch
+                [msg("system", VERIFY_SYSTEM), msg("user", en_para_payload(batch))],
+                VerifyBatch,
             )
-            for item in res.items:
-                rec = seed.get(item.word)
-                if not rec:
-                    continue
-                rec["origin_confidence"] = (item.confidence or "medium").lower()
-                if item.note:
-                    rec["origin_note"] = item.note.strip()
-                if item.corrected.strip():
-                    rec["explanation"]["en"] = item.corrected.strip()
-            save_seed(out, seed)
+            apply_verify(res)
+            save()
 
     # 3) Translation of the verified English into each target language.
     for lang in [c for c in langs if c != "en"]:
-        todo = [
-            w
-            for w in words
-            if "en" in seed.get(w, {}).get("explanation", {})
-            and lang not in seed[w]["explanation"]
-        ]
-        for i, batch in enumerate(chunk(todo, args.batch_size), start=1):
+        apply_translation = make_apply_translation(lang)
+        for i, batch in enumerate(
+            chunk(to_translate_words(lang), args.batch_size), start=1
+        ):
             print(f"[translate {lang}] batch {i} ({len(batch)} words)", flush=True)
-            payload = "\n".join(
-                f"{w}: {seed[w]['explanation']['en']}" for w in batch
-            )
             res = llm.get_data_completion(
                 [
-                    msg(
-                        "system",
-                        f"Translate each English word-explanation into language "
-                        f"code '{lang}', written naturally IN that language. "
-                        f"Preserve meaning, tone, hedges, and the ~50-word "
-                        f"length. Do NOT add facts. Output JSON `items` with "
-                        f"`word` and `text`.",
-                    ),
-                    msg("user", payload),
+                    msg("system", translate_system(lang)),
+                    msg("user", en_para_payload(batch)),
                 ],
                 TranslationBatch,
             )
-            for item in res.items:
-                rec = seed.get(item.word)
-                if rec and item.text.strip():
-                    rec["explanation"][lang] = item.text.strip()
-            save_seed(out, seed)
+            apply_translation(res)
+            save()
 
     print(f"Done. Wrote {out}")
 


### PR DESCRIPTION
### **User description**
## What

Adds a `--provider codex` backend to `generate_word_explanations.py` so the Phrase Flip word-explanation corpus can be generated on the **subscription codex-cli (FREE, gpt-5.5)** instead of the billed OpenAI API. **Additive** — the `openai` path is byte-for-byte unchanged in behavior (refactored only to share merge/selector helpers).

## Changes

- **Codex backend** (`generate_word_explanations.py`): composes each stage's system+user into one JSON-only `codex exec` prompt (codex has no system role), validates the reply against the existing `ExplanationBatch`/`VerifyBatch`/`TranslationBatch` pydantic schemas, retries a batch up to `--max-retries` (default 2) on parse/validation failure, then **skip-and-logs** so one bad batch can't wedge the run.
- **Parallelism + safe checkpointing**: batches run concurrently through a `ThreadPoolExecutor` of `codex exec` calls (`--concurrency`, default 8). The seed file is written under a lock after each completed batch, so two workers never clobber the checkpoint and a kill mid-run resumes cleanly (re-targets only unfinished words/langs via the same `load_seed`/`save_seed` merge-by-word).
- **Origin-clarity rule** (`ENGLISH_SYSTEM`): when an origin is surprising/counterintuitive (e.g. Italian *banca* → "bank", from a Germanic root) the author must state the borrowing path explicitly so a sharp reader doesn't mistake a correct fact for an error — still never confabulating, hedging when unsure.
- **`cor/utils/codex.py`**: pass `stdin=subprocess.DEVNULL` so `codex exec` never blocks on "Reading additional input from stdin..." in threaded/non-interactive use.
- **Tests** (`cor/utils/test_word_pack_codex.py`): prompt composition, schema validation, retry → skip-and-log, concurrent-stage apply+checkpoint, and resume selectors. **codex fully mocked** (no subprocess in CI); import-safe under stdlib + pydantic only — runs in the `dja · tests` gate (`pytest cor/utils`).
- **README**: documents the two backends, the knobs, measured latency, and projected wall-times.

## Validation (real codex, 39 words: polysemy + function words + surprising origins)

EN author → verify → translate `es` + `zh-Hans` → `build_word_pack.py`:

- **117 rows = 39 words × 3 langs** (en/es/zh-Hans each 39, asserted). 0 batch skips. confidence: 35 high / 4 medium.
- Spot-checks confirm faithful translation + the surprising-origin rule surviving into es/zh: `bank` → Italian *banca* "bench" from a Germanic root; `salary` → Latin *salarium*/salt (hedged); `nice` → Latin *nescius* "not knowing"; `clue` → ball of thread / Theseus.

## Rate-limit finding

No throttling (no 429 / rate-limit / usage-limit in stderr) at **concurrency 8 OR 16**. Mean batch latency barely rose (7.1s → 7.5s on short batches) going 8→16, so we are below the saturation knee. Safe to run at concurrency 12–16.

## Throughput + projected wall-time

- Per-batch (~50-word paragraphs): bs=4 → 11.4s (2.86s/word), bs=8 → 17.1s (2.14s/word), bs=12 → 20.3s (1.69s/word), bs=16 → 28.1s (1.76s/word). Sweet spot **bs=12**.
- **Recommended: `--batch-size 12 --concurrency 12`** (16 also safe).
- Projected: EN authoring + verify of all 11,757 words ≈ **~1 h**; full ×53-language translation ≈ **~1 day** (≈18 h at concurrency 16).

> Driver + validation + measurement only — does NOT launch the multi-hour full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Bug fix, Tests, Documentation


___

### **Description**
- Add free Codex generation backend

- Enable concurrent resumable checkpointed batches

- Prevent threaded `codex exec` hangs

- Document and test Codex workflow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cli["Generator CLI"] 
  provider["--provider selection"]
  openai["OpenAI backend"]
  codex["Codex backend"]
  batches["Concurrent validated batches"]
  seed["Locked seed checkpoint"]
  resume["Resumable corpus generation"]

  cli -- "parses options" --> provider
  provider -- "`openai`" --> openai
  provider -- "`codex`" --> codex
  codex -- "runs" --> batches
  batches -- "applies results" --> seed
  seed -- "enables" --> resume
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codex.py</strong><dd><code>Prevent Codex subprocess stdin hangs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/dja/cor/utils/codex.py

<ul><li>Closes <code>codex exec</code> stdin with <code>subprocess.DEVNULL</code>.<br> <li> Prevents blocking in non-interactive threaded contexts.<br> <li> Adds inline comment explaining the hang prevention.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/497/files#diff-387783ad92c3a734ea1dbf7e6b30a5758c4bc841f433f9dea319b4bb7230154a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_word_pack_codex.py</strong><dd><code>Test mocked Codex word-pack backend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/dja/cor/utils/test_word_pack_codex.py

<ul><li>Adds Codex backend tests with mocked <code>run_json</code>.<br> <li> Verifies prompt composition and origin guidance.<br> <li> Covers retry, skip-and-log, and Codex errors.<br> <li> Tests concurrent checkpointing and resume selectors.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/497/files#diff-bb249f96f3467ab6b5c1d226a6158488adc8ae0230d601ac1c79a9e57a94cb33">+301/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate_word_explanations.py</strong><dd><code>Add resumable concurrent Codex generation backend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/dja/word_pack/generate_word_explanations.py

<ul><li>Adds <code>--provider codex</code> backend with JSON-only prompts.<br> <li> Runs Codex batches concurrently with schema validation.<br> <li> Retries failed batches, then skips and logs.<br> <li> Refactors shared apply, save, and resume selectors.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/497/files#diff-fcba465348e7c07a9a2536f8cab4e90c1c4e7bfb1690ffeea40b3f3ecdb40def">+308/-59</a></td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document Codex backend generation workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/dja/word_pack/README.md

<ul><li>Documents <code>openai</code> versus <code>codex</code> backend usage.<br> <li> Adds recommended Codex command-line invocation.<br> <li> Explains retries, checkpointing, and resumability.<br> <li> Includes observed throughput and runtime guidance.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/497/files#diff-ba2c19a711f36cbc17594959c3acc0dac39ee23da7afdcd94f52c7918b3e2d3f">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

