### PR TITLE
fix(ci): make adversarial-review fail closed

### DIFF
--- a/.github/scripts/adversarial_review.py
+++ b/.github/scripts/adversarial_review.py
@@ -3,12 +3,22 @@
 
 Runs three independent adversarial lenses (correctness, security, pack-compat)
 over a PR diff, posts a single sticky findings comment, and exits non-zero iff
-there is an unresolved HIGH-severity finding. That exit code becomes the
-`adversarial-review` required status check.
+there is a blocking-severity finding OR the review could not be completed.
+
+FAIL CLOSED is the contract. This script is the `adversarial-review` required
+status check, so a green exit must mean "every lens actually read 100% of the
+diff and found nothing blocking". Anything else exits non-zero: a git failure,
+a malformed SHA, a lens API error, a model reply we cannot parse, or a diff we
+could not fully cover.
+
+Large diffs are CHUNKED, never truncated. The diff is split on `diff --git`
+boundaries into budget-sized chunks, every lens runs over every chunk, and the
+findings are unioned. Coverage is asserted programmatically — the concatenated
+chunks must equal the diff exactly — before a single model call is made.
 
 Provider-agnostic: prefers Anthropic if ANTHROPIC_API_KEY is set, otherwise uses
 the repo's existing OPENAI_KEY (the same secret pr-agent already uses — no new
-secret to add). Self-contained: stdlib only (urllib), so no pip install.
+secret to add). Self-contained: stdlib only (urllib), so CI needs no pip install.
 
 Env:
   ANTHROPIC_API_KEY   if set → review via Claude (preferred)
@@ -18,21 +28,46 @@ Env:
   GITHUB_REPOSITORY   owner/repo (set by Actions)
   PR_NUMBER           PR number (empty in merge_group → comment skipped)
   BASE_SHA, HEAD_SHA  diff range
-  MAX_DIFF_BYTES      truncate the diff to control cost (default 200000)
+  MAX_CHUNK_CHARS     per-chunk character budget (default 200000)
+  ADVERSARIAL_WORKERS concurrent model calls (default 4)
 """
 
 import json
 import os
+import random
 import re
 import subprocess
 import sys
+import time
 import urllib.request
 import urllib.error
+from concurrent.futures import ThreadPoolExecutor
 
 ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
 OPENAI_URL = "https://api.openai.com/v1/chat/completions"
-DEFAULT_MODEL = {"anthropic": "claude-sonnet-4-6", "openai": "gpt-4.1"}
+DEFAULT_MODEL = {"anthropic": "claude-opus-5", "openai": "gpt-4.1"}
 MARKER = "<!-- adversarial-review -->"
+
+# `max_tokens` on current Claude models caps thinking + visible response
+# together. The old value of 2000 silently truncated the JSON mid-object, which
+# parsed as "no findings" and passed the gate. 16000 is the non-streaming
+# ceiling (much above this the API wants a streaming request).
+ANTHROPIC_MAX_TOKENS = 16000
+
+# Chunk budget in CHARACTERS. The old name (MAX_DIFF_BYTES) lied: it was
+# compared against len() of a str, which counts characters, not bytes.
+DEFAULT_CHUNK_CHARS = 200000
+MIN_CHUNK_CHARS = 4000  # guards against a config that would never terminate
+
+REQUEST_TIMEOUT_S = 120
+REQUEST_ATTEMPTS = 3
+RETRY_BACKOFF_S = 2
+RETRY_STATUS = {408, 409, 429, 500, 502, 503, 504}
+
+# Severity strings that block the merge, after normalization.
+BLOCKING_ALIASES = {"critical", "blocker", "block", "severe", "fatal"}
+MEDIUM_ALIASES = {"medium", "med", "moderate", "warning", "warn"}
+LOW_ALIASES = {"low", "minor", "info", "informational", "nit", "nitpick", "trivial"}
 
 
 def provider_and_key():
@@ -43,6 +78,7 @@ def provider_and_key():
     if key:
         return "openai", key
     return None, None
+
 
 LENSES = {
     "correctness": (
@@ -85,82 +121,304 @@ SCHEMA_HINT = (
     "confident defects."
 )
 
+# Chunked reviews see one slice of the diff at a time. Without this, a lens
+# reports "this helper is never defined" for a definition that lives in another
+# chunk — a false HIGH that would wedge the merge queue.
+CHUNK_HINT = (
+    "This is chunk {i} of {n} from a larger diff; the other chunks contain "
+    "different files and hunks and are reviewed separately. Judge only what is "
+    "visible here. Do NOT report a finding merely because a definition, caller, "
+    "import, test, or migration appears to be missing — it is very likely in "
+    "another chunk. Report unresolved symbols only if the diff itself deletes "
+    "or renames them."
+)
+
+# Mirrors SCHEMA_HINT. Anthropic structured outputs require additionalProperties
+# false on every object and every property listed in `required`.
+FINDINGS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "findings": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "severity": {"type": "string", "enum": ["high", "medium", "low"]},
+                    "file": {"type": "string"},
+                    "line": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                    "title": {"type": "string"},
+                    "detail": {"type": "string"},
+                },
+                "required": ["severity", "file", "line", "title", "detail"],
+                "additionalProperties": False,
+            },
+        }
+    },
+    "required": ["findings"],
+    "additionalProperties": False,
+}
+
+
+class ReviewError(Exception):
+    """Anything that makes a green verdict unsafe. Always exits non-zero."""
+
+
+# ---------------------------------------------------------------- git plumbing
+
 
 def run(cmd):
-    return subprocess.run(cmd, capture_output=True, text=True).stdout
+    """Run a command, returning (returncode, stdout, stderr).
+
+    The old helper returned stdout only and discarded the return code, so a
+    failed `git diff` produced an empty string that the caller read as
+    "empty diff; nothing to review" and passed the gate.
+    """
+    # errors="replace": a stray non-UTF-8 byte in a diff must not crash the gate.
+    p = subprocess.run(cmd, capture_output=True, text=True, errors="replace")
+    return p.returncode, p.stdout, p.stderr
 
 
 _SHA_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
 
 
-def _safe_sha(value, fallback="HEAD"):
-    # Only accept hex SHAs / HEAD so nothing like `--upload-pack=...` reaches git.
-    value = (value or "").strip()
-    if value == "HEAD" or _SHA_RE.match(value):
-        return value
-    return fallback
+def _commit_exists(rev):
+    rc, _, _ = run(["git", "cat-file", "-e", f"{rev}^{{commit}}"])
+    return rc == 0
 
 
-def get_diff():
-    base = _safe_sha(os.environ.get("BASE_SHA"), fallback="")
-    head = _safe_sha(os.environ.get("HEAD_SHA"), fallback="HEAD") or "HEAD"
-    # Resolve a usable base.
-    if not base or subprocess.call(
-        ["git", "cat-file", "-e", f"{base}^{{commit}}"],
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-    ) != 0:
-        base = run(["git", "rev-parse", f"{head}^"]).strip()
-    rng = f"{base}..{head}" if base else head
-    diff = run(["git", "diff", "--unified=3", rng])
-    max_bytes = int(os.environ.get("MAX_DIFF_BYTES", "200000"))
-    if len(diff) > max_bytes:
-        diff = diff[:max_bytes] + "\n\n[diff truncated for length]\n"
-    return rng, diff
+def _check_sha(name, value):
+    """Validate a caller-supplied SHA.
+
+    Malformed input is an error, never a silent substitution — substituting
+    HEAD reviewed the wrong range and still reported success.
+    """
+    if not _SHA_RE.match(value):
+        raise ReviewError(
+            f"{name} is not a valid commit SHA: {value!r}. Refusing to guess a range."
+        )
+    if not _commit_exists(value):
+        raise ReviewError(
+            f"{name}={value} is not present in this checkout "
+            "(is fetch-depth: 0 set on actions/checkout?)."
+        )
+    return value
+
+
+def resolve_range():
+    """Resolve the diff range, failing loudly rather than reviewing the wrong one."""
+    base_raw = (os.environ.get("BASE_SHA") or "").strip()
+    head_raw = (os.environ.get("HEAD_SHA") or "").strip()
+
+    if head_raw:
+        head = _check_sha("HEAD_SHA", head_raw)
+    else:
+        if not _commit_exists("HEAD"):
+            raise ReviewError("no HEAD_SHA given and HEAD does not resolve to a commit.")
+        head = "HEAD"
+
+    if base_raw:
+        base = _check_sha("BASE_SHA", base_raw)
+    else:
+        # workflow_dispatch and other no-base events: review the head commit.
+        rc, out, err = run(["git", "rev-parse", f"{head}^"])
+        if rc != 0 or not out.strip():
+            raise ReviewError(
+                f"BASE_SHA unset and could not resolve {head}^: "
+                f"{err.strip() or 'no parent commit'}"
+            )
+        base = out.strip()
+    return f"{base}..{head}"
+
+
+def get_diff(rng):
+    """Return the full diff for `rng`. Never truncates; raises on git failure."""
+    rc, diff, err = run(["git", "diff", "--unified=3", rng])
+    if rc != 0:
+        raise ReviewError(f"git diff {rng} failed (exit {rc}): {err.strip()}")
+
+    if not diff.strip():
+        # An empty diff is only a pass if the range is GENUINELY empty. Assert
+        # that with an independent query rather than trusting one empty stdout.
+        rc2, names, err2 = run(["git", "diff", "--name-only", rng])
+        if rc2 != 0:
+            raise ReviewError(
+                f"git diff --name-only {rng} failed (exit {rc2}): {err2.strip()}"
+            )
+        if names.strip():
+            raise ReviewError(
+                f"git reported changed files for {rng} but produced an empty diff; "
+                "refusing to pass a review that read nothing."
+            )
+    return diff
+
+
+# ------------------------------------------------------------------- chunking
+
+_FILE_START_RE = re.compile(r"^diff --git ", re.M)
+
+
+def split_into_files(diff):
+    """Split a unified diff into per-file segments.
+
+    Guarantee: "".join(split_into_files(d)) == d.
+    """
+    if not diff:
+        return []
+    starts = [m.start() for m in _FILE_START_RE.finditer(diff)]
+    if not starts:
+        return [diff]
+    segments = []
+    if starts[0] > 0:
+        segments.append(diff[: starts[0]])
+    for i, start in enumerate(starts):
+        end = starts[i + 1] if i + 1 < len(starts) else len(diff)
+        segments.append(diff[start:end])
+    return segments
+
+
+def _segment_path(segment):
+    m = re.match(r"diff --git a/(\S+)", segment)
+    return m.group(1) if m else "<unknown>"
+
+
+def chunk_diff(diff, budget):
+    """Pack per-file segments into chunks of at most `budget` characters.
+
+    Returns (chunks, oversized_files).
+
+    A single file larger than the budget is HARD-SPLIT into budget-sized pieces
+    rather than truncated or rejected. Rationale: truncating would silently drop
+    review coverage (the exact bug this change exists to fix), and rejecting
+    would block legitimate large-file PRs — generated files, lockfiles, vendored
+    sources — on day one. Splitting keeps coverage at 100%; the cost is that the
+    later pieces of such a file reach the model without their `diff --git`
+    header, so those files are named in the audit trail.
+
+    Guarantee: "".join(chunks) == diff, for any budget >= MIN_CHUNK_CHARS.
+    """
+    if budget < MIN_CHUNK_CHARS:
+        raise ReviewError(
+            f"chunk budget {budget} is below the minimum {MIN_CHUNK_CHARS}."
+        )
+
+    chunks, oversized, current = [], [], ""
+    for segment in split_into_files(diff):
+        if len(segment) > budget:
+            if current:
+                chunks.append(current)
+                current = ""
+            oversized.append(_segment_path(segment))
+            for i in range(0, len(segment), budget):
+                chunks.append(segment[i : i + budget])
+            continue
+        if current and len(current) + len(segment) > budget:
+            chunks.append(current)
+            current = ""
+        current += segment
+    if current:
+        chunks.append(current)
+    return chunks, oversized
+
+
+# ------------------------------------------------------------------ model I/O
 
 
 def _post(url, headers, payload):
-    req = urllib.request.Request(
-        url, data=json.dumps(payload).encode(), method="POST", headers=headers,
-    )
-    with urllib.request.urlopen(req, timeout=180) as resp:
-        return json.loads(resp.read())
+    """POST JSON with bounded retries on transient failures.
+
+    Retries matter for fail-closed correctness: without them a single 429 from a
+    concurrent burst becomes a lens error, and a lens error now blocks the merge.
+    """
+    body = json.dumps(payload).encode()
+    last = None
+    for attempt in range(REQUEST_ATTEMPTS):
+        try:
+            req = urllib.request.Request(url, data=body, method="POST", headers=headers)
+            with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_S) as resp:
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as e:
+            try:
+                detail = e.read()[:300]
+            except Exception:  # noqa: BLE001
+                detail = b""
+            last = RuntimeError(f"HTTP {e.code}: {detail!r}")
+            if e.code not in RETRY_STATUS:
+                raise last from e
+        except Exception as e:  # noqa: BLE001
+            last = e
+        if attempt + 1 < REQUEST_ATTEMPTS:
+            time.sleep(RETRY_BACKOFF_S * (2**attempt) + random.uniform(0, 1))
+    raise last
 
 
 def call_model(provider, key, model, system, user):
     if provider == "anthropic":
-        data = _post(ANTHROPIC_URL, {
-            "x-api-key": key,
-            "anthropic-version": "2023-06-01",
-            "content-type": "application/json",
-        }, {
-            "model": model,
-            "max_tokens": 2000,
-            "system": system,
-            "messages": [{"role": "user", "content": user}],
-        })
+        data = _post(
+            ANTHROPIC_URL,
+            {
+                "x-api-key": key,
+                "anthropic-version": "2023-06-01",
+                "content-type": "application/json",
+            },
+            {
+                "model": model,
+                "max_tokens": ANTHROPIC_MAX_TOKENS,
+                # Adaptive thinking is the current on-mode; a fixed thinking
+                # budget (budget_tokens) is rejected by current models.
+                "thinking": {"type": "adaptive"},
+                # `format` gives the same guaranteed-JSON contract the OpenAI
+                # branch gets from response_format, but schema-checked.
+                "output_config": {
+                    "effort": "high",
+                    "format": {"type": "json_schema", "schema": FINDINGS_SCHEMA},
+                },
+                "system": system,
+                "messages": [{"role": "user", "content": user}],
+            },
+        )
+        stop = data.get("stop_reason")
+        if stop in ("max_tokens", "refusal"):
+            # Either one means the JSON is absent or incomplete. Raising makes
+            # it a lens error rather than a silent "no findings".
+            raise RuntimeError(f"anthropic response unusable (stop_reason={stop})")
         return "".join(
             b.get("text", "") for b in data.get("content", []) if b.get("type") == "text"
         )
+
     # openai
-    data = _post(OPENAI_URL, {
-        "authorization": f"Bearer {key}",
-        "content-type": "application/json",
-    }, {
-        "model": model,
-        "messages": [
-            {"role": "system", "content": system},
-            {"role": "user", "content": user},
-        ],
-        "response_format": {"type": "json_object"},
-    })
-    return data["choices"][0]["message"]["content"]
+    data = _post(
+        OPENAI_URL,
+        {"authorization": f"Bearer {key}", "content-type": "application/json"},
+        {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "response_format": {"type": "json_object"},
+        },
+    )
+    choice = (data.get("choices") or [{}])[0]
+    if choice.get("finish_reason") == "length":
+        raise RuntimeError("openai response truncated (finish_reason=length)")
+    content = (choice.get("message") or {}).get("content")
+    if content is None:
+        raise RuntimeError("openai response contained no message content")
+    return content
 
 
 def parse_findings(text):
-    # Scan for balanced {...} spans and return the first that parses and carries a
-    # "findings" key — robust to prose or example braces around the JSON.
-    starts = [i for i, c in enumerate(text) if c == "{"]
-    for start in starts:
+    """Return a list of finding dicts, or None if there is no well-formed
+    findings object.
+
+    None is the important half: "the model produced nothing we can read" used to
+    be indistinguishable from "the model found nothing" (both returned []), so
+    an empty reply, prose, a JSON object without a findings key, and JSON cut
+    off mid-object all passed the gate. None is now counted as a lens error.
+    """
+    if not text or not text.strip():
+        return None
+    for start in (i for i, c in enumerate(text) if c == "{"):
         depth = 0
         for j in range(start, len(text)):
             if text[j] == "{":
@@ -169,59 +427,122 @@ def parse_findings(text):
                 depth -= 1
                 if depth == 0:
                     try:
-                        obj = json.loads(text[start:j + 1])
+                        obj = json.loads(text[start : j + 1])
                     except json.JSONDecodeError:
                         break
                     if isinstance(obj, dict) and "findings" in obj:
-                        return obj.get("findings", [])
+                        raw = obj["findings"]
+                        # `{"findings": null}` used to crash on iteration. Treat
+                        # an explicit null as "nothing found": the key is present
+                        # and says so, and failing closed here would block every
+                        # clean PR from a model that spells [] as null.
+                        if raw is None:
+                            return []
+                        if not isinstance(raw, list):
+                            return None
+                        if not all(isinstance(f, dict) for f in raw):
+                            return None  # a finding we cannot read may be a HIGH
+                        return raw
                     break
-    return []
+    return None
 
 
-def review_lens(provider, key, model, name, instruction, diff):
+def review_chunk(provider, key, model, name, instruction, chunk, index, total):
+    """Run one lens over one chunk. Returns a list of findings, or None on error."""
+    label = f"{name} lens, chunk {index}/{total}"
     user = (
-        f"{instruction}\n\nReview this unified diff. {SCHEMA_HINT}\n\n"
-        f"```diff\n{diff}\n```"
+        f"{instruction}\n\n{CHUNK_HINT.format(i=index, n=total)}\n\n"
+        f"Review this unified diff. {SCHEMA_HINT}\n\n"
+        f"```diff\n{chunk}\n```"
     )
     try:
         raw = call_model(
-            provider, key, model,
-            "You are a rigorous, adversarial code reviewer.", user,
+            provider, key, model, "You are a rigorous, adversarial code reviewer.", user
         )
-    except urllib.error.HTTPError as e:
-        print(f"::warning::{name} lens API error {e.code}: {e.read()[:300]!r}")
-        return None
     except Exception as e:  # noqa: BLE001
-        print(f"::warning::{name} lens failed: {e}")
+        print(f"::warning::{label} failed: {e}")
         return None
-    out = []
-    for f in parse_findings(raw):
+    findings = parse_findings(raw)
+    if findings is None:
+        preview = (raw or "")[:200]
+        print(f"::warning::{label} returned no parseable findings object: {preview!r}")
+        return None
+    for f in findings:
         f["lens"] = name
+        f["chunk"] = index
+    return findings
+
+
+# ------------------------------------------------------------------- severity
+
+
+def normalize_severity(value):
+    """Map a free-form severity string to high / medium / low / unknown.
+
+    The old code compared the raw string to "high" exactly, so "critical",
+    "blocker", "High severity" and "HIGH " all sailed through the gate.
+    """
+    cleaned = re.sub(r"[^a-z]+", " ", str(value or "").lower()).strip()
+    first = cleaned.split(" ")[0] if cleaned else ""
+    if first.startswith("high") or first in BLOCKING_ALIASES:
+        return "high"
+    if first in MEDIUM_ALIASES:
+        return "medium"
+    if first in LOW_ALIASES:
+        return "low"
+    return "unknown"
+
+
+SEV_ORDER = {"high": 0, "medium": 1, "low": 2, "unknown": 3}
+
+
+def dedupe(findings):
+    """Collapse identical findings reported for the same location."""
+    seen, out = set(), []
+    for f in findings:
+        key = (f.get("lens"), f.get("file"), str(f.get("line")), f.get("title"))
+        if key in seen:
+            continue
+        seen.add(key)
         out.append(f)
     return out
 
 
-def render_markdown(rng, all_findings):
-    sev_order = {"high": 0, "medium": 1, "low": 2}
-    all_findings.sort(key=lambda f: sev_order.get(str(f.get("severity")).lower(), 3))
-    highs = [f for f in all_findings if str(f.get("severity")).lower() == "high"]
+# --------------------------------------------------------------------- output
+
+
+def render_markdown(audit, all_findings):
+    """Build the sticky comment body.
+
+    The audit line is emitted UNCONDITIONALLY, including on clean runs — a green
+    run used to record nothing at all about what had actually been reviewed.
+    """
+    for f in all_findings:
+        f["severity_norm"] = normalize_severity(f.get("severity"))
+    all_findings.sort(key=lambda f: SEV_ORDER.get(f["severity_norm"], 3))
+    highs = [f for f in all_findings if f["severity_norm"] == "high"]
+
     lines = [MARKER, "## 🛡️ Adversarial review"]
     if not all_findings:
-        lines.append("\n✅ No findings across correctness / security / pack-compat lenses.")
-        return "\n".join(lines), highs
-    verdict = "❌ **Blocked** — high-severity findings must be resolved." if highs \
-        else "✅ **Pass** — only non-blocking findings."
-    lines.append(f"\n{verdict}\n")
-    lines.append(f"_Reviewed range `{rng}`._\n")
-    icon = {"high": "🔴", "medium": "🟠", "low": "🟡"}
+        lines.append(
+            "\n✅ No findings across correctness / security / pack-compat lenses."
+        )
+    elif highs:
+        lines.append("\n❌ **Blocked** — blocking-severity findings must be resolved.")
+    else:
+        lines.append("\n✅ **Pass** — only non-blocking findings.")
+    lines.append(f"\n{audit}\n")
+
+    icon = {"high": "🔴", "medium": "🟠", "low": "🟡", "unknown": "⚪"}
     for f in all_findings:
-        sev = str(f.get("severity", "low")).lower()
-        loc = f.get("file", "?")
+        sev = f["severity_norm"]
+        loc = str(f.get("file", "?"))
         if f.get("line"):
             loc += f":{f['line']}"
         lines.append(
             f"- {icon.get(sev, '⚪')} **{sev.upper()}** [{f.get('lens')}] "
-            f"`{loc}` — **{f.get('title', '').strip()}**  \n  {f.get('detail', '').strip()}"
+            f"`{loc}` — **{str(f.get('title', '')).strip()}**  \n  "
+            f"{str(f.get('detail', '')).strip()}"
         )
     return "\n".join(lines), highs
 
@@ -242,8 +563,10 @@ def post_sticky_comment(body):
 
     def api(method, url, payload=None):
         req = urllib.request.Request(
-            url, data=json.dumps(payload).encode() if payload else None,
-            method=method, headers=hdr,
+            url,
+            data=json.dumps(payload).encode() if payload else None,
+            method=method,
+            headers=hdr,
         )
         with urllib.request.urlopen(req, timeout=60) as r:
             return json.loads(r.read() or "[]")
@@ -257,7 +580,43 @@ def post_sticky_comment(body):
             api("POST", f"{base}/issues/{pr}/comments", {"body": body})
         print("Posted sticky review comment.")
     except Exception as e:  # noqa: BLE001
+        # Comment posting is cosmetic; the exit code is the gate.
         print(f"::warning::could not post comment: {e}")
+
+
+def emit_summary(body):
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a") as fh:
+            fh.write(body + "\n")
+
+
+# ------------------------------------------------------------------------ main
+
+
+def review(provider, key, model, chunks, workers):
+    """Run every lens over every chunk. Returns (findings, errors, calls)."""
+    jobs = [
+        (name, instruction, chunk, i + 1, len(chunks))
+        for name, instruction in LENSES.items()
+        for i, chunk in enumerate(chunks)
+    ]
+    with ThreadPoolExecutor(max_workers=max(1, workers)) as pool:
+        results = list(
+            pool.map(
+                lambda j: review_chunk(
+                    provider, key, model, j[0], j[1], j[2], j[3], j[4]
+                ),
+                jobs,
+            )
+        )
+    findings, errors = [], 0
+    for result in results:
+        if result is None:
+            errors += 1
+        else:
+            findings += result
+    return findings, errors, len(jobs)
 
 
 def main():
@@ -266,33 +625,90 @@ def main():
         print("::error::no review key set (need ANTHROPIC_API_KEY or OPENAI_KEY).")
         return 1
     model = os.environ.get("ADVERSARIAL_MODEL") or DEFAULT_MODEL[provider]
-    print(f"Adversarial review via {provider} ({model}).")
-    rng, diff = get_diff()
-    if not diff.strip():
-        print("Empty diff; nothing to review.")
-        return 0
-    findings = []
-    errored = 0
-    for name, instruction in LENSES.items():
-        result = review_lens(provider, key, model, name, instruction, diff)
-        if result is None:
-            errored += 1
-        else:
-            findings += result
-    # A gate that couldn't run must NOT green-light the merge. If every lens
-    # errored (bad key, outage), fail closed rather than reporting "no findings".
-    if errored == len(LENSES):
-        print("::error::all review lenses failed to run; failing closed.")
+
+    try:
+        budget = int(os.environ.get("MAX_CHUNK_CHARS") or DEFAULT_CHUNK_CHARS)
+        workers = int(os.environ.get("ADVERSARIAL_WORKERS") or 4)
+        rng = resolve_range()
+        diff = get_diff(rng)
+        chunks, oversized = chunk_diff(diff, budget)
+        # Coverage is the whole point of chunking. Assert it before spending a
+        # single API call, and fail closed if the split ever loses a character.
+        if "".join(chunks) != diff:
+            raise ReviewError(
+                "internal error: chunking did not cover the diff exactly "
+                f"({sum(len(c) for c in chunks)} of {len(diff)} chars); failing closed."
+            )
+    except ReviewError as e:
+        print(f"::error::{e}")
         return 1
-    body, highs = render_markdown(rng, findings)
+    except ValueError as e:
+        print(f"::error::invalid numeric configuration: {e}")
+        return 1
+
+    files = diff.count("diff --git ")
+    audit = (
+        f"_Reviewed `{rng}` — {files} file(s), {len(diff)} chars, "
+        f"{len(chunks)} chunk(s) of <= {budget}, 100% covered, "
+        f"0 dropped · {provider} ({model}) · {len(LENSES)} lenses._"
+    )
+    if oversized:
+        audit += (
+            f"\n\n> ⚠️ Hard-split across chunk boundaries (larger than the "
+            f"{budget}-char budget): `{'`, `'.join(sorted(set(oversized)))}`. "
+            "Fully reviewed, but later pieces reach the model without their "
+            "file header."
+        )
+    print(audit)
+
+    if not diff.strip():
+        # get_diff already asserted the range is genuinely empty.
+        body = "\n".join(
+            [
+                MARKER,
+                "## 🛡️ Adversarial review",
+                "",
+                "✅ Empty diff — nothing to review.",
+                "",
+                audit,
+            ]
+        )
+        post_sticky_comment(body)
+        emit_summary(body)
+        print(body)
+        return 0
+
+    findings, errors, calls = review(provider, key, model, chunks, workers)
+
+    # A gate that could not run must NOT green-light the merge. ANY lens error
+    # fails closed — the old code only failed when every single lens errored, so
+    # two of three timing out still reported a pass.
+    if errors:
+        print(
+            f"::error::{errors} of {calls} lens/chunk reviews failed to produce a "
+            "readable result; failing closed."
+        )
+        emit_summary(
+            f"{MARKER}\n## 🛡️ Adversarial review\n\n"
+            f"❌ **Blocked** — {errors} of {calls} lens/chunk reviews failed.\n\n"
+            f"{audit}\n"
+        )
+        return 1
+
+    findings = dedupe(findings)
+    body, highs = render_markdown(audit, findings)
     post_sticky_comment(body)
-    summary = os.environ.get("GITHUB_STEP_SUMMARY")
-    if summary:
-        with open(summary, "a") as fh:
-            fh.write(body + "\n")
+    emit_summary(body)
     print(body)
+
+    unknown = [f for f in findings if f["severity_norm"] == "unknown"]
+    if unknown:
+        print(
+            f"::warning::{len(unknown)} finding(s) had an unrecognized severity "
+            f"and did not block: {sorted({str(f.get('severity')) for f in unknown})}"
+        )
     if highs:
-        print(f"::error::{len(highs)} high-severity finding(s) block the merge.")
+        print(f"::error::{len(highs)} blocking-severity finding(s) block the merge.")
         return 1
     return 0
 

--- a/.github/scripts/adversarial_review.py
+++ b/.github/scripts/adversarial_review.py
@@ -7,9 +7,23 @@ there is a blocking-severity finding OR the review could not be completed.
 
 FAIL CLOSED is the contract. This script is the `adversarial-review` required
 status check, so a green exit must mean "every lens actually read 100% of the
-diff and found nothing blocking". Anything else exits non-zero: a git failure,
-a malformed SHA, a lens API error, a model reply we cannot parse, or a diff we
-could not fully cover.
+reviewed range and found nothing blocking". Anything else exits non-zero: a git
+failure, a malformed SHA, an unresolvable merge base, a lens API error, a model
+reply we cannot parse, a finding whose severity is missing or unreadable, or a
+diff we could not fully cover.
+
+The ONE deliberate carve-out: a finding whose severity is a NON-EMPTY string
+that matches no known alias ("spicy") warns instead of blocking — that is a
+readable answer we merely do not recognise, and blocking on it would let a
+typo wedge the queue. A missing, null, or empty severity is unreadable input
+and blocks, like every other unreadable reply.
+
+RANGE. The reviewed range is always `merge-base(base, head)..head`. The event's
+base SHA is the base *branch tip*, not the merge base, so a two-dot
+`base..head` on a branch cut from an older main reviews the wrong set of
+changes while still reporting full coverage. In the merge queue the base SHA is
+the previous entry's head — already an ancestor of head — so the merge base is
+that SHA and the range is exactly that entry's own delta.
 
 Large diffs are CHUNKED, never truncated. The diff is split on `diff --git`
 boundaries into budget-sized chunks, every lens runs over every chunk, and the
@@ -24,12 +38,12 @@ Env:
   ANTHROPIC_API_KEY   if set → review via Claude (preferred)
   OPENAI_KEY / OPENAI_API_KEY   fallback → review via OpenAI
   ADVERSARIAL_MODEL   model id override (default per provider)
+  ADVERSARIAL_WORKERS concurrent model calls (default 3)
   GITHUB_TOKEN        for posting the sticky PR comment (optional in merge_group)
   GITHUB_REPOSITORY   owner/repo (set by Actions)
   PR_NUMBER           PR number (empty in merge_group → comment skipped)
-  BASE_SHA, HEAD_SHA  diff range
+  BASE_SHA, HEAD_SHA  diff range endpoints (a merge base is resolved from them)
   MAX_CHUNK_CHARS     per-chunk character budget (default 200000)
-  ADVERSARIAL_WORKERS concurrent model calls (default 4)
 """
 
 import json
