### PR TITLE
docs(dynawalla): record the founder's decisions — evaluation right-sized, Kids Category posture + Apple single-band constraint, accounts, monetization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ Cargo.lock
 web/io/out/
 web/io/.next/
 corpan/plugins/*/ios/.build/
+# Gradle's per-plugin build cache. Anchored and scoped to exactly the plugin
+# android/ dirs, mirroring the ios/.build/ line above. Directory-only (trailing
+# slash) so it can never match the TRACKED build.gradle.kts / settings.gradle
+# FILES that live in these same directories.
+corpan/plugins/*/android/.gradle/
 corpan/games/
 .DS_Store
 

--- a/dynawalla/docs/ACCEPTANCE_CRITERIA.md
+++ b/dynawalla/docs/ACCEPTANCE_CRITERIA.md
@@ -258,9 +258,11 @@ See [PACK_SYSTEM.md](PACK_SYSTEM.md) and
       A9 SM-X110 and launches.
       Verify: recorded install.
       Evidence: UNMET
-- [ ] **X-03** The generated Gradle `applicationId` is verified as
-      `inc.corpora.dynawalla` **before** the first AAB upload. The Play package name is
-      locked by the first upload and cannot be changed without Google support.
+- [ ] **X-03** The generated Gradle `applicationId` is read and verified as exactly
+      `inc.corpora.dynawalla` **before** the first AAB upload. **The Play package name is
+      locked forever by the first upload** — not by the first release — and cannot be
+      changed without Google support, which in practice means not at all. This is the
+      single most expensive mistake available in the store runbook (R-36).
       Verify: build log line quoted in the PR; upload timestamp after it.
       Evidence: UNMET
 - [ ] **X-04** `p_align == 0x4000` for every `.so` in the Dynawalla AAB.
@@ -507,22 +509,37 @@ See [PACK_SYSTEM.md](PACK_SYSTEM.md) and
       ([ADR-0010](DECISIONS/ADR-0010-standards-alignment-claim.md)); CG-20 stays
       report-only unless it says otherwise.
       Evidence: UNMET
-- [ ] **G-05** No third-party analytics or advertising SDK exists in either bundle.
+- [ ] **G-05** No SDK from any forbidden category exists in either bundle: ad networks,
+      third-party analytics, attribution/MMP, **third-party crash reporters**, push with
+      audience segmentation, targeted remote-config/A-B, social login, or anything
+      declaring `com.google.android.gms.permission.AD_ID` ([RISKS.md](RISKS.md) R-47).
       Verify: the CI dependency audit, cross-checked against the submitted Play Data
-      safety declaration.
+      safety declaration; plus the network-egress test asserting **zero** outbound
+      requests on cold launch and through a full lesson.
       Evidence: UNMET
-- [ ] **G-06** No AAID / IMEI / MAC / phone number is transmitted and no precise
-      location is collected.
-      Verify: dependency audit plus a device network capture during the release pass.
+- [ ] **G-06** None of AAID, SIM Serial, Build Serial, BSSID, MAC, SSID, IMEI or IMSI is
+      transmitted; the phone number is never requested via `TelephonyManager`; **no
+      location permission of any kind** is declared.
+      Verify: assertions on the **merged** `AndroidManifest.xml` (no `AD_ID`, no
+      `ACCESS_*_LOCATION`, no `READ_PHONE_STATE`), the iOS check for no
+      `ASIdentifierManager`/`ATTrackingManager` and no `NSUserTrackingUsageDescription`,
+      plus a device network capture during the release pass.
       Evidence: UNMET
 - [ ] **G-07** Apple age rating and Play target-audience/content-rating declarations
-      are complete and consistent with actual behaviour and with the CI audit.
+      are complete and consistent with actual behaviour and with the CI audit, and the
+      elected Apple band (5-and-under / 6-8 / 9-11 — exactly one) is consistent with the
+      shipped curriculum range ([ADR-0001](DECISIONS/ADR-0001-kids-category-posture.md)).
       Verify: both console declarations against the audit output.
       Evidence: UNMET
-- [ ] **G-08** A parental gate stands in front of every link-out and every purchase
-      flow.
-      Verify: route-guard test enumerating external links and purchase entry points;
-      device pass.
+- [ ] **G-08** A parental gate stands in front of every link-out, every purchase,
+      paywall and price display, Restore Purchases, the parent dashboard, anything that
+      emails or shares a child's work, and the microphone and push permission prompts.
+      The challenge is **non-arithmetic**, randomized and non-persistent across sessions
+      ([ADR-0005](DECISIONS/ADR-0005-shell-and-routing.md)); the privacy policy is an
+      in-app screen rather than an external URL, so it needs no gate.
+      Verify: route-guard test enumerating every entry point above; a test asserting the
+      challenge draws from a non-curricular pool and varies between invocations; device
+      pass.
       Evidence: UNMET
 - [ ] **G-09** Play Console shows the service account granted explicit per-app
       permission on the new Dynawalla app record.

--- a/dynawalla/docs/ACCEPTANCE_CRITERIA.md
+++ b/dynawalla/docs/ACCEPTANCE_CRITERIA.md
@@ -463,8 +463,10 @@ See [PACK_SYSTEM.md](PACK_SYSTEM.md) and
       child. No child observation exists for this path
       ([ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md),
       [RISKS.md](RISKS.md) R-46) and the report must say so rather than imply coverage.
-      Verify: recorded device pass with prompt text suppressed; every step reachable by
-      audio and touch alone.
+      Verify: a named person completes it from a **cold launch on a TestFlight or
+      Play-internal build** on a reference device, with prompt text suppressed and every
+      step reachable by audio and touch alone. (This is what keeps the `[device]` tag
+      honest — the instrument changed, the store-build bar did not.)
       Evidence: UNMET
 - [ ] **Q-12** Three children on one device have fully independent progress, verified
       by a test that cross-reads namespaces **and** by a named person on a real device.
@@ -563,11 +565,14 @@ The evaluator is the founder's 10-year-old son, observed by the founder
 recorded here. These are observations, not measurements of a population, and none of
 them may be restated publicly as a claim about children.
 
-- [ ] **T-01** `[playtest]` **M2**: the child completes two unsupervised 20-minute
+- [ ] **T-01** `[playtest]` **M2**: the child completes two **unassisted** 20-minute
       sessions on a reference device from a store build, on separate days. Recorded in
       `PLAYTEST-M2.md`: time to voluntary quit for each session, unprompted verbatims
       including the discouraging ones, next-day voluntary return (yes/no), where he got
       stuck, and what he skipped or worked around.
+      Verify: `PLAYTEST-M2.md` committed, containing all six fields for both sessions
+      plus the device and build number, per [PLAYTEST-PROTOCOL.md](PLAYTEST-PROTOCOL.md)
+      §4.
       Evidence: UNMET
 - [ ] **T-02** `[playtest]` **M2**: for **every** wrong answer across both sessions, what
       the child did next is recorded as one of retried / asked for the answer / studied
@@ -575,22 +580,31 @@ them may be restated publicly as a claim about children.
       does anything other than ask for the answer or disengage — that is the LOCATE
       contrast pair reading as punishment rather than as an explanation. The raw counts
       are reported as counts, never as a percentage.
+      Verify: the per-wrong-answer table in `PLAYTEST-M2.md`, one row per wrong answer
+      across both sessions, classified into the five responses in
+      [PLAYTEST-PROTOCOL.md](PLAYTEST-PROTOCOL.md) §4.
       Evidence: UNMET
 - [ ] **T-03** `[playtest]` **M2**: the child's per-item correctness with the predicted
       `b()` for each item served is exported from Developer Mode, committed as a fixture,
       and reported in `PLAYTEST-M2.md` **before** M7 spends on content breadth. One
       child's residuals detect a gross mismatch between predicted and observed
       difficulty; they do not calibrate `b()` and the report says so (`A-02`, R-26).
+      Verify: the fixture file committed from the Developer Mode export, referenced by
+      path in `PLAYTEST-M2.md`, with the M7 breadth PRs landing after it.
       Evidence: UNMET
 - [ ] **T-04** `[playtest]` **M6**: the same child returns for two more 20-minute
       sessions. Recorded in `PLAYTEST-M6.md`: can he say, unprompted, what he is building
       and why he chose it; did the chosen-chamber mechanic visibly change what he did.
+      Verify: `PLAYTEST-M6.md` committed, with the verbatim answer to the M6 question and
+      an explicit yes/no on the chamber mechanic.
       Evidence: UNMET
 - [ ] **T-05** `[playtest]` **M8**: his next attempt at the same mal-rule class after a
       LOCATE contrast pair, versus after a Stage-1 verify, recorded per occurrence in
       `PLAYTEST-M8.md`. If LOCATE shows no advantage, it is revised or cut. With one
       child this is an observation and not a measurement, and the report states that in
       those words rather than reporting a difference as though it were one.
+      Verify: `PLAYTEST-M8.md` committed, with one row per LOCATE-or-verify occurrence
+      and the next-attempt outcome for each.
       Evidence: UNMET
 - [ ] **T-06** Every playtest gate has a committed report and **none was waived**. There
       is no recruitment to wait for, so a missing report is a choice.

--- a/dynawalla/docs/ACCEPTANCE_CRITERIA.md
+++ b/dynawalla/docs/ACCEPTANCE_CRITERIA.md
@@ -4,12 +4,6 @@ The definition of done for V1. This is the document the program is graded agains
 
 **Every item below is currently UNMET.** Nothing has been built.
 
-> Links to `GATES.md`, `CURRICULUM.md`, `ADAPTIVE_LEARNING.md`, `ARCHITECTURE.md`,
-> `EXPERIENCE_DESIGN.md`, `PACK_SYSTEM.md`, `RELEASE_ENGINEERING.md`, `STORE.md` and
-> `TEST_STRATEGY.md` resolve once the reference-set PR lands. The two were split so
-> neither diff is truncated by the adversarial reviewer; delete this note in the
-> follow-up.
-
 ## How to use this file
 
 Each item has an id, a claim, and a **Verify** line naming the command or procedure
@@ -26,7 +20,10 @@ Rules that make this honest rather than aspirational:
   build. The repo's own counterexample: Journey merged 2026-07-04 and was unreachable
   by production users until 2026-07-14, across five releases.
 - **`[playtest]` items cannot be waived.** Waiving one voids every judgement
-  downstream of it — see [RISKS.md](RISKS.md) R-02.
+  downstream of it — see [RISKS.md](RISKS.md) R-02. They are **single-child
+  observations** ([ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md)): every
+  number recorded against one carries `n = 1` next to it, and none of them may be
+  restated as a rate, a proportion or a claim about children in general.
 - **`[founder]` items are not the program's to close.** They are listed so the
   critical path is visible, not so an agent can decide them.
 
@@ -159,8 +156,11 @@ Rules that make this honest rather than aspirational:
       **every** persona including the misspecification persona.
       Verify: nightly harness report.
       Evidence: UNMET
-- [ ] **A-02** EG-5 also holds against the M2 real-child residual fixture. This is the
-      only non-circular evidence that `b()` is real.
+- [ ] **A-02** EG-5 also holds against the M2 real-child residual fixture. One child's
+      residuals cannot calibrate `b()`; they can expose a gross mismatch, and that is the
+      only claim made for them. The non-circularity argument now rests on the
+      misspecified personas (`A-01`), not on this fixture — see
+      [RISKS.md](RISKS.md) R-26.
       Verify: fixture committed from `PLAYTEST-M2.md`; harness run green.
       Evidence: UNMET
 - [ ] **A-03** `accurate-counter-on` never accumulates a long-interval fact card and is
@@ -454,11 +454,15 @@ See [PACK_SYSTEM.md](PACK_SYSTEM.md) and
       colour alone, from the first representation authored.
       Verify: gate CG-18 green; a representation without a text alternative fails.
       Evidence: UNMET
-- [ ] **Q-11** `[device]` A grade-1 child who cannot read completes a session using
-      read-aloud only, observed.
-      Verify: the named non-reader in the `T-01` cohort, recorded in `PLAYTEST-M2.md`
-      under the standard observation protocol. If the cohort has no non-reader, `Q-11`
-      is UNMET — it is not waivable by a test.
+- [ ] **Q-11** `[device]` A full session is completed on read-aloud alone, with the
+      screen's text unreadable to the person doing it. This is an **adult proxy** run by
+      the founder on a reference device: it verifies that the capability is complete and
+      that no step requires reading, and it is **not** evidence about a pre-reading
+      child. No child observation exists for this path
+      ([ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md),
+      [RISKS.md](RISKS.md) R-46) and the report must say so rather than imply coverage.
+      Verify: recorded device pass with prompt text suppressed; every step reachable by
+      audio and touch alone.
       Evidence: UNMET
 - [ ] **Q-12** Three children on one device have fully independent progress, verified
       by a test that cross-reads namespaces **and** by a named person on a real device.
@@ -469,19 +473,32 @@ See [PACK_SYSTEM.md](PACK_SYSTEM.md) and
       Verify: timed observation with three parents.
       Evidence: UNMET
 - [ ] **Q-14** `[art]` Three strangers shown **only** the committed M6 screenshots,
-      unprompted, do not use the word "dashboard" or the word "template"; a **named**
-      art director signs off on those images.
+      unprompted, do not use the word "dashboard" or the word "template"; the art
+      director signs off on those images. The art director is the founder
+      ([ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md)) — the role is
+      filled, so this item is no longer blocked on anyone. The strangers are adults shown
+      images; they are not participants and need no consent regime, and their verbatims
+      are the part of this item that is **not** the founder's own judgement, which is why
+      they are not optional.
       Verify: verbatims plus a signed record in the M6 PR.
       Evidence: UNMET
 
 ## H. Compliance and governance
 
-- [ ] **G-01** `[founder]` The Kids Category / Play under-13 decision is recorded in
-      [ADR-0001](DECISIONS/ADR-0001-kids-category-posture.md) with status Accepted
-      **before** the first store submission. Apple 1.3 makes it a one-way door.
+- [ ] **G-01** `[founder]` The **category election** — Kids Category / Play under-13, or
+      Education with a 4+ rating — is written into
+      [ADR-0001](DECISIONS/ADR-0001-kids-category-posture.md) **before** the first store
+      submission. Apple 1.3 makes it a one-way door, and submitting without a recorded
+      election *is* electing. The engineering constraints (no third-party ads, analytics
+      or SDKs; a parental gate on every link-out and purchase) are already Accepted as of
+      2026-07-25 and are not what this item waits on.
       Evidence: UNMET
-- [ ] **G-02** `[founder]` The monetization model is decided and recorded in
-      [ADR-0013](DECISIONS/ADR-0013-monetization-model.md) before M9 completes.
+- [ ] **G-02** `[founder]` The **packaging and pricing** of the monetization direction —
+      what the free tier includes, what the subscription unlocks, what it costs — is
+      decided and recorded in
+      [ADR-0013](DECISIONS/ADR-0013-monetization-model.md) before M9 completes. The
+      direction (generous free tier + subscription, offline-first, never block an offline
+      subscriber) is Accepted as of 2026-07-25; the packaging is not, and carries R-45.
       Evidence: UNMET
 - [ ] **G-03** `[founder]` The repository license is decided and a `LICENSE` file
       exists ([ADR-0014](DECISIONS/ADR-0014-repository-license.md)).
@@ -523,31 +540,43 @@ See [PACK_SYSTEM.md](PACK_SYSTEM.md) and
 
 ## I. Playtest gates (cannot be waived)
 
-- [ ] **T-01** `[playtest]` **M2**: 6+ children aged 6–11 — including **at least one
-      grade-1 child who cannot yet read** (the `Q-11` instrument) — at least 2 of whom
-      dislike math, each complete two unsupervised 20-minute sessions on a real device.
-      Time-to-voluntary-quit, unprompted verbatims and next-day voluntary return rate
-      are recorded in `PLAYTEST-M2.md`.
+The evaluator is the founder's 10-year-old son, observed by the founder
+([ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md),
+[PLAYTEST-PROTOCOL.md](PLAYTEST-PROTOCOL.md)). `n = 1` is stated beside every number
+recorded here. These are observations, not measurements of a population, and none of
+them may be restated publicly as a claim about children.
+
+- [ ] **T-01** `[playtest]` **M2**: the child completes two unsupervised 20-minute
+      sessions on a reference device from a store build, on separate days. Recorded in
+      `PLAYTEST-M2.md`: time to voluntary quit for each session, unprompted verbatims
+      including the discouraging ones, next-day voluntary return (yes/no), where he got
+      stuck, and what he skipped or worked around.
       Evidence: UNMET
-- [ ] **T-02** `[playtest]` **M2**: at least 3 of the 6 children, unprompted, do
-      something after a wrong answer other than ask for the answer — i.e. the LOCATE
-      contrast pair reads as an explanation, not a punishment.
+- [ ] **T-02** `[playtest]` **M2**: for **every** wrong answer across both sessions, what
+      the child did next is recorded as one of retried / asked for the answer / studied
+      the contrast / ignored it / quit. The gate **fails** if he never once, unprompted,
+      does anything other than ask for the answer or disengage — that is the LOCATE
+      contrast pair reading as punishment rather than as an explanation. The raw counts
+      are reported as counts, never as a percentage.
       Evidence: UNMET
-- [ ] **T-03** `[playtest]` **M2**: residuals from the cohort are fitted against
-      predicted `b()` and reported in `PLAYTEST-M2.md`, **before** M7 spends on content
-      breadth.
+- [ ] **T-03** `[playtest]` **M2**: the child's per-item correctness with the predicted
+      `b()` for each item served is exported from Developer Mode, committed as a fixture,
+      and reported in `PLAYTEST-M2.md` **before** M7 spends on content breadth. One
+      child's residuals detect a gross mismatch between predicted and observed
+      difficulty; they do not calibrate `b()` and the report says so (`A-02`, R-26).
       Evidence: UNMET
-- [ ] **T-04** `[playtest]` **M6**: the same 6+ children return for two more 20-minute
-      sessions. Recorded in `PLAYTEST-M6.md`: can each child say, unprompted, what they
-      are building and why they chose it; does the chosen-chamber mechanic change what
-      they do.
+- [ ] **T-04** `[playtest]` **M6**: the same child returns for two more 20-minute
+      sessions. Recorded in `PLAYTEST-M6.md`: can he say, unprompted, what he is building
+      and why he chose it; did the chosen-chamber mechanic visibly change what he did.
       Evidence: UNMET
-- [ ] **T-05** `[playtest]` **M8**: with 6+ children, after a LOCATE contrast pair the
-      child's next attempt at the same mal-rule class is correct more often than after
-      a Stage-1 verify. If it is not, LOCATE is revised or cut. Recorded in
-      `PLAYTEST-M8.md`.
+- [ ] **T-05** `[playtest]` **M8**: his next attempt at the same mal-rule class after a
+      LOCATE contrast pair, versus after a Stage-1 verify, recorded per occurrence in
+      `PLAYTEST-M8.md`. If LOCATE shows no advantage, it is revised or cut. With one
+      child this is an observation and not a measurement, and the report states that in
+      those words rather than reporting a difference as though it were one.
       Evidence: UNMET
-- [ ] **T-06** Every playtest gate has a committed report and **none was waived**.
+- [ ] **T-06** Every playtest gate has a committed report and **none was waived**. There
+      is no recruitment to wait for, so a missing report is a choice.
       Verify: three reports exist and `STATUS.md` records no waiver.
       Evidence: UNMET
 

--- a/dynawalla/docs/ADAPTIVE_LEARNING.md
+++ b/dynawalla/docs/ADAPTIVE_LEARNING.md
@@ -238,10 +238,14 @@ plus one explicit **misspecification persona** whose true `b` differs from the e
 by a structured offset. EG-5 then measures robustness, which is what it was supposed to
 do.
 
-**And a real-child anchor before content breadth is bought:** residuals from the M2
-playtest cohort are fitted against predicted `b` and committed as a fixture
-(`T-03`, `A-02`). If that fit is skipped "until there is more content," the engine is
-unvalidated all the way to launch.
+**And a real-child sanity check before content breadth is bought:** residuals from the M2
+playtest are fitted against predicted `b` and committed as a fixture
+(`T-03`, `A-02`). It is **one child's** response data
+([ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md)), so it detects a gross
+mismatch between predicted and observed difficulty and it does not calibrate `b()`. The
+non-circularity argument therefore rests on the misspecified personas above; this fixture
+is the check that the personas are not all wrong in the same direction. If it is skipped
+"until there is more content," even that check is gone.
 
 **Eleven personas: ten behavioural plus one misspecification.** The ten behavioural ones
 are steady-strong, struggling, fast-careless, slow-accurate, **accurate-counter-on**,

--- a/dynawalla/docs/DECISIONS.md
+++ b/dynawalla/docs/DECISIONS.md
@@ -5,10 +5,16 @@ ADRs; they live in [ARCHITECTURE.md](ARCHITECTURE.md).
 
 **Status vocabulary**
 
-- **Accepted** — decided by the program, evidence recorded, implement against it.
+- **Accepted** — decided, evidence recorded, implement against it.
+- **Accepted (direction)** — the shape is decided and load-bearing engineering may
+  proceed against it; a named sub-decision inside it is explicitly still open. The ADR
+  says which.
 - **Proposed — awaiting founder** — the decision is the founder's. The ADR states the
   options and their consequences and **invents no answer**. Do not implement past the
   point where the choice becomes load-bearing.
+- **Deferred to <trigger>** — deliberately not decided yet, with the trigger named. The
+  ADR must also record what makes the deferral safe, i.e. why nothing is being built that
+  the later decision would invalidate.
 - **Superseded by ADR-NNNN** — kept for the record; never edited in place.
 
 An ADR is amended by writing a new one, not by rewriting the old one. The reasoning is
@@ -17,7 +23,7 @@ cheerfully reintroduce a mistake that was already paid for once.
 
 | ADR | Title | Status |
 |---|---|---|
-| [0001](DECISIONS/ADR-0001-kids-category-posture.md) | Apple Kids Category and Play under-13 target audience | **Proposed — awaiting founder** |
+| [0001](DECISIONS/ADR-0001-kids-category-posture.md) | Apple Kids Category and Play under-13 target audience | Accepted (constraints) · election **Deferred to submission** |
 | [0002](DECISIONS/ADR-0002-v1-scope-cut.md) | V1 covers number and arithmetic only | **Proposed — awaiting founder** |
 | [0003](DECISIONS/ADR-0003-no-downloadable-packs-v1.md) | No downloadable content packs in V1 | Accepted |
 | [0004](DECISIONS/ADR-0004-no-mic-no-llm-no-3d.md) | No microphone, no on-device LLM, no 3D | Accepted |
@@ -26,36 +32,52 @@ cheerfully reintroduce a mistake that was already paid for once.
 | [0007](DECISIONS/ADR-0007-launch-locales.md) | Five launch locales; Arabic numbering system deferred | Accepted (sub-decision open) |
 | [0008](DECISIONS/ADR-0008-fsrs-on-classes-latency-rating.md) | FSRS keyed on skill classes, rated on correctness **and** latency | Accepted |
 | [0009](DECISIONS/ADR-0009-stakes-without-loss.md) | The stakes are chamber choice, working mechanisms, and discovery | Accepted |
-| [0010](DECISIONS/ADR-0010-standards-alignment-claim.md) | Public standards-alignment claim | **Proposed — awaiting founder** |
+| [0010](DECISIONS/ADR-0010-standards-alignment-claim.md) | Public standards-alignment claim | **Proposed — awaiting founder** (research in flight) |
 | [0011](DECISIONS/ADR-0011-native-workspace-and-patch-placement.md) | `native/` workspace, independent app roots, `[patch]` stays put | Accepted |
 | [0012](DECISIONS/ADR-0012-ota-curriculum-deferral.md) | Curriculum ships bundled; OTA deferred with a stated trigger | Accepted |
-| [0013](DECISIONS/ADR-0013-monetization-model.md) | Monetization model | **Proposed — awaiting founder** |
-| [0014](DECISIONS/ADR-0014-repository-license.md) | Repository license | **Proposed — awaiting founder** |
-| [0015](DECISIONS/ADR-0015-developer-account-topology.md) | Developer-account topology | **Proposed — awaiting founder** |
-| [0016](DECISIONS/ADR-0016-app-store-product-name.md) | App Store product name | **Proposed — awaiting founder** |
-| [0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md) | Human evaluation resourcing | **Proposed — awaiting founder** |
+| [0013](DECISIONS/ADR-0013-monetization-model.md) | Monetization model | Accepted (direction); packaging open |
+| [0014](DECISIONS/ADR-0014-repository-license.md) | Repository license | **Proposed — awaiting founder** (research in flight) |
+| [0015](DECISIONS/ADR-0015-developer-account-topology.md) | Developer-account topology | Accepted |
+| [0016](DECISIONS/ADR-0016-app-store-product-name.md) | App Store product name | **Proposed — awaiting founder** (check in flight) |
+| [0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md) | Human evaluation resourcing | Accepted |
 | [0018](DECISIONS/ADR-0018-multi-child-profiles.md) | Multi-child profiles designed in from M2 | Accepted |
 | [0019](DECISIONS/ADR-0019-no-stage-environment.md) | No stage environment | Accepted |
 
-## Open founder decisions, in the order they bite
+## Decided on 2026-07-25
 
