### PR TITLE
fix(corpan): stop the dev server from serving signing material

### DIFF
--- a/corpan/DEV_LOOP.md
+++ b/corpan/DEV_LOOP.md
@@ -82,6 +82,26 @@ brew install libimobiledevice
 Pair the iPad with this Mac at least once (Xcode → Window → Devices &
 Simulators, trust the device).
 
+## Signing material must not be readable by the dev server
+
+`TAURI_DEV_HOST=<lan-ip> npm run tauri android dev` binds Vite to the **LAN**,
+not to loopback. That is how the phone reaches the dev server, and it is also
+how everything else on the network reaches it. Vite's root is `corpan-app/`,
+which contains `src-tauri/` — the directory `RELEASE_SETUP.md` points at for
+the Android upload keystore.
+
+So `vite.config.ts` denies signing and credential material outright: `*.jks`,
+`*.keystore`, `*.p8`, `*.p12`, `*.mobileprovision`, `*.cer`,
+`*.certSigningRequest`, `*service-account*.json`, on top of Vite's own `.env`
+defaults. The `/packs` middleware streams from disk itself and never passes
+through `server.fs`, so it repeats the same check. `src/dev/devServer.test.ts`
+fails the suite if either stops covering them, or if Vite's own defaults get
+dropped (that array is replaced, not merged).
+
+`.gitignore` keeps this material off GitHub; the deny list keeps it off the
+network. When you introduce a new kind of secret, add it to both — and prefer
+keeping it outside the repo entirely.
+
 ## The three terminals
 
 ### Terminal 1 — pack console receiver

--- a/corpan/corpan-app/CHANGELOG.md
+++ b/corpan/corpan-app/CHANGELOG.md
@@ -7,6 +7,30 @@ Conventions: `corpan/CHANGELOGS.md`.
 
 ## [Unreleased]
 
+### Security
+- **The dev server no longer hands out signing material.** `vite.config.ts` had
+  no `server.fs` block, so Vite's defaults applied: the allowed root is
+  `corpan-app/` — which contains `src-tauri/` — and the default deny list
+  covers `.env` and `*.{crt,pem}` but not `.jks`, `.keystore`, `.p8`,
+  `.mobileprovision`, `.cer` or `.certSigningRequest`. `TAURI_DEV_HOST`, which
+  on-device Android/iOS testing requires, takes the server off loopback and
+  onto the LAN, so while `npm run tauri android dev` was running,
+  `http://<lan-ip>:1421/src-tauri/upload-keystore.jks` returned the Android
+  upload keystore to anyone on the same network. Confirmed with planted
+  throwaway probe files (200 with body before, 403 after) — the real keystore
+  was never read or moved, and it has never been committed. `server.fs.deny`
+  now restates Vite's own defaults (the array is **replaced**, not merged) and
+  adds signing and credential material; `fs.allow` is untouched, because it is
+  a list of roots rather than a subtractive filter and could never have
+  excluded `src-tauri/`. The `/packs` middleware streams from disk and never
+  passes through `server.fs`, so it repeats the check, and its containment test
+  now includes the path separator (a bare `startsWith` also accepted a sibling
+  directory whose name merely prefixed `packs/`). Dev-only: `npm run build`,
+  `vite preview` and the shipped app have no fs guard to weaken and are
+  unaffected. `src/dev/devServer.test.ts` locks all of it in, checking the
+  "defaults preserved" half against the *installed* Vite so a version bump that
+  adds a default cannot slip past. (#536)
+
 ### Changed
 - Retired the vendored `ndk-context` fork (`[patch.crates-io]` +
   `src-tauri/vendor/ndk-context/`). It had been inert since 0.16.0, when

--- a/corpan/corpan-app/RELEASE_SETUP.md
+++ b/corpan/corpan-app/RELEASE_SETUP.md
@@ -60,6 +60,15 @@ repo, no secret needed.
 The app must exist in Play Console with an **internal testing** track and at
 least one internal tester (you) before the first upload.
 
+> **Where the keystore lives.** `corpan-app/src-tauri/upload-keystore.jks` is
+> inside the Vite dev server's root, and `TAURI_DEV_HOST` (on-device Android
+> testing) binds that server to the LAN. `.gitignore` keeps it out of the repo
+> and `vite.config.ts`'s `server.fs.deny` keeps it off the network, but the
+> durable answer is to keep signing material **outside the repo** — e.g.
+> `~/.corpan-signing/upload-keystore.jks`, referenced by absolute path from
+> `keystore.properties`. Never generate new signing material into a directory a
+> dev server can read.
+
 ---
 
 ## Honest caveats (read before the first run)