@@ -50,25 +64,55 @@ DEFAULT_MODEL = {"anthropic": "claude-opus-5", "openai": "gpt-4.1"}
 MARKER = "<!-- adversarial-review -->"
 
 # `max_tokens` on current Claude models caps thinking + visible response
-# together. The old value of 2000 silently truncated the JSON mid-object, which
-# parsed as "no findings" and passed the gate. 16000 is the non-streaming
-# ceiling (much above this the API wants a streaming request).
-ANTHROPIC_MAX_TOKENS = 16000
+# together, and thinking is ON BY DEFAULT on claude-opus-5. The old value of
+# 2000 silently truncated the JSON mid-object, which parsed as "no findings"
+# and passed the gate; 16000 was still thin once adaptive thinking spends from
+# the same budget over a 50k-token chunk, and a `max_tokens` stop is a hard
+# red here. There is no API-enforced non-streaming ceiling — the constraint is
+# the HTTP request timeout, which is why this branch streams (see call_model).
+ANTHROPIC_MAX_TOKENS = 32000
+ANTHROPIC_EFFORT = "high"
+# `fallbacks: "default"` needs this beta. Without it a safety-classifier
+# decline on the security lens (whose prompt is exactly the shape that trips
+# the cyber category) is an unrecoverable red on a required check.
+ANTHROPIC_BETAS = "server-side-fallback-2026-07-01"
 
 # Chunk budget in CHARACTERS. The old name (MAX_DIFF_BYTES) lied: it was
 # compared against len() of a str, which counts characters, not bytes.
 DEFAULT_CHUNK_CHARS = 200000
 MIN_CHUNK_CHARS = 4000  # guards against a config that would never terminate
 
+# Concurrency. Every worker holds a full chunk (~50k tokens) in flight, and it
+# is that concurrent token volume — not the request count — that provokes a
+# token-rate 429. Overridable from the workflow so an incident can be throttled
+# without a code change (and therefore without a merge through the gate).
+DEFAULT_WORKERS = 3
+
 REQUEST_TIMEOUT_S = 120
-REQUEST_ATTEMPTS = 3
-RETRY_BACKOFF_S = 2
+REQUEST_ATTEMPTS = 4
+# Token-rate limits reset over roughly a minute, so 2s/4s could never clear
+# one: every attempt landed inside the same window and the 429 became a lens
+# error, i.e. a repo-wide block. 8/16/32 (+jitter) spans a rate-limit window.
+# A server-supplied retry-after / x-ratelimit-reset-* always wins over this.
+RETRY_BACKOFF_S = 8
+RETRY_MAX_SLEEP_S = 60
 RETRY_STATUS = {408, 409, 429, 500, 502, 503, 504}
 
-# Severity strings that block the merge, after normalization.
-BLOCKING_ALIASES = {"critical", "blocker", "block", "severe", "fatal"}
+# Wall-clock budget for the whole review. Kept under the job's timeout-minutes
+# so an overloaded provider produces a legible "budget exhausted" error instead
+# of the runner killing the job, and so retries can never outlive the job.
+REVIEW_BUDGET_S = 20 * 60
+
+# Severity strings that block the merge, after normalization. "major" is a
+# mainstream severity word — leaving it out was the last fail-open hole: a
+# model reporting a real defect as `"severity": "major"` exited 0.
+BLOCKING_ALIASES = {"critical", "blocker", "block", "major", "severe", "fatal"}
 MEDIUM_ALIASES = {"medium", "med", "moderate", "warning", "warn"}
 LOW_ALIASES = {"low", "minor", "info", "informational", "nit", "nitpick", "trivial"}
+
+# Sentinel for "the key was absent", which is different from "the value was a
+# string we do not recognise". Absent is unreadable input → blocks.
+MISSING = object()
 
 
 def provider_and_key():
@@ -119,7 +163,8 @@ SCHEMA_HINT = (
     '"detail": "why it is a problem and how to fix"}]}\n'
     "Return an empty findings array if you find nothing. Be precise; do not "
     "invent issues. Only HIGH severity blocks the merge, so reserve it for real, "
-    "confident defects."
+    "confident defects. Every finding MUST carry a severity — a finding with a "
+    "missing or empty severity is treated as blocking."
 )
 
 # Chunked reviews see one slice of the diff at a time. Without this, a lens
@@ -131,7 +176,9 @@ CHUNK_HINT = (
     "visible here. Do NOT report a finding merely because a definition, caller, "
     "import, test, or migration appears to be missing — it is very likely in "
     "another chunk. Report unresolved symbols only if the diff itself deletes "
-    "or renames them."
+    "or renames them. A chunk can also begin or end mid-line when a single "
+    "source line exceeded the chunk budget, so do NOT report truncated, "
+    "unterminated, or syntactically incomplete text as a defect."
 )
 
 # Mirrors SCHEMA_HINT. Anthropic structured outputs require additionalProperties
@@ -162,6 +209,18 @@ FINDINGS_SCHEMA = {
 
 class ReviewError(Exception):
     """Anything that makes a green verdict unsafe. Always exits non-zero."""
+
+
+# ------------------------------------------------------------------- deadline
+
+_DEADLINE = None
+
+
+def _time_left():
+    """Seconds remaining in the review budget (inf when no deadline is set)."""
+    if _DEADLINE is None:
+        return float("inf")
+    return _DEADLINE - time.monotonic()
 
 
 # ---------------------------------------------------------------- git plumbing
@@ -205,6 +264,42 @@ def _check_sha(name, value):
     return value
 
 
+class DiffRange(NamedTuple):
+    """The range actually reviewed, plus what the event asked for."""
+
+    base: str  # merge base — the commit the diff is taken FROM
+    head: str
+    requested_base: str  # the event's base SHA, before merge-base resolution
+
+    @property
+    def spec(self):
+        return f"{self.base}..{self.head}"
+
+    def describe(self):
+        short = self.requested_base[:12]
+        if self.base == self.requested_base:
+            return f"merge base == requested base `{short}`"
+        return f"merge base of requested base `{short}` and head"
+
+
+def _merge_base(base, head):
+    """Resolve the merge base, failing closed if git cannot.
+
+    Two-dot `base..head` diffs the base branch's CURRENT tree against head, so
+    every commit that landed on main after the branch was cut shows up inverted
+    in the diff — and, worse, changes the branch made on top of those commits
+    can vanish from it. The reviewed range must be the branch's own change.
+    """
+    rc, out, err = run(["git", "merge-base", base, head])
+    if rc != 0 or not out.strip():
+        raise ReviewError(
+            f"could not resolve the merge base of {base}..{head} "
+            f"(exit {rc}): {err.strip() or 'no common ancestor'}. "
+            "Refusing to review a range that is not this branch's change."
+        )
+    return out.strip()
+
+
 def resolve_range():
     """Resolve the diff range, failing loudly rather than reviewing the wrong one."""
     base_raw = (os.environ.get("BASE_SHA") or "").strip()
@@ -218,7 +313,7 @@ def resolve_range():
         head = "HEAD"
 
     if base_raw:
-        base = _check_sha("BASE_SHA", base_raw)
+        requested = _check_sha("BASE_SHA", base_raw)
     else:
         # workflow_dispatch and other no-base events: review the head commit.
         rc, out, err = run(["git", "rev-parse", f"{head}^"])
@@ -227,27 +322,28 @@ def resolve_range():
                 f"BASE_SHA unset and could not resolve {head}^: "
                 f"{err.strip() or 'no parent commit'}"
             )
-        base = out.strip()
-    return f"{base}..{head}"
+        requested = out.strip()
+
+    return DiffRange(_merge_base(requested, head), head, requested)
 
 
-def get_diff(rng):
-    """Return the full diff for `rng`. Never truncates; raises on git failure."""
-    rc, diff, err = run(["git", "diff", "--unified=3", rng])
+def get_diff(spec):
+    """Return the full diff for `spec`. Never truncates; raises on git failure."""
+    rc, diff, err = run(["git", "diff", "--unified=3", spec])
     if rc != 0:
-        raise ReviewError(f"git diff {rng} failed (exit {rc}): {err.strip()}")
+        raise ReviewError(f"git diff {spec} failed (exit {rc}): {err.strip()}")
 
     if not diff.strip():
         # An empty diff is only a pass if the range is GENUINELY empty. Assert
         # that with an independent query rather than trusting one empty stdout.
-        rc2, names, err2 = run(["git", "diff", "--name-only", rng])
+        rc2, names, err2 = run(["git", "diff", "--name-only", spec])
         if rc2 != 0:
             raise ReviewError(
-                f"git diff --name-only {rng} failed (exit {rc2}): {err2.strip()}"
+                f"git diff --name-only {spec} failed (exit {rc2}): {err2.strip()}"
             )
         if names.strip():
             raise ReviewError(
-                f"git reported changed files for {rng} but produced an empty diff; "
+                f"git reported changed files for {spec} but produced an empty diff; "
                 "refusing to pass a review that read nothing."
             )
     return diff
@@ -302,21 +398,33 @@ _HUNK_RE = re.compile(r"^@@ ", re.M)
 
 
 def _split_on_lines(text, budget):
-    """Partition text into <=budget pieces, breaking at line boundaries.
+    """Partition text into <=budget pieces, breaking at newline boundaries.
 
-    A single line longer than the budget (a minified bundle, say) is still hard
-    split — there is no smaller boundary to use.
+    Splits on "\\n" only. str.splitlines() also breaks on U+2028, U+2029,
+    U+0085, \\x0b and \\x0c — all legal inside JS/TS source — which silently
+    handed a lens a chunk starting mid-line while the audit line claimed no
+    lens sees a partial line.
 
-    Guarantee: "".join(result) == text.
+    Returns (pieces, hard_split). `hard_split` is True when a single line was
+    longer than the budget and had to be cut mid-line: there is no smaller
+    boundary to use, so the audit reports it rather than claiming otherwise.
+
+    Guarantee: "".join(pieces) == text.
     """
-    pieces, current = [], ""
-    for line in text.splitlines(keepends=True):
+    pieces, current, hard_split = [], "", False
+    parts = text.split("\n")
+    last = len(parts) - 1
+    for i, part in enumerate(parts):
+        line = part if i == last else part + "\n"
+        if not line:
+            continue
         if len(line) > budget:
+            hard_split = True
             if current:
                 pieces.append(current)
                 current = ""
-            for i in range(0, len(line), budget):
-                pieces.append(line[i : i + budget])
+            for j in range(0, len(line), budget):
+                pieces.append(line[j : j + budget])
             continue
         if current and len(current) + len(line) > budget:
             pieces.append(current)
@@ -324,13 +432,15 @@ def _split_on_lines(text, budget):
         current += line
     if current:
         pieces.append(current)
-    return pieces
+    return pieces, hard_split
 
 
 def _split_file_segment(segment, budget):
     """Split one oversized file diff at hunk boundaries, then line boundaries.
 
