### PR TITLE
Pack runtime: the host↔pack contract, and the boundary that enforces it

### DIFF
--- a/dynawalla/dynawalla-app/src-tauri/Cargo.lock
+++ b/dynawalla/dynawalla-app/src-tauri/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +319,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +412,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -515,6 +550,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -685,8 +731,13 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 name = "dynawalla"
 version = "0.1.0"
 dependencies = [
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
+ "zip",
 ]
 
 [[package]]
@@ -1002,8 +1053,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1025,8 +1078,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1274,6 +1330,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1675,6 +1747,12 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markup5ever"
@@ -2275,6 +2353,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,6 +2428,32 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -2372,6 +2532,44 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -2405,6 +2603,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,10 +2632,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2616,6 +2869,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2685,7 +2950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2812,6 +3077,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -2976,7 +3247,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3278,6 +3549,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3568,6 +3849,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3755,6 +4042,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3808,6 +4105,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4038,6 +4344,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4353,6 +4668,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4386,7 +4707,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "thiserror 2.0.19",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/dynawalla/dynawalla-app/src-tauri/Cargo.toml
+++ b/dynawalla/dynawalla-app/src-tauri/Cargo.toml
@@ -16,6 +16,23 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = ["wry"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# The pack runtime's three jobs: fetch the archive, prove it is the archive the
+# catalogue promised, unpack it. All three are native rather than in the
+# WebView, which is what lets `tauri.conf.json` keep `connect-src` closed: the
+# app's own document never talks to the network at all.
+#
+# `rustls-tls` rather than the platform TLS stack so the trust anchors are the
+# same on every target and an Android build does not depend on an OS cert store.
+# `https_only` is set on the client as well; the origin is pinned in `packs`.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+sha2 = "0.10"
+# Read AND write: the write half is used only by `packs::tests`, which builds a
+# zip-slip archive and a compression bomb rather than committing binary fixtures
+# to a public repository.
+zip = { version = "2", default-features = false, features = ["deflate"] }
 
 [profile.release]
 opt-level = "z"   # Size, not speed: this is a mobile binary.

--- a/dynawalla/dynawalla-app/src-tauri/src/lib.rs
+++ b/dynawalla/dynawalla-app/src-tauri/src/lib.rs
@@ -1,13 +1,39 @@
 //! Dynawalla's native shell.
 //!
-//! Deliberately empty of plugins. The V1 native surface is haptics and TTS
-//! (ARCHITECTURE L8, ADR-0004) and neither is needed to render a screen, so
-//! nothing is registered here yet — every plugin added later also has to be
-//! granted a per-command permission in `capabilities/default.json`.
+//! It holds the pack runtime and nothing else. Packs are the product; the shell
+//! is what installs one, serves one, and keeps it inside its own directory.
+//!
+//! The `dynawalla-pack` URI scheme is registered here. It is a public API from
+//! the first release — the scheme name is baked into every published pack's
+//! built JavaScript on every device the pack is installed on — so it is never
+//! renamed. See `packs::PACK_SCHEME`.
+//!
+//! Every command registered below is invoked from exactly one module,
+//! `src/packs/native.ts`, and `src/packs/native.test.ts` asserts that the two
+//! lists are the same set in both directions. That test exists because of a
+//! real failure in this repository's other app: its install manager invokes a
+//! delete command the backend never registered, so uninstalled packs stay on
+//! disk permanently and nothing anywhere reports a problem.
+//!
+//! These are application commands, not plugin commands, so Tauri's ACL does not
+//! gate them and `capabilities/default.json` has nothing to say about them.
+//! That is precisely why the registration test is not optional.
+
+mod packs;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .register_uri_scheme_protocol(packs::PACK_SCHEME, |ctx, request| {
+            packs::serve(ctx.app_handle(), &request)
+        })
+        .invoke_handler(tauri::generate_handler![
+            packs::packs_list,
+            packs::packs_catalog,
+            packs::packs_install,
+            packs::packs_remove,
+            packs::packs_entry_url,
+        ])
         .run(tauri::generate_context!())
         .expect("error while running dynawalla");
 }

