### PR TITLE
docs(dynawalla): program reference set — architecture, curriculum, engine, gates, release, store

### DIFF
--- a/dynawalla/docs/ADAPTIVE_LEARNING.md
+++ b/dynawalla/docs/ADAPTIVE_LEARNING.md
@@ -100,16 +100,29 @@ repair scheduling.
 
 **Stage 2 LOCATE** (mal-rule matched, `β ≥ 2.2`). The mechanism the product is named
 for. If the wrong answer *equals* a computed buggy-procedure output, we know which step
-broke. On `5,001 − 2,798 = 3,797` the response is a **contrast pair** in which the buggy
-procedure produces a visibly absurd answer, with the counting board showing there are no
-thousands left to take from. The child sees the contradiction rather than being told.
+broke. On `5,001 − 2,798 = 3,203` — `mis.add.borrow-across-zero`, the variant that
+regroups all the way down but never decrements the thousands — the response is a
+**contrast pair** in which the buggy procedure produces a visibly absurd answer: on the
+counting board the thousand that was spent to feed the hundreds is still sitting in the
+answer, and adding back gives `6,001`, not `5,001`. The child sees the contradiction
+rather than being told.
+
+Two different mal-rules produce two different wrong answers on this one problem, and
+they are not interchangeable. The correct answer is `2,203`. `3,203` is
+borrow-across-zero — it is the correct answer plus exactly the 1,000 that was borrowed
+and never given up, which is what makes the counting board a real contradiction rather
+than an illustration. `3,797` is `mis.add.smaller-from-larger` (`|5−2| |0−7| |0−9|
+|1−8|`); it is not off by a place-value unit at all and its contrast is the number line,
+not the counting board. Binding one rule's LOCATE representation to the other rule's
+output is exactly the mapping error `CG-12` cannot catch, because both rules are
+individually valid and both diverge from the correct answer on ≥95% of seeds.
 
 **Scoped honestly.** There is no generic "make the contradiction self-evident" function:
 fraction addition needs a bar contradiction, magnitude comparison needs a number line. So
 LOCATE is built for the **8–12 mal-rules where a representation is genuinely
 load-bearing and the evidence base is real** — place-value regrouping, fraction addition,
 decimal comparison, division remainder — split by representation family across several
-PRs. Every other mal-rule routes to Stage 3. Gate C-22 enforces that only LOCATE-capable
+PRs. Every other mal-rule routes to Stage 3. Gate CG-22 enforces that only LOCATE-capable
 mal-rules are tagged as such, so Developer Mode and any external claim can be checked
 against the actual count.
 
@@ -176,9 +189,27 @@ difference between a tutor and a treadmill.
 
 ## Persisted state
 
-~60 KB per child in V1, bounded by construction: `SkillState` ~24 B × 160, `BugState`
-~12 B sparse, `FactCard` ~20 B × 180, `LearnerState` <1 KB, `SessionRollup` 64 B × 730
-downsampled, and a 2,000-event FIFO ring at 32 B. **It does not grow with sessions.**
+Bounded by construction, and the sum is stated so the next reader can check it:
+
+```
+SkillState      24 B × 160   =   3,840
+FactCard        20 B × 180   =   3,600
+BugState        12 B ×  64   =     768   sparse, hard cap
+LearnerState                 =   1,024
+SessionRollup   64 B × 180   =  11,520   last 180 days daily, older collapsed monthly
+Event ring      32 B × 512   =  16,384   FIFO, Developer Mode only
+                                -------
+                                 37,136 B  ≈ 36 KiB
+```
+
+**It does not grow with sessions.** Every component is a fixed-size array or a capped
+ring, so the 500-session measurement in `A-15` / `EG-3` reads the same number as the
+5-session one. The ~60 KB of headroom under the 100 KB bound absorbs codec overhead and
+leaves room to widen the ring later without renegotiating the gate.
+
+The first draft budgeted a 2,000-event ring and 730 daily rollups, which totals ~116 KiB
+— it busted its own acceptance bound. The ring and the rollup depth are the two knobs;
+both are capped here, not "downsampled" aspirationally.
 
 All model state is sufficient-statistic-shaped. The event log exists only for Developer
 Mode, the parent report, and future recalibration.
@@ -204,7 +235,7 @@ so the check passed by construction and measured nothing.
 **Corrected:** personas answer from a **3PL with per-child discrimination `a_i` and item
 features the engine cannot observe** (visual load, digit count, working-memory span),
 plus one explicit **misspecification persona** whose true `b` differs from the engine's
-by a structured offset. G-5 then measures robustness, which is what it was supposed to
+by a structured offset. EG-5 then measures robustness, which is what it was supposed to
 do.
 
 **And a real-child anchor before content breadth is bought:** residuals from the M2
@@ -212,9 +243,13 @@ playtest cohort are fitted against predicted `b` and committed as a fixture
 (`T-03`, `A-02`). If that fit is skipped "until there is more content," the engine is
 unvalidated all the way to launch.
 
-**The ten personas:** steady-strong, struggling, fast-careless, slow-accurate,
-**accurate-counter-on**, single-misconception, returning-lapser, pure-guesser,
-rapid-improver, fatiguer — plus the misspecification persona.
+**Eleven personas: ten behavioural plus one misspecification.** The ten behavioural ones
+are steady-strong, struggling, fast-careless, slow-accurate, **accurate-counter-on**,
+single-misconception, returning-lapser, pure-guesser, rapid-improver and fatiguer. The
+eleventh — the misspecification persona — is EG-5's instrument rather than an outcome
+persona: it runs in the calibration set only, so the nightly outcome budget below is ten
+personas, not eleven. `EG-8` in [GATES.md](GATES.md) maps each persona to its acceptance
+item, and says which five have none.
 
 **The synthetic child acquires skill from day one** (`α += 0.08` per spaced success, cap
 +1.5, no same-day credit). Corpán's harness modelled **fixed** ability, which made 3 of
@@ -222,8 +257,9 @@ its 11 ship gates mathematically unsatisfiable under any scheduler and cost two 
 calibration rounds plus a spec amendment to discover.
 
 **Runtime is budgeted.** Corpán's measured harness (25 learners × 180 days × 7 personas)
-takes 315.8 s. Ten personas × 100 children × 3 seeds is 5–12× that — 30–80 minutes. It is
-a **nightly job with a named owner**, never a per-PR check; PRs run a 3-persona ×
+takes 315.8 s. Ten behavioural personas × 100 children × 3 seeds is 5–12× that — 30–80
+minutes, plus the misspecification persona in the EG-5 calibration set. It is a
+**nightly job with a named owner**, never a per-PR check; PRs run a 3-persona ×
 20-learner smoke.
 
 **Every gate is labelled REGRESSION BOUND** (derived from a pilot run) **or PEDAGOGICAL

--- a/dynawalla/docs/ADAPTIVE_LEARNING.md
+++ b/dynawalla/docs/ADAPTIVE_LEARNING.md
@@ -1,0 +1,231 @@
+# Dynawalla — Adaptive learning
+
+The learner model, the scheduler, the invariants, and the harness that is supposed to
+falsify all of it. Scheduling decisions that are irreversible are in
+[ADR-0008](DECISIONS/ADR-0008-fsrs-on-classes-latency-rating.md).
+
+## Three layers
+
+### S — skill proficiency
+
+```
+P    = c + (1 − c)·σ(θ_s − b_item)          c = guess floor: 0 free entry, 1/k choice
+θ_s += U(n_s)·w·(y′ − P)                    U(n) = 0.9 / (1 + 0.06n)
+```
+
+Asymmetric credit (×1.0 correct, ×0.7 incorrect) so one mis-tap never craters a child.
+0.15× residual propagates to direct prerequisites.
+
+### F — fact memory
+
+FSRS-6 over the bounded **~180** enumerable V1 facts (add/sub within 20, the ×/÷
+tables), behind a one-file `Scheduler` seam with a test pinning the 21 default weights so
+a library upgrade fails loudly.
+
+Two things about it are non-obvious and both are load-bearing —
+[ADR-0008](DECISIONS/ADR-0008-fsrs-on-classes-latency-rating.md):
+
+- **Keyed on classes, never instances:** `skill:<id>#L<level>#<formId>`. Generated
+  exercises have no stable id, so per-item keys would mint a new card per instance and
+  silently degenerate spaced review into random practice.
+- **The rating is a function of `(correct, latency)`, not correctness alone.**
+  Fast-correct → Good/Easy; **slow-correct → Hard, with the interval capped**;
+  incorrect → Again. Card creation is gated on `φ_s` crossing a fluency threshold, so
+  facts the child still *computes* stay in the Layer-S fluency-burst pool.
+
+### B — misconception tracker
+
+Per `(skill, bugId)`: `β ← 0.9·β + 1{bug fired}`, active at `β ≥ 2.2`. It never subtracts
+from `θ`; it *gates* mastery and triggers repair.
+
+## Rejected alternatives, with reasons
+
+| Approach | Why not |
+|---|---|
+| BKT | Needs per-skill fitting we cannot do; confirmed semantic degeneracy; over-predicts collapse after a single failure — structurally punitive, which is disqualifying for children. |
+| DKT / SAKT | No corpus; ships a model artifact; cannot answer "why this exercise". |
+| Full IRT calibration | Needs ~200 responses per item. Undefined with zero users and infinitely many generated items. |
+| SM-2 / Leitner | FSRS-6 dominates SM-2 on the open benchmark; Leitner gives no retrievability estimate. |
+| FSRS over everything | Wrong unit. `34 + 29` is computed, not recalled. |
+
+## Cold start
+
+**No placement test.** One grade question seeds `θ_s^0 = b̄_s − 0.4` at or below the
+band and `b̄_s − 2.0` one band above. The first 20 exercises are a scripted-but-adaptive
+ladder inside the fiction (winding the first automaton), never labelled a test, and **no
+card in the first 20 may have `P̂ < 0.55`.**
+
+## Difficulty target
+
+**0.80**, band [0.70, 0.92].
+
+Not 0.85: Wilson's 85% rule is derived for stochastic-gradient binary classifiers and its
+authors scope it there. The closest real prior art (Math Garden — 3,648 children, 3.5M
+problems) samples at 0.75. Corbett & Anderson's 0.95 is a *mastery confidence*, not a
+success target.
+
+**Controller.** `pTarget ← clamp(pTarget + 0.06·fail − 0.015·pass, 0.70, 0.92)`, updated
+**per item**, and the batch is **re-planned on any invariant trip** rather than served to
+completion — otherwise a correction lands one batch late and reads to the child as the
+app randomly getting easy and then hard.
+
+**Batch composition is expressed as offsets from `pTarget`, never absolute `P̂`.** "One
+stretch item" means `pTarget − 0.07`, not a fixed 0.85 that is a stretch at the top clamp
+and a gift at the bottom. This is the boundary conflict the first draft had.
+
+Harness assertion: over any 50-item window, per-item `|ΔpTarget|` stays under bound and
+its sign does not alternate more than N times (`A-09`).
+
+## Scheduler pools
+
+`REPAIR` · `PREREQ` · `DUE_FACT` · `FRONTIER` · `NEW` · `FLUENCY` · `REVIEW_SKILL` ·
+`CHALLENGE` · `PLAY`.
+
+Batches are 8 cards. The child's chamber choice biases the pool toward that instrument's
+mathematics ([ADR-0009](DECISIONS/ADR-0009-stakes-without-loss.md), `P-05`).
+
+**Interleaving:** within any batch of 8, ≤2 consecutive from one skill, ≤3 from one
+operation, ≥3 distinct skills once ≥3 are reachable. **Exception:** a brand-new skill
+gets a blocked debut of 3–4 consecutive guided items.
+
+Interleaved practice *impairs* in-session performance while roughly **doubling**
+next-day test scores. Surface that trade-off in Developer Mode so nobody "fixes" the
+deliberately depressed in-session accuracy.
+
+## Corrective feedback — three stages
+
+**Stage 1 VERIFY** (first error, unclassified). Quiet. A strike mark, the correct answer
+seated beside it, one retry at `b = θ_s − 0.8`. No lecture. Evidence weight 0.5, no
+repair scheduling.
+
+**Stage 2 LOCATE** (mal-rule matched, `β ≥ 2.2`). The mechanism the product is named
+for. If the wrong answer *equals* a computed buggy-procedure output, we know which step
+broke. On `5,001 − 2,798 = 3,797` the response is a **contrast pair** in which the buggy
+procedure produces a visibly absurd answer, with the counting board showing there are no
+thousands left to take from. The child sees the contradiction rather than being told.
+
+**Scoped honestly.** There is no generic "make the contradiction self-evident" function:
+fraction addition needs a bar contradiction, magnitude comparison needs a number line. So
+LOCATE is built for the **8–12 mal-rules where a representation is genuinely
+load-bearing and the evidence base is real** — place-value regrouping, fraction addition,
+decimal comparison, division remainder — split by representation family across several
+PRs. Every other mal-rule routes to Stage 3. Gate C-22 enforces that only LOCATE-capable
+mal-rules are tagged as such, so Developer Mode and any external claim can be checked
+against the actual count.
+
+Repair items are capped at ≤25% of any batch (`A-12`). **Playtested specifically**
+(`T-05`): being handed a second, weirder problem after getting one wrong is a plausible
+way to lose a child.
+
+**Stage 3 RECONSTRUCT** (repeated failure or no match). A **faded worked example** —
+fading reduces extraneous load for novices and the faded step itself increases
+self-explanation, improving near- and far-transfer — then a 1–2 item probe of the weakest
+prerequisite, descending only on further failure. Return to the skill no sooner than 3
+cards later.
+
+## Discriminations most engines get wrong
+
+**Slow-but-correct vs fluent.** `θ_s` = can do it; `φ_s` = does it without counting.
+Low-`φ`/high-`θ` gets **short fluency bursts at `P̂ ≈ 0.90`, never harder problems**, and
+a hard assertion says **no skill promotion is ever denied on latency alone** (`A-05`).
+
+**Slip vs misconception.** Four discriminators: exact mal-rule match; decayed recurrence
+`β`; **self-correction** (revisions > 0 then correct → slip, never a bug increment — the
+cleanest signal available); and latency shape (slips fast `z < 1`, misconceptions
+confident `z ≈ 1`, "no idea" `z > 2`).
+
+**Lucky guess.** The `1/k` floor shrinks credit automatically; a correct-but-implausibly-
+fast choice gets weight 0.3; **choice items can never advance a skill past Practiced**;
+and any correct choice on a not-yet-Practiced skill is followed by a free-entry twin in
+the same session. Past credit is never retro-edited.
+
+## Fatigue as an anti-punitive mechanism
+
+Indicators: rising latency EWMA with accuracy holding; accuracy down ≥20 points versus
+the session's first third; minutes past the child's personal EWMA. **Any two** →
+fatigued → evidence weight 0.5, `pTarget` to 0.90, no new skills, no repair, and a
+stopping point at the next narrative beat.
+
+Assertable: replaying with the post-fatigue window excluded yields an **identical** set of
+skill levels — zero demotions attributable to tiredness (`A-07`).
+
+## Invariants — each a named unit test
+
+Anti-frustration:
+
+- Never re-serve an identical item within 6 cards.
+- Never two consecutive items below `pTarget − 0.20`.
+- Never more than 2 failures in any window of 5 without forcing a `pTarget + 0.10` card.
+- After 3 failures on one skill it is benched for the session.
+- **Never end a session on a failure.**
+- First and last card of every session at `pTarget + 0.10`.
+
+Anti-stagnation:
+
+- Every batch has ≥1 item at `pTarget − 0.07` once one skill is Practiced.
+- If the last 24 items were all easy with accuracy ≥0.95, force a promotion probe.
+- A Mastered skill unfailed for 21 days is **Retired** from normal pools.
+- ≤40% of a rolling 50-item window from any one skill.
+- If 3 sessions pass with `θ` improving <0.3, the scheduler **goes around** and re-queues
+  the stuck skill in a *different representation*.
+
+That second set is not polish. Tripling practice on one problem type (3 → 9 problems) had
+**no effect** on 1-week or 4-week test scores. Without the window cap and the Retired
+state, a child who is good at times tables gets times tables forever — which is the
+difference between a tutor and a treadmill.
+
+## Persisted state
+
+~60 KB per child in V1, bounded by construction: `SkillState` ~24 B × 160, `BugState`
+~12 B sparse, `FactCard` ~20 B × 180, `LearnerState` <1 KB, `SessionRollup` 64 B × 730
+downsampled, and a 2,000-event FIFO ring at 32 B. **It does not grow with sessions.**
+
+All model state is sufficient-statistic-shaped. The event log exists only for Developer
+Mode, the parent report, and future recalibration.
+
+## Developer Mode
+
+Every served card carries an immutable `SelectionTrace` produced by the **same code path
+that made the decision**:
+
+```
+{ cardId, skillId, pool, bTarget, bActual, pHat, pTargetBand, reasons[], rejected[], rngDraws, seed }
+```
+
+Golden-transcript tests assert on traces, so the explanation can never drift from the
+behaviour. Compiled out in production.
+
+## The simulation harness
+
+**It was circular and it has been fixed.** The original reliability gate had the engine
+computing `σ(θ − b)` while the persona answered from `σ(α − b)` against the *same* `b` —
+so the check passed by construction and measured nothing.
+
+**Corrected:** personas answer from a **3PL with per-child discrimination `a_i` and item
+features the engine cannot observe** (visual load, digit count, working-memory span),
+plus one explicit **misspecification persona** whose true `b` differs from the engine's
+by a structured offset. G-5 then measures robustness, which is what it was supposed to
+do.
+
+**And a real-child anchor before content breadth is bought:** residuals from the M2
+playtest cohort are fitted against predicted `b` and committed as a fixture
+(`T-03`, `A-02`). If that fit is skipped "until there is more content," the engine is
+unvalidated all the way to launch.
+
+**The ten personas:** steady-strong, struggling, fast-careless, slow-accurate,
+**accurate-counter-on**, single-misconception, returning-lapser, pure-guesser,
+rapid-improver, fatiguer — plus the misspecification persona.
+
+**The synthetic child acquires skill from day one** (`α += 0.08` per spaced success, cap
++1.5, no same-day credit). Corpán's harness modelled **fixed** ability, which made 3 of
+its 11 ship gates mathematically unsatisfiable under any scheduler and cost two full
+calibration rounds plus a spec amendment to discover.
+
+**Runtime is budgeted.** Corpán's measured harness (25 learners × 180 days × 7 personas)
+takes 315.8 s. Ten personas × 100 children × 3 seeds is 5–12× that — 30–80 minutes. It is
+a **nightly job with a named owner**, never a per-PR check; PRs run a 3-persona ×
+20-learner smoke.
+
+**Every gate is labelled REGRESSION BOUND** (derived from a pilot run) **or PEDAGOGICAL
+ASSERTION** (derived from theory), and "a different marginal leg fails on each seed" is
+reported as a FAIL, not as noise (`A-14`).

