### PR TITLE
dynawalla: eight generator families across five domains — rebased onto the stripped host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,15 @@ jobs:
           # EG-1 and M-05, but there is no CG-19 equivalent in it — so a
           # bare-string prompt added under `engine/src` failed the curriculum job
           # while the engine job stayed green, on a PR that ran neither.
-          set_output dynawalla_curriculum '^(dynawalla/(curriculum|engine)/|\.github/workflows/ci\.yml$)'
+          #
+          # `dynawalla/packs/shared/curriculum/` is where the library ITSELF lives.
+          # It moved there so packs could import it without reaching into the host
+          # app's tree, and this filter did not move with it: `dynawalla/curriculum/`
+          # kept only the devDependencies, the commands and the CLI, so every line
+          # of generator, mal-rule and gate source sat outside the pattern that
+          # decides whether the gates run at all. A pull request that rewrote the
+          # whole library would have skipped its own job and reported green.
+          set_output dynawalla_curriculum '^(dynawalla/(curriculum|engine|packs/shared/curriculum)/|\.github/workflows/ci\.yml$)'
           # Not the mirror image: the engine imports nothing at all (EG-1 asserts
           # exactly that), so a curriculum change cannot break the engine job.
           # `boundary.test.ts` duplicates the float scan for this reason — "the two

--- a/dynawalla/docs/CURRICULUM.md
+++ b/dynawalla/docs/CURRICULUM.md
@@ -160,7 +160,10 @@ V1 concentrates where the evidence is genuinely deep:
 larger in every column),
 `mis.add.borrow-across-zero` (602 − 437 = 265, and 5,001 − 2,798 = 3,203 — regrouped all
 the way down, never decremented the leading digit), `mis.add.misaligned-columns`,
-`mis.add.carry-dropped`, `mis.mul.makes-bigger`, `mis.mul.partial-product-misaligned`,
+`mis.add.carry-dropped`, `mis.mul.makes-bigger`, `mis.mul.partial-product-misaligned`
+and `mis.mul.forgot-the-shift` (both children of one `mul.shift-not-applied` parent —
+the same place-value slip, but `47 × 100` answered as `47` is not a row misplaced and
+does not get the two-row repair),
 `mis.div.divisor-must-be-smaller`, `mis.div.remainder-dropped`,
 `mis.frac.add-numerators-and-denominators`,
 `mis.frac.larger-denominator-larger-fraction` (both children of one

--- a/dynawalla/docs/GATES.md
+++ b/dynawalla/docs/GATES.md
@@ -32,7 +32,7 @@ Published before M4's first curriculum PR.
 | **CG-8** | **Renderer ownership** — merge blocker | PR-4.4 |
 | **CG-9** | Level coverage by **running** generators over N seeds, ≥`minVariants` distinct | PR-4.6 |
 | **CG-10** | Variant-space adequacy — <2% duplicates over 1,000 draws | PR-4.6 |
-| **CG-11** | Self-consistency — the family's own checker accepts `canonical` and every `alsoAccept`, and rejects every distractor, over 1,000 seeds | PR-4.6 |
+| **CG-11** | Self-consistency — the family's own checker accepts `canonical` and every `alsoAccept`, and rejects every distractor, over 1,000 seeds; and every generated item's `AnswerSchema` passes `schemaDefect` | PR-4.6 |
 | **CG-12** | Mal-rule fidelity — ≥95% divergence from the correct answer | PR-8.1 |
 | **CG-13** | **Choice-laundering ban** — no `conceptual`/`reasoning` skill binds a choice-only generator | PR-4.4 |
 | **CG-14** | **Locale round-trip** — every `canonical`/`alsoAccept` survives format→parse in all launch locales; every count slot declares its CLDR plural set | PR-4.7 |

--- a/dynawalla/packs/shared/curriculum/CHANGELOG.md
+++ b/dynawalla/packs/shared/curriculum/CHANGELOG.md
@@ -9,6 +9,45 @@ installed pack until that pack is rebuilt and republished.
 
 ## 0.1.0 — Unreleased
 
+### Eight generator families across five new domains
+
+The library taught addition and subtraction and nothing else. It now generates
+place value, comparison and ordering, rounding and estimation, multi-digit
+multiplication, long division, fraction equivalence, fraction arithmetic and
+missing-operand equations — `gen.number.place-value-decompose`,
+`gen.number.compare-order`, `gen.number.round-estimate`,
+`gen.arith.multidigit-mul`, `gen.arith.long-div`, `gen.frac.equivalence-simplify`,
+`gen.frac.arith` and `gen.arith.missing-operand` — over the five new domains `ns`,
+`mul`, `div`, `frac` and `alg`.
+
+- **Two answer schemas the judge was missing**: `fraction` (with the per-skill
+  `equivalence` decision, so `2/4` is the same answer as `1/2` everywhere except
+  on the skill that teaches simplifying) and `choice` (with the drawn options on
+  the schema, since a renderer is handed the schema and nothing else).
+- **Thirteen new mal-rules** wired to the new families — the table goes from 3 to
+  16 — each ≥95% divergent under CG-12, grouped once rather than re-filtered per
+  card on the path CG-17 budgets.
+- **CG-8 gained its missing half.** It checked the answer schema and the
+  representations and said nothing about the *question*, so a family could emit a
+  prompt template nobody could draw — an answer entry with nothing above it.
+  `render/prompts.ts` is the second registry, read off generated items rather than
+  off a declaration a family makes about itself.
+- **CG-11 now runs `schemaDefect` over generated output**, so a `choice` item
+  carrying two options of the same value fails the gate instead of reaching a
+  screen.
+- **`graph/promotionBlockers.ts`** names, per row, what stands between the 30
+  draft rows and `active` — and `families.property.test.ts` asserts the list in
+  both directions, so a row that slips under CG-10's floor must be named and a
+  generator widened past it must be struck off.
+- **Every renderer and prompt declaration reads `implemented: false`.** They were
+  satisfied by the host's practice loop; ADR-0022 deleted it, and no pack has
+  landed a replacement, so nothing in this repository draws a curriculum item
+  today. `--strict-renderers` fails on that, which is correct — a release in which
+  nothing draws a question is not a release — and the first pack renderer is what
+  clears it.
+
+### Relocation
+
 Relocated from `dynawalla/curriculum/src` so that packs — which are the product —
 can import it without reaching into the host app's tree. The mathematics is
 unchanged: every committed CG-16 output hash still matches, on the same 10,000-item

--- a/dynawalla/packs/shared/curriculum/src/boundary.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/boundary.test.ts
@@ -37,11 +37,18 @@ const SRC = new URL(".", import.meta.url).pathname;
  * has to be tight enough not to read prose. A specifier never spans a newline,
  * which is what keeps `"…the run to regroup from"` in a test message from being
  * mistaken for an import of whatever follows it.
+ *
+ * The keyword must also not itself be inside a string. `["from", "to"]` — a list
+ * of parameter names, which `render/representations.ts` has — otherwise reads as
+ * `from` followed by a quoted `, `, and the file gets accused of importing a bare
+ * specifier that is two characters of punctuation. The lookbehind rejects a
+ * keyword whose preceding character is a quote, which is exactly the shape a
+ * keyword-as-string-content has and an import never does.
  */
 function specifiersIn(path: string): string[] {
   const code = stripNonCode(readFileSync(path, "utf8"), true);
   const out: string[] = [];
-  const pattern = /(?:\bfrom|\bimport)\s*\(?\s*(["'])([^"'\n]+)\1/g;
+  const pattern = /(?<!["'])(?:\bfrom|\bimport)\s*\(?\s*(["'])([^"'\n]+)\1/g;
   let match = pattern.exec(code);
   while (match !== null) {
     const specifier = match[2];

--- a/dynawalla/packs/shared/curriculum/src/generators/columnOp/columnOp.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/columnOp/columnOp.test.ts
@@ -213,6 +213,7 @@ function stepLines(exercise: Exercise): string[] {
         if (slot === undefined) return `${name}=?`;
         if (slot.kind === "number") return `${name}=${toDecimalString(slot.value, slot.decimalPlaces) ?? "?"}`;
         if (slot.kind === "count") return `${name}=${String(slot.value)}`;
+        if (slot.kind === "fraction") return `${name}=${slot.num.toString()}/${slot.den.toString()}`;
         return `${name}=${slot.key}`;
       })
       .join(" ");
@@ -290,6 +291,51 @@ test("column-op: check rejects every distractor and names the bug that produced 
       assert.equal(verdict.correct, false);
       assert.equal(verdict.correct === false ? verdict.misconception : undefined, distractor.misconception);
     }
+  }
+});
+
+test("column-op: acceptance goes through the schema, so `equivalence` is not a dead knob", () => {
+  // `AnswerSchema.fraction.equivalence` is a curriculum decision — on
+  // `simplify-to-lowest-terms`, accepting `2/4` marks the thing being taught as
+  // correct — and it was declared with nothing on the judging path consulting
+  // it: `check` compared with `answerEquals`, the app never called
+  // `answerAccepted`, and the field would have been silently ignored by the
+  // first fraction family, marking every equivalent answer wrong.
+  //
+  // This family emits no fraction item, so the seam is what is tested: the one
+  // checker in the program, handed a fraction schema, honours the schema.
+  const exercise = generate(1, {}, [FORM_FREE_ENTRY]);
+  const half = { kind: "fraction", num: 1n, den: 2n } as const;
+  const quarters = { kind: "fraction", num: 2n, den: 4n } as const;
+
+  const strict: Exercise = {
+    ...exercise,
+    schema: { kind: "fraction", parts: ["num", "den"] },
+    answer: { canonical: half, alsoAccept: [] },
+  };
+  assert.equal(columnOpFamily.check(strict, half).correct, true);
+
+  const loose: Exercise = {
+    ...strict,
+    schema: { kind: "fraction", parts: ["num", "den"], equivalence: "any-equivalent" },
+  };
+  // The discriminating assertion: `2/4` is not `1/2` to `answerEquals`, and the
+  // only thing that can make this true is the checker reading the schema.
+  assert.equal(
+    columnOpFamily.check(loose, quarters).correct,
+    true,
+    "the schema says any equivalent counts and the checker ignored it",
+  );
+  // The refusing direction is `answerAccepted`'s own test: a *wrong* fraction
+  // here would fall through to `classify`, and this family's mal-rules run the
+  // column procedure, which has no fraction answer shape to run into.
+
+  // And the schemas this family really emits are unaffected: an `integer` or
+  // `columnAlgorithm` schema carries no `equivalence`, so `answerAccepted` is
+  // `answerEquals` on every item it generates.
+  for (let seed = 1; seed <= 50; seed++) {
+    const real = generate(seed);
+    assert.equal(columnOpFamily.check(real, real.answer.canonical).correct, true);
   }
 });
 

--- a/dynawalla/packs/shared/curriculum/src/generators/columnOp/family.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/columnOp/family.ts
@@ -25,7 +25,7 @@ import type { Rational } from "../../math/rational.ts";
 import { createRng, seedFrom } from "../../rng/rng.ts";
 import type { Rng } from "../../rng/rng.ts";
 import type { AnswerSchema, AnswerValue, ColumnMark } from "../../types/answer.ts";
-import { answerEquals } from "../../types/answer.ts";
+import { answerAccepted, answerEquals } from "../../types/answer.ts";
 import type { Distractor, Exercise, PromptSlot, SolutionStep } from "../../types/exercise.ts";
 import { exerciseIdOf } from "../../types/ids.ts";
 import type { FormId } from "../../types/ids.ts";
@@ -435,9 +435,17 @@ export const columnOpFamily: GeneratorFamily<ColumnOpParams> = {
   },
 
   check(exercise: Exercise, submitted: AnswerValue): Verdict {
-    if (answerEquals(submitted, exercise.answer.canonical)) return { correct: true };
+    // `answerAccepted`, not `answerEquals`: acceptance is the schema's decision
+    // wherever the schema has one to make. On every item this family emits the
+    // two are the same function — an `integer` or `columnAlgorithm` schema
+    // carries no `equivalence` — but this is the only checker in the program and
+    // the next one will be written by reading it. Routed through `answerEquals`,
+    // `fraction.equivalence: "any-equivalent"` was a declared knob nothing
+    // consulted, and the first child to write `2/4` where any equivalent was
+    // meant to be accepted would have been marked wrong.
+    if (answerAccepted(exercise.schema, exercise.answer.canonical, submitted)) return { correct: true };
     for (const accepted of exercise.answer.alsoAccept) {
-      if (answerEquals(submitted, accepted)) return { correct: true };
+      if (answerAccepted(exercise.schema, accepted, submitted)) return { correct: true };
     }
     const misconception = classify(exercise, submitted);
     return misconception === null ? { correct: false } : { correct: false, misconception };

--- a/dynawalla/packs/shared/curriculum/src/generators/compareOrder/constants.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/compareOrder/constants.ts
@@ -1,0 +1,70 @@
+/**
+ * `gen.number.compare-order` — ids, locale keys and difficulty coefficients.
+ *
+ *   b = b_skill + 0.30·(digits − 2) + 0.20·decimalPlaces + 0.35·sharedPrefix
+ *       − 0.35·sameNumerator + 0.05·maxDenominator + formOffset
+ *
+ * `sharedPrefix` is this family's `noAnchor` term: two numbers that agree for
+ * three digits give a child nothing to compare until the fourth, which is exactly
+ * "no landmark to count from". `sameNumerator` takes the `specialCase` slot — a
+ * comparison of two fractions with the same numerator is decided by one rule and
+ * is the easiest fraction comparison there is, which is also why it is the one
+ * that exposes whole-number bias.
+ */
+
+import { rational } from "../../math/rational.ts";
+import { familyId, locKey } from "../../types/ids.ts";
+
+export const COMPARE_ORDER_FAMILY = familyId("gen.number.compare-order");
+
+/** Bump whenever generated output changes for any seed. */
+export const COMPARE_ORDER_FAMILY_REV = 1;
+
+export const FORM_FREE_ENTRY = "free-entry";
+export const COMPARE_ORDER_FORMS = [FORM_FREE_ENTRY] as const;
+
+/**
+ * "Which of these is the greater number? Write it." — never "type < or >".
+ *
+ * The relation symbol would be a closed list of three, which is the choice
+ * laundering CG-13 exists to stop, and it is also the weaker task: writing the
+ * greater number down requires deciding which one it is *and* transcribing it,
+ * and the answer is a number the entry surfaces already draw.
+ */
+export const PROMPT_KEY_GREATER = locKey("dw.prompt.compare-order.greater");
+export const PROMPT_KEY_LESSER = locKey("dw.prompt.compare-order.lesser");
+
+export const SOLUTION_KEY_LINE_UP = locKey("dw.solution.compare-order.line-up");
+export const SOLUTION_KEY_FIRST_DIFFERENCE = locKey("dw.solution.compare-order.first-difference");
+export const SOLUTION_KEY_SAME_NUMERATOR = locKey("dw.solution.compare-order.same-numerator");
+export const SOLUTION_KEY_COMMON_DENOMINATOR = locKey("dw.solution.compare-order.common-denominator");
+export const SOLUTION_KEY_RESULT = locKey("dw.solution.compare-order.result");
+
+export const COMPARE_ORDER_LOC_KEYS = [
+  PROMPT_KEY_GREATER,
+  PROMPT_KEY_LESSER,
+  SOLUTION_KEY_LINE_UP,
+  SOLUTION_KEY_FIRST_DIFFERENCE,
+  SOLUTION_KEY_SAME_NUMERATOR,
+  SOLUTION_KEY_COMMON_DENOMINATOR,
+  SOLUTION_KEY_RESULT,
+] as const;
+
+export const SLOT_LEFT = "left";
+export const SLOT_RIGHT = "right";
+export const SLOT_ANSWER = "answer";
+export const SLOT_PLACE = "place";
+export const SLOT_DENOMINATOR = "denominator";
+export const SLOT_LEFT_SCALED = "leftScaled";
+export const SLOT_RIGHT_SCALED = "rightScaled";
+
+export const COEFF_DIGIT_OVER_TWO = rational(30n, 100n);
+export const COEFF_DECIMAL_PLACE = rational(20n, 100n);
+/** Every leading digit the two numbers share is one more column to read past. */
+export const COEFF_SHARED_PREFIX = rational(35n, 100n);
+/** The special case: one numerator, one rule. */
+export const COEFF_SAME_NUMERATOR = rational(-35n, 100n);
+/** Denominators past halves and thirds, per denominator. */
+export const COEFF_DENOMINATOR = rational(5n, 100n);
+
+export const FORM_OFFSET_FREE_ENTRY = rational(0n);

--- a/dynawalla/packs/shared/curriculum/src/generators/compareOrder/family.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/compareOrder/family.ts
@@ -1,0 +1,342 @@
+/**
+ * `gen.number.compare-order` — which of two numbers is the greater, over whole
+ * numbers, fractions and decimals.
+ *
+ * One family across three number types because comparison is one idea and the
+ * three types differ only in what "line them up" means: place columns for whole
+ * numbers, place columns after a point for decimals, a common denominator for
+ * fractions. CURRICULUM.md asks for exactly this shape.
+ *
+ * **The answer is the number, not a symbol.** "Type < or >" would be a closed list
+ * of three, which is the choice laundering CG-13 exists to stop. Writing the
+ * greater number down is also the stronger task: it requires deciding *and*
+ * transcribing, and it never has a 33% floor.
+ *
+ * Two items are never equal in value. An equal pair has no greater member, so the
+ * question would have no answer, and it is the one draw on which the whole-number
+ * bias rule cannot be wrong.
+ */
+
+import { cmp, mul, pow10, rational, add as ratAdd, toScaled } from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import { createRng, seedFrom } from "../../rng/rng.ts";
+import type { Rng } from "../../rng/rng.ts";
+import type { AnswerSchema, AnswerValue } from "../../types/answer.ts";
+import type { Exercise, PromptSlot, SolutionStep } from "../../types/exercise.ts";
+import { exerciseIdOf } from "../../types/ids.ts";
+import type { GenerateRequest, GeneratorFamily, Verdict } from "../../types/generator.ts";
+import { chooseForm, distractorsFor, judge } from "../shared/build.ts";
+import { decimalSlot, fractionSlot, numberSlot, termSlot } from "../shared/slots.ts";
+import { drawBetween, drawBetweenExcluding, drawWithDigits } from "../shared/draw.ts";
+import { InfeasibleLevelError } from "../shared/errors.ts";
+import { lcm, PROPER_PARTS, fractionSchema } from "../shared/fractions.ts";
+import { placeTerm } from "../shared/placeTerms.ts";
+import {
+  COEFF_DECIMAL_PLACE,
+  COEFF_DENOMINATOR,
+  COEFF_DIGIT_OVER_TWO,
+  COEFF_SAME_NUMERATOR,
+  COEFF_SHARED_PREFIX,
+  COMPARE_ORDER_FAMILY,
+  COMPARE_ORDER_FAMILY_REV,
+  COMPARE_ORDER_FORMS,
+  FORM_OFFSET_FREE_ENTRY,
+  PROMPT_KEY_GREATER,
+  PROMPT_KEY_LESSER,
+  SLOT_ANSWER,
+  SLOT_DENOMINATOR,
+  SLOT_LEFT,
+  SLOT_LEFT_SCALED,
+  SLOT_PLACE,
+  SLOT_RIGHT,
+  SLOT_RIGHT_SCALED,
+  SOLUTION_KEY_COMMON_DENOMINATOR,
+  SOLUTION_KEY_FIRST_DIFFERENCE,
+  SOLUTION_KEY_LINE_UP,
+  SOLUTION_KEY_RESULT,
+  SOLUTION_KEY_SAME_NUMERATOR,
+} from "./constants.ts";
+import { compareOrderParamSchema } from "./params.ts";
+import type { CompareOrderParams } from "./params.ts";
+import { operandAnswer, operandValue } from "./read.ts";
+import type { CompareOperand } from "./read.ts";
+
+type Pair = { readonly left: CompareOperand; readonly right: CompareOperand };
+
+/** An operand, written the way it is written — a decimal, or a fraction. */
+function operandSlot(operand: CompareOperand): PromptSlot {
+  return operand.kind === "number"
+    ? decimalSlot(operand.value, operand.decimalPlaces)
+    : fractionSlot(operand.num, operand.den);
+}
+
+function numberOperand(value: bigint, decimalPlaces: number): CompareOperand {
+  return { kind: "number", value: rational(value, pow10(decimalPlaces)), decimalPlaces };
+}
+
+/**
+ * Two whole numbers of the same written width, agreeing on `sharedPrefix` leading
+ * digits and differing somewhere after that.
+ *
+ * Same width on purpose: with different widths the comparison is decided by
+ * counting digits, which is a different (and much easier) skill, and it would also
+ * make "the longer number is the bigger one" *correct* — the misconception this
+ * family exists to confront survives only where it is wrong.
+ */
+function drawWhole(digits: number, sharedPrefix: number, rng: Rng): Pair {
+  const left = drawWithDigits(rng, digits);
+  const tailLength = digits - sharedPrefix;
+  const unit = pow10(tailLength);
+
+  // With no shared prefix the "tail" is the whole number, so it keeps the
+  // leading-digit rule; otherwise the tail may start with any digit.
+  const tailLo = sharedPrefix === 0 ? pow10(digits - 1) : 0n;
+  const tailHi = sharedPrefix === 0 ? pow10(digits) - 1n : unit - 1n;
+  const rightTail = drawBetweenExcluding(rng, tailLo, tailHi, left % unit);
+  const right = sharedPrefix === 0 ? rightTail : (left / unit) * unit + rightTail;
+
+  return { left: numberOperand(left, 0), right: numberOperand(right, 0) };
+}
+
+/**
+ * Two decimals with the same whole part, one written to more places than the
+ * other, and the **longer one is the smaller number**.
+ *
+ * That is a declared content decision, not a filter. `0.5` against `0.125` is the
+ * item that tells you whether a child is reading the digits after the point as a
+ * whole number; `0.5` against `0.625` is an item they can get right while holding
+ * exactly that belief. A diagnostic level poses the discriminating item, which is
+ * also what makes `mis.dec.longer-is-bigger` wrong on every item of the level
+ * without the rule ever inspecting the answer.
+ */
+function drawDecimal(digits: number, shortPlaces: number, gap: number, rng: Rng): Pair {
+  const longPlaces = shortPlaces + gap;
+  const whole = drawWithDigits(rng, digits);
+
+  const shortFraction = drawBetween(rng, 1n, pow10(shortPlaces) - 1n);
+  // Strictly less, as an exact comparison at the finer grid: the long number's
+  // fractional part is worth less than the short one's.
+  const longCeiling = shortFraction * pow10(gap) - 1n;
+  if (longCeiling < 1n) throw new InfeasibleLevelError("no decimal is strictly between zero and this one");
+  const longFraction = drawBetween(rng, 1n, longCeiling);
+
+  return {
+    left: numberOperand(whole * pow10(shortPlaces) + shortFraction, shortPlaces),
+    right: numberOperand(whole * pow10(longPlaces) + longFraction, longPlaces),
+  };
+}
+
+/** Two proper fractions with the same numerator and different denominators. */
+function drawSameNumerator(maxDenominator: number, rng: Rng): Pair {
+  const num = BigInt(rng.nextInt(1, maxDenominator - 2));
+  const lo = num + 1n;
+  const hi = BigInt(maxDenominator);
+  const first = drawBetween(rng, lo, hi);
+  const second = drawBetweenExcluding(rng, lo, hi, first);
+  return {
+    left: { kind: "fraction", num, den: first },
+    right: { kind: "fraction", num, den: second },
+  };
+}
+
+/**
+ * Two proper fractions of different value.
+ *
+ * A value has at most one writing with a given denominator, so the right operand's
+ * numerator is drawn from its range with that one writing removed. The single
+ * denominator that admits nothing — halves, when the left operand is already one
+ * half — steps up by one rather than retrying, because a retry loop's draw count
+ * depends on what it rejected and every later draw would shift with it.
+ */
+function drawUnlikeFractions(maxDenominator: number, rng: Rng): Pair {
+  const leftDen = drawBetween(rng, 2n, BigInt(maxDenominator));
+  const leftNum = drawBetween(rng, 1n, leftDen - 1n);
+
+  let rightDen = drawBetween(rng, 2n, BigInt(maxDenominator));
+  // The numerator that would make the two fractions equal, when it is a whole one.
+  const sameValueNumerator = (den: bigint): bigint | null =>
+    (leftNum * den) % leftDen === 0n ? (leftNum * den) / leftDen : null;
+
+  if (rightDen === 2n && sameValueNumerator(2n) === 1n) {
+    rightDen = 3n;
+    if (BigInt(maxDenominator) < 3n) throw new InfeasibleLevelError("halves alone hold one proper fraction");
+  }
+
+  const blocked = sameValueNumerator(rightDen);
+  const rightNum =
+    blocked === null
+      ? drawBetween(rng, 1n, rightDen - 1n)
+      : drawBetweenExcluding(rng, 1n, rightDen - 1n, blocked);
+
+  return {
+    left: { kind: "fraction", num: leftNum, den: leftDen },
+    right: { kind: "fraction", num: rightNum, den: rightDen },
+  };
+}
+
+function drawPair(params: CompareOrderParams, rng: Rng): Pair {
+  switch (params.numberType) {
+    case "whole":
+      return drawWhole(params.digits, params.sharedPrefix, rng);
+    case "decimal":
+      return drawDecimal(params.digits, params.decimalPlaces, params.placeGap, rng);
+    case "fraction":
+      return params.sameNumerator
+        ? drawSameNumerator(params.maxDenominator, rng)
+        : drawUnlikeFractions(params.maxDenominator, rng);
+  }
+}
+
+function schemaFor(params: CompareOrderParams): AnswerSchema {
+  switch (params.numberType) {
+    case "whole":
+      return { kind: "integer", digits: params.digits, decimalPlaces: 0 };
+    case "decimal":
+      // The field holds the longer writing; a child who answers with the shorter
+      // one writes fewer digits into the same field and the values still compare
+      // exactly, because comparison is on the rational and not on the characters.
+      return {
+        kind: "integer",
+        digits: params.digits + params.decimalPlaces + params.placeGap,
+        decimalPlaces: params.decimalPlaces + params.placeGap,
+      };
+    case "fraction":
+      // As written: the answer is one of the two fractions on the card, exactly as
+      // it is written there. Accepting any equivalent would accept a child who
+      // rewrote `2/6` as `1/3` — right about the value, and no longer answering
+      // the question that was asked.
+      return fractionSchema(PROPER_PARTS, "as-written");
+  }
+}
+
+/** The place, counted from the units column, where two written numbers first differ. */
+function firstDifferingPlace(left: bigint, right: bigint, places: number): number {
+  const width = Math.max(left.toString().length, right.toString().length);
+  for (let index = width - 1; index >= 0; index--) {
+    const unit = pow10(index);
+    if ((left / unit) % 10n !== (right / unit) % 10n) return index - places;
+  }
+  return -places;
+}
+
+function solutionFor(params: CompareOrderParams, pair: Pair, answer: CompareOperand): SolutionStep[] {
+  const steps: SolutionStep[] = [
+    {
+      key: SOLUTION_KEY_LINE_UP,
+      slots: { [SLOT_LEFT]: operandSlot(pair.left), [SLOT_RIGHT]: operandSlot(pair.right) },
+    },
+  ];
+
+  if (params.numberType === "fraction") {
+    if (params.sameNumerator) {
+      steps.push({
+        key: SOLUTION_KEY_SAME_NUMERATOR,
+        slots: { [SLOT_LEFT]: operandSlot(pair.left), [SLOT_RIGHT]: operandSlot(pair.right) },
+      });
+    } else if (pair.left.kind === "fraction" && pair.right.kind === "fraction") {
+      const common = lcm(pair.left.den, pair.right.den);
+      steps.push({
+        key: SOLUTION_KEY_COMMON_DENOMINATOR,
+        slots: {
+          [SLOT_DENOMINATOR]: numberSlot(common),
+          [SLOT_LEFT_SCALED]: fractionSlot(pair.left.num * (common / pair.left.den), common),
+          [SLOT_RIGHT_SCALED]: fractionSlot(pair.right.num * (common / pair.right.den), common),
+        },
+      });
+    }
+  } else if (pair.left.kind === "number" && pair.right.kind === "number") {
+    const places = Math.max(pair.left.decimalPlaces, pair.right.decimalPlaces);
+    const leftScaled = toScaled(pair.left.value, places);
+    const rightScaled = toScaled(pair.right.value, places);
+    const term = leftScaled === null || rightScaled === null
+      ? null
+      : placeTerm(firstDifferingPlace(leftScaled, rightScaled, places));
+    if (term !== null) {
+      steps.push({
+        key: SOLUTION_KEY_FIRST_DIFFERENCE,
+        slots: {
+          [SLOT_PLACE]: termSlot(term),
+          [SLOT_LEFT]: operandSlot(pair.left),
+          [SLOT_RIGHT]: operandSlot(pair.right),
+        },
+      });
+    }
+  }
+
+  steps.push({ key: SOLUTION_KEY_RESULT, slots: { [SLOT_ANSWER]: operandSlot(answer) } });
+  return steps;
+}
+
+export const compareOrderFamily: GeneratorFamily<CompareOrderParams> = {
+  family: COMPARE_ORDER_FAMILY,
+  familyRev: COMPARE_ORDER_FAMILY_REV,
+  paramSchema: compareOrderParamSchema,
+  forms: COMPARE_ORDER_FORMS,
+  choiceOnly: false,
+  representations: [],
+
+  answerSchema(params: CompareOrderParams): AnswerSchema {
+    return schemaFor(params);
+  },
+
+  difficultyOffset(params: CompareOrderParams): Rational {
+    if (params.numberType === "fraction") {
+      let b = mul(COEFF_DENOMINATOR, rational(BigInt(params.maxDenominator)));
+      if (params.sameNumerator) b = ratAdd(b, COEFF_SAME_NUMERATOR);
+      return b;
+    }
+    let b = mul(COEFF_DIGIT_OVER_TWO, rational(BigInt(params.digits - 2)));
+    b = ratAdd(b, mul(COEFF_SHARED_PREFIX, rational(BigInt(params.numberType === "whole" ? params.sharedPrefix : 0))));
+    if (params.numberType === "decimal") {
+      b = ratAdd(b, mul(COEFF_DECIMAL_PLACE, rational(BigInt(params.decimalPlaces + params.placeGap))));
+    }
+    return b;
+  },
+
+  formOffset(): Rational {
+    return FORM_OFFSET_FREE_ENTRY;
+  },
+
+  generate(request: GenerateRequest<CompareOrderParams>): Exercise {
+    const { skillId, level, seed, params, forms } = request;
+    const exerciseId = exerciseIdOf(COMPARE_ORDER_FAMILY, COMPARE_ORDER_FAMILY_REV, skillId, level, seed);
+    const rng = createRng(seedFrom(exerciseId));
+
+    const form = chooseForm(forms, COMPARE_ORDER_FORMS, rng);
+    const pair = drawPair(params, rng);
+
+    const order = cmp(operandValue(pair.left), operandValue(pair.right));
+    if (order === 0) {
+      throw new InfeasibleLevelError(`equal operands on ${exerciseId}: a comparison with no answer`);
+    }
+    const greater = order > 0 ? pair.left : pair.right;
+    const lesser = order > 0 ? pair.right : pair.left;
+    const answer = params.task === "greater" ? greater : lesser;
+
+    const schema = schemaFor(params);
+    const base: Exercise = {
+      exerciseId,
+      skillId,
+      level,
+      seed,
+      family: COMPARE_ORDER_FAMILY,
+      familyRev: COMPARE_ORDER_FAMILY_REV,
+      form,
+      prompt: {
+        key: params.task === "greater" ? PROMPT_KEY_GREATER : PROMPT_KEY_LESSER,
+        slots: { [SLOT_LEFT]: operandSlot(pair.left), [SLOT_RIGHT]: operandSlot(pair.right) },
+      },
+      schema,
+      answer: { canonical: operandAnswer(answer), alsoAccept: [] },
+      distractors: [],
+      check: { kind: "exact" },
+      solution: solutionFor(params, pair, answer),
+    };
+
+    return { ...base, distractors: distractorsFor(COMPARE_ORDER_FAMILY, base) };
+  },
+
+  check(exercise: Exercise, submitted: AnswerValue): Verdict {
+    return judge(exercise, submitted);
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/compareOrder/params.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/compareOrder/params.ts
@@ -1,0 +1,98 @@
+/**
+ * `gen.number.compare-order` parameters.
+ *
+ * A discriminated union rather than one flat record with dead fields. Column-op
+ * spells `acrossZero must be 0 for add` as a validator message because both of its
+ * operations share every other field; these three number types share almost
+ * nothing, and a flat record would make every level table carry four zeroes whose
+ * meaning is "not this kind of number".
+ */
+
+import { MAX_WHOLE_DIGITS } from "../shared/draw.ts";
+import { reader } from "../shared/paramReader.ts";
+import type { ParamResult, ParamSchema } from "../../types/generator.ts";
+
+export type CompareTask = "greater" | "lesser";
+export const COMPARE_TASKS: readonly CompareTask[] = ["greater", "lesser"];
+
+export type NumberType = "whole" | "fraction" | "decimal";
+export const NUMBER_TYPES: readonly NumberType[] = ["whole", "fraction", "decimal"];
+
+export type CompareOrderParams =
+  | {
+      readonly numberType: "whole";
+      readonly task: CompareTask;
+      /** Both numbers are written with exactly this many digits. */
+      readonly digits: number;
+      /** How many leading digits the two numbers are made to share. */
+      readonly sharedPrefix: number;
+    }
+  | {
+      readonly numberType: "decimal";
+      readonly task: CompareTask;
+      /** Digits in the whole part of both numbers. */
+      readonly digits: number;
+      /** Places after the point on the shorter-written number. */
+      readonly decimalPlaces: number;
+      /** Extra places on the longer-written one. Zero would defeat the point. */
+      readonly placeGap: number;
+    }
+  | {
+      readonly numberType: "fraction";
+      readonly task: CompareTask;
+      /** Denominators are drawn from 2..maxDenominator. */
+      readonly maxDenominator: number;
+      /**
+       * Draw both fractions with the same numerator.
+       *
+       * This is a *content* decision with a diagnostic purpose, declared in the
+       * level table where a reader can see it, and it is what makes
+       * `mis.frac.larger-denominator-larger-fraction` measurable: with one
+       * numerator, the larger denominator is the smaller number as a matter of
+       * arithmetic, so the buggy rule is wrong on every such item without the
+       * mal-rule ever inspecting the correct answer.
+       */
+      readonly sameNumerator: boolean;
+    };
+
+export const MIN_DENOMINATOR = 3;
+export const MAX_DENOMINATOR = 60;
+
+export const compareOrderParamSchema: ParamSchema<CompareOrderParams> = {
+  describe:
+    "{ numberType: 'whole', task, digits: 2..7, sharedPrefix: 0..digits-1 } | " +
+    "{ numberType: 'decimal', task, digits: 1..5, decimalPlaces: 1..3, placeGap: 1..2 } | " +
+    "{ numberType: 'fraction', task, maxDenominator: 3..60, sameNumerator: boolean }",
+
+  validate(raw: unknown): ParamResult<CompareOrderParams> {
+    const read = reader(raw);
+    const numberType = read.choice<NumberType>("numberType", NUMBER_TYPES);
+    const task = read.choice<CompareTask>("task", COMPARE_TASKS);
+
+    if (numberType === "whole") {
+      const digits = read.int("digits", 2, MAX_WHOLE_DIGITS);
+      const sharedPrefix = read.int("sharedPrefix", 0, Math.max(0, digits - 1));
+      return read.finish({ numberType, task, digits, sharedPrefix });
+    }
+
+    if (numberType === "decimal") {
+      const digits = read.int("digits", 1, 5);
+      const decimalPlaces = read.int("decimalPlaces", 1, 3);
+      const placeGap = read.int("placeGap", 1, 2);
+      if (read.clean() && decimalPlaces + placeGap > 4) {
+        read.reject("placeGap", "a number written to more than four places is not an elementary decimal");
+      }
+      return read.finish({ numberType, task, digits, decimalPlaces, placeGap });
+    }
+
+    const maxDenominator = read.int("maxDenominator", MIN_DENOMINATOR, MAX_DENOMINATOR);
+    const sameNumerator = read.boolean("sameNumerator");
+    if (read.clean() && sameNumerator && maxDenominator < 4) {
+      read.reject(
+        "maxDenominator",
+        "a same-numerator pair needs a numerator below two different denominators; 4 is the smallest that admits one",
+      );
+    }
+    return read.finish({ numberType, task, maxDenominator, sameNumerator });
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/compareOrder/read.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/compareOrder/read.ts
@@ -1,0 +1,67 @@
+/**
+ * Reading a comparison back out of a finished `Exercise`, for the mal-rules.
+ *
+ * The two operands are prompt slots, which is the published contract; nothing here
+ * reaches into the generator. Never throws — a rule handed another family's item
+ * declines it.
+ */
+
+import { rational } from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import type { AnswerValue } from "../../types/answer.ts";
+import type { Exercise, PromptSlot } from "../../types/exercise.ts";
+import { PROMPT_KEY_GREATER, PROMPT_KEY_LESSER, SLOT_LEFT, SLOT_RIGHT } from "./constants.ts";
+import type { CompareTask } from "./params.ts";
+
+export type CompareOperand =
+  | { readonly kind: "number"; readonly value: Rational; readonly decimalPlaces: number }
+  | { readonly kind: "fraction"; readonly num: bigint; readonly den: bigint };
+
+export type ComparePair = {
+  readonly task: CompareTask;
+  readonly left: CompareOperand;
+  readonly right: CompareOperand;
+};
+
+function operandOf(slot: PromptSlot | undefined): CompareOperand | null {
+  if (slot === undefined) return null;
+  if (slot.kind === "number") {
+    return { kind: "number", value: slot.value, decimalPlaces: slot.decimalPlaces };
+  }
+  if (slot.kind === "fraction") {
+    // A comparison never poses a mixed number: both operands are proper fractions
+    // written as one numerator over one denominator, which is what makes "same
+    // numerator" a readable property of the item.
+    if (slot.whole !== undefined && slot.whole !== 0n) return null;
+    return { kind: "fraction", num: slot.num, den: slot.den };
+  }
+  return null;
+}
+
+/** The exact value of an operand, whichever way it is written. */
+export function operandValue(operand: CompareOperand): Rational {
+  return operand.kind === "number" ? operand.value : rational(operand.num, operand.den);
+}
+
+/** The answer a child writes when they choose this operand. */
+export function operandAnswer(operand: CompareOperand): AnswerValue {
+  return operand.kind === "number"
+    ? { kind: "integer", value: operand.value }
+    : { kind: "fraction", num: operand.num, den: operand.den };
+}
+
+export function readComparePair(exercise: Exercise): ComparePair | null {
+  const task: CompareTask | null =
+    exercise.prompt.key === PROMPT_KEY_GREATER
+      ? "greater"
+      : exercise.prompt.key === PROMPT_KEY_LESSER
+        ? "lesser"
+        : null;
+  if (task === null) return null;
+
+  const left = operandOf(exercise.prompt.slots[SLOT_LEFT]);
+  const right = operandOf(exercise.prompt.slots[SLOT_RIGHT]);
+  if (left === null || right === null) return null;
+  if (left.kind !== right.kind) return null;
+  return { task, left, right };
+}

--- a/dynawalla/packs/shared/curriculum/src/generators/families.property.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/families.property.test.ts
@@ -1,0 +1,544 @@
+/**
+ * Property tests over **every bound level of every node, draft included**.
+ *
+ * This file exists because of an asymmetry that would otherwise be dangerous.
+ * `dw-curriculum check` builds its sample from `activeNodes` only — deliberately,
+ * so that draft rows cannot inflate any coverage number — and most of this graph is
+ * draft, waiting on the prompt renderer that `render/prompts.ts` declares. Left
+ * there, thirty rows and seven generator families would ship with **no gate having
+ * ever run them**, and the promotion PR that flips `status` would be the first
+ * thing to find out whether they work.
+ *
+ * So the measurements CG-9, CG-10, CG-11, CG-12, CG-16 and CG-17 make on the active
+ * graph are made here on the whole of it, at the same thresholds, and the case
+ * count is printed rather than claimed.
+ *
+ * Every invariant below is a statement about output, checked on every item:
+ *
+ *   1. seeded purity — the same seed twice is byte-identical
+ *   2. distinct seeds are not all the same item
+ *   3. the answer schema can be drawn (`schemaDefect`)
+ *   4. the representation spec can be drawn (`repSpecDefect`)
+ *   5. the prompt template has a registered renderer
+ *   6. every emitted locale key is well formed
+ *   7. the family's checker accepts its own answer and every `alsoAccept`
+ *   8. the checker rejects every distractor, and no distractor is the answer
+ *   9. a distractor's misconception is one the node declares
+ *  10. no answer is negative, and no fraction answer has a zero denominator
+ *  11. the level's variant space clears the node's own `minVariants`
+ *  12. every mal-rule diverges from the correct answer on **every** item it applies
+ *      to, and never returns `null` where it says it applies
+ *  13. the generator invariants two mal-rules depend on, on every bound level
+ *  14. every worked solution's rungs connect, and the last one states the answer
+ *  15. `generate()` stays inside CG-17's p95 and p99 budgets
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { allNodes } from "../graph/graph.ts";
+import { CG10_BLOCKED_LEVELS } from "../graph/promotionBlockers.ts";
+import { familyById } from "./registry.ts";
+import { malRules } from "../malrules/registry.ts";
+import { fingerprintItem, serializeExercise } from "../serialize.ts";
+import { answerAccepted, fractionRational, schemaDefect } from "../types/answer.ts";
+import type { AnswerValue } from "../types/answer.ts";
+import type { Exercise, PromptSlot } from "../types/exercise.ts";
+import { LOC_KEY_PATTERN } from "../types/ids.ts";
+import { cmp, eq as rationalEq, rational } from "../math/rational.ts";
+import type { Rational } from "../math/rational.ts";
+import { findPromptTemplate, promptRegistry } from "../render/prompts.ts";
+import { repSpecDefect } from "../render/representations.ts";
+import { operandValue, readComparePair } from "./compareOrder/read.ts";
+import { PROMPT_KEY_TO_IMPROPER, SLOT_FRACTION } from "./fracEquivalence/constants.ts";
+import {
+  FRAC_ARITH_FAMILY,
+  SLOT_ANSWER as FRAC_SLOT_ANSWER,
+  SLOT_COMBINED as FRAC_SLOT_COMBINED,
+  SOLUTION_KEY_RESULT as FRAC_SOLUTION_KEY_RESULT,
+  SOLUTION_KEY_SIMPLIFY as FRAC_SOLUTION_KEY_SIMPLIFY,
+} from "./fracArith/constants.ts";
+
+/**
+ * Seeds per level. Chosen so the variant-space measurement means something — the
+ * duplicate-rate estimator needs a sample well above the floor it is testing — and
+ * so the whole sweep still runs inside a PR job.
+ */
+const SEEDS_PER_LEVEL = 500;
+
+/** CG-10's floor, restated so the sweep can name the levels that do not clear it. */
+const VARIANT_SPACE_FLOOR = 975;
+
+/** CG-17's budgets, restated here so the draft rows are held to them too. */
+const P95_BUDGET_NS = 5_000_000n;
+const P99_BUDGET_NS = 20_000_000n;
+
+type Level = {
+  readonly label: string;
+  readonly nodeId: string;
+  readonly level: number;
+  readonly status: string;
+  readonly minVariants: number;
+  readonly declared: ReadonlySet<string>;
+  readonly exercises: readonly Exercise[];
+  readonly timingsNs: readonly bigint[];
+};
+
+/** Generate the whole graph once. Every test below reads the same draw. */
+function sweep(): Level[] {
+  const levels: Level[] = [];
+
+  for (const node of allNodes) {
+    if (node.status === "deprecated") continue;
+    const family = familyById(node.generator.family);
+    assert.ok(family !== undefined, `${node.id} binds unregistered family ${node.generator.family}`);
+
+    node.generator.params.forEach((params, level) => {
+      const validated = family.paramSchema.validate(params);
+      assert.ok(
+        validated.ok,
+        `${node.id} L${String(level)} params rejected: ${
+          validated.ok ? "" : validated.issues.map((i) => `${i.path}: ${i.message}`).join("; ")
+        }`,
+      );
+      if (!validated.ok) return;
+
+      const exercises: Exercise[] = [];
+      const timingsNs: bigint[] = [];
+      for (let seed = 1; seed <= SEEDS_PER_LEVEL; seed++) {
+        const started = process.hrtime.bigint();
+        const exercise = family.generate({
+          skillId: node.id,
+          level,
+          seed,
+          params: validated.value,
+          forms: node.generator.forms,
+        });
+        timingsNs.push(process.hrtime.bigint() - started);
+        exercises.push(exercise);
+      }
+
+      levels.push({
+        label: `${node.id} L${String(level)}`,
+        nodeId: node.id,
+        level,
+        status: node.status,
+        minVariants: node.generator.minVariants,
+        declared: new Set(node.misconceptions.map(String)),
+        exercises,
+        timingsNs,
+      });
+    });
+  }
+
+  return levels;
+}
+
+const LEVELS = sweep();
+const ALL_ITEMS: readonly Exercise[] = LEVELS.flatMap((level) => [...level.exercises]);
+
+/**
+ * The exact value a prompt slot writes, or `null` for a slot that writes no number.
+ *
+ * Values and not kinds: a worked solution states its result as whatever slot the
+ * renderer needs, and the last rung of a `columnAlgorithm` item writes a plain
+ * number. Asking "is this the same number" is the question; asking "is this the
+ * same kind of answer value" would fail on that item for no reason.
+ */
+function slotValue(slot: PromptSlot | undefined): Rational | null {
+  if (slot === undefined) return null;
+  switch (slot.kind) {
+    case "number":
+      return slot.value;
+    case "count":
+      return rational(BigInt(slot.value));
+    case "fraction":
+      return fractionRational({ kind: "fraction", num: slot.num, den: slot.den, ...(slot.whole === undefined ? {} : { whole: slot.whole }) });
+    case "term":
+      return null;
+  }
+}
+
+/** The exact value of an answer, or `null` for a choice index, which is not one. */
+function answerValue(value: AnswerValue): Rational | null {
+  switch (value.kind) {
+    case "integer":
+    case "columnAlgorithm":
+      return value.value;
+    case "fraction":
+      return fractionRational(value);
+    case "choice":
+      return null;
+  }
+}
+
+test("sweep: the case count is measured, not asserted from memory", () => {
+  const activeLevels = LEVELS.filter((level) => level.status === "active").length;
+  const draftLevels = LEVELS.filter((level) => level.status === "draft").length;
+  process.stdout.write(
+    `# sweep: ${String(ALL_ITEMS.length)} generated cases over ${String(LEVELS.length)} levels ` +
+      `(${String(activeLevels)} active, ${String(draftLevels)} draft) at ${String(SEEDS_PER_LEVEL)} seeds each\n`,
+  );
+  // A sweep that silently generated nothing would pass every test below.
+  assert.equal(ALL_ITEMS.length, LEVELS.length * SEEDS_PER_LEVEL);
+  assert.ok(LEVELS.length > 100, `expected the whole graph, got ${String(LEVELS.length)} levels`);
+});
+
+test("sweep: the same seed produces the identical exercise, every time", () => {
+  let checked = 0;
+  for (const level of LEVELS) {
+    const node = allNodes.find((candidate) => candidate.id === level.nodeId);
+    assert.ok(node !== undefined);
+    const family = familyById(node.generator.family);
+    assert.ok(family !== undefined);
+    const validated = family.paramSchema.validate(node.generator.params[level.level]);
+    if (!validated.ok) continue;
+
+    // Ten seeds per level rather than five hundred: purity is a property of the
+    // generator, not of the seed, and re-running the whole sweep twice would
+    // double a job that has to fit in ninety seconds.
+    for (const exercise of level.exercises.slice(0, 10)) {
+      const again: Exercise = family.generate({
+        skillId: node.id,
+        level: exercise.level,
+        seed: exercise.seed,
+        params: validated.value,
+        forms: node.generator.forms,
+      });
+      assert.equal(serializeExercise(again), serializeExercise(exercise), `${level.label} seed ${String(exercise.seed)}`);
+      checked += 1;
+    }
+  }
+  assert.ok(checked > 0);
+});
+
+test("sweep: every item is drawable — schema, representation, prompt and locale keys", () => {
+  for (const level of LEVELS) {
+    for (const exercise of level.exercises) {
+      const defect = schemaDefect(exercise.schema);
+      assert.equal(defect, null, `${exercise.exerciseId}: ${defect ?? ""}`);
+
+      if (exercise.representation !== undefined) {
+        const repDefect = repSpecDefect(exercise.representation.rep, exercise.representation.params);
+        assert.equal(repDefect, null, `${exercise.exerciseId}: ${repDefect ?? ""}`);
+      }
+
+      assert.ok(
+        findPromptTemplate(exercise.prompt.key) !== undefined,
+        `${exercise.exerciseId}: prompt template ${exercise.prompt.key} is not in the prompt registry`,
+      );
+
+      assert.match(exercise.prompt.key, LOC_KEY_PATTERN, exercise.exerciseId);
+      for (const slot of Object.values(exercise.prompt.slots)) {
+        if (slot.kind === "term") assert.match(slot.key, LOC_KEY_PATTERN, exercise.exerciseId);
+      }
+      for (const step of exercise.solution) {
+        assert.match(step.key, LOC_KEY_PATTERN, exercise.exerciseId);
+      }
+      // A worked solution that ends before the answer is a hint ladder with no
+      // bottom rung: the last step of every family states the result.
+      assert.ok(exercise.solution.length >= 2, `${exercise.exerciseId}: solution has no ladder`);
+    }
+  }
+});
+
+test("sweep: the prompt registry is closed in both directions", () => {
+  // One direction is asserted on every item above: a template the graph emits is
+  // registered, or a card draws its answer entry with no question above it. This
+  // is the other one, and it is the same shape as the app's `renderers.test.ts`:
+  // a declaration nobody satisfies is a lie, and a `PR-2.13` line item for a
+  // template no level produces is work nobody needs.
+  const emitted = new Set(ALL_ITEMS.map((exercise) => String(exercise.prompt.key)));
+  const declared = promptRegistry.map((entry) => String(entry.id));
+  assert.deepEqual(
+    declared.filter((id) => !emitted.has(id)),
+    [],
+    "prompt templates are declared that no bound level emits",
+  );
+  assert.equal(new Set(declared).size, declared.length, "a prompt template is declared twice");
+  process.stdout.write(`# prompt registry: ${String(declared.length)} template(s), all emitted\n`);
+});
+
+test("sweep: the checker agrees with its own output, and rejects every distractor", () => {
+  for (const level of LEVELS) {
+    const node = allNodes.find((candidate) => candidate.id === level.nodeId);
+    assert.ok(node !== undefined);
+    const family = familyById(node.generator.family);
+    assert.ok(family !== undefined);
+
+    for (const exercise of level.exercises) {
+      assert.ok(family.check(exercise, exercise.answer.canonical).correct, `${exercise.exerciseId}: canonical rejected`);
+      for (const accepted of exercise.answer.alsoAccept) {
+        assert.ok(family.check(exercise, accepted).correct, `${exercise.exerciseId}: alsoAccept rejected`);
+      }
+      for (const distractor of exercise.distractors) {
+        assert.ok(
+          !answerAccepted(exercise.schema, exercise.answer.canonical, distractor.value),
+          `${exercise.exerciseId}: a distractor counts as the answer`,
+        );
+        assert.ok(!family.check(exercise, distractor.value).correct, `${exercise.exerciseId}: checker accepts a distractor`);
+        if (distractor.misconception !== undefined) {
+          assert.ok(
+            level.declared.has(String(distractor.misconception)),
+            `${level.label} emits ${String(distractor.misconception)}, which the node does not declare`,
+          );
+        }
+      }
+    }
+  }
+});
+
+test("sweep: no answer is negative, and no fraction answer has a zero denominator", () => {
+  for (const exercise of ALL_ITEMS) {
+    const answer = exercise.answer.canonical;
+    if (answer.kind === "integer" || answer.kind === "columnAlgorithm") {
+      assert.ok(answer.value.n >= 0n, `${exercise.exerciseId}: negative answer`);
+    }
+    if (answer.kind === "fraction") {
+      assert.ok(answer.den > 0n, `${exercise.exerciseId}: non-positive denominator`);
+      assert.ok(answer.num >= 0n, `${exercise.exerciseId}: negative numerator`);
+      assert.ok((answer.whole ?? 0n) >= 0n, `${exercise.exerciseId}: negative whole part`);
+      assert.ok(
+        answer.num < answer.den || answer.whole === undefined,
+        `${exercise.exerciseId}: a mixed number with an improper fraction part`,
+      );
+    }
+  }
+});
+
+test("sweep: every level clears its own minVariants, and the sub-floor levels are named", () => {
+  const report: string[] = [];
+  const belowFloor: string[] = [];
+
+  for (const level of LEVELS) {
+    const distinct = new Set(level.exercises.map(fingerprintItem)).size;
+    const collisions = level.exercises.length - distinct;
+    const estimate =
+      collisions === 0
+        ? Math.floor((level.exercises.length * level.exercises.length) / 2)
+        : Math.floor((level.exercises.length * level.exercises.length) / (2 * collisions));
+    report.push(`#   ${level.label}: ${String(distinct)} distinct, ~${String(estimate)} variants`);
+    assert.ok(
+      distinct >= level.minVariants,
+      `${level.label}: ${String(distinct)} distinct items over ${String(level.exercises.length)} seeds, below minVariants ${String(level.minVariants)}`,
+    );
+    if (estimate < VARIANT_SPACE_FLOOR) {
+      // The measured count leads and the estimate follows, because only one of the
+      // two is a measurement. `N²/2C` is optimistic at high collision rates and the
+      // gap is not small: `dw.alg.equality.missing-addend` L0 draws both operands
+      // from 1..9 and its true space is exactly 81 items — pinned in
+      // `families.test.ts` — where the estimator reads ~298. A reader sizing the
+      // work on these rows has to see the number that was counted.
+      belowFloor.push(
+        `${level.label} (${String(distinct)} distinct in ${String(level.exercises.length)} draws, estimated ~${String(estimate)})`,
+      );
+    }
+  }
+
+  process.stdout.write(`# variant space, per level:\n${report.join("\n")}\n`);
+
+  // Named, not failed. CG-10's floor of 975 is derived from a 40-item practice run
+  // repeating no more than one item in fifty, and some content genuinely has fewer
+  // problems than that in the world: single-digit missing addends are 81 items,
+  // proper fractions with a denominator under 25 are 276. The floor and the
+  // content are in real conflict and it is not a generator's job to resolve it by
+  // padding the estimator, so the sweep prints the list and the promotion PR for
+  // any of these rows has to reconcile it with whoever owns CG-10.
+  process.stdout.write(
+    belowFloor.length === 0
+      ? `# every level clears CG-10's floor of ${String(VARIANT_SPACE_FLOOR)}\n`
+      : `# ${String(belowFloor.length)} level(s) below CG-10's floor of ${String(VARIANT_SPACE_FLOOR)} — none is active, and none may be promoted without reconciling it:\n#   ${belowFloor.join("\n#   ")}\n`,
+  );
+
+  // Both directions, against the authored list. A printed list is a thing a reader
+  // has to go and find in a test log; `promotionBlockers.ts` is a thing a promotion
+  // PR reads first, and this is what keeps the two from drifting. A level that
+  // slips under the floor has to be added there, and a generator widened past it
+  // has to be struck off.
+  assert.deepEqual(
+    belowFloor.map((line) => line.slice(0, line.indexOf(" ("))).sort(),
+    [...CG10_BLOCKED_LEVELS].sort(),
+    "the levels under CG-10's floor and promotionBlockers.ts disagree",
+  );
+
+  // The one thing that must never silently become true: an *active* level under
+  // the floor. CG-10 would fail on it, and this says so first and by name.
+  const activeBelow = LEVELS.filter((level) => level.status === "active").filter((level) => {
+    const distinct = new Set(level.exercises.map(fingerprintItem)).size;
+    const collisions = level.exercises.length - distinct;
+    if (collisions === 0) return false;
+    return Math.floor((level.exercises.length * level.exercises.length) / (2 * collisions)) < VARIANT_SPACE_FLOOR;
+  });
+  assert.deepEqual(
+    activeBelow.map((level) => level.label),
+    [],
+    "an active level is below CG-10's variant-space floor",
+  );
+});
+
+/**
+ * Divergence, at the bar the rules actually claim: **every** item, not 95% of them.
+ *
+ * CG-12 ships a 95% floor and that is the right floor for a graph that may one day
+ * carry an approximate rule. Every rule in this registry claims more than that —
+ * each docstring argues the buggy procedure cannot land on the correct answer on an
+ * item it is defined on — and a band two points wide would let a regression
+ * classify a correct answer as a diagnosed misconception on one item in twenty and
+ * still ship green. It is not hypothetical: removing the denominator-ten exclusion
+ * from `fracEquivalence`'s `to-improper` draw takes
+ * `mis.frac.mixed-number-concatenation` to 1426/1500 — 74 correct answers
+ * misclassified — which clears 95% comfortably. So the sweep asserts what the rules
+ * claim, and the two guards below hold up the two rules whose guarantee comes from
+ * the generator's content rather than from the arithmetic of `applies()`.
+ *
+ * Divergence is measured with `answerAccepted` and not `answerEquals`, because
+ * `answerAccepted` is what the child is judged with: on a schema that takes any
+ * equivalent fraction, a mal-rule output of `2/4` against a canonical `1/2` is
+ * *not* a wrong answer, however differently it is written. `distractorsFor` has
+ * always used this comparison; the gate and this sweep now match it.
+ */
+test("sweep: every mal-rule diverges from the correct answer on every item it applies to", () => {
+  const lines: string[] = [];
+  for (const rule of malRules) {
+    let applicable = 0;
+    let divergent = 0;
+
+    for (const exercise of ALL_ITEMS) {
+      if (exercise.family !== rule.family) continue;
+      if (!rule.applies(exercise)) continue;
+      applicable += 1;
+      const produced = rule.apply(exercise);
+      assert.ok(produced !== null, `${rule.id}: applies() is true and apply() returned null on ${exercise.exerciseId}`);
+      if (!answerAccepted(exercise.schema, exercise.answer.canonical, produced)) divergent += 1;
+    }
+
+    assert.ok(applicable > 0, `${rule.id}: no item in the whole graph triggers this rule`);
+    assert.equal(
+      divergent,
+      applicable,
+      `${rule.id}: reproduces the correct answer on ${String(applicable - divergent)} of ${String(applicable)} applicable items`,
+    );
+    lines.push(`#   ${rule.id}: ${String(divergent)}/${String(applicable)} divergent`);
+  }
+  process.stdout.write(`# mal-rule fidelity:\n${lines.join("\n")}\n`);
+});
+
+/**
+ * The two generator invariants a mal-rule's correctness rests on, asserted on every
+ * bound level rather than on one hand-picked param table.
+ *
+ * `mis.frac.mixed-number-concatenation` and `mis.dec.longer-is-bigger` both have an
+ * `applies()` that is true on items where the rule would be *right*, and are held
+ * up by a decision inside the generator instead: the denominator ten is never drawn
+ * for a `to-improper` item (`w n/10` written as `wn/10` **is** the correct improper
+ * fraction, since `w × 10 + n` is exactly the concatenation), and a decimal
+ * comparison always writes the longer number as the smaller one. Neither predicate
+ * can be tightened without asking about the answer, which the mal-rule contract
+ * forbids — so the coupling is tested here and named from both docstrings.
+ */
+test("sweep: the generator invariants that hold up two mal-rules", () => {
+  let improperItems = 0;
+  let decimalItems = 0;
+
+  for (const exercise of ALL_ITEMS) {
+    if (exercise.prompt.key === PROMPT_KEY_TO_IMPROPER) {
+      const shown: PromptSlot | undefined = exercise.prompt.slots[SLOT_FRACTION];
+      assert.ok(shown !== undefined && shown.kind === "fraction", exercise.exerciseId);
+      assert.notEqual(
+        shown.den,
+        10n,
+        `${exercise.exerciseId}: a to-improper item on tenths — writing the whole part in front of the numerator is the correct answer, and mis.frac.mixed-number-concatenation would be right`,
+      );
+      improperItems += 1;
+    }
+
+    const pair = readComparePair(exercise);
+    if (pair === null || pair.left.kind !== "number" || pair.right.kind !== "number") continue;
+    if (pair.left.decimalPlaces === pair.right.decimalPlaces) continue;
+    const longer = pair.left.decimalPlaces > pair.right.decimalPlaces ? pair.left : pair.right;
+    const shorter = longer === pair.left ? pair.right : pair.left;
+    assert.ok(
+      cmp(operandValue(longer), operandValue(shorter)) < 0,
+      `${exercise.exerciseId}: the longer-written decimal is not the smaller number, and mis.dec.longer-is-bigger would be right`,
+    );
+    decimalItems += 1;
+  }
+
+  assert.ok(improperItems > 0, "no to-improper item in the whole graph");
+  assert.ok(decimalItems > 0, "no unequal-length decimal comparison in the whole graph");
+  process.stdout.write(
+    `# generator invariants: ${String(improperItems)} to-improper item(s) off tenths, ` +
+      `${String(decimalItems)} decimal comparison(s) with the longer number smaller\n`,
+  );
+});
+
+/**
+ * The hint ladder has no gaps: every rung follows from the one above it.
+ *
+ * Two claims, and the second is the one that was broken. Every family's last rung
+ * states the canonical answer — a walkthrough that stops short is a ladder with no
+ * bottom rung. And in `gen.frac.arith`, where the combining rung writes a result
+ * over the common denominator and the answer is always reduced, the simplifying
+ * rung is present exactly when those two written forms differ. It used to be gated
+ * on `params.lowestTerms`, so the levels that do *not* teach simplifying — ten of
+ * the fifteen in the graph — jumped from `4/6` straight to `2/3` with nothing in
+ * between, on a fifth to a third of their items.
+ */
+test("sweep: every worked solution's last rung is the answer, and no rung is unexplained", () => {
+  let fracItems = 0;
+  let withSimplify = 0;
+
+  for (const exercise of ALL_ITEMS) {
+    const last = exercise.solution[exercise.solution.length - 1];
+    assert.ok(last !== undefined, `${exercise.exerciseId}: no solution`);
+    const stated = slotValue(last.slots["answer"]);
+    const canonical = answerValue(exercise.answer.canonical);
+    if (stated !== null && canonical !== null) {
+      assert.ok(
+        rationalEq(stated, canonical),
+        `${exercise.exerciseId}: the last solution rung states a different number from the answer`,
+      );
+    }
+
+    if (exercise.family !== FRAC_ARITH_FAMILY) continue;
+    fracItems += 1;
+    assert.equal(last.key, FRAC_SOLUTION_KEY_RESULT, exercise.exerciseId);
+
+    const combinedStep = exercise.solution.find((step) => step.slots[FRAC_SLOT_COMBINED] !== undefined);
+    assert.ok(combinedStep !== undefined, `${exercise.exerciseId}: no combining rung`);
+    const combined = combinedStep.slots[FRAC_SLOT_COMBINED];
+    assert.ok(combined !== undefined && combined.kind === "fraction", exercise.exerciseId);
+    const answer: PromptSlot | undefined = last.slots[FRAC_SLOT_ANSWER];
+    assert.ok(answer !== undefined && answer.kind === "fraction", exercise.exerciseId);
+
+    const rewritten = combined.num !== answer.num || combined.den !== answer.den;
+    const simplifies = exercise.solution.some((step) => step.key === FRAC_SOLUTION_KEY_SIMPLIFY);
+    assert.equal(
+      simplifies,
+      rewritten,
+      rewritten
+        ? `${exercise.exerciseId}: the ladder writes ${String(combined.num)}/${String(combined.den)} and then states ${String(answer.num)}/${String(answer.den)} with no rung between them`
+        : `${exercise.exerciseId}: a simplifying rung on an item that needs no simplifying`,
+    );
+    if (simplifies) withSimplify += 1;
+  }
+
+  process.stdout.write(
+    `# hint ladders: ${String(fracItems)} gen.frac.arith item(s), ${String(withSimplify)} with a simplifying rung\n`,
+  );
+});
+
+test("sweep: generate() stays inside CG-17's budget on the draft rows too", () => {
+  const timings = LEVELS.flatMap((level) => [...level.timingsNs]).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  const at = (percentile: number): bigint => {
+    const rank = Math.floor((percentile * timings.length + 99) / 100);
+    return timings[Math.min(timings.length - 1, Math.max(0, rank - 1))] ?? 0n;
+  };
+  const p95 = at(95);
+  const p99 = at(99);
+  process.stdout.write(
+    `# generate(): ${String(timings.length)} calls, p95 ${String(p95 / 1000n)} µs, p99 ${String(p99 / 1000n)} µs\n`,
+  );
+  assert.ok(p95 < P95_BUDGET_NS, `p95 ${String(p95)} ns exceeds the budget`);
+  assert.ok(p99 < P99_BUDGET_NS, `p99 ${String(p99)} ns exceeds the budget`);
+});

--- a/dynawalla/packs/shared/curriculum/src/generators/families.property.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/families.property.test.ts
@@ -245,8 +245,8 @@ test("sweep: every item is drawable — schema, representation, prompt and local
 test("sweep: the prompt registry is closed in both directions", () => {
   // One direction is asserted on every item above: a template the graph emits is
   // registered, or a card draws its answer entry with no question above it. This
-  // is the other one, and it is the same shape as the app's `renderers.test.ts`:
-  // a declaration nobody satisfies is a lie, and a `PR-2.13` line item for a
+  // is the other one, and it is the shape the consuming side's half of CG-8 takes
+  // too: a declaration nobody satisfies is a lie, and a `PR-2.13` line item for a
   // template no level produces is work nobody needs.
   const emitted = new Set(ALL_ITEMS.map((exercise) => String(exercise.prompt.key)));
   const declared = promptRegistry.map((entry) => String(entry.id));

--- a/dynawalla/packs/shared/curriculum/src/generators/families.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/families.test.ts
@@ -1,0 +1,718 @@
+/**
+ * Worked examples verified by hand, and the arithmetic every family claims,
+ * recomputed independently of the generator that produced it.
+ *
+ * Two kinds of test, and the second is the one that would catch a real bug. The
+ * first pins documented numbers — `4,208 ÷ 4 = 1,052` and the `152` a dropped zero
+ * writes — onto the pure procedures, checked against arithmetic done on paper. The
+ * second takes generated items and **re-derives the answer from the prompt**, using
+ * `Rational` and nothing the family exported, so a generator whose draw and whose
+ * answer agreed with each other and with nothing else would fail here.
+ *
+ * The edge cases are named in the same order the acceptance criteria name them:
+ * zeros, repeated digits, regrouping through zeros, boundary values, equal
+ * operands, remainders, unsimplified fractions and decimal precision.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  add as ratAdd,
+  cmp,
+  eq as ratEq,
+  mul as ratMul,
+  rational,
+  sub as ratSub,
+  toScaled,
+} from "../math/rational.ts";
+import type { Rational } from "../math/rational.ts";
+import { skillId } from "../types/ids.ts";
+import type { Exercise, PromptSlot } from "../types/exercise.ts";
+import { answerAccepted } from "../types/answer.ts";
+import { erase } from "../types/generator.ts";
+import type { AnyGeneratorFamily } from "../types/generator.ts";
+import { classify } from "../malrules/registry.ts";
+import { fingerprintItem } from "../serialize.ts";
+
+import { placeValueFamily } from "./placeValue/family.ts";
+import { placeValueParamSchema } from "./placeValue/params.ts";
+import { readPlaceValueQuestion } from "./placeValue/read.ts";
+import { MIS_DIGIT_FOR_VALUE } from "../malrules/placeValue.ts";
+
+import { compareOrderFamily } from "./compareOrder/family.ts";
+import { compareOrderParamSchema } from "./compareOrder/params.ts";
+import { operandValue, readComparePair } from "./compareOrder/read.ts";
+import { MIS_LARGER_DENOMINATOR_LARGER_FRACTION } from "../malrules/compareOrder.ts";
+
+import { roundEstimateFamily, roundHalfUp } from "./roundEstimate/family.ts";
+import { roundEstimateParamSchema } from "./roundEstimate/params.ts";
+
+import { multidigitMulFamily } from "./multidigitMul/family.ts";
+import { multidigitMulParamSchema } from "./multidigitMul/params.ts";
+import {
+  carryBeforeMultiply,
+  digitSum,
+  littleEndianDigits,
+  passCarries,
+  passCarriesInward,
+} from "./multidigitMul/procedure.ts";
+import { readFactors } from "./multidigitMul/read.ts";
+import { PROMPT_KEY_PRODUCT, SLOT_BOTTOM, SLOT_TOP } from "./multidigitMul/constants.ts";
+import { MIS_FORGOT_THE_SHIFT, carryAddedBeforeMultiplying } from "../malrules/multidigitMul.ts";
+
+import { longDivFamily } from "./longDiv/family.ts";
+import { longDivParamSchema } from "./longDiv/params.ts";
+import { hasInteriorZero, longDivisionSteps, withoutInteriorZeros } from "./longDiv/procedure.ts";
+import { readDivision } from "./longDiv/read.ts";
+
+import { fracEquivalenceFamily } from "./fracEquivalence/family.ts";
+import { fracEquivalenceParamSchema } from "./fracEquivalence/params.ts";
+import { readEquivalenceItem } from "./fracEquivalence/read.ts";
+import { MIS_MIXED_NUMBER_CONCATENATION } from "../malrules/fractions.ts";
+
+import { fracArithFamily } from "./fracArith/family.ts";
+import { fracArithParamSchema } from "./fracArith/params.ts";
+import { readFracOperands } from "./fracArith/read.ts";
+
+import { missingOperandFamily } from "./missingOperand/family.ts";
+import { missingOperandParamSchema } from "./missingOperand/params.ts";
+import { readSentence } from "./missingOperand/read.ts";
+import { MIS_ADD_ALL_NUMBERS, MIS_EQUALS_AS_OPERATOR } from "../malrules/missingOperand.ts";
+
+import { isReduced, reduce } from "./shared/fractions.ts";
+
+const SKILL = skillId("dw.ns.place.digit-value");
+const SEEDS = 300;
+
+/**
+ * Validate params the way the gates do, then generate. A bad table fails loudly.
+ *
+ * Takes the **erased** family — `erase()` exists for exactly this, and it is what
+ * lets one helper serve eight families with eight different parameter types
+ * without a cast at every call site. The parameter object is validated by the
+ * family's own schema first, which is the same order `buildSamples` uses.
+ */
+function items(family: AnyGeneratorFamily, raw: unknown, forms: readonly string[], seeds = SEEDS): Exercise[] {
+  const validated = family.paramSchema.validate(raw);
+  assert.ok(validated.ok, validated.ok ? "" : validated.issues.map((i) => `${i.path}: ${i.message}`).join("; "));
+  if (!validated.ok) return [];
+  const out: Exercise[] = [];
+  for (let seed = 1; seed <= seeds; seed++) {
+    out.push(family.generate({ skillId: SKILL, level: 0, seed, params: validated.value, forms }));
+  }
+  return out;
+}
+
+function numberSlot(exercise: Exercise, name: string): Rational {
+  const slot: PromptSlot | undefined = exercise.prompt.slots[name];
+  assert.ok(slot !== undefined && slot.kind === "number", `${exercise.exerciseId}: ${name} is not a number slot`);
+  return slot.kind === "number" ? slot.value : rational(0n);
+}
+
+function integerAnswer(exercise: Exercise): bigint {
+  const answer = exercise.answer.canonical;
+  assert.equal(answer.kind, "integer", exercise.exerciseId);
+  assert.ok(answer.kind === "integer");
+  assert.equal(answer.value.d, 1n, `${exercise.exerciseId}: answer is not a whole number`);
+  return answer.value.n;
+}
+
+// ---------------------------------------------------------------- place value
+
+test("place-value: the worked example, by hand — 4,738", () => {
+  // Hundreds is place 2. The digit there is 7, it is worth 700, and 4,738 holds
+  // 47 hundreds altogether. Checked on paper: 4738 ÷ 100 = 47 remainder 38.
+  const value = 4738n;
+  assert.equal((value / 100n) % 10n, 7n);
+  assert.equal(((value / 100n) % 10n) * 100n, 700n);
+  assert.equal(value / 100n, 47n);
+  assert.equal(value % 100n, 38n);
+});
+
+test("place-value: every answer is the digit, the value or the regrouped count of the number shown", () => {
+  for (const task of ["digit-value", "digit-in-place", "total-in-place"] as const) {
+    const params = { task, digits: 5, minPlace: task === "digit-in-place" ? 0 : 1, maxPlace: 3 };
+    for (const exercise of items(erase(placeValueFamily), params, ["free-entry"])) {
+      const question = readPlaceValueQuestion(exercise);
+      assert.ok(question !== null, exercise.exerciseId);
+      let unit = 1n;
+      for (let i = 0; i < question.place; i++) unit *= 10n;
+      const digit = (question.value / unit) % 10n;
+      const expected =
+        task === "digit-value" ? digit * unit : task === "digit-in-place" ? digit : question.value / unit;
+      assert.equal(integerAnswer(exercise), expected, exercise.exerciseId);
+      // The number is written to the width the level asked for, with no leading zero.
+      assert.equal(question.value.toString().length, 5, exercise.exerciseId);
+    }
+  }
+});
+
+test("place-value: a digit-value item never asks about a place holding a zero", () => {
+  // A zero there is worth zero, which is also what the digit-for-value bug answers:
+  // the one item on which the distractor would be the answer.
+  for (const exercise of items(erase(placeValueFamily), { task: "digit-value", digits: 4, minPlace: 1, maxPlace: 3 },
+    ["free-entry"],
+  )) {
+    const question = readPlaceValueQuestion(exercise);
+    assert.ok(question !== null && question.digit !== 0n, exercise.exerciseId);
+    assert.equal(classify(exercise, { kind: "integer", value: rational(question.digit) }), MIS_DIGIT_FOR_VALUE);
+  }
+});
+
+test("place-value: the validator rejects the questions that would have no content", () => {
+  // Units-column value and units-column count are both `digit-in-place` again.
+  assert.equal(placeValueParamSchema.validate({ task: "digit-value", digits: 3, minPlace: 0, maxPlace: 2 }).ok, false);
+  // "How many hundreds altogether in 738" is the hundreds digit, asked twice.
+  assert.equal(
+    placeValueParamSchema.validate({ task: "total-in-place", digits: 3, minPlace: 1, maxPlace: 2 }).ok,
+    false,
+  );
+  assert.equal(placeValueParamSchema.validate({ task: "digit-value", digits: 3, minPlace: 2, maxPlace: 1 }).ok, false);
+});
+
+// -------------------------------------------------------------- compare-order
+
+test("compare-order: the answer is always the greater (or lesser) of the two written numbers", () => {
+  const tables: unknown[] = [
+    { numberType: "whole", task: "greater", digits: 4, sharedPrefix: 2 },
+    { numberType: "whole", task: "lesser", digits: 3, sharedPrefix: 0 },
+    { numberType: "fraction", task: "greater", maxDenominator: 20, sameNumerator: true },
+    { numberType: "fraction", task: "lesser", maxDenominator: 16, sameNumerator: false },
+    { numberType: "decimal", task: "greater", digits: 2, decimalPlaces: 1, placeGap: 2 },
+  ];
+  for (const table of tables) {
+    for (const exercise of items(erase(compareOrderFamily), table, ["free-entry"])) {
+      const pair = readComparePair(exercise);
+      assert.ok(pair !== null, exercise.exerciseId);
+      const left = operandValue(pair.left);
+      const right = operandValue(pair.right);
+      // Never equal: a comparison of equals has no answer.
+      assert.notEqual(cmp(left, right), 0, exercise.exerciseId);
+      const wanted = pair.task === "greater" ? (cmp(left, right) > 0 ? left : right) : cmp(left, right) < 0 ? left : right;
+      const answer = exercise.answer.canonical;
+      const written =
+        answer.kind === "fraction" ? rational(answer.num, answer.den) : answer.kind === "integer" ? answer.value : null;
+      assert.ok(written !== null && ratEq(written, wanted), exercise.exerciseId);
+    }
+  }
+});
+
+test("compare-order: a same-numerator pair always diagnoses whole-number bias", () => {
+  // 1/3 against 1/5: the greater is 1/3, and the child who reads 5 > 3 writes 1/5.
+  assert.equal(cmp(rational(1n, 3n), rational(1n, 5n)), 1);
+  for (const exercise of items(erase(compareOrderFamily), { numberType: "fraction", task: "greater", maxDenominator: 20, sameNumerator: true },
+    ["free-entry"],
+  )) {
+    const pair = readComparePair(exercise);
+    assert.ok(pair !== null && pair.left.kind === "fraction" && pair.right.kind === "fraction");
+    assert.equal(pair.left.num, pair.right.num, exercise.exerciseId);
+    assert.notEqual(pair.left.den, pair.right.den, exercise.exerciseId);
+    const bigger = pair.left.den > pair.right.den ? pair.left : pair.right;
+    assert.equal(
+      classify(exercise, { kind: "fraction", num: bigger.num, den: bigger.den }),
+      MIS_LARGER_DENOMINATOR_LARGER_FRACTION,
+      exercise.exerciseId,
+    );
+  }
+});
+
+test("compare-order: a decimal item writes the longer number as the smaller one", () => {
+  for (const exercise of items(erase(compareOrderFamily), { numberType: "decimal", task: "greater", digits: 1, decimalPlaces: 1, placeGap: 2 },
+    ["free-entry"],
+  )) {
+    const pair = readComparePair(exercise);
+    assert.ok(pair !== null && pair.left.kind === "number" && pair.right.kind === "number");
+    assert.ok(pair.right.decimalPlaces > pair.left.decimalPlaces, exercise.exerciseId);
+    assert.equal(cmp(operandValue(pair.left), operandValue(pair.right)), 1, exercise.exerciseId);
+    // Both numbers sit exactly on their own decimal grid — no value needs a place
+    // it was not written to.
+    assert.notEqual(toScaled(pair.left.value, pair.left.decimalPlaces), null);
+    assert.notEqual(toScaled(pair.right.value, pair.right.decimalPlaces), null);
+  }
+});
+
+// ------------------------------------------------------------- round-estimate
+
+test("round-estimate: rounding half up, on paper", () => {
+  assert.equal(roundHalfUp(4750n, 100n), 4800n); // the tie goes up
+  assert.equal(roundHalfUp(4749n, 100n), 4700n);
+  assert.equal(roundHalfUp(4751n, 100n), 4800n);
+  assert.equal(roundHalfUp(9950n, 100n), 10000n); // and gains a digit
+  assert.equal(roundHalfUp(5n, 10n), 10n);
+  assert.equal(roundHalfUp(4n, 10n), 0n);
+});
+
+test("round-estimate: the number is never already round, and the answer is the nearest multiple", () => {
+  for (const table of [
+    { digits: 4, minPlace: 1, maxPlace: 3, ties: false },
+    { digits: 5, minPlace: 2, maxPlace: 3, ties: true },
+  ]) {
+    for (const exercise of items(erase(roundEstimateFamily), table, ["free-entry"])) {
+      const value = numberSlot(exercise, "number");
+      assert.equal(value.d, 1n);
+      const answer = integerAnswer(exercise);
+      // Recomputed from the answer's own trailing zeros rather than from the level.
+      const unit = answer === 0n ? 10n : (() => {
+        let u = 1n;
+        while (answer % (u * 10n) === 0n && u < 1000000n) u *= 10n;
+        return u;
+      })();
+      assert.notEqual(value.n % unit, 0n, `${exercise.exerciseId}: already round`);
+      assert.ok(
+        (value.n - answer) * 2n <= unit && (answer - value.n) * 2n <= unit,
+        `${exercise.exerciseId}: not the nearest multiple`,
+      );
+    }
+  }
+});
+
+// ------------------------------------------------------------ multidigit-mul
+
+test("multidigit-mul: the two mal-rules on 47 × 23 and 47 × 3, by hand", () => {
+  // 47 × 23 = 1,081. Written with both partial products in the units column:
+  // 47 × 3 = 141, 47 × 2 = 94, 141 + 94 = 235 — which is 47 × 5, the digit sum.
+  assert.equal(47n * 23n, 1081n);
+  assert.equal(digitSum(23n), 5n);
+  assert.equal(47n * digitSum(23n), 235n);
+
+  // 47 × 3 = 141. Adding the carry before multiplying: units 7 × 3 = 21, write 1
+  // carry 2; tens (4 + 2) × 3 = 18, write 8 carry 1 — 181, not 141.
+  assert.equal(47n * 3n, 141n);
+  assert.ok(passCarriesInward(littleEndianDigits(47n), 3));
+  assert.equal(carryBeforeMultiply(littleEndianDigits(47n), 3), 181n);
+
+  // With no carry there is nothing to add in the wrong order, and the two
+  // procedures are the same one.
+  assert.equal(passCarries(littleEndianDigits(11n), 3), false);
+  assert.equal(carryBeforeMultiply(littleEndianDigits(11n), 3), 33n);
+});
+
+test("multidigit-mul: a carry out of the leading column is not a carry the bug can reorder", () => {
+  // 50 × 2 = 100, and the buggy pass agrees. Correct: units 0 × 2 = 0, write 0
+  // carry 0; tens 5 × 2 = 10, write 0 carry 1; the carry is written — 100. Buggy:
+  // units (0 + 0) × 2 = 0, write 0 carry 0; tens (5 + 0) × 2 = 10, write 0 carry
+  // 1; the carry is written — 100. The pass *carries out* of the tens, but nothing
+  // ever carries *in*, so the two orders of operations never differ.
+  //
+  // The mal-rule read "carries out" once. It admitted 7,980 items like this one
+  // among the 795,390 it claimed over 10..99999 × 2..9, on every one of which it
+  // reproduced the correct answer and `distractorsFor` silently dropped it. The
+  // carry-in reading admits none.
+  const fifty = littleEndianDigits(50n);
+  assert.equal(50n * 2n, 100n);
+  assert.equal(carryBeforeMultiply(fifty, 2), 100n);
+  assert.equal(passCarries(fifty, 2), true);
+  assert.equal(passCarriesInward(fifty, 2), false);
+
+  // The same shape wherever the only carry is the leading one.
+  for (const [top, multiplier] of [
+    [20n, 5],
+    [21n, 9],
+    [30n, 4],
+    [64n, 2],
+    [700n, 3],
+  ] as const) {
+    assert.equal(carryBeforeMultiply(littleEndianDigits(top), multiplier), top * BigInt(multiplier));
+    assert.equal(passCarries(littleEndianDigits(top), multiplier), true);
+    assert.equal(passCarriesInward(littleEndianDigits(top), multiplier), false);
+  }
+
+  // And an exhaustive statement of the fix over the two- and three-digit space:
+  // under the carry-in reading the buggy product is never the correct one.
+  let inward = 0;
+  for (let top = 10n; top <= 999n; top++) {
+    for (let multiplier = 2; multiplier <= 9; multiplier++) {
+      const digits = littleEndianDigits(top);
+      if (!passCarriesInward(digits, multiplier)) continue;
+      inward += 1;
+      assert.notEqual(
+        carryBeforeMultiply(digits, multiplier),
+        top * BigInt(multiplier),
+        `${String(top)} × ${String(multiplier)}`,
+      );
+    }
+  }
+  assert.ok(inward > 5000, `expected a real space, got ${String(inward)} items`);
+});
+
+test("multidigit-mul: the mal-rule declines 50 × 2, which no shipped level can pose", () => {
+  // The sweep cannot see this. `drawCarrying` forces the units column to carry, so
+  // every item a level poses carries inward and the carries-out reading measures
+  // 100% divergence anyway — the guarantee would be a fact about the generator's
+  // content, not about the rule. `applies()` is public and `classify()` runs on
+  // whatever a child is holding, so it is tested on an item the graph cannot draw.
+  const base = items(erase(multidigitMulFamily), { shape: "general", digits: 2, multiplierDigits: 1, carries: true }, [
+    "free-entry",
+  ])[0];
+  assert.ok(base !== undefined);
+  const fiftyTimesTwo: Exercise = {
+    ...base,
+    prompt: {
+      key: PROMPT_KEY_PRODUCT,
+      slots: {
+        [SLOT_TOP]: { kind: "number", value: rational(50n), decimalPlaces: 0 },
+        [SLOT_BOTTOM]: { kind: "number", value: rational(2n), decimalPlaces: 0 },
+      },
+    },
+    answer: { canonical: { kind: "integer", value: rational(100n) }, alsoAccept: [] },
+  };
+
+  const factors = readFactors(fiftyTimesTwo);
+  assert.ok(factors !== null);
+  assert.equal(factors.top * factors.bottom, 100n);
+  // The buggy procedure lands on the correct answer here, so the rule must be
+  // undefined on the item rather than defined and wrong.
+  assert.equal(carryBeforeMultiply(littleEndianDigits(factors.top), Number(factors.bottom)), 100n);
+  assert.equal(carryAddedBeforeMultiplying.applies(fiftyTimesTwo), false);
+  assert.equal(carryAddedBeforeMultiplying.apply(fiftyTimesTwo), null);
+  assert.equal(classify(fiftyTimesTwo, { kind: "integer", value: rational(100n) }), null);
+});
+
+test("multidigit-mul: the answer is the exact product, and the level's carry promise holds", () => {
+  for (const table of [
+    { shape: "general", digits: 3, multiplierDigits: 1, carries: true },
+    { shape: "general", digits: 4, multiplierDigits: 2, carries: true },
+    { shape: "general", digits: 4, multiplierDigits: 1, carries: false },
+    { shape: "power-of-ten", digits: 3, maxPower: 3 },
+  ]) {
+    for (const exercise of items(erase(multidigitMulFamily), table, ["free-entry"])) {
+      const factors = readFactors(exercise);
+      assert.ok(factors !== null, exercise.exerciseId);
+      assert.ok(
+        ratEq(rational(integerAnswer(exercise)), ratMul(rational(factors.top), rational(factors.bottom))),
+        exercise.exerciseId,
+      );
+      if (table.shape === "general" && table.multiplierDigits === 1) {
+        assert.equal(
+          passCarries(littleEndianDigits(factors.top), Number(factors.bottom)),
+          table.carries,
+          `${exercise.exerciseId}: the level promised carries=${String(table.carries)}`,
+        );
+        // A carrying level does not merely carry, it carries *into* a column —
+        // which is what makes the add-the-carry-first bug defined on its items.
+        // `drawCarrying` forces the units column to carry out, so the tens column
+        // always has a carry in; nothing else in the family guarantees it.
+        assert.equal(
+          passCarriesInward(littleEndianDigits(factors.top), Number(factors.bottom)),
+          table.carries,
+          `${exercise.exerciseId}: the level promised a carry the bug can reorder`,
+        );
+      }
+      if (table.shape === "power-of-ten") {
+        assert.equal(factors.bottom.toString().replace(/0+$/, ""), "1", exercise.exerciseId);
+        // `47 × 100` answered as `47` is the shift never applied, not a partial
+        // product misplaced — the two rules are disjoint, so `classify` names one.
+        assert.equal(classify(exercise, { kind: "integer", value: rational(factors.top) }), MIS_FORGOT_THE_SHIFT);
+      }
+    }
+  }
+});
+
+test("multidigit-mul: the validator rejects a non-carrying multi-digit multiplier", () => {
+  assert.equal(
+    multidigitMulParamSchema.validate({ shape: "general", digits: 3, multiplierDigits: 2, carries: false }).ok,
+    false,
+  );
+});
+
+// ------------------------------------------------------------------- long-div
+
+test("long-div: 4,208 ÷ 4 and the zero children drop, by hand", () => {
+  assert.equal(4208n / 4n, 1052n);
+  assert.equal(4208n % 4n, 0n);
+  const steps = longDivisionSteps(4208n, 4n);
+  assert.deepEqual(
+    steps.map((step) => step.digit),
+    [1, 0, 5, 2],
+  );
+  assert.ok(hasInteriorZero(1052n));
+  assert.equal(withoutInteriorZeros(1052n), 152n);
+  // Removing a digit removes a place, so the two can never coincide.
+  assert.ok(withoutInteriorZeros(1052n) < 1052n);
+  // A leading digit is never removed: 1,052 keeps its 1.
+  assert.equal(withoutInteriorZeros(1000n), 1n);
+});
+
+test("long-div: the division identity holds, and the remainder is smaller than the divisor", () => {
+  for (const table of [
+    { task: "quotient", quotientDigits: 3, divisorDigits: 1, exact: true, quotientZeros: false },
+    { task: "remainder", quotientDigits: 3, divisorDigits: 2, exact: false, quotientZeros: false },
+    { task: "quotient-and-remainder", quotientDigits: 3, divisorDigits: 1, exact: false, quotientZeros: false },
+    { task: "quotient", quotientDigits: 4, divisorDigits: 1, exact: true, quotientZeros: true },
+  ]) {
+    for (const exercise of items(erase(longDivFamily), table, ["free-entry"])) {
+      const division = readDivision(exercise);
+      assert.ok(division !== null, exercise.exerciseId);
+      assert.equal(division.quotient * division.divisor + division.remainder, division.dividend, exercise.exerciseId);
+      assert.ok(division.remainder < division.divisor, exercise.exerciseId);
+      assert.ok(division.divisor >= 2n, `${exercise.exerciseId}: dividing by one asks nothing`);
+      assert.equal(division.quotient.toString().length, table.quotientDigits, exercise.exerciseId);
+      if (table.exact) assert.equal(division.remainder, 0n, exercise.exerciseId);
+      else assert.ok(division.remainder > 0n, exercise.exerciseId);
+      if (table.quotientZeros) assert.ok(hasInteriorZero(division.quotient), exercise.exerciseId);
+
+      if (table.task === "quotient-and-remainder") {
+        const answer = exercise.answer.canonical;
+        assert.ok(answer.kind === "fraction");
+        // The mixed number *is* the exact quotient: whole + remainder/divisor.
+        assert.ok(
+          ratEq(
+            ratAdd(rational(answer.whole ?? 0n), rational(answer.num, answer.den)),
+            rational(division.dividend, division.divisor),
+          ),
+          exercise.exerciseId,
+        );
+        // …and it is `as-written`: `7 4/6` is the answer, `7 2/3` is not.
+        assert.equal(answer.den, division.divisor, exercise.exerciseId);
+        assert.equal(
+          answerAccepted(exercise.schema, exercise.answer.canonical, {
+            kind: "fraction",
+            num: reduce(answer.num, answer.den).num,
+            den: reduce(answer.num, answer.den).den,
+            whole: answer.whole ?? 0n,
+          }),
+          isReduced(answer.num, answer.den),
+          exercise.exerciseId,
+        );
+      }
+    }
+  }
+});
+
+test("long-div: the validator rejects the three questions with no content", () => {
+  const base = { quotientDigits: 3, divisorDigits: 1, exact: true, quotientZeros: false };
+  assert.equal(longDivParamSchema.validate({ ...base, task: "remainder" }).ok, false);
+  assert.equal(longDivParamSchema.validate({ ...base, task: "quotient", exact: false }).ok, false);
+  assert.equal(
+    longDivParamSchema.validate({ ...base, task: "quotient", quotientDigits: 1, quotientZeros: true }).ok,
+    false,
+  );
+});
+
+// ---------------------------------------------------------- frac-equivalence
+
+test("frac-equivalence: 2 3/4 is 11/4, and the concatenation bug writes 23/4", () => {
+  assert.equal(2n * 4n + 3n, 11n);
+  assert.equal(BigInt("23"), 23n);
+  assert.notEqual(11n, 23n);
+  // The one denominator on which the two agree is ten, and the generator never
+  // draws it: 2 3/10 → 23/10 either way.
+  assert.equal(2n * 10n + 3n, 23n);
+});
+
+test("frac-equivalence: the rewriting never changes the number, and never rewrites nothing", () => {
+  for (const table of [
+    { task: "simplify", maxDenominator: 24, maxFactor: 4, maxWhole: 1 },
+    { task: "build", maxDenominator: 24, maxFactor: 6, maxWhole: 1 },
+    { task: "to-mixed", maxDenominator: 12, maxFactor: 2, maxWhole: 9 },
+    { task: "to-improper", maxDenominator: 12, maxFactor: 2, maxWhole: 9 },
+  ]) {
+    for (const exercise of items(erase(fracEquivalenceFamily), table, ["free-entry"])) {
+      const item = readEquivalenceItem(exercise);
+      assert.ok(item !== null, exercise.exerciseId);
+      const answer = exercise.answer.canonical;
+      assert.ok(answer.kind === "fraction");
+      const shown = ratAdd(rational(item.whole), rational(item.num, item.den));
+      const written = ratAdd(rational(answer.whole ?? 0n), rational(answer.num, answer.den));
+      assert.ok(ratEq(shown, written), `${exercise.exerciseId}: the rewriting changed the number`);
+      assert.ok(
+        item.num !== answer.num || item.den !== answer.den || item.whole !== (answer.whole ?? 0n),
+        `${exercise.exerciseId}: nothing was rewritten`,
+      );
+
+      if (table.task === "simplify") {
+        assert.ok(isReduced(answer.num, answer.den), `${exercise.exerciseId}: the answer is not in lowest terms`);
+        assert.ok(!isReduced(item.num, item.den), `${exercise.exerciseId}: the question was already simplified`);
+      }
+      if (table.task === "to-mixed") {
+        assert.ok((answer.whole ?? 0n) >= 1n && answer.num >= 1n && answer.num < answer.den, exercise.exerciseId);
+      }
+      if (table.task === "to-improper") {
+        assert.ok(answer.num > answer.den, exercise.exerciseId);
+        const concatenated = BigInt(`${item.whole.toString()}${item.num.toString()}`);
+        assert.notEqual(concatenated, answer.num, `${exercise.exerciseId}: the bug and the answer coincide`);
+        assert.equal(
+          classify(exercise, { kind: "fraction", num: concatenated, den: item.den }),
+          MIS_MIXED_NUMBER_CONCATENATION,
+          exercise.exerciseId,
+        );
+      }
+      // The denominator a child reads never exceeds what the level asked for.
+      assert.ok(item.den <= BigInt(table.maxDenominator), exercise.exerciseId);
+    }
+  }
+});
+
+// ----------------------------------------------------------------- frac-arith
+
+test("frac-arith: 1/2 + 1/3 is 5/6, and the mediant 2/5 is neither operand nor the sum", () => {
+  assert.ok(ratEq(ratAdd(rational(1n, 2n), rational(1n, 3n)), rational(5n, 6n)));
+  // (1+1)/(2+3) = 2/5, which lies strictly between 1/3 and 1/2 — so it can never be
+  // the sum, which is greater than both.
+  assert.equal(cmp(rational(2n, 5n), rational(1n, 2n)), -1);
+  assert.equal(cmp(rational(2n, 5n), rational(1n, 3n)), 1);
+  // 3/4 × 5 = 15/4. Scaling both parts gives 15/20, which is 3/4 again.
+  assert.ok(ratEq(ratMul(rational(3n, 4n), rational(5n)), rational(15n, 4n)));
+  assert.ok(ratEq(rational(15n, 20n), rational(3n, 4n)));
+});
+
+test("frac-arith: the answer is the exact result, positive, and never a whole number", () => {
+  for (const table of [
+    { op: "add", denominators: "like", maxDenominator: 12, lowestTerms: false },
+    { op: "add", denominators: "unlike", maxDenominator: 20, lowestTerms: true },
+    { op: "sub", denominators: "multiple", maxDenominator: 16, lowestTerms: false },
+    { op: "mul", wholeMultiplier: true, maxDenominator: 16, maxWhole: 9, lowestTerms: true },
+    { op: "mul", wholeMultiplier: false, maxDenominator: 12, maxWhole: 2, lowestTerms: false },
+  ]) {
+    for (const exercise of items(erase(fracArithFamily), table, ["free-entry"])) {
+      const operands = readFracOperands(exercise);
+      assert.ok(operands !== null, exercise.exerciseId);
+      const left = rational(operands.leftNum, operands.leftDen);
+      const right = rational(operands.rightNum, operands.rightDen);
+      const expected =
+        table.op === "add" ? ratAdd(left, right) : table.op === "sub" ? ratSub(left, right) : ratMul(left, right);
+
+      const answer = exercise.answer.canonical;
+      assert.ok(answer.kind === "fraction");
+      assert.ok(ratEq(rational(answer.num, answer.den), expected), exercise.exerciseId);
+      assert.ok(expected.n > 0n, `${exercise.exerciseId}: a non-positive result`);
+      assert.notEqual(expected.d, 1n, `${exercise.exerciseId}: a whole-number result in a fraction entry`);
+      assert.ok(isReduced(answer.num, answer.den), `${exercise.exerciseId}: canonical is not in lowest terms`);
+
+      // `lowestTerms` is the knob that decides whether an unsimplified answer
+      // counts. Doubling the canonical answer's parts is always a correct value
+      // and never lowest terms, so it is exactly the case the knob is about.
+      const unsimplified = { kind: "fraction" as const, num: answer.num * 2n, den: answer.den * 2n };
+      assert.equal(
+        answerAccepted(exercise.schema, exercise.answer.canonical, unsimplified),
+        !table.lowestTerms,
+        exercise.exerciseId,
+      );
+    }
+  }
+});
+
+// ------------------------------------------------------------ missing-operand
+
+test("missing-operand: 8 + 4 = ☐ + 5, by hand", () => {
+  // The answer is 7. The two documented wrong answers are 12 — the total of the
+  // side that is finished — and 17, every number on the card added up.
+  assert.equal(8n + 4n - 5n, 7n);
+  assert.equal(8n + 4n, 12n);
+  assert.equal(8n + 4n + 5n, 17n);
+  assert.notEqual(7n, 12n);
+  assert.notEqual(7n, 17n);
+  assert.notEqual(12n, 17n);
+});
+
+test("missing-operand: substituting the answer balances the sentence, on every shape", () => {
+  for (const shape of ["add-unknown", "sub-unknown", "sub-unknown-minuend", "mul-unknown", "both-sides"] as const) {
+    const table = { shape, digits: shape === "mul-unknown" ? 2 : 3, balance: shape === "both-sides" };
+    for (const exercise of items(erase(missingOperandFamily), table, ["free-entry"])) {
+      const sentence = readSentence(exercise);
+      assert.ok(sentence !== null, exercise.exerciseId);
+      const box = integerAnswer(exercise);
+      assert.ok(box > 0n, `${exercise.exerciseId}: the unknown is not positive`);
+
+      if (sentence.shape === "both-sides") {
+        assert.equal(sentence.leftA + sentence.leftB, box + sentence.rightKnown, exercise.exerciseId);
+        assert.equal(classify(exercise, { kind: "integer", value: rational(sentence.leftA + sentence.leftB) }), MIS_EQUALS_AS_OPERATOR);
+        assert.equal(
+          classify(exercise, {
+            kind: "integer",
+            value: rational(sentence.leftA + sentence.leftB + sentence.rightKnown),
+          }),
+          MIS_ADD_ALL_NUMBERS,
+        );
+        // The scale holds the finished side and the part that is already there.
+        assert.ok(exercise.representation !== undefined, exercise.exerciseId);
+        assert.equal(exercise.representation.params["left"], Number(sentence.leftA + sentence.leftB));
+        assert.equal(exercise.representation.params["right"], Number(sentence.rightKnown));
+      } else if (sentence.shape === "add-unknown") {
+        assert.equal(sentence.known + box, sentence.total, exercise.exerciseId);
+      } else if (sentence.shape === "sub-unknown") {
+        assert.equal(sentence.known - box, sentence.total, exercise.exerciseId);
+      } else if (sentence.shape === "sub-unknown-minuend") {
+        assert.equal(box - sentence.known, sentence.total, exercise.exerciseId);
+        // Adding every number on the card *is* the answer here, so the rule is
+        // undefined on this shape and must not be diagnosed.
+        assert.equal(classify(exercise, { kind: "integer", value: rational(box) }), null);
+      } else {
+        assert.equal(sentence.known * box, sentence.total, exercise.exerciseId);
+        assert.equal(sentence.total % sentence.known, 0n, `${exercise.exerciseId}: a missing factor with a remainder`);
+      }
+    }
+  }
+});
+
+test("missing-operand: a one-digit missing addend has exactly 81 items in the world", () => {
+  // `dw.alg.equality.missing-addend` L0 is `sentence("add-unknown", 1)`: the known
+  // addend and the answer are each drawn 1..9 and nothing else varies, so the true
+  // variant space is 9 × 9 = 81 — countable, not estimable.
+  //
+  // The sweep's `N²/2C` estimator reads ~298 on this level and CG-10 at 200 seeds
+  // reads 161; the node declares `minVariants: 40`, half its entire universe. This
+  // pins the real number so nobody sizes that row's promotion off the estimate:
+  // it is not a floor to negotiate, it is a generator that needs more shapes.
+  const drawn = new Set(
+    items(erase(missingOperandFamily), { shape: "add-unknown", digits: 1, balance: false }, ["free-entry"], 4000).map(
+      fingerprintItem,
+    ),
+  );
+  assert.equal(drawn.size, 81, "the one-digit add-unknown space is 9 × 9");
+});
+
+test("missing-operand: the balance scale is rejected on a sentence with one side", () => {
+  assert.equal(missingOperandParamSchema.validate({ shape: "add-unknown", digits: 2, balance: true }).ok, false);
+  assert.equal(missingOperandParamSchema.validate({ shape: "both-sides", digits: 2, balance: true }).ok, true);
+});
+
+// ------------------------------------------------------ validators, everywhere
+
+test("every validator rejects the parameter set that admits no item", () => {
+  // A validator is the first half of "never emits a contradictory or ambiguous
+  // problem": it is what lets `generate()` treat an infeasible draw as a bug
+  // rather than as input it has to guess about. Each case below is a level table
+  // somebody could plausibly write, and each one has no item in it at all.
+
+  // Two denominators above a shared numerator need room for two of them.
+  assert.equal(
+    compareOrderParamSchema.validate({ numberType: "fraction", task: "greater", maxDenominator: 3, sameNumerator: true }).ok,
+    false,
+  );
+  // A shared prefix cannot be the whole number, or the two are the same number.
+  assert.equal(
+    compareOrderParamSchema.validate({ numberType: "whole", task: "greater", digits: 3, sharedPrefix: 3 }).ok,
+    false,
+  );
+  // A backwards place range.
+  assert.equal(roundEstimateParamSchema.validate({ digits: 4, minPlace: 3, maxPlace: 1, ties: false }).ok, false);
+  // Rounding to a place at or above the number's own width answers itself.
+  assert.equal(roundEstimateParamSchema.validate({ digits: 3, minPlace: 3, maxPlace: 3, ties: false }).ok, false);
+  // A fraction scaled by up to six has a denominator of at least twelve; a
+  // ceiling of eight admits nothing.
+  assert.equal(
+    fracEquivalenceParamSchema.validate({ task: "simplify", maxDenominator: 8, maxFactor: 6, maxWhole: 1 }).ok,
+    false,
+  );
+  // A denominator that is a multiple of another needs room for both.
+  assert.equal(
+    fracArithParamSchema.validate({ op: "add", denominators: "multiple", maxDenominator: 4, lowestTerms: false }).ok,
+    false,
+  );
+  // …and the healthy tables those were built from all validate.
+  assert.equal(
+    compareOrderParamSchema.validate({ numberType: "fraction", task: "greater", maxDenominator: 20, sameNumerator: true }).ok,
+    true,
+  );
+  assert.equal(roundEstimateParamSchema.validate({ digits: 4, minPlace: 1, maxPlace: 3, ties: true }).ok, true);
+  assert.equal(
+    fracEquivalenceParamSchema.validate({ task: "simplify", maxDenominator: 24, maxFactor: 6, maxWhole: 1 }).ok,
+    true,
+  );
+  assert.equal(
+    fracArithParamSchema.validate({ op: "add", denominators: "multiple", maxDenominator: 12, lowestTerms: false }).ok,
+    true,
+  );
+});

--- a/dynawalla/packs/shared/curriculum/src/generators/fracArith/constants.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/fracArith/constants.ts
@@ -1,0 +1,66 @@
+/**
+ * `gen.frac.arith` — ids, locale keys and difficulty coefficients.
+ *
+ *   b = b_skill + 0.05·maxDenominator + 0.55·unlikeDenominators + 0.30·multipleDenominators
+ *       + 0.25·lowestTerms − 0.35·wholeMultiplier + formOffset
+ *
+ * Finding a common denominator is the step change in fraction addition, so it takes
+ * the 0.55 slot; the case where one denominator is already a multiple of the other
+ * takes 0.30, because the common denominator is one of the two you were given.
+ * Multiplying by a whole number takes the `specialCase` slot: the denominator does
+ * not move, which is precisely why children think it should.
+ */
+
+import { rational } from "../../math/rational.ts";
+import { familyId, locKey } from "../../types/ids.ts";
+
+export const FRAC_ARITH_FAMILY = familyId("gen.frac.arith");
+export const FRAC_ARITH_FAMILY_REV = 1;
+
+export const FORM_FREE_ENTRY = "free-entry";
+export const FRAC_ARITH_FORMS = [FORM_FREE_ENTRY] as const;
+
+export const PROMPT_KEY_ADD = locKey("dw.prompt.frac-arith.add");
+export const PROMPT_KEY_SUB = locKey("dw.prompt.frac-arith.sub");
+export const PROMPT_KEY_MUL = locKey("dw.prompt.frac-arith.mul");
+export const PROMPT_KEY_MUL_WHOLE = locKey("dw.prompt.frac-arith.mul-whole");
+
+export const SOLUTION_KEY_COMMON_DENOMINATOR = locKey("dw.solution.frac-arith.common-denominator");
+export const SOLUTION_KEY_RESTATE = locKey("dw.solution.frac-arith.restate");
+export const SOLUTION_KEY_COMBINE = locKey("dw.solution.frac-arith.combine");
+export const SOLUTION_KEY_MULTIPLY_PARTS = locKey("dw.solution.frac-arith.multiply-parts");
+export const SOLUTION_KEY_SIMPLIFY = locKey("dw.solution.frac-arith.simplify");
+export const SOLUTION_KEY_RESULT = locKey("dw.solution.frac-arith.result");
+
+export const FRAC_ARITH_LOC_KEYS = [
+  PROMPT_KEY_ADD,
+  PROMPT_KEY_SUB,
+  PROMPT_KEY_MUL,
+  PROMPT_KEY_MUL_WHOLE,
+  SOLUTION_KEY_COMMON_DENOMINATOR,
+  SOLUTION_KEY_RESTATE,
+  SOLUTION_KEY_COMBINE,
+  SOLUTION_KEY_MULTIPLY_PARTS,
+  SOLUTION_KEY_SIMPLIFY,
+  SOLUTION_KEY_RESULT,
+] as const;
+
+export const SLOT_LEFT = "left";
+export const SLOT_RIGHT = "right";
+export const SLOT_DENOMINATOR = "denominator";
+export const SLOT_LEFT_SCALED = "leftScaled";
+export const SLOT_RIGHT_SCALED = "rightScaled";
+export const SLOT_COMBINED = "combined";
+export const SLOT_ANSWER = "answer";
+
+export const COEFF_DENOMINATOR = rational(5n, 100n);
+/** 0.55: finding a common denominator neither operand gave you. */
+export const COEFF_UNLIKE = rational(55n, 100n);
+/** 0.30: the common denominator is one of the two on the card. */
+export const COEFF_MULTIPLE = rational(30n, 100n);
+/** 0.25 when the answer must be written in lowest terms. */
+export const COEFF_LOWEST_TERMS = rational(25n, 100n);
+/** The special case: a whole multiplier leaves the denominator alone. */
+export const COEFF_WHOLE_MULTIPLIER = rational(-35n, 100n);
+
+export const FORM_OFFSET_FREE_ENTRY = rational(0n);

--- a/dynawalla/packs/shared/curriculum/src/generators/fracArith/family.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/fracArith/family.ts
@@ -1,0 +1,343 @@
+/**
+ * `gen.frac.arith` — adding, subtracting and multiplying fractions.
+ *
+ * Three properties are guaranteed by construction rather than by filtering, because
+ * each of them is a way for a fraction item to be degenerate:
+ *
+ * - **A difference is never negative and never zero.** The two operands are ordered
+ *   after they are drawn, and equal values are excluded before that.
+ * - **A result is never a whole number.** `1/2 + 1/2` written as an answer is
+ *   `1/1`, which is a fraction entry holding a number nobody writes that way.
+ * - **A whole multiplier is never one.** Multiplying by one is the item on which
+ *   the scale-both-parts bug produces the right answer.
+ *
+ * The result is computed with `Rational` and then written back out as a numerator
+ * over a denominator, and the written answer's value is compared to the exact one
+ * on every call.
+ */
+
+import {
+  cmp,
+  eq as rationalEq,
+  mul,
+  add as ratAdd,
+  mul as ratMul,
+  sub as ratSub,
+  rational,
+} from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import { createRng, seedFrom } from "../../rng/rng.ts";
+import type { Rng } from "../../rng/rng.ts";
+import type { AnswerSchema, AnswerValue } from "../../types/answer.ts";
+import type { Exercise, PromptSlot, SolutionStep } from "../../types/exercise.ts";
+import { exerciseIdOf } from "../../types/ids.ts";
+import type { GenerateRequest, GeneratorFamily, Verdict } from "../../types/generator.ts";
+import { chooseForm, distractorsFor, judge } from "../shared/build.ts";
+import { fractionSlot, numberSlot } from "../shared/slots.ts";
+import { drawBetween, drawBetweenExcluding } from "../shared/draw.ts";
+import { InfeasibleLevelError } from "../shared/errors.ts";
+import { PROPER_PARTS, fractionAnswer, fractionSchema, lcm, reduce } from "../shared/fractions.ts";
+import {
+  COEFF_DENOMINATOR,
+  COEFF_LOWEST_TERMS,
+  COEFF_MULTIPLE,
+  COEFF_UNLIKE,
+  COEFF_WHOLE_MULTIPLIER,
+  FORM_OFFSET_FREE_ENTRY,
+  FRAC_ARITH_FAMILY,
+  FRAC_ARITH_FAMILY_REV,
+  FRAC_ARITH_FORMS,
+  PROMPT_KEY_ADD,
+  PROMPT_KEY_MUL,
+  PROMPT_KEY_MUL_WHOLE,
+  PROMPT_KEY_SUB,
+  SLOT_ANSWER,
+  SLOT_COMBINED,
+  SLOT_DENOMINATOR,
+  SLOT_LEFT,
+  SLOT_LEFT_SCALED,
+  SLOT_RIGHT,
+  SLOT_RIGHT_SCALED,
+  SOLUTION_KEY_COMBINE,
+  SOLUTION_KEY_COMMON_DENOMINATOR,
+  SOLUTION_KEY_MULTIPLY_PARTS,
+  SOLUTION_KEY_RESTATE,
+  SOLUTION_KEY_RESULT,
+  SOLUTION_KEY_SIMPLIFY,
+} from "./constants.ts";
+import { fracArithParamSchema } from "./params.ts";
+
+/**
+ * Bounds the deterministic retry loop that rejects degenerate draws — the same
+ * device `gen.arith.column-op` uses for `a − a = 0`. A whole-number result is the
+ * only draw this family rejects, it is rare, and the attempt index is part of the
+ * seed material so a retry is as reproducible as a first try.
+ */
+const MAX_GENERATE_ATTEMPTS = 32;
+import type { DenominatorRelation, FracArithParams } from "./params.ts";
+
+type Term = { readonly num: bigint; readonly den: bigint };
+
+type Draw = {
+  readonly left: Term;
+  readonly right: Term;
+  /** True when the right operand is a whole number written without a denominator. */
+  readonly rightIsWhole: boolean;
+};
+
+/** A proper fraction operand. A whole operand is a `numberSlot`, not a `x/1`. */
+function termSlot(term: Term): PromptSlot {
+  return fractionSlot(term.num, term.den);
+}
+
+function valueOfTerm(term: Term): Rational {
+  return rational(term.num, term.den);
+}
+
+/**
+ * A second denominator standing in the requested relation to the first.
+ *
+ * The `unlike` case walks forward from the drawn value until neither denominator
+ * divides the other, rather than drawing again: a redraw would consume a different
+ * number of `Rng` values on different seeds and every later quantity in the item
+ * would move with it. The walk is bounded by the ceiling and consumes nothing.
+ */
+function secondDenominator(first: bigint, relation: DenominatorRelation, ceiling: bigint, rng: Rng): bigint {
+  if (relation === "like") return first;
+  if (relation === "multiple") {
+    const factorCeiling = ceiling / first;
+    if (factorCeiling < 2n) throw new InfeasibleLevelError("no multiple of this denominator fits under the ceiling");
+    return first * drawBetween(rng, 2n, factorCeiling);
+  }
+  const drawn = drawBetween(rng, 2n, ceiling);
+  for (let step = 0n; step < ceiling; step++) {
+    const candidate = ((drawn - 2n + step) % (ceiling - 1n)) + 2n;
+    if (candidate % first !== 0n && first % candidate !== 0n) return candidate;
+  }
+  throw new InfeasibleLevelError("no denominator under the ceiling is coprime enough for an unlike pair");
+}
+
+function drawAddSub(params: Extract<FracArithParams, { op: "add" | "sub" }>, rng: Rng): Draw {
+  const ceiling = BigInt(params.maxDenominator);
+  // A `multiple` pair needs room above the first denominator for a second one.
+  const firstCeiling = params.denominators === "multiple" ? ceiling / 2n : ceiling;
+  // Halves hold exactly one proper fraction, so `a/2 ± b/2` is `1/2 ± 1/2` and
+  // nothing else — a zero difference or a whole sum, and the same item every time.
+  // A like-denominator level therefore starts at thirds. (The other two relations
+  // are safe at two: `unlike` excludes every denominator that divides the first,
+  // and `multiple` puts the larger denominator on the right.)
+  const firstFloor = params.denominators === "like" ? 3n : 2n;
+  const leftDen = drawBetween(rng, firstFloor, firstCeiling);
+  const rightDen = secondDenominator(leftDen, params.denominators, ceiling, rng);
+
+  const leftNum = drawBetween(rng, 1n, leftDen - 1n);
+  // Never the numerator that makes the two operands equal: a zero difference is a
+  // fraction entry holding nothing, and a doubled sum is a different question.
+  const equalNumerator = (leftNum * rightDen) % leftDen === 0n ? (leftNum * rightDen) / leftDen : null;
+  const rightNum =
+    equalNumerator === null || equalNumerator < 1n || equalNumerator > rightDen - 1n
+      ? drawBetween(rng, 1n, rightDen - 1n)
+      : drawBetweenExcluding(rng, 1n, rightDen - 1n, equalNumerator);
+
+  const left: Term = { num: leftNum, den: leftDen };
+  const right: Term = { num: rightNum, den: rightDen };
+  if (params.op === "add") return { left, right, rightIsWhole: false };
+
+  // Subtraction: the larger operand is written first, so the difference is
+  // positive without the level ever posing a negative answer.
+  return cmp(valueOfTerm(left), valueOfTerm(right)) > 0
+    ? { left, right, rightIsWhole: false }
+    : { left: right, right: left, rightIsWhole: false };
+}
+
+function drawMul(params: Extract<FracArithParams, { op: "mul" }>, rng: Rng): Draw {
+  const ceiling = BigInt(params.maxDenominator);
+  const leftDen = drawBetween(rng, 2n, ceiling);
+  const leftNum = drawBetween(rng, 1n, leftDen - 1n);
+  const left: Term = { num: leftNum, den: leftDen };
+
+  if (params.wholeMultiplier) {
+    // Never one: `2/3 × 1` is the one product on which scaling both parts of the
+    // fraction gives the correct answer.
+    const whole = drawBetween(rng, 2n, BigInt(params.maxWhole));
+    return { left, right: { num: whole, den: 1n }, rightIsWhole: true };
+  }
+
+  const rightDen = drawBetween(rng, 2n, ceiling);
+  const rightNum = drawBetween(rng, 1n, rightDen - 1n);
+  return { left, right: { num: rightNum, den: rightDen }, rightIsWhole: false };
+}
+
+function exactResult(params: FracArithParams, draw: Draw): Rational {
+  const left = valueOfTerm(draw.left);
+  const right = valueOfTerm(draw.right);
+  switch (params.op) {
+    case "add":
+      return ratAdd(left, right);
+    case "sub":
+      return ratSub(left, right);
+    case "mul":
+      return ratMul(left, right);
+  }
+}
+
+function promptKeyFor(params: FracArithParams, draw: Draw): typeof PROMPT_KEY_ADD {
+  if (params.op === "add") return PROMPT_KEY_ADD;
+  if (params.op === "sub") return PROMPT_KEY_SUB;
+  return draw.rightIsWhole ? PROMPT_KEY_MUL_WHOLE : PROMPT_KEY_MUL;
+}
+
+function schemaFor(params: FracArithParams): AnswerSchema {
+  // `lowestTerms` selects what counts as the same answer. A level about adding
+  // fifths accepts any correct writing; a level whose goal includes simplifying
+  // does not, or it marks the step that was skipped correct.
+  return fractionSchema(PROPER_PARTS, params.lowestTerms ? "as-written" : "any-equivalent");
+}
+
+/**
+ * The hint ladder, and the rung that used to be missing.
+ *
+ * Every rung has to follow from the one above it. The combining rung writes the
+ * result over the common denominator — `4/6` — and the final rung states the
+ * canonical answer, which `generate()` always reduces — `2/3`. Where those two
+ * differ there is a step, and the ladder says what it is.
+ *
+ * That rung used to be gated on `params.lowestTerms`, which is the wrong question.
+ * `lowestTerms` decides what the *checker accepts*, not what the walkthrough has to
+ * explain, and on a level that accepts `4/6` the walkthrough was jumping straight
+ * to `2/3` — worst on exactly the levels that do not teach simplifying, where the
+ * child was never asked to produce the form the last rung shows. Gating on "the
+ * written forms differ" instead covers both, and also drops the rung on the items
+ * where simplify and result carried identical slots and it said nothing.
+ */
+function solutionFor(params: FracArithParams, draw: Draw, answer: Term): SolutionStep[] {
+  const steps: SolutionStep[] = [];
+  /** The result as the previous rung wrote it, before any reducing. */
+  let combinedTerm: Term;
+
+  if (params.op === "mul") {
+    combinedTerm = { num: draw.left.num * draw.right.num, den: draw.left.den * draw.right.den };
+    steps.push({
+      key: SOLUTION_KEY_MULTIPLY_PARTS,
+      slots: {
+        [SLOT_LEFT]: termSlot(draw.left),
+        [SLOT_RIGHT]: draw.rightIsWhole ? numberSlot(draw.right.num) : termSlot(draw.right),
+        [SLOT_COMBINED]: fractionSlot(combinedTerm.num, combinedTerm.den),
+      },
+    });
+  } else {
+    const common = lcm(draw.left.den, draw.right.den);
+    steps.push({
+      key: SOLUTION_KEY_COMMON_DENOMINATOR,
+      slots: { [SLOT_DENOMINATOR]: numberSlot(common) },
+    });
+    steps.push({
+      key: SOLUTION_KEY_RESTATE,
+      slots: {
+        [SLOT_LEFT_SCALED]: fractionSlot(draw.left.num * (common / draw.left.den), common),
+        [SLOT_RIGHT_SCALED]: fractionSlot(draw.right.num * (common / draw.right.den), common),
+      },
+    });
+    const combined =
+      params.op === "add"
+        ? draw.left.num * (common / draw.left.den) + draw.right.num * (common / draw.right.den)
+        : draw.left.num * (common / draw.left.den) - draw.right.num * (common / draw.right.den);
+    combinedTerm = { num: combined, den: common };
+    steps.push({
+      key: SOLUTION_KEY_COMBINE,
+      slots: { [SLOT_COMBINED]: fractionSlot(combinedTerm.num, combinedTerm.den) },
+    });
+  }
+
+  if (combinedTerm.num !== answer.num || combinedTerm.den !== answer.den) {
+    steps.push({ key: SOLUTION_KEY_SIMPLIFY, slots: { [SLOT_ANSWER]: termSlot(answer) } });
+  }
+  steps.push({ key: SOLUTION_KEY_RESULT, slots: { [SLOT_ANSWER]: termSlot(answer) } });
+  return steps;
+}
+
+export const fracArithFamily: GeneratorFamily<FracArithParams> = {
+  family: FRAC_ARITH_FAMILY,
+  familyRev: FRAC_ARITH_FAMILY_REV,
+  paramSchema: fracArithParamSchema,
+  forms: FRAC_ARITH_FORMS,
+  choiceOnly: false,
+  representations: [],
+
+  answerSchema(params: FracArithParams): AnswerSchema {
+    return schemaFor(params);
+  },
+
+  difficultyOffset(params: FracArithParams): Rational {
+    let b = mul(COEFF_DENOMINATOR, rational(BigInt(params.maxDenominator)));
+    if (params.lowestTerms) b = ratAdd(b, COEFF_LOWEST_TERMS);
+    if (params.op === "mul") {
+      return params.wholeMultiplier ? ratAdd(b, COEFF_WHOLE_MULTIPLIER) : b;
+    }
+    if (params.denominators === "unlike") b = ratAdd(b, COEFF_UNLIKE);
+    if (params.denominators === "multiple") b = ratAdd(b, COEFF_MULTIPLE);
+    return b;
+  },
+
+  formOffset(): Rational {
+    return FORM_OFFSET_FREE_ENTRY;
+  },
+
+  generate(request: GenerateRequest<FracArithParams>): Exercise {
+    const { skillId, level, seed, params, forms } = request;
+    const exerciseId = exerciseIdOf(FRAC_ARITH_FAMILY, FRAC_ARITH_FAMILY_REV, skillId, level, seed);
+    for (let attempt = 0; attempt < MAX_GENERATE_ATTEMPTS; attempt++) {
+    const rng = createRng(seedFrom(exerciseId, String(attempt)));
+
+    const form = chooseForm(forms, FRAC_ARITH_FORMS, rng);
+    const draw = params.op === "mul" ? drawMul(params, rng) : drawAddSub(params, rng);
+
+    const exact = exactResult(params, draw);
+    if (exact.n <= 0n) throw new InfeasibleLevelError(`non-positive result on ${exerciseId}`);
+    if (exact.d === 1n) {
+      // A whole-number result written into a fraction entry is `3/1`, which is not
+      // how anybody writes three. Draw again rather than serve it.
+      continue;
+    }
+
+    const answerParts = reduce(exact.n, exact.d);
+    const answer: Term = { num: answerParts.num, den: answerParts.den };
+    if (!rationalEq(valueOfTerm(answer), exact)) {
+      throw new InfeasibleLevelError(`the written answer is not the exact result on ${exerciseId}`);
+    }
+
+    const schema = schemaFor(params);
+    const base: Exercise = {
+      exerciseId,
+      skillId,
+      level,
+      seed,
+      family: FRAC_ARITH_FAMILY,
+      familyRev: FRAC_ARITH_FAMILY_REV,
+      form,
+      prompt: {
+        key: promptKeyFor(params, draw),
+        slots: {
+          [SLOT_LEFT]: termSlot(draw.left),
+          [SLOT_RIGHT]: draw.rightIsWhole ? numberSlot(draw.right.num) : termSlot(draw.right),
+        },
+      },
+      schema,
+      answer: { canonical: fractionAnswer({ whole: 0n, num: answer.num, den: answer.den }), alsoAccept: [] },
+      distractors: [],
+      check: { kind: "exact" },
+      solution: solutionFor(params, draw, answer),
+    };
+
+    return { ...base, distractors: distractorsFor(FRAC_ARITH_FAMILY, base) };
+    }
+
+    throw new InfeasibleLevelError(
+      `every draw for ${exerciseId} came out whole after ${String(MAX_GENERATE_ATTEMPTS)} attempts`,
+    );
+  },
+
+  check(exercise: Exercise, submitted: AnswerValue): Verdict {
+    return judge(exercise, submitted);
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/fracArith/params.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/fracArith/params.ts
@@ -1,0 +1,71 @@
+/**
+ * `gen.frac.arith` parameters.
+ *
+ * `lowestTerms` is the one knob here that changes what counts as a right answer
+ * rather than what the item looks like, and it is spelled out because the two
+ * readings are both defensible and a family that left it implicit would pick one
+ * silently. On a level *about* adding fifths, `6/8` is a correct sum written
+ * plainly; on a level whose goal includes simplifying, it is the step that was not
+ * taken. The parameter selects `AnswerSchema.fraction.equivalence`, which is what a
+ * renderer and a checker both read.
+ */
+
+import { reader } from "../shared/paramReader.ts";
+import type { ParamResult, ParamSchema } from "../../types/generator.ts";
+
+export type FracOp = "add" | "sub" | "mul";
+export const FRAC_OPS: readonly FracOp[] = ["add", "sub", "mul"];
+
+export type DenominatorRelation = "like" | "multiple" | "unlike";
+export const DENOMINATOR_RELATIONS: readonly DenominatorRelation[] = ["like", "multiple", "unlike"];
+
+export type FracArithParams =
+  | {
+      readonly op: "add" | "sub";
+      readonly denominators: DenominatorRelation;
+      readonly maxDenominator: number;
+      readonly lowestTerms: boolean;
+    }
+  | {
+      readonly op: "mul";
+      /** A second fraction, or a whole number. */
+      readonly wholeMultiplier: boolean;
+      readonly maxDenominator: number;
+      /** Largest whole multiplier. Never one: multiplying by one changes nothing. */
+      readonly maxWhole: number;
+      readonly lowestTerms: boolean;
+    };
+
+export const MIN_MAX_DENOMINATOR = 3;
+export const MAX_MAX_DENOMINATOR = 24;
+
+export const fracArithParamSchema: ParamSchema<FracArithParams> = {
+  describe:
+    "{ op: 'add'|'sub', denominators: 'like'|'multiple'|'unlike', maxDenominator: 3..24, lowestTerms: boolean } | " +
+    "{ op: 'mul', wholeMultiplier: boolean, maxDenominator: 3..24, maxWhole: 2..12, lowestTerms: boolean }",
+
+  validate(raw: unknown): ParamResult<FracArithParams> {
+    const read = reader(raw);
+    const op = read.choice<FracOp>("op", FRAC_OPS);
+    const maxDenominator = read.int("maxDenominator", MIN_MAX_DENOMINATOR, MAX_MAX_DENOMINATOR);
+    const lowestTerms = read.boolean("lowestTerms");
+
+    if (op === "mul") {
+      const wholeMultiplier = read.boolean("wholeMultiplier");
+      const maxWhole = read.int("maxWhole", 2, 12);
+      return read.finish({ op, wholeMultiplier, maxDenominator, maxWhole, lowestTerms });
+    }
+
+    const denominators = read.choice<DenominatorRelation>("denominators", DENOMINATOR_RELATIONS);
+    if (read.clean() && denominators === "multiple" && maxDenominator < 6) {
+      read.reject(
+        "maxDenominator",
+        "a denominator that is a multiple of another needs a ceiling of at least six (2 and 6, say)",
+      );
+    }
+    if (read.clean() && denominators === "unlike" && maxDenominator < 5) {
+      read.reject("maxDenominator", "two denominators neither of which divides the other need a ceiling of five");
+    }
+    return read.finish({ op, denominators, maxDenominator, lowestTerms });
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/fracArith/read.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/fracArith/read.ts
@@ -1,0 +1,62 @@
+/**
+ * Reading a fraction calculation back out of a finished `Exercise`, for the
+ * mal-rules. The published contract only; never throws.
+ */
+
+import { asInteger } from "../../math/rational.ts";
+import type { Exercise, PromptSlot } from "../../types/exercise.ts";
+import {
+  PROMPT_KEY_ADD,
+  PROMPT_KEY_MUL,
+  PROMPT_KEY_MUL_WHOLE,
+  PROMPT_KEY_SUB,
+  SLOT_LEFT,
+  SLOT_RIGHT,
+} from "./constants.ts";
+
+export type FracOperation = "add" | "sub" | "mul" | "mul-whole";
+
+export type FracOperands = {
+  readonly operation: FracOperation;
+  readonly leftNum: bigint;
+  readonly leftDen: bigint;
+  /** On `mul-whole` this is the whole number, with `rightDen` one. */
+  readonly rightNum: bigint;
+  readonly rightDen: bigint;
+};
+
+function operationOf(key: string): FracOperation | null {
+  if (key === PROMPT_KEY_ADD) return "add";
+  if (key === PROMPT_KEY_SUB) return "sub";
+  if (key === PROMPT_KEY_MUL) return "mul";
+  if (key === PROMPT_KEY_MUL_WHOLE) return "mul-whole";
+  return null;
+}
+
+function fractionOf(slot: PromptSlot | undefined): { num: bigint; den: bigint } | null {
+  if (slot === undefined) return null;
+  if (slot.kind === "fraction") {
+    if (slot.whole !== undefined && slot.whole !== 0n) return null;
+    return slot.den > 0n ? { num: slot.num, den: slot.den } : null;
+  }
+  if (slot.kind === "number") {
+    const whole = asInteger(slot.value);
+    return whole === null ? null : { num: whole, den: 1n };
+  }
+  return null;
+}
+
+export function readFracOperands(exercise: Exercise): FracOperands | null {
+  const operation = operationOf(exercise.prompt.key);
+  if (operation === null) return null;
+  const left = fractionOf(exercise.prompt.slots[SLOT_LEFT]);
+  const right = fractionOf(exercise.prompt.slots[SLOT_RIGHT]);
+  if (left === null || right === null) return null;
+  return {
+    operation,
+    leftNum: left.num,
+    leftDen: left.den,
+    rightNum: right.num,
+    rightDen: right.den,
+  };
+}

--- a/dynawalla/packs/shared/curriculum/src/generators/fracEquivalence/constants.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/fracEquivalence/constants.ts
@@ -1,0 +1,64 @@
+/**
+ * `gen.frac.equivalence-simplify` — ids, locale keys and difficulty coefficients.
+ *
+ *   b = b_skill + 0.05·maxDenominator + 0.30·(factor − 1) + 0.25·wholePart
+ *       − 0.35·toMixed + formOffset
+ *
+ * Four tasks, one family, because all four are the same act: writing a number a
+ * different way without changing it. Simplifying, building an equivalent fraction,
+ * and moving between improper and mixed notation are the three places a child meets
+ * that idea in elementary school, and separating them into families would hide the
+ * fact that they can all be got wrong the same way.
+ *
+ * `toMixed` takes the `specialCase` slot: reading a division off an improper
+ * fraction is the one direction that needs no multiplication at all.
+ */
+
+import { rational } from "../../math/rational.ts";
+import { familyId, locKey } from "../../types/ids.ts";
+
+export const FRAC_EQUIVALENCE_FAMILY = familyId("gen.frac.equivalence-simplify");
+export const FRAC_EQUIVALENCE_FAMILY_REV = 1;
+
+export const FORM_FREE_ENTRY = "free-entry";
+export const FRAC_EQUIVALENCE_FORMS = [FORM_FREE_ENTRY] as const;
+
+export const PROMPT_KEY_SIMPLIFY = locKey("dw.prompt.frac-equivalence.simplify");
+export const PROMPT_KEY_BUILD = locKey("dw.prompt.frac-equivalence.build");
+export const PROMPT_KEY_TO_MIXED = locKey("dw.prompt.frac-equivalence.to-mixed");
+export const PROMPT_KEY_TO_IMPROPER = locKey("dw.prompt.frac-equivalence.to-improper");
+
+export const SOLUTION_KEY_COMMON_FACTOR = locKey("dw.solution.frac-equivalence.common-factor");
+export const SOLUTION_KEY_SCALE = locKey("dw.solution.frac-equivalence.scale");
+export const SOLUTION_KEY_DIVIDE_OUT = locKey("dw.solution.frac-equivalence.divide-out");
+export const SOLUTION_KEY_WHOLES_IN = locKey("dw.solution.frac-equivalence.wholes-in");
+export const SOLUTION_KEY_RESULT = locKey("dw.solution.frac-equivalence.result");
+
+export const FRAC_EQUIVALENCE_LOC_KEYS = [
+  PROMPT_KEY_SIMPLIFY,
+  PROMPT_KEY_BUILD,
+  PROMPT_KEY_TO_MIXED,
+  PROMPT_KEY_TO_IMPROPER,
+  SOLUTION_KEY_COMMON_FACTOR,
+  SOLUTION_KEY_SCALE,
+  SOLUTION_KEY_DIVIDE_OUT,
+  SOLUTION_KEY_WHOLES_IN,
+  SOLUTION_KEY_RESULT,
+] as const;
+
+export const SLOT_FRACTION = "fraction";
+export const SLOT_DENOMINATOR = "denominator";
+export const SLOT_FACTOR = "factor";
+export const SLOT_WHOLE = "whole";
+export const SLOT_ANSWER = "answer";
+
+/** 0.05 per unit of the denominator ceiling — bigger parts, more to hold. */
+export const COEFF_DENOMINATOR = rational(5n, 100n);
+/** 0.30 per unit of the scaling factor past one. */
+export const COEFF_FACTOR = rational(30n, 100n);
+/** 0.25 when a whole part is in play. */
+export const COEFF_WHOLE_PART = rational(25n, 100n);
+/** The special case: improper to mixed is one division and no multiplication. */
+export const COEFF_TO_MIXED = rational(-35n, 100n);
+
+export const FORM_OFFSET_FREE_ENTRY = rational(0n);

--- a/dynawalla/packs/shared/curriculum/src/generators/fracEquivalence/family.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/fracEquivalence/family.ts
@@ -1,0 +1,241 @@
+/**
+ * `gen.frac.equivalence-simplify` — the same number, written another way.
+ *
+ * Simplifying, building an equivalent fraction, and moving between improper and
+ * mixed notation are one family because they are one idea, and because the item
+ * that exposes the misconception in the fourth task is built out of the third.
+ *
+ * **Every answer is `as-written`, and that is the whole point.** On a
+ * simplification item, `2/4` is the *question*; accepting it as an answer would
+ * mark the thing being taught correct. `AnswerSchema.fraction.equivalence` exists
+ * so that this decision is written on the schema a renderer and a checker both see,
+ * rather than living in a comment.
+ *
+ * The answer's value is checked against the presented fraction's value with exact
+ * rational arithmetic on every call: a rewriting that changed the number is the one
+ * bug this family could have, and it cannot be served.
+ */
+
+import { eq as rationalEq, mul, rational, add as ratAdd } from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import { createRng, seedFrom } from "../../rng/rng.ts";
+import type { Rng } from "../../rng/rng.ts";
+import type { AnswerSchema, AnswerValue } from "../../types/answer.ts";
+import type { Exercise, PromptSlot, SolutionStep } from "../../types/exercise.ts";
+import { exerciseIdOf } from "../../types/ids.ts";
+import type { LocKey } from "../../types/ids.ts";
+import type { GenerateRequest, GeneratorFamily, Verdict } from "../../types/generator.ts";
+import { chooseForm, distractorsFor, judge } from "../shared/build.ts";
+import { fractionSlot, numberSlot } from "../shared/slots.ts";
+import { drawBetween, drawBetweenExcluding } from "../shared/draw.ts";
+import { InfeasibleLevelError } from "../shared/errors.ts";
+import { MIXED_PARTS, PROPER_PARTS, fractionAnswer, fractionSchema, reduce, valueOf } from "../shared/fractions.ts";
+import type { WrittenFraction } from "../shared/fractions.ts";
+import {
+  COEFF_DENOMINATOR,
+  COEFF_FACTOR,
+  COEFF_TO_MIXED,
+  COEFF_WHOLE_PART,
+  FORM_OFFSET_FREE_ENTRY,
+  FRAC_EQUIVALENCE_FAMILY,
+  FRAC_EQUIVALENCE_FAMILY_REV,
+  FRAC_EQUIVALENCE_FORMS,
+  PROMPT_KEY_BUILD,
+  PROMPT_KEY_SIMPLIFY,
+  PROMPT_KEY_TO_IMPROPER,
+  PROMPT_KEY_TO_MIXED,
+  SLOT_ANSWER,
+  SLOT_DENOMINATOR,
+  SLOT_FACTOR,
+  SLOT_FRACTION,
+  SLOT_WHOLE,
+  SOLUTION_KEY_COMMON_FACTOR,
+  SOLUTION_KEY_DIVIDE_OUT,
+  SOLUTION_KEY_RESULT,
+  SOLUTION_KEY_SCALE,
+  SOLUTION_KEY_WHOLES_IN,
+} from "./constants.ts";
+import { fracEquivalenceParamSchema } from "./params.ts";
+import type { EquivalenceTask, FracEquivalenceParams } from "./params.ts";
+
+const PROMPT_KEYS: Readonly<Record<EquivalenceTask, LocKey>> = {
+  simplify: PROMPT_KEY_SIMPLIFY,
+  build: PROMPT_KEY_BUILD,
+  "to-mixed": PROMPT_KEY_TO_MIXED,
+  "to-improper": PROMPT_KEY_TO_IMPROPER,
+};
+
+type Item = {
+  /** What is written on the card. */
+  readonly shown: WrittenFraction;
+  /** What the child writes. */
+  readonly answer: WrittenFraction;
+  /** The scaling factor between the two, where there is one. */
+  readonly factor: bigint;
+  /** The target denominator, on a `build` item. */
+  readonly target: bigint;
+};
+
+/** A written fraction, whole part and all. */
+function writtenSlot(written: WrittenFraction): PromptSlot {
+  return fractionSlot(written.num, written.den, written.whole);
+}
+
+/**
+ * A reduced proper fraction whose denominator leaves room to be scaled up.
+ *
+ * Drawn as any proper fraction and then reduced, rather than by rejecting until the
+ * draw happens to be in lowest terms: a rejection loop's draw count depends on what
+ * it rejected, and every later value in the item would move with it.
+ */
+function drawReducedBase(maxDenominator: number, rng: Rng): { num: bigint; den: bigint } {
+  const den = drawBetween(rng, 2n, BigInt(maxDenominator) / 2n);
+  const num = drawBetween(rng, 1n, den - 1n);
+  return reduce(num, den);
+}
+
+function drawItem(params: FracEquivalenceParams, rng: Rng): Item {
+  const ceiling = BigInt(params.maxDenominator);
+
+  if (params.task === "simplify" || params.task === "build") {
+    const base = drawReducedBase(params.maxDenominator, rng);
+    const factorCeiling = ceiling / base.den;
+    if (factorCeiling < 2n) throw new InfeasibleLevelError("no room to scale this fraction up");
+    const factor = drawBetween(rng, 2n, factorCeiling > BigInt(params.maxFactor) ? BigInt(params.maxFactor) : factorCeiling);
+    const scaled: WrittenFraction = { whole: 0n, num: base.num * factor, den: base.den * factor };
+    const reduced: WrittenFraction = { whole: 0n, num: base.num, den: base.den };
+
+    return params.task === "simplify"
+      ? { shown: scaled, answer: reduced, factor, target: base.den }
+      : { shown: reduced, answer: scaled, factor, target: base.den * factor };
+  }
+
+  // Improper and mixed. The denominator ten is excluded from the `to-improper`
+  // draw: with a single-digit numerator, writing the whole part in front of the
+  // numerator *is* multiplying by ten, so the concatenation bug would produce the
+  // correct answer and the item could not tell the two apart.
+  const den =
+    params.task === "to-improper"
+      ? drawBetweenExcluding(rng, 2n, ceiling, 10n)
+      : drawBetween(rng, 2n, ceiling);
+  const whole = drawBetween(rng, 1n, BigInt(params.maxWhole));
+  const num = drawBetween(rng, 1n, den - 1n);
+
+  const mixed: WrittenFraction = { whole, num, den };
+  const improper: WrittenFraction = { whole: 0n, num: whole * den + num, den };
+
+  return params.task === "to-mixed"
+    ? { shown: improper, answer: mixed, factor: 1n, target: den }
+    : { shown: mixed, answer: improper, factor: 1n, target: den };
+}
+
+function schemaFor(params: FracEquivalenceParams): AnswerSchema {
+  return params.task === "to-mixed"
+    ? fractionSchema(MIXED_PARTS, "as-written")
+    : fractionSchema(PROPER_PARTS, "as-written");
+}
+
+function promptSlots(task: EquivalenceTask, item: Item): Record<string, PromptSlot> {
+  return task === "build"
+    ? { [SLOT_FRACTION]: writtenSlot(item.shown), [SLOT_DENOMINATOR]: numberSlot(item.target) }
+    : { [SLOT_FRACTION]: writtenSlot(item.shown) };
+}
+
+function solutionFor(task: EquivalenceTask, item: Item): SolutionStep[] {
+  const steps: SolutionStep[] = [];
+
+  if (task === "simplify") {
+    steps.push({
+      key: SOLUTION_KEY_COMMON_FACTOR,
+      slots: { [SLOT_FRACTION]: writtenSlot(item.shown), [SLOT_FACTOR]: numberSlot(item.factor) },
+    });
+    steps.push({ key: SOLUTION_KEY_DIVIDE_OUT, slots: { [SLOT_ANSWER]: writtenSlot(item.answer) } });
+  } else if (task === "build") {
+    steps.push({
+      key: SOLUTION_KEY_SCALE,
+      slots: {
+        [SLOT_FRACTION]: writtenSlot(item.shown),
+        [SLOT_FACTOR]: numberSlot(item.factor),
+        [SLOT_DENOMINATOR]: numberSlot(item.target),
+      },
+    });
+  } else {
+    const mixed = task === "to-mixed" ? item.answer : item.shown;
+    steps.push({
+      key: SOLUTION_KEY_WHOLES_IN,
+      slots: {
+        [SLOT_WHOLE]: numberSlot(mixed.whole),
+        [SLOT_DENOMINATOR]: numberSlot(mixed.den),
+        [SLOT_FRACTION]: writtenSlot(task === "to-mixed" ? item.shown : item.answer),
+      },
+    });
+  }
+
+  steps.push({ key: SOLUTION_KEY_RESULT, slots: { [SLOT_ANSWER]: writtenSlot(item.answer) } });
+  return steps;
+}
+
+export const fracEquivalenceFamily: GeneratorFamily<FracEquivalenceParams> = {
+  family: FRAC_EQUIVALENCE_FAMILY,
+  familyRev: FRAC_EQUIVALENCE_FAMILY_REV,
+  paramSchema: fracEquivalenceParamSchema,
+  forms: FRAC_EQUIVALENCE_FORMS,
+  choiceOnly: false,
+  representations: [],
+
+  answerSchema(params: FracEquivalenceParams): AnswerSchema {
+    return schemaFor(params);
+  },
+
+  difficultyOffset(params: FracEquivalenceParams): Rational {
+    let b = mul(COEFF_DENOMINATOR, rational(BigInt(params.maxDenominator)));
+    b = ratAdd(b, mul(COEFF_FACTOR, rational(BigInt(params.maxFactor - 1))));
+    if (params.task === "to-mixed" || params.task === "to-improper") b = ratAdd(b, COEFF_WHOLE_PART);
+    if (params.task === "to-mixed") b = ratAdd(b, COEFF_TO_MIXED);
+    return b;
+  },
+
+  formOffset(): Rational {
+    return FORM_OFFSET_FREE_ENTRY;
+  },
+
+  generate(request: GenerateRequest<FracEquivalenceParams>): Exercise {
+    const { skillId, level, seed, params, forms } = request;
+    const exerciseId = exerciseIdOf(FRAC_EQUIVALENCE_FAMILY, FRAC_EQUIVALENCE_FAMILY_REV, skillId, level, seed);
+    const rng = createRng(seedFrom(exerciseId));
+
+    const form = chooseForm(forms, FRAC_EQUIVALENCE_FORMS, rng);
+    const item = drawItem(params, rng);
+
+    // A rewriting that changed the number is this family's one possible bug.
+    if (!rationalEq(valueOf(item.shown), valueOf(item.answer))) {
+      throw new InfeasibleLevelError(`the rewriting changed the number on ${exerciseId}`);
+    }
+    if (item.shown.num === item.answer.num && item.shown.den === item.answer.den) {
+      throw new InfeasibleLevelError(`nothing to rewrite on ${exerciseId}`);
+    }
+
+    const schema = schemaFor(params);
+    const base: Exercise = {
+      exerciseId,
+      skillId,
+      level,
+      seed,
+      family: FRAC_EQUIVALENCE_FAMILY,
+      familyRev: FRAC_EQUIVALENCE_FAMILY_REV,
+      form,
+      prompt: { key: PROMPT_KEYS[params.task], slots: promptSlots(params.task, item) },
+      schema,
+      answer: { canonical: fractionAnswer(item.answer), alsoAccept: [] },
+      distractors: [],
+      check: { kind: "exact" },
+      solution: solutionFor(params.task, item),
+    };
+
+    return { ...base, distractors: distractorsFor(FRAC_EQUIVALENCE_FAMILY, base) };
+  },
+
+  check(exercise: Exercise, submitted: AnswerValue): Verdict {
+    return judge(exercise, submitted);
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/fracEquivalence/params.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/fracEquivalence/params.ts
@@ -1,0 +1,56 @@
+/**
+ * `gen.frac.equivalence-simplify` parameters.
+ *
+ * `maxDenominator` bounds the denominator a child **reads**, not an intermediate:
+ * a simplification item whose written denominator is 96 is an item about factoring
+ * 96, and a level that meant "halves through twelfths" would silently pose it.
+ */
+
+import { reader } from "../shared/paramReader.ts";
+import type { ParamResult, ParamSchema } from "../../types/generator.ts";
+
+export type EquivalenceTask = "simplify" | "build" | "to-mixed" | "to-improper";
+
+export const EQUIVALENCE_TASKS: readonly EquivalenceTask[] = [
+  "simplify",
+  "build",
+  "to-mixed",
+  "to-improper",
+];
+
+export type FracEquivalenceParams = {
+  readonly task: EquivalenceTask;
+  /** The largest denominator that appears anywhere on the card. */
+  readonly maxDenominator: number;
+  /** The largest scaling factor between a fraction and its equivalent. */
+  readonly maxFactor: number;
+  /** The largest whole part in a mixed number. */
+  readonly maxWhole: number;
+};
+
+export const MIN_MAX_DENOMINATOR = 4;
+export const MAX_MAX_DENOMINATOR = 60;
+
+export const fracEquivalenceParamSchema: ParamSchema<FracEquivalenceParams> = {
+  describe:
+    "{ task: 'simplify'|'build'|'to-mixed'|'to-improper', maxDenominator: 4..60, " +
+    "maxFactor: 2..9, maxWhole: 1..20 }",
+
+  validate(raw: unknown): ParamResult<FracEquivalenceParams> {
+    const read = reader(raw);
+    const task = read.choice<EquivalenceTask>("task", EQUIVALENCE_TASKS);
+    const maxDenominator = read.int("maxDenominator", MIN_MAX_DENOMINATOR, MAX_MAX_DENOMINATOR);
+    const maxFactor = read.int("maxFactor", 2, 9);
+    const maxWhole = read.int("maxWhole", 1, 20);
+
+    if (read.clean() && (task === "simplify" || task === "build") && maxDenominator < 2 * maxFactor) {
+      // The written fraction is a reduced one scaled up, so its denominator is at
+      // least twice the factor. A ceiling below that admits no item at all.
+      read.reject(
+        "maxDenominator",
+        `a factor of up to ${String(maxFactor)} needs a denominator ceiling of at least ${String(2 * maxFactor)}`,
+      );
+    }
+    return read.finish({ task, maxDenominator, maxFactor, maxWhole });
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/fracEquivalence/read.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/fracEquivalence/read.ts
@@ -1,0 +1,38 @@
+/**
+ * Reading an equivalence item back out of a finished `Exercise`, for the mal-rules.
+ * The published contract only; never throws.
+ */
+
+import type { Exercise } from "../../types/exercise.ts";
+import {
+  PROMPT_KEY_BUILD,
+  PROMPT_KEY_SIMPLIFY,
+  PROMPT_KEY_TO_IMPROPER,
+  PROMPT_KEY_TO_MIXED,
+  SLOT_FRACTION,
+} from "./constants.ts";
+import type { EquivalenceTask } from "./params.ts";
+
+export type EquivalenceItem = {
+  readonly task: EquivalenceTask;
+  readonly whole: bigint;
+  readonly num: bigint;
+  readonly den: bigint;
+};
+
+function taskOf(key: string): EquivalenceTask | null {
+  if (key === PROMPT_KEY_SIMPLIFY) return "simplify";
+  if (key === PROMPT_KEY_BUILD) return "build";
+  if (key === PROMPT_KEY_TO_MIXED) return "to-mixed";
+  if (key === PROMPT_KEY_TO_IMPROPER) return "to-improper";
+  return null;
+}
+
+export function readEquivalenceItem(exercise: Exercise): EquivalenceItem | null {
+  const task = taskOf(exercise.prompt.key);
+  if (task === null) return null;
+  const slot = exercise.prompt.slots[SLOT_FRACTION];
+  if (slot === undefined || slot.kind !== "fraction") return null;
+  if (slot.den <= 0n || slot.num < 0n) return null;
+  return { task, whole: slot.whole ?? 0n, num: slot.num, den: slot.den };
+}

--- a/dynawalla/packs/shared/curriculum/src/generators/longDiv/constants.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/longDiv/constants.ts
@@ -1,0 +1,60 @@
+/**
+ * `gen.arith.long-div` — ids, locale keys and difficulty coefficients.
+ *
+ *   b = b_skill + 0.55·(divisorDigits − 1) + 0.30·(quotientDigits − 1)
+ *       + 0.25·remainder + 0.35·quotientZeros + formOffset
+ *
+ * A second digit in the divisor is the step change in this algorithm — estimating
+ * a quotient digit against a two-digit divisor is a different act from recalling a
+ * table fact — so it takes the 0.55 slot. `quotientZeros` takes the `noAnchor`
+ * slot at 0.35: the column where the partial dividend is smaller than the divisor
+ * is exactly the column with no landmark, and it is where the zero goes missing.
+ */
+
+import { rational } from "../../math/rational.ts";
+import { familyId, locKey } from "../../types/ids.ts";
+
+export const LONG_DIV_FAMILY = familyId("gen.arith.long-div");
+export const LONG_DIV_FAMILY_REV = 1;
+
+export const FORM_FREE_ENTRY = "free-entry";
+export const LONG_DIV_FORMS = [FORM_FREE_ENTRY] as const;
+
+export const PROMPT_KEY_QUOTIENT = locKey("dw.prompt.long-div.quotient");
+export const PROMPT_KEY_REMAINDER = locKey("dw.prompt.long-div.remainder");
+export const PROMPT_KEY_QUOTIENT_REMAINDER = locKey("dw.prompt.long-div.quotient-remainder");
+
+export const SOLUTION_KEY_SETUP = locKey("dw.solution.long-div.setup");
+export const SOLUTION_KEY_STEP = locKey("dw.solution.long-div.step");
+export const SOLUTION_KEY_LEFTOVER = locKey("dw.solution.long-div.leftover");
+export const SOLUTION_KEY_RESULT = locKey("dw.solution.long-div.result");
+
+export const LONG_DIV_LOC_KEYS = [
+  PROMPT_KEY_QUOTIENT,
+  PROMPT_KEY_REMAINDER,
+  PROMPT_KEY_QUOTIENT_REMAINDER,
+  SOLUTION_KEY_SETUP,
+  SOLUTION_KEY_STEP,
+  SOLUTION_KEY_LEFTOVER,
+  SOLUTION_KEY_RESULT,
+] as const;
+
+export const SLOT_DIVIDEND = "dividend";
+export const SLOT_DIVISOR = "divisor";
+export const SLOT_PARTIAL = "partial";
+export const SLOT_DIGIT = "digit";
+export const SLOT_PRODUCT = "product";
+export const SLOT_LEFTOVER = "leftover";
+export const SLOT_ANSWER = "answer";
+export const SLOT_REMAINDER = "remainder";
+
+/** 0.55 for a two-digit divisor: estimation replaces recall. */
+export const COEFF_DIVISOR_DIGIT = rational(55n, 100n);
+/** 0.30 per quotient digit past the first. */
+export const COEFF_QUOTIENT_DIGIT = rational(30n, 100n);
+/** 0.25 when the division does not come out even. */
+export const COEFF_REMAINDER = rational(25n, 100n);
+/** 0.35 for a quotient with an interior zero — the column with no landmark. */
+export const COEFF_QUOTIENT_ZEROS = rational(35n, 100n);
+
+export const FORM_OFFSET_FREE_ENTRY = rational(0n);

--- a/dynawalla/packs/shared/curriculum/src/generators/longDiv/family.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/longDiv/family.ts
@@ -1,0 +1,233 @@
+/**
+ * `gen.arith.long-div` — sharing and grouping, with the remainder taken seriously.
+ *
+ * The quotient is drawn and the dividend is multiplied back, so a level can promise
+ * "three quotient digits, one of them an interior zero, and something left over"
+ * and deliver it on every seed. Drawing a dividend instead would leave both
+ * properties to chance, and the interior zero — the digit children drop — would
+ * appear on roughly one item in ten.
+ *
+ * **The mixed-number answer is `as-written`.** `46 ÷ 6` is seven with four left
+ * over, written `7 4/6`: the numerator is the remainder and the denominator is the
+ * divisor. `7 2/3` is the same number and a different answer, and accepting it
+ * would accept a child who has stopped answering the question that was asked.
+ * That is the whole reason `AnswerSchema.fraction.equivalence` exists.
+ */
+
+import { mul, rational, add as ratAdd } from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import { createRng, seedFrom } from "../../rng/rng.ts";
+import type { Rng } from "../../rng/rng.ts";
+import type { AnswerSchema, AnswerValue } from "../../types/answer.ts";
+import type { Exercise, PromptSlot, SolutionStep } from "../../types/exercise.ts";
+import { exerciseIdOf } from "../../types/ids.ts";
+import type { LocKey } from "../../types/ids.ts";
+import type { GenerateRequest, GeneratorFamily, Verdict } from "../../types/generator.ts";
+import { chooseForm, distractorsFor, judge } from "../shared/build.ts";
+import { countSlot, fractionSlot, numberSlot } from "../shared/slots.ts";
+import { drawBetween, drawWithDigits } from "../shared/draw.ts";
+import { InfeasibleLevelError } from "../shared/errors.ts";
+import { MIXED_PARTS, fractionAnswer, fractionSchema } from "../shared/fractions.ts";
+import {
+  COEFF_DIVISOR_DIGIT,
+  COEFF_QUOTIENT_DIGIT,
+  COEFF_QUOTIENT_ZEROS,
+  COEFF_REMAINDER,
+  FORM_OFFSET_FREE_ENTRY,
+  LONG_DIV_FAMILY,
+  LONG_DIV_FAMILY_REV,
+  LONG_DIV_FORMS,
+  PROMPT_KEY_QUOTIENT,
+  PROMPT_KEY_QUOTIENT_REMAINDER,
+  PROMPT_KEY_REMAINDER,
+  SLOT_ANSWER,
+  SLOT_DIGIT,
+  SLOT_DIVIDEND,
+  SLOT_DIVISOR,
+  SLOT_LEFTOVER,
+  SLOT_PARTIAL,
+  SLOT_PRODUCT,
+  SLOT_REMAINDER,
+  SOLUTION_KEY_LEFTOVER,
+  SOLUTION_KEY_RESULT,
+  SOLUTION_KEY_SETUP,
+  SOLUTION_KEY_STEP,
+} from "./constants.ts";
+import { longDivParamSchema } from "./params.ts";
+import type { DivTask, LongDivParams } from "./params.ts";
+import { longDivisionSteps } from "./procedure.ts";
+
+const PROMPT_KEYS: Readonly<Record<DivTask, LocKey>> = {
+  quotient: PROMPT_KEY_QUOTIENT,
+  remainder: PROMPT_KEY_REMAINDER,
+  "quotient-and-remainder": PROMPT_KEY_QUOTIENT_REMAINDER,
+};
+
+type Draw = {
+  readonly dividend: bigint;
+  readonly divisor: bigint;
+  readonly quotient: bigint;
+  readonly remainder: bigint;
+};
+
+/**
+ * The divisor. Never one: dividing by one produces the dividend and asks nothing,
+ * and a level that drew it would serve that item one time in eight.
+ */
+function drawDivisor(divisorDigits: number, rng: Rng): bigint {
+  return divisorDigits === 1 ? BigInt(rng.nextInt(2, 9)) : drawWithDigits(rng, divisorDigits);
+}
+
+function drawQuotient(quotientDigits: number, interiorZero: boolean, rng: Rng): bigint {
+  const digits: number[] = [];
+  for (let index = 0; index < quotientDigits; index++) {
+    digits.push(rng.nextInt(index === 0 ? 1 : 0, 9));
+  }
+  if (interiorZero) {
+    // One position, never the leading one, forced to zero. Drawn rather than fixed
+    // so a level does not always put the zero in the same column.
+    digits[rng.nextInt(1, quotientDigits - 1)] = 0;
+  }
+  let value = 0n;
+  for (const digit of digits) value = value * 10n + BigInt(digit);
+  return value;
+}
+
+function drawFor(params: LongDivParams, rng: Rng): Draw {
+  const divisor = drawDivisor(params.divisorDigits, rng);
+  const quotient = drawQuotient(params.quotientDigits, params.quotientZeros, rng);
+  const remainder = params.exact ? 0n : drawBetween(rng, 1n, divisor - 1n);
+  return { dividend: quotient * divisor + remainder, divisor, quotient, remainder };
+}
+
+function schemaFor(params: LongDivParams): AnswerSchema {
+  switch (params.task) {
+    case "quotient":
+      return { kind: "integer", digits: params.quotientDigits, decimalPlaces: 0 };
+    case "remainder":
+      return { kind: "integer", digits: params.divisorDigits, decimalPlaces: 0 };
+    case "quotient-and-remainder":
+      return fractionSchema(MIXED_PARTS, "as-written");
+  }
+}
+
+function answerFor(task: DivTask, draw: Draw): AnswerValue {
+  switch (task) {
+    case "quotient":
+      return { kind: "integer", value: rational(draw.quotient) };
+    case "remainder":
+      return { kind: "integer", value: rational(draw.remainder) };
+    case "quotient-and-remainder":
+      return fractionAnswer({ whole: draw.quotient, num: draw.remainder, den: draw.divisor });
+  }
+}
+
+function answerSlot(task: DivTask, draw: Draw): PromptSlot {
+  return task === "quotient-and-remainder"
+    ? fractionSlot(draw.remainder, draw.divisor, draw.quotient)
+    : numberSlot(task === "quotient" ? draw.quotient : draw.remainder);
+}
+
+function solutionFor(task: DivTask, draw: Draw): SolutionStep[] {
+  const steps: SolutionStep[] = [
+    {
+      key: SOLUTION_KEY_SETUP,
+      slots: { [SLOT_DIVIDEND]: numberSlot(draw.dividend), [SLOT_DIVISOR]: numberSlot(draw.divisor) },
+    },
+  ];
+
+  longDivisionSteps(draw.dividend, draw.divisor).forEach((step, index) => {
+    steps.push({
+      key: SOLUTION_KEY_STEP,
+      slots: {
+        [SLOT_PARTIAL]: numberSlot(step.partial),
+        [SLOT_DIGIT]: countSlot(step.digit),
+        [SLOT_PRODUCT]: numberSlot(step.product),
+        [SLOT_LEFTOVER]: numberSlot(step.leftover),
+      },
+      focusColumn: index,
+    });
+  });
+
+  if (draw.remainder > 0n) {
+    steps.push({
+      key: SOLUTION_KEY_LEFTOVER,
+      slots: { [SLOT_REMAINDER]: numberSlot(draw.remainder), [SLOT_DIVISOR]: numberSlot(draw.divisor) },
+    });
+  }
+  steps.push({ key: SOLUTION_KEY_RESULT, slots: { [SLOT_ANSWER]: answerSlot(task, draw) } });
+  return steps;
+}
+
+export const longDivFamily: GeneratorFamily<LongDivParams> = {
+  family: LONG_DIV_FAMILY,
+  familyRev: LONG_DIV_FAMILY_REV,
+  paramSchema: longDivParamSchema,
+  forms: LONG_DIV_FORMS,
+  choiceOnly: false,
+  representations: [],
+
+  answerSchema(params: LongDivParams): AnswerSchema {
+    return schemaFor(params);
+  },
+
+  difficultyOffset(params: LongDivParams): Rational {
+    let b = mul(COEFF_DIVISOR_DIGIT, rational(BigInt(params.divisorDigits - 1)));
+    b = ratAdd(b, mul(COEFF_QUOTIENT_DIGIT, rational(BigInt(params.quotientDigits - 1))));
+    if (!params.exact) b = ratAdd(b, COEFF_REMAINDER);
+    if (params.quotientZeros) b = ratAdd(b, COEFF_QUOTIENT_ZEROS);
+    return b;
+  },
+
+  formOffset(): Rational {
+    return FORM_OFFSET_FREE_ENTRY;
+  },
+
+  generate(request: GenerateRequest<LongDivParams>): Exercise {
+    const { skillId, level, seed, params, forms } = request;
+    const exerciseId = exerciseIdOf(LONG_DIV_FAMILY, LONG_DIV_FAMILY_REV, skillId, level, seed);
+    const rng = createRng(seedFrom(exerciseId));
+
+    const form = chooseForm(forms, LONG_DIV_FORMS, rng);
+    const draw = drawFor(params, rng);
+
+    // The division identity, asserted on every call. A quotient drawn and
+    // multiplied back cannot be wrong, which is exactly why it is worth checking
+    // that the item's own dividend still divides the way the item says it does.
+    if (draw.quotient * draw.divisor + draw.remainder !== draw.dividend) {
+      throw new InfeasibleLevelError(`division identity failed on ${exerciseId}`);
+    }
+    if (draw.remainder >= draw.divisor) {
+      throw new InfeasibleLevelError(`remainder is not smaller than the divisor on ${exerciseId}`);
+    }
+
+    const schema = schemaFor(params);
+    const base: Exercise = {
+      exerciseId,
+      skillId,
+      level,
+      seed,
+      family: LONG_DIV_FAMILY,
+      familyRev: LONG_DIV_FAMILY_REV,
+      form,
+      prompt: {
+        key: PROMPT_KEYS[params.task],
+        slots: {
+          [SLOT_DIVIDEND]: numberSlot(draw.dividend),
+          [SLOT_DIVISOR]: numberSlot(draw.divisor),
+        },
+      },
+      schema,
+      answer: { canonical: answerFor(params.task, draw), alsoAccept: [] },
+      distractors: [],
+      check: { kind: "exact" },
+      solution: solutionFor(params.task, draw),
+    };
+
+    return { ...base, distractors: distractorsFor(LONG_DIV_FAMILY, base) };
+  },
+
+  check(exercise: Exercise, submitted: AnswerValue): Verdict {
+    return judge(exercise, submitted);
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/longDiv/params.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/longDiv/params.ts
@@ -1,0 +1,65 @@
+/**
+ * `gen.arith.long-div` parameters.
+ *
+ * The **quotient** is the parameterized quantity, not the dividend. Drawing a
+ * dividend and dividing it gives a quotient of whatever width falls out, and the
+ * two properties a division level actually cares about — how many quotient digits
+ * the child has to produce, and whether one of them is a zero they will drop — are
+ * then unstatable. Drawing the quotient and multiplying back makes both exact and
+ * makes the dividend's width a consequence.
+ *
+ * Three combinations are rejected because the question would have no content:
+ * asking for a remainder on a level that divides exactly (the answer is zero on
+ * every seed), asking for a plain quotient on a level that does not (the answer
+ * silently discards what is left over), and asking for an interior zero in a
+ * one-digit quotient.
+ */
+
+import { reader } from "../shared/paramReader.ts";
+import type { ParamResult, ParamSchema } from "../../types/generator.ts";
+
+export type DivTask = "quotient" | "remainder" | "quotient-and-remainder";
+export const DIV_TASKS: readonly DivTask[] = ["quotient", "remainder", "quotient-and-remainder"];
+
+export type LongDivParams = {
+  readonly task: DivTask;
+  /** Digits of the quotient the child must produce. */
+  readonly quotientDigits: number;
+  /** Digits of the divisor. Never one digit wide *and* the value one. */
+  readonly divisorDigits: number;
+  /** The division comes out even. */
+  readonly exact: boolean;
+  /** The quotient carries an interior zero — the digit children drop. */
+  readonly quotientZeros: boolean;
+};
+
+export const MAX_QUOTIENT_DIGITS = 4;
+export const MAX_DIVISOR_DIGITS = 2;
+
+export const longDivParamSchema: ParamSchema<LongDivParams> = {
+  describe:
+    "{ task: 'quotient'|'remainder'|'quotient-and-remainder', quotientDigits: 1..4, " +
+    "divisorDigits: 1..2, exact: boolean, quotientZeros: boolean }",
+
+  validate(raw: unknown): ParamResult<LongDivParams> {
+    const read = reader(raw);
+    const task = read.choice<DivTask>("task", DIV_TASKS);
+    const quotientDigits = read.int("quotientDigits", 1, MAX_QUOTIENT_DIGITS);
+    const divisorDigits = read.int("divisorDigits", 1, MAX_DIVISOR_DIGITS);
+    const exact = read.boolean("exact");
+    const quotientZeros = read.boolean("quotientZeros");
+
+    if (read.clean()) {
+      if (exact && task !== "quotient") {
+        read.reject("task", "a level that divides exactly has no remainder to ask about");
+      }
+      if (!exact && task === "quotient") {
+        read.reject("task", "asking for the quotient alone throws the remainder away without saying so");
+      }
+      if (quotientZeros && quotientDigits < 2) {
+        read.reject("quotientZeros", "an interior zero needs a quotient at least two digits wide");
+      }
+    }
+    return read.finish({ task, quotientDigits, divisorDigits, exact, quotientZeros });
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/longDiv/procedure.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/longDiv/procedure.ts
@@ -1,0 +1,64 @@
+/**
+ * Long division, once, for the generator's walkthrough and for the mal-rules.
+ *
+ * A quotient digit is written for every dividend digit from the first position at
+ * which the running partial dividend reaches the divisor — which is exactly where
+ * the written quotient starts, and exactly the rule a child who drops an interior
+ * zero has half-learned.
+ */
+
+import { digitsOf } from "../shared/draw.ts";
+
+export type DivisionStep = {
+  /** The partial dividend at this column, after the digit was brought down. */
+  readonly partial: bigint;
+  /** The quotient digit written above this column. */
+  readonly digit: number;
+  /** `digit × divisor`, the number written under the partial. */
+  readonly product: bigint;
+  /** What is left after subtracting, and carried into the next column. */
+  readonly leftover: bigint;
+};
+
+export function longDivisionSteps(dividend: bigint, divisor: bigint): DivisionStep[] {
+  if (divisor <= 0n) throw new RangeError("longDivisionSteps: divisor must be positive");
+  const steps: DivisionStep[] = [];
+  let partial = 0n;
+  let started = false;
+
+  for (const digit of digitsOf(dividend)) {
+    partial = partial * 10n + BigInt(digit);
+    // Before the partial first reaches the divisor no quotient digit is written —
+    // that is why 4,208 ÷ 4 has four quotient digits and 208 ÷ 4 has two.
+    if (!started && partial < divisor) continue;
+    started = true;
+    const quotientDigit = partial / divisor;
+    const product = quotientDigit * divisor;
+    const leftover = partial - product;
+    steps.push({ partial, digit: Number(quotientDigit), product, leftover });
+    partial = leftover;
+  }
+
+  return steps;
+}
+
+/**
+ * The quotient with every non-leading zero left out — the written result of the
+ * child who, at a column where the partial dividend is smaller than the divisor,
+ * brings the next digit down without first writing the zero.
+ *
+ * Strictly smaller than the quotient whenever there is a zero to drop, because
+ * removing a digit removes a place, so the two can never coincide.
+ */
+export function withoutInteriorZeros(quotient: bigint): bigint {
+  const digits = digitsOf(quotient);
+  const kept = digits.filter((digit, index) => index === 0 || digit !== 0);
+  let value = 0n;
+  for (const digit of kept) value = value * 10n + BigInt(digit);
+  return value;
+}
+
+/** True when the quotient carries a zero anywhere but its leading position. */
+export function hasInteriorZero(quotient: bigint): boolean {
+  return digitsOf(quotient).some((digit, index) => index > 0 && digit === 0);
+}

--- a/dynawalla/packs/shared/curriculum/src/generators/longDiv/read.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/longDiv/read.ts
@@ -1,0 +1,47 @@
+/**
+ * Reading a division back out of a finished `Exercise`, for the mal-rules.
+ * The published contract only; never throws.
+ */
+
+import { asInteger } from "../../math/rational.ts";
+import type { Exercise } from "../../types/exercise.ts";
+import {
+  PROMPT_KEY_QUOTIENT,
+  PROMPT_KEY_QUOTIENT_REMAINDER,
+  PROMPT_KEY_REMAINDER,
+  SLOT_DIVIDEND,
+  SLOT_DIVISOR,
+} from "./constants.ts";
+import type { DivTask } from "./params.ts";
+
+export type Division = {
+  readonly task: DivTask;
+  readonly dividend: bigint;
+  readonly divisor: bigint;
+  readonly quotient: bigint;
+  readonly remainder: bigint;
+};
+
+function taskOf(key: string): DivTask | null {
+  if (key === PROMPT_KEY_QUOTIENT) return "quotient";
+  if (key === PROMPT_KEY_REMAINDER) return "remainder";
+  if (key === PROMPT_KEY_QUOTIENT_REMAINDER) return "quotient-and-remainder";
+  return null;
+}
+
+export function readDivision(exercise: Exercise): Division | null {
+  const task = taskOf(exercise.prompt.key);
+  if (task === null) return null;
+
+  const dividendSlot = exercise.prompt.slots[SLOT_DIVIDEND];
+  const divisorSlot = exercise.prompt.slots[SLOT_DIVISOR];
+  if (dividendSlot === undefined || dividendSlot.kind !== "number") return null;
+  if (divisorSlot === undefined || divisorSlot.kind !== "number") return null;
+
+  const dividend = asInteger(dividendSlot.value);
+  const divisor = asInteger(divisorSlot.value);
+  if (dividend === null || divisor === null) return null;
+  if (dividend < 0n || divisor <= 0n) return null;
+
+  return { task, dividend, divisor, quotient: dividend / divisor, remainder: dividend % divisor };
+}

--- a/dynawalla/packs/shared/curriculum/src/generators/missingOperand/constants.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/missingOperand/constants.ts
@@ -1,0 +1,78 @@
+/**
+ * `gen.arith.missing-operand` — ids, locale keys and difficulty coefficients.
+ *
+ *   b = b_skill + 0.30·(digits − 2) + shapeOffset + formOffset
+ *
+ * **Every sentence shape is its own template key, and that is the point.** Where
+ * the box sits is not decoration a renderer can be trusted to guess: `a − ☐ = c`
+ * and `☐ − a = c` are different questions with different answers, and a family that
+ * carried the placement as a parameter rather than in the key would hand the
+ * renderer two items it could not tell apart.
+ *
+ * `both-sides` carries the largest offset because it is not a harder version of the
+ * others, it is the one the equals sign is really about: on `8 + 4 = ☐ + 5` roughly
+ * 5% of grade 1–2 children answer 7, and in one sample all 145 sixth graders
+ * answered 12 or 17.
+ */
+
+import { rational } from "../../math/rational.ts";
+import { familyId, locKey } from "../../types/ids.ts";
+import { REP_BALANCE_SCALE } from "../../render/representations.ts";
+
+export { REP_BALANCE_SCALE };
+
+export const MISSING_OPERAND_FAMILY = familyId("gen.arith.missing-operand");
+export const MISSING_OPERAND_FAMILY_REV = 1;
+
+export const FORM_FREE_ENTRY = "free-entry";
+export const MISSING_OPERAND_FORMS = [FORM_FREE_ENTRY] as const;
+
+/** `a + ☐ = c` */
+export const PROMPT_KEY_ADD_UNKNOWN = locKey("dw.prompt.missing-operand.add-unknown");
+/** `a − ☐ = c` */
+export const PROMPT_KEY_SUB_UNKNOWN = locKey("dw.prompt.missing-operand.sub-unknown");
+/** `☐ − a = c` */
+export const PROMPT_KEY_SUB_UNKNOWN_MINUEND = locKey("dw.prompt.missing-operand.sub-unknown-minuend");
+/** `a × ☐ = c` */
+export const PROMPT_KEY_MUL_UNKNOWN = locKey("dw.prompt.missing-operand.mul-unknown");
+/** `a + b = ☐ + d` */
+export const PROMPT_KEY_BOTH_SIDES = locKey("dw.prompt.missing-operand.both-sides");
+
+export const SOLUTION_KEY_READ_RELATION = locKey("dw.solution.missing-operand.read-relation");
+export const SOLUTION_KEY_BALANCE_SIDES = locKey("dw.solution.missing-operand.balance-sides");
+export const SOLUTION_KEY_UNDO = locKey("dw.solution.missing-operand.undo");
+export const SOLUTION_KEY_RESULT = locKey("dw.solution.missing-operand.result");
+
+export const MISSING_OPERAND_LOC_KEYS = [
+  PROMPT_KEY_ADD_UNKNOWN,
+  PROMPT_KEY_SUB_UNKNOWN,
+  PROMPT_KEY_SUB_UNKNOWN_MINUEND,
+  PROMPT_KEY_MUL_UNKNOWN,
+  PROMPT_KEY_BOTH_SIDES,
+  SOLUTION_KEY_READ_RELATION,
+  SOLUTION_KEY_BALANCE_SIDES,
+  SOLUTION_KEY_UNDO,
+  SOLUTION_KEY_RESULT,
+] as const;
+
+export const SLOT_KNOWN = "known";
+export const SLOT_TOTAL = "total";
+export const SLOT_LEFT_A = "leftA";
+export const SLOT_LEFT_B = "leftB";
+export const SLOT_RIGHT_KNOWN = "rightKnown";
+export const SLOT_LEFT_TOTAL = "leftTotal";
+export const SLOT_ANSWER = "answer";
+
+export const COEFF_DIGIT_OVER_TWO = rational(30n, 100n);
+/** The plainest of the five: a missing addend with the total on the right. */
+export const OFFSET_ADD_UNKNOWN = rational(-35n, 100n);
+/** Undoing runs the other way: the answer is what is *left*, not what is missing. */
+export const OFFSET_SUB_UNKNOWN = rational(0n);
+/** The unknown is the number being taken from, so the undoing is an addition. */
+export const OFFSET_SUB_UNKNOWN_MINUEND = rational(25n, 100n);
+/** A missing factor is a division nobody wrote down. */
+export const OFFSET_MUL_UNKNOWN = rational(45n, 100n);
+/** Numbers on both sides of the equals sign. */
+export const OFFSET_BOTH_SIDES = rational(55n, 100n);
+
+export const FORM_OFFSET_FREE_ENTRY = rational(0n);

--- a/dynawalla/packs/shared/curriculum/src/generators/missingOperand/family.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/missingOperand/family.ts
@@ -1,0 +1,247 @@
+/**
+ * `gen.arith.missing-operand` — the equals sign as a relation.
+ *
+ * The answer is always drawn first and the sentence is built around it, so no shape
+ * can produce a negative unknown, a zero unknown, or a missing factor that does not
+ * divide. Drawing the sentence and solving it would leave all three to chance, and
+ * "the box is 0" is an item whose two documented mal-rules both coincide with the
+ * correct answer.
+ *
+ * `both-sides` optionally carries the balance scale, whose pans hold the side that
+ * is complete and the part of the other side that is already there. That is the
+ * representation doing its job: the child sees two pans that do not balance and has
+ * to say what makes them.
+ */
+
+import { mul, rational, add as ratAdd } from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import { createRng, seedFrom } from "../../rng/rng.ts";
+import type { Rng } from "../../rng/rng.ts";
+import type { AnswerSchema, AnswerValue } from "../../types/answer.ts";
+import type { Exercise, PromptSlot, RepSpec, SolutionStep } from "../../types/exercise.ts";
+import { exerciseIdOf } from "../../types/ids.ts";
+import type { LocKey } from "../../types/ids.ts";
+import type { GenerateRequest, GeneratorFamily, Verdict } from "../../types/generator.ts";
+import { chooseForm, distractorsFor, judge } from "../shared/build.ts";
+import { numberSlot } from "../shared/slots.ts";
+import { drawBetween, drawWithDigits } from "../shared/draw.ts";
+import { InfeasibleLevelError } from "../shared/errors.ts";
+import {
+  COEFF_DIGIT_OVER_TWO,
+  FORM_OFFSET_FREE_ENTRY,
+  MISSING_OPERAND_FAMILY,
+  MISSING_OPERAND_FAMILY_REV,
+  MISSING_OPERAND_FORMS,
+  OFFSET_ADD_UNKNOWN,
+  OFFSET_BOTH_SIDES,
+  OFFSET_MUL_UNKNOWN,
+  OFFSET_SUB_UNKNOWN,
+  OFFSET_SUB_UNKNOWN_MINUEND,
+  PROMPT_KEY_ADD_UNKNOWN,
+  PROMPT_KEY_BOTH_SIDES,
+  PROMPT_KEY_MUL_UNKNOWN,
+  PROMPT_KEY_SUB_UNKNOWN,
+  PROMPT_KEY_SUB_UNKNOWN_MINUEND,
+  REP_BALANCE_SCALE,
+  SLOT_ANSWER,
+  SLOT_KNOWN,
+  SLOT_LEFT_A,
+  SLOT_LEFT_B,
+  SLOT_LEFT_TOTAL,
+  SLOT_RIGHT_KNOWN,
+  SLOT_TOTAL,
+  SOLUTION_KEY_BALANCE_SIDES,
+  SOLUTION_KEY_READ_RELATION,
+  SOLUTION_KEY_RESULT,
+  SOLUTION_KEY_UNDO,
+} from "./constants.ts";
+import { missingOperandParamSchema } from "./params.ts";
+import type { MissingOperandParams, SentenceShape } from "./params.ts";
+
+const PROMPT_KEYS: Readonly<Record<SentenceShape, LocKey>> = {
+  "add-unknown": PROMPT_KEY_ADD_UNKNOWN,
+  "sub-unknown": PROMPT_KEY_SUB_UNKNOWN,
+  "sub-unknown-minuend": PROMPT_KEY_SUB_UNKNOWN_MINUEND,
+  "mul-unknown": PROMPT_KEY_MUL_UNKNOWN,
+  "both-sides": PROMPT_KEY_BOTH_SIDES,
+};
+
+const SHAPE_OFFSETS: Readonly<Record<SentenceShape, Rational>> = {
+  "add-unknown": OFFSET_ADD_UNKNOWN,
+  "sub-unknown": OFFSET_SUB_UNKNOWN,
+  "sub-unknown-minuend": OFFSET_SUB_UNKNOWN_MINUEND,
+  "mul-unknown": OFFSET_MUL_UNKNOWN,
+  "both-sides": OFFSET_BOTH_SIDES,
+};
+
+type Sentence = {
+  readonly slots: Readonly<Record<string, PromptSlot>>;
+  readonly answer: bigint;
+  /** The complete side's total, on a `both-sides` item. */
+  readonly leftTotal: bigint;
+  readonly rightKnown: bigint;
+};
+
+/** A number written with exactly `digits` digits, or 1..9 at one digit. */
+function drawNumber(digits: number, rng: Rng): bigint {
+  return drawWithDigits(rng, digits);
+}
+
+function drawSentence(params: MissingOperandParams, rng: Rng): Sentence {
+  const { shape, digits } = params;
+
+  if (shape === "mul-unknown") {
+    // Both factors are drawn and the product is formed, so the sentence always has
+    // a whole-number answer and the child is never asked for a fraction in a box.
+    const known = digits === 1 ? BigInt(rng.nextInt(2, 9)) : drawNumber(digits, rng);
+    const answer = digits === 1 ? BigInt(rng.nextInt(2, 9)) : drawNumber(digits, rng);
+    return {
+      slots: { [SLOT_KNOWN]: numberSlot(known), [SLOT_TOTAL]: numberSlot(known * answer) },
+      answer,
+      leftTotal: known * answer,
+      rightKnown: known,
+    };
+  }
+
+  if (shape === "both-sides") {
+    // The right-hand known part is drawn strictly below the left-hand total, so the
+    // box is always a positive number.
+    const leftA = drawNumber(digits, rng);
+    const leftB = drawNumber(digits, rng);
+    const leftTotal = leftA + leftB;
+    const rightKnown = drawBetween(rng, 1n, leftTotal - 1n);
+    return {
+      slots: {
+        [SLOT_LEFT_A]: numberSlot(leftA),
+        [SLOT_LEFT_B]: numberSlot(leftB),
+        [SLOT_RIGHT_KNOWN]: numberSlot(rightKnown),
+      },
+      answer: leftTotal - rightKnown,
+      leftTotal,
+      rightKnown,
+    };
+  }
+
+  const known = drawNumber(digits, rng);
+  const answer = drawNumber(digits, rng);
+
+  if (shape === "add-unknown") {
+    // `known + ☐ = total`
+    return {
+      slots: { [SLOT_KNOWN]: numberSlot(known), [SLOT_TOTAL]: numberSlot(known + answer) },
+      answer,
+      leftTotal: known + answer,
+      rightKnown: known,
+    };
+  }
+  if (shape === "sub-unknown") {
+    // `known − ☐ = total`, so the number written first is the larger one.
+    return {
+      slots: { [SLOT_KNOWN]: numberSlot(known + answer), [SLOT_TOTAL]: numberSlot(known) },
+      answer,
+      leftTotal: known + answer,
+      rightKnown: known,
+    };
+  }
+  // `☐ − known = total`
+  return {
+    slots: { [SLOT_KNOWN]: numberSlot(known), [SLOT_TOTAL]: numberSlot(answer) },
+    answer: known + answer,
+    leftTotal: known + answer,
+    rightKnown: known,
+  };
+}
+
+function representationFor(params: MissingOperandParams, sentence: Sentence): RepSpec | undefined {
+  if (!params.balance) return undefined;
+  return {
+    rep: REP_BALANCE_SCALE,
+    // Whole units, both pans. The left pan holds the side that is complete; the
+    // right holds what is already there. What is missing is the answer.
+    params: { left: Number(sentence.leftTotal), right: Number(sentence.rightKnown) },
+  };
+}
+
+function solutionFor(params: MissingOperandParams, sentence: Sentence): SolutionStep[] {
+  const steps: SolutionStep[] = [{ key: SOLUTION_KEY_READ_RELATION, slots: {} }];
+
+  if (params.shape === "both-sides") {
+    steps.push({
+      key: SOLUTION_KEY_BALANCE_SIDES,
+      slots: {
+        [SLOT_LEFT_TOTAL]: numberSlot(sentence.leftTotal),
+        [SLOT_RIGHT_KNOWN]: numberSlot(sentence.rightKnown),
+      },
+    });
+  }
+  steps.push({
+    key: SOLUTION_KEY_UNDO,
+    slots: { [SLOT_ANSWER]: numberSlot(sentence.answer) },
+  });
+  steps.push({ key: SOLUTION_KEY_RESULT, slots: { [SLOT_ANSWER]: numberSlot(sentence.answer) } });
+  return steps;
+}
+
+function answerCapacity(params: MissingOperandParams): number {
+  // One wider than the numbers on the card: `☐ − 47 = 68` has a three-digit answer
+  // and a field that could not hold it would say so.
+  return params.shape === "mul-unknown" ? params.digits : params.digits + 1;
+}
+
+export const missingOperandFamily: GeneratorFamily<MissingOperandParams> = {
+  family: MISSING_OPERAND_FAMILY,
+  familyRev: MISSING_OPERAND_FAMILY_REV,
+  paramSchema: missingOperandParamSchema,
+  forms: MISSING_OPERAND_FORMS,
+  choiceOnly: false,
+  representations: [REP_BALANCE_SCALE],
+
+  answerSchema(params: MissingOperandParams): AnswerSchema {
+    return { kind: "integer", digits: answerCapacity(params), decimalPlaces: 0 };
+  },
+
+  difficultyOffset(params: MissingOperandParams): Rational {
+    const b = mul(COEFF_DIGIT_OVER_TWO, rational(BigInt(params.digits - 2)));
+    return ratAdd(b, SHAPE_OFFSETS[params.shape]);
+  },
+
+  formOffset(): Rational {
+    return FORM_OFFSET_FREE_ENTRY;
+  },
+
+  generate(request: GenerateRequest<MissingOperandParams>): Exercise {
+    const { skillId, level, seed, params, forms } = request;
+    const exerciseId = exerciseIdOf(MISSING_OPERAND_FAMILY, MISSING_OPERAND_FAMILY_REV, skillId, level, seed);
+    const rng = createRng(seedFrom(exerciseId));
+
+    const form = chooseForm(forms, MISSING_OPERAND_FORMS, rng);
+    const sentence = drawSentence(params, rng);
+    if (sentence.answer <= 0n) {
+      throw new InfeasibleLevelError(`the unknown is not positive on ${exerciseId}`);
+    }
+
+    const representation = representationFor(params, sentence);
+    const base: Exercise = {
+      exerciseId,
+      skillId,
+      level,
+      seed,
+      family: MISSING_OPERAND_FAMILY,
+      familyRev: MISSING_OPERAND_FAMILY_REV,
+      form,
+      prompt: { key: PROMPT_KEYS[params.shape], slots: sentence.slots },
+      ...(representation === undefined ? {} : { representation }),
+      schema: { kind: "integer", digits: answerCapacity(params), decimalPlaces: 0 },
+      answer: { canonical: { kind: "integer", value: rational(sentence.answer) }, alsoAccept: [] },
+      distractors: [],
+      check: { kind: "exact" },
+      solution: solutionFor(params, sentence),
+    };
+
+    return { ...base, distractors: distractorsFor(MISSING_OPERAND_FAMILY, base) };
+  },
+
+  check(exercise: Exercise, submitted: AnswerValue): Verdict {
+    return judge(exercise, submitted);
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/missingOperand/params.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/missingOperand/params.ts
@@ -1,0 +1,67 @@
+/**
+ * `gen.arith.missing-operand` parameters.
+ *
+ * Five sentence shapes, each a different question about the same equals sign:
+ *
+ * - `add-unknown` — `a + ☐ = c`, the missing addend.
+ * - `sub-unknown` — `a − ☐ = c`, where the undoing is a subtraction.
+ * - `sub-unknown-minuend` — `☐ − a = c`, where it is an addition.
+ * - `mul-unknown` — `a × ☐ = c`, always exact; a missing factor with a remainder
+ *   is a sentence with no whole-number answer.
+ * - `both-sides` — `a + b = ☐ + d`.
+ *
+ * `balance` is rejected on every shape but `both-sides`: the scale carries "these
+ * two sides are worth the same", and a sentence with one side is a scale with one
+ * pan.
+ */
+
+import { reader } from "../shared/paramReader.ts";
+import type { ParamResult, ParamSchema } from "../../types/generator.ts";
+
+export type SentenceShape =
+  | "add-unknown"
+  | "sub-unknown"
+  | "sub-unknown-minuend"
+  | "mul-unknown"
+  | "both-sides";
+
+export const SENTENCE_SHAPES: readonly SentenceShape[] = [
+  "add-unknown",
+  "sub-unknown",
+  "sub-unknown-minuend",
+  "mul-unknown",
+  "both-sides",
+];
+
+export type MissingOperandParams = {
+  readonly shape: SentenceShape;
+  /** Digit width of the numbers written on the card. */
+  readonly digits: number;
+  /** Draw the balance scale beside the sentence. `both-sides` only. */
+  readonly balance: boolean;
+};
+
+export const MAX_DIGITS = 4;
+
+export const missingOperandParamSchema: ParamSchema<MissingOperandParams> = {
+  describe:
+    "{ shape: 'add-unknown'|'sub-unknown'|'sub-unknown-minuend'|'mul-unknown'|'both-sides', " +
+    "digits: 1..4, balance: boolean }",
+
+  validate(raw: unknown): ParamResult<MissingOperandParams> {
+    const read = reader(raw);
+    const shape = read.choice<SentenceShape>("shape", SENTENCE_SHAPES);
+    const digits = read.int("digits", 1, MAX_DIGITS);
+    const balance = read.boolean("balance");
+
+    if (read.clean()) {
+      if (balance && shape !== "both-sides") {
+        read.reject("balance", "the balance scale draws two sides; only both-sides has them");
+      }
+      if (shape === "mul-unknown" && digits > 2) {
+        read.reject("digits", "a missing factor beyond two digits is a long division wearing a box");
+      }
+    }
+    return read.finish({ shape, digits, balance });
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/missingOperand/read.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/missingOperand/read.ts
@@ -1,0 +1,67 @@
+/**
+ * Reading a number sentence back out of a finished `Exercise`, for the mal-rules.
+ * The published contract only; never throws.
+ */
+
+import { asInteger } from "../../math/rational.ts";
+import type { Exercise, PromptSlot } from "../../types/exercise.ts";
+import {
+  PROMPT_KEY_ADD_UNKNOWN,
+  PROMPT_KEY_BOTH_SIDES,
+  PROMPT_KEY_MUL_UNKNOWN,
+  PROMPT_KEY_SUB_UNKNOWN,
+  PROMPT_KEY_SUB_UNKNOWN_MINUEND,
+  SLOT_KNOWN,
+  SLOT_LEFT_A,
+  SLOT_LEFT_B,
+  SLOT_RIGHT_KNOWN,
+  SLOT_TOTAL,
+} from "./constants.ts";
+import type { SentenceShape } from "./params.ts";
+
+export type Sentence =
+  | {
+      readonly shape: "add-unknown" | "sub-unknown" | "sub-unknown-minuend" | "mul-unknown";
+      /** The number written beside the box. */
+      readonly known: bigint;
+      /** The number on the other side of the equals sign. */
+      readonly total: bigint;
+    }
+  | {
+      readonly shape: "both-sides";
+      readonly leftA: bigint;
+      readonly leftB: bigint;
+      readonly rightKnown: bigint;
+    };
+
+function shapeOf(key: string): SentenceShape | null {
+  if (key === PROMPT_KEY_ADD_UNKNOWN) return "add-unknown";
+  if (key === PROMPT_KEY_SUB_UNKNOWN) return "sub-unknown";
+  if (key === PROMPT_KEY_SUB_UNKNOWN_MINUEND) return "sub-unknown-minuend";
+  if (key === PROMPT_KEY_MUL_UNKNOWN) return "mul-unknown";
+  if (key === PROMPT_KEY_BOTH_SIDES) return "both-sides";
+  return null;
+}
+
+function whole(slot: PromptSlot | undefined): bigint | null {
+  if (slot === undefined || slot.kind !== "number") return null;
+  return asInteger(slot.value);
+}
+
+export function readSentence(exercise: Exercise): Sentence | null {
+  const shape = shapeOf(exercise.prompt.key);
+  if (shape === null) return null;
+
+  if (shape === "both-sides") {
+    const leftA = whole(exercise.prompt.slots[SLOT_LEFT_A]);
+    const leftB = whole(exercise.prompt.slots[SLOT_LEFT_B]);
+    const rightKnown = whole(exercise.prompt.slots[SLOT_RIGHT_KNOWN]);
+    if (leftA === null || leftB === null || rightKnown === null) return null;
+    return { shape, leftA, leftB, rightKnown };
+  }
+
+  const known = whole(exercise.prompt.slots[SLOT_KNOWN]);
+  const total = whole(exercise.prompt.slots[SLOT_TOTAL]);
+  if (known === null || total === null) return null;
+  return { shape, known, total };
+}

--- a/dynawalla/packs/shared/curriculum/src/generators/multidigitMul/constants.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/multidigitMul/constants.ts
@@ -1,0 +1,55 @@
+/**
+ * `gen.arith.multidigit-mul` — ids, locale keys and difficulty coefficients.
+ *
+ *   b = b_skill + 0.55·(multiplierDigits − 1) + 0.30·(digits − 2) + 0.25·carries
+ *       − 0.35·powerOfTen + formOffset
+ *
+ * The 0.55 slot is column-op's `regroupings` coefficient spent on the thing that
+ * plays the same role here: each further digit in the multiplier is another whole
+ * partial product to form, place and add. `powerOfTen` takes the `specialCase`
+ * slot, which is what it is — a multiplication with no partial products at all.
+ */
+
+import { rational } from "../../math/rational.ts";
+import { familyId, locKey } from "../../types/ids.ts";
+
+export const MULTIDIGIT_MUL_FAMILY = familyId("gen.arith.multidigit-mul");
+export const MULTIDIGIT_MUL_FAMILY_REV = 1;
+
+export const FORM_FREE_ENTRY = "free-entry";
+export const MULTIDIGIT_MUL_FORMS = [FORM_FREE_ENTRY] as const;
+
+export const PROMPT_KEY_PRODUCT = locKey("dw.prompt.multidigit-mul.product");
+
+export const SOLUTION_KEY_SETUP = locKey("dw.solution.multidigit-mul.setup");
+export const SOLUTION_KEY_PARTIAL = locKey("dw.solution.multidigit-mul.partial");
+export const SOLUTION_KEY_ADD_PARTIALS = locKey("dw.solution.multidigit-mul.add-partials");
+export const SOLUTION_KEY_SHIFT = locKey("dw.solution.multidigit-mul.shift");
+export const SOLUTION_KEY_RESULT = locKey("dw.solution.multidigit-mul.result");
+
+export const MULTIDIGIT_MUL_LOC_KEYS = [
+  PROMPT_KEY_PRODUCT,
+  SOLUTION_KEY_SETUP,
+  SOLUTION_KEY_PARTIAL,
+  SOLUTION_KEY_ADD_PARTIALS,
+  SOLUTION_KEY_SHIFT,
+  SOLUTION_KEY_RESULT,
+] as const;
+
+export const SLOT_TOP = "top";
+export const SLOT_BOTTOM = "bottom";
+export const SLOT_DIGIT = "digit";
+export const SLOT_SHIFT = "shift";
+export const SLOT_PARTIAL = "partial";
+export const SLOT_ZEROS = "zeros";
+export const SLOT_ANSWER = "answer";
+
+/** 0.55 per partial product past the first. */
+export const COEFF_PARTIAL_PRODUCT = rational(55n, 100n);
+export const COEFF_DIGIT_OVER_TWO = rational(30n, 100n);
+/** 0.25 when the single-digit pass carries. */
+export const COEFF_CARRY = rational(25n, 100n);
+/** The special case: multiplying by a power of ten moves digits and forms nothing. */
+export const COEFF_POWER_OF_TEN = rational(-35n, 100n);
+
+export const FORM_OFFSET_FREE_ENTRY = rational(0n);

--- a/dynawalla/packs/shared/curriculum/src/generators/multidigitMul/family.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/multidigitMul/family.ts
@@ -1,0 +1,230 @@
+/**
+ * `gen.arith.multidigit-mul` — the multiplication algorithm.
+ *
+ * The carry structure is drawn first, exactly as `gen.arith.column-op` draws its
+ * regrouping pattern first: a level that says its first partial product carries
+ * gets that on every seed, rather than on the 80% of seeds a uniform draw would
+ * happen to give it. That is what makes `mis.mul.carry-added-before-multiplying`
+ * measurable — the bug is instantiated on every item of a carrying level.
+ *
+ * Both operands are non-negative and the product is checked against exact rational
+ * multiplication on every call, so a digit-wise slip cannot be served as an answer.
+ */
+
+import { eq as rationalEq, mul as ratMul, mul, pow10, rational, add as ratAdd } from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import { createRng, seedFrom } from "../../rng/rng.ts";
+import type { Rng } from "../../rng/rng.ts";
+import type { AnswerSchema, AnswerValue } from "../../types/answer.ts";
+import type { Exercise, SolutionStep } from "../../types/exercise.ts";
+import { exerciseIdOf } from "../../types/ids.ts";
+import type { GenerateRequest, GeneratorFamily, Verdict } from "../../types/generator.ts";
+import { chooseForm, distractorsFor, judge } from "../shared/build.ts";
+import { countSlot, numberSlot } from "../shared/slots.ts";
+import { InfeasibleLevelError } from "../shared/errors.ts";
+import {
+  COEFF_CARRY,
+  COEFF_DIGIT_OVER_TWO,
+  COEFF_PARTIAL_PRODUCT,
+  COEFF_POWER_OF_TEN,
+  FORM_OFFSET_FREE_ENTRY,
+  MULTIDIGIT_MUL_FAMILY,
+  MULTIDIGIT_MUL_FAMILY_REV,
+  MULTIDIGIT_MUL_FORMS,
+  PROMPT_KEY_PRODUCT,
+  SLOT_ANSWER,
+  SLOT_BOTTOM,
+  SLOT_DIGIT,
+  SLOT_PARTIAL,
+  SLOT_SHIFT,
+  SLOT_TOP,
+  SLOT_ZEROS,
+  SOLUTION_KEY_ADD_PARTIALS,
+  SOLUTION_KEY_PARTIAL,
+  SOLUTION_KEY_RESULT,
+  SOLUTION_KEY_SETUP,
+  SOLUTION_KEY_SHIFT,
+} from "./constants.ts";
+import { multidigitMulParamSchema } from "./params.ts";
+import type { MultidigitMulParams } from "./params.ts";
+import { littleEndianDigits } from "./procedure.ts";
+
+type Draw = { readonly top: bigint; readonly bottom: bigint; readonly zeros: number };
+
+/** `ceil(a / b)` for positive integers, in integers. */
+function ceilDiv(a: number, b: number): number {
+  return (a - (a % b)) / b + (a % b === 0 ? 0 : 1);
+}
+
+function fromDigits(digits: readonly number[]): bigint {
+  let value = 0n;
+  for (const digit of digits) value = value * 10n + BigInt(digit);
+  return value;
+}
+
+/**
+ * A multiplicand and a multiplier whose first partial product carries out of the
+ * units column.
+ *
+ * The units digit of the multiplier is drawn first, and the units digit of the
+ * multiplicand is then drawn from the range that forces `d × m ≥ 10`. Drawing both
+ * freely and rejecting would make the item stream depend on what was rejected.
+ */
+function drawCarrying(digits: number, multiplierDigits: number, rng: Rng): Draw {
+  const units = rng.nextInt(2, 9);
+  const multiplier: number[] = [units];
+  for (let index = 1; index < multiplierDigits; index++) {
+    multiplier.push(rng.nextInt(index === multiplierDigits - 1 ? 1 : 0, 9));
+  }
+
+  const top: number[] = [rng.nextInt(ceilDiv(10, units), 9)];
+  for (let index = 1; index < digits; index++) {
+    top.push(rng.nextInt(index === digits - 1 ? 1 : 0, 9));
+  }
+
+  return { top: fromDigits([...top].reverse()), bottom: fromDigits([...multiplier].reverse()), zeros: 0 };
+}
+
+/**
+ * A multiplicand and a single-digit multiplier whose product carries nowhere.
+ *
+ * Every digit must satisfy `d × m ≤ 9`, so the multiplier is drawn from 2..4: at 5
+ * and above the only admissible digits are 0 and 1 and the level would pose the
+ * same handful of items forever.
+ */
+function drawNonCarrying(digits: number, rng: Rng): Draw {
+  const multiplier = rng.nextInt(2, 4);
+  const ceiling = (9 - (9 % multiplier)) / multiplier;
+  const top: number[] = [];
+  for (let index = 0; index < digits; index++) {
+    top.push(rng.nextInt(index === 0 ? 1 : 0, ceiling));
+  }
+  return { top: fromDigits(top), bottom: BigInt(multiplier), zeros: 0 };
+}
+
+function drawPowerOfTen(digits: number, maxPower: number, rng: Rng): Draw {
+  const zeros = rng.nextInt(1, maxPower);
+  const top: number[] = [];
+  for (let index = 0; index < digits; index++) top.push(rng.nextInt(index === 0 ? 1 : 0, 9));
+  return { top: fromDigits(top), bottom: pow10(zeros), zeros };
+}
+
+function drawFor(params: MultidigitMulParams, rng: Rng): Draw {
+  if (params.shape === "power-of-ten") return drawPowerOfTen(params.digits, params.maxPower, rng);
+  return params.carries
+    ? drawCarrying(params.digits, params.multiplierDigits, rng)
+    : drawNonCarrying(params.digits, rng);
+}
+
+function answerCapacity(params: MultidigitMulParams): number {
+  // The widest product the level can produce, which is the field width and never
+  // this item's answer width.
+  return params.shape === "power-of-ten"
+    ? params.digits + params.maxPower
+    : params.digits + params.multiplierDigits;
+}
+
+function solutionFor(params: MultidigitMulParams, draw: Draw, answer: bigint): SolutionStep[] {
+  const steps: SolutionStep[] = [
+    { key: SOLUTION_KEY_SETUP, slots: { [SLOT_TOP]: numberSlot(draw.top), [SLOT_BOTTOM]: numberSlot(draw.bottom) } },
+  ];
+
+  if (params.shape === "power-of-ten") {
+    steps.push({
+      key: SOLUTION_KEY_SHIFT,
+      slots: {
+        [SLOT_TOP]: numberSlot(draw.top),
+        [SLOT_ZEROS]: countSlot(draw.zeros),
+        [SLOT_ANSWER]: numberSlot(answer),
+      },
+    });
+    steps.push({ key: SOLUTION_KEY_RESULT, slots: { [SLOT_ANSWER]: numberSlot(answer) } });
+    return steps;
+  }
+
+  const digits = littleEndianDigits(draw.bottom);
+  digits.forEach((digit, index) => {
+    steps.push({
+      key: SOLUTION_KEY_PARTIAL,
+      slots: {
+        [SLOT_DIGIT]: countSlot(digit),
+        [SLOT_SHIFT]: countSlot(index),
+        [SLOT_PARTIAL]: numberSlot(draw.top * BigInt(digit) * pow10(index)),
+      },
+      focusColumn: index,
+    });
+  });
+  // One partial product *is* the answer; announcing a sum of one term would be the
+  // walkthrough inventing a step the child does not take.
+  if (digits.length > 1) {
+    steps.push({ key: SOLUTION_KEY_ADD_PARTIALS, slots: { [SLOT_ANSWER]: numberSlot(answer) } });
+  }
+  steps.push({ key: SOLUTION_KEY_RESULT, slots: { [SLOT_ANSWER]: numberSlot(answer) } });
+  return steps;
+}
+
+export const multidigitMulFamily: GeneratorFamily<MultidigitMulParams> = {
+  family: MULTIDIGIT_MUL_FAMILY,
+  familyRev: MULTIDIGIT_MUL_FAMILY_REV,
+  paramSchema: multidigitMulParamSchema,
+  forms: MULTIDIGIT_MUL_FORMS,
+  choiceOnly: false,
+  representations: [],
+
+  answerSchema(params: MultidigitMulParams): AnswerSchema {
+    return { kind: "integer", digits: answerCapacity(params), decimalPlaces: 0 };
+  },
+
+  difficultyOffset(params: MultidigitMulParams): Rational {
+    let b = mul(COEFF_DIGIT_OVER_TWO, rational(BigInt(params.digits - 2)));
+    if (params.shape === "power-of-ten") return ratAdd(b, COEFF_POWER_OF_TEN);
+    b = ratAdd(b, mul(COEFF_PARTIAL_PRODUCT, rational(BigInt(params.multiplierDigits - 1))));
+    if (params.carries) b = ratAdd(b, COEFF_CARRY);
+    return b;
+  },
+
+  formOffset(): Rational {
+    return FORM_OFFSET_FREE_ENTRY;
+  },
+
+  generate(request: GenerateRequest<MultidigitMulParams>): Exercise {
+    const { skillId, level, seed, params, forms } = request;
+    const exerciseId = exerciseIdOf(MULTIDIGIT_MUL_FAMILY, MULTIDIGIT_MUL_FAMILY_REV, skillId, level, seed);
+    const rng = createRng(seedFrom(exerciseId));
+
+    const form = chooseForm(forms, MULTIDIGIT_MUL_FORMS, rng);
+    const draw = drawFor(params, rng);
+    const answer = draw.top * draw.bottom;
+
+    // The point of the family, asserted on every call: the digit work and exact
+    // rational arithmetic agree.
+    if (!rationalEq(ratMul(rational(draw.top), rational(draw.bottom)), rational(answer))) {
+      throw new InfeasibleLevelError(`multiplication disagreed with exact arithmetic on ${exerciseId}`);
+    }
+
+    const base: Exercise = {
+      exerciseId,
+      skillId,
+      level,
+      seed,
+      family: MULTIDIGIT_MUL_FAMILY,
+      familyRev: MULTIDIGIT_MUL_FAMILY_REV,
+      form,
+      prompt: {
+        key: PROMPT_KEY_PRODUCT,
+        slots: { [SLOT_TOP]: numberSlot(draw.top), [SLOT_BOTTOM]: numberSlot(draw.bottom) },
+      },
+      schema: { kind: "integer", digits: answerCapacity(params), decimalPlaces: 0 },
+      answer: { canonical: { kind: "integer", value: rational(answer) }, alsoAccept: [] },
+      distractors: [],
+      check: { kind: "exact" },
+      solution: solutionFor(params, draw, answer),
+    };
+
+    return { ...base, distractors: distractorsFor(MULTIDIGIT_MUL_FAMILY, base) };
+  },
+
+  check(exercise: Exercise, submitted: AnswerValue): Verdict {
+    return judge(exercise, submitted);
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/multidigitMul/params.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/multidigitMul/params.ts
@@ -1,0 +1,67 @@
+/**
+ * `gen.arith.multidigit-mul` parameters.
+ *
+ * `carries` is a level property rather than an accident of the draw, for the same
+ * reason column-op's `regroupings` is: "multiply a three-digit number by six" is
+ * not one skill, it is the carrying one and the non-carrying one, and a level that
+ * lets the draw decide serves a mixture of the two and can measure neither.
+ *
+ * A single-digit multiplier of 1 is rejected on a carrying level because nothing
+ * times one can carry, which is a contradiction rather than an empty draw.
+ */
+
+import { reader } from "../shared/paramReader.ts";
+import type { ParamResult, ParamSchema } from "../../types/generator.ts";
+
+export type MulShape = "general" | "power-of-ten";
+export const MUL_SHAPES: readonly MulShape[] = ["general", "power-of-ten"];
+
+export type MultidigitMulParams =
+  | {
+      readonly shape: "general";
+      /** Digits of the multiplicand. */
+      readonly digits: number;
+      /** Digits of the multiplier. */
+      readonly multiplierDigits: number;
+      /** The units column of the first partial product carries. */
+      readonly carries: boolean;
+    }
+  | {
+      readonly shape: "power-of-ten";
+      readonly digits: number;
+      /** The multiplier is `10^k` for a `k` drawn from 1..maxPower. */
+      readonly maxPower: number;
+    };
+
+export const MAX_MULTIPLICAND_DIGITS = 5;
+export const MAX_MULTIPLIER_DIGITS = 3;
+export const MAX_POWER = 4;
+
+export const multidigitMulParamSchema: ParamSchema<MultidigitMulParams> = {
+  describe:
+    "{ shape: 'general', digits: 2..5, multiplierDigits: 1..3, carries: boolean } | " +
+    "{ shape: 'power-of-ten', digits: 2..5, maxPower: 1..4 }",
+
+  validate(raw: unknown): ParamResult<MultidigitMulParams> {
+    const read = reader(raw);
+    const shape = read.choice<MulShape>("shape", MUL_SHAPES);
+    const digits = read.int("digits", 2, MAX_MULTIPLICAND_DIGITS);
+
+    if (shape === "power-of-ten") {
+      const maxPower = read.int("maxPower", 1, MAX_POWER);
+      return read.finish({ shape, digits, maxPower });
+    }
+
+    const multiplierDigits = read.int("multiplierDigits", 1, MAX_MULTIPLIER_DIGITS);
+    const carries = read.boolean("carries");
+    if (read.clean() && !carries && multiplierDigits > 1) {
+      // A multi-digit multiplier forms several partial products and the second one
+      // starts from a shifted column; "no carry anywhere" is then a constraint on
+      // every pass at once, and the digit ranges that satisfy it are so narrow that
+      // the level would pose the same few dozen items forever. A level that wants
+      // the non-carrying case asks for it with a single-digit multiplier.
+      read.reject("carries", "a non-carrying level needs a single-digit multiplier");
+    }
+    return read.finish({ shape, digits, multiplierDigits, carries });
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/multidigitMul/procedure.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/multidigitMul/procedure.ts
@@ -1,0 +1,114 @@
+/**
+ * The single-digit multiplication pass — the correct one, and whether it carries.
+ *
+ * One implementation, read by the generator (which needs to know a level carries)
+ * and by the mal-rules (which need to know the bug is instantiated at all). Two
+ * copies of this drifted in `gen.arith.column-op` and the drift shipped a worked
+ * example that performed the misconception it existed to repair; there is one copy
+ * here for that reason.
+ *
+ * Digit arrays are **little-endian**: index 0 is the units column, the order the
+ * algorithm is performed in.
+ */
+
+/** Re-exported so a mal-rule reads one module rather than two. */
+export { littleEndianDigits } from "../shared/draw.ts";
+import { littleEndianDigits } from "../shared/draw.ts";
+
+export type MulColumn = {
+  /** The carry coming into this column from the one on its right. */
+  readonly carryIn: number;
+  /** `digit × multiplier + carryIn`, before the ten is taken out. */
+  readonly total: number;
+  readonly written: number;
+  readonly carryOut: number;
+};
+
+/** The correct pass: multiply, then add the carry. */
+export function singleDigitPass(digits: readonly number[], multiplier: number): MulColumn[] {
+  const columns: MulColumn[] = [];
+  let carry = 0;
+  for (const digit of digits) {
+    const total = digit * multiplier + carry;
+    const carryOut = (total - (total % 10)) / 10;
+    columns.push({ carryIn: carry, total, written: total % 10, carryOut });
+    carry = carryOut;
+  }
+  return columns;
+}
+
+/**
+ * True when the correct pass carries **out of** at least one column.
+ *
+ * This is the level-design question — "does this item exercise carrying at all" —
+ * and it is what `carries: true` promises. It is **not** the condition under which
+ * the add-the-carry-first bug is instantiated; use `passCarriesInward` for that.
+ * The two differ on exactly the items whose only carry is out of the leading
+ * column, where there is no column to its left to carry into: `50 × 2` carries out
+ * of the tens and `passCarries` is true, but nothing is ever added in the wrong
+ * order and the buggy pass reproduces `100` exactly.
+ */
+export function passCarries(digits: readonly number[], multiplier: number): boolean {
+  return singleDigitPass(digits, multiplier).some((column) => column.carryOut > 0);
+}
+
+/**
+ * True when the correct pass carries **into** at least one column — equivalently,
+ * when some non-leading column carries out.
+ *
+ * This is the condition `carryBeforeMultiply` is defined under, and the reason is
+ * in that function's docstring: a carry out of the most significant column is
+ * never a carry into anything, so it cannot be added in the wrong order.
+ */
+export function passCarriesInward(digits: readonly number[], multiplier: number): boolean {
+  return singleDigitPass(digits, multiplier).some((column) => column.carryIn > 0);
+}
+
+/**
+ * The buggy pass: **add the carry, then multiply** — `(digit + carry) × multiplier`
+ * instead of `digit × multiplier + carry`.
+ *
+ * Documented, and larger than the correct product exactly when the correct pass
+ * carries **into** some column. Writing `b_i` for the carry this procedure brings
+ * into column `i`, telescoping the written digits gives
+ *
+ *     buggy = m·N + (m − 1)·Σ_{i ≥ 1} b_i·10^i
+ *
+ * — the leading carry-out cancels against the digits the final loop writes, so the
+ * sum runs over carries **in** and not over carries **out**. With `m ≥ 2` every
+ * term of that sum is non-negative, so the two procedures agree iff every `b_i` is
+ * zero. And `b_i` equals the correct pass's carry into column `i` for as long as
+ * both are zero (`b_1 = ⌊d_0·m / 10⌋ = c_1`, and inductively `b_i = c_i` while
+ * `c_1 … c_{i−1}` are all zero), so the first non-zero correct carry-in is a
+ * non-zero `b_i` and the two products differ there.
+ *
+ * The condition is therefore "some column has a non-zero carry **in**", never
+ * "some column carries out". `50 × 2` carries out of its leading column and the
+ * two procedures both return `100`; brute-forced over every multiplicand
+ * `10..99999` against every multiplier `2..9`, the carry-out reading admits 7,980
+ * such collisions in 795,390 items and the carry-in reading admits 0 in 787,410.
+ * That is why the mal-rule's `applies()` calls `passCarriesInward` — it is still a
+ * question about the item's own structure and never about the answer.
+ */
+export function carryBeforeMultiply(digits: readonly number[], multiplier: number): bigint {
+  let value = 0n;
+  let unit = 1n;
+  let carry = 0;
+  for (const digit of digits) {
+    const total = (digit + carry) * multiplier;
+    value += BigInt(total % 10) * unit;
+    carry = (total - (total % 10)) / 10;
+    unit *= 10n;
+  }
+  while (carry > 0) {
+    value += BigInt(carry % 10) * unit;
+    carry = (carry - (carry % 10)) / 10;
+    unit *= 10n;
+  }
+  return value;
+}
+
+/** The sum of a number's digits. The unshifted-partial-product bug multiplies by this. */
+export function digitSum(value: bigint): bigint {
+  return littleEndianDigits(value).reduce((total, digit) => total + BigInt(digit), 0n);
+}

--- a/dynawalla/packs/shared/curriculum/src/generators/multidigitMul/read.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/multidigitMul/read.ts
@@ -1,0 +1,23 @@
+/**
+ * Reading a multiplication back out of a finished `Exercise`, for the mal-rules.
+ * The published contract only; never throws.
+ */
+
+import { asInteger } from "../../math/rational.ts";
+import type { Exercise } from "../../types/exercise.ts";
+import { PROMPT_KEY_PRODUCT, SLOT_BOTTOM, SLOT_TOP } from "./constants.ts";
+
+export type Factors = { readonly top: bigint; readonly bottom: bigint };
+
+export function readFactors(exercise: Exercise): Factors | null {
+  if (exercise.prompt.key !== PROMPT_KEY_PRODUCT) return null;
+  const top = exercise.prompt.slots[SLOT_TOP];
+  const bottom = exercise.prompt.slots[SLOT_BOTTOM];
+  if (top === undefined || top.kind !== "number") return null;
+  if (bottom === undefined || bottom.kind !== "number") return null;
+  const topValue = asInteger(top.value);
+  const bottomValue = asInteger(bottom.value);
+  if (topValue === null || bottomValue === null) return null;
+  if (topValue < 0n || bottomValue < 0n) return null;
+  return { top: topValue, bottom: bottomValue };
+}

--- a/dynawalla/packs/shared/curriculum/src/generators/placeValue/constants.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/placeValue/constants.ts
@@ -1,0 +1,75 @@
+/**
+ * `gen.number.place-value-decompose` — ids, locale keys and difficulty coefficients.
+ *
+ * The difficulty shape follows CURRICULUM.md:
+ *
+ *   b = b_skill + 0.30·(digits − 2) + 0.20·place − 0.35·specialCase + formOffset
+ *
+ * `regroupings` and `zeroBorrowThrough` are column-op parameters and contribute
+ * nothing here. `place` takes the 0.20 slot the doc spends on `noAnchor`, because
+ * asking about the ten-thousands place is harder than asking about the tens for the
+ * same reason `noAnchor` is a difficulty term: there is no landmark to count from.
+ * `specialCase` is spent on `digit-in-place`, which is the one task of the three
+ * that needs no arithmetic at all — reading a digit off the page.
+ *
+ * `place` is drawn from a range, so the parameter-derived difficulty uses the
+ * range's midpoint. The midpoint of an integer range is a half, which is exactly
+ * why it is a `Rational` and not a number.
+ */
+
+import { rational } from "../../math/rational.ts";
+import { familyId, locKey } from "../../types/ids.ts";
+/**
+ * Re-exported, not redeclared. The place names are shared with
+ * `gen.number.round-estimate` and `gen.number.compare-order`, and two spellings of
+ * one `LocKey` is a template nobody translated twice.
+ */
+export { PLACE_TERM_KEYS } from "../shared/placeTerms.ts";
+import { PLACE_TERM_KEYS } from "../shared/placeTerms.ts";
+
+export const PLACE_VALUE_FAMILY = familyId("gen.number.place-value-decompose");
+
+/** Bump whenever generated output changes for any seed. CG-16 keys its hashes on it. */
+export const PLACE_VALUE_FAMILY_REV = 1;
+
+export const FORM_FREE_ENTRY = "free-entry";
+export const PLACE_VALUE_FORMS = [FORM_FREE_ENTRY] as const;
+
+export const PROMPT_KEY_DIGIT_VALUE = locKey("dw.prompt.place-value.digit-value");
+export const PROMPT_KEY_DIGIT_IN_PLACE = locKey("dw.prompt.place-value.digit-in-place");
+export const PROMPT_KEY_TOTAL_IN_PLACE = locKey("dw.prompt.place-value.total-in-place");
+
+export const SOLUTION_KEY_LOCATE = locKey("dw.solution.place-value.locate");
+export const SOLUTION_KEY_UNIT_WORTH = locKey("dw.solution.place-value.unit-worth");
+export const SOLUTION_KEY_GROUP = locKey("dw.solution.place-value.group");
+export const SOLUTION_KEY_RESULT = locKey("dw.solution.place-value.result");
+
+/** Every locale key this family can emit. Read by CG-19 rather than grepped. */
+export const PLACE_VALUE_LOC_KEYS = [
+  PROMPT_KEY_DIGIT_VALUE,
+  PROMPT_KEY_DIGIT_IN_PLACE,
+  PROMPT_KEY_TOTAL_IN_PLACE,
+  SOLUTION_KEY_LOCATE,
+  SOLUTION_KEY_UNIT_WORTH,
+  SOLUTION_KEY_GROUP,
+  SOLUTION_KEY_RESULT,
+  ...PLACE_TERM_KEYS,
+] as const;
+
+export const SLOT_NUMBER = "number";
+export const SLOT_PLACE = "place";
+export const SLOT_DIGIT = "digit";
+export const SLOT_UNIT = "unit";
+export const SLOT_ANSWER = "answer";
+export const SLOT_REST = "rest";
+
+/** 0.30 per digit beyond two. */
+export const COEFF_DIGIT_OVER_TWO = rational(30n, 100n);
+/** 0.20 per place above the units column, at the drawn range's midpoint. */
+export const COEFF_PLACE = rational(20n, 100n);
+/** −0.35 for `digit-in-place`, the one task that is reading rather than arithmetic. */
+export const COEFF_SPECIAL_CASE = rational(-35n, 100n);
+/** +0.45 for `total-in-place`: "how many hundreds altogether" is a regrouped count. */
+export const COEFF_REGROUPED_COUNT = rational(45n, 100n);
+
+export const FORM_OFFSET_FREE_ENTRY = rational(0n);

--- a/dynawalla/packs/shared/curriculum/src/generators/placeValue/family.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/placeValue/family.ts
@@ -1,0 +1,220 @@
+/**
+ * `gen.number.place-value-decompose` — what a digit is worth, which digit sits in a
+ * place, and how many of a unit a number holds altogether.
+ *
+ * The three tasks are one family because they are one idea asked three ways, and
+ * because the misconception that matters here — reading the *digit* where the
+ * question asked for the *quantity* — is only visible when the same number is
+ * asked about both ways.
+ *
+ * Two ambiguity traps are closed by construction rather than by hoping:
+ *
+ * - The question names the **place**, never the digit. "In 4737, what is the digit
+ *   7 worth?" has two answers; "what is the digit in the hundreds place worth?" has
+ *   one, whatever the digits happen to be.
+ * - `digit-value` never asks about a place holding a zero. "What is the 0 in the
+ *   hundreds place worth?" is a real question with the answer 0, and it is also the
+ *   one item on which the digit-for-value mal-rule produces the correct answer, so
+ *   it would be a distractor that is right.
+ */
+
+import { mul, pow10, rational, add as ratAdd } from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import { createRng, seedFrom } from "../../rng/rng.ts";
+import type { Rng } from "../../rng/rng.ts";
+import type { AnswerSchema, AnswerValue } from "../../types/answer.ts";
+import type { Exercise, PromptSlot, SolutionStep } from "../../types/exercise.ts";
+import { exerciseIdOf } from "../../types/ids.ts";
+import type { LocKey } from "../../types/ids.ts";
+import type { GenerateRequest, GeneratorFamily, Verdict } from "../../types/generator.ts";
+import { chooseForm, distractorsFor, judge } from "../shared/build.ts";
+import { countSlot, numberSlot, termSlot } from "../shared/slots.ts";
+import { InfeasibleLevelError } from "../shared/errors.ts";
+import {
+  COEFF_DIGIT_OVER_TWO,
+  COEFF_PLACE,
+  COEFF_REGROUPED_COUNT,
+  COEFF_SPECIAL_CASE,
+  FORM_OFFSET_FREE_ENTRY,
+  PLACE_TERM_KEYS,
+  PLACE_VALUE_FAMILY,
+  PLACE_VALUE_FAMILY_REV,
+  PLACE_VALUE_FORMS,
+  PROMPT_KEY_DIGIT_IN_PLACE,
+  PROMPT_KEY_DIGIT_VALUE,
+  PROMPT_KEY_TOTAL_IN_PLACE,
+  SLOT_ANSWER,
+  SLOT_DIGIT,
+  SLOT_NUMBER,
+  SLOT_PLACE,
+  SLOT_REST,
+  SLOT_UNIT,
+  SOLUTION_KEY_GROUP,
+  SOLUTION_KEY_LOCATE,
+  SOLUTION_KEY_RESULT,
+  SOLUTION_KEY_UNIT_WORTH,
+} from "./constants.ts";
+import { placeValueParamSchema } from "./params.ts";
+import type { PlaceValueParams, PlaceValueTask } from "./params.ts";
+
+
+const PROMPT_KEYS: Readonly<Record<PlaceValueTask, LocKey>> = {
+  "digit-value": PROMPT_KEY_DIGIT_VALUE,
+  "digit-in-place": PROMPT_KEY_DIGIT_IN_PLACE,
+  "total-in-place": PROMPT_KEY_TOTAL_IN_PLACE,
+};
+
+function placeSlot(place: number): PromptSlot {
+  const key = PLACE_TERM_KEYS[place];
+  if (key === undefined) throw new InfeasibleLevelError(`no place name for place ${String(place)}`);
+  return termSlot(key);
+}
+
+/**
+ * Draw the number, digit by digit, most significant first.
+ *
+ * Digit-wise rather than one draw over a range because `digit-value` has to be able
+ * to force one particular column non-zero, and forcing it after a whole-number draw
+ * would either bias the low digits or need a retry loop whose draw count depends on
+ * what it rejected — which makes the rest of the stream depend on a rejected value.
+ */
+function drawNumber(params: PlaceValueParams, place: number, rng: Rng): bigint {
+  const { digits, task } = params;
+  const cells: number[] = [];
+  for (let index = 0; index < digits; index++) {
+    // Index 0 is the most significant digit and may not be zero, or the number
+    // would be written with fewer digits than the level asked for.
+    cells.push(rng.nextInt(index === 0 ? 1 : 0, 9));
+  }
+  if (task === "digit-value") {
+    const column = digits - 1 - place;
+    if (cells[column] === 0) cells[column] = rng.nextInt(1, 9);
+  }
+  let value = 0n;
+  for (const cell of cells) value = value * 10n + BigInt(cell);
+  return value;
+}
+
+function answerFor(task: PlaceValueTask, value: bigint, place: number): bigint {
+  const unit = pow10(place);
+  const digit = (value / unit) % 10n;
+  switch (task) {
+    case "digit-value":
+      return digit * unit;
+    case "digit-in-place":
+      return digit;
+    case "total-in-place":
+      return value / unit;
+  }
+}
+
+function answerCapacity(params: PlaceValueParams): number {
+  // The field width, never this item's answer width: a field sized to the answer
+  // tells the child how many digits it has.
+  return params.task === "digit-in-place" ? 1 : params.digits;
+}
+
+function solutionFor(task: PlaceValueTask, value: bigint, place: number, answer: bigint): SolutionStep[] {
+  const unit = pow10(place);
+  const digit = (value / unit) % 10n;
+  const steps: SolutionStep[] = [
+    {
+      key: SOLUTION_KEY_LOCATE,
+      slots: { [SLOT_NUMBER]: numberSlot(value), [SLOT_PLACE]: placeSlot(place) },
+      focusColumn: place,
+    },
+  ];
+
+  if (task === "digit-value") {
+    steps.push({
+      key: SOLUTION_KEY_UNIT_WORTH,
+      slots: {
+        [SLOT_DIGIT]: countSlot(digit),
+        [SLOT_PLACE]: placeSlot(place),
+        [SLOT_UNIT]: numberSlot(unit),
+        [SLOT_ANSWER]: numberSlot(answer),
+      },
+      focusColumn: place,
+    });
+  }
+  if (task === "total-in-place") {
+    steps.push({
+      key: SOLUTION_KEY_GROUP,
+      slots: {
+        [SLOT_NUMBER]: numberSlot(value),
+        [SLOT_UNIT]: numberSlot(unit),
+        [SLOT_ANSWER]: numberSlot(answer),
+        [SLOT_REST]: numberSlot(value % unit),
+      },
+      focusColumn: place,
+    });
+  }
+
+  steps.push({ key: SOLUTION_KEY_RESULT, slots: { [SLOT_ANSWER]: numberSlot(answer) } });
+  return steps;
+}
+
+export const placeValueFamily: GeneratorFamily<PlaceValueParams> = {
+  family: PLACE_VALUE_FAMILY,
+  familyRev: PLACE_VALUE_FAMILY_REV,
+  paramSchema: placeValueParamSchema,
+  forms: PLACE_VALUE_FORMS,
+  choiceOnly: false,
+  representations: [],
+
+  answerSchema(params: PlaceValueParams): AnswerSchema {
+    return { kind: "integer", digits: answerCapacity(params), decimalPlaces: 0 };
+  },
+
+  difficultyOffset(params: PlaceValueParams): Rational {
+    let b = mul(COEFF_DIGIT_OVER_TWO, rational(BigInt(params.digits - 2)));
+    // The midpoint of the drawn place range. An integer range's midpoint is a half
+    // as often as not, which is why it is exact rather than rounded.
+    b = ratAdd(b, mul(COEFF_PLACE, rational(BigInt(params.minPlace + params.maxPlace), 2n)));
+    if (params.task === "digit-in-place") b = ratAdd(b, COEFF_SPECIAL_CASE);
+    if (params.task === "total-in-place") b = ratAdd(b, COEFF_REGROUPED_COUNT);
+    return b;
+  },
+
+  formOffset(): Rational {
+    return FORM_OFFSET_FREE_ENTRY;
+  },
+
+  generate(request: GenerateRequest<PlaceValueParams>): Exercise {
+    const { skillId, level, seed, params, forms } = request;
+    const exerciseId = exerciseIdOf(PLACE_VALUE_FAMILY, PLACE_VALUE_FAMILY_REV, skillId, level, seed);
+    const rng = createRng(seedFrom(exerciseId));
+
+    const form = chooseForm(forms, PLACE_VALUE_FORMS, rng);
+    const place = rng.nextInt(params.minPlace, params.maxPlace);
+    const value = drawNumber(params, place, rng);
+    const answer = answerFor(params.task, value, place);
+
+    const canonical: AnswerValue = { kind: "integer", value: rational(answer) };
+    const base: Exercise = {
+      exerciseId,
+      skillId,
+      level,
+      seed,
+      family: PLACE_VALUE_FAMILY,
+      familyRev: PLACE_VALUE_FAMILY_REV,
+      form,
+      prompt: {
+        key: PROMPT_KEYS[params.task],
+        slots: { [SLOT_NUMBER]: numberSlot(value), [SLOT_PLACE]: placeSlot(place) },
+      },
+      schema: { kind: "integer", digits: answerCapacity(params), decimalPlaces: 0 },
+      // Nothing else is the same answer: an integer answer has one writing.
+      answer: { canonical, alsoAccept: [] },
+      distractors: [],
+      check: { kind: "exact" },
+      solution: solutionFor(params.task, value, place, answer),
+    };
+
+    return { ...base, distractors: distractorsFor(PLACE_VALUE_FAMILY, base) };
+  },
+
+  check(exercise: Exercise, submitted: AnswerValue): Verdict {
+    return judge(exercise, submitted);
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/placeValue/params.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/placeValue/params.ts
@@ -1,0 +1,71 @@
+/**
+ * `gen.number.place-value-decompose` parameters.
+ *
+ * Three tasks over one number, and the validator's job is to reject the
+ * combinations that would produce a question with no answer or with two.
+ *
+ * - `digit-value` ("what is the digit in the hundreds place worth?") and
+ *   `total-in-place` ("how many hundreds altogether?") must not ask about the units
+ *   column: in units both questions collapse onto `digit-in-place` and the item
+ *   teaches nothing.
+ * - `total-in-place` must leave at least two digits above the place it asks about,
+ *   or the "altogether" count *is* the digit and the question is the same question
+ *   asked twice.
+ */
+
+import { MAX_WHOLE_DIGITS } from "../shared/draw.ts";
+import { reader } from "../shared/paramReader.ts";
+import type { ParamResult, ParamSchema } from "../../types/generator.ts";
+
+export type PlaceValueTask = "digit-value" | "digit-in-place" | "total-in-place";
+
+export const PLACE_VALUE_TASKS: readonly PlaceValueTask[] = [
+  "digit-value",
+  "digit-in-place",
+  "total-in-place",
+];
+
+export type PlaceValueParams = {
+  readonly task: PlaceValueTask;
+  /** Digit count of the number the question is about. */
+  readonly digits: number;
+  /** Lowest place the question may ask about, counted from the units column. */
+  readonly minPlace: number;
+  readonly maxPlace: number;
+};
+
+export const MIN_DIGITS = 2;
+
+export const placeValueParamSchema: ParamSchema<PlaceValueParams> = {
+  describe:
+    "{ task: 'digit-value'|'digit-in-place'|'total-in-place', digits: 2..7, " +
+    "minPlace: 0..digits-1, maxPlace: minPlace..digits-1 }",
+
+  validate(raw: unknown): ParamResult<PlaceValueParams> {
+    const read = reader(raw);
+    const task = read.choice<PlaceValueTask>("task", PLACE_VALUE_TASKS);
+    const digits = read.int("digits", MIN_DIGITS, MAX_WHOLE_DIGITS);
+    const minPlace = read.int("minPlace", 0, digits - 1);
+    const maxPlace = read.int("maxPlace", 0, digits - 1);
+
+    if (read.clean()) {
+      if (maxPlace < minPlace) {
+        read.reject("maxPlace", "maxPlace must be at least minPlace");
+      }
+      if (task !== "digit-in-place" && minPlace < 1) {
+        read.reject(
+          "minPlace",
+          `${task} in the units column is the same question as digit-in-place; minPlace must be at least 1`,
+        );
+      }
+      if (task === "total-in-place" && maxPlace > digits - 2) {
+        read.reject(
+          "maxPlace",
+          "total-in-place needs two digits above the place it counts, or the total is the digit itself",
+        );
+      }
+    }
+
+    return read.finish({ task, digits, minPlace, maxPlace });
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/placeValue/read.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/placeValue/read.ts
@@ -1,0 +1,56 @@
+/**
+ * Reading a place-value question back out of a finished `Exercise`.
+ *
+ * Mal-rules are `(exercise) => AnswerValue | null`: they see the published exercise
+ * contract and never the generator's internals, which is what lets the same
+ * function serve as a distractor source at authoring time and as a diagnosis at
+ * runtime. So they need a supported way to recover what was asked, and this is it.
+ *
+ * Never throws. A rule handed an item from another family declines it.
+ */
+
+import { asInteger, pow10 } from "../../math/rational.ts";
+import type { Exercise } from "../../types/exercise.ts";
+import {
+  PLACE_TERM_KEYS,
+  PROMPT_KEY_DIGIT_IN_PLACE,
+  PROMPT_KEY_DIGIT_VALUE,
+  PROMPT_KEY_TOTAL_IN_PLACE,
+  SLOT_NUMBER,
+  SLOT_PLACE,
+} from "./constants.ts";
+import type { PlaceValueTask } from "./params.ts";
+
+export type PlaceValueQuestion = {
+  readonly task: PlaceValueTask;
+  readonly value: bigint;
+  /** Counted from the units column, which is place 0. */
+  readonly place: number;
+  /** The digit written in that place. */
+  readonly digit: bigint;
+};
+
+function taskOf(key: string): PlaceValueTask | null {
+  if (key === PROMPT_KEY_DIGIT_VALUE) return "digit-value";
+  if (key === PROMPT_KEY_DIGIT_IN_PLACE) return "digit-in-place";
+  if (key === PROMPT_KEY_TOTAL_IN_PLACE) return "total-in-place";
+  return null;
+}
+
+export function readPlaceValueQuestion(exercise: Exercise): PlaceValueQuestion | null {
+  const task = taskOf(exercise.prompt.key);
+  if (task === null) return null;
+
+  const numberSlot = exercise.prompt.slots[SLOT_NUMBER];
+  const placeSlot = exercise.prompt.slots[SLOT_PLACE];
+  if (numberSlot === undefined || numberSlot.kind !== "number") return null;
+  if (placeSlot === undefined || placeSlot.kind !== "term") return null;
+
+  const value = asInteger(numberSlot.value);
+  if (value === null || value < 0n) return null;
+
+  const place = PLACE_TERM_KEYS.indexOf(placeSlot.key);
+  if (place < 0) return null;
+
+  return { task, value, place, digit: (value / pow10(place)) % 10n };
+}

--- a/dynawalla/packs/shared/curriculum/src/generators/registry.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/registry.ts
@@ -6,8 +6,26 @@ import { erase } from "../types/generator.ts";
 import type { AnyGeneratorFamily } from "../types/generator.ts";
 import type { FamilyId } from "../types/ids.ts";
 import { columnOpFamily } from "./columnOp/family.ts";
+import { compareOrderFamily } from "./compareOrder/family.ts";
+import { fracArithFamily } from "./fracArith/family.ts";
+import { fracEquivalenceFamily } from "./fracEquivalence/family.ts";
+import { longDivFamily } from "./longDiv/family.ts";
+import { missingOperandFamily } from "./missingOperand/family.ts";
+import { multidigitMulFamily } from "./multidigitMul/family.ts";
+import { placeValueFamily } from "./placeValue/family.ts";
+import { roundEstimateFamily } from "./roundEstimate/family.ts";
 
-export const generatorFamilies: readonly AnyGeneratorFamily[] = [erase(columnOpFamily)];
+export const generatorFamilies: readonly AnyGeneratorFamily[] = [
+  erase(columnOpFamily),
+  erase(placeValueFamily),
+  erase(compareOrderFamily),
+  erase(roundEstimateFamily),
+  erase(multidigitMulFamily),
+  erase(longDivFamily),
+  erase(fracEquivalenceFamily),
+  erase(fracArithFamily),
+  erase(missingOperandFamily),
+];
 
 export function familyById(
   id: FamilyId,

--- a/dynawalla/packs/shared/curriculum/src/generators/roundEstimate/constants.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/roundEstimate/constants.ts
@@ -1,0 +1,48 @@
+/**
+ * `gen.number.round-estimate` — ids, locale keys and difficulty coefficients.
+ *
+ *   b = b_skill + 0.30·(digits − 2) + 0.20·place + 0.35·ties + formOffset
+ *
+ * **Rounding half up, always.** Half-to-even is the convention of measurement and
+ * of IEEE arithmetic; half-up is the convention every elementary curriculum in this
+ * program's three frameworks teaches, and a generator that silently chose the other
+ * one would mark a correct child wrong on one item in twenty. `ties` is a declared
+ * level parameter rather than an accident of the draw, so a level either poses the
+ * case that makes the convention visible or it does not.
+ */
+
+import { rational } from "../../math/rational.ts";
+import { familyId, locKey } from "../../types/ids.ts";
+
+export const ROUND_ESTIMATE_FAMILY = familyId("gen.number.round-estimate");
+export const ROUND_ESTIMATE_FAMILY_REV = 1;
+
+export const FORM_FREE_ENTRY = "free-entry";
+export const ROUND_ESTIMATE_FORMS = [FORM_FREE_ENTRY] as const;
+
+export const PROMPT_KEY_ROUND = locKey("dw.prompt.round-estimate.round");
+
+export const SOLUTION_KEY_NEIGHBOURS = locKey("dw.solution.round-estimate.neighbours");
+export const SOLUTION_KEY_DECIDER = locKey("dw.solution.round-estimate.decider");
+export const SOLUTION_KEY_RESULT = locKey("dw.solution.round-estimate.result");
+
+export const ROUND_ESTIMATE_LOC_KEYS = [
+  PROMPT_KEY_ROUND,
+  SOLUTION_KEY_NEIGHBOURS,
+  SOLUTION_KEY_DECIDER,
+  SOLUTION_KEY_RESULT,
+] as const;
+
+export const SLOT_NUMBER = "number";
+export const SLOT_PLACE = "place";
+export const SLOT_LOWER = "lower";
+export const SLOT_UPPER = "upper";
+export const SLOT_DIGIT = "digit";
+export const SLOT_ANSWER = "answer";
+
+export const COEFF_DIGIT_OVER_TWO = rational(30n, 100n);
+export const COEFF_PLACE = rational(20n, 100n);
+/** The tie is the case the convention is for, and the case children lose. */
+export const COEFF_TIES = rational(35n, 100n);
+
+export const FORM_OFFSET_FREE_ENTRY = rational(0n);

--- a/dynawalla/packs/shared/curriculum/src/generators/roundEstimate/family.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/roundEstimate/family.ts
@@ -1,0 +1,188 @@
+/**
+ * `gen.number.round-estimate` — rounding a whole number to a named place.
+ *
+ * The number is built from its two halves rather than drawn and filtered: the part
+ * at and above the rounding place, and the part below it. That is what lets a level
+ * guarantee the two properties a rounding item needs and a filtered draw would only
+ * usually have —
+ *
+ * - the number is **never already round** (`4,700` to the nearest hundred is a
+ *   question whose answer is the question), and
+ * - a `ties` level poses the exact halfway number often enough to be a test of the
+ *   convention rather than a one-in-a-hundred surprise.
+ *
+ * **This family ships no mal-rules, and that is a decision, not an omission.** The
+ * documented rounding errors — truncating, and reading the last digit instead of
+ * the one below the place — produce the *correct* answer on roughly half of all
+ * items, because half of all items round down. CG-12 requires a mal-rule to diverge
+ * on 95% of the items it applies to, and the only ways to reach that number are to
+ * pose almost exclusively round-up items (which teaches the error) or to have
+ * `applies()` decline the items where the bug happens to be right (which is the
+ * self-filtering the mal-rule contract forbids in as many words). CURRICULUM.md's
+ * honesty rule covers this case: where the catalogue is thin, an unclassified error
+ * and a faded worked example, and never an invented bug.
+ */
+
+import { mul, pow10, rational, add as ratAdd } from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import { createRng, seedFrom } from "../../rng/rng.ts";
+import type { Rng } from "../../rng/rng.ts";
+import type { AnswerSchema, AnswerValue } from "../../types/answer.ts";
+import type { Exercise, SolutionStep } from "../../types/exercise.ts";
+import { exerciseIdOf } from "../../types/ids.ts";
+import type { GenerateRequest, GeneratorFamily, Verdict } from "../../types/generator.ts";
+import { chooseForm, distractorsFor, judge } from "../shared/build.ts";
+import { countSlot, numberSlot, termSlot } from "../shared/slots.ts";
+import { drawBetween, drawBetweenExcluding } from "../shared/draw.ts";
+import { InfeasibleLevelError } from "../shared/errors.ts";
+import { placeTerm } from "../shared/placeTerms.ts";
+import {
+  COEFF_DIGIT_OVER_TWO,
+  COEFF_PLACE,
+  COEFF_TIES,
+  FORM_OFFSET_FREE_ENTRY,
+  PROMPT_KEY_ROUND,
+  ROUND_ESTIMATE_FAMILY,
+  ROUND_ESTIMATE_FAMILY_REV,
+  ROUND_ESTIMATE_FORMS,
+  SLOT_ANSWER,
+  SLOT_DIGIT,
+  SLOT_LOWER,
+  SLOT_NUMBER,
+  SLOT_PLACE,
+  SLOT_UPPER,
+  SOLUTION_KEY_DECIDER,
+  SOLUTION_KEY_NEIGHBOURS,
+  SOLUTION_KEY_RESULT,
+} from "./constants.ts";
+import { roundEstimateParamSchema } from "./params.ts";
+import type { RoundEstimateParams } from "./params.ts";
+
+/** One tie in four on a `ties` level: often enough to be a test, rarely enough to be a level about something else. */
+const TIE_IN = 4;
+
+/**
+ * Round half up, exactly, in integers.
+ *
+ * `(value + unit/2) / unit * unit` with `/` as bigint division, which truncates —
+ * and truncation is floor on non-negative values, which is what half-up needs.
+ * Every operand here is a `bigint`; there is no division of a `number` anywhere on
+ * this path and therefore nothing to round twice.
+ */
+export function roundHalfUp(value: bigint, unit: bigint): bigint {
+  if (unit <= 0n) throw new RangeError("roundHalfUp: unit must be positive");
+  if (value < 0n) throw new RangeError("roundHalfUp: negative value");
+  return ((value + unit / 2n) / unit) * unit;
+}
+
+function drawNumber(params: RoundEstimateParams, place: number, rng: Rng): bigint {
+  const unit = pow10(place);
+  const half = unit / 2n;
+  const aboveDigits = params.digits - place;
+  if (aboveDigits < 1) throw new InfeasibleLevelError("nothing sits above the rounding place");
+
+  // The part at and above the place keeps the leading-digit rule, so the number is
+  // written with exactly the width the level asked for.
+  const above = drawBetween(rng, pow10(aboveDigits - 1), pow10(aboveDigits) - 1n);
+
+  const tie = params.ties && rng.nextInt(1, TIE_IN) === 1;
+  // Below the place: never zero, or the number is already round and the question
+  // answers itself. On a level that does not pose ties, never the exact half either.
+  const below = tie ? half : params.ties ? drawBetween(rng, 1n, unit - 1n) : drawBetweenExcluding(rng, 1n, unit - 1n, half);
+
+  return above * unit + below;
+}
+
+function solutionFor(value: bigint, place: number, answer: bigint): SolutionStep[] {
+  const unit = pow10(place);
+  const lower = (value / unit) * unit;
+  const term = placeTerm(place);
+  if (term === null) throw new InfeasibleLevelError(`no place name for place ${String(place)}`);
+
+  return [
+    {
+      key: SOLUTION_KEY_NEIGHBOURS,
+      slots: {
+        [SLOT_NUMBER]: numberSlot(value),
+        [SLOT_PLACE]: termSlot(term),
+        [SLOT_LOWER]: numberSlot(lower),
+        [SLOT_UPPER]: numberSlot(lower + unit),
+      },
+      focusColumn: place,
+    },
+    {
+      key: SOLUTION_KEY_DECIDER,
+      slots: {
+        [SLOT_DIGIT]: countSlot((value / (unit / 10n)) % 10n),
+        [SLOT_PLACE]: termSlot(term),
+      },
+      focusColumn: place - 1,
+    },
+    { key: SOLUTION_KEY_RESULT, slots: { [SLOT_ANSWER]: numberSlot(answer) } },
+  ];
+}
+
+export const roundEstimateFamily: GeneratorFamily<RoundEstimateParams> = {
+  family: ROUND_ESTIMATE_FAMILY,
+  familyRev: ROUND_ESTIMATE_FAMILY_REV,
+  paramSchema: roundEstimateParamSchema,
+  forms: ROUND_ESTIMATE_FORMS,
+  choiceOnly: false,
+  representations: [],
+
+  answerSchema(params: RoundEstimateParams): AnswerSchema {
+    // One digit wider than the number: rounding 9,750 to the nearest hundred is
+    // 9,800, but rounding 9,950 is 10,000, and a field that could not hold it
+    // would tell the child which of the two kinds of item they had.
+    return { kind: "integer", digits: params.digits + 1, decimalPlaces: 0 };
+  },
+
+  difficultyOffset(params: RoundEstimateParams): Rational {
+    let b = mul(COEFF_DIGIT_OVER_TWO, rational(BigInt(params.digits - 2)));
+    b = ratAdd(b, mul(COEFF_PLACE, rational(BigInt(params.minPlace + params.maxPlace), 2n)));
+    if (params.ties) b = ratAdd(b, COEFF_TIES);
+    return b;
+  },
+
+  formOffset(): Rational {
+    return FORM_OFFSET_FREE_ENTRY;
+  },
+
+  generate(request: GenerateRequest<RoundEstimateParams>): Exercise {
+    const { skillId, level, seed, params, forms } = request;
+    const exerciseId = exerciseIdOf(ROUND_ESTIMATE_FAMILY, ROUND_ESTIMATE_FAMILY_REV, skillId, level, seed);
+    const rng = createRng(seedFrom(exerciseId));
+
+    const form = chooseForm(forms, ROUND_ESTIMATE_FORMS, rng);
+    const place = rng.nextInt(params.minPlace, params.maxPlace);
+    const value = drawNumber(params, place, rng);
+    const answer = roundHalfUp(value, pow10(place));
+    const term = placeTerm(place);
+    if (term === null) throw new InfeasibleLevelError(`no place name for place ${String(place)}`);
+
+    const base: Exercise = {
+      exerciseId,
+      skillId,
+      level,
+      seed,
+      family: ROUND_ESTIMATE_FAMILY,
+      familyRev: ROUND_ESTIMATE_FAMILY_REV,
+      form,
+      prompt: {
+        key: PROMPT_KEY_ROUND,
+        slots: { [SLOT_NUMBER]: numberSlot(value), [SLOT_PLACE]: termSlot(term) },
+      },
+      schema: { kind: "integer", digits: params.digits + 1, decimalPlaces: 0 },
+      answer: { canonical: { kind: "integer", value: rational(answer) }, alsoAccept: [] },
+      distractors: [],
+      check: { kind: "exact" },
+      solution: solutionFor(value, place, answer),
+    };
+
+    return { ...base, distractors: distractorsFor(ROUND_ESTIMATE_FAMILY, base) };
+  },
+
+  check(exercise: Exercise, submitted: AnswerValue): Verdict {
+    return judge(exercise, submitted);
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/roundEstimate/params.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/roundEstimate/params.ts
@@ -1,0 +1,46 @@
+/**
+ * `gen.number.round-estimate` parameters.
+ *
+ * The place a level rounds to is drawn from a range, so one row covers "round to
+ * the nearest ten or hundred" without two level tables. The validator rejects the
+ * two combinations that produce a question with nothing in it: rounding to a place
+ * at or above the number's own width (every answer is 0 or the number itself), and
+ * a tie level whose place leaves no digit to be the deciding five.
+ */
+
+import { MAX_WHOLE_DIGITS } from "../shared/draw.ts";
+import { reader } from "../shared/paramReader.ts";
+import type { ParamResult, ParamSchema } from "../../types/generator.ts";
+
+export type RoundEstimateParams = {
+  readonly digits: number;
+  /** Lowest place the level rounds to, counted from the units column. */
+  readonly minPlace: number;
+  readonly maxPlace: number;
+  /**
+   * Pose exact halfway numbers — 4,750 to the nearest hundred.
+   *
+   * Rounding half up is the convention; a level that never poses the tie never
+   * finds out whether the child holds it.
+   */
+  readonly ties: boolean;
+};
+
+export const MIN_DIGITS = 2;
+
+export const roundEstimateParamSchema: ParamSchema<RoundEstimateParams> = {
+  describe: "{ digits: 2..7, minPlace: 1..digits-1, maxPlace: minPlace..digits-1, ties: boolean }",
+
+  validate(raw: unknown): ParamResult<RoundEstimateParams> {
+    const read = reader(raw);
+    const digits = read.int("digits", MIN_DIGITS, MAX_WHOLE_DIGITS);
+    const minPlace = read.int("minPlace", 1, Math.max(1, digits - 1));
+    const maxPlace = read.int("maxPlace", 1, Math.max(1, digits - 1));
+    const ties = read.boolean("ties");
+
+    if (read.clean() && maxPlace < minPlace) {
+      read.reject("maxPlace", "maxPlace must be at least minPlace");
+    }
+    return read.finish({ digits, minPlace, maxPlace, ties });
+  },
+};

--- a/dynawalla/packs/shared/curriculum/src/generators/shared/build.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/shared/build.ts
@@ -1,0 +1,82 @@
+/**
+ * The three pieces of a generator family that are the same in every family, and
+ * were copied five times before they were extracted.
+ *
+ * - `judge` is `GeneratorFamily.check`. It goes through `answerAccepted`, not
+ *   `answerEquals`, so `AnswerSchema.fraction.equivalence` is a knob that does
+ *   something: a skill that accepts any equivalent writing of the answer says so on
+ *   its schema, and a checker that reached for the structural comparison would mark
+ *   every child who wrote `2/4` wrong on a skill that accepts it.
+ * - `distractorsFor` runs the family's mal-rules over a finished item.
+ * - `chooseForm` validates the binding's forms against the family's own list.
+ *
+ * `gen.arith.column-op` predates all three and keeps its own copies; it is not
+ * rewritten here because rewriting it would change nothing about its output and
+ * everything about its CG-16 hashes' provenance.
+ */
+
+import { answerAccepted, answerEquals } from "../../types/answer.ts";
+import type { AnswerValue } from "../../types/answer.ts";
+import type { Distractor, Exercise } from "../../types/exercise.ts";
+import type { FamilyId, FormId } from "../../types/ids.ts";
+import type { Verdict } from "../../types/generator.ts";
+import { classify, malRulesForFamily } from "../../malrules/registry.ts";
+import type { Rng } from "../../rng/rng.ts";
+import { InfeasibleLevelError } from "./errors.ts";
+
+/**
+ * `check`, for every family that has no reason to differ.
+ *
+ * A wrong answer that no mal-rule explains returns `{ correct: false }` with no
+ * misconception, which is the honest outcome and the one CURRICULUM.md asks for
+ * where the catalogue is thin: an unclassified error routes to a faded worked
+ * example rather than to a repair for a bug the child may not have.
+ */
+export function judge(exercise: Exercise, submitted: AnswerValue): Verdict {
+  if (answerAccepted(exercise.schema, exercise.answer.canonical, submitted)) return { correct: true };
+  for (const accepted of exercise.answer.alsoAccept) {
+    if (answerAccepted(exercise.schema, accepted, submitted)) return { correct: true };
+  }
+  const misconception = classify(exercise, submitted);
+  return misconception === null ? { correct: false } : { correct: false, misconception };
+}
+
+/**
+ * Every mal-rule output this item admits, as distractors.
+ *
+ * Two exclusions, and the second one is the one that is easy to get wrong. A
+ * buggy procedure that lands on the right answer is not a distractor — but "the
+ * right answer" here means *what the checker would accept*, not what
+ * `answerEquals` says. On a schema that accepts any equivalent fraction, a
+ * mal-rule output of `2/4` against a canonical `1/2` is a distractor the family's
+ * own checker marks correct, which is exactly the contradiction CG-11 fails on.
+ */
+export function distractorsFor(family: FamilyId, exercise: Exercise): Distractor[] {
+  const out: Distractor[] = [];
+  for (const rule of malRulesForFamily(family)) {
+    if (!rule.applies(exercise)) continue;
+    const produced = rule.apply(exercise);
+    if (produced === null) continue;
+    if (answerAccepted(exercise.schema, exercise.answer.canonical, produced)) continue;
+    if (out.some((existing) => answerEquals(existing.value, produced))) continue;
+    out.push({ value: produced, misconception: rule.id });
+  }
+  return out;
+}
+
+/**
+ * The form this seed draws.
+ *
+ * A binding that names a form the family cannot emit is a curriculum error that
+ * CG-7 reports, and this is where it is detected: the alternative is a family that
+ * silently substitutes its default and a level that never serves the form its row
+ * claims.
+ */
+export function chooseForm(forms: readonly FormId[], allowed: readonly string[], rng: Rng): FormId {
+  const first = forms[0];
+  if (first === undefined) throw new InfeasibleLevelError("binding declares no forms");
+  for (const form of forms) {
+    if (!allowed.includes(form)) throw new InfeasibleLevelError(`unknown form ${JSON.stringify(form)}`);
+  }
+  return forms.length === 1 ? first : rng.pick(forms);
+}

--- a/dynawalla/packs/shared/curriculum/src/generators/shared/draw.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/shared/draw.ts
@@ -1,0 +1,84 @@
+/**
+ * Drawing whole numbers, exactly.
+ *
+ * `Rng.nextInt` works in `number` because rejection sampling needs a uint32 range,
+ * and every quantity a generator writes down is a `bigint` or a `Rational`. These
+ * are the two conversions between those worlds, in one place, with the bound that
+ * makes them safe stated as a constant rather than assumed.
+ *
+ * `MAX_WHOLE_DIGITS` is 7 because `nextInt` rejects a range wider than a uint32:
+ * eight digits spans 90,000,000, which is fine, but nine spans 900,000,000 and the
+ * next step after that does not fit. Seven is well inside the bound, is more than
+ * elementary arithmetic ever needs, and makes the failure a validator message
+ * rather than a `RangeError` from three layers down.
+ */
+
+import { pow10 } from "../../math/rational.ts";
+import type { Rng } from "../../rng/rng.ts";
+import { InfeasibleLevelError } from "./errors.ts";
+
+export const MAX_WHOLE_DIGITS = 7;
+
+/** How many decimal digits `value` is written with. `0` is one digit. */
+export function digitCount(value: bigint): number {
+  const magnitude = value < 0n ? -value : value;
+  return magnitude.toString().length;
+}
+
+/**
+ * A whole number written with exactly `digits` digits — no leading zero, so a
+ * 4-digit draw is 1000..9999 and never 0472.
+ */
+export function drawWithDigits(rng: Rng, digits: number): bigint {
+  if (digits < 1 || digits > MAX_WHOLE_DIGITS) {
+    throw new InfeasibleLevelError(`drawWithDigits: ${String(digits)} digits is outside 1..${String(MAX_WHOLE_DIGITS)}`);
+  }
+  if (digits === 1) return BigInt(rng.nextInt(1, 9));
+  const lo = pow10(digits - 1);
+  const hi = pow10(digits) - 1n;
+  return lo + BigInt(rng.nextInt(0, Number(hi - lo)));
+}
+
+/** A whole number in `[lo, hi]`, both inclusive. */
+export function drawBetween(rng: Rng, lo: bigint, hi: bigint): bigint {
+  if (hi < lo) {
+    throw new InfeasibleLevelError(`drawBetween: empty range ${lo.toString()}..${hi.toString()}`);
+  }
+  return lo + BigInt(rng.nextInt(0, Number(hi - lo)));
+}
+
+/**
+ * A whole number in `[lo, hi]` that is not `forbidden`.
+ *
+ * Drawn by picking from the range with one value removed rather than by retrying,
+ * so the draw count is fixed and the exercise stream does not depend on how many
+ * rejections happened — a retry loop here would make `Rng.draws()` (and therefore
+ * every later draw) depend on the value it rejected.
+ */
+export function drawBetweenExcluding(rng: Rng, lo: bigint, hi: bigint, forbidden: bigint): bigint {
+  if (forbidden < lo || forbidden > hi) return drawBetween(rng, lo, hi);
+  if (hi === lo) throw new InfeasibleLevelError("drawBetweenExcluding: the range holds only the forbidden value");
+  const drawn = drawBetween(rng, lo, hi - 1n);
+  return drawn >= forbidden ? drawn + 1n : drawn;
+}
+
+/**
+ * The digits of `value`, most significant first. Non-negative values only.
+ *
+ * Both orders are here rather than one each in the two families that first needed
+ * them: which end a digit array starts at is the thing this package is most likely
+ * to get wrong twice, and `gen.arith.column-op`'s own header records a drift
+ * between two copies of a digit-wise procedure that shipped a broken walkthrough.
+ */
+export function digitsOf(value: bigint): number[] {
+  if (value < 0n) throw new RangeError("digitsOf: negative value");
+  return value
+    .toString()
+    .split("")
+    .map((character) => Number(character));
+}
+
+/** The digits of `value`, units first — the order a column algorithm runs in. */
+export function littleEndianDigits(value: bigint): number[] {
+  return digitsOf(value).reverse();
+}

--- a/dynawalla/packs/shared/curriculum/src/generators/shared/errors.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/shared/errors.ts
@@ -1,0 +1,14 @@
+/**
+ * The one error a generator family throws when a validated parameter set turns out
+ * to admit no item.
+ *
+ * `gen.arith.column-op` declares its own `InfeasibleParamsError` for the same
+ * purpose. It is not re-used here on purpose: that class is exported from the
+ * column-op family module and is part of that family's published surface, and a
+ * second family importing it would make every later family depend on the first one
+ * that happened to need an error class. This is the shared one; column-op keeps its
+ * own name for compatibility with the app code that already catches it.
+ */
+
+/** A validated parameter set that no draw can satisfy. Always a bug, never input. */
+export class InfeasibleLevelError extends Error {}

--- a/dynawalla/packs/shared/curriculum/src/generators/shared/fractions.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/shared/fractions.ts
@@ -1,0 +1,95 @@
+/**
+ * Written fractions, and the arithmetic on them that keeps the writing.
+ *
+ * `Rational` normalizes — `2/4` and `1/2` are the same value and the same object.
+ * A fraction *answer* is not a value: on `simplify-to-lowest-terms`, `2/4` and
+ * `1/2` are two different answers and exactly one of them is right. So every
+ * fraction family works in written `(num, den, whole)` triples and converts to
+ * `Rational` only to assert that the written answer has the value exact arithmetic
+ * says it should.
+ *
+ * Nothing here reduces unless it is asked to.
+ */
+
+import { rational } from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import type { AnswerSchema, AnswerValue, FractionEquivalence } from "../../types/answer.ts";
+
+/** A fraction as it is written down: numerator, denominator, optional whole part. */
+export type WrittenFraction = {
+  readonly whole: bigint;
+  readonly num: bigint;
+  readonly den: bigint;
+};
+
+export function gcd(a: bigint, b: bigint): bigint {
+  let x = a < 0n ? -a : a;
+  let y = b < 0n ? -b : b;
+  while (y !== 0n) {
+    const t = x % y;
+    x = y;
+    y = t;
+  }
+  return x;
+}
+
+export function lcm(a: bigint, b: bigint): bigint {
+  if (a === 0n || b === 0n) throw new RangeError("lcm: zero has no least common multiple");
+  const divisor = gcd(a, b);
+  return (a / divisor) * b;
+}
+
+/** `num/den` in lowest terms, denominator positive. */
+export function reduce(num: bigint, den: bigint): { num: bigint; den: bigint } {
+  if (den === 0n) throw new RangeError("reduce: zero denominator");
+  const sign = den < 0n ? -1n : 1n;
+  const n = num * sign;
+  const d = den * sign;
+  if (n === 0n) return { num: 0n, den: 1n };
+  const divisor = gcd(n, d);
+  return { num: n / divisor, den: d / divisor };
+}
+
+export function isReduced(num: bigint, den: bigint): boolean {
+  return gcd(num, den) === 1n;
+}
+
+/** The exact value of a written fraction. Non-negative parts only — see `answer.ts`. */
+export function valueOf(written: WrittenFraction): Rational {
+  return rational(written.whole * written.den + written.num, written.den);
+}
+
+/** The `AnswerValue` for a written fraction. `whole` is omitted when it is zero. */
+export function fractionAnswer(written: WrittenFraction): AnswerValue {
+  return written.whole === 0n
+    ? { kind: "fraction", num: written.num, den: written.den }
+    : { kind: "fraction", num: written.num, den: written.den, whole: written.whole };
+}
+
+/**
+ * The schema for a fraction answer.
+ *
+ * `equivalence` defaults to `as-written`, which is the strict reading and the only
+ * safe default: a skill that accepts any equivalent form has to say so, and a skill
+ * that forgot to say so marks nothing wrong that should have been right.
+ */
+export function fractionSchema(
+  parts: readonly ("num" | "den" | "whole")[],
+  equivalence: FractionEquivalence = "as-written",
+): AnswerSchema {
+  return { kind: "fraction", parts, equivalence };
+}
+
+export const PROPER_PARTS = ["num", "den"] as const;
+export const MIXED_PARTS = ["whole", "num", "den"] as const;
+
+/** `whole + num/den` written as a single improper fraction, unreduced. */
+export function toImproper(written: WrittenFraction): WrittenFraction {
+  return { whole: 0n, num: written.whole * written.den + written.num, den: written.den };
+}
+
+/** `num/den` written as a mixed number, unreduced. Requires `den > 0`. */
+export function toMixed(num: bigint, den: bigint): WrittenFraction {
+  if (den <= 0n) throw new RangeError("toMixed: denominator must be positive");
+  return { whole: num / den, num: num % den, den };
+}

--- a/dynawalla/packs/shared/curriculum/src/generators/shared/paramReader.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/shared/paramReader.ts
@@ -1,0 +1,82 @@
+/**
+ * A small reader for `ParamSchema.validate`.
+ *
+ * Every family validates the same four shapes — a bounded integer, a bounded
+ * bigint-free count, a string from a closed set, a boolean — and the first two
+ * families that wrote it by hand disagreed about whether a missing key was
+ * `undefined` or an error. The reader settles that once: a missing key, a key of
+ * the wrong type and a key out of range are all *issues*, all reported together,
+ * and `finish` refuses to hand back a value while any issue stands.
+ *
+ * Collecting rather than throwing matters for the validator's output: CG-7 prints
+ * every issue a binding has, and a reader that threw on the first one would make a
+ * six-field mistake take six runs to fix.
+ */
+
+import type { ParamIssue, ParamResult } from "../../types/generator.ts";
+
+export type Reader = {
+  /** A safe integer in `[lo, hi]`. Returns `lo` after recording an issue. */
+  int(path: string, lo: number, hi: number): number;
+  /** One of `allowed`. Returns the first allowed value after recording an issue. */
+  choice<T extends string>(path: string, allowed: readonly T[]): T;
+  boolean(path: string): boolean;
+  /** Record a cross-field issue the individual readers cannot see. */
+  reject(path: string, message: string): void;
+  /** True when nothing has gone wrong yet, so cross-field checks can be skipped. */
+  clean(): boolean;
+  finish<P>(value: P): ParamResult<P>;
+};
+
+export function reader(raw: unknown): Reader {
+  const issues: ParamIssue[] = [];
+  const record: Record<string, unknown> | null =
+    typeof raw === "object" && raw !== null ? (raw as Record<string, unknown>) : null;
+  if (record === null) issues.push({ path: "", message: "params must be an object" });
+
+  const reject = (path: string, message: string): void => {
+    issues.push({ path, message });
+  };
+
+  return {
+    int(path: string, lo: number, hi: number): number {
+      const value = record?.[path];
+      if (typeof value !== "number" || !Number.isSafeInteger(value)) {
+        reject(path, `${path} must be an integer`);
+        return lo;
+      }
+      if (value < lo || value > hi) {
+        reject(path, `${path} must be ${String(lo)}..${String(hi)}, got ${String(value)}`);
+        return lo;
+      }
+      return value;
+    },
+
+    choice<T extends string>(path: string, allowed: readonly T[]): T {
+      const value = record?.[path];
+      const first = allowed[0];
+      if (first === undefined) throw new RangeError(`choice: ${path} has no allowed values`);
+      if (typeof value !== "string" || !(allowed as readonly string[]).includes(value)) {
+        reject(path, `${path} must be one of ${allowed.join(", ")}`);
+        return first;
+      }
+      return value as T;
+    },
+
+    boolean(path: string): boolean {
+      const value = record?.[path];
+      if (typeof value !== "boolean") {
+        reject(path, `${path} must be a boolean`);
+        return false;
+      }
+      return value;
+    },
+
+    reject,
+    clean: () => issues.length === 0,
+
+    finish<P>(value: P): ParamResult<P> {
+      return issues.length === 0 ? { ok: true, value } : { ok: false, issues };
+    },
+  };
+}

--- a/dynawalla/packs/shared/curriculum/src/generators/shared/placeTerms.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/shared/placeTerms.ts
@@ -1,0 +1,40 @@
+/**
+ * Place names, indexed from the units column.
+ *
+ * One key per place rather than a generated `dw.term.place.10-3`: a place name is
+ * a word in every language this ships in, several of them do not build it by
+ * exponent, and a key a translator cannot see is a key nobody translates.
+ *
+ * Shared because two families name a place — the one that asks what a digit in a
+ * place is worth, and the one that says which place two numbers first differ in —
+ * and two spellings of one `LocKey` is a template nobody translated twice.
+ */
+
+import { locKey } from "../../types/ids.ts";
+import type { LocKey } from "../../types/ids.ts";
+
+export const PLACE_TERM_KEYS: readonly LocKey[] = [
+  locKey("dw.term.place.ones"),
+  locKey("dw.term.place.tens"),
+  locKey("dw.term.place.hundreds"),
+  locKey("dw.term.place.thousands"),
+  locKey("dw.term.place.ten-thousands"),
+  locKey("dw.term.place.hundred-thousands"),
+  locKey("dw.term.place.millions"),
+];
+
+/** Places after the point, indexed from the first one. */
+export const DECIMAL_PLACE_TERM_KEYS: readonly LocKey[] = [
+  locKey("dw.term.place.tenths"),
+  locKey("dw.term.place.hundredths"),
+  locKey("dw.term.place.thousandths"),
+  locKey("dw.term.place.ten-thousandths"),
+];
+
+export const ALL_PLACE_TERM_KEYS = [...PLACE_TERM_KEYS, ...DECIMAL_PLACE_TERM_KEYS] as const;
+
+/** The term for a place, or `null` above the largest one this program names. */
+export function placeTerm(place: number): LocKey | null {
+  const key = place >= 0 ? PLACE_TERM_KEYS[place] : DECIMAL_PLACE_TERM_KEYS[-place - 1];
+  return key ?? null;
+}

--- a/dynawalla/packs/shared/curriculum/src/generators/shared/slots.ts
+++ b/dynawalla/packs/shared/curriculum/src/generators/shared/slots.ts
@@ -1,0 +1,56 @@
+/**
+ * Prompt and solution slots, built in one place.
+ *
+ * Seven families wrote their own `numberSlot`, three wrote `countSlot`, two wrote
+ * `fractionSlot`, and one wrote `numberSlot` and `wholeSlot` side by side with
+ * identical bodies. They agreed, which is the problem: nothing made them, and a
+ * slot is the boundary between a generator and a translated template — the place
+ * a silent disagreement about whether a digit is a `number` or a `count` would
+ * show up as a plural category chosen by whichever family drew the item.
+ *
+ * `gen.arith.column-op` keeps its own two, unchanged: they predate this module and
+ * rewriting them would move nothing except the provenance of its CG-16 hashes.
+ */
+
+import { rational } from "../../math/rational.ts";
+import type { Rational } from "../../math/rational.ts";
+import type { PromptSlot } from "../../types/exercise.ts";
+import type { LocKey } from "../../types/ids.ts";
+
+/** A whole number, written exactly. The common case. */
+export function numberSlot(value: bigint): PromptSlot {
+  return { kind: "number", value: rational(value), decimalPlaces: 0 };
+}
+
+/**
+ * A number written to a fixed number of decimal places.
+ *
+ * The places ride along because `1.50` and `1.5` are the same number and different
+ * notation, and the number layer needs the notation rather than the value's
+ * denominator.
+ */
+export function decimalSlot(value: Rational, decimalPlaces: number): PromptSlot {
+  return { kind: "number", value, decimalPlaces };
+}
+
+/**
+ * A counted quantity — seven *hundreds*, column *three*.
+ *
+ * Separate from `numberSlot` because it selects a CLDR plural category (CG-14),
+ * which is a fact about the sentence and not about the number.
+ */
+export function countSlot(value: number | bigint): PromptSlot {
+  return { kind: "count", value: Number(value) };
+}
+
+/** A written fraction. `whole` is omitted when it is zero, never written as `0`. */
+export function fractionSlot(num: bigint, den: bigint, whole = 0n): PromptSlot {
+  return whole === 0n
+    ? { kind: "fraction", num, den }
+    : { kind: "fraction", num, den, whole };
+}
+
+/** A word the template needs and the generator must not spell. */
+export function termSlot(key: LocKey): PromptSlot {
+  return { kind: "term", key };
+}

--- a/dynawalla/packs/shared/curriculum/src/graph/domains/add.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/domains/add.ts
@@ -31,6 +31,7 @@ import {
 import { capabilityTag, locKey, skillId } from "../../types/ids.ts";
 import type { SkillNode } from "../../types/skill.ts";
 
+const CAP_COLUMN_ALIGN = capabilityTag("cap.arith.column-align");
 const CAP_SUB_REGROUP = capabilityTag("cap.arith.sub-regroup");
 const CAP_SUB_ACROSS_ZERO = capabilityTag("cap.arith.sub-across-zero");
 const CAP_ADD_CARRY = capabilityTag("cap.arith.add-carry");
@@ -63,6 +64,10 @@ function b(hundredths: bigint) {
   return rational(hundredths, 100n);
 }
 
+export const SKILL_ADD_NO_REGROUP = skillId("dw.add.column.add-no-regroup");
+export const SKILL_SUBTRACT_NO_REGROUP = skillId("dw.add.column.subtract-no-regroup");
+export const SKILL_ADD_SHORT_ADDEND = skillId("dw.add.regroup.add-short-addend");
+export const SKILL_SUBTRACT_SHORT_SUBTRAHEND = skillId("dw.add.regroup.subtract-short-subtrahend");
 export const SKILL_SUBTRACT_MULTIDIGIT = skillId("dw.add.regroup.subtract-multidigit");
 export const SKILL_SUBTRACT_ACROSS_ZERO = skillId("dw.add.regroup.subtract-across-zero");
 export const SKILL_ADD_MULTIDIGIT = skillId("dw.add.regroup.add-multidigit");
@@ -70,7 +75,10 @@ export const SKILL_SUBTRACT_TENTHS = skillId("dw.add.regroup.subtract-tenths");
 
 const subtractMultidigit: SkillNode = {
   id: SKILL_SUBTRACT_MULTIDIGIT,
-  rev: 1,
+  // rev 2: gained the prerequisite it always had and never declared. Aligning the
+  // columns and subtracting without regrouping is not the same skill as regrouping,
+  // and a graph whose spine started at the harder one had no entry point.
+  rev: 2,
   status: "active",
   title: locKey("dw.skill.add.regroup.subtract-multidigit.title"),
   learnerGoal: locKey("dw.skill.add.regroup.subtract-multidigit.goal"),
@@ -82,7 +90,7 @@ const subtractMultidigit: SkillNode = {
   proficiency: { conceptual: 2, procedural: 3, strategic: 1, adaptive: 1 },
   classification: "procedural",
   fluencyTarget: { p50Ms: 12000 },
-  prereqs: [],
+  prereqs: [{ kind: "requires", to: SKILL_SUBTRACT_NO_REGROUP }],
   difficulty: {
     b: b(-50n),
     levels: [b(5n), b(35n), b(90n), b(120n)],
@@ -101,7 +109,7 @@ const subtractMultidigit: SkillNode = {
     params: [sub(2, 2, 1, 0), sub(3, 3, 1, 0), sub(3, 3, 2, 0), sub(4, 4, 2, 0)],
     forms: [FORM_FREE_ENTRY, FORM_COLUMN],
     minVariants: 24,
-    consumes: [],
+    consumes: [CAP_COLUMN_ALIGN],
   },
   probes: [
     { level: 0, seed: 1, purpose: "entry" },
@@ -152,7 +160,8 @@ const subtractAcrossZero: SkillNode = {
 
 const addMultidigit: SkillNode = {
   id: SKILL_ADD_MULTIDIGIT,
-  rev: 1,
+  /** rev 2: same as its sibling — the non-regrouping column sum is its prerequisite. */
+  rev: 2,
   status: "active",
   title: locKey("dw.skill.add.regroup.add-multidigit.title"),
   learnerGoal: locKey("dw.skill.add.regroup.add-multidigit.goal"),
@@ -164,7 +173,7 @@ const addMultidigit: SkillNode = {
   proficiency: { conceptual: 2, procedural: 3, strategic: 1, adaptive: 1 },
   classification: "procedural",
   fluencyTarget: { p50Ms: 12000 },
-  prereqs: [],
+  prereqs: [{ kind: "requires", to: SKILL_ADD_NO_REGROUP }],
   difficulty: {
     b: b(-60n),
     levels: [b(-5n), b(25n), b(80n)],
@@ -177,7 +186,7 @@ const addMultidigit: SkillNode = {
     params: [plus(2, 2, 1), plus(3, 3, 1), plus(3, 3, 2)],
     forms: [FORM_FREE_ENTRY, FORM_COLUMN],
     minVariants: 24,
-    consumes: [],
+    consumes: [CAP_COLUMN_ALIGN],
   },
   probes: [{ level: 0, seed: 1, purpose: "entry" }],
   provides: [CAP_ADD_CARRY],
@@ -221,9 +230,159 @@ const subtractTenths: SkillNode = {
   provides: [],
 };
 
+/**
+ * The two rows the spine was missing: line the columns up and subtract, with
+ * nothing to regroup.
+ *
+ * Both are `active`, and they are the only rows this change promotes. Column-op is
+ * the one family whose *question* the app can draw — `problem.ts` reads its two
+ * template keys and `ProblemSlate` writes the operands — so it is the one family
+ * whose rows can honestly go active today. Everything else this change adds is
+ * `draft` behind `render/prompts.ts`.
+ *
+ * Neither row carries a mal-rule, and the reason is in `malrules/columnOp.ts`:
+ * with nothing to regroup, taking the smaller digit from the larger *is* the
+ * correct procedure, so `applies()` is false on every item here. A level table
+ * that declared it would be claiming a diagnosis its items can never emit.
+ */
+const subtractNoRegroup: SkillNode = {
+  id: SKILL_SUBTRACT_NO_REGROUP,
+  rev: 1,
+  status: "active",
+  title: locKey("dw.skill.add.column.subtract-no-regroup.title"),
+  learnerGoal: locKey("dw.skill.add.column.subtract-no-regroup.goal"),
+  domain: "add",
+  cluster: "column",
+  bigIdeas: [locKey("dw.idea.place-value.line-up-the-columns")],
+  gradeBand: { earliest: 1, nominal: 1, latest: 2 },
+  strandRole: "spine",
+  proficiency: { conceptual: 1, procedural: 3, strategic: 0, adaptive: 1 },
+  classification: "procedural",
+  fluencyTarget: { p50Ms: 10000 },
+  prereqs: [],
+  difficulty: { b: b(-90n), levels: [b(-90n), b(-60n), b(-30n)] },
+  misconceptions: [],
+  representations: { required: [], optional: [REP_COUNTING_BOARD] },
+  generator: {
+    family: COLUMN_OP_FAMILY,
+    familyRev: COLUMN_OP_FAMILY_REV,
+    params: [sub(2, 2, 0, 0), sub(3, 3, 0, 0), sub(4, 4, 0, 0)],
+    forms: [FORM_FREE_ENTRY, FORM_COLUMN],
+    minVariants: 24,
+    consumes: [],
+  },
+  probes: [{ level: 0, seed: 1, purpose: "entry" }],
+  provides: [CAP_COLUMN_ALIGN],
+  standards: { ccss: ["1.NBT.C.6", "2.NBT.B.5"] },
+};
+
+const addNoRegroup: SkillNode = {
+  id: SKILL_ADD_NO_REGROUP,
+  rev: 1,
+  status: "active",
+  title: locKey("dw.skill.add.column.add-no-regroup.title"),
+  learnerGoal: locKey("dw.skill.add.column.add-no-regroup.goal"),
+  domain: "add",
+  cluster: "column",
+  bigIdeas: [locKey("dw.idea.place-value.line-up-the-columns")],
+  gradeBand: { earliest: 1, nominal: 1, latest: 2 },
+  strandRole: "spine",
+  proficiency: { conceptual: 1, procedural: 3, strategic: 0, adaptive: 1 },
+  classification: "procedural",
+  fluencyTarget: { p50Ms: 10000 },
+  prereqs: [],
+  difficulty: { b: b(-90n), levels: [b(-90n), b(-60n), b(-30n)] },
+  misconceptions: [],
+  representations: { required: [], optional: [REP_COUNTING_BOARD] },
+  generator: {
+    family: COLUMN_OP_FAMILY,
+    familyRev: COLUMN_OP_FAMILY_REV,
+    params: [plus(2, 2, 0), plus(3, 3, 0), plus(4, 4, 0)],
+    forms: [FORM_FREE_ENTRY, FORM_COLUMN],
+    minVariants: 24,
+    consumes: [],
+  },
+  probes: [{ level: 0, seed: 1, purpose: "entry" }],
+  provides: [CAP_COLUMN_ALIGN],
+  standards: { ccss: ["1.NBT.C.4", "2.NBT.B.5"] },
+};
+
+/**
+ * A short second operand under a long first one — `4,003 − 87`.
+ *
+ * A separate row rather than a level of the multidigit ones because the thing that
+ * goes wrong is different: the columns that have no digit underneath them are the
+ * ones children misalign, and `mis.add.misaligned-columns` is the mal-rule this row
+ * is waiting for. It is not shipped here — the buggy procedure needs to know where
+ * the child *wrote* the operand, which the exercise contract does not carry.
+ */
+const subtractShortSubtrahend: SkillNode = {
+  id: SKILL_SUBTRACT_SHORT_SUBTRAHEND,
+  rev: 1,
+  status: "active",
+  title: locKey("dw.skill.add.regroup.subtract-short-subtrahend.title"),
+  learnerGoal: locKey("dw.skill.add.regroup.subtract-short-subtrahend.goal"),
+  domain: "add",
+  cluster: "regroup",
+  bigIdeas: [locKey("dw.idea.place-value.line-up-the-columns"), locKey("dw.idea.place-value.regroup")],
+  gradeBand: { earliest: 2, nominal: 3, latest: 4 },
+  strandRole: "fluency",
+  proficiency: { conceptual: 2, procedural: 3, strategic: 1, adaptive: 2 },
+  classification: "procedural",
+  prereqs: [{ kind: "requires", to: SKILL_SUBTRACT_MULTIDIGIT }],
+  difficulty: { b: b(-50n), levels: [b(65n), b(150n), b(235n)] },
+  misconceptions: [MIS_SMALLER_FROM_LARGER, MIS_BORROW_ACROSS_ZERO],
+  representations: { required: [], optional: [REP_COUNTING_BOARD] },
+  generator: {
+    family: COLUMN_OP_FAMILY,
+    familyRev: COLUMN_OP_FAMILY_REV,
+    params: [sub(4, 2, 1, 0), sub(5, 3, 2, 0), sub(6, 3, 3, 0)],
+    forms: [FORM_FREE_ENTRY, FORM_COLUMN],
+    minVariants: 24,
+    consumes: [CAP_SUB_REGROUP],
+  },
+  probes: [],
+  provides: [],
+  standards: { ccss: ["3.NBT.A.2", "4.NBT.B.4"] },
+};
+
+const addShortAddend: SkillNode = {
+  id: SKILL_ADD_SHORT_ADDEND,
+  rev: 1,
+  status: "active",
+  title: locKey("dw.skill.add.regroup.add-short-addend.title"),
+  learnerGoal: locKey("dw.skill.add.regroup.add-short-addend.goal"),
+  domain: "add",
+  cluster: "regroup",
+  bigIdeas: [locKey("dw.idea.place-value.line-up-the-columns"), locKey("dw.idea.place-value.regroup")],
+  gradeBand: { earliest: 2, nominal: 3, latest: 4 },
+  strandRole: "fluency",
+  proficiency: { conceptual: 2, procedural: 3, strategic: 1, adaptive: 2 },
+  classification: "procedural",
+  prereqs: [{ kind: "requires", to: SKILL_ADD_MULTIDIGIT }],
+  difficulty: { b: b(-60n), levels: [b(55n), b(140n), b(195n)] },
+  misconceptions: [MIS_CARRY_DROPPED],
+  representations: { required: [], optional: [REP_COUNTING_BOARD] },
+  generator: {
+    family: COLUMN_OP_FAMILY,
+    familyRev: COLUMN_OP_FAMILY_REV,
+    params: [plus(4, 2, 1), plus(5, 2, 2), plus(5, 3, 3)],
+    forms: [FORM_FREE_ENTRY, FORM_COLUMN],
+    minVariants: 24,
+    consumes: [CAP_ADD_CARRY],
+  },
+  probes: [],
+  provides: [],
+  standards: { ccss: ["3.NBT.A.2", "4.NBT.B.4"] },
+};
+
 export const addDomainNodes: readonly SkillNode[] = [
+  addNoRegroup,
+  subtractNoRegroup,
   subtractMultidigit,
   subtractAcrossZero,
   addMultidigit,
+  addShortAddend,
+  subtractShortSubtrahend,
   subtractTenths,
 ];

--- a/dynawalla/packs/shared/curriculum/src/graph/domains/add.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/domains/add.ts
@@ -235,10 +235,16 @@ const subtractTenths: SkillNode = {
  * nothing to regroup.
  *
  * Both are `active`, and they are the only rows this change promotes. Column-op is
- * the one family whose *question* the app can draw — `problem.ts` reads its two
- * template keys and `ProblemSlate` writes the operands — so it is the one family
- * whose rows can honestly go active today. Everything else this change adds is
- * `draft` behind `render/prompts.ts`.
+ * the one family whose *question* a renderer ever read — it was the only prompt
+ * template the host's practice loop matched — so it is the one family whose rows
+ * sit alongside the column-op rows already active on trunk. Everything else this
+ * change adds is `draft` behind `render/prompts.ts`.
+ *
+ * `active` is a statement about the curriculum side being complete, and since
+ * ADR-0022 it is nothing more than that: the loop that drew column-op went with
+ * the host, and no pack has replaced it. CG-8 warns on every row in the graph for
+ * that reason and fails under `--strict-renderers`, which is what stops a release
+ * in which nothing draws a question.
  *
  * Neither row carries a mal-rule, and the reason is in `malrules/columnOp.ts`:
  * with nothing to regroup, taking the smaller digit from the larger *is* the

--- a/dynawalla/packs/shared/curriculum/src/graph/domains/alg.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/domains/alg.ts
@@ -1,0 +1,240 @@
+/**
+ * Domain `alg` — equality and early algebra.
+ *
+ * **This domain starts at grade 1**, which is the one place CURRICULUM.md departs
+ * from every framework it otherwise follows, and the evidence is specific: on
+ * `8 + 4 = ☐ + 5` roughly 5% of grade 1–2 children answer 7, in one sample all 145
+ * sixth graders answered 12 or 17, and equal-sign knowledge at second grade predicts
+ * fourth-grade algebra competence. A child who reads `=` as "and now write the
+ * answer" is not making an arithmetic mistake, and waiting until grade 6 to find out
+ * is how it survives to grade 6.
+ *
+ * Every row is `draft` — the generator is complete, the app cannot draw the
+ * question. See `render/prompts.ts`. **Every row in this domain is also under
+ * CG-10's variant-space floor at L0**, and here the conflict is real rather than a
+ * thin draw: a one-digit missing addend has 9 x 9 = 81 items in the world and the
+ * floor is 975. These rows need more shapes or a reconciled floor, not a field
+ * flip. See `promotionBlockers.ts`.
+ *
+ * `dw.alg.equality.balance-meaning` is the one row in this change that requires a
+ * representation: the balance scale, whose renderer **does** exist (PR-2.12). It is
+ * declared `required` rather than `optional` because on that row the scale is the
+ * skill — two pans that do not balance, and the question is what makes them.
+ */
+
+import { rational } from "../../math/rational.ts";
+import type { MissingOperandParams } from "../../generators/missingOperand/params.ts";
+import {
+  FORM_FREE_ENTRY as ALG_FORM,
+  MISSING_OPERAND_FAMILY,
+  MISSING_OPERAND_FAMILY_REV,
+  REP_BALANCE_SCALE,
+} from "../../generators/missingOperand/constants.ts";
+import { MIS_ADD_ALL_NUMBERS, MIS_EQUALS_AS_OPERATOR } from "../../malrules/missingOperand.ts";
+import { capabilityTag, locKey, skillId } from "../../types/ids.ts";
+import type { SkillNode } from "../../types/skill.ts";
+
+export const CAP_MISSING_ADDEND = capabilityTag("cap.alg.missing-addend");
+export const CAP_EQUALS_IS_A_RELATION = capabilityTag("cap.alg.equals-is-a-relation");
+
+function b(hundredths: bigint) {
+  return rational(hundredths, 100n);
+}
+
+function sentence(
+  shape: MissingOperandParams["shape"],
+  digits: number,
+  balance = false,
+): MissingOperandParams {
+  return { shape, digits, balance };
+}
+
+export const SKILL_MISSING_ADDEND = skillId("dw.alg.equality.missing-addend");
+export const SKILL_BALANCE_MEANING = skillId("dw.alg.equality.balance-meaning");
+export const SKILL_MISSING_SUBTRAHEND = skillId("dw.alg.equality.missing-subtrahend");
+export const SKILL_UNKNOWN_MINUEND = skillId("dw.alg.equality.unknown-minuend");
+export const SKILL_MISSING_FACTOR = skillId("dw.alg.equality.missing-factor");
+
+const missingAddend: SkillNode = {
+  id: SKILL_MISSING_ADDEND,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.alg.equality.missing-addend.title"),
+  learnerGoal: locKey("dw.skill.alg.equality.missing-addend.goal"),
+  domain: "alg",
+  cluster: "equality",
+  bigIdeas: [locKey("dw.idea.equality.the-two-sides-are-the-same")],
+  gradeBand: { earliest: 1, nominal: 1, latest: 3 },
+  strandRole: "spine",
+  proficiency: { conceptual: 2, procedural: 2, strategic: 2, adaptive: 1 },
+  classification: "procedural",
+  fluencyTarget: { p50Ms: 10000 },
+  prereqs: [],
+  difficulty: { b: b(-40n), levels: [b(-105n), b(-75n), b(-45n)] },
+  misconceptions: [MIS_ADD_ALL_NUMBERS],
+  representations: { required: [], optional: [REP_BALANCE_SCALE] },
+  generator: {
+    family: MISSING_OPERAND_FAMILY,
+    familyRev: MISSING_OPERAND_FAMILY_REV,
+    params: [sentence("add-unknown", 1), sentence("add-unknown", 2), sentence("add-unknown", 3)],
+    forms: [ALG_FORM],
+    minVariants: 40,
+    consumes: [],
+  },
+  probes: [{ level: 0, seed: 1, purpose: "entry" }],
+  provides: [CAP_MISSING_ADDEND],
+  standards: { ccss: ["1.OA.D.8", "2.OA.B.2"] },
+};
+
+/**
+ * `8 + 4 = ☐ + 5`, with the scale beside it.
+ *
+ * Grade 1, deliberately. This is the row the domain exists for, and it is the one
+ * item in the program where the two documented wrong answers — the total of the
+ * complete side, and every number on the card added up — are both produced by
+ * running a procedure rather than by guessing at one.
+ */
+const balanceMeaning: SkillNode = {
+  id: SKILL_BALANCE_MEANING,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.alg.equality.balance-meaning.title"),
+  learnerGoal: locKey("dw.skill.alg.equality.balance-meaning.goal"),
+  domain: "alg",
+  cluster: "equality",
+  bigIdeas: [
+    locKey("dw.idea.equality.the-two-sides-are-the-same"),
+    locKey("dw.idea.equality.equals-is-not-an-instruction"),
+  ],
+  gradeBand: { earliest: 1, nominal: 2, latest: 5 },
+  strandRole: "spine",
+  proficiency: { conceptual: 3, procedural: 1, strategic: 3, adaptive: 3 },
+  classification: "conceptual",
+  prereqs: [{ kind: "requires", to: SKILL_MISSING_ADDEND }],
+  difficulty: { b: b(-40n), levels: [b(-15n), b(15n), b(45n)] },
+  misconceptions: [MIS_EQUALS_AS_OPERATOR, MIS_ADD_ALL_NUMBERS],
+  // Required, not optional: on this row the scale is the skill. Its renderer
+  // exists (PR-2.12), which is why the requirement can be stated at all.
+  representations: { required: [REP_BALANCE_SCALE], optional: [] },
+  generator: {
+    family: MISSING_OPERAND_FAMILY,
+    familyRev: MISSING_OPERAND_FAMILY_REV,
+    params: [sentence("both-sides", 1, true), sentence("both-sides", 2, true), sentence("both-sides", 3, true)],
+    forms: [ALG_FORM],
+    minVariants: 40,
+    consumes: [CAP_MISSING_ADDEND],
+  },
+  probes: [
+    { level: 0, seed: 1, purpose: "entry" },
+    { level: 2, seed: 84, purpose: "promotion" },
+  ],
+  provides: [CAP_EQUALS_IS_A_RELATION],
+  standards: { ccss: ["1.OA.D.7", "3.OA.D.8"] },
+};
+
+const missingSubtrahend: SkillNode = {
+  id: SKILL_MISSING_SUBTRAHEND,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.alg.equality.missing-subtrahend.title"),
+  learnerGoal: locKey("dw.skill.alg.equality.missing-subtrahend.goal"),
+  domain: "alg",
+  cluster: "equality",
+  bigIdeas: [locKey("dw.idea.equality.the-two-sides-are-the-same")],
+  gradeBand: { earliest: 2, nominal: 3, latest: 4 },
+  strandRole: "spine",
+  proficiency: { conceptual: 2, procedural: 3, strategic: 2, adaptive: 2 },
+  classification: "procedural",
+  prereqs: [{ kind: "requires", to: SKILL_MISSING_ADDEND }],
+  difficulty: { b: b(-40n), levels: [b(-70n), b(-40n), b(-10n)] },
+  misconceptions: [MIS_ADD_ALL_NUMBERS],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: MISSING_OPERAND_FAMILY,
+    familyRev: MISSING_OPERAND_FAMILY_REV,
+    params: [sentence("sub-unknown", 1), sentence("sub-unknown", 2), sentence("sub-unknown", 3)],
+    forms: [ALG_FORM],
+    minVariants: 40,
+    consumes: [CAP_MISSING_ADDEND],
+  },
+  probes: [],
+  provides: [],
+  standards: { ccss: ["1.OA.D.8", "3.OA.D.8"] },
+};
+
+const unknownMinuend: SkillNode = {
+  id: SKILL_UNKNOWN_MINUEND,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.alg.equality.unknown-minuend.title"),
+  learnerGoal: locKey("dw.skill.alg.equality.unknown-minuend.goal"),
+  domain: "alg",
+  cluster: "equality",
+  bigIdeas: [locKey("dw.idea.equality.undoing-runs-both-ways")],
+  gradeBand: { earliest: 3, nominal: 4, latest: 5 },
+  strandRole: "bridge",
+  proficiency: { conceptual: 3, procedural: 2, strategic: 3, adaptive: 2 },
+  classification: "reasoning",
+  prereqs: [{ kind: "requires", to: SKILL_MISSING_SUBTRAHEND }],
+  difficulty: { b: b(-40n), levels: [b(-45n), b(-15n), b(15n)] },
+  // On `☐ − a = c`, adding every number on the card gives the correct answer, so
+  // the add-all rule is not instantiated here and this row declares nothing. A
+  // wrong answer is unclassified, which is the honest outcome.
+  misconceptions: [],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: MISSING_OPERAND_FAMILY,
+    familyRev: MISSING_OPERAND_FAMILY_REV,
+    params: [
+      sentence("sub-unknown-minuend", 1),
+      sentence("sub-unknown-minuend", 2),
+      sentence("sub-unknown-minuend", 3),
+    ],
+    forms: [ALG_FORM],
+    minVariants: 40,
+    consumes: [],
+  },
+  probes: [],
+  provides: [],
+  standards: { ccss: ["3.OA.D.8", "4.OA.A.3"] },
+};
+
+const missingFactor: SkillNode = {
+  id: SKILL_MISSING_FACTOR,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.alg.equality.missing-factor.title"),
+  learnerGoal: locKey("dw.skill.alg.equality.missing-factor.goal"),
+  domain: "alg",
+  cluster: "equality",
+  bigIdeas: [locKey("dw.idea.equality.undoing-runs-both-ways")],
+  gradeBand: { earliest: 3, nominal: 4, latest: 5 },
+  strandRole: "bridge",
+  proficiency: { conceptual: 3, procedural: 2, strategic: 3, adaptive: 2 },
+  classification: "reasoning",
+  prereqs: [{ kind: "requires", to: SKILL_MISSING_ADDEND }],
+  difficulty: { b: b(-40n), levels: [b(-25n), b(5n)] },
+  // `mis.alg.add-all-numbers` is not defined on a missing factor: nothing on the
+  // card is an addition, and a child reaching for one is not making this mistake.
+  misconceptions: [],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: MISSING_OPERAND_FAMILY,
+    familyRev: MISSING_OPERAND_FAMILY_REV,
+    params: [sentence("mul-unknown", 1), sentence("mul-unknown", 2)],
+    forms: [ALG_FORM],
+    minVariants: 40,
+    consumes: [],
+  },
+  probes: [],
+  provides: [],
+  standards: { ccss: ["3.OA.A.4", "4.OA.A.1"] },
+};
+
+export const algDomainNodes: readonly SkillNode[] = [
+  missingAddend,
+  balanceMeaning,
+  missingSubtrahend,
+  unknownMinuend,
+  missingFactor,
+];

--- a/dynawalla/packs/shared/curriculum/src/graph/domains/div.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/domains/div.ts
@@ -1,0 +1,205 @@
+/**
+ * Domain `div` — division, with the remainder taken seriously.
+ *
+ * `draft`, for the reason `ns.ts` states: the generator is complete and the app
+ * cannot draw the question. See `render/prompts.ts`. One level here needs a second
+ * thing before it can go active — `dw.div.whole.divide-exact` L0 is under CG-10's
+ * variant-space floor. See `promotionBlockers.ts`.
+ *
+ * The four rows are the four things a remainder can be asked to be: nothing (the
+ * division comes out even), the answer itself, the fraction part of a mixed number,
+ * and the thing a dropped zero in the quotient hides.
+ *
+ * `mis.div.divisor-must-be-smaller` is named in CURRICULUM.md and is deliberately
+ * absent — `malrules/longDiv.ts` says why: its home is an item where the divisor is
+ * the larger number, and whole-number long division never poses one.
+ */
+
+import { rational } from "../../math/rational.ts";
+import type { LongDivParams } from "../../generators/longDiv/params.ts";
+import {
+  FORM_FREE_ENTRY as DIV_FORM,
+  LONG_DIV_FAMILY,
+  LONG_DIV_FAMILY_REV,
+} from "../../generators/longDiv/constants.ts";
+import { MIS_QUOTIENT_ZERO_SKIPPED, MIS_REMAINDER_DROPPED } from "../../malrules/longDiv.ts";
+import { CAP_MUL_ONE_DIGIT } from "./mul.ts";
+import { capabilityTag, locKey, skillId } from "../../types/ids.ts";
+import type { SkillNode } from "../../types/skill.ts";
+
+export const CAP_DIV_EXACT = capabilityTag("cap.div.exact");
+export const CAP_DIV_REMAINDER = capabilityTag("cap.div.remainder");
+
+function b(hundredths: bigint) {
+  return rational(hundredths, 100n);
+}
+
+function divide(
+  task: LongDivParams["task"],
+  quotientDigits: number,
+  divisorDigits: number,
+  exact: boolean,
+  quotientZeros = false,
+): LongDivParams {
+  return { task, quotientDigits, divisorDigits, exact, quotientZeros };
+}
+
+export const SKILL_DIVIDE_EXACT = skillId("dw.div.whole.divide-exact");
+export const SKILL_DIVIDE_REMAINDER = skillId("dw.div.whole.find-the-remainder");
+export const SKILL_QUOTIENT_AND_REMAINDER = skillId("dw.div.whole.quotient-and-remainder");
+export const SKILL_ZERO_IN_QUOTIENT = skillId("dw.div.whole.zero-in-the-quotient");
+
+const divideExact: SkillNode = {
+  id: SKILL_DIVIDE_EXACT,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.div.whole.divide-exact.title"),
+  learnerGoal: locKey("dw.skill.div.whole.divide-exact.goal"),
+  domain: "div",
+  cluster: "whole",
+  bigIdeas: [locKey("dw.idea.division.sharing-and-grouping")],
+  gradeBand: { earliest: 3, nominal: 4, latest: 5 },
+  strandRole: "spine",
+  proficiency: { conceptual: 2, procedural: 3, strategic: 1, adaptive: 1 },
+  classification: "procedural",
+  fluencyTarget: { p50Ms: 18000 },
+  prereqs: [],
+  difficulty: { b: b(-40n), levels: [b(-10n), b(20n), b(75n), b(105n)] },
+  // Nothing is left over, so there is nothing to drop; the interior-zero rule needs
+  // a quotient wide enough to hide one, which the last level of this row provides.
+  misconceptions: [MIS_QUOTIENT_ZERO_SKIPPED],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: LONG_DIV_FAMILY,
+    familyRev: LONG_DIV_FAMILY_REV,
+    params: [
+      divide("quotient", 2, 1, true),
+      divide("quotient", 3, 1, true),
+      divide("quotient", 3, 2, true),
+      divide("quotient", 4, 2, true),
+    ],
+    forms: [DIV_FORM],
+    minVariants: 80,
+    consumes: [CAP_MUL_ONE_DIGIT],
+  },
+  probes: [{ level: 0, seed: 1, purpose: "entry" }],
+  provides: [CAP_DIV_EXACT],
+  standards: { ccss: ["4.NBT.B.6", "5.NBT.B.6"] },
+};
+
+const findTheRemainder: SkillNode = {
+  id: SKILL_DIVIDE_REMAINDER,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.div.whole.find-the-remainder.title"),
+  learnerGoal: locKey("dw.skill.div.whole.find-the-remainder.goal"),
+  domain: "div",
+  cluster: "whole",
+  bigIdeas: [locKey("dw.idea.division.what-is-left-over")],
+  gradeBand: { earliest: 3, nominal: 4, latest: 5 },
+  strandRole: "bridge",
+  proficiency: { conceptual: 3, procedural: 2, strategic: 2, adaptive: 2 },
+  classification: "conceptual",
+  prereqs: [{ kind: "requires", to: SKILL_DIVIDE_EXACT }],
+  difficulty: { b: b(-40n), levels: [b(15n), b(45n), b(100n)] },
+  misconceptions: [MIS_REMAINDER_DROPPED],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: LONG_DIV_FAMILY,
+    familyRev: LONG_DIV_FAMILY_REV,
+    params: [
+      divide("remainder", 2, 1, false),
+      divide("remainder", 3, 1, false),
+      divide("remainder", 3, 2, false),
+    ],
+    forms: [DIV_FORM],
+    minVariants: 60,
+    consumes: [CAP_DIV_EXACT],
+  },
+  probes: [],
+  provides: [CAP_DIV_REMAINDER],
+  standards: { ccss: ["4.OA.A.3", "4.NBT.B.6"] },
+};
+
+const quotientAndRemainder: SkillNode = {
+  id: SKILL_QUOTIENT_AND_REMAINDER,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.div.whole.quotient-and-remainder.title"),
+  learnerGoal: locKey("dw.skill.div.whole.quotient-and-remainder.goal"),
+  domain: "div",
+  cluster: "whole",
+  bigIdeas: [
+    locKey("dw.idea.division.what-is-left-over"),
+    locKey("dw.idea.fraction.a-fraction-is-a-division"),
+  ],
+  gradeBand: { earliest: 4, nominal: 5, latest: 5 },
+  strandRole: "bridge",
+  proficiency: { conceptual: 3, procedural: 3, strategic: 2, adaptive: 2 },
+  classification: "conceptual",
+  prereqs: [{ kind: "requires", to: SKILL_DIVIDE_REMAINDER }],
+  difficulty: { b: b(-40n), levels: [b(15n), b(45n), b(100n)] },
+  misconceptions: [MIS_REMAINDER_DROPPED, MIS_QUOTIENT_ZERO_SKIPPED],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: LONG_DIV_FAMILY,
+    familyRev: LONG_DIV_FAMILY_REV,
+    params: [
+      divide("quotient-and-remainder", 2, 1, false),
+      divide("quotient-and-remainder", 3, 1, false),
+      divide("quotient-and-remainder", 3, 2, false),
+    ],
+    forms: [DIV_FORM],
+    minVariants: 80,
+    consumes: [CAP_DIV_REMAINDER],
+  },
+  probes: [],
+  provides: [],
+  standards: { ccss: ["5.NF.B.3", "5.NBT.B.6"] },
+};
+
+/**
+ * The column where the partial dividend is smaller than the divisor, and the zero
+ * that belongs above it. `4,208 ÷ 4` is `1,052`, and the answer children write is
+ * `152`.
+ */
+const zeroInTheQuotient: SkillNode = {
+  id: SKILL_ZERO_IN_QUOTIENT,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.div.whole.zero-in-the-quotient.title"),
+  learnerGoal: locKey("dw.skill.div.whole.zero-in-the-quotient.goal"),
+  domain: "div",
+  cluster: "whole",
+  bigIdeas: [locKey("dw.idea.place-value.zero-holds-a-place")],
+  gradeBand: { earliest: 4, nominal: 5, latest: 5 },
+  strandRole: "fluency",
+  proficiency: { conceptual: 2, procedural: 3, strategic: 1, adaptive: 2 },
+  classification: "procedural",
+  prereqs: [{ kind: "requires", to: SKILL_DIVIDE_EXACT }],
+  difficulty: { b: b(-40n), levels: [b(55n), b(85n), b(140n)] },
+  misconceptions: [MIS_QUOTIENT_ZERO_SKIPPED],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: LONG_DIV_FAMILY,
+    familyRev: LONG_DIV_FAMILY_REV,
+    params: [
+      divide("quotient", 3, 1, true, true),
+      divide("quotient", 4, 1, true, true),
+      divide("quotient", 4, 2, true, true),
+    ],
+    forms: [DIV_FORM],
+    minVariants: 60,
+    consumes: [CAP_DIV_EXACT],
+  },
+  probes: [],
+  provides: [],
+  standards: { ccss: ["5.NBT.B.6"] },
+};
+
+export const divDomainNodes: readonly SkillNode[] = [
+  divideExact,
+  findTheRemainder,
+  quotientAndRemainder,
+  zeroInTheQuotient,
+];

--- a/dynawalla/packs/shared/curriculum/src/graph/domains/frac.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/domains/frac.ts
@@ -1,0 +1,486 @@
+/**
+ * Domain `frac` — fractions.
+ *
+ * CURRICULUM.md prioritizes this domain ahead of breadth anywhere else, and the
+ * reason is the strongest single finding in the literature the program is built on:
+ * elementary fraction and division knowledge uniquely predicts high-school algebra
+ * achievement five to six years later, controlling for IQ, working memory and
+ * family income, replicated in US and UK longitudinal samples.
+ *
+ * Every row is `draft`, and not for want of a generator. Fractions are the domain
+ * where the gap is starkest: `PromptSlot` gained a `fraction` kind in this change
+ * because until now a question about fractions could not be **stated** — the only
+ * way to write three quarters into a prompt was as the `Rational` 3/4, which a
+ * renderer can only write as `0.75`. The slot exists now; the renderer that draws
+ * it does not. See `render/prompts.ts`.
+ *
+ * The renderer is not the whole of it here. Nine of these eleven rows also sit
+ * under CG-10's variant-space floor on their easiest levels — small denominators
+ * genuinely hold few problems — so promoting them is a generator question as well
+ * as a `status` flip. `promotionBlockers.ts` names the levels.
+ *
+ * `mis.frac.whole-number-bias` is the root of two of the three mal-rules here, so a
+ * child who believes a fraction is two whole numbers stacked up is repaired once
+ * rather than twice.
+ */
+
+import { rational } from "../../math/rational.ts";
+import type { CompareOrderParams } from "../../generators/compareOrder/params.ts";
+import {
+  COMPARE_ORDER_FAMILY,
+  COMPARE_ORDER_FAMILY_REV,
+  FORM_FREE_ENTRY as COMPARE_FORM,
+} from "../../generators/compareOrder/constants.ts";
+import type { FracArithParams } from "../../generators/fracArith/params.ts";
+import {
+  FORM_FREE_ENTRY as ARITH_FORM,
+  FRAC_ARITH_FAMILY,
+  FRAC_ARITH_FAMILY_REV,
+} from "../../generators/fracArith/constants.ts";
+import type { FracEquivalenceParams } from "../../generators/fracEquivalence/params.ts";
+import {
+  FORM_FREE_ENTRY as EQUIV_FORM,
+  FRAC_EQUIVALENCE_FAMILY,
+  FRAC_EQUIVALENCE_FAMILY_REV,
+} from "../../generators/fracEquivalence/constants.ts";
+import { MIS_LARGER_DENOMINATOR_LARGER_FRACTION } from "../../malrules/compareOrder.ts";
+import {
+  MIS_ADD_NUMERATORS_AND_DENOMINATORS,
+  MIS_MIXED_NUMBER_CONCATENATION,
+  MIS_SCALE_BOTH_PARTS,
+} from "../../malrules/fractions.ts";
+import { capabilityTag, locKey, skillId } from "../../types/ids.ts";
+import type { SkillNode } from "../../types/skill.ts";
+
+export const CAP_FRAC_COMPARE = capabilityTag("cap.frac.compare");
+export const CAP_FRAC_EQUIVALENT = capabilityTag("cap.frac.equivalent");
+export const CAP_FRAC_LIKE_SUM = capabilityTag("cap.frac.like-sum");
+export const CAP_FRAC_MIXED = capabilityTag("cap.frac.mixed-number");
+
+function b(hundredths: bigint) {
+  return rational(hundredths, 100n);
+}
+
+function comparePair(maxDenominator: number, sameNumerator: boolean, task: "greater" | "lesser" = "greater"): CompareOrderParams {
+  return { numberType: "fraction", task, maxDenominator, sameNumerator };
+}
+
+function equivalence(
+  task: FracEquivalenceParams["task"],
+  maxDenominator: number,
+  maxFactor: number,
+  maxWhole: number,
+): FracEquivalenceParams {
+  return { task, maxDenominator, maxFactor, maxWhole };
+}
+
+function addSub(
+  op: "add" | "sub",
+  denominators: "like" | "multiple" | "unlike",
+  maxDenominator: number,
+  lowestTerms: boolean,
+): FracArithParams {
+  return { op, denominators, maxDenominator, lowestTerms };
+}
+
+function multiply(wholeMultiplier: boolean, maxDenominator: number, maxWhole: number, lowestTerms: boolean): FracArithParams {
+  return { op: "mul", wholeMultiplier, maxDenominator, maxWhole, lowestTerms };
+}
+
+export const SKILL_COMPARE_SAME_NUMERATOR = skillId("dw.frac.compare.same-numerator");
+export const SKILL_COMPARE_UNLIKE = skillId("dw.frac.compare.unlike-fractions");
+export const SKILL_BUILD_EQUIVALENT = skillId("dw.frac.equivalence.build-equivalent");
+export const SKILL_SIMPLIFY = skillId("dw.frac.equivalence.lowest-terms");
+export const SKILL_IMPROPER_TO_MIXED = skillId("dw.frac.equivalence.improper-to-mixed");
+export const SKILL_MIXED_TO_IMPROPER = skillId("dw.frac.equivalence.mixed-to-improper");
+export const SKILL_ADD_LIKE = skillId("dw.frac.arith.add-like-denominators");
+export const SKILL_ADD_UNLIKE = skillId("dw.frac.arith.add-unlike-denominators");
+export const SKILL_SUBTRACT = skillId("dw.frac.arith.subtract-fractions");
+export const SKILL_MULTIPLY_WHOLE = skillId("dw.frac.arith.multiply-by-a-whole");
+export const SKILL_MULTIPLY_FRACTION = skillId("dw.frac.arith.multiply-fractions");
+
+/**
+ * The diagnostic comparison: one numerator, two denominators.
+ *
+ * With the numerators equal, the larger denominator is the smaller number as a
+ * matter of arithmetic, so this level table is where whole-number bias is either
+ * visible or absent — and where the mal-rule that names it is wrong on every single
+ * item without ever inspecting the answer.
+ */
+const compareSameNumerator: SkillNode = {
+  id: SKILL_COMPARE_SAME_NUMERATOR,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.frac.compare.same-numerator.title"),
+  learnerGoal: locKey("dw.skill.frac.compare.same-numerator.goal"),
+  domain: "frac",
+  cluster: "compare",
+  bigIdeas: [locKey("dw.idea.fraction.more-parts-means-smaller-parts")],
+  gradeBand: { earliest: 2, nominal: 3, latest: 4 },
+  strandRole: "spine",
+  proficiency: { conceptual: 3, procedural: 1, strategic: 2, adaptive: 2 },
+  classification: "conceptual",
+  prereqs: [],
+  difficulty: { b: b(-90n), levels: [b(-25n), b(-5n), b(25n)] },
+  misconceptions: [MIS_LARGER_DENOMINATOR_LARGER_FRACTION],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: COMPARE_ORDER_FAMILY,
+    familyRev: COMPARE_ORDER_FAMILY_REV,
+    params: [comparePair(20, true), comparePair(24, true, "lesser"), comparePair(30, true)],
+    forms: [COMPARE_FORM],
+    minVariants: 80,
+    consumes: [],
+  },
+  probes: [{ level: 0, seed: 1, purpose: "entry" }],
+  provides: [CAP_FRAC_COMPARE],
+  standards: { ccss: ["3.NF.A.3.D"], sg: ["P3-FR-2"] },
+};
+
+const compareUnlike: SkillNode = {
+  id: SKILL_COMPARE_UNLIKE,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.frac.compare.unlike-fractions.title"),
+  learnerGoal: locKey("dw.skill.frac.compare.unlike-fractions.goal"),
+  domain: "frac",
+  cluster: "compare",
+  bigIdeas: [locKey("dw.idea.fraction.a-fraction-is-one-number")],
+  gradeBand: { earliest: 3, nominal: 4, latest: 5 },
+  strandRole: "spine",
+  proficiency: { conceptual: 3, procedural: 2, strategic: 2, adaptive: 2 },
+  classification: "conceptual",
+  prereqs: [{ kind: "requires", to: SKILL_COMPARE_SAME_NUMERATOR }],
+  difficulty: { b: b(-90n), levels: [b(-40n), b(-10n), b(30n)] },
+  // These levels draw the two fractions independently, so a same-numerator pair
+  // turns up by chance — measured at roughly one item in eight — and the
+  // whole-number-bias rule fires on it. A diagnosis the items emit and the node
+  // does not declare reaches the scheduler with nowhere to route, which is what
+  // the sweep caught and what CG-12 checks on the active graph.
+  misconceptions: [MIS_LARGER_DENOMINATOR_LARGER_FRACTION],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: COMPARE_ORDER_FAMILY,
+    familyRev: COMPARE_ORDER_FAMILY_REV,
+    params: [comparePair(10, false), comparePair(16, false, "lesser"), comparePair(24, false)],
+    forms: [COMPARE_FORM],
+    minVariants: 80,
+    consumes: [CAP_FRAC_COMPARE],
+  },
+  probes: [],
+  provides: [],
+  standards: { ccss: ["4.NF.A.2"] },
+};
+
+const buildEquivalent: SkillNode = {
+  id: SKILL_BUILD_EQUIVALENT,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.frac.equivalence.build-equivalent.title"),
+  learnerGoal: locKey("dw.skill.frac.equivalence.build-equivalent.goal"),
+  domain: "frac",
+  cluster: "equivalence",
+  bigIdeas: [locKey("dw.idea.fraction.same-number-many-writings")],
+  gradeBand: { earliest: 3, nominal: 4, latest: 5 },
+  strandRole: "spine",
+  proficiency: { conceptual: 3, procedural: 2, strategic: 1, adaptive: 1 },
+  classification: "conceptual",
+  prereqs: [],
+  difficulty: { b: b(-120n), levels: [b(150n), b(290n), b(420n)] },
+  misconceptions: [],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: FRAC_EQUIVALENCE_FAMILY,
+    familyRev: FRAC_EQUIVALENCE_FAMILY_REV,
+    params: [equivalence("build", 24, 6, 1), equivalence("build", 40, 8, 1), equivalence("build", 60, 9, 1)],
+    forms: [EQUIV_FORM],
+    minVariants: 40,
+    consumes: [],
+  },
+  probes: [{ level: 0, seed: 1, purpose: "entry" }],
+  provides: [CAP_FRAC_EQUIVALENT],
+  standards: { ccss: ["3.NF.A.3.B", "4.NF.A.1"] },
+};
+
+const simplify: SkillNode = {
+  id: SKILL_SIMPLIFY,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.frac.equivalence.lowest-terms.title"),
+  learnerGoal: locKey("dw.skill.frac.equivalence.lowest-terms.goal"),
+  domain: "frac",
+  cluster: "equivalence",
+  bigIdeas: [locKey("dw.idea.fraction.same-number-many-writings")],
+  gradeBand: { earliest: 4, nominal: 5, latest: 5 },
+  strandRole: "fluency",
+  proficiency: { conceptual: 2, procedural: 3, strategic: 2, adaptive: 1 },
+  classification: "procedural",
+  prereqs: [{ kind: "requires", to: SKILL_BUILD_EQUIVALENT }],
+  difficulty: { b: b(-120n), levels: [b(90n), b(230n), b(420n)] },
+  misconceptions: [],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: FRAC_EQUIVALENCE_FAMILY,
+    familyRev: FRAC_EQUIVALENCE_FAMILY_REV,
+    params: [
+      equivalence("simplify", 24, 4, 1),
+      equivalence("simplify", 40, 6, 1),
+      equivalence("simplify", 60, 9, 1),
+    ],
+    forms: [EQUIV_FORM],
+    minVariants: 40,
+    consumes: [CAP_FRAC_EQUIVALENT],
+  },
+  probes: [],
+  provides: [],
+  standards: { ccss: ["4.NF.A.1"] },
+};
+
+const improperToMixed: SkillNode = {
+  id: SKILL_IMPROPER_TO_MIXED,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.frac.equivalence.improper-to-mixed.title"),
+  learnerGoal: locKey("dw.skill.frac.equivalence.improper-to-mixed.goal"),
+  domain: "frac",
+  cluster: "equivalence",
+  bigIdeas: [
+    locKey("dw.idea.fraction.same-number-many-writings"),
+    locKey("dw.idea.fraction.a-fraction-is-a-division"),
+  ],
+  gradeBand: { earliest: 3, nominal: 4, latest: 5 },
+  strandRole: "bridge",
+  proficiency: { conceptual: 3, procedural: 2, strategic: 1, adaptive: 1 },
+  classification: "conceptual",
+  prereqs: [],
+  difficulty: { b: b(-100n), levels: [b(-40n), b(-20n), b(20n)] },
+  misconceptions: [],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: FRAC_EQUIVALENCE_FAMILY,
+    familyRev: FRAC_EQUIVALENCE_FAMILY_REV,
+    params: [
+      equivalence("to-mixed", 8, 2, 4),
+      equivalence("to-mixed", 12, 2, 9),
+      equivalence("to-mixed", 20, 2, 15),
+    ],
+    forms: [EQUIV_FORM],
+    minVariants: 60,
+    consumes: [],
+  },
+  probes: [],
+  provides: [CAP_FRAC_MIXED],
+  standards: { ccss: ["4.NF.B.3.B", "5.NF.B.3"] },
+};
+
+const mixedToImproper: SkillNode = {
+  id: SKILL_MIXED_TO_IMPROPER,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.frac.equivalence.mixed-to-improper.title"),
+  learnerGoal: locKey("dw.skill.frac.equivalence.mixed-to-improper.goal"),
+  domain: "frac",
+  cluster: "equivalence",
+  bigIdeas: [locKey("dw.idea.fraction.same-number-many-writings")],
+  gradeBand: { earliest: 4, nominal: 5, latest: 5 },
+  strandRole: "bridge",
+  proficiency: { conceptual: 3, procedural: 2, strategic: 1, adaptive: 2 },
+  classification: "conceptual",
+  prereqs: [{ kind: "requires", to: SKILL_IMPROPER_TO_MIXED }],
+  difficulty: { b: b(-100n), levels: [b(-5n), b(15n), b(55n)] },
+  misconceptions: [MIS_MIXED_NUMBER_CONCATENATION],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: FRAC_EQUIVALENCE_FAMILY,
+    familyRev: FRAC_EQUIVALENCE_FAMILY_REV,
+    params: [
+      equivalence("to-improper", 8, 2, 4),
+      equivalence("to-improper", 12, 2, 9),
+      equivalence("to-improper", 20, 2, 15),
+    ],
+    forms: [EQUIV_FORM],
+    minVariants: 60,
+    consumes: [CAP_FRAC_MIXED],
+  },
+  probes: [{ level: 2, seed: 7, purpose: "promotion" }],
+  provides: [],
+  standards: { ccss: ["4.NF.B.3.B"] },
+};
+
+const addLike: SkillNode = {
+  id: SKILL_ADD_LIKE,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.frac.arith.add-like-denominators.title"),
+  learnerGoal: locKey("dw.skill.frac.arith.add-like-denominators.goal"),
+  domain: "frac",
+  cluster: "arith",
+  bigIdeas: [locKey("dw.idea.fraction.add-the-parts-not-the-wholes")],
+  gradeBand: { earliest: 3, nominal: 4, latest: 5 },
+  strandRole: "spine",
+  proficiency: { conceptual: 3, procedural: 2, strategic: 1, adaptive: 2 },
+  classification: "conceptual",
+  prereqs: [],
+  difficulty: { b: b(-80n), levels: [b(-40n), b(0n), b(65n)] },
+  misconceptions: [MIS_ADD_NUMERATORS_AND_DENOMINATORS],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: FRAC_ARITH_FAMILY,
+    familyRev: FRAC_ARITH_FAMILY_REV,
+    params: [addSub("add", "like", 8, false), addSub("add", "like", 16, false), addSub("add", "like", 24, true)],
+    forms: [ARITH_FORM],
+    minVariants: 40,
+    consumes: [],
+  },
+  probes: [{ level: 0, seed: 1, purpose: "entry" }],
+  provides: [CAP_FRAC_LIKE_SUM],
+  standards: { ccss: ["4.NF.B.3.A"] },
+};
+
+const addUnlike: SkillNode = {
+  id: SKILL_ADD_UNLIKE,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.frac.arith.add-unlike-denominators.title"),
+  learnerGoal: locKey("dw.skill.frac.arith.add-unlike-denominators.goal"),
+  domain: "frac",
+  cluster: "arith",
+  bigIdeas: [locKey("dw.idea.fraction.add-the-parts-not-the-wholes")],
+  gradeBand: { earliest: 4, nominal: 5, latest: 5 },
+  strandRole: "spine",
+  proficiency: { conceptual: 3, procedural: 3, strategic: 2, adaptive: 2 },
+  classification: "conceptual",
+  prereqs: [
+    { kind: "requires", to: SKILL_ADD_LIKE },
+    { kind: "requires", to: SKILL_BUILD_EQUIVALENT },
+  ],
+  difficulty: { b: b(-80n), levels: [b(10n), b(35n), b(100n)] },
+  misconceptions: [MIS_ADD_NUMERATORS_AND_DENOMINATORS],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: FRAC_ARITH_FAMILY,
+    familyRev: FRAC_ARITH_FAMILY_REV,
+    params: [
+      addSub("add", "multiple", 12, false),
+      addSub("add", "unlike", 12, false),
+      addSub("add", "unlike", 20, true),
+    ],
+    forms: [ARITH_FORM],
+    minVariants: 40,
+    consumes: [CAP_FRAC_LIKE_SUM, CAP_FRAC_EQUIVALENT],
+  },
+  probes: [{ level: 2, seed: 11, purpose: "promotion" }],
+  provides: [],
+  standards: { ccss: ["5.NF.A.1"] },
+};
+
+const subtractFractions: SkillNode = {
+  id: SKILL_SUBTRACT,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.frac.arith.subtract-fractions.title"),
+  learnerGoal: locKey("dw.skill.frac.arith.subtract-fractions.goal"),
+  domain: "frac",
+  cluster: "arith",
+  bigIdeas: [locKey("dw.idea.fraction.add-the-parts-not-the-wholes")],
+  gradeBand: { earliest: 4, nominal: 5, latest: 5 },
+  strandRole: "spine",
+  proficiency: { conceptual: 2, procedural: 3, strategic: 2, adaptive: 2 },
+  classification: "procedural",
+  prereqs: [{ kind: "requires", to: SKILL_ADD_LIKE }],
+  difficulty: { b: b(-80n), levels: [b(-20n), b(30n), b(100n)] },
+  // The documented whole-number-bias rule is stated for addition. Its subtraction
+  // analogue divides by zero on like denominators and cannot be shown to diverge on
+  // the rest, so it is not shipped: never invent a bug.
+  misconceptions: [],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: FRAC_ARITH_FAMILY,
+    familyRev: FRAC_ARITH_FAMILY_REV,
+    params: [
+      addSub("sub", "like", 12, false),
+      addSub("sub", "multiple", 16, false),
+      addSub("sub", "unlike", 20, true),
+    ],
+    forms: [ARITH_FORM],
+    minVariants: 40,
+    consumes: [CAP_FRAC_LIKE_SUM],
+  },
+  probes: [],
+  provides: [],
+  standards: { ccss: ["4.NF.B.3.A", "5.NF.A.1"] },
+};
+
+const multiplyByWhole: SkillNode = {
+  id: SKILL_MULTIPLY_WHOLE,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.frac.arith.multiply-by-a-whole.title"),
+  learnerGoal: locKey("dw.skill.frac.arith.multiply-by-a-whole.goal"),
+  domain: "frac",
+  cluster: "arith",
+  bigIdeas: [locKey("dw.idea.fraction.a-fraction-of-a-number")],
+  gradeBand: { earliest: 4, nominal: 5, latest: 5 },
+  strandRole: "bridge",
+  proficiency: { conceptual: 3, procedural: 2, strategic: 2, adaptive: 2 },
+  classification: "conceptual",
+  prereqs: [{ kind: "requires", to: SKILL_ADD_LIKE }],
+  difficulty: { b: b(-60n), levels: [b(-45n), b(-15n), b(50n)] },
+  misconceptions: [MIS_SCALE_BOTH_PARTS],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: FRAC_ARITH_FAMILY,
+    familyRev: FRAC_ARITH_FAMILY_REV,
+    params: [multiply(true, 10, 6, false), multiply(true, 16, 9, false), multiply(true, 24, 12, true)],
+    forms: [ARITH_FORM],
+    minVariants: 40,
+    consumes: [CAP_FRAC_LIKE_SUM],
+  },
+  probes: [],
+  provides: [],
+  standards: { ccss: ["4.NF.B.4", "5.NF.B.4"] },
+};
+
+const multiplyFractions: SkillNode = {
+  id: SKILL_MULTIPLY_FRACTION,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.frac.arith.multiply-fractions.title"),
+  learnerGoal: locKey("dw.skill.frac.arith.multiply-fractions.goal"),
+  domain: "frac",
+  cluster: "arith",
+  bigIdeas: [locKey("dw.idea.fraction.a-fraction-of-a-number")],
+  gradeBand: { earliest: 4, nominal: 5, latest: 5 },
+  strandRole: "spine",
+  proficiency: { conceptual: 2, procedural: 3, strategic: 2, adaptive: 2 },
+  classification: "procedural",
+  prereqs: [{ kind: "requires", to: SKILL_MULTIPLY_WHOLE }],
+  difficulty: { b: b(-60n), levels: [b(-20n), b(0n), b(65n)] },
+  misconceptions: [],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: FRAC_ARITH_FAMILY,
+    familyRev: FRAC_ARITH_FAMILY_REV,
+    params: [multiply(false, 8, 2, false), multiply(false, 12, 2, false), multiply(false, 20, 2, true)],
+    forms: [ARITH_FORM],
+    minVariants: 40,
+    consumes: [],
+  },
+  probes: [],
+  provides: [],
+  standards: { ccss: ["5.NF.B.4"] },
+};
+
+export const fracDomainNodes: readonly SkillNode[] = [
+  compareSameNumerator,
+  compareUnlike,
+  buildEquivalent,
+  simplify,
+  improperToMixed,
+  mixedToImproper,
+  addLike,
+  addUnlike,
+  subtractFractions,
+  multiplyByWhole,
+  multiplyFractions,
+];

--- a/dynawalla/packs/shared/curriculum/src/graph/domains/mul.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/domains/mul.ts
@@ -1,0 +1,153 @@
+/**
+ * Domain `mul` — multiplication.
+ *
+ * `draft`, for the reason `ns.ts` states at length: the generator is complete and
+ * the app cannot draw the question. See `render/prompts.ts`. One level here needs a
+ * second thing before it can go active — `dw.mul.scale.times-power-of-ten` L0 is
+ * under CG-10's variant-space floor. See `promotionBlockers.ts`.
+ *
+ * **What is missing from this domain, and why.** CURRICULUM.md gives `mul` ten
+ * fact-recall skills, and there are none here. Times-table facts have at most 144
+ * distinct problems in the world; CG-10's variant-space floor is 975, derived from
+ * a 40-item practice run repeating no more than one item in fifty. A fact family
+ * cannot satisfy it and no amount of generator work will change that — the floor
+ * and the content are in genuine conflict, and the resolution belongs with whoever
+ * owns CG-10, not in a generator that games the estimator.
+ */
+
+import { rational } from "../../math/rational.ts";
+import type { MultidigitMulParams } from "../../generators/multidigitMul/params.ts";
+import {
+  FORM_FREE_ENTRY as MUL_FORM,
+  MULTIDIGIT_MUL_FAMILY,
+  MULTIDIGIT_MUL_FAMILY_REV,
+} from "../../generators/multidigitMul/constants.ts";
+import {
+  MIS_CARRY_ADDED_BEFORE_MULTIPLYING,
+  MIS_FORGOT_THE_SHIFT,
+  MIS_PARTIAL_PRODUCT_MISALIGNED,
+} from "../../malrules/multidigitMul.ts";
+import { capabilityTag, locKey, skillId } from "../../types/ids.ts";
+import type { SkillNode } from "../../types/skill.ts";
+
+export const CAP_MUL_ONE_DIGIT = capabilityTag("cap.mul.by-one-digit");
+export const CAP_MUL_MULTIDIGIT = capabilityTag("cap.mul.multidigit");
+
+function b(hundredths: bigint) {
+  return rational(hundredths, 100n);
+}
+
+function times(digits: number, multiplierDigits: number, carries: boolean): MultidigitMulParams {
+  return { shape: "general", digits, multiplierDigits, carries };
+}
+
+function powerOfTen(digits: number, maxPower: number): MultidigitMulParams {
+  return { shape: "power-of-ten", digits, maxPower };
+}
+
+export const SKILL_TIMES_POWER_OF_TEN = skillId("dw.mul.scale.times-power-of-ten");
+export const SKILL_TIMES_ONE_DIGIT = skillId("dw.mul.multidigit.times-one-digit");
+export const SKILL_TIMES_TWO_DIGIT = skillId("dw.mul.multidigit.times-two-digit");
+
+const timesPowerOfTen: SkillNode = {
+  id: SKILL_TIMES_POWER_OF_TEN,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.mul.scale.times-power-of-ten.title"),
+  learnerGoal: locKey("dw.skill.mul.scale.times-power-of-ten.goal"),
+  domain: "mul",
+  cluster: "scale",
+  bigIdeas: [locKey("dw.idea.place-value.ten-times-moves-a-place")],
+  gradeBand: { earliest: 2, nominal: 3, latest: 4 },
+  strandRole: "bridge",
+  proficiency: { conceptual: 3, procedural: 2, strategic: 1, adaptive: 1 },
+  classification: "conceptual",
+  prereqs: [],
+  difficulty: { b: b(-40n), levels: [b(-75n), b(-45n), b(-15n)] },
+  // `47 × 100` answered as `47`: the zeros that move the product up two places
+  // were never written. Same root cause as the missing placeholder zero in
+  // `47 × 23` — both are `mis.mul.shift-not-applied` — but a different rule and a
+  // different repair, because a child multiplying by a hundred is not writing two
+  // partial products and misplacing one. The generator already draws the two apart:
+  // the `power-of-ten` shape's walkthrough is a place-value shift and emits no
+  // partial-product step at all.
+  misconceptions: [MIS_FORGOT_THE_SHIFT],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: MULTIDIGIT_MUL_FAMILY,
+    familyRev: MULTIDIGIT_MUL_FAMILY_REV,
+    params: [powerOfTen(2, 1), powerOfTen(3, 2), powerOfTen(4, 3)],
+    forms: [MUL_FORM],
+    minVariants: 60,
+    consumes: [],
+  },
+  probes: [{ level: 0, seed: 1, purpose: "entry" }],
+  provides: [],
+  standards: { ccss: ["4.NBT.A.1", "5.NBT.A.2"] },
+};
+
+const timesOneDigit: SkillNode = {
+  id: SKILL_TIMES_ONE_DIGIT,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.mul.multidigit.times-one-digit.title"),
+  learnerGoal: locKey("dw.skill.mul.multidigit.times-one-digit.goal"),
+  domain: "mul",
+  cluster: "multidigit",
+  bigIdeas: [locKey("dw.idea.place-value.regroup"), locKey("dw.idea.multiplication.equal-groups")],
+  gradeBand: { earliest: 3, nominal: 4, latest: 5 },
+  strandRole: "spine",
+  proficiency: { conceptual: 2, procedural: 3, strategic: 1, adaptive: 1 },
+  classification: "procedural",
+  fluencyTarget: { p50Ms: 15000 },
+  prereqs: [],
+  difficulty: { b: b(-30n), levels: [b(25n), b(55n), b(85n)] },
+  misconceptions: [MIS_CARRY_ADDED_BEFORE_MULTIPLYING],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: MULTIDIGIT_MUL_FAMILY,
+    familyRev: MULTIDIGIT_MUL_FAMILY_REV,
+    params: [times(3, 1, true), times(4, 1, true), times(5, 1, true)],
+    forms: [MUL_FORM],
+    minVariants: 80,
+    consumes: [],
+  },
+  probes: [{ level: 0, seed: 1, purpose: "entry" }],
+  provides: [CAP_MUL_ONE_DIGIT],
+  standards: { ccss: ["4.NBT.B.5"], uk: ["Y4-MD-2"] },
+};
+
+const timesTwoDigit: SkillNode = {
+  id: SKILL_TIMES_TWO_DIGIT,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.mul.multidigit.times-two-digit.title"),
+  learnerGoal: locKey("dw.skill.mul.multidigit.times-two-digit.goal"),
+  domain: "mul",
+  cluster: "multidigit",
+  bigIdeas: [locKey("dw.idea.place-value.regroup"), locKey("dw.idea.multiplication.partial-products")],
+  gradeBand: { earliest: 4, nominal: 5, latest: 5 },
+  strandRole: "spine",
+  proficiency: { conceptual: 2, procedural: 3, strategic: 2, adaptive: 2 },
+  classification: "procedural",
+  prereqs: [
+    { kind: "requires", to: SKILL_TIMES_ONE_DIGIT },
+    { kind: "supports", to: SKILL_TIMES_POWER_OF_TEN },
+  ],
+  difficulty: { b: b(-30n), levels: [b(50n), b(80n), b(110n), b(135n)] },
+  misconceptions: [MIS_PARTIAL_PRODUCT_MISALIGNED],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: MULTIDIGIT_MUL_FAMILY,
+    familyRev: MULTIDIGIT_MUL_FAMILY_REV,
+    params: [times(2, 2, true), times(3, 2, true), times(4, 2, true), times(3, 3, true)],
+    forms: [MUL_FORM],
+    minVariants: 80,
+    consumes: [CAP_MUL_ONE_DIGIT],
+  },
+  probes: [{ level: 3, seed: 41, purpose: "promotion" }],
+  provides: [CAP_MUL_MULTIDIGIT],
+  standards: { ccss: ["5.NBT.B.5"], uk: ["Y5-MD-1"] },
+};
+
+export const mulDomainNodes: readonly SkillNode[] = [timesPowerOfTen, timesOneDigit, timesTwoDigit];

--- a/dynawalla/packs/shared/curriculum/src/graph/domains/ns.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/domains/ns.ts
@@ -1,0 +1,307 @@
+/**
+ * Domain `ns` — number sense and place value.
+ *
+ * **Every row here is `draft`, and the reason is not the generator.** Each of these
+ * nodes binds a family that generates, checks and diagnoses correctly over hundreds
+ * of thousands of seeds. What does not exist is a renderer for the *question*: the
+ * app reads an item out of `prompt.slots` by matching `prompt.key` against the two
+ * column-op templates and draws nothing for any other, so promoting these rows
+ * would put an answer keypad on a child's screen with no problem above it. That is
+ * the failure gate CG-8 exists for, and `render/prompts.ts` now makes it mechanical
+ * rather than a thing somebody has to notice.
+ *
+ * `PR-2.13` is not the only blocker on every row, and the difference matters to
+ * whoever plans the promotion. `dw.ns.place.digit-in-place` L0 and
+ * `dw.ns.round.whole-numbers` L0 are also under CG-10's variant-space floor and
+ * need a wider draw or a reconciliation with the floor before they can go active;
+ * the rest of this domain flips on `status` alone. `promotionBlockers.ts` holds the
+ * whole list and the property sweep keeps it honest.
+ *
+ * Ids are final. A draft id is as immutable as an active one — it is a mastery key
+ * the moment it ships, and the promotion PR must not be free to rename it.
+ */
+
+import { rational } from "../../math/rational.ts";
+import type { CompareOrderParams } from "../../generators/compareOrder/params.ts";
+import {
+  COMPARE_ORDER_FAMILY,
+  COMPARE_ORDER_FAMILY_REV,
+  FORM_FREE_ENTRY as COMPARE_FORM,
+} from "../../generators/compareOrder/constants.ts";
+import type { PlaceValueParams } from "../../generators/placeValue/params.ts";
+import {
+  FORM_FREE_ENTRY as PLACE_FORM,
+  PLACE_VALUE_FAMILY,
+  PLACE_VALUE_FAMILY_REV,
+} from "../../generators/placeValue/constants.ts";
+import type { RoundEstimateParams } from "../../generators/roundEstimate/params.ts";
+import {
+  FORM_FREE_ENTRY as ROUND_FORM,
+  ROUND_ESTIMATE_FAMILY,
+  ROUND_ESTIMATE_FAMILY_REV,
+} from "../../generators/roundEstimate/constants.ts";
+import { MIS_DIGIT_FOR_VALUE } from "../../malrules/placeValue.ts";
+import { MIS_LONGER_IS_BIGGER } from "../../malrules/compareOrder.ts";
+import { capabilityTag, locKey, skillId } from "../../types/ids.ts";
+import type { SkillNode } from "../../types/skill.ts";
+
+export const CAP_READ_PLACE = capabilityTag("cap.ns.read-place");
+export const CAP_DIGIT_VALUE = capabilityTag("cap.ns.digit-value");
+export const CAP_COMPARE_WHOLE = capabilityTag("cap.ns.compare-whole");
+
+/** Hundredths of a logit, spelled as an exact rational. */
+function b(hundredths: bigint) {
+  return rational(hundredths, 100n);
+}
+
+function place(
+  task: PlaceValueParams["task"],
+  digits: number,
+  minPlace: number,
+  maxPlace: number,
+): PlaceValueParams {
+  return { task, digits, minPlace, maxPlace };
+}
+
+function whole(digits: number, sharedPrefix: number, task: "greater" | "lesser" = "greater"): CompareOrderParams {
+  return { numberType: "whole", task, digits, sharedPrefix };
+}
+
+function decimalPair(digits: number, decimalPlaces: number, placeGap: number): CompareOrderParams {
+  return { numberType: "decimal", task: "greater", digits, decimalPlaces, placeGap };
+}
+
+function round(digits: number, minPlace: number, maxPlace: number, ties: boolean): RoundEstimateParams {
+  return { digits, minPlace, maxPlace, ties };
+}
+
+export const SKILL_DIGIT_IN_PLACE = skillId("dw.ns.place.digit-in-place");
+export const SKILL_DIGIT_VALUE = skillId("dw.ns.place.digit-value");
+export const SKILL_REGROUPED_COUNT = skillId("dw.ns.place.regrouped-count");
+export const SKILL_COMPARE_WHOLE = skillId("dw.ns.compare.whole-numbers");
+export const SKILL_COMPARE_DECIMAL = skillId("dw.ns.compare.decimals");
+export const SKILL_ROUND_WHOLE = skillId("dw.ns.round.whole-numbers");
+
+const digitInPlace: SkillNode = {
+  id: SKILL_DIGIT_IN_PLACE,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.ns.place.digit-in-place.title"),
+  learnerGoal: locKey("dw.skill.ns.place.digit-in-place.goal"),
+  domain: "ns",
+  cluster: "place",
+  bigIdeas: [locKey("dw.idea.place-value.position-carries-value")],
+  gradeBand: { earliest: 1, nominal: 2, latest: 3 },
+  strandRole: "spine",
+  proficiency: { conceptual: 2, procedural: 2, strategic: 0, adaptive: 1 },
+  classification: "procedural",
+  fluencyTarget: { p50Ms: 8000 },
+  prereqs: [],
+  difficulty: { b: b(-70n), levels: [b(-95n), b(-55n), b(-15n)] },
+  // Reading a digit off the page has no arithmetic in it to get wrong, so it has
+  // no mal-rule. The rule this family does carry is defined on the two tasks that
+  // ask for a quantity.
+  misconceptions: [],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: PLACE_VALUE_FAMILY,
+    familyRev: PLACE_VALUE_FAMILY_REV,
+    params: [place("digit-in-place", 2, 0, 1), place("digit-in-place", 3, 0, 2), place("digit-in-place", 4, 0, 3)],
+    forms: [PLACE_FORM],
+    minVariants: 60,
+    consumes: [],
+  },
+  probes: [{ level: 0, seed: 1, purpose: "entry" }],
+  provides: [CAP_READ_PLACE],
+  standards: { ccss: ["1.NBT.B.2", "2.NBT.A.1", "4.NBT.A.2"], uk: ["Y2-NPV-1"] },
+};
+
+const digitValue: SkillNode = {
+  id: SKILL_DIGIT_VALUE,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.ns.place.digit-value.title"),
+  learnerGoal: locKey("dw.skill.ns.place.digit-value.goal"),
+  domain: "ns",
+  cluster: "place",
+  bigIdeas: [locKey("dw.idea.place-value.position-carries-value")],
+  gradeBand: { earliest: 2, nominal: 3, latest: 4 },
+  strandRole: "spine",
+  proficiency: { conceptual: 3, procedural: 2, strategic: 1, adaptive: 1 },
+  classification: "conceptual",
+  prereqs: [{ kind: "requires", to: SKILL_DIGIT_IN_PLACE }],
+  difficulty: { b: b(-40n), levels: [b(20n), b(60n), b(110n)] },
+  misconceptions: [MIS_DIGIT_FOR_VALUE],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: PLACE_VALUE_FAMILY,
+    familyRev: PLACE_VALUE_FAMILY_REV,
+    params: [place("digit-value", 3, 1, 2), place("digit-value", 4, 1, 3), place("digit-value", 5, 2, 4)],
+    forms: [PLACE_FORM],
+    minVariants: 60,
+    consumes: [CAP_READ_PLACE],
+  },
+  probes: [{ level: 1, seed: 17, purpose: "promotion" }],
+  provides: [CAP_DIGIT_VALUE],
+  standards: { ccss: ["2.NBT.A.1", "4.NBT.A.1"] },
+};
+
+const regroupedCount: SkillNode = {
+  id: SKILL_REGROUPED_COUNT,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.ns.place.regrouped-count.title"),
+  learnerGoal: locKey("dw.skill.ns.place.regrouped-count.goal"),
+  domain: "ns",
+  cluster: "place",
+  bigIdeas: [
+    locKey("dw.idea.place-value.position-carries-value"),
+    locKey("dw.idea.place-value.regroup"),
+  ],
+  gradeBand: { earliest: 3, nominal: 4, latest: 5 },
+  strandRole: "bridge",
+  proficiency: { conceptual: 3, procedural: 2, strategic: 2, adaptive: 2 },
+  classification: "conceptual",
+  prereqs: [{ kind: "requires", to: SKILL_DIGIT_VALUE }],
+  difficulty: { b: b(-40n), levels: [b(95n), b(135n), b(185n)] },
+  misconceptions: [MIS_DIGIT_FOR_VALUE],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: PLACE_VALUE_FAMILY,
+    familyRev: PLACE_VALUE_FAMILY_REV,
+    params: [
+      place("total-in-place", 4, 1, 2),
+      place("total-in-place", 5, 1, 3),
+      place("total-in-place", 6, 2, 4),
+    ],
+    forms: [PLACE_FORM],
+    minVariants: 60,
+    consumes: [CAP_DIGIT_VALUE],
+  },
+  probes: [],
+  provides: [],
+  standards: { ccss: ["4.NBT.A.1"] },
+};
+
+const compareWhole: SkillNode = {
+  id: SKILL_COMPARE_WHOLE,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.ns.compare.whole-numbers.title"),
+  learnerGoal: locKey("dw.skill.ns.compare.whole-numbers.goal"),
+  domain: "ns",
+  cluster: "compare",
+  bigIdeas: [locKey("dw.idea.magnitude.numbers-have-order")],
+  gradeBand: { earliest: 1, nominal: 2, latest: 4 },
+  strandRole: "spine",
+  proficiency: { conceptual: 2, procedural: 2, strategic: 1, adaptive: 1 },
+  classification: "procedural",
+  fluencyTarget: { p50Ms: 9000 },
+  prereqs: [{ kind: "requires", to: SKILL_DIGIT_IN_PLACE }],
+  difficulty: { b: b(-60n), levels: [b(-30n), b(5n), b(70n), b(135n)] },
+  // The whole-number comparisons this level table poses are between two numbers of
+  // the same written width, so "the longer number is bigger" is not a rule that can
+  // fire on them — and where it could, it would be right.
+  misconceptions: [],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: COMPARE_ORDER_FAMILY,
+    familyRev: COMPARE_ORDER_FAMILY_REV,
+    params: [whole(3, 0), whole(3, 1, "lesser"), whole(4, 2), whole(5, 3, "lesser")],
+    forms: [COMPARE_FORM],
+    minVariants: 80,
+    consumes: [CAP_READ_PLACE],
+  },
+  probes: [{ level: 0, seed: 3, purpose: "entry" }],
+  provides: [CAP_COMPARE_WHOLE],
+  standards: { ccss: ["1.NBT.B.3", "2.NBT.A.4", "4.NBT.A.2"] },
+};
+
+/**
+ * Draft twice over.
+ *
+ * The prompt renderer is one blocker and the number layer is the other:
+ * `NumberFormat` — the decimal separator, grouping, numbering system and direction
+ * — is PR-2.2 and does not exist, so CG-14's locale round-trip cannot run on a
+ * decimal answer. `dw.add.regroup.subtract-tenths` is here on the same footing and
+ * has been since M2. Both blockers are named so a promotion PR knows it needs both.
+ */
+const compareDecimal: SkillNode = {
+  id: SKILL_COMPARE_DECIMAL,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.ns.compare.decimals.title"),
+  learnerGoal: locKey("dw.skill.ns.compare.decimals.goal"),
+  domain: "ns",
+  cluster: "compare",
+  bigIdeas: [
+    locKey("dw.idea.magnitude.numbers-have-order"),
+    locKey("dw.idea.place-value.position-carries-value"),
+  ],
+  gradeBand: { earliest: 4, nominal: 5, latest: 5 },
+  strandRole: "bridge",
+  proficiency: { conceptual: 3, procedural: 2, strategic: 1, adaptive: 2 },
+  classification: "conceptual",
+  prereqs: [{ kind: "requires", to: SKILL_COMPARE_WHOLE }],
+  difficulty: { b: b(-40n), levels: [b(-30n), b(20n), b(50n)] },
+  misconceptions: [MIS_LONGER_IS_BIGGER],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: COMPARE_ORDER_FAMILY,
+    familyRev: COMPARE_ORDER_FAMILY_REV,
+    params: [decimalPair(1, 1, 1), decimalPair(2, 1, 2), decimalPair(3, 2, 1)],
+    forms: [COMPARE_FORM],
+    minVariants: 80,
+    consumes: [CAP_COMPARE_WHOLE],
+  },
+  probes: [],
+  provides: [],
+  standards: { ccss: ["4.NF.C.7", "5.NBT.A.3"] },
+};
+
+const roundWhole: SkillNode = {
+  id: SKILL_ROUND_WHOLE,
+  rev: 1,
+  status: "draft",
+  title: locKey("dw.skill.ns.round.whole-numbers.title"),
+  learnerGoal: locKey("dw.skill.ns.round.whole-numbers.goal"),
+  domain: "ns",
+  cluster: "round",
+  bigIdeas: [locKey("dw.idea.magnitude.nearest-landmark")],
+  gradeBand: { earliest: 3, nominal: 4, latest: 5 },
+  strandRole: "application",
+  proficiency: { conceptual: 2, procedural: 3, strategic: 2, adaptive: 2 },
+  classification: "procedural",
+  prereqs: [
+    { kind: "requires", to: SKILL_COMPARE_WHOLE },
+    { kind: "supports", to: SKILL_DIGIT_VALUE },
+  ],
+  difficulty: { b: b(-30n), levels: [b(20n), b(60n), b(110n), b(145n)] },
+  // No mal-rule, and `malrules/placeValue.ts` and this family's own header say why:
+  // every documented rounding bug produces the correct answer on about half of all
+  // items, and the only routes to CG-12's 95% divergence are to bias the content
+  // towards rounding up or to have `applies()` decline the items where the bug is
+  // right. The second is the self-filtering the mal-rule contract forbids.
+  misconceptions: [],
+  representations: { required: [], optional: [] },
+  generator: {
+    family: ROUND_ESTIMATE_FAMILY,
+    familyRev: ROUND_ESTIMATE_FAMILY_REV,
+    params: [round(3, 1, 1, false), round(4, 1, 2, false), round(5, 2, 3, false), round(5, 2, 3, true)],
+    forms: [ROUND_FORM],
+    minVariants: 80,
+    consumes: [CAP_READ_PLACE],
+  },
+  probes: [],
+  provides: [],
+  standards: { ccss: ["3.NBT.A.1", "4.NBT.A.3"] },
+};
+
+export const nsDomainNodes: readonly SkillNode[] = [
+  digitInPlace,
+  digitValue,
+  regroupedCount,
+  compareWhole,
+  compareDecimal,
+  roundWhole,
+];

--- a/dynawalla/packs/shared/curriculum/src/graph/graph.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/graph.ts
@@ -4,13 +4,37 @@
  * `activeNodes` is the shipped graph. Draft nodes are authorable but are excluded
  * from it and from every coverage count, so the graph can never become a wish list
  * (CG-7).
+ *
+ * Six domains are represented here and one of them has active rows. That is not an
+ * accident of effort: `add` binds `gen.arith.column-op`, which is the only family
+ * whose **prompt template** the app can draw, and CG-8 now says so mechanically
+ * (`render/prompts.ts`). Every other row is a complete, property-tested generator
+ * waiting on the statement renderer PR-2.13 lands.
+ *
+ * For twelve of the thirty draft rows, `status` is then the only field that has to
+ * change. For the other eighteen it is not: their level tables sit under CG-10's
+ * variant-space floor and the gate fails the moment they go active. They are named
+ * in `promotionBlockers.ts`, and the property sweep asserts that list against what
+ * it measures so it cannot go stale.
  */
 
 import type { SkillId } from "../types/ids.ts";
 import type { SkillNode } from "../types/skill.ts";
 import { addDomainNodes } from "./domains/add.ts";
+import { algDomainNodes } from "./domains/alg.ts";
+import { divDomainNodes } from "./domains/div.ts";
+import { fracDomainNodes } from "./domains/frac.ts";
+import { mulDomainNodes } from "./domains/mul.ts";
+import { nsDomainNodes } from "./domains/ns.ts";
 
-export const allNodes: readonly SkillNode[] = [...addDomainNodes];
+export const allNodes: readonly SkillNode[] = [
+  ...nsDomainNodes,
+  ...addDomainNodes,
+  ...mulDomainNodes,
+  ...divDomainNodes,
+  ...fracDomainNodes,
+  ...algDomainNodes,
+];
 
 export function activeNodes(nodes: readonly SkillNode[] = allNodes): SkillNode[] {
   return nodes.filter((node) => node.status === "active");

--- a/dynawalla/packs/shared/curriculum/src/graph/promotionBlockers.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/promotionBlockers.ts
@@ -1,9 +1,11 @@
 /**
  * What stands between a `draft` row and an `active` one, per row.
  *
- * Every draft row in this graph waits on **PR-2.13**, the statement renderer: the
- * app matches `prompt.key` against the two column-op templates and draws nothing
- * for any other, so promoting a row without it puts an answer keypad on a child's
+ * Every draft row in this graph waits on **PR-2.13**, the statement renderer, and
+ * since [ADR-0022](../../../../docs/DECISIONS/ADR-0022-host-ships-no-content.md)
+ * that renderer is a **pack's** to land rather than the host's: the host ships no
+ * content, and stating a question is content. Nothing in this repository draws a
+ * curriculum item today, so promoting a row buys an answer entry on a child's
  * screen with no question above it (CG-8, `render/prompts.ts`).
  *
  * Eighteen of them wait on a **second** thing, and it is not a field flip. CG-10

--- a/dynawalla/packs/shared/curriculum/src/graph/promotionBlockers.ts
+++ b/dynawalla/packs/shared/curriculum/src/graph/promotionBlockers.ts
@@ -1,0 +1,61 @@
+/**
+ * What stands between a `draft` row and an `active` one, per row.
+ *
+ * Every draft row in this graph waits on **PR-2.13**, the statement renderer: the
+ * app matches `prompt.key` against the two column-op templates and draws nothing
+ * for any other, so promoting a row without it puts an answer keypad on a child's
+ * screen with no question above it (CG-8, `render/prompts.ts`).
+ *
+ * Eighteen of them wait on a **second** thing, and it is not a field flip. CG-10
+ * requires an estimated variant space of 975 — a 40-item practice run repeating no
+ * more than one item in fifty — and the levels named below do not clear it. Some
+ * are genuinely short of problems in the world: `dw.alg.equality.missing-addend` L0
+ * draws both operands from 1..9, so its true space is exactly 81 items, and no
+ * generator work changes that. Others would clear the floor with a wider draw.
+ * Either way the row needs a widened generator, a reconciliation with whoever owns
+ * CG-10, or both — and a promotion PR planned as "flip `status`" would fail the
+ * gate on the first run.
+ *
+ * The list is here rather than in a comment beside each `minVariants` because a
+ * comment cannot be checked. `families.property.test.ts` measures the sub-floor set
+ * over the whole graph and asserts it equals this list **in both directions**: a
+ * level that slips under the floor is named here or the sweep fails, and a
+ * generator widened past it must be struck off or the sweep fails too.
+ *
+ * Labels are `<skill id> L<level>`, the same form the sweep prints.
+ */
+
+export const CG10_BLOCKED_LEVELS: readonly string[] = [
+  "dw.ns.place.digit-in-place L0",
+  "dw.ns.round.whole-numbers L0",
+  "dw.mul.scale.times-power-of-ten L0",
+  "dw.div.whole.divide-exact L0",
+  "dw.frac.equivalence.build-equivalent L0",
+  "dw.frac.equivalence.build-equivalent L1",
+  "dw.frac.equivalence.build-equivalent L2",
+  "dw.frac.equivalence.lowest-terms L0",
+  "dw.frac.equivalence.lowest-terms L1",
+  "dw.frac.equivalence.lowest-terms L2",
+  "dw.frac.equivalence.improper-to-mixed L0",
+  "dw.frac.equivalence.improper-to-mixed L1",
+  "dw.frac.equivalence.mixed-to-improper L0",
+  "dw.frac.equivalence.mixed-to-improper L1",
+  "dw.frac.arith.add-like-denominators L0",
+  "dw.frac.arith.add-like-denominators L1",
+  "dw.frac.arith.add-unlike-denominators L0",
+  "dw.frac.arith.subtract-fractions L0",
+  "dw.frac.arith.subtract-fractions L1",
+  "dw.frac.arith.multiply-by-a-whole L0",
+  "dw.frac.arith.multiply-by-a-whole L1",
+  "dw.frac.arith.multiply-fractions L0",
+  "dw.alg.equality.missing-addend L0",
+  "dw.alg.equality.balance-meaning L0",
+  "dw.alg.equality.missing-subtrahend L0",
+  "dw.alg.equality.unknown-minuend L0",
+  "dw.alg.equality.missing-factor L0",
+];
+
+/** The skills above, deduplicated — 18 of the graph's 30 draft rows. */
+export const CG10_BLOCKED_SKILLS: readonly string[] = [
+  ...new Set(CG10_BLOCKED_LEVELS.map((label) => label.slice(0, label.lastIndexOf(" ")))),
+];

--- a/dynawalla/packs/shared/curriculum/src/index.ts
+++ b/dynawalla/packs/shared/curriculum/src/index.ts
@@ -96,6 +96,8 @@ export { findPromptTemplate, promptRegistry } from "./render/prompts.ts";
 export type { PromptTemplateDeclaration } from "./render/prompts.ts";
 export type { RendererDeclaration } from "./render/registry.ts";
 export {
+  balanceLowerPan,
+  numberLinePoint,
   repSpecDefect,
   REP_BALANCE_SCALE,
   REP_GEAR_TRAIN,

--- a/dynawalla/packs/shared/curriculum/src/index.ts
+++ b/dynawalla/packs/shared/curriculum/src/index.ts
@@ -24,11 +24,41 @@ export { fingerprintItem, serializeExercise } from "./serialize.ts";
 
 export { activeNodes, allNodes, nodeById, nodeIndex } from "./graph/graph.ts";
 export { addDomainNodes } from "./graph/domains/add.ts";
+export { algDomainNodes } from "./graph/domains/alg.ts";
+export { divDomainNodes } from "./graph/domains/div.ts";
+export { fracDomainNodes } from "./graph/domains/frac.ts";
+export { mulDomainNodes } from "./graph/domains/mul.ts";
+export { nsDomainNodes } from "./graph/domains/ns.ts";
 
 export { columnOpFamily, InfeasibleParamsError } from "./generators/columnOp/family.ts";
 export { columnOpParamSchema } from "./generators/columnOp/params.ts";
 export type { ColumnOpParams } from "./generators/columnOp/params.ts";
 export * from "./generators/columnOp/constants.ts";
+export { compareOrderFamily } from "./generators/compareOrder/family.ts";
+export { compareOrderParamSchema } from "./generators/compareOrder/params.ts";
+export type { CompareOrderParams } from "./generators/compareOrder/params.ts";
+export { fracArithFamily } from "./generators/fracArith/family.ts";
+export { fracArithParamSchema } from "./generators/fracArith/params.ts";
+export type { FracArithParams } from "./generators/fracArith/params.ts";
+export { fracEquivalenceFamily } from "./generators/fracEquivalence/family.ts";
+export { fracEquivalenceParamSchema } from "./generators/fracEquivalence/params.ts";
+export type { FracEquivalenceParams } from "./generators/fracEquivalence/params.ts";
+export { longDivFamily } from "./generators/longDiv/family.ts";
+export { longDivParamSchema } from "./generators/longDiv/params.ts";
+export type { LongDivParams } from "./generators/longDiv/params.ts";
+export { missingOperandFamily } from "./generators/missingOperand/family.ts";
+export { missingOperandParamSchema } from "./generators/missingOperand/params.ts";
+export type { MissingOperandParams } from "./generators/missingOperand/params.ts";
+export { multidigitMulFamily } from "./generators/multidigitMul/family.ts";
+export { multidigitMulParamSchema } from "./generators/multidigitMul/params.ts";
+export type { MultidigitMulParams } from "./generators/multidigitMul/params.ts";
+export { placeValueFamily } from "./generators/placeValue/family.ts";
+export { placeValueParamSchema } from "./generators/placeValue/params.ts";
+export type { PlaceValueParams } from "./generators/placeValue/params.ts";
+export { roundEstimateFamily } from "./generators/roundEstimate/family.ts";
+export { roundEstimateParamSchema } from "./generators/roundEstimate/params.ts";
+export type { RoundEstimateParams } from "./generators/roundEstimate/params.ts";
+export { InfeasibleLevelError } from "./generators/shared/errors.ts";
 export { familyById, generatorFamilies } from "./generators/registry.ts";
 
 export { classify, classifyAll, malRuleById, malRules, malRulesForFamily } from "./malrules/registry.ts";
@@ -43,8 +73,36 @@ export {
   REP_COUNTING_BOARD,
 } from "./malrules/columnOp.ts";
 
+export { compareOrderMalRules, MIS_LARGER_DENOMINATOR_LARGER_FRACTION, MIS_LONGER_IS_BIGGER } from "./malrules/compareOrder.ts";
+export {
+  fracArithMalRules,
+  fracEquivalenceMalRules,
+  MIS_ADD_NUMERATORS_AND_DENOMINATORS,
+  MIS_MIXED_NUMBER_CONCATENATION,
+  MIS_SCALE_BOTH_PARTS,
+} from "./malrules/fractions.ts";
+export { longDivMalRules, MIS_QUOTIENT_ZERO_SKIPPED, MIS_REMAINDER_DROPPED } from "./malrules/longDiv.ts";
+export { missingOperandMalRules, MIS_ADD_ALL_NUMBERS, MIS_EQUALS_AS_OPERATOR } from "./malrules/missingOperand.ts";
+export {
+  multidigitMulMalRules,
+  MIS_CARRY_ADDED_BEFORE_MULTIPLYING,
+  MIS_PARTIAL_PRODUCT_MISALIGNED,
+} from "./malrules/multidigitMul.ts";
+export { placeValueMalRules, MIS_DIGIT_FOR_VALUE } from "./malrules/placeValue.ts";
+export { MIS_WHOLE_NUMBER_BIAS } from "./malrules/roots.ts";
+
 export { answerRendererId, findRenderer, rendererRegistry, repRendererId } from "./render/registry.ts";
+export { findPromptTemplate, promptRegistry } from "./render/prompts.ts";
+export type { PromptTemplateDeclaration } from "./render/prompts.ts";
 export type { RendererDeclaration } from "./render/registry.ts";
+export {
+  repSpecDefect,
+  REP_BALANCE_SCALE,
+  REP_GEAR_TRAIN,
+  REP_NUMBER_LINE,
+  REQUIRED_REP_PARAMS,
+  V1_REPRESENTATIONS,
+} from "./render/representations.ts";
 
 export { digitsOf, plainDigits, readProblem, writtenAnswer } from "./board/problem.ts";
 export type { ColumnOp, ColumnProblem } from "./board/problem.ts";

--- a/dynawalla/packs/shared/curriculum/src/malrules/columnOp.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/malrules/columnOp.test.ts
@@ -247,7 +247,10 @@ test("mal-rule: registry metadata is honest about LOCATE", () => {
     malRulesForFamily(COLUMN_OP_FAMILY).map((rule) => rule.id),
     [MIS_SMALLER_FROM_LARGER, MIS_BORROW_ACROSS_ZERO, MIS_CARRY_DROPPED],
   );
-  assert.deepEqual(malRulesForFamily(familyId("gen.frac.arith")), []);
+  // A family with no rules of its own. `gen.frac.arith` used to stand in for one
+  // and now has three, which is why the stand-in is a family that owns zero skills
+  // by design rather than one that merely had none yet.
+  assert.deepEqual(malRulesForFamily(familyId("gen.logic.error-analysis")), []);
 });
 
 test("mal-rule: the shared procedure helpers agree with the worked examples", () => {

--- a/dynawalla/packs/shared/curriculum/src/malrules/columnOp.ts
+++ b/dynawalla/packs/shared/curriculum/src/malrules/columnOp.ts
@@ -38,8 +38,14 @@ export const MIS_SMALLER_FROM_LARGER = malRuleId("mis.add.smaller-from-larger");
 export const MIS_BORROW_ACROSS_ZERO = malRuleId("mis.add.borrow-across-zero");
 export const MIS_CARRY_DROPPED = malRuleId("mis.add.carry-dropped");
 
-/** The counting board is the LOCATE representation for borrow-across-zero. */
-export const REP_COUNTING_BOARD = "counting-board";
+/**
+ * The counting board is the LOCATE representation for borrow-across-zero.
+ * Re-exported, not redeclared: the id belongs to `render/representations.ts`
+ * with the other three, and two spellings of one `RepId` is a `RepSpec` that
+ * matches no renderer.
+ */
+export { REP_COUNTING_BOARD } from "../render/representations.ts";
+import { REP_COUNTING_BOARD } from "../render/representations.ts";
 
 type Trace = {
   readonly digits: readonly number[];

--- a/dynawalla/packs/shared/curriculum/src/malrules/compareOrder.ts
+++ b/dynawalla/packs/shared/curriculum/src/malrules/compareOrder.ts
@@ -1,0 +1,109 @@
+/**
+ * `gen.number.compare-order` mal-rules — whole-number bias, in two notations.
+ *
+ * Both rules are the same belief: that a number written with more of something is
+ * bigger. In fractions it is the denominator; in decimals it is the digits after
+ * the point. CURRICULUM.md files them as one root, `mis.frac.whole-number-bias`, so
+ * a child who holds it is repaired once rather than twice.
+ *
+ * Each rule's `applies()` names a **property of the item**, never a property of the
+ * answer. That distinction is what separates a bug that is undefined on an item
+ * from a bug that is being hidden where it happens to be right:
+ *
+ * - The fraction rule is defined where the two fractions share a numerator. With
+ *   one numerator, the larger denominator is the smaller number as a matter of
+ *   arithmetic, so the rule is wrong on every such item and the mal-rule never has
+ *   to look at the answer to know it.
+ * - The decimal rule is defined where the two numbers are written to different
+ *   numbers of places. Its level poses the discriminating item — equal whole parts,
+ *   longer writing on the smaller number — as a declared content decision, because
+ *   `0.5` against `0.625` is an item a child can get right while holding exactly
+ *   the belief being tested.
+ */
+
+import { cmp } from "../math/rational.ts";
+import { COMPARE_ORDER_FAMILY } from "../generators/compareOrder/constants.ts";
+import { operandAnswer, operandValue, readComparePair } from "../generators/compareOrder/read.ts";
+import type { CompareOperand, ComparePair } from "../generators/compareOrder/read.ts";
+import type { AnswerValue } from "../types/answer.ts";
+import type { Exercise } from "../types/exercise.ts";
+import { malRuleId } from "../types/ids.ts";
+import type { MalRule } from "../types/malrule.ts";
+import { MIS_WHOLE_NUMBER_BIAS } from "./roots.ts";
+
+export const MIS_LARGER_DENOMINATOR_LARGER_FRACTION = malRuleId(
+  "mis.frac.larger-denominator-larger-fraction",
+);
+export const MIS_LONGER_IS_BIGGER = malRuleId("mis.dec.longer-is-bigger");
+
+/** The operand the child picks, given which one their rule says is "bigger". */
+function pickedBy(pair: ComparePair, believedBigger: CompareOperand): AnswerValue {
+  const believedSmaller = believedBigger === pair.left ? pair.right : pair.left;
+  return operandAnswer(pair.task === "greater" ? believedBigger : believedSmaller);
+}
+
+function sameNumeratorPair(pair: ComparePair): boolean {
+  return (
+    pair.left.kind === "fraction" &&
+    pair.right.kind === "fraction" &&
+    pair.left.num === pair.right.num &&
+    pair.left.den !== pair.right.den
+  );
+}
+
+export const largerDenominatorLargerFraction: MalRule = {
+  id: MIS_LARGER_DENOMINATOR_LARGER_FRACTION,
+  family: COMPARE_ORDER_FAMILY,
+  parent: MIS_WHOLE_NUMBER_BIAS,
+  locateCapable: false,
+
+  applies(exercise: Exercise): boolean {
+    const pair = readComparePair(exercise);
+    return pair !== null && sameNumeratorPair(pair);
+  },
+
+  apply(exercise: Exercise): AnswerValue | null {
+    const pair = readComparePair(exercise);
+    if (pair === null || !sameNumeratorPair(pair)) return null;
+    if (pair.left.kind !== "fraction" || pair.right.kind !== "fraction") return null;
+    const believedBigger = pair.left.den > pair.right.den ? pair.left : pair.right;
+    return pickedBy(pair, believedBigger);
+  },
+};
+
+function differentPlaceCounts(pair: ComparePair): boolean {
+  return (
+    pair.left.kind === "number" &&
+    pair.right.kind === "number" &&
+    pair.left.decimalPlaces !== pair.right.decimalPlaces &&
+    // Whole numbers of the same width are not what this rule is about, and a whole
+    // number written with more digits genuinely is bigger.
+    (pair.left.decimalPlaces > 0 || pair.right.decimalPlaces > 0) &&
+    cmp(operandValue(pair.left), operandValue(pair.right)) !== 0
+  );
+}
+
+export const longerIsBigger: MalRule = {
+  id: MIS_LONGER_IS_BIGGER,
+  family: COMPARE_ORDER_FAMILY,
+  parent: MIS_WHOLE_NUMBER_BIAS,
+  locateCapable: false,
+
+  applies(exercise: Exercise): boolean {
+    const pair = readComparePair(exercise);
+    return pair !== null && differentPlaceCounts(pair);
+  },
+
+  apply(exercise: Exercise): AnswerValue | null {
+    const pair = readComparePair(exercise);
+    if (pair === null || !differentPlaceCounts(pair)) return null;
+    if (pair.left.kind !== "number" || pair.right.kind !== "number") return null;
+    const believedBigger = pair.left.decimalPlaces > pair.right.decimalPlaces ? pair.left : pair.right;
+    return pickedBy(pair, believedBigger);
+  },
+};
+
+export const compareOrderMalRules: readonly MalRule[] = [
+  largerDenominatorLargerFraction,
+  longerIsBigger,
+];

--- a/dynawalla/packs/shared/curriculum/src/malrules/fractions.ts
+++ b/dynawalla/packs/shared/curriculum/src/malrules/fractions.ts
@@ -1,0 +1,118 @@
+/**
+ * Fraction mal-rules, across two families.
+ *
+ * `mis.frac.add-numerators-and-denominators` is the deepest-evidenced error in
+ * elementary fractions and is a child of `mis.frac.whole-number-bias`, the same
+ * root as reading a larger denominator as a larger number. Both are the belief that
+ * a fraction is two whole numbers that happen to be written one above the other.
+ *
+ * Each one is wrong on every item it is defined on, provably rather than
+ * empirically:
+ *
+ * - The mediant `(a+c)/(b+d)` lies strictly between `a/b` and `c/d`, and a sum of
+ *   two positive fractions is strictly greater than both. They cannot be equal.
+ * - Scaling both parts of a fraction by the whole multiplier leaves the value
+ *   alone, and `a/b × w` for `w ≥ 2` does not.
+ * - Writing the whole part in front of the numerator multiplies it by a power of
+ *   ten; turning a mixed number into an improper fraction multiplies it by the
+ *   denominator. The generator never poses the one denominator on which those are
+ *   the same operation.
+ *
+ * `mis.mul.makes-bigger` is **not** here, and CURRICULUM.md's honesty rule is why.
+ * The documented finding is that children choose the operation that makes a number
+ * larger — it is a belief about which calculation to do, and its executable home is
+ * the word-problem families, where the child picks. In a written calculation there
+ * is nothing to pick, and a "procedure" invented to stand for it would be a bug
+ * nobody has observed.
+ */
+
+import { FRAC_ARITH_FAMILY } from "../generators/fracArith/constants.ts";
+import { readFracOperands } from "../generators/fracArith/read.ts";
+import { FRAC_EQUIVALENCE_FAMILY } from "../generators/fracEquivalence/constants.ts";
+import { readEquivalenceItem } from "../generators/fracEquivalence/read.ts";
+import { fractionAnswer } from "../generators/shared/fractions.ts";
+import type { AnswerValue } from "../types/answer.ts";
+import type { Exercise } from "../types/exercise.ts";
+import { malRuleId } from "../types/ids.ts";
+import type { MalRule } from "../types/malrule.ts";
+import { MIS_WHOLE_NUMBER_BIAS } from "./roots.ts";
+
+export const MIS_ADD_NUMERATORS_AND_DENOMINATORS = malRuleId(
+  "mis.frac.add-numerators-and-denominators",
+);
+export const MIS_SCALE_BOTH_PARTS = malRuleId("mis.frac.scale-both-parts");
+export const MIS_MIXED_NUMBER_CONCATENATION = malRuleId("mis.frac.mixed-number-concatenation");
+
+/** `a/b + c/d = (a+c)/(b+d)`. */
+export const addNumeratorsAndDenominators: MalRule = {
+  id: MIS_ADD_NUMERATORS_AND_DENOMINATORS,
+  family: FRAC_ARITH_FAMILY,
+  parent: MIS_WHOLE_NUMBER_BIAS,
+  locateCapable: false,
+
+  applies(exercise: Exercise): boolean {
+    const operands = readFracOperands(exercise);
+    return operands !== null && operands.operation === "add";
+  },
+
+  apply(exercise: Exercise): AnswerValue | null {
+    const operands = readFracOperands(exercise);
+    if (operands === null || operands.operation !== "add") return null;
+    return fractionAnswer({
+      whole: 0n,
+      num: operands.leftNum + operands.rightNum,
+      den: operands.leftDen + operands.rightDen,
+    });
+  },
+};
+
+/**
+ * `a/b × w = (a·w)/(b·w)` — the equivalent-fractions rule, applied to a product.
+ *
+ * The result is `a/b` again, which is what makes it recognisable: the child
+ * multiplied and the number did not change.
+ */
+export const scaleBothParts: MalRule = {
+  id: MIS_SCALE_BOTH_PARTS,
+  family: FRAC_ARITH_FAMILY,
+  parent: MIS_WHOLE_NUMBER_BIAS,
+  locateCapable: false,
+
+  applies(exercise: Exercise): boolean {
+    const operands = readFracOperands(exercise);
+    return operands !== null && operands.operation === "mul-whole" && operands.rightNum >= 2n;
+  },
+
+  apply(exercise: Exercise): AnswerValue | null {
+    const operands = readFracOperands(exercise);
+    if (operands === null || operands.operation !== "mul-whole" || operands.rightNum < 2n) return null;
+    return fractionAnswer({
+      whole: 0n,
+      num: operands.leftNum * operands.rightNum,
+      den: operands.leftDen * operands.rightNum,
+    });
+  },
+};
+
+/** `w n/d` written as `wn/d` — the whole part pushed in front of the numerator. */
+export const mixedNumberConcatenation: MalRule = {
+  id: MIS_MIXED_NUMBER_CONCATENATION,
+  family: FRAC_EQUIVALENCE_FAMILY,
+  locateCapable: false,
+
+  applies(exercise: Exercise): boolean {
+    const item = readEquivalenceItem(exercise);
+    return item !== null && item.task === "to-improper" && item.whole > 0n;
+  },
+
+  apply(exercise: Exercise): AnswerValue | null {
+    const item = readEquivalenceItem(exercise);
+    if (item === null || item.task !== "to-improper" || item.whole <= 0n) return null;
+    const concatenated = BigInt(`${item.whole.toString()}${item.num.toString()}`);
+    return fractionAnswer({ whole: 0n, num: concatenated, den: item.den });
+  },
+};
+
+export const fracArithMalRules: readonly MalRule[] = [addNumeratorsAndDenominators, scaleBothParts];
+export const fracEquivalenceMalRules: readonly MalRule[] = [mixedNumberConcatenation];
+export const fractionMalRules: readonly MalRule[] = [...fracArithMalRules, ...fracEquivalenceMalRules];

--- a/dynawalla/packs/shared/curriculum/src/malrules/longDiv.ts
+++ b/dynawalla/packs/shared/curriculum/src/malrules/longDiv.ts
@@ -1,0 +1,91 @@
+/**
+ * `gen.arith.long-div` mal-rules.
+ *
+ * `mis.div.divisor-must-be-smaller` — the belief that you divide the bigger number
+ * by the smaller one — is named in CURRICULUM.md and is **not** here. Its home is
+ * an item where the divisor is the larger number, and this family never poses one:
+ * whole-number long division with a divisor bigger than the dividend has no
+ * whole-number quotient. The bug belongs with the word-problem families, where the
+ * child chooses the operation, and with fraction division in V2. Shipping a
+ * version of it that could never fire would be a registry entry pretending to
+ * cover a misconception nothing tests.
+ */
+
+import { rational } from "../math/rational.ts";
+import { LONG_DIV_FAMILY } from "../generators/longDiv/constants.ts";
+import { hasInteriorZero, withoutInteriorZeros } from "../generators/longDiv/procedure.ts";
+import { readDivision } from "../generators/longDiv/read.ts";
+import { fractionAnswer } from "../generators/shared/fractions.ts";
+import type { AnswerValue } from "../types/answer.ts";
+import type { Exercise } from "../types/exercise.ts";
+import { malRuleId } from "../types/ids.ts";
+import type { MalRule } from "../types/malrule.ts";
+
+export const MIS_REMAINDER_DROPPED = malRuleId("mis.div.remainder-dropped");
+export const MIS_QUOTIENT_ZERO_SKIPPED = malRuleId("mis.div.quotient-zero-skipped");
+
+/**
+ * What is left over is thrown away — the division "came out even".
+ *
+ * Written two ways, because the item asks two ways: a remainder of zero where the
+ * remainder was the question, and a mixed number with nothing in its fraction part
+ * where the whole answer was. Defined only where something is actually left over,
+ * and wrong on every such item.
+ */
+export const remainderDropped: MalRule = {
+  id: MIS_REMAINDER_DROPPED,
+  family: LONG_DIV_FAMILY,
+  locateCapable: false,
+
+  applies(exercise: Exercise): boolean {
+    const division = readDivision(exercise);
+    return division !== null && division.remainder > 0n && division.task !== "quotient";
+  },
+
+  apply(exercise: Exercise): AnswerValue | null {
+    const division = readDivision(exercise);
+    if (division === null || division.remainder === 0n) return null;
+    if (division.task === "remainder") return { kind: "integer", value: rational(0n) };
+    if (division.task === "quotient-and-remainder") {
+      return fractionAnswer({ whole: division.quotient, num: 0n, den: division.divisor });
+    }
+    return null;
+  },
+};
+
+/**
+ * The zero in the quotient is never written.
+ *
+ * At a column where the partial dividend is smaller than the divisor, the child
+ * brings the next digit down without first recording the zero above the line:
+ * `4,208 ÷ 4` is written as `152` rather than `1,052`. Removing a digit removes a
+ * place, so the buggy quotient is strictly smaller than the correct one and the two
+ * can never coincide.
+ *
+ * Defined on the tasks whose answer *is* the quotient. On a remainder question the
+ * dropped zero changes the working and not the answer that was asked for, so there
+ * is nothing for the rule to produce.
+ */
+export const quotientZeroSkipped: MalRule = {
+  id: MIS_QUOTIENT_ZERO_SKIPPED,
+  family: LONG_DIV_FAMILY,
+  locateCapable: false,
+
+  applies(exercise: Exercise): boolean {
+    const division = readDivision(exercise);
+    if (division === null || division.task === "remainder") return false;
+    return hasInteriorZero(division.quotient);
+  },
+
+  apply(exercise: Exercise): AnswerValue | null {
+    const division = readDivision(exercise);
+    if (division === null || division.task === "remainder") return null;
+    if (!hasInteriorZero(division.quotient)) return null;
+    const written = withoutInteriorZeros(division.quotient);
+    return division.task === "quotient"
+      ? { kind: "integer", value: rational(written) }
+      : fractionAnswer({ whole: written, num: division.remainder, den: division.divisor });
+  },
+};
+
+export const longDivMalRules: readonly MalRule[] = [remainderDropped, quotientZeroSkipped];

--- a/dynawalla/packs/shared/curriculum/src/malrules/missingOperand.ts
+++ b/dynawalla/packs/shared/curriculum/src/malrules/missingOperand.ts
@@ -1,0 +1,92 @@
+/**
+ * `gen.arith.missing-operand` mal-rules — the equals sign read as an instruction.
+ *
+ * These two are the best-evidenced errors in elementary algebra. On `8 + 4 = ☐ + 5`
+ * the correct answer is 7; the two documented wrong answers are **12** (the total of
+ * the side that is complete — "the equals sign means write the answer") and **17**
+ * (every number on the card added up). Both are produced here by running the
+ * procedure, and both are wrong on every item they are defined on: the generator
+ * never writes a zero on the card, so 12 and 17 and 7 are three different numbers.
+ *
+ * They are also never both right about the same wrong answer, which matters more
+ * than it looks: `classify` returns `null` the moment two rules explain one
+ * response, and a Stage-2 repair built for the wrong one of these is a repair for a
+ * belief the child does not hold.
+ */
+
+import { rational } from "../math/rational.ts";
+import { MISSING_OPERAND_FAMILY } from "../generators/missingOperand/constants.ts";
+import { readSentence } from "../generators/missingOperand/read.ts";
+import type { Sentence } from "../generators/missingOperand/read.ts";
+import type { AnswerValue } from "../types/answer.ts";
+import type { Exercise } from "../types/exercise.ts";
+import { malRuleId } from "../types/ids.ts";
+import type { MalRule } from "../types/malrule.ts";
+
+export const MIS_EQUALS_AS_OPERATOR = malRuleId("mis.alg.equals-as-operator");
+export const MIS_ADD_ALL_NUMBERS = malRuleId("mis.alg.add-all-numbers");
+
+/**
+ * The total of the complete side, written into the box.
+ *
+ * Defined only on `both-sides`: it takes a side that is finished to total, and a
+ * sentence with one operator does not have one.
+ */
+export const equalsAsOperator: MalRule = {
+  id: MIS_EQUALS_AS_OPERATOR,
+  family: MISSING_OPERAND_FAMILY,
+  locateCapable: false,
+
+  applies(exercise: Exercise): boolean {
+    const sentence = readSentence(exercise);
+    return sentence !== null && sentence.shape === "both-sides";
+  },
+
+  apply(exercise: Exercise): AnswerValue | null {
+    const sentence = readSentence(exercise);
+    if (sentence === null || sentence.shape !== "both-sides") return null;
+    return { kind: "integer", value: rational(sentence.leftA + sentence.leftB) };
+  },
+};
+
+/** Every number on the card, added. */
+function allNumbers(sentence: Sentence): bigint {
+  return sentence.shape === "both-sides"
+    ? sentence.leftA + sentence.leftB + sentence.rightKnown
+    : sentence.known + sentence.total;
+}
+
+/**
+ * Defined on three of the five shapes, and the two exclusions are different kinds
+ * of undefined.
+ *
+ * `mul-unknown` has no addition on the card at all, so a child reaching for one is
+ * not making *this* mistake.
+ *
+ * `☐ − a = c` is the sharper case, and the sweep is what found it: adding every
+ * number on the card gives `a + c`, which is the **correct** answer to that
+ * sentence. The buggy procedure and the right one are the same procedure there, so
+ * the bug is not instantiated — exactly the reading `mis.add.smaller-from-larger`
+ * already uses for a subtraction with nothing to regroup. Leaving it in would have
+ * shipped a rule that agrees with the answer on a quarter of its items, and a
+ * "diagnosis" that fires on correct work is worse than none.
+ */
+export const addAllNumbers: MalRule = {
+  id: MIS_ADD_ALL_NUMBERS,
+  family: MISSING_OPERAND_FAMILY,
+  locateCapable: false,
+
+  applies(exercise: Exercise): boolean {
+    const sentence = readSentence(exercise);
+    return sentence !== null && sentence.shape !== "mul-unknown" && sentence.shape !== "sub-unknown-minuend";
+  },
+
+  apply(exercise: Exercise): AnswerValue | null {
+    const sentence = readSentence(exercise);
+    if (sentence === null || sentence.shape === "mul-unknown") return null;
+    if (sentence.shape === "sub-unknown-minuend") return null;
+    return { kind: "integer", value: rational(allNumbers(sentence)) };
+  },
+};
+
+export const missingOperandMalRules: readonly MalRule[] = [equalsAsOperator, addAllNumbers];

--- a/dynawalla/packs/shared/curriculum/src/malrules/multidigitMul.ts
+++ b/dynawalla/packs/shared/curriculum/src/malrules/multidigitMul.ts
@@ -1,0 +1,149 @@
+/**
+ * `gen.arith.multidigit-mul` mal-rules.
+ *
+ * All three run the buggy procedure rather than computing a shortcut from the
+ * correct answer, and all three are wrong on every item they are defined on as a
+ * matter of arithmetic rather than of measurement:
+ *
+ * - An unshifted second partial product multiplies by the multiplier's **digit
+ *   sum**, which is strictly smaller than the multiplier for any multiplier of ten
+ *   or more, so the product is strictly too small.
+ * - The same slip against a power of ten leaves the multiplicand exactly as it was
+ *   (`digitSum(10^k) = 1`), and `top × 1 ≠ top × 10^k` for `k ≥ 1` and `top > 0`.
+ * - Adding the carry before multiplying adds `(multiplier − 1) × carryIn` at every
+ *   column the correct pass carries **into**, all of which are positive, so the
+ *   buggy product is strictly larger. The condition is carries *in*, not carries
+ *   *out*: see `procedure.ts`, where the algebra is written out and the
+ *   counterexample to the carries-out reading (`50 × 2`) is named.
+ *
+ * `applies()` asks about the item's own structure — how many digits the multiplier
+ * has, whether it is a power of ten, and whether the standard algorithm carries
+ * into a column. None of those questions touches the answer, which is what keeps
+ * CG-12's divergence a measurement rather than a tautology.
+ */
+
+import { rational } from "../math/rational.ts";
+import { MULTIDIGIT_MUL_FAMILY } from "../generators/multidigitMul/constants.ts";
+import {
+  carryBeforeMultiply,
+  digitSum,
+  littleEndianDigits,
+  passCarriesInward,
+} from "../generators/multidigitMul/procedure.ts";
+import { readFactors } from "../generators/multidigitMul/read.ts";
+import type { AnswerValue } from "../types/answer.ts";
+import type { Exercise } from "../types/exercise.ts";
+import { malRuleId } from "../types/ids.ts";
+import type { MalRule } from "../types/malrule.ts";
+import { MIS_MUL_SHIFT_NOT_APPLIED } from "./roots.ts";
+
+export const MIS_PARTIAL_PRODUCT_MISALIGNED = malRuleId("mis.mul.partial-product-misaligned");
+export const MIS_FORGOT_THE_SHIFT = malRuleId("mis.mul.forgot-the-shift");
+export const MIS_CARRY_ADDED_BEFORE_MULTIPLYING = malRuleId("mis.mul.carry-added-before-multiplying");
+
+/** `10`, `100`, `1000`, … — one leading digit of one, and nothing else. */
+function isPowerOfTen(value: bigint): boolean {
+  if (value < 10n) return false;
+  let remaining = value;
+  while (remaining % 10n === 0n) remaining /= 10n;
+  return remaining === 1n;
+}
+
+/**
+ * Every partial product written in the units column — no placeholder zero under
+ * the second row.
+ *
+ * `47 × 23` becomes `47 × 3 + 47 × 2 = 141 + 94 = 235`, which is `47 × 5`. Defined
+ * wherever there is a second partial product to misplace **and the multiplier is
+ * not a power of ten**: multiplying by a power of ten is a one-row item the
+ * generator walks through as a place-value shift rather than as two partial
+ * products, and the child who answers `47` to `47 × 100` has not misaligned a row
+ * they never wrote. That case is `mis.mul.forgot-the-shift`, which produces the
+ * same number and asks for a different repair; the two predicates are disjoint so
+ * `classify` still names exactly one of them.
+ */
+export const partialProductMisaligned: MalRule = {
+  id: MIS_PARTIAL_PRODUCT_MISALIGNED,
+  family: MULTIDIGIT_MUL_FAMILY,
+  parent: MIS_MUL_SHIFT_NOT_APPLIED,
+  locateCapable: false,
+
+  applies(exercise: Exercise): boolean {
+    const factors = readFactors(exercise);
+    return factors !== null && factors.bottom >= 10n && factors.top > 0n && !isPowerOfTen(factors.bottom);
+  },
+
+  apply(exercise: Exercise): AnswerValue | null {
+    const factors = readFactors(exercise);
+    if (factors === null || factors.bottom < 10n || factors.top <= 0n) return null;
+    if (isPowerOfTen(factors.bottom)) return null;
+    return { kind: "integer", value: rational(factors.top * digitSum(factors.bottom)) };
+  },
+};
+
+/**
+ * The place-value shift never applied: `47 × 100` answered as `47`.
+ *
+ * The same root cause as the misaligned partial product — the zeros that move the
+ * product up a place were not written — on the item where it is most visible and
+ * where the repair is different. Defined wherever the multiplier is a power of ten
+ * and the multiplicand is positive, on which `top ≠ top × 10^k` for every `k ≥ 1`.
+ */
+export const forgotTheShift: MalRule = {
+  id: MIS_FORGOT_THE_SHIFT,
+  family: MULTIDIGIT_MUL_FAMILY,
+  parent: MIS_MUL_SHIFT_NOT_APPLIED,
+  locateCapable: false,
+
+  applies(exercise: Exercise): boolean {
+    const factors = readFactors(exercise);
+    return factors !== null && factors.top > 0n && isPowerOfTen(factors.bottom);
+  },
+
+  apply(exercise: Exercise): AnswerValue | null {
+    const factors = readFactors(exercise);
+    if (factors === null || factors.top <= 0n || !isPowerOfTen(factors.bottom)) return null;
+    return { kind: "integer", value: rational(factors.top) };
+  },
+};
+
+/**
+ * `(digit + carry) × multiplier`, instead of `digit × multiplier + carry`.
+ *
+ * Defined where a single-digit multiplier of two or more meets a multiplicand the
+ * standard algorithm carries **into a column** on — with no carry coming *in* there
+ * is nothing to add in the wrong order, so the buggy procedure is not instantiated.
+ * That is the procedure being undefined on the item, which the mal-rule contract
+ * allows, and not a filter on where it happens to be right: on every item where it
+ * *is* defined it is wrong, and `procedure.ts` shows why.
+ *
+ * The distinction between carrying *in* and carrying *out* is load-bearing and is
+ * not a nicety. Under the carries-out reading this predicate is true on `50 × 2`,
+ * where the buggy pass returns the correct `100` — 7,980 such items among the
+ * 795,390 the reading admits over `10..99999 × 2..9`.
+ */
+export const carryAddedBeforeMultiplying: MalRule = {
+  id: MIS_CARRY_ADDED_BEFORE_MULTIPLYING,
+  family: MULTIDIGIT_MUL_FAMILY,
+  locateCapable: false,
+
+  applies(exercise: Exercise): boolean {
+    const factors = readFactors(exercise);
+    if (factors === null || factors.bottom < 2n || factors.bottom > 9n) return false;
+    return passCarriesInward(littleEndianDigits(factors.top), Number(factors.bottom));
+  },
+
+  apply(exercise: Exercise): AnswerValue | null {
+    const factors = readFactors(exercise);
+    if (factors === null || factors.bottom < 2n || factors.bottom > 9n) return null;
+    const digits = littleEndianDigits(factors.top);
+    if (!passCarriesInward(digits, Number(factors.bottom))) return null;
+    return { kind: "integer", value: rational(carryBeforeMultiply(digits, Number(factors.bottom))) };
+  },
+};
+
+export const multidigitMulMalRules: readonly MalRule[] = [
+  partialProductMisaligned,
+  forgotTheShift,
+  carryAddedBeforeMultiplying,
+];

--- a/dynawalla/packs/shared/curriculum/src/malrules/placeValue.ts
+++ b/dynawalla/packs/shared/curriculum/src/malrules/placeValue.ts
@@ -1,0 +1,63 @@
+/**
+ * `gen.number.place-value-decompose` mal-rules.
+ *
+ * One rule, and one is the honest number. Reading the *digit* where the question
+ * asked for the *quantity* is the documented place-value error with a procedure
+ * behind it, and it is the one this family can pose in two different tasks and
+ * catch in both.
+ *
+ * The other candidate — counting places from the left instead of from the right —
+ * is not shipped: it produces the correct answer whenever the two digits happen to
+ * be equal, which is one item in ten, and the only ways to reach CG-12's 95%
+ * divergence are to bias the content or to have `applies()` decline the items where
+ * the bug is right. The second is the self-filtering the mal-rule contract forbids.
+ * CURRICULUM.md's honesty rule covers the rest: an unclassified error, never an
+ * invented bug.
+ */
+
+import { rational } from "../math/rational.ts";
+import { PLACE_VALUE_FAMILY } from "../generators/placeValue/constants.ts";
+import { readPlaceValueQuestion } from "../generators/placeValue/read.ts";
+import type { AnswerValue } from "../types/answer.ts";
+import type { Exercise } from "../types/exercise.ts";
+import { malRuleId } from "../types/ids.ts";
+import type { MalRule } from "../types/malrule.ts";
+
+export const MIS_DIGIT_FOR_VALUE = malRuleId("mis.ns.digit-for-value");
+
+/**
+ * The child answers with the digit itself.
+ *
+ * On "what is the digit in the hundreds place of 4,738 worth?" the answer is 700
+ * and this produces 7. On "how many hundreds are in 4,738 altogether?" the answer
+ * is 47 and this produces 7 again — the same reading, and the reason the two tasks
+ * are in one family.
+ *
+ * It is **defined only where the question asks for a quantity**. On
+ * `digit-in-place` the digit *is* the answer, so there is no misreading to make;
+ * that is the procedure being undefined, not a filter on where it is wrong. Where
+ * it is defined it is always wrong: the generator never asks about a place holding
+ * a zero, and a `total-in-place` question always has at least two digits above the
+ * place it counts.
+ */
+export const digitForValue: MalRule = {
+  id: MIS_DIGIT_FOR_VALUE,
+  family: PLACE_VALUE_FAMILY,
+  // No Stage-2 contrast is built for this rule. The counting board could carry it,
+  // and claiming `locateCapable` before the contrast pair exists would put a
+  // representation on a child's screen that nothing draws.
+  locateCapable: false,
+
+  applies(exercise: Exercise): boolean {
+    const question = readPlaceValueQuestion(exercise);
+    return question !== null && question.task !== "digit-in-place";
+  },
+
+  apply(exercise: Exercise): AnswerValue | null {
+    const question = readPlaceValueQuestion(exercise);
+    if (question === null || question.task === "digit-in-place") return null;
+    return { kind: "integer", value: rational(question.digit) };
+  },
+};
+
+export const placeValueMalRules: readonly MalRule[] = [digitForValue];

--- a/dynawalla/packs/shared/curriculum/src/malrules/registry.ts
+++ b/dynawalla/packs/shared/curriculum/src/malrules/registry.ts
@@ -14,11 +14,43 @@ import type { Exercise } from "../types/exercise.ts";
 import type { FamilyId, MalRuleId } from "../types/ids.ts";
 import type { MalRule } from "../types/malrule.ts";
 import { columnOpMalRules } from "./columnOp.ts";
+import { compareOrderMalRules } from "./compareOrder.ts";
+import { fracArithMalRules, fracEquivalenceMalRules } from "./fractions.ts";
+import { longDivMalRules } from "./longDiv.ts";
+import { missingOperandMalRules } from "./missingOperand.ts";
+import { multidigitMulMalRules } from "./multidigitMul.ts";
+import { placeValueMalRules } from "./placeValue.ts";
 
-export const malRules: readonly MalRule[] = [...columnOpMalRules];
+export const malRules: readonly MalRule[] = [
+  ...columnOpMalRules,
+  ...placeValueMalRules,
+  ...compareOrderMalRules,
+  ...multidigitMulMalRules,
+  ...longDivMalRules,
+  ...fracEquivalenceMalRules,
+  ...fracArithMalRules,
+  ...missingOperandMalRules,
+];
+
+/**
+ * The shipped registry, grouped once.
+ *
+ * `generate()` asks for its family's rules on **every item** — 59,500 of them in
+ * one property sweep — and a fresh `filter` over the whole table each time is an
+ * array allocation and fifteen predicate calls per card, on the path CG-17 puts a
+ * p95 budget on. The cache is keyed on the default table only; a caller that
+ * passes its own rules (every failing-case test does) still gets a fresh filter,
+ * so a fixture can never be answered from a cache built for the real one.
+ */
+const byFamily = new Map<FamilyId, MalRule[]>();
 
 export function malRulesForFamily(family: FamilyId, rules: readonly MalRule[] = malRules): MalRule[] {
-  return rules.filter((rule) => rule.family === family);
+  if (rules !== malRules) return rules.filter((rule) => rule.family === family);
+  const cached = byFamily.get(family);
+  if (cached !== undefined) return cached;
+  const grouped = malRules.filter((rule) => rule.family === family);
+  byFamily.set(family, grouped);
+  return grouped;
 }
 
 export function malRuleById(id: MalRuleId, rules: readonly MalRule[] = malRules): MalRule | undefined {

--- a/dynawalla/packs/shared/curriculum/src/malrules/registry.ts
+++ b/dynawalla/packs/shared/curriculum/src/malrules/registry.ts
@@ -35,9 +35,9 @@ export const malRules: readonly MalRule[] = [
 /**
  * The shipped registry, grouped once.
  *
- * `generate()` asks for its family's rules on **every item** — 59,500 of them in
+ * `generate()` asks for its family's rules on **every item** — 56,500 of them in
  * one property sweep — and a fresh `filter` over the whole table each time is an
- * array allocation and fifteen predicate calls per card, on the path CG-17 puts a
+ * array allocation and sixteen predicate calls per card, on the path CG-17 puts a
  * p95 budget on. The cache is keyed on the default table only; a caller that
  * passes its own rules (every failing-case test does) still gets a fresh filter,
  * so a fixture can never be answered from a cache built for the real one.

--- a/dynawalla/packs/shared/curriculum/src/malrules/roots.ts
+++ b/dynawalla/packs/shared/curriculum/src/malrules/roots.ts
@@ -1,0 +1,26 @@
+/**
+ * Mal-rule root ids — the `parent` a group of bugs shares.
+ *
+ * A root is a **routing key, not an executable rule**, and it is deliberately not
+ * in the registry. `MalRule.parent` exists so that several bugs with one cause
+ * remediate together; if the root were itself a registered rule it would produce an
+ * output of its own, that output would match on the same items as its children, and
+ * `classify` — which returns `null` the moment two rules explain one wrong answer —
+ * would stop diagnosing anything at all.
+ *
+ * `mis.frac.whole-number-bias` is the case CURRICULUM.md names: adding numerators
+ * and denominators, and reading a larger denominator as a larger number, are the
+ * same belief in two places, and a child who holds it needs one repair rather than
+ * two.
+ *
+ * `mis.mul.shift-not-applied` is the second: the placeholder zero missing under a
+ * second partial product, and the zeros missing from a multiplication by a power of
+ * ten, are one belief about place value. They stay separate *rules* because the
+ * contradiction you show a child differs — one is about where a row is written, the
+ * other about a number that did not move — but they route to one repair.
+ */
+
+import { malRuleId } from "../types/ids.ts";
+
+export const MIS_WHOLE_NUMBER_BIAS = malRuleId("mis.frac.whole-number-bias");
+export const MIS_MUL_SHIFT_NOT_APPLIED = malRuleId("mis.mul.shift-not-applied");

--- a/dynawalla/packs/shared/curriculum/src/render/prompts.ts
+++ b/dynawalla/packs/shared/curriculum/src/render/prompts.ts
@@ -4,16 +4,15 @@
  * ## What this file is for
  *
  * CG-8 stopped a curriculum row going `active` behind an answer schema or a
- * representation the app could not draw. It said nothing about the **question**.
+ * representation nobody could draw. It said nothing about the **question**.
  *
- * That is not a theoretical hole. `dynawalla-app/src/work/problem.ts` reads an item
- * back out of `Exercise.prompt.slots` by matching `prompt.key` against exactly two
- * template keys — `dw.prompt.column-op.sub` and `dw.prompt.column-op.add` — and
- * returns `null` for anything else. `ProblemSlate` and `ProblemStatement` both
- * render `null` when it does. So an item from any other family draws its answer
- * entry, its keypad, its verdict well and its representation, and **no question at
- * all**: a fraction card with two empty cells over a bar and nothing to say what
- * they are for.
+ * That is not a theoretical hole. The practice loop that used to live in the host
+ * read an item back out of `Exercise.prompt.slots` by matching `prompt.key` against
+ * exactly two template keys — `dw.prompt.column-op.sub` and `dw.prompt.column-op.add`
+ * — and returned `null` for anything else, and the slate rendered `null` when it
+ * did. So an item from any other family drew its answer entry, its keypad, its
+ * verdict well and its representation, and **no question at all**: a fraction card
+ * with two empty cells over a bar and nothing to say what they are for.
  *
  * That is precisely the failure the bidirectional gate exists to prevent, one level
  * up from where it was looking, and it is why every family this package has gained
@@ -21,13 +20,13 @@
  *
  * ## Why this is a second registry rather than a third `kind`
  *
- * `rendererRegistry` is consumed by `dynawalla-app/src/work/renderers.test.ts`,
- * which branches on `kind === "answerSchema"` and treats **everything else** as a
- * `rep:` id, slicing four characters off the front. A third kind in that array
- * would make the app's own half of CG-8 fail on a string it cannot parse — the
- * curriculum breaking the app's test suite from the outside. A sibling registry
- * leaves that loop untouched, and the app closes its half of this one when it lands
- * a prompt renderer.
+ * A consumer of `rendererRegistry` reasonably branches on
+ * `kind === "answerSchema"` and treats everything else as a `rep:` id, slicing
+ * four characters off the front — which is what the host's own half of CG-8 did
+ * before ADR-0022 deleted it. A third kind in that array would break such a
+ * reader on a string it cannot parse, from the outside. A sibling registry
+ * leaves that loop untouched, and whoever lands a prompt renderer closes their
+ * half of this one.
  *
  * ## What `implemented` means here
  *
@@ -48,7 +47,7 @@ export type PromptTemplateDeclaration = {
   /** The PR that owns landing the renderer. Required — an unowned entry is noise. */
   readonly owner: string;
   readonly implemented: boolean;
-  /** Path of the test that proves the app draws it. Required once implemented. */
+  /** Path of the test that proves it is drawn. Required once implemented. */
   readonly testRef?: string;
 };
 
@@ -63,22 +62,23 @@ const FRAC_ARITH = familyId("gen.frac.arith");
 const MISSING_OPERAND = familyId("gen.arith.missing-operand");
 
 /**
- * The one prompt renderer that exists. `problem.ts` reads these two keys and
- * `ProblemSlate` writes the two operands on the slate; `surface.test.ts` and
- * `fixtures.test.ts` are what hold it up.
- */
-const SLATE = "dynawalla-app/src/work/surface.test.ts";
-
-/**
  * Every prompt template every registered family can emit.
  *
- * `PR-2.13` is the app PR that must land a statement renderer for the templates
- * below. It does not exist yet, which is the honest state and the reason for the
- * `draft` rows: a family whose question cannot be drawn has nothing to promote.
+ * **Nothing below is implemented, including the two column-op keys.** They were,
+ * by the host's problem slate, until
+ * [ADR-0022](../../../../docs/DECISIONS/ADR-0022-host-ships-no-content.md) deleted
+ * `dynawalla-app/src/work/` — the host ships no content, and stating a question is
+ * content. A `testRef` pointing at `surface.test.ts` would now name a file that
+ * does not exist, so the two entries go back to `false` with the rest.
+ *
+ * `PR-2.13` was the app PR that owed a statement renderer; the work is now a
+ * pack's. Either way it does not exist, which is the honest state and the reason
+ * for the `draft` rows: a family whose question cannot be drawn has nothing to
+ * promote.
  */
 export const promptRegistry: readonly PromptTemplateDeclaration[] = [
-  { id: locKey("dw.prompt.column-op.sub"), family: COLUMN_OP, owner: "PR-2.4", implemented: true, testRef: SLATE },
-  { id: locKey("dw.prompt.column-op.add"), family: COLUMN_OP, owner: "PR-2.4", implemented: true, testRef: SLATE },
+  { id: locKey("dw.prompt.column-op.sub"), family: COLUMN_OP, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.column-op.add"), family: COLUMN_OP, owner: "PR-2.13", implemented: false },
 
   { id: locKey("dw.prompt.place-value.digit-value"), family: PLACE_VALUE, owner: "PR-2.13", implemented: false },
   { id: locKey("dw.prompt.place-value.digit-in-place"), family: PLACE_VALUE, owner: "PR-2.13", implemented: false },

--- a/dynawalla/packs/shared/curriculum/src/render/prompts.ts
+++ b/dynawalla/packs/shared/curriculum/src/render/prompts.ts
@@ -1,0 +1,155 @@
+/**
+ * Prompt-template renderer declarations — the missing half of gate CG-8.
+ *
+ * ## What this file is for
+ *
+ * CG-8 stopped a curriculum row going `active` behind an answer schema or a
+ * representation the app could not draw. It said nothing about the **question**.
+ *
+ * That is not a theoretical hole. `dynawalla-app/src/work/problem.ts` reads an item
+ * back out of `Exercise.prompt.slots` by matching `prompt.key` against exactly two
+ * template keys — `dw.prompt.column-op.sub` and `dw.prompt.column-op.add` — and
+ * returns `null` for anything else. `ProblemSlate` and `ProblemStatement` both
+ * render `null` when it does. So an item from any other family draws its answer
+ * entry, its keypad, its verdict well and its representation, and **no question at
+ * all**: a fraction card with two empty cells over a bar and nothing to say what
+ * they are for.
+ *
+ * That is precisely the failure the bidirectional gate exists to prevent, one level
+ * up from where it was looking, and it is why every family this package has gained
+ * beyond `column-op` binds `draft` rows only.
+ *
+ * ## Why this is a second registry rather than a third `kind`
+ *
+ * `rendererRegistry` is consumed by `dynawalla-app/src/work/renderers.test.ts`,
+ * which branches on `kind === "answerSchema"` and treats **everything else** as a
+ * `rep:` id, slicing four characters off the front. A third kind in that array
+ * would make the app's own half of CG-8 fail on a string it cannot parse — the
+ * curriculum breaking the app's test suite from the outside. A sibling registry
+ * leaves that loop untouched, and the app closes its half of this one when it lands
+ * a prompt renderer.
+ *
+ * ## What `implemented` means here
+ *
+ * The same as everywhere else in this directory: `false` until a renderer and its
+ * test exist, a warning by default so the curriculum can be authored ahead of the
+ * work surface, and a failure under `--strict-renderers`, which the release
+ * checklist runs. Declaring everything therefore buys nothing at release.
+ */
+
+import type { FamilyId, LocKey } from "../types/ids.ts";
+import { familyId, locKey } from "../types/ids.ts";
+
+export type PromptTemplateDeclaration = {
+  /** The `LocKey` a family writes into `Exercise.prompt.key`. */
+  readonly id: LocKey;
+  /** The family that emits it. Lets the gate report a family, not just a key. */
+  readonly family: FamilyId;
+  /** The PR that owns landing the renderer. Required — an unowned entry is noise. */
+  readonly owner: string;
+  readonly implemented: boolean;
+  /** Path of the test that proves the app draws it. Required once implemented. */
+  readonly testRef?: string;
+};
+
+const COLUMN_OP = familyId("gen.arith.column-op");
+const PLACE_VALUE = familyId("gen.number.place-value-decompose");
+const COMPARE_ORDER = familyId("gen.number.compare-order");
+const ROUND_ESTIMATE = familyId("gen.number.round-estimate");
+const MULTIDIGIT_MUL = familyId("gen.arith.multidigit-mul");
+const LONG_DIV = familyId("gen.arith.long-div");
+const FRAC_EQUIVALENCE = familyId("gen.frac.equivalence-simplify");
+const FRAC_ARITH = familyId("gen.frac.arith");
+const MISSING_OPERAND = familyId("gen.arith.missing-operand");
+
+/**
+ * The one prompt renderer that exists. `problem.ts` reads these two keys and
+ * `ProblemSlate` writes the two operands on the slate; `surface.test.ts` and
+ * `fixtures.test.ts` are what hold it up.
+ */
+const SLATE = "dynawalla-app/src/work/surface.test.ts";
+
+/**
+ * Every prompt template every registered family can emit.
+ *
+ * `PR-2.13` is the app PR that must land a statement renderer for the templates
+ * below. It does not exist yet, which is the honest state and the reason for the
+ * `draft` rows: a family whose question cannot be drawn has nothing to promote.
+ */
+export const promptRegistry: readonly PromptTemplateDeclaration[] = [
+  { id: locKey("dw.prompt.column-op.sub"), family: COLUMN_OP, owner: "PR-2.4", implemented: true, testRef: SLATE },
+  { id: locKey("dw.prompt.column-op.add"), family: COLUMN_OP, owner: "PR-2.4", implemented: true, testRef: SLATE },
+
+  { id: locKey("dw.prompt.place-value.digit-value"), family: PLACE_VALUE, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.place-value.digit-in-place"), family: PLACE_VALUE, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.place-value.total-in-place"), family: PLACE_VALUE, owner: "PR-2.13", implemented: false },
+
+  { id: locKey("dw.prompt.compare-order.greater"), family: COMPARE_ORDER, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.compare-order.lesser"), family: COMPARE_ORDER, owner: "PR-2.13", implemented: false },
+
+  { id: locKey("dw.prompt.round-estimate.round"), family: ROUND_ESTIMATE, owner: "PR-2.13", implemented: false },
+
+  { id: locKey("dw.prompt.multidigit-mul.product"), family: MULTIDIGIT_MUL, owner: "PR-2.13", implemented: false },
+
+  { id: locKey("dw.prompt.long-div.quotient"), family: LONG_DIV, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.long-div.remainder"), family: LONG_DIV, owner: "PR-2.13", implemented: false },
+  {
+    id: locKey("dw.prompt.long-div.quotient-remainder"),
+    family: LONG_DIV,
+    owner: "PR-2.13",
+    implemented: false,
+  },
+
+  { id: locKey("dw.prompt.frac-equivalence.simplify"), family: FRAC_EQUIVALENCE, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.frac-equivalence.build"), family: FRAC_EQUIVALENCE, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.frac-equivalence.to-mixed"), family: FRAC_EQUIVALENCE, owner: "PR-2.13", implemented: false },
+  {
+    id: locKey("dw.prompt.frac-equivalence.to-improper"),
+    family: FRAC_EQUIVALENCE,
+    owner: "PR-2.13",
+    implemented: false,
+  },
+
+  { id: locKey("dw.prompt.frac-arith.add"), family: FRAC_ARITH, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.frac-arith.sub"), family: FRAC_ARITH, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.frac-arith.mul"), family: FRAC_ARITH, owner: "PR-2.13", implemented: false },
+  { id: locKey("dw.prompt.frac-arith.mul-whole"), family: FRAC_ARITH, owner: "PR-2.13", implemented: false },
+
+  {
+    id: locKey("dw.prompt.missing-operand.add-unknown"),
+    family: MISSING_OPERAND,
+    owner: "PR-2.13",
+    implemented: false,
+  },
+  {
+    id: locKey("dw.prompt.missing-operand.sub-unknown"),
+    family: MISSING_OPERAND,
+    owner: "PR-2.13",
+    implemented: false,
+  },
+  {
+    id: locKey("dw.prompt.missing-operand.sub-unknown-minuend"),
+    family: MISSING_OPERAND,
+    owner: "PR-2.13",
+    implemented: false,
+  },
+  {
+    id: locKey("dw.prompt.missing-operand.mul-unknown"),
+    family: MISSING_OPERAND,
+    owner: "PR-2.13",
+    implemented: false,
+  },
+  {
+    id: locKey("dw.prompt.missing-operand.both-sides"),
+    family: MISSING_OPERAND,
+    owner: "PR-2.13",
+    implemented: false,
+  },
+];
+
+export function findPromptTemplate(
+  key: LocKey,
+  registry: readonly PromptTemplateDeclaration[] = promptRegistry,
+): PromptTemplateDeclaration | undefined {
+  return registry.find((entry) => entry.id === key);
+}

--- a/dynawalla/packs/shared/curriculum/src/render/registry.ts
+++ b/dynawalla/packs/shared/curriculum/src/render/registry.ts
@@ -6,9 +6,9 @@
  * `active` unless its generator's `AnswerSchema` kind **and every
  * `representations.required` RepId** has a registered, tested renderer.
  *
- * `curriculum/` cannot import the app, so the registry is a declaration the app
- * has to satisfy, not a live lookup. Three things keep that from becoming a
- * rubber stamp:
+ * `curriculum/` cannot import whoever draws, so the registry is a declaration
+ * that side has to satisfy, not a live lookup. Three things keep that from
+ * becoming a rubber stamp:
  *
  * - `owner` names the PR that must land the renderer; an entry with no owner is
  *   meaningless and the gate rejects it.
@@ -17,12 +17,26 @@
  *   authored ahead of the work surface); `--strict-renderers`, which the release
  *   checklist runs, does not. So "declare everything" buys nothing at release.
  * - `testRef` is the test that proves it draws, and CG-8 rejects `implemented`
- *   without one. `dynawalla-app/src/work/renderers.test.ts` closes the loop from
- *   the app's side, in both directions: a declaration nobody satisfies is a lie,
- *   and a renderer nobody declared cannot let its skills go active.
+ *   without one. Whoever claims a renderer closes the loop from their side, in
+ *   both directions: a declaration nobody satisfies is a lie, and a renderer
+ *   nobody declared cannot let its skills go active.
  *
- * Every `implemented: true` below is a renderer that exists today, not a
- * roadmap.
+ * ## Nothing here is implemented, and that is the honest state
+ *
+ * These entries used to be satisfied by the host's practice loop —
+ * `dynawalla-app/src/work/`. [ADR-0022](../../../../docs/DECISIONS/ADR-0022-host-ships-no-content.md)
+ * deleted that surface: the host ships no content, and drawing an exercise is
+ * content. **No module in this repository draws a curriculum item today.** The
+ * generators, the mal-rules and the walkthrough are a library; the thing that
+ * puts a question and an answer entry on a child's screen is a pack.
+ *
+ * So every entry below is `implemented: false` with the PR that owes it, and
+ * `--strict-renderers` fails — which is correct, because a release with nothing
+ * drawing anything is not a release. The first pack to draw a curriculum item
+ * flips the entries it satisfies and names the test that holds them up. Leaving
+ * them `true` with a `testRef` into a deleted file would have made CG-8 green by
+ * pointing at a file that no longer exists, which is exactly the rubber stamp
+ * the three rules above exist to prevent.
  */
 
 import type { AnswerSchemaKind } from "../types/answer.ts";
@@ -39,33 +53,25 @@ export type RendererDeclaration = {
   readonly testRef?: string;
 };
 
-const ENTRY_TEST = "dynawalla-app/src/work/entry.test.ts";
-const REP_TEST = "dynawalla-app/src/work/representation.test.ts";
+/**
+ * The pack renderer nobody has written. One constant rather than eight copies of
+ * the same string, so the day a pack lands one the diff is the entry it earned
+ * and not a search-and-replace over the whole table.
+ */
+const PACK = "PR-4.16 — a pack renderer, ADR-0022";
 
 export const rendererRegistry: readonly RendererDeclaration[] = [
-  { id: "answer:integer", kind: "answerSchema", owner: "PR-2.3", implemented: true, testRef: ENTRY_TEST },
-  {
-    id: "answer:columnAlgorithm",
-    kind: "answerSchema",
-    owner: "PR-2.4",
-    implemented: true,
-    testRef: ENTRY_TEST,
-  },
-  { id: "answer:fraction", kind: "answerSchema", owner: "PR-2.12", implemented: true, testRef: ENTRY_TEST },
-  { id: "answer:choice", kind: "answerSchema", owner: "PR-2.12", implemented: true, testRef: ENTRY_TEST },
-  {
-    id: "rep:counting-board",
-    kind: "representation",
-    owner: "PR-2.10",
-    implemented: true,
-    testRef: "dynawalla-app/src/work/diagnosis.test.ts",
-  },
-  { id: "rep:number-line", kind: "representation", owner: "PR-2.12", implemented: true, testRef: REP_TEST },
-  { id: "rep:balance-scale", kind: "representation", owner: "PR-2.12", implemented: true, testRef: REP_TEST },
-  // Declared, not built. The gear train carries multiples, factors and LCM
-  // (CURRICULUM.md), and none of that content exists yet — a renderer with no
-  // item to draw is a renderer nobody can check, and `--strict-renderers` is
-  // what keeps a skill going active behind it.
+  { id: "answer:integer", kind: "answerSchema", owner: PACK, implemented: false },
+  { id: "answer:columnAlgorithm", kind: "answerSchema", owner: PACK, implemented: false },
+  { id: "answer:fraction", kind: "answerSchema", owner: PACK, implemented: false },
+  { id: "answer:choice", kind: "answerSchema", owner: PACK, implemented: false },
+  { id: "rep:counting-board", kind: "representation", owner: PACK, implemented: false },
+  { id: "rep:number-line", kind: "representation", owner: PACK, implemented: false },
+  { id: "rep:balance-scale", kind: "representation", owner: PACK, implemented: false },
+  // Declared, not built, and for a second reason on top of the one above: the
+  // gear train carries multiples, factors and LCM (CURRICULUM.md), and none of
+  // that content exists yet — a renderer with no item to draw is a renderer
+  // nobody can check.
   { id: "rep:gear-train", kind: "representation", owner: "PR-7.14", implemented: false },
 ];
 

--- a/dynawalla/packs/shared/curriculum/src/render/registry.ts
+++ b/dynawalla/packs/shared/curriculum/src/render/registry.ts
@@ -7,18 +7,22 @@
  * `representations.required` RepId** has a registered, tested renderer.
  *
  * `curriculum/` cannot import the app, so the registry is a declaration the app
- * has to satisfy, not a live lookup. Two fields keep that from becoming a rubber
- * stamp:
+ * has to satisfy, not a live lookup. Three things keep that from becoming a
+ * rubber stamp:
  *
- * - `owner` names the PR that must land the renderer. An entry with no owner is
+ * - `owner` names the PR that must land the renderer; an entry with no owner is
  *   meaningless and the gate rejects it.
  * - `implemented` is `false` until the renderer and its test exist. The default
- *   gate accepts a declared-but-unimplemented renderer (the curriculum can be
+ *   gate accepts a declared-but-unimplemented renderer (the curriculum may be
  *   authored ahead of the work surface); `--strict-renderers`, which the release
  *   checklist runs, does not. So "declare everything" buys nothing at release.
+ * - `testRef` is the test that proves it draws, and CG-8 rejects `implemented`
+ *   without one. `dynawalla-app/src/work/renderers.test.ts` closes the loop from
+ *   the app's side, in both directions: a declaration nobody satisfies is a lie,
+ *   and a renderer nobody declared cannot let its skills go active.
  *
- * PR-2.3 and PR-2.4 flip `integer` and `columnAlgorithm` to implemented and add
- * `testRef`. PR-2.10 does the same for the counting board.
+ * Every `implemented: true` below is a renderer that exists today, not a
+ * roadmap.
  */
 
 import type { AnswerSchemaKind } from "../types/answer.ts";
@@ -35,10 +39,34 @@ export type RendererDeclaration = {
   readonly testRef?: string;
 };
 
+const ENTRY_TEST = "dynawalla-app/src/work/entry.test.ts";
+const REP_TEST = "dynawalla-app/src/work/representation.test.ts";
+
 export const rendererRegistry: readonly RendererDeclaration[] = [
-  { id: "answer:integer", kind: "answerSchema", owner: "PR-2.3", implemented: false },
-  { id: "answer:columnAlgorithm", kind: "answerSchema", owner: "PR-2.4", implemented: false },
-  { id: "rep:counting-board", kind: "representation", owner: "PR-2.10", implemented: false },
+  { id: "answer:integer", kind: "answerSchema", owner: "PR-2.3", implemented: true, testRef: ENTRY_TEST },
+  {
+    id: "answer:columnAlgorithm",
+    kind: "answerSchema",
+    owner: "PR-2.4",
+    implemented: true,
+    testRef: ENTRY_TEST,
+  },
+  { id: "answer:fraction", kind: "answerSchema", owner: "PR-2.12", implemented: true, testRef: ENTRY_TEST },
+  { id: "answer:choice", kind: "answerSchema", owner: "PR-2.12", implemented: true, testRef: ENTRY_TEST },
+  {
+    id: "rep:counting-board",
+    kind: "representation",
+    owner: "PR-2.10",
+    implemented: true,
+    testRef: "dynawalla-app/src/work/diagnosis.test.ts",
+  },
+  { id: "rep:number-line", kind: "representation", owner: "PR-2.12", implemented: true, testRef: REP_TEST },
+  { id: "rep:balance-scale", kind: "representation", owner: "PR-2.12", implemented: true, testRef: REP_TEST },
+  // Declared, not built. The gear train carries multiples, factors and LCM
+  // (CURRICULUM.md), and none of that content exists yet — a renderer with no
+  // item to draw is a renderer nobody can check, and `--strict-renderers` is
+  // what keeps a skill going active behind it.
+  { id: "rep:gear-train", kind: "representation", owner: "PR-7.14", implemented: false },
 ];
 
 export function answerRendererId(kind: AnswerSchemaKind): string {

--- a/dynawalla/packs/shared/curriculum/src/render/representations.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/render/representations.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The two representation semantics a renderer has already got wrong once.
+ *
+ * Both bugs shipped in an earlier attempt at these representations and neither
+ * was caught by reading the code. Both are properties of the **spec**, not of any
+ * one renderer, so they are pinned here — in the library every pack imports —
+ * rather than in a renderer that does not exist yet and will not be the last one.
+ *
+ * The renderers themselves went with the host (ADR-0022). These functions are
+ * what replaces them: the number a tick stands for, and the pan that hangs lower.
+ * A renderer that computes either for itself is free to reintroduce the bug; one
+ * that asks is not.
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { eq, rational, toString as rationalToString } from "../math/rational.ts";
+import {
+  balanceLowerPan,
+  numberLinePoint,
+  repSpecDefect,
+  REP_BALANCE_SCALE,
+  REP_COUNTING_BOARD,
+  REP_NUMBER_LINE,
+  V1_REPRESENTATIONS,
+} from "./representations.ts";
+
+test("the marked point is from + mark/denominator, not a whole part beside a fraction", () => {
+  // Non-negative lines, where the two readings agree and the bug hides.
+  assert.ok(eq(numberLinePoint(0, 3, 4), rational(3n, 4n)));
+  assert.ok(eq(numberLinePoint(0, 4, 4), rational(1n)));
+  assert.ok(eq(numberLinePoint(1, 5, 3), rational(8n, 3n)));
+  assert.ok(eq(numberLinePoint(2, 0, 3), rational(2n)));
+
+  // The case that broke. `{ from: -3, mark: 1, denominator: 4 }` is −11/4, and a
+  // renderer that wrote its whole part beside its fraction produced "-3 1/4",
+  // which parses back as −13/4: a different point, on a line drawn to teach
+  // where points are.
+  const point = numberLinePoint(-3, 1, 4);
+  assert.equal(rationalToString(point), "-11/4");
+  assert.ok(!eq(point, rational(-13n, 4n)), "the naive whole-part composition is a different number");
+
+  // A mixed reading of it is "−2 3/4": the whole part is −2, not the line's
+  // `from`, and the fractional part is 3/4, not `mark/denominator`.
+  assert.ok(eq(numberLinePoint(-3, 1, 4), rational(-2n * 4n - 3n, 4n)));
+
+  // Every other point on that line, so the assertion above is not one lucky case.
+  assert.equal(rationalToString(numberLinePoint(-3, 0, 4)), "-3");
+  assert.equal(rationalToString(numberLinePoint(-3, 2, 4)), "-5/2");
+  assert.equal(rationalToString(numberLinePoint(-3, 4, 4)), "-2");
+  assert.equal(rationalToString(numberLinePoint(-1, 1, 4)), "-3/4");
+});
+
+test("the heavier pan is the lower one", () => {
+  assert.equal(balanceLowerPan(7, 3), -1, "the left pan is heavier, so the left pan hangs lower");
+  assert.equal(balanceLowerPan(3, 7), 1, "the right pan is heavier, so the right pan hangs lower");
+  assert.equal(balanceLowerPan(5, 5), 0, "equal pans balance, which is the whole idea");
+
+  // Antisymmetry, over a small square of pan loads. A renderer whose beam angle
+  // is signed the wrong way in screen space satisfies "the two angles are mirror
+  // images" exactly as well as a correct one does, so mirror-image-ness is not
+  // the property to assert — which side is lower is.
+  for (let left = 0; left <= 6; left += 1) {
+    for (let right = 0; right <= 6; right += 1) {
+      const here = balanceLowerPan(left, right);
+      const swapped = balanceLowerPan(right, left);
+      // `0 === -0` is false under `Object.is`, which is what strict `assert`
+      // compares with, so the balanced case is stated rather than negated.
+      assert.equal(here, here === 0 ? swapped : -swapped);
+      if (left > right) assert.equal(here, -1);
+      if (left === right) assert.equal(here, 0);
+    }
+  }
+});
+
+test("a spec that cannot be drawn is rejected before anything draws it", () => {
+  assert.equal(repSpecDefect(REP_NUMBER_LINE, { from: 0, to: 1, denominator: 4, mark: 3 }), null);
+  assert.equal(repSpecDefect(REP_BALANCE_SCALE, { left: 4, right: 4 }), null);
+  assert.equal(repSpecDefect(REP_COUNTING_BOARD, {}), null);
+
+  assert.match(String(repSpecDefect("water-clock", {})), /no representation/);
+  assert.match(String(repSpecDefect(REP_NUMBER_LINE, { from: 0, to: 1, denominator: 4 })), /missing mark/);
+  assert.match(String(repSpecDefect(REP_NUMBER_LINE, { from: 2, to: 1, denominator: 4, mark: 0 })), /backwards/);
+  assert.match(String(repSpecDefect(REP_NUMBER_LINE, { from: 0, to: 1, denominator: 0, mark: 0 })), /subdivision/);
+  assert.match(String(repSpecDefect(REP_NUMBER_LINE, { from: 0, to: 1, denominator: 4, mark: 5 })), /off the line/);
+  assert.match(String(repSpecDefect(REP_NUMBER_LINE, { from: 0, to: 5, denominator: 8, mark: 1 })), /24 intervals/);
+  assert.match(String(repSpecDefect(REP_BALANCE_SCALE, { left: -1, right: 4 })), /negative/);
+
+  // ADR-0006's float bug wearing a hat: a tick label of `0.30000000000000004`.
+  const drifted = repSpecDefect(REP_NUMBER_LINE, { from: 0, to: 1, denominator: 3, mark: 1 / 3 });
+  assert.match(String(drifted), /not a safe integer/);
+});
+
+test("every V1 representation declares what it requires", () => {
+  for (const rep of V1_REPRESENTATIONS) {
+    // The gear train is declared and unbuilt, and has no params table yet; the
+    // other three must answer for themselves.
+    if (rep === "gear-train") continue;
+    assert.equal(repSpecDefect(rep, {}) === `no representation "${rep}"`, false, `${rep} has no params table`);
+  }
+});

--- a/dynawalla/packs/shared/curriculum/src/render/representations.ts
+++ b/dynawalla/packs/shared/curriculum/src/render/representations.ts
@@ -1,0 +1,85 @@
+/**
+ * The representation ids, and what each one is allowed to be handed.
+ *
+ * CURRICULUM.md fixes four for V1 — counting board, balance scale, gear train,
+ * number line — and each carries one idea. Ids live here rather than beside
+ * whichever module needed one first: a `RepId` is a string, and a typo is a
+ * `RepSpec` no renderer matches and a blank space on a child's screen.
+ *
+ * `RepSpec.params` is `Record<string, number>`, and the rule this module adds is
+ * that **every param is a safe integer**. A representation is drawing rather
+ * than arithmetic, but the numbers it draws are the numbers the answer is made
+ * of, and a `0.30000000000000004` tick label is ADR-0006's float bug wearing a
+ * hat. Thirds are `{ from: 0, to: 1, denominator: 3, mark: 2 }` — exact — and the
+ * renderer builds the `Rational` itself.
+ *
+ * `repSpecDefect` is the precondition, checked by the app before it draws and by
+ * `representation.test.ts`, so a malformed spec is a red test rather than a
+ * mis-drawn number.
+ */
+
+import type { RepId } from "../types/ids.ts";
+
+/** Place value and regrouping. The LOCATE representation for borrow-across-zero. */
+export const REP_COUNTING_BOARD: RepId = "counting-board";
+/** Magnitude, fractions, comparison. */
+export const REP_NUMBER_LINE: RepId = "number-line";
+/** The equals sign as a relation, not an operator. */
+export const REP_BALANCE_SCALE: RepId = "balance-scale";
+/** Multiples, factors, LCM. Not built — see the renderer registry. */
+export const REP_GEAR_TRAIN: RepId = "gear-train";
+
+export const V1_REPRESENTATIONS: readonly RepId[] = [
+  REP_COUNTING_BOARD,
+  REP_NUMBER_LINE,
+  REP_BALANCE_SCALE,
+  REP_GEAR_TRAIN,
+];
+
+/**
+ * Params each representation requires.
+ *
+ * `number-line`: the line runs `from`..`to` in whole units, each cut into
+ * `denominator` parts, with the index `mark` parts from the left end.
+ * `balance-scale`: what sits in each pan, in whole units — equal pans balance,
+ * which is the idea. `counting-board` takes none: it is built from the item's
+ * own digits by `contrast.ts`, which needs the exercise rather than a spec.
+ */
+export const REQUIRED_REP_PARAMS: Readonly<Record<string, readonly string[]>> = {
+  [REP_NUMBER_LINE]: ["from", "to", "denominator", "mark"],
+  [REP_BALANCE_SCALE]: ["left", "right"],
+  [REP_COUNTING_BOARD]: [],
+};
+
+/** Why this spec cannot be drawn, or `null`. */
+export function repSpecDefect(rep: RepId, params: Readonly<Record<string, number>>): string | null {
+  const required = REQUIRED_REP_PARAMS[rep];
+  if (required === undefined) return `no representation "${rep}"`;
+
+  for (const [name, value] of Object.entries(params)) {
+    if (!Number.isSafeInteger(value)) return `${rep}.${name} is not a safe integer: ${String(value)}`;
+  }
+  for (const name of required) {
+    if (params[name] === undefined) return `${rep} is missing ${name}`;
+  }
+
+  if (rep === REP_NUMBER_LINE) {
+    const from = params["from"] ?? 0;
+    const to = params["to"] ?? 0;
+    const denominator = params["denominator"] ?? 0;
+    const mark = params["mark"] ?? 0;
+    if (to <= from) return "number-line runs backwards or has no length";
+    if (denominator < 1) return "number-line has no subdivision";
+    if (mark < 0 || mark > (to - from) * denominator) return "number-line mark is off the line";
+    // A line a child can read. Twelve ticks is a fraction wall; sixty is a hairbrush.
+    if ((to - from) * denominator > 24) return "number-line has more than 24 intervals";
+  }
+
+  if (rep === REP_BALANCE_SCALE) {
+    const left = params["left"] ?? 0;
+    const right = params["right"] ?? 0;
+    if (left < 0 || right < 0) return "balance-scale pans cannot hold a negative amount";
+  }
+
+  return null;
+}

--- a/dynawalla/packs/shared/curriculum/src/render/representations.ts
+++ b/dynawalla/packs/shared/curriculum/src/render/representations.ts
@@ -13,11 +13,14 @@
  * hat. Thirds are `{ from: 0, to: 1, denominator: 3, mark: 2 }` — exact — and the
  * renderer builds the `Rational` itself.
  *
- * `repSpecDefect` is the precondition, checked by the app before it draws and by
- * `representation.test.ts`, so a malformed spec is a red test rather than a
- * mis-drawn number.
+ * `repSpecDefect` is the precondition. `families.property.test.ts` runs it over
+ * every representation every family emits, across the whole seed sweep, so a
+ * malformed spec is a red test here rather than a mis-drawn number on a screen —
+ * and whoever draws one calls it before drawing.
  */
 
+import type { Rational } from "../math/rational.ts";
+import { add, rational } from "../math/rational.ts";
 import type { RepId } from "../types/ids.ts";
 
 /** Place value and regrouping. The LOCATE representation for borrow-across-zero. */
@@ -44,6 +47,27 @@ export const V1_REPRESENTATIONS: readonly RepId[] = [
  * `balance-scale`: what sits in each pan, in whole units — equal pans balance,
  * which is the idea. `counting-board` takes none: it is built from the item's
  * own digits by `contrast.ts`, which needs the exercise rather than a spec.
+ *
+ * ## Two things a renderer of these gets wrong, written down because both were
+ *
+ * A previous attempt at these two shipped both, and neither was caught by reading
+ * the code. They are properties of the *spec*, so they belong here rather than in
+ * whichever renderer is next.
+ *
+ * **The marked point is `from + mark/denominator`, and it is one number.** It is
+ * not the whole part `from` written beside the fraction `mark/denominator`. That
+ * reading is indistinguishable from the right one on every non-negative line,
+ * which is why it survives review, and wrong on every negative one: `{ from: -3,
+ * mark: 1, denominator: 4 }` is −3 + 1/4 = −11/4, which is written **−2 3/4**.
+ * Writing "−3 1/4" reads back as −13/4 — a different point, on a line drawn to
+ * teach where points are.
+ *
+ * **The heavier pan hangs lower.** In screen space `y` grows downward, so CSS
+ * `rotate(a)` with a positive `a` lifts the *left* end of a beam, not lowers it.
+ * A beam whose angle is signed the intuitive way tips toward the lighter pan, and
+ * a balance that rises under weight teaches the opposite of the equals sign it
+ * exists to teach. Two mirror-image angles are not evidence of anything here —
+ * the inverted pair are mirror images too. Measure which drawn pan is lower.
  */
 export const REQUIRED_REP_PARAMS: Readonly<Record<string, readonly string[]>> = {
   [REP_NUMBER_LINE]: ["from", "to", "denominator", "mark"],
@@ -82,4 +106,38 @@ export function repSpecDefect(rep: RepId, params: Readonly<Record<string, number
   }
 
   return null;
+}
+
+/**
+ * The exact value of the marked point on a number line.
+ *
+ * `from + mark/denominator`, as a `Rational`, so a renderer never composes it out
+ * of a whole part and a fraction — the composition that produced "−3 1/4" for the
+ * point −11/4, a label that reads back as −13/4. Whatever a renderer writes on
+ * the tick must parse back to *this*, and `representations.test.ts` fixes the
+ * negative cases the composition gets wrong.
+ *
+ * Callers pass a spec `repSpecDefect` has already accepted; a denominator of zero
+ * throws, which is `rational`'s contract and not something to swallow here.
+ */
+export function numberLinePoint(from: number, mark: number, denominator: number): Rational {
+  return add(rational(BigInt(from)), rational(BigInt(mark), BigInt(denominator)));
+}
+
+/**
+ * Which pan of a balance hangs lower: `-1` left, `1` right, `0` level.
+ *
+ * The direction is a fact about weight, and it is stated here in those terms
+ * rather than as an angle, because an angle is where it goes wrong. In screen
+ * space `y` grows downward, so a positive CSS rotation *lifts* the left end of a
+ * beam; a renderer that signs its transform the intuitive way draws the heavier
+ * pan higher, and a balance that rises under weight teaches the reverse of the
+ * equals sign it exists to teach. Two mirror-image angles do not distinguish the
+ * two — the inverted pair are mirror images as well. A renderer maps this to its
+ * own transform and asserts the drawn geometry against it.
+ */
+export function balanceLowerPan(left: number, right: number): -1 | 0 | 1 {
+  if (left > right) return -1;
+  if (right > left) return 1;
+  return 0;
 }

--- a/dynawalla/packs/shared/curriculum/src/serialize.ts
+++ b/dynawalla/packs/shared/curriculum/src/serialize.ts
@@ -20,6 +20,11 @@ function slot(value: PromptSlot): string {
       return `c(${String(value.value)})`;
     case "term":
       return `t(${value.key})`;
+    case "fraction":
+      // The written parts, like `answerToString` — `2/4` and `1/2` are the same
+      // number and different problems, and a hash that could not tell them apart
+      // would let a generator swap one for the other with no snapshot change.
+      return `f(${(value.whole ?? 0n).toString()};${value.num.toString()}/${value.den.toString()})`;
   }
 }
 

--- a/dynawalla/packs/shared/curriculum/src/snapshots/generators.json
+++ b/dynawalla/packs/shared/curriculum/src/snapshots/generators.json
@@ -10,6 +10,18 @@
     "gen.arith.column-op@1|dw.add.regroup.subtract-across-zero|L2": "f9e45b9a8648926e",
     "gen.arith.column-op@1|dw.add.regroup.add-multidigit|L0": "4609c8bb844b7b81",
     "gen.arith.column-op@1|dw.add.regroup.add-multidigit|L1": "f9426934d400c3ae",
-    "gen.arith.column-op@1|dw.add.regroup.add-multidigit|L2": "4bcfbb15db1c766e"
+    "gen.arith.column-op@1|dw.add.regroup.add-multidigit|L2": "4bcfbb15db1c766e",
+    "gen.arith.column-op@1|dw.add.column.add-no-regroup|L0": "c88fd32d3a6d5e6b",
+    "gen.arith.column-op@1|dw.add.column.add-no-regroup|L1": "2323e14d00e6fd21",
+    "gen.arith.column-op@1|dw.add.column.add-no-regroup|L2": "ff2cdcf58cbdf3bd",
+    "gen.arith.column-op@1|dw.add.column.subtract-no-regroup|L0": "00e473a7680bc393",
+    "gen.arith.column-op@1|dw.add.column.subtract-no-regroup|L1": "4e29d6eabb1d995d",
+    "gen.arith.column-op@1|dw.add.column.subtract-no-regroup|L2": "0d90a12baf4b80f1",
+    "gen.arith.column-op@1|dw.add.regroup.add-short-addend|L0": "b6d4d2bd8777bb0b",
+    "gen.arith.column-op@1|dw.add.regroup.add-short-addend|L1": "b3daa1bfb588e482",
+    "gen.arith.column-op@1|dw.add.regroup.add-short-addend|L2": "a7cb31b4352648b9",
+    "gen.arith.column-op@1|dw.add.regroup.subtract-short-subtrahend|L0": "a365f4bf15426994",
+    "gen.arith.column-op@1|dw.add.regroup.subtract-short-subtrahend|L1": "22835dd4f74725c5",
+    "gen.arith.column-op@1|dw.add.regroup.subtract-short-subtrahend|L2": "2ab4671d595a2162"
   }
 }

--- a/dynawalla/packs/shared/curriculum/src/types/answer.ts
+++ b/dynawalla/packs/shared/curriculum/src/types/answer.ts
@@ -7,10 +7,57 @@
  *
  * Every numeric answer value is a `Rational`. Comparison is exact and structural —
  * there is no tolerance, no epsilon and no float anywhere on this path.
+ *
+ * `fraction.equivalence` and `choice.options` are here because a renderer receives
+ * the **schema** and nothing else: `EntryModel.init`, `.keys` and `.value` take a
+ * schema, not an `Exercise`. Anything the surface must know to draw an answer, or
+ * to decide what counts as the same answer, has to be on the schema or it is not
+ * knowable where it is needed.
+ *
+ * - **`equivalence`** answers "is `2/4` the same answer as `1/2`?" — a curriculum
+ *   decision per skill, not an arithmetic one, since on `simplify-to-lowest-terms`
+ *   accepting `2/4` marks the thing being taught as correct. Omitted means
+ *   `as-written`, the strict reading and the safe default.
+ * - **`options`** is the drawn list, in the order `AnswerValue.choice.index`
+ *   indexes. Without it a choice item is a number `k` with nothing to put on the
+ *   screen, and the shuffle deciding which slot holds the answer has nowhere
+ *   deterministic to live.
  */
 
 import type { Rational } from "../math/rational.ts";
-import { eq as rationalEq, toString as rationalToString } from "../math/rational.ts";
+import {
+  abs as rationalAbs,
+  add as rationalAdd,
+  eq as rationalEq,
+  rational,
+  sub as rationalSub,
+  toString as rationalToString,
+} from "../math/rational.ts";
+
+/**
+ * One drawn option of a choice item.
+ *
+ * Two kinds, both numbers, and the omission is the point. A word option would
+ * have to be a `LocKey` — CG-19 forbids a rendered string anywhere in an
+ * `Exercise` — and there is no i18n runtime to resolve one, so a renderer that
+ * accepted `term` today would draw `dw.opt.line-of-symmetry` on a child's
+ * screen. Adding the kind before the layer that can draw it is exactly the
+ * failure CG-8 exists to stop, so the kind waits for PR-1.6 and the skills that
+ * need words stay `draft` until then.
+ *
+ * `count` is absent for a different reason: an option is a thing to write, and a
+ * plural-sensitive count is a thing to say.
+ */
+export type ChoiceOption =
+  | { readonly kind: "number"; readonly value: Rational; readonly decimalPlaces: number }
+  | { readonly kind: "fraction"; readonly num: bigint; readonly den: bigint; readonly whole?: bigint };
+
+/** Which *written* forms of the same number count as the same answer. */
+export type FractionEquivalence =
+  /** `1/2` only. `2/4` is a different answer — which is the point of simplifying. */
+  | "as-written"
+  /** Any fraction equal in value, however written. `2/4`, `1/2` and `3/6` all pass. */
+  | "any-equivalent";
 
 export type AnswerSchema =
   | { readonly kind: "integer"; readonly digits: number; readonly decimalPlaces: number }
@@ -20,8 +67,18 @@ export type AnswerSchema =
       readonly marks: "carry" | "borrow" | "none";
       readonly decimalPlaces: number;
     }
-  | { readonly kind: "fraction"; readonly parts: readonly ("num" | "den" | "whole")[] }
-  | { readonly kind: "choice"; readonly k: 2 | 3 | 4 };
+  | {
+      readonly kind: "fraction";
+      readonly parts: readonly ("num" | "den" | "whole")[];
+      /** Absent means `as-written`. */
+      readonly equivalence?: FractionEquivalence;
+    }
+  | {
+      readonly kind: "choice";
+      readonly k: 2 | 3 | 4;
+      /** Exactly `k` of them, in the order `AnswerValue.choice.index` indexes. */
+      readonly options: readonly ChoiceOption[];
+    };
 
 export type AnswerSchemaKind = AnswerSchema["kind"];
 
@@ -41,18 +98,44 @@ export type AnswerValue =
     }
   // Fractions keep the *written* numerator and denominator: 2/4 and 1/2 are the same
   // number and different answers, and which one is accepted is a curriculum decision
-  // per skill, not an arithmetic one.
+  // per skill, not an arithmetic one. `AnswerSchema.fraction.equivalence` is where
+  // that decision is written down and `answerAccepted` is where it is applied.
   | { readonly kind: "fraction"; readonly num: bigint; readonly den: bigint; readonly whole?: bigint }
   | { readonly kind: "choice"; readonly index: number };
 
 export type AnswerValueKind = AnswerValue["kind"];
 
+export type FractionValue = Extract<AnswerValue, { kind: "fraction" }>;
+
 /**
- * Exact equality of two submitted answers.
+ * The exact value of a written fraction.
+ *
+ * A mixed number is `whole ± num/den`, and the sign rides on `whole` when there is
+ * one: "negative two and a third" is `-2 - 1/3`, never `-2 + 1/3`. Written out
+ * because the naive `whole + num/den` is right for every V1 item (elementary
+ * fractions are non-negative) and silently wrong the first time integers arrive.
+ *
+ * Throws on a zero denominator, which is what `rational` does and what an entry
+ * model must never hand over.
+ */
+export function fractionRational(value: FractionValue): Rational {
+  const whole = value.whole ?? 0n;
+  const part = rational(value.num, value.den);
+  return whole < 0n
+    ? rationalSub(rational(whole), rationalAbs(part))
+    : rationalAdd(rational(whole), part);
+}
+
+/**
+ * Exact equality of two submitted answers, **as written**.
  *
  * `columnAlgorithm` compares the *number* and ignores the marks: a child who
  * regroups mentally and writes only the digits is right. Marks are process
  * evidence for diagnosis, never a correctness condition.
+ *
+ * This is the structural comparison. Anything schema-dependent — which is to say
+ * anything about equivalent *forms* — is `answerAccepted` below, so that a caller
+ * holding only two values can still ask the narrow question.
  */
 export function answerEquals(a: AnswerValue, b: AnswerValue): boolean {
   if (a.kind !== b.kind) return false;
@@ -62,12 +145,50 @@ export function answerEquals(a: AnswerValue, b: AnswerValue): boolean {
     case "columnAlgorithm":
       return rationalEq(a.value, (b as Extract<AnswerValue, { kind: "columnAlgorithm" }>).value);
     case "fraction": {
-      const other = b as Extract<AnswerValue, { kind: "fraction" }>;
+      const other = b as FractionValue;
       return a.num === other.num && a.den === other.den && (a.whole ?? 0n) === (other.whole ?? 0n);
     }
     case "choice":
       return a.index === (b as Extract<AnswerValue, { kind: "choice" }>).index;
   }
+}
+
+/**
+ * Does `submitted` count as `expected` **under this schema**?
+ *
+ * Exactly `answerEquals`, widened in the one place a schema says a different
+ * writing of the same number is the same answer. Nothing here is a tolerance:
+ * `any-equivalent` compares two exact rationals, and a comparison that is not
+ * exact does not exist on this path.
+ *
+ * `0.5` is never an accepted fraction and `1/2` is never an accepted decimal —
+ * the kinds differ, so `answerEquals` already says no and this does not widen
+ * across kinds. That is deliberate: a fraction card draws a fraction entry, so a
+ * child cannot type `0.5` into it, and a skill that genuinely wants both notations
+ * lists the second one in `Exercise.answer.alsoAccept`, where the curriculum can
+ * see it.
+ *
+ * **This is on the judging path**, and it has to be: `GeneratorFamily.check` calls
+ * it, so `equivalence` is a knob that does something. It shipped as one that did
+ * not — `check` compared with `answerEquals` and nothing in the program reached
+ * here — which would have marked every child who wrote `2/4` on a skill that
+ * accepts any equivalent wrong. A family that reaches for `answerEquals` in its
+ * checker is declining a decision the curriculum already made.
+ */
+export function answerAccepted(
+  schema: AnswerSchema,
+  expected: AnswerValue,
+  submitted: AnswerValue,
+): boolean {
+  if (
+    schema.kind === "fraction" &&
+    schema.equivalence === "any-equivalent" &&
+    expected.kind === "fraction" &&
+    submitted.kind === "fraction"
+  ) {
+    return rationalEq(fractionRational(expected), fractionRational(submitted));
+  }
+  return answerEquals(expected, submitted);
 }
 
 /** Stable text form. Used for hashing, snapshots and dedupe — never shown to a child. */
@@ -91,4 +212,81 @@ export function answerToString(value: AnswerValue): string {
 /** True when the schema can only be answered by choosing from a closed list (CG-13). */
 export function isChoiceSchema(schema: AnswerSchema): boolean {
   return schema.kind === "choice";
+}
+
+/**
+ * Is this schema drawable as written — enough fields, enough options, a legal
+ * decimal position?
+ *
+ * The renderer's precondition, stated once. A generator that emits a four-option
+ * choice with three options, or a fraction with no denominator, produces a card
+ * the app cannot draw, and the failure would otherwise be a blank cell on a
+ * child's screen rather than a red gate.
+ */
+export function schemaDefect(schema: AnswerSchema): string | null {
+  switch (schema.kind) {
+    // A decimal answer is always written with a whole-number digit — `0.75`, never
+    // `.75` — so a schema whose places consume its whole capacity is not a defect,
+    // it is a schema whose renderer must floor the whole part at one column. Only
+    // an impossible width is a defect.
+    case "integer":
+      if (schema.digits < 1) return "integer schema has no digit capacity";
+      if (schema.decimalPlaces < 0) return "integer schema has negative decimalPlaces";
+      if (schema.decimalPlaces > schema.digits) return "integer schema has more places than digits";
+      return null;
+    case "columnAlgorithm":
+      if (schema.cols < 1) return "columnAlgorithm schema has no columns";
+      if (schema.decimalPlaces < 0) return "columnAlgorithm schema has negative decimalPlaces";
+      if (schema.decimalPlaces >= schema.cols) {
+        return "columnAlgorithm schema has no whole-number column left for its decimal places";
+      }
+      return null;
+    case "fraction": {
+      if (!schema.parts.includes("num")) return "fraction schema has no numerator";
+      if (!schema.parts.includes("den")) return "fraction schema has no denominator";
+      if (new Set(schema.parts).size !== schema.parts.length) return "fraction schema repeats a part";
+      return null;
+    }
+    case "choice": {
+      if (schema.options.length !== schema.k) {
+        return `choice schema declares k=${String(schema.k)} and carries ${String(schema.options.length)} option(s)`;
+      }
+      // Two options of the same value are two right answers, or two wrong ones,
+      // and an item with either is the "contradictory, ambiguous or degenerate"
+      // case this program forbids outright. Compared as **exact rationals**, not
+      // as the strings they are written as: `1/2` and `{ value: 1/2,
+      // decimalPlaces: 1 }` write as `1/2` and `0.5` and are the same number, so
+      // a child choosing the second of them is right and marked wrong. Value
+      // equality subsumes written collision — two options that write alike are
+      // equal fractions or equal decimals, so they are equal here first.
+      for (let i = 0; i < schema.options.length; i++) {
+        for (let j = i + 1; j < schema.options.length; j++) {
+          const a = schema.options[i];
+          const b = schema.options[j];
+          if (a === undefined || b === undefined) continue;
+          if (rationalEq(choiceOptionValue(a), choiceOptionValue(b))) {
+            return `choice schema offers option ${String(i + 1)} and option ${String(j + 1)} as the same number`;
+          }
+        }
+      }
+      return null;
+    }
+  }
+}
+
+/**
+ * The exact value of a drawn option, whichever way it is written.
+ *
+ * Both kinds are numbers, so "are these two options the same option" is one
+ * rational comparison and never a string one.
+ */
+export function choiceOptionValue(option: ChoiceOption): Rational {
+  if (option.kind === "number") return option.value;
+  const written: FractionValue = {
+    kind: "fraction",
+    num: option.num,
+    den: option.den,
+    ...(option.whole === undefined ? {} : { whole: option.whole }),
+  };
+  return fractionRational(written);
 }

--- a/dynawalla/packs/shared/curriculum/src/types/exercise.ts
+++ b/dynawalla/packs/shared/curriculum/src/types/exercise.ts
@@ -19,11 +19,22 @@ import type { ExerciseId, FamilyId, FormId, LocKey, MalRuleId, RepId, SkillId } 
  * written to, because `1.50` and `1.5` are the same number and different notation,
  * and the number layer needs the notation. `count` is separate from `number`
  * because it selects a CLDR plural category (CG-14).
+ *
+ * `fraction` is here for the same reason `ChoiceOption` has a fraction kind and for
+ * the same reason `AnswerValue.fraction` keeps the *written* parts: three quarters
+ * as a `number` slot is the `Rational` 3/4, and the only thing a renderer can do
+ * with that is write `0.75`, which is a different notation and on a fraction card a
+ * different subject. Without it a question about fractions cannot be *stated* — the
+ * answer surfaces landed in PR-2.12 and the prompt could still only say `0.75`.
+ *
+ * A mixed number carries `whole`; the sign convention is `answer.ts`'s
+ * (`fractionRational`), so `-2 3/4` is `-2 − 3/4`.
  */
 export type PromptSlot =
   | { readonly kind: "number"; readonly value: Rational; readonly decimalPlaces: number }
   | { readonly kind: "count"; readonly value: number }
-  | { readonly kind: "term"; readonly key: LocKey };
+  | { readonly kind: "term"; readonly key: LocKey }
+  | { readonly kind: "fraction"; readonly num: bigint; readonly den: bigint; readonly whole?: bigint };
 
 export type PromptSpec = {
   readonly key: LocKey;

--- a/dynawalla/packs/shared/curriculum/src/validate/cli.ts
+++ b/dynawalla/packs/shared/curriculum/src/validate/cli.ts
@@ -110,6 +110,9 @@ export function readJson<T>(path: string, whenMissing?: T): T {
   }
 }
 
+/** Gates whose `notes` are the point of running them, not a measurement trace. */
+const REPORTING_GATES: readonly string[] = ["CG-15"];
+
 const STATUS_LABEL: Readonly<Record<GateResult["status"], string>> = {
   pass: "pass   ",
   warn: "warn   ",
@@ -128,6 +131,14 @@ function printText(report: Report): void {
   lines.push("");
   for (const result of report.results) {
     lines.push(`  ${STATUS_LABEL[result.status]} ${result.gate.padEnd(6)} ${result.title}`);
+    // Most gates' notes are per-level measurements — a hundred and twenty lines of
+    // them — and printing those would bury the findings. CG-15 is the exception:
+    // its notes *are* its output. The coverage matrix is the number this program
+    // is judged on, and a report that made you pass `--report json` to see it is a
+    // report nobody reads.
+    if (REPORTING_GATES.includes(result.gate)) {
+      for (const note of result.notes) lines.push(`           ${note}`);
+    }
     for (const finding of result.findings) {
       const subject = finding.subject === undefined ? "" : `${finding.subject}: `;
       lines.push(`         ${finding.severity === "error" ? "×" : "!"} ${subject}${finding.message}`);

--- a/dynawalla/packs/shared/curriculum/src/validate/context.ts
+++ b/dynawalla/packs/shared/curriculum/src/validate/context.ts
@@ -13,6 +13,8 @@ import type { Exercise } from "../types/exercise.ts";
 import type { SkillNode } from "../types/skill.ts";
 import type { RendererDeclaration } from "../render/registry.ts";
 import { rendererRegistry } from "../render/registry.ts";
+import type { PromptTemplateDeclaration } from "../render/prompts.ts";
+import { promptRegistry } from "../render/prompts.ts";
 import { familyById, generatorFamilies } from "../generators/registry.ts";
 import { malRules } from "../malrules/registry.ts";
 import { activeNodes, allNodes } from "../graph/graph.ts";
@@ -27,6 +29,8 @@ export type ValidationContext = {
   readonly families: readonly AnyGeneratorFamily[];
   readonly malRules: readonly MalRule[];
   readonly renderers: readonly RendererDeclaration[];
+  /** Prompt-template renderer declarations — CG-8's third half. */
+  readonly prompts: readonly PromptTemplateDeclaration[];
   readonly shipped: ShippedIds;
   readonly seedsPerLevel: number;
   readonly strictRenderers: boolean;
@@ -51,6 +55,7 @@ export function defaultContext(overrides: Partial<ValidationContext> = {}): Vali
     families: generatorFamilies,
     malRules,
     renderers: rendererRegistry,
+    prompts: promptRegistry,
     shipped: EMPTY_SHIPPED,
     seedsPerLevel: 200,
     strictRenderers: false,

--- a/dynawalla/packs/shared/curriculum/src/validate/gates.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/validate/gates.test.ts
@@ -90,6 +90,19 @@ function cg8OnFresh(ctx: ValidationContext): ReturnType<typeof cg8> {
   return cg8(ctx, buildSamples(ctx));
 }
 
+/**
+ * One renderer or prompt declaration, as it would read once something drew it.
+ *
+ * Nothing in this repository draws a curriculum item today — ADR-0022 deleted the
+ * host's practice loop and no pack has landed a renderer — so every CG-8 case that
+ * needs a *satisfied* declaration has to build one. Reading a healthy case off the
+ * shipped registries would assert nothing at all while they are empty, which is
+ * the mirror image of the failing-case trap GATES.md warns about.
+ */
+function drawn<T extends { readonly implemented: boolean }>(entry: T): T & { readonly testRef: string } {
+  return { ...entry, implemented: true, testRef: "packs/example/src/draw.test.ts" };
+}
+
 /** The healthy graph. Every gate below must pass on it. */
 test("gates: the committed curriculum passes every implemented gate", () => {
   const healthy = context();
@@ -230,31 +243,40 @@ test("CG-8: a required representation with no renderer fails", () => {
 });
 
 test("CG-8: strict mode rejects a renderer that is declared but not implemented", () => {
-  // The violation is **constructed**, not borrowed from the shipped registry.
-  // It used to be borrowed: `integer`, `columnAlgorithm` and the counting board
-  // were all declared and unimplemented, so this test read its failing case off
-  // the real data — and the day the app grew those renderers, the test would
-  // have gone green while asserting nothing at all. A failing-case test that
-  // depends on the shipped data being broken stops being a test the moment it
-  // is fixed, which is the failure mode GATES.md names in as many words.
-  const unbuilt = rendererRegistry.map((entry) =>
-    entry.id === "answer:integer"
-      ? { id: entry.id, kind: entry.kind, owner: entry.owner, implemented: false }
-      : entry,
-  );
+  // **Both** the healthy case and the violation are constructed, and neither is
+  // borrowed from the shipped registries. Borrowing either makes the test a
+  // hostage to whatever the registries happen to say: today nothing in this
+  // repository draws a curriculum item — ADR-0022 deleted the host's practice
+  // loop and no pack has landed a renderer — so a failing case read off the real
+  // data would stop asserting anything the day one does, which is the failure
+  // mode GATES.md names in as many words. It cuts the other way too: a healthy
+  // case read off the real data asserts nothing while the real data is empty.
+  const built = { renderers: rendererRegistry.map(drawn), prompts: promptRegistry.map(drawn) };
+
+  assert.equal(cg8OnFresh(context(built)).status, "pass", "everything the graph reaches is drawn");
+  assert.notEqual(cg8OnFresh(context({ ...built, strictRenderers: true })).status, "fail");
+
+  const oneMissing = {
+    ...built,
+    renderers: built.renderers.map((entry) =>
+      entry.id === "answer:integer"
+        ? { id: entry.id, kind: entry.kind, owner: entry.owner, implemented: false }
+        : entry,
+    ),
+  };
   assert.equal(
-    cg8OnFresh(context({ renderers: unbuilt })).status,
+    cg8OnFresh(context(oneMissing)).status,
     "warn",
     "the default mode allows authoring ahead of the work surface",
   );
-  assertFails(cg8OnFresh(context({ renderers: unbuilt, strictRenderers: true })), "declared but not implemented");
+  assertFails(cg8OnFresh(context({ ...oneMissing, strictRenderers: true })), "declared but not implemented");
 
-  // …and the registry this repository actually ships passes both modes: every
-  // schema and representation the active graph reaches is drawn by the app, and
-  // `dynawalla-app/src/work/renderers.test.ts` is what keeps that claim true
-  // from the other side.
-  assert.equal(cg8OnFresh(context()).status, "pass");
-  assert.notEqual(cg8OnFresh(context({ strictRenderers: true })).status, "fail");
+  // …and the state this repository actually ships, asserted rather than assumed:
+  // every declaration is unimplemented, so the default mode warns and the release
+  // mode fails. That is not a defect in the gate. A release in which nothing draws
+  // a question is not a release, and the first pack renderer is what clears it.
+  assert.equal(cg8OnFresh(context()).status, "warn", "no renderer exists yet, and the gate says so out loud");
+  assertFails(cg8OnFresh(context({ strictRenderers: true })), "declared but not implemented");
 });
 
 test("CG-8: a renderer declaration with no owner, or implemented with no test, fails", () => {
@@ -269,26 +291,34 @@ test("CG-8: a renderer declaration with no owner, or implemented with no test, f
 });
 
 test("CG-8: a prompt template with no registered renderer fails", () => {
-  // The half the gate was missing, and not hypothetically: the app matches
-  // `prompt.key` against two column-op keys and draws nothing for anything else,
-  // so a template nobody registered is a card with an answer entry and no
+  // The half the gate was missing, and not hypothetically: the practice loop
+  // matched `prompt.key` against two column-op keys and drew nothing for anything
+  // else, so a template nobody registered is a card with an answer entry and no
   // question above it.
   const nothingRegistered = promptRegistry.filter((entry) => !entry.id.startsWith("dw.prompt.column-op."));
   assertFails(cg8OnFresh(context({ prompts: nothingRegistered })), "has no registered renderer");
 });
 
 test("CG-8: strict mode rejects a prompt template that is declared but not implemented", () => {
-  const unbuilt = promptRegistry.map((entry) =>
+  // Constructed for the same reason the renderer case above is: every shipped
+  // prompt declaration is unimplemented today, so flipping one of them off would
+  // be flipping a switch that is already off. The renderers are built too, so the
+  // failure the strict assertion catches can only be the prompt.
+  const renderers = rendererRegistry.map(drawn);
+  const unbuilt = promptRegistry.map(drawn).map((entry) =>
     entry.id === "dw.prompt.column-op.sub"
       ? { id: entry.id, family: entry.family, owner: entry.owner, implemented: false }
       : entry,
   );
   assert.equal(
-    cg8OnFresh(context({ prompts: unbuilt })).status,
+    cg8OnFresh(context({ renderers, prompts: unbuilt })).status,
     "warn",
     "the default mode allows the curriculum to be authored ahead of the work surface",
   );
-  assertFails(cg8OnFresh(context({ prompts: unbuilt, strictRenderers: true })), "declared but not implemented");
+  assertFails(
+    cg8OnFresh(context({ renderers, prompts: unbuilt, strictRenderers: true })),
+    "declared but not implemented",
+  );
 });
 
 test("CG-8: a prompt declaration with no owner, implemented with no test, or naming no family, fails", () => {

--- a/dynawalla/packs/shared/curriculum/src/validate/gates.test.ts
+++ b/dynawalla/packs/shared/curriculum/src/validate/gates.test.ts
@@ -22,6 +22,7 @@ import { generatorFamilies } from "../generators/registry.ts";
 import { MIS_SMALLER_FROM_LARGER } from "../malrules/columnOp.ts";
 import { malRules } from "../malrules/registry.ts";
 import { rendererRegistry } from "../render/registry.ts";
+import { promptRegistry } from "../render/prompts.ts";
 import { erase } from "../types/generator.ts";
 import type { AnyGeneratorFamily } from "../types/generator.ts";
 import { capabilityTag, familyId, malRuleId, skillId } from "../types/ids.ts";
@@ -37,6 +38,7 @@ import { cg13, cg22, cg7, cg8 } from "./gates/bindingGates.ts";
 import { cg10, cg11, cg12, cg16, cg17, cg9 } from "./gates/generatorGates.ts";
 import type { Snapshot } from "./gates/generatorGates.ts";
 import { cg19, m05 } from "./gates/lintGates.ts";
+import { cg15, coverageMatrix } from "./gates/coverageGates.ts";
 import type { GateResult } from "./types.ts";
 
 const SUBTRACT_MULTIDIGIT = skillId("dw.add.regroup.subtract-multidigit");
@@ -77,6 +79,17 @@ const CURRICULUM_SRC = new URL("..", import.meta.url).pathname;
 const DYNAWALLA_ROOT = join(CURRICULUM_SRC, "..", "..", "..", "..");
 const SOURCE_ROOTS = [CURRICULUM_SRC, join(DYNAWALLA_ROOT, "engine", "src")];
 
+/**
+ * CG-8 over a context and the items that context actually produces.
+ *
+ * The gate reads prompt keys off generated exercises rather than off a declaration
+ * a family makes about itself, so every failing-case below has to generate. Doing
+ * it in one helper keeps each test about the violation it is constructing.
+ */
+function cg8OnFresh(ctx: ValidationContext): ReturnType<typeof cg8> {
+  return cg8(ctx, buildSamples(ctx));
+}
+
 /** The healthy graph. Every gate below must pass on it. */
 test("gates: the committed curriculum passes every implemented gate", () => {
   const healthy = context();
@@ -90,7 +103,7 @@ test("gates: the committed curriculum passes every implemented gate", () => {
     cg5(healthy),
     cg6(healthy),
     cg7(healthy),
-    cg8(healthy),
+    cg8(healthy, samples),
     cg9(healthy, samples),
     cg10(healthy, samples),
     cg11(healthy, samples),
@@ -198,39 +211,132 @@ test("CG-7: an active row with no working generator binding fails", () => {
     cg7(context({ nodes: replace(SUBTRACT_MULTIDIGIT, { generator: { ...binding, forms: ["dial"] } }) })),
     "is not one of",
   );
-  assert.equal(cg7(context()).status, "pass");
+  // Not `pass`: the shipped graph warns, because seven generator families are
+  // bound only by draft rows waiting on a prompt renderer. What must never happen
+  // is a *failure* on the healthy graph.
+  assert.notEqual(cg7(context()).status, "fail");
 });
 
 test("CG-7: a registered family that no active skill binds fails", () => {
   const orphan: AnyGeneratorFamily = { ...erase(columnOpFamily), family: familyId("gen.arith.unbound") };
-  assertFails(cg7(context({ families: [...generatorFamilies, orphan] })), "bound by no active skill");
+  assertFails(cg7(context({ families: [...generatorFamilies, orphan] })), "bound by no skill at all");
 });
 
 test("CG-8: a required representation with no renderer fails", () => {
   const needsBoard = replace(SUBTRACT_ACROSS_ZERO, {
     representations: { required: ["water-clock"], optional: [] },
   });
-  assertFails(cg8(context({ nodes: needsBoard })), "has no registered renderer");
+  assertFails(cg8OnFresh(context({ nodes: needsBoard })), "has no registered renderer");
 });
 
 test("CG-8: strict mode rejects a renderer that is declared but not implemented", () => {
-  assert.equal(cg8(context()).status, "warn", "the default mode allows authoring ahead of the work surface");
-  assertFails(cg8(context({ strictRenderers: true })), "declared but not implemented");
-  const implemented = rendererRegistry.map((entry) =>
-    entry.kind === "answerSchema" ? { ...entry, implemented: true, testRef: "src/work/judge.test.ts" } : entry,
+  // The violation is **constructed**, not borrowed from the shipped registry.
+  // It used to be borrowed: `integer`, `columnAlgorithm` and the counting board
+  // were all declared and unimplemented, so this test read its failing case off
+  // the real data — and the day the app grew those renderers, the test would
+  // have gone green while asserting nothing at all. A failing-case test that
+  // depends on the shipped data being broken stops being a test the moment it
+  // is fixed, which is the failure mode GATES.md names in as many words.
+  const unbuilt = rendererRegistry.map((entry) =>
+    entry.id === "answer:integer"
+      ? { id: entry.id, kind: entry.kind, owner: entry.owner, implemented: false }
+      : entry,
   );
-  assert.notEqual(cg8(context({ renderers: implemented, strictRenderers: true })).status, "fail");
+  assert.equal(
+    cg8OnFresh(context({ renderers: unbuilt })).status,
+    "warn",
+    "the default mode allows authoring ahead of the work surface",
+  );
+  assertFails(cg8OnFresh(context({ renderers: unbuilt, strictRenderers: true })), "declared but not implemented");
+
+  // …and the registry this repository actually ships passes both modes: every
+  // schema and representation the active graph reaches is drawn by the app, and
+  // `dynawalla-app/src/work/renderers.test.ts` is what keeps that claim true
+  // from the other side.
+  assert.equal(cg8OnFresh(context()).status, "pass");
+  assert.notEqual(cg8OnFresh(context({ strictRenderers: true })).status, "fail");
 });
 
 test("CG-8: a renderer declaration with no owner, or implemented with no test, fails", () => {
   assertFails(
-    cg8(context({ renderers: rendererRegistry.map((entry) => ({ ...entry, owner: "" })) })),
+    cg8OnFresh(context({ renderers: rendererRegistry.map((entry) => ({ ...entry, owner: "" })) })),
     "has no owner",
   );
   assertFails(
-    cg8(context({ renderers: rendererRegistry.map((entry) => ({ ...entry, implemented: true })) })),
+    cg8OnFresh(context({ renderers: rendererRegistry.map((entry) => ({ ...entry, implemented: true })) })),
     "no testRef",
   );
+});
+
+test("CG-8: a prompt template with no registered renderer fails", () => {
+  // The half the gate was missing, and not hypothetically: the app matches
+  // `prompt.key` against two column-op keys and draws nothing for anything else,
+  // so a template nobody registered is a card with an answer entry and no
+  // question above it.
+  const nothingRegistered = promptRegistry.filter((entry) => !entry.id.startsWith("dw.prompt.column-op."));
+  assertFails(cg8OnFresh(context({ prompts: nothingRegistered })), "has no registered renderer");
+});
+
+test("CG-8: strict mode rejects a prompt template that is declared but not implemented", () => {
+  const unbuilt = promptRegistry.map((entry) =>
+    entry.id === "dw.prompt.column-op.sub"
+      ? { id: entry.id, family: entry.family, owner: entry.owner, implemented: false }
+      : entry,
+  );
+  assert.equal(
+    cg8OnFresh(context({ prompts: unbuilt })).status,
+    "warn",
+    "the default mode allows the curriculum to be authored ahead of the work surface",
+  );
+  assertFails(cg8OnFresh(context({ prompts: unbuilt, strictRenderers: true })), "declared but not implemented");
+});
+
+test("CG-8: a prompt declaration with no owner, implemented with no test, or naming no family, fails", () => {
+  assertFails(
+    cg8OnFresh(context({ prompts: promptRegistry.map((entry) => ({ ...entry, owner: "" })) })),
+    "has no owner",
+  );
+  assertFails(
+    cg8OnFresh(context({ prompts: promptRegistry.map((entry) => ({ ...entry, implemented: true })) })),
+    "no testRef",
+  );
+  assertFails(
+    cg8OnFresh(
+      context({ prompts: promptRegistry.map((entry) => ({ ...entry, family: familyId("gen.arith.nowhere") })) }),
+    ),
+    "unregistered family",
+  );
+});
+
+test("CG-7: a family bound only by draft rows warns, and one bound by nothing at all fails", () => {
+  // The distinction matters: a generator waiting on a renderer is a legitimate,
+  // and currently common, state, while a family no row mentions is dead code.
+  const draftOnly = context();
+  const warned = cg7(draftOnly).findings.filter((finding) => finding.severity === "warn");
+  assert.ok(
+    warned.some((finding) => finding.message.includes("bound only by draft rows")),
+    "the shipped graph has generator families whose rows are all draft",
+  );
+  assert.notEqual(cg7(draftOnly).status, "fail");
+
+  const orphan: AnyGeneratorFamily = { ...erase(columnOpFamily), family: familyId("gen.arith.mentioned-by-nobody") };
+  assertFails(cg7(context({ families: [...generatorFamilies, orphan] })), "bound by no skill at all");
+});
+
+test("CG-15: an empty cell warns in draft and fails at release", () => {
+  const healthy = context();
+  assert.equal(cg15(healthy).status, "warn", "the graph has domains whose rows are all draft");
+  assert.equal(cg15(context({ strictRenderers: true })).status, "fail", "at release an empty cell is a hole");
+
+  // The matrix separates the two numbers this program has most reason to keep
+  // apart: what exists, and what a child can be given.
+  const cells = coverageMatrix(allNodes);
+  const add = cells.filter((cell) => cell.domain === "add" && cell.expected);
+  assert.ok(add.every((cell) => cell.active > 0), "the one domain the app can draw is covered in every expected grade");
+  const frac = cells.filter((cell) => cell.domain === "frac" && cell.expected);
+  assert.ok(frac.every((cell) => cell.active === 0 && cell.draft > 0), "fractions are written and unpromoted");
+  // Division is not expected before grade 3, and the gate must not ask for it.
+  assert.ok(cells.some((cell) => cell.domain === "div" && cell.grade === 1 && !cell.expected));
 });
 
 test("CG-9: a level that cannot reach minVariants fails", () => {
@@ -302,6 +408,26 @@ test("CG-11: a checker that accepts a distractor fails", () => {
         : ({ ...sample.family, check: () => ({ correct: false }) } as AnyGeneratorFamily),
   }));
   assertFails(cg11(healthy, rejecting), "rejects its own canonical answer");
+
+  // …and an item whose schema cannot be drawn fails here too, before it reaches
+  // a surface that would throw on it. A `choice` set with the same number twice
+  // is two right answers on one card; nothing emits one today, which is why the
+  // gate has to be standing when something does.
+  const undrawable: LevelSample[] = samples.map((sample) => ({
+    ...sample,
+    exercises: sample.exercises.map((exercise) => ({
+      ...exercise,
+      schema: {
+        kind: "choice" as const,
+        k: 2 as const,
+        options: [
+          { kind: "fraction" as const, num: 1n, den: 2n },
+          { kind: "number" as const, value: rational(1n, 2n), decimalPlaces: 1 },
+        ],
+      },
+    })),
+  }));
+  assertFails(cg11(healthy, undrawable), "the same number")
 });
 
 test("CG-12: a mal-rule that reproduces the correct answer fails", () => {

--- a/dynawalla/packs/shared/curriculum/src/validate/gates/bindingGates.ts
+++ b/dynawalla/packs/shared/curriculum/src/validate/gates/bindingGates.ts
@@ -7,8 +7,9 @@
 import { activeNodes } from "../../graph/graph.ts";
 import { familyById } from "../../generators/registry.ts";
 import { answerRendererId, findRenderer, repRendererId } from "../../render/registry.ts";
+import { findPromptTemplate } from "../../render/prompts.ts";
 import type { FamilyId } from "../../types/ids.ts";
-import type { ValidationContext } from "../context.ts";
+import type { LevelSample, ValidationContext } from "../context.ts";
 import type { Finding, GateResult } from "../types.ts";
 import { fail, resultOf, warn } from "../types.ts";
 
@@ -95,19 +96,62 @@ export function cg7(context: ValidationContext): GateResult {
     });
   }
 
-  // The other direction: a registered family that no active node binds is either
-  // dead code or a family whose skills nobody promoted.
+  // The other direction, and it separates two states the first cut ran together.
+  //
+  // A registered family that **no node at all** binds is dead code: nothing can
+  // ever reach it and nobody is going to notice. That stays a failure.
+  //
+  // A family bound only by `draft` rows is the case this gate's own comment named
+  // — "a family whose skills nobody promoted" — and it is a legitimate, and now
+  // common, state: a generator can be complete and correct while the work surface
+  // that draws its questions does not exist (see `render/prompts.ts`). Failing on
+  // it would leave two options, both bad: promote rows the app cannot draw, or
+  // keep finished generators out of the registry where no gate ever runs them.
+  // It warns, and the warning names the rows that are waiting.
+  const draftBound = new Map<FamilyId, string[]>();
+  for (const node of context.nodes) {
+    if (node.status !== "draft") continue;
+    const rows = draftBound.get(node.generator.family) ?? [];
+    rows.push(node.id);
+    draftBound.set(node.generator.family, rows);
+  }
+
   for (const family of context.families) {
     if (boundFamilies.has(family.family)) continue;
     if (FAMILIES_WITHOUT_SKILLS.includes(family.family)) continue;
-    findings.push(fail("CG-7", "registered family is bound by no active skill", family.family));
+    const drafts = draftBound.get(family.family);
+    if (drafts === undefined) {
+      findings.push(fail("CG-7", "registered family is bound by no skill at all", family.family));
+      continue;
+    }
+    findings.push(
+      warn("CG-7", `bound only by draft rows, none promoted: ${drafts.join(", ")}`, family.family),
+    );
   }
 
   return resultOf("CG-7", "bidirectional generator ownership", findings);
 }
 
-/** CG-8 — renderer ownership. Merge blocker. */
-export function cg8(context: ValidationContext): GateResult {
+/**
+ * CG-8 — renderer ownership. Merge blocker.
+ *
+ * Three things a card is made of, and all three are checked: the **answer schema**
+ * the child writes into, every **required representation** drawn beside it, and —
+ * added here — the **prompt template** that states the question.
+ *
+ * The prompt half was missing, and it was not missing in theory. The app reads an
+ * item back out of `prompt.slots` by matching `prompt.key` against two column-op
+ * keys and renders nothing for anything else, so an item from any other family drew
+ * an answer entry, a keypad and a verdict well with no question above them. That is
+ * the exact shape of the failure this gate exists for, one level up from where it
+ * was looking.
+ *
+ * The prompt keys are read off **generated items** rather than off a declaration a
+ * family makes about itself. A family that could emit a template it never does is
+ * not the risk; a family that emits one nobody registered is, and only running it
+ * can tell you which it did.
+ */
+export function cg8(context: ValidationContext, samples: readonly LevelSample[]): GateResult {
   const findings: Finding[] = [];
 
   // Registry hygiene first: an entry with no owner, or one claiming to be
@@ -158,11 +202,60 @@ export function cg8(context: ValidationContext): GateResult {
     }
   }
 
+  // The prompt half, measured on the items the active levels actually produced.
+  const seenTemplates = new Set<string>();
+  for (const sample of samples) {
+    for (const exercise of sample.exercises) {
+      if (seenTemplates.has(exercise.prompt.key)) continue;
+      seenTemplates.add(exercise.prompt.key);
+      const entry = findPromptTemplate(exercise.prompt.key, context.prompts);
+      if (entry === undefined) {
+        findings.push(
+          fail(
+            "CG-8",
+            `prompt template "${exercise.prompt.key}" has no registered renderer — the card would draw its answer entry with no question above it`,
+            sample.node.id,
+          ),
+        );
+        continue;
+      }
+      if (entry.implemented) continue;
+      if (context.strictRenderers) {
+        findings.push(
+          fail(
+            "CG-8",
+            `prompt template "${exercise.prompt.key}" is declared but not implemented (${entry.owner})`,
+            sample.node.id,
+          ),
+        );
+      } else {
+        awaitingImplementation.set(`prompt:${exercise.prompt.key}`, entry.owner);
+      }
+    }
+  }
+
+  // Registry hygiene for the prompt half, in both directions the curriculum can
+  // see: an entry with no owner, one claiming to be implemented with no test, and
+  // one naming a family this package does not register.
+  for (const entry of context.prompts) {
+    if (entry.owner.trim() === "") {
+      findings.push(fail("CG-8", "prompt template declaration has no owner", entry.id));
+    }
+    if (entry.implemented && (entry.testRef === undefined || entry.testRef.trim() === "")) {
+      findings.push(fail("CG-8", "prompt template claims implemented with no testRef", entry.id));
+    }
+    if (familyById(entry.family, context.families) === undefined) {
+      findings.push(fail("CG-8", `prompt template names unregistered family ${entry.family}`, entry.id));
+    }
+  }
+
   for (const [id, owner] of awaitingImplementation) {
     findings.push(warn("CG-8", `renderer is declared but not implemented yet — ${owner} owns it`, id));
   }
 
-  return resultOf("CG-8", "renderer ownership", findings);
+  return resultOf("CG-8", "renderer ownership", findings, [
+    `${String(seenTemplates.size)} prompt template(s) emitted by active levels`,
+  ]);
 }
 
 /**

--- a/dynawalla/packs/shared/curriculum/src/validate/gates/coverageGates.ts
+++ b/dynawalla/packs/shared/curriculum/src/validate/gates/coverageGates.ts
@@ -1,0 +1,121 @@
+/**
+ * CG-15 — the grade-band coverage matrix.
+ *
+ * GATES.md: "grade × domain — empty cell is an error at release, a warning in
+ * draft". It was `pending` because there was one domain in the graph and a matrix
+ * of one column is a list. There are six now, and the number that matters for this
+ * program is not "how many skills exist" but **which cells of the matrix a child
+ * can actually be given work in**, which is a different number and a smaller one.
+ *
+ * Two decisions worth stating, because both could have gone the lazy way:
+ *
+ * - **A cell is only expected where V1 says it is.** CURRICULUM.md gives each
+ *   domain a grade range — division is grades 3–5, not 1–5 — and a matrix that
+ *   demanded a division skill in grade 1 would be a gate everybody learns to
+ *   ignore. `V1_DOMAIN_BANDS` is that table, and it is the gate's contract.
+ * - **A node counts in a cell only when it is `active`.** Draft rows are counted
+ *   separately and printed beside the active count, because "we have written it"
+ *   and "a child can be given it" are the two numbers this program has most
+ *   reason to keep apart. A cell with nothing active and something draft reads
+ *   `0(+4)`, which is the honest shape of a graph waiting on a renderer.
+ *
+ * A node occupies every grade in its band, `earliest` through `latest`, not just
+ * its nominal one: progression gates on prerequisites and never on grade, and a
+ * skill nominally taught in grade 3 that a grade-2 child can reach is coverage in
+ * grade 2.
+ */
+
+import { activeNodes } from "../../graph/graph.ts";
+import type { SkillNode } from "../../types/skill.ts";
+import type { ValidationContext } from "../context.ts";
+import type { Finding, GateResult } from "../types.ts";
+import { fail, resultOf, warn } from "../types.ts";
+
+/** The V1 domains and the grades each is expected to cover (CURRICULUM.md). */
+export const V1_DOMAIN_BANDS: readonly { readonly domain: string; readonly from: number; readonly to: number }[] = [
+  { domain: "ns", from: 1, to: 5 },
+  { domain: "add", from: 1, to: 4 },
+  { domain: "mul", from: 2, to: 5 },
+  { domain: "div", from: 3, to: 5 },
+  { domain: "frac", from: 2, to: 5 },
+  { domain: "alg", from: 1, to: 5 },
+];
+
+export const COVERAGE_GRADES: readonly number[] = [1, 2, 3, 4, 5];
+
+function occupies(node: SkillNode, grade: number): boolean {
+  return node.gradeBand.earliest <= grade && grade <= node.gradeBand.latest;
+}
+
+export type CoverageCell = {
+  readonly domain: string;
+  readonly grade: number;
+  readonly active: number;
+  readonly draft: number;
+  /** False where V1 does not expect this domain to reach this grade. */
+  readonly expected: boolean;
+};
+
+export function coverageMatrix(nodes: readonly SkillNode[]): CoverageCell[] {
+  const active = activeNodes(nodes);
+  const drafts = nodes.filter((node) => node.status === "draft");
+  const cells: CoverageCell[] = [];
+
+  for (const band of V1_DOMAIN_BANDS) {
+    for (const grade of COVERAGE_GRADES) {
+      cells.push({
+        domain: band.domain,
+        grade,
+        active: active.filter((node) => node.domain === band.domain && occupies(node, grade)).length,
+        draft: drafts.filter((node) => node.domain === band.domain && occupies(node, grade)).length,
+        expected: band.from <= grade && grade <= band.to,
+      });
+    }
+  }
+  return cells;
+}
+
+/** One row per domain, `active(+draft)` per grade. The report the release reads. */
+export function renderMatrix(cells: readonly CoverageCell[]): string[] {
+  const lines: string[] = [`domain  ${COVERAGE_GRADES.map((g) => `G${String(g)}`.padStart(7)).join("")}`];
+  for (const band of V1_DOMAIN_BANDS) {
+    const row = COVERAGE_GRADES.map((grade) => {
+      const cell = cells.find((candidate) => candidate.domain === band.domain && candidate.grade === grade);
+      if (cell === undefined) return "".padStart(7);
+      if (!cell.expected) return "—".padStart(7);
+      const text = cell.draft === 0 ? String(cell.active) : `${String(cell.active)}(+${String(cell.draft)})`;
+      return text.padStart(7);
+    }).join("");
+    lines.push(`${band.domain.padEnd(8)}${row}`);
+  }
+  return lines;
+}
+
+/**
+ * CG-15. `release` is the release invocation — the same one that turns on
+ * `--strict-renderers` — where an expected cell with no active skill in it stops
+ * being a note about work in progress and becomes a hole in the shipped product.
+ */
+export function cg15(context: ValidationContext): GateResult {
+  const cells = coverageMatrix(context.nodes);
+  const findings: Finding[] = [];
+  const release = context.strictRenderers;
+
+  for (const cell of cells) {
+    if (!cell.expected || cell.active > 0) continue;
+    const message =
+      cell.draft === 0
+        ? "no skill at all covers this cell"
+        : `no active skill covers this cell; ${String(cell.draft)} draft row(s) are waiting on a renderer`;
+    findings.push(
+      (release ? fail : warn)("CG-15", message, `${cell.domain} G${String(cell.grade)}`),
+    );
+  }
+
+  return resultOf("CG-15", "grade-band coverage matrix", findings, [
+    ...renderMatrix(cells),
+    `${String(activeNodes(context.nodes).length)} active, ${String(
+      context.nodes.filter((node) => node.status === "draft").length,
+    )} draft, over ${String(V1_DOMAIN_BANDS.length)} domains`,
+  ]);
+}

--- a/dynawalla/packs/shared/curriculum/src/validate/gates/generatorGates.ts
+++ b/dynawalla/packs/shared/curriculum/src/validate/gates/generatorGates.ts
@@ -6,7 +6,7 @@
  */
 
 import { add as ratAdd, cmp, toString as rationalToString } from "../../math/rational.ts";
-import { answerEquals } from "../../types/answer.ts";
+import { answerAccepted, answerEquals, schemaDefect } from "../../types/answer.ts";
 import type { Exercise } from "../../types/exercise.ts";
 import { fingerprintItem, serializeExercise } from "../../serialize.ts";
 import { fnv1a64Hex } from "../../rng/hash.ts";
@@ -183,6 +183,22 @@ export function cg11(_context: ValidationContext, samples: readonly LevelSample[
     if (family === undefined) continue;
     for (const exercise of sample.exercises) {
       checked += 1;
+      // The renderer's precondition, run over real generated output. Without
+      // this, a `choice` schema carrying two options of the same value — two
+      // right answers, or two wrong ones, on the same card — reaches a child's
+      // screen: `schemaDefect` is only called by the app's entry models, which
+      // throw at `init`, and a card that throws while drawing is a blank cell.
+      // No family emits `choice` yet, which is exactly why the check belongs
+      // here before one does.
+      //
+      // First, and then `continue`: an item that cannot be drawn is not an item
+      // whose checker is worth interrogating, and the mal-rules the checker runs
+      // are written against the schema kinds the family declares.
+      const defect = schemaDefect(exercise.schema);
+      if (defect !== null) {
+        findings.push(fail("CG-11", `the answer schema cannot be drawn — ${defect}`, exercise.exerciseId));
+        continue;
+      }
       if (!family.check(exercise, exercise.answer.canonical).correct) {
         findings.push(fail("CG-11", "checker rejects its own canonical answer", exercise.exerciseId));
       }
@@ -202,7 +218,9 @@ export function cg11(_context: ValidationContext, samples: readonly LevelSample[
     }
   }
 
-  return resultOf("CG-11", "checker self-consistency", findings, [`${String(checked)} items checked`]);
+  return resultOf("CG-11", "checker self-consistency and drawable schemas", findings, [
+    `${String(checked)} items checked`,
+  ]);
 }
 
 /**
@@ -238,11 +256,31 @@ export function cg12(context: ValidationContext, samples: readonly LevelSample[]
         undefinedOutput += 1;
         continue;
       }
-      if (!answerEquals(produced, exercise.answer.canonical)) divergent += 1;
+      // `answerAccepted` and not `answerEquals`, because this gate exists to keep a
+      // correct answer from being diagnosed as a bug, and "correct" means what the
+      // checker accepts. On a schema that takes any equivalent fraction, a mal-rule
+      // output of `2/4` against a canonical `1/2` is a correct answer written
+      // differently — `answerEquals` calls that divergence and `judge()` marks the
+      // same submission right. `distractorsFor` has always used this comparison.
+      if (!answerAccepted(exercise.schema, exercise.answer.canonical, produced)) divergent += 1;
     }
 
     if (applicable === 0) {
-      findings.push(warn("CG-12", "no sampled item triggers this rule", rule.id));
+      // Two very different states, and the message says which. A rule whose family
+      // no active skill binds *cannot* be sampled — the sample is built from active
+      // nodes only — so "no item triggers it" would read as a defect in the rule
+      // rather than as the graph waiting on a renderer. A rule whose family *is*
+      // bound and still never fires is the real warning.
+      const bound = activeNodes(context.nodes).some((node) => node.generator.family === rule.family);
+      findings.push(
+        warn(
+          "CG-12",
+          bound
+            ? "no sampled item triggers this rule"
+            : `no active skill binds ${rule.family}, so no sampled item can reach this rule`,
+          rule.id,
+        ),
+      );
       continue;
     }
     if (undefinedOutput > 0) {

--- a/dynawalla/packs/shared/curriculum/src/validate/runGates.ts
+++ b/dynawalla/packs/shared/curriculum/src/validate/runGates.ts
@@ -15,6 +15,7 @@ import { cg13, cg22, cg7, cg8 } from "./gates/bindingGates.ts";
 import { cg10, cg11, cg12, cg16, cg17, cg9 } from "./gates/generatorGates.ts";
 import type { Snapshot } from "./gates/generatorGates.ts";
 import { cg19, m05 } from "./gates/lintGates.ts";
+import { cg15 } from "./gates/coverageGates.ts";
 import type { GateResult, Report } from "./types.ts";
 import { pending } from "./types.ts";
 
@@ -30,7 +31,6 @@ export type RunOptions = {
 /** Gates defined in GATES.md that no PR has implemented yet, with their owner. */
 const PENDING_GATES: readonly (readonly [string, string, string])[] = [
   ["CG-14", "locale round-trip", "PR-4.7 (needs the M2 number layer)"],
-  ["CG-15", "grade-band coverage matrix", "PR-7.19"],
   ["CG-18", "representation accessibility", "PR-4.4"],
   ["CG-20", "standards traceback (report-only)", "PR-7.19"],
   ["CG-21", "word-problem context sets", "PR-7.18"],
@@ -50,12 +50,13 @@ export function runGates(options: RunOptions): { report: Report; snapshot: Snaps
     cg5(context),
     cg6(context),
     cg7(context),
-    cg8(context),
+    cg8(context, samples),
     cg9(context, samples),
     cg10(context, samples),
     cg11(context, samples),
     cg12(context, samples),
     cg13(context),
+    cg15(context),
     snapshotRun.result,
     cg17(context, samples),
     cg19(samples, roots),


### PR DESCRIPTION
Rebased onto the stripped host (`83a603cd0`). The eight generator families are the
point of this PR and they all survive; everything that touched the deleted
worksheet surface is gone.

## Why this exists

The founder's loudest complaint about the first build was that everything was
addition and subtraction. This is what fixes that. The curriculum library now
generates **eight families across five new domains** — place value, comparison and
ordering, rounding and estimation, multi-digit multiplication, long division,
fraction equivalence, fraction arithmetic and missing-operand equations, over
`ns`, `mul`, `div`, `frac` and `alg`.

Also: two answer schemas the judge was missing (`fraction` with the per-skill
equivalence decision, `choice` with the drawn options on the schema), thirteen new
mal-rules taking the table from 3 to 16, CG-8's missing prompt half, CG-11 running
`schemaDefect` over generated output, and `promotionBlockers.ts` naming per row
what stands between the 30 draft rows and `active`.

## What the rebase dropped

`#545` deleted `src/work/**` and `tools/drive-locate.mjs`, which is what made this
branch conflict. Rather than resurrect the worksheet, every hunk that touched it is
dropped:

- `dynawalla-app/src/work/**` — the entry models, the keypad, the four answer
  surfaces, the number line and balance renderers, and their tests.
- `dynawalla-app/src/preview/**`, `preview.html`, `tools/drive-schemas.mjs` — the
  renderer bench and its browser driver. They drove `src/work/`.
- `tools/drive-locate.mjs` — drove the deleted practice loop.
- `src/app/strings.ts`, `src/design/tokens.css`, `package.json`, `README.md` — the
  entry-surface strings, the `--dw-cell-*` tokens and the scripts that fed them.

**The host diff against `main` is empty.** `git diff origin/main..HEAD -- dynawalla/dynawalla-app`
returns nothing.

## What that forced, and what was found doing it

**The registries were claiming renderers that no longer exist.** Every entry in
`render/registry.ts` read `implemented: true` with a `testRef` into
`dynawalla-app/src/work/` — `entry.test.ts`, `representation.test.ts`,
`diagnosis.test.ts`, `surface.test.ts` — and all four are gone. CG-8 would have
stayed green pointing at nothing, which is exactly the rubber stamp
`owner`/`implemented`/`testRef` exist to prevent. Every renderer and prompt
declaration is `implemented: false` now, including the two column-op prompt keys,
because **no module in this repository draws a curriculum item today**.
`--strict-renderers` therefore fails, and that is correct rather than a regression:
a release in which nothing draws a question is not a release. The first pack
renderer clears it.

**The CG-8 tests were reading their healthy case off the shipped data** —
`assert.equal(cg8(context()).status, "pass")` was a claim about the registry being
full, so emptying it would have quietly inverted them. Both the satisfied case and
the violation are constructed now, and the shipped state is asserted explicitly:
warn by default, fail under `--strict-renderers`.

**CI was not running any of this.** The `dynawalla_curriculum` path filter matches
`^dynawalla/(curriculum|engine)/`, but the library lives at
`dynawalla/packs/shared/curriculum/` — `dynawalla/curriculum/` kept only the
devDependencies, the commands and the CLI. Every line of generator, mal-rule and
gate source sat outside the pattern that decides whether the gates run at all. A PR
that rewrote the whole library would have skipped its own job and reported green.
**This one would have.** Filter fixed.

## The two #542 bugs cannot return

Both lived in `dynawalla-app/src/work/`, which this branch no longer contains
(`grep -rn writeLinePosition` and any `BalanceScale`/`NumberLine` component return
nothing repo-wide). But deleting a bug is not the same as preventing it, and both
were *renderer* bugs that no amount of reading caught — so the two facts move into
the library every pack reads, with a test:

- `numberLinePoint(from, mark, denominator)` returns `from + mark/den` as an exact
  `Rational`. The composition that wrote `"-3 1/4"` for the point −11/4 (which
  parses back as −13/4) is not expressible. `representations.test.ts` pins every
  point on a negative line, and asserts the wrong reading is a *different number*.
- `balanceLowerPan(left, right)` states which pan hangs lower, **in weight rather
  than in an angle**, because the angle is where it went wrong: CSS `rotate()` is
  clockwise in a y-down space, so a positive angle raises the left end and the
  heavier pan was drawn 21.8 px *above* the lighter one. The test also states why
  "the two beam angles are mirror images" is not evidence — the inverted pair are
  mirror images too.

## Gates — real output

```
$ npm test
ℹ tests 156   ℹ pass 156   ℹ fail 0

$ npm run check
dw-curriculum check — incremental, 200 seeds per level
nodes=37  activeNodes=7  levels=22  generatedItems=4400  malRules=16  families=9
  pass CG-1  pass CG-2  pass CG-3  warn CG-4  pass CG-5  pass CG-6  warn CG-7
  warn CG-8  pass CG-9  pass CG-10 pass CG-11 warn CG-12 pass CG-13 pending CG-14
  warn CG-15 pass CG-16 pass CG-17 pending CG-18 pass CG-19 pending CG-20
  pending CG-21 pass CG-22 pass M-05
OK

$ npm run check:full
dw-curriculum check — full, 1000 seeds per level
nodes=37  activeNodes=7  levels=22  generatedItems=22000  malRules=16  families=9
  … same table …
OK
```

Property sweep, from `npm test`:

```
# sweep: 56500 generated cases over 113 levels (22 active, 91 draft) at 500 seeds each
# prompt registry: 25 template(s), all emitted
# 27 level(s) below CG-10's floor of 975 — none is active, and none may be promoted without reconciling it
# generator invariants: 1500 to-improper item(s) off tenths, 1500 decimal comparison(s) with the longer number smaller
# hint ladders: 7500 gen.frac.arith item(s), 3184 with a simplifying rung
# generate(): 56500 calls, p95 19 µs, p99 98 µs
```

Every `warn` is a fact about the graph, not a defect: CG-7/CG-12/CG-15 warn because
the eight new families bind `draft` rows only, and CG-8 warns because nothing draws
yet. `npm run tsc` is clean. CG-16 output hashes are unchanged.

## What still blocks a child seeing any of this

All 30 draft rows wait on a renderer, and that renderer is now a **pack's** to
land, not the host's. Eighteen of them wait on a second thing —
`promotionBlockers.ts` names them — because they do not clear CG-10's
variant-space floor, and some cannot: `dw.alg.equality.missing-addend` L0 draws
both operands from 1..9, so its true space is 81 items and no generator work
changes that. A promotion PR planned as "flip `status`" fails on the first run.
