### PR TITLE
beatlounge: flatten scratch-page first-load main-thread spike (#396)

### DIFF
--- a/corpan/packs/beatlounge/CHANGELOG.md
+++ b/corpan/packs/beatlounge/CHANGELOG.md
@@ -5,6 +5,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **Scratch page first-load stalled the main thread → brief audio glitch** (#396),
+  even on high-end devices. Loading a snippet ran one uninterrupted synchronous
+  block — two full-waveform word-span passes + buffer-padding + deck build — right
+  as `decodeAudioData` resolved, contending with the running audio callback. Load
+  now **builds and holds the deck first** (so the platter is playable immediately)
+  and **defers the word-span analysis behind yields**, so no single step shares
+  the audio render quantum. The master FX bus is also built in a mount effect
+  instead of the render body, so restoring a saved chain no longer constructs Tone
+  nodes synchronously during render.
+
 ## [0.7.0] - 2026-06-25
 
 ### Added

--- a/corpan/packs/beatlounge/CHANGELOG.md
+++ b/corpan/packs/beatlounge/CHANGELOG.md
@@ -11,8 +11,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   block — two full-waveform word-span passes + buffer-padding + deck build — right
   as `decodeAudioData` resolved, contending with the running audio callback. Load
   now **builds and holds the deck first** (so the platter is playable immediately)
-  and **defers the word-span analysis behind yields**, so no single step shares
-  the audio render quantum. The master FX bus is also built in a mount effect
+  and **defers the word-span analysis to main-thread idle** (`requestIdleCallback`
+  with a timeout fallback), so the two-pass scan never shares the audio render
+  quantum with the running transport. The master FX bus is also built in a mount
+  effect
   instead of the render body, so restoring a saved chain no longer constructs Tone
   nodes synchronously during render.
 

--- a/corpan/packs/beatlounge/src/modules/phrase-scratch/PhraseScratchImmersive.tsx
+++ b/corpan/packs/beatlounge/src/modules/phrase-scratch/PhraseScratchImmersive.tsx
@@ -73,6 +73,13 @@ import "../track-studio/track-studio.css"
 
 const LOG = "[beatlounge/phrase-scratch]"
 
+/** Yield a macrotask so the audio render quantum (and paint) can run between two
+ *  CPU-heavy steps. Used to break up snippet-load work — decode → pad+build deck
+ *  → word-span analysis — so no single block starves the audio thread on the
+ *  scratch page (#396). */
+const yieldToMain = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0))
+
 interface Props {
   host: BeatloungeHost
   store: BeatloungeStore
@@ -208,21 +215,24 @@ export const PhraseScratchImmersive = ({ host, store, audioSource }: Props) => {
   rtB.current.spinDir = dirB
 
   // ---- master FX bus: decks feed this; it inserts the chain → destination -----
-  // Built once; the decks connect into bus.input (their destination) so the chain
-  // colours BOTH decks. The chain is pushed whenever the config changes.
-  if (!fxBusRef.current) {
-    // Build the bus + wire the initial (bypassed) chain. Idempotent via the ref
-    // guard; recreated after a StrictMode dispose/remount. Toggles + param moves
-    // go through updateInsert/liveParam (no rebuild).
-    const bus = createScratchFxBus(host.audioContext())
-    bus.setInserts(fxChain)
-    fxBusRef.current = bus
-  }
+  // Built once on MOUNT (in an effect, OFF the render/commit path — so restoring
+  // a saved chain never constructs Tone effect nodes synchronously during render,
+  // which contended with the audio callback on first load, #396). The decks
+  // connect into bus.input so the chain colours BOTH decks; later toggles + param
+  // moves go through setInserts/updateInsert/liveParam (no rebuild).
   useEffect(() => {
+    if (!fxBusRef.current) {
+      const bus = createScratchFxBus(host.audioContext())
+      bus.setInserts(fxChain)
+      fxBusRef.current = bus
+    }
     return () => {
       fxBusRef.current?.dispose()
       fxBusRef.current = null
     }
+    // Mount-only: `fxChain` here is the RESTORED chain; live edits reach the bus
+    // directly (setInserts/updateInsert), never a rebuild.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // Warm the scratch AudioWorklet module the instant you enter the pane, so its
@@ -304,14 +314,13 @@ export const PhraseScratchImmersive = ({ host, store, audioSource }: Props) => {
           setLoading(false)
           return
         }
-        // Word spans live on the REAL phrase timeline (before padding).
-        const channel = decoded.getChannelData(0)
-        const { spans, labels } = resolveWordSpans(
-          channel,
-          decoded.sampleRate,
-          decoded.duration,
-          splitWords(text)
-        )
+        // Build + hold the deck FIRST so the platter is playable as soon as
+        // possible, and so neither the buffer-padding nor the (heavier) word-span
+        // analysis shares the audio render quantum on load (#396). A yield lets
+        // the audio callback breathe after decodeAudioData resolves, before the
+        // CPU-heavy pad + deck build.
+        await yieldToMain()
+        if (stale()) return
         // LOOP-ANGLE FIX: pad the wave with trailing silence to a WHOLE number of
         // revolutions (+ boundary fades) so the loop wraps at an integer disc turn —
         // the phrase START returns under the needle at the SAME angle every loop. The
@@ -326,16 +335,39 @@ export const PhraseScratchImmersive = ({ host, store, audioSource }: Props) => {
           return
         }
         rt.current.deck = deck
-        rt.current.spans = spans
-        rt.current.words = labels.length > 0 ? labels : [text]
         rt.current.durationSec = padded.duration
         rt.current.phraseSec = decoded.duration
+        // Provisional readout until the spans resolve below — the whole phrase as
+        // one label. Playback does not depend on the spans.
+        rt.current.spans = []
+        rt.current.words = [text]
         // Lock the needle to the audio: the engine reports its true playhead.
         rt.current.unsubPos = deck.onPos((p) => {
           rt.current.audioSec = p.seconds
         })
         deck.hold()
         setLoading(false)
+
+        // Word spans (two full-waveform passes) live on the REAL phrase timeline
+        // (before padding). They're NOT needed to play, so compute them AFTER a
+        // yield — off the load's critical path — and swap them in when ready. A
+        // span failure must never tank the already-playable deck.
+        await yieldToMain()
+        if (stale()) return
+        try {
+          const channel = decoded.getChannelData(0)
+          const { spans, labels } = resolveWordSpans(
+            channel,
+            decoded.sampleRate,
+            decoded.duration,
+            splitWords(text)
+          )
+          if (stale()) return
+          rt.current.spans = spans
+          rt.current.words = labels.length > 0 ? labels : [text]
+        } catch (err) {
+          console.warn(`${LOG} word-span analysis failed (playback unaffected):`, err)
+        }
       } catch (err) {
         console.warn(`${LOG} load failed:`, err)
         if (!stale()) {

--- a/corpan/packs/beatlounge/src/modules/phrase-scratch/PhraseScratchImmersive.tsx
+++ b/corpan/packs/beatlounge/src/modules/phrase-scratch/PhraseScratchImmersive.tsx
@@ -80,6 +80,19 @@ const LOG = "[beatlounge/phrase-scratch]"
 const yieldToMain = (): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, 0))
 
+/** Wait until the main thread is IDLE before running a heavy, non-urgent pass, so
+ *  it can't contend with audio scheduling (the two-pass word-span scan). Falls
+ *  back to a macrotask where requestIdleCallback is unavailable; the timeout
+ *  guarantees the pass still runs promptly on a busy thread (#396). */
+const onIdle = (): Promise<void> =>
+  new Promise((resolve) => {
+    if (typeof requestIdleCallback === "function") {
+      requestIdleCallback(() => resolve(), { timeout: 400 })
+    } else {
+      setTimeout(resolve, 0)
+    }
+  })
+
 interface Props {
   host: BeatloungeHost
   store: BeatloungeStore
@@ -349,10 +362,11 @@ export const PhraseScratchImmersive = ({ host, store, audioSource }: Props) => {
         setLoading(false)
 
         // Word spans (two full-waveform passes) live on the REAL phrase timeline
-        // (before padding). They're NOT needed to play, so compute them AFTER a
-        // yield — off the load's critical path — and swap them in when ready. A
+        // (before padding). They're NOT needed to play, so run them when the main
+        // thread is IDLE — off the load's critical path, never contending with the
+        // running transport's audio scheduling — and swap them in when ready. A
         // span failure must never tank the already-playable deck.
-        await yieldToMain()
+        await onIdle()
         if (stale()) return
         try {
           const channel = decoded.getChannelData(0)


### PR DESCRIPTION
### **User description**
Closes #396.

## The bug
Opening the scratch page / loading a snippet caused a brief (~couple ms) **audio glitch**, reproducible **even on high-end devices** — a genuine main-thread stall, not a slow-device problem.

## Root cause
When `decodeAudioData` resolved, `loadDeck` ran **one uninterrupted synchronous block**:
- `resolveWordSpans` → two full-waveform passes (peak-RMS + voiced-window),
- `padBufferToRevolution` → a full channel copy + per-sample boundary fade,
- the deck build (channel `.slice()` copies),

all contending with the already-running audio callback. Separately, restoring a saved FX chain built Tone effect nodes **synchronously in the render body**.

## The fix
- **Build + hold the deck first** so the platter is playable immediately, then **defer the word-span analysis behind macrotask yields** (`yieldToMain`) — decode → *yield* → pad + deck build → *yield* → word spans. No single step shares the audio render quantum. Word labels swap in a beat later; a span failure no longer tanks the already-playable deck.
- **Build the master FX bus in a mount effect** instead of the render body, so restoring a saved chain doesn't construct Tone nodes synchronously during render. Live FX edits still go straight to the bus (`setInserts`/`updateInsert`) — unchanged.

## Verification
- `tsc --noEmit` clean; **all 1321 pack tests pass**. No behaviour change to playback/looping/word readout (just *when* the work runs).
- ⚠️ **Needs an on-device profile** (per our hard rule + this being a device-only symptom): open the scratch page with the beat running and confirm the first-load audio hiccup is gone; check the word-label readout still populates and scratching feels identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent scratch-page load audio stalls

- Defer word-span analysis after playback readiness

- Move FX bus creation into mount effect

- Document first-load glitch fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Decode snippet audio"]
  B["Yield to main thread"]
  C["Pad buffer and build deck"]
  D["Deck playable immediately"]
  E["Yield again"]
  F["Compute word spans asynchronously"]
  A -- "after decode" --> B
  B -- "continue load" --> C
  C -- "hold deck" --> D
  D -- "non-critical work" --> E
  E -- "update labels" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PhraseScratchImmersive.tsx</strong><dd><code>Defer heavy scratch-load work past playback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/modules/phrase-scratch/PhraseScratchImmersive.tsx

<ul><li>Adds <code>yieldToMain</code> to split CPU-heavy load steps.<br> <li> Builds and holds the scratch deck before word-span analysis.<br> <li> Uses provisional phrase labels until spans resolve.<br> <li> Creates the master FX bus in a mount effect.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/507/files#diff-d99d0e0a7b507e7bdd422b2910e3f1a981db013bbdee747b0b8e247c177d0198">+52/-20</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document scratch first-load glitch fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/CHANGELOG.md

<ul><li>Adds an unreleased fix entry for issue <code>#396</code>.<br> <li> Documents deferred word-span analysis and earlier deck readiness.<br> <li> Notes FX bus construction moved out of render.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/507/files#diff-83e97c4e36caca34711c70ef258b21b23e7362bf0f79b312a22fb2679ced8def">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

