### PR TITLE
ci: make each area filter watch what its job actually compiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,23 +90,42 @@ jobs:
           # so its tests must run on any change to it (or to this workflow, or
           # to the workflow that invokes it).
           set_output ci_scripts '^(\.github/scripts/|\.github/workflows/(ci|adversarial-review)\.yml$)'
-          set_output corpan_app '^(corpan/corpan-app/|\.github/workflows/ci\.yml$)'
+          # `corpan/packs/shared/` and `corpan/packs/sdk/` are in here because the
+          # corpan-app job COMPILES them: `tsconfig.json` maps `@shared/*` onto
+          # `../packs/shared/*` and `include`s `../packs/shared/analytics`, vite
+          # aliases the same tree, twenty source files import it, the job runs
+          # `npm ci` in `packs/shared/capabilities`, and its contract-sync step
+          # diffs the generated copies under `packs/sdk/` and
+          # `packs/shared/capabilities/`.
+          #
+          # The `packs` filter does NOT stand in for this. `changed-packs` derives
+          # a pack name from the path and skips any directory with no
+          # `package.json`: `corpan/packs/shared` has none, so it is skipped
+          # outright, and `corpan/packs/sdk`'s declares no test/tsc/build script.
+          # Before this line a shared-only change ran nothing that compiled it.
+          set_output corpan_app '^(corpan/(corpan-app|packs/(shared|sdk))/|\.github/workflows/ci\.yml$)'
           set_output dja '^(corpan/dja/|\.github/workflows/ci\.yml$)'
           set_output lambda '^(corpan/infra/terraform/lambda/|\.github/workflows/ci\.yml$)'
-          set_output packs '^(corpan/packs/|\.github/workflows/(ci|deploy-pages)\.yml$)'
+          # `pack_catalog_check.js` is the entire body of the `pack-catalog` job.
+          # It lives under `.github/scripts/`, but `ci-scripts` runs pytest there
+          # and collects no JavaScript — so without this alternation the checker
+          # could be edited and never executed, and a break in it would surface on
+          # some later, unrelated packs/web PR. Same treatment the `native` filter
+          # below gives its two Python helpers.
+          set_output packs '^(corpan/packs/|\.github/workflows/(ci|deploy-pages)\.yml$|\.github/scripts/pack_catalog_check\.js$)'
           set_output terraform '^(corpan/infra/terraform/.*(\.tf|\.tfvars|\.tf\.json)$|corpan/infra/terraform/\.terraform\.lock\.hcl$|\.github/workflows/ci\.yml$)'
           set_output web '^(web/(io|data|pages|scripts)/|\.github/workflows/(ci|deploy-pages)\.yml$)'
 
-          # Dynawalla areas. No job consumes these yet — the filters land first
-          # so the jobs that follow are a one-line addition instead of a
-          # re-plumbing of this step.
-          # `dynawalla/curriculum/` is in here because the app compiles it: the
-          # practice loop imports the package's TypeScript source directly (it
-          # is private, has no build step and no resolvable name — see
-          # `src/work/curriculum.ts`). A curriculum change can therefore turn the
-          # app's tsc, tests or build red, and without this the app job would not
-          # run on the PR that did it.
-          set_output dynawalla_app '^(dynawalla/(dynawalla-app|curriculum)/|\.github/workflows/ci\.yml$)'
+          # Dynawalla areas. Every one of them is consumed by a job below.
+          #
+          # `dynawalla/curriculum/` AND `dynawalla/engine/` are in the app filter
+          # because the app compiles both: the practice loop imports each
+          # package's TypeScript source directly (they are private, have no build
+          # step and no resolvable name — see `src/work/curriculum.ts` and the
+          # `../../../engine/src/index.ts` imports across `src/work/`). A change to
+          # either can turn the app's tsc, tests or build red, and without this the
+          # app job would not run on the PR that did it.
+          set_output dynawalla_app '^(dynawalla/(dynawalla-app|curriculum|engine)/|\.github/workflows/ci\.yml$)'
           # The committed slice of gen/android and the recorded template it was
           # curated from. `tauri android init` never overwrites an existing
           # file, which is what makes the allowlist survive a CI re-init — and
