### PR TITLE
Mobile release pipeline: green end-to-end + corpan 0.20.0

### DIFF
--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -85,6 +85,18 @@ jobs:
           cache: "npm"
           cache-dependency-path: corpan/corpan-app/package-lock.json
 
+      - name: Select Xcode 16+
+        if: steps.secrets.outputs.have == 'true'
+        # xcodegen emits a project in the Xcode 16 file format (objectVersion 77);
+        # the macos-14 runner defaults to Xcode 15.4, which can't open it. Pick the
+        # newest installed Xcode.
+        run: |
+          XC=$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1)
+          [ -n "$XC" ] || XC=$(ls -d /Applications/Xcode_1*.app | sort -V | tail -1)
+          echo "Using $XC"
+          sudo xcode-select -s "$XC/Contents/Developer"
+          xcodebuild -version
+
       - name: Rust + iOS targets
         if: steps.secrets.outputs.have == 'true'
         run: |

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -136,6 +136,27 @@ jobs:
         # the tauri crate version in Cargo.lock.
         run: cargo install tauri-cli --version 2.11.2 --locked
 
+      # tauri-plugin-stt links a prebuilt whisper.cpp static XCFramework that is
+      # gitignored (~150 MB) and built locally per its ios/.gitignore. Reproduce
+      # it in CI, cached on the pinned whisper version so it builds only once.
+      - name: Cache whisper.xcframework
+        if: steps.secrets.outputs.have == 'true'
+        id: whisper_cache
+        uses: actions/cache@v4
+        with:
+          path: corpan/plugins/tauri-plugin-stt/ios/whisper.xcframework
+          key: whisper-xcframework-v1.8.4-${{ runner.os }}
+      - name: Build whisper.xcframework
+        if: steps.secrets.outputs.have == 'true' && steps.whisper_cache.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch v1.8.4 https://github.com/ggml-org/whisper.cpp.git "$RUNNER_TEMP/whisper.cpp"
+          cd "$RUNNER_TEMP/whisper.cpp"
+          BUILD_STATIC_XCFRAMEWORK=ON ./build-xcframework.sh
+          DEST="$GITHUB_WORKSPACE/corpan/plugins/tauri-plugin-stt/ios"
+          rm -rf "$DEST/whisper.xcframework"
+          mv build-apple/whisper.xcframework "$DEST/"
+          test -f "$DEST/whisper.xcframework/ios-arm64/whisper.framework/whisper"
+
       - name: Tauri iOS build (app-store-connect)
         if: steps.secrets.outputs.have == 'true'
         working-directory: corpan/corpan-app

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -63,7 +63,10 @@ jobs:
     name: iOS · build + TestFlight
     needs: gate
     if: needs.gate.outputs.do_ios == 'true'
-    runs-on: macos-14
+    # macos-26 ships Xcode 26 + the iOS 26 SDK, which App Store Connect now
+    # requires ("All iOS apps must be built with the iOS 26 SDK or later").
+    # macos-14 tops out at Xcode 16.2 (iOS 18.2 SDK) and uploads are rejected.
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
         with:
@@ -85,14 +88,14 @@ jobs:
           cache: "npm"
           cache-dependency-path: corpan/corpan-app/package-lock.json
 
-      - name: Select Xcode 16+
+      - name: Select newest Xcode
         if: steps.secrets.outputs.have == 'true'
-        # xcodegen emits a project in the Xcode 16 file format (objectVersion 77);
-        # the macos-14 runner defaults to Xcode 15.4, which can't open it. Pick the
-        # newest installed Xcode.
+        # Use the newest installed Xcode (26.x on macos-26) so the app is built
+        # with the iOS 26 SDK App Store Connect requires, and so xcodegen's
+        # project format is understood.
         run: |
-          XC=$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1)
-          [ -n "$XC" ] || XC=$(ls -d /Applications/Xcode_1*.app | sort -V | tail -1)
+          XC=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
+          [ -n "$XC" ] || XC=/Applications/Xcode.app
           echo "Using $XC"
           sudo xcode-select -s "$XC/Contents/Developer"
           xcodebuild -version

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -114,21 +114,16 @@ jobs:
           npm ci
           npm ci --prefix ../packs/shared/capabilities
 
-      - name: Build number (unique, monotonic)
-        if: steps.secrets.outputs.have == 'true'
-        run: echo "BUILD_NUMBER=${{ github.run_number }}" >> "$GITHUB_ENV"
-
       - name: Tauri iOS build (app-store-connect)
         if: steps.secrets.outputs.have == 'true'
         working-directory: corpan/corpan-app
         run: |