-1. **ADR-0001 Kids Category** — a one-way door under Apple Guideline 1.3. Must be
-   Accepted **before M1's first store submission**. The engineering plan already assumes
-   the strict posture, so choosing *in* costs nothing extra; choosing *out* is the
-   decision that would let constraints relax.
-2. **ADR-0017 Human evaluation resourcing** — the founder must supply a playtest cohort
-   and a named art director. Recruitment has weeks of lead time, which is why
-   [PLAYTEST-PROTOCOL.md](PLAYTEST-PROTOCOL.md) starts in the bootstrap PR.
-3. **ADR-0002 V1 scope cut** — narrows the founder-stated grade range (1–6 plus intro
+Four ADRs closed in one pass, recorded from the founder's own words in each ADR:
+
+- **ADR-0017 Human evaluation resourcing** — the evaluator is the founder's 10-year-old
+  son; the founder holds every adult role including art director. No external cohort, no
+  recruitment, no consent paperwork. The protocol keeps measuring the same five things
+  and the ADR states plainly what a sample of one cannot support.
+- **ADR-0015 Developer-account topology** — same Corpora accounts as Corpán, with the
+  shared blast radius and nomination pool accepted as costs.
+- **ADR-0013 Monetization** — direction only: generous free tier plus a subscription for
+  unlimited exercises and full access; packaging and pricing still open, and the
+  founder's own "hasn't worked in the slightest" is carried as R-45.
+- **ADR-0001 Kids Category** — the engineering constraints (no third-party ads,
+  analytics or SDKs) are locked unconditionally; a parental-gate primitive is built and
+  every link-out routes through it; the category election itself is deferred to
+  submission, after monetization is wired.
+
+## Still open, in the order they bite
+
+1. **ADR-0016 product name** — needed before the ASC and Play app records are created in
+   M1. The SKU and package name are literally immutable. The founder expects the name is
+   clear and asked for the check; the check is in flight.
+2. **ADR-0002 V1 scope cut** — narrows the founder-stated grade range (1–6 plus intro
    pre-algebra) to grades 1–5 number and arithmetic, and rewrites the public claim.
    Needed before any public scope statement, and before M4 buys curriculum breadth
    against one range or the other. The engineering argument is settled; the scope
-   decision is not the plan's.
-4. **ADR-0015 Developer-account topology** and **ADR-0016 product name** — both needed
-   before the ASC and Play app records are created in M1. The SKU and package name are
-   literally immutable.
-5. **ADR-0014 License** — decides whether outside contributions are wanted at all, and
-   therefore whether the fork-PR gate path is worth maintaining.
-6. **ADR-0010 Standards-alignment claim** — needed before any public marketing copy;
-   decides whether gate CG-20 stays report-only.
-7. **ADR-0013 Monetization** — deferring past M7 is fine; past M9 blocks launch.
+   decision is not the plan's. It now also interacts with
+   [ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md): grades 1–2 will ship
+   with no child observation behind them unless a younger evaluator is added.
+3. **ADR-0014 License** — decides whether outside contributions are wanted at all, and
+   therefore whether the fork-PR gate path is worth maintaining. Research in flight.
+4. **ADR-0010 Standards-alignment claim** — needed before any public marketing copy;
+   decides whether gate CG-20 stays report-only. Research in flight.
+5. **ADR-0001's category election** — deferred by design, but it is still a one-way door
+   and it must be written into the ADR before M1's first submission (`G-01`).
+6. **ADR-0013's packaging and pricing** — deferring past M7 is fine; past M9 blocks
+   launch (`G-02`).

--- a/dynawalla/docs/DECISIONS.md
+++ b/dynawalla/docs/DECISIONS.md
@@ -17,9 +17,26 @@ ADRs; they live in [ARCHITECTURE.md](ARCHITECTURE.md).
   the later decision would invalidate.
 - **Superseded by ADR-NNNN** — kept for the record; never edited in place.
 
-An ADR is amended by writing a new one, not by rewriting the old one. The reasoning is
-the artifact — several of these exist specifically so a future agent does not
-cheerfully reintroduce a mistake that was already paid for once.
+**When an ADR may be edited in place, amended 2026-07-25.** The original rule read "an
+ADR is amended by writing a new one, not by rewriting the old one," full stop. That rule
+is right for a *decided* ADR and wrong for the two cases this program actually hit first,
+so it is made precise rather than quietly broken:
+
+1. **Reaching a decision is not an amendment.** An ADR sitting at `Proposed — awaiting
+   founder` is an open question. Writing the founder's answer into it is the ADR arriving
+   at its purpose, not a rewrite of a decision. Record the answer, the date, and the
+   founder's own words; do not open a second ADR to say what the first one was for.
+2. **Correcting a factual error is not an amendment either** — provided the ADR has not
+   yet been implemented against, and provided **the error is left visible.** A wrong fact
+   that a future agent might re-derive must be quoted as superseded inside the ADR, with
+   what was wrong and why, exactly as ADR-0001 does for its parental-gate and age-band
+   errors. Deleting the mistake destroys the artifact; the reasoning *is* the artifact.
+3. **Everything else still requires a new ADR.** Once an ADR is `Accepted` and code or
+   store state depends on it, changing the decision means writing ADR-NNNN that supersedes
+   it. A `Superseded` ADR is never edited in place, for any reason.
+
+Any in-place edit carries a dated **Amended** or **Corrected** line in the ADR header
+saying what changed, so the history is readable without `git log`.
 
 | ADR | Title | Status |
 |---|---|---|
@@ -38,7 +55,7 @@ cheerfully reintroduce a mistake that was already paid for once.
 | [0013](DECISIONS/ADR-0013-monetization-model.md) | Monetization model | Accepted (direction); packaging open |
 | [0014](DECISIONS/ADR-0014-repository-license.md) | Repository license | **Proposed — awaiting founder** (research in flight) |
 | [0015](DECISIONS/ADR-0015-developer-account-topology.md) | Developer-account topology | Accepted |
-| [0016](DECISIONS/ADR-0016-app-store-product-name.md) | App Store product name | **Proposed — awaiting founder** (check in flight) |
+| [0016](DECISIONS/ADR-0016-app-store-product-name.md) | App Store product name | **Proposed — awaiting founder** (checks returned 2026-07-25; two counsel-grade collisions open) |
 | [0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md) | Human evaluation resourcing | Accepted |
 | [0018](DECISIONS/ADR-0018-multi-child-profiles.md) | Multi-child profiles designed in from M2 | Accepted |
 | [0019](DECISIONS/ADR-0019-no-stage-environment.md) | No stage environment | Accepted |
@@ -51,33 +68,28 @@ Four ADRs closed in one pass, recorded from the founder's own words in each ADR:
   son; the founder holds every adult role including art director. No external cohort, no
   recruitment, no consent paperwork. The protocol keeps measuring the same five things
   and the ADR states plainly what a sample of one cannot support.
-- **ADR-0015 Developer-account topology** — same Corpora accounts as Corpán, with the
-  shared blast radius and nomination pool accepted as costs.
+- **ADR-0015 Developer-account topology** — same Corpora accounts as Corpán. The founder
+  said "same as Corpan I think"; the blast-radius cost was identified by the program and
+  **was not put to him**, which the ADR now says in its header.
 - **ADR-0013 Monetization** — direction only: generous free tier plus a subscription for
   unlimited exercises and full access; packaging and pricing still open, and the
-  founder's own "hasn't worked in the slightest" is carried as R-45.
+  founder's own "I'm not sure" and "hasn't worked in the slightest" are carried as R-45
+  rather than smoothed into a mandate.
 - **ADR-0001 Kids Category** — the engineering constraints (no third-party ads,
   analytics or SDKs) are locked unconditionally; a parental-gate primitive is built and
-  every link-out routes through it; the category election itself is deferred to
-  submission, after monetization is wired.
+  every link-out routes through it; the category election, **and the age band inside
+  it**, are deferred to submission.
 
-## Still open, in the order they bite
+## Still open
 
-1. **ADR-0016 product name** — needed before the ASC and Play app records are created in
-   M1. The SKU and package name are literally immutable. The founder expects the name is
-   clear and asked for the check; the check is in flight.
-2. **ADR-0002 V1 scope cut** — narrows the founder-stated grade range (1–6 plus intro
-   pre-algebra) to grades 1–5 number and arithmetic, and rewrites the public claim.
-   Needed before any public scope statement, and before M4 buys curriculum breadth
-   against one range or the other. The engineering argument is settled; the scope
-   decision is not the plan's. It now also interacts with
-   [ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md): grades 1–2 will ship
-   with no child observation behind them unless a younger evaluator is added.
-3. **ADR-0014 License** — decides whether outside contributions are wanted at all, and
-   therefore whether the fork-PR gate path is worth maintaining. Research in flight.
-4. **ADR-0010 Standards-alignment claim** — needed before any public marketing copy;
-   decides whether gate CG-20 stays report-only. Research in flight.
-5. **ADR-0001's category election** — deferred by design, but it is still a one-way door
-   and it must be written into the ADR before M1's first submission (`G-01`).
-6. **ADR-0013's packaging and pricing** — deferring past M7 is fine; past M9 blocks
-   launch (`G-02`).
+**[STATUS.md](STATUS.md) is the single source of truth for what is open and when it
+bites** — it is the file kept current in the PR that changes it. This index previously
+disagreed with both STATUS.md and MISSION.md about how many decisions were outstanding,
+which is exactly how one goes unnoticed. Do not re-enumerate them here.
+
+The short version, for orientation only: **ADR-0016** (name), **ADR-0002** (scope cut),
+**ADR-0014** (license) and **ADR-0010** (standards claim) are open at the ADR level; and
+two decisions live *inside* ADRs that are otherwise decided — **ADR-0001's category
+election and age band** (`G-01`) and **ADR-0013's packaging and pricing** (`G-02`). The
+**age-band choice is the newest and the least expected**: no V1 scope currently proposed
+fits a single Apple Kids band.

--- a/dynawalla/docs/DECISIONS/ADR-0001-kids-category-posture.md
+++ b/dynawalla/docs/DECISIONS/ADR-0001-kids-category-posture.md
@@ -6,8 +6,12 @@ mechanism. **The category election itself is Deferred to submission** (`G-01`), 
 the product's scope" below, which couples this ADR to
 [ADR-0002](ADR-0002-v1-scope-cut.md).
 
-**Amended 2026-07-25:** the parental-gate reasoning in the first revision was inverted and
-is corrected below; the store-reconnaissance placeholders are filled with verified data.
+**Corrected 2026-07-25, twice.** The first revision's parental-gate reasoning was
+inverted, and its age-band section described 9-11 as a "ceiling" that a grades 1–5 scope
+would fit. Both were wrong, both are corrected below, and **both are quoted as superseded
+rather than deleted** so they are not re-derived — per the in-place-edit rule in
+[DECISIONS.md](../DECISIONS.md). The store-reconnaissance placeholders are also filled
+with verified data.
 
 ## Context
 
@@ -62,8 +66,10 @@ challenge *is* the canonical parental gate, so it costs us almost nothing." **Th
 backwards and it is recorded here so it is not re-derived.**
 
 Apple's canonical illustrated parental gate *is* a maths problem — which is exactly why a
-mathematics app cannot use one. A grade-4 child solves `6 × 7` faster than their parent
-does. Being a maths app makes an arithmetic gate **useless**, not free: the app spends
+mathematics app cannot usefully use one. **Apple does not forbid it; it is simply
+ineffective here, and that is our engineering judgement rather than a store rule.** A
+grade-4 child solves `6 × 7` faster than their parent does. Being a maths app makes an
+arithmetic gate **useless**, not free: the app spends
 every session training the precise skill the gate uses as its filter, and it succeeds at
 it. There is no "set the arithmetic above the curriculum band" fix either, because the
 band moves upward as the child improves and the gate would have to outrun its own users.
@@ -98,35 +104,62 @@ electable at submission time with zero rework** — and so does plain Education 
 rating. The decision is reversible by construction because the expensive half is built
 either way.
 
-### The age bands do not span the product's scope
+### No Apple Kids band expresses this product, at any V1 scope
 
 This is new information and it **couples this ADR to
 [ADR-0002](ADR-0002-v1-scope-cut.md)**. It was not previously recorded in either.
 
 | Store | Bands | Selection |
 |---|---|---|
-| Apple Kids Category | 5-and-under · 6-8 · **9-11** | **Exactly one** |
-| Play target audience | 5-and-under · 6-8 · **9-12** · 13-15 · 16-17 · 18+ | Multi-select |
+| Apple Kids Category | 5-and-under · 6-8 · 9-11 | **Exactly one** |
+| Play target audience | 5-and-under · 6-8 · 9-12 · 13-15 · 16-17 · 18+ | Multi-select |
 
-The founder-stated scope — grades 1–6 plus intro pre-algebra — spans roughly **ages
-6–12**. **Apple has no band above 9-11.** Play's 9-12 covers the range; Apple's does not.
+Apple's requirement is to *choose one* of three bands — **not** to declare a maximum age.
+Play's declaration is multi-select and can simply express a range.
 
-ADR-0002's proposed cut to grades 1–5 lands **exactly inside Apple's 9-11 ceiling**.
-Grade 6 plus pre-algebra pushes past it. So the scope decision and the category decision
-are the same decision viewed from two sides, and neither ADR could see that until now.
+**An earlier revision of this ADR got this wrong and the error is corrected here.** It
+described 9-11 as a "ceiling," and claimed that ADR-0002's cut to grades 1–5 "lands
+exactly inside" it so the scope and band decisions "become consistent for free." That
+reasoning does not survive the docs' own grade-to-age mapping:
+
+- Grades 1–6 plus pre-algebra ≈ **ages 6–12**.
+- Grades 1–5 ≈ **ages 6–11** — which spans **both the 6-8 band and the 9-11 band**.
+
+So **cutting grade 6 removes the overflow past age 11 and resolves nothing about which
+single band gets declared.** No Apple Kids band expresses grades 1–5 either. The band
+problem is not a consequence of the scope being too wide at the top; it is a consequence
+of a grade-school maths product spanning more childhood than one Apple band covers, and
+**it survives every V1 scope currently on the table.**
+
+The only V1 cuts that genuinely fit one band are roughly:
+
+| Cut | Band | What it costs |
+|---|---|---|
+| ~grades 4–5 | 9-11 | Discards grades 1–3 — the foundational number and place-value work, and read-aloud's entire reason for landing at M2. |
+| ~grades 1–3 | 6-8 | Discards multiplication, division and fractions — including the fraction work that the evidence in ADR-0002 says uniquely predicts later algebra achievement. |
+
+Both are far more expensive than the scope cut ADR-0002 is currently proposing, and
+neither is being recommended here. They are recorded so the founder can see the **real**
+price of electing the Kids Category, rather than being told the coupling is cheap.
 
 Options, **not decided**:
 
-- **(a) Declare 9-11 and accept the top-end skew.** The listing then reads as a 9–11
-  product while the curriculum starts at grade 1, which is a discovery and expectation
-  cost at the young end.
-- **(b) Two SKUs**, split by band. Doubles the store surface, the review exposure, the
-  release pipeline and the support burden, for one product.
-- **(c) Skip the Kids Category.** **This is a trap, not an escape.** Guideline 2.3.8
-  reserves "For Kids" / "For Children" metadata *to* the Kids Category, and 5.1.4(b)
-  forbids child-implying metadata *outside* it. For a grade-school mathematics app that
-  is close to unworkable — the honest description of the product is the metadata the
-  guideline forbids.
+- **(a) Declare one band and accept the mismatch.** Under 9-11 the listing reads as a
+  9–11 product while the curriculum starts at grade 1; under 6-8 it reads as a 6–8 product
+  while the curriculum runs to grade 5. **This skew is unavoidable at grades 1–5 exactly
+  as it is at grades 1–6** — the scope cut does not reduce it. Cheapest option, and it
+  means the store's age signal is knowingly not the product's actual range.
+- **(b) Two SKUs**, split by band. The only option that represents the product honestly
+  on Apple's terms. Doubles the store surface, the review exposure, the release pipeline
+  and the support burden, for one product.
+- **(c) Narrow V1 to one band** — the table above. Honest and expensive; it is a
+  curriculum decision wearing a store-metadata costume, and it belongs to
+  [ADR-0002](ADR-0002-v1-scope-cut.md).
+- **(d) Skip the Kids Category.** **A trap, not an escape.** Guideline 2.3.8 reserves
+  "For Kids" / "For Children" metadata *to* the Kids Category, and 5.1.4(b) forbids
+  child-implying metadata *outside* it. For a grade-school mathematics app that is close
+  to unworkable — the honest description of the product is the metadata the guideline
+  forbids.
 
 This is a founder decision and it is **not yet made**.
 
@@ -175,7 +208,9 @@ election is verifiable after the fact rather than a matter of recollection. Corp
   paid on every link forever. It is also a real component with real cost — a randomized,
   non-persistent, non-curricular challenge is not something the app already has lying
   around. The earlier "it is nearly free because we are a maths app" framing was wrong in
-  both directions: the gate is neither free nor allowed to be arithmetic.
+  both directions: the gate is neither free nor usefully arithmetic. (Apple does not
+  *forbid* an arithmetic gate — its own illustrated example is one. It is ineffective
+  **for this product**, which is our decision, not a store rule.)
 - **Routing the privacy policy through an in-app screen rather than an external URL
   removes one gate entirely**, and is the cheapest single decision in this whole area.
 - **Electing in locks the constraint set forever**, through any future pivot, including
@@ -191,9 +226,10 @@ election is verifiable after the fact rather than a matter of recollection. Corp
 - **Deferring has a cost of its own:** store listing copy, the age-band selection and any
   Teacher Approved positioning are written against an undecided posture, so some listing
   work may be done twice.
-- **The band question outlives the election.** Even electing in leaves the 9-11 ceiling
-  versus a grades 1–6 scope unresolved, which is why it is written up above as a founder
-  decision in its own right rather than as a listing detail.
+- **The band question outlives the scope question.** No V1 scope currently proposed fits
+  a single Apple band, so electing in forces a choice between misdeclaring the age range,
+  shipping two SKUs, or cutting the curriculum to fit a band. That is written up above as
+  a founder decision in its own right rather than as a listing detail.
 - Either way, the declarations must be consistent with actual behaviour and with the CI
   dependency audit (`G-07`).
 

--- a/dynawalla/docs/DECISIONS/ADR-0001-kids-category-posture.md
+++ b/dynawalla/docs/DECISIONS/ADR-0001-kids-category-posture.md
@@ -1,7 +1,7 @@
 # ADR-0001 — Apple Kids Category and Play under-13 target audience
 
-**Status:** Proposed — awaiting founder
-**Deadline:** must be Accepted **before M1's first store submission** (`G-01`)
+**Status:** Accepted — 2026-07-25, for the engineering constraints and the deferral
+mechanism. **The category election itself is Deferred to submission** (`G-01`).
 
 ## Context
 
@@ -10,33 +10,101 @@ meet these guidelines in subsequent updates, **even if you decide to deselect th
 category**." It is a one-way door. Google Play's target-audience declaration carries the
 Families Policy with it.
 
-The engineering plan already assumes the strict posture regardless: on-device-only
-instrumentation, no third-party analytics or advertising SDKs, and a parental-gate
-primitive in M1's shell. So the strict posture is being built either way.
+The founder's position:
 
-## Options
+> "I like Apple kids category. I think it's worth it to stay clean. We are privacy
+> focused anyways and we don't want third party garbage and such anyways. I'm not sure
+> about link outs and stuff ... maybe 3+/4+ without the kids category is enough. Whatever
+> Corpan is is fine .. we don't have a parental consent for external links (github, our
+> website ...) ... no third party ads/analytics etc .. links though 🤷‍♂️"
 
-**A. In — Kids Category (Apple) + under-13 target audience (Play).**
-Requires an age band (5-and-under / 6-8 / 9-11), parental gates on every link-out and
-purchase, and permanently forbids third-party analytics and behavioural advertising.
-Gains Kids Category discovery and Play's Teacher Approved eligibility. Costs nothing
-extra over the plan as written.
+That splits cleanly into a settled part and an open part, and this ADR records them
+separately so the settled part stops being re-litigated.
 
-**B. Out — Education category with an honest 4+ rating.**
-Keeps options open (a future analytics SDK, a future ad-supported tier) and forfeits the
-Kids Category discovery surface. This is the option that would let the engineering
-constraints relax; nothing in the plan currently depends on that relaxation.
+## Decision
 
-## Consequences
+### Locked now, unconditionally, independent of any category election
 
-- **A** locks the constraint set forever, including through any future pivot, and makes
-  `G-05`/`G-06` permanent product invariants rather than V1 choices.
-- **B** requires an explicit decision about what would then be permitted, otherwise it
-  is strictly worse than A: all of the cost, none of the discovery.
-- Either way the age band or content rating must be consistent with actual behaviour and
-  with the CI dependency audit (`G-07`).
+- **No third-party advertising SDK.**
+- **No third-party analytics SDK.** All instrumentation is on-device; there is no
+  telemetry endpoint and no server profile.
+- **No third-party SDK of the kind the Kids Category forbids**, and every dependency
+  addition is a compliance decision rather than a build decision.
+- **No AAID / IMEI / MAC / phone number transmitted, no precise location collected.**
 
-## Notes for whoever decides
+These are the founder's stated preference regardless of category, so they are product
+invariants and not V1 choices. `G-05` and `G-06` enforce them mechanically via the CI
+dependency audit, cross-checked against the submitted Play Data safety declaration.
+Nothing downstream needs to wait for the election to build against them.
 
-Do not let this be decided implicitly by a store submission. Submitting M1's build
-without a recorded decision **is** choosing, and it is the branch that cannot be undone.
+### The open variable is external links
+
+Apple's Kids Category requires a parental gate before a link out of the app and before a
+purchase. Corpán today links out to GitHub and the website with no gate. That is the only
+part of the strict posture Dynawalla does not already satisfy by construction, and it is
+the part the founder flagged.
+
+### Decision: build the gate, defer the election
+
+**Build a parental-gate primitive in M1's shell and route every external link and every
+purchase entry point through it** (`G-08`, [ADR-0005](ADR-0005-shell-and-routing.md)).
+
+The observation that makes this cheap: **for a mathematics app, an arithmetic challenge
+is the canonical Apple-acceptable parental gate.** The gate is literally the product.
+Other apps pay a real UX tax and a real implementation cost for a mechanism unrelated to
+anything else they do; here it is a rendering of a component the app already has, in a
+visual language it already speaks.
+
+With the gate shipped and no third-party SDKs present, **the Kids Category remains
+electable at submission time with zero rework** — and so does plain Education with a 4+
+rating. The decision is reversible by construction because the expensive half is built
+either way.
+
+### Final election is deferred to submission
+
+Specifically, **until monetization is wired**. Play's Families Policy and Apple's Kids
+Category both constrain how purchases may be surfaced to children, and
+[ADR-0013](ADR-0013-monetization-model.md) now sets a direction (free tier plus a
+subscription) whose purchase surface does not exist yet. Electing a category before that
+surface is in hand means deciding the interaction twice.
+
+### Default if nothing changes
+
+**Match Corpán's existing App Store category and age rating.** The founder's "whatever
+Corpan is is fine" is the recorded default.
+
+`TODO(store-recon)` — a store reconnaissance is in flight to confirm what Corpán is
+actually categorised and rated as today, on both stores. The specific category and rating
+values are deliberately **not written here**, because guessing them and then treating the
+guess as a decision is exactly how a one-way door gets walked through by accident.
+
+## Consequences, including the ones that cost something
+
+- **A parental gate in front of every link-out is friction for adults too.** A parent who
+  wants the privacy policy or the GitHub repo solves an arithmetic problem first. That is
+  the tax, it is small, and it is paid on every link forever.
+- **The gate's arithmetic has to be beyond the app's own target range**, or the children
+  being taught grades 1–5 arithmetic will walk straight through the thing that exists to
+  exclude them. This is a genuine and slightly absurd tension unique to this product: our
+  users are being trained on the exact skill the gate uses as its filter. The gate must
+  therefore sit above the V1 band and be re-checked whenever the curriculum's ceiling
+  moves.
+- **Electing in locks the constraint set forever**, through any future pivot, including
+  one where an analytics SDK or an ad-supported tier would have been the obvious answer.
+  Nothing in the plan currently depends on that relaxation, but a future product might.
+- **Electing out is only rational with an explicit statement of what would then be
+  permitted.** Taking the Education/4+ route while keeping every Kids Category constraint
+  voluntarily is all of the cost and none of the discovery — strictly worse than electing
+  in. If the election goes that way, record what relaxes.
+- **Deferring has a cost of its own:** store listing copy, the age-band selection (Kids
+  Category requires 5-and-under / 6-8 / 9-11) and any Teacher Approved positioning are
+  written against an undecided posture, so some listing work may be done twice.
+- Either way, the declarations must be consistent with actual behaviour and with the CI
+  dependency audit (`G-07`).
+
+## Notes for whoever closes this
+
+Do not let the election be decided implicitly by a store submission. Submitting M1's
+build without a recorded election **is** choosing, and it is the branch that cannot be
+undone. `G-01` is met when the election is written into this ADR before the first
+submission — not when someone clicks a category picker.

--- a/dynawalla/docs/DECISIONS/ADR-0001-kids-category-posture.md
+++ b/dynawalla/docs/DECISIONS/ADR-0001-kids-category-posture.md
@@ -1,7 +1,13 @@
 # ADR-0001 — Apple Kids Category and Play under-13 target audience
 
 **Status:** Accepted — 2026-07-25, for the engineering constraints and the deferral
-mechanism. **The category election itself is Deferred to submission** (`G-01`).
+mechanism. **The category election itself is Deferred to submission** (`G-01`), and the
+**age-band choice inside it is an open founder decision** — see "The age bands do not span
+the product's scope" below, which couples this ADR to
+[ADR-0002](ADR-0002-v1-scope-cut.md).
+
+**Amended 2026-07-25:** the parental-gate reasoning in the first revision was inverted and
+is corrected below; the store-reconnaissance placeholders are filled with verified data.
 
 ## Context
 
@@ -49,16 +55,80 @@ the part the founder flagged.
 **Build a parental-gate primitive in M1's shell and route every external link and every
 purchase entry point through it** (`G-08`, [ADR-0005](ADR-0005-shell-and-routing.md)).
 
-The observation that makes this cheap: **for a mathematics app, an arithmetic challenge
-is the canonical Apple-acceptable parental gate.** The gate is literally the product.
-Other apps pay a real UX tax and a real implementation cost for a mechanism unrelated to
-anything else they do; here it is a rendering of a component the app already has, in a
-visual language it already speaks.
+#### The gate must not be arithmetic — corrected 2026-07-25
+
+An earlier revision of this ADR claimed that "for a mathematics app an arithmetic
+challenge *is* the canonical parental gate, so it costs us almost nothing." **That is
+backwards and it is recorded here so it is not re-derived.**
+
+Apple's canonical illustrated parental gate *is* a maths problem — which is exactly why a
+mathematics app cannot use one. A grade-4 child solves `6 × 7` faster than their parent
+does. Being a maths app makes an arithmetic gate **useless**, not free: the app spends
+every session training the precise skill the gate uses as its filter, and it succeeds at
+it. There is no "set the arithmetic above the curriculum band" fix either, because the
+band moves upward as the child improves and the gate would have to outrun its own users.
+
+**The real barrier for a six-year-old is reading load, not arithmetic.** So:
+
+- **Non-curricular challenge.** Viable shapes: type the current four-digit year; type a
+  spelled-out multi-syllable word shown on screen; press-and-hold-and-drag for N seconds.
+- **Randomized.** A fixed challenge is memorised within a week — by a child who is, by
+  design, good at noticing patterns.
+- **Non-persistent across sessions.** Passing once does not unlock the app's gates for
+  later launches.
+- **Voiceover prompt paired with it if the 5-and-under band is ever elected**, where even
+  the reading-load barrier is doing something different than intended.
+
+#### Where a gate is required
+
+Link-outs; **the privacy-policy link if it is implemented as an external URL** — render
+it as an in-app screen instead and the requirement disappears; any purchase, paywall or
+price display; Restore Purchases; the parent dashboard; and anything that emails or
+shares a child's work.
+
+**Treat permission prompts (microphone, push) as requiring a gate too.** This appears in
+Apple's 2019 Kids Category announcement but not in the current Guideline 1.3 text, which
+makes it reviewer-discretion territory. It is cheap to just do.
+
+**Play imposes no general parental-gate mandate.** Build **one** component and use it on
+both platforms; do not fork the behaviour per store.
 
 With the gate shipped and no third-party SDKs present, **the Kids Category remains
 electable at submission time with zero rework** — and so does plain Education with a 4+
 rating. The decision is reversible by construction because the expensive half is built
 either way.
