### PR TITLE
beatlounge: fade scratch word/START indicator on the silent round (#421)

### DIFF
--- a/corpan/packs/beatlounge/CHANGELOG.md
+++ b/corpan/packs/beatlounge/CHANGELOG.md
@@ -5,6 +5,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- **Scratch: the word + START indicators now fade on a silent round** (#421). The
+  loop is rev-quantized to whole revolutions, so a phrase shorter than the loop
+  has a trailing silent pass; the indicators used to keep showing through it,
+  implying audio that wasn't there. They now fade out while the playhead is in
+  the padded tail and return on the sounding round.
+
 ## [0.7.0] - 2026-06-25
 
 ### Added

--- a/corpan/packs/beatlounge/src/modules/phrase-scratch/PhraseScratchImmersive.tsx
+++ b/corpan/packs/beatlounge/src/modules/phrase-scratch/PhraseScratchImmersive.tsx
@@ -127,9 +127,19 @@ interface DeckView {
   rate: number
   playheadSec: number
   wordIdx: number
+  /** The playhead is in the padded SILENT tail (past the real phrase) — the loop
+   *  is rev-quantized to whole revolutions, so a longer phrase has a trailing
+   *  silent pass. The word/START indicators fade during it (#421). */
+  silent: boolean
 }
 
-const freshView = (): DeckView => ({ rotation: 0, rate: 0, playheadSec: 0, wordIdx: -1 })
+const freshView = (): DeckView => ({
+  rotation: 0,
+  rate: 0,
+  playheadSec: 0,
+  wordIdx: -1,
+  silent: false,
+})
 
 export const PhraseScratchImmersive = ({ host, store, audioSource }: Props) => {
   const doc = useBeatloungeStore(store, (s) => s.doc)
@@ -406,7 +416,11 @@ export const PhraseScratchImmersive = ({ host, store, audioSource }: Props) => {
       const playheadSec = rotationToPlayhead(rt.discRot, dur)
       const rate = angularVelocityToRate(rt.angVel)
       const wordIdx = wordIndexAt(rt.spans, playheadSec)
-      return { rotation: rt.discRot, rate, playheadSec, wordIdx }
+      // In the padded silent tail (past the real phrase, before the loop wraps)
+      // there's no audio — flag it so the indicators fade (#421). Only meaningful
+      // when the phrase is actually shorter than the rev-quantized loop.
+      const silent = rt.phraseSec > 0 && dur > rt.phraseSec && playheadSec >= rt.phraseSec
+      return { rotation: rt.discRot, rate, playheadSec, wordIdx, silent }
     }
 
     // Write the disc rotation straight to the DOM (no React). Reduced motion → 0
@@ -421,6 +435,7 @@ export const PhraseScratchImmersive = ({ host, store, audioSource }: Props) => {
     const READOUT_MS = 120
     const shouldEmit = (p: DeckView, v: DeckView, lastEmit: number, ts: number): boolean => {
       if (p.wordIdx !== v.wordIdx) return true
+      if (p.silent !== v.silent) return true
       if (Math.abs(p.rate - v.rate) > 0.02) return true
       return ts - lastEmit > READOUT_MS && Math.abs(p.playheadSec - v.playheadSec) > 0.02
     }
@@ -712,6 +727,7 @@ export const PhraseScratchImmersive = ({ host, store, audioSource }: Props) => {
             spans={rt.current.spans}
             words={rt.current.words}
             currentWord={view.wordIdx}
+            silent={view.silent}
             langTag={langTag}
             active={active}
             onGrab={onGrab(rt)}

--- a/corpan/packs/beatlounge/src/modules/phrase-scratch/Platter.tsx
+++ b/corpan/packs/beatlounge/src/modules/phrase-scratch/Platter.tsx
@@ -43,6 +43,9 @@ interface Props {
   words: string[]
   /** Index of the current word (under the needle); −1 if none. */
   currentWord: number
+  /** The playhead is in the padded SILENT round (no audio) — fade the word +
+   *  START indicators so they don't imply sound that isn't there (#421). */
+  silent?: boolean
   /** Language tag for the word labels. */
   langTag?: string
   /** True while a finger is scratching (rim glows). */
@@ -64,6 +67,7 @@ export const Platter = ({
   spans,
   words,
   currentWord,
+  silent = false,
   langTag,
   active,
   onGrab,
@@ -170,7 +174,7 @@ export const Platter = ({
         <div className="bl-scr-grooves" />
         {/* The single START marker — fixed on the disc at the phrase start (t=0). */}
         <span
-          className="bl-scr-start"
+          className={`bl-scr-start${silent ? " is-silent" : ""}`}
           style={{
             ["--bl-scr-sx" as string]: `${startX}%`,
             ["--bl-scr-sy" as string]: `${startY}%`,
@@ -179,7 +183,7 @@ export const Platter = ({
         {wordDots.map((w) => (
           <span
             key={w.i}
-            className={`bl-scr-word${w.i === currentWord ? " is-cur" : ""}`}
+            className={`bl-scr-word${w.i === currentWord ? " is-cur" : ""}${silent ? " is-silent" : ""}`}
             lang={langTag}
             style={{
               ["--bl-scr-wx" as string]: `${w.x}%`,

--- a/corpan/packs/beatlounge/src/modules/phrase-scratch/phrase-scratch.css
+++ b/corpan/packs/beatlounge/src/modules/phrase-scratch/phrase-scratch.css
@@ -288,11 +288,20 @@
   max-width: 38%;
   overflow: hidden;
   text-overflow: ellipsis;
-  transition: color var(--bl-dur-fast) var(--bl-ease);
+  transition:
+    color var(--bl-dur-fast) var(--bl-ease),
+    opacity 280ms var(--bl-ease);
 }
 .bl-scr-word.is-cur {
   color: var(--bl-accent);
   text-shadow: var(--bl-glow) var(--bl-accent);
+}
+/* Silent round: the loop is rev-quantized to whole revolutions, so a longer
+   phrase has a trailing SILENT pass. Fade the word + START indicators during it
+   so they don't imply audio that isn't there; they return on the sounding round
+   (#421). */
+.bl-scr-word.is-silent {
+  opacity: 0.12;
 }
 
 /* The single START marker — a tasteful tick fixed on the disc at the phrase start
@@ -311,6 +320,10 @@
   box-shadow: var(--bl-glow) var(--bl-accent);
   opacity: 0.92;
   pointer-events: none;
+  transition: opacity 280ms var(--bl-ease);
+}
+.bl-scr-start.is-silent {
+  opacity: 0.1;
 }
 
 /* Fixed needle at 3 o'clock (the RIGHT): never rotates. The arm comes in from the


### PR DESCRIPTION
### **User description**
Closes #421.

## The bug
The scratch loop is rev-quantized to whole revolutions (so the phrase START returns under the needle at the same angle every loop). A phrase shorter than the loop therefore has a **trailing silent pass** — but the word dots + START marker kept showing through it, implying audio that isn't there.

## The fix
`driveDeck` now flags `silent` when the playhead is in the padded tail (`playheadSec >= phraseSec`, and only when the loop is actually longer than the phrase). It rides through the existing view / `shouldEmit` path — emitting on the *transition* only, so there's no per-frame churn — to the `Platter`, which **fades the word + START indicators** via CSS (280ms). They return on the sounding round.

## Verification
- `tsc --noEmit` clean; **all 1321 pack tests pass**.
- ⚠️ **Needs an on-device check**: load a phrase longer than one revolution, spin, and confirm the indicators fade during the silent pass and come back when the audio loops around.

> Note: touches `PhraseScratchImmersive.tsx`, which also changes in #507 (#396) — non-overlapping regions, but heads-up for merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Detect padded silent scratch rounds

- Fade word and START indicators

- Propagate silence through platter view

- Document silent-round indicator behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Scratch playhead"]
  B["Silent tail detection"]
  C["Deck view state"]
  D["Platter indicators"]
  E["CSS fade transition"]
  A -- "past phrase duration" --> B
  B -- "sets silent flag" --> C
  C -- "passes prop" --> D
  D -- "adds silent classes" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PhraseScratchImmersive.tsx</strong><dd><code>Track silent scratch rounds in deck view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/modules/phrase-scratch/PhraseScratchImmersive.tsx

<ul><li>Adds <code>silent</code> to <code>DeckView</code> defaults.<br> <li> Detects playhead position in padded tail.<br> <li> Emits view updates on silent-state transitions.<br> <li> Passes <code>silent</code> into <code>Platter</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/508/files#diff-d99d0e0a7b507e7bdd422b2910e3f1a981db013bbdee747b0b8e247c177d0198">+18/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Platter.tsx</strong><dd><code>Apply silent state to platter indicators</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/modules/phrase-scratch/Platter.tsx

<ul><li>Adds optional <code>silent</code> prop.<br> <li> Defaults <code>silent</code> to <code>false</code>.<br> <li> Applies <code>is-silent</code> class to START marker.<br> <li> Applies <code>is-silent</code> class to word labels.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/508/files#diff-64aa5e7bee3125e75cf03cf4794a0f0c483ad4f47fc093863c2789d7d6162629">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>phrase-scratch.css</strong><dd><code>Fade platter indicators during silent rounds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/modules/phrase-scratch/phrase-scratch.css

<ul><li>Adds opacity transitions for word labels.<br> <li> Fades word labels during silent rounds.<br> <li> Adds START marker opacity transition.<br> <li> Fades START marker during silent rounds.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/508/files#diff-f75a485257f867b7c0b4ab9312a66859f90025f72c510fabae30f6cfecd41dfb">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document silent-round scratch indicator fade</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/CHANGELOG.md

<ul><li>Documents scratch indicator silent-round behavior.<br> <li> Explains rev-quantized padded-tail context.<br> <li> Notes indicators return on sounding rounds.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/508/files#diff-83e97c4e36caca34711c70ef258b21b23e7362bf0f79b312a22fb2679ced8def">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

