### PR TITLE
feat(dynawalla): the practice loop — structure-aware entry, exact judging, and the counting-board contrast pair

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,13 @@ jobs:
           # Dynawalla areas. No job consumes these yet — the filters land first
           # so the jobs that follow are a one-line addition instead of a
           # re-plumbing of this step.
-          set_output dynawalla_app '^(dynawalla/dynawalla-app/|\.github/workflows/ci\.yml$)'
+          # `dynawalla/curriculum/` is in here because the app compiles it: the
+          # practice loop imports the package's TypeScript source directly (it
+          # is private, has no build step and no resolvable name — see
+          # `src/work/curriculum.ts`). A curriculum change can therefore turn the
+          # app's tsc, tests or build red, and without this the app job would not
+          # run on the PR that did it.
+          set_output dynawalla_app '^(dynawalla/(dynawalla-app|curriculum)/|\.github/workflows/ci\.yml$)'
           # The committed slice of gen/android and the recorded template it was
           # curated from. `tauri android init` never overwrites an existing
           # file, which is what makes the allowlist survive a CI re-init — and

--- a/dynawalla/docs/ACCEPTANCE_CRITERIA.md
+++ b/dynawalla/docs/ACCEPTANCE_CRITERIA.md
@@ -569,8 +569,12 @@ them may be restated publicly as a claim about children.
       sessions on a reference device from a store build, on separate days. Recorded in
       `PLAYTEST-M2.md`: time to voluntary quit for each session, unprompted verbatims
       including the discouraging ones, next-day voluntary return (yes/no), where he got
-      stuck, and what he skipped or worked around.
-      Verify: `PLAYTEST-M2.md` committed, containing all six fields for both sessions
+      stuck, what he skipped or worked around, and **whether being wrong was the more
+      interesting event** — the `energy(SLIP) < energy(SEAT)` invariant, which
+      EXPERIENCE_DESIGN says a determined designer can satisfy in the unit test while
+      still making failure the moment worth reaching for, and which is therefore asked
+      here rather than only asserted.
+      Verify: `PLAYTEST-M2.md` committed, containing all seven fields for both sessions
       plus the device and build number, per [PLAYTEST-PROTOCOL.md](PLAYTEST-PROTOCOL.md)
       §4.
       Evidence: UNMET

--- a/dynawalla/docs/PLAYTEST-PROTOCOL.md
+++ b/dynawalla/docs/PLAYTEST-PROTOCOL.md
@@ -137,6 +137,7 @@ Per session. Everything here is observable — no inference, no scoring of the c
 | moments the child asked the observer a question | with the question |
 | moments the child looked away, sighed, or slumped | timestamp + what was on screen |
 | **what the child did after each wrong answer** | one of: retried, asked for the answer, studied the contrast, ignored it, quit |
+| **which moment he attended to more — right or wrong** | asked directly at the end ("which bit did you like watching?") *and* observed: whether he lingered on a struck card, whether he ever answered carelessly to reach one, whether he looked away during a correct answer |
 | **what the child skipped or avoided** | including anything he found a way around |
 | **next-day voluntary return** | yes / no |
 | anything the child did that the design did not anticipate | free text |
@@ -148,6 +149,16 @@ Per session. Everything here is observable — no inference, no scoring of the c
   for `T-03`: per-item correctness with the predicted `b()` for each item served,
   exported from Developer Mode. One child's residuals cannot calibrate `b()`; they can
   show a gross mismatch, and that is the whole claim made for them.
+- **M2 — the reaction asymmetry, asked as its own question.** EXPERIENCE_DESIGN makes
+  `energy(SLIP) < energy(SEAT)` a hard invariant *and* says outright that a determined
+  designer can satisfy the unit test while still making failure the interesting moment,
+  which is why it is playtested rather than only asserted. So `T-01` records it
+  explicitly: **is being wrong the more interesting event?** The structural facts to note
+  alongside the observation are how long each verdict is on screen, whether a wrong
+  answer buys more cards than a right one, and whether any illustration in the build is
+  reachable *only* by being wrong. A build where the contrast pair is the only picture is
+  a build where the honest answer to this question may be "yes" however the unit test
+  scores.
 - **M6** — whether the child can say, unprompted, **what** he is building and **why he
   chose it**; and whether the chosen-chamber mechanic visibly changed what he did.
 - **M8** — the accuracy of his **next attempt at the same mal-rule class** after a LOCATE

--- a/dynawalla/dynawalla-app/package.json
+++ b/dynawalla/dynawalla-app/package.json
@@ -13,7 +13,10 @@
     "tauri": "tauri",
     "tsc": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json && tsc --noEmit -p tsconfig.node.json",
     "lint": "eslint .",
-    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'"
+    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'",
+    "bench:generate": "node --experimental-strip-types --no-warnings=ExperimentalWarning tools/bench-generate.mjs",
+    "bench:loop": "node tools/bench-loop.mjs",
+    "drive:locate": "node tools/drive-locate.mjs"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.11.1",

--- a/dynawalla/dynawalla-app/src/app/router.tsx
+++ b/dynawalla/dynawalla-app/src/app/router.tsx
@@ -4,6 +4,7 @@ import { Shell } from "./Shell.tsx"
 import { ROUTE_PATHS } from "./routes.ts"
 import { Home } from "../screens/Home.tsx"
 import { Destination } from "../screens/Destination.tsx"
+import { PracticeScreen } from "../screens/Practice.tsx"
 import { SettingsScreen } from "../screens/Settings.tsx"
 
 // Hash routing, per ADR-0005: `tauri://` and `http://tauri.localhost` are
@@ -18,7 +19,7 @@ export const router = createHashRouter([
     element: <Shell />,
     children: [
       { index: true, element: <Home /> },
-      { path: ROUTE_PATHS.practice, element: <Destination />, handle: "practice" },
+      { path: ROUTE_PATHS.practice, element: <PracticeScreen />, handle: "practice" },
       { path: ROUTE_PATHS.world, element: <Destination />, handle: "world" },
       { path: ROUTE_PATHS.progress, element: <Destination />, handle: "progress" },
       { path: ROUTE_PATHS.profiles, element: <Destination />, handle: "profiles" },

--- a/dynawalla/dynawalla-app/src/app/routes.ts
+++ b/dynawalla/dynawalla-app/src/app/routes.ts
@@ -7,7 +7,12 @@
 
 export const ROUTE_PATHS = {
   home: "/",
-  /** `:skillId?` is optional: /practice resumes, /practice/<id> drills one skill. */
+  /**
+   * `:skillId?` is ADR-0005's pattern, not this screen's: **`PracticeScreen` does
+   * not read the parameter yet**, so `/practice/<id>` resumes the fixed ladder
+   * exactly as `/practice` does. Drilling one skill needs a scheduler to pin,
+   * which is M5. Nothing links a skill href today.
+   */
   practice: "/practice/:skillId?",
   world: "/world",
   progress: "/progress",
@@ -54,7 +59,12 @@ export function destinationPath(destination: Destination): string {
   return literalPrefix(ROUTE_PATHS[destination])
 }
 
-/** The href for one skill's practice session. */
+/**
+ * The href for one skill's practice session. Not linked from anywhere, and
+ * deliberately: it exists so `routes.test.ts` can ask the *installed* router
+ * whether ADR-0005's optional segment still matches — asserting the pattern
+ * string would pass on a version that had dropped the feature.
+ */
 export function practicePath(skillId: string): string {
   const base = literalPrefix(ROUTE_PATHS.practice)
   return `${base === "/" ? "" : base}/${encodeURIComponent(skillId)}`

--- a/dynawalla/dynawalla-app/src/app/strings.ts
+++ b/dynawalla/dynawalla-app/src/app/strings.ts
@@ -27,13 +27,18 @@ export const strings = {
     dark: "Dark",
   },
 
-  // The practice loop. Seven strings, and each one is either an action the child
-  // has to take or a label a screen reader has to read. There is no status copy,
-  // no encouragement and no narration of what the app is doing: a right answer
-  // is shown by the answer seating, a wrong one by the correct answer appearing
-  // beneath it, and neither needs a sentence. `done` and `keepGoing` are the
-  // equal-weight pair at a designed stopping point (P-10) — same plate, same
-  // size, no emphasis between them.
+  // The practice loop. Every string is either an action the child has to take or
+  // the text alternative for something drawn (`Q-10`). No status copy, no
+  // encouragement, no narration.
+  //
+  // Seven are text alternatives, added because the first cut had none: the verdict
+  // well's accessible text was the empty string on a correct answer, the operators
+  // were `aria-hidden` so an item read as "95 19", and every counter and socket on
+  // the board was `aria-hidden` with nothing in its place — "which board closes"
+  // was carried by colour. Five translations each is cheap against that.
+  //
+  // `done` and `keepGoing` are the equal-weight pair at a designed stopping point
+  // (P-10) — same plate, same size, no emphasis between them.
   practice: {
     /** The commit action. Explicit: an answer is never submitted by a keystroke count. */
     check: "Check",
@@ -46,5 +51,34 @@ export const strings = {
     delete: "Delete",
     /** The one line on the contrast card. It says what the two boards are doing. */
     rebuild: "Put it back together.",
+
+    /** The operators, read aloud. The glyphs themselves are decorative. */
+    minus: "minus",
+    plus: "plus",
+    /** The seated verdict, read aloud. The mark is decorative and colour is not a
+        text alternative, so without this the well announced nothing at all. */
+    correct: "Correct.",
+
+    /** One plate's check, read aloud: the visible `407 + 199 = 606`. */
+    boardSum: "{{addend}} plus {{subtrahend}} makes {{sum}}.",
+    /** One place column: sockets carved, counters sitting in them. */
+    boardPlace: "{{place}}: {{seated}} of {{sockets}}.",
+    /** …and the counters that could not sit. This is the contradiction, in words. */
+    boardSpare: "{{place}}: {{spare}} with nowhere to sit.",
+    /** Said of the plate that closes. Never its opposite — the plate that does not
+        close is described by what is left over, not by a verdict on the child. */
+    boardCloses: "Every counter has a place.",
   },
 } as const
+
+/**
+ * Substitute `{{slot}}` placeholders — the whole interpolation layer until PR-1.6
+ * brings the real one, in the syntax the locale bundles will use so the call
+ * sites do not change. An unknown slot is left standing rather than silently
+ * emptied: a visible `{{sum}}` in a translation is a bug report.
+ */
+export function fill(template: string, values: Record<string, string | number>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (slot, key: string) =>
+    key in values ? String(values[key]) : slot,
+  )
+}

--- a/dynawalla/dynawalla-app/src/app/strings.ts
+++ b/dynawalla/dynawalla-app/src/app/strings.ts
@@ -26,4 +26,25 @@ export const strings = {
     light: "Light",
     dark: "Dark",
   },
+
+  // The practice loop. Seven strings, and each one is either an action the child
+  // has to take or a label a screen reader has to read. There is no status copy,
+  // no encouragement and no narration of what the app is doing: a right answer
+  // is shown by the answer seating, a wrong one by the correct answer appearing
+  // beneath it, and neither needs a sentence. `done` and `keepGoing` are the
+  // equal-weight pair at a designed stopping point (P-10) — same plate, same
+  // size, no emphasis between them.
+  practice: {
+    /** The commit action. Explicit: an answer is never submitted by a keystroke count. */
+    check: "Check",
+    next: "Next",
+    done: "Done",
+    keepGoing: "Keep going",
+    /** Screen-reader label for the answer line. */
+    answer: "Answer",
+    /** Screen-reader label for the delete key. */
+    delete: "Delete",
+    /** The one line on the contrast card. It says what the two boards are doing. */
+    rebuild: "Put it back together.",
+  },
 } as const

--- a/dynawalla/dynawalla-app/src/design/tokens.css
+++ b/dynawalla/dynawalla-app/src/design/tokens.css
@@ -93,6 +93,15 @@
   /* Glazed tile — cool ceramic, for calm affirmative surfaces. */
   --color-tile-400: #45a3a8;
   --color-tile-600: #1f7379;
+  /* …and the same glaze as a wash, thin enough to be a ground rather than a
+     fill. Two entries because a wash is a material: on parchment the dark tile
+     at 14% is a tint you can see, and on basalt it is nothing at all, so the
+     dark theme washes with the lighter glaze and a little more of it. Written
+     as alpha rather than `color-mix` because this bundle's floor is iOS 16.0
+     and `color-mix` lands in 16.2 — an unsupported declaration would drop the
+     recess silently on the oldest devices we ship to. */
+  --color-tile-600-wash: rgb(31 115 121 / 0.14);
+  --color-tile-400-wash: rgb(69 163 168 / 0.18);
 
   /* Copper and its oxide — the tone of a struck, incorrect mark. */
   --color-copper-500: #a85b33;
@@ -141,6 +150,13 @@
      Neither is ever the only carrier of meaning (CG-18). */
   --dw-seat: var(--color-tile-600);
   --dw-strike: var(--color-copper-500);
+
+  /* The seat colour as a ground: the recess a correct answer settles into.
+     A role of its own, because `ground-sunk` cannot do this job — under
+     `.dw-dark` it and `ground-deep` are both basalt-950, so a recess drawn
+     with it is invisible on exactly the surface the answer sits on. Same class
+     of bug as the subtraction bar that disappeared in dark. */
+  --dw-seat-ground: var(--color-tile-600-wash);
 
   /* Case and frame. */
   --dw-case: var(--color-walnut-600);
@@ -214,6 +230,7 @@
 
   --dw-seat: var(--color-tile-400);
   --dw-strike: var(--color-copper-700);
+  --dw-seat-ground: var(--color-tile-400-wash);
 
   --dw-case: var(--color-walnut-800);
 

--- a/dynawalla/dynawalla-app/src/index.css
+++ b/dynawalla/dynawalla-app/src/index.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "./design/tokens.css";
+@import "./work/work.css";
 
 /* The theme class the shell toggles on <html>. `:where()` keeps specificity at
    zero so a dark utility never outranks a more specific rule by accident. */

--- a/dynawalla/dynawalla-app/src/screens/Practice.tsx
+++ b/dynawalla/dynawalla-app/src/screens/Practice.tsx
@@ -1,0 +1,179 @@
+import { useCallback, useEffect } from "react"
+import { useNavigate } from "react-router"
+
+import { Destination } from "./Destination.tsx"
+import { strings } from "../app/strings.ts"
+import { entryModelFor, glyphFromKey } from "../work/entry.ts"
+import { now, record } from "../work/metrics.ts"
+import { autoAdvanceMs, committable, enterAction } from "../work/session.ts"
+import { scheduleDeckFill, usePractice } from "../work/store.ts"
+import { CountingBoardCard } from "../work/ui/CountingBoardCard.tsx"
+import { Keypad } from "../work/ui/Keypad.tsx"
+import { Plate } from "../work/ui/Plate.tsx"
+import { ProblemSlate } from "../work/ui/ProblemSlate.tsx"
+
+/**
+ * The practice loop.
+ *
+ * The screen is a renderer and a scheduler. Every decision — what the answer is,
+ * which misconception a wrong one matches, what comes next — was made in
+ * `src/work/*.ts` by a pure function, which is what makes any of it testable
+ * without a browser.
+ *
+ * Three timing rules are implemented here and nowhere else:
+ *
+ *   * The commit span is measured from the input event to the frame that paints
+ *     the verdict — a double `requestAnimationFrame`, because the first one runs
+ *     before the paint it schedules.
+ *   * The deck is topped up from `requestIdleCallback`, so the problem after the
+ *     one on screen is generated while the child is reading, never when they
+ *     answer.
+ *   * A seated answer holds for `SEAT_HOLD_MS` and then presents the next card
+ *     by itself. A struck one never auto-advances: the child is looking at the
+ *     correct answer and taking that away is the app deciding it has finished
+ *     with them.
+ */
+export function PracticeScreen() {
+  const session = usePractice((state) => state.session)
+  const begin = usePractice((state) => state.begin)
+  const press = usePractice((state) => state.press)
+  const commitAnswer = usePractice((state) => state.commitAnswer)
+  const next = usePractice((state) => state.next)
+  const end = usePractice((state) => state.end)
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    begin()
+  }, [begin])
+
+  // Idle generation. Re-armed whenever the session changes, which is more often
+  // than strictly needed and costs nothing: `prepare` returns the same state
+  // when there is no work, so the store does not even re-render.
+  useEffect(() => scheduleDeckFill(), [session])
+
+  // Commit, and time the frame the verdict lands on.
+  //
+  // The measurement is here rather than in an effect on purpose: an effect keyed
+  // on the session re-runs when the idle pass tops the deck up, cancelling the
+  // pending frame callback and dropping roughly a quarter of the samples. Two
+  // frames, because the first callback runs *before* the paint it was scheduled
+  // for and the second runs after it.
+  const commitNow = useCallback(() => {
+    const started = now()
+    commitAnswer()
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        record("commitToFeedback", now() - started)
+      })
+    })
+  }, [commitAnswer])
+
+  // A seated answer presents the next card on its own.
+  useEffect(() => {
+    if (session === null) return
+    const hold = autoAdvanceMs(session)
+    if (hold === null) return
+    const handle = setTimeout(next, hold)
+    return () => clearTimeout(handle)
+  }, [session, next])
+
+  // The hardware keyboard, at the window, so the loop is fully operable without
+  // ever hitting Tab. Enter is left alone while a button has focus — that is the
+  // button's activation and stealing it would break keyboard-only operation
+  // rather than improve it.
+  useEffect(() => {
+    if (session === null) return
+    const onKeyDown = (event: KeyboardEvent) => {
+      const glyph = glyphFromKey(event.key)
+      if (glyph !== null) {
+        event.preventDefault()
+        press({ kind: "glyph", glyph })
+        return
+      }
+      if (event.key === "Backspace") {
+        event.preventDefault()
+        press({ kind: "delete" })
+        return
+      }
+      if (event.key === "Escape") {
+        event.preventDefault()
+        press({ kind: "clear" })
+        return
+      }
+      if (event.key === "Enter" && !(document.activeElement instanceof HTMLButtonElement)) {
+        event.preventDefault()
+        if (enterAction(session) === "commit") commitNow()
+        else next()
+      }
+    }
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [session, press, commitNow, next])
+
+  if (session === null) return <Destination />
+
+  const { card, entry, feedback } = session
+  const model = card.kind === "problem" ? entryModelFor(card.exercise.schema) : undefined
+
+  return (
+    <Destination>
+      <div className="flex flex-col gap-6">
+        {card.kind === "problem" ? (
+          <ProblemSlate
+            key={card.exercise.exerciseId}
+            card={card}
+            entry={entry}
+            feedback={feedback}
+          />
+        ) : (
+          <CountingBoardCard board={card.board} />
+        )}
+
+        {/* Capped and centred: on a tablet an uncapped three-column grid makes
+            each key a 220 px slab across the whole plate, which is further from
+            a thumb than it is from the last key. The cap keeps the pad the size
+            of a hand at every width. */}
+        <div className="mx-auto flex w-full max-w-xs flex-col gap-4">
+          {/* The keypad stays mounted while a verdict is up, disabled rather
+              than removed. Unmounting it would pull the action row a hundred
+              pixels up the screen at the exact moment the child is looking at
+              their answer — the jolting reflow the design rules forbid. */}
+          {card.kind === "problem" && model !== undefined ? (
+            <Keypad
+              model={model}
+              schema={card.exercise.schema}
+              onKey={press}
+              disabled={feedback !== null}
+            />
+          ) : null}
+
+          <div className="flex gap-3">
+            {session.stopping ? (
+              <>
+                <Plate
+                  onPress={() => {
+                    // Ends the run, not the progress: the ladder position, the
+                    // seed cursor and the totals are already persisted. Coming
+                    // back gives a fresh card where they left off rather than
+                    // the one they walked away from.
+                    end()
+                    void navigate("/")
+                  }}
+                >
+                  {strings.practice.done}
+                </Plate>
+                <Plate onPress={next}>{strings.practice.keepGoing}</Plate>
+              </>
+            ) : feedback === null && card.kind === "problem" ? (
+              <Plate onPress={commitNow} disabled={!committable(session)}>
+                {strings.practice.check}
+              </Plate>
+            ) : (
+              <Plate onPress={next}>{strings.practice.next}</Plate>
+            )}
+          </div>
+        </div>
+      </div>
+    </Destination>
+  )
+}

--- a/dynawalla/dynawalla-app/src/work/contrast.ts
+++ b/dynawalla/dynawalla-app/src/work/contrast.ts
@@ -1,0 +1,127 @@
+// The Stage-2 LOCATE contrast pair, on the counting board.
+//
+// This is the mechanism the product is named for, so it is worth being exact
+// about what it does and does not claim.
+//
+// A child who answers `5001 − 2798 = 3203` regrouped all the way down through the
+// zeros, wrote them as 9s, and never took the thousand off the leading digit. The
+// answer is the correct one plus exactly the 1,000 that was borrowed and never
+// given up. That surplus is not an abstraction: put the answer back together with
+// the subtrahend and the board holds `6001` where `5001` was carved. One counter
+// has no socket. The contradiction is a thing on the board, not a sentence.
+//
+//   correct   2203 + 2798 = 5001   every counter seats
+//   yours     3203 + 2798 = 6001   one thousand-counter left over
+//
+// The *pair* is those two boards side by side. Neither board on its own is a
+// contrast: "you were wrong" is the left one alone, and the right one alone is a
+// worked example. What makes it an explanation rather than a verdict is that the
+// child's own procedure is carried out faithfully to the point where it fails to
+// close.
+//
+// The distinction the program has already got wrong once: `3797` on this same
+// problem is a *different* rule (`mis.add.smaller-from-larger`, taking the smaller
+// digit from the larger in every column). It is not off by a place-value unit at
+// all, so the counting board is not its contradiction and it must never be served
+// this card. `judge.ts` decides that; this module only draws what it is given and
+// returns `null` when the board cannot honestly be built.
+
+import { exact } from "./curriculum.ts"
+import type { AnswerValue, Exercise } from "./curriculum.ts"
+import { digitsOf, readProblem } from "./problem.ts"
+
+export interface BoardColumn {
+  /** The power of ten this column holds: 3 is thousands. */
+  readonly place: number
+  /** Counters carved into the board — what the top number actually is. */
+  readonly sockets: number
+  /** Counters the check put there. Above `sockets`, they have nowhere to sit. */
+  readonly counters: number
+}
+
+export interface BoardCheck {
+  /** The answer being put back, as written. */
+  readonly addend: string
+  /** `addend + subtrahend`, as written. */
+  readonly sum: string
+  readonly columns: readonly BoardColumn[]
+  /** Does the board close — does the check rebuild the number it started from? */
+  readonly rebuilds: boolean
+}
+
+export interface CountingBoard {
+  readonly minuend: string
+  readonly subtrahend: string
+  readonly correct: BoardCheck
+  readonly yours: BoardCheck
+  /** The place value of the surplus, e.g. 3 for a thousand. `null` if none. */
+  readonly surplusPlace: number | null
+}
+
+function columnsFor(sum: bigint, target: bigint): BoardColumn[] {
+  const width = Math.max(sum.toString().length, target.toString().length)
+  const sumDigits = digitsOf(sum)
+  const targetDigits = digitsOf(target)
+  const out: BoardColumn[] = []
+  for (let i = 0; i < width; i++) {
+    const place = width - 1 - i
+    out.push({
+      place,
+      sockets: targetDigits[targetDigits.length - 1 - place] ?? 0,
+      counters: sumDigits[sumDigits.length - 1 - place] ?? 0,
+    })
+  }
+  return out
+}
+
+function checkFor(addend: bigint, subtrahend: bigint, target: bigint): BoardCheck {
+  const sum = addend + subtrahend
+  return {
+    addend: addend.toString(),
+    sum: sum.toString(),
+    columns: columnsFor(sum, target),
+    rebuilds: sum === target,
+  }
+}
+
+/**
+ * The board for this item and this wrong answer, or `null` when it cannot be
+ * drawn honestly.
+ *
+ * `null` is returned for a non-subtraction item, a decimal one (the board is a
+ * whole-unit place-value board), a wrong answer that happens to rebuild the
+ * minuend anyway, and anything whose values are not exact whole numbers. Every
+ * one of those is a case where the two plates would look identical or the
+ * contradiction would not be visible, and a LOCATE card that shows no
+ * contradiction is worse than a Stage-1 strike mark. The caller falls back.
+ */
+export function countingBoard(exercise: Exercise, submitted: AnswerValue): CountingBoard | null {
+  const problem = readProblem(exercise)
+  if (problem === null || problem.op !== "sub" || problem.decimalPlaces !== 0) return null
+  if (submitted.kind !== "integer" && submitted.kind !== "columnAlgorithm") return null
+
+  const yours = exact.toScaled(submitted.value, 0)
+  const canonical = exercise.answer.canonical
+  if (canonical.kind !== "integer" && canonical.kind !== "columnAlgorithm") return null
+  const right = exact.toScaled(canonical.value, 0)
+  if (yours === null || right === null || yours < 0n) return null
+
+  const { topScaled: minuend, bottomScaled: subtrahend } = problem
+  const yourCheck = checkFor(yours, subtrahend, minuend)
+  if (yourCheck.rebuilds) return null
+
+  const correctCheck = checkFor(right, subtrahend, minuend)
+  // The correct answer must close the board. If it does not, the item is
+  // inconsistent and nothing here is worth showing a child.
+  if (!correctCheck.rebuilds) return null
+
+  const surplus = yourCheck.columns.find((column) => column.counters > column.sockets)
+
+  return {
+    minuend: problem.top,
+    subtrahend: problem.bottom,
+    correct: correctCheck,
+    yours: yourCheck,
+    surplusPlace: surplus?.place ?? null,
+  }
+}

--- a/dynawalla/dynawalla-app/src/work/contrast.ts
+++ b/dynawalla/dynawalla-app/src/work/contrast.ts
@@ -7,8 +7,9 @@
 // zeros, wrote them as 9s, and never took the thousand off the leading digit. The
 // answer is the correct one plus exactly the 1,000 that was borrowed and never
 // given up. That surplus is not an abstraction: put the answer back together with
-// the subtrahend and the board holds `6001` where `5001` was carved. One counter
-// has no socket. The contradiction is a thing on the board, not a sentence.
+// the subtrahend and you are holding `6001` worth of counters over a board carved
+// for `5001`. One counter has no socket. The contradiction is a thing on the
+// board, not a sentence.
 //
 //   correct   2203 + 2798 = 5001   every counter seats
 //   yours     3203 + 2798 = 6001   one thousand-counter left over
@@ -19,6 +20,30 @@
 // child's own procedure is carried out faithfully to the point where it fails to
 // close.
 //
+// ## Quantity, not digits — the bug this module was rewritten to kill
+//
+// The first version compared the **decimal digits** of `answer + subtrahend`
+// against the digits of the minuend, place by place. That is a digit comparison
+// in a quantity comparison's clothes, and the two agree only where the surplus
+// does not carry. On `903 − 778` (correct 125, the bug gives 225) the check is
+// `225 + 778 = 1003`; digit-wise against 903 that reads hundreds 9 sockets / *0*
+// counters, so the plate drew nine EMPTY hundreds beside a diamond in a column
+// the correct plate did not have. A child shaky on regrouping through zero reads
+// that as "I lost all nine hundreds" — a second misconception, taught on the one
+// screen whose job is to repair the first. Measured: 11–16% of contrast cards on
+// every rung the diagnosis reaches, 4,000 seeds per rung.
+//
+// A board is a quantity. 1003 in counters over a board carved for 903 fills every
+// socket and leaves 1003 − 903 = 100 standing outside; counters trade ten-for-one,
+// so any quantity at or above the carved total fills the sockets exactly and the
+// remainder is drawn in the places its own digits name. Both plates are built as
+// *sockets, all seated, plus the surplus* — never a digit-by-digit diff — so a
+// plate can never show an empty socket its partner fills.
+//
+// A check coming to **less** than the board holds has no honest place-by-place
+// drawing (only empty sockets and stranded counters at once), so it returns
+// `null` and the caller falls back to Stage 1.
+//
 // The distinction the program has already got wrong once: `3797` on this same
 // problem is a *different* rule (`mis.add.smaller-from-larger`, taking the smaller
 // digit from the larger in every column). It is not off by a place-value unit at
@@ -28,15 +53,17 @@
 
 import { exact } from "./curriculum.ts"
 import type { AnswerValue, Exercise } from "./curriculum.ts"