+
+### The age bands do not span the product's scope
+
+This is new information and it **couples this ADR to
+[ADR-0002](ADR-0002-v1-scope-cut.md)**. It was not previously recorded in either.
+
+| Store | Bands | Selection |
+|---|---|---|
+| Apple Kids Category | 5-and-under · 6-8 · **9-11** | **Exactly one** |
+| Play target audience | 5-and-under · 6-8 · **9-12** · 13-15 · 16-17 · 18+ | Multi-select |
+
+The founder-stated scope — grades 1–6 plus intro pre-algebra — spans roughly **ages
+6–12**. **Apple has no band above 9-11.** Play's 9-12 covers the range; Apple's does not.
+
+ADR-0002's proposed cut to grades 1–5 lands **exactly inside Apple's 9-11 ceiling**.
+Grade 6 plus pre-algebra pushes past it. So the scope decision and the category decision
+are the same decision viewed from two sides, and neither ADR could see that until now.
+
+Options, **not decided**:
+
+- **(a) Declare 9-11 and accept the top-end skew.** The listing then reads as a 9–11
+  product while the curriculum starts at grade 1, which is a discovery and expectation
+  cost at the young end.
+- **(b) Two SKUs**, split by band. Doubles the store surface, the review exposure, the
+  release pipeline and the support burden, for one product.
+- **(c) Skip the Kids Category.** **This is a trap, not an escape.** Guideline 2.3.8
+  reserves "For Kids" / "For Children" metadata *to* the Kids Category, and 5.1.4(b)
+  forbids child-implying metadata *outside* it. For a grade-school mathematics app that
+  is close to unworkable — the honest description of the product is the metadata the
+  guideline forbids.
+
+This is a founder decision and it is **not yet made**.
 
 ### Final election is deferred to submission
 
@@ -71,34 +141,59 @@ surface is in hand means deciding the interaction twice.
 ### Default if nothing changes
 
 **Match Corpán's existing App Store category and age rating.** The founder's "whatever
-Corpan is is fine" is the recorded default.
+Corpan is is fine" is the recorded default. Store reconnaissance returned 2026-07-25 and
+that default is now a specific posture rather than a placeholder:
 
-`TODO(store-recon)` — a store reconnaissance is in flight to confirm what Corpán is
-actually categorised and rated as today, on both stores. The specific category and rating
-values are deliberately **not written here**, because guessing them and then treating the
-guess as a decision is exactly how a one-way door gets walked through by accident.
+| | Corpán, verified live |
+|---|---|
+| Bundle id / SKU | `com.corpora.corpan` |
+| Categories | **EDUCATION** (primary) / **REFERENCE** (secondary) |
+| Age rating | **4+**, all content declarations `NONE` |
+| `kidsAgeBand` | `null` |
+| `isOrEverWasMadeForKids` | **`false`** |
+| Apple Team ID | `F9AV5HKF6N` |
+
+**All four Corpora apps** — Corpán, Homeschool Offline, Yìjīng, PaKO A1 — are 4+, in
+Education or Lifestyle, and **none has ever been in the Kids Category**. So "match
+Corpán" means Education / 4+ / no Kids Category, and there is **no in-house precedent to
+inherit** for a Kids Category submission: it would be the first, and every process step
+would be new.
+
+### The one-way door is a readable API field
+
+`isOrEverWasMadeForKids` on `/v1/apps/{id}` is the **API-visible, permanent expression of
+Apple's "even if you decide to deselect the category" rule**. It is not a setting that
+gets toggled back; it records that the app was *ever* made for kids, and it is queryable.
+
+That is the concrete irreversibility this ADR keeps warning about, and it means the
+election is verifiable after the fact rather than a matter of recollection. Corpán's is
+`false` today. Dynawalla's first submission decides its value forever.
 
 ## Consequences, including the ones that cost something
 
-- **A parental gate in front of every link-out is friction for adults too.** A parent who
-  wants the privacy policy or the GitHub repo solves an arithmetic problem first. That is
-  the tax, it is small, and it is paid on every link forever.
-- **The gate's arithmetic has to be beyond the app's own target range**, or the children
-  being taught grades 1–5 arithmetic will walk straight through the thing that exists to
-  exclude them. This is a genuine and slightly absurd tension unique to this product: our
-  users are being trained on the exact skill the gate uses as its filter. The gate must
-  therefore sit above the V1 band and be re-checked whenever the curriculum's ceiling
-  moves.
+- **A parental gate in front of every link-out is friction for adults too**, and it is
+  paid on every link forever. It is also a real component with real cost — a randomized,
+  non-persistent, non-curricular challenge is not something the app already has lying
+  around. The earlier "it is nearly free because we are a maths app" framing was wrong in
+  both directions: the gate is neither free nor allowed to be arithmetic.
+- **Routing the privacy policy through an in-app screen rather than an external URL
+  removes one gate entirely**, and is the cheapest single decision in this whole area.
 - **Electing in locks the constraint set forever**, through any future pivot, including
   one where an analytics SDK or an ad-supported tier would have been the obvious answer.
   Nothing in the plan currently depends on that relaxation, but a future product might.
 - **Electing out is only rational with an explicit statement of what would then be
   permitted.** Taking the Education/4+ route while keeping every Kids Category constraint
   voluntarily is all of the cost and none of the discovery — strictly worse than electing
-  in. If the election goes that way, record what relaxes.
-- **Deferring has a cost of its own:** store listing copy, the age-band selection (Kids
-  Category requires 5-and-under / 6-8 / 9-11) and any Teacher Approved positioning are
-  written against an undecided posture, so some listing work may be done twice.
+  in. Note that it does **not** buy freedom in the listing: 2.3.8 and 5.1.4(b) still
+  forbid child-implying metadata outside the category, so "skip it and describe the
+  product honestly" is not an available combination. If the election goes that way,
+  record what actually relaxes.
+- **Deferring has a cost of its own:** store listing copy, the age-band selection and any
+  Teacher Approved positioning are written against an undecided posture, so some listing
+  work may be done twice.
+- **The band question outlives the election.** Even electing in leaves the 9-11 ceiling
+  versus a grades 1–6 scope unresolved, which is why it is written up above as a founder
+  decision in its own right rather than as a listing detail.
 - Either way, the declarations must be consistent with actual behaviour and with the CI
   dependency audit (`G-07`).
 

--- a/dynawalla/docs/DECISIONS/ADR-0002-v1-scope-cut.md
+++ b/dynawalla/docs/DECISIONS/ADR-0002-v1-scope-cut.md
@@ -37,25 +37,27 @@ exists to avoid.
 New information, and it means this ADR and
 [ADR-0001](ADR-0001-kids-category-posture.md) are two views of one decision.
 
-**Apple's Kids Category bands are 5-and-under, 6-8 and 9-11, and exactly one is
-chosen. There is no band above 9-11.** Play's target-audience declaration is
-multi-select and does have a 9-12 band, so Play can express the founder-stated scope and
-Apple cannot.
+**If the Kids Category is elected, Apple requires choosing exactly one of three bands:
+5-and-under, 6-8, or 9-11.** It is a choice among three, **not** a maximum age. Play's
+target-audience declaration is multi-select and can express a range directly.
 
-Grades 1–6 plus intro pre-algebra spans roughly **ages 6–12**:
+Grades 1–6 plus intro pre-algebra ≈ **ages 6–12**. Grades 1–5 ≈ **ages 6–11**.
 
-- **Option A below (grades 1–5) lands exactly inside Apple's 9-11 ceiling.** The scope
-  cut and the Apple band become consistent for free.
-- **Option B (the founder-stated scope) pushes past it**, and then requires one of:
-  declaring 9-11 anyway and skewing the listing to the top of the range; splitting into
-  two SKUs; or skipping the Kids Category — which Guideline 2.3.8 and 5.1.4(b) make a
-  trap rather than an escape, because child-implying metadata is reserved *to* the
-  category and forbidden *outside* it.
+**Neither option A nor option B fits an Apple band.** Ages 6–11 spans *both* 6-8 and
+9-11, so **the cut proposed below does not resolve the band question at all** — it
+removes the overflow past age 11 and leaves the actual problem untouched. An earlier
+revision of this section claimed option A made the scope and the band "consistent for
+free"; that was wrong and is corrected here.
 
-This is not an argument for option A. It is a cost that was previously invisible on
-option B and should be priced in when the founder decides. The band choice itself is a
-separate founder decision and is **not made**; see
-[ADR-0001](ADR-0001-kids-category-posture.md).
+The only V1 cuts that fit a single band are roughly **grades 4–5** (9-11), which discards
+the foundational place-value work and read-aloud's reason for existing at M2, or
+**grades 1–3** (6-8), which discards multiplication, division and the fraction work that
+the evidence below says uniquely predicts later algebra achievement. **Both are far more
+expensive than option A**, and neither is recommended.
+
+So this is a real cost on **every** option on this page, not a discriminator between
+them, and it should be priced in as such. The band choice belongs to
+[ADR-0001](ADR-0001-kids-category-posture.md) and is **not made**.
 
 ## Options
 

