### PR TITLE
beatlounge: fix Record stuck-ON across surfaces + session-scope arm (#391)

### DIFF
--- a/corpan/packs/beatlounge/CHANGELOG.md
+++ b/corpan/packs/beatlounge/CHANGELOG.md
@@ -5,6 +5,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **Record could get stuck ON after switching instruments** (#391). Two causes:
+  the immersive Ribbon armed a *different* track (the first melodic voice) than
+  the Instruments page / DockRail / home widget (the *selected* voice), so
+  turning Record off on one surface left it armed on another; and the arm was
+  persisted to `localStorage`, so a reload came back silently armed. Now every
+  surface arms the **selected voice**, and arm is **session-scoped** — sticky per
+  voice within a session, but a full app reload always starts OFF (a record arm
+  is mildly destructive; you should never come back quietly recording).
+
 ## [0.7.0] - 2026-06-25
 
 ### Added

--- a/corpan/packs/beatlounge/src/modules/ribbon/RibbonImmersive.tsx
+++ b/corpan/packs/beatlounge/src/modules/ribbon/RibbonImmersive.tsx
@@ -3,25 +3,47 @@
  *
  * Thin wrapper: the ribbon's whole gesture/harmony/record surface now lives in
  * the reusable <InstrumentRibbon> (modules/instrument-surface), shared with the
- * Instruments page. The standalone Ribbon module is the quick-perform surface —
- * it owns its own Record arm and plays/records the bound melodic track through
- * that track's real instrument (polyphonic, through its FX + mixer).
+ * Instruments page. This is the quick-perform surface — it plays/records through
+ * the bound melodic track's real instrument (polyphonic, through its FX + mixer).
+ *
+ * It binds to the PERSISTED selected voice (`useSelectedInstrument`) — the SAME
+ * track the Instruments page, the Shell DockRail Record button, and the home
+ * Ribbon widget arm and record into. That keeps Record-arm consistent across
+ * every surface (fixes #391: turning Record off on one surface no longer leaves
+ * it armed here, because they were pointing at different tracks). The mount's
+ * `trackId` is only a fallback for when nothing is selected yet.
  */
 
 import type { BeatloungeHost } from "../../contracts/module"
 import type { BeatloungeStore } from "../../store/store"
 import type { AudioFacade } from "../../contracts/audioFacade"
 import type { Id } from "../../model/document"
+import { useBeatloungeStore } from "../../store/store"
+import { useSelectedInstrument } from "../../store/selectedInstrument"
 import { InstrumentRibbon } from "../instrument-surface/InstrumentRibbon"
 
 interface Props {
   host: BeatloungeHost
   store: BeatloungeStore
   audio: AudioFacade
-  /** The melodic track the ribbon plays + records into. */
+  /** Fallback melodic track when no voice is selected yet. */
   trackId: Id
 }
 
-export const RibbonImmersive = ({ host, store, audio, trackId }: Props) => (
-  <InstrumentRibbon host={host} store={store} audio={audio} trackId={trackId} />
-)
+export const RibbonImmersive = ({ host, store, audio, trackId }: Props) => {
+  const doc = useBeatloungeStore(store, (s) => s.doc)
+  // Reactive: re-render on a selection change (slice) AND a doc change, so the
+  // strip always performs — and records into — the page's current voice.
+  const { trackId: selected } = useSelectedInstrument(doc)
+  const bound = selected ?? trackId
+  return (
+    <InstrumentRibbon
+      // Remount on a voice change so no note dangles across the switch.
+      key={bound}
+      host={host}
+      store={store}
+      audio={audio}
+      trackId={bound}
+    />
+  )
+}

--- a/corpan/packs/beatlounge/src/store/recordArm.test.ts
+++ b/corpan/packs/beatlounge/src/store/recordArm.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, beforeEach } from "vitest"
-import { isRecordArmed, setRecordArmed, disarmAllRecord } from "./recordArm"
+import {
+  isRecordArmed,
+  setRecordArmed,
+  disarmAllRecord,
+  __resetRecordArmForTest,
+} from "./recordArm"
 
 describe("recordArm — per-track, sticky, default OFF", () => {
   beforeEach(() => disarmAllRecord())
@@ -38,5 +43,23 @@ describe("recordArm — per-track, sticky, default OFF", () => {
     disarmAllRecord()
     expect(isRecordArmed("trk-a")).toBe(false)
     expect(isRecordArmed("trk-b")).toBe(false)
+  })
+
+  it("session-scoped: a reload never comes up silently armed (#391)", () => {
+    // A prior session armed a track, and (to prove it can't leak back) we also
+    // stash a matching entry in localStorage — what a persisted store WOULD
+    // rehydrate on load.
+    setRecordArmed("trk-a", true)
+    try {
+      if (typeof localStorage !== "undefined") {
+        localStorage.setItem("beatlounge:recordArm", JSON.stringify(["trk-a"]))
+      }
+    } catch {
+      /* no localStorage in this env — the in-memory guarantee still holds */
+    }
+    // A full app reload re-initialises the store: arm is in-memory only, so it
+    // must come back OFF — never silently re-armed, never quietly recording.
+    __resetRecordArmForTest()
+    expect(isRecordArmed("trk-a")).toBe(false)
   })
 })

--- a/corpan/packs/beatlounge/src/store/recordArm.ts
+++ b/corpan/packs/beatlounge/src/store/recordArm.ts
@@ -1,16 +1,24 @@
 /**
  * beatlounge — the PER-TRACK RECORD-ARM slice: ONE source of truth for which
  * tracks are armed to record, shared across every surface that can record (the
- * Instruments page header, the Ribbon widget/immersive) and PERSISTED so the
- * arm is sticky — it survives switching voices, leaving the page, and a reload.
+ * Instruments page header, the Shell DockRail button, the Ribbon widget /
+ * immersive). Arm is keyed by trackId and lives in ONE module-scoped vanilla
+ * zustand store (mirrors selectedGroove.ts / selectedInstrument.ts), so each
+ * voice remembers its OWN arm; default is OFF; turning it off sticks for that
+ * track only.
  *
- * The bug this fixes: record-arm was transient `useState` — a single shared flag
- * on the Instruments page (so arming one synth bled onto every other voice) plus
- * a second local flag inside the ribbon. Turning it "off" never reliably stuck,
- * and switching synths showed the wrong arm. Now arm is keyed by trackId, lives
- * in one module-scoped vanilla zustand store (mirrors selectedGroove.ts /
- * selectedInstrument.ts), and is persisted to localStorage. Each voice remembers
- * its OWN arm; default is OFF; turning it off sticks for that track only.
+ * SESSION-SCOPED (fixes #391): arm is sticky WITHIN a running session — it
+ * survives switching voices and leaving/returning to a surface (the module
+ * store outlives component unmount) — but it is held in memory only and is NOT
+ * persisted. A full app reload/restart re-initialises the store to empty, so
+ * you can never come back to a voice that is SILENTLY armed and quietly
+ * overwriting your track. A record arm is (mildly) destructive; the safe
+ * default is to start OFF every session.
+ *
+ * The bug this originally fixed: record-arm was transient `useState` — a single
+ * shared flag on the Instruments page (so arming one synth bled onto every other
+ * voice) plus a second local flag inside the ribbon. Turning it "off" never
+ * reliably stuck, and switching synths showed the wrong arm.
  */
 
 import { createStore } from "zustand/vanilla"
@@ -22,36 +30,14 @@ interface RecordArmState {
   armed: Record<Id, true>
 }
 
-const LS_KEY = "beatlounge:recordArm"
+/**
+ * The initial armed set for a fresh session: ALWAYS empty. Session-scoped by
+ * design — nothing is read from storage, so a reload never rehydrates an arm.
+ * Kept as a named seam so a fresh load and the test reset share one definition.
+ */
+const initialArmed = (): Record<Id, true> => ({})
 
-/** Read the persisted armed-id set (graceful in SSR / private mode). */
-const readPersisted = (): Record<Id, true> => {
-  try {
-    if (typeof localStorage === "undefined") return {}
-    const raw = localStorage.getItem(LS_KEY)
-    if (!raw) return {}
-    const ids = JSON.parse(raw) as unknown
-    if (!Array.isArray(ids)) return {}
-    const out: Record<Id, true> = {}
-    for (const id of ids) if (typeof id === "string") out[id] = true
-    return out
-  } catch {
-    return {}
-  }
-}
-
-/** Persist the armed-id set (best-effort). */
-const writePersisted = (armed: Record<Id, true>): void => {
-  try {
-    if (typeof localStorage !== "undefined") {
-      localStorage.setItem(LS_KEY, JSON.stringify(Object.keys(armed)))
-    }
-  } catch {
-    /* private mode / quota — in-memory store still works */
-  }
-}
-
-const armStore = createStore<RecordArmState>(() => ({ armed: readPersisted() }))
+const armStore = createStore<RecordArmState>(() => ({ armed: initialArmed() }))
 
 /** Is this track armed to record? (false for an unknown/undefined id) */
 export const isRecordArmed = (trackId: Id | undefined): boolean =>
@@ -66,23 +52,30 @@ export const setRecordArmed = (trackId: Id | undefined, on: boolean): void => {
   if (on) next[trackId] = true
   else delete next[trackId]
   armStore.setState({ armed: next })
-  writePersisted(next)
 }
 
 /** Disarm every track (used when the whole song is replaced). */
 export const disarmAllRecord = (): void => {
   if (Object.keys(armStore.getState().armed).length === 0) return
   armStore.setState({ armed: {} })
-  writePersisted({})
 }
 
 /**
  * The hook every record surface uses. Subscribes to THIS track's arm (selective
- * re-render) and returns a setter scoped to it. Default OFF; sticky + persisted.
+ * re-render) and returns a setter scoped to it. Default OFF; sticky within the
+ * session, per track.
  */
 export const useRecordArm = (
   trackId: Id | undefined
 ): { armed: boolean; setArmed: (on: boolean) => void } => {
   const armed = useStore(armStore, (s) => (trackId ? s.armed[trackId] === true : false))
   return { armed, setArmed: (on: boolean) => setRecordArmed(trackId, on) }
+}
+
+/**
+ * Test seam: re-initialise the singleton to a fresh-session state (empty).
+ * Simulates a full app reload so a test can prove arm never silently rehydrates.
+ */
+export const __resetRecordArmForTest = (): void => {
+  armStore.setState({ armed: initialArmed() })
 }


### PR DESCRIPTION
### **User description**
Closes #391.

## The bug
Per-instrument **Record** got **stuck ON**: turn it off, switch instruments (or reload), and it's armed again.

## Root cause (two of them)
1. **Cross-surface mismatch.** The immersive Ribbon armed a *different* track than every other surface. It bound to `resolveMelodicTrackId` (the *first* melodic voice), while the Instruments page, the Shell **DockRail** Record button, and the home Ribbon widget all bind to the *persisted selected* voice (`useSelectedInstrument`). So arming/disarming on one surface never reflected on another — you turned Record "off" on one, and it was still "on" on another.
2. **Persisted arm.** Arm was written to `localStorage`, so a full app reload came back **silently armed** — quietly overwriting your track.

## The fix (agreed behaviour: sticky per voice, OFF on reload)
- `RibbonImmersive` now binds to the **selected voice** (mirrors `RibbonWidget`), so **every surface arms/records the same track**. `key={trackId}` remounts cleanly on a voice switch.
- Record-arm is **session-scoped**: sticky per voice *within* a session (the module store outlives component unmount, so switching away & back keeps each voice's arm), but a **reload/restart starts OFF**. A record arm is mildly destructive, so the safe default is never to come back quietly recording. Dropped the `localStorage` read/write.
- Added a `__resetRecordArmForTest` seam + a **guard test**: a prior session (and a stray persisted entry) never rehydrates an arm after a simulated reload.

## Verification
- `tsc --noEmit` clean; **all 1322 pack tests pass** (incl. the new guard test).
- ⚠️ **Needs an on-device human test** before merge (per our hard rule): confirm the stuck-ON repro is gone and that the immersive Ribbon now performs/records the selected voice. This changes *which voice* the full-screen ribbon plays (now follows the Instruments selection instead of always the first melodic track) — worth a feel-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Align Record surfaces to selected voice

- Make record arm session-scoped

- Prevent reloads from silently re-arming

- Document and test stuck-ON fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  selected["Selected voice"] 
  surfaces["Record surfaces"]
  armStore["Session record-arm store"]
  reload["App reload"]
  off["Record starts OFF"]
  selected -- "binds" --> surfaces
  surfaces -- "updates per track" --> armStore
  reload -- "resets" --> off
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RibbonImmersive.tsx</strong><dd><code>Bind immersive Ribbon to selected voice</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/modules/ribbon/RibbonImmersive.tsx

<ul><li>Binds immersive Ribbon to <code>useSelectedInstrument</code>.<br> <li> Falls back to provided <code>trackId</code> when unselected.<br> <li> Remounts <code>InstrumentRibbon</code> with <code>key={bound}</code> on voice changes.<br> <li> Updates comments to explain cross-surface Record consistency.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/505/files#diff-67cd981788ba205a38f505e41688d291a4e4ebdcc3c15a3b567e15519db6153d">+29/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>recordArm.ts</strong><dd><code>Make record arm session-scoped</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/store/recordArm.ts

<ul><li>Removes <code>localStorage</code> record-arm persistence.<br> <li> Initializes record arm state as empty per session.<br> <li> Keeps per-track arm state sticky only in memory.<br> <li> Adds <code>__resetRecordArmForTest</code> reload simulation seam.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/505/files#diff-6a7e1a20adacfd32e4f2714b8ca23f232be0b3957eca1713a6e42a057f6bfa2a">+34/-41</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>recordArm.test.ts</strong><dd><code>Test reload cannot re-arm Record</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/store/recordArm.test.ts

<ul><li>Imports <code>__resetRecordArmForTest</code> test seam.<br> <li> Adds regression test for reload-safe Record state.<br> <li> Verifies stale <code>localStorage</code> entries are ignored.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/505/files#diff-7baa13e2662033ccef8d51786b9a431a92004362fb8c206b58f3544036b17cdb">+24/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document Record stuck-ON fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/CHANGELOG.md

<ul><li>Adds unreleased fix note for issue <code>#391</code>.<br> <li> Explains selected-voice alignment across Record surfaces.<br> <li> Documents session-scoped arm behavior and reload OFF default.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/505/files#diff-83e97c4e36caca34711c70ef258b21b23e7362bf0f79b312a22fb2679ced8def">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

