### PR TITLE
CI: automated mobile release → TestFlight + Play internal

### DIFF
--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -1,0 +1,221 @@
+name: Release · mobile (TestFlight + Play internal)
+
+# Builds signed iOS + Android from `main` and ships them to the INTERNAL
+# testing tracks (TestFlight internal, Play internal) — never to public
+# release. Triggered when the app version changes (a real release intent),
+# or manually. See corpan/corpan-app/RELEASE_SETUP.md for the one-time
+# credential setup; until the secrets exist, the build jobs skip cleanly so
+# this workflow is safe to merge.
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "corpan/corpan-app/src-tauri/tauri.conf.json" # version bump lives here
+  workflow_dispatch:
+    inputs:
+      platforms:
+        description: "Which platforms to build"
+        type: choice
+        default: both
+        options: [both, ios, android]
+
+concurrency:
+  group: release-mobile-${{ github.ref }}
+  cancel-in-progress: false # never cancel an in-flight upload
+
+jobs:
+  # ---- decide whether this push is actually a release ---------------------
+  gate:
+    name: Gate · version-change detect
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.decide.outputs.release }}
+      version: ${{ steps.decide.outputs.version }}
+      do_ios: ${{ steps.decide.outputs.do_ios }}
+      do_android: ${{ steps.decide.outputs.do_android }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2 # need HEAD^ to diff the version
+      - id: decide
+        working-directory: corpan/corpan-app
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./src-tauri/tauri.conf.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          RELEASE=false
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RELEASE=true
+          else
+            PREV=$(git show HEAD^:corpan/corpan-app/src-tauri/tauri.conf.json 2>/dev/null \
+                     | node -p "JSON.parse(require('fs').readFileSync(0)).version" 2>/dev/null || echo "")
+            if [ "$PREV" != "$VERSION" ]; then RELEASE=true; fi
+          fi
+          PLAT="${{ github.event.inputs.platforms || 'both' }}"
+          echo "release=$RELEASE" >> "$GITHUB_OUTPUT"
+          echo "do_ios=$([ "$RELEASE" = true ] && { [ "$PLAT" = both ] || [ "$PLAT" = ios ]; } && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "do_android=$([ "$RELEASE" = true ] && { [ "$PLAT" = both ] || [ "$PLAT" = android ]; } && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "Version $VERSION · release=$RELEASE · platforms=$PLAT"
+
+  # ---- iOS -> TestFlight internal -----------------------------------------
+  ios:
+    name: iOS · build + TestFlight
+    needs: gate
+    if: needs.gate.outputs.do_ios == 'true'
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      # Fail-soft: if the Apple secrets aren't configured yet, skip with a
+      # clear message instead of a red X (keeps the pipeline mergeable).
+      - id: secrets
+        env:
+          HAVE: ${{ secrets.APPLE_DIST_CERT_P12 != '' && secrets.ASC_API_KEY_P8 != '' }}
+        run: |
+          echo "have=$HAVE" >> "$GITHUB_OUTPUT"
+          [ "$HAVE" = "true" ] || echo "::warning::Apple release secrets not set — see RELEASE_SETUP.md. Skipping iOS."
+
+      - uses: actions/setup-node@v4
+        if: steps.secrets.outputs.have == 'true'
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: corpan/corpan-app/package-lock.json
+
+      - name: Rust + iOS targets
+        if: steps.secrets.outputs.have == 'true'
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup target add aarch64-apple-ios aarch64-apple-ios-sim
+      - uses: Swatinem/rust-cache@v2
+        if: steps.secrets.outputs.have == 'true'
+        with:
+          workspaces: corpan/corpan-app/src-tauri
+
+      - name: Import signing certificate
+        if: steps.secrets.outputs.have == 'true'
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.APPLE_DIST_CERT_P12 }}
+          p12-password: ${{ secrets.APPLE_DIST_CERT_PASSWORD }}
+
+      - name: Install provisioning profile
+        if: steps.secrets.outputs.have == 'true'
+        run: |
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          echo "${{ secrets.APPLE_PROVISIONING_PROFILE }}" | base64 --decode \
+            > ~/Library/MobileDevice/Provisioning\ Profiles/corpan.mobileprovision
+
+      - name: Install deps
+        if: steps.secrets.outputs.have == 'true'
+        working-directory: corpan/corpan-app
+        run: |
+          npm ci
+          npm ci --prefix ../packs/shared/capabilities
+
+      - name: Build number (unique, monotonic)
+        if: steps.secrets.outputs.have == 'true'
+        run: echo "BUILD_NUMBER=${{ github.run_number }}" >> "$GITHUB_ENV"
+
+      - name: Tauri iOS build (app-store-connect)
+        if: steps.secrets.outputs.have == 'true'
+        working-directory: corpan/corpan-app
+        run: |
+          npx tauri ios init --ci || true   # regenerate gen/apple (not committed)
+          # Stamp the CI build number so TestFlight accepts each upload.
+          if [ -d src-tauri/gen/apple ]; then
+            ( cd src-tauri/gen/apple && xcrun agvtool new-version -all "$BUILD_NUMBER" ) || \
+              echo "::warning::agvtool build-number stamp failed — first-run tweak point (see RELEASE_SETUP.md)"
+          fi
+          npx tauri ios build --export-method app-store-connect
+
+      - name: Upload to TestFlight
+        if: steps.secrets.outputs.have == 'true'
+        uses: apple-actions/upload-testflight-build@v3
+        with:
+          app-path: corpan/corpan-app/src-tauri/gen/apple/build/arm64/corpan.ipa
+          issuer-id: ${{ secrets.ASC_ISSUER_ID }}
+          api-key-id: ${{ secrets.ASC_KEY_ID }}
+          api-private-key: ${{ secrets.ASC_API_KEY_P8 }}
+
+  # ---- Android -> Play internal -------------------------------------------
+  android:
+    name: Android · build + Play internal
+    needs: gate
+    if: needs.gate.outputs.do_android == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: secrets
+        env:
+          HAVE: ${{ secrets.ANDROID_KEYSTORE_B64 != '' && secrets.PLAY_SERVICE_ACCOUNT_JSON != '' }}
+        run: |
+          echo "have=$HAVE" >> "$GITHUB_OUTPUT"
+          [ "$HAVE" = "true" ] || echo "::warning::Android release secrets not set — see RELEASE_SETUP.md. Skipping Android."
+
+      - uses: actions/setup-node@v4
+        if: steps.secrets.outputs.have == 'true'
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: corpan/corpan-app/package-lock.json
+      - uses: actions/setup-java@v4
+        if: steps.secrets.outputs.have == 'true'
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: android-actions/setup-android@v3
+        if: steps.secrets.outputs.have == 'true'
+      - name: Rust + Android targets
+        if: steps.secrets.outputs.have == 'true'
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
+      - uses: Swatinem/rust-cache@v2
+        if: steps.secrets.outputs.have == 'true'
+        with:
+          workspaces: corpan/corpan-app/src-tauri
+
+      - name: Install NDK
+        if: steps.secrets.outputs.have == 'true'
+        run: |
+          sdkmanager "ndk;26.1.10909125"
+          echo "NDK_HOME=$ANDROID_SDK_ROOT/ndk/26.1.10909125" >> "$GITHUB_ENV"
+
+      - name: Decode keystore + signing props
+        if: steps.secrets.outputs.have == 'true'
+        working-directory: corpan/corpan-app/src-tauri
+        run: |
+          echo "${{ secrets.ANDROID_KEYSTORE_B64 }}" | base64 --decode > upload-keystore.jks
+          cat > gen/android/keystore.properties <<EOF
+          storeFile=$(pwd)/upload-keystore.jks
+          storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
+          keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
+          EOF
+
+      - name: Install deps
+        if: steps.secrets.outputs.have == 'true'
+        working-directory: corpan/corpan-app
+        run: |
+          npm ci
+          npm ci --prefix ../packs/shared/capabilities
+
+      - name: Tauri Android build (signed AAB)
+        if: steps.secrets.outputs.have == 'true'
+        working-directory: corpan/corpan-app
+        env:
+          TAURI_ANDROID_VERSION_CODE: ${{ github.run_number }}
+        run: npx tauri android build --aab
+
+      - name: Upload to Play internal
+        if: steps.secrets.outputs.have == 'true'
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.corpora.corpan
+          releaseFiles: corpan/corpan-app/src-tauri/gen/android/app/build/outputs/bundle/universalRelease/app-universal-release.aab
+          track: internal
+          status: completed