-          npx tauri ios init --ci || true   # regenerate gen/apple (not committed)
-          # Stamp the CI build number so TestFlight accepts each upload.
-          if [ -d src-tauri/gen/apple ]; then
-            ( cd src-tauri/gen/apple && xcrun agvtool new-version -all "$BUILD_NUMBER" ) || \
-              echo "::warning::agvtool build-number stamp failed — first-run tweak point (see RELEASE_SETUP.md)"
-          fi
-          npx tauri ios build --export-method app-store-connect
+          npx tauri ios init --ci   # (re)generate gen/apple from project.yml
+          # --build-number stamps CFBundleVersion so TestFlight accepts each
+          # upload (must be unique + increasing); github.run_number is both.
+          npx tauri ios build --ci \
+            --export-method app-store-connect \
+            --build-number "${{ github.run_number }}"
 
       - name: Upload to TestFlight
         if: steps.secrets.outputs.have == 'true'

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -66,6 +66,8 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true # icons/*.png + bundled *.sqlite3 are Git LFS
 
       # Fail-soft: if the Apple secrets aren't configured yet, skip with a
       # clear message instead of a red X (keeps the pipeline mergeable).
@@ -121,7 +123,15 @@ jobs:
         # TestFlight accepts each upload even when the version string is unchanged.
         run: |
           BUILD_NUMBER=$(( $(date +%s) / 60 ))
-          npx tauri ios init --ci   # (re)generate gen/apple from project.yml
+          # Tauri's ios init does NOT copy the StoreKit test config from the
+          # ios/ template into gen/apple, so xcodegen fails on a fresh checkout
+          # ("missing source directory .../Corpan.storekit"). Locally it only
+          # works because the file already persists in gen/apple. First init
+          # writes project.yml (then fails at xcodegen); we supply the file and
+          # re-init (init does not wipe gen/apple), which then succeeds.
+          npx tauri ios init --ci || true
+          cp -f src-tauri/ios/Corpan.storekit src-tauri/gen/apple/Corpan.storekit
+          npx tauri ios init --ci
           npx tauri ios build --ci \
             --export-method app-store-connect \
             --build-number "$BUILD_NUMBER"
@@ -143,6 +153,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true # icons/*.png + bundled *.sqlite3 are Git LFS
 
       - id: secrets
         env:

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -131,12 +131,19 @@ jobs:
           npm ci
           npm ci --prefix ../packs/shared/capabilities
 
-      - name: Install cargo-tauri CLI
+      # The Xcode "Build Rust Code" phase (project.yml preBuildScript) runs
+      # `cargo tauri ios xcode-script`, which needs the tauri CLI installed as a
+      # cargo subcommand — CI otherwise only has the npm `npx tauri`. Cache the
+      # compiled binary so we don't rebuild it (~3-4 min) every run.
+      - name: Cache cargo-tauri
         if: steps.secrets.outputs.have == 'true'
-        # The Xcode "Build Rust Code" phase (project.yml preBuildScript) runs
-        # `cargo tauri ios xcode-script`, which needs the tauri CLI installed as a
-        # cargo subcommand — CI otherwise only has the npm `npx tauri`. Pinned to
-        # the tauri crate version in Cargo.lock.
+        id: cargo_tauri_cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-tauri
+          key: cargo-tauri-2.11.2-${{ runner.os }}-${{ runner.arch }}
+      - name: Install cargo-tauri CLI
+        if: steps.secrets.outputs.have == 'true' && steps.cargo_tauri_cache.outputs.cache-hit != 'true'
         run: cargo install tauri-cli --version 2.11.2 --locked
 
       # tauri-plugin-stt links a prebuilt whisper.cpp static XCFramework that is
@@ -276,6 +283,25 @@ jobs:
         if: steps.secrets.outputs.have == 'true'
         with:
           workspaces: corpan/corpan-app/src-tauri
