### PR TITLE
beatlounge: record captures note sustain, not zero-length dots (#397)

### DIFF
--- a/corpan/packs/beatlounge/CHANGELOG.md
+++ b/corpan/packs/beatlounge/CHANGELOG.md
@@ -5,6 +5,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **Recorded held notes played back as zero-length dots** (#397). The ribbon
+  captured only the note-ON (a fixed one-step note) and never measured the hold,
+  so sustained playing collapsed to instant blips. Each finger now remembers the
+  note it laid and, on the next crossing or the release, **extends its duration**
+  to how long it was held (`heldNoteDuration` → an `editNote` patch). Free-timing
+  records the raw held length; quantized recording rounds it to whole steps; a
+  tap still stays one step (no undo churn). Sustains through glides (legato).
+
 ## [0.7.0] - 2026-06-25
 
 ### Added

--- a/corpan/packs/beatlounge/src/modules/instrument-surface/InstrumentRibbon.tsx
+++ b/corpan/packs/beatlounge/src/modules/instrument-surface/InstrumentRibbon.tsx
@@ -35,8 +35,9 @@ import type { BeatloungeStore } from "../../store/store"
 import type { AudioFacade, LiveVoiceHandle } from "../../contracts/audioFacade"
 import { useBeatloungeStore } from "../../store/store"
 import { useRecordArm, isRecordArmed } from "../../store/recordArm"
-import { findTrack, isInstrumentTrack, type Id } from "../../model/document"
-import { stepForTick } from "../../model/timing"
+import { findTrack, isInstrumentTrack, type Id, type Tick } from "../../model/document"
+import { gridTicks, stepForTick } from "../../model/timing"
+import { heldNoteDuration } from "./recordSustain"
 import {
   KEY_NAMES,
   midiToX,
@@ -94,6 +95,11 @@ interface Touch {
   lastRecordedStep: number
   /** The finger's current x (0..1) — drives its own lit marker. */
   x: number
+  /** The recorded note this finger is currently holding — so a later crossing
+   *  or the release can extend its DURATION to how long it was held (#397). */
+  recNoteId?: Id
+  /** The held note's start tick (its own coordinate for the duration math). */
+  recNoteTick?: Tick
 }
 
 /** How many simultaneous lit markers the surface can show (one per finger). A
@@ -183,7 +189,12 @@ export const InstrumentRibbon = ({
   useEffect(() => {
     const map = touches.current
     return () => {
-      for (const t of map.values()) t.handle?.release()
+      // Switching voice / unmounting mid-hold: seal each finger's sustain, then
+      // release its live voice so nothing dangles and no note stays a dot (#397).
+      for (const t of map.values()) {
+        closeRecordedNote(t)
+        t.handle?.release()
+      }
       map.clear()
       for (const node of markerRefs.current) if (node) node.style.opacity = "0"
       for (const label of markerLabelRefs.current) if (label) label.textContent = ""
@@ -310,7 +321,44 @@ export const InstrumentRibbon = ({
       midi,
     })
     t.lastRecordedStep = result.lastRecordedStep
-    if (result.command) store.dispatch(result.command)
+    if (!result.command || result.command.t !== "addNote") return
+    // A NEW note begins here → the finger's previous held note ends now: extend
+    // it to the current playhead before laying the next one (#397 legato hold).
+    closeRecordedNote(t)
+    store.dispatch(result.command)
+    // Remember the note we just laid (unique tick+pitch at this instant — the
+    // placement guard rejects a duplicate cell) so a later crossing / the
+    // release can sustain it. Its id is assigned by the reducer, so read it back.
+    const laid = result.command.note
+    const after = findTrack(store.vanilla.getState().doc, trackId)
+    const added =
+      after && isInstrumentTrack(after)
+        ? after.notes.find((n) => n.tick === laid.tick && n.pitch === laid.pitch)
+        : undefined
+    t.recNoteId = added?.id
+    t.recNoteTick = added?.tick
+  }
+
+  /** Sustain the note this finger has been holding: patch its duration to how
+   *  long it was held (note-on → now). No-op for a tap — the one-step note that
+   *  placeRecordedNote already laid is left alone, so there's no undo churn. */
+  const closeRecordedNote = (t: Touch) => {
+    const noteId = t.recNoteId
+    if (!noteId || t.recNoteTick == null) return
+    const cur = findTrack(store.vanilla.getState().doc, trackId)
+    if (cur && isInstrumentTrack(cur)) {
+      const dur = heldNoteDuration(
+        t.recNoteTick,
+        playTickRef.current,
+        cur.grid,
+        live.current.quantizeRecord
+      )
+      if (dur > gridTicks(cur.grid)) {
+        store.dispatch({ t: "editNote", trackId, noteId, patch: { duration: dur } })
+      }
+    }
+    t.recNoteId = undefined
+    t.recNoteTick = undefined
   }
 
   const onDown = (e: React.PointerEvent) => {
@@ -369,6 +417,8 @@ export const InstrumentRibbon = ({
   const endPointer = (e: React.PointerEvent) => {
     const t = touches.current.get(e.pointerId)
     if (!t) return
+    // Seal the held note's sustain at the release before the voice goes silent.
+    closeRecordedNote(t)
     t.handle?.release()
     touches.current.delete(e.pointerId)
     paintMarkers()

--- a/corpan/packs/beatlounge/src/modules/instrument-surface/recordSustain.test.ts
+++ b/corpan/packs/beatlounge/src/modules/instrument-surface/recordSustain.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import type { Grid } from "../../model/document"
+import { gridTicks } from "../../model/timing"
+import { heldNoteDuration } from "./recordSustain"
+
+const grid: Grid = { denominator: 16 } // 1/16 → 240 ticks at PPQ 960
+const STEP = gridTicks(grid)
+
+describe("heldNoteDuration — record sustain (#397)", () => {
+  it("a tap (no elapsed time) stays one step — never a zero-length dot", () => {
+    expect(heldNoteDuration(0, 0, grid, false)).toBe(STEP)
+    expect(heldNoteDuration(480, 480, grid, true)).toBe(STEP)
+  })
+
+  it("a stopped transport (nowTick < 0) falls back to one step", () => {
+    expect(heldNoteDuration(0, -1, grid, false)).toBe(STEP)
+    expect(heldNoteDuration(0, -1, grid, true)).toBe(STEP)
+  })
+
+  it("free timing: the raw held length, floored at one step", () => {
+    expect(heldNoteDuration(1000, 1000 + STEP * 3, grid, false)).toBe(STEP * 3)
+    // held shorter than a step still floors to a step
+    expect(heldNoteDuration(1000, 1000 + 10, grid, false)).toBe(STEP)
+  })
+
+  it("quantized: the held length rounds to whole steps", () => {
+    // started at step 0, playhead ~3.4 steps in → 3 whole steps
+    expect(heldNoteDuration(0, Math.round(STEP * 3.4), grid, true)).toBe(STEP * 3)
+    // held within the same step → one step
+    expect(heldNoteDuration(0, Math.round(STEP * 0.4), grid, true)).toBe(STEP)
+    // start already on a step boundary (a quantized note's tick), 5 steps held
+    expect(heldNoteDuration(STEP * 2, STEP * 7, grid, true)).toBe(STEP * 5)
+  })
+})

--- a/corpan/packs/beatlounge/src/modules/instrument-surface/recordSustain.ts
+++ b/corpan/packs/beatlounge/src/modules/instrument-surface/recordSustain.ts
@@ -1,0 +1,36 @@
+/**
+ * beatlounge — PURE hold-duration for the InstrumentRibbon record path (#397).
+ *
+ * A recorded note is laid at its note-ON one grid step long (see
+ * recordPlacement). While the finger is HELD, the note should SUSTAIN — this
+ * computes how long, given where the note started and where the playhead is NOW
+ * (the next crossing for that finger, or the release). Floors at one step, so a
+ * tap stays a step and never collapses to a zero-length dot; quantized recording
+ * rounds the held length to whole steps so a sustained note still lands on grid.
+ *
+ * Pure (no React/Tone) so the note-on → note-off length unit-tests without a DOM.
+ */
+
+import type { Grid, Tick } from "../../model/document"
+import { gridTicks, stepForTick } from "../../model/timing"
+
+/**
+ * Ticks a held note should span from `startTick` to the playhead `nowTick`.
+ *  • nowTick < 0 (transport stopped) or no elapsed time ⇒ one step (the default).
+ *  • quantize ⇒ whole steps held (min one).
+ *  • free timing ⇒ the raw held length, floored at one step.
+ */
+export const heldNoteDuration = (
+  startTick: Tick,
+  nowTick: Tick,
+  grid: Grid,
+  quantize: boolean
+): Tick => {
+  const step = gridTicks(grid)
+  if (nowTick < 0 || nowTick <= startTick) return step
+  if (quantize) {
+    const steps = Math.max(1, stepForTick(nowTick, grid) - stepForTick(startTick, grid))
+    return steps * step
+  }
+  return Math.max(step, nowTick - startTick)
+}


### PR DESCRIPTION
### **User description**
Closes #397.

## The bug
Record with **held** notes → on playback they're **instant dots**, not the sustained notes you played. The ribbon captured the note-**on** (a fixed one-step note via `placeRecordedNote`) and never measured the hold, so every recorded note was durationless.

## The fix
Each finger now remembers the note it laid (id + start tick, read back after `addNote`) and **extends its duration** to how long it was held:
- on the **next crossing** for that finger → the previous note sustains up to there (legato glides);
- on the **release** (`endPointer`) → the held note sustains to the lift;
- on a **mid-hold voice switch / unmount** → the sustain is sealed too.

Duration math lives in a pure, unit-tested helper `recordSustain.ts` (`heldNoteDuration`):
- **free timing** → the raw held length;
- **quantized** → rounded to whole steps (stays on grid);
- a **tap** → still one step, and it skips the `editNote` entirely (no undo churn).

`placeRecordedNote` is **unchanged** — the one-step note-on is still the right default; only genuinely-held notes get patched.

## Verification
- `tsc --noEmit` clean; **all 1325 pack tests pass** (4 new `recordSustain` tests for tap / stopped / free / quantized).
- ⚠️ **Needs an on-device human test** (per our hard rule): record while the transport plays, hold notes of varying lengths (quantized and free), and confirm playback bars/audio match the hold — including a glide (each pitch sustains until the next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Captures recorded note sustain duration

- Seals held notes on release

- Supports quantized and free timing

- Adds tests and changelog entry


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Finger records note-on"] -- "stores note id and tick" --> B["Held note tracked"]
  B -- "next crossing or release" --> C["Compute held duration"]
  C -- "dispatch editNote patch" --> D["Sustained playback bar"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InstrumentRibbon.tsx</strong><dd><code>Track and close held recorded notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/modules/instrument-surface/InstrumentRibbon.tsx

<ul><li>Tracks each touch's recorded note id and tick.<br> <li> Closes prior held notes before new crossings.<br> <li> Extends note duration on release or unmount.<br> <li> Uses <code>heldNoteDuration</code> for sustain calculation.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/506/files#diff-f4e3b05f6df4bc610ab3a70fc45f72b18d2f3da1bc44525aee785035a306fe2a">+54/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>recordSustain.ts</strong><dd><code>Compute held note record durations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/modules/instrument-surface/recordSustain.ts

<ul><li>Adds pure <code>heldNoteDuration</code> helper.<br> <li> Floors taps and stopped transport to one step.<br> <li> Preserves raw duration for free timing.<br> <li> Rounds quantized holds to whole grid steps.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/506/files#diff-c39c32e214de64e039b89049b51cc01c2c3c4a5d41ec6ddaabc2cc9b47856f4c">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>recordSustain.test.ts</strong><dd><code>Add record sustain duration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/modules/instrument-surface/recordSustain.test.ts

<ul><li>Tests taps remain one grid step.<br> <li> Tests stopped transport fallback behavior.<br> <li> Covers free-timing raw held lengths.<br> <li> Covers quantized whole-step duration rounding.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/506/files#diff-3a5ff5fcf7ebf7dc73aac024b644c79778dcc4deafafc6badb4a8089758a9347">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document recorded sustain fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/CHANGELOG.md

<ul><li>Documents fixed recorded held-note sustain bug.<br> <li> Notes glide, quantized, and free-timing behavior.<br> <li> References <code>heldNoteDuration</code> and <code>editNote</code> patching.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/506/files#diff-83e97c4e36caca34711c70ef258b21b23e7362bf0f79b312a22fb2679ced8def">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

