### PR TITLE
corpan 0.20.4 — patch: kill the why-card trap, phantom scrollbar, unreadable etymology

### DIFF
--- a/corpan/corpan-app/CHANGELOG.md
+++ b/corpan/corpan-app/CHANGELOG.md
@@ -7,6 +7,23 @@ Conventions: `corpan/CHANGELOGS.md`.
 
 ## [Unreleased]
 
+## [0.20.4] — 2026-07-11
+
+### Fixed
+- **Removed the "Why this card?" popover that could trap you.** Its long-press
+  gesture collided with hold-to-speak (a speak card *is* a press-and-hold), so
+  holding the mic summoned the explainer, it covered the mic, and every retry
+  re-summoned it. It was also read-back status copy the design avoids. Gone.
+- **No more phantom scrollbar over the Journey feed.** The CSS that freezes
+  Home's scroller behind a full-screen experience only matched
+  `data-experience-active="true"`, but the Journey surface tags it `"journey"` —
+  so Home stayed scrollable and Android painted its overlay scrollbar through the
+  opaque overlay. The selector now matches any active experience.
+- **A meaning/etymology you can actually read.** A settled word card showing a
+  wordpan meaning/etymology paragraph no longer auto-advances after 2.2s — it
+  waits for a swipe, so a 40–60 word etymology is readable. Cards with no meaning
+  still auto-advance fast.
+
 ## [0.20.3] — 2026-07-10
 
 ### Added

--- a/corpan/corpan-app/package.json
+++ b/corpan/corpan-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "corpan",
   "private": true,