--- a/dynawalla/docs/ARCHITECTURE.md
+++ b/dynawalla/docs/ARCHITECTURE.md
@@ -1,0 +1,204 @@
+# Dynawalla — Architecture
+
+Reversible decisions live here. Irreversible ones are ADRs — see
+[DECISIONS.md](DECISIONS.md).
+
+## Placement
+
+`dynawalla/` is a **top-level sibling of `corpan/`**. Every product in this repo is
+already top-level; there is no `apps/` or `packages/`, no npm workspaces and no Cargo
+workspace. Every `ci.yml` area filter is rooted at a top-level path segment, so
+introducing an `apps/` layer would mean rewriting every filter and relocating 5,000+
+Corpán files for no benefit.
+
+```
+encorpora/
+├── AGENTS.md                  # one trunk runbook, both products
+├── native/                    # M3 — product-neutral Rust
+│   ├── plugins/tauri-plugin-{haptics,tts,iap,subscriptions,llm,game-packs,...}
+│   ├── crates/{corpora-crash-breadcrumb, corpora-asr-contract}
+│   └── vendor/{ndk-context, llama-cpp-sys-2}   # dirs move; [patch] does NOT
+├── shared/                    # alias @platform/* — three modules only
+│   ├── kernel/                # rng.ts, clock.ts, boundary.test.ts
+│   ├── i18n-gate/             # check-i18n.mjs, parameterized
+│   └── tooling/               # bump-version.mjs, parameterized
+├── corpan/                    # unchanged
+└── dynawalla/
+    ├── AGENTS.md              # delta only; inherits root AGENTS.md
+    ├── docs/                  # this directory
+    ├── curriculum/            # no React, no DOM — own CI filter
+    │   ├── graph/domains/*.ts · generators/*.ts · malrules/*.ts
+    │   ├── validate/          # C-gates, `dw-curriculum check`
+    │   └── build/compile.ts   # -> dynawalla-app/public/curriculum/*.sqlite3
+    ├── engine/                # pure TS learner model, no IO
+    │   ├── {types,constants,elo,facts,bugs,scheduler,flow,latency}.ts
+    │   ├── boundary.test.ts · sim/  (personas, G-gates)
+    └── dynawalla-app/
+        ├── public/{locales,curriculum}/
+        ├── src/{app,design,number,work,reactions,world,profiles,store}/
+        └── src-tauri/         # OWN workspace root, OWN Cargo.lock, OWN [patch]
+```
+
+`curriculum/` and `engine/` are **siblings of the app, not inside it**: both must be
+importable and testable without building Tauri, and both need their own CI filter so a
+curriculum edit does not rebuild the app.
+
+`native/` and `shared/` stay separate because a Rust change and a TypeScript change have
+different toolchains and different blast radii. One coarse `platform/` filter would run
+cargo on a TypeScript edit.
+
+## Reversible decisions, made
+
+| Concern | Decision |
+|---|---|
+| Frontend | React 19 + Vite + TS + Tailwind 4 — the versions CI already builds |
+| Routing | react-router v7 `createHashRouter` ([ADR-0005](DECISIONS/ADR-0005-shell-and-routing.md)) |
+| State | zustand 5, per-entity persisted stores read at point of use; never prop-drilled |
+| Tests | `node --experimental-strip-types --test`, Node 24 via `.nvmrc` + `engines`. No vitest |
+| Generators | TypeScript, exact integer/rational arithmetic, own seeded PRNG |
+| Curriculum authoring | Typed TS modules compiled to SQLite |
+| Event namespace | `corpora:` prefix, typed dispatcher |
+| Reference devices | Samsung Galaxy Tab A9 SM-X110 (4 GB) · Pixel 6a · iPad 10th gen |
+
+## The eight layers
+
+### L1 — Shell
+One Tauri window, hash router, theme applied synchronously at module load via a store
+subscription toggling one `classList` entry. The design system is built fresh. Exactly
+one mechanical layer is inherited from Corpán's stylesheet: the
+`--safe-{top,right,bottom,left}` `env()` tokens, `--dialog-max-h`, and the `--z-*`
+ladder. Those are platform facts, not taste.
+
+The `<ParentalGate>` component and route guard ship here, in M1
+([ADR-0005](DECISIONS/ADR-0005-shell-and-routing.md)).
+
+**Architectural law: the work surface never waits for the world.** Problem, keypad and
+verdict own input in DOM/CSS; reactions live on one `pointer-events: none` canvas; the
+world is procedural SVG. A static AST test fails the build if anything under
+`src/world/` or `src/reactions/` imports from `src/work/` or `engine/`.
+
+### L2 — Number layer (`src/number/`)
+This layer does not exist anywhere in this repo today: `rg 'Intl\.NumberFormat|toLocaleString'`
+over the Corpán app returns **zero** hits, and zero CLDR plural-category keys exist
+across 55 locale directories.
+
+`NumberFormat` owns the decimal separator, grouping separator, numbering system and
+numeral direction. It drives the keypad glyphs, the slate renderer **and `judge`**, which
+normalizes the locale separator before comparison and accepts `3,5` in fr/de. Gate C-14
+requires every generator's `canonical` and `alsoAccept` to round-trip through
+format→parse in all launch locales. `columnAlgorithm` is forced `dir="ltr"` with an
+explicit test.
+
+It is L2 and it ships in M2 because math notation is content, not chrome. See
+[ADR-0007](DECISIONS/ADR-0007-launch-locales.md).
+
+### L3 — Work surface (`src/work/`)
+Four answer schemas in V1, not eight:
+
+```ts
+type AnswerSchema =
+  | { kind: "integer"; digits: number }
+  | { kind: "columnAlgorithm"; cols: number; marks: "carry" | "borrow" | "none" }
+  | { kind: "fraction"; parts: ("num" | "den" | "whole")[] }
+  | { kind: "choice"; k: 2 | 3 | 4 }
+
+judge(schema, submitted, canonical, alsoAccept, locale): Verdict
+```
+
+`decimal` is a parameterization of `integer` + `NumberFormat`. `orderCards`,
+`plotPoint`, `buildExpression` and the V2 manipulation schemas (`dragPlace`,
+`drawSegment`, `dialRead`, `buildChart`) are V2, each with its own judge branch,
+touch-target model and accessibility story.
+
+`judge` is pure, synchronous and sub-millisecond; persistence happens *after* the verdict
+paints. Input binds `pointerdown` with `touch-action: manipulation`, with ≥2 cm targets
+for grades 1–3.
+
+**No auto-submit keyed off digit count.** A unit test asserts no schema exposes
+`canonical.length` to the input layer, because that silently tells a child how many
+digits the answer has.
+
+**Read-aloud lives in this layer, in M2.** Grade-1 content ships at M4 and a six-year-old
+cannot read the prompts, so read-aloud is an input method, not an accessibility nicety.
+WebView `speechSynthesis` first (free, no plugin), native TTS plugin behind the same seam
+from M3.
+
+### L4 — Reactions (`src/reactions/`)
+See [EXPERIENCE_DESIGN.md](EXPERIENCE_DESIGN.md) for the vocabulary and budgets. The
+architectural contract:
+
+```ts
+interface Reaction { play(): void; settleNow(): void; dispose(): void }
+```
+
+The input handler calls `settleNow()` **synchronously** before processing any event. No
+reaction is ever awaited. Reactions anchor in world space so the world can animate around
+the next problem while the work surface has already moved on.
+
+### L5 — Curriculum
+See [CURRICULUM.md](CURRICULUM.md).
+
+### L6 — Learner model
+See [ADAPTIVE_LEARNING.md](ADAPTIVE_LEARNING.md). Engine purity is enforced by
+`boundary.test.ts` in the **first** engine PR, before any model code.
+
+### L7 — Storage
+Two tiers: `localStorage` for settings that must be read synchronously at module load,
+IndexedDB for the event ring. Both namespaced by `profileId` from the first write
+([ADR-0018](DECISIONS/ADR-0018-multi-child-profiles.md)).
+
+Dynawalla writes its own ~300-line adapter and does **not** adopt Corpán's storage layer.
+With a bundled curriculum, no audio assets, no models and bounded per-child state, the
+`QuotaExceededError` class of failure that justifies Corpán's much larger layer does not
+exist here.
+
+### L8 — Native boundary
+V1 plugin set: **haptics, tts**; iap/subscriptions only if
+[ADR-0013](DECISIONS/ADR-0013-monetization-model.md) requires them. Nothing else — see
+[ADR-0004](DECISIONS/ADR-0004-no-mic-no-llm-no-3d.md).
+
+The Tauri capability surface is narrow from day one: **non-null CSP and per-command
+grants**, not Corpán's single `capabilities/default.json` with every plugin at `:default`
+and `csp: null`. A live app cannot narrow permissions later, so this is creation-time.
+
+## Shared platform
+
+The policy, tightened by adversarial review: **extract only where it deletes lines net,
+today, with both consumers already calling it.** Anything else is three units of work
+(write it in Dynawalla, write it again generically, delete one, re-verify Corpán) plus a
+production risk, for a module with two callers.
+
+**Wave 0 (M0a, blocking): the native CI gate.** Nothing moves until one exists. Today
+there is zero `cargo`/`clippy`/`rustup` invocation in any required check;
+`corpan/plugins/**` matches none of the area filters; the only cargo in PR CI is a
+non-required workflow with workflow-level `paths:` and no `merge_group:`.
+
+**Wave 1 (M3): `native/`.** The plugin directory move, the vendor directory move (with
+`[patch]` staying put — [ADR-0011](DECISIONS/ADR-0011-native-workspace-and-patch-placement.md)),
+a new `corpora-crash-breadcrumb` crate, a generated `.cargo/config.toml`, and the
+hygiene items.
+
+**Wave 2 (M1–M2): `shared/`, three TypeScript modules and no more.**
+
+| Module | Contents | Corpán cost | When |
+|---|---|---|---|
+| `shared/kernel/` | `rng.ts` (FNV-1a + mulberry32, pinned known-answer vectors), `clock.ts`, `boundary.test.ts` | ~3 import lines, migrated in the same PR | M2 |
+| `shared/i18n-gate/` | `check-i18n.mjs` parameterized by locale root and reference locale; preserves the existing checks and **adds CLDR plural-category checking** | 1 line | M1 |
+| `shared/tooling/` | `bump-version.mjs` parameterized by app dir; keeps package.json / tauri.conf.json / Cargo.toml / Cargo.lock in lockstep and exits nonzero rather than no-op | 1 line | M1 |
+
+Consumption is a build-time source alias `@platform/*` → `shared/*`, matching the
+existing `@shared/*` precedent in the Corpán app's tsconfig and vite config. The old
+alias is untouched.
+
+**Moved to share-later**, on the "does it delete lines today" test: `shared/feel`
+(Dynawalla's reaction layer is built in M2 and the picker's streak coupling means it must
+diverge anyway), `shared/storage` (no quota problem here), `shared/net-cache` and
+`shared/pack-install` (moot — [ADR-0003](DECISIONS/ADR-0003-no-downloadable-packs-v1.md)),
+and the Corpán pack runtime (~2,900 lines inside `corpan_lib` reached through eight Tauri
+commands, with `corpan-pack://` URLs baked into installed packs' JS on user devices —
+real surgery, not a move).
+
+**Kept separate permanently:** Corpán's corpus/SQLite layer and Django CMS, the TTS
+voice-picker machinery, the Journey exercise renderers and its strand/CEFR/phonology
+model, the onboarding draft flow, `hostApi.ts`, `tauri-plugin-stt`,
+`tauri-plugin-radio-stream`, and `corpan/corpan-app/AGENTS.md`.

--- a/dynawalla/docs/ARCHITECTURE.md
+++ b/dynawalla/docs/ARCHITECTURE.md
@@ -84,7 +84,7 @@ across 55 locale directories.
 
 `NumberFormat` owns the decimal separator, grouping separator, numbering system and
 numeral direction. It drives the keypad glyphs, the slate renderer **and `judge`**, which
-normalizes the locale separator before comparison and accepts `3,5` in fr/de. Gate C-14
+normalizes the locale separator before comparison and accepts `3,5` in fr/de. Gate CG-14
 requires every generator's `canonical` and `alsoAccept` to round-trip through
 format→parse in all launch locales. `columnAlgorithm` is forced `dir="ltr"` with an
 explicit test.
@@ -158,8 +158,11 @@ V1 plugin set: **haptics, tts**; iap/subscriptions only if
 [ADR-0004](DECISIONS/ADR-0004-no-mic-no-llm-no-3d.md).
 
 The Tauri capability surface is narrow from day one: **non-null CSP and per-command
-grants**, not Corpán's single `capabilities/default.json` with every plugin at `:default`
-and `csp: null`. A live app cannot narrow permissions later, so this is creation-time.
+grants**, not Corpán's single `capabilities/default.json` with almost every plugin at
+`:default` and `csp: null` — 11 of its 14 grants are `:default`; only
+`clipboard-manager:allow-write-text`, `tts:allow-speak` and
+`subscriptions:allow-show-manage-subscriptions` name a command. A live app cannot narrow
+permissions later, so this is creation-time.
 
 ## Shared platform
 

