### PR TITLE
fix(ci): calibrate the adversarial security lens on impact, not confidence

### DIFF
--- a/.github/scripts/adversarial_review.py
+++ b/.github/scripts/adversarial_review.py
@@ -31,17 +31,27 @@ finding this gate ever produced was mechanically correct and over-graded, and
 the cause was an uncalibrated one-sentence security prompt next to three
 paragraphs of correctness calibration.
 
-CONFIRMATION. A finding that grades HIGH is re-asked once, alone, against the
-WHOLE FILE at head instead of one diff chunk. Only a positive "not a blocking
-problem" verdict clears it; a confirmed HIGH, an errored confirmation, an
-unparseable verdict, and a HIGH we could not build full-file context for all
-still block. Cleared HIGHs are NOT hidden — they are listed in the sticky
-comment and logged, so an over-eager clear is visible. Confirmation costs one
-call per HIGH finding and nothing at all on a clean diff.
+CONFIRMATION. A finding that grades HIGH is re-asked once, alone, against BOTH
+the whole file at head AND the diff this branch applied to that file — the two
+halves the first pass lacked. The diff is not decoration: a finding about
+something the change REMOVED (a deleted guard, a dropped back-compat alias) is
+invisible in head state, where the honest read is "I see no such code", so a
+head-only confirmer would clear exactly the change-relative findings the
+correctness and pack-compat lenses exist to catch. A HIGH naming a file the
+reviewed range never touched is NOT confirmed at all — the second pass would be
+reading unrelated pre-existing code — and stays blocking.
+
+Only a positive "not a blocking problem" verdict clears a HIGH; a confirmed
+HIGH, an errored confirmation, an unparseable verdict, an off-diff file, an
+unreadable file and over-budget context all still block. Cleared HIGHs are NOT
+hidden — they are listed in the sticky comment and logged, so an over-eager
+clear is visible. Confirmation costs one call per DISTINCT finding (all three
+lenses reporting one defect share a single call) and nothing on a clean diff.
 
 MODELS are pinned to ALLOWED_MODELS. ADVERSARIAL_MODEL can only select from
 that set, so weakening every lens at once takes a PR through this gate rather
-than a silent repo-variable edit with no audit trail.
+than a silent repo-variable edit with no audit trail. It is NOT a spend knob:
+an unrecognised value is a hard error, not a fallback.
 
 There is deliberately NO waiver, suppression, annotation, or PR-body override.
 See the note above confirm_findings before adding one.
@@ -65,7 +75,10 @@ secret to add). Self-contained: stdlib only (urllib), so CI needs no pip install
 Env:
   ANTHROPIC_API_KEY   if set → review via Claude (preferred)
   OPENAI_KEY / OPENAI_API_KEY   fallback → review via OpenAI
-  ADVERSARIAL_MODEL   model id override; MUST be in ALLOWED_MODELS[provider]
+  ADVERSARIAL_MODEL   model id override; MUST be in ALLOWED_MODELS[provider].
+                      Anything else is a hard error, NOT a fallback — so this
+                      is not a cost lever, and setting it to an unlisted id
+                      reds this required check until it is unset again.
   ADVERSARIAL_WORKERS concurrent model calls (default 3)
   GITHUB_TOKEN        for posting the sticky PR comment (optional in merge_group)
   GITHUB_REPOSITORY   owner/repo (set by Actions)
@@ -102,12 +115,26 @@ MARKER = "<!-- adversarial-review -->"
 # every check stayed green. Widening this set is a code change that must itself
 # pass this gate.
 #
-# Keep entries to models actually validated against these prompts. The OpenAI
-# branch lists only the id this repo has ever run, deliberately: an id that
-# does not exist is a 400, which is a lens error, which is a repo-wide block —
-# so a guessed entry is worse than no entry.
+# Every entry must be an id this gate has ACTUALLY RUN against these prompts
+# and this exact request shape, so today each provider lists exactly one: the
+# default. ADVERSARIAL_MODEL has never been set, so nothing else has ever been
+# exercised, and an entry that fails is a 400 → a lens error → a repo-wide
+# block. A guessed entry is worse than no entry.
+#
+# The first draft of this list also carried claude-fable-5 and claude-opus-4-8.
+# Neither had run. Both are one repo-variable edit from a repo-wide red: this
+# script always sends `fallbacks: "default"` under the
+# server-side-fallback-2026-07-01 beta, and the fallback target set is a
+# property of the REQUESTED model (claude-opus-4-8 is itself Opus 5's documented
+# fallback target), while claude-fable-5 additionally requires 30-day
+# organization data retention or every request 400s. Unproven against the
+# payload we send = not in the set.
+#
+# Widening it means running the candidate against this script and updating
+# test_the_allow_list_holds_only_ids_this_gate_has_run — deliberately, in a PR
+# that passes this gate.
 ALLOWED_MODELS = {
-    "anthropic": {"claude-opus-5", "claude-fable-5", "claude-opus-4-8"},
+    "anthropic": {"claude-opus-5"},
     "openai": {"gpt-4.1"},
 }
 