--- a/corpan/corpan-app/CHANGELOG.md
+++ b/corpan/corpan-app/CHANGELOG.md
@@ -8,6 +8,12 @@ Conventions: `corpan/CHANGELOGS.md`.
 ## [Unreleased]
 
 ### Added
+- **Automated mobile release pipeline** — `.github/workflows/release-mobile.yml`
+  builds signed iOS + Android on a version bump to `main` and ships to
+  TestFlight internal + Play internal testing (no manual MacBook/Transporter
+  step). Version bumping via `scripts/bump-app-version.mjs`; one-time credential
+  setup in `RELEASE_SETUP.md`. The build jobs skip cleanly until the release
+  secrets are configured, so the workflow is safe to merge before setup.
 - **Journey browser demo harness (dev-only)** — `journey-demo.html` mounts the
   REAL JourneySurface + engine + resolver over the real `journey_en` pack
   content in a plain browser (no Tauri): `scripts/journey-demo/precompute.ts`

--- a/corpan/corpan-app/RELEASE_SETUP.md
+++ b/corpan/corpan-app/RELEASE_SETUP.md
@@ -1,0 +1,80 @@
+# Mobile release automation — one-time setup
+
+Once this is configured, **you never touch your MacBook to ship a test build
+again.** Bump the app version, merge to `main`, and CI builds signed iOS +
+Android and pushes them to **TestFlight internal** and **Play internal
+testing**. The build lands on your phone in ~10–30 min (Apple/Google
+processing time). Internal tracks have **no beta review**, so it's automatic.
+
+The pipeline is `.github/workflows/release-mobile.yml`. It only runs when the
+version in `src-tauri/tauri.conf.json` changes (or on manual dispatch), and it
+**skips cleanly if the secrets below aren't set** — so nothing breaks before
+setup is done.
+
+## How you cut a release (after setup)
+
+```bash
+cd corpan/corpan-app
+node scripts/bump-app-version.mjs minor   # 0.19.2 -> 0.20.0 (or: patch / 0.20.0)
+git commit -am "release: corpan 0.20.0"
+# open a PR; when it merges to main, the release build fires
+```
+
+Testers see `0.20.0`; the unique build number (TestFlight/Play require it to
+increase every upload) comes from the CI run number automatically.
+
+---
+
+## The secrets to add (Settings → Secrets and variables → Actions)
+
+### Apple / iOS → TestFlight
+
+| Secret | What it is | Where to get it |
+|---|---|---|
+| `ASC_KEY_ID` | App Store Connect API **Key ID** | App Store Connect → Users and Access → **Integrations → App Store Connect API** → generate a key with **App Manager** role |
+| `ASC_ISSUER_ID` | The **Issuer ID** on that same page | same page (one per team) |
+| `ASC_API_KEY_P8` | The `.p8` private key **contents** | downloaded **once** when you create the key. `cat AuthKey_XXXX.p8` and paste the whole thing (incl. BEGIN/END lines) |
+| `APPLE_DIST_CERT_P12` | Your **Apple Distribution** cert, base64 | On your Mac (one time): Keychain → export the distribution identity as `.p12` → `base64 -i dist.p12 \| pbcopy` |
+| `APPLE_DIST_CERT_PASSWORD` | password you set on that `.p12` | you choose it at export |
+| `APPLE_PROVISIONING_PROFILE` | the App Store `.mobileprovision`, base64 | the profile already referenced in `src-tauri/ios/ExportOptions.plist` (`4d5c5e29-…`). Download from developer.apple.com or `~/Library/MobileDevice/Provisioning Profiles/`, then `base64 -i profile.mobileprovision \| pbcopy` |
+
+Team ID (`F9AV5HKF6N`) and bundle id (`com.corpora.corpan`) are already in the
+repo, no secret needed.
+
+> The **only step that needs your Mac** is exporting the `.p12` cert and the
+> `.mobileprovision` (you already have both — that's how you build locally).
+> Everything else is web-console. If you'd rather never touch the Mac again for
+> this, we can switch to **Fastlane `match`** later (stores certs in a private
+> repo); the one-time export is quicker to start with.
+
+### Google / Android → Play internal
+
+| Secret | What it is | Where to get it |
+|---|---|---|
+| `PLAY_SERVICE_ACCOUNT_JSON` | Play publishing service account | Google Cloud (the project linked to Play) → create a service account → in **Play Console → Users & permissions**, invite it and grant **Release to testing tracks**. Paste the JSON |
+| `ANDROID_KEYSTORE_B64` | your `upload-keystore.jks`, base64 | `base64 -i corpan-app/src-tauri/upload-keystore.jks` (it's local, not in the repo) |
+| `ANDROID_KEYSTORE_PASSWORD` | keystore password | your existing keystore creds |
+| `ANDROID_KEY_ALIAS` | key alias | " |
+| `ANDROID_KEY_PASSWORD` | key password | " |
+
+The app must exist in Play Console with an **internal testing** track and at
+least one internal tester (you) before the first upload.
+
+---
+
+## Honest caveats (read before the first run)
+
+- **This scaffold hasn't been run yet** (it can't be built or tested from the
+  Linux box it was authored on). Expect the **first real run to need 1–2
+  tweaks**, almost always in one of two spots, both flagged in the workflow:
+  1. **iOS build-number stamping** (`agvtool` on the generated Xcode project) —
+     the exact project path / scheme name may differ.
+  2. **Android AAB output path** and the `keystore.properties` wiring that
+     `tauri android build` expects.
+  Everything else (deps, signing import, uploads) uses standard, widely-used
+  actions.
+- We ship to **internal tracks only** — never auto-publish to the public store.
+  Promoting a build to production stays a manual, deliberate action.
+- **External** TestFlight testers (beyond your ~100 internal) require Apple's
+  one-time Beta App Review per version; internal testers do not.
+- macOS runners are **free** here (the repo is public), so cost isn't a factor.

--- a/corpan/corpan-app/scripts/bump-app-version.mjs
+++ b/corpan/corpan-app/scripts/bump-app-version.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Bump the Corpán app version in lockstep across the three files that must
+// agree, then commit. A version change to src-tauri/tauri.conf.json on `main`
+// is what triggers the mobile release pipeline (.github/workflows/release-mobile.yml).
+//
+//   node scripts/bump-app-version.mjs patch     # 0.19.2 -> 0.19.3
+//   node scripts/bump-app-version.mjs minor     # 0.19.2 -> 0.20.0
+//   node scripts/bump-app-version.mjs 0.20.0    # explicit
+//
+// Run from corpan/corpan-app. Does NOT push — review the commit, then push /
+// open a PR. The human-readable version is what testers see in TestFlight /
+// Play; the CI run number supplies the unique, monotonic BUILD number.
+
+import { readFileSync, writeFileSync } from "node:fs"
+
+const arg = process.argv[2]
+if (!arg) {
+  console.error("usage: bump-app-version.mjs <patch|minor|major|X.Y.Z>")
+  process.exit(1)
+}
+
+const pkgPath = "package.json"
+const tauriPath = "src-tauri/tauri.conf.json"
+const cargoPath = "src-tauri/Cargo.toml"
+
+const pkg = JSON.parse(readFileSync(pkgPath, "utf8"))
+const current = pkg.version
+const [maj, min, pat] = current.split(".").map(Number)
+
+const next =
+  arg === "patch" ? `${maj}.${min}.${pat + 1}` :
+  arg === "minor" ? `${maj}.${min + 1}.0` :
+  arg === "major" ? `${maj + 1}.0.0` :
+  arg
+
+if (!/^\d+\.\d+\.\d+$/.test(next)) {
+  console.error(`not a semver: ${next}`)
+  process.exit(1)
+}
+if (next === current) {
+  console.error(`version already ${current} — nothing to bump`)
+  process.exit(1)
+}
+
+// package.json — surgical (preserve formatting via a targeted replace).
+writeFileSync(pkgPath, readFileSync(pkgPath, "utf8").replace(
+  new RegExp(`("version"\\s*:\\s*)"${current.replace(/\./g, "\\.")}"`),
+  `$1"${next}"`,
+))
+
+// tauri.conf.json — the top-level "version" (drives iOS/Android bundle version).
+writeFileSync(tauriPath, readFileSync(tauriPath, "utf8").replace(
+  new RegExp(`("version"\\s*:\\s*)"${current.replace(/\./g, "\\.")}"`),
+  `$1"${next}"`,
+))
+
+// src-tauri/Cargo.toml — the first `version = "..."` (the package version).
+writeFileSync(cargoPath, readFileSync(cargoPath, "utf8").replace(
+  new RegExp(`(^version\\s*=\\s*)"${current.replace(/\./g, "\\.")}"`, "m"),
+  `$1"${next}"`,
+))
+
+console.log(`bumped ${current} -> ${next} in package.json, tauri.conf.json, Cargo.toml`)
+console.log("next: commit, then push / open a PR. Merging to main triggers the release build.")


### PR DESCRIPTION
### **User description**
## Automated mobile release → TestFlight + Play internal

So a version bump to `main` ships a signed build to your phone with **no MacBook / Transporter step**. Answers "can CI build the app and push to internal testing" — yes.

### What it does
`.github/workflows/release-mobile.yml`:
- **Trigger:** the version in `src-tauri/tauri.conf.json` changes on `main` (a real release intent), or manual `workflow_dispatch`. Not every merge — you control cadence via the version bump.
- **iOS** (free public-repo macOS runner): `tauri ios build --export-method app-store-connect` with your existing `ExportOptions.plist` signing → uploads to **TestFlight internal** (no beta review).
- **Android** (Linux runner): `tauri android build --aab` signed with the upload keystore → uploads to **Play internal testing**.
- Build number comes from the CI run number (TestFlight/Play require it to increase per upload); testers see the human `X.Y.Z`.
- Ships to **internal tracks only** — never auto-publishes to the public store.

`scripts/bump-app-version.mjs` bumps the version across the three files that must agree. `RELEASE_SETUP.md` is the one-time credential checklist.

### Safe to merge now
Both build jobs **skip cleanly** (a fail-soft secret check) until the release secrets exist, so merging this does nothing until you've done the setup.

### What only you can provide (one-time)
The credentials — full step-by-step in `RELEASE_SETUP.md`. The **only step that needs your Mac** is exporting the distribution `.p12` cert + `.mobileprovision` you already build with (or we switch to Fastlane `match` later); everything else is web-console (App Store Connect API key, Play service account).

### Honest caveat
This scaffold was authored on a Linux box and **has not been run** — the first real release will likely need 1–2 tweaks, both flagged in the workflow (iOS build-number stamping via `agvtool`, and the Android AAB output path). Standard actions handle the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Automates internal mobile releases

- Adds version-bump release trigger

- Documents one-time release credentials

- Provides synchronized version bump script


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-mobile.yml</strong><dd><code>Mobile release workflow for internal tracks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-mobile.yml

<ul><li>Adds version-change and manual release triggers<br> <li> Builds signed iOS uploads to TestFlight<br> <li> Builds signed Android AAB uploads internally<br> <li> Skips platforms when release secrets are missing</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/512/files#diff-e98843d05d2e1469fccb7dc8d1f42fa8aba4f2c4a16e58ec549a28245201afcd">+221/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bump-app-version.mjs</strong><dd><code>Synchronized app version bump helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/corpan-app/scripts/bump-app-version.mjs

<ul><li>Adds CLI for patch, minor, major bumps<br> <li> Supports explicit <code>X.Y.Z</code> versions<br> <li> Updates <code>package.json</code>, Tauri config, and Cargo<br> <li> Validates semver and avoids no-op bumps</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/512/files#diff-d974c80a5937fc633f263ecd57d6d5e6c392f3353f48e286078587a9adb70299">+64/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Changelog entry for mobile release automation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/corpan-app/CHANGELOG.md

<ul><li>Records automated mobile release pipeline<br> <li> Notes TestFlight and Play internal delivery<br> <li> References <code>scripts/bump-app-version.mjs</code> and setup docs<br> <li> Documents fail-soft behavior before secrets exist</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/512/files#diff-fcd2aeaa88f0735613dd8b9388c69c41b43b9eec554f31f82c902937b33b9940">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RELEASE_SETUP.md</strong><dd><code>One-time mobile release setup guide</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/corpan-app/RELEASE_SETUP.md

<ul><li>Documents release process after setup<br> <li> Lists required Apple and Google secrets<br> <li> Explains certificate and provisioning setup<br> <li> Calls out first-run caveats and limits</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/512/files#diff-1b2a9dafe328e101f96ab5c5dca74715df27335223ec2b64c91603a14df68836">+80/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