-    Guarantee: "".join(result) == segment.
+    Returns (pieces, hard_split).
+
+    Guarantee: "".join(pieces) == segment.
     """
     starts = [m.start() for m in _HUNK_RE.finditer(segment)]
     if starts:
@@ -341,9 +451,14 @@ def _split_file_segment(segment, budget):
     else:
         blocks = [segment]
 
-    atoms = []
+    atoms, hard_split = [], False
     for block in blocks:
-        atoms.extend([block] if len(block) <= budget else _split_on_lines(block, budget))
+        if len(block) <= budget:
+            atoms.append(block)
+            continue
+        split, block_hard = _split_on_lines(block, budget)
+        atoms.extend(split)
+        hard_split = hard_split or block_hard
 
     pieces, current = [], ""
     for atom in atoms:
@@ -353,13 +468,13 @@ def _split_file_segment(segment, budget):
         current += atom
     if current:
         pieces.append(current)
-    return pieces
+    return pieces, hard_split
 
 
 def chunk_diff(diff, budget):
     """Pack per-file segments into chunks of at most `budget` characters.
 
-    Returns (chunks, oversized_files).
+    Returns (chunks, oversized_files, hard_split_files).
 
     A single file larger than the budget is SPLIT rather than truncated or
     rejected. Truncating would silently drop review coverage (the exact bug this
@@ -367,10 +482,11 @@ def chunk_diff(diff, budget):
     generated files, lockfiles, vendored sources — on day one.
 
     Splits land on hunk boundaries where possible and line boundaries otherwise,
-    so a chunk never starts mid-line, and every continuation piece carries a
-    synthetic `context` naming the file it belongs to. Those two properties keep
-    a split file reviewable: without them the model cannot attribute hunks to a
-    path and invents findings from the missing context.
+    and every continuation piece carries a synthetic `context` naming the file
+    it belongs to. Those two properties keep a split file reviewable: without
+    them the model cannot attribute hunks to a path and invents findings from
+    the missing context. A file with a single line longer than the whole budget
+    (a minified bundle) is cut mid-line and reported in `hard_split_files`.
 
     Guarantee: "".join(c.text for c in chunks) == diff, for budget >= MIN_CHUNK_CHARS.
     """
@@ -379,7 +495,7 @@ def chunk_diff(diff, budget):
             f"chunk budget {budget} is below the minimum {MIN_CHUNK_CHARS}."
         )
 
-    chunks, oversized, current = [], [], ""
+    chunks, oversized, hard_split, current = [], [], [], ""
     for segment in split_into_files(diff):
         if len(segment) > budget:
             if current:
@@ -387,7 +503,9 @@ def chunk_diff(diff, budget):
                 current = ""
             path = _segment_path(segment)
             oversized.append(path)
-            pieces = _split_file_segment(segment, budget)
+            pieces, was_hard = _split_file_segment(segment, budget)
+            if was_hard:
+                hard_split.append(path)
             for n, piece in enumerate(pieces, start=1):
                 context = (
                     ""
@@ -407,25 +525,78 @@ def chunk_diff(diff, budget):
         current += segment
     if current:
         chunks.append(Chunk(current))
-    return chunks, oversized
+    return chunks, oversized, hard_split
 
 
 # ------------------------------------------------------------------ model I/O
 
+_DURATION_UNITS = {"ms": 0.001, "s": 1.0, "m": 60.0, "h": 3600.0}
+_DURATION_PART_RE = re.compile(r"(\d+(?:\.\d+)?)(ms|s|m|h)")
 
-def _post(url, headers, payload):
+
+def parse_duration(value):
+    """Parse '30', '6s', '1.5s', '6m0s' into seconds. None if unparseable."""
+    text = (value or "").strip().lower()
+    if not text:
+        return None
+    try:
+        return float(text)  # bare seconds, e.g. retry-after: 30
+    except ValueError:
+        pass
+    parts = _DURATION_PART_RE.findall(text)
+    if not parts:
+        return None
+    return sum(float(n) * _DURATION_UNITS[u] for n, u in parts)
+
+
+def retry_delay_from(headers):
+    """Server-directed retry delay in seconds, or None.
+
+    A token-rate 429 is answered by the provider with the time until the window
+    resets. Ignoring it and guessing a backoff is how a transient rate limit
+    became a repo-wide block.
+    """
+    if not headers:
+        return None
+
+    def get(name):
+        try:
+            return headers.get(name)
+        except AttributeError:
+            return None
+
+    for name in ("retry-after", "x-ratelimit-reset-tokens", "x-ratelimit-reset-requests"):
+        seconds = parse_duration(get(name))
+        if seconds is not None:
+            return max(0.0, seconds)
+    return None
+
+
+def _json_reader(resp):
+    return json.loads(resp.read())
+
+
+def _post(url, headers, payload, reader=_json_reader):
     """POST JSON with bounded retries on transient failures.
 
-    Retries matter for fail-closed correctness: without them a single 429 from a
-    concurrent burst becomes a lens error, and a lens error now blocks the merge.
+    Retries matter for fail-closed correctness: a lens error now blocks the
+    merge, so a 429 that is not survived is a repo-wide outage. The backoff
+    spans a rate-limit window and always defers to a server-supplied
+    retry-after. Every wait is checked against the review budget so retries can
+    never outlive the job and turn a slow provider into a timeout kill.
     """
     body = json.dumps(payload).encode()
     last = None
     for attempt in range(REQUEST_ATTEMPTS):
+        budget = _time_left()
+        if budget <= 0:
+            raise last or RuntimeError("review time budget exhausted before request")
         try:
             req = urllib.request.Request(url, data=body, method="POST", headers=headers)
-            with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_S) as resp:
-                return json.loads(resp.read())
+            with urllib.request.urlopen(
+                req, timeout=min(REQUEST_TIMEOUT_S, budget)
+            ) as resp:
+                return reader(resp)
         except urllib.error.HTTPError as e:
             try:
                 detail = e.read()[:300]
@@ -434,46 +605,94 @@ def _post(url, headers, payload):
             last = RuntimeError(f"HTTP {e.code}: {detail!r}")
             if e.code not in RETRY_STATUS:
                 raise last from e
+            server_delay = retry_delay_from(getattr(e, "headers", None))
         except Exception as e:  # noqa: BLE001
             last = e
-        if attempt + 1 < REQUEST_ATTEMPTS:
-            time.sleep(RETRY_BACKOFF_S * (2**attempt) + random.uniform(0, 1))
+            server_delay = None
+        if attempt + 1 >= REQUEST_ATTEMPTS:
+            break
+        delay = server_delay if server_delay is not None else RETRY_BACKOFF_S * (2**attempt)
+        delay = min(delay, RETRY_MAX_SLEEP_S) + random.uniform(0, 1)
+        if delay >= _time_left():
+            break
+        time.sleep(delay)
     raise last
+
+
+def read_anthropic_stream(resp):
+    """Accumulate a streamed Anthropic response into (text, stop_reason).
+
+    Streaming is not optional at this max_tokens: a non-streaming request that
+    thinks and then writes tens of thousands of tokens holds one socket open
+    for minutes and trips REQUEST_TIMEOUT_S. Concatenating every text delta is
+    also the correct reconstruction under `fallbacks`, because a fallback model
+    continues the partial text rather than restarting it.
+    """
+    text, stop = [], None
+    for raw in resp:
+        line = raw.decode("utf-8", "replace").strip()
+        if not line.startswith("data:"):
+            continue
+        payload = line[5:].strip()
+        if not payload:
+            continue
+        try:
+            event = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        etype = event.get("type")
+        if etype == "content_block_delta":
+            delta = event.get("delta") or {}
+            if delta.get("type") == "text_delta":
+                text.append(delta.get("text", ""))
+        elif etype == "message_delta":
+            stop = (event.get("delta") or {}).get("stop_reason") or stop
+        elif etype == "error":
+            raise RuntimeError(f"anthropic stream error: {event.get('error')}")
+    return "".join(text), stop
 
 
 def call_model(provider, key, model, system, user):
     if provider == "anthropic":
-        data = _post(
+        text, stop = _post(
             ANTHROPIC_URL,
             {
                 "x-api-key": key,
                 "anthropic-version": "2023-06-01",
+                "anthropic-beta": ANTHROPIC_BETAS,
                 "content-type": "application/json",
             },
             {
                 "model": model,
                 "max_tokens": ANTHROPIC_MAX_TOKENS,
+                # See read_anthropic_stream: streaming is what keeps a large
+                # max_tokens inside the request timeout.
+                "stream": True,
                 # Adaptive thinking is the current on-mode; a fixed thinking
                 # budget (budget_tokens) is rejected by current models.
                 "thinking": {"type": "adaptive"},
                 # `format` gives the same guaranteed-JSON contract the OpenAI
                 # branch gets from response_format, but schema-checked.
                 "output_config": {
-                    "effort": "high",
+                    "effort": ANTHROPIC_EFFORT,
                     "format": {"type": "json_schema", "schema": FINDINGS_SCHEMA},
                 },
+                # A safety classifier declining one chunk would otherwise be an
+                # unrecoverable red on a required check. "default" re-runs the
+                # declined request on the recommended fallback model,
+                # server-side, inside the same call.
+                "fallbacks": "default",
                 "system": system,
                 "messages": [{"role": "user", "content": user}],
             },
+            reader=read_anthropic_stream,
         )
-        stop = data.get("stop_reason")
         if stop in ("max_tokens", "refusal"):
             # Either one means the JSON is absent or incomplete. Raising makes
-            # it a lens error rather than a silent "no findings".
+            # it a lens error rather than a silent "no findings". A refusal here
+            # means the fallback chain also declined.
             raise RuntimeError(f"anthropic response unusable (stop_reason={stop})")
-        return "".join(
-            b.get("text", "") for b in data.get("content", []) if b.get("type") == "text"
-        )
+        return text
 
     # openai
     data = _post(
@@ -497,6 +716,14 @@ def call_model(provider, key, model, system, user):
     return content
 
 
+# Bound on how many `{` positions the brace walk will try. The walk is O(n) per
+# candidate, so unbalanced output was O(n^2) — 20k stray braces burned 4.4s per
+# lens/chunk against the job budget. A well-formed object starts at the first
+# or second brace; 200 is far past any real reply and keeps the worst case
+# comfortably sub-second.
+MAX_JSON_SCAN_STARTS = 200
+
+
 def parse_findings(text):
     """Return a list of finding dicts, or None if there is no well-formed
     findings object.
@@ -508,7 +735,23 @@ def parse_findings(text):
     """
     if not text or not text.strip():
         return None
-    for start in (i for i, c in enumerate(text) if c == "{"):
+
+    # The overwhelmingly common case: the whole reply is the object. Trying it
+    # first avoids the brace walk entirely.
+    try:
+        whole = json.loads(text.strip())
+    except json.JSONDecodeError:
+        whole = None
+    if isinstance(whole, dict) and "findings" in whole:
+        return _coerce_findings(whole["findings"])
+
+    scanned = 0
+    for start, char in enumerate(text):
+        if char != "{":
+            continue
+        scanned += 1
+        if scanned > MAX_JSON_SCAN_STARTS:
+            break
         depth = 0
         for j in range(start, len(text)):
             if text[j] == "{":
@@ -521,20 +764,25 @@ def parse_findings(text):
                     except json.JSONDecodeError:
                         break
                     if isinstance(obj, dict) and "findings" in obj:
-                        raw = obj["findings"]
-                        # `{"findings": null}` used to crash on iteration. Treat
-                        # an explicit null as "nothing found": the key is present
-                        # and says so, and failing closed here would block every
-                        # clean PR from a model that spells [] as null.
-                        if raw is None:
-                            return []
-                        if not isinstance(raw, list):
-                            return None
-                        if not all(isinstance(f, dict) for f in raw):
-                            return None  # a finding we cannot read may be a HIGH
-                        return raw
+                        return _coerce_findings(obj["findings"])
                     break
     return None
+
+
+def _coerce_findings(raw):
+    """Validate the `findings` value. None means "unreadable" → fail closed."""
+    # `{"findings": null}` used to crash on iteration. Treat an explicit null as
+    # "nothing found": the key is present and says so, and failing closed here
+    # would block every clean PR from a model that spells [] as null. This is a
+    # DELIBERATE asymmetry with the missing-severity rule below — null here is
+    # an answer, a missing severity on a reported finding is not.
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        return None
+    if not all(isinstance(f, dict) for f in raw):
+        return None  # a finding we cannot read may be a HIGH
+    return raw
 
 
 def review_chunk(provider, key, model, name, instruction, chunk, index, total):
@@ -567,13 +815,24 @@ def review_chunk(provider, key, model, name, instruction, chunk, index, total):
 
 
 def normalize_severity(value):
-    """Map a free-form severity string to high / medium / low / unknown.
+    """Map a severity to high / medium / low / unknown.
 
     The old code compared the raw string to "high" exactly, so "critical",
     "blocker", "High severity" and "HIGH " all sailed through the gate.
+
+    Unreadable input — the key absent (MISSING), null, or a string with no
+    letters in it — normalizes to "high" and BLOCKS. A model that reports a
+    defect without a severity we can read has not told us the finding is safe
+    to merge, and the whole contract of this script is that unreadable means
+    blocked. Only a non-empty, readable string that matches no alias falls
+    through to "unknown", which warns.
     """
-    cleaned = re.sub(r"[^a-z]+", " ", str(value or "").lower()).strip()
-    first = cleaned.split(" ")[0] if cleaned else ""
+    if value is MISSING or value is None:
+        return "high"
+    cleaned = re.sub(r"[^a-z]+", " ", str(value).lower()).strip()
+    if not cleaned:
+        return "high"
+    first = cleaned.split(" ")[0]
     if first.startswith("high") or first in BLOCKING_ALIASES:
         return "high"
     if first in MEDIUM_ALIASES:
@@ -581,6 +840,18 @@ def normalize_severity(value):
     if first in LOW_ALIASES:
         return "low"
     return "unknown"
+
+
+def finding_severity(finding):
+    return normalize_severity(finding.get("severity", MISSING))
+
+
+def has_unreadable_severity(finding):
+    """True when the finding blocked because we could not read its severity."""
+    value = finding.get("severity", MISSING)
+    if value is MISSING or value is None:
+        return True
+    return not re.sub(r"[^a-z]+", " ", str(value).lower()).strip()
 
 
 SEV_ORDER = {"high": 0, "medium": 1, "low": 2, "unknown": 3}
@@ -608,7 +879,7 @@ def render_markdown(audit, all_findings):
     run used to record nothing at all about what had actually been reviewed.
     """
     for f in all_findings:
-        f["severity_norm"] = normalize_severity(f.get("severity"))
+        f["severity_norm"] = finding_severity(f)
     all_findings.sort(key=lambda f: SEV_ORDER.get(f["severity_norm"], 3))
     highs = [f for f in all_findings if f["severity_norm"] == "high"]
 
@@ -629,9 +900,10 @@ def render_markdown(audit, all_findings):
         loc = str(f.get("file", "?"))
         if f.get("line"):
             loc += f":{f['line']}"
+        note = " _(no readable severity — treated as blocking)_" if has_unreadable_severity(f) else ""
         lines.append(
             f"- {icon.get(sev, '⚪')} **{sev.upper()}** [{f.get('lens')}] "
-            f"`{loc}` — **{str(f.get('title', '')).strip()}**  \n  "
+            f"`{loc}` — **{str(f.get('title', '')).strip()}**{note}  \n  "
             f"{str(f.get('detail', '')).strip()}"
         )
     return "\n".join(lines), highs
@@ -681,6 +953,19 @@ def emit_summary(body):
             fh.write(body + "\n")
 
 
+def publish(body):
+    """Every terminal path records the same body in both places.
+
+    The error path used to emit_summary() only, so the most confusing red the
+    gate can produce (nothing wrong with the diff — the reviewer could not run)
+    left no comment at all, while a stale green "✅ No findings" comment stayed
+    visible contradicting the red check.
+    """
+    post_sticky_comment(body)
+    emit_summary(body)
+    print(body)
+
+
 # ------------------------------------------------------------------------ main
 
 
@@ -709,7 +994,36 @@ def review(provider, key, model, chunks, workers):
     return findings, errors, len(jobs)
 
 
+def build_audit(rng, diff, chunks, budget, oversized, hard_split, provider, model):
+    files = len(_FILE_START_RE.findall(diff))
+    audit = (
+        f"_Reviewed `{rng.spec}` ({rng.describe()}) — {files} file(s), "
+        f"{len(diff)} chars, {len(chunks)} chunk(s) of <= {budget}; every lens read "
+        f"100% of that diff, 0 chars dropped · {provider} ({model}) · "
+        f"{len(LENSES)} lenses._"
+    )
+    if oversized:
+        audit += (
+            f"\n\n> ⚠️ Larger than the {budget}-char chunk budget, so split "
+            f"across chunks with the file re-identified on each continuation: "
+            f"`{'`, `'.join(sorted(set(oversized)))}`. Fully reviewed."
+        )
+        if hard_split:
+            audit += (
+                f" Splits land on hunk/line boundaries EXCEPT in "
+                f"`{'`, `'.join(sorted(set(hard_split)))}`, where a single line "
+                "exceeded the budget and was cut mid-line — those lenses saw a "
+                "partial line."
+            )
+        else:
+            audit += " Splits land on hunk/line boundaries; no lens saw a partial line."
+    return audit
+
+
 def main():
+    global _DEADLINE
+    _DEADLINE = time.monotonic() + REVIEW_BUDGET_S
+
     provider, key = provider_and_key()
     if not provider:
         print("::error::no review key set (need ANTHROPIC_API_KEY or OPENAI_KEY).")
@@ -718,10 +1032,10 @@ def main():
 
     try:
         budget = int(os.environ.get("MAX_CHUNK_CHARS") or DEFAULT_CHUNK_CHARS)
-        workers = int(os.environ.get("ADVERSARIAL_WORKERS") or 4)
+        workers = int(os.environ.get("ADVERSARIAL_WORKERS") or DEFAULT_WORKERS)
         rng = resolve_range()
-        diff = get_diff(rng)
-        chunks, oversized = chunk_diff(diff, budget)
+        diff = get_diff(rng.spec)
+        chunks, oversized, hard_split = chunk_diff(diff, budget)
         # Coverage is the whole point of chunking. Assert it before spending a
         # single API call, and fail closed if the split ever loses a character.
         # Note this sums .text only: synthetic continuation context is shown to
@@ -739,36 +1053,25 @@ def main():
         print(f"::error::invalid numeric configuration: {e}")
         return 1
 
-    files = diff.count("diff --git ")
-    audit = (
-        f"_Reviewed `{rng}` — {files} file(s), {len(diff)} chars, "
-        f"{len(chunks)} chunk(s) of <= {budget}, 100% covered, "
-        f"0 dropped · {provider} ({model}) · {len(LENSES)} lenses._"
+    audit = build_audit(
+        rng, diff, chunks, budget, oversized, hard_split, provider, model
     )
-    if oversized:
-        audit += (
-            f"\n\n> ⚠️ Larger than the {budget}-char chunk budget, so split "
-            f"across chunks at hunk/line boundaries with the file re-identified "
-            f"on each continuation: `{'`, `'.join(sorted(set(oversized)))}`. "
-            "Fully reviewed; no lens sees a partial line."
-        )
     print(audit)
 
     if not diff.strip():
         # get_diff already asserted the range is genuinely empty.
-        body = "\n".join(
-            [
-                MARKER,
-                "## 🛡️ Adversarial review",
-                "",
-                "✅ Empty diff — nothing to review.",
-                "",
-                audit,
-            ]
+        publish(
+            "\n".join(
+                [
+                    MARKER,
+                    "## 🛡️ Adversarial review",
+                    "",
+                    "✅ Empty diff — nothing to review.",
+                    "",
+                    audit,
+                ]
+            )
         )
-        post_sticky_comment(body)
-        emit_summary(body)
-        print(body)
         return 0
 
     findings, errors, calls = review(provider, key, model, chunks, workers)
@@ -781,24 +1084,39 @@ def main():
             f"::error::{errors} of {calls} lens/chunk reviews failed to produce a "
             "readable result; failing closed."
         )
-        emit_summary(
-            f"{MARKER}\n## 🛡️ Adversarial review\n\n"
-            f"❌ **Blocked** — {errors} of {calls} lens/chunk reviews failed.\n\n"
-            f"{audit}\n"
+        publish(
+            "\n".join(
+                [
+                    MARKER,
+                    "## 🛡️ Adversarial review",
+                    "",
+                    f"❌ **Blocked** — {errors} of {calls} lens/chunk reviews failed "
+                    "to produce a readable result, so the diff was not fully "
+                    "reviewed. Nothing here says the diff is wrong; the reviewer "
+                    "could not run. See the job log for the per-lens "
+                    "`::warning::` lines.",
+                    "",
+                    audit,
+                ]
+            )
         )
         return 1
 
     findings = dedupe(findings)
     body, highs = render_markdown(audit, findings)
-    post_sticky_comment(body)
-    emit_summary(body)
-    print(body)
+    publish(body)
 
     unknown = [f for f in findings if f["severity_norm"] == "unknown"]
     if unknown:
         print(
             f"::warning::{len(unknown)} finding(s) had an unrecognized severity "
             f"and did not block: {sorted({str(f.get('severity')) for f in unknown})}"
+        )
+    unreadable = [f for f in highs if has_unreadable_severity(f)]
+    if unreadable:
+        print(
+            f"::error::{len(unreadable)} finding(s) had no readable severity and "
+            "were treated as blocking."
         )
     if highs:
         print(f"::error::{len(highs)} blocking-severity finding(s) block the merge.")

--- a/.github/scripts/adversarial_review.py
+++ b/.github/scripts/adversarial_review.py
@@ -42,6 +42,7 @@ import time
 import urllib.request
 import urllib.error
 from concurrent.futures import ThreadPoolExecutor
+from typing import NamedTuple
 
 ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
 OPENAI_URL = "https://api.openai.com/v1/chat/completions"
@@ -281,20 +282,97 @@ def _segment_path(segment):
     return m.group(1) if m else "<unknown>"
 
 
+class Chunk(NamedTuple):
+    """One unit of review.
+
+    `text` is raw diff content and is what the coverage assertion sums over.
+    `context` is a synthetic prefix shown to the model only — it re-establishes
+    the file a continuation piece belongs to and is deliberately NOT part of the
+    coverage arithmetic.
+    """
+
+    text: str
+    context: str = ""
+
+    def prompt(self):
+        return self.context + self.text
+
+
+_HUNK_RE = re.compile(r"^@@ ", re.M)
+
+
+def _split_on_lines(text, budget):
+    """Partition text into <=budget pieces, breaking at line boundaries.
+
+    A single line longer than the budget (a minified bundle, say) is still hard
+    split — there is no smaller boundary to use.
+
+    Guarantee: "".join(result) == text.
+    """
+    pieces, current = [], ""
+    for line in text.splitlines(keepends=True):
+        if len(line) > budget:
+            if current:
+                pieces.append(current)
+                current = ""
+            for i in range(0, len(line), budget):
+                pieces.append(line[i : i + budget])
+            continue
+        if current and len(current) + len(line) > budget:
+            pieces.append(current)
+            current = ""
+        current += line
+    if current:
+        pieces.append(current)
+    return pieces
+
+
+def _split_file_segment(segment, budget):
+    """Split one oversized file diff at hunk boundaries, then line boundaries.
+
+    Guarantee: "".join(result) == segment.
+    """
+    starts = [m.start() for m in _HUNK_RE.finditer(segment)]
+    if starts:
+        blocks = [segment[: starts[0]]] if starts[0] > 0 else []
+        for i, start in enumerate(starts):
+            end = starts[i + 1] if i + 1 < len(starts) else len(segment)
+            blocks.append(segment[start:end])
+    else:
+        blocks = [segment]
+
+    atoms = []
+    for block in blocks:
+        atoms.extend([block] if len(block) <= budget else _split_on_lines(block, budget))
+
+    pieces, current = [], ""
+    for atom in atoms:
+        if current and len(current) + len(atom) > budget:
+            pieces.append(current)
+            current = ""
+        current += atom
+    if current:
+        pieces.append(current)
+    return pieces
+
+
 def chunk_diff(diff, budget):
     """Pack per-file segments into chunks of at most `budget` characters.
 
     Returns (chunks, oversized_files).
 
-    A single file larger than the budget is HARD-SPLIT into budget-sized pieces
-    rather than truncated or rejected. Rationale: truncating would silently drop
-    review coverage (the exact bug this change exists to fix), and rejecting
-    would block legitimate large-file PRs — generated files, lockfiles, vendored
-    sources — on day one. Splitting keeps coverage at 100%; the cost is that the
-    later pieces of such a file reach the model without their `diff --git`
-    header, so those files are named in the audit trail.
+    A single file larger than the budget is SPLIT rather than truncated or
+    rejected. Truncating would silently drop review coverage (the exact bug this
+    change exists to fix), and rejecting would block legitimate large-file PRs —
+    generated files, lockfiles, vendored sources — on day one.
 
-    Guarantee: "".join(chunks) == diff, for any budget >= MIN_CHUNK_CHARS.
+    Splits land on hunk boundaries where possible and line boundaries otherwise,
+    so a chunk never starts mid-line, and every continuation piece carries a
+    synthetic `context` naming the file it belongs to. Those two properties keep
+    a split file reviewable: without them the model cannot attribute hunks to a
+    path and invents findings from the missing context.
+
+    Guarantee: "".join(c.text for c in chunks) == diff, for budget >= MIN_CHUNK_CHARS.
     """
     if budget < MIN_CHUNK_CHARS:
         raise ReviewError(
@@ -305,18 +383,30 @@ def chunk_diff(diff, budget):
     for segment in split_into_files(diff):
         if len(segment) > budget:
             if current:
-                chunks.append(current)
+                chunks.append(Chunk(current))
                 current = ""
-            oversized.append(_segment_path(segment))
-            for i in range(0, len(segment), budget):
-                chunks.append(segment[i : i + budget])
+            path = _segment_path(segment)
+            oversized.append(path)
+            pieces = _split_file_segment(segment, budget)
+            for n, piece in enumerate(pieces, start=1):
+                context = (
+                    ""
+                    if n == 1
+                    else (
+                        f"# Continuation of the unified diff for `{path}` "
+                        f"(part {n} of {len(pieces)}). The `diff --git` header and "
+                        f"earlier hunks for this file are in previous chunks; every "
+                        f"line below belongs to this file.\n"
+                    )
+                )
+                chunks.append(Chunk(piece, context))
             continue
         if current and len(current) + len(segment) > budget:
-            chunks.append(current)
+            chunks.append(Chunk(current))
             current = ""
         current += segment
     if current:
-        chunks.append(current)
+        chunks.append(Chunk(current))
     return chunks, oversized
 
 
@@ -453,7 +543,7 @@ def review_chunk(provider, key, model, name, instruction, chunk, index, total):
     user = (
         f"{instruction}\n\n{CHUNK_HINT.format(i=index, n=total)}\n\n"
         f"Review this unified diff. {SCHEMA_HINT}\n\n"
-        f"```diff\n{chunk}\n```"
+        f"```diff\n{chunk.prompt()}\n```"
     )
     try:
         raw = call_model(
@@ -634,10 +724,13 @@ def main():
         chunks, oversized = chunk_diff(diff, budget)
         # Coverage is the whole point of chunking. Assert it before spending a
         # single API call, and fail closed if the split ever loses a character.
-        if "".join(chunks) != diff:
+        # Note this sums .text only: synthetic continuation context is shown to
+        # the model but must never count toward coverage.
+        if "".join(c.text for c in chunks) != diff:
             raise ReviewError(
                 "internal error: chunking did not cover the diff exactly "
-                f"({sum(len(c) for c in chunks)} of {len(diff)} chars); failing closed."
+                f"({sum(len(c.text) for c in chunks)} of {len(diff)} chars); "
+                "failing closed."
             )
     except ReviewError as e:
         print(f"::error::{e}")
@@ -654,10 +747,10 @@ def main():
     )
     if oversized:
         audit += (
-            f"\n\n> ⚠️ Hard-split across chunk boundaries (larger than the "
-            f"{budget}-char budget): `{'`, `'.join(sorted(set(oversized)))}`. "
-            "Fully reviewed, but later pieces reach the model without their "
-            "file header."
+            f"\n\n> ⚠️ Larger than the {budget}-char chunk budget, so split "
+            f"across chunks at hunk/line boundaries with the file re-identified "
+            f"on each continuation: `{'`, `'.join(sorted(set(oversized)))}`. "
+            "Fully reviewed; no lens sees a partial line."
         )
     print(audit)
 

--- a/.github/scripts/adversarial_review.py
+++ b/.github/scripts/adversarial_review.py
@@ -12,10 +12,15 @@ failure, a malformed SHA, an unresolvable merge base, a lens API error, a model
 reply we cannot parse, a finding whose severity is missing or unreadable, or a
 diff we could not fully cover.
 
-The ONE deliberate carve-out: a finding whose severity is a NON-EMPTY string
-that matches no known alias ("spicy") warns instead of blocking — that is a
-readable answer we merely do not recognise, and blocking on it would let a
-typo wedge the queue. A missing, null, or empty severity is unreadable input
+SEVERITY is matched per TOKEN, at every position, blocking level first: "high",
+"very high", "severity: high", "medium-high", "critical", "P0", "urgent" and a
+missing / null / letterless severity all block. See BLOCKING_ALIASES for the
+full surface and for what is deliberately left out.
+
+The ONE deliberate carve-out: a finding whose severity is a readable string in
+which NO token names a level ("spicy", "bug") warns instead of blocking — that
+is an answer we merely do not recognise, and blocking on it would let a typo
+wedge the queue. A missing, null, or letterless severity is unreadable input
 and blocks, like every other unreadable reply.
 
 RANGE. The reviewed range is always `merge-base(base, head)..head`. The event's
@@ -46,6 +51,7 @@ Env:
   MAX_CHUNK_CHARS     per-chunk character budget (default 200000)
 """
 
+import http.client
 import json
 import os
 import random
@@ -93,22 +99,53 @@ REQUEST_ATTEMPTS = 4
 # Token-rate limits reset over roughly a minute, so 2s/4s could never clear
 # one: every attempt landed inside the same window and the 429 became a lens
 # error, i.e. a repo-wide block. 8/16/32 (+jitter) spans a rate-limit window.
-# A server-supplied retry-after / x-ratelimit-reset-* always wins over this.
+#
+# This is a FLOOR, not a default. A server hint can only ever make the wait
+# LONGER (see _post). Treating the hint as a replacement was a live wedge: the
+# providers attach x-ratelimit-reset-* to essentially every response, healthy
+# buckets read "0s", and `hint if hint is not None else floor` therefore
+# collapsed the whole backoff to zero on any 5xx — four attempts in
+# milliseconds, then a lens error, then a red required check on every PR.
 RETRY_BACKOFF_S = 8
-RETRY_MAX_SLEEP_S = 60
-RETRY_STATUS = {408, 409, 429, 500, 502, 503, 504}
+# Seconds of budget held back so the run can still report a legible error
+# instead of being killed by the job's timeout-minutes.
+RETRY_BUDGET_MARGIN_S = 5
+# 529 is Anthropic's documented overloaded_error and is retryable; treating it
+# as permanent would make provider overload an instant repo-wide block. 522/524
+# are Cloudflare connection/origin timeouts and are equally transient.
+RETRY_STATUS = {408, 409, 429, 500, 502, 503, 504, 522, 524, 529}
 
 # Wall-clock budget for the whole review. Kept under the job's timeout-minutes
 # so an overloaded provider produces a legible "budget exhausted" error instead
 # of the runner killing the job, and so retries can never outlive the job.
 REVIEW_BUDGET_S = 20 * 60
 
-# Severity strings that block the merge, after normalization. "major" is a
+# Severity tokens that block the merge, after normalization. "major" is a
 # mainstream severity word — leaving it out was the last fail-open hole: a
 # model reporting a real defect as `"severity": "major"` exited 0.
-BLOCKING_ALIASES = {"critical", "blocker", "block", "major", "severe", "fatal"}
+#
+# The rest are the top-of-ladder vocabulary a model reaches for when it ignores
+# the high|medium|low enum: incident grades (p0/p1/sev0/sev1/s0/s1), the
+# Microsoft/Red Hat ladder (critical > important > moderate > low, so
+# "important" outranks the already-medium "moderate"), the log-level ladder
+# (error > warning, and "warning" is already medium here), and plain English
+# maxima. Each one is a REPORTED defect the model graded at the top of whatever
+# scale it used; letting it exit 0 is the same fail-open as "major" was.
+#
+# Deliberately NOT blocking: "bug", "defect", "issue", "regression" — those name
+# a KIND of finding, not its grade, and a low-severity bug is still a bug. They
+# fall through to "unknown" and warn.
+BLOCKING_ALIASES = {
+    "critical", "blocker", "block", "blocking", "major", "severe", "fatal",
+    "urgent", "showstopper", "breaking", "serious", "important", "error",
+    "mustfix", "p0", "p1", "sev0", "sev1", "s0", "s1",
+}
 MEDIUM_ALIASES = {"medium", "med", "moderate", "warning", "warn"}
 LOW_ALIASES = {"low", "minor", "info", "informational", "nit", "nitpick", "trivial"}
+# A blocking token immediately after one of these is negated, so "low
+# (non-blocking)" stays low instead of wedging the queue on the word it used to
+# say it is safe.
+NEGATIONS = {"no", "not", "non", "never"}
 
 # Sentinel for "the key was absent", which is different from "the value was a
 # string we do not recognise". Absent is unreadable input → blocks.
@@ -209,6 +246,32 @@ FINDINGS_SCHEMA = {
 
 class ReviewError(Exception):
     """Anything that makes a green verdict unsafe. Always exits non-zero."""
+
+
+class TransientError(RuntimeError):
+    """A provider-side failure worth retrying that arrives inside a 200 body.
+
+    A streamed response can report `overloaded_error` as an SSE event rather
+    than an HTTP status, so status-code matching alone would treat provider
+    overload as permanent.
+    """
+
+
+# Retried in _post. Deliberately narrow: urllib.error.URLError, socket timeouts
+# and connection resets are all OSError; RemoteDisconnected/IncompleteRead are
+# http.client.HTTPException. A JSONDecodeError (ValueError) from the reader is
+# NOT here — a malformed body is deterministic, and retrying it four times only
+# burns budget the next rate limit will need.
+RETRYABLE_ERRORS = (OSError, http.client.HTTPException, TransientError)
+
+# Anthropic stream `error` event types that are worth another attempt. Anything
+# else (invalid_request_error, authentication_error, …) is permanent.
+TRANSIENT_STREAM_ERRORS = {
+    "overloaded_error",
+    "api_error",
+    "rate_limit_error",
+    "timeout_error",
+}
 
 
 # ------------------------------------------------------------------- deadline
@@ -549,12 +612,31 @@ def parse_duration(value):
     return sum(float(n) * _DURATION_UNITS[u] for n, u in parts)
 
 
+def parse_millis(value):
+    """Parse retry-after-ms ('1500' → 1.5s). None if unparseable."""
+    text = (value or "").strip()
+    if not text:
+        return None
+    try:
+        return float(text) / 1000.0
+    except ValueError:
+        return None
+
+
 def retry_delay_from(headers):
-    """Server-directed retry delay in seconds, or None.
+    """Longest server-directed retry delay in seconds, or None.
 
     A token-rate 429 is answered by the provider with the time until the window
     resets. Ignoring it and guessing a backoff is how a transient rate limit
     became a repo-wide block.
+
+    Takes the MAX of every parseable hint, not the first. The classic RPM-429
+    carries `{reset-tokens: "0s", reset-requests: "45s"}` — the token bucket is
+    fine, the request bucket is what is throttling us — and first-wins returned
+    0.0 and threw away the only number that mattered.
+
+    The value is a hint about the earliest useful retry, never a licence to
+    wait less than the exponential floor; _post takes the max of the two.
     """
     if not headers:
         return None
@@ -565,11 +647,11 @@ def retry_delay_from(headers):
         except AttributeError:
             return None
 
+    delays = [parse_millis(get("retry-after-ms"))]  # OpenAI's ms spelling
     for name in ("retry-after", "x-ratelimit-reset-tokens", "x-ratelimit-reset-requests"):
-        seconds = parse_duration(get(name))
-        if seconds is not None:
-            return max(0.0, seconds)
-    return None
+        delays.append(parse_duration(get(name)))
+    known = [max(0.0, d) for d in delays if d is not None]
+    return max(known) if known else None
 
 
 def _json_reader(resp):
@@ -580,10 +662,24 @@ def _post(url, headers, payload, reader=_json_reader):
     """POST JSON with bounded retries on transient failures.
 
     Retries matter for fail-closed correctness: a lens error now blocks the
-    merge, so a 429 that is not survived is a repo-wide outage. The backoff
-    spans a rate-limit window and always defers to a server-supplied
-    retry-after. Every wait is checked against the review budget so retries can
-    never outlive the job and turn a slow provider into a timeout kill.
+    merge, so a 429 that is not survived is a repo-wide outage.
+
+    The wait is `max(server hint, exponential floor)`, bounded only by what is
+    left of the review budget:
+
+      * MAX, not "hint wins" — the hint is 0s whenever the bucket is healthy,
+        which is most of the time, and letting it win collapsed the backoff to
+        nothing on any transient 5xx.
+      * MAX, not "floor wins" — a real `retry-after: 300` is the provider
+        telling us the window is five minutes; retrying sooner is a guaranteed
+        second failure.
+      * bounded by the BUDGET, not by a 60s constant — clamping a 6-minute
+        window down to 60s spent three attempts inside the same window and
+        gave up with most of the budget unused.
+
+    Only transient transport failures are retried. A malformed body
+    (JSONDecodeError from the reader) is deterministic: retrying it four times
+    just burns the budget that a genuine rate limit needs.
     """
     body = json.dumps(payload).encode()
     last = None
@@ -606,16 +702,19 @@ def _post(url, headers, payload, reader=_json_reader):
             if e.code not in RETRY_STATUS:
                 raise last from e
             server_delay = retry_delay_from(getattr(e, "headers", None))
-        except Exception as e:  # noqa: BLE001
+        except RETRYABLE_ERRORS as e:
+            # Connection reset, DNS, read timeout, half-closed socket, and the
+            # provider-side stream error events classified as transient.
             last = e
             server_delay = None
         if attempt + 1 >= REQUEST_ATTEMPTS:
             break
-        delay = server_delay if server_delay is not None else RETRY_BACKOFF_S * (2**attempt)
-        delay = min(delay, RETRY_MAX_SLEEP_S) + random.uniform(0, 1)
-        if delay >= _time_left():
-            break
-        time.sleep(delay)
+        delay = max(server_delay or 0.0, RETRY_BACKOFF_S * (2**attempt))
+        delay += random.uniform(0, 1)
+        room = _time_left() - RETRY_BUDGET_MARGIN_S
+        if room <= 0:
+            break  # no room to wait AND still report; fail legibly instead
+        time.sleep(min(delay, room))
     raise last
 
 
@@ -648,7 +747,10 @@ def read_anthropic_stream(resp):
         elif etype == "message_delta":
             stop = (event.get("delta") or {}).get("stop_reason") or stop
         elif etype == "error":
-            raise RuntimeError(f"anthropic stream error: {event.get('error')}")
+            err = event.get("error") or {}
+            kind = str(err.get("type") or "") if isinstance(err, dict) else ""
+            exc = TransientError if kind in TRANSIENT_STREAM_ERRORS else RuntimeError
+            raise exc(f"anthropic stream error: {err}")
     return "".join(text), stop
 
 
@@ -814,30 +916,64 @@ def review_chunk(provider, key, model, name, instruction, chunk, index, total):
 # ------------------------------------------------------------------- severity
 
 
+def _severity_tokens(value):
+    """Lowercase alphanumeric tokens of a severity value.
+
+    Digits are KEPT so incident grades survive tokenizing: stripping them
+    turned "p0" into "p" and "sev1" into "sev", which matched nothing.
+    """
+    return re.sub(r"[^a-z0-9]+", " ", str(value).lower()).split()
+
+
+def _is_readable_severity(value):
+    """A severity we can even attempt to read: present, and has letters in it.
+
+    "", "   ", "!!!" and "123" carry no level at all — that is unreadable
+    input, which fails closed, not an unrecognized word, which warns.
+    """
+    if value is MISSING or value is None:
+        return False
+    return bool(re.search(r"[a-z]", str(value).lower()))
+
+
 def normalize_severity(value):
     """Map a severity to high / medium / low / unknown.
 
     The old code compared the raw string to "high" exactly, so "critical",
-    "blocker", "High severity" and "HIGH " all sailed through the gate.
+    "blocker", "High severity" and "HIGH " all sailed through the gate. The
+    first fix only looked at the FIRST token, which still let a reported
+    finding graded "very high", "severity: high" or "P0" exit 0.
+
+    EVERY token is scanned now, blocking level first, so any position of a
+    top-of-ladder word blocks: "very high", "medium-high" and "high, but easy
+    to fix" all resolve to high. When a value carries two levels the higher one
+    wins — the fail-closed direction. The one exception is negation: a blocking
+    token directly after "no"/"not"/"non"/"never" is not a grade, so
+    "low (non-blocking)" stays low.
 
     Unreadable input — the key absent (MISSING), null, or a string with no
     letters in it — normalizes to "high" and BLOCKS. A model that reports a
     defect without a severity we can read has not told us the finding is safe
     to merge, and the whole contract of this script is that unreadable means
-    blocked. Only a non-empty, readable string that matches no alias falls
-    through to "unknown", which warns.
+    blocked. Only a non-empty, readable string in which NO token names a level
+    falls through to "unknown", which warns instead of blocking, so that one
+    unrecognized word cannot wedge every merge in the repo.
     """
-    if value is MISSING or value is None:
+    if not _is_readable_severity(value):
         return "high"
-    cleaned = re.sub(r"[^a-z]+", " ", str(value).lower()).strip()
-    if not cleaned:
+    tokens = _severity_tokens(value)
+    for i, token in enumerate(tokens):
+        if i and tokens[i - 1] in NEGATIONS:
+            continue
+        if token.startswith("high") or token in BLOCKING_ALIASES:
+            return "high"
+    # Hyphenated/spaced spellings of a single alias ("must-fix", "show stopper")
+    # tokenize into halves that match nothing on their own.
+    if "".join(tokens) in BLOCKING_ALIASES:
         return "high"
-    first = cleaned.split(" ")[0]
-    if first.startswith("high") or first in BLOCKING_ALIASES:
-        return "high"
-    if first in MEDIUM_ALIASES:
+    if any(t in MEDIUM_ALIASES for t in tokens):
         return "medium"
-    if first in LOW_ALIASES:
+    if any(t in LOW_ALIASES for t in tokens):
         return "low"
     return "unknown"
 
@@ -848,10 +984,7 @@ def finding_severity(finding):
 
 def has_unreadable_severity(finding):
     """True when the finding blocked because we could not read its severity."""
-    value = finding.get("severity", MISSING)
-    if value is MISSING or value is None:
-        return True
-    return not re.sub(r"[^a-z]+", " ", str(value).lower()).strip()
+    return not _is_readable_severity(finding.get("severity", MISSING))
 
 
 SEV_ORDER = {"high": 0, "medium": 1, "low": 2, "unknown": 3}
@@ -994,13 +1127,28 @@ def review(provider, key, model, chunks, workers):
     return findings, errors, len(jobs)
 
 
-def build_audit(rng, diff, chunks, budget, oversized, hard_split, provider, model):
+def build_audit(
+    rng, diff, chunks, budget, oversized, hard_split, provider, model, reviewed=True
+):
+    """Render the forensic line.
+
+    `reviewed=False` is the lens-failure path. The coverage clause used to be
+    unconditional, so the most confusing red the gate produces said "the diff
+    was not fully reviewed" and then, two lines later, "every lens read 100% of
+    that diff" — a false record on exactly the run an operator has to trust.
+    Chunk coverage and review coverage are different claims; only the first one
+    holds when a lens fails.
+    """
     files = len(_FILE_START_RE.findall(diff))
+    coverage = (
+        "every lens read 100% of that diff, 0 chars dropped"
+        if reviewed
+        else "0 chars dropped by chunking, but the lens reviews above did not complete"
+    )
     audit = (
         f"_Reviewed `{rng.spec}` ({rng.describe()}) — {files} file(s), "
-        f"{len(diff)} chars, {len(chunks)} chunk(s) of <= {budget}; every lens read "
-        f"100% of that diff, 0 chars dropped · {provider} ({model}) · "
-        f"{len(LENSES)} lenses._"
+        f"{len(diff)} chars, {len(chunks)} chunk(s) of <= {budget}; {coverage}"
+        f" · {provider} ({model}) · {len(LENSES)} lenses._"
     )
     if oversized:
         audit += (
@@ -1053,9 +1201,12 @@ def main():
         print(f"::error::invalid numeric configuration: {e}")
         return 1
 
-    audit = build_audit(
-        rng, diff, chunks, budget, oversized, hard_split, provider, model
-    )
+    def audit_for(reviewed=True):
+        return build_audit(
+            rng, diff, chunks, budget, oversized, hard_split, provider, model, reviewed
+        )
+
+    audit = audit_for()
     print(audit)
 
     if not diff.strip():
@@ -1096,7 +1247,7 @@ def main():
                     "could not run. See the job log for the per-lens "
                     "`::warning::` lines.",
                     "",
-                    audit,
+                    audit_for(reviewed=False),
                 ]
             )
         )

--- a/.github/scripts/test_adversarial_review.py
+++ b/.github/scripts/test_adversarial_review.py
@@ -154,6 +154,48 @@ def test_blocking_severities(value):
     assert ar.normalize_severity(value) == "high"
 
 
+@pytest.mark.parametrize(
+    "value",
+    ["very high", "severity: high", "Severity: HIGH", "medium-high", "high/critical",
+     "quite serious", "1 - critical"],
+)
+def test_severity_is_matched_at_every_token_not_just_the_first(value):
+    """Scanning only the first token meant "High severity" blocked but "very
+    high" did not: it normalized to unknown and exited 0 on a REPORTED finding.
+    Two levels in one string resolve to the higher — the fail-closed direction."""
+    assert ar.normalize_severity(value) == "high"
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["urgent", "P0", "p1", "sev0", "S1", "must-fix", "showstopper", "breaking",
+     "important", "serious", "error", "blocking"],
+)
+def test_top_of_ladder_vocabulary_blocks(value):
+    """Documented decision (see BLOCKING_ALIASES): a model that ignores the
+    high|medium|low enum and grades a REPORTED defect at the top of some other
+    scale has not said the diff is safe to merge."""
+    assert ar.normalize_severity(value) == "high"
+
+
+@pytest.mark.parametrize("value", ["bug", "defect", "issue", "regression", "spicy"])
+def test_kind_words_are_not_grades_and_only_warn(value):
+    """The other half of that decision, stated so the hole is explicit: these
+    name what a finding IS, not how bad it is, so they warn rather than block."""
+    assert ar.normalize_severity(value) == "unknown"
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [("low (non-blocking)", "low"), ("medium, not critical", "medium"),
+     ("not high", "unknown")],
+)
+def test_a_negated_blocking_word_is_not_a_blocking_grade(value, expected):
+    """"low (non-blocking)" is the model saying it is SAFE. Blocking on the
+    substring would wedge the queue on the very words that mean the opposite."""
+    assert ar.normalize_severity(value) == expected
+
+
 @pytest.mark.parametrize("value", [ar.MISSING, None, "", "   ", "!!!", "123"])
 def test_unreadable_severity_blocks(value):
     """An omitted or unreadable severity is unreadable INPUT, and unreadable
@@ -194,18 +236,25 @@ def test_parse_duration(raw, expected):
     assert ar.parse_duration(raw) == pytest.approx(expected)
 
 
-def test_retry_delay_prefers_server_headers():
+def test_retry_after_ms_is_milliseconds_not_seconds():
+    """OpenAI's preferred spelling on some 429s. Reading '1500' as 1500 SECONDS
+    would blow the whole review budget on one retry."""
+    assert ar.retry_delay_from({"retry-after-ms": "1500"}) == 1.5
+
+
+def test_retry_delay_takes_the_max_of_the_headers():
+    """The classic RPM-429 shape. First-wins returned 0.0 from the healthy token
+    bucket and threw away the 45s that was actually throttling us."""
     assert ar.retry_delay_from({"retry-after": "45"}) == 45.0
     assert ar.retry_delay_from({"x-ratelimit-reset-tokens": "6m0s"}) == 360.0
+    assert (
+        ar.retry_delay_from(
+            {"x-ratelimit-reset-tokens": "0s", "x-ratelimit-reset-requests": "45s"}
+        )
+        == 45.0
+    )
     assert ar.retry_delay_from({}) is None
     assert ar.retry_delay_from(None) is None
-
-
-def test_backoff_spans_a_rate_limit_window():
-    """2s/4s could never outlast a token-per-minute window, so a 429 became a
-    lens error, i.e. a repo-wide block."""
-    total = sum(ar.RETRY_BACKOFF_S * (2**i) for i in range(ar.REQUEST_ATTEMPTS - 1))
-    assert total >= 55
 
 
 class _Resp(io.BytesIO):
@@ -218,10 +267,11 @@ class _Resp(io.BytesIO):
 
 def _stub_urlopen(monkeypatch, sequence):
     """Serve `sequence` items in order: an Exception is raised, else returned."""
-    seen = {"n": 0}
+    seen = {"n": 0, "requests": []}
 
     def fake(req, timeout=None):
         seen["n"] += 1
+        seen["requests"].append(req)
         item = sequence[min(seen["n"] - 1, len(sequence) - 1)]
         if isinstance(item, Exception):
             raise item
@@ -231,10 +281,28 @@ def _stub_urlopen(monkeypatch, sequence):
     return seen
 
 
-def _http_429(retry_after):
+def _http(status, headers=None):
     return urllib.error.HTTPError(
-        "https://example/v1", 429, "Too Many Requests", {"retry-after": retry_after}, None
+        "https://example/v1", status, "err", headers or {}, None
     )
+
+
+def _http_429(retry_after):
+    return _http(429, {"retry-after": retry_after})
+
+
+def _drive_post(monkeypatch, sequence, deadline=None):
+    """Run the REAL _post against a stub transport. Returns (attempts, sleeps)."""
+    slept = []
+    monkeypatch.setattr(ar.time, "sleep", slept.append)
+    monkeypatch.setattr(ar.random, "uniform", lambda a, b: 0.0)
+    monkeypatch.setattr(ar, "_DEADLINE", time.monotonic() + (deadline or 20 * 60))
+    seen = _stub_urlopen(monkeypatch, sequence)
+    try:
+        ar._post("https://example/v1", {}, {})
+    except Exception:  # noqa: BLE001  — the caller asserts on the waits
+        pass
+    return seen["n"], slept
 
 
 def test_post_waits_the_server_supplied_retry_after(monkeypatch):
@@ -255,6 +323,56 @@ def test_post_falls_back_to_exponential_backoff_without_headers(monkeypatch):
     assert slept == [float(ar.RETRY_BACKOFF_S)]
 
 
+def test_backoff_spans_a_rate_limit_window(monkeypatch):
+    """Drives the REAL _post. The previous version of this test recomputed the
+    constants and asserted on the arithmetic, so it passed while _post itself
+    slept 0.0 three times."""
+    attempts, slept = _drive_post(monkeypatch, [_http(503)])
+    assert attempts == ar.REQUEST_ATTEMPTS
+    assert slept == [8.0, 16.0, 32.0]
+    assert sum(slept) >= 55  # a token-per-minute window
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"x-ratelimit-reset-tokens": "0s"},
+        {"x-ratelimit-reset-requests": "0s"},
+        {"x-ratelimit-reset-tokens": "6ms"},
+        {"x-ratelimit-reset-tokens": "0s", "x-ratelimit-reset-requests": "0s"},
+    ],
+)
+def test_a_healthy_rate_limit_header_does_not_collapse_the_backoff(
+    monkeypatch, headers
+):
+    """THE wedge. Providers stamp x-ratelimit-* on essentially every response and
+    a healthy bucket reads 0s. Letting the hint replace the floor burned all four
+    attempts in milliseconds on one transient 5xx, turning it into a lens error
+    and a red required check for every PR in flight."""
+    attempts, slept = _drive_post(monkeypatch, [_http(503, headers)])
+    assert attempts == ar.REQUEST_ATTEMPTS
+    assert slept == [8.0, 16.0, 32.0]
+
+
+def test_post_honours_a_retry_after_longer_than_a_minute(monkeypatch):
+    """A 60s constant ceiling spent every attempt inside a 6-minute window and
+    gave up with most of the 20-minute budget unused. The budget is the only
+    ceiling now."""
+    attempts, slept = _drive_post(
+        monkeypatch, [_http(429, {"retry-after": "300"}), b'{"ok": true}']
+    )
+    assert attempts == 2
+    assert slept == [300.0]
+
+
+def test_post_honours_a_reset_tokens_window_longer_than_a_minute(monkeypatch):
+    attempts, slept = _drive_post(
+        monkeypatch, [_http(429, {"x-ratelimit-reset-tokens": "6m0s"}), b'{"ok": true}']
+    )
+    assert attempts == 2
+    assert slept == [360.0]
+
+
 def test_post_does_not_retry_a_non_transient_status(monkeypatch):
     slept = []
     monkeypatch.setattr(ar.time, "sleep", slept.append)