@@ -115,7 +134,20 @@ jobs:
           # compiling Android for either app. So: any move of the CLI pin, of
           # the tracked files, or of the baseline re-runs the drift job.
           set_output dynawalla_android_gen '^(dynawalla/dynawalla-app/(package(-lock)?\.json$|android-template-baseline/|src-tauri/gen/android/)|\.github/workflows/ci\.yml$)'
-          set_output dynawalla_curriculum '^(dynawalla/curriculum/|\.github/workflows/ci\.yml$)'
+          # `dynawalla/engine/` is in the curriculum filter because the curriculum
+          # gates SCAN engine source: `validate/cli.ts` passes
+          # `[curriculum/src, engine/src]` as the lint roots, so `npm run check`
+          # (M-05, CG-19, CG-16) and `validate/gates.test.ts` under `npm test` both
+          # read it. The engine's own `boundary.test.ts` deliberately duplicates
+          # EG-1 and M-05, but there is no CG-19 equivalent in it — so a
+          # bare-string prompt added under `engine/src` failed the curriculum job
+          # while the engine job stayed green, on a PR that ran neither.
+          set_output dynawalla_curriculum '^(dynawalla/(curriculum|engine)/|\.github/workflows/ci\.yml$)'
+          # Not the mirror image: the engine imports nothing at all (EG-1 asserts
+          # exactly that), so a curriculum change cannot break the engine job.
+          # `boundary.test.ts` duplicates the float scan for this reason — "the two
+          # packages have independent CI filters, and an engine-only pull request
+          # must be able to fail this on its own."
           set_output dynawalla_engine '^(dynawalla/engine/|\.github/workflows/ci\.yml$)'
           # Cross-product area. Deliberately no `ci.yml` self-trigger: it exists
           # to answer "did shared code move", and a workflow edit is not a


### PR DESCRIPTION
`.github/workflows/ci.yml`'s area filters had four holes of one shape: **a job compiles, imports or executes something outside the directory its filter watches.** A change to that something merges with the job skipped, and breaks a later, unrelated PR.

The one that prompted this: #540 wired `dynawalla-app` to `dynawalla/engine/`, but `dynawalla_app` did not watch it. An engine-only change ran the engine's unit tests and never the app's typecheck or build against the engine it now imports. A reviewer flagged it on #540; the implementer correctly declined it as outside that PR's file scope. This is the follow-up, and it audits the same class everywhere else rather than fixing the one line.

## Filter changes

| filter | added | why |
| --- | --- | --- |
| `dynawalla_app` | `dynawalla/engine/` | `src/work/{plan,session,progress,respond,store,catalog,ladder}.ts` import `../../../engine/src/index.ts` directly — private package, no build step, no resolvable name |
| `dynawalla_curriculum` | `dynawalla/engine/` | `curriculum/src/validate/cli.ts:136` passes `roots: [CURRICULUM_SRC, ENGINE_SRC]`, so `npm run check` (M-05, CG-19, CG-16) **and** `validate/gates.test.ts` under `npm test` scan engine source |
| `corpan_app` | `corpan/packs/shared/`, `corpan/packs/sdk/` | corpan-app's `tsconfig.json` maps `@shared/*` → `../packs/shared/*` and `include`s `../packs/shared/analytics`; vite aliases the same tree; 20 source files import it; the job runs `npm ci` in `packs/shared/capabilities` and diffs the generated contract copies under `packs/sdk/` and `packs/shared/capabilities/` |
| `packs` | `.github/scripts/pack_catalog_check.js` | that script is the entire body of the `pack-catalog` job; it sets only `ci_scripts`, whose job runs `pytest` and collects no JavaScript |

The `corpan/packs/shared/` case is worth spelling out, because `packs` *looks* like it covers it. It does not: `changed-packs` derives a pack name from the path and `continue`s on any directory with no `package.json`. `corpan/packs/shared` has none, so it is skipped outright; `corpan/packs/sdk`'s exists but declares no `test`/`tsc`/`build` script. A shared-only change therefore compiled **nowhere**, while twenty corpan-app files import it.

Deliberately **not** changed: `dynawalla_engine` does not gain the curriculum or the app. The engine imports nothing at all (EG-1 asserts exactly that) and `boundary.test.ts` duplicates the float scan for the stated reason — "the two packages have independent CI filters, and an engine-only pull request must be able to fail this on its own."

Also drops the stale `# Dynawalla areas. No job consumes these yet` note; all four have been consumed since #534/#540.