--- a/dynawalla/dynawalla-app/src-tauri/src/packs/mod.rs
+++ b/dynawalla/dynawalla-app/src-tauri/src/packs/mod.rs
@@ -1,0 +1,686 @@
+//! The pack runtime: where a pack lives, how it gets there, and how it is
+//! served.
+//!
+//! Everything a pack can reach on this device passes through this module, so it
+//! is written as though every input is hostile — because two of them are. The
+//! archive comes off the network, and the paths inside it were chosen by
+//! whoever built it.
+//!
+//! Four properties, each enforced here rather than upstream:
+//!
+//! 1. **A pack cannot escape its directory.** Every served path is resolved
+//!    against a canonicalised root and rejected unless it is still inside it
+//!    afterwards, which is a check that `..`-in-the-string is not: a symlink
+//!    committed into an archive passes the string test and fails this one.
+//! 2. **A pack cannot reach the network.** The document is served with a CSP
+//!    that admits only this scheme. The WebView enforces it; nothing has to
+//!    remember to.
+//! 3. **A pack cannot be swapped for something else.** The archive is verified
+//!    against the SHA-256 in the manifest the catalogue was signed off on,
+//!    before a single byte is extracted.
+//! 4. **A pack that is removed is gone.** `packs_remove` is registered — the
+//!    frontend invoking a command the backend never registered is how Corpán's
+//!    uninstalled packs came to live on disk forever.
+//!
+//! The scheme name `dynawalla-pack` is baked into the built JavaScript of every
+//! pack ever published. It is a public API from the first release and it can
+//! never be renamed.
+
+use std::fs;
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tauri::http::{Request as HttpRequest, Response, StatusCode, header};
+use tauri::ipc::Channel;
+use tauri::{AppHandle, Manager, Runtime};
+
+/// Public API from the first release. Renaming it breaks every installed pack
+/// at runtime while compiling perfectly. See the module docs.
+pub const PACK_SCHEME: &str = "dynawalla-pack";
+
+/// The one origin a pack may be downloaded from, pinned in native code so that
+/// nothing in the WebView — including a pack — can point the installer
+/// somewhere else. Changing this is a release decision, not a configuration.
+const PACK_ORIGIN: &str = "https://encorpora.io/dynawalla/packs/";
+
+/// Mirrors `MAX_DOWNLOAD_BYTES` in the SDK's manifest schema. Restated rather
+/// than shared because this side must hold even if a manifest lies.
+const MAX_DOWNLOAD_BYTES: u64 = 256 * 1024 * 1024;
+/// Mirrors `MAX_INSTALLED_BYTES`. The decompression bomb ceiling.
+const MAX_INSTALLED_BYTES: u64 = 512 * 1024 * 1024;
+/// Mirrors `MAX_FILES`.
+const MAX_FILES: usize = 20_000;
+
+/// Progress is reported at most this often, so a fast download does not post
+/// one message per TCP segment into the WebView.
+const PROGRESS_STEP_BYTES: u64 = 256 * 1024;
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct InstalledPack {
+    pub id: String,
+    pub version: String,
+    /// The manifest verbatim, parsed and validated by the SDK on the JS side.
+    /// Rust reads two fields out of it and takes no view on the rest, so the
+    /// schema can grow without a native release.
+    pub manifest: String,
+    pub bytes: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstallRequest {
+    pub pack_id: String,
+    pub version: String,
+    pub url: String,
+    pub sha256: String,
+    pub bytes: u64,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(tag = "phase", rename_all = "camelCase")]
+pub enum Progress {
+    #[serde(rename_all = "camelCase")]
+    Downloading {
+        received: u64,
+        total: u64,
+    },
+    Verifying,
+    Extracting,
+    Installing,
+}
+
+/// What the manifest inside the archive must agree with the catalogue about.
+#[derive(Debug, Deserialize)]
+struct ManifestIdentity {
+    id: String,
+    version: String,
+}
+
+// ─── Layout ──────────────────────────────────────────────────────────────────
+
+fn pack_root<R: Runtime>(app: &AppHandle<R>) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("no app data directory: {e}"))?
+        .join("packs");
+    fs::create_dir_all(&dir).map_err(|e| format!("cannot create pack root: {e}"))?;
+    Ok(dir)
+}
+
+/// A pack id is a directory name on three operating systems. It is validated
+/// against the same shape the manifest schema states, here as well as there,
+/// because this is the side that turns it into a path.
+fn valid_pack_id(id: &str) -> bool {
+    if id.is_empty() || id.len() > 64 {
+        return false;
+    }
+    let mut previous_separator = true;
+    for byte in id.bytes() {
+        match byte {
+            b'a'..=b'z' | b'0'..=b'9' => previous_separator = false,
+            b'.' | b'-' => {
+                if previous_separator {
+                    return false;
+                }
+                previous_separator = true;
+            }
+            _ => return false,
+        }
+    }
+    // Must start with a letter and must not end with a separator.
+    !previous_separator
+        && id
+            .as_bytes()
+            .first()
+            .is_some_and(|b| b.is_ascii_lowercase())
+}
+
+/// Resolve `rel` inside `pack_dir`, or refuse.
+///
+/// The refusal is by canonicalised prefix, not by looking for `..` in the
+/// string. Both are needed: the lexical pass rejects a traversal before the
+/// filesystem is touched, and the canonical pass is what actually catches a
+/// symlink, which no amount of string inspection can see.
+fn resolve_asset(pack_dir: &Path, rel: &str) -> Option<PathBuf> {
+    if rel.is_empty() || rel.contains('\0') || rel.contains('\\') {
+        return None;
+    }
+    let mut candidate = pack_dir.to_path_buf();
+    for segment in rel.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            return None;
+        }
+        candidate.push(segment);
+    }
+    let real_root = pack_dir.canonicalize().ok()?;
+    let real = candidate.canonicalize().ok()?;
+    if !real.starts_with(&real_root) {
+        return None;
+    }
+    if !real.is_file() {
+        return None;
+    }
+    Some(real)
+}
+
+/// The same rule applied to a path coming out of a ZIP entry, before it exists.
+///
+/// `zip` yields an attacker-chosen string. `../../../.ssh/authorized_keys` and
+/// `/etc/passwd` and `C:\Windows\x` all have to die here, and so does anything
+/// with a prefix or root component on any platform.
+fn safe_entry_path(name: &str) -> Option<PathBuf> {
+    if name.is_empty() || name.contains('\0') {
+        return None;
+    }
+    let normalised = name.replace('\\', "/");
+    if normalised.starts_with('/') {
+        return None;
+    }
+    // `Path::components` is platform-dependent: on Unix `C:/Windows/evil.js`
+    // has no `Prefix` component at all and would extract into a directory
+    // literally named `C:`, which is harmless here and is an absolute path the
+    // moment the same archive is opened on Windows. A colon is not a legal
+    // filename character on Windows anyway, so refusing it everywhere makes the
+    // rule identical on every target instead of merely usually identical.
+    if normalised.contains(':') {
+        return None;
+    }
+    let mut out = PathBuf::new();
+    for component in Path::new(&normalised).components() {
+        match component {
+            Component::Normal(part) => out.push(part),
+            // CurDir is harmless but pointless; everything else is an escape.
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    if out.as_os_str().is_empty() {
+        None
+    } else {
+        Some(out)
+    }
+}
+
+fn directory_bytes(dir: &Path) -> u64 {
+    let mut total = 0;
+    let Ok(entries) = fs::read_dir(dir) else {
+        return 0;
+    };
+    for entry in entries.flatten() {
+        let Ok(kind) = entry.file_type() else {
+            continue;
+        };
+        if kind.is_dir() {
+            total += directory_bytes(&entry.path());
+        } else if kind.is_file() {
+            total += entry.metadata().map(|m| m.len()).unwrap_or(0);
+        }
+    }
+    total
+}
+
+fn read_installed(pack_dir: &Path) -> Option<InstalledPack> {
+    let manifest = fs::read_to_string(pack_dir.join("manifest.json")).ok()?;
+    let identity: ManifestIdentity = serde_json::from_str(&manifest).ok()?;
+    Some(InstalledPack {
+        id: identity.id,
+        version: identity.version,
+        manifest,
+        bytes: directory_bytes(pack_dir),
+    })
+}
+
+// ─── Serving ─────────────────────────────────────────────────────────────────
+
+/// Sources the pack document may load from: this scheme, in the two forms Tauri
+/// serves it under (`http://<scheme>.localhost` on Android and Windows, the
+/// scheme itself everywhere else). Both are listed unconditionally so the
+/// policy string does not depend on the build target.
+const SCHEME_SOURCES: &str = "dynawalla-pack: http://dynawalla-pack.localhost";
+
+/// The policy a pack runs under.
+///
+/// `default-src 'none'` and then only what a game genuinely needs. There is no
+/// remote origin in it at any position, which is what makes "a pack cannot
+/// reach the network" a property of the WebView rather than a promise.
+///
+/// `'self'` is deliberately absent: the frame is sandboxed *without*
+/// `allow-same-origin`, so its origin is opaque and `'self'` would match
+/// nothing at all — a policy that looks strict and denies everything, including
+/// the pack's own scripts. Naming the scheme is the form that works.
+fn pack_csp() -> String {
+    format!(
+        "default-src 'none'; \
+         script-src {sources} 'wasm-unsafe-eval'; \
+         style-src {sources} 'unsafe-inline'; \
+         img-src {sources} data: blob:; \
+         media-src {sources} blob:; \
+         font-src {sources}; \
+         connect-src {sources}; \
+         worker-src {sources} blob:; \
+         frame-src 'none'; \
+         child-src 'none'; \
+         object-src 'none'; \
+         base-uri 'none'; \
+         form-action 'none'",
+        sources = SCHEME_SOURCES
+    )
+}
+
+fn content_type_for(path: &Path) -> &'static str {
+    match path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "html" => "text/html; charset=utf-8",
+        "js" | "mjs" => "text/javascript; charset=utf-8",
+        "css" => "text/css; charset=utf-8",
+        "json" => "application/json; charset=utf-8",
+        "svg" => "image/svg+xml",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "webp" => "image/webp",
+        "avif" => "image/avif",
+        "ktx2" => "image/ktx2",
+        "woff2" => "font/woff2",
+        "mp3" => "audio/mpeg",
+        "ogg" => "audio/ogg",
+        "opus" => "audio/opus",
+        "wav" => "audio/wav",
+        "mp4" => "video/mp4",
+        "webm" => "video/webm",
+        "wasm" => "application/wasm",
+        "glb" => "model/gltf-binary",
+        "gltf" => "model/gltf+json",
+        "bin" => "application/octet-stream",
+        _ => "application/octet-stream",
+    }
+}
+
+fn refuse(status: StatusCode, message: &'static str) -> Response<Vec<u8>> {
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
+        .header(header::CONTENT_SECURITY_POLICY, "default-src 'none'")
+        .body(message.as_bytes().to_vec())
+        .expect("static response")
+}
+
+pub fn serve<R: Runtime>(app: &AppHandle<R>, request: &HttpRequest<Vec<u8>>) -> Response<Vec<u8>> {
+    // Only reads. A pack has no write verb, and refusing here means one does
+    // not appear by accident later.
+    if request.method() != tauri::http::Method::GET && request.method() != tauri::http::Method::HEAD
+    {
+        return refuse(StatusCode::METHOD_NOT_ALLOWED, "read only");
+    }
+
+    let Ok(root) = pack_root(app) else {
+        return refuse(StatusCode::INTERNAL_SERVER_ERROR, "no pack root");
+    };
+
+    let path = request.uri().path().trim_start_matches('/');
+    let mut parts = path.splitn(2, '/');
+    let pack_id = parts.next().unwrap_or("");
+    let rel = parts.next().unwrap_or("");
+    if !valid_pack_id(pack_id) {
+        return refuse(StatusCode::BAD_REQUEST, "bad pack id");
+    }
+
+    let Some(file) = resolve_asset(&root.join(pack_id), rel) else {
+        return refuse(StatusCode::NOT_FOUND, "not found");
+    };
+    let Ok(bytes) = fs::read(&file) else {
+        return refuse(StatusCode::NOT_FOUND, "not found");
+    };
+
+    let mut builder = Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, content_type_for(&file))
+        .header("X-Content-Type-Options", "nosniff")
+        // The frame is opaque-origin, so every subresource it loads is a
+        // cross-origin request against this scheme. Without this the pack
+        // cannot fetch its own level data.
+        .header(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        .header("Cross-Origin-Resource-Policy", "cross-origin")
+        // A pack directory is replaced in place on upgrade, so a cached asset
+        // from the previous version would be indistinguishable from the new
+        // one. Packs are local; there is nothing to save.
+        .header(header::CACHE_CONTROL, "no-store");
+
+    if file.extension().and_then(|e| e.to_str()) == Some("html") {
+        builder = builder.header(header::CONTENT_SECURITY_POLICY, pack_csp());
+    }
+
+    builder
+        .body(bytes)
+        .unwrap_or_else(|_| refuse(StatusCode::INTERNAL_SERVER_ERROR, "response"))
+}
+
+// ─── Commands ────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn packs_list<R: Runtime>(app: AppHandle<R>) -> Result<Vec<InstalledPack>, String> {
+    let root = pack_root(&app)?;
+    let mut packs = vec![];
+    for entry in fs::read_dir(&root).map_err(|e| e.to_string())?.flatten() {
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !valid_pack_id(&name) {
+            // `.staging` and `.trash` live here too, and anything else is not
+            // a pack whatever it claims inside.
+            continue;
+        }
+        // The directory name and the manifest's id must agree, or two ids could
+        // serve the same files at two different pack URLs.
+        if let Some(pack) = read_installed(&entry.path())
+            && pack.id == name
+        {
+            packs.push(pack);
+        }
+    }
+    packs.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(packs)
+}
+
+/// The URL the host frames. Built here so the platform difference between the
+/// custom scheme and the localhost form is decided once, in the place that
+/// registered the scheme.
+#[tauri::command]
+pub fn packs_entry_url(pack_id: String, entry: String) -> Result<String, String> {
+    if !valid_pack_id(&pack_id) {
+        return Err("bad pack id".into());
+    }
+    for segment in entry.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            return Err("bad entry path".into());
+        }
+    }
+    #[cfg(any(target_os = "android", target_os = "windows"))]
+    let url = format!("http://{PACK_SCHEME}.localhost/{pack_id}/{entry}");
+    #[cfg(not(any(target_os = "android", target_os = "windows")))]
+    let url = format!("{PACK_SCHEME}://localhost/{pack_id}/{entry}");
+    Ok(url)
+}
+
+/// The catalogue, fetched natively from the pinned origin.
+///
+/// The WebView never makes this request: `tauri.conf.json` keeps `connect-src`
+/// closed, so the app's own document cannot reach the network at all and the
+/// only URL that can be asked for is the one compiled in here. The body is
+/// returned as text and validated by the SDK's schema on the JS side, which is
+/// the single copy of that logic.
+#[tauri::command]
+pub async fn packs_catalog() -> Result<String, String> {
+    let client = reqwest::Client::builder()
+        .https_only(true)
+        .user_agent(concat!("Dynawalla/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| format!("cannot build a client: {e}"))?;
+    let response = client
+        .get(format!("{PACK_ORIGIN}catalog.json"))
+        .send()
+        .await
+        .map_err(|e| format!("catalogue unreachable: {e}"))?;
+    if !response.status().is_success() {
+        return Err(format!("catalogue unreachable: HTTP {}", response.status()));
+    }
+    let body = response
+        .text()
+        .await
+        .map_err(|e| format!("catalogue unreadable: {e}"))?;
+    if body.len() > 4 * 1024 * 1024 {
+        return Err("catalogue is implausibly large".into());
+    }
+    Ok(body)
+}
+
+#[tauri::command]
+pub async fn packs_remove<R: Runtime>(app: AppHandle<R>, pack_id: String) -> Result<(), String> {
+    if !valid_pack_id(&pack_id) {
+        return Err("bad pack id".into());
+    }
+    let dir = pack_root(&app)?.join(&pack_id);
+    if !dir.exists() {
+        return Ok(());
+    }
+    fs::remove_dir_all(&dir).map_err(|e| format!("cannot remove {pack_id}: {e}"))
+}
+
+/// Download, verify, extract, swap.
+///
+/// Nothing touches the live pack directory until the archive has been verified
+/// and fully extracted somewhere else, so a failure at any step leaves the
+/// installed pack exactly as it was. An interrupted install is a wasted
+/// download, never a broken pack.
+#[tauri::command]
+pub async fn packs_install<R: Runtime>(
+    app: AppHandle<R>,
+    request: InstallRequest,
+    progress: Channel<Progress>,
+) -> Result<InstalledPack, String> {
+    if !valid_pack_id(&request.pack_id) {
+        return Err("bad pack id".into());
+    }
+    if request.sha256.len() != 64 || !request.sha256.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err("sha256 must be 64 hex characters".into());
+    }
+    // Origin pinning. A URL is data from a catalogue file; this is the check
+    // that keeps it from being an instruction.
+    if !request.url.starts_with(PACK_ORIGIN) {
+        return Err(format!("refusing an origin that is not {PACK_ORIGIN}"));
+    }
+    if request.bytes == 0 || request.bytes > MAX_DOWNLOAD_BYTES {
+        return Err("declared download size is out of range".into());
+    }
+
+    let root = pack_root(&app)?;
+    let staging = root
+        .join(".staging")
+        .join(format!("{}-{}", request.pack_id, request.version));
+    let _ = fs::remove_dir_all(&staging);
+    fs::create_dir_all(&staging).map_err(|e| format!("cannot stage: {e}"))?;
+
+    let archive = download(&request, &progress).await.inspect_err(|_| {
+        let _ = fs::remove_dir_all(&staging);
+    })?;
+
+    let _ = progress.send(Progress::Extracting);
+    let staging_for_task = staging.clone();
+    let extracted =
+        tauri::async_runtime::spawn_blocking(move || extract(&archive, &staging_for_task))
+            .await
+            .map_err(|e| format!("extract task failed: {e}"))?;
+
+    if let Err(problem) = extracted {
+        let _ = fs::remove_dir_all(&staging);
+        return Err(problem);
+    }
+
+    // The archive says who it is. The catalogue said who it should be. Drift
+    // between them means the download is not the update the parent agreed to,
+    // and it is recorded as a failure rather than as a success with a surprise
+    // in it.
+    let installed = read_installed(&staging).ok_or_else(|| {
+        let _ = fs::remove_dir_all(&staging);
+        "archive has no readable manifest.json at its root".to_string()
+    })?;
+    if installed.id != request.pack_id || installed.version != request.version {
+        let _ = fs::remove_dir_all(&staging);
+        return Err(format!(
+            "archive declares {}@{} but the catalogue promised {}@{}",
+            installed.id, installed.version, request.pack_id, request.version
+        ));
+    }
+
+    let _ = progress.send(Progress::Installing);
+    let final_dir = root.join(&request.pack_id);
+    if final_dir.exists() {
+        let trash = root
+            .join(".trash")
+            .join(format!("{}-{}", request.pack_id, now_millis()));
+        fs::create_dir_all(trash.parent().unwrap_or(&root)).map_err(|e| e.to_string())?;
+        fs::rename(&final_dir, &trash).map_err(|e| format!("cannot retire the old pack: {e}"))?;
+        let _ = fs::remove_dir_all(&trash);
+    }
+    fs::rename(&staging, &final_dir).map_err(|e| format!("cannot install: {e}"))?;
+
+    read_installed(&final_dir).ok_or_else(|| "installed pack is unreadable".to_string())
+}
+
+fn now_millis() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
+}
+
+/// Stream the archive into memory, hashing as it goes, refusing to grow past
+/// what the manifest declared.
+///
+/// In memory rather than to a file so that a failed verification leaves nothing
+/// on disk to clean up, and because the ceiling is already bounded by
+/// `MAX_DOWNLOAD_BYTES`.
+async fn download(
+    request: &InstallRequest,
+    progress: &Channel<Progress>,
+) -> Result<Vec<u8>, String> {
+    let client = reqwest::Client::builder()
+        .https_only(true)
+        .user_agent(concat!("Dynawalla/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| format!("cannot build a client: {e}"))?;
+
+    let mut response = client
+        .get(&request.url)
+        .send()
+        .await
+        .map_err(|e| format!("download failed: {e}"))?;
+    if !response.status().is_success() {
+        return Err(format!("download failed: HTTP {}", response.status()));
+    }
+
+    let mut body = Vec::with_capacity(request.bytes.min(8 * 1024 * 1024) as usize);
+    let mut hasher = Sha256::new();
+    let mut announced = 0u64;
+    let _ = progress.send(Progress::Downloading {
+        received: 0,
+        total: request.bytes,
+    });
+
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|e| format!("download interrupted: {e}"))?
+    {
+        if body.len() as u64 + chunk.len() as u64 > request.bytes {
+            return Err("download is larger than the manifest declared".into());
+        }
+        hasher.update(&chunk);
+        body.extend_from_slice(&chunk);
+        if body.len() as u64 - announced >= PROGRESS_STEP_BYTES {
+            announced = body.len() as u64;
+            let _ = progress.send(Progress::Downloading {
+                received: announced,
+                total: request.bytes,
+            });
+        }
+    }
+
+    if body.len() as u64 != request.bytes {
+        return Err("download is shorter than the manifest declared".into());
+    }
+
+    let _ = progress.send(Progress::Verifying);
+    let digest = hasher.finalize();
+    let actual = digest
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>();
+    if actual != request.sha256.to_ascii_lowercase() {
+        // Deliberately not logged with the URL: this is the interesting failure
+        // and the message is what a support reply quotes.
+        return Err(format!(
+            "integrity check failed: expected {}, got {actual}",
+            request.sha256
+        ));
+    }
+    Ok(body)
+}
+
+/// Extract, with every limit the manifest schema promises enforced again here.
+///
+/// A ZIP is a list of paths chosen by whoever built it. Three things are
+/// refused: a path that leaves the destination, a file count above `MAX_FILES`,
+/// and a total uncompressed size above `MAX_INSTALLED_BYTES` — the last being
+/// the difference between a large pack and a 42-kilobyte archive that fills the
+/// device.
+fn extract(archive: &[u8], destination: &Path) -> Result<(), String> {
+    extract_within(archive, destination, MAX_FILES, MAX_INSTALLED_BYTES)
+}
+
+/// The limits are parameters so a test can prove the ceiling refuses rather
+/// than assert that 512 MB is a number. Production has exactly one caller.
+fn extract_within(
+    archive: &[u8],
+    destination: &Path,
+    max_files: usize,
+    max_bytes: u64,
+) -> Result<(), String> {
+    let cursor = std::io::Cursor::new(archive);
+    let mut zip = zip::ZipArchive::new(cursor).map_err(|e| format!("not a zip archive: {e}"))?;
+    if zip.len() > max_files {
+        return Err(format!("archive has more than {max_files} entries"));
+    }
+
+    let mut written: u64 = 0;
+    for index in 0..zip.len() {
+        let mut entry = zip
+            .by_index(index)
+            .map_err(|e| format!("unreadable entry: {e}"))?;
+        let raw_name = entry.name().to_string();
+        if entry.is_dir() {
+            continue;
+        }
+        let Some(relative) = safe_entry_path(&raw_name) else {
+            return Err(format!(
+                "archive entry escapes the pack directory: {raw_name}"
+            ));
+        };
+        let target = destination.join(&relative);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).map_err(|e| format!("cannot create {parent:?}: {e}"))?;
+        }
+
+        // Read through a limited reader so a lying header cannot be believed:
+        // the cap is on the bytes actually produced, not on `entry.size()`.
+        let remaining = max_bytes.saturating_sub(written);
+        let mut buffer = Vec::new();
+        let read = entry
+            .by_ref()
+            .take(remaining + 1)
+            .read_to_end(&mut buffer)
+            .map_err(|e| format!("cannot read {raw_name}: {e}"))? as u64;
+        if read > remaining {
+            return Err("archive expands past the installed-size limit".into());
+        }
+        written += read;
+        fs::write(&target, &buffer).map_err(|e| format!("cannot write {target:?}: {e}"))?;
+    }
+
+    if written == 0 {
+        return Err("archive is empty".into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/dynawalla/dynawalla-app/src-tauri/src/packs/tests.rs
+++ b/dynawalla/dynawalla-app/src-tauri/src/packs/tests.rs
@@ -1,0 +1,316 @@
+//! The path and archive rules, exercised against a real filesystem.
+//!
+//! Every one of these is a hole that a string check would leave open. They run
+//! under `cargo test` in seconds and none of them needs a WebView, which is the
+//! point: the parts of the pack runtime that can be tested without a device are
+//! exactly the parts that are dangerous.
+
+use super::*;
+use std::io::Write;
+
+fn scratch(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("dynawalla-packs-test-{name}-{}", now_millis()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).expect("scratch");
+    dir
+}
+
+#[test]
+fn pack_ids_are_directory_names_and_are_treated_as_such() {
+    for id in ["abacus", "abacus.tower", "abacus-tower", "a1.b2-c3"] {
+        assert!(valid_pack_id(id), "{id} should be valid");
+    }
+    for id in [
+        "",
+        ".",
+        "..",
+        "../etc",
+        "Abacus",
+        "abacus/tower",
+        "abacus tower",
+        "abacus.",
+        "-abacus",
+        "9lives",
+        "abacus..tower",
+        "abacus\\tower",
+        "abacus\0",
+    ] {
+        assert!(!valid_pack_id(id), "{id:?} should be refused");
+    }
+    assert!(!valid_pack_id(&"a".repeat(65)));
+}
+
+#[test]
+fn an_asset_path_cannot_leave_the_pack_directory() {
+    let root = scratch("resolve");
+    let pack = root.join("abacus");
+    fs::create_dir_all(pack.join("dist")).unwrap();
+    fs::write(pack.join("dist/app.js"), b"ok").unwrap();
+    fs::write(root.join("secret.txt"), b"no").unwrap();
+
+    assert!(resolve_asset(&pack, "dist/app.js").is_some());
+    for bad in [
+        "../secret.txt",
+        "dist/../../secret.txt",
+        "./dist/app.js",
+        "",
+        "dist",
+        "dist\\app.js",
+        "/dist/app.js",
+        "dist/app.js\0",
+    ] {
+        assert!(resolve_asset(&pack, bad).is_none(), "{bad:?} resolved");
+    }
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[cfg(unix)]
+#[test]
+fn a_symlink_out_of_the_pack_is_refused_although_its_path_looks_innocent() {
+    // The case the `..`-in-the-string check cannot see, and the reason
+    // `resolve_asset` canonicalises. `escape.txt` contains no traversal at all.
+    let root = scratch("symlink");
+    let pack = root.join("abacus");
+    fs::create_dir_all(&pack).unwrap();
+    fs::write(root.join("secret.txt"), b"no").unwrap();
+    std::os::unix::fs::symlink(root.join("secret.txt"), pack.join("escape.txt")).unwrap();
+
+    assert!(!pack.join("escape.txt").to_string_lossy().contains(".."));
+    assert!(
+        resolve_asset(&pack, "escape.txt").is_none(),
+        "symlink escaped"
+    );
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn zip_entry_names_that_escape_are_rejected_before_anything_is_created() {
+    for name in [
+        "../evil.js",
+        "a/../../evil.js",
+        "/etc/passwd",
+        "..\\evil.js",
+        "C:\\Windows\\evil.js",
+        "",
+        "\0",
+        "..",
+    ] {
+        assert!(safe_entry_path(name).is_none(), "{name:?} was accepted");
+    }
+    assert_eq!(
+        safe_entry_path("index.html"),
+        Some(PathBuf::from("index.html"))
+    );
+    assert_eq!(
+        safe_entry_path("dist/app.js"),
+        Some(PathBuf::from("dist/app.js"))
+    );
+    assert_eq!(
+        safe_entry_path("./dist/app.js"),
+        Some(PathBuf::from("dist/app.js"))
+    );
+}
+
+fn zip_of(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut buffer = std::io::Cursor::new(Vec::new());
+    {
+        let mut writer = zip::ZipWriter::new(&mut buffer);
+        let options: zip::write::FileOptions<'_, ()> =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+        for (name, body) in entries {
+            writer.start_file(*name, options).unwrap();
+            writer.write_all(body).unwrap();
+        }
+        writer.finish().unwrap();
+    }
+    buffer.into_inner()
+}
+
+#[test]
+fn a_normal_archive_extracts() {
+    let dir = scratch("extract");
+    let archive = zip_of(&[
+        ("manifest.json", br#"{"id":"abacus","version":"1.0.0"}"#),
+        ("dist/app.js", b"console.log(1)"),
+    ]);
+    extract(&archive, &dir).expect("extract");
+    assert_eq!(
+        fs::read_to_string(dir.join("dist/app.js")).unwrap(),
+        "console.log(1)"
+    );
+    let installed = read_installed(&dir).expect("manifest");
+    assert_eq!(installed.id, "abacus");
+    assert_eq!(installed.version, "1.0.0");
+    assert!(installed.bytes > 0);
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_zip_slip_archive_is_refused_and_writes_nothing_outside() {
+    let root = scratch("slip");
+    let dir = root.join("into");
+    fs::create_dir_all(&dir).unwrap();
+    let archive = zip_of(&[("../owned.js", b"pwn")]);
+
+    let problem = extract(&archive, &dir).expect_err("zip slip extracted");
+    assert!(problem.contains("escapes"), "{problem}");
+    assert!(
+        !root.join("owned.js").exists(),
+        "a file was written outside the destination"
+    );
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn an_archive_that_expands_past_the_ceiling_is_refused() {
+    // A zip bomb in miniature: 64 KB of zeroes compresses to a few hundred
+    // bytes, and the ceiling is applied to what comes OUT, so the compressed
+    // size the archive advertises is not consulted and cannot lie.
+    let dir = scratch("bomb");
+    let archive = zip_of(&[("big.bin", &vec![0u8; 64 * 1024])]);
+    assert!(
+        archive.len() < 4096,
+        "the fixture is not actually compressed"
+    );
+
+    let problem = extract_within(&archive, &dir, MAX_FILES, 4096).expect_err("the bomb extracted");
+    assert!(problem.contains("installed-size limit"), "{problem}");
+
+    // And the same archive is fine under the real ceiling.
+    extract(&archive, &dir).expect("64 KB is not a bomb at 512 MB");
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn an_archive_with_too_many_entries_is_refused_before_any_of_them_is_read() {
+    let dir = scratch("many");
+    let bodies: Vec<(String, Vec<u8>)> = (0..5)
+        .map(|i| (format!("f{i}.txt"), b"x".to_vec()))
+        .collect();
+    let borrowed: Vec<(&str, &[u8])> = bodies
+        .iter()
+        .map(|(n, b)| (n.as_str(), b.as_slice()))
+        .collect();
+    let archive = zip_of(&borrowed);
+
+    let problem = extract_within(&archive, &dir, 4, MAX_INSTALLED_BYTES).expect_err("accepted");
+    assert!(problem.contains("more than 4 entries"), "{problem}");
+    assert!(
+        !dir.join("f0.txt").exists(),
+        "an entry was written before the count was checked"
+    );
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn an_empty_archive_is_not_a_pack() {
+    let dir = scratch("empty");
+    let problem = extract(&zip_of(&[]), &dir).expect_err("empty archive accepted");
+    assert!(problem.contains("empty"), "{problem}");
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn an_archive_without_a_manifest_has_no_identity() {
+    let dir = scratch("noman");
+    extract(&zip_of(&[("index.html", b"<!doctype html>")]), &dir).unwrap();
+    assert!(read_installed(&dir).is_none());
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn the_pack_policy_admits_no_remote_origin_and_never_says_self() {
+    let policy = pack_csp();
+    assert!(policy.starts_with("default-src 'none'"));
+    for directive in [
+        "script-src",
+        "style-src",
+        "img-src",
+        "media-src",
+        "font-src",
+        "connect-src",
+        "worker-src",
+    ] {
+        assert!(policy.contains(directive), "missing {directive}");
+    }
+    // `'self'` is an opaque origin inside the sandbox: it would match nothing.
+    assert!(
+        !policy.contains("'self'"),
+        "'self' is meaningless in an opaque-origin frame"
+    );
+    // No network. This is the property, stated as an assertion.
+    assert!(!policy.contains("https://"));
+    assert!(!policy.contains("http://") || policy.contains("http://dynawalla-pack.localhost"));
+    for remote in [
+        "*",
+        "data: script-src",
+        "'unsafe-eval'",
+        "'unsafe-inline' ; script",
+    ] {
+        assert!(!policy.contains(remote), "policy admits {remote}");
+    }
+    assert!(
+        policy.contains("frame-src 'none'"),
+        "a pack may not frame anything"
+    );
+    assert!(policy.contains("form-action 'none'"));
+    assert!(policy.contains("base-uri 'none'"));
+}
+
+#[test]
+fn scripts_are_external_only_and_wasm_is_allowed() {
+    let policy = pack_csp();
+    let script = policy
+        .split(';')
+        .map(str::trim)
+        .find(|d| d.starts_with("script-src"))
+        .expect("script-src");
+    assert!(
+        !script.contains("'unsafe-inline'"),
+        "inline script in a pack"
+    );
+    assert!(
+        script.contains("'wasm-unsafe-eval'"),
+        "3D packs need WebAssembly"
+    );
+}
+
+#[test]
+fn content_types_are_declared_rather_than_sniffed() {
+    assert_eq!(
+        content_type_for(Path::new("a/index.html")),
+        "text/html; charset=utf-8"
+    );
+    assert_eq!(
+        content_type_for(Path::new("a/app.JS")),
+        "text/javascript; charset=utf-8"
+    );
+    assert_eq!(
+        content_type_for(Path::new("a/model.glb")),
+        "model/gltf-binary"
+    );
+    assert_eq!(content_type_for(Path::new("a/x.wasm")), "application/wasm");
+    assert_eq!(
+        content_type_for(Path::new("a/unknown")),
+        "application/octet-stream"
+    );
+}
+
+#[test]
+fn an_entry_url_names_the_pack_scheme_and_refuses_a_traversal() {
+    let url = packs_entry_url("abacus".into(), "index.html".into()).unwrap();
+    assert!(url.contains("abacus/index.html"), "{url}");
+    assert!(url.contains(PACK_SCHEME), "{url}");
+    assert!(packs_entry_url("../etc".into(), "index.html".into()).is_err());
+    assert!(packs_entry_url("abacus".into(), "../../etc/passwd".into()).is_err());
+    assert!(packs_entry_url("abacus".into(), "".into()).is_err());
+}
+
+#[test]
+fn the_download_origin_is_pinned_to_one_https_prefix() {
+    assert!(PACK_ORIGIN.starts_with("https://"));
+    assert!(
+        PACK_ORIGIN.ends_with('/'),
+        "a prefix without a trailing slash matches a sibling host"
+    );
+}

--- a/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
+++ b/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self' ipc: http://ipc.localhost; media-src 'none'; object-src 'none'; frame-src 'none'; worker-src 'none'; base-uri 'none'; form-action 'none'"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self' ipc: http://ipc.localhost; media-src 'none'; object-src 'none'; frame-src dynawalla-pack: http://dynawalla-pack.localhost; worker-src 'none'; base-uri 'none'; form-action 'none'"
     }
   },
   "bundle": {

--- a/dynawalla/dynawalla-app/src/app/capabilities.test.ts
+++ b/dynawalla/dynawalla-app/src/app/capabilities.test.ts
@@ -46,11 +46,21 @@ test("the CSP is non-null and closed by default", () => {
   assert.doesNotMatch(policy, /'unsafe-eval'/)
   assert.doesNotMatch(policy, /\*/, "a wildcard source defeats the policy")
 
-  // The app is offline by design (ADR-0003, ADR-0004): no remote origin should
-  // ever appear here. `ipc:`/`http://ipc.localhost` are Tauri's own bridge.
+  // The app's own document is offline: no remote origin appears here. The two
+  // permitted sources are both local schemes Tauri serves itself —
+  // `http://ipc.localhost` is its bridge, and `http://dynawalla-pack.localhost`
+  // is the pack scheme in the form Android and Windows serve it under (it is
+  // `dynawalla-pack:` everywhere else, which is not an http source at all).
+  // Content packs are downloaded and verified in Rust, never fetched here.
+  const LOCAL_SCHEME_HOSTS = new Set(["http://ipc.localhost", "http://dynawalla-pack.localhost"])
   for (const source of policy.matchAll(/https?:\/\/[^\s;]+/g)) {
-    assert.equal(source[0], "http://ipc.localhost", `remote origin in CSP: ${source[0]}`)
+    assert.ok(LOCAL_SCHEME_HOSTS.has(source[0]), `remote origin in CSP: ${source[0]}`)
   }
+
+  // A pack is framed, and the only thing that may be framed is a pack.
+  const frameSrc = /frame-src ([^;]+)/.exec(policy)?.[1] ?? ""
+  assert.match(frameSrc, /dynawalla-pack:/, "the pack scheme cannot be framed")
+  assert.doesNotMatch(frameSrc, /'self'|https:|data:|blob:/, `frame-src admits ${frameSrc}`)
 
   // script-src must not admit inline script: the whole point of the policy.
   assert.match(policy, /script-src 'self'\s*;/)
@@ -98,8 +108,21 @@ test("no grant is a whole plugin", () => {
 })
 
 test("grants and native calls are the same set, in both directions", () => {
+  // `null` is an application command, which the ACL does not gate and a
+  // capability file cannot name. Those rows are held to a different check —
+  // `packs/native.test.ts` asserts each one is actually registered in Rust —
+  // and a row with neither a permission nor a command is declared by nobody.
+  for (const call of NATIVE_CALLS) {
+    if (call.permission === null) {
+      assert.ok(call.command, `${call.module}.${call.fn} has no permission and no command`)
+    } else {
+      assert.equal(call.command, undefined, `${call.permission} is a plugin grant, not a command`)
+    }
+  }
   const granted = [...permissions].sort()
-  const required = [...new Set(NATIVE_CALLS.map((call) => call.permission))].sort()
+  const required = [
+    ...new Set(NATIVE_CALLS.map((call) => call.permission).filter((p) => p !== null)),
+  ].sort()
   assert.deepEqual(granted, required)
 })
 

--- a/dynawalla/dynawalla-app/src/app/permissions.ts
+++ b/dynawalla/dynawalla-app/src/app/permissions.ts
@@ -14,8 +14,23 @@ export interface NativeCall {
   module: string
   /** The exported function. */
   fn: string
-  /** The single command permission it requires. */
-  permission: string
+  /**
+   * The single command permission it requires, or `null` for a command this
+   * application defines itself.
+   *
+   * Tauri's ACL gates plugin commands — `core:*` and every `tauri-plugin-*` —
+   * and says nothing about commands registered by the app's own
+   * `generate_handler!`. A capability entry for one is not merely unnecessary,
+   * it is unexpressible. `null` records that fact rather than leaving the row
+   * out, because a row that is not here is a native call nobody declared.
+   */
+  permission: string | null
+  /**
+   * The Rust command, for a `null` permission. `packs/native.test.ts` asserts
+   * every one of these is registered in `src-tauri/src/lib.rs` — the check that
+   * stands in for the grant the ACL cannot give.
+   */
+  command?: string
   /** Why the app needs it. */
   why: string
 }
@@ -26,5 +41,47 @@ export const NATIVE_CALLS: readonly NativeCall[] = [
     fn: "getVersion",
     permission: "core:app:allow-version",
     why: "The settings screen shows the installed build, which is the first thing a parent reporting a problem is asked for.",
+  },
+  {
+    module: "@tauri-apps/api/core",
+    fn: "invoke",
+    permission: null,
+    command: "packs_list",
+    why: "The pack runtime reads what is installed. Packs are the product; the shell is what installs and serves them.",
+  },
+  {
+    module: "@tauri-apps/api/core",
+    fn: "invoke",
+    permission: null,
+    command: "packs_catalog",
+    why: "Fetching the catalogue natively is what lets the WebView's connect-src stay closed: the app's own document never talks to the network.",
+  },
+  {
+    module: "@tauri-apps/api/core",
+    fn: "invoke",
+    permission: null,
+    command: "packs_install",
+    why: "Download, verify against the manifest's sha256, and extract. All three are native so no pack archive is ever handled in the WebView.",
+  },
+  {
+    module: "@tauri-apps/api/core",
+    fn: "invoke",
+    permission: null,
+    command: "packs_remove",
+    why: "Uninstall. Registered, and asserted to be registered: Corpán's delete command is not, and its uninstalled packs stay on disk forever.",
+  },
+  {
+    module: "@tauri-apps/api/core",
+    fn: "invoke",
+    permission: null,
+    command: "packs_entry_url",
+    why: "The pack-scheme URL the frame loads, built natively so the platform difference between the custom scheme and the localhost form is decided once.",
+  },
+  {
+    module: "@tauri-apps/api/core",
+    fn: "Channel",
+    permission: null,
+    command: "packs_install",
+    why: "Install progress. A channel argument rather than a global event so no listen permission is needed and no other window can hear it.",
   },
 ]

--- a/dynawalla/dynawalla-app/src/packs/PackFrame.tsx
+++ b/dynawalla/dynawalla-app/src/packs/PackFrame.tsx
@@ -1,0 +1,75 @@
+// The React surface of a mounted pack: an element to put it in, and a
+// lifecycle that survives being mounted twice.
+//
+// It renders no text. Every string a pack surface needs — a name, a refusal, a
+// consent sheet — belongs to the screen that owns the decision, because each
+// one costs a full set of translations and this component is not in a position
+// to know which of them is worth that.
+
+import { useEffect, useRef } from "react"
+
+import type { Capability, Settings } from "../../../packs/sdk/src/index.ts"
+import type { HostServices } from "./bridge.ts"
+import { mountPack } from "./frame.ts"
+import type { MountedPack } from "./frame.ts"
+
+import "./packs.css"
+
+export type PackFrameProps = {
+  readonly packId: string
+  readonly entryUrl: string
+  readonly granted: readonly Capability[]
+  readonly services: HostServices
+  readonly hostVersion: string
+  /** The pack's localised name. The frame's accessible name, nothing more. */
+  readonly title: string
+  /** Pushed to the pack whenever it changes; the pack re-reads and re-renders. */
+  readonly settings: Settings
+  /** Paused packs stop their own loop. The host decides when, not the pack. */
+  readonly paused?: boolean
+  readonly onError?: (reason: string) => void
+}
+
+export function PackFrame(props: PackFrameProps) {
+  const container = useRef<HTMLDivElement | null>(null)
+  const mounted = useRef<MountedPack | null>(null)
+
+  // The identity of a mount is the pack and the document it framed. Everything
+  // else — settings, paused — is pushed to a live pack rather than remounting
+  // it, because remounting a 3D world to change a text scale is not a change,
+  // it is a restart.
+  const { packId, entryUrl, granted, services, hostVersion, title, onError } = props
+  useEffect(() => {
+    const host = container.current
+    if (!host) return
+    const pack = mountPack({
+      container: host,
+      packId,
+      entryUrl,
+      granted,
+      services,
+      hostVersion,
+      title,
+      ...(onError ? { onError } : {}),
+    })
+    mounted.current = pack
+    return () => {
+      pack.dispose()
+      mounted.current = null
+    }
+    // `granted` and `services` are stable for the life of a launch: both are
+    // decided by `gateRun` before this component exists. Listing them would
+    // remount the pack on every parent render that rebuilt an array literal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [packId, entryUrl, hostVersion, title])
+
+  useEffect(() => {
+    mounted.current?.pushSettings(props.settings)
+  }, [props.settings])
+
+  useEffect(() => {
+    mounted.current?.send(props.paused ? "pause" : "resume")
+  }, [props.paused])
+
+  return <div className="pack-frame-host" ref={container} />
+}

--- a/dynawalla/dynawalla-app/src/packs/bridge.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/bridge.test.ts
@@ -1,0 +1,336 @@
+// The enforcement point, exercised as an adversary would.
+//
+// Half of these send messages no honest pack would ever send. That is the test:
+// the bridge is the only thing between third-party code and the host, in a
+// product used by children, and "no pack would do that" is not a security
+// property.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { createBridge, MAX_STORAGE_KEYS, MAX_STORAGE_VALUE_LENGTH } from "./bridge.ts"
+import type { HostServices } from "./bridge.ts"
+import { CAPABILITIES, CAPABILITY_IDS, METHODS, SESSION_METHODS } from "../../../packs/sdk/src/index.ts"
+import type { Capability, Item, Response } from "../../../packs/sdk/src/index.ts"
+
+const ITEM: Item = {
+  id: "i1",
+  skillId: "sub.4digit.zero",
+  level: 3,
+  form: "binary-op",
+  operator: "-",
+  operands: ["5001", "2798"],
+  prompt: "5001 minus 2798",
+  answerKind: "integer",
+  digits: 4,
+}
+
+type Calls = { name: string; input: unknown }[]
+
+function services(calls: Calls, overrides: Partial<HostServices> = {}): HostServices {
+  const store = new Map<string, string>()
+  const record = <T>(name: string, value: T) => (input: unknown) => {
+    calls.push({ name, input })
+    return value
+  }
+  return {
+    nextItem: async (input) => record("nextItem", ITEM)(input),
+    // 5001 − 2798 = 2203, verified by hand. 3797 is smaller-from-larger: it
+    // subtracts the smaller digit from the larger in each column rather than
+    // borrowing across the zero.
+    judge: async (input) => {
+      calls.push({ name: "judge", input })
+      const correct = (input as { response: string }).response === "2203"
+      return correct
+        ? { correct: true, canonical: "2203", advance: true }
+        : { correct: false, canonical: "2203", diagnosis: "smaller-from-larger", advance: true }
+    },
+    skip: async (input) => void record("skip", undefined)(input),
+    reveal: async (input) => record("reveal", "2203")(input),
+    learnerSummary: async (input) => record("learnerSummary", { skills: [] })(input),
+    haptic: async (input) => void record("haptic", undefined)(input),
+    sound: async (input) => void record("sound", undefined)(input),
+    milestone: async (input) => void record("milestone", undefined)(input),
+    storage: {
+      get: async ({ key }) => store.get(key) ?? null,
+      set: async ({ key, value }) => void store.set(key, value),
+      remove: async ({ key }) => void store.delete(key),
+      keys: async () => [...store.keys()],
+    },
+    progress: (input) => void record("progress", undefined)(input),
+    end: (input) => void record("end", undefined)(input),
+    settings: () => ({
+      locale: "en",
+      reducedMotion: false,
+      quality: "high",
+      textScale: 1,
+      colorScheme: "light",
+      sound: true,
+      haptics: true,
+    }),
+    ...overrides,
+  }
+}
+
+const bridgeWith = (granted: readonly Capability[], calls: Calls = [], extra: Partial<HostServices> = {}) =>
+  createBridge({ packId: "abacus.tower", granted, services: services(calls, extra) })
+
+const errorOf = (response: Response | null) => (response && !response.ok ? response.error.code : null)
+
+test("a granted method reaches the host", async () => {
+  const calls: Calls = []
+  const bridge = bridgeWith(["items"], calls)
+  const response = await bridge.handle({ id: 1, method: "items.next", params: {} })
+  assert.deepEqual(response, { id: 1, ok: true, result: { item: ITEM } })
+  assert.equal(calls[0]?.name, "nextItem")
+})
+
+test("every method of every capability is denied to a pack without it", async () => {
+  // The exhaustive version. A method added to the SDK without a grant would be
+  // callable by every pack, and this is what notices.
+  for (const entry of CAPABILITIES) {
+    const others = CAPABILITY_IDS.filter((id) => id !== entry.id)
+    for (const method of entry.methods) {
+      const calls: Calls = []
+      const bridge = bridgeWith(others, calls)
+      const response = await bridge.handle({ id: 1, method, params: {} })
+      assert.equal(errorOf(response), "denied", `${method} was not denied`)
+      assert.deepEqual(calls, [], `${method} reached the host while denied`)
+      assert.equal(bridge.stats.denied, 1)
+    }
+  }
+})
+
+test("a denial does not depend on the parameters", async () => {
+  // Otherwise the error a pack gets back tells it about what it was denied.
+  const bridge = bridgeWith([])
+  const withGarbage = await bridge.handle({ id: 1, method: "items.answer", params: { itemId: 5 } })
+  const withNothing = await bridge.handle({ id: 2, method: "items.answer", params: {} })
+  assert.equal(errorOf(withGarbage), "denied")
+  assert.equal(errorOf(withNothing), "denied")
+})
+
+test("session methods work with no grants at all", async () => {
+  const calls: Calls = []
+  const bridge = bridgeWith([], calls)
+  for (const method of SESSION_METHODS) {
+    const params =
+      method === "session.progress" ? { fraction: 0.5 } : method === "session.end" ? { reason: "quit" } : {}
+    const response = await bridge.handle({ id: 1, method, params })
+    assert.ok(response?.ok, `${method} was refused`)
+  }
+})
+
+test("an unknown method is refused and never dispatched", async () => {
+  const calls: Calls = []
+  const bridge = bridgeWith(CAPABILITY_IDS, calls)
+  assert.equal(errorOf(await bridge.handle({ id: 1, method: "items.eval", params: {} })), "unknown_method")
+  assert.equal(errorOf(await bridge.handle({ id: 2, method: "__proto__", params: {} })), "unknown_method")
+  assert.equal(errorOf(await bridge.handle({ id: 3, method: "constructor", params: {} })), "unknown_method")
+  assert.deepEqual(calls, [])
+})
+
+test("a message with no usable id is dropped rather than answered", async () => {
+  // Answering with an invented id would resolve a promise the pack is holding
+  // for something else.
+  const bridge = bridgeWith(CAPABILITY_IDS)
+  assert.equal(await bridge.handle(null), null)
+  assert.equal(await bridge.handle("items.next"), null)
+  assert.equal(await bridge.handle({ method: "items.next" }), null)
+  assert.equal(await bridge.handle({ id: -1, method: "items.next" }), null)
+  assert.equal(bridge.stats.malformed, 4)
+})
+
+test("the whole method table is reachable when everything is granted", async () => {
+  // A method in the SDK that the bridge forgot to implement would return
+  // undefined and hang the pack's promise forever.
+  const bridge = bridgeWith(CAPABILITY_IDS)
+  const params: Record<string, unknown> = {
+    itemId: "i1",
+    response: "2203",
+    latencyMs: 100,
+    revisions: 0,
+    key: "k",
+    value: "v",
+    name: "tower.built",
+    cue: "seat",
+    fraction: 0.5,
+    reason: "quit",
+  }
+  for (const method of METHODS) {
+    const response = await bridge.handle({ id: 1, method, params })
+    assert.notEqual(response, null, `${method} produced no response`)
+    assert.ok(response?.ok, `${method} failed: ${JSON.stringify(response)}`)
+  }
+})
+
+test("reading the answer costs the attempt", async () => {
+  // The property the whole design turns on: `items.next` does not carry the
+  // canonical value, and the only way to get it is `items.answer`, which
+  // records the attempt first. A pack cannot learn what is right for free.
+  const calls: Calls = []
+  const bridge = bridgeWith(["items"], calls)
+
+  const served = await bridge.handle({ id: 1, method: "items.next", params: {} })
+  assert.ok(served?.ok)
+  const item = (served as { result: { item: Item } }).result.item
+  assert.ok(!JSON.stringify(item).includes("2203"), "the served item carried the answer")
+
+  const wrong = await bridge.handle({
+    id: 2,
+    method: "items.answer",
+    params: { itemId: "i1", response: "3797", latencyMs: 4200, revisions: 0 },
+  })
+  assert.ok(wrong?.ok)
+  const judgement = (wrong as { result: { correct: boolean; canonical: string; diagnosis?: string } }).result
+  assert.equal(judgement.correct, false)
+  assert.equal(judgement.canonical, "2203")
+  assert.equal(judgement.diagnosis, "smaller-from-larger")
+  assert.equal(calls.filter((call) => call.name === "judge").length, 1, "the attempt was not recorded")
+})
+
+test("reading the answer early is a separate grant", async () => {
+  const withItems = bridgeWith(["items"])
+  assert.equal(
+    errorOf(await withItems.handle({ id: 1, method: "items.reveal", params: { itemId: "i1" } })),
+    "denied",
+  )
+  const withReveal = bridgeWith(["items", "items.reveal"])
+  const response = await withReveal.handle({ id: 1, method: "items.reveal", params: { itemId: "i1" } })
+  assert.deepEqual(response, { id: 1, ok: true, result: { canonical: "2203" } })
+})
+
+test("parameters are checked, and a wrong one is invalid_params rather than a crash", async () => {
+  const bridge = bridgeWith(CAPABILITY_IDS)
+  const cases: [string, Record<string, unknown>][] = [
+    ["items.answer", { response: "1", latencyMs: 1, revisions: 0 }],
+    ["items.answer", { itemId: "i1", response: 5, latencyMs: 1, revisions: 0 }],
+    ["items.answer", { itemId: "i1", response: "1", latencyMs: -1, revisions: 0 }],
+    ["items.answer", { itemId: "i1", response: "1", latencyMs: Number.NaN, revisions: 0 }],
+    ["items.skip", {}],
+    ["items.reveal", { itemId: "" }],
+    ["feedback.haptic", { cue: "explode" }],
+    ["feedback.sound", { cue: 7 }],
+    ["milestone.reach", {}],
+    ["session.progress", { fraction: "half" }],
+    ["session.end", { reason: "crashed" }],
+    ["storage.get", {}],
+    ["storage.set", { key: "k" }],
+    ["storage.set", { key: "k", value: 7 }],
+  ]
+  for (const [method, params] of cases) {
+    const response = await bridge.handle({ id: 1, method, params })
+    assert.equal(errorOf(response), "invalid_params", `${method} ${JSON.stringify(params)}`)
+  }
+})
+
+test("a latency nobody could have produced is clamped, not refused", async () => {
+  // A child who leaves the tablet on the sofa for an hour has not answered in
+  // an hour; refusing the report would lose the attempt entirely.
+  const calls: Calls = []
+  const bridge = bridgeWith(["items"], calls)
+  await bridge.handle({
+    id: 1,
+    method: "items.answer",
+    params: { itemId: "i1", response: "2203", latencyMs: 99_999_999, revisions: 3.7 },
+  })
+  const judged = calls.find((call) => call.name === "judge")?.input as {
+    latencyMs: number
+    revisions: number
+  }
+  assert.equal(judged.latencyMs, 600_000)
+  assert.equal(judged.revisions, 4, "revisions are whole")
+})
+
+test("a pack that floods is rate-limited, and recovers when it stops", async () => {
+  let clock = 1_000
+  const calls: Calls = []
+  const bridge = createBridge({
+    packId: "abacus.tower",
+    granted: ["items"],
+    services: services(calls),
+    now: () => clock,
+    maxRequestsPerSecond: 5,
+  })
+
+  for (let index = 0; index < 5; index += 1) {
+    const response = await bridge.handle({ id: index, method: "items.next", params: {} })
+    assert.ok(response?.ok, `request ${index} should have been served`)
+  }
+  assert.equal(errorOf(await bridge.handle({ id: 5, method: "items.next", params: {} })), "rate_limited")
+  assert.equal(calls.length, 5, "a rate-limited request still reached the host")
+
+  clock += 1001
+  assert.ok((await bridge.handle({ id: 6, method: "items.next", params: {} }))?.ok)
+  assert.equal(bridge.stats.rateLimited, 1)
+})
+
+test("rate limiting is applied after the denial, so a denied flood is still denied", async () => {
+  const clock = 1_000
+  const bridge = createBridge({
+    packId: "abacus.tower",
+    granted: [],
+    services: services([]),
+    now: () => clock,
+    maxRequestsPerSecond: 2,
+  })
+  for (let index = 0; index < 10; index += 1) {
+    assert.equal(errorOf(await bridge.handle({ id: index, method: "items.next", params: {} })), "denied")
+  }
+})
+
+test("pack storage is bounded in both directions", async () => {
+  // Filling the key budget takes more requests than a second allows, which is
+  // the rate limiter doing its job and not what this test is about.
+  const bridge = createBridge({
+    packId: "abacus.tower",
+    granted: ["storage"],
+    services: services([]),
+    maxRequestsPerSecond: 100_000,
+  })
+  const set = (key: string, value: string) =>
+    bridge.handle({ id: 1, method: "storage.set", params: { key, value } })
+
+  assert.ok((await set("level", "7"))?.ok)
+  assert.deepEqual(await bridge.handle({ id: 2, method: "storage.get", params: { key: "level" } }), {
+    id: 2,
+    ok: true,
+    result: { value: "7" },
+  })
+
+  assert.equal(errorOf(await set("big", "x".repeat(MAX_STORAGE_VALUE_LENGTH + 1))), "quota")
+
+  for (let index = 0; index < MAX_STORAGE_KEYS; index += 1) {
+    await set(`k${index}`, "v")
+  }
+  assert.equal(errorOf(await set("one-too-many", "v")), "quota")
+  // Overwriting an existing key is always allowed, full or not.
+  assert.ok((await set("k0", "w"))?.ok)
+})
+
+test("a host that throws tells the pack nothing about why", async () => {
+  const bridge = bridgeWith(["items"], [], {
+    nextItem: async () => {
+      throw new Error("SQLITE_CORRUPT: /Users/someone/Library/…/learner.db")
+    },
+  })
+  const response = await bridge.handle({ id: 1, method: "items.next", params: {} })
+  assert.equal(errorOf(response), "internal")
+  assert.ok(response && !response.ok)
+  if (response && !response.ok) {
+    assert.doesNotMatch(response.error.message, /SQLITE|Users|db/)
+  }
+})
+
+test("the pack id the host is told is the host's, never the pack's", async () => {
+  // A pack that puts a `packId` in its params must not be able to read or write
+  // another pack's storage with it.
+  const calls: Calls = []
+  const bridge = bridgeWith(["storage", "items"], calls)
+  await bridge.handle({
+    id: 1,
+    method: "items.next",
+    params: { packId: "someone.else", skillId: "add.1" },
+  })
+  assert.deepEqual(calls[0]?.input, { packId: "abacus.tower", skillId: "add.1" })
+})

--- a/dynawalla/dynawalla-app/src/packs/bridge.ts
+++ b/dynawalla/dynawalla-app/src/packs/bridge.ts
@@ -1,0 +1,297 @@
+// The host's side of the wire. This is the enforcement point.
+//
+// Every message a pack ever sends arrives at `handle`. It is validated, gated,
+// rate-limited, its parameters are checked, and only then does anything the
+// host owns get called. There is no other path: `PackFrame` gives the pack one
+// `MessagePort` and this module is the only thing on the other end of it.
+//
+// The order is fixed and matters:
+//
+//   shape → method exists → capability granted → rate → parameters → dispatch
+//
+// A denial must never depend on the parameters, or the error a pack gets back
+// tells it something about what it was denied. And rate limiting sits before
+// parameter validation so that a flood of malformed messages costs the same as
+// a flood of well-formed ones.
+//
+// The bridge is deliberately ignorant of what an item is. It hands opaque
+// values to `HostServices` and returns whatever comes back. The adaptive engine
+// chooses, the curriculum judges, and neither of them is reachable from here
+// except through that interface — which is what keeps this file a boundary
+// rather than a second implementation of the practice loop.
+
+import type {
+  Capability,
+  ErrorCode,
+  HapticCue,
+  Item,
+  Judgement,
+  LearnerSummary,
+  Method,
+  Response,
+  Settings,
+  SoundCue,
+} from "../../../packs/sdk/src/index.ts"
+import {
+  MAX_REQUESTS_PER_SECOND,
+  numberParam,
+  parseRequest,
+  permits,
+  stringParam,
+} from "../../../packs/sdk/src/index.ts"
+
+/** A pack's own key-value store. Small on purpose: it is not a database. */
+export const MAX_STORAGE_KEYS = 200
+export const MAX_STORAGE_KEY_LENGTH = 128
+export const MAX_STORAGE_VALUE_LENGTH = 16 * 1024
+
+/** A latency a pack reports is clamped to this. Anything longer is not a fact. */
+const MAX_LATENCY_MS = 10 * 60 * 1000
+const MAX_REVISIONS = 1000
+
+const HAPTIC_CUES: readonly HapticCue[] = ["tick", "seat", "settle", "refuse"]
+const SOUND_CUES: readonly SoundCue[] = ["tick", "seat", "settle", "refuse", "arrive"]
+
+/**
+ * Everything the host can be asked to do, as one interface.
+ *
+ * The pack surface is this list and the SDK's method table, and they are the
+ * same size on purpose. Adding a capability means adding a method here and a
+ * row in the SDK's table; there is no way to add reach to a pack by editing
+ * only one file.
+ */
+export type HostServices = {
+  nextItem(input: { packId: string; skillId?: string }): Promise<Item | null>
+  /** Records the attempt and judges it. One call, in that order. */
+  judge(input: {
+    packId: string
+    itemId: string
+    response: string
+    latencyMs: number
+    revisions: number
+  }): Promise<Judgement>
+  skip(input: { packId: string; itemId: string }): Promise<void>
+  reveal(input: { packId: string; itemId: string }): Promise<string>
+  learnerSummary(input: { packId: string }): Promise<LearnerSummary>
+  haptic(input: { packId: string; cue: HapticCue }): Promise<void>
+  sound(input: { packId: string; cue: SoundCue }): Promise<void>
+  milestone(input: { packId: string; name: string }): Promise<void>
+  storage: {
+    get(input: { packId: string; key: string }): Promise<string | null>
+    set(input: { packId: string; key: string; value: string }): Promise<void>
+    remove(input: { packId: string; key: string }): Promise<void>
+    keys(input: { packId: string }): Promise<string[]>
+  }
+  progress(input: { packId: string; fraction: number }): void
+  end(input: { packId: string; reason: "finished" | "quit" }): void
+  settings(): Settings
+}
+
+export type Bridge = {
+  /** One message in, one response out. `null` for a message with no reply. */
+  handle(message: unknown): Promise<Response | null>
+  /** Counters, for the developer surface and for the tests. */
+  readonly stats: { denied: number; rateLimited: number; malformed: number; served: number }
+}
+
+export type BridgeOptions = {
+  readonly packId: string
+  readonly granted: readonly Capability[]
+  readonly services: HostServices
+  /** Injectable so a test does not sleep. Milliseconds. */
+  readonly now?: () => number
+  readonly maxRequestsPerSecond?: number
+}
+
+const ok = (id: number, result: unknown): Response => ({ id, ok: true, result })
+const err = (id: number, code: ErrorCode, message: string): Response => ({
+  id,
+  ok: false,
+  error: { code, message },
+})
+
+export function createBridge(options: BridgeOptions): Bridge {
+  const { packId, granted, services } = options
+  const now = options.now ?? (() => Date.now())
+  const limit = options.maxRequestsPerSecond ?? MAX_REQUESTS_PER_SECOND
+  const stats = { denied: 0, rateLimited: 0, malformed: 0, served: 0 }
+
+  /**
+   * A sliding one-second window rather than a token bucket: the rule the SDK
+   * documents is "requests per second", and a bucket with a refill rate is a
+   * different rule that is only approximately that one.
+   */
+  const window: number[] = []
+  const withinRate = (): boolean => {
+    const cutoff = now() - 1000
+    while (window.length > 0 && (window[0] ?? 0) <= cutoff) window.shift()
+    if (window.length >= limit) return false
+    window.push(now())
+    return true
+  }
+
+  const dispatch = async (
+    id: number,
+    method: Method,
+    params: Readonly<Record<string, unknown>>,
+  ): Promise<Response | null> => {
+    switch (method) {
+      case "session.settings":
+        return ok(id, services.settings())
+
+      case "session.progress": {
+        const fraction = numberParam(params, "fraction", 1)
+        if (fraction === null) return err(id, "invalid_params", "fraction must be 0–1")
+        services.progress({ packId, fraction })
+        return ok(id, null)
+      }
+
+      case "session.end": {
+        const reason = params["reason"]
+        if (reason !== "finished" && reason !== "quit") {
+          return err(id, "invalid_params", "reason must be finished or quit")
+        }
+        services.end({ packId, reason })
+        return ok(id, null)
+      }
+
+      case "items.next": {
+        const skillId = stringParam(params, "skillId", 128)
+        const item = await services.nextItem(skillId === null ? { packId } : { packId, skillId })
+        return ok(id, { item })
+      }
+
+      case "items.answer": {
+        const itemId = stringParam(params, "itemId", 128)
+        // A response can be long — a pack may collect a written expression —
+        // but it is bounded, and it is a string so no float ever enters here.
+        const response = stringParam(params, "response", 256)
+        const latencyMs = numberParam(params, "latencyMs", MAX_LATENCY_MS)
+        const revisions = numberParam(params, "revisions", MAX_REVISIONS)
+        if (itemId === null || response === null || latencyMs === null || revisions === null) {
+          return err(id, "invalid_params", "itemId, response, latencyMs and revisions are required")
+        }
+        const judgement = await services.judge({
+          packId,
+          itemId,
+          response,
+          latencyMs,
+          revisions: Math.round(revisions),
+        })
+        return ok(id, judgement)
+      }
+
+      case "items.skip": {
+        const itemId = stringParam(params, "itemId", 128)
+        if (itemId === null) return err(id, "invalid_params", "itemId is required")
+        await services.skip({ packId, itemId })
+        return ok(id, null)
+      }
+
+      case "items.reveal": {
+        const itemId = stringParam(params, "itemId", 128)
+        if (itemId === null) return err(id, "invalid_params", "itemId is required")
+        return ok(id, { canonical: await services.reveal({ packId, itemId }) })
+      }
+
+      case "learner.summary":
+        return ok(id, await services.learnerSummary({ packId }))
+
+      case "feedback.haptic": {
+        const cue = params["cue"]
+        if (!HAPTIC_CUES.includes(cue as HapticCue)) {
+          return err(id, "invalid_params", "cue is not one of the named haptics")
+        }
+        await services.haptic({ packId, cue: cue as HapticCue })
+        return ok(id, null)
+      }
+
+      case "feedback.sound": {
+        const cue = params["cue"]
+        if (!SOUND_CUES.includes(cue as SoundCue)) {
+          return err(id, "invalid_params", "cue is not one of the named sounds")
+        }
+        await services.sound({ packId, cue: cue as SoundCue })
+        return ok(id, null)
+      }
+
+      case "milestone.reach": {
+        const name = stringParam(params, "name", 64)
+        if (name === null) return err(id, "invalid_params", "name is required")
+        await services.milestone({ packId, name })
+        return ok(id, null)
+      }
+
+      case "storage.get": {
+        const key = stringParam(params, "key", MAX_STORAGE_KEY_LENGTH)
+        if (key === null) return err(id, "invalid_params", "key is required")
+        return ok(id, { value: await services.storage.get({ packId, key }) })
+      }
+
+      case "storage.set": {
+        const key = stringParam(params, "key", MAX_STORAGE_KEY_LENGTH)
+        const value = params["value"]
+        if (key === null) return err(id, "invalid_params", "key is required")
+        if (typeof value !== "string") return err(id, "invalid_params", "value must be a string")
+        if (value.length > MAX_STORAGE_VALUE_LENGTH) {
+          return err(id, "quota", `a value is capped at ${MAX_STORAGE_VALUE_LENGTH} characters`)
+        }
+        const existing = await services.storage.keys({ packId })
+        if (!existing.includes(key) && existing.length >= MAX_STORAGE_KEYS) {
+          return err(id, "quota", `a pack may keep ${MAX_STORAGE_KEYS} keys`)
+        }
+        await services.storage.set({ packId, key, value })
+        return ok(id, null)
+      }
+
+      case "storage.remove": {
+        const key = stringParam(params, "key", MAX_STORAGE_KEY_LENGTH)
+        if (key === null) return err(id, "invalid_params", "key is required")
+        await services.storage.remove({ packId, key })
+        return ok(id, null)
+      }
+
+      case "storage.keys":
+        return ok(id, { keys: await services.storage.keys({ packId }) })
+    }
+  }
+
+  return {
+    stats,
+    handle: async (message: unknown): Promise<Response | null> => {
+      const parsed = parseRequest(message)
+      if (!parsed.ok) {
+        stats.malformed += 1
+        // A message with no readable id cannot be answered — replying with a
+        // made-up id would resolve a promise the pack is holding for something
+        // else. It is dropped, and counted.
+        const id = (message as { id?: unknown })?.id
+        if (typeof id !== "number" || !Number.isSafeInteger(id) || id < 0) return null
+        return err(id, parsed.code, parsed.message)
+      }
+
+      const { id, method, params } = parsed.request
+
+      if (!permits(granted, method)) {
+        stats.denied += 1
+        return err(id, "denied", `${method} was not granted to this pack`)
+      }
+
+      if (!withinRate()) {
+        stats.rateLimited += 1
+        return err(id, "rate_limited", `at most ${limit} requests per second`)
+      }
+
+      try {
+        const response = await dispatch(id, method, params)
+        stats.served += 1
+        return response
+      } catch (error) {
+        // The pack is told that it failed and nothing else. A host stack trace
+        // is not a pack's business and is not a child's.
+        console.error(`[packs] ${packId} ${method} failed`, error)
+        return err(id, "internal", "the app could not do that")
+      }
+    },
+  }
+}

--- a/dynawalla/dynawalla-app/src/packs/catalog.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/catalog.test.ts
@@ -1,0 +1,79 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { parseCatalog } from "./catalog.ts"
+import { SDK_VERSION } from "../../../packs/sdk/src/index.ts"
+
+const entry = (overrides: Record<string, unknown> = {}) => ({
+  schema: 1,
+  id: "abacus.tower",
+  version: "1.2.0",
+  name: "Abacus Tower",
+  description: "Carry beads up the tower.",
+  sdk: SDK_VERSION,
+  host: { min: "0.3.0" },
+  entry: "index.html",
+  capabilities: ["items"],
+  covers: { skills: ["add.2digit.regroup"], grades: [1, 3] },
+  locales: ["en"],
+  assets: { files: 12, bytes: 400_000 },
+  download: {
+    url: "https://encorpora.io/dynawalla/packs/a.zip",
+    bytes: 90_000,
+    sha256: "a".repeat(64),
+  },
+  ...overrides,
+})
+
+const catalog = (packs: unknown[], schema = 1) => JSON.stringify({ schema, packs })
+
+test("a catalogue of manifests parses into manifests", () => {
+  const result = parseCatalog(catalog([entry(), entry({ id: "other.pack" })]))
+  assert.equal(result.ok, true)
+  if (!result.ok) return
+  assert.deepEqual(
+    result.packs.map((pack) => pack.id),
+    ["abacus.tower", "other.pack"],
+  )
+  assert.deepEqual(result.rejected, [])
+})
+
+test("one bad entry does not hide the good ones", () => {
+  // A malformed pack must not take forty others off a child's shelf.
+  const result = parseCatalog(catalog([entry(), { schema: 1, id: "junk" }, entry({ id: "third.pack" })]))
+  assert.equal(result.ok, true)
+  if (!result.ok) return
+  assert.deepEqual(
+    result.packs.map((pack) => pack.id),
+    ["abacus.tower", "third.pack"],
+  )
+  assert.equal(result.rejected.length, 1)
+  assert.equal(result.rejected[0]?.index, 1)
+  assert.ok((result.rejected[0]?.problems ?? []).length > 0)
+})
+
+test("a duplicated id is rejected, because an id has one artefact", () => {
+  const result = parseCatalog(catalog([entry(), entry({ version: "1.3.0" })]))
+  assert.equal(result.ok, true)
+  if (!result.ok) return
+  assert.equal(result.packs.length, 1)
+  assert.match(result.rejected[0]?.problems[0] ?? "", /duplicate/)
+})
+
+test("a catalogue that is not a catalogue fails as a whole", () => {
+  for (const text of ["", "not json", "[]", "null", '"a string"', "7"]) {
+    assert.equal(parseCatalog(text).ok, false, `${text} parsed`)
+  }
+  const wrongSchema = parseCatalog(catalog([entry()], 2))
+  assert.equal(wrongSchema.ok, false)
+  if (!wrongSchema.ok) assert.match(wrongSchema.problem, /schema/)
+
+  const noPacks = parseCatalog(JSON.stringify({ schema: 1 }))
+  assert.equal(noPacks.ok, false)
+})
+
+test("an empty catalogue is a catalogue", () => {
+  const result = parseCatalog(catalog([]))
+  assert.equal(result.ok, true)
+  if (result.ok) assert.deepEqual(result.packs, [])
+})

--- a/dynawalla/dynawalla-app/src/packs/catalog.ts
+++ b/dynawalla/dynawalla-app/src/packs/catalog.ts
@@ -1,0 +1,72 @@
+// The catalogue: a list of manifests, and nothing else.
+//
+// There is no second schema for "the catalogue's idea of a pack" — the entries
+// ARE manifests, validated by the same parser the installed copy goes through.
+// Corpán learned the alternative the expensive way: a catalogue that carries
+// its own version field next to the artefact's produces drift between what was
+// advertised and what was downloaded, and every consumer then has to decide
+// which one it believes.
+//
+// Fetching is native (`packs_catalog`), because the WebView's `connect-src` is
+// closed and the origin is pinned in Rust. This module only ever sees text.
+
+import type { PackManifest } from "../../../packs/sdk/src/index.ts"
+import { parseManifest } from "../../../packs/sdk/src/index.ts"
+
+export const CATALOG_SCHEMA = 1
+
+export type CatalogResult =
+  | {
+      readonly ok: true
+      readonly packs: readonly PackManifest[]
+      /**
+       * Entries that did not validate, with their reasons.
+       *
+       * A bad entry does not fail the catalogue: one malformed pack must not
+       * hide the other forty from a child. It is reported so it is visible in
+       * a log rather than silently absent.
+       */
+      readonly rejected: readonly { readonly index: number; readonly problems: readonly string[] }[]
+    }
+  | { readonly ok: false; readonly problem: string }
+
+export function parseCatalog(text: string): CatalogResult {
+  let document: unknown
+  try {
+    document = JSON.parse(text)
+  } catch {
+    return { ok: false, problem: "the catalogue is not JSON" }
+  }
+  if (typeof document !== "object" || document === null || Array.isArray(document)) {
+    return { ok: false, problem: "the catalogue is not an object" }
+  }
+  const record = document as Record<string, unknown>
+  if (record["schema"] !== CATALOG_SCHEMA) {
+    return { ok: false, problem: `the catalogue is schema ${String(record["schema"])}, not ${CATALOG_SCHEMA}` }
+  }
+  const entries = record["packs"]
+  if (!Array.isArray(entries)) {
+    return { ok: false, problem: "the catalogue has no packs array" }
+  }
+
+  const packs: PackManifest[] = []
+  const rejected: { index: number; problems: readonly string[] }[] = []
+  const seen = new Set<string>()
+  entries.forEach((entry, index) => {
+    const parsed = parseManifest(entry)
+    if (!parsed.ok) {
+      rejected.push({ index, problems: parsed.problems })
+      return
+    }
+    if (seen.has(parsed.manifest.id)) {
+      // Two entries for one id means the catalogue cannot say which artefact an
+      // id refers to, which is the one thing an id is for.
+      rejected.push({ index, problems: [`duplicate pack id: ${parsed.manifest.id}`] })
+      return
+    }
+    seen.add(parsed.manifest.id)
+    packs.push(parsed.manifest)
+  })
+
+  return { ok: true, packs, rejected }
+}

--- a/dynawalla/dynawalla-app/src/packs/frame.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/frame.test.ts
@@ -1,0 +1,252 @@
+// The isolation, asserted rather than described.
+//
+// `mountPack` takes its `document` and `window`, so the whole handshake runs in
+// Node against a fake frame and a real `MessageChannel`. What cannot be tested
+// here is the WebView's enforcement of the sandbox attribute — but the
+// attribute itself is the entire boundary, and an edit that drops
+// `allow-same-origin` back in would be invisible in every other test in this
+// repository. This is the one that fails.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { mountPack } from "./frame.ts"
+import type { HostServices } from "./bridge.ts"
+import type { Capability, Connect, Settings } from "../../../packs/sdk/src/index.ts"
+
+const SETTINGS: Settings = {
+  locale: "en",
+  reducedMotion: false,
+  quality: "high",
+  textScale: 1,
+  colorScheme: "light",
+  sound: true,
+  haptics: true,
+}
+
+const services = (): HostServices => ({
+  nextItem: async () => null,
+  judge: async () => ({ correct: true, canonical: "2203", advance: true }),
+  skip: async () => {},
+  reveal: async () => "2203",
+  learnerSummary: async () => ({ skills: [] }),
+  haptic: async () => {},
+  sound: async () => {},
+  milestone: async () => {},
+  storage: {
+    get: async () => null,
+    set: async () => {},
+    remove: async () => {},
+    keys: async () => [],
+  },
+  progress: () => {},
+  end: () => {},
+  settings: () => SETTINGS,
+})
+
+type Posted = { data: unknown; targetOrigin: string; transfer: readonly MessagePort[] }
+
+type Harness = {
+  mounted: ReturnType<typeof mountPack>
+  frame: Record<string, unknown>
+  posted: Posted[]
+  children: unknown[]
+  listeners: Map<string, Set<(event: unknown) => void>>
+  removed: boolean
+  fire(event: { source: unknown; data: unknown }): void
+}
+
+function harness(granted: readonly Capability[] = ["items"]): Harness {
+  const posted: Posted[] = []
+  const children: unknown[] = []
+  const listeners = new Map<string, Set<(event: unknown) => void>>()
+  const attributes = new Map<string, string>()
+  const state = { removed: false }
+
+  const contentWindow = {
+    postMessage: (data: unknown, targetOrigin: string, transfer: readonly MessagePort[] = []) => {
+      posted.push({ data, targetOrigin, transfer })
+    },
+  }
+
+  const frame: Record<string, unknown> = {
+    contentWindow,
+    setAttribute: (name: string, value: string) => attributes.set(name, value),
+    getAttribute: (name: string) => attributes.get(name) ?? null,
+    addEventListener: () => {},
+    remove: () => {
+      state.removed = true
+    },
+  }
+
+  const doc = { createElement: () => frame } as unknown as Document
+  const win = {
+    addEventListener: (type: string, listener: (event: unknown) => void) => {
+      const set = listeners.get(type) ?? new Set()
+      set.add(listener)
+      listeners.set(type, set)
+    },
+    removeEventListener: (type: string, listener: (event: unknown) => void) => {
+      listeners.get(type)?.delete(listener)
+    },
+  } as unknown as Window
+
+  const container = {
+    appendChild: (child: unknown) => children.push(child),
+  } as unknown as HTMLElement
+
+  const mounted = mountPack({
+    container,
+    packId: "abacus.tower",
+    entryUrl: "dynawalla-pack://localhost/abacus.tower/index.html",
+    granted,
+    services: services(),
+    hostVersion: "0.4.0",
+    title: "Abacus Tower",
+    document: doc,
+    window: win,
+  })
+
+  return {
+    mounted,
+    frame,
+    posted,
+    children,
+    listeners,
+    get removed() {
+      return state.removed
+    },
+    fire: (event) => {
+      for (const listener of [...(listeners.get("message") ?? [])]) listener(event)
+    },
+  }
+}
+
+const shake = (test: Harness) => test.fire({ source: test.frame["contentWindow"], data: { event: "ready" } })
+
+test("the frame is sandboxed without allow-same-origin — this is the boundary", () => {
+  const test = harness()
+  const sandbox = (test.frame["getAttribute"] as (n: string) => string | null)("sandbox")
+  assert.equal(sandbox, "allow-scripts")
+  assert.ok(!sandbox?.includes("allow-same-origin"), "the pack would share the app's origin")
+  assert.ok(!sandbox?.includes("allow-top-navigation"), "a pack could replace the app")
+  assert.ok(!sandbox?.includes("allow-popups"))
+  test.mounted.dispose()
+})
+
+test("the frame asks for no device permissions and leaks no referrer", () => {
+  const test = harness()
+  const get = test.frame["getAttribute"] as (n: string) => string | null
+  assert.equal(get("allow"), "", "a permissions-policy grant would reach the camera or the mic")
+  assert.equal(get("referrerpolicy"), "no-referrer")
+  test.mounted.dispose()
+})
+
+test("the pack is framed at the pack scheme and nothing else", () => {
+  const test = harness()
+  assert.match(String(test.frame["src"]), /^dynawalla-pack:\/\//)
+  assert.equal(test.children.length, 1)
+  test.mounted.dispose()
+})
+
+test("a ready from anywhere but this frame is ignored", () => {
+  // `event.origin` is the string "null" for a sandboxed frame and authenticates
+  // nothing. The frame identity is the only thing that can.
+  const test = harness()
+  test.fire({ source: { not: "our frame" }, data: { event: "ready" } })
+  test.fire({ source: test.frame["contentWindow"], data: { event: "hello" } })
+  test.fire({ source: test.frame["contentWindow"], data: null })
+  assert.equal(test.mounted.connected(), false)
+  assert.deepEqual(test.posted, [])
+  test.mounted.dispose()
+})
+
+test("the handshake transfers exactly one port and states the grant set", () => {
+  const test = harness(["items", "haptics"])
+  shake(test)
+  assert.equal(test.mounted.connected(), true)
+  assert.equal(test.posted.length, 1)
+
+  const message = test.posted[0]
+  assert.equal(message?.transfer.length, 1, "the port IS the grant")
+  // An opaque origin cannot be named, so the payload must carry no secret.
+  assert.equal(message?.targetOrigin, "*")
+
+  const connect = message?.data as Connect
+  assert.equal(connect.event, "connect")
+  assert.equal(connect.packId, "abacus.tower")
+  assert.equal(connect.host, "0.4.0")
+  assert.deepEqual(connect.granted, ["items", "haptics"])
+  assert.deepEqual(connect.settings, SETTINGS)
+  test.mounted.dispose()
+})
+
+test("a second ready does not hand out a second port", () => {
+  const test = harness()
+  shake(test)
+  shake(test)
+  assert.equal(test.posted.length, 1)
+  test.mounted.dispose()
+})
+
+test("traffic on the port reaches the bridge and comes back", async () => {
+  const test = harness(["items"])
+  shake(test)
+  const packPort = test.posted[0]?.transfer[0]
+  assert.ok(packPort)
+
+  const replies: unknown[] = []
+  packPort.onmessage = (event: MessageEvent) => replies.push(event.data)
+  packPort.start()
+  packPort.postMessage({ id: 1, method: "items.next", params: {} })
+  // And something the pack was not granted, to prove the bridge is in the path.
+  packPort.postMessage({ id: 2, method: "storage.get", params: { key: "k" } })
+
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  assert.deepEqual(replies[0], { id: 1, ok: true, result: { item: null } })
+  assert.deepEqual(replies[1], { id: 2, ok: false, error: { code: "denied", message: "storage.get was not granted to this pack" } })
+  packPort.close()
+  test.mounted.dispose()
+})
+
+test("host events only go out once a pack is connected", () => {
+  const test = harness()
+  test.mounted.send("pause")
+  assert.deepEqual(test.posted, [], "an event was sent to a frame that had not connected")
+  test.mounted.dispose()
+})
+
+test("dispose is idempotent, unhooks the listener and destroys the frame", () => {
+  const test = harness()
+  shake(test)
+  assert.equal(test.listeners.get("message")?.size, 1)
+
+  test.mounted.dispose()
+  test.mounted.dispose()
+
+  assert.equal(test.listeners.get("message")?.size, 0, "a message listener outlived the pack")
+  assert.equal(test.removed, true, "the frame element was left in the document")
+  assert.equal(test.frame["src"], "about:blank")
+})
+
+test("dispose before the handshake is safe, and the frame never connects afterwards", () => {
+  const test = harness()
+  test.mounted.dispose()
+  shake(test)
+  assert.equal(test.mounted.connected(), false)
+  assert.deepEqual(test.posted, [])
+})
+
+test("mounting twice makes two independent packs — StrictMode does exactly this", () => {
+  // Two Babylon engines in one console is the tell for the bug this prevents.
+  // The contract is that disposing the first leaves the second untouched.
+  const first = harness()
+  const second = harness()
+  shake(first)
+  shake(second)
+  first.mounted.dispose()
+
+  assert.equal(second.mounted.connected(), true)
+  assert.equal(second.removed, false)
+  second.mounted.dispose()
+})

--- a/dynawalla/dynawalla-app/src/packs/frame.ts
+++ b/dynawalla/dynawalla-app/src/packs/frame.ts
@@ -1,0 +1,177 @@
+// Mounting a pack: the sandbox, the handshake, and taking it all down again.
+//
+// ── Why an iframe ────────────────────────────────────────────────────────────
+// The obvious way to run a pack is a `<script>` tag, and it is what Corpán
+// does. It puts pack code in the host's own realm, where `window.__TAURI__`,
+// every store, the DOM and each other pack are all reachable, and the
+// "capability boundary" is then a naming convention: a pack that does not use
+// the host API is not prevented from anything, it merely did not ask nicely.
+//
+// This mounts the pack in an iframe with `sandbox="allow-scripts"` and NOT
+// `allow-same-origin`. That single omission is the whole boundary:
+//
+//   * the frame's origin is opaque, so `window.parent` is cross-origin and
+//     unreadable — the pack cannot reach the Tauri bridge, the practice store,
+//     or another pack;
+//   * there is no localStorage, no IndexedDB, no cookies, so a pack cannot
+//     keep anything the host did not agree to keep for it (which is what the
+//     `storage` capability is);
+//   * top-level navigation is blocked, so a pack cannot replace the app.
+//
+// What it gets instead is one `MessagePort`, and everything on that port goes
+// through `bridge.ts`. Handing over a port is the act of granting; there is no
+// way for a frame to obtain one by asking.
+//
+// The cost is that the pack's own CSP cannot use `'self'` — an opaque origin
+// matches nothing — which is why the Rust scheme handler names the scheme
+// explicitly in the policy it serves.
+
+import type { Capability, Connect, HostEventName, Settings } from "../../../packs/sdk/src/index.ts"
+import { PROTOCOL_VERSION, SDK_VERSION } from "../../../packs/sdk/src/index.ts"
+import type { Bridge, HostServices } from "./bridge.ts"
+import { createBridge } from "./bridge.ts"
+
+/** A pack that has not said `ready` by now is not going to. */
+const HANDSHAKE_TIMEOUT_MS = 20_000
+
+export type MountOptions = {
+  readonly container: HTMLElement
+  readonly packId: string
+  /** From `packs_entry_url`. Always on the pack scheme. */
+  readonly entryUrl: string
+  readonly granted: readonly Capability[]
+  readonly services: HostServices
+  readonly hostVersion: string
+  /** The frame's accessible name. A pack is a region of the app, not a picture. */
+  readonly title: string
+  readonly onError?: (reason: string) => void
+  /** Injected in tests. Defaults to the real document. */
+  readonly document?: Document
+  readonly window?: Window
+}
+
+export type MountedPack = {
+  readonly element: HTMLIFrameElement
+  readonly bridge: Bridge
+  /** True once the pack has completed the handshake. */
+  readonly connected: () => boolean
+  send(event: HostEventName, data?: unknown): void
+  pushSettings(settings: Settings): void
+  dispose(): void
+}
+
+/**
+ * Frame a pack and connect it.
+ *
+ * Idempotent teardown is the whole of the lifecycle contract: `dispose` may be
+ * called twice, may be called before the handshake completes, and must leave no
+ * listener, no port and no element behind. React's StrictMode calls the effect
+ * cleanup on the first mount, and a pack runtime that leaks one engine per
+ * mount is the failure this repository has already paid for once.
+ */
+export function mountPack(options: MountOptions): MountedPack {
+  const doc = options.document ?? document
+  const win = options.window ?? window
+
+  const bridge = createBridge({
+    packId: options.packId,
+    granted: options.granted,
+    services: options.services,
+  })
+
+  const frame = doc.createElement("iframe")
+  frame.title = options.title
+  frame.className = "pack-frame"
+  // No `allow-same-origin`. See the module note — this is the boundary.
+  frame.setAttribute("sandbox", "allow-scripts")
+  // Nothing in the permissions policy: no camera, no microphone, no geolocation,
+  // no autoplay grant. A pack asks the host for feedback, it does not take it.
+  frame.setAttribute("allow", "")
+  frame.setAttribute("referrerpolicy", "no-referrer")
+  frame.setAttribute("loading", "eager")
+
+  let channel: MessageChannel | null = null
+  let connected = false
+  let disposed = false
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  const onReady = (event: MessageEvent) => {
+    // The only thing that authenticates this message is the frame it came from.
+    // `event.origin` is `"null"` for a sandboxed frame and is worth nothing.
+    if (disposed || connected) return
+    if (event.source !== frame.contentWindow) return
+    const data: unknown = event.data
+    if (typeof data !== "object" || data === null) return
+    if ((data as { event?: unknown }).event !== "ready") return
+
+    connected = true
+    if (timer !== null) clearTimeout(timer)
+    timer = null
+
+    channel = new MessageChannel()
+    channel.port1.onmessage = (message: MessageEvent) => {
+      void bridge.handle(message.data).then((response) => {
+        if (response !== null && !disposed) channel?.port1.postMessage(response)
+      })
+    }
+    channel.port1.start()
+
+    const connect: Connect = {
+      event: "connect",
+      protocol: PROTOCOL_VERSION,
+      sdk: SDK_VERSION,
+      host: options.hostVersion,
+      packId: options.packId,
+      granted: options.granted,
+      settings: options.services.settings(),
+    }
+    // `"*"` because an opaque origin cannot be named. The payload is not a
+    // secret; the transferred port is the grant, and only this frame receives
+    // it. `frame-src` in the app's CSP is what keeps this frame from being
+    // navigated somewhere else first.
+    frame.contentWindow?.postMessage(connect, "*", [channel.port2])
+  }
+
+  win.addEventListener("message", onReady)
+
+  timer = setTimeout(() => {
+    if (connected || disposed) return
+    options.onError?.("This pack did not start.")
+  }, HANDSHAKE_TIMEOUT_MS)
+
+  frame.addEventListener("error", () => options.onError?.("This pack could not be opened."))
+  frame.src = options.entryUrl
+  options.container.appendChild(frame)
+
+  const send = (event: HostEventName, data?: unknown) => {
+    if (!connected || disposed) return
+    channel?.port1.postMessage(data === undefined ? { event } : { event, data })
+  }
+
+  return {
+    element: frame,
+    bridge,
+    connected: () => connected,
+    send,
+    pushSettings: (settings) => send("settings", settings),
+    dispose: () => {
+      if (disposed) return
+      disposed = true
+      if (timer !== null) clearTimeout(timer)
+      timer = null
+      // Tell the pack first, so it can stop its own loop before its port dies.
+      if (connected) channel?.port1.postMessage({ event: "dispose" })
+      win.removeEventListener("message", onReady)
+      if (channel) {
+        channel.port1.onmessage = null
+        channel.port1.close()
+        channel.port2.close()
+        channel = null
+      }
+      // Blanking `src` before removal stops an in-flight load; removing the
+      // element is what destroys the frame's realm and everything in it.
+      frame.src = "about:blank"
+      frame.remove()
+    },
+  }
+}

--- a/dynawalla/dynawalla-app/src/packs/gate.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/gate.test.ts
@@ -1,0 +1,134 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { gateInstall, gateRun } from "./gate.ts"
+import type { HostProfile } from "./gate.ts"
+import { SDK_VERSION } from "../../../packs/sdk/src/index.ts"
+
+const host: HostProfile = {
+  version: "0.4.0",
+  supports: ["items", "items.reveal", "learner.read", "haptics", "audio", "milestones", "storage"],
+}
+
+const manifest = (overrides: Record<string, unknown> = {}) => ({
+  schema: 1,
+  id: "abacus.tower",
+  version: "1.2.0",
+  name: "Abacus Tower",
+  description: "Carry beads up the tower.",
+  sdk: SDK_VERSION,
+  host: { min: "0.3.0", max: "1.0.0" },
+  entry: "index.html",
+  capabilities: ["items", "haptics"],
+  covers: { skills: ["add.2digit.regroup"], grades: [1, 3] },
+  locales: ["en"],
+  assets: { files: 12, bytes: 400_000 },
+  download: { url: "https://encorpora.io/dynawalla/packs/a.zip", bytes: 90_000, sha256: "a".repeat(64) },
+  ...overrides,
+})
+
+test("a fresh pack that fits installs", () => {
+  const verdict = gateInstall({ raw: manifest(), host })
+  assert.equal(verdict.ok, true)
+  if (!verdict.ok) return
+  assert.equal(verdict.action, "install")
+})
+
+test("a newer version of an installed pack is an upgrade", () => {
+  const verdict = gateInstall({ raw: manifest(), host, installedVersion: "1.1.9" })
+  assert.equal(verdict.ok, true)
+  if (!verdict.ok) return
+  assert.equal(verdict.action, "upgrade")
+})
+
+test("the same version is not an upgrade, and an older one is refused outright", () => {
+  const same = gateInstall({ raw: manifest(), host, installedVersion: "1.2.0" })
+  assert.equal(same.ok, false)
+  if (!same.ok) assert.equal(same.refusal.code, "already_current")
+
+  // A published artefact is immutable, so an older version arriving from the
+  // catalogue means the catalogue is wrong — not that the device is ahead.
+  const older = gateInstall({ raw: manifest(), host, installedVersion: "1.3.0" })
+  assert.equal(older.ok, false)
+  if (!older.ok) assert.equal(older.refusal.code, "downgrade")
+})
+
+test("0.10.0 is newer than 0.9.0 here too", () => {
+  const verdict = gateInstall({
+    raw: manifest({ version: "0.10.0", host: { min: "0.3.0" } }),
+    host,
+    installedVersion: "0.9.0",
+  })
+  assert.equal(verdict.ok, true)
+  if (verdict.ok) assert.equal(verdict.action, "upgrade")
+})
+
+test("a host outside the declared range is refused with both bounds named", () => {
+  const tooOld = gateInstall({ raw: manifest(), host: { ...host, version: "0.2.0" } })
+  assert.equal(tooOld.ok, false)
+  if (!tooOld.ok) {
+    assert.equal(tooOld.refusal.code, "host_version")
+    assert.match(tooOld.refusal.message, /0\.3\.0/)
+    assert.match(tooOld.refusal.message, /1\.0\.0/)
+    assert.match(tooOld.refusal.message, /0\.2\.0/)
+  }
+
+  const tooNew = gateInstall({ raw: manifest(), host: { ...host, version: "1.0.0" } })
+  assert.equal(tooNew.ok, false, "host.max is exclusive")
+})
+
+test("a pack built against a newer SDK than this host implements is refused", () => {
+  const verdict = gateInstall({ raw: manifest({ sdk: "1.9.0" }), host })
+  assert.equal(verdict.ok, false)
+  if (!verdict.ok) assert.equal(verdict.refusal.code, "sdk_version")
+})
+
+test("a capability this build cannot honour is refused by name", () => {
+  const verdict = gateInstall({
+    raw: manifest({ capabilities: ["items", "audio"] }),
+    host: { ...host, supports: ["items"] },
+  })
+  assert.equal(verdict.ok, false)
+  if (!verdict.ok) {
+    assert.equal(verdict.refusal.code, "capability")
+    assert.match(verdict.refusal.message, /audio/)
+  }
+})
+
+test("a manifest that is not a manifest carries every reason with it", () => {
+  const verdict = gateInstall({ raw: { schema: 1, id: "X" }, host })
+  assert.equal(verdict.ok, false)
+  if (!verdict.ok) {
+    assert.equal(verdict.refusal.code, "manifest")
+    assert.ok((verdict.refusal.problems ?? []).length > 3)
+  }
+})
+
+test("the gate is asked again at launch, because the app is what changes", () => {
+  // Installed under 0.4.0, still fine. Then the app grows past the ceiling and
+  // the same bytes on disk must stop launching rather than fail inside a game.
+  const raw = manifest()
+  assert.equal(gateRun({ raw, host }).ok, true)
+
+  const later = gateRun({ raw, host: { ...host, version: "1.4.0" } })
+  assert.equal(later.ok, false)
+  if (!later.ok) {
+    assert.equal(later.refusal.code, "host_version")
+    assert.match(later.refusal.message, /update/i, "a refusal should say what can be done")
+  }
+})
+
+test("the grant set is the intersection, so a pack cannot outlive a capability", () => {
+  // Installed while this build supported haptics; the build no longer does.
+  // The pack still runs, with `haptics` simply absent from its grants.
+  const verdict = gateRun({ raw: manifest(), host: { ...host, supports: ["items"] } })
+  assert.equal(verdict.ok, true)
+  if (!verdict.ok) return
+  assert.deepEqual(verdict.granted, ["items"])
+})
+
+test("a damaged installed manifest does not launch", () => {
+  const verdict = gateRun({ raw: { schema: 1 }, host })
+  assert.equal(verdict.ok, false)
+  if (!verdict.ok) assert.equal(verdict.refusal.code, "manifest")
+})

--- a/dynawalla/dynawalla-app/src/packs/gate.ts
+++ b/dynawalla/dynawalla-app/src/packs/gate.ts
@@ -1,0 +1,176 @@
+// Whether a pack may be installed, and whether an installed pack may run.
+//
+// Two questions, asked at two different times, and the second is the one that
+// is easy to forget: a pack passes the install gate once, and then the host is
+// upgraded twenty times underneath it. A pack whose `host.max` the app has
+// grown past must stop running — quietly refusing to launch with a reason the
+// parent can act on, rather than mounting and failing somewhere inside a game.
+//
+// Nothing here does IO, so all of it is decided in a Node test.
+
+import type { Capability, PackManifest } from "../../../packs/sdk/src/index.ts"
+import {
+  compareVersions,
+  parseManifest,
+  satisfies,
+  sdkCompatible,
+  SDK_VERSION,
+} from "../../../packs/sdk/src/index.ts"
+
+export type RefusalCode =
+  /** The manifest is not a manifest. */
+  | "manifest"
+  /** This app is older or newer than the pack supports. */
+  | "host_version"
+  /** The pack was built against an SDK this host does not implement. */
+  | "sdk_version"
+  /** The pack asks for something this build cannot do at all. */
+  | "capability"
+  /** The catalogue is offering what is already installed. */
+  | "already_current"
+  /** The catalogue is offering something older than what is installed. */
+  | "downgrade"
+
+export type Refusal = {
+  readonly code: RefusalCode
+  /** One sentence. Not shown raw to a child; the shell decides the wording. */
+  readonly message: string
+  /** Every schema problem, when the code is `manifest`. */
+  readonly problems?: readonly string[]
+}
+
+export type InstallVerdict =
+  | { readonly ok: true; readonly manifest: PackManifest; readonly action: "install" | "upgrade" }
+  | { readonly ok: false; readonly refusal: Refusal }
+
+export type HostProfile = {
+  /** The app's own version, from `package.json` via `__APP_VERSION__`. */
+  readonly version: string
+  /** The SDK version this host implements. Defaults to the SDK's own. */
+  readonly sdk?: string
+  /**
+   * Capabilities this build can honour at all.
+   *
+   * Not the same as what a pack is granted: a capability missing from here is a
+   * thing the app cannot do on any device (no audio subsystem compiled in), and
+   * a pack that requires it is refused rather than mounted and disappointed.
+   */
+  readonly supports: readonly Capability[]
+}
+
+const refuse = (code: RefusalCode, message: string, problems?: readonly string[]): InstallVerdict =>
+  problems ? { ok: false, refusal: { code, message, problems } } : { ok: false, refusal: { code, message } }
+
+/**
+ * The whole install decision, from an untrusted manifest to a verdict.
+ *
+ * Order matters and is the order a parent would ask the questions in: is this a
+ * manifest at all, does it run here, does it want anything we cannot give, and
+ * only then is it worth downloading.
+ */
+export function gateInstall(input: {
+  readonly raw: unknown
+  readonly host: HostProfile
+  /** The version already on disk, if any. */
+  readonly installedVersion?: string
+}): InstallVerdict {
+  const parsed = parseManifest(input.raw)
+  if (!parsed.ok) {
+    return refuse("manifest", "This pack's manifest is not valid.", parsed.problems)
+  }
+  const manifest = parsed.manifest
+
+  if (!satisfies(input.host.version, manifest.host)) {
+    const ceiling = manifest.host.max ? ` and below ${manifest.host.max}` : ""
+    return refuse(
+      "host_version",
+      `This pack needs Dynawalla ${manifest.host.min}${ceiling}; this is ${input.host.version}.`,
+    )
+  }
+
+  const hostSdk = input.host.sdk ?? SDK_VERSION
+  if (!sdkCompatible(manifest.sdk, hostSdk)) {
+    return refuse(
+      "sdk_version",
+      `This pack was built for pack SDK ${manifest.sdk}; this app implements ${hostSdk}.`,
+    )
+  }
+
+  const missing = manifest.capabilities.filter(
+    (capability) => !input.host.supports.includes(capability),
+  )
+  if (missing.length > 0) {
+    return refuse("capability", `This pack needs something this app cannot do: ${missing.join(", ")}.`)
+  }
+
+  if (input.installedVersion !== undefined) {
+    const order = compareVersions(manifest.version, input.installedVersion)
+    if (order === null) {
+      return refuse("manifest", "The installed version is unreadable.")
+    }
+    if (order === 0) {
+      return refuse("already_current", `Version ${manifest.version} is already installed.`)
+    }
+    if (order < 0) {
+      // Never automatic. A published artefact is immutable, so an older version
+      // arriving from the catalogue means the catalogue is wrong, not that the
+      // device is ahead.
+      return refuse(
+        "downgrade",
+        `The catalogue offers ${manifest.version}, which is older than the installed ${input.installedVersion}.`,
+      )
+    }
+    return { ok: true, manifest, action: "upgrade" }
+  }
+
+  return { ok: true, manifest, action: "install" }
+}
+
+export type RunVerdict =
+  | { readonly ok: true; readonly manifest: PackManifest; readonly granted: readonly Capability[] }
+  | { readonly ok: false; readonly refusal: Refusal }
+
+/**
+ * Whether an already-installed pack may be launched now.
+ *
+ * Re-asked every launch rather than cached at install: the app is what changes.
+ * The grant set returned is the intersection of what the pack declared and what
+ * this build supports, so a pack cannot widen its reach by being installed
+ * before a capability was removed.
+ */
+export function gateRun(input: {
+  readonly raw: unknown
+  readonly host: HostProfile
+}): RunVerdict {
+  const parsed = parseManifest(input.raw)
+  if (!parsed.ok) {
+    return { ok: false, refusal: { code: "manifest", message: "This pack is damaged.", problems: parsed.problems } }
+  }
+  const manifest = parsed.manifest
+
+  if (!satisfies(input.host.version, manifest.host)) {
+    return {
+      ok: false,
+      refusal: {
+        code: "host_version",
+        message: `This pack does not run on Dynawalla ${input.host.version}. There may be an update for it.`,
+      },
+    }
+  }
+
+  const hostSdk = input.host.sdk ?? SDK_VERSION
+  if (!sdkCompatible(manifest.sdk, hostSdk)) {
+    return {
+      ok: false,
+      refusal: {
+        code: "sdk_version",
+        message: `This pack was built for pack SDK ${manifest.sdk}. There may be an update for it.`,
+      },
+    }
+  }
+
+  const granted = manifest.capabilities.filter((capability) =>
+    input.host.supports.includes(capability),
+  )
+  return { ok: true, manifest, granted }
+}

--- a/dynawalla/dynawalla-app/src/packs/index.ts
+++ b/dynawalla/dynawalla-app/src/packs/index.ts
@@ -1,0 +1,48 @@
+// The pack runtime, as one surface.
+//
+// A screen imports from here. The split inside is by question, not by layer:
+// `gate` decides whether a pack may run, `install` decides what to put on disk,
+// `catalog` reads what is on offer, `bridge` decides what a running pack may
+// do, and `frame`/`PackFrame` are where it runs. `native` is the only module
+// that touches Tauri, which is why every one of the others is testable in Node.
+
+export { parseCatalog, CATALOG_SCHEMA } from "./catalog.ts"
+export type { CatalogResult } from "./catalog.ts"
+
+export { gateInstall, gateRun } from "./gate.ts"
+export type { HostProfile, InstallVerdict, Refusal, RefusalCode, RunVerdict } from "./gate.ts"
+
+export { installPack, planUpdates, readInstalled, removePack } from "./install.ts"
+export type {
+  Consent,
+  FailureCode,
+  InstallDeps,
+  InstallFailure,
+  InstallOutcome,
+  InstalledPack,
+  ReadResult,
+  UpdateOffer,
+} from "./install.ts"
+
+export {
+  createBridge,
+  MAX_STORAGE_KEYS,
+  MAX_STORAGE_KEY_LENGTH,
+  MAX_STORAGE_VALUE_LENGTH,
+} from "./bridge.ts"
+export type { Bridge, BridgeOptions, HostServices } from "./bridge.ts"
+
+export { mountPack } from "./frame.ts"
+export type { MountOptions, MountedPack } from "./frame.ts"
+
+export { PackFrame } from "./PackFrame.tsx"
+export type { PackFrameProps } from "./PackFrame.tsx"
+
+export { PACK_COMMANDS, tauriNative } from "./native.ts"
+export type {
+  InstallArgs,
+  InstallProgress,
+  InstalledPackRow,
+  PackCommand,
+  PackNative,
+} from "./native.ts"

--- a/dynawalla/dynawalla-app/src/packs/install.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/install.test.ts
@@ -1,0 +1,285 @@
+// Install, upgrade, refuse, remove — every path, with the native side faked.
+//
+// The fake is deliberately dumb: it records what it was asked to do and answers
+// with whatever the test wants. All the behaviour under test is in `install.ts`,
+// which is the point of having a port at all — the interesting cases here
+// (a declined consent, a corrupt archive, a pack that is not what the catalogue
+// said) are ones nobody would reproduce on a device twice.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { installPack, planUpdates, readInstalled, removePack } from "./install.ts"
+import type { Consent, InstallDeps, InstalledPack } from "./install.ts"
+import type { InstallArgs, InstalledPackRow, PackNative } from "./native.ts"
+import type { HostProfile } from "./gate.ts"
+import { parseManifest, SDK_VERSION } from "../../../packs/sdk/src/index.ts"
+import type { PackManifest } from "../../../packs/sdk/src/index.ts"
+
+const host: HostProfile = {
+  version: "0.4.0",
+  supports: ["items", "items.reveal", "learner.read", "haptics", "audio", "milestones", "storage"],
+}
+
+const raw = (overrides: Record<string, unknown> = {}) => ({
+  schema: 1,
+  id: "abacus.tower",
+  version: "1.2.0",
+  name: "Abacus Tower",
+  description: "Carry beads up the tower.",
+  sdk: SDK_VERSION,
+  host: { min: "0.3.0", max: "1.0.0" },
+  entry: "index.html",
+  capabilities: ["items", "haptics"],
+  covers: { skills: ["add.2digit.regroup"], grades: [1, 3] },
+  locales: ["en"],
+  assets: { files: 12, bytes: 400_000 },
+  download: {
+    url: "https://encorpora.io/dynawalla/packs/abacus-tower-1.2.0.zip",
+    bytes: 90_000,
+    sha256: "a".repeat(64),
+  },
+  ...overrides,
+})
+
+const asManifest = (value: unknown): PackManifest => {
+  const parsed = parseManifest(value)
+  assert.equal(parsed.ok, true, parsed.ok ? "" : parsed.problems.join("; "))
+  if (!parsed.ok) throw new Error("unreachable")
+  return parsed.manifest
+}
+
+type Recorder = {
+  native: PackNative
+  installs: InstallArgs[]
+  removals: string[]
+}
+
+function fakeNative(options: {
+  rows?: InstalledPackRow[]
+  onInstall?: (args: InstallArgs) => InstalledPackRow | Error
+  catalog?: string
+} = {}): Recorder {
+  const installs: InstallArgs[] = []
+  const removals: string[] = []
+  return {
+    installs,
+    removals,
+    native: {
+      list: async () => options.rows ?? [],
+      catalog: async () => options.catalog ?? "{}",
+      install: async (args) => {
+        installs.push(args)
+        const result =
+          options.onInstall?.(args) ??
+          ({ id: args.packId, version: args.version, manifest: "{}", bytes: 400_000 } as InstalledPackRow)
+        if (result instanceof Error) throw result
+        return result
+      },
+      remove: async (packId) => {
+        removals.push(packId)
+      },
+      entryUrl: async (packId, entry) => `dynawalla-pack://localhost/${packId}/${entry}`,
+    },
+  }
+}
+
+const deps = (recorder: Recorder, confirm: InstallDeps["confirm"]): InstallDeps => ({
+  native: recorder.native,
+  host,
+  confirm,
+})
+
+const yes = async () => true
+const no = async () => false
+
+test("a fresh install asks first, then downloads exactly what the manifest declared", async () => {
+  const recorder = fakeNative()
+  const seen: Consent[] = []
+  const outcome = await installPack(
+    raw(),
+    [],
+    deps(recorder, async (consent) => {
+      seen.push(consent)
+      return true
+    }),
+  )
+
+  assert.equal(outcome.ok, true)
+  if (!outcome.ok) return
+  assert.equal(outcome.action, "install")
+
+  // The consent sheet carries the two facts a silent install hides.
+  assert.equal(seen.length, 1)
+  assert.equal(seen[0]?.downloadBytes, 90_000)
+  assert.equal(seen[0]?.installedBytes, 400_000)
+  assert.deepEqual(seen[0]?.capabilities, ["items", "haptics"])
+  assert.equal(seen[0]?.name, "Abacus Tower")
+
+  assert.deepEqual(recorder.installs, [
+    {
+      packId: "abacus.tower",
+      version: "1.2.0",
+      url: "https://encorpora.io/dynawalla/packs/abacus-tower-1.2.0.zip",
+      sha256: "a".repeat(64),
+      bytes: 90_000,
+    },
+  ])
+})
+
+test("declining downloads nothing at all", async () => {
+  const recorder = fakeNative()
+  const outcome = await installPack(raw(), [], deps(recorder, no))
+  assert.equal(outcome.ok, false)
+  if (!outcome.ok) assert.equal(outcome.failure.code, "declined")
+  assert.deepEqual(recorder.installs, [], "a declined install still downloaded")
+})
+
+test("the consent sheet is shown before the download, not after", async () => {
+  const order: string[] = []
+  const recorder = fakeNative({
+    onInstall: (args) => {
+      order.push("download")
+      return { id: args.packId, version: args.version, manifest: "{}", bytes: 1 }
+    },
+  })
+  await installPack(
+    raw(),
+    [],
+    deps(recorder, async () => {
+      order.push("ask")
+      return true
+    }),
+  )
+  assert.deepEqual(order, ["ask", "download"])
+})
+
+test("an upgrade is offered as an upgrade and refused when it is a downgrade", async () => {
+  const installed: InstalledPack[] = [{ manifest: asManifest(raw({ version: "1.1.0" })), bytes: 1 }]
+  const upgrade = await installPack(raw(), installed, deps(fakeNative(), yes))
+  assert.equal(upgrade.ok, true)
+  if (upgrade.ok) assert.equal(upgrade.action, "upgrade")
+
+  const ahead: InstalledPack[] = [{ manifest: asManifest(raw({ version: "1.4.0" })), bytes: 1 }]
+  const recorder = fakeNative()
+  const backwards = await installPack(raw(), ahead, deps(recorder, yes))
+  assert.equal(backwards.ok, false)
+  if (!backwards.ok) assert.equal(backwards.failure.code, "downgrade")
+  assert.deepEqual(recorder.installs, [], "a downgrade was downloaded")
+})
+
+test("a failed integrity check is an integrity failure and installs nothing", async () => {
+  const recorder = fakeNative({
+    onInstall: () => new Error("integrity check failed: expected aaa…, got bbb…"),
+  })
+  const outcome = await installPack(raw(), [], deps(recorder, yes))
+  assert.equal(outcome.ok, false)
+  if (!outcome.ok) assert.equal(outcome.failure.code, "integrity")
+})
+
+test("an archive that is not what the catalogue promised is not a successful install", async () => {
+  // The version-drift case: recording it as installed would both lie about
+  // success and leave the update offer re-offering forever, because the
+  // installed version would never converge on the catalogue's.
+  const recorder = fakeNative({
+    onInstall: (args) => ({ id: args.packId, version: "0.9.0", manifest: "{}", bytes: 1 }),
+  })
+  const outcome = await installPack(raw(), [], deps(recorder, yes))
+  assert.equal(outcome.ok, false)
+  if (!outcome.ok) {
+    assert.equal(outcome.failure.code, "identity")
+    assert.match(outcome.failure.message, /0\.9\.0/)
+  }
+})
+
+test("a download that never arrives is a network failure, not a silent nothing", async () => {
+  const recorder = fakeNative({ onInstall: () => new Error("download interrupted: reset") })
+  const outcome = await installPack(raw(), [], deps(recorder, yes))
+  assert.equal(outcome.ok, false)
+  if (!outcome.ok) assert.equal(outcome.failure.code, "network")
+})
+
+test("a catalogue entry with no artefact is refused before the parent is asked", async () => {
+  const recorder = fakeNative()
+  let asked = false
+  const outcome = await installPack(
+    raw({ download: { bytes: 90_000, sha256: "a".repeat(64) } }),
+    [],
+    deps(recorder, async () => {
+      asked = true
+      return true
+    }),
+  )
+  assert.equal(outcome.ok, false)
+  if (!outcome.ok) assert.equal(outcome.failure.code, "unavailable")
+  assert.equal(asked, false)
+})
+
+test("a manifest that does not validate never reaches the native side", async () => {
+  const recorder = fakeNative()
+  const outcome = await installPack({ schema: 1, id: "x" }, [], deps(recorder, yes))
+  assert.equal(outcome.ok, false)
+  if (!outcome.ok) assert.equal(outcome.failure.code, "manifest")
+  assert.deepEqual(recorder.installs, [])
+})
+
+test("reading what is installed separates the usable from the damaged", async () => {
+  const good = JSON.stringify(raw())
+  const recorder = fakeNative({
+    rows: [
+      { id: "abacus.tower", version: "1.2.0", manifest: good, bytes: 400_000 },
+      { id: "broken.one", version: "1.0.0", manifest: "{not json", bytes: 10 },
+      { id: "wrong.schema", version: "1.0.0", manifest: '{"schema":1,"id":"wrong.schema"}', bytes: 10 },
+      // A directory whose manifest claims to be a different pack: the id is the
+      // directory name and the two must agree, or `dynawalla-pack://a/…` and
+      // `dynawalla-pack://b/…` could serve the same files.
+      {
+        id: "imposter",
+        version: "1.2.0",
+        manifest: good,
+        bytes: 10,
+      },
+    ],
+  })
+
+  const result = await readInstalled(recorder.native)
+  assert.deepEqual(
+    result.packs.map((pack) => pack.manifest.id),
+    ["abacus.tower"],
+  )
+  assert.deepEqual(
+    result.damaged.map((entry) => entry.id).sort(),
+    ["broken.one", "imposter", "wrong.schema"],
+  )
+  // Damaged packs are reported rather than hidden: they are occupying disk and
+  // the parent has to be able to remove them.
+  assert.ok(result.damaged.every((entry) => entry.problems.length > 0))
+})
+
+test("removal goes through", async () => {
+  const recorder = fakeNative()
+  await removePack(recorder.native, "abacus.tower")
+  assert.deepEqual(recorder.removals, ["abacus.tower"])
+})
+
+test("update planning offers only what would actually install", async () => {
+  const installed: InstalledPack[] = [
+    { manifest: asManifest(raw({ version: "1.1.0" })), bytes: 1 },
+    { manifest: asManifest(raw({ id: "other.pack", version: "2.0.0" })), bytes: 1 },
+    { manifest: asManifest(raw({ id: "orphan.pack", version: "1.0.0" })), bytes: 1 },
+  ]
+  const catalog = [
+    asManifest(raw()), // 1.2.0 — a real upgrade
+    asManifest(raw({ id: "other.pack", version: "1.0.0" })), // older than installed
+    // A newer version of an installed pack that this app is too old to run.
+    // Never offered: a parent must not be shown an update that would be refused.
+    asManifest(raw({ id: "orphan.pack", version: "9.0.0", host: { min: "5.0.0" } })),
+  ]
+
+  const offers = planUpdates(catalog, installed, host)
+  assert.deepEqual(
+    offers.map((offer) => [offer.manifest.id, offer.from, offer.to]),
+    [["abacus.tower", "1.1.0", "1.2.0"]],
+  )
+  assert.equal(offers[0]?.downloadBytes, 90_000)
+})

--- a/dynawalla/dynawalla-app/src/packs/install.ts
+++ b/dynawalla/dynawalla-app/src/packs/install.ts
@@ -1,0 +1,252 @@
+// Install, upgrade, remove — the decisions, with the IO behind a port.
+//
+// Nothing in this module downloads anything. `PackNative` is an interface and
+// the Tauri implementation of it lives in `native.ts`, which is what lets every
+// path here — a refused downgrade, a declined confirmation, a corrupt archive,
+// a pack that is not what the catalogue said it was — be a Node test rather
+// than a device session nobody will run twice.
+//
+// Two rules that are not negotiable, both learned elsewhere in this repository:
+//
+//   * **Nothing downloads without being asked.** `confirm` is a required
+//     argument, not an option with a default, so a caller cannot forget it. It
+//     is handed the size and the capability list, because those are the two
+//     facts a parent needs and the two a silent install hides.
+//   * **A version mismatch is a failure, not a footnote.** If the artefact does
+//     not declare exactly what the catalogue promised, the install failed. It
+//     is not recorded, the installed copy is not touched, and the update banner
+//     keeps offering — which is correct, because the update genuinely has not
+//     happened.
+
+import type { Capability, PackManifest } from "../../../packs/sdk/src/index.ts"
+import { localizedName, parseManifest } from "../../../packs/sdk/src/index.ts"
+import type { InstallProgress, InstalledPackRow, PackNative } from "./native.ts"
+import type { HostProfile, Refusal, RefusalCode } from "./gate.ts"
+import { gateInstall } from "./gate.ts"
+
+export type InstalledPack = {
+  readonly manifest: PackManifest
+  readonly bytes: number
+}
+
+export type FailureCode =
+  | RefusalCode
+  /** The parent said no. Not an error; nothing is retried and nothing is logged. */
+  | "declined"
+  /** The download did not finish, or the origin refused. */
+  | "network"
+  /** The archive is not the one the manifest describes. */
+  | "integrity"
+  /** The archive is a pack, but not this pack. */
+  | "identity"
+  /** Nothing to install: the catalogue entry has no artefact. */
+  | "unavailable"
+
+export type InstallFailure = {
+  readonly code: FailureCode
+  readonly message: string
+  readonly problems?: readonly string[]
+}
+
+export type InstallOutcome =
+  | { readonly ok: true; readonly pack: InstalledPack; readonly action: "install" | "upgrade" }
+  | { readonly ok: false; readonly failure: InstallFailure }
+
+/** What the parent is shown before a byte moves. */
+export type Consent = {
+  readonly name: string
+  readonly version: string
+  readonly action: "install" | "upgrade"
+  /** Compressed bytes to fetch. */
+  readonly downloadBytes: number
+  /** Bytes the pack will occupy once installed. */
+  readonly installedBytes: number
+  readonly capabilities: readonly Capability[]
+}
+
+export type InstallDeps = {
+  readonly native: PackNative
+  readonly host: HostProfile
+  /** Resolves false to abandon the install. Required — see the module note. */
+  readonly confirm: (consent: Consent) => Promise<boolean>
+  readonly onProgress?: (progress: InstallProgress) => void
+  /** Display locale, for the name in the consent sheet. */
+  readonly locale?: string
+}
+
+const fail = (code: FailureCode, message: string, problems?: readonly string[]): InstallOutcome =>
+  problems
+    ? { ok: false, failure: { code, message, problems } }
+    : { ok: false, failure: { code, message } }
+
+const refusalToFailure = (refusal: Refusal): InstallOutcome =>
+  refusal.problems
+    ? { ok: false, failure: { code: refusal.code, message: refusal.message, problems: refusal.problems } }
+    : { ok: false, failure: { code: refusal.code, message: refusal.message } }
+
+/**
+ * Install or upgrade one pack from a catalogue manifest.
+ *
+ * `raw` is the manifest as it came out of the catalogue — unvalidated on
+ * purpose, because validating it is the first thing that happens and a caller
+ * holding a `PackManifest` it parsed somewhere else has already made the
+ * decision this function exists to make.
+ */
+export async function installPack(
+  raw: unknown,
+  installed: readonly InstalledPack[],
+  deps: InstallDeps,
+): Promise<InstallOutcome> {
+  const current = installed.find(
+    (entry) => typeof raw === "object" && raw !== null && entry.manifest.id === (raw as { id?: unknown }).id,
+  )
+
+  const verdict = gateInstall(
+    current
+      ? { raw, host: deps.host, installedVersion: current.manifest.version }
+      : { raw, host: deps.host },
+  )
+  if (!verdict.ok) return refusalToFailure(verdict.refusal)
+
+  const manifest = verdict.manifest
+  const url = manifest.download.url
+  if (url === undefined) {
+    return fail("unavailable", `${manifest.name} has no download for this device.`)
+  }
+
+  const consented = await deps.confirm({
+    name: localizedName(manifest, deps.locale ?? "en"),
+    version: manifest.version,
+    action: verdict.action,
+    downloadBytes: manifest.download.bytes,
+    installedBytes: manifest.assets.bytes,
+    capabilities: manifest.capabilities,
+  })
+  if (!consented) return fail("declined", "")
+
+  let row: InstalledPackRow
+  try {
+    row = await deps.native.install(
+      {
+        packId: manifest.id,
+        version: manifest.version,
+        url,
+        sha256: manifest.download.sha256,
+        bytes: manifest.download.bytes,
+      },
+      deps.onProgress ?? (() => {}),
+    )
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    // The native side distinguishes these; the wording it produces is the only
+    // place they differ, so the classification is done once, here.
+    const code: FailureCode = /integrity/i.test(message)
+      ? "integrity"
+      : /declares|promised/i.test(message)
+        ? "identity"
+        : "network"
+    return fail(code, message)
+  }
+
+  // Defence in depth. Rust refuses a mismatched archive already; this catches
+  // the case where it did not, which is the case where it matters.
+  if (row.id !== manifest.id || row.version !== manifest.version) {
+    return fail(
+      "identity",
+      `Installed ${row.id}@${row.version} but the catalogue promised ${manifest.id}@${manifest.version}.`,
+    )
+  }
+
+  return { ok: true, pack: { manifest, bytes: row.bytes }, action: verdict.action }
+}
+
+export type ReadResult = {
+  readonly packs: readonly InstalledPack[]
+  /** Directories that are on disk but are not usable, with the reason. */
+  readonly damaged: readonly { readonly id: string; readonly problems: readonly string[] }[]
+}
+
+/**
+ * Everything installed, validated.
+ *
+ * A pack whose manifest no longer parses is reported as damaged rather than
+ * dropped: it is occupying disk and the parent needs to be able to remove it,
+ * which they cannot do if the app pretends it is not there.
+ */
+export async function readInstalled(native: PackNative): Promise<ReadResult> {
+  const rows = await native.list()
+  const packs: InstalledPack[] = []
+  const damaged: { id: string; problems: readonly string[] }[] = []
+
+  for (const row of rows) {
+    let raw: unknown
+    try {
+      raw = JSON.parse(row.manifest)
+    } catch {
+      damaged.push({ id: row.id, problems: ["manifest.json is not JSON"] })
+      continue
+    }
+    const parsed = parseManifest(raw)
+    if (!parsed.ok) {
+      damaged.push({ id: row.id, problems: parsed.problems })
+      continue
+    }
+    if (parsed.manifest.id !== row.id) {
+      damaged.push({ id: row.id, problems: [`manifest claims to be ${parsed.manifest.id}`] })
+      continue
+    }
+    packs.push({ manifest: parsed.manifest, bytes: row.bytes })
+  }
+
+  return { packs, damaged }
+}
+
+/**
+ * Remove a pack.
+ *
+ * Thin on purpose — the interesting part is that it exists, is exported, and is
+ * wired to a command the backend actually registers.
+ */
+export async function removePack(native: PackNative, packId: string): Promise<void> {
+  await native.remove(packId)
+}
+
+export type UpdateOffer = {
+  readonly manifest: PackManifest
+  readonly from: string
+  readonly to: string
+  readonly downloadBytes: number
+}
+
+/**
+ * What the catalogue has that the device does not.
+ *
+ * Only upgrades: a catalogue entry that is older than what is installed is a
+ * broken catalogue, and `gateInstall` refuses it individually. This never
+ * offers a pack that would fail the gate, so a parent is not shown an update
+ * they cannot apply.
+ */
+export function planUpdates(
+  catalog: readonly PackManifest[],
+  installed: readonly InstalledPack[],
+  host: HostProfile,
+): readonly UpdateOffer[] {
+  const offers: UpdateOffer[] = []
+  for (const entry of installed) {
+    const candidate = catalog.find((manifest) => manifest.id === entry.manifest.id)
+    if (!candidate) continue
+    const verdict = gateInstall({
+      raw: candidate,
+      host,
+      installedVersion: entry.manifest.version,
+    })
+    if (!verdict.ok || verdict.action !== "upgrade") continue
+    offers.push({
+      manifest: candidate,
+      from: entry.manifest.version,
+      to: candidate.version,
+      downloadBytes: candidate.download.bytes,
+    })
+  }
+  return offers
+}

--- a/dynawalla/dynawalla-app/src/packs/native.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/native.test.ts
@@ -1,0 +1,110 @@
+// The command list, checked against the backend that has to answer it.
+//
+// This is the test that exists because of a specific bug in the other app in
+// this repository: `corpan-app`'s install manager invokes `content_packs_delete`,
+// which is not among the commands `corpan_lib` registers. Uninstalling a pack
+// therefore leaves its files on the device permanently, and nothing fails —
+// not the build, not the types, not a review. The only thing that catches it is
+// reading both lists and comparing them.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { PACK_COMMANDS } from "./native.ts"
+import { NATIVE_CALLS } from "../app/permissions.ts"
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const packsDir = here
+const libRs = fs.readFileSync(path.resolve(here, "../../src-tauri/src/lib.rs"), "utf8")
+
+/** The names inside `tauri::generate_handler![ ... ]`, module path stripped. */
+function registeredCommands(source: string): string[] {
+  const block = /generate_handler!\s*\[([^\]]*)\]/.exec(source)
+  assert.ok(block, "lib.rs has no generate_handler! block")
+  return (block[1] ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0 && !entry.startsWith("//"))
+    .map((entry) => entry.split("::").pop() ?? entry)
+}
+
+test("every command the frontend invokes is registered in Rust, and none is stranded", () => {
+  const registered = [...registeredCommands(libRs)].sort()
+  const invoked = [...PACK_COMMANDS].sort()
+  assert.deepEqual(
+    registered,
+    invoked,
+    "the command list in native.ts and the handlers in lib.rs have diverged",
+  )
+})
+
+test("removal is one of them", () => {
+  // Stated separately, because this is the one that was missing elsewhere and a
+  // set comparison would go green the day someone deletes both sides of it.
+  assert.ok(PACK_COMMANDS.includes("packs_remove"))
+  assert.ok(registeredCommands(libRs).includes("packs_remove"))
+})
+
+test("every pack command is declared in the native-call table", () => {
+  const declared = NATIVE_CALLS.filter((call) => call.command !== undefined).map(
+    (call) => call.command,
+  )
+  for (const command of PACK_COMMANDS) {
+    assert.ok(declared.includes(command), `${command} is invoked but not declared`)
+  }
+  for (const command of declared) {
+    assert.ok(
+      (PACK_COMMANDS as readonly string[]).includes(command as string),
+      `${command} is declared but no longer invoked`,
+    )
+  }
+})
+
+test("an application command declares no permission, because none can exist", () => {
+  for (const call of NATIVE_CALLS) {
+    if (call.command === undefined) continue
+    assert.equal(call.permission, null, `${call.command} claims an ACL permission`)
+    assert.ok(call.why.length > 40, `${call.command} has no real justification`)
+  }
+})
+
+test("native.ts is the only module in src/packs that reaches the bridge", () => {
+  // The port in `native.ts` is what makes the install state machine testable in
+  // Node. A second module importing `@tauri-apps/*` would quietly reintroduce
+  // the coupling — and would be authorised by the declaration above, which is
+  // written as though there is exactly one such file.
+  const offenders: string[] = []
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        walk(full)
+        continue
+      }
+      if (!/\.(ts|tsx)$/.test(entry.name)) continue
+      if (entry.name === "native.ts") continue
+      // Tests name the module scope in prose, and this one has to.
+      if (entry.name.endsWith(".test.ts")) continue
+      if (/@tauri-apps\//.test(fs.readFileSync(full, "utf8"))) {
+        offenders.push(path.relative(packsDir, full))
+      }
+    }
+  }
+  walk(packsDir)
+  assert.deepEqual(offenders, [])
+})
+
+test("the pack scheme name is the same string on both sides of the boundary", () => {
+  // It is baked into every published pack's built JavaScript on every device.
+  // Renaming it compiles cleanly and breaks every installed pack at runtime.
+  const packsRs = fs.readFileSync(path.resolve(here, "../../src-tauri/src/packs/mod.rs"), "utf8")
+  assert.match(packsRs, /pub const PACK_SCHEME: &str = "dynawalla-pack";/)
+
+  const config = JSON.parse(
+    fs.readFileSync(path.resolve(here, "../../src-tauri/tauri.conf.json"), "utf8"),
+  ) as { app: { security: { csp: string } } }
+  assert.match(config.app.security.csp, /frame-src [^;]*dynawalla-pack:/)
+})

--- a/dynawalla/dynawalla-app/src/packs/native.ts
+++ b/dynawalla/dynawalla-app/src/packs/native.ts
@@ -1,0 +1,78 @@
+// The one module in the app that speaks to the pack runtime in Rust.
+//
+// Every native command the pack system uses is named here exactly once, and
+// `native.test.ts` reads `src-tauri/src/lib.rs` and asserts that this list and
+// the registered handlers are the same set in both directions. That is not
+// ceremony: Corpán's install manager invokes a `content_packs_delete` command
+// its backend never registered, so every uninstalled pack's data stays on the
+// device forever and nothing reports a problem. A command list that only exists
+// in one of the two languages is the shape of that bug.
+//
+// These are application commands rather than plugin commands, so Tauri's ACL
+// does not gate them and `capabilities/default.json` cannot express them. The
+// declaration in `src/app/permissions.ts` and this test are what stands in for
+// a grant.
+
+import { Channel, invoke } from "@tauri-apps/api/core"
+
+/** The commands `src-tauri/src/lib.rs` registers. Kept in one place. */
+export const PACK_COMMANDS = [
+  "packs_list",
+  "packs_catalog",
+  "packs_install",
+  "packs_remove",
+  "packs_entry_url",
+] as const
+
+export type PackCommand = (typeof PACK_COMMANDS)[number]
+
+/** One installed pack, as Rust found it on disk. */
+export type InstalledPackRow = {
+  readonly id: string
+  readonly version: string
+  /** The manifest verbatim. Parsed by the SDK, never by Rust. */
+  readonly manifest: string
+  readonly bytes: number
+}
+
+export type InstallProgress =
+  | { readonly phase: "downloading"; readonly received: number; readonly total: number }
+  | { readonly phase: "verifying" }
+  | { readonly phase: "extracting" }
+  | { readonly phase: "installing" }
+
+export type InstallArgs = {
+  readonly packId: string
+  readonly version: string
+  readonly url: string
+  readonly sha256: string
+  readonly bytes: number
+}
+
+/**
+ * The native surface, as an interface.
+ *
+ * Everything above this line is IO; everything below it in `install.ts` is a
+ * decision. Splitting them at a port is what lets the install state machine —
+ * the part with the version comparisons, the refusals and the failure paths —
+ * be tested in Node without a WebView, a device or a network.
+ */
+export type PackNative = {
+  list(): Promise<InstalledPackRow[]>
+  catalog(): Promise<string>
+  install(args: InstallArgs, onProgress: (progress: InstallProgress) => void): Promise<InstalledPackRow>
+  remove(packId: string): Promise<void>
+  entryUrl(packId: string, entry: string): Promise<string>
+}
+
+export const tauriNative: PackNative = {
+  list: () => invoke<InstalledPackRow[]>("packs_list"),
+  catalog: () => invoke<string>("packs_catalog"),
+  install: (args, onProgress) => {
+    const progress = new Channel<InstallProgress>()
+    progress.onmessage = onProgress
+    return invoke<InstalledPackRow>("packs_install", { request: args, progress })
+  },
+  remove: (packId) => invoke<void>("packs_remove", { packId }),
+  entryUrl: (packId, entry) => invoke<string>("packs_entry_url", { packId, entry }),
+}

--- a/dynawalla/dynawalla-app/src/packs/packs.css
+++ b/dynawalla/dynawalla-app/src/packs/packs.css
@@ -1,0 +1,34 @@
+/* The frame a pack lives in.
+ *
+ * The host owns the rectangle and nothing inside it. There are no styles here
+ * that reach into the pack — they could not: the frame is a separate document
+ * on an opaque origin, and that is the point. What is left is the two rules
+ * that decide how much room a pack gets and that it never becomes a scrolling
+ * region inside a scrolling page.
+ */
+
+.pack-frame-host {
+  position: relative;
+  inline-size: 100%;
+  block-size: 100%;
+  /* A pack fills what it is given and nothing more; a 320px phone is the floor
+     the whole app is designed to, so the container never sets a minimum width
+     a pack could overflow. */
+  min-inline-size: 0;
+  overflow: hidden;
+}
+
+.pack-frame {
+  display: block;
+  inline-size: 100%;
+  block-size: 100%;
+  border: 0;
+  /* Carved stone, not a browser-chrome grey: a pack that has not painted yet
+     should read as part of the app rather than as a hole in it. The token, not
+     a literal — this is the one surface whose colour cannot be re-cut for dark
+     by the pack, because the pack is a different document. */
+  background: var(--dw-ground-deep);
+  /* An iframe is focusable and its content is keyboard-reachable; nothing here
+     may put it behind a transparent overlay. */
+  color-scheme: light dark;
+}

--- a/dynawalla/packs/sdk/README.md
+++ b/dynawalla/packs/sdk/README.md
@@ -1,0 +1,190 @@
+# `@dynawalla/pack-sdk`
+
+The contract between the Dynawalla host and a pack. One copy, imported by both
+sides, so a change that would break a pack cannot typecheck in the host either.
+
+Packs are the product. The host is a shell: profiles, storage, the pack
+registry, the runtime, and the adaptive model that decides what a child should
+practise next. Every game, world, exercise, sound and asset lives in a pack.
+
+---
+
+## The shape of a pack
+
+A pack is a directory with a `manifest.json` at its root and an HTML document as
+its entry.
+
+```
+abacus-tower/
+  manifest.json
+  index.html          ← the entry. It is FRAMED, never evaluated.
+  pack.js
+  pack.css
+  assets/…
+```
+
+It is served from `dynawalla-pack://localhost/<id>/…` and framed with
+`sandbox="allow-scripts"` — deliberately **without** `allow-same-origin`. That
+one omission is the whole security model:
+
+- the frame's origin is opaque, so `window.parent` is cross-origin and
+  unreadable. A pack cannot reach the native bridge, the app's stores, or
+  another pack.
+- there is no `localStorage`, no `IndexedDB`, no cookies. Anything a pack keeps
+  is kept for it by the host, through the `storage` capability.
+- the document is served with a Content Security Policy that names only the pack
+  scheme. **A pack cannot reach the network.** Not "should not" — cannot.
+- top-level navigation is blocked. A pack cannot replace the app.
+
+What a pack gets instead is one `MessagePort`, handed over at the end of a
+handshake, and everything on that port is validated and gated by the host.
+
+Two consequences worth planning around:
+
+- **Inline `<script>` and `onclick=` are dropped.** `script-src` has no
+  `'unsafe-inline'`. Put your code in a file.
+- **`'self'` does not work in your own CSS or CSP.** An opaque origin matches
+  nothing. Use relative URLs, which resolve against the document, and they are
+  fine.
+
+---
+
+## The manifest
+
+```json
+{
+  "schema": 1,
+  "id": "abacus.tower",
+  "version": "1.2.0",
+  "name": "Abacus Tower",
+  "description": "Carry beads up the tower.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.3.0", "max": "1.0.0" },
+  "entry": "index.html",
+  "capabilities": ["items", "haptics"],
+  "covers": { "skills": ["add.2digit.regroup"], "grades": [1, 3] },
+  "locales": ["en", "es"],
+  "assets": { "files": 42, "bytes": 3000000 },
+  "download": {
+    "url": "https://encorpora.io/dynawalla/packs/abacus-tower-1.2.0.zip",
+    "bytes": 900000,
+    "sha256": "…64 hex…"
+  }
+}
+```
+
+Notes that are not obvious from the shape:
+
+- `id` is the on-disk directory name and a public identifier forever. Lower
+  case, dotted or hyphenated, starting with a letter.
+- `host.min` is inclusive and `host.max` is exclusive. There are no npm ranges,
+  no `^`, no `~`, and no unions.
+- `assets.bytes` and `download.bytes` are shown to a parent **before** anything
+  is downloaded. `dw-pack check` fails if the directory is bigger than declared.
+- `download.sha256` is verified in Rust against the bytes that arrive, before a
+  single entry is extracted. A published artefact is immutable: to change a
+  pack, bump the version. Never replace a published file in place — that
+  produces two different hashes for one version number and is unresolvable from
+  the device.
+- `covers` is how the host routes a skill to a pack that can teach it.
+
+---
+
+## Talking to the host
+
+```ts
+import { connect } from "@dynawalla/pack-sdk"
+
+const host = await connect()
+
+const item = await host.nextItem()
+// { id, skillId, operands: ["5001", "2798"], operator: "−", prompt, digits: 4 }
+
+const judgement = await host.answer({
+  itemId: item.id,
+  response: typed,
+  latencyMs: elapsed,
+})
+// { correct: false, canonical: "2203", diagnosis: "smaller-from-larger", advance: true }
+```
+
+### The pack does not do the arithmetic
+
+`items.next` does not carry the answer. `items.answer` records the attempt and
+*then* returns the canonical value — so there is no way to learn what is correct
+without spending the attempt you would have had to report anyway.
+
+This is the point of the whole contract. A mathematics game that decides for
+itself whether a child was right is a game that can be beaten by fiddling with
+the game. The adaptive model chooses the item, the curriculum judges the answer,
+and neither of them is inside your pack.
+
+Every operand and every answer is a **string**, and it is exact. The curriculum
+computes in rationals. Parsing one into a `number` to lay it out introduces the
+first floating-point error in the system; use `digits` for layout and `BigInt`
+if you must compute.
+
+`items.reveal` exists for a game that has to place the correct target before the
+child reaches it — a runner that must know which gate is right. It is a separate
+declared capability, it is shown to the parent, and it changes nothing about who
+judges.
+
+### Capabilities
+
+Declare only what you use. A method whose capability you did not declare fails
+locally in the client, without a round trip.
+
+| capability     | what it lets you do                                    |
+| -------------- | ------------------------------------------------------ |
+| `items`        | ask for questions, report answers, skip                |
+| `items.reveal` | read the answer before it is answered                  |
+| `learner.read` | read which topics have been practised                  |
+| `haptics`      | `host.haptic("seat")`                                   |
+| `audio`        | `host.sound("settle")`                                  |
+| `milestones`   | `host.milestone("tower.built")`                         |
+| `storage`      | 200 keys, 16 KB per value, scoped to your pack          |
+
+`host.progress(fraction)` and `host.end(reason)` need no capability: they are
+how a session is a session.
+
+Read `host.granted` and hide the surfaces you cannot drive. `host.settings`
+carries the locale, `prefers-reduced-motion`, a quality tier, the text scale and
+the colour scheme, and it follows the host — re-read it on the `settings` event.
+
+### Rules the host will hold you to
+
+- **120 requests per second.** Above that you get `rate_limited`. This is far
+  above any real surface and far below a loop.
+- **Reduced motion loses no information.** If motion carries meaning, carry it
+  another way as well.
+- **Nothing by colour alone**, a keyboard path to everything, child-sized
+  targets, and 320 px with no horizontal overflow.
+
+---
+
+## Developing a pack
+
+```
+node bin/dw-pack.mjs check <dir>    # validate against the schema
+node bin/dw-pack.mjs serve <dir>    # play it, at http://127.0.0.1:1425
+```
+
+`serve` frames your pack exactly as the shipped runtime does — same
+`sandbox="allow-scripts"`, same style of CSP — against a mock host. The two
+failures that would otherwise only show up on a device (an inline script the
+policy refuses, and code that assumes `window.parent` is reachable) happen on
+your first run instead.
+
+The mock host **answers** the protocol; it does not **enforce** it. Capability
+denial, rate limiting and parameter validation live in the app's `bridge.ts` and
+are tested there. `check` is the gate; `serve` is the workbench.
+
+`example/` is the smallest thing that is a pack: four files, no build step, and
+it plays. It is the SDK's own smoke test and is never shipped.
+
+## Testing
+
+```
+npm test        # node --test over src/**/*.test.ts
+npm run tsc
+```

--- a/dynawalla/packs/sdk/bin/dw-pack.mjs
+++ b/dynawalla/packs/sdk/bin/dw-pack.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+// The pack author's two commands.
+//
+//   dw-pack check <dir>    validate a pack directory against the schema
+//   dw-pack serve <dir>    run it in a browser, against a mock host
+//
+// `serve` exists so that building a pack does not require building, signing,
+// publishing and installing one. It serves the pack under the same Content
+// Security Policy the shipped runtime serves it under, and frames it with the
+// same `sandbox="allow-scripts"` — so the two failures that would otherwise be
+// discovered only on a device (an inline script the policy refuses, and code
+// that assumes `window.parent` is reachable) happen on the first run here.
+//
+// What it is NOT: the mock host answers the protocol, it does not enforce it.
+// Capability denial, rate limiting and parameter validation live in the app's
+// `bridge.ts` and are tested there. A pack that works here can still be refused
+// by a real host, which is why `check` is the gate and this is the workbench.
+
+import fs from "node:fs"
+import http from "node:http"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { parseManifest, isSafeRelativePath } from "../src/manifest.ts"
+import { CAPABILITIES, SESSION_METHODS } from "../src/capabilities.ts"
+import { PROTOCOL_VERSION, SDK_VERSION } from "../src/protocol.ts"
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+
+/**
+ * The policy the pack document is served under, mirroring `pack_csp()` in
+ * `src-tauri/src/packs/mod.rs`.
+ *
+ * The origin is named rather than written `'self'` for the same reason it is
+ * there: the frame is sandboxed without `allow-same-origin`, so its origin is
+ * opaque and `'self'` matches nothing at all. Getting this wrong produces a
+ * policy that looks strict and refuses the pack's own scripts.
+ */
+const packCsp = (port) => {
+  const origin = `http://127.0.0.1:${port}`
+  return [
+    "default-src 'none'",
+    `script-src ${origin} 'wasm-unsafe-eval'`,
+    `style-src ${origin} 'unsafe-inline'`,
+    `img-src ${origin} data: blob:`,
+    `media-src ${origin} blob:`,
+    `font-src ${origin}`,
+    `connect-src ${origin}`,
+    `worker-src ${origin} blob:`,
+    "frame-src 'none'",
+    "object-src 'none'",
+    "base-uri 'none'",
+    "form-action 'none'",
+  ].join("; ")
+}
+
+const TYPES = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".wasm": "application/wasm",
+  ".glb": "model/gltf-binary",
+  ".mp3": "audio/mpeg",
+  ".ogg": "audio/ogg",
+  ".woff2": "font/woff2",
+}
+
+/** Every file under `dir`, relative, sorted. */
+function walk(dir, base = dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) walk(full, base, out)
+    else if (entry.isFile()) out.push(path.relative(base, full))
+  }
+  return out.sort()
+}
+
+function loadPack(dir) {
+  const manifestPath = path.join(dir, "manifest.json")
+  if (!fs.existsSync(manifestPath)) {
+    return { ok: false, problems: [`no manifest.json in ${dir}`] }
+  }
+  let raw
+  try {
+    raw = JSON.parse(fs.readFileSync(manifestPath, "utf8"))
+  } catch (error) {
+    return { ok: false, problems: [`manifest.json is not JSON: ${error.message}`] }
+  }
+  const parsed = parseManifest(raw)
+  if (!parsed.ok) return { ok: false, problems: [...parsed.problems] }
+
+  const problems = []
+  const manifest = parsed.manifest
+  if (!isSafeRelativePath(manifest.entry) || !fs.existsSync(path.join(dir, manifest.entry))) {
+    problems.push(`entry ${manifest.entry} does not exist`)
+  }
+
+  // The declared sizes are what a parent is shown before agreeing to a
+  // download. A manifest that understates them is not a rounding error.
+  const files = walk(dir)
+  const bytes = files.reduce((total, file) => total + fs.statSync(path.join(dir, file)).size, 0)
+  if (files.length !== manifest.assets.files) {
+    problems.push(`assets.files says ${manifest.assets.files}, the directory has ${files.length}`)
+  }
+  if (bytes > manifest.assets.bytes) {
+    problems.push(`assets.bytes says ${manifest.assets.bytes}, the directory is ${bytes}`)
+  }
+
+  return problems.length > 0 ? { ok: false, problems } : { ok: true, manifest, files, bytes }
+}
+
+function check(dir) {
+  const result = loadPack(dir)
+  if (!result.ok) {
+    console.error(`${dir} is not a valid pack:`)
+    for (const problem of result.problems) console.error(`  · ${problem}`)
+    process.exitCode = 1
+    return
+  }
+  const { manifest, files, bytes } = result
+  console.log(`${manifest.id}@${manifest.version} — ${manifest.name}`)
+  console.log(`  entry        ${manifest.entry}`)
+  console.log(`  host         ${manifest.host.min}${manifest.host.max ? ` … <${manifest.host.max}` : " and later"}`)
+  console.log(`  sdk          ${manifest.sdk} (this SDK is ${SDK_VERSION})`)
+  console.log(`  capabilities ${manifest.capabilities.join(", ") || "none"}`)
+  console.log(`  covers       ${manifest.covers.skills.length} skills, grades ${manifest.covers.grades.join("–")}`)
+  console.log(`  on disk      ${files.length} files, ${bytes} bytes`)
+}
+
+function serve(dir, port) {
+  const result = loadPack(dir)
+  if (!result.ok) {
+    console.error(`${dir} is not a valid pack — fix it before serving:`)
+    for (const problem of result.problems) console.error(`  · ${problem}`)
+    process.exitCode = 1
+    return
+  }
+  const manifest = result.manifest
+
+  // The method table is read from the SDK rather than restated, so the mock
+  // host cannot drift from the contract it is standing in for.
+  const surface = JSON.stringify({
+    methods: [...SESSION_METHODS, ...CAPABILITIES.flatMap((entry) => entry.methods)],
+    granted: manifest.capabilities,
+    packId: manifest.id,
+    entry: manifest.entry,
+    protocol: PROTOCOL_VERSION,
+    sdk: SDK_VERSION,
+  })
+
+  const harness = fs.readFileSync(path.join(here, "harness.html"), "utf8")
+  const mock = fs.readFileSync(path.join(here, "harness.js"), "utf8")
+
+  const server = http.createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://localhost")
+    const send = (status, type, body, extra = {}) => {
+      response.writeHead(status, { "Content-Type": type, "X-Content-Type-Options": "nosniff", ...extra })
+      response.end(body)
+    }
+
+    if (url.pathname === "/") return send(200, TYPES[".html"], harness)
+    if (url.pathname === "/__dev/host.js") {
+      return send(200, TYPES[".js"], `globalThis.__DW_SURFACE = ${surface};\n${mock}`)
+    }
+
+    const relative = url.pathname.replace(/^\/+/, "")
+    if (relative === "" || !isSafeRelativePath(relative)) return send(404, "text/plain", "not found")
+    const file = path.join(dir, relative)
+    if (!fs.existsSync(file) || !fs.statSync(file).isFile()) return send(404, "text/plain", "not found")
+
+    const type = TYPES[path.extname(file).toLowerCase()] ?? "application/octet-stream"
+    const headers = path.extname(file) === ".html" ? { "Content-Security-Policy": packCsp(port) } : {}
+    send(200, type, fs.readFileSync(file), headers)
+  })
+
+  server.listen(port, "127.0.0.1", () => {
+    console.log(`${manifest.id}@${manifest.version} on http://127.0.0.1:${port}`)
+    console.log(`granting ${manifest.capabilities.join(", ") || "nothing but the session"}`)
+  })
+}
+
+const [command, target = ".", ...rest] = process.argv.slice(2)
+const portFlag = rest.indexOf("--port")
+const port = portFlag >= 0 ? Number(rest[portFlag + 1]) : 1425
+
+if (command === "check") check(path.resolve(target))
+else if (command === "serve") serve(path.resolve(target), port)
+else {
+  console.error("usage: dw-pack check <dir> | dw-pack serve <dir> [--port 1425]")
+  process.exitCode = 1
+}

--- a/dynawalla/packs/sdk/bin/harness.html
+++ b/dynawalla/packs/sdk/bin/harness.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Pack workbench</title>
+    <style>
+      /* The workbench is a developer tool. It is deliberately plain: anything
+         it draws around the pack is something the real host does not, and a
+         pack author reading a designed chrome would learn the wrong shape. */
+      :root { color-scheme: dark; }
+      html, body { margin: 0; height: 100%; background: #16130f; color: #d9cfc0; font: 13px/1.5 ui-monospace, monospace; }
+      body { display: grid; grid-template-rows: 1fr auto; }
+      iframe { display: block; width: 100%; height: 100%; border: 0; background: #16130f; }
+      #log { max-height: 12rem; overflow: auto; border-top: 1px solid #3b332a; padding: .5rem .75rem; }
+      #log div { white-space: pre-wrap; }
+      #log .out { color: #8fb6a0; }
+      #log .in { color: #c8b48a; }
+      #log .no { color: #d08a7a; }
+    </style>
+  </head>
+  <body>
+    <iframe id="pack" sandbox="allow-scripts" allow="" referrerpolicy="no-referrer" title="Pack under development"></iframe>
+    <div id="log" aria-live="polite"></div>
+    <script src="/__dev/host.js"></script>
+  </body>
+</html>

--- a/dynawalla/packs/sdk/bin/harness.js
+++ b/dynawalla/packs/sdk/bin/harness.js
@@ -1,0 +1,189 @@
+// The workbench's mock host.
+//
+// It answers the protocol so a pack can be developed and played. It does NOT
+// enforce it: capability denial, rate limiting and parameter validation are the
+// real host's job and are tested there. Two things it does take seriously,
+// because a pack built against a sloppy version of either would be wrong on a
+// device:
+//
+//   * **Arithmetic is exact.** Every operand and every answer is a string, and
+//     the comparison is `BigInt`. There is no point at which a `number` holds a
+//     value the child is asked about.
+//   * **The answer is not in the item.** `items.next` returns no canonical
+//     value; `items.answer` records the attempt and only then returns one. A
+//     pack that works here therefore cannot be written to peek, which is the
+//     property the real host guarantees.
+
+const surface = globalThis.__DW_SURFACE
+
+const log = document.getElementById("log")
+const write = (kind, text) => {
+  const line = document.createElement("div")
+  line.className = kind
+  line.textContent = text
+  log.append(line)
+  log.scrollTop = log.scrollHeight
+}
+
+/** Deterministic: the same seed gives the same session, every run. */
+let seed = 0x9e3779b9
+const random = () => {
+  seed = (seed + 0x6d2b79f5) | 0
+  let t = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+}
+const between = (low, high) => low + Math.floor(random() * (high - low + 1))
+
+/** Live items, by id. An item is answerable once. */
+const served = new Map()
+let counter = 0
+
+function makeItem() {
+  // Four-digit subtraction with a zero in the minuend: the case whose classic
+  // error is taking the smaller digit from the larger instead of borrowing.
+  const minuend = BigInt(between(5, 9) * 1000 + between(0, 0) * 100 + between(0, 9) * 10 + between(0, 9))
+  const subtrahend = BigInt(between(1, 4) * 1000 + between(0, 9) * 100 + between(0, 9) * 10 + between(0, 9))
+  const id = `dev-${(counter += 1)}`
+  const item = {
+    id,
+    skillId: "sub.4digit.zero",
+    level: 3,
+    form: "binary-op",
+    operator: "−",
+    operands: [String(minuend), String(subtrahend)],
+    prompt: `${minuend} minus ${subtrahend}`,
+    answerKind: "integer",
+    digits: 4,
+  }
+  served.set(id, { minuend, subtrahend, canonical: String(minuend - subtrahend) })
+  return item
+}
+
+/** The one mal-rule the workbench knows: column-wise |a−b|, no borrowing. */
+function smallerFromLarger(minuend, subtrahend) {
+  const left = String(minuend).padStart(4, "0")
+  const right = String(subtrahend).padStart(4, "0")
+  let out = ""
+  for (let index = 0; index < 4; index += 1) {
+    out += String(Math.abs(Number(left[index]) - Number(right[index])))
+  }
+  return String(BigInt(out))
+}
+
+const settings = {
+  locale: "en",
+  reducedMotion: matchMedia("(prefers-reduced-motion: reduce)").matches,
+  quality: "high",
+  textScale: 1,
+  colorScheme: "dark",
+  sound: true,
+  haptics: true,
+}
+
+const storage = new Map()
+
+async function answer(method, params) {
+  switch (method) {
+    case "session.settings":
+      return settings
+    case "session.progress":
+      return null
+    case "session.end":
+      write("in", `session.end (${params.reason})`)
+      return null
+
+    case "items.next":
+      return { item: makeItem() }
+
+    case "items.answer": {
+      const record = served.get(params.itemId)
+      if (!record) return { correct: false, canonical: "", advance: false }
+      served.delete(params.itemId)
+      const correct = BigInt(params.response || "0") === BigInt(record.canonical)
+      const diagnosis =
+        !correct && params.response === smallerFromLarger(record.minuend, record.subtrahend)
+          ? "smaller-from-larger"
+          : undefined
+      write("in", `answered ${params.response} → ${correct ? "correct" : record.canonical}${diagnosis ? ` (${diagnosis})` : ""}`)
+      return { correct, canonical: record.canonical, diagnosis, advance: true }
+    }
+
+    case "items.skip":
+      served.delete(params.itemId)
+      return null
+
+    case "items.reveal": {
+      const record = served.get(params.itemId)
+      return { canonical: record ? record.canonical : "" }
+    }
+
+    case "learner.summary":
+      return { skills: [{ id: "sub.4digit.zero", level: "practiced" }] }
+
+    case "feedback.haptic":
+    case "feedback.sound":
+      write("in", `${method} ${params.cue}`)
+      return null
+
+    case "milestone.reach":
+      write("in", `milestone ${params.name}`)
+      return null
+
+    case "storage.get":
+      return { value: storage.get(params.key) ?? null }
+    case "storage.set":
+      storage.set(params.key, params.value)
+      return null
+    case "storage.remove":
+      storage.delete(params.key)
+      return null
+    case "storage.keys":
+      return { keys: [...storage.keys()] }
+
+    default:
+      return undefined
+  }
+}
+
+const frame = document.getElementById("pack")
+
+addEventListener("message", (event) => {
+  if (event.source !== frame.contentWindow) return
+  if (!event.data || event.data.event !== "ready") return
+
+  const channel = new MessageChannel()
+  channel.port1.onmessage = async (message) => {
+    const { id, method, params = {} } = message.data ?? {}
+    if (!surface.methods.includes(method)) {
+      write("no", `unknown method ${method}`)
+      channel.port1.postMessage({ id, ok: false, error: { code: "unknown_method", message: String(method) } })
+      return
+    }
+    try {
+      const result = await answer(method, params)
+      channel.port1.postMessage({ id, ok: true, result: result ?? null })
+    } catch (error) {
+      write("no", `${method} threw: ${error.message}`)
+      channel.port1.postMessage({ id, ok: false, error: { code: "internal", message: "" } })
+    }
+  }
+  channel.port1.start()
+
+  frame.contentWindow.postMessage(
+    {
+      event: "connect",
+      protocol: surface.protocol,
+      sdk: surface.sdk,
+      host: "0.0.0-workbench",
+      packId: surface.packId,
+      granted: surface.granted,
+      settings,
+    },
+    "*",
+    [channel.port2],
+  )
+  write("out", `connected ${surface.packId} — granted: ${surface.granted.join(", ") || "session only"}`)
+})
+
+frame.src = `/${surface.entry}`

--- a/dynawalla/packs/sdk/example/index.html
+++ b/dynawalla/packs/sdk/example/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>SDK Example</title>
+    <link rel="stylesheet" href="pack.css" />
+  </head>
+  <body>
+    <!-- No inline script anywhere. The policy the host serves this document
+         under has no `'unsafe-inline'` in `script-src`, so an inline handler or
+         an inline <script> is silently dropped — which looks exactly like a
+         pack that does nothing. Everything is in pack.js. -->
+    <main class="slate">
+      <p class="problem" id="problem" aria-live="polite"></p>
+      <p class="entry" id="entry" aria-live="polite"></p>
+      <div class="keys" id="keys"></div>
+    </main>
+    <script src="pack.js"></script>
+  </body>
+</html>

--- a/dynawalla/packs/sdk/example/manifest.json
+++ b/dynawalla/packs/sdk/example/manifest.json
@@ -1,0 +1,18 @@
+{
+  "schema": 1,
+  "id": "sdk.example",
+  "version": "1.0.0",
+  "name": "SDK Example",
+  "description": "The smallest thing that is a pack. A reference and a smoke test, never shipped.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0" },
+  "entry": "index.html",
+  "capabilities": ["items", "haptics"],
+  "covers": { "skills": ["sub.4digit.zero"], "grades": [2, 4] },
+  "locales": ["en"],
+  "assets": { "files": 4, "bytes": 32768 },
+  "download": {
+    "bytes": 8192,
+    "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+  }
+}

--- a/dynawalla/packs/sdk/example/pack.css
+++ b/dynawalla/packs/sdk/example/pack.css
@@ -1,0 +1,79 @@
+/* The example's whole appearance. It is austere on purpose: this file exists to
+   be read by a pack author, not admired. A real pack owns its look entirely —
+   the host styles nothing inside the frame and could not if it wanted to. */
+
+:root {
+  color-scheme: light dark;
+  --ink: #ece2d2;
+  --stone: #16130f;
+  --brass: #c9a227;
+  --recess: #221d17;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  height: 100%;
+  background: var(--stone);
+  color: var(--ink);
+  font-family: ui-serif, Georgia, serif;
+  font-variant-numeric: tabular-nums;
+}
+
+.slate {
+  height: 100%;
+  display: grid;
+  grid-template-rows: 1fr auto auto;
+  align-content: center;
+  gap: 1rem;
+  padding: 1rem;
+  max-width: 30rem;
+  margin-inline: auto;
+}
+
+.problem {
+  margin: 0;
+  align-self: end;
+  text-align: center;
+  font-size: clamp(2rem, 12vw, 4rem);
+  letter-spacing: 0.04em;
+}
+
+.entry {
+  margin: 0;
+  text-align: center;
+  font-size: clamp(1.5rem, 8vw, 3rem);
+  min-height: 1.2em;
+  color: var(--brass);
+  border-bottom: 2px solid var(--recess);
+}
+
+.keys {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+}
+
+button {
+  /* 48px is the floor for a child's finger, and it does not move with the
+     type scale. */
+  min-height: 3rem;
+  font: inherit;
+  font-size: 1.25rem;
+  color: var(--ink);
+  background: var(--recess);
+  border: 1px solid #3b332a;
+  border-radius: 8px;
+}
+
+button:focus-visible {
+  outline: 3px solid var(--brass);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  button { transition: background-color 120ms ease-out; }
+}
+
+button:active { background: #2e281f; }

--- a/dynawalla/packs/sdk/example/pack.js
+++ b/dynawalla/packs/sdk/example/pack.js
@@ -1,0 +1,121 @@
+// The smallest thing that is a pack.
+//
+// It is plain JavaScript with no build step, so the handshake is written out by
+// hand. A real pack bundles the SDK and writes:
+//
+//     import { connect } from "@dynawalla/pack-sdk"
+//     const host = await connect()
+//     const item = await host.nextItem()
+//
+// which is the same three messages with types on them. Everything below the
+// `connect` function here is what any pack does: draw the item, collect a
+// response, hand it to the host, draw what the host said.
+//
+// Note what is NOT here. There is no arithmetic. The pack does not know what
+// 5001 − 2798 is and never computes it — it sends the child's response to the
+// host and is told. That is the rule the whole contract exists to enforce: a
+// game cannot be beaten by fiddling with the game, because the thing that
+// decides whether the child was right is not in it.
+
+function connect() {
+  return new Promise((resolve, reject) => {
+    if (window.parent === window) {
+      reject(new Error("not framed by a host"))
+      return
+    }
+    const timer = setTimeout(() => reject(new Error("no host")), 15000)
+    addEventListener("message", function onMessage(event) {
+      if (!event.data || event.data.event !== "connect") return
+      const port = event.ports[0]
+      if (!port) return
+      clearTimeout(timer)
+      removeEventListener("message", onMessage)
+
+      const pending = new Map()
+      let nextId = 1
+      port.onmessage = (message) => {
+        const { id, ok, result, error } = message.data ?? {}
+        const entry = pending.get(id)
+        if (!entry) return
+        pending.delete(id)
+        if (ok) entry.resolve(result)
+        else entry.reject(new Error(error?.code ?? "failed"))
+      }
+      port.start()
+
+      const call = (method, params = {}) =>
+        new Promise((ok2, no) => {
+          const id = nextId++
+          pending.set(id, { resolve: ok2, reject: no })
+          port.postMessage({ id, method, params })
+        })
+
+      resolve({ granted: event.data.granted, settings: event.data.settings, call })
+    })
+    window.parent.postMessage({ event: "ready", protocol: 1 }, "*")
+  })
+}
+
+const problem = document.getElementById("problem")
+const entry = document.getElementById("entry")
+const keys = document.getElementById("keys")
+
+const KEYS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "⌫", "0", "✓"]
+
+async function main() {
+  const host = await connect()
+  const canHaptic = host.granted.includes("haptics")
+
+  let item = null
+  let typed = ""
+  let shownAt = 0
+
+  const draw = () => {
+    problem.textContent = item ? `${item.operands[0]} ${item.operator} ${item.operands[1]}` : ""
+    entry.textContent = typed
+  }
+
+  const serve = async () => {
+    typed = ""
+    item = await host.call("items.next")
+    item = item.item
+    shownAt = performance.now()
+    draw()
+  }
+
+  const submit = async () => {
+    if (!item || typed === "") return
+    const judgement = await host.call("items.answer", {
+      itemId: item.id,
+      response: typed,
+      latencyMs: Math.round(performance.now() - shownAt),
+      revisions: 0,
+    })
+    // The canonical value arrives only now, after the attempt is on record.
+    entry.textContent = judgement.correct ? typed : `${typed} → ${judgement.canonical}`
+    if (canHaptic) await host.call("feedback.haptic", { cue: judgement.correct ? "seat" : "refuse" })
+    if (judgement.advance) setTimeout(serve, 900)
+  }
+
+  for (const label of KEYS) {
+    const key = document.createElement("button")
+    key.type = "button"
+    key.textContent = label
+    key.addEventListener("click", () => {
+      if (label === "⌫") typed = typed.slice(0, -1)
+      else if (label === "✓") return void submit()
+      else if (typed.length < 6) typed += label
+      draw()
+    })
+    keys.append(key)
+  }
+
+  await serve()
+}
+
+main().catch((error) => {
+  // A pack that cannot reach a host says so on its own surface rather than
+  // showing a frozen loading state forever.
+  problem.textContent = "No host."
+  entry.textContent = error.message
+})

--- a/dynawalla/packs/sdk/package.json
+++ b/dynawalla/packs/sdk/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@dynawalla/pack-sdk",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "The Dynawalla host↔pack contract: manifest schema, capability table, wire protocol and the guest client. No DOM assumptions beyond MessagePort, no Tauri, no app imports.",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
+    "tsc": "tsc --noEmit",
+    "check": "node bin/dw-pack.mjs check",
+    "serve": "node bin/dw-pack.mjs serve"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^6.0.0"
+  }
+}

--- a/dynawalla/packs/sdk/src/capabilities.test.ts
+++ b/dynawalla/packs/sdk/src/capabilities.test.ts
@@ -1,0 +1,99 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import {
+  CAPABILITIES,
+  CAPABILITY_IDS,
+  METHODS,
+  SESSION_METHODS,
+  capabilityOf,
+  isCapability,
+  isMethod,
+  labelOf,
+  permits,
+} from "./capabilities.ts"
+import type { Method } from "./capabilities.ts"
+
+test("every method belongs to exactly one capability, or to the session", () => {
+  // The property that makes `permits` a complete gate. A method reachable from
+  // no capability would be callable by every pack; a method in two would make
+  // "which grant does this need" ambiguous at the install sheet.
+  const owners = new Map<string, string[]>()
+  for (const entry of CAPABILITIES) {
+    for (const method of entry.methods) {
+      owners.set(method, [...(owners.get(method) ?? []), entry.id])
+    }
+  }
+  for (const [method, list] of owners) {
+    assert.equal(list.length, 1, `${method} is owned by ${list.join(" and ")}`)
+  }
+  for (const method of METHODS) {
+    const session = (SESSION_METHODS as readonly string[]).includes(method)
+    assert.ok(session !== owners.has(method), `${method} is both a session method and a grant`)
+  }
+})
+
+test("no method name is duplicated across the whole surface", () => {
+  assert.equal(new Set(METHODS).size, METHODS.length)
+})
+
+test("an ungranted method is refused, one capability at a time", () => {
+  for (const entry of CAPABILITIES) {
+    const others = CAPABILITY_IDS.filter((id) => id !== entry.id)
+    for (const method of entry.methods) {
+      assert.equal(permits([entry.id], method), true, `${entry.id} should permit ${method}`)
+      assert.equal(permits(others, method), false, `${method} passed without ${entry.id}`)
+      assert.equal(permits([], method), false, `${method} passed with no grants at all`)
+    }
+  }
+})
+
+test("session methods need no grant and nothing else does", () => {
+  for (const method of SESSION_METHODS) {
+    assert.equal(permits([], method), true)
+    assert.equal(capabilityOf(method), null)
+  }
+  for (const entry of CAPABILITIES) {
+    for (const method of entry.methods) assert.equal(capabilityOf(method), entry.id)
+  }
+})
+
+test("a method that is not a method is not a method", () => {
+  for (const value of ["items.eval", "", "__proto__", "toString", null, 7, {}, ["items.next"]]) {
+    assert.equal(isMethod(value), false, `${JSON.stringify(value)} was accepted`)
+    assert.equal(permits(CAPABILITY_IDS, value as Method), false)
+  }
+  assert.equal(isMethod("items.next"), true)
+})
+
+test("a capability that is not a capability is not a capability", () => {
+  for (const value of ["filesystem", "network", "", null, "__proto__"]) {
+    assert.equal(isCapability(value), false)
+  }
+  for (const id of CAPABILITY_IDS) assert.equal(isCapability(id), true)
+})
+
+test("every capability has a sentence a parent can read", () => {
+  for (const id of CAPABILITY_IDS) {
+    const label = labelOf(id)
+    assert.notEqual(label, id, `${id} has no parent-facing label`)
+    assert.ok(label.length > 12 && label.length < 80, `${id}: ${label}`)
+    assert.match(label, /^[A-Z]/)
+    // No jargon a parent would have to look up.
+    assert.doesNotMatch(label, /\b(API|IPC|capability|sandbox|IndexedDB)\b/i)
+  }
+})
+
+test("reading the answer early is its own grant, separate from asking questions", () => {
+  // A game that needs the key to place a target declares it; a game that does
+  // not, cannot get it by declaring `items`.
+  assert.equal(permits(["items"], "items.reveal"), false)
+  assert.equal(permits(["items.reveal"], "items.reveal"), true)
+})
+
+test("nothing in the table grants the things a pack must never have", () => {
+  const surface = JSON.stringify(CAPABILITIES).toLowerCase()
+  for (const forbidden of ["fetch", "network", "http", "file", "exec", "invoke", "eval", "camera", "microphone", "location"]) {
+    assert.ok(!surface.includes(forbidden), `the capability table mentions ${forbidden}`)
+  }
+})

--- a/dynawalla/packs/sdk/src/capabilities.ts
+++ b/dynawalla/packs/sdk/src/capabilities.ts
@@ -1,0 +1,115 @@
+// What a pack may ask the host for. The whole list.
+//
+// A pack is third-party code running in a children's product. It does not get
+// the native bridge, it does not get the filesystem, it does not get the
+// network, and it does not get an escape hatch — it gets the methods below and
+// nothing else. The isolation that makes that true is structural (an
+// opaque-origin sandboxed frame with its own CSP, see the host's `PackFrame`);
+// this table is what the host will answer once a pack is inside it.
+//
+// Two rules keep it honest:
+//
+//   1. Every method belongs to exactly one capability. `capabilityOf` is total
+//      over `METHODS` and a method with no capability is unreachable, so an
+//      added method cannot arrive ungated by omission.
+//   2. A capability the manifest does not declare is refused at the bridge,
+//      not merely absent from a helper the pack could have skipped.
+//
+// `session` is not in the list because it is not a grant: settings, progress
+// and end are how the frame is a frame at all, and a pack that could not
+// report a session ending would leak one.
+
+/** Methods every pack may call, with no declaration and no grant. */
+export const SESSION_METHODS = ["session.settings", "session.progress", "session.end"] as const
+
+export const CAPABILITIES = [
+  {
+    id: "items",
+    methods: ["items.next", "items.answer", "items.skip"],
+    /** Shown to a parent, in their language, before the pack is installed. */
+    label: "Ask for practice questions and report answers",
+  },
+  {
+    id: "items.reveal",
+    methods: ["items.reveal"],
+    label: "Read the answer to the current question before it is answered",
+  },
+  {
+    id: "learner.read",
+    methods: ["learner.summary"],
+    label: "Read which topics have been practised",
+  },
+  {
+    id: "haptics",
+    methods: ["feedback.haptic"],
+    label: "Vibrate the device",
+  },
+  {
+    id: "audio",
+    methods: ["feedback.sound"],
+    label: "Play the app's sounds",
+  },
+  {
+    id: "milestones",
+    methods: ["milestone.reach"],
+    label: "Mark that something was finished",
+  },
+  {
+    id: "storage",
+    methods: ["storage.get", "storage.set", "storage.remove", "storage.keys"],
+    label: "Save its own progress on this device",
+  },
+] as const
+
+export type Capability = (typeof CAPABILITIES)[number]["id"]
+
+export type SessionMethod = (typeof SESSION_METHODS)[number]
+export type CapabilityMethod = (typeof CAPABILITIES)[number]["methods"][number]
+export type Method = SessionMethod | CapabilityMethod
+
+export const CAPABILITY_IDS: readonly Capability[] = CAPABILITIES.map((entry) => entry.id)
+
+const BY_METHOD = new Map<string, Capability>(
+  CAPABILITIES.flatMap((entry) => entry.methods.map((method) => [method as string, entry.id])),
+)
+
+const SESSION = new Set<string>(SESSION_METHODS)
+
+export const METHODS: readonly Method[] = [
+  ...SESSION_METHODS,
+  ...CAPABILITIES.flatMap((entry) => entry.methods),
+]
+
+export function isMethod(value: unknown): value is Method {
+  return typeof value === "string" && (SESSION.has(value) || BY_METHOD.has(value))
+}
+
+export function isCapability(value: unknown): value is Capability {
+  return typeof value === "string" && CAPABILITY_IDS.includes(value as Capability)
+}
+
+/** The parent-facing label for a capability, for the install sheet. */
+export function labelOf(capability: Capability): string {
+  return CAPABILITIES.find((entry) => entry.id === capability)?.label ?? capability
+}
+
+/**
+ * The capability a method needs, or `null` when it needs none.
+ *
+ * `undefined` is never returned: an unknown method is not a method, and the
+ * bridge rejects it before asking. Callers get `null` only for the session
+ * methods, which is a different thing from "not gated yet".
+ */
+export function capabilityOf(method: Method): Capability | null {
+  if (SESSION.has(method)) return null
+  const capability = BY_METHOD.get(method)
+  return capability ?? null
+}
+
+/** Whether `granted` admits `method`. The single enforcement predicate. */
+export function permits(granted: Iterable<Capability>, method: Method): boolean {
+  const capability = capabilityOf(method)
+  if (capability === null) return SESSION.has(method)
+  for (const entry of granted) if (entry === capability) return true
+  return false
+}

--- a/dynawalla/packs/sdk/src/guest.test.ts
+++ b/dynawalla/packs/sdk/src/guest.test.ts
@@ -1,0 +1,290 @@
+// The guest client, driven over a real `MessageChannel`.
+//
+// Node has `MessageChannel` and `MessagePort`, so the only thing stubbed here
+// is the frame relationship — `window.parent` and one `postMessage`. Everything
+// the pack actually talks over is the real transport, which is what makes this
+// a test of the handshake rather than of a mock.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { connect, PackError } from "./guest.ts"
+import type { HostClient } from "./guest.ts"
+import type { Request, Response } from "./protocol.ts"
+
+type Listener = (event: { data: unknown; ports: readonly MessagePort[] }) => void
+
+type Frame = {
+  client: Promise<HostClient>
+  /** Requests the fake host received, in order. */
+  seen: Request[]
+  /** The host's end of the port, for pushing events at the pack. */
+  hostPort: MessagePort
+}
+
+/** Stand up a fake frame, then answer its `ready` the way the host does. */
+function withFakeFrame(
+  options: {
+    granted?: string[]
+    /** Answers one request. Return `undefined` to leave it pending. */
+    answer?: (request: Request) => Omit<Response, "id"> | undefined
+    framed?: boolean
+  } = {},
+): Frame {
+  const listeners = new Set<Listener>()
+  const seen: Request[] = []
+  const channel = new MessageChannel()
+
+  const postMessage = (data: unknown) => {
+    // This is the pack's `ready`. The host answers by transferring a port.
+    if ((data as { event?: string }).event !== "ready") return
+    queueMicrotask(() => {
+      for (const listener of [...listeners]) {
+        listener({
+          data: {
+            event: "connect",
+            protocol: 1,
+            sdk: "1.0.0",
+            host: "0.1.0",
+            packId: "abacus.tower",
+            granted: options.granted ?? ["items", "storage"],
+            settings: {
+              locale: "en",
+              reducedMotion: false,
+              quality: "high",
+              textScale: 1,
+              colorScheme: "light",
+              sound: true,
+              haptics: true,
+            },
+          },
+          ports: [channel.port2],
+        })
+      }
+    })
+  }
+
+  const fakeWindow: Record<string, unknown> = {
+    addEventListener: (_type: string, listener: Listener) => listeners.add(listener),
+    removeEventListener: (_type: string, listener: Listener) => listeners.delete(listener),
+    postMessage,
+  }
+  fakeWindow["parent"] = options.framed === false ? fakeWindow : { postMessage }
+  ;(globalThis as { window?: unknown }).window = fakeWindow
+
+  channel.port1.onmessage = (event: MessageEvent) => {
+    const request = event.data as Request
+    seen.push(request)
+    const reply = options.answer?.(request)
+    if (reply !== undefined) channel.port1.postMessage({ id: request.id, ...reply })
+  }
+  channel.port1.start()
+
+  open.push(channel.port1, channel.port2)
+  return { client: connect({ timeoutMs: 500 }), seen, hostPort: channel.port1 }
+}
+
+/**
+ * Ports opened by a test. A live `MessagePort` is a ref'd handle: leaving one
+ * open holds the event loop open and the whole run hangs after the last
+ * assertion passes, which looks exactly like a failing test and is not one.
+ */
+const open: MessagePort[] = []
+
+const cleanup = () => {
+  delete (globalThis as { window?: unknown }).window
+  for (const port of open.splice(0)) port.close()
+}
+
+const ok = (result: unknown) => ({ ok: true as const, result })
+
+test("the handshake completes and the grant set arrives with it", async (t) => {
+  t.after(cleanup)
+  const { client } = withFakeFrame({ granted: ["items"] })
+  const host = await client
+  assert.equal(host.packId, "abacus.tower")
+  assert.equal(host.hostVersion, "0.1.0")
+  assert.deepEqual(host.granted, ["items"])
+  assert.equal(host.settings.locale, "en")
+  assert.equal(host.can("items.next"), true)
+  assert.equal(host.can("storage.get"), false)
+  host.dispose()
+})
+
+test("an ungranted call fails locally, without reaching the host", async (t) => {
+  t.after(cleanup)
+  const { client, seen } = withFakeFrame({ granted: ["items"] })
+  const host = await client
+  await assert.rejects(
+    () => host.storage.get("k"),
+    (error: unknown) => error instanceof PackError && error.code === "denied",
+  )
+  // The point: the host never had to refuse it, so a denial costs no round trip
+  // and a pack cannot probe what a parent declined by timing the answer.
+  assert.deepEqual(seen, [])
+  host.dispose()
+})
+
+test("a call round-trips and returns the host's result", async (t) => {
+  t.after(cleanup)
+  const item = {
+    id: "i1",
+    skillId: "add.1",
+    level: 1,
+    form: "binary-op",
+    operands: ["2", "3"],
+    prompt: "2 plus 3",
+    answerKind: "integer",
+  }
+  const { client, seen } = withFakeFrame({
+    answer: (request) => (request.method === "items.next" ? ok({ item }) : ok({})),
+  })
+  const host = await client
+  assert.deepEqual(await host.nextItem({ skillId: "add.1" }), item)
+  assert.deepEqual(seen[0], { id: 1, method: "items.next", params: { skillId: "add.1" } })
+  host.dispose()
+})
+
+test("no item is null, not an error — a pack renders a finished session", async (t) => {
+  t.after(cleanup)
+  const { client } = withFakeFrame({ answer: () => ok({ item: null }) })
+  const host = await client
+  assert.equal(await host.nextItem(), null)
+  host.dispose()
+})
+
+test("an error response becomes a PackError carrying the host's code", async (t) => {
+  t.after(cleanup)
+  const { client } = withFakeFrame({
+    answer: () => ({ ok: false as const, error: { code: "rate_limited" as const, message: "slow down" } }),
+  })
+  const host = await client
+  await assert.rejects(
+    () => host.nextItem(),
+    (error: unknown) =>
+      error instanceof PackError && error.code === "rate_limited" && error.message === "slow down",
+  )
+  host.dispose()
+})
+
+test("answering reports the attempt and gets the canonical value back", async (t) => {
+  t.after(cleanup)
+  const { client, seen } = withFakeFrame({
+    answer: () =>
+      ok({ correct: false, canonical: "2203", diagnosis: "smaller-from-larger", advance: true }),
+  })
+  const host = await client
+  const judgement = await host.answer({
+    itemId: "i1",
+    response: "3797",
+    latencyMs: 4200,
+    revisions: 1,
+  })
+  assert.equal(judgement.correct, false)
+  // 5001 − 2798 = 2203. 3797 is smaller-from-larger, and the host is the only
+  // thing that gets to say so.
+  assert.equal(judgement.canonical, "2203")
+  assert.equal(judgement.diagnosis, "smaller-from-larger")
+  assert.deepEqual(seen[0]?.params, {
+    itemId: "i1",
+    response: "3797",
+    latencyMs: 4200,
+    revisions: 1,
+  })
+  host.dispose()
+})
+
+test("revisions default to zero rather than to undefined on the wire", async (t) => {
+  t.after(cleanup)
+  const { client, seen } = withFakeFrame({ answer: () => ok({}) })
+  const host = await client
+  await host.answer({ itemId: "i1", response: "5", latencyMs: 100 })
+  assert.equal((seen[0]?.params as { revisions: number }).revisions, 0)
+  host.dispose()
+})
+
+test("host events reach listeners, and settings follow the host", async (t) => {
+  t.after(cleanup)
+  const { client, hostPort } = withFakeFrame()
+  const host = await client
+
+  const paused: unknown[] = []
+  const off = host.on("pause", (data) => paused.push(data ?? "paused"))
+  hostPort.postMessage({ event: "pause" })
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  assert.deepEqual(paused, ["paused"])
+
+  off()
+  hostPort.postMessage({ event: "pause" })
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  assert.equal(paused.length, 1, "unsubscribing unsubscribed")
+
+  hostPort.postMessage({
+    event: "settings",
+    data: { ...host.settings, reducedMotion: true, quality: "low" },
+  })
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  assert.equal(host.settings.reducedMotion, true)
+  assert.equal(host.settings.quality, "low")
+  host.dispose()
+})
+
+test("a dispose event from the host closes the client", async (t) => {
+  t.after(cleanup)
+  const { client, hostPort } = withFakeFrame()
+  const host = await client
+  hostPort.postMessage({ event: "dispose" })
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  await assert.rejects(
+    () => host.nextItem(),
+    (error: unknown) => error instanceof PackError && error.code === "closed",
+  )
+})
+
+test("closing rejects everything still in flight instead of leaking it", async (t) => {
+  t.after(cleanup)
+  const { client } = withFakeFrame({ answer: () => undefined })
+  const host = await client
+  const pending = host.nextItem()
+  host.dispose()
+  await assert.rejects(
+    () => pending,
+    (error: unknown) => error instanceof PackError && error.code === "closed",
+  )
+})
+
+test("a document that is not framed says so instead of hanging", async (t) => {
+  t.after(cleanup)
+  const { client } = withFakeFrame({ framed: false })
+  await assert.rejects(
+    () => client,
+    (error: unknown) => error instanceof PackError && error.code === "no_host",
+  )
+})
+
+test("no host at all times out with a reason", async (t) => {
+  t.after(cleanup)
+  const listeners = new Set<Listener>()
+  ;(globalThis as { window?: unknown }).window = {
+    addEventListener: (_type: string, listener: Listener) => listeners.add(listener),
+    removeEventListener: (_type: string, listener: Listener) => listeners.delete(listener),
+    postMessage: () => {},
+    parent: { postMessage: () => {} },
+  }
+  await assert.rejects(
+    () => connect({ timeoutMs: 20 }),
+    (error: unknown) => error instanceof PackError && error.code === "timeout",
+  )
+})
+
+test("after dispose, every call fails closed and dispose is idempotent", async (t) => {
+  t.after(cleanup)
+  const { client } = withFakeFrame({ answer: () => ok({}) })
+  const host = await client
+  host.dispose()
+  host.dispose()
+  await assert.rejects(
+    () => host.nextItem(),
+    (error: unknown) => error instanceof PackError && error.code === "closed",
+  )
+})

--- a/dynawalla/packs/sdk/src/guest.ts
+++ b/dynawalla/packs/sdk/src/guest.ts
@@ -1,0 +1,262 @@
+// The pack's side of the wire: `connect()` and a typed client.
+//
+// A pack does `const host = await connect()` and then calls methods. It never
+// touches `postMessage`, never sees an envelope, and never has to know that the
+// grant set it was given is the reason a method it declared is missing — the
+// client simply does not expose an ungranted surface, so "hide what you cannot
+// drive" is the default rather than a discipline.
+//
+// The handshake, in full:
+//
+//   1. The pack document loads and this module posts `{ event: "ready" }` to
+//      its parent.
+//   2. The host answers by transferring one end of a `MessageChannel`.
+//   3. Everything after that is on the port.
+//
+// Step 2 is the capability: an opaque-origin frame has no reference to the
+// host, cannot name it, and cannot obtain a port by asking a third party for
+// one. The `connect` payload itself carries no secret — a token would have to
+// be posted with `targetOrigin: "*"` (an opaque origin cannot be named either)
+// and would therefore be worth nothing.
+
+import type { Capability, Method } from "./capabilities.ts"
+import { permits } from "./capabilities.ts"
+import type {
+  Connect,
+  HapticCue,
+  HostEventName,
+  Item,
+  Judgement,
+  LearnerSummary,
+  Settings,
+  SoundCue,
+} from "./protocol.ts"
+import { isConnect, isResponse, PROTOCOL_VERSION } from "./protocol.ts"
+
+export class PackError extends Error {
+  readonly code: string
+  constructor(code: string, message: string) {
+    super(message)
+    this.name = "PackError"
+    this.code = code
+  }
+}
+
+export type HostClient = {
+  readonly packId: string
+  /** The host app's version, for a pack that renders a compatibility note. */
+  readonly hostVersion: string
+  readonly granted: readonly Capability[]
+  /** Live: re-read it, it follows the host's `settings` event. */
+  readonly settings: Settings
+
+  can(method: Method): boolean
+
+  /** The next question for this pack, or `null` when the host has none. */
+  nextItem(options?: { skillId?: string }): Promise<Item | null>
+  /**
+   * Record an attempt and learn whether it was right.
+   *
+   * The attempt is recorded before the answer comes back, which is what makes
+   * `canonical` safe to return: there is no way to read it without spending
+   * the attempt.
+   */
+  answer(input: {
+    itemId: string
+    response: string
+    latencyMs: number
+    revisions?: number
+  }): Promise<Judgement>
+  skip(itemId: string): Promise<void>
+  /** Requires the `items.reveal` capability. */
+  reveal(itemId: string): Promise<string>
+
+  learnerSummary(): Promise<LearnerSummary>
+  haptic(cue: HapticCue): Promise<void>
+  sound(cue: SoundCue): Promise<void>
+  milestone(name: string): Promise<void>
+
+  storage: {
+    get(key: string): Promise<string | null>
+    set(key: string, value: string): Promise<void>
+    remove(key: string): Promise<void>
+    keys(): Promise<string[]>
+  }
+
+  /** Fraction in 0–1. The host draws the progress, the pack does not. */
+  progress(fraction: number): Promise<void>
+  end(reason: "finished" | "quit"): Promise<void>
+
+  on(event: HostEventName, listener: (data: unknown) => void): () => void
+  dispose(): void
+}
+
+type Pending = {
+  resolve: (value: unknown) => void
+  reject: (error: PackError) => void
+}
+
+const DEFAULT_TIMEOUT_MS = 15_000
+
+/**
+ * Wait for the host to hand over a port.
+ *
+ * Rejects rather than hanging: a pack that is loaded outside a host — opened
+ * directly in a browser, say — should say so on its own surface instead of
+ * showing a frozen loading state forever.
+ */
+export function connect(options: { timeoutMs?: number } = {}): Promise<HostClient> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  return new Promise<HostClient>((resolve, reject) => {
+    if (typeof window === "undefined" || window.parent === window) {
+      reject(new PackError("no_host", "this document is not framed by a Dynawalla host"))
+      return
+    }
+
+    const timer = setTimeout(() => {
+      window.removeEventListener("message", onMessage)
+      reject(new PackError("timeout", `no host connect within ${timeoutMs}ms`))
+    }, timeoutMs)
+
+    const onMessage = (event: MessageEvent) => {
+      if (!isConnect(event.data)) return
+      const port = event.ports[0]
+      if (!port) return
+      clearTimeout(timer)
+      window.removeEventListener("message", onMessage)
+      resolve(makeClient(event.data, port))
+    }
+
+    window.addEventListener("message", onMessage)
+    // The host is listening for this before it frames anything.
+    window.parent.postMessage({ event: "ready", protocol: PROTOCOL_VERSION }, "*")
+  })
+}
+
+function makeClient(connectMessage: Connect, port: MessagePort): HostClient {
+  const pending = new Map<number, Pending>()
+  const listeners = new Map<HostEventName, Set<(data: unknown) => void>>()
+  let nextId = 1
+  let closed = false
+
+  const settings: { current: Settings } = { current: connectMessage.settings }
+
+  port.onmessage = (event: MessageEvent) => {
+    const data: unknown = event.data
+    if (isResponse(data)) {
+      const entry = pending.get(data.id)
+      if (!entry) return
+      pending.delete(data.id)
+      if (data.ok) entry.resolve(data.result)
+      else entry.reject(new PackError(data.error.code, data.error.message))
+      return
+    }
+    if (typeof data === "object" && data !== null && "event" in data) {
+      const name = (data as { event: HostEventName }).event
+      const payload = (data as { data?: unknown }).data
+      if (name === "settings" && payload && typeof payload === "object") {
+        settings.current = payload as Settings
+      }
+      for (const listener of listeners.get(name) ?? []) listener(payload)
+      if (name === "dispose") close()
+    }
+  }
+  port.start()
+
+  const close = () => {
+    if (closed) return
+    closed = true
+    for (const entry of pending.values()) {
+      entry.reject(new PackError("closed", "the host closed this pack"))
+    }
+    pending.clear()
+    port.onmessage = null
+    port.close()
+  }
+
+  const call = (method: Method, params: Record<string, unknown> = {}): Promise<unknown> => {
+    if (closed) return Promise.reject(new PackError("closed", "the host closed this pack"))
+    if (!permits(connectMessage.granted, method)) {
+      // Locally, without a round trip: the host would refuse this anyway, and a
+      // pack should not be able to tell the difference between a capability it
+      // did not declare and one the parent declined.
+      return Promise.reject(new PackError("denied", `${method} was not granted to this pack`))
+    }
+    const id = nextId++
+    return new Promise<unknown>((resolve, reject) => {
+      pending.set(id, { resolve, reject })
+      port.postMessage({ id, method, params })
+    })
+  }
+
+  return {
+    packId: connectMessage.packId,
+    hostVersion: connectMessage.host,
+    granted: connectMessage.granted,
+    get settings() {
+      return settings.current
+    },
+
+    can: (method) => permits(connectMessage.granted, method),
+
+    nextItem: async (options = {}) => {
+      const result = await call(
+        "items.next",
+        options.skillId === undefined ? {} : { skillId: options.skillId },
+      )
+      return (result as { item: Item | null }).item
+    },
+    answer: async (input) =>
+      (await call("items.answer", {
+        itemId: input.itemId,
+        response: input.response,
+        latencyMs: input.latencyMs,
+        revisions: input.revisions ?? 0,
+      })) as Judgement,
+    skip: async (itemId) => {
+      await call("items.skip", { itemId })
+    },
+    reveal: async (itemId) =>
+      ((await call("items.reveal", { itemId })) as { canonical: string }).canonical,
+
+    learnerSummary: async () => (await call("learner.summary")) as LearnerSummary,
+    haptic: async (cue) => {
+      await call("feedback.haptic", { cue })
+    },
+    sound: async (cue) => {
+      await call("feedback.sound", { cue })
+    },
+    milestone: async (name) => {
+      await call("milestone.reach", { name })
+    },
+
+    storage: {
+      get: async (key) => ((await call("storage.get", { key })) as { value: string | null }).value,
+      set: async (key, value) => {
+        await call("storage.set", { key, value })
+      },
+      remove: async (key) => {
+        await call("storage.remove", { key })
+      },
+      keys: async () => ((await call("storage.keys")) as { keys: string[] }).keys,
+    },
+
+    progress: async (fraction) => {
+      await call("session.progress", { fraction })
+    },
+    end: async (reason) => {
+      await call("session.end", { reason })
+    },
+
+    on: (event, listener) => {
+      const set = listeners.get(event) ?? new Set()
+      set.add(listener)
+      listeners.set(event, set)
+      return () => {
+        set.delete(listener)
+      }
+    },
+
+    dispose: close,
+  }
+}

--- a/dynawalla/packs/sdk/src/index.ts
+++ b/dynawalla/packs/sdk/src/index.ts
@@ -1,0 +1,66 @@
+// The pack SDK's public surface.
+//
+// A pack imports from here and from nowhere else. The host imports the same
+// modules — one copy of the contract, so a change that would break a pack
+// cannot typecheck in the host either.
+
+export {
+  CAPABILITIES,
+  CAPABILITY_IDS,
+  METHODS,
+  SESSION_METHODS,
+  capabilityOf,
+  isCapability,
+  isMethod,
+  labelOf,
+  permits,
+} from "./capabilities.ts"
+export type { Capability, Method, CapabilityMethod, SessionMethod } from "./capabilities.ts"
+
+export {
+  MANIFEST_SCHEMA,
+  MAX_DOWNLOAD_BYTES,
+  MAX_FILES,
+  MAX_INSTALLED_BYTES,
+  INTEGRITY_PATTERN,
+  PACK_ID_PATTERN,
+  isSafeRelativePath,
+  localizedDescription,
+  localizedName,
+  parseManifest,
+} from "./manifest.ts"
+export type { ManifestResult, PackManifest } from "./manifest.ts"
+
+export {
+  MAX_REQUESTS_PER_SECOND,
+  PROTOCOL_VERSION,
+  SDK_VERSION,
+  isConnect,
+  isHostEvent,
+  isResponse,
+  numberParam,
+  parseRequest,
+  stringParam,
+} from "./protocol.ts"
+export type {
+  Connect,
+  ErrorCode,
+  HapticCue,
+  HostEvent,
+  HostEventName,
+  Item,
+  ItemChoice,
+  Judgement,
+  LearnerSummary,
+  ParsedRequest,
+  Request,
+  Response,
+  Settings,
+  SoundCue,
+} from "./protocol.ts"
+
+export { compareSemver, compareVersions, isSemver, parseSemver, satisfies, sdkCompatible } from "./semver.ts"
+export type { HostRange, Semver } from "./semver.ts"
+
+export { PackError, connect } from "./guest.ts"
+export type { HostClient } from "./guest.ts"

--- a/dynawalla/packs/sdk/src/manifest.test.ts
+++ b/dynawalla/packs/sdk/src/manifest.test.ts
@@ -1,0 +1,174 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import {
+  MAX_INSTALLED_BYTES,
+  isSafeRelativePath,
+  localizedDescription,
+  localizedName,
+  parseManifest,
+} from "./manifest.ts"
+import type { PackManifest } from "./manifest.ts"
+
+/** A manifest that is valid, so a test can make exactly one thing wrong. */
+const valid = () => ({
+  schema: 1,
+  id: "abacus.tower",
+  version: "1.2.0",
+  name: "Abacus Tower",
+  description: "Carry beads up the tower.",
+  sdk: "1.0.0",
+  host: { min: "0.1.0", max: "1.0.0" },
+  entry: "index.html",
+  capabilities: ["items", "haptics"],
+  covers: { skills: ["add.2digit.regroup"], grades: [1, 3] },
+  locales: ["en", "es"],
+  assets: { files: 42, bytes: 3_000_000 },
+  download: { url: "https://packs.example/abacus-tower-1.2.0.zip", bytes: 900_000, sha256: "a".repeat(64) },
+})
+
+const problemsFor = (mutate: (draft: Record<string, unknown>) => void): readonly string[] => {
+  const draft = valid() as unknown as Record<string, unknown>
+  mutate(draft)
+  const result = parseManifest(draft)
+  assert.equal(result.ok, false, "expected this manifest to be rejected")
+  return result.ok ? [] : result.problems
+}
+
+test("a well-formed manifest parses", () => {
+  const result = parseManifest(valid())
+  assert.equal(result.ok, true, result.ok ? "" : result.problems.join("; "))
+})
+
+test("every problem is reported, not just the first", () => {
+  const problems = problemsFor((draft) => {
+    draft["version"] = "1.2"
+    draft["entry"] = "app.js"
+    draft["capabilities"] = ["items", "root"]
+  })
+  assert.ok(problems.length >= 3, `expected three problems, got ${problems.join("; ")}`)
+})
+
+test("the entry must be a document, because a pack is framed and never evaluated", () => {
+  const problems = problemsFor((draft) => {
+    draft["entry"] = "dist/app.js"
+  })
+  assert.ok(problems.some((p) => p.includes("framed")))
+})
+
+test("an entry path cannot climb out of the pack", () => {
+  for (const entry of ["../secrets.html", "/etc/passwd", "a/../../b.html", "C:\\x.html", "x\\y.html"]) {
+    assert.equal(isSafeRelativePath(entry), false, `${entry} was accepted`)
+  }
+  assert.equal(isSafeRelativePath("index.html"), true)
+  assert.equal(isSafeRelativePath("dist/index.html"), true)
+})
+
+test("an unknown capability is refused by name", () => {
+  const problems = problemsFor((draft) => {
+    draft["capabilities"] = ["items", "filesystem"]
+  })
+  assert.ok(problems.some((p) => p.includes("filesystem")))
+})
+
+test("a duplicated capability is refused, so a grant set cannot be padded", () => {
+  const problems = problemsFor((draft) => {
+    draft["capabilities"] = ["items", "items"]
+  })
+  assert.ok(problems.some((p) => p.includes("duplicate")))
+})
+
+test("integrity must be sha-256 hex, and sizes must be real", () => {
+  assert.ok(
+    problemsFor((draft) => {
+      draft["download"] = { bytes: 10, sha256: "not-a-hash" }
+    }).some((p) => p.includes("sha256")),
+  )
+  assert.ok(
+    problemsFor((draft) => {
+      draft["download"] = { bytes: 0, sha256: "b".repeat(64) }
+    }).some((p) => p.includes("bytes")),
+  )
+  assert.ok(
+    problemsFor((draft) => {
+      draft["assets"] = { files: 1, bytes: MAX_INSTALLED_BYTES + 1 }
+    }).some((p) => p.includes("assets.bytes")),
+  )
+})
+
+test("a download origin is https or the manifest never ships", () => {
+  assert.ok(
+    problemsFor((draft) => {
+      draft["download"] = {
+        url: "http://packs.example/x.zip",
+        bytes: 10,
+        sha256: "c".repeat(64),
+      }
+    }).some((p) => p.includes("https")),
+  )
+})
+
+test("a pack with no download url is legal — it shipped with the app", () => {
+  const draft = valid() as unknown as Record<string, unknown>
+  draft["download"] = { bytes: 900_000, sha256: "d".repeat(64) }
+  assert.equal(parseManifest(draft).ok, true)
+})
+
+test("ids are the on-disk directory name and are constrained to look like one", () => {
+  for (const id of ["Abacus", "../x", "a b", "a/b", "9lives", "", "a".repeat(65)]) {
+    const problems = problemsFor((draft) => {
+      draft["id"] = id
+    })
+    assert.ok(problems.some((p) => p.startsWith("id must")), `${id} was accepted`)
+  }
+  for (const id of ["abacus", "abacus.tower", "abacus-tower", "a1.b2-c3"]) {
+    const draft = valid() as unknown as Record<string, unknown>
+    draft["id"] = id
+    assert.equal(parseManifest(draft).ok, true, `${id} was rejected`)
+  }
+})
+
+test("a grade band is inclusive, ordered and inside 0–12", () => {
+  for (const grades of [[3, 1], [-1, 3], [1, 13], [1], [1, 2, 3], ["1", "3"]]) {
+    const problems = problemsFor((draft) => {
+      const covers = draft["covers"] as Record<string, unknown>
+      draft["covers"] = { ...covers, grades }
+    })
+    assert.ok(problems.some((p) => p.includes("covers.grades")), `${JSON.stringify(grades)} passed`)
+  }
+})
+
+test("en is required, because name and description are the fallback", () => {
+  assert.ok(
+    problemsFor((draft) => {
+      draft["locales"] = ["es"]
+    }).some((p) => p.includes("en")),
+  )
+})
+
+test("a schema bump is a wall, not a warning", () => {
+  assert.ok(
+    problemsFor((draft) => {
+      draft["schema"] = 2
+    }).some((p) => p.includes("schema")),
+  )
+})
+
+test("nothing but an object is a manifest", () => {
+  for (const input of [null, undefined, 7, "{}", [], true]) {
+    assert.equal(parseManifest(input).ok, false)
+  }
+})
+
+test("localisation falls back by base tag and then to the plain field", () => {
+  const manifest = {
+    ...valid(),
+    nameLocalized: { es: "Torre de ábaco" },
+    descriptionLocalized: { es: "Sube las cuentas." },
+  } as unknown as PackManifest
+  assert.equal(localizedName(manifest, "es"), "Torre de ábaco")
+  assert.equal(localizedName(manifest, "es-MX"), "Torre de ábaco", "base tag")
+  assert.equal(localizedName(manifest, "fr"), "Abacus Tower", "fallback")
+  assert.equal(localizedDescription(manifest, "fr"), "Carry beads up the tower.")
+  assert.equal(localizedName(valid() as unknown as PackManifest, "es"), "Abacus Tower")
+})

--- a/dynawalla/packs/sdk/src/manifest.ts
+++ b/dynawalla/packs/sdk/src/manifest.ts
@@ -1,0 +1,307 @@
+// The pack manifest, and the validator that is the only way to get one.
+//
+// A manifest arrives from a catalog over the network and from a ZIP on disk,
+// and the two are compared against each other, so this parser treats its input
+// as hostile in both directions. It reports **every** problem rather than the
+// first: a pack author fixing one field at a time across a build-publish cycle
+// is how a schema gets a reputation, and the same list is what a support reply
+// needs.
+//
+// Fields exist here for one of three reasons and no others:
+//
+//   * the host cannot install without it (id, version, integrity, sizes),
+//   * the host cannot decide whether to run it (host range, sdk, capabilities),
+//   * a parent or the router has to choose between packs (name, covers,
+//     locales).
+//
+// There is no field for anything a pack could put in its own files.
+
+import type { Capability } from "./capabilities.ts"
+import { CAPABILITY_IDS } from "./capabilities.ts"
+import { isSemver } from "./semver.ts"
+
+/** Bumped only for a change that an older host would misread. */
+export const MANIFEST_SCHEMA = 1
+
+/** Lower-case dotted segments. Stable forever: it is the on-disk directory. */
+export const PACK_ID_PATTERN = /^[a-z][a-z0-9]*(?:[-.][a-z0-9]+)*$/
+
+/** SHA-256, lower-case hex. The only integrity algorithm this schema admits. */
+export const INTEGRITY_PATTERN = /^[0-9a-f]{64}$/
+
+/**
+ * 512 MB installed. Large enough for a 3D world with audio, small enough that
+ * the number is a decision rather than an accident, and it bounds what a
+ * malicious archive can do to a device before the extractor gives up.
+ */
+export const MAX_INSTALLED_BYTES = 512 * 1024 * 1024
+
+/** 256 MB compressed. */
+export const MAX_DOWNLOAD_BYTES = 256 * 1024 * 1024
+
+export const MAX_FILES = 20_000
+
+export type PackManifest = {
+  readonly schema: number
+  readonly id: string
+  readonly version: string
+  /** English fallback. `nameLocalized[locale]` is preferred when present. */
+  readonly name: string
+  readonly nameLocalized?: Readonly<Record<string, string>>
+  readonly description: string
+  readonly descriptionLocalized?: Readonly<Record<string, string>>
+  /** The SDK version the pack was built against. */
+  readonly sdk: string
+  /** Host app versions this pack runs on: `min` inclusive, `max` exclusive. */
+  readonly host: { readonly min: string; readonly max?: string }
+  /** Relative path to the document the host frames. Always an HTML file. */
+  readonly entry: string
+  readonly capabilities: readonly Capability[]
+  /** What the pack can teach, so the router can hand it a skill. */
+  readonly covers: {
+    readonly skills: readonly string[]
+    /** Inclusive school-grade band. `[1, 3]` is grades one to three. */
+    readonly grades: readonly [number, number]
+  }
+  /** BCP-47 tags the pack renders. `en` is required. */
+  readonly locales: readonly string[]
+  readonly assets: { readonly files: number; readonly bytes: number }
+  readonly download: {
+    /** Absent for a pack that ships with the app or is side-loaded in dev. */
+    readonly url?: string
+    readonly bytes: number
+    readonly sha256: string
+  }
+}
+
+export type ManifestResult =
+  | { readonly ok: true; readonly manifest: PackManifest }
+  | { readonly ok: false; readonly problems: readonly string[] }
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const stringArray = (value: unknown): string[] | null => {
+  if (!Array.isArray(value)) return null
+  const out: string[] = []
+  for (const entry of value) {
+    if (typeof entry !== "string") return null
+    out.push(entry)
+  }
+  return out
+}
+
+const localizedMap = (value: unknown): Record<string, string> | null => {
+  if (!isRecord(value)) return null
+  const out: Record<string, string> = {}
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry !== "string") return null
+    out[key] = entry
+  }
+  return out
+}
+
+/**
+ * An entry path that cannot leave the pack directory and cannot be mistaken for
+ * an absolute or a UNC path on any platform the app ships to.
+ *
+ * The Rust side re-checks this against a canonicalised root — a path rule
+ * enforced only in TypeScript is a comment — but rejecting it here means a
+ * malformed pack fails at validation with a readable reason instead of at a
+ * 404 the user has to interpret.
+ */
+export function isSafeRelativePath(value: string): boolean {
+  if (value.length === 0 || value.length > 512) return false
+  if (value.startsWith("/") || value.startsWith("\\")) return false
+  if (/^[a-zA-Z]:/.test(value)) return false
+  if (value.includes("\\")) return false
+  if (value.includes("\0")) return false
+  for (const segment of value.split("/")) {
+    if (segment === "" || segment === "." || segment === "..") return false
+  }
+  return true
+}
+
+/** Parse and validate. The only constructor of a `PackManifest`. */
+export function parseManifest(input: unknown): ManifestResult {
+  const problems: string[] = []
+  const fail = (message: string) => problems.push(message)
+
+  if (!isRecord(input)) {
+    return { ok: false, problems: ["manifest is not an object"] }
+  }
+
+  const schema = input["schema"]
+  if (schema !== MANIFEST_SCHEMA) {
+    fail(`schema must be ${MANIFEST_SCHEMA}, got ${JSON.stringify(schema)}`)
+  }
+
+  const id = input["id"]
+  if (typeof id !== "string" || !PACK_ID_PATTERN.test(id) || id.length > 64) {
+    fail(`id must match ${PACK_ID_PATTERN.source} and be at most 64 characters`)
+  }
+
+  const version = input["version"]
+  if (typeof version !== "string" || !isSemver(version)) {
+    fail("version must be a semantic version")
+  }
+
+  const name = input["name"]
+  if (typeof name !== "string" || name.trim().length === 0 || name.length > 64) {
+    fail("name must be a non-empty string of at most 64 characters")
+  }
+
+  const description = input["description"]
+  if (typeof description !== "string" || description.length > 280) {
+    fail("description must be a string of at most 280 characters")
+  }
+
+  const nameLocalized = input["nameLocalized"]
+  if (nameLocalized !== undefined && localizedMap(nameLocalized) === null) {
+    fail("nameLocalized must map locale tags to strings")
+  }
+  const descriptionLocalized = input["descriptionLocalized"]
+  if (descriptionLocalized !== undefined && localizedMap(descriptionLocalized) === null) {
+    fail("descriptionLocalized must map locale tags to strings")
+  }
+
+  const sdk = input["sdk"]
+  if (typeof sdk !== "string" || !isSemver(sdk)) {
+    fail("sdk must be the semantic version of the SDK the pack was built against")
+  }
+
+  const host = input["host"]
+  if (!isRecord(host)) {
+    fail("host must be { min, max? }")
+  } else {
+    const min = host["min"]
+    const max = host["max"]
+    if (typeof min !== "string" || !isSemver(min)) fail("host.min must be a semantic version")
+    if (max !== undefined && (typeof max !== "string" || !isSemver(max))) {
+      fail("host.max must be a semantic version when present")
+    }
+  }
+
+  const entry = input["entry"]
+  if (typeof entry !== "string" || !isSafeRelativePath(entry)) {
+    fail("entry must be a relative path inside the pack")
+  } else if (!entry.endsWith(".html")) {
+    // The document IS the isolation boundary: the host frames it, it does not
+    // evaluate it. A script entry would put pack code in the host's realm,
+    // which is the one thing this design exists to prevent.
+    fail("entry must be an .html document — a pack is framed, never evaluated")
+  }
+
+  const capabilities = stringArray(input["capabilities"])
+  if (capabilities === null) {
+    fail("capabilities must be an array of strings")
+  } else {
+    for (const capability of capabilities) {
+      if (!CAPABILITY_IDS.includes(capability as Capability)) {
+        fail(`unknown capability: ${capability}`)
+      }
+    }
+    if (new Set(capabilities).size !== capabilities.length) {
+      fail("capabilities contains a duplicate")
+    }
+  }
+
+  const covers = input["covers"]
+  if (!isRecord(covers)) {
+    fail("covers must be { skills, grades }")
+  } else {
+    const skills = stringArray(covers["skills"])
+    if (skills === null || skills.length === 0) {
+      fail("covers.skills must be a non-empty array of skill ids")
+    } else if (skills.length > 512) {
+      fail("covers.skills is capped at 512 entries")
+    }
+    const grades = covers["grades"]
+    if (
+      !Array.isArray(grades) ||
+      grades.length !== 2 ||
+      typeof grades[0] !== "number" ||
+      typeof grades[1] !== "number" ||
+      !Number.isInteger(grades[0]) ||
+      !Number.isInteger(grades[1]) ||
+      grades[0] < 0 ||
+      grades[1] > 12 ||
+      grades[0] > grades[1]
+    ) {
+      fail("covers.grades must be an inclusive [low, high] band within 0–12")
+    }
+  }
+
+  const locales = stringArray(input["locales"])
+  if (locales === null || locales.length === 0) {
+    fail("locales must be a non-empty array of BCP-47 tags")
+  } else if (!locales.includes("en")) {
+    // Not chauvinism: `name` and `description` above are the English fallback,
+    // and a pack whose only locale is one the device does not have would render
+    // nothing at all.
+    fail("locales must include en, which is the fallback for name and description")
+  }
+
+  const assets = input["assets"]
+  if (!isRecord(assets)) {
+    fail("assets must be { files, bytes }")
+  } else {
+    const files = assets["files"]
+    const bytes = assets["bytes"]
+    if (typeof files !== "number" || !Number.isInteger(files) || files <= 0 || files > MAX_FILES) {
+      fail(`assets.files must be an integer in 1–${MAX_FILES}`)
+    }
+    if (
+      typeof bytes !== "number" ||
+      !Number.isInteger(bytes) ||
+      bytes <= 0 ||
+      bytes > MAX_INSTALLED_BYTES
+    ) {
+      fail(`assets.bytes must be an integer in 1–${MAX_INSTALLED_BYTES}`)
+    }
+  }
+
+  const download = input["download"]
+  if (!isRecord(download)) {
+    fail("download must be { url?, bytes, sha256 }")
+  } else {
+    const url = download["url"]
+    if (url !== undefined && typeof url !== "string") {
+      fail("download.url must be a string when present")
+    } else if (typeof url === "string" && !url.startsWith("https://")) {
+      // The host fetches this natively, not from the WebView, and it will
+      // refuse a non-pinned origin as well — but a manifest that states
+      // `http://` should never reach a device in the first place.
+      fail("download.url must be https")
+    }
+    const bytes = download["bytes"]
+    if (
+      typeof bytes !== "number" ||
+      !Number.isInteger(bytes) ||
+      bytes <= 0 ||
+      bytes > MAX_DOWNLOAD_BYTES
+    ) {
+      fail(`download.bytes must be an integer in 1–${MAX_DOWNLOAD_BYTES}`)
+    }
+    const sha256 = download["sha256"]
+    if (typeof sha256 !== "string" || !INTEGRITY_PATTERN.test(sha256)) {
+      fail("download.sha256 must be 64 lower-case hex characters")
+    }
+  }
+
+  if (problems.length > 0) return { ok: false, problems }
+  return { ok: true, manifest: input as unknown as PackManifest }
+}
+
+/** The display name for a locale, falling back the way the schema promises. */
+export function localizedName(manifest: PackManifest, locale: string): string {
+  const map = manifest.nameLocalized
+  if (!map) return manifest.name
+  return map[locale] ?? map[locale.split("-")[0] ?? ""] ?? manifest.name
+}
+
+export function localizedDescription(manifest: PackManifest, locale: string): string {
+  const map = manifest.descriptionLocalized
+  if (!map) return manifest.description
+  return map[locale] ?? map[locale.split("-")[0] ?? ""] ?? manifest.description
+}

--- a/dynawalla/packs/sdk/src/protocol.test.ts
+++ b/dynawalla/packs/sdk/src/protocol.test.ts
@@ -1,0 +1,114 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import {
+  isConnect,
+  isHostEvent,
+  isResponse,
+  numberParam,
+  parseRequest,
+  stringParam,
+} from "./protocol.ts"
+
+test("a well-formed request parses and carries an object of params", () => {
+  const parsed = parseRequest({ id: 3, method: "items.next", params: { skillId: "add.1" } })
+  assert.equal(parsed.ok, true)
+  if (!parsed.ok) return
+  assert.equal(parsed.request.id, 3)
+  assert.equal(parsed.request.method, "items.next")
+  assert.deepEqual(parsed.request.params, { skillId: "add.1" })
+})
+
+test("missing params become an empty object rather than undefined", () => {
+  const parsed = parseRequest({ id: 0, method: "session.end" })
+  assert.equal(parsed.ok, true)
+  if (!parsed.ok) return
+  assert.deepEqual(parsed.request.params, {})
+})
+
+test("an unknown method is unknown_method, not invalid_params", () => {
+  // The distinction matters: one is a pack built against a newer SDK, which the
+  // host can tell a parent about; the other is a bug in the pack.
+  const parsed = parseRequest({ id: 1, method: "items.eval" })
+  assert.equal(parsed.ok, false)
+  if (parsed.ok) return
+  assert.equal(parsed.code, "unknown_method")
+})
+
+test("everything that is not a request is rejected", () => {
+  const bad: unknown[] = [
+    null,
+    undefined,
+    7,
+    "items.next",
+    [],
+    {},
+    { id: 1 },
+    { method: "items.next" },
+    { id: -1, method: "items.next" },
+    { id: 1.5, method: "items.next" },
+    { id: Number.MAX_SAFE_INTEGER + 2, method: "items.next" },
+    { id: "1", method: "items.next" },
+    { id: 1, method: "items.next", params: [] },
+    { id: 1, method: "items.next", params: "x" },
+  ]
+  for (const value of bad) {
+    assert.equal(parseRequest(value).ok, false, `${JSON.stringify(value)} parsed`)
+  }
+})
+
+test("a prototype-polluting payload is just data", () => {
+  // Structured clone will not carry a prototype across, but the guard should
+  // not depend on that: `params` is read with bracket access and never spread
+  // onto anything the host owns.
+  const parsed = parseRequest(JSON.parse('{"id":1,"method":"storage.set","params":{"__proto__":{"x":1},"key":"k","value":"v"}}'))
+  assert.equal(parsed.ok, true)
+  if (!parsed.ok) return
+  assert.equal(stringParam(parsed.request.params, "key"), "k")
+  assert.equal(({} as Record<string, unknown>)["x"], undefined)
+})
+
+test("string parameters are present, non-empty and bounded", () => {
+  assert.equal(stringParam({ k: "v" }, "k"), "v")
+  assert.equal(stringParam({ k: "" }, "k"), null)
+  assert.equal(stringParam({ k: "x".repeat(257) }, "k"), null)
+  assert.equal(stringParam({ k: "x".repeat(257) }, "k", 300), "x".repeat(257))
+  assert.equal(stringParam({}, "k"), null)
+  assert.equal(stringParam({ k: 7 }, "k"), null)
+  assert.equal(stringParam({ k: null }, "k"), null)
+})
+
+test("number parameters clamp rather than reject, but refuse nonsense", () => {
+  assert.equal(numberParam({ n: 5 }, "n", 10), 5)
+  assert.equal(numberParam({ n: 50 }, "n", 10), 10, "a long latency is clamped, not an error")
+  assert.equal(numberParam({ n: -1 }, "n", 10), null)
+  assert.equal(numberParam({ n: Number.NaN }, "n", 10), null)
+  assert.equal(numberParam({ n: Number.POSITIVE_INFINITY }, "n", 10), null)
+  assert.equal(numberParam({ n: "5" }, "n", 10), null)
+})
+
+test("the guards a pack uses on host traffic are equally exact", () => {
+  assert.equal(isResponse({ id: 1, ok: true, result: null }), true)
+  assert.equal(isResponse({ id: 1, ok: false, error: { code: "denied", message: "" } }), true)
+  assert.equal(isResponse({ id: 1, ok: false }), false)
+  assert.equal(isResponse({ ok: true, result: 1 }), false)
+  assert.equal(isResponse(null), false)
+
+  assert.equal(isHostEvent({ event: "pause" }), true)
+  assert.equal(isHostEvent({ event: "settings", data: {} }), true)
+  assert.equal(isHostEvent({ event: "connect" }), false)
+  assert.equal(isHostEvent({ event: "destroy" }), false)
+
+  const connect = {
+    event: "connect",
+    protocol: 1,
+    sdk: "1.0.0",
+    host: "0.1.0",
+    packId: "abacus.tower",
+    granted: ["items"],
+    settings: {},
+  }
+  assert.equal(isConnect(connect), true)
+  assert.equal(isConnect({ ...connect, granted: "items" }), false)
+  assert.equal(isConnect({ ...connect, event: "ready" }), false)
+})

--- a/dynawalla/packs/sdk/src/protocol.ts
+++ b/dynawalla/packs/sdk/src/protocol.ts
@@ -1,0 +1,242 @@
+// The host↔pack wire, and the guards that make it a boundary rather than a
+// convention.
+//
+// Everything crossing it is a structured-clone of plain data over a
+// `MessagePort`, so every value arriving from a pack is attacker-controlled and
+// is validated here before anything else looks at it. The guards are exhaustive
+// and they are the only way in: `parseRequest` returns a typed request or a
+// reason, never a partially-trusted object.
+//
+// Shape of one exchange:
+//
+//     pack → host   { id: 7, method: "items.answer", params: {...} }
+//     host → pack   { id: 7, ok: true, result: {...} }
+//               or  { id: 7, ok: false, error: { code, message } }
+//
+// and, unsolicited, host → pack `{ event: "pause" }`.
+//
+// ── Why the host judges ──────────────────────────────────────────────────────
+// `items.next` does not carry the answer. `items.answer` records the attempt
+// and *then* returns the canonical value, so a pack cannot learn what is
+// correct without spending the attempt it would have to report anyway. The
+// consequence is the one that matters for a mathematics product: a game cannot
+// be beaten by fiddling with what it renders, because the thing that decides
+// whether the child was right is not in the game.
+//
+// `items.reveal` is the deliberate exception, for a game that must place the
+// correct target before the child reaches it. It is a declared capability, it
+// is visible to the parent, and it changes nothing about who judges.
+
+import type { Capability, Method } from "./capabilities.ts"
+import { isMethod } from "./capabilities.ts"
+
+/** Bumped when a message shape changes in a way an old pack would misread. */
+export const PROTOCOL_VERSION = 1
+
+/** The version of this SDK's method surface. Compared with `sdkCompatible`. */
+export const SDK_VERSION = "1.0.0"
+
+/**
+ * A pack may not queue work faster than a child can cause it. 120 requests per
+ * rolling second is roughly two per animation frame — far above any real
+ * surface, far below a loop that would starve the host's own event handling.
+ */
+export const MAX_REQUESTS_PER_SECOND = 120
+
+// ─── Envelopes ───────────────────────────────────────────────────────────────
+
+export type Request = {
+  readonly id: number
+  readonly method: Method
+  readonly params: Readonly<Record<string, unknown>>
+}
+
+export type ErrorCode =
+  /** The method is not in the SDK at this version. */
+  | "unknown_method"
+  /** The pack did not declare the capability the method needs. */
+  | "denied"
+  /** The parameters did not typecheck. */
+  | "invalid_params"
+  /** Well-formed, but there is nothing to answer with (no item served, etc.). */
+  | "no_item"
+  /** The pack exceeded `MAX_REQUESTS_PER_SECOND`. */
+  | "rate_limited"
+  /** The host cannot do this on this device right now (no haptics hardware). */
+  | "unavailable"
+  /** A budget the pack was told about (storage bytes, key count). */
+  | "quota"
+  /** The host threw. The pack is told nothing about what. */
+  | "internal"
+
+export type Response =
+  | { readonly id: number; readonly ok: true; readonly result: unknown }
+  | {
+      readonly id: number
+      readonly ok: false
+      readonly error: { readonly code: ErrorCode; readonly message: string }
+    }
+
+export type HostEventName = "settings" | "pause" | "resume" | "dispose"
+
+export type HostEvent = { readonly event: HostEventName; readonly data?: unknown }
+
+/**
+ * The first message on the port, host → pack: what the pack got and what it
+ * did not. A pack reads `granted` and hides the surfaces it cannot drive
+ * instead of failing at the first tap.
+ */
+export type Connect = {
+  readonly event: "connect"
+  readonly protocol: number
+  readonly sdk: string
+  readonly host: string
+  readonly packId: string
+  readonly granted: readonly Capability[]
+  readonly settings: Settings
+}
+
+// ─── Payloads ────────────────────────────────────────────────────────────────
+
+export type Settings = {
+  /** BCP-47. Every string the pack renders should follow it. */
+  readonly locale: string
+  /** `prefers-reduced-motion`. No information may be carried by motion alone. */
+  readonly reducedMotion: boolean
+  /** Set from the device, not guessed from the frame rate. */
+  readonly quality: "low" | "medium" | "high"
+  /** Multiplier on the pack's base type size. */
+  readonly textScale: number
+  readonly colorScheme: "light" | "dark"
+  readonly sound: boolean
+  readonly haptics: boolean
+}
+
+export type ItemChoice = {
+  readonly id: string
+  /** Renderable text. Exact decimal — never a float, never rounded. */
+  readonly text: string
+}
+
+/**
+ * One question, as much of it as a pack needs to draw it and no more.
+ *
+ * `operands`, `text` and every numeric field are **strings**, and they are
+ * exact: the curriculum computes in rationals and serialises, and a pack that
+ * parses one into a `number` to lay it out has introduced the first floating
+ * point error in the system. Layout wants `digits`, which is given.
+ */
+export type Item = {
+  /** Opaque, one serve. `items.answer` quotes it back. */
+  readonly id: string
+  readonly skillId: string
+  readonly level: number
+  readonly form: "binary-op" | "value" | "compare" | "sequence"
+  readonly operator?: "+" | "-" | "×" | "÷" | "<" | ">" | "="
+  readonly operands: readonly string[]
+  /** The whole question as text, for a screen reader and for speech. */
+  readonly prompt: string
+  /** Present only for a closed item. Absent means free entry. */
+  readonly choices?: readonly ItemChoice[]
+  readonly answerKind: "integer" | "rational" | "choice"
+  /** Entry slots a keypad should show. Absent for a choice item. */
+  readonly digits?: number
+}
+
+export type Judgement = {
+  readonly correct: boolean
+  /** The right answer, returned only once the attempt above is recorded. */
+  readonly canonical: string
+  /** A named misconception, when the response matched exactly one mal-rule. */
+  readonly diagnosis?: string
+  /** The host's decision, not the pack's: whether to move on. */
+  readonly advance: boolean
+}
+
+export type LearnerSummary = {
+  readonly skills: readonly {
+    readonly id: string
+    readonly level: "new" | "practiced" | "mastered" | "retired"
+  }[]
+}
+
+/** Named, so a pack cannot invent a waveform or a duration. */
+export type HapticCue = "tick" | "seat" | "settle" | "refuse"
+export type SoundCue = "tick" | "seat" | "settle" | "refuse" | "arrive"
+
+// ─── Guards ──────────────────────────────────────────────────────────────────
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+export type ParsedRequest = { ok: true; request: Request } | { ok: false; code: ErrorCode; message: string }
+
+/**
+ * The one entry point for anything a pack sends.
+ *
+ * Ordering is deliberate: shape, then method, then capability (at the bridge,
+ * which owns the grant set), then parameters. A denial must never depend on
+ * what the parameters were.
+ */
+export function parseRequest(value: unknown): ParsedRequest {
+  if (!isRecord(value)) {
+    return { ok: false, code: "invalid_params", message: "message is not an object" }
+  }
+  const id = value["id"]
+  if (typeof id !== "number" || !Number.isSafeInteger(id) || id < 0) {
+    return { ok: false, code: "invalid_params", message: "id must be a non-negative integer" }
+  }
+  const method = value["method"]
+  if (!isMethod(method)) {
+    return { ok: false, code: "unknown_method", message: `no such method: ${String(method)}` }
+  }
+  const params = value["params"]
+  if (params !== undefined && !isRecord(params)) {
+    return { ok: false, code: "invalid_params", message: "params must be an object" }
+  }
+  return { ok: true, request: { id, method, params: isRecord(params) ? params : {} } }
+}
+
+/** A string parameter, present and non-empty and not absurdly long. */
+export function stringParam(
+  params: Readonly<Record<string, unknown>>,
+  key: string,
+  maxLength = 256,
+): string | null {
+  const value = params[key]
+  if (typeof value !== "string") return null
+  if (value.length === 0 || value.length > maxLength) return null
+  return value
+}
+
+/** A finite non-negative number parameter, clamped rather than rejected. */
+export function numberParam(
+  params: Readonly<Record<string, unknown>>,
+  key: string,
+  max: number,
+): number | null {
+  const value = params[key]
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return null
+  return Math.min(value, max)
+}
+
+export function isConnect(value: unknown): value is Connect {
+  if (!isRecord(value)) return false
+  if (value["event"] !== "connect") return false
+  if (typeof value["protocol"] !== "number") return false
+  if (typeof value["packId"] !== "string") return false
+  return Array.isArray(value["granted"]) && isRecord(value["settings"])
+}
+
+export function isResponse(value: unknown): value is Response {
+  if (!isRecord(value)) return false
+  if (typeof value["id"] !== "number") return false
+  if (value["ok"] === true) return true
+  return value["ok"] === false && isRecord(value["error"])
+}
+
+export function isHostEvent(value: unknown): value is HostEvent {
+  if (!isRecord(value)) return false
+  const name = value["event"]
+  return name === "settings" || name === "pause" || name === "resume" || name === "dispose"
+}

--- a/dynawalla/packs/sdk/src/semver.test.ts
+++ b/dynawalla/packs/sdk/src/semver.test.ts
@@ -1,0 +1,69 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { compareVersions, isSemver, parseSemver, satisfies, sdkCompatible } from "./semver.ts"
+
+test("the case a string compare gets wrong", () => {
+  // The one that will happen first, and the reason this module exists.
+  assert.equal(compareVersions("0.10.0", "0.9.0"), 1)
+  assert.equal(compareVersions("1.0.0", "1.0.10"), -1)
+  assert.equal(compareVersions("2.0.0", "10.0.0"), -1)
+})
+
+test("versions parse or they do not", () => {
+  assert.deepEqual(parseSemver("1.2.3"), { major: 1, minor: 2, patch: 3, prerelease: [] })
+  assert.deepEqual(parseSemver("1.2.3+build.5"), {
+    major: 1,
+    minor: 2,
+    patch: 3,
+    prerelease: [],
+  })
+  assert.deepEqual(parseSemver("1.2.3-alpha.1"), {
+    major: 1,
+    minor: 2,
+    patch: 3,
+    prerelease: ["alpha", 1],
+  })
+  for (const bad of ["1.2", "1.2.3.4", "v1.2.3", "01.2.3", "1.2.3-", "", "latest", "1.2.-3"]) {
+    assert.equal(parseSemver(bad), null, `${bad} parsed`)
+    assert.equal(isSemver(bad), false)
+  }
+})
+
+test("a prerelease sorts below its own release (SemVer §11)", () => {
+  assert.equal(compareVersions("1.0.0-alpha", "1.0.0"), -1)
+  assert.equal(compareVersions("1.0.0-alpha", "1.0.0-alpha.1"), -1)
+  assert.equal(compareVersions("1.0.0-alpha.1", "1.0.0-alpha.beta"), -1)
+  assert.equal(compareVersions("1.0.0-beta.2", "1.0.0-beta.11"), -1, "numeric, not lexical")
+  assert.equal(compareVersions("1.0.0-rc.1", "1.0.0"), -1)
+  assert.equal(compareVersions("1.0.0", "1.0.0"), 0)
+})
+
+test("unparseable input compares to null rather than to something", () => {
+  assert.equal(compareVersions("nope", "1.0.0"), null)
+  assert.equal(compareVersions("1.0.0", "nope"), null)
+})
+
+test("a range is min-inclusive and max-exclusive", () => {
+  const range = { min: "0.3.0", max: "1.0.0" }
+  assert.equal(satisfies("0.3.0", range), true, "min is inclusive")
+  assert.equal(satisfies("0.9.9", range), true)
+  assert.equal(satisfies("1.0.0", range), false, "max is exclusive")
+  assert.equal(satisfies("0.2.9", range), false)
+  assert.equal(satisfies("2.0.0", { min: "0.3.0" }), true, "no ceiling means no ceiling")
+})
+
+test("a pack that cannot say what it needs does not run", () => {
+  assert.equal(satisfies("1.0.0", { min: "not-a-version" }), false)
+  assert.equal(satisfies("also-not", { min: "1.0.0" }), false)
+  assert.equal(satisfies("1.0.0", { min: "1.0.0", max: "garbage" }), false)
+})
+
+test("SDK compatibility is same-major and host-not-behind", () => {
+  assert.equal(sdkCompatible("1.2.0", "1.4.0"), true, "additive minor: fine")
+  assert.equal(sdkCompatible("1.4.0", "1.4.0"), true)
+  assert.equal(sdkCompatible("1.5.0", "1.4.0"), false, "pack uses methods this host lacks")
+  assert.equal(sdkCompatible("2.0.0", "1.9.0"), false)
+  assert.equal(sdkCompatible("0.9.0", "1.0.0"), false, "major 0 is not a free-for-all")
+  assert.equal(sdkCompatible("1.0.0", "nonsense"), false)
+})

--- a/dynawalla/packs/sdk/src/semver.ts
+++ b/dynawalla/packs/sdk/src/semver.ts
@@ -1,0 +1,126 @@
+// Semantic versions, compared exactly.
+//
+// A pack declares the host versions it runs on and the SDK it was built
+// against, and the host refuses to load one that does not fit. That refusal is
+// the only thing standing between a two-year-old installed pack and a host that
+// has since changed the contract under it, so the comparison has to be right
+// rather than approximately right — `"0.10.0" < "0.9.0"` is what a string
+// compare says, and it is the exact case that will happen first.
+//
+// Ranges are deliberately not npm ranges. A pack states a minimum host
+// (inclusive) and an optional exclusive ceiling. There is no `^`, no `~`, no
+// union, no `||`: every one of those is a small parser with its own edge cases,
+// and none of them expresses anything this system needs.
+
+export type Semver = {
+  readonly major: number
+  readonly minor: number
+  readonly patch: number
+  /** Dot-separated identifiers after `-`. Numeric ones compare as numbers. */
+  readonly prerelease: readonly (string | number)[]
+}
+
+/** `major.minor.patch` with an optional `-prerelease` and an ignored `+build`. */
+const PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:[0-9a-zA-Z-]+)(?:\.[0-9a-zA-Z-]+)*))?(?:\+[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)?$/
+
+/** `null` rather than a throw: every caller here is validating input. */
+export function parseSemver(input: string): Semver | null {
+  const match = PATTERN.exec(input)
+  if (!match) return null
+  const prerelease = (match[4] ?? "")
+    .split(".")
+    .filter((part) => part.length > 0)
+    .map((part) => (/^(0|[1-9]\d*)$/.test(part) ? Number(part) : part))
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease,
+  }
+}
+
+export function isSemver(input: string): boolean {
+  return PATTERN.test(input)
+}
+
+const sign = (a: number, b: number): -1 | 0 | 1 => (a < b ? -1 : a > b ? 1 : 0)
+
+/** SemVer §11 precedence. A prerelease sorts BELOW its own release. */
+export function compareSemver(a: Semver, b: Semver): -1 | 0 | 1 {
+  if (a.major !== b.major) return sign(a.major, b.major)
+  if (a.minor !== b.minor) return sign(a.minor, b.minor)
+  if (a.patch !== b.patch) return sign(a.patch, b.patch)
+
+  // 1.0.0-alpha < 1.0.0, and no prerelease on either side is equality.
+  if (a.prerelease.length === 0 && b.prerelease.length === 0) return 0
+  if (a.prerelease.length === 0) return 1
+  if (b.prerelease.length === 0) return -1
+
+  const length = Math.max(a.prerelease.length, b.prerelease.length)
+  for (let index = 0; index < length; index += 1) {
+    const left = a.prerelease[index]
+    const right = b.prerelease[index]
+    // A shorter set of identifiers sorts lower when all preceding ones match.
+    if (left === undefined) return -1
+    if (right === undefined) return 1
+    if (left === right) continue
+    const leftNumeric = typeof left === "number"
+    const rightNumeric = typeof right === "number"
+    if (leftNumeric && rightNumeric) return sign(left, right)
+    // Numeric identifiers always have lower precedence than alphanumeric ones.
+    if (leftNumeric) return -1
+    if (rightNumeric) return 1
+    return String(left) < String(right) ? -1 : 1
+  }
+  return 0
+}
+
+/** `-1 | 0 | 1`, or `null` if either side is not a version. */
+export function compareVersions(a: string, b: string): -1 | 0 | 1 | null {
+  const left = parseSemver(a)
+  const right = parseSemver(b)
+  if (!left || !right) return null
+  return compareSemver(left, right)
+}
+
+/** `min` inclusive, `max` exclusive — the only range shape a manifest may state. */
+export type HostRange = { readonly min: string; readonly max?: string }
+
+/**
+ * Whether `version` sits inside `range`.
+ *
+ * Unparseable input is outside every range. A pack that cannot say what it
+ * needs does not get to run; that is the safe direction, and it is checked by
+ * the manifest validator long before this is reached.
+ */
+export function satisfies(version: string, range: HostRange): boolean {
+  const value = parseSemver(version)
+  const min = parseSemver(range.min)
+  if (!value || !min) return false
+  if (compareSemver(value, min) < 0) return false
+  if (range.max === undefined) return true
+  const max = parseSemver(range.max)
+  if (!max) return false
+  return compareSemver(value, max) < 0
+}
+
+/**
+ * Whether a pack built against SDK `built` may talk to a host implementing
+ * SDK `host`.
+ *
+ * Same major, and the host's minor is not behind the pack's: a pack built
+ * against 1.3 uses methods 1.3 added, which a 1.2 host does not answer. The
+ * reverse — a 1.1 pack on a 1.4 host — is exactly what additive minor versions
+ * are for and is allowed. Major 0 is treated as strictly as any other major
+ * rather than as "anything goes", because this contract ships to devices and
+ * an installed pack outlives the release that built it.
+ */
+export function sdkCompatible(built: string, host: string): boolean {
+  const packSdk = parseSemver(built)
+  const hostSdk = parseSemver(host)
+  if (!packSdk || !hostSdk) return false
+  if (packSdk.major !== hostSdk.major) return false
+  if (packSdk.minor > hostSdk.minor) return false
+  return true
+}