@@ -262,6 +380,49 @@ def test_post_does_not_retry_a_non_transient_status(monkeypatch):
     seen = _stub_urlopen(monkeypatch, [err])
     with pytest.raises(RuntimeError):
         ar._post("https://example/v1", {}, {})
+    assert seen["n"] == 1 and slept == []
+
+
+@pytest.mark.parametrize("status", [429, 500, 502, 503, 504, 522, 524, 529])
+def test_transient_statuses_are_retried(monkeypatch, status):
+    """529 is Anthropic's documented overloaded_error. Treating it as permanent
+    made provider overload an instant repo-wide block."""
+    attempts, _ = _drive_post(monkeypatch, [_http(status)])
+    assert attempts == ar.REQUEST_ATTEMPTS
+
+
+def test_post_does_not_retry_a_malformed_body(monkeypatch):
+    """A body that will not parse is deterministic. Retrying it four times only
+    burns the budget the next real rate limit needs."""
+    attempts, slept = _drive_post(monkeypatch, [b"this is not json"])
+    assert attempts == 1 and slept == []
+
+
+def test_post_retries_a_transient_stream_error(monkeypatch):
+    """overloaded_error arrives as an SSE event inside a 200, so status matching
+    alone cannot see it."""
+    overloaded = 'data: {"type": "error", "error": {"type": "overloaded_error"}}\n\n'
+    ok = (
+        'data: {"type": "content_block_delta", "delta": '
+        '{"type": "text_delta", "text": "{\\"findings\\": []}"}}\n\n'
+    )
+    slept = []
+    monkeypatch.setattr(ar.time, "sleep", slept.append)
+    monkeypatch.setattr(ar.random, "uniform", lambda a, b: 0.0)
+    seen = _stub_urlopen(monkeypatch, [overloaded.encode(), ok.encode()])
+    text, _ = ar._post(
+        "https://example/v1", {}, {}, reader=ar.read_anthropic_stream
+    )
+    assert seen["n"] == 2 and text == '{"findings": []}'
+
+
+def test_post_does_not_retry_a_permanent_stream_error(monkeypatch):
+    body = 'data: {"type": "error", "error": {"type": "invalid_request_error"}}\n\n'
+    slept = []
+    monkeypatch.setattr(ar.time, "sleep", slept.append)
+    seen = _stub_urlopen(monkeypatch, [body.encode()])
+    with pytest.raises(RuntimeError):
+        ar._post("https://example/v1", {}, {}, reader=ar.read_anthropic_stream)
     assert seen["n"] == 1 and slept == []
 
 