--- a/corpan/corpan-app/src/dev/devServer.test.ts
+++ b/corpan/corpan-app/src/dev/devServer.test.ts
@@ -1,0 +1,189 @@
+// What the dev server is willing to hand out over HTTP, as a gate rather than
+// a comment in vite.config.ts.
+//
+// `server.fs` has no effect on `npm run build`, on `vite preview`, or on the
+// shipped Tauri bundle — Rollup has no fs guard and the installed app loads
+// from its bundle, not from a server. So nothing here protects a Corpán user.
+// What it protects is the founder's machine, while `npm run dev` /
+// `npm run tauri android dev` is running.
+//
+// That window is not hypothetical. `TAURI_DEV_HOST` is how you run on a phone,
+// and setting it takes the server off 127.0.0.1 and onto the LAN, where every
+// file the fs guard allows is readable by any host on the network. The repo is
+// public, so its source is not the concern. The concern is the material that is
+// deliberately NOT in it: `src-tauri/.gitignore` ignores `*.jks` precisely
+// because an upload keystore is expected to live inside the dev server's root.
+//
+// Rather than parse vite.config.ts as text, this resolves it through Vite and
+// asks the resolved config's own matcher. `fsDenyGlob` is the exact picomatch
+// instance `server.fs` uses at request time, so a passing test here means the
+// real server denies these paths — and the "Vite's defaults survive" check is
+// computed from the INSTALLED Vite rather than from a hardcoded list, so a
+// version bump that adds a default cannot slip past it.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { resolveConfig } from "vite"
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const appRoot = path.resolve(here, "../..")
+const configFile = path.join(appRoot, "vite.config.ts")
+
+type ResolvedWithMatcher = Awaited<ReturnType<typeof resolveConfig>> & {
+  fsDenyGlob: (file: string) => boolean
+}
+
+const resolve = async (configArg: string | false) =>
+  (await resolveConfig(
+    { configFile: configArg, root: appRoot, logLevel: "silent" },
+    "serve"
+  )) as ResolvedWithMatcher
+
+const ours = await resolve(configFile)
+// The same Vite, with no config at all: its untouched defaults.
+const bare = await resolve(false)
+
+/**
+ * Credential material that can plausibly land inside this app's tree. Every
+ * one of these was served with a 200 and its body before the deny list existed.
+ */
+const MUST_BE_DENIED = [
+  "src-tauri/upload-keystore.jks",
+  "src-tauri/release.keystore",
+  "src-tauri/AuthKey_ABC123.p8",
+  "src-tauri/dist.p12",
+  "src-tauri/gen/apple/build/embedded.mobileprovision",
+  "src-tauri/distribution.cer",
+  "src-tauri/CertificateSigningRequest.certSigningRequest",
+  "src-tauri/play-service-account.json",
+  ".env",
+  ".env.local",
+]
+
+/** Things `npm run dev` must keep serving. */
+const MUST_BE_SERVED = [
+  "src/main.tsx",
+  "index.html",
+  "public/locales/en/common.json",
+  "src-tauri/tauri.conf.json",
+  "../packs/drift/manifest.json",
+]
+
+test("the dev server denies signing and credential material", () => {
+  const served = MUST_BE_DENIED.filter((file) => !ours.fsDenyGlob(path.join(appRoot, file)))
+  assert.deepEqual(served, [], "the dev server would hand these files to anyone who asks")
+})
+
+test("the deny list does not swallow the app itself", () => {
+  const denied = MUST_BE_SERVED.filter((file) => ours.fsDenyGlob(path.join(appRoot, file)))
+  assert.deepEqual(denied, [], "the deny list is too broad — dev would 403 on these")
+})
+
+/**
+ * A concrete filename each glob would match, so "did we keep Vite's defaults"
+ * can be asked behaviourally instead of by string equality. Our list is a
+ * deliberate superset — `*.{crt,pem,key,p12,pfx,cer,der}` covers 8.0's
+ * `*.{crt,pem}` without being the same string — and it is the coverage, not
+ * the spelling, that matters.
+ */
+function examplesFor(pattern: string): string[] {
+  const braces = /\{([^}]*)\}/.exec(pattern)
+  if (braces) {
+    return braces[1]
+      .split(",")
+      .flatMap((option) => examplesFor(pattern.replace(braces[0], option.trim())))
+  }
+  return [pattern.replace(/\*\*\//g, "").replace(/\*+/g, "x")]
+}
+
+test("restating the deny list keeps every default of the installed Vite", () => {
+  // Vite REPLACES `server.fs.deny` rather than extending it
+  // (`mergeWithDefaultsRecursively` assigns arrays), so restating five of six
+  // silently drops the sixth: a config that looks like hardening and is the
+  // opposite. `bare` is whatever the installed version ships today, so a Vite
+  // upgrade that adds a default is checked here without anyone editing a list.
+  const uncovered = bare.server.fs.deny
+    .flatMap(examplesFor)
+    .filter((file) => !ours.fsDenyGlob(path.join(appRoot, file)))
+  assert.deepEqual(
+    uncovered,
+    [],
+    "a Vite default is no longer covered by server.fs.deny — the array is replaced, not merged"
+  )
+})
+
+test("the dev server's filesystem reach is not widened past Vite's default", () => {
+  // Vite's default here is this app's own directory: `searchForWorkspaceRoot`
+  // finds no workspace marker above it and falls back to the nearest package
+  // root. `../packs/shared` is reached through the import graph
+  // (`safeModulePaths`, consulted before `allow`), not through this list.
+  //
+  // Note that narrowing `allow` could never have fixed the keystore: `allow` is
+  // a list of roots, not a subtractive filter, and `src-tauri/` is inside the
+  // root the app is served from. `deny` is checked first and is the only lever.
+  assert.deepEqual(
+    ours.server.fs.allow,
+    bare.server.fs.allow,
+    "server.fs.allow no longer matches Vite's default"
+  )
+})
+
+test("the dev server stays on loopback unless TAURI_DEV_HOST is set", () => {
+  // The one switch that puts this server on the network, and the reason the
+  // deny list is load-bearing. An unconditional `host: true` would bind every
+  // interface for every developer, always.
+  //
+  // Asserted as a relationship rather than against an absolute, so running the
+  // suite in a shell that already exports TAURI_DEV_HOST is not a false alarm.
+  const devHost = process.env.TAURI_DEV_HOST
+  assert.equal(
+    ours.server.host,
+    devHost || "127.0.0.1",
+    devHost
+      ? "TAURI_DEV_HOST is set but the dev server did not follow it"
+      : "the dev server no longer defaults to loopback"
+  )
+})
+
+test("the /packs middleware enforces the same denies Vite does", async () => {
+  // This middleware streams from disk itself and never passes through
+  // `server.fs`, so it is a complete bypass of every assertion above unless it
+  // repeats the check.
+  const plugin = ours.plugins.find((p) => p.name === "serve-corpan-packs")
+  assert.ok(plugin?.configureServer, "the pack-serving plugin is gone")
+
+  const routes = new Map<string, (req: any, res: any, next: () => void) => void>()
+  const configure = plugin.configureServer as any
+  await configure({ middlewares: { use: (route: string, fn: any) => routes.set(route, fn) } })
+  const packs = routes.get("/packs")
+  assert.ok(packs, "/packs is no longer served by this middleware")
+
+  // The rejection is synchronous; falling through to the file lookup is not
+  // (`fs.stat` calls back), so this settles on whichever happens.
+  const ask = (url: string) =>
+    new Promise<{ status: number; passed: boolean }>((done) => {
+      const res = {
+        statusCode: 200,
+        end: () => done({ status: res.statusCode, passed: false }),
+        setHeader: () => {},
+      }
+      packs({ url }, res, () => done({ status: res.statusCode, passed: true }))
+    })
+
+  assert.equal((await ask("/some-pack/upload-keystore.jks")).status, 403, "a keystore under packs/ is servable")
+  assert.equal((await ask("/some-pack/AuthKey.p8")).status, 403, "an App Store Connect key under packs/ is servable")
+  assert.equal((await ask("/some-pack/.env")).status, 403, "a .env under packs/ is servable")
+  // A bare `startsWith(rootDir)` also accepts a sibling directory whose name
+  // merely begins with the root's, so the check has to include the separator.
+  assert.equal(
+    (await ask("/../corpan-app/src-tauri/upload-keystore.jks")).status,
+    403,
+    "path traversal escapes packs/"
+  )
+
+  const legit = await ask("/no-such-pack/manifest.json")
+  assert.equal(legit.status, 200, "a normal pack request is being blocked")
+  assert.ok(legit.passed, "a normal pack request never reached the file lookup")
+})

--- a/corpan/corpan-app/vite.config.ts
+++ b/corpan/corpan-app/vite.config.ts
@@ -6,12 +6,72 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath, URL } from "url";
 
