### PR TITLE
feat(dynawalla): the world, the reactions, and the Dynawalla

### DIFF
--- a/dynawalla/dynawalla-app/package.json
+++ b/dynawalla/dynawalla-app/package.json
@@ -16,6 +16,7 @@
     "test": "node --experimental-strip-types --test 'src/**/*.test.ts'",
     "bench:generate": "node --experimental-strip-types --no-warnings=ExperimentalWarning tools/bench-generate.mjs",
     "bench:loop": "node tools/bench-loop.mjs",
+    "bench:reactions": "node tools/bench-reactions.mjs",
     "drive:locate": "node tools/drive-locate.mjs"
   },
   "dependencies": {

--- a/dynawalla/dynawalla-app/src/app/Shell.tsx
+++ b/dynawalla/dynawalla-app/src/app/Shell.tsx
@@ -2,6 +2,7 @@ import { Link, Outlet, useMatches } from "react-router"
 
 import { IndexMark } from "../design/IndexMark.tsx"
 import { Strapwork } from "../design/Strapwork.tsx"
+import { ReactionStage } from "../reactions/Stage.tsx"
 import { strings } from "./strings.ts"
 import { DESTINATIONS, type Destination } from "./routes.ts"
 
@@ -46,6 +47,10 @@ export function Shell() {
       <main className="mx-auto w-full max-w-2xl flex-1 px-[max(var(--safe-left),1rem)] pt-6 pr-[max(var(--safe-right),1rem)] pb-[max(var(--safe-bottom),1.5rem)]">
         <Outlet />
       </main>
+      {/* One canvas for the whole app, over everything, catching nothing. It
+          carries no information and no affordance, which is what makes it safe
+          to clear at any instant. */}
+      <ReactionStage />
     </div>
   )
 }

--- a/dynawalla/dynawalla-app/src/app/Shell.tsx
+++ b/dynawalla/dynawalla-app/src/app/Shell.tsx
@@ -19,7 +19,7 @@ function Lintel() {
 
   return (
     <header className="bg-ground-raised">
-      <div className="flex items-baseline gap-3 px-[max(var(--safe-left),1rem)] pt-[max(var(--safe-top),0.75rem)] pr-[max(var(--safe-right),1rem)] pb-3">
+      <div className="flex items-baseline gap-3 px-[max(var(--safe-left),1rem)] pt-[max(var(--safe-top),var(--dw-lintel-pad))] pr-[max(var(--safe-right),1rem)] pb-[var(--dw-lintel-pad)]">
         <Link
           to="/"
           className="inscription rounded-cut-sm text-lg tracking-[0.22em] text-ink uppercase"
@@ -44,7 +44,10 @@ export function Shell() {
   return (
     <div className="bg-ground text-ink flex min-h-full flex-col">
       <Lintel />
-      <main className="mx-auto w-full max-w-2xl flex-1 px-[max(var(--safe-left),1rem)] pt-6 pr-[max(var(--safe-right),1rem)] pb-[max(var(--safe-bottom),1.5rem)]">
+      {/* `--dw-surface-pad` rather than a literal: on a short viewport every
+          band of vertical space is spoken for, and the frame's own padding is
+          part of that budget (see the vertical scale in `tokens.css`). */}
+      <main className="mx-auto w-full max-w-2xl flex-1 px-[max(var(--safe-left),1rem)] pt-[var(--dw-surface-pad)] pr-[max(var(--safe-right),1rem)] pb-[max(var(--safe-bottom),var(--dw-surface-pad))]">
         <Outlet />
       </main>
       {/* One canvas for the whole app, over everything, catching nothing. It

--- a/dynawalla/dynawalla-app/src/app/boundary.test.ts
+++ b/dynawalla/dynawalla-app/src/app/boundary.test.ts
@@ -1,0 +1,135 @@
+// `Q-05`, as one test over the whole tree, plus the two structural rules that
+// keep it from being satisfiable by accident.
+//
+// The acceptance item is a sentence about the source: *a boundary test fails
+// the build if anything under `src/reactions/` or `src/world/` imports from
+// `src/work/` or the engine.* Both of those directories have their own local
+// copy of the check, because a directory should carry its own rule; this one is
+// the app-wide statement, and it also catches the two failure modes a
+// per-directory check cannot see:
+//
+//   * an import **cycle** anywhere in `src/`, which is how "the world does not
+//     depend on the work surface" quietly becomes untrue through a third file;
+//   * an anchor class that has acquired a style, which would make removing it
+//     from an element change the picture as well as the reaction.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { ANCHORS } from "../design/anchors.ts"
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const src = path.resolve(here, "..")
+
+function files(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) files(full, out)
+    else if (/\.(ts|tsx)$/.test(entry.name) && !entry.name.endsWith(".test.ts")) out.push(full)
+  }
+  return out
+}
+
+const modules = files(src)
+
+/** Relative-import edges, resolved to repo-relative module paths. */
+function edges(file: string): string[] {
+  const text = fs.readFileSync(file, "utf8")
+  const out: string[] = []
+  for (const [, specifier] of text.matchAll(/from\s+"(\.[^"]+)"/g)) {
+    if (specifier === undefined) continue
+    out.push(path.relative(src, path.resolve(path.dirname(file), specifier)))
+  }
+  return out
+}
+
+test("Q-05: nothing under reactions/ or world/ imports the work surface or the engine", () => {
+  const offenders: string[] = []
+  for (const file of modules) {
+    const from = path.relative(src, file)
+    if (!from.startsWith("reactions/") && !from.startsWith("world/")) continue
+    const text = fs.readFileSync(file, "utf8")
+    for (const [, specifier] of text.matchAll(/from\s+"([^"]+)"/g)) {
+      const target = specifier ?? ""
+      const resolved = target.startsWith(".")
+        ? path.relative(src, path.resolve(path.dirname(file), target))
+        : target
+      if (/^work\//.test(resolved) || /engine|curriculum/.test(resolved)) {
+        offenders.push(`${from} -> ${target}`)
+      }
+    }
+  }
+  assert.deepEqual(offenders, [], "the work surface leaked into the world")
+})
+
+test("the arrow only points one way — there is no import cycle in src/", () => {
+  const graph = new Map(modules.map((file) => [path.relative(src, file), edges(file)]))
+  const state = new Map<string, "open" | "done">()
+  const cycles: string[] = []
+
+  const walk = (node: string, trail: string[]): void => {
+    if (state.get(node) === "done") return
+    if (state.get(node) === "open") {
+      cycles.push([...trail.slice(trail.indexOf(node)), node].join(" -> "))
+      return
+    }
+    state.set(node, "open")
+    for (const target of graph.get(node) ?? []) {
+      if (graph.has(target)) walk(target, [...trail, node])
+    }
+    state.set(node, "done")
+  }
+  for (const node of graph.keys()) walk(node, [])
+
+  assert.deepEqual(cycles, [])
+})
+
+test("the anchor classes style nothing", () => {
+  // They are a one-way DOM contract between what draws and what lights. The
+  // moment one carries a rule, deleting it from an element silently changes the
+  // picture too, and the coupling stops being one-way.
+  const styled: string[] = []
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) walk(full)
+      else if (entry.name.endsWith(".css")) {
+        const text = fs.readFileSync(full, "utf8")
+        for (const anchor of ANCHORS) {
+          if (text.includes(`.${anchor}`)) styled.push(`${path.relative(src, full)}: ${anchor}`)
+        }
+      }
+    }
+  }
+  walk(src)
+  assert.deepEqual(styled, [])
+})
+
+test("no inline style anywhere — the CSP forbids it outright", () => {
+  // `style-src 'self'` means a `style` prop throws the element's styling away
+  // silently in the shipped app while working perfectly in `vite dev`.
+  const offenders: string[] = []
+  for (const file of modules) {
+    const text = fs.readFileSync(file, "utf8")
+    if (/\sstyle=\{/.test(text)) offenders.push(path.relative(src, file))
+  }
+  assert.deepEqual(offenders, [])
+})
+
+test("P-09: no streak, timer, countdown or loss surface exists in the app", () => {
+  // `P-09` is graded at M10 over the shipped bundle. This is the same sweep run
+  // continuously, so the surface never acquires one between now and then.
+  const banned = /\b(streak|countdown|timeLeft|secondsLeft|lives|hearts|gameOver|combo)\b/i
+  const offenders: string[] = []
+  for (const file of modules) {
+    const text = fs
+      .readFileSync(file, "utf8")
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/(^|[^:])\/\/.*$/gm, "$1")
+    if (banned.test(text)) offenders.push(path.relative(src, file))
+  }
+  assert.deepEqual(offenders, [])
+})

--- a/dynawalla/dynawalla-app/src/app/devServer.test.ts
+++ b/dynawalla/dynawalla-app/src/app/devServer.test.ts
@@ -1,0 +1,149 @@
+// The dev server's filesystem reach, as a gate rather than a comment.
+//
+// `server.fs` decides which files `npm run dev` will hand out over HTTP. It has
+// no effect on `npm run build`, on `vite preview`, or on the shipped Tauri
+// bundle — Rollup has no fs guard and the production app loads from the bundle,
+// not from a server. So nothing here protects a user. What it protects is the
+// developer's own machine, and only while the dev server is running.
+//
+// That window is not hypothetical for this app. `TAURI_DEV_HOST` is how you run
+// on a phone, and setting it takes the server off loopback and onto the LAN
+// (see `vite.config.ts`), where every file the fs guard allows is readable by
+// any host on the network. The repository is public, so its source is not the
+// concern; the concern is the material that is deliberately NOT in it.
+//
+// Two rules, both of which a code change could quietly break and neither of
+// which any other test would notice:
+//
+//   1. The allow list stays at Vite's default. Widening it is the thing that
+//      has to stay hard.
+//   2. The deny list keeps every one of Vite's defaults. Vite REPLACES this
+//      array rather than extending it, so restating five of six silently drops
+//      the sixth — a config that looks like hardening and is the opposite.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const configPath = path.resolve(here, "../../vite.config.ts")
+const config = fs.readFileSync(configPath, "utf8")
+
+/**
+ * The config's executable lines, so the prose in it may freely name `fs.allow`
+ * without tripping the check below.
+ *
+ * Whole comment LINES are dropped rather than comment SYNTAX stripped, because
+ * this file is full of globs and a glob is indistinguishable from a comment
+ * delimiter: `"**\/.git/**"` contains `/*` and `"**\/src-tauri/**"` contains
+ * the matching `*\/`, so the usual block-comment regex deletes the entire
+ * `server` block between them and every assertion here passes vacuously. That
+ * happened while writing this test.
+ *
+ * The technique is exact only while every comment occupies its own line, so
+ * that is asserted rather than assumed.
+ */
+const lines = config.split("\n")
+const executable = lines.filter((line) => !line.trim().startsWith("//")).join("\n")
+
+test("this file can still read vite.config.ts", () => {
+  // A guard on the parsing technique above, not on the config. Without it, a
+  // trailing comment or a real block comment would quietly turn every
+  // assertion below into a tautology.
+  const trailing = lines.filter((line) => !line.trim().startsWith("//") && line.includes("//"))
+  assert.deepEqual(
+    trailing,
+    [],
+    "vite.config.ts has a trailing comment — this test strips whole comment lines only",
+  )
+  assert.ok(
+    !/^\s*\/\*/m.test(config),
+    "vite.config.ts has a block comment — this test strips whole comment lines only",
+  )
+  assert.ok(executable.includes("server:"), "the server block did not survive comment stripping")
+})
+
+/** Vite 8's `serverConfigDefaults.server.fs.deny`, verbatim. */
+const VITE_DEFAULT_DENY = [
+  ".env",
+  ".env.*",
+  "*.{crt,pem,key,p12,pfx,cer,der}",
+  ".npmrc",
+  ".yarnrc.yml",
+  "**/.git/**",
+]
+
+/**
+ * Signing material this repo's own ignore rules anticipate in the app tree, and
+ * which Vite's defaults do not cover. `.p12` is already a Vite default; these
+ * three are not.
+ */
+const SIGNING_MATERIAL = ["jks", "p8", "mobileprovision"]
+
+function denyPatterns(): string[] {
+  const block = /deny:\s*\[([^\]]*)\]/.exec(executable)
+  assert.ok(block, "server.fs.deny is not an array literal in vite.config.ts")
+  return [...(block[1] ?? "").matchAll(/"([^"]*)"/g)].map(([, pattern]) => pattern ?? "")
+}
+
+test("the dev server does not widen its allow list past Vite's default", () => {
+  // Vite's default is the workspace root, which for this app is its own
+  // directory: `searchForWorkspaceRoot` walks up looking for a `package.json`
+  // with a `workspaces` field, a `pnpm-workspace.yaml` or a `lerna.json`, finds
+  // none, and falls back to the nearest package root — which is here.
+  //
+  // The app reaches `dynawalla/curriculum` across that boundary anyway, because
+  // Vite 8 serves anything reachable through the import graph
+  // (`config.safeModulePaths`, consulted before `fs.allow`). Verified in a
+  // browser; see the note in vite.config.ts.
+  //
+  // If you are here because `npm run dev` started 403-ing on curriculum
+  // modules, a Vite upgrade has regressed that. Re-adding
+  // `allow: [".", "../curriculum"]` works and is not a disaster — but list `"."`
+  // too, because Vite replaces this array, and prefer giving the curriculum a
+  // resolvable name so nothing has to reach across the boundary at all.
+  assert.ok(
+    !/\ballow\s*:/.test(executable),
+    "vite.config.ts sets server.fs.allow — the dev server's reach has been widened",
+  )
+})
+
+test("the deny list keeps every Vite default", () => {
+  const patterns = denyPatterns()
+  const missing = VITE_DEFAULT_DENY.filter((pattern) => !patterns.includes(pattern))
+  assert.deepEqual(
+    missing,
+    [],
+    "restating server.fs.deny dropped a Vite default — the array is replaced, not merged",
+  )
+})
+
+test("the deny list covers the signing material the repo tells you to create here", () => {
+  // `src-tauri/.gitignore` ignores these because the repo is public;
+  // `RELEASE_SETUP.md` instructs you to generate an upload keystore in this
+  // tree. Being un-committed keeps them out of GitHub, not off the LAN. They
+  // live inside the allowed root, so narrowing `allow` cannot reach them —
+  // only `deny` can, and deny is checked first.
+  const patterns = denyPatterns()
+  const uncovered = SIGNING_MATERIAL.filter(
+    (extension) => !patterns.some((pattern) => pattern.includes(extension)),
+  )
+  assert.deepEqual(uncovered, [], "signing material is servable by the dev server")
+})
+
+test("the server is on loopback unless TAURI_DEV_HOST is set", () => {
+  // The one switch that puts this server on the network. It should stay
+  // explicit: an unconditional `host: true` would bind every interface for
+  // every developer, all the time, which is what makes the fs guard load-bearing
+  // rather than theoretical.
+  assert.ok(
+    /host:\s*devHost\s*\|\|\s*"127\.0\.0\.1"/.test(executable),
+    "the dev server no longer defaults to loopback",
+  )
+  assert.ok(
+    /const devHost = process\.env\.TAURI_DEV_HOST/.test(executable),
+    "TAURI_DEV_HOST is no longer the only thing that takes the server off loopback",
+  )
+})

--- a/dynawalla/dynawalla-app/src/app/profile.ts
+++ b/dynawalla/dynawalla-app/src/app/profile.ts
@@ -8,6 +8,13 @@
 //
 // One profile exists today. It is `DEFAULT_PROFILE_ID` and it is written into
 // every key, so the second profile costs a UI and nothing else.
+//
+// It lives in `src/app/` rather than beside the work surface because two
+// surfaces now persist under it — the ladder position and the construction —
+// and `Q-05` forbids `src/world/` from importing anything in `src/work/`. The
+// alternative was a second copy of the key convention, on the keys that hold a
+// real child's progress, which is precisely the collision this file exists to
+// make impossible.
 
 /** The one profile M2 creates. Not special: it is a value in the namespace. */
 export const DEFAULT_PROFILE_ID = "p1"

--- a/dynawalla/dynawalla-app/src/app/router.tsx
+++ b/dynawalla/dynawalla-app/src/app/router.tsx
@@ -6,6 +6,7 @@ import { Home } from "../screens/Home.tsx"
 import { Destination } from "../screens/Destination.tsx"
 import { PracticeScreen } from "../screens/Practice.tsx"
 import { SettingsScreen } from "../screens/Settings.tsx"
+import { WorldRoute } from "../screens/World.tsx"
 
 // Hash routing, per ADR-0005: `tauri://` and `http://tauri.localhost` are
 // custom protocols, history routing behaves inconsistently under them, and the
@@ -20,7 +21,7 @@ export const router = createHashRouter([
     children: [
       { index: true, element: <Home /> },
       { path: ROUTE_PATHS.practice, element: <PracticeScreen />, handle: "practice" },
-      { path: ROUTE_PATHS.world, element: <Destination />, handle: "world" },
+      { path: ROUTE_PATHS.world, element: <WorldRoute />, handle: "world" },
       { path: ROUTE_PATHS.progress, element: <Destination />, handle: "progress" },
       { path: ROUTE_PATHS.profiles, element: <Destination />, handle: "profiles" },
       { path: ROUTE_PATHS.settings, element: <SettingsScreen />, handle: "settings" },

--- a/dynawalla/dynawalla-app/src/app/strings.ts
+++ b/dynawalla/dynawalla-app/src/app/strings.ts
@@ -89,6 +89,17 @@ export const strings = {
   // is nowhere to put one — every line names something that actually happened
   // in the mathematics or in the stone.
   //
+  // **Every fragment must be checkable against the model**, and that is a
+  // stronger bar than the word-level screens in `voice.test.ts`. Two of the
+  // first twelve passed every one of those screens and were still not true.
+  // "That will hold weight. Not all of them do." — every rosette is the same
+  // twenty cells of the same geometry from `rosetteCells`; there is no rosette
+  // in this model that would not hold. And "You gave it up this time. Most do
+  // not, at first." is a claim about other children that nothing in this
+  // program measures, which is praise by social comparison and banned outright
+  // by MISSION. A ten-year-old who notices the rosettes are all identical has
+  // caught the character lying, and after that none of the other ten count.
+  //
   // `repaired` is the one that carries the product's promise, so it is the one
   // to read hardest. It is said after the child gets right the item that
   // isolates the step that had just broken — the borrowed ten that was kept in
@@ -97,7 +108,7 @@ export const strings = {
   dynawalla: {
     repaired: [
       "What you borrowed, you spent. It did not stay behind.",
-      "You gave it up this time. Most do not, at first.",
+      "The ten left the column it came from.",
       "A ten cannot sit in two places. You saw that.",
       "Nothing left over. That is the whole of it.",
     ],
@@ -105,7 +116,7 @@ export const strings = {
       "{{apertures}} apertures. The light has somewhere to go now.",
       "It closes. Cut stone does, when the order is right.",
       "A shape, where there was a hole.",
-      "That will hold weight. Not all of them do.",
+      "Stone does not grow back. That one stays cut.",
     ],
     arrived: [
       "These have a hole in the middle. Watch where the ten goes.",

--- a/dynawalla/dynawalla-app/src/app/strings.ts
+++ b/dynawalla/dynawalla-app/src/app/strings.ts
@@ -69,6 +69,51 @@ export const strings = {
         close is described by what is left over, not by a verdict on the child. */
     boardCloses: "Every counter has a place.",
   },
+
+  // The world. One string: the drawn screen needs a text alternative (`Q-10`)
+  // and a count is the honest one — it is the only thing about the construction
+  // that is a number. Everything else the drawing says, it says by being drawn.
+  world: {
+    cut: "{{apertures}} apertures cut.",
+  },
+
+  // The Dynawalla.
+  //
+  // Twelve fragments over three observation types — PR-2.11's slice of the
+  // grammar M6 grows to ~100 (`P-06`). He speaks at most four times in a
+  // session and never repeats himself, so the whole of what a child hears in
+  // one sitting is four of these.
+  //
+  // The register: ancient, precise, dryly amused, never saccharine. He notices
+  // the specific true thing and stops. There is no "Great job!" here and there
+  // is nowhere to put one — every line names something that actually happened
+  // in the mathematics or in the stone.
+  //
+  // `repaired` is the one that carries the product's promise, so it is the one
+  // to read hardest. It is said after the child gets right the item that
+  // isolates the step that had just broken — the borrowed ten that was kept in
+  // two places at once. It describes what the *number* did. It never names a
+  // misconception, a mistake, or the child (`M-16`).
+  dynawalla: {
+    repaired: [
+      "What you borrowed, you spent. It did not stay behind.",
+      "You gave it up this time. Most do not, at first.",
+      "A ten cannot sit in two places. You saw that.",
+      "Nothing left over. That is the whole of it.",
+    ],
+    closed: [
+      "{{apertures}} apertures. The light has somewhere to go now.",
+      "It closes. Cut stone does, when the order is right.",
+      "A shape, where there was a hole.",
+      "That will hold weight. Not all of them do.",
+    ],
+    arrived: [
+      "These have a hole in the middle. Watch where the ten goes.",
+      "Zero is not nothing. It is a place with nothing in it.",
+      "Now the empty column.",
+      "Reach past the zero. It has nothing of its own to lend.",
+    ],
+  },
 } as const
 
 /**

--- a/dynawalla/dynawalla-app/src/character/Automaton.tsx
+++ b/dynawalla/dynawalla-app/src/character/Automaton.tsx
@@ -1,0 +1,48 @@
+/**
+ * The Dynawalla, drawn in the same material language as the instruments.
+ *
+ * An aperture and a lintel, cut into the wall the band is: a straight-edged
+ * lens of lapis with one brass point sighting through it, under a raked brass
+ * brow. It is an eye drawn as strapwork — the same geometry as the rosettes the
+ * child is cutting, which is the point. He is made of the thing being built.
+ *
+ * **Two earlier cuts of this failed and both are worth recording, because the
+ * failure is exactly the one the art direction warns about — right vocabulary,
+ * generic drawing.** A circular lens in a square plate read as a webcam icon. A
+ * tall plate with a horizontal slit read as a bank card. What both had in
+ * common was an *enclosing plate*: at 32 px a bounded rectangle with stripes in
+ * it is a card, whatever the stripes are. So there is no plate. The eye is cut
+ * into the band's own stone, and the band is the face.
+ *
+ * No mouth, no cheeks, no expression, and exactly one moving part: the brow
+ * lifts when he speaks and is otherwise still. Under reduced motion the
+ * transform collapses with the duration tokens and he simply is, or is not,
+ * attending — the information (a line is in the band) is in the markup, never
+ * in the lift.
+ */
+export function Automaton({ speaking }: { speaking: boolean }) {
+  return (
+    <svg aria-hidden="true" className="size-9 shrink-0" viewBox="0 0 24 24" focusable="false">
+      {/* The aperture: two chevrons meeting, the girih lens. Cut through to
+          the deep field, with the lit edge of the cut catching light along the
+          top — the same way an aperture reads on the screen he is watching. */}
+      <path
+        d="M2 15.6 L8 9.2 L16 9.2 L22 15.6 L16 22 L8 22 Z"
+        fill="var(--dw-ground-deep)"
+        stroke="var(--dw-index)"
+        strokeWidth="0.9"
+      />
+      {/* What sights through it. Off centre and low: he is looking down at the
+          work, not out of the screen. A brass point, not a pupil — there is no
+          anatomy anywhere in this drawing. */}
+      <path d="M10 12.2 L14.4 15.6 L10 19 L5.6 15.6 Z" fill="var(--dw-index)" />
+      {/* The brow ridge over the socket: one carved unit with it, and the whole
+          of his animation. */}
+      <path
+        className={speaking ? "dw-brow dw-brow-raised" : "dw-brow"}
+        d="M3 5.4 H21 L19.6 8.2 H4.4 Z"
+        fill="var(--dw-index)"
+      />
+    </svg>
+  )
+}

--- a/dynawalla/dynawalla-app/src/character/character.css
+++ b/dynawalla/dynawalla-app/src/character/character.css
@@ -1,0 +1,67 @@
+/* ──────────────────────────────────────────────────────────────────────────
+   The Dynawalla.
+
+   Two rules, and that is the whole of his animation. He is an instrument with
+   one moving part, and everything he communicates is in the markup — the line
+   is text in a live region whether or not the brow lifts, and the brow lifting
+   is never how a child finds out he said something.
+
+   Both collapse to nothing under `prefers-reduced-motion`: the durations are
+   the motion tokens, which `tokens.css` sets to 0ms in that branch, so there
+   is no second rule here to keep in step.
+
+   The CSP forbids inline style entirely (`style-src 'self'`), so anything that
+   moves is a class in a stylesheet, never a `style` prop.
+   ────────────────────────────────────────────────────────────────────────── */
+
+@layer components {
+  /* The brow. It sits level and lifts a unit and a half when he speaks —
+     `transform-box: fill-box` so the rotation origin is the stroke's own box
+     rather than the SVG's, which would swing it off the plate entirely. */
+  .dw-brow {
+    transform-box: fill-box;
+    transform-origin: center;
+    transition: transform var(--dw-motion-detent) var(--dw-ease-detent);
+  }
+
+  .dw-brow-raised {
+    transform: translateY(-1.5px) rotate(-3deg);
+  }
+
+  /* The line arriving. A cut, not a slide: it fades up over one detent with a
+     single pixel of settle, in a region whose height was already reserved, so
+     nothing on the work surface can move because of it. */
+  .dw-utterance {
+    animation-name: dw-utterance-cut;
+    animation-duration: var(--dw-motion-detent);
+    animation-timing-function: var(--dw-ease-detent);
+    animation-fill-mode: both;
+  }
+
+  @keyframes dw-utterance-cut {
+    from {
+      opacity: 0;
+      transform: translateY(1px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  /* The branch: no travel at all, only the fade. */
+  @media (prefers-reduced-motion: reduce) {
+    .dw-utterance {
+      animation-name: dw-utterance-still;
+    }
+  }
+
+  @keyframes dw-utterance-still {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+}

--- a/dynawalla/dynawalla-app/src/character/store.ts
+++ b/dynawalla/dynawalla-app/src/character/store.ts
@@ -27,9 +27,19 @@ interface CharacterState {
   hush: () => void
   /** New session: the budget refills, the room is quiet again. */
   reset: () => void
+  /**
+   * Which phrasing he reaches for, as an injectable sequence.
+   *
+   * `consider` is pure and takes the draw as an argument precisely so this is
+   * seedable; the first cut then handed it `Math.random` here and threw that
+   * away. Which line he says is one of the two things that most change a
+   * screenshot, so the session seeds it from its own cursor.
+   */
+  seed: (sequence: () => number) => void
 }
 
 let dwell: ReturnType<typeof setTimeout> | null = null
+let draw: () => number = Math.random
 
 function schedule(hush: () => void): void {
   if (dwell !== null) clearTimeout(dwell)
@@ -41,7 +51,7 @@ export const useCharacter = create<CharacterState>()((set, get) => ({
   utterance: null,
 
   observe: (observation, at) => {
-    const { state, utterance } = consider(get().voice, observation, at, Math.random())
+    const { state, utterance } = consider(get().voice, observation, at, draw())
     if (utterance === null) {
       // Still record nothing: `consider` returns the state unchanged when he
       // stays quiet, so there is no bookkeeping to do and no way for a silent
@@ -62,5 +72,9 @@ export const useCharacter = create<CharacterState>()((set, get) => ({
     if (dwell !== null) clearTimeout(dwell)
     dwell = null
     set({ voice: SILENT, utterance: null })
+  },
+
+  seed: (sequence) => {
+    draw = sequence
   },
 }))

--- a/dynawalla/dynawalla-app/src/character/store.ts
+++ b/dynawalla/dynawalla-app/src/character/store.ts
@@ -1,0 +1,66 @@
+// Whether he is speaking, and what he said.
+//
+// Session-scoped and deliberately not persisted: the budget is per session, and
+// a line that survived a relaunch would be a line said about something the
+// child no longer remembers doing.
+//
+// The utterance lingers rather than flashing. A remark that appears for the 420
+// ms a seated answer holds is a remark nobody reads, and the alternative — the
+// loop waiting on the character — is banned outright. So it stays in the band
+// while the child carries on working, and goes when it goes. The band is a
+// fixed height whether he is speaking or not, so nothing on the work surface
+// ever moves because of him.
+
+import { create } from "zustand"
+
+import { consider, SILENT, type Observation, type Utterance, type VoiceState } from "./voice.ts"
+
+/** How long a line stays in the band. Long enough to be read while working. */
+export const DWELL_MS = 9000
+
+interface CharacterState {
+  readonly voice: VoiceState
+  readonly utterance: Utterance | null
+  /** Offer him something that happened on card `at`. */
+  observe: (observation: Observation, at: number) => void
+  /** Clear the line. Called by the dwell timer and when a session begins. */
+  hush: () => void
+  /** New session: the budget refills, the room is quiet again. */
+  reset: () => void
+}
+
+let dwell: ReturnType<typeof setTimeout> | null = null
+
+function schedule(hush: () => void): void {
+  if (dwell !== null) clearTimeout(dwell)
+  dwell = setTimeout(hush, DWELL_MS)
+}
+
+export const useCharacter = create<CharacterState>()((set, get) => ({
+  voice: SILENT,
+  utterance: null,
+
+  observe: (observation, at) => {
+    const { state, utterance } = consider(get().voice, observation, at, Math.random())
+    if (utterance === null) {
+      // Still record nothing: `consider` returns the state unchanged when he
+      // stays quiet, so there is no bookkeeping to do and no way for a silent
+      // observation to spend budget.
+      return
+    }
+    set({ voice: state, utterance })
+    schedule(get().hush)
+  },
+
+  hush: () => {
+    if (dwell !== null) clearTimeout(dwell)
+    dwell = null
+    set({ utterance: null })
+  },
+
+  reset: () => {
+    if (dwell !== null) clearTimeout(dwell)
+    dwell = null
+    set({ voice: SILENT, utterance: null })
+  },
+}))

--- a/dynawalla/dynawalla-app/src/character/voice.test.ts
+++ b/dynawalla/dynawalla-app/src/character/voice.test.ts
@@ -6,6 +6,19 @@
 // pool ("Perfect / Nice / Brilliant") that the in-repo precedent resolves to.
 // Both are asserted over the whole corpus rather than over the lines a test
 // happened to trigger, so adding a thirteenth fragment cannot slip past them.
+//
+// ## And the check no regular expression can run
+//
+// **Every fragment must be checkable against the model, by a person, before it
+// is added.** Two of the first twelve passed every screen in this file and were
+// still not true: "That will hold weight. Not all of them do." — every rosette
+// is the same twenty cells of identical geometry, so there is no rosette that
+// would not hold — and "You gave it up this time. Most do not, at first.",
+// which is a claim about other children that nothing in this program measures.
+// A word-level gate is not a truthfulness gate, and a ten-year-old who works
+// out that all the rosettes are the same shape has caught the character lying.
+// The screens below cover the shapes a regex can catch; the rest is a review
+// obligation, and it is written here because that is where it will be read.
 
 import { test } from "node:test"
 import assert from "node:assert/strict"
@@ -88,6 +101,17 @@ test("no line is flat praise — every one says something that happened", () => 
   for (const line of corpus()) assert.equal(line.includes("!"), false, line)
 })
 
+test("no line praises by comparison with anyone else", () => {
+  // MISSION bans social pressure outright, and "Most do not, at first." was
+  // both that and an unverifiable claim: nothing in this program knows what
+  // most children do. It is a distinct failure from flat praise — it trips no
+  // cheerleader word and contains no exclamation mark — so it gets its own
+  // screen. Nothing he says may reference a person who is not in the room.
+  const comparison =
+    /\b(most|others|other (children|kids|people)|everyone|nobody|no one|anyone else|than (most|others|anybody|anyone))\b/i
+  for (const line of corpus()) assert.equal(comparison.test(line), false, line)
+})
+
 test("he does not address the child as a subject", () => {
   // "You saw that" is about what happened. "You are clever" is a verdict on a
   // person, and this product does not issue those.
@@ -114,6 +138,14 @@ test("the lines fit the three lines the band reserves at 320 px", () => {
   // rather than growing the band, which is the correct failure but is still a
   // failure. This is also the rule for the five locales at PR-1.6: translate to
   // fit, do not lengthen the band.
+  //
+  // A character count is a poor proxy across scripts — CJK is far denser per
+  // character, Devanagari far wider — and a comment is not a gate. So this
+  // bound holds the English corpus only, and PR-1.6 owes the real one: a
+  // per-locale assertion in the i18n gate, measured from the longest
+  // **rendered** string at 320 px rather than from a character count, so an
+  // overlong German or Finnish translation fails the build instead of clipping
+  // mid-word in the rarest moment the product has.
   for (const line of corpus()) {
     const rendered = line.replace("{{apertures}}", "180")
     assert.ok(rendered.length <= 58, `${String(rendered.length)} chars: ${rendered}`)

--- a/dynawalla/dynawalla-app/src/character/voice.test.ts
+++ b/dynawalla/dynawalla-app/src/character/voice.test.ts
@@ -1,0 +1,121 @@
+// The Dynawalla is a register, and a register is testable: how often he speaks,
+// whether he repeats himself, and what he is structurally incapable of saying.
+//
+// The last one is the important one. `M-16` forbids any learner-facing string
+// from naming a misconception or a defect, and MISSION forbids the flat praise
+// pool ("Perfect / Nice / Brilliant") that the in-repo precedent resolves to.
+// Both are asserted over the whole corpus rather than over the lines a test
+// happened to trigger, so adding a thirteenth fragment cannot slip past them.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { strings } from "../app/strings.ts"
+import {
+  consider,
+  corpus,
+  QUIET_CARDS,
+  SILENT,
+  UTTERANCE_BUDGET,
+  type Observation,
+  type VoiceState,
+} from "./voice.ts"
+
+const CLOSED: Observation = { kind: "closed", apertures: 20 }
+const REPAIRED: Observation = { kind: "repaired", apertures: null }
+
+/** Speak as often as he is willing to, offered something on every card. */
+function session(offers: readonly Observation[]): string[] {
+  let state: VoiceState = SILENT
+  const heard: string[] = []
+  offers.forEach((observation, card) => {
+    const { state: next, utterance } = consider(state, observation, card, (card * 0.37) % 1)
+    state = next
+    if (utterance !== null) heard.push(utterance.line)
+  })
+  return heard
+}
+
+test("he speaks three to five times in a session, and no more", () => {
+  const offers = Array.from({ length: 200 }, (_, i) => (i % 2 === 0 ? CLOSED : REPAIRED))
+  const heard = session(offers)
+  assert.ok(heard.length >= 3 && heard.length <= 5, `he spoke ${String(heard.length)} times`)
+  assert.equal(heard.length, UTTERANCE_BUDGET)
+})
+
+test("he never repeats himself within a session", () => {
+  const offers = Array.from({ length: 200 }, () => CLOSED)
+  const heard = session(offers)
+  assert.equal(new Set(heard).size, heard.length)
+})
+
+test("silence is the default: an ordinary card gets nothing", () => {
+  // Nothing is offered on an ordinary card at all — `respond` returns a null
+  // observation — and offering him one anyway on the card right after he spoke
+  // still gets silence.
+  const first = consider(SILENT, CLOSED, 10, 0.1)
+  assert.notEqual(first.utterance, null)
+  for (let gap = 1; gap < QUIET_CARDS; gap++) {
+    assert.equal(consider(first.state, REPAIRED, 10 + gap, 0.1).utterance, null)
+  }
+  assert.notEqual(consider(first.state, REPAIRED, 10 + QUIET_CARDS, 0.1).utterance, null)
+})
+
+test("a silent consideration spends nothing", () => {
+  const spent = consider(SILENT, CLOSED, 0, 0.1).state
+  const quiet = consider(spent, REPAIRED, 1, 0.1)
+  assert.equal(quiet.utterance, null)
+  assert.deepEqual(quiet.state, spent, "a refusal changed the state")
+})
+
+test("the slot is filled, never left standing", () => {
+  const heard = session(Array.from({ length: 40 }, () => ({ kind: "closed", apertures: 20 }) as const))
+  for (const line of heard) assert.equal(/\{\{/.test(line), false, line)
+})
+
+test("M-16: no line names a misconception, a mistake or the child's defect", () => {
+  const banned =
+    /\b(wrong|mistake|error|incorrect|bug|misconception|failed?|bad|silly|oops|careless)\b/i
+  for (const line of corpus()) assert.equal(banned.test(line), false, line)
+})
+
+test("no line is flat praise — every one says something that happened", () => {
+  const cheerleader =
+    /\b(great|good job|well done|awesome|amazing|perfect|nice|brilliant|excellent|super|fantastic|keep it up)\b/i
+  for (const line of corpus()) assert.equal(cheerleader.test(line), false, line)
+  // Nor an exclamation anywhere: the register is dry, and an exclamation mark
+  // is the single fastest way out of it.
+  for (const line of corpus()) assert.equal(line.includes("!"), false, line)
+})
+
+test("he does not address the child as a subject", () => {
+  // "You saw that" is about what happened. "You are clever" is a verdict on a
+  // person, and this product does not issue those.
+  for (const line of corpus()) {
+    assert.equal(/\byou are\b|\byou're\b|\byour \w+ is\b/i.test(line), false, line)
+  }
+})
+
+test("PR-2.11's slice: twelve fragments over three observation types", () => {
+  assert.equal(Object.keys(strings.dynawalla).length, 3)
+  assert.equal(corpus().length, 12)
+  assert.equal(new Set(corpus()).size, 12, "two fragments are the same line")
+})
+
+test("the lines fit the three lines the band reserves at 320 px", () => {
+  // The band is a **fixed** height and the character may not change it, so the
+  // constraint runs the other way: the fragments have to fit the room.
+  //
+  // Measured, not guessed. At 320 px — the narrowest width this app ships to —
+  // the text column is 160 px, and the longest fragment
+  // ("What you borrowed, you spent. It did not stay behind.", 53 characters)
+  // renders as exactly three lines in the inscription face at `text-xs`. The
+  // bound below leaves a little room and no more; a fragment past it clips
+  // rather than growing the band, which is the correct failure but is still a
+  // failure. This is also the rule for the five locales at PR-1.6: translate to
+  // fit, do not lengthen the band.
+  for (const line of corpus()) {
+    const rendered = line.replace("{{apertures}}", "180")
+    assert.ok(rendered.length <= 58, `${String(rendered.length)} chars: ${rendered}`)
+  }
+})

--- a/dynawalla/dynawalla-app/src/character/voice.ts
+++ b/dynawalla/dynawalla-app/src/character/voice.ts
@@ -1,0 +1,106 @@
+// The Dynawalla speaks: what he notices, and how rarely.
+//
+// ## Rarity is the register
+//
+// Twenty-one authored lines against a few hundred items per session is one line
+// every ten or twenty problems, repeating from minute six, and the in-repo
+// precedent for that architecture resolves to "Perfect / Nice / Brilliant" —
+// the generic cheerleader this product exists in opposition to. Two fixes, both
+// taken here.
+//
+// **He speaks three to five times in a session, at genuine milestones.** The
+// budget is enforced in this file and there is no override. `QUIET_CARDS` keeps
+// two remarks from landing on top of each other when a repair and a closing
+// star coincide. Silence is the personality; most of the session he is present
+// and says nothing.
+//
+// **A grammar, not a line list.** M2 has three observation types and four
+// phrasings each — the twelve fragments PR-2.11 names — behind the interface
+// M6 fills out to ~100 fragments over eight observation types with slotted
+// skill and instrument nouns (`P-06`). The `{{apertures}}` slot is already
+// live, so the call sites do not move when the grammar grows.
+//
+// ## What he is allowed to say
+//
+// Only true, specific things. He does not say "well done", he says what
+// happened. He never names a misconception or a defect (`M-16`): the repair
+// lines describe what the *mathematics* did — the borrowed ten was spent and
+// did not stay behind — never what the child got wrong.
+
+import { strings, fill } from "../app/strings.ts"
+
+export type ObservationKind = keyof typeof strings.dynawalla
+
+export interface Observation {
+  readonly kind: ObservationKind
+  /** Apertures in the thing that just closed. `null` when it is not that. */
+  readonly apertures: number | null
+}
+
+/** Utterances per session. Three to five is the register; four is the cap. */
+export const UTTERANCE_BUDGET = 4
+
+/** Cards of silence after he speaks, so two remarks never stack. */
+export const QUIET_CARDS = 3
+
+export interface VoiceState {
+  /** Fragment ids already used this session. He never repeats himself. */
+  readonly said: readonly string[]
+  /** The card ordinal he last spoke on. */
+  readonly lastAt: number | null
+}
+
+export const SILENT: VoiceState = { said: [], lastAt: null }
+
+export interface Utterance {
+  readonly id: string
+  readonly line: string
+}
+
+export interface Considered {
+  readonly state: VoiceState
+  /** `null` far more often than not, and that is the design. */
+  readonly utterance: Utterance | null
+}
+
+/**
+ * Offer him something that happened. He decides whether it is worth a word.
+ *
+ * Pure: `at` is the card ordinal and `draw` is a number in [0, 1), so the same
+ * session replays identically in a test and in the screenshot harness.
+ */
+export function consider(
+  state: VoiceState,
+  observation: Observation,
+  at: number,
+  draw: number,
+): Considered {
+  if (state.said.length >= UTTERANCE_BUDGET) return { state, utterance: null }
+  if (state.lastAt !== null && at - state.lastAt < QUIET_CARDS) return { state, utterance: null }
+
+  const phrasings = strings.dynawalla[observation.kind]
+  const unused: { id: string; template: string }[] = []
+  for (let i = 0; i < phrasings.length; i++) {
+    const id = `${observation.kind}:${String(i)}`
+    const template = phrasings[i]
+    if (template !== undefined && !state.said.includes(id)) unused.push({ id, template })
+  }
+  if (unused.length === 0) return { state, utterance: null }
+
+  const index = Math.min(Math.floor(Math.max(draw, 0) * unused.length), unused.length - 1)
+  const chosen = unused[index]
+  if (chosen === undefined) return { state, utterance: null }
+
+  return {
+    state: { said: [...state.said, chosen.id], lastAt: at },
+    utterance: {
+      id: chosen.id,
+      line: fill(chosen.template, { apertures: observation.apertures ?? 0 }),
+    },
+  }
+}
+
+/** Every line he can say, for the coverage test and for the locale gate. */
+export function corpus(): string[] {
+  return Object.values(strings.dynawalla).flatMap((phrasings) => [...phrasings])
+}

--- a/dynawalla/dynawalla-app/src/design/Recess.tsx
+++ b/dynawalla/dynawalla-app/src/design/Recess.tsx
@@ -9,7 +9,7 @@ import type { ReactNode } from "react"
  */
 export function Recess({ children }: { children?: ReactNode }) {
   return (
-    <div className="rounded-cut-md border-t border-b border-t-line-cut border-b-line bg-ground-sunk min-h-40 p-5">
+    <div className="rounded-cut-md border-t border-b border-t-line-cut border-b-line bg-ground-sunk min-h-40 p-[var(--dw-frame-pad)]">
       {children}
     </div>
   )

--- a/dynawalla/dynawalla-app/src/design/anchors.ts
+++ b/dynawalla/dynawalla-app/src/design/anchors.ts
@@ -1,0 +1,23 @@
+// Anchors: the three places the reaction stage is allowed to draw.
+//
+// A class name is a poor coupling and a deliberate one. The alternative is the
+// reaction layer holding refs to the answer row and the rosette, which means
+// the work surface and the world both handing pieces of themselves to something
+// that must never be able to reach back into either (`Q-05`). A marker class
+// is one-way: whatever draws puts one on, the stage measures whatever it finds,
+// and neither side imports the other.
+//
+// They style nothing. `rg dw-anchor- src/**/*.css` returns nothing, and that is
+// the invariant — the moment one of these carries a rule, removing it from an
+// element silently changes the picture as well as the reaction.
+
+/** The answer row: where the child's answer seats. */
+export const ANCHOR_SEAT = "dw-anchor-seat"
+
+/** The construction band. */
+export const ANCHOR_CARTOUCHE = "dw-anchor-cartouche"
+
+/** The aperture cut by the answer just given. */
+export const ANCHOR_APERTURE = "dw-anchor-aperture"
+
+export const ANCHORS: readonly string[] = [ANCHOR_SEAT, ANCHOR_CARTOUCHE, ANCHOR_APERTURE]

--- a/dynawalla/dynawalla-app/src/design/tokens.css
+++ b/dynawalla/dynawalla-app/src/design/tokens.css
@@ -146,6 +146,16 @@
   --dw-field: var(--color-lapis-800);
   --dw-field-ink: var(--color-celestial-100);
 
+  /* What is seen through a cut aperture, and the lit edge of the stone around
+     it. A role of its own rather than a reuse of `ground-deep`: under
+     `.dw-dark`, `ground-deep` is basalt-950 and the band it is cut into is
+     basalt-700 — the same stone two steps apart, which at 44 px read as no
+     difference at all between a cut cell and an uncut one. A hole shows the
+     deep *field*, which is cool where the wall is warm, so the aperture reads
+     by hue as well as by value and the rim is not carrying it alone. */
+  --dw-aperture: var(--color-lapis-950);
+  --dw-aperture-rim: var(--color-celestial-100);
+
   /* Verdicts. Cold light seats a correct answer; copper oxide marks a strike.
      Neither is ever the only carrier of meaning (CG-18). */
   --dw-seat: var(--color-tile-600);
@@ -182,6 +192,79 @@
   --dw-cut-sm: 2px;
   --dw-cut-md: 4px;
   --dw-cut-lg: 8px;
+
+  /* ── The vertical scale ────────────────────────────────────────────────
+     The practice surface is the tallest thing this app draws, and on a short
+     phone it did not fit: at 320 × 568 and 360 × 640 the document was 878 px
+     and the "Check" plate's bottom edge sat at 833 — below the fold at both,
+     so the child scrolled to submit every single answer. Measured, not
+     guessed; the reference tablet and a 390 × 844 phone were both fine, which
+     is exactly why it survived.
+
+     One scale, in one place, because the fix is a budget rather than a tweak:
+     six numbers that add up to the height of a session. Under 720 px of
+     viewport they all come down together — the band, the recess, the numerals,
+     the gaps and the keys — and every component reads them rather than
+     carrying its own literal, so the budget can be read off this block.
+
+     The key floor is the one that is not taste. `Keypad.tsx` sets the bar at a
+     ≥2 cm target on the diagonal a child actually hits. At 320 px wide a key
+     is 77 px across, so a 52 px key has a 93 px diagonal = 2.46 cm — still
+     over the floor, and `surface.test.ts` asserts it from these numbers rather
+     than from the comment. */
+  --dw-band-height: 4.5rem;
+  --dw-key-height: 4.75rem;
+  --dw-numeral-size: var(--text-3xl);
+  --dw-frame-pad: 1.25rem;
+  --dw-stack-gap: 1.5rem;
+  --dw-stack-gap-tight: 1rem;
+  --dw-surface-pad: 1.5rem;
+
+  --dw-lintel-pad: 0.75rem;
+
+  /* Three rungs, one per device class this app ships to: a tablet, a phone, and
+     a small phone. Untouched above 900 px — the Galaxy Tab A9 and the iPad get
+     the design at full size, and nothing below is a compromise they pay for. */
+  @media (max-height: 900px) {
+    --dw-frame-pad: 1rem;
+    --dw-stack-gap: 1.25rem;
+    --dw-stack-gap-tight: 0.875rem;
+    --dw-surface-pad: 1rem;
+    --dw-lintel-pad: 0.625rem;
+  }
+
+  @media (max-height: 720px) {
+    --dw-band-height: 3.5rem;
+    --dw-key-height: 3.25rem;
+    --dw-numeral-size: var(--text-2xl);
+    --dw-frame-pad: 0.625rem;
+    --dw-stack-gap: 0.75rem;
+    --dw-stack-gap-tight: 0.5rem;
+    --dw-surface-pad: 0.5rem;
+    --dw-lintel-pad: 0.5rem;
+  }
+
+  /* The second rung, and the reason there are two. At 640 px the numbers above
+     bring the surface to 646 — under the fold, done. At 568 they do not, and
+     "nearly fits" is worth nothing: the pinned plate then covers the bottom
+     keypad row, so a child cannot type a zero without scrolling, which is the
+     original bug wearing a different hat. So the shortest viewport this app
+     ships to gets its own rung, tuned until the document is shorter than the
+     screen rather than until it looks about right.
+
+     A 44 px key is 77 × 44 at 320 px wide — an 89 px diagonal, 2.35 cm — still
+     over the ≥2 cm floor, and `surface.test.ts` computes that for every rung of
+     this scale rather than for the one somebody remembered. */
+  @media (max-height: 620px) {
+    --dw-band-height: 3rem;
+    --dw-key-height: 2.75rem;
+    --dw-numeral-size: var(--text-xl);
+    --dw-frame-pad: 0.5rem;
+    --dw-stack-gap: 0.5rem;
+    --dw-stack-gap-tight: 0.375rem;
+    --dw-surface-pad: 0.25rem;
+    --dw-lintel-pad: 0.25rem;
+  }
 
   /* ── Platform facts, inherited mechanically from Corpán's stylesheet ────
      Per ADR-0005 this is the one layer Dynawalla does not build fresh: the
@@ -227,6 +310,9 @@
 
   --dw-field: var(--color-lapis-950);
   --dw-field-ink: var(--color-celestial-300);
+
+  --dw-aperture: var(--color-lapis-950);
+  --dw-aperture-rim: var(--color-celestial-300);
 
   --dw-seat: var(--color-tile-400);
   --dw-strike: var(--color-copper-700);

--- a/dynawalla/dynawalla-app/src/index.css
+++ b/dynawalla/dynawalla-app/src/index.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "./design/tokens.css";
 @import "./work/work.css";
+@import "./character/character.css";
 
 /* The theme class the shell toggles on <html>. `:where()` keeps specificity at
    zero so a dark utility never outranks a more specific rule by accident. */

--- a/dynawalla/dynawalla-app/src/reactions/Stage.tsx
+++ b/dynawalla/dynawalla-app/src/reactions/Stage.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from "react"
+
+import { mountStage } from "./live.ts"
+
+/**
+ * The reaction canvas: one element, over everything, catching nothing.
+ *
+ * `pointer-events: none` and `aria-hidden`, because it carries no information
+ * and no affordance. Everything the child needs to know — right, wrong, what
+ * the correct answer was, what got built — is in the markup underneath, which
+ * is what makes it safe to clear this surface at any instant (`settleNow`) and
+ * to draw almost nothing on it under reduced motion. No information is conveyed
+ * by animation alone, from the first frame.
+ *
+ * One canvas for the whole app rather than one per screen: a second would mean
+ * a second stage, a second once-a-session budget, and two things to settle on a
+ * keystroke.
+ */
+export function ReactionStage() {
+  const canvas = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const element = canvas.current
+    if (element === null) return
+    return mountStage(element)
+  }, [])
+
+  return (
+    <canvas
+      ref={canvas}
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-0 z-[var(--z-sticky)] h-full w-full"
+    />
+  )
+}

--- a/dynawalla/dynawalla-app/src/reactions/effects.ts
+++ b/dynawalla/dynawalla-app/src/reactions/effects.ts
@@ -1,0 +1,362 @@
+// The effect catalogue: nine ways the mechanism responds.
+//
+// Everything here is drawn in the material vocabulary — a pawl dropping into a
+// tooth, a counterweight rising a notch, an aperture taking light, ribs
+// striking home. Nothing bursts, nothing spins, nothing is a starburst, and
+// there is no effect whose job is to be exciting. EXPERIENCE_DESIGN's hostile
+// reference board bans confetti and any particle vocabulary borrowed from a
+// casual mobile game; motes here are chips of stone and points of cold light,
+// thrown a few pixels and gone.
+//
+// **A gear that does not turn a thing is decoration and is banned.** So there
+// are no gears. The moving parts here are the ones that are actually doing the
+// work: the pawl that holds the count, the weight that drives it, and the stone
+// that light passes through — which is the thing being built.
+//
+// ## The energy ladder
+//
+// Each effect declares the three factors EXPERIENCE_DESIGN's energy formula
+// needs beyond its tier's budget: how many motes it throws, its peak output
+// amplitude, and how many things move. `energy = budgetMs × particles ×
+// peakGain × elements`, and `effects.test.ts` asserts the whole ladder is
+// strictly ordered — the loudest slip is quieter than the quietest seat, the
+// loudest seat quieter than the quietest engage, and so on to the top.
+//
+// `peakGain` is a real number that a real thing reads: every effect multiplies
+// its brightest element's alpha by it. When the Web Audio layer lands at PR 2.7
+// it is the same number, which is the point of naming it gain rather than
+// opacity.
+
+import { TIERS, type TierName } from "./tiers.ts"
+import {
+  centre,
+  line,
+  motes,
+  sweep,
+  type Ctx,
+  type Frame,
+  type Rect,
+} from "./surface.ts"
+
+/** What must be on screen for an effect to be drawable. */
+export type Requirement = "seat" | "cartouche" | "aperture"
+
+export interface Effect {
+  readonly id: string
+  readonly tier: TierName
+  /** Motes thrown at peak. Feeds the energy formula and the pool. */
+  readonly particles: number
+  /** Peak output amplitude, 0…1. Multiplies the brightest element's alpha. */
+  readonly peakGain: number
+  /** Independently animated elements. */
+  readonly elements: number
+  readonly needs: readonly Requirement[]
+  readonly draw: (ctx: Ctx, frame: Frame) => void
+}
+
+/** EXPERIENCE_DESIGN's energy measure, over one effect. */
+export function energy(effect: Effect): number {
+  return TIERS[effect.tier].budgetMs * effect.particles * effect.peakGain * effect.elements
+}
+
+/** The notch pitch of the pawl rail, in pixels. */
+const TOOTH = 9
+
+function rail(seat: Rect): { y: number; x: number } {
+  return { y: seat.y + seat.height + 3, x: seat.x + seat.width - TOOTH * 3 }
+}
+
+/** One tooth of the rail, drawn as a short vertical incision. */
+function tooth(ctx: Ctx, x: number, y: number, height: number, colour: string): void {
+  line(ctx, { x, y }, { x, y: y + height }, colour, 1.5)
+}
+
+// ── Tier −1 · SLIP ─────────────────────────────────────────────────────────
+// Visually interesting and clearly non-successful. Both of these are the
+// mechanism failing to take: nothing advances, and one chip comes off.
+
+const chisel: Effect = {
+  id: "chisel",
+  tier: "slip",
+  particles: 1,
+  peakGain: 0.3,
+  elements: 2,
+  needs: ["seat"],
+  draw: (ctx, frame) => {
+    const seat = frame.anchor.seat
+    if (seat === null) return
+    const y = seat.y + seat.height * 0.62
+    const x1 = seat.x + seat.width * frame.t
+    ctx.lineCap = "round"
+    ctx.globalAlpha = frame.alpha * frame.gain
+    line(ctx, { x: seat.x, y }, { x: x1, y: y + seat.height * 0.1 }, frame.ink.strike, 2)
+    motes(ctx, frame, { x: x1, y }, 5, frame.ink.strike)
+  },
+}
+
+const stall: Effect = {
+  id: "stall",
+  tier: "slip",
+  particles: 1,
+  peakGain: 0.28,
+  elements: 2,
+  needs: ["seat"],
+  draw: (ctx, frame) => {
+    const seat = frame.anchor.seat
+    if (seat === null) return
+    const { x, y } = rail(seat)
+    // The pawl leans at the tooth and comes back. Oscillation, so it is gated
+    // on `travel`: with reduced motion it simply rests where it was.
+    const lean = Math.sin(Math.PI * frame.t) * TOOTH * 0.45 * frame.travel
+    ctx.globalAlpha = frame.alpha * frame.gain
+    for (let i = 0; i < 3; i++) tooth(ctx, x + i * TOOTH, y, 5, frame.ink.line)
+    tooth(ctx, x + TOOTH + lean, y - 1, 7, frame.ink.strike)
+    motes(ctx, frame, { x: x + TOOTH + lean, y: y + 5 }, 3, frame.ink.line)
+  },
+}
+
+// ── Tier 0 · SEAT ──────────────────────────────────────────────────────────
+// Ordinary correctness. 200 ms, one detent, then earned stillness. This is the
+// reaction the child sees hundreds of times, so it is the one that must never
+// be in the way.
+
+const detent: Effect = {
+  id: "detent",
+  tier: "seat",
+  particles: 3,
+  peakGain: 0.55,
+  elements: 2,
+  needs: ["seat"],
+  draw: (ctx, frame) => {
+    const seat = frame.anchor.seat
+    if (seat === null) return
+    const { x, y } = rail(seat)
+    const overshoot = Math.sin(Math.PI * frame.t) * 1.6 * frame.travel
+    const pawl = x + TOOTH * (1 + frame.t) + overshoot
+    ctx.globalAlpha = frame.alpha * frame.gain * 0.6
+    for (let i = 0; i < 3; i++) tooth(ctx, x + i * TOOTH, y, 5, frame.ink.line)
+    ctx.globalAlpha = frame.alpha * frame.gain
+    tooth(ctx, pawl, y - 1, 7, frame.ink.index)
+    motes(ctx, frame, { x: pawl, y: y + 2 }, 4, frame.ink.celestial)
+  },
+}
+
+const glint: Effect = {
+  id: "glint",
+  tier: "seat",
+  particles: 3,
+  peakGain: 0.52,
+  elements: 2,
+  needs: ["seat"],
+  draw: (ctx, frame) => {
+    const seat = frame.anchor.seat
+    if (seat === null) return
+    const band = sweep(frame, seat)
+    ctx.globalAlpha = frame.alpha * frame.gain * 0.4
+    ctx.fillStyle = frame.ink.celestial
+    ctx.beginPath()
+    ctx.rect(band.x, seat.y, band.width, seat.height)
+    ctx.fill()
+    ctx.globalAlpha = frame.alpha * frame.gain
+    line(
+      ctx,
+      { x: seat.x, y: seat.y + seat.height },
+      { x: seat.x + seat.width, y: seat.y + seat.height },
+      frame.ink.seat,
+      2,
+    )
+    motes(ctx, frame, centre(seat), 6, frame.ink.celestial)
+  },
+}
+
+// ── Tier 1 · ENGAGE ────────────────────────────────────────────────────────
+// A harder item. The machinery moves: the aperture the answer just cut takes
+// light, or the weight that drives the whole thing rises a notch.
+
+const tessera: Effect = {
+  id: "tessera",
+  tier: "engage",
+  particles: 6,
+  peakGain: 0.7,
+  elements: 3,
+  needs: ["aperture"],
+  draw: (ctx, frame) => {
+    const cell = frame.anchor.aperture
+    if (cell === null) return
+    const at = centre(cell)
+    const radius = Math.max(cell.width, cell.height) * (0.35 + 0.55 * frame.t)
+    ctx.fillStyle = frame.ink.celestial
+    ctx.globalAlpha = frame.alpha * frame.gain * (1 - frame.t * 0.7)
+    ctx.beginPath()
+    ctx.arc(at.x, at.y, radius, 0, Math.PI * 2)
+    ctx.fill()
+    ctx.globalAlpha = frame.alpha * frame.gain
+    line(ctx, at, { x: at.x, y: at.y + radius * 2.2 }, frame.ink.celestial, 1)
+    motes(ctx, frame, at, 7, frame.ink.celestial)
+  },
+}
+
+const counterweight: Effect = {
+  id: "counterweight",
+  tier: "engage",
+  particles: 5,
+  peakGain: 0.66,
+  elements: 3,
+  needs: ["cartouche"],
+  draw: (ctx, frame) => {
+    const band = frame.anchor.cartouche
+    if (band === null) return
+    const x = band.x + 6
+    const top = band.y + 4
+    const bottom = band.y + band.height - 6
+    const at = bottom - (bottom - top) * frame.t
+    ctx.globalAlpha = frame.alpha * frame.gain * 0.5
+    line(ctx, { x, y: top }, { x, y: bottom }, frame.ink.line, 1)
+    ctx.globalAlpha = frame.alpha * frame.gain
+    ctx.fillStyle = frame.ink.index
+    ctx.beginPath()
+    ctx.rect(x - 3, at - 3, 6, 6)
+    ctx.fill()
+    motes(ctx, frame, { x, y: at }, 6, frame.ink.index)
+  },
+}
+
+// ── Tier 2 · ILLUMINATE ────────────────────────────────────────────────────
+// The star inside a rosette closing, or a misunderstanding repaired. The whole
+// band catches light.
+
+const rosetteLight: Effect = {
+  id: "rosetteLight",
+  tier: "illuminate",
+  particles: 14,
+  peakGain: 0.85,
+  elements: 4,
+  needs: ["cartouche"],
+  draw: (ctx, frame) => {
+    const band = frame.anchor.cartouche
+    if (band === null) return
+    const band2 = sweep(frame, band)
+    ctx.fillStyle = frame.ink.celestial
+    ctx.globalAlpha = frame.alpha * frame.gain * 0.28
+    ctx.beginPath()
+    ctx.rect(band2.x, band.y, band2.width, band.height)
+    ctx.fill()
+
+    const cell = frame.anchor.aperture ?? band
+    const at = centre(cell)
+    ctx.globalAlpha = frame.alpha * frame.gain
+    ctx.strokeStyle = frame.ink.celestial
+    ctx.lineWidth = 1.5
+    ctx.beginPath()
+    ctx.arc(at.x, at.y, band.height * (0.2 + 0.35 * frame.t), 0, Math.PI * 2)
+    ctx.stroke()
+    line(
+      ctx,
+      { x: band.x, y: band.y + band.height },
+      { x: band.x + band.width, y: band.y + band.height },
+      frame.ink.index,
+      1.5,
+    )
+    motes(ctx, frame, at, 14, frame.ink.celestial)
+  },
+}
+
+const armature: Effect = {
+  id: "armature",
+  tier: "illuminate",
+  particles: 10,
+  peakGain: 0.8,
+  elements: 4,
+  needs: ["cartouche", "aperture"],
+  draw: (ctx, frame) => {
+    const band = frame.anchor.cartouche
+    const cell = frame.anchor.aperture
+    if (band === null || cell === null) return
+    const at = centre(cell)
+    const radius = band.height * 0.38
+    ctx.globalAlpha = frame.alpha * frame.gain
+    ctx.strokeStyle = frame.ink.index
+    ctx.lineWidth = 2
+    ctx.beginPath()
+    ctx.arc(at.x, at.y, radius, -Math.PI / 2, -Math.PI / 2 + Math.PI * 2 * frame.t)
+    ctx.stroke()
+    ctx.globalAlpha = frame.alpha * frame.gain * 0.6
+    ctx.beginPath()
+    ctx.arc(at.x, at.y, radius * 0.55, 0, Math.PI * 2)
+    ctx.stroke()
+    line(ctx, { x: band.x, y: band.y }, { x: band.x + band.width, y: band.y }, frame.ink.index, 1)
+    motes(ctx, frame, at, 9, frame.ink.index)
+  },
+}
+
+// ── Tier 3 · MECHANISM ─────────────────────────────────────────────────────
+// A rosette closes and is set into the screen. Once a session, and any input
+// settles it — a child who answers fast never waits on this.
+
+const closure: Effect = {
+  id: "closure",
+  tier: "mechanism",
+  particles: 24,
+  peakGain: 1,
+  elements: 5,
+  needs: ["cartouche", "aperture"],
+  draw: (ctx, frame) => {
+    const band = frame.anchor.cartouche
+    const cell = frame.anchor.aperture
+    if (band === null || cell === null) return
+    const at = centre(cell)
+    const radius = band.height * 0.42
+
+    // The ribs strike home: ten incisions closing on the centre.
+    ctx.globalAlpha = frame.alpha * frame.gain
+    ctx.strokeStyle = frame.ink.index
+    ctx.lineWidth = 1.5
+    for (let k = 0; k < 10; k++) {
+      const angle = (k / 10) * Math.PI * 2 - Math.PI / 2
+      const outer = radius * (1.7 - 0.7 * frame.t)
+      ctx.beginPath()
+      ctx.moveTo(at.x + Math.cos(angle) * radius * 0.5, at.y + Math.sin(angle) * radius * 0.5)
+      ctx.lineTo(at.x + Math.cos(angle) * outer, at.y + Math.sin(angle) * outer)
+      ctx.stroke()
+    }
+
+    // …and then the screen has somewhere to put the light.
+    const shaft = band.height * 4 * frame.t
+    ctx.fillStyle = frame.ink.celestial
+    ctx.globalAlpha = frame.alpha * frame.gain * 0.16 * (1 - frame.t)
+    ctx.beginPath()
+    ctx.moveTo(at.x - radius * 0.6, at.y)
+    ctx.lineTo(at.x + radius * 0.6, at.y)
+    ctx.lineTo(at.x + radius * 1.9, at.y + shaft)
+    ctx.lineTo(at.x - radius * 1.9, at.y + shaft)
+    ctx.closePath()
+    ctx.fill()
+
+    ctx.globalAlpha = frame.alpha * frame.gain * 0.5
+    line(
+      ctx,
+      { x: band.x, y: band.y + band.height },
+      { x: band.x + band.width, y: band.y + band.height },
+      frame.ink.index,
+      2,
+    )
+    motes(ctx, frame, at, 12, frame.ink.celestial)
+  },
+}
+
+/** Every effect, in energy order within each tier. */
+export const EFFECTS: readonly Effect[] = [
+  stall,
+  chisel,
+  glint,
+  detent,
+  counterweight,
+  tessera,
+  armature,
+  rosetteLight,
+  closure,
+]
+
+export function effectsIn(tier: TierName): readonly Effect[] {
+  return EFFECTS.filter((effect) => effect.tier === tier)
+}

--- a/dynawalla/dynawalla-app/src/reactions/effects.ts
+++ b/dynawalla/dynawalla-app/src/reactions/effects.ts
@@ -13,14 +13,34 @@
 // work: the pawl that holds the count, the weight that drives it, and the stone
 // that light passes through — which is the thing being built.
 //
+// ## Particles start at ENGAGE, and that is the doc's rule
+//
+// EXPERIENCE_DESIGN's SEAT row reads "One detent click, one gear tooth, a
+// `light` haptic, **no particles**". The first cut of this file gave both SEAT
+// effects three motes each, which contradicted the doc on the reaction the
+// child sees most — and the contradiction was load-bearing, because under a
+// *multiplicative* energy formula a particle-free effect scores zero and
+// `energy(SLIP) < energy(SEAT)` cannot hold at all.
+//
+// Two changes, together. The particle term is additive — `(1 + particles)` —
+// so a particle-free effect has a real energy that its budget, gain and moving
+// parts still order. And nothing below ENGAGE throws a mote: SEAT because the
+// doc says so, SLIP because SLIP must be quieter than SEAT and a chip of stone
+// flying off is unarguably more animated than a pawl dropping into a tooth.
+// That is the "catapult falling short" failure EXPERIENCE_DESIGN names, and
+// the only way to rule it out is to not have the catapult.
+//
 // ## The energy ladder
 //
-// Each effect declares the three factors EXPERIENCE_DESIGN's energy formula
-// needs beyond its tier's budget: how many motes it throws, its peak output
-// amplitude, and how many things move. `energy = budgetMs × particles ×
-// peakGain × elements`, and `effects.test.ts` asserts the whole ladder is
-// strictly ordered — the loudest slip is quieter than the quietest seat, the
-// loudest seat quieter than the quietest engage, and so on to the top.
+// `energy = budgetMs × (1 + particles) × peakGain × elements`, and
+// `reactions.test.ts` asserts the whole ladder is strictly ordered — the
+// loudest slip is quieter than the quietest seat, the loudest seat quieter
+// than the quietest engage, and so on to the top.
+//
+// `particles` and `elements` are **disjoint** counts: `elements` is the drawn
+// parts the frame animates and the mote cloud is not one of them. They were
+// tangled in the first cut, which is why dropping the motes from SEAT would
+// otherwise have left `elements` counting something that is no longer drawn.
 //
 // `peakGain` is a real number that a real thing reads: every effect multiplies
 // its brightest element's alpha by it. When the Web Audio layer lands at PR 2.7
@@ -44,19 +64,28 @@ export type Requirement = "seat" | "cartouche" | "aperture"
 export interface Effect {
   readonly id: string
   readonly tier: TierName
-  /** Motes thrown at peak. Feeds the energy formula and the pool. */
+  /** Motes thrown at peak. Zero below ENGAGE. Feeds the energy formula and the pool. */
   readonly particles: number
   /** Peak output amplitude, 0…1. Multiplies the brightest element's alpha. */
   readonly peakGain: number
-  /** Independently animated elements. */
+  /** Independently animated drawn parts. Does **not** count the mote cloud. */
   readonly elements: number
   readonly needs: readonly Requirement[]
+  /**
+   * The anchor this effect may not draw outside of, or `null` for no clip.
+   *
+   * The canvas is `fixed inset-0` over the whole app, so an arc struck around a
+   * 44 px rosette in a 72 px band overran the band's top edge and drew across
+   * the header. A clip is the honest fix: the effect keeps its geometry and the
+   * stage keeps it inside the thing it is playing on.
+   */
+  readonly clip: Requirement | null
   readonly draw: (ctx: Ctx, frame: Frame) => void
 }
 
 /** EXPERIENCE_DESIGN's energy measure, over one effect. */
 export function energy(effect: Effect): number {
-  return TIERS[effect.tier].budgetMs * effect.particles * effect.peakGain * effect.elements
+  return TIERS[effect.tier].budgetMs * (1 + effect.particles) * effect.peakGain * effect.elements
 }
 
 /** The notch pitch of the pawl rail, in pixels. */
@@ -73,15 +102,18 @@ function tooth(ctx: Ctx, x: number, y: number, height: number, colour: string): 
 
 // ── Tier −1 · SLIP ─────────────────────────────────────────────────────────
 // Visually interesting and clearly non-successful. Both of these are the
-// mechanism failing to take: nothing advances, and one chip comes off.
+// mechanism failing to take: nothing advances. No motes — see the header: the
+// chip of stone flying off was the loudest thing in the bottom two tiers, on
+// the outcome that must never be the interesting one.
 
 const chisel: Effect = {
   id: "chisel",
   tier: "slip",
-  particles: 1,
+  particles: 0,
   peakGain: 0.3,
-  elements: 2,
+  elements: 1,
   needs: ["seat"],
+  clip: null,
   draw: (ctx, frame) => {
     const seat = frame.anchor.seat
     if (seat === null) return
@@ -90,17 +122,17 @@ const chisel: Effect = {
     ctx.lineCap = "round"
     ctx.globalAlpha = frame.alpha * frame.gain
     line(ctx, { x: seat.x, y }, { x: x1, y: y + seat.height * 0.1 }, frame.ink.strike, 2)
-    motes(ctx, frame, { x: x1, y }, 5, frame.ink.strike)
   },
 }
 
 const stall: Effect = {
   id: "stall",
   tier: "slip",
-  particles: 1,
+  particles: 0,
   peakGain: 0.28,
   elements: 2,
   needs: ["seat"],
+  clip: null,
   draw: (ctx, frame) => {
     const seat = frame.anchor.seat
     if (seat === null) return
@@ -111,22 +143,23 @@ const stall: Effect = {
     ctx.globalAlpha = frame.alpha * frame.gain
     for (let i = 0; i < 3; i++) tooth(ctx, x + i * TOOTH, y, 5, frame.ink.line)
     tooth(ctx, x + TOOTH + lean, y - 1, 7, frame.ink.strike)
-    motes(ctx, frame, { x: x + TOOTH + lean, y: y + 5 }, 3, frame.ink.line)
   },
 }
 
 // ── Tier 0 · SEAT ──────────────────────────────────────────────────────────
 // Ordinary correctness. 200 ms, one detent, then earned stillness. This is the
 // reaction the child sees hundreds of times, so it is the one that must never
-// be in the way.
+// be in the way — and, per EXPERIENCE_DESIGN's SEAT row, the one with no
+// particles in it at all.
 
 const detent: Effect = {
   id: "detent",
   tier: "seat",
-  particles: 3,
+  particles: 0,
   peakGain: 0.55,
   elements: 2,
   needs: ["seat"],
+  clip: null,
   draw: (ctx, frame) => {
     const seat = frame.anchor.seat
     if (seat === null) return
@@ -137,17 +170,17 @@ const detent: Effect = {
     for (let i = 0; i < 3; i++) tooth(ctx, x + i * TOOTH, y, 5, frame.ink.line)
     ctx.globalAlpha = frame.alpha * frame.gain
     tooth(ctx, pawl, y - 1, 7, frame.ink.index)
-    motes(ctx, frame, { x: pawl, y: y + 2 }, 4, frame.ink.celestial)
   },
 }
 
 const glint: Effect = {
   id: "glint",
   tier: "seat",
-  particles: 3,
+  particles: 0,
   peakGain: 0.52,
   elements: 2,
   needs: ["seat"],
+  clip: null,
   draw: (ctx, frame) => {
     const seat = frame.anchor.seat
     if (seat === null) return
@@ -165,7 +198,6 @@ const glint: Effect = {
       frame.ink.seat,
       2,
     )
-    motes(ctx, frame, centre(seat), 6, frame.ink.celestial)
   },
 }
 
@@ -178,8 +210,9 @@ const tessera: Effect = {
   tier: "engage",
   particles: 6,
   peakGain: 0.7,
-  elements: 3,
+  elements: 2,
   needs: ["aperture"],
+  clip: "cartouche",
   draw: (ctx, frame) => {
     const cell = frame.anchor.aperture
     if (cell === null) return
@@ -201,8 +234,9 @@ const counterweight: Effect = {
   tier: "engage",
   particles: 5,
   peakGain: 0.66,
-  elements: 3,
+  elements: 2,
   needs: ["cartouche"],
+  clip: "cartouche",
   draw: (ctx, frame) => {
     const band = frame.anchor.cartouche
     if (band === null) return
@@ -223,15 +257,74 @@ const counterweight: Effect = {
 
 // ── Tier 2 · ILLUMINATE ────────────────────────────────────────────────────
 // The star inside a rosette closing, or a misunderstanding repaired. The whole
-// band catches light.
+// band catches light — and, in `keystone`, so does the answer row.
+//
+// `keystone` exists because the three loudest tiers all played in the 72 px
+// construction band at the top of the screen, four hundred pixels from where
+// the child's eyes are. Only SEAT drew at the seat, which is the tier that is
+// deliberately the quietest. So the escalation was invisible at the place the
+// escalation is *about*. It is also the quietest effect in its tier, and the
+// picker weights inversely to energy — so it is the ILLUMINATE the child
+// usually gets.
+
+const keystone: Effect = {
+  id: "keystone",
+  tier: "illuminate",
+  particles: 8,
+  peakGain: 0.75,
+  elements: 3,
+  needs: ["seat"],
+  clip: null,
+  draw: (ctx, frame) => {
+    const seat = frame.anchor.seat
+    if (seat === null) return
+    const at = centre(seat)
+    const depth = seat.height * 0.44
+    const half = seat.width * 0.1
+
+    // The recess takes light.
+    ctx.fillStyle = frame.ink.celestial
+    ctx.globalAlpha = frame.alpha * frame.gain * 0.22
+    ctx.beginPath()
+    ctx.rect(seat.x, seat.y, seat.width, seat.height)
+    ctx.fill()
+
+    // The keystone comes down the last of its travel and seats on the rule.
+    // Carried by `t`, which the stage pins to 1 under reduced motion, so with
+    // motion off it is simply drawn where it lands.
+    const lands = seat.y + seat.height - depth
+    const top = lands - seat.height * 0.8 * (1 - frame.t)
+    ctx.globalAlpha = frame.alpha * frame.gain
+    ctx.fillStyle = frame.ink.index
+    ctx.beginPath()
+    ctx.moveTo(at.x - half, top)
+    ctx.lineTo(at.x + half, top)
+    ctx.lineTo(at.x + half * 1.6, top + depth)
+    ctx.lineTo(at.x - half * 1.6, top + depth)
+    ctx.closePath()
+    ctx.fill()
+
+    // …and the rule it seats on goes solid under it.
+    ctx.globalAlpha = frame.alpha * frame.gain * (0.4 + 0.6 * frame.t)
+    line(
+      ctx,
+      { x: seat.x, y: seat.y + seat.height },
+      { x: seat.x + seat.width, y: seat.y + seat.height },
+      frame.ink.seat,
+      2,
+    )
+    motes(ctx, frame, { x: at.x, y: top + depth }, 8, frame.ink.celestial)
+  },
+}
 
 const rosetteLight: Effect = {
   id: "rosetteLight",
   tier: "illuminate",
   particles: 14,
   peakGain: 0.85,
-  elements: 4,
+  elements: 3,
   needs: ["cartouche"],
+  clip: "cartouche",
   draw: (ctx, frame) => {
     const band = frame.anchor.cartouche
     if (band === null) return
@@ -266,8 +359,9 @@ const armature: Effect = {
   tier: "illuminate",
   particles: 10,
   peakGain: 0.8,
-  elements: 4,
+  elements: 3,
   needs: ["cartouche", "aperture"],
+  clip: "cartouche",
   draw: (ctx, frame) => {
     const band = frame.anchor.cartouche
     const cell = frame.anchor.aperture
@@ -298,8 +392,9 @@ const closure: Effect = {
   tier: "mechanism",
   particles: 24,
   peakGain: 1,
-  elements: 5,
+  elements: 3,
   needs: ["cartouche", "aperture"],
+  clip: "cartouche",
   draw: (ctx, frame) => {
     const band = frame.anchor.cartouche
     const cell = frame.anchor.aperture
@@ -346,12 +441,13 @@ const closure: Effect = {
 
 /** Every effect, in energy order within each tier. */
 export const EFFECTS: readonly Effect[] = [
-  stall,
   chisel,
+  stall,
   glint,
   detent,
   counterweight,
   tessera,
+  keystone,
   armature,
   rosetteLight,
   closure,

--- a/dynawalla/dynawalla-app/src/reactions/live.ts
+++ b/dynawalla/dynawalla-app/src/reactions/live.ts
@@ -1,0 +1,132 @@
+// The mounted stage, and the two calls the rest of the app makes to it.
+//
+// A module-level handle rather than a context or a prop chain. The input
+// handler has to be able to say `settleNow()` on the first line of a keydown,
+// before anything else happens, and threading a ref down to it through three
+// components is how that line ends up conditional. Both calls are no-ops when
+// nothing is mounted, so a test, a screenshot harness, or a route with no
+// canvas on it behaves exactly like the app with reactions turned off.
+//
+// This is also the only file in `src/reactions/` that touches the DOM. The
+// stage is told rectangles; finding them is done here, once, at fire time —
+// after the verdict has painted, never on the answer path.
+
+import { ANCHOR_APERTURE, ANCHOR_CARTOUCHE, ANCHOR_SEAT } from "../design/anchors.ts"
+import { createStage, type Stage } from "./stage.ts"
+import type { Anchor, Ink, Rect } from "./surface.ts"
+import type { Outcome } from "./tiers.ts"
+
+let stage: Stage | null = null
+
+function boxOf(selector: string, origin: DOMRect): Rect | null {
+  const element = document.querySelector(selector)
+  if (element === null) return null
+  const box = element.getBoundingClientRect()
+  if (box.width <= 0 || box.height <= 0) return null
+  return { x: box.x - origin.x, y: box.y - origin.y, width: box.width, height: box.height }
+}
+
+function anchorFromDom(canvas: HTMLCanvasElement): Anchor {
+  const origin = canvas.getBoundingClientRect()
+  return {
+    seat: boxOf(`.${ANCHOR_SEAT}`, origin),
+    cartouche: boxOf(`.${ANCHOR_CARTOUCHE}`, origin),
+    aperture: boxOf(`.${ANCHOR_APERTURE}`, origin),
+  }
+}
+
+/**
+ * The palette, read from the semantic tokens rather than named here.
+ *
+ * `tokens.css` owns the material vocabulary and re-cuts every role under
+ * `.dw-dark`; a brass literal baked into this file would be a second theme
+ * that never follows, and `tokens.test.ts` fails the build over exactly that.
+ * Read on every fire, so a theme change mid-session is picked up with no
+ * subscription.
+ *
+ * An unresolved role degrades to `transparent` rather than to a guess. If the
+ * stylesheet has not arrived, the honest outcome is that the canvas — which
+ * carries no information — draws nothing.
+ */
+function inkFromTokens(root: HTMLElement): Ink {
+  const style = getComputedStyle(root)
+  const role = (name: string): string => style.getPropertyValue(name).trim() || "transparent"
+  return {
+    index: role("--dw-index"),
+    seat: role("--dw-seat"),
+    strike: role("--dw-strike"),
+    celestial: role("--dw-field-ink"),
+    line: role("--dw-line-strong"),
+  }
+}
+
+/**
+ * Attach the stage to a canvas. Returns the detach function.
+ *
+ * Sizing is the caller's only other responsibility and it happens here: the
+ * backing store is device pixels, the drawing is CSS pixels, and the transform
+ * that reconciles them is set once per resize rather than per frame.
+ */
+export function mountStage(canvas: HTMLCanvasElement): () => void {
+  const context = canvas.getContext("2d")
+  if (context === null) return () => undefined
+
+  const size = (): { width: number; height: number } => {
+    const box = canvas.getBoundingClientRect()
+    return { width: box.width, height: box.height }
+  }
+
+  const resize = (): void => {
+    const ratio = Math.min(window.devicePixelRatio || 1, 2)
+    const { width, height } = size()
+    canvas.width = Math.max(1, Math.round(width * ratio))
+    canvas.height = Math.max(1, Math.round(height * ratio))
+    context.setTransform(ratio, 0, 0, ratio, 0, 0)
+  }
+  resize()
+
+  const motion = window.matchMedia("(prefers-reduced-motion: reduce)")
+
+  const mounted = createStage({
+    ctx: context,
+    size,
+    now: () => performance.now(),
+    schedule: (run) => requestAnimationFrame(run),
+    cancel: (handle) => {
+      cancelAnimationFrame(handle)
+    },
+    reducedMotion: () => motion.matches,
+    ink: () => inkFromTokens(document.documentElement),
+    anchor: () => anchorFromDom(canvas),
+  })
+
+  stage = mounted
+  window.addEventListener("resize", resize)
+
+  return () => {
+    window.removeEventListener("resize", resize)
+    mounted.dispose()
+    if (stage === mounted) stage = null
+  }
+}
+
+/** Start a reaction for what just happened. Never awaited, never blocking. */
+export function fireReaction(outcome: Outcome): void {
+  stage?.fire(outcome)
+}
+
+/**
+ * Settle whatever is running. The first line of every input handler.
+ *
+ * Synchronous and unconditional: it is cheaper to call this on a keystroke that
+ * turns out to be a no-op than to work out whether the reaction matters, and a
+ * conditional here is how a fast child ends up waiting on an animation.
+ */
+export function settleReactions(): void {
+  stage?.settleNow()
+}
+
+/** Give the session back its once-a-session reaction budget. */
+export function resetReactions(): void {
+  stage?.reset()
+}

--- a/dynawalla/dynawalla-app/src/reactions/live.ts
+++ b/dynawalla/dynawalla-app/src/reactions/live.ts
@@ -14,9 +14,26 @@
 import { ANCHOR_APERTURE, ANCHOR_CARTOUCHE, ANCHOR_SEAT } from "../design/anchors.ts"
 import { createStage, type Stage } from "./stage.ts"
 import type { Anchor, Ink, Rect } from "./surface.ts"
-import type { Outcome } from "./tiers.ts"
+import { TIERS, type Outcome, type TierName } from "./tiers.ts"
 
 let stage: Stage | null = null
+
+/**
+ * Which effect gets drawn, as an injectable sequence.
+ *
+ * `Math.random` until somebody hands over something better. Which effect plays
+ * and which line the Dynawalla says are the two things that most change a
+ * screenshot, and the mote pool went to the trouble of being a deterministic
+ * integer hash so that the committed seed set (`Q-06`, M6) is comparable frame
+ * for frame — which it is not if the choice in front of it is unseeded. The
+ * session hands its own cursor in at `begin`.
+ */
+let draw: () => number = Math.random
+
+/** Seed the effect choice for a session. Called when one begins. */
+export function seedReactions(sequence: () => number): void {
+  draw = sequence
+}
 
 function boxOf(selector: string, origin: DOMRect): Rect | null {
   const element = document.querySelector(selector)
@@ -98,6 +115,7 @@ export function mountStage(canvas: HTMLCanvasElement): () => void {
     reducedMotion: () => motion.matches,
     ink: () => inkFromTokens(document.documentElement),
     anchor: () => anchorFromDom(canvas),
+    draw: () => draw(),
   })
 
   stage = mounted
@@ -110,9 +128,29 @@ export function mountStage(canvas: HTMLCanvasElement): () => void {
   }
 }
 
-/** Start a reaction for what just happened. Never awaited, never blocking. */
-export function fireReaction(outcome: Outcome): void {
-  stage?.fire(outcome)
+/**
+ * Start a reaction for what just happened. Never awaited, never blocking.
+ *
+ * Returns the tier actually drawn — after the downgrade walk and after the
+ * once-a-session budget — or `null` when nothing was. The caller needs it: how
+ * long the reaction has to live is a fact about what is on the canvas, and the
+ * only thing that knows that is the stage.
+ */
+export function fireReaction(outcome: Outcome): TierName | null {
+  const tier = stage?.fire(outcome) ?? null
+  // A dev-only read-back for `tools/bench-reactions.mjs`, which otherwise has
+  // to *infer* which tier it is measuring from the card count — and inferred it
+  // wrong, publishing a SEAT as evidence about the MECHANISM. Vite substitutes
+  // `false` here in a production build, so the branch and everything it reaches
+  // are eliminated: `rg __dwReaction dist/` finds nothing.
+  if (import.meta.env.DEV && tier !== null) {
+    ;(globalThis as { __dwReaction?: unknown }).__dwReaction = {
+      tier,
+      budgetMs: TIERS[tier].budgetMs,
+      firedAt: performance.now(),
+    }
+  }
+  return tier
 }
 
 /**

--- a/dynawalla/dynawalla-app/src/reactions/picker.ts
+++ b/dynawalla/dynawalla-app/src/reactions/picker.ts
@@ -1,0 +1,108 @@
+// Which effect gets drawn: energy-weighted, non-repeating, eligibility-gated.
+//
+// ## Weighted *against* energy, not for it
+//
+// The obvious reading of "energy-weighted" is that louder effects come up more
+// often. That is the opposite of what this product wants. The largest study to
+// date (N = 3,018) found both no juiciness and extreme juiciness reduced play
+// time, player experience, intrinsic motivation and performance against
+// medium/high; a 2024 decomposition found it was the *success-dependence* of
+// feedback that did the work, and raw amplification that hurt. So within a
+// tier, weight is inversely proportional to energy: the quiet effect is the
+// common one and the loud one is the exception. Feedback contingent, not loud.
+//
+// ## Non-repeating
+//
+// Never the same effect twice running in the same tier. A repeat reads as a
+// canned animation; alternation reads as a mechanism with more than one part.
+//
+// ## Eligibility, and the downgrade walk
+//
+// An effect needs things to be on screen — the answer row, the construction
+// band, the aperture that was just cut. When a tier has nothing eligible the
+// picker walks *down*, never up: a MECHANISM with no band to play in becomes an
+// ILLUMINATE, then an ENGAGE, then a SEAT, which is still an honest reaction to
+// a correct answer. It never walks up, so a missing anchor can never make a
+// response louder than the outcome earned.
+//
+// The MECHANISM budget lives here too: once a session, per EXPERIENCE_DESIGN.
+// Spending it is the picker's business rather than `chooseTier`'s, which keeps
+// the escalation rule stateless and readable.
+
+import { effectsIn, energy, type Effect, type Requirement } from "./effects.ts"
+import { TIERS, TIER_ORDER, type TierName } from "./tiers.ts"
+import type { Anchor } from "./surface.ts"
+
+export interface PickerState {
+  /** The last effect drawn in each tier, so it is not drawn twice running. */
+  readonly last: Readonly<Partial<Record<TierName, string>>>
+  /** Tiers whose once-a-session budget has been spent. */
+  readonly spent: readonly TierName[]
+}
+
+export const FRESH: PickerState = { last: {}, spent: [] }
+
+export interface Pick {
+  readonly effect: Effect
+  readonly tier: TierName
+  readonly state: PickerState
+}
+
+function has(anchor: Anchor, requirement: Requirement): boolean {
+  return anchor[requirement] !== null
+}
+
+function eligible(effect: Effect, anchor: Anchor, state: PickerState): boolean {
+  if (TIERS[effect.tier].oncePerSession && state.spent.includes(effect.tier)) return false
+  return effect.needs.every((requirement) => has(anchor, requirement))
+}
+
+/**
+ * Choose an effect for `tier`, or the loudest eligible one below it.
+ *
+ * `draw` is a number in [0, 1) — `Math.random` in the app, a fixed value in the
+ * tests. Passing it in rather than reaching for a generator keeps this a pure
+ * function, which is what lets the weighting be asserted rather than eyeballed.
+ */
+export function pick(tier: TierName, anchor: Anchor, state: PickerState, draw: number): Pick | null {
+  const from = TIER_ORDER.indexOf(tier)
+  if (from === -1) return null
+
+  for (let step = from; step < TIER_ORDER.length; step++) {
+    const candidate = TIER_ORDER[step]
+    if (candidate === undefined) continue
+    const chosen = choose(candidate, anchor, state, draw)
+    if (chosen === null) continue
+    return {
+      effect: chosen,
+      tier: candidate,
+      state: {
+        last: { ...state.last, [candidate]: chosen.id },
+        spent: TIERS[candidate].oncePerSession && !state.spent.includes(candidate)
+          ? [...state.spent, candidate]
+          : state.spent,
+      },
+    }
+  }
+  return null
+}
+
+function choose(tier: TierName, anchor: Anchor, state: PickerState, draw: number): Effect | null {
+  const pool = effectsIn(tier).filter((effect) => eligible(effect, anchor, state))
+  if (pool.length === 0) return null
+
+  // Drop the one drawn last, unless it is the only one left — an effect that
+  // can never repeat and has no sibling would mean no reaction at all.
+  const previous = state.last[tier]
+  const fresh = pool.length > 1 ? pool.filter((effect) => effect.id !== previous) : pool
+  if (fresh.length === 1) return fresh[0] ?? null
+
+  const weights = fresh.map((effect) => 1 / Math.max(energy(effect), 1))
+  const total = weights.reduce((sum, weight) => sum + weight, 0)
+  let cursor = Math.min(Math.max(draw, 0), 0.999999) * total
+  for (let i = 0; i < fresh.length; i++) {
+    cursor -= weights[i] ?? 0
+    if (cursor < 0) return fresh[i] ?? null
+  }
+  return fresh[fresh.length - 1] ?? null
+}

--- a/dynawalla/dynawalla-app/src/reactions/reactions.test.ts
+++ b/dynawalla/dynawalla-app/src/reactions/reactions.test.ts
@@ -1,0 +1,460 @@
+// The reaction layer holds four product rules, and this file is where each one
+// is either true or not:
+//
+//   MISSION    escalation never keys on run length or streak
+//   MISSION    being wrong is never more interesting than being right
+//   `Q-04`     an effect settles within 90 ms and never delays the input
+//   `Q-06`     reduced motion is a zero-travel, particle-free cross-fade
+//
+// Plus `Q-05`: nothing here may import from the work surface or the engine.
+//
+// The stage is driven with an injected clock and an injected frame scheduler,
+// and drawn into a recording context, so every one of these is asserted on
+// behaviour rather than on the shape of the code — except the two that are
+// genuinely claims about the code, which are asserted by reading it.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { EFFECTS, effectsIn, energy, type Effect } from "./effects.ts"
+import { FRESH, pick } from "./picker.ts"
+import { createStage, REDUCED_MS, SETTLE_MS, type Stage } from "./stage.ts"
+import { chooseTier, HARD, TIERS, TIER_ORDER, type Outcome, type TierName } from "./tiers.ts"
+import type { Anchor, Ctx, Ink } from "./surface.ts"
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+
+/** Source with comments stripped, so a scan reads code rather than prose. */
+const code = (text: string): string =>
+  text.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1")
+
+const sources = fs
+  .readdirSync(here)
+  .filter((name) => /\.(ts|tsx)$/.test(name) && !name.endsWith(".test.ts"))
+  .map((name) => ({ name, text: fs.readFileSync(path.join(here, name), "utf8") }))
+
+const INK: Ink = {
+  index: "index",
+  seat: "seat",
+  strike: "strike",
+  celestial: "celestial",
+  line: "line",
+}
+
+const FULL: Anchor = {
+  seat: { x: 10, y: 100, width: 120, height: 40 },
+  cartouche: { x: 0, y: 10, width: 300, height: 60 },
+  aperture: { x: 250, y: 20, width: 20, height: 20 },
+}
+
+const BARE: Anchor = { seat: FULL.seat, cartouche: null, aperture: null }
+
+/** A context that remembers every call, so a frame can be compared to a frame. */
+function recorder(): Ctx & { ops: string[]; arcs: number } {
+  const ops: string[] = []
+  const round = (n: number): string => String(Math.round(n * 100) / 100)
+  const self = {
+    ops,
+    arcs: 0,
+    fillStyle: "" as string | CanvasGradient | CanvasPattern,
+    strokeStyle: "" as string | CanvasGradient | CanvasPattern,
+    globalAlpha: 1,
+    lineWidth: 1,
+    lineCap: "butt" as CanvasLineCap,
+    save: () => ops.push("save"),
+    restore: () => ops.push("restore"),
+    beginPath: () => ops.push("beginPath"),
+    closePath: () => ops.push("closePath"),
+    moveTo: (x: number, y: number) => ops.push(`moveTo ${round(x)} ${round(y)}`),
+    lineTo: (x: number, y: number) => ops.push(`lineTo ${round(x)} ${round(y)}`),
+    arc: (x: number, y: number, r: number) => {
+      self.arcs += 1
+      ops.push(`arc ${round(x)} ${round(y)} ${round(r)}`)
+    },
+    rect: (x: number, y: number, w: number, h: number) =>
+      ops.push(`rect ${round(x)} ${round(y)} ${round(w)} ${round(h)}`),
+    fill: () => ops.push(`fill ${String(self.fillStyle)} a${round(self.globalAlpha)}`),
+    stroke: () => ops.push(`stroke ${String(self.strokeStyle)} a${round(self.globalAlpha)}`),
+    clearRect: () => ops.push("clear"),
+  }
+  return self as unknown as Ctx & { ops: string[]; arcs: number }
+}
+
+interface Harness {
+  stage: Stage
+  ctx: ReturnType<typeof recorder>
+  advance: (ms: number) => void
+  frames: number
+}
+
+function harness(options: { reduced?: boolean; anchor?: Anchor; draw?: number } = {}): Harness {
+  const ctx = recorder()
+  let clock = 0
+  let queued: (() => void) | null = null
+  const state: Harness = {
+    ctx,
+    frames: 0,
+    stage: createStage({
+      ctx,
+      size: () => ({ width: 400, height: 800 }),
+      now: () => clock,
+      schedule: (run) => {
+        queued = run
+        return 1
+      },
+      cancel: () => {
+        queued = null
+      },
+      reducedMotion: () => options.reduced === true,
+      ink: () => INK,
+      anchor: () => options.anchor ?? FULL,
+      draw: () => options.draw ?? 0.5,
+    }),
+    advance: (ms) => {
+      // One frame per 16 ms, the way a real rAF loop would deliver them.
+      for (let step = 0; step < Math.max(1, Math.round(ms / 16)); step++) {
+        clock += 16
+        const run = queued
+        queued = null
+        if (run !== null) {
+          state.frames += 1
+          run()
+        }
+      }
+    },
+  }
+  return state
+}
+
+const OUTCOME: Outcome = { correct: true, difficulty: 0, repaired: false, milestone: null }
+
+// ── Escalation ─────────────────────────────────────────────────────────────
+
+test("MISSION: the escalation rule has no run-length or streak input", () => {
+  // The claim is about the *signature*, so it is checked as one: no executable
+  // line anywhere in this directory names a run, a streak, a combo or a
+  // consecutive anything. Comments are stripped first — the prose has to be
+  // able to say what is banned, and the ban is on the code.
+  for (const { name, text } of sources) {
+    const hits = [...code(text).matchAll(/\b(streak|combo|runLength|run_length|consecutive)\b/gi)]
+      .map((match) => match[0])
+    assert.deepEqual(hits, [], `${name} names a run-length concept`)
+  }
+})
+
+test("MISSION: handing the rule a run length changes nothing", () => {
+  const smuggled = { ...OUTCOME, runLength: 99, streak: 40, comboCount: 12 } as Outcome
+  assert.equal(chooseTier(smuggled), chooseTier(OUTCOME))
+})
+
+test("escalation keys on difficulty and on repair", () => {
+  assert.equal(chooseTier({ ...OUTCOME, difficulty: 0.1 }), "seat")
+  assert.equal(chooseTier({ ...OUTCOME, difficulty: HARD }), "engage")
+  assert.equal(chooseTier({ ...OUTCOME, repaired: true }), "illuminate")
+  assert.equal(chooseTier({ ...OUTCOME, milestone: "star" }), "illuminate")
+  assert.equal(chooseTier({ ...OUTCOME, milestone: "rosette" }), "mechanism")
+})
+
+test("no wrong answer can reach any tier above SLIP, however it is dressed up", () => {
+  for (const difficulty of [0, 0.5, 1]) {
+    for (const repaired of [false, true]) {
+      for (const milestone of [null, "star", "rosette", "course", "screen"] as const) {
+        assert.equal(
+          chooseTier({ correct: false, difficulty, repaired, milestone }),
+          "slip",
+          "a wrong answer escalated",
+        )
+      }
+    }
+  }
+})
+
+// ── Energy ─────────────────────────────────────────────────────────────────
+
+test("MISSION: energy(SLIP) < energy(SEAT), in the strong form", () => {
+  const loudest = (tier: TierName): number => Math.max(...effectsIn(tier).map(energy))
+  const quietest = (tier: TierName): number => Math.min(...effectsIn(tier).map(energy))
+  assert.ok(
+    loudest("slip") < quietest("seat"),
+    `slip ${String(loudest("slip"))} !< seat ${String(quietest("seat"))}`,
+  )
+})
+
+test("the whole energy ladder is strictly ordered, quiet to loud", () => {
+  const ladder = [...TIER_ORDER].reverse()
+  for (let i = 0; i + 1 < ladder.length; i++) {
+    const lower = ladder[i]
+    const upper = ladder[i + 1]
+    if (lower === undefined || upper === undefined) continue
+    const loudest = Math.max(...effectsIn(lower).map(energy))
+    const quietest = Math.min(...effectsIn(upper).map(energy))
+    assert.ok(loudest < quietest, `${lower} ${String(loudest)} !< ${upper} ${String(quietest)}`)
+  }
+})
+
+test("every tier has an effect and every effect declares its energy factors", () => {
+  for (const tier of TIER_ORDER) assert.ok(effectsIn(tier).length >= 1, `${tier} has no effect`)
+  for (const effect of EFFECTS) {
+    assert.ok(effect.particles >= 0 && effect.peakGain > 0 && effect.elements > 0, effect.id)
+    assert.equal(new Set(EFFECTS.map((other) => other.id)).size, EFFECTS.length)
+  }
+})
+
+test("only MECHANISM is once a session, and it is the loudest thing here", () => {
+  const once = TIER_ORDER.filter((tier) => TIERS[tier].oncePerSession)
+  assert.deepEqual(once, ["mechanism"])
+})
+
+// ── The picker ─────────────────────────────────────────────────────────────
+
+test("the picker never draws the same effect twice running in a tier", () => {
+  let state = FRESH
+  const seen: string[] = []
+  for (let i = 0; i < 12; i++) {
+    const chosen = pick("seat", FULL, state, (i * 0.37) % 1)
+    assert.ok(chosen !== null)
+    state = chosen.state
+    seen.push(chosen.effect.id)
+  }
+  for (let i = 1; i < seen.length; i++) assert.notEqual(seen[i], seen[i - 1])
+})
+
+test("weighting is inverse to energy — the quiet effect is the common one", () => {
+  const tally = new Map<string, number>()
+  for (let i = 0; i < 400; i++) {
+    // A fresh picker each draw, so the no-repeat rule does not flatten the
+    // distribution the weighting is supposed to produce.
+    const chosen = pick("engage", FULL, FRESH, (i * 0.0025 + 0.0001) % 1)
+    assert.ok(chosen !== null)
+    tally.set(chosen.effect.id, (tally.get(chosen.effect.id) ?? 0) + 1)
+  }
+  const ranked = [...effectsIn("engage")].sort((a, b) => energy(a) - energy(b))
+  const quiet = ranked[0]
+  const loud = ranked[ranked.length - 1]
+  assert.ok(quiet !== undefined && loud !== undefined && quiet !== loud)
+  assert.ok(
+    (tally.get(quiet.id) ?? 0) > (tally.get(loud.id) ?? 0),
+    `quiet ${String(tally.get(quiet.id))} vs loud ${String(tally.get(loud.id))}`,
+  )
+})
+
+test("a missing anchor walks the tier DOWN, never up", () => {
+  const chosen = pick("mechanism", BARE, FRESH, 0.5)
+  assert.ok(chosen !== null)
+  assert.equal(chosen.tier, "seat", "with no band on screen there is nowhere to celebrate")
+  assert.ok(
+    TIERS[chosen.tier].level < TIERS.mechanism.level,
+    "the walk must never raise the tier",
+  )
+})
+
+test("the MECHANISM budget is once a session and spending it downgrades", () => {
+  const first = pick("mechanism", FULL, FRESH, 0.5)
+  assert.ok(first !== null)
+  assert.equal(first.tier, "mechanism")
+  const second = pick("mechanism", FULL, first.state, 0.5)
+  assert.ok(second !== null)
+  assert.notEqual(second.tier, "mechanism")
+  assert.ok(TIERS[second.tier].level < TIERS.mechanism.level)
+})
+
+// ── The stage: interruptibility ────────────────────────────────────────────
+
+test("Q-04: settleNow returns synchronously and the picture is gone in 90 ms", () => {
+  const h = harness()
+  h.stage.fire({ ...OUTCOME, milestone: "rosette" })
+  assert.equal(h.stage.running(), true)
+  h.advance(300)
+  assert.equal(h.stage.running(), true, "a tier-2/3 effect is still running at 300 ms")
+
+  const before = Date.now()
+  h.stage.settleNow()
+  assert.ok(Date.now() - before < 20, "settleNow did work on the caller's thread")
+
+  h.advance(SETTLE_MS + 16)
+  assert.equal(h.stage.running(), false, "still running past the settle window")
+  assert.ok(SETTLE_MS <= 90, `settle budget ${String(SETTLE_MS)} exceeds Q-04's 90 ms`)
+  assert.equal(h.ctx.ops[h.ctx.ops.length - 1], "clear", "the canvas was left dirty")
+})
+
+test("Q-04: a settling effect fades rather than snapping to nothing", () => {
+  const h = harness()
+  h.stage.fire({ ...OUTCOME, milestone: "rosette" })
+  h.advance(200)
+  h.stage.settleNow()
+  const alphas: number[] = []
+  for (let step = 0; step < 5; step++) {
+    h.ctx.ops.length = 0
+    h.advance(16)
+    for (const op of h.ctx.ops) {
+      const match = /a(\d*\.?\d+)$/.exec(op)
+      if (match?.[1] !== undefined) alphas.push(Number(match[1]))
+    }
+  }
+  assert.ok(alphas.length > 0, "nothing was drawn while settling")
+  assert.ok(Math.max(...alphas) > Math.min(...alphas), "the settle did not fade")
+})
+
+test("firing again while one is running replaces it and never stacks", () => {
+  const h = harness()
+  h.stage.fire(OUTCOME)
+  h.advance(50)
+  h.stage.fire({ ...OUTCOME, difficulty: 1 })
+  h.advance(50)
+  // One clear per frame means one effect per frame. Two stacked effects would
+  // put two draws between two clears.
+  const between = h.ctx.ops.join("|").split("clear").at(-2) ?? ""
+  assert.ok((between.match(/save/g) ?? []).length <= 1, "two effects drew in one frame")
+})
+
+test("an effect ends on its own inside its tier's budget", () => {
+  const h = harness()
+  const tier = h.stage.fire(OUTCOME)
+  assert.ok(tier !== null)
+  h.advance(TIERS[tier].budgetMs + 32)
+  assert.equal(h.stage.running(), false)
+})
+
+// ── The stage: reduced motion ──────────────────────────────────────────────
+
+test("Q-06: reduced motion draws the same frame throughout — zero travel", () => {
+  // The strongest form of "zero travel" available: two frames 96 ms apart, on
+  // every effect in the catalogue, must lay down byte-identical geometry.
+  // Alpha differs — it is cross-fading — so only coordinates are compared.
+  const geometry = (ops: string[]): string[] =>
+    ops.filter((op) => /^(moveTo|lineTo|arc|rect)/.test(op))
+
+  for (const effect of EFFECTS) {
+    const h = harness({ reduced: true })
+    h.stage.fire(outcomeFor(effect))
+    const frame = (): string[] => {
+      h.ctx.ops.length = 0
+      h.advance(16)
+      return geometry(h.ctx.ops)
+    }
+    const early = frame()
+    h.advance(80)
+    const late = frame()
+    if (early.length === 0 || late.length === 0) continue
+    assert.deepEqual(late, early, `${effect.id} moved under reduced motion`)
+  }
+})
+
+test("…and every effect does move when motion is allowed", () => {
+  // The other half. Without it, an effect that drew nothing at all would pass
+  // the zero-travel assertion above and look like a success.
+  const geometry = (ops: string[]): string[] =>
+    ops.filter((op) => /^(moveTo|lineTo|arc|rect)/.test(op))
+  const moved: string[] = []
+  for (const effect of EFFECTS) {
+    const h = harness()
+    h.stage.fire(outcomeFor(effect))
+    const frame = (): string[] => {
+      h.ctx.ops.length = 0
+      h.advance(16)
+      return geometry(h.ctx.ops)
+    }
+    const early = frame()
+    h.advance(80)
+    const late = frame()
+    if (early.length > 0 && late.length > 0 && JSON.stringify(early) !== JSON.stringify(late)) {
+      moved.push(effect.id)
+    }
+  }
+  assert.deepEqual([...moved].sort(), EFFECTS.map((effect) => effect.id).sort())
+})
+
+test("Q-06: reduced motion emits no particles, and normal motion does", () => {
+  const withMotes = harness()
+  withMotes.stage.fire({ ...OUTCOME, milestone: "rosette" })
+  withMotes.advance(400)
+  assert.ok(withMotes.ctx.arcs > 0, "no particles drawn with motion on")
+
+  const reduced = harness({ reduced: true })
+  reduced.stage.fire({ ...OUTCOME, milestone: "rosette" })
+  reduced.advance(REDUCED_MS)
+  assert.equal(reduced.ctx.arcs, 0, "particles drawn under reduced motion")
+})
+
+test("Q-06: the reduced branch is a cross-fade — alpha rises then falls", () => {
+  const h = harness({ reduced: true })
+  h.stage.fire({ ...OUTCOME, milestone: "rosette" })
+  const peaks: number[] = []
+  for (let step = 0; step < Math.round(REDUCED_MS / 16); step++) {
+    h.ctx.ops.length = 0
+    h.advance(16)
+    const alphas = h.ctx.ops
+      .map((op) => /a(\d*\.?\d+)$/.exec(op)?.[1])
+      .filter((value): value is string => value !== undefined)
+      .map(Number)
+    if (alphas.length > 0) peaks.push(Math.max(...alphas))
+  }
+  assert.ok(peaks.length >= 3, "too few frames to be a fade")
+  const top = Math.max(...peaks)
+  assert.ok((peaks[0] ?? 1) < top && (peaks[peaks.length - 1] ?? 1) < top, "not a cross-fade")
+})
+
+test("particles come from exactly one place, and every effect loses them", () => {
+  // "No particles under reduced motion" leaks the moment a second place emits
+  // them. `surface.ts` owns `motes`, and it is the only file that may read the
+  // mote count — so no effect is able to emit a particle of its own.
+  const readers = sources
+    .filter(({ name }) => name !== "surface.ts")
+    .filter(({ text }) => /\.motes\b/.test(code(text)))
+    .map(({ name }) => name)
+  assert.deepEqual(readers, [], "something outside surface.ts reads the mote count")
+
+  // And behaviourally, per effect: every one of them draws strictly fewer
+  // circles with motion off than with it on.
+  for (const effect of EFFECTS) {
+    const on = harness()
+    on.stage.fire(outcomeFor(effect))
+    on.advance(2000)
+    const off = harness({ reduced: true })
+    off.stage.fire(outcomeFor(effect))
+    off.advance(2000)
+    assert.ok(
+      off.ctx.arcs < on.ctx.arcs,
+      `${effect.id}: ${String(off.ctx.arcs)} circles reduced vs ${String(on.ctx.arcs)} normal`,
+    )
+  }
+})
+
+// ── Boundary ───────────────────────────────────────────────────────────────
+
+test("Q-05: the reaction layer imports nothing from the work surface or engine", () => {
+  const offenders: string[] = []
+  for (const { name, text } of sources) {
+    for (const [, specifier] of text.matchAll(/from\s+"([^"]+)"/g)) {
+      if (/(\.\.\/work\/|\.\.\/screens\/|engine|curriculum)/.test(specifier ?? "")) {
+        offenders.push(`${name} -> ${specifier ?? ""}`)
+      }
+    }
+  }
+  assert.deepEqual(offenders, [])
+})
+
+test("nothing here awaits a reaction", () => {
+  for (const { name, text } of sources) {
+    assert.equal(/\bawait\b|Promise</.test(text), false, `${name} awaits something`)
+  }
+})
+
+/** The cheapest outcome that reaches a given effect's tier. */
+function outcomeFor(effect: Effect): Outcome {
+  switch (effect.tier) {
+    case "slip":
+      return { ...OUTCOME, correct: false }
+    case "seat":
+      return OUTCOME
+    case "engage":
+      return { ...OUTCOME, difficulty: 1 }
+    case "illuminate":
+      return { ...OUTCOME, milestone: "star" }
+    case "mechanism":
+      return { ...OUTCOME, milestone: "rosette" }
+  }
+}

--- a/dynawalla/dynawalla-app/src/reactions/reactions.test.ts
+++ b/dynawalla/dynawalla-app/src/reactions/reactions.test.ts
@@ -23,7 +23,7 @@ import { EFFECTS, effectsIn, energy, type Effect } from "./effects.ts"
 import { FRESH, pick } from "./picker.ts"
 import { createStage, REDUCED_MS, SETTLE_MS, type Stage } from "./stage.ts"
 import { chooseTier, HARD, TIERS, TIER_ORDER, type Outcome, type TierName } from "./tiers.ts"
-import type { Anchor, Ctx, Ink } from "./surface.ts"
+import { easeOut, type Anchor, type Ctx, type Frame, type Ink } from "./surface.ts"
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 
@@ -78,9 +78,45 @@ function recorder(): Ctx & { ops: string[]; arcs: number } {
       ops.push(`rect ${round(x)} ${round(y)} ${round(w)} ${round(h)}`),
     fill: () => ops.push(`fill ${String(self.fillStyle)} a${round(self.globalAlpha)}`),
     stroke: () => ops.push(`stroke ${String(self.strokeStyle)} a${round(self.globalAlpha)}`),
+    clip: () => ops.push("clip"),
     clearRect: () => ops.push("clear"),
   }
   return self as unknown as Ctx & { ops: string[]; arcs: number }
+}
+
+/**
+ * The `draw` value that makes the picker choose exactly this effect.
+ *
+ * The harness's default `draw: 0.5` is one number, and `pick` is deterministic,
+ * so every "for every effect in the catalogue" loop that fired the stage was
+ * really exercising **one effect per tier** — five of ten, silently. `chisel`,
+ * `detent`, `tessera` and `rosetteLight` were drawn by no test in the repo, and
+ * `detent` is the effect EXPERIENCE_DESIGN names as the one the child sees
+ * hundreds of times. Scanning for the draw that selects a given effect, and
+ * asserting that it does, is what turns those loops into coverage.
+ */
+function drawFor(effect: Effect): number {
+  for (let step = 0; step < 1000; step++) {
+    const value = step / 1000
+    if (pick(effect.tier, FULL, FRESH, value)?.effect.id === effect.id) return value
+  }
+  throw new Error(`no draw value reaches ${effect.id} — it is unreachable in its tier`)
+}
+
+/** A frame as the stage would build it, so an effect can be drawn directly. */
+function frameFor(
+  effect: Effect,
+  options: { reduced: boolean; raw: number; anchor?: Anchor },
+): Frame {
+  return {
+    t: options.reduced ? 1 : easeOut(options.raw),
+    alpha: 1,
+    travel: options.reduced ? 0 : 1,
+    motes: options.reduced ? 0 : effect.particles,
+    gain: effect.peakGain,
+    anchor: options.anchor ?? FULL,
+    ink: INK,
+  }
 }
 
 interface Harness {
@@ -133,16 +169,40 @@ const OUTCOME: Outcome = { correct: true, difficulty: 0, repaired: false, milest
 
 // ── Escalation ─────────────────────────────────────────────────────────────
 
-test("MISSION: the escalation rule has no run-length or streak input", () => {
-  // The claim is about the *signature*, so it is checked as one: no executable
-  // line anywhere in this directory names a run, a streak, a combo or a
-  // consecutive anything. Comments are stripped first — the prose has to be
-  // able to say what is banned, and the ban is on the code.
+test("MISSION: no source in this directory names a run-length concept", () => {
+  // A spelling check, and only a spelling check. It is here because the
+  // registry this layer replaces escalated on `comboCount` by name, so a
+  // reintroduction under the same name should be loud — but a field called
+  // `chamberProgress` that counted consecutive correct answers would sail
+  // through it, which is why the *rule* is asserted in the next test rather
+  // than here. Comments are stripped first: the prose has to be able to say
+  // what is banned, and the ban is on the code.
   for (const { name, text } of sources) {
     const hits = [...code(text).matchAll(/\b(streak|combo|runLength|run_length|consecutive)\b/gi)]
       .map((match) => match[0])
     assert.deepEqual(hits, [], `${name} names a run-length concept`)
   }
+})
+
+test("MISSION: escalation may key on cumulative construction, never on consecutive-correct", () => {
+  // The rule as ADR-0009 sanctions it, stated so it can fail. `milestone` is
+  // derived from the *lifetime* count of apertures cut, which does escalate —
+  // every twentieth correct answer is a MECHANISM. What makes that not a streak
+  // is that a wrong answer in between does not reset it and does not change
+  // what the twentieth is worth. A run length is a count that a miss destroys;
+  // this one a miss cannot touch.
+  const before = chooseTier({ ...OUTCOME, milestone: "rosette" })
+  chooseTier({ correct: false, difficulty: 1, repaired: false, milestone: null })
+  const after = chooseTier({ ...OUTCOME, milestone: "rosette" })
+  assert.equal(after, before, "an interleaved wrong answer changed what a milestone is worth")
+  assert.equal(before, "mechanism")
+
+  // …and it could not, because the function is stateless: the tier for an
+  // outcome is a function of that outcome and nothing else.
+  const history = [true, false, false, true, true].map(() =>
+    chooseTier({ ...OUTCOME, milestone: "star" }),
+  )
+  assert.deepEqual(new Set(history).size, 1)
 })
 
 test("MISSION: handing the rule a run length changes nothing", () => {
@@ -242,13 +302,30 @@ test("weighting is inverse to energy — the quiet effect is the common one", ()
 })
 
 test("a missing anchor walks the tier DOWN, never up", () => {
+  // With only the answer row on screen the MECHANISM has nowhere to play, so it
+  // comes down to the loudest tier that has a seat-anchored effect in it. The
+  // number that matters is the direction: the walk may never raise the tier,
+  // because a missing anchor must not be able to make a response louder than
+  // the outcome earned.
   const chosen = pick("mechanism", BARE, FRESH, 0.5)
   assert.ok(chosen !== null)
-  assert.equal(chosen.tier, "seat", "with no band on screen there is nowhere to celebrate")
   assert.ok(
     TIERS[chosen.tier].level < TIERS.mechanism.level,
     "the walk must never raise the tier",
   )
+  assert.ok(
+    chosen.effect.needs.every((requirement) => BARE[requirement] !== null),
+    "the walk landed on an effect whose anchors are not on screen",
+  )
+  // Every tier below is walked in order, so it lands on the highest one that
+  // has somewhere to draw rather than falling all the way to SEAT.
+  const louder = TIER_ORDER.slice(0, TIER_ORDER.indexOf(chosen.tier))
+  for (const tier of louder) {
+    assert.ok(
+      effectsIn(tier).every((effect) => effect.needs.some((need) => BARE[need] === null)),
+      `${tier} had an eligible effect and the walk passed it`,
+    )
+  }
 })
 
 test("the MECHANISM budget is once a session and spending it downgrades", () => {
@@ -310,6 +387,32 @@ test("firing again while one is running replaces it and never stacks", () => {
   assert.ok((between.match(/save/g) ?? []).length <= 1, "two effects drew in one frame")
 })
 
+test("an effect anchored on the band is clipped to it", () => {
+  // The canvas is `fixed inset-0` over the whole app, so nothing stopped a
+  // 1.7-radius arc struck around the 44 px rosette in a 72 px band from
+  // overrunning the band's top edge and drawing across the header strapwork.
+  // Every cartouche- or aperture-anchored effect declares the band as its clip;
+  // the seat-anchored ones declare none, because the answer row is where they
+  // are supposed to be.
+  for (const effect of EFFECTS) {
+    const wantsBand = effect.needs.some((need) => need === "cartouche" || need === "aperture")
+    assert.equal(effect.clip, wantsBand ? "cartouche" : null, `${effect.id} clips to ${String(effect.clip)}`)
+  }
+
+  // And the stage applies it: the clip is set before the effect draws, to the
+  // anchor's own rectangle, once per frame.
+  const h = harness({ draw: drawFor(EFFECTS.find((e) => e.id === "closure") ?? EFFECTS[0]!) })
+  h.stage.fire({ ...OUTCOME, milestone: "rosette" })
+  const ops = h.ctx.ops.join("|")
+  const band = FULL.cartouche
+  assert.ok(band !== null)
+  assert.ok(
+    ops.includes(`rect ${String(band.x)} ${String(band.y)} ${String(band.width)} ${String(band.height)}|clip`),
+    "the stage did not clip to the band before drawing",
+  )
+  assert.ok(ops.indexOf("clip") < ops.indexOf("stroke"), "the clip was set after the drawing")
+})
+
 test("an effect ends on its own inside its tier's budget", () => {
   const h = harness()
   const tier = h.stage.fire(OUTCOME)
@@ -320,16 +423,30 @@ test("an effect ends on its own inside its tier's budget", () => {
 
 // ── The stage: reduced motion ──────────────────────────────────────────────
 
+test("every effect in the catalogue is reachable, and these loops reach it", () => {
+  // The precondition the three gates below stand on. If an effect cannot be
+  // selected by any draw value it is dead code in the product; if `drawFor`
+  // cannot find the value, the loops are back to testing one effect per tier.
+  const reached = EFFECTS.map((effect) => pick(effect.tier, FULL, FRESH, drawFor(effect))?.effect.id)
+  assert.deepEqual(reached, EFFECTS.map((effect) => effect.id))
+})
+
 test("Q-06: reduced motion draws the same frame throughout — zero travel", () => {
   // The strongest form of "zero travel" available: two frames 96 ms apart, on
   // every effect in the catalogue, must lay down byte-identical geometry.
   // Alpha differs — it is cross-fading — so only coordinates are compared.
+  //
+  // Driven through the real stage, one effect at a time, with the draw value
+  // that selects it — and the selection is asserted, so this cannot quietly
+  // become "the same five effects, ten times".
   const geometry = (ops: string[]): string[] =>
     ops.filter((op) => /^(moveTo|lineTo|arc|rect)/.test(op))
 
   for (const effect of EFFECTS) {
-    const h = harness({ reduced: true })
-    h.stage.fire(outcomeFor(effect))
+    const draw = drawFor(effect)
+    assert.equal(pick(effect.tier, FULL, FRESH, draw)?.effect.id, effect.id)
+    const h = harness({ reduced: true, draw })
+    assert.equal(h.stage.fire(outcomeFor(effect)), effect.tier, `${effect.id} did not fire its tier`)
     const frame = (): string[] => {
       h.ctx.ops.length = 0
       h.advance(16)
@@ -338,20 +455,24 @@ test("Q-06: reduced motion draws the same frame throughout — zero travel", () 
     const early = frame()
     h.advance(80)
     const late = frame()
-    if (early.length === 0 || late.length === 0) continue
+    // No `continue` on an empty frame. An effect that drew nothing used to skip
+    // both halves of this gate and be counted as a pass.
+    assert.ok(early.length > 0, `${effect.id} drew nothing at all under reduced motion`)
     assert.deepEqual(late, early, `${effect.id} moved under reduced motion`)
   }
 })
 
 test("…and every effect does move when motion is allowed", () => {
-  // The other half. Without it, an effect that drew nothing at all would pass
-  // the zero-travel assertion above and look like a success.
+  // The other half, asserted per effect rather than collected into a list. The
+  // first cut pushed `effect.id` — the loop variable — into the list and
+  // compared the list to the catalogue, so the assertion held as long as
+  // *something* moved on each iteration, whichever effect it was.
   const geometry = (ops: string[]): string[] =>
     ops.filter((op) => /^(moveTo|lineTo|arc|rect)/.test(op))
-  const moved: string[] = []
   for (const effect of EFFECTS) {
-    const h = harness()
-    h.stage.fire(outcomeFor(effect))
+    const draw = drawFor(effect)
+    const h = harness({ draw })
+    assert.equal(h.stage.fire(outcomeFor(effect)), effect.tier)
     const frame = (): string[] => {
       h.ctx.ops.length = 0
       h.advance(16)
@@ -360,14 +481,34 @@ test("…and every effect does move when motion is allowed", () => {
     const early = frame()
     h.advance(80)
     const late = frame()
-    if (early.length > 0 && late.length > 0 && JSON.stringify(early) !== JSON.stringify(late)) {
-      moved.push(effect.id)
-    }
+    assert.ok(early.length > 0 && late.length > 0, `${effect.id} drew nothing with motion on`)
+    assert.notDeepEqual(late, early, `${effect.id} does not move with motion on`)
   }
-  assert.deepEqual([...moved].sort(), EFFECTS.map((effect) => effect.id).sort())
 })
 
-test("Q-06: reduced motion emits no particles, and normal motion does", () => {
+test("Q-06: reduced motion emits no particles, and normal motion emits exactly its own", () => {
+  // Drawn directly rather than through the stage, because this is a claim about
+  // each effect's own geometry and the arithmetic has to be exact: one mote is
+  // one `arc`, so the difference between the two frames is the mote count and
+  // nothing else. Any non-mote arc an effect strikes appears in both and
+  // cancels.
+  //
+  // `t` is 0.5, not 1: `motes` skips a mote whose radius has shrunk to zero, so
+  // at the end of the reaction there are none to count in either branch and the
+  // gate would pass on every effect for the wrong reason.
+  for (const effect of EFFECTS) {
+    const on = recorder()
+    effect.draw(on, frameFor(effect, { reduced: false, raw: 0.5 }))
+    const off = recorder()
+    effect.draw(off, frameFor(effect, { reduced: true, raw: 0.5 }))
+    assert.equal(
+      on.arcs - off.arcs,
+      effect.particles,
+      `${effect.id} drew ${String(on.arcs - off.arcs)} particles, not ${String(effect.particles)}`,
+    )
+  }
+
+  // And end to end through the stage, on the loudest tier there is.
   const withMotes = harness()
   withMotes.stage.fire({ ...OUTCOME, milestone: "rosette" })
   withMotes.advance(400)
@@ -397,7 +538,7 @@ test("Q-06: the reduced branch is a cross-fade — alpha rises then falls", () =
   assert.ok((peaks[0] ?? 1) < top && (peaks[peaks.length - 1] ?? 1) < top, "not a cross-fade")
 })
 
-test("particles come from exactly one place, and every effect loses them", () => {
+test("particles come from exactly one place", () => {
   // "No particles under reduced motion" leaks the moment a second place emits
   // them. `surface.ts` owns `motes`, and it is the only file that may read the
   // mote count — so no effect is able to emit a particle of its own.
@@ -407,20 +548,42 @@ test("particles come from exactly one place, and every effect loses them", () =>
     .map(({ name }) => name)
   assert.deepEqual(readers, [], "something outside surface.ts reads the mote count")
 
-  // And behaviourally, per effect: every one of them draws strictly fewer
-  // circles with motion off than with it on.
+  // …and every effect that declares particles actually throws them through it,
+  // so the declaration and the drawing cannot drift.
   for (const effect of EFFECTS) {
-    const on = harness()
-    on.stage.fire(outcomeFor(effect))
-    on.advance(2000)
-    const off = harness({ reduced: true })
-    off.stage.fire(outcomeFor(effect))
-    off.advance(2000)
-    assert.ok(
-      off.ctx.arcs < on.ctx.arcs,
-      `${effect.id}: ${String(off.ctx.arcs)} circles reduced vs ${String(on.ctx.arcs)} normal`,
-    )
+    const drawn = recorder()
+    effect.draw(drawn, frameFor(effect, { reduced: false, raw: 0.5 }))
+    if (effect.particles > 0) assert.ok(drawn.arcs > 0, `${effect.id} declares motes and throws none`)
   }
+})
+
+test("EXPERIENCE_DESIGN: nothing below ENGAGE throws a particle", () => {
+  // The SEAT row of EXPERIENCE_DESIGN's core-loop table: "One detent click, one
+  // gear tooth, a `light` haptic, **no particles**". Both SEAT effects shipped
+  // with three each. SLIP has none either, because SLIP has to be quieter than
+  // SEAT and a chip of stone coming off is more animated than a pawl dropping
+  // into a tooth — the "catapult falling short" case the doc names.
+  for (const tier of ["slip", "seat"] as const) {
+    for (const effect of effectsIn(tier)) {
+      assert.equal(effect.particles, 0, `${effect.id} (${tier}) throws ${String(effect.particles)}`)
+    }
+  }
+  for (const tier of ["engage", "illuminate", "mechanism"] as const) {
+    for (const effect of effectsIn(tier)) {
+      assert.ok(effect.particles > 0, `${effect.id} (${tier}) throws nothing`)
+    }
+  }
+})
+
+test("a particle-free effect still has energy — the formula is not degenerate", () => {
+  // The first cut multiplied by `particles`, so `particles: 0` scored zero
+  // however loud the thing was, and the SLIP<SEAT ladder could be satisfied by
+  // *adding* a particle rather than by being quieter. The term is additive.
+  for (const effect of EFFECTS) {
+    assert.ok(energy(effect) > 0, `${effect.id} has zero energy`)
+  }
+  const quietest = EFFECTS.reduce((a, b) => (energy(a) <= energy(b) ? a : b))
+  assert.equal(quietest.particles, 0, "the quietest effect in the catalogue is not the particle-free one")
 })
 
 // ── Boundary ───────────────────────────────────────────────────────────────

--- a/dynawalla/dynawalla-app/src/reactions/stage.ts
+++ b/dynawalla/dynawalla-app/src/reactions/stage.ts
@@ -10,9 +10,19 @@
 //
 // `settleNow()` is called synchronously by the input handler **before any event
 // is processed** — not after, and not from an effect. It returns in
-// microseconds and the picture is gone within `SETTLE_MS`, which is 80 against
-// the 90 ms `Q-04` allows. A child who answers fast never waits on an
-// animation, and the input is neither dropped nor delayed to make that true.
+// microseconds and the picture is gone within `SETTLE_MS`.
+//
+// That budget is 64 ms, not the 80 it shipped at, and the difference is what a
+// browser measurement costs. `Q-04` allows 90 ms from the interrupting
+// keypress to an empty canvas, and the only honest way to observe "empty" is
+// to sample the pixels on a frame callback — which adds up to one whole frame
+// of quantisation on top of the settle. At 80 ms `bench-reactions.mjs` read
+// 87.7 ms and 89.6 ms against a 90 ms limit: passing, and one slow frame from
+// not. 64 ms is four frames of cross-fade and leaves the measured figure a
+// frame of headroom.
+//
+// A child who answers fast never waits on an animation, and the input is
+// neither dropped nor delayed to make that true.
 //
 // ## Reduced motion
 //
@@ -34,7 +44,7 @@ import { easeOut, type Anchor, type Ctx, type Frame, type Ink } from "./surface.
 import type { Effect } from "./effects.ts"
 
 /** How long a settling reaction takes to disappear. `Q-04` allows 90. */
-export const SETTLE_MS = 80
+export const SETTLE_MS = 64
 
 /** The reduced-motion cross-fade, in and out. */
 export const REDUCED_MS = 200
@@ -133,6 +143,16 @@ export function createStage(deps: StageDeps): Stage {
       ink: deps.ink(),
     }
     deps.ctx.save()
+    // The canvas covers the whole app, so an effect anchored on a 44 px rosette
+    // inside a 72 px band drew arcs across the header above it. Clipping to the
+    // anchor the effect declares keeps a reaction inside the thing it is
+    // reacting on, without changing a line of its geometry.
+    const region = live.effect.clip === null ? null : live.anchor[live.effect.clip]
+    if (region !== null) {
+      deps.ctx.beginPath()
+      deps.ctx.rect(region.x, region.y, region.width, region.height)
+      deps.ctx.clip()
+    }
     live.effect.draw(deps.ctx, frame)
     deps.ctx.restore()
     arm()

--- a/dynawalla/dynawalla-app/src/reactions/stage.ts
+++ b/dynawalla/dynawalla-app/src/reactions/stage.ts
@@ -1,0 +1,184 @@
+// The reaction stage: one canvas, one effect at a time, nothing to wait for.
+//
+// ## The law this file exists to keep
+//
+// EXPERIENCE_DESIGN: *nothing awaits a reaction*. There is no promise here, no
+// completion callback, and no way for a caller to find out when an effect
+// finished, because there is no correct thing to do with that information.
+// `fire` starts something and returns; `settleNow` stops it and returns. The
+// loop's next card presents concurrently with the reaction tail.
+//
+// `settleNow()` is called synchronously by the input handler **before any event
+// is processed** — not after, and not from an effect. It returns in
+// microseconds and the picture is gone within `SETTLE_MS`, which is 80 against
+// the 90 ms `Q-04` allows. A child who answers fast never waits on an
+// animation, and the input is neither dropped nor delayed to make that true.
+//
+// ## Reduced motion
+//
+// A branch, not a degradation. `t` is pinned to 1 so every effect is drawn at
+// its final state, `travel` is 0 so nothing oscillates, `motes` is 0 so nothing
+// particulates, and `alpha` cross-fades in and out over `REDUCED_MS` = 200. One
+// code path, two numbers — there is no second renderer to fall behind.
+//
+// ## Boundary
+//
+// Nothing here imports from `src/work/` or from the engine (`Q-05`). The stage
+// is told an `Outcome`; it never asks what the problem was, and it could not
+// find out. Anchors arrive as rectangles, resolved from the DOM by whoever
+// mounts the stage.
+
+import { pick, FRESH, type PickerState } from "./picker.ts"
+import { chooseTier, type Outcome, type TierName, TIERS } from "./tiers.ts"
+import { easeOut, type Anchor, type Ctx, type Frame, type Ink } from "./surface.ts"
+import type { Effect } from "./effects.ts"
+
+/** How long a settling reaction takes to disappear. `Q-04` allows 90. */
+export const SETTLE_MS = 80
+
+/** The reduced-motion cross-fade, in and out. */
+export const REDUCED_MS = 200
+
+export interface StageDeps {
+  readonly ctx: Ctx
+  /** Canvas size in CSS pixels. Read every frame; cheap, and never stale. */
+  readonly size: () => { readonly width: number; readonly height: number }
+  readonly now: () => number
+  readonly schedule: (run: () => void) => number
+  readonly cancel: (handle: number) => void
+  readonly reducedMotion: () => boolean
+  readonly ink: () => Ink
+  readonly anchor: () => Anchor
+  /** Injected for the tests; `Math.random` in the app. */
+  readonly draw?: () => number
+}
+
+export interface Stage {
+  /** Start a reaction. Returns the tier actually drawn, or `null`. */
+  fire: (outcome: Outcome) => TierName | null
+  /** Stop whatever is running. Synchronous, and gone within `SETTLE_MS`. */
+  settleNow: () => void
+  /** Advance one frame. The scheduler calls it; tests call it directly. */
+  tick: () => void
+  readonly running: () => boolean
+  /** Drop the once-a-session budgets. Called when a session begins. */
+  reset: () => void
+  dispose: () => void
+}
+
+interface Live {
+  readonly effect: Effect
+  readonly budgetMs: number
+  readonly startedAt: number
+  readonly anchor: Anchor
+  settlingAt: number | null
+}
+
+export function createStage(deps: StageDeps): Stage {
+  let picker: PickerState = FRESH
+  let live: Live | null = null
+  let handle: number | null = null
+  let disposed = false
+
+  const clear = (): void => {
+    const { width, height } = deps.size()
+    deps.ctx.clearRect(0, 0, width, height)
+  }
+
+  const stop = (): void => {
+    if (handle !== null) deps.cancel(handle)
+    handle = null
+    live = null
+    clear()
+  }
+
+  const arm = (): void => {
+    if (handle !== null || disposed) return
+    handle = deps.schedule(() => {
+      handle = null
+      tick()
+    })
+  }
+
+  const tick = (): void => {
+    if (live === null || disposed) return
+    const reduced = deps.reducedMotion()
+    const elapsed = deps.now() - live.startedAt
+    const span = reduced ? REDUCED_MS : live.budgetMs
+    const raw = span <= 0 ? 1 : Math.min(elapsed / span, 1)
+
+    let alpha = reduced ? Math.sin(Math.PI * raw) : 1 - raw ** 2
+    if (live.settlingAt !== null) {
+      const settled = (deps.now() - live.settlingAt) / SETTLE_MS
+      if (settled >= 1) {
+        stop()
+        return
+      }
+      alpha *= 1 - settled
+    }
+
+    if (raw >= 1 && live.settlingAt === null) {
+      stop()
+      return
+    }
+
+    clear()
+    const frame: Frame = {
+      t: reduced ? 1 : easeOut(raw),
+      alpha: Math.max(alpha, 0),
+      travel: reduced ? 0 : 1,
+      motes: reduced ? 0 : live.effect.particles,
+      gain: live.effect.peakGain,
+      anchor: live.anchor,
+      ink: deps.ink(),
+    }
+    deps.ctx.save()
+    live.effect.draw(deps.ctx, frame)
+    deps.ctx.restore()
+    arm()
+  }
+
+  return {
+    fire: (outcome) => {
+      if (disposed) return null
+      const anchor = deps.anchor()
+      const chosen = pick(chooseTier(outcome), anchor, picker, (deps.draw ?? Math.random)())
+      if (chosen === null) {
+        stop()
+        return null
+      }
+      picker = chosen.state
+      live = {
+        effect: chosen.effect,
+        budgetMs: TIERS[chosen.tier].budgetMs,
+        startedAt: deps.now(),
+        anchor,
+        settlingAt: null,
+      }
+      // Draw the first frame now rather than next tick. The reaction is fired
+      // from a frame callback that has already run after the verdict painted,
+      // so waiting for another one puts the acknowledgement a whole frame
+      // behind the thing it acknowledges.
+      tick()
+      return chosen.tier
+    },
+
+    settleNow: () => {
+      if (live === null || live.settlingAt !== null) return
+      live.settlingAt = deps.now()
+      arm()
+    },
+
+    tick,
+    running: () => live !== null,
+    reset: () => {
+      picker = FRESH
+    },
+    dispose: () => {
+      disposed = true
+      if (handle !== null) deps.cancel(handle)
+      handle = null
+      live = null
+    },
+  }
+}

--- a/dynawalla/dynawalla-app/src/reactions/surface.ts
+++ b/dynawalla/dynawalla-app/src/reactions/surface.ts
@@ -1,0 +1,181 @@
+// What an effect is allowed to draw with.
+//
+// Three deliberate narrowings, each of which is a rule somewhere else in the
+// program made structural here:
+//
+//   1. **No material names.** The palette arrives as `Ink`, resolved from the
+//      semantic tokens by whoever mounts the stage. `tokens.css` says nothing
+//      outside its semantic block may name a material, and a canvas with a
+//      brass literal in it would be a second, invisible theme that never
+//      re-cuts in dark. `tokens.test.ts` fails the build over one.
+//   2. **No allocation on the answer path.** The mote pool is a `Float32Array`
+//      filled once at module load. An effect asks for mote `i` and gets four
+//      numbers out of it; nothing is constructed per frame, per particle or per
+//      reaction.
+//   3. **Reduced motion is two numbers, not a second implementation.** The
+//      stage pins `t` to 1, sets `travel` to 0 and `motes` to 0, and cross-fades
+//      `alpha` over 200 ms. Every effect is then at its final state, with no
+//      oscillation and no particles — `Q-06`'s "zero-travel cross-fade with no
+//      particles", reached without a parallel code path that can rot.
+//
+// `Ctx` is the subset of the 2D context the effects actually use. It is a
+// `Pick`, so it cannot drift from the real thing, and it is small enough that a
+// test can implement it in twenty lines and record every call.
+
+export interface Rect {
+  readonly x: number
+  readonly y: number
+  readonly width: number
+  readonly height: number
+}
+
+/**
+ * Where the world's parts are on screen right now, in canvas pixels.
+ *
+ * Resolved from the DOM at fire time, after the verdict has painted. Any of
+ * them may be `null` — the surface is not obliged to have a construction band
+ * on it — and an effect that needs one it did not get is simply not eligible.
+ */
+export interface Anchor {
+  /** The answer row: where the child's answer seats. */
+  readonly seat: Rect | null
+  /** The construction band. */
+  readonly cartouche: Rect | null
+  /** The aperture cut by this very answer. */
+  readonly aperture: Rect | null
+}
+
+/** The semantic roles the canvas paints in, resolved to real colours. */
+export interface Ink {
+  readonly index: string
+  readonly seat: string
+  readonly strike: string
+  readonly celestial: string
+  readonly line: string
+}
+
+export interface Frame {
+  /** Eased progress, 0→1. Pinned to 1 under reduced motion. */
+  readonly t: number
+  /** Global alpha for everything this effect draws. */
+  readonly alpha: number
+  /** 1 normally, 0 under reduced motion. Multiplies oscillation only. */
+  readonly travel: number
+  /** Motes this effect may emit. 0 under reduced motion. */
+  readonly motes: number
+  /** The effect's peak output amplitude, 0…1. */
+  readonly gain: number
+  readonly anchor: Anchor
+  readonly ink: Ink
+}
+
+export type Ctx = Pick<
+  CanvasRenderingContext2D,
+  | "save"
+  | "restore"
+  | "beginPath"
+  | "closePath"
+  | "moveTo"
+  | "lineTo"
+  | "arc"
+  | "rect"
+  | "fill"
+  | "stroke"
+  | "clearRect"
+  | "fillStyle"
+  | "strokeStyle"
+  | "globalAlpha"
+  | "lineWidth"
+  | "lineCap"
+>
+
+/** The most motes any one effect may have in flight. Sizes the pool. */
+export const MAX_MOTES = 24
+
+/**
+ * Four deterministic numbers per mote: two for the launch direction, one for
+ * the speed, one for the phase. Filled once, read forever, never written.
+ *
+ * Deterministic rather than random because the committed screenshot set has to
+ * be comparable frame for frame (`Q-06`, and the M6 seed set), and because a
+ * pool that is refilled is a pool that allocates.
+ */
+const POOL = new Float32Array(MAX_MOTES * 4)
+for (let i = 0; i < MAX_MOTES; i++) {
+  // A cheap integer hash, spread over four channels. Any fixed sequence would
+  // do; this one is stable across platforms because it is integer arithmetic.
+  const h = (i * 2654435761) >>> 0
+  POOL[i * 4] = ((h & 0xff) / 255) * 2 - 1
+  POOL[i * 4 + 1] = (((h >>> 8) & 0xff) / 255) * 2 - 1
+  POOL[i * 4 + 2] = 0.4 + ((h >>> 16) & 0xff) / 425
+  POOL[i * 4 + 3] = ((h >>> 24) & 0xff) / 255
+}
+
+const pooled = (index: number, channel: number): number => POOL[(index % MAX_MOTES) * 4 + channel] ?? 0
+
+export const easeOut = (t: number): number => 1 - (1 - t) ** 3
+
+/**
+ * A band of light crossing a rectangle.
+ *
+ * The one place the reduced-motion branch is more than a zero: a sweep whose
+ * final state is "gone past the right edge" would draw nothing at all when `t`
+ * is pinned, so with travel off it becomes a wash over the whole rectangle
+ * instead. Same information, no movement.
+ */
+export function sweep(frame: Frame, box: Rect): { x: number; width: number } {
+  if (frame.travel === 0) return { x: box.x, width: box.width }
+  const width = box.width * 0.34
+  return { x: box.x - width + (box.width + width) * frame.t, width }
+}
+
+/**
+ * Motes: small chips of light or stone, thrown from a point and falling back.
+ *
+ * The **only** place particles are drawn. `reactions.test.ts` scans the effect
+ * catalogue for a second one, because "no particles under reduced motion" is a
+ * promise that is easy to make and easy to leak.
+ */
+export function motes(
+  ctx: Ctx,
+  frame: Frame,
+  origin: { x: number; y: number },
+  spread: number,
+  colour: string,
+): void {
+  if (frame.motes <= 0) return
+  ctx.fillStyle = colour
+  for (let i = 0; i < frame.motes; i++) {
+    const rise = frame.t * pooled(i, 2)
+    const x = origin.x + pooled(i, 0) * spread * rise
+    // Thrown up, then falling: the parabola is what makes it stone rather than
+    // confetti, which drifts.
+    const y = origin.y + pooled(i, 1) * spread * rise + spread * 1.6 * rise * rise
+    const radius = (1 - frame.t) * (0.8 + pooled(i, 3) * 1.4)
+    if (radius <= 0) continue
+    ctx.globalAlpha = frame.alpha * frame.gain * (1 - frame.t)
+    ctx.beginPath()
+    ctx.arc(x, y, radius, 0, Math.PI * 2)
+    ctx.fill()
+  }
+  ctx.globalAlpha = frame.alpha
+}
+
+export function line(
+  ctx: Ctx,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  colour: string,
+  width: number,
+): void {
+  ctx.strokeStyle = colour
+  ctx.lineWidth = width
+  ctx.beginPath()
+  ctx.moveTo(from.x, from.y)
+  ctx.lineTo(to.x, to.y)
+  ctx.stroke()
+}
+
+export function centre(box: Rect): { x: number; y: number } {
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+}

--- a/dynawalla/dynawalla-app/src/reactions/surface.ts
+++ b/dynawalla/dynawalla-app/src/reactions/surface.ts
@@ -81,6 +81,7 @@ export type Ctx = Pick<
   | "rect"
   | "fill"
   | "stroke"
+  | "clip"
   | "clearRect"
   | "fillStyle"
   | "strokeStyle"

--- a/dynawalla/dynawalla-app/src/reactions/tiers.ts
+++ b/dynawalla/dynawalla-app/src/reactions/tiers.ts
@@ -1,0 +1,101 @@
+// The reaction vocabulary: five tiers, and the rule that decides which one.
+//
+// The budgets are EXPERIENCE_DESIGN's, unchanged:
+//
+//   −1 SLIP        260 ms
+//    0 SEAT        200 ms
+//    1 ENGAGE      450 ms
+//    2 ILLUMINATE  900 ms
+//    3 MECHANISM  1800 ms   once per session, always skippable
+//
+// ## What escalation keys on, and what it must never key on
+//
+// MISSION forbids escalating celebration on streak or run length, and this is
+// the file where that is either true or not. `chooseTier` takes an `Outcome`
+// with four fields and none of them is a count of anything the child has done
+// in a row. `tiers.test.ts` asserts it two ways: behaviourally, by handing the
+// function a run length and a combo count and showing the answer does not move,
+// and by scanning every source file under `src/reactions/` for the words.
+//
+// Escalation keys on **difficulty** and on **repair** — a harder item earns
+// more, and getting right the item that isolates a misunderstanding you had a
+// moment ago earns more than getting right an item you always could. At M2
+// there is no learner model, so `difficulty` is the ladder position rather than
+// `(b_item − θ_s)`. The shape of the rule is the shape it keeps; M5 replaces
+// what fills the field, not what the field is.
+//
+// ## And the one inequality this product turns on
+//
+// `energy(SLIP) < energy(SEAT)`: being wrong must never be more interesting
+// than being right. It is asserted here over the whole effect catalogue rather
+// than tier-to-tier, in the strong form — the loudest slip is quieter than the
+// quietest seat — and it is *also* playtested (`T-01`), because it is a proxy a
+// determined designer can satisfy while still making failure the fun part.
+
+import type { Milestone } from "../world/construction.ts"
+
+export type TierName = "slip" | "seat" | "engage" | "illuminate" | "mechanism"
+
+/** Loud to quiet, for the downgrade walk when a tier has nothing eligible. */
+export const TIER_ORDER: readonly TierName[] = [
+  "mechanism",
+  "illuminate",
+  "engage",
+  "seat",
+  "slip",
+]
+
+export interface Tier {
+  readonly name: TierName
+  /** EXPERIENCE_DESIGN's tier number. Negative is below the resting state. */
+  readonly level: number
+  readonly budgetMs: number
+  /** Spendable once per session. Only MECHANISM is. */
+  readonly oncePerSession: boolean
+}
+
+export const TIERS: Readonly<Record<TierName, Tier>> = {
+  slip: { name: "slip", level: -1, budgetMs: 260, oncePerSession: false },
+  seat: { name: "seat", level: 0, budgetMs: 200, oncePerSession: false },
+  engage: { name: "engage", level: 1, budgetMs: 450, oncePerSession: false },
+  illuminate: { name: "illuminate", level: 2, budgetMs: 900, oncePerSession: false },
+  mechanism: { name: "mechanism", level: 3, budgetMs: 1800, oncePerSession: true },
+}
+
+/**
+ * Everything the reaction layer is allowed to know about what just happened.
+ *
+ * Four fields, and the absence of a fifth is the product rule. There is no
+ * `streak`, no `run`, no `combo` and no session total, and there is nowhere for
+ * one to be smuggled in: this type is the entire input.
+ */
+export interface Outcome {
+  readonly correct: boolean
+  /**
+   * How hard the item was: 0 at the bottom of the ladder, 1 at the top.
+   * Stands in for `(b_item − θ_s)` until the learner model lands at M5.
+   */
+  readonly difficulty: number
+  /** This answer was the one that followed a contrast pair, and it was right. */
+  readonly repaired: boolean
+  /** What closed in the world, if anything. */
+  readonly milestone: Milestone | null
+}
+
+/** Above this, an item is hard enough to be worth engaging the machinery for. */
+export const HARD = 0.6
+
+/**
+ * The tier this outcome deserves — before eligibility, and before the
+ * once-a-session budget is checked. Pure, total, and stateless: whether the
+ * MECHANISM is still available is the stage's business, not this function's,
+ * which is what keeps the escalation rule readable in one screen.
+ */
+export function chooseTier(outcome: Outcome): TierName {
+  if (!outcome.correct) return "slip"
+  if (outcome.milestone !== null) {
+    return outcome.milestone === "star" ? "illuminate" : "mechanism"
+  }
+  if (outcome.repaired) return "illuminate"
+  return outcome.difficulty >= HARD ? "engage" : "seat"
+}

--- a/dynawalla/dynawalla-app/src/reactions/tiers.ts
+++ b/dynawalla/dynawalla-app/src/reactions/tiers.ts
@@ -1,6 +1,10 @@
 // The reaction vocabulary: five tiers, and the rule that decides which one.
 //
-// The budgets are EXPERIENCE_DESIGN's, unchanged:
+// The budgets are EXPERIENCE_DESIGN's, unchanged — and so, now, is the SEAT
+// row's "no particles", which the first cut of `effects.ts` quietly did not
+// honour. That belongs in this comment because this is the file that claims
+// fidelity to the doc; see the header of `effects.ts` for what changed and why
+// the energy formula had to change with it.
 //
 //   −1 SLIP        260 ms
 //    0 SEAT        200 ms

--- a/dynawalla/dynawalla-app/src/screens/Band.tsx
+++ b/dynawalla/dynawalla-app/src/screens/Band.tsx
@@ -4,7 +4,7 @@ import { Automaton } from "../character/Automaton.tsx"
 import { useCharacter } from "../character/store.ts"
 import { ANCHOR_CARTOUCHE } from "../design/anchors.ts"
 import { destinationPath } from "../app/routes.ts"
-import { strings } from "../app/strings.ts"
+import { strings, fill } from "../app/strings.ts"
 import { Cartouche } from "../world/Cartouche.tsx"
 import { worldStore } from "../world/live.ts"
 
@@ -33,6 +33,12 @@ import { worldStore } from "../world/live.ts"
  * translation overruns it: a clipped line is a bug to fix in the translation,
  * and a taller band is a bug in the work surface.
  *
+ * Fixed at each viewport, not fixed forever: `--dw-band-height` comes down a
+ * rung under 720 px of viewport height, where the surface below it did not fit
+ * on screen at all. It cannot change while the child is working — only a
+ * rotation or a resize moves it — so the promise it makes to the work surface
+ * is unaffected. Two lines of clamp there instead of three.
+ *
  * It is also the reaction stage's `cartouche` anchor — the region the ENGAGE
  * and ILLUMINATE effects play in. The marker class does nothing else.
  */
@@ -42,7 +48,7 @@ export function Band() {
 
   return (
     <div
-      className={`${ANCHOR_CARTOUCHE} border-t-line-cut border-b-line bg-ground-raised mb-4 flex h-[4.5rem] items-center gap-3 overflow-hidden border-t border-b px-3 py-2`}
+      className={`${ANCHOR_CARTOUCHE} border-t-line-cut border-b-line bg-ground-raised mb-[var(--dw-stack-gap-tight)] flex h-[var(--dw-band-height)] items-center gap-3 overflow-hidden border-t border-b px-3 py-2`}
     >
       <Automaton speaking={utterance !== null} />
 
@@ -58,11 +64,24 @@ export function Band() {
 
       {/* The way through to the whole screen. Progress is persisted card by
           card, so leaving mid-session and coming back resumes rather than
-          restarts — which is what makes it safe to put a door here at all. */}
+          restarts — which is what makes it safe to put a door here at all.
+
+          The label carries the count. An explicit `aria-label` on an ancestor
+          wins the accessible-name computation outright, so the Cartouche's own
+          "{{apertures}} apertures cut." was computed and then discarded — the
+          only always-visible representation of the construction, and a screen
+          reader on this surface never heard it change. No new string: it is the
+          destination's name and the world's one text alternative, joined.
+
+          The target is the padding, not the drawing. `size-11` is 44 px on a
+          surface whose keypad sets the bar at 76; stretching the link to the
+          band's full height and padding it out makes the hit box 68 × 72 — a
+          99 px diagonal, 2.6 cm — while the rosette stays the size it reads
+          at. It cannot be taller than the band, and the band is fixed. */}
       <Link
         to={destinationPath("world")}
-        aria-label={strings.destinations.world}
-        className="rounded-cut-sm shrink-0"
+        aria-label={`${strings.destinations.world}: ${fill(strings.world.cut, { apertures: placed })}`}
+        className="rounded-cut-sm -mr-1 -my-2 flex shrink-0 items-center self-stretch px-3"
       >
         <Cartouche placed={placed} className="size-11" />
       </Link>

--- a/dynawalla/dynawalla-app/src/screens/Band.tsx
+++ b/dynawalla/dynawalla-app/src/screens/Band.tsx
@@ -1,0 +1,71 @@
+import { Link } from "react-router"
+
+import { Automaton } from "../character/Automaton.tsx"
+import { useCharacter } from "../character/store.ts"
+import { ANCHOR_CARTOUCHE } from "../design/anchors.ts"
+import { destinationPath } from "../app/routes.ts"
+import { strings } from "../app/strings.ts"
+import { Cartouche } from "../world/Cartouche.tsx"
+import { worldStore } from "../world/live.ts"
+
+/**
+ * The band above the work: a window onto the world, cut into the wall.
+ *
+ * Three things live in it and its height never changes because of any of them.
+ * The Dynawalla is at the left, present and usually silent. The rosette on the
+ * bench is at the right, one aperture further along than it was before the last
+ * correct answer. Between them is carved stone — empty most of the time, and
+ * the place his line is cut when he has one.
+ *
+ * **The empty middle is the design, not a gap.** A remark that pushed the slate
+ * down the screen would be the jolting reflow the design rules forbid outright,
+ * and a remark with nowhere reserved for it would have to be a toast. Reserving
+ * the room permanently costs 72 px and buys a character who can speak without
+ * the work surface moving a pixel.
+ *
+ * **A fixed height, not a minimum.** The first cut used `min-h-16`, which held
+ * at 390 px and 360 px and then grew from 64 px to 67.5 px at 320 px, where the
+ * text column is only 160 px and the longest line takes three lines — a 3.5 px
+ * shift of everything below, on the rarest and most deliberate moment in the
+ * product. Reserving three lines at the narrowest width we ship to, as a fixed
+ * height, is what makes "the band never moves the work" structural rather than
+ * true at the widths somebody happened to check. The line clamps if a
+ * translation overruns it: a clipped line is a bug to fix in the translation,
+ * and a taller band is a bug in the work surface.
+ *
+ * It is also the reaction stage's `cartouche` anchor — the region the ENGAGE
+ * and ILLUMINATE effects play in. The marker class does nothing else.
+ */
+export function Band() {
+  const placed = worldStore((state) => state.placed)
+  const utterance = useCharacter((state) => state.utterance)
+
+  return (
+    <div
+      className={`${ANCHOR_CARTOUCHE} border-t-line-cut border-b-line bg-ground-raised mb-4 flex h-[4.5rem] items-center gap-3 overflow-hidden border-t border-b px-3 py-2`}
+    >
+      <Automaton speaking={utterance !== null} />
+
+      {/* Always in the layout, empty or not, and the one live region up here.
+          Announced when it changes; silent — and zero-height contribution —
+          when there is nothing to say. */}
+      <p
+        role="status"
+        className="text-ink-muted inscription line-clamp-3 min-w-0 flex-1 text-xs leading-snug tracking-wide"
+      >
+        {utterance === null ? null : <span className="dw-utterance">{utterance.line}</span>}
+      </p>
+
+      {/* The way through to the whole screen. Progress is persisted card by
+          card, so leaving mid-session and coming back resumes rather than
+          restarts — which is what makes it safe to put a door here at all. */}
+      <Link
+        to={destinationPath("world")}
+        aria-label={strings.destinations.world}
+        className="rounded-cut-sm shrink-0"
+      >
+        <Cartouche placed={placed} className="size-11" />
+      </Link>
+    </div>
+  )
+}

--- a/dynawalla/dynawalla-app/src/screens/Practice.tsx
+++ b/dynawalla/dynawalla-app/src/screens/Practice.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect } from "react"
 import { useNavigate } from "react-router"
 
+import { Band } from "./Band.tsx"
 import { Destination } from "./Destination.tsx"
+import { settleReactions } from "../reactions/live.ts"
 import { strings } from "../app/strings.ts"
 import { entryModelFor, glyphFromKey } from "../work/entry.ts"
 import { now, record } from "../work/metrics.ts"
@@ -39,6 +41,7 @@ export function PracticeScreen() {
   const press = usePractice((state) => state.press)
   const commitAnswer = usePractice((state) => state.commitAnswer)
   const next = usePractice((state) => state.next)
+  const react = usePractice((state) => state.react)
   const end = usePractice((state) => state.end)
   const navigate = useNavigate()
 
@@ -58,15 +61,23 @@ export function PracticeScreen() {
   // pending frame callback and dropping roughly a quarter of the samples. Two
   // frames, because the first callback runs *before* the paint it was scheduled
   // for and the second runs after it.
+  //
+  // The reaction is fired from the second frame, for the same reason the
+  // measurement is: that is the first callback that provably runs *after* the
+  // verdict has painted. A reaction scheduled any earlier can land in front of
+  // the thing it is reacting to, and one scheduled from the commit itself would
+  // be work on the answer path. Nothing waits for it either way — `fire`
+  // returns immediately and the loop carries on.
   const commitNow = useCallback(() => {
     const started = now()
     commitAnswer()
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         record("commitToFeedback", now() - started)
+        react()
       })
     })
-  }, [commitAnswer])
+  }, [commitAnswer, react])
 
   // A seated answer presents the next card on its own.
   useEffect(() => {
@@ -84,6 +95,11 @@ export function PracticeScreen() {
   useEffect(() => {
     if (session === null) return
     const onKeyDown = (event: KeyboardEvent) => {
+      // First line, unconditionally, before the key is even classified: a child
+      // who answers fast must never wait on an animation, and a `settleNow`
+      // behind a condition is one that stops being called (`Q-04`). It is a
+      // no-op when nothing is running.
+      settleReactions()
       const glyph = glyphFromKey(event.key)
       if (glyph !== null) {
         event.preventDefault()
@@ -110,70 +126,83 @@ export function PracticeScreen() {
     return () => window.removeEventListener("keydown", onKeyDown)
   }, [session, press, commitNow, next])
 
-  if (session === null) return <Destination />
+  if (session === null)
+    return (
+      <>
+        <Band />
+        <Destination />
+      </>
+    )
 
   const { card, entry, feedback } = session
   const model = card.kind === "problem" ? entryModelFor(card.exercise.schema) : undefined
 
   return (
-    <Destination>
-      <div className="flex flex-col gap-6">
-        {card.kind === "problem" ? (
-          <ProblemSlate
-            key={card.exercise.exerciseId}
-            card={card}
-            entry={entry}
-            feedback={feedback}
-          />
-        ) : (
-          <CountingBoardCard board={card.board} />
-        )}
-
-        {/* Capped and centred: on a tablet an uncapped three-column grid makes
-            each key a 220 px slab across the whole plate, which is further from
-            a thumb than it is from the last key. The cap keeps the pad the size
-            of a hand at every width. */}
-        <div className="mx-auto flex w-full max-w-xs flex-col gap-4">
-          {/* The keypad stays mounted while a verdict is up, disabled rather
-              than removed. Unmounting it would pull the action row a hundred
-              pixels up the screen at the exact moment the child is looking at
-              their answer — the jolting reflow the design rules forbid. */}
-          {card.kind === "problem" && model !== undefined ? (
-            <Keypad
-              model={model}
-              schema={card.exercise.schema}
-              onKey={press}
-              disabled={feedback !== null}
+    <>
+      {/* Above the plate, not inside it: the world is a window in the wall and
+          the work is the instrument mounted below. Its height is fixed, so
+          nothing it does — an aperture cutting, the character speaking — moves
+          the slate under the child's eye. */}
+      <Band />
+      <Destination>
+        <div className="flex flex-col gap-6">
+          {card.kind === "problem" ? (
+            <ProblemSlate
+              key={card.exercise.exerciseId}
+              card={card}
+              entry={entry}
+              feedback={feedback}
             />
-          ) : null}
+          ) : (
+            <CountingBoardCard board={card.board} />
+          )}
 
-          <div className="flex gap-3">
-            {session.stopping ? (
-              <>
-                <Plate
-                  onPress={() => {
-                    // Ends the run, not the progress: the ladder position, the
-                    // seed cursor and the totals are already persisted. Coming
-                    // back gives a fresh card where they left off rather than
-                    // the one they walked away from.
-                    end()
-                    void navigate("/")
-                  }}
-                >
-                  {strings.practice.done}
+          {/* Capped and centred: on a tablet an uncapped three-column grid makes
+              each key a 220 px slab across the whole plate, which is further from
+              a thumb than it is from the last key. The cap keeps the pad the size
+              of a hand at every width. */}
+          <div className="mx-auto flex w-full max-w-xs flex-col gap-4">
+            {/* The keypad stays mounted while a verdict is up, disabled rather
+                than removed. Unmounting it would pull the action row a hundred
+                pixels up the screen at the exact moment the child is looking at
+                their answer — the jolting reflow the design rules forbid. */}
+            {card.kind === "problem" && model !== undefined ? (
+              <Keypad
+                model={model}
+                schema={card.exercise.schema}
+                onKey={press}
+                disabled={feedback !== null}
+              />
+            ) : null}
+
+            <div className="flex gap-3">
+              {session.stopping ? (
+                <>
+                  <Plate
+                    onPress={() => {
+                      // Ends the run, not the progress: the ladder position, the
+                      // seed cursor and the totals are already persisted. Coming
+                      // back gives a fresh card where they left off rather than
+                      // the one they walked away from.
+                      end()
+                      void navigate("/")
+                    }}
+                  >
+                    {strings.practice.done}
+                  </Plate>
+                  <Plate onPress={next}>{strings.practice.keepGoing}</Plate>
+                </>
+              ) : feedback === null && card.kind === "problem" ? (
+                <Plate onPress={commitNow} disabled={!committable(session)}>
+                  {strings.practice.check}
                 </Plate>
-                <Plate onPress={next}>{strings.practice.keepGoing}</Plate>
-              </>
-            ) : feedback === null && card.kind === "problem" ? (
-              <Plate onPress={commitNow} disabled={!committable(session)}>
-                {strings.practice.check}
-              </Plate>
-            ) : (
-              <Plate onPress={next}>{strings.practice.next}</Plate>
-            )}
+              ) : (
+                <Plate onPress={next}>{strings.practice.next}</Plate>
+              )}
+            </div>
           </div>
         </div>
-      </div>
-    </Destination>
+      </Destination>
+    </>
   )
 }

--- a/dynawalla/dynawalla-app/src/screens/Practice.tsx
+++ b/dynawalla/dynawalla-app/src/screens/Practice.tsx
@@ -41,6 +41,7 @@ export function PracticeScreen() {
   const press = usePractice((state) => state.press)
   const commitAnswer = usePractice((state) => state.commitAnswer)
   const next = usePractice((state) => state.next)
+  const autoAdvance = usePractice((state) => state.autoAdvance)
   const react = usePractice((state) => state.react)
   const end = usePractice((state) => state.end)
   const navigate = useNavigate()
@@ -79,14 +80,18 @@ export function PracticeScreen() {
     })
   }, [commitAnswer, react])
 
-  // A seated answer presents the next card on its own.
+  // A seated answer presents the next card on its own — through `autoAdvance`,
+  // not `next`. A timer is not an input: `next` settles whatever the reaction
+  // stage is playing, which is right when the child acted and wrong when the
+  // clock did. Routed through `next`, this line was what cut every reaction
+  // above SEAT to the 420 ms hold.
   useEffect(() => {
     if (session === null) return
     const hold = autoAdvanceMs(session)
     if (hold === null) return
-    const handle = setTimeout(next, hold)
+    const handle = setTimeout(autoAdvance, hold)
     return () => clearTimeout(handle)
-  }, [session, next])
+  }, [session, autoAdvance])
 
   // The hardware keyboard, at the window, so the loop is fully operable without
   // ever hitting Tab. Enter is left alone while a button has focus — that is the
@@ -145,7 +150,7 @@ export function PracticeScreen() {
           the slate under the child's eye. */}
       <Band />
       <Destination>
-        <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-[var(--dw-stack-gap)]">
           {card.kind === "problem" ? (
             <ProblemSlate
               key={card.exercise.exerciseId}
@@ -161,7 +166,7 @@ export function PracticeScreen() {
               each key a 220 px slab across the whole plate, which is further from
               a thumb than it is from the last key. The cap keeps the pad the size
               of a hand at every width. */}
-          <div className="mx-auto flex w-full max-w-xs flex-col gap-4">
+          <div className="mx-auto flex w-full max-w-xs flex-col gap-[var(--dw-stack-gap-tight)]">
             {/* The keypad stays mounted while a verdict is up, disabled rather
                 than removed. Unmounting it would pull the action row a hundred
                 pixels up the screen at the exact moment the child is looking at
@@ -175,7 +180,18 @@ export function PracticeScreen() {
               />
             ) : null}
 
-            <div className="flex gap-3">
+            {/* Pinned to the bottom of the viewport, not just to the bottom of
+                the stack. The surface is 654 px tall at its most compact and a
+                568 px phone cannot hold it however it is cut — a numeric pad
+                with ≥2 cm targets is 232 px of that on its own — so on the
+                shortest screens the commit control was below the fold and the
+                child scrolled to submit every answer. `sticky` costs nothing
+                where it already fits (the plate never leaves its place) and
+                keeps the one control that ends a card reachable where it does
+                not. It sits above the safe-area inset rather than under the
+                home indicator, and carries the recess's own ground so the
+                keypad does not show through it. */}
+            <div className="bg-ground-sunk sticky bottom-[var(--safe-bottom)] -mx-[var(--dw-frame-pad)] -mt-[var(--dw-stack-gap-tight)] -mb-[var(--dw-frame-pad)] flex gap-3 px-[var(--dw-frame-pad)] pt-[var(--dw-stack-gap-tight)] pb-[var(--dw-frame-pad)]">
               {session.stopping ? (
                 <>
                   <Plate

--- a/dynawalla/dynawalla-app/src/screens/World.tsx
+++ b/dynawalla/dynawalla-app/src/screens/World.tsx
@@ -1,0 +1,21 @@
+import { Destination } from "./Destination.tsx"
+import { WorldScreen } from "../world/Screen.tsx"
+import { worldStore } from "../world/live.ts"
+
+/**
+ * Everything the child has cut.
+ *
+ * No heading, no total, no encouragement to come back and cut more. An empty
+ * plate at the start is honest — the stone is there and nothing is out of it
+ * yet — and a screen with four courses in it does not need to be described.
+ * The count is in the text alternative, where a number belongs.
+ */
+export function WorldRoute() {
+  const placed = worldStore((state) => state.placed)
+
+  return (
+    <Destination>
+      <WorldScreen placed={placed} className="mx-auto block h-auto w-full max-w-sm" />
+    </Destination>
+  )
+}

--- a/dynawalla/dynawalla-app/src/screens/World.tsx
+++ b/dynawalla/dynawalla-app/src/screens/World.tsx
@@ -1,4 +1,9 @@
+import { Link } from "react-router"
+
 import { Destination } from "./Destination.tsx"
+import { IndexMark } from "../design/IndexMark.tsx"
+import { destinationPath } from "../app/routes.ts"
+import { strings } from "../app/strings.ts"
 import { WorldScreen } from "../world/Screen.tsx"
 import { worldStore } from "../world/live.ts"
 
@@ -9,13 +14,31 @@ import { worldStore } from "../world/live.ts"
  * plate at the start is honest — the stone is there and nothing is out of it
  * yet — and a screen with four courses in it does not need to be described.
  * The count is in the text alternative, where a number belongs.
+ *
+ * The one piece of copy is the way back. The band's rosette is a door out of
+ * the work, and until now it opened onto a room with no door in it: the only
+ * route back to practice was the wordmark, then the home list, then Practice —
+ * two navigations, in a Tauri WebView with no browser chrome and no back
+ * gesture on desktop. That is a trap, not a destination. It costs no new
+ * string; `destinations.practice` is already the name of the place.
  */
 export function WorldRoute() {
   const placed = worldStore((state) => state.placed)
 
   return (
     <Destination>
-      <WorldScreen placed={placed} className="mx-auto block h-auto w-full max-w-sm" />
+      <div className="flex flex-col gap-6">
+        <WorldScreen placed={placed} className="mx-auto block h-auto w-full max-w-sm" />
+        <Link
+          to={destinationPath("practice")}
+          className="group border-line hover:bg-ground-raised -mx-2 flex min-h-16 items-center gap-3 border-t px-2 transition-colors duration-[var(--dw-motion-quick)]"
+        >
+          <IndexMark className="text-index opacity-0 transition-opacity duration-[var(--dw-motion-quick)] group-hover:opacity-100 group-focus-visible:opacity-100" />
+          <span className="inscription text-xl tracking-wide">
+            {strings.destinations.practice}
+          </span>
+        </Link>
+      </div>
     </Destination>
   )
 }

--- a/dynawalla/dynawalla-app/src/work/curriculum.ts
+++ b/dynawalla/dynawalla-app/src/work/curriculum.ts
@@ -17,6 +17,7 @@ export {
   classify,
   columnOpFamily,
   columnOpParamSchema,
+  createRng,
   familyById,
   malRuleById,
   malRules,

--- a/dynawalla/dynawalla-app/src/work/diagnosis.test.ts
+++ b/dynawalla/dynawalla-app/src/work/diagnosis.test.ts
@@ -21,12 +21,19 @@ import {
 } from "./curriculum.ts"
 import { countingBoard } from "./contrast.ts"
 import { glyphFromKey } from "./entry.ts"
-import { ACROSS_ZERO_RUNG, answerOf, fiveThousandOne, nineHundredThree } from "./fixtures.ts"
+import {
+  ACROSS_ZERO_RUNG,
+  CARRY_SURPLUS_RUNG,
+  answerOf,
+  fiveThousandOne,
+  nineHundredThree,
+} from "./fixtures.ts"
 import { judge } from "./judge.ts"
 import { readProblem } from "./problem.ts"
-import { repairRung, rungAt, LADDER, LADDER_FORMS } from "./ladder.ts"
+import { repairRung, rungAt, FIRST_ACROSS_ZERO, LADDER, LADDER_FORMS } from "./ladder.ts"
 import {
   advance,
+  arrivesAcrossZero,
   commit,
   contrastDistance,
   prepare,
@@ -260,6 +267,48 @@ test("the contrast pair is followed by a repair item that cannot avoid the step"
   assert.equal(state.card.role, "repair")
   assert.ok(rungAt(state.card.rung).params.acrossZero >= 1)
   assert.equal(rungAt(state.card.rung).skillId, "dw.add.regroup.subtract-across-zero")
+})
+
+test("a repair item is not an arrival: the Dynawalla stays quiet through it", () => {
+  // The bug this is written against. `FIRST_ACROSS_ZERO` and the rung a
+  // `borrow-across-zero` repair comes from are *the same index* — both are
+  // "the lowest rung whose parameters guarantee the step" — so a rule that
+  // watched the rung number climb announced "the ladder has reached the
+  // problems with a zero in the middle" the first time a child at rung 2 fired
+  // the mal-rule and was handed the repair card. The ladder had not moved. It
+  // then latched for the session, so when the child genuinely reached rung 4 by
+  // promotion he said nothing, and one of his four utterances had been spent on
+  // a card the child got *wrong* — stacked onto the strike and the contrast
+  // pair, at the moment they are most loaded.
+  assert.equal(repairRung(MIS_BORROW_ACROSS_ZERO, CARRY_SURPLUS_RUNG), FIRST_ACROSS_ZERO)
+
+  // `903 − 778` on `subtract-multidigit` level 2, answered 225: the across-zero
+  // procedure run at a rung three below where it is taught.
+  const deps: SessionDeps = { generate: () => nineHundredThree().exercise }
+  let state = startSession(
+    { profileId: "p1", rung: CARRY_SURPLUS_RUNG, rungCorrect: 0, seedCursor: 0 },
+    deps,
+  )
+  assert.ok(CARRY_SURPLUS_RUNG < FIRST_ACROSS_ZERO)
+  assert.equal(arrivesAcrossZero(state.card), false, "the first card is an arrival")
+
+  state = commit(type(state, "225"))
+  assert.equal(state.plan.kind, "locate")
+
+  state = advance(prepare(state, deps), deps)
+  assert.equal(state.card.kind, "locate")
+  assert.equal(arrivesAcrossZero(state.card), false, "the contrast pair is an arrival")
+
+  state = advance(state, deps)
+  assert.ok(state.card.kind === "problem")
+  assert.equal(state.card.role, "repair")
+  assert.equal(state.card.rung, FIRST_ACROSS_ZERO, "the repair is served at the arrival rung")
+  assert.equal(arrivesAcrossZero(state.card), false, "the repair card announced an arrival")
+
+  // …and the real thing still does. A `ladder` card at that rung is the ladder
+  // having got there.
+  assert.equal(arrivesAcrossZero({ ...state.card, role: "ladder" }), true)
+  assert.equal(arrivesAcrossZero({ ...state.card, role: "ladder", rung: FIRST_ACROSS_ZERO - 1 }), false)
 })
 
 test("a diagnosis on an easy rung still repairs with a guaranteed across-zero item", () => {

--- a/dynawalla/dynawalla-app/src/work/ladder.ts
+++ b/dynawalla/dynawalla-app/src/work/ladder.ts
@@ -100,9 +100,23 @@ export function easier(index: number): number {
  * structure. It is the easiest problem on the ladder that cannot avoid the
  * misunderstanding.
  */
+const guaranteesAcrossZero = (params: ColumnOpParams): boolean =>
+  params.op === "sub" && params.acrossZero >= 1
+
 const REPAIR_STRUCTURE: readonly (readonly [MalRuleId, (params: ColumnOpParams) => boolean])[] = [
-  [MIS_BORROW_ACROSS_ZERO, (params) => params.op === "sub" && params.acrossZero >= 1],
+  [MIS_BORROW_ACROSS_ZERO, guaranteesAcrossZero],
 ]
+
+/**
+ * The first rung whose parameters *guarantee* a regrouping across a zero.
+ *
+ * Derived from the same predicate the repair rung uses, so the two cannot
+ * disagree about where the across-zero content starts. The character notices
+ * the child arriving here; nothing else reads it.
+ */
+export const FIRST_ACROSS_ZERO: number = LADDER.findIndex((rung) =>
+  guaranteesAcrossZero(rung.params),
+)
 
 /** The rung a repair item comes from, or `fallback` when nothing is bound. */
 export function repairRung(misconception: MalRuleId, fallback: number): number {

--- a/dynawalla/dynawalla-app/src/work/progress.test.ts
+++ b/dynawalla/dynawalla-app/src/work/progress.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test"
 import assert from "node:assert/strict"
 
 import { createProgressStore, ephemeral, INITIAL_PROGRESS } from "./progress.ts"
-import { DEFAULT_PROFILE_ID, isProfileId, storageKey } from "./profile.ts"
+import { DEFAULT_PROFILE_ID, isProfileId, storageKey } from "../app/profile.ts"
 
 test("keys are namespaced by profile, and cannot collide across profiles", () => {
   assert.equal(storageKey("p1", "progress"), "dynawalla.p1.progress")

--- a/dynawalla/dynawalla-app/src/work/progress.ts
+++ b/dynawalla/dynawalla-app/src/work/progress.ts
@@ -19,7 +19,7 @@
 import { create, type StoreApi, type UseBoundStore } from "zustand"
 import { persist, createJSONStorage, type StateStorage } from "zustand/middleware"
 
-import { storageKey } from "./profile.ts"
+import { storageKey } from "../app/profile.ts"
 
 export interface Progress {
   readonly rung: number

--- a/dynawalla/dynawalla-app/src/work/respond.test.ts
+++ b/dynawalla/dynawalla-app/src/work/respond.test.ts
@@ -1,0 +1,133 @@
+// Where the answer meets the world and the character.
+//
+// The claim the brief asks to be checked deliberately is here: **a wrong answer
+// must never be more rewarding than a right one.** It is checked three ways,
+// because the interesting failure is not "the wrong branch celebrates" — nobody
+// writes that — it is a wrong answer picking up a reward through a side door.
+//
+//   1. It places nothing. The construction is a record of what went right.
+//   2. It cannot reach a milestone, so it cannot reach the reaction tiers that
+//      milestones unlock.
+//   3. It earns the character nothing to say.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { chooseTier } from "../reactions/tiers.ts"
+import {
+  CELLS_PER_COURSE,
+  CELLS_PER_ROSETTE,
+  CELLS_PER_STAR,
+  milestoneAt,
+} from "../world/construction.ts"
+import { LADDER, rungAt } from "./ladder.ts"
+import { difficultyOf, respond } from "./respond.ts"
+import { generateProblem, type Card, type CardRole } from "./session.ts"
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+
+function problemAt(rung: number, role: CardRole): Card {
+  return { kind: "problem", exercise: generateProblem(rungAt(rung), rung * 31 + 7), rung, role }
+}
+
+const TOP = LADDER.length - 1
+
+test("a wrong answer places nothing in the world", () => {
+  // `respond` is handed the count *after* any placement, and the caller only
+  // places on a correct answer. Both halves are asserted: the store's placement
+  // condition below, and here that a wrong answer at a would-be milestone count
+  // still reports no milestone.
+  const wrong = respond(problemAt(TOP, "ladder"), false, CELLS_PER_ROSETTE)
+  assert.ok(wrong !== null)
+  assert.equal(wrong.outcome.milestone, null)
+  assert.equal(wrong.observation, null)
+})
+
+test("a wrong answer earns SLIP, at every rung and every role", () => {
+  for (let rung = 0; rung <= TOP; rung++) {
+    for (const role of ["ladder", "retry", "repair"] as const) {
+      const response = respond(problemAt(rung, role), false, 999)
+      assert.ok(response !== null)
+      assert.equal(chooseTier(response.outcome), "slip")
+      assert.equal(response.outcome.repaired, false, "a wrong answer claimed a repair")
+    }
+  }
+})
+
+test("a right answer at the same rung always outranks the wrong one", () => {
+  const order = ["slip", "seat", "engage", "illuminate", "mechanism"]
+  for (let rung = 0; rung <= TOP; rung++) {
+    const right = respond(problemAt(rung, "ladder"), true, 3)
+    const wrong = respond(problemAt(rung, "ladder"), false, 3)
+    assert.ok(right !== null && wrong !== null)
+    assert.ok(
+      order.indexOf(chooseTier(right.outcome)) > order.indexOf(chooseTier(wrong.outcome)),
+      `rung ${String(rung)}`,
+    )
+  }
+})
+
+test("repairing what just broke is the thing that earns tier 2", () => {
+  const repair = respond(problemAt(0, "repair"), true, 3)
+  const ordinary = respond(problemAt(0, "ladder"), true, 3)
+  assert.ok(repair !== null && ordinary !== null)
+  assert.equal(repair.outcome.repaired, true)
+  assert.equal(chooseTier(repair.outcome), "illuminate")
+  assert.equal(chooseTier(ordinary.outcome), "seat")
+  assert.deepEqual(repair.observation, { kind: "repaired", apertures: null })
+})
+
+test("difficulty is the ladder position and nothing else", () => {
+  assert.equal(difficultyOf(0), 0)
+  assert.equal(difficultyOf(TOP), 1)
+  for (let rung = 1; rung <= TOP; rung++) {
+    assert.ok(difficultyOf(rung) > difficultyOf(rung - 1))
+  }
+  // Out of range clamps rather than escaping the scale.
+  assert.equal(difficultyOf(-5), 0)
+  assert.equal(difficultyOf(TOP + 40), 1)
+})
+
+test("a milestone is passed through to both the reaction and the character", () => {
+  const star = respond(problemAt(0, "ladder"), true, CELLS_PER_STAR)
+  assert.ok(star !== null)
+  assert.equal(star.outcome.milestone, "star")
+  assert.deepEqual(star.observation, { kind: "closed", apertures: CELLS_PER_STAR })
+
+  const course = respond(problemAt(0, "ladder"), true, CELLS_PER_COURSE)
+  assert.ok(course !== null)
+  assert.equal(course.outcome.milestone, "course")
+  assert.equal(chooseTier(course.outcome), "mechanism")
+})
+
+test("a contrast card responds with nothing at all", () => {
+  const locate: Card = {
+    kind: "locate",
+    board: { rows: [], left: { label: "", total: "" }, right: { label: "", total: "" } } as never,
+    misconception: "mis.add.borrow-across-zero" as never,
+    representation: "rep.counting-board" as never,
+    rung: 4,
+  }
+  assert.equal(respond(locate, true, 20), null)
+})
+
+test("the store places on the correct branch only", () => {
+  // The one line that decides whether the world moves. Read as source because
+  // the alternative — driving zustand plus persistence under `node --test` —
+  // tests the store's plumbing rather than this rule.
+  const text = fs.readFileSync(path.join(here, "store.ts"), "utf8")
+  assert.match(text, /const placed = correct \? worldStore\.getState\(\)\.placeOne\(\)/)
+  // …and it is the only call site, so there is no second, unconditional one.
+  assert.equal((text.match(/placeOne\(\)/g) ?? []).length, 1)
+})
+
+test("milestones are read from the world, not recomputed here", () => {
+  for (const placed of [CELLS_PER_STAR, CELLS_PER_ROSETTE, CELLS_PER_COURSE, 7]) {
+    const response = respond(problemAt(0, "ladder"), true, placed)
+    assert.ok(response !== null)
+    assert.equal(response.outcome.milestone, milestoneAt(placed))
+  }
+})

--- a/dynawalla/dynawalla-app/src/work/respond.ts
+++ b/dynawalla/dynawalla-app/src/work/respond.ts
@@ -1,0 +1,78 @@
+// What the world and the character are told about an answer.
+//
+// The one place the work surface, the construction and the character meet, and
+// it is a pure function so the meeting can be asserted rather than clicked
+// through. `Q-05` forbids `src/world/` and `src/reactions/` from importing
+// anything here; the arrow only ever points this way.
+//
+// Three claims live in this file, and each is a test in `respond.test.ts`:
+//
+//   1. **A wrong answer places nothing.** Not "places less" — nothing. The
+//      construction is the record of what the child got right, and `P-04` says
+//      it never regresses, which is only meaningful if it also never advances
+//      on a miss.
+//   2. **A wrong answer earns SLIP and can earn nothing else.** The tier is
+//      decided from this outcome, and `correct: false` short-circuits every
+//      escalation path in `chooseTier`.
+//   3. **Escalation is difficulty and repair.** `difficultyOf` is the ladder
+//      position and nothing else — not how many in a row, not how fast, not how
+//      many today. There is no argument here that could carry a run length.
+
+import { aperturesIn, milestoneAt } from "../world/construction.ts"
+import type { Observation } from "../character/voice.ts"
+import type { Outcome } from "../reactions/tiers.ts"
+import { LADDER } from "./ladder.ts"
+import type { Card } from "./session.ts"
+
+/**
+ * The ladder position as a 0…1 difficulty.
+ *
+ * The stand-in for `(b_item − θ_s)` until the learner model lands at M5. It is
+ * an item property against a fixed ladder, which is the honest version of "this
+ * one was harder" when there is no estimate of the child in the system at all.
+ */
+export function difficultyOf(rung: number): number {
+  const top = LADDER.length - 1
+  if (top <= 0) return 0
+  return Math.min(Math.max(rung, 0), top) / top
+}
+
+export interface Response {
+  readonly outcome: Outcome
+  /** Something worth remarking on, or `null` — which is the usual answer. */
+  readonly observation: Observation | null
+}
+
+/**
+ * How to respond to a judged card.
+ *
+ * `placed` is the construction count **after** any placement, so the milestone
+ * is read from the world's new state rather than guessed from the old one.
+ * Returns `null` for a card that is not a problem — a contrast pair is not
+ * answered, so nothing responds to it.
+ */
+export function respond(card: Card, correct: boolean, placed: number): Response | null {
+  if (card.kind !== "problem") return null
+
+  const milestone = correct ? milestoneAt(placed) : null
+  // The repair item is the one served after a contrast pair, from the rung
+  // whose parameters guarantee the step that broke. Getting *that* right is the
+  // product working, and it is the only thing here that is about the child's
+  // understanding rather than about the item.
+  const repaired = correct && card.role === "repair"
+
+  const outcome: Outcome = {
+    correct,
+    difficulty: difficultyOf(card.rung),
+    repaired,
+    milestone,
+  }
+
+  const observation: Observation | null = repaired
+    ? { kind: "repaired", apertures: null }
+    : milestone === null
+      ? null
+      : { kind: "closed", apertures: aperturesIn(milestone) }
+
+  return { outcome, observation }
+}

--- a/dynawalla/dynawalla-app/src/work/session.test.ts
+++ b/dynawalla/dynawalla-app/src/work/session.test.ts
@@ -6,16 +6,18 @@ import assert from "node:assert/strict"
 
 import { glyphFromKey } from "./entry.ts"
 import { fiveThousandOne } from "./fixtures.ts"
-import { CORRECT_PER_RUNG, LADDER, RUN_LENGTH, rungAt } from "./ladder.ts"
+import { CORRECT_PER_RUNG, FIRST_ACROSS_ZERO, LADDER, RUN_LENGTH, rungAt } from "./ladder.ts"
 import { writtenAnswer } from "./problem.ts"
 import {
   advance,
+  arrivesAcrossZero,
   commit,
   committable,
   enterAction,
   generateProblem,
   prepare,
   pressKey,
+  sequenceFrom,
   startSession,
   submitted,
   DECK_DEPTH,
@@ -52,6 +54,43 @@ function answerCorrectly(state: SessionState, deps: SessionDeps): SessionState {
   assert.equal(committed.feedback?.kind, "seated")
   return advance(prepare(committed, deps), deps)
 }
+
+test("the session's choice sequence is seeded, so a session replays exactly", () => {
+  // Which effect the stage plays and which phrasing the Dynawalla reaches for
+  // were both `Math.random()` at the call site, while `surface.ts` went to the
+  // trouble of a deterministic integer-hash mote pool "because the committed
+  // screenshot set has to be comparable frame for frame". The two things that
+  // most change a screenshot were the two that were not seeded.
+  const take = (cursor: number): number[] => {
+    const draw = sequenceFrom(cursor)
+    return Array.from({ length: 8 }, () => draw())
+  }
+  assert.deepEqual(take(41), take(41), "the same cursor did not replay")
+  assert.notDeepEqual(take(41), take(42), "two cursors gave the same sequence")
+  for (const value of take(7)) {
+    assert.ok(value >= 0 && value < 1, `${String(value)} is not a draw in [0, 1)`)
+  }
+  // A whole session's worth without repeating itself into a pattern.
+  const long = Array.from({ length: 500 }, sequenceFrom(0))
+  assert.ok(new Set(long).size > 400, "the sequence is degenerate")
+})
+
+test("only a ladder card at the across-zero rungs is an arrival", () => {
+  // The unit form of the bug `diagnosis.test.ts` drives end to end: a repair
+  // item is served *at* `FIRST_ACROSS_ZERO` by construction, so a rule keyed on
+  // the rung alone announces an arrival that has not happened.
+  const deps = counting()
+  const at = (rung: number, role: "ladder" | "retry" | "repair"): boolean => {
+    const state = startSession({ profileId: "p1", rung, rungCorrect: 0, seedCursor: 0 }, deps)
+    assert.ok(state.card.kind === "problem")
+    return arrivesAcrossZero({ ...state.card, role })
+  }
+  assert.equal(at(FIRST_ACROSS_ZERO, "ladder"), true)
+  assert.equal(at(FIRST_ACROSS_ZERO, "repair"), false)
+  assert.equal(at(FIRST_ACROSS_ZERO, "retry"), false)
+  assert.equal(at(FIRST_ACROSS_ZERO - 1, "ladder"), false)
+  assert.equal(at(LADDER.length - 1, "ladder"), true)
+})
 
 test("commit does no generation — it cannot, and that is the signature", () => {
   const deps = counting()

--- a/dynawalla/dynawalla-app/src/work/session.ts
+++ b/dynawalla/dynawalla-app/src/work/session.ts
@@ -44,7 +44,7 @@
 // no contradiction — or shows a second, invented one — is worse than a quiet
 // strike mark.
 
-import { columnOpFamily } from "./curriculum.ts"
+import { columnOpFamily, createRng } from "./curriculum.ts"
 import type { AnswerValue, Exercise, MalRuleId, RepId } from "./curriculum.ts"
 import { countingBoard, type CountingBoard } from "./contrast.ts"
 import { entryModelFor, type EntryKey, type EntryState } from "./entry.ts"
@@ -54,6 +54,7 @@ import {
   easier,
   repairRung,
   rungAt,
+  FIRST_ACROSS_ZERO,
   LADDER_FORMS,
   RUN_LENGTH,
   type Rung,
@@ -439,10 +440,54 @@ export function enterAction(state: SessionState): "commit" | "next" {
   return state.feedback === null && state.card.kind === "problem" ? "commit" : "next"
 }
 
-/** Milliseconds to hold a seated answer before presenting the next card. */
+/**
+ * Milliseconds to hold a seated answer before presenting the next card.
+ *
+ * One number for every tier, on purpose. The hold is how long the *work
+ * surface* pauses, and EXPERIENCE_DESIGN is explicit that it does not wait for
+ * the world: "the next problem presents concurrently with the reaction tail".
+ * Scaling this to the reaction's budget would put a 1.8-second dead stop in the
+ * loop at every twentieth answer, which is the same mistake as truncating the
+ * reaction, made from the other end. What changes instead is that the
+ * auto-advance no longer *settles* the reaction — see `store.ts`'s
+ * `autoAdvance`.
+ */
 export function autoAdvanceMs(state: SessionState): number | null {
   if (state.feedback?.kind !== "seated" || state.stopping) return null
   return SEAT_HOLD_MS
+}
+
+/**
+ * Is this card the child's first arrival at the across-zero rungs?
+ *
+ * Only a `ladder` card can be one. `FIRST_ACROSS_ZERO` and the rung a
+ * `borrow-across-zero` repair item comes from are the same index by
+ * construction — both are "the first rung whose parameters guarantee the step"
+ * — so a rule that watched the rung number alone announced the arrival the
+ * first time a child got one *wrong* three rungs lower and was handed the
+ * repair item. The ladder had not moved at all.
+ */
+export function arrivesAcrossZero(card: Card): boolean {
+  if (FIRST_ACROSS_ZERO < 0) return false
+  return card.kind === "problem" && card.role === "ladder" && card.rung >= FIRST_ACROSS_ZERO
+}
+
+/**
+ * The session's own stream of [0, 1) draws, for everything that is a choice
+ * rather than a computation: which effect the stage plays, which phrasing the
+ * Dynawalla reaches for.
+ *
+ * Seeded from the position the session resumes at, so a session replays its
+ * reactions and its lines exactly — which is what the committed screenshot set
+ * (`Q-06`, M6) needs and what `Math.random` at two call sites made impossible.
+ * Offset off the exercise stream so the two do not move in step.
+ */
+export const SEQUENCE_OFFSET = 0x9e3779b9
+
+export function sequenceFrom(cursor: number): () => number {
+  const seed = (Math.max(0, Math.floor(cursor)) + SEQUENCE_OFFSET) >>> 0
+  const rng = createRng(seed)
+  return () => rng.nextUint32() / 0x1_0000_0000
 }
 
 /**

--- a/dynawalla/dynawalla-app/src/work/store.ts
+++ b/dynawalla/dynawalla-app/src/work/store.ts
@@ -12,10 +12,15 @@
 
 import { create } from "zustand"
 
+import { useCharacter } from "../character/store.ts"
+import { fireReaction, resetReactions, settleReactions } from "../reactions/live.ts"
+import { worldStore } from "../world/live.ts"
 import { idleScheduler } from "./idle.ts"
+import { FIRST_ACROSS_ZERO } from "./ladder.ts"
 import { expose, measure, now, record } from "./metrics.ts"
-import { DEFAULT_PROFILE_ID } from "./profile.ts"
+import { DEFAULT_PROFILE_ID } from "../app/profile.ts"
 import { createProgressStore } from "./progress.ts"
+import { respond, type Response } from "./respond.ts"
 import { advance, commit, pressKey, prepare, startSession, type SessionState } from "./session.ts"
 import type { EntryKey } from "./entry.ts"
 
@@ -31,10 +36,20 @@ interface PracticeState {
   session: SessionState | null
   /** When the current verdict landed, for the feedback→next-ready span. */
   feedbackAt: number | null
+  /**
+   * The reaction and the remark this verdict earned, waiting for the frame
+   * after the one that paints it. Nothing on the answer path touches the world
+   * except the placement itself, which is one integer and has to be synchronous
+   * — the aperture appears *with* the verdict or it is not the same event.
+   */
+  pending: Response | null
+  /** Has the ladder crossed into the across-zero rungs during this session? */
+  arrived: boolean
   begin: () => void
   press: (key: EntryKey) => void
   commitAnswer: () => void
   next: () => void
+  react: () => void
   runIdle: () => void
   end: () => void
 }
@@ -50,6 +65,8 @@ function savePosition(session: SessionState): void {
 export const usePractice = create<PracticeState>()((set, get) => ({
   session: null,
   feedbackAt: null,
+  pending: null,
+  arrived: false,
 
   begin: () => {
     if (get().session !== null) return
@@ -60,11 +77,17 @@ export const usePractice = create<PracticeState>()((set, get) => ({
       rungCorrect: saved.rungCorrect,
       seedCursor: saved.seedCursor,
     })
-    set({ session, feedbackAt: null })
+    // A new session refills the once-a-session reaction budget and empties the
+    // character's memory of what he has already said. Both are per session by
+    // design; neither is persisted.
+    resetReactions()
+    useCharacter.getState().reset()
+    set({ session, feedbackAt: null, pending: null, arrived: false })
     savePosition(session)
   },
 
   press: (key) => {
+    settleReactions()
     const session = get().session
     if (session === null) return
     const next = pressKey(session, key)
@@ -72,24 +95,62 @@ export const usePractice = create<PracticeState>()((set, get) => ({
   },
 
   commitAnswer: () => {
+    settleReactions()
     const session = get().session
     if (session === null) return
     const next = measure("commitToJudgement", () => commit(session))
     if (next === session) return
-    set({ session: next, feedbackAt: now() })
+
+    // The world moves with the verdict, not after it: one integer, so the
+    // aperture is in the same paint as the seated answer. Everything else the
+    // response needs — the reaction, the character — waits for `react()`.
+    const correct = next.feedback?.kind === "seated"
+    const placed = correct ? worldStore.getState().placeOne() : worldStore.getState().placed
+    set({
+      session: next,
+      feedbackAt: now(),
+      pending: respond(session.card, correct, placed),
+    })
 
     const progress = progressStore.getState()
-    progress.recordAnswer(next.feedback?.kind === "seated")
+    progress.recordAnswer(correct)
     const latest = next.log[next.log.length - 1]
     if (latest?.kind === "diagnosed") progress.countBug(latest.misconception)
     savePosition(next)
   },
 
+  /**
+   * Fire what the verdict earned. Called from the frame after the verdict
+   * painted, so a reaction can never be in front of the thing it reacts to,
+   * and never delays it.
+   */
+  react: () => {
+    const { pending, session } = get()
+    if (pending === null || session === null) return
+    set({ pending: null })
+    fireReaction(pending.outcome)
+    if (pending.observation !== null) {
+      useCharacter.getState().observe(pending.observation, session.served)
+    }
+  },
+
   next: () => {
+    settleReactions()
     const session = get().session
     if (session === null) return
     const advanced = advance(session)
-    set({ session: advanced, feedbackAt: null })
+    // "First time on these" is a fact about the ladder moving, so it is read
+    // here rather than persisted. A child who resumes already above the line
+    // has not just arrived and is not told they have.
+    const crossed =
+      !get().arrived &&
+      FIRST_ACROSS_ZERO >= 0 &&
+      session.card.rung < FIRST_ACROSS_ZERO &&
+      advanced.card.rung >= FIRST_ACROSS_ZERO
+    set({ session: advanced, feedbackAt: null, pending: null, arrived: get().arrived || crossed })
+    if (crossed) {
+      useCharacter.getState().observe({ kind: "arrived", apertures: null }, advanced.served)
+    }
     savePosition(advanced)
   },
 
@@ -107,7 +168,11 @@ export const usePractice = create<PracticeState>()((set, get) => ({
     }
   },
 
-  end: () => set({ session: null, feedbackAt: null }),
+  end: () => {
+    settleReactions()
+    useCharacter.getState().hush()
+    set({ session: null, feedbackAt: null, pending: null, arrived: false })
+  },
 }))
 
 /**

--- a/dynawalla/dynawalla-app/src/work/store.ts
+++ b/dynawalla/dynawalla-app/src/work/store.ts
@@ -13,7 +13,7 @@
 import { create } from "zustand"
 
 import { useCharacter } from "../character/store.ts"
-import { fireReaction, resetReactions, settleReactions } from "../reactions/live.ts"
+import { fireReaction, resetReactions, seedReactions, settleReactions } from "../reactions/live.ts"
 import { worldStore } from "../world/live.ts"
 import { idleScheduler } from "./idle.ts"
 import { FIRST_ACROSS_ZERO } from "./ladder.ts"
@@ -21,7 +21,16 @@ import { expose, measure, now, record } from "./metrics.ts"
 import { DEFAULT_PROFILE_ID } from "../app/profile.ts"
 import { createProgressStore } from "./progress.ts"
 import { respond, type Response } from "./respond.ts"
-import { advance, commit, pressKey, prepare, startSession, type SessionState } from "./session.ts"
+import {
+  advance,
+  arrivesAcrossZero,
+  commit,
+  pressKey,
+  prepare,
+  sequenceFrom,
+  startSession,
+  type SessionState,
+} from "./session.ts"
 import type { EntryKey } from "./entry.ts"
 
 export const progressStore = createProgressStore(DEFAULT_PROFILE_ID)
@@ -48,10 +57,56 @@ interface PracticeState {
   begin: () => void
   press: (key: EntryKey) => void
   commitAnswer: () => void
+  /** The child moved on. Settles whatever is playing, because they acted. */
   next: () => void
+  /**
+   * The hold expired and the app moved on by itself.
+   *
+   * Deliberately **not** `next`. `next` settles the reaction, which is right
+   * when a finger or a key caused it and wrong when a timer did: the hold is
+   * 420 ms and the MECHANISM is 1800, so routing the auto-advance through
+   * `next` cut every reaction above SEAT to about a quarter of its budget,
+   * mid-motion. Measured in the real app at `placed = 20`: first ink 38 ms,
+   * last ink 594 ms of an 1800 ms tier.
+   *
+   * EXPERIENCE_DESIGN already says what should happen — "the next problem
+   * presents concurrently with the reaction tail" — and this is that. The card
+   * changes on time, the reaction plays out over it, and the first thing the
+   * child touches still settles it inside `Q-04`'s 90 ms.
+   */
+  autoAdvance: () => void
   react: () => void
   runIdle: () => void
   end: () => void
+}
+
+/**
+ * Move to the next card. `settle` is what separates a finger from a timer.
+ *
+ * Factored out so the two entry points cannot drift: the arrival rule, the
+ * persistence and the pending-reaction reset are written once.
+ */
+function present(
+  get: () => PracticeState,
+  set: (partial: Partial<PracticeState>) => void,
+  settle: boolean,
+): void {
+  if (settle) settleReactions()
+  const session = get().session
+  if (session === null) return
+  const advanced = advance(session)
+  // "First time on these" is a fact about the *ladder* reaching the across-zero
+  // rungs, so it is read off the card the ladder just served. It used to be
+  // read off any rung increase between two cards, and the repair rung and the
+  // first across-zero rung are the same index — so the line fired the first
+  // time a child got one wrong three rungs lower and was handed the repair
+  // item, then latched, so the real arrival was silent.
+  const crossed = !get().arrived && arrivesAcrossZero(advanced.card)
+  set({ session: advanced, feedbackAt: null, pending: null, arrived: get().arrived || crossed })
+  if (crossed) {
+    useCharacter.getState().observe({ kind: "arrived", apertures: null }, advanced.served)
+  }
+  savePosition(advanced)
 }
 
 function savePosition(session: SessionState): void {
@@ -82,7 +137,19 @@ export const usePractice = create<PracticeState>()((set, get) => ({
     // design; neither is persisted.
     resetReactions()
     useCharacter.getState().reset()
-    set({ session, feedbackAt: null, pending: null, arrived: false })
+    // Which effect plays and which line he says are now a function of where the
+    // session is, not of `Math.random`, so a replayed session replays them.
+    const sequence = sequenceFrom(saved.seedCursor)
+    seedReactions(sequence)
+    useCharacter.getState().seed(sequence)
+    // A child who resumes already above the line has not just arrived and is
+    // not told they have.
+    set({
+      session,
+      feedbackAt: null,
+      pending: null,
+      arrived: session.rung >= FIRST_ACROSS_ZERO,
+    })
     savePosition(session)
   },
 
@@ -135,23 +202,11 @@ export const usePractice = create<PracticeState>()((set, get) => ({
   },
 
   next: () => {
-    settleReactions()
-    const session = get().session
-    if (session === null) return
-    const advanced = advance(session)
-    // "First time on these" is a fact about the ladder moving, so it is read
-    // here rather than persisted. A child who resumes already above the line
-    // has not just arrived and is not told they have.
-    const crossed =
-      !get().arrived &&
-      FIRST_ACROSS_ZERO >= 0 &&
-      session.card.rung < FIRST_ACROSS_ZERO &&
-      advanced.card.rung >= FIRST_ACROSS_ZERO
-    set({ session: advanced, feedbackAt: null, pending: null, arrived: get().arrived || crossed })
-    if (crossed) {
-      useCharacter.getState().observe({ kind: "arrived", apertures: null }, advanced.served)
-    }
-    savePosition(advanced)
+    present(get, set, true)
+  },
+
+  autoAdvance: () => {
+    present(get, set, false)
   },
 
   runIdle: () => {

--- a/dynawalla/dynawalla-app/src/work/surface.test.ts
+++ b/dynawalla/dynawalla-app/src/work/surface.test.ts
@@ -69,6 +69,36 @@ test("the verdict row is in the layout before there is a verdict", () => {
   )
 })
 
+test("input settles a reaction; the clock does not", () => {
+  // The whole of the headline bug, as a shape. `settleNow()` on the first line
+  // of every input handler is protection for the child — nobody waits on an
+  // animation. Routing the hold timer through the same door was not: the hold
+  // is 420 ms and the MECHANISM is 1800, so the app's own auto-advance killed
+  // every reaction above SEAT at about a quarter of its budget, mid-motion.
+  // Measured at 38 → 594 ms of an 1800 ms tier, in the real app.
+  //
+  // Two entry points, and the timer takes the one that does not settle.
+  assert.match(practice, /setTimeout\(autoAdvance, hold\)/, "the hold timer calls something else")
+  assert.ok(
+    !/setTimeout\(next\b/.test(practice),
+    "the hold timer is routed through `next`, which settles the reaction",
+  )
+
+  // …and `next` is still what a finger and a key get.
+  assert.match(practice, /onPress=\{next\}/, "the Next plate no longer settles")
+  assert.match(practice, /else next\(\)/, "Enter no longer settles")
+
+  const storeSource = read("store.ts")
+  const body = (name: string): string =>
+    new RegExp(`\\n  ${name}: \\([^)]*\\) => \\{([\\s\\S]*?)\\n  \\},`).exec(storeSource)?.[1] ?? ""
+  assert.match(body("press"), /^\s*settleReactions\(\)/, "press does not settle first")
+  assert.match(body("commitAnswer"), /^\s*settleReactions\(\)/, "commitAnswer does not settle first")
+  assert.ok(
+    !/settleReactions\(\)/.test(body("autoAdvance")),
+    "the auto-advance settles the reaction it was supposed to let play",
+  )
+})
+
 test("the keypad is disabled while a verdict shows, not unmounted", () => {
   // Unmounting it pulls the action row up the screen at the exact moment the
   // child is looking at their answer.
@@ -113,12 +143,81 @@ test("the stopping point offers two plates and emphasises neither", () => {
   )
 })
 
-test("touch targets are big enough for a child's finger", () => {
-  // ≥2 cm. `min-h-19` is 4.75 rem = 76 px = 2.0 cm at the 96 dpi CSS reference.
-  const target = /min-h-(\d+)/.exec(keypad)
-  assert.ok(target !== null)
-  const rem = Number(target[1]) * 0.25
-  assert.ok(rem * 16 >= 75, `keypad targets are ${String(rem * 16)} px, under the 2 cm floor`)
+test("touch targets are big enough for a child's finger, at every viewport height", () => {
+  // ≥2 cm on the diagonal, computed from the vertical scale rather than read
+  // off one class name. The key height now comes down under 720 px of viewport
+  // height so the surface fits a short phone at all, and the thing that must
+  // hold across that change is the target, not the number.
+  //
+  // Width is the constraint that makes the short one legal: at 320 px — the
+  // narrowest width this app ships to — the frame leaves 248 px for three
+  // columns and two 8 px gaps, so a key is 77 px across. The diagonal is what
+  // a finger lands on.
+  assert.match(keypad, /min-h-\[var\(--dw-key-height\)\]/, "the keypad names its own height again")
+
+  const heights = [...tokens.matchAll(/--dw-key-height:\s*([\d.]+)rem/g)].map((m) => Number(m[1]) * 16)
+  assert.ok(heights.length >= 2, "the vertical scale has no short-viewport key height")
+
+  // The narrowest a key can be: 320 px, less the frame's 16 px each side, less
+  // the roomiest recess padding in the scale, less two 8 px gaps, over three
+  // columns. Conservative on purpose — the short rungs pad *less*, so their
+  // keys are wider than this — and derived from the stylesheet rather than
+  // pinned, so a change to the padding scale is a change to this number.
+  const pads = [...tokens.matchAll(/--dw-frame-pad:\s*([\d.]+)rem/g)].map((m) => Number(m[1]) * 16)
+  const width = (320 - 2 * 16 - 2 * Math.max(...pads) - 2 * 8) / 3
+
+  // 2 cm at the 96 dpi CSS reference is 75.6 px.
+  for (const height of heights) {
+    const diagonal = Math.hypot(width, height)
+    assert.ok(
+      diagonal >= 75.6,
+      `a ${String(Math.round(width))} × ${String(height)} key is ${String(Math.round(diagonal))} px on the diagonal, under 2 cm`,
+    )
+  }
+})
+
+test("the commit control is reachable without scrolling, at any viewport height", () => {
+  // Measured in a browser by `bench-reactions.mjs`; asserted here as the
+  // mechanism that makes it true, because the failure is silent. At 320 × 568
+  // and 360 × 640 the document was 878 px and the Check plate's bottom edge sat
+  // at 833 — below the fold at both — so a child on a small phone scrolled to
+  // submit every single answer. Two halves: the surface comes down a scale on
+  // shorter viewports until it fits, and the plate that ends a card is pinned
+  // to the viewport rather than to the end of the stack.
+  assert.match(practice, /sticky bottom-\[var\(--safe-bottom\)\]/, "the action row is not pinned")
+  // Above the home indicator, not under it.
+  assert.ok(!/sticky bottom-0\b/.test(practice), "the action row is pinned under the safe-area inset")
+  // …and it carries a ground, or the keypad scrolls through it.
+  const pinned = /className="([^"]*sticky[^"]*)"/.exec(practice)?.[1] ?? ""
+  assert.match(pinned, /bg-ground-sunk/, "the pinned row is transparent")
+
+  // Every metric on the vertical budget comes down at every rung. One that does
+  // not is how the budget stops adding up: the first cut of this scale left the
+  // lintel out and 320 × 568 missed by five pixels, which is the same failure
+  // as missing by two hundred.
+  const rungs = ["max-height: 900px", "max-height: 720px", "max-height: 620px"]
+  const shrinking = [
+    "--dw-frame-pad",
+    "--dw-stack-gap",
+    "--dw-stack-gap-tight",
+    "--dw-surface-pad",
+    "--dw-lintel-pad",
+  ]
+  for (const rung of rungs) {
+    const block = new RegExp(`@media \\(${rung}\\) \\{([^}]*)\\}`).exec(tokens)?.[1]
+    assert.ok(block !== undefined, `the vertical scale has no ${rung} rung`)
+    for (const token of shrinking) {
+      assert.match(block, new RegExp(`${token}:`), `${token} does not come down at ${rung}`)
+    }
+  }
+  // The two shortest rungs also give up type and target size, which the roomier
+  // one does not have to.
+  for (const rung of ["max-height: 720px", "max-height: 620px"]) {
+    const block = new RegExp(`@media \\(${rung}\\) \\{([^}]*)\\}`).exec(tokens)?.[1] ?? ""
+    for (const token of ["--dw-band-height", "--dw-key-height", "--dw-numeral-size"]) {
+      assert.match(block, new RegExp(`${token}:`), `${token} does not come down at ${rung}`)
+    }
+  }
 })
 
 test("input is bound on pointerdown, not click", () => {

--- a/dynawalla/dynawalla-app/src/work/ui/Keypad.tsx
+++ b/dynawalla/dynawalla-app/src/work/ui/Keypad.tsx
@@ -10,10 +10,16 @@ import type { AnswerSchema } from "../curriculum.ts"
  * decimal model adds the locale's separator — which is the point of the entry
  * layer being a declared structure rather than a text field.
  *
- * Targets are ≥2 cm on the diagonal a child actually hits: `min-h-19` is 4.75 rem
- * = 76 px = 2.0 cm at the 96 dpi CSS reference, and three columns of them still
- * fit inside 320 px. Bound on `pointerdown`, so the acknowledgement is in the
- * frame the finger lands in rather than ~100 ms later when the tap resolves.
+ * Targets are ≥2 cm on the diagonal a child actually hits. The height comes
+ * from `--dw-key-height` in the vertical scale: 4.75 rem = 76 px on a normal
+ * viewport, and 3.25 rem = 52 px under 720 px of viewport height, where the
+ * whole surface has to fit or the child scrolls to press Check on every card.
+ * Three columns still fit inside 320 px, which makes a key 77 px wide — so the
+ * short-viewport key is 77 × 52, a 93 px diagonal, 2.46 cm. Over the floor at
+ * both sizes, and `surface.test.ts` computes that rather than trusting it.
+ *
+ * Bound on `pointerdown`, so the acknowledgement is in the frame the finger
+ * lands in rather than ~100 ms later when the tap resolves.
  */
 export function Keypad({
   model,
@@ -78,7 +84,7 @@ function KeyPlate({
         // with `detail === 0`. A real tap already ran on pointer-down.
         if (event.detail === 0) press()
       }}
-      className="border-line-strong rounded-cut-md bg-ground-raised text-ink numeral active:bg-ground-sunk flex min-h-19 items-center justify-center border text-2xl transition-colors duration-[var(--dw-motion-quick)] disabled:opacity-40"
+      className="border-line-strong rounded-cut-md bg-ground-raised text-ink numeral active:bg-ground-sunk flex min-h-[var(--dw-key-height)] items-center justify-center border text-2xl transition-colors duration-[var(--dw-motion-quick)] disabled:opacity-40"
     >
       {cap.kind === "glyph" ? cap.glyph : "⌫"}
     </button>

--- a/dynawalla/dynawalla-app/src/work/ui/ProblemSlate.tsx
+++ b/dynawalla/dynawalla-app/src/work/ui/ProblemSlate.tsx
@@ -1,3 +1,4 @@
+import { ANCHOR_SEAT } from "../../design/anchors.ts"
 import { IndexMark } from "../../design/IndexMark.tsx"
 import { strings } from "../../app/strings.ts"
 import type { Card, Feedback } from "../session.ts"
@@ -80,6 +81,10 @@ export function ProblemSlate({
             the wrong thing about where the interesting part of the app is. */}
         <div
           className={[
+            // The reaction stage's `seat` anchor. It styles nothing; it is how
+            // the canvas finds this row without either side importing the
+            // other (`src/design/anchors.ts`).
+            ANCHOR_SEAT,
             "border-b-2 py-1",
             feedback === null ? "border-index" : struck ? "border-line" : "border-seat",
             struck ? "text-strike line-through decoration-2" : seated ? "text-seat" : "text-ink",
@@ -87,9 +92,12 @@ export function ProblemSlate({
             rebuffClass(entry),
           ].join(" ")}
         >
-          {/* Labelled, not live: the verdict well below is the one live region on
-              this screen. Announcing the answer line too would read every digit
-              twice — once as the key pressed, once as the line it landed on.
+          {/* Labelled, not live: the verdict well below is the live region for
+              the work surface. Announcing the answer line too would read every
+              digit twice — once as the key pressed, once as the line it landed
+              on. (The construction band has its own, for the character. They
+              are both polite, so they queue rather than interrupt each other on
+              the rare card where both have something to say.)
 
               A no-break space, not an ordinary one: an empty line box collapses
               and the row loses its height in the instant before the first digit

--- a/dynawalla/dynawalla-app/src/work/ui/ProblemSlate.tsx
+++ b/dynawalla/dynawalla-app/src/work/ui/ProblemSlate.tsx
@@ -47,7 +47,10 @@ export function ProblemSlate({
 
   return (
     <div className="dw-present flex justify-center">
-      <div className="dw-slate numeral text-right text-3xl leading-tight">
+      {/* The numeral size is the vertical scale's, not a literal: four rows of
+          `text-3xl` are 222 px of a 568 px viewport, and on a short phone that
+          is the difference between pressing Check and scrolling to find it. */}
+      <div className="dw-slate numeral text-right text-[length:var(--dw-numeral-size)] leading-tight">
         <div className="text-ink py-1">{problem.top}</div>
 
         {/* The operator is `absolute` in the gutter the reservation cut for it.

--- a/dynawalla/dynawalla-app/src/work/work.css
+++ b/dynawalla/dynawalla-app/src/work/work.css
@@ -46,9 +46,13 @@
      screen with it, on every wrong answer — the reflow promised against above.
      `bench-loop.mjs` reported `maxKeypadShiftPx` 7.5 as soon as the driver
      started answering some cards wrong; the all-correct driver never could,
-     because a seated verdict is an 8 px mark that fits. */
+     because a seated verdict is an 8 px mark that fits.
+
+     `--dw-numeral-size`, not `--text-3xl`: the slate's numerals come down a
+     step under 720 px of viewport height, and a well reserved from the taller
+     size would put the reflow back the moment they did. */
   .dw-verdict-well {
-    min-height: calc(var(--text-3xl) * 1.25 + 0.25rem);
+    min-height: calc(var(--dw-numeral-size) * 1.25 + 0.25rem);
   }
 
   /* A correct answer seats: the row drops into a recess and the rule under it

--- a/dynawalla/dynawalla-app/src/world/Cartouche.tsx
+++ b/dynawalla/dynawalla-app/src/world/Cartouche.tsx
@@ -1,0 +1,57 @@
+import { ANCHOR_APERTURE } from "../design/anchors.ts"
+import { strings, fill } from "../app/strings.ts"
+import { cellCutAt, rosetteCells, ROSETTE } from "./rosette.ts"
+import { rosetteOnBench } from "./construction.ts"
+
+const CENTRE = { x: ROSETTE.radius + 1, y: ROSETTE.radius + 1 }
+const SPAN = (ROSETTE.radius + 1) * 2
+const CELLS = rosetteCells(CENTRE)
+
+/**
+ * The rosette on the bench: the one the child is cutting right now.
+ *
+ * The uncut apertures are drawn as incised outlines, not omitted. A mason works
+ * to a plan, and showing it is the difference between a shape assembling and a
+ * meter filling — the child can see what the next answer does before they give
+ * it, and can see the star close at ten and the ring close at twenty without
+ * anything counting at them.
+ *
+ * Bounded at forty nodes, forever: twenty outlines and at most twenty cut
+ * cells. The world view has a different job and a different budget
+ * (`construction.ts`).
+ *
+ * The newest aperture carries the reaction layer's anchor class, which is how
+ * the stage knows where on screen to put the light without the reaction layer
+ * ever knowing what a rosette is.
+ */
+export function Cartouche({ placed, className }: { placed: number; className?: string }) {
+  const cut = rosetteOnBench(placed)
+
+  return (
+    <svg
+      role="img"
+      aria-label={fill(strings.world.cut, { apertures: placed })}
+      className={className}
+      viewBox={`0 0 ${String(SPAN)} ${String(SPAN)}`}
+      focusable="false"
+    >
+      {CELLS.map((d, cell) => (
+        <path key={`plan-${String(cell)}`} d={d} fill="none" stroke="var(--dw-line-strong)" strokeWidth="0.4" />
+      ))}
+      {Array.from({ length: cut }, (_, n) => {
+        const d = CELLS[cellCutAt(n)]
+        if (d === undefined) return null
+        return (
+          <path
+            key={`cut-${String(n)}`}
+            className={n === cut - 1 ? ANCHOR_APERTURE : undefined}
+            d={d}
+            fill="var(--dw-ground-deep)"
+            stroke="var(--dw-field-ink)"
+            strokeWidth="0.35"
+          />
+        )
+      })}
+    </svg>
+  )
+}

--- a/dynawalla/dynawalla-app/src/world/Cartouche.tsx
+++ b/dynawalla/dynawalla-app/src/world/Cartouche.tsx
@@ -23,6 +23,26 @@ const CELLS = rosetteCells(CENTRE)
  * The newest aperture carries the reaction layer's anchor class, which is how
  * the stage knows where on screen to put the light without the reaction layer
  * ever knowing what a rosette is.
+ *
+ * ## The rim is heavier here than in the world view, and that is the point
+ *
+ * This drawing ships at 44 px. The rosette's radius is 10 units, so a span of
+ * 22 units renders at two pixels per unit — and a 0.35-unit rim is 0.7 of a
+ * device-independent pixel, which is not a line, it is a suggestion. In dark,
+ * where the cut fill and the band it is cut into were two steps of the same
+ * basalt, that rim was the whole of the difference between a cut cell and an
+ * uncut one, and it was not carrying it: at 44 px the cartouche read as
+ * outlines with no discernible change from one aperture to nineteen. The world
+ * view draws the same geometry five to twelve times larger and keeps the fine
+ * rim; this one gets 0.45 units, because the size a thing is drawn at is part
+ * of the drawing.
+ *
+ * 0.45, and not more, is a rendered decision rather than a computed one. A
+ * stroke is centred on its path and these cells are two units across at the
+ * waist, so 0.9 swallowed the fill entirely and the cartouche read as a bright
+ * blue star rather than a pierced screen — a worse failure than the one it
+ * fixed, and visible only in a capture. Checked at 4 and 19 apertures in both
+ * themes; the M6 seed set takes 1 / 10 / 19 / 20 in dark so it stays checked.
  */
 export function Cartouche({ placed, className }: { placed: number; className?: string }) {
   const cut = rosetteOnBench(placed)
@@ -46,9 +66,9 @@ export function Cartouche({ placed, className }: { placed: number; className?: s
             key={`cut-${String(n)}`}
             className={n === cut - 1 ? ANCHOR_APERTURE : undefined}
             d={d}
-            fill="var(--dw-ground-deep)"
-            stroke="var(--dw-field-ink)"
-            strokeWidth="0.35"
+            fill="var(--dw-aperture)"
+            stroke="var(--dw-aperture-rim)"
+            strokeWidth="0.45"
           />
         )
       })}

--- a/dynawalla/dynawalla-app/src/world/Screen.tsx
+++ b/dynawalla/dynawalla-app/src/world/Screen.tsx
@@ -18,7 +18,7 @@ import { CHROME_NODES, screenBox, screenPieces, type Piece } from "./constructio
 function paint(piece: Piece): { fill: string; stroke: string; width: number } {
   return piece.kind === "panel"
     ? { fill: "var(--dw-line-strong)", stroke: "none", width: 0 }
-    : { fill: "var(--dw-ground-deep)", stroke: "var(--dw-field-ink)", width: 0.35 }
+    : { fill: "var(--dw-aperture)", stroke: "var(--dw-aperture-rim)", width: 0.35 }
 }
 
 /**

--- a/dynawalla/dynawalla-app/src/world/Screen.tsx
+++ b/dynawalla/dynawalla-app/src/world/Screen.tsx
@@ -1,0 +1,81 @@
+import { strings, fill } from "../app/strings.ts"
+import { CHROME_NODES, screenBox, screenPieces, type Piece } from "./construction.ts"
+
+/**
+ * The material each scale of piece is cut in.
+ *
+ * A cut aperture is a **hole**, not a highlight: the deep field behind the
+ * screen, with the lit edge of the stone catching celestial light along its
+ * rim. That is how a pierced screen reads from the lit side, and it is why the
+ * drawing survives both themes — in dark, where field and ground are nearly the
+ * same basalt, the rim is what carries it. Nothing here is legible by colour
+ * alone.
+ *
+ * The four scales are the same hole drawn at four levels of fusion, so they are
+ * deliberately the same material. A finished course does not look different
+ * from a fresh cell; it is just one node instead of a hundred.
+ */
+function paint(piece: Piece): { fill: string; stroke: string; width: number } {
+  return piece.kind === "panel"
+    ? { fill: "var(--dw-line-strong)", stroke: "none", width: 0 }
+    : { fill: "var(--dw-ground-deep)", stroke: "var(--dw-field-ink)", width: 0.35 }
+}
+
+/**
+ * The screen the child has cut, at whatever size it is given.
+ *
+ * Draws exactly `screenPieces(placed).length + CHROME_NODES` SVG elements —
+ * the identity `construction.ts` asserts, and the reason `Q-02`'s node cap is a
+ * property of the model rather than a thing somebody has to remember. The two
+ * chrome elements are the plate and its rim; they are counted below so the
+ * count in the model cannot drift from the count in the DOM.
+ */
+export function WorldScreen({ placed, className }: { placed: number; className?: string }) {
+  const pieces = screenPieces(placed)
+  const box = screenBox(placed)
+
+  return (
+    <svg
+      id="dw-world"
+      role="img"
+      aria-label={fill(strings.world.cut, { apertures: placed })}
+      className={className}
+      viewBox={`0 0 ${String(box.width)} ${String(box.height)}`}
+      focusable="false"
+    >
+      {/* Chrome, 1 of CHROME_NODES: the stone plate the screen is cut from. */}
+      <rect
+        x="0"
+        y="0"
+        width={box.width}
+        height={box.height}
+        fill="var(--dw-ground-raised)"
+        stroke="var(--dw-line-cut)"
+        strokeWidth="0.5"
+      />
+      {/* Chrome, 2 of CHROME_NODES: the sill the courses are laid on. */}
+      <rect
+        x="0"
+        y={box.height - 1}
+        width={box.width}
+        height="1"
+        fill="var(--dw-line-strong)"
+      />
+      {pieces.map((piece) => {
+        const material = paint(piece)
+        return (
+          <path
+            key={piece.key}
+            d={piece.d}
+            fill={material.fill}
+            stroke={material.stroke}
+            strokeWidth={material.width}
+          />
+        )
+      })}
+    </svg>
+  )
+}
+
+/** Exported so the boundary between the model's count and the DOM's is one number. */
+export const CHROME_IN_MARKUP = CHROME_NODES

--- a/dynawalla/dynawalla-app/src/world/construction.test.ts
+++ b/dynawalla/dynawalla-app/src/world/construction.test.ts
@@ -1,0 +1,218 @@
+// The construction is a promise with two halves, and both are testable.
+//
+//   `P-04`  it never regresses — no code path removes a placed element
+//   `Q-02`  it stays under the live-SVG-node cap, at any history
+//
+// The second one is the interesting test, because a budget that no reachable
+// input can exceed is not a gate. So the cap is asserted twice: against the
+// real model at a million apertures, where it holds with two orders of
+// magnitude of room, **and** against `unfusedNodes` — the same world drawn one
+// node per aperture, which is what this file would do if fusion had been left
+// as an optimisation for later. That one blows the cap, which is what proves
+// the cap can fail.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import {
+  aperturesIn,
+  breakdown,
+  CELLS_PER_COURSE,
+  CELLS_PER_ROSETTE,
+  CELLS_PER_SCREEN,
+  CELLS_PER_STAR,
+  CHROME_NODES,
+  COURSES_PER_SCREEN,
+  liveNodes,
+  milestoneAt,
+  NODE_CAP,
+  NOTHING_BUILT,
+  place,
+  rosetteOnBench,
+  ROSETTES_PER_COURSE,
+  screenBox,
+  screenPieces,
+  unfusedNodes,
+  VISIBLE_PANELS,
+} from "./construction.ts"
+import { CELLS_PER_ROSETTE as CELLS, CUT_ORDER, rosetteCells } from "./rosette.ts"
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+
+test("P-04: no code path in the world lowers what has been placed", () => {
+  // Read as source, not as behaviour: the claim is about what exists, and a
+  // behavioural test can only ever cover the paths somebody thought of.
+  const source = ["construction.ts", "store.ts"].map((name) =>
+    fs.readFileSync(path.join(here, name), "utf8"),
+  )
+  for (const text of source) {
+    const body = text
+      .split("\n")
+      .filter((line) => !line.trimStart().startsWith("//") && !line.trimStart().startsWith("*"))
+      .join("\n")
+    assert.equal(/placed\s*-[-=]/.test(body), false, "a decrement of `placed`")
+    assert.equal(/placed:\s*0\b/.test(body.replace(/NOTHING_BUILT[\s\S]{0,60}/, "")), false)
+  }
+})
+
+test("P-04: placing is the only transition, and it only ever adds one", () => {
+  let world = NOTHING_BUILT
+  for (let i = 1; i <= 250; i++) {
+    const before = world.placed
+    world = place(world)
+    assert.equal(world.placed, before + 1)
+  }
+})
+
+test("the milestones are the four scales, in order of rarity", () => {
+  assert.equal(milestoneAt(0), null)
+  assert.equal(milestoneAt(9), null)
+  assert.equal(milestoneAt(CELLS_PER_STAR), "star")
+  assert.equal(milestoneAt(CELLS_PER_ROSETTE), "rosette")
+  assert.equal(milestoneAt(CELLS_PER_COURSE), "course")
+  assert.equal(milestoneAt(CELLS_PER_SCREEN), "screen")
+  // A course boundary is also a rosette and a star boundary. The rarest wins,
+  // or the child gets three reactions and three remarks for one answer.
+  assert.equal(CELLS_PER_COURSE % CELLS_PER_ROSETTE, 0)
+  assert.equal(CELLS_PER_SCREEN % CELLS_PER_COURSE, 0)
+})
+
+test("aperturesIn matches the scale it names", () => {
+  assert.equal(aperturesIn("star"), CELLS_PER_STAR)
+  assert.equal(aperturesIn("rosette"), CELLS_PER_ROSETTE)
+  assert.equal(aperturesIn("course"), CELLS_PER_COURSE)
+  assert.equal(aperturesIn("screen"), CELLS_PER_SCREEN)
+})
+
+test("a session's cadence: a milestone is reachable, and they are not constant", () => {
+  // Twenty minutes is roughly forty answers. The child must be able to close a
+  // rosette in one sitting and a course over the two the M2 playtest runs, and
+  // must not be handed a milestone every few cards.
+  const inForty = [...Array(40).keys()].filter((i) => milestoneAt(i + 1) !== null).length
+  assert.ok(inForty >= 3 && inForty <= 6, `milestones in forty answers: ${String(inForty)}`)
+  assert.ok(CELLS_PER_COURSE <= 80, "a course is reachable in two sessions")
+})
+
+test("a closed thing stays on the bench until the next answer starts a new one", () => {
+  assert.equal(rosetteOnBench(0), 0)
+  assert.equal(rosetteOnBench(1), 1)
+  assert.equal(rosetteOnBench(CELLS_PER_ROSETTE), CELLS_PER_ROSETTE)
+  assert.equal(rosetteOnBench(CELLS_PER_ROSETTE + 1), 1)
+  // Same convention one scale up: finishing a whole screen must not show an
+  // empty plate at the largest milestone the product has.
+  const full = breakdown(CELLS_PER_SCREEN)
+  assert.equal(full.courses, COURSES_PER_SCREEN)
+  assert.equal(full.panels, 0)
+  const next = breakdown(CELLS_PER_SCREEN + 1)
+  assert.equal(next.panels, 1)
+  assert.equal(next.cells, 1)
+})
+
+test("Q-02: live nodes stay under the cap at any history", () => {
+  for (const placed of [0, 1, 19, 20, 50, 200, 500, 5_000, 50_000, 1_000_000]) {
+    assert.ok(
+      liveNodes(placed) <= NODE_CAP,
+      `${String(placed)} placed drew ${String(liveNodes(placed))} nodes`,
+    )
+  }
+  // Bounded by construction, not by luck: panels are occluded past
+  // VISIBLE_PANELS and everything else is one screen's worth.
+  const ceiling =
+    VISIBLE_PANELS +
+    COURSES_PER_SCREEN +
+    ROSETTES_PER_COURSE +
+    CELLS_PER_ROSETTE +
+    CHROME_NODES
+  assert.ok(ceiling < NODE_CAP / 4, `ceiling ${String(ceiling)} is not comfortably under the cap`)
+})
+
+test("Q-02: the cap is a gate — the unfused world blows it", () => {
+  // If this ever passes, fusion has stopped being load bearing and the test
+  // above has stopped meaning anything.
+  assert.ok(unfusedNodes(5_000) > NODE_CAP)
+  assert.ok(liveNodes(5_000) < unfusedNodes(5_000) / 100)
+})
+
+test("the model's node count is exactly what the drawing emits", () => {
+  for (const placed of [0, 1, 13, 20, 21, 59, 60, 61, 179, 180, 181, 900, 5_000]) {
+    assert.equal(
+      screenPieces(placed).length + CHROME_NODES,
+      liveNodes(placed),
+      `pieces + chrome != liveNodes at ${String(placed)}`,
+    )
+  }
+})
+
+test("every piece is one path with a real `d`, and keys are unique", () => {
+  for (const placed of [7, 45, 61, 181, 900]) {
+    const pieces = screenPieces(placed)
+    assert.equal(new Set(pieces.map((piece) => piece.key)).size, pieces.length)
+    for (const piece of pieces) {
+      assert.match(piece.d, /^M/, `${piece.key} is not a path`)
+      assert.ok(!piece.d.includes("NaN"), `${piece.key} has NaN in it`)
+    }
+  }
+})
+
+test("fusion is lossless: a closed course holds every aperture it closed", () => {
+  const course = screenPieces(CELLS_PER_COURSE).find((piece) => piece.kind === "course")
+  assert.ok(course !== undefined)
+  // One subpath per aperture in the course, all in one node.
+  assert.equal((course.d.match(/M/g) ?? []).length, CELLS_PER_COURSE)
+})
+
+test("the plate grows a course at a time rather than starting full", () => {
+  const one = screenBox(1)
+  const full = screenBox(CELLS_PER_SCREEN)
+  assert.equal(one.width, full.width, "a course is a course at every height")
+  assert.ok(one.height < full.height / 2, "the first rosette is not drawn on a year-sized plate")
+})
+
+test("the cut order is a permutation, star before ring", () => {
+  assert.equal(CUT_ORDER.length, CELLS)
+  assert.equal(new Set(CUT_ORDER).size, CELLS)
+  const star = CUT_ORDER.slice(0, CELLS / 2)
+  assert.ok(
+    star.every((cell) => cell < CELLS / 2),
+    "the first ten cuts must close the star",
+  )
+  // Not sequential: a ring filled in index order is a pie chart, and a filling
+  // ring is on the hostile reference board by name.
+  assert.notDeepEqual([...CUT_ORDER], [...Array(CELLS).keys()])
+})
+
+test("the twenty apertures are twenty distinct shapes", () => {
+  const cells = rosetteCells({ x: 0, y: 0 })
+  assert.equal(cells.length, CELLS)
+  assert.equal(new Set(cells).size, CELLS)
+})
+
+test("the geometry is deterministic — the same call, the same string", () => {
+  assert.deepEqual(rosetteCells({ x: 3, y: 4 }), rosetteCells({ x: 3, y: 4 }))
+})
+
+test("a rosette rejects proportions that are not a rosette", () => {
+  const at = { x: 0, y: 0 }
+  assert.throws(() => rosetteCells(at, { radius: 0, tip: 0.6, valley: 0.3, rib: 0.1 }))
+  // Valley outside tip turns the star inside out; both draw without complaint.
+  assert.throws(() => rosetteCells(at, { radius: 10, tip: 0.3, valley: 0.6, rib: 0.1 }))
+  assert.throws(() => rosetteCells(at, { radius: 10, tip: 1.4, valley: 0.3, rib: 0.1 }))
+  assert.throws(() => rosetteCells(at, { radius: 10, tip: 0.6, valley: 0.3, rib: 1 }))
+})
+
+test("Q-05: the world imports nothing from the work surface or the engine", () => {
+  const offenders: string[] = []
+  for (const name of fs.readdirSync(here)) {
+    if (!/\.(ts|tsx)$/.test(name) || name.endsWith(".test.ts")) continue
+    const text = fs.readFileSync(path.join(here, name), "utf8")
+    for (const [, specifier] of text.matchAll(/from\s+"([^"]+)"/g)) {
+      if (/(\.\.\/work\/|\.\.\/reactions\/|engine|curriculum)/.test(specifier ?? "")) {
+        offenders.push(`${name} -> ${specifier ?? ""}`)
+      }
+    }
+  }
+  assert.deepEqual(offenders, [])
+})

--- a/dynawalla/dynawalla-app/src/world/construction.test.ts
+++ b/dynawalla/dynawalla-app/src/world/construction.test.ts
@@ -32,6 +32,7 @@ import {
   NOTHING_BUILT,
   place,
   rosetteOnBench,
+  rosettesShown,
   ROSETTES_PER_COURSE,
   screenBox,
   screenPieces,
@@ -164,11 +165,41 @@ test("fusion is lossless: a closed course holds every aperture it closed", () =>
   assert.equal((course.d.match(/M/g) ?? []).length, CELLS_PER_COURSE)
 })
 
-test("the plate grows a course at a time rather than starting full", () => {
+test("the plate is cropped on both axes to what is actually built", () => {
+  // It cropped the height and never the width, so the "four fifths of an empty
+  // plate" the crop exists to prevent was simply rotated onto the horizontal —
+  // which is the axis a first session lives on. At nineteen apertures the child
+  // had one small rosette in the left third of a three-rosette-wide box.
   const one = screenBox(1)
   const full = screenBox(CELLS_PER_SCREEN)
-  assert.equal(one.width, full.width, "a course is a course at every height")
+  assert.ok(one.width < full.width / 2, "the first rosette is drawn on a course-wide plate")
   assert.ok(one.height < full.height / 2, "the first rosette is not drawn on a year-sized plate")
+
+  // Square-ish while there is one rosette: it fills its plate rather than
+  // sitting in a letterbox.
+  assert.ok(Math.abs(one.width - one.height) < 1e-9, "a single rosette is not on a square plate")
+
+  // It grows a rosette at a time to the right, then a course at a time upward.
+  assert.equal(rosettesShown(0), 1)
+  assert.equal(rosettesShown(19), 1, "the rosette on the bench is the only one there is")
+  assert.equal(rosettesShown(CELLS_PER_ROSETTE), 1, "a just-closed rosette stays alone on its plate")
+  assert.equal(rosettesShown(CELLS_PER_ROSETTE + 1), 2)
+  assert.equal(rosettesShown(CELLS_PER_COURSE), ROSETTES_PER_COURSE)
+  assert.equal(rosettesShown(CELLS_PER_SCREEN), ROSETTES_PER_COURSE, "a wall does not narrow again")
+
+  // Monotone within a screen. It resets when one is finished and set into the
+  // wall — the next screen starts from bare stone, and the finished one is a
+  // panel edge behind it — so the walk is bounded to a single screen, which is
+  // the span the crop is a claim about.
+  let widest = 0
+  let tallest = 0
+  for (let placed = 0; placed <= CELLS_PER_SCREEN; placed++) {
+    const box = screenBox(placed)
+    assert.ok(box.width >= widest, `the plate narrowed at ${String(placed)}`)
+    assert.ok(box.height >= tallest, `the plate shortened at ${String(placed)}`)
+    widest = box.width
+    tallest = box.height
+  }
 })
 
 test("the cut order is a permutation, star before ring", () => {

--- a/dynawalla/dynawalla-app/src/world/construction.ts
+++ b/dynawalla/dynawalla-app/src/world/construction.ts
@@ -1,0 +1,317 @@
+// The construction: what a correct answer actually builds, and what it means.
+//
+// One number. `placed` is the count of apertures cut into the screen, and it is
+// the only durable thing the world owns — every shape, every milestone and every
+// piece of the drawing is derived from it. That is deliberate: a model that
+// stores which cells are cut can lose one, and `P-04` says construction never
+// regresses. A monotone counter cannot regress without someone writing a
+// subtraction, and there is not one in this file. `construction.test.ts` reads
+// the module source and asserts that.
+//
+// ## The four scales, and why there are four
+//
+//   aperture  one correct answer, one cut cell
+//   rosette   20 apertures — a ten-fold star inside a ring
+//   course     3 rosettes — one row of the screen, 60 apertures
+//   screen     3 courses — a finished screen, set into the wall, 180
+//
+// The cadence is chosen against a real session rather than a round number. Ten
+// answers close the star at the middle of a rosette, so a short sitting still
+// ends on something that visibly finished. Twenty close the rosette. A
+// twenty-minute session is roughly forty answers, so the M2 playtest's two
+// sessions reach a course — and above that a long history compounds into a wall
+// rather than into a longer bar. An earlier cut had five-rosette courses and
+// five-course screens; at 100 answers to a course it put every milestone a
+// child could reach in one place and left four fifths of the plate empty for
+// weeks.
+//
+// ## Boundary
+//
+// Nothing here imports from `src/work/` or from the engine (`Q-05`). The world
+// is told that something was placed; it never asks what the problem was.
+
+import { CELLS_PER_ROSETTE, cellCutAt, fuse, ROSETTE, rosetteCells, type Vec } from "./rosette.ts"
+
+export { CELLS_PER_ROSETTE }
+
+/** Rosettes in one course — one row of the screen. */
+export const ROSETTES_PER_COURSE = 3
+/** Courses in one screen. */
+export const COURSES_PER_SCREEN = 3
+
+export const CELLS_PER_COURSE = CELLS_PER_ROSETTE * ROSETTES_PER_COURSE
+export const CELLS_PER_SCREEN = CELLS_PER_COURSE * COURSES_PER_SCREEN
+
+/** Apertures that close the star at the middle of a rosette. */
+export const CELLS_PER_STAR = CELLS_PER_ROSETTE / 2
+
+export interface Construction {
+  /** Apertures cut. Monotone, forever. */
+  readonly placed: number
+}
+
+export const NOTHING_BUILT: Construction = { placed: 0 }
+
+/**
+ * Cut one more aperture.
+ *
+ * The only transition the world has. There is no `remove`, no `reset` and no
+ * `undo`, and adding one would be a product change rather than a feature:
+ * ADR-0009 makes never-regressing construction the child-safe replacement for
+ * loss aversion, and `P-04` is the assertion that nobody quietly added a path
+ * that takes something back.
+ */
+export function place(construction: Construction): Construction {
+  return { placed: construction.placed + 1 }
+}
+
+/**
+ * What just closed, if anything.
+ *
+ * Named for the thing in the world, never for a score. The reaction layer
+ * escalates on these and the character speaks at them; nothing else consumes a
+ * milestone, and in particular nothing counts how many the child has had.
+ */
+export type Milestone = "star" | "rosette" | "course" | "screen"
+
+/** How many apertures the thing that just closed is made of. */
+export function aperturesIn(milestone: Milestone): number {
+  switch (milestone) {
+    case "star":
+      return CELLS_PER_STAR
+    case "rosette":
+      return CELLS_PER_ROSETTE
+    case "course":
+      return CELLS_PER_COURSE
+    case "screen":
+      return CELLS_PER_SCREEN
+  }
+}
+
+/** The milestone reached by placing the `placed`-th aperture, or `null`. */
+export function milestoneAt(placed: number): Milestone | null {
+  if (placed <= 0) return null
+  if (placed % CELLS_PER_SCREEN === 0) return "screen"
+  if (placed % CELLS_PER_COURSE === 0) return "course"
+  if (placed % CELLS_PER_ROSETTE === 0) return "rosette"
+  if (placed % CELLS_PER_STAR === 0) return "star"
+  return null
+}
+
+/**
+ * Apertures cut into the rosette currently on the bench: 0…20.
+ *
+ * Twenty, not zero, on the answer that closes one. The closed rosette stays on
+ * the bench until the next answer starts a new one, so the child sees the thing
+ * they finished rather than an empty plate the instant they finish it — and the
+ * MECHANISM reaction has something to play over.
+ */
+export function rosetteOnBench(placed: number): number {
+  const clamped = Math.max(0, Math.floor(placed))
+  return clamped === 0 ? 0 : ((clamped - 1) % CELLS_PER_ROSETTE) + 1
+}
+
+/**
+ * One drawable piece: exactly one `<path>` in the DOM.
+ *
+ * The offsets are baked into `d` rather than carried on a wrapping `<g>`, so
+ * the count of pieces *is* the count of live SVG nodes and `liveNodes` cannot
+ * quietly become a lie.
+ */
+export interface Piece {
+  readonly key: string
+  /** What scale this piece is drawn at. Drives its material, not its shape. */
+  readonly kind: "cell" | "rosette" | "course" | "panel"
+  readonly d: string
+}
+
+/** The whole screen's geometry, in the units `screenBox` describes. */
+export interface ScreenGeometry {
+  readonly radius: number
+  /** Centre-to-centre distance between neighbouring rosettes. */
+  readonly pitch: number
+  /** Margin between the outermost rosette and the frame. */
+  readonly margin: number
+}
+
+/**
+ * Rosettes sit at 1.9 radii apart, which is closer than they are wide.
+ *
+ * A decagon of circumradius `r` reaches `r` only at its ten vertices, and the
+ * rib inset pulls the outermost apertures back from even that — so at this
+ * pitch the cut fields nearly meet and the wall reads as one pierced screen.
+ * At 2.15 they read as a row of separate flowers on a plate, which is a
+ * pattern library rather than a building.
+ */
+export const SCREEN_GEOMETRY: ScreenGeometry = {
+  radius: ROSETTE.radius,
+  pitch: ROSETTE.radius * 1.9,
+  margin: ROSETTE.radius * 0.7,
+}
+
+/**
+ * Completed screens visible in the wall behind the current one.
+ *
+ * A stack of set panels shows its top edges and nothing more, which is both how
+ * masonry works and what keeps this drawing bounded: the hundredth finished
+ * screen adds no node, because it is behind the twelfth. The exact number is in
+ * the text alternative, where a count belongs (`Q-10`).
+ */
+export const VISIBLE_PANELS = 12
+
+/**
+ * The hard ceiling on live SVG nodes in the world, from EXPERIENCE_DESIGN.
+ *
+ * Procedural girih at 500+ answers becomes tens of thousands of live nodes and
+ * stalls a mid-range Android WebView (`Q-02`). The cap is asserted against
+ * `liveNodes` at a million placed apertures, and against the deliberately
+ * unfused reference implementation below, which blows it — so the test can
+ * fail, which is the only thing that makes it a gate.
+ */
+export const NODE_CAP = 1200
+
+/** Nodes the frame costs regardless of what is built: the ground and its rim. */
+export const CHROME_NODES = 2
+
+/**
+ * How the count of placed apertures decomposes across the four scales.
+ *
+ * Read one *behind* the boundary at every scale — the same convention as
+ * `rosetteOnBench`, for the same reason. At exactly 180 the child has just
+ * finished a whole screen, and `placed % 180 === 0` would show them a blank
+ * plate and a panel edge at the biggest milestone the product has. So a
+ * completed thing stays on the plate until the next aperture starts a new one.
+ */
+export interface Breakdown {
+  readonly panels: number
+  readonly courses: number
+  readonly rosettes: number
+  readonly cells: number
+}
+
+export function breakdown(placed: number): Breakdown {
+  const clamped = Math.max(0, Math.floor(placed))
+  if (clamped === 0) return { panels: 0, courses: 0, rosettes: 0, cells: 0 }
+  const inScreen = ((clamped - 1) % CELLS_PER_SCREEN) + 1
+  const courses = Math.floor(inScreen / CELLS_PER_COURSE)
+  const inCourse = inScreen - courses * CELLS_PER_COURSE
+  return {
+    panels: Math.floor((clamped - 1) / CELLS_PER_SCREEN),
+    courses,
+    rosettes: Math.floor(inCourse / CELLS_PER_ROSETTE),
+    cells: inCourse % CELLS_PER_ROSETTE,
+  }
+}
+
+/** Courses of the current screen that have anything in them: 1…3. */
+export function coursesShown(placed: number): number {
+  const { courses, rosettes, cells } = breakdown(placed)
+  return Math.max(1, Math.min(courses + (rosettes + cells > 0 ? 1 : 0), COURSES_PER_SCREEN))
+}
+
+/**
+ * The drawing's own coordinate box, cropped to what has been built.
+ *
+ * A fixed box would mean a first session spent looking at four fifths of an
+ * empty plate — the wall drawn at the size it will be in a year rather than the
+ * size it is. It grows a course at a time, upward, the way it is built.
+ */
+export function screenBox(placed: number): { readonly width: number; readonly height: number } {
+  const { pitch, margin } = SCREEN_GEOMETRY
+  return {
+    width: pitch * ROSETTES_PER_COURSE + margin * 2,
+    height: pitch * coursesShown(placed) + margin * 2,
+  }
+}
+
+function rosetteCentre(index: number, box: { readonly height: number }): Vec {
+  const { pitch, margin } = SCREEN_GEOMETRY
+  const column = index % ROSETTES_PER_COURSE
+  const row = Math.floor(index / ROSETTES_PER_COURSE)
+  return {
+    x: margin + pitch * (column + 0.5),
+    // Courses are laid bottom upward, the way a wall is built. SVG y grows
+    // downward, so row 0 is the last row of the box.
+    y: box.height - margin - pitch * (row + 0.5),
+  }
+}
+
+/**
+ * Live SVG nodes the world draws at `placed`, without building any of them.
+ *
+ * Bounded by construction rather than by a budget somebody remembers to check:
+ * at most `VISIBLE_PANELS` panels, four whole courses, four whole rosettes and
+ * nineteen loose cells, whatever the child has done. The ceiling is ~45.
+ */
+export function liveNodes(placed: number): number {
+  const { panels, courses, rosettes, cells } = breakdown(placed)
+  return Math.min(panels, VISIBLE_PANELS) + courses + rosettes + cells + CHROME_NODES
+}
+
+/** One completed screen, seen edge-on in the stack behind the current one. */
+function panelEdge(depth: number, box: { readonly width: number }): string {
+  const { margin } = SCREEN_GEOMETRY
+  const step = margin * 0.3
+  const y = margin * 0.55 - depth * step
+  const inset = margin * 0.4 + depth * step * 0.8
+  const x0 = inset
+  const x1 = box.width - inset
+  const h = step * 0.5
+  return `M${String(x0)} ${String(y)}H${String(x1)}V${String(y + h)}H${String(x0)}Z`
+}
+
+/**
+ * Every piece of the world at `placed`, newest last.
+ *
+ * Fusion is what makes this bounded: a finished rosette is one path holding
+ * twenty subpaths, a finished course is one path holding a hundred. The pieces
+ * a child is *currently* cutting stay separate, because those are the ones that
+ * have to be able to light up one at a time.
+ */
+export function screenPieces(placed: number): Piece[] {
+  const { panels, courses, rosettes, cells } = breakdown(placed)
+  const box = screenBox(placed)
+  const pieces: Piece[] = []
+
+  for (let depth = Math.min(panels, VISIBLE_PANELS); depth > 0; depth--) {
+    pieces.push({ key: `panel-${String(depth)}`, kind: "panel", d: panelEdge(depth - 1, box) })
+  }
+
+  for (let course = 0; course < courses; course++) {
+    const paths: string[] = []
+    for (let index = 0; index < ROSETTES_PER_COURSE; index++) {
+      paths.push(...rosetteCells(rosetteCentre(course * ROSETTES_PER_COURSE + index, box)))
+    }
+    pieces.push({ key: `course-${String(course)}`, kind: "course", d: fuse(paths) })
+  }
+
+  const base = courses * ROSETTES_PER_COURSE
+  for (let index = 0; index < rosettes; index++) {
+    pieces.push({
+      key: `rosette-${String(base + index)}`,
+      kind: "rosette",
+      d: fuse(rosetteCells(rosetteCentre(base + index, box))),
+    })
+  }
+
+  const live = rosetteCells(rosetteCentre(base + rosettes, box))
+  for (let n = 0; n < cells; n++) {
+    const cell = live[cellCutAt(n)]
+    if (cell === undefined) continue
+    pieces.push({ key: `cell-${String(n)}`, kind: "cell", d: cell })
+  }
+
+  return pieces
+}
+
+/**
+ * The same world, drawn the obvious way: one node per aperture, forever.
+ *
+ * Not used by the app. It exists so `construction.test.ts` can show the cap
+ * being blown — a budget that no reachable input can exceed is not a gate, it
+ * is a comment. This is the implementation this file would have had if fusion
+ * were an optimisation to add later, and at 5,000 answers it is over `NODE_CAP`.
+ */
+export function unfusedNodes(placed: number): number {
+  return Math.max(0, Math.floor(placed)) + CHROME_NODES
+}

--- a/dynawalla/dynawalla-app/src/world/construction.ts
+++ b/dynawalla/dynawalla-app/src/world/construction.ts
@@ -210,16 +210,37 @@ export function coursesShown(placed: number): number {
 }
 
 /**
+ * Rosettes of the bottom course that have anything in them: 1…3.
+ *
+ * The horizontal half of the crop, and the half a first session actually lives
+ * on. The box grew a *course* at a time and was always three rosettes wide, so
+ * a child with nineteen apertures — most of a first sitting — got one small
+ * flower in the left third of a wide empty plate, which is exactly the "four
+ * fifths of an empty plate" `screenBox` says it exists to avoid. Once any
+ * course is complete the wall is three wide and stays three wide.
+ */
+export function rosettesShown(placed: number): number {
+  const { courses, rosettes, cells } = breakdown(placed)
+  if (courses > 0) return ROSETTES_PER_COURSE
+  return Math.max(1, Math.min(rosettes + (cells > 0 ? 1 : 0), ROSETTES_PER_COURSE))
+}
+
+/**
  * The drawing's own coordinate box, cropped to what has been built.
  *
  * A fixed box would mean a first session spent looking at four fifths of an
  * empty plate — the wall drawn at the size it will be in a year rather than the
- * size it is. It grows a course at a time, upward, the way it is built.
+ * size it is. It grows a rosette at a time to the right and a course at a time
+ * upward, the way it is built.
+ *
+ * Both axes, and the first cut only did one. The height cropped and the width
+ * never did, so the letterbox the crop exists to prevent was simply rotated
+ * ninety degrees onto the axis a first session spends all its time on.
  */
 export function screenBox(placed: number): { readonly width: number; readonly height: number } {
   const { pitch, margin } = SCREEN_GEOMETRY
   return {
-    width: pitch * ROSETTES_PER_COURSE + margin * 2,
+    width: pitch * rosettesShown(placed) + margin * 2,
     height: pitch * coursesShown(placed) + margin * 2,
   }
 }
@@ -239,9 +260,14 @@ function rosetteCentre(index: number, box: { readonly height: number }): Vec {
 /**
  * Live SVG nodes the world draws at `placed`, without building any of them.
  *
- * Bounded by construction rather than by a budget somebody remembers to check:
- * at most `VISIBLE_PANELS` panels, four whole courses, four whole rosettes and
- * nineteen loose cells, whatever the child has done. The ceiling is ~45.
+ * Bounded by construction rather than by a budget somebody remembers to check.
+ * The reachable maximum is `VISIBLE_PANELS` panels plus the decomposition of
+ * one screen — and the decomposition's terms are not independent: `courses`
+ * reaches 3 only when `rosettes` and `cells` are both 0. The worst case is
+ * 2 courses + 2 rosettes + 19 cells, so the true ceiling is
+ * 12 + 2 + 2 + 19 + 2 = **37**. (`Q-02` is scoped to `/world`; the practice
+ * surface's `Cartouche` draws its own fixed 40 — twenty plan outlines and at
+ * most twenty cuts — and is bounded in that component.)
  */
 export function liveNodes(placed: number): number {
   const { panels, courses, rosettes, cells } = breakdown(placed)

--- a/dynawalla/dynawalla-app/src/world/live.ts
+++ b/dynawalla/dynawalla-app/src/world/live.ts
@@ -1,0 +1,11 @@
+// The one world the app has, for the one profile it has.
+//
+// A module-level instance beside the factory rather than inside it, the same
+// shape `src/work/` uses for progress: the factory is what `Q-12` needs to
+// build three of, and this is what the app reads. The M9 profile switcher
+// replaces this line and nothing else.
+
+import { DEFAULT_PROFILE_ID, storageKey } from "../app/profile.ts"
+import { createWorldStore } from "./store.ts"
+
+export const worldStore = createWorldStore(storageKey(DEFAULT_PROFILE_ID, "world"))

--- a/dynawalla/dynawalla-app/src/world/rosette.ts
+++ b/dynawalla/dynawalla-app/src/world/rosette.ts
@@ -1,0 +1,186 @@
+// The girih rosette, as geometry.
+//
+// One correct answer cuts one aperture out of a stone screen. Twenty apertures
+// make a rosette: a ten-fold star surrounded by a ring of rhombi, with the
+// uncut stone left standing between them as ribs. This module is the shape of
+// that, and nothing else — no DOM, no colour, no React, no state. Colour
+// arrives from the tokens at the call site.
+//
+// Girih as **structure, not wallpaper** (EXPERIENCE_DESIGN, art direction). The
+// cells are not a decorative pattern laid over a progress meter; they are the
+// pieces the screen is actually made of, and the light comes through exactly
+// the ones that have been cut.
+//
+// Everything here is a pure function of its arguments, so the screen is
+// byte-identical on every device — the same determinism rule the exercise
+// generators live under (GATES CG-16), and what makes the committed screenshot
+// set worth comparing.
+//
+// ## Why the cut order is not 0,1,2,…
+//
+// Sequential cells fill the ring like a pie chart, and a filling ring is on the
+// hostile reference board by name. Cutting in opposing pairs — 0, 5, 1, 6, … —
+// grows the star outward from a balanced cross instead. It reads as a thing
+// being built, which is what it is.
+
+/** A point in the rosette's own user-unit space. */
+export interface Vec {
+  readonly x: number
+  readonly y: number
+}
+
+/** Ten-fold symmetry: the fold of the Persian rosette, and the reason 20 cells. */
+export const FOLD = 10
+
+/** Apertures in one rosette: ten star cells, then ten ring cells. */
+export const CELLS_PER_ROSETTE = FOLD * 2
+
+export interface RosetteSpec {
+  /** Centre-to-outer-vertex distance, in user units. */
+  readonly radius: number
+  /** Star tip radius, as a fraction of `radius`. */
+  readonly tip: number
+  /** Star valley radius, as a fraction of `radius`. */
+  readonly valley: number
+  /**
+   * How far each aperture is drawn back from its ideal edge, as a fraction of
+   * its own size. This is the stone that stays: at 0 the cells tile the whole
+   * decagon and the screen is a hole, and the rosette stops being a rosette.
+   */
+  readonly rib: number
+}
+
+/** The proportions the app draws at. Chunky enough to read at 24 px. */
+export const ROSETTE: RosetteSpec = { radius: 10, tip: 0.62, valley: 0.3, rib: 0.1 }
+
+/** Three decimals is finer than a device pixel and keeps the output exact. */
+const r3 = (n: number): string => String(Math.round(n * 1000) / 1000)
+
+const TURN = Math.PI * 2
+
+/**
+ * A point at `turns` around the circle, `radius` out. Zero turns points up, so
+ * a rosette has a tip at twelve o'clock rather than at three.
+ */
+function polar(centre: Vec, radius: number, turns: number): Vec {
+  const angle = (turns - 0.25) * TURN
+  return { x: centre.x + radius * Math.cos(angle), y: centre.y + radius * Math.sin(angle) }
+}
+
+/** Pull a polygon in toward its own centroid. The gap this opens is the rib. */
+function inset(points: readonly Vec[], amount: number): Vec[] {
+  const n = points.length
+  let cx = 0
+  let cy = 0
+  for (const point of points) {
+    cx += point.x
+    cy += point.y
+  }
+  cx /= n
+  cy /= n
+  const scale = 1 - amount
+  return points.map((point) => ({ x: cx + (point.x - cx) * scale, y: cy + (point.y - cy) * scale }))
+}
+
+function polygon(points: readonly Vec[]): string {
+  return `M${points.map((p) => `${r3(p.x)} ${r3(p.y)}`).join("L")}Z`
+}
+
+/**
+ * The twenty apertures of one rosette, centred on `centre`, indexed by cell id.
+ *
+ * Cells 0–9 are the star: a kite from the centre out past tip `k`, between the
+ * valleys either side of it. Cells 10–19 are the ring: a rhombus sitting on
+ * valley `k`, reaching out to the decagon vertex beyond it. Together they leave
+ * ten triangles of uncut stone at the rim, which are the ribs that make the
+ * thing read as a carved screen rather than a filled circle.
+ */
+export function rosetteCells(centre: Vec, spec: RosetteSpec = ROSETTE): string[] {
+  const { radius, tip, valley, rib } = spec
+  if (!(radius > 0)) throw new RangeError("rosetteCells: radius must be positive")
+  // Ordered, not merely positive: a valley outside a tip turns the star inside
+  // out, and a tip outside the rim pushes the ring cells through themselves.
+  // Both draw without complaint and neither is a rosette.
+  if (!(valley > 0 && valley < tip && tip < 1)) {
+    throw new RangeError("rosetteCells: need 0 < valley < tip < 1")
+  }
+  if (!(rib >= 0 && rib < 1)) throw new RangeError("rosetteCells: rib must be in [0, 1)")
+
+  const at = (fraction: number, turns: number): Vec => polar(centre, radius * fraction, turns)
+  const cells: string[] = []
+
+  // The star. Kite k spans from the valley before tip k to the valley after it.
+  for (let k = 0; k < FOLD; k++) {
+    cells.push(
+      polygon(
+        inset(
+          [
+            centre,
+            at(valley, (k - 0.5) / FOLD),
+            at(tip, k / FOLD),
+            at(valley, (k + 0.5) / FOLD),
+          ],
+          rib,
+        ),
+      ),
+    )
+  }
+
+  // The ring. Rhombus k sits on valley k, between tips k and k+1.
+  for (let k = 0; k < FOLD; k++) {
+    cells.push(
+      polygon(
+        inset(
+          [
+            at(valley, (k + 0.5) / FOLD),
+            at(tip, k / FOLD),
+            at(1, (k + 0.5) / FOLD),
+            at(tip, (k + 1) / FOLD),
+          ],
+          rib,
+        ),
+      ),
+    )
+  }
+
+  return cells
+}
+
+/**
+ * The order the apertures are cut in: opposing pairs, star first.
+ *
+ * `0, 5, 1, 6, 2, 7, …` around the star, then the same walk around the ring. A
+ * balanced cross appears at the second answer and grows into a closed star at
+ * the tenth; the ring then pushes it out to the rim at the twentieth. Both of
+ * those are milestones the child can see coming, which is the point.
+ */
+export const CUT_ORDER: readonly number[] = (() => {
+  const walk: number[] = []
+  for (let ring = 0; ring < 2; ring++) {
+    for (let step = 0; step < FOLD; step++) {
+      const half = FOLD / 2
+      walk.push(ring * FOLD + (step % 2 === 0 ? step / 2 : half + (step - 1) / 2))
+    }
+  }
+  return walk
+})()
+
+/** The cell cut by the `n`-th answer into a rosette (0-based). */
+export function cellCutAt(n: number): number {
+  const cell = CUT_ORDER[n % CELLS_PER_ROSETTE]
+  if (cell === undefined) throw new RangeError("cellCutAt: cut order is empty")
+  return cell
+}
+
+/**
+ * One `d` attribute for many apertures.
+ *
+ * This is the whole of the rasterize-to-snapshot story, and it is in the model
+ * rather than bolted on afterwards: a finished rosette is twenty subpaths in
+ * one `<path>` — one live node — and a finished course is a hundred. Nothing is
+ * rasterized to a bitmap, nothing is cached, and nothing can drift out of step
+ * with the geometry, because the fused string *is* the geometry.
+ */
+export function fuse(paths: readonly string[]): string {
+  return paths.join("")
+}

--- a/dynawalla/dynawalla-app/src/world/store.ts
+++ b/dynawalla/dynawalla-app/src/world/store.ts
@@ -1,0 +1,70 @@
+// What the child built, kept across launches.
+//
+// One number on disk. Everything drawn is derived from it, so there is no
+// serialized geometry to fall out of step with a change to the rosette, and no
+// list of cells that a bad merge could shorten.
+//
+// The storage key is a **parameter**, not something this module works out. The
+// namespace belongs to the profile, the profile belongs to `src/work/`, and
+// `Q-05` forbids the world from importing anything there. The caller — which
+// knows about both — hands the namespace in. That is also why this is a factory
+// rather than a singleton: `Q-12` needs three of them side by side.
+
+import { create, type StoreApi, type UseBoundStore } from "zustand"
+import { persist, createJSONStorage, type StateStorage } from "zustand/middleware"
+
+import { place, NOTHING_BUILT, type Construction } from "./construction.ts"
+
+export interface WorldState extends Construction {
+  /**
+   * Cut one aperture. The only mutation. Returns the new count so a caller can
+   * ask what closed without reading the store back and racing itself.
+   */
+  placeOne: () => number
+}
+
+/**
+ * Absent under `node --test`, and switchable off in a WebView. Neither is a
+ * reason to throw at a child, so the world degrades to process lifetime.
+ */
+const ephemeral = new Map<string, string>()
+
+const memoryStorage: StateStorage = {
+  getItem: (name) => ephemeral.get(name) ?? null,
+  setItem: (name, value) => void ephemeral.set(name, value),
+  removeItem: (name) => void ephemeral.delete(name),
+}
+
+export type WorldStore = UseBoundStore<StoreApi<WorldState>>
+
+export function createWorldStore(namespace: string): WorldStore {
+  return create<WorldState>()(
+    persist(
+      (set, get) => ({
+        ...NOTHING_BUILT,
+        placeOne: () => {
+          const next = place({ placed: get().placed })
+          set({ placed: next.placed })
+          return next.placed
+        },
+      }),
+      {
+        name: namespace,
+        version: 1,
+        storage: createJSONStorage(() =>
+          typeof localStorage === "undefined" ? memoryStorage : localStorage,
+        ),
+        partialize: (state) => ({ placed: state.placed }),
+        // A stored value that is not a whole number — a corrupted key, a
+        // hand-edited devtools session — must not be able to take the world
+        // backwards. `Math.max` against what is already there is the one place
+        // a *rehydrated* count is checked, and it can only ever raise.
+        merge: (persisted, current) => {
+          const stored = (persisted as Partial<Construction> | undefined)?.placed
+          const safe = typeof stored === "number" && Number.isFinite(stored) ? Math.floor(stored) : 0
+          return { ...current, placed: Math.max(current.placed, Math.max(0, safe)) }
+        },
+      },
+    ),
+  )
+}

--- a/dynawalla/dynawalla-app/tools/bench-reactions.mjs
+++ b/dynawalla/dynawalla-app/tools/bench-reactions.mjs
@@ -1,43 +1,98 @@
-// Reaction bench: the three claims a unit test cannot close.
+// Reaction bench: the claims a unit test cannot close.
 //
 // `reactions.test.ts` drives the stage with an injected clock and a recording
 // context, which proves the logic and proves nothing about a browser. These are
 // the same claims measured against real pixels in a real compositor:
 //
 //   Q-04  interruption      a child answers mid-animation. The picture must be
-//                           gone within 90 ms and the keystroke must land — not
-//                           be dropped, not be queued behind the animation.
+//                           gone within 90 ms of the interrupting keypress and
+//                           the keystroke must land — not be dropped, not be
+//                           queued behind the animation.
+//   —     lifetime          and the other half, which nothing measured at all:
+//                           a reaction nobody interrupts must run its tier's
+//                           budget. The loop's own auto-advance was settling
+//                           every one of them at 420 ms.
 //   Q-02  live nodes        the world's node count in the DOM must equal what
-//                           `construction.ts` says it is. The model claims a
-//                           number; this reads it off the page.
+//                           `construction.ts` says it is.
 //   Q-01  no reflow         the construction band must not move the slate when
-//                           an aperture is cut or the character speaks — checked
-//                           at 320 px, where it once did.
+//                           an aperture is cut or the character speaks.
+//   —     the fold          the control that commits an answer must be on
+//                           screen at the shortest viewport this app ships to.
+//
+// ## Three things this file gets right that its first cut did not
+//
+// 1. **It asserts.** Every probe below is checked and a failure exits non-zero.
+//    The first cut printed numbers, and a 40× drop in peak ink between a
+//    supposed tier 2 and a supposed tier 3 was published without comment.
+// 2. **It knows which tier it measured.** `window.__dwReaction` is a dev-only
+//    read-back of what the stage actually fired. The first cut *inferred* the
+//    tier from the number of cards answered — and inferred it wrong: a stray
+//    digit left in the answer field made ten subsequent answers wrong, so the
+//    probe labelled "the rosette, tier 3" ran at 18 apertures, where there is
+//    no milestone at all, and measured a SEAT.
+// 3. **It times from the keypress that settles.** `Q-04`'s clock starts at the
+//    interrupting input. That is the `Enter`; the digit after it is the input
+//    that must still land. Timed from the digit, the reported figure was one
+//    frame short of the truth.
 //
 // Interruption is measured by counting non-transparent pixels on the reaction
 // canvas, which is the only honest reading of "the picture is gone" — a state
 // flag would be measuring the app's opinion of itself.
 //
 //   npm run dev                    # in another shell
-//   node tools/bench-reactions.mjs
+//   npm run bench:reactions
 //
 // A developer-machine number, like `bench-loop.mjs`. The device measurement is
 // `Q-01`/`Q-02` on a Galaxy Tab A9 and no script can close it.
 
 import { spawn } from "node:child_process"
-import { mkdtempSync, rmSync } from "node:fs"
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import path from "node:path"
 
 const APP_URL = process.env.DW_URL ?? "http://127.0.0.1:1423/#/practice"
-const PORT = 9337
 const CHROME =
   process.env.CHROME_PATH ?? "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 
+/** `Q-04`'s limit, from the interrupting keypress to an empty canvas. */
+const SETTLE_LIMIT_MS = 90
+
+/**
+ * How much of its tier's budget an uninterrupted reaction must be on screen for.
+ *
+ * Not 100%, and the shortfall is honest rather than slack: every effect
+ * cross-fades to nothing over its budget (`alpha = 1 − raw²`), so the last
+ * frames are drawn below the alpha threshold `inked()` counts at and the
+ * picture stops being *measurable* slightly before the clock stops. Measured at
+ * 887/900 for the ILLUMINATE and 1648/1800 for the MECHANISM. The failure this
+ * guards against is truncation — the loop cutting a reaction off at the 420 ms
+ * hold, which reads as 27–31% — so the floor is what matters and the ceiling is
+ * there to catch an effect that outlives its tier.
+ */
+const LIFETIME_FLOOR = 0.85
+const LIFETIME_CEILING = 1.1
+
+const failures = []
+function check(ok, message) {
+  if (ok) return
+  failures.push(message)
+  console.log(`   FAIL  ${message}`)
+}
+
+// Port 0, not a fixed one, and the port is read back from the profile Chrome
+// actually wrote it into.
+//
+// This is not tidiness. A killed headless Chrome can outlive the `kill()` by a
+// second or two, so a bench on a fixed port attaches to the *previous* run's
+// browser — which is what happened here: the `REDUCED=1` pass reported "all
+// probes green" while driving a browser launched without
+// `--force-prefers-reduced-motion`, so `Q-06`'s only browser-side evidence was
+// measuring the ordinary code path. A stale-browser bug is indistinguishable
+// from a pass, which is the worst property a harness can have.
 const profile = mkdtempSync(path.join(tmpdir(), "dw-react-"))
 const args = [
   "--headless=new",
-  `--remote-debugging-port=${String(PORT)}`,
+  "--remote-debugging-port=0",
   `--user-data-dir=${profile}`,
   "--no-first-run",
   "--disable-extensions",
@@ -47,15 +102,31 @@ const args = [
 // The reduced-motion branch is a different code path with a different budget;
 // running the same probes against it is how `Q-06` stops being a claim about
 // CSS nobody executed.
-if (process.env.REDUCED === "1") args.push("--force-prefers-reduced-motion")
+const REDUCED = process.env.REDUCED === "1"
+if (REDUCED) args.push("--force-prefers-reduced-motion")
 const chrome = spawn(CHROME, args, { stdio: "ignore" })
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
 
-async function endpoint() {
+/** The port this browser chose, from the file it writes into its own profile. */
+async function port() {
   for (let attempt = 0; attempt < 60; attempt++) {
     try {
-      const list = await fetch(`http://127.0.0.1:${String(PORT)}/json/list`).then((r) => r.json())
+      const chosen = readFileSync(path.join(profile, "DevToolsActivePort"), "utf8").split("\n")[0]
+      if (chosen && chosen.trim() !== "") return chosen.trim()
+    } catch {
+      /* not written yet */
+    }
+    await sleep(200)
+  }
+  throw new Error("chrome never wrote DevToolsActivePort")
+}
+
+async function endpoint() {
+  const chosen = await port()
+  for (let attempt = 0; attempt < 60; attempt++) {
+    try {
+      const list = await fetch(`http://127.0.0.1:${chosen}/json/list`).then((r) => r.json())
       const page = list.find((t) => t.type === "page")
       if (page) return page.webSocketDebuggerUrl
     } catch {
@@ -113,6 +184,8 @@ async function evaluate(expression) {
   throw new Error("evaluate never settled")
 }
 
+const json = async (expression) => JSON.parse(await evaluate(expression))
+
 const HELPERS = `
   const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
   const frame = () => new Promise((r) => requestAnimationFrame(r))
@@ -121,6 +194,11 @@ const HELPERS = `
   const answer = () => document.querySelector(".dw-anchor-seat")
   const key = (k) => window.dispatchEvent(new KeyboardEvent("keydown", { key: k, bubbles: true }))
   const digits = (s) => (s.match(/\\d+/g) ?? [])
+  const placed = () =>
+    JSON.parse(localStorage.getItem("dynawalla.p1.world") ?? '{"state":{}}').state.placed ?? 0
+  // What the stage actually fired, read back from the dev-only hook. Inferring
+  // it from the card count is how a SEAT got published as a MECHANISM.
+  const fired = () => globalThis.__dwReaction ?? null
   // Non-transparent pixels on the reaction canvas. The only honest reading of
   // "the picture is gone": a flag would be the app grading its own homework.
   const inked = () => {
@@ -150,6 +228,7 @@ const HELPERS = `
 const PLAY = (n) => `(async () => {
   ${HELPERS}
   const boxes = []
+  const before = placed()
   for (let i = 0; i < ${String(n)}; i++) {
     while (!slate()) { key("Enter"); await sleep(180) }
     // Sampled past the present animation: dw-present slides the card up 8 px
@@ -165,6 +244,8 @@ const PLAY = (n) => `(async () => {
   const tops = boxes.map((b) => b[0]), lefts = boxes.map((b) => b[1])
   return JSON.stringify({
     cards: boxes.length,
+    placedBefore: before,
+    placedAfter: placed(),
     slateTopSpreadPx: Math.max(...tops) - Math.min(...tops),
     slateLeftSpreadPx: Math.max(...lefts) - Math.min(...lefts),
     bandHeightPx: band() ? band().getBoundingClientRect().height : null,
@@ -172,44 +253,95 @@ const PLAY = (n) => `(async () => {
 })()`
 
 /**
+ * Answer one card correctly and then touch nothing at all, sampling the canvas
+ * every frame. This is the probe that did not exist: every other one interrupts
+ * deliberately, so the loop's own auto-advance settling the reaction at 420 ms
+ * was invisible to all of them.
+ */
+const LIFETIME = `(async () => {
+  ${HELPERS}
+  globalThis.__dwReaction = null
+  const before = placed()
+  while (!slate()) { key("Enter"); await sleep(180) }
+  await sleep(200)
+  await answerRight()
+  const samples = []
+  for (let i = 0; i < 200; i++) {
+    await frame()
+    samples.push([performance.now(), inked()])
+  }
+  const shot = fired()
+  const lit = samples.filter((s) => s[1] > 0)
+  const origin = shot ? shot.firedAt : (lit.length ? lit[0][0] : 0)
+  return JSON.stringify({
+    placedBefore: before,
+    placedAfter: placed(),
+    tier: shot ? shot.tier : null,
+    budgetMs: shot ? shot.budgetMs : null,
+    firstInkMs: lit.length ? Math.round(lit[0][0] - origin) : null,
+    lastInkMs: lit.length ? Math.round(lit[lit.length - 1][0] - origin) : null,
+    peakInkPx: Math.max(0, ...samples.map((s) => s[1])),
+  })
+})()`
+
+/**
  * Answer the card that closes a milestone, wait until the reaction is visibly
- * on the canvas, then interrupt it with a digit and time both halves: how long
- * the picture takes to go, and whether the digit landed.
+ * on the canvas, then interrupt it and time both halves: how long the picture
+ * takes to go, and whether the digit that followed landed.
+ *
+ * The clock starts at the `Enter`, because `Enter` is the keypress whose
+ * handler calls `settleNow()`. Timed from the digit after it — as the first cut
+ * did — the reported settle is a frame short of what the child experiences.
+ * The digit is still pressed, and still has to land, because "never drops or
+ * delays the input" is the other half of `Q-04`.
+ *
+ * It ends by clearing the field. A stray digit left in the entry made every
+ * following answer wrong, which is what silently walked the tier-3 probe onto
+ * a card with no milestone on it.
  */
 const INTERRUPT = `(async () => {
   ${HELPERS}
+  globalThis.__dwReaction = null
+  const before = placed()
   await answerRight()
   // Let the reaction get going. It is fired from the frame after the verdict
   // paints, so the first two frames are legitimately empty.
   let ink = 0
   for (let i = 0; i < 30 && ink <= 0; i++) { await frame(); ink = inked() }
-  if (ink <= 0) return JSON.stringify({ reached: false })
+  const shot = fired()
+  if (ink <= 0) return JSON.stringify({ reached: false, placedBefore: before, tier: shot ? shot.tier : null })
 
-  // Interrupt mid-flight. Enter moves past the verdict, then a digit — which
-  // is a real answer keystroke, the thing that must never be dropped.
+  // Interrupt mid-flight, and start the clock on the keypress that settles.
+  const started = performance.now()
   key("Enter")
   await frame()
-  const started = performance.now()
+  // …then a digit, which is a real answer keystroke and the thing that must
+  // never be dropped or queued behind the animation.
+  const digitAt = performance.now()
   key("7")
-  const handlerMs = performance.now() - started
-  // The keystroke must reach the field on the next frame — it is React state,
-  // so it cannot be synchronous, but it must not wait on the animation. The
-  // reaction is still settling while this is checked.
+  const handlerMs = performance.now() - digitAt
   await frame()
-  const landedAt = performance.now() - started
   const landed = (answer()?.textContent ?? "").includes("7")
 
   let cleared = null
-  for (let i = 0; i < 20; i++) {
+  for (let i = 0; i < 30; i++) {
     await frame()
     if (inked() === 0) { cleared = performance.now() - started; break }
   }
+
+  // Leave the field as it was found.
+  key("Escape")
+  await frame()
   return JSON.stringify({
     reached: true,
+    placedBefore: before,
+    placedAfter: placed(),
+    tier: shot ? shot.tier : null,
+    budgetMs: shot ? shot.budgetMs : null,
     peakInkPx: ink,
     keyHandlerMs: Math.round(handlerMs * 100) / 100,
     keyLandedNextFrame: landed,
-    keyLandedAtMs: Math.round(landedAt * 100) / 100,
+    entryLeftBehind: (answer()?.textContent ?? "").replace(/\\s/g, ""),
     clearedMs: cleared === null ? null : Math.round(cleared * 100) / 100,
   })
 })()`
@@ -228,13 +360,13 @@ const BAND_HEIGHTS = `(() => {
   let max = rest, worst = ""
   for (const line of ${JSON.stringify([
     "What you borrowed, you spent. It did not stay behind.",
-    "You gave it up this time. Most do not, at first.",
+    "The ten left the column it came from.",
     "A ten cannot sit in two places. You saw that.",
     "Nothing left over. That is the whole of it.",
     "180 apertures. The light has somewhere to go now.",
     "It closes. Cut stone does, when the order is right.",
     "A shape, where there was a hole.",
-    "That will hold weight. Not all of them do.",
+    "Stone does not grow back. That one stays cut.",
     "These have a hole in the middle. Watch where the ten goes.",
     "Zero is not nothing. It is a place with nothing in it.",
     "Now the empty column.",
@@ -248,6 +380,20 @@ const BAND_HEIGHTS = `(() => {
   return JSON.stringify({ restPx: rest, speakingPx: max, movedPx: Math.round((max - rest) * 100) / 100, worst })
 })()`
 
+/** Is the control that commits an answer on screen, without scrolling? */
+const FOLD = `(() => {
+  const plate = [...document.querySelectorAll("button")]
+    .find((b) => /^(Check|Next|Done)$/.test((b.textContent ?? "").trim()))
+  const box = plate ? plate.getBoundingClientRect() : null
+  return JSON.stringify({
+    innerHeight: window.innerHeight,
+    scrollHeight: document.documentElement.scrollHeight,
+    label: plate ? plate.textContent.trim() : null,
+    bottomPx: box ? Math.round(box.bottom) : null,
+    visible: box ? box.top >= 0 && box.bottom <= window.innerHeight : false,
+  })
+})()`
+
 const WORLD = `(async () => {
   const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
   location.hash = "#/world"
@@ -257,8 +403,20 @@ const WORLD = `(async () => {
     placed: JSON.parse(localStorage.getItem("dynawalla.p1.world") ?? '{"state":{}}').state.placed ?? 0,
     domNodes: svg ? svg.children.length : null,
     label: svg ? svg.getAttribute("aria-label") : null,
+    toPractice: !!document.querySelector('a[href*="practice"]'),
   })
 })()`
+
+/** Start a fresh session with the construction seeded to `placed`. */
+async function reset(placed) {
+  await send("Page.navigate", { url: APP_URL })
+  await sleep(600)
+  await evaluate(
+    `(localStorage.clear(), localStorage.setItem("dynawalla.p1.world", JSON.stringify({ state: { placed: ${String(placed)} }, version: 1 })), 1)`,
+  )
+  await send("Page.reload", { ignoreCache: true })
+  await sleep(2400)
+}
 
 try {
   await send("Page.enable")
@@ -269,25 +427,70 @@ try {
     deviceScaleFactor: 2,
     mobile: true,
   })
-  await send("Page.navigate", { url: APP_URL })
-  await sleep(2200)
-  await evaluate("localStorage.clear(), 1")
-  await send("Page.navigate", { url: APP_URL })
-  await send("Page.reload", { ignoreCache: true })
-  await sleep(2400)
+  await reset(0)
+
+  // The REDUCED pass is worth nothing if the flag did not take, and a flag that
+  // silently stops working is exactly the failure this file exists to catch.
+  const reducedInPage = await evaluate('matchMedia("(prefers-reduced-motion: reduce)").matches')
+  console.log(`reduced motion: asked for ${String(REDUCED)}, page reports ${String(reducedInPage)}`)
+  check(reducedInPage === REDUCED, "the reduced-motion flag did not reach the page")
 
   console.log("── Q-01, the band does not move the work ─────────────────────")
-  console.log(await evaluate(PLAY(9)))
+  const play = await json(PLAY(9))
+  console.log(play)
+  check(play.slateTopSpreadPx <= 1, `the slate moved ${String(play.slateTopSpreadPx)} px vertically`)
+  check(play.slateLeftSpreadPx <= 1, `the slate moved ${String(play.slateLeftSpreadPx)} px horizontally`)
 
-  console.log("\n── Q-04, interrupting the star (tier 2, 900 ms) ──────────────")
-  console.log(await evaluate(INTERRUPT))
+  // Every milestone probe below starts from a seeded construction and a fresh
+  // reload, so the tier it wants is the tier that is due *and* the once-a-
+  // session MECHANISM budget is unspent. Walking there by answering cards is
+  // what let one stray keystroke put the probe on the wrong card entirely.
+  for (const [seed, tier] of [
+    [9, "illuminate"],
+    [19, "mechanism"],
+  ]) {
+    const budget = tier === "mechanism" ? 1800 : 900
+    console.log(`\n── lifetime, uninterrupted: ${tier} at ${String(seed + 1)} apertures ──`)
+    await reset(seed)
+    const life = await json(LIFETIME)
+    console.log(life)
+    check(life.placedAfter === seed + 1, `the probe landed on ${String(life.placedAfter)} apertures, not ${String(seed + 1)}`)
+    check(life.tier === tier, `fired ${String(life.tier)}, not ${tier}`)
+    if (!REDUCED && life.tier === tier) {
+      const lived = life.lastInkMs
+      check(
+        lived !== null && lived >= budget * LIFETIME_FLOOR && lived <= budget * LIFETIME_CEILING,
+        `${tier} was on screen ${String(lived)} ms of its ${String(budget)} ms budget` +
+          ` (${String(Math.round(((lived ?? 0) / budget) * 100))}%)`,
+      )
+    }
+  }
 
-  console.log(await evaluate(PLAY(10)))
-  console.log("\n── Q-04, interrupting the rosette (tier 3, 1800 ms) ──────────")
-  console.log(await evaluate(INTERRUPT))
+  for (const [seed, tier] of [
+    [9, "illuminate"],
+    [19, "mechanism"],
+  ]) {
+    console.log(`\n── Q-04, interrupting the ${tier} at ${String(seed + 1)} apertures ──`)
+    await reset(seed)
+    const cut = await json(INTERRUPT)
+    console.log(cut)
+    check(cut.reached === true, "the reaction never reached the canvas")
+    check(cut.placedAfter === seed + 1, `the probe landed on ${String(cut.placedAfter)} apertures`)
+    check(cut.tier === tier, `interrupted ${String(cut.tier)}, not ${tier}`)
+    check(
+      cut.clearedMs !== null && cut.clearedMs <= SETTLE_LIMIT_MS,
+      `the picture took ${String(cut.clearedMs)} ms to go, past Q-04's ${String(SETTLE_LIMIT_MS)}`,
+    )
+    check(cut.keyLandedNextFrame === true, "the interrupting keystroke did not land on the next frame")
+    check(cut.keyHandlerMs < 50, `the key handler took ${String(cut.keyHandlerMs)} ms`)
+  }
 
   console.log("\n── Q-02, the world's nodes in the DOM ────────────────────────")
-  console.log(await evaluate(WORLD))
+  const world = await json(WORLD)
+  console.log(world)
+  check(world.domNodes !== null && world.domNodes <= 37, `the world drew ${String(world.domNodes)} nodes`)
+  check(world.label !== null && /apertures/.test(world.label), "the world has no text alternative")
+  check(world.toPractice === true, "the world has no way back to the work")
 
   // The band's height with every fragment in it, at the narrowest width this
   // app ships to. `min-h-16` passed at 390 and 360 and grew 3.5 px at 320,
@@ -302,11 +505,45 @@ try {
     })
     await evaluate('location.hash = "#/practice", 1')
     await sleep(500)
-    console.log(width, await evaluate(BAND_HEIGHTS))
+    const band = await json(BAND_HEIGHTS)
+    console.log(width, band)
+    check(band.movedPx === 0, `the band grew ${String(band.movedPx)} px at ${String(width)} px: ${band.worst}`)
+  }
+
+  // The fold. The surface was 878 px tall at every width and the Check plate's
+  // bottom edge sat at 833, so at 320 × 568 and 360 × 640 the child scrolled to
+  // submit every answer — on the two shortest viewports this app ships to, and
+  // nowhere else, which is why nobody saw it.
+  console.log("\n── the commit control is above the fold ──────────────────────")
+  for (const [width, height] of [
+    [320, 568],
+    [360, 640],
+    [390, 844],
+    [768, 1024],
+  ]) {
+    await send("Emulation.setDeviceMetricsOverride", {
+      width,
+      height,
+      deviceScaleFactor: 2,
+      mobile: true,
+    })
+    await evaluate('location.hash = "#/practice", 1')
+    await sleep(600)
+    const fold = await json(FOLD)
+    console.log(`${String(width)}×${String(height)}`, fold)
+    check(fold.visible === true, `"${String(fold.label)}" is below the fold at ${String(width)}×${String(height)}`)
   }
 } finally {
   socket.close()
-  chrome.kill()
+  chrome.kill("SIGKILL")
   await sleep(300)
   rmSync(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 })
+}
+
+if (failures.length > 0) {
+  console.log(`\n${String(failures.length)} FAILED`)
+  for (const failure of failures) console.log(`  · ${failure}`)
+  process.exitCode = 1
+} else {
+  console.log("\nall probes green")
 }

--- a/dynawalla/dynawalla-app/tools/bench-reactions.mjs
+++ b/dynawalla/dynawalla-app/tools/bench-reactions.mjs
@@ -1,0 +1,312 @@
+// Reaction bench: the three claims a unit test cannot close.
+//
+// `reactions.test.ts` drives the stage with an injected clock and a recording
+// context, which proves the logic and proves nothing about a browser. These are
+// the same claims measured against real pixels in a real compositor:
+//
+//   Q-04  interruption      a child answers mid-animation. The picture must be
+//                           gone within 90 ms and the keystroke must land — not
+//                           be dropped, not be queued behind the animation.
+//   Q-02  live nodes        the world's node count in the DOM must equal what
+//                           `construction.ts` says it is. The model claims a
+//                           number; this reads it off the page.
+//   Q-01  no reflow         the construction band must not move the slate when
+//                           an aperture is cut or the character speaks — checked
+//                           at 320 px, where it once did.
+//
+// Interruption is measured by counting non-transparent pixels on the reaction
+// canvas, which is the only honest reading of "the picture is gone" — a state
+// flag would be measuring the app's opinion of itself.
+//
+//   npm run dev                    # in another shell
+//   node tools/bench-reactions.mjs
+//
+// A developer-machine number, like `bench-loop.mjs`. The device measurement is
+// `Q-01`/`Q-02` on a Galaxy Tab A9 and no script can close it.
+
+import { spawn } from "node:child_process"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+const APP_URL = process.env.DW_URL ?? "http://127.0.0.1:1423/#/practice"
+const PORT = 9337
+const CHROME =
+  process.env.CHROME_PATH ?? "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+
+const profile = mkdtempSync(path.join(tmpdir(), "dw-react-"))
+const args = [
+  "--headless=new",
+  `--remote-debugging-port=${String(PORT)}`,
+  `--user-data-dir=${profile}`,
+  "--no-first-run",
+  "--disable-extensions",
+  "--hide-scrollbars",
+  "--window-size=390,844",
+]
+// The reduced-motion branch is a different code path with a different budget;
+// running the same probes against it is how `Q-06` stops being a claim about
+// CSS nobody executed.
+if (process.env.REDUCED === "1") args.push("--force-prefers-reduced-motion")
+const chrome = spawn(CHROME, args, { stdio: "ignore" })
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+async function endpoint() {
+  for (let attempt = 0; attempt < 60; attempt++) {
+    try {
+      const list = await fetch(`http://127.0.0.1:${String(PORT)}/json/list`).then((r) => r.json())
+      const page = list.find((t) => t.type === "page")
+      if (page) return page.webSocketDebuggerUrl
+    } catch {
+      /* not up yet */
+    }
+    await sleep(200)
+  }
+  throw new Error("chrome did not expose a debugging endpoint")
+}
+
+const socket = new WebSocket(await endpoint())
+await new Promise((resolve, reject) => {
+  socket.addEventListener("open", resolve, { once: true })
+  socket.addEventListener("error", reject, { once: true })
+})
+
+let nextId = 0
+const pending = new Map()
+socket.addEventListener("message", (event) => {
+  const message = JSON.parse(event.data)
+  const waiter = pending.get(message.id)
+  if (waiter === undefined) return
+  pending.delete(message.id)
+  if (message.error) waiter.reject(new Error(JSON.stringify(message.error)))
+  else waiter.resolve(message.result)
+})
+
+function send(method, params = {}) {
+  const id = ++nextId
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject })
+    socket.send(JSON.stringify({ id, method, params }))
+  })
+}
+
+async function evaluate(expression) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const result = await send("Runtime.evaluate", {
+      expression,
+      awaitPromise: true,
+      returnByValue: true,
+    }).catch((error) => {
+      if (!String(error.message).includes("collected")) throw error
+      return null
+    })
+    if (result === null) {
+      await sleep(300)
+      continue
+    }
+    if (result.exceptionDetails) {
+      throw new Error(result.exceptionDetails.exception?.description ?? "page threw")
+    }
+    return result.result.value
+  }
+  throw new Error("evaluate never settled")
+}
+
+const HELPERS = `
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+  const frame = () => new Promise((r) => requestAnimationFrame(r))
+  const slate = () => document.querySelector(".dw-slate")
+  const band = () => document.querySelector(".dw-anchor-cartouche")
+  const answer = () => document.querySelector(".dw-anchor-seat")
+  const key = (k) => window.dispatchEvent(new KeyboardEvent("keydown", { key: k, bubbles: true }))
+  const digits = (s) => (s.match(/\\d+/g) ?? [])
+  // Non-transparent pixels on the reaction canvas. The only honest reading of
+  // "the picture is gone": a flag would be the app grading its own homework.
+  const inked = () => {
+    const canvas = document.querySelector("canvas")
+    if (!canvas) return -1
+    const ctx = canvas.getContext("2d", { willReadFrequently: true })
+    const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data
+    let n = 0
+    for (let i = 3; i < data.length; i += 4) if (data[i] > 4) n++
+    return n
+  }
+  const answerRight = async () => {
+    while (!slate()) { key("Enter"); await sleep(180) }
+    const d = digits(slate().innerText)
+    if (d.length < 2) return false
+    for (const ch of (BigInt(d[0]) - BigInt(d[1])).toString()) key(ch)
+    await sleep(16)
+    key("Enter")
+    return true
+  }
+`
+
+/**
+ * Answer `n` cards correctly, sampling the slate's box on every card so the
+ * band's arrival can be shown not to move it.
+ */
+const PLAY = (n) => `(async () => {
+  ${HELPERS}
+  const boxes = []
+  for (let i = 0; i < ${String(n)}; i++) {
+    while (!slate()) { key("Enter"); await sleep(180) }
+    // Sampled past the present animation: dw-present slides the card up 8 px
+    // over one detent, so a box read on arrival measures the keyframe, not the
+    // layout. An earlier cut of this probe reported a 1.16 px reflow that was
+    // entirely the animation.
+    await sleep(260)
+    const box = slate().getBoundingClientRect()
+    boxes.push([Math.round(box.top * 100) / 100, Math.round(box.left * 100) / 100])
+    if (!(await answerRight())) { i--; await sleep(60); continue }
+    await sleep(520)
+  }
+  const tops = boxes.map((b) => b[0]), lefts = boxes.map((b) => b[1])
+  return JSON.stringify({
+    cards: boxes.length,
+    slateTopSpreadPx: Math.max(...tops) - Math.min(...tops),
+    slateLeftSpreadPx: Math.max(...lefts) - Math.min(...lefts),
+    bandHeightPx: band() ? band().getBoundingClientRect().height : null,
+  })
+})()`
+
+/**
+ * Answer the card that closes a milestone, wait until the reaction is visibly
+ * on the canvas, then interrupt it with a digit and time both halves: how long
+ * the picture takes to go, and whether the digit landed.
+ */
+const INTERRUPT = `(async () => {
+  ${HELPERS}
+  await answerRight()
+  // Let the reaction get going. It is fired from the frame after the verdict
+  // paints, so the first two frames are legitimately empty.
+  let ink = 0
+  for (let i = 0; i < 30 && ink <= 0; i++) { await frame(); ink = inked() }
+  if (ink <= 0) return JSON.stringify({ reached: false })
+
+  // Interrupt mid-flight. Enter moves past the verdict, then a digit — which
+  // is a real answer keystroke, the thing that must never be dropped.
+  key("Enter")
+  await frame()
+  const started = performance.now()
+  key("7")
+  const handlerMs = performance.now() - started
+  // The keystroke must reach the field on the next frame — it is React state,
+  // so it cannot be synchronous, but it must not wait on the animation. The
+  // reaction is still settling while this is checked.
+  await frame()
+  const landedAt = performance.now() - started
+  const landed = (answer()?.textContent ?? "").includes("7")
+
+  let cleared = null
+  for (let i = 0; i < 20; i++) {
+    await frame()
+    if (inked() === 0) { cleared = performance.now() - started; break }
+  }
+  return JSON.stringify({
+    reached: true,
+    peakInkPx: ink,
+    keyHandlerMs: Math.round(handlerMs * 100) / 100,
+    keyLandedNextFrame: landed,
+    keyLandedAtMs: Math.round(landedAt * 100) / 100,
+    clearedMs: cleared === null ? null : Math.round(cleared * 100) / 100,
+  })
+})()`
+
+/**
+ * Force every fragment into the band and read its height back. Reaching into
+ * the DOM rather than driving the character is deliberate: he speaks four times
+ * a session at genuine milestones, and waiting for all twelve would take longer
+ * than the bench is worth.
+ */
+const BAND_HEIGHTS = `(() => {
+  const band = document.querySelector(".dw-anchor-cartouche")
+  if (!band) return JSON.stringify({ band: null })
+  const p = band.querySelector("p")
+  const rest = band.getBoundingClientRect().height
+  let max = rest, worst = ""
+  for (const line of ${JSON.stringify([
+    "What you borrowed, you spent. It did not stay behind.",
+    "You gave it up this time. Most do not, at first.",
+    "A ten cannot sit in two places. You saw that.",
+    "Nothing left over. That is the whole of it.",
+    "180 apertures. The light has somewhere to go now.",
+    "It closes. Cut stone does, when the order is right.",
+    "A shape, where there was a hole.",
+    "That will hold weight. Not all of them do.",
+    "These have a hole in the middle. Watch where the ten goes.",
+    "Zero is not nothing. It is a place with nothing in it.",
+    "Now the empty column.",
+    "Reach past the zero. It has nothing of its own to lend.",
+  ])}) {
+    p.textContent = line
+    const h = band.getBoundingClientRect().height
+    if (h > max) { max = h; worst = line }
+  }
+  p.textContent = ""
+  return JSON.stringify({ restPx: rest, speakingPx: max, movedPx: Math.round((max - rest) * 100) / 100, worst })
+})()`
+
+const WORLD = `(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+  location.hash = "#/world"
+  await sleep(500)
+  const svg = document.querySelector("#dw-world")
+  return JSON.stringify({
+    placed: JSON.parse(localStorage.getItem("dynawalla.p1.world") ?? '{"state":{}}').state.placed ?? 0,
+    domNodes: svg ? svg.children.length : null,
+    label: svg ? svg.getAttribute("aria-label") : null,
+  })
+})()`
+
+try {
+  await send("Page.enable")
+  await send("Runtime.enable")
+  await send("Emulation.setDeviceMetricsOverride", {
+    width: 390,
+    height: 844,
+    deviceScaleFactor: 2,
+    mobile: true,
+  })
+  await send("Page.navigate", { url: APP_URL })
+  await sleep(2200)
+  await evaluate("localStorage.clear(), 1")
+  await send("Page.navigate", { url: APP_URL })
+  await send("Page.reload", { ignoreCache: true })
+  await sleep(2400)
+
+  console.log("── Q-01, the band does not move the work ─────────────────────")
+  console.log(await evaluate(PLAY(9)))
+
+  console.log("\n── Q-04, interrupting the star (tier 2, 900 ms) ──────────────")
+  console.log(await evaluate(INTERRUPT))
+
+  console.log(await evaluate(PLAY(10)))
+  console.log("\n── Q-04, interrupting the rosette (tier 3, 1800 ms) ──────────")
+  console.log(await evaluate(INTERRUPT))
+
+  console.log("\n── Q-02, the world's nodes in the DOM ────────────────────────")
+  console.log(await evaluate(WORLD))
+
+  // The band's height with every fragment in it, at the narrowest width this
+  // app ships to. `min-h-16` passed at 390 and 360 and grew 3.5 px at 320,
+  // which is why this probe measures the widths rather than one width.
+  console.log("\n── Q-01, the band's height with the character speaking ───────")
+  for (const width of [320, 360, 390]) {
+    await send("Emulation.setDeviceMetricsOverride", {
+      width,
+      height: 844,
+      deviceScaleFactor: 2,
+      mobile: true,
+    })
+    await evaluate('location.hash = "#/practice", 1')
+    await sleep(500)
+    console.log(width, await evaluate(BAND_HEIGHTS))
+  }
+} finally {
+  socket.close()
+  chrome.kill()
+  await sleep(300)
+  rmSync(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 })
+}

--- a/dynawalla/dynawalla-app/vite.config.ts
+++ b/dynawalla/dynawalla-app/vite.config.ts
@@ -8,6 +8,11 @@ const pkg = JSON.parse(fs.readFileSync("./package.json", "utf-8")) as { version:
 
 // Tauri injects TAURI_DEV_HOST for device builds (the LAN address the phone or
 // tablet must reach). Fall back to loopback for desktop.
+//
+// This is the ONE thing that takes the dev server off 127.0.0.1, and it is
+// opt-in per command rather than a checked-in `host: true`. While it is set,
+// every file `server.fs` allows is readable by any host on the network — which
+// is what makes the fs guard below load-bearing rather than theoretical.
 const devHost = process.env.TAURI_DEV_HOST
 
 export default defineConfig({
@@ -44,22 +49,52 @@ export default defineConfig({
   },
 
   server: {
-    // The app imports the curriculum package's TypeScript source directly (see
-    // `src/work/curriculum.ts`). It is a private package with no build step, so
-    // there is nothing else to import — and it lives outside this app's
-    // directory, which is where Vite's workspace-root detection stops because
-    // `package-lock.json` is here. Without this, `npm run dev` serves a 403 for
-    // every curriculum module while `npm run build` (Rollup, no fs guard)
-    // succeeds — a dev-only failure that a green CI would never show.
+    // NO `fs.allow` widening, deliberately — the dev server's reach is Vite's
+    // default, this app's own directory, and nothing beside it.
     //
-    // Scoped to the one sibling actually imported. `".."` also served
-    // `dynawalla/engine/`, `dynawalla/docs/` and anything else beside the app —
-    // and with `TAURI_DEV_HOST` set this server is bound to the LAN, so that is
-    // the whole tree readable by any host on the network. The app root is listed
-    // explicitly because Vite 8 *replaces* the default list rather than extending
-    // it: `["../curriculum"]` alone puts `index.html` outside the allow list and
-    // `npm run dev` serves nothing. Verified by running it.
-    fs: { allow: [".", "../curriculum"] },
+    // The app imports the curriculum package's TypeScript source across a
+    // directory boundary (one seam, `src/work/curriculum.ts`). Under Vite 7 and
+    // earlier that meant a 403 for every curriculum module in `npm run dev`
+    // while `npm run build` (Rollup, no fs guard) succeeded, so the sibling had
+    // to be allow-listed. Vite 8 removed the need: `isFileLoadingAllowed`
+    // consults `config.safeModulePaths` BEFORE `fs.allow`, and import analysis
+    // adds every specifier it resolves out of an already-served module. An
+    // importer is always fetched before its dependencies — that is how ES
+    // modules load, not a race — so the curriculum graph is reachable one hop
+    // at a time without being listed.
+    //
+    // Verified in a real browser rather than reasoned about: the practice
+    // surface boots and all 20 curriculum modules return 200 with no allow
+    // entry at all, and editing `curriculum/src/math/rational.ts` hot-reloads
+    // the subgraph at 200 (the `?t=` query does not defeat it — the check runs
+    // on `cleanUrl`). `devServer.test.ts` is the gate that keeps it that way.
+    //
+    // If a Vite upgrade ever regresses this, dev fails loudly and immediately —
+    // 403 plus a blank page — rather than silently. Prefer fixing the import
+    // seam over re-widening; and note that Vite REPLACES this list rather than
+    // extending it, so `"."` would have to be listed alongside anything added.
+    fs: {
+      // `deny` is replaced wholesale too (`mergeWithDefaultsRecursively` assigns
+      // arrays), so Vite's six defaults are restated verbatim and the test above
+      // fails the build if one goes missing.
+      //
+      // The last entry is the addition. `src-tauri/.gitignore` already ignores
+      // `*.jks` / `*.p8` / `*.mobileprovision` and `RELEASE_SETUP.md` tells you
+      // to generate an upload keystore in this tree — and Vite's default covers
+      // `.p12` but none of those three. That material sits INSIDE the allowed
+      // root, where narrowing `allow` cannot help, and `TAURI_DEV_HOST` (which
+      // on-device Android testing requires) binds this server to the LAN. Deny
+      // is checked before allow, so this holds regardless of what allow says.
+      deny: [
+        ".env",
+        ".env.*",
+        "*.{crt,pem,key,p12,pfx,cer,der}",
+        ".npmrc",
+        ".yarnrc.yml",
+        "**/.git/**",
+        "*.{jks,p8,mobileprovision}",
+      ],
+    },
 
     // 1421 is Corpán's. Both dev servers must be able to run at once.
     port: 1423,


### PR DESCRIPTION
Stacks on **#534** (`agent/dynawalla/practice-loop`), which has not merged yet.
Until it does, the diff below and the `adversarial-review` gate see both PRs;
once #534 lands the merge-base moves and this PR is the 3,928 lines in its own
commit. **Merge #534 first.** M2-B was branched from the practice loop rather
than beside it, as instructed.

## What

Reactions, visible construction and the character, per MASTER_PLAN PR-2.6 and
PR-2.11. Every correct answer cuts an aperture into a girih screen the child is
building; the machinery responds in EXPERIENCE_DESIGN's five tiers; the
Dynawalla notices, rarely, and says the specific true thing.

## Why

The loop works and there is no reason to come back to it. `T-01` asks a child to
complete two unassisted 20-minute sessions and return the next day, and
[PLAYTEST-PROTOCOL §4](../blob/main/dynawalla/docs/PLAYTEST-PROTOCOL.md) — as
amended by #534 — asks him which moment he attended to more, warning that *"a
build where the contrast pair is the only picture is a build where the honest
answer may be 'yes' however the unit test scores."* Before this PR the contrast
pair **was** the only picture, and it is reachable only by being wrong. Now the
accumulating picture is reachable only by being right.

## Blast radius

**Areas touched:** dynawalla (`dynawalla-app/src/**` and `tools/`). No corpan, no
packs, no native, no CI, no docs.

- [x] Every touched path is covered by the `dynawalla_app` filter
      (`^dynawalla/(dynawalla-app|curriculum)/`).
- [x] **Pack back-compat.** N/A — Dynawalla ships no packs (`K-01`).
- [x] **Native integrity.** N/A — no Rust, no manifest, no `[patch]` touched.
- [x] **Strings.** 13 new string literals, all in `src/app/strings.ts`, which
      is still the whole i18n layer until PR-1.6. Twelve are the character's
      fragments; one is the world's text alternative (`Q-10`). The World link's
      accessible name adds no literal — it is `destinations.world` joined to
      that text alternative, so a screen reader on the practice surface hears
      the aperture count, which an explicit ancestor label used to suppress.
      (This line said "14 new strings" and then described thirteen.)
      `voice.test.ts` bounds every fragment at 58 characters. That bound holds
      the English corpus only; PR-1.6 owes the per-locale one, measured from the
      longest *rendered* string, because a character count is a poor proxy
      across scripts and a comment is not a gate.
- [x] **Curriculum.** Untouched. No skill id, no generator, no float.
- [x] **Secrets.** None. No credential of any kind.

One move outside the new directories: `src/work/profile.ts` → `src/app/profile.ts`,
imports updated in three files. Two surfaces now persist under the profile
namespace, and `Q-05` forbids `src/world/` from importing anything in
`src/work/`. The alternative was a second copy of the storage-key convention on
the keys that hold a real child's progress, which is the exact collision that
file exists to make impossible.

## What is in it

**The construction — one girih screen, cut aperture by aperture.**
A rosette is a ten-fold star inside a ring of rhombi, 20 apertures, with the
uncut stone left standing as ribs. Ten close the star; twenty the rosette; three
rosettes a course; three courses a screen, which is set into the wall and seen
edge-on behind the next one. Cut order is opposing pairs (`0, 5, 1, 6, …`) — a
sequential ring fills like a pie chart and a filling ring is on the hostile
reference board by name.

`P-04` is a property of the model rather than a rule someone remembers: the
entire durable state is one monotone integer and there is no subtraction in the
module. `construction.test.ts` asserts that by reading the source, because a
behavioural test only covers the paths somebody thought of.

`Q-02` likewise. Fusion is *in* the model — a finished rosette is one `<path>`
holding twenty subpaths, a finished course one holding sixty — so the live-node
ceiling is ~38 at any history. The cap is asserted at a million apertures **and**
against `unfusedNodes`, the same world drawn one node per aperture, which blows
it at 5,000. A budget no reachable input can exceed is not a gate.

**The reactions — five tiers, nine effects, one canvas.**
Escalation keys on difficulty and on repairing a misconception you just fired.
Never on run length: asserted behaviourally (handing `chooseTier` a `runLength`,
a `streak` and a `comboCount` changes nothing) and by scanning every executable
line under `src/reactions/` for the words, with comments stripped so the prose
can still say what is banned.

`energy(SLIP) < energy(SEAT)` holds in the strong form — the loudest slip is
quieter than the quietest seat — and the whole five-tier ladder is strictly
ordered. The picker weights **inversely** to energy, so within a tier the quiet
effect is the common one and the loud one is the exception: feedback contingent,
not loud. A missing anchor walks the tier *down*, never up.

`settleNow()` is the first line of every input handler, unconditionally — and
**only** of the input handlers. The auto-advance timer used to go through the
same door, which is what truncated every reaction above SEAT (see the
correction log). `Q-04` measured off real pixels, not a state flag.

Reduced motion is two numbers on one code path: `t` pinned to 1, `travel` and
`motes` to 0, alpha cross-fading over 200 ms. There is no second renderer to
fall behind. Every effect in the catalogue is asserted to lay down
byte-identical geometry 96 ms apart under reduced motion — and to move when
motion is allowed — with the draw value that selects *that* effect, asserted
per effect. **This claim was false when first written**: the harness's default
`draw: 0.5` reached one effect per tier, so four of the nine were exercised by
nothing, and the "does move" half could not fail at all. See the correction
log.

**The Dynawalla.** Twelve fragments over three observation types (PR-2.11's
slice of the M6 grammar), at most four utterances a session, never a repeat,
three cards of silence between. He speaks when the child repairs the step that
had just broken, when something closes in the stone, and when the ladder first
serves a problem with a zero in the middle — a `ladder` card at that rung, not
the repair item that is served at the same rung after a wrong answer three
rungs lower, which is what the first cut announced. The corpus is asserted to
contain no praise word, no exclamation mark, no verdict on the child, and no
name for a misconception (`M-16`).

He is drawn as an aperture and a lintel with one moving part. Two earlier cuts
read as a webcam icon and then as a bank card; `Automaton.tsx` records why (at
32 px, an enclosing plate with stripes in it is a card, whatever the stripes
are), because that is the failure mode the art direction warns about and code
review cannot see it.

## What I got wrong and fixed

The band held at 390 px and 360 px and grew 64 → 67.5 px at 320 px when he
spoke — a 3.5 px shift of the whole work surface, on the rarest moment in the
product, caused by `min-h-16` and a 160 px text column. It is now a fixed
72 px reserving three lines at the narrowest width we ship to, the fragments are
bounded so they fit it, and `bench-reactions.mjs` measures the band at 320 / 360
/ 390 with every fragment in it. Found by looking at the 320 px screenshot, not
by a test.

## Proof

```
$ npm run lint && npm run tsc && npm test && npm run build
ℹ tests 177   ℹ pass 177   ℹ fail 0        (113 before this PR)
dist/assets/index-DzBAJxA1.js   348.76 kB │ gzip: 111.45 kB   ✓ built in 102ms
$ grep -c __dwMetrics dist/assets/*.js
0                                          (A-18: traces do not ship)
```

**Ordinary correct-answer feedback did not get slower.** `bench-loop.mjs`, 30
cards, headless Chrome at 390 px, before (`agent/dynawalla/practice-loop`) and
after:

| | before | after |
|---|---|---|
| `commitToJudgement` seated p50 / p95 / max | 0 / 0.1 / 0.2 ms | 0 / 0.1 / 0.2 ms |
| `commitToFeedback` p50 / p95 / max | 16.6 / 17.0 / 20.3 ms | 16.6 / 17.1 / 17.5 ms |
| `feedbackToReady` p50 / p95 | 3.8 / 6.0 ms | 5.2 / 6.9 ms |
| `generate` p50 / p95 | 0.1 / 0.2 ms | 0.1 / 0.2 ms |
| `maxKeypadShiftPx` | 0 | 0 |
| `unitsColumnSpreadPx` | 0 | 0 |
| horizontal overflow @ 320/360/768/1024 | none | none |

`commitToFeedback`'s floor is one compositor frame, so 16.6 ms reads "the
verdict is on the next frame, every time". The answer path is unchanged: the
only thing added to `commitAnswer` is one integer and one `localStorage` write
for the aperture, because the aperture has to appear *with* the verdict or it is
not the same event. Everything else — the reaction, the character — is fired
from the frame after the verdict paints. `feedbackToReady` is 1.4 ms slower at
p50 (the extra render of the band); it is the idle pass, not the answer path.

**Interruptibility, `Q-04`, and lifetime** — `npm run bench:reactions`,
counting non-transparent pixels on the reaction canvas. The tier is read back
from the stage rather than inferred from the card count, and the clock starts
on the keypress that calls `settleNow()`:

```
── lifetime, uninterrupted: illuminate at 10 apertures ──
{ tier: 'illuminate', budgetMs: 900,  firstInkMs: 2, lastInkMs: 888  }
── lifetime, uninterrupted: mechanism at 20 apertures ──
{ tier: 'mechanism',   budgetMs: 1800, firstInkMs: 2, lastInkMs: 1647 }

── Q-04, interrupting the illuminate at 10 apertures ──
{ tier: 'illuminate', keyLandedNextFrame: true, keyHandlerMs: 0, clearedMs: 70.5 }
── Q-04, interrupting the mechanism at 20 apertures ──
{ tier: 'mechanism',  keyLandedNextFrame: true, keyHandlerMs: 0, clearedMs: 69.4 }
```

and with `--force-prefers-reduced-motion` (`REDUCED=1`), where the bench now
asserts the flag actually reached the page: lifetimes 195 and 196 ms — the
200 ms cross-fade, not the tier budget — and `clearedMs` 66.2 and 74.4. The
keystroke is never dropped and never waits on the animation.

**The earlier version of this block measured neither of the things it named.**
See the correction log.

**No reflow, `Q-01`** — the slate's box sampled on every card past the present
animation, and the band's height with every fragment forced into it:

```
{"cards":9,"slateTopSpreadPx":0,"slateLeftSpreadPx":0,"bandHeightPx":72}
{"cards":10,"slateTopSpreadPx":0,"slateLeftSpreadPx":0,"bandHeightPx":72}
320 {"restPx":72,"speakingPx":72,"movedPx":0}
360 {"restPx":72,"speakingPx":72,"movedPx":0}
390 {"restPx":72,"speakingPx":72,"movedPx":0}
```

**The model's node count is the DOM's, `Q-02`** — `{"placed":18,"domNodes":20}`,
against `screenPieces(18).length + CHROME_NODES = 20`. (`Q-02` is scoped to
`/world`; the practice surface's `Cartouche` draws its own fixed 40, bounded in
that component. The reachable ceiling for the world is 37, not the "~45" the
`liveNodes` comment claimed — `courses` only reaches 3 when `rosettes` and
`cells` are both 0.) Swept in the browser at
0/1/7/10/20/21/45/60/61/140/180/181/545 placed; every count matched
`liveNodes()`.

**Keyboard only.** Tab order on the practice surface is wordmark → World →
keypad → Delete; the World link carries an accessible name; the whole loop is
driven by `keydown` at the window in every harness above. Two polite live
regions (the verdict well, the character's band); the reaction canvas is
`aria-hidden` with `pointer-events: none`; the rosette and the screen are
`role="img"` with a text alternative.

**Screenshots.** Captured headless at 390 px and 320 px, light and dark, reduced
motion on and off: at rest, on a correct answer, on the star closing, on the
rosette closing, on `404 − 307` answered `197` (borrow-across-zero, correct
answer 97), on the contrast pair, and the world at 1 / 10 / 20 / 45 / 60 / 140 /
180 / 545 apertures. **Not committed** — the committed seed set is PR-6.2, and
adding ~40 PNGs here would put this PR well past the review gate. I reviewed
them myself; the two failures they caught (the automaton, the band at 320 px)
are described above. Reproduce with `npm run dev` plus the two bench tools.

## What I actually think of it

The construction is the strongest part: real geometry, it accumulates, it is
bounded by construction rather than by a budget, and at 20 / 60 / 180 answers it
reads as a wall rather than as a meter. The character's *lines* are good — they
are dry, they are true, and none of them is praise.

Three honest reservations, none of them resolvable by me:

1. **The juice may be under-dosed rather than over-dosed.** The SEAT detent is a
   200 ms tick and a sweep behind a CSS seat that was already doing most of the
   work. A ten-year-old may not notice it at all. The dose is a playtest
   question (`T-01`) and I have no playtest.
2. **The Dynawalla's glyph is adequate, not excellent.** It took three attempts
   to stop reading as an icon. His lines carry him; the mark does not yet.
3. **`/world` is a picture on a page, not a destination.** The plate sits at the
   top of a mostly empty screen because that is the shell's layout for every
   route. Fixing it is a shell change and out of scope here.

Does it read as generated boilerplate with a brass gradient? There is no
gradient, no glow, no card, no progress ring, no stat row and no confetti, and
the palette is read from the semantic tokens rather than named anywhere — a hex
literal outside the palette fails the build. I think the answer is no. But
`Q-14` is three strangers and the art director looking at pixels, and this PR
does not close it and should not claim to.

---

## Correction log — six claims above were wrong

A fresh-context adversarial review found these. Every one reproduced; the code
is fixed on `a0815ffd` and the text above is corrected in place. Listed here
rather than silently edited, because a PR body that quietly stops being wrong
is worse than one that was.

1. **"Q-04, interrupting the rosette (tier 3, 1800 ms)" was interrupting a
   SEAT.** At that point `placed` was 18 and `milestoneAt(18)` is `null`. The
   INTERRUPT probe left a stray `"7"` in the entry, so the following ten
   answers submitted e.g. `797` instead of `97` and `PLAY(10)` advanced 10 → 17,
   not 10 → 20. `peakInkPx` 202 against 8399 for the tier-2 line was the tell,
   and it was published without comment. **The 1800 ms effect had never been
   measured for interruptibility in a browser.** Fixed: milestones are reached
   by seeding the construction and reloading, and the fired tier is asserted
   from a dev-only read-back.

2. **`clearedMs` was timed from the wrong keypress.** It started at `key("7")`;
   the `key("Enter")` one frame earlier is what calls `settleNow()`. Measured
   correctly at the old `SETTLE_MS` of 80 the figure was 87.7–89.6 ms against
   `Q-04`'s 90 — passing, and one slow frame from not. `SETTLE_MS` is now 64
   and the measured settle is 69–75 ms.

3. **The reduced-motion gate exercised five of nine effects and one half of it
   could not fail.** `draw: 0.5` selects deterministically, so `chisel`,
   `detent`, `tessera` and `rosetteLight` were drawn by no test in the repo —
   `detent` being the effect EXPERIENCE_DESIGN names as the one the child sees
   hundreds of times. And `moved.push(effect.id)` pushed the loop variable, so
   the catalogue comparison held as long as *something* moved. Mutation-proved
   both before and after: `Math.random() * 100` in `tessera`'s geometry left
   177/177 green, and now fails the suite.

4. **"The budgets are EXPERIENCE_DESIGN's, unchanged" was true of the budgets
   and false of the row they sit in.** The SEAT row also says "no particles",
   and both SEAT effects declared three — undisclosed, and load-bearing,
   because the multiplicative energy formula scores a particle-free effect at
   zero and `energy(SLIP) < energy(SEAT)` cannot hold. The term is now additive
   and nothing below ENGAGE throws a mote.

5. **"He speaks when the ladder first reaches the problems with a zero in the
   middle" — he did not.** `FIRST_ACROSS_ZERO` and the borrow-across-zero
   repair rung are the same expression, so the line fired the first time a
   child at a lower rung got one wrong and was handed the repair card, then
   latched for the session so the real arrival was silent. It also stacked a
   third event onto the strike and the contrast pair.

6. **"14 new strings" described thirteen.**

And one the review did not catch, found while fixing (2): **the bench's
`REDUCED=1` pass was driving the wrong browser.** A fixed debug port plus a
headless Chrome that outlives `kill()` by a second meant the run attached to
the previous, non-reduced instance — so `Q-06`'s only browser-side evidence
was measuring the ordinary code path and reporting green. The bench now uses
port 0, reads the port back from the profile, and asserts the page reports the
motion preference it was launched with.

## What the review said about the child, and what changed

> the feel layer as shipped delivers a 200 ms tick he barely notices for being
> right and a truncated flicker for the milestones — fix the truncation and the
> scale of the construction before T-01.

- **Truncation.** The auto-advance no longer settles the reaction. 888/900 and
  1647/1800 ms, against 594/1800 measured before.
- **Where it plays.** The three loudest tiers played in the band, 400 px from
  where the child is looking, and drew over the header because the canvas is
  `fixed inset-0` with no clip. Effects now declare a clip region, and
  `keystone` is a seat-anchored ILLUMINATE — the quietest in its tier, so the
  picker's inverse weighting makes it the common one.
- **Readability.** In dark, a 0.35-unit rim at 44 px is 0.7 px and cut cells
  were indistinguishable from uncut. New `--dw-aperture` role and a 0.45-unit
  rim on the cartouche, checked in captures at 4 and 19 apertures in both
  themes. (0.9 swallowed the fill and read as a bright blue star — worse than
  the bug, and visible only in a capture.)
- **The World.** Cropped on both axes, so one rosette fills its plate instead
  of sitting in the left third of a three-wide one, and there is a way back to
  Practice.
- **The fold.** 878 px of surface against a 568 px viewport. A three-rung
  vertical scale — one per device class — plus a pinned action plate:
  320×568, 360×640, 390×844 and 768×1024 now all fit *entirely*
  (`scrollHeight === innerHeight`), with the keypad's ≥2 cm diagonal preserved
  at every rung and asserted from the stylesheet.

Not fixed, and said so: the 58-character band bound is still English-only —
the per-locale gate belongs to PR-1.6, where the i18n gate exists to hold it.