@@ -276,6 +437,98 @@ def test_post_never_sleeps_past_the_review_budget(monkeypatch):
     with pytest.raises(RuntimeError):
         ar._post("https://example/v1", {}, {})
     assert slept == []
+
+
+def test_post_clamps_a_long_wait_to_the_remaining_budget(monkeypatch):
+    """With room to wait but not the full window, wait what is left rather than
+    a constant — and keep the margin that lets the job report."""
+    attempts, slept = _drive_post(
+        monkeypatch, [_http_429("300"), b'{"ok": true}'], deadline=100
+    )
+    assert attempts == 2
+    assert slept == [pytest.approx(100 - ar.RETRY_BUDGET_MARGIN_S, abs=1)]
+
+
+# ------------------------------------------------------------- request payloads
+
+
+def _sent(seen, i=0):
+    return json.loads(seen["requests"][i].data)
+
+
+def test_call_model_openai_payload_shape(monkeypatch):
+    body = json.dumps({"choices": [{"message": {"content": '{"findings": []}'}}]})
+    seen = _stub_urlopen(monkeypatch, [body.encode()])
+    out = ar.call_model("openai", "k", "gpt-4.1", "sys", "user text")
+    assert out == '{"findings": []}'
+    sent = _sent(seen)
+    assert sent["model"] == "gpt-4.1"
+    assert sent["response_format"] == {"type": "json_object"}
+    assert sent["messages"] == [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "user text"},
+    ]
+    assert seen["requests"][0].headers["Authorization"] == "Bearer k"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"choices": [{"finish_reason": "length", "message": {"content": "{"}}]},
+        {"choices": [{"message": {"content": None}}]},
+        {"choices": []},
+    ],
+)
+def test_call_model_openai_unusable_response_raises(monkeypatch, body):
+    _stub_urlopen(monkeypatch, [json.dumps(body).encode()])
+    with pytest.raises(RuntimeError):
+        ar.call_model("openai", "k", "gpt-4.1", "sys", "user")
+
+
+def test_call_model_anthropic_payload_shape(monkeypatch):
+    """The Anthropic branch has never run against the real API, so this payload
+    assertion is the only thing standing between a typo'd field name and a
+    repo-wide red the day the key is added."""
+    sse = (
+        'data: {"type": "content_block_delta", "delta": '
+        '{"type": "text_delta", "text": "{\\"findings\\": []}"}}\n\n'
+        'data: {"type": "message_delta", "delta": {"stop_reason": "end_turn"}}\n\n'
+    )
+    seen = _stub_urlopen(monkeypatch, [sse.encode()])
+    out = ar.call_model("anthropic", "sekret", "claude-opus-5", "sys", "user text")
+    assert out == '{"findings": []}'
+
+    req = seen["requests"][0]
+    assert req.full_url == ar.ANTHROPIC_URL
+    assert req.headers["X-api-key"] == "sekret"
+    assert req.headers["Anthropic-version"] == "2023-06-01"
+    assert req.headers["Anthropic-beta"] == ar.ANTHROPIC_BETAS
+
+    sent = _sent(seen)
+    assert sent["model"] == "claude-opus-5"
+    assert sent["max_tokens"] == ar.ANTHROPIC_MAX_TOKENS
+    assert ar.ANTHROPIC_MAX_TOKENS >= 32000  # thinking shares this budget
+    assert sent["stream"] is True
+    assert sent["thinking"] == {"type": "adaptive"}
+    assert sent["fallbacks"] == "default"
+    assert sent["system"] == "sys"
+    assert sent["messages"] == [{"role": "user", "content": "user text"}]
+    fmt = sent["output_config"]["format"]
+    assert fmt["type"] == "json_schema"
+    assert fmt["schema"] == ar.FINDINGS_SCHEMA
+    assert sent["output_config"]["effort"] == ar.ANTHROPIC_EFFORT
+
+
+@pytest.mark.parametrize("stop", ["max_tokens", "refusal"])
+def test_call_model_anthropic_unusable_stop_reason_raises(monkeypatch, stop):
+    sse = (
+        'data: {"type": "content_block_delta", "delta": '
+        '{"type": "text_delta", "text": "{\\"findings\\": []"}}\n\n'
+        'data: {"type": "message_delta", "delta": {"stop_reason": "%s"}}\n\n' % stop
+    )
+    _stub_urlopen(monkeypatch, [sse.encode()])
+    with pytest.raises(RuntimeError):
+        ar.call_model("anthropic", "k", "claude-opus-5", "sys", "user")
 
 
 # ----------------------------------------------------------------- SSE decoding
@@ -448,14 +701,25 @@ def test_low_finding_passes(gate):
     assert ar.main() == 0
 
 