-import { digitsOf, readProblem } from "./problem.ts"
+import { readProblem } from "./problem.ts"
 
 export interface BoardColumn {
   /** The power of ten this column holds: 3 is thousands. */
   readonly place: number
   /** Counters carved into the board — what the top number actually is. */
   readonly sockets: number
-  /** Counters the check put there. Above `sockets`, they have nowhere to sit. */
-  readonly counters: number
+  /** Counters sitting in those sockets. Never more than `sockets`. */
+  readonly seated: number
+  /** Counters this check has left with nowhere to sit. */
+  readonly spare: number
 }
 
 export interface BoardCheck {
@@ -44,6 +71,7 @@ export interface BoardCheck {
   readonly addend: string
   /** `addend + subtrahend`, as written. */
   readonly sum: string
+  /** One entry per place in `CountingBoard.places`, in the same order. */
   readonly columns: readonly BoardColumn[]
   /** Does the board close — does the check rebuild the number it started from? */
   readonly rebuilds: boolean
@@ -52,34 +80,40 @@ export interface BoardCheck {
 export interface CountingBoard {
   readonly minuend: string
   readonly subtrahend: string
+  /**
+   * The one column set both plates are drawn over, highest place first.
+   *
+   * Shared, not per-plate: if one plate omits its empty leading places, its
+   * hundreds sit under the other's thousands and the comparison the card exists
+   * to make is not available. An empty place is still a column.
+   */
+  readonly places: readonly number[]
   readonly correct: BoardCheck
   readonly yours: BoardCheck
-  /** The place value of the surplus, e.g. 3 for a thousand. `null` if none. */
-  readonly surplusPlace: number | null
 }
 
-function columnsFor(sum: bigint, target: bigint): BoardColumn[] {
-  const width = Math.max(sum.toString().length, target.toString().length)
-  const sumDigits = digitsOf(sum)
-  const targetDigits = digitsOf(target)
-  const out: BoardColumn[] = []
-  for (let i = 0; i < width; i++) {
-    const place = width - 1 - i
-    out.push({
-      place,
-      sockets: targetDigits[targetDigits.length - 1 - place] ?? 0,
-      counters: sumDigits[sumDigits.length - 1 - place] ?? 0,
-    })
-  }
-  return out
+/** The digit of `value` at a power of ten. `value` is non-negative. */
+function digitAt(value: bigint, place: number): number {
+  return Number((value / 10n ** BigInt(place)) % 10n)
 }
 
-function checkFor(addend: bigint, subtrahend: bigint, target: bigint): BoardCheck {
+/** One plate: every socket filled, plus whatever the check leaves over.
+ *  `sum >= target` is the caller's guarantee, which is what makes "every" true. */
+function checkFor(
+  addend: bigint,
+  subtrahend: bigint,
+  target: bigint,
+  places: readonly number[],
+): BoardCheck {
   const sum = addend + subtrahend
+  const spare = sum - target
   return {
     addend: addend.toString(),
     sum: sum.toString(),
-    columns: columnsFor(sum, target),
+    columns: places.map((place) => {
+      const sockets = digitAt(target, place)
+      return { place, sockets, seated: sockets, spare: digitAt(spare, place) }
+    }),
     rebuilds: sum === target,
   }
 }
@@ -88,12 +122,12 @@ function checkFor(addend: bigint, subtrahend: bigint, target: bigint): BoardChec
  * The board for this item and this wrong answer, or `null` when it cannot be
  * drawn honestly.
  *
- * `null` is returned for a non-subtraction item, a decimal one (the board is a
- * whole-unit place-value board), a wrong answer that happens to rebuild the
- * minuend anyway, and anything whose values are not exact whole numbers. Every
- * one of those is a case where the two plates would look identical or the
- * contradiction would not be visible, and a LOCATE card that shows no
- * contradiction is worse than a Stage-1 strike mark. The caller falls back.
+ * `null` for: a non-subtraction item, a decimal one (this board is whole-unit),
+ * values that are not exact whole numbers, an answer that rebuilds the minuend
+ * anyway, and an answer whose check comes to *less* than the board holds. In
+ * every one the plates look identical or the contradiction is not a single
+ * readable thing, and a LOCATE card showing no contradiction is worse than a
+ * Stage-1 strike mark. The caller falls back.
  */
 export function countingBoard(exercise: Exercise, submitted: AnswerValue): CountingBoard | null {
   const problem = readProblem(exercise)
@@ -107,21 +141,24 @@ export function countingBoard(exercise: Exercise, submitted: AnswerValue): Count
   if (yours === null || right === null || yours < 0n) return null
 
   const { topScaled: minuend, bottomScaled: subtrahend } = problem
-  const yourCheck = checkFor(yours, subtrahend, minuend)
-  if (yourCheck.rebuilds) return null
 
-  const correctCheck = checkFor(right, subtrahend, minuend)
   // The correct answer must close the board. If it does not, the item is
   // inconsistent and nothing here is worth showing a child.
-  if (!correctCheck.rebuilds) return null
+  if (right + subtrahend !== minuend) return null
 
-  const surplus = yourCheck.columns.find((column) => column.counters > column.sockets)
+  // The child's check must overflow the board: strictly more than it holds. Equal
+  // is not a contradiction, and less has no honest place-by-place drawing.
+  const yourSum = yours + subtrahend
+  if (yourSum <= minuend) return null
+
+  const width = Math.max(minuend.toString().length, yourSum.toString().length)
+  const places = Array.from({ length: width }, (_, i) => width - 1 - i)
 
   return {
     minuend: problem.top,
     subtrahend: problem.bottom,
-    correct: correctCheck,
-    yours: yourCheck,
-    surplusPlace: surplus?.place ?? null,
+    places,
+    correct: checkFor(right, subtrahend, minuend, places),
+    yours: checkFor(yours, subtrahend, minuend, places),
   }
 }

--- a/dynawalla/dynawalla-app/src/work/curriculum.ts
+++ b/dynawalla/dynawalla-app/src/work/curriculum.ts
@@ -1,0 +1,55 @@
+// The one place the app reaches into `dynawalla/curriculum`.
+//
+// A relative path, deliberately, and exactly one of them. `@dynawalla/curriculum`
+// is a private package with no `main`, no `exports` and no build step — its
+// source is the artifact — so a bare specifier would resolve under Vite (an
+// alias) and not under `node --experimental-strip-types --test`, which is what
+// runs this app's tests. One relative import that all three toolchains resolve
+// identically is worth more than a specifier that needs a config entry per tool.
+//
+// Everything the work surface uses passes through here, so when the package does
+// gain a resolvable name, one file changes.
+
+export {
+  activeNodes,
+  answerEquals,
+  answerToString,
+  classify,
+  columnOpFamily,
+  columnOpParamSchema,
+  familyById,
+  malRuleById,
+  malRules,
+  nodeById,
+  skillId,
+  COLUMN_OP_FAMILY,
+  FORM_FREE_ENTRY,
+  MIS_BORROW_ACROSS_ZERO,
+  MIS_CARRY_DROPPED,
+  MIS_SMALLER_FROM_LARGER,
+  PROMPT_KEY_ADD,
+  PROMPT_KEY_SUB,
+  REP_COUNTING_BOARD,
+  SLOT_BOTTOM,
+  SLOT_TOP,
+} from "../../../curriculum/src/index.ts"
+
+// The exact-rational module, as a namespace. Every number that reaches a
+// comparison or a rendered digit goes through it; nothing on this path is a
+// JavaScript `number` that came from arithmetic.
+export { rational as exact } from "../../../curriculum/src/index.ts"
+
+export type {
+  AnswerSchema,
+  AnswerSchemaKind,
+  AnswerValue,
+  ColumnOpParams,
+  Exercise,
+  MalRuleId,
+  PromptSlot,
+  Rational,
+  RepId,
+  SkillId,
+  SkillNode,
+  Verdict,
+} from "../../../curriculum/src/index.ts"

--- a/dynawalla/dynawalla-app/src/work/diagnosis.test.ts
+++ b/dynawalla/dynawalla-app/src/work/diagnosis.test.ts
@@ -1,0 +1,198 @@
+// The behaviour the slice exists to prove.
+//
+// `P-03`: on `5001 − 2798` answered `3203`, the app identifies
+// `mis.add.borrow-across-zero` and serves the counting-board contrast pair within
+// three cards. The same problem answered `3797` identifies
+// `mis.add.smaller-from-larger` instead — "a wrong rule-to-answer mapping passes
+// CG-12 and fails here", which is exactly what these tests are for.
+//
+// Every assertion below runs against a real generated exercise (see
+// `fixtures.ts`) and the real judging path the screen calls.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { MIS_BORROW_ACROSS_ZERO, MIS_SMALLER_FROM_LARGER, REP_COUNTING_BOARD } from "./curriculum.ts"
+import { countingBoard } from "./contrast.ts"
+import { glyphFromKey } from "./entry.ts"
+import { ACROSS_ZERO_RUNG, answerOf, fiveThousandOne } from "./fixtures.ts"
+import { judge } from "./judge.ts"
+import { repairRung, rungAt } from "./ladder.ts"
+import {
+  advance,
+  commit,
+  contrastDistance,
+  prepare,
+  pressKey,
+  startSession,
+  type SessionDeps,
+  type SessionState,
+} from "./session.ts"
+
+test("2203 is judged correct, exactly", () => {
+  const { exercise } = fiveThousandOne()
+  assert.deepEqual(judge(exercise, answerOf(2203n)), { kind: "seated" })
+})
+
+test("3203 identifies borrow-across-zero and routes to the counting board", () => {
+  const { exercise } = fiveThousandOne()
+  const verdict = judge(exercise, answerOf(3203n))
+  assert.equal(verdict.kind, "struck")
+  assert.ok(verdict.kind === "struck")
+  assert.equal(verdict.diagnosis?.misconception, MIS_BORROW_ACROSS_ZERO)
+  assert.equal(verdict.diagnosis?.contrast, REP_COUNTING_BOARD)
+})
+
+test("3797 identifies smaller-from-larger and does NOT get the counting board", () => {
+  // The mapping error the program has already made once. Both rules are valid,
+  // both diverge from the correct answer on ≥95% of seeds, and CG-12 cannot tell
+  // them apart — so it is asserted here, on the answer, not on the rule table.
+  const { exercise } = fiveThousandOne()
+  const verdict = judge(exercise, answerOf(3797n))
+  assert.ok(verdict.kind === "struck")
+  assert.equal(verdict.diagnosis?.misconception, MIS_SMALLER_FROM_LARGER)
+  assert.equal(
+    verdict.diagnosis?.contrast,
+    null,
+    "smaller-from-larger's contradiction is the number line, not the counting board",
+  )
+})
+
+test("an unexplained wrong answer gets no diagnosis rather than a guessed one", () => {
+  const { exercise } = fiveThousandOne()
+  const verdict = judge(exercise, answerOf(4444n))
+  assert.ok(verdict.kind === "struck")
+  assert.equal(verdict.diagnosis, null)
+})
+
+test("the counting board holds the contradiction, in exact whole counters", () => {
+  const { exercise } = fiveThousandOne()
+  const board = countingBoard(exercise, answerOf(3203n))
+  assert.ok(board !== null)
+
+  assert.equal(board.minuend, "5001")
+  assert.equal(board.subtrahend, "2798")
+
+  // The correct answer closes the board.
+  assert.equal(board.correct.addend, "2203")
+  assert.equal(board.correct.sum, "5001")
+  assert.equal(board.correct.rebuilds, true)
+  assert.ok(board.correct.columns.every((c) => c.counters === c.sockets))
+
+  // The child's does not, and the surplus is exactly one counter in the
+  // thousands column — the thousand that was borrowed and never given up.
+  assert.equal(board.yours.addend, "3203")
+  assert.equal(board.yours.sum, "6001")
+  assert.equal(board.yours.rebuilds, false)
+  assert.equal(board.surplusPlace, 3)
+  const thousands = board.yours.columns.find((c) => c.place === 3)
+  assert.deepEqual(thousands, { place: 3, sockets: 5, counters: 6 })
+})
+
+test("the board is never built for the misconception it does not explain", () => {
+  // 3797 + 2798 = 6595, which is not 5001 either — but it is not a *place-value*
+  // surplus, so a counting board would show two unrelated numbers rather than a
+  // contradiction. `judge` is what stops it; this asserts the numbers, so the
+  // reason is on the record rather than only the routing.
+  assert.equal(3797n + 2798n, 6595n)
+  assert.notEqual(6595n - 5001n, 1000n)
+})
+
+// ── The loop-level criterion ────────────────────────────────────────────────
+
+/** Every problem this session serves is the `5001 − 2798` fixture. */
+const fixtureDeps: SessionDeps = { generate: () => fiveThousandOne().exercise }
+
+function fixtureSession(): SessionState {
+  return startSession({ profileId: "p1", rung: ACROSS_ZERO_RUNG, rungCorrect: 0, seedCursor: 0 }, fixtureDeps)
+}
+
+/** Type digits the way a child does — through the same key path the keypad uses. */
+function type(state: SessionState, digits: string): SessionState {
+  return digits.split("").reduce<SessionState>((next, digit) => {
+    const glyph = glyphFromKey(digit)
+    assert.ok(glyph !== null)
+    return pressKey(next, { kind: "glyph", glyph })
+  }, state)
+}
+
+test("3203 puts the counting board on the very next card — one, not three", () => {
+  let state = fixtureSession()
+  state = type(state, "3203")
+  state = commit(state)
+
+  assert.equal(state.feedback?.kind, "struck")
+  assert.ok(state.feedback?.kind === "struck")
+  assert.equal(state.feedback.stage, "locate")
+  assert.equal(state.feedback.answer, "2203", "the correct answer is seated beside the strike")
+
+  state = prepare(state, fixtureDeps)
+  state = advance(state, fixtureDeps)
+
+  assert.equal(state.card.kind, "locate")
+  assert.ok(state.card.kind === "locate")
+  assert.equal(state.card.misconception, MIS_BORROW_ACROSS_ZERO)
+  assert.equal(state.card.representation, REP_COUNTING_BOARD)
+  assert.equal(state.card.board.yours.sum, "6001")
+
+  const distance = contrastDistance(state.log, MIS_BORROW_ACROSS_ZERO)
+  assert.equal(distance, 1)
+  assert.ok(distance !== null && distance <= 3, "P-03 allows three cards; this takes one")
+})
+
+test("the contrast pair is followed by a repair item that cannot avoid the step", () => {
+  // "A targeted follow-up that isolates the misunderstanding." The card after
+  // the board comes from a rung whose *parameters* demand a borrow through a
+  // zero — not from wherever the child was standing, which for the multidigit
+  // rungs would usually be a problem with no zero in it at all.
+  let state = fixtureSession()
+  state = commit(type(state, "3203"))
+  state = advance(prepare(state, fixtureDeps), fixtureDeps)
+  state = advance(state, fixtureDeps)
+
+  assert.ok(state.card.kind === "problem")
+  assert.equal(state.card.role, "repair")
+  assert.ok(rungAt(state.card.rung).params.acrossZero >= 1)
+  assert.equal(rungAt(state.card.rung).skillId, "dw.add.regroup.subtract-across-zero")
+})
+
+test("a diagnosis on an easy rung still repairs with a guaranteed across-zero item", () => {
+  // The case that made this necessary: `subtract-multidigit` level 2 asks for
+  // two regroupings and no zeros, and a drawn zero fires this diagnosis anyway.
+  // Repairing at that rung hands back a problem with no zero in it.
+  const easyRung = 2
+  assert.equal(rungAt(easyRung).params.acrossZero, 0)
+  assert.ok(rungAt(repairRung(MIS_BORROW_ACROSS_ZERO, easyRung)).params.acrossZero >= 1)
+  // A rule with no bound structure keeps the child where they were.
+  assert.equal(repairRung(MIS_SMALLER_FROM_LARGER, easyRung), easyRung)
+})
+
+test("3797 gets Stage 1, not the board: a strike, the answer, one easier retry", () => {
+  let state = fixtureSession()
+  state = commit(type(state, "3797"))
+
+  assert.ok(state.feedback?.kind === "struck")
+  assert.equal(state.feedback.stage, "verify")
+  assert.equal(state.feedback.answer, "2203")
+
+  state = advance(prepare(state, fixtureDeps), fixtureDeps)
+  assert.equal(state.card.kind, "problem")
+  assert.ok(state.card.kind === "problem")
+  assert.equal(state.card.role, "retry")
+  assert.equal(state.card.rung, ACROSS_ZERO_RUNG - 1, "one rung easier, never lower than the bottom")
+
+  assert.equal(
+    contrastDistance(state.log, MIS_SMALLER_FROM_LARGER),
+    null,
+    "no contrast exists for this rule in this build, and none is claimed",
+  )
+})
+
+test("a child who taps straight through still gets the contrast pair", () => {
+  // The follow-up must not depend on the idle pass having run. A fast tap
+  // between commit and idle is the ordinary case on a fast device.
+  let state = fixtureSession()
+  state = commit(type(state, "3203"))
+  state = advance(state, fixtureDeps) // no `prepare` in between
+  assert.equal(state.card.kind, "locate")
+})

--- a/dynawalla/dynawalla-app/src/work/diagnosis.test.ts
+++ b/dynawalla/dynawalla-app/src/work/diagnosis.test.ts
@@ -12,12 +12,19 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
 
-import { MIS_BORROW_ACROSS_ZERO, MIS_SMALLER_FROM_LARGER, REP_COUNTING_BOARD } from "./curriculum.ts"
+import {
+  columnOpFamily,
+  exact,
+  MIS_BORROW_ACROSS_ZERO,
+  MIS_SMALLER_FROM_LARGER,
+  REP_COUNTING_BOARD,
+} from "./curriculum.ts"
 import { countingBoard } from "./contrast.ts"
 import { glyphFromKey } from "./entry.ts"
-import { ACROSS_ZERO_RUNG, answerOf, fiveThousandOne } from "./fixtures.ts"
+import { ACROSS_ZERO_RUNG, answerOf, fiveThousandOne, nineHundredThree } from "./fixtures.ts"
 import { judge } from "./judge.ts"
-import { repairRung, rungAt } from "./ladder.ts"
+import { readProblem } from "./problem.ts"
+import { repairRung, rungAt, LADDER, LADDER_FORMS } from "./ladder.ts"
 import {
   advance,
   commit,
@@ -73,20 +80,119 @@ test("the counting board holds the contradiction, in exact whole counters", () =
   assert.equal(board.minuend, "5001")
   assert.equal(board.subtrahend, "2798")
 
+  // One column set, shared: the hundreds of one plate sit under the hundreds of
+  // the other, which is the only way "side by side" is a comparison at all.
+  assert.deepEqual([...board.places], [3, 2, 1, 0])
+  assert.equal(board.correct.columns.length, board.places.length)
+  assert.equal(board.yours.columns.length, board.places.length)
+
   // The correct answer closes the board.
   assert.equal(board.correct.addend, "2203")
   assert.equal(board.correct.sum, "5001")
   assert.equal(board.correct.rebuilds, true)
-  assert.ok(board.correct.columns.every((c) => c.counters === c.sockets))
+  assert.ok(board.correct.columns.every((c) => c.seated === c.sockets && c.spare === 0))
 
   // The child's does not, and the surplus is exactly one counter in the
   // thousands column — the thousand that was borrowed and never given up.
   assert.equal(board.yours.addend, "3203")
   assert.equal(board.yours.sum, "6001")
   assert.equal(board.yours.rebuilds, false)
-  assert.equal(board.surplusPlace, 3)
   const thousands = board.yours.columns.find((c) => c.place === 3)
-  assert.deepEqual(thousands, { place: 3, sockets: 5, counters: 6 })
+  assert.deepEqual(thousands, { place: 3, sockets: 5, seated: 5, spare: 1 })
+  assert.equal(
+    board.yours.columns.reduce((n, c) => n + c.spare, 0),
+    1,
+    "one counter over, not a scattering",
+  )
+})
+
+test("903 − 778 answered 225: one hundred over, and nine hundreds still seated", () => {
+  // The shape that broke the first version, and why it was rewritten.
+  // `903 − 778 = 125` (778 + 125 = 903). The buggy procedure regroups through
+  // the zero and never decrements the 9: units 13−8=5, tens 9−7=2, hundreds
+  // 9−7=2 → 225 = 125 + 100. Putting it back gives 225 + 778 = 1003 against a
+  // board carved for 903. Comparing the *digits* of 1003 with those of 903 said
+  // nine empty hundreds sockets and a counter in a thousands column the correct
+  // plate did not have: true of the digits, false of the board (1003 in counters
+  // fills all nine hundreds and leaves one over), and what a child saw read "you
+  // lost all nine hundreds" on the screen meant to repair regrouping.
+  assert.equal(903n - 778n, 125n)
+  assert.equal(778n + 125n, 903n)
+  assert.equal(125n + 100n, 225n)
+  assert.equal(225n + 778n, 1003n)
+
+  const board = countingBoard(nineHundredThree().exercise, answerOf(225n))
+  assert.ok(board !== null)
+  assert.deepEqual([...board.places], [3, 2, 1, 0])
+
+  assert.deepEqual([...board.correct.columns], [
+    { place: 3, sockets: 0, seated: 0, spare: 0 },
+    { place: 2, sockets: 9, seated: 9, spare: 0 },
+    { place: 1, sockets: 0, seated: 0, spare: 0 },
+    { place: 0, sockets: 3, seated: 3, spare: 0 },
+  ])
+  assert.deepEqual([...board.yours.columns], [
+    { place: 3, sockets: 0, seated: 0, spare: 0 },
+    // Nine hundreds seated, exactly as on the plate above, and one over.
+    { place: 2, sockets: 9, seated: 9, spare: 1 },
+    { place: 1, sockets: 0, seated: 0, spare: 0 },
+    { place: 0, sockets: 3, seated: 3, spare: 0 },
+  ])
+})
+
+test("no contrast card ever draws a hole the other plate fills", () => {
+  // Over every rung the diagnosis reaches. The old digit-wise model failed this
+  // on 11–16% of contrast cards per rung; every test and both drivers used
+  // `5001 − 2798` or `606 − 199`, the shapes where the surplus does not carry.
+  const SEEDS = 1000
+  let cards = 0
+
+  for (let rung = 0; rung < LADDER.length; rung++) {
+    const at = rungAt(rung)
+    for (let seed = 0; seed < SEEDS; seed++) {
+      const exercise = columnOpFamily.generate({
+        skillId: at.skillId,
+        level: at.level,
+        seed,
+        params: at.params,
+        forms: LADDER_FORMS,
+      })
+      const problem = readProblem(exercise)
+      const canonical = exercise.answer.canonical
+      if (problem === null || canonical.kind !== "integer") continue
+      const right = exact.toScaled(canonical.value, 0)
+      if (right === null) continue
+
+      for (let place = 1; place <= 4; place++) {
+        const wrong = answerOf(right + 10n ** BigInt(place))
+        const verdict = judge(exercise, wrong)
+        if (verdict.kind !== "struck" || verdict.diagnosis?.contrast == null) continue
+        const board = countingBoard(exercise, wrong)
+        if (board === null) continue
+        cards += 1
+
+        const where = `rung ${String(rung)} seed ${String(seed)}: ${problem.top} − ${problem.bottom}`
+        for (const plate of [board.correct, board.yours] as const) {
+          assert.equal(plate.columns.length, board.places.length, `${where}: plates disagree on columns`)
+          for (const column of plate.columns) {
+            assert.equal(column.seated, column.sockets, `${where}: an empty socket at 10^${String(column.place)}`)
+          }
+        }
+        // The child's plate holds exactly their own check, no more and no less.
+        const drawn = board.yours.columns.reduce(
+          (total, c) => total + BigInt(c.seated + c.spare) * 10n ** BigInt(c.place),
+          0n,
+        )
+        assert.equal(drawn.toString(), board.yours.sum, `${where}: the plate is not the child's sum`)
+        assert.equal(board.correct.columns.every((c) => c.spare === 0), true, `${where}: the correct plate spills`)
+        assert.equal(board.correct.rebuilds, true)
+        assert.equal(board.yours.rebuilds, false)
+        break
+      }
+    }
+  }
+
+  assert.ok(cards > 2000, `only ${String(cards)} contrast cards exercised`)
 })
 
 test("the board is never built for the misconception it does not explain", () => {

--- a/dynawalla/dynawalla-app/src/work/entry.test.ts
+++ b/dynawalla/dynawalla-app/src/work/entry.test.ts
@@ -20,6 +20,34 @@ test("digits accumulate and the field is capped at the schema's width", () => {
   assert.equal(fieldText(typed("22035")), "2203", "a fifth digit is dropped, not wrapped")
 })
 
+test("a key the field cannot take is counted, so the surface can say so", () => {
+  // The one rejection a child can neither see nor infer. On `95 − 19` the cap is
+  // two, so 9 · 7 · 6 left "97" and the 6 vanished in silence. Transient status
+  // text is forbidden, so the count drives a colour tick on the answer rule — a
+  // count, not a flag, because a flag already `true` cannot say "again".
+  const twoDigits: AnswerSchema = { kind: "integer", digits: 2, decimalPlaces: 0 }
+  const press = (state: ReturnType<typeof integerEntry.init>, ch: string) =>
+    integerEntry.press(state, { kind: "glyph", glyph: glyphFromKey(ch)! })
+
+  let state = integerEntry.init(twoDigits)
+  assert.equal(state.rebuffed, 0)
+  state = press(press(state, "9"), "7")
+  assert.equal(fieldText(state), "97")
+  assert.equal(state.rebuffed, 0, "nothing was refused yet")
+
+  const full = state
+  state = press(state, "6")
+  assert.equal(fieldText(state), "97", "the digit is still dropped, not wrapped")
+  assert.notEqual(state, full, "the refusal returned the identical state and the slate cannot see it")
+  assert.equal(state.rebuffed, 1)
+  assert.equal(press(state, "5").rebuffed, 2, "consecutive refusals are distinguishable")
+
+  // Refusals that *are* visible on the face of the field stay silent.
+  const empty = integerEntry.init(twoDigits)
+  assert.equal(integerEntry.press(empty, { kind: "delete" }), empty)
+  assert.equal(integerEntry.press(empty, { kind: "clear" }), empty)
+})
+
 test("the field width is the schema's, never the answer's", () => {
   // Sizing the field to the answer would tell a child how many digits it has.
   // `answerDigitCapacity` is `digits` for subtraction regardless of whether this

--- a/dynawalla/dynawalla-app/src/work/entry.test.ts
+++ b/dynawalla/dynawalla-app/src/work/entry.test.ts
@@ -1,0 +1,107 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { exact } from "./curriculum.ts"
+import type { AnswerSchema } from "./curriculum.ts"
+import { entryModelFor, fieldText, glyphFromKey, integerEntry } from "./entry.ts"
+
+const FOUR_DIGITS: AnswerSchema = { kind: "integer", digits: 4, decimalPlaces: 0 }
+
+function typed(text: string) {
+  return text.split("").reduce((state, ch) => {
+    const glyph = glyphFromKey(ch)
+    assert.ok(glyph !== null)
+    return integerEntry.press(state, { kind: "glyph", glyph })
+  }, integerEntry.init(FOUR_DIGITS))
+}
+
+test("digits accumulate and the field is capped at the schema's width", () => {
+  assert.equal(fieldText(typed("2203")), "2203")
+  assert.equal(fieldText(typed("22035")), "2203", "a fifth digit is dropped, not wrapped")
+})
+
+test("the field width is the schema's, never the answer's", () => {
+  // Sizing the field to the answer would tell a child how many digits it has.
+  // `answerDigitCapacity` is `digits` for subtraction regardless of whether this
+  // item's difference is shorter, and the entry model must not second-guess it.
+  const state = integerEntry.init(FOUR_DIGITS)
+  assert.equal(state.fields[0]?.maxLength, 4)
+})
+
+test("delete removes one digit; clear removes all; neither goes below empty", () => {
+  const four = typed("2203")
+  assert.equal(fieldText(integerEntry.press(four, { kind: "delete" })), "220")
+  assert.equal(fieldText(integerEntry.press(four, { kind: "clear" })), "")
+  const empty = integerEntry.init(FOUR_DIGITS)
+  assert.equal(integerEntry.press(empty, { kind: "delete" }), empty, "returns the same state, not a copy")
+  assert.equal(integerEntry.press(empty, { kind: "clear" }), empty)
+})
+
+test("an empty field is not committable; one digit is", () => {
+  assert.equal(integerEntry.complete(integerEntry.init(FOUR_DIGITS)), false)
+  assert.equal(integerEntry.complete(typed("0")), true)
+})
+
+test("the value is exact, and leading zeros are typing rather than arithmetic", () => {
+  const value = integerEntry.value(typed("2203"), FOUR_DIGITS)
+  assert.deepEqual(value, { kind: "integer", value: exact.rational(2203n) })
+  assert.deepEqual(integerEntry.value(typed("0512"), FOUR_DIGITS), {
+    kind: "integer",
+    value: exact.rational(512n),
+  })
+  assert.equal(integerEntry.value(integerEntry.init(FOUR_DIGITS), FOUR_DIGITS), null)
+})
+
+test("nothing on the entry path is a JavaScript number", () => {
+  const value = integerEntry.value(typed("9999"), FOUR_DIGITS)
+  assert.ok(value?.kind === "integer")
+  assert.equal(typeof value.value.n, "bigint")
+  assert.equal(typeof value.value.d, "bigint")
+})
+
+test("decimal places ride on the schema and scale the value, without a float", () => {
+  // The `decimal` schema is `integer` + the number layer, which is why the model
+  // already handles `decimalPlaces` even though no active skill uses it yet.
+  const tenths: AnswerSchema = { kind: "integer", digits: 3, decimalPlaces: 1 }
+  const state = ["3", "5"].reduce(
+    (s, ch) => integerEntry.press(s, { kind: "glyph", glyph: glyphFromKey(ch)! }),
+    integerEntry.init(tenths),
+  )
+  assert.deepEqual(integerEntry.value(state, tenths), {
+    kind: "integer",
+    value: exact.rational(7n, 2n),
+  })
+})
+
+test("the keypad layout comes from the model, in calculator order", () => {
+  const caps = integerEntry.keys(FOUR_DIGITS)
+  assert.equal(caps.length, 12, "three columns, four rows")
+  assert.deepEqual(
+    caps.map((cap) => (cap.kind === "glyph" ? cap.glyph : cap.kind)),
+    ["7", "8", "9", "4", "5", "6", "1", "2", "3", "blank", "0", "delete"],
+  )
+})
+
+test("no key commits — committing is a separate, explicit action", () => {
+  for (const cap of integerEntry.keys(FOUR_DIGITS)) {
+    assert.notEqual(cap.kind, "commit")
+  }
+})
+
+test("the registry knows what it can draw, and admits what it cannot", () => {
+  assert.equal(entryModelFor(FOUR_DIGITS), integerEntry)
+  assert.equal(
+    entryModelFor({ kind: "columnAlgorithm", cols: 4, marks: "borrow", decimalPlaces: 0 }),
+    undefined,
+    "the borrow grid is PR-2.4; claiming it here would serve an unanswerable card",
+  )
+  assert.equal(entryModelFor({ kind: "fraction", parts: ["num", "den"] }), undefined)
+  assert.equal(entryModelFor({ kind: "choice", k: 4 }), undefined)
+})
+
+test("the keyboard and the keypad go through one path", () => {
+  assert.deepEqual(glyphFromKey("7"), "7")
+  assert.equal(glyphFromKey("Enter"), null)
+  assert.equal(glyphFromKey("e"), null)
+  assert.equal(glyphFromKey("."), null)
+})

--- a/dynawalla/dynawalla-app/src/work/entry.ts
+++ b/dynawalla/dynawalla-app/src/work/entry.ts
@@ -1,0 +1,172 @@
+// Structure-aware answer entry.
+//
+// Not a text box. A text box accepts "about 3", "3 apples" and "3.0000001", and
+// then something downstream has to guess what a child meant — which is exactly
+// where a float, a locale bug or a false negative gets in. Entry here is a
+// *typed* structure: an ordered list of fields, each accepting a declared set of
+// glyphs to a declared length, converted to an exact `AnswerValue` by the model
+// that owns the schema.
+//
+// The generalisation is deliberate and it is the whole point of the shape below.
+// V1 needs fractions (`num`/`den`/`whole`), decimals (a `.` glyph), mixed
+// numbers, units and coordinates. Every one of those is "more fields, more
+// glyphs" — not a different component. So:
+//
+//   * `EntryState` is fields + focus. A fraction is two fields; a coordinate is
+//     two fields; an integer is one. The renderer draws `state.fields` and never
+//     knows which it has.
+//   * `EntryModel.keys()` declares the keypad. A fraction model adds `/`, a
+//     decimal model adds the locale's separator, and `Keypad.tsx` changes not at
+//     all.
+//   * `value()` is the only place a typed string becomes an `AnswerValue`, and
+//     it builds it with `BigInt`. No `parseFloat` exists on this path.
+//
+// M2 registers exactly one model. The others are not stubbed, because a stub
+// that returns `null` is a card a child cannot answer; `entryModelFor` returns
+// `undefined` and `ladder.test.ts` asserts every rung the ladder can serve has a
+// model, which is the app-side echo of gate CG-8.
+
+import { exact } from "./curriculum.ts"
+import type { AnswerSchema, AnswerSchemaKind, AnswerValue } from "./curriculum.ts"
+
+/** A glyph a field can hold. Digits now; `.` and `/` when their models land. */
+export type Glyph = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+
+export const DIGITS: readonly Glyph[] = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
+
+export interface EntryField {
+  /** Stable within a schema: "value", later "num" / "den" / "whole" / "x" / "y". */
+  readonly id: string
+  readonly text: string
+  readonly maxLength: number
+}
+
+export interface EntryState {
+  readonly fields: readonly EntryField[]
+  /** Index into `fields`. Multi-field schemas move it; a one-field schema never does. */
+  readonly focus: number
+}
+
+export type EntryKey =
+  | { readonly kind: "glyph"; readonly glyph: Glyph }
+  | { readonly kind: "delete" }
+  | { readonly kind: "clear" }
+  | { readonly kind: "focus"; readonly field: number }
+
+/**
+ * What the keypad draws, in the order it draws it. Layout is the model's
+ * business — a calculator pad is not a phone pad, and a fraction pad is neither
+ * — so the keypad component takes this list and does no arranging of its own.
+ * `blank` is a held cell, which is how a 3-wide grid gets a centred zero.
+ *
+ * Commit is not here. It is an explicit, separate action, never a key.
+ */
+export type KeyCap =
+  | { readonly kind: "glyph"; readonly glyph: Glyph }
+  | { readonly kind: "delete" }
+  | { readonly kind: "blank" }
+
+export interface EntryModel {
+  readonly schemaKind: AnswerSchemaKind
+  init(schema: AnswerSchema): EntryState
+  /** Pure. Rejecting a key returns the same state, so the caller needs no guard. */
+  press(state: EntryState, key: EntryKey): EntryState
+  /** May this state be committed? An empty answer is not an answer. */
+  complete(state: EntryState): boolean
+  keys(schema: AnswerSchema): readonly KeyCap[]
+  /** The exact value, or `null` when the state is not committable. */
+  value(state: EntryState, schema: AnswerSchema): AnswerValue | null
+}
+
+function replaceField(state: EntryState, index: number, text: string): EntryState {
+  const fields = state.fields.map((field, i) => (i === index ? { ...field, text } : field))
+  return { ...state, fields }
+}
+
+function focused(state: EntryState): EntryField | undefined {
+  return state.fields[state.focus]
+}
+
+/**
+ * `integer` — one field, digits only, capped at the schema's field width.
+ *
+ * The cap is `schema.digits`, which the family documents as the *field* width and
+ * never the width of this item's answer: sizing the field to the answer would
+ * tell a child how many digits it has. So the slate shows one right-aligned run
+ * of numerals, not a row of empty boxes.
+ *
+ * Leading zeros are kept as typed and ignored by `value()`. `0512` is 512 —
+ * marking it wrong would be the app grading typing, not arithmetic.
+ */
+export const integerEntry: EntryModel = {
+  schemaKind: "integer",
+
+  init(schema: AnswerSchema): EntryState {
+    // `entryModelFor` dispatches on the kind, so a mismatch here is a wiring
+    // bug. Failing loudly beats returning a state that renders as an empty,
+    // uncommittable slate a child can only stare at.
+    if (schema.kind !== "integer") throw new TypeError(`integerEntry: not an integer schema: ${schema.kind}`)
+    return { fields: [{ id: "value", text: "", maxLength: schema.digits + schema.decimalPlaces }], focus: 0 }
+  },
+
+  press(state: EntryState, key: EntryKey): EntryState {
+    const field = focused(state)
+    if (field === undefined) return state
+    switch (key.kind) {
+      case "glyph": {
+        if (field.text.length >= field.maxLength) return state
+        return replaceField(state, state.focus, field.text + key.glyph)
+      }
+      case "delete":
+        return field.text === "" ? state : replaceField(state, state.focus, field.text.slice(0, -1))
+      case "clear":
+        return field.text === "" ? state : replaceField(state, state.focus, "")
+      case "focus":
+        // One field: focus has nowhere to go. Multi-field models move it.
+        return state
+    }
+  },
+
+  complete(state: EntryState): boolean {
+    return (focused(state)?.text.length ?? 0) > 0
+  },
+
+  keys(): readonly KeyCap[] {
+    // Calculator order, three wide: 7 8 9 / 4 5 6 / 1 2 3 / _ 0 ⌫. A child who
+    // has used a number pad anywhere else already knows where 7 is, and delete
+    // sits under the thumb rather than next to the digits it undoes.
+    const glyph = (g: Glyph): KeyCap => ({ kind: "glyph", glyph: g })
+    return [
+      glyph("7"), glyph("8"), glyph("9"),
+      glyph("4"), glyph("5"), glyph("6"),
+      glyph("1"), glyph("2"), glyph("3"),
+      { kind: "blank" }, glyph("0"), { kind: "delete" },
+    ]
+  },
+
+  value(state: EntryState, schema: AnswerSchema): AnswerValue | null {
+    if (schema.kind !== "integer") return null
+    const text = state.fields[0]?.text ?? ""
+    if (text === "") return null
+    // `BigInt` on a digits-only string is exact at any length. `Number` is not,
+    // and neither is anything that goes through a float on the way.
+    return { kind: "integer", value: exact.fromScaled(BigInt(text), schema.decimalPlaces) }
+  },
+}
+
+const MODELS: readonly EntryModel[] = [integerEntry]
+
+/** The model that owns a schema, or `undefined` when the app cannot draw it yet. */
+export function entryModelFor(schema: AnswerSchema): EntryModel | undefined {
+  return MODELS.find((model) => model.schemaKind === schema.kind)
+}
+
+/** The glyph a keyboard event carries, or `null`. Keyboard and keypad share one path. */
+export function glyphFromKey(key: string): Glyph | null {
+  return (DIGITS as readonly string[]).includes(key) ? (key as Glyph) : null
+}
+
+/** What one field currently reads as. Rendered right-aligned on the slate. */
+export function fieldText(state: EntryState, index = 0): string {
+  return state.fields[index]?.text ?? ""
+}

--- a/dynawalla/dynawalla-app/src/work/entry.ts
+++ b/dynawalla/dynawalla-app/src/work/entry.ts
@@ -45,6 +45,14 @@ export interface EntryState {
   readonly fields: readonly EntryField[]
   /** Index into `fields`. Multi-field schemas move it; a one-field schema never does. */
   readonly focus: number
+  /**
+   * Keys the field could not take, counted. A count and not a flag: the renderer
+   * restarts the acknowledgement by flipping two class names on its parity, and
+   * a boolean already `true` cannot say "again". A full field used to swallow the
+   * key in silence — on `95 − 19` the cap is two, so 9 · 7 · 6 left "97" with
+   * nothing to say the 6 had gone.
+   */
+  readonly rebuffed: number
 }
 
 export type EntryKey =
@@ -69,7 +77,11 @@ export type KeyCap =
 export interface EntryModel {
   readonly schemaKind: AnswerSchemaKind
   init(schema: AnswerSchema): EntryState
-  /** Pure. Rejecting a key returns the same state, so the caller needs no guard. */
+  /**
+   * Pure. Rejecting a key returns the same state — so the caller needs no guard
+   * — *except* where the rejection is invisible on the face of the field, which
+   * bumps `rebuffed` so the surface can acknowledge it.
+   */
   press(state: EntryState, key: EntryKey): EntryState
   /** May this state be committed? An empty answer is not an answer. */
   complete(state: EntryState): boolean
@@ -106,7 +118,11 @@ export const integerEntry: EntryModel = {
     // bug. Failing loudly beats returning a state that renders as an empty,
     // uncommittable slate a child can only stare at.
     if (schema.kind !== "integer") throw new TypeError(`integerEntry: not an integer schema: ${schema.kind}`)
-    return { fields: [{ id: "value", text: "", maxLength: schema.digits + schema.decimalPlaces }], focus: 0 }
+    return {
+      fields: [{ id: "value", text: "", maxLength: schema.digits + schema.decimalPlaces }],
+      focus: 0,
+      rebuffed: 0,
+    }
   },
 
   press(state: EntryState, key: EntryKey): EntryState {
@@ -114,7 +130,11 @@ export const integerEntry: EntryModel = {
     if (field === undefined) return state
     switch (key.kind) {
       case "glyph": {
-        if (field.text.length >= field.maxLength) return state
+        // The one rejection a child can neither see nor infer: the field looks
+        // the same and holds a plausible number. So it returns a *different*
+        // state carrying the count the slate acknowledges it with. The others
+        // below are visible on their face and return the same state.
+        if (field.text.length >= field.maxLength) return { ...state, rebuffed: state.rebuffed + 1 }
         return replaceField(state, state.focus, field.text + key.glyph)
       }
       case "delete":

--- a/dynawalla/dynawalla-app/src/work/fixtures.test.ts
+++ b/dynawalla/dynawalla-app/src/work/fixtures.test.ts
@@ -1,0 +1,79 @@
+// The arithmetic behind the fixture, checked by hand and then asserted.
+//
+//   5001 − 2798 = 2203        check: 2798 + 2203 = 5001 ✓
+//
+//   3203  is `mis.add.borrow-across-zero`.
+//         The child regroups down through both zeros, writing them as 9s, and
+//         never takes the thousand off the 5:
+//           units      11 − 8 = 3
+//           tens        9 − 9 = 0
+//           hundreds    9 − 7 = 2
+//           thousands   5 − 2 = 3   ← the 5 was never decremented
+//         → 3203, which is 2203 + 1000. Exactly one place-value unit too big,
+//           which is what makes the counting board a contradiction: putting it
+//           back gives 3203 + 2798 = 6001, not 5001.
+//
+//   3797  is `mis.add.smaller-from-larger`.
+//         Column by column, smaller from larger regardless of which is on top:
+//           |5−2| |0−7| |0−9| |1−8|  =  3, 7, 9, 7  →  3797
+//         It is not off by a place-value unit at all — 3797 − 2203 = 1594 — so
+//         the counting board is *not* its contradiction and it must never be
+//         served that card. This is the mapping the program has already got
+//         wrong once, in three documents, before a reviewer caught it.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { exact, SLOT_BOTTOM, SLOT_TOP } from "./curriculum.ts"
+import { CACHED_SEED, fiveThousandOne, operand, scaledAnswer } from "./fixtures.ts"
+
+test("the fixture is the problem P-03 names, generated and not hand-built", () => {
+  const { seed, exercise } = fiveThousandOne()
+  assert.equal(
+    seed,
+    CACHED_SEED,
+    `the cached seed no longer produces 5001 − 2798 — update CACHED_SEED to ${String(seed)}`,
+  )
+  assert.equal(operand(exercise, SLOT_TOP), 5001n)
+  assert.equal(operand(exercise, SLOT_BOTTOM), 2798n)
+})
+
+test("the correct answer is 2203, and it is the generator's, not this file's", () => {
+  const { exercise } = fiveThousandOne()
+  assert.equal(scaledAnswer(exercise.answer.canonical), 2203n)
+  // Checked by hand above; asserted here as arithmetic.
+  assert.equal(5001n - 2798n, 2203n)
+  assert.equal(2798n + 2203n, 5001n)
+})
+
+test("3203 is a thousand too big; 3797 is not off by a place-value unit at all", () => {
+  assert.equal(3203n - 2203n, 1000n)
+  assert.equal(3203n + 2798n, 6001n)
+  assert.equal(3797n - 2203n, 1594n)
+  assert.notEqual(3797n - 2203n, 1000n)
+})
+
+test("both wrong answers are the generator's own distractors, on this item", () => {
+  // If the mal-rules did not produce these numbers on this item, every
+  // downstream assertion about diagnosis would be testing this file's opinion
+  // rather than the curriculum's behaviour.
+  const { exercise } = fiveThousandOne()
+  const byRule = new Map<string, bigint | null>()
+  for (const distractor of exercise.distractors) {
+    if (distractor.misconception === undefined) continue
+    byRule.set(String(distractor.misconception), scaledAnswer(distractor.value))
+  }
+  assert.equal(byRule.get("mis.add.borrow-across-zero"), 3203n)
+  assert.equal(byRule.get("mis.add.smaller-from-larger"), 3797n)
+})
+
+test("the exact layer never sees a float", () => {
+  // The whole no-float rule reduces to this: a value that came from arithmetic
+  // is a Rational of BigInts, and comparison is structural.
+  const { exercise } = fiveThousandOne()
+  const canonical = exercise.answer.canonical
+  assert.ok(canonical.kind === "integer")
+  assert.equal(typeof canonical.value.n, "bigint")
+  assert.equal(typeof canonical.value.d, "bigint")
+  assert.ok(exact.eq(canonical.value, exact.rational(2203n)))
+})

--- a/dynawalla/dynawalla-app/src/work/fixtures.ts
+++ b/dynawalla/dynawalla-app/src/work/fixtures.ts
@@ -1,0 +1,82 @@
+// The `5001 − 2798` fixture.
+//
+// `P-03` is written against one specific problem, so the tests want that exact
+// item — not something like it. It is reachable: the across-zero skill's level 2
+// is `sub(4, 4, 3, 2)`, four digits with three regroupings through a run of two
+// zeros, which is precisely the shape of `5001 − 2798`. So the fixture is a
+// **real generated exercise**, found by seed search, rather than a hand-built
+// object literal that could drift from what the generator actually emits.
+//
+// The seed is cached and re-derived if it stops working. `exerciseIdOf` mixes
+// `familyRev` into the seed, so a legitimate generator change moves every seed at
+// once; a hard-pinned constant would then fail with "wrong numbers" and tell
+// nobody why. The search is bounded and takes well under a second.
+//
+// Test-only. Nothing in the app imports it, so it is not in the bundle.
+
+import { columnOpFamily, exact, FORM_FREE_ENTRY, SLOT_BOTTOM, SLOT_TOP } from "./curriculum.ts"
+import type { AnswerValue, Exercise } from "./curriculum.ts"
+import { rungAt, LADDER } from "./ladder.ts"
+
+/** The across-zero rung: `dw.add.regroup.subtract-across-zero` level 2. */
+export const ACROSS_ZERO_RUNG = LADDER.length - 1
+
+/** Known-good at `familyRev` 1. Re-derived automatically if it stops matching. */
+export const CACHED_SEED = 159579
+
+const SEARCH_LIMIT = 400_000
+
+/** The scaled whole-unit value of a prompt slot, or `null`. */
+export function operand(exercise: Exercise, slot: string): bigint | null {
+  const value = exercise.prompt.slots[slot]
+  if (value === undefined || value.kind !== "number") return null
+  return exact.toScaled(value.value, value.decimalPlaces)
+}
+
+function isFiveThousandOne(exercise: Exercise): boolean {
+  return operand(exercise, SLOT_TOP) === 5001n && operand(exercise, SLOT_BOTTOM) === 2798n
+}
+
+export function generateAt(seed: number): Exercise {
+  const rung = rungAt(ACROSS_ZERO_RUNG)
+  return columnOpFamily.generate({
+    skillId: rung.skillId,
+    level: rung.level,
+    seed,
+    params: rung.params,
+    forms: [FORM_FREE_ENTRY],
+  })
+}
+
+let cache: { seed: number; exercise: Exercise } | null = null
+
+/** The real `5001 − 2798` item, and the seed that produces it. */
+export function fiveThousandOne(): { seed: number; exercise: Exercise } {
+  if (cache !== null) return cache
+  const cached = generateAt(CACHED_SEED)
+  if (isFiveThousandOne(cached)) {
+    cache = { seed: CACHED_SEED, exercise: cached }
+    return cache
+  }
+  for (let seed = 0; seed < SEARCH_LIMIT; seed++) {
+    const exercise = generateAt(seed)
+    if (isFiveThousandOne(exercise)) {
+      cache = { seed, exercise }
+      return cache
+    }
+  }
+  throw new Error(
+    `no seed under ${String(SEARCH_LIMIT)} produces 5001 − 2798 on rung ${String(ACROSS_ZERO_RUNG)}`,
+  )
+}
+
+/** An exact integer answer value. */
+export function answerOf(value: bigint): AnswerValue {
+  return { kind: "integer", value: exact.rational(value) }
+}
+
+/** The whole-unit value of an answer, or `null` for a shape that has none. */
+export function scaledAnswer(value: AnswerValue): bigint | null {
+  if (value.kind !== "integer" && value.kind !== "columnAlgorithm") return null
+  return exact.toScaled(value.value, 0)
+}

--- a/dynawalla/dynawalla-app/src/work/fixtures.ts
+++ b/dynawalla/dynawalla-app/src/work/fixtures.ts
@@ -21,8 +21,21 @@ import { rungAt, LADDER } from "./ladder.ts"
 /** The across-zero rung: `dw.add.regroup.subtract-across-zero` level 2. */
 export const ACROSS_ZERO_RUNG = LADDER.length - 1
 
-/** Known-good at `familyRev` 1. Re-derived automatically if it stops matching. */
+/**
+ * `903 − 778`, on `subtract-multidigit` level 2.
+ *
+ * The second fixture, and it is here for a reason `5001 − 2798` cannot serve.
+ * On `5001` the borrowed thousand lands in a place the minuend already has, so
+ * comparing digits and comparing quantities agree. On `903` it does not: the
+ * child's check `225 + 778 = 1003` carries into a place `903` has no digit for,
+ * and the two models disagree. Every test in this slice used the agreeing shape,
+ * which is exactly why the disagreeing one went unnoticed.
+ */
+export const CARRY_SURPLUS_RUNG = 2
+
+/** Known-good at `familyRev` 1. Re-derived automatically if they stop matching. */
 export const CACHED_SEED = 159579
+export const CACHED_SEED_903 = 5656
 
 const SEARCH_LIMIT = 400_000
 
@@ -33,41 +46,54 @@ export function operand(exercise: Exercise, slot: string): bigint | null {
   return exact.toScaled(value.value, value.decimalPlaces)
 }
 
-function isFiveThousandOne(exercise: Exercise): boolean {
-  return operand(exercise, SLOT_TOP) === 5001n && operand(exercise, SLOT_BOTTOM) === 2798n
+export interface Fixture {
+  readonly seed: number
+  readonly exercise: Exercise
 }
 
-export function generateAt(seed: number): Exercise {
-  const rung = rungAt(ACROSS_ZERO_RUNG)
+export function generateAtRung(rung: number, seed: number): Exercise {
+  const at = rungAt(rung)
   return columnOpFamily.generate({
-    skillId: rung.skillId,
-    level: rung.level,
+    skillId: at.skillId,
+    level: at.level,
     seed,
-    params: rung.params,
+    params: at.params,
     forms: [FORM_FREE_ENTRY],
   })
 }
 
-let cache: { seed: number; exercise: Exercise } | null = null
+export function generateAt(seed: number): Exercise {
+  return generateAtRung(ACROSS_ZERO_RUNG, seed)
+}
 
-/** The real `5001 − 2798` item, and the seed that produces it. */
-export function fiveThousandOne(): { seed: number; exercise: Exercise } {
-  if (cache !== null) return cache
-  const cached = generateAt(CACHED_SEED)
-  if (isFiveThousandOne(cached)) {
-    cache = { seed: CACHED_SEED, exercise: cached }
-    return cache
-  }
+function find(rung: number, top: bigint, bottom: bigint, cachedSeed: number): Fixture {
+  const matches = (exercise: Exercise): boolean =>
+    operand(exercise, SLOT_TOP) === top && operand(exercise, SLOT_BOTTOM) === bottom
+
+  const cached = generateAtRung(rung, cachedSeed)
+  if (matches(cached)) return { seed: cachedSeed, exercise: cached }
   for (let seed = 0; seed < SEARCH_LIMIT; seed++) {
-    const exercise = generateAt(seed)
-    if (isFiveThousandOne(exercise)) {
-      cache = { seed, exercise }
-      return cache
-    }
+    const exercise = generateAtRung(rung, seed)
+    if (matches(exercise)) return { seed, exercise }
   }
   throw new Error(
-    `no seed under ${String(SEARCH_LIMIT)} produces 5001 − 2798 on rung ${String(ACROSS_ZERO_RUNG)}`,
+    `no seed under ${String(SEARCH_LIMIT)} produces ${top.toString()} − ${bottom.toString()} on rung ${String(rung)}`,
   )
+}
+
+let cache: Fixture | null = null
+let cache903: Fixture | null = null
+
+/** The real `5001 − 2798` item, and the seed that produces it. */
+export function fiveThousandOne(): Fixture {
+  cache ??= find(ACROSS_ZERO_RUNG, 5001n, 2798n, CACHED_SEED)
+  return cache
+}
+
+/** The real `903 − 778` item — the shape where digits and quantities disagree. */
+export function nineHundredThree(): Fixture {
+  cache903 ??= find(CARRY_SURPLUS_RUNG, 903n, 778n, CACHED_SEED_903)
+  return cache903
 }
 
 /** An exact integer answer value. */

--- a/dynawalla/dynawalla-app/src/work/idle.ts
+++ b/dynawalla/dynawalla-app/src/work/idle.ts
@@ -1,0 +1,35 @@
+// Idle scheduling.
+//
+// The next problem is generated while the child is reading the current one, so
+// nothing generates on the answer path. `requestIdleCallback` is the right
+// instrument and it is not universal: Safari only shipped it in 16.4 and this app
+// promises iOS 16.0. A `setTimeout(…, 0)` fallback runs after the current task
+// and after paint, which is the property that actually matters — it is a worse
+// scheduler, not a missing one.
+//
+// A seam, not a wrapper for its own sake: the tests drive `runIdle` with a
+// recording scheduler and assert that generation happened *there* and not inside
+// the commit handler.
+
+export type IdleScheduler = (run: () => void) => () => void
+
+const timeoutScheduler: IdleScheduler = (run) => {
+  const handle = setTimeout(run, 0)
+  return () => clearTimeout(handle)
+}
+
+/** The platform's idle scheduler, resolved at call time so a test can stub it. */
+export function idleScheduler(): IdleScheduler {
+  const ric = (globalThis as { requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number })
+    .requestIdleCallback
+  const cancel = (globalThis as { cancelIdleCallback?: (handle: number) => void }).cancelIdleCallback
+  if (typeof ric !== "function") return timeoutScheduler
+  return (run) => {
+    // A timeout, because an idle callback with no deadline can be starved
+    // indefinitely on a busy WebView and the deck must not go empty.
+    const handle = ric(run, { timeout: 200 })
+    return () => {
+      if (typeof cancel === "function") cancel(handle)
+    }
+  }
+}

--- a/dynawalla/dynawalla-app/src/work/judge.ts
+++ b/dynawalla/dynawalla-app/src/work/judge.ts
@@ -21,7 +21,7 @@
 // app's half of that contract; it is the reason a curriculum PR cannot silently
 // promise a child a representation this bundle cannot draw.
 
-import { classify, familyById, malRuleById, REP_COUNTING_BOARD } from "./curriculum.ts"
+import { familyById, malRuleById, REP_COUNTING_BOARD } from "./curriculum.ts"
 import type { AnswerValue, Exercise, MalRuleId, RepId } from "./curriculum.ts"
 
 /** Contrast representations this bundle can actually draw. */
@@ -50,12 +50,17 @@ export function judge(exercise: Exercise, submitted: AnswerValue): Judgement {
   const verdict = family.check(exercise, submitted)
   if (verdict.correct) return { kind: "seated" }
 
-  // `check` already classifies, but only for its own family's rules and only
-  // when it is the one that generated the item. Re-classifying here would be a
-  // second implementation of the same decision; taking the verdict's answer is
-  // the single source of truth.
-  const misconception = verdict.misconception ?? classify(exercise, submitted)
-  if (misconception === undefined || misconception === null) return { kind: "struck", diagnosis: null }
+  // The family's verdict is the single source of diagnosis, and not a partial
+  // one: `check` calls the same global `classify` this module would, and
+  // `classify` already filters the registry to `exercise.family`. A second pass
+  // could find nothing. It used to run one anyway — `verdict.misconception ??
+  // classify(…)` — re-executing every mal-rule's full column procedure on the
+  // unexplained-wrong branch to reach the same `undefined`.
+  //
+  // The contract: a family that wants its wrong answers diagnosed classifies
+  // them in `check`. `diagnosis.test.ts` asserts the one this build serves does.
+  const misconception = verdict.misconception
+  if (misconception === undefined) return { kind: "struck", diagnosis: null }
 
   return { kind: "struck", diagnosis: { misconception, contrast: contrastFor(misconception) } }
 }

--- a/dynawalla/dynawalla-app/src/work/judge.ts
+++ b/dynawalla/dynawalla-app/src/work/judge.ts
@@ -1,0 +1,73 @@
+// Judging and diagnosis.
+//
+// Two claims live here and both are load-bearing.
+//
+// **The mathematics is real.** Correctness is `family.check`, which is exact
+// structural comparison of `Rational`s. No tolerance, no epsilon, no float, no
+// model, no language model. A child's answer is right or it is not, and the same
+// answer is judged the same way on every device forever.
+//
+// **A wrong answer is not just wrong.** If it *equals* the output of an
+// executable buggy procedure, we know which procedure the child ran. That is the
+// product. `classify` returns the single rule that explains the answer, or `null`
+// when none or several do — an ambiguous diagnosis is worse than none, because
+// Stage 2 would then show a contradiction built for a misconception the child may
+// not hold.
+//
+// The routing decision — Stage 1 VERIFY or Stage 2 LOCATE — is made here and
+// nowhere else. A rule may be tagged LOCATE-capable in the curriculum and still
+// route to Stage 1 in *this build*, because tagging is a curriculum claim and
+// drawing the contrast is an app capability. `LOCATABLE_REPRESENTATIONS` is the
+// app's half of that contract; it is the reason a curriculum PR cannot silently
+// promise a child a representation this bundle cannot draw.
+
+import { classify, familyById, malRuleById, REP_COUNTING_BOARD } from "./curriculum.ts"
+import type { AnswerValue, Exercise, MalRuleId, RepId } from "./curriculum.ts"
+
+/** Contrast representations this bundle can actually draw. */
+export const LOCATABLE_REPRESENTATIONS: readonly RepId[] = [REP_COUNTING_BOARD]
+
+export interface Diagnosis {
+  /** Internal forever. No learner-facing string ever names it (M-16). */
+  readonly misconception: MalRuleId
+  /** The contrast representation to show, or `null` for Stage 1. */
+  readonly contrast: RepId | null
+}
+
+export type Judgement =
+  | { readonly kind: "seated" }
+  | { readonly kind: "struck"; readonly diagnosis: Diagnosis | null }
+
+/**
+ * Exact judgement plus diagnosis. Synchronous and pure: nothing here reads a
+ * clock, touches storage or awaits anything, because it runs between the child's
+ * commit and the next painted frame.
+ */
+export function judge(exercise: Exercise, submitted: AnswerValue): Judgement {
+  const family = familyById(exercise.family)
+  if (family === undefined) throw new RangeError(`judge: no family ${exercise.family}`)
+
+  const verdict = family.check(exercise, submitted)
+  if (verdict.correct) return { kind: "seated" }
+
+  // `check` already classifies, but only for its own family's rules and only
+  // when it is the one that generated the item. Re-classifying here would be a
+  // second implementation of the same decision; taking the verdict's answer is
+  // the single source of truth.
+  const misconception = verdict.misconception ?? classify(exercise, submitted)
+  if (misconception === undefined || misconception === null) return { kind: "struck", diagnosis: null }
+
+  return { kind: "struck", diagnosis: { misconception, contrast: contrastFor(misconception) } }
+}
+
+/**
+ * The contrast representation bound to a misconception, if this build can draw
+ * it. `null` routes to Stage 1.
+ */
+export function contrastFor(misconception: MalRuleId): RepId | null {
+  const rule = malRuleById(misconception)
+  if (rule === undefined || !rule.locateCapable) return null
+  const rep = rule.contrastRep
+  if (rep === undefined) return null
+  return LOCATABLE_REPRESENTATIONS.includes(rep) ? rep : null
+}

--- a/dynawalla/dynawalla-app/src/work/ladder.test.ts
+++ b/dynawalla/dynawalla-app/src/work/ladder.test.ts
@@ -1,0 +1,111 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { columnOpFamily, exact, nodeById, FORM_FREE_ENTRY } from "./curriculum.ts"
+import type { Rational } from "./curriculum.ts"
+import { entryModelFor } from "./entry.ts"
+import {
+  advanceRung,
+  easier,
+  rungAt,
+  CORRECT_PER_RUNG,
+  LADDER,
+  LADDER_FORMS,
+  SLATE_COLUMNS,
+} from "./ladder.ts"
+
+test("every rung binds an active skill and a level that skill actually has", () => {
+  // `rungOf` throws on construction, so importing the module is most of this
+  // test. What is left is the claim that nothing was silently clamped.
+  for (const rung of LADDER) {
+    const node = nodeById(rung.skillId)
+    assert.ok(node !== undefined, `${rung.skillId} is not in the graph`)
+    assert.equal(node.status, "active")
+    assert.ok(rung.level < node.generator.params.length)
+  }
+})
+
+test("the ladder climbs: item difficulty never goes down a rung", () => {
+  // `b_item` is the node's own contribution plus the generator's parameter
+  // offset, and the two are not interchangeable: `sub(3,3,2,1)` has a *lower*
+  // parameter offset than `sub(4,4,2,0)` and is nonetheless the harder item,
+  // because borrowing through a zero belongs to a harder skill. Comparing
+  // offsets alone would have ordered this ladder wrong and passed.
+  let previous: Rational | null = null
+  for (const rung of LADDER) {
+    const node = nodeById(rung.skillId)
+    assert.ok(node !== undefined)
+    const b = exact.add(node.difficulty.b, columnOpFamily.difficultyOffset(rung.params))
+    if (previous !== null) {
+      assert.ok(
+        exact.gte(b, previous),
+        `rung ${rung.skillId}/${String(rung.level)} is easier than the one before it`,
+      )
+    }
+    // The curriculum states the expected value per level; CG-9 checks it against
+    // the params. Asserting against it here means a ladder built on a level the
+    // graph does not actually declare fails loudly.
+    assert.ok(exact.eq(b, node.difficulty.levels[rung.level] ?? b))
+    previous = b
+  }
+})
+
+test("the ladder reaches the across-zero case the slice exists to test", () => {
+  const top = rungAt(LADDER.length - 1)
+  assert.equal(top.skillId, "dw.add.regroup.subtract-across-zero")
+  assert.ok(top.params.acrossZero >= 2, "the top rung borrows through two zeros")
+  assert.equal(top.params.op, "sub")
+})
+
+test("every rung the ladder can serve has an entry model — the app-side CG-8", () => {
+  // A curriculum row the app cannot draw is exactly what CG-8 exists to stop on
+  // the curriculum side. This is the same claim from the app's side: a rung
+  // whose schema has no registered entry model is a card a child cannot answer.
+  for (const rung of LADDER) {
+    const schema = columnOpFamily.answerSchema(rung.params, FORM_FREE_ENTRY)
+    assert.ok(
+      entryModelFor(schema) !== undefined,
+      `${rung.skillId}/${String(rung.level)} produces a ${schema.kind} schema with no entry model`,
+    )
+  }
+})
+
+test("the ladder asks for one form, and it is the one with a model", () => {
+  assert.deepEqual(LADDER_FORMS, [FORM_FREE_ENTRY])
+})
+
+test("the position only ever rises", () => {
+  let rung = 0
+  let rungCorrect = 0
+  for (let i = 0; i < 200; i++) {
+    const next = advanceRung(rung, rungCorrect)
+    assert.ok(next.rung >= rung, "a correct answer lowered the ladder position")
+    rung = next.rung
+    rungCorrect = next.rungCorrect
+  }
+  assert.equal(rung, LADDER.length - 1, "the top rung repeats rather than running off the end")
+})
+
+test("four correct answers advance one rung, and not three", () => {
+  let state = { rung: 0, rungCorrect: 0 }
+  for (let i = 1; i < CORRECT_PER_RUNG; i++) {
+    state = advanceRung(state.rung, state.rungCorrect)
+    assert.equal(state.rung, 0, `advanced after ${String(i)} correct`)
+  }
+  state = advanceRung(state.rung, state.rungCorrect)
+  assert.equal(state.rung, 1)
+  assert.equal(state.rungCorrect, 0)
+})
+
+test("the retry rung is one easier and never below the bottom", () => {
+  assert.equal(easier(0), 0)
+  assert.equal(easier(1), 0)
+  assert.equal(easier(LADDER.length - 1), LADDER.length - 2)
+  assert.equal(easier(999), LADDER.length - 2)
+})
+
+test("the slate reservation covers the widest number any rung can write", () => {
+  const widest = LADDER.reduce((n, rung) => Math.max(n, rung.params.digits), 0)
+  assert.equal(SLATE_COLUMNS, widest)
+  assert.equal(SLATE_COLUMNS, 4, "the M2 ladder tops out at four digits")
+})

--- a/dynawalla/dynawalla-app/src/work/ladder.ts
+++ b/dynawalla/dynawalla-app/src/work/ladder.ts
@@ -1,0 +1,132 @@
+// The fixed difficulty ladder.
+//
+// **There is no adaptivity here, on purpose.** The learner model is M5. This is
+// seven rungs in a written order and one counter: four correct answers at a rung
+// advance to the next, the top rung repeats forever, and nothing ever descends.
+// That last clause is not a simplification — no loss, no demotion, no streak is a
+// product rule (MISSION, engagement ethics), so the counter is monotone by
+// construction rather than by a check somewhere.
+//
+// A retry or a repair item is served at a rung *without* moving the position;
+// only `rungCorrect` moves the ladder. Otherwise getting an item wrong and then
+// right on the easier retry would promote a child for the easier item.
+//
+// The rungs walk the two M2 skills from two-digit borrowing to the across-zero
+// case the slice exists to test: `dw.add.regroup.subtract-multidigit` levels 0–3,
+// then `dw.add.regroup.subtract-across-zero` levels 0–2. The parameters are the
+// curriculum's, read from the graph — this file names a (skill, level) pair and
+// nothing else, so a level's difficulty stays a curriculum fact.
+
+import {
+  columnOpParamSchema,
+  nodeById,
+  skillId,
+  FORM_FREE_ENTRY,
+  MIS_BORROW_ACROSS_ZERO,
+} from "./curriculum.ts"
+import type { ColumnOpParams, MalRuleId, SkillId, SkillNode } from "./curriculum.ts"
+
+/** Correct answers at a rung before the ladder moves up. */
+export const CORRECT_PER_RUNG = 4
+
+/** Cards in one run before a designed stopping point is offered. */
+export const RUN_LENGTH = 12
+
+export const SKILL_SUBTRACT_MULTIDIGIT = skillId("dw.add.regroup.subtract-multidigit")
+export const SKILL_SUBTRACT_ACROSS_ZERO = skillId("dw.add.regroup.subtract-across-zero")
+
+/**
+ * Free entry only, for now. The family also emits `column` — the borrow grid with
+ * its written regrouping marks — and that form needs a `columnAlgorithm` renderer
+ * and entry model this PR does not build. Asking for one form is how the request
+ * contract says so; the family picks deterministically among whatever it is given.
+ */
+export const LADDER_FORMS: readonly string[] = [FORM_FREE_ENTRY]
+
+export interface Rung {
+  readonly skillId: SkillId
+  readonly level: number
+  readonly params: ColumnOpParams
+}
+
+const STEPS: readonly (readonly [SkillId, number])[] = [
+  [SKILL_SUBTRACT_MULTIDIGIT, 0],
+  [SKILL_SUBTRACT_MULTIDIGIT, 1],
+  [SKILL_SUBTRACT_MULTIDIGIT, 2],
+  [SKILL_SUBTRACT_MULTIDIGIT, 3],
+  [SKILL_SUBTRACT_ACROSS_ZERO, 0],
+  [SKILL_SUBTRACT_ACROSS_ZERO, 1],
+  [SKILL_SUBTRACT_ACROSS_ZERO, 2],
+]
+
+function rungOf(id: SkillId, level: number): Rung {
+  const node: SkillNode | undefined = nodeById(id)
+  if (node === undefined) throw new RangeError(`ladder: no skill ${id}`)
+  if (node.status !== "active") throw new RangeError(`ladder: ${id} is ${node.status}, not active`)
+  const raw = node.generator.params[level]
+  if (raw === undefined) throw new RangeError(`ladder: ${id} has no level ${String(level)}`)
+  const parsed = columnOpParamSchema.validate(raw)
+  if (!parsed.ok) throw new RangeError(`ladder: ${id} level ${String(level)} has invalid params`)
+  return { skillId: id, level, params: parsed.value }
+}
+
+export const LADDER: readonly Rung[] = STEPS.map(([id, level]) => rungOf(id, level))
+
+/** The rung at `index`, clamped. Above the top the ladder simply repeats. */
+export function rungAt(index: number): Rung {
+  const clamped = Math.min(Math.max(index, 0), LADDER.length - 1)
+  const rung = LADDER[clamped]
+  if (rung === undefined) throw new RangeError("ladder: empty")
+  return rung
+}
+
+/** One rung easier, for the Stage-1 retry. Never below the bottom. */
+export function easier(index: number): number {
+  return Math.max(0, Math.min(index, LADDER.length - 1) - 1)
+}
+
+/**
+ * Parameters that *guarantee* an item exercises the step a misconception breaks.
+ *
+ * This is what makes the follow-up after a contrast pair a repair rather than
+ * another card. The child's own rung will not do: `dw.add.regroup.subtract-
+ * multidigit` level 2 asks for two regroupings and no zeros, and a zero turns up
+ * in a drawn digit often enough to fire this diagnosis anyway — 155 items in
+ * 4,000, by the curriculum's own measurement. Serving the next item from that
+ * same rung would usually hand back a problem with no zero in it at all, which
+ * tests nothing about the step that just broke.
+ *
+ * So the repair comes from the lowest rung whose *parameters* demand the
+ * structure. It is the easiest problem on the ladder that cannot avoid the
+ * misunderstanding.
+ */
+const REPAIR_STRUCTURE: readonly (readonly [MalRuleId, (params: ColumnOpParams) => boolean])[] = [
+  [MIS_BORROW_ACROSS_ZERO, (params) => params.op === "sub" && params.acrossZero >= 1],
+]
+
+/** The rung a repair item comes from, or `fallback` when nothing is bound. */
+export function repairRung(misconception: MalRuleId, fallback: number): number {
+  const bound = REPAIR_STRUCTURE.find(([id]) => id === misconception)
+  if (bound === undefined) return fallback
+  const index = LADDER.findIndex((rung) => bound[1](rung.params))
+  return index === -1 ? fallback : index
+}
+
+/** Where the position goes after a correct answer at `index`. Monotone. */
+export function advanceRung(index: number, rungCorrect: number): { rung: number; rungCorrect: number } {
+  const next = rungCorrect + 1
+  if (next < CORRECT_PER_RUNG) return { rung: index, rungCorrect: next }
+  return { rung: Math.min(index + 1, LADDER.length - 1), rungCorrect: 0 }
+}
+
+/**
+ * The widest number any rung can put on the slate.
+ *
+ * The slate reserves this many numeral columns for every item, so a two-digit
+ * problem and a four-digit one occupy the same box and the layout does not move
+ * between cards. Derived, so adding a rung cannot leave the reservation stale.
+ */
+export const SLATE_COLUMNS: number = LADDER.reduce(
+  (widest, rung) => Math.max(widest, rung.params.digits + rung.params.decimalPlaces),
+  0,
+)

--- a/dynawalla/dynawalla-app/src/work/metrics.test.ts
+++ b/dynawalla/dynawalla-app/src/work/metrics.test.ts
@@ -1,0 +1,89 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { idleScheduler } from "./idle.ts"
+import { measure, percentile, record, report, reset, samples } from "./metrics.ts"
+import { generateProblem } from "./session.ts"
+import { LADDER, rungAt } from "./ladder.ts"
+
+test("percentiles are nearest-rank and empty rings report nothing rather than zero", () => {
+  reset()
+  assert.equal(percentile("generate", 95), null)
+  assert.deepEqual(report("generate"), { count: 0, p50: null, p95: null, max: null })
+  for (const ms of [5, 1, 4, 2, 3]) record("generate", ms)
+  assert.equal(percentile("generate", 50), 3)
+  assert.equal(percentile("generate", 100), 5)
+  assert.equal(report("generate").max, 5)
+})
+
+test("the ring is bounded, so a long session does not grow without limit", () => {
+  reset()
+  for (let i = 0; i < 1000; i++) record("commitToFeedback", i)
+  assert.equal(samples("commitToFeedback").length, 256)
+})
+
+test("generate() stays inside the per-item budget on every rung", () => {
+  // EXPERIENCE_DESIGN: if a single `generate()` exceeds 4 ms measured, generation
+  // moves to a Worker rather than being optimised in place. This is that
+  // measurement, on the developer machine — the device number is `Q-01` and is a
+  // device item. The bound here is deliberately generous relative to what the
+  // family actually costs, so it catches a regression of an order of magnitude
+  // and not CI jitter.
+  reset()
+  for (let rung = 0; rung < LADDER.length; rung++) {
+    for (let seed = 0; seed < 200; seed++) {
+      measure("generate", () => generateProblem(rungAt(rung), seed))
+    }
+  }
+  const generated = report("generate")
+  assert.equal(generated.count, 256, "the ring is bounded; the last 256 are what is reported")
+  assert.ok(
+    (generated.p95 ?? Infinity) < 4,
+    `generate() p95 is ${String(generated.p95)} ms — over the 4 ms Worker threshold`,
+  )
+})
+
+test("the idle scheduler falls back where requestIdleCallback does not exist", () => {
+  // Safari shipped `requestIdleCallback` in 16.4 and this app promises iOS 16.0.
+  // A missing scheduler must degrade to a worse one, never to no generation.
+  const host = globalThis as { requestIdleCallback?: unknown }
+  const original = host.requestIdleCallback
+  try {
+    delete host.requestIdleCallback
+    const schedule = idleScheduler()
+    let ran = false
+    const cancel = schedule(() => {
+      ran = true
+    })
+    assert.equal(typeof cancel, "function")
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        assert.equal(ran, true, "the fallback never ran the callback")
+        resolve()
+      }, 5)
+    })
+  } finally {
+    if (original !== undefined) host.requestIdleCallback = original
+  }
+})
+
+test("an idle callback is given a timeout so a busy WebView cannot starve the deck", () => {
+  const host = globalThis as {
+    requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number
+    cancelIdleCallback?: (handle: number) => void
+  }
+  const original = host.requestIdleCallback
+  let sawTimeout: number | undefined
+  try {
+    host.requestIdleCallback = (_cb, opts) => {
+      sawTimeout = opts?.timeout
+      return 1
+    }
+    idleScheduler()(() => undefined)
+    assert.equal(typeof sawTimeout, "number")
+    assert.ok((sawTimeout ?? 0) > 0)
+  } finally {
+    if (original === undefined) delete host.requestIdleCallback
+    else host.requestIdleCallback = original
+  }
+})

--- a/dynawalla/dynawalla-app/src/work/metrics.ts
+++ b/dynawalla/dynawalla-app/src/work/metrics.ts
@@ -1,0 +1,98 @@
+// Latency instrumentation for the loop.
+//
+// EXPERIENCE_DESIGN budgets the machine's contribution and never the child's:
+// `commit → judgement` under 1 ms, the first feedback frame within 16 ms, and the
+// next problem ready without the current one waiting. Those are numbers, so they
+// are measured rather than asserted.
+//
+// Two spans, kept apart on purpose:
+//
+//   `commitToJudgement` the pure decision: judge, diagnose, plan the follow-up.
+//                       Budgeted under 1 ms and synchronous. This is the number
+//                       that is actually the app's work.
+//   `commitToFeedback`  the child's key to the frame that paints the verdict.
+//                       Probed with a double `requestAnimationFrame`, so its
+//                       floor is one compositor frame (16.7 ms at 60 Hz) by
+//                       construction: it answers "does the verdict land on the
+//                       next frame", not "how many milliseconds of work".
+//   `feedbackToReady`   the verdict painting to the next card being in hand.
+//                       Concurrent with the reaction tail; if it is ever on the
+//                       critical path, the deck was empty and that is a bug.
+//
+// A fixed-size ring, no allocation per sample beyond the number itself, and no
+// consumer in the shipped bundle: `expose()` is called only under
+// `import.meta.env.DEV`, so a production build tree-shakes the window handle
+// away. Traces never ship (A-18).
+
+export type Span = "commitToJudgement" | "commitToFeedback" | "feedbackToReady" | "generate"
+
+const CAPACITY = 256
+
+const rings: Record<Span, number[]> = {
+  commitToJudgement: [],
+  commitToFeedback: [],
+  feedbackToReady: [],
+  generate: [],
+}
+
+/** Monotonic milliseconds. `performance` is absent under `node --test`. */
+export function now(): number {
+  const perf = (globalThis as { performance?: { now: () => number } }).performance
+  return typeof perf?.now === "function" ? perf.now() : Date.now()
+}
+
+export function record(span: Span, ms: number): void {
+  const ring = rings[span]
+  ring.push(ms)
+  if (ring.length > CAPACITY) ring.shift()
+}
+
+/** Time `run` into `span` and return its value. */
+export function measure<T>(span: Span, run: () => T): T {
+  const started = now()
+  const out = run()
+  record(span, now() - started)
+  return out
+}
+
+export function samples(span: Span): readonly number[] {
+  return rings[span]
+}
+
+export function reset(): void {
+  for (const span of Object.keys(rings) as Span[]) rings[span] = []
+}
+
+/** Nearest-rank percentile. `p` is 0..100. `null` on an empty ring. */
+export function percentile(span: Span, p: number): number | null {
+  const sorted = [...rings[span]].sort((a, b) => a - b)
+  if (sorted.length === 0) return null
+  const rank = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1))
+  return sorted[rank] ?? null
+}
+
+export interface MetricsReport {
+  readonly count: number
+  readonly p50: number | null
+  readonly p95: number | null
+  readonly max: number | null
+}
+
+export function report(span: Span): MetricsReport {
+  const ring = rings[span]
+  return {
+    count: ring.length,
+    p50: percentile(span, 50),
+    p95: percentile(span, 95),
+    max: ring.length === 0 ? null : Math.max(...ring),
+  }
+}
+
+/**
+ * Hand the rings to whatever is driving the app in dev — a browser session, the
+ * bench, a person with a console open. Guarded by the caller, never called in a
+ * production bundle.
+ */
+export function expose(): void {
+  ;(globalThis as { __dwMetrics?: unknown }).__dwMetrics = { report, samples, reset }
+}

--- a/dynawalla/dynawalla-app/src/work/problem.ts
+++ b/dynawalla/dynawalla-app/src/work/problem.ts
@@ -1,0 +1,93 @@
+// Reading a column-op item back out of the exercise contract.
+//
+// The slate, the verdict and the counting board all need the written operands.
+// They read them from `Exercise.prompt.slots`, which is the *public* contract —
+// the same surface the mal-rules are required to use (`curriculum/.../digits.ts`
+// says so in as many words). Nothing here reaches into the generator's private
+// draw.
+//
+// This is NOT the number layer. `NumberFormat` — decimal separator, grouping,
+// numbering system, direction — is PR-2.2 and owns every locale question. What
+// this module produces is the *unformatted* digit string a formatter will later
+// take as input, and the digit array the counting board places counters from.
+// An English build renders `5001`, not `5,001`, until that layer lands.
+
+import { exact, PROMPT_KEY_ADD, PROMPT_KEY_SUB, SLOT_BOTTOM, SLOT_TOP } from "./curriculum.ts"
+import type { Exercise, Rational } from "./curriculum.ts"
+
+export type ColumnOp = "add" | "sub"
+
+export interface ColumnProblem {
+  readonly op: ColumnOp
+  /** The minuend / first addend, exactly as written. */
+  readonly top: string
+  readonly bottom: string
+  /** Scaled to whole units at `decimalPlaces`, so digit work stays integral. */
+  readonly topScaled: bigint
+  readonly bottomScaled: bigint
+  readonly decimalPlaces: number
+}
+
+/** Big-endian digits of a non-negative integer: index 0 is the leading digit. */
+export function digitsOf(value: bigint): number[] {
+  if (value < 0n) throw new RangeError("digitsOf: negative value")
+  return value
+    .toString()
+    .split("")
+    .map((c) => Number(c))
+}
+
+/**
+ * The plain digit string for an exact value written to `decimalPlaces`.
+ *
+ * Returns `null` rather than guessing when the value cannot be written at that
+ * precision — a third is not a decimal, and rendering `0.333` would be the app
+ * inventing a number the curriculum did not produce.
+ */
+export function plainDigits(value: Rational, decimalPlaces: number): string | null {
+  return exact.toDecimalString(value, decimalPlaces)
+}
+
+function numberSlot(exercise: Exercise, name: string): { value: Rational; decimalPlaces: number } | null {
+  const slot = exercise.prompt.slots[name]
+  if (slot === undefined || slot.kind !== "number") return null
+  return { value: slot.value, decimalPlaces: slot.decimalPlaces }
+}
+
+/** The written operands, or `null` when this is not a column-op item. Never throws. */
+export function readProblem(exercise: Exercise): ColumnProblem | null {
+  const op: ColumnOp | null =
+    exercise.prompt.key === PROMPT_KEY_SUB
+      ? "sub"
+      : exercise.prompt.key === PROMPT_KEY_ADD
+        ? "add"
+        : null
+  if (op === null) return null
+
+  const top = numberSlot(exercise, SLOT_TOP)
+  const bottom = numberSlot(exercise, SLOT_BOTTOM)
+  if (top === null || bottom === null) return null
+  if (top.decimalPlaces !== bottom.decimalPlaces) return null
+
+  const decimalPlaces = top.decimalPlaces
+  const topScaled = exact.toScaled(top.value, decimalPlaces)
+  const bottomScaled = exact.toScaled(bottom.value, decimalPlaces)
+  if (topScaled === null || bottomScaled === null) return null
+  if (topScaled < 0n || bottomScaled < 0n) return null
+
+  const topText = plainDigits(top.value, decimalPlaces)
+  const bottomText = plainDigits(bottom.value, decimalPlaces)
+  if (topText === null || bottomText === null) return null
+
+  return { op, top: topText, bottom: bottomText, topScaled, bottomScaled, decimalPlaces }
+}
+
+/** The answer as a plain digit string, or `null` for a schema the slate cannot write. */
+export function writtenAnswer(exercise: Exercise): string | null {
+  const answer = exercise.answer.canonical
+  if (answer.kind !== "integer" && answer.kind !== "columnAlgorithm") return null
+  const places = exercise.schema.kind === "choice" || exercise.schema.kind === "fraction"
+    ? 0
+    : exercise.schema.decimalPlaces
+  return plainDigits(answer.value, places)
+}

--- a/dynawalla/dynawalla-app/src/work/profile.ts
+++ b/dynawalla/dynawalla-app/src/work/profile.ts
@@ -1,0 +1,34 @@
+// Profile-namespaced storage keys.
+//
+// ADR-0018: all storage is namespaced by `profileId` from M2, in the same PR that
+// first persists anything — which is this one. The profile *switcher* is M9; the
+// data model has to be right now, because retrofitting a profile dimension onto
+// keys that already hold a real child's progress means migrating them on a device
+// with no way to test the migration first.
+//
+// One profile exists today. It is `DEFAULT_PROFILE_ID` and it is written into
+// every key, so the second profile costs a UI and nothing else.
+
+/** The one profile M2 creates. Not special: it is a value in the namespace. */
+export const DEFAULT_PROFILE_ID = "p1"
+
+const PREFIX = "dynawalla"
+const SEPARATOR = "."
+
+/** A profile id safe to put in a storage key: no separator, non-empty. */
+export function isProfileId(value: string): boolean {
+  return value.length > 0 && !value.includes(SEPARATOR)
+}
+
+/**
+ * `dynawalla.<profileId>.<name>`.
+ *
+ * The separator is banned inside a profile id, which is what stops `a.b` + `c`
+ * and `a` + `b.c` from colliding on one key — the failure mode that would silently
+ * merge two children's progress and only show up on a family's tablet.
+ */
+export function storageKey(profileId: string, name: string): string {
+  if (!isProfileId(profileId)) throw new RangeError(`storageKey: bad profile id ${JSON.stringify(profileId)}`)
+  if (!isProfileId(name)) throw new RangeError(`storageKey: bad name ${JSON.stringify(name)}`)
+  return [PREFIX, profileId, name].join(SEPARATOR)
+}

--- a/dynawalla/dynawalla-app/src/work/progress.test.ts
+++ b/dynawalla/dynawalla-app/src/work/progress.test.ts
@@ -1,0 +1,87 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { createProgressStore, ephemeral, INITIAL_PROGRESS } from "./progress.ts"
+import { DEFAULT_PROFILE_ID, isProfileId, storageKey } from "./profile.ts"
+
+test("keys are namespaced by profile, and cannot collide across profiles", () => {
+  assert.equal(storageKey("p1", "progress"), "dynawalla.p1.progress")
+  assert.notEqual(storageKey("p1", "progress"), storageKey("p2", "progress"))
+  // The separator is banned inside an id, which is what stops `a.b` + `c` and
+  // `a` + `b.c` from resolving to one key and silently merging two children.
+  assert.equal(isProfileId("a.b"), false)
+  assert.throws(() => storageKey("a.b", "progress"), RangeError)
+  assert.throws(() => storageKey("", "progress"), RangeError)
+})
+
+test("three children on one device have independent progress", () => {
+  // `Q-12`, from the storage side. The device half is a device item; this is the
+  // test that catches a shared key, which a device check would only find after a
+  // family had already used the app.
+  ephemeral.clear()
+  const stores = ["a", "b", "c"].map((id) => ({ id, store: createProgressStore(id) }))
+
+  stores.forEach(({ store }, i) => {
+    store.getState().savePosition({ rung: i, rungCorrect: i, seedCursor: i * 10 })
+    for (let n = 0; n <= i; n++) store.getState().recordAnswer(true)
+    store.getState().countBug("mis.add.borrow-across-zero")
+  })
+
+  stores.forEach(({ store }, i) => {
+    assert.equal(store.getState().rung, i)
+    assert.equal(store.getState().seedCursor, i * 10)
+    assert.equal(store.getState().correct, i + 1)
+  })
+
+  const keys = [...ephemeral.keys()].sort()
+  assert.deepEqual(keys, ["dynawalla.a.progress", "dynawalla.b.progress", "dynawalla.c.progress"])
+  for (const { id, store } of stores) {
+    const written = ephemeral.get(storageKey(id, "progress"))
+    assert.ok(written !== undefined)
+    assert.equal((JSON.parse(written) as { state: { rung: number } }).state.rung, store.getState().rung)
+  }
+})
+
+test("progress survives a relaunch: a new store on the same key reads it back", () => {
+  ephemeral.clear()
+  const first = createProgressStore("relaunch")
+  first.getState().savePosition({ rung: 5, rungCorrect: 2, seedCursor: 41 })
+  first.getState().recordAnswer(true)
+  first.getState().recordAnswer(false)
+
+  const second = createProgressStore("relaunch")
+  assert.equal(second.getState().rung, 5)
+  assert.equal(second.getState().rungCorrect, 2)
+  assert.equal(second.getState().seedCursor, 41)
+  assert.equal(second.getState().answered, 2)
+  assert.equal(second.getState().correct, 1)
+})
+
+test("totals only rise: no action lowers a count or a rung", () => {
+  ephemeral.clear()
+  const store = createProgressStore("monotone")
+  store.getState().savePosition({ rung: 3, rungCorrect: 1, seedCursor: 9 })
+  for (let i = 0; i < 5; i++) store.getState().recordAnswer(false)
+  assert.equal(store.getState().answered, 5)
+  assert.equal(store.getState().correct, 0)
+  assert.equal(store.getState().rung, 3, "a run of wrong answers moved the ladder")
+})
+
+test("diagnoses are counted, and only as ids", () => {
+  ephemeral.clear()
+  const store = createProgressStore("bugs")
+  store.getState().countBug("mis.add.borrow-across-zero")
+  store.getState().countBug("mis.add.borrow-across-zero")
+  store.getState().countBug("mis.add.smaller-from-larger")
+  assert.deepEqual(store.getState().bugs, {
+    "mis.add.borrow-across-zero": 2,
+    "mis.add.smaller-from-larger": 1,
+  })
+})
+
+test("a fresh profile starts at the bottom of the ladder", () => {
+  ephemeral.clear()
+  const store = createProgressStore(DEFAULT_PROFILE_ID)
+  assert.equal(store.getState().rung, INITIAL_PROGRESS.rung)
+  assert.equal(store.getState().seedCursor, 0)
+})

--- a/dynawalla/dynawalla-app/src/work/progress.ts
+++ b/dynawalla/dynawalla-app/src/work/progress.ts
@@ -1,0 +1,109 @@
+// Durable progress, per profile.
+//
+// What survives a launch is deliberately small: where the child is on the ladder,
+// how many correct answers they have at that rung, the seed cursor so the same
+// problems are not served twice, and running totals. Everything else — the card
+// on screen, the deck, the entry — is rebuilt from those four numbers, so there
+// is no serialization of an `Exercise` (whose values are `BigInt`s and therefore
+// not JSON) and no possibility of a stored card drifting out of step with a
+// generator revision.
+//
+// Storage is `localStorage` because it is synchronous at module load; ADR-0018's
+// second tier (IndexedDB for the event ring) arrives with the engine at M5 and
+// has nothing to hold yet.
+//
+// `bugs` counts diagnoses per mal-rule id. It is a mastery-adjacent record, so it
+// is namespaced with everything else, and it is internal: no learner-facing
+// string ever names a misconception (M-16).
+
+import { create, type StoreApi, type UseBoundStore } from "zustand"
+import { persist, createJSONStorage, type StateStorage } from "zustand/middleware"
+
+import { storageKey } from "./profile.ts"
+
+export interface Progress {
+  readonly rung: number
+  readonly rungCorrect: number
+  readonly seedCursor: number
+  readonly answered: number
+  readonly correct: number
+  readonly bugs: Readonly<Record<string, number>>
+}
+
+export const INITIAL_PROGRESS: Progress = {
+  rung: 0,
+  rungCorrect: 0,
+  seedCursor: 0,
+  answered: 0,
+  correct: 0,
+  bugs: {},
+}
+
+/** Where the child is. Written whenever the ladder or the seed cursor moves. */
+export type Position = Pick<Progress, "rung" | "rungCorrect" | "seedCursor">
+
+export interface ProgressState extends Progress {
+  savePosition: (position: Position) => void
+  recordAnswer: (correct: boolean) => void
+  countBug: (misconception: string) => void
+}
+
+/**
+ * Web storage is absent under `node --test` and can be disabled in a WebView.
+ * Neither is a reason to throw at a child, so the preference degrades to process
+ * lifetime. Shared and module-level on purpose: the namespacing test reads it to
+ * prove three profiles wrote three keys.
+ */
+export const ephemeral = new Map<string, string>()
+
+const memoryStorage: StateStorage = {
+  getItem: (name) => ephemeral.get(name) ?? null,
+  setItem: (name, value) => void ephemeral.set(name, value),
+  removeItem: (name) => void ephemeral.delete(name),
+}
+
+export type ProgressStore = UseBoundStore<StoreApi<ProgressState>>
+
+/**
+ * One store per profile, keyed by the profile's namespace.
+ *
+ * A factory rather than a singleton because the profile dimension is the point:
+ * `progress.test.ts` builds three and cross-reads their keys, which is the test
+ * `Q-12` names. The app instantiates exactly one until the M9 switcher exists.
+ */
+export function createProgressStore(profileId: string): ProgressStore {
+  return create<ProgressState>()(
+    persist(
+      (set) => ({
+        ...INITIAL_PROGRESS,
+        savePosition: (position) => set(position),
+        // Totals only ever rise. There is no code path that lowers `correct`,
+        // clears the ladder or forgets a rung — no loss is a product rule, and
+        // the absence of a decrement here is where it is enforced (P-04's shape,
+        // one milestone early).
+        recordAnswer: (correct) =>
+          set((state) => ({
+            answered: state.answered + 1,
+            correct: state.correct + (correct ? 1 : 0),
+          })),
+        countBug: (misconception) =>
+          set((state) => ({ bugs: { ...state.bugs, [misconception]: (state.bugs[misconception] ?? 0) + 1 } })),
+      }),
+      {
+        name: storageKey(profileId, "progress"),
+        version: 1,
+        storage: createJSONStorage(() =>
+          typeof localStorage === "undefined" ? memoryStorage : localStorage,
+        ),
+        partialize: (state) => ({
+          rung: state.rung,
+          rungCorrect: state.rungCorrect,
+          seedCursor: state.seedCursor,
+          answered: state.answered,
+          correct: state.correct,
+          bugs: state.bugs,
+        }),
+      },
+    ),
+  )
+}

--- a/dynawalla/dynawalla-app/src/work/session.test.ts
+++ b/dynawalla/dynawalla-app/src/work/session.test.ts
@@ -191,6 +191,61 @@ test("a stopping point is never offered in the middle of a repair sequence", () 
   assert.equal(state.stopping, false, "a repair sequence was interrupted by a stopping point")
 })
 
+test("the way out is offered on cards done, not on cards done right", () => {
+  // Computed only on the seated branch, answering card 12 wrong pushed the offer
+  // to card 24 and a run of wrong answers suppressed it altogether: withheld
+  // from the child having the worst time, which is ADR-0009 inverted.
+  const deps = counting()
+  let state = startSession({ profileId: "p1", rung: 0, rungCorrect: 0, seedCursor: 0 }, deps)
+  for (let i = 0; i < RUN_LENGTH - 1; i++) state = answerCorrectly(state, deps)
+
+  assert.ok(state.card.kind === "problem")
+  const wrong = commit(type(state, "1"))
+  assert.equal(wrong.answered, RUN_LENGTH)
+  assert.equal(wrong.feedback?.kind, "struck")
+  assert.equal(wrong.stopping, true, "a wrong answer at the run boundary withheld the offer")
+
+  // …and "Keep going" still leads into the retry the wrong answer earned.
+  const kept = advance(prepare(wrong, deps), deps)
+  assert.equal(kept.stopping, false)
+  assert.ok(kept.card.kind === "problem")
+  assert.equal(kept.card.role, "retry")
+})
+
+test("the same board is never served twice in one session", () => {
+  // The repair loop had no floor: the same bug brought the identical board back
+  // with `stopping` suppressed throughout, so the way out was withheld for as
+  // long as the child was stuck. ADAPTIVE_LEARNING sends repeated failure to
+  // Stage 3, which M2 has not built; Stage 1 is its stand-in.
+  const deps: SessionDeps = { generate: () => fiveThousandOne().exercise }
+  let state = startSession({ profileId: "p1", rung: LADDER.length - 1, rungCorrect: 0, seedCursor: 0 }, deps)
+
+  state = commit(type(state, "3203"))
+  assert.ok(state.feedback?.kind === "struck")
+  assert.equal(state.feedback.stage, "locate")
+
+  state = advance(prepare(state, deps), deps)
+  assert.equal(state.card.kind, "locate")
+  state = advance(state, deps)
+  assert.ok(state.card.kind === "problem")
+  assert.equal(state.card.role, "repair")
+
+  // The same bug on the repair item. The diagnosis is still made — progress
+  // still counts it — but the card that follows is a quiet Stage 1, not the
+  // board a third time.
+  state = commit(type(state, "3203"))
+  assert.ok(state.feedback?.kind === "struck")
+  assert.equal(state.feedback.stage, "verify")
+  assert.equal(
+    state.log.filter((entry) => entry.kind === "diagnosed").length,
+    2,
+    "the second diagnosis was dropped rather than routed",
+  )
+  state = advance(prepare(state, deps), deps)
+  assert.ok(state.card.kind === "problem")
+  assert.equal(state.card.role, "retry")
+})
+
 test("nothing lowers the ladder or the totals", () => {
   const deps = counting()
   let state = startSession({ profileId: "p1", rung: 4, rungCorrect: 2, seedCursor: 0 }, deps)

--- a/dynawalla/dynawalla-app/src/work/session.test.ts
+++ b/dynawalla/dynawalla-app/src/work/session.test.ts
@@ -1,0 +1,205 @@
+// The loop's shape: what runs on the answer path, what runs in idle, and what
+// the session does over a run of cards.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { glyphFromKey } from "./entry.ts"
+import { fiveThousandOne } from "./fixtures.ts"
+import { CORRECT_PER_RUNG, LADDER, RUN_LENGTH, rungAt } from "./ladder.ts"
+import { writtenAnswer } from "./problem.ts"
+import {
+  advance,
+  commit,
+  committable,
+  enterAction,
+  generateProblem,
+  prepare,
+  pressKey,
+  startSession,
+  submitted,
+  DECK_DEPTH,
+  type SessionDeps,
+  type SessionState,
+} from "./session.ts"
+
+/** Counts generator calls so "what runs where" is measured, not asserted. */
+function counting(): SessionDeps & { calls: () => number } {
+  let calls = 0
+  return {
+    generate: (rung, seed) => {
+      calls += 1
+      return generateProblem(rung, seed)
+    },
+    calls: () => calls,
+  }
+}
+
+function type(state: SessionState, digits: string): SessionState {
+  return digits.split("").reduce<SessionState>((next, digit) => {
+    const glyph = glyphFromKey(digit)
+    assert.ok(glyph !== null)
+    return pressKey(next, { kind: "glyph", glyph })
+  }, state)
+}
+
+/** Answer the card on screen correctly, then move on. */
+function answerCorrectly(state: SessionState, deps: SessionDeps): SessionState {
+  assert.ok(state.card.kind === "problem")
+  const text = writtenAnswer(state.card.exercise)
+  assert.ok(text !== null)
+  const committed = commit(type(state, text))
+  assert.equal(committed.feedback?.kind, "seated")
+  return advance(prepare(committed, deps), deps)
+}
+
+test("commit does no generation — it cannot, and that is the signature", () => {
+  const deps = counting()
+  let state = startSession({ profileId: "p1", rung: 0, rungCorrect: 0, seedCursor: 0 }, deps)
+  state = prepare(state, deps)
+
+  const before = deps.calls()
+  assert.ok(state.card.kind === "problem")
+  const text = writtenAnswer(state.card.exercise)
+  assert.ok(text !== null)
+  const committed = commit(type(state, text))
+  assert.equal(committed.feedback?.kind, "seated")
+  assert.equal(deps.calls(), before, "the answer path generated a problem")
+})
+
+test("the deck is filled ahead and never starves in ordinary play", () => {
+  const deps = counting()
+  let state = startSession({ profileId: "p1", rung: 0, rungCorrect: 0, seedCursor: 0 }, deps)
+  state = prepare(state, deps)
+  assert.equal(state.deck.length, DECK_DEPTH)
+
+  for (let i = 0; i < 30; i++) state = answerCorrectly(state, deps)
+  assert.equal(state.starved, 0, "advance had to generate inline; the idle pass is not keeping up")
+})
+
+test("prepare is idempotent and returns the same state when there is nothing to do", () => {
+  const deps = counting()
+  const state = prepare(startSession({ profileId: "p1", rung: 0, rungCorrect: 0, seedCursor: 0 }, deps), deps)
+  const calls = deps.calls()
+  assert.equal(prepare(state, deps), state)
+  assert.equal(deps.calls(), calls)
+})
+
+test("seeds never repeat, so a relaunch does not re-serve the same problem", () => {
+  const deps = counting()
+  let state = startSession({ profileId: "p1", rung: 0, rungCorrect: 0, seedCursor: 0 }, deps)
+  const ids = new Set<string>()
+  for (let i = 0; i < 20; i++) {
+    assert.ok(state.card.kind === "problem")
+    ids.add(state.card.exercise.exerciseId)
+    state = answerCorrectly(state, deps)
+  }
+  assert.equal(ids.size, 20)
+  assert.ok(state.seedCursor >= 20)
+})
+
+test("the ladder is climbed by correct answers on ladder cards only", () => {
+  const deps = counting()
+  let state = startSession({ profileId: "p1", rung: 0, rungCorrect: 0, seedCursor: 0 }, deps)
+  for (let i = 0; i < CORRECT_PER_RUNG; i++) state = answerCorrectly(state, deps)
+  assert.equal(state.rung, 1)
+})
+
+test("a correct answer on a retry card does not promote", () => {
+  const deps = counting()
+  let state = startSession({ profileId: "p1", rung: 3, rungCorrect: 3, seedCursor: 0 }, deps)
+
+  // Wrong, unexplained → Stage 1 → a retry card one rung easier.
+  state = commit(type(state, "1"))
+  assert.equal(state.rung, 3)
+  state = advance(prepare(state, deps), deps)
+  assert.ok(state.card.kind === "problem")
+  assert.equal(state.card.role, "retry")
+
+  const before = state.rung
+  state = answerCorrectly(state, deps)
+  assert.equal(state.rung, before, "the easier retry promoted the child")
+})
+
+test("an entry that is empty cannot be committed", () => {
+  const deps = counting()
+  const state = startSession({ profileId: "p1", rung: 0, rungCorrect: 0, seedCursor: 0 }, deps)
+  assert.equal(committable(state), false)
+  assert.equal(submitted(state), null)
+  assert.equal(commit(state), state)
+})
+
+test("Enter commits an answerable card and moves on from everything else", () => {
+  const deps: SessionDeps = { generate: () => fiveThousandOne().exercise }
+  let state = startSession({ profileId: "p1", rung: LADDER.length - 1, rungCorrect: 0, seedCursor: 0 }, deps)
+  assert.equal(enterAction(state), "commit")
+
+  state = commit(type(state, "3203"))
+  assert.equal(enterAction(state), "next", "a verdict is up; Enter must not re-commit")
+
+  state = advance(state, deps)
+  assert.equal(state.card.kind, "locate")
+  assert.equal(
+    enterAction(state),
+    "next",
+    "the contrast card has no entry — committing it does nothing and traps the keyboard",
+  )
+})
+
+test("input is ignored once a verdict is up", () => {
+  const deps = counting()
+  let state = startSession({ profileId: "p1", rung: 0, rungCorrect: 0, seedCursor: 0 }, deps)
+  state = commit(type(state, "1"))
+  assert.equal(pressKey(state, { kind: "glyph", glyph: "9" }), state)
+})
+
+test("a run reaches a designed stopping point, and it is not a wall", () => {
+  const deps = counting()
+  let state = startSession({ profileId: "p1", rung: 0, rungCorrect: 0, seedCursor: 0 }, deps)
+  for (let i = 0; i < RUN_LENGTH - 1; i++) {
+    assert.ok(state.card.kind === "problem")
+    const text = writtenAnswer(state.card.exercise)
+    assert.ok(text !== null)
+    const committed = commit(type(state, text))
+    assert.equal(committed.stopping, false)
+    state = advance(prepare(committed, deps), deps)
+  }
+  assert.ok(state.card.kind === "problem")
+  const last = writtenAnswer(state.card.exercise)
+  assert.ok(last !== null)
+  state = commit(type(state, last))
+  assert.equal(state.answered, RUN_LENGTH)
+  assert.equal(state.stopping, true)
+
+  // "Keep going" is just `advance`. Nothing is gated behind stopping.
+  const kept = advance(prepare(state, deps), deps)
+  assert.equal(kept.stopping, false)
+  assert.equal(kept.card.kind, "problem")
+})
+
+test("a stopping point is never offered in the middle of a repair sequence", () => {
+  const deps: SessionDeps = { generate: () => fiveThousandOne().exercise }
+  let state = startSession(
+    { profileId: "p1", rung: LADDER.length - 1, rungCorrect: 0, seedCursor: 0 },
+    deps,
+  )
+  for (let i = 0; i < RUN_LENGTH - 1; i++) {
+    state = advance(commit(type(state, "2203")), deps)
+  }
+  state = commit(type(state, "3203"))
+  assert.equal(state.answered, RUN_LENGTH)
+  assert.equal(state.stopping, false, "a repair sequence was interrupted by a stopping point")
+})
+
+test("nothing lowers the ladder or the totals", () => {
+  const deps = counting()
+  let state = startSession({ profileId: "p1", rung: 4, rungCorrect: 2, seedCursor: 0 }, deps)
+  const rung = state.rung
+  const correct = state.correct
+  for (let i = 0; i < 6; i++) {
+    state = advance(prepare(commit(type(state, "1")), deps), deps)
+  }
+  assert.ok(state.rung >= rung, "a wrong answer moved the ladder down")
+  assert.ok(state.correct >= correct)
+  assert.equal(rungAt(state.rung).skillId, rungAt(rung).skillId)
+})

--- a/dynawalla/dynawalla-app/src/work/session.ts
+++ b/dynawalla/dynawalla-app/src/work/session.ts
@@ -1,0 +1,434 @@
+// The practice loop, as a pure state machine.
+//
+// Everything a card does — present, accept a key, judge, decide what comes next,
+// prepare it — is a function from state to state with no clock, no storage, no
+// DOM and no React in it. That is what lets the loop be tested at all: a React
+// component is not testable under `node --experimental-strip-types --test`, and
+// the behaviour worth testing is not "does a div render", it is "does answering
+// 3203 on 5001 − 2798 produce the counting board and answering 3797 not".
+//
+// ## The concurrency rule, and how the types enforce it
+//
+// EXPERIENCE_DESIGN: *the work surface never waits for the world*. Commit to
+// judgement is under a millisecond, synchronous and pure; the next problem is
+// generated during idle, before it is needed.
+//
+// So `commit` **takes no generator**. Not "does not call one" — cannot. It is the
+// only operation on the answer path and its signature is the proof it does no
+// work there. Generation lives in `prepare`, which the store runs from
+// `requestIdleCallback`, and in `advance`'s starvation fallback, which increments
+// a counter a test asserts stays at zero.
+//
+// ## The three-stage corrective model (ADAPTIVE_LEARNING)
+//
+//   Stage 1 VERIFY   wrong, unexplained. A strike mark, the correct answer
+//                    seated beside it, one retry a rung easier. No lecture.
+//   Stage 2 LOCATE   wrong, and the answer *equals* a known buggy procedure's
+//                    output, and this build can draw that procedure's
+//                    contradiction. The contrast pair, then one repair item at
+//                    the same rung — the follow-up that isolates the
+//                    misunderstanding rather than repeating the card.
+//   Stage 3          not built. Repeated failure routes to Stage 1 again in M2.
+//
+// The contrast pair is served as the **very next card**, which is a distance of
+// one — well inside the three the exit criterion allows.
+//
+// Stage 2 is not reachable by a rule that merely *claims* LOCATE capability:
+// `judge.contrastFor` requires this bundle to have the representation, and
+// `countingBoard` returns `null` when the contradiction would not actually be
+// visible. Both fall back to Stage 1. A LOCATE card that shows no contradiction
+// is worse than a quiet strike mark.
+
+import { columnOpFamily } from "./curriculum.ts"
+import type { AnswerValue, Exercise, MalRuleId, RepId } from "./curriculum.ts"
+import { countingBoard, type CountingBoard } from "./contrast.ts"
+import { entryModelFor, type EntryKey, type EntryState } from "./entry.ts"
+import { judge, type Judgement } from "./judge.ts"
+import {
+  advanceRung,
+  easier,
+  repairRung,
+  rungAt,
+  LADDER_FORMS,
+  RUN_LENGTH,
+  type Rung,
+} from "./ladder.ts"
+import { measure } from "./metrics.ts"
+import { writtenAnswer } from "./problem.ts"
+
+/** How the card got here. Only `ladder` cards can move the ladder position. */
+export type CardRole = "ladder" | "retry" | "repair"
+
+export type Card =
+  | { readonly kind: "problem"; readonly exercise: Exercise; readonly rung: number; readonly role: CardRole }
+  | {
+      readonly kind: "locate"
+      readonly board: CountingBoard
+      readonly misconception: MalRuleId
+      readonly representation: RepId
+      readonly rung: number
+    }
+
+export type Feedback =
+  | { readonly kind: "seated" }
+  /** `answer` is the correct one, written plainly. The misconception is never shown. */
+  | { readonly kind: "struck"; readonly answer: string; readonly stage: "verify" | "locate" }
+
+type Plan =
+  | { readonly kind: "none" }
+  | { readonly kind: "retry"; readonly rung: number }
+  | {
+      readonly kind: "locate"
+      readonly board: CountingBoard
+      readonly misconception: MalRuleId
+      readonly representation: RepId
+      readonly rung: number
+    }
+
+/** What happened, in card ordinals, so "within N cards" is a measurable claim. */
+export type LogEntry =
+  | { readonly kind: "diagnosed"; readonly at: number; readonly misconception: MalRuleId }
+  | { readonly kind: "contrast"; readonly at: number; readonly misconception: MalRuleId; readonly representation: RepId }
+
+export interface SessionState {
+  readonly profileId: string
+  /** Ladder position. Monotone: nothing in this module ever lowers it. */
+  readonly rung: number
+  readonly rungCorrect: number
+  readonly seedCursor: number
+  /** Cards presented this session, 1-based on the card currently on screen. */
+  readonly served: number
+  readonly answered: number
+  readonly correct: number
+  readonly card: Card
+  readonly entry: EntryState | null
+  readonly feedback: Feedback | null
+  readonly plan: Plan
+  /** Forced follow-ups. Always taken before the deck. */
+  readonly queued: readonly Card[]
+  /** Pre-generated ladder cards. */
+  readonly deck: readonly Card[]
+  readonly log: readonly LogEntry[]
+  /** A designed stopping point is on offer. Never a wall — both ways out are equal. */
+  readonly stopping: boolean
+  /** Times `advance` had to generate inline because the deck was empty. */
+  readonly starved: number
+}
+
+export interface SessionDeps {
+  readonly generate: (rung: Rung, seed: number) => Exercise
+}
+
+/** Cards kept on deck. Two, per EXPERIENCE_DESIGN's `N+1` and `N+2`. */
+export const DECK_DEPTH = 2
+
+/** How long a seated answer holds before the next card presents, in ms. */
+export const SEAT_HOLD_MS = 420
+
+export function generateProblem(rung: Rung, seed: number): Exercise {
+  return measure("generate", () =>
+    columnOpFamily.generate({
+      skillId: rung.skillId,
+      level: rung.level,
+      seed,
+      params: rung.params,
+      forms: LADDER_FORMS,
+    }),
+  )
+}
+
+export const defaultDeps: SessionDeps = { generate: generateProblem }
+
+function problemCard(rung: number, seed: number, role: CardRole, deps: SessionDeps): Card {
+  const exercise = deps.generate(rungAt(rung), seed)
+  // Belt and braces for the app side of CG-8: a schema with no entry model is a
+  // card a child cannot answer. It cannot happen with the ladder as written —
+  // `ladder.test.ts` asserts it for every rung — so if it happens, something
+  // upstream changed and a loud failure is the correct outcome.
+  if (entryModelFor(exercise.schema) === undefined) {
+    throw new RangeError(`session: no entry model for schema ${exercise.schema.kind}`)
+  }
+  return { kind: "problem", exercise, rung, role }
+}
+
+function freshEntry(card: Card): EntryState | null {
+  if (card.kind !== "problem") return null
+  const model = entryModelFor(card.exercise.schema)
+  return model === undefined ? null : model.init(card.exercise.schema)
+}
+
+export interface SessionSeed {
+  readonly profileId: string
+  readonly rung: number
+  readonly rungCorrect: number
+  readonly seedCursor: number
+}
+
+export function startSession(seed: SessionSeed, deps: SessionDeps = defaultDeps): SessionState {
+  const card = problemCard(seed.rung, seed.seedCursor, "ladder", deps)
+  return {
+    profileId: seed.profileId,
+    rung: seed.rung,
+    rungCorrect: seed.rungCorrect,
+    seedCursor: seed.seedCursor + 1,
+    served: 1,
+    answered: 0,
+    correct: 0,
+    card,
+    entry: freshEntry(card),
+    feedback: null,
+    plan: { kind: "none" },
+    queued: [],
+    deck: [],
+    log: [],
+    stopping: false,
+    starved: 0,
+  }
+}
+
+/** A key from the keypad or the hardware keyboard. Ignored once a verdict is up. */
+export function pressKey(state: SessionState, key: EntryKey): SessionState {
+  if (state.feedback !== null || state.entry === null || state.card.kind !== "problem") return state
+  const model = entryModelFor(state.card.exercise.schema)
+  if (model === undefined) return state
+  const entry = model.press(state.entry, key)
+  return entry === state.entry ? state : { ...state, entry }
+}
+
+/** May this state be committed? Drives the commit control's disabled attribute. */
+export function committable(state: SessionState): boolean {
+  if (state.feedback !== null || state.entry === null || state.card.kind !== "problem") return false
+  const model = entryModelFor(state.card.exercise.schema)
+  return model !== undefined && model.complete(state.entry)
+}
+
+/** The exact value currently entered, or `null`. */
+export function submitted(state: SessionState): AnswerValue | null {
+  if (state.entry === null || state.card.kind !== "problem") return null
+  const model = entryModelFor(state.card.exercise.schema)
+  return model === undefined ? null : model.value(state.entry, state.card.exercise.schema)
+}
+
+/**
+ * Judge the entered answer and decide what follows.
+ *
+ * No generator parameter, by design: this is the whole of the answer path and it
+ * is arithmetic on values that already exist. Everything that costs anything
+ * happens in `prepare`, after the verdict has painted.
+ */
+export function commit(state: SessionState): SessionState {
+  if (!committable(state) || state.card.kind !== "problem") return state
+  const value = submitted(state)
+  if (value === null) return state
+
+  const exercise = state.card.exercise
+  const judgement: Judgement = judge(exercise, value)
+  const answered = state.answered + 1
+
+  if (judgement.kind === "seated") {
+    const moved =
+      state.card.role === "ladder"
+        ? advanceRung(state.rung, state.rungCorrect)
+        : { rung: state.rung, rungCorrect: state.rungCorrect }
+    return {
+      ...state,
+      rung: moved.rung,
+      rungCorrect: moved.rungCorrect,
+      answered,
+      correct: state.correct + 1,
+      feedback: { kind: "seated" },
+      plan: { kind: "none" },
+      stopping: stopOffered(answered, state.queued.length),
+    }
+  }
+
+  const answer = writtenAnswer(exercise) ?? ""
+  const diagnosis = judgement.diagnosis
+  const log = [...state.log]
+
+  if (diagnosis !== null) {
+    log.push({ kind: "diagnosed", at: state.served, misconception: diagnosis.misconception })
+  }
+
+  const board =
+    diagnosis !== null && diagnosis.contrast !== null ? countingBoard(exercise, value) : null
+
+  if (diagnosis !== null && diagnosis.contrast !== null && board !== null) {
+    return {
+      ...state,
+      answered,
+      feedback: { kind: "struck", answer, stage: "locate" },
+      plan: {
+        kind: "locate",
+        board,
+        misconception: diagnosis.misconception,
+        representation: diagnosis.contrast,
+        rung: state.card.rung,
+      },
+      log,
+      // A repair sequence is not a place to offer a stopping point.
+      stopping: false,
+    }
+  }
+
+  return {
+    ...state,
+    answered,
+    feedback: { kind: "struck", answer, stage: "verify" },
+    plan: { kind: "retry", rung: easier(state.card.rung) },
+    log,
+    stopping: false,
+  }
+}
+
+function stopOffered(answered: number, queuedLength: number): boolean {
+  return answered > 0 && answered % RUN_LENGTH === 0 && queuedLength === 0
+}
+
+/**
+ * Idle work: materialise the follow-ups the verdict planned, and top the deck up.
+ *
+ * Runs after the verdict paints, never before it. Idempotent — calling it twice
+ * generates nothing the second time — so the store can schedule it liberally.
+ */
+export function prepare(state: SessionState, deps: SessionDeps = defaultDeps): SessionState {
+  const deckReady = state.deck.length >= DECK_DEPTH && state.deck.every((card) => card.rung === state.rung)
+  if (state.plan.kind === "none" && deckReady) return state
+
+  let next = state
+  let cursor = next.seedCursor
+  let queued = next.queued
+
+  if (next.plan.kind === "retry") {
+    queued = [...queued, problemCard(next.plan.rung, cursor, "retry", deps)]
+    cursor += 1
+    next = { ...next, plan: { kind: "none" } }
+  } else if (next.plan.kind === "locate") {
+    const { board, misconception, representation, rung } = next.plan
+    queued = [
+      ...queued,
+      { kind: "locate", board, misconception, representation, rung },
+      // The repair comes from the rung whose parameters *guarantee* the step,
+      // not from wherever the child happened to be standing.
+      problemCard(repairRung(misconception, rung), cursor, "repair", deps),
+    ]
+    cursor += 1
+    next = { ...next, plan: { kind: "none" } }
+  }
+
+  // A correct answer can move the ladder, which strands whatever was on deck for
+  // the rung below. Drop it here, during idle, so `advance` still finds a card in
+  // hand rather than generating one at present-time.
+  const deck = next.deck.filter((card) => card.rung === next.rung)
+  while (deck.length < DECK_DEPTH) {
+    deck.push(problemCard(next.rung, cursor, "ladder", deps))
+    cursor += 1
+  }
+
+  return { ...next, queued, deck, seedCursor: cursor }
+}
+
+/**
+ * Present the next card.
+ *
+ * Forced follow-ups first, then the deck. If both are empty the deck starved and
+ * this generates inline — correct behaviour, and counted, because a starving deck
+ * means the idle pass is not running and that is a latency bug worth failing a
+ * test over.
+ */
+export function advance(state: SessionState, deps: SessionDeps = defaultDeps): SessionState {
+  // A child who taps through before the idle pass ran must still get the
+  // contrast pair. Materialising a pending plan here is what makes "within N
+  // cards" a property of the machine rather than of how fast the browser felt
+  // like being idle.
+  const base = state.plan.kind === "none" ? state : prepare(state, deps)
+
+  let queued = base.queued
+  let deck = base.deck
+  let cursor = base.seedCursor
+  let starved = base.starved
+  let card: Card
+
+  const forced = queued[0]
+  if (forced !== undefined) {
+    card = forced
+    queued = queued.slice(1)
+  } else {
+    const ready = deck[0]
+    if (ready !== undefined && ready.rung === base.rung) {
+      card = ready
+      deck = deck.slice(1)
+    } else {
+      // Either nothing on deck, or what is on deck was generated for a rung the
+      // ladder has since left. Both are inline generation; only the first is a
+      // latency fault, and a rung change discards at most `DECK_DEPTH` cards.
+      if (ready === undefined) starved += 1
+      else deck = []
+      card = problemCard(base.rung, cursor, "ladder", deps)
+      cursor += 1
+    }
+  }
+
+  const served = base.served + 1
+  const log =
+    card.kind === "locate"
+      ? [
+          ...base.log,
+          {
+            kind: "contrast" as const,
+            at: served,
+            misconception: card.misconception,
+            representation: card.representation,
+          },
+        ]
+      : base.log
+
+  return {
+    ...base,
+    card,
+    entry: freshEntry(card),
+    feedback: null,
+    queued,
+    deck,
+    seedCursor: cursor,
+    served,
+    starved,
+    log,
+    stopping: false,
+  }
+}
+
+/**
+ * What Enter does on the card currently on screen.
+ *
+ * A decision, not a rendering detail, so it lives here where it can be tested.
+ * Getting it wrong is invisible to every other test in this file and to the type
+ * checker: the first version committed on every card, which on the contrast pair
+ * meant committing an entry that does not exist — Enter silently did nothing and
+ * the card could only be left by pointing at it. Found by driving the real
+ * screen, which is the only place it was ever going to show up.
+ */
+export function enterAction(state: SessionState): "commit" | "next" {
+  return state.feedback === null && state.card.kind === "problem" ? "commit" : "next"
+}
+
+/** Milliseconds to hold a seated answer before presenting the next card. */
+export function autoAdvanceMs(state: SessionState): number | null {
+  if (state.feedback?.kind !== "seated" || state.stopping) return null
+  return SEAT_HOLD_MS
+}
+
+/**
+ * Cards between a diagnosis and the contrast pair that answered it.
+ *
+ * The exit criterion is a number, so it is computed from the log rather than
+ * asserted from the code's shape. `null` means the diagnosis was never answered
+ * with a contrast — which is the correct outcome for a misconception this build
+ * has no representation for.
+ */
+export function contrastDistance(log: readonly LogEntry[], misconception: MalRuleId): number | null {
+  const diagnosed = log.find((entry) => entry.kind === "diagnosed" && entry.misconception === misconception)
+  const shown = log.find((entry) => entry.kind === "contrast" && entry.misconception === misconception)
+  if (diagnosed === undefined || shown === undefined) return null
+  return shown.at - diagnosed.at
+}

--- a/dynawalla/dynawalla-app/src/work/session.ts
+++ b/dynawalla/dynawalla-app/src/work/session.ts
@@ -25,19 +25,24 @@
 //                    seated beside it, one retry a rung easier. No lecture.
 //   Stage 2 LOCATE   wrong, and the answer *equals* a known buggy procedure's
 //                    output, and this build can draw that procedure's
-//                    contradiction. The contrast pair, then one repair item at
-//                    the same rung — the follow-up that isolates the
+//                    contradiction, and this session has not already drawn it
+//                    for that misconception. The contrast pair, then one repair
+//                    item at the same rung — the follow-up that isolates the
 //                    misunderstanding rather than repeating the card.
-//   Stage 3          not built. Repeated failure routes to Stage 1 again in M2.
+//   Stage 3          not built. Repeated failure routes to Stage 1 again in M2,
+//                    and that is also the floor under the repair loop: the same
+//                    board is never served twice in one session, because a child
+//                    who did not read it the first time is not helped by a third.
 //
 // The contrast pair is served as the **very next card**, which is a distance of
 // one — well inside the three the exit criterion allows.
 //
 // Stage 2 is not reachable by a rule that merely *claims* LOCATE capability:
 // `judge.contrastFor` requires this bundle to have the representation, and
-// `countingBoard` returns `null` when the contradiction would not actually be
-// visible. Both fall back to Stage 1. A LOCATE card that shows no contradiction
-// is worse than a quiet strike mark.
+// `countingBoard` returns `null` for every shape whose two plates cannot be drawn
+// as one honest comparison. Both fall back to Stage 1. A LOCATE card that shows
+// no contradiction — or shows a second, invented one — is worse than a quiet
+// strike mark.
 
 import { columnOpFamily } from "./curriculum.ts"
 import type { AnswerValue, Exercise, MalRuleId, RepId } from "./curriculum.ts"
@@ -238,7 +243,7 @@ export function commit(state: SessionState): SessionState {
       correct: state.correct + 1,
       feedback: { kind: "seated" },
       plan: { kind: "none" },
-      stopping: stopOffered(answered, state.queued.length),
+      stopping: stopOffered(answered, state.queued.length > 0),
     }
   }
 
@@ -250,8 +255,21 @@ export function commit(state: SessionState): SessionState {
     log.push({ kind: "diagnosed", at: state.served, misconception: diagnosis.misconception })
   }
 
+  // The floor under the repair loop. The first cut served the identical board
+  // again on every repeat, with the stopping point suppressed throughout, so the
+  // way out was withheld from exactly the run that needed it. ADAPTIVE_LEARNING
+  // routes repeated failure to Stage 3 RECONSTRUCT, which M2 has not built; its
+  // stand-in is Stage 1. One contrast pair per misconception per session.
+  const alreadyExplained =
+    diagnosis !== null &&
+    state.log.some(
+      (entry) => entry.kind === "contrast" && entry.misconception === diagnosis.misconception,
+    )
+
   const board =
-    diagnosis !== null && diagnosis.contrast !== null ? countingBoard(exercise, value) : null
+    diagnosis !== null && diagnosis.contrast !== null && !alreadyExplained
+      ? countingBoard(exercise, value)
+      : null
 
   if (diagnosis !== null && diagnosis.contrast !== null && board !== null) {
     return {
@@ -266,7 +284,9 @@ export function commit(state: SessionState): SessionState {
         rung: state.card.rung,
       },
       log,
-      // A repair sequence is not a place to offer a stopping point.
+      // The one suppression: never between a diagnosis and the explanation it
+      // earned. The contrast pair is the next card; putting "Done" in front of
+      // it is the app abandoning its own answer.
       stopping: false,
     }
   }
@@ -277,12 +297,19 @@ export function commit(state: SessionState): SessionState {
     feedback: { kind: "struck", answer, stage: "verify" },
     plan: { kind: "retry", rung: easier(state.card.rung) },
     log,
-    stopping: false,
+    stopping: stopOffered(answered, state.queued.length > 0),
   }
 }
 
-function stopOffered(answered: number, queuedLength: number): boolean {
-  return answered > 0 && answered % RUN_LENGTH === 0 && queuedLength === 0
+/**
+ * Is a designed stopping point on offer? A function of cards **done**, not cards
+ * done right. Computed only on the seated branch, answering card 12 wrong pushed
+ * the offer to card 24 and a bad run suppressed it entirely — withheld from the
+ * child who most needs it, which inverts ADR-0009. `blocked` is the mid-sequence
+ * suppression: a follow-up in hand, or a contrast pair about to be served.
+ */
+function stopOffered(answered: number, blocked: boolean): boolean {
+  return answered > 0 && answered % RUN_LENGTH === 0 && !blocked
 }
 
 /**

--- a/dynawalla/dynawalla-app/src/work/store.ts
+++ b/dynawalla/dynawalla-app/src/work/store.ts
@@ -1,0 +1,124 @@
+// The live session, held where every component reads it directly.
+//
+// Session state is not component state. The slate, the keypad, the verdict and
+// the counting board all need the same card, and threading it through props (or
+// worse, mirroring it into `useState`) is how a surface ends up with two answers
+// to "what is on screen". One store, read at the point of use.
+//
+// The split is: `session.ts` decides, this file schedules. Every transition here
+// is a call into a pure function plus the two things a pure function cannot do —
+// write to storage, and ask the platform for idle time. Both happen *after* the
+// verdict is in the store, which is after the frame that paints it is scheduled.
+
+import { create } from "zustand"
+
+import { idleScheduler } from "./idle.ts"
+import { expose, measure, now, record } from "./metrics.ts"
+import { DEFAULT_PROFILE_ID } from "./profile.ts"
+import { createProgressStore } from "./progress.ts"
+import { advance, commit, pressKey, prepare, startSession, type SessionState } from "./session.ts"
+import type { EntryKey } from "./entry.ts"
+
+export const progressStore = createProgressStore(DEFAULT_PROFILE_ID)
+
+// The latency rings, reachable from a console or a driver script — in dev only.
+// Vite substitutes `false` here in a production build, so the branch and
+// everything it reaches are eliminated: `rg __dwMetrics dist/` finds nothing.
+// Traces do not ship (A-18).
+if (import.meta.env.DEV) expose()
+
+interface PracticeState {
+  session: SessionState | null
+  /** When the current verdict landed, for the feedback→next-ready span. */
+  feedbackAt: number | null
+  begin: () => void
+  press: (key: EntryKey) => void
+  commitAnswer: () => void
+  next: () => void
+  runIdle: () => void
+  end: () => void
+}
+
+function savePosition(session: SessionState): void {
+  progressStore.getState().savePosition({
+    rung: session.rung,
+    rungCorrect: session.rungCorrect,
+    seedCursor: session.seedCursor,
+  })
+}
+
+export const usePractice = create<PracticeState>()((set, get) => ({
+  session: null,
+  feedbackAt: null,
+
+  begin: () => {
+    if (get().session !== null) return
+    const saved = progressStore.getState()
+    const session = startSession({
+      profileId: DEFAULT_PROFILE_ID,
+      rung: saved.rung,
+      rungCorrect: saved.rungCorrect,
+      seedCursor: saved.seedCursor,
+    })
+    set({ session, feedbackAt: null })
+    savePosition(session)
+  },
+
+  press: (key) => {
+    const session = get().session
+    if (session === null) return
+    const next = pressKey(session, key)
+    if (next !== session) set({ session: next })
+  },
+
+  commitAnswer: () => {
+    const session = get().session
+    if (session === null) return
+    const next = measure("commitToJudgement", () => commit(session))
+    if (next === session) return
+    set({ session: next, feedbackAt: now() })
+
+    const progress = progressStore.getState()
+    progress.recordAnswer(next.feedback?.kind === "seated")
+    const latest = next.log[next.log.length - 1]
+    if (latest?.kind === "diagnosed") progress.countBug(latest.misconception)
+    savePosition(next)
+  },
+
+  next: () => {
+    const session = get().session
+    if (session === null) return
+    const advanced = advance(session)
+    set({ session: advanced, feedbackAt: null })
+    savePosition(advanced)
+  },
+
+  runIdle: () => {
+    const { session, feedbackAt } = get()
+    if (session === null) return
+    const next = prepare(session)
+    if (next !== session) {
+      set({ session: next })
+      savePosition(next)
+    }
+    if (feedbackAt !== null) {
+      record("feedbackToReady", now() - feedbackAt)
+      set({ feedbackAt: null })
+    }
+  },
+
+  end: () => set({ session: null, feedbackAt: null }),
+}))
+
+/**
+ * Ask the platform for idle time and top the deck up in it.
+ *
+ * Returns its own canceller. Called from an effect on every state change the
+ * screen renders, which is more often than strictly needed and costs nothing:
+ * `prepare` is idempotent and returns the same object when there is no work.
+ */
+export function scheduleDeckFill(): () => void {
+  return idleScheduler()(() => {
+    usePractice.getState().runIdle()
+  })
+}

--- a/dynawalla/dynawalla-app/src/work/surface.test.ts
+++ b/dynawalla/dynawalla-app/src/work/surface.test.ts
@@ -26,6 +26,7 @@ const plate = read("ui/Plate.tsx")
 const slate = read("ui/ProblemSlate.tsx")
 const keypad = read("ui/Keypad.tsx")
 const board = read("ui/CountingBoardCard.tsx")
+const tokens = read("../design/tokens.css")
 
 test("the slate reservation in CSS matches the ladder it was computed from", () => {
   // Written in two languages, so they can drift. One numeral column per digit
@@ -33,6 +34,26 @@ test("the slate reservation in CSS matches the ladder it was computed from", () 
   const declared = /--dw-slate-columns:\s*(\d+)/.exec(workCss)
   assert.ok(declared !== null, "work.css declares no --dw-slate-columns")
   assert.equal(Number(declared[1]), SLATE_COLUMNS + 1)
+})
+
+test("the slate reservation actually binds — a width, not a minimum", () => {
+  // It shipped as `min-width` and never bound: the operator row sized the box
+  // past it, so the slate measured 115.22 px on a two-digit rung against
+  // 140.72 px on a four-digit one — `Q-01`'s reflow. Two halves: the box is
+  // declared, and nothing in the flow can outgrow it.
+  const rule = /\.dw-slate\s*\{([\s\S]*?)\n {2}\}/.exec(workCss)
+  assert.ok(rule !== null, "work.css has no .dw-slate rule")
+  // Declarations only. The comment explaining why it is not a `min-width` says
+  // "min-width", and a test that reads prose rather than CSS is a test that
+  // fails on its own explanation.
+  const body = (rule[1] ?? "").replace(/\/\*[\s\S]*?\*\//g, "")
+  assert.match(body, /(?<!min-)width:\s*calc\(var\(--dw-slate-columns\)/)
+  assert.ok(!/min-width/.test(body), "the reservation is a minimum again, and minimums do not bind")
+
+  // …and the operator is positioned, not laid out. In the flow it is the thing
+  // that sized the box.
+  const operatorRow = /<span className="absolute[^"]*"[\s\S]{0,80}OPERATOR\[problem\.op\]/.exec(slate)
+  assert.ok(operatorRow !== null, "the slate's operator is back in the flow")
 })
 
 test("the verdict row is in the layout before there is a verdict", () => {
@@ -135,16 +156,83 @@ test("nothing on the surface names a misconception to a child", () => {
   assert.ok(!/misconception/.test(board.split("*/").slice(1).join("*/")), "the board renders a rule id")
 })
 
-test("the practice surface costs seven strings and no status copy", () => {
+test("the practice surface costs fourteen strings and no status copy", () => {
   // Every string is five translations. This is the check that stops the count
   // creeping, and the list is here so adding one is a visible decision.
+  //
+  // Seven are text alternatives (`Q-10`), each replacing something announced as
+  // nothing at all: the verdict well was the empty string after a correct
+  // answer, the operators were `aria-hidden` so an item read as "95 19", and the
+  // counting board was twenty `aria-hidden` circles.
   assert.deepEqual(Object.keys(strings.practice).sort(), [
     "answer",
+    "boardCloses",
+    "boardPlace",
+    "boardSpare",
+    "boardSum",
     "check",
+    "correct",
     "delete",
     "done",
     "keepGoing",
+    "minus",
     "next",
+    "plus",
     "rebuild",
   ])
+})
+
+test("every representation on this surface has a text alternative", () => {
+  // `Q-10`, from the first representation authored. The board was `role`-less
+  // divs of `aria-hidden` spans: bare place numerals, no counts, nothing saying
+  // which plate rebuilds the number, and "this one is right" carried by
+  // `text-seat` versus `text-strike`. Colour is not an alternative.
+  assert.match(board, /role="img"/)
+  assert.match(board, /aria-label=\{plateLabel\(/)
+  for (const key of ["boardSum", "boardPlace", "boardSpare", "boardCloses"] as const) {
+    assert.ok(board.includes(`strings.practice.${key}`), `the board never reads ${key}`)
+  }
+
+  // Both verdict states put something non-visual in the live region. An
+  // `aria-hidden` mark and a bare number announce "" and "2203" respectively,
+  // and `line-through` is not exposed to assistive technology at all.
+  const well = /dw-verdict-well[\s\S]*?\n {8}<\/div>/.exec(slate)
+  assert.ok(well !== null, "the verdict well is not where this test thinks it is")
+  assert.match(well[0], /sr-only">\{strings\.practice\.correct\}/)
+  assert.match(well[0], /sr-only">\{strings\.practice\.answer\}/)
+
+  // The operator is spoken, not just drawn. Hidden with nothing in its place,
+  // `95 − 19` reads as "95 19".
+  assert.match(slate, /sr-only">\{OPERATOR_WORD\[problem\.op\]\}/)
+  assert.match(board, /sr-only">\{strings\.practice\.minus\}/)
+})
+
+test("being right is a visible event on the answer row, not a mark beside it", () => {
+  // `energy(SLIP) < energy(SEAT)` was structurally inverted: correct was an 8 px
+  // `aria-hidden` lozenge held 420 ms, wrong stopped the app, printed the answer,
+  // waited, and — when diagnosed — handed over the only illustration in the
+  // product. PR-2.6 closes it properly; the answer row seating is what this build
+  // can honestly do, and it must not quietly go away.
+  assert.match(workCss, /\.dw-seated\s*\{/)
+  assert.match(slate, /seated \? "dw-seated"/)
+  assert.match(slate, /border-seat/)
+  // No layout in it. A seated answer that changes a size moves the keypad.
+  const seatedRule = /\.dw-seated\s*\{([\s\S]*?)\n {2}\}/.exec(workCss)
+  assert.ok(seatedRule !== null)
+  assert.ok(
+    !/(^|[^-])(width|height|padding|margin|border-width|font-size):/.test(seatedRule[1] ?? ""),
+    "the seated state changes the box",
+  )
+
+  // …and it survives the dark recut. `ground-sunk` is `basalt-950` under
+  // `.dw-dark`, the same basalt as the surface the slate sits on, so a recess
+  // drawn with it is invisible in dark — the bug that ate the subtraction bar,
+  // found in a screenshot and nowhere else.
+  assert.ok(
+    !/background-color:\s*var\(--dw-ground-/.test(seatedRule[1] ?? ""),
+    "the seated recess is drawn with a ground that collapses in dark",
+  )
+  assert.match(seatedRule[1] ?? "", /background-color:\s*var\(--dw-seat-ground\)/)
+  assert.match(tokens, /:root\s*\{[\s\S]*?--dw-seat-ground:/)
+  assert.match(tokens, /\.dw-dark\s*\{[\s\S]*?--dw-seat-ground:/)
 })

--- a/dynawalla/dynawalla-app/src/work/surface.test.ts
+++ b/dynawalla/dynawalla-app/src/work/surface.test.ts
@@ -1,0 +1,150 @@
+// The claims a browser makes that a unit test cannot see — asserted against the
+// source, because the failure modes are all silent.
+//
+// A reflowing slate, a verdict that pushes the keypad down, a reduced-motion
+// branch that still travels, an emphasised "Keep going" next to a plain "Done":
+// none of these throw, none fail a type check, and a code reviewer reading a
+// diff cannot see any of them either. Every one is a rule this program wrote
+// down, so every one gets a mechanical check here and a look in a real browser
+// in the PR.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { SLATE_COLUMNS } from "./ladder.ts"
+import { strings } from "../app/strings.ts"
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const read = (relative: string): string => fs.readFileSync(path.join(here, relative), "utf8")
+
+const workCss = read("work.css")
+const practice = read("../screens/Practice.tsx")
+const plate = read("ui/Plate.tsx")
+const slate = read("ui/ProblemSlate.tsx")
+const keypad = read("ui/Keypad.tsx")
+const board = read("ui/CountingBoardCard.tsx")
+
+test("the slate reservation in CSS matches the ladder it was computed from", () => {
+  // Written in two languages, so they can drift. One numeral column per digit
+  // the ladder can write, plus one for the operator gutter.
+  const declared = /--dw-slate-columns:\s*(\d+)/.exec(workCss)
+  assert.ok(declared !== null, "work.css declares no --dw-slate-columns")
+  assert.equal(Number(declared[1]), SLATE_COLUMNS + 1)
+})
+
+test("the verdict row is in the layout before there is a verdict", () => {
+  // Feedback changes what is in the well, never whether the well exists. A
+  // conditionally rendered verdict is the reflow the design rules forbid.
+  assert.match(workCss, /\.dw-verdict-well\s*\{[^}]*min-height/)
+  assert.match(slate, /dw-verdict-well/)
+  const well = /dw-verdict-well[\s\S]*?<\/div>/.exec(slate)
+  assert.ok(well !== null)
+  assert.ok(
+    !/\{feedback\s*(!==|===)\s*null\s*\?[\s\S]{0,40}<div/.test(slate),
+    "the well itself is behind a conditional",
+  )
+})
+
+test("the keypad is disabled while a verdict shows, not unmounted", () => {
+  // Unmounting it pulls the action row up the screen at the exact moment the
+  // child is looking at their answer.
+  assert.match(practice, /disabled=\{feedback !== null\}/)
+  assert.ok(
+    !/feedback === null \? \(\s*<Keypad/.test(practice),
+    "the keypad is conditionally rendered on feedback",
+  )
+})
+
+test("reduced motion is a branch with no travel in it", () => {
+  const reduced = /@media \(prefers-reduced-motion: reduce\)\s*\{([\s\S]*?)\n {2}\}/.exec(workCss)
+  assert.ok(reduced !== null, "work.css has no reduced-motion branch")
+  const stillName = /animation-name:\s*([a-z-]+)/.exec(reduced[1] ?? "")?.[1]
+  assert.ok(stillName !== undefined)
+  assert.notEqual(stillName, "dw-seat-in", "reduced motion reuses the travelling keyframes")
+
+  const keyframes = new RegExp(`@keyframes ${stillName}\\s*\\{([\\s\\S]*?)\\n  \\}`).exec(workCss)
+  assert.ok(keyframes !== null, `work.css has no @keyframes ${stillName}`)
+  assert.ok(!/transform/.test(keyframes[1] ?? ""), "the reduced-motion keyframes still move the card")
+})
+
+test("the stopping point offers two plates and emphasises neither", () => {
+  // `P-10`. There is exactly one control shape on this surface and no
+  // emphasised variant to reach for, which is what makes equal weight
+  // structural rather than a thing someone eyeballs in a screenshot.
+  const stopping = /session\.stopping \? \(([\s\S]*?)<\/>/.exec(practice)
+  assert.ok(stopping !== null, "the stopping point is not where this test thinks it is")
+  const branch = stopping[1] ?? ""
+  assert.equal((branch.match(/<Plate\b/g) ?? []).length, 2, "the stopping point is not exactly two plates")
+  assert.match(branch, /strings\.practice\.done/)
+  assert.match(branch, /strings\.practice\.keepGoing/)
+  assert.ok(
+    !/className=|variant=|primary|emphas/i.test(branch),
+    "a stopping plate is styled differently from its pair",
+  )
+  // …and there is no such prop to pass. A declaration, not a mention: the
+  // component's own comment explains why the variant does not exist.
+  assert.ok(
+    !/\b(variant|primary|emphasis|tone)\s*[?:]/.test(plate),
+    "Plate.tsx has grown an emphasised variant",
+  )
+})
+
+test("touch targets are big enough for a child's finger", () => {
+  // ≥2 cm. `min-h-19` is 4.75 rem = 76 px = 2.0 cm at the 96 dpi CSS reference.
+  const target = /min-h-(\d+)/.exec(keypad)
+  assert.ok(target !== null)
+  const rem = Number(target[1]) * 0.25
+  assert.ok(rem * 16 >= 75, `keypad targets are ${String(rem * 16)} px, under the 2 cm floor`)
+})
+
+test("input is bound on pointerdown, not click", () => {
+  // A click resolves ~100 ms after the finger lands. Every keypress budget in
+  // EXPERIENCE_DESIGN is written against the frame the finger is in.
+  assert.match(keypad, /onPointerDown/)
+  assert.match(plate, /onPointerDown/)
+  // …and a keyboard still works, because keyboards send no pointer events.
+  assert.match(keypad, /event\.detail === 0/)
+  assert.match(plate, /event\.detail !== 0/)
+})
+
+test("no inline style anywhere on the surface — the CSP forbids it outright", () => {
+  // `style-src 'self'` with no `unsafe-inline`. A `style={{…}}` prop is silently
+  // dropped in the WebView and works perfectly in a dev browser.
+  for (const [name, source] of [
+    ["Practice.tsx", practice],
+    ["Plate.tsx", plate],
+    ["ProblemSlate.tsx", slate],
+    ["Keypad.tsx", keypad],
+    ["CountingBoardCard.tsx", board],
+  ] as const) {
+    assert.ok(!/style=\{/.test(source), `${name} sets an inline style`)
+  }
+})
+
+test("nothing on the surface names a misconception to a child", () => {
+  // `M-16`. The ids are internal; a learner-facing string that says
+  // "borrow-across-zero", "mistake", "error" or "wrong" is a bug.
+  const banned = /mis\.|misconception|mal-?rule|mistake|incorrect|wrong/i
+  for (const [key, value] of Object.entries(strings.practice)) {
+    assert.ok(!banned.test(value), `strings.practice.${key} names a defect: ${value}`)
+  }
+  // The board renders the misconception's *consequence*, never its name.
+  assert.ok(!/misconception/.test(board.split("*/").slice(1).join("*/")), "the board renders a rule id")
+})
+
+test("the practice surface costs seven strings and no status copy", () => {
+  // Every string is five translations. This is the check that stops the count
+  // creeping, and the list is here so adding one is a visible decision.
+  assert.deepEqual(Object.keys(strings.practice).sort(), [
+    "answer",
+    "check",
+    "delete",
+    "done",
+    "keepGoing",
+    "next",
+    "rebuild",
+  ])
+})

--- a/dynawalla/dynawalla-app/src/work/ui/CountingBoardCard.tsx
+++ b/dynawalla/dynawalla-app/src/work/ui/CountingBoardCard.tsx
@@ -1,29 +1,33 @@
 import { IndexMark } from "../../design/IndexMark.tsx"
-import { strings } from "../../app/strings.ts"
+import { fill, strings } from "../../app/strings.ts"
 import type { BoardCheck, BoardColumn, CountingBoard } from "../contrast.ts"
 
 /**
  * The Stage-2 LOCATE contrast pair.
  *
- * Two boards. On each, the sockets carved into the stone are the number the
- * problem started from, and the counters are what that answer plus the
- * subtrahend actually comes to. The correct answer fills every socket and no
- * more. The child's answer leaves one counter with nowhere to sit — the thousand
- * that was borrowed and never given up, standing proud of the board.
+ * Two boards over **one** column set. The sockets carved in the stone are the
+ * number the problem started from; the counters are what that answer plus the
+ * subtrahend comes to. The correct answer fills every socket and no more; the
+ * child's fills them too and has a counter left over — the thousand borrowed and
+ * never given up, standing proud of the board.
  *
- * The contradiction is a thing you can see, and it is *the child's own procedure*
- * carried through to where it stops closing. Nothing here names a misconception,
- * says a step was missed, or tells the child they were wrong (M-16): the boards
- * go side by side and the arithmetic is left to do the talking.
+ * The shared column set is load-bearing, not tidiness: a plate that omits its
+ * empty leading places puts its hundreds under the other's thousands, and the
+ * comparison the card exists to make is gone. Every place in `board.places` is
+ * drawn on both plates, empty or not.
  *
- * A counter that seats is a disc; one that cannot is a diamond, outside the
- * socket run. Shape and position, not colour, carry it (`Q-10`).
+ * Nothing here names a misconception, says a step was missed, or tells the child
+ * they were wrong (M-16). `Q-10`: a counter that seats is a disc, one that cannot
+ * is a diamond outside the run — shape and position, never colour — and each
+ * plate is a `role="img"` carrying the whole board in words, counts and all.
  */
 export function CountingBoardCard({ board }: { board: CountingBoard }) {
   return (
     <div className="dw-present flex flex-col gap-4">
       <p className="numeral text-ink text-xl">
-        {board.minuend} <span aria-hidden="true">−</span> {board.subtrahend}
+        {board.minuend}{" "}
+        <span aria-hidden="true">−</span>
+        <span className="sr-only">{strings.practice.minus}</span> {board.subtrahend}
       </p>
       <p className="text-ink-muted text-sm tracking-wide">{strings.practice.rebuild}</p>
 
@@ -35,12 +39,61 @@ export function CountingBoardCard({ board }: { board: CountingBoard }) {
   )
 }
 
+/**
+ * One plate, in words: the sum, then every place that holds anything, then the
+ * counters with nowhere to sit — or the fact that there are none. Empty places
+ * are drawn (the columns must line up) and skipped here (silence is not a column).
+ */
+function plateLabel(board: CountingBoard, check: BoardCheck): string {
+  const parts = [
+    fill(strings.practice.boardSum, {
+      addend: check.addend,
+      subtrahend: board.subtrahend,
+      sum: check.sum,
+    }),
+  ]
+  for (const column of check.columns) {
+    if (column.sockets > 0) {
+      parts.push(
+        fill(strings.practice.boardPlace, {
+          place: placeLabel(column.place),
+          seated: column.seated,
+          sockets: column.sockets,
+        }),
+      )
+    }
+  }
+  for (const column of check.columns) {
+    if (column.spare > 0) {
+      parts.push(
+        fill(strings.practice.boardSpare, {
+          place: placeLabel(column.place),
+          spare: column.spare,
+        }),
+      )
+    }
+  }
+  if (check.rebuilds) parts.push(strings.practice.boardCloses)
+  return parts.join(" ")
+}
+
 function BoardPlate({ board, check }: { board: CountingBoard; check: BoardCheck }) {
   return (
-    <div className="border-line-cut rounded-cut-md bg-ground-sunk flex-1 border-t border-b p-3">
-      <p className="numeral text-ink mb-3 flex items-center gap-2 text-lg">
+    <div
+      // `role="img"`: the plate is a picture and this is its alternative. Under
+      // that role the descendants are presentational, so the numerals and place
+      // labels are not read a second time in a different order.
+      role="img"
+      aria-label={plateLabel(board, check)}
+      className="border-line-cut rounded-cut-md bg-ground-sunk flex-1 border-t border-b p-3"
+    >
+      {/* Explicitly presentational. `role="img"` makes descendants presentational
+          by the ARIA spec, but Chrome still lists every numeral in the tree it
+          hands a driver, so the drawing is hidden outright and the label above is
+          the only thing exposed. */}
+      <p aria-hidden="true" className="numeral text-ink mb-3 flex items-center gap-2 text-lg">
         <span>
-          {check.addend} <span aria-hidden="true">+</span> {board.subtrahend} ={" "}
+          {check.addend} + {board.subtrahend} ={" "}
           <span className={check.rebuilds ? "text-seat" : "text-strike"}>{check.sum}</span>
         </span>
         {check.rebuilds ? <IndexMark className="text-seat" /> : null}
@@ -50,7 +103,7 @@ function BoardPlate({ board, check }: { board: CountingBoard; check: BoardCheck 
           labels land on one line. A place with nothing in it — the tens of
           606 — is then an empty column with a floor, which is what it is,
           rather than a label floating at the top of the board. */}
-      <div className="flex items-stretch justify-start gap-1 overflow-x-auto">
+      <div aria-hidden="true" className="flex items-stretch justify-start gap-1 overflow-x-auto">
         {check.columns.map((column) => (
           <PlaceColumn key={column.place} column={column} />
         ))}
@@ -64,31 +117,24 @@ function BoardPlate({ board, check }: { board: CountingBoard; check: BoardCheck 
  * anything left over sitting above the run with nowhere to go.
  */
 function PlaceColumn({ column }: { column: BoardColumn }) {
-  const seated = Math.min(column.counters, column.sockets)
-  const empty = Math.max(0, column.sockets - column.counters)
-  const surplus = Math.max(0, column.counters - column.sockets)
-
   return (
     <div className="flex min-w-10 flex-col items-center justify-end gap-1 px-1">
-      {range(surplus).map((i) => (
+      {range(column.spare).map((i) => (
         <span
-          key={`surplus-${String(i)}`}
+          key={`spare-${String(i)}`}
           className="border-strike bg-ground-raised mb-2 block size-4 rotate-45 border-2"
-          aria-hidden="true"
         />
       ))}
-      {range(seated).map((i) => (
+      {range(column.seated).map((i) => (
         <span
           key={`seated-${String(i)}`}
           className="border-line-cut bg-index block size-4 rounded-full border"
-          aria-hidden="true"
         />
       ))}
-      {range(empty).map((i) => (
+      {range(column.sockets - column.seated).map((i) => (
         <span
           key={`empty-${String(i)}`}
           className="border-line-cut block size-4 rounded-full border border-dashed"
-          aria-hidden="true"
         />
       ))}
       <span className="numeral text-ink-muted border-line mt-1 w-full border-t pt-1 text-center text-xs">

--- a/dynawalla/dynawalla-app/src/work/ui/CountingBoardCard.tsx
+++ b/dynawalla/dynawalla-app/src/work/ui/CountingBoardCard.tsx
@@ -1,0 +1,108 @@
+import { IndexMark } from "../../design/IndexMark.tsx"
+import { strings } from "../../app/strings.ts"
+import type { BoardCheck, BoardColumn, CountingBoard } from "../contrast.ts"
+
+/**
+ * The Stage-2 LOCATE contrast pair.
+ *
+ * Two boards. On each, the sockets carved into the stone are the number the
+ * problem started from, and the counters are what that answer plus the
+ * subtrahend actually comes to. The correct answer fills every socket and no
+ * more. The child's answer leaves one counter with nowhere to sit — the thousand
+ * that was borrowed and never given up, standing proud of the board.
+ *
+ * The contradiction is a thing you can see, and it is *the child's own procedure*
+ * carried through to where it stops closing. Nothing here names a misconception,
+ * says a step was missed, or tells the child they were wrong (M-16): the boards
+ * go side by side and the arithmetic is left to do the talking.
+ *
+ * A counter that seats is a disc; one that cannot is a diamond, outside the
+ * socket run. Shape and position, not colour, carry it (`Q-10`).
+ */
+export function CountingBoardCard({ board }: { board: CountingBoard }) {
+  return (
+    <div className="dw-present flex flex-col gap-4">
+      <p className="numeral text-ink text-xl">
+        {board.minuend} <span aria-hidden="true">−</span> {board.subtrahend}
+      </p>
+      <p className="text-ink-muted text-sm tracking-wide">{strings.practice.rebuild}</p>
+
+      <div className="flex flex-col gap-4 sm:flex-row">
+        <BoardPlate board={board} check={board.correct} />
+        <BoardPlate board={board} check={board.yours} />
+      </div>
+    </div>
+  )
+}
+
+function BoardPlate({ board, check }: { board: CountingBoard; check: BoardCheck }) {
+  return (
+    <div className="border-line-cut rounded-cut-md bg-ground-sunk flex-1 border-t border-b p-3">
+      <p className="numeral text-ink mb-3 flex items-center gap-2 text-lg">
+        <span>
+          {check.addend} <span aria-hidden="true">+</span> {board.subtrahend} ={" "}
+          <span className={check.rebuilds ? "text-seat" : "text-strike"}>{check.sum}</span>
+        </span>
+        {check.rebuilds ? <IndexMark className="text-seat" /> : null}
+      </p>
+
+      {/* `items-stretch` so every column is as tall as the tallest and the place
+          labels land on one line. A place with nothing in it — the tens of
+          606 — is then an empty column with a floor, which is what it is,
+          rather than a label floating at the top of the board. */}
+      <div className="flex items-stretch justify-start gap-1 overflow-x-auto">
+        {check.columns.map((column) => (
+          <PlaceColumn key={column.place} column={column} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * One place value: the sockets cut for it, the counters dropped into them, and
+ * anything left over sitting above the run with nowhere to go.
+ */
+function PlaceColumn({ column }: { column: BoardColumn }) {
+  const seated = Math.min(column.counters, column.sockets)
+  const empty = Math.max(0, column.sockets - column.counters)
+  const surplus = Math.max(0, column.counters - column.sockets)
+
+  return (
+    <div className="flex min-w-10 flex-col items-center justify-end gap-1 px-1">
+      {range(surplus).map((i) => (
+        <span
+          key={`surplus-${String(i)}`}
+          className="border-strike bg-ground-raised mb-2 block size-4 rotate-45 border-2"
+          aria-hidden="true"
+        />
+      ))}
+      {range(seated).map((i) => (
+        <span
+          key={`seated-${String(i)}`}
+          className="border-line-cut bg-index block size-4 rounded-full border"
+          aria-hidden="true"
+        />
+      ))}
+      {range(empty).map((i) => (
+        <span
+          key={`empty-${String(i)}`}
+          className="border-line-cut block size-4 rounded-full border border-dashed"
+          aria-hidden="true"
+        />
+      ))}
+      <span className="numeral text-ink-muted border-line mt-1 w-full border-t pt-1 text-center text-xs">
+        {placeLabel(column.place)}
+      </span>
+    </div>
+  )
+}
+
+/** The place written as the unit it holds: 1, 10, 100, 1000. */
+function placeLabel(place: number): string {
+  return `1${"0".repeat(place)}`
+}
+
+function range(n: number): number[] {
+  return Array.from({ length: n }, (_, i) => i)
+}

--- a/dynawalla/dynawalla-app/src/work/ui/Keypad.tsx
+++ b/dynawalla/dynawalla-app/src/work/ui/Keypad.tsx
@@ -1,0 +1,86 @@
+import { strings } from "../../app/strings.ts"
+import type { EntryKey, EntryModel, KeyCap } from "../entry.ts"
+import type { AnswerSchema } from "../curriculum.ts"
+
+/**
+ * The keypad, laid out from whatever the entry model declares.
+ *
+ * It reads `model.keys(schema)` and draws that. It does not know what an integer
+ * is, and it will not need changing when a fraction model adds a `/` cap or a
+ * decimal model adds the locale's separator — which is the point of the entry
+ * layer being a declared structure rather than a text field.
+ *
+ * Targets are ≥2 cm on the diagonal a child actually hits: `min-h-19` is 4.75 rem
+ * = 76 px = 2.0 cm at the 96 dpi CSS reference, and three columns of them still
+ * fit inside 320 px. Bound on `pointerdown`, so the acknowledgement is in the
+ * frame the finger lands in rather than ~100 ms later when the tap resolves.
+ */
+export function Keypad({
+  model,
+  schema,
+  onKey,
+  disabled,
+}: {
+  model: EntryModel
+  schema: AnswerSchema
+  onKey: (key: EntryKey) => void
+  disabled: boolean
+}) {
+  const caps = model.keys(schema)
+
+  return (
+    <div className="grid grid-cols-3 gap-2">
+      {caps.map((cap, index) =>
+        cap.kind === "blank" ? (
+          <div key={`blank-${String(index)}`} aria-hidden="true" />
+        ) : (
+          <KeyPlate key={capId(cap)} cap={cap} onKey={onKey} disabled={disabled} />
+        ),
+      )}
+    </div>
+  )
+}
+
+type PressableCap = Exclude<KeyCap, { kind: "blank" }>
+
+function capId(cap: PressableCap): string {
+  return cap.kind === "glyph" ? cap.glyph : cap.kind
+}
+
+function capKey(cap: PressableCap): EntryKey {
+  return cap.kind === "glyph" ? { kind: "glyph", glyph: cap.glyph } : { kind: "delete" }
+}
+
+function KeyPlate({
+  cap,
+  onKey,
+  disabled,
+}: {
+  cap: PressableCap
+  onKey: (key: EntryKey) => void
+  disabled: boolean
+}) {
+  const press = () => {
+    if (!disabled) onKey(capKey(cap))
+  }
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      aria-label={cap.kind === "delete" ? strings.practice.delete : undefined}
+      onPointerDown={(event) => {
+        event.preventDefault()
+        press()
+      }}
+      onClick={(event) => {
+        // Keyboards do not send pointer events; Enter and Space arrive here
+        // with `detail === 0`. A real tap already ran on pointer-down.
+        if (event.detail === 0) press()
+      }}
+      className="border-line-strong rounded-cut-md bg-ground-raised text-ink numeral active:bg-ground-sunk flex min-h-19 items-center justify-center border text-2xl transition-colors duration-[var(--dw-motion-quick)] disabled:opacity-40"
+    >
+      {cap.kind === "glyph" ? cap.glyph : "⌫"}
+    </button>
+  )
+}

--- a/dynawalla/dynawalla-app/src/work/ui/Plate.tsx
+++ b/dynawalla/dynawalla-app/src/work/ui/Plate.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from "react"
+
+/**
+ * A cut plate: the one control shape this surface has.
+ *
+ * There is exactly one, and that is the point. `P-10` requires "Done" and "Keep
+ * going" to be equal-weight at every designed stopping point, and the only way to
+ * make that structurally true rather than a thing someone checks in a screenshot
+ * is for there to be no emphasised variant to reach for. No `primary`, no
+ * `accent`, no size prop. `stopping.test.ts` reads this file and the screen that
+ * uses it and asserts the pair renders through it with nothing added.
+ *
+ * Squared off — 4 px chamfers, not pills. Minimum 3rem tall so a child's finger
+ * lands on it, and `touch-action: manipulation` inherited from the body so a
+ * double tap never zooms the work surface.
+ */
+export function Plate({
+  children,
+  onPress,
+  disabled = false,
+}: {
+  children: ReactNode
+  onPress: () => void
+  disabled?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      // `pointerdown`, not `click`: EXPERIENCE_DESIGN binds every keypress on
+      // pointer-down so the visual acknowledgement lands in the same frame as
+      // the finger, rather than ~100 ms later when the tap resolves.
+      onPointerDown={(event) => {
+        if (disabled) return
+        // Keeps focus where it is and stops the synthetic click that follows.
+        event.preventDefault()
+        onPress()
+      }}
+      // Keyboards do not send pointer events. Enter and Space arrive as clicks.
+      onClick={(event) => {
+        if (event.detail !== 0 || disabled) return
+        onPress()
+      }}
+      className="border-line-strong rounded-cut-md bg-ground-raised text-ink inscription hover:bg-ground-sunk flex min-h-12 flex-1 items-center justify-center border px-5 text-lg tracking-wide transition-colors duration-[var(--dw-motion-quick)] disabled:opacity-40"
+    >
+      {children}
+    </button>
+  )
+}

--- a/dynawalla/dynawalla-app/src/work/ui/ProblemSlate.tsx
+++ b/dynawalla/dynawalla-app/src/work/ui/ProblemSlate.tsx
@@ -5,23 +5,28 @@ import { readProblem } from "../problem.ts"
 import { fieldText, type EntryState } from "../entry.ts"
 
 const OPERATOR = { sub: "−", add: "+" } as const
+/** The operator read aloud. The glyph is decorative; without this an item is "95 19". */
+const OPERATOR_WORD = { sub: strings.practice.minus, add: strings.practice.plus } as const
 
 /**
  * The problem, written the way it is written on paper.
  *
- * Right-aligned on a fixed run of numeral columns (`.dw-slate`) with tabular
- * figures, so the units column of a two-digit problem sits exactly where the
- * units column of a four-digit one sits and the surface does not move between
- * cards. That is not a nicety: a slate that reflows is a slate whose next
- * problem cost a layout, which is the one thing the answer path may not do.
+ * Right-aligned on a **fixed** run of numeral columns (`.dw-slate`) with tabular
+ * figures, so the units column of a two-digit problem sits where the units column
+ * of a four-digit one sits and the surface does not move between cards. The
+ * operator sits in the reserved gutter rather than in the row: in the flow it was
+ * the operator row that sized the box, the reservation was a `min-width` that
+ * never bound, and the slate measured 115 px on a two-digit rung against 141 px
+ * on a four-digit one.
  *
- * The verdict lands *in the slate*, in the place the answer goes — not in a
- * banner elsewhere on the screen. Its row is in the layout from the first frame
- * and holds its height whether it is empty, seated or struck, so feedback
- * appearing never moves the keypad under the child's finger.
+ * The verdict lands *in the slate*, where the answer goes. Its row is in the
+ * layout from the first frame and holds its height empty, seated or struck, so
+ * feedback never moves the keypad under the child's finger.
  *
- * Nothing here is carried by colour alone: a wrong answer is struck through and
- * the correct one is written beneath it; a right answer takes the index mark.
+ * Nothing here is carried by colour alone, and none of it by pixels alone: a
+ * correct answer *seats* — the glyphs settle onto a solid rule in a recess that
+ * was not there a frame ago — and the well says so in words a screen reader
+ * reads. A wrong answer is struck through with the correct one labelled beneath.
  */
 export function ProblemSlate({
   card,
@@ -37,15 +42,21 @@ export function ProblemSlate({
 
   const typed = entry === null ? "" : fieldText(entry)
   const struck = feedback?.kind === "struck"
+  const seated = feedback?.kind === "seated"
 
   return (
     <div className="dw-present flex justify-center">
       <div className="dw-slate numeral text-right text-3xl leading-tight">
         <div className="text-ink py-1">{problem.top}</div>
 
-        <div className="text-ink flex items-baseline justify-between gap-6 py-1">
-          <span aria-hidden="true">{OPERATOR[problem.op]}</span>
-          <span>{problem.bottom}</span>
+        {/* The operator is `absolute` in the gutter the reservation cut for it.
+            Laid out in the row it always sized the box past the reservation, so
+            the units column moved between rungs — the reflow `Q-01` forbids. */}
+        <div className="text-ink relative py-1">
+          <span className="absolute top-1 left-0" aria-hidden="true">
+            {OPERATOR[problem.op]}
+          </span>
+          <span className="sr-only">{OPERATOR_WORD[problem.op]}</span> {problem.bottom}
         </div>
 
         {/* The subtraction bar is a structural edge (`line-strong`), not the
@@ -61,15 +72,19 @@ export function ProblemSlate({
             the right of the digits and push them off the column the problem is
             written in — and the units digit landing under the units digit is the
             entire reason this is a slate and not a form. A colour change on a
-            rule that is always there costs no layout at all. */}
+            rule that is always there costs no layout at all.
+
+            A correct answer turns that rule solid and drops the row into a
+            recess (`dw-seated`). Being right has to be the state that visibly
+            happens: a surface where only being wrong produces an event teaches
+            the wrong thing about where the interesting part of the app is. */}
         <div
           className={[
             "border-b-2 py-1",
-            // Brass while the surface is live; a hairline that separates a
-            // struck answer from the correct one; gone when there is nothing to
-            // separate. The width never changes, so neither does the layout.
-            feedback === null ? "border-index" : struck ? "border-line" : "border-transparent",
-            struck ? "text-strike line-through decoration-2" : "text-ink",
+            feedback === null ? "border-index" : struck ? "border-line" : "border-seat",
+            struck ? "text-strike line-through decoration-2" : seated ? "text-seat" : "text-ink",
+            seated ? "dw-seated" : "",
+            rebuffClass(entry),
           ].join(" ")}
         >
           {/* Labelled, not live: the verdict well below is the one live region on
@@ -80,15 +95,45 @@ export function ProblemSlate({
               and the row loses its height in the instant before the first digit
               lands — a layout shift on every single card. */}
           <span role="group" aria-label={strings.practice.answer}>
-            {typed === "" ? "\u00A0" : typed}
+            {typed === "" ? " " : typed}
           </span>
         </div>
 
+        {/* The one live region. It has text in **both** verdict states: an
+            `aria-hidden` mark and a bare number announce nothing and "wrong" is
+            then carried by `line-through`, which assistive technology does not
+            expose at all (`Q-09`, `Q-10`). */}
         <div className="dw-verdict-well flex items-center justify-end gap-2 pt-1" role="status">
-          {feedback?.kind === "seated" ? <IndexMark className="text-seat" /> : null}
-          {feedback?.kind === "struck" ? <span className="text-seat">{feedback.answer}</span> : null}
+          {seated ? (
+            <>
+              <span className="sr-only">{strings.practice.correct}</span>
+              <IndexMark className="text-seat size-4" />
+            </>
+          ) : null}
+          {feedback?.kind === "struck" ? (
+            <>
+              {/* The trailing space is inside the hidden span on purpose: as a
+                  text node between two flex items it would be an anonymous
+                  flex item of its own, and this row's height is a promise. */}
+              <span className="sr-only">{strings.practice.answer}{" "}</span>
+              <span className="text-seat">{feedback.answer}</span>
+            </>
+          ) : null}
         </div>
       </div>
     </div>
   )
+}
+
+/**
+ * The acknowledgement for a key the field could not take. A full field swallowed
+ * it silently: on `95 − 19` the cap is two, so 9 · 7 · 6 left "97" with nothing
+ * to say the 6 had gone, and a child who presses a key and sees nothing assumes
+ * the app is broken. Transient status text is forbidden, so the answer rule ticks
+ * its colour for one beat — no layout, no string. `entry.rebuffed` is a count,
+ * not a flag, so the two class names alternate and restart the animation.
+ */
+function rebuffClass(entry: EntryState | null): string {
+  if (entry === null || entry.rebuffed === 0) return ""
+  return entry.rebuffed % 2 === 1 ? "dw-rebuff-a" : "dw-rebuff-b"
 }

--- a/dynawalla/dynawalla-app/src/work/ui/ProblemSlate.tsx
+++ b/dynawalla/dynawalla-app/src/work/ui/ProblemSlate.tsx
@@ -1,0 +1,94 @@
+import { IndexMark } from "../../design/IndexMark.tsx"
+import { strings } from "../../app/strings.ts"
+import type { Card, Feedback } from "../session.ts"
+import { readProblem } from "../problem.ts"
+import { fieldText, type EntryState } from "../entry.ts"
+
+const OPERATOR = { sub: "−", add: "+" } as const
+
+/**
+ * The problem, written the way it is written on paper.
+ *
+ * Right-aligned on a fixed run of numeral columns (`.dw-slate`) with tabular
+ * figures, so the units column of a two-digit problem sits exactly where the
+ * units column of a four-digit one sits and the surface does not move between
+ * cards. That is not a nicety: a slate that reflows is a slate whose next
+ * problem cost a layout, which is the one thing the answer path may not do.
+ *
+ * The verdict lands *in the slate*, in the place the answer goes — not in a
+ * banner elsewhere on the screen. Its row is in the layout from the first frame
+ * and holds its height whether it is empty, seated or struck, so feedback
+ * appearing never moves the keypad under the child's finger.
+ *
+ * Nothing here is carried by colour alone: a wrong answer is struck through and
+ * the correct one is written beneath it; a right answer takes the index mark.
+ */
+export function ProblemSlate({
+  card,
+  entry,
+  feedback,
+}: {
+  card: Extract<Card, { kind: "problem" }>
+  entry: EntryState | null
+  feedback: Feedback | null
+}) {
+  const problem = readProblem(card.exercise)
+  if (problem === null) return null
+
+  const typed = entry === null ? "" : fieldText(entry)
+  const struck = feedback?.kind === "struck"
+
+  return (
+    <div className="dw-present flex justify-center">
+      <div className="dw-slate numeral text-right text-3xl leading-tight">
+        <div className="text-ink py-1">{problem.top}</div>
+
+        <div className="text-ink flex items-baseline justify-between gap-6 py-1">
+          <span aria-hidden="true">{OPERATOR[problem.op]}</span>
+          <span>{problem.bottom}</span>
+        </div>
+
+        {/* The subtraction bar is a structural edge (`line-strong`), not the
+            shadow inside a carved groove (`line-cut`). In dark, `line-cut` and
+            `ground-sunk` are the same basalt — the bar disappeared entirely and
+            the answer read as a third operand. Only visible in the dark
+            screenshots; nothing else would have caught it. */}
+        <div className="border-line-strong border-t-2" />
+
+        {/* Where the answer is written.
+            The affordance is the guide line under it, brass while the surface is
+            taking input and stone once it is not. A caret would have to sit to
+            the right of the digits and push them off the column the problem is
+            written in — and the units digit landing under the units digit is the
+            entire reason this is a slate and not a form. A colour change on a
+            rule that is always there costs no layout at all. */}
+        <div
+          className={[
+            "border-b-2 py-1",
+            // Brass while the surface is live; a hairline that separates a
+            // struck answer from the correct one; gone when there is nothing to
+            // separate. The width never changes, so neither does the layout.
+            feedback === null ? "border-index" : struck ? "border-line" : "border-transparent",
+            struck ? "text-strike line-through decoration-2" : "text-ink",
+          ].join(" ")}
+        >
+          {/* Labelled, not live: the verdict well below is the one live region on
+              this screen. Announcing the answer line too would read every digit
+              twice — once as the key pressed, once as the line it landed on.
+
+              A no-break space, not an ordinary one: an empty line box collapses
+              and the row loses its height in the instant before the first digit
+              lands — a layout shift on every single card. */}
+          <span role="group" aria-label={strings.practice.answer}>
+            {typed === "" ? "\u00A0" : typed}
+          </span>
+        </div>
+
+        <div className="dw-verdict-well flex items-center justify-end gap-2 pt-1" role="status">
+          {feedback?.kind === "seated" ? <IndexMark className="text-seat" /> : null}
+          {feedback?.kind === "struck" ? <span className="text-seat">{feedback.answer}</span> : null}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dynawalla/dynawalla-app/src/work/work.css
+++ b/dynawalla/dynawalla-app/src/work/work.css
@@ -1,7 +1,7 @@
 /* ──────────────────────────────────────────────────────────────────────────
    The work surface.
 
-   Three things that cannot be expressed as utilities on an element, because
+   Four things that cannot be expressed as utilities on an element, because
    they are structural promises the loop makes and a test reads this file to
    check them:
 
@@ -11,7 +11,9 @@
      2. The verdict well is always in the layout. Feedback changes what is
         inside it and never whether it exists — a strike mark that pushes the
         keypad down is the "jolting reflow" the design rules forbid outright.
-     3. The present animation has a reduced-motion branch, not a degradation:
+     3. A correct answer is a visible event on the answer row itself, not a
+        decorative mark beside it.
+     4. The present animation has a reduced-motion branch, not a degradation:
         a different keyframe set with no `transform` in it at all.
 
    The CSP forbids inline style entirely (`style-src 'self'`), so anything
@@ -21,16 +23,79 @@
 @layer components {
   .dw-slate {
     /* One numeral column per digit the ladder can put on the slate, plus one
-       for the operator gutter. `work.test.ts` asserts this equals
+       for the operator gutter. `surface.test.ts` asserts this equals
        `SLATE_COLUMNS + 1` computed from the ladder — the two cannot drift. */
     --dw-slate-columns: 5;
-    min-width: calc(var(--dw-slate-columns) * 1ch);
+
+    /* `width`, not `min-width`. As a minimum it never bound: the operator row
+       sized the box past it on every card, so the slate measured 115.22 px on a
+       two-digit rung against 140.72 px on a four-digit one and the units column
+       moved 12.75 px between cards. The operator is out of the flow (see
+       `ProblemSlate`) so the bottom row cannot size the box either, and
+       `.numeral` is `tabular-nums`, so a digit is exactly one `ch`. */
+    width: calc(var(--dw-slate-columns) * 1ch);
   }
 
   /* One numeral line, reserved from the first frame. Feedback changes what is
-     in it, never whether it is there. */
+     in it, never whether it is there.
+
+     Derived from the tokens, not eyeballed. It was `2.75rem` = 44 px, while the
+     line it must hold is `--text-3xl` (38 px) at the slate's `leading-tight`
+     (1.25) = 47.5 px plus 4 px of padding = 51.5 px. So the well grew 7.5 px the
+     moment a correct answer was written into it and took the keypad down the
+     screen with it, on every wrong answer — the reflow promised against above.
+     `bench-loop.mjs` reported `maxKeypadShiftPx` 7.5 as soon as the driver
+     started answering some cards wrong; the all-correct driver never could,
+     because a seated verdict is an 8 px mark that fits. */
   .dw-verdict-well {
-    min-height: 2.75rem;
+    min-height: calc(var(--text-3xl) * 1.25 + 0.25rem);
+  }
+
+  /* A correct answer seats: the row drops into a recess and the rule under it
+     goes solid. Colour, background and an inset edge only — no size, margin or
+     border-width — so the event costs nothing in layout. It exists because the
+     seated state was an 8 px lozenge held 420 ms while the struck state stopped
+     the app, printed the answer and waited: `energy(SLIP) < energy(SEAT)` was
+     structurally inverted long before any reaction shipped. */
+  .dw-seated {
+    background-color: var(--dw-seat-ground);
+    box-shadow: inset 0 2px 0 -1px var(--dw-line-cut);
+    animation-name: dw-seat-settle;
+    animation-duration: var(--dw-motion-detent);
+    animation-timing-function: var(--dw-ease-detent);
+    animation-fill-mode: both;
+  }
+
+  @keyframes dw-seat-settle {
+    from {
+      background-color: transparent;
+    }
+    to {
+      background-color: var(--dw-seat-ground);
+    }
+  }
+
+  /* A key the field could not take: one beat of the rule going hard, then back.
+     Two names for one animation so consecutive rejections alternate and restart
+     it; `ProblemSlate` picks by parity. No travel and no layout, which is why
+     there is no reduced-motion branch — there is no motion to reduce. */
+  .dw-rebuff-a,
+  .dw-rebuff-b {
+    animation-name: dw-rebuff;
+    animation-duration: var(--dw-motion-detent);
+    animation-timing-function: var(--dw-ease-detent);
+  }
+
+  @keyframes dw-rebuff {
+    0% {
+      border-bottom-color: var(--dw-index);
+    }
+    40% {
+      border-bottom-color: var(--dw-line-strong);
+    }
+    100% {
+      border-bottom-color: var(--dw-index);
+    }
   }
 
   .dw-present {

--- a/dynawalla/dynawalla-app/src/work/work.css
+++ b/dynawalla/dynawalla-app/src/work/work.css
@@ -1,0 +1,70 @@
+/* ──────────────────────────────────────────────────────────────────────────
+   The work surface.
+
+   Three things that cannot be expressed as utilities on an element, because
+   they are structural promises the loop makes and a test reads this file to
+   check them:
+
+     1. The slate reserves a fixed run of numeral columns. A two-digit problem
+        and a four-digit one occupy the same box, so nothing reflows between
+        cards (`Q-01`).
+     2. The verdict well is always in the layout. Feedback changes what is
+        inside it and never whether it exists — a strike mark that pushes the
+        keypad down is the "jolting reflow" the design rules forbid outright.
+     3. The present animation has a reduced-motion branch, not a degradation:
+        a different keyframe set with no `transform` in it at all.
+
+   The CSP forbids inline style entirely (`style-src 'self'`), so anything
+   dynamic is a class here, never a `style` prop.
+   ────────────────────────────────────────────────────────────────────────── */
+
+@layer components {
+  .dw-slate {
+    /* One numeral column per digit the ladder can put on the slate, plus one
+       for the operator gutter. `work.test.ts` asserts this equals
+       `SLATE_COLUMNS + 1` computed from the ladder — the two cannot drift. */
+    --dw-slate-columns: 5;
+    min-width: calc(var(--dw-slate-columns) * 1ch);
+  }
+
+  /* One numeral line, reserved from the first frame. Feedback changes what is
+     in it, never whether it is there. */
+  .dw-verdict-well {
+    min-height: 2.75rem;
+  }
+
+  .dw-present {
+    animation-name: dw-seat-in;
+    animation-duration: var(--dw-motion-detent);
+    animation-timing-function: var(--dw-ease-detent);
+    animation-fill-mode: both;
+  }
+
+  @keyframes dw-seat-in {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  /* The branch. Zero travel, no particles — the keyframes contain opacity and
+     nothing else, so there is no transform left to shorten. */
+  @media (prefers-reduced-motion: reduce) {
+    .dw-present {
+      animation-name: dw-seat-in-still;
+    }
+  }
+
+  @keyframes dw-seat-in-still {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+}

--- a/dynawalla/dynawalla-app/tools/bench-generate.mjs
+++ b/dynawalla/dynawalla-app/tools/bench-generate.mjs
@@ -1,0 +1,57 @@
+// Headless generation bench.
+//
+// EXPERIENCE_DESIGN puts a hard rule on this number: "if any single `generate()`
+// exceeds 4 ms measured, move generation to a Worker — do not optimise in place."
+// So it is measured, on demand, and the number is printed rather than described.
+//
+//   node --experimental-strip-types tools/bench-generate.mjs [iterations]
+//
+// This is a *developer machine* number. `Q-01` is the same measurement on a
+// Galaxy Tab A9 and is a `[device]` item that no script can close.
+
+import { LADDER, rungAt } from "../src/work/ladder.ts"
+import { generateProblem } from "../src/work/session.ts"
+
+const iterations = Number(process.argv[2] ?? 2000)
+
+function percentile(sorted, p) {
+  const rank = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1))
+  return sorted[rank]
+}
+
+const rows = []
+
+for (let rung = 0; rung < LADDER.length; rung++) {
+  const spec = rungAt(rung)
+  const samples = []
+  // Warm the JIT so the first few calls do not dominate a short run.
+  for (let i = 0; i < 200; i++) generateProblem(spec, i)
+  for (let i = 0; i < iterations; i++) {
+    const started = performance.now()
+    generateProblem(spec, i + 1_000_000)
+    samples.push(performance.now() - started)
+  }
+  samples.sort((a, b) => a - b)
+  rows.push({
+    rung,
+    skill: spec.skillId,
+    level: spec.level,
+    p50: percentile(samples, 50),
+    p95: percentile(samples, 95),
+    p99: percentile(samples, 99),
+    max: samples[samples.length - 1],
+  })
+}
+
+const ms = (n) => `${n.toFixed(3)} ms`
+console.log(`generate() over ${String(iterations)} seeds per rung\n`)
+for (const row of rows) {
+  console.log(
+    `rung ${String(row.rung)}  ${row.skill} L${String(row.level)}  ` +
+      `p50 ${ms(row.p50)}  p95 ${ms(row.p95)}  p99 ${ms(row.p99)}  max ${ms(row.max)}`,
+  )
+}
+
+const worstP95 = Math.max(...rows.map((r) => r.p95))
+console.log(`\nworst p95 across rungs: ${ms(worstP95)}  (Worker threshold: 4 ms)`)
+process.exitCode = worstP95 < 4 ? 0 : 1

--- a/dynawalla/dynawalla-app/tools/bench-generate.mjs
+++ b/dynawalla/dynawalla-app/tools/bench-generate.mjs
@@ -1,14 +1,25 @@
-// Headless generation bench.
+// Headless generation and answer-path bench.
 //
-// EXPERIENCE_DESIGN puts a hard rule on this number: "if any single `generate()`
+// EXPERIENCE_DESIGN puts a hard rule on generation: "if any single `generate()`
 // exceeds 4 ms measured, move generation to a Worker — do not optimise in place."
-// So it is measured, on demand, and the number is printed rather than described.
+// And it budgets `commit → judgement` under 1 ms. Both are measured on demand,
+// and the numbers are printed rather than described.
 //
 //   node --experimental-strip-types tools/bench-generate.mjs [iterations]
+//
+// The answer-path half is here, not only in the browser bench, because the
+// branches are not equally reachable from a driver: the app serves one contrast
+// pair per misconception per session, so a browser run yields one diagnosed
+// sample however hard it tries. In Node the same judging path runs over thousands
+// of real items on every branch, which is what makes the budget claim cover the
+// branch it says it covers.
 //
 // This is a *developer machine* number. `Q-01` is the same measurement on a
 // Galaxy Tab A9 and is a `[device]` item that no script can close.
 
+import { countingBoard } from "../src/work/contrast.ts"
+import { exact } from "../src/work/curriculum.ts"
+import { judge } from "../src/work/judge.ts"
 import { LADDER, rungAt } from "../src/work/ladder.ts"
 import { generateProblem } from "../src/work/session.ts"
 
@@ -54,4 +65,68 @@ for (const row of rows) {
 
 const worstP95 = Math.max(...rows.map((r) => r.p95))
 console.log(`\nworst p95 across rungs: ${ms(worstP95)}  (Worker threshold: 4 ms)`)
-process.exitCode = worstP95 < 4 ? 0 : 1
+
+// ── commit → judgement, per branch ──────────────────────────────────────────
+//
+// The work `commit` does that depends on the answer: judge (classifying through
+// every mal-rule of the family) and, where this build can draw one, the counting
+// board. The rest of that path is object spreads over state that already exists.
+
+const answerOf = (value) => ({ kind: "integer", value: exact.rational(value) })
+
+const branches = { seated: [], diagnosed: [], unexplained: [] }
+
+for (let rung = 0; rung < LADDER.length; rung++) {
+  const spec = rungAt(rung)
+  for (let i = 0; i < iterations; i++) {
+    const exercise = generateProblem(spec, i + 2_000_000)
+    const canonical = exercise.answer.canonical
+    if (canonical.kind !== "integer") continue
+    const right = exact.toScaled(canonical.value, 0)
+    if (right === null) continue
+
+    // The buggy answer, if this item admits one this build can draw a board for.
+    let buggy = null
+    for (let place = 1; place <= 4 && buggy === null; place++) {
+      const candidate = answerOf(right + 10n ** BigInt(place))
+      const verdict = judge(exercise, candidate)
+      if (verdict.kind === "struck" && verdict.diagnosis?.contrast != null) buggy = candidate
+    }
+
+    const cases = [
+      ["seated", answerOf(right)],
+      ["unexplained", answerOf(right + 7n)],
+      ...(buggy === null ? [] : [["diagnosed", buggy]]),
+    ]
+    for (const [branch, value] of cases) {
+      const started = performance.now()
+      const verdict = judge(exercise, value)
+      if (verdict.kind === "struck" && verdict.diagnosis?.contrast != null) {
+        countingBoard(exercise, value)
+      }
+      branches[branch].push(performance.now() - started)
+    }
+  }
+}
+
+console.log(`\ncommit → judgement, by branch (budget: < 1 ms)\n`)
+for (const [name, samples] of Object.entries(branches)) {
+  if (samples.length === 0) {
+    console.log(`${name.padEnd(12)}  no samples`)
+    continue
+  }
+  samples.sort((a, b) => a - b)
+  console.log(
+    `${name.padEnd(12)}  n ${String(samples.length).padStart(6)}  ` +
+      `p50 ${ms(percentile(samples, 50))}  p95 ${ms(percentile(samples, 95))}  ` +
+      `max ${ms(samples[samples.length - 1])}`,
+  )
+}
+
+const worstJudge = Math.max(
+  ...Object.values(branches)
+    .filter((s) => s.length > 0)
+    .map((s) => percentile(s, 95)),
+)
+console.log(`\nworst p95 across branches: ${ms(worstJudge)}  (budget: 1 ms)`)
+process.exitCode = worstP95 < 4 && worstJudge < 1 ? 0 : 1

--- a/dynawalla/dynawalla-app/tools/bench-loop.mjs
+++ b/dynawalla/dynawalla-app/tools/bench-loop.mjs
@@ -1,0 +1,207 @@
+// End-to-end loop bench, in a real browser.
+//
+// EXPERIENCE_DESIGN budgets the machine's contribution to the loop, and a budget
+// nobody measures is a wish. This drives the running app through Chrome DevTools
+// Protocol and reports:
+//
+//   commit → judgement            the app's actual work: judge, diagnose, plan
+//   commit → feedback painted     the child's key to the frame the verdict is on
+//   feedback → next card ready    the on-deck problem being in hand
+//   generate()                    per-item generation cost
+//   layout shift                  the keypad's box before and after feedback
+//   horizontal overflow           at 320, 360, 768 and 1024 CSS px
+//
+// Note what `commit → feedback painted` can and cannot say. It is probed with a
+// double `requestAnimationFrame`, so its floor is one compositor frame — 16.7 ms
+// at 60 Hz — whatever the app does. A p50 of ~16.6 ms therefore reads "the
+// verdict is on the next frame, every time", not "16.6 ms of work". The work is
+// `commit → judgement`.
+//
+// It uses `requestAnimationFrame` twice to find the painted frame, so the page
+// must actually be rendering: a backgrounded tab never fires rAF and would
+// report nothing rather than something wrong. Headless Chrome renders.
+//
+//   npm run dev                       # in another shell
+//   node tools/bench-loop.mjs [cards]
+//
+// This is a developer-machine number. `Q-01` is the same measurement on a Galaxy
+// Tab A9 and is a `[device]` item no script can close.
+
+import { spawn } from "node:child_process"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+const APP_URL = process.env.DW_URL ?? "http://127.0.0.1:1423/#/practice"
+const CARDS = Number(process.argv[2] ?? 24)
+const PORT = 9333
+
+const CHROME =
+  process.env.CHROME_PATH ??
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+
+const profile = mkdtempSync(path.join(tmpdir(), "dw-bench-"))
+
+const chrome = spawn(
+  CHROME,
+  [
+    "--headless=new",
+    `--remote-debugging-port=${String(PORT)}`,
+    `--user-data-dir=${profile}`,
+    "--no-first-run",
+    "--disable-extensions",
+    "--hide-scrollbars",
+    "--window-size=390,844",
+  ],
+  { stdio: "ignore" },
+)
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+async function endpoint() {
+  for (let attempt = 0; attempt < 60; attempt++) {
+    try {
+      const list = await fetch(`http://127.0.0.1:${String(PORT)}/json/list`).then((r) => r.json())
+      const page = list.find((t) => t.type === "page")
+      if (page) return page.webSocketDebuggerUrl
+    } catch {
+      /* not up yet */
+    }
+    await sleep(200)
+  }
+  throw new Error("chrome did not expose a debugging endpoint")
+}
+
+const socket = new WebSocket(await endpoint())
+await new Promise((resolve, reject) => {
+  socket.addEventListener("open", resolve, { once: true })
+  socket.addEventListener("error", reject, { once: true })
+})
+
+let nextId = 0
+const pending = new Map()
+socket.addEventListener("message", (event) => {
+  const message = JSON.parse(event.data)
+  const waiter = pending.get(message.id)
+  if (waiter === undefined) return
+  pending.delete(message.id)
+  if (message.error) waiter.reject(new Error(JSON.stringify(message.error)))
+  else waiter.resolve(message.result)
+})
+
+function send(method, params = {}) {
+  const id = ++nextId
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject })
+    socket.send(JSON.stringify({ id, method, params }))
+  })
+}
+
+async function evaluate(expression) {
+  const result = await send("Runtime.evaluate", {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+  })
+  if (result.exceptionDetails) {
+    throw new Error(result.exceptionDetails.exception?.description ?? "page threw")
+  }
+  return result.result.value
+}
+
+async function widthProbe(width) {
+  await send("Emulation.setDeviceMetricsOverride", {
+    width,
+    height: 844,
+    deviceScaleFactor: 2,
+    mobile: true,
+  })
+  await sleep(250)
+  return evaluate(`(() => {
+    const doc = document.documentElement
+    const overflow = [...document.querySelectorAll("body *")]
+      .filter((el) => el.getBoundingClientRect().right > doc.clientWidth + 0.5)
+      .map((el) => el.className || el.tagName)
+    return JSON.stringify({
+      width: ${String(width)},
+      scrollWidth: doc.scrollWidth,
+      clientWidth: doc.clientWidth,
+      horizontalOverflow: doc.scrollWidth > doc.clientWidth,
+      offenders: overflow.slice(0, 5),
+    })
+  })()`)
+}
+
+const DRIVER = (cards) => `(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+  const frame = () => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)))
+  const digits = (s) => (s.match(/\\d+/g) ?? [])
+  const slate = () => document.querySelector(".dw-slate")
+  const keypad = () => document.querySelector(".grid.grid-cols-3")
+  const key = (k) => window.dispatchEvent(new KeyboardEvent("keydown", { key: k, bubbles: true }))
+
+  window.__dwMetrics.reset()
+  const shifts = []
+  const played = []
+
+  for (let i = 0; i < ${String(cards)}; i++) {
+    await frame()
+    const el = slate()
+    if (!el) { await sleep(60); continue }
+    const nums = digits(el.innerText)
+    if (nums.length < 2) { await sleep(60); continue }
+    const top = BigInt(nums[0]), bottom = BigInt(nums[1])
+    const answer = (top - bottom).toString()
+
+    const before = keypad().getBoundingClientRect()
+    for (const ch of answer) key(ch)
+    await frame()
+    key("Enter")
+    await frame()
+    const after = keypad().getBoundingClientRect()
+    shifts.push(Math.round((Math.abs(after.top - before.top) + Math.abs(after.left - before.left)) * 100) / 100)
+    played.push(top + "-" + bottom + "=" + answer)
+    await sleep(480)
+  }
+
+  return JSON.stringify({
+    cards: played.length,
+    sample: played.slice(0, 4),
+    commitToJudgement: window.__dwMetrics.report("commitToJudgement"),
+    commitToFeedback: window.__dwMetrics.report("commitToFeedback"),
+    feedbackToReady: window.__dwMetrics.report("feedbackToReady"),
+    generate: window.__dwMetrics.report("generate"),
+    maxKeypadShiftPx: Math.max(0, ...shifts),
+  })
+})()`
+
+try {
+  await send("Page.enable")
+  await send("Runtime.enable")
+  await send("Emulation.setDeviceMetricsOverride", {
+    width: 390,
+    height: 844,
+    deviceScaleFactor: 2,
+    mobile: true,
+  })
+  await send("Page.navigate", { url: APP_URL })
+  await sleep(2000)
+  await evaluate("localStorage.clear(), location.reload(), 1")
+  await sleep(1500)
+
+  const loop = JSON.parse(await evaluate(DRIVER(CARDS)))
+  console.log("── loop, 390 px viewport ─────────────────────────────────────")
+  console.log(JSON.stringify(loop, null, 1))
+
+  console.log("\n── horizontal overflow ───────────────────────────────────────")
+  for (const width of [320, 360, 768, 1024]) {
+    console.log(await widthProbe(width))
+  }
+} finally {
+  socket.close()
+  chrome.kill()
+  // Chrome is still flushing its profile as it exits, so a bare `rmSync` races
+  // it and throws ENOTEMPTY over a temp directory nobody cares about.
+  await sleep(300)
+  rmSync(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 })
+}

--- a/dynawalla/dynawalla-app/tools/bench-loop.mjs
+++ b/dynawalla/dynawalla-app/tools/bench-loop.mjs
@@ -5,11 +5,28 @@
 // Protocol and reports:
 //
 //   commit → judgement            the app's actual work: judge, diagnose, plan
+//                                 — reported **per branch**, because they are
+//                                 not the same work at all
 //   commit → feedback painted     the child's key to the frame the verdict is on
 //   feedback → next card ready    the on-deck problem being in hand
 //   generate()                    per-item generation cost
+//   slate box, every card         `Q-01`: the units column may not move between
+//                                 a two-digit problem and a four-digit one
 //   layout shift                  the keypad's box before and after feedback
-//   horizontal overflow           at 320, 360, 768 and 1024 CSS px
+//   horizontal overflow           at 320, 360, 768 and 1024 CSS px, parked on
+//                                 the contrast card — the widest surface here
+//
+// Two things this used to claim and could not see, both fixed:
+//
+//   * It answered `top − bottom` on every card, so every `commitToJudgement`
+//     sample came from the `seated` branch, which does no diagnosis at all. The
+//     driver now plays a mix and buckets each sample by the branch the app took.
+//     `diagnosedWithBoard` has a small `count`, and that is the product working:
+//     one contrast pair per misconception per session. The high-n measurement of
+//     that branch is `bench-generate.mjs`, in Node over thousands of items.
+//   * It recorded the keypad's box before and after feedback *within one card*.
+//     `Q-01` asks whether the surface moves *between* problems of different digit
+//     counts, so the slate's box is now recorded on every card.
 //
 // Note what `commit → feedback painted` can and cannot say. It is probed with a
 // double `requestAnimationFrame`, so its floor is one compositor frame — 16.7 ms
@@ -132,47 +149,182 @@ async function widthProbe(width) {
   })()`)
 }
 
+/**
+ * The buggy procedure, implemented here rather than imported: a driver that asks
+ * the code under test what the wrong answer is proves only that the code agrees
+ * with itself. Regroups down through a run of zeros, writing them as 9s, and
+ * never decrements the digit above the run. `null` when the item does not
+ * exercise it. Same twenty lines as `drive-locate.mjs`, on purpose.
+ */
+const BUGGY = `
+function borrowAcrossZero(top, bottom) {
+  const cols = Math.max(top.length, bottom.length)
+  const work = top.padStart(cols, "0").split("").reverse().map(Number)
+  const lower = bottom.padStart(cols, "0").split("").reverse().map(Number)
+  const out = []
+  let crossed = false
+  for (let i = 0; i < cols; i++) {
+    let a = work[i]
+    const b = lower[i]
+    if (a < b) {
+      let j = i + 1
+      while (j < cols && work[j] === 0) { work[j] = 9; j++ }
+      if (j >= cols) return null
+      if (j > i + 1) crossed = true
+      else work[j] -= 1
+      a += 10
+    }
+    out.push(a - b)
+  }
+  return crossed ? BigInt(out.reverse().join("")) : null
+}`
+
 const DRIVER = (cards) => `(async () => {
   const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
   const frame = () => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)))
   const digits = (s) => (s.match(/\\d+/g) ?? [])
   const slate = () => document.querySelector(".dw-slate")
   const keypad = () => document.querySelector(".grid.grid-cols-3")
+  const well = () => document.querySelector(".dw-verdict-well")
   const key = (k) => window.dispatchEvent(new KeyboardEvent("keydown", { key: k, bubbles: true }))
+  const round2 = (n) => Math.round(n * 100) / 100
+  ${BUGGY}
+
+  const stats = (xs) => {
+    if (xs.length === 0) return { count: 0, p50: null, p95: null, max: null }
+    const s = [...xs].sort((a, b) => a - b)
+    const at = (p) => s[Math.min(s.length - 1, Math.max(0, Math.ceil((p / 100) * s.length) - 1))]
+    return { count: s.length, p50: at(50), p95: at(95), max: s[s.length - 1] }
+  }
 
   window.__dwMetrics.reset()
+  const judged = () => window.__dwMetrics.samples("commitToJudgement")
   const shifts = []
+  const slates = []
+  const branches = { seated: [], diagnosedWithBoard: [], struckNoBoard: [] }
   const played = []
 
-  for (let i = 0; i < ${String(cards)}; i++) {
+  let guard = 0
+  let climbing = true
+  for (let i = 0; i < ${String(cards)} && guard < ${String(cards)} * 4; i++) {
+    guard++
     await frame()
     const el = slate()
-    if (!el) { await sleep(60); continue }
+    if (!el) {
+      // A contrast card. It has no entry; Enter moves on. The old driver
+      // never reached one, because it never answered anything wrong.
+      key("Enter")
+      await sleep(260)
+      i--
+      continue
+    }
     const nums = digits(el.innerText)
-    if (nums.length < 2) { await sleep(60); continue }
+    if (nums.length < 2) { await sleep(60); i--; continue }
     const top = BigInt(nums[0]), bottom = BigInt(nums[1])
-    const answer = (top - bottom).toString()
+
+    // Q-01 is a between-card question, so the box is recorded per card.
+    const box = el.getBoundingClientRect()
+    slates.push({
+      digits: nums[0].length,
+      width: round2(box.width),
+      right: round2(box.right),
+      // A fixed width pins the units column, but it has to actually hold the
+      // digits: if 1ch were narrower than the tabular advance, the numerals
+      // would spill out of the reservation they are supposed to sit in.
+      clipped: el.scrollWidth > el.clientWidth + 0.5,
+    })
+
+    // Climb first, then mix. The ladder only moves on correct answers, so a
+    // driver that is wrong a third of the time never leaves the two-digit
+    // rungs — and Q-01 is a question about two-digit *against* four-digit
+    // problems. Once the widest rung is on screen, every branch of the answer
+    // path gets sampled: right, the documented bug where the item admits it,
+    // and a wrong answer no mal-rule explains.
+    if (nums[0].length >= 4) climbing = false
+    const correct = top - bottom
+    const bug = borrowAcrossZero(nums[0], nums[1])
+    const plan = climbing ? 0 : i % 3
+    const answer =
+      plan === 1 && bug !== null && bug !== correct ? bug
+      : plan === 2 ? correct + 7n
+      : correct
 
     const before = keypad().getBoundingClientRect()
-    for (const ch of answer) key(ch)
+    for (const ch of answer.toString()) key(ch)
     await frame()
+    const samplesBefore = judged().length
     key("Enter")
     await frame()
     const after = keypad().getBoundingClientRect()
-    shifts.push(Math.round((Math.abs(after.top - before.top) + Math.abs(after.left - before.left)) * 100) / 100)
-    played.push(top + "-" + bottom + "=" + answer)
-    await sleep(480)
+    const shift = round2(Math.abs(after.top - before.top) + Math.abs(after.left - before.left))
+    shifts.push(shift)
+
+    const sample = judged()[samplesBefore]
+    const seated = (well()?.textContent ?? "").indexOf(String(correct)) === -1
+    await sleep(seated ? 520 : 120)
+    if (!seated) { key("Enter"); await sleep(260) }
+    // The app decides the branch, not the driver. The third bucket is the union
+    // of "no rule explains this" and "one does, but its board was spent this
+    // session" — indistinguishable from outside, bounded the same either way.
+    const branch = seated ? "seated" : slate() === null ? "diagnosedWithBoard" : "struckNoBoard"
+    if (sample !== undefined) branches[branch].push(sample)
+    played.push(top + "-" + bottom + "=" + answer + " [" + branch + (shift ? " shift " + shift : "") + "]")
   }
 
+  const widths = slates.map((s) => s.width)
   return JSON.stringify({
     cards: played.length,
-    sample: played.slice(0, 4),
+    sample: played.slice(0, 6),
     commitToJudgement: window.__dwMetrics.report("commitToJudgement"),
+    commitToJudgementByBranch: {
+      seated: stats(branches.seated),
+      diagnosedWithBoard: stats(branches.diagnosedWithBoard),
+      struckNoBoard: stats(branches.struckNoBoard),
+    },
     commitToFeedback: window.__dwMetrics.report("commitToFeedback"),
     feedbackToReady: window.__dwMetrics.report("feedbackToReady"),
     generate: window.__dwMetrics.report("generate"),
     maxKeypadShiftPx: Math.max(0, ...shifts),
+    slate: {
+      cards: slates.length,
+      digitWidths: [...new Set(slates.map((s) => s.digits))].sort(),
+      minWidthPx: Math.min(...widths),
+      maxWidthPx: Math.max(...widths),
+      widthSpreadPx: round2(Math.max(...widths) - Math.min(...widths)),
+      unitsColumnSpreadPx: round2(
+        Math.max(...slates.map((s) => s.right)) - Math.min(...slates.map((s) => s.right)),
+      ),
+      clippedCards: slates.filter((s) => s.clipped).length,
+    },
   })
+})()`
+
+/**
+ * Leave the app parked on the contrast card. The overflow probe used to run
+ * wherever an all-correct loop stopped, which is never the contrast pair — two
+ * plates of counters, and the widest thing this build draws.
+ */
+const PARK_ON_CONTRAST = `(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+  const digits = (s) => (s.match(/\\d+/g) ?? [])
+  const slate = () => document.querySelector(".dw-slate")
+  const key = (k) => window.dispatchEvent(new KeyboardEvent("keydown", { key: k, bubbles: true }))
+  ${BUGGY}
+
+  for (let card = 0; card < 80; card++) {
+    if (slate() === null) return JSON.stringify({ parked: true, text: document.body.innerText.replace(/\\n+/g, " | ") })
+    const nums = digits(slate().innerText)
+    if (nums.length < 2) { await sleep(80); continue }
+    const correct = BigInt(nums[0]) - BigInt(nums[1])
+    const bug = borrowAcrossZero(nums[0], nums[1])
+    const answer = bug !== null && bug !== correct ? bug : correct
+    for (const ch of answer.toString()) key(ch)
+    await sleep(40)
+    key("Enter")
+    await sleep(260)
+    if (answer !== correct) { key("Enter"); await sleep(300) }
+  }
+  return JSON.stringify({ parked: false })
 })()`
 
 try {
@@ -193,7 +345,16 @@ try {
   console.log("── loop, 390 px viewport ─────────────────────────────────────")
   console.log(JSON.stringify(loop, null, 1))
 
-  console.log("\n── horizontal overflow ───────────────────────────────────────")
+  // A fresh session before parking: the app serves one contrast pair per
+  // misconception per session, and the loop above has already spent it, so
+  // without this the probe silently measures an ordinary problem card — which
+  // is the bug it was written to fix.
+  await evaluate("localStorage.clear(), location.reload(), 1")
+  await sleep(1500)
+  const parked = JSON.parse(await evaluate(PARK_ON_CONTRAST))
+  console.log("\n── horizontal overflow, ON THE CONTRAST CARD ─────────────────")
+  console.log(`parked on the contrast pair: ${String(parked.parked)}`)
+  if (parked.parked) console.log(parked.text)
   for (const width of [320, 360, 768, 1024]) {
     console.log(await widthProbe(width))
   }

--- a/dynawalla/dynawalla-app/tools/drive-locate.mjs
+++ b/dynawalla/dynawalla-app/tools/drive-locate.mjs
@@ -1,0 +1,266 @@
+// Drive the real UI to the contrast pair, and photograph it.
+//
+// Nothing here reaches into the store, sets a flag, or calls a bypass hook. It
+// reads the numbers off the slate, presses keys at the window the way a keyboard
+// does, and climbs the ladder by answering correctly — the same path a child
+// takes — until a problem with a run of zeros in the minuend appears. Then it
+// answers with the *borrow-across-zero* result: the correct difference plus the
+// place value of the zero run, which is the answer a child gives who regrouped
+// all the way down and never gave the thousand up.
+//
+// If the contrast pair does not appear on the next card, this exits non-zero.
+// A harness that proves the diagnosis by asking the diagnosis code proves
+// nothing about the screen.
+//
+//   npm run dev                  # in another shell
+//   node tools/drive-locate.mjs [outDir]
+//
+// Screenshots land in `outDir` (default: a temp dir, path printed).
+
+import { spawn } from "node:child_process"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+const APP_URL = process.env.DW_URL ?? "http://127.0.0.1:1423/#/practice"
+const OUT = process.argv[2] ?? mkdtempSync(path.join(tmpdir(), "dw-shots-"))
+const PORT = 9334
+const CHROME =
+  process.env.CHROME_PATH ?? "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+
+mkdirSync(OUT, { recursive: true })
+const profile = mkdtempSync(path.join(tmpdir(), "dw-drive-"))
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+const chrome = spawn(
+  CHROME,
+  [
+    "--headless=new",
+    `--remote-debugging-port=${String(PORT)}`,
+    `--user-data-dir=${profile}`,
+    "--no-first-run",
+    "--disable-extensions",
+    "--hide-scrollbars",
+    "--window-size=390,900",
+  ],
+  { stdio: "ignore" },
+)
+
+async function endpoint() {
+  for (let attempt = 0; attempt < 60; attempt++) {
+    try {
+      const list = await fetch(`http://127.0.0.1:${String(PORT)}/json/list`).then((r) => r.json())
+      const page = list.find((t) => t.type === "page")
+      if (page) return page.webSocketDebuggerUrl
+    } catch {
+      /* not up yet */
+    }
+    await sleep(200)
+  }
+  throw new Error("chrome did not expose a debugging endpoint")
+}
+
+const socket = new WebSocket(await endpoint())
+await new Promise((resolve, reject) => {
+  socket.addEventListener("open", resolve, { once: true })
+  socket.addEventListener("error", reject, { once: true })
+})
+
+let nextId = 0
+const pending = new Map()
+socket.addEventListener("message", (event) => {
+  const message = JSON.parse(event.data)
+  const waiter = pending.get(message.id)
+  if (waiter === undefined) return
+  pending.delete(message.id)
+  if (message.error) waiter.reject(new Error(JSON.stringify(message.error)))
+  else waiter.resolve(message.result)
+})
+
+function send(method, params = {}) {
+  const id = ++nextId
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject })
+    socket.send(JSON.stringify({ id, method, params }))
+  })
+}
+
+async function evaluate(expression) {
+  const result = await send("Runtime.evaluate", { expression, awaitPromise: true, returnByValue: true })
+  if (result.exceptionDetails) {
+    throw new Error(result.exceptionDetails.exception?.description ?? "page threw")
+  }
+  return result.result.value
+}
+
+async function shot(name) {
+  const { data } = await send("Page.captureScreenshot", { format: "png", captureBeyondViewport: true })
+  const file = path.join(OUT, `${name}.png`)
+  writeFileSync(file, Buffer.from(data, "base64"))
+  return file
+}
+
+const PAGE_HELPERS = `
+window.__dw = {
+  sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+  frame: () => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r))),
+  key: (k) => window.dispatchEvent(new KeyboardEvent("keydown", { key: k, bubbles: true })),
+  slate: () => document.querySelector(".dw-slate"),
+  board: () => document.querySelector(".dw-present p.numeral"),
+  text: () => document.body.innerText.replace(/\\n+/g, " | "),
+  problem: () => {
+    const el = document.querySelector(".dw-slate")
+    if (!el) return null
+    const nums = el.innerText.match(/\\d+/g)
+    return nums && nums.length >= 2 ? { top: nums[0], bottom: nums[1] } : null
+  },
+}
+"ok"`
+
+/**
+ * The answer a child writes who regroups all the way down through a run of
+ * zeros — turning them into 9s — and never decrements the digit above the run.
+ *
+ * Written out here rather than imported from the curriculum on purpose: a driver
+ * that asks the code under test what the wrong answer is proves only that the
+ * code agrees with itself. This is the procedure from the documented bug,
+ * implemented independently, and `null` when this problem does not exercise it —
+ * a borrow that travels only one column is ordinary regrouping, not this.
+ */
+function borrowAcrossZeroAnswer(top, bottom) {
+  const cols = Math.max(top.length, bottom.length)
+  const work = top.padStart(cols, "0").split("").reverse().map(Number)
+  const lower = bottom.padStart(cols, "0").split("").reverse().map(Number)
+  const out = []
+  let crossedZero = false
+
+  for (let i = 0; i < cols; i++) {
+    let a = work[i]
+    const b = lower[i]
+    if (a < b) {
+      let j = i + 1
+      while (j < cols && work[j] === 0) {
+        work[j] = 9
+        j++
+      }
+      if (j >= cols) return null
+      if (j > i + 1) crossedZero = true
+      else work[j] -= 1
+      a += 10
+    }
+    out.push(a - b)
+  }
+  if (!crossedZero) return null
+
+  const buggy = BigInt(out.reverse().join(""))
+  const correct = BigInt(top) - BigInt(bottom)
+  return { correct, buggy, surplus: buggy - correct }
+}
+
+let failure = null
+
+async function run() {
+  await send("Page.enable")
+  await send("Runtime.enable")
+  await send("Emulation.setDeviceMetricsOverride", {
+    width: 390,
+    height: 900,
+    deviceScaleFactor: 2,
+    mobile: true,
+  })
+  await send("Page.navigate", { url: APP_URL })
+  await sleep(1800)
+  await evaluate("localStorage.clear(), location.reload(), 1")
+  await sleep(1500)
+  await evaluate(PAGE_HELPERS)
+
+  console.log(`first problem: ${JSON.stringify(await evaluate("JSON.stringify(window.__dw.problem())"))}`)
+  console.log(`screenshot: ${await shot("01-problem")}`)
+
+  // Climb until a zero-run minuend appears. Answering correctly is the only way
+  // up: the ladder moves on four correct answers a rung.
+  let target = null
+  for (let card = 0; card < 60 && target === null; card++) {
+    const problem = JSON.parse(await evaluate("JSON.stringify(window.__dw.problem())"))
+    if (problem === null) {
+      await evaluate("window.__dw.key('Enter')")
+      await sleep(200)
+      continue
+    }
+    const candidate = borrowAcrossZeroAnswer(problem.top, problem.bottom)
+    if (candidate !== null) {
+      target = { problem, ...candidate }
+      break
+    }
+    const answer = (BigInt(problem.top) - BigInt(problem.bottom)).toString()
+    await evaluate(
+      `(async () => { for (const c of ${JSON.stringify(answer)}) window.__dw.key(c); await window.__dw.frame(); window.__dw.key('Enter'); await window.__dw.sleep(520) })()`,
+    )
+  }
+
+  if (target === null) throw new Error("never reached a problem with a zero run in the minuend")
+
+  console.log(
+    `\nreached ${target.problem.top} − ${target.problem.bottom}` +
+      `  correct ${target.correct}  answering ${target.buggy} (= correct + ${target.surplus})`,
+  )
+  console.log(`screenshot: ${await shot("02-across-zero-problem")}`)
+
+  await evaluate(
+    `(async () => { for (const c of ${JSON.stringify(target.buggy.toString())}) window.__dw.key(c); await window.__dw.frame() })()`,
+  )
+  console.log(`screenshot: ${await shot("03-answer-typed")}`)
+
+  await evaluate("(async () => { window.__dw.key('Enter'); await window.__dw.sleep(120) })()")
+  const verdict = await evaluate("window.__dw.text()")
+  console.log(`\nverdict screen: ${verdict}`)
+  console.log(`screenshot: ${await shot("04-struck")}`)
+
+  await evaluate("(async () => { window.__dw.key('Enter'); await window.__dw.sleep(200) })()")
+  const contrast = await evaluate("window.__dw.text()")
+  console.log(`\ncontrast card: ${contrast}`)
+  console.log(`screenshot: ${await shot("05-contrast-pair")}`)
+
+  const expectedSum = (target.buggy + BigInt(target.problem.bottom)).toString()
+  const ok =
+    contrast.includes("Put it back together") &&
+    contrast.includes(expectedSum) &&
+    contrast.includes(target.problem.top)
+  if (!ok) throw new Error(`the contrast pair did not appear on the next card: ${contrast}`)
+  console.log(
+    `\nOK  the board shows ${target.buggy} + ${target.problem.bottom} = ${expectedSum}, ` +
+      `against ${target.problem.top}`,
+  )
+
+  await evaluate("(async () => { window.__dw.key('Enter'); await window.__dw.sleep(250) })()")
+  const repair = JSON.parse(await evaluate("JSON.stringify(window.__dw.problem())"))
+  console.log(`\nrepair card: ${JSON.stringify(repair)}`)
+  console.log(`screenshot: ${await shot("06-repair")}`)
+
+  if (repair === null) throw new Error("no problem on the card after the contrast pair")
+  const repairable = borrowAcrossZeroAnswer(repair.top, repair.bottom)
+  if (repairable === null) {
+    throw new Error(
+      `the repair item ${repair.top} − ${repair.bottom} does not borrow through a zero — ` +
+        "it cannot test the step that just broke",
+    )
+  }
+  console.log(
+    `OK  the repair item borrows through a zero: ${repair.top} − ${repair.bottom}, ` +
+      `the same step, correct ${repairable.correct}`,
+  )
+}
+
+try {
+  await run()
+} catch (error) {
+  failure = error
+  console.error(`\nFAILED: ${error.message}`)
+} finally {
+  socket.close()
+  chrome.kill()
+  await sleep(300)
+  rmSync(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 })
+}
+
+process.exitCode = failure === null ? 0 : 1

--- a/dynawalla/dynawalla-app/vite.config.ts
+++ b/dynawalla/dynawalla-app/vite.config.ts
@@ -44,6 +44,15 @@ export default defineConfig({
   },
 
   server: {
+    // The app imports the curriculum package's TypeScript source directly (see
+    // `src/work/curriculum.ts`). It is a private package with no build step, so
+    // there is nothing else to import — and it lives outside this app's
+    // directory, which is where Vite's workspace-root detection stops because
+    // `package-lock.json` is here. Without this, `npm run dev` serves a 403 for
+    // every curriculum module while `npm run build` (Rollup, no fs guard)
+    // succeeds — a dev-only failure that a green CI would never show.
+    fs: { allow: [".."] },
+
     // 1421 is Corpán's. Both dev servers must be able to run at once.
     port: 1423,
     strictPort: true,

--- a/dynawalla/dynawalla-app/vite.config.ts
+++ b/dynawalla/dynawalla-app/vite.config.ts
@@ -51,7 +51,15 @@ export default defineConfig({
     // `package-lock.json` is here. Without this, `npm run dev` serves a 403 for
     // every curriculum module while `npm run build` (Rollup, no fs guard)
     // succeeds — a dev-only failure that a green CI would never show.
-    fs: { allow: [".."] },
+    //
+    // Scoped to the one sibling actually imported. `".."` also served
+    // `dynawalla/engine/`, `dynawalla/docs/` and anything else beside the app —
+    // and with `TAURI_DEV_HOST` set this server is bound to the LAN, so that is
+    // the whole tree readable by any host on the network. The app root is listed
+    // explicitly because Vite 8 *replaces* the default list rather than extending
+    // it: `["../curriculum"]` alone puts `index.html` outside the allow list and
+    // `npm run dev` serves nothing. Verified by running it.
+    fs: { allow: [".", "../curriculum"] },
 
     // 1421 is Corpán's. Both dev servers must be able to run at once.
     port: 1423,


### PR DESCRIPTION
## What

Make `/practice` playable. A problem presents, the child answers on a
structure-aware numeric entry, the answer is judged exactly, and a wrong answer
that matches a known buggy procedure is diagnosed and answered with the
counting-board contrast pair on the very next card.

One skill cluster, end to end: multi-digit subtraction with regrouping,
including across zeros.

## Why

MASTER_PLAN M2 — the vertical slice that tests the thesis rather than juice on
drill. This is the loop half of PR-2.3 / 2.4 / 2.10 / 2.12 and moves:

- **P-02** a person reaches the practice loop with no dev flags — reachable now;
  the `[device]` half (TestFlight / Play-internal) stays open.
- **P-03** `5001 − 2798` answered `3203` identifies `mis.add.borrow-across-zero`
  and serves the counting-board contrast pair **within 3 cards**; the same
  problem answered `3797` identifies `mis.add.smaller-from-larger` instead.
  Measured distance: **1 card**. The `[device]` half stays open.
- **Q-01** (partial) `generate()` and the machine-side contribution measured,
  per branch; the slate's box recorded on **every** card and identical across
  2-, 3- and 4-digit rungs. Dev-machine numbers; the Galaxy Tab A9 measurement
  is the `[device]` item.
- **Q-10** every representation on this surface has a text alternative, and
  nothing right-versus-wrong is carried by colour. The counting board is the
  first representation this program authors and it now has one.
- **M-16** no learner-facing string names a misconception — asserted by a test
  over `strings.practice` and the board component.
- **ADR-0018** all storage namespaced by `profileId` from the first write, which
  is this PR.

Not in scope and not started: reactions (2.6), audio (2.7), read-aloud (2.5),
`NumberFormat` (2.2), construction and the character (2.11), the `column` form's
borrow grid, and the learner model (M5).

## How it is built

**Every decision is a pure function in `src/work/*.ts`; the screen renders and
schedules.** That is what makes the loop testable at all — a React component is
not testable under `node --experimental-strip-types --test`, and the behaviour
worth testing is not "does a div render", it is "does answering 3203 on
5001 − 2798 produce the counting board, and answering 3797 not".

- **`commit` takes no generator.** Not "does not call one" — cannot. It is the
  only operation on the answer path and its signature is the proof it does no
  work there. Generation lives in `prepare`, run from `requestIdleCallback`, and
  in `advance`'s starvation fallback, which increments a counter a test asserts
  stays at zero over 30 cards.
- **Entry is a declared structure**, not a text box: ordered fields, each taking
  declared glyphs to a declared length, converted to an exact `AnswerValue` with
  `BigInt`. The keypad is drawn from `model.keys(schema)` and does not know what
  an integer is. Fractions (`num`/`den`/`whole`), decimals (a `.` glyph), mixed
  numbers, units and coordinates are more fields and more glyphs — not a
  rewrite. None of them is stubbed: `entryModelFor` returns `undefined` for a
  schema this build cannot draw, and a test asserts every ladder rung has one.
- **Judging is `family.check`** — exact structural comparison of `Rational`s. No
  tolerance, no epsilon, no float, no model, no LLM.
- **Routing is decided in `judge.ts` and nowhere else.** A mal-rule may be tagged
  LOCATE-capable in the curriculum and still route to Stage 1 in *this* build:
  `LOCATABLE_REPRESENTATIONS` is the app's half of that contract, and
  `countingBoard()` returns `null` for every shape whose two plates cannot be
  drawn as one honest comparison — a non-subtraction or decimal item, an answer
  that rebuilds the minuend anyway, and an answer whose check comes to *less*
  than the board holds. Both fall back to a quiet Stage 1. (The earlier version
  of this bullet claimed `null` "when the contradiction would not actually be
  visible", which was a claim the code did not implement — see below.)
- **The board is a quantity, not a digit diff.** Each plate is the sockets carved
  for the minuend, all of them filled, plus `sum − target` drawn in the places its
  own digits name, over one column set shared by both plates. It used to compare
  `digitsOf(answer + subtrahend)` against `digitsOf(minuend)` place by place,
  which is the same thing only where the surplus does not carry.
- **The repair item is targeted.** It comes from the lowest rung whose
  *parameters* guarantee a borrow through a zero — not from wherever the child
  was standing. `subtract-multidigit` level 2 asks for two regroupings and no
  zeros, and a drawn zero fires this diagnosis anyway (155 items in 4,000, by the
  curriculum's own measurement), so repairing at that rung usually hands back a
  problem with no zero in it and tests nothing.
- **Fixed ladder, no adaptivity.** Seven rungs, four correct answers per rung,
  never descends. A counter, not a learner model.

## What changed after review

The adversarial review requested changes and was right about the mechanism. What
it found, and what happened to it:

| finding | outcome |
|---|---|
| **BLOCKING** the board is a digit comparison, so a carrying surplus draws a deficit | fixed — quantity model, property test over 1,000 items per rung |
| **MAJOR** the two plates do not share a column set | fixed — one `board.places`, both plates drawn over it |
| **MAJOR** being wrong is structurally more rewarding than being right | partly fixed, partly refuted: the seated answer now visibly seats, and `T-01` asks the question explicitly; the 420 ms hold is kept because it *is* EXPERIENCE_DESIGN's cadence (200 ms SEAT + 120 ms stillness) |
| **MAJOR** the counting board has no text alternative | fixed — `role="img"` per plate, counts and closure in words |
| **MAJOR** the verdict well's accessible text is the empty string | fixed — both states say something non-visual |
| **MINOR** the slate reservation never binds | fixed — a `width`, operator out of the flow; and it uncovered a second, larger shift in the verdict well |
| **MINOR** the bench samples only the cheap branch | fixed — mixed driver, per-branch report, plus a high-n Node bench |
| **MINOR** the stopping point is withheld from a bad run | fixed — a function of cards done |
| **MINOR** a rejected key is silent | fixed — the answer rule ticks |
| **MINOR** `judge` re-runs `classify` | fixed |
| **MINOR** the keyboard claim is not reproducible | claim corrected below; behaviour kept, with reasons |
| **NIT** `surplusPlace` is dead | deleted; the columns carry the surplus and the test asserts them |
| **NIT** `fs.allow: [".."]` | scoped — **but not to the patch suggested**: in Vite 8 `fs.allow` *replaces* the default list, so `["../curriculum"]` alone puts `index.html` outside the allow list and `npm run dev` serves nothing. It is `[".", "../curriculum"]`, verified by running it |
| **NIT** `/practice/:skillId?` has no behaviour | not changed — the pattern is [ADR-0005](docs/DECISIONS/ADR-0005-shell-and-routing.md)'s, and `practicePath` exists so `routes.test.ts` can ask the *installed* router whether the optional segment still matches. The misleading comment saying it "drills one skill" is corrected to say the screen does not read the parameter |

Two bugs the fixes then found on their own, neither of them in the review:

1. **The verdict well grew 7.5 px on every wrong answer.** It reserved 44 px for a
   51.5 px line, so the keypad moved down the screen under the child's finger —
   the reflow `work.css` invariant #2 promises against. Invisible to the old bench
   because it only ever answered correctly, and a seated verdict is an 8 px mark
   that fits.
2. **The seated recess was invisible in dark.** Drawn with `ground-sunk`, which is
   `basalt-950` under `.dw-dark` — the same basalt as the surface it sits on. Same
   class of bug as the subtraction bar this PR already fixed once, so it is now a
   `--dw-seat-ground` role with both cuts, and a test asserts the role rather than
   trusting a screenshot.

## The arithmetic, checked by hand

```
5001 − 2798 = 2203        check: 2798 + 2203 = 5001 ✓

3203  mis.add.borrow-across-zero
      units 11−8=3 · tens 9−9=0 · hundreds 9−7=2 · thousands 5−2=3
      (the 5 was never decremented) → 3203 = 2203 + 1000.
      Exactly one place-value unit too big, which is what makes the board a
      contradiction: 3203 + 2798 = 6001, not 5001.

3797  mis.add.smaller-from-larger
      |5−2| |0−7| |0−9| |1−8| = 3,7,9,7
      3797 − 2203 = 1594, NOT 1000. Not off by a place-value unit at all, so
      the counting board is not its contradiction and it never gets that card.
```

The fixture is a **real generated exercise** found by seed search, not a
hand-built object literal, so the distractors under test are the generator's own
and the seed re-derives itself if a `familyRev` bump moves it.

## Blast radius

**Areas touched:** dynawalla (`dynawalla-app/src/**`, `tools/`), CI (one
additive line).

- [x] Every touched path is covered by a `ci.yml` area filter. **One additive
      change:** `dynawalla_app` now also matches `dynawalla/curriculum/`, because
      the app compiles that package's TypeScript source directly (it is private,
      has no build step and no resolvable name — see `src/work/curriculum.ts`).
      Without it, a curriculum change that breaks the app's tsc, tests or build
      would not run the app job on the PR that did it.
- [x] **Pack back-compat.** N/A — no pack, catalog or `corpan/` path touched.
- [x] **Native integrity.** N/A — no Rust, no manifest, no `[patch]`.
- [x] **Strings.** Fourteen, all in `src/app/strings.ts`. Seven are the surface's
      text alternatives (`Q-10`) — the board's counts, the operators, the seated
      verdict — added because the first cut announced the empty string on a
      correct answer and read an item as "95 19". Dynawalla has no locale bundles
      yet (PR-1.6); `corpan/.../locales/` is untouched, so `check:i18n` is
      unaffected. A test pins the list, so a fifteenth is a visible decision.
- [x] **PR size.** `git diff origin/main | wc -c` is **210,037**, above the
      200,000 `MAX_CHUNK_CHARS`. `adversarial_review.py` **chunks** rather than
      truncates (its own docstring, and the concatenation-equals-diff assertion),
      so coverage is complete — this is two chunks, not half a review. Worth
      flagging: `dynawalla/AGENTS.md` still says it truncates and reports green,
      which was true before that fix landed and is not true of the script on
      `main` today.
- [x] **Curriculum.** No skill id renamed or reused. `dynawalla/curriculum/` and
      `dynawalla/engine/` are **not modified** — the app only reads them. All
      answers are exact rationals; the entry layer builds them with `BigInt` and
      there is no `parseFloat` on the path.
- [x] **Secrets.** None.

**Out of scope, worth a look:**

- `src/design/Recess.tsx` uses `border-t-line-cut`, and under `.dw-dark` both
  `--dw-line-cut` and `--dw-ground-sunk` resolve to `basalt-950` — the recess's
  top edge is invisible in dark. Same class of bug as the subtraction bar fixed
  inside the slate here; left alone because it is the shell's decision, not this
  PR's.
- The Tauri CSP sets `worker-src 'none'`. EXPERIENCE_DESIGN's escape hatch for
  slow generation is "move generation to a Worker", which would need a CSP
  change. Not needed today: measured `generate()` p95 is 0.012 ms against the
  4 ms threshold.

## Proof

Every number below is real output, on this branch, on this machine.

### Gates

```
$ npm test
# tests 113
# pass 113
# fail 0

$ npm run lint     # eslint . — clean, no output
$ npm run tsc      # tsc --noEmit ×3 — clean, no output
$ npm run build
dist/assets/index-DDMCfbzY.css   21.87 kB │ gzip:   5.23 kB
dist/assets/index-CxuUsxAQ.js   330.82 kB │ gzip: 105.42 kB
✓ built in 96ms

$ grep -c __dwMetrics dist/assets/*.js
0                         # traces do not ship (A-18)
```

### Latency, measured in a real browser (`npm run bench:loop`)

Headless Chrome, 390 px viewport, dev build, 30 cards driven through the real
keyboard path. **Read the second row carefully:** it is probed with a double
`requestAnimationFrame`, so its floor is one compositor frame — 16.7 ms at 60 Hz
— whatever the app does. A p50 of 16.6 ms reads "the verdict is on the next
frame, every time", not "16.6 ms of work". The work is the first row.

| span | budget (EXPERIENCE_DESIGN) | p50 | p95 | max |
|---|---|---|---|---|
| commit → judgement | < 1 ms, synchronous and pure | 0 ms | 0.2 ms | 0.6 ms |
| commit → feedback painted | ≤ 16 ms — one frame | 16.6 ms | 16.9 ms | 17.1 ms |
| feedback → next card ready | concurrent with the reaction tail | 3.7 ms | 6.0 ms | 7.0 ms |
| `generate()` | < 4 ms or move to a Worker | 0.1 ms | 0.2 ms | 0.3 ms |

**Per branch, because they are not the same work.** The driver used to answer
`top − bottom` on every card, so every sample came from `seated`, which does no
diagnosis at all — the number was right and the proof covered the wrong branch.
The driver now plays a mix and the app decides the bucket:

```
"commitToJudgementByBranch": {
 "seated":             { "count": 28, "p50": 0,   "p95": 0.1, "max": 0.1 },
 "diagnosedWithBoard": { "count": 1,  "p50": 0.6, "p95": 0.6, "max": 0.6 },
 "struckNoBoard":      { "count": 19, "p50": 0.1, "p95": 0.3, "max": 0.3 }
}
```

`diagnosedWithBoard` has n = 1 by design — one contrast pair per misconception
per session — so the high-n measurement of that branch is in Node, over the real
generator (`npm run bench:generate`, 2000 seeds × 7 rungs):

```
commit → judgement, by branch (budget: < 1 ms)
seated        n  14000  p50 0.000 ms  p95 0.000 ms  max 0.011 ms
diagnosed     n   6316  p50 0.002 ms  p95 0.004 ms  max 0.196 ms
unexplained   n  14000  p50 0.001 ms  p95 0.001 ms  max 0.294 ms
```

### Layout, measured between cards and not only within one

`Q-01` asks whether the surface moves between problems of *different digit
counts*; the old bench compared the keypad's box before and after feedback on the
same card, which cannot see that. Both are measured now, over 50 cards:

```
"maxKeypadShiftPx": 0,
"slate": { "cards": 50, "digitWidths": [2, 3, 4],
           "minWidthPx": 115.22, "maxWidthPx": 115.22,
           "widthSpreadPx": 0, "unitsColumnSpreadPx": 0, "clippedCards": 0 }
```

Both numbers were wrong before this pass and both are fixed, not re-measured:

* `--dw-slate-columns` was applied as `min-width` and never bound, because the
  `justify-between` + `gap-6` operator row always sized the box — 115.22 px on a
  two-digit rung against 140.72 px on a four-digit one, moving the units column
  12.75 px. It is now a `width` with the operator positioned in the reserved
  gutter, so nothing in the flow can outgrow the reservation.
* Once the driver started answering some cards wrong, `maxKeypadShiftPx` came
  back **7.5**: the verdict well reserved `2.75rem` = 44 px for a line that is
  `--text-3xl` (38 px) at `leading-tight` plus 4 px of padding = 51.5 px, so it
  grew and took the keypad down the screen on every wrong answer. The
  reservation is now derived from the tokens.

Headless generation bench (`npm run bench:generate`, 2000 seeds × 7 rungs):

```
rung 0  subtract-multidigit  L0  p50 0.007 ms  p95 0.012 ms  max 0.142 ms
rung 6  subtract-across-zero L2  p50 0.003 ms  p95 0.003 ms  max 0.087 ms
worst p95 across rungs: 0.012 ms  (Worker threshold: 4 ms)
```

### Horizontal overflow — none at any width, on the widest card

The probe used to run wherever an all-correct loop stopped, which is never the
contrast pair. The bench now parks there first (`parked on the contrast pair:
true`) and probes that:

```
{"width":320,"scrollWidth":320,"clientWidth":320,"horizontalOverflow":false,"offenders":[]}
{"width":360,"scrollWidth":360,"clientWidth":360,"horizontalOverflow":false,"offenders":[]}
{"width":768,"scrollWidth":768,"clientWidth":768,"horizontalOverflow":false,"offenders":[]}
{"width":1024,"scrollWidth":1024,"clientWidth":1024,"horizontalOverflow":false,"offenders":[]}
```

### The diagnosis, driven through the real UI (`npm run drive:locate`)

No bypass hook, no store poke. It reads the numbers off the slate, presses keys
at the window, and climbs the ladder by answering correctly until a problem with
a zero run appears — then answers with the borrow-across-zero result computed by
an **independent** implementation of the buggy procedure, so the driver is not
asking the code under test what the wrong answer is.

```
first problem: {"top":"95","bottom":"19"}
reached 606 − 199  correct 407  answering 507 (= correct + 100)
verdict screen: … 606 | − | minus | 199 | 507 | Answer | 407 | … | Next
contrast card:  … 606 − | minus | 199 | Put it back together. |
                407 + 199 = 606 | 100 | 10 | 1 |
                507 + 199 = 706 | 100 | 10 | 1 | Next
OK  the board shows 507 + 199 = 706, against 606
repair card: {"top":"500","bottom":"464"}
OK  the repair item borrows through a zero: 500 − 464, the same step, correct 36
```

`606 − 199 = 407` ✓ (199 + 407 = 606). `500 − 464 = 36` ✓.

**And the shape that broke the first version of the board.** `606 − 199` is one
of the two problems where comparing digits and comparing quantities happen to
agree, which is why every test and both drivers used it and nothing caught the
bug. Driven to a *carrying* case instead — `5904 − 4889`, correct `1015`, the
buggy procedure gives `1115`, check `1115 + 4889 = 6004` against a board carved
for `5904`:

```
5904 − 4889 = 1015   check: 4889 + 1015 = 5904 ✓
1115 = 1015 + 100    check: 1115 + 4889 = 6004, and 6004 − 5904 = 100 ✓
```

Digit-wise, `6004` against `5904` says hundreds 9 sockets / **0** counters — nine
empty sockets and a diamond in a thousands column the correct plate does not
have. As quantities, `6004` in counters fills all nine hundreds and leaves one
hundred over. The plates now render 5 · 9 · 0 · 4 seated on both, with a single
outlined diamond above the child's hundreds run.

The accessibility tree on that card, read out of Chrome rather than out of the
DOM:

```
image: "407 plus 199 makes 606. 100: 6 of 6. 1: 6 of 6. Every counter has a place."
image: "507 plus 199 makes 706. 100: 6 of 6. 1: 6 of 6. 100: 1 with nowhere to sit."
```

Before this pass the same card gave a screen reader `100 | 10 | 1 | 100 | 10 | 1`
— bare place labels, no counts, and nothing saying which board rebuilds the
number. Which one closed was `text-seat` versus `text-strike`.

### Stopping point and persistence, in the browser

Twelve answers, then measured directly rather than eyeballed:

```
Done       153 × 48 px   border-line-strong rounded-cut-md bg-ground-raised text-ink inscription …
Keep going 153 × 48 px   border-line-strong rounded-cut-md bg-ground-raised text-ink inscription …
```

Identical class string, identical box. `P-10` equal weight is structural: there
is one `Plate` component and no emphasised variant to reach for, and a test reads
the source to keep it that way.

```
persisted: {"state":{"rung":3,"rungCorrect":0,"seedCursor":20,"answered":12,"correct":12,"bugs":{}},"version":1}
after relaunch, problem: {"top":"5225","bottom":"4960"}
after relaunch: {"state":{"rung":3,…,"seedCursor":23,"answered":12,"correct":12,…},"version":1}
```

Resumes at the same rung with a *new* problem — the seed cursor moved, so a
relaunch does not re-serve what was already seen.

### Keyboard only, with real key events

**The trace in the previous version of this description was wrong** and the
review was right to reject it: it showed `focused control: BUTTON:8` beside
`typed: 76 … → Enter → seated`, which conflates two different focus states —
digits type through the *window* handler, and that handler deliberately leaves
Enter alone while a button has focus. Re-driven with `Input.dispatchKeyEvent`,
one state at a time:

```
A. no focus in the pad (the primary path), on 95 − 19
   typed: 76   focus: BODY
   Backspace → 7    6 → 76    Enter → verdict well: "Correct."

B. Tab, Tab, Tab → BUTTON:8, then Enter
   Enter with no text payload:  field "" → ""        (nothing at all)
   Enter carrying "\r":         field "" → "8"       (the button's own
                                                      activation — it types an
                                                      8, and never commits)

C. tab stops from BUTTON:8 to the commit control, with a digit typed
   ["9","4","5","6","1","2","3","0","⌫","Check"]     (10)
```

Kept as it is, and the reasons stated rather than the behaviour claimed away:
Enter on a focused button is that button's activation and stealing it would break
keyboard operation of the pad, and the path that needs no Tab at all — type,
Backspace, Enter — is the one above. `Check` is correctly out of the tab order
while the field is empty (it is `disabled`), which is why it does not appear in a
tab sweep taken before anything is typed.

### Reduced motion, resolved in the browser

```
{"animationName":"dw-seat-in-still","duration":"0.001s"}
```

A different keyframe set with no `transform` in it at all — a branch, not a
shortened travel. A test reads `work.css` and fails if the reduced-motion branch
ever points back at the travelling keyframes.

### Two bugs the first pass found that no test would have

1. **Enter did nothing on the contrast card.** It committed on every card, and
   the contrast card has no entry to commit — so a keyboard user could not leave
   it. Fixed; the decision is now `enterAction(state)`, a pure function with its
   own test.
2. **The subtraction bar vanished in dark.** `--dw-line-cut` and
   `--dw-ground-sunk` are both `basalt-950` under `.dw-dark`, so the bar was
   invisible and the answer read as a third operand. Only the dark screenshots
   showed it.

### What I did *not* verify

- Nothing on a device. Every number here is a developer machine and headless
  Chrome; `Q-01`, `Q-03`, `P-02` and `P-03` all keep their `[device]` halves.
- No child has seen this. The `[playtest]` gates `T-01`/`T-02`/`T-03` are
  untouched and this PR makes no claim about them.
- VoiceOver / TalkBack (`Q-09`) — the accessible names above are Chrome's
  accessibility tree, read through CDP. That is what a screen reader is given, not
  what one announces: no VoiceOver or TalkBack session has been run, and `Q-09`
  keeps its `[device]` half.
- The reviewer's first finding about the child experience is not answered by this
  PR and should not be read as answered: **nothing on screen ever says he got
  anywhere.** No score, no count, no chamber. Construction is PR-2.11 and P-09
  constrains its shape (no streak, no counter), so inventing a progress surface
  here would be the wrong shape shipped early — but "drill with no visible
  progress" is the XtraMath criticism MISSION exists to answer, and until 2.11
  lands the gap M2 is meant to test is only visible when the child is wrong.