+
+      - name: Cache Gradle
+        if: steps.secrets.outputs.have == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('corpan/corpan-app/src-tauri/gen/android/**/*.gradle*', 'corpan/corpan-app/src-tauri/gen/android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: gradle-${{ runner.os }}-
+      - name: Cache whisper Android native build (.cxx)
+        if: steps.secrets.outputs.have == 'true'
+        # The STT plugin's externalNativeBuild compiles whisper.cpp via CMake/ninja
+        # (~15 min). ninja does incremental builds, so caching its object dir lets
+        # subsequent runs skip recompilation. Keyed on the pinned whisper version.
+        uses: actions/cache@v4
+        with:
+          path: corpan/plugins/tauri-plugin-stt/android/.cxx
+          key: whisper-android-cxx-v1.8.4-${{ runner.os }}
 
       - name: Install NDK + retarget cargo toolchain paths for CI
         if: steps.secrets.outputs.have == 'true'

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -281,6 +281,17 @@ jobs:
         # go timestamp-based we stay timestamp-based (never revert to derived).
         run: echo "VERSION_CODE=$(( $(date +%s) / 60 ))" >> "$GITHUB_ENV"
 
+      - name: Vendor whisper.cpp source (tauri-plugin-stt JNI)
+        if: steps.secrets.outputs.have == 'true'
+        # The STT plugin's Android externalNativeBuild add_subdirectory(whisper.cpp)
+        # compiles a vendored, gitignored whisper.cpp checkout. Clone the pinned
+        # version per android/.gitignore so CMake can find it.
+        run: |
+          DST=corpan/plugins/tauri-plugin-stt/android/src/main/cpp/whisper.cpp
+          if [ ! -f "$DST/CMakeLists.txt" ]; then
+            git clone --depth 1 --branch v1.8.4 https://github.com/ggml-org/whisper.cpp.git "$DST"
+          fi
+
       - name: Tauri Android build (unsigned AAB)
         if: steps.secrets.outputs.have == 'true'
         working-directory: corpan/corpan-app

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -174,46 +174,32 @@ jobs:
         with:
           workspaces: corpan/corpan-app/src-tauri
 
-      - name: Install NDK + pin CI toolchain
+      - name: Install NDK + retarget cargo toolchain paths for CI
         if: steps.secrets.outputs.have == 'true'
         # gen/android/app/build.gradle.kts pins ndkVersion 28.2.13676358, so we
         # install exactly that. src-tauri/.cargo/config.toml hardcodes this dev's
-        # local *darwin* NDK paths for the Android linker/CC/AR + ANDROID_NDK_ROOT;
-        # those [env] entries are non-forced by design ("a real shell env var still
-        # wins (e.g. CI)"), so we override them here with the runner's linux-x86_64
-        # toolchain. Also overrides the per-target `linker` via CARGO_TARGET_*_LINKER
-        # (env beats config). API level 24 matches the config's *-android24-clang.
+        # LOCAL macOS NDK toolchain paths (linker/CC/CXX/AR + ANDROID_NDK_ROOT) —
+        # `/Users/skyl/Android/ndk/28.2.13676358/.../darwin-x86_64/...`. cargo's
+        # [env] uses dash-named vars (CC_aarch64-linux-android) which $GITHUB_ENV
+        # cannot set, so we can't override them from env. Instead we rewrite just
+        # the host-specific path prefix in the checked-out config (CI working copy
+        # only, never committed): base dir -> the runner's NDK, darwin -> linux.
+        # This preserves every intent of the file (same NDK 28.2, same API-24
+        # clang, 16 KB page linker flags) and touches nothing Apple.
         run: |
           NDK_VER=28.2.13676358
           yes | sdkmanager "ndk;$NDK_VER" "platforms;android-36" "build-tools;36.0.0" >/dev/null
           NDK="$ANDROID_SDK_ROOT/ndk/$NDK_VER"
-          BIN="$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          test -x "$BIN/aarch64-linux-android24-clang" || { echo "NDK clang missing at $BIN"; ls "$BIN" | head; exit 1; }
-          {
-            echo "NDK_HOME=$NDK"
-            echo "ANDROID_NDK_ROOT=$NDK"
-            echo "ANDROID_NDK_HOME=$NDK"
-            echo "ANDROID_NDK=$NDK"
-            echo "NDK_ROOT=$NDK"
-            # per-target linkers (override [target.<triple>].linker)
-            echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=$BIN/aarch64-linux-android24-clang"
-            echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=$BIN/armv7a-linux-androideabi24-clang"
-            echo "CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=$BIN/x86_64-linux-android24-clang"
-            echo "CARGO_TARGET_I686_LINUX_ANDROID_LINKER=$BIN/i686-linux-android24-clang"
-            # cc-rs compilers/archiver per triple (override [env] CC_/CXX_/AR_)
-            echo "CC_aarch64-linux-android=$BIN/aarch64-linux-android24-clang"
-            echo "CXX_aarch64-linux-android=$BIN/aarch64-linux-android24-clang++"
-            echo "AR_aarch64-linux-android=$BIN/llvm-ar"
-            echo "CC_armv7-linux-androideabi=$BIN/armv7a-linux-androideabi24-clang"
-            echo "CXX_armv7-linux-androideabi=$BIN/armv7a-linux-androideabi24-clang++"
-            echo "AR_armv7-linux-androideabi=$BIN/llvm-ar"
-            echo "CC_x86_64-linux-android=$BIN/x86_64-linux-android24-clang"
-            echo "CXX_x86_64-linux-android=$BIN/x86_64-linux-android24-clang++"
-            echo "AR_x86_64-linux-android=$BIN/llvm-ar"
-            echo "CC_i686-linux-android=$BIN/i686-linux-android24-clang"
-            echo "CXX_i686-linux-android=$BIN/i686-linux-android24-clang++"
-            echo "AR_i686-linux-android=$BIN/llvm-ar"
-          } >> "$GITHUB_ENV"
+          echo "NDK_HOME=$NDK" >> "$GITHUB_ENV"
+          CFG=corpan/corpan-app/src-tauri/.cargo/config.toml
+          sed -i \
+            -e "s#/Users/skyl/Android/ndk/$NDK_VER#$NDK#g" \
+            -e "s#prebuilt/darwin-x86_64#prebuilt/linux-x86_64#g" \
+            "$CFG"
+          echo "--- rewritten Android toolchain paths ---"
+          grep -nE "linux-android|ANDROID_NDK" "$CFG" | grep -iE "ndk|linux-android24|androideabi24" | head
+          test -x "$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang" \
+            || { echo "CI NDK clang not found"; exit 1; }
 
       - name: Decode upload keystore
         if: steps.secrets.outputs.have == 'true'

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -259,6 +259,11 @@ jobs:
         # release AAB comes out unsigned — we sign it with jarsigner below (the
         # correct signing scheme for AABs / Play upload keys).
         run: |
+          # gen/android/buildSrc (which defines the custom `rust` Gradle plugin
+          # applied by app/build.gradle.kts) is gitignored, so a fresh checkout
+          # is missing it -> "Plugin [id: 'rust'] was not found". init regenerates
+          # buildSrc without touching the committed, customized gradle files.
+          npx tauri android init --ci
           npx tauri android build --ci --aab \
             -c '{"bundle":{"android":{"versionCode":'"$VERSION_CODE"'}}}'
 

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -190,15 +190,45 @@ jobs:
           npx tauri ios init --ci || true
           cp -f src-tauri/ios/Corpan.storekit src-tauri/gen/apple/Corpan.storekit
           npx tauri ios init --ci
-          npx tauri ios build --ci \
+          # Archive only. Tauri's own export writes a minimal ExportOptions (method
+          # only) which fails app-store export under manual signing ("requires a
+          # provisioning profile"). We export ourselves below with a manual
+          # ExportOptions that pins the profile + distribution cert.
+          npx tauri ios build --ci --archive-only \
             --export-method app-store-connect \
             --build-number "$BUILD_NUMBER"
+
+      - name: Export signed IPA (manual ExportOptions)
+        if: steps.secrets.outputs.have == 'true'
+        working-directory: corpan/corpan-app
+        run: |
+          ARCHIVE=$(ls -d src-tauri/gen/apple/build/*.xcarchive | head -1)
+          echo "Archive: $ARCHIVE"
+          cat > "$RUNNER_TEMP/ExportOptions.plist" <<'PLIST'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0"><dict>
+            <key>method</key><string>app-store-connect</string>
+            <key>teamID</key><string>F9AV5HKF6N</string>
+            <key>signingStyle</key><string>manual</string>
+            <key>signingCertificate</key><string>Apple Distribution</string>
+            <key>provisioningProfiles</key><dict>
+              <key>com.corpora.corpan</key><string>corpan appstore ci</string>
+            </dict>
+            <key>uploadSymbols</key><true/>
+          </dict></plist>
+          PLIST
+          xcodebuild -exportArchive \
+            -archivePath "$ARCHIVE" \
+            -exportPath src-tauri/gen/apple/build/export \
+            -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist"
+          ls -la src-tauri/gen/apple/build/export
 
       - name: Upload to TestFlight
         if: steps.secrets.outputs.have == 'true'
         uses: apple-actions/upload-testflight-build@v3
         with:
-          app-path: corpan/corpan-app/src-tauri/gen/apple/build/arm64/corpan.ipa
+          app-path: corpan/corpan-app/src-tauri/gen/apple/build/export/corpan.ipa
           issuer-id: ${{ secrets.ASC_ISSUER_ID }}
           api-key-id: ${{ secrets.ASC_KEY_ID }}
           api-private-key: ${{ secrets.ASC_API_KEY_P8 }}

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -174,11 +174,46 @@ jobs:
         with:
           workspaces: corpan/corpan-app/src-tauri
 
-      - name: Install NDK
+      - name: Install NDK + pin CI toolchain
         if: steps.secrets.outputs.have == 'true'
+        # gen/android/app/build.gradle.kts pins ndkVersion 28.2.13676358, so we
+        # install exactly that. src-tauri/.cargo/config.toml hardcodes this dev's
+        # local *darwin* NDK paths for the Android linker/CC/AR + ANDROID_NDK_ROOT;
+        # those [env] entries are non-forced by design ("a real shell env var still
+        # wins (e.g. CI)"), so we override them here with the runner's linux-x86_64
+        # toolchain. Also overrides the per-target `linker` via CARGO_TARGET_*_LINKER
+        # (env beats config). API level 24 matches the config's *-android24-clang.
         run: |
-          sdkmanager "ndk;26.1.10909125"
-          echo "NDK_HOME=$ANDROID_SDK_ROOT/ndk/26.1.10909125" >> "$GITHUB_ENV"
+          NDK_VER=28.2.13676358
+          yes | sdkmanager "ndk;$NDK_VER" "platforms;android-36" "build-tools;36.0.0" >/dev/null
+          NDK="$ANDROID_SDK_ROOT/ndk/$NDK_VER"
+          BIN="$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          test -x "$BIN/aarch64-linux-android24-clang" || { echo "NDK clang missing at $BIN"; ls "$BIN" | head; exit 1; }
+          {
+            echo "NDK_HOME=$NDK"
+            echo "ANDROID_NDK_ROOT=$NDK"
+            echo "ANDROID_NDK_HOME=$NDK"
+            echo "ANDROID_NDK=$NDK"
+            echo "NDK_ROOT=$NDK"
+            # per-target linkers (override [target.<triple>].linker)
+            echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=$BIN/aarch64-linux-android24-clang"
+            echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=$BIN/armv7a-linux-androideabi24-clang"
+            echo "CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=$BIN/x86_64-linux-android24-clang"
+            echo "CARGO_TARGET_I686_LINUX_ANDROID_LINKER=$BIN/i686-linux-android24-clang"
+            # cc-rs compilers/archiver per triple (override [env] CC_/CXX_/AR_)
+            echo "CC_aarch64-linux-android=$BIN/aarch64-linux-android24-clang"
+            echo "CXX_aarch64-linux-android=$BIN/aarch64-linux-android24-clang++"
+            echo "AR_aarch64-linux-android=$BIN/llvm-ar"
+            echo "CC_armv7-linux-androideabi=$BIN/armv7a-linux-androideabi24-clang"
+            echo "CXX_armv7-linux-androideabi=$BIN/armv7a-linux-androideabi24-clang++"
+            echo "AR_armv7-linux-androideabi=$BIN/llvm-ar"
+            echo "CC_x86_64-linux-android=$BIN/x86_64-linux-android24-clang"
+            echo "CXX_x86_64-linux-android=$BIN/x86_64-linux-android24-clang++"
+            echo "AR_x86_64-linux-android=$BIN/llvm-ar"
+            echo "CC_i686-linux-android=$BIN/i686-linux-android24-clang"
+            echo "CXX_i686-linux-android=$BIN/i686-linux-android24-clang++"
+            echo "AR_i686-linux-android=$BIN/llvm-ar"
+          } >> "$GITHUB_ENV"
 
       - name: Decode upload keystore
         if: steps.secrets.outputs.have == 'true'

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -135,6 +135,14 @@ jobs:
         # TestFlight accepts each upload even when the version string is unchanged.
         run: |
           BUILD_NUMBER=$(( $(date +%s) / 60 ))
+          # The project template uses automatic signing, which needs a logged-in
+          # Xcode account (fine locally, impossible headless: "No Accounts / No
+          # profiles found"). Force MANUAL signing in the CI working copy only —
+          # the committed template stays automatic for local dev. Uses the App
+          # Store profile minted via the ASC API + the imported distribution cert.
+          sed -i \
+            -e 's|^        CODE_SIGN_STYLE: Automatic|        CODE_SIGN_STYLE: Manual\n        PROVISIONING_PROFILE_SPECIFIER: "corpan appstore ci"\n        CODE_SIGN_IDENTITY: "Apple Distribution"|' \
+            src-tauri/ios/project.yml
           # Tauri's ios init does NOT copy the StoreKit test config from the
           # ios/ template into gen/apple, so xcodegen fails on a fresh checkout
           # ("missing source directory .../Corpan.storekit"). Locally it only

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -117,13 +117,14 @@ jobs:
       - name: Tauri iOS build (app-store-connect)
         if: steps.secrets.outputs.have == 'true'
         working-directory: corpan/corpan-app
+        # Minutes-since-epoch build number: unique + increasing across runs, so
+        # TestFlight accepts each upload even when the version string is unchanged.
         run: |
+          BUILD_NUMBER=$(( $(date +%s) / 60 ))
           npx tauri ios init --ci   # (re)generate gen/apple from project.yml
-          # --build-number stamps CFBundleVersion so TestFlight accepts each
-          # upload (must be unique + increasing); github.run_number is both.
           npx tauri ios build --ci \
             --export-method app-store-connect \
-            --build-number "${{ github.run_number }}"
+            --build-number "$BUILD_NUMBER"
 
       - name: Upload to TestFlight
         if: steps.secrets.outputs.have == 'true'
@@ -179,17 +180,10 @@ jobs:
           sdkmanager "ndk;26.1.10909125"
           echo "NDK_HOME=$ANDROID_SDK_ROOT/ndk/26.1.10909125" >> "$GITHUB_ENV"
 
-      - name: Decode keystore + signing props
+      - name: Decode upload keystore
         if: steps.secrets.outputs.have == 'true'
-        working-directory: corpan/corpan-app/src-tauri
         run: |
-          echo "${{ secrets.ANDROID_KEYSTORE_B64 }}" | base64 --decode > upload-keystore.jks
-          cat > gen/android/keystore.properties <<EOF
-          storeFile=$(pwd)/upload-keystore.jks
-          storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
-          keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
-          EOF
+          echo "${{ secrets.ANDROID_KEYSTORE_B64 }}" | base64 --decode > "$RUNNER_TEMP/upload-keystore.jks"
 
       - name: Install deps
         if: steps.secrets.outputs.have == 'true'
@@ -198,12 +192,33 @@ jobs:
           npm ci
           npm ci --prefix ../packs/shared/capabilities
 
-      - name: Tauri Android build (signed AAB)
+      - name: Version code (unique, monotonic)
+        if: steps.secrets.outputs.have == 'true'
+        # Minutes-since-epoch: always increasing across runs and safely above the
+        # semver-derived default (0.19.2 -> 19002, already live on Play). Once we
+        # go timestamp-based we stay timestamp-based (never revert to derived).
+        run: echo "VERSION_CODE=$(( $(date +%s) / 60 ))" >> "$GITHUB_ENV"
+
+      - name: Tauri Android build (unsigned AAB)
         if: steps.secrets.outputs.have == 'true'
         working-directory: corpan/corpan-app
-        env:
-          TAURI_ANDROID_VERSION_CODE: ${{ github.run_number }}
-        run: npx tauri android build --aab
+        # Tauri's generated Gradle project has no release signingConfig, so the
+        # release AAB comes out unsigned — we sign it with jarsigner below (the
+        # correct signing scheme for AABs / Play upload keys).
+        run: |
+          npx tauri android build --ci --aab \
+            -c '{"bundle":{"android":{"versionCode":'"$VERSION_CODE"'}}}'
+
+      - name: Sign AAB with upload key (jarsigner)
+        if: steps.secrets.outputs.have == 'true'
+        working-directory: corpan/corpan-app/src-tauri
+        run: |
+          AAB=gen/android/app/build/outputs/bundle/universalRelease/app-universal-release.aab
+          jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 \
+            -keystore "$RUNNER_TEMP/upload-keystore.jks" \
+            -storepass "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" \
+            "$AAB" "${{ secrets.ANDROID_KEY_ALIAS }}"
+          jarsigner -verify "$AAB" && echo "AAB signature verified"
 
       - name: Upload to Play internal
         if: steps.secrets.outputs.have == 'true'

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -172,6 +172,15 @@ jobs:
           sed -i \
             -e 's|^        CODE_SIGN_STYLE: Automatic|        CODE_SIGN_STYLE: Manual\n        PROVISIONING_PROFILE_SPECIFIER: "corpan appstore ci"\n        CODE_SIGN_IDENTITY: "Apple Distribution"|' \
             src-tauri/ios/project.yml
+          # tauri-plugin-stt/build.rs emits `cargo:rustc-link-lib=framework=whisper`,
+          # but that cargo directive does not reach Xcode's final Ld in CI (locally
+          # the static whisper folds into libapp.a; here it doesn't), so the app
+          # link fails with undefined _whisper_* symbols. Force the device-slice
+          # framework onto the Xcode linker via OTHER_LDFLAGS.
+          WHISPER_SLICE="$GITHUB_WORKSPACE/corpan/plugins/tauri-plugin-stt/ios/whisper.xcframework/ios-arm64"
+          sed -i \
+            -e 's#^        ENABLE_BITCODE: false#        ENABLE_BITCODE: false\n        OTHER_LDFLAGS: "$(inherited) -F'"$WHISPER_SLICE"' -framework whisper -framework Accelerate -framework CoreML"#' \
+            src-tauri/ios/project.yml
           # Tauri's ios init does NOT copy the StoreKit test config from the
           # ios/ template into gen/apple, so xcodegen fails on a fresh checkout
           # ("missing source directory .../Corpan.storekit"). Locally it only

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -128,6 +128,14 @@ jobs:
           npm ci
           npm ci --prefix ../packs/shared/capabilities
 
+      - name: Install cargo-tauri CLI
+        if: steps.secrets.outputs.have == 'true'
+        # The Xcode "Build Rust Code" phase (project.yml preBuildScript) runs
+        # `cargo tauri ios xcode-script`, which needs the tauri CLI installed as a
+        # cargo subcommand — CI otherwise only has the npm `npx tauri`. Pinned to
+        # the tauri crate version in Cargo.lock.
+        run: cargo install tauri-cli --version 2.11.2 --locked
+
       - name: Tauri iOS build (app-store-connect)
         if: steps.secrets.outputs.have == 'true'
         working-directory: corpan/corpan-app

--- a/corpan/corpan-app/CHANGELOG.md
+++ b/corpan/corpan-app/CHANGELOG.md
@@ -7,13 +7,21 @@ Conventions: `corpan/CHANGELOGS.md`.
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-07-06
+
 ### Added
-- **Automated mobile release pipeline** — `.github/workflows/release-mobile.yml`
-  builds signed iOS + Android on a version bump to `main` and ships to
-  TestFlight internal + Play internal testing (no manual MacBook/Transporter
-  step). Version bumping via `scripts/bump-app-version.mjs`; one-time credential
-  setup in `RELEASE_SETUP.md`. The build jobs skip cleanly until the release
-  secrets are configured, so the workflow is safe to merge before setup.
+- **Automated mobile release pipeline — proven end-to-end.**
+  `.github/workflows/release-mobile.yml` builds signed iOS + Android on a version
+  bump to `main` and ships to TestFlight internal + Play internal testing (no
+  manual MacBook/Transporter step). Version bumping via
+  `scripts/bump-app-version.mjs`; one-time credential setup in `RELEASE_SETUP.md`.
+  0.20.0 is the first release cut this way — both platforms uploaded green.
+  Hardened for a real repo checkout: Git-LFS fetch (icons + DB), whisper.cpp
+  vendored/built in CI for the STT plugin (iOS XCFramework + Android JNI), CI
+  rewrite of the machine-specific `.cargo/config.toml` NDK paths, `buildSrc`
+  regeneration, manual iOS signing with an ASC-API-minted profile, a
+  profile-pinned `xcodebuild -exportArchive`, jarsigner AAB signing, monotonic
+  version codes, `macos-26`/Xcode 26 (iOS 26 SDK), and build/toolchain caching.
 - **Journey browser demo harness (dev-only)** — `journey-demo.html` mounts the
   REAL JourneySurface + engine + resolver over the real `journey_en` pack
   content in a plain browser (no Tauri): `scripts/journey-demo/precompute.ts`

--- a/corpan/corpan-app/package.json
+++ b/corpan/corpan-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "corpan",
   "private": true,
-  "version": "0.19.2",
+  "version": "0.20.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/corpan/corpan-app/src-tauri/Cargo.toml
+++ b/corpan/corpan-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corpan"
-version = "0.19.2"
+version = "0.20.0"
 description = "Language learning app"
 authors = ["you"]
 edition = "2021"

--- a/corpan/corpan-app/src-tauri/tauri.conf.json
+++ b/corpan/corpan-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "corpan",
-  "version": "0.19.2",
+  "version": "0.20.0",
   "identifier": "com.corpora.corpan",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
### **User description**
Makes `release-mobile.yml` (from #512) actually build and ship signed **iOS →
TestFlight internal** and **Android → Play internal** from GitHub Actions, and
cuts **corpan 0.20.0** as the first release through it. Both platforms uploaded
green at 0.20.0 before this PR (validated on the branch).

## What was broken (each a real repo-specific gotcha the blind scaffold couldn't know)
- **Android version code**: Gradle project has no release signingConfig → build
  unsigned AAB + `jarsigner` (correct AAB scheme); monotonic (minutes-epoch)
  version codes above the live 19002.
- **`.cargo/config.toml`** hardcodes this dev's local macOS NDK paths → rewrite
  to the runner's linux NDK toolchain (CI working copy only).
- **Git LFS**: icons + bundled `.sqlite3` are LFS → `checkout lfs:true`.
- **whisper.cpp** (STT plugin) is gitignored on both platforms → build the iOS
  XCFramework + vendor the Android JNI source in CI (cached).
- **iOS**: `Corpan.storekit` not copied by init; xcodegen needs Xcode 16+;
  automatic signing needs an account → manual signing w/ an ASC-API-minted
  profile; `cargo tauri` subcommand; force `-framework whisper` into Ld;
  profile-pinned `xcodebuild -exportArchive`; **macos-26 / Xcode 26** for the
  iOS 26 SDK App Store Connect now requires.
- **`buildSrc`** (custom `rust` Gradle plugin) gitignored → `tauri android init`.

## Also
- Gradle + whisper-`.cxx` + cargo-tauri caches.
- Version bump 0.19.2 → 0.20.0; CHANGELOG promoted.

Merging bumps the version on `main`, which triggers this workflow to cut 0.20.0
to both internal tracks from the production path.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Hardens iOS TestFlight automation

- Hardens Android Play internal automation

- Bumps Corpan to 0.20.0

- Documents verified release pipeline


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Version bump to 0.20.0"]
  B["Mobile release workflow"]
  C["iOS TestFlight internal"]
  D["Android Play internal"]
  E["Changelog release notes"]
  A -- "triggers" --> B
  B -- "manual signing + export" --> C
  B -- "AAB build + jarsigner" --> D
  A -- "documented in" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-mobile.yml</strong><dd><code>Harden mobile CI release builds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-mobile.yml

<ul><li>Switches iOS builds to <code>macos-26</code> and selects the newest Xcode for iOS <br>26 SDK uploads.<br> <li> Enables Git LFS checkout and caches/builds required <code>cargo-tauri</code> and <br><code>whisper.xcframework</code> artifacts.<br> <li> Adds manual iOS signing, archive-only Tauri build, explicit <br><code>ExportOptions.plist</code>, and exported IPA upload path.<br> <li> Hardens Android CI with Gradle/whisper caches, NDK path rewriting, <br>monotonic version codes, unsigned AAB builds, and <code>jarsigner</code> signing.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/513/files#diff-e98843d05d2e1469fccb7dc8d1f42fa8aba4f2c4a16e58ec549a28245201afcd">+203/-27</a></td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document verified 0.20.0 release automation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/corpan-app/CHANGELOG.md

<ul><li>Adds the <code>0.20.0</code> release section.<br> <li> Marks the automated mobile release pipeline as proven end-to-end.<br> <li> Documents repo-specific CI fixes for LFS, whisper.cpp, signing, NDK <br>paths, version codes, and caching.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/513/files#diff-fcd2aeaa88f0735613dd8b9388c69c41b43b9eec554f31f82c902937b33b9940">+14/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump npm app version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/corpan-app/package.json

- Bumps the Corpan app npm package version from `0.19.2` to `0.20.0`.


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/513/files#diff-6f3835061316357e8d8d2db1c1be20a177080546158dd0c5f79c6a916b484c74">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump Rust package version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/corpan-app/src-tauri/Cargo.toml

- Bumps the Tauri Rust package version from `0.19.2` to `0.20.0`.


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/513/files#diff-9ef6389f1df3c4b4d85e794fe98cd4483e38e4bb188e0c7a608c28e262389dfa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tauri.conf.json</strong><dd><code>Bump Tauri release version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/corpan-app/src-tauri/tauri.conf.json

<ul><li>Bumps the Tauri app configuration version from <code>0.19.2</code> to <code>0.20.0</code>.<br> <li> Provides the version-change trigger for the mobile release workflow on <br><code>main</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/513/files#diff-c63059cb2f0219fa2102fa1693da4fdf0aac37f378e1d2596598d0864430e0db">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