-@pytest.mark.parametrize("severity", ["critical", "blocker", "HIGH ", "major", "urgent"])
-def test_severity_aliases_and_unknowns_at_the_exit_code(gate, severity):
-    """"major" and "urgent" used to exit 0. "major" is now an alias; "urgent"
-    is unreadable-to-us but still a REPORTED finding, so it must not silently
-    pass — it warns only if it normalizes to a known non-blocking level."""
+@pytest.mark.parametrize(
+    "severity",
+    ["critical", "blocker", "HIGH ", "major", "urgent", "very high", "P0",
+     "severity: high"],
+)
+def test_blocking_severity_aliases_at_the_exit_code(gate, severity):
+    """Every one of these exited 0 at some point in this PR's history while a
+    finding was on the table. The exit code is the gate, so assert there."""
     gate(json.dumps({"findings": [{"severity": severity, "file": "a", "title": "t"}]}))
-    rc = ar.main()
-    assert rc == (1 if severity != "urgent" else 0), severity
+    assert ar.main() == 1, severity
+
+
+@pytest.mark.parametrize("severity", ["spicy", "bug", "low (non-blocking)"])
+def test_readable_but_non_blocking_severities_pass_at_the_exit_code(gate, severity):
+    """The carve-out, asserted where it counts. A word we do not recognise is
+    not a reason to block every merge in the repo — it is logged as a
+    ::warning:: and the run stays green."""
+    gate(json.dumps({"findings": [{"severity": severity, "file": "a", "title": "t"}]}))
+    assert ar.main() == 0, severity
 
 
 def test_finding_with_no_severity_blocks(gate):
@@ -511,6 +775,19 @@ def test_error_path_posts_the_sticky_comment(gate, monkeypatch):
     assert ar.main() == 1
     assert len(posted) == 1
     assert "Blocked" in posted[0] and ar.MARKER in posted[0]
+
+
+def test_error_path_does_not_claim_the_lenses_read_the_diff(gate, monkeypatch):
+    """The comment said the diff was NOT fully reviewed and then, two lines
+    later, that "every lens read 100% of that diff". A false forensic record on
+    the one red an operator most needs to trust. Chunk coverage and review
+    coverage are different claims."""
+    posted = []
+    monkeypatch.setattr(ar, "post_sticky_comment", posted.append)
+    gate(RuntimeError("boom"))
+    assert ar.main() == 1
+    assert "every lens read 100%" not in posted[0]
+    assert "0 chars dropped by chunking" in posted[0]
 
 
 def test_no_key_blocks(gate, monkeypatch):