--- a/dynawalla/docs/DECISIONS/ADR-0002-v1-scope-cut.md
+++ b/dynawalla/docs/DECISIONS/ADR-0002-v1-scope-cut.md
@@ -32,6 +32,31 @@ quarter of the advertised coverage, or get laundered into `{kind: "choice", k: 4
 frame. It teaches nothing about symmetry and it is exactly the failure mode this product
 exists to avoid.
 
+## The store age bands constrain this decision — recorded 2026-07-25
+
+New information, and it means this ADR and
+[ADR-0001](ADR-0001-kids-category-posture.md) are two views of one decision.
+
+**Apple's Kids Category bands are 5-and-under, 6-8 and 9-11, and exactly one is
+chosen. There is no band above 9-11.** Play's target-audience declaration is
+multi-select and does have a 9-12 band, so Play can express the founder-stated scope and
+Apple cannot.
+
+Grades 1–6 plus intro pre-algebra spans roughly **ages 6–12**:
+
+- **Option A below (grades 1–5) lands exactly inside Apple's 9-11 ceiling.** The scope
+  cut and the Apple band become consistent for free.
+- **Option B (the founder-stated scope) pushes past it**, and then requires one of:
+  declaring 9-11 anyway and skewing the listing to the top of the range; splitting into
+  two SKUs; or skipping the Kids Category — which Guideline 2.3.8 and 5.1.4(b) make a
+  trap rather than an escape, because child-implying metadata is reserved *to* the
+  category and forbidden *outside* it.
+
+This is not an argument for option A. It is a cost that was previously invisible on
+option B and should be priced in when the founder decides. The band choice itself is a
+separate founder decision and is **not made**; see
+[ADR-0001](ADR-0001-kids-category-posture.md).
+
 ## Options
 
 **A — V1 as scoped below (recommended by the program).** Ship grades 1–5 number and

--- a/dynawalla/docs/DECISIONS/ADR-0005-shell-and-routing.md
+++ b/dynawalla/docs/DECISIONS/ADR-0005-shell-and-routing.md
@@ -19,7 +19,23 @@ had been built around no gate.
 2. **Theme is applied synchronously at module load** via a store subscription toggling
    one `classList` entry — no flash, no effect-ordering bug.
 3. **The `<ParentalGate>` component and its route guard ship in M1's shell**, before any
-   link-out or purchase surface exists.
+   link-out or purchase surface exists. Design constraints, amended 2026-07-25 by
+   [ADR-0001](ADR-0001-kids-category-posture.md):
+   - **The challenge is never arithmetic.** Apple's canonical illustrated gate is a maths
+     problem, which is precisely why *this* app cannot use one — it spends every session
+     training the skill the gate filters on. Reading load, not arithmetic, is the real
+     barrier for a six-year-old. Viable: type the current four-digit year; type a
+     spelled-out multi-syllable word; press-and-hold-and-drag for N seconds.
+   - **Randomized** — a fixed challenge is memorised within a week.
+   - **Non-persistent across sessions** — passing once never unlocks later launches.
+   - Paired with a voiceover prompt if a 5-and-under band is ever elected.
+   - **One component, both platforms.** Play mandates no general gate; do not fork the
+     behaviour per store.
+   - Guards: link-outs, any purchase/paywall/price display, Restore Purchases, the parent
+     dashboard, anything that emails or shares a child's work, and — cheaply, because it
+     is reviewer-discretion territory — microphone and push permission prompts. The
+     privacy policy is rendered as an **in-app screen**, not an external URL, which
+     removes that guard entirely.
 4. **The Tauri capability surface is narrow from day one:** non-null CSP, per-command
    grants, never `<plugin>:default`.
 

--- a/dynawalla/docs/DECISIONS/ADR-0005-shell-and-routing.md
+++ b/dynawalla/docs/DECISIONS/ADR-0005-shell-and-routing.md
@@ -22,8 +22,9 @@ had been built around no gate.
    link-out or purchase surface exists. Design constraints, amended 2026-07-25 by
    [ADR-0001](ADR-0001-kids-category-posture.md):
    - **The challenge is never arithmetic.** Apple's canonical illustrated gate is a maths
-     problem, which is precisely why *this* app cannot use one — it spends every session
-     training the skill the gate filters on. Reading load, not arithmetic, is the real
+     problem and Apple permits one; it is *this* app that cannot use one usefully, because
+     it spends every session training the skill the gate filters on. A program decision,
+     not a store requirement. Reading load, not arithmetic, is the real
      barrier for a six-year-old. Viable: type the current four-digit year; type a
      spelled-out multi-syllable word; press-and-hold-and-drag for N seconds.
    - **Randomized** — a fixed challenge is memorised within a week.

--- a/dynawalla/docs/DECISIONS/ADR-0010-standards-alignment-claim.md
+++ b/dynawalla/docs/DECISIONS/ADR-0010-standards-alignment-claim.md
@@ -2,6 +2,10 @@
 
 **Status:** Proposed — awaiting founder
 **Needed before:** any public marketing copy or store listing text
+**Research commissioned 2026-07-25; a recommendation is pending.** The founder asked for
+a dedicated research pass on the licensing and claim exposure rather than a decision from
+the program. Nothing here is decided. Add the recommendation to this ADR when it lands;
+the founder still makes the call, and CG-20 stays report-only until then.
 
 ## Context
 

--- a/dynawalla/docs/DECISIONS/ADR-0010-standards-alignment-claim.md
+++ b/dynawalla/docs/DECISIONS/ADR-0010-standards-alignment-claim.md
@@ -3,7 +3,8 @@
 **Status:** Proposed — awaiting founder
 **Needed before:** any public marketing copy or store listing text
 **Research commissioned 2026-07-25; a recommendation is pending.** The founder asked for
-a dedicated research pass on the licensing and claim exposure rather than a decision from
+a dedicated research pass on the standards-alignment claim and its exposure rather than a
+decision from
 the program. Nothing here is decided. Add the recommendation to this ADR when it lands;
 the founder still makes the call, and CG-20 stays report-only until then.
 

--- a/dynawalla/docs/DECISIONS/ADR-0013-monetization-model.md
+++ b/dynawalla/docs/DECISIONS/ADR-0013-monetization-model.md
@@ -63,13 +63,27 @@ parent can understand before they hit it. [RISKS.md](../RISKS.md) R-45 carries t
 
 This ADR being `Accepted (direction)` explicitly does **not** close that question.
 
+**And the obvious fallback does not exist.** "Ship clean, add an ad-supported tier if the
+subscription underperforms" is not available: **Play's Families Self-Certified Ads SDK
+program is closed to new applicants** ([RISKS.md](../RISKS.md) R-47). Whatever this
+product's revenue model turns out to be, it is a paid one or it is nothing.
+
+**Keep entitlements local.** Both stores define "collect" as transmitting off-device, so
+the local-first architecture earns **Apple "Data Not Collected"** and **Play "nothing
+collected, nothing shared"** for free. A **receipt-validation backend is one of exactly
+two things that would break it** (the other being a third-party crash SDK) by forcing a
+Purchases disclosure. That is a genuine constraint on how the subscription is verified,
+not a preference — and it happens to point the same way as the
+never-block-an-offline-subscriber policy above.
+
 ## Consequences that apply to any paid option
 
-- Every purchase surface sits behind the `<ParentalGate>` shipped in M1 (`G-08`), and the
-  category interaction is [ADR-0001](ADR-0001-kids-category-posture.md): Play's Families
-  Policy and Apple's Kids Category both constrain how a purchase may be surfaced to a
-  child, which is why the category election is deferred until the purchase surface
-  exists.
+- Every purchase surface sits behind the `<ParentalGate>` shipped in M1 (`G-08`) — every
+  paywall, every **price display**, and **Restore Purchases** — and the gate's challenge
+  is **never arithmetic** ([ADR-0005](ADR-0005-shell-and-routing.md)). The category
+  interaction is [ADR-0001](ADR-0001-kids-category-posture.md): Play's Families Policy and
+  Apple's Kids Category both constrain how a purchase may be surfaced to a child, which is
+  why the category election is deferred until the purchase surface exists.
 - Purchase surfaces must never be adjacent to a failure or a challenge outcome. The
   negative example is documented: reviewers logged 16 membership ads in a 19-minute
   Prodigy session, which drew an FTC complaint alleging manipulative upselling to

--- a/dynawalla/docs/DECISIONS/ADR-0013-monetization-model.md
+++ b/dynawalla/docs/DECISIONS/ADR-0013-monetization-model.md
@@ -1,7 +1,7 @@
 # ADR-0013 — Monetization model
 
-**Status:** Proposed — awaiting founder
-**Deferring past M7 is fine. Deferring past M9 blocks launch (`G-02`).**
+**Status:** Accepted (direction) — 2026-07-25. **Implementation deferred**; the packaging
+and pricing decision is not made and blocks launch if it is still open past M9 (`G-02`).
 
 ## Context
 
@@ -14,30 +14,62 @@ It also decides real engineering: whether the `iap` and `subscriptions` plugins 
 wired at all, whether Corpán's never-block-an-offline-subscriber policy is adopted, and
 whether M6's "optional challenge run" may ever sit adjacent to a purchase surface.
 
-## Options
+## Decision — direction
 
-**A. Free, no monetization.** Simplest compliance posture; no IAP plugins; no
-entitlement layer. No revenue.
+The founder's answer:
 
-**B. One-time purchase (paid up front, or a single unlock).** No subscription lifecycle,
-no renewal edge cases, no offline-entitlement problem of any consequence. Weakest fit for
-content that grows over years.
+> "I'm not sure about monetization really. I think ultimately we try something like
+> Corpan (although that hasn't worked in the slightest) .. you get a generous free tier
+> and it's fun and cool. But if you want unlimited exercises and unlimited access to
+> everything then you pay a subscription price. But, our run rate is low because we
+> design so basically everything runs offline with no big server overhead."
 
-**C. Subscription.** Requires the full entitlement layer. If chosen, adopt Corpán's
-policy verbatim: a durable Plus snapshot with optimistic merge seeding on launch, and
-downgrade **only** on a definitive online `not_owned` past a 48-hour grace — never block
-a real offline subscriber.
+Recorded as the direction (option **E**, a free tier plus **C**):
 
-**D. School and district license.** A different sales motion, a different support
-burden, and probably a different distribution channel (Apple School Manager / Play
-managed distribution). Largely orthogonal to the client work but it changes what a
-"profile" means.
+1. **A generous free tier**, and a **subscription** that unlocks unlimited exercises and
+   full access.
+2. **Offline-first architecture keeps marginal cost per user near zero.** There is no
+   server profile, no telemetry endpoint, no model hosting and no content CDN in V1
+   ([ADR-0003](ADR-0003-no-downloadable-packs-v1.md),
+   [ADR-0012](ADR-0012-ota-curriculum-deferral.md)). The free tier can therefore be
+   genuinely generous rather than a nag: nobody on it is costing anything to serve, so
+   there is no cost argument for making it unpleasant.
+3. **Adopt Corpán's never-block-an-offline-subscriber policy.** The implementation to
+   copy is real and lives at `corpan/corpan-app/src/store/entitlements.ts` (durable
+   `lastKnownSubscription` + `lastVerifiedAt`, persisted, re-seeded into the live
+   `subscription` on launch through the store's `merge`) with the grace window in
+   `corpan/corpan-app/src/contentPacks/purchase.ts` (`SUBSCRIPTION_GRACE_MS = 48 * 60 *
+   60 * 1000`). Downgrade happens **only** on a definitive online `not_owned` past that
+   grace; offline or inconclusive keeps the entitlement. The stated priority is to prefer
+   letting a stale entitlement persist over ever blocking a real paying user who is
+   offline.
+4. **Nothing about packaging or price is decided.** What "generous" means in exercises,
+   content or features, what the subscription costs, whether there is a trial, and
+   whether a family plan exists are all open.
 
-**E. Hybrid** — a free tier plus one of B/C/D.
+## The open risk this direction carries
+
+The founder's own assessment of the model being copied is that it **"hasn't worked in the
+slightest."** That is recorded here rather than smoothed over, because copying a model
+wholesale copies the result.
+
+"Generous free tier plus subscription" is a **direction, not a validated design**. It has
+no evidence behind it in this company beyond one product where it underperformed, and
+adopting it by default means the second product inherits the first product's unexamined
+pricing and packaging assumptions along with its architecture. Pricing and packaging need
+their own evidence pass before launch — at minimum: what specifically is behind the
+paywall, why a parent would pay for it, and what the free tier's ceiling is in terms a
+parent can understand before they hit it. [RISKS.md](../RISKS.md) R-45 carries this.
+
+This ADR being `Accepted (direction)` explicitly does **not** close that question.
 
 ## Consequences that apply to any paid option
 
-- Every purchase surface sits behind the `<ParentalGate>` shipped in M1 (`G-08`).
+- Every purchase surface sits behind the `<ParentalGate>` shipped in M1 (`G-08`), and the
+  category interaction is [ADR-0001](ADR-0001-kids-category-posture.md): Play's Families
+  Policy and Apple's Kids Category both constrain how a purchase may be surfaced to a
+  child, which is why the category election is deferred until the purchase surface
+  exists.
 - Purchase surfaces must never be adjacent to a failure or a challenge outcome. The
   negative example is documented: reviewers logged 16 membership ads in a 19-minute
   Prodigy session, which drew an FTC complaint alleging manipulative upselling to
@@ -48,8 +80,18 @@ managed distribution). Largely orthogonal to the client work but it changes what
 - IAP requires the explicit App ID and a non-wildcard provisioning profile, which is
   already how [STORE.md](../STORE.md) plans the signing identity.
 
-## Note
+## The tension nobody should discover at M9
 
-If the answer is A (free), say so explicitly and record it — an unrecorded "free for
-now" leaves the IAP plumbing question open at M10, which is exactly the launch-pressure
-retrofit this program is trying to avoid everywhere else.
+**"Unlimited exercises" implies the free tier has an exercise limit, and a daily exercise
+cap is a stopping mechanism imposed by billing rather than by the child.**
+[MISSION.md](../MISSION.md) forbids play-by-appointment and grinding gates, and requires
+designed stopping points with equal-weight "Done" and "Keep going" (`P-10`). A free-tier
+cap that ends a child's session mid-flow is close enough to play-by-appointment to be
+worth naming now rather than arguing about under launch pressure.
+
+The resolution space — cap **breadth** (skills, chambers, curriculum range) rather than
+**session length**; or gate the parent report, additional chambers and advanced content;
+or make the free tier time-unlimited and content-bounded — is deferred with the rest of
+packaging. What is decided is that a free-tier limit which cuts a willing child off
+mid-session is not an acceptable shape, because the product's stated ethics already
+forbid it.

--- a/dynawalla/docs/DECISIONS/ADR-0013-monetization-model.md
+++ b/dynawalla/docs/DECISIONS/ADR-0013-monetization-model.md
@@ -3,6 +3,14 @@
 **Status:** Accepted (direction) — 2026-07-25. **Implementation deferred**; the packaging
 and pricing decision is not made and blocks launch if it is still open past M9 (`G-02`).
 
+**How strong is this mandate: weak, and the status line should not be read as more.** The
+founder's answer opens *"I'm not sure about monetization really"* and describes the model
+as *"something like Corpan (although that hasn't worked in the slightest)."* That is a
+working hypothesis offered under stated uncertainty, not a settled direction. `Accepted
+(direction)` is used here so engineering is not blocked on an open question — **it is not
+a claim that the founder committed to this model.** Anyone proposing to revisit it should
+expect an open door, and should read R-45 first.
+
 ## Context
 
 This decision is product identity and it is externally constrained. Apple requires a
@@ -65,7 +73,8 @@ This ADR being `Accepted (direction)` explicitly does **not** close that questio
 
 **And the obvious fallback does not exist.** "Ship clean, add an ad-supported tier if the
 subscription underperforms" is not available: **Play's Families Self-Certified Ads SDK
-program is closed to new applicants** ([RISKS.md](../RISKS.md) R-47). Whatever this
+program is currently not accepting new applicants** — Google says the window will
+reopen, on no stated date ([RISKS.md](../RISKS.md) R-47). Whatever this
 product's revenue model turns out to be, it is a paid one or it is nothing.
 
 **Keep entitlements local.** Both stores define "collect" as transmitting off-device, so

--- a/dynawalla/docs/DECISIONS/ADR-0014-repository-license.md
+++ b/dynawalla/docs/DECISIONS/ADR-0014-repository-license.md
@@ -1,6 +1,10 @@
 # ADR-0014 — Repository license
 
 **Status:** Proposed — awaiting founder (and counsel)
+**Research commissioned 2026-07-25; a recommendation is pending.** The founder asked for
+a dedicated research pass on this specific question rather than a decision from the
+program. Nothing here is decided, and no agent should decide it. Add the recommendation
+to this ADR when it lands; the founder still makes the call.
 
 ## Context
 

--- a/dynawalla/docs/DECISIONS/ADR-0015-developer-account-topology.md
+++ b/dynawalla/docs/DECISIONS/ADR-0015-developer-account-topology.md
@@ -25,11 +25,38 @@ The founder's answer:
 Play developer account as Corpán.** Option A. Everything in [STORE.md](../STORE.md) as
 written holds.
 
-`TODO(store-recon)` — a store reconnaissance is in flight to confirm the exact reuse
-matrix: which Apple certificate, key and identifier records are genuinely reusable versus
-which must be minted new, and the Play service account's current role. The two
-new-credential items above are asserted by the plan; the recon confirms them rather than
-this ADR asserting more specifics than have been verified.
+## The reuse matrix, verified 2026-07-25
+
+Store reconnaissance returned. Everything below was checked with live GET-only API calls;
+nothing here is inferred from the plan.
+
+**Reused — no new artifact needed:**
+
+- The **Apple Distribution certificate** (`Apple Distribution: Corpora Inc`, expires
+  2027-04-16, team-wide).
+- The **ASC API key** — see the correction in [STORE.md](../STORE.md): it does *not* need
+  re-minting.
+- The **Apple Team ID** `F9AV5HKF6N`.
+- The **Play service-account identity** — the identity only, not its access.
+- The existing **parameterized tooling**, `corpan/infra/asc/asc_monetization.py` and
+  `corpan/infra/play/play_monetization.py`, both already keyed off a bundle-id /
+  package-name variable.
+
+**New and mandatory:**
+
+- The **iOS provisioning profile.** Profiles bind to one explicit bundle id; no wildcard
+  spans both `com.corpora.*` and `inc.corpora.*`, **and wildcards cannot carry IAP**.
+- The **Android upload keystore**, deliberately separate so one compromised key does not
+  risk two shipping apps.
+- **Play App Signing enrolment.**
+- A **new AWS secret path.** Do **not** widen `corpan/content-packs/verify` — a live
+  purchase-verify lambda reads it.
+- An **explicit per-app Play permission grant** for the service account (`G-09`).
+
+**Proven, not assumed:** the Play service account returns **403** on
+`com.corpora.homeschool` and `com.pako.app`. Two sibling apps on the same account are
+already invisible to it today. Per-app grants demonstrably do not inherit, so `G-09` is a
+real step and not a formality.
 
 ## Consequences, accepted as trade-offs
 

--- a/dynawalla/docs/DECISIONS/ADR-0015-developer-account-topology.md
+++ b/dynawalla/docs/DECISIONS/ADR-0015-developer-account-topology.md
@@ -3,6 +3,13 @@
 **Status:** Accepted — 2026-07-25
 **Needed before:** the ASC and Play app records are created in M1 (met)
 
+**Mandate strength:** the founder's answer was *"it can just be the same as Corpan **I
+think**"* — a reasonable default offered in passing, not a considered acceptance of the
+trade-offs below. **The blast-radius cost in particular was never put to him**: it was
+identified by the program, and it reaches Corpán's paying subscribers. If the founder has
+not read the Consequences section, this decision has not actually been made with the
+information in it. Flagged rather than assumed.
+
 ## Context
 
 Dynawalla can ship under the same Apple developer team and Google Play developer account
@@ -58,10 +65,13 @@ nothing here is inferred from the plan.
 already invisible to it today. Per-app grants demonstrably do not inherit, so `G-09` is a
 real step and not a formality.
 
-## Consequences, accepted as trade-offs
+## Consequences — costs the program identified, not costs the founder priced
 
-These were the reasons to consider separate accounts. They are now accepted costs, not
-open questions.
+These were the reasons to consider separate accounts. The program treats them as accepted
+so work can proceed, but **none of them was in front of the founder when he answered**
+(see the mandate note in the header). The first one deserves an explicit confirmation
+before M1 creates the app records, because it is the one that can reach a shipping product
+with paying users.
 
 - **Shared policy-violation blast radius.** An enforcement action against the account —
   a Play policy strike, an Apple account-level suspension — affects **both apps**. Corpán

--- a/dynawalla/docs/DECISIONS/ADR-0015-developer-account-topology.md
+++ b/dynawalla/docs/DECISIONS/ADR-0015-developer-account-topology.md
@@ -1,7 +1,7 @@
 # ADR-0015 — Developer-account topology
 
-**Status:** Proposed — awaiting founder
-**Needed before:** the ASC and Play app records are created in M1
+**Status:** Accepted — 2026-07-25
+**Needed before:** the ASC and Play app records are created in M1 (met)
 
 ## Context
 
@@ -15,28 +15,48 @@ cannot carry IAP) and the Android upload keystore (deliberately separate so one
 compromised key does not risk two shipping apps). The Apple Distribution certificate and
 the Play service account are reused.
 
-## Options
+## Decision
 
-**A. Same accounts as Corpán.** Reuses the distribution certificate and the Play service
-account. Requires an explicit per-app permission grant for the service account on the new
-Play app record — it does **not** inherit (`G-09`). Consequences: the two apps compete
-for the same App Store Featured and Play Teacher Approved nominations, share a
-policy-violation blast radius (an enforcement action against one account affects both),
-and share the account's DSA trader status.
+The founder's answer:
 
-**B. Separate accounts.** Isolates the policy blast radius and the nomination pools.
-Costs a second Apple Developer Program enrolment and a second Play developer account,
-new certificates, new service-account plumbing, a second set of store secrets and
-environments, and duplicated tax/banking/trader setup.
+> "Yeah, this is a Corpora project so it can just be the same as Corpan I think."
 
-## Consequences
+**Dynawalla ships under the same Corpora Inc Apple developer team and the same Google
+Play developer account as Corpán.** Option A. Everything in [STORE.md](../STORE.md) as
+written holds.
 
+`TODO(store-recon)` — a store reconnaissance is in flight to confirm the exact reuse
+matrix: which Apple certificate, key and identifier records are genuinely reusable versus
+which must be minted new, and the Play service account's current role. The two
+new-credential items above are asserted by the plan; the recon confirms them rather than
+this ADR asserting more specifics than have been verified.
+
+## Consequences, accepted as trade-offs
+
+These were the reasons to consider separate accounts. They are now accepted costs, not
+open questions.
+
+- **Shared policy-violation blast radius.** An enforcement action against the account —
+  a Play policy strike, an Apple account-level suspension — affects **both apps**. Corpán
+  is a shipping product with paying subscribers; a Dynawalla compliance mistake can reach
+  it. This is the largest cost of the decision and the one most likely to be regretted at
+  the exact moment it lands.
+- **The two apps compete for the same nominations.** App Store Featured placement and
+  Play Teacher Approved are allocated per developer account, so Dynawalla and Corpán are
+  in the same pool rather than in two.
+- **Shared DSA trader status** and the account's tax, banking and trader declarations.
+  One set of facts covers both apps, which is a simplification until one app needs a
+  different answer.
 - **Reversing after the app record exists means a new record and orphaning any installed
-  base.** This is effectively a one-way door once M1 submits.
-- Under **A**, everything in [STORE.md](../STORE.md) as written holds. Under **B**, the
-  reusable release workflow needs a second credential set per platform and the
-  environment list doubles.
-- Under either option, a **new AWS secret `dynawalla/store/credentials`** is created
-  rather than widening the existing Corpán secret, which a live purchase-verify lambda
-  reads.
-- Under either option, no credential value ever enters this repository (`G-11`).
+  base.** This is effectively a one-way door once M1 submits, so the acceptance above is
+  the real decision, not a provisional one.
+
+## Operational consequences that still apply
+
+- The Play service account requires an **explicit per-app permission grant** on the new
+  Dynawalla app record — it does **not** inherit (`G-09`). This is a founder console
+  action, not an API call.
+- A **new AWS secret `dynawalla/store/credentials`** is created rather than widening the
+  existing Corpán secret, which a live purchase-verify lambda reads. Sharing an account
+  is not a reason to share a secret.
+- No credential value ever enters this repository (`G-11`).

--- a/dynawalla/docs/DECISIONS/ADR-0016-app-store-product-name.md
+++ b/dynawalla/docs/DECISIONS/ADR-0016-app-store-product-name.md
@@ -57,16 +57,16 @@ materials — no goods overlap.
 
 **We already own the name, and it has baggage**
 
-The founder owns **`dynawalla.com`** (GitHub org `dynawalla`, repo
-`dynawalla/dynawalla.com`, all five commits authored from his address in 2015, a dormant
-lion's-mane nootropic page; domain expires 2027-07-15). Two things to fix before the name
-carries a product for children:
+The founder owns the matching domain (registered 2015, dormant, expires 2027-07-15). Two
+things to fix before the name carries a product for children:
 
-1. **Live subdomain-takeover vector.** The A/MX/TXT records point at
-   `dynawalla.com.herokudns.com`, which **no longer resolves**. Anyone who claims that
-   Heroku hostname serves content on our domain.
-2. **A public repo tying the name to supplement health claims** should be archived or
-   scrubbed. It is one search away from a product aimed at seven-year-olds.
+1. **Dangling DNS records on a domain we own need clearing.** Details are deliberately
+   **not committed to this public repository** — publishing an unremediated hosting
+   misconfiguration is publishing the exploit. The founder has the specifics out of band;
+   this line exists so the work is tracked, not so it is reproducible. Remove this note
+   once the records are cleared.
+2. **A public repo tying the name to dietary-supplement health claims** should be archived
+   or scrubbed. It is one search away from a product aimed at seven-year-olds.
 
 **Two collision vectors for a founder-and-counsel call**
 

--- a/dynawalla/docs/DECISIONS/ADR-0016-app-store-product-name.md
+++ b/dynawalla/docs/DECISIONS/ADR-0016-app-store-product-name.md
@@ -34,10 +34,53 @@ Confirm the product name, or supply a different one, before M1 creates the app r
 So the working name stands unless a check says otherwise, and the founder has explicitly
 asked for the check rather than asserting the name is clear.
 
-`TODO(store-recon)` — an availability check on both stores and a trademark search are in
-flight. This ADR stays **Proposed** until they come back: the founder's expectation is
-recorded, but "I doubt anyone has it" is not the confirmation that makes an immutable SKU
-safe to create.
+## What the checks found — 2026-07-25
+
+The founder's expectation holds up. The ADR stays **Proposed** anyway, because two of the
+findings are counsel questions and one is a hygiene problem that should be fixed before
+the name carries a children's product.
+
+**Identifier availability**
+
+- `inc.corpora.dynawalla`: **0 matches** across Apple bundle ids; **404** on Play.
+- **Honest limit:** both queries are **account-scoped**. Neither store exposes a *global*
+  availability check, so a third party could be holding the identifier and we would only
+  discover it at registration.
+- **App Store product-name availability cannot be tested read-only** on either store. It
+  is checked at reservation time, which is the moment it stops being cheap.
+
+**Third-party use of "Dynawalla": none found anywhere**
+
+0 apps via iTunes Search; no companies; npm 404; PyPI 404; every major TLD free; no
+`DYNAWALLA` trademark. The live `DYNAWALL` registration 7020156 is Class 6 construction
+materials — no goods overlap.
+
+**We already own the name, and it has baggage**
+
+The founder owns **`dynawalla.com`** (GitHub org `dynawalla`, repo
+`dynawalla/dynawalla.com`, all five commits authored from his address in 2015, a dormant
+lion's-mane nootropic page; domain expires 2027-07-15). Two things to fix before the name
+carries a product for children:
+
+1. **Live subdomain-takeover vector.** The A/MX/TXT records point at
+   `dynawalla.com.herokudns.com`, which **no longer resolves**. Anyone who claims that
+   Heroku hostname serves content on our domain.
+2. **A public repo tying the name to supplement health claims** should be archived or
+   scrubbed. It is one search away from a product aimed at seven-year-olds.
+
+**Two collision vectors for a founder-and-counsel call**
+
+- **Dynamo Maths** (`dynamomaths.co.uk`) — a live UK children's mathematics intervention,
+  ages 6–11, dyscalculia focus. Shared `Dyna-` prefix, same customers, same subject.
+  **This is the one an attorney circles.**
+- **Physics Wallah** won an ex-parte Delhi High Court injunction asserting rights over a
+  *"family of trademarks using the suffix 'wallah'"*. Relevant **only if India is a launch
+  market** — and worth knowing before, not after, that decision.
+
+**Caveat, stated plainly:** USPTO, Justia, TMview and WIPO all bot-blocked the search.
+This is **strong negative evidence gathered from a mirror, not a first-party clearance
+search.** A paid clearance search before filing remains advisable, and this ADR should
+not be read as clearing the name.
 
 ## Consequences
 

--- a/dynawalla/docs/DECISIONS/ADR-0016-app-store-product-name.md
+++ b/dynawalla/docs/DECISIONS/ADR-0016-app-store-product-name.md
@@ -27,6 +27,18 @@ the word-of-mouth.
 
 Confirm the product name, or supply a different one, before M1 creates the app records.
 
+**Founder's expectation, 2026-07-25:**
+
+> "I doubt anyone has Dynawalla but you should be able to check."
+
+So the working name stands unless a check says otherwise, and the founder has explicitly
+asked for the check rather than asserting the name is clear.
+
+`TODO(store-recon)` — an availability check on both stores and a trademark search are in
+flight. This ADR stays **Proposed** until they come back: the founder's expectation is
+recorded, but "I doubt anyone has it" is not the confirmation that makes an immutable SKU
+safe to create.
+
 ## Consequences
 
 - The bundle id does not have to match the display name and will not be changed by this

--- a/dynawalla/docs/DECISIONS/ADR-0017-human-evaluation-resourcing.md
+++ b/dynawalla/docs/DECISIONS/ADR-0017-human-evaluation-resourcing.md
@@ -1,54 +1,136 @@
 # ADR-0017 — Human evaluation resourcing
 
-**Status:** Proposed — awaiting founder
-**Recruitment starts now. Consent has weeks of lead time.**
+**Status:** Accepted — 2026-07-25
+**Supersedes the recruitment plan this ADR originally proposed.**
 
 ## Context
 
-Two gates in this program require people the plan cannot supply for itself. Both have
-kill/revise authority over milestones. Neither has a substitute instrument.
+Two things in this program cannot be decided by a test: whether the loop is any good,
+and whether the art looks right. The first draft of this ADR answered that by specifying
+an external instrument — 6+ children aged 7–11 including at least 2 who dislike math,
+documented parental consent under COPPA and the UK Children's Code, and a separately
+named human art director whose sign-off gated M6.
 
-**(a) A child playtest cohort.** 6+ children aged 7–11, including at least 2 who dislike
-math, with documented parental consent under COPPA and the UK Children's Code. Gates at
-M2, M6 and M8 (`T-01`..`T-06`).
+That was the plan over-specifying. Nobody had committed to supplying any of it, the
+lead time was quoted in weeks, and a gate that depends on a cohort nobody is recruiting
+is a gate that gets waived at the first schedule squeeze — which is worse than a smaller
+gate honestly described.
 
-**(b) A named human art director.** Their sign-off on the committed M6 screenshots is an
-exit criterion (`Q-14`).
+## Decision
 
-## Why there is no alternative instrument
+The founder corrected the resourcing directly:
 
-For (a): Apple's Kids Category (1.3 / 5.1.4) bars third-party analytics and behavioural
-advertising, and the UK Children's Code restricts nudge techniques and using children's
-data to keep them on a platform. **The feel therefore cannot be A/B tested remotely.**
-Scheduled in-person playtesting is the binding constraint, not an oversight. Without it,
-every judgement about pacing, reaction budgets, the difficulty target and "wrong must not
-be more fun than right" reverts to a claim about children that a simulator the team wrote
-cannot falsify.
+> "I am the art director and any other adult needed and my 10 year old son will play any
+> 6+ children needed."
 
-For (b): the art direction has the highest slop risk in the program — procedural girih
-plus a brass-and-lapis palette is precisely the recipe that renders as a gradient
-dashboard with gear icons — and **code review cannot see it**. The committed-screenshot
-gate exists so the images can be reviewed as images, but that only works if someone who
-can see it is accountable for the verdict.
+Recorded as decided:
 
-## What the founder must supply
+1. **The child evaluator is the founder's son, age 10.** One child. There is no
+   external cohort, no recruitment, and no recruitment lead time on any milestone.
+2. **Consent is parental consent, given by the founder, who is the parent.** No forms,
+   no counsel review of a template, no COPPA/Children's-Code participant paperwork. The
+   data-handling rules in [PLAYTEST-PROTOCOL.md](../PLAYTEST-PROTOCOL.md) §2 still apply
+   and are stricter than the regulation, for a different reason: this repository is
+   public.
+3. **The founder holds every adult role the protocol calls for** — art director and
+   design authority, observer, product owner, and QA. `Q-14`'s "named art director" is
+   the founder. There is no second sign-off to wait for.
+4. **What is measured does not change.** Time to voluntary quit, unprompted verbatims,
+   next-day voluntary return, where the child gets stuck, and what the child skips are
+   the same five signals the external protocol specified. They survive a sample of one;
+   the inferences drawn from them do not, which is the subject of the next section.
 
-1. Access to a cohort meeting the [PLAYTEST-PROTOCOL.md](../PLAYTEST-PROTOCOL.md)
-   definition, with consent forms returned before the first M2 session. Recruitment
-   begins in the bootstrap PR because consent takes weeks, not days.
-2. A named art director, and their commitment to review three screenshot sets (M6, plus
-   any subsequent art PR that changes the palette or the world vocabulary).
-3. A named owner for the nightly simulation harness with a paging path (`A-19`).
+## What this instrument can and cannot tell us
 
-## Consequences of not supplying them
+Stating this plainly is the point of the ADR. Direct observation of a real child using
+the real build on a real device is the highest-signal instrument available to this
+program, and it is enormously better than none — a simulator the team wrote cannot
+falsify a claim about children. It is also one child, in one household, observed by the
+parent who is building the product. Both halves are true.
 
-- Without (a), the product's core claim is untested at every gate and there is no legal
-  path to testing it remotely. The honest response is to say so publicly rather than to
-  claim evidence the program does not have.
-- Without (b), the highest-slop-risk surface ships unreviewed by anyone who can see it,
-  and `Q-14` has no mitigation at all ([RISKS.md](../RISKS.md) R-32).
-- Without a nightly harness owner, an unwatched nightly is a gate that silently stops
-  gating.
+**It can tell us:**
 
-These are the three items most likely to be quietly waived. Waiving them does not save
-time; it converts measured claims into unmeasured ones.
+- Whether the loop holds one real child's attention without an adult driving it, and for
+  how long, by the clock rather than by opinion.
+- Whether the LOCATE contrast pair is *legible* — whether a child who gets one wrong can
+  see what the app is showing them, or asks what it means.
+- Where the interface breaks: what gets mis-tapped, what gets skipped, what prompts a
+  question, what is quietly abandoned.
+- Whether the child comes back the next day without being asked. In a household the
+  device is present every day, so this is measured under natural conditions rather than
+  simulated by leaving a loaner tablet behind.
+- Longitudinally: the same child at M2, M6 and M8, with no attrition risk. Cohort
+  retention was a listed hazard of the external plan and it does not exist here.
+
+**It cannot tell us:**
+
+- Anything generalizable about engagement. n = 1 supports no rate, no proportion, and no
+  comparison against a population.
+- Anything about efficacy. No claim of learning gain may cite these sessions.
+- Anything the child is biased toward. He knows who built it and he wants the adult to
+  be pleased. Verbal praise is therefore the least trustworthy datum this instrument
+  produces, and [PLAYTEST-PROTOCOL.md](../PLAYTEST-PROTOCOL.md) §5 forbids using it as
+  gate evidence; behavioural signals (quit time, return, what he does after a wrong
+  answer) are weighted because they are harder to give away to please someone.
+- Anything about accessibility needs nobody in the household has — low vision, motor
+  impairment, and screen-reader use are covered by `Q-09`/`Q-10` and by device testing,
+  not by this.
+- Anything about the grade 1–2 end of the curriculum. See below.
+
+## The age asymmetry, which is half good news
+
+A 10-year-old is roughly grade 4–5.
+
+**Covered, and this matters more than it might look:** V1's vertical slice is subtraction
+with regrouping across zero, and the LOCATE contrast pair built on it. That is squarely
+in this child's range. The highest-uncertainty, highest-risk, thesis-carrying content in
+V1 is directly observable by the one evaluator the program has. The instrument is small
+but it is pointed at the right thing.
+
+**Not covered:** the grade 1–2 end — early counting, number formation, first
+addition and subtraction facts — and specifically **every flow that assumes a child who
+cannot yet read the interface**. Pre-reader UX is the named blind area: icon-only
+affordances, audio-first instruction, read-aloud as the primary input path rather than an
+accessibility fallback, and touch targets sized for smaller hands. M2 argues read-aloud
+forward from M9 on a pre-reading child's behalf, and no pre-reading child will see it.
+
+Options, none of which are the plan's to pick:
+
+- **(a) Accept it.** Ship grades 1–2 on design heuristics plus the adaptive engine's
+  placement, which keeps a young learner out of content they cannot attempt. Cheapest;
+  leaves the least-observed content in the hands of the least-experienced users.
+- **(b) Narrow the advertised band** to what can actually be observed. Honest, entirely
+  within the program's control, and it interacts with
+  [ADR-0002](ADR-0002-v1-scope-cut.md), which is also open. It discards real curriculum
+  work and removes read-aloud's whole justification for landing at M2.
+- **(c) One additional younger evaluator, later.** Not a cohort — one child, aged
+  roughly 6–7, for one session before M9's accessibility and i18n fill. This is the only
+  option that converts the blind area into an observed one, and it is a much smaller ask
+  than the cohort this ADR just deleted.
+
+**Recommendation: (c), with (a) as the interim posture and (b) as the fallback with a
+trigger.** Treat grade 1–2 flows as unobserved until a younger evaluator sees them, say
+so rather than implying coverage we do not have, and if no younger evaluator has played
+by M9, narrow the advertised band to the range that was observed instead of shipping a
+claim with nothing behind it. **This is the founder's call and he has not made it.**
+
+## Consequences
+
+- Three gates (`T-01`, `T-04`, `T-05`) become single-child observations. Their pass
+  conditions are rewritten in [ACCEPTANCE_CRITERIA.md](../ACCEPTANCE_CRITERIA.md) as
+  per-child observations with recorded verdicts, not as counts of children. **They still
+  cannot be waived** (`T-06`) — a small instrument that runs beats a large one that does
+  not.
+- `T-03`'s real-child residual fit is directional only. One child's response data cannot
+  calibrate `b()`; it can only show a gross mismatch. The engine's difficulty model
+  therefore leans harder on the misspecified-persona harness than the original plan
+  assumed, and [RISKS.md](../RISKS.md) R-26 is updated to say so rather than to keep
+  citing a real-child anchor that no longer carries that weight.
+- `Q-11` — a pre-reading child completing a session on read-aloud alone — **has no
+  instrument.** It is rewritten as an adult-proxy device check, which verifies the
+  capability and explicitly does not evidence the child claim.
+- `Q-14`'s art-director sign-off is the founder's and can happen the same day. The
+  three-strangers screenshot test is unaffected: those are adults, not participants, and
+  need no consent regime.
+- The program loses its excuse. There is no recruitment to wait for, so a missing
+  playtest report at M2, M6 or M8 is a choice, not a resourcing failure.

--- a/dynawalla/docs/DECISIONS/ADR-0017-human-evaluation-resourcing.md
+++ b/dynawalla/docs/DECISIONS/ADR-0017-human-evaluation-resourcing.md
@@ -1,7 +1,10 @@
 # ADR-0017 — Human evaluation resourcing
 
 **Status:** Accepted — 2026-07-25
-**Supersedes the recruitment plan this ADR originally proposed.**
+**Amended 2026-07-25:** this ADR was `Proposed — awaiting founder`; the founder's answer
+is recorded below and it replaces the recruitment plan the ADR originally proposed. The
+superseded plan is quoted in Context rather than deleted, per the in-place-edit rule in
+[DECISIONS.md](../DECISIONS.md).
 
 ## Context
 
@@ -69,7 +72,7 @@ parent who is building the product. Both halves are true.
 - Anything about efficacy. No claim of learning gain may cite these sessions.
 - Anything the child is biased toward. He knows who built it and he wants the adult to
   be pleased. Verbal praise is therefore the least trustworthy datum this instrument
-  produces, and [PLAYTEST-PROTOCOL.md](../PLAYTEST-PROTOCOL.md) §5 forbids using it as
+  produces, and [PLAYTEST-PROTOCOL.md](../PLAYTEST-PROTOCOL.md) §3a forbids using it as
   gate evidence; behavioural signals (quit time, return, what he does after a wrong
   answer) are weighted because they are harder to give away to please someone.
 - Anything about accessibility needs nobody in the household has — low vision, motor

--- a/dynawalla/docs/EXPERIENCE_DESIGN.md
+++ b/dynawalla/docs/EXPERIENCE_DESIGN.md
@@ -152,8 +152,9 @@ driver) that the first draft of this plan never noticed.
 M6 adds a deterministic seed set capturing the world at 0 / 50 / 200 / 500 placed
 elements plus all five reaction tiers, at 320 px / 768 px / iPad, light and dark,
 reduced-motion on and off. **The PNGs are committed and the images are reviewed in the
-PR, not the code.** A named human art director signs off on those images as an exit
-criterion.
+PR, not the code.** The art director — the founder
+([ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md)) — signs off on those
+images as an exit criterion.
 
 The M6 stranger test: three strangers shown **only** the screenshots, unprompted, do not
 use the word "dashboard" or the word "template."

--- a/dynawalla/docs/MASTER_PLAN.md
+++ b/dynawalla/docs/MASTER_PLAN.md
@@ -166,12 +166,15 @@ minutes of founder time in two consoles. See [STORE.md](STORE.md).
 
 ---
 
-## M2 — The vertical slice, in front of children
+## M2 — The vertical slice, in front of a child
 
 **Goal.** Prove or kill the actual thesis: that a child gets something here they cannot
 get from a drill app. One skill cluster — **subtraction with regrouping across zero** —
 end to end: locale-correct entry, three mal-rules, the Stage-2 LOCATE contrast pair,
-visible construction, the character. And six real children.
+visible construction, the character. And a real child playing it, unhelped, on a store
+build ([ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md)). The slice was
+chosen before the evaluator was, and it happens to sit squarely in his range — the
+highest-uncertainty content in V1 is the content that can actually be observed.
 
 **Depends on:** M1.
 
@@ -200,7 +203,9 @@ borrow-across-zero and serves a contrast pair within 3 cards" moved **up** to he
 **Why read-aloud is here and not at M9.** Grade-1 content ships at M4. A six-year-old
 cannot read the prompts. Read-aloud is the input method, not an accessibility nicety;
 without it, every pacing target and persona gate for grades 1–2 is measured against a
-child who does not exist.
+child who does not exist. It also ships with **no child observation behind it** — the
+program's one evaluator is 10 — so `Q-11` is an adult-proxy device check and the grade
+1–2 gap is carried openly as R-46 rather than assumed away.
 
 **Why `NumberFormat` is here and not at M9.** Math notation is content. `1.000` means
 one thousand to a German child and one to an English one, and a French child writing
@@ -213,7 +218,9 @@ the playtest gates `T-01`, `T-02`, `T-03`.
 
 **This milestone has kill/revise authority over everything after it.** If the M2
 playtest says the LOCATE pair reads as punishment, the plan changes here, before
-content breadth is bought.
+content breadth is bought. One child saying that is enough to trigger the revision; one
+child not saying it is not enough to prove the opposite, and the report is written that
+way round.
 
 ---
 
@@ -359,7 +366,11 @@ behind the art PRs, the world ships and then has to be rebuilt.
 **Why the art gate is images, not code.** Code review cannot see that the observatory
 looks like a Bootstrap admin panel. Procedural girih plus a brass-and-lapis palette is
 precisely the recipe that renders as a gradient dashboard with gear icons. The committed
-screenshots and a **named** art director are the only instruments.
+screenshots and the art director are the only instruments. The art director is the
+founder ([ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md)), so the sign-off
+blocks on nobody — which also means the three-strangers verbatims in `Q-14` are the only
+part of the gate that is not the founder judging his own product, and they are therefore
+not optional.
 
 **Exit criteria:** `P-04`, `P-05`, `P-06`, `P-07`, `P-08`, `P-10`, `Q-02`, `Q-06`,
 `Q-14`, and the playtest gate `T-04`.
@@ -442,6 +453,13 @@ without surveilling, and a child who cannot see well or cannot yet read.
 | 9.5 | i18n fill: all five locales complete including every character fragment and every prompt template. **Agents translate directly**; do not resurrect the retired translation scripts. |
 | 9.6 | Parent controls: disable speed rewards, set/override grade, session-length preference. |
 | 9.7 | `ar` / `hi` / `zh-Hans` groundwork behind the `NumberFormat` layer: Arabic-Indic numbering-system support and LTR-forced numerals inside RTL, with the numbering-system choice recorded in [ADR-0007](DECISIONS/ADR-0007-launch-locales.md). Shipping those locales is V1.1. |
+
+**The pre-reader half of that goal ships unobserved.** `Q-11` is an adult-proxy device
+check, not a child observation, because the program's one evaluator is 10 (R-46). M9 is
+the last point at which the alternative — one younger evaluator for one session — is
+still cheap; after it, the only honest options are shipping on heuristics or narrowing the
+advertised grade band. [ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md)
+recommends; the founder decides.
 
 **Exit criteria:** `A-17`, `Q-08`, `Q-09`, `Q-11`, `Q-12`, `Q-13`.
 

--- a/dynawalla/docs/MISSION.md
+++ b/dynawalla/docs/MISSION.md
@@ -3,12 +3,6 @@
 Status: discovery complete, nothing built. See [STATUS.md](STATUS.md).
 Index: [README.md](README.md).
 
-> Links to `GATES.md`, `CURRICULUM.md`, `ADAPTIVE_LEARNING.md`, `ARCHITECTURE.md`,
-> `EXPERIENCE_DESIGN.md`, `PACK_SYSTEM.md`, `RELEASE_ENGINEERING.md`, `STORE.md` and
-> `TEST_STRATEGY.md` resolve once the reference-set PR lands. The two were split so
-> neither diff is truncated by the adversarial reviewer; delete this note in the
-> follow-up.
-
 ## What it is
 
 A mathematics practice product for children, shipping as `inc.corpora.dynawalla` on iOS,
@@ -95,8 +89,10 @@ The compliance regime makes this partly structural rather than voluntary: Apple'
 Category (1.3 / 5.1.4) bars third-party analytics and behavioural advertising, and the
 UK Children's Code restricts nudge techniques and using children's data to keep them
 on a platform. **The practical consequence is that the feel cannot be A/B tested
-remotely.** In-person playtesting is therefore the binding instrument, not a nicety —
-which is why [PLAYTEST-PROTOCOL.md](PLAYTEST-PROTOCOL.md) starts in the bootstrap.
+remotely.** Direct observation is therefore the binding instrument, not a nicety — see
+[PLAYTEST-PROTOCOL.md](PLAYTEST-PROTOCOL.md). That instrument is one child, the founder's
+10-year-old son, and the honest account of what it can and cannot support is
+[ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md).
 
 ## Locked founder decisions
 
@@ -110,14 +106,26 @@ which is why [PLAYTEST-PROTOCOL.md](PLAYTEST-PROTOCOL.md) starts in the bootstra
 | 6 | Bundle id `inc.corpora.dynawalla` (note: `inc.` — Corpán is `com.corpora.corpan`, and both conventions now coexist permanently). |
 | 7 | Ancient-futurist setting: Byzantine / Persian / Fertile Crescent; astrolabes, gears, automata, mechanical computers. Sourced from al-Jazari's 1206 *Book of Knowledge of Ingenious Mechanical Devices* and the Banū Mūsā's 9th-century *Book of Ingenious Devices*. No steampunk goggles, no gears-as-decoration. |
 
-## Open founder decisions
+## Founder decisions, recorded 2026-07-25
 
-Eight decisions are the founder's and are not made. Each has an ADR with status
-`Proposed — awaiting founder` stating the options and their consequences. Three are on
-the critical path: the Kids Category posture is a one-way door that must be decided
-before M1's first store submission; the playtest cohort plus a named art director are
-people the plan cannot supply for itself; and the V1 scope cut narrows the founder-stated
-grade range, so it is not the plan's to ratify. See [DECISIONS.md](DECISIONS.md).
+Four of the eight open decisions were answered by the founder and are recorded in their
+ADRs from his own words: human evaluation resourcing
+([0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md) — one child evaluator, his
+10-year-old son; the founder is the art director), developer-account topology
+([0015](DECISIONS/ADR-0015-developer-account-topology.md) — same accounts as Corpán),
+monetization direction ([0013](DECISIONS/ADR-0013-monetization-model.md) — generous free
+tier plus a subscription, packaging still open), and the Kids Category engineering
+posture ([0001](DECISIONS/ADR-0001-kids-category-posture.md) — no third-party ads,
+analytics or SDKs, ever; a parental gate on every link-out; the category election itself
+deferred to submission).
+
+Four remain the founder's and are not made: the **V1 scope cut**
+([0002](DECISIONS/ADR-0002-v1-scope-cut.md)), which narrows a founder-stated grade range
+and so is not the plan's to ratify; the **product name**
+([0016](DECISIONS/ADR-0016-app-store-product-name.md)), needed before an immutable SKU
+exists; the **repository license** ([0014](DECISIONS/ADR-0014-repository-license.md)) and
+the **standards-alignment claim** ([0010](DECISIONS/ADR-0010-standards-alignment-claim.md)),
+both with dedicated research in flight. See [DECISIONS.md](DECISIONS.md).
 
 ## How this product is graded
 

--- a/dynawalla/docs/MISSION.md
+++ b/dynawalla/docs/MISSION.md
@@ -67,8 +67,12 @@ These are product constraints, not aspirations. Each has an enforcement mechanis
 - Name a child's defect in learner-facing copy. Mal-rule labels are internal; feedback
   names the correct idea. A lint enforces it.
 - Send behavioural data anywhere. All instrumentation is on-device. No third-party
-  analytics SDK, no advertising SDK — enforced by a CI dependency audit that is
-  cross-checked against the submitted Play Data safety declaration.
+  analytics SDK, no advertising SDK, no attribution SDK — and **no third-party crash
+  reporter**, which Guideline 1.3 forbids by naming device information explicitly and
+  which is the one people add without noticing ([RISKS.md](RISKS.md) R-47). Enforced by a
+  CI dependency audit cross-checked against the submitted Play Data safety declaration.
+  Because both stores define "collect" as transmitting off-device, this earns Apple's
+  **"Data Not Collected"** and Play's **"nothing collected, nothing shared"** outright.
 
 **We will:**
 

--- a/dynawalla/docs/MISSION.md
+++ b/dynawalla/docs/MISSION.md
@@ -90,7 +90,9 @@ These are product constraints, not aspirations. Each has an enforcement mechanis
   performance relative to medium/high. Feedback must be contingent, not loud.
 
 The compliance regime makes this partly structural rather than voluntary: Apple's Kids
-Category (1.3 / 5.1.4) bars third-party analytics and behavioural advertising, and the
+Category (1.3 / 5.1.4) says apps **should not** include third-party analytics or
+behavioural advertising and permits neither except in limited, conditioned cases — our
+posture of *none, ever* is stricter than the rule — and the
 UK Children's Code restricts nudge techniques and using children's data to keep them
 on a platform. **The practical consequence is that the feel cannot be A/B tested
 remotely.** Direct observation is therefore the binding instrument, not a nicety — see
@@ -112,8 +114,8 @@ remotely.** Direct observation is therefore the binding instrument, not a nicety
 
 ## Founder decisions, recorded 2026-07-25
 
-Four of the eight open decisions were answered by the founder and are recorded in their
-ADRs from his own words: human evaluation resourcing
+Four of the eight ADR-level open decisions were answered by the founder and are recorded
+in their ADRs from his own words: human evaluation resourcing
 ([0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md) — one child evaluator, his
 10-year-old son; the founder is the art director), developer-account topology
 ([0015](DECISIONS/ADR-0015-developer-account-topology.md) — same accounts as Corpán),
@@ -123,13 +125,13 @@ posture ([0001](DECISIONS/ADR-0001-kids-category-posture.md) — no third-party 
 analytics or SDKs, ever; a parental gate on every link-out; the category election itself
 deferred to submission).
 
-Four remain the founder's and are not made: the **V1 scope cut**
-([0002](DECISIONS/ADR-0002-v1-scope-cut.md)), which narrows a founder-stated grade range
-and so is not the plan's to ratify; the **product name**
-([0016](DECISIONS/ADR-0016-app-store-product-name.md)), needed before an immutable SKU
-exists; the **repository license** ([0014](DECISIONS/ADR-0014-repository-license.md)) and
-the **standards-alignment claim** ([0010](DECISIONS/ADR-0010-standards-alignment-claim.md)),
-both with dedicated research in flight. See [DECISIONS.md](DECISIONS.md).
+**Several remain open, and this file deliberately does not list them.** Three documents
+previously carried three different counts, which is how a founder ends up not knowing a
+decision is waiting on him. **[STATUS.md](STATUS.md) is the single source of truth for
+which founder decisions are open and when each one bites** — including the ones that live
+*inside* an otherwise-decided ADR, such as the Kids Category election and age band
+(`G-01`) and monetization packaging (`G-02`). [DECISIONS.md](DECISIONS.md) indexes the
+ADRs; STATUS.md says what is outstanding.
 
 ## How this product is graded
 

--- a/dynawalla/docs/PLAYTEST-PROTOCOL.md
+++ b/dynawalla/docs/PLAYTEST-PROTOCOL.md
@@ -6,11 +6,17 @@ Three gates use this protocol: **M2** (`T-01`, `T-02`, `T-03`), **M6** (`T-04`),
 
 ## Why this is the binding instrument
 
-Apple's Kids Category (1.3 / 5.1.4) bars third-party analytics and behavioural
-advertising, and the UK Children's Code restricts nudge techniques and using children's
-data to keep them on a platform. All Dynawalla instrumentation is on-device and there is
-no telemetry endpoint. **The feel therefore cannot be A/B tested remotely.** Direct
-observation is the measurement, not a supplement to it.
+Guideline 1.3 says Kids Category apps **should not** include third-party analytics or
+advertising, and that **"in limited cases"** third-party analytics and contextual
+advertising **may be permitted** under conditions. **Our posture is stricter than the
+rule: none, ever** ([ADR-0001](DECISIONS/ADR-0001-kids-category-posture.md)) — that is a
+program decision, not a store mandate, and it should not be restated as a prohibition.
+The UK Children's Code separately restricts nudge techniques and using children's data to
+keep them on a platform.
+
+The consequence for measurement is the same either way: all Dynawalla instrumentation is
+on-device and there is no telemetry endpoint, so **the feel cannot be A/B tested
+remotely.** Direct observation is the measurement, not a supplement to it.
 
 ---
 
@@ -63,7 +69,8 @@ to a named founder is identified.
 ## 3. Session protocol
 
 **Two sessions per gate, 20 minutes each, on separate days**, at least one day apart.
-Sessions are **unsupervised**: the observer is in the room, not at the child's shoulder.
+Sessions are **unassisted**: the observer is in the room, but does not help, prompt or
+sit at the child's shoulder.
 
 **Setup (observer, before the session)**
 

--- a/dynawalla/docs/PLAYTEST-PROTOCOL.md
+++ b/dynawalla/docs/PLAYTEST-PROTOCOL.md
@@ -1,9 +1,5 @@
 # Dynawalla — Playtest protocol
 
-This lands in the bootstrap, not at M2, because **recruitment and consent take weeks**.
-Starting them at M2 makes the M2 gate unreachable on schedule, and an unreachable gate is
-a waived gate.
-
 Three gates use this protocol: **M2** (`T-01`, `T-02`, `T-03`), **M6** (`T-04`), **M8**
 (`T-05`). Each produces a committed report — `PLAYTEST-M2.md`, `PLAYTEST-M6.md`,
 `PLAYTEST-M8.md` — in this directory. **None may be waived** (`T-06`).
@@ -12,61 +8,53 @@ Three gates use this protocol: **M2** (`T-01`, `T-02`, `T-03`), **M6** (`T-04`),
 
 Apple's Kids Category (1.3 / 5.1.4) bars third-party analytics and behavioural
 advertising, and the UK Children's Code restricts nudge techniques and using children's
-data to keep them on a platform. **The feel cannot be A/B tested remotely.** There is no
-substitute instrument, so scheduled in-person sessions are the measurement, not a
-supplement to it. See [ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md).
+data to keep them on a platform. All Dynawalla instrumentation is on-device and there is
+no telemetry endpoint. **The feel therefore cannot be A/B tested remotely.** Direct
+observation is the measurement, not a supplement to it.
 
 ---
 
-## 1. Cohort
+## 1. Who
 
-**Minimum 6 children, aged 6–11**, with **at least 2 who dislike math** — self-reported
-by the child or reported by the parent. The second condition is not decoration: a cohort
-of children who enjoy arithmetic will find almost any competent drill app acceptable and
-will tell you nothing about the product's actual claim.
+**One child evaluator: the founder's son, age 10.** The founder observes, and holds
+every adult role this protocol calls for — art director, design authority, product owner
+and QA. Recorded in [ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md).
 
-**At least one must be a grade-1 child who cannot yet read.** This is a recruitment
-requirement, not a preference. Read-aloud is argued into M2 rather than M9 on exactly
-that child's behalf, and `Q-11` is the only item that tests it — a cohort starting at 7
-leaves `Q-11` with no instrument, which is how an unwaivable gate gets quietly waived.
-
-Aim for:
-
-- a spread across the age range rather than six 9-year-olds;
-- at least one child at each end of fluency (one who counts on fingers, one who recalls);
-- at least one child who has used a math app before and can compare.
-
-**The same cohort returns for M6 and M8.** Longitudinal comparison is most of the value:
-"did the same child come back, and did they remember what they were building."
-Recruit 8 to retain 6.
+That ADR is the honest account of what a sample of one, in the builder's own household,
+can and cannot support. The two-sentence version: it is the highest-signal instrument
+available and far better than none, and it licenses **no** generalizable engagement
+claim, **no** efficacy claim, and **no** coverage claim for the grade 1–2 end of the
+curriculum, which will ship unobserved unless a younger evaluator is added.
 
 **Devices.** Sessions run on the named reference devices — Samsung Galaxy Tab A9
 SM-X110 (4 GB), Pixel 6a, iPad 10th gen — from a **TestFlight or Play-internal build**,
 never a dev server. A child on a laptop with a hot-reloading dev build is testing a
 different product.
 
-**Exclusions.** No child of anyone on the program. Not because of ethics theatre — a
-child who wants the adult to be pleased produces unusable verbatims.
+**The same child returns at M6 and M8.** Longitudinal comparison is most of the value
+this instrument has: did he come back, and does he remember what he was building. The
+cohort-attrition hazard the external plan carried does not exist here.
 
 ---
 
-## 2. Consent and data handling
+## 2. Data handling
 
-Consent must be documented **before the first session** under COPPA and, for any UK
-participant, the UK Children's Code. Template in §6. **Have it reviewed by counsel before
-use** — the template below is a starting point, not legal advice.
+The founder is the parent, so there is no consent paperwork, no template and no counsel
+review. Ask the child himself, in one sentence, at the start of the first session; a
+child who does not want to is not a participant.
 
-Data rules, which are stricter than the regulation and deliberately so:
+The data rules below are stricter than the regulation, and they matter **more** here
+rather than less: **this repository is public**, and a child identified by relationship
+to a named founder is identified.
 
 - **No video or audio recording of the child.** Written observation only.
-- **No child's name in any committed artifact.** Children are `C1`..`C8` in every report.
-  The mapping lives offline with the founder, never in this repository.
+- **No child's name in any committed artifact.** The evaluator is `C1` in every report.
+- **No age-adjacent detail** that narrows identification beyond what
+  [ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md) already states.
 - **No account, no upload, no telemetry.** Sessions use local device state only; the app
   has no server profile.
-- **Devices are wiped between children** (fresh profile, or app data cleared) so one
-  child's progress never seeds another's session.
-- **Withdrawal is honoured immediately and retroactively** — on request, that child's
-  observations are removed from the report and the report is amended in a normal PR.
+- **Fresh profile per session-set** so a previous gate's progress never seeds a later
+  session's starting difficulty.
 - Only two things leave the room: the structured observations in §4, and verbatim quotes
   with no identifying content.
 
@@ -74,24 +62,15 @@ Data rules, which are stricter than the regulation and deliberately so:
 
 ## 3. Session protocol
 
-**Two sessions per child per gate, 20 minutes each, on separate days**, at least one day
-apart. Sessions are **unsupervised**: the observer is in the room, not at the child's
-shoulder.
+**Two sessions per gate, 20 minutes each, on separate days**, at least one day apart.
+Sessions are **unsupervised**: the observer is in the room, not at the child's shoulder.
 
-**Six-year-olds.** Same protocol, three adjustments. The framing sentence is spoken, not
-handed over on paper. The session ends at 20 minutes rather than 30 if the child is still
-going, because a six-year-old will keep going past the point the measurement means
-anything. And the consent conversation happens with the parent present in the room — the
-child's own assent is asked for separately, in one sentence, and a "no" ends it. For the
-`Q-11` observation, record whether the child ever tapped the read-aloud control
-unprompted, and what they did when a prompt they could not read appeared.
-
-**Setup (observer, before the child arrives)**
+**Setup (observer, before the session)**
 
 1. Reference device, store build, build number written down.
 2. Fresh profile. Sound on, headphones available. Reduced motion off unless the child
    uses it.
-3. Note the child's id, age, and the "likes/dislikes math" flag from recruitment.
+3. Note the device and which gate this is.
 
 **Session**
 
@@ -102,119 +81,101 @@ unprompted, and what they did when a prompt they could not read appeared.
    anything except "whatever you want — or you can stop." Every question the child has to
    ask is a finding.
 3. **Do not stop the child at 20 minutes.** The clock is a measurement, not a limit.
-   Note the 20-minute mark and let them continue if they want to.
+   Note the 20-minute mark and let him continue if he wants to.
 4. **End when the child stops**, or at 30 minutes, whichever comes first.
 5. **One question afterwards, and only one, chosen per gate:**
    - M2: "What happened when you got one wrong?"
    - M6: "What are you building, and why did you pick that one?"
    - M8: "Was there a bit where you figured out what you'd been doing wrong?"
 
-**Next day (M2 and M6 only).** The device is left with the family overnight where
-possible. Record whether the child opened the app again **without being asked**. That
-single number is worth more than the rest of the session.
+**Next day (M2 and M6).** The device stays in the house, which it does anyway. Record
+whether the child opened the app again **without being asked**. That single fact is worth
+more than the rest of the session.
+
+---
+
+## 3a. Bias, and what is actually done about it
+
+The observer built the product and is the child's parent. That is the instrument's
+central defect and it cannot be designed away, only contained. What containment looks
+like:
+
+- **The framing sentence is fixed and minimal**, delivered identically every time, and
+  the observer then sits where the child cannot read his face. Approval leaks through
+  expression faster than through words.
+- **Praise is not evidence.** A child who wants a parent to be pleased will say the app
+  is good. Verbatims of approval are recorded for the record and **may not be cited as
+  the pass condition for any gate**. Gates key on behaviour: how long he chose to keep
+  going, whether he came back the next day unprompted, and what he did after a wrong
+  answer. Those are harder to hand over to please someone.
+- **The report states what the sessions falsified**, not what they confirmed (§5). A
+  report with no negative finding is treated as a failed observation, not a clean one.
+- **Every count is reported as a raw count with n = 1 attached**, never as a rate or a
+  proportion. "1 of 1" is not 100%.
 
 ---
 
 ## 4. What is recorded
 
-Per child, per session. Everything here is observable — no inference, no scoring of the
-child.
+Per session. Everything here is observable — no inference, no scoring of the child.
 
 | Field | How |
 |---|---|
-| `childId`, age, dislikes-math flag | from recruitment |
+| `childId` (`C1`) | fixed |
 | device, build number, store channel | written before the session |
 | session number (1 or 2), date | |
-| **time to voluntary quit** | stopwatch from first problem to the child stopping; note if they were still going at 30 min |
+| **time to voluntary quit** | stopwatch from first problem to the child stopping; note if he was still going at 30 min |
 | problems attempted / correct | from the on-device Developer Mode summary, not by hand |
-| **unprompted verbatims** | written down as spoken, including the boring ones |
+| **unprompted verbatims** | written down as spoken, including the boring ones and the discouraging ones |
 | moments the child asked the observer a question | with the question |
 | moments the child looked away, sighed, or slumped | timestamp + what was on screen |
 | **what the child did after each wrong answer** | one of: retried, asked for the answer, studied the contrast, ignored it, quit |
+| **what the child skipped or avoided** | including anything he found a way around |
 | **next-day voluntary return** | yes / no |
 | anything the child did that the design did not anticipate | free text |
 
 **Per gate, additionally:**
 
-- **M2** — the specific counts behind `T-02`: how many of the six children, unprompted,
-  did something after a wrong answer *other than* ask for the answer. And the raw
-  response data needed for `T-03`: per-item correctness with the predicted `b()` for each
-  item served, exported from Developer Mode, so residuals can be fitted against predicted
-  difficulty and committed as an engine fixture.
-- **M6** — whether each child can say, unprompted, **what** they are building and **why
-  they chose it**; and whether the chosen-chamber mechanic visibly changed what they did.
-- **M8** — for each child, the accuracy of their **next attempt at the same mal-rule
-  class** after a LOCATE contrast pair, versus after a Stage-1 verify. This is the
-  product's thesis and it is measured, not assumed.
+- **M2** — the per-wrong-answer breakdown behind `T-02`: for every wrong answer across
+  both sessions, which of the five responses above occurred. And the raw response data
+  for `T-03`: per-item correctness with the predicted `b()` for each item served,
+  exported from Developer Mode. One child's residuals cannot calibrate `b()`; they can
+  show a gross mismatch, and that is the whole claim made for them.
+- **M6** — whether the child can say, unprompted, **what** he is building and **why he
+  chose it**; and whether the chosen-chamber mechanic visibly changed what he did.
+- **M8** — the accuracy of his **next attempt at the same mal-rule class** after a LOCATE
+  contrast pair, versus after a Stage-1 verify. This is the product's thesis. With one
+  child it is an observation, not a measurement, and the report says so in those words.
+
+---
 
 ## 5. Reporting and authority
 
-Each gate's report is a committed markdown file in this directory containing: the cohort
-table (ids only), the raw per-session records above, the verbatims, the gate verdict, and
-**an explicit statement of what the sessions falsified**.
+Each gate's report is a committed markdown file in this directory containing: the
+per-session records above, the verbatims, the gate verdict, and **an explicit statement
+of what the sessions falsified**.
 
 A report that finds nothing wrong is a suspicious report. Write down the thing that
 went badly even when the gate passes.
 
-**These gates have kill/revise authority.** If M2's cohort shows the LOCATE contrast pair
-reading as punishment, LOCATE is revised before M7 spends on content breadth. If M8 shows
-no advantage over a Stage-1 verify, **LOCATE is revised or cut** — that is the whole
-thesis, and cutting it is a legitimate outcome of the measurement.
+**These gates have kill/revise authority.** If M2 shows the LOCATE contrast pair reading
+as punishment, LOCATE is revised before M7 spends on content breadth. If M8 shows no
+advantage over a Stage-1 verify, **LOCATE is revised or cut** — that is the whole thesis,
+and cutting it is a legitimate outcome of the observation.
 
-A gate is not passed by a majority of observers feeling good about it. It is passed by
-the numbers in `T-01`..`T-05`.
+A gate is not passed by the observer feeling good about it. It is passed by the recorded
+behaviour in `T-01`..`T-05`, with n = 1 stated next to every number.
 
----
+## 6. What this protocol does not cover
 
-## 6. Parental consent template
+Named here so it is not mistaken for covered:
 
-**Draft. Review with counsel before use.** Placeholders in `[brackets]` must be filled;
-do not ship the template with a placeholder in it.
-
-> **Consent for a child to try a maths app in development**
->
-> **What this is.** `[Organisation]` is building a maths practice app for children. We
-> would like your child to try it and tell us what they think. It is not a test of your
-> child, and nothing about their performance is reported to you, to a school, or to
-> anyone else.
->
-> **What happens.** Your child uses the app on a tablet or phone we provide, for about
-> 20 minutes, on two separate days. An adult stays in the room but does not help or
-> watch over their shoulder. Your child can stop at any time, for any reason, without
-> giving one.
->
-> **What we write down.** How long your child chose to keep playing, what they said out
-> loud, what they did after they got a question wrong, and how many questions they
-> answered. We do **not** record video or audio. We do **not** write down your child's
-> name — they are identified only by a code in our notes.
->
-> **What we do not collect.** No account, no email address, no location, no advertising
-> identifier, no photographs. The app sends nothing to any server. There is no
-> third-party analytics or advertising in it, and there never will be.
->
-> **Where it goes.** The written observations are used to decide how to build the app.
-> Anonymised summaries and quotes may appear in our public development notes. Nothing
-> that could identify your child ever appears anywhere.
->
-> **Withdrawal.** You or your child can withdraw at any time, including after the
-> session. Email `[contact]` and we will delete your child's observations and correct
-> any published summary. You do not have to give a reason.
->
-> **How long we keep it.** Written observations are kept for `[retention period]` and
-> then destroyed. The code-to-name mapping is held only by `[named person]`, offline, and
-> is destroyed at the end of the study.
->
-> **Contact.** `[named person]`, `[contact]`.
->
-> ---
->
-> I am the parent or legal guardian of `[child's name]`, aged `[age]`.
-> I have read the above and I consent to my child taking part.
->
-> Parent/guardian name · Signature · Date
->
-> `[  ]` I also consent to anonymised quotes from my child appearing in public
-> development notes. *(Optional — participation does not depend on this.)*
-
-Ask the child too, in their own words, at the start of the first session. A child who
-does not want to is not a participant, whatever the form says.
+- **Grade 1–2 content and pre-reader flows.** Read-aloud as a primary input path,
+  icon-only affordances and small-hand touch targets will ship with no child
+  observation behind them. `Q-11` is an adult-proxy device check for exactly this
+  reason. See [ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md) and
+  [RISKS.md](RISKS.md) R-46.
+- **Accessibility needs nobody in the household has.** `Q-09` (VoiceOver / TalkBack) and
+  `Q-10` (text alternatives, nothing solvable by colour alone) are the instruments there.
+- **Anything about a population.** No rate, no proportion, no comparison to other
+  products, no learning-gain claim.

--- a/dynawalla/docs/README.md
+++ b/dynawalla/docs/README.md
@@ -39,13 +39,8 @@ Read in this order on your first task. Skim headings after that.
 - [RISKS.md](RISKS.md) — every risk with a mitigation and an owner.
 - [DECISIONS.md](DECISIONS.md) — the ADR index, including the open founder decisions.
 - [DECISIONS/](DECISIONS/) — one ADR per irreversible choice.
-- [PLAYTEST-PROTOCOL.md](PLAYTEST-PROTOCOL.md) — cohort, session protocol, what gets
-  recorded, parental-consent template.
+- [PLAYTEST-PROTOCOL.md](PLAYTEST-PROTOCOL.md) — who the evaluator is, the session
+  protocol, what gets recorded, and what this instrument cannot tell us.
 
 Agent rules for this directory tree: [`../AGENTS.md`](../AGENTS.md), which is a delta
 over the root [`../../AGENTS.md`](../../AGENTS.md).
-
-> The **Reference** set lands in a follow-up PR on branch
-> `agent/dynawalla/program-docs-reference`; it was split out so neither diff exceeds the
-> adversarial reviewer's size limit and gets truncated. Those links resolve once it
-> merges.

--- a/dynawalla/docs/RISKS.md
+++ b/dynawalla/docs/RISKS.md
@@ -364,7 +364,9 @@ already assumes the strict posture, so choosing **in** costs nothing extra; choo
 ### R-35 · M · Program
 **Child-directed compliance constrains engineering, not paperwork.** Play's Families
 Policy forbids transmitting AAID/IMEI/MAC/phone number and collecting precise location
-from child users; Apple 1.3/5.1.4 bars third-party analytics and advertising outright.
+from child users; Apple 1.3/5.1.4 says apps **should not** carry third-party analytics or
+advertising and allows both only in limited, conditioned cases — the program's absolute
+ban is stricter than the guideline, deliberately.
 Every dependency addition becomes a compliance decision.
 **Mitigation:** the CI dependency audit is the only mechanical enforcement (`G-05`,
 `G-06`).
@@ -380,15 +382,18 @@ dead for that app record without Google support.
 **Two founder browser clicks are unavoidable and on the critical path.** Apple has no
 app-create operation at all — verified against OpenAPI spec 4.4.1 (966 paths, no
 `apps_createInstance`), and Apple's own docs say "create new apps on the App Store Connect
-website." The Play `androidpublisher` v3 discovery document has no application-create
-method either. **Corrected 2026-07-25:** the ASC API key does **not** need re-minting —
-it already returns 200 on the Provisioning endpoints *and* on Admin-scoped `/v1/users`.
-The Play service account does still need an explicit per-app grant.
+website." Play's `androidpublisher` v3 has no method to create **your own** app record.
+**Corrected 2026-07-25:** the ASC API key does **not** need re-minting — it already
+returns 200 on the Provisioning endpoints *and* on Admin-scoped `/v1/users`. The Play
+service account does still need an explicit per-app grant.
 **Mitigation:** schedule the ~10 minutes of founder console time as an M1 task, not a
 surprise (`G-09`). `grants.create` may automate the Play half but needs the numeric
 developer account id, which is not recorded anywhere in this repo.
-**Trap:** `appstoreappsreview.createappstorehostedapp` reads exactly like the app-create
-endpoint and is the **DMA alternative-app-store** pipeline. Do not call it.
+**Trap, on the Google side:** `androidpublisher` v3 *does* contain
+`appstoreappsreview.createappstorehostedapp`
+(`POST .../androidpublisher/v3/appstore/{appStorePackageName}/apps:create`), which reads
+exactly like the app-create endpoint and is for **third-party Android app stores**
+registering apps they host. Do not call it.
 
 ### R-38 · L · Release
 **Play's first-release draft gate will bite.** On a never-published app the API can only
@@ -519,7 +524,9 @@ collecting nothing.**
   store-provided age signals, using them **only** for compliance, and **deleting them
   after use** — so consume, never persist. (Secondary sourcing; flag for counsel.)
 - Also queued: **California AADCA** partially revived by the Ninth Circuit 2026-03-12;
-  **Nebraska AADC** effective 2026-01-01; **Vermont** 2027-01-01.
+  **Nebraska AADC** effective 2026-01-01; **Vermont** 2027-01-01. *(Same secondary
+  sourcing as the bullet above — specific dates and holdings are unverified against
+  primary sources and are for counsel to confirm, not to be relied on as stated.)*
 
 **Mitigation:** write the three documents while the answer is "nothing" — they are cheap
 now and they are the first artifacts a school district, a regulator or an acquirer asks

--- a/dynawalla/docs/RISKS.md
+++ b/dynawalla/docs/RISKS.md
@@ -377,18 +377,34 @@ dead for that app record without Google support.
 `X-03` exists for this reason alone.
 
 ### R-37 · M · Release
-**Two founder browser clicks are unavoidable and on the critical path.** Apple
-`POST /v1/apps` returns 404 and an ASC API key gets 403 on create; the Play
-`androidpublisher` v3 discovery document has no application-create method. The ASC API
-key almost certainly needs re-minting at Admin role, and the existing Play service
-account needs an explicit per-app permission grant on the new record.
+**Two founder browser clicks are unavoidable and on the critical path.** Apple has no
+app-create operation at all — verified against OpenAPI spec 4.4.1 (966 paths, no
+`apps_createInstance`), and Apple's own docs say "create new apps on the App Store Connect
+website." The Play `androidpublisher` v3 discovery document has no application-create
+method either. **Corrected 2026-07-25:** the ASC API key does **not** need re-minting —
+it already returns 200 on the Provisioning endpoints *and* on Admin-scoped `/v1/users`.
+The Play service account does still need an explicit per-app grant.
 **Mitigation:** schedule the ~10 minutes of founder console time as an M1 task, not a
-surprise (`G-09`).
+surprise (`G-09`). `grants.create` may automate the Play half but needs the numeric
+developer account id, which is not recorded anywhere in this repo.
+**Trap:** `appstoreappsreview.createappstorehostedapp` reads exactly like the app-create
+endpoint and is the **DMA alternative-app-store** pipeline. Do not call it.
 
 ### R-38 · L · Release
 **Play's first-release draft gate will bite.** On a never-published app the API can only
 create draft releases. This is Google's anti-abuse gate, not a code bug, and should not
 be debugged as one. **Mitigation:** budget one Console-side publish (`G-10`).
+
+### R-38b · M · Release + Founder
+**Play's 12-testers-for-14-continuous-days closed-testing gate may add two weeks to
+M1.** It applies to *personal* developer accounts created after 2023-11-13; organization
+accounts are exempt. **The Corpora account's type is unverified.** No engineering
+recovers a two-week calendar hit discovered at submission time.
+**Mitigation:** a founder console check, done early rather than at M1. Two other unknowns
+are worth the same trip: the **numeric Play developer account id** (needed if
+`grants.create` is to automate `G-09`), and the fact that the **Play Developer Reporting
+API is disabled** on GCP project `corpora1`, so the account's apps can only be probed by
+known package name, never enumerated.
 
 ### R-39 · L · Release
 **Play target API 36 is mandatory for new apps from 2026-08-31.** A Tauri template
@@ -469,3 +485,45 @@ design heuristics; narrow the advertised grade band to what was observed (intera
 roughly 6–7, for a single session before M9. ADR-0017 recommends the third with the
 second as a triggered fallback at M9. Until one is chosen, no public claim about grade
 1–2 suitability should be made.
+
+### R-47 · H · Native + Release
+**The forbidden-SDK list is wider than "no ads, no analytics," and one category on it is
+routinely treated as infrastructure.** Guideline 1.3 names *device information*
+explicitly, which puts **third-party crash reporters — Crashlytics, Sentry, Bugsnag — on
+the forbidden list**. Teams add those without thinking of them as a compliance decision at
+all. The full set: ad networks; third-party analytics (Firebase Analytics, Amplitude,
+Mixpanel, GA4); attribution / MMP (AppsFlyer, Adjust, Branch); crash reporters; push SDKs
+with audience segmentation; targeted remote-config and A/B tooling; social login; and
+**any SDK that declares `com.google.android.gms.permission.AD_ID`**.
+**Mitigation:** the CI dependency audit (`G-05`) plus the four mechanical gates planned in
+[STORE.md](STORE.md) — above all the **network-egress test**, which catches a chatty
+transitive dependency that no manifest inspection would.
+**Consequence if breached:** it is not only a policy problem. A crash SDK forces a
+Diagnostics disclosure and a receipt-validation backend forces a Purchases disclosure,
+either of which downgrades the "Data Not Collected" / "nothing collected, nothing shared"
+declarations that local-first earns for free.
+**And there is no fallback:** **Play's Families Self-Certified Ads SDK program is closed
+to new applicants**, so "ship clean, add ads later if the subscription underperforms" is
+not an option that exists. That interacts directly with R-45.
+
+### R-48 · M · Founder + Program
+**Two children's-privacy obligations are already in force and neither is satisfied by
+collecting nothing.**
+
+- **COPPA's 2025 amendments required full compliance by 2026-04-22 — that date has
+  passed.** Even at "we transmit nothing," the rule wants a written **§312.10
+  retention-and-deletion policy** and a written **§312.8 security program**. A UK
+  Children's Code **DPIA** is the analogous artifact on that side.
+- **Texas SB2420 and Utah's App Store Accountability Acts are in force as of July 2026
+  and apply to *all* apps, not only child-directed ones.** They require consuming
+  store-provided age signals, using them **only** for compliance, and **deleting them
+  after use** — so consume, never persist. (Secondary sourcing; flag for counsel.)
+- Also queued: **California AADCA** partially revived by the Ninth Circuit 2026-03-12;
+  **Nebraska AADC** effective 2026-01-01; **Vermont** 2027-01-01.
+
+**Mitigation:** write the three documents while the answer is "nothing" — they are cheap
+now and they are the first artifacts a school district, a regulator or an acquirer asks
+for. The store-signal rule is an architectural constraint, not paperwork: any age signal
+that arrives must be consumed and dropped, never written to storage.
+**Residual:** nobody is assigned to any of it, and "we collect nothing" reads like an
+exemption right up until someone asks for the policy document.

--- a/dynawalla/docs/RISKS.md
+++ b/dynawalla/docs/RISKS.md
@@ -28,13 +28,18 @@ write it up.
 
 ### R-02 · H · Founder + Program
 **The playtest gates are the most likely thing to be waived, and waiving them voids the
-program.** Recruiting six children with documented parental consent takes weeks and has
-zero slots today. Compliance forbids remote A/B testing, so there is no substitute
-instrument: if M2 ships without children, every judgement about pacing, reaction
-budgets, the 0.80 difficulty target and "wrong must not be more fun than right" reverts
-to being a claim about children that a simulator the team wrote cannot falsify.
-**Mitigation:** recruitment starts in the bootstrap PR, not at M2.
-See [PLAYTEST-PROTOCOL.md](PLAYTEST-PROTOCOL.md).
+program.** Compliance forbids remote A/B testing, so there is no substitute instrument:
+if M2 ships without a child playing it, every judgement about pacing, reaction budgets,
+the 0.80 difficulty target and "wrong must not be more fun than right" reverts to being a
+claim about children that a simulator the team wrote cannot falsify.
+**Mitigation:** [ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md) removed the
+excuse — the evaluator is the founder's 10-year-old son, there is no recruitment and no
+consent lead time, so a missing report is a choice rather than a resourcing failure.
+**Residual, and it is large:** `n = 1`, observed by the parent who built the product.
+This instrument reliably detects a loop that fails and cannot establish that one
+succeeds, so every gate is written to fire on a negative and never to certify a positive.
+See [PLAYTEST-PROTOCOL.md](PLAYTEST-PROTOCOL.md) §3a for what is actually done about the
+bias, and R-46 for the age gap.
 
 ### R-03 · H · Program
 **Merged is not done, and this repo has the counterexample.** Journey merged
@@ -267,10 +272,16 @@ A public *alignment claim* is a separate exposure —
 reliability gate was circular: the engine computes `σ(θ − b)` and the persona answered
 from `σ(α − b)` against the same `b`, so it passed by construction.
 **Mitigation:** personas answer from a 3PL with per-child discrimination and item
-features the engine cannot observe, plus one explicit misspecification persona, plus
-real-child residuals from the M2 playtest fitted before content breadth is bought
-(`A-01`, `A-02`). **Residual:** if the M2 residual fit is skipped "until there is more
-content," the engine is unvalidated all the way to launch.
+features the engine cannot observe, plus one explicit misspecification persona
+(`A-01`), plus a real-child residual fixture from the M2 playtest fitted before content
+breadth is bought (`A-02`). **Residual, revised 2026-07-25:** the real-child fixture is
+**one child's** response data
+([ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md)). It detects a gross
+mismatch and cannot calibrate `b()`, so the weight the original plan put on it moves onto
+the misspecified personas. The engine's difficulty model is consequently validated almost
+entirely against synthetic learners, which is a weaker position than this register
+previously claimed. If the M2 fixture is skipped as well, even the gross-mismatch check
+is gone.
 
 ### R-27 · M · Engine
 **The harness is a nightly job with a named owner or it is nothing.** Corpán's measured
@@ -322,8 +333,13 @@ brass-and-lapis palette is precisely the recipe that renders as a gradient dashb
 with gear icons, and code review cannot see it.
 **Mitigation:** committed screenshots reviewed as **images** in the PR, a hostile
 reference board naming what it must not look like, three strangers who must not say
-"dashboard" or "template," and a **named** art director whose sign-off is an exit
-criterion (`Q-14`). Without a named art director this risk has no mitigation at all.
+"dashboard" or "template," and the art director's sign-off as an exit criterion
+(`Q-14`). The art director is the founder
+([ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md)), so the role is filled
+and the gate can run. **Residual:** the art director is also the person who commissioned
+the art and owns the product, so the sign-off is not independent review. The three
+strangers are the only outside eyes in the whole mitigation, which is why `Q-14` keeps
+them.
 
 ### R-33 · M · Experience
 **The character is the differentiation claim and is easy to under-build.** ~100
@@ -405,12 +421,51 @@ directory.
 **The repo is public with no license.** GitHub reports `license: null` and no `LICENSE`
 file exists, while several shipped decisions rest on "it's open source anyway."
 **Mitigation:** a `LICENSE` placeholder lands in the bootstrap PR pointing at
-[ADR-0014](DECISIONS/ADR-0014-repository-license.md); the real decision is the
-founder's and counsel's.
+[ADR-0014](DECISIONS/ADR-0014-repository-license.md); dedicated research was commissioned
+2026-07-25 and a recommendation is pending; the decision is the founder's and counsel's.
 
 ### R-44 · M · Program
-**A role with no name is a gate that does not run.** Three roles in this register are
-currently unassigned, and two acceptance items (`A-19` nightly harness owner, `Q-14` art
-director) name a person as their pass condition.
+**A role with no name is a gate that does not run.** Several roles in this register are
+still unassigned, and two acceptance items name a person as their pass condition:
+`A-19` (nightly harness owner) and `Q-14` (art director). `Q-14`'s is now filled — the
+art director is the founder
+([ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md)) — and `A-19`'s is not.
 **Mitigation:** [STATUS.md](STATUS.md) carries the role→person table and is updated in
 the PR that changes it.
+
+### R-45 · M · Founder + Program
+**The monetization direction is copied from a model the founder says did not work.** His
+own words on Corpán's subscription: "that hasn't worked in the slightest." Dynawalla's
+direction — generous free tier plus a subscription for unlimited exercises and full
+access ([ADR-0013](DECISIONS/ADR-0013-monetization-model.md)) — is the same shape, so
+adopting it by default inherits the pricing and packaging assumptions that produced that
+result along with the architecture that makes it cheap to run. It is a **direction, not a
+validated design**, and no evidence pass has been done on what a parent would actually
+pay for here.
+**Mitigation:** `G-02` requires packaging and pricing to be decided and recorded before
+M9 completes, separately from the direction; ADR-0013 records the tension between an
+"unlimited exercises" upsell and [MISSION.md](MISSION.md)'s ban on play-by-appointment
+and grinding gates, so a free-tier session cap is ruled out before launch pressure makes
+it look reasonable. **Residual:** nobody is currently assigned to do that evidence pass,
+and low run-rate makes it easy to defer indefinitely — a free product with no revenue is
+not obviously failing, which is exactly how it stays undecided.
+
+### R-46 · M · Founder + Experience
+**Grades 1–2 and every pre-reader flow will ship with zero child observation.** The
+program's one evaluator is 10 years old, roughly grade 4–5
+([ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md)). Early counting, number
+formation, first addition and subtraction facts, and specifically the flows that assume a
+child who cannot read the interface — read-aloud as the primary input path, icon-only
+affordances, touch targets for smaller hands — are unobserved. Read-aloud is argued
+forward from M9 to M2 on behalf of a child nobody will watch use it. The V1 slice itself
+is covered, which is the good half of the same fact: the highest-uncertainty content sits
+squarely in the evaluator's range.
+**Mitigation:** `Q-11` becomes an adult-proxy device check that verifies the capability
+and explicitly does not evidence the child claim; the adaptive engine's placement keeps a
+young learner out of content they cannot attempt.
+**Open, and it is the founder's call — he has not made it:** accept the gap and ship on
+design heuristics; narrow the advertised grade band to what was observed (interacts with
+[ADR-0002](DECISIONS/ADR-0002-v1-scope-cut.md)); or add one younger evaluator, aged
+roughly 6–7, for a single session before M9. ADR-0017 recommends the third with the
+second as a triggered fallback at M9. Until one is chosen, no public claim about grade
+1–2 suitability should be made.

--- a/dynawalla/docs/STATUS.md
+++ b/dynawalla/docs/STATUS.md
@@ -17,6 +17,10 @@ adversarial critics produced 42 findings, of which the blocking ones changed the
 The revised positions are what is written here — see
 [MASTER_PLAN.md](MASTER_PLAN.md) and [RISKS.md](RISKS.md), not any earlier draft.
 
+The bootstrap docs and CI groundwork are merged. Four of the eight open founder decisions
+have been answered and recorded. What remains before code starts is the native CI gate
+and the adversarial-review fixes.
+
 The four corrections most likely to be cheerfully undone by a future agent are recorded
 where they will be read before the mistake is made:
 
@@ -29,24 +33,47 @@ where they will be read before the mistake is made:
 
 ## Merged
 
-Nothing yet.
+`main` is at `7fc5b7d98`.
+
+| PR | What |
+|---|---|
+| #522 | Removed the `pr-agent` workflow |
+| #523 | Deprecated-methodology expunge, false-claim corrections, `LICENSE` placeholder |
+| #524 | Project-scoped Claude control plane + additive `ci.yml` area filters |
+| #525 | Program plan: mission, acceptance criteria, master plan, ADRs |
+| #526 | Program reference set: architecture, curriculum, engine, gates, release, store |
 
 ## In flight (M0a bootstrap)
 
-| Work | Owner | State |
-|---|---|---|
-| `dynawalla/docs/**` + `dynawalla/AGENTS.md` (this set) | program-docs agent | PR open |
-| Root runbook amendments (`AGENTS.md`) | separate agent | PR open |
-| Committed agent configuration (`.claude/**`, `.gitignore` negations) | separate agent | PR open |
-| Additive `ci.yml` area filters + `uncovered` in warn mode | separate agent | PR open |
-| Delete `.github/workflows/pr-agent.yml` | with the bootstrap PR | not landed |
-| Deprecated-methodology expunge across ~22 doc sites | separate agent | PR open |
-| `LICENSE` placeholder | with the bootstrap PR | not landed |
+| Work | State |
+|---|---|
+| Founder decisions recorded in ADRs 0001 / 0013 / 0015 / 0017 | this PR |
+| Repository-license research ([ADR-0014](DECISIONS/ADR-0014-repository-license.md)) | commissioned 2026-07-25, recommendation pending |
+| Standards-alignment research ([ADR-0010](DECISIONS/ADR-0010-standards-alignment-claim.md)) | commissioned 2026-07-25, recommendation pending |
+| Store reconnaissance — Corpán's live category/rating, the account reuse matrix, the Dynawalla name check | in flight; `TODO(store-recon)` markers left in ADR-0001, ADR-0015, ADR-0016 |
+| Is the vendored `ndk-context` `[patch]` actually applying, or already inert? | under investigation — see below |
+| `adversarial-review` fail-open audit | under investigation — see below |
 
 Not started: PR-0a.2 (adversarial-review fixes), PR-0a.3 (fail-closed flip), PR-0a.4
 (`.cargo/config.toml` template), PR-0a.5 (native CI gate + delete `ios-native.yml`),
 PR-0a.6 (SHA-pinning), PR-0a.7 (branch-protection → ruleset migration, a scripted
 settings change rather than a PR).
+
+## Findings under investigation
+
+Two live findings. Neither has a verdict yet; nothing here should be cited as settled.
+
+1. **The `ndk-context` `[patch]` may be inert.** R-06 and
+   [ADR-0011](DECISIONS/ADR-0011-native-workspace-and-patch-placement.md) treat the
+   vendored fork as load-bearing — upstream `ndk-context` aborts the process on Android
+   Activity recreation. An investigation is checking whether the patch actually resolves
+   to the vendored fork in the shipping build today. If it does not, the M3 move is not
+   the only thing at risk: Corpán is already shipping without it, and R-06's severity is
+   understated rather than overstated.
+2. **`adversarial-review` fails open.** It truncates oversized diffs and still reports
+   success, and it only fails when *all* lenses error. An audit is establishing how many
+   merged PRs were reviewed by a truncated diff or a partially-failed lens run. Until
+   PR-0a.2 lands, the diff-size discipline this program depends on is unenforced.
 
 ## Acceptance
 
@@ -54,38 +81,49 @@ settings change rather than a PR).
 
 ## Blockers
 
-1. **No playtest cohort exists.** Recruitment and consent take weeks and gate M2.
-   Nothing in the program can substitute for it (R-02,
-   [ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md)).
-2. **No named art director.** `Q-14` has no mitigation without one (R-32).
-3. **No native CI gate exists at all** — zero `cargo`/`clippy`/`rustup` invocation in
+1. **No native CI gate exists at all** — zero `cargo`/`clippy`/`rustup` invocation in
    any required check. Until PR-0a.5 lands, every native change is unverified by CI, and
    M3 must not start.
-4. **`adversarial-review` currently fails open**: it truncates oversized diffs and still
-   reports success, and it only fails when *all* lenses error. Until PR-0a.2 lands, the
-   diff-size discipline this program depends on is unenforced.
-5. **Two founder console sessions** (~10 minutes) are on M1's critical path and cannot
+2. **`adversarial-review` fails open** (finding 2 above). Until PR-0a.2 lands, an
+   oversized PR is reviewed by a truncated diff and reported green.
+3. **Two founder console sessions** (~10 minutes) are on M1's critical path and cannot
    be automated — Apple `POST /v1/apps` returns 404 for API keys, and Play has no
    application-create method (R-37).
 
-## Open founder decisions
+**No longer a blocker:** the playtest cohort and the named art director. Both were
+resolved by [ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md) — the evaluator
+is the founder's 10-year-old son and the founder is the art director. That removes the
+recruitment lead time from the critical path and replaces it with a stated limitation:
+`n = 1`, observed by the builder, with grades 1–2 and every pre-reader flow unobserved
+(R-46).
 
-Eight, ordered by when they bite; see [DECISIONS.md](DECISIONS.md) for the full list.
+## Founder decisions
+
+Recorded 2026-07-25, from the founder's own words, in each ADR:
+
+| ADR | Decision |
+|---|---|
+| [0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md) | One child evaluator — the founder's 10-year-old son. The founder holds every adult role, including art director. |
+| [0015](DECISIONS/ADR-0015-developer-account-topology.md) | Same Corpora Apple team and Play account as Corpán; shared blast radius and nomination pool accepted. |
+| [0013](DECISIONS/ADR-0013-monetization-model.md) | Direction: generous free tier + subscription for unlimited exercises and full access; offline-first keeps marginal cost near zero. Packaging and pricing still open (R-45). |
+| [0001](DECISIONS/ADR-0001-kids-category-posture.md) | No third-party ads, analytics or SDKs, unconditionally. Parental gate on every link-out. Category election deferred to submission. |
+
+Still open, ordered by when they bite:
 
 | ADR | Decision | Bites at |
 |---|---|---|
-| [0001](DECISIONS/ADR-0001-kids-category-posture.md) | Kids Category posture (one-way door) | M1, first store submission |
-| [0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md) | Playtest cohort + named art director | now (weeks of lead time) |
+| [0016](DECISIONS/ADR-0016-app-store-product-name.md) | Product name (name check in flight) | M1, app-record creation |
 | [0002](DECISIONS/ADR-0002-v1-scope-cut.md) | V1 scope cut: grades 1–5, number and arithmetic | any public scope statement; M4 curriculum breadth |
-| [0015](DECISIONS/ADR-0015-developer-account-topology.md) / [0016](DECISIONS/ADR-0016-app-store-product-name.md) | Account topology, product name | M1, app-record creation |
-| [0014](DECISIONS/ADR-0014-repository-license.md) | Repository license | M0a (fork-PR posture) |
-| [0010](DECISIONS/ADR-0010-standards-alignment-claim.md) | Standards-alignment claim | first public marketing copy |
-| [0013](DECISIONS/ADR-0013-monetization-model.md) | Monetization model | M9 |
+| [0014](DECISIONS/ADR-0014-repository-license.md) | Repository license (research in flight) | M0a (fork-PR posture) |
+| [0010](DECISIONS/ADR-0010-standards-alignment-claim.md) | Standards-alignment claim (research in flight) | first public marketing copy |
+| [0001](DECISIONS/ADR-0001-kids-category-posture.md) | The category election itself | M1, first store submission (`G-01`) |
+| [0013](DECISIONS/ADR-0013-monetization-model.md) | Packaging and pricing | M9 (`G-02`) |
+| — | Whether to add one younger evaluator for the grade 1–2 gap (R-46) | M9 at the latest |
 
 ## Roles
 
 An unassigned role is itself a risk (R-44). Two acceptance items name a person as their
-pass condition.
+pass condition; one of them is now filled.
 
 | Role | Person |
 |---|---|
@@ -96,7 +134,8 @@ pass condition.
 | Engine (learner model) | unassigned |
 | Experience | unassigned |
 | Nightly harness owner (`A-19`) | unassigned |
-| Art director (`Q-14`) | unassigned |
+| Art director (`Q-14`) | Skylar Saveland |
+| Playtest observer | Skylar Saveland |
 | Founder | Skylar Saveland |
 
 ## Incident log

--- a/dynawalla/docs/STATUS.md
+++ b/dynawalla/docs/STATUS.md
@@ -50,7 +50,7 @@ where they will be read before the mistake is made:
 | Founder decisions recorded in ADRs 0001 / 0013 / 0015 / 0017 | this PR |
 | Repository-license research ([ADR-0014](DECISIONS/ADR-0014-repository-license.md)) | commissioned 2026-07-25, recommendation pending |
 | Standards-alignment research ([ADR-0010](DECISIONS/ADR-0010-standards-alignment-claim.md)) | commissioned 2026-07-25, recommendation pending |
-| Store reconnaissance — Corpán's live category/rating, the account reuse matrix, the Dynawalla name check | in flight; `TODO(store-recon)` markers left in ADR-0001, ADR-0015, ADR-0016 |
+| Store reconnaissance — Corpán's live posture, the account reuse matrix, the name check | **returned 2026-07-25**; every `TODO(store-recon)` filled in ADR-0001, ADR-0015, ADR-0016 and [STORE.md](STORE.md) |
 | Is the vendored `ndk-context` `[patch]` actually applying, or already inert? | under investigation — see below |
 | `adversarial-review` fail-open audit | under investigation — see below |
 
@@ -75,6 +75,27 @@ Two live findings. Neither has a verdict yet; nothing here should be cited as se
    merged PRs were reviewed by a truncated diff or a partially-failed lens run. Until
    PR-0a.2 lands, the diff-size discipline this program depends on is unenforced.
 
+## What the store reconnaissance changed
+
+Verified live by GET-only API calls, 2026-07-25. Four things the plan had wrong or blank:
+
+1. **Corpán is EDUCATION / REFERENCE, 4+, `kidsAgeBand: null`,
+   `isOrEverWasMadeForKids: false`** (Team `F9AV5HKF6N`). All four Corpora apps are 4+ and
+   **none has ever been in the Kids Category** — so "match Corpán" means *not* Kids, and a
+   Kids submission would inherit no in-house precedent.
+2. **Apple's Kids age bands stop at 9-11**; Play's go to 9-12. Grades 1–6 spans ages
+   6–12, so Apple cannot express the founder-stated scope. This couples
+   [ADR-0001](DECISIONS/ADR-0001-kids-category-posture.md) to
+   [ADR-0002](DECISIONS/ADR-0002-v1-scope-cut.md) and is an **open founder decision**.
+3. **The ASC API key does not need re-minting** — [STORE.md](STORE.md) said it "almost
+   certainly" did. It is already a Team key with Admin scope. Budget zero.
+4. **The name is clear but not cleared.** No third-party use of "Dynawalla" anywhere; the
+   founder already owns `dynawalla.com`. Two hygiene items (a live **subdomain-takeover
+   vector** on dangling `herokudns.com` records, and a public repo tying the name to
+   supplement health claims) and two collision vectors for counsel (**Dynamo Maths**;
+   **Physics Wallah**'s "family of 'wallah' marks" injunction, if India is a market).
+   Trademark databases bot-blocked the search, so this is mirror evidence, not clearance.
+
 ## Acceptance
 
 **0 of 117** items met — [ACCEPTANCE_CRITERIA.md](ACCEPTANCE_CRITERIA.md).
@@ -87,8 +108,17 @@ Two live findings. Neither has a verdict yet; nothing here should be cited as se
 2. **`adversarial-review` fails open** (finding 2 above). Until PR-0a.2 lands, an
    oversized PR is reviewed by a truncated diff and reported green.
 3. **Two founder console sessions** (~10 minutes) are on M1's critical path and cannot
-   be automated — Apple `POST /v1/apps` returns 404 for API keys, and Play has no
-   application-create method (R-37).
+   be automated — Apple has no app-create operation at all (verified against OpenAPI
+   4.4.1) and Play has no application-create method (R-37).
+4. **Unverified and potentially a two-week calendar hit:** whether the Play developer
+   account is an *organization* account. Personal accounts created after 2023-11-13 carry
+   the **12-testers-for-14-days closed-testing gate**; organization accounts are exempt.
+   A founder console check, worth doing well before M1 (R-38b). Same trip: the numeric
+   Play developer account id, which is recorded nowhere in this repo.
+5. **Three unwritten compliance documents** whose deadlines have already passed or are in
+   force: a COPPA §312.10 retention-and-deletion policy, a §312.8 written security
+   program, and a UK Children's Code DPIA. Cheap while the answer is "we transmit
+   nothing"; nobody is assigned (R-48).
 
 **No longer a blocker:** the playtest cohort and the named art director. Both were
 resolved by [ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md) — the evaluator
@@ -112,7 +142,8 @@ Still open, ordered by when they bite:
 
 | ADR | Decision | Bites at |
 |---|---|---|
-| [0016](DECISIONS/ADR-0016-app-store-product-name.md) | Product name (name check in flight) | M1, app-record creation |
+| [0016](DECISIONS/ADR-0016-app-store-product-name.md) | Product name — checks returned clean; two counsel-grade collision vectors remain | M1, app-record creation |
+| [0001](DECISIONS/ADR-0001-kids-category-posture.md) / [0002](DECISIONS/ADR-0002-v1-scope-cut.md) | **New:** Apple's 9-11 band ceiling vs a grades 1–6 scope — declare 9-11, split SKUs, or skip the category (a trap under 2.3.8 / 5.1.4(b)) | M1, app-record creation |
 | [0002](DECISIONS/ADR-0002-v1-scope-cut.md) | V1 scope cut: grades 1–5, number and arithmetic | any public scope statement; M4 curriculum breadth |
 | [0014](DECISIONS/ADR-0014-repository-license.md) | Repository license (research in flight) | M0a (fork-PR posture) |
 | [0010](DECISIONS/ADR-0010-standards-alignment-claim.md) | Standards-alignment claim (research in flight) | first public marketing copy |

--- a/dynawalla/docs/STATUS.md
+++ b/dynawalla/docs/STATUS.md
@@ -83,18 +83,22 @@ Verified live by GET-only API calls, 2026-07-25. Four things the plan had wrong 
    `isOrEverWasMadeForKids: false`** (Team `F9AV5HKF6N`). All four Corpora apps are 4+ and
    **none has ever been in the Kids Category** — so "match Corpán" means *not* Kids, and a
    Kids submission would inherit no in-house precedent.
-2. **Apple's Kids age bands stop at 9-11**; Play's go to 9-12. Grades 1–6 spans ages
-   6–12, so Apple cannot express the founder-stated scope. This couples
+2. **Apple Kids requires choosing exactly one band** — 5-and-under / 6-8 / 9-11 — and
+   **no V1 scope on the table fits one.** Grades 1–6 ≈ ages 6–12; grades 1–5 ≈ ages 6–11,
+   which still spans two bands, so the ADR-0002 cut does not resolve it. The cuts that
+   *would* fit one band (roughly grades 4–5, or grades 1–3) are far more expensive than
+   anything currently proposed. Couples
    [ADR-0001](DECISIONS/ADR-0001-kids-category-posture.md) to
-   [ADR-0002](DECISIONS/ADR-0002-v1-scope-cut.md) and is an **open founder decision**.
+   [ADR-0002](DECISIONS/ADR-0002-v1-scope-cut.md); **open founder decision**.
 3. **The ASC API key does not need re-minting** — [STORE.md](STORE.md) said it "almost
    certainly" did. It is already a Team key with Admin scope. Budget zero.
-4. **The name is clear but not cleared.** No third-party use of "Dynawalla" anywhere; the
-   founder already owns `dynawalla.com`. Two hygiene items (a live **subdomain-takeover
-   vector** on dangling `herokudns.com` records, and a public repo tying the name to
-   supplement health claims) and two collision vectors for counsel (**Dynamo Maths**;
-   **Physics Wallah**'s "family of 'wallah' marks" injunction, if India is a market).
-   Trademark databases bot-blocked the search, so this is mirror evidence, not clearance.
+4. **The name is clear but not cleared.** No third-party use of "Dynawalla" found
+   anywhere; the founder already owns the matching domain. Two hygiene items — **dangling
+   DNS records on a domain we own** (specifics held out of band, not committed to a public
+   repo until remediated) and a public repo tying the name to dietary-supplement health
+   claims — and two collision vectors for counsel (**Dynamo Maths**; **Physics Wallah**'s
+   "family of 'wallah' marks" injunction, if India is a market). Trademark databases
+   bot-blocked the search, so this is mirror evidence, not clearance.
 
 ## Acceptance
 
@@ -143,7 +147,7 @@ Still open, ordered by when they bite:
 | ADR | Decision | Bites at |
 |---|---|---|
 | [0016](DECISIONS/ADR-0016-app-store-product-name.md) | Product name — checks returned clean; two counsel-grade collision vectors remain | M1, app-record creation |
-| [0001](DECISIONS/ADR-0001-kids-category-posture.md) / [0002](DECISIONS/ADR-0002-v1-scope-cut.md) | **New:** Apple's 9-11 band ceiling vs a grades 1–6 scope — declare 9-11, split SKUs, or skip the category (a trap under 2.3.8 / 5.1.4(b)) | M1, app-record creation |
+| [0001](DECISIONS/ADR-0001-kids-category-posture.md) / [0002](DECISIONS/ADR-0002-v1-scope-cut.md) | **New:** Apple Kids requires **exactly one** of 5-and-under / 6-8 / 9-11, and **no V1 scope on the table fits one band** — declare one and misdeclare the range, ship two SKUs, cut V1 to a single band, or skip the category (a trap under 2.3.8 / 5.1.4(b)) | M1, app-record creation |
 | [0002](DECISIONS/ADR-0002-v1-scope-cut.md) | V1 scope cut: grades 1–5, number and arithmetic | any public scope statement; M4 curriculum breadth |
 | [0014](DECISIONS/ADR-0014-repository-license.md) | Repository license (research in flight) | M0a (fork-PR posture) |
 | [0010](DECISIONS/ADR-0010-standards-alignment-claim.md) | Standards-alignment claim (research in flight) | first public marketing copy |

--- a/dynawalla/docs/STORE.md
+++ b/dynawalla/docs/STORE.md
@@ -89,17 +89,19 @@ package-name variable):
 
 **Not automatable — budget founder console time:**
 
-1. **Creating the App Store Connect app record.** `POST /v1/apps` returns **404 because
-   the operation does not exist**, not because the path is wrong — a bad *path* 404s, but
-   a disallowed *method on a real resource* 403s, so the 404 is the tell. Verified against
-   Apple's OpenAPI spec 4.4.1: 966 paths, **no `apps_createInstance` operation**. Apple's
-   own documentation says it outright: *"Don't use this API to create new apps; instead,
-   create new apps on the App Store Connect website."* Stop looking for the endpoint.
-   **Do not mistake `appstoreappsreview.createappstorehostedapp` for it.** It reads
-   exactly like the endpoint you want and it is the **DMA alternative-app-store**
-   pipeline for third-party marketplaces. It is not this.
-2. **Creating the Play app record.** The `androidpublisher` v3 discovery document has no
-   application-create method.
+1. **Creating the App Store Connect app record.** There is no app-create operation in the
+   API. Verified against Apple's OpenAPI spec 4.4.1: 966 paths, **no `apps_createInstance`
+   operation**; `POST /v1/apps` 404s. Apple's own documentation says it outright:
+   *"Don't use this API to create new apps; instead, create new apps on the App Store
+   Connect website."* Stop looking for the endpoint.
+2. **Creating the Play app record.** `androidpublisher` v3 has **no method to create your
+   own app record.**
+   **Trap — and note this is a *Google* method, not an Apple one:** the same API does
+   contain `appstoreappsreview.createappstorehostedapp`
+   (`POST .../androidpublisher/v3/appstore/{appStorePackageName}/apps:create`). It reads
+   exactly like the endpoint you want. It is the pipeline for **third-party Android app
+   stores** to register apps they host, not for publishing your own app to Google Play.
+   Do not call it.
 3. **The first Play release publish.** On a never-published app the API can only create
    **draft** releases. This is Google's anti-abuse gate, not a code bug, and should not be
    debugged as one — budget one Console-side publish (`G-10`).
@@ -144,11 +146,14 @@ The default if nothing changes is to match Corpán, which was verified live 2026
 **none has ever been in the Kids Category**, so a Kids submission would be the first and
 inherits no in-house precedent.
 
-**The age bands do not span the product's scope.** Apple's Kids bands are 5-and-under /
-6-8 / **9-11**, choose exactly one; Play's are multi-select and include **9-12**. Grades
-1–6 plus pre-algebra is roughly ages 6–12, so Play can express it and **Apple cannot**.
-That couples the category decision to [ADR-0002](DECISIONS/ADR-0002-v1-scope-cut.md) and
-is an open founder decision.
+**No Apple Kids band expresses this product at any V1 scope.** Apple requires choosing
+**exactly one** of 5-and-under / 6-8 / 9-11 — a choice among three, not a maximum age.
+Play's declaration is multi-select and expresses a range directly. Grades 1–6 ≈ ages 6–12
+and **grades 1–5 ≈ ages 6–11, which still spans two Apple bands**, so the ADR-0002 scope
+cut does not resolve this. Electing Kids forces one of: declare a band that misstates the
+range, ship two SKUs, cut V1 down to a single band, or skip the category (a trap under
+2.3.8 / 5.1.4(b)). Open founder decision — see
+[ADR-0001](DECISIONS/ADR-0001-kids-category-posture.md).
 
 The strict engineering posture is **Accepted unconditionally** as of 2026-07-25,
 independent of the election, so nothing below waits on it:
@@ -171,7 +176,8 @@ independent of the election, so nothing below waits on it:
 - **A parental gate stands in front of every link-out and every purchase flow** (`G-08`).
   The primitive ships in M1's shell, not at M10, so no surface is ever built without one.
   **The challenge is never arithmetic** — Apple's canonical gate is a maths problem, which
-  is exactly why this app cannot use one; a grade-4 child beats their parent to `6 × 7`.
+  is exactly why it is useless *here*: a grade-4 child beats their parent to `6 × 7`.
+  (Apple permits arithmetic gates; this is our judgement, not a store rule.)
   Reading load is the real barrier. Randomized, non-persistent across sessions, one
   component used on both platforms (Play mandates no general gate). Full design
   constraints in [ADR-0005](DECISIONS/ADR-0005-shell-and-routing.md); guarded surfaces in
@@ -214,7 +220,7 @@ are recorded as planned work rather than smuggled in. Priority order:
    margin — it catches a chatty transitive dependency that no manifest inspection would.
 2. **Merged-manifest assertions on Android**: the *merged* `AndroidManifest.xml` contains
    no `AD_ID` permission, no `ACCESS_*_LOCATION`, no `READ_PHONE_STATE`, and
-   `targetSdk >= 33`. Merged, not the source manifest — a dependency contributes
+   `targetSdk >= 36`. Merged, not the source manifest — a dependency contributes
    permissions the app never wrote.
 3. **iOS binary and plist assertions**: no reference to `ASIdentifierManager` or
    `ATTrackingManager`, and **no `NSUserTrackingUsageDescription` in `Info.plist`**. A
@@ -225,9 +231,11 @@ are recorded as planned work rather than smuggled in. Priority order:
 
 ### Do not plan on adding ads later
 
-**Play's Families Self-Certified Ads SDK program is closed to new applicants.** "Ship
+**Play's Families Self-Certified Ads SDK program is currently not accepting new
+applicants**; Google says the application window will reopen, on no stated date. "Ship
 clean now, monetize with ads if the subscription underperforms" is **not an available
-fallback** — the door is shut before we reach it. Price that into R-45.
+fallback** — it depends on a window that is shut today and may or may not be open when
+we want it. Price that uncertainty into R-45.
 
 ## Release trigger
 

--- a/dynawalla/docs/STORE.md
+++ b/dynawalla/docs/STORE.md
@@ -85,12 +85,18 @@ Items 1–3 are roughly ten minutes of founder time and they sit on M1's critica
 
 ## Compliance posture
 
-The decision itself is [ADR-0001](DECISIONS/ADR-0001-kids-category-posture.md) and is
-**a one-way door**: Apple Guideline 1.3 states the requirements continue to bind "in
-subsequent updates, even if you decide to deselect the category." It must be recorded
-before M1's first submission (`G-01`).
+The decision itself is [ADR-0001](DECISIONS/ADR-0001-kids-category-posture.md). The
+**category election** is **a one-way door** — Apple Guideline 1.3 states the requirements
+continue to bind "in subsequent updates, even if you decide to deselect the category" —
+and it is deliberately **deferred to submission**, after monetization is wired, because
+Play's Families Policy and the Kids Category both constrain how a purchase may be
+surfaced to a child. It must be written into the ADR before M1's first submission
+(`G-01`); submitting without it is electing by accident. The default if nothing changes
+is to match Corpán's current category and rating (`TODO(store-recon)` — the specific
+values are not asserted here).
 
-The engineering plan already assumes the strict posture regardless:
+The strict engineering posture is **Accepted unconditionally** as of 2026-07-25,
+independent of the election, so nothing below waits on it:
 
 - **No third-party analytics SDK, no advertising SDK, in either bundle.** Enforced by a
   CI dependency audit that is cross-checked against the submitted Play Data safety
@@ -100,10 +106,14 @@ The engineering plan already assumes the strict posture regardless:
   collected** (`G-06`). Play's Families Policy forbids all of them for child users.
 - **All instrumentation is on-device.** There is no server profile, no account, and no
   telemetry endpoint. The practical consequence is that the product's feel **cannot be
-  A/B tested remotely**, which is why in-person playtesting is the binding instrument
+  A/B tested remotely**, which is why direct observation is the binding instrument
   rather than a supplement ([PLAYTEST-PROTOCOL.md](PLAYTEST-PROTOCOL.md)).
 - **A parental gate stands in front of every link-out and every purchase flow** (`G-08`).
   The primitive ships in M1's shell, not at M10, so no surface is ever built without one.
+  For a mathematics app an arithmetic challenge **is** the canonical Apple-acceptable
+  gate, so this costs almost nothing here; the one catch is that its arithmetic must sit
+  **above** the V1 curriculum band, or the children being taught grades 1–5 will solve
+  the thing that exists to exclude them.
 - **No nudge techniques.** The UK Children's Code Standard 13 restricts them and
   Standard 5 cautions against using children's data to keep them on a platform. The
   forbidden mechanics list in [MISSION.md](MISSION.md) is stricter than either.

--- a/dynawalla/docs/STORE.md
+++ b/dynawalla/docs/STORE.md
@@ -21,26 +21,44 @@ in both stores. Any tooling deriving paths, keychain entries, `os_log` subsystem
 store lookups from a bundle-id prefix must take it as a **parameter** — a `corpan`
 literal already appears in 7+ Rust/Swift/Kotlin sites (RISKS R-40).
 
-**Play's package name is locked by the first uploaded AAB** and cannot be changed without
-Google support. Verify the generated Gradle `applicationId` **before** the first upload;
-`X-03` exists for this reason alone.
+> ## ⚠ The single most expensive mistake available in this document
+>
+> **The Play package name is locked FOREVER by the first uploaded AAB.** Not until the
+> first release — by the first *upload*. It cannot be changed afterwards without Google
+> support, and in practice it cannot be changed at all.
+>
+> **Read the generated Gradle `applicationId` with your own eyes and confirm it is
+> exactly `inc.corpora.dynawalla` before that file is uploaded.** A Tauri-template
+> default or a `com.corpora.dynawalla` typo ends the naming convention for that app
+> record permanently. `X-03` exists for this reason alone (RISKS R-36).
 
 **Android target API 36 is mandatory for new apps from 2026-08-31.** Dynawalla ships at
 36 from PR-1.2, so this is don't-regress rather than migrate.
 
 ## Credentials
 
-Account topology is [ADR-0015](DECISIONS/ADR-0015-developer-account-topology.md) and is
-the founder's decision. Under the assumed same-account option:
+Account topology is [ADR-0015](DECISIONS/ADR-0015-developer-account-topology.md):
+**same Corpora accounts as Corpán**, decided 2026-07-25. The matrix below was verified
+live by GET-only API calls on that date.
 
 | Credential | Reused or new |
 |---|---|
-| Apple Distribution certificate | **Reused** (team-wide) |
+| Apple Distribution certificate | **Reused** — `Apple Distribution: Corpora Inc`, expires 2027-04-16, team-wide. |
+| Apple Team ID | **Reused** — `F9AV5HKF6N`. |
 | iOS provisioning profile | **New.** Profiles bind to one explicit bundle id; no wildcard spans both `com.corpora.*` and `inc.corpora.*`, and **wildcards cannot carry IAP**. |
 | Android upload keystore | **New**, deliberately separate, so one compromised key does not risk two shipping apps. |
-| Play service account | **Reused** — but it does **not** inherit access. It needs an **explicit per-app permission grant** in Play Console on the new app record (`G-09`). |
-| ASC API key | Reused; almost certainly needs re-minting at Admin role for app-record operations. |
-| AWS secret | **New** path `dynawalla/store/credentials`, rather than widening the existing Corpán secret that a live purchase-verify lambda reads. |
+| Play App Signing | **New enrolment.** |
+| Play service account | **Identity reused; access is not.** It needs an **explicit per-app permission grant** on the new app record (`G-09`). **Proven:** the SA returns **403** on `com.corpora.homeschool` and `com.pako.app` — two sibling apps on the same account are already invisible to it. |
+| ASC API key | **Reused as-is.** It does **not** need re-minting — see below. |
+| ASC / Play tooling | **Reused** — `corpan/infra/asc/asc_monetization.py` and `corpan/infra/play/play_monetization.py` are already parameterized by bundle id / package name. |
+| AWS secret | **New** path `dynawalla/store/credentials`. Do **not** widen `corpan/content-packs/verify` — a live purchase-verify lambda reads it. |
+
+**Correction (2026-07-25): the ASC API key does not need re-minting at Admin role.** This
+document previously said it "almost certainly" did. It does not: the existing key returns
+200 on `/v1/bundleIds`, `/v1/certificates`, `/v1/profiles`, `/v1/devices` **and** on the
+Admin-scoped `/v1/users`. It is already a Team key with Admin scope. Apple's actual rule
+is that *Individual* keys cannot use the Provisioning endpoints; Team keys can. Budget
+zero time for this.
 
 GitHub environments: `dynawalla-ios`, `dynawalla-android` (alongside `corpan-ios`,
 `corpan-android`). Note that `secrets: inherit` passes repository and organisation secrets
@@ -71,8 +89,15 @@ package-name variable):
 
 **Not automatable — budget founder console time:**
 