-const pkg = JSON.parse(fs.readFileSync("./package.json", "utf-8"));
+// Relative to this file, not to the working directory, so the config also
+// resolves when something other than `npm run dev` loads it (devServer.test.ts).
+const pkg = JSON.parse(
+  fs.readFileSync(fileURLToPath(new URL("./package.json", import.meta.url)), "utf-8")
+);
 
-// We *can* still read TAURI_DEV_HOST for iOS / future,
-// but we always fall back to 0.0.0.0 so Android can reach us.
+// Tauri sets TAURI_DEV_HOST to the LAN address a phone or tablet has to reach;
+// without it we stay on loopback. (The old comment here claimed a 0.0.0.0
+// fallback — it has been 127.0.0.1 for as long as the line below has read that
+// way, and the difference is the whole point of the deny list.)
+//
+// This is the one switch that takes the dev server off loopback. On-device
+// Android/iOS testing needs it, and while it is set every file the dev server
+// is willing to read is readable by any host on the LAN — which is what makes
+// `server.fs.deny` below load-bearing rather than decorative.
 const rawHost = process.env.TAURI_DEV_HOST;
 const serverHost = rawHost || "127.0.0.1";
+
+// Vite's own `server.fs.deny` default, restated because Vite REPLACES this
+// array rather than extending it (`mergeWithDefaultsRecursively` assigns
+// arrays), so anything we omit here is silently un-denied.
+//
+// This is the UNION of Vite 8.0's four defaults (`.env`, `.env.*`,
+// `*.{crt,pem}`, `**/.git/**`) and 8.1's wider six. package.json floats on
+// `^8.0.0`, so an `npm install` can move between them; a union can only ever
+// be stricter than whichever version is actually installed. `devServer.test.ts`
+// checks this against the installed Vite instead of trusting the comment.
+const VITE_DEFAULT_DENY = [
+  ".env",
+  ".env.*",
+  "*.{crt,pem,key,p12,pfx,cer,der}",
+  ".npmrc",
+  ".yarnrc.yml",
+  "**/.git/**",
+];
+
+// The addition, and the reason this block exists.
+//
+// `src-tauri/` sits INSIDE the dev server's root, `src-tauri/.gitignore`
+// ignores `*.jks` because an upload keystore is expected to live there, and
+// RELEASE_SETUP.md tells you to create one. Un-committed keeps it off GitHub,
+// not off the network. Vite's defaults cover `.p12` (8.1 only) but none of
+// these. `allow` cannot help — it is a list of roots, not a subtractive
+// filter — but `deny` is checked before `allow`, so this holds regardless.
+const SIGNING_MATERIAL_DENY = [
+  "*.{jks,keystore,pkcs12,p8,mobileprovision,provisionprofile,certSigningRequest}",
+  "*service-account*.json",
+];
+
+const DEV_SERVER_DENY = [...VITE_DEFAULT_DENY, ...SIGNING_MATERIAL_DENY];
+
+// The `/packs` middleware below streams files off disk itself and so never
+// passes through Vite's `server.fs` guard. Re-check the same material here or
+// the guard has a hole shaped like `/packs`.
+const DENIED_EXTENSIONS = new Set([
+  ".crt", ".pem", ".key", ".p12", ".pfx", ".cer", ".der",
+  ".jks", ".keystore", ".pkcs12", ".p8", ".mobileprovision",
+  ".provisionprofile", ".certsigningrequest",
+]);
+
+const isDeniedFile = (filePath: string) => {
+  const name = path.basename(filePath).toLowerCase();
+  if (name === ".env" || name.startsWith(".env.")) return true;
+  if (name.endsWith(".json") && name.includes("service-account")) return true;
+  return DENIED_EXTENSIONS.has(path.extname(name));
+};
 
 const packsRoot = fileURLToPath(new URL("../packs", import.meta.url));
 const outPacksRoot = fileURLToPath(
@@ -31,7 +91,9 @@ const serveStaticFromRoot = (rootDir: string) => (req: any, res: any, next: any)
   if (!req.url) return next();
   const requestPath = decodeURIComponent(req.url.split("?")[0]);
   const filePath = path.join(rootDir, requestPath);
-  if (!filePath.startsWith(rootDir)) {
+  // `rootDir + sep`, not `rootDir`: a bare prefix test also accepts a sibling
+  // directory whose name merely starts with the root's ("packs-private").
+  if (!filePath.startsWith(rootDir + path.sep) || isDeniedFile(filePath)) {
     res.statusCode = 403;
     res.end("Forbidden");
     return;
@@ -142,6 +204,16 @@ export default defineConfig(async () => ({
     port: 1421,
     strictPort: true,
     host: serverHost,
+
+    fs: {
+      // No `allow` entry, deliberately. Vite's default is already this app's
+      // own directory (`searchForWorkspaceRoot` finds no workspace marker
+      // above it and falls back to the nearest package root), and the app
+      // reaches `../packs/shared` through the import graph rather than through
+      // `allow` — Vite 8 consults `safeModulePaths` first. Listing anything
+      // here replaces that default and would have to restate `"."` too.
+      deny: DEV_SERVER_DENY,
+    },
 
     // Extra Host-header names the dev server should answer to (e.g. a
     // tailscale MagicDNS name when testing from another device):


### PR DESCRIPTION
## Severity, stated plainly

**Local dev exposure. Not a user-facing vulnerability, and no evidence of compromise.**

Exploiting it needed all of: `TAURI_DEV_HOST` set (which the on-device Android/iOS
workflow requires), the dev server actually running, and an attacker on the same
LAN. `server.fs` has no effect on `npm run build`, on `vite preview`, or on the
shipped Tauri bundle — Rollup has no fs guard and the installed app loads from its
bundle, not from a server. **No Corpán user was ever exposed by this.** The upload
keystore has never been committed (`src-tauri/.gitignore:1`), and nothing here
suggests it was ever fetched. What was at risk was the founder's machine, during
the window a device-testing dev server was up.

It is worth fixing anyway, because the Android upload keystore is the one artifact
that cannot be rotated casually.

## The chain, each link verified

1. `corpan/corpan-app/vite.config.ts` had **no `server.fs` block**, so Vite's
   defaults applied.
2. `fs.allow` defaults to `searchForWorkspaceRoot(root)`. No `pnpm-workspace.yaml`,
   `lerna.json` or `workspaces` field exists above `corpan-app/`, so it falls back
   to the nearest package root — `corpan-app/` itself, which **contains
   `src-tauri/`**. Confirmed by resolving the real config:
   `allow: ["…/corpan/corpan-app", "…/node_modules/vite/dist/client"]`.
3. The installed Vite (8.0.16) denies exactly `[".env", ".env.*", "*.{crt,pem}",
   "**/.git/**"]` — **not** `.jks`, `.keystore`, `.p8`, `.p12`,
   `.mobileprovision`, `.cer` or `.certSigningRequest`.
4. `const serverHost = rawHost || "127.0.0.1"` binds the server to the **LAN**
   whenever `TAURI_DEV_HOST` is set, which is the documented on-device workflow.
5. `corpan-app/src-tauri/upload-keystore.jks` exists on disk (2,760 bytes,
   gitignored) — `RELEASE_SETUP.md` names that path for `ANDROID_KEYSTORE_B64`.

Net: `TAURI_DEV_HOST=<lan-ip> npm run tauri android dev` made
`http://<lan-ip>:1421/src-tauri/upload-keystore.jks` fetchable by anything on the
network. No `/@fs/` prefix needed — the plain path under the dev root is enough.

The same mechanism was proven empirically on Dynawalla in #535; this follows that
pattern rather than inventing a new one.

## Proof

Throwaway probe files with obviously fake contents, planted in a **worktree**
(never the real keystore, which was never read, moved, or committed), against a
dev server bound to `127.0.0.1` only.

**Before** — `GET /@fs/…/src-tauri/<probe>`:

```
probe-upload.jks                 200  FAKE-PROBE-NOT-A-REAL-SECRET probe-upload.jks
probe-release.keystore           200  FAKE-PROBE-NOT-A-REAL-SECRET probe-release.keystore
probe-authkey.p8                 200  FAKE-PROBE-NOT-A-REAL-SECRET probe-authkey.p8
probe-cert.p12                   200  FAKE-PROBE-NOT-A-REAL-SECRET probe-cert.p12
probe-embedded.mobileprovision   200  FAKE-PROBE-NOT-A-REAL-SECRET probe-embedded.mobileprovision
probe-dist.cer                   200  FAKE-PROBE-NOT-A-REAL-SECRET probe-dist.cer
probe-req.certSigningRequest     200  FAKE-PROBE-NOT-A-REAL-SECRET probe-req.certSigningRequest
probe-play-service-account.json  200  FAKE-PROBE-NOT-A-REAL-SECRET probe-play-service-account.json
probe-cert.pem                   403  (Vite default)
.env                             403  (Vite default)
```

`GET /src-tauri/probe-upload.jks` (no `/@fs`) was also **200 with the body**.

**After**, same probes, both routes:

```
--- signing material under the dev root ---
  403 /src-tauri/probe-upload.jks
  403 /src-tauri/probe-release.keystore
  403 /src-tauri/probe-authkey.p8
  403 /src-tauri/probe-cert.p12
  403 /src-tauri/probe-embedded.mobileprovision
  403 /src-tauri/probe-dist.cer
  403 /src-tauri/probe-req.certSigningRequest
  403 /src-tauri/probe-play-service-account.json
--- /packs middleware (never sees server.fs) ---
  403 /packs/probe-pack/upload-keystore.jks
  403 /packs/../corpan-app/src-tauri/probe-upload.jks
--- legitimate traffic ---
  200 /
  200 /src/main.tsx
  200 /locales/en/common.json
  200 /packs/drift/manifest.json
  200 /packs/hover-runner/manifest.json
```

And the app's whole dev module graph still resolves, including the 16 modules that
live outside the allowed root in `../packs/shared`:

```
crawled 342 modules from /src/main.tsx
modules resolved out of ../packs/shared: 16
non-200 responses: 0
```

All probes deleted afterwards. The real `upload-keystore.jks` is byte-identical and
its mtime is unchanged (`size=2760 mtime=1753686732 md5=4315f8…`) before and after.

## What changed

**`server.fs.deny`** — Vite **replaces** this array rather than extending it
(`mergeWithDefaultsRecursively` assigns arrays), so anything omitted is silently
un-denied. The config restates the defaults as the **union of Vite 8.0's four and
8.1's six**: `package.json` floats on `^8.0.0`, 8.0.16 is installed here while
Dynawalla resolved 8.1.x with a wider list, and an `npm install` can move between
them. A union can only ever be stricter than whichever version is installed. On top
of that: `*.{jks,keystore,pkcs12,p8,mobileprovision,provisionprofile,certSigningRequest}`
and `*service-account*.json`.

**`fs.allow` is deliberately untouched.** It is a list of roots, not a subtractive
filter, so it could never have excluded `src-tauri/` — which is *inside* the root
the app is served from. `deny` is checked first and is the only lever that reaches
this. Narrowing would also put the `@shared` → `../packs/shared` seam at risk (16
modules, served via Vite 8's `safeModulePaths` import-graph reachability) for zero
security gain. Leaving it at the default keeps `npm run dev` exactly as it was.

**The `/packs` middleware repeats the check.** It streams files off disk itself and
never passes through `server.fs`, so it was a complete bypass of the deny list for
anything under `corpan/packs/` or `web/io/out/corpan/packs/`. Its containment test
also grew a path separator: `filePath.startsWith(rootDir)` accepts a sibling
directory whose name merely prefixes the root's (`packs-private/`).

**`src/dev/devServer.test.ts`** (6 tests, in the existing `npm test` Node runner).
Rather than parsing the config as text, it resolves it through Vite and queries the
resolved config's own `fsDenyGlob` — the exact picomatch instance the server uses at
request time. The "Vite's defaults survive" half is computed from the *installed*
Vite (`resolveConfig({ configFile: false })`) and compared behaviourally, so a
version bump that adds a default is caught with nobody editing a hardcoded list.

Mutation-proved — each break, and the test that caught it:

| Mutation | Test that failed |
|---|---|
| drop the signing-material deny line | denies signing and credential material |
| drop `.env` / `.env.*` from the restated defaults | that, **and** keeps every default of the installed Vite |
| delete the whole `server.fs` block | denies signing and credential material |
| widen `fs.allow` to the monorepo | filesystem reach is not widened past Vite's default |
| drop the deny check from the `/packs` middleware | `/packs` middleware enforces the same denies |
| over-broad deny (`*.json`) | deny list does not swallow the app itself |
| bind to `0.0.0.0` unconditionally | server stays on loopback unless `TAURI_DEV_HOST` |

**Docs** — `corpan/DEV_LOOP.md` gains a short "Signing material must not be readable
by the dev server" section (where the founder actually works), and
`corpan-app/RELEASE_SETUP.md` gains a note next to the keystore secret.

Also fixed in passing: the config read `./package.json` relative to the *working
directory* (now relative to the config file, so the test can load it), and the
comment above `serverHost` claimed a `0.0.0.0` fallback that has not been true.

## Checks

- `npm test` — 695/695 pass (6 new)
- `npm run tsc` — clean
- `npm run build` — succeeds (unchanged; `server.fs` is dev-only)

## Audit of every other Vite config in the repo

`web/io` is Next.js, so it has no `server.fs` at all — out of scope.

| Config | Host binding | `server.fs` | Verdict |
|---|---|---|---|
| `corpan/corpan-app` | `TAURI_DEV_HOST` → LAN | **fixed here** | was exposed, keystore present |
| `dynawalla/dynawalla-app` | `TAURI_DEV_HOST` → LAN | fixed in #535 | done |
| `corpus-reader` | `TAURI_DEV_HOST` → LAN | none | **same shape**, `src-tauri/` present, **no credential material on disk today** |
| `homeschool-offline/app` | `TAURI_DEV_HOST` → LAN | none | same shape, no credential material today |
| `panko/pako` | `TAURI_DEV_HOST` → LAN | none | same shape, no credential material today |
| `corpan/plugins/tauri-plugin-iap/examples/iap-demo` | `TAURI_DEV_HOST` → LAN | none | same shape, demo only |
| `packs/shared/capabilities/{pronounce,segment-player,squeeze}/harness` | **`host: "0.0.0.0"` unconditionally** | none | always on the LAN when run, but its root resolves to the capability's own directory — no credentials in reach |
| the 16 pack configs (`beatlounge`, `corpan-city`, `drift`, …) | default (loopback) | none | not exposed |

Deliberately **not** fixed here, to keep this reviewable: none of the four Tauri
side-apps currently has signing material on disk, and none ships to a store. They
each need the same block the moment someone generates a keystore in them —
`RELEASE_SETUP.md`-style instructions are exactly how that happens. The harnesses'
unconditional `0.0.0.0` is worth a second look on its own merits; it is a wider
default than anything else in the repo.

## Three things to decide, not fixed here

**1. The keystore should live outside any served root.** `RELEASE_SETUP.md` (both
Corpán and Dynawalla) points at `src-tauri/` as the place to keep an upload
keystore, and that instruction is what created this hazard. `~/.corpan-signing/`,
referenced by absolute path from `keystore.properties`, removes the class rather
than the instance. The deny list is a backstop, not the answer. This PR adds a note
saying so; moving the file is the founder's call, since CI reads it from
`ANDROID_KEYSTORE_B64` and only local builds touch the file.

**2. The two `embedded.mobileprovision` files under `src-tauri/gen/apple/build/` are
the mildest item here.** A provisioning profile is a signed plist listing an app id,
team id, entitlements, device UDIDs and the *public* signing certificates. It
contains **no private key** — it is useless for signing without the `.p12` in the
keychain. Realistic downside is disclosure of device UDIDs and the team id (already
public in this repo). They are denied now because they are cheap to deny, not
because they were the emergency.

**3. `hygiene.yml`/gitleaks catches only half this class.** Tested empirically with
gitleaks 8.18.4 — the exact version the workflow pins — against a throwaway
`keytool` keystore and matching PEM/PKCS12 material, in a scratch repo (all deleted):

```
FLAGGED  play-service-account.json    rule=private-key
FLAGGED  AuthKey_THROWAWAY.p8         rule=private-key
MISSED   throwaway.jks
MISSED   throwaway.keystore
MISSED   throwaway.p12
MISSED   throwaway.crt
```

PEM-armoured keys trip `private-key`; binary keystores carry no such marker and slip
through, and at 2.5 KB the 5 MiB big-file guard never sees them. A filename guard in
the `hygiene` job would close it cheaply:

```yaml
- name: No signing material in the diff
  run: |
    set -euo pipefail
    bad=$(git diff --name-only --diff-filter=A "${BASE}..${HEAD}" \
      | grep -Ei '\.(jks|keystore|p12|pfx|p8|mobileprovision|provisionprofile)$' || true)
    [ -z "$bad" ] || { echo "signing material added: $bad"; exit 1; }
```

Left out of this PR on purpose — it is a CI change, not a dev-server change, and it
deserves its own review.
