### PR TITLE
CI: generate app icons + declare export compliance

### DIFF
--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -200,6 +200,11 @@ jobs:
           npx tauri ios init --ci || true
           cp -f src-tauri/ios/Corpan.storekit src-tauri/gen/apple/Corpan.storekit
           npx tauri ios init --ci
+          # gen/apple/Assets.xcassets/AppIcon.appiconset is gitignored (generated),
+          # so a fresh checkout ships no app icon. Regenerate from the alpha-free
+          # white-background source (the RGBA icons/512x512.png can't be the iOS
+          # marketing icon — Apple rejects alpha).
+          npx tauri icon src-tauri/icons/512x512_white.png
           # Archive only. Tauri's own export writes a minimal ExportOptions (method
           # only) which fails app-store export under manual signing ("requires a
           # provisioning profile"). We export ourselves below with a manual
@@ -372,6 +377,9 @@ jobs:
           # is missing it -> "Plugin [id: 'rust'] was not found". init regenerates
           # buildSrc without touching the committed, customized gradle files.
           npx tauri android init --ci
+          # res/mipmap-* launcher icons are gitignored (generated) — regenerate
+          # them so the installed app isn't iconless.
+          npx tauri icon src-tauri/icons/512x512_white.png
           npx tauri android build --ci --aab \
             -c '{"bundle":{"android":{"versionCode":'"$VERSION_CODE"'}}}'
 

--- a/corpan/corpan-app/src-tauri/ios/project.yml
+++ b/corpan/corpan-app/src-tauri/ios/project.yml
@@ -42,6 +42,11 @@ targets:
       path: corpan_iOS/Info.plist
       properties:
         LSRequiresIPhoneOS: true
+        # Only exempt encryption (HTTPS, Apple IAP, on-device ML) — declaring this
+        # lets TestFlight/App Store skip the export-compliance prompt so uploaded
+        # builds become available to testers immediately instead of sitting in
+        # "Missing Compliance".
+        ITSAppUsesNonExemptEncryption: false
         UILaunchStoryboardName: LaunchScreen
         UIRequiredDeviceCapabilities: [arm64, metal]
         UISupportedInterfaceOrientations:


### PR DESCRIPTION
### **User description**
Two fixes found while getting 0.20.0 onto TestFlight:

- **App icons** — the generated icon assets (iOS `AppIcon.appiconset`, Android
  `mipmap-*`) are gitignored, so CI shipped an iconless app. Run `tauri icon`
  from `icons/512x512_white.png` (the alpha-free source; `bundle.icon`'s
  `512x512.png` is RGBA, which Apple rejects for the marketing icon) before each
  build.
- **Export compliance** — add `ITSAppUsesNonExemptEncryption: false` to
  `ios/project.yml` so TestFlight/App Store skip the compliance prompt. Without
  it, 0.20.0 builds sat in "Missing Compliance" and never reached testers
  (TestFlight kept showing 0.19.2). The app only uses exempt encryption
  (HTTPS / Apple IAP / on-device ML).

Verified: the resulting build is VALID, `usesNonExemptEncryption=false` (auto),
and carries the icon, on both TestFlight internal and Play internal.


___

### **PR Type**
Bug fix


___

### **Description**
- Regenerate mobile app icons in CI

- Declare iOS export compliance status


___

### Diagram Walkthrough


```mermaid
flowchart LR
  source["Alpha-free 512x512 icon"] --> ios["iOS AppIcon assets"]
  source --> android["Android launcher mipmaps"]
  ios --> release["Mobile release builds"]
  android --> release
  compliance["Export compliance flag"] --> testflight["TestFlight availability"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-mobile.yml</strong><dd><code>Regenerate mobile app icons in CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-mobile.yml

<ul><li>Runs <code>npx tauri icon src-tauri/icons/512x512_white.png</code> after iOS <br>initialization.<br> <li> Regenerates gitignored iOS <code>AppIcon.appiconset</code> assets for fresh CI <br>checkouts.<br> <li> Runs the same icon generation before Android AAB builds.<br> <li> Restores generated Android <code>res/mipmap-*</code> launcher icons in release CI.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/514/files#diff-e98843d05d2e1469fccb7dc8d1f42fa8aba4f2c4a16e58ec549a28245201afcd">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>project.yml</strong><dd><code>Declare iOS export compliance flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/corpan-app/src-tauri/ios/project.yml

<ul><li>Adds <code>ITSAppUsesNonExemptEncryption: false</code> to generated iOS <code>Info.plist</code> <br>properties.<br> <li> Documents that the app only uses exempt encryption paths.<br> <li> Allows TestFlight/App Store uploads to bypass the missing compliance <br>prompt.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/514/files#diff-039f3618cb555cd64a69e622261324fc786a40f8995c95e03b817b0e031483c2">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

