### PR TITLE
deploy-pages: publish wordpan es→en pack to Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -78,6 +78,13 @@ jobs:
         working-directory: corpan/packs/hanzipan
         run: node scripts/pack.mjs
 
+      # Wordpan is a DATA-ONLY pack (no JS build) — the built-in Phrase Flip
+      # experience queries its word_explanation table on long-press. The
+      # data/word.sqlite3 ships via Git LFS (checkout sets lfs: true above).
+      - name: Package Wordpan (es→en word explanations)
+        working-directory: corpan/packs/wordpan
+        run: node scripts/pack.mjs
+
       - name: Install Juice Squeeze Dependencies
         working-directory: corpan/packs/juice-squeeze
         run: npm install --legacy-peer-deps
@@ -256,6 +263,12 @@ jobs:
           cp -R corpan/packs/hanzipan/dist "web/io/out/corpan/packs/hanzipan/"
           cp -R corpan/packs/hanzipan/data "web/io/out/corpan/packs/hanzipan/"
           cp corpan/packs/hanzipan/hanzipan.zip "web/io/out/corpan/packs/hanzipan.zip"
+
+      - name: Copy Wordpan into io/out
+        run: |
+          mkdir -p "web/io/out/corpan/packs/wordpan"
+          cp corpan/packs/wordpan/manifest.json "web/io/out/corpan/packs/wordpan/"
+          cp corpan/packs/wordpan/wordpan-es-en.zip "web/io/out/corpan/packs/wordpan-es-en.zip"
 
       - name: Copy Juice Squeeze into io/out
         run: |


### PR DESCRIPTION
### **User description**
Adds the two additive `deploy-pages.yml` steps that publish the `wordpan_es_en` data pack (merged in #498) to GitHub Pages:

- **Package step** — `node scripts/pack.mjs` in `corpan/packs/wordpan` (data-only pack, no JS build; `data/word.sqlite3` ships via Git LFS, checkout already sets `lfs: true`).
- **Copy step** — copies `manifest.json` + `wordpan-es-en.zip` into `web/io/out/corpan/packs/`, so the catalog `zipUrl` `/corpan/packs/wordpan-es-en.zip` resolves (HTTP 200) instead of 404-ing on install.

Mirrors the existing Hanzipan pattern exactly. **No gate logic touched — additive only (#393).** Refs #477 #478 #479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Publish Wordpan pack in Pages

- Build `wordpan-es-en.zip` during deploy

- Copy manifest and zip output


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Deploy Pages workflow"] -- "packages" --> B["Wordpan data pack"]
  B -- "creates" --> C["wordpan-es-en.zip"]
  C -- "copies to" --> D["web/io/out/corpan/packs"]
  D -- "serves" --> E["catalog zipUrl install"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy-pages.yml</strong><dd><code>Add Wordpan Pages packaging and publish steps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy-pages.yml

<ul><li>Adds a Wordpan packaging step in deploy.<br> <li> Runs <code>node scripts/pack.mjs</code> under <code>corpan/packs/wordpan</code>.<br> <li> Copies <code>manifest.json</code> into the Pages pack folder.<br> <li> Copies <code>wordpan-es-en.zip</code> to the catalog URL path.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/499/files#diff-0f132b0962009071404990a6789b3466dbd8723d1f7b744f6aca0312396a7900">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

