### PR TITLE
beatlounge: phrase breakdown offers ALL n-grams, not capped at 6 (#420)

### DIFF
--- a/corpan/packs/beatlounge/CHANGELOG.md
+++ b/corpan/packs/beatlounge/CHANGELOG.md
@@ -5,6 +5,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- **Phrase breakdown now offers ALL n-grams, not just up to 6** (#420). The
+  discovery / scratch phrase chooser capped the longest band at N=6 on long
+  phrases; it now shows every contiguous sub-phrase. Deeper bands stay collapsed
+  by default so a long phrase is browsable rather than overwhelming. (Also
+  resolves the n-gram-cap half of #465.)
+
 ## [0.7.0] - 2026-06-25
 
 ### Added

--- a/corpan/packs/beatlounge/src/modules/phrase-sampler/PhraseSamplerImmersive.tsx
+++ b/corpan/packs/beatlounge/src/modules/phrase-sampler/PhraseSamplerImmersive.tsx
@@ -43,8 +43,6 @@ const SEARCH_DEBOUNCE_MS = 220
 const PAGE = 80
 const ROW_HEIGHT = 88
 const OVERSCAN = 4
-/** Cap the longest n-gram band for long phrases; what's hidden is surfaced. */
-const COMBO_MAX_N = 6
 
 const LOG = "[beatlounge/phrase-discovery]"
 
@@ -556,7 +554,9 @@ interface ComboViewProps {
 
 const ComboBreakdownView = ({ host, store, audioSource, row, nativeCode, onSaved }: ComboViewProps) => {
   const [voiceId, setVoiceId] = useState<string | undefined>(undefined)
-  const breakdown = useMemo(() => comboBreakdown(row.text, row.code, COMBO_MAX_N), [row])
+  // Offer ALL n-grams of the phrase (#420) — no cap; the deeper bands stay
+  // collapsed by default so a long phrase is browsable, not overwhelming.
+  const breakdown = useMemo(() => comboBreakdown(row.text, row.code), [row])
   // Which N bands are expanded. N=1 and N=2 open by default; deeper bands collapse.
   const [openBands, setOpenBands] = useState<Set<number>>(new Set([1, 2]))
   useEffect(() => setOpenBands(new Set([1, 2])), [row.code, row.text])


### PR DESCRIPTION
### **User description**
Closes #420. Also resolves the n-gram-cap half of #465.

## The bug
The phrase breakdown (the discovery screen **and** the scratch phrase chooser, which reuses it) capped the longest n-gram band at **N=6** (`COMBO_MAX_N`). Longer phrases silently hid their bigger sub-phrases.

## The fix
Removed the cap — `comboBreakdown(row.text, row.code)` now returns **every** contiguous sub-phrase. The UI already collapses the deeper bands by default (`openBands = {1,2}`), so a long phrase stays browsable rather than overwhelming. With no cap, `comboBreakdown` returns `cappedAtN=undefined` / `hiddenCount=0`, so the "capped" note is simply never rendered (it's guarded).

`comboBreakdown` keeps its optional `maxN` param (still unit-tested) — only the caller stops passing a cap.

## Verification
- `tsc --noEmit` clean; n-gram tests (`combos`, `discoveryModel`) pass; full suite green.
- ⚠️ **Quick device check**: open a long phrase in the chooser and confirm all bands are offered (deeper ones collapsed, tappable to expand) with no layout blowup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Removes six-gram phrase breakdown cap

- Offers every contiguous phrase n-gram

- Documents unreleased beatlounge behavior change


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Phrase text"] -- "passes without cap" --> B["comboBreakdown"]
  B -- "returns all n-grams" --> C["Breakdown chooser"]
  C -- "keeps deep bands collapsed" --> D["Browsable long phrases"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PhraseSamplerImmersive.tsx</strong><dd><code>Remove phrase n-gram cap</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/modules/phrase-sampler/PhraseSamplerImmersive.tsx

<ul><li>Removes the <code>COMBO_MAX_N</code> six-gram constant.<br> <li> Calls <code>comboBreakdown(row.text, row.code)</code> without a maximum.<br> <li> Adds a comment explaining all n-grams are offered.<br> <li> Keeps deeper n-gram bands collapsed by default.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/509/files#diff-ba178006ef536f8361be9411bd49c865ef64d392359a474e4a9a7615f31d0280">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document full n-gram breakdown behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/CHANGELOG.md

<ul><li>Adds an Unreleased changelog entry.<br> <li> Notes phrase breakdown now shows all n-grams.<br> <li> Documents that deeper bands remain collapsed.<br> <li> References issue <code>#420</code> and partial <code>#465</code> coverage.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/509/files#diff-83e97c4e36caca34711c70ef258b21b23e7362bf0f79b312a22fb2679ced8def">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

