### PR TITLE
ci: add the native/Rust gate (fmt ratchet, compile, clippy, patch integrity)

### DIFF
--- a/.github/scripts/clippy_report.py
+++ b/.github/scripts/clippy_report.py
@@ -27,14 +27,27 @@ import sys
 from typing import IO
 
 
-def diagnostic_key(message: dict) -> tuple:
-    """Identity of a diagnostic, stable across the targets that re-emit it."""
+def diagnostic_key(record: dict) -> tuple:
+    """Identity of a diagnostic, stable across the targets that re-emit it.
+
+    Takes the whole cargo envelope, not just `message`, because `file_name` in
+    the span is relative to the PACKAGE root: two crates each warning at
+    `src/lib.rs:42:5` with the same lint and text are indistinguishable without
+    `package_id`, and the second would be both uncounted and unprinted. The job
+    compiles eleven plugin crates as path deps (cargo does not `--cap-lints
+    allow` a path source), so that collision is reachable.
+
+    `--all-targets` re-emits a lib diagnostic for the lib-test target under the
+    SAME `package_id`, so cross-target de-duplication is unaffected.
+    """
+    message = record.get("message") or {}
     code = (message.get("code") or {}).get("code") or ""
     spans = message.get("spans") or []
     primary = next((s for s in spans if s.get("is_primary")), None)
     if primary is None:
         primary = spans[0] if spans else {}
     return (
+        record.get("package_id") or "",
         code,
         primary.get("file_name", ""),
         primary.get("line_start", 0),
@@ -64,7 +77,7 @@ def process(stream: IO[str], out: IO[str]) -> tuple[int, int]:
         if level not in ("warning", "error"):
             continue
 
-        key = diagnostic_key(message)
+        key = diagnostic_key(record)
         (errors if level == "error" else warnings).add(key)
 
         if key not in printed:

--- a/.github/scripts/clippy_report.py
+++ b/.github/scripts/clippy_report.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Render `cargo --message-format=json` diagnostics and count the unique ones.
+
+Why not parse cargo's own human summary: it prints
+
+    warning: `corpan` (lib) generated 2 warnings (1 duplicate)
+    warning: `corpan` (lib test) generated 2 warnings (1 duplicate)
+
+for `--all-targets`, tagging BOTH lines as containing duplicates. Summing them
+double-counts; dropping every line that says "duplicate" counts zero. Neither is
+the number a human wants. So: read the structured stream, de-duplicate on the
+diagnostic's own identity (lint code + span + text), and print that.
+
+Usage:
+    cargo clippy --message-format=json ... | clippy_report.py --count-file F
+
+stdout of cargo is JSON; its stderr (progress, the final error summary) is left
+alone and flows straight to the job log. This reads stdin to EOF — it must never
+exit early, or cargo takes SIGPIPE and the pipeline returns 141.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import IO
+
+
+def diagnostic_key(message: dict) -> tuple:
+    """Identity of a diagnostic, stable across the targets that re-emit it."""
+    code = (message.get("code") or {}).get("code") or ""
+    spans = message.get("spans") or []
+    primary = next((s for s in spans if s.get("is_primary")), None)
+    if primary is None:
+        primary = spans[0] if spans else {}
+    return (
+        code,
+        primary.get("file_name", ""),
+        primary.get("line_start", 0),
+        primary.get("column_start", 0),
+        message.get("message", ""),
+    )
+
+
+def process(stream: IO[str], out: IO[str]) -> tuple[int, int]:
+    """Print rendered diagnostics; return (unique warnings, unique errors)."""
+    warnings: set[tuple] = set()
+    errors: set[tuple] = set()
+    printed: set[tuple] = set()
+
+    for line in stream:
+        line = line.strip()
+        if not line or not line.startswith("{"):
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if record.get("reason") != "compiler-message":
+            continue
+        message = record.get("message") or {}
+        level = message.get("level")
+        if level not in ("warning", "error"):
+            continue
+
+        key = diagnostic_key(message)
+        (errors if level == "error" else warnings).add(key)
+
+        if key not in printed:
+            printed.add(key)
+            rendered = message.get("rendered")
+            if rendered:
+                out.write(rendered if rendered.endswith("\n") else rendered + "\n")
+
+    return len(warnings), len(errors)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--count-file",
+        help="File to append the unique warning count to (one integer per line).",
+    )
+    parser.add_argument(
+        "--label", default="", help="Prefix for the summary line, e.g. the crate path."
+    )
+    args = parser.parse_args(argv)
+
+    warnings, errors = process(sys.stdin, sys.stdout)
+
+    label = f"{args.label}: " if args.label else ""
+    print(f"{label}{warnings} unique clippy warning(s), {errors} unique error(s)")
+
+    if args.count_file:
+        with open(args.count_file, "a", encoding="utf-8") as fh:
+            fh.write(f"{warnings}\n")
+
+    # Always 0: the compile verdict is cargo's exit code, which `pipefail`
+    # propagates. Failing here too would report the same failure twice and
+    # would make a lint warning look like a build break.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/scripts/patch_integrity.py
+++ b/.github/scripts/patch_integrity.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Assert every `[patch.*]` in the repo is actually applied.
+
+A Cargo patch that stops matching does not fail a build. Cargo emits
+
+    warning: Patch `foo v1.2.3 (/path)` was not used in the crate graph.
+
+on **stderr**, exits 0, and quietly resolves the upstream crate instead. This
+repo has already lost a vendored crash fix that way: the patched crate was
+silently dropped, the app compiled, tested and clippied clean, and the
+regression only surfaced on a device.
+
+Three assertions, in increasing strength:
+
+1. No tracked `Cargo.lock` contains a `[[patch.unused]]` stanza. Cargo writes
+   that section when a declared patch does not apply, so a lock is a durable,
+   grep-able record of the failure.
+2. `cargo metadata` for each patching manifest emits no "was not used in the
+   crate graph" warning. This is the load-bearing one — `cargo metadata` exits
+   0 either way, so the *only* signal is the stderr text.
+3. Every patched package resolves in the graph to the vendored path the patch
+   declares, not to a registry copy.
+
+Run with the manifests to inspect, or with no arguments to inspect every
+tracked manifest that declares a patch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+# Cargo's wording for a patch that resolved to nothing. Matched as a substring
+# because the surrounding text (crate name, version, source) varies.
+UNUSED_PATCH_MARKER = "was not used in the crate graph"
+
+# Third-party trees we neither format nor own. A vendored fork's own manifest
+# is exempt from inspection; the patch that POINTS at it is not.
+EXCLUDED_PATH_PARTS = ("vendor", "node_modules", "target")
+
+
+def has_unused_patch_stanza(lock_text: str) -> bool:
+    """True when a Cargo.lock records a patch that did not apply."""
+    return re.search(r"^\[\[patch\.unused\]\]", lock_text, re.MULTILINE) is not None
+
+
+def unused_patch_warnings(stderr: str) -> list[str]:
+    """The `cargo` stderr lines reporting a patch that matched nothing."""
+    return [line.strip() for line in stderr.splitlines() if UNUSED_PATCH_MARKER in line]
+
+
+def patch_entries(manifest: Path) -> list[tuple[str, str, Path]]:
+    """(registry, crate, resolved path) for every path-based patch in a manifest.
+
+    Patches that are not path-based (git, version-only) are returned with a
+    path of ``None`` by the caller's contract — none exist in this repo today,
+    so they are skipped rather than guessed at.
+    """
+    data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+    out: list[tuple[str, str, Path]] = []
+    for registry, crates in (data.get("patch") or {}).items():
+        for crate, spec in crates.items():
+            path = spec.get("path") if isinstance(spec, dict) else None
+            if path is None:
+                continue
+            out.append((registry, crate, (manifest.parent / path).resolve()))
+    return out
+
+
+def tracked_files(pattern: str, repo_root: Path) -> list[Path]:
+    out = subprocess.run(
+        ["git", "ls-files", "-z", pattern],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    paths = [repo_root / p for p in out.split("\0") if p]
+    return [
+        p for p in paths if not any(part in EXCLUDED_PATH_PARTS for part in p.parts)
+    ]
+
+
+def cargo_metadata(manifest: Path) -> tuple[dict, str]:
+    """Full (dependency-resolving) metadata plus cargo's stderr.
+
+    `--no-deps` would skip resolution entirely, which is exactly the step that
+    decides whether a patch applies — so it must not be used here.
+    """
+    proc = subprocess.run(
+        [
+            "cargo",
+            "metadata",
+            "--locked",
+            "--format-version",
+            "1",
+            "--manifest-path",
+            str(manifest),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise SystemExit(
+            f"cargo metadata failed for {manifest} (exit {proc.returncode}):\n"
+            f"{proc.stderr}"
+        )
+    return json.loads(proc.stdout), proc.stderr
+
+
+def check_locks(repo_root: Path) -> list[str]:
+    failures = []
+    locks = tracked_files("*Cargo.lock", repo_root)
+    for lock in locks:
+        rel = lock.relative_to(repo_root)
+        if has_unused_patch_stanza(lock.read_text(encoding="utf-8")):
+            failures.append(
+                f"{rel}: contains a [[patch.unused]] stanza — a declared "
+                f"[patch] no longer matches anything in the graph."
+            )
+        else:
+            print(f"  ok  {rel}: no [[patch.unused]]")
+    if not locks:
+        failures.append("no tracked Cargo.lock found — is this the repo root?")
+    return failures
+
+
+def check_manifest(manifest: Path, repo_root: Path) -> list[str]:
+    rel = manifest.relative_to(repo_root)
+    failures = []
+    entries = patch_entries(manifest)
+    if not entries:
+        return failures
+
+    metadata, stderr = cargo_metadata(manifest)
+
+    for line in unused_patch_warnings(stderr):
+        failures.append(f"{rel}: cargo reported an unapplied patch: {line}")
+
+    by_name: dict[str, list[dict]] = {}
+    for pkg in metadata.get("packages", []):
+        by_name.setdefault(pkg["name"], []).append(pkg)
+
+    for registry, crate, path in entries:
+        want = (path / "Cargo.toml").resolve()
+        candidates = by_name.get(crate, [])
+        if not candidates:
+            failures.append(
+                f"{rel}: [patch.{registry}] declares `{crate}` but no package "
+                f"of that name is in the resolved graph."
+            )
+            continue
+        resolved = [Path(p["manifest_path"]).resolve() for p in candidates]
+        if want in resolved:
+            print(f"  ok  {rel}: {crate} -> {want.relative_to(repo_root)}")
+        else:
+            failures.append(
+                f"{rel}: [patch.{registry}] `{crate}` should resolve to {want} "
+                f"but the graph has {', '.join(str(r) for r in resolved)}."
+            )
+    return failures
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "manifests",
+        nargs="*",
+        help="Cargo.toml files to inspect (default: every tracked manifest).",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(
+        subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    )
+
+    print("Cargo.lock [[patch.unused]] scan:")
+    failures = check_locks(repo_root)
+
+    if args.manifests:
+        manifests = [Path(m).resolve() for m in args.manifests]
+    else:
+        manifests = tracked_files("*Cargo.toml", repo_root)
+
+    print("Declared [patch] resolution:")
+    patching = [m for m in manifests if patch_entries(m)]
+    if not patching:
+        print("  (no manifest declares a path-based [patch])")
+    for manifest in patching:
+        failures.extend(check_manifest(manifest, repo_root))
+
+    if failures:
+        print()
+        for f in failures:
+            print(f"::error::{f}")
+        print(
+            "\nA [patch] that stops matching is SILENT: cargo warns on stderr "
+            "and exits 0.\nRe-point the patch at the vendored path, or delete "
+            "it if the fork is no longer needed.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nAll declared patches apply.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/scripts/patch_integrity.py
+++ b/.github/scripts/patch_integrity.py
@@ -15,11 +15,24 @@ Three assertions, in increasing strength:
 1. No tracked `Cargo.lock` contains a `[[patch.unused]]` stanza. Cargo writes
    that section when a declared patch does not apply, so a lock is a durable,
    grep-able record of the failure.
-2. `cargo metadata` for each patching manifest emits no "was not used in the
-   crate graph" warning. This is the load-bearing one — `cargo metadata` exits
-   0 either way, so the *only* signal is the stderr text.
-3. Every patched package resolves in the graph to the vendored path the patch
-   declares, not to a registry copy.
+2. `cargo metadata --locked` for every manifest that declares a `[patch]` of
+   ANY shape — path, git or version — emits no "was not used in the crate
+   graph" warning. Assertion 2 runs on the mere presence of a `[patch]` table,
+   never on the shape of its entries: a git patch goes unused exactly as
+   silently as a path one, and scoping the run to path patches was a fail-open.
+3. Every patched package that declares a `path` resolves in the graph to that
+   vendored path, not to a registry copy. Only this assertion is path-specific,
+   because only a path patch names a directory to compare against.
+
+Cargo's exit code, measured on cargo 1.93.1 and 1.97.1, depends on the lock:
+
+* lock already carries the `[[patch.unused]]` stanza -> exit **0**, and the
+  stderr text is the only signal metadata gives (assertion 1 also fires).
+* lock is clean, so `--locked` would have to rewrite it -> exit **101**
+  ("cannot update the lock file ... because --locked was passed").
+
+Both are treated as failures. The stderr grep is what makes the first case
+visible, which is why it is not optional.
 
 Run with the manifests to inspect, or with no arguments to inspect every
 tracked manifest that declares a patch.
@@ -54,16 +67,37 @@ def unused_patch_warnings(stderr: str) -> list[str]:
     return [line.strip() for line in stderr.splitlines() if UNUSED_PATCH_MARKER in line]
 
 
+def patch_tables(manifest: Path) -> dict[str, dict]:
+    """The `[patch.<registry>]` tables in a manifest, empty ones dropped."""
+    data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+    return {
+        registry: crates
+        for registry, crates in (data.get("patch") or {}).items()
+        if crates
+    }
+
+
+def has_any_patch(manifest: Path) -> bool:
+    """True when the manifest declares a patch of ANY shape.
+
+    This — not :func:`patch_entries` — is what selects a manifest for the
+    `cargo metadata` run. A git or version patch that stops matching is just as
+    silent as a path one, so keying the run on "has a path patch" would skip
+    the assertion for exactly the case nothing else covers.
+    """
+    return bool(patch_tables(manifest))
+
+
 def patch_entries(manifest: Path) -> list[tuple[str, str, Path]]:
     """(registry, crate, resolved path) for every path-based patch in a manifest.
 
-    Patches that are not path-based (git, version-only) are returned with a
-    path of ``None`` by the caller's contract — none exist in this repo today,
-    so they are skipped rather than guessed at.
+    Path-only, and deliberately so: this feeds the "resolves to the vendored
+    directory" assertion, and a git or version patch names no directory to
+    compare against. Non-path patches are skipped HERE and picked up by
+    :func:`has_any_patch`, which is what gates the metadata run.
     """
-    data = tomllib.loads(manifest.read_text(encoding="utf-8"))
     out: list[tuple[str, str, Path]] = []
-    for registry, crates in (data.get("patch") or {}).items():
+    for registry, crates in patch_tables(manifest).items():
         for crate, spec in crates.items():
             path = spec.get("path") if isinstance(spec, dict) else None
             if path is None:
@@ -86,11 +120,16 @@ def tracked_files(pattern: str, repo_root: Path) -> list[Path]:
     ]
 
 
-def cargo_metadata(manifest: Path) -> tuple[dict, str]:
-    """Full (dependency-resolving) metadata plus cargo's stderr.
+def cargo_metadata(manifest: Path) -> tuple[dict | None, str, int]:
+    """Full (dependency-resolving) metadata, cargo's stderr, and its exit code.
 
     `--no-deps` would skip resolution entirely, which is exactly the step that
     decides whether a patch applies — so it must not be used here.
+
+    A non-zero exit returns ``None`` for the graph rather than raising, so the
+    caller can still report the stderr warnings it collected: an unused patch
+    against a clean lock produces BOTH the warning and exit 101, and the
+    warning is the line that names the crate.
     """
     proc = subprocess.run(
         [
@@ -106,11 +145,8 @@ def cargo_metadata(manifest: Path) -> tuple[dict, str]:
         text=True,
     )
     if proc.returncode != 0:
-        raise SystemExit(
-            f"cargo metadata failed for {manifest} (exit {proc.returncode}):\n"
-            f"{proc.stderr}"
-        )
-    return json.loads(proc.stdout), proc.stderr
+        return None, proc.stderr, proc.returncode
+    return json.loads(proc.stdout), proc.stderr, 0
 
 
 def check_locks(repo_root: Path) -> list[str]:
@@ -133,14 +169,31 @@ def check_locks(repo_root: Path) -> list[str]:
 def check_manifest(manifest: Path, repo_root: Path) -> list[str]:
     rel = manifest.relative_to(repo_root)
     failures = []
-    entries = patch_entries(manifest)
-    if not entries:
+    # Presence of ANY [patch] table, not of a path-based one — see has_any_patch.
+    if not has_any_patch(manifest):
         return failures
 
-    metadata, stderr = cargo_metadata(manifest)
+    metadata, stderr, code = cargo_metadata(manifest)
 
     for line in unused_patch_warnings(stderr):
         failures.append(f"{rel}: cargo reported an unapplied patch: {line}")
+
+    if metadata is None:
+        failures.append(
+            f"{rel}: `cargo metadata --locked` exited {code} — the graph could "
+            f"not be resolved against the committed lock. cargo said:\n"
+            f"{stderr.strip()}"
+        )
+        return failures
+
+    # Logged unconditionally so a manifest whose only patches are git-based —
+    # which reaches assertion 2 but has nothing for assertion 3 to print —
+    # still shows up as inspected rather than as silence.
+    declared = sum(len(c) for c in patch_tables(manifest).values())
+    print(f"  ok  {rel}: graph resolved, no unused-patch warning ({declared} declared)")
+
+    # Assertion 3 is path-only: a git or version patch names no directory.
+    entries = patch_entries(manifest)
 
     by_name: dict[str, list[dict]] = {}
     for pkg in metadata.get("packages", []):
@@ -193,9 +246,9 @@ def main(argv: list[str]) -> int:
         manifests = tracked_files("*Cargo.toml", repo_root)
 
     print("Declared [patch] resolution:")
-    patching = [m for m in manifests if patch_entries(m)]
+    patching = [m for m in manifests if has_any_patch(m)]
     if not patching:
-        print("  (no manifest declares a path-based [patch])")
+        print("  (no manifest declares a [patch])")
     for manifest in patching:
         failures.extend(check_manifest(manifest, repo_root))
 

--- a/.github/scripts/test_clippy_report.py
+++ b/.github/scripts/test_clippy_report.py
@@ -6,10 +6,11 @@ import json
 import clippy_report as cr
 
 
-def _msg(level, code, file_name, line, text, rendered=None):
+def _msg(level, code, file_name, line, text, rendered=None, package_id="pkg#0.1.0"):
     return json.dumps(
         {
             "reason": "compiler-message",
+            "package_id": package_id,
             "message": {
                 "level": level,
                 "code": {"code": code} if code else None,
@@ -88,3 +89,28 @@ def test_interleaved_non_json_lines_do_not_abort_the_stream():
 def test_note_level_is_not_counted():
     stream = io.StringIO(_msg("note", None, "src/lib.rs", 1, "an aside"))
     assert cr.process(stream, io.StringIO()) == (0, 0)
+
+
+def test_identical_spans_in_two_packages_count_twice():
+    """`file_name` is package-relative — two crates collide at src/lib.rs:42."""
+    args = ("warning", "dead_code", "src/lib.rs", 42, "field `x` is never read")
+    stream = io.StringIO(
+        _msg(*args, package_id="path+file:///repo/plugins/a#0.1.0")
+        + "\n"
+        + _msg(*args, package_id="path+file:///repo/plugins/b#0.1.0")
+    )
+    out = io.StringIO()
+    assert cr.process(stream, out) == (2, 0)
+    # Both must reach the log; suppressing the second hides a real diagnostic.
+    assert out.getvalue().count("field `x` is never read") == 2
+
+
+def test_same_package_same_span_still_counts_once():
+    """The lib/lib-test re-emission shares a package_id, so dedup survives."""
+    args = ("warning", "dead_code", "src/lib.rs", 42, "field `x` is never read")
+    stream = io.StringIO(
+        _msg(*args, package_id="path+file:///repo/a#0.1.0")
+        + "\n"
+        + _msg(*args, package_id="path+file:///repo/a#0.1.0")
+    )
+    assert cr.process(stream, io.StringIO()) == (1, 0)

--- a/.github/scripts/test_clippy_report.py
+++ b/.github/scripts/test_clippy_report.py
@@ -1,0 +1,90 @@
+"""Unit tests for the clippy diagnostic renderer / counter."""
+
+import io
+import json
+
+import clippy_report as cr
+
+
+def _msg(level, code, file_name, line, text, rendered=None):
+    return json.dumps(
+        {
+            "reason": "compiler-message",
+            "message": {
+                "level": level,
+                "code": {"code": code} if code else None,
+                "message": text,
+                "rendered": rendered or f"{level}: {text}\n",
+                "spans": [
+                    {
+                        "is_primary": True,
+                        "file_name": file_name,
+                        "line_start": line,
+                        "column_start": 1,
+                    }
+                ],
+            },
+        }
+    )
+
+
+def test_same_warning_from_two_targets_counts_once():
+    """`--all-targets` re-emits a lib warning for the lib-test target."""
+    stream = io.StringIO(
+        "\n".join(
+            [
+                _msg("warning", "unused_imports", "src/lib.rs", 3, "unused import"),
+                _msg("warning", "unused_imports", "src/lib.rs", 3, "unused import"),
+            ]
+        )
+    )
+    out = io.StringIO()
+    assert cr.process(stream, out) == (1, 0)
+    assert out.getvalue().count("unused import") == 1
+
+
+def test_distinct_warnings_are_counted_separately():
+    stream = io.StringIO(
+        "\n".join(
+            [
+                _msg("warning", "unused_imports", "src/lib.rs", 3, "unused import"),
+                _msg("warning", "dead_code", "src/net.rs", 49, "field never read"),
+            ]
+        )
+    )
+    assert cr.process(stream, io.StringIO()) == (2, 0)
+
+
+def test_errors_are_counted_apart_from_warnings():
+    stream = io.StringIO(
+        _msg("error", "E0308", "src/lib.rs", 10, "mismatched types")
+        + "\n"
+        + _msg("warning", "dead_code", "src/lib.rs", 20, "never read")
+    )
+    assert cr.process(stream, io.StringIO()) == (1, 1)
+
+
+def test_non_diagnostic_records_are_ignored():
+    stream = io.StringIO(
+        json.dumps({"reason": "compiler-artifact", "target": {"name": "corpan"}})
+        + "\n"
+        + json.dumps({"reason": "build-finished", "success": True})
+    )
+    assert cr.process(stream, io.StringIO()) == (0, 0)
+
+
+def test_interleaved_non_json_lines_do_not_abort_the_stream():
+    """Cargo progress on a merged stream must not stop the count."""
+    stream = io.StringIO(
+        "   Compiling corpan v0.20.6\n"
+        + _msg("warning", "dead_code", "src/lib.rs", 20, "never read")
+        + "\nnot json at all\n"
+        + _msg("warning", "unused_mut", "src/lib.rs", 30, "unused mut")
+        + "\n"
+    )
+    assert cr.process(stream, io.StringIO()) == (2, 0)
+
+
+def test_note_level_is_not_counted():
+    stream = io.StringIO(_msg("note", None, "src/lib.rs", 1, "an aside"))
+    assert cr.process(stream, io.StringIO()) == (0, 0)

--- a/.github/scripts/test_patch_integrity.py
+++ b/.github/scripts/test_patch_integrity.py
@@ -7,6 +7,8 @@ tests pin it.
 
 from pathlib import Path
 
+import pytest
+
 import patch_integrity as pi
 
 
@@ -91,13 +93,96 @@ def test_patch_entries_empty_without_a_patch_section(tmp_path: Path):
     assert pi.patch_entries(manifest) == []
 
 
-def test_non_path_patches_are_skipped(tmp_path: Path):
-    """Only path patches are asserted; a git patch has no vendored dir to check."""
-    manifest = tmp_path / "Cargo.toml"
+def _write(manifest: Path, patch_body: str) -> Path:
+    manifest.parent.mkdir(parents=True, exist_ok=True)
     manifest.write_text(
-        '[package]\nname = "x"\nversion = "0.1.0"\n\n'
-        "[patch.crates-io]\n"
-        'foo = { git = "https://example.invalid/foo" }\n',
-        encoding="utf-8",
+        '[package]\nname = "x"\nversion = "0.1.0"\n\n' + patch_body, encoding="utf-8"
     )
+    return manifest
+
+
+GIT_PATCH = '[patch.crates-io]\nfoo = { git = "https://example.invalid/foo" }\n'
+
+
+def test_patch_entries_skips_non_path_specs(tmp_path: Path):
+    """Assertion 3 is path-only — a git patch names no vendored dir to compare."""
+    manifest = _write(tmp_path / "Cargo.toml", GIT_PATCH)
     assert pi.patch_entries(manifest) == []
+
+
+def test_has_any_patch_sees_a_git_patch(tmp_path: Path):
+    """The metadata run is gated on this, NOT on patch_entries."""
+    assert pi.has_any_patch(_write(tmp_path / "Cargo.toml", GIT_PATCH)) is True
+
+
+def test_has_any_patch_sees_a_version_only_patch(tmp_path: Path):
+    body = '[patch.crates-io]\nfoo = { version = "1.0.0" }\n'
+    assert pi.has_any_patch(_write(tmp_path / "Cargo.toml", body)) is True
+
+
+def test_has_any_patch_false_without_a_patch_section(tmp_path: Path):
+    assert pi.has_any_patch(_write(tmp_path / "Cargo.toml", "")) is False
+
+
+def test_has_any_patch_false_for_an_empty_patch_table(tmp_path: Path):
+    assert pi.has_any_patch(_write(tmp_path / "Cargo.toml", "[patch.crates-io]\n")) is False
+
+
+def test_git_only_patch_still_gets_a_metadata_run(tmp_path: Path, monkeypatch):
+    """The fail-open this gate exists to prevent: a git patch skipped entirely.
+
+    `check_manifest` used to return before running `cargo metadata` whenever no
+    PATH patch was declared, so a git patch that stopped applying passed
+    silently — the same outcome as having no gate.
+    """
+    manifest = _write(tmp_path / "src-tauri" / "Cargo.toml", GIT_PATCH)
+    calls = []
+
+    def fake_metadata(path):
+        calls.append(path)
+        return (
+            {"packages": []},
+            "warning: patch `foo v1.0.0 (https://example.invalid/foo)` was not "
+            "used in the crate graph\n",
+            0,
+        )
+
+    monkeypatch.setattr(pi, "cargo_metadata", fake_metadata)
+    failures = pi.check_manifest(manifest, tmp_path)
+
+    assert calls == [manifest], "cargo metadata must run for a git-only patch"
+    assert len(failures) == 1
+    assert "unapplied patch" in failures[0]
+
+
+def test_no_patch_section_runs_no_metadata(tmp_path: Path, monkeypatch):
+    """The early return still applies when there is genuinely nothing to check."""
+    manifest = _write(tmp_path / "Cargo.toml", "")
+    monkeypatch.setattr(
+        pi, "cargo_metadata", lambda p: pytest.fail("metadata must not run")
+    )
+    assert pi.check_manifest(manifest, tmp_path) == []
+
+
+def test_locked_failure_is_reported_not_swallowed(tmp_path: Path, monkeypatch):
+    """`cargo metadata --locked` exits 101 when the lock would have to move.
+
+    Measured on cargo 1.93.1: an unused patch against a clean lock emits the
+    stderr warning AND exits 101. Both lines must surface.
+    """
+    manifest = _write(tmp_path / "Cargo.toml", GIT_PATCH)
+    monkeypatch.setattr(
+        pi,
+        "cargo_metadata",
+        lambda p: (
+            None,
+            "warning: patch `foo v1.0.0 (https://example.invalid/foo)` was not "
+            "used in the crate graph\n"
+            "error: cannot update the lock file ... because --locked was passed\n",
+            101,
+        ),
+    )
+    failures = pi.check_manifest(manifest, tmp_path)
+    assert len(failures) == 2
+    assert "unapplied patch" in failures[0]
+    assert "exited 101" in failures[1]

--- a/.github/scripts/test_patch_integrity.py
+++ b/.github/scripts/test_patch_integrity.py
@@ -1,0 +1,103 @@
+"""Unit tests for the Cargo [patch] integrity gate.
+
+The gate's failure mode is to PASS wrongly — `cargo metadata` exits 0 whether or
+not a patch applied — so the string matching below is the whole signal. These
+tests pin it.
+"""
+
+from pathlib import Path
+
+import patch_integrity as pi
+
+
+def test_unused_stanza_detected():
+    lock = """
+version = 3
+
+[[package]]
+name = "llama-cpp-sys-2"
+version = "0.1.146"
+
+[[patch.unused]]
+name = "llama-cpp-sys-2"
+version = "0.1.146"
+"""
+    assert pi.has_unused_patch_stanza(lock) is True
+
+
+def test_clean_lock_has_no_unused_stanza():
+    lock = '\nversion = 3\n\n[[package]]\nname = "serde"\nversion = "1.0.0"\n'
+    assert pi.has_unused_patch_stanza(lock) is False
+
+
+def test_unused_stanza_must_start_a_line():
+    """A mention inside a comment or a name is not a stanza."""
+    lock = '# see [[patch.unused]] in the cargo book\nname = "x"\n'
+    assert pi.has_unused_patch_stanza(lock) is False
+
+
+def test_unused_patch_warning_is_read_from_stderr():
+    stderr = (
+        "    Updating crates.io index\n"
+        "warning: Patch `llama-cpp-sys-2 v0.1.146 (/repo/vendor/llama-cpp-sys-2)` "
+        "was not used in the crate graph.\n"
+        "Check that the patched package version and available features are "
+        "compatible\n"
+    )
+    hits = pi.unused_patch_warnings(stderr)
+    assert len(hits) == 1
+    assert "llama-cpp-sys-2" in hits[0]
+
+
+def test_unused_patch_warning_matches_current_cargo_wording():
+    """Verbatim from cargo 1.93 — lowercase `patch`, no trailing period.
+
+    The wording has drifted (older cargo capitalised it and ended with a full
+    stop), which is why the matcher keys on the invariant phrase alone.
+    """
+    stderr = (
+        "warning: patch `libc v0.1.0 (/repo/vendor/libc)` was not used in the "
+        "crate graph\n"
+    )
+    assert len(pi.unused_patch_warnings(stderr)) == 1
+
+
+def test_quiet_stderr_yields_no_warning():
+    assert pi.unused_patch_warnings("    Updating crates.io index\n") == []
+
+
+def test_patch_entries_resolves_relative_paths(tmp_path: Path):
+    manifest = tmp_path / "src-tauri" / "Cargo.toml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        '[package]\nname = "app"\nversion = "0.1.0"\n\n'
+        "[patch.crates-io]\n"
+        'llama-cpp-sys-2 = { path = "vendor/llama-cpp-sys-2" }\n',
+        encoding="utf-8",
+    )
+    entries = pi.patch_entries(manifest)
+    assert entries == [
+        (
+            "crates-io",
+            "llama-cpp-sys-2",
+            (tmp_path / "src-tauri" / "vendor" / "llama-cpp-sys-2").resolve(),
+        )
+    ]
+
+
+def test_patch_entries_empty_without_a_patch_section(tmp_path: Path):
+    manifest = tmp_path / "Cargo.toml"
+    manifest.write_text('[package]\nname = "x"\nversion = "0.1.0"\n', encoding="utf-8")
+    assert pi.patch_entries(manifest) == []
+
+
+def test_non_path_patches_are_skipped(tmp_path: Path):
+    """Only path patches are asserted; a git patch has no vendored dir to check."""
+    manifest = tmp_path / "Cargo.toml"
+    manifest.write_text(
+        '[package]\nname = "x"\nversion = "0.1.0"\n\n'
+        "[patch.crates-io]\n"
+        'foo = { git = "https://example.invalid/foo" }\n',
+        encoding="utf-8",
+    )
+    assert pi.patch_entries(manifest) == []

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,12 +192,16 @@ jobs:
           # The `native` job compiles exactly two src-tauri trees: Corpán's and
           # Dynawalla's. The four listed below are NOT compiled by any job.
           # `corpus-reader` and `panko` are dormant (last touched by a repo-wide
-          # sweep in June); `panko` resolves a plugin from a git BRANCH and
-          # `homeschool-offline` tracks no Cargo.lock, so neither can sit behind
-          # a `--locked` gate as it stands; the iap example is a demo, not
-          # shipped. All four ARE rustfmt-gated — the ratchet in the `native`
-          # job walks every tracked manifest — which is why this warning is
-          # about COMPILE coverage specifically.
+          # sweep in June); `panko` also resolves a plugin from a git BRANCH and
+          # `homeschool-offline` tracks no Cargo.lock at all; the iap example is
+          # a demo, not shipped.
+          #
+          # The rustfmt ratchet in `native` WALKS all four, but walking is not
+          # gating: `corpus-reader/src-tauri` and both `homeschool-offline`
+          # crates are on its DEBT list, so their diffs are reported as
+          # warnings and cannot fail the job. `panko/pako/src-tauri` and the
+          # iap example are off the list and therefore enforced. This warning
+          # is about COMPILE coverage specifically.
           ungated='^(corpus-reader/src-tauri/|panko/pako/src-tauri/|homeschool-offline/app/src-tauri/|corpan/plugins/tauri-plugin-iap/examples/)'
 
           # Gate-free by design: CI config, agent control plane, docs, dotfiles.
@@ -310,10 +314,9 @@ jobs:
 
   # Dynawalla's app shell. Node-only, exactly like `corpan-app`: lint, the
   # native test runner, tsc and a production vite build. It does NOT compile
-  # the Rust under dynawalla/dynawalla-app/src-tauri — there is no cargo gate
-  # in this workflow for either app, and adding one is its own PR with its own
-  # runner-cost and caching decisions. The `uncovered` warning above keeps
-  # flagging `src-tauri/` paths until that lands, which is accurate.
+  # the Rust under dynawalla/dynawalla-app/src-tauri — the `native` job below
+  # does, with `cargo clippy --locked --all-targets`, so `src-tauri/` paths no
+  # longer fall through to the `uncovered` warning above. Keep this job npm-only.
   #
   # Path-gated, and therefore NOT a required status context: it reports into
   # `ci-gate` below. A required context that never reports on unrelated PRs
@@ -330,9 +333,10 @@ jobs:
         # `*.png` is Git LFS repo-wide, so a plain checkout leaves a pointer
         # file where the icon should be. `lfs: true` would pull every sqlite3,
         # epub and pdf in the monorepo for the sake of 10 kB, so this fetches
-        # the one path that is read: `capabilities.test.ts` asserts the icon's
-        # PNG colour type, because tauri-codegen panics on anything but RGBA
-        # and does it two minutes into a cargo build no job here runs.
+        # the one path that is read twice: `capabilities.test.ts` asserts the
+        # icon's PNG colour type, and the `native` job's tauri-codegen build
+        # decodes the same file. tauri-codegen panics on anything but RGBA,
+        # minutes into the cargo build — this test catches it in seconds.
         run: git lfs pull --include="dynawalla/dynawalla-app/src-tauri/icons/*"
       - uses: actions/setup-node@v4
         with:
@@ -736,10 +740,30 @@ jobs:
         # Tauri v2 on Linux links webkit2gtk/soup; llama-cpp-sys-2's build
         # script drives cmake and bindgen (libclang). `cargo clippy` runs build
         # scripts, so these are needed for a check-only build too.
+        #
+        # Retried because this job reports into the REQUIRED `ci-gate`, and in
+        # the merge queue a red `ci-gate` ejects the entry under ALLGREEN. A
+        # flaky apt mirror should cost 20 s, not a re-queue. Still fails closed:
+        # `until` is exempt from errexit, and the function returns 1 after the
+        # third attempt.
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+
+          retry() {
+            local n=0
+            until "$@"; do
+              n=$((n + 1))
+              if [ "${n}" -ge 3 ]; then
+                echo "::error::failed after ${n} attempts: $*"
+                return 1
+              fi
+              echo "attempt ${n} failed, retrying in $((n * 5))s: $*"
+              sleep "$((n * 5))"
+            done
+          }
+
+          retry sudo apt-get update
+          retry sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev \
             libjavascriptcoregtk-4.1-dev \
             libsoup-3.0-dev \
@@ -799,8 +823,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Pre-existing rustfmt debt, recorded at rustfmt 1.8.0 (Rust 1.93).
-          # Remove a line the moment its crate is formatted — CI tells you to.
+          # Pre-existing rustfmt debt. Measured identically under rustfmt 1.8.0
+          # (Rust 1.93, a local checkout) and rustfmt 1.9.0-stable (rustc
+          # 1.97.1, what the runner image shipped for this PR) — the toolchain
+          # is deliberately unpinned, so the bar is "whatever stable rustfmt
+          # ships". rustfmt guarantees output stability within a style edition
+          # and `style_edition` defaults to the crate's `edition`, so the only
+          # thing that can move this list without a code change is bumping a
+          # crate's edition (these span 2021 and 2024). Remove a line the moment
+          # its crate is formatted — CI tells you to.
           DEBT='corpan/corpan-app/src-tauri
           corpan/plugins/corpan-asr-contract
           corpan/plugins/tauri-plugin-asr-native
@@ -821,6 +852,7 @@ jobs:
           # `pipefail` turns a successful lookup into status 141. That has
           # silently inverted a compliance check in this repo before.
           seen="$(mktemp)"
+          trap 'rm -f "${seen}"' EXIT
           fail=0
           while IFS= read -r manifest; do
             # `vendor/` is a third-party fork carried verbatim; reformatting it
@@ -874,24 +906,34 @@ jobs:
 
       # ── [patch.crates-io] integrity ──────────────────────────────────────
       #
-      # A Cargo patch that stops matching is SILENT: cargo warns on stderr and
-      # exits 0, and the build compiles, tests and clippies clean against the
-      # upstream crate. This repo has already lost a vendored fix that way.
-      # Cheap (~6 s, resolution only, no compilation), so it runs before the
-      # long build and fails fast.
+      # A Cargo patch that stops matching can be SILENT: when the lock already
+      # carries the `[[patch.unused]]` stanza, `cargo metadata --locked` exits
+      # 0 and the stderr warning is the only signal, and the build compiles,
+      # tests and clippies clean against the upstream crate. This repo has
+      # already lost a vendored fix that way. (Against a CLEAN lock the same
+      # patch exits 101 instead — the script treats both as failures.)
+      # Cheap (~1 s measured, resolution only, no compilation), so it runs
+      # before the long build and fails fast.
       - name: Cargo [patch] integrity
         run: python3 .github/scripts/patch_integrity.py
 
       # ── compile + lint ───────────────────────────────────────────────────
       #
-      # `--locked` is load-bearing twice over: it fails if the committed lock
-      # would have to move (so CI compiles the versions that ship), and it is
-      # only possible because both shipping apps track a Cargo.lock. The other
-      # src-tauri trees do not, which is why they are not here.
+      # `--locked` is load-bearing: it fails if the committed lock would have to
+      # move, so CI compiles the versions that ship. It is possible for all four
+      # tracked locks (`git ls-files '*Cargo.lock'` — corpan, corpus-reader,
+      # dynawalla, panko). The two trees compiled here are the two that ship;
+      # `corpus-reader` and `panko` are dormant and `homeschool-offline` tracks
+      # no Cargo.lock at all. See the `ungated` list in the `changes` job.
       #
       # `--all-targets` also compiles test and bin targets. On a check-only
       # build nothing links, so the marginal cost is small and it is what
       # catches a broken `#[cfg(test)]` module before someone runs the tests.
+      #
+      # Clippy is a BUDGET, not warn-only: CLIPPY_BUDGET below is bidirectional
+      # in the same shape as the rustfmt DEBT list. Over it fails, under it
+      # fails and tells you to lower the number. A count that is printed and
+      # discarded is a log line, not a gate — 16 would drift to 60 unnoticed.
       - name: Compile + clippy (host target)
         run: |
           set -euo pipefail
@@ -926,17 +968,32 @@ jobs:
 
           echo "disk after: $(df -h / | sed -n '2p')"
 
+          # Pre-existing clippy debt across both shipping apps, measured on this
+          # branch: 16 in corpan/corpan-app/src-tauri, 0 in dynawalla's. Every
+          # warning is rendered in the groups above, so a rise names itself.
+          #
+          # Bidirectional, like the rustfmt DEBT list: fixing warnings without
+          # lowering this FAILS, with the number to write. That is what turns
+          # the eventual `-- -D warnings` into a countdown rather than one
+          # heroic PR, and what stops the ratchet rusting open.
+          CLIPPY_BUDGET=16
+
           total="$(awk '{ s += $1 } END { print s + 0 }' "${counts}")"
           {
             echo "### native gate"
             echo
-            echo "Unique clippy warnings across both shipping apps: **${total}**"
-            echo
-            echo "Warn-only today. To enforce, drive that count to 0 in a"
-            echo "Rust-only PR, then append \`-- -D warnings\` to the clippy"
-            echo "invocation in \`.github/workflows/ci.yml\`."
+            echo "Unique clippy warnings: **${total}** (budget ${CLIPPY_BUDGET})"
           } >> "${GITHUB_STEP_SUMMARY}"
-          echo "TOTAL unique clippy warnings: ${total}"
+          echo "TOTAL unique clippy warnings: ${total} (budget ${CLIPPY_BUDGET})"
+
+          if [ "${total}" -gt "${CLIPPY_BUDGET}" ]; then
+            echo "::error::clippy warnings rose to ${total}, over the budget of ${CLIPPY_BUDGET}. Fix the new warning(s) listed above, or justify raising CLIPPY_BUDGET in .github/workflows/ci.yml."
+            exit 1
+          fi
+          if [ "${total}" -lt "${CLIPPY_BUDGET}" ]; then
+            echo "::error::clippy warnings dropped to ${total}. Lower CLIPPY_BUDGET to ${total} in .github/workflows/ci.yml so the gain is held."
+            exit 1
+          fi
 
   # Single summary status that aggregates every job above. THIS is the context to
   # mark as a required check on `main` — it always runs (if: always()) and always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,10 @@ jobs:
       ci_scripts: ${{ steps.filter.outputs.ci_scripts }}
       corpan_app: ${{ steps.filter.outputs.corpan_app }}
       dja: ${{ steps.filter.outputs.dja }}
-      # dynawalla_*, native and shared_ts are declared ahead of the jobs that
-      # will consume them. Nothing reads them yet, so they cannot affect any
-      # gate; declaring them here keeps the follow-up PR a one-line `if:`.
+      # `shared_ts` is declared ahead of the job that will consume it.
+      # Nothing reads it yet, so it cannot affect any gate; declaring it here
+      # keeps the follow-up PR a one-line `if:`. Every other output below is
+      # consumed by a job in this file.
       dynawalla_android_gen: ${{ steps.filter.outputs.dynawalla_android_gen }}
       dynawalla_app: ${{ steps.filter.outputs.dynawalla_app }}
       dynawalla_curriculum: ${{ steps.filter.outputs.dynawalla_curriculum }}
@@ -116,11 +117,17 @@ jobs:
           set_output dynawalla_android_gen '^(dynawalla/dynawalla-app/(package(-lock)?\.json$|android-template-baseline/|src-tauri/gen/android/)|\.github/workflows/ci\.yml$)'
           set_output dynawalla_curriculum '^(dynawalla/curriculum/|\.github/workflows/ci\.yml$)'
           set_output dynawalla_engine '^(dynawalla/engine/|\.github/workflows/ci\.yml$)'
-          # Cross-product areas. Deliberately no `ci.yml` self-trigger: these
-          # exist to answer "did shared code / the native layer move", and a
-          # workflow edit is not a change to either.
+          # Cross-product area. Deliberately no `ci.yml` self-trigger: it exists
+          # to answer "did shared code move", and a workflow edit is not a
+          # change to it. No job consumes it yet.
           set_output shared_ts '^(shared/|corpan/packs/shared/)'
-          set_output native '^(native/|.*/src-tauri/|corpan/plugins/)'
+          # The Rust/native layer: both apps' `src-tauri` trees and every Tauri
+          # plugin crate. Consumed by the `native` job below, so — unlike
+          # `shared_ts` above and unlike this filter before that job existed —
+          # it DOES self-trigger on `ci.yml`, exactly like every other filter
+          # that drives a job. A workflow edit that breaks the native gate has
+          # to be caught by the native gate.
+          set_output native '^(native/|.*/src-tauri/|corpan/plugins/|\.github/workflows/ci\.yml$|\.github/scripts/(patch_integrity|clippy_report)\.py$)'
 
       # Coverage warning. WARN-ONLY, and permanently scoped to `pull_request`.
       #
@@ -159,29 +166,38 @@ jobs:
 
           # Areas a job actually consumes today, minus the `ci.yml` self-triggers
           # (a workflow edit is exempt below anyway). NOT the union of every
-          # filter above: `native` and `shared_ts` are declared ahead of their
-          # jobs, so paths they match are genuinely ungated and must keep
-          # warning until those jobs land. `dynawalla/dynawalla-app/`,
-          # `dynawalla/curriculum/` and `dynawalla/engine/` have each graduated,
-          # as the jobs below now consume their filters.
+          # filter above: `shared_ts` is declared ahead of its job, so paths it
+          # matches are genuinely ungated and must keep warning until that job
+          # lands. `dynawalla/dynawalla-app/`, `dynawalla/curriculum/`,
+          # `dynawalla/engine/` and now `native` have each graduated, as the
+          # jobs below consume their filters.
           #
           # The terraform member is copied verbatim from the `terraform` filter —
           # extension-scoped, not the bare directory. A bare `corpan/infra/
           # terraform/` would mark helper scripts under it as covered when no job
           # runs them.
           #
-          # `corpan/plugins/` is covered only by `.github/workflows/ios-native.yml`,
-          # which is ADVISORY (not a required check). It compiles, so it counts
-          # here, but a red run has to be read by hand.
+          # `corpan/plugins/` is now compiled by the REQUIRED `native` job below
+          # (every plugin is a path dependency of Corpán's src-tauri, so a host
+          # `cargo clippy` of the app compiles all of them). `.github/workflows/
+          # ios-native.yml` additionally compiles their Swift, but it is
+          # advisory and does not count here.
           covered='^(corpan/corpan-app/|corpan/dja/|corpan/infra/terraform/lambda/|corpan/packs/|corpan/infra/terraform/.*(\.tf|\.tfvars|\.tf\.json)$|corpan/infra/terraform/\.terraform\.lock\.hcl$|web/(io|data|pages|scripts)/|corpan/plugins/|dynawalla/dynawalla-app/|dynawalla/(curriculum|engine)/)'
 
           # Carve-outs checked BEFORE `covered`, because a broader area prefix
-          # would otherwise swallow them. `corpan-app`'s job is npm only —
-          # `npm test`/`tsc`/`build`. It never compiles the Rust under
-          # `src-tauri/`, so `corpan/corpan-app/src-tauri/**` is ungated even
-          # though `corpan/corpan-app/` is covered. grep -E has no negative
-          # lookahead, hence a separate pattern.
-          ungated='(^|/)src-tauri/'
+          # would otherwise swallow them. grep -E has no negative lookahead,
+          # hence a separate pattern rather than an exclusion inside `covered`.
+          #
+          # The `native` job compiles exactly two src-tauri trees: Corpán's and
+          # Dynawalla's. The three listed below are NOT compiled by any job —
+          # `corpus-reader` and `panko` are dormant (last touched by a repo-wide
+          # sweep in June), `panko` resolves a plugin from a git BRANCH and
+          # `homeschool-offline` has no tracked Cargo.lock, so neither can be
+          # put behind a `--locked` gate as it stands. The iap example app is a
+          # demo, not shipped. All four are still rustfmt-gated (the ratchet in
+          # the `native` job walks every tracked manifest), which is why this is
+          # a warning about COMPILE coverage specifically.
+          ungated='^(corpus-reader/src-tauri/|panko/pako/src-tauri/|homeschool-offline/app/src-tauri/|corpan/plugins/tauri-plugin-iap/examples/)'
 
           # Gate-free by design: CI config, agent control plane, docs, dotfiles.
           exempt='(^\.github/|^\.claude/|^\.gitignore$|^\.gitattributes$|^LICENSE$|\.md$)'
@@ -653,6 +669,249 @@ jobs:
         working-directory: dynawalla/engine
         run: npm run tsc
 
+  # ───────────────────────────────────────────────────────────────────────────
+  # The Rust / native gate.
+  #
+  # Before this job, NOTHING required ran cargo, rustfmt, clippy or rustup —
+  # every Rust change in both shipping apps merged uncompiled, and the first
+  # signal was a release build at store-submission time. `ios-native.yml`
+  # compiles plugin Swift but is advisory, has no `merge_group` trigger and
+  # carries a top-level `paths:` filter (which is why it can never BE required:
+  # it would not report on unrelated PRs and would deadlock the queue forever).
+  #
+  # This job is path-gated, so it is NOT a required status context either. It
+  # reports into `ci-gate`, which is already required and always reports. That
+  # is what makes this safe by construction: adding a `needs` entry to an
+  # always-reporting aggregate adds coverage without adding a context branch
+  # protection is waiting on, so the merge queue cannot deadlock on it.
+  #
+  # SCOPE — deliberately the host target only:
+  #   * `cargo clippy` (not `cargo check`) because clippy IS a check plus lints:
+  #     one compile, both signals. A compile error fails it; lint warnings are
+  #     counted and reported but do NOT fail, so the first PR to touch Rust is
+  #     not blocked by pre-existing debt. See the enforcement note below.
+  #   * Corpán's src-tauri depends on all eleven plugin crates by path, so
+  #     compiling it compiles every plugin. Clippy LINTS only the app crate
+  #     (path deps outside the workspace dir do not get the clippy wrapper);
+  #     the plugins are compile-checked, not linted.
+  #   * `#[cfg(mobile)]` code (each plugin's `mobile.rs`, the Android JNI and
+  #     crash-breadcrumb blocks in Corpán's lib.rs) is NOT compiled here — a
+  #     linux host build takes the `desktop` cfg. iOS Rust+Swift is covered
+  #     advisory-only by ios-native.yml; the Android Rust glue is covered by
+  #     nothing. Closing that needs an NDK on the runner and is its own PR.
+  native:
+    name: native · fmt + compile + clippy
+    needs: changes
+    if: needs.changes.outputs.native == 'true'
+    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fetch the app icons (Git LFS)
+        # `*.png` is Git LFS repo-wide (.gitattributes:2), and Tauri's
+        # `generate_context!` decodes the icon during compilation — a pointer
+        # file panics tauri-codegen minutes into the build. Same targeted pull
+        # as the dynawalla-app job; `lfs: true` on checkout would drag every
+        # sqlite3/epub/pdf in the monorepo along for ~20 kB of PNG.
+        run: |
+          git lfs pull \
+            --include="corpan/corpan-app/src-tauri/icons/*,dynawalla/dynawalla-app/src-tauri/icons/*"
+      - name: Toolchain
+        # The runner image ships rustup + stable with rustfmt and clippy. No
+        # third-party toolchain action, no extra download on the happy path;
+        # `component add` is a no-op when they are already present.
+        run: |
+          set -euo pipefail
+          rustup component add rustfmt clippy
+          rustc --version
+          cargo --version
+          cargo fmt --version
+          cargo clippy --version
+      - name: System libraries (Tauri + llama.cpp)
+        # Tauri v2 on Linux links webkit2gtk/soup; llama-cpp-sys-2's build
+        # script drives cmake and bindgen (libclang). `cargo clippy` runs build
+        # scripts, so these are needed for a check-only build too.
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libsoup-3.0-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libxdo-dev \
+            libssl-dev \
+            cmake \
+            libclang-dev
+      - name: Cache cargo registry + target dirs
+        # SHA-pinned to the commit tag v2.9.1 dereferences to. Keyed
+        # per-workspace; the two src-tauri trees are separate implicit
+        # workspaces with separate lockfiles.
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        with:
+          workspaces: |
+            corpan/corpan-app/src-tauri
+            dynawalla/dynawalla-app/src-tauri
+          # llama.cpp's cmake output lives under target/*/build/llama-cpp-sys-2-*.
+          # Caching it is the difference between a warm run and a cold one.
+          cache-all-crates: "true"
+
+      # ── rustfmt, as a ratchet ────────────────────────────────────────────
+      #
+      # Fourteen of the eighteen tracked crates carry pre-existing formatting
+      # debt (see DEBT below), so a blanket `cargo fmt --check` would fail on
+      # day one and get deleted. Instead: every crate NOT on the list is
+      # enforced — including every crate added from here on, since the default
+      # is "enforced" — and the listed ones are reported.
+      #
+      # The list is bidirectional on purpose. Formatting a debt crate without
+      # removing it here FAILS, with the exact line to delete. That is what
+      # keeps the ratchet from rusting open.
+      - name: rustfmt (enforced outside the debt list)
+        run: |
+          set -euo pipefail
+
+          # Pre-existing rustfmt debt, recorded at rustfmt 1.8.0 (Rust 1.93).
+          # Remove a line the moment its crate is formatted — CI tells you to.
+          DEBT='corpan/corpan-app/src-tauri
+          corpan/plugins/corpan-asr-contract
+          corpan/plugins/tauri-plugin-asr-native
+          corpan/plugins/tauri-plugin-audio-keepalive
+          corpan/plugins/tauri-plugin-corpan-llm
+          corpan/plugins/tauri-plugin-game-packs
+          corpan/plugins/tauri-plugin-iap
+          corpan/plugins/tauri-plugin-radio-stream
+          corpan/plugins/tauri-plugin-stt
+          corpan/plugins/tauri-plugin-subscriptions
+          corpan/plugins/tauri-plugin-tts
+          corpus-reader/src-tauri
+          homeschool-offline/app/src-tauri
+          homeschool-offline/app/src-tauri/plugins/tauri-plugin-ios-share'
+
+          # Membership is tested with a here-string, never `printf | grep -q`:
+          # `grep -q` exits on the first match, the producer takes SIGPIPE and
+          # `pipefail` turns a successful lookup into status 141. That has
+          # silently inverted a compliance check in this repo before.
+          seen="$(mktemp)"
+          fail=0
+          while IFS= read -r manifest; do
+            # `vendor/` is a third-party fork carried verbatim; reformatting it
+            # would fight every rebase against upstream.
+            case "${manifest}" in */vendor/*) continue ;; esac
+            crate="$(dirname "${manifest}")"
+
+            if grep -Fxq -- "${crate}" <<< "${DEBT}"; then
+              listed=true
+              printf '%s\n' "${crate}" >> "${seen}"
+            else
+              listed=false
+            fi
+
+            if cargo fmt --manifest-path "${manifest}" --check > /dev/null 2>&1; then
+              if [ "${listed}" = true ]; then
+                echo "::error::${crate} is now rustfmt-clean — delete it from the DEBT list in .github/workflows/ci.yml so it stays that way."
+                fail=1
+              else
+                echo "  ok    ${crate}"
+              fi
+              continue
+            fi
+
+            # `cargo fmt --check` exits 1 when it finds diffs, so the `|| true`
+            # is load bearing: without it `errexit` kills this step on the
+            # first debt crate, before a single line is printed.
+            hunks="$(
+              { cargo fmt --manifest-path "${manifest}" --check 2>/dev/null || true; } \
+                | sed -n 's/^Diff in .*/x/p' | wc -l | tr -d ' '
+            )"
+            if [ "${listed}" = true ]; then
+              echo "::warning::${crate} has ${hunks} rustfmt diff(s) (known debt)"
+              echo "  debt  ${crate} (${hunks} diffs)"
+            else
+              echo "::error::${crate} is not rustfmt-clean. Run: cargo fmt --manifest-path ${manifest}"
+              fail=1
+            fi
+          done < <(git ls-files '*Cargo.toml')
+
+          # A DEBT entry for a crate that no longer exists rots silently.
+          while IFS= read -r entry; do
+            [ -n "${entry}" ] || continue
+            if ! grep -Fxq -- "${entry}" "${seen}"; then
+              echo "::error::DEBT lists ${entry}, which is not a tracked crate. Delete the line."
+              fail=1
+            fi
+          done <<< "${DEBT}"
+
+          exit "${fail}"
+
+      # ── [patch.crates-io] integrity ──────────────────────────────────────
+      #
+      # A Cargo patch that stops matching is SILENT: cargo warns on stderr and
+      # exits 0, and the build compiles, tests and clippies clean against the
+      # upstream crate. This repo has already lost a vendored fix that way.
+      # Cheap (~6 s, resolution only, no compilation), so it runs before the
+      # long build and fails fast.
+      - name: Cargo [patch] integrity
+        run: python3 .github/scripts/patch_integrity.py
+
+      # ── compile + lint ───────────────────────────────────────────────────
+      #
+      # `--locked` is load-bearing twice over: it fails if the committed lock
+      # would have to move (so CI compiles the versions that ship), and it is
+      # only possible because both shipping apps track a Cargo.lock. The other
+      # src-tauri trees do not, which is why they are not here.
+      #
+      # `--all-targets` also compiles test and bin targets. On a check-only
+      # build nothing links, so the marginal cost is small and it is what
+      # catches a broken `#[cfg(test)]` module before someone runs the tests.
+      - name: Compile + clippy (host target)
+        run: |
+          set -euo pipefail
+
+          # Neither app has a `dist/` in a fresh checkout — the frontends are
+          # built by their own npm jobs, not here. tauri-codegen embeds
+          # whatever is at `frontendDist`; an empty dir keeps this a pure Rust
+          # gate instead of dragging two full npm builds into a compile check.
+          mkdir -p corpan/corpan-app/dist dynawalla/dynawalla-app/dist
+
+          echo "disk before: $(df -h / | sed -n '2p')"
+
+          counts="${RUNNER_TEMP}/clippy-counts.txt"
+          : > "${counts}"
+
+          for app in corpan/corpan-app/src-tauri dynawalla/dynawalla-app/src-tauri; do
+            echo "::group::${app} · cargo clippy --locked --all-targets"
+            started="${SECONDS}"
+            # stdout is the JSON diagnostic stream (rendered + de-duplicated by
+            # the reporter); stderr stays on the job log for cargo's progress
+            # and its final "could not compile" summary. `pipefail` carries
+            # cargo's exit code, so a COMPILE ERROR fails this step while lint
+            # warnings do not — the reporter always exits 0.
+            cargo clippy --locked --all-targets \
+              --manifest-path "${app}/Cargo.toml" \
+              --message-format=json \
+              | python3 .github/scripts/clippy_report.py \
+                  --label "${app}" --count-file "${counts}"
+            echo "${app}: compiled + linted in $(( SECONDS - started ))s"
+            echo "::endgroup::"
+          done
+
+          echo "disk after: $(df -h / | sed -n '2p')"
+
+          total="$(awk '{ s += $1 } END { print s + 0 }' "${counts}")"
+          {
+            echo "### native gate"
+            echo
+            echo "Unique clippy warnings across both shipping apps: **${total}**"
+            echo
+            echo "Warn-only today. To enforce, drive that count to 0 in a"
+            echo "Rust-only PR, then append \`-- -D warnings\` to the clippy"
+            echo "invocation in \`.github/workflows/ci.yml\`."
+          } >> "${GITHUB_STEP_SUMMARY}"
+          echo "TOTAL unique clippy warnings: ${total}"
+
   # Single summary status that aggregates every job above. THIS is the context to
   # mark as a required check on `main` — it always runs (if: always()) and always
   # reports, so path-skipped sub-jobs never deadlock the branch protection / queue.
@@ -668,6 +927,7 @@ jobs:
         dynawalla-app,
         dynawalla-android-gen,
         lambda,
+        native,
         web-io,
         changed-packs,
         terraform,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -759,19 +759,29 @@ jobs:
             corpan/corpan-app/src-tauri
             dynawalla/dynawalla-app/src-tauri
           cache-all-crates: "true"
-          # MEASURED, not cargo-culted. By default rust-cache strips every
-          # PATH-sourced crate from the target dir before saving. Here that is
-          # the vendored llama-cpp-sys-2 fork plus all eleven plugins — so a
-          # "full match" warm run still re-ran llama.cpp's cmake + bindgen and
-          # rebuilt every plugin: 165 s warm against 265 s stone cold. Those
-          # crates move rarely and cost the most, which is exactly the case
-          # this flag exists for. Cargo's fingerprints still force a rebuild
-          # when one of them actually changes.
-          cache-workspace-crates: "true"
-          # Extra key material. rust-cache does NOT re-save on a full key
-          # match, so a caching change alone would never take effect against an
-          # existing cache. Bump this when the cache needs to be rebuilt.
-          key: "native-v1"
+          #
+          # MEASURED CEILING — read this before trying to speed the job up.
+          #
+          # Warm (full cache match) is ~4m15s of which ~156s is Corpán's
+          # compile; stone cold is ~7m. The residual is NOT registry deps: on a
+          # full match cargo still rebuilds every PATH-sourced crate — the
+          # vendored llama-cpp-sys-2 fork (cmake + bindgen over llama.cpp,
+          # the single biggest item), all eleven plugins, and the app crate.
+          # rust-cache strips those from the target dir before saving.
+          #
+          # `cache-workspace-crates: true` was tried and measured: 156s against
+          # 165s, inside the noise, because the plugins live OUTSIDE the
+          # workspace root and are not "workspace crates" by that flag's
+          # definition. It is deliberately not set. The real lever is a
+          # compiler cache (sccache, which also fronts the C++ via
+          # CMAKE_C_COMPILER_LAUNCHER); that is a separate PR with its own
+          # correctness argument.
+          #
+          # Trap for whoever tries: rust-cache does NOT re-save on a full key
+          # match, so a caching change alone appears to do nothing against an
+          # existing cache. Bump `prefix-key` to force a rebuild while
+          # measuring, and note that a PR-event cache is scoped to that PR —
+          # only the `push: main` run populates a cache every PR can read.
 
       # ── rustfmt, as a ratchet ────────────────────────────────────────────
       #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,11 +177,12 @@ jobs:
           # terraform/` would mark helper scripts under it as covered when no job
           # runs them.
           #
-          # `corpan/plugins/` is now compiled by the REQUIRED `native` job below
-          # (every plugin is a path dependency of Corpán's src-tauri, so a host
-          # `cargo clippy` of the app compiles all of them). `.github/workflows/
-          # ios-native.yml` additionally compiles their Swift, but it is
-          # advisory and does not count here.
+          # `corpan/plugins/` is now compiled by the `native` job below, which
+          # reports into the required `ci-gate` (every plugin is a path
+          # dependency of Corpán's src-tauri, so a host `cargo clippy` of the
+          # app compiles all of them). `.github/workflows/ios-native.yml`
+          # additionally compiles their Swift, but it is advisory and does not
+          # count here.
           covered='^(corpan/corpan-app/|corpan/dja/|corpan/infra/terraform/lambda/|corpan/packs/|corpan/infra/terraform/.*(\.tf|\.tfvars|\.tf\.json)$|corpan/infra/terraform/\.terraform\.lock\.hcl$|web/(io|data|pages|scripts)/|corpan/plugins/|dynawalla/dynawalla-app/|dynawalla/(curriculum|engine)/)'
 
           # Carve-outs checked BEFORE `covered`, because a broader area prefix
@@ -189,14 +190,14 @@ jobs:
           # hence a separate pattern rather than an exclusion inside `covered`.
           #
           # The `native` job compiles exactly two src-tauri trees: Corpán's and
-          # Dynawalla's. The three listed below are NOT compiled by any job —
+          # Dynawalla's. The four listed below are NOT compiled by any job.
           # `corpus-reader` and `panko` are dormant (last touched by a repo-wide
-          # sweep in June), `panko` resolves a plugin from a git BRANCH and
-          # `homeschool-offline` has no tracked Cargo.lock, so neither can be
-          # put behind a `--locked` gate as it stands. The iap example app is a
-          # demo, not shipped. All four are still rustfmt-gated (the ratchet in
-          # the `native` job walks every tracked manifest), which is why this is
-          # a warning about COMPILE coverage specifically.
+          # sweep in June); `panko` resolves a plugin from a git BRANCH and
+          # `homeschool-offline` tracks no Cargo.lock, so neither can sit behind
+          # a `--locked` gate as it stands; the iap example is a demo, not
+          # shipped. All four ARE rustfmt-gated — the ratchet in the `native`
+          # job walks every tracked manifest — which is why this warning is
+          # about COMPILE coverage specifically.
           ungated='^(corpus-reader/src-tauri/|panko/pako/src-tauri/|homeschool-offline/app/src-tauri/|corpan/plugins/tauri-plugin-iap/examples/)'
 
           # Gate-free by design: CI config, agent control plane, docs, dotfiles.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -704,7 +704,10 @@ jobs:
     name: native · fmt + compile + clippy
     needs: changes
     if: needs.changes.outputs.native == 'true'
-    timeout-minutes: 45
+    # Measured: 7m18s stone cold, ~2m warm. 30 is headroom for a cold cache on
+    # a slow runner while still catching a hang, rather than burning 45 minutes
+    # of queue time before anyone notices.
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -755,9 +758,16 @@ jobs:
           workspaces: |
             corpan/corpan-app/src-tauri
             dynawalla/dynawalla-app/src-tauri
-          # llama.cpp's cmake output lives under target/*/build/llama-cpp-sys-2-*.
-          # Caching it is the difference between a warm run and a cold one.
           cache-all-crates: "true"
+          # MEASURED, not cargo-culted. rust-cache deletes workspace MEMBERS
+          # from the target dir before saving, and the vendored llama-cpp-sys-2
+          # fork lives at `corpan/corpan-app/src-tauri/vendor/`, i.e. inside
+          # Corpán's implicit workspace — so it counts as a member and its
+          # cmake build of llama.cpp was being thrown away and redone on every
+          # run (warm Corpán: 171 s, against 265 s stone cold). Keeping members
+          # caches that C++ build. The vendored fork moves about once a year;
+          # cargo's fingerprints still force a rebuild when it does.
+          cache-workspace-crates: "true"
 
       # ── rustfmt, as a ratchet ────────────────────────────────────────────
       #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -704,9 +704,10 @@ jobs:
     name: native · fmt + compile + clippy
     needs: changes
     if: needs.changes.outputs.native == 'true'
-    # Measured: 7m18s stone cold, ~2m warm. 30 is headroom for a cold cache on
-    # a slow runner while still catching a hang, rather than burning 45 minutes
-    # of queue time before anyone notices.
+    # Measured on ubuntu-latest: 7m18s stone cold, 4m09s on a full cache match.
+    # 30 is headroom over the cold number on a slow runner while still catching
+    # a hang, rather than burning 45 minutes of queue time before anyone
+    # notices. See the cache step for where the warm time actually goes.
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -759,15 +759,19 @@ jobs:
             corpan/corpan-app/src-tauri
             dynawalla/dynawalla-app/src-tauri
           cache-all-crates: "true"
-          # MEASURED, not cargo-culted. rust-cache deletes workspace MEMBERS
-          # from the target dir before saving, and the vendored llama-cpp-sys-2
-          # fork lives at `corpan/corpan-app/src-tauri/vendor/`, i.e. inside
-          # Corpán's implicit workspace — so it counts as a member and its
-          # cmake build of llama.cpp was being thrown away and redone on every
-          # run (warm Corpán: 171 s, against 265 s stone cold). Keeping members
-          # caches that C++ build. The vendored fork moves about once a year;
-          # cargo's fingerprints still force a rebuild when it does.
+          # MEASURED, not cargo-culted. By default rust-cache strips every
+          # PATH-sourced crate from the target dir before saving. Here that is
+          # the vendored llama-cpp-sys-2 fork plus all eleven plugins — so a
+          # "full match" warm run still re-ran llama.cpp's cmake + bindgen and
+          # rebuilt every plugin: 165 s warm against 265 s stone cold. Those
+          # crates move rarely and cost the most, which is exactly the case
+          # this flag exists for. Cargo's fingerprints still force a rebuild
+          # when one of them actually changes.
           cache-workspace-crates: "true"
+          # Extra key material. rust-cache does NOT re-save on a full key
+          # match, so a caching change alone would never take effect against an
+          # existing cache. Bump this when the cache needs to be rebuilt.
+          key: "native-v1"
 
       # ── rustfmt, as a ratchet ────────────────────────────────────────────
       #


### PR DESCRIPTION
## What

Add a `native` job to `ci.yml` that runs rustfmt, `cargo clippy --locked --all-targets`
and a Cargo `[patch]` integrity assertion over the Rust tree, and wire it into
`ci-gate`'s `needs`.

## Why

Nothing required in this repo ran `cargo`, `rustfmt`, `clippy` or `rustup`. Every
Rust change in both shipping apps merged uncompiled, and the first signal was a
release build at store-submission time. `ios-native.yml` compiles plugin Swift but
is advisory, has no `merge_group` trigger, and carries a top-level `paths:` filter —
which is exactly why it can never be promoted to a required context: it would not
report on unrelated PRs and would deadlock the merge queue permanently.

The hook was already built and unconsumed: `changes` has been declaring
`set_output native '^(native/|.*/src-tauri/|corpan/plugins/)'` with no job reading it.

## Blast radius

**Areas touched:** CI

**Why this cannot deadlock the merge queue.** The `native` job is path-gated, so it
is *not* a required status context — it reports into `ci-gate`, which is already
required and always reports (`if: always()`). Adding a `needs` entry to an
always-reporting aggregate adds coverage without adding a context branch protection
is waiting on. `ci-gate` already treats `skipped` as a pass, so a docs-only PR that
skips `native` still gets a green gate. Zero queue risk by construction.

- [x] Every touched path is covered by a `ci.yml` area filter. This PR *tightens*
      the `uncovered` warning: `src-tauri/` is no longer blanket-ungated, and the
      four trees this job does not compile are named explicitly in `ungated`
      (`corpus-reader/src-tauri/`, `panko/pako/src-tauri/`,
      `homeschool-offline/app/src-tauri/`, `corpan/plugins/tauri-plugin-iap/examples/`).
- [x] **Pack back-compat.** N/A — no pack touched.
- [x] **Native integrity.** No Rust source changed. This PR is what starts
      enforcing that checkbox: it asserts no `[[patch.unused]]` in any tracked
      lock, that `cargo metadata --locked` emits no "was not used in the crate
      graph" on **stderr** for every manifest declaring a `[patch]` of any shape
      (path, git or version), and that each *path* patch resolves to its vendored
      directory. That is the exact failure mode that once reverted the vendored
      `ndk-context` fork.
- [x] **Strings.** N/A — no user-visible string.
- [x] **Curriculum.** N/A.
- [x] **Secrets.** None.

## What it does, and what it deliberately does not

**Compiles** `cargo clippy --locked --all-targets` on both shipping `src-tauri`
trees. Clippy rather than `cargo check` because clippy *is* a check plus lints:
one compile, both signals. A compile error fails the job (cargo's exit code, carried
by `pipefail`). Lint warnings are de-duplicated, counted, rendered, and held to a
**bidirectional budget** — `CLIPPY_BUDGET=16`, the measured debt — so the first PR
to touch Rust is not blocked by pre-existing debt, but the count cannot drift up
unnoticed, and driving it down without lowering the budget fails with the number to
write.

Corpán's `src-tauri` declares ten plugin path deps; the eleventh crate,
`corpan-asr-contract`, is reached transitively via `tauri-plugin-asr-native`. So
compiling the app compiles all eleven — including `tauri-plugin-stt`, which
`ios-native.yml` skips. Verified against the resolved graph:

```
$ cargo metadata --locked --manifest-path corpan/corpan-app/src-tauri/Cargo.toml
  # packages under corpan/plugins/ →
  corpan-asr-contract, tauri-plugin-asr-native, tauri-plugin-audio-keepalive,
  tauri-plugin-corpan-llm, tauri-plugin-game-packs, tauri-plugin-haptics,
  tauri-plugin-iap, tauri-plugin-radio-stream, tauri-plugin-stt,
  tauri-plugin-subscriptions, tauri-plugin-tts        # count = 11
```

**rustfmt as a bidirectional ratchet.** Fourteen of the eighteen tracked crates
carry formatting debt, so a blanket `--check` would fail on day one and get deleted.
Every crate *not* on the `DEBT` list is enforced, including every crate added from
here on. Formatting a debt crate without deleting its line also fails, with the
exact line to delete — that is what keeps the ratchet from rusting open. The
toolchain is deliberately unpinned; the split was measured as identical under
rustfmt 1.8.0 (rustc 1.93.1, local) and rustfmt 1.9.0-stable (rustc 1.97.1, what
the runner shipped), with identical per-crate diff counts.

**Not covered, on purpose** (named in the workflow comments rather than papered over):

- `#[cfg(mobile)]` code. A Linux host build takes the `desktop` cfg, so each
  plugin's `mobile.rs` and Corpán's Android JNI / crash-breadcrumb blocks are not
  compiled. iOS Rust+Swift is advisory-only via `ios-native.yml`; the **Android
  Rust glue is covered by nothing**. Closing that needs an NDK on the runner.
- Clippy *lints* only the two app crates. Path deps outside the workspace directory
  do not get the clippy wrapper, so the plugins are compile-checked, not linted.
- `corpus-reader`, `panko/pako` and `homeschool-offline` are **not compiled**.
  `corpus-reader` and `panko` are dormant; `panko` additionally resolves a plugin
  from a git *branch*; `homeschool-offline` is the only one of the three with no
  tracked `Cargo.lock`, so it alone could not sit behind `--locked` today.
  (`git ls-files '*Cargo.lock'` returns four: corpan, corpus-reader, dynawalla,
  panko.) The rustfmt ratchet **walks** all of them, but `corpus-reader` and both
  `homeschool-offline` crates are on the `DEBT` list, so they are reported as
  `::warning::` and cannot fail the job — walked, not gated. `panko/pako/src-tauri`
  and the iap example are off the list and are enforced. The `uncovered` step names
  all four so the warning keeps pointing at the real remaining hole.

## Two second-order costs, stated up front

- `native` self-triggers on `.github/workflows/ci.yml`, like every other filter that
  drives a job, so every future CI-config PR pays a ~4–7 min Rust build in both the
  PR and the `merge_group` run. That is deliberate: a workflow edit that breaks the
  native gate has to be caught by the native gate.
- The first `merge_group` entry after this merges runs cold (~7 min) because no
  `main`-scoped rust-cache exists yet — inside both the job's 30 min timeout and the
  queue's 60 min `check_response_timeout_minutes`.

## Proof

See the checks on this PR, and the comments below for measured timings, the
aggregation invariant, the both-directions filter proof, and the review round that
closed the `[patch]` fail-open and added the clippy budget.