-1. **Creating the App Store Connect app record.** `POST /v1/apps` returns 404 and an ASC
-   API key gets 403 on create.
+1. **Creating the App Store Connect app record.** `POST /v1/apps` returns **404 because
+   the operation does not exist**, not because the path is wrong — a bad *path* 404s, but
+   a disallowed *method on a real resource* 403s, so the 404 is the tell. Verified against
+   Apple's OpenAPI spec 4.4.1: 966 paths, **no `apps_createInstance` operation**. Apple's
+   own documentation says it outright: *"Don't use this API to create new apps; instead,
+   create new apps on the App Store Connect website."* Stop looking for the endpoint.
+   **Do not mistake `appstoreappsreview.createappstorehostedapp` for it.** It reads
+   exactly like the endpoint you want and it is the **DMA alternative-app-store**
+   pipeline for third-party marketplaces. It is not this.
 2. **Creating the Play app record.** The `androidpublisher` v3 discovery document has no
    application-create method.
 3. **The first Play release publish.** On a never-published app the API can only create
@@ -83,6 +108,24 @@ package-name variable):
 Items 1–3 are roughly ten minutes of founder time and they sit on M1's critical path
 (RISKS R-37).
 
+**Possibly automatable, worth ten minutes of investigation:** `G-09`, granting the
+service account per-app access, may be reachable via `androidpublisher`
+**`grants.create`** — which needs the **numeric Play developer account id**, and that id
+is **not recorded anywhere in this repo**. Treat this as a possible automation win, not a
+certainty, and plan the founder console step as though it is manual until it is proven
+otherwise.
+
+**Operational findings, 2026-07-25:**
+
+- The **Play Developer Reporting API is disabled** on GCP project `corpora1`, so the
+  account's apps cannot be enumerated by API — they can only be probed by known package
+  name. Any tooling that wants a list must be given one.
+- **Play's closed-testing gate (12 testers for 14 continuous days) applies to *personal*
+  developer accounts created after 2023-11-13; organization accounts are exempt.** The
+  Corpora account's type is **unverified**. This is a founder console check and it is
+  worth doing early: if it bites, it is a **two-week calendar hit on M1** that no amount
+  of engineering recovers.
+
 ## Compliance posture
 
 The decision itself is [ADR-0001](DECISIONS/ADR-0001-kids-category-posture.md). The
