### PR TITLE
beatlounge: scratch record splits no-space scripts into real tokens (#465)

### DIFF
--- a/corpan/packs/beatlounge/CHANGELOG.md
+++ b/corpan/packs/beatlounge/CHANGELOG.md
@@ -5,6 +5,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **Scratch record: no-space-script phrases now split into real word tokens**
+  (#465). The scratch "record" segmented its groove-word labels with a naive
+  `split(/\s+/)`, so Chinese/Japanese/Thai (zh/ja/th) phrases became ONE blob
+  around the disc. It now uses the shared language-aware `tokenizePhrase`
+  (Intl.Segmenter) — the same fix class as Lingo Hero #463. (The n-gram-cap half
+  of #465 shipped with #420.)
+
 ## [0.7.0] - 2026-06-25
 
 ### Added

--- a/corpan/packs/beatlounge/src/modules/phrase-scratch/PhraseScratchImmersive.tsx
+++ b/corpan/packs/beatlounge/src/modules/phrase-scratch/PhraseScratchImmersive.tsx
@@ -36,6 +36,7 @@ import { createScratchDeck, ensureWorkletModule, type ScratchDeck } from "./scra
 import { padBufferToRevolution } from "./scratchPad"
 import { resolveWordSpans } from "./wordTiming"
 import { createLoadToken } from "./loadToken"
+import { splitWords } from "./grooveWords"
 import {
   advanceRotationByVel,
   angularVelocityToRate,
@@ -81,10 +82,6 @@ interface Props {
 
 /** A snippet's stable identity for picker selection + dedup. */
 const refKey = (r: FragmentRef): string => `${r.language ?? ""}:${r.text ?? ""}:${r.voiceId ?? ""}`
-
-/** Split a phrase into word tokens for per-word labels (best-effort). */
-const splitWords = (text: string): string[] =>
-  text.split(/\s+/).map((w) => w.trim()).filter(Boolean)
 
 /** Per-deck live state held in refs (no per-frame React churn). */
 interface DeckRuntime {
@@ -310,7 +307,7 @@ export const PhraseScratchImmersive = ({ host, store, audioSource }: Props) => {
           channel,
           decoded.sampleRate,
           decoded.duration,
-          splitWords(text)
+          splitWords(text, language)
         )
         // LOOP-ANGLE FIX: pad the wave with trailing silence to a WHOLE number of
         // revolutions (+ boundary fades) so the loop wraps at an integer disc turn —

--- a/corpan/packs/beatlounge/src/modules/phrase-scratch/grooveWords.test.ts
+++ b/corpan/packs/beatlounge/src/modules/phrase-scratch/grooveWords.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+import { splitWords } from "./grooveWords"
+
+describe("splitWords — language-aware groove tokens (#465)", () => {
+  it("splits spaced scripts on whitespace", () => {
+    expect(splitWords("the cat sat", "en")).toEqual(["the", "cat", "sat"])
+  })
+
+  it("segments no-space Chinese into multiple tokens, not one blob", () => {
+    const toks = splitWords("我爱你", "zh")
+    expect(toks.length).toBeGreaterThan(1)
+    expect(toks.join("")).toBe("我爱你")
+  })
+
+  it("segments no-space Japanese", () => {
+    expect(splitWords("夜明け", "ja").length).toBeGreaterThan(1)
+  })
+
+  it("empty / whitespace-only yields no tokens", () => {
+    expect(splitWords("   ", "en")).toEqual([])
+    expect(splitWords("", "zh")).toEqual([])
+  })
+})

--- a/corpan/packs/beatlounge/src/modules/phrase-scratch/grooveWords.ts
+++ b/corpan/packs/beatlounge/src/modules/phrase-scratch/grooveWords.ts
@@ -1,0 +1,18 @@
+/**
+ * beatlounge — split a phrase into the per-word tokens the scratch "record" uses
+ * for its groove labels (the words placed around the disc).
+ *
+ * LANGUAGE-AWARE (#465): no-space scripts (Chinese zh, Japanese ja, Thai th)
+ * segment into real tokens via the shared `tokenizePhrase` (Intl.Segmenter),
+ * instead of the old naive `split(/\s+/)` that returned the whole phrase as ONE
+ * blob for no-space scripts — the same class of bug as Lingo Hero #463.
+ *
+ * Pure (no React/Tone) so it unit-tests without a DOM.
+ */
+
+import { tokenizePhrase } from "../../phrase/tokenize"
+
+export const splitWords = (text: string, lang?: string): string[] =>
+  tokenizePhrase(text, lang)
+    .map((t) => t.text)
+    .filter(Boolean)


### PR DESCRIPTION
### **User description**
Closes #465. (The n-gram-cap half of this issue shipped with #420 / PR #509.)

## The bug
The scratch **record** placed its per-word groove labels around the disc using a naive `splitWords = text.split(/\s+/)`. For no-space scripts (Chinese **zh**, Japanese **ja**, Thai **th**) that yields **one token = the whole phrase**, so the record couldn't be segmented into words — the same class of bug as Lingo Hero #463.

## The fix
Extracted `splitWords` into a pure `grooveWords.ts` that delegates to the shared, language-aware **`tokenizePhrase`** (`Intl.Segmenter`, already used by the discovery breakdown), and threaded the loaded fragment's `language` through at the call site. Spaced scripts are unchanged; no-space scripts now segment into real tokens.

Added a regression test (`grooveWords.test.ts`): spaced English, no-space zh/ja, and empty input.

## Verification
- `tsc --noEmit` clean; **all 1325 pack tests pass** (4 new).
- ⚠️ **Device check**: load a Chinese/Japanese phrase onto the scratch record and confirm the groove shows multiple word dots (not one blob), each under the needle as it plays.

> Note: touches `PhraseScratchImmersive.tsx`, which also changes in #507 (#396) and #508 (#421). The `splitWords` call site is the region #507 moved — heads-up for merge order (rebase after #507).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Segment no-space scratch record phrases

- Reuse shared language-aware tokenizer

- Add groove token regression tests

- Document unreleased scratch record fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Loaded phrase text"]
  B["Fragment language"]
  C["splitWords"]
  D["tokenizePhrase"]
  E["Groove word labels"]
  A -- "text" --> C
  B -- "language" --> C
  C -- "delegates" --> D
  D -- "tokens" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PhraseScratchImmersive.tsx</strong><dd><code>Thread language into groove token splitting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/modules/phrase-scratch/PhraseScratchImmersive.tsx

<ul><li>Imports <code>splitWords</code> from <code>grooveWords</code><br> <li> Removes the local whitespace-only splitter<br> <li> Passes <code>language</code> into scratch groove tokenization</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/510/files#diff-d99d0e0a7b507e7bdd422b2910e3f1a981db013bbdee747b0b8e247c177d0198">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>grooveWords.ts</strong><dd><code>Add shared tokenizer-backed groove splitter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/modules/phrase-scratch/grooveWords.ts

<ul><li>Adds pure <code>splitWords</code> helper for scratch records<br> <li> Delegates segmentation to shared <code>tokenizePhrase</code><br> <li> Supports no-space scripts through language-aware tokenization<br> <li> Returns filtered token text for groove labels</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/510/files#diff-adaf5b702bd8f81e402df0725156c841733c39d76967faeb9d4da8956f46aad8">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>grooveWords.test.ts</strong><dd><code>Test language-aware groove word splitting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/src/modules/phrase-scratch/grooveWords.test.ts

<ul><li>Adds regression coverage for <code>splitWords</code><br> <li> Verifies whitespace splitting for English<br> <li> Verifies Chinese and Japanese split into multiple tokens<br> <li> Covers empty and whitespace-only input</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/510/files#diff-bc95ac71d97c93b5b2513dbe735abfc5dd445641d4ac5b3e0c4e91e7a7fe1fe6">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document no-space-script record fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/packs/beatlounge/CHANGELOG.md

<ul><li>Adds an Unreleased fixed entry<br> <li> Documents no-space-script scratch record token splitting<br> <li> Notes use of shared <code>tokenizePhrase</code><br> <li> References issue <code>#465</code> and related n-gram context</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/510/files#diff-83e97c4e36caca34711c70ef258b21b23e7362bf0f79b312a22fb2679ced8def">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