@@ -405,10 +432,16 @@ CONFIRM_MARKER = "SECOND-PASS CONFIRMATION"
 CONFIRM_HINT = (
     CONFIRM_MARKER + ". A first-pass reviewer saw ONE CHUNK of a unified diff "
     "and graded the finding below at blocking severity. You are now looking at "
-    "the COMPLETE file as it stands at the head of this branch — the full "
-    "context that pass did not have.\n\n"
+    "BOTH halves of the context that pass did not have: the COMPLETE CHANGE "
+    "this branch made to the file, and the COMPLETE FILE as it stands at the "
+    "head of the branch.\n"
+    "Read BOTH. The diff is the only place a REMOVAL is visible — if the "
+    "finding is about something the change deleted, renamed, or replaced (a "
+    "dropped guard, a removed alias, a deleted check), the head file will not "
+    "contain it and its absence there is NOT evidence the finding is wrong. "
+    "The file is where you see the surrounding code the chunk cut off.\n\n"
     "Decide one thing: is this a real, blocking-severity problem?\n"
-    "Answer false when the full file shows the concern is already handled, "
+    "Answer false when the full context shows the concern is already handled, "
     "when it rested on context the chunk was missing, when the code is not "
     "what the first pass took it for, or when it is a real defect that the "
     "severity ladder does not put at HIGH.\n"
@@ -416,7 +449,7 @@ CONFIRM_HINT = (
     "specific thing they gain, per that ladder.\n\n"
     "This is a precision check on ONE finding, not a re-review: do not look "
     "for new problems, and do not confirm this finding because you noticed a "
-    "different one. If the file does not let you decide, answer true — an "
+    "different one. If the context does not let you decide, answer true — an "
     "undecidable blocking finding stays blocking.\n\n"
     'Respond with ONLY a JSON object, no prose: {"confirmed": true|false, '
     '"reason": "one sentence"}'
@@ -428,15 +461,16 @@ CONFIRM_SYSTEM = (
     "real defects: a wrong block and a missed defect are both failures."
 )
 
-# Confirmation reads whole files, so it needs its own ceiling. A file over this
-# budget is not confirmed at all rather than confirmed against a truncated
-# view — truncation is what the first pass already suffered from, and
-# "confirmed against half a file" is a worse answer than "not checked".
-CONFIRM_MAX_FILE_CHARS = 400000
+# Confirmation reads a whole file PLUS the change that produced the finding, so
+# it needs its own ceiling — measured over both, because that is what is sent.
+# Context over this budget is not confirmed at all rather than confirmed against
+# a truncated view: truncation is what the first pass already suffered from, and
+# "confirmed against half the context" is a worse answer than "not checked".
+CONFIRM_MAX_CONTEXT_CHARS = 400000
 
-# Upper bound on confirmation calls per run. Past this the PR is thoroughly
-# blocked anyway, and the remaining HIGHs stay blocking unchecked — the
-# fail-closed direction.
+# Upper bound on confirmation calls per run, counted over DISTINCT findings.
+# Past this the PR is thoroughly blocked anyway, and the remaining HIGHs stay
+# blocking unchecked — the fail-closed direction.
 MAX_CONFIRMATIONS = 20
 
 
@@ -606,6 +640,34 @@ def get_diff(spec):
                 "refusing to pass a review that read nothing."
             )
     return diff
+
+
+def changed_files(spec):
+    """The set of paths `spec` changed, spelled exactly as git spells them.
+
+    Used to reject a finding whose file the branch never touched. `-z` because
+    core.quotePath renders a non-ASCII path as a C-quoted string that would
+    never match the path `git show` resolved, turning a legitimate confirmation
+    into a skip for anyone with an accented filename.
+    """
+    rc, out, err = run(["git", "diff", "--name-only", "-z", spec])
+    if rc != 0:
+        raise ReviewError(
+            f"git diff --name-only {spec} failed (exit {rc}): {err.strip()}"
+        )
+    return {name for name in out.split("\0") if name}
+
+
+def file_diff(spec, path):
+    """The unified diff this branch applied to one path, or "" if git failed.
+
+    Empty is safe rather than fail-closed here: the caller has already
+    established the path IS in the reviewed range, and losing the diff only
+    degrades the second pass to the head-only view it had before — which
+    answers "true" (blocking) when it cannot decide.
+    """
+    rc, out, _ = run(["git", "diff", "--unified=3", spec, "--", path])
+    return out if rc == 0 else ""
 
 
 # ------------------------------------------------------------------- chunking
@@ -1253,8 +1315,21 @@ def is_blocking(finding):
     return finding.get("confirmation") != CONFIRM_CLEARED
 
 
+class FileAtHead(NamedTuple):
+    """A file the confirmation pass resolved, and the path git resolved it AT.
+
+    `path` matters as much as `text`: `file_at` tries several spellings of a
+    model-supplied path, so the caller must test membership of the reviewed
+    diff against the spelling git actually accepted, not the one the model
+    wrote.
+    """
+
+    path: str
+    text: str
+
+
 def file_at(head, path):
-    """Full text of `path` at `head`, or None when it cannot be read.
+    """`FileAtHead` for `path` at `head`, or None when it cannot be read.
 
     None is a legitimate answer — a deleted file, a path the model invented,
     or a binary blob — and the caller treats it as "cannot confirm", which
@@ -1265,48 +1340,73 @@ def file_at(head, path):
     path = (path or "").strip()
     if not path or "\n" in path or len(path) > 400 or path in ("?", "<unknown>"):
         return None
-    candidates = [path]
-    # Diff headers are `a/<path>` / `b/<path>` and models sometimes copy the
-    # prefix into the finding. Try the literal path FIRST so a real top-level
-    # `a/` directory is never shadowed by the stripped form.
-    if path.startswith(("a/", "b/")):
-        candidates.append(path[2:])
+    candidates = []
+    # `./` FIRST, unlike the diff prefixes below. A git tree can never hold a
+    # literal `./` entry; `git show <head>:./x` resolves only because the rev
+    # parser expands it against the working directory, and the caller would
+    # then be holding a spelling `git diff --name-only` never prints — so a
+    # `./`-prefixed finding would look like it named an untouched file.
     if path.startswith("./"):
+        candidates.append(path[2:])
+    candidates.append(path)
+    # Diff headers are `a/<path>` / `b/<path>` and models sometimes copy the
+    # prefix into the finding. Try the literal path FIRST here, so a real
+    # top-level `a/` directory is never shadowed by the stripped form; when the
+    # prefix IS an artifact the literal simply does not resolve.
+    if path.startswith(("a/", "b/")):
         candidates.append(path[2:])
     for candidate in candidates:
         rc, out, _ = run(["git", "show", f"{head}:{candidate}"])
         if rc == 0:
-            return out
+            return FileAtHead(candidate, out)
     return None
 
 
-def build_confirm_prompt(finding, source):
-    """The single-finding, whole-file question put to the second pass."""
-    lens = str(finding.get("lens") or "")
-    location = str(finding.get("file", "?"))
+def build_confirm_prompt(finding, lenses, source, diff):
+    """The single-finding question put to the second pass.
+
+    Carries BOTH halves of the context the first pass lacked: the change this
+    branch made to the file, and the whole file at head. The diff is NOT
+    optional. A finding about something the change deleted — a removed guard, a
+    dropped back-compat alias, a deleted platform floor — cannot be judged from
+    head state, where the thing simply is not present and the honest reading is
+    "I see no such code, not a blocking problem". That is a clearance, and it
+    is wrong, and it is the shape most of what the correctness and pack-compat
+    lenses look for takes.
+
+    `lenses` is every lens that reported this finding: one defect all three
+    noticed is confirmed once, so the confirmer gets all three framings.
+    """
+    path = str(finding.get("file", "?"))
+    location = path
     if finding.get("line"):
         location += f":{finding['line']}"
+    instructions = "\n\n".join(LENSES[name] for name in lenses if name in LENSES)
+    change = diff.strip() or "(git produced no diff for this path)"
     return (
-        f"{LENSES.get(lens, '')}\n\n{SEVERITY_LADDER}\n\n{CONFIRM_HINT}\n\n"
-        f"FINDING (reported by the {lens} lens at blocking severity)\n"
+        f"{instructions}\n\n{SEVERITY_LADDER}\n\n{CONFIRM_HINT}\n\n"
+        f"FINDING (reported at blocking severity by: "
+        f"{', '.join(lenses) or 'unknown'})\n"
         f"location: {location}\n"
         f"title: {str(finding.get('title', '')).strip()}\n"
         f"detail: {str(finding.get('detail', '')).strip()}\n\n"
-        f"COMPLETE CURRENT CONTENTS OF `{finding.get('file', '?')}`:\n"
+        f"THE CHANGE UNDER REVIEW — what this branch did to `{path}`:\n"
+        f"```diff\n{change}\n```\n\n"
+        f"COMPLETE CONTENTS OF `{path}` AT THE HEAD OF THIS BRANCH:\n"
         f"```\n{source}\n```"
     )
 
 
-def _confirm_one(provider, key, model, finding, source):
+def _confirm_one(provider, key, model, finding, lenses, source, diff):
     """Second-pass verdict on one finding. Returns (state, reason)."""
-    label = f"confirmation of {finding.get('lens')} finding in {finding.get('file')}"
+    label = f"confirmation of {'/'.join(lenses)} finding in {finding.get('file')}"
     try:
         raw = call_model(
             provider,
             key,
             model,
             CONFIRM_SYSTEM,
-            build_confirm_prompt(finding, source),
+            build_confirm_prompt(finding, lenses, source, diff),
             schema=CONFIRM_SCHEMA,
         )
     except Exception as e:  # noqa: BLE001
@@ -1323,13 +1423,34 @@ def _confirm_one(provider, key, model, finding, source):
     return (CONFIRM_UPHELD if confirmed else CONFIRM_CLEARED), reason
 
 
-def confirm_findings(provider, key, model, findings, head, workers):
-    """Re-check every blocking-severity finding against its whole file.
+def _mark(group, state, reason):
+    """Record one confirmation outcome across every finding that shares it."""
+    for f in group:
+        f["confirmation"] = state
+        f["confirmation_reason"] = reason
+
+
+def confirm_findings(provider, key, model, findings, rng, changed, workers):
+    """Re-check every blocking-severity finding against its file AND its diff.
 
     This targets the gate's measured failure mode: ONE low-precision call that
     saw a diff chunk and nothing else. It runs only on HIGH findings, so a
     clean diff costs nothing and a normal diff costs at most a handful of
     calls.
+
+    THREE things must hold before a HIGH is re-asked at all; each failure is a
+    SKIP, which keeps the finding blocking:
+
+      * the severity was a graded judgment (an unreadable one is not a judgment
+        to re-check — it fails closed on its own terms),
+      * the file resolves at head, and
+      * the resolved file is IN the reviewed range. A model naming the wrong
+        file is a routine error — a chunk spans several files and the finding
+        lands under the wrong `diff --git` header — and confirming it would
+        send the second pass into unrelated code that predates this branch,
+        where the correct answer to "is this a real, blocking problem" is
+        "no". That is a clearance produced by a mis-typed path, which is the
+        least reliable field in the whole finding.
 
     DELIBERATE: this is the ONLY mechanism that can stop a HIGH from blocking,
     and it is the model re-reading the file. There is NO waiver, no suppression
@@ -1351,37 +1472,74 @@ def confirm_findings(provider, key, model, findings, head, workers):
             continue
         pending.append(f)
 
-    for f in pending[MAX_CONFIRMATIONS:]:
-        f["confirmation"] = CONFIRM_SKIPPED
-        f["confirmation_reason"] = (
-            f"more than {MAX_CONFIRMATIONS} blocking findings — not re-checked"
+    # One call per DISTINCT defect, not per lens that noticed it. dedupe() keys
+    # on the lens as well, so a single defect all three lenses report survives
+    # as three findings — and confirming each of them separately spent three
+    # whole-file calls, from a fixed budget, asking one question. Group them and
+    # fan the verdict back out.
+    groups = {}
+    for f in pending:
+        ident = (str(f.get("file")), str(f.get("line")), str(f.get("title")))
+        groups.setdefault(ident, []).append(f)
+    ordered = list(groups.values())
+
+    for group in ordered[MAX_CONFIRMATIONS:]:
+        _mark(
+            group,
+            CONFIRM_SKIPPED,
+            f"more than {MAX_CONFIRMATIONS} distinct blocking findings — "
+            "not re-checked",
         )
 
     jobs = []
-    for f in pending[:MAX_CONFIRMATIONS]:
-        source = file_at(head, str(f.get("file") or ""))
-        if source is None:
-            f["confirmation"] = CONFIRM_SKIPPED
-            f["confirmation_reason"] = "could not read the full file at head"
-        elif len(source) > CONFIRM_MAX_FILE_CHARS:
-            f["confirmation"] = CONFIRM_SKIPPED
-            f["confirmation_reason"] = (
-                f"file exceeds the {CONFIRM_MAX_FILE_CHARS}-char confirmation budget"
+    for group in ordered[:MAX_CONFIRMATIONS]:
+        at_head = file_at(rng.head, str(group[0].get("file") or ""))
+        if at_head is None:
+            _mark(group, CONFIRM_SKIPPED, "could not read the full file at head")
+            continue
+        if at_head.path not in changed:
+            _mark(
+                group,
+                CONFIRM_SKIPPED,
+                f"`{at_head.path}` is not in the reviewed diff — not re-checked",
             )
-        else:
-            jobs.append((f, source))
+            continue
+        diff = file_diff(rng.spec, at_head.path)
+        if len(at_head.text) + len(diff) > CONFIRM_MAX_CONTEXT_CHARS:
+            _mark(
+                group,
+                CONFIRM_SKIPPED,
+                f"file and diff exceed the {CONFIRM_MAX_CONTEXT_CHARS}-char "
+                "confirmation budget",
+            )
+            continue
+        lenses = list(dict.fromkeys(str(f.get("lens") or "") for f in group))
+        jobs.append((group, lenses, at_head.text, diff))
+
+    # The lens pass has already spent from the same wall clock. Say so rather
+    # than letting every remaining call fail one at a time and reporting it as
+    # "confirmation call failed", which reads as a provider outage.
+    if jobs and _time_left() <= 0:
+        for group, *_ in jobs:
+            _mark(
+                group,
+                CONFIRM_SKIPPED,
+                "review time budget exhausted before the confirmation pass",
+            )
+        jobs = []
 
     if jobs:
         with ThreadPoolExecutor(max_workers=max(1, workers)) as pool:
             results = list(
                 pool.map(
-                    lambda job: _confirm_one(provider, key, model, job[0], job[1]),
+                    lambda job: _confirm_one(
+                        provider, key, model, job[0][0], job[1], job[2], job[3]
+                    ),
                     jobs,
                 )
             )
-        for (f, _), (state, reason) in zip(jobs, results):
-            f["confirmation"] = state
-            f["confirmation_reason"] = reason
+        for (group, *_), (state, reason) in zip(jobs, results):
+            _mark(group, state, reason)
     return findings
 
 
@@ -1408,9 +1566,12 @@ def render_markdown(audit, all_findings):
         for f in all_findings
         if f["severity_norm"] == "high" and not is_blocking(f)
     ]
-    # Partition by IDENTITY, not equality: `f not in cleared` compares dicts by
-    # value, so two findings that happen to render identically would both
-    # vanish from the main list.
+    # Partition by IDENTITY, not equality. Defensive rather than load-bearing:
+    # every cleared finding carries confirmation == CONFIRM_CLEARED and every
+    # blocking one carries something else, so no cleared/blocking pair can be
+    # dict-equal today and `f not in cleared` would behave the same. Identity is
+    # free, is right whatever a later change does to those fields, and is not
+    # O(n^2) — but it is not fixing an observed bug.
     cleared_ids = {id(f) for f in cleared}
     listed = [f for f in all_findings if id(f) not in cleared_ids]
 
@@ -1607,6 +1768,9 @@ def main():
         workers = int(os.environ.get("ADVERSARIAL_WORKERS") or DEFAULT_WORKERS)
         rng = resolve_range()
         diff = get_diff(rng.spec)
+        # Resolved once, up front, and used by the confirmation pass to reject
+        # a finding whose file this branch never touched.
+        changed = changed_files(rng.spec)
         chunks, oversized, hard_split = chunk_diff(diff, budget)
         # Coverage is the whole point of chunking. Assert it before spending a
         # single API call, and fail closed if the split ever loses a character.
@@ -1679,9 +1843,12 @@ def main():
 
     findings = dedupe(findings)
     # Precision pass on blocking findings only: re-read each against its whole
-    # file. Only an explicit clearance stops one blocking; every other outcome,
-    # including an API error, leaves it blocking.
-    findings = confirm_findings(provider, key, model, findings, rng.head, workers)
+    # file AND the change this branch made to it. Only an explicit clearance
+    # stops one blocking; every other outcome, including an API error, an
+    # off-diff file, and an exhausted budget, leaves it blocking.
+    findings = confirm_findings(
+        provider, key, model, findings, rng, changed, workers
+    )
     body, blocking = render_markdown(audit, findings)
     publish(body)
 

--- a/.github/scripts/adversarial_review.py
+++ b/.github/scripts/adversarial_review.py
@@ -23,6 +23,29 @@ is an answer we merely do not recognise, and blocking on it would let a typo
 wedge the queue. A missing, null, or letterless severity is unreadable input
 and blocks, like every other unreadable reply.
 
+GRADING is calibrated on IMPACT and REACHABILITY, not on confidence. The lenses
+carry SEVERITY_LADDER (what HIGH/MEDIUM/LOW mean here, with worked examples from
+this repository) and the security lens carries a THREAT MODEL for this system —
+a public repo shipping a local Tauri app and a static site. The first blocking
+finding this gate ever produced was mechanically correct and over-graded, and
+the cause was an uncalibrated one-sentence security prompt next to three
+paragraphs of correctness calibration.
+
+CONFIRMATION. A finding that grades HIGH is re-asked once, alone, against the
+WHOLE FILE at head instead of one diff chunk. Only a positive "not a blocking
+problem" verdict clears it; a confirmed HIGH, an errored confirmation, an
+unparseable verdict, and a HIGH we could not build full-file context for all
+still block. Cleared HIGHs are NOT hidden — they are listed in the sticky
+comment and logged, so an over-eager clear is visible. Confirmation costs one
+call per HIGH finding and nothing at all on a clean diff.
+
+MODELS are pinned to ALLOWED_MODELS. ADVERSARIAL_MODEL can only select from
+that set, so weakening every lens at once takes a PR through this gate rather
+than a silent repo-variable edit with no audit trail.
+
+There is deliberately NO waiver, suppression, annotation, or PR-body override.
+See the note above confirm_findings before adding one.
+
 RANGE. The reviewed range is always `merge-base(base, head)..head`. The event's
 base SHA is the base *branch tip*, not the merge base, so a two-dot
 `base..head` on a branch cut from an older main reviews the wrong set of
@@ -42,7 +65,7 @@ secret to add). Self-contained: stdlib only (urllib), so CI needs no pip install
 Env:
   ANTHROPIC_API_KEY   if set → review via Claude (preferred)
   OPENAI_KEY / OPENAI_API_KEY   fallback → review via OpenAI
-  ADVERSARIAL_MODEL   model id override (default per provider)
+  ADVERSARIAL_MODEL   model id override; MUST be in ALLOWED_MODELS[provider]
   ADVERSARIAL_WORKERS concurrent model calls (default 3)
   GITHUB_TOKEN        for posting the sticky PR comment (optional in merge_group)
   GITHUB_REPOSITORY   owner/repo (set by Actions)
@@ -68,6 +91,25 @@ ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
 OPENAI_URL = "https://api.openai.com/v1/chat/completions"
 DEFAULT_MODEL = {"anthropic": "claude-opus-5", "openai": "gpt-4.1"}
 MARKER = "<!-- adversarial-review -->"
+
+# The models this gate is allowed to review with. ADVERSARIAL_MODEL selects
+# FROM this set and cannot introduce a new value.
+#
+# Why an allow-list and not a free-form repo variable: the model is the single
+# input that silently sets the quality of all three lenses at once. As a bare
+# repo variable it could be pointed at something cheap and weak forever, with
+# no PR, no diff, and no audit trail — the whole gate quietly downgraded while
+# every check stayed green. Widening this set is a code change that must itself
+# pass this gate.
+#
+# Keep entries to models actually validated against these prompts. The OpenAI
+# branch lists only the id this repo has ever run, deliberately: an id that
+# does not exist is a 400, which is a lens error, which is a repo-wide block —
+# so a guessed entry is worse than no entry.
+ALLOWED_MODELS = {
+    "anthropic": {"claude-opus-5", "claude-fable-5", "claude-opus-4-8"},
+    "openai": {"gpt-4.1"},
+}
 
 # `max_tokens` on current Claude models caps thinking + visible response
 # together, and thinking is ON BY DEFAULT on claude-opus-5. The old value of
@@ -162,6 +204,28 @@ def provider_and_key():
     return None, None
 
 
+def resolve_model(provider):
+    """Pick the review model, refusing any id outside ALLOWED_MODELS.
+
+    An unrecognised override is an ERROR, not a fallback to the default. A
+    silent fallback would make a typo'd or downgraded ADVERSARIAL_MODEL
+    indistinguishable from an unset one in the logs, which is the audit-trail
+    hole this allow-list exists to close.
+    """
+    allowed = ALLOWED_MODELS[provider]
+    override = (os.environ.get("ADVERSARIAL_MODEL") or "").strip()
+    if not override:
+        return DEFAULT_MODEL[provider]
+    if override not in allowed:
+        raise ReviewError(
+            f"ADVERSARIAL_MODEL={override!r} is not in the {provider} allow-list "
+            f"({', '.join(sorted(allowed))}). The review model sets the quality "
+            "of every lens, so changing it is a code change that must pass this "
+            "gate — not a repo-variable edit."
+        )
+    return override
+
+
 LENSES = {
     "correctness": (
         "You are a correctness reviewer. Find logic bugs, broken edge cases, "
@@ -178,10 +242,43 @@ LENSES = {
         "early-return flag cleared synchronously at entry, or a clamp), treat the "
         "concern as resolved and do NOT re-raise it."
     ),
+    # This lens used to be exactly one sentence — the first four lines below —
+    # while the correctness lens above carried three paragraphs of hard-won
+    # calibration. That asymmetry is what produced this gate's first false
+    # block: a mechanically correct finding, graded HIGH, against a
+    # dev-server-only config change on a public repo. A reviewer told to find
+    # injection/SSRF/authz with no description of the system it is reviewing
+    # will grade against a generic multi-tenant web service, because that is
+    # what those words describe. So describe the system.
     "security": (
         "You are a security reviewer. Find injection, secret/credential exposure, "
         "unsafe deserialization, path traversal, SSRF, missing authz, and unsafe "
-        "handling of untrusted input introduced by this diff."
+        "handling of untrusted input introduced by this diff.\n\n"
+        "THREAT MODEL — grade against THIS system, not a generic web service:\n"
+        "* This repository is PUBLIC and open source. Source disclosure is not "
+        "itself an exposure: reading the code, an endpoint URL, the pack "
+        "catalog, or these security checks themselves gains an attacker nothing "
+        "they could not get by cloning the repo. What matters is real SECRET "
+        "material — keystores, .jks/.p8/.pem/.keystore files, service-account "
+        "JSON, API tokens, signing keys — anything that would still be a leak "
+        "after the source is already published.\n"
+        "* The products are a LOCAL Tauri desktop/mobile app and a STATIC site "
+        "on GitHub Pages. There is no server-side authorization layer, no "
+        "session or tenant boundary, and no multi-tenant data. 'Missing authz', "
+        "'IDOR', and 'privilege escalation' presuppose a server enforcing "
+        "authorization on behalf of many users; if this diff does not add one, "
+        "those findings do not apply. Data the app holds is the user's own data "
+        "on the user's own device — reading it locally is not exfiltration.\n"
+        "* Dev-only surfaces NEVER SHIP and are not in any built artifact: "
+        "`server.*` dev-server config, tests, benches, fixtures, QA harnesses, "
+        "CI workflows and scripts, and local tooling. A weakness that exists "
+        "only while a developer runs a dev server on their own machine is "
+        "bounded by who can reach that machine.\n"
+        "* Untrusted input that genuinely DOES matter here: downloaded content "
+        "packs and the code inside them, catalog/manifest JSON fetched over the "
+        "network, model output, remote narration/book assets, and anything else "
+        "a remote host serves to an installed app.\n"
+        "Grade on IMPACT and REACHABILITY, per the severity ladder below."
     ),
     "pack-compat": (
         "You are a content-pack back-compat reviewer for the Corpán app. Find "
@@ -193,15 +290,61 @@ LENSES = {
     ),
 }
 
+# What the levels MEAN. The old guidance was one clause — "reserve it for real,
+# confident defects" — which grades CONFIDENCE, and HIGH vs MEDIUM was never
+# defined anywhere. A reviewer that is certain about a harmless fact reads that
+# as licence to block, which is exactly what happened. Severity is a claim about
+# impact and reachability; confidence is a separate axis, handled by the
+# confirmation pass, not by the ladder.
+#
+# The two worked examples are real events in this repository and are chosen to
+# share a reachability class and differ only in impact — that is the distinction
+# a reviewer has to be able to make, and abstract definitions do not teach it.
+SEVERITY_LADDER = (
+    "SEVERITY LADDER — only HIGH blocks the merge. Grade on IMPACT and "
+    "REACHABILITY: what an attacker gains, and how they reach it. Do NOT grade "
+    "on how confident you are that you have read the code correctly — a "
+    "certain observation about a harmless fact is still LOW.\n"
+    "* HIGH — someone who is NOT the developer at their own machine gains "
+    "something real: leaked signing material or a live credential, code "
+    "execution or arbitrary file write on a user's device from content the app "
+    "fetches, silent data loss on a user's device, or a shipped artifact that "
+    "is broken for every user. A HIGH must be able to name WHO reaches it and "
+    "WHAT they get.\n"
+    "* MEDIUM — a real defect whose reach or impact is bounded: it needs an "
+    "unlikely precondition, it affects only the developer's own machine, it "
+    "weakens a defense in depth without breaking it, or it degrades one "
+    "feature rather than the shipped artifact.\n"
+    "* LOW — hardening, hygiene, and defense in depth with no concrete path to "
+    "harm; anything confined to tests, benches, fixtures, CI, or dev tooling "
+    "that never ships; and source disclosure in a repository that is already "
+    "public.\n"
+    "Two worked examples from THIS repository. They have the SAME reachability "
+    "— a dev server on a developer's machine — and different grades, because "
+    "the difference is impact, not confidence:\n"
+    "* TRUE HIGH: the Vite dev server served the production Android upload "
+    "KEYSTORE, because Vite's default deny list does not cover `.jks`. Any peer "
+    "on the developer's network could fetch the signing key for the shipped "
+    "app. Real secret, reachable by a non-developer, unfixable by rotation "
+    "alone — that is what HIGH is for.\n"
+    "* NOT HIGH: widening `server.fs.allow` in that same dev-server config so "
+    "Vite may read more of the repository. Dev-server only, never shipped, and "
+    "what it exposes is source code in a public open-source repository — no "
+    "secret, no gain. That is LOW.\n"
+    "If you cannot name a specific actor and a specific consequence, it is not "
+    "HIGH."
+)
+
 SCHEMA_HINT = (
     'Respond with ONLY a JSON object, no prose, of the form:\n'
     '{"findings": [{"severity": "high|medium|low", "file": "path", '
     '"line": "n or range or null", "title": "short", '
     '"detail": "why it is a problem and how to fix"}]}\n'
     "Return an empty findings array if you find nothing. Be precise; do not "
-    "invent issues. Only HIGH severity blocks the merge, so reserve it for real, "
-    "confident defects. Every finding MUST carry a severity — a finding with a "
-    "missing or empty severity is treated as blocking."
+    "invent issues. Grade every finding against the severity ladder above, and "
+    "for a HIGH say in `detail` who reaches it and what they gain. Every "
+    "finding MUST carry a severity — a finding with a missing or empty "
+    "severity is treated as blocking."
 )
 
 # Chunked reviews see one slice of the diff at a time. Without this, a lens
@@ -242,6 +385,59 @@ FINDINGS_SCHEMA = {
     "required": ["findings"],
     "additionalProperties": False,
 }
+
+# The confirmation pass asks one question about one finding, so it gets its own
+# schema. Both fields are required: a verdict with no reason is not reviewable
+# by the human reading the sticky comment.
+CONFIRM_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "confirmed": {"type": "boolean"},
+        "reason": {"type": "string"},
+    },
+    "required": ["confirmed", "reason"],
+    "additionalProperties": False,
+}
+
+# Marker string so the second pass is identifiable in a log or a test stub.
+CONFIRM_MARKER = "SECOND-PASS CONFIRMATION"
+
+CONFIRM_HINT = (
+    CONFIRM_MARKER + ". A first-pass reviewer saw ONE CHUNK of a unified diff "
+    "and graded the finding below at blocking severity. You are now looking at "
+    "the COMPLETE file as it stands at the head of this branch — the full "
+    "context that pass did not have.\n\n"
+    "Decide one thing: is this a real, blocking-severity problem?\n"
+    "Answer false when the full file shows the concern is already handled, "
+    "when it rested on context the chunk was missing, when the code is not "
+    "what the first pass took it for, or when it is a real defect that the "
+    "severity ladder does not put at HIGH.\n"
+    "Answer true when you can name a specific actor who reaches it and a "
+    "specific thing they gain, per that ladder.\n\n"
+    "This is a precision check on ONE finding, not a re-review: do not look "
+    "for new problems, and do not confirm this finding because you noticed a "
+    "different one. If the file does not let you decide, answer true — an "
+    "undecidable blocking finding stays blocking.\n\n"
+    'Respond with ONLY a JSON object, no prose: {"confirmed": true|false, '
+    '"reason": "one sentence"}'
+)
+
+CONFIRM_SYSTEM = (
+    "You are a rigorous code reviewer performing a second-pass precision check "
+    "on a single finding. You are as adversarial about false alarms as about "
+    "real defects: a wrong block and a missed defect are both failures."
+)
+
+# Confirmation reads whole files, so it needs its own ceiling. A file over this
+# budget is not confirmed at all rather than confirmed against a truncated
+# view — truncation is what the first pass already suffered from, and
+# "confirmed against half a file" is a worse answer than "not checked".
+CONFIRM_MAX_FILE_CHARS = 400000
+
+# Upper bound on confirmation calls per run. Past this the PR is thoroughly
+# blocked anyway, and the remaining HIGHs stay blocking unchecked — the
+# fail-closed direction.
+MAX_CONFIRMATIONS = 20
 
 
 class ReviewError(Exception):
@@ -754,7 +950,7 @@ def read_anthropic_stream(resp):
     return "".join(text), stop
 
 
-def call_model(provider, key, model, system, user):
+def call_model(provider, key, model, system, user, schema=FINDINGS_SCHEMA):
     if provider == "anthropic":
         text, stop = _post(
             ANTHROPIC_URL,
@@ -777,7 +973,7 @@ def call_model(provider, key, model, system, user):
                 # branch gets from response_format, but schema-checked.
                 "output_config": {
                     "effort": ANTHROPIC_EFFORT,
-                    "format": {"type": "json_schema", "schema": FINDINGS_SCHEMA},
+                    "format": {"type": "json_schema", "schema": schema},
                 },
                 # A safety classifier declining one chunk would otherwise be an
                 # unrecoverable red on a required check. "default" re-runs the
@@ -826,14 +1022,12 @@ def call_model(provider, key, model, system, user):
 MAX_JSON_SCAN_STARTS = 200
 
 
-def parse_findings(text):
-    """Return a list of finding dicts, or None if there is no well-formed
-    findings object.
+def _extract_json_object(text, key):
+    """First well-formed JSON object in `text` carrying `key`, else None.
 
-    None is the important half: "the model produced nothing we can read" used to
-    be indistinguishable from "the model found nothing" (both returned []), so
-    an empty reply, prose, a JSON object without a findings key, and JSON cut
-    off mid-object all passed the gate. None is now counted as a lens error.
+    Shared by both reply parsers so the bounded brace walk — and therefore the
+    MAX_JSON_SCAN_STARTS protection against O(n^2) on degenerate output — is
+    written once and cannot drift between them.
     """
     if not text or not text.strip():
         return None
@@ -844,8 +1038,8 @@ def parse_findings(text):
         whole = json.loads(text.strip())
     except json.JSONDecodeError:
         whole = None
-    if isinstance(whole, dict) and "findings" in whole:
-        return _coerce_findings(whole["findings"])
+    if isinstance(whole, dict) and key in whole:
+        return whole
 
     scanned = 0
     for start, char in enumerate(text):
@@ -865,10 +1059,43 @@ def parse_findings(text):
                         obj = json.loads(text[start : j + 1])
                     except json.JSONDecodeError:
                         break
-                    if isinstance(obj, dict) and "findings" in obj:
-                        return _coerce_findings(obj["findings"])
+                    if isinstance(obj, dict) and key in obj:
+                        return obj
                     break
     return None
+
+
+def parse_findings(text):
+    """Return a list of finding dicts, or None if there is no well-formed
+    findings object.
+
+    None is the important half: "the model produced nothing we can read" used to
+    be indistinguishable from "the model found nothing" (both returned []), so
+    an empty reply, prose, a JSON object without a findings key, and JSON cut
+    off mid-object all passed the gate. None is now counted as a lens error.
+    """
+    obj = _extract_json_object(text, "findings")
+    if obj is None:
+        return None
+    return _coerce_findings(obj["findings"])
+
+
+def parse_confirmation(text):
+    """Return (confirmed: bool, reason: str) from a verdict reply, else None.
+
+    None means "unreadable", and an unreadable verdict must never read as
+    "cleared" — the caller turns it into a blocking confirmation error. The
+    `confirmed` value must be a real bool: a string "false" or a 0 is not an
+    answer we are willing to clear a blocking finding on.
+    """
+    obj = _extract_json_object(text, "confirmed")
+    if obj is None:
+        return None
+    verdict = obj["confirmed"]
+    if not isinstance(verdict, bool):
+        return None
+    reason = obj.get("reason")
+    return verdict, str(reason).strip() if reason else ""
 
 
 def _coerce_findings(raw):
@@ -892,6 +1119,7 @@ def review_chunk(provider, key, model, name, instruction, chunk, index, total):
     label = f"{name} lens, chunk {index}/{total}"
     user = (
         f"{instruction}\n\n{CHUNK_HINT.format(i=index, n=total)}\n\n"
+        f"{SEVERITY_LADDER}\n\n"
         f"Review this unified diff. {SCHEMA_HINT}\n\n"
         f"```diff\n{chunk.prompt()}\n```"
     )
@@ -1002,44 +1230,240 @@ def dedupe(findings):
     return out
 
 
+# --------------------------------------------------------------- confirmation
+
+# CONFIRMATION STATES. Exactly one of these clears a blocking finding.
+CONFIRM_CLEARED = "unconfirmed"  # the ONLY non-blocking outcome
+CONFIRM_UPHELD = "confirmed"
+CONFIRM_ERROR = "error"  # call failed or verdict unreadable → blocks
+CONFIRM_SKIPPED = "unchecked"  # no second pass was possible → blocks
+
+
+def is_blocking(finding):
+    """True unless the confirmation pass positively cleared this finding.
+
+    Written as "not cleared" rather than "confirmed" on purpose: every new
+    confirmation state that anyone adds later defaults to BLOCKING, which is
+    the direction this gate must fail in. An error, a skip, an unreadable
+    verdict, and a state nobody has invented yet all block; only an explicit
+    CONFIRM_CLEARED lets a blocking-severity finding through.
+    """
+    if finding_severity(finding) != "high":
+        return False
+    return finding.get("confirmation") != CONFIRM_CLEARED
+
+
+def file_at(head, path):
+    """Full text of `path` at `head`, or None when it cannot be read.
+
+    None is a legitimate answer — a deleted file, a path the model invented,
+    or a binary blob — and the caller treats it as "cannot confirm", which
+    blocks. This never falls back to the diff chunk: confirming against the
+    same partial view that produced the finding would make the second pass
+    ceremonial.
+    """
+    path = (path or "").strip()
+    if not path or "\n" in path or len(path) > 400 or path in ("?", "<unknown>"):
+        return None
+    candidates = [path]
+    # Diff headers are `a/<path>` / `b/<path>` and models sometimes copy the
+    # prefix into the finding. Try the literal path FIRST so a real top-level
+    # `a/` directory is never shadowed by the stripped form.
+    if path.startswith(("a/", "b/")):
+        candidates.append(path[2:])
+    if path.startswith("./"):
+        candidates.append(path[2:])
+    for candidate in candidates:
+        rc, out, _ = run(["git", "show", f"{head}:{candidate}"])
+        if rc == 0:
+            return out
+    return None
+
+
+def build_confirm_prompt(finding, source):
+    """The single-finding, whole-file question put to the second pass."""
+    lens = str(finding.get("lens") or "")
+    location = str(finding.get("file", "?"))
+    if finding.get("line"):
+        location += f":{finding['line']}"
+    return (
+        f"{LENSES.get(lens, '')}\n\n{SEVERITY_LADDER}\n\n{CONFIRM_HINT}\n\n"
+        f"FINDING (reported by the {lens} lens at blocking severity)\n"
+        f"location: {location}\n"
+        f"title: {str(finding.get('title', '')).strip()}\n"
+        f"detail: {str(finding.get('detail', '')).strip()}\n\n"
+        f"COMPLETE CURRENT CONTENTS OF `{finding.get('file', '?')}`:\n"
+        f"```\n{source}\n```"
+    )
+
+
+def _confirm_one(provider, key, model, finding, source):
+    """Second-pass verdict on one finding. Returns (state, reason)."""
+    label = f"confirmation of {finding.get('lens')} finding in {finding.get('file')}"
+    try:
+        raw = call_model(
+            provider,
+            key,
+            model,
+            CONFIRM_SYSTEM,
+            build_confirm_prompt(finding, source),
+            schema=CONFIRM_SCHEMA,
+        )
+    except Exception as e:  # noqa: BLE001
+        # Fail CLOSED. A confirmation we could not run is not a clearance:
+        # letting an API error delete a blocking finding would turn a flaky
+        # provider into a way to merge anything.
+        print(f"::warning::{label} failed: {e}")
+        return CONFIRM_ERROR, f"confirmation call failed: {e}"
+    verdict = parse_confirmation(raw)
+    if verdict is None:
+        print(f"::warning::{label} returned no parseable verdict: {(raw or '')[:200]!r}")
+        return CONFIRM_ERROR, "confirmation reply could not be parsed"
+    confirmed, reason = verdict
+    return (CONFIRM_UPHELD if confirmed else CONFIRM_CLEARED), reason
+
+
+def confirm_findings(provider, key, model, findings, head, workers):
+    """Re-check every blocking-severity finding against its whole file.
+
+    This targets the gate's measured failure mode: ONE low-precision call that
+    saw a diff chunk and nothing else. It runs only on HIGH findings, so a
+    clean diff costs nothing and a normal diff costs at most a handful of
+    calls.
+
+    DELIBERATE: this is the ONLY mechanism that can stop a HIGH from blocking,
+    and it is the model re-reading the file. There is NO waiver, no suppression
+    comment, no annotation, and no PR-body override — and none may be added.
+    In this repository agents author both the diff and the PR body, so any such
+    mechanism would be a waiver the reviewed party grants itself, which is not
+    a gate at all. If that feels inconvenient, the fix is a better finding or a
+    better prompt, not an escape hatch.
+    """
+    pending = []
+    for f in findings:
+        if finding_severity(f) != "high":
+            continue
+        if has_unreadable_severity(f):
+            # There is no graded judgment here to re-check — the severity was
+            # unreadable input, which fails closed on its own terms.
+            f["confirmation"] = CONFIRM_SKIPPED
+            f["confirmation_reason"] = "no readable severity — nothing to re-check"
+            continue
+        pending.append(f)
+
+    for f in pending[MAX_CONFIRMATIONS:]:
+        f["confirmation"] = CONFIRM_SKIPPED
+        f["confirmation_reason"] = (
+            f"more than {MAX_CONFIRMATIONS} blocking findings — not re-checked"
+        )
+
+    jobs = []
+    for f in pending[:MAX_CONFIRMATIONS]:
+        source = file_at(head, str(f.get("file") or ""))
+        if source is None:
+            f["confirmation"] = CONFIRM_SKIPPED
+            f["confirmation_reason"] = "could not read the full file at head"
+        elif len(source) > CONFIRM_MAX_FILE_CHARS:
+            f["confirmation"] = CONFIRM_SKIPPED
+            f["confirmation_reason"] = (
+                f"file exceeds the {CONFIRM_MAX_FILE_CHARS}-char confirmation budget"
+            )
+        else:
+            jobs.append((f, source))
+
+    if jobs:
+        with ThreadPoolExecutor(max_workers=max(1, workers)) as pool:
+            results = list(
+                pool.map(
+                    lambda job: _confirm_one(provider, key, model, job[0], job[1]),
+                    jobs,
+                )
+            )
+        for (f, _), (state, reason) in zip(jobs, results):
+            f["confirmation"] = state
+            f["confirmation_reason"] = reason
+    return findings
+
+
 # --------------------------------------------------------------------- output
 
 
 def render_markdown(audit, all_findings):
-    """Build the sticky comment body.
+    """Build the sticky comment body. Returns (body, blocking_findings).
 
     The audit line is emitted UNCONDITIONALLY, including on clean runs — a green
     run used to record nothing at all about what had actually been reviewed.
+
+    Findings the confirmation pass CLEARED are rendered too, in their own
+    section. Silently dropping them would make the second pass a place where
+    real defects could disappear with no trace; listing them means an
+    over-eager clear is reviewable by whoever reads the comment.
     """
     for f in all_findings:
         f["severity_norm"] = finding_severity(f)
     all_findings.sort(key=lambda f: SEV_ORDER.get(f["severity_norm"], 3))
-    highs = [f for f in all_findings if f["severity_norm"] == "high"]
+    blocking = [f for f in all_findings if is_blocking(f)]
+    cleared = [
+        f
+        for f in all_findings
+        if f["severity_norm"] == "high" and not is_blocking(f)
+    ]
+    # Partition by IDENTITY, not equality: `f not in cleared` compares dicts by
+    # value, so two findings that happen to render identically would both
+    # vanish from the main list.
+    cleared_ids = {id(f) for f in cleared}
+    listed = [f for f in all_findings if id(f) not in cleared_ids]
 
     lines = [MARKER, "## 🛡️ Adversarial review"]
     if not all_findings:
         lines.append(
             "\n✅ No findings across correctness / security / pack-compat lenses."
         )
-    elif highs:
+    elif blocking:
         lines.append("\n❌ **Blocked** — blocking-severity findings must be resolved.")
     else:
         lines.append("\n✅ **Pass** — only non-blocking findings.")
     lines.append(f"\n{audit}\n")
 
     icon = {"high": "🔴", "medium": "🟠", "low": "🟡", "unknown": "⚪"}
-    for f in all_findings:
+
+    def render(f, note):
         sev = f["severity_norm"]
         loc = str(f.get("file", "?"))
         if f.get("line"):
             loc += f":{f['line']}"
-        note = " _(no readable severity — treated as blocking)_" if has_unreadable_severity(f) else ""
-        lines.append(
+        return (
             f"- {icon.get(sev, '⚪')} **{sev.upper()}** [{f.get('lens')}] "
             f"`{loc}` — **{str(f.get('title', '')).strip()}**{note}  \n  "
             f"{str(f.get('detail', '')).strip()}"
         )
-    return "\n".join(lines), highs
+
+    for f in listed:
+        note = ""
+        if has_unreadable_severity(f):
+            note = " _(no readable severity — treated as blocking)_"
+        elif f.get("confirmation") in (CONFIRM_ERROR, CONFIRM_SKIPPED):
+            note = (
+                f" _(not re-checked: {f.get('confirmation_reason', '')} — "
+                "still blocking)_"
+            )
+        lines.append(render(f, note))
+
+    if cleared:
+        lines.append(
+            "\n<details><summary>🔎 "
+            f"{len(cleared)} blocking-severity finding(s) cleared by the "
+            "second pass — reported, not blocking</summary>\n\n"
+            "Each was re-read against the whole file rather than one diff "
+            "chunk and judged not to be a blocking problem. They are listed "
+            "so the clearance is reviewable; nothing here was hidden.\n"
+        )
+        for f in cleared:
+            lines.append(
+                render(f, f" _(cleared: {f.get('confirmation_reason', '')})_")
+            )
+        lines.append("\n</details>")
+    return "\n".join(lines), blocking
 
 
 def post_sticky_comment(body):
@@ -1176,9 +1600,9 @@ def main():
     if not provider:
         print("::error::no review key set (need ANTHROPIC_API_KEY or OPENAI_KEY).")
         return 1
-    model = os.environ.get("ADVERSARIAL_MODEL") or DEFAULT_MODEL[provider]
 
     try:
+        model = resolve_model(provider)
         budget = int(os.environ.get("MAX_CHUNK_CHARS") or DEFAULT_CHUNK_CHARS)
         workers = int(os.environ.get("ADVERSARIAL_WORKERS") or DEFAULT_WORKERS)
         rng = resolve_range()
@@ -1254,7 +1678,11 @@ def main():
         return 1
 
     findings = dedupe(findings)
-    body, highs = render_markdown(audit, findings)
+    # Precision pass on blocking findings only: re-read each against its whole
+    # file. Only an explicit clearance stops one blocking; every other outcome,
+    # including an API error, leaves it blocking.
+    findings = confirm_findings(provider, key, model, findings, rng.head, workers)
+    body, blocking = render_markdown(audit, findings)
     publish(body)
 
     unknown = [f for f in findings if f["severity_norm"] == "unknown"]
@@ -1263,14 +1691,25 @@ def main():
             f"::warning::{len(unknown)} finding(s) had an unrecognized severity "
             f"and did not block: {sorted({str(f.get('severity')) for f in unknown})}"
         )
-    unreadable = [f for f in highs if has_unreadable_severity(f)]
+    cleared = [
+        f for f in findings if f["severity_norm"] == "high" and not is_blocking(f)
+    ]
+    if cleared:
+        # Logged as well as rendered: a clearance is the one place this gate
+        # gets quieter, so it leaves a trace in the job log too.
+        print(
+            f"::warning::{len(cleared)} blocking-severity finding(s) were cleared "
+            "by the whole-file confirmation pass and did not block; they are "
+            "listed in the review comment."
+        )
+    unreadable = [f for f in blocking if has_unreadable_severity(f)]
     if unreadable:
         print(
             f"::error::{len(unreadable)} finding(s) had no readable severity and "
             "were treated as blocking."
         )
-    if highs:
-        print(f"::error::{len(highs)} blocking-severity finding(s) block the merge.")
+    if blocking:
+        print(f"::error::{len(blocking)} blocking-severity finding(s) block the merge.")
         return 1
     return 0
 

--- a/.github/scripts/test_adversarial_review.py
+++ b/.github/scripts/test_adversarial_review.py
@@ -10,6 +10,12 @@ pre-fix script violated it and still reported green:
   * severity matching is alias-aware, and an unreadable severity blocks
   * a bad SHA / git failure is an error, never a silent substitution
 
+The confirmation-pass tests below guard the same property from the other side:
+the second pass is the only thing in this gate that makes a blocking finding
+stop blocking, so every way it can go wrong — an API error, an unreadable
+verdict, a file it cannot read — must still block, and a clearance must stay
+visible rather than deleting the finding.
+
 Run: python -m pytest .github/scripts -q
 """
 
@@ -574,12 +580,21 @@ def repo(tmp_path, monkeypatch):
     git("config", "user.email", "t@example.com")
     git("config", "user.name", "t")
     (tmp_path / "base.txt").write_text("base\n")
+    # A file that PREDATES the branch, so its diff hunk shows only a few lines
+    # while the whole file holds much more. SENTINEL sits far from the edited
+    # line, which makes it a witness for "the confirmation pass read the file,
+    # not the chunk" — a diff can never contain it.
+    lines = [f"line {i}\n" for i in range(1, 61)]
+    lines[4] = "SENTINEL_ONLY_IN_THE_WHOLE_FILE\n"
+    (tmp_path / "context.txt").write_text("".join(lines))
     git("add", "-A")
     git("commit", "-qm", "base")
     root = rev("HEAD")
 
     git("checkout", "-q", "-b", "feature")
     (tmp_path / "feature.txt").write_text("feature change\n")
+    lines[54] = "line 55 edited on the feature branch\n"
+    (tmp_path / "context.txt").write_text("".join(lines))
     # Two more files, each comfortably over MIN_CHUNK_CHARS/2, so the branch
     # diff spans several chunks at the minimum budget — that is the only way to
     # exercise the multi-chunk exit paths.
@@ -675,7 +690,7 @@ def gate(repo, monkeypatch, tmp_path):
 
     def install(reply):
         """`reply` is a str, an Exception to raise, or a callable(user)->str."""
-        def fake(provider, key, model, system, user):
+        def fake(provider, key, model, system, user, schema=None):
             value = reply(user) if callable(reply) else reply
             if isinstance(value, Exception):
                 raise value
@@ -684,6 +699,38 @@ def gate(repo, monkeypatch, tmp_path):
         monkeypatch.setattr(ar, "call_model", fake)
 
     return install
+
+
+def _confirming(review_reply, verdict, reason="because"):
+    """Reply router: `review_reply` for lens calls, `verdict` for confirmations.
+
+    `verdict` is True/False for a clean verdict, an Exception to raise, or a
+    raw string to return unparsed.
+    """
+    def reply(user):
+        if ar.CONFIRM_MARKER not in user:
+            return review_reply
+        if isinstance(verdict, (Exception, str)):
+            return verdict
+        return json.dumps({"confirmed": verdict, "reason": reason})
+
+    return reply
+
+
+def _high(file="context.txt", severity="high", title="t"):
+    return json.dumps(
+        {
+            "findings": [
+                {
+                    "severity": severity,
+                    "file": file,
+                    "line": "55",
+                    "title": title,
+                    "detail": "d",
+                }
+            ]
+        }
+    )
 
 
 def test_clean_diff_passes(gate):
@@ -808,3 +855,391 @@ def test_audit_line_names_the_range_and_covers_the_diff(gate, capsys):
     out = capsys.readouterr().out
     assert "merge base" in out
     assert "100% of that diff" in out
+
+
+# ------------------------------------------------------- lens calibration
+#
+# The gate's first real block was mechanically correct and over-graded: a
+# dev-server-only Vite `server.fs.allow` widening on a PUBLIC repo, called
+# HIGH. Two causes, asserted here so neither can be quietly reverted — the
+# security lens had no threat model, and "severity" was never defined.
+
+
+def test_security_lens_carries_a_threat_model():
+    """One sentence of "find injection, SSRF, missing authz" with no system
+    description grades against a generic multi-tenant web service, because
+    that is what those words describe. The lens has to know what ships."""
+    lens = ar.LENSES["security"].lower()
+    assert "public" in lens and "open source" in lens
+    assert "tauri" in lens and "static" in lens
+    assert "authorization" in lens  # no server-side authz layer to bypass
+    assert "multi-tenant" in lens
+    assert "never ship" in lens  # dev server / tests / CI
+    assert "server.*" in ar.LENSES["security"]
+
+
+def test_security_lens_is_not_shorter_than_the_correctness_calibration():
+    """The asymmetry WAS the bug: three paragraphs of "do NOT report" guidance
+    on correctness, one sentence on security."""
+    assert len(ar.LENSES["security"]) > len(ar.LENSES["correctness"])
+
+
+def test_severity_ladder_defines_every_level():
+    ladder = ar.SEVERITY_LADDER
+    for level in ("HIGH", "MEDIUM", "LOW"):
+        assert f"* {level} —" in ladder, level
+
+
+def test_severity_ladder_grades_impact_not_confidence():
+    """The old guidance ("reserve it for real, confident defects") calibrated
+    CONFIDENCE. A reviewer certain about a harmless fact reads that as licence
+    to block — which is precisely what happened."""
+    ladder = ar.SEVERITY_LADDER
+    assert "IMPACT and REACHABILITY" in ladder
+    assert "how confident you are" in ladder
+    assert "confident defects" not in ar.SCHEMA_HINT
+
+
+def test_severity_ladder_carries_both_worked_examples():
+    """Same reachability, different grade — that contrast is the whole lesson,
+    and an abstract definition does not teach it."""
+    ladder = ar.SEVERITY_LADDER
+    assert ".jks" in ladder and "KEYSTORE" in ladder  # the real TRUE high
+    assert "server.fs.allow" in ladder  # the real over-grade, called LOW
+    assert "TRUE HIGH" in ladder and "NOT HIGH" in ladder
+
+
+def test_reviewers_are_told_high_needs_a_reachable_actor():
+    ladder = ar.SEVERITY_LADDER.lower()
+    assert "not the developer at their own machine" in ladder
+    assert "name a specific actor and a specific consequence" in ladder
+
+
+def test_the_ladder_reaches_every_lens(gate, monkeypatch):
+    """A ladder only the security lens sees would leave correctness and
+    pack-compat grading on the old confidence rule."""
+    seen = []
+    gate(lambda user: seen.append(user) or '{"findings": []}')
+    assert ar.main() == 0
+    lenses = {name for name in ar.LENSES}
+    assert len(seen) >= len(lenses)
+    assert all(ar.SEVERITY_LADDER in u for u in seen)
+
+
+# ------------------------------------------------------------ model allow-list
+
+
+def test_default_models_are_in_the_allow_list():
+    for provider, default in ar.DEFAULT_MODEL.items():
+        assert default in ar.ALLOWED_MODELS[provider], provider
+
+
+def test_model_override_outside_the_allow_list_is_an_error(monkeypatch):
+    """ADVERSARIAL_MODEL was a repo variable that could silently downgrade all
+    three lenses forever, with no PR and no audit trail."""
+    monkeypatch.setenv("ADVERSARIAL_MODEL", "gpt-3.5-turbo")
+    with pytest.raises(ar.ReviewError):
+        ar.resolve_model("openai")
+
+
+def test_model_override_outside_the_allow_list_blocks_at_the_exit_code(
+    gate, monkeypatch
+):
+    gate('{"findings": []}')
+    monkeypatch.setenv("ADVERSARIAL_MODEL", "something-cheap")
+    assert ar.main() == 1
+
+
+def test_an_unrecognized_model_is_not_silently_replaced_by_the_default(monkeypatch):
+    """Falling back to the default would make a downgraded ADVERSARIAL_MODEL
+    indistinguishable from an unset one in the logs."""
+    monkeypatch.setenv("ADVERSARIAL_MODEL", "claude-tiny")
+    with pytest.raises(ar.ReviewError) as e:
+        ar.resolve_model("anthropic")
+    assert "allow-list" in str(e.value)
+
+
+def test_allowed_override_is_used(monkeypatch):
+    monkeypatch.setenv("ADVERSARIAL_MODEL", "claude-opus-4-8")
+    assert ar.resolve_model("anthropic") == "claude-opus-4-8"
+
+
+def test_unset_or_blank_override_uses_the_default(monkeypatch):
+    monkeypatch.delenv("ADVERSARIAL_MODEL", raising=False)
+    assert ar.resolve_model("anthropic") == ar.DEFAULT_MODEL["anthropic"]
+    monkeypatch.setenv("ADVERSARIAL_MODEL", "   ")
+    assert ar.resolve_model("anthropic") == ar.DEFAULT_MODEL["anthropic"]
+
+
+# --------------------------------------------------------- confirmation pass
+
+
+def test_parse_confirmation_reads_a_verdict():
+    assert ar.parse_confirmation('{"confirmed": true, "reason": "r"}') == (True, "r")
+    assert ar.parse_confirmation('{"confirmed": false, "reason": "r"}') == (False, "r")
+    assert ar.parse_confirmation('prose {"confirmed": false, "reason": "r"} tail') == (
+        False,
+        "r",
+    )
+
+
+@pytest.mark.parametrize(
+    "reply",
+    [
+        "",
+        "   ",
+        "I think it is fine.",
+        '{"ok": true}',
+        '{"confirmed": "false"}',  # string, not bool
+        '{"confirmed": 0}',  # falsy int, not bool
+        '{"confirmed": null}',
+        '{"confirmed": fal',  # truncated
+    ],
+)
+def test_unreadable_verdicts_are_none(reply):
+    """None must never read as "cleared" — the caller turns it into a blocking
+    confirmation error. A string "false" clearing a real HIGH is the exact
+    fail-open this guards."""
+    assert ar.parse_confirmation(reply) is None
+
+
+def _count_confirmations(gate, review_reply, verdict):
+    """Drive main() and return (exit_code, number of confirmation calls made).
+
+    The call count is what keeps the fail-closed tests below honest: "blocked"
+    is also what a gate with no confirmation pass at all returns, so asserting
+    only the exit code would pass for the wrong reason.
+    """
+    inner = _confirming(review_reply, verdict)
+    calls = {"n": 0}
+
+    def reply(user):
+        if ar.CONFIRM_MARKER in user:
+            calls["n"] += 1
+        return inner(user)
+
+    gate(reply)
+    return ar.main(), calls["n"]
+
+
+def test_confirmed_high_blocks(gate):
+    # One confirmation per reporting lens: all three report the same finding.
+    code, confirmations = _count_confirmations(gate, _high(), True)
+    assert (code, confirmations) == (1, len(ar.LENSES))
+
+
+def test_unconfirmed_high_does_not_block(gate):
+    """The whole point: a HIGH the second pass rejects stops wedging the queue."""
+    gate(_confirming(_high(), False))
+    assert ar.main() == 0
+
+
+def test_unconfirmed_high_is_still_reported(gate, monkeypatch):
+    """Cleared is not deleted. If the second pass could make findings vanish
+    silently, it would be a place for real defects to disappear."""
+    posted = []
+    monkeypatch.setattr(ar, "post_sticky_comment", posted.append)
+    gate(_confirming(_high(title="dev server serves the keystore"), False, "dev only"))
+    assert ar.main() == 0
+    assert "dev server serves the keystore" in posted[0]
+    assert "cleared" in posted[0].lower()
+    assert "dev only" in posted[0]
+
+
+def test_cleared_finding_is_logged_as_a_warning(gate, capsys):
+    gate(_confirming(_high(), False))
+    assert ar.main() == 0
+    assert "cleared" in capsys.readouterr().out
+
+
+def test_confirmation_error_blocks(gate):
+    """FAIL CLOSED. If an API error could delete a blocking finding, a flaky
+    provider becomes a way to merge anything. The call-count assertion proves
+    the confirmation actually ran and errored, rather than never happening."""
+    code, confirmations = _count_confirmations(gate, _high(), RuntimeError("HTTP 500"))
+    assert (code, confirmations) == (1, len(ar.LENSES))
+
+
+def test_confirmation_unparseable_reply_blocks(gate):
+    code, confirmations = _count_confirmations(gate, _high(), "looks fine to me")
+    assert (code, confirmations) == (1, len(ar.LENSES))
+
+
+def test_confirmation_reads_the_whole_file_not_the_diff_chunk(gate):
+    """The measured failure mode was ONE context-poor call. Confirming against
+    the same chunk that produced the finding would be ceremonial."""
+    prompts = []
+
+    def reply(user):
+        prompts.append(user)
+        if ar.CONFIRM_MARKER not in user:
+            return _high()
+        return '{"confirmed": false, "reason": "r"}'
+
+    gate(reply)
+    assert ar.main() == 0
+    # One confirmation per reporting lens — they are distinct findings.
+    confirms = [p for p in prompts if ar.CONFIRM_MARKER in p]
+    assert len(confirms) == len(ar.LENSES)
+    # Present in the file at head, and impossible for any diff hunk to contain.
+    assert all("SENTINEL_ONLY_IN_THE_WHOLE_FILE" in p for p in confirms)
+    reviews = [p for p in prompts if ar.CONFIRM_MARKER not in p]
+    assert not any("SENTINEL_ONLY_IN_THE_WHOLE_FILE" in p for p in reviews)
+
+
+def test_a_high_on_an_unreadable_file_blocks_without_a_second_pass(gate):
+    """No full-file context means no confirmation, and no confirmation means
+    the finding stands."""
+    prompts = []
+
+    def reply(user):
+        prompts.append(user)
+        return _high(file="does/not/exist.ts")
+
+    gate(reply)
+    assert ar.main() == 1
+    assert not any(ar.CONFIRM_MARKER in p for p in prompts)
+
+
+def test_unreadable_severity_blocks_without_a_second_pass(gate):
+    """An omitted severity is unreadable INPUT, not a graded judgment — there
+    is nothing for the second pass to re-check, and it must not be a way in."""
+    prompts = []
+
+    def reply(user):
+        prompts.append(user)
+        if ar.CONFIRM_MARKER in user:
+            return '{"confirmed": false, "reason": "r"}'
+        return '{"findings": [{"file": "context.txt", "title": "t", "detail": "d"}]}'
+
+    gate(reply)
+    assert ar.main() == 1
+    assert not any(ar.CONFIRM_MARKER in p for p in prompts)
+
+
+@pytest.mark.parametrize("severity", ["medium", "low", "spicy"])
+def test_non_blocking_findings_are_never_confirmed(gate, severity):
+    """Cost guard: the second pass runs on HIGH only, so a clean or merely
+    noisy diff pays nothing for it."""
+    prompts = []
+
+    def reply(user):
+        prompts.append(user)
+        return _high(severity=severity)
+
+    gate(reply)
+    assert ar.main() == 0
+    assert not any(ar.CONFIRM_MARKER in p for p in prompts)
+
+
+def test_clean_diff_makes_no_confirmation_calls(gate):
+    prompts = []
+    gate(lambda user: prompts.append(user) or '{"findings": []}')
+    assert ar.main() == 0
+    assert not any(ar.CONFIRM_MARKER in p for p in prompts)
+
+
+def test_confirmation_prompt_carries_the_ladder_and_the_finding(gate):
+    prompts = []
+
+    def reply(user):
+        prompts.append(user)
+        if ar.CONFIRM_MARKER not in user:
+            return _high(title="unique-title-here")
+        return '{"confirmed": true, "reason": "r"}'
+
+    gate(reply)
+    assert ar.main() == 1
+    confirm = next(p for p in prompts if ar.CONFIRM_MARKER in p)
+    assert ar.SEVERITY_LADDER in confirm
+    assert "unique-title-here" in confirm
+    assert "context.txt:55" in confirm
+
+
+def test_is_blocking_defaults_every_unknown_state_to_blocking():
+    """Written as "not cleared" rather than "confirmed" on purpose: a
+    confirmation state someone adds later must block, not slip through."""
+    high = {"severity": "high"}
+    assert ar.is_blocking(dict(high)) is True  # no confirmation recorded at all
+    for state in (ar.CONFIRM_UPHELD, ar.CONFIRM_ERROR, ar.CONFIRM_SKIPPED, "novel"):
+        assert ar.is_blocking({**high, "confirmation": state}) is True, state
+    assert ar.is_blocking({**high, "confirmation": ar.CONFIRM_CLEARED}) is False
+    assert ar.is_blocking({"severity": "low", "confirmation": ar.CONFIRM_UPHELD}) is False
+
+
+def test_confirmation_is_bounded(gate):
+    """A run cannot spend unbounded calls, and the overflow stays blocking."""
+    many = json.dumps(
+        {
+            "findings": [
+                {
+                    "severity": "high",
+                    "file": "context.txt",
+                    "line": str(i),
+                    "title": f"t{i}",
+                    "detail": "d",
+                }
+                for i in range(ar.MAX_CONFIRMATIONS + 15)
+            ]
+        }
+    )
+    prompts = []
+
+    def reply(user):
+        prompts.append(user)
+        if ar.CONFIRM_MARKER not in user:
+            return many
+        return '{"confirmed": false, "reason": "r"}'
+
+    gate(reply)
+    assert ar.main() == 1  # the overflow was never cleared
+    assert sum(ar.CONFIRM_MARKER in p for p in prompts) == ar.MAX_CONFIRMATIONS
+
+
+def test_file_at_resolves_a_diff_prefixed_path(repo):
+    assert "SENTINEL" in ar.file_at(repo["head"], "context.txt")
+    assert "SENTINEL" in ar.file_at(repo["head"], "b/context.txt")
+    assert "SENTINEL" in ar.file_at(repo["head"], "./context.txt")
+
+
+@pytest.mark.parametrize("path", ["", "   ", "?", "<unknown>", "no/such/file.ts", None])
+def test_file_at_returns_none_rather_than_guessing(repo, path):
+    assert ar.file_at(repo["head"], path) is None
+
+
+def test_oversized_file_is_not_confirmed_against_a_truncated_view(gate, monkeypatch):
+    """Truncation is what the first pass already suffered from. "Confirmed
+    against half a file" is a worse answer than "not checked"."""
+    monkeypatch.setattr(ar, "CONFIRM_MAX_FILE_CHARS", 10)
+    prompts = []
+
+    def reply(user):
+        prompts.append(user)
+        if ar.CONFIRM_MARKER not in user:
+            return _high()
+        return '{"confirmed": false, "reason": "r"}'
+
+    gate(reply)
+    assert ar.main() == 1
+    assert not any(ar.CONFIRM_MARKER in p for p in prompts)
+
+
+# -------------------------------------------------------------- no waivers
+
+
+def test_there_is_no_waiver_mechanism():
+    """DELIBERATE, and asserted so nobody adds one later: agents author both
+    the diff and the PR body here, so a waiver is the reviewed party silencing
+    the reviewer."""
+    src = Path(ar.__file__).read_text()
+    assert "no waiver" in src.lower()  # the decision is recorded in the script
+    for escape_hatch in (
+        "PR_BODY",
+        "pull_request.body",
+        "skip-adversarial",
+        "adversarial-skip",
+        "ALLOW_HIGH",
+        "OVERRIDE",
+        "noqa: adversarial",
+    ):
+        assert escape_hatch not in src, escape_hatch

--- a/.github/scripts/test_adversarial_review.py
+++ b/.github/scripts/test_adversarial_review.py
@@ -960,8 +960,23 @@ def test_an_unrecognized_model_is_not_silently_replaced_by_the_default(monkeypat
 
 
 def test_allowed_override_is_used(monkeypatch):
-    monkeypatch.setenv("ADVERSARIAL_MODEL", "claude-opus-4-8")
-    assert ar.resolve_model("anthropic") == "claude-opus-4-8"
+    for provider, allowed in ar.ALLOWED_MODELS.items():
+        for model in sorted(allowed):
+            monkeypatch.setenv("ADVERSARIAL_MODEL", model)
+            assert ar.resolve_model(provider) == model, (provider, model)
+
+
+def test_the_allow_list_holds_only_ids_this_gate_has_run():
+    """The allow-list's whole value is that a listed id is SAFE to select. An
+    id nobody has run against this exact request shape is one repo-variable
+    edit from a 400, which is a lens error, which is a repo-wide block — the
+    outcome the list exists to prevent.
+
+    ADVERSARIAL_MODEL has never been set, so the only id each provider has
+    actually run is its default. Widening the set means running the candidate
+    first and then changing this test on purpose."""
+    for provider, allowed in ar.ALLOWED_MODELS.items():
+        assert allowed == {ar.DEFAULT_MODEL[provider]}, provider
 
 
 def test_unset_or_blank_override_uses_the_default(monkeypatch):
@@ -1023,9 +1038,23 @@ def _count_confirmations(gate, review_reply, verdict):
 
 
 def test_confirmed_high_blocks(gate):
-    # One confirmation per reporting lens: all three report the same finding.
+    # ONE confirmation, not one per lens: all three report the same defect at
+    # the same location, so it is one question and one whole-file call.
     code, confirmations = _count_confirmations(gate, _high(), True)
-    assert (code, confirmations) == (1, len(ar.LENSES))
+    assert (code, confirmations) == (1, 1)
+
+
+def test_one_defect_costs_one_confirmation_and_the_verdict_fans_out(gate, monkeypatch):
+    """dedupe() keys on the lens, so a defect all three lenses notice survives
+    as three findings. Confirming each separately spent three whole-file calls
+    — from a budget of 20 — asking one question three times."""
+    posted = []
+    monkeypatch.setattr(ar, "post_sticky_comment", posted.append)
+    code, confirmations = _count_confirmations(gate, _high(title="one defect"), False)
+    assert (code, confirmations) == (0, 1)
+    # The single verdict reached every lens's copy of the finding.
+    assert posted[0].count("one defect") == len(ar.LENSES)
+    assert posted[0].count("cleared: because") == len(ar.LENSES)
 
 
 def test_unconfirmed_high_does_not_block(gate):
@@ -1057,12 +1086,12 @@ def test_confirmation_error_blocks(gate):
     provider becomes a way to merge anything. The call-count assertion proves
     the confirmation actually ran and errored, rather than never happening."""
     code, confirmations = _count_confirmations(gate, _high(), RuntimeError("HTTP 500"))
-    assert (code, confirmations) == (1, len(ar.LENSES))
+    assert (code, confirmations) == (1, 1)
 
 
 def test_confirmation_unparseable_reply_blocks(gate):
     code, confirmations = _count_confirmations(gate, _high(), "looks fine to me")
-    assert (code, confirmations) == (1, len(ar.LENSES))
+    assert (code, confirmations) == (1, 1)
 
 
 def test_confirmation_reads_the_whole_file_not_the_diff_chunk(gate):
@@ -1078,13 +1107,104 @@ def test_confirmation_reads_the_whole_file_not_the_diff_chunk(gate):
 
     gate(reply)
     assert ar.main() == 0
-    # One confirmation per reporting lens — they are distinct findings.
     confirms = [p for p in prompts if ar.CONFIRM_MARKER in p]
-    assert len(confirms) == len(ar.LENSES)
+    assert len(confirms) == 1
     # Present in the file at head, and impossible for any diff hunk to contain.
     assert all("SENTINEL_ONLY_IN_THE_WHOLE_FILE" in p for p in confirms)
     reviews = [p for p in prompts if ar.CONFIRM_MARKER not in p]
     assert not any("SENTINEL_ONLY_IN_THE_WHOLE_FILE" in p for p in reviews)
+
+
+def test_confirmation_also_carries_the_change_not_only_head_state(gate):
+    """Head state alone cannot answer a finding about a REMOVAL: the removed
+    line is not in the file, and the honest reading of its absence is "no such
+    code, not a blocking problem" — a clearance, and a wrong one. The stub
+    below stands in for that honest confirmer: it upholds the finding only if
+    the prompt actually shows the deletion."""
+    prompts = []
+
+    def reply(user):
+        prompts.append(user)
+        if ar.CONFIRM_MARKER not in user:
+            return _high(title="the change deleted `line 55`")
+        removed = "\n-line 55\n" in user
+        return json.dumps({"confirmed": removed, "reason": "read the diff"})
+
+    gate(reply)
+    assert ar.main() == 1  # the deletion was visible, so the HIGH stood
+    confirm = next(p for p in prompts if ar.CONFIRM_MARKER in p)
+    assert "```diff" in confirm
+    assert "\n-line 55\n" in confirm  # what the branch removed
+    assert "\n+line 55 edited on the feature branch\n" in confirm  # ...and added
+    assert "SENTINEL_ONLY_IN_THE_WHOLE_FILE" in confirm  # ...plus the whole file
+
+
+def test_a_high_on_a_file_outside_the_reviewed_diff_is_never_confirmed(gate):
+    """`base.txt` predates the branch and the reviewed range does not touch it.
+    Confirming a finding against it would put the second pass in unrelated,
+    pre-existing code — where "no, not a blocking problem introduced here" is
+    the correct answer and a clearance is the wrong outcome. A mis-attributed
+    path is a routine model error, so the least reliable field in the finding
+    must not be able to select what the only un-blocking mechanism reads."""
+    prompts = []
+
+    def reply(user):
+        prompts.append(user)
+        if ar.CONFIRM_MARKER not in user:
+            return _high(file="base.txt")
+        return '{"confirmed": false, "reason": "nothing wrong in this file"}'
+
+    gate(reply)
+    assert ar.main() == 1
+    assert not any(ar.CONFIRM_MARKER in p for p in prompts)
+
+
+@pytest.mark.parametrize("spelling", ["context.txt", "b/context.txt", "./context.txt"])
+def test_a_prefixed_path_is_still_recognised_as_part_of_the_diff(gate, spelling):
+    """The off-diff check must not turn every model spelling of a real path
+    into a skip. `git diff --name-only` prints `context.txt`; the finding may
+    say `b/context.txt` or `./context.txt`, and `git show` accepts both."""
+    prompts = []
+
+    def reply(user):
+        prompts.append(user)
+        if ar.CONFIRM_MARKER not in user:
+            return _high(file=spelling)
+        return '{"confirmed": false, "reason": "r"}'
+
+    gate(reply)
+    assert ar.main() == 0, spelling
+    assert sum(ar.CONFIRM_MARKER in p for p in prompts) == 1, spelling
+
+
+def test_an_off_diff_finding_says_why_it_was_not_re_checked(gate, monkeypatch):
+    """"not re-checked" must not read as a provider outage."""
+    posted = []
+    monkeypatch.setattr(ar, "post_sticky_comment", posted.append)
+    gate(_confirming(_high(file="base.txt"), False))
+    assert ar.main() == 1
+    assert "not in the reviewed diff" in posted[0]
+
+
+def test_an_exhausted_budget_is_reported_as_such_not_as_an_api_failure(
+    gate, monkeypatch
+):
+    """The lens pass spends from the same wall clock. When it has spent all of
+    it, every remaining confirmation would fail one at a time and render as
+    "confirmation call failed", which reads as the provider being down."""
+    posted = []
+    monkeypatch.setattr(ar, "post_sticky_comment", posted.append)
+    monkeypatch.setattr(ar, "_time_left", lambda: 0.0)
+    prompts = []
+
+    def reply(user):
+        prompts.append(user)
+        return _high()
+
+    gate(reply)
+    assert ar.main() == 1
+    assert not any(ar.CONFIRM_MARKER in p for p in prompts)
+    assert "budget exhausted" in posted[0]
 
 
 def test_a_high_on_an_unreadable_file_blocks_without_a_second_pass(gate):
@@ -1197,9 +1317,13 @@ def test_confirmation_is_bounded(gate):
 
 
 def test_file_at_resolves_a_diff_prefixed_path(repo):
-    assert "SENTINEL" in ar.file_at(repo["head"], "context.txt")
-    assert "SENTINEL" in ar.file_at(repo["head"], "b/context.txt")
-    assert "SENTINEL" in ar.file_at(repo["head"], "./context.txt")
+    for spelling in ("context.txt", "b/context.txt", "./context.txt"):
+        at_head = ar.file_at(repo["head"], spelling)
+        assert "SENTINEL" in at_head.text, spelling
+        # The path git ACCEPTED, not the one the model wrote — the caller tests
+        # membership of the reviewed diff against this, and `b/context.txt` is
+        # not a path git ever reports as changed.
+        assert at_head.path == "context.txt", spelling
 
 
 @pytest.mark.parametrize("path", ["", "   ", "?", "<unknown>", "no/such/file.ts", None])
@@ -1207,10 +1331,10 @@ def test_file_at_returns_none_rather_than_guessing(repo, path):
     assert ar.file_at(repo["head"], path) is None
 
 
-def test_oversized_file_is_not_confirmed_against_a_truncated_view(gate, monkeypatch):
+def test_oversized_context_is_not_confirmed_against_a_truncated_view(gate, monkeypatch):
     """Truncation is what the first pass already suffered from. "Confirmed
-    against half a file" is a worse answer than "not checked"."""
-    monkeypatch.setattr(ar, "CONFIRM_MAX_FILE_CHARS", 10)
+    against half the context" is a worse answer than "not checked"."""
+    monkeypatch.setattr(ar, "CONFIRM_MAX_CONTEXT_CHARS", 10)
     prompts = []
 
     def reply(user):

--- a/.github/workflows/adversarial-review.yml
+++ b/.github/workflows/adversarial-review.yml
@@ -22,13 +22,24 @@ name: adversarial-review
 #   budget= 50000   18 chunks     54 calls
 #   budget=  4000  319 chunks    957 calls   <- can outlive the 20-minute budget
 #
-# To cut spend, RAISE it (or set a cheaper ADVERSARIAL_MODEL). Lower it only to
-# fit a model's context window, and never below the script's MIN_CHUNK_CHARS
-# floor of 4000, which it rejects.
+# To cut spend, RAISE it. Lower it only to fit a model's context window, and
+# never below the script's MIN_CHUNK_CHARS floor of 4000, which it rejects.
 #
-# ADVERSARIAL_WORKERS is the throttle for a rate-limit incident: it lowers
-# concurrency without changing the number of calls. That is the knob to reach
-# for mid-incident, not MAX_CHUNK_CHARS.
+# ADVERSARIAL_MODEL IS NOT A SPEND KNOB — do not reach for it. The script pins
+# the review model to ALLOWED_MODELS in `.github/scripts/adversarial_review.py`,
+# which holds only ids this gate has actually been run with (today: exactly the
+# default, per provider). Any other value — including a cheaper model — is a
+# HARD ERROR, not a fallback: the script exits non-zero and this REQUIRED check
+# goes red on every open PR and every merge-queue entry until the variable is
+# deleted again. Widening the set is a code change that must itself pass this
+# gate. If a run does go red this way, the job log carries an `::error::` line
+# naming the rejected value, and every successful run prints the resolved
+# provider and model id in its audit line.
+#
+# The mid-incident levers are MAX_CHUNK_CHARS and ADVERSARIAL_WORKERS, which the
+# script accepts as given. ADVERSARIAL_WORKERS is the throttle for a rate-limit
+# incident: it lowers concurrency without changing the number of calls. That is
+# the knob to reach for mid-incident, not MAX_CHUNK_CHARS.
 #
 # A false positive that blocks the queue is a detrimental process — fix the
 # prompt fast rather than routing around the gate.
@@ -78,6 +89,10 @@ jobs:
           # Claude automatically if ANTHROPIC_API_KEY is ever added to secrets.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+          # Selects FROM the script's ALLOWED_MODELS; it cannot introduce a new
+          # value. An unrecognized id is a hard error that reds this required
+          # check repo-wide, so leave it unset unless you mean to pick another
+          # allow-listed model. Not a cost lever — see the header comment.
           ADVERSARIAL_MODEL: ${{ vars.ADVERSARIAL_MODEL }}
           MAX_CHUNK_CHARS: ${{ vars.MAX_CHUNK_CHARS }}
           # The throttle you reach for mid-incident. Every worker holds a full


### PR DESCRIPTION
## What

Give the `adversarial-review` security lens a threat model, define the severity
ladder explicitly, add a confirmation pass on HIGH findings only, and pin
`ADVERSARIAL_MODEL` to an allow-list.

## Why

The gate's first real block was **mechanically correct but over-graded**: a Vite
`server.fs.allow` widening — dev-server only, on a PUBLIC repo, reachable only by
a LAN peer of the developer — graded HIGH. Taking the lens seriously did surface a
genuine keystore exposure, so the lens has value; the problem is precision, not the
lens existing. Reading the script, three causes:

1. **The security lens was one sentence with no threat model**, sitting next to
   three paragraphs of hard-won "do NOT report" calibration on the correctness
   lens (plus a whole `CHUNK_HINT` that exists solely to prevent false HIGHs).
   That asymmetry is the bug. A reviewer told to find injection / SSRF / missing
   authz, with no description of the system, grades against a generic
   multi-tenant web service — because that is what those words describe.
2. **Severity guidance calibrated CONFIDENCE, not impact** — "reserve it for real,
   confident defects" — and HIGH vs MEDIUM was never defined anywhere. A reviewer
   that is *certain* about a *harmless* fact reads that as licence to block.
3. **One low-precision, context-poor call decided it.** The lens saw a diff chunk
   and nothing else, and there was no second look.

## What changed

**Threat model on the security lens.** It now knows the repo is PUBLIC and open
source (so source disclosure is not itself an exposure — only real secret material
is), that the products are a local Tauri app and a static site with no server-side
authz layer and no multi-tenant data (so "missing authz"/IDOR presuppose a server
this diff would have to add), that `server.*` config, tests, benches, CI and dev
tooling never ship, and what untrusted input genuinely *does* matter here
(downloaded packs, catalog JSON, model output, remote assets).

**`SEVERITY_LADDER`,** shared by all three lenses, grading impact and reachability
with HIGH reserved for something reachable by someone who is not the developer at
their own machine. It teaches the distinction with two real events from this repo
that share a reachability class and differ only in impact:

- **TRUE HIGH** — the production Android upload **keystore** served over the LAN
  by the dev server, because Vite's default deny list does not cover `.jks`.
- **NOT HIGH** — widening `server.fs.allow` in that same dev config, which exposes
  source code in an already-public repo. That is LOW.

**Confirmation pass on HIGH only.** Each blocking finding is re-asked once, alone,
against **both the whole file at head and the diff this branch applied to that
file** — the two halves the first pass lacked. It costs nothing on a clean diff.

The diff half is load-bearing, not decoration. A first draft of this PR sent head
state only, and review proved the consequence against the real code: a HIGH about
something the change *removed* — a deleted guard, a dropped `voiceId` alias, a
lowered platform floor — shows the confirmer a file where the thing is simply
absent, and the honest reading of that absence is "I see no such code, not a
blocking problem" → cleared → exit 0. That is most of what the correctness and
pack-compat lenses exist to catch, so `CONFIRM_HINT` now tells the pass to read
both and that an absence at head is *not* evidence against the finding.

**Off-diff findings are never confirmed.** `file_at` resolves any path that exists
at head, so a HIGH naming a file the reviewed range never touched was being
confirmed against that file's unrelated, pre-existing contents — where "not a
blocking problem introduced here" is the *correct* answer, and the clearance was
selected by the model-written `file` string, the least reliable field in the whole
finding. Mis-attribution is a routine model error (a chunk spans several files and
the finding lands under the wrong `diff --git` header). Such findings are now
skipped, which blocks. `file_at` returns the path git *accepted* so the membership
test uses git's own spelling, and `./`-prefixed paths resolve stripped first —
`git show <head>:./x` succeeds but reports back a spelling `git diff --name-only`
never prints, which would otherwise have made every `./`-prefixed finding look
off-diff.

**One confirmation per distinct finding.** `dedupe` keys on the lens, so one defect
all three lenses noticed survived as three findings and spent three whole-file
calls — up to `CONFIRM_MAX_CONTEXT_CHARS` (400k) each, from a budget of 20 — asking
one question three times. They are now grouped on `(file, line, title)`, confirmed
once with all three lens framings in the prompt, and the verdict fans back out. An
exhausted wall clock is also reported as such, instead of surfacing as up to 20
consecutive "confirmation call failed" lines that read like a provider outage.

**`ADVERSARIAL_MODEL` allow-list.** It was the quietest unlocked door: a repo
variable that could silently downgrade all three lenses forever, with no PR and no
audit trail. See *Model allow-list* below for exactly what is in the set and why.

**No waiver, by design.** No annotation, suppression, or PR-body override — and a
test asserts none appears. Agents author both the diff and the PR body in this
repo, so any such mechanism is a waiver the reviewed party grants itself. The
rationale is recorded as a comment above `confirm_findings` so nobody adds one later.

## Model allow-list

The set holds **only ids this gate has actually run** against these prompts and
this exact request shape — today that is exactly the default, per provider:
`claude-opus-5` and `gpt-4.1`.

An earlier revision of this PR also listed `claude-fable-5` and `claude-opus-4-8`
and described them as validated. **They were not.** `ADVERSARIAL_MODEL` has never
been set, so every call this gate has ever made used a default. Both are one
variable edit from a repo-wide red: `call_model` always sends `fallbacks: "default"`
under the `server-side-fallback-2026-07-01` beta, and the fallback target set is a
property of the *requested* model (`claude-opus-4-8` is itself Opus 5's documented
fallback target), while `claude-fable-5` additionally requires 30-day organization
data retention or every request returns `400 invalid_request_error`. Both are
removed, and `test_the_allow_list_holds_only_ids_this_gate_has_run` now pins the
set so widening it is a deliberate change that must prove the new id first.

**An unlisted value is a hard error, not a fallback** — that is the point (a silent
fallback makes a downgraded variable indistinguishable from an unset one), but it
means the variable is *not* a spend knob, and `adversarial-review.yml` said it was.
That comment is fixed in this PR; see *Blast radius*.

## Fail-closed, preserved

Only an explicit clearance stops a HIGH blocking. A **confirmed HIGH, an errored
confirmation call, an unparseable verdict, a file that cannot be read, a file whose
path is not in the reviewed diff, context over the budget, and an exhausted review
budget all still block.** `is_blocking` is written as "not cleared" rather than
"confirmed" precisely so any future state defaults to blocking. Cleared HIGHs are
**listed in the sticky comment** and logged as a warning — a clearance is the one
place this gate gets quieter, so it leaves a trace.

**This change can only ever remove blocks, never add one:** blocking findings are a
strict subset of HIGH findings, which all blocked unconditionally before. (The
single exception is a deliberately rejected `ADVERSARIAL_MODEL` — see below.)

Re-verified intact: chunk-and-union coverage with the programmatic coverage
assertion, `merge-base` range resolution failing closed, any lens error blocking,
unparseable/empty/truncated replies counting as lens errors, severity
normalization, the always-emitted audit line, `timeout-minutes: 25`, and both
`pull_request` and `merge_group` triggers.

Loaded the `claude-api` skill before touching model config. The Anthropic branch
keeps `claude-opus-5`, adaptive thinking, and `fallbacks: "default"`; the only
behavioural change there is that the JSON schema is a parameter so the confirmation
pass can use its own.

## Blast radius

**Areas touched:** CI — `.github/scripts/` plus **comments only** in
`.github/workflows/adversarial-review.yml`.

The workflow edit is required, not incidental. Its header comment told operators
"to cut spend, RAISE it (or set a cheaper `ADVERSARIAL_MODEL`)" — advice that,
after the allow-list lands, reds this required check on every open PR and every
merge-queue entry until the variable is deleted again. It now states that the model
is pinned, that an unlisted value is a hard error rather than a fallback, that
widening the set takes a PR, and that `MAX_CHUNK_CHARS` / `ADVERSARIAL_WORKERS`
remain the mid-incident levers. Proven comments-only: the parsed YAML is equal to
`origin/main` (below), so no trigger, job, name, timeout, or required context changes.

- [x] Every touched path is covered by a `ci.yml` area filter — the `ci_scripts`
      filter is `^(\.github/scripts/|\.github/workflows/(ci|adversarial-review)\.yml$)`,
      which matches all three files and gates the `ci-scripts · tests` job.
- [x] **Pack back-compat.** N/A — no pack, catalog, or `voiceId` touched.
- [x] **Native integrity.** N/A — no Rust or Cargo manifest touched.
- [x] **Strings.** N/A — no user-visible app strings. The prompt/comment text added
      here is CI-internal and never localized.
- [x] **Curriculum.** N/A — no skill or generator touched.
- [x] **Secrets.** None. Prompt text and control flow only.

Risk is concentrated in one place: the confirmation pass is the only mechanism that
can make a blocking finding stop blocking. It is bounded (`MAX_CONFIRMATIONS = 20`,
counted over distinct findings), fail-closed on every error path, and its
clearances are visible in the comment and the job log.

**Residual risk, stated honestly.** An `ADVERSARIAL_MODEL` set to an unlisted value
reds this required check repo-wide until it is unset. The repo-scope variable list
is empty (below), but `vars.*` also resolves organization- and environment-scope
variables, and `gh api orgs/corpora-inc/actions/variables` returns 403 without
`admin:org` — so *enumeration* cannot rule that out. The gate answers it directly
instead: this branch's own `adversarial-review` run resolved and printed
`openai (gpt-4.1)` and exited green, which means the variable resolves to the
default at every scope GitHub consults today. The live provider is OpenAI (no
`ANTHROPIC_API_KEY` secret is set), and this PR does not change the OpenAI set, so
the allow-list reduction cannot affect the running gate at all. Recovery, if it ever
fires, is deleting a variable — not merging a PR.

## Proof

Full suite on this branch:

```
$ python -m pytest .github/scripts -q
232 passed in 10.57s
```

The same test file run against the **original** `adversarial_review.py` from
`origin/main` — 40 of the 103 test functions (56 parametrized cases) fail without
this change, so nothing here is untested:

```
$ python -m pytest . -q          # original script + new tests
56 failed, 140 passed in 10.21s
```

Confirmation-pass coverage, exercised against a stubbed provider:

```
$ python -m pytest .github/scripts -q -k "confirm"
21 passed, 211 deselected in 3.05s
```

Those fail-closed tests assert the **number of confirmation calls actually made**,
because "blocked" is what a gate with no confirmation pass at all returns —
asserting only the exit code would have passed for the wrong reason.

**Each fix was mutation-tested — reverted in place, and caught by exactly the test
that claims it:**

```
MUTATION: drop the diff from build_confirm_prompt
  -> FAILED test_confirmation_also_carries_the_change_not_only_head_state
     (and the run printed "3 blocking-severity finding(s) were cleared" — the
      deletion finding fails open on head state alone, exactly as reviewed)

MUTATION: delete the off-diff membership check
  -> FAILED test_a_high_on_a_file_outside_the_reviewed_diff_is_never_confirmed
  -> FAILED test_an_off_diff_finding_says_why_it_was_not_re_checked
     (again: "3 blocking-severity finding(s) were cleared", exit 0)

MUTATION: key the confirmation memo on the lens too
  -> 8 FAILED, incl. test_one_defect_costs_one_confirmation_and_the_verdict_fans_out

MUTATION: delete the budget-exhausted guard
  -> FAILED test_an_exhausted_budget_is_reported_as_such_not_as_an_api_failure
```

Fail-closed behaviour re-verified by mutation after the refactor:

```
MUTATION: _confirm_one error branch returns CONFIRM_CLEARED
  -> FAILED test_confirmation_error_blocks
MUTATION: unparseable-verdict branch returns CONFIRM_CLEARED
  -> FAILED test_confirmation_unparseable_reply_blocks
MUTATION: delete the has_unreadable_severity skip
  -> FAILED test_unreadable_severity_blocks_without_a_second_pass
```

The workflow change is comments-only (`yaml.safe_load` of `origin/main` vs `HEAD`):

```
PARSED YAML IDENTICAL TO origin/main: True
```

`ci-gate` aggregation is complete and the touched files are covered:

```
jobs: 14 | ci-gate.needs: 13
NOT AGGREGATED BY ci-gate: []

.github/scripts/adversarial_review.py:       ci_scripts matched = True
.github/scripts/test_adversarial_review.py:  ci_scripts matched = True
.github/workflows/adversarial-review.yml:    ci_scripts matched = True
```

Diff size, against the 200000-**char** chunk budget. `MAX_CHUNK_CHARS` is
compared against `len()` of a `str`, so characters are the number that matters;
`wc -c` counts bytes and reads high because of the em dashes in the prose:

```
$ git diff --unified=3 origin/main...HEAD | wc -c
68404                      # bytes

# the gate's own audit line for this very commit, in chars:
_Reviewed `9bc35eed9..b9dabcd2f` (merge base == requested base `9bc35eed920b`)
 — 3 file(s), 68192 chars, 1 chunk(s) of <= 200000; every lens read 100% of
 that diff, 0 chars dropped · openai (gpt-4.1) · 3 lenses._
```

That audit line is also the end-to-end proof: the gate reviewed this change,
resolved its model through the new allow-list, covered 100% of the diff in one
chunk, and exited green.

Repo-scope variables (org scope is not enumerable without `admin:org` — see
*Residual risk*):

```
$ gh api repos/corpora-inc/encorpora/actions/variables
{"names":[],"total_count":0}
```
