### PR TITLE
feat(dynawalla): engine and curriculum foundations — exact rationals, column-op, three mal-rules, seventeen gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,15 +582,23 @@ jobs:
   # what dynawalla's `engines` pins and what its `--experimental-strip-types` tests
   # are written against.
   #
-  # Running the gates on ubuntu is half of CG-16: the committed generator output
-  # hashes are written on macOS and verified here, so a generator that is not
-  # platform-stable fails rather than shipping different exercises per device.
+  # Two runners, because CG-16 is a claim about two operating systems: generators
+  # run in a WebView on iOS, Android and desktop, and output that is not
+  # platform-stable makes every committed golden transcript and every bug report
+  # irreproducible. Verifying the committed hashes on one runner would only prove
+  # they match whichever machine happened to write them. `fail-fast: false` so a
+  # divergence shows which side diverged. ci-gate takes the combined result of the
+  # matrix, so this is still one entry in its `needs` and no new required context.
   dynawalla-curriculum:
-    name: dynawalla-curriculum · tests + gates
+    name: dynawalla-curriculum · tests + gates (${{ matrix.os }})
     needs: changes
     if: needs.changes.outputs.dynawalla_curriculum == 'true'
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,11 +153,11 @@ jobs:
 
           # Areas a job actually consumes today, minus the `ci.yml` self-triggers
           # (a workflow edit is exempt below anyway). NOT the union of every
-          # filter above: `dynawalla_curriculum`, `dynawalla_engine`, `native`
-          # and `shared_ts` are declared ahead of their jobs, so paths they
-          # match are genuinely ungated and must keep warning until those jobs
-          # land. `dynawalla/dynawalla-app/` graduated when the `dynawalla-app`
-          # job below started consuming its filter.
+          # filter above: `native` and `shared_ts` are declared ahead of their
+          # jobs, so paths they match are genuinely ungated and must keep
+          # warning until those jobs land. `dynawalla/dynawalla-app/`,
+          # `dynawalla/curriculum/` and `dynawalla/engine/` have each graduated,
+          # as the jobs below now consume their filters.
           #
           # The terraform member is copied verbatim from the `terraform` filter —
           # extension-scoped, not the bare directory. A bare `corpan/infra/
@@ -167,7 +167,7 @@ jobs:
           # `corpan/plugins/` is covered only by `.github/workflows/ios-native.yml`,
           # which is ADVISORY (not a required check). It compiles, so it counts
           # here, but a red run has to be read by hand.
-          covered='^(corpan/corpan-app/|corpan/dja/|corpan/infra/terraform/lambda/|corpan/packs/|corpan/infra/terraform/.*(\.tf|\.tfvars|\.tf\.json)$|corpan/infra/terraform/\.terraform\.lock\.hcl$|web/(io|data|pages|scripts)/|corpan/plugins/|dynawalla/dynawalla-app/)'
+          covered='^(corpan/corpan-app/|corpan/dja/|corpan/infra/terraform/lambda/|corpan/packs/|corpan/infra/terraform/.*(\.tf|\.tfvars|\.tf\.json)$|corpan/infra/terraform/\.terraform\.lock\.hcl$|web/(io|data|pages|scripts)/|corpan/plugins/|dynawalla/dynawalla-app/|dynawalla/(curriculum|engine)/)'
 
           # Carve-outs checked BEFORE `covered`, because a broader area prefix
           # would otherwise swallow them. `corpan-app`'s job is npm only —
@@ -576,6 +576,69 @@ jobs:
       - name: Validate pack ids + artwork against the catalog
         run: node .github/scripts/pack_catalog_check.js
 
+  # Dynawalla curriculum: the skill graph, the generator families, the mal-rules
+  # and `dw-curriculum check`. Pure TypeScript with no DOM and no Tauri, so this is
+  # npm ci plus Node's own test runner — no vitest, matching corpan-app. Node 24 is
+  # what dynawalla's `engines` pins and what its `--experimental-strip-types` tests
+  # are written against.
+  #
+  # Running the gates on ubuntu is half of CG-16: the committed generator output
+  # hashes are written on macOS and verified here, so a generator that is not
+  # platform-stable fails rather than shipping different exercises per device.
+  dynawalla-curriculum:
+    name: dynawalla-curriculum · tests + gates
+    needs: changes
+    if: needs.changes.outputs.dynawalla_curriculum == 'true'
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: dynawalla/curriculum/package-lock.json
+      - name: Install
+        working-directory: dynawalla/curriculum
+        run: npm ci
+      - name: Test
+        working-directory: dynawalla/curriculum
+        run: npm test
+      - name: Typecheck
+        working-directory: dynawalla/curriculum
+        run: npm run tsc
+      - name: Curriculum gates
+        working-directory: dynawalla/curriculum
+        run: npm run check
+
+  # Dynawalla learner model. Independent of the curriculum job on purpose: the two
+  # packages do not import each other, so a curriculum edit must not rebuild the
+  # engine or vice versa. The engine carries its own copy of the float and purity
+  # scan (`src/boundary.test.ts`, gate EG-1) so an engine-only PR is fully covered
+  # by this job alone.
+  dynawalla-engine:
+    name: dynawalla-engine · tests
+    needs: changes
+    if: needs.changes.outputs.dynawalla_engine == 'true'
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: dynawalla/engine/package-lock.json
+      - name: Install
+        working-directory: dynawalla/engine
+        run: npm ci
+      - name: Test
+        working-directory: dynawalla/engine
+        run: npm test
+      - name: Typecheck
+        working-directory: dynawalla/engine
+        run: npm run tsc
+
   # Single summary status that aggregates every job above. THIS is the context to
   # mark as a required check on `main` — it always runs (if: always()) and always
   # reports, so path-skipped sub-jobs never deadlock the branch protection / queue.
@@ -595,6 +658,8 @@ jobs:
         changed-packs,
         terraform,
         pack-catalog,
+        dynawalla-curriculum,
+        dynawalla-engine,
       ]
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/dynawalla/curriculum/README.md
+++ b/dynawalla/curriculum/README.md
@@ -1,0 +1,79 @@
+# `@dynawalla/curriculum`
+
+The curriculum graph, its generator families, its mal-rules and the gates that
+validate all three. No React, no DOM, no Tauri: this package is importable and
+testable without building the app, which is what makes the mathematics verifiable
+in CI in seconds.
+
+Specification: [`../docs/CURRICULUM.md`](../docs/CURRICULUM.md),
+[`../docs/GATES.md`](../docs/GATES.md),
+[ADR-0006](../docs/DECISIONS/ADR-0006-typed-ts-curriculum-exact-arithmetic.md).
+
+```
+npm test                    # unit + property tests
+npm run tsc                 # typecheck
+npm run check               # dw-curriculum check — incremental, 200 seeds per level
+npm run check:full          # the full sweep, 1000 seeds per level
+npm run check -- --report json
+npm run snapshots:update    # rewrite the CG-16 output hashes
+```
+
+## What is here
+
+| Path | What |
+|---|---|
+| `src/math/rational.ts` | Exact rational arithmetic over BigInt. Nothing that reaches an answer is a float. |
+| `src/rng/` | Seeded integer-only PRNG (FNV-1a + mulberry32) and the FNV-1a-64 used for output hashes. Moves to `shared/kernel/` at M2. |
+| `src/types/` | `SkillNode`, `Exercise`, `AnswerSchema`, `PromptSpec`, the generator contract, the mal-rule contract. |
+| `src/generators/columnOp/` | `gen.arith.column-op` — the column algorithm, add and subtract, with exact regrouping control including across zeros. |
+| `src/malrules/` | Three executable buggy procedures for that family, and the classifier. |
+| `src/graph/` | The `add` domain seed: three active nodes and one draft. |
+| `src/render/registry.ts` | Renderer *declarations*. The data behind CG-8. |
+| `src/validate/` | The gates and `dw-curriculum check`. |
+
+## Three rules that are not negotiable
+
+**Exact arithmetic.** `0.1 + 0.2 !== 0.3` marks correct decimal work wrong
+*deterministically*, so no flaky-test detector would ever surface it. Every value
+that reaches an answer or a comparison is a `Rational` over BigInt, and gate `M-05`
+fails the build on a fractional literal, a `Math.exp`, a `parseFloat` or a
+`toFixed` anywhere in this package or in `engine/`.
+
+**Seeded and platform-stable.** The same seed produces the identical exercise on
+every device. Never `Math.random`, no `Intl` inside generation, no key-order
+assumptions. CG-16 commits an output hash per level and checks it on macOS and
+Linux.
+
+**Structured prompts.** `Exercise.prompt` is a `PromptSpec` — a locale key and
+typed slots — never a rendered string. One template translated once serves every
+seeded instance for ever, which is what makes five locales affordable across ~160
+skills.
+
+## The gates
+
+`dw-curriculum check` reports every gate in GATES.md. Seventeen are implemented;
+five print as `pending` with the PR that owns them, because a gate table where an
+unimplemented gate reads as green is worse than no table.
+
+Each implemented gate has a failing-case test in `src/validate/gates.test.ts` that
+deliberately violates it and asserts it goes red.
+
+Two implementation notes where the document and the code differ, both deliberate:
+
+- **CG-10** is worded as "<2% duplicates over 1,000 draws". Two-digit subtraction
+  with one regrouping has on the order of 1,600 distinct problems *in total*, so
+  1,000 draws from it collide about 20% of the time however good the generator is,
+  and the literal gate is unsatisfiable for every grade-1 level. It is implemented
+  as the thing that wording is *for*: a floor on the estimated size of the variant
+  space, measured from the collisions actually observed. The estimator is
+  optimistic at high collision rates, so the floor carries an order of magnitude of
+  margin and CG-9's hard `minVariants` count backs it up.
+- **Incremental mode** is seed-scoped, not diff-scoped. The graph is four nodes; a
+  diff scoper today would be untested machinery guarding nothing. PR-4.6 owns it.
+
+## Adding a generator family
+
+One family per PR. It needs a `paramSchema` that rejects parameter combinations no
+item could satisfy, property tests over thousands of seeds, mal-rules where the
+evidence base is real (**never invent a bug**), prompt templates as locale keys, a
+renderer declaration for every answer schema it emits, and a committed output hash.

--- a/dynawalla/curriculum/README.md
+++ b/dynawalla/curriculum/README.md
@@ -40,9 +40,10 @@ fails the build on a fractional literal, a `Math.exp`, a `parseFloat` or a
 `toFixed` anywhere in this package or in `engine/`.
 
 **Seeded and platform-stable.** The same seed produces the identical exercise on
-every device. Never `Math.random`, no `Intl` inside generation, no key-order
-assumptions. CG-16 commits an output hash per level and checks it on macOS and
-Linux.
+every device. Never `Math.random`, no `Intl` or `localeCompare` anywhere, no
+key-order assumptions. CG-16 commits an output hash for the first 20 seeds of every
+level, checks it on macOS and Linux, and scans both packages for locale-dependent
+ordering — the one form of drift that regenerating in-process cannot see.
 
 **Structured prompts.** `Exercise.prompt` is a `PromptSpec` — a locale key and
 typed slots — never a rendered string. One template translated once serves every
@@ -63,13 +64,26 @@ Two implementation notes where the document and the code differ, both deliberate
 - **CG-10** is worded as "<2% duplicates over 1,000 draws". Two-digit subtraction
   with one regrouping has on the order of 1,600 distinct problems *in total*, so
   1,000 draws from it collide about 20% of the time however good the generator is,
-  and the literal gate is unsatisfiable for every grade-1 level. It is implemented
-  as the thing that wording is *for*: a floor on the estimated size of the variant
-  space, measured from the collisions actually observed. The estimator is
-  optimistic at high collision rates, so the floor carries an order of magnitude of
-  margin and CG-9's hard `minVariants` count backs it up.
+  and the literal gate is unsatisfiable for every grade-1 level. The 1,000 is the
+  gate's sample size; a child never sees 1,000 items at one level. So the duplicate
+  rate is stated about the run a child does experience — at most one repeat in
+  fifty over a 40-item practice run — and the floor follows from it: `S ≥ (n−1)·D/2`,
+  which is 975 problems per level. The space itself is estimated from the collisions
+  observed, and that estimator is optimistic at high collision rates, so a level
+  near the floor deserves a look and CG-9's hard `minVariants` count backs it up.
+- **CG-12** also checks the *declaration* half of the mal-rule contract: every id in
+  a node's `misconceptions` resolves in the registry and belongs to the family the
+  node binds, and every diagnosis the node's own items emit as a distractor is
+  declared on the node. GATES.md words CG-12 as the ≥95% divergence clause alone;
+  without this half the field is unvalidated metadata that repair routing reads.
+- **CG-16** carries a third check the other two cannot make: a source scan for
+  `localeCompare`, `Intl` and `Collator`. In-process regeneration and two CI runners
+  with the same ICU data both agree with themselves; a device is where they stop.
 - **Incremental mode** is seed-scoped, not diff-scoped. The graph is four nodes; a
   diff scoper today would be untested machinery guarding nothing. PR-4.6 owns it.
+- **The full sweep** (`npm run check:full`, 1,000 seeds per level) is a command, not
+  a job. GATES.md puts it on a nightly with a named owner, and that owner (`A-19`)
+  is unassigned; PR-4.6/4.17 own wiring it up. CI runs the incremental check.
 
 ## Adding a generator family
 

--- a/dynawalla/curriculum/bin/dw-curriculum.mjs
+++ b/dynawalla/curriculum/bin/dw-curriculum.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+// `dw-curriculum check`. Re-execs node with type stripping so the same entry point
+// works on the pinned Node 24 (where stripping is on by default) and on an older
+// Node 22 that still needs the flag.
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const cli = fileURLToPath(new URL("../src/validate/cli.ts", import.meta.url));
+const result = spawnSync(
+  process.execPath,
+  ["--experimental-strip-types", "--no-warnings=ExperimentalWarning", cli, ...process.argv.slice(2)],
+  { stdio: "inherit" },
+);
+process.exit(result.status ?? 1);

--- a/dynawalla/curriculum/package-lock.json
+++ b/dynawalla/curriculum/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "@dynawalla/curriculum",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@dynawalla/curriculum",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@types/node": "^25.9.0",
+        "typescript": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/dynawalla/curriculum/package.json
+++ b/dynawalla/curriculum/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@dynawalla/curriculum",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Dynawalla curriculum graph, generators, mal-rules and validation gates. No DOM, no Tauri, no app imports.",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "scripts": {
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
+    "tsc": "tsc --noEmit",
+    "check": "node bin/dw-curriculum.mjs check",
+    "check:full": "node bin/dw-curriculum.mjs check --full",
+    "snapshots:update": "node bin/dw-curriculum.mjs check --update-snapshots"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^6.0.0"
+  }
+}

--- a/dynawalla/curriculum/src/generators/columnOp/answerValue.ts
+++ b/dynawalla/curriculum/src/generators/columnOp/answerValue.ts
@@ -1,0 +1,23 @@
+/**
+ * Wrap an exact value in the answer shape a column-op item's schema expects.
+ * Shared by the generator and by the mal-rules, so a buggy procedure's output is
+ * always comparable to the canonical answer with `answerEquals`.
+ */
+
+import type { Rational } from "../../math/rational.ts";
+import type { AnswerSchema, AnswerValue, ColumnMark } from "../../types/answer.ts";
+
+export function answerValueFor(
+  schema: AnswerSchema,
+  value: Rational,
+  marks: readonly ColumnMark[] = [],
+): AnswerValue {
+  switch (schema.kind) {
+    case "integer":
+      return { kind: "integer", value };
+    case "columnAlgorithm":
+      return { kind: "columnAlgorithm", value, marks };
+    default:
+      throw new TypeError(`gen.arith.column-op does not emit a ${schema.kind} answer`);
+  }
+}

--- a/dynawalla/curriculum/src/generators/columnOp/columnOp.property.test.ts
+++ b/dynawalla/curriculum/src/generators/columnOp/columnOp.property.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Property tests for `gen.arith.column-op`.
+ *
+ * Seeded purity, exact-arithmetic correctness, checker self-consistency and
+ * structural adequacy are statements over thousands of seeds, not over three
+ * examples. Every invariant below is checked on every item of every configuration,
+ * and the case count is printed so the number in a PR body is a measurement rather
+ * than a claim.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { eq, add as ratAdd, sub as ratSub, toScaled } from "../../math/rational.ts";
+import { answerEquals, answerToString } from "../../types/answer.ts";
+import type { Exercise } from "../../types/exercise.ts";
+import { LOC_KEY_PATTERN, skillId } from "../../types/ids.ts";
+import { serializeExercise } from "../../serialize.ts";
+import { correctBorrows, correctCarries } from "../../malrules/columnOp.ts";
+import { columnOpFamily } from "./family.ts";
+import { FORM_COLUMN, FORM_FREE_ENTRY } from "./constants.ts";
+import type { GenerateRequest } from "../../types/generator.ts";
+import { columnOpParamSchema } from "./params.ts";
+import type { ColumnOpParams } from "./params.ts";
+import { readOperands } from "./digits.ts";
+
+const SEEDS_PER_CONFIG = 2500;
+const SKILL = skillId("dw.add.regroup.subtract-across-zero");
+const BOTH_FORMS = [FORM_FREE_ENTRY, FORM_COLUMN];
+
+type Config = { readonly name: string; readonly params: ColumnOpParams };
+
+function config(name: string, overrides: Partial<ColumnOpParams>): Config {
+  return {
+    name,
+    params: {
+      op: "sub",
+      digits: 4,
+      operandDigits: 4,
+      regroupings: 1,
+      acrossZero: 0,
+      decimalPlaces: 0,
+      allowZeroResult: false,
+      ...overrides,
+    },
+  };
+}
+
+/** Deliberately spans the edges: zeros, repeated regrouping, short operands, decimals. */
+const CONFIGS: readonly Config[] = [
+  config("two-digit, one borrow", { digits: 2, operandDigits: 2, regroupings: 1 }),
+  config("three-digit, two borrows", { digits: 3, operandDigits: 3, regroupings: 2 }),
+  config("four-digit, borrow across one zero", { regroupings: 2, acrossZero: 1 }),
+  config("four-digit, borrow across two zeros", { regroupings: 3, acrossZero: 2 }),
+  config("five-digit, borrow across three zeros", { digits: 5, operandDigits: 5, regroupings: 4, acrossZero: 3 }),
+  config("short subtrahend", { digits: 4, operandDigits: 2, regroupings: 1 }),
+  config("short subtrahend across zeros", { digits: 4, operandDigits: 1, regroupings: 3, acrossZero: 2 }),
+  config("no regrouping at all", { digits: 3, operandDigits: 3, regroupings: 0 }),
+  config("tenths", { digits: 3, operandDigits: 3, regroupings: 1, decimalPlaces: 1 }),
+  config("hundredths across a zero", { digits: 4, operandDigits: 4, regroupings: 2, acrossZero: 1, decimalPlaces: 2 }),
+  config("two-digit addition, one carry", { op: "add", digits: 2, operandDigits: 2, regroupings: 1 }),
+  config("three-digit addition, carry every column", { op: "add", digits: 3, operandDigits: 3, regroupings: 3 }),
+  config("addition with a short addend", { op: "add", digits: 4, operandDigits: 2, regroupings: 2 }),
+];
+
+function checkItem(exercise: Exercise, params: ColumnOpParams, label: string): void {
+  const operands = readOperands(exercise);
+  assert.ok(operands !== null, `${label}: operands must be recoverable from the exercise`);
+
+  const top = exercise.prompt.slots["top"];
+  const bottom = exercise.prompt.slots["bottom"];
+  assert.ok(top !== undefined && top.kind === "number", `${label}: top slot`);
+  assert.ok(bottom !== undefined && bottom.kind === "number", `${label}: bottom slot`);
+  const canonical = exercise.answer.canonical;
+  assert.ok(canonical.kind === "integer" || canonical.kind === "columnAlgorithm", `${label}: answer kind`);
+
+  // 1. The answer is exact rational arithmetic on the two operands.
+  const expected = params.op === "sub" ? ratSub(top.value, bottom.value) : ratAdd(top.value, bottom.value);
+  assert.ok(eq(canonical.value, expected), `${label}: answer is not the exact difference/sum`);
+
+  // 2. No unintended negative, and no degenerate zero.
+  assert.ok(canonical.value.n >= 0n, `${label}: negative answer`);
+  if (!params.allowZeroResult) assert.ok(canonical.value.n > 0n, `${label}: zero answer`);
+
+  // 3. Both operands are written to the requested width, with no leading zero.
+  const scale = params.decimalPlaces;
+  const topDigits = (toScaled(top.value, scale) ?? 0n).toString();
+  const bottomDigits = (toScaled(bottom.value, scale) ?? 0n).toString();
+  assert.equal(topDigits.length, params.digits, `${label}: top operand width`);
+  assert.equal(bottomDigits.length, params.operandDigits, `${label}: bottom operand width`);
+  assert.equal(top.decimalPlaces, params.decimalPlaces, `${label}: top decimal places`);
+  assert.equal(bottom.decimalPlaces, params.decimalPlaces, `${label}: bottom decimal places`);
+
+  // 4. The regrouping structure is exactly what the level asked for.
+  const regroupings =
+    params.op === "sub"
+      ? correctBorrows(operands.top, operands.bottom, operands.cols).filter(Boolean).length
+      : correctCarries(operands.top, operands.bottom, operands.cols).filter(Boolean).length;
+  assert.equal(regroupings, params.regroupings, `${label}: regrouping count`);
+
+  // 5. The across-zero run is where the parameters say it is.
+  if (params.acrossZero > 0) {
+    for (let column = 1; column <= params.acrossZero; column++) {
+      assert.equal(operands.top[column], 0, `${label}: column ${String(column)} should be a zero`);
+    }
+    assert.notEqual(operands.top[params.acrossZero + 1], 0, `${label}: the run must terminate on a non-zero digit`);
+  }
+
+  // 6. Nothing has more decimal places than the level declares.
+  for (const value of [top.value, bottom.value, canonical.value]) {
+    assert.notEqual(toScaled(value, params.decimalPlaces), null, `${label}: value is not on the decimal grid`);
+  }
+
+  // 7. The item is answerable and its distractors are all wrong.
+  assert.ok(columnOpFamily.check(exercise, canonical).correct, `${label}: checker rejects its own answer`);
+  for (const accepted of exercise.answer.alsoAccept) {
+    assert.ok(columnOpFamily.check(exercise, accepted).correct, `${label}: checker rejects an alsoAccept answer`);
+  }
+  const seen = new Set<string>();
+  for (const distractor of exercise.distractors) {
+    assert.ok(!answerEquals(distractor.value, canonical), `${label}: distractor equals the answer`);
+    assert.equal(columnOpFamily.check(exercise, distractor.value).correct, false, `${label}: distractor accepted`);
+    const key = answerToString(distractor.value);
+    assert.ok(!seen.has(key), `${label}: duplicate distractor`);
+    seen.add(key);
+    assert.ok(distractor.misconception !== undefined, `${label}: distractor with no mal-rule`);
+    if (distractor.value.kind === "integer" || distractor.value.kind === "columnAlgorithm") {
+      assert.ok(distractor.value.value.n >= 0n, `${label}: negative distractor`);
+    }
+  }
+
+  // 8. Prompts are structured, and every key is a locale key.
+  assert.ok(LOC_KEY_PATTERN.test(exercise.prompt.key), `${label}: prompt key`);
+  for (const step of exercise.solution) assert.ok(LOC_KEY_PATTERN.test(step.key), `${label}: solution key`);
+  assert.equal(exercise.family, "gen.arith.column-op");
+  assert.equal(exercise.familyRev, 1);
+  assert.ok(BOTH_FORMS.includes(exercise.form), `${label}: unknown form`);
+
+  // 9. The answer field is a parameter, never the answer's own width.
+  const capacity = params.op === "add" ? params.digits + 1 : params.digits;
+  if (exercise.schema.kind === "integer") assert.equal(exercise.schema.digits, capacity, `${label}: field width`);
+  if (exercise.schema.kind === "columnAlgorithm") assert.equal(exercise.schema.cols, capacity, `${label}: cols`);
+}
+
+test("column-op: every configuration holds every invariant on every seed", (t) => {
+  let items = 0;
+
+  for (const { name, params } of CONFIGS) {
+    const validated = columnOpParamSchema.validate(params);
+    assert.equal(validated.ok, true, `${name}: parameters must validate — ${JSON.stringify(validated)}`);
+    if (!validated.ok) continue;
+
+    for (let seed = 1; seed <= SEEDS_PER_CONFIG; seed++) {
+      const exercise = columnOpFamily.generate({
+        skillId: SKILL,
+        level: 0,
+        seed,
+        params: validated.value,
+        forms: BOTH_FORMS,
+      });
+      checkItem(exercise, params, `${name} seed ${String(seed)}`);
+      items += 1;
+    }
+  }
+
+  t.diagnostic(`${String(items)} generated items across ${String(CONFIGS.length)} configurations`);
+  assert.equal(items, CONFIGS.length * SEEDS_PER_CONFIG);
+});
+
+test("column-op: generation is reproducible from the seed alone", (t) => {
+  let items = 0;
+  for (const { name, params } of CONFIGS) {
+    const validated = columnOpParamSchema.validate(params);
+    if (!validated.ok) continue;
+    for (let seed = 1; seed <= 500; seed++) {
+      const request: GenerateRequest<ColumnOpParams> = {
+        skillId: SKILL,
+        level: 0,
+        seed,
+        params: validated.value,
+        forms: BOTH_FORMS,
+      };
+      assert.equal(
+        serializeExercise(columnOpFamily.generate(request)),
+        serializeExercise(columnOpFamily.generate(request)),
+        `${name} seed ${String(seed)} is not reproducible`,
+      );
+      items += 1;
+    }
+  }
+  t.diagnostic(`${String(items)} items regenerated and compared byte for byte`);
+});
+
+test("column-op: the level and skill are part of the draw, not just of the label", (t) => {
+  // Two skills sharing a level's parameters must not serve the same problems in
+  // the same order, or a child who has met one has met the other.
+  const validated = columnOpParamSchema.validate(CONFIGS[3]?.params);
+  assert.equal(validated.ok, true);
+  if (!validated.ok) return;
+
+  let differing = 0;
+  for (let seed = 1; seed <= 500; seed++) {
+    const a = columnOpFamily.generate({
+      skillId: SKILL,
+      level: 0,
+      seed,
+      params: validated.value,
+      forms: [FORM_FREE_ENTRY],
+    });
+    const b = columnOpFamily.generate({
+      skillId: skillId("dw.add.regroup.subtract-multidigit"),
+      level: 2,
+      seed,
+      params: validated.value,
+      forms: [FORM_FREE_ENTRY],
+    });
+    if (answerToString(a.answer.canonical) !== answerToString(b.answer.canonical)) differing += 1;
+  }
+  t.diagnostic(`${String(differing)}/500 seeds differ between two skills at the same parameters`);
+  assert.ok(differing > 490, "the skill id and level must reseed the draw");
+});

--- a/dynawalla/curriculum/src/generators/columnOp/columnOp.property.test.ts
+++ b/dynawalla/curriculum/src/generators/columnOp/columnOp.property.test.ts
@@ -17,7 +17,16 @@ import { LOC_KEY_PATTERN, skillId } from "../../types/ids.ts";
 import { serializeExercise } from "../../serialize.ts";
 import { correctBorrows, correctCarries } from "../../malrules/columnOp.ts";
 import { columnOpFamily } from "./family.ts";
-import { FORM_COLUMN, FORM_FREE_ENTRY } from "./constants.ts";
+import {
+  FORM_COLUMN,
+  FORM_FREE_ENTRY,
+  SLOT_COLUMN,
+  SLOT_TOP,
+  SLOT_VALUE,
+  SOLUTION_KEY_CARRY,
+  SOLUTION_KEY_COLUMN,
+  SOLUTION_KEY_REGROUP,
+} from "./constants.ts";
 import type { GenerateRequest } from "../../types/generator.ts";
 import { columnOpParamSchema } from "./params.ts";
 import type { ColumnOpParams } from "./params.ts";
@@ -139,6 +148,42 @@ function checkItem(exercise: Exercise, params: ColumnOpParams, label: string): v
   const capacity = params.op === "add" ? params.digits + 1 : params.digits;
   if (exercise.schema.kind === "integer") assert.equal(exercise.schema.digits, capacity, `${label}: field width`);
   if (exercise.schema.kind === "columnAlgorithm") assert.equal(exercise.schema.cols, capacity, `${label}: cols`);
+
+  // 10. The walkthrough never asserts a digit the child has not been shown.
+  //
+  // Every column step states the value being worked with. That value may differ
+  // from the digit written on the page only if an earlier step said so — a regroup
+  // step naming this column, or a carry step delivering one into it. This is the
+  // general form of the bug the `4007 − 2888` example pins: a step list that
+  // silently turns the zeros of a borrow chain into nines is a demonstration of
+  // `mis.add.borrow-across-zero`, in the worked example that repairs it.
+  const restated = new Map<number, number>();
+  const carried = new Set<number>();
+  for (const step of exercise.solution) {
+    const column = step.slots[SLOT_COLUMN];
+    const value = step.slots[SLOT_VALUE];
+    if (column === undefined || column.kind !== "count") continue;
+
+    if (step.key === SOLUTION_KEY_REGROUP && value !== undefined && value.kind === "count") {
+      restated.set(column.value, value.value);
+      continue;
+    }
+    if (step.key === SOLUTION_KEY_CARRY) {
+      carried.add(column.value);
+      continue;
+    }
+    if (step.key !== SOLUTION_KEY_COLUMN) continue;
+
+    const worked = step.slots[SLOT_TOP];
+    assert.ok(worked !== undefined && worked.kind === "count", `${label}: column step has no top digit`);
+    const written: number = operands.top[column.value] ?? 0;
+    const shown: number = restated.get(column.value) ?? written + (carried.has(column.value) ? 1 : 0);
+    assert.equal(
+      worked.value,
+      shown,
+      `${label}: column ${String(column.value)} is worked as ${String(worked.value)} but the child was shown ${String(shown)}`,
+    );
+  }
 }
 
 test("column-op: every configuration holds every invariant on every seed", (t) => {

--- a/dynawalla/curriculum/src/generators/columnOp/columnOp.test.ts
+++ b/dynawalla/curriculum/src/generators/columnOp/columnOp.test.ts
@@ -1,0 +1,278 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { eq, sub as ratSub, add as ratAdd, toDecimalString, toScaled, rational } from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import { serializeExercise } from "../../serialize.ts";
+import { MIS_BORROW_ACROSS_ZERO, MIS_SMALLER_FROM_LARGER } from "../../malrules/columnOp.ts";
+import type { Exercise } from "../../types/exercise.ts";
+import { skillId } from "../../types/ids.ts";
+import { columnOpFamily, InfeasibleParamsError } from "./family.ts";
+import { FORM_COLUMN, FORM_FREE_ENTRY, PROMPT_KEY_ADD, PROMPT_KEY_SUB } from "./constants.ts";
+import { columnOpParamSchema } from "./params.ts";
+import type { ColumnOpParams } from "./params.ts";
+import { readOperands } from "./digits.ts";
+
+const SKILL = skillId("dw.add.regroup.subtract-across-zero");
+const BOTH_FORMS = [FORM_FREE_ENTRY, FORM_COLUMN];
+
+function params(overrides: Partial<ColumnOpParams> = {}): ColumnOpParams {
+  return {
+    op: "sub",
+    digits: 4,
+    operandDigits: 4,
+    regroupings: 3,
+    acrossZero: 2,
+    decimalPlaces: 0,
+    allowZeroResult: false,
+    ...overrides,
+  };
+}
+
+function generate(seed: number, overrides: Partial<ColumnOpParams> = {}, forms = BOTH_FORMS): Exercise {
+  return columnOpFamily.generate({ skillId: SKILL, level: 0, seed, params: params(overrides), forms });
+}
+
+function operandOf(exercise: Exercise, slot: "top" | "bottom"): Rational {
+  const value = exercise.prompt.slots[slot];
+  assert.ok(value !== undefined && value.kind === "number", "operand slot must be a number slot");
+  return value.value;
+}
+
+function answerOf(exercise: Exercise): Rational {
+  const canonical = exercise.answer.canonical;
+  assert.ok(canonical.kind === "integer" || canonical.kind === "columnAlgorithm");
+  return canonical.value;
+}
+
+test("column-op: the same seed always produces the identical exercise", () => {
+  for (const seed of [1, 2, 97, 5001, 4294967295]) {
+    const first = generate(seed);
+    const second = generate(seed);
+    assert.equal(serializeExercise(first), serializeExercise(second));
+    assert.equal(first.exerciseId, `gen.arith.column-op@1:${SKILL}:L0:${String(seed)}`);
+  }
+  assert.notEqual(serializeExercise(generate(1)), serializeExercise(generate(2)));
+});
+
+test("column-op: the answer equals exact rational subtraction, not digit bookkeeping", () => {
+  for (let seed = 1; seed <= 200; seed++) {
+    const exercise = generate(seed);
+    assert.ok(eq(answerOf(exercise), ratSub(operandOf(exercise, "top"), operandOf(exercise, "bottom"))));
+  }
+});
+
+test("column-op: a documented across-zero item behaves as the program describes", () => {
+  // 5001 − 2798 is the worked example the whole diagnosis story hangs on. It is one
+  // draw out of ~126,000 for this level, so it is asserted here through the
+  // structure rather than by hunting for its seed: every item at this level has a
+  // two-zero run, a three-borrow chain, and the two mal-rule distractors.
+  const exercise = generate(1);
+  const operands = readOperands(exercise);
+  assert.ok(operands !== null);
+  assert.equal(operands.op, "sub");
+  assert.equal(operands.top[1], 0, "the tens digit of the minuend is a zero the borrow crosses");
+  assert.equal(operands.top[2], 0, "the hundreds digit too");
+  assert.ok((operands.top[3] ?? 0) >= 2, "and there is a digit above the run to regroup from");
+
+  const misconceptions = exercise.distractors.map((distractor) => distractor.misconception);
+  assert.deepEqual([...misconceptions].sort(), [MIS_BORROW_ACROSS_ZERO, MIS_SMALLER_FROM_LARGER].sort());
+
+  // Borrow-across-zero is the correct answer plus exactly the thousand that was
+  // borrowed and never given up.
+  const borrowBug = exercise.distractors.find((d) => d.misconception === MIS_BORROW_ACROSS_ZERO);
+  assert.ok(borrowBug !== undefined && borrowBug.value.kind !== "choice" && borrowBug.value.kind !== "fraction");
+  assert.ok(eq(borrowBug.value.value, ratAdd(answerOf(exercise), rational(1000n))));
+});
+
+test("column-op: never negative, never zero, never a trivial subtrahend", () => {
+  for (let seed = 1; seed <= 500; seed++) {
+    const exercise = generate(seed);
+    const answer = answerOf(exercise);
+    assert.ok(answer.n > 0n, `seed ${String(seed)} produced a non-positive answer`);
+    assert.ok(operandOf(exercise, "bottom").n > 0n, "the subtrahend is never zero");
+  }
+});
+
+test("column-op: the answer field is sized to the parameters, not to the answer", () => {
+  // Auto-sizing an input to the answer tells a child how many digits it has.
+  // ARCHITECTURE L3 forbids it; this is the generator's half of that promise.
+  let sawShorterAnswer = false;
+  for (let seed = 1; seed <= 2000; seed++) {
+    const exercise = generate(seed, { regroupings: 3 }, [FORM_FREE_ENTRY]);
+    assert.equal(exercise.schema.kind, "integer");
+    if (exercise.schema.kind !== "integer") continue;
+    assert.equal(exercise.schema.digits, 4, "field width comes from params.digits");
+    const written = (toScaled(answerOf(exercise), 0) ?? 0n).toString().length;
+    if (written < exercise.schema.digits) sawShorterAnswer = true;
+  }
+  assert.ok(sawShorterAnswer, "at least one answer is shorter than the field, which is the point");
+});
+
+test("column-op: decimals are exact", () => {
+  for (let seed = 1; seed <= 300; seed++) {
+    const exercise = generate(seed, {
+      digits: 3,
+      operandDigits: 3,
+      regroupings: 1,
+      acrossZero: 0,
+      decimalPlaces: 1,
+    });
+    const top = operandOf(exercise, "top");
+    const bottom = operandOf(exercise, "bottom");
+    const answer = answerOf(exercise);
+    assert.ok(eq(answer, ratSub(top, bottom)));
+    // Every value is an exact multiple of a tenth: denominators divide 10.
+    for (const value of [top, bottom, answer]) assert.equal(10n % value.d, 0n);
+    assert.ok(toDecimalString(answer, 1) !== null);
+  }
+});
+
+test("column-op: a zero result is refused by default and allowed on request", () => {
+  const equalOperands = { digits: 2, operandDigits: 2, regroupings: 0, acrossZero: 0 } as const;
+  for (let seed = 1; seed <= 3000; seed++) {
+    assert.ok(answerOf(generate(seed, equalOperands)).n > 0n, `seed ${String(seed)} produced zero`);
+  }
+  let sawZero = false;
+  for (let seed = 1; seed <= 3000 && !sawZero; seed++) {
+    if (answerOf(generate(seed, { ...equalOperands, allowZeroResult: true })).n === 0n) sawZero = true;
+  }
+  assert.ok(sawZero, "a - a = 0 is reachable when the level asks for it");
+});
+
+test("column-op: addition carries, and the sum may gain a digit", () => {
+  let sawExtraDigit = false;
+  for (let seed = 1; seed <= 500; seed++) {
+    const exercise = generate(seed, {
+      op: "add",
+      digits: 3,
+      operandDigits: 3,
+      regroupings: 3,
+      acrossZero: 0,
+    });
+    assert.equal(exercise.prompt.key, PROMPT_KEY_ADD);
+    assert.ok(eq(answerOf(exercise), ratAdd(operandOf(exercise, "top"), operandOf(exercise, "bottom"))));
+    if (exercise.schema.kind === "integer") assert.equal(exercise.schema.digits, 4);
+    if ((toScaled(answerOf(exercise), 0) ?? 0n) >= 1000n) sawExtraDigit = true;
+  }
+  assert.ok(sawExtraDigit, "carrying out of the top column widens the answer");
+});
+
+test("column-op: subtraction and addition use different prompt templates", () => {
+  assert.equal(generate(3).prompt.key, PROMPT_KEY_SUB);
+  assert.equal(generate(3, { op: "add", regroupings: 1, acrossZero: 0 }).prompt.key, PROMPT_KEY_ADD);
+});
+
+test("column-op: forms are drawn from the binding and both appear", () => {
+  const seen = new Set<string>();
+  for (let seed = 1; seed <= 100; seed++) seen.add(generate(seed).form);
+  assert.deepEqual([...seen].sort(), [FORM_COLUMN, FORM_FREE_ENTRY]);
+  for (let seed = 1; seed <= 20; seed++) {
+    assert.equal(generate(seed, {}, [FORM_COLUMN]).form, FORM_COLUMN);
+  }
+  assert.throws(() => generate(1, {}, []), InfeasibleParamsError);
+  assert.throws(() => generate(1, {}, ["dial"]), InfeasibleParamsError);
+});
+
+test("column-op: the column form accepts the digits with or without regrouping marks", () => {
+  for (let seed = 1; seed <= 100; seed++) {
+    const exercise = generate(seed, {}, [FORM_COLUMN]);
+    assert.equal(exercise.schema.kind, "columnAlgorithm");
+    const canonical = exercise.answer.canonical;
+    assert.ok(canonical.kind === "columnAlgorithm");
+    assert.ok(canonical.marks.length > 0, "the canonical answer records the regrouping");
+    assert.equal(exercise.answer.alsoAccept.length, 1);
+    const unmarked = exercise.answer.alsoAccept[0];
+    assert.ok(unmarked !== undefined && unmarked.kind === "columnAlgorithm");
+    assert.equal(unmarked.marks.length, 0);
+    assert.ok(columnOpFamily.check(exercise, unmarked).correct, "regrouping mentally is still correct");
+    assert.ok(columnOpFamily.check(exercise, canonical).correct);
+  }
+});
+
+test("column-op: the free-entry form has nothing extra to accept", () => {
+  const exercise = generate(1, {}, [FORM_FREE_ENTRY]);
+  assert.deepEqual(exercise.answer.alsoAccept, []);
+});
+
+test("column-op: check rejects every distractor and names the bug that produced it", () => {
+  for (let seed = 1; seed <= 200; seed++) {
+    const exercise = generate(seed);
+    for (const distractor of exercise.distractors) {
+      const verdict = columnOpFamily.check(exercise, distractor.value);
+      assert.equal(verdict.correct, false);
+      assert.equal(verdict.correct === false ? verdict.misconception : undefined, distractor.misconception);
+    }
+  }
+});
+
+test("column-op: an unclassified wrong answer is wrong without a diagnosis", () => {
+  const exercise = generate(1, {}, [FORM_FREE_ENTRY]);
+  const wrong = { kind: "integer", value: ratAdd(answerOf(exercise), rational(7n)) } as const;
+  const verdict = columnOpFamily.check(exercise, wrong);
+  assert.equal(verdict.correct, false);
+  assert.equal(verdict.correct === false ? verdict.misconception : "unset", undefined);
+});
+
+test("column-op: the solution walks every column and ends on the answer", () => {
+  const exercise = generate(1, {}, [FORM_FREE_ENTRY]);
+  assert.ok(exercise.solution.length >= params().digits + 2);
+  const columns = exercise.solution
+    .filter((step) => step.focusColumn !== undefined)
+    .map((step) => step.focusColumn ?? -1);
+  assert.deepEqual([...columns].sort((a, b) => a - b), columns, "steps run right to left in order");
+  const last = exercise.solution.at(-1);
+  assert.ok(last !== undefined);
+  const answerSlot = last.slots["answer"];
+  assert.ok(answerSlot !== undefined && answerSlot.kind === "number");
+  assert.ok(eq(answerSlot.value, answerOf(exercise)));
+});
+
+test("column-op: difficulty is a pure function of the parameters", () => {
+  const easy = columnOpFamily.difficultyOffset(params({ digits: 2, operandDigits: 2, regroupings: 1, acrossZero: 0 }));
+  const hard = columnOpFamily.difficultyOffset(params());
+  assert.ok(easy.n * hard.d < hard.n * easy.d, "more regrouping and more zeros is harder");
+  // 0.55·3 + 0.30·2 + 0.25·2 = 2.75
+  assert.deepEqual(columnOpFamily.difficultyOffset(params()), rational(275n, 100n));
+  assert.deepEqual(columnOpFamily.formOffset(FORM_COLUMN), rational(-15n, 100n));
+  assert.deepEqual(columnOpFamily.formOffset(FORM_FREE_ENTRY), rational(0n));
+});
+
+test("column-op params: accepts the levels the graph binds", () => {
+  for (const candidate of [
+    params(),
+    params({ digits: 2, operandDigits: 2, regroupings: 1, acrossZero: 0 }),
+    params({ digits: 4, operandDigits: 1, regroupings: 3, acrossZero: 2 }),
+    params({ op: "add", regroupings: 4, acrossZero: 0 }),
+  ]) {
+    assert.equal(columnOpParamSchema.validate(candidate).ok, true, JSON.stringify(candidate));
+  }
+});
+
+test("column-op params: rejects combinations no digit assignment could satisfy", () => {
+  const cases: readonly (readonly [Partial<ColumnOpParams>, string])[] = [
+    [{ digits: 2, operandDigits: 2, regroupings: 2, acrossZero: 0 }, "regroupings"],
+    [{ digits: 3, operandDigits: 3, regroupings: 1, acrossZero: 1 }, "regroupings"],
+    [{ digits: 3, operandDigits: 3, regroupings: 3, acrossZero: 2 }, "acrossZero"],
+    [{ operandDigits: 5 }, "operandDigits"],
+    [{ digits: 1, operandDigits: 1, regroupings: 0, acrossZero: 0 }, "digits"],
+    [{ decimalPlaces: 3 }, "decimalPlaces"],
+    [{ op: "add", acrossZero: 1 }, "acrossZero"],
+    [{ regroupings: -1, acrossZero: 0 }, "regroupings"],
+  ];
+  for (const [overrides, path] of cases) {
+    const result = columnOpParamSchema.validate(params(overrides));
+    assert.equal(result.ok, false, `expected ${JSON.stringify(overrides)} to be rejected`);
+    if (!result.ok) {
+      assert.ok(
+        result.issues.some((issue) => issue.path === path),
+        `expected an issue on ${path}, got ${JSON.stringify(result.issues)}`,
+      );
+    }
+  }
+});
+
+test("column-op params: rejects the wrong shape outright", () => {
+  for (const bad of [null, 42, "sub", {}, { ...params(), op: "times" }, { ...params(), digits: "4" }]) {
+    assert.equal(columnOpParamSchema.validate(bad).ok, false, JSON.stringify(bad));
+  }
+});

--- a/dynawalla/curriculum/src/generators/columnOp/columnOp.test.ts
+++ b/dynawalla/curriculum/src/generators/columnOp/columnOp.test.ts
@@ -11,6 +11,7 @@ import { FORM_COLUMN, FORM_FREE_ENTRY, PROMPT_KEY_ADD, PROMPT_KEY_SUB } from "./
 import { columnOpParamSchema } from "./params.ts";
 import type { ColumnOpParams } from "./params.ts";
 import { readOperands } from "./digits.ts";
+import { addColumns, subtractColumns } from "./procedure.ts";
 
 const SKILL = skillId("dw.add.regroup.subtract-across-zero");
 const BOTH_FORMS = [FORM_FREE_ENTRY, FORM_COLUMN];
@@ -180,18 +181,105 @@ test("column-op: the column form accepts the digits with or without regrouping m
     const canonical = exercise.answer.canonical;
     assert.ok(canonical.kind === "columnAlgorithm");
     assert.ok(canonical.marks.length > 0, "the canonical answer records the regrouping");
-    assert.equal(exercise.answer.alsoAccept.length, 1);
-    const unmarked = exercise.answer.alsoAccept[0];
-    assert.ok(unmarked !== undefined && unmarked.kind === "columnAlgorithm");
-    assert.equal(unmarked.marks.length, 0);
-    assert.ok(columnOpFamily.check(exercise, unmarked).correct, "regrouping mentally is still correct");
     assert.ok(columnOpFamily.check(exercise, canonical).correct);
+
+    // Marks are process evidence, never a correctness condition, so the number
+    // alone is right and so is the number with someone else's marks. `alsoAccept`
+    // stays empty rather than listing a value that is already equal to canonical.
+    assert.deepEqual(exercise.answer.alsoAccept, []);
+    const unmarked = { kind: "columnAlgorithm", value: answerOf(exercise), marks: [] } as const;
+    const misMarked = {
+      kind: "columnAlgorithm",
+      value: answerOf(exercise),
+      marks: [{ column: 0, kind: "borrow", value: 3 } as const],
+    } as const;
+    assert.ok(columnOpFamily.check(exercise, unmarked).correct, "regrouping mentally is still correct");
+    assert.ok(columnOpFamily.check(exercise, misMarked).correct, "and the marks are never graded");
   }
 });
 
 test("column-op: the free-entry form has nothing extra to accept", () => {
   const exercise = generate(1, {}, [FORM_FREE_ENTRY]);
   assert.deepEqual(exercise.answer.alsoAccept, []);
+});
+
+/** One line per solution step: `key@focusColumn slot=value …`, slots in name order. */
+function stepLines(exercise: Exercise): string[] {
+  return exercise.solution.map((step) => {
+    const slots = Object.keys(step.slots)
+      .sort()
+      .map((name) => {
+        const slot = step.slots[name];
+        if (slot === undefined) return `${name}=?`;
+        if (slot.kind === "number") return `${name}=${toDecimalString(slot.value, slot.decimalPlaces) ?? "?"}`;
+        if (slot.kind === "count") return `${name}=${String(slot.value)}`;
+        return `${name}=${slot.key}`;
+      })
+      .join(" ");
+    return `${step.key.replace("dw.solution.column-op.", "")}@${step.focusColumn ?? "-"} ${slots}`;
+  });
+}
+
+test("column-op: the walkthrough shows every regrouping, including the ones across zeros", () => {
+  // The faded worked example for `dw.add.regroup.subtract-across-zero` is the
+  // remediation for `mis.add.borrow-across-zero`, and that misconception *is*
+  // leaving the zero run and the digit above it unchanged. A walkthrough that
+  // announces only the column which could not subtract, and then asserts that the
+  // zeros were nines all along, performs the bug it is repairing. So the whole step
+  // list is pinned, not its length.
+  const acrossZero = columnOpFamily.generate({
+    skillId: SKILL,
+    level: 2,
+    seed: 1,
+    params: params(),
+    forms: [FORM_FREE_ENTRY],
+  });
+  assert.deepEqual(stepLines(acrossZero), [
+    "setup@- bottom=2888 top=4007",
+    "regroup@0 column=0 value=17", // 7 cannot take 8, so the chain runs left
+    "column@0 bottom=8 column=0 digit=9 top=17",
+    "regroup@1 column=1 value=9", // the first zero it crossed
+    "column@1 bottom=8 column=1 digit=1 top=9",
+    "regroup@2 column=2 value=9", // the second
+    "column@2 bottom=8 column=2 digit=1 top=9",
+    "regroup@3 column=3 value=3", // and the 4 it finally took from
+    "column@3 bottom=2 column=3 digit=1 top=3",
+    "result@- answer=1119",
+  ]);
+
+  // 5001 − 2798, the worked example the whole diagnosis story hangs on, generated
+  // rather than hand-built: one draw in ~126,000 at this level, found by search.
+  const documented = columnOpFamily.generate({
+    skillId: SKILL,
+    level: 2,
+    seed: 159579,
+    params: params(),
+    forms: [FORM_FREE_ENTRY],
+  });
+  assert.deepEqual(stepLines(documented), [
+    "setup@- bottom=2798 top=5001",
+    "regroup@0 column=0 value=11",
+    "column@0 bottom=8 column=0 digit=3 top=11",
+    "regroup@1 column=1 value=9",
+    "column@1 bottom=9 column=1 digit=0 top=9",
+    "regroup@2 column=2 value=9",
+    "column@2 bottom=7 column=2 digit=2 top=9",
+    "regroup@3 column=3 value=4",
+    "column@3 bottom=2 column=3 digit=2 top=4",
+    "result@- answer=2203",
+  ]);
+
+  // The digit that was borrowed from is announced in the small case too, where it
+  // is the only regrouping there is: 32 − 16 must not assert that the 3 is a 2.
+  const oneBorrow = generate(1, { digits: 2, operandDigits: 2, regroupings: 1, acrossZero: 0 }, [FORM_FREE_ENTRY]);
+  assert.deepEqual(stepLines(oneBorrow), [
+    "setup@- bottom=16 top=32",
+    "regroup@0 column=0 value=12",
+    "column@0 bottom=6 column=0 digit=6 top=12",
+    "regroup@1 column=1 value=2",
+    "column@1 bottom=1 column=1 digit=1 top=2",
+    "result@- answer=16",
+  ]);
 });
 
 test("column-op: check rejects every distractor and names the bug that produced it", () => {
@@ -225,6 +313,40 @@ test("column-op: the solution walks every column and ends on the answer", () => 
   const answerSlot = last.slots["answer"];
   assert.ok(answerSlot !== undefined && answerSlot.kind === "number");
   assert.ok(eq(answerSlot.value, answerOf(exercise)));
+});
+
+test("column-op: the shared procedure matches the worked example, column by column", () => {
+  // 5001 − 2798, hand-derived: the units column takes ten and becomes 11; the two
+  // zeros the chain crosses are rewritten as 9s and each takes ten of its own; the
+  // 5 gives one up and becomes 4. Both the generator and the mal-rules read this,
+  // so a hand-checked table here is what stops the two drifting apart again.
+  const trace = subtractColumns([1, 0, 0, 5], [8, 9, 7, 2], 4);
+  assert.equal(trace.defined, true);
+  assert.deepEqual(
+    trace.columns.map((column) => [column.borrowed, column.restated, column.effective, column.digit]),
+    [
+      [true, 1, 11, 3],
+      [true, 9, 9, 0],
+      [true, 9, 9, 2],
+      [false, 4, 4, 2],
+    ],
+  );
+
+  // 102 − 456: the borrow runs off the top and the difference is negative, which
+  // this family never emits.
+  assert.equal(subtractColumns([2, 0, 1], [6, 5, 4], 3).defined, false);
+
+  // 47 + 25 = 72: the units carry, the tens do not, and the carry out is zero.
+  const sum = addColumns([7, 4], [5, 2], 2);
+  assert.deepEqual(
+    sum.columns.map((column) => [column.carried, column.effective, column.digit]),
+    [
+      [true, 7, 2],
+      [false, 5, 7],
+    ],
+  );
+  assert.equal(sum.carryOut, 0);
+  assert.equal(addColumns([9, 9], [9, 9], 2).carryOut, 1);
 });
 
 test("column-op: difficulty is a pure function of the parameters", () => {

--- a/dynawalla/curriculum/src/generators/columnOp/constants.ts
+++ b/dynawalla/curriculum/src/generators/columnOp/constants.ts
@@ -1,0 +1,90 @@
+/**
+ * `gen.arith.column-op` constants — ids, locale keys and every difficulty
+ * coefficient, in one place.
+ *
+ * CURRICULUM.md pins the shape of the difficulty function:
+ *
+ *   b = b_skill
+ *     + 0.55·regroupings
+ *     + 0.30·(maxDigits − 2)
+ *     + 0.25·zeroBorrowThrough
+ *     + 0.20·noAnchor
+ *     − 0.35·specialCase
+ *     + repOffset + formOffset
+ *
+ * with every coefficient in one `constants.ts`. Of those terms, `regroupings`,
+ * `maxDigits` and `zeroBorrowThrough` are column-op parameters. `noAnchor` and
+ * `specialCase` are not — this family has no anchor or special-case parameter — so
+ * they contribute zero here and the 0.20 slot is spent instead on `decimalPlaces`,
+ * which is a column-op parameter and does make an item harder. That substitution is
+ * a deliberate, falsifiable claim about difficulty; gate EG-5 is what tests it.
+ *
+ * Every coefficient is an exact rational. `0.55` as a float would make `b` — and
+ * therefore `P̂` — platform-dependent in the last bits.
+ */
+
+import { rational } from "../../math/rational.ts";
+import { familyId, locKey } from "../../types/ids.ts";
+
+export const COLUMN_OP_FAMILY = familyId("gen.arith.column-op");
+
+/**
+ * Bump whenever generated output changes for any seed. CG-16 keys its committed
+ * output hashes on this value.
+ */
+export const COLUMN_OP_FAMILY_REV = 1;
+
+export const FORM_FREE_ENTRY = "free-entry";
+export const FORM_COLUMN = "column";
+export const COLUMN_OP_FORMS = [FORM_FREE_ENTRY, FORM_COLUMN] as const;
+
+export const PROMPT_KEY_SUB = locKey("dw.prompt.column-op.sub");
+export const PROMPT_KEY_ADD = locKey("dw.prompt.column-op.add");
+
+export const SOLUTION_KEY_SETUP = locKey("dw.solution.column-op.setup");
+export const SOLUTION_KEY_REGROUP = locKey("dw.solution.column-op.regroup");
+export const SOLUTION_KEY_CARRY = locKey("dw.solution.column-op.carry");
+export const SOLUTION_KEY_COLUMN = locKey("dw.solution.column-op.column");
+export const SOLUTION_KEY_RESULT = locKey("dw.solution.column-op.result");
+
+/**
+ * Every locale key this family can emit. The i18n gate (CG-19, PR-4.7) reads this
+ * rather than grepping, so a new template that nobody translated fails loudly.
+ */
+export const COLUMN_OP_LOC_KEYS = [
+  PROMPT_KEY_SUB,
+  PROMPT_KEY_ADD,
+  SOLUTION_KEY_SETUP,
+  SOLUTION_KEY_REGROUP,
+  SOLUTION_KEY_CARRY,
+  SOLUTION_KEY_COLUMN,
+  SOLUTION_KEY_RESULT,
+] as const;
+
+/** Prompt slot names. Stable: they are part of the translated template. */
+export const SLOT_TOP = "top";
+export const SLOT_BOTTOM = "bottom";
+export const SLOT_ANSWER = "answer";
+export const SLOT_COLUMN = "column";
+export const SLOT_VALUE = "value";
+export const SLOT_DIGIT = "digit";
+
+/** 0.55 per regrouping (borrow or carry). */
+export const COEFF_REGROUPING = rational(55n, 100n);
+/** 0.30 per digit beyond two. */
+export const COEFF_DIGIT_OVER_TWO = rational(30n, 100n);
+/** 0.25 per zero a borrow has to travel through. */
+export const COEFF_ZERO_BORROW_THROUGH = rational(25n, 100n);
+/** 0.20 per decimal place (see the note above about the `noAnchor` slot). */
+export const COEFF_DECIMAL_PLACE = rational(20n, 100n);
+
+/**
+ * Form offsets. The column form draws the scaffold — the grid, the place-value
+ * alignment and the space for regrouping marks — so the same numbers are easier
+ * there than in free entry. Provisional until the M2 playtest (T-03).
+ */
+export const FORM_OFFSET_FREE_ENTRY = rational(0n);
+export const FORM_OFFSET_COLUMN = rational(-15n, 100n);
+
+/** Bounds the deterministic retry loop that rejects degenerate draws. */
+export const MAX_GENERATE_ATTEMPTS = 32;

--- a/dynawalla/curriculum/src/generators/columnOp/digits.ts
+++ b/dynawalla/curriculum/src/generators/columnOp/digits.ts
@@ -1,0 +1,101 @@
+/**
+ * Digit-array helpers, and the one way to read a column-op item's operands back
+ * out of an `Exercise`.
+ *
+ * Mal-rules are `(exercise) => AnswerValue | null` — they see the public exercise
+ * contract, not the generator's internals. That is what makes them usable for
+ * diagnosis at runtime and for `gen.logic.error-analysis` content later. They
+ * therefore need a supported way to recover the written digits, which is this.
+ *
+ * Digit arrays are **little-endian**: index 0 is the units column, which is the
+ * order the column algorithm is actually performed in.
+ */
+
+import { fromScaled, toScaled } from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import type { Exercise } from "../../types/exercise.ts";
+import { PROMPT_KEY_ADD, PROMPT_KEY_SUB, SLOT_BOTTOM, SLOT_TOP } from "./constants.ts";
+import type { ColumnOp } from "./params.ts";
+
+export type Operands = {
+  readonly op: ColumnOp;
+  /** Little-endian digits of the top operand, padded to `cols`. */
+  readonly top: readonly number[];
+  /** Little-endian digits of the bottom operand, padded to `cols`. */
+  readonly bottom: readonly number[];
+  readonly cols: number;
+  readonly decimalPlaces: number;
+};
+
+/** Little-endian digits of a non-negative integer, padded to at least `width`. */
+export function toDigits(value: bigint, width: number): number[] {
+  if (value < 0n) throw new RangeError("toDigits: negative value");
+  const out: number[] = [];
+  let rest = value;
+  while (rest > 0n) {
+    out.push(Number(rest % 10n));
+    rest /= 10n;
+  }
+  while (out.length < width) out.push(0);
+  return out;
+}
+
+/** Inverse of `toDigits`. */
+export function fromDigits(digits: readonly number[]): bigint {
+  let out = 0n;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    const digit = digits[i];
+    if (digit === undefined || digit < 0 || digit > 9) {
+      throw new RangeError(`fromDigits: bad digit at ${String(i)}`);
+    }
+    out = out * 10n + BigInt(digit);
+  }
+  return out;
+}
+
+/** A digit array as a rational, given the decimal-point position. */
+export function digitsToRational(digits: readonly number[], decimalPlaces: number): Rational {
+  return fromScaled(fromDigits(digits), decimalPlaces);
+}
+
+function readNumberSlot(exercise: Exercise, name: string): { value: Rational; decimalPlaces: number } | null {
+  const slot = exercise.prompt.slots[name];
+  if (slot === undefined || slot.kind !== "number") return null;
+  return { value: slot.value, decimalPlaces: slot.decimalPlaces };
+}
+
+/**
+ * Recover the written operands, or `null` when the exercise is not a column-op
+ * item. Never throws: a mal-rule handed an item from another family must simply
+ * decline it.
+ */
+export function readOperands(exercise: Exercise): Operands | null {
+  const op: ColumnOp | null =
+    exercise.prompt.key === PROMPT_KEY_SUB ? "sub" : exercise.prompt.key === PROMPT_KEY_ADD ? "add" : null;
+  if (op === null) return null;
+
+  const top = readNumberSlot(exercise, SLOT_TOP);
+  const bottom = readNumberSlot(exercise, SLOT_BOTTOM);
+  if (top === null || bottom === null) return null;
+  if (top.decimalPlaces !== bottom.decimalPlaces) return null;
+
+  const decimalPlaces = top.decimalPlaces;
+  const topScaled = toScaled(top.value, decimalPlaces);
+  const bottomScaled = toScaled(bottom.value, decimalPlaces);
+  if (topScaled === null || bottomScaled === null) return null;
+  if (topScaled < 0n || bottomScaled < 0n) return null;
+
+  const width = Math.max(topScaled.toString().length, bottomScaled.toString().length);
+  return {
+    op,
+    top: toDigits(topScaled, width),
+    bottom: toDigits(bottomScaled, width),
+    cols: width,
+    decimalPlaces,
+  };
+}
+
+/** The digit at `index`, or 0 above the written number. */
+export function digitAt(digits: readonly number[], index: number): number {
+  return digits[index] ?? 0;
+}

--- a/dynawalla/curriculum/src/generators/columnOp/family.ts
+++ b/dynawalla/curriculum/src/generators/columnOp/family.ts
@@ -1,0 +1,449 @@
+/**
+ * `gen.arith.column-op` — the column algorithm, add and subtract, with exact
+ * regrouping control including regrouping across zeros.
+ *
+ * How generation works, and why it works this way.
+ *
+ * The naive approach is to draw two numbers and hope the requested number of
+ * regroupings falls out. It does not: "4-digit subtraction borrowing through two
+ * zeros" is rare under uniform draws, so a rejection-sampling generator either runs
+ * for a long time or quietly serves items that miss the thing the skill is about.
+ *
+ * So the *regrouping pattern is drawn first* and the digits are then chosen column
+ * by column from the ranges that pattern forces. Every item therefore has exactly
+ * the requested structure by construction, a difference is never negative (the top
+ * column never borrows out), and the only rejection is the degenerate `a − a = 0`
+ * draw.
+ *
+ * All arithmetic is BigInt and `Rational`. The digit-wise result is cross-checked
+ * against `Rational` addition/subtraction on every single call — a mismatch throws
+ * rather than serving a wrong answer.
+ */
+
+import { eq as rationalEq, mul, add as ratAdd, sub as ratSub, rational } from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import { createRng, seedFrom } from "../../rng/rng.ts";
+import type { Rng } from "../../rng/rng.ts";
+import type { AnswerSchema, AnswerValue, ColumnMark } from "../../types/answer.ts";
+import { answerEquals } from "../../types/answer.ts";
+import type { Distractor, Exercise, PromptSlot, SolutionStep } from "../../types/exercise.ts";
+import { exerciseIdOf } from "../../types/ids.ts";
+import type { FormId } from "../../types/ids.ts";
+import type { GenerateRequest, GeneratorFamily, Verdict } from "../../types/generator.ts";
+import { classify, malRulesForFamily } from "../../malrules/registry.ts";
+import { answerValueFor } from "./answerValue.ts";
+import {
+  COEFF_DECIMAL_PLACE,
+  COEFF_DIGIT_OVER_TWO,
+  COEFF_REGROUPING,
+  COEFF_ZERO_BORROW_THROUGH,
+  COLUMN_OP_FAMILY,
+  COLUMN_OP_FAMILY_REV,
+  COLUMN_OP_FORMS,
+  FORM_COLUMN,
+  FORM_OFFSET_COLUMN,
+  FORM_OFFSET_FREE_ENTRY,
+  MAX_GENERATE_ATTEMPTS,
+  PROMPT_KEY_ADD,
+  PROMPT_KEY_SUB,
+  SLOT_ANSWER,
+  SLOT_BOTTOM,
+  SLOT_COLUMN,
+  SLOT_DIGIT,
+  SLOT_TOP,
+  SLOT_VALUE,
+  SOLUTION_KEY_CARRY,
+  SOLUTION_KEY_COLUMN,
+  SOLUTION_KEY_REGROUP,
+  SOLUTION_KEY_RESULT,
+  SOLUTION_KEY_SETUP,
+} from "./constants.ts";
+import { digitsToRational, fromDigits } from "./digits.ts";
+import { chainRegroupings, columnOpParamSchema, extraRegroupColumns } from "./params.ts";
+import type { ColumnOpParams } from "./params.ts";
+
+/** Thrown when a parameter set reaches generation that no digit assignment satisfies. */
+export class InfeasibleParamsError extends Error {}
+
+type Draw = {
+  readonly top: number[];
+  readonly bottom: number[];
+  readonly result: number[];
+  /** Did column `i` regroup (borrow out for `sub`, carry out for `add`)? */
+  readonly regrouped: boolean[];
+  /** The value actually worked with in column `i` (10..18 after a borrow). */
+  readonly effectiveTop: number[];
+  readonly marks: ColumnMark[];
+};
+
+function at(digits: readonly number[], index: number): number {
+  return digits[index] ?? 0;
+}
+
+function pickInt(rng: Rng, lo: number, hi: number, what: string): number {
+  if (lo > hi) {
+    throw new InfeasibleParamsError(`${what}: empty digit range ${String(lo)}..${String(hi)}`);
+  }
+  return rng.nextInt(lo, hi);
+}
+
+/** Choose which columns regroup: the across-zero chain first, then extra columns. */
+function regroupPattern(params: ColumnOpParams, rng: Rng): { regroup: boolean[]; zeroCols: Set<number> } {
+  const regroup = new Array<boolean>(params.digits).fill(false);
+  const zeroCols = new Set<number>();
+
+  if (params.op === "sub" && params.acrossZero > 0) {
+    // Columns 0..acrossZero all borrow out; columns 1..acrossZero are zeros in the
+    // minuend, so the borrow travels through them to the digit above the run.
+    for (let i = 0; i <= params.acrossZero; i++) regroup[i] = true;
+    for (let i = 1; i <= params.acrossZero; i++) zeroCols.add(i);
+  }
+
+  const extra = params.regroupings - chainRegroupings(params);
+  if (extra > 0) {
+    const candidates = extraRegroupColumns(params);
+    if (extra > candidates.length) {
+      throw new InfeasibleParamsError(
+        `cannot place ${String(extra)} further regrouping(s) in ${String(candidates.length)} column(s)`,
+      );
+    }
+    for (const column of rng.sample(candidates, extra)) regroup[column] = true;
+  }
+  return { regroup, zeroCols };
+}
+
+function drawSub(params: ColumnOpParams, rng: Rng): Draw {
+  const { digits: cols, operandDigits } = params;
+  const { regroup, zeroCols } = regroupPattern(params, rng);
+
+  const top: number[] = [];
+  const bottom: number[] = [];
+
+  for (let i = 0; i < cols; i++) {
+    const incoming = i > 0 && regroup[i - 1] === true ? 1 : 0;
+    const outgoing = regroup[i] === true ? 1 : 0;
+    const isTopColumn = i === cols - 1;
+    const hasBottom = i < operandDigits;
+    const isBottomLead = i === operandDigits - 1;
+    const forcedZero = zeroCols.has(i);
+
+    let mLo = isTopColumn ? 1 : 0;
+    let mHi = 9;
+    if (outgoing === 1) {
+      // Borrowing needs bottom > top − incoming, and a bottom digit is at most 9.
+      mHi = Math.min(mHi, 8 + incoming);
+      if (!hasBottom) {
+        // Nothing to subtract here, so the only way this column borrows is as part
+        // of a zero run: the digit is 0 and the borrow came in from the right.
+        if (incoming !== 1) {
+          throw new InfeasibleParamsError(`column ${String(i)} cannot borrow with no bottom digit`);
+        }
+        mLo = 0;
+        mHi = 0;
+      }
+    } else {
+      mLo = Math.max(mLo, incoming + (isBottomLead ? 1 : 0));
+    }
+    if (forcedZero) {
+      mLo = 0;
+      mHi = 0;
+    }
+    const m = pickInt(rng, mLo, mHi, `sub top digit ${String(i)}`);
+
+    let s: number;
+    if (!hasBottom) {
+      s = 0;
+    } else if (outgoing === 1) {
+      s = pickInt(rng, Math.max(m - incoming + 1, isBottomLead ? 1 : 0), 9, `sub bottom digit ${String(i)}`);
+    } else {
+      s = pickInt(rng, isBottomLead ? 1 : 0, m - incoming, `sub bottom digit ${String(i)}`);
+    }
+
+    top.push(m);
+    bottom.push(s);
+  }
+
+  // Run the *correct* procedure for the result digits and the regrouping marks.
+  const work = [...top];
+  const result: number[] = [];
+  const regrouped: boolean[] = [];
+  const effectiveTop: number[] = [];
+  const marks: ColumnMark[] = [];
+
+  for (let i = 0; i < cols; i++) {
+    let t = at(work, i);
+    const s = at(bottom, i);
+    if (t < s) {
+      let j = i + 1;
+      while (j < cols && at(work, j) === 0) {
+        work[j] = 9;
+        j += 1;
+      }
+      if (j >= cols) throw new InfeasibleParamsError(`column ${String(i)} has nothing to borrow from`);
+      work[j] = at(work, j) - 1;
+      t += 10;
+      regrouped.push(true);
+    } else {
+      regrouped.push(false);
+    }
+    effectiveTop.push(t);
+    result.push(t - s);
+  }
+  for (let j = 0; j < cols; j++) {
+    if (at(work, j) !== at(top, j)) marks.push({ column: j, kind: "borrow", value: at(work, j) });
+  }
+
+  return { top, bottom, result, regrouped, effectiveTop, marks };
+}
+
+function drawAdd(params: ColumnOpParams, rng: Rng): Draw {
+  const { digits: cols, operandDigits } = params;
+  const { regroup } = regroupPattern(params, rng);
+
+  const top: number[] = [];
+  const bottom: number[] = [];
+
+  for (let i = 0; i < cols; i++) {
+    const incoming = i > 0 && regroup[i - 1] === true ? 1 : 0;
+    const outgoing = regroup[i] === true ? 1 : 0;
+    const isTopColumn = i === cols - 1;
+    const hasBottom = i < operandDigits;
+    const isBottomLead = i === operandDigits - 1;
+
+    let mLo = isTopColumn ? 1 : 0;
+    let mHi = 9;
+    if (outgoing === 1) {
+      mLo = Math.max(mLo, 1 - incoming);
+      // With no bottom digit the only way to carry is 9 + an incoming carry.
+      if (!hasBottom) mLo = Math.max(mLo, 10 - incoming);
+    } else {
+      mHi = Math.min(mHi, 9 - incoming - (isBottomLead ? 1 : 0));
+    }
+    const m = pickInt(rng, mLo, mHi, `add top digit ${String(i)}`);
+
+    let s: number;
+    if (!hasBottom) {
+      s = 0;
+    } else if (outgoing === 1) {
+      s = pickInt(rng, Math.max(10 - incoming - m, isBottomLead ? 1 : 0), 9, `add bottom digit ${String(i)}`);
+    } else {
+      s = pickInt(rng, isBottomLead ? 1 : 0, 9 - incoming - m, `add bottom digit ${String(i)}`);
+    }
+
+    top.push(m);
+    bottom.push(s);
+  }
+
+  const result: number[] = [];
+  const regrouped: boolean[] = [];
+  const effectiveTop: number[] = [];
+  const marks: ColumnMark[] = [];
+  let carry = 0;
+
+  for (let i = 0; i < cols; i++) {
+    const sum = at(top, i) + at(bottom, i) + carry;
+    effectiveTop.push(at(top, i) + carry);
+    result.push(sum % 10);
+    carry = sum >= 10 ? 1 : 0;
+    regrouped.push(carry === 1);
+    if (carry === 1) marks.push({ column: i + 1, kind: "carry", value: 1 });
+  }
+  // The final carry occupies one more column; it is 0 when there was none.
+  result.push(carry);
+
+  return { top, bottom, result, regrouped, effectiveTop, marks };
+}
+
+function answerDigitCapacity(params: ColumnOpParams): number {
+  // The *field* width, never the width of this item's answer. Sizing the field to
+  // the answer would tell a child how many digits it has (ARCHITECTURE L3).
+  return params.op === "add" ? params.digits + 1 : params.digits;
+}
+
+function schemaFor(params: ColumnOpParams, form: FormId): AnswerSchema {
+  if (form === FORM_COLUMN) {
+    return {
+      kind: "columnAlgorithm",
+      cols: answerDigitCapacity(params),
+      marks: params.op === "sub" ? "borrow" : "carry",
+      decimalPlaces: params.decimalPlaces,
+    };
+  }
+  return { kind: "integer", digits: answerDigitCapacity(params), decimalPlaces: params.decimalPlaces };
+}
+
+function numberSlot(value: Rational, decimalPlaces: number): PromptSlot {
+  return { kind: "number", value, decimalPlaces };
+}
+
+function countSlot(value: number): PromptSlot {
+  return { kind: "count", value };
+}
+
+function solutionFor(
+  params: ColumnOpParams,
+  draw: Draw,
+  topValue: Rational,
+  bottomValue: Rational,
+  answer: Rational,
+): SolutionStep[] {
+  const dp = params.decimalPlaces;
+  const steps: SolutionStep[] = [
+    {
+      key: SOLUTION_KEY_SETUP,
+      slots: { [SLOT_TOP]: numberSlot(topValue, dp), [SLOT_BOTTOM]: numberSlot(bottomValue, dp) },
+    },
+  ];
+
+  for (let i = 0; i < params.digits; i++) {
+    const regrouped = draw.regrouped[i] === true;
+    if (params.op === "sub" && regrouped) {
+      steps.push({
+        key: SOLUTION_KEY_REGROUP,
+        slots: { [SLOT_COLUMN]: countSlot(i), [SLOT_VALUE]: countSlot(at(draw.effectiveTop, i)) },
+        focusColumn: i,
+      });
+    }
+    steps.push({
+      key: SOLUTION_KEY_COLUMN,
+      slots: {
+        [SLOT_COLUMN]: countSlot(i),
+        [SLOT_TOP]: countSlot(at(draw.effectiveTop, i)),
+        [SLOT_BOTTOM]: countSlot(at(draw.bottom, i)),
+        [SLOT_DIGIT]: countSlot(at(draw.result, i)),
+      },
+      focusColumn: i,
+    });
+    if (params.op === "add" && regrouped) {
+      steps.push({
+        key: SOLUTION_KEY_CARRY,
+        slots: { [SLOT_COLUMN]: countSlot(i + 1), [SLOT_VALUE]: countSlot(1) },
+        focusColumn: i + 1,
+      });
+    }
+  }
+
+  steps.push({ key: SOLUTION_KEY_RESULT, slots: { [SLOT_ANSWER]: numberSlot(answer, dp) } });
+  return steps;
+}
+
+function distractorsFor(exercise: Exercise): Distractor[] {
+  const canonical = exercise.answer.canonical;
+  const out: Distractor[] = [];
+  for (const rule of malRulesForFamily(COLUMN_OP_FAMILY)) {
+    if (!rule.applies(exercise)) continue;
+    const produced = rule.apply(exercise);
+    if (produced === null) continue;
+    // A buggy procedure that lands on the right answer for this item is not a
+    // distractor, and neither is a duplicate of one already offered.
+    if (answerEquals(produced, canonical)) continue;
+    if (out.some((d) => answerEquals(d.value, produced))) continue;
+    out.push({ value: produced, misconception: rule.id });
+  }
+  return out;
+}
+
+function pickForm(forms: readonly FormId[], rng: Rng): FormId {
+  const first = forms[0];
+  if (first === undefined) throw new InfeasibleParamsError("binding declares no forms");
+  for (const form of forms) {
+    if (!(COLUMN_OP_FORMS as readonly string[]).includes(form)) {
+      throw new InfeasibleParamsError(`unknown form ${JSON.stringify(form)}`);
+    }
+  }
+  return forms.length === 1 ? first : rng.pick(forms);
+}
+
+export const columnOpFamily: GeneratorFamily<ColumnOpParams> = {
+  family: COLUMN_OP_FAMILY,
+  familyRev: COLUMN_OP_FAMILY_REV,
+  paramSchema: columnOpParamSchema,
+  forms: COLUMN_OP_FORMS,
+  choiceOnly: false,
+  representations: [],
+
+  answerSchema(params: ColumnOpParams, form: FormId): AnswerSchema {
+    return schemaFor(params, form);
+  },
+
+  difficultyOffset(params: ColumnOpParams): Rational {
+    let b = mul(COEFF_REGROUPING, rational(BigInt(params.regroupings)));
+    b = ratAdd(b, mul(COEFF_DIGIT_OVER_TWO, rational(BigInt(params.digits - 2))));
+    b = ratAdd(b, mul(COEFF_ZERO_BORROW_THROUGH, rational(BigInt(params.acrossZero))));
+    b = ratAdd(b, mul(COEFF_DECIMAL_PLACE, rational(BigInt(params.decimalPlaces))));
+    return b;
+  },
+
+  formOffset(form: FormId): Rational {
+    return form === FORM_COLUMN ? FORM_OFFSET_COLUMN : FORM_OFFSET_FREE_ENTRY;
+  },
+
+  generate(request: GenerateRequest<ColumnOpParams>): Exercise {
+    const { skillId, level, seed, params, forms } = request;
+    const exerciseId = exerciseIdOf(COLUMN_OP_FAMILY, COLUMN_OP_FAMILY_REV, skillId, level, seed);
+
+    for (let attempt = 0; attempt < MAX_GENERATE_ATTEMPTS; attempt++) {
+      const rng = createRng(seedFrom(exerciseId, String(attempt)));
+      const form = pickForm(forms, rng);
+      const draw = params.op === "sub" ? drawSub(params, rng) : drawAdd(params, rng);
+
+      const dp = params.decimalPlaces;
+      const topValue = digitsToRational(draw.top, dp);
+      const bottomValue = digitsToRational(draw.bottom, dp);
+      const answer = digitsToRational(draw.result, dp);
+
+      // The whole point of the family, asserted on every call: the digit-wise
+      // column algorithm and exact rational arithmetic agree.
+      const exact = params.op === "sub" ? ratSub(topValue, bottomValue) : ratAdd(topValue, bottomValue);
+      if (!rationalEq(exact, answer)) {
+        throw new Error(`column algorithm disagreed with exact arithmetic on ${exerciseId}`);
+      }
+      if (fromDigits(draw.result) === 0n && !params.allowZeroResult) continue;
+
+      const schema = schemaFor(params, form);
+      const canonical = answerValueFor(schema, answer, draw.marks);
+      const alsoAccept: AnswerValue[] =
+        schema.kind === "columnAlgorithm"
+          ? // A child who regroups mentally and writes only the digits is right.
+            [answerValueFor(schema, answer, [])]
+          : [];
+
+      const base: Exercise = {
+        exerciseId,
+        skillId,
+        level,
+        seed,
+        family: COLUMN_OP_FAMILY,
+        familyRev: COLUMN_OP_FAMILY_REV,
+        form,
+        prompt: {
+          key: params.op === "sub" ? PROMPT_KEY_SUB : PROMPT_KEY_ADD,
+          slots: {
+            [SLOT_TOP]: numberSlot(topValue, dp),
+            [SLOT_BOTTOM]: numberSlot(bottomValue, dp),
+          },
+        },
+        schema,
+        answer: { canonical, alsoAccept },
+        distractors: [],
+        check: { kind: "exact" },
+        solution: solutionFor(params, draw, topValue, bottomValue, answer),
+      };
+
+      return { ...base, distractors: distractorsFor(base) };
+    }
+
+    throw new InfeasibleParamsError(
+      `every draw for ${exerciseId} was degenerate after ${String(MAX_GENERATE_ATTEMPTS)} attempts`,
+    );
+  },
+
+  check(exercise: Exercise, submitted: AnswerValue): Verdict {
+    if (answerEquals(submitted, exercise.answer.canonical)) return { correct: true };
+    for (const accepted of exercise.answer.alsoAccept) {
+      if (answerEquals(submitted, accepted)) return { correct: true };
+    }
+    const misconception = classify(exercise, submitted);
+    return misconception === null ? { correct: false } : { correct: false, misconception };
+  },
+};

--- a/dynawalla/curriculum/src/generators/columnOp/family.ts
+++ b/dynawalla/curriculum/src/generators/columnOp/family.ts
@@ -61,6 +61,7 @@ import {
 import { digitsToRational, fromDigits } from "./digits.ts";
 import { chainRegroupings, columnOpParamSchema, extraRegroupColumns } from "./params.ts";
 import type { ColumnOpParams } from "./params.ts";
+import { addColumns, subtractColumns } from "./procedure.ts";
 
 /** Thrown when a parameter set reaches generation that no digit assignment satisfies. */
 export class InfeasibleParamsError extends Error {}
@@ -69,7 +70,7 @@ type Draw = {
   readonly top: number[];
   readonly bottom: number[];
   readonly result: number[];
-  /** Did column `i` regroup (borrow out for `sub`, carry out for `add`)? */
+  /** Did column `i` regroup — take ten from its left for `sub`, carry out for `add`? */
   readonly regrouped: boolean[];
   /** The value actually worked with in column `i` (10..18 after a borrow). */
   readonly effectiveTop: number[];
@@ -163,35 +164,25 @@ function drawSub(params: ColumnOpParams, rng: Rng): Draw {
     bottom.push(s);
   }
 
-  // Run the *correct* procedure for the result digits and the regrouping marks.
-  const work = [...top];
+  // Run the *correct* procedure — the one the mal-rules measure against — for the
+  // result digits, the regrouping marks and the value each column is worked with.
+  const trace = subtractColumns(top, bottom, cols);
+  if (!trace.defined) throw new InfeasibleParamsError("the borrow runs off the top column");
+
   const result: number[] = [];
   const regrouped: boolean[] = [];
   const effectiveTop: number[] = [];
   const marks: ColumnMark[] = [];
 
-  for (let i = 0; i < cols; i++) {
-    let t = at(work, i);
-    const s = at(bottom, i);
-    if (t < s) {
-      let j = i + 1;
-      while (j < cols && at(work, j) === 0) {
-        work[j] = 9;
-        j += 1;
-      }
-      if (j >= cols) throw new InfeasibleParamsError(`column ${String(i)} has nothing to borrow from`);
-      work[j] = at(work, j) - 1;
-      t += 10;
-      regrouped.push(true);
-    } else {
-      regrouped.push(false);
-    }
-    effectiveTop.push(t);
-    result.push(t - s);
-  }
-  for (let j = 0; j < cols; j++) {
-    if (at(work, j) !== at(top, j)) marks.push({ column: j, kind: "borrow", value: at(work, j) });
-  }
+  trace.columns.forEach((column, i) => {
+    result.push(column.digit);
+    regrouped.push(column.borrowed);
+    effectiveTop.push(column.effective);
+    // A mark is a digit the child rewrites: the zeros a chain crossed, and the digit
+    // it finally took from. The column that triggered the chain writes its ten in
+    // front of the digit rather than over it, which is not a mark.
+    if (column.restated !== at(top, i)) marks.push({ column: i, kind: "borrow", value: column.restated });
+  });
 
   return { top, bottom, result, regrouped, effectiveTop, marks };
 }
@@ -234,22 +225,20 @@ function drawAdd(params: ColumnOpParams, rng: Rng): Draw {
     bottom.push(s);
   }
 
+  const trace = addColumns(top, bottom, cols);
   const result: number[] = [];
   const regrouped: boolean[] = [];
   const effectiveTop: number[] = [];
   const marks: ColumnMark[] = [];
-  let carry = 0;
 
-  for (let i = 0; i < cols; i++) {
-    const sum = at(top, i) + at(bottom, i) + carry;
-    effectiveTop.push(at(top, i) + carry);
-    result.push(sum % 10);
-    carry = sum >= 10 ? 1 : 0;
-    regrouped.push(carry === 1);
-    if (carry === 1) marks.push({ column: i + 1, kind: "carry", value: 1 });
-  }
+  trace.columns.forEach((column, i) => {
+    result.push(column.digit);
+    regrouped.push(column.carried);
+    effectiveTop.push(column.effective);
+    if (column.carried) marks.push({ column: i + 1, kind: "carry", value: 1 });
+  });
   // The final carry occupies one more column; it is 0 when there was none.
-  result.push(carry);
+  result.push(trace.carryOut);
 
   return { top, bottom, result, regrouped, effectiveTop, marks };
 }
@@ -297,7 +286,14 @@ function solutionFor(
 
   for (let i = 0; i < params.digits; i++) {
     const regrouped = draw.regrouped[i] === true;
-    if (params.op === "sub" && regrouped) {
+    // Announce *every* column the regrouping changed, not only the one that could
+    // not subtract: the zeros a borrow chain rewrote as 9s and the digit it finally
+    // took from are changes the child cannot read off the page either. Omitting them
+    // is `mis.add.borrow-across-zero` — and this walkthrough is that misconception's
+    // remediation, so it must not perform it. The test for `4007 − 2888` is the
+    // guard. `effectiveTop` differs from the written digit exactly when something
+    // happened to the column, which covers all three cases with one condition.
+    if (params.op === "sub" && at(draw.effectiveTop, i) !== at(draw.top, i)) {
       steps.push({
         key: SOLUTION_KEY_REGROUP,
         slots: { [SLOT_COLUMN]: countSlot(i), [SLOT_VALUE]: countSlot(at(draw.effectiveTop, i)) },
@@ -402,11 +398,6 @@ export const columnOpFamily: GeneratorFamily<ColumnOpParams> = {
 
       const schema = schemaFor(params, form);
       const canonical = answerValueFor(schema, answer, draw.marks);
-      const alsoAccept: AnswerValue[] =
-        schema.kind === "columnAlgorithm"
-          ? // A child who regroups mentally and writes only the digits is right.
-            [answerValueFor(schema, answer, [])]
-          : [];
 
       const base: Exercise = {
         exerciseId,
@@ -424,7 +415,12 @@ export const columnOpFamily: GeneratorFamily<ColumnOpParams> = {
           },
         },
         schema,
-        answer: { canonical, alsoAccept },
+        // `alsoAccept` stays empty on purpose. `answerEquals` compares the number
+        // and ignores the marks, so the unmarked column answer a child who regroups
+        // mentally writes is already equal to `canonical`; listing it would make
+        // CG-11's `alsoAccept` loop re-assert the canonical check on a value equal to
+        // canonical, and would put a redundant field in every CG-16 hash.
+        answer: { canonical, alsoAccept: [] },
         distractors: [],
         check: { kind: "exact" },
         solution: solutionFor(params, draw, topValue, bottomValue, answer),

--- a/dynawalla/curriculum/src/generators/columnOp/params.ts
+++ b/dynawalla/curriculum/src/generators/columnOp/params.ts
@@ -1,0 +1,171 @@
+/**
+ * `gen.arith.column-op` parameters and their validator.
+ *
+ * The validator is not decoration: it is the first half of "never emits a
+ * contradictory or ambiguous problem". It rejects parameter combinations that no
+ * digit assignment could satisfy — three borrows in a two-digit problem, a borrow
+ * across a zero with no digit left to regroup from, a subtrahend longer than the
+ * minuend — so `generate()` can treat an infeasible draw as a bug rather than as
+ * input it has to guess about.
+ */
+
+import type { ParamIssue, ParamResult, ParamSchema } from "../../types/generator.ts";
+
+export type ColumnOp = "add" | "sub";
+
+export type ColumnOpParams = {
+  readonly op: ColumnOp;
+  /** Digit count of the top operand, decimal digits included. */
+  readonly digits: number;
+  /** Digit count of the bottom operand, decimal digits included. */
+  readonly operandDigits: number;
+  /** Exactly how many columns regroup (borrow for `sub`, carry for `add`). */
+  readonly regroupings: number;
+  /** `sub` only: how many zeros in the minuend a single borrow travels through. */
+  readonly acrossZero: number;
+  readonly decimalPlaces: number;
+  /** Allow `a − a = 0`. Off by default: a zero answer teaches nothing here. */
+  readonly allowZeroResult: boolean;
+};
+
+export const MIN_DIGITS = 2;
+export const MAX_DIGITS = 6;
+export const MAX_DECIMAL_PLACES = 2;
+
+function isInt(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value);
+}
+
+/**
+ * Columns that may carry an *extra* regrouping, beyond the ones the across-zero
+ * chain already accounts for. Exported because both the validator and the
+ * generator need exactly the same answer, and a disagreement between them is the
+ * bug class this family is most likely to have.
+ */
+export function extraRegroupColumns(params: ColumnOpParams): number[] {
+  const { op, digits, operandDigits, acrossZero } = params;
+  const columns: number[] = [];
+  if (op === "sub") {
+    // A borrow at column i needs a bottom digit at i (or a zero-run continuation,
+    // which the chain below already owns), and the top column can never borrow out
+    // or the answer would be negative.
+    const lo = acrossZero > 0 ? acrossZero + 2 : 0;
+    const hi = Math.min(digits - 2, operandDigits - 1);
+    for (let i = lo; i <= hi; i++) columns.push(i);
+    return columns;
+  }
+  // A carry at column i needs a bottom digit at i. Carrying out of the top column
+  // is allowed: the sum simply gains a digit.
+  for (let i = 0; i <= operandDigits - 1; i++) columns.push(i);
+  return columns;
+}
+
+/** Regroupings the across-zero chain accounts for on its own. */
+export function chainRegroupings(params: ColumnOpParams): number {
+  return params.op === "sub" && params.acrossZero > 0 ? params.acrossZero + 1 : 0;
+}
+
+function validateShape(raw: unknown, issues: ParamIssue[]): ColumnOpParams | null {
+  if (typeof raw !== "object" || raw === null) {
+    issues.push({ path: "", message: "params must be an object" });
+    return null;
+  }
+  const r = raw as Record<string, unknown>;
+  const op = r["op"];
+  if (op !== "add" && op !== "sub") {
+    issues.push({ path: "op", message: 'op must be "add" or "sub"' });
+  }
+  for (const key of ["digits", "operandDigits", "regroupings", "acrossZero", "decimalPlaces"]) {
+    if (!isInt(r[key])) issues.push({ path: key, message: `${key} must be an integer` });
+  }
+  if (typeof r["allowZeroResult"] !== "boolean") {
+    issues.push({ path: "allowZeroResult", message: "allowZeroResult must be a boolean" });
+  }
+  if (issues.length > 0) return null;
+  return {
+    op: op as ColumnOp,
+    digits: r["digits"] as number,
+    operandDigits: r["operandDigits"] as number,
+    regroupings: r["regroupings"] as number,
+    acrossZero: r["acrossZero"] as number,
+    decimalPlaces: r["decimalPlaces"] as number,
+    allowZeroResult: r["allowZeroResult"] as boolean,
+  };
+}
+
+export const columnOpParamSchema: ParamSchema<ColumnOpParams> = {
+  describe:
+    "{ op: 'add'|'sub', digits: 2..6, operandDigits: 1..digits, regroupings: int, " +
+    "acrossZero: int (sub only), decimalPlaces: 0..2, allowZeroResult: boolean }",
+
+  validate(raw: unknown): ParamResult<ColumnOpParams> {
+    const issues: ParamIssue[] = [];
+    const p = validateShape(raw, issues);
+    if (p === null) return { ok: false, issues };
+
+    if (p.digits < MIN_DIGITS || p.digits > MAX_DIGITS) {
+      issues.push({ path: "digits", message: `digits must be ${MIN_DIGITS}..${MAX_DIGITS}` });
+    }
+    if (p.operandDigits < 1 || p.operandDigits > p.digits) {
+      issues.push({ path: "operandDigits", message: "operandDigits must be 1..digits" });
+    }
+    if (p.decimalPlaces < 0 || p.decimalPlaces > MAX_DECIMAL_PLACES) {
+      issues.push({ path: "decimalPlaces", message: `decimalPlaces must be 0..${MAX_DECIMAL_PLACES}` });
+    }
+    if (p.decimalPlaces > Math.min(p.digits, p.operandDigits)) {
+      issues.push({
+        path: "decimalPlaces",
+        message: "decimalPlaces cannot exceed the digit count of either operand",
+      });
+    }
+    if (p.regroupings < 0) {
+      issues.push({ path: "regroupings", message: "regroupings must be >= 0" });
+    }
+    if (p.acrossZero < 0) {
+      issues.push({ path: "acrossZero", message: "acrossZero must be >= 0" });
+    }
+    if (p.op === "add" && p.acrossZero !== 0) {
+      issues.push({ path: "acrossZero", message: "acrossZero applies to subtraction only" });
+    }
+    if (issues.length > 0) return { ok: false, issues };
+
+    if (p.op === "sub") {
+      if (p.regroupings > p.digits - 1) {
+        issues.push({
+          path: "regroupings",
+          message: "the top column cannot borrow out; regroupings must be <= digits - 1",
+        });
+      }
+      if (p.acrossZero > 0) {
+        if (p.acrossZero > p.digits - 2) {
+          issues.push({
+            path: "acrossZero",
+            message: "a borrow across zeros needs a non-zero digit above the run to regroup from",
+          });
+        }
+        if (p.regroupings < p.acrossZero + 1) {
+          issues.push({
+            path: "regroupings",
+            message: `a run of ${String(p.acrossZero)} zeros already implies ${String(p.acrossZero + 1)} regroupings`,
+          });
+        }
+      }
+    } else if (p.regroupings > p.digits) {
+      issues.push({ path: "regroupings", message: "regroupings must be <= digits" });
+    }
+    if (issues.length > 0) return { ok: false, issues };
+
+    const extra = p.regroupings - chainRegroupings(p);
+    const columns = extraRegroupColumns(p);
+    if (extra > columns.length) {
+      issues.push({
+        path: "regroupings",
+        message:
+          `${String(p.regroupings)} regroupings are not placeable: the chain accounts for ` +
+          `${String(chainRegroupings(p))} and only ${String(columns.length)} further column(s) can regroup`,
+      });
+    }
+    if (issues.length > 0) return { ok: false, issues };
+    return { ok: true, value: p };
+  },
+};

--- a/dynawalla/curriculum/src/generators/columnOp/procedure.ts
+++ b/dynawalla/curriculum/src/generators/columnOp/procedure.ts
@@ -1,0 +1,101 @@
+/**
+ * The **correct** column algorithms, subtract and add, in one implementation.
+ *
+ * Two callers need this procedure and they used to run their own copies: the
+ * generator, which needs the difference digits, the regrouping marks and the value
+ * each column is actually worked with; and the mal-rules, which need to know which
+ * columns regroup. The copies drifted, in the way `params.ts` predicted they would.
+ * The generator recorded a regrouping only on the column that *triggered* a borrow
+ * chain, so the walkthrough it emitted for `4007 − 2888` announced the 7 becoming
+ * 17 and then silently asserted that the two zeros were 9s and the 4 was a 3 —
+ * which is `mis.add.borrow-across-zero` being demonstrated by the worked example
+ * that exists to repair it.
+ *
+ * So there is one procedure, stated column by column, and both callers read it.
+ *
+ * Digit arrays are **little-endian**: index 0 is the units column, which is the
+ * order the algorithm is performed in.
+ */
+
+import { digitAt } from "./digits.ts";
+
+export type SubtractColumn = {
+  /** This column has to take ten from the column to its left. */
+  readonly borrowed: boolean;
+  /**
+   * What the column holds once the column to its **right** has taken its ten — the
+   * digit a child crosses out and rewrites. Equal to the written digit when nothing
+   * was taken from it, and 9 when it is a zero a borrow chain travelled through.
+   */
+  readonly restated: number;
+  /** The value actually subtracted from: `restated`, plus ten when `borrowed`. */
+  readonly effective: number;
+  /** The difference digit for this column. */
+  readonly digit: number;
+};
+
+export type SubtractTrace = {
+  readonly columns: readonly SubtractColumn[];
+  /**
+   * False when the borrow runs off the top of the number — the subtrahend is the
+   * larger number and the difference would be negative.
+   */
+  readonly defined: boolean;
+};
+
+export type AddColumn = {
+  /** This column carries one into the column to its left. */
+  readonly carried: boolean;
+  /** The value actually added: the top digit plus any carry into this column. */
+  readonly effective: number;
+  /** The sum digit for this column. */
+  readonly digit: number;
+};
+
+export type AddTrace = {
+  readonly columns: readonly AddColumn[];
+  /** The carry out of the top column: one more digit, or zero when there is none. */
+  readonly carryOut: number;
+};
+
+/**
+ * Column subtraction as it is taught: each column takes ten from its left when it
+ * cannot subtract, and the column that gives it up is one smaller. A zero that a
+ * borrow travels through goes to −1 here and comes back as 9, which is exactly the
+ * digit a child writes above it.
+ */
+export function subtractColumns(
+  top: readonly number[],
+  bottom: readonly number[],
+  cols: number,
+): SubtractTrace {
+  const columns: SubtractColumn[] = [];
+  let taken = 0;
+
+  for (let i = 0; i < cols; i++) {
+    const raw = digitAt(top, i) - taken;
+    const subtrahend = digitAt(bottom, i);
+    const borrowed = raw < subtrahend;
+    const restated = raw < 0 ? raw + 10 : raw;
+    const effective = borrowed ? raw + 10 : raw;
+    columns.push({ borrowed, restated, effective, digit: effective - subtrahend });
+    taken = borrowed ? 1 : 0;
+  }
+
+  return { columns, defined: taken === 0 };
+}
+
+/** Column addition. The carry out of the top column is a further digit. */
+export function addColumns(top: readonly number[], bottom: readonly number[], cols: number): AddTrace {
+  const columns: AddColumn[] = [];
+  let carry = 0;
+
+  for (let i = 0; i < cols; i++) {
+    const effective = digitAt(top, i) + carry;
+    const sum = effective + digitAt(bottom, i);
+    carry = sum >= 10 ? 1 : 0;
+    columns.push({ carried: carry === 1, effective, digit: sum % 10 });
+  }
+
+  return { columns, carryOut: carry };
+}

--- a/dynawalla/curriculum/src/generators/registry.ts
+++ b/dynawalla/curriculum/src/generators/registry.ts
@@ -1,0 +1,17 @@
+/**
+ * Generator-family registry. One entry per family; 18 by the end of V1.
+ */
+
+import { erase } from "../types/generator.ts";
+import type { AnyGeneratorFamily } from "../types/generator.ts";
+import type { FamilyId } from "../types/ids.ts";
+import { columnOpFamily } from "./columnOp/family.ts";
+
+export const generatorFamilies: readonly AnyGeneratorFamily[] = [erase(columnOpFamily)];
+
+export function familyById(
+  id: FamilyId,
+  families: readonly AnyGeneratorFamily[] = generatorFamilies,
+): AnyGeneratorFamily | undefined {
+  return families.find((family) => family.family === id);
+}

--- a/dynawalla/curriculum/src/graph/domains/add.ts
+++ b/dynawalla/curriculum/src/graph/domains/add.ts
@@ -87,7 +87,13 @@ const subtractMultidigit: SkillNode = {
     b: b(-50n),
     levels: [b(5n), b(35n), b(90n), b(120n)],
   },
-  misconceptions: [MIS_SMALLER_FROM_LARGER],
+  // Borrow-across-zero is declared here as well as on the node named for it: this
+  // level table does not *ask* for a zero in the minuend, but a drawn digit is a
+  // zero often enough that the items emit that diagnosis on their own (measured:
+  // 155 of 4,000 items in the full sweep). A diagnosis the scheduler can receive
+  // and the node does not declare has nowhere to route. CG-12 checks both
+  // directions.
+  misconceptions: [MIS_SMALLER_FROM_LARGER, MIS_BORROW_ACROSS_ZERO],
   representations: { required: [], optional: [REP_COUNTING_BOARD] },
   generator: {
     family: COLUMN_OP_FAMILY,

--- a/dynawalla/curriculum/src/graph/domains/add.ts
+++ b/dynawalla/curriculum/src/graph/domains/add.ts
@@ -1,0 +1,223 @@
+/**
+ * Domain `add` — addition and subtraction.
+ *
+ * The seed of the V1 graph: the three column-algorithm nodes M2 needs, plus one
+ * `draft` node that exists to prove draft rows are excluded from the shipped graph
+ * and from all coverage math (CG-7).
+ *
+ * The full 32-node domain lands in the M4 promotion PR. Every id here is final —
+ * ids are mastery keys on learner devices and are immutable forever.
+ *
+ * `difficulty.levels` restates what `family.difficultyOffset(params)` computes.
+ * That is deliberate redundancy: it makes "b is a pure function of generator
+ * parameters" a claim a gate can check, and CG-9 fails on any drift between the
+ * two.
+ */
+
+import { rational } from "../../math/rational.ts";
+import type { ColumnOpParams } from "../../generators/columnOp/params.ts";
+import {
+  COLUMN_OP_FAMILY,
+  COLUMN_OP_FAMILY_REV,
+  FORM_COLUMN,
+  FORM_FREE_ENTRY,
+} from "../../generators/columnOp/constants.ts";
+import {
+  MIS_BORROW_ACROSS_ZERO,
+  MIS_CARRY_DROPPED,
+  MIS_SMALLER_FROM_LARGER,
+  REP_COUNTING_BOARD,
+} from "../../malrules/columnOp.ts";
+import { capabilityTag, locKey, skillId } from "../../types/ids.ts";
+import type { SkillNode } from "../../types/skill.ts";
+
+const CAP_SUB_REGROUP = capabilityTag("cap.arith.sub-regroup");
+const CAP_SUB_ACROSS_ZERO = capabilityTag("cap.arith.sub-across-zero");
+const CAP_ADD_CARRY = capabilityTag("cap.arith.add-carry");
+
+/** Written out so the level tables below read as tables. */
+function sub(
+  digits: number,
+  operandDigits: number,
+  regroupings: number,
+  acrossZero: number,
+  decimalPlaces = 0,
+): ColumnOpParams {
+  return { op: "sub", digits, operandDigits, regroupings, acrossZero, decimalPlaces, allowZeroResult: false };
+}
+
+function plus(digits: number, operandDigits: number, regroupings: number): ColumnOpParams {
+  return {
+    op: "add",
+    digits,
+    operandDigits,
+    regroupings,
+    acrossZero: 0,
+    decimalPlaces: 0,
+    allowZeroResult: false,
+  };
+}
+
+/** Hundredths of a logit, spelled as an exact rational. */
+function b(hundredths: bigint) {
+  return rational(hundredths, 100n);
+}
+
+export const SKILL_SUBTRACT_MULTIDIGIT = skillId("dw.add.regroup.subtract-multidigit");
+export const SKILL_SUBTRACT_ACROSS_ZERO = skillId("dw.add.regroup.subtract-across-zero");
+export const SKILL_ADD_MULTIDIGIT = skillId("dw.add.regroup.add-multidigit");
+export const SKILL_SUBTRACT_TENTHS = skillId("dw.add.regroup.subtract-tenths");
+
+const subtractMultidigit: SkillNode = {
+  id: SKILL_SUBTRACT_MULTIDIGIT,
+  rev: 1,
+  status: "active",
+  title: locKey("dw.skill.add.regroup.subtract-multidigit.title"),
+  learnerGoal: locKey("dw.skill.add.regroup.subtract-multidigit.goal"),
+  domain: "add",
+  cluster: "regroup",
+  bigIdeas: [locKey("dw.idea.place-value.regroup")],
+  gradeBand: { earliest: 1, nominal: 2, latest: 3 },
+  strandRole: "spine",
+  proficiency: { conceptual: 2, procedural: 3, strategic: 1, adaptive: 1 },
+  classification: "procedural",
+  fluencyTarget: { p50Ms: 12000 },
+  prereqs: [],
+  difficulty: {
+    b: b(-50n),
+    levels: [b(5n), b(35n), b(90n), b(120n)],
+  },
+  misconceptions: [MIS_SMALLER_FROM_LARGER],
+  representations: { required: [], optional: [REP_COUNTING_BOARD] },
+  generator: {
+    family: COLUMN_OP_FAMILY,
+    familyRev: COLUMN_OP_FAMILY_REV,
+    params: [sub(2, 2, 1, 0), sub(3, 3, 1, 0), sub(3, 3, 2, 0), sub(4, 4, 2, 0)],
+    forms: [FORM_FREE_ENTRY, FORM_COLUMN],
+    minVariants: 24,
+    consumes: [],
+  },
+  probes: [
+    { level: 0, seed: 1, purpose: "entry" },
+    { level: 3, seed: 2, purpose: "promotion" },
+  ],
+  provides: [CAP_SUB_REGROUP],
+  standards: { ccss: ["2.NBT.B.5", "3.NBT.A.2"], uk: ["Y3-NPV-2"] },
+};
+
+const subtractAcrossZero: SkillNode = {
+  id: SKILL_SUBTRACT_ACROSS_ZERO,
+  rev: 1,
+  status: "active",
+  title: locKey("dw.skill.add.regroup.subtract-across-zero.title"),
+  learnerGoal: locKey("dw.skill.add.regroup.subtract-across-zero.goal"),
+  domain: "add",
+  cluster: "regroup",
+  bigIdeas: [locKey("dw.idea.place-value.regroup"), locKey("dw.idea.place-value.zero-holds-a-place")],
+  gradeBand: { earliest: 2, nominal: 3, latest: 4 },
+  strandRole: "spine",
+  proficiency: { conceptual: 3, procedural: 3, strategic: 1, adaptive: 2 },
+  classification: "procedural",
+  prereqs: [{ kind: "requires", to: SKILL_SUBTRACT_MULTIDIGIT }],
+  difficulty: {
+    b: b(0n),
+    levels: [b(165n), b(195n), b(275n)],
+  },
+  misconceptions: [MIS_BORROW_ACROSS_ZERO, MIS_SMALLER_FROM_LARGER],
+  representations: {
+    // The counting board becomes `required` in PR-2.10, with the Stage-2 LOCATE
+    // contrast pair; until that renderer exists, claiming it here would be a
+    // curriculum row the app cannot draw, which is exactly what CG-8 exists to stop.
+    required: [],
+    optional: [REP_COUNTING_BOARD],
+  },
+  generator: {
+    family: COLUMN_OP_FAMILY,
+    familyRev: COLUMN_OP_FAMILY_REV,
+    params: [sub(3, 3, 2, 1), sub(4, 4, 2, 1), sub(4, 4, 3, 2)],
+    forms: [FORM_FREE_ENTRY, FORM_COLUMN],
+    minVariants: 24,
+    consumes: [CAP_SUB_REGROUP],
+  },
+  probes: [{ level: 2, seed: 5001, purpose: "promotion" }],
+  provides: [CAP_SUB_ACROSS_ZERO],
+  standards: { ccss: ["3.NBT.A.2", "4.NBT.B.4"] },
+};
+
+const addMultidigit: SkillNode = {
+  id: SKILL_ADD_MULTIDIGIT,
+  rev: 1,
+  status: "active",
+  title: locKey("dw.skill.add.regroup.add-multidigit.title"),
+  learnerGoal: locKey("dw.skill.add.regroup.add-multidigit.goal"),
+  domain: "add",
+  cluster: "regroup",
+  bigIdeas: [locKey("dw.idea.place-value.regroup")],
+  gradeBand: { earliest: 1, nominal: 2, latest: 3 },
+  strandRole: "spine",
+  proficiency: { conceptual: 2, procedural: 3, strategic: 1, adaptive: 1 },
+  classification: "procedural",
+  fluencyTarget: { p50Ms: 12000 },
+  prereqs: [],
+  difficulty: {
+    b: b(-60n),
+    levels: [b(-5n), b(25n), b(80n)],
+  },
+  misconceptions: [MIS_CARRY_DROPPED],
+  representations: { required: [], optional: [REP_COUNTING_BOARD] },
+  generator: {
+    family: COLUMN_OP_FAMILY,
+    familyRev: COLUMN_OP_FAMILY_REV,
+    params: [plus(2, 2, 1), plus(3, 3, 1), plus(3, 3, 2)],
+    forms: [FORM_FREE_ENTRY, FORM_COLUMN],
+    minVariants: 24,
+    consumes: [],
+  },
+  probes: [{ level: 0, seed: 1, purpose: "entry" }],
+  provides: [CAP_ADD_CARRY],
+  standards: { ccss: ["2.NBT.B.5", "3.NBT.A.2"] },
+};
+
+/**
+ * Draft: subtraction of tenths. The generator already handles it exactly — a
+ * decimal problem is an integer problem plus a decimal-point position — but the
+ * number layer that owns the decimal separator does not exist until M2, so CG-14
+ * cannot run and this row must not be `active`. It is here to keep the draft path
+ * exercised: a draft node is excluded from the shipped graph and from all coverage
+ * math, and if that ever stops being true a test fails.
+ */
+const subtractTenths: SkillNode = {
+  id: SKILL_SUBTRACT_TENTHS,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.add.regroup.subtract-tenths.title"),
+  learnerGoal: locKey("dw.skill.add.regroup.subtract-tenths.goal"),
+  domain: "add",
+  cluster: "regroup",
+  bigIdeas: [locKey("dw.idea.place-value.regroup")],
+  gradeBand: { earliest: 4, nominal: 5, latest: 6 },
+  strandRole: "bridge",
+  proficiency: { conceptual: 3, procedural: 2, strategic: 1, adaptive: 2 },
+  classification: "procedural",
+  prereqs: [{ kind: "requires", to: SKILL_SUBTRACT_ACROSS_ZERO }],
+  difficulty: { b: b(0n), levels: [b(105n)] },
+  misconceptions: [MIS_SMALLER_FROM_LARGER],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: COLUMN_OP_FAMILY,
+    familyRev: COLUMN_OP_FAMILY_REV,
+    params: [sub(3, 3, 1, 0, 1)],
+    forms: [FORM_FREE_ENTRY],
+    minVariants: 24,
+    consumes: [CAP_SUB_ACROSS_ZERO],
+  },
+  probes: [],
+  provides: [],
+};
+
+export const addDomainNodes: readonly SkillNode[] = [
+  subtractMultidigit,
+  subtractAcrossZero,
+  addMultidigit,
+  subtractTenths,
+];

--- a/dynawalla/curriculum/src/graph/graph.ts
+++ b/dynawalla/curriculum/src/graph/graph.ts
@@ -1,0 +1,27 @@
+/**
+ * The curriculum graph: every authored node, and the lookups the gates need.
+ *
+ * `activeNodes` is the shipped graph. Draft nodes are authorable but are excluded
+ * from it and from every coverage count, so the graph can never become a wish list
+ * (CG-7).
+ */
+
+import type { SkillId } from "../types/ids.ts";
+import type { SkillNode } from "../types/skill.ts";
+import { addDomainNodes } from "./domains/add.ts";
+
+export const allNodes: readonly SkillNode[] = [...addDomainNodes];
+
+export function activeNodes(nodes: readonly SkillNode[] = allNodes): SkillNode[] {
+  return nodes.filter((node) => node.status === "active");
+}
+
+export function nodeById(id: SkillId, nodes: readonly SkillNode[] = allNodes): SkillNode | undefined {
+  return nodes.find((node) => node.id === id);
+}
+
+export function nodeIndex(nodes: readonly SkillNode[] = allNodes): Map<SkillId, SkillNode> {
+  const index = new Map<SkillId, SkillNode>();
+  for (const node of nodes) index.set(node.id, node);
+  return index;
+}

--- a/dynawalla/curriculum/src/graph/shipped-ids.json
+++ b/dynawalla/curriculum/src/graph/shipped-ids.json
@@ -1,0 +1,4 @@
+{
+  "note": "Skill ids that have shipped in a release, per release tag. Ids are mastery keys on learner devices: once an id appears here it must exist forever, and CG-1 fails if one disappears, is demoted to draft, or is deprecated with no successor. Nothing has shipped yet, so this is empty. The release checklist appends a tag here at each release.",
+  "releases": {}
+}

--- a/dynawalla/curriculum/src/index.ts
+++ b/dynawalla/curriculum/src/index.ts
@@ -1,0 +1,47 @@
+/**
+ * `@dynawalla/curriculum` — the graph, the generators, the mal-rules.
+ *
+ * The app imports from here. The validator imports the gates directly; they are
+ * tooling and are deliberately not part of this surface.
+ */
+
+export * from "./types/ids.ts";
+export * from "./types/answer.ts";
+export type * from "./types/exercise.ts";
+export type * from "./types/skill.ts";
+export type * from "./types/generator.ts";
+export type * from "./types/malrule.ts";
+export { erase } from "./types/generator.ts";
+
+export * as rational from "./math/rational.ts";
+export type { Rational } from "./math/rational.ts";
+
+export { createRng, fnv1a32, seedFrom, SEED_SEPARATOR } from "./rng/rng.ts";
+export type { Rng } from "./rng/rng.ts";
+export { fnv1a64, fnv1a64Hex } from "./rng/hash.ts";
+
+export { fingerprintItem, serializeExercise } from "./serialize.ts";
+
+export { activeNodes, allNodes, nodeById, nodeIndex } from "./graph/graph.ts";
+export { addDomainNodes } from "./graph/domains/add.ts";
+
+export { columnOpFamily, InfeasibleParamsError } from "./generators/columnOp/family.ts";
+export { columnOpParamSchema } from "./generators/columnOp/params.ts";
+export type { ColumnOpParams } from "./generators/columnOp/params.ts";
+export * from "./generators/columnOp/constants.ts";
+export { familyById, generatorFamilies } from "./generators/registry.ts";
+
+export { classify, classifyAll, malRuleById, malRules, malRulesForFamily } from "./malrules/registry.ts";
+export {
+  borrowAcrossZero,
+  carryDropped,
+  columnOpMalRules,
+  smallerFromLarger,
+  MIS_BORROW_ACROSS_ZERO,
+  MIS_CARRY_DROPPED,
+  MIS_SMALLER_FROM_LARGER,
+  REP_COUNTING_BOARD,
+} from "./malrules/columnOp.ts";
+
+export { answerRendererId, findRenderer, rendererRegistry, repRendererId } from "./render/registry.ts";
+export type { RendererDeclaration } from "./render/registry.ts";

--- a/dynawalla/curriculum/src/malrules/columnOp.test.ts
+++ b/dynawalla/curriculum/src/malrules/columnOp.test.ts
@@ -1,0 +1,260 @@
+/**
+ * The mal-rule tests.
+ *
+ * These assert the mathematics against worked examples, by hand, because the one
+ * error this program has already had to correct is a *mapping* error between two
+ * individually-valid rules — and no gate can catch that. CG-12 only measures that
+ * each rule diverges from the correct answer; both of these do, on nearly every
+ * seed. The mapping is only ever as good as the assertions in this file.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fromScaled, add as ratAdd, sub as ratSub, toDecimalString, rational } from "../math/rational.ts";
+import { COLUMN_OP_FAMILY, COLUMN_OP_FAMILY_REV, PROMPT_KEY_ADD, PROMPT_KEY_SUB } from "../generators/columnOp/constants.ts";
+import type { AnswerValue } from "../types/answer.ts";
+import type { Exercise } from "../types/exercise.ts";
+import { familyId, malRuleId, skillId } from "../types/ids.ts";
+import type { MalRule } from "../types/malrule.ts";
+import {
+  MIS_BORROW_ACROSS_ZERO,
+  MIS_CARRY_DROPPED,
+  MIS_SMALLER_FROM_LARGER,
+  REP_COUNTING_BOARD,
+  borrowAcrossZero,
+  carryDropped,
+  correctBorrows,
+  correctCarries,
+  smallerFromLarger,
+} from "./columnOp.ts";
+import { classify, classifyAll, malRulesForFamily } from "./registry.ts";
+
+const SKILL = skillId("dw.add.regroup.subtract-across-zero");
+
+/**
+ * Build a column-op item by hand. Mal-rules read the public `Exercise` contract,
+ * so an item assembled here exercises exactly the same path as a generated one —
+ * and it lets a worked example be written as the worked example, rather than found
+ * by hunting for the seed that produces it (5001 − 2798 is one draw in ~126,000).
+ */
+function item(top: bigint, bottom: bigint, op: "sub" | "add" = "sub", decimalPlaces = 0): Exercise {
+  const topValue = fromScaled(top, decimalPlaces);
+  const bottomValue = fromScaled(bottom, decimalPlaces);
+  const answer = op === "sub" ? ratSub(topValue, bottomValue) : ratAdd(topValue, bottomValue);
+  const width = Math.max(top.toString().length, bottom.toString().length);
+  return {
+    exerciseId: `${COLUMN_OP_FAMILY}@1:${SKILL}:L0:0`,
+    skillId: SKILL,
+    level: 0,
+    seed: 0,
+    family: COLUMN_OP_FAMILY,
+    familyRev: COLUMN_OP_FAMILY_REV,
+    form: "free-entry",
+    prompt: {
+      key: op === "sub" ? PROMPT_KEY_SUB : PROMPT_KEY_ADD,
+      slots: {
+        top: { kind: "number", value: topValue, decimalPlaces },
+        bottom: { kind: "number", value: bottomValue, decimalPlaces },
+      },
+    },
+    schema: { kind: "integer", digits: width + (op === "add" ? 1 : 0), decimalPlaces },
+    answer: { canonical: { kind: "integer", value: answer }, alsoAccept: [] },
+    distractors: [],
+    check: { kind: "exact" },
+    solution: [],
+  };
+}
+
+function valueOf(answer: AnswerValue | null): string {
+  assert.ok(answer !== null, "expected the rule to produce an answer");
+  assert.ok(answer.kind === "integer", "expected an integer answer");
+  return toDecimalString(answer.value, 0) ?? "?";
+}
+
+function decimalValueOf(answer: AnswerValue | null, places: number): string {
+  assert.ok(answer !== null, "expected the rule to produce an answer");
+  assert.ok(answer.kind === "integer", "expected an integer answer");
+  return toDecimalString(answer.value, places) ?? "?";
+}
+
+test("mal-rule: 5001 − 2798 separates the two subtraction bugs", () => {
+  const exercise = item(5001n, 2798n);
+  assert.equal(valueOf(exercise.answer.canonical), "2203", "the correct answer");
+
+  // |5−2| |0−7| |0−9| |1−8| — the smaller digit taken from the larger in every
+  // column, no regrouping anywhere. Not off by a place-value unit at all.
+  assert.ok(smallerFromLarger.applies(exercise));
+  assert.equal(valueOf(smallerFromLarger.apply(exercise)), "3797");
+
+  // Regrouped all the way down: the zeros became 9s and the thousands digit was
+  // never decremented, so the answer is exactly 1,000 too big.
+  assert.ok(borrowAcrossZero.applies(exercise));
+  assert.equal(valueOf(borrowAcrossZero.apply(exercise)), "3203");
+
+  const canonical = exercise.answer.canonical;
+  assert.ok(canonical.kind === "integer");
+  const borrowBug = borrowAcrossZero.apply(exercise);
+  assert.ok(borrowBug !== null && borrowBug.kind === "integer");
+  assert.equal(
+    toDecimalString(ratSub(borrowBug.value, canonical.value), 0),
+    "1000",
+    "borrow-across-zero is the correct answer plus the thousand that was never given up",
+  );
+});
+
+test("mal-rule: the classifier does not confuse the two", () => {
+  const exercise = item(5001n, 2798n);
+  const wrongBySmallerFromLarger = smallerFromLarger.apply(exercise);
+  const wrongByBorrowAcrossZero = borrowAcrossZero.apply(exercise);
+  assert.ok(wrongBySmallerFromLarger !== null && wrongByBorrowAcrossZero !== null);
+
+  assert.equal(classify(exercise, wrongBySmallerFromLarger), MIS_SMALLER_FROM_LARGER);
+  assert.equal(classify(exercise, wrongByBorrowAcrossZero), MIS_BORROW_ACROSS_ZERO);
+  assert.deepEqual(classifyAll(exercise, wrongBySmallerFromLarger), [MIS_SMALLER_FROM_LARGER]);
+  assert.deepEqual(classifyAll(exercise, wrongByBorrowAcrossZero), [MIS_BORROW_ACROSS_ZERO]);
+});
+
+test("mal-rule: an answer no buggy procedure produces gets no diagnosis", () => {
+  const exercise = item(5001n, 2798n);
+  assert.equal(classify(exercise, exercise.answer.canonical), null, "the correct answer is not a bug");
+  for (const offset of [1n, -1n, 7n, 100n, 900n]) {
+    const canonical = exercise.answer.canonical;
+    assert.ok(canonical.kind === "integer");
+    const wrong: AnswerValue = { kind: "integer", value: ratAdd(canonical.value, rational(offset)) };
+    const matched = classifyAll(exercise, wrong);
+    // 3203 is exactly +1000 and 3797 is +1594, so none of these offsets can match.
+    assert.deepEqual(matched, [], `offset ${String(offset)} should not match a rule`);
+    assert.equal(classify(exercise, wrong), null);
+  }
+});
+
+test("mal-rule: 602 − 437 is the other documented borrow-across-zero example", () => {
+  const exercise = item(602n, 437n);
+  assert.equal(valueOf(exercise.answer.canonical), "165");
+  assert.ok(borrowAcrossZero.applies(exercise));
+  assert.equal(valueOf(borrowAcrossZero.apply(exercise)), "265", "the hundred that was borrowed and never given up");
+  assert.equal(valueOf(smallerFromLarger.apply(exercise)), "235", "|6−4| |0−3| |2−7|");
+});
+
+test("mal-rule: borrow-across-zero does not fire when no borrow crosses a zero", () => {
+  // 52 − 28 needs a borrow, but from a non-zero digit, so the buggy procedure and
+  // the correct one are the same procedure. `applies` is what keeps CG-12 honest:
+  // without it this item would be counted as a non-divergent case.
+  const exercise = item(52n, 28n);
+  assert.equal(valueOf(exercise.answer.canonical), "24");
+  assert.equal(borrowAcrossZero.applies(exercise), false);
+  assert.equal(valueOf(borrowAcrossZero.apply(exercise)), "24", "it reproduces the correct procedure here");
+  assert.ok(smallerFromLarger.applies(exercise));
+  assert.equal(valueOf(smallerFromLarger.apply(exercise)), "36", "|5−2| |2−8|");
+});
+
+test("mal-rule: smaller-from-larger does not fire when nothing needs regrouping", () => {
+  const exercise = item(58n, 23n);
+  assert.equal(smallerFromLarger.applies(exercise), false);
+  assert.equal(valueOf(smallerFromLarger.apply(exercise)), "35", "identical to the correct answer, hence not evidence");
+});
+
+test("mal-rule: carry-dropped adds every column and records no carry", () => {
+  const exercise = item(47n, 25n, "add");
+  assert.equal(valueOf(exercise.answer.canonical), "72");
+  assert.ok(carryDropped.applies(exercise));
+  assert.equal(valueOf(carryDropped.apply(exercise)), "62");
+
+  const allNines = item(99n, 99n, "add");
+  assert.equal(valueOf(allNines.answer.canonical), "198");
+  assert.equal(valueOf(carryDropped.apply(allNines)), "88");
+
+  const noCarry = item(21n, 34n, "add");
+  assert.equal(carryDropped.applies(noCarry), false);
+  assert.equal(valueOf(carryDropped.apply(noCarry)), "55", "identical to the correct answer, hence not evidence");
+});
+
+test("mal-rule: each rule declines an item it has nothing to say about", () => {
+  const subtraction = item(5001n, 2798n);
+  const addition = item(47n, 25n, "add");
+  assert.equal(carryDropped.apply(subtraction), null);
+  assert.equal(carryDropped.applies(subtraction), false);
+  assert.equal(smallerFromLarger.apply(addition), null);
+  assert.equal(borrowAcrossZero.apply(addition), null);
+  assert.equal(smallerFromLarger.applies(addition), false);
+  assert.equal(borrowAcrossZero.applies(addition), false);
+
+  // An item whose prompt has no operand slots — a shape from some other family —
+  // is declined rather than guessed at.
+  const slotless: Exercise = { ...subtraction, prompt: { ...subtraction.prompt, slots: {} } };
+  assert.equal(smallerFromLarger.apply(slotless), null);
+  assert.equal(borrowAcrossZero.apply(slotless), null);
+  assert.equal(carryDropped.apply({ ...addition, prompt: { ...addition.prompt, slots: {} } }), null);
+});
+
+test("mal-rule: an undefined buggy procedure returns null rather than nonsense", () => {
+  // 102 − 456 is not a well-formed item (the answer would be negative). The buggy
+  // procedure runs out of digits to borrow from, and must decline rather than
+  // invent a wrap-around.
+  const malformed = item(102n, 456n);
+  assert.equal(borrowAcrossZero.apply(malformed), null);
+  assert.equal(borrowAcrossZero.applies(malformed), false);
+});
+
+test("mal-rule: the bugs work on decimals too", () => {
+  const exercise = item(501n, 279n, "sub", 1);
+  assert.equal(decimalValueOf(exercise.answer.canonical, 1), "22.2");
+  assert.equal(decimalValueOf(smallerFromLarger.apply(exercise), 1), "37.8", "|5−2| |0−7| |1−9|");
+  assert.ok(borrowAcrossZero.applies(exercise));
+  assert.equal(decimalValueOf(borrowAcrossZero.apply(exercise), 1), "32.2", "ten tenths never given up");
+});
+
+test("mal-rule: two rules that agree on an answer produce no diagnosis at all", () => {
+  // A confident diagnosis that names one of two equally likely bugs is worse than
+  // none: Stage 2 would show a contrast pair built for a misconception the child
+  // may not hold. Ambiguity has to route to Stage 3.
+  const exercise = item(5001n, 2798n);
+  const twin = (id: string): MalRule => ({
+    id: malRuleId(id),
+    family: COLUMN_OP_FAMILY,
+    locateCapable: false,
+    applies: () => true,
+    apply: (target) => smallerFromLarger.apply(target),
+  });
+  const rules = [smallerFromLarger, twin("mis.add.smaller-from-larger-twin")];
+  const wrong = smallerFromLarger.apply(exercise);
+  assert.ok(wrong !== null);
+  assert.equal(classifyAll(exercise, wrong, rules).length, 2);
+  assert.equal(classify(exercise, wrong, rules), null);
+});
+
+test("mal-rule: a rule from another family never fires on this item", () => {
+  const exercise = item(5001n, 2798n);
+  const foreign: MalRule = {
+    id: malRuleId("mis.frac.add-numerators-and-denominators"),
+    family: familyId("gen.frac.arith"),
+    locateCapable: false,
+    applies: () => true,
+    apply: () => exercise.answer.canonical,
+  };
+  assert.deepEqual(classifyAll(exercise, exercise.answer.canonical, [foreign]), []);
+});
+
+test("mal-rule: registry metadata is honest about LOCATE", () => {
+  assert.equal(borrowAcrossZero.locateCapable, true);
+  assert.equal(borrowAcrossZero.contrastRep, REP_COUNTING_BOARD);
+  // The contrast for smaller-from-larger is magnitude — a number line, not a
+  // counting board — and that pair is not built, so it must not claim LOCATE.
+  assert.equal(smallerFromLarger.locateCapable, false);
+  assert.equal(smallerFromLarger.contrastRep, undefined);
+  assert.equal(carryDropped.locateCapable, false);
+  assert.deepEqual(
+    malRulesForFamily(COLUMN_OP_FAMILY).map((rule) => rule.id),
+    [MIS_SMALLER_FROM_LARGER, MIS_BORROW_ACROSS_ZERO, MIS_CARRY_DROPPED],
+  );
+  assert.deepEqual(malRulesForFamily(familyId("gen.frac.arith")), []);
+});
+
+test("mal-rule: the shared procedure helpers agree with the worked examples", () => {
+  assert.deepEqual(correctBorrows([1, 0, 0, 5], [8, 9, 7, 2], 4), [true, true, true, false]);
+  assert.deepEqual(correctBorrows([2, 5], [8, 2], 2), [true, false]);
+  assert.deepEqual(correctBorrows([8, 5], [3, 2], 2), [false, false]);
+  assert.deepEqual(correctCarries([7, 4], [5, 2], 2), [true, false]);
+  assert.deepEqual(correctCarries([9, 9], [9, 9], 2), [true, true]);
+  assert.deepEqual(correctCarries([1, 2], [4, 3], 2), [false, false]);
+});

--- a/dynawalla/curriculum/src/malrules/columnOp.ts
+++ b/dynawalla/curriculum/src/malrules/columnOp.ts
@@ -1,0 +1,210 @@
+/**
+ * The three `gen.arith.column-op` mal-rules.
+ *
+ * Each one *runs the buggy procedure* rather than computing a shortcut from the
+ * correct answer. That matters: `mis.add.borrow-across-zero` happens to come out
+ * as "the correct answer plus the 1,000 that was borrowed and never given up", but
+ * that identity is a consequence of the procedure, not its definition, and encoding
+ * the shortcut instead would silently stop matching the moment the borrow chain has
+ * a different shape. The identity is asserted as a *test*, not used as the
+ * implementation.
+ *
+ * The distinction the program has already got wrong once, and must not again:
+ *
+ *   5001 − 2798.  Correct: 2203.
+ *   3797 is `mis.add.smaller-from-larger` — |5−2| |0−7| |0−9| |1−8|, the smaller
+ *         digit taken from the larger in every column. It is not off by a
+ *         place-value unit at all, and its contrast is the number line.
+ *   3203 is `mis.add.borrow-across-zero` — regrouped all the way down, the zeros
+ *         written as 9s, and the thousand never taken off the leading digit. It is
+ *         exactly 1,000 more than the correct answer, which is what makes the
+ *         counting board a real contradiction rather than an illustration.
+ *
+ * Both rules are individually valid and both diverge from the correct answer on
+ * ≥95% of seeds, so CG-12 cannot catch a mapping error between them (see
+ * ADAPTIVE_LEARNING.md). `columnOp.test.ts` asserts the mapping directly.
+ */
+
+import { digitsToRational, readOperands } from "../generators/columnOp/digits.ts";
+import { answerValueFor } from "../generators/columnOp/answerValue.ts";
+import { COLUMN_OP_FAMILY } from "../generators/columnOp/constants.ts";
+import type { AnswerValue } from "../types/answer.ts";
+import type { Exercise } from "../types/exercise.ts";
+import { malRuleId } from "../types/ids.ts";
+import type { MalRule } from "../types/malrule.ts";
+
+export const MIS_SMALLER_FROM_LARGER = malRuleId("mis.add.smaller-from-larger");
+export const MIS_BORROW_ACROSS_ZERO = malRuleId("mis.add.borrow-across-zero");
+export const MIS_CARRY_DROPPED = malRuleId("mis.add.carry-dropped");
+
+/** The counting board is the LOCATE representation for borrow-across-zero. */
+export const REP_COUNTING_BOARD = "counting-board";
+
+type Trace = {
+  readonly digits: readonly number[];
+  /** The buggy borrow chain crossed at least one zero. */
+  readonly crossedZero: boolean;
+  readonly defined: boolean;
+};
+
+const UNDEFINED_TRACE: Trace = { digits: [], crossedZero: false, defined: false };
+
+/**
+ * Column subtraction as a child performs it who regroups across a zero run —
+ * writing the zeros as 9s — but never decrements the non-zero digit that the run
+ * was supposed to borrow from.
+ */
+export function traceBorrowAcrossZero(
+  top: readonly number[],
+  bottom: readonly number[],
+  cols: number,
+): Trace {
+  const work = [...top];
+  const out: number[] = [];
+  let crossedZero = false;
+
+  for (let i = 0; i < cols; i++) {
+    let t = work[i] ?? 0;
+    const s = bottom[i] ?? 0;
+    if (t < s) {
+      let j = i + 1;
+      while (j < cols && (work[j] ?? 0) === 0) {
+        work[j] = 9;
+        j += 1;
+      }
+      if (j >= cols) return UNDEFINED_TRACE;
+      if (j > i + 1) {
+        // The bug: the run of zeros became 9s and the digit above it was left alone.
+        crossedZero = true;
+      } else {
+        work[j] = (work[j] ?? 0) - 1;
+      }
+      t += 10;
+    }
+    out.push(t - s);
+  }
+  return { digits: out, crossedZero, defined: true };
+}
+
+/** Correct column subtraction, for `applies` predicates and for canonical marks. */
+export function correctBorrows(
+  top: readonly number[],
+  bottom: readonly number[],
+  cols: number,
+): boolean[] {
+  const borrows: boolean[] = [];
+  let incoming = 0;
+  for (let i = 0; i < cols; i++) {
+    const t = (top[i] ?? 0) - incoming;
+    const s = bottom[i] ?? 0;
+    const borrowed = t < s;
+    borrows.push(borrowed);
+    incoming = borrowed ? 1 : 0;
+  }
+  return borrows;
+}
+
+/** Correct column addition carries. */
+export function correctCarries(
+  top: readonly number[],
+  bottom: readonly number[],
+  cols: number,
+): boolean[] {
+  const carries: boolean[] = [];
+  let incoming = 0;
+  for (let i = 0; i < cols; i++) {
+    const sum = (top[i] ?? 0) + (bottom[i] ?? 0) + incoming;
+    const carried = sum >= 10;
+    carries.push(carried);
+    incoming = carried ? 1 : 0;
+  }
+  return carries;
+}
+
+function output(exercise: Exercise, digits: readonly number[], decimalPlaces: number): AnswerValue {
+  return answerValueFor(exercise.schema, digitsToRational(digits, decimalPlaces));
+}
+
+/**
+ * `mis.add.smaller-from-larger` — in every column the smaller digit is taken from
+ * the larger one, whichever is on top, and no regrouping happens at all.
+ */
+export const smallerFromLarger: MalRule = {
+  id: MIS_SMALLER_FROM_LARGER,
+  family: COLUMN_OP_FAMILY,
+  // The contrast for this bug is magnitude (the answer is far too large), which is
+  // a number-line contradiction, not a counting-board one. Stage 2 for it is not
+  // built yet, so it is not tagged LOCATE-capable (CG-22).
+  locateCapable: false,
+
+  applies(exercise: Exercise): boolean {
+    const operands = readOperands(exercise);
+    if (operands === null || operands.op !== "sub") return false;
+    // Undefined unless at least one column would have needed regrouping — with no
+    // regrouping the buggy procedure and the correct one are the same procedure.
+    return operands.top.some((digit, i) => (operands.bottom[i] ?? 0) > digit);
+  },
+
+  apply(exercise: Exercise): AnswerValue | null {
+    const operands = readOperands(exercise);
+    if (operands === null || operands.op !== "sub") return null;
+    const digits = operands.top.map((digit, i) => Math.abs(digit - (operands.bottom[i] ?? 0)));
+    return output(exercise, digits, operands.decimalPlaces);
+  },
+};
+
+/**
+ * `mis.add.borrow-across-zero` — regrouped all the way down through the zeros,
+ * never decremented the digit above the run.
+ */
+export const borrowAcrossZero: MalRule = {
+  id: MIS_BORROW_ACROSS_ZERO,
+  family: COLUMN_OP_FAMILY,
+  locateCapable: true,
+  contrastRep: REP_COUNTING_BOARD,
+
+  applies(exercise: Exercise): boolean {
+    const operands = readOperands(exercise);
+    if (operands === null || operands.op !== "sub") return false;
+    const trace = traceBorrowAcrossZero(operands.top, operands.bottom, operands.cols);
+    return trace.defined && trace.crossedZero;
+  },
+
+  apply(exercise: Exercise): AnswerValue | null {
+    const operands = readOperands(exercise);
+    if (operands === null || operands.op !== "sub") return null;
+    const trace = traceBorrowAcrossZero(operands.top, operands.bottom, operands.cols);
+    if (!trace.defined) return null;
+    return output(exercise, trace.digits, operands.decimalPlaces);
+  },
+};
+
+/**
+ * `mis.add.carry-dropped` — every column added correctly, no carry ever recorded
+ * or added into the next column.
+ */
+export const carryDropped: MalRule = {
+  id: MIS_CARRY_DROPPED,
+  family: COLUMN_OP_FAMILY,
+  locateCapable: false,
+
+  applies(exercise: Exercise): boolean {
+    const operands = readOperands(exercise);
+    if (operands === null || operands.op !== "add") return false;
+    return correctCarries(operands.top, operands.bottom, operands.cols).some(Boolean);
+  },
+
+  apply(exercise: Exercise): AnswerValue | null {
+    const operands = readOperands(exercise);
+    if (operands === null || operands.op !== "add") return null;
+    const digits = operands.top.map((digit, i) => (digit + (operands.bottom[i] ?? 0)) % 10);
+    return output(exercise, digits, operands.decimalPlaces);
+  },
+};
+
+/** Registry order is stable: it fixes distractor order in generated items. */
+export const columnOpMalRules: readonly MalRule[] = [
+  smallerFromLarger,
+  borrowAcrossZero,
+  carryDropped,
+];

--- a/dynawalla/curriculum/src/malrules/columnOp.ts
+++ b/dynawalla/curriculum/src/malrules/columnOp.ts
@@ -28,6 +28,7 @@
 import { digitsToRational, readOperands } from "../generators/columnOp/digits.ts";
 import { answerValueFor } from "../generators/columnOp/answerValue.ts";
 import { COLUMN_OP_FAMILY } from "../generators/columnOp/constants.ts";
+import { addColumns, subtractColumns } from "../generators/columnOp/procedure.ts";
 import type { AnswerValue } from "../types/answer.ts";
 import type { Exercise } from "../types/exercise.ts";
 import { malRuleId } from "../types/ids.ts";
@@ -86,22 +87,21 @@ export function traceBorrowAcrossZero(
   return { digits: out, crossedZero, defined: true };
 }
 
-/** Correct column subtraction, for `applies` predicates and for canonical marks. */
+/**
+ * Which columns regroup under the correct procedure — the yardstick the buggy ones
+ * are measured against, and what the property tests use as the *definition* of a
+ * level's regrouping count.
+ *
+ * Both read `procedure.ts`, which is also what the generator runs. A second copy of
+ * the borrow procedure here is the divergence `params.ts` warns about, and it has
+ * already happened once in this family.
+ */
 export function correctBorrows(
   top: readonly number[],
   bottom: readonly number[],
   cols: number,
 ): boolean[] {
-  const borrows: boolean[] = [];
-  let incoming = 0;
-  for (let i = 0; i < cols; i++) {
-    const t = (top[i] ?? 0) - incoming;
-    const s = bottom[i] ?? 0;
-    const borrowed = t < s;
-    borrows.push(borrowed);
-    incoming = borrowed ? 1 : 0;
-  }
-  return borrows;
+  return subtractColumns(top, bottom, cols).columns.map((column) => column.borrowed);
 }
 
 /** Correct column addition carries. */
@@ -110,15 +110,7 @@ export function correctCarries(
   bottom: readonly number[],
   cols: number,
 ): boolean[] {
-  const carries: boolean[] = [];
-  let incoming = 0;
-  for (let i = 0; i < cols; i++) {
-    const sum = (top[i] ?? 0) + (bottom[i] ?? 0) + incoming;
-    const carried = sum >= 10;
-    carries.push(carried);
-    incoming = carried ? 1 : 0;
-  }
-  return carries;
+  return addColumns(top, bottom, cols).columns.map((column) => column.carried);
 }
 
 function output(exercise: Exercise, digits: readonly number[], decimalPlaces: number): AnswerValue {

--- a/dynawalla/curriculum/src/malrules/registry.ts
+++ b/dynawalla/curriculum/src/malrules/registry.ts
@@ -1,0 +1,52 @@
+/**
+ * Mal-rule registry and the diagnosis entry point.
+ *
+ * `classify` deliberately returns `null` when two rules produce the same wrong
+ * answer on an item. A confident diagnosis that names one of two equally likely
+ * bugs is worse than no diagnosis: Stage 2 LOCATE would then show a contrast pair
+ * built for a misconception the child may not hold. Ambiguity routes to Stage 3
+ * (a faded worked example), which is correct for both.
+ */
+
+import type { AnswerValue } from "../types/answer.ts";
+import { answerEquals } from "../types/answer.ts";
+import type { Exercise } from "../types/exercise.ts";
+import type { FamilyId, MalRuleId } from "../types/ids.ts";
+import type { MalRule } from "../types/malrule.ts";
+import { columnOpMalRules } from "./columnOp.ts";
+
+export const malRules: readonly MalRule[] = [...columnOpMalRules];
+
+export function malRulesForFamily(family: FamilyId, rules: readonly MalRule[] = malRules): MalRule[] {
+  return rules.filter((rule) => rule.family === family);
+}
+
+export function malRuleById(id: MalRuleId, rules: readonly MalRule[] = malRules): MalRule | undefined {
+  return rules.find((rule) => rule.id === id);
+}
+
+/** Every rule whose buggy output equals `submitted` on this item. */
+export function classifyAll(
+  exercise: Exercise,
+  submitted: AnswerValue,
+  rules: readonly MalRule[] = malRules,
+): MalRuleId[] {
+  const matched: MalRuleId[] = [];
+  for (const rule of rules) {
+    if (rule.family !== exercise.family) continue;
+    if (!rule.applies(exercise)) continue;
+    const produced = rule.apply(exercise);
+    if (produced !== null && answerEquals(produced, submitted)) matched.push(rule.id);
+  }
+  return matched;
+}
+
+/** The one rule that explains this wrong answer, or `null` if none or several do. */
+export function classify(
+  exercise: Exercise,
+  submitted: AnswerValue,
+  rules: readonly MalRule[] = malRules,
+): MalRuleId | null {
+  const matched = classifyAll(exercise, submitted, rules);
+  return matched.length === 1 ? (matched[0] ?? null) : null;
+}

--- a/dynawalla/curriculum/src/math/rational.test.ts
+++ b/dynawalla/curriculum/src/math/rational.test.ts
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createRng } from "../rng/rng.ts";
+import type { Rational } from "./rational.ts";
+import {
+  ONE,
+  ZERO,
+  abs,
+  add,
+  asInteger,
+  cmp,
+  div,
+  eq,
+  floor,
+  fromSafeInt,
+  fromScaled,
+  gt,
+  inv,
+  isInteger,
+  isZero,
+  max,
+  min,
+  mul,
+  neg,
+  parseRational,
+  pow10,
+  rational,
+  sign,
+  sub,
+  toDecimalString,
+  toScaled,
+  toString as rationalToString,
+} from "./rational.ts";
+
+const PROPERTY_CASES = 5000;
+
+test("rational: normalizes to a single representation", () => {
+  assert.deepEqual(rational(2n, 4n), { n: 1n, d: 2n });
+  assert.deepEqual(rational(-2n, 4n), { n: -1n, d: 2n });
+  assert.deepEqual(rational(2n, -4n), { n: -1n, d: 2n });
+  assert.deepEqual(rational(-2n, -4n), { n: 1n, d: 2n });
+  assert.deepEqual(rational(0n, 7n), ZERO);
+  assert.deepEqual(rational(0n, -7n), ZERO);
+  assert.deepEqual(rational(6n, 3n), { n: 2n, d: 1n });
+});
+
+test("rational: rejects a zero denominator and a reciprocal of zero", () => {
+  assert.throws(() => rational(1n, 0n), RangeError);
+  assert.throws(() => div(ONE, ZERO), RangeError);
+  assert.throws(() => inv(ZERO), RangeError);
+});
+
+test("rational: rejects a JS number that is not a safe integer", () => {
+  assert.equal(rationalToString(fromSafeInt(-7)), "-7");
+  assert.throws(() => fromSafeInt(1 / 3), RangeError);
+  assert.throws(() => fromSafeInt(Number.MAX_SAFE_INTEGER + 2), RangeError);
+});
+
+test("rational: 0.1 + 0.2 is exactly 0.3", () => {
+  // The whole reason this module exists. In IEEE doubles this comparison is false,
+  // and a decimal generator built on doubles marks correct work wrong for ever.
+  const tenth = parseRational("0.1");
+  const fifth = parseRational("0.2");
+  const threeTenths = parseRational("0.3");
+  assert.ok(eq(add(tenth, fifth), threeTenths));
+  assert.deepEqual(add(tenth, fifth), { n: 3n, d: 10n });
+  assert.equal(toDecimalString(add(tenth, fifth), 1), "0.3");
+});
+
+test("rational: 0.3 - 0.1 is exactly 0.2, and a tenth times three is three tenths", () => {
+  assert.ok(eq(sub(parseRational("0.3"), parseRational("0.1")), parseRational("0.2")));
+  assert.ok(eq(mul(parseRational("0.1"), fromSafeInt(3)), parseRational("0.3")));
+  assert.ok(eq(add(add(parseRational("0.1"), parseRational("0.1")), parseRational("0.1")), parseRational("0.3")));
+});
+
+test("rational: parses integers, fractions and decimals", () => {
+  assert.deepEqual(parseRational("42"), { n: 42n, d: 1n });
+  assert.deepEqual(parseRational("-42"), { n: -42n, d: 1n });
+  assert.deepEqual(parseRational("+42"), { n: 42n, d: 1n });
+  assert.deepEqual(parseRational("-3/4"), { n: -3n, d: 4n });
+  assert.deepEqual(parseRational("6/4"), { n: 3n, d: 2n });
+  assert.deepEqual(parseRational("0.75"), { n: 3n, d: 4n });
+  assert.deepEqual(parseRational(".5"), { n: 1n, d: 2n });
+  assert.deepEqual(parseRational("-0.125"), { n: -1n, d: 8n });
+  assert.deepEqual(parseRational("  7  "), { n: 7n, d: 1n });
+  assert.throws(() => parseRational("1.2.3"), SyntaxError);
+  assert.throws(() => parseRational("one"), SyntaxError);
+  assert.throws(() => parseRational(""), SyntaxError);
+});
+
+test("rational: parsing never loses precision on long decimals", () => {
+  const value = parseRational("0.12345678901234567890123456789");
+  assert.equal(toDecimalString(value, 29), "0.12345678901234567890123456789");
+  assert.equal(value.d, pow10(29));
+});
+
+test("rational: scaled construction and recovery", () => {
+  assert.deepEqual(fromScaled(2503n, 2), { n: 2503n, d: 100n });
+  assert.equal(toScaled(fromScaled(2503n, 2), 2), 2503n);
+  assert.equal(toScaled(fromScaled(2503n, 2), 3), 25030n);
+  assert.equal(toScaled(rational(1n, 3n), 2), null);
+  assert.equal(toDecimalString(rational(1n, 3n), 2), null);
+  assert.equal(toDecimalString(rational(5n, 2n), 2), "2.50");
+  assert.equal(toDecimalString(rational(-5n, 2n), 1), "-2.5");
+  assert.equal(toDecimalString(rational(1n, 100n), 2), "0.01");
+  assert.equal(toDecimalString(fromSafeInt(7), 0), "7");
+});
+
+test("rational: comparison, sign, floor and integrality", () => {
+  assert.equal(cmp(rational(1n, 3n), rational(1n, 2n)), -1);
+  assert.equal(cmp(rational(1n, 2n), rational(2n, 4n)), 0);
+  assert.equal(cmp(rational(-1n, 3n), rational(-1n, 2n)), 1);
+  assert.equal(sign(rational(-1n, 3n)), -1);
+  assert.equal(sign(ZERO), 0);
+  assert.ok(isZero(sub(rational(3n, 7n), rational(3n, 7n))));
+  assert.ok(isInteger(rational(4n, 2n)));
+  assert.equal(asInteger(rational(4n, 2n)), 2n);
+  assert.equal(asInteger(rational(1n, 2n)), null);
+  assert.equal(floor(rational(7n, 2n)), 3n);
+  assert.equal(floor(rational(-7n, 2n)), -4n);
+  assert.equal(floor(rational(-4n, 2n)), -2n);
+  assert.ok(gt(max(rational(1n, 3n), rational(1n, 4n)), min(rational(1n, 3n), rational(1n, 4n))));
+});
+
+test("rational: huge values stay exact where doubles would not", () => {
+  const big = rational(BigInt(Number.MAX_SAFE_INTEGER) * 1000n + 1n);
+  assert.ok(eq(sub(add(big, ONE), ONE), big));
+  assert.ok(eq(sub(big, big), ZERO));
+  // 2^53 + 1 is not representable as a double; as a rational it is just an integer.
+  const beyondDouble = rational(9007199254740993n);
+  assert.equal(rationalToString(beyondDouble), "9007199254740993");
+  assert.ok(!eq(beyondDouble, rational(9007199254740992n)));
+});
+
+function randomRational(rng: ReturnType<typeof createRng>): Rational {
+  return rational(BigInt(rng.nextInt(-1000, 1000)), BigInt(rng.nextInt(1, 1000)));
+}
+
+test("rational: field laws hold over generated triples", (t) => {
+  const rng = createRng(20260725);
+  let cases = 0;
+
+  for (let i = 0; i < PROPERTY_CASES; i++) {
+    const a = randomRational(rng);
+    const b = randomRational(rng);
+    const c = randomRational(rng);
+    cases += 1;
+
+    // Canonical form: positive denominator, fully reduced, zero is 0/1.
+    for (const value of [a, b, c, add(a, b), mul(a, b), sub(a, b)]) {
+      assert.ok(value.d > 0n, "denominator must be positive");
+      if (value.n === 0n) assert.equal(value.d, 1n, "zero has one representation");
+    }
+
+    assert.ok(eq(add(a, b), add(b, a)), "addition commutes");
+    assert.ok(eq(mul(a, b), mul(b, a)), "multiplication commutes");
+    assert.ok(eq(add(add(a, b), c), add(a, add(b, c))), "addition associates");
+    assert.ok(eq(mul(mul(a, b), c), mul(a, mul(b, c))), "multiplication associates");
+    assert.ok(eq(mul(a, add(b, c)), add(mul(a, b), mul(a, c))), "multiplication distributes");
+    assert.ok(eq(sub(add(a, b), b), a), "subtraction undoes addition");
+    assert.ok(eq(add(a, neg(a)), ZERO), "a + (-a) = 0");
+    assert.ok(eq(add(a, ZERO), a), "0 is the additive identity");
+    assert.ok(eq(mul(a, ONE), a), "1 is the multiplicative identity");
+    if (!isZero(b)) {
+      assert.ok(eq(mul(div(a, b), b), a), "division undoes multiplication");
+      assert.ok(eq(div(b, b), ONE), "b / b = 1");
+    }
+
+    // Comparison is a total order that agrees with subtraction.
+    assert.equal(cmp(a, b), -cmp(b, a) as -1 | 0 | 1, "comparison is antisymmetric");
+    assert.equal(cmp(a, b), sign(sub(a, b)), "comparison agrees with subtraction");
+    if (cmp(a, b) <= 0 && cmp(b, c) <= 0) assert.ok(cmp(a, c) <= 0, "comparison is transitive");
+    assert.ok(!isZero(abs(a)) || isZero(a));
+    assert.ok(cmp(abs(a), ZERO) >= 0, "absolute value is non-negative");
+  }
+
+  t.diagnostic(`field laws checked over ${String(cases)} generated triples`);
+  assert.equal(cases, PROPERTY_CASES);
+});
+
+test("rational: decimal round-trip is exact for every value with a finite expansion", (t) => {
+  const rng = createRng(4711);
+  let cases = 0;
+
+  for (let i = 0; i < PROPERTY_CASES; i++) {
+    const places = rng.nextInt(0, 4);
+    const scaled = BigInt(rng.nextInt(-99999, 99999));
+    const value = fromScaled(scaled, places);
+    const text = toDecimalString(value, places);
+    assert.ok(text !== null, "a value built from a scaled integer must print at that scale");
+    assert.ok(eq(parseRational(text), value), `round-trip failed for ${text}`);
+    assert.equal(toScaled(value, places), scaled);
+    cases += 1;
+  }
+
+  t.diagnostic(`decimal round-trip checked over ${String(cases)} generated values`);
+  assert.equal(cases, PROPERTY_CASES);
+});

--- a/dynawalla/curriculum/src/math/rational.ts
+++ b/dynawalla/curriculum/src/math/rational.ts
@@ -1,0 +1,229 @@
+/**
+ * Exact rational arithmetic over BigInt.
+ *
+ * ADR-0006: no IEEE floats in any generator or checker. `0.1 + 0.2 !== 0.3` marks
+ * correct decimal work *wrong*, deterministically, so no flaky-test detector would
+ * ever surface it. Every numeric quantity that reaches an answer, a comparison or a
+ * difficulty coefficient is a `Rational`.
+ *
+ * Invariants held by construction for every value produced by this module:
+ *   - `d > 0n`
+ *   - `gcd(|n|, d) === 1n`
+ *   - `0` is exactly `{ n: 0n, d: 1n }`
+ * so structural equality and `cmp` agree, and a value has exactly one representation.
+ */
+
+export type Rational = {
+  readonly n: bigint;
+  readonly d: bigint;
+};
+
+function gcd(a: bigint, b: bigint): bigint {
+  let x = a < 0n ? -a : a;
+  let y = b < 0n ? -b : b;
+  while (y !== 0n) {
+    const t = x % y;
+    x = y;
+    y = t;
+  }
+  return x;
+}
+
+/** Construct a normalized rational. Throws on a zero denominator. */
+export function rational(n: bigint, d: bigint = 1n): Rational {
+  if (d === 0n) throw new RangeError("rational: zero denominator");
+  let num = n;
+  let den = d;
+  if (den < 0n) {
+    num = -num;
+    den = -den;
+  }
+  if (num === 0n) return ZERO;
+  const g = gcd(num, den);
+  return { n: num / g, d: den / g };
+}
+
+export const ZERO: Rational = { n: 0n, d: 1n };
+export const ONE: Rational = { n: 1n, d: 1n };
+
+/**
+ * Lift a JS number. Rejects anything that is not a safe integer — the point of this
+ * module is that a fractional `number` can never enter the system silently.
+ */
+export function fromSafeInt(v: number): Rational {
+  if (!Number.isSafeInteger(v)) {
+    throw new RangeError(`fromSafeInt: not a safe integer: ${String(v)}`);
+  }
+  return rational(BigInt(v));
+}
+
+/** `10^k` as a positive integer bigint. `k` must be >= 0. */
+export function pow10(k: number): bigint {
+  if (!Number.isSafeInteger(k) || k < 0) throw new RangeError(`pow10: bad exponent ${String(k)}`);
+  let out = 1n;
+  for (let i = 0; i < k; i++) out *= 10n;
+  return out;
+}
+
+/** `value / 10^places`, exactly. The one sanctioned way to build a decimal. */
+export function fromScaled(value: bigint, places: number): Rational {
+  return rational(value, pow10(places));
+}
+
+export function add(a: Rational, b: Rational): Rational {
+  return rational(a.n * b.d + b.n * a.d, a.d * b.d);
+}
+
+export function sub(a: Rational, b: Rational): Rational {
+  return rational(a.n * b.d - b.n * a.d, a.d * b.d);
+}
+
+export function mul(a: Rational, b: Rational): Rational {
+  return rational(a.n * b.n, a.d * b.d);
+}
+
+export function div(a: Rational, b: Rational): Rational {
+  if (b.n === 0n) throw new RangeError("div: division by zero");
+  return rational(a.n * b.d, a.d * b.n);
+}
+
+export function neg(a: Rational): Rational {
+  return a.n === 0n ? ZERO : { n: -a.n, d: a.d };
+}
+
+export function abs(a: Rational): Rational {
+  return a.n < 0n ? { n: -a.n, d: a.d } : a;
+}
+
+export function inv(a: Rational): Rational {
+  if (a.n === 0n) throw new RangeError("inv: zero has no reciprocal");
+  return rational(a.d, a.n);
+}
+
+export function cmp(a: Rational, b: Rational): -1 | 0 | 1 {
+  const left = a.n * b.d;
+  const right = b.n * a.d;
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+export function eq(a: Rational, b: Rational): boolean {
+  return a.n === b.n && a.d === b.d;
+}
+
+export function lt(a: Rational, b: Rational): boolean {
+  return cmp(a, b) < 0;
+}
+
+export function lte(a: Rational, b: Rational): boolean {
+  return cmp(a, b) <= 0;
+}
+
+export function gt(a: Rational, b: Rational): boolean {
+  return cmp(a, b) > 0;
+}
+
+export function gte(a: Rational, b: Rational): boolean {
+  return cmp(a, b) >= 0;
+}
+
+export function isZero(a: Rational): boolean {
+  return a.n === 0n;
+}
+
+export function isInteger(a: Rational): boolean {
+  return a.d === 1n;
+}
+
+export function sign(a: Rational): -1 | 0 | 1 {
+  if (a.n < 0n) return -1;
+  if (a.n > 0n) return 1;
+  return 0;
+}
+
+export function min(a: Rational, b: Rational): Rational {
+  return cmp(a, b) <= 0 ? a : b;
+}
+
+export function max(a: Rational, b: Rational): Rational {
+  return cmp(a, b) >= 0 ? a : b;
+}
+
+/** The integer value, or `null` when the rational is not an integer. */
+export function asInteger(a: Rational): bigint | null {
+  return a.d === 1n ? a.n : null;
+}
+
+/** Floor of the value, as a bigint. Exact for negatives too. */
+export function floor(a: Rational): bigint {
+  const q = a.n / a.d;
+  const r = a.n % a.d;
+  return r < 0n ? q - 1n : q;
+}
+
+/**
+ * `value * 10^places` when that product is an integer, else `null`.
+ * This is the bridge to a digit-wise column algorithm: a decimal problem is an
+ * integer problem plus a decimal-point position, and nothing else.
+ */
+export function toScaled(a: Rational, places: number): bigint | null {
+  const scaled = a.n * pow10(places);
+  return scaled % a.d === 0n ? scaled / a.d : null;
+}
+
+/**
+ * Exact fixed-place decimal string, or `null` when the value does not fit in
+ * `places` decimal digits. Never rounds: rounding is a display decision that
+ * belongs to the number layer (ARCHITECTURE L2), not to the arithmetic.
+ *
+ * The separator is always `.`; localizing it is the number layer's job (CG-14).
+ */
+export function toDecimalString(a: Rational, places: number): string | null {
+  const scaled = toScaled(a, places);
+  if (scaled === null) return null;
+  const negative = scaled < 0n;
+  const digits = (negative ? -scaled : scaled).toString().padStart(places + 1, "0");
+  const whole = digits.slice(0, digits.length - places);
+  const frac = places === 0 ? "" : `.${digits.slice(digits.length - places)}`;
+  return `${negative ? "-" : ""}${whole}${frac}`;
+}
+
+/** Canonical `n/d` (or `n` when integral). Stable, used for hashing and snapshots. */
+export function toString(a: Rational): string {
+  return a.d === 1n ? a.n.toString() : `${a.n.toString()}/${a.d.toString()}`;
+}
+
+const INTEGER_PATTERN = /^[+-]?\d+$/;
+const FRACTION_PATTERN = /^([+-]?\d+)\/(\d+)$/;
+const DECIMAL_PATTERN = /^([+-]?)(\d*)\.(\d+)$/;
+
+/**
+ * Parse `"3"`, `"-3/4"` or `"0.75"` into an exact rational.
+ *
+ * This is the only place a decimal *string* becomes a number in this package, and it
+ * goes through BigInt digits — never `parseFloat`. `parseRational("0.1")` is exactly
+ * one tenth.
+ */
+export function parseRational(text: string): Rational {
+  const s = text.trim();
+  if (INTEGER_PATTERN.test(s)) return rational(BigInt(s));
+
+  const frac = FRACTION_PATTERN.exec(s);
+  if (frac) {
+    const [, num, den] = frac;
+    if (num === undefined || den === undefined) throw new SyntaxError(`parseRational: ${text}`);
+    return rational(BigInt(num), BigInt(den));
+  }
+
+  const dec = DECIMAL_PATTERN.exec(s);
+  if (dec) {
+    const [, signPart, wholePart, fracPart] = dec;
+    if (fracPart === undefined) throw new SyntaxError(`parseRational: ${text}`);
+    const digits = `${wholePart === undefined || wholePart === "" ? "0" : wholePart}${fracPart}`;
+    const value = BigInt(digits) * (signPart === "-" ? -1n : 1n);
+    return rational(value, pow10(fracPart.length));
+  }
+
+  throw new SyntaxError(`parseRational: cannot parse ${JSON.stringify(text)}`);
+}

--- a/dynawalla/curriculum/src/render/registry.ts
+++ b/dynawalla/curriculum/src/render/registry.ts
@@ -1,0 +1,57 @@
+/**
+ * Renderer ownership declarations — the data behind gate CG-8.
+ *
+ * CG-8 is the gate the first program draft was missing entirely: a generator can
+ * emit a perfectly valid `Exercise` that the app cannot draw. A skill may not go
+ * `active` unless its generator's `AnswerSchema` kind **and every
+ * `representations.required` RepId** has a registered, tested renderer.
+ *
+ * `curriculum/` cannot import the app, so the registry is a declaration the app
+ * has to satisfy, not a live lookup. Two fields keep that from becoming a rubber
+ * stamp:
+ *
+ * - `owner` names the PR that must land the renderer. An entry with no owner is
+ *   meaningless and the gate rejects it.
+ * - `implemented` is `false` until the renderer and its test exist. The default
+ *   gate accepts a declared-but-unimplemented renderer (the curriculum can be
+ *   authored ahead of the work surface); `--strict-renderers`, which the release
+ *   checklist runs, does not. So "declare everything" buys nothing at release.
+ *
+ * PR-2.3 and PR-2.4 flip `integer` and `columnAlgorithm` to implemented and add
+ * `testRef`. PR-2.10 does the same for the counting board.
+ */
+
+import type { AnswerSchemaKind } from "../types/answer.ts";
+import type { RepId } from "../types/ids.ts";
+
+export type RendererDeclaration = {
+  /** `answer:<schema kind>` or `rep:<rep id>`. */
+  readonly id: string;
+  readonly kind: "answerSchema" | "representation";
+  /** The PR that owns landing this renderer. Required — see above. */
+  readonly owner: string;
+  readonly implemented: boolean;
+  /** Path of the test that proves it renders. Required once implemented. */
+  readonly testRef?: string;
+};
+
+export const rendererRegistry: readonly RendererDeclaration[] = [
+  { id: "answer:integer", kind: "answerSchema", owner: "PR-2.3", implemented: false },
+  { id: "answer:columnAlgorithm", kind: "answerSchema", owner: "PR-2.4", implemented: false },
+  { id: "rep:counting-board", kind: "representation", owner: "PR-2.10", implemented: false },
+];
+
+export function answerRendererId(kind: AnswerSchemaKind): string {
+  return `answer:${kind}`;
+}
+
+export function repRendererId(rep: RepId): string {
+  return `rep:${rep}`;
+}
+
+export function findRenderer(
+  id: string,
+  registry: readonly RendererDeclaration[] = rendererRegistry,
+): RendererDeclaration | undefined {
+  return registry.find((entry) => entry.id === id);
+}

--- a/dynawalla/curriculum/src/rng/hash.ts
+++ b/dynawalla/curriculum/src/rng/hash.ts
@@ -1,0 +1,27 @@
+/**
+ * FNV-1a, 64-bit, over BigInt. Used for the CG-16 committed output hashes.
+ *
+ * Deliberately not `node:crypto`: the same hash has to be computable from the app
+ * bundle (a WebView) as from the validator, and a curriculum module may not depend
+ * on Node built-ins.
+ */
+
+const OFFSET = 0xcbf29ce484222325n;
+const PRIME = 0x100000001b3n;
+const MASK = 0xffffffffffffffffn;
+
+export function fnv1a64(text: string): bigint {
+  let hash = OFFSET;
+  // Hash UTF-8 bytes, not UTF-16 code units, so the value does not depend on the
+  // JS string encoding of any character above U+007F.
+  const bytes = new TextEncoder().encode(text);
+  for (const byte of bytes) {
+    hash = (hash ^ BigInt(byte)) & MASK;
+    hash = (hash * PRIME) & MASK;
+  }
+  return hash;
+}
+
+export function fnv1a64Hex(text: string): string {
+  return fnv1a64(text).toString(16).padStart(16, "0");
+}

--- a/dynawalla/curriculum/src/rng/rng.test.ts
+++ b/dynawalla/curriculum/src/rng/rng.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fnv1a64, fnv1a64Hex } from "./hash.ts";
+import { SEED_SEPARATOR, createRng, fnv1a32, seedFrom } from "./rng.ts";
+
+test("fnv1a32: published test vectors", () => {
+  // From the FNV reference test suite. These are an independent oracle: a typo in
+  // the offset basis or the prime fails here rather than silently reshuffling
+  // every generated exercise.
+  assert.equal(fnv1a32(""), 0x811c9dc5);
+  assert.equal(fnv1a32("a"), 0xe40c292c);
+  assert.equal(fnv1a32("b"), 0xe70c2de5);
+  assert.equal(fnv1a32("foobar"), 0xbf9cf968);
+});
+
+test("fnv1a64: published test vectors", () => {
+  assert.equal(fnv1a64(""), 0xcbf29ce484222325n);
+  assert.equal(fnv1a64("a"), 0xaf63dc4c8601ec8cn);
+  assert.equal(fnv1a64("foobar"), 0x85944171f73967e8n);
+  assert.equal(fnv1a64Hex("foobar"), "85944171f73967e8");
+});
+
+test("fnv1a64: hashes UTF-8 bytes, not UTF-16 code units", () => {
+  // Two strings that differ only above the ASCII range must not collide because
+  // of a lossy encoding step.
+  assert.notEqual(fnv1a64Hex("é"), fnv1a64Hex("e"));
+  assert.equal(fnv1a64Hex("é").length, 16);
+});
+
+test("rng: pinned known-answer vectors", () => {
+  // A regression pin, not an oracle: these are what this implementation produces
+  // today. Changing them changes every generated exercise, which is why CG-16
+  // hashes generator output on two operating systems.
+  assert.deepEqual(
+    Array.from({ length: 6 }, () => createRng(0)).map((rng) => rng.nextUint32()),
+    [1144304738, 1144304738, 1144304738, 1144304738, 1144304738, 1144304738],
+  );
+  const stream = createRng(0);
+  assert.deepEqual(
+    Array.from({ length: 6 }, () => stream.nextUint32()),
+    [1144304738, 1416247, 958946056, 627933444, 2007157716, 2340967985],
+  );
+  const seeded = createRng(0x9e3779b9);
+  assert.deepEqual(
+    Array.from({ length: 4 }, () => seeded.nextUint32()),
+    [1541420728, 454851044, 2900350524, 3942498910],
+  );
+});
+
+test("rng: same seed, same stream; different seed, different stream", () => {
+  const a = Array.from({ length: 64 }, () => 0);
+  const first = createRng(12345);
+  const second = createRng(12345);
+  const third = createRng(12346);
+  for (let i = 0; i < a.length; i++) {
+    assert.equal(first.nextUint32(), second.nextUint32());
+  }
+  assert.notEqual(createRng(12345).nextUint32(), third.nextUint32());
+});
+
+test("rng: rejects a seed that is not a uint32", () => {
+  assert.throws(() => createRng(-1), RangeError);
+  assert.throws(() => createRng(4294967296), RangeError);
+  assert.throws(() => createRng(1 / 3), RangeError);
+});
+
+test("rng: nextInt stays in range and counts its draws", () => {
+  const rng = createRng(7);
+  for (let i = 0; i < 10000; i++) {
+    const value = rng.nextInt(-5, 5);
+    assert.ok(value >= -5 && value <= 5, `out of range: ${String(value)}`);
+    assert.ok(Number.isSafeInteger(value));
+  }
+  assert.ok(rng.draws() >= 10000, "every draw is counted");
+  assert.equal(createRng(7).nextInt(3, 3), 3, "a single-value range consumes no draw");
+  assert.equal(createRng(7).draws(), 0);
+  assert.throws(() => createRng(7).nextInt(5, 4), RangeError);
+});
+
+test("rng: nextInt is close to uniform", (t) => {
+  const rng = createRng(99);
+  const buckets = new Array<number>(10).fill(0);
+  const draws = 100000;
+  for (let i = 0; i < draws; i++) {
+    const index = rng.nextInt(0, 9);
+    buckets[index] = (buckets[index] ?? 0) + 1;
+  }
+  const expected = draws / 10;
+  for (const [index, count] of buckets.entries()) {
+    // ±5% of the expected count. Rejection sampling makes this a statement about
+    // the generator, not about the modulo.
+    assert.ok(
+      count * 100 >= expected * 95 && count * 100 <= expected * 105,
+      `bucket ${String(index)} had ${String(count)}, expected about ${String(expected)}`,
+    );
+  }
+  t.diagnostic(`uniformity checked over ${String(draws)} draws into 10 buckets`);
+});
+
+test("rng: sample takes distinct elements in order", () => {
+  const items = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  const rng = createRng(31337);
+  for (let i = 0; i < 2000; i++) {
+    const count = rng.nextInt(0, items.length);
+    const drawn = rng.sample(items, count);
+    assert.equal(drawn.length, count);
+    assert.equal(new Set(drawn).size, count, "elements are distinct");
+    assert.deepEqual([...drawn].sort((a, b) => a - b), drawn, "order is preserved");
+  }
+  assert.throws(() => createRng(1).sample(items, items.length + 1), RangeError);
+  assert.throws(() => createRng(1).pick([]), RangeError);
+});
+
+test("rng: seedFrom is stable and separates its parts", () => {
+  assert.equal(seedFrom("a", "b"), fnv1a32(`a${SEED_SEPARATOR}b`));
+  // The separator matters: without one, ("ab","c") and ("a","bc") would be the
+  // same seed, and two different exercises would be the same exercise.
+  assert.notEqual(seedFrom("ab", "c"), seedFrom("a", "bc"));
+  assert.ok(seedFrom("dw.add.regroup.subtract-across-zero", "2") < 4294967296);
+});

--- a/dynawalla/curriculum/src/rng/rng.ts
+++ b/dynawalla/curriculum/src/rng/rng.ts
@@ -1,0 +1,119 @@
+/**
+ * Seeded, integer-only PRNG.
+ *
+ * ADR-0006 / CG-16: generation is seeded, pure and platform-stable. Never
+ * `Math.random`, no `Intl` inside generation, no key-order assumptions.
+ *
+ * `mulberry32` is normally written to return a float in [0, 1). It does not here:
+ * every draw is a uint32 and every derived value is produced by integer arithmetic
+ * with rejection sampling, so the stream is identical on x86 and arm64 and no
+ * float ever enters generation.
+ *
+ * This module is the local home of what ARCHITECTURE.md schedules as
+ * `shared/kernel/rng.ts` at M2 (PR-2.1). `shared/` does not exist yet; when it
+ * does, this file moves and the known-answer vectors move with it.
+ */
+
+const UINT32 = 4294967296;
+
+/** FNV-1a, 32-bit. Maps seed material (an exercise id) to a uint32 seed. */
+export function fnv1a32(text: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+export type Rng = {
+  /** Uniform uint32. */
+  nextUint32(): number;
+  /** Uniform integer in `[lo, hi]`, both inclusive. Rejection-sampled, unbiased. */
+  nextInt(lo: number, hi: number): number;
+  /** Uniform element of a non-empty array. */
+  pick<T>(items: readonly T[]): T;
+  /** `count` distinct elements of `items`, in ascending index order. */
+  sample<T>(items: readonly T[], count: number): T[];
+  /** How many uint32 draws have been consumed. Feeds `SelectionTrace.rngDraws`. */
+  draws(): number;
+};
+
+/**
+ * mulberry32, emitting uint32 rather than a float.
+ * Known-answer vectors for seed 0 and seed 0x9E3779B9 are pinned in `rng.test.ts`;
+ * a change to this stream changes every generated exercise, which is why CG-16
+ * hashes generator output on two operating systems.
+ */
+export function createRng(seed: number): Rng {
+  if (!Number.isSafeInteger(seed) || seed < 0 || seed >= UINT32) {
+    throw new RangeError(`createRng: seed must be a uint32, got ${String(seed)}`);
+  }
+  let state = seed >>> 0;
+  let consumed = 0;
+
+  const nextUint32 = (): number => {
+    consumed += 1;
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return (t ^ (t >>> 14)) >>> 0;
+  };
+
+  const nextInt = (lo: number, hi: number): number => {
+    if (!Number.isSafeInteger(lo) || !Number.isSafeInteger(hi)) {
+      throw new RangeError(`nextInt: bounds must be integers, got ${String(lo)}..${String(hi)}`);
+    }
+    if (hi < lo) throw new RangeError(`nextInt: empty range ${String(lo)}..${String(hi)}`);
+    const range = hi - lo + 1;
+    if (range > UINT32) throw new RangeError("nextInt: range exceeds uint32");
+    if (range === 1) return lo;
+    // Reject the ragged tail so every value in the range is equally likely.
+    const limit = UINT32 - (UINT32 % range);
+    let draw = nextUint32();
+    while (draw >= limit) draw = nextUint32();
+    return lo + (draw % range);
+  };
+
+  return {
+    nextUint32,
+    nextInt,
+    pick<T>(items: readonly T[]): T {
+      if (items.length === 0) throw new RangeError("pick: empty array");
+      const chosen = items[nextInt(0, items.length - 1)];
+      if (chosen === undefined) throw new RangeError("pick: undefined element");
+      return chosen;
+    },
+    sample<T>(items: readonly T[], count: number): T[] {
+      if (count < 0 || count > items.length) {
+        throw new RangeError(`sample: cannot take ${String(count)} of ${String(items.length)}`);
+      }
+      // Selection sampling (Knuth 3.4.2 S): one pass, order-preserving, and it
+      // consumes a draw count that depends only on `items.length`.
+      const out: T[] = [];
+      let remaining = count;
+      for (let i = 0; i < items.length && remaining > 0; i++) {
+        const left = items.length - i;
+        if (nextInt(1, left) <= remaining) {
+          const item = items[i];
+          if (item === undefined) throw new RangeError("sample: undefined element");
+          out.push(item);
+          remaining -= 1;
+        }
+      }
+      return out;
+    },
+    draws: () => consumed,
+  };
+}
+
+/**
+ * Separator for seed material. Explicit and printable so the seed of any exercise
+ * can be reproduced by hand from its id.
+ */
+export const SEED_SEPARATOR = "|";
+
+/** Derive a uint32 seed from stable string material (usually the exercise id). */
+export function seedFrom(...parts: readonly string[]): number {
+  return fnv1a32(parts.join(SEED_SEPARATOR));
+}

--- a/dynawalla/curriculum/src/serialize.ts
+++ b/dynawalla/curriculum/src/serialize.ts
@@ -9,7 +9,7 @@
 
 import { toString as rationalToString } from "./math/rational.ts";
 import { answerToString } from "./types/answer.ts";
-import type { AnswerValue } from "./types/answer.ts";
+import type { AnswerSchema, AnswerValue } from "./types/answer.ts";
 import type { Exercise, PromptSlot, PromptSpec, SolutionStep } from "./types/exercise.ts";
 
 function slot(value: PromptSlot): string {
@@ -42,6 +42,24 @@ function step(value: SolutionStep): string {
   return `${value.key}${focus}{${slots(value.slots)}}`;
 }
 
+/**
+ * Fields in a fixed order, like everything else here. `JSON.stringify` would make
+ * the hash depend on the order of the object literal the generator happens to
+ * build, which is the failure this module exists to prevent.
+ */
+function schema(value: AnswerSchema): string {
+  switch (value.kind) {
+    case "integer":
+      return `integer(${String(value.digits)},${String(value.decimalPlaces)})`;
+    case "columnAlgorithm":
+      return `columnAlgorithm(${String(value.cols)},${value.marks},${String(value.decimalPlaces)})`;
+    case "fraction":
+      return `fraction(${value.parts.join("+")})`;
+    case "choice":
+      return `choice(${String(value.k)})`;
+  }
+}
+
 function answers(values: readonly AnswerValue[]): string {
   return values.map(answerToString).join("|");
 }
@@ -67,7 +85,7 @@ export function serializeExercise(exercise: Exercise): string {
     exercise.form,
     prompt(exercise.prompt),
     representation(exercise),
-    JSON.stringify(exercise.schema),
+    schema(exercise.schema),
     answerToString(exercise.answer.canonical),
     answers(exercise.answer.alsoAccept),
     exercise.distractors.map((d) => `${answerToString(d.value)}~${d.misconception ?? ""}`).join("|"),

--- a/dynawalla/curriculum/src/serialize.ts
+++ b/dynawalla/curriculum/src/serialize.ts
@@ -1,0 +1,86 @@
+/**
+ * Canonical serialization.
+ *
+ * Never `JSON.stringify` of a generated object: key order would then be an
+ * implementation detail of the generator, and CG-16's committed output hashes
+ * would change when someone reorders a literal. Every field is written here in a
+ * fixed order, and a new field has to be added here deliberately.
+ */
+
+import { toString as rationalToString } from "./math/rational.ts";
+import { answerToString } from "./types/answer.ts";
+import type { AnswerValue } from "./types/answer.ts";
+import type { Exercise, PromptSlot, PromptSpec, SolutionStep } from "./types/exercise.ts";
+
+function slot(value: PromptSlot): string {
+  switch (value.kind) {
+    case "number":
+      return `n(${rationalToString(value.value)},${String(value.decimalPlaces)})`;
+    case "count":
+      return `c(${String(value.value)})`;
+    case "term":
+      return `t(${value.key})`;
+  }
+}
+
+function slots(record: Readonly<Record<string, PromptSlot>>): string {
+  return Object.keys(record)
+    .sort()
+    .map((name) => {
+      const value = record[name];
+      return value === undefined ? "" : `${name}=${slot(value)}`;
+    })
+    .join(";");
+}
+
+function prompt(spec: PromptSpec): string {
+  return `${spec.key}{${slots(spec.slots)}}`;
+}
+
+function step(value: SolutionStep): string {
+  const focus = value.focusColumn === undefined ? "" : `@${String(value.focusColumn)}`;
+  return `${value.key}${focus}{${slots(value.slots)}}`;
+}
+
+function answers(values: readonly AnswerValue[]): string {
+  return values.map(answerToString).join("|");
+}
+
+function representation(exercise: Exercise): string {
+  const spec = exercise.representation;
+  if (spec === undefined) return "-";
+  const params = Object.keys(spec.params)
+    .sort()
+    .map((name) => `${name}=${String(spec.params[name])}`)
+    .join(";");
+  return `${spec.rep}{${params}}`;
+}
+
+/** Everything about the item, including ids and marks. Used for CG-16 hashes. */
+export function serializeExercise(exercise: Exercise): string {
+  return [
+    exercise.exerciseId,
+    exercise.skillId,
+    `L${String(exercise.level)}`,
+    `S${String(exercise.seed)}`,
+    `${exercise.family}@${String(exercise.familyRev)}`,
+    exercise.form,
+    prompt(exercise.prompt),
+    representation(exercise),
+    JSON.stringify(exercise.schema),
+    answerToString(exercise.answer.canonical),
+    answers(exercise.answer.alsoAccept),
+    exercise.distractors.map((d) => `${answerToString(d.value)}~${d.misconception ?? ""}`).join("|"),
+    exercise.check.kind === "exact" ? "exact" : `tol(${rationalToString(exercise.check.tolerance)})`,
+    exercise.solution.map(step).join("|"),
+  ].join("\n");
+}
+
+/**
+ * What a child would call "the same problem": the numbers and the answer, with the
+ * form, the seed and the ids stripped. This is what CG-9 counts distinct instances
+ * of — the same subtraction posed twice is one problem, not two.
+ */
+export function fingerprintItem(exercise: Exercise): string {
+  return `${prompt(exercise.prompt)}=>${answerToString(exercise.answer.canonical)}`;
+}

--- a/dynawalla/curriculum/src/snapshots/generators.json
+++ b/dynawalla/curriculum/src/snapshots/generators.json
@@ -1,15 +1,15 @@
 {
   "note": "CG-16 output hashes. One entry per family@rev|skill|level, over the first 20 seeds. Written on one operating system and verified on the other, so a generator that is not platform-stable fails CI. Regenerate with `npm run snapshots:update` — and only after bumping familyRev, if the family's output changed on purpose.",
   "entries": {
-    "gen.arith.column-op@1|dw.add.regroup.subtract-multidigit|L0": "05fb21028c5df2db",
-    "gen.arith.column-op@1|dw.add.regroup.subtract-multidigit|L1": "649eab1e0b17ce73",
-    "gen.arith.column-op@1|dw.add.regroup.subtract-multidigit|L2": "dee3e99ee9d5f5d9",
-    "gen.arith.column-op@1|dw.add.regroup.subtract-multidigit|L3": "49a5095f44d1a6f1",
-    "gen.arith.column-op@1|dw.add.regroup.subtract-across-zero|L0": "fb17a391adb419cb",
-    "gen.arith.column-op@1|dw.add.regroup.subtract-across-zero|L1": "204d008fb78643b9",
-    "gen.arith.column-op@1|dw.add.regroup.subtract-across-zero|L2": "d29c8c06988cb6a0",
-    "gen.arith.column-op@1|dw.add.regroup.add-multidigit|L0": "6ecd5bcc349c5b56",
-    "gen.arith.column-op@1|dw.add.regroup.add-multidigit|L1": "70c3ee3b87e82597",
-    "gen.arith.column-op@1|dw.add.regroup.add-multidigit|L2": "f4202fe16c5356e2"
+    "gen.arith.column-op@1|dw.add.regroup.subtract-multidigit|L0": "86368f55f57c4052",
+    "gen.arith.column-op@1|dw.add.regroup.subtract-multidigit|L1": "09a387c45a7f5147",
+    "gen.arith.column-op@1|dw.add.regroup.subtract-multidigit|L2": "92c903db966e6769",
+    "gen.arith.column-op@1|dw.add.regroup.subtract-multidigit|L3": "12528a279b0181ad",
+    "gen.arith.column-op@1|dw.add.regroup.subtract-across-zero|L0": "147f99a737b53863",
+    "gen.arith.column-op@1|dw.add.regroup.subtract-across-zero|L1": "1aff9d712bdea518",
+    "gen.arith.column-op@1|dw.add.regroup.subtract-across-zero|L2": "f9e45b9a8648926e",
+    "gen.arith.column-op@1|dw.add.regroup.add-multidigit|L0": "4609c8bb844b7b81",
+    "gen.arith.column-op@1|dw.add.regroup.add-multidigit|L1": "f9426934d400c3ae",
+    "gen.arith.column-op@1|dw.add.regroup.add-multidigit|L2": "4bcfbb15db1c766e"
   }
 }

--- a/dynawalla/curriculum/src/snapshots/generators.json
+++ b/dynawalla/curriculum/src/snapshots/generators.json
@@ -1,0 +1,15 @@
+{
+  "note": "CG-16 output hashes. One entry per family@rev|skill|level, over the first 20 seeds. Written on one operating system and verified on the other, so a generator that is not platform-stable fails CI. Regenerate with `npm run snapshots:update` — and only after bumping familyRev, if the family's output changed on purpose.",
+  "entries": {
+    "gen.arith.column-op@1|dw.add.regroup.subtract-multidigit|L0": "05fb21028c5df2db",
+    "gen.arith.column-op@1|dw.add.regroup.subtract-multidigit|L1": "649eab1e0b17ce73",
+    "gen.arith.column-op@1|dw.add.regroup.subtract-multidigit|L2": "dee3e99ee9d5f5d9",
+    "gen.arith.column-op@1|dw.add.regroup.subtract-multidigit|L3": "49a5095f44d1a6f1",
+    "gen.arith.column-op@1|dw.add.regroup.subtract-across-zero|L0": "fb17a391adb419cb",
+    "gen.arith.column-op@1|dw.add.regroup.subtract-across-zero|L1": "204d008fb78643b9",
+    "gen.arith.column-op@1|dw.add.regroup.subtract-across-zero|L2": "d29c8c06988cb6a0",
+    "gen.arith.column-op@1|dw.add.regroup.add-multidigit|L0": "6ecd5bcc349c5b56",
+    "gen.arith.column-op@1|dw.add.regroup.add-multidigit|L1": "70c3ee3b87e82597",
+    "gen.arith.column-op@1|dw.add.regroup.add-multidigit|L2": "f4202fe16c5356e2"
+  }
+}

--- a/dynawalla/curriculum/src/types/answer.ts
+++ b/dynawalla/curriculum/src/types/answer.ts
@@ -1,0 +1,94 @@
+/**
+ * Answer schemas and answer values.
+ *
+ * Four schemas in V1 (ARCHITECTURE L3). `decimal` is deliberately *not* a fifth: it
+ * is `integer` + the number layer's `NumberFormat`, which is why `decimalPlaces`
+ * rides on the schema instead of forking it.
+ *
+ * Every numeric answer value is a `Rational`. Comparison is exact and structural —
+ * there is no tolerance, no epsilon and no float anywhere on this path.
+ */
+
+import type { Rational } from "../math/rational.ts";
+import { eq as rationalEq, toString as rationalToString } from "../math/rational.ts";
+
+export type AnswerSchema =
+  | { readonly kind: "integer"; readonly digits: number; readonly decimalPlaces: number }
+  | {
+      readonly kind: "columnAlgorithm";
+      readonly cols: number;
+      readonly marks: "carry" | "borrow" | "none";
+      readonly decimalPlaces: number;
+    }
+  | { readonly kind: "fraction"; readonly parts: readonly ("num" | "den" | "whole")[] }
+  | { readonly kind: "choice"; readonly k: 2 | 3 | 4 };
+
+export type AnswerSchemaKind = AnswerSchema["kind"];
+
+/** A borrow or carry annotation a child writes above a column. */
+export type ColumnMark = {
+  readonly column: number;
+  readonly kind: "borrow" | "carry";
+  readonly value: number;
+};
+
+export type AnswerValue =
+  | { readonly kind: "integer"; readonly value: Rational }
+  | {
+      readonly kind: "columnAlgorithm";
+      readonly value: Rational;
+      readonly marks: readonly ColumnMark[];
+    }
+  // Fractions keep the *written* numerator and denominator: 2/4 and 1/2 are the same
+  // number and different answers, and which one is accepted is a curriculum decision
+  // per skill, not an arithmetic one.
+  | { readonly kind: "fraction"; readonly num: bigint; readonly den: bigint; readonly whole?: bigint }
+  | { readonly kind: "choice"; readonly index: number };
+
+export type AnswerValueKind = AnswerValue["kind"];
+
+/**
+ * Exact equality of two submitted answers.
+ *
+ * `columnAlgorithm` compares the *number* and ignores the marks: a child who
+ * regroups mentally and writes only the digits is right. Marks are process
+ * evidence for diagnosis, never a correctness condition.
+ */
+export function answerEquals(a: AnswerValue, b: AnswerValue): boolean {
+  if (a.kind !== b.kind) return false;
+  switch (a.kind) {
+    case "integer":
+      return rationalEq(a.value, (b as Extract<AnswerValue, { kind: "integer" }>).value);
+    case "columnAlgorithm":
+      return rationalEq(a.value, (b as Extract<AnswerValue, { kind: "columnAlgorithm" }>).value);
+    case "fraction": {
+      const other = b as Extract<AnswerValue, { kind: "fraction" }>;
+      return a.num === other.num && a.den === other.den && (a.whole ?? 0n) === (other.whole ?? 0n);
+    }
+    case "choice":
+      return a.index === (b as Extract<AnswerValue, { kind: "choice" }>).index;
+  }
+}
+
+/** Stable text form. Used for hashing, snapshots and dedupe — never shown to a child. */
+export function answerToString(value: AnswerValue): string {
+  switch (value.kind) {
+    case "integer":
+      return `int:${rationalToString(value.value)}`;
+    case "columnAlgorithm": {
+      const marks = value.marks
+        .map((m) => `${String(m.column)}${m.kind === "borrow" ? "b" : "c"}${String(m.value)}`)
+        .join(",");
+      return `col:${rationalToString(value.value)}[${marks}]`;
+    }
+    case "fraction":
+      return `frac:${(value.whole ?? 0n).toString()};${value.num.toString()}/${value.den.toString()}`;
+    case "choice":
+      return `choice:${String(value.index)}`;
+  }
+}
+
+/** True when the schema can only be answered by choosing from a closed list (CG-13). */
+export function isChoiceSchema(schema: AnswerSchema): boolean {
+  return schema.kind === "choice";
+}

--- a/dynawalla/curriculum/src/types/exercise.ts
+++ b/dynawalla/curriculum/src/types/exercise.ts
@@ -1,0 +1,82 @@
+/**
+ * The exercise contract (CURRICULUM.md, "three non-negotiables").
+ *
+ * 1. Exact rational arithmetic only — see `answer.ts`.
+ * 2. Seeded, pure, platform-stable — see `../rng/rng.ts`.
+ * 3. Structured prompts, never rendered strings — `PromptSpec` below. One template
+ *    key translated once serves every seeded instance forever, so localization cost
+ *    scales with template count instead of content volume (gate CG-19).
+ */
+
+import type { Rational } from "../math/rational.ts";
+import type { AnswerSchema, AnswerValue } from "./answer.ts";
+import type { ExerciseId, FamilyId, FormId, LocKey, MalRuleId, RepId, SkillId } from "./ids.ts";
+
+/**
+ * A prompt slot. Never a rendered string.
+ *
+ * `number` carries the exact value plus how many decimal places the *problem* is
+ * written to, because `1.50` and `1.5` are the same number and different notation,
+ * and the number layer needs the notation. `count` is separate from `number`
+ * because it selects a CLDR plural category (CG-14).
+ */
+export type PromptSlot =
+  | { readonly kind: "number"; readonly value: Rational; readonly decimalPlaces: number }
+  | { readonly kind: "count"; readonly value: number }
+  | { readonly kind: "term"; readonly key: LocKey };
+
+export type PromptSpec = {
+  readonly key: LocKey;
+  readonly slots: Readonly<Record<string, PromptSlot>>;
+};
+
+export type RepSpec = {
+  readonly rep: RepId;
+  readonly params: Readonly<Record<string, number>>;
+};
+
+export type SolutionStep = {
+  readonly key: LocKey;
+  readonly slots: Readonly<Record<string, PromptSlot>>;
+  /** Column this step acts on, units = 0. Lets a renderer highlight in place. */
+  readonly focusColumn?: number;
+};
+
+export type Distractor = {
+  readonly value: AnswerValue;
+  /** Which buggy procedure produced it. Internal only — never shown to a child (M-16). */
+  readonly misconception?: MalRuleId;
+};
+
+export type CheckSpec =
+  /** Exact structural equality against `canonical` or one of `alsoAccept`. */
+  | { readonly kind: "exact" }
+  /** Exact-rational tolerance band. Still no floats: the tolerance is a rational. */
+  | { readonly kind: "tolerance"; readonly tolerance: Rational };
+
+export type Exercise = {
+  readonly exerciseId: ExerciseId;
+  readonly skillId: SkillId;
+  readonly level: number;
+  readonly seed: number;
+  readonly family: FamilyId;
+  readonly familyRev: number;
+  /**
+   * Which interaction form this instance took. Not in the doc's sketch of
+   * `Exercise`, but the fact-memory layer keys cards on
+   * `skill:<id>#L<level>#<formId>` (ADR-0008), so the form has to be recoverable
+   * from the item that was served.
+   */
+  readonly form: FormId;
+  readonly prompt: PromptSpec;
+  readonly representation?: RepSpec;
+  /** The schema the work surface must render and `judge` must interpret. */
+  readonly schema: AnswerSchema;
+  readonly answer: {
+    readonly canonical: AnswerValue;
+    readonly alsoAccept: readonly AnswerValue[];
+  };
+  readonly distractors: readonly Distractor[];
+  readonly check: CheckSpec;
+  readonly solution: readonly SolutionStep[];
+};

--- a/dynawalla/curriculum/src/types/generator.ts
+++ b/dynawalla/curriculum/src/types/generator.ts
@@ -1,0 +1,81 @@
+/**
+ * The generator-family contract.
+ *
+ * A family owns its parameter schema, its difficulty contribution, its generation
+ * and its checker. Difficulty is *parameters*, not families: `column-op` with
+ * `{ op, digits, regroupings, acrossZero, decimalPlaces }` spans 2-digit addition
+ * through decimal subtraction, which is why V1 needs 18 families and not 60.
+ */
+
+import type { Rational } from "../math/rational.ts";
+import type { AnswerSchema, AnswerValue } from "./answer.ts";
+import type { Exercise } from "./exercise.ts";
+import type { FamilyId, FormId, MalRuleId, RepId, SkillId } from "./ids.ts";
+
+export type ParamIssue = {
+  readonly path: string;
+  readonly message: string;
+};
+
+export type ParamResult<P> =
+  | { readonly ok: true; readonly value: P }
+  | { readonly ok: false; readonly issues: readonly ParamIssue[] };
+
+export type ParamSchema<P> = {
+  /** Human-readable shape, printed by the validator when a binding is rejected. */
+  readonly describe: string;
+  validate(raw: unknown): ParamResult<P>;
+};
+
+export type GenerateRequest<P> = {
+  readonly skillId: SkillId;
+  readonly level: number;
+  readonly seed: number;
+  readonly params: P;
+  /** The binding's allowed forms; the family picks one deterministically. */
+  readonly forms: readonly FormId[];
+};
+
+export type Verdict =
+  | { readonly correct: true }
+  | { readonly correct: false; readonly misconception?: MalRuleId };
+
+export type GeneratorFamily<P> = {
+  readonly family: FamilyId;
+  /**
+   * Bumped whenever generated output changes. CG-16 keys its committed output
+   * hashes on this, so changing output without bumping it is a CI failure (M-08).
+   */
+  readonly familyRev: number;
+  readonly paramSchema: ParamSchema<P>;
+  /** Every form this family can emit. */
+  readonly forms: readonly FormId[];
+  /** True when *every* form is a closed-list choice. Read by CG-13. */
+  readonly choiceOnly: boolean;
+  /** Representations this family can attach to an item. */
+  readonly representations: readonly RepId[];
+
+  answerSchema(params: P, form: FormId): AnswerSchema;
+  /**
+   * The parameter-derived part of `b`. Form and representation offsets are added
+   * separately so a level's difficulty does not depend on which form a seed drew.
+   */
+  difficultyOffset(params: P): Rational;
+  formOffset(form: FormId): Rational;
+
+  generate(request: GenerateRequest<P>): Exercise;
+  check(exercise: Exercise, submitted: AnswerValue): Verdict;
+};
+
+/** A family with its parameter type erased, for registries and gates. */
+export type AnyGeneratorFamily = GeneratorFamily<never> & {
+  readonly paramSchema: ParamSchema<unknown>;
+  answerSchema(params: unknown, form: FormId): AnswerSchema;
+  difficultyOffset(params: unknown): Rational;
+  generate(request: GenerateRequest<unknown>): Exercise;
+};
+
+/** Erase the parameter type. Safe because the schema validates before every call. */
+export function erase<P>(family: GeneratorFamily<P>): AnyGeneratorFamily {
+  return family as unknown as AnyGeneratorFamily;
+}

--- a/dynawalla/curriculum/src/types/ids.ts
+++ b/dynawalla/curriculum/src/types/ids.ts
@@ -1,0 +1,90 @@
+/**
+ * Identifier types.
+ *
+ * Skill ids are `dw.<domain>.<cluster>.<slug>` and **immutable forever** — they are
+ * mastery keys on learner devices. A rename means minting a new id and setting
+ * `status: "deprecated"` + `supersededBy` on the old one (CURRICULUM.md, gate CG-1).
+ *
+ * Every id is a branded string so an untagged string cannot be passed where an id is
+ * expected. Branding is type-level only; nothing survives type stripping.
+ */
+
+declare const skillIdBrand: unique symbol;
+declare const locKeyBrand: unique symbol;
+declare const familyIdBrand: unique symbol;
+declare const malRuleIdBrand: unique symbol;
+declare const capabilityBrand: unique symbol;
+
+export type SkillId = string & { readonly [skillIdBrand]: true };
+export type LocKey = string & { readonly [locKeyBrand]: true };
+export type FamilyId = string & { readonly [familyIdBrand]: true };
+export type MalRuleId = string & { readonly [malRuleIdBrand]: true };
+export type CapabilityTag = string & { readonly [capabilityBrand]: true };
+
+/** Not branded: a form id is family-scoped and never leaves its family's namespace. */
+export type FormId = string;
+/** Not branded for the same reason; the representation registry owns the values. */
+export type RepId = string;
+/** `${family}@${familyRev}:${skillId}:L${level}:${seed}` */
+export type ExerciseId = string;
+
+export const SKILL_ID_PATTERN = /^dw\.[a-z0-9-]+\.[a-z0-9-]+\.[a-z0-9-]+$/;
+export const LOC_KEY_PATTERN = /^dw\.[a-z0-9]+(\.[a-z0-9-]+)+$/;
+export const FAMILY_ID_PATTERN = /^gen\.[a-z0-9-]+(\.[a-z0-9-]+)*$/;
+export const MAL_RULE_ID_PATTERN = /^mis\.[a-z0-9-]+\.[a-z0-9-]+$/;
+export const CAPABILITY_PATTERN = /^cap\.[a-z0-9-]+(\.[a-z0-9-]+)*$/;
+
+export function isSkillId(value: string): value is SkillId {
+  return SKILL_ID_PATTERN.test(value);
+}
+
+export function skillId(value: string): SkillId {
+  if (!isSkillId(value)) throw new SyntaxError(`bad skill id: ${JSON.stringify(value)}`);
+  return value;
+}
+
+export function locKey(value: string): LocKey {
+  if (!LOC_KEY_PATTERN.test(value)) throw new SyntaxError(`bad locale key: ${JSON.stringify(value)}`);
+  return value as LocKey;
+}
+
+export function familyId(value: string): FamilyId {
+  if (!FAMILY_ID_PATTERN.test(value)) throw new SyntaxError(`bad family id: ${JSON.stringify(value)}`);
+  return value as FamilyId;
+}
+
+export function malRuleId(value: string): MalRuleId {
+  if (!MAL_RULE_ID_PATTERN.test(value)) throw new SyntaxError(`bad mal-rule id: ${JSON.stringify(value)}`);
+  return value as MalRuleId;
+}
+
+export function capabilityTag(value: string): CapabilityTag {
+  if (!CAPABILITY_PATTERN.test(value)) throw new SyntaxError(`bad capability tag: ${JSON.stringify(value)}`);
+  return value as CapabilityTag;
+}
+
+export function exerciseIdOf(
+  family: FamilyId,
+  familyRev: number,
+  skill: SkillId,
+  level: number,
+  seed: number,
+): ExerciseId {
+  return `${family}@${String(familyRev)}:${skill}:L${String(level)}:${String(seed)}`;
+}
+
+/** The domain segment of a skill id (`ns`, `add`, `mul`, `div`, `frac`, `alg`). */
+export function domainOf(id: SkillId): string {
+  const parts = id.split(".");
+  const domain = parts[1];
+  if (domain === undefined) throw new SyntaxError(`bad skill id: ${id}`);
+  return domain;
+}
+
+/** The cluster segment of a skill id. */
+export function clusterOf(id: SkillId): string {
+  const parts = id.split(".");
+  const cluster = parts[2];
+  if (cluster === undefined) throw new SyntaxError(`bad skill id: ${id}`);
+  return cluster;
+}

--- a/dynawalla/curriculum/src/types/malrule.ts
+++ b/dynawalla/curriculum/src/types/malrule.ts
@@ -1,0 +1,51 @@
+/**
+ * Mal-rules — executable, triple-duty.
+ *
+ * A mal-rule is a pure `(exercise) => AnswerValue | null` reproducing a documented
+ * buggy procedure. One function gives three things: a principled distractor (a wrong
+ * answer a real child would actually produce), a diagnosis (if the child's answer
+ * *equals* the mal-rule output you know which bug fired), and error-analysis content
+ * for free.
+ *
+ * **Safety rule (M-16): mal-rule labels are internal.** There is deliberately no
+ * `title` or `description` locale key on this type. Learner-facing feedback names
+ * the correct idea, never the child's defect.
+ */
+
+import type { AnswerValue } from "./answer.ts";
+import type { Exercise } from "./exercise.ts";
+import type { FamilyId, MalRuleId, RepId } from "./ids.ts";
+
+export type MalRule = {
+  readonly id: MalRuleId;
+  readonly family: FamilyId;
+  /**
+   * Parent rule, when several bugs share a root cause and should remediate
+   * together (e.g. the two whole-number-bias fraction rules).
+   */
+  readonly parent?: MalRuleId;
+
+  /**
+   * Whether Stage-2 LOCATE is built for this rule. There is no generic "make the
+   * contradiction self-evident" function, so this is true only where a
+   * representation is genuinely load-bearing and the evidence base is real.
+   * CG-22 requires `contrastRep` whenever this is true.
+   */
+  readonly locateCapable: boolean;
+  readonly contrastRep?: RepId;
+
+  /**
+   * Whether the buggy procedure is even defined on this item. A rule that does not
+   * apply is not evidence of anything, and CG-12 measures divergence only over
+   * items where it does.
+   */
+  applies(exercise: Exercise): boolean;
+
+  /**
+   * Run the buggy procedure. Returns `null` when the procedure is undefined on this
+   * item. Deliberately does **not** filter out outputs that happen to equal the
+   * correct answer: that is what CG-12 measures, and self-filtering here would make
+   * the gate pass by construction.
+   */
+  apply(exercise: Exercise): AnswerValue | null;
+};

--- a/dynawalla/curriculum/src/types/skill.ts
+++ b/dynawalla/curriculum/src/types/skill.ts
@@ -1,0 +1,119 @@
+/**
+ * `SkillNode` — one row of the curriculum graph.
+ *
+ * Fields follow CURRICULUM.md. Two of them are load-bearing in ways that are easy
+ * to miss:
+ *
+ * - **Grade is not in the id.** It is `gradeBand`, because Singapore, CCSS and the
+ *   English national curriculum agree on the spine and disagree on timing by 1–2
+ *   years. Progression gates on prerequisites, never on grade.
+ * - **Difficulty is not in the id.** `b` is a pure function of generator parameters;
+ *   `difficulty.levels` stores the *expected* per-level value so gate CG-9 can
+ *   recompute it from the params and fail on drift.
+ */
+
+import type { Rational } from "../math/rational.ts";
+import type { CapabilityTag, FamilyId, FormId, LocKey, MalRuleId, RepId, SkillId } from "./ids.ts";
+
+export type SkillStatus = "draft" | "active" | "deprecated";
+
+export type EdgeKind = "requires" | "extends" | "supports" | "contrasts";
+
+export type Edge = {
+  readonly kind: EdgeKind;
+  readonly to: SkillId;
+};
+
+export type GradeBand = {
+  readonly earliest: number;
+  readonly nominal: number;
+  readonly latest: number;
+};
+
+/**
+ * Where the node sits in its strand. Authored here rather than quoted from a
+ * framework; provisional until the M4 domain PRs exercise all four.
+ */
+export type StrandRole = "spine" | "bridge" | "fluency" | "application";
+
+/** NRC proficiency emphasis, 0–3 per strand. Integers: no floats in this package. */
+export type Proficiency = {
+  readonly conceptual: 0 | 1 | 2 | 3;
+  readonly procedural: 0 | 1 | 2 | 3;
+  readonly strategic: 0 | 1 | 2 | 3;
+  readonly adaptive: 0 | 1 | 2 | 3;
+};
+
+/**
+ * What kind of knowing this node claims. CG-13 (the choice-laundering ban) reads
+ * this: a `conceptual` or `reasoning` node may not bind a choice-only generator.
+ */
+export type Classification = "conceptual" | "procedural" | "reasoning" | "fluency";
+
+/** Median-latency target for fluency, in whole milliseconds. */
+export type FluencyTarget = { readonly p50Ms: number };
+
+export type GeneratorBinding = {
+  readonly family: FamilyId;
+  readonly familyRev: number;
+  /** One parameter object per level, validated by the family's `paramSchema`. */
+  readonly params: readonly unknown[];
+  readonly forms: readonly FormId[];
+  readonly minVariants: number;
+  /** Capabilities the generated items assume the child already has (gate CG-6). */
+  readonly consumes: readonly CapabilityTag[];
+};
+
+export type Difficulty = {
+  /** `b_skill`: the node's own contribution, before generator parameters. */
+  readonly b: Rational;
+  /** Expected item difficulty per level. Recomputed and checked by CG-9. */
+  readonly levels: readonly Rational[];
+};
+
+export type ProbeSpec = {
+  readonly level: number;
+  readonly seed: number;
+  readonly purpose: "entry" | "promotion" | "repair";
+};
+
+/** Standards are stored as **codes only** — never framework prose (ADR-0010, M-18). */
+export type StandardsCodes = {
+  readonly ccss?: readonly string[];
+  readonly sg?: readonly string[];
+  readonly uk?: readonly string[];
+};
+
+export type SkillNode = {
+  readonly id: SkillId;
+  readonly rev: number;
+  readonly status: SkillStatus;
+  /** Set on a deprecated node that a new id replaced. Never reuse an id. */
+  readonly supersededBy?: SkillId;
+
+  /** Locale keys, never English literals. */
+  readonly title: LocKey;
+  readonly learnerGoal: LocKey;
+
+  readonly domain: string;
+  readonly cluster: string;
+  readonly bigIdeas: readonly LocKey[];
+  readonly gradeBand: GradeBand;
+  readonly strandRole: StrandRole;
+  readonly proficiency: Proficiency;
+  readonly classification: Classification;
+  readonly fluencyTarget?: FluencyTarget;
+
+  readonly prereqs: readonly Edge[];
+  readonly difficulty: Difficulty;
+  readonly misconceptions: readonly MalRuleId[];
+  readonly contrastsWith?: readonly SkillId[];
+  readonly representations: {
+    readonly required: readonly RepId[];
+    readonly optional: readonly RepId[];
+  };
+  readonly generator: GeneratorBinding;
+  readonly probes: readonly ProbeSpec[];
+  readonly provides: readonly CapabilityTag[];
+  readonly standards?: StandardsCodes;
+};

--- a/dynawalla/curriculum/src/validate/cli.test.ts
+++ b/dynawalla/curriculum/src/validate/cli.test.ts
@@ -1,0 +1,47 @@
+/**
+ * The validator's inputs.
+ *
+ * A gate that goes green because its input file could not be read is the failure
+ * mode this whole package argues against, and CG-1 is the gate where it would
+ * matter most: mastery keys are the one thing that cannot be repaired after ship.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { readJson, SHIPPED_IDS_PATH, SNAPSHOT_PATH } from "./cli.ts";
+import type { ShippedIds } from "./context.ts";
+import type { Snapshot } from "./gates/generatorGates.ts";
+
+test("cli: a missing input is a fallback only where the caller says absence is legitimate", () => {
+  const dir = mkdtempSync(join(tmpdir(), "dw-cli-"));
+  try {
+    const missing = join(dir, "not-here.json");
+    assert.deepEqual(readJson(missing, { note: "", entries: {} }), { note: "", entries: {} });
+    // `shipped-ids.json` is committed. Its absence is a broken checkout, not a
+    // first run, and CG-1 must not quietly become a no-op that still prints OK.
+    assert.throws(() => readJson(missing), /cannot read/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("cli: a malformed input throws rather than degrading to the fallback", () => {
+  const dir = mkdtempSync(join(tmpdir(), "dw-cli-"));
+  try {
+    const path = join(dir, "broken.json");
+    writeFileSync(path, '{"releases": [', "utf8");
+    assert.throws(() => readJson(path, { note: "", releases: {} }), /is not valid JSON/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("cli: the committed inputs parse", () => {
+  const shipped = readJson<ShippedIds>(SHIPPED_IDS_PATH);
+  assert.equal(typeof shipped.releases, "object");
+  const snapshot = readJson<Snapshot>(SNAPSHOT_PATH);
+  assert.ok(Object.keys(snapshot.entries).length > 0, "the snapshot has committed hashes");
+});

--- a/dynawalla/curriculum/src/validate/cli.ts
+++ b/dynawalla/curriculum/src/validate/cli.ts
@@ -31,6 +31,8 @@ const SHIPPED_IDS_PATH = join(CURRICULUM_SRC, "graph", "shipped-ids.json");
 export const INCREMENTAL_SEEDS = 200;
 export const FULL_SEEDS = 1000;
 
+export { SHIPPED_IDS_PATH, SNAPSHOT_PATH };
+
 type Options = {
   readonly full: boolean;
   readonly json: boolean;
@@ -59,11 +61,36 @@ function parseArgs(argv: readonly string[]): Options {
   };
 }
 
-function readJson<T>(path: string, fallback: T): T {
+function isNotFound(cause: unknown): boolean {
+  return typeof cause === "object" && cause !== null && (cause as { code?: unknown }).code === "ENOENT";
+}
+
+/**
+ * Read a committed JSON input.
+ *
+ * A gate whose input file cannot be read must never go green. CG-1's immutability
+ * check is the one failure in this program that cannot be repaired after ship — a
+ * mastery key that moved is a child's history pointing at nothing — and swallowing
+ * the read error would quietly turn it into a no-op that still prints `OK`.
+ *
+ * So a malformed file always throws, and a missing file throws too unless the
+ * caller says absence is a legitimate state by passing `whenMissing`. It is for the
+ * snapshot file (an empty snapshot makes CG-16 fail loudly with "no committed
+ * hash") and it is not for `shipped-ids.json`, which is committed and whose absence
+ * is a broken checkout.
+ */
+export function readJson<T>(path: string, whenMissing?: T): T {
+  let text: string;
   try {
-    return JSON.parse(readFileSync(path, "utf8")) as T;
-  } catch {
-    return fallback;
+    text = readFileSync(path, "utf8");
+  } catch (cause) {
+    if (isNotFound(cause) && whenMissing !== undefined) return whenMissing;
+    throw new Error(`cannot read ${path}: ${cause instanceof Error ? cause.message : String(cause)}`);
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch (cause) {
+    throw new Error(`${path} is not valid JSON: ${cause instanceof Error ? cause.message : String(cause)}`);
   }
 }
 
@@ -97,7 +124,7 @@ function printText(report: Report): void {
 
 export function main(argv: readonly string[]): number {
   const options = parseArgs(argv);
-  const shipped = readJson<ShippedIds>(SHIPPED_IDS_PATH, { note: "", releases: {} });
+  const shipped = readJson<ShippedIds>(SHIPPED_IDS_PATH);
   const snapshot = readJson<Snapshot>(SNAPSHOT_PATH, EMPTY_SNAPSHOT);
 
   const { report, snapshot: next } = runGates({

--- a/dynawalla/curriculum/src/validate/cli.ts
+++ b/dynawalla/curriculum/src/validate/cli.ts
@@ -1,0 +1,128 @@
+/**
+ * `dw-curriculum check` — the curriculum validator.
+ *
+ * Modes follow GATES.md: **incremental** on PR, **full** nightly. The incremental
+ * mode here is seed-scoped rather than diff-scoped, because the graph is four nodes
+ * and a diff scoper would be untested machinery guarding nothing. PR-4.6 owns
+ * diff scoping, at the point where it starts to matter.
+ *
+ *   npm run check                    # incremental: 200 seeds per level
+ *   npm run check:full               # full sweep: 1000 seeds per level
+ *   npm run check -- --report json   # machine-readable
+ *   npm run snapshots:update         # rewrite the CG-16 output hashes
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defaultContext } from "./context.ts";
+import type { ShippedIds } from "./context.ts";
+import { EMPTY_SNAPSHOT } from "./gates/generatorGates.ts";
+import type { Snapshot } from "./gates/generatorGates.ts";
+import { runGates } from "./runGates.ts";
+import type { GateResult, Report } from "./types.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CURRICULUM_SRC = join(HERE, "..");
+const ENGINE_SRC = join(HERE, "..", "..", "..", "engine", "src");
+const SNAPSHOT_PATH = join(CURRICULUM_SRC, "snapshots", "generators.json");
+const SHIPPED_IDS_PATH = join(CURRICULUM_SRC, "graph", "shipped-ids.json");
+
+export const INCREMENTAL_SEEDS = 200;
+export const FULL_SEEDS = 1000;
+
+type Options = {
+  readonly full: boolean;
+  readonly json: boolean;
+  readonly update: boolean;
+  readonly strictRenderers: boolean;
+};
+
+function parseArgs(argv: readonly string[]): Options {
+  const args = argv.filter((arg) => arg !== "check");
+  const has = (flag: string): boolean => args.includes(flag);
+  const reportIndex = args.indexOf("--report");
+  const json = has("--json") || (reportIndex >= 0 && args[reportIndex + 1] === "json");
+  for (const arg of args) {
+    if (
+      arg.startsWith("-") &&
+      !["--full", "--json", "--report", "--update-snapshots", "--strict-renderers"].includes(arg)
+    ) {
+      throw new Error(`unknown flag ${arg}`);
+    }
+  }
+  return {
+    full: has("--full"),
+    json,
+    update: has("--update-snapshots"),
+    strictRenderers: has("--strict-renderers"),
+  };
+}
+
+function readJson<T>(path: string, fallback: T): T {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+const STATUS_LABEL: Readonly<Record<GateResult["status"], string>> = {
+  pass: "pass   ",
+  warn: "warn   ",
+  fail: "FAIL   ",
+  pending: "pending",
+};
+
+function printText(report: Report): void {
+  const lines: string[] = [];
+  lines.push(`dw-curriculum check — ${report.mode}, ${String(report.seedsPerLevel)} seeds per level`);
+  lines.push(
+    Object.entries(report.stats)
+      .map(([key, value]) => `${key}=${String(value)}`)
+      .join("  "),
+  );
+  lines.push("");
+  for (const result of report.results) {
+    lines.push(`  ${STATUS_LABEL[result.status]} ${result.gate.padEnd(6)} ${result.title}`);
+    for (const finding of result.findings) {
+      const subject = finding.subject === undefined ? "" : `${finding.subject}: `;
+      lines.push(`         ${finding.severity === "error" ? "×" : "!"} ${subject}${finding.message}`);
+    }
+  }
+  lines.push("");
+  lines.push(report.ok ? "OK" : "FAILED");
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+export function main(argv: readonly string[]): number {
+  const options = parseArgs(argv);
+  const shipped = readJson<ShippedIds>(SHIPPED_IDS_PATH, { note: "", releases: {} });
+  const snapshot = readJson<Snapshot>(SNAPSHOT_PATH, EMPTY_SNAPSHOT);
+
+  const { report, snapshot: next } = runGates({
+    context: defaultContext({
+      shipped,
+      seedsPerLevel: options.full ? FULL_SEEDS : INCREMENTAL_SEEDS,
+      strictRenderers: options.strictRenderers,
+    }),
+    roots: [CURRICULUM_SRC, ENGINE_SRC],
+    snapshot,
+    updateSnapshots: options.update,
+    mode: options.full ? "full" : "incremental",
+  });
+
+  if (options.update) {
+    writeFileSync(SNAPSHOT_PATH, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+    process.stdout.write(`wrote ${SNAPSHOT_PATH}\n`);
+  }
+
+  if (options.json) process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  else printText(report);
+
+  return report.ok ? 0 : 1;
+}
+
+if (process.argv[1] !== undefined && process.argv[1].endsWith("cli.ts")) {
+  process.exitCode = main(process.argv.slice(2));
+}

--- a/dynawalla/curriculum/src/validate/context.ts
+++ b/dynawalla/curriculum/src/validate/context.ts
@@ -1,0 +1,137 @@
+/**
+ * The validation context, and the generated sample every execution gate shares.
+ *
+ * Generating once and sharing is not just a speed trick: CG-9, CG-10, CG-11, CG-12
+ * and CG-16 must all be talking about the *same* items, or a mal-rule fidelity
+ * number is measured against a different draw than the coverage number and the two
+ * cannot be reconciled when one of them fails.
+ */
+
+import type { AnyGeneratorFamily } from "../types/generator.ts";
+import type { MalRule } from "../types/malrule.ts";
+import type { Exercise } from "../types/exercise.ts";
+import type { SkillNode } from "../types/skill.ts";
+import type { RendererDeclaration } from "../render/registry.ts";
+import { rendererRegistry } from "../render/registry.ts";
+import { familyById, generatorFamilies } from "../generators/registry.ts";
+import { malRules } from "../malrules/registry.ts";
+import { activeNodes, allNodes } from "../graph/graph.ts";
+
+export type ShippedIds = {
+  readonly note: string;
+  readonly releases: Readonly<Record<string, readonly string[]>>;
+};
+
+export type ValidationContext = {
+  readonly nodes: readonly SkillNode[];
+  readonly families: readonly AnyGeneratorFamily[];
+  readonly malRules: readonly MalRule[];
+  readonly renderers: readonly RendererDeclaration[];
+  readonly shipped: ShippedIds;
+  readonly seedsPerLevel: number;
+  readonly strictRenderers: boolean;
+};
+
+export type LevelSample = {
+  readonly node: SkillNode;
+  readonly level: number;
+  readonly params: unknown;
+  readonly family: AnyGeneratorFamily | undefined;
+  readonly exercises: readonly Exercise[];
+  /** Nanoseconds per `generate()` call, in draw order. */
+  readonly timingsNs: readonly bigint[];
+  readonly error?: string;
+};
+
+export const EMPTY_SHIPPED: ShippedIds = { note: "", releases: {} };
+
+export function defaultContext(overrides: Partial<ValidationContext> = {}): ValidationContext {
+  return {
+    nodes: allNodes,
+    families: generatorFamilies,
+    malRules,
+    renderers: rendererRegistry,
+    shipped: EMPTY_SHIPPED,
+    seedsPerLevel: 200,
+    strictRenderers: false,
+    ...overrides,
+  };
+}
+
+/**
+ * Generate `seedsPerLevel` items for every level of every **active** node.
+ * Draft and deprecated rows are excluded here, which is what makes "draft nodes
+ * are excluded from all coverage math" true rather than aspirational.
+ */
+export function buildSamples(context: ValidationContext): LevelSample[] {
+  const samples: LevelSample[] = [];
+
+  for (const node of activeNodes(context.nodes)) {
+    const family = familyById(node.generator.family, context.families);
+    const levels = node.generator.params.length;
+
+    for (let level = 0; level < levels; level++) {
+      const params = node.generator.params[level];
+      if (family === undefined) {
+        samples.push({
+          node,
+          level,
+          params,
+          family,
+          exercises: [],
+          timingsNs: [],
+          error: `no registered generator family ${node.generator.family}`,
+        });
+        continue;
+      }
+
+      const validated = family.paramSchema.validate(params);
+      if (!validated.ok) {
+        samples.push({
+          node,
+          level,
+          params,
+          family,
+          exercises: [],
+          timingsNs: [],
+          error: validated.issues.map((i) => `${i.path}: ${i.message}`).join("; "),
+        });
+        continue;
+      }
+
+      const exercises: Exercise[] = [];
+      const timingsNs: bigint[] = [];
+      let error: string | undefined;
+
+      for (let seed = 1; seed <= context.seedsPerLevel; seed++) {
+        try {
+          const started = process.hrtime.bigint();
+          const exercise = family.generate({
+            skillId: node.id,
+            level,
+            seed,
+            params: validated.value,
+            forms: node.generator.forms,
+          });
+          timingsNs.push(process.hrtime.bigint() - started);
+          exercises.push(exercise);
+        } catch (cause) {
+          error = `seed ${String(seed)}: ${cause instanceof Error ? cause.message : String(cause)}`;
+          break;
+        }
+      }
+
+      samples.push(
+        error === undefined
+          ? { node, level, params, family, exercises, timingsNs }
+          : { node, level, params, family, exercises, timingsNs, error },
+      );
+    }
+  }
+
+  return samples;
+}
+
+export function sampleLabel(sample: LevelSample): string {
+  return `${sample.node.id} L${String(sample.level)}`;
+}

--- a/dynawalla/curriculum/src/validate/gates.test.ts
+++ b/dynawalla/curriculum/src/validate/gates.test.ts
@@ -1,0 +1,441 @@
+/**
+ * Failing-case tests for every implemented gate.
+ *
+ * GATES.md: "Every gate ships with a test that **deliberately violates it** and
+ * asserts the gate goes red. A gate with no failing-case test is indistinguishable
+ * from a gate that silently passes everything, and this program has an in-repo
+ * precedent for exactly that failure mode."
+ *
+ * So each block below builds a curriculum that breaks one rule and asserts the
+ * gate fails *and* that the healthy graph passes it.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { rational } from "../math/rational.ts";
+import { allNodes } from "../graph/graph.ts";
+import { columnOpFamily } from "../generators/columnOp/family.ts";
+import { generatorFamilies } from "../generators/registry.ts";
+import { malRules } from "../malrules/registry.ts";
+import { rendererRegistry } from "../render/registry.ts";
+import { erase } from "../types/generator.ts";
+import type { AnyGeneratorFamily } from "../types/generator.ts";
+import { capabilityTag, familyId, malRuleId, skillId } from "../types/ids.ts";
+import type { LocKey, SkillId } from "../types/ids.ts";
+import type { MalRule } from "../types/malrule.ts";
+import type { SkillNode } from "../types/skill.ts";
+import { defaultContext, buildSamples } from "./context.ts";
+import type { LevelSample, ValidationContext } from "./context.ts";
+import { cg1, cg2, cg3, cg4, cg5, cg6 } from "./gates/graphGates.ts";
+import { cg13, cg22, cg7, cg8 } from "./gates/bindingGates.ts";
+import { cg10, cg11, cg12, cg16, cg17, cg9 } from "./gates/generatorGates.ts";
+import type { Snapshot } from "./gates/generatorGates.ts";
+import { cg19, m05 } from "./gates/lintGates.ts";
+import type { GateResult } from "./types.ts";
+
+const SUBTRACT_MULTIDIGIT = skillId("dw.add.regroup.subtract-multidigit");
+const SUBTRACT_ACROSS_ZERO = skillId("dw.add.regroup.subtract-across-zero");
+
+function node(id: SkillId): SkillNode {
+  const found = allNodes.find((candidate) => candidate.id === id);
+  assert.ok(found !== undefined, `fixture needs ${id}`);
+  return found;
+}
+
+function replace(id: SkillId, overrides: Partial<SkillNode>): SkillNode[] {
+  return allNodes.map((candidate) => (candidate.id === id ? { ...candidate, ...overrides } : candidate));
+}
+
+function context(overrides: Partial<ValidationContext> = {}): ValidationContext {
+  return defaultContext({ seedsPerLevel: 40, ...overrides });
+}
+
+function messages(result: GateResult): string {
+  return result.findings.map((finding) => `${finding.subject ?? ""} ${finding.message}`).join(" | ");
+}
+
+function assertFails(result: GateResult, expected: string): void {
+  assert.equal(result.status, "fail", `expected ${result.gate} to fail, got ${result.status}`);
+  assert.ok(
+    messages(result).includes(expected),
+    `expected ${result.gate} to mention ${JSON.stringify(expected)}, got: ${messages(result)}`,
+  );
+}
+
+/** The healthy graph. Every gate below must pass on it. */
+test("gates: the committed curriculum passes every implemented gate", () => {
+  const healthy = context();
+  const samples = buildSamples(healthy);
+  const snapshot: Snapshot = { note: "", entries: {} };
+  for (const result of [
+    cg1(healthy),
+    cg2(healthy),
+    cg3(healthy),
+    cg4(healthy),
+    cg5(healthy),
+    cg6(healthy),
+    cg7(healthy),
+    cg8(healthy),
+    cg9(healthy, samples),
+    cg10(healthy, samples),
+    cg11(healthy, samples),
+    cg12(healthy, samples),
+    cg13(healthy),
+    cg16(healthy, snapshot, true).result,
+    cg17(healthy, samples),
+    cg22(healthy),
+  ]) {
+    assert.notEqual(result.status, "fail", `${result.gate} failed on the committed graph: ${messages(result)}`);
+  }
+});
+
+test("CG-1: an id that shipped and then vanished fails", () => {
+  const shipped = { note: "", releases: { "dynawalla-v1.0.0": ["dw.add.regroup.gone-forever"] } };
+  assertFails(cg1(context({ shipped })), "no longer exists");
+  assert.equal(cg1(context()).status, "pass");
+});
+
+test("CG-1: a shipped id demoted to draft fails", () => {
+  const shipped = { note: "", releases: { "dynawalla-v1.0.0": [SUBTRACT_MULTIDIGIT] } };
+  assert.equal(cg1(context({ shipped })).status, "pass");
+  assertFails(
+    cg1(context({ shipped, nodes: replace(SUBTRACT_MULTIDIGIT, { status: "draft" }) })),
+    "demoted to draft",
+  );
+});
+
+test("CG-1: a duplicate id, a mismatched domain and an orphan deprecation all fail", () => {
+  assertFails(cg1(context({ nodes: [...allNodes, node(SUBTRACT_MULTIDIGIT)] })), "duplicate skill id");
+  assertFails(cg1(context({ nodes: replace(SUBTRACT_MULTIDIGIT, { domain: "mul" }) })), "id domain");
+  assertFails(cg1(context({ nodes: replace(SUBTRACT_MULTIDIGIT, { status: "deprecated" }) })), "no supersededBy");
+});
+
+test("CG-2: a prerequisite cycle fails and the message names the cycle", () => {
+  const cyclic = replace(SUBTRACT_MULTIDIGIT, {
+    prereqs: [{ kind: "requires", to: SUBTRACT_ACROSS_ZERO }],
+  });
+  const result = cg2(context({ nodes: cyclic }));
+  assert.equal(result.status, "fail");
+  assert.ok(messages(result).includes("->"), `expected a printed cycle, got: ${messages(result)}`);
+  assert.ok(messages(result).includes(SUBTRACT_MULTIDIGIT));
+  assert.ok(messages(result).includes(SUBTRACT_ACROSS_ZERO));
+  assert.equal(cg2(context()).status, "pass");
+});
+
+test("CG-3: an edge to a node that does not exist fails", () => {
+  const dangling = replace(SUBTRACT_ACROSS_ZERO, {
+    prereqs: [{ kind: "requires", to: skillId("dw.add.regroup.not-a-node") }],
+  });
+  assertFails(cg3(context({ nodes: dangling })), "missing node");
+  assertFails(
+    cg3(context({ nodes: replace(SUBTRACT_ACROSS_ZERO, { prereqs: [{ kind: "requires", to: SUBTRACT_ACROSS_ZERO }] }) })),
+    "self edge",
+  );
+  assert.equal(cg3(context()).status, "pass");
+});
+
+test("CG-4: an active node whose prerequisite is not active is unreachable", () => {
+  const stranded = replace(SUBTRACT_MULTIDIGIT, { status: "draft" });
+  assertFails(cg4(context({ nodes: stranded })), "unreachable");
+});
+
+test("CG-5: a prerequisite taught after its dependent fails", () => {
+  const inverted = replace(SUBTRACT_MULTIDIGIT, {
+    gradeBand: { earliest: 4, nominal: 5, latest: 6 },
+  });
+  assertFails(cg5(context({ nodes: inverted })), "after grade");
+  assertFails(
+    cg5(context({ nodes: replace(SUBTRACT_MULTIDIGIT, { gradeBand: { earliest: 4, nominal: 2, latest: 3 } }) })),
+    "earliest <= nominal <= latest",
+  );
+  assert.equal(cg5(context()).status, "pass");
+});
+
+test("CG-6: consuming a capability no prerequisite provides fails, and it suggests the edge", () => {
+  const orphaned = replace(SUBTRACT_ACROSS_ZERO, { prereqs: [] });
+  const result = cg6(context({ nodes: orphaned }));
+  assert.equal(result.status, "fail");
+  assert.ok(messages(result).includes('add { kind: "requires"'), messages(result));
+  assert.ok(messages(result).includes(SUBTRACT_MULTIDIGIT), messages(result));
+
+  const unknown = replace(SUBTRACT_ACROSS_ZERO, {
+    generator: { ...node(SUBTRACT_ACROSS_ZERO).generator, consumes: [capabilityTag("cap.arith.nobody-provides")] },
+  });
+  assertFails(cg6(context({ nodes: unknown })), "no active node provides it");
+  assert.equal(cg6(context()).status, "pass");
+});
+
+test("CG-7: an active row with no working generator binding fails", () => {
+  const binding = node(SUBTRACT_MULTIDIGIT).generator;
+  assertFails(
+    cg7(context({ nodes: replace(SUBTRACT_MULTIDIGIT, { generator: { ...binding, family: familyId("gen.arith.nope") } }) })),
+    "unknown family",
+  );
+  assertFails(
+    cg7(context({ nodes: replace(SUBTRACT_MULTIDIGIT, { generator: { ...binding, familyRev: 99 } }) })),
+    "the family is at rev 1",
+  );
+  assertFails(
+    cg7(context({ nodes: replace(SUBTRACT_MULTIDIGIT, { generator: { ...binding, params: [{ op: "sub" }] } }) })),
+    "params invalid",
+  );
+  assertFails(
+    cg7(context({ nodes: replace(SUBTRACT_MULTIDIGIT, { generator: { ...binding, forms: ["dial"] } }) })),
+    "is not one of",
+  );
+  assert.equal(cg7(context()).status, "pass");
+});
+
+test("CG-7: a registered family that no active skill binds fails", () => {
+  const orphan: AnyGeneratorFamily = { ...erase(columnOpFamily), family: familyId("gen.arith.unbound") };
+  assertFails(cg7(context({ families: [...generatorFamilies, orphan] })), "bound by no active skill");
+});
+
+test("CG-8: a required representation with no renderer fails", () => {
+  const needsBoard = replace(SUBTRACT_ACROSS_ZERO, {
+    representations: { required: ["water-clock"], optional: [] },
+  });
+  assertFails(cg8(context({ nodes: needsBoard })), "has no registered renderer");
+});
+
+test("CG-8: strict mode rejects a renderer that is declared but not implemented", () => {
+  assert.equal(cg8(context()).status, "warn", "the default mode allows authoring ahead of the work surface");
+  assertFails(cg8(context({ strictRenderers: true })), "declared but not implemented");
+  const implemented = rendererRegistry.map((entry) =>
+    entry.kind === "answerSchema" ? { ...entry, implemented: true, testRef: "src/work/judge.test.ts" } : entry,
+  );
+  assert.notEqual(cg8(context({ renderers: implemented, strictRenderers: true })).status, "fail");
+});
+
+test("CG-8: a renderer declaration with no owner, or implemented with no test, fails", () => {
+  assertFails(
+    cg8(context({ renderers: rendererRegistry.map((entry) => ({ ...entry, owner: "" })) })),
+    "has no owner",
+  );
+  assertFails(
+    cg8(context({ renderers: rendererRegistry.map((entry) => ({ ...entry, implemented: true })) })),
+    "no testRef",
+  );
+});
+
+test("CG-9: a level that cannot reach minVariants fails", () => {
+  const greedy = replace(SUBTRACT_MULTIDIGIT, {
+    generator: { ...node(SUBTRACT_MULTIDIGIT).generator, minVariants: 10000 },
+  });
+  const broken = context({ nodes: greedy });
+  assertFails(cg9(broken, buildSamples(broken)), "below minVariants");
+});
+
+test("CG-9: a difficulty table that disagrees with the parameters fails", () => {
+  const drifted = replace(SUBTRACT_MULTIDIGIT, {
+    difficulty: { b: rational(-50n, 100n), levels: [rational(1n), rational(35n, 100n), rational(90n, 100n), rational(120n, 100n)] },
+  });
+  const broken = context({ nodes: drifted });
+  assertFails(cg9(broken, buildSamples(broken)), "the parameters compute");
+});
+
+test("CG-9: levels that do not get harder fail", () => {
+  const flat = replace(SUBTRACT_MULTIDIGIT, {
+    generator: {
+      ...node(SUBTRACT_MULTIDIGIT).generator,
+      params: [
+        { op: "sub", digits: 3, operandDigits: 3, regroupings: 2, acrossZero: 0, decimalPlaces: 0, allowZeroResult: false },
+        { op: "sub", digits: 2, operandDigits: 2, regroupings: 1, acrossZero: 0, decimalPlaces: 0, allowZeroResult: false },
+      ],
+    },
+    difficulty: { b: rational(-50n, 100n), levels: [rational(90n, 100n), rational(5n, 100n)] },
+  });
+  const broken = context({ nodes: flat });
+  assertFails(cg9(broken, buildSamples(broken)), "is not above");
+});
+
+test("CG-10: a level whose variant space is too small fails", () => {
+  const narrow = replace(SUBTRACT_MULTIDIGIT, {
+    generator: {
+      ...node(SUBTRACT_MULTIDIGIT).generator,
+      // 2-digit, single-digit subtrahend, one borrow: a few hundred problems in
+      // total, which is not enough room for 200 distinct practice items.
+      params: [{ op: "sub", digits: 2, operandDigits: 1, regroupings: 1, acrossZero: 0, decimalPlaces: 0, allowZeroResult: false }],
+      minVariants: 200,
+    },
+    difficulty: { b: rational(-50n, 100n), levels: [rational(5n, 100n)] },
+  });
+  const broken = context({ nodes: narrow, seedsPerLevel: 400 });
+  assertFails(cg10(broken, buildSamples(broken)), "below the floor");
+});
+
+test("CG-11: a checker that accepts a distractor fails", () => {
+  const healthy = context();
+  const samples = buildSamples(healthy);
+  const permissive: LevelSample[] = samples.map((sample) => ({
+    ...sample,
+    family:
+      sample.family === undefined
+        ? undefined
+        : ({ ...sample.family, check: () => ({ correct: true }) } as AnyGeneratorFamily),
+  }));
+  assertFails(cg11(healthy, permissive), "checker accepts a distractor");
+
+  const rejecting: LevelSample[] = samples.map((sample) => ({
+    ...sample,
+    family:
+      sample.family === undefined
+        ? undefined
+        : ({ ...sample.family, check: () => ({ correct: false }) } as AnyGeneratorFamily),
+  }));
+  assertFails(cg11(healthy, rejecting), "rejects its own canonical answer");
+});
+
+test("CG-12: a mal-rule that reproduces the correct answer fails", () => {
+  const impostor: MalRule = {
+    id: malRuleId("mis.add.not-really-a-bug"),
+    family: columnOpFamily.family,
+    locateCapable: false,
+    applies: () => true,
+    apply: (exercise) => exercise.answer.canonical,
+  };
+  const broken = context({ malRules: [...malRules, impostor] });
+  assertFails(cg12(broken, buildSamples(broken)), "below 95%");
+});
+
+test("CG-12: a mal-rule nothing can trigger is reported, not silently green", () => {
+  const inert: MalRule = {
+    id: malRuleId("mis.add.never-fires"),
+    family: columnOpFamily.family,
+    locateCapable: false,
+    applies: () => false,
+    apply: () => null,
+  };
+  const ctx = context({ malRules: [inert] });
+  const result = cg12(ctx, buildSamples(ctx));
+  assert.equal(result.status, "warn");
+  assert.ok(messages(result).includes("no sampled item triggers"));
+});
+
+test("CG-13: a conceptual skill answered by picking from a list fails", () => {
+  const choiceFamily: AnyGeneratorFamily = {
+    ...erase(columnOpFamily),
+    family: familyId("gen.arith.pick-one"),
+    choiceOnly: true,
+  };
+  const laundered = replace(SUBTRACT_MULTIDIGIT, {
+    classification: "conceptual",
+    generator: { ...node(SUBTRACT_MULTIDIGIT).generator, family: choiceFamily.family },
+  });
+  assertFails(
+    cg13(context({ nodes: laundered, families: [...generatorFamilies, choiceFamily] })),
+    "choice-only family",
+  );
+  assert.equal(cg13(context({ nodes: replace(SUBTRACT_MULTIDIGIT, { classification: "conceptual" }) })).status, "pass");
+});
+
+test("CG-16: a changed output hash fails, and a missing one fails", () => {
+  const healthy = context();
+  const key = `gen.arith.column-op@1|${SUBTRACT_MULTIDIGIT}|L0`;
+  const truthful = cg16(healthy, { note: "", entries: {} }, true).next;
+  assert.notEqual(truthful.entries[key], undefined);
+  assert.equal(cg16(healthy, truthful, false).result.status, "pass");
+
+  assertFails(cg16(healthy, { note: "", entries: {} }, false).result, "no committed hash");
+  const tampered: Snapshot = { note: "", entries: { ...truthful.entries, [key]: "0000000000000000" } };
+  assertFails(cg16(healthy, tampered, false).result, "does not match the committed");
+});
+
+test("CG-16: a familyRev bump asks for a new snapshot rather than silently reusing the old one", () => {
+  const healthy = context();
+  const truthful = cg16(healthy, { note: "", entries: {} }, true).next;
+  const bumped: AnyGeneratorFamily = { ...erase(columnOpFamily), familyRev: 2 };
+  const revved = context({ families: [bumped] });
+  assertFails(cg16(revved, truthful, false).result, "no committed hash");
+});
+
+test("CG-17: generation slower than the budget fails", () => {
+  const healthy = context();
+  const samples = buildSamples(healthy);
+  const slow: LevelSample[] = samples.map((sample) => ({
+    ...sample,
+    timingsNs: sample.timingsNs.map(() => 6_000_000n),
+  }));
+  assertFails(cg17(healthy, slow), "p95");
+  assert.equal(cg17(healthy, samples).status, "pass");
+});
+
+test("CG-19: a bare string prompt in source fails", () => {
+  const dir = mkdtempSync(join(tmpdir(), "dw-cg19-"));
+  try {
+    // Assembled rather than written literally, so this test file does not trip the
+    // lint it is testing.
+    writeFileSync(join(dir, "bad.ts"), `export const e = { ${"prompt"}: ${'"7 minus 4"'} };\n`, "utf8");
+    assertFails(cg19([], [dir]), "bare string prompt");
+    writeFileSync(join(dir, "bad.ts"), "export const e = { prompt: { key: KEY, slots: {} } };\n", "utf8");
+    assert.equal(cg19([], [dir]).status, "pass");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("CG-19: an emitted locale key that is not a locale key fails", () => {
+  const healthy = context();
+  const samples = buildSamples(healthy);
+  const first = samples[0];
+  assert.ok(first !== undefined && first.exercises[0] !== undefined);
+  const broken: LevelSample = {
+    ...first,
+    // Cast: `locKey()` would refuse to build this, which is the point — the gate
+    // is the backstop for a key that reached an item some other way.
+    exercises: [{ ...first.exercises[0], prompt: { ...first.exercises[0].prompt, key: "dw.x" as LocKey } }],
+  };
+  // `dw.x` has too few segments to be a template key.
+  assertFails(cg19([broken], []), "does not match the key pattern");
+  assert.equal(cg19(samples, []).status, "pass");
+});
+
+test("M-05: a float in curriculum or engine source fails the lint", () => {
+  const dir = mkdtempSync(join(tmpdir(), "dw-m05-"));
+  try {
+    const tenth = `0${"."}1`;
+    const fifth = `0${"."}2`;
+    writeFileSync(join(dir, "bad.ts"), `export const wrong = ${tenth} + ${fifth};\n`, "utf8");
+    assertFails(m05([dir]), "fractional numeric literal");
+
+    writeFileSync(join(dir, "bad.ts"), `export const r = Math${"."}random();\n`, "utf8");
+    assertFails(m05([dir]), "Math member");
+
+    writeFileSync(join(dir, "bad.ts"), `export const p = parse${"Float"}("1");\n`, "utf8");
+    assertFails(m05([dir]), "parseFloat");
+
+    writeFileSync(join(dir, "bad.ts"), `export const s = (1).to${"Fixed"}(2);\n`, "utf8");
+    assertFails(m05([dir]), "toFixed");
+
+    // The same text inside a comment or a string is not a violation, or the lint
+    // would fire on its own documentation.
+    writeFileSync(join(dir, "bad.ts"), `// coefficient ${tenth}\nexport const ok = "${tenth}";\n`, "utf8");
+    assert.equal(m05([dir]).status, "pass");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("M-05: the committed curriculum and engine sources are float-free", () => {
+  const here = new URL("..", import.meta.url).pathname;
+  const result = m05([here, join(here, "..", "..", "engine", "src")]);
+  assert.equal(result.status, "pass", messages(result));
+});
+
+test("CG-22: a LOCATE claim with no contrast representation fails", () => {
+  const unbacked: MalRule = {
+    id: malRuleId("mis.add.claims-locate"),
+    family: columnOpFamily.family,
+    locateCapable: true,
+    applies: () => false,
+    apply: () => null,
+  };
+  assertFails(cg22(context({ malRules: [unbacked] })), "no contrast representation");
+
+  const undrawable: MalRule = { ...unbacked, contrastRep: "astrolabe" };
+  assertFails(cg22(context({ malRules: [undrawable] })), "no registered renderer");
+  assert.equal(cg22(context()).status, "pass");
+});

--- a/dynawalla/curriculum/src/validate/gates.test.ts
+++ b/dynawalla/curriculum/src/validate/gates.test.ts
@@ -19,6 +19,7 @@ import { rational } from "../math/rational.ts";
 import { allNodes } from "../graph/graph.ts";
 import { columnOpFamily } from "../generators/columnOp/family.ts";
 import { generatorFamilies } from "../generators/registry.ts";
+import { MIS_SMALLER_FROM_LARGER } from "../malrules/columnOp.ts";
 import { malRules } from "../malrules/registry.ts";
 import { rendererRegistry } from "../render/registry.ts";
 import { erase } from "../types/generator.ts";
@@ -65,6 +66,10 @@ function assertFails(result: GateResult, expected: string): void {
   );
 }
 
+/** `curriculum/src` and `engine/src` — what the source-scanning gates read. */
+const CURRICULUM_SRC = new URL("..", import.meta.url).pathname;
+const SOURCE_ROOTS = [CURRICULUM_SRC, join(CURRICULUM_SRC, "..", "..", "engine", "src")];
+
 /** The healthy graph. Every gate below must pass on it. */
 test("gates: the committed curriculum passes every implemented gate", () => {
   const healthy = context();
@@ -84,7 +89,7 @@ test("gates: the committed curriculum passes every implemented gate", () => {
     cg11(healthy, samples),
     cg12(healthy, samples),
     cg13(healthy),
-    cg16(healthy, snapshot, true).result,
+    cg16(healthy, snapshot, true, SOURCE_ROOTS).result,
     cg17(healthy, samples),
     cg22(healthy),
   ]) {
@@ -256,15 +261,18 @@ test("CG-10: a level whose variant space is too small fails", () => {
   const narrow = replace(SUBTRACT_MULTIDIGIT, {
     generator: {
       ...node(SUBTRACT_MULTIDIGIT).generator,
-      // 2-digit, single-digit subtrahend, one borrow: a few hundred problems in
-      // total, which is not enough room for 200 distinct practice items.
+      // 2-digit minuend, single-digit subtrahend, one borrow: 45 × 9 = 405 problems
+      // in total, so a 40-item practice run would repeat about two of them.
       params: [{ op: "sub", digits: 2, operandDigits: 1, regroupings: 1, acrossZero: 0, decimalPlaces: 0, allowZeroResult: false }],
-      minVariants: 200,
     },
     difficulty: { b: rational(-50n, 100n), levels: [rational(5n, 100n)] },
   });
   const broken = context({ nodes: narrow, seedsPerLevel: 400 });
   assertFails(cg10(broken, buildSamples(broken)), "below the floor");
+  // And the floor is not a restatement of what the author wrote: minVariants is
+  // untouched here, and the healthy graph passes with the same 24 on every node.
+  const healthy = context({ seedsPerLevel: 400 });
+  assert.equal(cg10(healthy, buildSamples(healthy)).status, "pass");
 });
 
 test("CG-11: a checker that accepts a distractor fails", () => {
@@ -309,10 +317,44 @@ test("CG-12: a mal-rule nothing can trigger is reported, not silently green", ()
     applies: () => false,
     apply: () => null,
   };
-  const ctx = context({ malRules: [inert] });
+  // Against the healthy registry, so the only thing this fixture changes is the
+  // rule that cannot fire.
+  const ctx = context({ malRules: [...malRules, inert] });
   const result = cg12(ctx, buildSamples(ctx));
-  assert.equal(result.status, "warn");
+  assert.equal(result.status, "warn", messages(result));
   assert.ok(messages(result).includes("no sampled item triggers"));
+});
+
+test("CG-12: a node that declares a mal-rule nothing resolves, or one from another family, fails", () => {
+  const ghost = replace(SUBTRACT_MULTIDIGIT, { misconceptions: [malRuleId("mis.add.not-in-the-registry")] });
+  const ghostContext = context({ nodes: ghost });
+  assertFails(cg12(ghostContext, buildSamples(ghostContext)), "which no registered mal-rule resolves");
+
+  const foreign: MalRule = {
+    id: malRuleId("mis.mul.times-table-slip"),
+    family: familyId("gen.arith.times-table"),
+    locateCapable: false,
+    applies: () => false,
+    apply: () => null,
+  };
+  const borrowed = context({
+    nodes: replace(SUBTRACT_MULTIDIGIT, { misconceptions: [foreign.id] }),
+    malRules: [...malRules, foreign],
+  });
+  assertFails(cg12(borrowed, buildSamples(borrowed)), "but binds gen.arith.column-op");
+});
+
+test("CG-12: a diagnosis the items emit but the node does not declare fails", () => {
+  // `subtract-multidigit` does not ask for a zero in the minuend, but one is drawn
+  // often enough that 155 items in 4,000 offer the across-zero distractor. A
+  // diagnosis that reaches the scheduler and is not on the node has nowhere to
+  // route — this is what stops `misconceptions` becoming decorative metadata.
+  const undeclared = replace(SUBTRACT_MULTIDIGIT, { misconceptions: [MIS_SMALLER_FROM_LARGER] });
+  const broken = context({ nodes: undeclared, seedsPerLevel: 400 });
+  assertFails(
+    cg12(broken, buildSamples(broken)),
+    "items emit mis.add.borrow-across-zero as a distractor, which the node does not declare",
+  );
 });
 
 test("CG-13: a conceptual skill answered by picking from a list fails", () => {
@@ -335,21 +377,41 @@ test("CG-13: a conceptual skill answered by picking from a list fails", () => {
 test("CG-16: a changed output hash fails, and a missing one fails", () => {
   const healthy = context();
   const key = `gen.arith.column-op@1|${SUBTRACT_MULTIDIGIT}|L0`;
-  const truthful = cg16(healthy, { note: "", entries: {} }, true).next;
+  const truthful = cg16(healthy, { note: "", entries: {} }, true, []).next;
   assert.notEqual(truthful.entries[key], undefined);
-  assert.equal(cg16(healthy, truthful, false).result.status, "pass");
+  assert.equal(cg16(healthy, truthful, false, []).result.status, "pass");
 
-  assertFails(cg16(healthy, { note: "", entries: {} }, false).result, "no committed hash");
+  assertFails(cg16(healthy, { note: "", entries: {} }, false, []).result, "no committed hash");
   const tampered: Snapshot = { note: "", entries: { ...truthful.entries, [key]: "0000000000000000" } };
-  assertFails(cg16(healthy, tampered, false).result, "does not match the committed");
+  assertFails(cg16(healthy, tampered, false, []).result, "does not match the committed");
+});
+
+test("CG-16: ordering a list by locale collation fails, and the committed sources do not", () => {
+  // The hole the in-process comparison and the two-runner hash both leave open:
+  // ICU collation is stable within a process and across two runners with the same
+  // ICU data, and disagrees with code-unit order on a device.
+  const healthy = context();
+  const dir = mkdtempSync(join(tmpdir(), "dw-cg16-"));
+  try {
+    // Assembled, so this test file does not trip the lint it is testing.
+    writeFileSync(join(dir, "bad.ts"), `export const s = ids.sort((a, b) => a.locale${"Compare"}(b));\n`, "utf8");
+    assertFails(cg16(healthy, { note: "", entries: {} }, true, [dir]).result, "locale-dependent collation");
+
+    writeFileSync(join(dir, "bad.ts"), "export const s = [...ids].sort();\n", "utf8");
+    assert.equal(cg16(healthy, { note: "", entries: {} }, true, [dir]).result.status, "pass");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+
+  assert.equal(cg16(healthy, { note: "", entries: {} }, true, SOURCE_ROOTS).result.status, "pass");
 });
 
 test("CG-16: a familyRev bump asks for a new snapshot rather than silently reusing the old one", () => {
   const healthy = context();
-  const truthful = cg16(healthy, { note: "", entries: {} }, true).next;
+  const truthful = cg16(healthy, { note: "", entries: {} }, true, []).next;
   const bumped: AnyGeneratorFamily = { ...erase(columnOpFamily), familyRev: 2 };
   const revved = context({ families: [bumped] });
-  assertFails(cg16(revved, truthful, false).result, "no committed hash");
+  assertFails(cg16(revved, truthful, false, []).result, "no committed hash");
 });
 
 test("CG-17: generation slower than the budget fails", () => {

--- a/dynawalla/curriculum/src/validate/gates/bindingGates.ts
+++ b/dynawalla/curriculum/src/validate/gates/bindingGates.ts
@@ -1,0 +1,243 @@
+/**
+ * CG-7, CG-8, CG-13, CG-22 — the ownership gates. These are the merge blockers:
+ * they are what stop a curriculum row existing that no generator can fill or no
+ * renderer can draw.
+ */
+
+import { activeNodes } from "../../graph/graph.ts";
+import { familyById } from "../../generators/registry.ts";
+import { answerRendererId, findRenderer, repRendererId } from "../../render/registry.ts";
+import type { FamilyId } from "../../types/ids.ts";
+import type { ValidationContext } from "../context.ts";
+import type { Finding, GateResult } from "../types.ts";
+import { fail, resultOf, warn } from "../types.ts";
+
+/**
+ * Families that own zero skills **by design**. `gen.logic.error-analysis` is driven
+ * by the mal-rule table rather than by a curriculum row. Anything else with no
+ * active binding is dead code and CG-7 says so.
+ */
+const FAMILIES_WITHOUT_SKILLS: readonly string[] = ["gen.logic.error-analysis", "gen.logic.odd-one-out"];
+
+/** CG-7 — bidirectional generator ownership. Merge blocker. */
+export function cg7(context: ValidationContext): GateResult {
+  const findings: Finding[] = [];
+  const active = activeNodes(context.nodes);
+  const boundFamilies = new Set<FamilyId>();
+
+  for (const node of active) {
+    const binding = node.generator;
+    boundFamilies.add(binding.family);
+    const family = familyById(binding.family, context.families);
+
+    if (family === undefined) {
+      findings.push(fail("CG-7", `active node binds unknown family ${binding.family}`, node.id));
+      continue;
+    }
+    if (family.familyRev !== binding.familyRev) {
+      findings.push(
+        fail(
+          "CG-7",
+          `binding pins ${binding.family}@${String(binding.familyRev)} but the family is at rev ${String(family.familyRev)}`,
+          node.id,
+        ),
+      );
+    }
+    if (binding.params.length === 0) {
+      findings.push(fail("CG-7", "active node binds no levels", node.id));
+    }
+    if (binding.forms.length === 0) {
+      findings.push(fail("CG-7", "active node declares no forms", node.id));
+    }
+    for (const form of binding.forms) {
+      if (!family.forms.includes(form)) {
+        findings.push(fail("CG-7", `form ${form} is not one of ${family.family}'s forms`, node.id));
+      }
+    }
+    if (binding.minVariants <= 0) {
+      findings.push(fail("CG-7", "minVariants must be positive", node.id));
+    }
+    if (node.difficulty.levels.length !== binding.params.length) {
+      findings.push(
+        fail(
+          "CG-7",
+          `difficulty.levels has ${String(node.difficulty.levels.length)} entries for ${String(binding.params.length)} level(s)`,
+          node.id,
+        ),
+      );
+    }
+
+    binding.params.forEach((params, level) => {
+      const validated = family.paramSchema.validate(params);
+      if (!validated.ok) {
+        for (const issue of validated.issues) {
+          findings.push(fail("CG-7", `L${String(level)} params invalid — ${issue.path}: ${issue.message}`, node.id));
+        }
+        return;
+      }
+      try {
+        family.generate({
+          skillId: node.id,
+          level,
+          seed: 1,
+          params: validated.value,
+          forms: binding.forms,
+        });
+      } catch (cause) {
+        findings.push(
+          fail(
+            "CG-7",
+            `L${String(level)} does not generate: ${cause instanceof Error ? cause.message : String(cause)}`,
+            node.id,
+          ),
+        );
+      }
+    });
+  }
+
+  // The other direction: a registered family that no active node binds is either
+  // dead code or a family whose skills nobody promoted.
+  for (const family of context.families) {
+    if (boundFamilies.has(family.family)) continue;
+    if (FAMILIES_WITHOUT_SKILLS.includes(family.family)) continue;
+    findings.push(fail("CG-7", "registered family is bound by no active skill", family.family));
+  }
+
+  return resultOf("CG-7", "bidirectional generator ownership", findings);
+}
+
+/** CG-8 — renderer ownership. Merge blocker. */
+export function cg8(context: ValidationContext): GateResult {
+  const findings: Finding[] = [];
+
+  // Registry hygiene first: an entry with no owner, or one claiming to be
+  // implemented with no test, would make the gate below meaningless.
+  for (const entry of context.renderers) {
+    if (entry.owner.trim() === "") {
+      findings.push(fail("CG-8", "renderer declaration has no owner", entry.id));
+    }
+    if (entry.implemented && (entry.testRef === undefined || entry.testRef.trim() === "")) {
+      findings.push(fail("CG-8", "renderer claims implemented with no testRef", entry.id));
+    }
+  }
+
+  // Declared-but-unimplemented is a fact about the registry, not about each node
+  // that needs it, so it is reported once per renderer rather than once per
+  // node × level × form. Ten identical warnings train people to skim.
+  const awaitingImplementation = new Map<string, string>();
+
+  const requireRenderer = (id: string, subject: string, what: string): void => {
+    const entry = findRenderer(id, context.renderers);
+    if (entry === undefined) {
+      findings.push(fail("CG-8", `${what} has no registered renderer (${id})`, subject));
+      return;
+    }
+    if (entry.implemented) return;
+    if (context.strictRenderers) {
+      findings.push(fail("CG-8", `${what} renderer ${id} is declared but not implemented (${entry.owner})`, subject));
+    } else {
+      awaitingImplementation.set(id, entry.owner);
+    }
+  };
+
+  for (const node of activeNodes(context.nodes)) {
+    const family = familyById(node.generator.family, context.families);
+    if (family === undefined) continue; // CG-7 owns this failure.
+
+    node.generator.params.forEach((params, level) => {
+      const validated = family.paramSchema.validate(params);
+      if (!validated.ok) return; // CG-7 owns this failure.
+      for (const form of node.generator.forms) {
+        const schema = family.answerSchema(validated.value, form);
+        requireRenderer(answerRendererId(schema.kind), node.id, `L${String(level)} ${form} answer schema "${schema.kind}"`);
+      }
+    });
+
+    for (const rep of node.representations.required) {
+      requireRenderer(repRendererId(rep), node.id, `required representation "${rep}"`);
+    }
+  }
+
+  for (const [id, owner] of awaitingImplementation) {
+    findings.push(warn("CG-8", `renderer is declared but not implemented yet — ${owner} owns it`, id));
+  }
+
+  return resultOf("CG-8", "renderer ownership", findings);
+}
+
+/**
+ * CG-13 — the choice-laundering ban.
+ *
+ * CG-7 and CG-8 are both trivially satisfiable by making everything multiple
+ * choice. This is what stops that: a node that claims conceptual understanding or
+ * reasoning may not be answered by picking from a closed list.
+ */
+export function cg13(context: ValidationContext): GateResult {
+  const findings: Finding[] = [];
+
+  for (const node of activeNodes(context.nodes)) {
+    if (node.classification !== "conceptual" && node.classification !== "reasoning") continue;
+    const family = familyById(node.generator.family, context.families);
+    if (family === undefined) continue;
+
+    if (family.choiceOnly) {
+      findings.push(
+        fail("CG-13", `${node.classification} skill binds choice-only family ${family.family}`, node.id),
+      );
+      continue;
+    }
+
+    let everyFormIsChoice = node.generator.forms.length > 0;
+    for (const params of node.generator.params) {
+      const validated = family.paramSchema.validate(params);
+      if (!validated.ok) continue;
+      for (const form of node.generator.forms) {
+        if (family.answerSchema(validated.value, form).kind !== "choice") everyFormIsChoice = false;
+      }
+    }
+    if (everyFormIsChoice) {
+      findings.push(
+        fail("CG-13", `${node.classification} skill emits only choice answers on every bound form`, node.id),
+      );
+    }
+  }
+
+  return resultOf("CG-13", "choice-laundering ban", findings);
+}
+
+/**
+ * CG-22 — LOCATE capability. A mal-rule may be tagged LOCATE-capable only if it has
+ * a bound contrast representation, and that representation must have a renderer
+ * declaration, or Stage 2 has nothing to draw.
+ */
+export function cg22(context: ValidationContext): GateResult {
+  const findings: Finding[] = [];
+
+  for (const rule of context.malRules) {
+    if (!rule.locateCapable) {
+      if (rule.contrastRep !== undefined) {
+        findings.push(warn("CG-22", "declares a contrast representation but is not LOCATE-capable", rule.id));
+      }
+      continue;
+    }
+    if (rule.contrastRep === undefined) {
+      findings.push(fail("CG-22", "tagged LOCATE-capable with no contrast representation", rule.id));
+      continue;
+    }
+    const entry = findRenderer(repRendererId(rule.contrastRep), context.renderers);
+    if (entry === undefined) {
+      findings.push(
+        fail("CG-22", `contrast representation "${rule.contrastRep}" has no registered renderer`, rule.id),
+      );
+    } else if (context.strictRenderers && !entry.implemented) {
+      findings.push(
+        fail("CG-22", `contrast representation "${rule.contrastRep}" is declared but not implemented`, rule.id),
+      );
+    }
+  }
+
+  const count = context.malRules.filter((rule) => rule.locateCapable).length;
+  return resultOf("CG-22", "LOCATE capability", findings, [
+    `${String(count)} of ${String(context.malRules.length)} mal-rules are LOCATE-capable`,
+  ]);
+}

--- a/dynawalla/curriculum/src/validate/gates/generatorGates.ts
+++ b/dynawalla/curriculum/src/validate/gates/generatorGates.ts
@@ -12,35 +12,48 @@ import { fingerprintItem, serializeExercise } from "../../serialize.ts";
 import { fnv1a64Hex } from "../../rng/hash.ts";
 import { activeNodes } from "../../graph/graph.ts";
 import { familyById } from "../../generators/registry.ts";
+import { findLocaleViolations } from "../lints/localeOrder.ts";
+import { listSourceFiles, readSource } from "../lints/scan.ts";
 import type { LevelSample, ValidationContext } from "../context.ts";
 import { sampleLabel } from "../context.ts";
 import type { Finding, GateResult } from "../types.ts";
 import { fail, resultOf, warn } from "../types.ts";
 
 /**
- * How much bigger than `minVariants` a level's *estimated* variant space has to be.
+ * CG-10's floor on a level's variant space, and where the number comes from.
  *
  * GATES.md words CG-10 as "<2% duplicates over 1,000 draws". That wording embeds an
  * assumption that is false for the content this program starts with: two-digit
  * subtraction with one regrouping has on the order of 1,600 distinct problems in
  * total, so 1,000 draws from it collide about 20% of the time no matter how good
  * the generator is, and the literal gate would be unsatisfiable for every grade-1
- * level in the graph.
+ * level in the graph. The 1,000 is the *gate's* sample size, and a child never sees
+ * 1,000 items at one level.
  *
- * What CG-10 is *for* is "the variant space is big enough that a child does not see
- * repeats". So it is implemented as a lower bound on the space itself, estimated
- * from the collisions actually observed: with N draws and C collisions the space is
- * about N²/2C.
+ * So the duplicate rate is stated about the run a child actually experiences, and
+ * the floor is derived from it. Drawing `n` items from a space of `S` produces about
+ * `n(n−1)/2S` repeats; requiring at most one repeat per `D` items gives
+ * `S ≥ (n−1)·D/2`. With a practice run of 40 items and 2% (one in fifty) that is
+ * **975 problems per level**, and the floor is that number — not a multiple of
+ * `minVariants`, which the curriculum author also writes, and which would make the
+ * gate assert only what the author already asserted.
  *
- * The estimator's bias, measured rather than assumed: at N=200 against a true space
- * of ~1,600 it reads ~1,300 (low, safe); at N=1,000 against the same space it reads
- * ~2,000 (high by about a quarter, because the first-order approximation stops
- * holding once N approaches S). It is therefore **optimistic at high collision
- * rates**, which is the unsafe direction for a floor — so the floor is set with an
- * order of magnitude of margin rather than a fine one, and CG-9's hard
- * `minVariants` count backs it up independently.
+ * The space itself is estimated from the collisions observed in the gate's own
+ * sample: with N draws and C collisions it is about N²/2C. That estimator's bias,
+ * measured rather than assumed: at N=200 against a true space of ~1,600 it reads
+ * ~1,300 (low, safe); at N=1,000 against the same space it reads ~2,000 (high by
+ * about a quarter, because the first-order approximation stops holding once N
+ * approaches S). It is therefore **optimistic at high collision rates**, which is
+ * the unsafe direction for a floor — so a level near the floor deserves a look, and
+ * CG-9's hard `minVariants` count backs the gate up independently.
  */
-export const VARIANT_SPACE_FACTOR = 12;
+export const PRACTICE_RUN_ITEMS = 40;
+
+/** One repeat per fifty items — GATES.md's 2%, applied to the practice run. */
+export const REPEAT_RATE_DENOMINATOR = 50;
+
+/** `(n − 1)·D / 2`, exact in integers: 39 × 50 / 2. */
+export const VARIANT_SPACE_FLOOR = ((PRACTICE_RUN_ITEMS - 1) * REPEAT_RATE_DENOMINATOR) / 2;
 
 /** Seeds hashed for the CG-16 snapshot. Fixed, so incremental and full agree. */
 export const SNAPSHOT_SEEDS = 20;
@@ -115,7 +128,7 @@ export function cg9(context: ValidationContext, samples: readonly LevelSample[])
   return resultOf("CG-9", "level coverage and difficulty table", findings, notes);
 }
 
-/** CG-10 — variant-space adequacy. See `VARIANT_SPACE_FACTOR`. */
+/** CG-10 — variant-space adequacy. See `VARIANT_SPACE_FLOOR`. */
 export function cg10(_context: ValidationContext, samples: readonly LevelSample[]): GateResult {
   const findings: Finding[] = [];
   const notes: string[] = [];
@@ -126,15 +139,28 @@ export function cg10(_context: ValidationContext, samples: readonly LevelSample[
     if (draws === 0) continue;
     const distinct = new Set(sample.exercises.map(fingerprintItem)).size;
     const collisions = draws - distinct;
-    const floor = sample.node.generator.minVariants * VARIANT_SPACE_FACTOR;
     // N^2 / 2C, integer, with C=0 meaning "no evidence of any bound below N^2/2".
     const estimate = collisions === 0 ? Math.floor((draws * draws) / 2) : Math.floor((draws * draws) / (2 * collisions));
 
-    if (estimate < floor) {
+    // N draws with no collision at all can only evidence a space of N²/2, so below
+    // that many draws the gate is not measuring anything and says so rather than
+    // failing a healthy generator or passing a bad one.
+    if (Math.floor((draws * draws) / 2) < VARIANT_SPACE_FLOOR) {
+      findings.push(
+        warn(
+          "CG-10",
+          `${String(draws)} draws cannot evidence a space of ${String(VARIANT_SPACE_FLOOR)}; sample more seeds`,
+          sampleLabel(sample),
+        ),
+      );
+      continue;
+    }
+
+    if (estimate < VARIANT_SPACE_FLOOR) {
       findings.push(
         fail(
           "CG-10",
-          `estimated variant space ${String(estimate)} (${String(collisions)} collisions in ${String(draws)} draws) is below the floor ${String(floor)}`,
+          `estimated variant space ${String(estimate)} (${String(collisions)} collisions in ${String(draws)} draws) is below the floor ${String(VARIANT_SPACE_FLOOR)}: a ${String(PRACTICE_RUN_ITEMS)}-item practice run would repeat more than one item in ${String(REPEAT_RATE_DENOMINATOR)}`,
           sampleLabel(sample),
         ),
       );
@@ -179,7 +205,20 @@ export function cg11(_context: ValidationContext, samples: readonly LevelSample[
   return resultOf("CG-11", "checker self-consistency", findings, [`${String(checked)} items checked`]);
 }
 
-/** CG-12 — mal-rule fidelity: ≥95% divergence from the correct answer. */
+/**
+ * CG-12 — mal-rule fidelity (≥95% divergence from the correct answer), and the
+ * declaration half of the same contract.
+ *
+ * `SkillNode.misconceptions` is what repair routing and Stage-2 selection read. An
+ * id there that no registry entry resolves has nothing to run; an id from another
+ * family cannot fire on this node's items at all; and a diagnosis the node's own
+ * items *emit* that the node never declares reaches the scheduler with nowhere to
+ * route. That is the same drift CG-7 prevents between rows and generators, and
+ * without this half the field is unvalidated metadata.
+ *
+ * Distractors come from the family registry, so the emitted set is a fact about the
+ * generator, measured on the same sample every other execution gate uses.
+ */
 export function cg12(context: ValidationContext, samples: readonly LevelSample[]): GateResult {
   const findings: Finding[] = [];
   const notes: string[] = [];
@@ -224,6 +263,46 @@ export function cg12(context: ValidationContext, samples: readonly LevelSample[]
     notes.push(`${rule.id}: ${String(divergent)}/${String(applicable)} divergent`);
   }
 
+  const byId = new Map(context.malRules.map((rule) => [String(rule.id), rule]));
+
+  for (const node of activeNodes(context.nodes)) {
+    const declared = new Set<string>(node.misconceptions.map(String));
+
+    for (const id of declared) {
+      const rule = byId.get(id);
+      if (rule === undefined) {
+        findings.push(fail("CG-12", `declares ${id}, which no registered mal-rule resolves`, node.id));
+        continue;
+      }
+      if (rule.family !== node.generator.family) {
+        findings.push(
+          fail(
+            "CG-12",
+            `declares ${id}, a mal-rule of ${rule.family}, but binds ${node.generator.family}`,
+            node.id,
+          ),
+        );
+      }
+    }
+
+    const emitted = new Set<string>();
+    for (const sample of samples) {
+      if (sample.node.id !== node.id) continue;
+      for (const exercise of sample.exercises) {
+        for (const distractor of exercise.distractors) {
+          if (distractor.misconception !== undefined) emitted.add(String(distractor.misconception));
+        }
+      }
+    }
+    for (const id of emitted) {
+      if (!declared.has(id)) {
+        findings.push(fail("CG-12", `items emit ${id} as a distractor, which the node does not declare`, node.id));
+      }
+    }
+
+    notes.push(`${node.id}: declares ${String(declared.size)}, emits ${String(emitted.size)}`);
+  }
+
   return resultOf("CG-12", "mal-rule fidelity", findings, notes);
 }
 
@@ -234,20 +313,39 @@ function snapshotKey(sample: { node: { id: string }; level: number }, family: st
 /**
  * CG-16 — determinism and committed output hashes.
  *
- * Two separate claims. First, that generating twice in this process gives
- * byte-identical output — a `Math.random` or a `Date.now` in a generator dies here.
- * Second, that the output matches the committed hash, which is what makes the
- * macOS/Linux pair meaningful: the snapshot is written on one and verified on the
- * other.
+ * Three claims. First, that generating twice in this process gives byte-identical
+ * output — a `Math.random` or a `Date.now` in a generator dies here. Second, that
+ * the output matches the committed hash, which is what makes the macOS/Linux pair
+ * meaningful: the snapshot is written on one and verified on the other. Note the
+ * scope of that second one honestly — it hashes `SNAPSHOT_SEEDS` seeds per level,
+ * not the whole sweep.
+ *
+ * Third, a source scan, because the first two cannot see the failure that matters
+ * most on a child's device: `localeCompare` and `Intl` agree with themselves
+ * in-process and agree across two CI runners with the same ICU data, and disagree
+ * on a phone. See `lints/localeOrder.ts`.
  */
 export function cg16(
   context: ValidationContext,
   snapshot: Snapshot,
   update: boolean,
+  roots: readonly string[],
 ): { result: GateResult; next: Snapshot } {
   const findings: Finding[] = [];
   const entries: Record<string, string> = { ...snapshot.entries };
   const seenKeys = new Set<string>();
+  let scanned = 0;
+
+  for (const root of roots) {
+    for (const path of listSourceFiles(root)) {
+      scanned += 1;
+      for (const violation of findLocaleViolations(readSource(path))) {
+        findings.push(
+          fail("CG-16", `${violation.rule}: ${violation.excerpt}`, `${violation.path}:${String(violation.line)}`),
+        );
+      }
+    }
+  }
 
   for (const node of activeNodes(context.nodes)) {
     const family = familyById(node.generator.family, context.families);
@@ -318,6 +416,7 @@ export function cg16(
   return {
     result: resultOf("CG-16", "determinism and output snapshots", findings, [
       `${String(seenKeys.size)} snapshot key(s), ${String(SNAPSHOT_SEEDS)} seeds each`,
+      `${String(scanned)} source file(s) scanned for locale-dependent ordering`,
     ]),
     next: { note: snapshot.note, entries },
   };

--- a/dynawalla/curriculum/src/validate/gates/generatorGates.ts
+++ b/dynawalla/curriculum/src/validate/gates/generatorGates.ts
@@ -1,0 +1,357 @@
+/**
+ * CG-9, CG-10, CG-11, CG-12, CG-16, CG-17 — the gates that run generators.
+ *
+ * All six read the shared sample built in `context.ts`, so every number they
+ * report is measured on the same draw.
+ */
+
+import { add as ratAdd, cmp, toString as rationalToString } from "../../math/rational.ts";
+import { answerEquals } from "../../types/answer.ts";
+import type { Exercise } from "../../types/exercise.ts";
+import { fingerprintItem, serializeExercise } from "../../serialize.ts";
+import { fnv1a64Hex } from "../../rng/hash.ts";
+import { activeNodes } from "../../graph/graph.ts";
+import { familyById } from "../../generators/registry.ts";
+import type { LevelSample, ValidationContext } from "../context.ts";
+import { sampleLabel } from "../context.ts";
+import type { Finding, GateResult } from "../types.ts";
+import { fail, resultOf, warn } from "../types.ts";
+
+/**
+ * How much bigger than `minVariants` a level's *estimated* variant space has to be.
+ *
+ * GATES.md words CG-10 as "<2% duplicates over 1,000 draws". That wording embeds an
+ * assumption that is false for the content this program starts with: two-digit
+ * subtraction with one regrouping has on the order of 1,600 distinct problems in
+ * total, so 1,000 draws from it collide about 20% of the time no matter how good
+ * the generator is, and the literal gate would be unsatisfiable for every grade-1
+ * level in the graph.
+ *
+ * What CG-10 is *for* is "the variant space is big enough that a child does not see
+ * repeats". So it is implemented as a lower bound on the space itself, estimated
+ * from the collisions actually observed: with N draws and C collisions the space is
+ * about N²/2C.
+ *
+ * The estimator's bias, measured rather than assumed: at N=200 against a true space
+ * of ~1,600 it reads ~1,300 (low, safe); at N=1,000 against the same space it reads
+ * ~2,000 (high by about a quarter, because the first-order approximation stops
+ * holding once N approaches S). It is therefore **optimistic at high collision
+ * rates**, which is the unsafe direction for a floor — so the floor is set with an
+ * order of magnitude of margin rather than a fine one, and CG-9's hard
+ * `minVariants` count backs it up independently.
+ */
+export const VARIANT_SPACE_FACTOR = 12;
+
+/** Seeds hashed for the CG-16 snapshot. Fixed, so incremental and full agree. */
+export const SNAPSHOT_SEEDS = 20;
+
+export type Snapshot = {
+  readonly note: string;
+  readonly entries: Readonly<Record<string, string>>;
+};
+
+export const EMPTY_SNAPSHOT: Snapshot = { note: "", entries: {} };
+
+/** CG-9 — level coverage by running generators, plus difficulty-table integrity. */
+export function cg9(context: ValidationContext, samples: readonly LevelSample[]): GateResult {
+  const findings: Finding[] = [];
+  const notes: string[] = [];
+
+  for (const sample of samples) {
+    if (sample.error !== undefined) {
+      findings.push(fail("CG-9", `generation failed — ${sample.error}`, sampleLabel(sample)));
+      continue;
+    }
+    const distinct = new Set(sample.exercises.map(fingerprintItem)).size;
+    const required = sample.node.generator.minVariants;
+    if (distinct < required) {
+      findings.push(
+        fail(
+          "CG-9",
+          `${String(distinct)} distinct items over ${String(sample.exercises.length)} seeds, below minVariants ${String(required)}`,
+          sampleLabel(sample),
+        ),
+      );
+    }
+    notes.push(`${sampleLabel(sample)}: ${String(distinct)}/${String(sample.exercises.length)} distinct`);
+  }
+
+  // The difficulty table restates what the family computes. Check it, and check
+  // that levels actually get harder — a level table that goes backwards is a
+  // scheduling bug that no scheduler test would catch.
+  for (const node of activeNodes(context.nodes)) {
+    const family = familyById(node.generator.family, context.families);
+    if (family === undefined) continue;
+    let previous: (typeof node.difficulty.levels)[number] | undefined;
+
+    node.generator.params.forEach((params, level) => {
+      const validated = family.paramSchema.validate(params);
+      if (!validated.ok) return;
+      const expected = ratAdd(node.difficulty.b, family.difficultyOffset(validated.value));
+      const declared = node.difficulty.levels[level];
+      if (declared === undefined) return; // CG-7 owns the length mismatch.
+      if (cmp(expected, declared) !== 0) {
+        findings.push(
+          fail(
+            "CG-9",
+            `L${String(level)} difficulty is ${rationalToString(declared)} but the parameters compute ${rationalToString(expected)}`,
+            node.id,
+          ),
+        );
+      }
+      if (previous !== undefined && cmp(declared, previous) <= 0) {
+        findings.push(
+          fail(
+            "CG-9",
+            `L${String(level)} difficulty ${rationalToString(declared)} is not above L${String(level - 1)} ${rationalToString(previous)}`,
+            node.id,
+          ),
+        );
+      }
+      previous = declared;
+    });
+  }
+
+  return resultOf("CG-9", "level coverage and difficulty table", findings, notes);
+}
+
+/** CG-10 — variant-space adequacy. See `VARIANT_SPACE_FACTOR`. */
+export function cg10(_context: ValidationContext, samples: readonly LevelSample[]): GateResult {
+  const findings: Finding[] = [];
+  const notes: string[] = [];
+
+  for (const sample of samples) {
+    if (sample.error !== undefined) continue; // CG-9 owns generation failures.
+    const draws = sample.exercises.length;
+    if (draws === 0) continue;
+    const distinct = new Set(sample.exercises.map(fingerprintItem)).size;
+    const collisions = draws - distinct;
+    const floor = sample.node.generator.minVariants * VARIANT_SPACE_FACTOR;
+    // N^2 / 2C, integer, with C=0 meaning "no evidence of any bound below N^2/2".
+    const estimate = collisions === 0 ? Math.floor((draws * draws) / 2) : Math.floor((draws * draws) / (2 * collisions));
+
+    if (estimate < floor) {
+      findings.push(
+        fail(
+          "CG-10",
+          `estimated variant space ${String(estimate)} (${String(collisions)} collisions in ${String(draws)} draws) is below the floor ${String(floor)}`,
+          sampleLabel(sample),
+        ),
+      );
+    }
+    notes.push(
+      `${sampleLabel(sample)}: ~${String(estimate)} variants, ${String(collisions)} collision(s) in ${String(draws)} draws`,
+    );
+  }
+
+  return resultOf("CG-10", "variant-space adequacy", findings, notes);
+}
+
+/** CG-11 — self-consistency: the family's own checker agrees with its own output. */
+export function cg11(_context: ValidationContext, samples: readonly LevelSample[]): GateResult {
+  const findings: Finding[] = [];
+  let checked = 0;
+
+  for (const sample of samples) {
+    const family = sample.family;
+    if (family === undefined) continue;
+    for (const exercise of sample.exercises) {
+      checked += 1;
+      if (!family.check(exercise, exercise.answer.canonical).correct) {
+        findings.push(fail("CG-11", "checker rejects its own canonical answer", exercise.exerciseId));
+      }
+      for (const accepted of exercise.answer.alsoAccept) {
+        if (!family.check(exercise, accepted).correct) {
+          findings.push(fail("CG-11", "checker rejects a declared alsoAccept answer", exercise.exerciseId));
+        }
+      }
+      for (const distractor of exercise.distractors) {
+        if (answerEquals(distractor.value, exercise.answer.canonical)) {
+          findings.push(fail("CG-11", "a distractor equals the canonical answer", exercise.exerciseId));
+        }
+        if (family.check(exercise, distractor.value).correct) {
+          findings.push(fail("CG-11", "checker accepts a distractor", exercise.exerciseId));
+        }
+      }
+    }
+  }
+
+  return resultOf("CG-11", "checker self-consistency", findings, [`${String(checked)} items checked`]);
+}
+
+/** CG-12 — mal-rule fidelity: ≥95% divergence from the correct answer. */
+export function cg12(context: ValidationContext, samples: readonly LevelSample[]): GateResult {
+  const findings: Finding[] = [];
+  const notes: string[] = [];
+  const all: Exercise[] = samples.flatMap((sample) => [...sample.exercises]);
+
+  for (const rule of context.malRules) {
+    let applicable = 0;
+    let divergent = 0;
+    let undefinedOutput = 0;
+
+    for (const exercise of all) {
+      if (exercise.family !== rule.family) continue;
+      if (!rule.applies(exercise)) continue;
+      applicable += 1;
+      const produced = rule.apply(exercise);
+      if (produced === null) {
+        undefinedOutput += 1;
+        continue;
+      }
+      if (!answerEquals(produced, exercise.answer.canonical)) divergent += 1;
+    }
+
+    if (applicable === 0) {
+      findings.push(warn("CG-12", "no sampled item triggers this rule", rule.id));
+      continue;
+    }
+    if (undefinedOutput > 0) {
+      findings.push(
+        fail("CG-12", `applies() is true but apply() returned null on ${String(undefinedOutput)} item(s)`, rule.id),
+      );
+    }
+    // Integer comparison: divergent/applicable >= 95/100.
+    if (divergent * 100 < applicable * 95) {
+      findings.push(
+        fail(
+          "CG-12",
+          `diverges from the correct answer on ${String(divergent)}/${String(applicable)} applicable items, below 95%`,
+          rule.id,
+        ),
+      );
+    }
+    notes.push(`${rule.id}: ${String(divergent)}/${String(applicable)} divergent`);
+  }
+
+  return resultOf("CG-12", "mal-rule fidelity", findings, notes);
+}
+
+function snapshotKey(sample: { node: { id: string }; level: number }, family: string, rev: number): string {
+  return `${family}@${String(rev)}|${sample.node.id}|L${String(sample.level)}`;
+}
+
+/**
+ * CG-16 — determinism and committed output hashes.
+ *
+ * Two separate claims. First, that generating twice in this process gives
+ * byte-identical output — a `Math.random` or a `Date.now` in a generator dies here.
+ * Second, that the output matches the committed hash, which is what makes the
+ * macOS/Linux pair meaningful: the snapshot is written on one and verified on the
+ * other.
+ */
+export function cg16(
+  context: ValidationContext,
+  snapshot: Snapshot,
+  update: boolean,
+): { result: GateResult; next: Snapshot } {
+  const findings: Finding[] = [];
+  const entries: Record<string, string> = { ...snapshot.entries };
+  const seenKeys = new Set<string>();
+
+  for (const node of activeNodes(context.nodes)) {
+    const family = familyById(node.generator.family, context.families);
+    if (family === undefined) continue;
+
+    node.generator.params.forEach((params, level) => {
+      const validated = family.paramSchema.validate(params);
+      if (!validated.ok) return;
+
+      const render = (): string[] =>
+        Array.from({ length: SNAPSHOT_SEEDS }, (_unused, index) =>
+          serializeExercise(
+            family.generate({
+              skillId: node.id,
+              level,
+              seed: index + 1,
+              params: validated.value,
+              forms: node.generator.forms,
+            }),
+          ),
+        );
+
+      const first = render();
+      const second = render();
+      const label = `${node.id} L${String(level)}`;
+      for (let i = 0; i < first.length; i++) {
+        if (first[i] !== second[i]) {
+          findings.push(fail("CG-16", `seed ${String(i + 1)} generated different output on a second call`, label));
+          return;
+        }
+      }
+
+      const key = snapshotKey({ node, level }, family.family, family.familyRev);
+      seenKeys.add(key);
+      const hash = fnv1a64Hex(first.join("\n"));
+      const committed = entries[key];
+
+      if (update) {
+        entries[key] = hash;
+        return;
+      }
+      if (committed === undefined) {
+        findings.push(
+          fail(
+            "CG-16",
+            `no committed hash for ${key} — if the family's output changed on purpose, bump familyRev and run \`npm run snapshots:update\``,
+            label,
+          ),
+        );
+        return;
+      }
+      if (committed !== hash) {
+        findings.push(
+          fail(
+            "CG-16",
+            `output hash ${hash} does not match the committed ${committed}; a generator changed without a familyRev bump`,
+            label,
+          ),
+        );
+      }
+    });
+  }
+
+  if (update) {
+    for (const key of Object.keys(entries)) if (!seenKeys.has(key)) delete entries[key];
+  }
+
+  return {
+    result: resultOf("CG-16", "determinism and output snapshots", findings, [
+      `${String(seenKeys.size)} snapshot key(s), ${String(SNAPSHOT_SEEDS)} seeds each`,
+    ]),
+    next: { note: snapshot.note, entries },
+  };
+}
+
+/** Nearest-rank percentile over a sorted array. Integer arithmetic only. */
+function percentile(sortedNs: readonly bigint[], p: number): bigint {
+  if (sortedNs.length === 0) return 0n;
+  const rank = Math.floor((p * sortedNs.length + 99) / 100);
+  const index = Math.min(sortedNs.length - 1, Math.max(0, rank - 1));
+  return sortedNs[index] ?? 0n;
+}
+
+export const P95_BUDGET_NS = 5_000_000n;
+export const P99_BUDGET_NS = 20_000_000n;
+
+/** CG-17 — `generate()` p95 < 5 ms, p99 < 20 ms. */
+export function cg17(_context: ValidationContext, samples: readonly LevelSample[]): GateResult {
+  const findings: Finding[] = [];
+  const timings = samples.flatMap((sample) => [...sample.timingsNs]).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  if (timings.length === 0) {
+    return resultOf("CG-17", "generate() performance", [warn("CG-17", "no timings collected")]);
+  }
+
+  const p95 = percentile(timings, 95);
+  const p99 = percentile(timings, 99);
+  if (p95 >= P95_BUDGET_NS) {
+    findings.push(fail("CG-17", `p95 ${String(p95)} ns exceeds the ${String(P95_BUDGET_NS)} ns budget`));
+  }
+  if (p99 >= P99_BUDGET_NS) {
+    findings.push(fail("CG-17", `p99 ${String(p99)} ns exceeds the ${String(P99_BUDGET_NS)} ns budget`));
+  }
+
+  return resultOf("CG-17", "generate() performance", findings, [
+    `${String(timings.length)} calls: p95 ${String(p95 / 1000n)} µs, p99 ${String(p99 / 1000n)} µs`,
+  ]);
+}

--- a/dynawalla/curriculum/src/validate/gates/graphGates.ts
+++ b/dynawalla/curriculum/src/validate/gates/graphGates.ts
@@ -1,0 +1,294 @@
+/**
+ * CG-1..CG-6 — the graph gates. They need no generated items.
+ */
+
+import { SKILL_ID_PATTERN } from "../../types/ids.ts";
+import type { CapabilityTag, SkillId } from "../../types/ids.ts";
+import type { EdgeKind, SkillNode } from "../../types/skill.ts";
+import { activeNodes } from "../../graph/graph.ts";
+import type { ValidationContext } from "../context.ts";
+import type { Finding, GateResult } from "../types.ts";
+import { fail, resultOf, warn } from "../types.ts";
+
+const EDGE_KINDS: readonly EdgeKind[] = ["requires", "extends", "supports", "contrasts"];
+/** The edge kinds that carry prerequisite ordering (CG-2, CG-4, CG-5, CG-6). */
+const ORDERING_KINDS: readonly EdgeKind[] = ["requires", "extends"];
+
+/** CG-1 — id hygiene and immutability. */
+export function cg1(context: ValidationContext): GateResult {
+  const findings: Finding[] = [];
+  const seen = new Set<string>();
+
+  for (const node of context.nodes) {
+    if (!SKILL_ID_PATTERN.test(node.id)) {
+      findings.push(fail("CG-1", `id does not match dw.<domain>.<cluster>.<slug>`, node.id));
+    }
+    if (seen.has(node.id)) findings.push(fail("CG-1", "duplicate skill id", node.id));
+    seen.add(node.id);
+
+    const idDomain = node.id.split(".")[1];
+    const idCluster = node.id.split(".")[2];
+    if (idDomain !== node.domain) {
+      findings.push(fail("CG-1", `id domain ${String(idDomain)} != domain field ${node.domain}`, node.id));
+    }
+    if (idCluster !== node.cluster) {
+      findings.push(fail("CG-1", `id cluster ${String(idCluster)} != cluster field ${node.cluster}`, node.id));
+    }
+    if (node.status === "deprecated" && node.supersededBy === undefined) {
+      findings.push(fail("CG-1", "deprecated node has no supersededBy", node.id));
+    }
+    if (node.supersededBy !== undefined && !context.nodes.some((other) => other.id === node.supersededBy)) {
+      findings.push(fail("CG-1", `supersededBy points at a missing id ${node.supersededBy}`, node.id));
+    }
+  }
+
+  // Immutability: an id that shipped in a release must still exist, and must still
+  // be schedulable or explicitly deprecated. Renaming one silently orphans every
+  // learner's mastery record for it.
+  for (const [release, ids] of Object.entries(context.shipped.releases)) {
+    for (const id of ids) {
+      const node = context.nodes.find((candidate) => candidate.id === id);
+      if (node === undefined) {
+        findings.push(fail("CG-1", `id shipped in ${release} no longer exists`, id));
+        continue;
+      }
+      if (node.status === "draft") {
+        findings.push(fail("CG-1", `id shipped in ${release} was demoted to draft`, id));
+      }
+      if (node.status === "deprecated" && node.supersededBy === undefined) {
+        findings.push(fail("CG-1", `id shipped in ${release} was deprecated with no successor`, id));
+      }
+    }
+  }
+
+  return resultOf("CG-1", "id hygiene and immutability", findings);
+}
+
+/** CG-2 — acyclic `requires ∪ extends`, by Kahn topological sort, printing the cycle. */
+export function cg2(context: ValidationContext): GateResult {
+  const findings: Finding[] = [];
+  const nodes = context.nodes;
+  const ids = new Set<SkillId>(nodes.map((node) => node.id));
+
+  const outgoing = new Map<SkillId, SkillId[]>();
+  const indegree = new Map<SkillId, number>();
+  for (const node of nodes) {
+    outgoing.set(node.id, []);
+    indegree.set(node.id, 0);
+  }
+  for (const node of nodes) {
+    for (const edge of node.prereqs) {
+      if (!ORDERING_KINDS.includes(edge.kind)) continue;
+      if (!ids.has(edge.to)) continue; // CG-3 reports the dangling edge.
+      outgoing.get(edge.to)?.push(node.id);
+      indegree.set(node.id, (indegree.get(node.id) ?? 0) + 1);
+    }
+  }
+
+  const queue: SkillId[] = [];
+  for (const [id, degree] of indegree) if (degree === 0) queue.push(id);
+  let visited = 0;
+  while (queue.length > 0) {
+    const id = queue.shift();
+    if (id === undefined) break;
+    visited += 1;
+    for (const next of outgoing.get(id) ?? []) {
+      const degree = (indegree.get(next) ?? 0) - 1;
+      indegree.set(next, degree);
+      if (degree === 0) queue.push(next);
+    }
+  }
+
+  if (visited !== nodes.length) {
+    const stuck = [...indegree.entries()].filter(([, degree]) => degree > 0).map(([id]) => id);
+    const cycle = findCycle(nodes, new Set(stuck));
+    findings.push(
+      fail(
+        "CG-2",
+        cycle === null
+          ? `prerequisite cycle among: ${stuck.join(", ")}`
+          : `prerequisite cycle: ${cycle.join(" -> ")}`,
+      ),
+    );
+  }
+
+  return resultOf("CG-2", "acyclic requires ∪ extends", findings);
+}
+
+/** Depth-first walk that returns one concrete cycle, so the message is actionable. */
+function findCycle(nodes: readonly SkillNode[], candidates: ReadonlySet<SkillId>): SkillId[] | null {
+  const byId = new Map<SkillId, SkillNode>(nodes.map((node) => [node.id, node]));
+  const state = new Map<SkillId, "open" | "done">();
+  const stack: SkillId[] = [];
+
+  const walk = (id: SkillId): SkillId[] | null => {
+    const status = state.get(id);
+    if (status === "done") return null;
+    if (status === "open") {
+      const from = stack.indexOf(id);
+      return [...stack.slice(from), id];
+    }
+    state.set(id, "open");
+    stack.push(id);
+    for (const edge of byId.get(id)?.prereqs ?? []) {
+      if (!ORDERING_KINDS.includes(edge.kind)) continue;
+      if (!byId.has(edge.to)) continue;
+      const found = walk(edge.to);
+      if (found !== null) return found;
+    }
+    stack.pop();
+    state.set(id, "done");
+    return null;
+  };
+
+  for (const id of candidates) {
+    const found = walk(id);
+    if (found !== null) return found;
+  }
+  return null;
+}
+
+/** CG-3 — edge integrity: targets exist, edge kinds valid, no self edges. */
+export function cg3(context: ValidationContext): GateResult {
+  const findings: Finding[] = [];
+  const ids = new Set<SkillId>(context.nodes.map((node) => node.id));
+
+  for (const node of context.nodes) {
+    for (const edge of node.prereqs) {
+      if (!EDGE_KINDS.includes(edge.kind)) {
+        findings.push(fail("CG-3", `unknown edge kind ${String(edge.kind)}`, node.id));
+      }
+      if (!ids.has(edge.to)) {
+        findings.push(fail("CG-3", `edge points at a missing node ${edge.to}`, node.id));
+      }
+      if (edge.to === node.id) findings.push(fail("CG-3", "self edge", node.id));
+    }
+    for (const contrast of node.contrastsWith ?? []) {
+      if (!ids.has(contrast)) {
+        findings.push(fail("CG-3", `contrastsWith points at a missing node ${contrast}`, node.id));
+      }
+    }
+  }
+
+  return resultOf("CG-3", "edge integrity", findings);
+}
+
+/**
+ * CG-4 — two-way reachability. Unreachable is an error, dead-end is a warning.
+ *
+ * Reading, spelled out because "reachable" has more than one sensible meaning in a
+ * DAG: an active node is **unreachable** when a `requires` prerequisite of it is
+ * not itself active, because no child can ever satisfy it. It is a **dead end**
+ * when nothing active requires it and nothing consumes any capability it provides
+ * — legitimate at the frontier of a graph under construction, which is why it
+ * warns rather than fails.
+ */
+export function cg4(context: ValidationContext): GateResult {
+  const findings: Finding[] = [];
+  const active = activeNodes(context.nodes);
+  const activeIds = new Set<SkillId>(active.map((node) => node.id));
+
+  // Draft rows count as dependents here, and only here: a draft node that requires
+  // this one is a stated intention to build on it, which is exactly what a dead-end
+  // warning is asking about. Drafts are still excluded from every other gate.
+  const requiredBy = new Set<SkillId>();
+  const consumed = new Set<CapabilityTag>();
+  for (const node of context.nodes) {
+    if (node.status === "deprecated") continue;
+    for (const edge of node.prereqs) {
+      if (ORDERING_KINDS.includes(edge.kind)) requiredBy.add(edge.to);
+    }
+    for (const tag of node.generator.consumes) consumed.add(tag);
+  }
+
+  for (const node of active) {
+    for (const edge of node.prereqs) {
+      if (edge.kind !== "requires") continue;
+      if (!activeIds.has(edge.to)) {
+        findings.push(
+          fail("CG-4", `unreachable: requires ${edge.to}, which is not active`, node.id),
+        );
+      }
+    }
+    const providesSomethingUsed = node.provides.some((tag) => consumed.has(tag));
+    if (!requiredBy.has(node.id) && !providesSomethingUsed) {
+      findings.push(warn("CG-4", "dead end: nothing requires it and nothing consumes what it provides", node.id));
+    }
+  }
+
+  return resultOf("CG-4", "two-way reachability", findings);
+}
+
+/** CG-5 — grade sanity: a prerequisite is not nominally taught later than its dependent. */
+export function cg5(context: ValidationContext): GateResult {
+  const findings: Finding[] = [];
+  const byId = new Map<SkillId, SkillNode>(context.nodes.map((node) => [node.id, node]));
+
+  for (const node of context.nodes) {
+    for (const edge of node.prereqs) {
+      if (!ORDERING_KINDS.includes(edge.kind)) continue;
+      const prereq = byId.get(edge.to);
+      if (prereq === undefined) continue;
+      if (prereq.gradeBand.nominal > node.gradeBand.nominal) {
+        findings.push(
+          fail(
+            "CG-5",
+            `prerequisite ${prereq.id} is nominally grade ${String(prereq.gradeBand.nominal)}, after grade ${String(node.gradeBand.nominal)}`,
+            node.id,
+          ),
+        );
+      }
+    }
+    const { earliest, nominal, latest } = node.gradeBand;
+    if (!(earliest <= nominal && nominal <= latest)) {
+      findings.push(fail("CG-5", "gradeBand is not earliest <= nominal <= latest", node.id));
+    }
+  }
+
+  return resultOf("CG-5", "grade sanity", findings);
+}
+
+/**
+ * CG-6 — capability flow. Every capability a binding `consumes` must be `provides`d
+ * by a transitive prerequisite. This is the only mechanically sound missing-edge
+ * detector in the set, and when it fires it names the node that would fix it.
+ */
+export function cg6(context: ValidationContext): GateResult {
+  const findings: Finding[] = [];
+  const active = activeNodes(context.nodes);
+  const byId = new Map<SkillId, SkillNode>(active.map((node) => [node.id, node]));
+
+  const ancestors = (start: SkillNode): Set<SkillId> => {
+    const seen = new Set<SkillId>();
+    const stack: SkillId[] = [];
+    for (const edge of start.prereqs) if (ORDERING_KINDS.includes(edge.kind)) stack.push(edge.to);
+    while (stack.length > 0) {
+      const id = stack.pop();
+      if (id === undefined || seen.has(id)) continue;
+      seen.add(id);
+      for (const edge of byId.get(id)?.prereqs ?? []) {
+        if (ORDERING_KINDS.includes(edge.kind)) stack.push(edge.to);
+      }
+    }
+    return seen;
+  };
+
+  for (const node of active) {
+    if (node.generator.consumes.length === 0) continue;
+    const reachable = ancestors(node);
+    const provided = new Set<CapabilityTag>();
+    for (const id of reachable) for (const tag of byId.get(id)?.provides ?? []) provided.add(tag);
+
+    for (const tag of node.generator.consumes) {
+      if (provided.has(tag)) continue;
+      const suppliers = active.filter((other) => other.id !== node.id && other.provides.includes(tag));
+      const suggestion =
+        suppliers.length === 0
+          ? "no active node provides it"
+          : `add { kind: "requires", to: "${suppliers.map((s) => s.id).join('" } or "')}" }`;
+      findings.push(fail("CG-6", `consumes ${tag} with no prerequisite that provides it — ${suggestion}`, node.id));
+    }
+  }
+
+  return resultOf("CG-6", "capability flow", findings);
+}

--- a/dynawalla/curriculum/src/validate/gates/lintGates.ts
+++ b/dynawalla/curriculum/src/validate/gates/lintGates.ts
@@ -1,0 +1,76 @@
+/**
+ * CG-19 (i18n hygiene) and M-05 (the no-float lint).
+ *
+ * Both have a source half and a runtime half. The source half is the `rg`-style
+ * check the acceptance criteria name. The runtime half looks at what the
+ * generators actually emitted, which is the half that catches a prompt key
+ * assembled at runtime out of pieces that individually look fine.
+ */
+
+import { LOC_KEY_PATTERN } from "../../types/ids.ts";
+import type { LevelSample } from "../context.ts";
+import { findFloatViolations } from "../lints/noFloat.ts";
+import { findInCodeWithStrings, listSourceFiles, readSource } from "../lints/scan.ts";
+import type { Finding, GateResult } from "../types.ts";
+import { fail, resultOf } from "../types.ts";
+
+/** `prompt: "…"` — the exact shape M-06 says must return zero hits. */
+const BARE_STRING_PROMPT = /\bprompt\s*:\s*["'`]/;
+
+/** CG-19 — no bare-string prompt, and every emitted locale key is well formed. */
+export function cg19(samples: readonly LevelSample[], roots: readonly string[]): GateResult {
+  const findings: Finding[] = [];
+  let scanned = 0;
+
+  for (const root of roots) {
+    for (const path of listSourceFiles(root)) {
+      const file = readSource(path);
+      scanned += 1;
+      for (const hit of findInCodeWithStrings(file, BARE_STRING_PROMPT)) {
+        findings.push(fail("CG-19", `bare string prompt: ${hit.excerpt}`, `${hit.path}:${String(hit.line)}`));
+      }
+    }
+  }
+
+  const badKeys = new Set<string>();
+  for (const sample of samples) {
+    for (const exercise of sample.exercises) {
+      if (!LOC_KEY_PATTERN.test(exercise.prompt.key)) badKeys.add(exercise.prompt.key);
+      for (const slot of Object.values(exercise.prompt.slots)) {
+        if (slot.kind === "term" && !LOC_KEY_PATTERN.test(slot.key)) badKeys.add(slot.key);
+      }
+      for (const step of exercise.solution) {
+        if (!LOC_KEY_PATTERN.test(step.key)) badKeys.add(step.key);
+      }
+    }
+  }
+  for (const key of badKeys) {
+    findings.push(fail("CG-19", "emitted locale key does not match the key pattern", key));
+  }
+
+  return resultOf("CG-19", "i18n hygiene", findings, [`${String(scanned)} source file(s) scanned`]);
+}
+
+/** M-05 — no floating-point arithmetic in `curriculum/` or `engine/`. */
+export function m05(roots: readonly string[]): GateResult {
+  const findings: Finding[] = [];
+  let scanned = 0;
+
+  for (const root of roots) {
+    for (const path of listSourceFiles(root)) {
+      const file = readSource(path);
+      scanned += 1;
+      for (const violation of findFloatViolations(file)) {
+        findings.push(
+          fail(
+            "M-05",
+            `${violation.rule}: ${violation.excerpt}`,
+            `${violation.path}:${String(violation.line)}`,
+          ),
+        );
+      }
+    }
+  }
+
+  return resultOf("M-05", "exact arithmetic only", findings, [`${String(scanned)} source file(s) scanned`]);
+}

--- a/dynawalla/curriculum/src/validate/lints/localeOrder.ts
+++ b/dynawalla/curriculum/src/validate/lints/localeOrder.ts
@@ -1,0 +1,36 @@
+/**
+ * The locale-dependence lint, sibling of the no-float lint and half of CG-16.
+ *
+ * CG-16 proves determinism by generating twice in one process and comparing the
+ * bytes, then by matching a hash committed on the other operating system. Neither
+ * catches `localeCompare`: it agrees with itself in-process, and two CI runners with
+ * the same ICU data agree with each other. It is still a hole — ICU collation
+ * varies by ICU version and by locale, it does not agree with code-unit order for
+ * the punctuation ids in this program contain (`-` is a variable-weight character),
+ * and the same build on a child's device is where it would first disagree.
+ *
+ * So ordering is code-unit ordering everywhere: `a < b ? -1 : a > b ? 1 : 0`, or a
+ * bare `.sort()`, which is defined as code-unit order.
+ *
+ * The engine keeps its own copy of this pattern in `boundary.test.ts` — the two
+ * packages have independent CI filters, and each must be able to fail on its own.
+ */
+
+import type { LintHit, SourceFile } from "./scan.ts";
+import { findInCode } from "./scan.ts";
+
+export const LOCALE_PATTERNS: readonly { readonly name: string; readonly pattern: RegExp }[] = [
+  { name: "locale-dependent collation", pattern: /\blocaleCompare\b/ },
+  { name: "locale-dependent formatting", pattern: /\bIntl\s*\.|\btoLocale[A-Z]/ },
+  { name: "locale-dependent collator", pattern: /\bCollator\b/ },
+];
+
+export type LocaleViolation = LintHit & { readonly rule: string };
+
+export function findLocaleViolations(file: SourceFile): LocaleViolation[] {
+  const out: LocaleViolation[] = [];
+  for (const { name, pattern } of LOCALE_PATTERNS) {
+    for (const hit of findInCode(file, pattern)) out.push({ ...hit, rule: name });
+  }
+  return out;
+}

--- a/dynawalla/curriculum/src/validate/lints/noFloat.ts
+++ b/dynawalla/curriculum/src/validate/lints/noFloat.ts
@@ -1,0 +1,80 @@
+/**
+ * The no-float lint (acceptance item M-05, ADR-0006).
+ *
+ * `0.1 + 0.2 !== 0.3` marks correct decimal work *wrong*, deterministically, so no
+ * flaky-test detector will ever surface it. This lint is the only guard, and a
+ * suppression comment inside `curriculum/` or `engine/` is a review blocker.
+ *
+ * What it catches: a fractional numeric literal, a negative-exponent literal, a
+ * transcendental or random `Math` member, `parseFloat`, and the float-formatting
+ * methods. Comments and string literals are excluded — see `scan.ts`.
+ *
+ * What it does not catch, stated so nobody over-trusts it: `/` between two values
+ * that happen to be non-integers at runtime. Integer division on `number` is a
+ * legitimate and exact operation (`(a - (a % b)) / b`), and no regex can tell the
+ * two apart. The structural defence against that is that every quantity in these
+ * two packages is either a `bigint`, a `Rational`, or a documented fixed-point
+ * integer, and the tests compare against exact rational arithmetic.
+ */
+
+import type { LintHit, SourceFile } from "./scan.ts";
+import { findInCode } from "./scan.ts";
+
+/**
+ * Built from a word list rather than written as one literal, so this file does not
+ * match its own lint when the lint is run over the package that contains it.
+ */
+const FLOAT_MATH_MEMBERS = [
+  "random",
+  "exp",
+  "expm1",
+  "log",
+  "log1p",
+  "log2",
+  "log10",
+  "pow",
+  "sqrt",
+  "cbrt",
+  "hypot",
+  "sin",
+  "cos",
+  "tan",
+  "asin",
+  "acos",
+  "atan",
+  "atan2",
+  "sinh",
+  "cosh",
+  "tanh",
+  "fround",
+  "E",
+  "PI",
+  "LN2",
+  "LN10",
+  "LOG2E",
+  "LOG10E",
+  "SQRT2",
+  "SQRT1_2",
+];
+
+export const FLOAT_PATTERNS: readonly { readonly name: string; readonly pattern: RegExp }[] = [
+  { name: "fractional numeric literal", pattern: /(?<![\w$.])\d[\d_]*\.\d/ },
+  { name: "leading-dot numeric literal", pattern: /(?<![\w$.)\]])\.\d/ },
+  { name: "negative-exponent literal", pattern: /(?<![\w$.])\d[\d_]*(\.\d+)?[eE]-\d/ },
+  { name: "floating-point Math member", pattern: new RegExp(`\\bMath\\.(${FLOAT_MATH_MEMBERS.join("|")})\\b`) },
+  { name: "parseFloat", pattern: /\bparseFloat\s*\(/ },
+  { name: "Number.parseFloat", pattern: /\bNumber\s*\.\s*parseFloat\b/ },
+  { name: "Number.EPSILON", pattern: /\bNumber\s*\.\s*EPSILON\b/ },
+  { name: "toFixed", pattern: /\.toFixed\s*\(/ },
+  { name: "toPrecision", pattern: /\.toPrecision\s*\(/ },
+];
+
+export type FloatViolation = LintHit & { readonly rule: string };
+
+export function findFloatViolations(file: SourceFile): FloatViolation[] {
+  const out: FloatViolation[] = [];
+  for (const { name, pattern } of FLOAT_PATTERNS) {
+    for (const hit of findInCode(file, pattern)) out.push({ ...hit, rule: name });
+  }
+  return out;
+}

--- a/dynawalla/curriculum/src/validate/lints/scan.ts
+++ b/dynawalla/curriculum/src/validate/lints/scan.ts
@@ -1,0 +1,141 @@
+/**
+ * Source scanning for the lint gates.
+ *
+ * Comments and string/template literals are stripped before any pattern runs. That
+ * is not a nicety: this very file, and every constants file in the package,
+ * discusses decimal coefficients in prose, and a lint that fired on its own
+ * documentation would be turned off within a week.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+export type SourceFile = {
+  readonly path: string;
+  readonly text: string;
+  /** `text` with comments and string literals blanked out, line numbers preserved. */
+  readonly code: string;
+  /** `text` with comments blanked out but string literals intact. */
+  readonly codeWithStrings: string;
+};
+
+export type LintHit = {
+  readonly path: string;
+  readonly line: number;
+  readonly excerpt: string;
+};
+
+export function listSourceFiles(root: string, extensions: readonly string[] = [".ts", ".mts"]): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    let names: string[];
+    try {
+      names = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const name of names.sort()) {
+      if (name === "node_modules" || name.startsWith(".")) continue;
+      const full = join(dir, name);
+      const stat = statSync(full);
+      if (stat.isDirectory()) walk(full);
+      else if (extensions.some((extension) => name.endsWith(extension))) out.push(full);
+    }
+  };
+  walk(root);
+  return out;
+}
+
+/**
+ * Blank out comments and, when asked, string literals — preserving length and
+ * newlines so line numbers stay meaningful.
+ *
+ * Two modes because the two lints want different things. The float lint must not
+ * see prose or string content. The bare-string-prompt lint must see string
+ * content — a string *is* the violation it looks for — but still not prose.
+ */
+export function stripNonCode(text: string, keepStrings = false): string {
+  const out: string[] = [];
+  let index = 0;
+  const blank = (from: number, to: number): void => {
+    for (let i = from; i < to; i++) out.push(text[i] === "\n" ? "\n" : " ");
+  };
+
+  while (index < text.length) {
+    const char = text[index];
+    const next = text[index + 1];
+
+    if (char === "/" && next === "/") {
+      const end = text.indexOf("\n", index);
+      const stop = end === -1 ? text.length : end;
+      blank(index, stop);
+      index = stop;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      const end = text.indexOf("*/", index + 2);
+      const stop = end === -1 ? text.length : end + 2;
+      blank(index, stop);
+      index = stop;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === "`") {
+      const quote = char;
+      let i = index + 1;
+      while (i < text.length) {
+        if (text[i] === "\\") {
+          i += 2;
+          continue;
+        }
+        if (text[i] === quote) {
+          i += 1;
+          break;
+        }
+        i += 1;
+      }
+      if (keepStrings) for (let j = index; j < i; j++) out.push(text[j] ?? "");
+      else blank(index, i);
+      index = i;
+      continue;
+    }
+    out.push(char ?? "");
+    index += 1;
+  }
+  return out.join("");
+}
+
+export function readSource(path: string): SourceFile {
+  const text = readFileSync(path, "utf8");
+  return { path, text, code: stripNonCode(text), codeWithStrings: stripNonCode(text, true) };
+}
+
+/** Every match of `pattern` in the code (comments and strings already removed). */
+export function findInCode(file: SourceFile, pattern: RegExp): LintHit[] {
+  return matches(file, file.code, pattern);
+}
+
+/** Every match of `pattern` in the code with string literals left in place. */
+export function findInCodeWithStrings(file: SourceFile, pattern: RegExp): LintHit[] {
+  return matches(file, file.codeWithStrings, pattern);
+}
+
+function matches(file: SourceFile, source: string, pattern: RegExp): LintHit[] {
+  const hits: LintHit[] = [];
+  const lines = source.split("\n");
+  const sourceLines = file.text.split("\n");
+  lines.forEach((line, index) => {
+    const scoped = new RegExp(pattern.source, pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`);
+    let match = scoped.exec(line);
+    while (match !== null) {
+      hits.push({
+        path: file.path,
+        line: index + 1,
+        excerpt: (sourceLines[index] ?? "").trim(),
+      });
+      // A zero-width match would never advance `lastIndex`.
+      if (match.index === scoped.lastIndex) scoped.lastIndex += 1;
+      match = scoped.exec(line);
+    }
+  });
+  return hits;
+}

--- a/dynawalla/curriculum/src/validate/runGates.ts
+++ b/dynawalla/curriculum/src/validate/runGates.ts
@@ -1,0 +1,93 @@
+/**
+ * The gate runner.
+ *
+ * Every gate in GATES.md appears in the output. The seventeen that are implemented
+ * report `pass`, `warn` or `fail`; the five that are not report `pending` with the
+ * PR that owns them. A gate table where an unimplemented gate reads as green is
+ * worse than no table — this repo has an in-repo precedent for exactly that failure
+ * mode.
+ */
+
+import type { LevelSample, ValidationContext } from "./context.ts";
+import { buildSamples } from "./context.ts";
+import { cg1, cg2, cg3, cg4, cg5, cg6 } from "./gates/graphGates.ts";
+import { cg13, cg22, cg7, cg8 } from "./gates/bindingGates.ts";
+import { cg10, cg11, cg12, cg16, cg17, cg9 } from "./gates/generatorGates.ts";
+import type { Snapshot } from "./gates/generatorGates.ts";
+import { cg19, m05 } from "./gates/lintGates.ts";
+import type { GateResult, Report } from "./types.ts";
+import { pending } from "./types.ts";
+
+export type RunOptions = {
+  readonly context: ValidationContext;
+  /** Source roots the lints scan — normally `curriculum/src` and `engine/src`. */
+  readonly roots: readonly string[];
+  readonly snapshot: Snapshot;
+  readonly updateSnapshots: boolean;
+  readonly mode: "incremental" | "full";
+};
+
+/** Gates defined in GATES.md that no PR has implemented yet, with their owner. */
+const PENDING_GATES: readonly (readonly [string, string, string])[] = [
+  ["CG-14", "locale round-trip", "PR-4.7 (needs the M2 number layer)"],
+  ["CG-15", "grade-band coverage matrix", "PR-7.19"],
+  ["CG-18", "representation accessibility", "PR-4.4"],
+  ["CG-20", "standards traceback (report-only)", "PR-7.19"],
+  ["CG-21", "word-problem context sets", "PR-7.18"],
+];
+
+export function runGates(options: RunOptions): { report: Report; snapshot: Snapshot; samples: LevelSample[] } {
+  const { context, roots, snapshot, updateSnapshots, mode } = options;
+  const samples = buildSamples(context);
+
+  const snapshotRun = cg16(context, snapshot, updateSnapshots);
+
+  const results: GateResult[] = [
+    cg1(context),
+    cg2(context),
+    cg3(context),
+    cg4(context),
+    cg5(context),
+    cg6(context),
+    cg7(context),
+    cg8(context),
+    cg9(context, samples),
+    cg10(context, samples),
+    cg11(context, samples),
+    cg12(context, samples),
+    cg13(context),
+    snapshotRun.result,
+    cg17(context, samples),
+    cg19(samples, roots),
+    cg22(context),
+    m05(roots),
+    ...PENDING_GATES.map(([id, title, owner]) => pending(id, title, owner)),
+  ];
+
+  const ordered = [...results].sort((a, b) => gateOrder(a.gate) - gateOrder(b.gate));
+  const generated = samples.reduce((total, sample) => total + sample.exercises.length, 0);
+
+  return {
+    report: {
+      ok: ordered.every((result) => result.status !== "fail"),
+      mode,
+      seedsPerLevel: context.seedsPerLevel,
+      results: ordered,
+      stats: {
+        nodes: context.nodes.length,
+        activeNodes: context.nodes.filter((node) => node.status === "active").length,
+        levels: samples.length,
+        generatedItems: generated,
+        malRules: context.malRules.length,
+        families: context.families.length,
+      },
+    },
+    snapshot: snapshotRun.next,
+    samples,
+  };
+}
+
+function gateOrder(gate: string): number {
+  const match = /^CG-(\d+)$/.exec(gate);
+  return match?.[1] === undefined ? 1000 : Number(match[1]);
+}

--- a/dynawalla/curriculum/src/validate/runGates.ts
+++ b/dynawalla/curriculum/src/validate/runGates.ts
@@ -40,7 +40,7 @@ export function runGates(options: RunOptions): { report: Report; snapshot: Snaps
   const { context, roots, snapshot, updateSnapshots, mode } = options;
   const samples = buildSamples(context);
 
-  const snapshotRun = cg16(context, snapshot, updateSnapshots);
+  const snapshotRun = cg16(context, snapshot, updateSnapshots, roots);
 
   const results: GateResult[] = [
     cg1(context),

--- a/dynawalla/curriculum/src/validate/types.ts
+++ b/dynawalla/curriculum/src/validate/types.ts
@@ -1,0 +1,70 @@
+/**
+ * Gate result types.
+ *
+ * A gate is `pending` when it is defined in GATES.md but has no implementation
+ * here yet. Pending is printed, never counted as a pass — a gate table where an
+ * unimplemented gate reads as green is worse than no table.
+ */
+
+export type Severity = "error" | "warn";
+
+export type Finding = {
+  readonly gate: string;
+  readonly severity: Severity;
+  readonly subject?: string;
+  readonly message: string;
+};
+
+export type GateStatus = "pass" | "fail" | "warn" | "pending";
+
+export type GateResult = {
+  readonly gate: string;
+  readonly title: string;
+  readonly status: GateStatus;
+  readonly findings: readonly Finding[];
+  readonly notes: readonly string[];
+};
+
+export type Report = {
+  readonly ok: boolean;
+  readonly mode: "incremental" | "full";
+  readonly seedsPerLevel: number;
+  readonly results: readonly GateResult[];
+  readonly stats: Readonly<Record<string, string | number>>;
+};
+
+export function fail(gate: string, message: string, subject?: string): Finding {
+  return subject === undefined
+    ? { gate, severity: "error", message }
+    : { gate, severity: "error", message, subject };
+}
+
+export function warn(gate: string, message: string, subject?: string): Finding {
+  return subject === undefined
+    ? { gate, severity: "warn", message }
+    : { gate, severity: "warn", message, subject };
+}
+
+export function resultOf(
+  gate: string,
+  title: string,
+  findings: readonly Finding[],
+  notes: readonly string[] = [],
+): GateResult {
+  const status: GateStatus = findings.some((f) => f.severity === "error")
+    ? "fail"
+    : findings.length > 0
+      ? "warn"
+      : "pass";
+  return { gate, title, status, findings, notes };
+}
+
+export function pending(gate: string, title: string, owner: string): GateResult {
+  return {
+    gate,
+    title,
+    status: "pending",
+    findings: [],
+    notes: [`not implemented yet — owned by ${owner}`],
+  };
+}

--- a/dynawalla/curriculum/tsconfig.json
+++ b/dynawalla/curriculum/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "lib": ["es2023"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["node"],
+
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": false,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "bin/**/*.mjs"]
+}

--- a/dynawalla/engine/README.md
+++ b/dynawalla/engine/README.md
@@ -1,0 +1,49 @@
+# `@dynawalla/engine`
+
+The learner model. Pure TypeScript: no IO, no DOM, no clock, no randomness, and no
+import from the app or from the curriculum — `src/boundary.test.ts` fails the build
+if any of that stops being true (gate EG-1).
+
+Specification: [`../docs/ADAPTIVE_LEARNING.md`](../docs/ADAPTIVE_LEARNING.md),
+[`../docs/GATES.md`](../docs/GATES.md),
+[ADR-0008](../docs/DECISIONS/ADR-0008-fsrs-on-classes-latency-rating.md).
+
+```
+npm test        # unit + invariant tests
+npm run tsc     # typecheck
+```
+
+## Three layers
+
+| Layer | File | What it holds |
+|---|---|---|
+| **S** — skill proficiency | `skill.ts` | `P = c + (1−c)·σ(θ−b)`, `θ += U(n)·w·(y′−P)`, asymmetric credit, 0.15× prerequisite propagation, mastery. |
+| **F** — fact memory | `facts.ts` | The card key, the `(correct, latency) → rating` rule, the latency model, and the `FactScheduler` seam FSRS-6 lands behind. |
+| **B** — misconceptions | `bugs.ts` | `β ← 0.9·β + 1{fired}`, active at 2.2, and the slip-versus-misconception discrimination. |
+
+`controller.ts` holds the per-item `pTarget` controller; `scheduler.ts` holds the
+seam the selection policy will implement, plus every anti-frustration and
+anti-stagnation invariant as a checkable function.
+
+## No floats, at all
+
+`math/fixed.ts` is an integer count of millionths and `math/logistic.ts` computes σ
+and `e^-x` in BigInt. Two independent reasons: acceptance item `M-05` bans
+floating-point arithmetic in this package outright, and gate EG-2 requires
+identical seeds to produce **byte-identical transcripts across macOS and Linux**,
+which float accumulation order quietly breaks.
+
+`logistic.test.ts` checks the output against published values of σ, so the
+implementation is measured against the mathematics rather than against itself.
+
+## What is deliberately not here
+
+The selection policy (PR-5.6), the FSRS-6 implementation behind the seam (PR-5.5),
+and the simulation harness (PR-5.3). What is here is the data model, the update
+rules the documents pin down, and the invariants — expressed as functions so that
+gate EG-6 can require every one of them to be its own named test.
+
+Constants that the documents pin are traced to them in `constants.ts`. Constants
+that the documents leave open are marked **PROVISIONAL** in the same file. When a
+gate fails, that label is what tells you whether to fix the code or to question the
+number.

--- a/dynawalla/engine/package-lock.json
+++ b/dynawalla/engine/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "@dynawalla/engine",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@dynawalla/engine",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@types/node": "^25.9.0",
+        "typescript": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/dynawalla/engine/package.json
+++ b/dynawalla/engine/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@dynawalla/engine",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Dynawalla learner model. Pure TypeScript: no IO, no DOM, no clock, no randomness, no app imports.",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "scripts": {
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
+    "tsc": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^6.0.0"
+  }
+}

--- a/dynawalla/engine/src/boundary.test.ts
+++ b/dynawalla/engine/src/boundary.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Gate EG-1 — engine purity, as a build failure.
+ *
+ * ARCHITECTURE.md puts this test in the **first** engine PR, before any model code,
+ * and TEST_STRATEGY.md calls it architecture as a build failure. What it asserts:
+ * nothing under `engine/src` reaches IO, the DOM, `Date.now` or `Math.random`, and
+ * nothing imports the app, the curriculum, or any package at all.
+ *
+ * That is not tidiness. Determinism is a gate (EG-2: identical seeds produce
+ * byte-identical transcripts on macOS and Linux), and a single `Date.now()` inside
+ * the model would make a bug report irreproducible and every golden transcript a
+ * coin flip.
+ *
+ * The float scan is duplicated here rather than imported from `curriculum/`,
+ * deliberately: the two packages have independent CI filters, and an engine-only
+ * pull request must be able to fail this on its own.
+ */
+
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const SRC = dirname(fileURLToPath(import.meta.url));
+
+function sourceFiles(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    for (const name of readdirSync(dir).sort()) {
+      const full = join(dir, name);
+      if (statSync(full).isDirectory()) walk(full);
+      else if (name.endsWith(".ts")) out.push(full);
+    }
+  };
+  walk(SRC);
+  return out;
+}
+
+/** Blank out comments and string literals so prose cannot trip a scan. */
+function code(text: string): string {
+  const out: string[] = [];
+  let i = 0;
+  const blank = (from: number, to: number): void => {
+    for (let j = from; j < to; j++) out.push(text[j] === "\n" ? "\n" : " ");
+  };
+  while (i < text.length) {
+    const char = text[i];
+    const next = text[i + 1];
+    if (char === "/" && next === "/") {
+      const end = text.indexOf("\n", i);
+      const stop = end === -1 ? text.length : end;
+      blank(i, stop);
+      i = stop;
+    } else if (char === "/" && next === "*") {
+      const end = text.indexOf("*/", i + 2);
+      const stop = end === -1 ? text.length : end + 2;
+      blank(i, stop);
+      i = stop;
+    } else if (char === '"' || char === "'" || char === "`") {
+      let j = i + 1;
+      while (j < text.length) {
+        if (text[j] === "\\") {
+          j += 2;
+          continue;
+        }
+        if (text[j] === char) {
+          j += 1;
+          break;
+        }
+        j += 1;
+      }
+      blank(i, j);
+      i = j;
+    } else {
+      out.push(char ?? "");
+      i += 1;
+    }
+  }
+  return out.join("");
+}
+
+const IMPERATIVE = [
+  { name: "wall clock", pattern: /\bDate\s*\.\s*now\b|\bnew\s+Date\b/ },
+  { name: "randomness", pattern: /\bMath\s*\.\s*random\b|\bcrypto\s*\.\s*getRandomValues\b/ },
+  { name: "high-resolution clock", pattern: /\bperformance\s*\.\s*now\b|\bprocess\s*\.\s*hrtime\b/ },
+  { name: "timer", pattern: /\bsetTimeout\b|\bsetInterval\b|\brequestAnimationFrame\b/ },
+  { name: "DOM", pattern: /\b(document|window|navigator|localStorage|indexedDB)\s*\./ },
+  { name: "network", pattern: /\bfetch\s*\(|\bXMLHttpRequest\b|\bWebSocket\b/ },
+  { name: "process or filesystem", pattern: /\bprocess\s*\.\s*(env|argv|cwd)\b|\breadFileSync\b|\bwriteFileSync\b/ },
+  { name: "locale-dependent formatting", pattern: /\bIntl\s*\.|\btoLocale[A-Z]/ },
+] as const;
+
+const FLOAT_MATH = [
+  "random",
+  "exp",
+  "expm1",
+  "log",
+  "log1p",
+  "log2",
+  "log10",
+  "pow",
+  "sqrt",
+  "cbrt",
+  "hypot",
+  "sin",
+  "cos",
+  "tan",
+  "asin",
+  "acos",
+  "atan",
+  "atan2",
+  "sinh",
+  "cosh",
+  "tanh",
+  "fround",
+  "E",
+  "PI",
+  "LN2",
+  "LN10",
+  "LOG2E",
+  "LOG10E",
+  "SQRT2",
+  "SQRT1_2",
+];
+
+const FLOATS = [
+  { name: "fractional numeric literal", pattern: /(?<![\w$.])\d[\d_]*\.\d/ },
+  { name: "leading-dot numeric literal", pattern: /(?<![\w$.)\]])\.\d/ },
+  { name: "negative-exponent literal", pattern: /(?<![\w$.])\d[\d_]*(\.\d+)?[eE]-\d/ },
+  { name: "floating-point Math member", pattern: new RegExp(`\\bMath\\.(${FLOAT_MATH.join("|")})\\b`) },
+  { name: "parseFloat", pattern: /\bparseFloat\s*\(/ },
+  { name: "toFixed", pattern: /\.toFixed\s*\(/ },
+] as const;
+
+const IMPORT = /^\s*import\s[^;]*?from\s*["']([^"']+)["']/gm;
+
+function offenders(files: readonly string[], patterns: readonly { name: string; pattern: RegExp }[]): string[] {
+  const found: string[] = [];
+  for (const file of files) {
+    const scanned = code(readFileSync(file, "utf8"));
+    scanned.split("\n").forEach((line, index) => {
+      for (const { name, pattern } of patterns) {
+        if (new RegExp(pattern.source, pattern.flags).test(line)) {
+          found.push(`${file}:${String(index + 1)} ${name}: ${line.trim()}`);
+        }
+      }
+    });
+  }
+  return found;
+}
+
+test("EG-1: the engine reaches no clock, no randomness, no IO and no DOM", () => {
+  const files = sourceFiles().filter((file) => !file.endsWith(".test.ts"));
+  assert.ok(files.length >= 8, `expected engine sources, found ${String(files.length)}`);
+  assert.deepEqual(offenders(files, IMPERATIVE), []);
+});
+
+test("EG-1: even the tests use no clock and no randomness", () => {
+  // A test that reaches for `Math.random` makes EG-2 unfalsifiable: the transcript
+  // it produces is not the transcript anyone else produces.
+  const tests = sourceFiles().filter((file) => file.endsWith(".test.ts"));
+  const forbidden = IMPERATIVE.filter(
+    (rule) => rule.name === "wall clock" || rule.name === "randomness" || rule.name === "high-resolution clock",
+  );
+  assert.deepEqual(offenders(tests, forbidden), []);
+});
+
+test("EG-1: the engine imports nothing outside itself", () => {
+  const files = sourceFiles().filter((file) => !file.endsWith(".test.ts"));
+  const external: string[] = [];
+  for (const file of files) {
+    const text = readFileSync(file, "utf8");
+    for (const match of text.matchAll(IMPORT)) {
+      const specifier = match[1];
+      if (specifier === undefined) continue;
+      if (specifier.startsWith("./") || specifier.startsWith("../")) {
+        if (specifier.includes("curriculum") || specifier.includes("dynawalla-app")) {
+          external.push(`${file}: ${specifier}`);
+        }
+        continue;
+      }
+      external.push(`${file}: ${specifier}`);
+    }
+  }
+  assert.deepEqual(external, [], "the learner model is a pure library and depends on nothing");
+});
+
+test("M-05: no floating-point arithmetic anywhere in the engine", () => {
+  assert.deepEqual(offenders(sourceFiles(), FLOATS), []);
+});
+
+test("EG-1: the purity scan itself can fail", () => {
+  // A gate with no failing case is indistinguishable from a gate that passes
+  // everything. These fixtures are assembled rather than written, so this file
+  // does not violate the rules it enforces.
+  const clock = `const t = Date${"."}now();`;
+  const random = `const r = Math${"."}random();`;
+  const float = `const x = 0${"."}5;`;
+  const write = (text: string): string[] => {
+    const line = code(text);
+    const hits: string[] = [];
+    for (const { name, pattern } of [...IMPERATIVE, ...FLOATS]) {
+      if (new RegExp(pattern.source, pattern.flags).test(line)) hits.push(name);
+    }
+    return hits;
+  };
+  assert.deepEqual(write(clock), ["wall clock"]);
+  assert.deepEqual(write(random), ["randomness", "floating-point Math member"]);
+  assert.deepEqual(write(float), ["fractional numeric literal"]);
+  assert.deepEqual(write(`const s = "Date${"."}now()";`), [], "a string is not a call");
+  assert.deepEqual(write(`// Date${"."}now() is banned`), [], "and a comment is not either");
+});

--- a/dynawalla/engine/src/boundary.test.ts
+++ b/dynawalla/engine/src/boundary.test.ts
@@ -88,7 +88,11 @@ const IMPERATIVE = [
   { name: "DOM", pattern: /\b(document|window|navigator|localStorage|indexedDB)\s*\./ },
   { name: "network", pattern: /\bfetch\s*\(|\bXMLHttpRequest\b|\bWebSocket\b/ },
   { name: "process or filesystem", pattern: /\bprocess\s*\.\s*(env|argv|cwd)\b|\breadFileSync\b|\bwriteFileSync\b/ },
-  { name: "locale-dependent formatting", pattern: /\bIntl\s*\.|\btoLocale[A-Z]/ },
+  // Collation as well as formatting. `localeCompare` is the one that hides: it is
+  // deterministic in-process and identical on two CI runners with the same ICU
+  // data, and disagrees with code-unit order on a device — which is where EG-2's
+  // byte-identical transcripts are actually claimed.
+  { name: "locale-dependent formatting", pattern: /\bIntl\s*\.|\btoLocale[A-Z]|\blocaleCompare\b|\bCollator\b/ },
 ] as const;
 
 const FLOAT_MATH = [
@@ -197,6 +201,7 @@ test("EG-1: the purity scan itself can fail", () => {
   const clock = `const t = Date${"."}now();`;
   const random = `const r = Math${"."}random();`;
   const float = `const x = 0${"."}5;`;
+  const collated = `ids.sort((a, b) => a.locale${"Compare"}(b));`;
   const write = (text: string): string[] => {
     const line = code(text);
     const hits: string[] = [];
@@ -208,6 +213,7 @@ test("EG-1: the purity scan itself can fail", () => {
   assert.deepEqual(write(clock), ["wall clock"]);
   assert.deepEqual(write(random), ["randomness", "floating-point Math member"]);
   assert.deepEqual(write(float), ["fractional numeric literal"]);
+  assert.deepEqual(write(collated), ["locale-dependent formatting"]);
   assert.deepEqual(write(`const s = "Date${"."}now()";`), [], "a string is not a call");
   assert.deepEqual(write(`// Date${"."}now() is banned`), [], "and a comment is not either");
 });

--- a/dynawalla/engine/src/bugs.test.ts
+++ b/dynawalla/engine/src/bugs.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { BUG_ACTIVE_THRESHOLD, BUG_DECAY, MAX_TRACKED_BUGS } from "./constants.ts";
+import { ONE, ZERO, add, fromInt, fromRatio, mul } from "./math/fixed.ts";
+import type { Fix } from "./math/fixed.ts";
+import { classifyError, firingsToActivate, isBugActive, latencyShape, pruneBugs, updateBug } from "./bugs.ts";
+import { NEW_BUG_STATE, bugKey } from "./types.ts";
+import type { AttemptOutcome, BugState } from "./types.ts";
+
+function outcome(overrides: Partial<AttemptOutcome> = {}): AttemptOutcome {
+  return {
+    correct: false,
+    latencyMs: 5000,
+    revisions: 0,
+    itemDifficulty: ZERO,
+    guessFloor: ZERO,
+    fromChoice: false,
+    evidenceWeight: ONE,
+    ...overrides,
+  };
+}
+
+test("bugs: β ← 0.9·β + 1 when the bug fires, and decays when it does not", () => {
+  const first = updateBug(undefined, true);
+  assert.equal(first.beta, ONE);
+  assert.equal(first.firings, 1);
+
+  const second = updateBug(first, true);
+  assert.equal(second.beta, add(mul(BUG_DECAY, ONE), ONE), "0.9·1 + 1 = 1.9");
+  assert.equal(second.beta, fromRatio(19, 10));
+
+  const decayed = updateBug(second, false);
+  assert.equal(decayed.beta, mul(BUG_DECAY, second.beta), "0.9·1.9 = 1.71");
+  assert.equal(decayed.firings, 2, "a decay is not a firing");
+});
+
+test("bugs: three consecutive firings activate, and it takes a while to fall silent", () => {
+  assert.equal(firingsToActivate(), 3);
+
+  let state: BugState | undefined;
+  assert.equal(isBugActive(state), false);
+  state = updateBug(state, true);
+  assert.equal(isBugActive(state), false, "one wrong answer is not a misconception");
+  state = updateBug(state, true);
+  assert.equal(isBugActive(state), false, "nor are two");
+  state = updateBug(state, true);
+  assert.equal(isBugActive(state), true, "β = 2.71");
+  assert.ok(state.beta >= BUG_ACTIVE_THRESHOLD);
+
+  let quiet = 0;
+  while (isBugActive(state) && quiet < 20) {
+    state = updateBug(state, false);
+    quiet += 1;
+  }
+  // 2.71 → 2.439 → 2.195: two clean items put the bug back below the threshold,
+  // so a child who stops making the mistake stops being treated as though they do.
+  assert.equal(quiet, 2);
+});
+
+test("bugs: the tracker never subtracts from ability — it has no access to θ", () => {
+  // Structural rather than behavioural: `updateBug` takes a bug state and a
+  // boolean. There is no path from Layer B to θ, which is the point.
+  assert.deepEqual(Object.keys(NEW_BUG_STATE).sort(), ["beta", "firings"]);
+  assert.equal(updateBug(undefined, false).beta, ZERO);
+});
+
+test("bugs: a self-corrected answer is a slip and never increments a bug", () => {
+  assert.equal(classifyError(outcome({ revisions: 2, misconception: "mis.add.borrow-across-zero" })), "slip");
+  assert.equal(classifyError(outcome({ revisions: 0, misconception: "mis.add.borrow-across-zero" })), "misconception");
+  assert.equal(classifyError(outcome({ revisions: 0 })), "unclassified");
+  assert.equal(classifyError(outcome({ correct: true })), "unclassified");
+  assert.equal(classifyError(outcome({ correct: true, revisions: 1 })), "slip");
+});
+
+test("bugs: the tracker is sparse and hard-capped", () => {
+  const bugs: Record<string, BugState> = {};
+  for (let i = 0; i < MAX_TRACKED_BUGS * 2; i++) {
+    bugs[bugKey(`dw.add.regroup.skill-${String(i)}`, "mis.add.carry-dropped")] = {
+      beta: fromInt(i) as Fix,
+      firings: i,
+    };
+  }
+  const pruned = pruneBugs(bugs);
+  assert.equal(Object.keys(pruned).length, MAX_TRACKED_BUGS);
+  const smallest = Math.min(...Object.values(pruned).map((state) => state.beta));
+  assert.equal(smallest, fromInt(MAX_TRACKED_BUGS), "the least current evidence is what gets dropped");
+  assert.equal(Object.keys(pruneBugs({})).length, 0);
+});
+
+test("bugs: latency shape separates a slip from a confident error from no idea", () => {
+  assert.equal(latencyShape(ZERO), "fast");
+  assert.equal(latencyShape(fromRatio(9, 10)), "fast");
+  assert.equal(latencyShape(fromInt(1)), "confident");
+  assert.equal(latencyShape(fromRatio(19, 10)), "confident");
+  assert.equal(latencyShape(fromInt(2)), "stalled");
+  assert.equal(latencyShape(fromInt(9)), "stalled");
+});

--- a/dynawalla/engine/src/bugs.ts
+++ b/dynawalla/engine/src/bugs.ts
@@ -1,0 +1,86 @@
+/**
+ * Layer B — the misconception tracker.
+ *
+ *   β ← 0.9·β + 1{bug fired},  active at β ≥ 2.2
+ *
+ * It **never subtracts from θ**. It gates mastery and triggers repair, and that
+ * separation is deliberate: a child with a consistent buggy procedure is not less
+ * able, they are doing something specific and fixable, and an engine that punishes
+ * θ for it makes the whole model read as "you are bad at this".
+ *
+ * Slip versus misconception is decided here too. Four discriminators are named in
+ * ADAPTIVE_LEARNING.md; the cleanest is **self-correction** — revisions > 0 and
+ * then correct is a slip, and never increments a bug.
+ */
+
+import { BUG_ACTIVE_THRESHOLD, BUG_DECAY, LATENCY_Z_NO_IDEA, LATENCY_Z_SLIP, MAX_TRACKED_BUGS } from "./constants.ts";
+import { ONE, add, mul } from "./math/fixed.ts";
+import type { Fix } from "./math/fixed.ts";
+import { NEW_BUG_STATE } from "./types.ts";
+import type { AttemptOutcome, BugState } from "./types.ts";
+
+export type ErrorKind = "slip" | "misconception" | "unclassified";
+
+/**
+ * What kind of error this was.
+ *
+ * A self-corrected answer is a slip whatever else is true — that is the cleanest
+ * signal available and it costs nothing to honour. A matched mal-rule is a
+ * misconception. Everything else is unclassified, which routes to a faded worked
+ * example rather than to a contrast pair the child may not need.
+ */
+export function classifyError(outcome: AttemptOutcome): ErrorKind {
+  if (outcome.correct) return outcome.revisions > 0 ? "slip" : "unclassified";
+  if (outcome.revisions > 0) return "slip";
+  return outcome.misconception === undefined ? "unclassified" : "misconception";
+}
+
+/** `β ← 0.9·β + 1{fired}`. */
+export function updateBug(state: BugState | undefined, fired: boolean): BugState {
+  const current = state ?? NEW_BUG_STATE;
+  const decayed = mul(BUG_DECAY, current.beta);
+  return {
+    beta: fired ? add(decayed, ONE) : decayed,
+    firings: current.firings + (fired ? 1 : 0),
+  };
+}
+
+export function isBugActive(state: BugState | undefined): boolean {
+  return state !== undefined && state.beta >= BUG_ACTIVE_THRESHOLD;
+}
+
+/**
+ * How many firings in a row it takes to activate a bug, given the decay. Exposed
+ * because the Stage-2 threshold is a claim about the child's experience — "after
+ * about three of these you will see a contrast pair" — and it should be checkable
+ * rather than folklore.
+ */
+export function firingsToActivate(): number {
+  let state: BugState | undefined;
+  for (let count = 1; count <= 32; count++) {
+    state = updateBug(state, true);
+    if (isBugActive(state)) return count;
+  }
+  return -1;
+}
+
+/**
+ * Keep the tracker sparse and hard-capped: state may not grow with use (EG-3).
+ * When the cap is reached the weakest entry is dropped, because a decayed β is by
+ * construction the least current evidence.
+ */
+export function pruneBugs(bugs: Readonly<Record<string, BugState>>): Record<string, BugState> {
+  const entries = Object.entries(bugs);
+  if (entries.length <= MAX_TRACKED_BUGS) return { ...bugs };
+  const kept = entries
+    .sort((a, b) => (b[1].beta === a[1].beta ? a[0].localeCompare(b[0]) : b[1].beta - a[1].beta))
+    .slice(0, MAX_TRACKED_BUGS);
+  return Object.fromEntries(kept);
+}
+
+/** Latency shape: slips are fast, misconceptions are confident, "no idea" is slow. */
+export function latencyShape(z: Fix): "fast" | "confident" | "stalled" {
+  if (z < LATENCY_Z_SLIP) return "fast";
+  if (z < LATENCY_Z_NO_IDEA) return "confident";
+  return "stalled";
+}

--- a/dynawalla/engine/src/bugs.ts
+++ b/dynawalla/engine/src/bugs.ts
@@ -72,8 +72,13 @@ export function firingsToActivate(): number {
 export function pruneBugs(bugs: Readonly<Record<string, BugState>>): Record<string, BugState> {
   const entries = Object.entries(bugs);
   if (entries.length <= MAX_TRACKED_BUGS) return { ...bugs };
+  // Ties break on the id in **code-unit** order, never `localeCompare`: ICU
+  // collation varies by locale and by ICU version, and it does not agree with code
+  // units on the `-` these ids contain. This decides which record survives, so a
+  // locale-dependent comparison here would make EG-2's byte-identical transcripts
+  // a property of the device's ICU data.
   const kept = entries
-    .sort((a, b) => (b[1].beta === a[1].beta ? a[0].localeCompare(b[0]) : b[1].beta - a[1].beta))
+    .sort((a, b) => (b[1].beta === a[1].beta ? (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0) : b[1].beta - a[1].beta))
     .slice(0, MAX_TRACKED_BUGS);
   return Object.fromEntries(kept);
 }

--- a/dynawalla/engine/src/constants.ts
+++ b/dynawalla/engine/src/constants.ts
@@ -1,0 +1,127 @@
+/**
+ * Every coefficient the learner model uses, in one file, each one traced to the
+ * line of ADAPTIVE_LEARNING.md it comes from — or marked PROVISIONAL where the
+ * document pins the *shape* of a rule but not its number.
+ *
+ * The distinction matters, and it is the same one GATES.md draws between a
+ * REGRESSION BOUND and a PEDAGOGICAL ASSERTION: when something fails, the label
+ * tells you whether to fix the code or to question the constant. Corpán set eleven
+ * ship gates of which three were unsatisfiable under any scheduler, and it cost two
+ * calibration rounds to find out.
+ */
+
+import { fromInt, fromMicro, fromRatio } from "./math/fixed.ts";
+import type { Fix } from "./math/fixed.ts";
+
+// ---------------------------------------------------------------- Layer S ----
+
+/** `U(n) = 0.9 / (1 + 0.06n)` — the learning-rate numerator. */
+export const UPDATE_RATE_NUMERATOR: Fix = fromRatio(9, 10);
+/** …and the 0.06 in its denominator. */
+export const UPDATE_RATE_DECAY: Fix = fromRatio(6, 100);
+
+/** Asymmetric credit: ×1.0 correct, ×0.7 incorrect, so one mis-tap never craters a child. */
+export const CREDIT_CORRECT: Fix = fromInt(1);
+export const CREDIT_INCORRECT: Fix = fromRatio(7, 10);
+
+/** 0.15× of the residual propagates to each direct prerequisite. */
+export const PREREQ_PROPAGATION: Fix = fromRatio(15, 100);
+
+/** Evidence weights. 1 is the default; the others are named at their call sites. */
+export const EVIDENCE_FULL: Fix = fromInt(1);
+export const EVIDENCE_HALVED: Fix = fromRatio(1, 2);
+export const EVIDENCE_LUCKY_CHOICE: Fix = fromRatio(3, 10);
+
+/**
+ * φ, the fluency estimate, moves on the same evidence but at a fifth of the rate
+ * and only on speed. PROVISIONAL: the document defines φ's role — "does it without
+ * counting" — but not its update constant.
+ */
+export const FLUENCY_RATE: Fix = fromRatio(2, 10);
+
+// -------------------------------------------------------------- Mastery ----
+
+/**
+ * PROVISIONAL. The document pins three hard rules — a choice item can never
+ * advance past Practiced, no promotion is ever denied on latency alone (A-05), and
+ * a Mastered skill unfailed for 21 days is Retired — but not the thresholds. These
+ * are the knobs EG-5 calibration will move; the rules above are not knobs.
+ */
+export const PRACTICED_MIN_ATTEMPTS = 4;
+export const PRACTICED_MARGIN: Fix = fromRatio(3, 10);
+export const MASTERED_MIN_ATTEMPTS = 8;
+export const MASTERED_MARGIN: Fix = fromInt(1);
+/** A Mastered skill unfailed for this many days is Retired from normal pools. */
+export const RETIREMENT_DAYS = 21;
+
+// ---------------------------------------------------------------- Layer B ----
+
+/** `β ← 0.9·β + 1{bug fired}`. */
+export const BUG_DECAY: Fix = fromRatio(9, 10);
+/** A bug is active at β ≥ 2.2 — roughly three firings in short order. */
+export const BUG_ACTIVE_THRESHOLD: Fix = fromRatio(22, 10);
+/** Sparse and hard-capped, so state size cannot grow with use (EG-3). */
+export const MAX_TRACKED_BUGS = 64;
+
+// -------------------------------------------------------------- Controller ----
+
+/** Difficulty target 0.80, band [0.70, 0.92]. Not 0.85 — see ADAPTIVE_LEARNING.md. */
+export const P_TARGET_DEFAULT: Fix = fromRatio(80, 100);
+export const P_TARGET_MIN: Fix = fromRatio(70, 100);
+export const P_TARGET_MAX: Fix = fromRatio(92, 100);
+/** `pTarget ← clamp(pTarget + 0.06·fail − 0.015·pass, 0.70, 0.92)`, per item. */
+export const P_TARGET_UP_ON_FAIL: Fix = fromRatio(6, 100);
+export const P_TARGET_DOWN_ON_PASS: Fix = fromRatio(15, 1000);
+
+/** Batch composition is expressed as offsets from `pTarget`, never absolute `P̂`. */
+export const STRETCH_OFFSET: Fix = fromMicro(-70_000);
+export const CONFIDENCE_OFFSET: Fix = fromMicro(100_000);
+/** Never two consecutive items below `pTarget − 0.20`. */
+export const FRUSTRATION_OFFSET: Fix = fromMicro(-200_000);
+
+// -------------------------------------------------------------- Scheduler ----
+
+export const BATCH_SIZE = 8;
+/** Within a batch: ≤2 consecutive from one skill, ≤3 from one operation. */
+export const MAX_CONSECUTIVE_SAME_SKILL = 2;
+export const MAX_PER_OPERATION = 3;
+/** ≥3 distinct skills once three are reachable. */
+export const MIN_DISTINCT_SKILLS = 3;
+/** A brand-new skill gets a blocked debut of 3–4 consecutive guided items. */
+export const DEBUT_BLOCK_MIN = 3;
+export const DEBUT_BLOCK_MAX = 4;
+/** Repair items are capped at ≤25% of any batch (A-12). */
+export const MAX_REPAIR_FRACTION_PERCENT = 25;
+/** Never re-serve an identical item within 6 cards. */
+export const NO_REPEAT_WINDOW = 6;
+/** After 3 failures on one skill it is benched for the session. */
+export const BENCH_AFTER_FAILURES = 3;
+/** ≤40% of a rolling 50-item window from any one skill. */
+export const ROLLING_WINDOW = 50;
+export const MAX_WINDOW_SHARE_PERCENT = 40;
+
+// ---------------------------------------------------------------- Latency ----
+
+/** EWMA weight for the child's personal latency baseline. PROVISIONAL. */
+export const LATENCY_EWMA_WEIGHT: Fix = fromRatio(2, 10);
+/**
+ * Rating thresholds as a fraction of the child's own baseline. The document pins
+ * the shape — fast-correct → Good/Easy, slow-correct → Hard with the interval
+ * capped, incorrect → Again — and these are PROVISIONAL numbers for it.
+ */
+export const RATING_EASY_RATIO_PERCENT = 60;
+export const RATING_GOOD_RATIO_PERCENT = 140;
+/** A fact card is only created once the child is fluent enough to be recalling it. */
+export const FACT_ELIGIBILITY_PHI: Fix = fromRatio(1, 2);
+
+/** z-score bands for the slip / misconception / no-idea discrimination. */
+export const LATENCY_Z_SLIP: Fix = fromInt(1);
+export const LATENCY_Z_NO_IDEA: Fix = fromInt(2);
+
+// ---------------------------------------------------------------- Fatigue ----
+
+/** Accuracy down ≥20 points against the session's first third. */
+export const FATIGUE_ACCURACY_DROP_POINTS = 20;
+/** Any two indicators → fatigued: evidence halved, pTarget to 0.90, no new skills. */
+export const FATIGUE_INDICATORS_REQUIRED = 2;
+export const FATIGUE_P_TARGET: Fix = fromRatio(90, 100);

--- a/dynawalla/engine/src/controller.test.ts
+++ b/dynawalla/engine/src/controller.test.ts
@@ -104,3 +104,31 @@ test("controller: the first and last card of a session are confidence cards", ()
   assert.ok(!middle.includes("stretch"), "a child with nothing practised is not stretched");
   assert.throws(() => batchIntents(0, { first: true, last: true, anyPracticed: true }), RangeError);
 });
+
+test("controller: no card overwrites another, at any batch size", () => {
+  // Both placements are stated as invariants — the first and last card of a session
+  // are confidence cards, and every batch carries a stretch once something is
+  // Practiced. Writing the stretch first let a confidence card land on top of it,
+  // silently, and only at sizes BATCH_SIZE does not use today. A batch too small to
+  // hold all three says so instead of quietly dropping one.
+  for (let size = 3; size <= 12; size++) {
+    const intents = batchIntents(size, { first: true, last: true, anyPracticed: true });
+    assert.equal(intents[0], "confidence", `size ${String(size)}: first card`);
+    assert.equal(intents.at(-1), "confidence", `size ${String(size)}: last card`);
+    assert.equal(
+      intents.filter((intent) => intent === "stretch").length,
+      1,
+      `size ${String(size)}: exactly one stretch survives`,
+    );
+  }
+
+  for (const size of [1, 2]) {
+    assert.throws(
+      () => batchIntents(size, { first: true, last: true, anyPracticed: true }),
+      RangeError,
+      `a batch of ${String(size)} cannot hold two confidence cards and a stretch`,
+    );
+    // Without the confidence cards there is room, and the stretch is still placed.
+    assert.ok(batchIntents(size, { first: false, last: false, anyPracticed: true }).includes("stretch"));
+  }
+});

--- a/dynawalla/engine/src/controller.test.ts
+++ b/dynawalla/engine/src/controller.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  P_TARGET_DOWN_ON_PASS,
+  P_TARGET_UP_ON_FAIL,
+  STRETCH_OFFSET,
+} from "./constants.ts";
+import { abs, add, fromRatio, sub } from "./math/fixed.ts";
+import type { Fix } from "./math/fixed.ts";
+import {
+  P_TARGET_DEFAULT,
+  P_TARGET_MAX,
+  P_TARGET_MIN,
+  batchIntents,
+  fatiguedPTarget,
+  frustrationFloor,
+  targetFor,
+  updatePTarget,
+} from "./controller.ts";
+
+test("controller: the default target is 0.80 in a band of [0.70, 0.92]", () => {
+  assert.equal(P_TARGET_DEFAULT, fromRatio(80, 100));
+  assert.equal(P_TARGET_MIN, fromRatio(70, 100));
+  assert.equal(P_TARGET_MAX, fromRatio(92, 100));
+});
+
+test("controller: a failure raises the target and a pass lowers it, per item", () => {
+  assert.equal(updatePTarget(P_TARGET_DEFAULT, false), add(P_TARGET_DEFAULT, P_TARGET_UP_ON_FAIL));
+  assert.equal(updatePTarget(P_TARGET_DEFAULT, true), sub(P_TARGET_DEFAULT, P_TARGET_DOWN_ON_PASS));
+});
+
+test("controller: the band is a hard clamp in both directions", () => {
+  let low = P_TARGET_DEFAULT;
+  for (let i = 0; i < 100; i++) low = updatePTarget(low, true);
+  assert.equal(low, P_TARGET_MIN);
+  let high = P_TARGET_DEFAULT;
+  for (let i = 0; i < 100; i++) high = updatePTarget(high, false);
+  assert.equal(high, P_TARGET_MAX);
+});
+
+test("controller: over any 50-item window the step is bounded (EG-7)", (t) => {
+  // The controller has to be able to react without oscillating. Two properties:
+  // no single step exceeds the failure step, and a steady stream of one outcome
+  // does not alternate in sign.
+  const outcomes: boolean[] = [];
+  let seed = 7;
+  for (let i = 0; i < 50; i++) {
+    seed = (Math.imul(seed, 1103515245) + 12345) >>> 0;
+    outcomes.push(seed % 100 < 80);
+  }
+  let pTarget = P_TARGET_DEFAULT;
+  let signChanges = 0;
+  let previousSign = 0;
+  let maxStep = 0 as Fix;
+  for (const correct of outcomes) {
+    const next = updatePTarget(pTarget, correct);
+    const step = sub(next, pTarget);
+    if (abs(step) > maxStep) maxStep = abs(step);
+    const sign = step > 0 ? 1 : step < 0 ? -1 : 0;
+    if (sign !== 0 && previousSign !== 0 && sign !== previousSign) signChanges += 1;
+    if (sign !== 0) previousSign = sign;
+    pTarget = next;
+  }
+  assert.ok(maxStep <= P_TARGET_UP_ON_FAIL, "no step exceeds the failure step");
+  assert.ok(pTarget >= P_TARGET_MIN && pTarget <= P_TARGET_MAX);
+  t.diagnostic(`50 items: ${String(signChanges)} sign changes, max step ${String(maxStep)} micro`);
+});
+
+test("controller: a steady 80% success rate leaves the target roughly where it started", () => {
+  // 0.06 up on a failure and 0.015 down on a pass balance at exactly 80%, which is
+  // where the target is set. That is not a coincidence and it should stay true.
+  let pTarget = P_TARGET_DEFAULT;
+  for (let i = 0; i < 500; i++) pTarget = updatePTarget(pTarget, i % 5 !== 0);
+  assert.ok(abs(sub(pTarget, P_TARGET_DEFAULT)) <= fromRatio(5, 100), `drifted to ${String(pTarget)}`);
+});
+
+test("controller: batch difficulty is an offset from the target, never an absolute", () => {
+  // The boundary conflict the first draft of the plan had: "one stretch item" must
+  // mean pTarget − 0.07, not a fixed 0.85 that is a stretch at the top of the
+  // clamp and a gift at the bottom of it.
+  for (const pTarget of [P_TARGET_MIN, P_TARGET_DEFAULT, P_TARGET_MAX]) {
+    assert.equal(targetFor(pTarget, "steady"), pTarget);
+    assert.equal(targetFor(pTarget, "stretch"), add(pTarget, STRETCH_OFFSET));
+    assert.ok(targetFor(pTarget, "confidence") > pTarget);
+    assert.ok(targetFor(pTarget, "stretch") < pTarget);
+    assert.ok(frustrationFloor(pTarget) < targetFor(pTarget, "stretch"));
+  }
+});
+
+test("controller: fatigue raises the target rather than lowering it", () => {
+  assert.ok(fatiguedPTarget() > P_TARGET_DEFAULT);
+  assert.ok(fatiguedPTarget() <= P_TARGET_MAX);
+});
+
+test("controller: the first and last card of a session are confidence cards", () => {
+  const intents = batchIntents(8, { first: true, last: true, anyPracticed: true });
+  assert.equal(intents.length, 8);
+  assert.equal(intents[0], "confidence");
+  assert.equal(intents.at(-1), "confidence");
+  assert.ok(intents.includes("stretch"), "and every batch has a stretch item once a skill is Practiced");
+
+  const middle = batchIntents(8, { first: false, last: false, anyPracticed: false });
+  assert.ok(!middle.includes("confidence"));
+  assert.ok(!middle.includes("stretch"), "a child with nothing practised is not stretched");
+  assert.throws(() => batchIntents(0, { first: true, last: true, anyPracticed: true }), RangeError);
+});

--- a/dynawalla/engine/src/controller.ts
+++ b/dynawalla/engine/src/controller.ts
@@ -1,0 +1,74 @@
+/**
+ * The difficulty controller.
+ *
+ *   pTarget ← clamp(pTarget + 0.06·fail − 0.015·pass, 0.70, 0.92)
+ *
+ * updated **per item**, with the batch re-planned on any invariant trip rather
+ * than served to completion — otherwise a correction lands one batch late and
+ * reads to the child as the app randomly getting easy and then hard.
+ *
+ * The target is 0.80, not Wilson's 0.85: that rule is derived for stochastic-
+ * gradient binary classifiers and its authors scope it there. The closest real
+ * prior art, Math Garden, samples at 0.75 across 3,648 children.
+ */
+
+import {
+  CONFIDENCE_OFFSET,
+  FATIGUE_P_TARGET,
+  FRUSTRATION_OFFSET,
+  P_TARGET_DEFAULT,
+  P_TARGET_DOWN_ON_PASS,
+  P_TARGET_MAX,
+  P_TARGET_MIN,
+  P_TARGET_UP_ON_FAIL,
+  STRETCH_OFFSET,
+} from "./constants.ts";
+import { ONE, ZERO, add, clamp, sub } from "./math/fixed.ts";
+import type { Fix } from "./math/fixed.ts";
+
+export { P_TARGET_DEFAULT, P_TARGET_MAX, P_TARGET_MIN };
+
+/** One item's effect on the target. */
+export function updatePTarget(pTarget: Fix, correct: boolean): Fix {
+  const moved = correct ? sub(pTarget, P_TARGET_DOWN_ON_PASS) : add(pTarget, P_TARGET_UP_ON_FAIL);
+  return clamp(moved, P_TARGET_MIN, P_TARGET_MAX);
+}
+
+/** Fatigue does not lower the target; it raises it and stops introducing anything new. */
+export function fatiguedPTarget(): Fix {
+  return FATIGUE_P_TARGET;
+}
+
+export type CardIntent = "stretch" | "steady" | "confidence";
+
+/**
+ * The success probability a card of this intent should have, **as an offset from
+ * `pTarget`** and never as an absolute number.
+ *
+ * This is the boundary conflict the first draft of the plan had: "one stretch
+ * item" means `pTarget − 0.07`, not a fixed 0.85 that is a stretch at the top of
+ * the clamp and a gift at the bottom of it.
+ */
+export function targetFor(pTarget: Fix, intent: CardIntent): Fix {
+  const offset = intent === "stretch" ? STRETCH_OFFSET : intent === "confidence" ? CONFIDENCE_OFFSET : ZERO;
+  return clamp(add(pTarget, offset), ZERO, ONE);
+}
+
+/** Below this, two in a row is the anti-frustration trip wire. */
+export function frustrationFloor(pTarget: Fix): Fix {
+  return clamp(add(pTarget, FRUSTRATION_OFFSET), ZERO, ONE);
+}
+
+/**
+ * The intents of a batch, in order. First and last card of a session are at
+ * `pTarget + 0.10`, and every batch carries at least one stretch item once a skill
+ * is Practiced (the anti-stagnation rule).
+ */
+export function batchIntents(size: number, options: { first: boolean; last: boolean; anyPracticed: boolean }): CardIntent[] {
+  if (size <= 0) throw new RangeError("batchIntents: empty batch");
+  const intents: CardIntent[] = new Array<CardIntent>(size).fill("steady");
+  if (options.anyPracticed) intents[Math.min(size - 1, Math.floor(size / 2))] = "stretch";
+  if (options.first) intents[0] = "confidence";
+  if (options.last) intents[size - 1] = "confidence";
+  return intents;
+}

--- a/dynawalla/engine/src/controller.ts
+++ b/dynawalla/engine/src/controller.ts
@@ -63,12 +63,30 @@ export function frustrationFloor(pTarget: Fix): Fix {
  * The intents of a batch, in order. First and last card of a session are at
  * `pTarget + 0.10`, and every batch carries at least one stretch item once a skill
  * is Practiced (the anti-stagnation rule).
+ *
+ * The confidence cards are placed first and the stretch takes a slot neither of them
+ * claims, because both rules are stated as invariants and writing the stretch first
+ * would let a confidence card overwrite it — silently, and only for small batches,
+ * which is the shape of bug that survives until something else depends on it.
+ * `BATCH_SIZE` is 8, so a batch that cannot hold all three is a caller error.
  */
 export function batchIntents(size: number, options: { first: boolean; last: boolean; anyPracticed: boolean }): CardIntent[] {
   if (size <= 0) throw new RangeError("batchIntents: empty batch");
   const intents: CardIntent[] = new Array<CardIntent>(size).fill("steady");
-  if (options.anyPracticed) intents[Math.min(size - 1, Math.floor(size / 2))] = "stretch";
   if (options.first) intents[0] = "confidence";
   if (options.last) intents[size - 1] = "confidence";
+
+  if (options.anyPracticed) {
+    const preferred = Math.min(size - 1, Math.floor(size / 2));
+    let slot = -1;
+    for (let offset = 0; offset < size && slot < 0; offset++) {
+      if (intents[(preferred + offset) % size] === "steady") slot = (preferred + offset) % size;
+    }
+    if (slot < 0) {
+      throw new RangeError(`batchIntents: a batch of ${String(size)} has no room for a stretch card`);
+    }
+    intents[slot] = "stretch";
+  }
+
   return intents;
 }

--- a/dynawalla/engine/src/facts.test.ts
+++ b/dynawalla/engine/src/facts.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { FACT_ELIGIBILITY_PHI } from "./constants.ts";
+import { ONE, ZERO, fromInt, fromRatio } from "./math/fixed.ts";
+import {
+  NEW_LATENCY_STATS,
+  isDue,
+  isFactEligible,
+  latencyToSeconds,
+  latencyZ,
+  observeLatency,
+  ratingFor,
+} from "./facts.ts";
+import { factKey } from "./types.ts";
+import type { FactCard, LatencyStats } from "./types.ts";
+
+function baseline(meanMs: number, count = 20): LatencyStats {
+  let stats = NEW_LATENCY_STATS;
+  for (let i = 0; i < count; i++) stats = observeLatency(stats, meanMs);
+  return stats;
+}
+
+test("facts: a card is keyed on the class of item, never on the instance", () => {
+  // ADR-0008: generated exercises have no stable id, so a per-item key would mint
+  // a new card per instance and degenerate spaced review into random practice.
+  assert.equal(factKey("dw.add.regroup.subtract-multidigit", 2, "free-entry"), "skill:dw.add.regroup.subtract-multidigit#L2#free-entry");
+  assert.equal(
+    factKey("dw.add.regroup.subtract-multidigit", 2, "free-entry"),
+    factKey("dw.add.regroup.subtract-multidigit", 2, "free-entry"),
+    "two different seeds of the same class share one card",
+  );
+  assert.notEqual(
+    factKey("dw.add.regroup.subtract-multidigit", 2, "free-entry"),
+    factKey("dw.add.regroup.subtract-multidigit", 2, "column"),
+    "but a different form is a different card",
+  );
+});
+
+test("facts: latency is tracked in seconds and converted exactly", () => {
+  assert.equal(latencyToSeconds(1000), ONE);
+  assert.equal(latencyToSeconds(1500), fromRatio(3, 2));
+  assert.equal(latencyToSeconds(0), ZERO);
+  assert.throws(() => latencyToSeconds(-1), RangeError);
+});
+
+test("facts: the latency baseline is the child's own, and it moves toward new evidence", () => {
+  const stats = baseline(4000);
+  assert.ok(stats.meanS > fromRatio(35, 10) && stats.meanS <= fromInt(4));
+  const slower = observeLatency(stats, 20000);
+  assert.ok(slower.meanS > stats.meanS);
+  assert.ok(slower.varianceS2 > stats.varianceS2, "an outlier widens the spread too");
+  assert.equal(observeLatency(NEW_LATENCY_STATS, 3000).count, 1);
+});
+
+test("facts: z is zero until there is enough evidence to say anything", () => {
+  assert.equal(latencyZ(NEW_LATENCY_STATS, 9000), ZERO);
+  assert.equal(latencyZ(observeLatency(NEW_LATENCY_STATS, 3000), 9000), ZERO);
+  const stats = baseline(4000, 30);
+  const varied = observeLatency(observeLatency(stats, 8000), 2000);
+  assert.notEqual(latencyZ(varied, 30000), ZERO);
+  assert.ok(latencyZ(varied, 30000) > latencyZ(varied, 4000), "slower is further from the mean");
+});
+
+test("facts: the rating is a function of correctness AND latency", () => {
+  const stats = baseline(4000);
+  assert.deepEqual(ratingFor(false, 1000, stats), { rating: "again", capInterval: true });
+  assert.deepEqual(ratingFor(true, 1000, stats), { rating: "easy", capInterval: false });
+  assert.deepEqual(ratingFor(true, 4000, stats), { rating: "good", capInterval: false });
+  // Slow-correct is Hard, and the interval is capped: a child who is still
+  // computing an answer is not recalling it, however right they are.
+  assert.deepEqual(ratingFor(true, 30000, stats), { rating: "hard", capInterval: true });
+  assert.deepEqual(ratingFor(true, 9000, NEW_LATENCY_STATS), { rating: "good", capInterval: false });
+});
+
+test("facts: card creation is gated on fluency, not on correctness", () => {
+  assert.equal(isFactEligible(ZERO), false);
+  assert.equal(isFactEligible(FACT_ELIGIBILITY_PHI), true);
+  assert.equal(isFactEligible(ONE), true);
+  assert.equal(isFactEligible(fromRatio(49, 100)), false);
+});
+
+test("facts: due dates are whole days, compared without a clock", () => {
+  const card: FactCard = { stability: ONE, difficulty: fromInt(5), dueDay: 30, reps: 2, lapses: 0 };
+  assert.equal(isDue(card, 29), false);
+  assert.equal(isDue(card, 30), true);
+  assert.equal(isDue(card, 31), true);
+});

--- a/dynawalla/engine/src/facts.ts
+++ b/dynawalla/engine/src/facts.ts
@@ -1,0 +1,114 @@
+/**
+ * Layer F — fact memory, and the latency model the rest of the engine reads.
+ *
+ * Two things about this layer are non-obvious and both are load-bearing
+ * (ADR-0008):
+ *
+ * - **Cards are keyed on classes, never instances.** Generated exercises have no
+ *   stable id, so a per-item key would mint a new card per instance and silently
+ *   degenerate spaced review into random practice. The key is
+ *   `skill:<id>#L<level>#<formId>`.
+ * - **The rating is a function of `(correct, latency)`, not correctness alone.**
+ *   Fast-correct → Good/Easy; slow-correct → **Hard, with the interval capped**;
+ *   incorrect → Again.
+ *
+ * The FSRS-6 implementation itself is deliberately *not* here. It is a one-file
+ * `FactScheduler` seam with a test pinning the default weights, so a library
+ * upgrade fails loudly instead of quietly reshuffling every interval.
+ */
+
+import {
+  FACT_ELIGIBILITY_PHI,
+  LATENCY_EWMA_WEIGHT,
+  RATING_EASY_RATIO_PERCENT,
+  RATING_GOOD_RATIO_PERCENT,
+} from "./constants.ts";
+import { ZERO, add, div, fromRatio, mul, sqrt, sub } from "./math/fixed.ts";
+import type { Fix } from "./math/fixed.ts";
+import type { Day, FactCard, LatencyStats, Rating } from "./types.ts";
+
+export const NEW_LATENCY_STATS: LatencyStats = { meanS: ZERO, varianceS2: ZERO, count: 0 };
+
+/** Milliseconds as fixed-point seconds. Seconds keep the variance in a small range. */
+export function latencyToSeconds(latencyMs: number): Fix {
+  if (!Number.isFinite(latencyMs) || latencyMs < 0) throw new RangeError("latency must be a non-negative number");
+  return fromRatio(Math.round(latencyMs), 1000);
+}
+
+/** EWMA of the child's own latency, with the matching EWMA of the squared deviation. */
+export function observeLatency(stats: LatencyStats, latencyMs: number): LatencyStats {
+  const value = latencyToSeconds(latencyMs);
+  if (stats.count === 0) return { meanS: value, varianceS2: ZERO, count: 1 };
+  const deviation = sub(value, stats.meanS);
+  const meanS = add(stats.meanS, mul(LATENCY_EWMA_WEIGHT, deviation));
+  const varianceS2 = add(stats.varianceS2, mul(LATENCY_EWMA_WEIGHT, sub(mul(deviation, deviation), stats.varianceS2)));
+  return { meanS, varianceS2, count: stats.count + 1 };
+}
+
+/**
+ * How unusual this latency is for this child, in standard deviations. Returns 0
+ * before there is enough evidence to say anything — an engine that reads noise as
+ * a signal on the second card of a session is worse than one that waits.
+ */
+export function latencyZ(stats: LatencyStats, latencyMs: number): Fix {
+  if (stats.count < 5 || stats.varianceS2 <= ZERO) return ZERO;
+  const deviation = sub(latencyToSeconds(latencyMs), stats.meanS);
+  return div(deviation, sqrt(stats.varianceS2));
+}
+
+export type RatingDecision = {
+  readonly rating: Rating;
+  /**
+   * True when the interval must not be allowed to grow. A slow-correct answer is
+   * still an answer, but treating it as evidence of durable recall is how a child
+   * ends up being asked for a fact they are actually still computing.
+   */
+  readonly capInterval: boolean;
+};
+
+/**
+ * `(correct, latency) → rating`, relative to the child's own baseline rather than
+ * to a fixed millisecond count: a six-year-old and a ten-year-old do not share a
+ * clock.
+ */
+export function ratingFor(correct: boolean, latencyMs: number, baseline: LatencyStats): RatingDecision {
+  if (!correct) return { rating: "again", capInterval: true };
+  if (baseline.count === 0) return { rating: "good", capInterval: false };
+
+  const value = latencyToSeconds(latencyMs);
+  const easyCeiling = mulPercent(baseline.meanS, RATING_EASY_RATIO_PERCENT);
+  const goodCeiling = mulPercent(baseline.meanS, RATING_GOOD_RATIO_PERCENT);
+  if (value <= easyCeiling) return { rating: "easy", capInterval: false };
+  if (value <= goodCeiling) return { rating: "good", capInterval: false };
+  return { rating: "hard", capInterval: true };
+}
+
+function mulPercent(value: Fix, percent: number): Fix {
+  return mul(value, fromRatio(percent, 100));
+}
+
+/**
+ * Card creation is gated on φ crossing a fluency threshold, so facts the child
+ * still *computes* stay in the Layer-S fluency-burst pool instead of entering
+ * spaced review as though they were recalled.
+ */
+export function isFactEligible(phi: Fix): boolean {
+  return phi >= FACT_ELIGIBILITY_PHI;
+}
+
+/**
+ * The spaced-repetition seam. FSRS-6 lands behind this interface in PR-5.5, with a
+ * test pinning its 21 default weights. Nothing else in the engine may know which
+ * algorithm is behind it.
+ */
+export type FactScheduler = {
+  readonly name: string;
+  /** Number of weights the implementation carries, pinned by a test. */
+  readonly weightCount: number;
+  create(today: Day): FactCard;
+  review(card: FactCard, rating: Rating, today: Day, capInterval: boolean): FactCard;
+};
+
+export function isDue(card: FactCard, today: Day): boolean {
+  return card.dueDay <= today;
+}

--- a/dynawalla/engine/src/index.ts
+++ b/dynawalla/engine/src/index.ts
@@ -1,0 +1,17 @@
+/**
+ * `@dynawalla/engine` — the learner model.
+ *
+ * Pure TypeScript: no IO, no DOM, no clock, no randomness, and no import from the
+ * app or from the curriculum. `boundary.test.ts` fails the build if that stops
+ * being true (gate EG-1).
+ */
+
+export * from "./types.ts";
+export * from "./constants.ts";
+export * as fixed from "./math/fixed.ts";
+export { expNeg, sigmoid, HALF, SIGMOID_DOMAIN } from "./math/logistic.ts";
+export * from "./skill.ts";
+export * from "./bugs.ts";
+export * from "./facts.ts";
+export * from "./controller.ts";
+export * from "./scheduler.ts";

--- a/dynawalla/engine/src/math/fixed.test.ts
+++ b/dynawalla/engine/src/math/fixed.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  FIX_SCALE,
+  ONE,
+  ZERO,
+  abs,
+  add,
+  clamp,
+  cmp,
+  div,
+  format,
+  fromInt,
+  fromMicro,
+  fromRatio,
+  isqrt,
+  max,
+  min,
+  mul,
+  neg,
+  scale,
+  sqrt,
+  sub,
+  toRoundedInt,
+} from "./fixed.ts";
+import type { Fix } from "./fixed.ts";
+
+const CASES = 20000;
+
+/** A deterministic integer stream, so this file needs no randomness of its own. */
+function* lcg(seed: number): Generator<number> {
+  let state = seed >>> 0;
+  for (;;) {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    yield state;
+  }
+}
+
+test("fixed: constructors and constants", () => {
+  assert.equal(ONE, FIX_SCALE);
+  assert.equal(ZERO, 0);
+  assert.equal(fromInt(3), 3_000_000);
+  assert.equal(fromInt(-3), -3_000_000);
+  assert.equal(fromMicro(1), 1);
+  assert.equal(fromRatio(1, 2), 500_000);
+  assert.equal(fromRatio(-1, 2), -500_000);
+  assert.equal(fromRatio(1, 3), 333_333, "rounds to the nearest millionth");
+  assert.equal(fromRatio(2, 3), 666_667);
+  assert.throws(() => fromInt(1 / 3), RangeError);
+  assert.throws(() => fromRatio(1, 0), RangeError);
+  assert.throws(() => div(ONE, ZERO), RangeError);
+});
+
+test("fixed: arithmetic rounds half away from zero", () => {
+  assert.equal(mul(fromRatio(1, 2), fromRatio(1, 2)), 250_000);
+  assert.equal(mul(ONE, fromMicro(7)), 7);
+  assert.equal(mul(fromMicro(1), fromMicro(1)), 0, "a millionth of a millionth is below the grid");
+  assert.equal(mul(fromMicro(1), fromRatio(1, 2)), 1, "and half a millionth rounds away from zero");
+  assert.equal(mul(fromMicro(-1), fromRatio(1, 2)), -1);
+  assert.equal(div(ONE, fromInt(3)), 333_333);
+  assert.equal(div(fromInt(2), fromInt(3)), 666_667);
+  assert.equal(scale(fromInt(7), 1, 3), 2_333_333);
+  assert.equal(add(fromInt(2), fromRatio(1, 4)), 2_250_000);
+  assert.equal(sub(fromInt(2), fromRatio(1, 4)), 1_750_000);
+  assert.equal(neg(fromInt(2)), -2_000_000);
+  assert.equal(abs(fromInt(-2)), 2_000_000);
+  assert.equal(toRoundedInt(fromRatio(3, 2)), 2);
+  assert.equal(toRoundedInt(fromRatio(-3, 2)), -2);
+  assert.equal(toRoundedInt(fromRatio(4, 3)), 1);
+});
+
+test("fixed: every value is an integer, always", (t) => {
+  const stream = lcg(20260725);
+  let cases = 0;
+  for (let i = 0; i < CASES; i++) {
+    const a = fromMicro((stream.next().value % 20_000_001) - 10_000_000);
+    const b = fromMicro((stream.next().value % 20_000_001) - 10_000_000);
+    for (const value of [add(a, b), sub(a, b), mul(a, b), neg(a), abs(a), min(a, b), max(a, b)]) {
+      assert.ok(Number.isSafeInteger(value), `not an integer: ${String(value)}`);
+    }
+    if (b !== 0) assert.ok(Number.isSafeInteger(div(a, b)));
+    cases += 1;
+  }
+  t.diagnostic(`${String(cases)} fixed-point operand pairs checked`);
+});
+
+test("fixed: algebraic identities hold", (t) => {
+  const stream = lcg(4711);
+  let cases = 0;
+  for (let i = 0; i < CASES; i++) {
+    const a = fromMicro((stream.next().value % 2_000_001) - 1_000_000);
+    const b = fromMicro((stream.next().value % 2_000_001) - 1_000_000);
+    assert.equal(add(a, b), add(b, a));
+    assert.equal(mul(a, b), mul(b, a));
+    assert.equal(sub(add(a, b), b), a, "addition is exact, so it is invertible");
+    assert.equal(add(a, ZERO), a);
+    assert.equal(mul(a, ONE), a);
+    assert.equal(mul(a, ZERO), ZERO);
+    assert.equal(cmp(a, b), -cmp(b, a) as -1 | 0 | 1);
+    assert.equal(clamp(a, b, b), b);
+    cases += 1;
+  }
+  t.diagnostic(`${String(cases)} identity checks`);
+});
+
+test("fixed: multiplication matches exact rational arithmetic", (t) => {
+  // The claim this module rests on: `mul` is the exact product rounded once. The
+  // oracle is BigInt, computed a different way (numerator/denominator) from the
+  // implementation.
+  const stream = lcg(99991);
+  let cases = 0;
+  for (let i = 0; i < CASES; i++) {
+    const a = (stream.next().value % 4_000_001) - 2_000_000;
+    const b = (stream.next().value % 4_000_001) - 2_000_000;
+    const exactNumerator = BigInt(a) * BigInt(b);
+    const scaled = exactNumerator * 2n;
+    const rounded =
+      scaled >= 0n
+        ? (scaled + BigInt(FIX_SCALE)) / (2n * BigInt(FIX_SCALE))
+        : -((-scaled + BigInt(FIX_SCALE)) / (2n * BigInt(FIX_SCALE)));
+    assert.equal(BigInt(mul(fromMicro(a), fromMicro(b))), rounded, `${String(a)} * ${String(b)}`);
+    cases += 1;
+  }
+  t.diagnostic(`${String(cases)} products compared against exact BigInt arithmetic`);
+});
+
+test("fixed: overflow is refused, not silently wrong", () => {
+  const huge = fromMicro(Number.MAX_SAFE_INTEGER - 1);
+  assert.throws(() => mul(huge, huge), RangeError);
+  assert.throws(() => add(huge, huge), RangeError);
+  assert.throws(() => fromInt(Number.MAX_SAFE_INTEGER), RangeError);
+});
+
+test("fixed: integer square root is exact", () => {
+  assert.equal(isqrt(0n), 0n);
+  assert.equal(isqrt(1n), 1n);
+  assert.equal(isqrt(15n), 3n);
+  assert.equal(isqrt(16n), 4n);
+  assert.equal(isqrt(10n ** 30n), 10n ** 15n);
+  for (let n = 0n; n < 2000n; n++) {
+    const root = isqrt(n);
+    assert.ok(root * root <= n && (root + 1n) * (root + 1n) > n, `isqrt(${n.toString()})`);
+  }
+  assert.throws(() => isqrt(-1n), RangeError);
+});
+
+test("fixed: square root, to the millionth", () => {
+  assert.equal(sqrt(fromInt(4)), fromInt(2));
+  assert.equal(sqrt(ZERO), ZERO);
+  assert.equal(sqrt(fromInt(2)), 1_414_213, "√2 = 1.414213562…, floored to the millionth");
+  assert.equal(sqrt(fromRatio(1, 4)), 500_000);
+  assert.throws(() => sqrt(fromInt(-1) as Fix), RangeError);
+});
+
+test("fixed: formatting is exact and never invents precision", () => {
+  assert.equal(format(fromRatio(1, 2)), "0.500000");
+  assert.equal(format(fromRatio(1, 2), 2), "0.50");
+  assert.equal(format(fromRatio(1, 3), 3), "0.333");
+  assert.equal(format(fromRatio(2, 3), 3), "0.667");
+  assert.equal(format(fromInt(-2), 1), "-2.0");
+  assert.equal(format(fromInt(7), 0), "7");
+  assert.equal(format(fromMicro(-1), 0), "0", "a signed zero prints as zero");
+  assert.throws(() => format(ONE, 9), RangeError);
+});

--- a/dynawalla/engine/src/math/fixed.ts
+++ b/dynawalla/engine/src/math/fixed.ts
@@ -1,0 +1,185 @@
+/**
+ * Fixed-point scalars.
+ *
+ * The learner model needs logistic probabilities and exponential decay, which
+ * cannot be exact rationals. It also may not use floats: acceptance item M-05
+ * bans floating-point arithmetic in `engine/` outright, and there is a second,
+ * independent reason — gate EG-2 requires identical seeds to produce
+ * **byte-identical transcripts across macOS and Linux**, and float accumulation
+ * order is exactly the kind of thing that survives one refactor and not the next.
+ *
+ * So every model quantity is an integer count of millionths, and every operation
+ * that could round goes through BigInt. No `number` in this package ever holds a
+ * fractional value.
+ *
+ * Range: values are held as JS numbers, so |value| must stay under 2^53 / 10^6 ≈
+ * 9 × 10^9. Every product and quotient is bounds-checked rather than trusted.
+ */
+
+declare const fixBrand: unique symbol;
+
+/** An integer count of millionths. Never fractional. */
+export type Fix = number & { readonly [fixBrand]: true };
+
+export const FIX_SCALE = 1_000_000;
+const SCALE = BigInt(FIX_SCALE);
+
+export const ZERO = 0 as Fix;
+export const ONE = FIX_SCALE as Fix;
+
+function assertInteger(value: number, what: string): void {
+  if (!Number.isSafeInteger(value)) {
+    throw new RangeError(`${what}: fixed-point values are safe integers, got ${String(value)}`);
+  }
+}
+
+function toFix(value: bigint, what: string): Fix {
+  const out = Number(value);
+  if (!Number.isSafeInteger(out)) {
+    throw new RangeError(`${what}: fixed-point overflow (${value.toString()})`);
+  }
+  return out as Fix;
+}
+
+/** Round half away from zero, in exact integer arithmetic. */
+function divRound(numerator: bigint, denominator: bigint): bigint {
+  if (denominator === 0n) throw new RangeError("divRound: division by zero");
+  const sign = denominator < 0n ? -1n : 1n;
+  const d = denominator * sign;
+  const n = numerator * sign;
+  const q = n / d;
+  const r = n % d;
+  const twice = (r < 0n ? -r : r) * 2n;
+  if (twice < d) return q;
+  return n < 0n ? q - 1n : q + 1n;
+}
+
+/** A whole number as a fixed-point value. */
+export function fromInt(value: number): Fix {
+  assertInteger(value, "fromInt");
+  return toFix(BigInt(value) * SCALE, "fromInt");
+}
+
+/** A raw count of millionths. The only way to write a fractional constant here. */
+export function fromMicro(value: number): Fix {
+  assertInteger(value, "fromMicro");
+  return value as Fix;
+}
+
+/** `numerator / denominator`, rounded to the nearest millionth. */
+export function fromRatio(numerator: number, denominator: number): Fix {
+  assertInteger(numerator, "fromRatio");
+  assertInteger(denominator, "fromRatio");
+  if (denominator === 0) throw new RangeError("fromRatio: zero denominator");
+  return toFix(divRound(BigInt(numerator) * SCALE, BigInt(denominator)), "fromRatio");
+}
+
+export function toMicro(value: Fix): number {
+  return value;
+}
+
+/** Nearest whole number. */
+export function toRoundedInt(value: Fix): number {
+  return Number(divRound(BigInt(value), SCALE));
+}
+
+export function add(a: Fix, b: Fix): Fix {
+  return toFix(BigInt(a) + BigInt(b), "add");
+}
+
+export function sub(a: Fix, b: Fix): Fix {
+  return toFix(BigInt(a) - BigInt(b), "sub");
+}
+
+export function neg(a: Fix): Fix {
+  return -a as Fix;
+}
+
+export function abs(a: Fix): Fix {
+  return (a < 0 ? -a : a) as Fix;
+}
+
+export function mul(a: Fix, b: Fix): Fix {
+  return toFix(divRound(BigInt(a) * BigInt(b), SCALE), "mul");
+}
+
+export function div(a: Fix, b: Fix): Fix {
+  if (b === 0) throw new RangeError("div: division by zero");
+  return toFix(divRound(BigInt(a) * SCALE, BigInt(b)), "div");
+}
+
+/** `a * numerator / denominator` with a single rounding step. */
+export function scale(a: Fix, numerator: number, denominator: number): Fix {
+  assertInteger(numerator, "scale");
+  assertInteger(denominator, "scale");
+  if (denominator === 0) throw new RangeError("scale: zero denominator");
+  return toFix(divRound(BigInt(a) * BigInt(numerator), BigInt(denominator)), "scale");
+}
+
+export function cmp(a: Fix, b: Fix): -1 | 0 | 1 {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+export function lt(a: Fix, b: Fix): boolean {
+  return a < b;
+}
+
+export function lte(a: Fix, b: Fix): boolean {
+  return a <= b;
+}
+
+export function gt(a: Fix, b: Fix): boolean {
+  return a > b;
+}
+
+export function gte(a: Fix, b: Fix): boolean {
+  return a >= b;
+}
+
+export function min(a: Fix, b: Fix): Fix {
+  return a <= b ? a : b;
+}
+
+export function max(a: Fix, b: Fix): Fix {
+  return a >= b ? a : b;
+}
+
+export function clamp(value: Fix, low: Fix, high: Fix): Fix {
+  if (low > high) throw new RangeError("clamp: empty range");
+  return value < low ? low : value > high ? high : value;
+}
+
+/** Integer square root of a non-negative bigint (Newton's method, exact). */
+export function isqrt(value: bigint): bigint {
+  if (value < 0n) throw new RangeError("isqrt: negative value");
+  if (value < 2n) return value;
+  let guess = value;
+  let next = (guess + 1n) / 2n;
+  while (next < guess) {
+    guess = next;
+    next = (guess + value / guess) / 2n;
+  }
+  return guess;
+}
+
+/** Square root, rounded down to the millionth. */
+export function sqrt(value: Fix): Fix {
+  if (value < 0) throw new RangeError("sqrt: negative value");
+  return toFix(isqrt(BigInt(value) * SCALE), "sqrt");
+}
+
+/**
+ * Decimal text, for diagnostics and golden transcripts. Exact: a fixed-point
+ * value is an integer, so printing it cannot lose anything.
+ */
+export function format(value: Fix, places = 6): string {
+  if (places < 0 || places > 6) throw new RangeError("format: 0..6 places");
+  const negative = value < 0;
+  const micro = BigInt(negative ? -value : value);
+  const divisor = 10n ** BigInt(6 - places);
+  const rounded = divRound(micro, divisor);
+  const digits = rounded.toString().padStart(places + 1, "0");
+  const whole = digits.slice(0, digits.length - places);
+  const fraction = places === 0 ? "" : `.${digits.slice(digits.length - places)}`;
+  return `${negative && rounded !== 0n ? "-" : ""}${whole}${fraction}`;
+}

--- a/dynawalla/engine/src/math/fixed.ts
+++ b/dynawalla/engine/src/math/fixed.ts
@@ -169,8 +169,13 @@ export function sqrt(value: Fix): Fix {
 }
 
 /**
- * Decimal text, for diagnostics and golden transcripts. Exact: a fixed-point
- * value is an integer, so printing it cannot lose anything.
+ * Decimal text, for diagnostics and golden transcripts.
+ *
+ * Lossless **only at the default `places = 6`**, where every millionth is printed.
+ * Fewer places rounds, half away from zero. A golden-transcript writer that shortens
+ * the output is therefore comparing rounded text, and two runs that differ below the
+ * printed place compare equal — which is the kind of difference nobody would think
+ * to look for.
  */
 export function format(value: Fix, places = 6): string {
   if (places < 0 || places > 6) throw new RangeError("format: 0..6 places");

--- a/dynawalla/engine/src/math/logistic.test.ts
+++ b/dynawalla/engine/src/math/logistic.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ONE, ZERO, fromInt, fromMicro, fromRatio, neg, sub } from "./fixed.ts";
+import type { Fix } from "./fixed.ts";
+import { HALF, SIGMOID_DOMAIN, expNeg, sigmoid } from "./logistic.ts";
+
+/**
+ * Published values of the logistic function, rounded to the millionth. These are
+ * an oracle independent of the implementation: they come from the mathematics, not
+ * from running this code, so a wrong series or a wrong reduction fails here.
+ *
+ *   σ(0.1)  = 0.524979187478…
+ *   σ(0.25) = 0.562176500885…
+ *   σ(0.5)  = 0.622459331201…
+ *   σ(1)    = 0.731058578630…
+ *   σ(2)    = 0.880797077978…
+ *   σ(3)    = 0.952574126822…
+ *   σ(4)    = 0.982013790038…
+ *   σ(5)    = 0.993307149076…
+ *   σ(8)    = 0.999664649318…
+ *   σ(10)   = 0.999954602131…
+ */
+const KNOWN: readonly (readonly [Fix, number])[] = [
+  [fromRatio(1, 10), 524_979],
+  [fromRatio(1, 4), 562_177],
+  [fromRatio(1, 2), 622_459],
+  [fromInt(1), 731_059],
+  [fromInt(2), 880_797],
+  [fromInt(3), 952_574],
+  [fromInt(4), 982_014],
+  [fromInt(5), 993_307],
+  [fromInt(8), 999_665],
+  [fromInt(10), 999_955],
+];
+
+test("logistic: matches published values of σ to the millionth", () => {
+  assert.equal(sigmoid(ZERO), HALF);
+  for (const [x, expected] of KNOWN) {
+    assert.equal(sigmoid(x), expected, `σ(${String(x)} micro)`);
+    assert.equal(sigmoid(neg(x)), ONE - expected, `σ(-${String(x)} micro)`);
+  }
+});
+
+test("logistic: symmetry about zero is exact, not approximate", (t) => {
+  let cases = 0;
+  for (let micro = -8_000_000; micro <= 8_000_000; micro += 1301) {
+    const x = fromMicro(micro);
+    assert.equal(sigmoid(x), sub(ONE, sigmoid(neg(x))), `σ(-x) = 1 - σ(x) at ${String(micro)}`);
+    cases += 1;
+  }
+  t.diagnostic(`symmetry checked at ${String(cases)} points`);
+});
+
+test("logistic: monotone increasing, bounded, and saturating", (t) => {
+  let previous = -1;
+  let cases = 0;
+  for (let micro = -25_000_000; micro <= 25_000_000; micro += 977) {
+    const value = sigmoid(fromMicro(micro));
+    assert.ok(value >= previous, `not monotone at ${String(micro)}`);
+    assert.ok(value >= ZERO && value <= ONE, `out of range at ${String(micro)}`);
+    previous = value;
+    cases += 1;
+  }
+  assert.equal(sigmoid(SIGMOID_DOMAIN), ONE, "saturates to certainty at the domain edge");
+  assert.equal(sigmoid(neg(SIGMOID_DOMAIN)), ZERO);
+  assert.equal(sigmoid(fromInt(1000)), ONE, "and clamps beyond it rather than overflowing");
+  t.diagnostic(`monotonicity checked at ${String(cases)} points`);
+});
+
+test("logistic: the derivative peaks at the middle, as it must", () => {
+  // A crude but genuine shape check: the central difference over a window of 0.1
+  // is largest when the window is centred on zero. It has to be symmetric, so the
+  // difference is taken about the point rather than forward from it.
+  const slopeAt = (tenths: number): number =>
+    sigmoid(fromRatio(2 * tenths + 1, 20)) - sigmoid(fromRatio(2 * tenths - 1, 20));
+  const middle = slopeAt(0);
+  for (const tenths of [1, 2, 5, 10, 20, -1, -2, -5, -10, -20]) {
+    assert.ok(slopeAt(tenths) < middle, `slope at ${String(tenths)}/10 should be below the slope at 0`);
+  }
+  assert.equal(slopeAt(3), slopeAt(-3), "and the slope is symmetric about zero");
+});
+
+test("logistic: e^-x matches published values", () => {
+  //   e^-0 = 1, e^-1 = 0.367879441171…, e^-2 = 0.135335283237…,
+  //   e^-5 = 0.006737946999…, e^-10 = 0.000045399929…
+  assert.equal(expNeg(ZERO), ONE);
+  assert.equal(expNeg(fromInt(1)), 367_879);
+  assert.equal(expNeg(fromInt(2)), 135_335);
+  assert.equal(expNeg(fromInt(5)), 6_738);
+  assert.equal(expNeg(fromInt(10)), 45);
+  assert.equal(expNeg(fromRatio(1, 2)), 606_531, "e^-0.5 = 0.606530659…");
+  assert.throws(() => expNeg(fromInt(-1)), RangeError);
+});
+
+test("logistic: σ and e^-x agree with each other", (t) => {
+  // σ(x)·(1 + e^-x) = 1. Computed through two different code paths, so this
+  // catches a reduction or series error that a single-path test would not.
+  let cases = 0;
+  for (let micro = 0; micro <= 6_000_000; micro += 7919) {
+    const x = fromMicro(micro);
+    const sigma = sigmoid(x);
+    const exponential = expNeg(x);
+    const product = (BigInt(sigma) * (BigInt(ONE) + BigInt(exponential))) / BigInt(ONE);
+    const drift = product - BigInt(ONE);
+    assert.ok(drift < 4n && drift > -4n, `σ(x)(1 + e^-x) drifted by ${drift.toString()} at ${String(micro)}`);
+    cases += 1;
+  }
+  t.diagnostic(`cross-checked σ against e^-x at ${String(cases)} points`);
+});

--- a/dynawalla/engine/src/math/logistic.ts
+++ b/dynawalla/engine/src/math/logistic.ts
@@ -1,0 +1,80 @@
+/**
+ * The logistic function, in integer arithmetic.
+ *
+ * `P = c + (1 − c)·σ(θ_s − b_item)` is the centre of the learner model, and σ needs
+ * an exponential. This computes it with BigInt at 10^-18 and rounds the answer to a
+ * millionth, so it is deterministic on every platform and contains no float.
+ *
+ * Method: reduce by 64, sum the Taylor series for `e^-r` (18 terms is far more than
+ * enough at |r| ≤ 0.32), then square six times. The residual error is around 10^-15
+ * relative — nine orders of magnitude below the millionth the result is rounded to.
+ * `logistic.test.ts` checks the output against published values of σ, which is an
+ * oracle independent of this implementation.
+ */
+
+import { ONE, ZERO, clamp, fromInt, fromMicro, neg, sub } from "./fixed.ts";
+import type { Fix } from "./fixed.ts";
+
+/** Exactly one half. σ(0) is this value and nothing near it. */
+export const HALF = fromMicro(500_000);
+
+const SCALE18 = 10n ** 18n;
+const MICRO_PER_SCALE18 = 10n ** 12n;
+const REDUCTION_SHIFTS = 6; // divide by 2^6 = 64, then square back six times
+const REDUCTION = 64n;
+const SERIES_TERMS = 18;
+
+/** Beyond this the result is 0 or 1 to the last millionth anyway. */
+export const SIGMOID_DOMAIN = fromInt(20);
+
+function divRound(numerator: bigint, denominator: bigint): bigint {
+  const q = numerator / denominator;
+  const r = numerator % denominator;
+  const twice = (r < 0n ? -r : r) * 2n;
+  if (twice < denominator) return q;
+  return numerator < 0n ? q - 1n : q + 1n;
+}
+
+/** `e^-x` at 10^-18, for `x >= 0`. */
+function expNeg18(x18: bigint): bigint {
+  const r = divRound(x18, REDUCTION);
+
+  let term = SCALE18;
+  let sum = SCALE18;
+  for (let k = 1; k <= SERIES_TERMS; k++) {
+    term = divRound(term * r, SCALE18 * BigInt(k));
+    sum = k % 2 === 0 ? sum + term : sum - term;
+  }
+
+  let value = sum;
+  for (let i = 0; i < REDUCTION_SHIFTS; i++) value = divRound(value * value, SCALE18);
+  return value;
+}
+
+/**
+ * `σ(x) = 1 / (1 + e^-x)`.
+ *
+ * Negative inputs are computed as `1 − σ(-x)` rather than directly, so the
+ * identity `σ(-x) = 1 − σ(x)` holds exactly at the millionth rather than up to a
+ * rounding step. A model whose predictions are not symmetric about zero would
+ * bias every difficulty decision in one direction.
+ */
+export function sigmoid(x: Fix): Fix {
+  const bounded = clamp(x, neg(SIGMOID_DOMAIN), SIGMOID_DOMAIN);
+  if (bounded === ZERO) return HALF;
+  if (bounded < 0) return sub(ONE, sigmoid(neg(bounded)));
+
+  const x18 = BigInt(bounded) * MICRO_PER_SCALE18;
+  const exp18 = expNeg18(x18);
+  const sigma18 = divRound(SCALE18 * SCALE18, SCALE18 + exp18);
+  const micro = divRound(sigma18, MICRO_PER_SCALE18);
+  return clamp(Number(micro) as Fix, ZERO, ONE);
+}
+
+/** `e^-x` as a fixed-point value, for `x >= 0`. Used by the decay terms. */
+export function expNeg(x: Fix): Fix {
+  if (x < 0) throw new RangeError("expNeg: negative exponent");
+  const bounded = clamp(x, ZERO, fromInt(40));
+  const value = expNeg18(BigInt(bounded) * MICRO_PER_SCALE18);
+  return Number(divRound(value, MICRO_PER_SCALE18)) as Fix;
+}

--- a/dynawalla/engine/src/scheduler.test.ts
+++ b/dynawalla/engine/src/scheduler.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Named invariant tests.
+ *
+ * TEST_STRATEGY.md: every scheduler invariant in ADAPTIVE_LEARNING.md is its own
+ * test with a name that matches the invariant's wording, so an invariant cannot be
+ * deleted from the code without a test disappearing loudly.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { BATCH_SIZE, ROLLING_WINDOW } from "./constants.ts";
+import { P_TARGET_DEFAULT, frustrationFloor } from "./controller.ts";
+import { fromRatio } from "./math/fixed.ts";
+import type { Fix } from "./math/fixed.ts";
+import { checkInterleaving, checkSequence, detectFatigue } from "./scheduler.ts";
+import type { PlannedCard, Pool } from "./scheduler.ts";
+
+let counter = 0;
+
+function card(overrides: Partial<PlannedCard> = {}): PlannedCard {
+  counter += 1;
+  const skillId = overrides.skillId ?? "dw.add.regroup.subtract-multidigit";
+  return {
+    cardId: `card-${String(counter)}`,
+    skillId,
+    level: 0,
+    formId: "free-entry",
+    seed: counter,
+    pool: "FRONTIER" as Pool,
+    intent: "steady",
+    pHat: P_TARGET_DEFAULT,
+    operation: "sub",
+    itemKey: `${skillId}#${String(counter)}`,
+    ...overrides,
+  };
+}
+
+function rules(violations: readonly { rule: string }[]): string[] {
+  return violations.map((violation) => violation.rule);
+}
+
+test("invariant: at most two consecutive cards from one skill", () => {
+  const ok = [card({ skillId: "a" }), card({ skillId: "a" }), card({ skillId: "b" })];
+  assert.deepEqual(rules(checkInterleaving(ok)), []);
+  const bad = [card({ skillId: "a" }), card({ skillId: "a" }), card({ skillId: "a" })];
+  assert.ok(rules(checkInterleaving(bad)).includes("max-consecutive-same-skill"));
+});
+
+test("invariant: a brand-new skill gets a blocked debut of three or four items", () => {
+  const debut = [
+    card({ skillId: "new" }),
+    card({ skillId: "new" }),
+    card({ skillId: "new" }),
+    card({ skillId: "b", operation: "add" }),
+  ];
+  assert.deepEqual(rules(checkInterleaving(debut, { reachableSkills: 1, debutSkill: "new" })), []);
+  assert.ok(rules(checkInterleaving(debut, { reachableSkills: 1 })).includes("max-consecutive-same-skill"));
+  const tooLong = Array.from({ length: 5 }, () => card({ skillId: "new" }));
+  assert.ok(
+    rules(checkInterleaving(tooLong, { reachableSkills: 1, debutSkill: "new" })).includes("max-consecutive-same-skill"),
+    "a blocked debut is three or four items, not five",
+  );
+});
+
+test("invariant: at most three cards of one operation per batch", () => {
+  const batch = Array.from({ length: 4 }, (_unused, index) =>
+    card({ skillId: `skill-${String(index)}`, operation: "mul" }),
+  );
+  assert.ok(rules(checkInterleaving(batch)).includes("max-per-operation"));
+  const mixed = [
+    card({ skillId: "a", operation: "mul" }),
+    card({ skillId: "b", operation: "sub" }),
+    card({ skillId: "c", operation: "mul" }),
+    card({ skillId: "d", operation: "add" }),
+  ];
+  assert.deepEqual(rules(checkInterleaving(mixed)), []);
+});
+
+test("invariant: at least three distinct skills once three are reachable", () => {
+  const two = [card({ skillId: "a" }), card({ skillId: "b" }), card({ skillId: "a" })];
+  assert.deepEqual(rules(checkInterleaving(two, { reachableSkills: 2 })), []);
+  assert.ok(rules(checkInterleaving(two, { reachableSkills: 3 })).includes("min-distinct-skills"));
+});
+
+test("invariant: repair items are at most a quarter of a batch (A-12)", () => {
+  const batch = Array.from({ length: BATCH_SIZE }, (_unused, index) =>
+    card({
+      skillId: `skill-${String(index % 4)}`,
+      operation: ["add", "sub", "mul", "div"][index % 4] ?? "add",
+      pool: index < 2 ? "REPAIR" : "FRONTIER",
+    }),
+  );
+  assert.deepEqual(rules(checkInterleaving(batch)), []);
+  const heavy = batch.map((entry, index) => (index < 3 ? { ...entry, pool: "REPAIR" as Pool } : entry));
+  assert.ok(rules(checkInterleaving(heavy)).includes("max-repair-share"));
+});
+
+test("invariant: never re-serve an identical item within six cards", () => {
+  const repeated = card({ itemKey: "same" });
+  const near = [repeated, card(), card(), { ...card(), itemKey: "same" }];
+  assert.ok(rules(checkSequence(near, [true, true, true, true], P_TARGET_DEFAULT)).includes("no-repeat-window"));
+  const far = [repeated, ...Array.from({ length: 6 }, () => card()), { ...card(), itemKey: "same" }];
+  assert.ok(!rules(checkSequence(far, far.map(() => true), P_TARGET_DEFAULT)).includes("no-repeat-window"));
+});
+
+test("invariant: never two consecutive items below pTarget − 0.20", () => {
+  const hard = frustrationFloor(P_TARGET_DEFAULT) - 1;
+  const two = [card({ pHat: hard as Fix }), card({ pHat: hard as Fix })];
+  assert.ok(rules(checkSequence(two, [false, false], P_TARGET_DEFAULT)).includes("no-two-hard-in-a-row"));
+  const spaced = [card({ pHat: hard as Fix }), card(), card({ pHat: hard as Fix })];
+  assert.ok(!rules(checkSequence(spaced, [false, true, false], P_TARGET_DEFAULT)).includes("no-two-hard-in-a-row"));
+});
+
+test("invariant: more than two failures in five forces a confidence card", () => {
+  const five = Array.from({ length: 5 }, () => card({ skillId: "a" }));
+  const outcomes = [false, false, false, true, true];
+  assert.ok(rules(checkSequence(five, outcomes, P_TARGET_DEFAULT)).includes("failure-relief"));
+  const relieved = five.map((entry, index) => (index === 3 ? { ...entry, intent: "confidence" as const } : entry));
+  assert.ok(!rules(checkSequence(relieved, outcomes, P_TARGET_DEFAULT)).includes("failure-relief"));
+});
+
+test("invariant: after three failures a skill is benched for the session", () => {
+  const cards = [
+    card({ skillId: "a" }),
+    card({ skillId: "a" }),
+    card({ skillId: "a" }),
+    card({ skillId: "a" }),
+  ];
+  assert.ok(
+    rules(checkSequence(cards, [false, false, false, false], P_TARGET_DEFAULT)).includes("bench-after-failures"),
+  );
+  const benched = cards.slice(0, 3);
+  assert.ok(!rules(checkSequence(benched, [false, false, false], P_TARGET_DEFAULT)).includes("bench-after-failures"));
+});
+
+test("invariant: never end a session on a failure", () => {
+  const cards = [card(), card()];
+  assert.ok(
+    rules(checkSequence(cards, [true, false], P_TARGET_DEFAULT, { sessionEnded: true })).includes("never-end-on-failure"),
+  );
+  assert.ok(
+    !rules(checkSequence(cards, [false, true], P_TARGET_DEFAULT, { sessionEnded: true })).includes("never-end-on-failure"),
+  );
+  assert.ok(
+    !rules(checkSequence(cards, [true, false], P_TARGET_DEFAULT, { sessionEnded: false })).includes("never-end-on-failure"),
+  );
+});
+
+test("invariant: at most 40% of a rolling 50-item window from one skill", () => {
+  // Tripling practice on one problem type had no effect on 1-week or 4-week test
+  // scores. Without this cap, a child who is good at times tables gets times
+  // tables for ever.
+  const skewed = Array.from({ length: ROLLING_WINDOW }, (_unused, index) =>
+    card({ skillId: index % 2 === 0 ? "a" : `b-${String(index)}` }),
+  );
+  assert.ok(rules(checkSequence(skewed, skewed.map(() => true), P_TARGET_DEFAULT)).includes("max-window-share"));
+  const spread = Array.from({ length: ROLLING_WINDOW }, (_unused, index) =>
+    card({ skillId: `skill-${String(index % 5)}` }),
+  );
+  assert.ok(!rules(checkSequence(spread, spread.map(() => true), P_TARGET_DEFAULT)).includes("max-window-share"));
+});
+
+test("fatigue: any two indicators, and never one", () => {
+  const none = {
+    latencyRising: false,
+    accuracyNowPoints: 80,
+    accuracyFirstThirdPoints: 82,
+    minutesElapsed: 10,
+    personalSessionMinutes: 20,
+  };
+  assert.equal(detectFatigue(none), false);
+  assert.equal(detectFatigue({ ...none, latencyRising: true }), false, "one indicator is not fatigue");
+  assert.equal(detectFatigue({ ...none, accuracyNowPoints: 55 }), false);
+  assert.equal(detectFatigue({ ...none, latencyRising: true, accuracyNowPoints: 55 }), true);
+  assert.equal(detectFatigue({ ...none, latencyRising: true, minutesElapsed: 25 }), true);
+  assert.equal(detectFatigue({ ...none, accuracyNowPoints: 62, minutesElapsed: 25 }), true);
+});
+
+test("scheduler: a healthy batch of eight trips no rule", () => {
+  const batch = Array.from({ length: BATCH_SIZE }, (_unused, index) =>
+    card({
+      skillId: `skill-${String(index % 4)}`,
+      operation: ["add", "sub", "mul", "div"][index % 4] ?? "add",
+      pool: index === 0 ? "REPAIR" : "FRONTIER",
+      pHat: fromRatio(80, 100),
+      intent: index === 0 ? "confidence" : "steady",
+    }),
+  );
+  assert.deepEqual(rules(checkInterleaving(batch, { reachableSkills: 4 })), []);
+  assert.deepEqual(rules(checkSequence(batch, batch.map(() => true), P_TARGET_DEFAULT)), []);
+});

--- a/dynawalla/engine/src/scheduler.ts
+++ b/dynawalla/engine/src/scheduler.ts
@@ -1,0 +1,282 @@
+/**
+ * The scheduler seam, its trace type, and the invariants a batch has to satisfy.
+ *
+ * The selection policy itself lands at PR-5.6. What is here is the shape it has to
+ * fit and the rules it has to obey — expressed as checkable functions rather than
+ * as prose, because gate EG-6 requires every anti-frustration and anti-stagnation
+ * rule to be its own named test, and a rule that only exists inside a scheduler
+ * implementation cannot be one.
+ *
+ * The anti-stagnation half is not polish. Tripling practice on one problem type
+ * (3 → 9 problems) had **no effect** on 1-week or 4-week test scores. Without the
+ * window cap and the Retired state, a child who is good at times tables gets times
+ * tables for ever — which is the difference between a tutor and a treadmill.
+ */
+
+import {
+  BENCH_AFTER_FAILURES,
+  DEBUT_BLOCK_MAX,
+  DEBUT_BLOCK_MIN,
+  FATIGUE_ACCURACY_DROP_POINTS,
+  FATIGUE_INDICATORS_REQUIRED,
+  MAX_CONSECUTIVE_SAME_SKILL,
+  MAX_PER_OPERATION,
+  MAX_REPAIR_FRACTION_PERCENT,
+  MAX_WINDOW_SHARE_PERCENT,
+  MIN_DISTINCT_SKILLS,
+  NO_REPEAT_WINDOW,
+  ROLLING_WINDOW,
+} from "./constants.ts";
+import { frustrationFloor } from "./controller.ts";
+import type { CardIntent } from "./controller.ts";
+import type { Fix } from "./math/fixed.ts";
+import type { LearnerState, SkillId } from "./types.ts";
+
+/** The nine pools a card can come from. */
+export type Pool =
+  | "REPAIR"
+  | "PREREQ"
+  | "DUE_FACT"
+  | "FRONTIER"
+  | "NEW"
+  | "FLUENCY"
+  | "REVIEW_SKILL"
+  | "CHALLENGE"
+  | "PLAY";
+
+export const REPAIR_POOLS: readonly Pool[] = ["REPAIR"];
+
+/**
+ * Produced by the **same code path that made the decision**, so the explanation in
+ * Developer Mode can never drift from the behaviour. Compiled out in production.
+ */
+export type SelectionTrace = {
+  readonly cardId: string;
+  readonly skillId: SkillId;
+  readonly pool: Pool;
+  readonly bTarget: Fix;
+  readonly bActual: Fix;
+  readonly pHat: Fix;
+  readonly pTargetBand: readonly [Fix, Fix];
+  readonly reasons: readonly string[];
+  readonly rejected: readonly string[];
+  readonly rngDraws: number;
+  readonly seed: number;
+};
+
+export type PlannedCard = {
+  readonly cardId: string;
+  readonly skillId: SkillId;
+  readonly level: number;
+  readonly formId: string;
+  readonly seed: number;
+  readonly pool: Pool;
+  readonly intent: CardIntent;
+  readonly pHat: Fix;
+  /** A tag the interleaving rule groups on — `add`, `sub`, `mul`, `div`. */
+  readonly operation: string;
+  /** Identifies the exact item, for the no-repeat window. */
+  readonly itemKey: string;
+  readonly trace?: SelectionTrace;
+};
+
+export type AppliedResult = {
+  readonly card: PlannedCard;
+  readonly correct: boolean;
+};
+
+/**
+ * The engine's whole public surface to the app. Both methods are pure: the state
+ * goes in and a new state comes out, with no persistence and no clock behind them.
+ */
+export type Scheduler = {
+  readonly name: string;
+  nextExercises(state: LearnerState, count: number): readonly PlannedCard[];
+  applyResult(state: LearnerState, result: AppliedResult): LearnerState;
+};
+
+export type Violation = {
+  readonly rule: string;
+  readonly detail: string;
+};
+
+/**
+ * Interleaving: within any batch of 8, ≤2 consecutive from one skill, ≤3 from one
+ * operation, ≥3 distinct skills once ≥3 are reachable.
+ *
+ * Interleaved practice *impairs* in-session performance while roughly **doubling**
+ * next-day test scores. That trade-off is surfaced in Developer Mode precisely so
+ * nobody "fixes" the deliberately depressed in-session accuracy.
+ *
+ * The one exception: a brand-new skill gets a blocked debut of 3–4 consecutive
+ * guided items.
+ */
+export function checkInterleaving(
+  batch: readonly PlannedCard[],
+  options: { readonly reachableSkills: number; readonly debutSkill?: SkillId } = { reachableSkills: 0 },
+): Violation[] {
+  const violations: Violation[] = [];
+  if (batch.length === 0) return violations;
+
+  let run = 1;
+  for (let i = 1; i < batch.length; i++) {
+    const current = batch[i];
+    const previous = batch[i - 1];
+    if (current === undefined || previous === undefined) continue;
+    if (current.skillId !== previous.skillId) {
+      run = 1;
+      continue;
+    }
+    run += 1;
+    const isDebut = options.debutSkill !== undefined && current.skillId === options.debutSkill;
+    const limit = isDebut ? DEBUT_BLOCK_MAX : MAX_CONSECUTIVE_SAME_SKILL;
+    if (run > limit) {
+      violations.push({
+        rule: "max-consecutive-same-skill",
+        detail: `${String(run)} consecutive cards from ${current.skillId} (limit ${String(limit)})`,
+      });
+      run = 0;
+    }
+  }
+
+  // The blocked-debut exception has to cover the operation rule as well as the
+  // consecutive-skill rule. ADAPTIVE_LEARNING.md states it against the latter, but
+  // four consecutive cards of one skill are necessarily four cards of one
+  // operation, so counting them against a limit of three would make the stated
+  // 3-4 card debut unsatisfiable. The debut cards are therefore excluded from the
+  // operation count, and only while the debut is itself within its stated length.
+  const debutCards =
+    options.debutSkill === undefined ? 0 : batch.filter((card) => card.skillId === options.debutSkill).length;
+  const legitimateDebut = debutCards >= DEBUT_BLOCK_MIN && debutCards <= DEBUT_BLOCK_MAX;
+
+  const perOperation = new Map<string, number>();
+  for (const card of batch) {
+    if (legitimateDebut && card.skillId === options.debutSkill) continue;
+    perOperation.set(card.operation, (perOperation.get(card.operation) ?? 0) + 1);
+  }
+  for (const [operation, count] of perOperation) {
+    if (count > MAX_PER_OPERATION) {
+      violations.push({
+        rule: "max-per-operation",
+        detail: `${String(count)} cards of operation ${operation} (limit ${String(MAX_PER_OPERATION)})`,
+      });
+    }
+  }
+
+  const distinct = new Set(batch.map((card) => card.skillId)).size;
+  if (options.reachableSkills >= MIN_DISTINCT_SKILLS && distinct < MIN_DISTINCT_SKILLS && !legitimateDebut) {
+    violations.push({
+      rule: "min-distinct-skills",
+      detail: `${String(distinct)} distinct skills with ${String(options.reachableSkills)} reachable`,
+    });
+  }
+
+  const repair = batch.filter((card) => REPAIR_POOLS.includes(card.pool)).length;
+  if (repair * 100 > batch.length * MAX_REPAIR_FRACTION_PERCENT) {
+    violations.push({
+      rule: "max-repair-share",
+      detail: `${String(repair)}/${String(batch.length)} repair cards (limit ${String(MAX_REPAIR_FRACTION_PERCENT)}%)`,
+    });
+  }
+
+  return violations;
+}
+
+/**
+ * The anti-frustration rules that are properties of a *sequence*: no identical item
+ * within 6 cards, never two consecutive items below `pTarget − 0.20`, never more
+ * than 2 failures in any window of 5 without a `pTarget + 0.10` card, a skill
+ * benched after 3 failures, and never ending a session on a failure.
+ */
+export function checkSequence(
+  cards: readonly PlannedCard[],
+  outcomes: readonly boolean[],
+  pTarget: Fix,
+  options: { readonly sessionEnded: boolean } = { sessionEnded: false },
+): Violation[] {
+  const violations: Violation[] = [];
+  const floor = frustrationFloor(pTarget);
+
+  cards.forEach((card, index) => {
+    const earlier = cards.slice(Math.max(0, index - NO_REPEAT_WINDOW), index);
+    if (earlier.some((other) => other.itemKey === card.itemKey)) {
+      violations.push({
+        rule: "no-repeat-window",
+        detail: `${card.itemKey} re-served within ${String(NO_REPEAT_WINDOW)} cards`,
+      });
+    }
+    const previous = index > 0 ? cards[index - 1] : undefined;
+    if (previous !== undefined && card.pHat < floor && previous.pHat < floor) {
+      violations.push({ rule: "no-two-hard-in-a-row", detail: `cards ${String(index - 1)} and ${String(index)}` });
+    }
+  });
+
+  for (let end = 5; end <= outcomes.length; end++) {
+    const fiveCards = outcomes.slice(end - 5, end);
+    const failures = fiveCards.filter((correct) => !correct).length;
+    if (failures <= 2) continue;
+    const relief = cards.slice(end - 5, end).some((card) => card.intent === "confidence");
+    if (!relief) {
+      violations.push({
+        rule: "failure-relief",
+        detail: `${String(failures)} failures in cards ${String(end - 5)}..${String(end - 1)} with no confidence card`,
+      });
+    }
+  }
+
+  const failuresBySkill = new Map<SkillId, number>();
+  cards.forEach((card, index) => {
+    if (outcomes[index] === false) {
+      const count = (failuresBySkill.get(card.skillId) ?? 0) + 1;
+      failuresBySkill.set(card.skillId, count);
+      const laterSameSkill = cards.slice(index + 1).some((other) => other.skillId === card.skillId);
+      if (count >= BENCH_AFTER_FAILURES && laterSameSkill) {
+        violations.push({ rule: "bench-after-failures", detail: `${card.skillId} served after ${String(count)} failures` });
+      }
+    }
+  });
+
+  if (options.sessionEnded && outcomes.length > 0 && outcomes.at(-1) === false) {
+    violations.push({ rule: "never-end-on-failure", detail: "the session's last card was failed" });
+  }
+
+  const perSkill = new Map<SkillId, number>();
+  const recent = cards.slice(-ROLLING_WINDOW);
+  for (const card of recent) perSkill.set(card.skillId, (perSkill.get(card.skillId) ?? 0) + 1);
+  for (const [skill, count] of perSkill) {
+    if (recent.length >= ROLLING_WINDOW && count * 100 > recent.length * MAX_WINDOW_SHARE_PERCENT) {
+      violations.push({
+        rule: "max-window-share",
+        detail: `${skill} is ${String(count)}/${String(recent.length)} of the rolling window`,
+      });
+    }
+  }
+
+  return violations;
+}
+
+export type FatigueSignals = {
+  /** Latency EWMA is rising while accuracy holds. */
+  readonly latencyRising: boolean;
+  /** Accuracy in this third of the session, in points. */
+  readonly accuracyNowPoints: number;
+  readonly accuracyFirstThirdPoints: number;
+  readonly minutesElapsed: number;
+  /** The child's own typical session length, in minutes. */
+  readonly personalSessionMinutes: number;
+};
+
+/**
+ * Fatigue is an **anti-punitive** mechanism, not a difficulty one: two indicators
+ * and the engine halves the evidence weight, raises `pTarget` to 0.90, stops
+ * introducing skills and stops scheduling repair. Assertion A-07 is that replaying
+ * a session with the post-fatigue window excluded yields an identical set of skill
+ * levels — zero demotions attributable to tiredness.
+ */
+export function detectFatigue(signals: FatigueSignals): boolean {
+  let indicators = 0;
+  if (signals.latencyRising) indicators += 1;
+  if (signals.accuracyFirstThirdPoints - signals.accuracyNowPoints >= FATIGUE_ACCURACY_DROP_POINTS) indicators += 1;
+  if (signals.minutesElapsed > signals.personalSessionMinutes) indicators += 1;
+  return indicators >= FATIGUE_INDICATORS_REQUIRED;
+}

--- a/dynawalla/engine/src/skill.test.ts
+++ b/dynawalla/engine/src/skill.test.ts
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  CREDIT_INCORRECT,
+  EVIDENCE_FULL,
+  EVIDENCE_HALVED,
+  MASTERED_MARGIN,
+  PRACTICED_MARGIN,
+  PREREQ_PROPAGATION,
+  RETIREMENT_DAYS,
+} from "./constants.ts";
+import { ONE, ZERO, abs, add, fromInt, fromRatio, mul, sub } from "./math/fixed.ts";
+import type { Fix } from "./math/fixed.ts";
+import { sigmoid } from "./math/logistic.ts";
+import {
+  applyAttempt,
+  masteryFor,
+  predictP,
+  propagateToPrerequisite,
+  seedSkill,
+  updateRate,
+} from "./skill.ts";
+import { NEW_SKILL_STATE } from "./types.ts";
+import type { AttemptOutcome, SkillState } from "./types.ts";
+
+const EASY = ZERO;
+const DAY = 100;
+
+function outcome(overrides: Partial<AttemptOutcome> = {}): AttemptOutcome {
+  return {
+    correct: true,
+    latencyMs: 3000,
+    revisions: 0,
+    itemDifficulty: ZERO,
+    guessFloor: ZERO,
+    fromChoice: false,
+    evidenceWeight: EVIDENCE_FULL,
+    ...overrides,
+  };
+}
+
+function state(overrides: Partial<SkillState> = {}): SkillState {
+  return { ...NEW_SKILL_STATE, ...overrides };
+}
+
+test("predictP: free entry has no guess floor, choice does", () => {
+  assert.equal(predictP(ZERO, ZERO, ZERO), sigmoid(ZERO), "σ(0) with no floor");
+  // c + (1 − c)·σ(0) with c = 1/4 is 0.25 + 0.75·0.5 = 0.625.
+  assert.equal(predictP(ZERO, ZERO, fromRatio(1, 4)), fromRatio(625, 1000));
+  // A four-way choice can never predict below its own floor, however hard the item.
+  assert.ok(predictP(fromInt(-8), fromInt(4), fromRatio(1, 4)) >= fromRatio(1, 4));
+  // σ(8) = 0.999665: an easy item for a strong child is nearly certain, never certain.
+  assert.ok(predictP(fromInt(4), fromInt(-4), ZERO) > fromRatio(999, 1000));
+  assert.ok(predictP(fromInt(4), fromInt(-4), ZERO) < ONE);
+});
+
+test("predictP: ability above item difficulty predicts better than a coin flip", () => {
+  const above = predictP(fromInt(1), ZERO, ZERO);
+  const level = predictP(ZERO, ZERO, ZERO);
+  const below = predictP(fromInt(-1), ZERO, ZERO);
+  assert.ok(above > level && level > below);
+  assert.equal(add(above, below), ONE, "and the model is symmetric about a matched item");
+});
+
+test("updateRate: U(n) = 0.9 / (1 + 0.06n)", () => {
+  assert.equal(updateRate(0), fromRatio(9, 10));
+  // 0.9 / 1.6 = 0.5625 at n = 10.
+  assert.equal(updateRate(10), fromRatio(5625, 10000));
+  // 0.9 / 4 = 0.225 at n = 50.
+  assert.equal(updateRate(50), fromRatio(225, 1000));
+  let previous = updateRate(0);
+  for (let n = 1; n <= 500; n++) {
+    const rate = updateRate(n);
+    assert.ok(rate < previous, `U(${String(n)}) should be below U(${String(n - 1)})`);
+    assert.ok(rate > ZERO, "the update never reaches zero");
+    previous = rate;
+  }
+  assert.throws(() => updateRate(-1), RangeError);
+});
+
+test("applyAttempt: a correct answer raises θ by U·w·(1 − P)", () => {
+  const before = state();
+  const result = applyAttempt(before, outcome(), EASY, DAY);
+  const expected = mul(updateRate(0), sub(ONE, result.predicted));
+  assert.equal(result.delta, expected);
+  assert.equal(result.state.theta, add(before.theta, expected));
+  assert.equal(result.state.attempts, 1);
+  assert.equal(result.state.correct, 1);
+  assert.equal(result.state.consecutiveFailures, 0);
+});
+
+test("applyAttempt: credit is asymmetric, so one mis-tap never craters a child", () => {
+  const up = applyAttempt(state(), outcome({ correct: true }), EASY, DAY);
+  const down = applyAttempt(state(), outcome({ correct: false }), EASY, DAY);
+  assert.ok(up.delta > ZERO && down.delta < ZERO);
+  // Both residuals are 0.5 in magnitude at θ = b, so the ratio is exactly the
+  // asymmetric credit: a wrong answer moves θ by 0.7 of what a right one does.
+  assert.equal(abs(down.delta), mul(abs(up.delta), CREDIT_INCORRECT));
+});
+
+test("applyAttempt: evidence weight scales the update without changing its sign", () => {
+  const full = applyAttempt(state(), outcome(), EASY, DAY);
+  const halved = applyAttempt(state(), outcome({ evidenceWeight: EVIDENCE_HALVED }), EASY, DAY);
+  assert.equal(halved.delta, mul(full.delta, EVIDENCE_HALVED));
+  assert.ok(halved.delta > ZERO);
+});
+
+test("applyAttempt: the update shrinks as evidence accumulates", () => {
+  let current = state();
+  let previous: Fix | undefined;
+  for (let i = 0; i < 20; i++) {
+    const result = applyAttempt(current, outcome({ itemDifficulty: current.theta }), EASY, DAY);
+    if (previous !== undefined) assert.ok(result.delta < previous, `step ${String(i)} did not shrink`);
+    previous = result.delta;
+    current = result.state;
+  }
+});
+
+test("applyAttempt: θ converges toward a child who gets a fixed item right about half the time", () => {
+  // A crude but real behavioural check: alternating right and wrong on an item of
+  // difficulty 1 should settle θ near 1, where P ≈ 0.5.
+  let current = state({ theta: fromInt(-3) });
+  for (let i = 0; i < 400; i++) {
+    current = applyAttempt(current, outcome({ correct: i % 2 === 0, itemDifficulty: fromInt(1) }), EASY, DAY).state;
+  }
+  assert.ok(abs(sub(current.theta, fromInt(1))) < fromRatio(6, 10), `θ settled at ${String(current.theta)}`);
+});
+
+test("propagateToPrerequisite: a prerequisite takes 0.15× and nothing else", () => {
+  const prereq = state({ theta: fromInt(1), attempts: 9, correct: 5 });
+  const delta = fromRatio(4, 10);
+  const moved = propagateToPrerequisite(prereq, delta);
+  assert.equal(moved.theta, add(prereq.theta, mul(PREREQ_PROPAGATION, delta)));
+  assert.equal(moved.attempts, prereq.attempts, "the prerequisite was not practised");
+  assert.equal(moved.correct, prereq.correct);
+  assert.equal(moved.level, prereq.level);
+});
+
+test("mastery: a choice item can never advance a skill past Practiced", () => {
+  const strong = state({
+    theta: add(EASY, add(MASTERED_MARGIN, fromInt(1))),
+    attempts: 40,
+    correct: 40,
+    freeEntryEvidence: false,
+  });
+  assert.equal(masteryFor(strong, EASY, DAY), "practiced");
+  assert.equal(masteryFor({ ...strong, freeEntryEvidence: true }, EASY, DAY), "mastered");
+});
+
+test("mastery: a correct free-entry answer is what unlocks the ceiling", () => {
+  let current = state({
+    theta: add(EASY, add(MASTERED_MARGIN, fromInt(2))),
+    attempts: 40,
+    correct: 40,
+    level: "practiced",
+    masteredSinceDay: DAY,
+    lastFailureDay: DAY,
+  });
+  current = applyAttempt(current, outcome({ fromChoice: true, itemDifficulty: fromInt(-4) }), EASY, DAY).state;
+  assert.equal(current.level, "practiced", "choice evidence alone stops here");
+  current = applyAttempt(current, outcome({ fromChoice: false, itemDifficulty: fromInt(-4) }), EASY, DAY).state;
+  assert.equal(current.level, "mastered");
+});
+
+test("mastery: promotion is never denied on latency alone (A-05)", () => {
+  const base = state({
+    theta: add(EASY, add(MASTERED_MARGIN, fromInt(1))),
+    attempts: 40,
+    correct: 40,
+    freeEntryEvidence: true,
+  });
+  const slow = { ...base, phi: ZERO };
+  const fluent = { ...base, phi: ONE };
+  assert.equal(masteryFor(slow, EASY, DAY), masteryFor(fluent, EASY, DAY));
+  assert.equal(masteryFor(slow, EASY, DAY), "mastered");
+});
+
+test("mastery: a Mastered skill unfailed for 21 days is Retired", () => {
+  const mastered = state({
+    theta: add(EASY, add(MASTERED_MARGIN, fromInt(1))),
+    attempts: 40,
+    correct: 40,
+    freeEntryEvidence: true,
+    level: "mastered",
+    masteredSinceDay: DAY,
+    lastFailureDay: DAY,
+  });
+  assert.equal(masteryFor(mastered, EASY, DAY + RETIREMENT_DAYS - 1), "mastered");
+  assert.equal(masteryFor(mastered, EASY, DAY + RETIREMENT_DAYS), "retired");
+  const recentlyFailed = { ...mastered, lastFailureDay: DAY + RETIREMENT_DAYS - 2 };
+  assert.equal(masteryFor(recentlyFailed, EASY, DAY + RETIREMENT_DAYS), "mastered", "the clock restarts on a failure");
+});
+
+test("mastery: a retired skill comes back on a real failure, not on a quiet day", () => {
+  const retired = state({
+    theta: add(EASY, add(MASTERED_MARGIN, fromInt(1))),
+    attempts: 40,
+    correct: 40,
+    freeEntryEvidence: true,
+    level: "retired",
+    consecutiveFailures: 0,
+  });
+  assert.equal(masteryFor(retired, EASY, DAY + 999), "retired");
+  assert.equal(masteryFor({ ...retired, consecutiveFailures: 1 }, EASY, DAY), "practiced");
+});
+
+test("mastery: Practiced needs both attempts and ability", () => {
+  const able = state({ theta: add(EASY, add(PRACTICED_MARGIN, fromInt(1))), attempts: 2 });
+  assert.equal(masteryFor(able, EASY, DAY), "new", "two attempts is not evidence");
+  assert.equal(masteryFor({ ...able, attempts: 6 }, EASY, DAY), "practiced");
+  const practised = state({ theta: sub(EASY, fromInt(1)), attempts: 20 });
+  assert.equal(masteryFor(practised, EASY, DAY), "new", "attempts without ability is not evidence either");
+});
+
+test("seedSkill: cold start places a child at a stated ability with no history", () => {
+  const seeded = seedSkill(fromRatio(-4, 10), DAY);
+  assert.equal(seeded.theta, fromRatio(-4, 10));
+  assert.equal(seeded.attempts, 0);
+  assert.equal(seeded.level, "new");
+  assert.equal(seeded.lastSeenDay, DAY);
+});
+
+test("state: a skill record has no field that can grow", () => {
+  // EG-3 is a claim about shape, not about usage: if every field is a bounded
+  // scalar then 500 sessions cost exactly what 5 do.
+  const populated = applyAttempt(state(), outcome(), EASY, DAY).state;
+  for (const [key, value] of Object.entries(populated)) {
+    assert.ok(
+      typeof value === "number" || typeof value === "boolean" || typeof value === "string",
+      `${key} is not a bounded scalar`,
+    );
+    if (typeof value === "string") {
+      assert.ok(value.length <= 16, `${key} is an unbounded string`);
+    }
+  }
+  assert.equal(Object.keys(populated).length, Object.keys(NEW_SKILL_STATE).length);
+});

--- a/dynawalla/engine/src/skill.ts
+++ b/dynawalla/engine/src/skill.ts
@@ -1,0 +1,165 @@
+/**
+ * Layer S — skill proficiency.
+ *
+ *   P    = c + (1 − c)·σ(θ_s − b_item)      c = guess floor: 0 free entry, 1/k choice
+ *   θ_s += U(n_s)·w·(y′ − P)                U(n) = 0.9 / (1 + 0.06n)
+ *
+ * with asymmetric credit (×1.0 correct, ×0.7 incorrect) so one mis-tap never
+ * craters a child, and 0.15× of the residual propagating to direct prerequisites.
+ *
+ * Every function here is pure: state in, state out, no clock, no randomness. The
+ * caller owns the day number, which is why `Day` is a parameter and not a lookup.
+ */
+
+import {
+  CREDIT_CORRECT,
+  CREDIT_INCORRECT,
+  FLUENCY_RATE,
+  MASTERED_MARGIN,
+  MASTERED_MIN_ATTEMPTS,
+  PRACTICED_MARGIN,
+  PRACTICED_MIN_ATTEMPTS,
+  PREREQ_PROPAGATION,
+  RETIREMENT_DAYS,
+  UPDATE_RATE_DECAY,
+  UPDATE_RATE_NUMERATOR,
+} from "./constants.ts";
+import { ONE, ZERO, add, div, fromInt, mul, sub } from "./math/fixed.ts";
+import type { Fix } from "./math/fixed.ts";
+import { sigmoid } from "./math/logistic.ts";
+import { NEW_SKILL_STATE } from "./types.ts";
+import type { AttemptOutcome, Day, MasteryLevel, SkillState } from "./types.ts";
+
+/**
+ * `P = c + (1 − c)·σ(θ − b)`.
+ *
+ * The guess floor is what stops a 4-way choice item being read as evidence of
+ * knowing something: a child who knows nothing still gets a quarter of them right,
+ * so the model must expect that before it updates on it.
+ */
+export function predictP(theta: Fix, itemDifficulty: Fix, guessFloor: Fix): Fix {
+  const base = sigmoid(sub(theta, itemDifficulty));
+  return add(guessFloor, mul(sub(ONE, guessFloor), base));
+}
+
+/** `U(n) = 0.9 / (1 + 0.06n)` — the update shrinks as evidence accumulates. */
+export function updateRate(attempts: number): Fix {
+  if (attempts < 0) throw new RangeError("updateRate: negative attempt count");
+  return div(UPDATE_RATE_NUMERATOR, add(ONE, mul(UPDATE_RATE_DECAY, fromInt(attempts))));
+}
+
+export type SkillUpdate = {
+  readonly state: SkillState;
+  /** The residual `U·w·(y′ − P)` that was applied. Prerequisites take 0.15× of it. */
+  readonly delta: Fix;
+  readonly predicted: Fix;
+};
+
+/**
+ * Apply one answered card to a skill.
+ *
+ * `skillDifficulty` is the node's own `b̄`, used only for the mastery decision —
+ * θ is meaningless without something to compare it to, and comparing it to the
+ * item that happened to be served would make promotion depend on the draw.
+ */
+export function applyAttempt(
+  state: SkillState,
+  outcome: AttemptOutcome,
+  skillDifficulty: Fix,
+  today: Day,
+): SkillUpdate {
+  const predicted = predictP(state.theta, outcome.itemDifficulty, outcome.guessFloor);
+  const observed = outcome.correct ? ONE : ZERO;
+  const credit = outcome.correct ? CREDIT_CORRECT : CREDIT_INCORRECT;
+  const weight = mul(credit, outcome.evidenceWeight);
+  const delta = mul(mul(updateRate(state.attempts), weight), sub(observed, predicted));
+
+  const attempts = state.attempts + 1;
+  const correct = state.correct + (outcome.correct ? 1 : 0);
+  const consecutiveFailures = outcome.correct ? 0 : state.consecutiveFailures + 1;
+
+  const moved: SkillState = {
+    ...state,
+    theta: add(state.theta, delta),
+    phi: updateFluency(state.phi, outcome),
+    attempts,
+    correct,
+    consecutiveFailures,
+    freeEntryEvidence: state.freeEntryEvidence || (outcome.correct && !outcome.fromChoice),
+    lastSeenDay: today,
+    lastFailureDay: outcome.correct ? state.lastFailureDay : today,
+  };
+
+  return { state: promote(moved, skillDifficulty, today), delta, predicted };
+}
+
+/**
+ * φ tracks *fluency*, not correctness: it rises on a fast correct answer and falls
+ * on a slow one. It never gates promotion — A-05 says no skill promotion is ever
+ * denied on latency alone — so it exists to route a child to short fluency bursts
+ * rather than to harder problems.
+ */
+function updateFluency(phi: Fix, outcome: AttemptOutcome): Fix {
+  if (!outcome.correct) return phi;
+  const fluent = outcome.latencyMs <= FLUENT_LATENCY_MS ? ONE : ZERO;
+  return add(phi, mul(FLUENCY_RATE, sub(fluent, phi)));
+}
+
+/** PROVISIONAL: the latency below which an answer counts as recalled, not computed. */
+export const FLUENT_LATENCY_MS = 4000;
+
+/**
+ * Decide the mastery level.
+ *
+ * Two rules here are not knobs:
+ *  - a choice item can never advance a skill past Practiced, so `freeEntryEvidence`
+ *    is required for Mastered;
+ *  - latency never blocks a promotion, so φ appears nowhere in this function.
+ */
+export function promote(state: SkillState, skillDifficulty: Fix, today: Day): SkillState {
+  const level = masteryFor(state, skillDifficulty, today);
+  if (level === state.level) return state;
+  return {
+    ...state,
+    level,
+    masteredSinceDay: level === "mastered" && state.level !== "mastered" ? today : state.masteredSinceDay,
+  };
+}
+
+export function masteryFor(state: SkillState, skillDifficulty: Fix, today: Day): MasteryLevel {
+  const mastered =
+    state.attempts >= MASTERED_MIN_ATTEMPTS &&
+    state.theta >= add(skillDifficulty, MASTERED_MARGIN) &&
+    state.consecutiveFailures === 0 &&
+    state.freeEntryEvidence;
+
+  if (mastered) {
+    // Retirement only applies to a skill that is *already* mastered. Retiring one
+    // at the moment it is promoted would hide it from the pools on the strength of
+    // day stamps that predate its mastery.
+    const alreadyMastered = state.level === "mastered" || state.level === "retired";
+    const quietSince = Math.max(state.masteredSinceDay, state.lastFailureDay);
+    const retired = alreadyMastered && today - quietSince >= RETIREMENT_DAYS;
+    return retired ? "retired" : "mastered";
+  }
+  if (state.level === "retired" || state.level === "mastered") {
+    // Demotion needs a real failure, not a quiet day.
+    return state.consecutiveFailures > 0 ? "practiced" : state.level;
+  }
+  const practiced = state.attempts >= PRACTICED_MIN_ATTEMPTS && state.theta >= add(skillDifficulty, PRACTICED_MARGIN);
+  return practiced ? "practiced" : "new";
+}
+
+/**
+ * A prerequisite gets 0.15× of the residual. Nothing else about it changes: it was
+ * not practised, so its attempt count, its streak and its mastery level are not
+ * evidence of anything new.
+ */
+export function propagateToPrerequisite(state: SkillState, delta: Fix): SkillState {
+  return { ...state, theta: add(state.theta, mul(PREREQ_PROPAGATION, delta)) };
+}
+
+/** Seed a skill at cold start. One grade question, no placement test. */
+export function seedSkill(theta: Fix, today: Day): SkillState {
+  return { ...NEW_SKILL_STATE, theta, lastSeenDay: today, lastFailureDay: today, masteredSinceDay: today };
+}

--- a/dynawalla/engine/src/types.ts
+++ b/dynawalla/engine/src/types.ts
@@ -1,0 +1,123 @@
+/**
+ * The learner model's data types.
+ *
+ * Three layers (ADAPTIVE_LEARNING.md): **S** skill proficiency, **F** fact memory,
+ * **B** misconception tracking. They are separate because the unit differs —
+ * `34 + 29` is computed, not recalled — and merging them is the mistake that makes
+ * spaced repetition degenerate into random practice.
+ *
+ * Every state record is **bounded by construction**: fixed fields, no arrays that
+ * grow with use, no free-form strings. That is what makes the 100 KB budget in
+ * gate EG-3 a property of the shape rather than a hope about usage.
+ *
+ * The engine does not import the curriculum. Ids are opaque strings here, so a
+ * curriculum change cannot force an engine rebuild and the two CI filters stay
+ * independent.
+ */
+
+import type { Fix } from "./math/fixed.ts";
+
+export type SkillId = string;
+export type BugId = string;
+/** `skill:<id>#L<level>#<formId>` — a class of item, never an instance (ADR-0008). */
+export type FactKey = string;
+
+/** Whole days since an arbitrary epoch. The engine never reads a clock (EG-1). */
+export type Day = number;
+
+export type MasteryLevel = "new" | "practiced" | "mastered" | "retired";
+
+/** 24 bytes packed: 2 fixed-point scalars, 4 small counters, 2 day stamps, 2 flags. */
+export type SkillState = {
+  /** θ: can do it. */
+  readonly theta: Fix;
+  /** φ: does it without counting. Never gates promotion (A-05). */
+  readonly phi: Fix;
+  readonly attempts: number;
+  readonly correct: number;
+  readonly consecutiveFailures: number;
+  readonly level: MasteryLevel;
+  /**
+   * Whether any correct answer came from free entry rather than a closed list.
+   * A choice item can never advance a skill past Practiced.
+   */
+  readonly freeEntryEvidence: boolean;
+  readonly lastSeenDay: Day;
+  readonly lastFailureDay: Day;
+  readonly masteredSinceDay: Day;
+};
+
+/** 12 bytes: one decayed count and one raw count. Sparse, hard-capped. */
+export type BugState = {
+  /** β ← 0.9·β + 1{bug fired}. Active at β ≥ 2.2. */
+  readonly beta: Fix;
+  readonly firings: number;
+};
+
+/** 20 bytes. The FSRS card; the scheduler that advances it is a seam, not code here. */
+export type FactCard = {
+  readonly stability: Fix;
+  readonly difficulty: Fix;
+  readonly dueDay: Day;
+  readonly reps: number;
+  readonly lapses: number;
+};
+
+export type Rating = "again" | "hard" | "good" | "easy";
+
+/** What the engine is told about one answered card. */
+export type AttemptOutcome = {
+  readonly correct: boolean;
+  readonly latencyMs: number;
+  /** Answer revisions before submitting. >0 then correct is a slip, never a bug. */
+  readonly revisions: number;
+  /** `b` of the item that was served. */
+  readonly itemDifficulty: Fix;
+  /** `c`: 0 for free entry, 1/k for a k-way choice. */
+  readonly guessFloor: Fix;
+  readonly fromChoice: boolean;
+  /** The mal-rule the answer matched, if exactly one did. */
+  readonly misconception?: BugId;
+  /** 1 normally; 0.5 when fatigued or on a first unclassified error; 0.3 for a lucky-looking choice. */
+  readonly evidenceWeight: Fix;
+};
+
+export type LatencyStats = {
+  /** Seconds, fixed-point. Seconds rather than milliseconds keeps the variance small. */
+  readonly meanS: Fix;
+  readonly varianceS2: Fix;
+  readonly count: number;
+};
+
+export type LearnerState = {
+  readonly pTarget: Fix;
+  readonly skills: Readonly<Record<SkillId, SkillState>>;
+  readonly bugs: Readonly<Record<string, BugState>>;
+  readonly facts: Readonly<Record<FactKey, FactCard>>;
+  readonly latency: LatencyStats;
+  readonly today: Day;
+};
+
+export const NEW_SKILL_STATE: SkillState = {
+  theta: 0 as Fix,
+  phi: 0 as Fix,
+  attempts: 0,
+  correct: 0,
+  consecutiveFailures: 0,
+  level: "new",
+  freeEntryEvidence: false,
+  lastSeenDay: 0,
+  lastFailureDay: 0,
+  masteredSinceDay: 0,
+};
+
+export const NEW_BUG_STATE: BugState = { beta: 0 as Fix, firings: 0 };
+
+/** The key a `BugState` is stored under: one entry per (skill, bug) pair. */
+export function bugKey(skill: SkillId, bug: BugId): string {
+  return `${skill}#${bug}`;
+}
+
+export function factKey(skill: SkillId, level: number, formId: string): FactKey {
+  return `skill:${skill}#L${String(level)}#${formId}`;
+}

--- a/dynawalla/engine/tsconfig.json
+++ b/dynawalla/engine/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "lib": ["es2023"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["node"],
+
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": false,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What

Create `dynawalla/curriculum/` and `dynawalla/engine/` as siblings of the app, and gate both
in CI. Both are importable and testable without building Tauri or touching a DOM —
`ARCHITECTURE.md`'s hard constraint, and what makes the mathematics verifiable in seconds.

Moves **M-05** (no floats), **M-06** (no bare-string prompts) and **M-07** (deterministic,
platform-stable generation) from UNMET to MET for the content that exists, and lands the
first implementations of gates **CG-1..CG-13, CG-16, CG-17, CG-19, CG-22** with a
failing-case test each — **M-13**'s mechanism, for seventeen of the twenty-two.

Master-plan order: this is deliberately out of order. `MASTER_PLAN.md` puts
`gen.arith.column-op` at PR-2.8, its three mal-rules at PR-2.9 and the engine at M5. The
foundations of all three land here because the engine and the curriculum are what every
later milestone measures against, and because `dynawalla/**` currently matches no CI job at
all — code merged there today is unverified.

## Why

- `dynawalla/**` has no CI job. PR #524 added the `dynawalla_*` filters as inert. Anything
  landing in these directories merges unchecked until a job consumes them.
- Exact arithmetic is the most common way a maths app ships wrong answers, and it fails
  *deterministically*: `0.1 + 0.2 !== 0.3` marks correct decimal work wrong and no
  flaky-test detector ever surfaces it. It has to be the first thing built and the first
  thing linted.
- The `5001 − 2798` mal-rule mapping was already got wrong once in this program. `3797` is
  smaller-from-larger, `3203` is borrow-across-zero, and CG-12 cannot tell them apart —
  both are individually valid and both diverge from `2203` on ~100% of seeds. Only an
  assertion on the worked example can.

## Blast radius

**Areas touched:** dynawalla (new), CI

- [x] Every touched path is covered by a `ci.yml` area filter. The two new jobs consume the
      existing `dynawalla_curriculum` / `dynawalla_engine` filters and feed the `ci-gate`
      aggregate. **No new required status context** — a path-gated required check would
      block the merge queue forever. `dynawalla/(curriculum|engine)/` also moves into the
      `uncovered` step's `covered` list, since it is now genuinely covered.
- [x] **Curriculum.** No skill id renamed or reused — these are the first four ids and
      `shipped-ids.json` is empty, because nothing has shipped. Answers are exact rationals
      over BigInt; a lint fails the build on a fractional literal, a transcendental `Math`
      member, `parseFloat` or `toFixed` anywhere in `curriculum/` or `engine/`. No skill is
      `active` without a passing generator binding (CG-7) and a renderer declaration for
      every answer schema it emits (CG-8).
- [x] **Strings.** No user-visible string ships here. Prompts and solutions are locale
      *keys* with typed slots; the templates themselves land with the number layer at M2.
- [x] **Secrets.** None.
- [ ] Pack back-compat, native integrity: N/A.

**Concurrency:** another agent is adding a `dynawalla-app` job to the same `ci.yml`. The edit
here is additive — two job blocks plus two entries on `ci-gate.needs` — so the only likely
conflict is that one `needs:` line.

**PR size: 380 KB, above `adversarial-review`'s 200,000-byte truncation.** Stated because it
will otherwise look reviewed when it is not. It does not split cleanly in two: `curriculum/`
alone is 264 KB. Reading order is `math/rational.ts` → `generators/columnOp/` →
`malrules/columnOp.ts` → `validate/`, then the engine.

## Proof

Node 24.18.0, from a clean `npm ci` in each package.

```
$ cd dynawalla/curriculum && npm test
ℹ tests 96
ℹ pass 96
ℹ fail 0
ℹ duration_ms 544.502750

ℹ field laws checked over 5000 generated triples
ℹ decimal round-trip checked over 5000 generated values
ℹ uniformity checked over 100000 draws into 10 buckets
ℹ 32500 generated items across 13 configurations
ℹ 6500 items regenerated and compared byte for byte
ℹ 499/500 seeds differ between two skills at the same parameters

$ cd dynawalla/engine && npm test
ℹ tests 72
ℹ pass 72
ℹ fail 0
ℹ duration_ms 231.731208

ℹ 20000 fixed-point operand pairs checked
ℹ 20000 products compared against exact BigInt arithmetic
ℹ symmetry checked at 12299 points
ℹ monotonicity checked at 51178 points
ℹ cross-checked σ against e^-x at 758 points
```

Both packages typecheck (`npm run tsc`, TypeScript 6.0.3, `erasableSyntaxOnly`).

### The gates

```
$ npm run check
dw-curriculum check — incremental, 200 seeds per level
nodes=4  activeNodes=3  levels=10  generatedItems=2000  malRules=3  families=1

  pass    CG-1   id hygiene and immutability
  pass    CG-2   acyclic requires ∪ extends
  pass    CG-3   edge integrity
  warn    CG-4   two-way reachability
         ! dw.add.regroup.add-multidigit: dead end: nothing requires it and nothing consumes what it provides
  pass    CG-5   grade sanity
  pass    CG-6   capability flow
  pass    CG-7   bidirectional generator ownership
  warn    CG-8   renderer ownership
         ! answer:integer: renderer is declared but not implemented yet — PR-2.3 owns it
         ! answer:columnAlgorithm: renderer is declared but not implemented yet — PR-2.4 owns it
  pass    CG-9   level coverage and difficulty table
  pass    CG-10  variant-space adequacy
  pass    CG-11  checker self-consistency
  pass    CG-12  mal-rule fidelity
  pass    CG-13  choice-laundering ban
  pending CG-14  locale round-trip
  pending CG-15  grade-band coverage matrix
  pass    CG-16  determinism and output snapshots
  pass    CG-17  generate() performance
  pending CG-18  representation accessibility
  pass    CG-19  i18n hygiene
  pending CG-20  standards traceback (report-only)
  pending CG-21  word-problem context sets
  pass    CG-22  LOCATE capability
  pass    M-05   exact arithmetic only

OK
```

Pending is printed, never counted as a pass: a gate table where an unimplemented gate reads
as green is worse than no table. The two warnings are the honest state — `add-multidigit`
has no dependents yet, and the two answer-schema renderers are declared with an owner but not
implemented. `--strict-renderers` turns those two warnings into failures, and **nothing runs
it today** — it is a CLI flag waiting for the renderers. PR-4.4 owns turning it on.

The full sweep, 10,000 generated items in 0.4 s. **Run by hand, not by a job:** GATES.md puts
it on a nightly with a named owner, that owner (`A-19`) is unassigned, and PR-4.6/4.17 own
wiring it up. CI runs `npm run check` — incremental, 200 seeds per level.

```
$ npm run check -- --full --report json
CG-9  pass | 752/1000 … 1000/1000 distinct per level
CG-10 pass | L0 ~2016 variants (248 collisions in 1000 draws) … L3 ~500000 variants
CG-11 pass | 10000 items checked
CG-12 pass | mis.add.smaller-from-larger 7000/7000 divergent
            | mis.add.borrow-across-zero  3155/3155 divergent
            | mis.add.carry-dropped       3000/3000 divergent
            | every node declares what its items emit, and nothing else
CG-17 pass | 10000 calls: p95 9 µs, p99 18 µs   (budget 5 ms / 20 ms)
```

CG-16's committed hashes are verified on **both** operating systems the gate names: the
`dynawalla-curriculum` job is a `[ubuntu-latest, macos-latest]` matrix. Checking them on one
runner would only prove they match whichever machine wrote them, and a generator that is not
platform-stable ships different exercises per device with CI green. Its scope, stated
plainly: **20 seeds per level, 200 items** — not the 2,000 the incremental run generates, and
not the 10,000 of the sweep. What the second runner adds is platform stability for those 200.

Byte-identical output is not the whole of determinism either, so CG-16 also scans both
packages for `localeCompare`, `Intl` and `Collator`. ICU collation agrees with itself
in-process and agrees across two runners carrying the same ICU data, and disagrees on a
device — the engine had one, in the tie-break that decides which tracked bug survives
pruning.

### The mal-rule mapping, asserted directly

```
5001 − 2798.  correct 2203
3797  mis.add.smaller-from-larger   |5−2| |0−7| |0−9| |1−8|
3203  mis.add.borrow-across-zero    = 2203 + exactly the 1,000 never given up
602 − 437.    correct 165, borrow-across-zero 265
```

Each rule *runs the buggy procedure* rather than computing a shortcut from the correct
answer; the "+1000" identity is asserted as a consequence, not used as the implementation.
`classify()` returns each id for its own output, `null` for the correct answer, `null` for
five other wrong answers, and `null` when two rules agree — a confident diagnosis naming one
of two equally likely bugs is worse than none, because Stage 2 would then show a contrast
pair built for a misconception the child may not hold.

### Where this diverges from the committed docs

All deliberate, all commented at the code:

1. **CG-10** is worded "<2% duplicates over 1,000 draws". Two-digit subtraction with one
   regrouping has ~1,600 distinct problems *in total*, so 1,000 draws collide ~25% of the
   time however good the generator is (measured: 248 collisions). The literal gate is
   unsatisfiable for every grade-1 level — and the 1,000 is the gate's sample size, which no
   child ever sees at one level. So the duplicate rate is stated about the run a child does
   experience, and the floor follows from it: at most one repeat in fifty over a 40-item
   practice run means `S ≥ (n−1)·D/2` = **975 problems per level**. The space is estimated
   from observed collisions, and that estimator is optimistic at high collision rates, so
   CG-9's hard `minVariants` count backs the gate up independently.
2. **CG-12** also checks the declaration half of the mal-rule contract: every id in a node's
   `misconceptions` resolves in the registry and belongs to the family the node binds, and
   every diagnosis the node's own items emit as a distractor is declared on the node.
   GATES.md words CG-12 as the divergence clause alone. Without this half the field is
   unvalidated metadata that repair routing reads — and it was already wrong:
   `subtract-multidigit` emits `mis.add.borrow-across-zero` on 155 of 4,000 items (a zero in
   the minuend is drawn, not asked for) and declared only `smaller-from-larger`. **GATES.md's
   CG-12 row wants a sentence added; it is outside this PR's file scope, so it is not edited
   here.**
3. **CG-16** carries a third check, the locale scan above. Same reasoning: the gate's stated
   claim is platform-stable output, and the two existing checks cannot see the one call that
   breaks it.
4. **Incremental mode** is seed-scoped, not diff-scoped. The graph is four nodes; a diff
   scoper today would be untested machinery guarding nothing. PR-4.6 owns it.
5. **The blocked-debut exception** in `ADAPTIVE_LEARNING.md` is stated against the
   consecutive-skill rule. Four consecutive cards of one skill are necessarily four cards of
   one operation, so counting them against "≤3 from one operation" would make the stated 3–4
   card debut unsatisfiable. The exception is read as covering both, and only while the debut
   is within its stated length.

One correction to the docs' own arithmetic, found by a test: a bug fires at β ≥ 2.2 after
three consecutive firings (1.0 → 1.9 → 2.71) and falls silent after **two** clean items
(2.439 → 2.195), not three.

### Review round: what changed after the adversarial review

The mathematics held — every worked example re-derived by hand checks out — but two things
did not, and both are fixed here.

**The walkthrough contradicted itself on the skill this product is named for.** `drawSub`
recorded a regrouping only on the column that *triggered* a borrow chain, so
`4007 − 2888` emitted: `regroup{column 0 → 17}`, then column steps asserting that column 1
was a 9, column 2 was a 9 and column 3 was a 3. The child sees `0`, `0` and `4`. Leaving the
zero run and the digit above it unchanged **is** `mis.add.borrow-across-zero` — so the faded
worked example for that skill demonstrated the misconception it exists to repair. It was
invisible because the only solution test checked the step *count*.

- One implementation of the correct column procedure (`generators/columnOp/procedure.ts`),
  read by the generator and by `correctBorrows`/`correctCarries`. Two copies of the borrow
  procedure is the divergence `params.ts` predicted, and this was it.
- A regroup step for every column the chain changed. Pinned by the full step list for
  `4007 − 2888`, for `5001 − 2798` (generated — seed 159579 of ~126,000 finds it) and for the
  two-digit case, plus a property over all 32,500 generated items: **a column step may never
  state a value the child has not been shown.**
- `procedure.ts` itself is pinned against a hand-derived table, column by column, so the one
  implementation cannot drift quietly.

**`pruneBugs` broke beta ties with `localeCompare`** — locale- and ICU-version-dependent,
disagreeing with code-unit order on the `-` these ids contain, in the tie-break deciding
which of 64 tracked bugs survives. Now `a < b ? -1 : a > b ? 1 : 0`, and both purity scans
catch the next one.

Also from the review: `misconceptions` is now gated (above); CG-10's floor is derived rather
than `minVariants × 12`, which restated what the author had already written; the validator
throws on an unreadable input instead of degrading CG-1 to a no-op that still prints `OK`;
the tautological `alsoAccept` is gone and the promise it stood for is asserted directly;
`serialize.ts` writes the schema field by field as its own header requires; `batchIntents`
places the stretch card where no confidence card can overwrite it; and `format()` documents
that it rounds below six places.

Output hashes were regenerated — the steps, the schema encoding and the empty `alsoAccept`
all change what a level serialises to. `familyRev` stays at 1: `gen.arith.column-op` is
introduced by this unmerged PR, `shipped-ids.json` is empty, and rev 1 has never existed
anywhere but on this branch.

### What is deliberately not here

The scheduler's selection policy (PR-5.6), FSRS-6 behind the `FactScheduler` seam (PR-5.5),
the simulation harness (PR-5.3), the number layer that CG-14 needs (PR-2.2), and the
renderers themselves (PR-2.3/2.4/2.10). Constants the documents pin are traced to them in
`engine/src/constants.ts`; constants the documents leave open are marked **PROVISIONAL** in
the same file, so that when a gate fails the label says whether to fix the code or question
the number.