--- a/dynawalla/docs/CURRICULUM.md
+++ b/dynawalla/docs/CURRICULUM.md
@@ -99,7 +99,7 @@ b = b_skill
 ```
 
 with every coefficient in one `constants.ts`. That is why no item-calibration corpus is
-needed — and it is falsifiable, which is what gate **G-5** exists to do. See
+needed — and it is falsifiable, which is what gate **EG-5** exists to do. See
 [ADAPTIVE_LEARNING.md](ADAPTIVE_LEARNING.md).
 
 ## The 18 V1 generator families
@@ -135,7 +135,7 @@ differ irreducibly across these groups.
 ## Word problems are locale content, not translation
 
 `contextTheme` is a **locale-scoped asset**: per-locale name pools, object pools,
-currency and unit sets, **authored** by whoever owns that locale. Gate C-21 requires
+currency and unit sets, **authored** by whoever owns that locale. Gate CG-21 requires
 every active word-problem family to have a populated context set in all launch locales.
 The CCSS compare phrasings ("how many more", "how many fewer") do not map one-to-one
 across languages and are reviewed by a native speaker per locale before those families
@@ -155,8 +155,11 @@ The evidence base: Brown & Burton's BUGGY work found 39% of 1,300 students showe
 consistent buggy behaviour on place-value subtraction; recent catalogues encode ~101
 mal-rules across ~498 templates.
 
-V1 concentrates where the evidence is genuinely deep: `mis.add.smaller-from-larger`,
-`mis.add.borrow-across-zero` (602 − 437 = 265), `mis.add.misaligned-columns`,
+V1 concentrates where the evidence is genuinely deep:
+`mis.add.smaller-from-larger` (5,001 − 2,798 = 3,797 — the smaller digit taken from the
+larger in every column),
+`mis.add.borrow-across-zero` (602 − 437 = 265, and 5,001 − 2,798 = 3,203 — regrouped all
+the way down, never decremented the leading digit), `mis.add.misaligned-columns`,
 `mis.add.carry-dropped`, `mis.mul.makes-bigger`, `mis.mul.partial-product-misaligned`,
 `mis.div.divisor-must-be-smaller`, `mis.div.remainder-dropped`,
 `mis.frac.add-numerators-and-denominators`,
@@ -189,15 +192,22 @@ probability with an invented mechanism.
 
 ## Staging
 
-| Stage | Milestone | Content |
-|---|---|---|
-| V1.0 | M4 | Grade 1–2 spine: `ns` + `add` + `alg` equality, ~62 skills / 8 families |
-| V1.1 | M7 | Grade 3–4: `mul` + `div`, +58 skills / +6 families |
-| V1.2 | M7 | Fractions and grade-5 depth, +40 skills / +4 families |
+| Stage | Milestone | Content | Families |
+|---|---|---|---|
+| V1.0 | M4 | Grade 1–2 spine: `ns` + `add` + `alg` equality, ~62 skills | 7 — `column-op`, `fact-recall`, `mental-strategy`, `missing-operand`, `place-value-decompose`, `compare-order`, `numberline-locate` |
+| V1.1 | M7 | Grade 3–4: `mul` + `div`, +58 skills | +7 — `multidigit-mul`, `long-div`, `round-estimate`, `factor-multiple`, both word families, `gen.logic.error-analysis` |
+| V1.2 | M7 | Fractions and grade-5 depth, +40 skills | +4 — `frac.partition-model`, `frac.equivalence-simplify`, `frac.arith`, `frac.convert` |
+
+7 + 7 + 4 = **18**, which is the number in [ADR-0002](DECISIONS/ADR-0002-v1-scope-cut.md)
+and the number of family PRs in [MASTER_PLAN.md](MASTER_PLAN.md) (`column-op` ships early,
+at M2, and is bound at M4 with the rest of the spine). A family is *bound* at the
+milestone that implements its generator; individual nodes go `active` in the domain
+promotion PRs, which is why M4 binds seven families but activates ~62 skills rather than
+all of their levels.
 
 ## Validator runtime
 
-C-9/10/11/12 over 160 skills × 4 levels × 1,000 seeds is roughly 640k `generate()`
+CG-9/10/11/12 over 160 skills × 4 levels × 1,000 seeds is roughly 640k `generate()`
 calls — far too slow per PR. **Incremental mode** (diff-scoped, reusing the `changes`
 job pattern) runs on PR; a **nightly full sweep** with a named owner runs the whole
 graph. Both from day one, not retrofitted when it gets slow.

--- a/dynawalla/docs/CURRICULUM.md
+++ b/dynawalla/docs/CURRICULUM.md
@@ -1,0 +1,215 @@
+# Dynawalla — Curriculum
+
+Authoring model and immutability rules: [ADR-0006](DECISIONS/ADR-0006-typed-ts-curriculum-exact-arithmetic.md).
+Scope cut and why: [ADR-0002](DECISIONS/ADR-0002-v1-scope-cut.md).
+The gates that enforce all of this: [GATES.md](GATES.md).
+
+## V1 shape
+
+**6 domains · ~160 active skills · 18 generator families · ~28 executable mal-rules ·
+4 answer schemas · 4 representations.**
+
+| Domain | id | V1 skills | Grades |
+|---|---|---|---|
+| Number sense and place value | `ns` | 34 | 1–5 |
+| Addition and subtraction | `add` | 32 | 1–4 |
+| Multiplication | `mul` | 26 | 2–5 |
+| Division | `div` | 22 | 3–5 |
+| Fractions | `frac` | 32 | 2–5 |
+| Equality and early algebra | `alg` | 14 | **1**–5 |
+
+Cut to V2 and named in the non-goals list: geometry and spatial, measurement, data and
+probability, ratios and rates, integers, decimals-as-a-domain, grade 6, formal
+pre-algebra.
+
+**`alg` starts at grade 1.** On `8 + 4 = ☐ + 5`, roughly 5% of grade 1–2 children answer
+7; in one sample *all 145 sixth graders* answered 12 or 17; equal-sign knowledge at
+second grade predicts fourth-grade algebra competence.
+`dw.alg.equality.balance-meaning` is a grade-1 node and the balance scale is one of the
+four V1 representations.
+
+**Fractions are prioritized ahead of any breadth elsewhere.** Elementary fraction and
+division knowledge uniquely predicts high-school algebra achievement 5–6 years later,
+controlling for IQ, working memory and family income, replicated in US and UK
+longitudinal samples.
+
+## Node identity
+
+Ids are `dw.<domain>.<cluster>.<slug>`, matching
+`^dw\.[a-z0-9-]+\.[a-z0-9-]+\.[a-z0-9-]+$`, and are **immutable forever** — they are
+mastery keys on learner devices. A rename means minting a new id and setting
+`status: "deprecated"` + `supersededBy` on the old one, which stays hidden from
+scheduling.
+
+**Grade is not in the id.** It is `gradeBand { earliest, nominal, latest }`, because
+Singapore teaches fraction-of-a-whole at P2, CCSS starts fractions at grade 3, and
+England mandates 12×12 tables by Y4. All three frameworks agree on the spine and
+disagree on timing by 1–2 years, so **progression gates on prerequisites, never on
+grade.**
+
+**Difficulty is not in the id.** It is a per-level generator parameter.
+
+`SkillNode` carries: `rev`, `status`, `title`/`learnerGoal` as locale keys (never
+English literals), `domain`, `cluster`, `bigIdeas`, `gradeBand`, `strandRole`, an NRC
+`proficiency` 4-tuple, `classification`, `fluencyTarget?`, `prereqs: Edge[]`,
+`difficulty { b, levels }`, `misconceptions`, `contrastsWith?`,
+`representations { required, optional }`,
+`generator { family, familyRev, params, forms, minVariants, consumes }`, `probes`,
+`provides: CapabilityTag[]`, and `standards? { ccss, sg, uk }` **as codes only**.
+
+Edges are `requires` / `extends` / `supports` / `contrasts`.
+
+## Exercise contract — three non-negotiables
+
+```ts
+Exercise {
+  exerciseId: `${family}@${familyRev}:${skillId}:L${level}:${seed}`
+  skillId, level, seed
+  prompt: PromptSpec          // { key: LocKey, slots } — NEVER a rendered string
+  representation?: RepSpec
+  answer: { canonical, alsoAccept }
+  distractors: { value, misconception? }[]
+  check: { kind, tolerance? }
+  solution: SolutionStep[]
+}
+```
+
+1. **Exact rational arithmetic only.** No IEEE floats in any generator or checker.
+   `0.1 + 0.2 !== 0.3` produces deterministically wrong decimal answers that no
+   flaky-test detector will ever surface. A lint bans bare float ops in `curriculum/` and
+   `engine/`.
+2. **Seeded, pure and platform-stable.** Own PRNG, never `Math.random`, byte-identical
+   on x86 and arm64, no `Intl` inside generation, no key-order assumptions.
+3. **Structured prompts, never strings.** One template key translated once serves every
+   seeded instance forever, so localization cost scales with template count rather than
+   content volume.
+
+## Difficulty
+
+`b` is a **pure function of generator parameters**, e.g.
+
+```
+b = b_skill
+  + 0.55·regroupings
+  + 0.30·(maxDigits − 2)
+  + 0.25·zeroBorrowThrough
+  + 0.20·noAnchor
+  − 0.35·specialCase
+  + repOffset + formOffset
+```
+
+with every coefficient in one `constants.ts`. That is why no item-calibration corpus is
+needed — and it is falsifiable, which is what gate **G-5** exists to do. See
+[ADAPTIVE_LEARNING.md](ADAPTIVE_LEARNING.md).
+
+## The 18 V1 generator families
+
+**Arithmetic core (6):** `gen.arith.column-op` (12 skills), `fact-recall` (10),
+`mental-strategy` (8), `multidigit-mul` (7), `long-div` (7), `missing-operand` (9).
+
+**Number (5):** `place-value-decompose` (12), `compare-order` (14 — one family over
+whole/fraction/decimal via a `numberType` param), `numberline-locate` (10),
+`round-estimate` (7), `factor-multiple` (8).
+
+**Rational (4):** `frac.partition-model` (10), `frac.equivalence-simplify` (9),
+`frac.arith` (13), `frac.convert` (7).
+
+**Word problems (2):** `gen.word.additive-situation`, parameterized by the 12 cells of
+the CCSS Glossary Table 1 matrix (Add-To / Take-From / Put-Together / Compare ×
+Result / Change / Start) crossed with `unknownPosition`, `comparePhrasing`,
+`numberRange` and `contextTheme`; and `gen.word.multiplicative-situation` (3 situation
+types × 3 unknowns).
+
+**Cross-cutting (1, owns zero skills):** `gen.logic.error-analysis`, driven by the
+mal-rule table — every mal-rule becomes "here is the apprentice's work, find the mistake"
+content for free, and it teaches the meta-skill of checking work. Built in V1.
+
+(`gen.logic.odd-one-out`, driven by `contrasts` edges, is V2 with the domains that make
+it interesting.)
+
+Not 60 families, because difficulty is *parameters*: `column-op` with
+`{ op, digits, regroupPositions, acrossZero, decimalPlaces }` covers 2-digit addition
+through decimal subtraction. Not 6, because the interaction form and the answer checker
+differ irreducibly across these groups.
+
+## Word problems are locale content, not translation
+
+`contextTheme` is a **locale-scoped asset**: per-locale name pools, object pools,
+currency and unit sets, **authored** by whoever owns that locale. Gate C-21 requires
+every active word-problem family to have a populated context set in all launch locales.
+The CCSS compare phrasings ("how many more", "how many fewer") do not map one-to-one
+across languages and are reviewed by a native speaker per locale before those families
+go `active`.
+
+## Mal-rules — executable, triple-duty
+
+A mal-rule is a pure `(exercise) => AnswerValue | null` reproducing a documented buggy
+procedure. One function gives three things:
+
+- **principled distractors** (a wrong answer a real child would actually produce),
+- **diagnosis** — if the child's answer *equals* the mal-rule output, you know *which*
+  bug fired,
+- **error-analysis content**, free, via `gen.logic.error-analysis`.
+
+The evidence base: Brown & Burton's BUGGY work found 39% of 1,300 students showed
+consistent buggy behaviour on place-value subtraction; recent catalogues encode ~101
+mal-rules across ~498 templates.
+
+V1 concentrates where the evidence is genuinely deep: `mis.add.smaller-from-larger`,
+`mis.add.borrow-across-zero` (602 − 437 = 265), `mis.add.misaligned-columns`,
+`mis.add.carry-dropped`, `mis.mul.makes-bigger`, `mis.mul.partial-product-misaligned`,
+`mis.div.divisor-must-be-smaller`, `mis.div.remainder-dropped`,
+`mis.frac.add-numerators-and-denominators`,
+`mis.frac.larger-denominator-larger-fraction` (both children of one
+`whole-number-bias` parent so remediation routes together),
+`mis.frac.mixed-number-concatenation`, `mis.alg.equals-as-operator`,
+`mis.ns.place-value-digit-reversal`, plus ~15 more.
+
+**Safety rule: mal-rule labels are internal.** Learner-facing feedback names the *correct
+idea*, never the child's defect. A lint enforces it (`M-16`).
+
+**Honesty rule:** the catalogue is deep for multi-digit subtraction, decent for the
+multiplication and division algorithms, and thin for fractions and word problems. Where
+it is thin, default to "unclassified error" and a faded worked example. **Never invent a
+bug**, and never promise "we always tell you where your thinking broke."
+
+## Representations — four in V1
+
+| Representation | Carries |
+|---|---|
+| Counting board / abacus | Place value and regrouping. This is the LOCATE representation for borrow-across-zero. |
+| Balance scale | The equals sign as a **relation**, not an operator. |
+| Gear train | Multiples, factors, LCM. |
+| Number line / bar model | Magnitude, fractions, comparison. |
+
+The astrolabe, water clock, girih tessellation and market weights remain **world
+architecture** in V1 and become math representations in V2 with geometry and
+measurement. That is how the fiction stays honest instead of being stretched to cover
+probability with an invented mechanism.
+
+## Staging
+
+| Stage | Milestone | Content |
+|---|---|---|
+| V1.0 | M4 | Grade 1–2 spine: `ns` + `add` + `alg` equality, ~62 skills / 8 families |
+| V1.1 | M7 | Grade 3–4: `mul` + `div`, +58 skills / +6 families |
+| V1.2 | M7 | Fractions and grade-5 depth, +40 skills / +4 families |
+
+## Validator runtime
+
+C-9/10/11/12 over 160 skills × 4 levels × 1,000 seeds is roughly 640k `generate()`
+calls — far too slow per PR. **Incremental mode** (diff-scoped, reusing the `changes`
+job pattern) runs on PR; a **nightly full sweep** with a named owner runs the whole
+graph. Both from day one, not retrofitted when it gets slow.
+
+## Legal
+
+Titles and descriptions are **authored originally**; standards are stored as **codes
+only**. CCSS text is copyrighted by the NGA Center and CCSSO under a license limited to
+purposes supporting the Initiative and requiring a specific notice, and this repository
+is public. Codes are short factual identifiers. A public *alignment claim* is a separate
+exposure — [ADR-0010](DECISIONS/ADR-0010-standards-alignment-claim.md).
+
+`030-grade3/` and `math-foundations-02-grade/` in this repo may be mined once as a naming
+and coverage seed, then the dependency dropped. They are book prose, not a graph, and
+must never become a second source of truth.

--- a/dynawalla/docs/EXPERIENCE_DESIGN.md
+++ b/dynawalla/docs/EXPERIENCE_DESIGN.md
@@ -1,0 +1,180 @@
+# Dynawalla — Experience design
+
+The stakes model is [ADR-0009](DECISIONS/ADR-0009-stakes-without-loss.md). The ethics
+list is in [MISSION.md](MISSION.md) and is not restated here.
+
+## The core loop, in milliseconds
+
+**Law: the work surface never waits for the world.**
+
+| Moment | Budget | What happens |
+|---|---|---|
+| `T−N` idle | ≤50 ms per chunk | The generator produces problems N+1 and N+2 into an on-deck buffer inside `requestIdleCallback`. If any single `generate()` exceeds 4 ms measured, **move generation to a Worker** — do not optimise in place. |
+| `T=0` PRESENT | 180 ms | The next problem is already in the DOM at `opacity: 0; translateY(8px)`; compositor-only transition. **No layout, no text measurement** — numerals sit on a fixed tabular grid so a 4-digit problem does not reflow after a 1-digit one. |
+| `T=0→C` COMPREHENSION | not budgeted | The child's time. Measured, never limited. `timeToFirstKeyMs` and `timeToCommitMs` are recorded **separately** — long first-key is retrieval difficulty, long key-to-commit is execution difficulty. Corpán conflates them into one `latencyMs`; we will not. |
+| every KEYPRESS | 0→16 ms visual, ≤50 ms handler | Bound on `pointerdown`. |
+| COMMIT → JUDGEMENT | <1 ms | Synchronous and pure. Persistence happens *after* the verdict paints. |
+| +≤16 ms FIRST FEEDBACK FRAME | one frame | Correct: glyphs seat into the carved recess with a cold celestial highlight. Incorrect: a chiselled strike mark, copper-oxide tone. **This frame is the whole product** and it depends on no world animation succeeding. |
+| +≤220 ms SEAT | 200 ms | One detent click, one gear tooth, a `light` haptic, no particles — then 120 ms of earned stillness. The next problem presents concurrently with the reaction tail. |
+
+**Cadence targets**, instrumented p50/p90 and never shown to the child: single-digit fact
+2.8 s / 6 s; two-digit with regrouping 6 s / 14 s; the `5,001 − 2,798` class 16 s / 40 s.
+**Machine-side contribution <120 ms** in every case (`Q-01`).
+
+**Never on the answer path:** network, IndexedDB read, font load, image decode, model
+load, or `await` of anything.
+
+## Reaction vocabulary
+
+| Tier | Name | Budget |
+|---|---|---|
+| −1 | SLIP | 260 ms |
+| 0 | SEAT | 200 ms |
+| 1 | ENGAGE | 450 ms |
+| 2 | ILLUMINATE | 900 ms |
+| 3 | MECHANISM | 1800 ms — once per session, always skippable |
+
+Effects are drawn by an energy-weighted, non-repeating, eligibility-gated picker.
+
+**Escalation is on difficulty and repair, never run length.** The reaction registry being
+ported from Corpán escalates on `comboCount` via a combo-momentum function — exactly the
+loop this product bans. Dynawalla scales tier on **`(b_item − θ_s)`** (harder problems
+earn more) plus a dedicated tier-2 for **repairing a mal-rule you used to fire**. A unit
+test asserts the weight function's signature takes no run-length or streak argument.
+
+**Two more invariants, both unit tests:**
+
+- `energy(SLIP) < energy(SEAT)`, where energy = budgetMs × particles × peakGain ×
+  animatedElements. Being wrong must not be more interesting than being right.
+- Nothing awaits a reaction. `settleNow()` is called synchronously by the input handler
+  before any event is processed, and completes within 90 ms (`Q-04`).
+
+**Reduced motion is a branch**, not a degradation: a 200 ms opacity cross-fade with zero
+travel and no particles, verified in a test **and** in the committed screenshot set
+(`Q-06`).
+
+**Audio** is asset-free Web Audio: a struck felt-mallet timbre (sine + a 0.22-gain
+triangle octave) over a C5–C6 pentatonic. Chimes are **dropped, never queued**, when
+speech is active.
+
+**Haptics** go through the native plugin — `navigator.vibrate` does not exist in iOS
+WKWebView, so a WebView-only implementation silently does nothing on iPhone (`X-08`).
+
+## Juice dose is a hard ceiling
+
+In the largest study to date (N = 3,018), **both** None and Extreme juiciness
+significantly decreased play time, player experience, intrinsic motivation and
+performance versus Medium/High. A 2024 decomposition found that the
+*success-dependence* of feedback enhanced all motives while raw amplification reduced
+them.
+
+Feedback must be **contingent, not loud**. The vocabulary is mechanical, not confetti:
+gears engaging, counterweights rising, tesserae illuminating, a water clock advancing, an
+automaton's eyebrow.
+
+`energy(SLIP) < energy(SEAT)` is a proxy a determined designer can satisfy while still
+making failure the interesting moment — a catapult falling short is inherently more
+animated than a gear ticking. So it is **playtested specifically** (`T-01`), not just
+unit-tested.
+
+## Construction
+
+Progress is a **building, not a flame with a number**. Every correct answer places
+something real — a tessera, a gear tooth, a course of brick. **Construction never
+regresses** (`P-04`): the child-safe version of loss aversion. The pull to return is "my
+observatory is unfinished," not "my streak is at risk."
+
+Technically procedural SVG, with completed chambers rasterized to snapshots. **That
+rasterization is load-bearing from the first build, not an optimisation.** A hard cap of
+~1,200 live SVG nodes with a failing perf test above it lands **before any art PR**,
+because girih at 500+ answers becomes tens of thousands of nodes and will stall a
+mid-range Android WebView (`Q-02`).
+
+## The character — combinatorial, and rare
+
+Twenty-one authored lines against 200–400 items per session is one line per 10–20
+problems, repeating from minute six. The in-repo precedent for that architecture resolves
+to "Perfect / Nice / Brilliant / Boom / Nailed it" — the exact generic cheerleader this
+product forbids. Both fixes are taken.
+
+**A grammar, not a line list.** ~8 observation types (got faster on X · fixed an error
+you used to make · chose the harder route · first time on X · returned after N days ·
+built the mechanism correctly · finished a chamber · noticed a pattern) × slotted
+skill/instrument nouns × 3–4 phrasings ≈ 100 authored fragments, yielding thousands of
+**true, specific** utterances at a bounded localization bill (`P-06`, `P-07`).
+
+**Rarity as register.** The Dynawalla speaks **3–5 times per session**, at genuine
+milestones. Silence is the personality. An automaton apprentice-master: ancient,
+precise, dryly amused, never saccharine. It never says "Great job!" It says the specific
+true thing.
+
+Voice acting is deferred — TTS in a dry-ironic register is currently poor, and a
+mis-delivered dry line reads as broken rather than laconic.
+
+## Art direction
+
+Ancient-futurist, sourced specifically: al-Jazari's 1206 *Book of Knowledge of Ingenious
+Mechanical Devices* (50 machines he actually built; he introduced the camshaft) and the
+Banū Mūsā's 9th-century *Book of Ingenious Devices*. Brass, lapis, carved stone, cold
+celestial light. Girih strapwork as **structure**, not wallpaper. 2D throughout.
+
+### Hostile reference board — what it must NOT look like
+
+This list exists because "brass and lapis with procedural girih" is precisely the recipe
+that renders as a gradient dashboard with gear icons, and code review cannot see the
+difference. Every item here is a failure mode to check the screenshots against:
+
+- **A SaaS dashboard.** Cards with drop shadows on a neutral background, a stat row, a
+  progress ring, an accent colour used for "primary action". If a stranger says
+  "dashboard," the gate has failed (`Q-14`).
+- **A template.** Symmetrical three-column layout, evenly-spaced rounded rectangles,
+  stock-icon set, a hero band at the top.
+- **Steampunk.** Goggles, top hats, riveted copper plating, brass-for-brass's-sake.
+  Gears must *do something* — a gear that does not turn a thing is decoration and is
+  banned.
+- **Gradient soup.** Purple-to-teal backgrounds, glassmorphism, neon glow. The palette is
+  material, not lighting effects.
+- **Confetti and starbursts.** Any particle vocabulary borrowed from a casual mobile
+  game.
+- **Emoji or cartoon mascots.** The character is an automaton, drawn in the same material
+  language as the instruments.
+- **Duolingo-adjacent.** Rounded sans-serif everything, a bouncing character, a streak
+  flame, a green tick with a swoosh.
+- **AI-generated "ancient" texture.** Wood-grain-and-parchment noise layers standing in
+  for structure.
+
+### The rendered-output gate
+
+Code review cannot see that the observatory looks wrong. The repo already has a
+device-pixel capture pipeline (`corpan/scripts/dev/ipad/screenshot.py` plus its CDP
+driver) that the first draft of this plan never noticed.
+
+M6 adds a deterministic seed set capturing the world at 0 / 50 / 200 / 500 placed
+elements plus all five reaction tiers, at 320 px / 768 px / iPad, light and dark,
+reduced-motion on and off. **The PNGs are committed and the images are reviewed in the
+PR, not the code.** A named human art director signs off on those images as an exit
+criterion.
+
+The M6 stranger test: three strangers shown **only** the screenshots, unprompted, do not
+use the word "dashboard" or the word "template."
+
+## Agency, stakes, and stopping
+
+Fully specified in [ADR-0009](DECISIONS/ADR-0009-stakes-without-loss.md). In summary: the
+child chooses which chamber to build and that choice biases the scheduler; a completed
+chamber's instrument actually operates and only correctly if built correctly; parts are
+revealed by depth rather than gated by scarcity.
+
+Designed stopping points offer **equal-weight** "Done" and "Keep going" (`P-10`). A
+returning child after 30 days sees a restoration beat, not a punishment beat (`P-08`).
+
+## The comparison that defines the target
+
+The negative example is Prodigy: an FTC complaint alleging manipulative upselling to
+children, with reviewers logging 16 membership ads in a 19-minute session. The positive
+one is XtraMath — real spaced retrieval, ESSA Tier IV evidence — whose fair criticism is
+that it "does not teach mathematical concepts or problem-solving."
+
+**That criticism is the gap this product exists to fill**, which is why M2 must test
+*that gap* and not juice-on-drill. An M2 that is merely fun proves nothing: juice on
+drill is a solved, commoditized thing.

--- a/dynawalla/docs/GATES.md
+++ b/dynawalla/docs/GATES.md
@@ -1,0 +1,129 @@
+# Dynawalla — Gates
+
+Two families of automated gate. **C-series** validate the curriculum, its generators and
+its renderers. **G-series** validate the engine against simulated and real learners.
+
+The first draft's table had one identifier naming two different gates, four identifiers
+naming nothing, and three defined gates with no implementing PR. This table is the
+corrected one: **C-1..C-22 with no holes, one owning PR each, and a failing-case test per
+gate.** `M-13` asserts none is orphaned.
+
+Published before M4's first curriculum PR.
+
+---
+
+## C-series — curriculum
+
+| Gate | What it checks | Owner PR |
+|---|---|---|
+| **C-1** | Id hygiene and immutability — no shipped `active` id removed or re-pointed | PR-4.2 |
+| **C-2** | Acyclic `requires ∪ extends`, by Kahn topological sort, **printing the actual cycle** | PR-4.2 |
+| **C-3** | Edge integrity — targets exist, edge kinds valid | PR-4.2 |
+| **C-4** | Two-way reachability — unreachable node = error, dead-end = warn | PR-4.2 |
+| **C-5** | Grade sanity — `prereq.nominal ≤ node.nominal` | PR-4.2 |
+| **C-6** | **Capability flow** — `provides` on skills, `consumes` on bindings; the only mechanically sound *missing-edge* detector, and it suggests the edge | PR-4.5 |
+| **C-7** | **Bidirectional generator ownership** — merge blocker | PR-4.3 |
+| **C-8** | **Renderer ownership** — merge blocker | PR-4.4 |
+| **C-9** | Level coverage by **running** generators over N seeds, ≥`minVariants` distinct | PR-4.6 |
+| **C-10** | Variant-space adequacy — <2% duplicates over 1,000 draws | PR-4.6 |
+| **C-11** | Self-consistency — the family's own checker accepts `canonical` and every `alsoAccept`, and rejects every distractor, over 1,000 seeds | PR-4.6 |
+| **C-12** | Mal-rule fidelity — ≥95% divergence from the correct answer | PR-8.1 |
+| **C-13** | **Choice-laundering ban** — no `conceptual`/`reasoning` skill binds a choice-only generator | PR-4.4 |
+| **C-14** | **Locale round-trip** — every `canonical`/`alsoAccept` survives format→parse in all launch locales; every count slot declares its CLDR plural set | PR-4.7 |
+| **C-15** | Grade-band coverage matrix (grade × domain) — empty cell is an error at release, a warning in draft | PR-7.24 |
+| **C-16** | Determinism + committed output-hash snapshots on **macOS and Linux**; changed output without a `familyRev` bump is an error | PR-4.6 |
+| **C-17** | Performance — `generate()` p95 <5 ms, p99 <20 ms | PR-4.6 |
+| **C-18** | **Accessibility** — every representation has a text alternative; nothing solvable by colour alone | PR-4.4 |
+| **C-19** | i18n completeness, plus a lint that no `Exercise.prompt` is a bare string | PR-4.7 |
+| **C-20** | Standards traceback — **report-only, never blocking** | PR-7.24 |
+| **C-21** | Word-problem context sets populated per locale for every active word family | PR-7.23 |
+| **C-22** | **LOCATE capability** — a mal-rule may be tagged LOCATE-capable only if it has a bound contrast representation | PR-8.3 |
+
+### The four that carry the most weight
+
+**C-7 — generator ownership.** A curriculum row without a working generator cannot reach
+`status: active`. Draft nodes are allowed but are excluded from the shipped graph and
+from all coverage math. Without this, the graph becomes a wish list.
+
+**C-8 — renderer ownership.** A skill cannot go `active` unless its generator's
+`AnswerSchema` kind **and every `representations.required` RepId** has a registered,
+tested renderer. This is the gate the first draft was missing entirely: a generator can
+emit a perfectly valid `Exercise` that the app cannot draw.
+
+**C-13 — choice-laundering ban.** C-7 and C-8 are both trivially satisfiable by making
+everything multiple choice. C-13 is what stops "Which of these is a line of symmetry?
+A B C D" from counting as geometry coverage. It is the mechanical form of
+[ADR-0002](DECISIONS/ADR-0002-v1-scope-cut.md) and without it the scope cut is a
+promise rather than a constraint.
+
+**C-16 — determinism.** Generators run in a WebView on iOS, Android and desktop. Any
+`Math.random`, any `Intl` inside generation, or any key-order assumption produces
+different exercises per device and makes a bug report irreproducible. Snapshots are
+committed and checked on both runners. Note the residual: C-16 does not run in a real
+Android WebView, so a device spot-check belongs in the M7 device pass.
+
+### Failing-case tests
+
+Every gate ships with a test that **deliberately violates it** and asserts the gate goes
+red. A gate with no failing-case test is indistinguishable from a gate that silently
+passes everything, and this program has an in-repo precedent for exactly that failure
+mode (the pack-shared directory that sets a filter true and is then skipped by the job
+that consumes it).
+
+### Runtime and where each gate runs
+
+C-9/10/11/12 over 160 skills × 4 levels × 1,000 seeds is roughly 640k `generate()` calls
+— far too slow to run per PR.
+
+| Mode | Scope | Where |
+|---|---|---|
+| **Incremental** | Diff-scoped: only the families and nodes the PR touches, plus their dependents | `dynawalla-curriculum` job in `ci-gate.needs`, on `pull_request` and `merge_group`. Must complete in <90 s (`C-20` acceptance item). |
+| **Full sweep** | The entire graph, all gates | Nightly, with a **named owner** who is paged on failure. |
+
+Both from day one. Retrofitting incremental mode after the graph is large is how a
+validator becomes a thing people skip.
+
+---
+
+## G-series — engine
+
+Run by the simulation harness. See [ADAPTIVE_LEARNING.md](ADAPTIVE_LEARNING.md).
+
+| Gate | What it checks | Owner PR |
+|---|---|---|
+| **G-1** | Engine purity — no IO, no DOM, no `Date.now`, no `Math.random` reachable from `engine/` | PR-5.1 |
+| **G-2** | Determinism — identical seed yields byte-identical transcripts across two runs and across macOS and Linux | PR-5.1 |
+| **G-3** | State size — <100 KB per learner after 500 simulated sessions, every persona | PR-5.2 |
+| **G-4** | Performance — `nextExercises(8)` p99 <5 ms, `applyResult` p99 <1 ms | PR-5.2 |
+| **G-5** | **Calibration** — reliability diagram within ±0.06 per 0.05 bin over ≥200 items, against the **misspecified** personas and against the M2 real-child residual fixture | PR-5.4 |
+| **G-6** | Scheduler invariants — every anti-frustration and anti-stagnation rule as its own named test | PR-5.6 |
+| **G-7** | Controller stability — over any 50-item window, per-item `\|ΔpTarget\|` under bound, sign alternating ≤ N times | PR-5.6 |
+| **G-8** | Persona outcome gates — the ten personas' named pass conditions (`A-03`..`A-08`) | PR-5.10 |
+| **G-9** | Diagnosis quality — bug recall ≥0.85 within 6 firings; false-positive rate <0.05 on bug-free personas; `\|Δθ\| < 0.2` on untouched skills | PR-8.10 |
+| **G-10** | Trace fidelity — golden transcripts assert on `SelectionTrace`, produced by the same code path that made the decision | PR-5.9 |
+
+**G-5 lands before the scheduler, deliberately.** Everything downstream measures the
+wrong thing if `b()` is not real, and against a self-consistent simulator G-5 would pass
+by construction and tell you nothing.
+
+### Every G-gate is labelled
+
+**REGRESSION BOUND** — the threshold is derived from a pilot run and exists to catch
+drift. **PEDAGOGICAL ASSERTION** — the threshold is derived from theory and a violation
+means the behaviour is wrong, not that the bound is tight.
+
+This labelling is not bureaucracy. Corpán set 11 ship gates of which three were
+mathematically unsatisfiable under any scheduler, because the synthetic learner had
+**fixed ability**; it cost two full calibration rounds and a spec amendment to discover.
+When a gate fails, the label tells you whether to fix the code or to question the bound —
+and "a different marginal leg fails on each seed" is treated as a **FAIL**, not as noise.
+
+### PR versus nightly
+
+| Mode | Scope | Runtime |
+|---|---|---|
+| PR smoke | 3 personas × 20 learners | seconds |
+| Nightly | 10 personas × 100 children × 3 seeds | 30–80 minutes |
+
+The nightly job has a named owner and a paging path (`A-19`). An unwatched nightly is a
+gate that silently stops gating.

--- a/dynawalla/docs/GATES.md
+++ b/dynawalla/docs/GATES.md
@@ -1,65 +1,71 @@
 # Dynawalla — Gates
 
-Two families of automated gate. **C-series** validate the curriculum, its generators and
-its renderers. **G-series** validate the engine against simulated and real learners.
+Two families of automated gate. **CG-series** validate the curriculum, its generators and
+its renderers. **EG-series** validate the engine against simulated and real learners.
+
+**Gate ids are `CG-`/`EG-` prefixed on purpose.** Acceptance criteria use bare `C-NN` and
+`G-NN` for the CI/CD and governance sections, and an earlier draft distinguished the two
+families only by zero-padding — which is not a distinction any script or reader can be
+trusted to hold. A `CG-`/`EG-` id is always a gate in this file; a bare `C-`/`G-` id is
+always an item in [ACCEPTANCE_CRITERIA.md](ACCEPTANCE_CRITERIA.md).
 
 The first draft's table had one identifier naming two different gates, four identifiers
 naming nothing, and three defined gates with no implementing PR. This table is the
-corrected one: **C-1..C-22 with no holes, one owning PR each, and a failing-case test per
+corrected one: **CG-1..CG-22 with no holes, one owning PR each, and a failing-case test per
 gate.** `M-13` asserts none is orphaned.
 
 Published before M4's first curriculum PR.
 
 ---
 
-## C-series — curriculum
+## CG-series — curriculum
 
 | Gate | What it checks | Owner PR |
 |---|---|---|
-| **C-1** | Id hygiene and immutability — no shipped `active` id removed or re-pointed | PR-4.2 |
-| **C-2** | Acyclic `requires ∪ extends`, by Kahn topological sort, **printing the actual cycle** | PR-4.2 |
-| **C-3** | Edge integrity — targets exist, edge kinds valid | PR-4.2 |
-| **C-4** | Two-way reachability — unreachable node = error, dead-end = warn | PR-4.2 |
-| **C-5** | Grade sanity — `prereq.nominal ≤ node.nominal` | PR-4.2 |
-| **C-6** | **Capability flow** — `provides` on skills, `consumes` on bindings; the only mechanically sound *missing-edge* detector, and it suggests the edge | PR-4.5 |
-| **C-7** | **Bidirectional generator ownership** — merge blocker | PR-4.3 |
-| **C-8** | **Renderer ownership** — merge blocker | PR-4.4 |
-| **C-9** | Level coverage by **running** generators over N seeds, ≥`minVariants` distinct | PR-4.6 |
-| **C-10** | Variant-space adequacy — <2% duplicates over 1,000 draws | PR-4.6 |
-| **C-11** | Self-consistency — the family's own checker accepts `canonical` and every `alsoAccept`, and rejects every distractor, over 1,000 seeds | PR-4.6 |
-| **C-12** | Mal-rule fidelity — ≥95% divergence from the correct answer | PR-8.1 |
-| **C-13** | **Choice-laundering ban** — no `conceptual`/`reasoning` skill binds a choice-only generator | PR-4.4 |
-| **C-14** | **Locale round-trip** — every `canonical`/`alsoAccept` survives format→parse in all launch locales; every count slot declares its CLDR plural set | PR-4.7 |
-| **C-15** | Grade-band coverage matrix (grade × domain) — empty cell is an error at release, a warning in draft | PR-7.24 |
-| **C-16** | Determinism + committed output-hash snapshots on **macOS and Linux**; changed output without a `familyRev` bump is an error | PR-4.6 |
-| **C-17** | Performance — `generate()` p95 <5 ms, p99 <20 ms | PR-4.6 |
-| **C-18** | **Accessibility** — every representation has a text alternative; nothing solvable by colour alone | PR-4.4 |
-| **C-19** | i18n completeness, plus a lint that no `Exercise.prompt` is a bare string | PR-4.7 |
-| **C-20** | Standards traceback — **report-only, never blocking** | PR-7.24 |
-| **C-21** | Word-problem context sets populated per locale for every active word family | PR-7.23 |
-| **C-22** | **LOCATE capability** — a mal-rule may be tagged LOCATE-capable only if it has a bound contrast representation | PR-8.3 |
+| **CG-1** | Id hygiene and immutability — no shipped `active` id removed or re-pointed | PR-4.2 |
+| **CG-2** | Acyclic `requires ∪ extends`, by Kahn topological sort, **printing the actual cycle** | PR-4.2 |
+| **CG-3** | Edge integrity — targets exist, edge kinds valid | PR-4.2 |
+| **CG-4** | Two-way reachability — unreachable node = error, dead-end = warn | PR-4.2 |
+| **CG-5** | Grade sanity — `prereq.nominal ≤ node.nominal` | PR-4.2 |
+| **CG-6** | **Capability flow** — `provides` on skills, `consumes` on bindings; the only mechanically sound *missing-edge* detector, and it suggests the edge | PR-4.5 |
+| **CG-7** | **Bidirectional generator ownership** — merge blocker | PR-4.3 |
+| **CG-8** | **Renderer ownership** — merge blocker | PR-4.4 |
+| **CG-9** | Level coverage by **running** generators over N seeds, ≥`minVariants` distinct | PR-4.6 |
+| **CG-10** | Variant-space adequacy — <2% duplicates over 1,000 draws | PR-4.6 |
+| **CG-11** | Self-consistency — the family's own checker accepts `canonical` and every `alsoAccept`, and rejects every distractor, over 1,000 seeds | PR-4.6 |
+| **CG-12** | Mal-rule fidelity — ≥95% divergence from the correct answer | PR-8.1 |
+| **CG-13** | **Choice-laundering ban** — no `conceptual`/`reasoning` skill binds a choice-only generator | PR-4.4 |
+| **CG-14** | **Locale round-trip** — every `canonical`/`alsoAccept` survives format→parse in all launch locales; every count slot declares its CLDR plural set | PR-4.7 |
+| **CG-15** | Grade-band coverage matrix (grade × domain) — empty cell is an error at release, a warning in draft | PR-7.19 |
+| **CG-16** | Determinism + committed output-hash snapshots on **macOS and Linux**; changed output without a `familyRev` bump is an error | PR-4.6 |
+| **CG-17** | Performance — `generate()` p95 <5 ms, p99 <20 ms | PR-4.6 |
+| **CG-18** | **Accessibility** — every representation has a text alternative; nothing solvable by colour alone | PR-4.4 |
+| **CG-19** | i18n completeness, plus a lint that no `Exercise.prompt` is a bare string | PR-4.7 |
+| **CG-20** | Standards traceback — **report-only, never blocking** | PR-7.19 |
+| **CG-21** | Word-problem context sets populated per locale for every active word family | PR-7.18 |
+| **CG-22** | **LOCATE capability** — a mal-rule may be tagged LOCATE-capable only if it has a bound contrast representation | PR-8.3 |
 
 ### The four that carry the most weight
 
-**C-7 — generator ownership.** A curriculum row without a working generator cannot reach
+**CG-7 — generator ownership.** A curriculum row without a working generator cannot reach
 `status: active`. Draft nodes are allowed but are excluded from the shipped graph and
 from all coverage math. Without this, the graph becomes a wish list.
 
-**C-8 — renderer ownership.** A skill cannot go `active` unless its generator's
+**CG-8 — renderer ownership.** A skill cannot go `active` unless its generator's
 `AnswerSchema` kind **and every `representations.required` RepId** has a registered,
 tested renderer. This is the gate the first draft was missing entirely: a generator can
 emit a perfectly valid `Exercise` that the app cannot draw.
 
-**C-13 — choice-laundering ban.** C-7 and C-8 are both trivially satisfiable by making
-everything multiple choice. C-13 is what stops "Which of these is a line of symmetry?
+**CG-13 — choice-laundering ban.** CG-7 and CG-8 are both trivially satisfiable by making
+everything multiple choice. CG-13 is what stops "Which of these is a line of symmetry?
 A B C D" from counting as geometry coverage. It is the mechanical form of
 [ADR-0002](DECISIONS/ADR-0002-v1-scope-cut.md) and without it the scope cut is a
 promise rather than a constraint.
 
-**C-16 — determinism.** Generators run in a WebView on iOS, Android and desktop. Any
+**CG-16 — determinism.** Generators run in a WebView on iOS, Android and desktop. Any
 `Math.random`, any `Intl` inside generation, or any key-order assumption produces
 different exercises per device and makes a bug report irreproducible. Snapshots are
-committed and checked on both runners. Note the residual: C-16 does not run in a real
+committed and checked on both runners. Note the residual: CG-16 does not run in a real
 Android WebView, so a device spot-check belongs in the M7 device pass.
 
 ### Failing-case tests
@@ -72,12 +78,12 @@ that consumes it).
 
 ### Runtime and where each gate runs
 
-C-9/10/11/12 over 160 skills × 4 levels × 1,000 seeds is roughly 640k `generate()` calls
+CG-9/10/11/12 over 160 skills × 4 levels × 1,000 seeds is roughly 640k `generate()` calls
 — far too slow to run per PR.
 
 | Mode | Scope | Where |
 |---|---|---|
-| **Incremental** | Diff-scoped: only the families and nodes the PR touches, plus their dependents | `dynawalla-curriculum` job in `ci-gate.needs`, on `pull_request` and `merge_group`. Must complete in <90 s (`C-20` acceptance item). |
+| **Incremental** | Diff-scoped: only the families and nodes the PR touches, plus their dependents | `dynawalla-curriculum` job in `ci-gate.needs`, on `pull_request` and `merge_group`. Must complete in <90 s (acceptance item `C-20`). |
 | **Full sweep** | The entire graph, all gates | Nightly, with a **named owner** who is paged on failure. |
 
 Both from day one. Retrofitting incremental mode after the graph is large is how a
@@ -85,28 +91,47 @@ validator becomes a thing people skip.
 
 ---
 
-## G-series — engine
+## EG-series — engine
 
 Run by the simulation harness. See [ADAPTIVE_LEARNING.md](ADAPTIVE_LEARNING.md).
 
 | Gate | What it checks | Owner PR |
 |---|---|---|
-| **G-1** | Engine purity — no IO, no DOM, no `Date.now`, no `Math.random` reachable from `engine/` | PR-5.1 |
-| **G-2** | Determinism — identical seed yields byte-identical transcripts across two runs and across macOS and Linux | PR-5.1 |
-| **G-3** | State size — <100 KB per learner after 500 simulated sessions, every persona | PR-5.2 |
-| **G-4** | Performance — `nextExercises(8)` p99 <5 ms, `applyResult` p99 <1 ms | PR-5.2 |
-| **G-5** | **Calibration** — reliability diagram within ±0.06 per 0.05 bin over ≥200 items, against the **misspecified** personas and against the M2 real-child residual fixture | PR-5.4 |
-| **G-6** | Scheduler invariants — every anti-frustration and anti-stagnation rule as its own named test | PR-5.6 |
-| **G-7** | Controller stability — over any 50-item window, per-item `\|ΔpTarget\|` under bound, sign alternating ≤ N times | PR-5.6 |
-| **G-8** | Persona outcome gates — the ten personas' named pass conditions (`A-03`..`A-08`) | PR-5.10 |
-| **G-9** | Diagnosis quality — bug recall ≥0.85 within 6 firings; false-positive rate <0.05 on bug-free personas; `\|Δθ\| < 0.2` on untouched skills | PR-8.10 |
-| **G-10** | Trace fidelity — golden transcripts assert on `SelectionTrace`, produced by the same code path that made the decision | PR-5.9 |
+| **EG-1** | Engine purity — no IO, no DOM, no `Date.now`, no `Math.random` reachable from `engine/` | PR-5.1 |
+| **EG-2** | Determinism — identical seed yields byte-identical transcripts across two runs and across macOS and Linux | PR-5.1 |
+| **EG-3** | State size — <100 KB per learner after 500 simulated sessions, every persona | PR-5.2 |
+| **EG-4** | Performance — `nextExercises(8)` p99 <5 ms, `applyResult` p99 <1 ms | PR-5.2 |
+| **EG-5** | **Calibration** — reliability diagram within ±0.06 per 0.05 bin over ≥200 items, against the **misspecified** personas and against the M2 real-child residual fixture | PR-5.4 |
+| **EG-6** | Scheduler invariants — every anti-frustration and anti-stagnation rule as its own named test | PR-5.6 |
+| **EG-7** | Controller stability — over any 50-item window, per-item `\|ΔpTarget\|` under bound, sign alternating ≤ N times | PR-5.6 |
+| **EG-8** | Persona outcome gates — see the mapping below | PR-5.10 |
+| **EG-9** | Diagnosis quality — bug recall ≥0.85 within 6 firings; false-positive rate <0.05 on bug-free personas; `\|Δθ\| < 0.2` on untouched skills | PR-8.10 |
+| **EG-10** | Trace fidelity — golden transcripts assert on `SelectionTrace`, produced by the same code path that made the decision | PR-5.9 |
 
-**G-5 lands before the scheduler, deliberately.** Everything downstream measures the
-wrong thing if `b()` is not real, and against a self-consistent simulator G-5 would pass
+**EG-5 lands before the scheduler, deliberately.** Everything downstream measures the
+wrong thing if `b()` is not real, and against a self-consistent simulator EG-5 would pass
 by construction and tell you nothing.
 
-### Every G-gate is labelled
+### EG-8 — which persona maps to which acceptance item
+
+There are **eleven** personas: ten behavioural plus one misspecification persona
+([ADAPTIVE_LEARNING.md](ADAPTIVE_LEARNING.md)). Six have an acceptance-level pass
+condition; the other five are covered by other gates, and EG-8 does not invent one for
+them.
+
+| Persona | Pass condition |
+|---|---|
+| `accurate-counter-on` | `A-03` |
+| `pure-guesser` | `A-04` |
+| `slow-accurate` | `A-05` |
+| `fast-careless` | `A-06` |
+| `fatiguer` | `A-07` |
+| `struggling` | `A-08` |
+| `steady-strong`, `returning-lapser`, `rapid-improver` | no EG-8 condition — covered by EG-5 calibration and EG-6 invariants |
+| `single-misconception` | no EG-8 condition — covered by EG-9 |
+| misspecification | no EG-8 condition — it is EG-5's instrument, not an outcome persona |
+
+### Every EG-gate is labelled
 
 **REGRESSION BOUND** — the threshold is derived from a pilot run and exists to catch
 drift. **PEDAGOGICAL ASSERTION** — the threshold is derived from theory and a violation
@@ -123,7 +148,7 @@ and "a different marginal leg fails on each seed" is treated as a **FAIL**, not 
 | Mode | Scope | Runtime |
 |---|---|---|
 | PR smoke | 3 personas × 20 learners | seconds |
-| Nightly | 10 personas × 100 children × 3 seeds | 30–80 minutes |
+| Nightly | 10 behavioural personas × 100 children × 3 seeds, plus the misspecification persona in the EG-5 set only | 30–80 minutes |
 
 The nightly job has a named owner and a paging path (`A-19`). An unwatched nightly is a
 gate that silently stops gating.

--- a/dynawalla/docs/PACK_SYSTEM.md
+++ b/dynawalla/docs/PACK_SYSTEM.md
@@ -1,0 +1,89 @@
+# Dynawalla — Pack system
+
+**There is no Dynawalla pack system in V1.** Curriculum is a compiled SQLite artifact
+bundled in the app. See [ADR-0003](DECISIONS/ADR-0003-no-downloadable-packs-v1.md) and
+[ADR-0012](DECISIONS/ADR-0012-ota-curriculum-deferral.md).
+
+This document exists so that (a) the absence is verifiable rather than accidental, and
+(b) whoever eventually builds one inherits what Corpán's pack system already learned
+instead of rediscovering it.
+
+## What "no pack system" means concretely
+
+Acceptance is **by absence** (`K-01`, `K-02`, `K-03`):
+
+- No catalog file, no catalog fetch, no catalog store.
+- No installer, no install manager, no download UI, no progress surface.
+- No CDN or S3 origin serving Dynawalla content.
+- No custom URI scheme handler.
+- No Rust pack runtime and no pack-related Tauri commands.
+- The app makes **zero** network requests for curriculum content — asserted by a test and
+  confirmed by a device network capture during the M7 device pass.
+
+What replaces it: `dynawalla/curriculum/build/compile.ts` emits a deterministic
+hash-stamped SQLite file into the app's `public/curriculum/`, bundled at build time. A
+release-checklist gate asserts the shipped artifact's hash matches the compiled source
+(`M-17`), and the artifact is capped at 12 MB.
+
+## What this deletes from the critical path
+
+A pack system is not a feature; it is a subsystem with its own failure modes. Declining
+it removes, from V1:
+
+- A from-scratch Rust pack runtime (Corpán's is ~2,900 lines inside `corpan_lib`, reached
+  through eight Tauri commands) with connect and stall watchdogs and fail-closed sha256
+  verification.
+- A catalog surface, a CDN publishing path and an install manager.
+- Three shared-TypeScript extraction waves that only exist to make the above reusable.
+- Version skew between an installed pack and the host app, and the back-compat routing
+  that manages it.
+- On-device quota exhaustion.
+- A second security boundary in a children's product.
+
+## What Corpán's pack system already taught, for whoever revives this
+
+Each of these cost something to learn. Read them before designing anything.
+
+**The Pages artifact is whole-site.** `deploy-pages.yml` uploads `web/io/out` via
+`upload-pages-artifact`, which atomically replaces everything at the site root, and no
+pack ZIP is committed — every ZIP is produced from source at build time. Therefore
+"build only the changed packs" 404s every unrebuilt pack the instant the artifact
+publishes, and **immutable versioned URLs are structurally unachievable on a
+source-rebuilt Pages site**: the artifact can only contain the version in the git tree.
+Versioned artifacts must live on S3/CloudFront. See
+[RELEASE_ENGINEERING.md](RELEASE_ENGINEERING.md).
+
+**The ETag/304 "free poll" is off in production.** Every Corpán catalog policy sets
+`skipConditionalGet: true` because CloudFront/Fastly reject the `If-None-Match` CORS
+preflight. Do not plan polling capacity on conditional GET.
+
+**Never change a published artifact in place.** Bump the version. A pack ZIP was once
+swapped in place at the same version and produced two different SHAs for one version
+number, which is unresolvable from the client side.
+
+**A silent auto-install is a user-hostile download.** Never fetch content without asking:
+show the size, show progress, and degrade gracefully if the user declines.
+
+**Adding a catalog entry without a build step is a 404.** In Corpán, a pack listed in the
+catalog but not built by the deploy workflow simply does not exist at its URL, and
+nothing fails loudly.
+
+**A pack's identifier surface is a public API.** `corpan-pack://` is baked into installed
+packs' built JS on user devices; renaming the plugin that registers it breaks every
+installed pack at runtime while compiling cleanly. Any URI scheme Dynawalla ever
+registers inherits the same permanence.
+
+**A delete path that is never registered leaks forever.** Corpán's install manager
+invokes a `content_packs_delete` command that is not among the registered Tauri commands,
+so uninstalled pack data stays on disk permanently. Whatever the runtime is, enumerate
+the commands the frontend invokes and assert each one is registered.
+
+## Trigger for building one
+
+Both conditions together, per [ADR-0012](DECISIONS/ADR-0012-ota-curriculum-deferral.md):
+an installed base large enough that an app-review cycle is a real cost to real users,
+**and** a curriculum defect that cannot wait for a review cycle. Either alone is not a
+trigger.
+
+When it fires, the design starts from **signed, versioned, immutable artifacts on
+S3/CloudFront**, not from a Pages object, and it gets its own ADR.