@@ -91,9 +134,21 @@ continue to bind "in subsequent updates, even if you decide to deselect the cate
 and it is deliberately **deferred to submission**, after monetization is wired, because
 Play's Families Policy and the Kids Category both constrain how a purchase may be
 surfaced to a child. It must be written into the ADR before M1's first submission
-(`G-01`); submitting without it is electing by accident. The default if nothing changes
-is to match Corpán's current category and rating (`TODO(store-recon)` — the specific
-values are not asserted here).
+(`G-01`); submitting without it is electing by accident. Note that the door is a
+**readable API field**: `isOrEverWasMadeForKids` on `/v1/apps/{id}` is the permanent,
+queryable record of the election.
+
+The default if nothing changes is to match Corpán, which was verified live 2026-07-25:
+**EDUCATION / REFERENCE, 4+, all declarations `NONE`, `kidsAgeBand: null`,
+`isOrEverWasMadeForKids: false`.** All four Corpora apps are 4+ Education-or-Lifestyle and
+**none has ever been in the Kids Category**, so a Kids submission would be the first and
+inherits no in-house precedent.
+
+**The age bands do not span the product's scope.** Apple's Kids bands are 5-and-under /
+6-8 / **9-11**, choose exactly one; Play's are multi-select and include **9-12**. Grades
+1–6 plus pre-algebra is roughly ages 6–12, so Play can express it and **Apple cannot**.
+That couples the category decision to [ADR-0002](DECISIONS/ADR-0002-v1-scope-cut.md) and
+is an open founder decision.
 
 The strict engineering posture is **Accepted unconditionally** as of 2026-07-25,
 independent of the election, so nothing below waits on it:
@@ -101,27 +156,78 @@ independent of the election, so nothing below waits on it:
 - **No third-party analytics SDK, no advertising SDK, in either bundle.** Enforced by a
   CI dependency audit that is cross-checked against the submitted Play Data safety
   declaration (`G-05`). This is the only mechanical enforcement — every dependency
-  addition is a compliance decision.
-- **No AAID, IMEI, MAC address or phone number transmitted; no precise location
-  collected** (`G-06`). Play's Families Policy forbids all of them for child users.
+  addition is a compliance decision. The **forbidden categories** are wider than most
+  teams assume and are listed in [RISKS.md](RISKS.md) R-47; the one that surprises people
+  is **third-party crash reporters** (Crashlytics, Sentry, Bugsnag), because 1.3 names
+  *device information* explicitly.
+- **Play's hard identifier list for child-directed apps**, none of which may ever be
+  transmitted: **AAID, SIM Serial, Build Serial, BSSID, MAC, SSID, IMEI, IMSI**. Never
+  request the phone number via `TelephonyManager`. **No location permissions at all** —
+  not coarse, not "only while using" (`G-06`).
 - **All instrumentation is on-device.** There is no server profile, no account, and no
   telemetry endpoint. The practical consequence is that the product's feel **cannot be
   A/B tested remotely**, which is why direct observation is the binding instrument
   rather than a supplement ([PLAYTEST-PROTOCOL.md](PLAYTEST-PROTOCOL.md)).
 - **A parental gate stands in front of every link-out and every purchase flow** (`G-08`).
   The primitive ships in M1's shell, not at M10, so no surface is ever built without one.
-  For a mathematics app an arithmetic challenge **is** the canonical Apple-acceptable
-  gate, so this costs almost nothing here; the one catch is that its arithmetic must sit
-  **above** the V1 curriculum band, or the children being taught grades 1–5 will solve
-  the thing that exists to exclude them.
+  **The challenge is never arithmetic** — Apple's canonical gate is a maths problem, which
+  is exactly why this app cannot use one; a grade-4 child beats their parent to `6 × 7`.
+  Reading load is the real barrier. Randomized, non-persistent across sessions, one
+  component used on both platforms (Play mandates no general gate). Full design
+  constraints in [ADR-0005](DECISIONS/ADR-0005-shell-and-routing.md); guarded surfaces in
+  [ADR-0001](DECISIONS/ADR-0001-kids-category-posture.md).
 - **No nudge techniques.** The UK Children's Code Standard 13 restricts them and
   Standard 5 cautions against using children's data to keep them on a platform. The
   forbidden mechanics list in [MISSION.md](MISSION.md) is stricter than either.