## Proof

The `Detect changed areas` step was extracted **verbatim** from `ci.yml` with PyYAML and run against real single-file commits in a throwaway repo. Only the filters listed above move; every other case is bit-identical.

```
                                            BEFORE                          AFTER
engine-only          dynawalla/engine/src/select.ts
                     dynawalla_engine                dynawalla_app dynawalla_curriculum dynawalla_engine
app-only             dynawalla/dynawalla-app/src/work/plan.ts
                     dynawalla_app                   dynawalla_app                          (unchanged)
curriculum-only      dynawalla/curriculum/src/graph/nodes.ts
                     dynawalla_app                   dynawalla_app
                     dynawalla_curriculum            dynawalla_curriculum                   (unchanged)
docs-only            dynawalla/docs/ARCHITECTURE.md
                     (none)                          (none)                                (unchanged)
packs-shared-only    corpan/packs/shared/streak/src/index.ts
                     packs shared_ts                 corpan_app packs shared_ts
packs-sdk-only       corpan/packs/sdk/activityContract.ts
                     packs                           corpan_app packs
corpan-app-only      corpan/corpan-app/src/App.tsx
                     corpan_app                      corpan_app                             (unchanged)
catalog-script-only  .github/scripts/pack_catalog_check.js
                     ci_scripts                      ci_scripts packs
one-real-pack        corpan/packs/beatlounge/src/main.ts
                     packs                           packs                                 (unchanged)
ci.yml-only          .github/workflows/ci.yml
                     all 12 consumed filters         all 12 consumed filters                (unchanged)
```

`docs-only` sets nothing before and after; `.md` stays exempt.

## Invariants

Aggregation, checked with PyYAML — top-level jobs minus `{ci-gate, changes}` must be a subset of `ci-gate.needs`:

```
jobs (15): changed-packs changes ci-gate ci-scripts corpan-app dja dynawalla-android-gen
           dynawalla-app dynawalla-curriculum dynawalla-engine lambda native pack-catalog
           terraform web-io
ci-gate.needs (14): changed-packs changes ci-scripts corpan-app dja dynawalla-android-gen
           dynawalla-app dynawalla-curriculum dynawalla-engine lambda native pack-catalog
           terraform web-io
not aggregated: []
needs entries with no such job: []
subset invariant holds: True
```

Structural diff against `origin/main`, same parser:

```
job set identical: True
jobs whose `if:` changed: []
jobs whose `needs:` changed: []
changes.outputs identical: True
ci-gate.if: ${{ always() }}
changes steps changed: ['filter']       # only the filter step's `run` body
```

**Why widening is safe, confirmed rather than assumed:** every consumer of a `changes` output is a positive `== 'true'` test — `grep -n "== 'false'\|!= 'true'\|!needs\."` over `ci.yml` returns nothing. So widening a pattern can only flip an output `false → true`, and a job `skipped → run`. `ci-gate` counts a skip as a pass and only fails on `failure`/`cancelled`, so more jobs running is strictly more coverage and can never turn a green gate red by itself. No new required status context; no top-level `paths:` filter.

## Audited, found real, NOT fixed here

- **`changed-packs` vs `corpan/packs/shared/`.** Eleven packs (beatlounge, corpan-city, teletron, tutomaton, world-radio, …) import `../shared/`. A shared-only change rebuilds none of them, because `changed-packs` only builds the pack directories that appear in the diff. Closing it means the job fanning out to *every* pack whenever `shared/` moves — a script change with a real runner-cost decision behind it, not a filter change. This PR closes the corpan-app half of the same dependency; the packs half is still open.
- **Android/mobile Rust.** Noted already in #539's own comments; `#[cfg(mobile)]` code is compiled by nothing.
- **`changed-packs`' pack-name `awk`.** `/^corpan\/packs\/[^/]+\//` has an unescaped `/` inside a bracket expression. gawk/mawk accept it (so it works on `ubuntu-latest`); BSD awk rejects it outright. Harmless where it runs, cosmetic, left alone.

Checked and correct as-is: `dja`, `lambda`, `terraform`, `ci-scripts`, `dynawalla-android-gen` are self-contained. `web-io`'s `prebuild` runs `../scripts/generate-book-catalog.js`, and the `web` filter already covers `web/scripts/`.