--- a/dynawalla/docs/RELEASE_ENGINEERING.md
+++ b/dynawalla/docs/RELEASE_ENGINEERING.md
@@ -51,7 +51,7 @@ incident log — the override is the thing that will be abused.
 and a fork-only required approval.
 
 **Failing on truncation is chosen over chunking deliberately.** It mechanically enforces
-the small-PR discipline that trunk-based development requires. Budget: ~121 PRs × 3
+the small-PR discipline that trunk-based development requires. Budget: ~122 PRs × 3
 lenses × ~2.5 evaluations ≈ 900 model calls.
 
 ## Fix 2 — `ci.yml` fails closed on unknown paths
@@ -197,7 +197,8 @@ Then **SHA-pin every third-party action** with a trailing `# vX.Y.Z` comment, an
 
 ## `deploy-pages.yml` — Corpán-only hygiene
 
-427 lines, 15 hand-written `npm install --legacy-peer-deps` blocks,
+427 lines, 14 hand-written `npm install --legacy-peer-deps` blocks (plus one more at
+`ci.yml:245`, which is the one that also needs the per-pack `.npmrc`),
 `concurrency: { group: "pages", cancel-in-progress: true }`, and a smoke workflow that
 only runs on `conclusion == 'success'` — so a cancelled deploy is never smoke-tested.
 