--- a/dynawalla/packs/sdk/tsconfig.json
+++ b/dynawalla/packs/sdk/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  /* The same strictness the app is held to, so a type that passes here cannot
+     fail when the host imports the identical file. `erasableSyntaxOnly` keeps
+     every module runnable under `node --experimental-strip-types`. */
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "types": ["node"]
+  },
+  "include": ["src", "bin"]
+}


### PR DESCRIPTION
Packs are the product. This is the machinery that runs them: a manifest schema, an install/verify/update/remove path, a capability boundary that is structural rather than conventional, the host↔pack API, and an SDK with local dev serving.

## The boundary

A pack is an HTML document, served from a `dynawalla-pack://` scheme handler and framed with `sandbox="allow-scripts"` and deliberately **not** `allow-same-origin`. That one omission is the security model:

- the frame's origin is opaque, so `window.parent` is cross-origin and unreadable — no Tauri bridge, no app stores, no other pack;
- no `localStorage`, no `IndexedDB`, no cookies, so anything a pack keeps is kept for it through the `storage` capability;
- the document is served with a CSP naming only the pack scheme, so **a pack cannot reach the network**. Not "should not" — cannot;
- top-level navigation is blocked.

Corpán's `<script>`-tag packs are the precedent deliberately not followed: they run in the host's realm, where "capability boundary" means a pack that did not call the host API merely did not ask nicely.