-- The privacy policy ships in-app and in both listings.
+- **The privacy policy ships in-app and in both listings** — required by both stores
+  regardless of what is collected, and it must describe **retention and deletion**. Render
+  the in-app copy as a **screen, not an external URL**: an external URL needs a parental
+  gate in front of it, an in-app screen does not.
 
 Apple age rating and Play target-audience/content-rating declarations must be **complete
 and consistent with actual behaviour and with the CI audit** (`G-07`) — an inconsistency
 between the declaration and the bundle is a review rejection at best.
+
+### The disclosure posture this buys
+
+Both stores define "collect" as **transmitting off-device**. Local-first therefore yields
+**Apple "Data Not Collected"** and **Play "no data collected, no data shared"** — the
+strongest declarations either store offers, and they are earned by the architecture rather
+than argued for.
+
+**Exactly two things break it**, and both are choices this program has already made
+against:
+
+1. **A third-party crash SDK** → a Diagnostics disclosure.
+2. **A receipt-validation backend** → a Purchases disclosure. This is the live one:
+   [ADR-0013](DECISIONS/ADR-0013-monetization-model.md) wires a subscription, so
+   **keep entitlements local** or the declaration changes.
+
+### Planned mechanical gates
+
+Recommended, **not implemented here** — `.github/**` belongs to another agent, and these
+are recorded as planned work rather than smuggled in. Priority order:
+
+1. **A network-egress test.** Run the app under a proxy and assert **zero** outbound
+   requests on a cold launch and through a complete lesson. This converts "we collect
+   nothing" from a claim into a test, and it is the highest-value guard here by a wide
+   margin — it catches a chatty transitive dependency that no manifest inspection would.
+2. **Merged-manifest assertions on Android**: the *merged* `AndroidManifest.xml` contains
+   no `AD_ID` permission, no `ACCESS_*_LOCATION`, no `READ_PHONE_STATE`, and
+   `targetSdk >= 33`. Merged, not the source manifest — a dependency contributes
+   permissions the app never wrote.
+3. **iOS binary and plist assertions**: no reference to `ASIdentifierManager` or
+   `ATTrackingManager`, and **no `NSUserTrackingUsageDescription` in `Info.plist`**. A
+   Kids app must never show the ATT prompt.
+4. **Fail the build on any newly-appearing third-party `PrivacyInfo.xcprivacy`** — a new
+   one appearing is a new SDK arriving, which is a compliance decision that must not pass
+   silently.
+
+### Do not plan on adding ads later
+
+**Play's Families Self-Certified Ads SDK program is closed to new applicants.** "Ship
+clean now, monetize with ads if the subscription underperforms" is **not an available
+fallback** — the door is shut before we reach it. Price that into R-45.
 
 ## Release trigger
 

--- a/dynawalla/docs/TEST_STRATEGY.md
+++ b/dynawalla/docs/TEST_STRATEGY.md
@@ -101,11 +101,15 @@ Stated explicitly, because the failure mode of a heavily-gated program is believ
 gates cover everything.
 
 1. **Whether it is any good.** No automated check distinguishes a compelling loop from a
-   competently-built drill. Only the playtest cohort can, and compliance forbids the
-   remote alternative.
+   competently-built drill. Only a real child can, compliance forbids the remote
+   alternative, and the program has exactly one child evaluator
+   ([ADR-0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md)). So this is not merely
+   untested by the harness — it is observed at `n = 1`, which detects a loop that fails
+   and cannot establish that one succeeds.
 2. **Whether it looks right.** Code review cannot see that the observatory renders as a
-   gradient dashboard with gear icons. The screenshot gate plus a named art director is
-   the entire instrument.
+   gradient dashboard with gear icons. The screenshot gate plus the art director's
+   sign-off is the entire instrument, and the art director is the founder — so the
+   three-strangers verbatims are the only outside eyes on it.
 3. **Whether a wrong answer was diagnosed usefully.** Bug recall on a synthetic persona
    measures whether the matcher fires; it says nothing about whether the child understood
    the contrast pair. `T-05` is the measurement.


### PR DESCRIPTION
Records the founder's answers in the Dynawalla ADRs, and fixes one gate that could not be satisfied as written.

## 1. ADR-0017 — human evaluation resourcing (the important one)

The committed protocol demanded **6+ recruited children aged 7–11 with documented COPPA / UK Children's Code parental consent**, plus a **separately named art director** whose sign-off gated M6. Nobody had committed to supplying any of it and the lead time was quoted in weeks. That was the plan over-specifying.

The founder corrected it:

> "I am the art director and any other adult needed and my 10 year old son will play any 6+ children needed."

Recorded as **Accepted, 2026-07-25**:

- **One child evaluator** — the founder's son, age 10. No external cohort, no recruitment, no consent paperwork (he is the parent).
- **The founder holds every adult role** — art director, design authority, observer, product owner, QA. `Q-14`'s "named art director" is filled.
- **WHAT is measured is unchanged.** Time to voluntary quit, unprompted verbatims, next-day voluntary return, where he gets stuck, what he skips. Only WHO changed.

### The honesty section, which is the point

Both halves are stated in the ADR and in `PLAYTEST-PROTOCOL.md`, neither dressed up nor dismissed:

- **It can** tell us whether the loop holds a real child's attention without an adult driving it, whether the LOCATE contrast pair is legible, where the interface breaks, and whether he comes back the next day — measured in a household, longitudinally, with no attrition risk.
- **It cannot** support any generalizable engagement claim, any efficacy claim, or accessibility coverage for needs nobody in the family has. `n = 1`, observed by the parent who built the product.
- **Bias containment is concrete rather than performative** (`PLAYTEST-PROTOCOL.md` §3a): fixed framing sentence, observer sits where his face cannot be read, and **praise may not be cited as the pass condition for any gate** — only behaviour can, because behaviour is harder to hand over to please someone. Every count is reported as a raw count with `n = 1` attached, never as a percentage.
- Gates are written to **fire on a negative and never to certify a positive**.

### The age asymmetry — new R-46

- **Covered, and it is good news:** V1's slice is subtraction with regrouping across zero, squarely in a 10-year-old's range. The highest-uncertainty content in V1 is directly observable by the one evaluator we have.
- **Not covered:** grades 1–2 and **every flow that assumes a child who cannot yet read the UI** — read-aloud as primary input, icon-only affordances, small-hand touch targets. Read-aloud is argued forward from M9 to M2 on behalf of a child nobody will watch use it.
- Options stated, not silently accepted: (a) accept and lean on heuristics + engine placement, (b) narrow the advertised grade band, (c) one additional younger evaluator for one session. **Recommended: (c), with (a) interim and (b) as a triggered fallback at M9.** Explicitly marked as the founder's call, not made.

### Dependent items updated

`T-01`..`T-06` are now per-child observations; `Q-11` becomes an **adult-proxy device check** that verifies the capability and explicitly does not evidence the child claim; `Q-14` names the founder as art director and keeps the three-strangers verbatims as the only outside eyes; `A-02`/R-26 downgrade the real-child residual fixture from "the only non-circular evidence that `b()` is real" to a gross-mismatch check, moving that weight onto the misspecified personas; M2/M6/M9 milestone text, `TEST_STRATEGY.md`, `ADAPTIVE_LEARNING.md`, `EXPERIENCE_DESIGN.md`, R-02, R-32 and R-44 follow.

## 2. ADR-0001 — Kids Category posture

**Accepted** for the engineering constraints and the deferral mechanism; **the category election itself is `Deferred to submission`.**

- **Locked unconditionally:** no third-party advertising, analytics or Kids-Category-forbidden SDKs. The founder's stated preference independent of category, so engineering stops waiting on it.
- **The open variable is external links.** Corpán links out to GitHub and the website with no gate.
- **Decision (CTO, reversible by construction):** build a parental-gate primitive in M1's shell and route every link-out and purchase through it. With it in place and no third-party SDKs, Kids Category stays electable at submission with zero rework, and so does Education/4+.
  > ⚠️ **~~For a maths app an arithmetic challenge IS the canonical parental gate, so it costs us almost nothing.~~ SUPERSEDED — see §2 and §9.** Backwards: Apple's canonical gate *is* a maths problem, which is exactly why a maths app cannot use one usefully. Struck at first mention rather than quietly corrected further down, because the body is what people read.
- **Election deferred until monetization is wired**, because Play's Families policy and the Kids Category both constrain how purchases are surfaced to children.
- **Default: match Corpán's current posture** — now filled with verified data (below).
- **The gate is never arithmetic — corrected in the second commit.** Apple's canonical illustrated gate *is* a maths problem, which is exactly why this app cannot use one **usefully** — note Apple *permits* arithmetic gates; ineffectiveness here is our engineering judgement, not a store rule: a grade-4 child beats their parent to `6 × 7`, and the app spends every session training the skill the gate filters on. **Reading load, not arithmetic, is the real barrier for a six-year-old.** Viable: four-digit year, spelled-out multi-syllable word, press-and-hold-and-drag. Randomized (a fixed challenge is memorised in a week), non-persistent across sessions, voiceover-paired if a 5-and-under band is elected. One component, both platforms — Play mandates no general gate. Guarded surfaces enumerated including permission prompts (reviewer-discretion territory, cheap to just do), and **rendering the privacy policy as an in-app screen rather than an external URL removes one gate entirely**. Design constraints live in `ADR-0005`, which owns the primitive.

## 3. ADR-0015 — developer-account topology

**Accepted:** same Corpora Apple team and Google Play account as Corpán. Shared policy-violation blast radius (Corpán has paying subscribers), competing for the same Featured / Teacher-Approved nominations, and shared DSA trader status are recorded as **accepted costs**, not open questions.

**Reuse matrix, verified live.** REUSE: Apple Distribution cert (`Apple Distribution: Corpora Inc`, exp. 2027-04-16, team-wide), ASC API key, Team ID `F9AV5HKF6N`, the Play SA *identity*, and the already-parameterized `asc_monetization.py` / `play_monetization.py`. NEW AND MANDATORY: iOS provisioning profile (no wildcard spans `com.corpora.*` and `inc.corpora.*`, **and wildcards cannot carry IAP**), Android upload keystore, Play App Signing enrolment, a new AWS secret path (do **not** widen `corpan/content-packs/verify` — a live purchase-verify lambda reads it), and an explicit per-app Play grant. **Proven, not assumed:** the SA already returns **403** on `com.corpora.homeschool` and `com.pako.app`.

## 4. ADR-0013 — monetization

**Accepted (direction)**, implementation deferred. Generous free tier; subscription unlocks unlimited exercises and full access; offline-first keeps marginal cost near zero so the free tier can be genuinely generous rather than a nag. Adopts Corpán's never-block-an-offline-subscriber policy, citing the real implementation (`corpan/corpan-app/src/store/entitlements.ts`, and `SUBSCRIPTION_GRACE_MS = 48h` in `corpan/corpan-app/src/contentPacks/purchase.ts`).

Two things not papered over:

- **R-45 (new):** the founder's own "that hasn't worked in the slightest" about Corpán's model. Copying the model copies the result. Pricing and packaging need their own evidence pass; "generous free tier + subscription" is a direction, not a validated design.
- **The tension nobody should discover at M9:** "unlimited exercises" implies the free tier has an exercise cap, and a cap that ends a willing child's session mid-flow is close enough to the play-by-appointment mechanic `MISSION.md` already forbids. Ruled out now; the resolution space (cap breadth, not session length) is deferred with the rest of packaging.

## 5–6. Left undecided on purpose

- **ADR-0016** stays `Proposed`. The checks came back and the founder's expectation holds: `inc.corpora.dynawalla` is free on both stores (**account-scoped queries only** — neither store exposes a global check, and product-name availability cannot be tested read-only at all), and **no third party anywhere uses "Dynawalla"** — 0 apps, no companies, npm/PyPI 404, all major TLDs free, no `DYNAWALLA` mark (`DYNAWALL` 7020156 is Class 6 construction materials). **The founder already owns `dynawalla.com`.** Two hygiene items: its A/MX/TXT records point at `dynawalla.com.herokudns.com`, which **no longer resolves — a live subdomain-takeover vector**; and a public repo tying the name to supplement health claims should be scrubbed before the name carries a children's product. Two collision vectors for counsel: **Dynamo Maths** (live UK children's maths intervention, ages 6–11, shared `Dyna-` prefix, same subject — the one an attorney circles) and **Physics Wallah**'s ex-parte Delhi injunction over a *"family of trademarks using the suffix 'wallah'"*, relevant only if India is a launch market. USPTO/Justia/TMview/WIPO all bot-blocked, so this is **strong negative evidence from a mirror, not a first-party clearance search**.
- **ADR-0014** (license) and **ADR-0010** (standards claim) stay `Proposed — awaiting founder`, each noting research was commissioned 2026-07-25 with a recommendation pending. **Not decided here.**

## 8. Second commit — correction, the age-band ceiling, and the store recon

### The parental-gate reasoning was inverted (my error, faithfully recorded, now fixed)

Covered in §2 above. The old passage is quoted inside ADR-0001 as the superseded claim rather than deleted, so it is not re-derived in six months.

### NEW: Apple's age bands do not span the product's scope

Not previously in either ADR, and it **couples ADR-0001 to ADR-0002**. Recorded in both, cross-referenced.

| Store | Bands | Selection |
|---|---|---|
| Apple Kids Category | 5-and-under · 6-8 · **9-11** | **Exactly one** |
| Play target audience | 5-and-under · 6-8 · **9-12** · 13-15 · 16-17 · 18+ | Multi-select |

Grades 1–6 + intro pre-algebra is roughly **ages 6–12**. **Apple has no band above 9-11.** ADR-0002's proposed cut to grades 1–5 lands *exactly* inside the ceiling; grade 6 + pre-algebra pushes past it — so the scope decision and the category decision are one decision seen from two sides. Options: (a) declare 9-11 and accept top-end skew, (b) two SKUs, (c) skip the Kids Category — **(c) is a trap**, since 2.3.8 reserves "For Kids"/"For Children" metadata *to* the category and 5.1.4(b) forbids child-implying metadata *outside* it, which is close to unworkable for a grade-school maths app. **Open founder decision, not made.**

### Store recon: every `TODO(store-recon)` filled with verified data

**Corpán's actual posture** — bundle/SKU `com.corpora.corpan`, **EDUCATION / REFERENCE**, **4+** (all declarations `NONE`), `kidsAgeBand: null`, **`isOrEverWasMadeForKids: false`**, Team **`F9AV5HKF6N`**. All four Corpora apps are 4+ Education-or-Lifestyle and **none has ever been in the Kids Category** — so "match Corpán" means *not* Kids, and a Kids submission would be the first with **no in-house precedent to inherit**.

**The one-way door is a readable API field.** `isOrEverWasMadeForKids` on `/v1/apps/{id}` is the API-visible, permanent expression of Apple's "even if you deselect the category" rule. That is now the concrete irreversibility in ADR-0001, replacing a paragraph of warning with a queryable fact.

### Three corrections to `STORE.md`

1. **The ASC API key does not need re-minting.** The doc said it "almost certainly" did. It returns 200 on `/v1/bundleIds`, `/v1/certificates`, `/v1/profiles`, `/v1/devices` **and** Admin-scoped `/v1/users` — already a Team key with Admin scope. Apple's actual rule: *Individual* keys can't use Provisioning endpoints, Team keys can. Budget zero.
2. **`POST /v1/apps` 404s because the operation does not exist**, not because the path is wrong — a bad path 404s, a disallowed method on a real resource 403s. Verified against OpenAPI 4.4.1 (966 paths, no `apps_createInstance`) plus Apple's own text. Also added: **`appstoreappsreview.createappstorehostedapp` reads exactly like the endpoint you want and is the DMA alternative-app-store pipeline.** Do not call it.
3. **`G-09` may be API-able** via `androidpublisher` **`grants.create`**, given the numeric Play developer account id — **not recorded anywhere in this repo**. Noted as a possible automation win, not a certainty.

`X-03` promoted to the loudest line in the store runbook: the Play package name is locked forever by the first *upload*, not the first release.

### Compliance that binds engineering — R-47 and R-48

- **R-47 (SDK categories).** Wider than "no ads, no analytics": attribution/MMP, push-with-segmentation, targeted remote-config, social login, anything declaring `AD_ID` — and **third-party crash reporters (Crashlytics, Sentry, Bugsnag)**, which 1.3 forbids by naming *device information* explicitly. That is the one teams add without treating it as a compliance decision. **Play's Families Self-Certified Ads SDK program is closed to new applicants**, so "add ads later if the subscription underperforms" is not an available fallback — priced into R-45.
- **R-48 (privacy law).** **COPPA's 2025 amendments required compliance by 2026-04-22 — passed.** Even at "we transmit nothing," write the §312.10 retention/deletion policy, the §312.8 security program, and a UK Children's Code DPIA. **Texas SB2420 and Utah's App Store Accountability Acts are in force and apply to all apps** — consume store age signals, use only for compliance, **delete after use** (consume, never persist; flagged for counsel as secondary sourcing). AADCA partially revived 2026-03-12; Nebraska 2026-01-01; Vermont 2027-01-01.
- **Disclosure posture:** both stores define "collect" as transmitting off-device, so local-first earns **Apple "Data Not Collected"** and **Play "nothing collected, nothing shared"**. Exactly two things break it — a third-party crash SDK, or a receipt-validation backend — so **keep entitlements local**, which points the same way as the never-block-an-offline-subscriber policy.
- **Four mechanical CI gates recommended, not implemented** (`.github/**` is another agent's): the **network-egress test** first — zero outbound requests on cold launch and through a full lesson, which converts "we collect nothing" from a claim into a test — then merged-`AndroidManifest.xml` assertions, iOS `ASIdentifierManager`/ATT/`NSUserTrackingUsageDescription` assertions, and failing on any new third-party `PrivacyInfo.xcprivacy`.
- **R-38b:** Play's **12-testers-for-14-days** closed-testing gate applies to *personal* accounts created after 2023-11-13; organization accounts are exempt. **The account type is unverified** — a founder console check, because if it bites it is a two-week calendar hit on M1. Also unverified: the numeric Play developer account id. And the **Play Developer Reporting API is disabled** on GCP project `corpora1`, so apps can only be probed by known package name.

## 7. Housekeeping

- **Stale split notes removed** from `MISSION.md`, `ACCEPTANCE_CRITERIA.md` and `README.md` — #526 landed, so "resolves once the follow-up PR merges" is now false.
- **`.gitignore`:** `corpan/plugins/*/android/.gradle/` — anchored (mirrors the existing `corpan/plugins/*/ios/.build/` line) and **directory-only**, so it can never match the tracked `build.gradle.kts` / `settings.gradle` **files** in those same directories. Verified below.
- **`STATUS.md`** brought current: #522–#526 merged, `main` at `7fc5b7d98`, founder decisions recorded, research in flight, and the two live findings (the possibly-inert `ndk-context` `[patch]`, the `adversarial-review` fail-open audit) listed as **under investigation with no verdict**. The playtest-cohort and art-director blockers are gone; the native CI gate and the fail-open reviewer remain.

## Verification

```
$ git diff origin/main --stat        22 files changed, 1404 insertions(+), 469 deletions(-)
$ git diff origin/main | wc -c       155422        (limit 200000; no split needed)
```

**`TODO(store-recon)`** — no placeholder remains. `rg` returns a single hit, and it is prose in `STATUS.md` recording *that* the placeholders were filled, not a placeholder itself.

**Cohort language** — stated precisely, because the earlier "no remaining reference" claim is not what `rg` shows. `6+ children` returns **2 hits, both in ADR-0017**: the Context paragraph describing the superseded plan, and the founder's own quote. `COPPA` returns **4** — two in ADR-0017 saying the paperwork does *not* apply, two in R-48/`STATUS.md` about the genuinely applicable §312.10 and §312.8 obligations. `named art director` returns **2**, both stating the role is now the founder's. **No occurrence describes a cohort the program intends to recruit**, which is the real claim and is weaker than "zero hits."

**Split notes** — `rg 'resolve once|reference-set PR|follow-up PR|program-docs-reference|were split so'` over `dynawalla/docs/` returns **no matches**.

**`.gitignore`** — the method, since the bare count is not reproducible on its own: check out each `.gitignore` version in turn, pipe all tracked paths through `git check-ignore -v --stdin --no-index`, normalise away line numbers, diff the two result sets.

```
tracked paths tested : 9748
matched BEFORE       : 129
matched AFTER        : 129
--- set difference ---
IDENTICAL
```

Identical sets mean no tracked path changed status **and** no existing rule changed which paths it matches. The four target dirs resolve to `.gitignore:23:corpan/plugins/*/android/.gradle/`; the tracked `build.gradle.kts` / `settings.gradle` files in those same directories are confirmed not ignored, because the rule is directory-only.

**Other checks:** all markdown links under `dynawalla/docs/` resolve; `ACCEPTANCE_CRITERIA.md` totals **117** items against a summary table saying 117 (G-05/G-06/G-07/G-08/X-03/Q-11 were strengthened in place, never added to); all six `T-0*` items now carry a `Verify:` line; `targetSdk >= 36` in the CI gate; no domain or DNS specifics anywhere under `dynawalla/`; the only surviving "ceiling" and "cannot use one" strings are the deliberately-quoted superseded claims inside ADR-0001.

## 9. Third commit — adversarial review fixes

A fresh-context reviewer found one blocking error and several majors. Each was verified before acting.

### BLOCKING — the age-band "ceiling" framing was a logic error

The previous commit claimed Apple's 9-11 is a **ceiling** and that ADR-0002's cut to grades 1–5 "lands exactly inside" it, so scope and band "become consistent for free." **Confirmed wrong.** Apple requires choosing **exactly one** of three bands, not declaring a maximum age. By the docs' own mapping, grades 1–5 ≈ ages 6–11 — which spans **both** the 6-8 and 9-11 bands. Cutting grade 6 removes overflow past age 11 and **resolves nothing**. ADR-0001 even contradicted itself twelve lines later, describing the identical skew under option (a).

Purged from ADR-0001, ADR-0002, `STATUS.md` and `STORE.md`. The corrected version states that **no Apple band expresses grades 1–5 either**, that option (a)'s skew is unavoidable at both grade ranges, and adds the cuts that *would* fit one band — ~grades 4–5 (discards foundational place value and read-aloud's reason to exist at M2) or ~grades 1–3 (discards multiplication, division, and the fraction work ADR-0002's own evidence says predicts later algebra). Both far more expensive than what was proposed. **The point is that electing Kids Category is expensive, not cheap** — the corrected text is written so that cannot be softened back.

### Majors

- **`appstoreappsreview.createappstorehostedapp` is a Google method, filed under the Apple bullet.** Confirmed: `resource.method` naming and the `:create` custom-verb path are Google Discovery conventions. It is `androidpublisher` v3, `POST .../appstore/{appStorePackageName}/apps:create`, for third-party Android app stores. Moved to the Play side with the full path — and the adjacent contradiction fixed, since item 2 claimed androidpublisher "has no application-create method" while that is the very API containing `apps:create`. Now: no method to create **your own** app record.
- **Three documents, three different answers to "which founder decisions are open"** — and the age-band decision *this PR exists to record* was missing from two. `STATUS.md` is now the single source; `MISSION.md` and `DECISIONS.md` link to it instead of re-enumerating.
- **SECURITY: ADR-0016 published a working, unremediated subdomain-takeover recipe in a public repo** — domain, exact dangling target, record types, and confirmation the target no longer resolves. Reduced to "dangling DNS records on a domain we own need clearing before the name carries a product." **Deliberate redaction: the founder already has the specifics out of band.** Also scrubbed from `STATUS.md`.
- **Store policy overstated as prohibition, twice.** Apple does **not** forbid arithmetic parental gates — its own illustrated example is one. The true claim is that arithmetic is ineffective *for this product*, which is our judgement. And Guideline 1.3 says third-party analytics **"should not"** be included and **"in limited cases may be permitted"** — so our none-ever posture is **stricter than the rule**, which is what now gets written. Fixed in ADR-0001, ADR-0005, `STORE.md`, and all four "bars" sites.
- **`DECISIONS.md` still said the name check was "in flight"** after it returned.

### Minors applied

R-48's Ninth Circuit / state-date bullet now carries the same secondary-sourcing caveat as its neighbour · "closed to new applicants" softened to "currently not accepting; Google says the window will reopen" (STORE, R-47, ADR-0013) · CI-gate `targetSdk >= 33` → **36**, since a gate passing at 33 cannot catch the regression it exists for · **deleted the 403-vs-404 status-code inference** (405 is the correct status for a disallowed method, and many APIs 404 regardless) while keeping the OpenAPI-spec and Apple-docs evidence the conclusion actually rests on · ADR-0017 cited §5 for the praise rule, it is §3a · ADR-0010 said the research covered "licensing" (that is ADR-0014) · **Q-11 kept its `[device]` tag but had dropped the store-build requirement that tag mandates** — restored · "unsupervised: the observer is in the room" → **"unassisted"** · **T-01..T-05 had no `Verify:` lines** though the file mandates them — all five added.

### Governance

**This PR was breaking a rule it edits around.** `DECISIONS.md` said "an ADR is amended by writing a new one," while ADR-0001 and ADR-0017 were rewritten in place. Rather than leave the contradiction, the vocabulary is amended in this same PR: reaching a decision on a `Proposed` ADR is not an amendment; correcting a factual error in an unimplemented ADR is not either, **provided the error stays visible**; everything else still requires a superseding ADR, and a `Superseded` ADR is never edited. In-place edits now carry a dated `Amended` / `Corrected` header line — ADR-0001's says it was corrected twice.

**The founder's mandate was overstated.** His monetization answer opens *"I'm not sure about monetization really"*; his account answer was *"same as Corpan **I think**"* — and ADR-0015 then booked a shared policy-violation blast radius **reaching Corpán's paying subscribers** as an accepted cost that was never put to him. The decisions stand; the status lines and consequence sections now say how strong the mandate actually is, and ADR-0015's Consequences heading changed from "accepted as trade-offs" to "costs the program identified, not costs the founder priced," with the blast radius flagged for explicit confirmation before M1.

## Where I did not verify

**Corrected in the third commit rather than defended:** the age-band "ceiling" reasoning (a genuine logic error, and the finding this PR had been proudest of), the Google/Apple API misattribution, two overstated store prohibitions, and a security-sensitive detail that should never have been committed. The reviewer was right on all of them.

Recorded as unverified in-doc rather than asserted: the **Play developer account type** (personal vs organization — R-38b, a possible two-week M1 hit), the **numeric Play developer account id** (needed if `grants.create` is to automate `G-09`), and whether `grants.create` in fact works for this purpose. Trademark clearance is **mirror evidence, not a first-party search** — the databases bot-blocked, and ADR-0016 says so rather than implying the name is cleared. The Texas/Utah age-signal requirements are secondary-sourced and flagged for counsel. The two findings in `STATUS.md` remain open investigations with no verdict claimed.