--- a/dynawalla/docs/RELEASE_ENGINEERING.md
+++ b/dynawalla/docs/RELEASE_ENGINEERING.md
@@ -1,0 +1,264 @@
+# Dynawalla — Release engineering
+
+CI topology, the merge queue, release triggers, build numbers, and the traps. This is the
+operational document for anyone touching `.github/`.
+
+## What is already right and must not be replaced
+
+`ci.yml` documents the exact trap it solves: **a workflow-level `paths:` filter on a
+required check leaves unrelated PRs "expecting" it forever and deadlocks the queue.** It
+solves it with a cheap always-running `changes` job, `if:`-gated heavy jobs, and an
+`if: always()` `ci-gate` aggregator that treats `skipped` as pass.
+
+Keep it. **Required contexts stay exactly three: `ci-gate`, `adversarial-review`,
+`hygiene`**, all on `pull_request` and `merge_group`, with no workflow-level `paths:`.
+**Dynawalla adds jobs to `ci-gate.needs`, never a fourth context** (`C-01`).
+
+`dorny/paths-filter` is rejected — this repo solved the problem in about 20 lines of
+`git diff` and the solution is better than the action.
+
+## Fix 1 — the adversarial reviewer
+
+This is the highest-value change in the program, because the diff-size discipline that
+makes constant merging safe is currently unenforced.
+
+Three defects, all verified:
+
+1. **It truncates and still reports green.** `adversarial_review.py:115` truncates at
+   `MAX_DIFF_BYTES` (default 200,000). Measured: PR #521 was 850,261 diff bytes across
+   186 files; the model saw 67 of them, stopping mid-alphabet, and the conclusion was
+   `success`.
+2. **It fails closed only when *all* lenses error.** The guard is
+   `if errored == len(LENSES)`, so two of three lenses timing out yields a green required
+   check on one lens' output.
+3. **The provider is not what anyone assumes.** There is no `ANTHROPIC_API_KEY` among the
+   repository secrets and no repository variables at all, so `provider_and_key()` falls
+   through to the OpenAI key and a hardcoded default model.
+
+**One PR fixes all of it** (PR-0a.2): truncation exits non-zero with
+`::error::diff too large to review — split this PR`; **any** lens error fails; the
+resolved provider and model are printed into `$GITHUB_STEP_SUMMARY`; and a 1-token ping
+asserts the model responds before spending three full-diff calls. `MAX_DIFF_BYTES`
+becomes a repo *variable* starting at 400,000. The hardcoded app version in the prompt is
+replaced by a read of `tauri.conf.json`.
+
+**Break-glass:** an `admin-override` label that a named bypass actor can apply, so a
+provider outage does not freeze the trunk. Every use of it goes in the `STATUS.md`
+incident log — the override is the thing that will be abused.
+
+**Fork PRs:** when no key is present **and** the head repo is a fork, print
+`::notice::fork PR — maintainer review required` and exit 0, paired with `CODEOWNERS`
+and a fork-only required approval.
+
+**Failing on truncation is chosen over chunking deliberately.** It mechanically enforces
+the small-PR discipline that trunk-based development requires. Budget: ~121 PRs × 3
+lenses × ~2.5 evaluations ≈ 900 model calls.
+
+## Fix 2 — `ci.yml` fails closed on unknown paths
+
+The area filters are a hand-maintained allowlist with no catch-all. `dynawalla/**`
+matches none of them, so a Dynawalla PR would run zero jobs and pass green. A live
+instance of the same bug already exists: `corpan/packs/shared/**` sets `packs=true`, but
+the changed-packs step skips any pack directory without a `package.json`, and
+`corpan/packs/shared/package.json` does not exist — while nine Corpán app files import
+from it.
+
+Add an `uncovered` step that fails on any changed file matching no area pattern and no
+explicit no-CI allowlist entry (`\.md$`, `books/`, `voices/`, the frozen book corpora,
+`LICENSE`, image directories).
+
+**It runs only on `pull_request`** (`if: github.event_name == 'pull_request'`). The
+`changes` job diffs `merge_group.base_sha..head_sha`, which spans every entry in a batch,
+so a fail-closed uncovered check inside the queue would eject up to five PRs under
+`ALLGREEN` and re-run three model calls per entry on retry. **Path coverage is a property
+of the individual PR and is fully knowable before enqueue** (`C-05`).
+
+## Fix 3 — a real native gate that can actually execute
+
+There is **no** native gate today: zero `cargo`/`clippy`/`rustup` invocation in any
+required check.
+
+The obvious design cannot run. `aarch64-apple-ios` needs macOS and Xcode (which is why
+the existing non-required iOS workflow pins a macOS runner while every `ci.yml` job is
+ubuntu); `aarch64-linux-android` needs the NDK, and the committed `.cargo/config.toml`
+hardcodes a local NDK path that the release workflow sed-rewrites in CI; and `needs:`
+cannot reference a job in another workflow, so a separate workflow can never feed
+`ci-gate`.
+
+**Both jobs live inside `ci.yml` so they can be `ci-gate` needs:**
+
+- **`rust-linux`** (ubuntu, `if: native`): `cargo fmt --check`;
+  `cargo clippy --all-targets -D warnings` and `cargo test` over `native/`; **plus
+  explicit `--manifest-path corpan/corpan-app/src-tauri/Cargo.toml`** clippy and test,
+  and the Dynawalla equivalent — otherwise the gate never compiles `corpan_lib`, which is
+  the content-pack code, the blob store, the offline cache and the SIGSEGV breadcrumb,
+  i.e. the exact code it exists to protect. Plus
+  `cargo check --target aarch64-linux-android` using `android-actions/setup-android` and
+  a config generated from `$ANDROID_NDK_HOME`. Plus the two `cargo metadata` vendored-fork
+  assertions.
+- **`rust-apple`** (macos-14, `if: native`): the per-plugin
+  `cargo build --target aarch64-apple-ios` loop, lifted verbatim from the existing iOS
+  workflow.
+
+Then **delete `ios-native.yml`.**
+
+Gating `rust-apple` behind the `native` filter is load-bearing: GitHub-hosted macOS bills
+at a 10× minute multiplier and `ALLGREEN` re-forms groups on any failure, so an ungated
+macOS job on every queue entry would become the dominant CI cost line, spent almost
+entirely on PRs touching zero native code. A skipped job costs nothing and `ci-gate`
+treats skipped as pass (`C-07`).
+
+**`config.toml.in` must land before this job, not after.**
+
+**New area filters:**
+
+```
+dynawalla_app        ^(dynawalla/dynawalla-app/|\.github/workflows/ci\.yml$)
+dynawalla_curriculum ^(dynawalla/curriculum/|\.github/workflows/ci\.yml$)
+dynawalla_engine     ^(dynawalla/engine/|\.github/workflows/ci\.yml$)
+shared_ts            ^(shared/|corpan/packs/shared/)      # also sets corpan_app + dynawalla_app
+native               ^(native/|.*/src-tauri/|corpan/plugins/)
+```
+
+## Merge queue
+
+**Batched releases are silently dropped.** The current release trigger detects a release
+by comparing `git show HEAD^:...tauri.conf.json`; the queue ruleset sets
+`max_entries_to_merge: 5` with `ALLGREEN` and a 5-minute minimum wait. A version bump
+batched with any later PR yields `release=false` and **nothing ships**.
+
+**Move both apps to tag-triggered release** (`corpan-v*`, `dynawalla-v*`) plus
+`workflow_dispatch`, keeping the path filter as belt (`C-11`, `C-12`).
+
+### Build numbers do NOT change
+
+`release-mobile.yml:176` (CFBundleVersion) and `:355` (versionCode) are
+`$(( $(date +%s) / 60 ))` — about 29,750,000 today — with an in-file warning never to
+revert to a derived scheme.
+
+`github.run_number` is scoped to a workflow *file path* and restarts at 1 on rename. It
+would **decrease** the build number, and Play rejects a versionCode that is not strictly
+greater while ASC rejects the CFBundleVersion for the same short-version string. Because
+the upload is the last step of a 60-minute macOS job, that surfaces as a red X at the end
+of a release rather than at PR time.
+
+**Keep minutes-since-epoch for both apps.** Add a **preflight** that queries the current
+highest build (`androidpublisher edits.tracks.get`, ASC `/v1/preReleaseVersions`) and
+hard-fails if the computed number is not strictly greater — turning a 60-minute discovery
+into a 10-second one (`C-14`, `C-15`).
+
+**Open risk introduced by the constant-merge cadence:** two release runs of the same app
+in the **same minute** compute the **same** build number, and the second upload is
+rejected as a duplicate. The preflight catches it in seconds; whether to move to
+`max(preflight_highest + 1, minutes_since_epoch)` is an open decision that needs its own
+PR and its own verification run. Do not fold it into an unrelated release PR.
+See RISKS R-12.
+
+### Where protection lives
+
+**Protection lives in two objects, and most people edit the wrong one.**
+
+- Required checks are in **classic branch protection**:
+  `contexts: [ci-gate, adversarial-review, hygiene]`, `strict: true`,
+  `enforce_admins: false`, `required_linear_history: true`.
+- The merge queue is in **ruleset 18008260**.
+- Ruleset **11721169** ("main") has only `deletion` and `non_fast_forward`.
+
+Anyone told to "add the check to the main ruleset" edits ruleset 11721169 and silently
+changes nothing.
+
+**Migration is strictly ordered, scripted, and recorded with the revert payload written
+FIRST** — deleting classic protection before the ruleset rule is verified leaves `main`
+with an active merge queue and **zero** required checks, and auto-merge would drain the
+queue unreviewed:
+
+1. `PUT` `required_status_checks` into ruleset 11721169 with all three contexts.
+2. Open a throwaway PR with a deliberately failing check; confirm the UI attributes the
+   block to the **ruleset** rule.
+3. Only then `DELETE /branches/main/protection`.
+4. Re-run the throwaway PR; confirm it is still blocked.
+5. Separately: `enforce_admins` via ruleset with one named break-glass bypass actor.
+
+`strict: true` is confirmed set but empirically not blocking — the last 20 merges,
+including 186- and 619-file PRs, all landed through the queue. Demoted from "bug" to
+housekeeping: drop it while migrating, spend no more attention on it.
+
+### Delete `pr-agent.yml` in the very first PR
+
+It is the highest-severity supply-chain item in the repository: a second LLM reviewer
+pinned to a **mutable** third-party action ref, holding `contents: write` +
+`issues: write` + `pull-requests: write`, triggered by an **unfiltered** `issue_comment`
+on a public repo that also holds Apple signing certs, an ASC API key and a Play service
+account. Its own `/review`-only gate sits commented out. It duplicates
+`adversarial-review`.
+
+Then **SHA-pin every third-party action** with a trailing `# vX.Y.Z` comment, and set
+`sha_pinning_required: true` (`C-10`).
+
+## `deploy-pages.yml` — Corpán-only hygiene
+
+427 lines, 15 hand-written `npm install --legacy-peer-deps` blocks,
+`concurrency: { group: "pages", cancel-in-progress: true }`, and a smoke workflow that
+only runs on `conclusion == 'success'` — so a cancelled deploy is never smoke-tested.
+
+**The per-pack-matrix idea is wrong and is replaced.** `upload-pages-artifact` publishes
+`path: web/io/out` as a **whole-site artifact** that atomically replaces everything at
+encorpora.io, and `git ls-files 'corpan/packs/*/*.zip'` returns **0** — every ZIP is
+produced from source at build time. Building only changed packs would 404 every
+unrebuilt pack's ZIP and `dist/` the instant it publishes: the drift.zip incident, for
+every other pack at once. And immutable versioned URLs are structurally unachievable on
+a source-rebuilt Pages site, because the artifact can only contain the version in the git
+tree.
+
+The two concerns split:
+
+- **Build cost:** always assemble the COMPLETE site; use `actions/cache` keyed on a
+  per-pack content hash to skip npm-install/build for unchanged packs, restoring the
+  cached `dist/` + `.zip` into `web/io/out`.
+- **Immutability:** move versioned pack ZIPs to the S3/CloudFront path this repo already
+  operates for narration and phrase packs, where objects genuinely persist per version,
+  and point the catalog there. Keep only a current-version convenience URL on Pages.
+- **Prerequisite, not follow-up:** commit a `package-lock.json` per pack and switch both
+  the deploy and CI to `npm ci`, with `--legacy-peer-deps` moved into each pack's
+  versioned `.npmrc`. Unpinned installs mean a transitive publish can break the
+  production deploy or silently change a shipped bundle with zero repo change.
+- Emit **sha256** into the catalog at build time; move the complete-localization check
+  out of the deploy build into a PR gate (so one missing locale on one pack cannot take
+  down the publish of every pack plus the website); set `cancel-in-progress: false`.
+
+Because Dynawalla V1 has **no downloadable packs**, all of this is M0b — parallel to
+M1/M2 and blocking nothing Dynawalla does.
+
+## Store pipelines
+
+`release-mobile.yml` hardcodes `corpan/corpan-app` in 18 places, plus a Corpán signing
+profile name and package name. Extract
+`.github/workflows/release-mobile-reusable.yml` (`workflow_call`) with inputs
+`app_dir, bundle_id, package_name, profile_name, product_name, runner, environment`.
+**Corpán is the first caller** (which proves parity), Dynawalla second.
+
+**Preserved verbatim, because each is load-bearing:** the `macos-26` runner and the
+"select newest Xcode" step (the iOS 26 SDK has been required for uploads since
+2026-04-28); manual signing with a self-written `ExportOptions.plist` and a self-run
+`xcodebuild -exportArchive`; `jarsigner` on the unsigned AAB; the 16 KB page-size triple
+belt; and minutes-since-epoch build numbers.
+
+**Fail-hard on missing secrets lands BEFORE the environment migration.** Today the
+workflow emits `::warning::`, skips every step and reports **success** — so a mis-scoped
+secret produces a green run that ships nothing (`C-13`).
+
+**`secrets: inherit` does not pass environment secrets.** It passes repository and
+organisation secrets only; environment secrets resolve from the `environment:` key of the
+consuming job **in the called workflow**. So the reusable workflow takes an `environment`
+input and declares `environment: ${{ inputs.environment }}` per job. Environments:
+`corpan-ios`, `corpan-android`, `dynawalla-ios`, `dynawalla-android`.
+
+Credentials for Dynawalla are covered in [STORE.md](STORE.md). Nothing in this repository
+ever contains a credential value; secrets are referenced by their GitHub secret **name**
+only.
+
+## No stage environment
+
+GitHub Pages serves exactly one site per repository, so `stage.encorpora.io` is not
+buildable here without a second repo. See
+[ADR-0019](DECISIONS/ADR-0019-no-stage-environment.md).