What a pack gets instead is one `MessagePort`, and everything on it goes through `bridge.ts` in a fixed order — shape, method exists, capability granted, rate, parameters, dispatch. A denial never depends on the parameters, so an error cannot leak what was denied.

An opaque origin makes `'self'` match nothing, which is why both the Rust CSP and the dev workbench name the origin explicitly. That trap is documented at both sites.

## The host judges

`items.next` does not carry the answer. `items.answer` records the attempt and *then* returns the canonical value, so a pack cannot learn what is correct without spending the attempt it would have had to report anyway. A mathematics game that decides for itself whether a child was right is a game that can be beaten by fiddling with the game.

`items.reveal` is the deliberate, separately-declared, parent-visible exception for a game that must place the correct target before the child reaches it. It changes nothing about who judges.

Every operand and every answer on the wire is a **string**. The curriculum computes in rationals; a pack that parses one into a `number` to lay it out introduces the first floating-point error in the system, so `digits` is provided for layout instead.

## Native (`src-tauri/src/packs/`)

- Scheme handler resolves every path against a **canonicalised** root — the check that catches a symlink, which `..`-in-the-string does not (tested).
- Installer: origin pinned in Rust, streamed download bounded by the declared size, SHA-256 verified **before** extraction, zip-slip / drive-letter / file-count / decompression-bomb refusals, stage-and-swap so a failure leaves the installed pack untouched.
- Download and catalogue fetch are native, which is what lets the app's own `connect-src` stay closed.