-  "version": "0.20.3",
+  "version": "0.20.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/corpan/corpan-app/src-tauri/tauri.conf.json
+++ b/corpan/corpan-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "corpan",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "identifier": "com.corpora.corpan",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/corpan/corpan-app/src/index.css
+++ b/corpan/corpan-app/src/index.css
@@ -298,8 +298,12 @@ body {
    container. Home is `position:fixed; overflow-y:auto` (its own scroll
    context), so on Android WebView its scrollbar otherwise paints THROUGH
    the opaque pack overlay on top. Locking it removes the bleed-through and
-   stops a hidden second scroller from eating momentum. iOS is unaffected. */
-body[data-experience-active="true"] [data-home-scroll] {
+   stops a hidden second scroller from eating momentum. iOS is unaffected.
+
+   Match ANY attribute value (App sets "true"; JourneySurface sets "journey").
+   The earlier `="true"` selector missed Journey → phantom scrollbar over the
+   Journey feed. Attribute-present is the documented contract (PERFORMANCE.md). */
+body[data-experience-active] [data-home-scroll] {
     overflow: hidden !important;
 }
 

--- a/corpan/corpan-app/src/journey/feed/FeedCardFrame.tsx
+++ b/corpan/corpan-app/src/journey/feed/FeedCardFrame.tsx
@@ -1,17 +1,19 @@
 // src/journey/feed/FeedCardFrame.tsx — the card frame (feed-ux §1.3/§3.1):
-// settled checkmark stamp, "viewed earlier" chip in review mode, and the
-// why-this-card long-press transparency popover (§3.1, engagement §2.9.7).
+// settled checkmark stamp + "viewed earlier" chip in review mode.
 //
 // (File name: the spec calls this FeedCard.tsx; renamed to avoid colliding
 // with the FeedCard TYPE in types.ts — same component, same duties.)
+//
+// The old long-press "why this card?" transparency popover was removed: its
+// press-and-hold gesture collided with hold-to-speak (a speak card IS a long
+// press), so it obscured the mic and re-summoned itself on every retry — and it
+// was read-back status copy the design bans. State is shown through the card
+// itself, not narrated.
 
-import { useRef, useState } from "react"
 import { AnimatePresence, motion } from "framer-motion"
 import { useTranslation } from "react-i18next"
 import { Check } from "lucide-react"
 import type { FeedCard } from "../types.ts"
-
-const WHY_PRESS_MS = 500
 
 export function FeedCardFrame(props: {
   card: FeedCard
@@ -20,33 +22,9 @@ export function FeedCardFrame(props: {
   children: React.ReactNode
 }) {
   const { t } = useTranslation()
-  const [why, setWhy] = useState(false)
-  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  const reason = (): string => {
-    const c = props.card
-    if (c.kind !== "exercise") return t("journey.exercise.whyGuided")
-    const pool = c.prepared.engine.meta.pool
-    if (pool === "new") return t("journey.exercise.whyNew")
-    if (pool === "due" || pool === "replay") return t("journey.exercise.whyReview")
-    if (pool === "repair") return t("journey.exercise.whyRepair")
-    return t("journey.exercise.whyGuided")
-  }
 
   return (
-    <div
-      className="relative flex h-full w-full flex-col items-center justify-center px-5 py-6"
-      onPointerDown={() => {
-        if (timer.current) clearTimeout(timer.current)
-        timer.current = setTimeout(() => setWhy(true), WHY_PRESS_MS)
-      }}
-      onPointerUp={() => {
-        if (timer.current) clearTimeout(timer.current)
-      }}
-      onPointerLeave={() => {
-        if (timer.current) clearTimeout(timer.current)
-      }}
-    >
+    <div className="relative flex h-full w-full flex-col items-center justify-center px-5 py-6">
       <motion.div
         className="mx-auto flex w-full max-w-[40rem] flex-1 flex-col items-center justify-center"
         animate={{ scale: props.settled ? 0.98 : 1 }}
@@ -69,21 +47,6 @@ export function FeedCardFrame(props: {
           >
             <Check className="h-5 w-5" />
           </motion.div>
-        )}
-        {why && (
-          <motion.button
-            type="button"
-            initial={{ opacity: 0, y: 6 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0 }}
-            onClick={() => setWhy(false)}
-            className="absolute inset-x-6 bottom-8 rounded-xl border border-border bg-card px-4 py-3 text-start text-sm text-foreground shadow-lg"
-          >
-            <span className="mb-0.5 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              {t("journey.exercise.whyThisCard")}
-            </span>
-            {reason()}
-          </motion.button>
         )}
       </AnimatePresence>
     </div>

--- a/corpan/corpan-app/src/journey/feed/advanceRules.test.ts
+++ b/corpan/corpan-app/src/journey/feed/advanceRules.test.ts
@@ -7,6 +7,7 @@ import assert from "node:assert/strict"
 import { advanceRule, isListeningCard, isListeningRunStart } from "./advanceRules.ts"
 import type { FeedCard, PreparedExercise } from "../types.ts"
 import type { EngineCard } from "../engine/index.ts"
+import type { ResolvedItem } from "../content/resolve.ts"
 
 const engineCard = (activityType: string): EngineCard => ({
   spec: { specId: "s1", activityType, itemRefs: [], targetLang: "en" },
@@ -30,6 +31,30 @@ const exercise = (activityType: string, params?: Record<string, unknown>): FeedC
 
 test("choice_pick: swipe in swipe mode, auto+2200 in auto (default) mode", () => {
   assert.deepEqual(advanceRule(exercise("choice_pick"), "swipe"), { kind: "swipe" })
+  assert.deepEqual(advanceRule(exercise("choice_pick"), "auto"), { kind: "auto", delayMs: 2200 })
+})
+
+const withMeaning = (activityType: string): FeedCard => {
+  const c = exercise(activityType)
+  if (c.kind === "exercise") {
+    c.prepared.items = [
+      {
+        kind: "word",
+        target: { text: "welcome" },
+        extras: { kind: "word", explanationNative: "Del inglés antiguo wilcuma…" },
+      } as unknown as ResolvedItem,
+    ]
+  }
+  return c
+}
+
+test("word card with a meaning/etymology waits for a swipe — never auto-advances", () => {
+  // A 50-word etymology must not be yanked away on the 2.2s timer; the learner
+  // reads and swipes on. Holds across exercise types, even in auto mode.
+  assert.deepEqual(advanceRule(withMeaning("choice_pick"), "auto"), { kind: "swipe" })
+  assert.deepEqual(advanceRule(withMeaning("listen_type"), "auto"), { kind: "swipe" })
+  assert.deepEqual(advanceRule(withMeaning("speak_echo"), "auto"), { kind: "swipe" })
+  // A word with no meaning still auto-advances fast (no regression).
   assert.deepEqual(advanceRule(exercise("choice_pick"), "auto"), { kind: "auto", delayMs: 2200 })
 })
 

--- a/corpan/corpan-app/src/journey/feed/advanceRules.ts
+++ b/corpan/corpan-app/src/journey/feed/advanceRules.ts
@@ -50,6 +50,11 @@ export function advanceRule(
       break
   }
   if (card.rare) return { kind: "manual" } // anticipation is never rushed
+  // A settled word card carrying a meaning/etymology paragraph is a READING
+  // beat — never auto-advance it out from under the learner (a 50-word etymology
+  // in 2.2s is unreadable). Wait for a deliberate swipe (the chevron cues it);
+  // fast learners flick on instantly, readers take their time.
+  if (hasReadableMeaning(card)) return { kind: "swipe" }
   const t = card.spec.activityType
   if (t === "speak_echo") return { kind: "auto", delayMs: 1000 } // hands/mouth busy
   // Explicit-completion cards: the learner presses Continue (intro_echo) or
@@ -68,4 +73,14 @@ export function advanceRule(
 /** Listening-run detection (§3.2): ≥2 consecutive listen_* cards queued. */
 export function isListeningRunStart(current: FeedCard, next: FeedCard | null): boolean {
   return isListeningCard(current) && next !== null && isListeningCard(next)
+}
+
+/** A word exercise whose resolved item carries a wordpan meaning/etymology
+ *  paragraph. The post-answer enrichment renders real reading (often 40–60
+ *  words), so the settled card must not auto-advance — the learner reads and
+ *  swipes on when ready. (Function declaration → hoisted; safe to call above.) */
+function hasReadableMeaning(card: FeedCard): boolean {
+  if (card.kind !== "exercise") return false
+  const extras = card.prepared.items[0]?.extras
+  return extras?.kind === "word" && !!(extras.explanationNative || extras.explanationTarget)
 }


### PR DESCRIPTION
### **User description**
Fast patch on top of 0.20.3 for three device-testing traps. Bumps **0.20.3 → 0.20.4** (merging triggers the mobile pipeline → TestFlight + Play internal).

## Fixed
- **"Why this card?" popover trap** — its long-press gesture collided with hold-to-speak, so holding the mic summoned the explainer, it covered the mic, and every retry re-summoned it (couldn't dismiss → stuck). Also read-back status copy the design avoids. **Removed the feature.**
- **Phantom scrollbar over the feed** — the CSS freezing Home's scroller only matched `data-experience-active="true"`, but the Journey surface tags it `"journey"` — so Home stayed scrollable and Android painted its overlay scrollbar through the opaque overlay. **Selector now matches any active experience** (the documented contract).
- **Unreadable meaning/etymology** — a settled word card showing a 40–60 word wordpan meaning/etymology auto-advanced after 2.2s. It now **waits for a swipe** (the chevron cues it); cards with no meaning still auto-advance fast.

## Verification
`tsc` ✓ · app tests **507/507** ✓ · `check:i18n` ✓ · `vite build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Removes trapping why-card long press

- Freezes Home scroll for Journey overlays

- Keeps readable meanings swipe-controlled

- Bumps Corpan release to 0.20.4


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Journey feed issues"] 
  B["Remove why-card popover"]
  C["Freeze Home scroller"]
  D["Swipe for readable meanings"]
  E["Release 0.20.4"]
  A -- "gesture trap" --> B
  A -- "Android scrollbar bleed" --> C
  A -- "unreadable enrichment" --> D
  B -- "patch release" --> E
  C -- "patch release" --> E
  D -- "patch release" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>FeedCardFrame.tsx</strong><dd><code>Removes long-press why-card popover</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/518/files#diff-e9566ddee7fd00976fa10a96ad6251898d36f0b1513ca4d99923c42f0b508b56">+8/-45</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>advanceRules.ts</strong><dd><code>Prevents auto-advance for readable word meanings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/518/files#diff-aea799008d408ebcaa6f5ec73875886d06de02612c126120131d66ac0e71b711">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.css</strong><dd><code>Freezes Home scroll for active experiences</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/518/files#diff-5ce490a16a31748b221f1dbf4195c0ef7ca652f31e8e47ab337756cfa3ea24b7">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>advanceRules.test.ts</strong><dd><code>Tests swipe behavior for readable meanings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/518/files#diff-213fa4d7fbfd250dace5dbf182c0e00543c768f062f27eeac864a6bcff34ab37">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Documents Corpan 0.20.4 fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/518/files#diff-fcd2aeaa88f0735613dd8b9388c69c41b43b9eec554f31f82c902937b33b9940">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>package.json</strong><dd><code>Bumps app package version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/518/files#diff-6f3835061316357e8d8d2db1c1be20a177080546158dd0c5f79c6a916b484c74">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tauri.conf.json</strong><dd><code>Bumps Tauri app version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/518/files#diff-c63059cb2f0219fa2102fa1693da4fdf0aac37f378e1d2596598d0864430e0db">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