--- a/dynawalla/docs/STORE.md
+++ b/dynawalla/docs/STORE.md
@@ -1,0 +1,125 @@
+# Dynawalla — Store
+
+App Store and Google Play bootstrap, compliance posture, and what is automatable.
+
+**No credential value ever appears in this repository.** Secrets are referenced by their
+GitHub secret **name** or their AWS Secrets Manager **path** only — never a key id, an
+issuer id, a provisioning-profile UUID, a keystore password, a `.p8`, or a
+service-account JSON. The repository is public (`G-11`).
+
+## Identity
+
+| | Value |
+|---|---|
+| Bundle id / applicationId | `inc.corpora.dynawalla` (founder decision #6 — note `inc.`, not `com.`) |
+| Working product name | Dynawalla: Apprentice of Numbers — [ADR-0016](DECISIONS/ADR-0016-app-store-product-name.md) |
+| iOS deployment target | 16.0, `ITSAppUsesNonExemptEncryption: false` |
+| Android | `minSdk 26`, `compileSdk 36`, `targetSdk 36` |
+
+**Two bundle-id conventions now coexist permanently.** `com.corpora.corpan` is immutable
+in both stores. Any tooling deriving paths, keychain entries, `os_log` subsystems or
+store lookups from a bundle-id prefix must take it as a **parameter** — a `corpan`
+literal already appears in 7+ Rust/Swift/Kotlin sites (RISKS R-40).
+
+**Play's package name is locked by the first uploaded AAB** and cannot be changed without
+Google support. Verify the generated Gradle `applicationId` **before** the first upload;
+`X-03` exists for this reason alone.
+
+**Android target API 36 is mandatory for new apps from 2026-08-31.** Dynawalla ships at
+36 from PR-1.2, so this is don't-regress rather than migrate.
+
+## Credentials
+
+Account topology is [ADR-0015](DECISIONS/ADR-0015-developer-account-topology.md) and is
+the founder's decision. Under the assumed same-account option:
+
+| Credential | Reused or new |
+|---|---|
+| Apple Distribution certificate | **Reused** (team-wide) |
+| iOS provisioning profile | **New.** Profiles bind to one explicit bundle id; no wildcard spans both `com.corpora.*` and `inc.corpora.*`, and **wildcards cannot carry IAP**. |
+| Android upload keystore | **New**, deliberately separate, so one compromised key does not risk two shipping apps. |
+| Play service account | **Reused** — but it does **not** inherit access. It needs an **explicit per-app permission grant** in Play Console on the new app record (`G-09`). |
+| ASC API key | Reused; almost certainly needs re-minting at Admin role for app-record operations. |
+| AWS secret | **New** path `dynawalla/store/credentials`, rather than widening the existing Corpán secret that a live purchase-verify lambda reads. |
+
+GitHub environments: `dynawalla-ios`, `dynawalla-android` (alongside `corpan-ios`,
+`corpan-android`). Note that `secrets: inherit` passes repository and organisation secrets
+**only** — environment secrets resolve from the `environment:` key of the consuming job in
+the *called* workflow. See [RELEASE_ENGINEERING.md](RELEASE_ENGINEERING.md).
+
+**Do not copy any provisioning-profile UUID out of another product's setup document into
+Dynawalla's configuration.** A profile bound to a different bundle id produces an
+unsignable App Store build; there is at least one document in this repo that instructs
+exactly that, and it is on the M0a expunge list.
+
+## What is automatable, and what is not
+
+Drive both stores by API. The browser is for the two things that have no API.
+
+**Automatable** (reusing the existing parameterized ASC and Play tooling under
+`corpan/infra/asc/` and `corpan/infra/play/`, both already keyed off a bundle-id /
+package-name variable):
+
+- Bundle ids, capabilities, certificates, provisioning profiles.
+- Category, age-rating declaration including `kidsAgeBand`.
+- Beta groups and TestFlight distribution.
+- Store listings, screenshots, descriptions.
+- Play Data safety declaration.
+- IAP products and subscription groups, if
+  [ADR-0013](DECISIONS/ADR-0013-monetization-model.md) calls for them.
+- Build uploads, track promotion, release notes.
+
+**Not automatable — budget founder console time:**
+
+1. **Creating the App Store Connect app record.** `POST /v1/apps` returns 404 and an ASC
+   API key gets 403 on create.
+2. **Creating the Play app record.** The `androidpublisher` v3 discovery document has no
+   application-create method.
+3. **The first Play release publish.** On a never-published app the API can only create
+   **draft** releases. This is Google's anti-abuse gate, not a code bug, and should not be
+   debugged as one — budget one Console-side publish (`G-10`).
+4. **Play promo codes**, if ever needed.
+
+Items 1–3 are roughly ten minutes of founder time and they sit on M1's critical path
+(RISKS R-37).
+
+## Compliance posture
+
+The decision itself is [ADR-0001](DECISIONS/ADR-0001-kids-category-posture.md) and is
+**a one-way door**: Apple Guideline 1.3 states the requirements continue to bind "in
+subsequent updates, even if you decide to deselect the category." It must be recorded
+before M1's first submission (`G-01`).
+
+The engineering plan already assumes the strict posture regardless:
+
+- **No third-party analytics SDK, no advertising SDK, in either bundle.** Enforced by a
+  CI dependency audit that is cross-checked against the submitted Play Data safety
+  declaration (`G-05`). This is the only mechanical enforcement — every dependency
+  addition is a compliance decision.
+- **No AAID, IMEI, MAC address or phone number transmitted; no precise location
+  collected** (`G-06`). Play's Families Policy forbids all of them for child users.
+- **All instrumentation is on-device.** There is no server profile, no account, and no
+  telemetry endpoint. The practical consequence is that the product's feel **cannot be
+  A/B tested remotely**, which is why in-person playtesting is the binding instrument
+  rather than a supplement ([PLAYTEST-PROTOCOL.md](PLAYTEST-PROTOCOL.md)).
+- **A parental gate stands in front of every link-out and every purchase flow** (`G-08`).
+  The primitive ships in M1's shell, not at M10, so no surface is ever built without one.
+- **No nudge techniques.** The UK Children's Code Standard 13 restricts them and
+  Standard 5 cautions against using children's data to keep them on a platform. The
+  forbidden mechanics list in [MISSION.md](MISSION.md) is stricter than either.
+- The privacy policy ships in-app and in both listings.
+
+Apple age rating and Play target-audience/content-rating declarations must be **complete
+and consistent with actual behaviour and with the CI audit** (`G-07`) — an inconsistency
+between the declaration and the bundle is a review rejection at best.
+
+## Release trigger
+
+Tag `dynawalla-v*` triggers `release-dynawalla.yml`, which calls the shared reusable
+workflow. `workflow_dispatch` is the fallback. A merge to `main` does **not** trigger a
+release — the old version-bump detector is silently defeated by a batched merge queue
+(`C-11`, RISKS R-14).
+
+Build numbers are minutes-since-epoch and **do not change**. See
+[RELEASE_ENGINEERING.md](RELEASE_ENGINEERING.md) for why, and for the preflight that
+catches a non-monotonic number in ten seconds instead of sixty minutes.

--- a/dynawalla/docs/TEST_STRATEGY.md
+++ b/dynawalla/docs/TEST_STRATEGY.md
@@ -55,13 +55,14 @@ say why the behaviour changed.
 
 ### 4. Determinism snapshots on two operating systems
 
-Generator output hashes are committed and checked on **macOS and Linux** CI (C-16).
+Generator output hashes are committed and checked on **macOS and Linux** CI (CG-16).
 Changed output without a `familyRev` bump is an error, because a silently changed
 generator invalidates every committed golden transcript and every bug report.
 
 ### 5. The simulation harness
 
-Nightly, 10 personas × 100 children × 3 seeds, 30–80 minutes, with a named owner and a
+Nightly, 10 behavioural personas × 100 children × 3 seeds (plus the misspecification
+persona in the EG-5 set), 30–80 minutes, with a named owner and a
 paging path. PRs run a 3-persona × 20-learner smoke. See
 [ADAPTIVE_LEARNING.md](ADAPTIVE_LEARNING.md) for why the personas are deliberately
 misspecified relative to the engine's belief model.

--- a/dynawalla/docs/TEST_STRATEGY.md
+++ b/dynawalla/docs/TEST_STRATEGY.md
@@ -1,0 +1,127 @@
+# Dynawalla — Test strategy
+
+What is tested where, what each layer can and cannot tell us, and the four things no
+test in this program will ever establish.
+
+Automated curriculum and engine gates are enumerated in [GATES.md](GATES.md); this
+document is the surrounding strategy.
+
+## Runner
+
+`node --experimental-strip-types --test`, Node 24, pinned via `.nvmrc` and `engines`.
+**No vitest.** This matches the Corpán app's zero-dependency runner and avoids the
+version-drift class of failure documented in RISKS R-41 — the repo already spans Node 20,
+22 and 24, and `--experimental-strip-types` behaves differently across those majors, so a
+job on the wrong Node fails in ways that look like code bugs.
+
+## Layers
+
+### 1. Unit and property tests — the bulk
+
+Everything pure lives in `curriculum/` and `engine/`, both importable without building
+Tauri. That is the point of their placement.
+
+Property tests carry most of the weight for generators: seeded purity, exact-arithmetic
+correctness, checker self-consistency, and variant adequacy are all statements over
+1,000 seeds rather than over three examples.
+
+**Named invariant tests.** Every scheduler invariant in
+[ADAPTIVE_LEARNING.md](ADAPTIVE_LEARNING.md) is its own test with a name that matches the
+invariant's wording (`A-13`). CI checks the mapping is one-to-one, so an invariant cannot
+be deleted from the code without a test disappearing loudly.
+
+### 2. Boundary tests — architecture as a build failure
+
+A static AST test fails the build if anything under `src/reactions/` or `src/world/`
+imports from `src/work/` or `engine/` (`Q-05`), and a second asserts `engine/` reaches no
+IO, no DOM, no `Date.now` and no `Math.random`.
+
+Two more of the same shape, both guarding a specific past mistake:
+
+- **No schema exposes `canonical.length` to the input layer.** Auto-submit keyed off
+  digit count silently tells a child how many digits the answer has.
+- **The reaction weight function's signature takes no run-length or streak argument.**
+  The registry being ported escalates on combo count; the signature test is what stops it
+  coming back by copy-paste.
+
+### 3. Golden transcripts
+
+Fixed seed, fixed persona, fixed expected sequence — asserted on the `SelectionTrace`
+rather than on the rendered output, so the explanation can never drift from the
+behaviour.
+
+Golden files are committed. A diff in a golden file is a **review artifact**: the PR must
+say why the behaviour changed.
+
+### 4. Determinism snapshots on two operating systems
+
+Generator output hashes are committed and checked on **macOS and Linux** CI (C-16).
+Changed output without a `familyRev` bump is an error, because a silently changed
+generator invalidates every committed golden transcript and every bug report.
+
+### 5. The simulation harness
+
+Nightly, 10 personas × 100 children × 3 seeds, 30–80 minutes, with a named owner and a
+paging path. PRs run a 3-persona × 20-learner smoke. See
+[ADAPTIVE_LEARNING.md](ADAPTIVE_LEARNING.md) for why the personas are deliberately
+misspecified relative to the engine's belief model.
+
+### 6. Rendered-output review
+
+Committed screenshots at 0 / 50 / 200 / 500 placed elements, all five reaction tiers, at
+320 px / 768 px / iPad, light and dark, reduced-motion on and off. **The images are
+reviewed in the PR, not the code** (`Q-14`).
+
+This is a test in the sense that matters: it produces an artifact a human can be wrong
+about in public.
+
+### 7. Device passes
+
+Every product milestone requires a named person to reach the capability from a **cold
+launch on a TestFlight or Play-internal build** — the `[device]` items in
+[ACCEPTANCE_CRITERIA.md](ACCEPTANCE_CRITERIA.md).
+
+This exists because this repo has the counterexample: a feature merged 2026-07-04 and was
+unreachable by production users until 2026-07-14, across five releases, while every check
+was green the entire time. **Merged is not done.**
+
+On-device measurement is not optional either: p95 machine-side contribution, `generate()`
+p95, live SVG node count and frame rate are all measured on the Galaxy Tab A9 (4 GB), not
+on a development laptop.
+
+### 8. Playtests
+
+[PLAYTEST-PROTOCOL.md](PLAYTEST-PROTOCOL.md). Gates at M2, M6, M8, each with kill/revise
+authority.
+
+## What tests cannot tell us
+
+Stated explicitly, because the failure mode of a heavily-gated program is believing the
+gates cover everything.
+
+1. **Whether it is any good.** No automated check distinguishes a compelling loop from a
+   competently-built drill. Only the playtest cohort can, and compliance forbids the
+   remote alternative.
+2. **Whether it looks right.** Code review cannot see that the observatory renders as a
+   gradient dashboard with gear icons. The screenshot gate plus a named art director is
+   the entire instrument.
+3. **Whether a wrong answer was diagnosed usefully.** Bug recall on a synthetic persona
+   measures whether the matcher fires; it says nothing about whether the child understood
+   the contrast pair. `T-05` is the measurement.
+4. **Whether a native change is safe.** `cargo check` proves nothing about
+   signal-handler chaining, and both `[patch]` regressions in
+   [ADR-0011](DECISIONS/ADR-0011-native-workspace-and-patch-placement.md) compile, test
+   and clippy **clean**. That is why the `cargo metadata` assertions and the device
+   tombstone check exist as separate instruments.
+
+## Two anti-patterns this program specifically forbids
+
+**A bypass hook or an over-generous mock proves nothing about the device path.** A
+sibling product in this repo had a quest that no child could finish, with every harness
+green, because the mock host reported a capability the device did not have and every
+proof used a bypass hook. If a test path can skip the thing being tested, it is not
+evidence.
+
+**Do not blame the build.** When a gate goes red, the default hypothesis is that the
+change is wrong, not that the gate is flaky. If a gate genuinely produces false
+positives, fix the gate in its own PR — do not disable it and do not merge around it.


### PR DESCRIPTION
### **User description**
**Follow-up to #525.** Same scope, split into two PRs so that neither diff exceeds
`MAX_DIFF_BYTES` and gets truncated by `adversarial-review` — a truncated review is a
weak review, and #525 sits at 186 KB. The two branches touch **disjoint files**, but
**merge #525 first, then this one in the same session**: the gate-id renamespace and the
mal-rule correction span both, and #525's `MISSION.md`, `README.md` and
`ACCEPTANCE_CRITERIA.md` each carry a one-line note that the links into this PR resolve
once it lands. Delete those notes here.

## What

Nine reference documents under `dynawalla/docs/`. **9 new files, no existing file
modified.**

| Doc | Contents |
|---|---|
| `ARCHITECTURE.md` | Placement in the monorepo, the directory tree, the eight layers, the shared-platform policy and what was deliberately *not* extracted. |
| `CURRICULUM.md` | Skill graph and node identity, the exercise contract, the 18 V1 generator families, mal-rules, the four representations, staging, legal posture. |
| `ADAPTIVE_LEARNING.md` | The three-layer learner model, rejected alternatives with reasons, cold start, the difficulty controller, the three feedback stages, the invariants, the harness. |
| `EXPERIENCE_DESIGN.md` | The core loop in milliseconds, reaction tiers and their trigger, construction, the character grammar, art direction and the **hostile reference board**. |
| `PACK_SYSTEM.md` | Why V1 has none, how the absence is verified, and what Corpán's pack system already learned for whoever revives it. |
| `RELEASE_ENGINEERING.md` | CI topology, the three reviewer fixes, the native gate, the merge queue, build numbers, where protection actually lives, `deploy-pages`, store pipelines. |
| `TEST_STRATEGY.md` | The eight test layers, and an explicit list of the four things no test here will ever establish. |
| `GATES.md` | `CG-1..CG-22` and `EG-1..EG-10`, each with an owning PR, no holes, plus the PR-vs-nightly runtime split and the EG-8 persona mapping. |
| `STORE.md` | Identity, credentials by name only, what is automatable vs the two founder browser clicks, compliance posture, release trigger. |

## Why

These are the documents an implementer opens while writing the code, and each carries a
correction that a plausible-looking implementation would otherwise undo:

- **`RELEASE_ENGINEERING.md` / `PACK_SYSTEM.md`** — `deploy-pages.yml` uploads
  `web/io/out` as a **whole-site** artifact and `git ls-files 'corpan/packs/*/*.zip'`
  returns 0, so "build only the changed packs" 404s every unrebuilt pack, and immutable
  versioned URLs are structurally unachievable on a source-rebuilt Pages site. Both are
  stated where someone optimising the deploy will read them.
- **`RELEASE_ENGINEERING.md`** — `release-mobile.yml:176,355` derive build numbers as
  `$(date +%s)/60` (~29.75M). `github.run_number` is scoped to a workflow file path and
  restarts at 1 on rename, so switching *decreases* the number and both stores reject
  the upload. Also documents the migration order for the branch-protection → ruleset
  move **with the revert payload written first**, and which of the three protection
  objects actually holds the required checks.
- **`RELEASE_ENGINEERING.md`** — required contexts stay exactly three; Dynawalla joins
  `ci-gate.needs`. A path-gated required check never reports on PRs missing its paths
  and blocks the merge queue forever.
- **`GATES.md`** — `CG-1..CG-22` with **no holes and one owning PR each**, including the
  two gates the first draft lacked entirely: **CG-8** renderer ownership and **CG-13**
  the choice-laundering ban.
- **`ADAPTIVE_LEARNING.md`** — EG-5 lands *before* the scheduler and runs against
  deliberately misspecified 3PL personas plus a real-child residual fixture, because the
  original check had the engine and the persona sharing the same `b` and passed by
  construction.
- **`EXPERIENCE_DESIGN.md`** — a hostile reference board, because code review cannot see
  that the observatory renders as a gradient dashboard with gear icons.

## Review round 2 — what the adversarial review changed

- **The gate id namespace collided with the acceptance namespace.** The earlier draft
  fixed "one id naming two gates" *inside* the C-series and reintroduced a worse version
  across families: `GATES.md`'s `C-1..C-22`/`G-1..G-10` versus
  `ACCEPTANCE_CRITERIA.md`'s `C-01..C-22`/`G-01..G-11`, separated only by zero-padding.
  Gates are now `CG-`/`EG-` prefixed, the file says why in its own preamble, and the
  incremental-validator row cites **acceptance item `C-20`** explicitly instead of
  relying on a parenthetical to disambiguate from gate C-20. Every citation across both
  PRs is updated.
- **`EG-8` claimed "the ten personas' named pass conditions (`A-03`..`A-08`)"** — six
  items for ten personas, while `ADAPTIVE_LEARNING.md` listed ten "plus the
  misspecification persona". Stated once now: **eleven personas, ten behavioural plus one
  misspecification**, which runs in the EG-5 calibration set only (so the nightly outcome
  budget stays ten). `EG-8` gains a table mapping each persona to its acceptance item and
  naming the five that have none.
- **The LOCATE example was attributed to the wrong mal-rule.**
  `5,001 − 2,798 = 3,797` is `mis.add.smaller-from-larger`; borrow-across-zero gives
  **`3,203`** — the correct answer `2,203` plus exactly the 1,000 that was borrowed and
  never given up. `CURRICULUM.md` now carries both worked examples on the same problem so
  the distinction cannot be lost again.
- **The persisted-state budget did not add up and busted its own bound.** The stated
  components (2,000-event ring at 32 B, 730 rollups at 64 B, …) total ~116 KiB against a
  `<100 KB` bound in `A-15`/`EG-3` and a "~60 KB" claim in the same sentence. Recomputed
  with a 512-event ring and 180 rollups, itemized and **summed in the doc**: 37,136 B.
- **`CURRICULUM.md`'s staging table did not reconcile with `MASTER_PLAN.md`.** 8 + 6 + 4
  in one document, 8 + 16 in the other, against a stated 18. The table now names the
  families per stage: 7 at M4, 7 + 4 at M7, 18 total — and `MASTER_PLAN.md` moves the six
  grade-1–2 families into M4, where the spine actually needs them.
- **`deploy-pages.yml` has 14 `--legacy-peer-deps` blocks, not 15** — the fifteenth is at
  `ci.yml:245`, and it is the one that also needs the per-pack `.npmrc`.
- **Corpán grants 11 of its 14 permissions at `:default`, not all 14**
  (`clipboard-manager:allow-write-text`, `tts:allow-speak` and
  `subscriptions:allow-show-manage-subscriptions` are per-command). `ARCHITECTURE.md`
  overstated it; the argument for narrowing from day one is unaffected.
- **Program total** aligned to ~122 PRs.

## Blast radius

- [x] Areas touched: `dynawalla/docs/` only (all new files)
- [x] No existing file modified; disjoint from #525's file set
- [x] No code, no workflow, no gate behaviour changed
- [x] No new user-visible string
- [x] No secret, credential, keystore, `.p8`, service-account JSON, issuer id, key id or
      provisioning-profile UUID. `STORE.md` names credentials by GitHub secret name and
      AWS secret path only, and explicitly instructs never to copy another product's
      provisioning-profile UUID.

## Proof

```
$ git diff origin/main --stat | tail -1
 9 files changed, 1640 insertions(+)

$ git diff origin/main | wc -c
90972           # well under MAX_DIFF_BYTES (200000)

$ grep -rniE 'F9AV5HKF6N|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|BEGIN [A-Z ]*PRIVATE KEY|AKIA[0-9A-Z]{16}|sk-[A-Za-z0-9]{20}' dynawalla/
(no matches)
```

Cross-reference sweep over the union of both branches:

```
gates defined: 32 | unresolved CG-/EG- refs: none
risks defined: 44 | unresolved R-NN refs:    none
acceptance items: 117 | unclaimed by any milestone exit list: none
bare C-NN / G-NN refs that do not resolve to an acceptance id: none
relative markdown links that do not resolve: none
```

State-budget arithmetic, shown in the doc and checked here:

```
24×160 + 20×180 + 12×64 + 1024 + 64×180 + 32×512 = 37,136 B   (< 100 KB, A-15 / EG-3)
```

Repo facts re-verified against `origin/main` at `1028ccf2c`: 14 `--legacy-peer-deps`
blocks in `deploy-pages.yml` (427 lines) plus one at `ci.yml:245`, `path: web/io/out`,
`git ls-files 'corpan/packs/*/*.zip'` == 0, `$(date +%s)/60` at
`release-mobile.yml:176,355`, and 11-of-14 `:default` grants in
`corpan/corpan-app/src-tauri/capabilities/default.json`.

___

### **PR Type**
Documentation


___

### **Description**
- Defines Dynawalla architecture and curriculum contracts

- Specifies adaptive learning and automated gates

- Documents experience, testing, and pack boundaries

- Establishes release and store operational constraints


___

### Diagram Walkthrough


```mermaid
flowchart LR
  architecture["Architecture and boundaries"]
  curriculum["Curriculum contracts"]
  learning["Adaptive learning engine"]
  gates["Automated gates and tests"]
  experience["Experience design"]
  delivery["Release and store delivery"]
  architecture -- "structures" --> curriculum
  curriculum -- "feeds" --> learning
  learning -- "validated by" --> gates
  experience -- "constrains" --> architecture
  gates -- "protect" --> delivery
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>ADAPTIVE_LEARNING.md</strong><dd><code>Defines learner model, scheduler, feedback, and simulation</code></dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/526/files#diff-a00b4ff4edcf00ee23b28d2ad436bbe2d67d21cc6bb9f404a26b0641eb451f1a">+231/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ARCHITECTURE.md</strong><dd><code>Establishes product layers, boundaries, and shared platform</code></dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/526/files#diff-37955052881e0e06c0c5a550be8b4e099e0ba722a1034282f4a7909d99f618b9">+204/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>CURRICULUM.md</strong><dd><code>Specifies curriculum graph, generators, mal-rules, and representations</code></dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/526/files#diff-afb6e8415ed452ebd55bd1074b26782454a321354c2f53e01949eb339eac2cdb">+215/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>EXPERIENCE_DESIGN.md</strong><dd><code>Defines interaction cadence, reactions, construction, and art </code><br><code>direction</code></dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/526/files#diff-c6b3be6b367dd5f66510e0c92e5d8928e8f455d7b4bdce639148f76a79de5812">+180/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>GATES.md</strong><dd><code>Enumerates curriculum and engine validation gates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/526/files#diff-38f105a86c9ac4c4398bfad708bec99358df15762a3e2398306e277085f40787">+129/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>PACK_SYSTEM.md</strong><dd><code>Documents bundled curriculum and deferred pack architecture</code></dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/526/files#diff-c7ba3bd17c11dbfce343513071a2ab6a6bd1daed867dbfe41bf53d92e384b644">+89/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RELEASE_ENGINEERING.md</strong><dd><code>Defines CI, release, merge, and deployment safeguards</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/526/files#diff-86ec9d239f1cf1d6c37d5d50401f63e1be64206b71e64dc2ea8186f062ca84e3">+264/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>STORE.md</strong><dd><code>Documents store identity, credentials, compliance, and releases</code></dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/526/files#diff-7dc83fde378942eb19324fa6778a8c1f1a353adcea2e7ce67322c0e35454d233">+125/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>TEST_STRATEGY.md</strong><dd><code>Defines testing layers, evidence limits, and anti-patterns</code></dd></td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/526/files#diff-ac83e72e3ece53ff7039198487d725a0cc94484aed754422cd58a00003c9de76">+127/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