## Two lessons from `docs/PACK_SYSTEM.md`, wired to tests rather than comments

- `packs_remove` is registered, and `native.test.ts` reads `lib.rs` and asserts the invoked and registered command lists are the same set **in both directions**. Corpán invokes `content_packs_delete`, which its backend never registered, so every uninstalled pack's data stays on the device forever and nothing fails.
- A version mismatch between the catalogue and the artefact is a failure, not a footnote: it is not recorded, the installed copy is not touched, and the update offer keeps offering — which is correct, because the update has not happened.

## Reuse decision

`corpan/plugins/tauri-plugin-game-packs` is read and its design borrowed (scheme handler, content types, install shape), but not shared: it is hard-coded to Corpán's `corpan-packs` directory and its own bundle, `corpan-pack://` is a permanent public identifier for installed Corpán packs, and `corpan/**` is out of this track's scope. The Dynawalla handler fixes what that one gets wrong — string-only traversal check, no integrity verification, no serve-side CSP, an unregistered delete.

## Scope notes

- `src/app/permissions.ts` and `src/app/capabilities.test.ts` are touched. Tauri's ACL gates plugin commands and says nothing about application commands, so a capability entry for these is unexpressible; `permission: null` plus a registration test records that instead of leaving the row out. The CSP `frame-src` change also needed the origin allow-list widened by exactly one local scheme host.
- `docs/PACK_SYSTEM.md` still says there is no pack system (ADR-0003/0004, which the founder reversed). Left alone deliberately — docs are another track's.
- Nothing in `src/screens` or the router references `PackFrame` yet; wiring the runtime into a screen belongs to whoever owns those files.
- Sandbox enforcement, the pack-scheme fetch path and progress reporting still want a device pass. The scheme handler cannot be exercised without a WebView; everything around it can be and is.

## Verification

- `cargo test` 15 passed · `cargo clippy --all-targets` clean · `cargo fmt --check` clean
- SDK `node --test` 52 passed
- App `npm test` 256 passed · `npm run tsc` clean · `npm run lint` clean · `npm run build` clean
- The `example/` pack played end to end in Chrome through `dw-pack serve` — real handshake, real opaque-origin sandbox, real CSP, real port transfer: `6069 − 1304`, answered `1000`, told `4765` only after the attempt was recorded, and the haptic cue landed. (`6069 − 1304 = 4765`, checked by hand.)