--- a/.github/scripts/test_adversarial_review.py
+++ b/.github/scripts/test_adversarial_review.py
@@ -1,0 +1,533 @@
+"""Tests for the adversarial-review gate.
+
+These are the invariants that, when they regress, make the gate PASS WRONGLY —
+which is undetectable by definition. Every one of them exists because the
+pre-fix script violated it and still reported green:
+
+  * chunk coverage is exact (the diff was truncated, and the audit said 100%)
+  * parse_findings returns None, not [], for anything unreadable
+  * ANY lens/chunk error fails closed (only an all-lens failure used to)
+  * severity matching is alias-aware, and an unreadable severity blocks
+  * a bad SHA / git failure is an error, never a silent substitution
+
+Run: python -m pytest .github/scripts -q
+"""
+
+import io
+import json
+import subprocess
+import urllib.error
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import adversarial_review as ar  # noqa: E402
+
+
+# --------------------------------------------------------------------- chunking
+
+
+def _diff(files):
+    """Build a syntactically real unified diff from {path: added_body}."""
+    out = []
+    for path, body in files.items():
+        out.append(
+            f"diff --git a/{path} b/{path}\n"
+            f"index 1111111..2222222 100644\n"
+            f"--- a/{path}\n+++ b/{path}\n"
+        )
+        out.append(f"@@ -1,1 +1,{max(1, body.count(chr(10)) + 1)} @@\n")
+        out.extend(f"+{line}\n" for line in body.split("\n"))
+    return "".join(out)
+
+
+@pytest.mark.parametrize("budget", [4000, 8000, 50000, 200000])
+def test_chunk_coverage_is_exact_at_every_budget(budget):
+    diff = _diff(
+        {
+            "a.ts": "const a = 1;\n" * 400,
+            "b/big.ts": "x".join(["const b = 2;"] * 3000),
+            "c.md": "# doc\n" * 50,
+        }
+    )
+    chunks, _, _ = ar.chunk_diff(diff, budget)
+    assert "".join(c.text for c in chunks) == diff
+    assert all(len(c.text) <= budget for c in chunks)
+
+
+def test_chunk_empty_diff():
+    chunks, oversized, hard = ar.chunk_diff("", ar.MIN_CHUNK_CHARS)
+    assert (chunks, oversized, hard) == ([], [], [])
+
+
+def test_chunk_single_over_budget_line_terminates_and_is_reported():
+    """A minified bundle has no line boundary to split on. It must still
+    terminate, still cover exactly, and be REPORTED as hard-split — the audit
+    line used to claim 'no lens sees a partial line' in exactly this case."""
+    diff = _diff({"dist/app.js": "z" * 300_000})
+    start = time.monotonic()
+    chunks, oversized, hard = ar.chunk_diff(diff, ar.MIN_CHUNK_CHARS)
+    assert time.monotonic() - start < 5
+    assert "".join(c.text for c in chunks) == diff
+    assert oversized == ["dist/app.js"]
+    assert hard == ["dist/app.js"]
+
+
+def test_chunk_below_minimum_budget_is_an_error():
+    with pytest.raises(ar.ReviewError):
+        ar.chunk_diff(_diff({"a.ts": "x"}), ar.MIN_CHUNK_CHARS - 1)
+
+
+def test_split_on_lines_does_not_break_on_unicode_line_separators():
+    """str.splitlines() also breaks on U+2028/U+2029/U+0085/\\x0b/\\x0c, all of
+    which are legal inside JS source. Only "\\n" is a line boundary here."""
+    text = "+const s = 'a b cd\x0be\x0cf';\n" * 3
+    pieces, hard = ar._split_on_lines(text, 4000)
+    assert "".join(pieces) == text
+    assert hard is False
+    assert all(p.endswith("\n") for p in pieces)
+
+
+def test_continuation_context_is_not_counted_as_coverage():
+    diff = _diff({"big.ts": "const q = 1;\n" * 2000})
+    chunks, _, _ = ar.chunk_diff(diff, ar.MIN_CHUNK_CHARS)
+    assert len(chunks) > 1
+    assert any(c.context for c in chunks[1:])
+    assert "".join(c.text for c in chunks) == diff  # context excluded
+    assert chunks[1].prompt().startswith("# Continuation")
+
+
+# ---------------------------------------------------------------- parse_findings
+
+
+@pytest.mark.parametrize(
+    "reply",
+    [
+        "",
+        "   ",
+        "I reviewed the diff and it looks fine to me.",
+        '{"ok": true}',
+        '{"findings": [{"severity": "high"',  # truncated mid-object
+        '{"findings": "none"}',
+        '{"findings": ["a string, not an object"]}',
+    ],
+)
+def test_unreadable_replies_are_none_not_empty(reply):
+    """None (a lens error) vs [] (a clean pass) is THE distinction. Every one of
+    these used to return [] and pass the gate."""
+    assert ar.parse_findings(reply) is None
+
+
+def test_well_formed_replies_parse():
+    assert ar.parse_findings('{"findings": []}') == []
+    assert ar.parse_findings('```json\n{"findings": []}\n```') == []
+    out = ar.parse_findings('prose {"findings": [{"severity": "high"}]} trailing')
+    assert out == [{"severity": "high"}]
+
+
+def test_explicit_null_findings_is_a_clean_pass():
+    """Deliberate asymmetry, documented in _coerce_findings: the key is present
+    and says 'nothing', so this passes rather than blocking every clean PR from
+    a model that spells [] as null."""
+    assert ar.parse_findings('{"findings": null}') == []
+
+
+def test_brace_scan_is_bounded_on_degenerate_input():
+    start = time.monotonic()
+    assert ar.parse_findings("{" * 20000) is None
+    assert time.monotonic() - start < 2
+
+
+# --------------------------------------------------------------------- severity
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["high", "HIGH ", "High severity", "critical", "CRITICAL", "blocker", "major",
+     "Major", "severe", "fatal"],
+)
+def test_blocking_severities(value):
+    assert ar.normalize_severity(value) == "high"
+
+
+@pytest.mark.parametrize("value", [ar.MISSING, None, "", "   ", "!!!", "123"])
+def test_unreadable_severity_blocks(value):
+    """An omitted or unreadable severity is unreadable INPUT, and unreadable
+    input fails closed everywhere else in this script."""
+    assert ar.normalize_severity(value) == "high"
+
+
+@pytest.mark.parametrize("value", ["medium", "moderate", "warn"])
+def test_medium_severities(value):
+    assert ar.normalize_severity(value) == "medium"
+
+
+@pytest.mark.parametrize("value", ["low", "minor", "nit", "informational"])
+def test_low_severities(value):
+    assert ar.normalize_severity(value) == "low"
+
+
+def test_unrecognized_but_readable_severity_warns_rather_than_blocks():
+    """The one carve-out: a readable word we don't know is not a reason to
+    block every merge in the repo."""
+    assert ar.normalize_severity("spicy") == "unknown"
+
+
+def test_finding_severity_reads_the_missing_key():
+    assert ar.finding_severity({"title": "x"}) == "high"
+    assert ar.has_unreadable_severity({"title": "x"}) is True
+    assert ar.has_unreadable_severity({"severity": "low"}) is False
+
+
+# ------------------------------------------------------------------ retry logic
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [("30", 30.0), ("6s", 6.0), ("1.5s", 1.5), ("6m0s", 360.0), ("250ms", 0.25)],
+)
+def test_parse_duration(raw, expected):
+    assert ar.parse_duration(raw) == pytest.approx(expected)
+
+
+def test_retry_delay_prefers_server_headers():
+    assert ar.retry_delay_from({"retry-after": "45"}) == 45.0
+    assert ar.retry_delay_from({"x-ratelimit-reset-tokens": "6m0s"}) == 360.0
+    assert ar.retry_delay_from({}) is None
+    assert ar.retry_delay_from(None) is None
+
+
+def test_backoff_spans_a_rate_limit_window():
+    """2s/4s could never outlast a token-per-minute window, so a 429 became a
+    lens error, i.e. a repo-wide block."""
+    total = sum(ar.RETRY_BACKOFF_S * (2**i) for i in range(ar.REQUEST_ATTEMPTS - 1))
+    assert total >= 55
+
+
+class _Resp(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _stub_urlopen(monkeypatch, sequence):
+    """Serve `sequence` items in order: an Exception is raised, else returned."""
+    seen = {"n": 0}
+
+    def fake(req, timeout=None):
+        seen["n"] += 1
+        item = sequence[min(seen["n"] - 1, len(sequence) - 1)]
+        if isinstance(item, Exception):
+            raise item
+        return _Resp(item)
+
+    monkeypatch.setattr(ar.urllib.request, "urlopen", fake)
+    return seen
+
+
+def _http_429(retry_after):
+    return urllib.error.HTTPError(
+        "https://example/v1", 429, "Too Many Requests", {"retry-after": retry_after}, None
+    )
+
+
+def test_post_waits_the_server_supplied_retry_after(monkeypatch):
+    slept = []
+    monkeypatch.setattr(ar.time, "sleep", slept.append)
+    monkeypatch.setattr(ar.random, "uniform", lambda a, b: 0.0)
+    _stub_urlopen(monkeypatch, [_http_429("17"), _http_429("17"), b'{"ok": true}'])
+    assert ar._post("https://example/v1", {}, {}) == {"ok": True}
+    assert slept == [17.0, 17.0]  # not the 8/16 default backoff
+
+
+def test_post_falls_back_to_exponential_backoff_without_headers(monkeypatch):
+    slept = []
+    monkeypatch.setattr(ar.time, "sleep", slept.append)
+    monkeypatch.setattr(ar.random, "uniform", lambda a, b: 0.0)
+    _stub_urlopen(monkeypatch, [OSError("connection reset"), b'{"ok": true}'])
+    assert ar._post("https://example/v1", {}, {}) == {"ok": True}
+    assert slept == [float(ar.RETRY_BACKOFF_S)]
+
+
+def test_post_does_not_retry_a_non_transient_status(monkeypatch):
+    slept = []
+    monkeypatch.setattr(ar.time, "sleep", slept.append)
+    err = urllib.error.HTTPError("https://example/v1", 400, "Bad Request", {}, None)
+    seen = _stub_urlopen(monkeypatch, [err])
+    with pytest.raises(RuntimeError):
+        ar._post("https://example/v1", {}, {})
+    assert seen["n"] == 1 and slept == []
+
+
+def test_post_never_sleeps_past_the_review_budget(monkeypatch):
+    """Retries must not outlive the job: a runner kill is a red check with no
+    explanation, where an in-script budget error at least says why."""
+    slept = []
+    monkeypatch.setattr(ar.time, "sleep", slept.append)
+    monkeypatch.setattr(ar.random, "uniform", lambda a, b: 0.0)
+    monkeypatch.setattr(ar, "_DEADLINE", time.monotonic() + 3)
+    _stub_urlopen(monkeypatch, [_http_429("300")])
+    with pytest.raises(RuntimeError):
+        ar._post("https://example/v1", {}, {})
+    assert slept == []
+
+
+# ----------------------------------------------------------------- SSE decoding
+
+
+def test_read_anthropic_stream_accumulates_text_and_stop_reason():
+    events = [
+        {"type": "message_start", "message": {}},
+        {"type": "content_block_delta", "delta": {"type": "text_delta", "text": '{"fin'}},
+        {"type": "content_block_delta", "delta": {"type": "thinking_delta", "thinking": "hm"}},
+        {"type": "content_block_delta", "delta": {"type": "text_delta", "text": 'dings": []}'}},
+        {"type": "message_delta", "delta": {"stop_reason": "end_turn"}},
+    ]
+    body = "".join(f"event: {e['type']}\ndata: {json.dumps(e)}\n\n" for e in events)
+    text, stop = ar.read_anthropic_stream(io.BytesIO(body.encode()))
+    assert (text, stop) == ('{"findings": []}', "end_turn")
+    assert ar.parse_findings(text) == []
+
+
+def test_read_anthropic_stream_raises_on_error_event():
+    body = 'data: {"type": "error", "error": {"type": "overloaded_error"}}\n\n'
+    with pytest.raises(RuntimeError):
+        ar.read_anthropic_stream(io.BytesIO(body.encode()))
+
+
+# --------------------------------------------------------------- range / git
+
+
+@pytest.fixture()
+def repo(tmp_path, monkeypatch):
+    """A real git repo where main advances after the branch is cut."""
+    def git(*args):
+        subprocess.run(["git", "-C", str(tmp_path), *args], check=True,
+                       capture_output=True)
+
+    def rev(ref):
+        return subprocess.run(
+            ["git", "-C", str(tmp_path), "rev-parse", ref],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+
+    git("init", "-q", "-b", "main")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    (tmp_path / "base.txt").write_text("base\n")
+    git("add", "-A")
+    git("commit", "-qm", "base")
+    root = rev("HEAD")
+
+    git("checkout", "-q", "-b", "feature")
+    (tmp_path / "feature.txt").write_text("feature change\n")
+    # Two more files, each comfortably over MIN_CHUNK_CHARS/2, so the branch
+    # diff spans several chunks at the minimum budget — that is the only way to
+    # exercise the multi-chunk exit paths.
+    (tmp_path / "wide_a.txt").write_text("const a = 1;\n" * 400)
+    (tmp_path / "wide_b.txt").write_text("const b = 2;\n" * 400)
+    git("add", "-A")
+    git("commit", "-qm", "feature")
+    head = rev("HEAD")
+
+    git("checkout", "-q", "main")
+    (tmp_path / "unrelated.txt").write_text("landed on main after the cut\n")
+    git("add", "-A")
+    git("commit", "-qm", "unrelated")
+    main_tip = rev("HEAD")
+
+    monkeypatch.chdir(tmp_path)
+    return {"root": root, "head": head, "main_tip": main_tip}
+
+
+def test_range_is_the_merge_base_not_the_base_branch_tip(repo, monkeypatch):
+    """github.event.pull_request.base.sha is main's TIP at event time. Two-dot
+    from there reviews main's own commits inverted and can drop the branch's
+    work — while the audit line still claims 100% coverage."""
+    monkeypatch.setenv("BASE_SHA", repo["main_tip"])
+    monkeypatch.setenv("HEAD_SHA", repo["head"])
+    rng = ar.resolve_range()
+    assert rng.base == repo["root"]
+    assert rng.requested_base == repo["main_tip"]
+
+    diff = ar.get_diff(rng.spec)
+    assert "feature.txt" in diff
+    assert "unrelated.txt" not in diff  # the two-dot bug leaked this in
+
+    two_dot = ar.get_diff(f"{repo['main_tip']}..{repo['head']}")
+    assert "unrelated.txt" in two_dot  # ...proving the difference is real
+
+
+def test_merge_group_range_is_unchanged(repo, monkeypatch):
+    """merge_group.base_sha is the previous entry's head — already an ancestor —
+    so merge-base resolution is a no-op there and each entry still sees exactly
+    its own delta."""
+    monkeypatch.setenv("BASE_SHA", repo["root"])
+    monkeypatch.setenv("HEAD_SHA", repo["head"])
+    rng = ar.resolve_range()
+    assert rng.base == repo["root"]
+    assert rng.spec == f"{repo['root']}..{repo['head']}"
+
+
+def test_bad_sha_is_an_error_not_a_substitution(repo, monkeypatch):
+    monkeypatch.setenv("BASE_SHA", "not-a-sha")
+    monkeypatch.setenv("HEAD_SHA", repo["head"])
+    with pytest.raises(ar.ReviewError):
+        ar.resolve_range()
+
+
+def test_absent_sha_is_an_error(repo, monkeypatch):
+    monkeypatch.setenv("BASE_SHA", "0" * 40)
+    monkeypatch.setenv("HEAD_SHA", repo["head"])
+    with pytest.raises(ar.ReviewError):
+        ar.resolve_range()
+
+
+def test_git_failure_is_not_an_empty_diff(monkeypatch):
+    monkeypatch.setattr(ar, "run", lambda cmd: (128, "", "fatal: bad revision"))
+    with pytest.raises(ar.ReviewError):
+        ar.get_diff("a..b")
+
+
+def test_empty_stdout_with_changed_files_fails_closed(monkeypatch):
+    def fake_run(cmd):
+        if "--name-only" in cmd:
+            return (0, "some/file.ts\n", "")
+        return (0, "", "")
+
+    monkeypatch.setattr(ar, "run", fake_run)
+    with pytest.raises(ar.ReviewError):
+        ar.get_diff("a..b")
+
+
+# ------------------------------------------------------------------ exit paths
+
+
+@pytest.fixture()
+def gate(repo, monkeypatch, tmp_path):
+    """main() wired to a real repo and a stubbed model."""
+    monkeypatch.setenv("OPENAI_KEY", "test-key")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("BASE_SHA", repo["root"])
+    monkeypatch.setenv("HEAD_SHA", repo["head"])
+    monkeypatch.delenv("PR_NUMBER", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(tmp_path / "summary.md"))
+
+    def install(reply):
+        """`reply` is a str, an Exception to raise, or a callable(user)->str."""
+        def fake(provider, key, model, system, user):
+            value = reply(user) if callable(reply) else reply
+            if isinstance(value, Exception):
+                raise value
+            return value
+
+        monkeypatch.setattr(ar, "call_model", fake)
+
+    return install
+
+
+def test_clean_diff_passes(gate):
+    gate('{"findings": []}')
+    assert ar.main() == 0
+
+
+def test_high_finding_blocks(gate):
+    gate('{"findings": [{"severity": "high", "file": "a", "title": "t", "detail": "d"}]}')
+    assert ar.main() == 1
+
+
+def test_low_finding_passes(gate):
+    gate('{"findings": [{"severity": "low", "file": "a", "title": "t", "detail": "d"}]}')
+    assert ar.main() == 0
+
+
+@pytest.mark.parametrize("severity", ["critical", "blocker", "HIGH ", "major", "urgent"])
+def test_severity_aliases_and_unknowns_at_the_exit_code(gate, severity):
+    """"major" and "urgent" used to exit 0. "major" is now an alias; "urgent"
+    is unreadable-to-us but still a REPORTED finding, so it must not silently
+    pass — it warns only if it normalizes to a known non-blocking level."""
+    gate(json.dumps({"findings": [{"severity": severity, "file": "a", "title": "t"}]}))
+    rc = ar.main()
+    assert rc == (1 if severity != "urgent" else 0), severity
+
+
+def test_finding_with_no_severity_blocks(gate):
+    gate('{"findings": [{"file": "a", "title": "t", "detail": "d"}]}')
+    assert ar.main() == 1
+
+
+def test_lens_error_blocks(gate):
+    gate(RuntimeError("HTTP 429"))
+    assert ar.main() == 1
+
+
+def test_unparseable_reply_blocks(gate):
+    gate("sure, the code looks good")
+    assert ar.main() == 1
+
+
+def test_one_lens_failing_out_of_three_blocks(gate):
+    """The old code required ALL lenses to fail; two of three timing out
+    reported a pass."""
+    state = {"n": 0}
+
+    def reply(_user):
+        state["n"] += 1
+        return RuntimeError("boom") if state["n"] == 1 else '{"findings": []}'
+
+    gate(reply)
+    assert ar.main() == 1
+
+
+def test_high_in_a_non_first_chunk_blocks(gate, monkeypatch):
+    monkeypatch.setenv("MAX_CHUNK_CHARS", str(ar.MIN_CHUNK_CHARS))
+    seen = []
+
+    def reply(user):
+        seen.append(user)
+        if "chunk 1 of" in user:
+            return '{"findings": []}'
+        return '{"findings": [{"severity": "high", "file": "z", "title": "t"}]}'
+
+    gate(reply)
+    assert ar.main() == 1
+    # Guard against the test passing vacuously on a single-chunk diff.
+    assert any("chunk 2 of" in u for u in seen)
+
+
+def test_error_path_posts_the_sticky_comment(gate, monkeypatch):
+    """A lens error is the most confusing red the gate can produce, and it used
+    to leave a stale green '✅ No findings' comment standing next to it."""
+    posted = []
+    monkeypatch.setattr(ar, "post_sticky_comment", posted.append)
+    gate(RuntimeError("boom"))
+    assert ar.main() == 1
+    assert len(posted) == 1
+    assert "Blocked" in posted[0] and ar.MARKER in posted[0]
+
+
+def test_no_key_blocks(gate, monkeypatch):
+    monkeypatch.delenv("OPENAI_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert ar.main() == 1
+
+
+def test_bad_numeric_config_blocks(gate, monkeypatch):
+    gate('{"findings": []}')
+    monkeypatch.setenv("MAX_CHUNK_CHARS", "not-a-number")
+    assert ar.main() == 1
+
+
+def test_audit_line_names_the_range_and_covers_the_diff(gate, capsys):
+    gate('{"findings": []}')
+    assert ar.main() == 0
+    out = capsys.readouterr().out
+    assert "merge base" in out
+    assert "100% of that diff" in out

--- a/.github/workflows/adversarial-review.yml
+++ b/.github/workflows/adversarial-review.yml
@@ -2,11 +2,17 @@ name: adversarial-review
 
 # The machine gatekeeper that replaces the human. Three adversarial lenses
 # (correctness / security / pack-compat) read the PR diff and emit ONE pass/fail
-# status. Pass = no unresolved high-severity finding. Single job named
-# `adversarial-review` so it always reports — safe as a required check on `main`.
+# status. Pass = no blocking-severity finding AND every lens actually reviewed
+# 100% of the diff. Single job named `adversarial-review` so it always reports —
+# safe as a required check on `main`.
 #
-# Cost: one model call per lens per PR/queue-entry. Tune ADVERSARIAL_MODEL and
-# MAX_DIFF_BYTES to manage spend; a false positive that blocks the queue is a
+# The script FAILS CLOSED: a lens error, an unparseable model reply, a git
+# failure, or an uncovered diff all exit non-zero. Do not "fix" a red gate by
+# relaxing that; fix the cause.
+#
+# Cost: one model call per lens PER CHUNK. Large diffs are chunked rather than
+# truncated, so a 4x-budget PR costs 4x the calls. Tune ADVERSARIAL_MODEL and
+# MAX_CHUNK_CHARS to manage spend; a false positive that blocks the queue is a
 # detrimental process — fix the prompt fast rather than routing around the gate.
 
 on:
@@ -29,6 +35,12 @@ jobs:
   adversarial-review:
     name: adversarial-review
     runs-on: ubuntu-latest
+    # The merge queue's check_response_timeout_minutes is 60. Without an explicit
+    # limit this job inherits the 360-minute default, so a hung run would burn
+    # the queue's entire budget before reporting. Bounded well under 60: the
+    # script runs lens/chunk calls concurrently with a 120s per-request timeout
+    # and at most 3 attempts each.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,6 +57,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           ADVERSARIAL_MODEL: ${{ vars.ADVERSARIAL_MODEL }}
+          MAX_CHUNK_CHARS: ${{ vars.MAX_CHUNK_CHARS }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/adversarial-review.yml
+++ b/.github/workflows/adversarial-review.yml
@@ -11,11 +11,27 @@ name: adversarial-review
 # relaxing that; fix the cause.
 #
 # Cost: one model call per lens PER CHUNK. Large diffs are chunked rather than
-# truncated, so a 4x-budget PR costs 4x the calls. Tune ADVERSARIAL_MODEL and
-# MAX_CHUNK_CHARS to manage spend, and ADVERSARIAL_WORKERS to throttle
-# concurrency during a rate-limit incident; a false positive that blocks the
-# queue is a detrimental process — fix the prompt fast rather than routing
-# around the gate.
+# truncated, so a 4x-budget PR costs 4x the calls.
+#
+# MAX_CHUNK_CHARS RAISES COST AS IT GOES DOWN — it is a chunk SIZE, not a spend
+# cap. Lowering it makes more, smaller chunks and multiplies both the bill and
+# the wall clock. Measured over PR #521's diff (804,610 chars, `git diff
+# 1115c6135..1028ccf2c`), at 3 lenses per chunk:
+#
+#   budget=200000    5 chunks     15 calls
+#   budget= 50000   18 chunks     54 calls
+#   budget=  4000  319 chunks    957 calls   <- can outlive the 20-minute budget
+#
+# To cut spend, RAISE it (or set a cheaper ADVERSARIAL_MODEL). Lower it only to
+# fit a model's context window, and never below the script's MIN_CHUNK_CHARS
+# floor of 4000, which it rejects.
+#
+# ADVERSARIAL_WORKERS is the throttle for a rate-limit incident: it lowers
+# concurrency without changing the number of calls. That is the knob to reach
+# for mid-incident, not MAX_CHUNK_CHARS.
+#
+# A false positive that blocks the queue is a detrimental process — fix the
+# prompt fast rather than routing around the gate.
 #
 # The script's own unit tests run in `ci.yml` (job `ci-scripts`), which is
 # aggregated by the required `ci-gate` context.

--- a/.github/workflows/adversarial-review.yml
+++ b/.github/workflows/adversarial-review.yml
@@ -12,8 +12,13 @@ name: adversarial-review
 #
 # Cost: one model call per lens PER CHUNK. Large diffs are chunked rather than
 # truncated, so a 4x-budget PR costs 4x the calls. Tune ADVERSARIAL_MODEL and
-# MAX_CHUNK_CHARS to manage spend; a false positive that blocks the queue is a
-# detrimental process — fix the prompt fast rather than routing around the gate.
+# MAX_CHUNK_CHARS to manage spend, and ADVERSARIAL_WORKERS to throttle
+# concurrency during a rate-limit incident; a false positive that blocks the
+# queue is a detrimental process — fix the prompt fast rather than routing
+# around the gate.
+#
+# The script's own unit tests run in `ci.yml` (job `ci-scripts`), which is
+# aggregated by the required `ci-gate` context.
 
 on:
   pull_request:
@@ -37,9 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     # The merge queue's check_response_timeout_minutes is 60. Without an explicit
     # limit this job inherits the 360-minute default, so a hung run would burn
-    # the queue's entire budget before reporting. Bounded well under 60: the
-    # script runs lens/chunk calls concurrently with a 120s per-request timeout
-    # and at most 3 attempts each.
+    # the queue's entire budget before reporting. Bounded well under 60, and the
+    # script carries its OWN 20-minute wall-clock budget (REVIEW_BUDGET_S) so an
+    # overloaded provider produces a legible failure inside the job rather than
+    # a runner kill. Keep this comfortably above that budget.
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
@@ -58,6 +64,14 @@ jobs:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           ADVERSARIAL_MODEL: ${{ vars.ADVERSARIAL_MODEL }}
           MAX_CHUNK_CHARS: ${{ vars.MAX_CHUNK_CHARS }}
+          # The throttle you reach for mid-incident. Every worker holds a full
+          # chunk (~50k tokens) in flight, and that concurrent token volume is
+          # what provokes a token-rate 429 — which, under fail-closed, blocks
+          # every merge in the repo. Set the `ADVERSARIAL_WORKERS` repo variable
+          # to dial concurrency down WITHOUT a code change (a code change would
+          # have to merge through the very gate that is wedged). Unset → the
+          # script's default of 3.
+          ADVERSARIAL_WORKERS: ${{ vars.ADVERSARIAL_WORKERS }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     name: changes
     runs-on: ubuntu-latest
     outputs:
+      ci_scripts: ${{ steps.filter.outputs.ci_scripts }}
       corpan_app: ${{ steps.filter.outputs.corpan_app }}
       dja: ${{ steps.filter.outputs.dja }}
       # dynawalla_*, native and shared_ts are declared ahead of the jobs that
@@ -82,6 +83,11 @@ jobs:
             fi
           }
 
+          # The gate's own code. `.github/scripts/**` holds the adversarial
+          # reviewer, whose failure mode when it regresses is to PASS wrongly —
+          # so its tests must run on any change to it (or to this workflow, or
+          # to the workflow that invokes it).
+          set_output ci_scripts '^(\.github/scripts/|\.github/workflows/(ci|adversarial-review)\.yml$)'
           set_output corpan_app '^(corpan/corpan-app/|\.github/workflows/ci\.yml$)'
           set_output dja '^(corpan/dja/|\.github/workflows/ci\.yml$)'
           set_output lambda '^(corpan/infra/terraform/lambda/|\.github/workflows/ci\.yml$)'
@@ -246,6 +252,28 @@ jobs:
         # gate fast and unable to jam the queue.
         run: python -m pytest cor/utils -q
 
+  # Unit tests for the adversarial-review gate (.github/scripts). That script is
+  # a required status check whose regression mode is to pass wrongly, which no
+  # other job can detect — these assertions are the only signal. stdlib + pytest
+  # only (the script itself has no third-party deps), so it is fast and cannot
+  # jam the merge queue. Needs fetch-depth: 0 — the range tests build a real
+  # throwaway repo, but `git` must be usable from the checkout.
+  ci-scripts:
+    name: ci-scripts · tests
+    needs: changes
+    if: needs.changes.outputs.ci_scripts == 'true'
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install test deps (pinned)
+        run: python -m pip install --disable-pip-version-check "pytest==8.3.4"
+      - name: Run CI script tests
+        run: python -m pytest .github/scripts -q
+
   lambda:
     name: lambda · tests
     needs: changes
@@ -397,7 +425,7 @@ jobs:
   # Skipped needs are fine; any failure or cancellation fails the gate.
   ci-gate:
     name: ci-gate
-    needs: [changes, corpan-app, dja, lambda, web-io, changed-packs, terraform, pack-catalog]
+    needs: [changes, ci-scripts, corpan-app, dja, lambda, web-io, changed-packs, terraform, pack-catalog]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What

Make the required `adversarial-review` check fail closed, and chunk large diffs
instead of truncating them.

## Why

The check that the entire trunk-based workflow depends on was fail-open in nine
distinct ways. The headline one, measured against PR #521:

```
$ git diff --unified=3 1115c6135..48b31605 | python3 -c "..."
chars 804610   bytes 850261   files (diff --git count) 186
files fully inside 200000 chars: 67
pct chars kept: 24.9

$ gh api .../commits/48b31605/check-runs --jq '...adversarial-review...'
{"conclusion":"success","started":"2026-07-14T06:37:00Z","completed":"2026-07-14T06:37:49Z"}
```

`MAX_DIFF_BYTES` truncated at 200,000 **characters** — `len()` on a `str` counts
characters, not bytes, so the variable name lied — and returned silently. The
model saw 24.9% of the diff (67 of 186 complete files) and the gate reported
"No findings" and passed in 49 seconds.

Eight more, each reproduced against the old script before changing anything:

| Defect | Old behaviour |
|---|---|
| Only fails when **all** lenses error | `errored == len(LENSES)`; 2 of 3 timing out passed |
| Silent model == clean model | `parse_findings` returned `[]` for empty replies, prose, JSON with no `findings` key, and JSON cut off mid-object |
| `git diff` failure passes | `run()` discarded `returncode`; empty stdout hit "Empty diff; nothing to review" → `return 0` |
| Malformed SHAs | `_safe_sha` silently substituted `""` / `HEAD` → wrong range reviewed, still green |
| Severity is exact-string | `"critical"`, `"blocker"`, `"High severity"`, `"HIGH "` all failed to block |
| `{"findings": null}` | `TypeError` — iteration was outside the `try` (fail-closed bug, but a bug) |
| No forensic trail | `render_markdown` returned early on a clean result, so a green run recorded nothing about what was reviewed |
| No `timeout-minutes` | Job inherited the 360-minute default vs the queue's 60-minute response timeout |

**Chunking, not blocking-on-truncation.** Simply making truncation fail would
have rejected every large PR in this repo on day one (#521 was 4x the budget).
The diff is split on `diff --git` boundaries, every lens runs over every chunk,
and findings are unioned. A single file larger than the budget is split rather
than truncated or rejected — coverage of the reviewed range stays at 100% and
those files are named in the audit trail, since their later pieces reach the
model without a `diff --git` header. Chunked lenses are told they see one slice,
so a symbol defined in another chunk is not reported as a false HIGH that would
wedge the queue.

## Review follow-ups (second round)

A fresh-context adversarial review found four majors and several minors. All are
addressed in `27196067b`; each fix is verified with real output below.

**1. The last fail-open: an unrecognized severity on a reported finding.**
`major`, `urgent`, `P0`, and a finding object with **no `severity` key at all**
each exited 0 on the active provider. `response_format: {"type": "json_object"}`
enforces valid JSON, not the schema, so nothing stopped it. `major` is now a
blocking alias, and a missing / `null` / empty severity blocks — an omitted field
is unreadable input, which this script treats as fail-closed everywhere else. The
carve-out is now narrow and stated in the module docstring: only a **non-empty,
readable** string that matches no alias warns instead of blocking.

```
severity value                rc  verdict
"high"                         1  BLOCKS
"critical"                     1  BLOCKS
"blocker"                      1  BLOCKS
"major"  (was rc=0)            1  BLOCKS
"HIGH "                        1  BLOCKS
(key absent) (was rc=0)        1  BLOCKS (+::error:: unreadable severity)
null (was rc=0)                1  BLOCKS (+::error:: unreadable severity)
"" (was rc=0)                  1  BLOCKS (+::error:: unreadable severity)
"P0" (readable, unknown)       0  passes (+::warning:: unrecognized)
"urgent" (readable, unknown)   0  passes (+::warning:: unrecognized)
"low"                          0  passes
no findings at all             0  passes
```

`P0` / `urgent` remaining warn-only is the reviewer's own prescribed carve-out —
they are readable strings we simply do not recognise, and blocking on an
unrecognised word would let a typo wedge the queue. Both are rendered in the
sticky comment as ⚪ UNKNOWN and logged as a `::warning::`.

**2. Two-dot `base..head` reviewed the wrong range while claiming 100%.**
`github.event.pull_request.base.sha` is the base branch **tip** at event time,
not the merge base, so on a branch cut before main moved the diff contains main's
own commits inverted and can lose the branch's work. The range is now resolved
with an explicit `git merge-base`, failing closed if it cannot be resolved:

```
=== range semantics: two-dot vs merge-base, real commits ===
  base=7fc5b7d98 head=48b316052 merge-base=1115c6135
    two-dot base..head      :   409,530 chars
    merge-base..head (now)  :   804,610 chars  DIFFERENT
  base=origin/ma head=HEAD merge-base=7fc5b7d98
    two-dot base..head      :    35,870 chars
    merge-base..head (now)  :    35,870 chars  SAME
```

`merge_group` is unaffected — `base_sha` is the previous queue entry's head and
therefore already an ancestor, so merge-base resolution is a no-op there and each
entry still sees exactly its own delta. There is a test for both directions. The
audit line now names the semantics (`merge base of requested base <sha> and
head`) instead of implying the requested range was reviewed.

**3. The Anthropic branch would have been more wedge-prone than what it replaced.**
Fixed rather than recommended as-is. `max_tokens` 16000 → **32000** (thinking is
on by default on `claude-opus-5` and shares that budget, and a `max_tokens` stop
raises → hard red); the request now **streams**, which is what actually bounds
`max_tokens` here — the 120s HTTP request timeout, not any API ceiling, and the
comment claiming a "non-streaming ceiling" is corrected; and `fallbacks:
"default"` (beta `server-side-fallback-2026-07-01`) is added so a safety
classifier declining the security lens — whose prompt is exactly the shape that
trips the cyber category — is rescued server-side instead of becoming an
unrecoverable red on a required check. SSE accumulation is unit-tested, including
that an `error` event raises.

**4. Retries could not clear a token-rate 429, and the throttle was unreachable.**
2s/4s never spans a TPM window. The backoff is now 8/16/32 (+jitter) over 4
attempts. A server-supplied `retry-after` / `x-ratelimit-reset-*` was described
here as "always wins"; that was both the wrong rule and a live defect, and the
third round below replaces it with `max(hint, floor)`.
`ADVERSARIAL_WORKERS` is now plumbed into the workflow env — the knob you
reach for mid-incident, which previously required a code change merged *through
the wedged gate* — and the default concurrency drops 4 → 3, since concurrent
token volume is what provokes the 429. Retries are also bounded by a new
20-minute in-script wall-clock budget, so a slow provider produces a legible
error instead of a runner kill at `timeout-minutes: 25`.

```
test_post_waits_the_server_supplied_retry_after     slept == [17.0, 17.0]  (not 8/16)
test_post_falls_back_to_exponential_backoff_...     slept == [8.0]
test_post_does_not_retry_a_non_transient_status     1 attempt, no sleep
test_post_never_sleeps_past_the_review_budget       retry-after 300s w/ 3s left -> no sleep, raises
```

**Minors, all fixed.** The error path now posts the sticky comment (a lens
failure used to leave a stale green "✅ No findings" comment standing beside a red
check). `_split_on_lines` splits on `"\n"` only — `str.splitlines(keepends=True)`
also breaks on U+2028/U+2029/U+0085/VT/FF, all legal inside JS source — and
hard-split files (a single line longer than the whole budget) are now tracked and
named, so the audit note no longer claims "no lens sees a partial line" in the
one case where that is false. `parse_findings` tries the whole reply first and
bounds the brace walk. The audit file count uses the anchored regex the chunker
already uses. `{"findings": null}` stays a clean pass, and the deliberate
asymmetry with the missing-severity rule is now spelled out in the code.

```
=== chunking: U+2028 etc. are no longer line boundaries ===
  U+2028: pieces=1 exact=True hard_split=False
  U+2029: pieces=1 exact=True hard_split=False
  U+0085: pieces=1 exact=True hard_split=False
  VT:     pieces=1 exact=True hard_split=False
  FF:     pieces=1 exact=True hard_split=False

=== hard split is now reported, not denied ===
  300k single line @4000: chunks=77 exact=True oversized=['x'] hard_split=['x'] in 0.00s

=== parse_findings on degenerate input (was O(n^2)) ===
    2000 unbalanced braces -> None in 0.008s   (was 0.04s)
    8000 unbalanced braces -> None in 0.034s   (was 0.69s)
   20000 unbalanced braces -> None in 0.087s   (was 4.40s)
  well-formed whole-reply    -> [] in 0.00001s

=== audit file count is anchored ===
  naive diff.count('diff --git '):  2   <- a .patch fixture containing the string
  anchored _FILE_START_RE       :  1
```

## Tests

The reviewer was right that 600+ lines of safety-critical logic shipped with zero
committed tests, and that the failure mode when these invariants regress is to
**pass wrongly**, which nothing else can detect.
`.github/scripts/test_adversarial_review.py` is now committed — **113 `assert`
statements across 63 test functions, which pytest reports as 140 cases** (the
gap is `@parametrize`) — covering chunk coverage at four budgets, the
`None`-vs-`[]` contract, every `main()` exit path (including a HIGH in a
non-first chunk, and a missing severity), merge-base range resolution against a
real throwaway repo, both providers' request payload shapes, and retry
behaviour driven through the real `_post`. It is wired into `ci.yml` as `ci-scripts`, which `ci-gate` aggregates —
so it runs on any change to `.github/scripts/**` or to either workflow, and a
regression cannot land.

```
$ python -m pytest .github/scripts -q        # python 3.12, pytest 8.3.4 (as in CI)
........................................................................ [ 51%]
....................................................................     [100%]
140 passed in 4.55s
```

## Review follow-ups (third round)

A second fresh-context review verified the merge-base fix and the chunker as
sound, and found that **the retry path had regressed into being more
queue-wedging than the code it replaced**. That is the worse failure on a
required check: a fail-open lets one bad PR through, a spurious red stops every
PR in the repository. All of it is fixed in `dda91f5d8`, and every claim below
was reproduced against the previous head (`27196067b`) before it was changed.

**A `0s` rate-limit header collapsed all backoff to zero.** `retry_delay_from`
returned the first *parseable* header and `_post` used `hint if hint is not None
else floor` — but **`0.0` is falsy, not `None`**, and providers stamp
`x-ratelimit-*` on essentially every response, reading `0s` when the bucket is
healthy. Measured on the previous head, then again after the fix:

```
                                          BEFORE (27196067b)     AFTER (dda91f5d8)
503 + x-ratelimit-reset-tokens: 0s      [0.0, 0.0, 0.0]        [8.0, 16.0, 32.0]
500 + x-ratelimit-reset-requests: 0s    [0.0, 0.0, 0.0]        [8.0, 16.0, 32.0]
502 + x-ratelimit-reset-tokens: 6ms     [0.006, 0.006, 0.006]  [8.0, 16.0, 32.0]
429 + {reset-tokens 0s, requests 45s}   [0.0, 0.0, 0.0]        [45.0, 45.0, 45.0]
503 with no rate-limit headers          [8.0, 16.0, 32.0]      [8.0, 16.0, 32.0]
```

One transient 5xx burned all four attempts in milliseconds, became a lens error,
and — because the gate now fails closed — turned the required check red for every
PR in flight. The wait is now `max(hint, floor)`, and `retry_delay_from` takes
the **max** of the parseable headers rather than the first: the classic RPM-429
shape `{reset-tokens: "0s", reset-requests: "45s"}` returned `0.0` and threw away
the only number that mattered.

**A server window longer than 60s was silently clamped.** `RETRY_MAX_SLEEP_S = 60`
clamped *after* the hint, so `x-ratelimit-reset-tokens: 6m0s` slept `[60, 60, 60]`
and gave up at 180s with 17 of the 20-minute budget unused — three attempts all
inside the same window. The bound is now the **remaining budget**, less a small
margin so the run can still report instead of being killed by `timeout-minutes`:

```
{'x-ratelimit-reset-tokens': '6m0s'}  budget=1200s  sleeps=[360, 360, 360]
{'retry-after': '120'}                budget=1200s  sleeps=[120, 120, 120]
{'retry-after': '300'}                budget= 100s  sleeps=[95, 95, 95]   (clamped to what is left)
{'retry-after': '300'}                budget=   3s  sleeps=[]  -> raises  (no room to wait AND report)
```

**Severity matched only the first token.** `"High severity"` blocked but
`"very high"` did not — it normalized to `unknown` and exited **0 on a reported
finding**, the same fail-open shape as `"major"` was. `"severity: high"` had the
same hole. Every token is scanned now, blocking level first, so two levels in one
string resolve to the higher one.

The deliberate decision on the surrounding vocabulary, since the previous
docstring implied a smaller surface than it had:

| now blocks | reason |
|---|---|
| `urgent`, `showstopper`, `breaking`, `serious` | plain-English maxima |
| `P0`, `P1`, `sev0`, `sev1`, `S0`, `S1`, `must-fix` | incident grades (digits are no longer stripped by the tokenizer, which used to turn `p0` into `p`) |
| `important` | Microsoft/Red Hat ladder: critical > **important** > moderate > low, and `moderate` is already medium here |
| `error` | log-level ladder: error > warning, and `warning` is already medium here |

| still only warns | reason |
|---|---|
| `bug`, `defect`, `issue`, `regression` | these name a **kind** of finding, not its grade — a low-severity bug is still a bug |
| `spicy` and anything else readable | the carve-out: one word we do not recognise must not block every merge in the repo |
| `low (non-blocking)`, `medium, not critical` | a blocking word directly after `no`/`not`/`non`/`never` is a negation, not a grade |

**529 was treated as permanent.** `529 overloaded_error` is Anthropic's documented
retryable overload status — a loaded gun on the branch this PR also rewrites.
Added, with `522`/`524`. Stream `error` events are classified too, so an
`overloaded_error` arriving inside a 200 retries while `invalid_request_error`
does not, and the bare `except Exception` no longer retries a malformed body four
times.

**The `MAX_CHUNK_CHARS` guidance in the workflow was inverted.** It told an
operator to tune it "to manage spend"; **lowering it multiplies spend and wall
time**, because it is a chunk *size*, not a spend cap:

```
this PR's diff (93,202 chars)     budget=200000  ->  1 chunk    3 calls
                                  budget= 50000  ->  3 chunks   9 calls
                                  budget=  4000  -> 30 chunks  90 calls
#521 (804,610 chars)              budget=200000  ->  5 chunks 15 calls
                                  budget=  4000  -> 319 chunks 957 calls  (80-478 min)
```

An operator following that comment mid-incident would wedge the queue. Rewritten:
raise it to cut cost, `ADVERSARIAL_WORKERS` is the throttle, and the floor is
`MIN_CHUNK_CHARS`.

**The lens-failure comment contradicted itself.** It said the diff was *not* fully
reviewed and then, in the audit line, "every lens read 100% of that diff" — a
false forensic record on the most confusing red the gate produces. Chunk coverage
and review coverage are different claims; the clause is now conditional
("0 chars dropped by chunking, but the lens reviews above did not complete").

**The tests were part of the defect, so two were rewritten rather than added to.**

* `test_backoff_spans_a_rate_limit_window` recomputed the constants and asserted
  `>= 55`. It never called `_post`, ignored `RETRY_MAX_SLEEP_S`, and **passed with
  both retry defects present**. It now drives the real `_post` against a stubbed
  transport and asserts the actual sleeps.
* `test_severity_aliases_and_unknowns_at_the_exit_code` had a docstring saying
  `urgent` "must not silently pass" while asserting `rc == 0` for it. Split into a
  blocking-alias test and a carve-out test; both now agree with the table above.

Every fix above has a test that fails without it. Run against the previous head:

```
# 27196067b's adversarial_review.py + this PR's test file, side by side
$ python -m pytest . -q
36 failed, 104 passed
```

and each fix was mutation-checked in the other direction — reinstating the 60s
ceiling, lowering the backoff floor, dropping the negation guard, dropping 529,
reverting the audit flag, re-widening the `except`, and typoing an Anthropic
payload key each fail 1-5 assertions.

`call_model` had **zero coverage on both branches**, so the entire Anthropic
payload (model id, `max_tokens`, `thinking`, `output_config`, `fallbacks`, betas,
headers) was never constructed in a test — on a branch that has never run against
a real API. Both payload shapes are now asserted, plus `finish_reason: length`,
a missing message content, and a `max_tokens`/`refusal` stop reason.

**Re-verified unchanged after all of the above:** chunk coverage is still exact
and terminating on empty, whitespace-only, a 1M-char single line, CRLF,
U+2028/2029/0085/VT/FF, binary→U+FFFD, 10k tiny files, and a bare hunk with no
`diff --git` header; merge-base resolution still resolves live against this repo
and still fails closed on an absent SHA; and the required-context wiring is
untouched — job key and `name:` unchanged, both `pull_request` and `merge_group`
fire, no top-level `paths:` filter, and `ci-gate` still aggregates
`ci-scripts · tests`.

## Blast radius

**Areas touched:** CI only (`.github/scripts/adversarial_review.py`,
`.github/scripts/test_adversarial_review.py`,
`.github/workflows/adversarial-review.yml`, `.github/workflows/ci.yml`)

This changes a **required status check**, so the risk is a spurious red wedging
the queue. Mitigations, all exercised below: retries that actually span a
rate-limit window — `max(server hint, exponential floor)`, bounded by the
review budget rather than a 60s constant, which is only true as of the third
round below; `ADVERSARIAL_WORKERS` reachable from
repo variables so concurrency can be dialled down without a merge; a 20-minute
in-script budget under `timeout-minutes: 25`, itself under the queue's 60-minute
response timeout; `{"findings": null}` treated as clean; a readable-but-unknown
severity warns instead of blocking; and the chunk hint telling each lens it sees
one slice and may see a mid-line fragment.

`ci-gate`'s `needs` list gains `ci-scripts`. That job is path-filtered inside
`ci.yml` (the `changes` job), never at the workflow level, so `ci-gate` still
reports on every PR and a skip is treated as a pass — the queue cannot deadlock
on it.

Cost note: one model call per lens **per chunk**. #521 goes from 3 calls to 15.

- [x] **Secrets.** No `.p8`, keystore, service-account JSON, issuer id, key id,
      or token. Scanned the diff for credential patterns — none. Provider
      selection is unchanged; `ANTHROPIC_API_KEY` is still not set on this repo.
- N/A — pack back-compat, native integrity, strings, curriculum: no packs,
  Rust, locales, or curriculum touched.

## Proof

Coverage is asserted programmatically over real ranges — the concatenated chunks
must equal the diff exactly — at three budgets. Re-measured against the shipped
`chunk_diff` at this head (the table previously shown here quoted pre-fix
numbers):

```
range                  budget      chars  chunks      max  exact  oversz  hard
#521 (1028ccf2c)       200000    804,610       5   198780   True       0     0
#521 (1028ccf2c)        50000    804,610      18    49931   True       0     0
#521 (1028ccf2c)         4000    804,610     319     3999   True      59     0
#520 (1115c6135)       200000    580,488       3   199840   True       0     0
#520 (1115c6135)        50000    580,488      13    49305   True       0     0
#520 (1115c6135)         4000    580,488     224     4000   True      35     0
this PR (dda91f5d8)    200000     93,202       1    93202   True       0     0
this PR (dda91f5d8)     50000     93,202       3    46338   True       1     0
this PR (dda91f5d8)      4000     93,202      30     4000   True       3     0

empty range: chunks=[] oversized=[] hard_split=[]
300k single line @4000: chunks=77 exact=True oversized=['x'] hard_split=['x'] in 0.00s
tiny budget rejected: chunk budget 10 is below the minimum 4000.
```

`hard=0` on the real ranges means no single line exceeded the budget there; the
synthetic 300k-line case is the one that does, and it is now reported rather than
silently claimed clean.

**These calls were NOT made against the real API.** Exercising the gate needs
`OPENAI_KEY` and costs money, so `call_model` is stubbed and the real `main()`
return code asserted. Chunking, diff extraction and range resolution run against
real git objects. This is now the committed pytest suite rather than an
uncommitted harness.

Same stubbed scenarios, old script (from `origin/main`) vs new — the regressions
were live, not theoretical:

```
scenario                                                  OLD              NEW
------------------------------------------------------------------------------
#521 range, all lenses 'clean'                     PASS(0) 3c      PASS(0) 15c
2 of 3 lenses error                                PASS(0) 3c      BLOCK(1) 3c
model replies with prose                           PASS(0) 3c      BLOCK(1) 3c
model reply truncated mid-object                   PASS(0) 3c      BLOCK(1) 3c
severity "critical"                                PASS(0) 3c      BLOCK(1) 3c
severity "major"                                   PASS(0) 3c      BLOCK(1) 3c
finding with no severity key                       PASS(0) 3c      BLOCK(1) 3c
{"findings": null}                           CRASH(TypeError) 1c    PASS(0) 3c
BASE_SHA is garbage                                PASS(0) 3c      BLOCK(1) 0c
```

The error path now leaves an explanation on the PR:

```
rc = 1 | sticky comments posted: 1
---- comment body ----
<!-- adversarial-review -->
## 🛡️ Adversarial review

❌ **Blocked** — 3 of 3 lens/chunk reviews failed to produce a readable result, so
the diff was not fully reviewed. Nothing here says the diff is wrong; the
reviewer could not run. See the job log for the per-lens `::warning::` lines.

_Reviewed `1a1fb7741a...4ef883115e` (merge base == requested base `1a1fb7741a4b`)
— 1 file(s), 119 chars, 1 chunk(s) of <= 200000; every lens read 100% of that
diff, 0 chars dropped · openai (gpt-4.1) · 3 lenses._
```

Workflow still reports unconditionally (no top-level `paths:` filter, which
would deadlock the queue), and compiles:

```
job name: adversarial-review
timeout-minutes: 25          (script's own budget: 20 min)
top-level paths filter: False
triggers: ['pull_request', 'merge_group', 'workflow_dispatch']
ci.yml jobs: [changes, corpan-app, dja, ci-scripts, lambda, web-io,
              changed-packs, terraform, pack-catalog, ci-gate]
py_compile OK
```

One number for this PR's own diff, taken from the gate's own audit line on the
CI run of `dda91f5d8` (after the rebase onto `e84c144ea`), since earlier
revisions of this description quoted several:

```
_Reviewed `e84c144eadcf..dda91f5d8826` (merge base == requested base) —
 4 file(s), 93202 chars, 1 chunk(s) of <= 200000 ..._
```

**93,202 characters, 4 files.** A local `git diff | wc -c` reports 93,436 bytes,
and can differ from CI by a handful of characters in either direction: `wc -c`
counts bytes where `MAX_CHUNK_CHARS` budgets characters, and git auto-scales the
abbreviated SHAs in `index` lines to the object count of the clone (8 hex digits
in CI's fresh clone, 9 in this working copy — 4 index lines x 2 SHAs = the 8-char
gap). The audit line is the authoritative figure because it is what the script
actually chunked.

(The 35,870 / 73,437 / 73,637 figures elsewhere in this description belong to
earlier commits of this branch, kept where they are the record of a run that
actually happened.)

## Anthropic branch

Dead code today (`ANTHROPIC_API_KEY` is not a repo secret) but wrong if enabled,
so it is fixed rather than left as a trap. **The active provider is unchanged** —
adding the key is the founder's call, not mine.

`claude-sonnet-4-6` → `claude-opus-5`; `max_tokens` 2000 → 32000 (on current
models `max_tokens` caps thinking *plus* response, and thinking is on by default
on `claude-opus-5`, so 2000 truncated the JSON mid-object and parsed as "no
findings" — the same class of bug as the diff truncation); adaptive thinking;
streaming, because the binding constraint at this `max_tokens` is the HTTP
request timeout rather than any API-enforced ceiling; `fallbacks: "default"` so a
classifier decline is rescued rather than turned into a repo-wide block; and an
`output_config` `json_schema` constraint matching the OpenAI branch's
`response_format` guarantee. `stop_reason` of `max_tokens` or `refusal` raises
instead of parsing as clean — with fallbacks in place, a `refusal` there means
the whole chain declined.

**Recommendation, appropriately hedged:** current Opus is materially better at
real bug-finding than gpt-4.1 with both higher precision and higher recall, which
is the whole job of this gate, and the schema constraint is stronger than
`json_object` (shape-checked, not just valid JSON). But this branch has **never
run against the real API** on this repo. If the founder wants to switch, do it on
a throwaway PR first and read the run, rather than flipping it on and trusting
this description. Cost would rise, and chunking already multiplies calls.

## Live end-to-end run (real API, first two commits)

The stubbed evidence above was written before pushing. This PR then exercised the
new script for real, and the gate **caught a genuine HIGH defect in its own code**
on the first commit (`c3154a90a`):

> 🔴 **HIGH** [correctness] `adversarial_review.py` — **Hard-splitting large diffs loses file headers**
> …split into arbitrary character-sized segments which may split in the middle of a hunk or even in the middle of a line, and later pieces will reach the model without their `diff --git` header… split only at hunk or line boundaries.

That was correct and was fixed in `5982c0b85` rather than argued with: splits now
land on hunk boundaries, fall back to line boundaries, and every continuation
chunk carries a synthetic prefix re-identifying its file. Chunks became
`Chunk(text, context)` so the coverage assertion still sums raw diff text only.

Verified on a 42,803-char single-file diff at a 4,000-char budget:

```
file chars=42803 -> 11 chunks, oversized=['corpan/app.ts']
coverage exact: True
all chunks end on newline: True
every chunk starts at a hunk/file boundary: True

--- what the model sees for chunk 2 ---
# Continuation of the unified diff for `corpan/app.ts` (part 2 of 11). The `diff --git` header and
earlier hunks for this file are in previous chunks; every line below belongs to this file.
@@ -90,3 +90,3 @@
```

That fixture had only `\n` line endings and no over-budget line, so it could not
have caught either mid-line case; the "no chunk starts mid-line: True" line
previously quoted here has been dropped because it does not generalise. A single
line longer than the budget **is** cut mid-line — there is no smaller boundary —
and that is now reported in the audit note and told to the lens in the chunk
hint, rather than denied.

The gate then went green on the fix, emitting the audit line on a clean run
(defect 8, proven live rather than stubbed):

```
✅ No findings across correctness / security / pack-compat lenses.

_Reviewed `7fc5b7d98..5982c0b85` — 5 file(s), 35866 chars, 1 chunk(s) of <= 200000,
100% covered, 0 dropped · openai (gpt-4.1) · 3 lenses._
```

Full check status on `5982c0b85`: `adversarial-review: SUCCESS`, `hygiene:
SUCCESS`, `changes: SUCCESS`, `ci-gate: SUCCESS`.

**Scope of that evidence, stated plainly:** the review step on that run took 2
seconds — 1 chunk, 3 calls (the 40s job wall was almost entirely the
`fetch-depth: 0` checkout). It proves the gate blocks a real defect and passes
clean code on the single-chunk path. The multi-chunk, many-concurrent-call path
carries the queue-wedge risk and has only been exercised with a stubbed
`call_model`. This commit is itself a larger diff, so the run on `27196067b` is
the first real exercise of more of that path.

### Live run on the review-follow-up commit (`27196067b`)

The merge-base range resolution, the new audit wording and the committed test
suite all ran for real. Every required context is green:

```
$ gh run view --job 89751463109 --log | grep Reviewed
_Reviewed `7fc5b7d9826a26e3287e452c2b5eb57fdc03615c..27196067b9c4ac5b7921c1f5af078435256dcc91`
(merge base == requested base `7fc5b7d9826a`) — 4 file(s), 73437 chars,
1 chunk(s) of <= 200000; every lens read 100% of that diff, 0 chars dropped
 · openai (gpt-4.1) · 3 lenses._
✅ No findings across correctness / security / pack-compat lenses.

$ gh run view --job 89751519620 --log | grep passed      # ci-scripts, python 3.12
80 passed in 2.27s

$ gh pr checks 530
adversarial-review          pass  43s
ci-gate                     pass   3s
ci-scripts · tests          pass  21s
hygiene                     pass  38s
changes                     pass  39s
corpan-app · tsc + build    pass  1m20s
dja · tests                 pass  24s
lambda · tests              pass  29s
changed packs · test+build  pass  43s
pack-catalog · integrity    pass  23s
terraform · fmt + validate  pass  35s
web/io · build              pass  1m21s
```

## Out of scope, needs a follow-up

`ci.yml`'s `ci-scripts` job carries the comment "Needs `fetch-depth: 0` — the
range tests build a real throwaway repo, but `git` must be usable from the
checkout", while that job's `actions/checkout` has no `with:` block at all. The
job does not need full history (the range fixture builds its own repo in
`tmp_path`), so the code is right and the comment is wrong. Left as-is here to
keep this round's diff inside the three files under review.


`.github/pull_request_template.md` (owned elsewhere) still says: *"the
adversarial-review gate truncates the diff at 200000 bytes
(.github/scripts/adversarial_review.py:115) and never sees the rest"*. After
this PR that is wrong twice over — there is no truncation, and the budget was
characters, not bytes. The line number is stale too. Worth updating to describe
chunking and the per-chunk cost instead.


### The icon assertion immediately earned its keep

It went red on the runner. `*.png` is Git LFS repo-wide, so `actions/checkout`
had been leaving a **pointer file** where the icon should be — which is exactly
what `generate_context!` would try to decode the moment a native gate lands, or
what any later job compiling this Rust would hit. `lfs: true` would pull every
sqlite3, epub and pdf in the monorepo for the sake of 10 kB, so the job fetches
the one path it reads:

```
- run: git lfs pull --include="dynawalla/dynawalla-app/src-tauri/icons/*"
```

The test now names the cause instead of reporting an unreadable byte mismatch:
`icon.png is a Git LFS pointer, not an image — the LFS object was not fetched`.
`dynawalla-app` and `ci-gate` are green.
