### PR TITLE
FUSE — a merge game where the merge is the addition (dynawalla/games/merge)

### DIFF
--- a/dynawalla/games/merge/.gitignore
+++ b/dynawalla/games/merge/.gitignore
@@ -1,0 +1,8 @@
+dist/
+
+# The lockfile is deliberately not tracked yet. No CI job builds this package
+# (no `dynawalla/games/**` path filter exists), and `adversarial-review`
+# truncates a diff at 200,000 bytes — a 30 kB lockfile sorts before `src/` and
+# would push that much real source out of review for zero reviewer value.
+# Whoever adds the CI job should commit it in the same PR.
+package-lock.json

--- a/dynawalla/games/merge/README.md
+++ b/dynawalla/games/merge/README.md
@@ -1,0 +1,167 @@
+# FUSE
+
+**Touching chips that add up to the KEY fuse.** That is the whole game and the
+only sentence anyone needs.
+
+A number drops into a magnetic containment well. If it lands touching chips that
+sum to the KEY — 10 at first, 100 by the end — they slam together, detonate, and
+the sum flies out of the well as a glowing core. Everything above falls, which
+makes new pairs, which fuse, which makes more pairs. The well rises underneath
+you the whole time.
+
+```bash
+npm install
+npm run dev      # http://127.0.0.1:5183
+npm test         # 69 tests, no framework
+npm run tsc      # strict, noUncheckedIndexedAccess
+npm run build
+```
+
+`?seed=<text>` for a reproducible run. `?debug=1` for fps / particle / phase.
+
+---
+
+## The math is the mechanic
+
+Merging **is** addition. Not "addition unlocks a merge" — the merge is the sum.
+
+- **Complements.** The single most valuable fact family in primary arithmetic is
+  "what makes ten". This game is nothing but that, for eleven values of ten.
+- **Repeated addition and chains.** A cascade is the same sum happening again
+  from the pieces that fell, at a rising multiplier and a rising pitch.
+- **Place value emerges.** The KEY ladder runs 10 → 12 → 15 → 20 → 24 → 25 → 30
+  → 40 → 50 → 60 → 75 → 100. By level 10 you are finding what makes 50 out of
+  two-digit chips, in about three seconds.
+- **Expression faces.** From level 3 a chip stops showing `7` and starts showing
+  `15 − 8`. It is still worth 7 and it still fuses with a 3. Now you have to
+  evaluate it to aim. Same game, deeper arithmetic, no new rules and no new UI.
+- **RESONANCE.** Every fuse charges the reactor. Full, it goes white and you can
+  tap it — time drops to a crawl, one big question appears, and every chip on
+  the board is an answer button. Get it right and every chip of that value plus
+  its neighbours erupts. This is also the rescue: when the well breaches, you
+  get exactly one of these to save the run. **Math instead of an ad**, once per
+  run, no scarcity games.
+
+Wrong answers cost the only thing a puzzle game can honestly charge: space. A
+chip you cannot place is a chip that fills the well. Guessing is available and
+guessing loses, because the well rises whether or not you were sure.
+
+Every value, every comparison and every score is an integer. There is not a
+floating-point number anywhere in `core/` or in an answer.
+
+## Why it looks like this
+
+A fusion reactor, because that is literally what the mechanic is: light nuclei
+combining into a heavier one and releasing energy. Near-black indigo, thin
+bright vector rims, additive plasma, no cards and no gradients-with-rounded-
+corners anywhere.
+
+The 3D is real, not a drop shadow. Every chip is an extruded octagonal prism,
+swept toward a vanishing point above the well, so chips at the edges show their
+sides and chips in the middle stand straight up. The well's walls are built the
+same way. It costs two extra fills per chip and it is the single thing that
+stops this reading as a flat puzzle grid.
+
+Chip colour encodes size *relative to the KEY*, so a 7 at KEY 10 and a 70 at KEY
+100 look the same and the palette never runs out. Colour is decorative: the
+number is always printed, so nothing is ever carried by hue alone.
+
+## The juice, with numbers
+
+| Channel | What it does |
+|---|---|
+| Screen shake | Trauma model (Eiserloh): store trauma, shake by trauma², decay 1.85/s. A land is 0.09–0.22, a chain-5 fuse is 0.61, a resonance hit is 0.85. |
+| Hitstop | 28–50 ms on a land, `34 + 16×chain` ms on a fuse. Logic freezes, rendering does not. |
+| Camera punch | Spring-damped additive zoom, k=190 c=17, so it overshoots once. 0.7 on a land, up to 3.4 on a resonance hit. |
+| Slow motion | Chain ≥ 3 drops the time scale to 0.42 for 200 + 30×chain ms; a resonance hit to 0.32 for 420 ms. |
+| Squash & stretch | Every chip is a spring (k=380, c=23, hard-clamped to ±0.55). A landing chip squashes to 1.34×0.66 and rings back; the chips under it ripple by 0.2/depth. |
+| Particles | 1100-slot pool in flat typed arrays, zero allocation after construction. Streaks, additive dots, spinning shards, ambient embers. Budget drops to 0.65 under 52 fps and 0.35 under 42. |
+| Shockwaves | Expanding fronts whose alpha falls as (1−t)^2.6 — a thinning front, not an outline. |
+| Trails | The falling chip leaves four fading afterimages. |
+| Easing | `outBack` on chip pop-in and panel entry, `outQuint`+`inQuad` on the fuse bloom, `outCubic` on ring growth, `inOutCubic` on core flight. |
+| Audio | Every sound is transient + body + tail, detuned ±30 cents per trigger. Chains climb a pentatonic ladder so a nine-chain is a melody. All procedural, no assets, fully mutable. |
+| Haptics | light on land, medium on fuse, heavy on chain ≥ 3, success on level-up and resonance hit, failure on breach. |
+
+## Safety, because children play this
+
+- `prefers-reduced-motion` zeroes shake, punch, rotation, slow-motion and **all**
+  flashes. Hitstop survives, capped at 40 ms — it is timing, not motion, and it
+  moves nothing on screen. Nothing informational is lost. Asserted in
+  `fx/camera.test.ts`.
+- Full-screen flashes are hard-limited to **3 per second** and **alpha 0.34**,
+  regardless of what the game asks for. Asserted in the same file.
+- No streaks, no loss aversion, no variable-ratio rewards, no loot, no ads, no
+  social pressure, no artificial scarcity. One rescue per run, fixed.
+- Colour never carries meaning alone: the danger band is red *and* hatched, the
+  fuse preview is a glow *and* a rim, the chip is a colour *and* a numeral.
+
+## Performance
+
+Measured on the dense board at level 7, 2502×1822 device pixels (DPR 2):
+
+- **0.50 ms/frame** idle, **1.63 ms/frame** at saturation — 1100 live particles,
+  the ring and pop pools full, camera thrashing every frame. That is 10% of a
+  16.7 ms budget, leaving roughly 6–10 ms of headroom on a mid-range tablet.
+- One canvas, one RAF loop, no DOM work per frame, no `shadowBlur` and no
+  `filter` in the hot path. Glows, chips and numerals are rasterised once into
+  cached bitmaps and blitted; the background plasma is rendered at 1/7 scale and
+  upscaled, which is where the softness comes from for free.
+- The frame budget is measured continuously and the particle budget follows it,
+  so a slow device loses sparks rather than frames.
+
+## Input — two designs, not one ported
+
+**Touch.** Press anywhere, the chip follows your thumb across columns with a
+live landing ghost, lift to slam. Your hand is at the bottom and the chip is at
+the top, so you never cover what you are aiming.
+
+**Desktop.** The chip tracks the mouse with no button held; click to slam.
+`←`/`→` or `A`/`D` to move, `Space`/`↓`/`Enter` to drop, `1`–`6` to drop
+straight into a column, `E`/`Shift` for resonance, `M` mute, `R` restart. During
+resonance, `1`–`6` picks the top chip in that column. A fast player never
+touches the mouse.
+
+## Layout
+
+Portrait puts the instruments in a band above the well; landscape puts them in
+rails either side. Two designs, not one stretched. `layout.test.ts` asserts on
+ten viewports from a 320-wide phone to a 1920 desktop that the well fits, the
+held chip has headroom, and nothing overlaps the well.
+
+## Structure
+
+```
+src/
+  contract.ts        Host / Question — kept EXACTLY the shared shape
+  core/              pure, integer-exact, fully tested
+    rules.ts         the board, group finding, cascade, gravity, the rise
+    deck.ts          complement bag randomiser — you are never dealt a dead chip
+    levels.ts        the escalation curve
+    rng.ts           seeded uint32 stream
+  host/
+    questions.ts     exact generation for a chosen answer, with real mal-rules
+    stubHost.ts      the local host, so this is playable standalone today
+  fx/                camera, particles, sprite cache, palette
+  audio/audio.ts     procedural, three-layer, no assets
+  game.ts            the state machine
+  render.ts          the draw
+  layout.ts input.ts mount.ts
+```
+
+`core/` and `host/` have no DOM dependency and are tested directly with the Node
+test runner — no framework, no jsdom.
+
+The engine *solves* a drop completely (`planDrop`) and the renderer plays that
+plan back with timing. That split is the reason the rules are testable at all,
+and the reason a cascade animates identically to how it was computed.
+
+## Swapping in the real host
+
+`mount(el, host)` already takes the shared `Host`. The stub is only referenced by
+`main.ts`. A host may optionally implement `focus({ key, wanted })` to bias its
+question stream toward the chip values that are about to spawn; without it the
+game simply shows fewer expression faces and everything else is unchanged.
+
+Correctness is reported when it is genuinely known: an expression chip that
+fuses is correct with the time it took, one that is buried by a breach is not,
+and a resonance answer is reported exactly as tapped.

--- a/dynawalla/games/merge/index.html
+++ b/dynawalla/games/merge/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no, maximum-scale=1"
+    />
+    <meta name="theme-color" content="#04050d" />
+    <title>FUSE</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        background: #04050d;
+        overflow: hidden;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #root {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/merge/package.json
+++ b/dynawalla/games/merge/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@dynawalla/game-merge",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "FUSE — a fusion-reactor merge game. Touching tiles that add to the KEY fuse.",
+  "engines": {
+    "node": ">=22.12"
+  },
+  "main": "./src/index.ts",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4173",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "typescript": "~6.0.3",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/games/merge/src/audio/audio.ts
+++ b/dynawalla/games/merge/src/audio/audio.ts
@@ -1,0 +1,269 @@
+/**
+ * Procedural audio. No assets, no samples, nothing to download.
+ *
+ * Every sound is built from three layers, which is what stops synthesised SFX
+ * sounding like a 1980s calculator:
+ *   transient — a few ms of filtered noise, the "click" your ear localises
+ *   body      — the pitched part that says what happened
+ *   tail      — a decaying resonance that gives the room a size
+ *
+ * Everything is detuned by a small random amount on every trigger, so a
+ * twenty-chain never turns into a machine gun of identical clicks.
+ *
+ * Audio is decorative by construction: nothing here is the only channel for any
+ * piece of information, and the whole kit can be switched off.
+ */
+
+const PENTA = [0, 2, 4, 7, 9, 12, 14, 16, 19, 21, 24, 26, 28, 31, 33, 36];
+
+export class AudioKit {
+  private ctx: AudioContext | null = null;
+  private master: GainNode | null = null;
+  private noise: AudioBuffer | null = null;
+  enabled = true;
+  private failed = false;
+
+  /** Must be called from a user gesture on iOS. Safe to call repeatedly. */
+  resume(): void {
+    if (this.failed) return;
+    try {
+      if (!this.ctx) {
+        const Ctor =
+          window.AudioContext ??
+          (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+        if (!Ctor) {
+          this.failed = true;
+          return;
+        }
+        this.ctx = new Ctor();
+        const comp = this.ctx.createDynamicsCompressor();
+        comp.threshold.value = -12;
+        comp.knee.value = 18;
+        comp.ratio.value = 9;
+        comp.attack.value = 0.003;
+        comp.release.value = 0.14;
+        const g = this.ctx.createGain();
+        g.gain.value = 0.62;
+        g.connect(comp);
+        comp.connect(this.ctx.destination);
+        this.master = g;
+
+        const len = Math.floor(this.ctx.sampleRate * 1.2);
+        const buf = this.ctx.createBuffer(1, len, this.ctx.sampleRate);
+        const d = buf.getChannelData(0);
+        let s = 12345;
+        for (let i = 0; i < len; i++) {
+          s = (Math.imul(s, 1664525) + 1013904223) >>> 0;
+          d[i] = (s / 0xffffffff) * 2 - 1;
+        }
+        this.noise = buf;
+      }
+      if (this.ctx.state === "suspended") void this.ctx.resume();
+    } catch {
+      this.failed = true;
+    }
+  }
+
+  setEnabled(on: boolean): void {
+    this.enabled = on;
+    if (on) this.resume();
+    if (this.master && this.ctx) {
+      this.master.gain.setTargetAtTime(on ? 0.62 : 0, this.ctx.currentTime, 0.02);
+    }
+  }
+
+  private get t(): number {
+    return this.ctx ? this.ctx.currentTime : 0;
+  }
+
+  private ok(): boolean {
+    return this.enabled && !!this.ctx && !!this.master && this.ctx.state === "running";
+  }
+
+  private jitter(cents = 30): number {
+    return 2 ** ((Math.random() * 2 - 1) * (cents / 1200));
+  }
+
+  private env(gain: GainNode, t0: number, peak: number, attack: number, decay: number): void {
+    gain.gain.setValueAtTime(0.0001, t0);
+    gain.gain.exponentialRampToValueAtTime(Math.max(0.0002, peak), t0 + attack);
+    gain.gain.exponentialRampToValueAtTime(0.0001, t0 + attack + decay);
+  }
+
+  /** transient: a short burst of filtered noise */
+  private hit(t0: number, gain: number, hz: number, q: number, decay: number, type: BiquadFilterType = "bandpass"): void {
+    if (!this.ctx || !this.master || !this.noise) return;
+    const src = this.ctx.createBufferSource();
+    src.buffer = this.noise;
+    src.playbackRate.value = 0.85 + Math.random() * 0.3;
+    const f = this.ctx.createBiquadFilter();
+    f.type = type;
+    f.frequency.value = hz;
+    f.Q.value = q;
+    const g = this.ctx.createGain();
+    this.env(g, t0, gain, 0.002, decay);
+    src.connect(f);
+    f.connect(g);
+    g.connect(this.master);
+    src.start(t0);
+    src.stop(t0 + decay + 0.06);
+  }
+
+  /** body: a pitched oscillator with an optional glide */
+  private tone(
+    t0: number,
+    hz: number,
+    to: number,
+    gain: number,
+    decay: number,
+    type: OscillatorType = "sine",
+    attack = 0.004,
+  ): void {
+    if (!this.ctx || !this.master) return;
+    const o = this.ctx.createOscillator();
+    o.type = type;
+    const j = this.jitter();
+    o.frequency.setValueAtTime(hz * j, t0);
+    if (to !== hz) o.frequency.exponentialRampToValueAtTime(Math.max(20, to * j), t0 + decay);
+    const g = this.ctx.createGain();
+    this.env(g, t0, gain, attack, decay);
+    o.connect(g);
+    g.connect(this.master);
+    o.start(t0);
+    o.stop(t0 + decay + 0.08);
+  }
+
+  /** an FM bell — carrier plus a modulator at a non-integer ratio */
+  private bell(t0: number, hz: number, gain: number, decay: number, ratio = 2.41, index = 320): void {
+    if (!this.ctx || !this.master) return;
+    const j = this.jitter(18);
+    const car = this.ctx.createOscillator();
+    car.frequency.value = hz * j;
+    const mod = this.ctx.createOscillator();
+    mod.frequency.value = hz * ratio * j;
+    const modGain = this.ctx.createGain();
+    modGain.gain.setValueAtTime(index, t0);
+    modGain.gain.exponentialRampToValueAtTime(1, t0 + decay * 0.7);
+    const g = this.ctx.createGain();
+    this.env(g, t0, gain, 0.003, decay);
+    mod.connect(modGain);
+    modGain.connect(car.frequency);
+    car.connect(g);
+    g.connect(this.master);
+    mod.start(t0);
+    car.start(t0);
+    mod.stop(t0 + decay + 0.1);
+    car.stop(t0 + decay + 0.1);
+  }
+
+  /* ---------------- the kit ---------------- */
+
+  move(): void {
+    if (!this.ok()) return;
+    this.hit(this.t, 0.05, 2600 + Math.random() * 900, 3, 0.03, "highpass");
+  }
+
+  hold(): void {
+    if (!this.ok()) return;
+    this.tone(this.t, 420, 520, 0.05, 0.07, "triangle");
+  }
+
+  /** hardness 0..1 — how far the chip fell */
+  land(hardness: number): void {
+    if (!this.ok()) return;
+    const t0 = this.t;
+    const h = Math.max(0, Math.min(1, hardness));
+    this.hit(t0, 0.16 + h * 0.2, 1400 - h * 500, 1.1, 0.05 + h * 0.04);
+    this.tone(t0, 150 + h * 60, 52, 0.34 + h * 0.2, 0.14 + h * 0.06, "sine");
+    this.tone(t0 + 0.005, 92, 46, 0.2, 0.2, "triangle");
+    this.hit(t0 + 0.01, 0.05 + h * 0.05, 320, 0.7, 0.28, "lowpass");
+  }
+
+  /** the fuse — brighter and higher every step of a chain */
+  fuse(step: number, size: number): void {
+    if (!this.ok()) return;
+    const t0 = this.t;
+    const semis = PENTA[Math.min(PENTA.length - 1, step - 1)] ?? 0;
+    const base = 392; // G4
+    const hz = base * 2 ** (semis / 12);
+    this.hit(t0, 0.14, 4200, 2.2, 0.045, "highpass");
+    this.bell(t0, hz, 0.3, 0.42 + size * 0.05, 2.41, 260 + step * 40);
+    this.bell(t0 + 0.012, hz * 2, 0.12, 0.24, 3.13, 140);
+    this.tone(t0, hz / 2, hz / 2, 0.14, 0.3, "triangle");
+    if (size >= 3) this.tone(t0 + 0.02, hz * 1.5, hz * 1.5, 0.1, 0.34, "sine");
+  }
+
+  /** a core arriving at the gauge */
+  core(step: number): void {
+    if (!this.ok()) return;
+    const semis = PENTA[Math.min(PENTA.length - 1, step)] ?? 0;
+    this.tone(this.t, 660 * 2 ** (semis / 12), 990 * 2 ** (semis / 12), 0.09, 0.1, "sine", 0.002);
+  }
+
+  chainPeak(step: number): void {
+    if (!this.ok()) return;
+    const t0 = this.t;
+    for (let i = 0; i < 4; i++) {
+      const semis = PENTA[Math.min(PENTA.length - 1, step + i)] ?? 0;
+      this.tone(t0 + i * 0.045, 523 * 2 ** (semis / 12), 523 * 2 ** (semis / 12), 0.12, 0.26, "triangle");
+    }
+    this.hit(t0, 0.16, 5200, 1.4, 0.1, "highpass");
+  }
+
+  levelUp(): void {
+    if (!this.ok()) return;
+    const t0 = this.t;
+    const root = 261.6;
+    for (const [i, semis] of [0, 4, 7, 11, 14].entries()) {
+      this.tone(t0 + i * 0.055, root * 2 ** (semis / 12), root * 2 ** (semis / 12), 0.14, 0.7, "sawtooth", 0.02);
+    }
+    this.tone(t0, 60, 120, 0.3, 0.8, "sine");
+    this.hit(t0, 0.2, 900, 0.6, 0.7, "lowpass");
+  }
+
+  chargeReady(): void {
+    if (!this.ok()) return;
+    const t0 = this.t;
+    this.bell(t0, 880, 0.16, 0.6, 1.51, 120);
+    this.bell(t0 + 0.09, 1320, 0.12, 0.5, 1.51, 120);
+  }
+
+  resonanceEnter(): void {
+    if (!this.ok()) return;
+    const t0 = this.t;
+    this.tone(t0, 700, 90, 0.22, 0.55, "sawtooth", 0.01);
+    this.hit(t0, 0.22, 2400, 0.8, 0.6, "lowpass");
+    this.tone(t0 + 0.05, 44, 40, 0.3, 0.9, "sine");
+  }
+
+  resonanceHit(): void {
+    if (!this.ok()) return;
+    const t0 = this.t;
+    this.hit(t0, 0.32, 3000, 0.7, 0.28, "highpass");
+    this.tone(t0, 180, 40, 0.42, 0.5, "sine");
+    for (let i = 0; i < 6; i++) {
+      const semis = PENTA[i] ?? 0;
+      this.bell(t0 + i * 0.035, 523 * 2 ** (semis / 12), 0.16, 0.5, 2.02, 300);
+    }
+  }
+
+  resonanceMiss(): void {
+    if (!this.ok()) return;
+    const t0 = this.t;
+    this.tone(t0, 190, 70, 0.22, 0.34, "square");
+    this.hit(t0, 0.14, 700, 1.4, 0.24, "lowpass");
+  }
+
+  breach(): void {
+    if (!this.ok()) return;
+    const t0 = this.t;
+    this.tone(t0, 220, 26, 0.4, 1.5, "sawtooth", 0.02);
+    this.tone(t0, 110, 20, 0.34, 1.8, "sine");
+    this.hit(t0, 0.3, 1800, 0.4, 1.6, "lowpass");
+  }
+
+  ui(up = true): void {
+    if (!this.ok()) return;
+    this.tone(this.t, up ? 620 : 420, up ? 880 : 300, 0.1, 0.09, "triangle");
+  }
+}

--- a/dynawalla/games/merge/src/contract.ts
+++ b/dynawalla/games/merge/src/contract.ts
@@ -1,0 +1,44 @@
+/**
+ * The Dynawalla game <-> host contract.
+ *
+ * This file is a temporary local copy of the shared contract. Keep it EXACTLY
+ * this shape so swapping in the shared package is a one-line import change.
+ */
+
+export type Question = {
+  id: string;
+  /** "15 − 8" */
+  prompt: string;
+  /** "7" — exact, canonical */
+  answer: string;
+  /** plausible wrong answers, ideally real mal-rule outputs */
+  distractors: string[];
+  /** "add-sub" | "fractions" | ... */
+  domain: string;
+  /** 0..1 */
+  difficulty: number;
+};
+
+export type Host = {
+  /** pull the next question */
+  next(): Question;
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void;
+  haptic(kind: "light" | "medium" | "heavy" | "success" | "failure"): void;
+  prefersReducedMotion(): boolean;
+};
+
+export function mount(_el: HTMLElement, _host: Host): { unmount(): void } {
+  throw new Error("contract stub — import mount from ./mount.ts");
+}
+
+/**
+ * OPTIONAL host extension, feature-detected — never required.
+ *
+ * FUSE spawns tiles whose face may be an expression with a specific value, so
+ * it wants questions with a chosen answer. A host that can bias its stream
+ * implements `focus`; one that cannot simply produces fewer expression tiles.
+ * The base `Host` shape above is untouched.
+ */
+export type FocusableHost = Host & {
+  focus?(spec: { key: number; wanted: number[] }): void;
+};

--- a/dynawalla/games/merge/src/core/deck.test.ts
+++ b/dynawalla/games/merge/src/core/deck.test.ts
@@ -1,0 +1,125 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Rng, hashSeed } from "./rng.ts";
+import { Deck } from "./deck.ts";
+import { levelAt, spawnPool, tierOf } from "./levels.ts";
+
+test("the deck only ever deals values the key can use", () => {
+  for (const key of [10, 12, 15, 20, 24, 25, 30, 40, 50, 60, 75, 100]) {
+    const d = new Deck(new Rng(hashSeed(`k${key}`)), key, 20);
+    for (let i = 0; i < 500; i++) {
+      const v = d.deal();
+      assert.ok(Number.isInteger(v), `${v} is not an integer`);
+      assert.ok(v >= 1 && v < key, `${v} out of range for key ${key}`);
+    }
+  }
+});
+
+test("every dealt tile has a partner in the near stream", () => {
+  // Deal a long run and check that for each value, the complement shows up
+  // within a small window — the promise that keeps the well drainable.
+  const key = 20;
+  const d = new Deck(new Rng(hashSeed("partners")), key, 0);
+  const run: number[] = [];
+  for (let i = 0; i < 400; i++) run.push(d.deal());
+  let unmatched = 0;
+  const pool = run.slice();
+  for (let i = 0; i < pool.length; i++) {
+    const v = pool[i];
+    if (v == null) continue;
+    let found = -1;
+    for (let j = i + 1; j < Math.min(pool.length, i + 30); j++) {
+      if (pool[j] === key - v) {
+        found = j;
+        break;
+      }
+    }
+    if (found < 0) unmatched++;
+    else {
+      pool[i] = undefined as unknown as number;
+      pool[found] = undefined as unknown as number;
+    }
+  }
+  assert.ok(unmatched < 30, `${unmatched} tiles had no partner within 30 deals`);
+});
+
+test("triples sum to the key too", () => {
+  const key = 12;
+  const d = new Deck(new Rng(hashSeed("triples")), key, 100);
+  // With triplePct 100 every refill is triples; totals over a full bag drain
+  // are multiples of the key.
+  let total = 0;
+  for (let i = 0; i < 300; i++) total += d.deal();
+  assert.ok(total > 0);
+});
+
+test("the deck is deterministic for a seed", () => {
+  const a = new Deck(new Rng(hashSeed("det")), 15, 15);
+  const b = new Deck(new Rng(hashSeed("det")), 15, 15);
+  for (let i = 0; i < 200; i++) assert.equal(a.deal(), b.deal());
+});
+
+test("retune switches key cleanly", () => {
+  const d = new Deck(new Rng(hashSeed("re")), 10, 10);
+  for (let i = 0; i < 5; i++) d.deal();
+  d.retune(40, 20);
+  for (let i = 0; i < 200; i++) {
+    const v = d.deal();
+    assert.ok(v >= 1 && v < 40);
+  }
+});
+
+test("the level curve escalates and then holds", () => {
+  let prevTime = Infinity;
+  for (let n = 1; n <= 30; n++) {
+    const l = levelAt(n);
+    assert.ok(l.fuseTime <= prevTime, `fuse time went up at level ${n}`);
+    prevTime = l.fuseTime;
+    assert.ok(l.key >= 10);
+    assert.ok(l.exprPct >= 0 && l.exprPct <= 100);
+    assert.ok(l.quota > 0);
+  }
+  assert.equal(levelAt(1).exprPct, 0, "level 1 is numerals only — learn the feel first");
+  assert.ok(levelAt(9).exprPct > 0);
+  assert.equal(levelAt(1).preview, "full");
+  assert.equal(levelAt(9).preview, "none");
+  assert.equal(levelAt(60).fuseTime, levelAt(30).fuseTime, "the curve bottoms out, it does not invert");
+});
+
+test("spawnPool covers every value below the key", () => {
+  assert.deepEqual(spawnPool(10), [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  assert.equal(spawnPool(100).length, 99);
+});
+
+test("tier is relative to the key, so the palette never runs out", () => {
+  assert.equal(tierOf(1, 10), tierOf(10, 100));
+  assert.equal(tierOf(9, 10), tierOf(90, 100));
+  for (const key of [10, 20, 100]) {
+    for (let v = 1; v < key; v++) {
+      const t = tierOf(v, key);
+      assert.ok(t >= 0 && t <= 5, `tier ${t} out of range`);
+    }
+  }
+});
+
+test("the rng is a deterministic uint32 stream", () => {
+  const a = new Rng(42);
+  const b = new Rng(42);
+  for (let i = 0; i < 100; i++) assert.equal(a.u32(), b.u32());
+  const c = new Rng(42);
+  const s = c.state();
+  const first = c.int(1000);
+  c.setState(s);
+  assert.equal(c.int(1000), first);
+});
+
+test("rng.int stays in range and covers it", () => {
+  const r = new Rng(hashSeed("cover"));
+  const seen = new Set<number>();
+  for (let i = 0; i < 5000; i++) {
+    const v = r.int(7);
+    assert.ok(v >= 0 && v < 7);
+    seen.add(v);
+  }
+  assert.equal(seen.size, 7);
+});

--- a/dynawalla/games/merge/src/core/deck.ts
+++ b/dynawalla/games/merge/src/core/deck.ts
@@ -1,0 +1,68 @@
+import { Rng } from "./rng.ts";
+
+/**
+ * The spawn deck.
+ *
+ * A bag randomiser that deals in *complements*: every value it hands you has a
+ * partner already in the bag. You are never dealt a tile the well cannot use —
+ * if the run ends it is because of where you put things, which is the only
+ * honest reason for a puzzle game to end.
+ *
+ * Items are drawn from a random position in the bag, so the partner arrives
+ * some unpredictable number of tiles later. That gap is the whole game.
+ */
+export class Deck {
+  private bag: number[] = [];
+  private key: number;
+  private rng: Rng;
+  private triplePct: number;
+
+  constructor(rng: Rng, key: number, triplePct = 12) {
+    this.rng = rng;
+    this.key = key;
+    this.triplePct = triplePct;
+    this.refill();
+  }
+
+  /** Reset for a new KEY. Any partner still owed under the old key is dropped. */
+  retune(key: number, triplePct: number): void {
+    this.key = key;
+    this.triplePct = triplePct;
+    this.bag = [];
+    this.refill();
+  }
+
+  private addPair(): void {
+    // a in [1, key-1]; the pair is (a, key-a)
+    const a = this.rng.range(1, this.key - 1);
+    this.bag.push(a, this.key - a);
+  }
+
+  private addTriple(): void {
+    // a + b + c = key, each >= 1
+    const a = this.rng.range(1, this.key - 2);
+    const b = this.rng.range(1, this.key - a - 1);
+    this.bag.push(a, b, this.key - a - b);
+  }
+
+  private refill(): void {
+    while (this.bag.length < 14) {
+      if (this.key >= 3 && this.rng.chance(this.triplePct, 100)) this.addTriple();
+      else this.addPair();
+    }
+  }
+
+  /** Next tile value. */
+  deal(): number {
+    this.refill();
+    const i = this.rng.int(this.bag.length);
+    const v = this.bag[i] as number;
+    this.bag.splice(i, 1);
+    return v;
+  }
+
+  /** Peek at what is still owed, for the "incoming" strip. */
+  size(): number {
+    return this.bag.length;
+  }
+}

--- a/dynawalla/games/merge/src/core/levels.ts
+++ b/dynawalla/games/merge/src/core/levels.ts
@@ -1,0 +1,67 @@
+/**
+ * The escalation curve.
+ *
+ * The KEY climbs, the well drains faster, and more tile faces stop being
+ * numerals and start being expressions you have to evaluate. Same game, harder
+ * arithmetic, all the way up. Nothing here is random.
+ */
+
+export type Level = {
+  n: number;
+  /** the sum a fusing group must make */
+  key: number;
+  /** ms the held tile waits before it drops itself */
+  fuseTime: number;
+  /** expression-face probability, in 1/100 */
+  exprPct: number;
+  /** fuses needed to advance */
+  quota: number;
+  /** chance a dealt item is a triple instead of a pair, in 1/100 */
+  triplePct: number;
+  /** show which tiles would fuse while aiming: full | faint | none */
+  preview: "full" | "faint" | "none";
+  /** drops between one rise of the well and the next */
+  riseEvery: number;
+  /** rows pushed in per rise */
+  riseRows: number;
+};
+
+const KEYS = [10, 10, 12, 15, 20, 20, 24, 25, 30, 40, 50, 60, 75, 100];
+
+export function levelAt(n: number): Level {
+  const i = Math.min(n - 1, KEYS.length - 1);
+  const key = KEYS[Math.max(0, i)] as number;
+  const fuseTime = Math.max(2400, 7600 - (n - 1) * 460);
+  const exprPct = n <= 2 ? 0 : Math.min(70, 12 + (n - 3) * 8);
+  const triplePct = n <= 1 ? 8 : Math.min(28, 8 + (n - 1) * 3);
+  const preview = n <= 3 ? "full" : n <= 6 ? "faint" : "none";
+  return {
+    n,
+    key,
+    fuseTime,
+    exprPct,
+    quota: 8 + n * 2,
+    triplePct,
+    preview,
+    riseEvery: Math.max(3, 7 - Math.floor((n - 1) / 2)),
+    riseRows: n >= 9 ? 2 : 1,
+  };
+}
+
+/** Every value the spawner may emit at this KEY. */
+export function spawnPool(key: number): number[] {
+  const out: number[] = [];
+  for (let v = 1; v < key; v++) out.push(v);
+  return out;
+}
+
+/**
+ * Tile tiers drive colour and glow. A tier is "how big is this number,
+ * relative to the KEY" — so a 7 at KEY 10 and a 70 at KEY 100 read the same,
+ * and the palette never runs out.
+ */
+export function tierOf(value: number, key: number): number {
+  if (key <= 0) return 0;
+  const q = Math.floor((value * 6) / key);
+  return Math.max(0, Math.min(5, q));
+}

--- a/dynawalla/games/merge/src/core/rng.ts
+++ b/dynawalla/games/merge/src/core/rng.ts
@@ -1,0 +1,77 @@
+/**
+ * Seeded, deterministic integer RNG.
+ *
+ * mulberry32 on a uint32 state. Every consumer in `core/` draws integers only —
+ * no float ever reaches a value, a comparison or an answer.
+ */
+
+export class Rng {
+  private s: number;
+
+  constructor(seed: number) {
+    // Force a uint32 that is never 0 (mulberry32 is fine with 0 but a zero seed
+    // reads like "unseeded" in a bug report).
+    this.s = (seed >>> 0) || 0x9e3779b9;
+  }
+
+  /** Raw uint32. */
+  u32(): number {
+    this.s = (this.s + 0x6d2b79f5) >>> 0;
+    let t = this.s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return (t ^ (t >>> 14)) >>> 0;
+  }
+
+  /** Uniform integer in [0, n). n must be a positive integer. */
+  int(n: number): number {
+    if (n <= 0) return 0;
+    // Rejection-free modulo bias is irrelevant at our n (<= a few hundred) but
+    // the multiply-shift keeps it uniform enough and stays integer-only.
+    return this.u32() % n;
+  }
+
+  /** Uniform integer in [lo, hi] inclusive. */
+  range(lo: number, hi: number): number {
+    if (hi <= lo) return lo;
+    return lo + this.int(hi - lo + 1);
+  }
+
+  /** True with probability numerator/denominator. */
+  chance(numerator: number, denominator: number): boolean {
+    return this.int(denominator) < numerator;
+  }
+
+  pick<T>(xs: readonly T[]): T {
+    return xs[this.int(xs.length)] as T;
+  }
+
+  /** In-place Fisher-Yates. Deterministic for a given state. */
+  shuffle<T>(xs: T[]): T[] {
+    for (let i = xs.length - 1; i > 0; i--) {
+      const j = this.int(i + 1);
+      const a = xs[i] as T;
+      xs[i] = xs[j] as T;
+      xs[j] = a;
+    }
+    return xs;
+  }
+
+  /** Snapshot / restore, so a replay can fork without disturbing the run. */
+  state(): number {
+    return this.s;
+  }
+  setState(s: number): void {
+    this.s = s >>> 0;
+  }
+}
+
+/** Cheap string -> uint32, for turning a seed phrase into a seed. */
+export function hashSeed(text: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < text.length; i++) {
+    h ^= text.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}

--- a/dynawalla/games/merge/src/core/rules.test.ts
+++ b/dynawalla/games/merge/src/core/rules.test.ts
@@ -1,0 +1,350 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  COLS,
+  ROWS,
+  applyGravity,
+  boardValues,
+  cascade,
+  dropRow,
+  emptyBoard,
+  fillRatio,
+  findGroups,
+  groupScore,
+  idx,
+  planDrop,
+  previewFuse,
+  riseBoard,
+  selectGroups,
+  strandedTiles,
+  type Board,
+  type CoreTile,
+} from "./rules.ts";
+
+let nextId = 1;
+const T = (value: number): CoreTile => ({ id: nextId++, value });
+
+function put(b: Board, r: number, c: number, value: number): CoreTile {
+  const t = T(value);
+  b[idx(r, c)] = t;
+  return t;
+}
+
+test("dropRow finds the floor and then stacks", () => {
+  const b = emptyBoard();
+  assert.equal(dropRow(b, 0), ROWS - 1);
+  put(b, ROWS - 1, 0, 3);
+  assert.equal(dropRow(b, 0), ROWS - 2);
+  for (let r = 0; r < ROWS; r++) b[idx(r, 1)] = T(1);
+  assert.equal(dropRow(b, 1), -1);
+});
+
+test("a horizontal pair summing to the key is a group", () => {
+  const b = emptyBoard();
+  put(b, ROWS - 1, 0, 3);
+  put(b, ROWS - 1, 1, 7);
+  const g = findGroups(b, 10);
+  assert.equal(g.length, 1);
+  assert.equal(g[0]!.cells.length, 2);
+  assert.equal(g[0]!.sum, 10);
+});
+
+test("a vertical pair summing to the key is a group", () => {
+  const b = emptyBoard();
+  put(b, ROWS - 1, 2, 4);
+  put(b, ROWS - 2, 2, 6);
+  assert.equal(findGroups(b, 10).length, 1);
+});
+
+test("diagonal neighbours never fuse", () => {
+  const b = emptyBoard();
+  put(b, ROWS - 1, 0, 4);
+  put(b, ROWS - 2, 1, 6);
+  assert.equal(findGroups(b, 10).length, 0);
+});
+
+test("a connected triple summing to the key is a group", () => {
+  const b = emptyBoard();
+  put(b, ROWS - 1, 0, 3);
+  put(b, ROWS - 1, 1, 3);
+  put(b, ROWS - 1, 2, 4);
+  const gs = findGroups(b, 10);
+  const triples = gs.filter((g) => g.cells.length === 3);
+  assert.equal(triples.length, 1);
+  assert.equal(triples[0]!.sum, 10);
+});
+
+test("an L-shaped triple counts, a disconnected trio does not", () => {
+  const b = emptyBoard();
+  put(b, ROWS - 1, 0, 2);
+  put(b, ROWS - 1, 1, 3);
+  put(b, ROWS - 2, 1, 5);
+  assert.equal(
+    findGroups(b, 10).filter((g) => g.cells.length === 3).length,
+    1,
+  );
+
+  const d = emptyBoard();
+  put(d, ROWS - 1, 0, 2);
+  put(d, ROWS - 1, 2, 3);
+  put(d, ROWS - 1, 4, 5);
+  assert.equal(findGroups(d, 10).length, 0);
+});
+
+test("groups are deduplicated by tile identity", () => {
+  const b = emptyBoard();
+  put(b, ROWS - 1, 1, 5);
+  put(b, ROWS - 1, 0, 2);
+  put(b, ROWS - 1, 2, 3);
+  const gs = findGroups(b, 10);
+  const sigs = new Set(gs.map((g) => g.ids.join(",")));
+  assert.equal(sigs.size, gs.length);
+});
+
+test("selectGroups prefers triples and never overlaps", () => {
+  const b = emptyBoard();
+  // 3 | 3 | 4  -> the triple (10) and the pair 3+... nothing else
+  put(b, ROWS - 1, 0, 6);
+  put(b, ROWS - 1, 1, 4);
+  put(b, ROWS - 1, 2, 6);
+  const chosen = selectGroups(findGroups(b, 10));
+  const seen = new Set<number>();
+  for (const g of chosen) for (const id of g.ids) {
+    assert.equal(seen.has(id), false, "a tile may not be in two chosen groups");
+    seen.add(id);
+  }
+});
+
+test("selection is deterministic across identical boards", () => {
+  const build = () => {
+    const b = emptyBoard();
+    put(b, ROWS - 1, 0, 6);
+    put(b, ROWS - 1, 1, 4);
+    put(b, ROWS - 1, 2, 6);
+    put(b, ROWS - 2, 1, 4);
+    return b;
+  };
+  nextId = 500;
+  const a = selectGroups(findGroups(build(), 10)).map((g) => g.cells.map((p) => idx(p.r, p.c)));
+  nextId = 500;
+  const z = selectGroups(findGroups(build(), 10)).map((g) => g.cells.map((p) => idx(p.r, p.c)));
+  assert.deepEqual(a, z);
+});
+
+test("gravity collapses a column and reports the moves", () => {
+  const b = emptyBoard();
+  const t = put(b, 2, 3, 9);
+  const moves = applyGravity(b);
+  assert.equal(b[idx(ROWS - 1, 3)]!.id, t.id);
+  assert.deepEqual(moves, [{ id: t.id, from: { r: 2, c: 3 }, to: { r: ROWS - 1, c: 3 } }]);
+});
+
+test("planDrop does not mutate the board it was given", () => {
+  const b = emptyBoard();
+  put(b, ROWS - 1, 0, 3);
+  const before = b.map((t) => t?.value ?? 0);
+  planDrop(b, 0, T(7), { key: 10, nextId: () => nextId++ });
+  assert.deepEqual(
+    b.map((t) => t?.value ?? 0),
+    before,
+  );
+});
+
+test("a drop that completes the key fuses and empties the well", () => {
+  const b = emptyBoard();
+  put(b, ROWS - 1, 0, 3);
+  const plan = planDrop(b, 0, T(7), { key: 10, nextId: () => nextId++ });
+  assert.equal(plan.steps.length, 1);
+  assert.equal(plan.steps[0]!.fused.length, 1);
+  assert.equal(plan.steps[0]!.fused[0]!.sum, 10);
+  assert.equal(boardValues(plan.final).length, 0);
+  assert.equal(plan.totalScore, groupScore(10, 2, 1));
+});
+
+test("a fuse leaves nothing behind by default", () => {
+  const b = emptyBoard();
+  put(b, ROWS - 1, 0, 4);
+  const plan = planDrop(b, 0, T(6), { key: 10, nextId: () => nextId++ });
+  assert.equal(plan.steps[0]!.born.length, 0);
+  assert.equal(plan.final.filter(Boolean).length, 0);
+});
+
+test("bornValue seam leaves a live tile when asked", () => {
+  const b = emptyBoard();
+  put(b, ROWS - 1, 0, 4);
+  const plan = planDrop(b, 0, T(6), { key: 10, bornValue: 10, nextId: () => nextId++ });
+  assert.equal(plan.steps[0]!.born.length, 1);
+  assert.deepEqual(boardValues(plan.final), [10]);
+});
+
+test("planDrop resolves every group it finds, not only the dropped tile's", () => {
+  // A settled board never actually holds a live pair — the previous drop would
+  // have cleared it — but the solver must not depend on that.
+  const b = emptyBoard();
+  put(b, ROWS - 1, 0, 1);
+  put(b, ROWS - 2, 0, 9);
+  const plan = planDrop(b, 0, T(5), { key: 10, nextId: () => nextId++ });
+  assert.equal(plan.steps.length, 1);
+  assert.equal(plan.steps[0]!.chain, 1);
+  assert.deepEqual(boardValues(plan.final), [5]);
+});
+
+test("removing a tile lets the stack fall into a second fuse", () => {
+  //        c0   c1   c2   c3
+  //  r-2:   .    3    .    .
+  //  r-1:   4    6    7   (1 dropped)
+  // 4+6 fuses; the 3 falls beside the 7; 3+7 fuses at chain 2.
+  const b = emptyBoard();
+  put(b, ROWS - 1, 0, 4);
+  put(b, ROWS - 1, 1, 6);
+  put(b, ROWS - 1, 2, 7);
+  put(b, ROWS - 2, 1, 3);
+  const plan = planDrop(b, 3, T(1), { key: 10, nextId: () => nextId++ });
+  assert.equal(plan.maxChain, 2);
+  assert.equal(plan.steps.length, 2);
+  assert.equal(plan.steps[0]!.score, groupScore(10, 2, 1));
+  assert.equal(plan.steps[1]!.score, groupScore(10, 2, 2));
+  assert.equal(plan.totalScore, 60);
+  assert.deepEqual(boardValues(plan.final), [1]);
+});
+
+test("a full column is a breach", () => {
+  const b = emptyBoard();
+  for (let r = 0; r < ROWS; r++) b[idx(r, 2)] = T(1);
+  const plan = planDrop(b, 2, T(1), { key: 10, nextId: () => nextId++ });
+  assert.equal(plan.landing, null);
+  assert.equal(plan.breach, true);
+});
+
+test("a tile settling in the top row is a breach", () => {
+  const b = emptyBoard();
+  for (let r = 1; r < ROWS; r++) b[idx(r, 4)] = T(1);
+  const plan = planDrop(b, 4, T(1), { key: 10, nextId: () => nextId++ });
+  assert.notEqual(plan.landing, null);
+  assert.equal(plan.breach, true);
+});
+
+test("previewFuse shows the landing cell and stays quiet when nothing fuses", () => {
+  const b = emptyBoard();
+  put(b, ROWS - 1, 0, 3);
+  put(b, ROWS - 1, 1, 8);
+  // a 4 landing on the 3 makes 7, and beside the 8 diagonally: nothing fuses
+  const p = previewFuse(b, 0, 4, 10);
+  assert.deepEqual(p.landing, { r: ROWS - 2, c: 0 });
+  assert.equal(p.cells.length, 0);
+  // a 7 landing on the same cell is vertically adjacent to the 3: it fuses
+  const q = previewFuse(b, 0, 7, 10);
+  assert.equal(q.cells.length, 2);
+});
+
+test("previewFuse lights the partner when the drop lands beside it", () => {
+  const b = emptyBoard();
+  put(b, ROWS - 1, 1, 3);
+  const p = previewFuse(b, 0, 7, 10);
+  assert.equal(p.cells.length, 2);
+});
+
+test("previewFuse on a full column reports no landing", () => {
+  const b = emptyBoard();
+  for (let r = 0; r < ROWS; r++) b[idx(r, 5)] = T(2);
+  assert.deepEqual(previewFuse(b, 5, 8, 10).landing, null);
+});
+
+test("fillRatio grows as the well fills", () => {
+  const b = emptyBoard();
+  assert.equal(fillRatio(b), 0);
+  put(b, ROWS - 1, 0, 1);
+  assert.ok(fillRatio(b) > 0 && fillRatio(b) < 0.2);
+  put(b, 0, 0, 1);
+  assert.equal(fillRatio(b), 1);
+});
+
+test("strandedTiles finds what the new key can never use", () => {
+  const b = emptyBoard();
+  const dead = put(b, ROWS - 1, 0, 9);
+  put(b, ROWS - 1, 1, 3);
+  // key 40, pool 1..39: 9 needs 31 (spawnable) -> alive. 3 needs 37 -> alive.
+  assert.equal(strandedTiles(b, 40, [1, 2, 3]).length, 2);
+  const pool: number[] = [];
+  for (let v = 1; v < 40; v++) pool.push(v);
+  assert.equal(strandedTiles(b, 40, pool).length, 0);
+  // key 5: a 9 can never help
+  assert.deepEqual(
+    strandedTiles(b, 5, [1, 2, 3, 4]).map((t) => t.id),
+    [dead.id],
+  );
+});
+
+test("groupScore is exact integer arithmetic", () => {
+  assert.equal(groupScore(10, 2, 1), 20);
+  assert.equal(groupScore(10, 3, 4), 120);
+  assert.equal(Number.isInteger(groupScore(75, 3, 7)), true);
+});
+
+test("the board geometry is what the renderer assumes", () => {
+  assert.equal(COLS, 6);
+  assert.equal(ROWS, 11);
+  assert.equal(emptyBoard().length, COLS * ROWS);
+});
+
+test("a rise pushes every chip up one row and lays a fresh floor", () => {
+  const b = emptyBoard();
+  const a = put(b, ROWS - 1, 0, 4);
+  const z = put(b, ROWS - 2, 0, 5);
+  const out = riseBoard(b, [1, 2, 3, 4, 5, 6], () => nextId++);
+  assert.equal(out.breach, false);
+  assert.equal(b[idx(ROWS - 2, 0)]!.id, a.id);
+  assert.equal(b[idx(ROWS - 3, 0)]!.id, z.id);
+  assert.deepEqual(
+    Array.from({ length: COLS }, (_, c) => b[idx(ROWS - 1, c)]!.value),
+    [1, 2, 3, 4, 5, 6],
+  );
+  assert.equal(out.born.length, COLS);
+  assert.equal(out.moves.length, 2);
+});
+
+test("a rise refuses rather than deleting a chip out of the top row", () => {
+  const b = emptyBoard();
+  for (let r = 0; r < ROWS; r++) b[idx(r, 3)] = T(1);
+  const before = b.map((t) => t?.id ?? 0);
+  const out = riseBoard(b, [1, 1, 1, 1, 1, 1], () => nextId++);
+  assert.equal(out.breach, true);
+  assert.deepEqual(
+    b.map((t) => t?.id ?? 0),
+    before,
+    "the board must be untouched when a rise is refused",
+  );
+});
+
+test("a rise can itself set off a cascade", () => {
+  const b = emptyBoard();
+  put(b, ROWS - 1, 0, 7);
+  const out = riseBoard(b, [3, 1, 1, 1, 1, 1], () => nextId++);
+  assert.equal(out.breach, false);
+  const res = cascade(b, { key: 10, nextId: () => nextId++ });
+  assert.equal(res.steps.length, 1, "the 7 lands on the new 3 and fuses");
+  assert.equal(res.maxChain, 1);
+});
+
+test("cascade and planDrop agree on the same board", () => {
+  const build = () => {
+    const b = emptyBoard();
+    put(b, ROWS - 1, 0, 4);
+    put(b, ROWS - 1, 1, 6);
+    put(b, ROWS - 1, 2, 7);
+    put(b, ROWS - 2, 1, 3);
+    return b;
+  };
+  nextId = 900;
+  const viaPlan = planDrop(build(), 3, T(1), { key: 10, nextId: () => nextId++ });
+  nextId = 900;
+  const live = build();
+  live[idx(ROWS - 1, 3)] = T(1);
+  const viaCascade = cascade(live, { key: 10, nextId: () => nextId++ });
+  assert.equal(viaCascade.steps.length, viaPlan.steps.length);
+  assert.equal(viaCascade.totalScore, viaPlan.totalScore);
+  assert.deepEqual(
+    live.map((t) => t?.value ?? 0),
+    viaPlan.final.map((t) => t?.value ?? 0),
+  );
+});

--- a/dynawalla/games/merge/src/core/rules.ts
+++ b/dynawalla/games/merge/src/core/rules.ts
@@ -1,0 +1,386 @@
+/**
+ * FUSE — the rule engine.
+ *
+ * ONE RULE: touching tiles whose values add up to the KEY fuse into the KEY.
+ * A fusing group is 2 or 3 orthogonally-connected tiles.
+ *
+ * Everything here is integer-exact and deterministic. The engine *solves* a
+ * drop completely and returns a plan of discrete steps; the renderer plays that
+ * plan back with timing. That split is why the rules are testable at all.
+ */
+
+export const COLS = 6;
+export const ROWS = 11;
+
+/** A tile as the rules see it. Render state lives elsewhere. */
+export type CoreTile = {
+  id: number;
+  /** exact integer */
+  value: number;
+};
+
+/** row-major, index = r * COLS + c, r = 0 is the top. */
+export type Board = (CoreTile | null)[];
+
+export function emptyBoard(): Board {
+  return new Array<CoreTile | null>(COLS * ROWS).fill(null);
+}
+
+export function idx(r: number, c: number): number {
+  return r * COLS + c;
+}
+
+export function at(b: Board, r: number, c: number): CoreTile | null {
+  if (r < 0 || r >= ROWS || c < 0 || c >= COLS) return null;
+  return b[idx(r, c)] ?? null;
+}
+
+export function cloneBoard(b: Board): Board {
+  return b.slice();
+}
+
+/** Lowest empty row in a column, or -1 if the column is full. */
+export function dropRow(b: Board, c: number): number {
+  for (let r = ROWS - 1; r >= 0; r--) {
+    if (b[idx(r, c)] == null) return r;
+  }
+  return -1;
+}
+
+export type Cell = { r: number; c: number };
+export type Group = { cells: Cell[]; ids: number[]; sum: number };
+
+/**
+ * Every connected 2- or 3-tile group whose values add to `key`.
+ *
+ * Connected triples in a 4-neighbour grid are always "a centre plus two of its
+ * neighbours", so enumerating (centre, neighbour-pair) covers all of them
+ * exactly once per centre. Duplicates are removed by canonical id ordering.
+ */
+export function findGroups(b: Board, key: number): Group[] {
+  const out: Group[] = [];
+  const seen = new Set<string>();
+
+  const push = (cells: Cell[]) => {
+    const ids = cells.map((p) => (b[idx(p.r, p.c)] as CoreTile).id).sort((x, y) => x - y);
+    const sig = ids.join(",");
+    if (seen.has(sig)) return;
+    seen.add(sig);
+    const sum = cells.reduce((acc, p) => acc + (b[idx(p.r, p.c)] as CoreTile).value, 0);
+    out.push({ cells, ids, sum });
+  };
+
+  for (let r = 0; r < ROWS; r++) {
+    for (let c = 0; c < COLS; c++) {
+      const t = b[idx(r, c)];
+      if (t == null) continue;
+
+      // pairs: only right and down, so each pair is visited once
+      const right = at(b, r, c + 1);
+      if (right && t.value + right.value === key) {
+        push([
+          { r, c },
+          { r, c: c + 1 },
+        ]);
+      }
+      const down = at(b, r + 1, c);
+      if (down && t.value + down.value === key) {
+        push([
+          { r, c },
+          { r: r + 1, c },
+        ]);
+      }
+
+      // triples: this cell as the centre
+      const nbrs: Cell[] = [];
+      if (at(b, r - 1, c)) nbrs.push({ r: r - 1, c });
+      if (at(b, r + 1, c)) nbrs.push({ r: r + 1, c });
+      if (at(b, r, c - 1)) nbrs.push({ r, c: c - 1 });
+      if (at(b, r, c + 1)) nbrs.push({ r, c: c + 1 });
+      for (let i = 0; i < nbrs.length; i++) {
+        for (let j = i + 1; j < nbrs.length; j++) {
+          const a = nbrs[i] as Cell;
+          const d = nbrs[j] as Cell;
+          const va = (b[idx(a.r, a.c)] as CoreTile).value;
+          const vd = (b[idx(d.r, d.c)] as CoreTile).value;
+          if (t.value + va + vd === key) push([a, { r, c }, d]);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Pick a non-overlapping set of groups to fuse this step.
+ *
+ * Deterministic: larger groups first (they clear more and look better), then
+ * lowest cell index, then id order. Greedy over that order.
+ */
+export function selectGroups(groups: Group[]): Group[] {
+  const keyOf = (g: Group) => Math.min(...g.cells.map((p) => idx(p.r, p.c)));
+  const sorted = groups.slice().sort((a, z) => {
+    if (a.cells.length !== z.cells.length) return z.cells.length - a.cells.length;
+    const ka = keyOf(a);
+    const kz = keyOf(z);
+    if (ka !== kz) return ka - kz;
+    return (a.ids[0] as number) - (z.ids[0] as number);
+  });
+  const used = new Set<number>();
+  const chosen: Group[] = [];
+  for (const g of sorted) {
+    if (g.ids.some((id) => used.has(id))) continue;
+    for (const id of g.ids) used.add(id);
+    chosen.push(g);
+  }
+  return chosen;
+}
+
+export type Move = { id: number; from: Cell; to: Cell };
+
+/** Collapse every column downward. Returns the moves that happened. */
+export function applyGravity(b: Board): Move[] {
+  const moves: Move[] = [];
+  for (let c = 0; c < COLS; c++) {
+    let write = ROWS - 1;
+    for (let r = ROWS - 1; r >= 0; r--) {
+      const t = b[idx(r, c)];
+      if (t == null) continue;
+      if (r !== write) {
+        b[idx(write, c)] = t;
+        b[idx(r, c)] = null;
+        moves.push({ id: t.id, from: { r, c }, to: { r: write, c } });
+      }
+      write--;
+    }
+  }
+  return moves;
+}
+
+/** One beat of the cascade: what fused, what fell, what was scored. */
+export type Step = {
+  /** 1-based cascade depth; 1 is the drop's own fuse. */
+  chain: number;
+  fused: Group[];
+  /** the KEY tile born at the centre of each fused group */
+  born: { id: number; value: number; cell: Cell }[];
+  falls: Move[];
+  score: number;
+};
+
+export type DropPlan = {
+  /** where the dropped tile lands; null means the column was full. */
+  landing: Cell | null;
+  steps: Step[];
+  /** board after everything settles */
+  final: Board;
+  /** true when a tile occupies the top row after settling */
+  breach: boolean;
+  totalScore: number;
+  maxChain: number;
+};
+
+export type PlanOptions = {
+  key: number;
+  /**
+   * Value of the tile left behind by a fuse.
+   *
+   * 0 by default: the sum leaves the well entirely as a CORE that flies to the
+   * reactor gauge. A KEY-valued tile left on the board would be permanently
+   * dead weight (nothing adds to KEY with KEY), which clogs the well and makes
+   * every good chain punish you. The seam stays for target-variants where the
+   * born tile is a live value.
+   */
+  bornValue?: number;
+  /** id allocator for born tiles */
+  nextId: () => number;
+};
+
+/** score for one group at one chain depth */
+export function groupScore(key: number, size: number, chain: number): number {
+  return key * size * chain;
+}
+
+/**
+ * Run the cascade to completion on `b`, which IS mutated.
+ *
+ * Shared by the drop solver and by the rising well, so both use exactly the
+ * same rules and the same deterministic group ordering.
+ */
+export function cascade(b: Board, opts: PlanOptions): {
+  steps: Step[];
+  totalScore: number;
+  maxChain: number;
+} {
+  const steps: Step[] = [];
+  let chain = 0;
+  let totalScore = 0;
+  for (;;) {
+    const groups = selectGroups(findGroups(b, opts.key));
+    if (groups.length === 0) break;
+    chain++;
+
+    let score = 0;
+    const born: { id: number; value: number; cell: Cell }[] = [];
+    for (const g of groups) {
+      score += groupScore(opts.key, g.cells.length, chain);
+      for (const p of g.cells) b[idx(p.r, p.c)] = null;
+      const bv = opts.bornValue ?? 0;
+      if (bv > 0) {
+        // The KEY tile is born in the group's lowest cell — it looks like the
+        // pieces collapsing into one another rather than floating up.
+        let best = g.cells[0] as Cell;
+        for (const p of g.cells) if (p.r > best.r || (p.r === best.r && p.c < best.c)) best = p;
+        const t: CoreTile = { id: opts.nextId(), value: bv };
+        b[idx(best.r, best.c)] = t;
+        born.push({ id: t.id, value: bv, cell: best });
+      }
+    }
+    totalScore += score;
+    const falls = applyGravity(b);
+    steps.push({ chain, fused: groups, born, falls, score });
+  }
+  return { steps, totalScore, maxChain: chain };
+}
+
+/**
+ * Solve a drop end to end.
+ *
+ * `board` is not mutated. The dropped tile must not already be on the board.
+ */
+export function planDrop(board: Board, col: number, tile: CoreTile, opts: PlanOptions): DropPlan {
+  const b = cloneBoard(board);
+  const r = dropRow(b, col);
+  if (r < 0) {
+    return { landing: null, steps: [], final: b, breach: true, totalScore: 0, maxChain: 0 };
+  }
+  b[idx(r, col)] = tile;
+  const out = cascade(b, opts);
+  let breach = false;
+  for (let c = 0; c < COLS; c++) if (b[idx(0, c)] != null) breach = true;
+  return {
+    landing: { r, c: col },
+    steps: out.steps,
+    final: b,
+    breach,
+    totalScore: out.totalScore,
+    maxChain: out.maxChain,
+  };
+}
+
+/**
+ * The well rises: every chip moves up one row and a fresh row is pushed in
+ * underneath.
+ *
+ * This is the pressure that stops a good player clearing forever. Refuses (and
+ * reports a breach) when anything is already in the top row, so a rise can
+ * never silently delete a chip.
+ */
+export function riseBoard(
+  b: Board,
+  values: readonly number[],
+  nextId: () => number,
+): { moves: Move[]; born: CoreTile[]; breach: boolean } {
+  for (let c = 0; c < COLS; c++) {
+    if (b[idx(0, c)] != null) return { moves: [], born: [], breach: true };
+  }
+  const moves: Move[] = [];
+  for (let r = 0; r < ROWS - 1; r++) {
+    for (let c = 0; c < COLS; c++) {
+      const t = b[idx(r + 1, c)] ?? null;
+      b[idx(r, c)] = t;
+      if (t) moves.push({ id: t.id, from: { r: r + 1, c }, to: { r, c } });
+    }
+  }
+  const born: CoreTile[] = [];
+  for (let c = 0; c < COLS; c++) {
+    const t: CoreTile = { id: nextId(), value: values[c] ?? 1 };
+    b[idx(ROWS - 1, c)] = t;
+    born.push(t);
+  }
+  return { moves, born, breach: false };
+}
+
+/**
+ * Cells that WOULD fuse if `value` were dropped into `col` right now.
+ *
+ * Used for the aim preview: the whole rule is taught by watching two tiles
+ * light up, with no words at all.
+ */
+export function previewFuse(
+  board: Board,
+  col: number,
+  value: number,
+  key: number,
+): { landing: Cell | null; cells: Cell[] } {
+  const r = dropRow(board, col);
+  if (r < 0) return { landing: null, cells: [] };
+  const b = cloneBoard(board);
+  const ghost: CoreTile = { id: -1, value };
+  b[idx(r, col)] = ghost;
+  const groups = selectGroups(findGroups(b, key));
+  const hit = groups.filter((g) => g.ids.includes(-1));
+  const cells: Cell[] = [];
+  for (const g of hit) for (const p of g.cells) cells.push(p);
+  return { landing: { r, c: col }, cells };
+}
+
+/** How high the stack is, 0..1, for the danger meter. */
+export function fillRatio(b: Board): number {
+  let top = ROWS;
+  for (let r = 0; r < ROWS; r++) {
+    for (let c = 0; c < COLS; c++) {
+      if (b[idx(r, c)] != null) {
+        top = r;
+        r = ROWS;
+        break;
+      }
+    }
+  }
+  return (ROWS - top) / ROWS;
+}
+
+/**
+ * Tiles that can never fuse under `key` with anything the spawner can produce.
+ * These are burned off when the KEY changes, so a level-up is relief, not a
+ * dead board.
+ */
+export function strandedTiles(b: Board, key: number, spawnable: readonly number[]): CoreTile[] {
+  const pool = new Set(spawnable);
+  const out: CoreTile[] = [];
+  for (const t of b) {
+    if (t == null) continue;
+    if (t.value >= key) {
+      out.push(t);
+      continue;
+    }
+    // survives if some spawnable value completes it as a pair, or if two do as
+    // a triple
+    const need = key - t.value;
+    if (pool.has(need)) continue;
+    let ok = false;
+    for (const a of pool) {
+      if (pool.has(need - a)) {
+        ok = true;
+        break;
+      }
+    }
+    if (!ok) out.push(t);
+  }
+  return out;
+}
+
+export function removeIds(b: Board, ids: readonly number[]): void {
+  const kill = new Set(ids);
+  for (let i = 0; i < b.length; i++) {
+    const t = b[i];
+    if (t && kill.has(t.id)) b[i] = null;
+  }
+}
+
+/** Every distinct tile value currently on the board, ascending. */
+export function boardValues(b: Board): number[] {
+  const s = new Set<number>();
+  for (const t of b) if (t) s.add(t.value);
+  return [...s].sort((a, z) => a - z);
+}

--- a/dynawalla/games/merge/src/fx/camera.test.ts
+++ b/dynawalla/games/merge/src/fx/camera.test.ts
@@ -1,0 +1,130 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Camera, clamp01, ease } from "./camera.ts";
+
+const step = (c: Camera, seconds: number, dt = 1 / 60) => {
+  let logic = 0;
+  for (let t = 0; t < seconds; t += dt) logic += c.update(dt);
+  return logic;
+};
+
+test("trauma decays to nothing and the offset goes with it", () => {
+  const c = new Camera();
+  c.shake(1);
+  c.update(1 / 60);
+  assert.ok(Math.abs(c.x) > 0 || Math.abs(c.y) > 0, "a full-trauma shake must move the camera");
+  step(c, 1.2);
+  assert.equal(c.trauma, 0);
+  assert.equal(c.x, 0);
+  assert.equal(c.y, 0);
+  assert.equal(c.rot, 0);
+});
+
+test("shake is quadratic in trauma, so a small hit stays subtle", () => {
+  const big = new Camera();
+  big.shake(1);
+  big.update(1 / 60);
+  const small = new Camera();
+  small.shake(0.3);
+  small.update(1 / 60);
+  const mag = (c: Camera) => Math.hypot(c.x, c.y);
+  // 0.3^2 / 1^2 ~ 0.09, so a third of the trauma is under a fifth of the shake
+  assert.ok(mag(small) < mag(big) * 0.2, `${mag(small)} vs ${mag(big)}`);
+});
+
+test("the zoom punch springs back and settles exactly at zero", () => {
+  const c = new Camera();
+  c.punch(3);
+  c.update(1 / 60);
+  assert.ok(c.zoom > 0);
+  step(c, 3);
+  assert.equal(c.zoom, 0);
+});
+
+test("hitstop eats logic time and then gives it back", () => {
+  const c = new Camera();
+  c.stop(50);
+  const first = c.update(1 / 60);
+  assert.equal(first, 0, "a frame inside hitstop advances no logic");
+  step(c, 0.2);
+  const after = c.update(1 / 60);
+  assert.ok(after > 0.015, "logic resumes at full speed once hitstop ends");
+});
+
+test("slow motion scales logic time and recovers", () => {
+  const c = new Camera();
+  c.slowmo(0.25, 200);
+  step(c, 0.05);
+  const slow = c.update(1 / 60);
+  assert.ok(slow < 1 / 60, "logic must run slower than real time");
+  step(c, 1.5);
+  const back = c.update(1 / 60);
+  assert.ok(back > 0.0164, `expected real time back, got ${back}`);
+});
+
+/* ---- the two guarantees that exist because children play this ---- */
+
+test("flashes are rate limited to three per second and capped in strength", () => {
+  const c = new Camera();
+  for (let i = 0; i < 20; i++) c.flash([255, 255, 255], 1);
+  assert.equal(c.flashes.length, 3, "no more than three flashes may start in one second");
+  for (const f of c.flashes) assert.ok(f.a <= 0.34, `flash alpha ${f.a} exceeds the cap`);
+
+  step(c, 1.2); // let the window slide
+  c.flash([255, 255, 255], 1);
+  assert.ok(c.flashes.length >= 1, "a flash is allowed again once the window has passed");
+});
+
+test("reduced motion removes every motion channel and every flash", () => {
+  const c = new Camera();
+  c.reduced = true;
+  c.shake(1);
+  c.punch(4);
+  c.slowmo(0.1, 900);
+  c.flash([255, 255, 255], 1);
+  c.update(1 / 60);
+  assert.equal(c.trauma, 0);
+  assert.equal(c.x, 0);
+  assert.equal(c.y, 0);
+  assert.equal(c.rot, 0);
+  assert.equal(c.zoom, 0);
+  assert.equal(c.timeScale, 1);
+  assert.equal(c.flashes.length, 0);
+  assert.equal(c.flashAlpha(), null);
+});
+
+test("reduced motion keeps hitstop, but caps it", () => {
+  // Hitstop is timing, not motion: it is what makes an impact feel heavy, and
+  // it moves nothing on screen. It stays, bounded.
+  const c = new Camera();
+  c.reduced = true;
+  c.stop(400);
+  assert.ok(c.hitstop > 0 && c.hitstop <= 40);
+});
+
+test("reset returns the camera to a clean state", () => {
+  const c = new Camera();
+  c.shake(1);
+  c.punch(2);
+  c.flash([255, 0, 0], 0.3);
+  c.stop(100);
+  c.reset();
+  assert.equal(c.trauma, 0);
+  assert.equal(c.zoom, 0);
+  assert.equal(c.hitstop, 0);
+  assert.equal(c.flashes.length, 0);
+  assert.equal(c.timeScale, 1);
+});
+
+test("easings hit their endpoints", () => {
+  for (const [name, fn] of Object.entries(ease)) {
+    assert.ok(Math.abs(fn(0) - 0) < 1e-6, `${name}(0)`);
+    assert.ok(Math.abs(fn(1) - 1) < 1e-6, `${name}(1)`);
+  }
+});
+
+test("clamp01 clamps", () => {
+  assert.equal(clamp01(-3), 0);
+  assert.equal(clamp01(0.4), 0.4);
+  assert.equal(clamp01(9), 1);
+});

--- a/dynawalla/games/merge/src/fx/camera.ts
+++ b/dynawalla/games/merge/src/fx/camera.ts
@@ -1,0 +1,187 @@
+import type { Rgb } from "./palette.ts";
+
+/**
+ * The screenshake module, in the Vlambeer sense.
+ *
+ * Trauma-based shake (Squirrel Eiserloh's model: store trauma, shake by
+ * trauma^2 so small hits are subtle and big ones are violent), a spring-damped
+ * zoom punch, hitstop, and a slow-motion time scale. Every one of these is a
+ * *feel* channel and every one degrades to nothing under reduced motion —
+ * without ever removing information, because none of them carry any.
+ */
+
+export type Flash = { a: number; c: Rgb; t: number };
+
+const TAU = Math.PI * 2;
+
+export class Camera {
+  trauma = 0;
+  /** additive zoom, 0 = neutral */
+  zoom = 0;
+  private zoomV = 0;
+  rot = 0;
+  x = 0;
+  y = 0;
+
+  /** ms of frozen logic remaining */
+  hitstop = 0;
+  /** current time scale applied to logic */
+  timeScale = 1;
+  private slowUntil = 0;
+  private slowAmount = 1;
+
+  flashes: Flash[] = [];
+  private flashTimes: number[] = [];
+
+  reduced = false;
+  private seed = 1337;
+  private clock = 0;
+
+  private noise(t: number, o: number): number {
+    // cheap deterministic value noise: sum of two sines with irrational-ish
+    // ratios. No allocation, no Math.random, stable per frame.
+    const a = Math.sin((t * 21.7 + o * 13.3) * 0.001 * TAU * 6.3 + this.seed);
+    const b = Math.sin((t * 9.1 + o * 41.7) * 0.001 * TAU * 11.9 - this.seed);
+    return a * 0.62 + b * 0.38;
+  }
+
+  shake(amount: number): void {
+    if (this.reduced) return;
+    this.trauma = Math.min(1, this.trauma + amount);
+  }
+
+  punch(amount: number): void {
+    if (this.reduced) {
+      return;
+    }
+    this.zoomV += amount;
+  }
+
+  stop(ms: number): void {
+    // Hitstop survives reduced motion at a fraction: it is a *timing* device,
+    // not a motion device, and it carries the weight of an impact. Capped hard.
+    this.hitstop = Math.max(this.hitstop, this.reduced ? Math.min(ms, 40) : ms);
+  }
+
+  slowmo(scale: number, ms: number): void {
+    if (this.reduced) return;
+    this.slowAmount = Math.min(this.slowAmount, scale);
+    this.slowUntil = Math.max(this.slowUntil, this.clock + ms);
+  }
+
+  /**
+   * Full-screen flash, rate limited.
+   *
+   * This is a children's product: never more than 3 flashes in any second, and
+   * never above 0.34 alpha, which keeps the luminance swing well under the
+   * WCAG 2.3.1 general-flash threshold at any plausible screen brightness.
+   * Under reduced motion there are no flashes at all.
+   */
+  flash(c: Rgb, a: number): void {
+    if (this.reduced) return;
+    const now = this.clock;
+    this.flashTimes = this.flashTimes.filter((t) => now - t < 1000);
+    if (this.flashTimes.length >= 3) return;
+    this.flashTimes.push(now);
+    this.flashes.push({ a: Math.min(0.34, a), c, t: 0 });
+  }
+
+  /** Advance. `dt` is real seconds. Returns the logic dt after hitstop/slowmo. */
+  update(dt: number): number {
+    this.clock += dt * 1000;
+
+    let logic = dt;
+    if (this.hitstop > 0) {
+      const used = Math.min(this.hitstop, dt * 1000);
+      this.hitstop -= used;
+      logic = Math.max(0, dt - used / 1000);
+    }
+
+    if (this.clock < this.slowUntil) {
+      this.timeScale += (this.slowAmount - this.timeScale) * Math.min(1, dt * 26);
+    } else {
+      this.slowAmount = 1;
+      this.timeScale += (1 - this.timeScale) * Math.min(1, dt * 7);
+    }
+    logic *= this.timeScale;
+
+    this.trauma = Math.max(0, this.trauma - dt * 1.85);
+    const s = this.trauma * this.trauma;
+    if (s > 0) {
+      this.x = this.noise(this.clock, 0) * s * 30;
+      this.y = this.noise(this.clock, 7) * s * 26;
+      this.rot = this.noise(this.clock, 19) * s * 0.028;
+    } else {
+      this.x = 0;
+      this.y = 0;
+      this.rot = 0;
+    }
+
+    // zoom spring: stiff, slightly underdamped, so it overshoots once
+    const k = 190;
+    const c = 17;
+    this.zoomV += (-k * this.zoom - c * this.zoomV) * dt;
+    this.zoom += this.zoomV * dt;
+    if (Math.abs(this.zoom) < 0.0002 && Math.abs(this.zoomV) < 0.002) {
+      this.zoom = 0;
+      this.zoomV = 0;
+    }
+
+    for (const f of this.flashes) f.t += dt;
+    this.flashes = this.flashes.filter((f) => f.t < 0.22);
+
+    return logic;
+  }
+
+  flashAlpha(): { a: number; c: Rgb } | null {
+    if (this.flashes.length === 0) return null;
+    let best: Flash | null = null;
+    let bestA = 0;
+    for (const f of this.flashes) {
+      const a = f.a * Math.max(0, 1 - f.t / 0.22) ** 2;
+      if (a > bestA) {
+        bestA = a;
+        best = f;
+      }
+    }
+    return best ? { a: bestA, c: best.c } : null;
+  }
+
+  reset(): void {
+    this.trauma = 0;
+    this.zoom = 0;
+    this.zoomV = 0;
+    this.hitstop = 0;
+    this.timeScale = 1;
+    this.slowUntil = 0;
+    this.slowAmount = 1;
+    this.flashes = [];
+    this.flashTimes = [];
+  }
+}
+
+/* ---- easing, by name ---- */
+
+export const ease = {
+  outCubic: (t: number) => 1 - (1 - t) ** 3,
+  outQuint: (t: number) => 1 - (1 - t) ** 5,
+  inCubic: (t: number) => t * t * t,
+  inOutCubic: (t: number) => (t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2),
+  outBack: (t: number) => {
+    const c1 = 2.2;
+    const c3 = c1 + 1;
+    return 1 + c3 * (t - 1) ** 3 + c1 * (t - 1) ** 2;
+  },
+  outElastic: (t: number) => {
+    if (t <= 0) return 0;
+    if (t >= 1) return 1;
+    const p = 0.36;
+    return 2 ** (-10 * t) * Math.sin(((t * 10 - 0.75) * (2 * Math.PI)) / p / 3.2) + 1;
+  },
+  outExpo: (t: number) => (t >= 1 ? 1 : 1 - 2 ** (-10 * t)),
+  inQuad: (t: number) => t * t,
+};
+
+export function clamp01(t: number): number {
+  return t < 0 ? 0 : t > 1 ? 1 : t;
+}

--- a/dynawalla/games/merge/src/fx/palette.ts
+++ b/dynawalla/games/merge/src/fx/palette.ts
@@ -1,0 +1,64 @@
+/**
+ * FUSE looks like a magnetic containment well seen from above: near-black
+ * indigo, thin bright vector rims, additive plasma. Nothing is a card, nothing
+ * is a gradient panel, nothing is beige.
+ *
+ * Tile colour encodes tier (how big the number is relative to the KEY) and is
+ * decorative only — the number itself is always printed, so no information is
+ * ever carried by colour alone.
+ */
+
+export type Rgb = readonly [number, number, number];
+
+export const BG_DEEP: Rgb = [4, 5, 13];
+export const BG_MID: Rgb = [10, 13, 31];
+export const WELL_BACK: Rgb = [7, 10, 24];
+export const WELL_RIM: Rgb = [42, 58, 112];
+export const HAIRLINE: Rgb = [24, 33, 66];
+
+export const HOT: Rgb = [255, 240, 214];
+export const KEYC: Rgb = [255, 214, 120];
+export const DANGER: Rgb = [255, 51, 85];
+export const CHARGE: Rgb = [110, 255, 214];
+
+/** tier 0..5, low numbers cool, high numbers hot */
+export const TIERS: Rgb[] = [
+  [46, 230, 255], // cyan
+  [77, 140, 255], // blue
+  [164, 92, 255], // violet
+  [255, 77, 157], // magenta
+  [255, 138, 61], // ember
+  [255, 216, 77], // gold
+];
+
+export function tierColor(tier: number): Rgb {
+  return TIERS[Math.max(0, Math.min(TIERS.length - 1, tier))] as Rgb;
+}
+
+export function rgb(c: Rgb, a = 1): string {
+  return a >= 1 ? `rgb(${c[0]},${c[1]},${c[2]})` : `rgba(${c[0]},${c[1]},${c[2]},${a})`;
+}
+
+export function mix(a: Rgb, b: Rgb, t: number): Rgb {
+  const k = Math.max(0, Math.min(1, t));
+  return [
+    Math.round(a[0] + (b[0] - a[0]) * k),
+    Math.round(a[1] + (b[1] - a[1]) * k),
+    Math.round(a[2] + (b[2] - a[2]) * k),
+  ];
+}
+
+export function shade(c: Rgb, k: number): Rgb {
+  return [
+    Math.max(0, Math.min(255, Math.round(c[0] * k))),
+    Math.max(0, Math.min(255, Math.round(c[1] * k))),
+    Math.max(0, Math.min(255, Math.round(c[2] * k))),
+  ];
+}
+
+export const FONT_STACK =
+  '"Avenir Next", "Segoe UI", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif';
+
+export function font(px: number, weight = 800): string {
+  return `${weight} ${px}px ${FONT_STACK}`;
+}

--- a/dynawalla/games/merge/src/fx/particles.ts
+++ b/dynawalla/games/merge/src/fx/particles.ts
@@ -1,0 +1,415 @@
+import { Rng } from "../core/rng.ts";
+import type { SpriteCache } from "./sprites.ts";
+import { rgb, type Rgb } from "./palette.ts";
+
+/**
+ * Pooled particles in flat typed arrays.
+ *
+ * One allocation at construction, none afterwards. Draws are batched by kind so
+ * the composite mode and stroke style are set a handful of times per frame
+ * rather than once per particle — that, not the particle count, is what costs
+ * frames in Canvas2D.
+ */
+
+export const KIND_STREAK = 0;
+export const KIND_DOT = 1;
+export const KIND_SHARD = 2;
+export const KIND_EMBER = 3;
+
+export class Particles {
+  private cap: number;
+  private x: Float32Array;
+  private y: Float32Array;
+  private vx: Float32Array;
+  private vy: Float32Array;
+  private life: Float32Array;
+  private max: Float32Array;
+  private size: Float32Array;
+  private rot: Float32Array;
+  private spin: Float32Array;
+  private drag: Float32Array;
+  private grav: Float32Array;
+  private kind: Uint8Array;
+  private r: Uint8Array;
+  private g: Uint8Array;
+  private b: Uint8Array;
+  private n = 0;
+  private rng: Rng;
+
+  /** raised while the run is quiet, lowered when the frame budget is tight */
+  budget = 1;
+
+  constructor(cap = 1100, seed = 20260726) {
+    this.cap = cap;
+    this.x = new Float32Array(cap);
+    this.y = new Float32Array(cap);
+    this.vx = new Float32Array(cap);
+    this.vy = new Float32Array(cap);
+    this.life = new Float32Array(cap);
+    this.max = new Float32Array(cap);
+    this.size = new Float32Array(cap);
+    this.rot = new Float32Array(cap);
+    this.spin = new Float32Array(cap);
+    this.drag = new Float32Array(cap);
+    this.grav = new Float32Array(cap);
+    this.kind = new Uint8Array(cap);
+    this.r = new Uint8Array(cap);
+    this.g = new Uint8Array(cap);
+    this.b = new Uint8Array(cap);
+    this.rng = new Rng(seed);
+  }
+
+  get count(): number {
+    return this.n;
+  }
+
+  clear(): void {
+    this.n = 0;
+  }
+
+  private spawn(): number {
+    if (this.n < this.cap) return this.n++;
+    // Full: recycle the particle with the least life left, so a big burst
+    // never gets silently swallowed by a stale ember field.
+    let worst = 0;
+    let worstLife = Infinity;
+    for (let i = 0; i < this.n; i += 7) {
+      if (this.life[i]! < worstLife) {
+        worstLife = this.life[i]!;
+        worst = i;
+      }
+    }
+    return worst;
+  }
+
+  private put(
+    i: number,
+    k: number,
+    x: number,
+    y: number,
+    vx: number,
+    vy: number,
+    life: number,
+    size: number,
+    c: Rgb,
+    drag: number,
+    grav: number,
+    spin: number,
+  ): void {
+    this.kind[i] = k;
+    this.x[i] = x;
+    this.y[i] = y;
+    this.vx[i] = vx;
+    this.vy[i] = vy;
+    this.life[i] = life;
+    this.max[i] = life;
+    this.size[i] = size;
+    this.drag[i] = drag;
+    this.grav[i] = grav;
+    this.rot[i] = this.rng.int(628) / 100;
+    this.spin[i] = spin;
+    this.r[i] = c[0];
+    this.g[i] = c[1];
+    this.b[i] = c[2];
+  }
+
+  /** A hard radial burst — the fuse. */
+  burst(x: number, y: number, c: Rgb, power: number, count: number): void {
+    const n = Math.max(1, Math.round(count * this.budget));
+    for (let i = 0; i < n; i++) {
+      const idx = this.spawn();
+      const a = (this.rng.int(6283) / 1000) as number;
+      const sp = power * (0.35 + this.rng.int(100) / 100);
+      this.put(
+        idx,
+        this.rng.chance(3, 4) ? KIND_STREAK : KIND_DOT,
+        x,
+        y,
+        Math.cos(a) * sp,
+        Math.sin(a) * sp,
+        0.28 + this.rng.int(45) / 100,
+        2 + this.rng.int(4),
+        c,
+        2.6,
+        900,
+        0,
+      );
+    }
+  }
+
+  /** Chunks of a destroyed chip, with spin and gravity. */
+  shards(x: number, y: number, c: Rgb, size: number, count: number): void {
+    const n = Math.max(1, Math.round(count * this.budget));
+    for (let i = 0; i < n; i++) {
+      const idx = this.spawn();
+      const a = (this.rng.int(6283) / 1000) as number;
+      const sp = 90 + this.rng.int(340);
+      this.put(
+        idx,
+        KIND_SHARD,
+        x,
+        y,
+        Math.cos(a) * sp,
+        Math.sin(a) * sp - 120,
+        0.55 + this.rng.int(50) / 100,
+        size * (0.14 + this.rng.int(16) / 100),
+        c,
+        0.7,
+        1500,
+        (this.rng.int(200) - 100) / 12,
+      );
+    }
+  }
+
+  /** Slow drifting motes — the ambient reactor haze. */
+  ember(x: number, y: number, c: Rgb, count: number): void {
+    const n = Math.max(1, Math.round(count * this.budget));
+    for (let i = 0; i < n; i++) {
+      const idx = this.spawn();
+      this.put(
+        idx,
+        KIND_EMBER,
+        x + this.rng.int(40) - 20,
+        y + this.rng.int(40) - 20,
+        this.rng.int(40) - 20,
+        -20 - this.rng.int(50),
+        1.1 + this.rng.int(90) / 100,
+        1.5 + this.rng.int(3),
+        c,
+        0.5,
+        -30,
+        0,
+      );
+    }
+  }
+
+  /** A directional spray — impact dust when a chip lands. */
+  spray(x: number, y: number, c: Rgb, dir: number, spread: number, count: number, power: number): void {
+    const n = Math.max(1, Math.round(count * this.budget));
+    for (let i = 0; i < n; i++) {
+      const idx = this.spawn();
+      const a = dir + (this.rng.int(1000) / 1000 - 0.5) * spread;
+      const sp = power * (0.4 + this.rng.int(100) / 100);
+      this.put(
+        idx,
+        KIND_STREAK,
+        x,
+        y,
+        Math.cos(a) * sp,
+        Math.sin(a) * sp,
+        0.2 + this.rng.int(28) / 100,
+        1.5 + this.rng.int(3),
+        c,
+        3.4,
+        700,
+        0,
+      );
+    }
+  }
+
+  update(dt: number): void {
+    let i = 0;
+    while (i < this.n) {
+      const l = this.life[i]! - dt;
+      if (l <= 0) {
+        const last = --this.n;
+        if (i !== last) {
+          this.x[i] = this.x[last]!;
+          this.y[i] = this.y[last]!;
+          this.vx[i] = this.vx[last]!;
+          this.vy[i] = this.vy[last]!;
+          this.life[i] = this.life[last]!;
+          this.max[i] = this.max[last]!;
+          this.size[i] = this.size[last]!;
+          this.rot[i] = this.rot[last]!;
+          this.spin[i] = this.spin[last]!;
+          this.drag[i] = this.drag[last]!;
+          this.grav[i] = this.grav[last]!;
+          this.kind[i] = this.kind[last]!;
+          this.r[i] = this.r[last]!;
+          this.g[i] = this.g[last]!;
+          this.b[i] = this.b[last]!;
+        }
+        continue;
+      }
+      this.life[i] = l;
+      const d = Math.max(0, 1 - this.drag[i]! * dt);
+      this.vx[i] = this.vx[i]! * d;
+      this.vy[i] = this.vy[i]! * d + this.grav[i]! * dt;
+      this.x[i] = this.x[i]! + this.vx[i]! * dt;
+      this.y[i] = this.y[i]! + this.vy[i]! * dt;
+      this.rot[i] = this.rot[i]! + this.spin[i]! * dt;
+      i++;
+    }
+  }
+
+  draw(g: CanvasRenderingContext2D, sprites: SpriteCache): void {
+    if (this.n === 0) return;
+    g.save();
+    g.globalCompositeOperation = "lighter";
+
+    // streaks + embers: strokes, one path per colour-ish run
+    g.lineCap = "round";
+    for (let i = 0; i < this.n; i++) {
+      const k = this.kind[i]!;
+      if (k !== KIND_STREAK && k !== KIND_EMBER) continue;
+      const t = this.life[i]! / this.max[i]!;
+      const a = k === KIND_EMBER ? t * 0.5 : t;
+      const x = this.x[i]!;
+      const y = this.y[i]!;
+      const len = k === KIND_EMBER ? 0.004 : 0.018;
+      g.strokeStyle = `rgba(${this.r[i]},${this.g[i]},${this.b[i]},${a})`;
+      g.lineWidth = this.size[i]! * (0.35 + t * 0.8);
+      g.beginPath();
+      g.moveTo(x - this.vx[i]! * len, y - this.vy[i]! * len);
+      g.lineTo(x, y);
+      g.stroke();
+    }
+
+    // dots: cached glow blits
+    for (let i = 0; i < this.n; i++) {
+      if (this.kind[i] !== KIND_DOT) continue;
+      const t = this.life[i]! / this.max[i]!;
+      const s = this.size[i]! * 5 * (0.4 + t);
+      const spr = sprites.glow([this.r[i]!, this.g[i]!, this.b[i]!] as Rgb, 40);
+      g.globalAlpha = t;
+      g.drawImage(spr as CanvasImageSource, this.x[i]! - s / 2, this.y[i]! - s / 2, s, s);
+    }
+    g.globalAlpha = 1;
+
+    // shards: little rotating slabs, drawn solid over the additive pass
+    g.globalCompositeOperation = "source-over";
+    for (let i = 0; i < this.n; i++) {
+      if (this.kind[i] !== KIND_SHARD) continue;
+      const t = this.life[i]! / this.max[i]!;
+      const s = this.size[i]!;
+      g.save();
+      g.translate(this.x[i]!, this.y[i]!);
+      g.rotate(this.rot[i]!);
+      g.fillStyle = `rgba(${this.r[i]},${this.g[i]},${this.b[i]},${Math.min(1, t * 1.6)})`;
+      g.fillRect(-s / 2, -s / 2, s, s * 0.7);
+      g.restore();
+    }
+    g.restore();
+  }
+}
+
+/* ---------- shockwave rings ---------- */
+
+export type Ring = {
+  x: number;
+  y: number;
+  r0: number;
+  r1: number;
+  t: number;
+  dur: number;
+  w: number;
+  c: Rgb;
+  alive: boolean;
+};
+
+export class Rings {
+  private pool: Ring[] = [];
+  constructor(cap = 40) {
+    for (let i = 0; i < cap; i++)
+      this.pool.push({ x: 0, y: 0, r0: 0, r1: 0, t: 0, dur: 1, w: 2, c: [255, 255, 255], alive: false });
+  }
+  add(x: number, y: number, r0: number, r1: number, dur: number, w: number, c: Rgb): void {
+    let slot = this.pool.find((p) => !p.alive);
+    if (!slot) slot = this.pool[0] as Ring;
+    slot.x = x;
+    slot.y = y;
+    slot.r0 = r0;
+    slot.r1 = r1;
+    slot.t = 0;
+    slot.dur = dur;
+    slot.w = w;
+    slot.c = c;
+    slot.alive = true;
+  }
+  update(dt: number): void {
+    for (const p of this.pool) {
+      if (!p.alive) continue;
+      p.t += dt;
+      if (p.t >= p.dur) p.alive = false;
+    }
+  }
+  clear(): void {
+    for (const p of this.pool) p.alive = false;
+  }
+  draw(g: CanvasRenderingContext2D): void {
+    g.save();
+    g.globalCompositeOperation = "lighter";
+    for (const p of this.pool) {
+      if (!p.alive) continue;
+      const t = p.t / p.dur;
+      const e = 1 - (1 - t) ** 3;
+      const r = p.r0 + (p.r1 - p.r0) * e;
+      // A shockwave is a thinning, fading front — not an outline. The alpha
+      // falls off faster than the radius grows, so a dozen at once still reads
+      // as one blast rather than a stack of circles.
+      const a = (1 - t) ** 2.6;
+      g.strokeStyle = rgb(p.c, a * 0.85);
+      g.lineWidth = Math.max(0.6, p.w * (1 - t) ** 1.6);
+      g.beginPath();
+      g.arc(p.x, p.y, r, 0, Math.PI * 2);
+      g.stroke();
+      if (a > 0.25) {
+        g.strokeStyle = rgb(p.c, a * 0.3);
+        g.lineWidth = Math.max(1, p.w * 2.2 * (1 - t) ** 1.6);
+        g.stroke();
+      }
+    }
+    g.restore();
+  }
+}
+
+/* ---------- floating score pops ---------- */
+
+export type Pop = { x: number; y: number; vy: number; t: number; dur: number; text: string; c: Rgb; size: number; alive: boolean };
+
+export class Pops {
+  private pool: Pop[] = [];
+  constructor(cap = 32) {
+    for (let i = 0; i < cap; i++)
+      this.pool.push({ x: 0, y: 0, vy: 0, t: 0, dur: 1, text: "", c: [255, 255, 255], size: 20, alive: false });
+  }
+  add(x: number, y: number, text: string, c: Rgb, size: number, dur = 0.9): void {
+    let slot = this.pool.find((p) => !p.alive);
+    if (!slot) slot = this.pool[0] as Pop;
+    slot.x = x;
+    slot.y = y;
+    slot.vy = -90;
+    slot.t = 0;
+    slot.dur = dur;
+    slot.text = text;
+    slot.c = c;
+    slot.size = size;
+    slot.alive = true;
+  }
+  update(dt: number): void {
+    for (const p of this.pool) {
+      if (!p.alive) continue;
+      p.t += dt;
+      p.y += p.vy * dt;
+      p.vy += 130 * dt;
+      if (p.t >= p.dur) p.alive = false;
+    }
+  }
+  clear(): void {
+    for (const p of this.pool) p.alive = false;
+  }
+  draw(g: CanvasRenderingContext2D, sprites: SpriteCache): void {
+    for (const p of this.pool) {
+      if (!p.alive) continue;
+      const t = p.t / p.dur;
+      const pop = t < 0.16 ? 0.5 + (t / 0.16) * 0.72 : 1.22 - (t - 0.16) * 0.22;
+      const a = t > 0.6 ? 1 - (t - 0.6) / 0.4 : 1;
+      g.save();
+      g.translate(p.x, p.y);
+      g.scale(pop, pop);
+      sprites.drawText(g, p.text, p.size, p.c, 0, 0, 900, a);
+      g.restore();
+    }
+  }
+}

--- a/dynawalla/games/merge/src/fx/sprites.ts
+++ b/dynawalla/games/merge/src/fx/sprites.ts
@@ -1,0 +1,210 @@
+import { font, rgb, shade, type Rgb } from "./palette.ts";
+
+/**
+ * Everything expensive is rasterised once and blitted forever.
+ *
+ * No `shadowBlur`, no `filter`, no per-frame gradient construction in the hot
+ * path — those are what actually cost frames in Canvas2D. Glows are pre-blurred
+ * radial sprites drawn with `lighter`; chips and numerals are cached bitmaps.
+ * The cache is keyed by everything that affects the pixels, and cleared on
+ * resize (which is the only time the device pixel ratio can change).
+ */
+
+type Canvas = HTMLCanvasElement | OffscreenCanvas;
+
+function makeCanvas(w: number, h: number): Canvas {
+  if (typeof OffscreenCanvas === "function") return new OffscreenCanvas(Math.max(1, w), Math.max(1, h));
+  const c = document.createElement("canvas");
+  c.width = Math.max(1, w);
+  c.height = Math.max(1, h);
+  return c;
+}
+
+function ctxOf(c: Canvas): CanvasRenderingContext2D {
+  return c.getContext("2d") as unknown as CanvasRenderingContext2D;
+}
+
+export class SpriteCache {
+  private glows = new Map<string, Canvas>();
+  private chips = new Map<string, Canvas>();
+  private texts = new Map<string, { c: Canvas; w: number; h: number }>();
+  private textOrder: string[] = [];
+  dpr = 1;
+
+  reset(dpr: number): void {
+    this.dpr = dpr;
+    this.glows.clear();
+    this.chips.clear();
+    this.texts.clear();
+    this.textOrder = [];
+  }
+
+  /** Soft additive blob. Draw with globalCompositeOperation = "lighter". */
+  glow(c: Rgb, size: number, softness = 1): Canvas {
+    const px = Math.max(8, Math.round(size * this.dpr));
+    const key = `${c[0]},${c[1]},${c[2]}|${px}|${softness}`;
+    const hit = this.glows.get(key);
+    if (hit) return hit;
+    const cv = makeCanvas(px, px);
+    const g = ctxOf(cv);
+    const r = px / 2;
+    const grad = g.createRadialGradient(r, r, 0, r, r, r);
+    // A gaussian-ish falloff. Four stops is enough and stays cheap to build.
+    grad.addColorStop(0, `rgba(${c[0]},${c[1]},${c[2]},${0.95 / softness})`);
+    grad.addColorStop(0.28, `rgba(${c[0]},${c[1]},${c[2]},${0.42 / softness})`);
+    grad.addColorStop(0.6, `rgba(${c[0]},${c[1]},${c[2]},${0.12 / softness})`);
+    grad.addColorStop(1, `rgba(${c[0]},${c[1]},${c[2]},0)`);
+    g.fillStyle = grad;
+    g.fillRect(0, 0, px, px);
+    this.glows.set(key, cv);
+    return cv;
+  }
+
+  /**
+   * A reactor cell: a cut-cornered octagon, dark tinted interior, bright rim,
+   * with an inner bevel highlight so it reads as a solid object under light.
+   */
+  chip(c: Rgb, size: number, hot: boolean): Canvas {
+    const px = Math.max(8, Math.round(size * this.dpr));
+    const key = `${c[0]},${c[1]},${c[2]}|${px}|${hot ? 1 : 0}`;
+    const hit = this.chips.get(key);
+    if (hit) return hit;
+    const cv = makeCanvas(px, px);
+    const g = ctxOf(cv);
+    const s = px;
+    const cut = s * 0.22;
+
+    const path = () => {
+      g.beginPath();
+      g.moveTo(cut, 0);
+      g.lineTo(s - cut, 0);
+      g.lineTo(s, cut);
+      g.lineTo(s, s - cut);
+      g.lineTo(s - cut, s);
+      g.lineTo(cut, s);
+      g.lineTo(0, s - cut);
+      g.lineTo(0, cut);
+      g.closePath();
+    };
+
+    // interior: a vertical gradient from tinted dark to almost black
+    path();
+    const inner = g.createLinearGradient(0, 0, 0, s);
+    const top = shade(c, hot ? 0.62 : 0.3);
+    const bot = shade(c, hot ? 0.2 : 0.09);
+    inner.addColorStop(0, `rgb(${top[0]},${top[1]},${top[2]})`);
+    inner.addColorStop(1, `rgb(${bot[0]},${bot[1]},${bot[2]})`);
+    g.fillStyle = inner;
+    g.fill();
+
+    // bevel: a bright sliver along the top-left edge
+    g.save();
+    path();
+    g.clip();
+    g.globalCompositeOperation = "lighter";
+    const bev = g.createLinearGradient(0, 0, s * 0.7, s * 0.7);
+    bev.addColorStop(0, `rgba(${c[0]},${c[1]},${c[2]},${hot ? 0.55 : 0.3})`);
+    bev.addColorStop(0.35, `rgba(${c[0]},${c[1]},${c[2]},0)`);
+    g.fillStyle = bev;
+    g.fillRect(0, 0, s, s);
+    g.restore();
+
+    // rim
+    g.lineWidth = Math.max(1.5, s * 0.055);
+    g.strokeStyle = rgb(c, hot ? 1 : 0.92);
+    path();
+    g.stroke();
+
+    // inner hairline, inset — reads as thickness
+    g.save();
+    g.translate(s / 2, s / 2);
+    g.scale(0.86, 0.86);
+    g.translate(-s / 2, -s / 2);
+    g.lineWidth = Math.max(1, s * 0.022);
+    g.strokeStyle = rgb(c, hot ? 0.5 : 0.22);
+    path();
+    g.stroke();
+    g.restore();
+
+    this.chips.set(key, cv);
+    return cv;
+  }
+
+  /** Rasterised text. LRU-capped because expression faces are unbounded. */
+  text(str: string, px: number, c: Rgb, weight = 800): { c: Canvas; w: number; h: number } {
+    const size = Math.max(6, Math.round(px * this.dpr));
+    const key = `${str}|${size}|${weight}|${c[0]},${c[1]},${c[2]}`;
+    const hit = this.texts.get(key);
+    if (hit) return hit;
+
+    const probe = makeCanvas(4, 4);
+    const pg = ctxOf(probe);
+    pg.font = font(size, weight);
+    const m = pg.measureText(str);
+    const w = Math.ceil(m.width) + Math.ceil(size * 0.5);
+    const h = Math.ceil(size * 1.5);
+
+    const cv = makeCanvas(w, h);
+    const g = ctxOf(cv);
+    g.font = font(size, weight);
+    g.textAlign = "center";
+    g.textBaseline = "middle";
+    g.fillStyle = rgb(c);
+    g.fillText(str, w / 2, h / 2);
+
+    const entry = { c: cv, w: w / this.dpr, h: h / this.dpr };
+    this.texts.set(key, entry);
+    this.textOrder.push(key);
+    if (this.textOrder.length > 420) {
+      const dead = this.textOrder.shift();
+      if (dead) this.texts.delete(dead);
+    }
+    return entry;
+  }
+
+  /** Draw a cached text bitmap centred on (x, y) at CSS pixels. */
+  drawText(
+    g: CanvasRenderingContext2D,
+    str: string,
+    px: number,
+    c: Rgb,
+    x: number,
+    y: number,
+    weight = 800,
+    alpha = 1,
+  ): void {
+    const t = this.text(str, px, c, weight);
+    if (alpha !== 1) g.globalAlpha = alpha;
+    g.drawImage(t.c as CanvasImageSource, x - t.w / 2, y - t.h / 2, t.w, t.h);
+    if (alpha !== 1) g.globalAlpha = 1;
+  }
+
+  measure(str: string, px: number): number {
+    return this.text(str, px, [255, 255, 255]).w;
+  }
+
+  stats(): { glows: number; chips: number; texts: number } {
+    return { glows: this.glows.size, chips: this.chips.size, texts: this.texts.size };
+  }
+}
+
+/** Cut-cornered octagon path, for things drawn live (the well, the gauge). */
+export function chipPath(
+  g: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  cut: number,
+): void {
+  g.beginPath();
+  g.moveTo(x + cut, y);
+  g.lineTo(x + w - cut, y);
+  g.lineTo(x + w, y + cut);
+  g.lineTo(x + w, y + h - cut);
+  g.lineTo(x + w - cut, y + h);
+  g.lineTo(x + cut, y + h);
+  g.lineTo(x, y + h - cut);
+  g.lineTo(x, y + cut);
+  g.closePath();
+}

--- a/dynawalla/games/merge/src/game.ts
+++ b/dynawalla/games/merge/src/game.ts
@@ -1,0 +1,1237 @@
+import type { FocusableHost, Question } from "./contract.ts";
+import { Rng, hashSeed } from "./core/rng.ts";
+import { Deck } from "./core/deck.ts";
+import { levelAt, spawnPool, tierOf, type Level } from "./core/levels.ts";
+import {
+  COLS,
+  ROWS,
+  applyGravity,
+  boardValues,
+  dropRow,
+  emptyBoard,
+  fillRatio,
+  idx,
+  cascade,
+  cloneBoard,
+  planDrop,
+  previewFuse,
+  removeIds,
+  riseBoard,
+  strandedTiles,
+  type Board,
+  type Cell,
+  type CoreTile,
+  type Step,
+} from "./core/rules.ts";
+import { questionFor } from "./host/questions.ts";
+import { AudioKit } from "./audio/audio.ts";
+import { Camera, clamp01, ease } from "./fx/camera.ts";
+import { Particles, Pops, Rings } from "./fx/particles.ts";
+import { CHARGE, DANGER, HOT, KEYC, tierColor, type Rgb } from "./fx/palette.ts";
+import { cellCenter, type Layout } from "./layout.ts";
+
+export type Face =
+  | { kind: "num" }
+  | { kind: "expr"; text: string; qid: string; fromHost: boolean };
+
+export type TileView = {
+  id: number;
+  value: number;
+  face: Face;
+  r: number;
+  c: number;
+  /** render position in grid units (col, row), floats */
+  px: number;
+  py: number;
+  vy: number;
+  /** squash amount: +stretch horizontally, -vertically */
+  q: number;
+  qv: number;
+  hot: number;
+  spawnAt: number;
+  landedAt: number;
+};
+
+export type Dying = {
+  r: number;
+  c: number;
+  value: number;
+  tier: number;
+  t: number;
+  dur: number;
+  kind: "fuse" | "purge";
+};
+
+export type FlyCore = {
+  x0: number;
+  y0: number;
+  cx: number;
+  cy: number;
+  t: number;
+  dur: number;
+  value: number;
+  color: Rgb;
+  alive: boolean;
+};
+
+export type Phase = "boot" | "aim" | "drop" | "fuse" | "fall" | "levelup" | "resonance" | "breach";
+
+export type Resonance = {
+  active: boolean;
+  rescue: boolean;
+  target: number;
+  question: Question | null;
+  fromHost: boolean;
+  t: number;
+  limit: number;
+  askedAt: number;
+  result: "none" | "hit" | "miss";
+  resultT: number;
+  pickedCell: Cell | null;
+};
+
+const CHARGE_MAX = 8;
+const FUSE_BEAT = 0.2;
+const FALL_MAX = 0.62;
+const BOOT_TIME = 1.3;
+const LEVELUP_TIME = 1.45;
+const BREACH_TIME = 1.5;
+const RES_LIMIT = 9;
+const DROP_V0 = 22;
+const DROP_G = 150;
+const FALL_G = 118;
+const BEST_KEY = "dynawalla.fuse.best";
+
+export class Game {
+  host: FocusableHost;
+  audio = new AudioKit();
+  cam = new Camera();
+  parts = new Particles();
+  rings = new Rings();
+  pops = new Pops();
+
+  rng: Rng;
+  /** cosmetic-only stream, so particle jitter can never shift the run */
+  fxRng: Rng;
+  seedText: string;
+  deck: Deck;
+  level: Level = levelAt(1);
+  levelN = 1;
+
+  board: Board = emptyBoard();
+  tiles = new Map<number, TileView>();
+  dying: Dying[] = [];
+  cores: FlyCore[] = [];
+
+  held: TileView | null = null;
+  heldCol = 2;
+  aimT = 0;
+  previewCells: Cell[] = [];
+  previewLanding: Cell | null = null;
+
+  phase: Phase = "boot";
+  pt = 0;
+  plan: { steps: Step[] } | null = null;
+  stepI = 0;
+  fallT = 0;
+  dropsSinceRise = 0;
+  riseFlash = 0;
+  private levelSeeded = false;
+
+  score = 0;
+  shownScore = 0;
+  best = 0;
+  newBest = false;
+  fusesThisLevel = 0;
+  totalFuses = 0;
+  chainShown = 0;
+  chainShownT = 0;
+  charge = 0;
+  chargeReadyPulse = 0;
+  rescueUsed = false;
+  keyMorph = 0;
+  prevKey = 10;
+
+  res: Resonance = {
+    active: false,
+    rescue: false,
+    target: 0,
+    question: null,
+    fromHost: false,
+    t: 0,
+    limit: RES_LIMIT,
+    askedAt: 0,
+    result: "none",
+    resultT: 0,
+    pickedCell: null,
+  };
+
+  layout: Layout | null = null;
+  paused = false;
+  soundOn = true;
+  danger = 0;
+  fps = 60;
+
+  private nextTileId = 1;
+  private qPool: Question[] = [];
+  private qSeq = 0;
+  private upcoming: number[] = [];
+  private now = 0;
+
+  constructor(host: FocusableHost, seedText = `fuse-${Date.now() & 0xffff}`) {
+    this.host = host;
+    this.seedText = seedText;
+    this.rng = new Rng(hashSeed(seedText));
+    this.fxRng = new Rng(hashSeed(seedText) ^ 0x5bf03635);
+    this.deck = new Deck(this.rng, this.level.key, this.level.triplePct);
+    this.cam.reduced = host.prefersReducedMotion();
+    this.best = readBest();
+    this.fillUpcoming();
+    this.seedWell(3);
+  }
+
+  /* ------------------------------------------------------------------ */
+
+  reset(seedText?: string): void {
+    const s = seedText ?? `${this.seedText}+`;
+    this.seedText = s;
+    this.rng = new Rng(hashSeed(s));
+    this.fxRng = new Rng(hashSeed(s) ^ 0x5bf03635);
+    this.levelN = 1;
+    this.level = levelAt(1);
+    this.deck = new Deck(this.rng, this.level.key, this.level.triplePct);
+    this.board = emptyBoard();
+    this.tiles.clear();
+    this.dying = [];
+    this.cores = [];
+    this.held = null;
+    this.heldCol = 2;
+    this.aimT = 0;
+    this.plan = null;
+    this.stepI = 0;
+    this.dropsSinceRise = 0;
+    this.score = 0;
+    this.shownScore = 0;
+    this.newBest = false;
+    this.fusesThisLevel = 0;
+    this.totalFuses = 0;
+    this.charge = 0;
+    this.rescueUsed = false;
+    this.res.active = false;
+    this.res.result = "none";
+    this.previewCells = [];
+    this.qPool = [];
+    this.upcoming = [];
+    this.prevKey = this.level.key;
+    this.keyMorph = 0;
+    this.parts.clear();
+    this.rings.clear();
+    this.pops.clear();
+    this.cam.reset();
+    this.fillUpcoming();
+    this.seedWell(3);
+    this.phase = "boot";
+    this.pt = 0;
+  }
+
+  private fillUpcoming(): void {
+    while (this.upcoming.length < 6) this.upcoming.push(this.deck.deal());
+  }
+
+  /* ---------------- question plumbing ---------------- */
+
+  private difficulty(): number {
+    return Math.max(0.1, Math.min(0.95, (this.level.key - 6) / 100 + 0.15 + this.levelN * 0.012));
+  }
+
+  private pumpQuestions(n: number, wanted: number[]): void {
+    // A focusable host is told exactly which chip values are coming, so the
+    // expression on a chip face is guaranteed to equal that chip. A host that
+    // cannot focus still works — the pool just matches less often and fewer
+    // chips wear an expression.
+    this.host.focus?.({ key: this.level.key, wanted });
+    for (let i = 0; i < n && this.qPool.length < 26; i++) {
+      try {
+        this.qPool.push(this.host.next());
+      } catch {
+        break;
+      }
+    }
+  }
+
+  private takeQuestionFor(value: number): Question | null {
+    const want = String(value);
+    let i = this.qPool.findIndex((q) => q.answer === want);
+    if (i < 0) {
+      this.pumpQuestions(6, [value, value, ...this.upcoming]);
+      i = this.qPool.findIndex((q) => q.answer === want);
+    }
+    if (i < 0) return null;
+    const q = this.qPool[i] as Question;
+    this.qPool.splice(i, 1);
+    return q;
+  }
+
+  private faceFor(value: number): Face {
+    if (this.level.exprPct <= 0) return { kind: "num" };
+    if (!this.rng.chance(this.level.exprPct, 100)) return { kind: "num" };
+    const q = this.takeQuestionFor(value);
+    if (!q) return { kind: "num" };
+    return { kind: "expr", text: q.prompt, qid: q.id, fromHost: true };
+  }
+
+  private report(face: Face, correct: boolean, ms: number, answered: string): void {
+    if (face.kind !== "expr" || !face.fromHost) return;
+    try {
+      this.host.report({ questionId: face.qid, correct, ms: Math.round(ms), answered });
+    } catch {
+      /* a host that throws on report must not kill the run */
+    }
+  }
+
+  /* ---------------- spawning ---------------- */
+
+  private spawnHeld(): void {
+    this.fillUpcoming();
+    const value = this.upcoming.shift() as number;
+    this.fillUpcoming();
+    const t: TileView = {
+      id: this.nextTileId++,
+      value,
+      face: this.faceFor(value),
+      r: -1,
+      c: this.heldCol,
+      px: this.heldCol,
+      py: -1.35,
+      vy: 0,
+      q: 0.34,
+      qv: 0,
+      hot: 0,
+      spawnAt: this.now,
+      landedAt: 0,
+    };
+    this.held = t;
+    this.aimT = 0;
+    this.updatePreview();
+    this.audio.hold();
+  }
+
+  updatePreview(): void {
+    if (!this.held) {
+      this.previewCells = [];
+      this.previewLanding = null;
+      return;
+    }
+    const p = previewFuse(this.board, this.heldCol, this.held.value, this.level.key);
+    this.previewLanding = p.landing;
+    this.previewCells = this.level.preview === "none" ? [] : p.cells;
+  }
+
+  /* ---------------- input intents ---------------- */
+
+  moveTo(col: number): void {
+    const c = Math.max(0, Math.min(COLS - 1, col));
+    if (this.phase !== "aim" || !this.held || c === this.heldCol) return;
+    this.heldCol = c;
+    this.held.c = c;
+    this.updatePreview();
+    this.audio.move();
+  }
+
+  nudge(d: number): void {
+    this.moveTo(this.heldCol + d);
+  }
+
+  drop(): void {
+    if (this.phase !== "aim" || !this.held) return;
+    const tile = this.held;
+    const r = dropRow(this.board, this.heldCol);
+    if (r < 0) {
+      // The chosen column is full. Refuse, do not punish: a wasted tap is not a
+      // game-ending mistake in any good puzzle game.
+      this.cam.shake(0.12);
+      this.audio.resonanceMiss();
+      return;
+    }
+    const core: CoreTile = { id: tile.id, value: tile.value };
+    this.plan = {
+      steps: planDrop(this.board, this.heldCol, core, {
+        key: this.level.key,
+        nextId: () => this.nextTileId++,
+      }).steps,
+    };
+    this.dropsSinceRise++;
+    tile.r = r;
+    tile.c = this.heldCol;
+    tile.px = this.heldCol;
+    tile.vy = DROP_V0;
+    this.phase = "drop";
+    this.pt = 0;
+    this.audio.resume();
+  }
+
+  toggleSound(): void {
+    this.soundOn = !this.soundOn;
+    this.audio.setEnabled(this.soundOn);
+    if (this.soundOn) this.audio.ui(true);
+  }
+
+  /** the KEY orb was tapped */
+  pokeReactor(): void {
+    if (this.phase === "aim" && this.charge >= CHARGE_MAX) this.enterResonance(false);
+  }
+
+  /* ---------------- resonance ---------------- */
+
+  private enterResonance(rescue: boolean): void {
+    const vals = boardValues(this.board);
+    if (vals.length === 0) {
+      if (rescue) this.enterBreach();
+      return;
+    }
+    const counts = new Map<number, number>();
+    for (const t of this.board) if (t) counts.set(t.value, (counts.get(t.value) ?? 0) + 1);
+    const plural = vals.filter((v) => (counts.get(v) ?? 0) >= 2);
+    const target = this.rng.pick(plural.length > 0 ? plural : vals);
+
+    let q = this.takeQuestionFor(target);
+    let fromHost = true;
+    if (!q) {
+      this.pumpQuestions(10, [target, target, target]);
+      q = this.takeQuestionFor(target);
+    }
+    if (!q) {
+      q = questionFor(target, this.difficulty(), this.rng, ++this.qSeq);
+      fromHost = false;
+    }
+
+    this.res = {
+      active: true,
+      rescue,
+      target,
+      question: q,
+      fromHost,
+      t: 0,
+      limit: RES_LIMIT,
+      askedAt: this.now,
+      result: "none",
+      resultT: 0,
+      pickedCell: null,
+    };
+    if (!rescue) this.charge = 0;
+    this.phase = "resonance";
+    this.pt = 0;
+    this.audio.resonanceEnter();
+    this.host.haptic("medium");
+    this.cam.shake(0.24);
+    this.cam.punch(1.6);
+  }
+
+  /** a board cell was tapped during resonance */
+  pickCell(r: number, c: number): void {
+    if (this.phase !== "resonance" || this.res.result !== "none") return;
+    const t = this.board[idx(r, c)];
+    if (!t) return;
+    this.res.pickedCell = { r, c };
+    const ms = this.now - this.res.askedAt;
+    const correct = t.value === this.res.target;
+    if (this.res.fromHost && this.res.question) {
+      try {
+        this.host.report({
+          questionId: this.res.question.id,
+          correct,
+          ms: Math.round(ms),
+          answered: String(t.value),
+        });
+      } catch {
+        /* ignore */
+      }
+    }
+    if (correct) this.resonanceHit();
+    else this.resonanceMiss();
+  }
+
+  private resonanceHit(): void {
+    this.res.result = "hit";
+    this.res.resultT = 0;
+    const radius = this.res.rescue ? 2 : 1;
+    const doomed = new Set<number>();
+    const seeds: Cell[] = [];
+    for (let r = 0; r < ROWS; r++) {
+      for (let c = 0; c < COLS; c++) {
+        const t = this.board[idx(r, c)];
+        if (t && t.value === this.res.target) seeds.push({ r, c });
+      }
+    }
+    // orthogonal flood to `radius`
+    let frontier = seeds;
+    const mark = (p: Cell) => {
+      const t = this.board[idx(p.r, p.c)];
+      if (t) doomed.add(t.id);
+    };
+    for (const p of frontier) mark(p);
+    for (let step = 0; step < radius; step++) {
+      const next: Cell[] = [];
+      for (const p of frontier) {
+        for (const d of [
+          { r: p.r - 1, c: p.c },
+          { r: p.r + 1, c: p.c },
+          { r: p.r, c: p.c - 1 },
+          { r: p.r, c: p.c + 1 },
+        ]) {
+          if (d.r < 0 || d.r >= ROWS || d.c < 0 || d.c >= COLS) continue;
+          const t = this.board[idx(d.r, d.c)];
+          if (t && !doomed.has(t.id)) {
+            doomed.add(t.id);
+            next.push(d);
+          }
+        }
+      }
+      frontier = next;
+    }
+
+    const l = this.layout;
+    let n = 0;
+    let sx = 0;
+    let sy = 0;
+    for (let r = 0; r < ROWS; r++) {
+      for (let c = 0; c < COLS; c++) {
+        const t = this.board[idx(r, c)];
+        if (!t || !doomed.has(t.id)) continue;
+        const tier = tierOf(t.value, this.level.key);
+        this.dying.push({ r, c, value: t.value, tier, t: -0.012 * n, dur: 0.44, kind: "purge" });
+        const v = this.tiles.get(t.id);
+        if (v) this.report(v.face, true, this.now - v.spawnAt, String(v.value));
+        this.tiles.delete(t.id);
+        if (l) {
+          const p = cellCenter(l, r, c);
+          sx += p.x;
+          sy += p.y;
+          this.parts.burst(p.x, p.y, tierColor(tier), 420, 16);
+          this.parts.shards(p.x, p.y, tierColor(tier), l.cell, 5);
+          // one ring per few chips: a dozen concentric circles is geometry,
+          // not a blast
+          if (n % 3 === 0) this.rings.add(p.x, p.y, l.cell * 0.2, l.cell * 2.1, 0.5, 3, tierColor(tier));
+        }
+        n++;
+      }
+    }
+    if (l && n > 0) {
+      this.rings.add(sx / n, sy / n, l.cell * 0.4, l.cell * (3 + n * 0.35), 0.75, 6, HOT);
+    }
+    removeIds(this.board, [...doomed]);
+    const moves = applyGravity(this.board);
+    for (const m of moves) {
+      const v = this.tiles.get(m.id);
+      if (v) {
+        v.r = m.to.r;
+        v.c = m.to.c;
+      }
+    }
+    const gain = this.level.key * 10 * Math.max(1, n);
+    this.addScore(gain);
+    if (l) {
+      this.pops.add(
+        l.boardX + l.boardW / 2,
+        l.boardY + l.boardH * 0.66,
+        `+${gain}`,
+        HOT,
+        Math.max(26, l.cell * 0.7),
+        1.3,
+      );
+    }
+    this.audio.resonanceHit();
+    this.host.haptic("success");
+    this.cam.shake(0.85);
+    this.cam.punch(3.4);
+    this.cam.slowmo(0.32, 420);
+    this.cam.flash(HOT, 0.26);
+  }
+
+  private resonanceMiss(): void {
+    this.res.result = "miss";
+    this.res.resultT = 0;
+    this.audio.resonanceMiss();
+    this.host.haptic("failure");
+    this.cam.shake(0.34);
+    this.cam.punch(-1.1);
+  }
+
+  /* ---------------- scoring / progression ---------------- */
+
+  private addScore(n: number): void {
+    this.score += n;
+    if (this.score > this.best) {
+      if (!this.newBest && this.best > 0) {
+        this.newBest = true;
+        this.cam.flash(KEYC, 0.16);
+      }
+      this.best = this.score;
+      writeBest(this.best);
+    }
+  }
+
+  private enterBreach(): void {
+    this.phase = "breach";
+    this.pt = 0;
+    this.held = null;
+    for (const [, v] of this.tiles) this.report(v.face, false, this.now - v.spawnAt, "");
+    this.audio.breach();
+    this.host.haptic("failure");
+    this.cam.shake(1);
+    this.cam.punch(-2.6);
+    this.cam.slowmo(0.25, 700);
+  }
+
+  private enterLevelUp(): void {
+    this.phase = "levelup";
+    this.pt = 0;
+    this.levelSeeded = false;
+    this.prevKey = this.level.key;
+    this.levelN++;
+    this.level = levelAt(this.levelN);
+    this.fusesThisLevel = 0;
+    this.dropsSinceRise = 0;
+    this.keyMorph = this.prevKey === this.level.key ? 0 : 1;
+    this.deck.retune(this.level.key, this.level.triplePct);
+    this.upcoming = [];
+    this.fillUpcoming();
+    this.qPool = [];
+
+    // burn off everything the new KEY can never use, so a level-up is relief
+    const stranded = strandedTiles(this.board, this.level.key, spawnPool(this.level.key));
+    const l = this.layout;
+    for (const t of stranded) {
+      const v = this.tiles.get(t.id);
+      if (!v) continue;
+      this.dying.push({
+        r: v.r,
+        c: v.c,
+        value: v.value,
+        tier: tierOf(v.value, this.prevKey),
+        t: -0.02 * v.c,
+        dur: 0.5,
+        kind: "purge",
+      });
+      this.report(v.face, false, this.now - v.spawnAt, "");
+      this.tiles.delete(t.id);
+      if (l) {
+        const p = cellCenter(l, v.r, v.c);
+        this.parts.burst(p.x, p.y, KEYC, 300, 12);
+      }
+    }
+    if (stranded.length > 0) {
+      removeIds(
+        this.board,
+        stranded.map((t) => t.id),
+      );
+      const moves = applyGravity(this.board);
+      for (const m of moves) {
+        const v = this.tiles.get(m.id);
+        if (v) {
+          v.r = m.to.r;
+          v.c = m.to.c;
+        }
+      }
+    }
+
+    this.audio.levelUp();
+    this.host.haptic("success");
+    this.cam.shake(0.6);
+    this.cam.punch(2.6);
+    this.cam.slowmo(0.45, 460);
+    this.cam.flash(KEYC, 0.2);
+    if (l) {
+      this.rings.add(l.keyX, l.keyY, l.keyR * 0.6, Math.max(l.w, l.h) * 0.7, 0.9, 5, KEYC);
+      this.pops.add(l.boardX + l.boardW / 2, l.boardY + l.boardH * 0.4, `${this.level.key}`, KEYC, l.cell * 1.3, 1.3);
+    }
+  }
+
+  /* ---------------- the cascade ---------------- */
+
+  private beginFuseStep(): void {
+    const plan = this.plan;
+    if (!plan || this.stepI >= plan.steps.length) {
+      this.finishResolution();
+      return;
+    }
+    const step = plan.steps[this.stepI] as Step;
+    const l = this.layout;
+    const chain = step.chain;
+
+    for (const g of step.fused) {
+      let sx = 0;
+      let sy = 0;
+      for (const p of g.cells) {
+        const t = this.board[idx(p.r, p.c)];
+        const value = t ? t.value : 0;
+        const tier = tierOf(value, this.level.key);
+        this.dying.push({ r: p.r, c: p.c, value, tier, t: 0, dur: FUSE_BEAT + 0.14, kind: "fuse" });
+        if (t) {
+          const v = this.tiles.get(t.id);
+          if (v) this.report(v.face, true, this.now - v.spawnAt, String(v.value));
+          this.tiles.delete(t.id);
+        }
+        if (l) {
+          const q = cellCenter(l, p.r, p.c);
+          sx += q.x;
+          sy += q.y;
+          const col = tierColor(tier);
+          this.parts.burst(q.x, q.y, col, 300 + chain * 90, 14 + chain * 3);
+          this.parts.shards(q.x, q.y, col, l.cell, 4);
+        }
+      }
+      if (l) {
+        sx /= g.cells.length;
+        sy /= g.cells.length;
+        const col = chain >= 3 ? HOT : KEYC;
+        this.rings.add(sx, sy, l.cell * 0.25, l.cell * (1.9 + chain * 0.5), 0.5, 3 + chain, col);
+        this.cores.push({
+          x0: sx,
+          y0: sy,
+          cx: (sx + l.keyX) / 2 + (this.fxRng.int(160) - 80),
+          cy: Math.min(sy, l.keyY) - l.cell * 1.6,
+          t: 0,
+          dur: 0.44 + this.fxRng.int(16) / 100,
+          value: g.sum,
+          color: col,
+          alive: true,
+        });
+        this.pops.add(sx, sy - l.cell * 0.3, `+${step.score}`, col, Math.max(15, l.cell * 0.42), 0.85);
+      }
+      removeIds(
+        this.board,
+        g.ids.filter((id) => id >= 0),
+      );
+    }
+
+    this.addScore(step.score);
+    this.fusesThisLevel += step.fused.length;
+    this.totalFuses += step.fused.length;
+    this.chainShown = chain;
+    this.chainShownT = 0;
+
+    const size = Math.max(...step.fused.map((g) => g.cells.length));
+    this.audio.fuse(chain, size);
+    this.cam.stop(34 + chain * 16);
+    this.cam.shake(0.16 + chain * 0.09);
+    this.cam.punch(1.2 + chain * 0.55);
+    this.host.haptic(chain >= 3 ? "heavy" : "medium");
+    if (chain >= 3) {
+      this.cam.slowmo(0.42, 200 + chain * 30);
+      this.cam.flash(HOT, 0.1 + chain * 0.02);
+      this.audio.chainPeak(chain);
+    }
+
+    this.phase = "fuse";
+    this.pt = 0;
+  }
+
+  private endFuseStep(): void {
+    const moves = applyGravity(this.board);
+    for (const m of moves) {
+      const v = this.tiles.get(m.id);
+      if (v) {
+        v.r = m.to.r;
+        v.c = m.to.c;
+      }
+    }
+    this.phase = "fall";
+    this.pt = 0;
+    this.fallT = 0;
+  }
+
+  private finishResolution(): void {
+    this.plan = null;
+    this.stepI = 0;
+    let breach = false;
+    for (let c = 0; c < COLS; c++) if (this.board[idx(0, c)] != null) breach = true;
+    let allFull = true;
+    for (let c = 0; c < COLS; c++) if (dropRow(this.board, c) >= 0) allFull = false;
+
+    if (breach || allFull) {
+      if (!this.rescueUsed) {
+        this.rescueUsed = true;
+        this.enterResonance(true);
+      } else {
+        this.enterBreach();
+      }
+      return;
+    }
+    if (this.fusesThisLevel >= this.level.quota) {
+      this.enterLevelUp();
+      return;
+    }
+    if (this.dropsSinceRise >= this.level.riseEvery) {
+      this.dropsSinceRise = 0;
+      this.rise();
+      return;
+    }
+    if (!this.held) this.spawnHeld();
+    else this.updatePreview();
+    this.phase = "aim";
+    this.pt = 0;
+  }
+
+  /**
+   * The well rises. This is the pressure: a good player who clears every pair
+   * still watches the floor climb, so the run always ends and the next one is
+   * always worth starting.
+   */
+  private pushRow(silent = false): boolean {
+    const probe = cloneBoard(this.board);
+    // Straight from the deck, not from `upcoming` — the incoming strip is a
+    // promise to the player and a rise must not quietly rewrite it.
+    const values: number[] = [];
+    for (let c = 0; c < COLS; c++) values.push(this.deck.deal());
+    const out = riseBoard(probe, values, () => this.nextTileId++);
+    if (out.breach) return false;
+    this.board = probe;
+    for (const m of out.moves) {
+      const v = this.tiles.get(m.id);
+      if (v) {
+        v.r = m.to.r;
+        v.c = m.to.c;
+        v.py = silent ? m.to.r : m.from.r;
+        v.q = silent ? 0 : 0.18;
+      }
+    }
+    for (let c = 0; c < COLS; c++) {
+      const t = out.born[c] as CoreTile;
+      this.tiles.set(t.id, {
+        id: t.id,
+        value: t.value,
+        face: this.faceFor(t.value),
+        r: ROWS - 1,
+        c,
+        px: c,
+        py: silent ? ROWS - 1 : ROWS - 0.45,
+        vy: 0,
+        q: silent ? 0 : 0.4,
+        qv: 0,
+        hot: 0,
+        spawnAt: this.now,
+        landedAt: this.now,
+      });
+    }
+    return true;
+  }
+
+  /** Clear any group the board is currently holding, unscored and unanimated. */
+  private resolveSilently(): void {
+    const b = cloneBoard(this.board);
+    const res = cascade(b, { key: this.level.key, nextId: () => this.nextTileId++ });
+    if (res.steps.length === 0) return;
+    for (const st of res.steps) for (const gp of st.fused) for (const id of gp.ids) this.tiles.delete(id);
+    this.board = b;
+    for (let r = 0; r < ROWS; r++) {
+      for (let c = 0; c < COLS; c++) {
+        const t = this.board[idx(r, c)];
+        if (!t) continue;
+        const v = this.tiles.get(t.id);
+        if (!v) continue;
+        v.r = r;
+        v.c = c;
+        v.px = c;
+        v.py = r;
+      }
+    }
+  }
+
+  /**
+   * Fill the well before the first chip falls.
+   *
+   * An empty well means the opening drop does nothing, which is the worst
+   * possible first three seconds. Rows are pushed until the board is genuinely
+   * full enough to fuse into, topping up whatever the seed's own cascade ate.
+   */
+  private seedWell(rows: number): void {
+    const target = rows * COLS - 4;
+    for (let i = 0; i < rows; i++) {
+      this.pushRow(true);
+      this.resolveSilently();
+    }
+    let guard = 0;
+    while (this.tiles.size < target && guard++ < 12) {
+      this.pushRow(true);
+      this.resolveSilently();
+    }
+  }
+
+  private rise(rows = this.level.riseRows): void {
+    for (let i = 0; i < rows; i++) {
+      if (!this.pushRow()) {
+        if (!this.rescueUsed) {
+          this.rescueUsed = true;
+          this.enterResonance(true);
+        } else {
+          this.enterBreach();
+        }
+        return;
+      }
+    }
+
+    const l = this.layout;
+    this.audio.resonanceEnter();
+    this.host.haptic("medium");
+    this.cam.shake(0.4);
+    this.cam.punch(1.4);
+    this.riseFlash = 1;
+    if (l) {
+      for (let c = 0; c < COLS; c++) {
+        const p = cellCenter(l, ROWS - 1, c);
+        this.parts.spray(p.x, p.y + l.cell * 0.4, DANGER, -Math.PI / 2, 1.1, 6, 300);
+      }
+      this.rings.add(
+        l.boardX + l.boardW / 2,
+        l.boardY + l.boardH,
+        l.cell * 0.5,
+        l.boardW * 0.9,
+        0.55,
+        4,
+        DANGER,
+      );
+    }
+
+    const after = cloneBoard(this.board);
+    const res = cascade(after, { key: this.level.key, nextId: () => this.nextTileId++ });
+    this.plan = { steps: res.steps };
+    this.stepI = 0;
+    if (res.steps.length > 0) this.beginFuseStep();
+    else {
+      this.phase = "fall";
+      this.pt = 0;
+      this.fallT = 0;
+    }
+  }
+
+  /* ---------------- the loop ---------------- */
+
+  update(dtReal: number, nowMs: number): void {
+    this.now = nowMs;
+    if (this.paused) return;
+    const dt = this.cam.update(dtReal);
+
+    this.parts.update(dt);
+    this.rings.update(dt);
+    this.pops.update(dt);
+    this.updateCores(dt);
+    this.updateDying(dt);
+    this.updateTilePhysics(dt);
+
+    this.shownScore += (this.score - this.shownScore) * Math.min(1, dtReal * 9);
+    if (Math.abs(this.score - this.shownScore) < 0.7) this.shownScore = this.score;
+    this.chainShownT += dtReal;
+    if (this.riseFlash > 0) this.riseFlash = Math.max(0, this.riseFlash - dtReal * 1.6);
+    this.danger += (fillRatio(this.board) - this.danger) * Math.min(1, dtReal * 5);
+    if (this.charge >= CHARGE_MAX) this.chargeReadyPulse += dtReal;
+    else this.chargeReadyPulse = 0;
+    if (this.keyMorph > 0) this.keyMorph = Math.max(0, this.keyMorph - dtReal * 1.6);
+
+    this.pt += dt;
+
+    switch (this.phase) {
+      case "boot": {
+        if (this.pt >= BOOT_TIME) {
+          if (!this.held) this.spawnHeld();
+          this.phase = "aim";
+          this.pt = 0;
+        }
+        break;
+      }
+      case "aim": {
+        this.aimT += dt;
+        const limit = this.level.fuseTime / 1000;
+        if (this.held) {
+          this.held.px += (this.heldCol - this.held.px) * Math.min(1, dt * 26);
+          if (this.aimT >= limit) this.drop();
+        }
+        // A charged reactor left alone goes critical by itself, so the big
+        // question always happens even for a player who never found the tap.
+        if (this.charge >= CHARGE_MAX && this.chargeReadyPulse > 7) this.enterResonance(false);
+        break;
+      }
+      case "drop": {
+        const t = this.held;
+        if (!t) {
+          this.phase = "aim";
+          break;
+        }
+        t.vy += DROP_G * dt;
+        t.py += t.vy * dt;
+        t.px += (this.heldCol - t.px) * Math.min(1, dt * 30);
+        if (t.py >= t.r) {
+          const hardness = clamp01((t.py - -1.35) / ROWS);
+          t.py = t.r;
+          t.px = t.c;
+          t.vy = 0;
+          t.q = 0.34 + hardness * 0.16;
+          t.qv = 0;
+          t.landedAt = this.now;
+          this.board[idx(t.r, t.c)] = { id: t.id, value: t.value };
+          this.tiles.set(t.id, t);
+          this.held = null;
+          this.impact(t, hardness);
+          this.stepI = 0;
+          if (this.plan && this.plan.steps.length > 0) this.beginFuseStep();
+          else this.finishResolution();
+        }
+        break;
+      }
+      case "fuse": {
+        if (this.pt >= FUSE_BEAT) this.endFuseStep();
+        break;
+      }
+      case "fall": {
+        this.fallT += dt;
+        let settled = true;
+        for (const [, v] of this.tiles) if (v.py < v.r - 0.001) settled = false;
+        if (settled || this.fallT > FALL_MAX) {
+          for (const [, v] of this.tiles) {
+            if (v.py < v.r) {
+              v.py = v.r;
+              v.vy = 0;
+            }
+          }
+          this.stepI++;
+          if (this.plan && this.stepI < this.plan.steps.length) this.beginFuseStep();
+          else this.finishResolution();
+        }
+        break;
+      }
+      case "levelup": {
+        if (!this.levelSeeded && this.pt >= LEVELUP_TIME * 0.55) {
+          this.levelSeeded = true;
+          for (let i = 0; i < 2; i++) this.pushRow();
+          this.cam.shake(0.3);
+          this.audio.land(0.8);
+        }
+        if (this.pt >= LEVELUP_TIME) {
+          if (!this.held) this.spawnHeld();
+          else this.updatePreview();
+          this.phase = "aim";
+          this.pt = 0;
+        }
+        break;
+      }
+      case "resonance": {
+        if (this.res.result === "none") {
+          this.res.t += dtReal;
+          if (this.res.t >= this.res.limit) {
+            if (this.res.fromHost && this.res.question) {
+              try {
+                this.host.report({
+                  questionId: this.res.question.id,
+                  correct: false,
+                  ms: Math.round(this.now - this.res.askedAt),
+                  answered: "",
+                });
+              } catch {
+                /* ignore */
+              }
+            }
+            this.resonanceMiss();
+          }
+        } else {
+          this.res.resultT += dtReal;
+          if (this.res.resultT >= (this.res.result === "hit" ? 0.85 : 0.7)) {
+            this.res.active = false;
+            if (this.res.result === "miss" && this.res.rescue) {
+              this.enterBreach();
+            } else {
+              this.phase = "fall";
+              this.pt = 0;
+              this.fallT = 0;
+              if (!this.held) {
+                this.plan = null;
+                this.stepI = 0;
+              }
+            }
+          }
+        }
+        break;
+      }
+      case "breach": {
+        if (this.pt < BREACH_TIME) {
+          // stagger the whole well going up, bottom rows last
+          const wave = this.pt / (BREACH_TIME * 0.55);
+          for (const [id, v] of [...this.tiles]) {
+            const k = 1 - v.r / ROWS;
+            if (k <= wave) {
+              this.tiles.delete(id);
+              this.board[idx(v.r, v.c)] = null;
+              this.dying.push({
+                r: v.r,
+                c: v.c,
+                value: v.value,
+                tier: tierOf(v.value, this.level.key),
+                t: 0,
+                dur: 0.5,
+                kind: "purge",
+              });
+              const l = this.layout;
+              if (l) {
+                const p = cellCenter(l, v.r, v.c);
+                this.parts.burst(p.x, p.y, DANGER, 380, 12);
+                this.parts.shards(p.x, p.y, tierColor(tierOf(v.value, this.level.key)), l.cell, 4);
+              }
+              this.cam.shake(0.1);
+            }
+          }
+        }
+        break;
+      }
+    }
+
+    if (this.layout && this.fxRng.chance(1, 5) && this.parts.count < 320) {
+      const l = this.layout;
+      this.parts.ember(
+        l.boardX + this.fxRng.int(Math.max(1, l.boardW)),
+        l.boardY + l.boardH,
+        [40, 90, 180],
+        1,
+      );
+    }
+  }
+
+  private impact(t: TileView, hardness: number): void {
+    const l = this.layout;
+    this.audio.land(hardness);
+    this.host.haptic("light");
+    this.cam.stop(28 + hardness * 22);
+    this.cam.shake(0.09 + hardness * 0.13);
+    this.cam.punch(0.7 + hardness * 0.5);
+    if (l) {
+      const p = cellCenter(l, t.r, t.c);
+      const col = tierColor(tierOf(t.value, this.level.key));
+      this.parts.spray(p.x - l.cell * 0.4, p.y + l.cell * 0.34, col, Math.PI, 0.9, 5, 240);
+      this.parts.spray(p.x + l.cell * 0.4, p.y + l.cell * 0.34, col, 0, 0.9, 5, 240);
+      this.rings.add(p.x, p.y + l.cell * 0.3, l.cell * 0.15, l.cell * 1.25, 0.34, 2.5, col);
+    }
+    // the stack below feels it
+    for (let rr = t.r + 1; rr < ROWS; rr++) {
+      const below = this.board[idx(rr, t.c)];
+      if (!below) break;
+      const v = this.tiles.get(below.id);
+      if (v) v.q = Math.max(v.q, 0.2 / (rr - t.r));
+    }
+  }
+
+  private updateTilePhysics(dt: number): void {
+    const springK = 380;
+    const springC = 23;
+    for (const [, v] of this.tiles) {
+      if (v.py < v.r) {
+        v.vy += FALL_G * dt;
+        v.py += v.vy * dt;
+        if (v.py >= v.r) {
+          v.py = v.r;
+          v.vy = 0;
+          v.q = Math.max(v.q, 0.22);
+          this.audio.land(0.25);
+        }
+      } else if (v.py > v.r) {
+        // pushed up by a rise: a fast lurch, not a fall
+        v.py += (v.r - v.py) * Math.min(1, dt * 17);
+        if (v.py - v.r < 0.02) v.py = v.r;
+      }
+      v.px += (v.c - v.px) * Math.min(1, dt * 24);
+      v.qv += (-springK * v.q - springC * v.qv) * dt;
+      v.q += v.qv * dt;
+      // Hard clamp: impulses arrive from several places at once (a slam, the
+      // stack ripple, a rise) and a chip drawn at 1.9x wide by 0.1x tall is a
+      // sliver, not a chip. The spring may ring, it may not invert geometry.
+      if (v.q > 0.55) v.q = 0.55;
+      else if (v.q < -0.45) v.q = -0.45;
+      if (Math.abs(v.q) < 0.002 && Math.abs(v.qv) < 0.02) {
+        v.q = 0;
+        v.qv = 0;
+      }
+      const wanted = this.previewCells.some((p) => p.r === v.r && p.c === v.c) ? 1 : 0;
+      v.hot += (wanted - v.hot) * Math.min(1, dt * 14);
+    }
+    const h = this.held;
+    if (h) {
+      h.qv += (-springK * h.q - springC * h.qv) * dt;
+      h.q += h.qv * dt;
+      if (h.q > 0.55) h.q = 0.55;
+      else if (h.q < -0.45) h.q = -0.45;
+    }
+  }
+
+  private updateDying(dt: number): void {
+    for (const d of this.dying) d.t += dt;
+    this.dying = this.dying.filter((d) => d.t < d.dur);
+  }
+
+  private updateCores(dt: number): void {
+    const l = this.layout;
+    for (const c of this.cores) {
+      if (!c.alive) continue;
+      c.t += dt;
+      if (c.t >= c.dur) {
+        c.alive = false;
+        this.charge = Math.min(CHARGE_MAX, this.charge + 1);
+        this.audio.core(Math.min(8, this.chainShown));
+        if (l) {
+          this.rings.add(l.keyX, l.keyY, l.keyR * 0.5, l.keyR * 2.1, 0.34, 2.5, c.color);
+          this.parts.burst(l.keyX, l.keyY, c.color, 200, 7);
+        }
+        this.cam.punch(0.35);
+        if (this.charge === CHARGE_MAX) {
+          this.audio.chargeReady();
+          this.cam.punch(1.1);
+          if (l) this.rings.add(l.keyX, l.keyY, l.keyR * 0.6, l.keyR * 4, 0.7, 3, CHARGE);
+        }
+      }
+    }
+    this.cores = this.cores.filter((c) => c.alive);
+  }
+
+  /** quadratic bezier position of a flying core */
+  corePos(c: FlyCore): { x: number; y: number; s: number } {
+    const l = this.layout;
+    const x1 = l ? l.keyX : c.x0;
+    const y1 = l ? l.keyY : c.y0;
+    const t = ease.inOutCubic(clamp01(c.t / c.dur));
+    const u = 1 - t;
+    return {
+      x: u * u * c.x0 + 2 * u * t * c.cx + t * t * x1,
+      y: u * u * c.y0 + 2 * u * t * c.cy + t * t * y1,
+      s: 1 - t * 0.45,
+    };
+  }
+
+  chargeRatio(): number {
+    return this.charge / CHARGE_MAX;
+  }
+
+  levelProgress(): number {
+    return clamp01(this.fusesThisLevel / this.level.quota);
+  }
+
+  aimRatio(): number {
+    return clamp01(this.aimT / (this.level.fuseTime / 1000));
+  }
+
+  peekUpcoming(n: number): number[] {
+    return this.upcoming.slice(0, n);
+  }
+}
+
+function readBest(): number {
+  try {
+    const v = Number(localStorage.getItem(BEST_KEY) ?? "0");
+    return Number.isFinite(v) && v > 0 ? Math.floor(v) : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function writeBest(v: number): void {
+  try {
+    localStorage.setItem(BEST_KEY, String(Math.floor(v)));
+  } catch {
+    /* private mode is not an error */
+  }
+}

--- a/dynawalla/games/merge/src/host/questions.test.ts
+++ b/dynawalla/games/merge/src/host/questions.test.ts
@@ -1,0 +1,116 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Rng, hashSeed } from "../core/rng.ts";
+import {
+  DIVIDE,
+  MINUS,
+  TIMES,
+  evaluatePrompt,
+  formsFor,
+  noCarryAdd,
+  questionFor,
+  smallerFromLarger,
+} from "./questions.ts";
+import { createStubHost } from "./stubHost.ts";
+
+test("every generated prompt evaluates exactly to its stated answer", () => {
+  for (let d = 0; d <= 10; d++) {
+    const rng = new Rng(hashSeed(`d${d}`));
+    for (let v = 1; v <= 99; v++) {
+      const q = questionFor(v, d / 10, rng, v);
+      assert.equal(String(evaluatePrompt(q.prompt)), q.answer, `${q.prompt} != ${q.answer}`);
+      assert.equal(q.answer, String(v));
+    }
+  }
+});
+
+test("no answer or distractor is ever a float", () => {
+  const rng = new Rng(1234);
+  for (let v = 1; v <= 120; v++) {
+    const q = questionFor(v, 0.9, rng, v);
+    assert.equal(Number.isInteger(Number(q.answer)), true, q.prompt);
+    for (const d of q.distractors) {
+      assert.equal(Number.isInteger(Number(d)), true, `${q.prompt} -> ${d}`);
+      assert.ok(Number(d) > 0);
+      assert.notEqual(d, q.answer);
+    }
+    assert.equal(new Set(q.distractors).size, q.distractors.length);
+  }
+});
+
+test("division prompts always divide exactly", () => {
+  const rng = new Rng(99);
+  let saw = 0;
+  for (let v = 2; v <= 60; v++) {
+    for (let i = 0; i < 8; i++) {
+      const q = questionFor(v, 0.7, rng, v);
+      if (!q.prompt.includes(DIVIDE)) continue;
+      saw++;
+      const [m, d] = q.prompt.split(` ${DIVIDE} `).map(Number) as [number, number];
+      assert.equal(m % d, 0, q.prompt);
+      assert.equal(m / d, v);
+    }
+  }
+  assert.ok(saw > 0, "expected some division prompts at difficulty 0.7");
+});
+
+test("generation is deterministic for a seed", () => {
+  const a = new Rng(hashSeed("same"));
+  const b = new Rng(hashSeed("same"));
+  for (let v = 1; v < 40; v++) {
+    assert.deepEqual(questionFor(v, 0.6, a, v), questionFor(v, 0.6, b, v));
+  }
+});
+
+test("difficulty unlocks forms monotonically", () => {
+  let prev = formsFor(0).length;
+  for (let d = 0; d <= 10; d++) {
+    const n = formsFor(d / 10).length;
+    assert.ok(n >= prev, `forms shrank at ${d / 10}`);
+    prev = n;
+  }
+  assert.deepEqual(formsFor(0), ["add"]);
+  assert.ok(formsFor(0.9).includes("muladd"));
+});
+
+test("prompts use the real minus sign and multiplication sign", () => {
+  const rng = new Rng(7);
+  for (let v = 2; v <= 40; v++) {
+    const q = questionFor(v, 0.5, rng, v);
+    assert.equal(q.prompt.includes("-"), false, `hyphen in ${q.prompt}`);
+    assert.equal(q.prompt.includes("*"), false);
+    assert.equal(q.prompt.includes("x"), false);
+  }
+  assert.equal(MINUS.charCodeAt(0), 0x2212);
+  assert.equal(TIMES.charCodeAt(0), 0x00d7);
+});
+
+test("mal-rules reproduce the real bugs", () => {
+  // 42 − 17: the smaller-from-larger bug gives 35, not 25
+  assert.equal(smallerFromLarger(42, 17), 35);
+  assert.equal(42 - 17, 25);
+  // 27 + 48: dropping the carry gives 65, not 75
+  assert.equal(noCarryAdd(27, 48), 65);
+});
+
+test("the stub host honours focus and reports a tally", () => {
+  const host = createStubHost("seed-a");
+  host.focus?.({ key: 20, wanted: [7, 13, 4] });
+  assert.equal(host.next().answer, "7");
+  assert.equal(host.next().answer, "13");
+  assert.equal(host.next().answer, "4");
+  const free = host.next();
+  assert.ok(Number(free.answer) >= 1 && Number(free.answer) < 20);
+
+  host.report({ questionId: free.id, correct: true, ms: 900, answered: free.answer });
+  host.report({ questionId: free.id, correct: false, ms: 100, answered: "0" });
+  assert.deepEqual(host.tally(), { asked: 4, correct: 1, totalMs: 1000 });
+});
+
+test("two stub hosts on the same seed produce identical streams", () => {
+  const a = createStubHost("twin");
+  const b = createStubHost("twin");
+  a.focus?.({ key: 24, wanted: [5, 19, 12] });
+  b.focus?.({ key: 24, wanted: [5, 19, 12] });
+  for (let i = 0; i < 20; i++) assert.deepEqual(a.next(), b.next());
+});

--- a/dynawalla/games/merge/src/host/questions.ts
+++ b/dynawalla/games/merge/src/host/questions.ts
@@ -1,0 +1,228 @@
+import { Rng } from "../core/rng.ts";
+import type { Question } from "../contract.ts";
+
+/**
+ * Exact, seeded question generation for FUSE.
+ *
+ * FUSE needs questions with a *chosen answer*: a tile is worth 7, so its face
+ * must be an expression that equals 7. Everything is integer arithmetic; no
+ * float is ever produced, compared or displayed.
+ *
+ * Prompts are purely symbolic — no words at all. That keeps a tile face legible
+ * at 40px, keeps the game free of translation, and matches the bar: a child
+ * should read "15 − 8" and act, with nothing explained.
+ */
+
+export const MINUS = "−"; // U+2212 MINUS SIGN, not a hyphen
+export const TIMES = "×";
+export const DIVIDE = "÷";
+
+export type Form = "add" | "sub" | "mul" | "add3" | "sub2" | "muladd" | "div";
+
+/** Forms unlocked at a difficulty in 0..1. */
+export function formsFor(difficulty: number): Form[] {
+  const f: Form[] = ["add"];
+  if (difficulty >= 0.15) f.push("sub");
+  if (difficulty >= 0.35) f.push("mul");
+  if (difficulty >= 0.45) f.push("add3");
+  if (difficulty >= 0.6) f.push("sub2", "div");
+  if (difficulty >= 0.75) f.push("muladd");
+  return f;
+}
+
+function factorPairs(v: number): [number, number][] {
+  const out: [number, number][] = [];
+  for (let p = 2; p * p <= v; p++) {
+    if (v % p === 0) out.push([p, v / p]);
+  }
+  return out;
+}
+
+function uniquePositive(answer: number, xs: number[]): string[] {
+  const seen = new Set<number>([answer]);
+  const out: string[] = [];
+  for (const x of xs) {
+    if (!Number.isInteger(x) || x <= 0 || seen.has(x)) continue;
+    seen.add(x);
+    out.push(String(x));
+    if (out.length === 3) break;
+  }
+  return out;
+}
+
+/** Digit-wise subtraction taking the smaller digit from the larger — the classic bug. */
+export function smallerFromLarger(m: number, s: number): number {
+  const ms = String(m).split("").reverse();
+  const ss = String(s).split("").reverse();
+  let out = "";
+  for (let i = 0; i < ms.length; i++) {
+    const a = Number(ms[i] ?? "0");
+    const b = Number(ss[i] ?? "0");
+    out = String(Math.abs(a - b)) + out;
+  }
+  return Number(out);
+}
+
+/** Column addition that drops every carry. */
+export function noCarryAdd(a: number, b: number): number {
+  const as = String(a).split("").reverse();
+  const bs = String(b).split("").reverse();
+  const n = Math.max(as.length, bs.length);
+  let out = "";
+  for (let i = 0; i < n; i++) {
+    const x = Number(as[i] ?? "0") + Number(bs[i] ?? "0");
+    out = String(x % 10) + out;
+  }
+  return Number(out);
+}
+
+type Built = { prompt: string; distractors: string[]; domain: string };
+
+function build(form: Form, value: number, rng: Rng): Built | null {
+  switch (form) {
+    case "add": {
+      if (value < 2) return null;
+      const a = rng.range(1, value - 1);
+      const b = value - a;
+      return {
+        prompt: `${a} + ${b}`,
+        distractors: uniquePositive(value, [
+          noCarryAdd(a, b),
+          value + 1,
+          value - 1,
+          Math.abs(a - b),
+          value + 10,
+        ]),
+        domain: "add-sub",
+      };
+    }
+    case "sub": {
+      const s = rng.range(1, Math.max(2, Math.min(19, value + 8)));
+      const m = value + s;
+      return {
+        prompt: `${m} ${MINUS} ${s}`,
+        distractors: uniquePositive(value, [
+          smallerFromLarger(m, s),
+          value + 1,
+          value - 1,
+          m + s,
+          value + 10,
+        ]),
+        domain: "add-sub",
+      };
+    }
+    case "mul": {
+      const pairs = factorPairs(value);
+      if (pairs.length === 0) return null;
+      const [p, q] = rng.pick(pairs);
+      return {
+        prompt: `${p} ${TIMES} ${q}`,
+        distractors: uniquePositive(value, [p + q, value + p, value - p, value + q]),
+        domain: "mul-div",
+      };
+    }
+    case "div": {
+      if (value < 2) return null;
+      const d = rng.range(2, 9);
+      const m = value * d;
+      return {
+        prompt: `${m} ${DIVIDE} ${d}`,
+        distractors: uniquePositive(value, [m - d, value + d, value * 2, value + 1]),
+        domain: "mul-div",
+      };
+    }
+    case "add3": {
+      if (value < 3) return null;
+      const a = rng.range(1, value - 2);
+      const b = rng.range(1, value - a - 1);
+      const c = value - a - b;
+      return {
+        prompt: `${a} + ${b} + ${c}`,
+        distractors: uniquePositive(value, [a + b, value + 1, value - 1, a + b + c + c]),
+        domain: "add-sub",
+      };
+    }
+    case "sub2": {
+      const s = rng.range(1, 9);
+      const t = rng.range(1, 9);
+      const m = value + s + t;
+      return {
+        prompt: `${m} ${MINUS} ${s} ${MINUS} ${t}`,
+        distractors: uniquePositive(value, [m - s + t, value + s, value + t, value + 1]),
+        domain: "add-sub",
+      };
+    }
+    case "muladd": {
+      const pairs = factorPairs(value - 1).concat(factorPairs(value - 2));
+      const r = pairs.length > 0 && rng.chance(1, 2) ? 1 : 2;
+      const base = value - r;
+      const fp = factorPairs(base);
+      if (fp.length === 0) return null;
+      const [p, q] = rng.pick(fp);
+      return {
+        prompt: `${p} ${TIMES} ${q} + ${r}`,
+        distractors: uniquePositive(value, [p * (q + r), base, value + p, p + q + r]),
+        domain: "mul-div",
+      };
+    }
+  }
+}
+
+/**
+ * A question whose exact answer is `value`.
+ *
+ * Deterministic for a given rng state. Falls back down the form list until one
+ * fits, so it never returns null for value >= 1.
+ */
+export function questionFor(value: number, difficulty: number, rng: Rng, seq: number): Question {
+  const allowed = formsFor(difficulty);
+  const order = rng.shuffle(allowed.slice());
+  for (const form of order) {
+    const built = build(form, value, rng);
+    if (!built) continue;
+    if (built.distractors.length < 2) continue;
+    return {
+      id: `fuse-${seq}-${value}`,
+      prompt: built.prompt,
+      answer: String(value),
+      distractors: built.distractors,
+      domain: built.domain,
+      difficulty,
+    };
+  }
+  // value 1 with only "add" available: 1 has no split. Emit an exact identity.
+  return {
+    id: `fuse-${seq}-${value}`,
+    prompt: `${value + 4} ${MINUS} 4`,
+    answer: String(value),
+    distractors: uniquePositive(value, [value + 4, value + 1, value + 8, value + 2]),
+    domain: "add-sub",
+    difficulty,
+  };
+}
+
+/** Evaluate a generated prompt exactly, for tests. Integer arithmetic only. */
+export function evaluatePrompt(prompt: string): number {
+  const tokens = prompt.split(" ");
+  // handle × and ÷ first, left to right
+  const mul: (string | number)[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i] as string;
+    if (t === TIMES || t === DIVIDE) {
+      const left = mul.pop() as number;
+      const right = Number(tokens[++i]);
+      mul.push(t === TIMES ? left * right : Math.trunc(left / right));
+    } else if (t === "+" || t === MINUS) {
+      mul.push(t);
+    } else {
+      mul.push(Number(t));
+    }
+  }
+  let acc = mul[0] as number;
+  for (let i = 1; i < mul.length; i += 2) {
+    const op = mul[i] as string;
+    const v = mul[i + 1] as number;
+    acc = op === "+" ? acc + v : acc - v;
+  }
+  return acc;
+}

--- a/dynawalla/games/merge/src/host/stubHost.ts
+++ b/dynawalla/games/merge/src/host/stubHost.ts
@@ -1,0 +1,80 @@
+import type { FocusableHost, Question } from "../contract.ts";
+import { Rng, hashSeed } from "../core/rng.ts";
+import { questionFor } from "./questions.ts";
+
+/**
+ * The local stub Host.
+ *
+ * It exists so FUSE is fully playable with `npm run dev` before the real
+ * Dynawalla host lands. It generates exactly the same shape the real one will,
+ * from a seed, so a run is reproducible.
+ *
+ * It also implements the optional `focus` extension: FUSE tells it which tile
+ * values are coming, and it produces expressions for those values. A host
+ * without `focus` still works — the game simply shows fewer expression tiles.
+ */
+export type StubTally = {
+  asked: number;
+  correct: number;
+  totalMs: number;
+};
+
+export function createStubHost(seedText = "fuse"): FocusableHost & {
+  tally(): StubTally;
+  log: { questionId: string; correct: boolean; ms: number; answered: string }[];
+} {
+  const rng = new Rng(hashSeed(seedText));
+  let seq = 0;
+  let difficulty = 0.2;
+  let wanted: number[] = [];
+  let key = 10;
+  const log: { questionId: string; correct: boolean; ms: number; answered: string }[] = [];
+  const tally: StubTally = { asked: 0, correct: 0, totalMs: 0 };
+
+  const canVibrate =
+    typeof navigator !== "undefined" && typeof navigator.vibrate === "function";
+
+  const patterns: Record<string, number | number[]> = {
+    light: 8,
+    medium: 18,
+    heavy: [26, 20, 34],
+    success: [12, 40, 12],
+    failure: [40, 30, 60],
+  };
+
+  return {
+    next(): Question {
+      seq++;
+      tally.asked++;
+      const value = wanted.length > 0 ? (wanted.shift() as number) : rng.range(1, key - 1);
+      return questionFor(Math.max(1, value), difficulty, rng, seq);
+    },
+    report(r) {
+      log.push(r);
+      if (r.correct) tally.correct++;
+      tally.totalMs += r.ms;
+    },
+    haptic(kind) {
+      if (!canVibrate) return;
+      try {
+        navigator.vibrate(patterns[kind] ?? 10);
+      } catch {
+        /* a browser that refuses to buzz is not an error */
+      }
+    },
+    prefersReducedMotion() {
+      if (typeof matchMedia !== "function") return false;
+      return matchMedia("(prefers-reduced-motion: reduce)").matches;
+    },
+    focus(spec) {
+      key = spec.key;
+      wanted = spec.wanted.slice(0, 24);
+      // difficulty tracks the key ladder: complements of 10 are easy, of 100 are not
+      difficulty = Math.max(0.1, Math.min(0.95, (spec.key - 6) / 100 + 0.15));
+    },
+    tally() {
+      return { ...tally };
+    },
+    log,
+  };
+}

--- a/dynawalla/games/merge/src/index.ts
+++ b/dynawalla/games/merge/src/index.ts
@@ -1,0 +1,3 @@
+export { mount } from "./mount.ts";
+export type { Host, Question } from "./contract.ts";
+export { createStubHost } from "./host/stubHost.ts";

--- a/dynawalla/games/merge/src/input.ts
+++ b/dynawalla/games/merge/src/input.ts
@@ -1,0 +1,211 @@
+import { COLS, ROWS, idx } from "./core/rules.ts";
+import type { Game } from "./game.ts";
+import { colAt, type Layout } from "./layout.ts";
+
+/**
+ * Two input designs, not one ported to the other.
+ *
+ * Touch: press anywhere and the chip follows your thumb across columns with a
+ * live landing ghost; lift to slam. Your thumb never covers the chip because
+ * the chip is at the top and your hand is at the bottom.
+ *
+ * Desktop: the chip tracks the mouse with no button held, click to slam, and
+ * the whole game is playable from the keyboard — arrows or 1-6 to pick a
+ * column, space to drop, so a fast player never touches the mouse.
+ */
+
+export type InputBinding = { dispose(): void };
+
+function hit(x: number, y: number, cx: number, cy: number, r: number): boolean {
+  const dx = x - cx;
+  const dy = y - cy;
+  return dx * dx + dy * dy <= r * r;
+}
+
+export function bindInput(
+  canvas: HTMLCanvasElement,
+  game: Game,
+  getLayout: () => Layout | null,
+): InputBinding {
+  let aiming = false;
+  let pointerId = -1;
+
+  const local = (e: PointerEvent): { x: number; y: number } => {
+    const b = canvas.getBoundingClientRect();
+    return { x: e.clientX - b.left, y: e.clientY - b.top };
+  };
+
+  const boardCell = (l: Layout, x: number, y: number): { r: number; c: number } | null => {
+    const c = Math.floor((x - l.boardX) / l.cell);
+    const r = Math.floor((y - l.boardY) / l.cell);
+    if (c < 0 || c >= COLS || r < 0 || r >= ROWS) return null;
+    return { r, c };
+  };
+
+  const onDown = (e: PointerEvent) => {
+    const l = getLayout();
+    if (!l) return;
+    const { x, y } = local(e);
+    game.audio.resume();
+
+    if (hit(x, y, l.soundX, l.soundY, l.soundR + 10)) {
+      game.toggleSound();
+      return;
+    }
+
+    if (game.phase === "breach") {
+      if (game.pt > 0.55) game.reset();
+      return;
+    }
+
+    if (game.phase === "resonance") {
+      const cell = boardCell(l, x, y);
+      if (cell) game.pickCell(cell.r, cell.c);
+      return;
+    }
+
+    if (hit(x, y, l.keyX, l.keyY, l.keyR * 1.5)) {
+      game.pokeReactor();
+      return;
+    }
+
+    if (game.phase === "aim") {
+      aiming = true;
+      pointerId = e.pointerId;
+      // Capture keeps the drag alive when the finger leaves the canvas. It
+      // throws on a pointer the browser no longer considers active, and losing
+      // the drop to that would be unforgivable.
+      try {
+        canvas.setPointerCapture?.(e.pointerId);
+      } catch {
+        /* capture is an optimisation, not a requirement */
+      }
+      game.moveTo(colAt(l, x));
+    }
+  };
+
+  const onMove = (e: PointerEvent) => {
+    const l = getLayout();
+    if (!l || game.phase !== "aim") return;
+    const { x, y } = local(e);
+    if (aiming && e.pointerId === pointerId) {
+      game.moveTo(colAt(l, x));
+      return;
+    }
+    // hover-aim, mouse only: a finger resting on the glass must not move the chip
+    if (e.pointerType === "mouse" && y > l.boardY - l.cell * 2) game.moveTo(colAt(l, x));
+  };
+
+  const onUp = (e: PointerEvent) => {
+    if (!aiming || e.pointerId !== pointerId) return;
+    aiming = false;
+    pointerId = -1;
+    try {
+      canvas.releasePointerCapture?.(e.pointerId);
+    } catch {
+      /* already released */
+    }
+    if (game.phase === "aim") game.drop();
+  };
+
+  const onCancel = () => {
+    aiming = false;
+    pointerId = -1;
+  };
+
+  const onKey = (e: KeyboardEvent) => {
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    const k = e.key;
+    game.audio.resume();
+
+    if (game.phase === "breach") {
+      if (k === " " || k === "Enter" || k === "r" || k === "R") {
+        e.preventDefault();
+        if (game.pt > 0.55) game.reset();
+      }
+      return;
+    }
+
+    if (game.phase === "resonance") {
+      if (k >= "1" && k <= "6") {
+        e.preventDefault();
+        pickColumnTop(game, Number(k) - 1);
+      }
+      return;
+    }
+
+    switch (k) {
+      case "ArrowLeft":
+      case "a":
+      case "A":
+        e.preventDefault();
+        game.nudge(-1);
+        break;
+      case "ArrowRight":
+      case "d":
+      case "D":
+        e.preventDefault();
+        game.nudge(1);
+        break;
+      case " ":
+      case "Enter":
+      case "ArrowDown":
+      case "s":
+      case "S":
+        e.preventDefault();
+        game.drop();
+        break;
+      case "e":
+      case "E":
+      case "Shift":
+        e.preventDefault();
+        game.pokeReactor();
+        break;
+      case "m":
+      case "M":
+        game.toggleSound();
+        break;
+      case "r":
+      case "R":
+        game.reset();
+        break;
+      default:
+        if (k >= "1" && k <= "6") {
+          e.preventDefault();
+          game.moveTo(Number(k) - 1);
+          game.drop();
+        }
+    }
+  };
+
+  canvas.addEventListener("pointerdown", onDown);
+  canvas.addEventListener("pointermove", onMove);
+  window.addEventListener("pointerup", onUp);
+  window.addEventListener("pointercancel", onCancel);
+  window.addEventListener("keydown", onKey);
+  const stopScroll = (e: Event) => e.preventDefault();
+  canvas.addEventListener("touchstart", stopScroll, { passive: false });
+  canvas.addEventListener("touchmove", stopScroll, { passive: false });
+
+  return {
+    dispose() {
+      canvas.removeEventListener("pointerdown", onDown);
+      canvas.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onCancel);
+      window.removeEventListener("keydown", onKey);
+      canvas.removeEventListener("touchstart", stopScroll);
+      canvas.removeEventListener("touchmove", stopScroll);
+    },
+  };
+}
+
+/** keyboard route into resonance: pick the topmost chip in a column */
+export function pickColumnTop(game: Game, c: number): void {
+  for (let r = 0; r < ROWS; r++) {
+    if (game.board[idx(r, c)]) {
+      game.pickCell(r, c);
+      return;
+    }
+  }
+}

--- a/dynawalla/games/merge/src/layout.test.ts
+++ b/dynawalla/games/merge/src/layout.test.ts
@@ -1,0 +1,131 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { COLS, ROWS } from "./core/rules.ts";
+import { cellCenter, colAt, computeLayout } from "./layout.ts";
+
+/** every viewport the game is expected to survive */
+const SIZES: [string, number, number][] = [
+  ["iPhone SE portrait", 320, 568],
+  ["iPhone 13 portrait", 390, 844],
+  ["iPhone 13 landscape", 844, 390],
+  ["Pixel 7 portrait", 412, 915],
+  ["iPad mini portrait", 744, 1133],
+  ["iPad Pro landscape", 1366, 1024],
+  ["small desktop", 1024, 640],
+  ["wide desktop", 1920, 1080],
+  ["absurdly narrow", 280, 760],
+  ["absurdly short", 900, 320],
+];
+
+test("the well always fits inside the viewport", () => {
+  for (const [name, w, h] of SIZES) {
+    const l = computeLayout(w, h, 2);
+    assert.ok(l.wellX >= 0, `${name}: well hangs off the left (${l.wellX})`);
+    assert.ok(l.wellX + l.wellW <= w, `${name}: well hangs off the right`);
+    assert.ok(l.wellY >= 0, `${name}: well hangs off the top (${l.wellY})`);
+    assert.ok(l.wellY + l.wellH <= h, `${name}: well hangs off the bottom`);
+  }
+});
+
+test("there is always headroom above the well for the held chip", () => {
+  for (const [name, w, h] of SIZES) {
+    const l = computeLayout(w, h, 2);
+    assert.ok(l.headY > 0, `${name}: the held chip is off screen`);
+    assert.ok(l.headY < l.boardY, `${name}: the held chip is inside the well`);
+    assert.ok(
+      l.boardY - l.headY > l.cell * 0.4,
+      `${name}: the held chip overlaps the well rim`,
+    );
+  }
+});
+
+test("the sound toggle never sits on the well", () => {
+  for (const [name, w, h] of SIZES) {
+    const l = computeLayout(w, h, 2);
+    const r = l.soundR + 6;
+    const overlaps =
+      l.soundX + r > l.wellX &&
+      l.soundX - r < l.wellX + l.wellW &&
+      l.soundY + r > l.wellY &&
+      l.soundY - r < l.wellY + l.wellH;
+    assert.equal(overlaps, false, `${name}: the sound toggle covers the well`);
+    assert.ok(l.soundX > 0 && l.soundX < w, `${name}: sound toggle off screen`);
+    assert.ok(l.soundY > 0 && l.soundY < h, `${name}: sound toggle off screen`);
+  }
+});
+
+test("the reactor orb never sits on the well", () => {
+  for (const [name, w, h] of SIZES) {
+    const l = computeLayout(w, h, 2);
+    const r = l.keyR * 1.35;
+    const overlaps =
+      l.keyX + r > l.wellX &&
+      l.keyX - r < l.wellX + l.wellW &&
+      l.keyY + r > l.wellY &&
+      l.keyY - r < l.wellY + l.wellH;
+    assert.equal(overlaps, false, `${name}: the reactor covers the well`);
+  }
+});
+
+test("the incoming strip stays on screen", () => {
+  for (const [name, w, h] of SIZES) {
+    const l = computeLayout(w, h, 2);
+    for (let i = 0; i < 3; i++) {
+      const x = l.incomingVertical ? l.incomingX : l.incomingX + i * l.incomingStep;
+      const y = l.incomingVertical ? l.incomingY + i * l.incomingStep : l.incomingY;
+      assert.ok(x - l.chipSize / 2 >= 0 && x + l.chipSize / 2 <= w, `${name}: incoming ${i} off x`);
+      assert.ok(y - l.chipSize / 2 >= 0 && y + l.chipSize / 2 <= h, `${name}: incoming ${i} off y`);
+    }
+  }
+});
+
+test("cells tile the board exactly, with no gap and no overlap", () => {
+  const l = computeLayout(900, 1200, 2);
+  const first = cellCenter(l, 0, 0);
+  const last = cellCenter(l, ROWS - 1, COLS - 1);
+  assert.equal(Math.round(first.x - l.cell / 2), l.boardX);
+  assert.equal(Math.round(first.y - l.cell / 2), l.boardY);
+  assert.equal(Math.round(last.x + l.cell / 2), l.boardX + l.boardW);
+  assert.equal(Math.round(last.y + l.cell / 2), l.boardY + l.boardH);
+});
+
+test("colAt inverts cellCenter and clamps outside the board", () => {
+  for (const [, w, h] of SIZES) {
+    const l = computeLayout(w, h, 2);
+    for (let c = 0; c < COLS; c++) {
+      assert.equal(colAt(l, cellCenter(l, 0, c).x), c);
+    }
+    assert.equal(colAt(l, -9999), 0);
+    assert.equal(colAt(l, 9999), COLS - 1);
+  }
+});
+
+test("orientation picks a different design, not a stretched one", () => {
+  assert.equal(computeLayout(390, 844, 2).landscape, false);
+  assert.equal(computeLayout(844, 390, 2).landscape, true);
+  // portrait puts the score on the left of a top band; landscape centres it in a rail
+  assert.equal(computeLayout(390, 844, 2).scoreAlign, "left");
+  assert.equal(computeLayout(844, 390, 2).scoreAlign, "center");
+});
+
+test("cells stay aimable on every real phone and tablet", () => {
+  // 28px is deliberately under the 44px tap guideline: aiming here is a drag
+  // with a live landing ghost, not a discrete tap, so the target is "sweep
+  // until the ghost is where you want it" and column width sets precision, not
+  // success. A landscape phone (11 rows into 390px) is the tightest case there
+  // is; portrait, which is how a well-shaped board is actually held, is roomy.
+  for (const [name, w, h] of SIZES) {
+    if (Math.min(w, h) < 360) continue;
+    const l = computeLayout(w, h, 2);
+    assert.ok(l.cell >= 28, `${name}: ${l.cell}px cells are too small to aim`);
+  }
+  assert.ok(computeLayout(390, 844, 2).cell >= 50, "portrait phone should be roomy");
+  assert.ok(computeLayout(744, 1133, 2).cell >= 70, "tablet should be generous");
+});
+
+test("a squashed window still lays out legally, just smaller", () => {
+  const l = computeLayout(900, 320, 2);
+  assert.ok(l.cell >= 18);
+  assert.ok(l.wellY >= 0 && l.wellY + l.wellH <= 320);
+  assert.ok(l.headY > 0 && l.headY < l.boardY);
+});

--- a/dynawalla/games/merge/src/layout.ts
+++ b/dynawalla/games/merge/src/layout.ts
@@ -1,0 +1,172 @@
+import { COLS, ROWS } from "./core/rules.ts";
+
+/**
+ * Geometry, recomputed on every resize.
+ *
+ * Portrait and landscape are two designs, not one stretched: portrait puts the
+ * instrument band above the well, landscape puts it in rails either side, and
+ * in both the well is as large as it can possibly be. The well never scrolls
+ * and never clips.
+ */
+
+export type Layout = {
+  w: number;
+  h: number;
+  dpr: number;
+  landscape: boolean;
+  pad: number;
+  cell: number;
+  /** top-left of grid cell (0,0) */
+  boardX: number;
+  boardY: number;
+  boardW: number;
+  boardH: number;
+  /** the rim box drawn around the grid */
+  wellX: number;
+  wellY: number;
+  wellW: number;
+  wellH: number;
+  /** centre y of the held chip, above the well */
+  headY: number;
+  /** instrument anchors */
+  scoreX: number;
+  scoreY: number;
+  scoreAlign: "left" | "center";
+  keyX: number;
+  keyY: number;
+  keyR: number;
+  levelX: number;
+  levelY: number;
+  incomingX: number;
+  incomingY: number;
+  incomingStep: number;
+  incomingVertical: boolean;
+  chipSize: number;
+  soundX: number;
+  soundY: number;
+  soundR: number;
+};
+
+export const HEADROOM = 1.85;
+/** A squashed landscape window has no height to spare; give it back to the well. */
+export const HEADROOM_SHORT = 1.3;
+
+export function computeLayout(w: number, h: number, dpr: number): Layout {
+  const landscape = w / h > 1.15;
+  const pad = Math.max(10, Math.round(Math.min(w, h) * 0.028));
+  const headroom = h < 440 ? HEADROOM_SHORT : HEADROOM;
+
+  let cell: number;
+  let bandH = 0;
+  let rail = 0;
+
+  if (landscape) {
+    rail = Math.max(140, Math.min(280, w * 0.21));
+    const availW = w - rail * 2 - pad * 2;
+    const availH = h - pad * 2;
+    cell = Math.floor(Math.min(availW / COLS, availH / (ROWS + headroom)));
+  } else {
+    bandH = Math.max(96, Math.min(168, h * 0.17));
+    const availW = w - pad * 2;
+    const availH = h - bandH - pad * 2;
+    cell = Math.floor(Math.min(availW / COLS, availH / (ROWS + headroom)));
+  }
+  cell = Math.max(18, cell);
+
+  const boardW = cell * COLS;
+  const boardH = cell * ROWS;
+  const blockH = boardH + cell * headroom;
+
+  const boardX = Math.round((w - boardW) / 2);
+  const boardY = landscape
+    ? Math.round((h - blockH) / 2 + cell * headroom)
+    : Math.round(bandH + (h - bandH - blockH) / 2 + cell * headroom);
+
+  const rim = Math.max(6, Math.round(cell * 0.16));
+  const chipSize = Math.max(16, Math.round(cell * 0.52));
+
+  const keyR = landscape
+    ? Math.max(34, Math.min(64, rail * 0.3))
+    : Math.max(30, Math.min(56, bandH * 0.36));
+
+  const base: Layout = {
+    w,
+    h,
+    dpr,
+    landscape,
+    pad,
+    cell,
+    boardX,
+    boardY,
+    boardW,
+    boardH,
+    wellX: boardX - rim,
+    wellY: boardY - rim,
+    wellW: boardW + rim * 2,
+    wellH: boardH + rim * 2,
+    headY: boardY - cell * (headroom * 0.58),
+    scoreX: 0,
+    scoreY: 0,
+    scoreAlign: "left",
+    keyX: 0,
+    keyY: 0,
+    keyR,
+    levelX: 0,
+    levelY: 0,
+    incomingX: 0,
+    incomingY: 0,
+    incomingStep: chipSize * 1.22,
+    incomingVertical: landscape,
+    chipSize,
+    soundX: w - pad - 18,
+    soundY: pad + 18,
+    soundR: 16,
+  };
+
+  if (landscape) {
+    const lx = pad + rail * 0.5;
+    const rx = w - pad - rail * 0.5;
+    base.scoreX = lx;
+    base.scoreY = h * 0.34;
+    base.scoreAlign = "center";
+    base.levelX = lx;
+    base.levelY = h * 0.5;
+    base.keyX = rx;
+    base.keyY = h * 0.36;
+    base.incomingX = rx;
+    base.incomingY = h * 0.56;
+    base.soundX = pad + 22;
+    base.soundY = h - pad - 22;
+  } else {
+    const top = pad + (bandH - pad) * 0.5;
+    base.scoreX = pad + 4;
+    base.scoreY = top;
+    base.scoreAlign = "left";
+    base.keyX = w / 2;
+    base.keyY = top;
+    base.levelX = w - pad - 4;
+    base.levelY = top - keyR * 0.5;
+    // The next chip is leftmost and the queue fades to the right, so it reads
+    // in the direction the eye already travels.
+    base.incomingStep = chipSize * 1.22;
+    base.incomingX = w - pad - chipSize / 2 - base.incomingStep * 2;
+    base.incomingY = top + keyR * 0.52;
+    // Portrait has no room beside the well, so the toggle lives in the band's
+    // top-left corner where nothing else is drawn.
+    base.soundX = pad + 16;
+    base.soundY = pad + 16;
+  }
+
+  return base;
+}
+
+/** grid cell -> screen centre */
+export function cellCenter(l: Layout, r: number, c: number): { x: number; y: number } {
+  return { x: l.boardX + (c + 0.5) * l.cell, y: l.boardY + (r + 0.5) * l.cell };
+}
+
+/** screen x -> column, clamped */
+export function colAt(l: Layout, x: number): number {
+  const c = Math.floor((x - l.boardX) / l.cell);
+  return Math.max(0, Math.min(COLS - 1, c));
+}

--- a/dynawalla/games/merge/src/main.ts
+++ b/dynawalla/games/merge/src/main.ts
@@ -1,0 +1,28 @@
+import { mount } from "./mount.ts";
+import { createStubHost } from "./host/stubHost.ts";
+
+/**
+ * Standalone entry. `npm run dev` gives a fully playable FUSE against the local
+ * stub host; the real Dynawalla host drops in by replacing these two lines.
+ *
+ *   ?seed=<text>  reproducible run
+ *   ?debug=1      fps / particle / phase readout
+ */
+const params = new URLSearchParams(location.search);
+const seed = params.get("seed") ?? undefined;
+const host = createStubHost(seed ?? "fuse");
+const root = document.getElementById("root") as HTMLElement;
+
+const probe: Record<string, unknown> = { host };
+const instance = mount(root, host, {
+  seed,
+  debug: params.has("debug"),
+  onReady: (p) => {
+    probe.game = p.game;
+    probe.step = p.step;
+  },
+});
+probe.instance = instance;
+
+// expose for the playtest harness
+Object.assign(window as unknown as Record<string, unknown>, { __fuse: probe });

--- a/dynawalla/games/merge/src/mount.ts
+++ b/dynawalla/games/merge/src/mount.ts
@@ -1,0 +1,130 @@
+import type { Host, FocusableHost } from "./contract.ts";
+import { Game } from "./game.ts";
+import { Renderer } from "./render.ts";
+import { bindInput } from "./input.ts";
+import { computeLayout, type Layout } from "./layout.ts";
+
+export type MountOptions = {
+  seed?: string;
+  debug?: boolean;
+  /**
+   * Playtest hook. Hands back the live game plus a manual stepper so a harness
+   * can drive exact moments — a nine-chain, a breach, a resonance — instead of
+   * hoping to stumble into them. Never used by the real host.
+   */
+  onReady?(probe: { game: Game; step(dtMs: number, frames?: number): void }): void;
+};
+
+/**
+ * Mount FUSE into an element.
+ *
+ * One canvas, one RAF loop, no DOM churn per frame. The frame budget is
+ * measured continuously and the particle budget follows it, so a slower tablet
+ * loses sparks rather than frames.
+ */
+export function mount(el: HTMLElement, host: Host, opts: MountOptions = {}): { unmount(): void } {
+  const canvas = document.createElement("canvas");
+  canvas.style.cssText = "position:absolute;inset:0;width:100%;height:100%;display:block;touch-action:none";
+  canvas.setAttribute("role", "img");
+  canvas.setAttribute(
+    "aria-label",
+    "FUSE. Drop numbered chips into the well. Touching chips that add up to the key number fuse.",
+  );
+  el.style.position = el.style.position || "relative";
+  el.appendChild(canvas);
+
+  const g = canvas.getContext("2d", { alpha: false }) as CanvasRenderingContext2D;
+  const game = new Game(host as FocusableHost, opts.seed);
+  const renderer = new Renderer();
+  renderer.debug = !!opts.debug;
+
+  let layout: Layout | null = null;
+  let raf = 0;
+  let last = performance.now();
+  let acc = 0;
+  const frameTimes: number[] = [];
+
+  const resize = () => {
+    const w = Math.max(1, el.clientWidth || window.innerWidth);
+    const h = Math.max(1, el.clientHeight || window.innerHeight);
+    const dpr = Math.min(2, window.devicePixelRatio || 1);
+    canvas.width = Math.round(w * dpr);
+    canvas.height = Math.round(h * dpr);
+    canvas.style.width = `${w}px`;
+    canvas.style.height = `${h}px`;
+    layout = computeLayout(w, h, dpr);
+    game.layout = layout;
+    renderer.resize(layout);
+  };
+  resize();
+
+  const ro = typeof ResizeObserver === "function" ? new ResizeObserver(resize) : null;
+  ro?.observe(el);
+  window.addEventListener("resize", resize);
+  window.addEventListener("orientationchange", resize);
+
+  const onVis = () => {
+    game.paused = document.hidden;
+    if (!document.hidden) last = performance.now();
+  };
+  document.addEventListener("visibilitychange", onVis);
+
+  const motionQuery =
+    typeof matchMedia === "function" ? matchMedia("(prefers-reduced-motion: reduce)") : null;
+  const onMotion = () => {
+    game.cam.reduced = host.prefersReducedMotion();
+  };
+  motionQuery?.addEventListener?.("change", onMotion);
+
+  const input = bindInput(canvas, game, () => layout);
+
+  const loop = (now: number) => {
+    raf = requestAnimationFrame(loop);
+    let dt = (now - last) / 1000;
+    last = now;
+    if (dt > 0.1) dt = 0.1; // a backgrounded tab must not teleport the well
+
+    frameTimes.push(dt);
+    if (frameTimes.length > 45) frameTimes.shift();
+    acc += dt;
+    if (acc > 0.35 && frameTimes.length > 10) {
+      acc = 0;
+      const mean = frameTimes.reduce((a, b) => a + b, 0) / frameTimes.length;
+      game.fps = 1 / Math.max(0.0005, mean);
+      // Spend the budget on sparks only while there is budget to spend.
+      game.parts.budget = game.fps < 42 ? 0.35 : game.fps < 52 ? 0.65 : 1;
+      if (game.cam.reduced) game.parts.budget = Math.min(game.parts.budget, 0.25);
+    }
+
+    game.update(dt, now);
+    if (layout) renderer.draw(g, game, layout, now / 1000);
+  };
+  raf = requestAnimationFrame(loop);
+
+  opts.onReady?.({
+    game,
+    step(dtMs: number, frames = 1) {
+      const wasPaused = game.paused;
+      game.paused = false;
+      for (let i = 0; i < frames; i++) {
+        const t = performance.now();
+        game.update(dtMs / 1000, t);
+        if (layout) renderer.draw(g, game, layout, t / 1000);
+      }
+      game.paused = wasPaused;
+    },
+  });
+
+  return {
+    unmount() {
+      cancelAnimationFrame(raf);
+      input.dispose();
+      ro?.disconnect();
+      window.removeEventListener("resize", resize);
+      window.removeEventListener("orientationchange", resize);
+      document.removeEventListener("visibilitychange", onVis);
+      motionQuery?.removeEventListener?.("change", onMotion);
+      canvas.remove();
+    },
+  };
+}

--- a/dynawalla/games/merge/src/render.ts
+++ b/dynawalla/games/merge/src/render.ts
@@ -1,0 +1,999 @@
+import { COLS, ROWS, idx } from "./core/rules.ts";
+import { tierOf } from "./core/levels.ts";
+import type { Game, TileView } from "./game.ts";
+import { cellCenter, type Layout } from "./layout.ts";
+import { clamp01, ease } from "./fx/camera.ts";
+import { SpriteCache, chipPath } from "./fx/sprites.ts";
+import {
+  BG_DEEP,
+  BG_MID,
+  CHARGE,
+  DANGER,
+  HAIRLINE,
+  HOT,
+  KEYC,
+  WELL_BACK,
+  WELL_RIM,
+  mix,
+  rgb,
+  shade,
+  tierColor,
+  type Rgb,
+} from "./fx/palette.ts";
+
+/**
+ * The look: a magnetic containment well seen slightly from above.
+ *
+ * The 3D is real, not a drop shadow — every chip is an extruded octagonal prism
+ * swept toward a vanishing point above the well, so chips at the edges show
+ * their sides and chips in the middle stand straight up. The well's own walls
+ * are drawn the same way. It costs two extra fills per chip and it is the
+ * single thing that stops this reading as a flat puzzle grid.
+ */
+
+const DEPTH = 0.062;
+const CUT = 0.22;
+
+export type Pt = { x: number; y: number };
+
+/**
+ * A cut-cornered octagon. The corner cut is an ABSOLUTE length, not a fraction
+ * of each axis — cutting 22% off a tall rectangle's height turns a well into a
+ * lozenge, which is exactly what it did the first time.
+ */
+function octPts(x: number, y: number, w: number, h: number, cut: number): Pt[] {
+  const hw = w / 2;
+  const hh = h / 2;
+  const k = Math.min(cut, Math.min(hw, hh) * 0.85);
+  return [
+    { x: x - hw + k, y: y - hh },
+    { x: x + hw - k, y: y - hh },
+    { x: x + hw, y: y - hh + k },
+    { x: x + hw, y: y + hh - k },
+    { x: x + hw - k, y: y + hh },
+    { x: x - hw + k, y: y + hh },
+    { x: x - hw, y: y + hh - k },
+    { x: x - hw, y: y - hh + k },
+  ];
+}
+
+function tracePath(g: CanvasRenderingContext2D, pts: Pt[]): void {
+  g.beginPath();
+  const f = pts[0] as Pt;
+  g.moveTo(f.x, f.y);
+  for (let i = 1; i < pts.length; i++) {
+    const p = pts[i] as Pt;
+    g.lineTo(p.x, p.y);
+  }
+  g.closePath();
+}
+
+/**
+ * The silhouette of a convex polygon swept by (ox, oy) — i.e. the side faces of
+ * an extruded prism. Standard construction: walk the edges, find where the edge
+ * normal flips relative to the sweep, and stitch the two chains.
+ */
+function sweptHull(g: CanvasRenderingContext2D, pts: Pt[], ox: number, oy: number): void {
+  const n = pts.length;
+  const facing: boolean[] = [];
+  for (let i = 0; i < n; i++) {
+    const a = pts[i] as Pt;
+    const b = pts[(i + 1) % n] as Pt;
+    const nx = b.y - a.y;
+    const ny = -(b.x - a.x);
+    facing.push(nx * ox + ny * oy > 0);
+  }
+  let start = -1;
+  for (let i = 0; i < n; i++) {
+    if (facing[i] && !facing[(i - 1 + n) % n]) start = i;
+  }
+  if (start < 0) return;
+  let count = 0;
+  while (facing[(start + count) % n] && count < n) count++;
+  g.beginPath();
+  const first = pts[start] as Pt;
+  g.moveTo(first.x, first.y);
+  for (let i = 1; i <= count; i++) {
+    const p = pts[(start + i) % n] as Pt;
+    g.lineTo(p.x, p.y);
+  }
+  for (let i = count; i >= 0; i--) {
+    const p = pts[(start + i) % n] as Pt;
+    g.lineTo(p.x + ox, p.y + oy);
+  }
+  g.closePath();
+  g.fill();
+}
+
+/** square-ish shapes: chips, the reactor orb, the replay button */
+function octAt(x: number, y: number, w: number, h: number): Pt[] {
+  return octPts(x, y, w, h, Math.min(w, h) * CUT);
+}
+
+export class Renderer {
+  sprites = new SpriteCache();
+  private plasma: HTMLCanvasElement | null = null;
+  private wellTex: HTMLCanvasElement | null = null;
+  private texKey = "";
+  debug = false;
+
+  private vpx = 0;
+  private vpy = 0;
+
+  resize(l: Layout): void {
+    this.sprites.reset(l.dpr);
+    const pw = Math.max(24, Math.round(l.w / 7));
+    const ph = Math.max(24, Math.round(l.h / 7));
+    if (!this.plasma) this.plasma = document.createElement("canvas");
+    this.plasma.width = pw;
+    this.plasma.height = ph;
+    this.texKey = "";
+  }
+
+  private maxOff = 24;
+
+  private offsetAt(x: number, y: number): { ox: number; oy: number } {
+    const m = this.maxOff;
+    const cl = (v: number) => (v > m ? m : v < -m ? -m : v);
+    return { ox: cl((x - this.vpx) * DEPTH), oy: cl((y - this.vpy) * DEPTH) };
+  }
+
+  draw(g: CanvasRenderingContext2D, game: Game, l: Layout, timeS: number): void {
+    this.vpx = l.boardX + l.boardW / 2;
+    this.vpy = l.boardY - l.cell * 5.5;
+    this.maxOff = l.cell * 0.42;
+
+    const cam = game.cam;
+    g.setTransform(l.dpr, 0, 0, l.dpr, 0, 0);
+    this.background(g, l, timeS, game);
+
+    g.save();
+    const z = 1 + cam.zoom * 0.02;
+    g.translate(l.w / 2 + cam.x, l.h / 2 + cam.y);
+    g.rotate(cam.rot);
+    g.scale(z, z);
+    g.translate(-l.w / 2, -l.h / 2);
+
+    this.well(g, l, game, timeS);
+    this.aimBeam(g, l, game, timeS);
+    this.tiles(g, l, game, timeS);
+    this.dying(g, l, game);
+    game.parts.draw(g, this.sprites);
+    game.rings.draw(g);
+    this.cores(g, game);
+    this.heldChip(g, l, game, timeS);
+    game.pops.draw(g, this.sprites);
+    g.restore();
+
+    this.hud(g, l, game, timeS);
+    this.overlays(g, l, game, timeS);
+
+    const f = cam.flashAlpha();
+    if (f) {
+      g.save();
+      g.globalCompositeOperation = "lighter";
+      g.fillStyle = rgb(f.c, f.a);
+      g.fillRect(0, 0, l.w, l.h);
+      g.restore();
+    }
+
+    if (this.debug) {
+      const s = this.sprites.stats();
+      this.sprites.drawText(
+        g,
+        `${Math.round(game.fps)}fps  p${game.parts.count}  s${s.chips + s.glows + s.texts}  ${game.phase}`,
+        12,
+        [140, 200, 255],
+        l.w / 2,
+        14,
+        700,
+        0.7,
+      );
+    }
+  }
+
+  /* ---------------- background ---------------- */
+
+  private background(g: CanvasRenderingContext2D, l: Layout, t: number, game: Game): void {
+    const grad = g.createLinearGradient(0, 0, 0, l.h);
+    grad.addColorStop(0, rgb(BG_MID));
+    grad.addColorStop(0.55, rgb(BG_DEEP));
+    grad.addColorStop(1, rgb(shade(BG_MID, 0.7)));
+    g.fillStyle = grad;
+    g.fillRect(0, 0, l.w, l.h);
+
+    // plasma: three slow blobs on a tiny canvas, upscaled. Blur for free.
+    const p = this.plasma;
+    if (p) {
+      const pg = p.getContext("2d") as CanvasRenderingContext2D;
+      pg.clearRect(0, 0, p.width, p.height);
+      pg.globalCompositeOperation = "lighter";
+      const blobs: [Rgb, number, number, number][] = [
+        [[30, 90, 200], 0.5 + Math.sin(t * 0.17) * 0.34, 0.34 + Math.cos(t * 0.13) * 0.22, 0.62],
+        [[120, 40, 190], 0.42 + Math.cos(t * 0.11) * 0.36, 0.7 + Math.sin(t * 0.19) * 0.2, 0.55],
+        [
+          game.danger > 0.62 ? DANGER : ([20, 150, 170] as Rgb),
+          0.5 + Math.sin(t * 0.23 + 2) * 0.3,
+          0.5 + Math.cos(t * 0.09 + 1) * 0.3,
+          0.45 + game.danger * 0.3,
+        ],
+      ];
+      for (const [c, bx, by, br] of blobs) {
+        const cx = bx * p.width;
+        const cy = by * p.height;
+        const r = br * p.width;
+        const rg = pg.createRadialGradient(cx, cy, 0, cx, cy, r);
+        rg.addColorStop(0, `rgba(${c[0]},${c[1]},${c[2]},0.55)`);
+        rg.addColorStop(1, `rgba(${c[0]},${c[1]},${c[2]},0)`);
+        pg.fillStyle = rg;
+        pg.fillRect(0, 0, p.width, p.height);
+      }
+      g.save();
+      g.globalCompositeOperation = "lighter";
+      g.globalAlpha = 0.5;
+      g.imageSmoothingEnabled = true;
+      g.drawImage(p, 0, 0, l.w, l.h);
+      g.restore();
+    }
+
+    // a faint scan grid, drawn live because it is only a few dozen strokes
+    g.save();
+    g.strokeStyle = rgb(HAIRLINE, 0.34);
+    g.lineWidth = 1;
+    const step = Math.max(46, l.cell);
+    g.beginPath();
+    for (let x = (t * 6) % step; x < l.w; x += step) {
+      g.moveTo(x, 0);
+      g.lineTo(x, l.h);
+    }
+    for (let y = 0; y < l.h; y += step) {
+      g.moveTo(0, y);
+      g.lineTo(l.w, y);
+    }
+    g.stroke();
+    g.restore();
+  }
+
+  /* ---------------- the well ---------------- */
+
+  private well(g: CanvasRenderingContext2D, l: Layout, game: Game, t: number): void {
+    const key = `${l.w}x${l.h}x${l.cell}x${l.boardX}x${l.boardY}`;
+    if (!this.wellTex || this.texKey !== key) {
+      this.wellTex = document.createElement("canvas");
+      this.wellTex.width = Math.max(1, Math.round(l.boardW * l.dpr));
+      this.wellTex.height = Math.max(1, Math.round(l.boardH * l.dpr));
+      const wg = this.wellTex.getContext("2d") as CanvasRenderingContext2D;
+      wg.scale(l.dpr, l.dpr);
+      const bg = wg.createLinearGradient(0, 0, 0, l.boardH);
+      bg.addColorStop(0, rgb(shade(WELL_BACK, 0.55)));
+      bg.addColorStop(1, rgb(WELL_BACK));
+      wg.fillStyle = bg;
+      wg.fillRect(0, 0, l.boardW, l.boardH);
+      wg.strokeStyle = rgb(HAIRLINE, 0.85);
+      wg.lineWidth = 1;
+      wg.beginPath();
+      for (let c = 1; c < COLS; c++) {
+        wg.moveTo(c * l.cell, 0);
+        wg.lineTo(c * l.cell, l.boardH);
+      }
+      for (let r = 1; r < ROWS; r++) {
+        wg.moveTo(0, r * l.cell);
+        wg.lineTo(l.boardW, r * l.cell);
+      }
+      wg.stroke();
+      // socket rings, so empty cells read as machined seats
+      wg.strokeStyle = rgb(HAIRLINE, 0.6);
+      for (let r = 0; r < ROWS; r++) {
+        for (let c = 0; c < COLS; c++) {
+          tracePath(wg, octAt((c + 0.5) * l.cell, (r + 0.5) * l.cell, l.cell * 0.62, l.cell * 0.62));
+          wg.stroke();
+        }
+      }
+      this.texKey = key;
+    }
+
+    // outer prism walls — swept away from the vanishing point, so the well
+    // reads as a slab of machined metal you are looking down into
+    const wcx = l.wellX + l.wellW / 2;
+    const wcy = l.wellY + l.wellH / 2;
+    const cut = l.cell * 0.62;
+    const outer = octPts(wcx, wcy, l.wellW, l.wellH, cut);
+    g.fillStyle = rgb(shade(WELL_RIM, 0.34));
+    sweptHull(g, outer, 0, l.cell * 0.34);
+    g.fillStyle = rgb(shade(WELL_RIM, 0.5));
+    sweptHull(g, outer, (wcx - this.vpx) * 0.02, l.cell * 0.16);
+
+    g.save();
+    tracePath(g, outer);
+    g.fillStyle = rgb(shade(WELL_BACK, 0.6));
+    g.fill();
+    g.clip();
+    g.drawImage(this.wellTex, l.boardX, l.boardY, l.boardW, l.boardH);
+    g.restore();
+
+    // danger: a hazard band you cannot miss, plus a hatch so the warning is
+    // never carried by red alone
+    const dz = game.danger;
+    if (dz > 0.42) {
+      const k = clamp01((dz - 0.42) / 0.45);
+      const a = k * (0.34 + Math.sin(t * 7) * 0.12);
+      g.save();
+      // everything in here is machinery inside the well and must stay in it
+      g.beginPath();
+      g.rect(l.boardX, l.boardY, l.boardW, l.cell * 3);
+      g.clip();
+      g.globalCompositeOperation = "lighter";
+      const hg = g.createLinearGradient(0, l.boardY, 0, l.boardY + l.cell * 3);
+      hg.addColorStop(0, rgb(DANGER, a));
+      hg.addColorStop(1, rgb(DANGER, 0));
+      g.fillStyle = hg;
+      g.fillRect(l.boardX, l.boardY, l.boardW, l.cell * 3);
+
+      // diagonal hazard hatching across the top two rows
+      g.globalAlpha = k * 0.5;
+      g.strokeStyle = rgb(DANGER, 0.9);
+      g.lineWidth = Math.max(2, l.cell * 0.07);
+      const band = l.cell * 1.35;
+      const step = l.cell * 0.5;
+      g.beginPath();
+      for (let x = -band; x < l.boardW + band; x += step) {
+        g.moveTo(l.boardX + x, l.boardY);
+        g.lineTo(l.boardX + x + band, l.boardY + band);
+      }
+      g.stroke();
+      g.globalAlpha = 1;
+      g.restore();
+    }
+
+    // rim
+    g.lineWidth = Math.max(2, l.cell * 0.06);
+    const hot = clamp01((dz - 0.55) * 2.4) * (0.6 + Math.sin(t * 6.5) * 0.4);
+    g.strokeStyle = rgb(mix(WELL_RIM, DANGER, hot), 0.95);
+    if (hot > 0.15) {
+      g.save();
+      g.globalCompositeOperation = "lighter";
+      const gl = this.sprites.glow(DANGER, 128);
+      g.globalAlpha = hot * 0.35;
+      g.drawImage(
+        gl as CanvasImageSource,
+        l.wellX - l.cell,
+        l.wellY - l.cell,
+        l.wellW + l.cell * 2,
+        l.wellH + l.cell * 2,
+      );
+      g.restore();
+    }
+    tracePath(g, outer);
+    g.stroke();
+  }
+
+  /* ---------------- aim ---------------- */
+
+  private rail(g: CanvasRenderingContext2D, l: Layout, game: Game): void {
+    const y = l.headY + l.cell * 0.66;
+    g.save();
+    g.strokeStyle = rgb(WELL_RIM, 0.75);
+    g.lineWidth = Math.max(1.5, l.cell * 0.05);
+    g.beginPath();
+    g.moveTo(l.boardX - l.cell * 0.2, y);
+    g.lineTo(l.boardX + l.boardW + l.cell * 0.2, y);
+    g.stroke();
+    g.lineWidth = Math.max(1, l.cell * 0.03);
+    for (let c = 0; c < COLS; c++) {
+      const x = l.boardX + (c + 0.5) * l.cell;
+      const on = c === game.heldCol;
+      g.strokeStyle = rgb(on ? HOT : WELL_RIM, on ? 0.9 : 0.5);
+      g.beginPath();
+      g.moveTo(x, y - l.cell * (on ? 0.16 : 0.09));
+      g.lineTo(x, y + l.cell * (on ? 0.16 : 0.09));
+      g.stroke();
+    }
+    g.restore();
+  }
+
+  private aimBeam(g: CanvasRenderingContext2D, l: Layout, game: Game, t: number): void {
+    if (game.phase !== "aim" && game.phase !== "drop") return;
+    this.rail(g, l, game);
+    const land = game.previewLanding;
+    const col = game.heldCol;
+    const x = l.boardX + (col + 0.5) * l.cell;
+    const bottom = land ? cellCenter(l, land.r, land.c).y : l.boardY + l.boardH;
+    const tint = game.previewCells.length > 0 ? HOT : ([90, 170, 255] as Rgb);
+
+    g.save();
+    g.globalCompositeOperation = "lighter";
+    const bg = g.createLinearGradient(0, l.boardY, 0, bottom);
+    // Quiet until it means something: the beam is a faint cyan guide, and it
+    // turns hot the instant the landing would fuse. That contrast is the whole
+    // tutorial — nobody has to be told the rule, they see it light up.
+    const live = game.previewCells.length > 0;
+    bg.addColorStop(0, rgb(tint, 0.01));
+    bg.addColorStop(1, rgb(tint, live ? 0.5 : 0.13));
+    g.fillStyle = bg;
+    g.fillRect(x - l.cell * 0.46, l.boardY, l.cell * 0.92, bottom - l.boardY);
+    // bright guide edges
+    g.strokeStyle = rgb(tint, live ? 0.6 : 0.13);
+    g.lineWidth = Math.max(1, l.cell * 0.03);
+    g.beginPath();
+    g.moveTo(x - l.cell * 0.46, l.boardY);
+    g.lineTo(x - l.cell * 0.46, bottom);
+    g.moveTo(x + l.cell * 0.46, l.boardY);
+    g.lineTo(x + l.cell * 0.46, bottom);
+    g.stroke();
+
+    // chevrons falling down the beam
+    const n = 4;
+    for (let i = 0; i < n; i++) {
+      const p = ((t * 1.35 + i / n) % 1) as number;
+      const y = l.boardY + p * (bottom - l.boardY);
+      const a = (1 - p) * (live ? 0.85 : 0.4);
+      g.strokeStyle = rgb(tint, a);
+      g.lineWidth = Math.max(1.5, l.cell * 0.05);
+      g.beginPath();
+      g.moveTo(x - l.cell * 0.22, y - l.cell * 0.1);
+      g.lineTo(x, y + l.cell * 0.1);
+      g.lineTo(x + l.cell * 0.22, y - l.cell * 0.1);
+      g.stroke();
+    }
+    g.restore();
+
+    if (land) {
+      const c = cellCenter(l, land.r, land.c);
+      const pulse = 0.86 + Math.sin(t * 8) * 0.05;
+      const pts = octAt(c.x, c.y, l.cell * pulse, l.cell * pulse);
+      g.save();
+      g.globalCompositeOperation = "lighter";
+      g.strokeStyle = rgb(tint, live ? 0.85 : 0.42);
+      g.lineWidth = Math.max(1.5, l.cell * (live ? 0.06 : 0.04));
+      g.setLineDash([l.cell * 0.16, l.cell * 0.12]);
+      g.lineDashOffset = -t * 40;
+      tracePath(g, pts);
+      g.stroke();
+      g.restore();
+    }
+  }
+
+  /* ---------------- chips ---------------- */
+
+  private chip(
+    g: CanvasRenderingContext2D,
+    l: Layout,
+    x: number,
+    y: number,
+    size: number,
+    value: number,
+    key: number,
+    face: { kind: "num" } | { kind: "expr"; text: string },
+    hot: number,
+    sx: number,
+    sy: number,
+    alpha = 1,
+  ): void {
+    const tier = tierOf(value, key);
+    const c = tierColor(tier);
+    const w = size * sx;
+    const h = size * sy;
+    // The prism depth is a property of the chip, not of the screen: a 30px
+    // instrument chip must not grow the same 28px tail as a chip in the well.
+    const raw = this.offsetAt(x, y);
+    const lim = size * 0.17;
+    const mag = Math.hypot(raw.ox, raw.oy);
+    const k = mag > lim ? lim / mag : 1;
+    const ox = raw.ox * k;
+    const oy = raw.oy * k + size * 0.05;
+
+    g.globalAlpha = alpha;
+
+    // side faces
+    const pts = octAt(x, y, w, h);
+    g.fillStyle = rgb(shade(c, hot > 0.05 ? 0.5 : 0.3));
+    sweptHull(g, pts, ox, oy);
+
+    // under-glow
+    g.save();
+    g.globalCompositeOperation = "lighter";
+    const gl = this.sprites.glow(c, 64);
+    const gs = size * (1.75 + hot * 0.7);
+    g.globalAlpha = alpha * (0.42 + hot * 0.45);
+    g.drawImage(gl as CanvasImageSource, x - gs / 2, y - gs / 2, gs, gs);
+    g.restore();
+
+    // top face
+    g.globalAlpha = alpha;
+    const spr = this.sprites.chip(c, size, hot > 0.35);
+    g.drawImage(spr as CanvasImageSource, x - w / 2, y - h / 2, w, h);
+
+    // numeral / expression
+    const label = face.kind === "num" ? String(value) : face.text;
+    const ideal = face.kind === "num" ? size * 0.5 : size * 0.3;
+    let px = Math.max(8, Math.round(ideal));
+    const maxW = size * 0.82;
+    const measured = this.sprites.measure(label, px);
+    if (measured > maxW) px = Math.max(7, Math.round((px * maxW) / measured));
+    const textColor = hot > 0.35 ? HOT : mix([235, 245, 255], c, 0.25);
+    this.sprites.drawText(g, label, px, textColor, x, y - h * 0.005, 800, alpha);
+
+    if (face.kind === "expr") {
+      // a hairline under an expression face: this chip is worth what it says
+      g.strokeStyle = rgb(c, alpha * 0.55);
+      g.lineWidth = Math.max(1, l.cell * 0.02);
+      g.beginPath();
+      g.moveTo(x - w * 0.22, y + h * 0.3);
+      g.lineTo(x + w * 0.22, y + h * 0.3);
+      g.stroke();
+    }
+    g.globalAlpha = 1;
+  }
+
+  private tiles(g: CanvasRenderingContext2D, l: Layout, game: Game, t: number): void {
+    const key = game.level.key;
+    for (let r = ROWS - 1; r >= 0; r--) {
+      for (let c = 0; c < COLS; c++) {
+        const cell = game.board[idx(r, c)];
+        if (!cell) continue;
+        const v = game.tiles.get(cell.id);
+        if (!v) continue;
+        this.drawTile(g, l, v, key, t);
+      }
+    }
+  }
+
+  private drawTile(g: CanvasRenderingContext2D, l: Layout, v: TileView, key: number, t: number): void {
+    const x = l.boardX + (v.px + 0.5) * l.cell;
+    const y = l.boardY + (v.py + 0.5) * l.cell;
+    const born = clamp01((t * 1000 - v.landedAt) / 180);
+    const pop = v.landedAt > 0 ? 0.9 + ease.outBack(born) * 0.1 : 1;
+    const hot = v.hot;
+    const size = l.cell * 0.9 * pop;
+    this.chip(
+      g,
+      l,
+      x,
+      y,
+      size,
+      v.value,
+      key,
+      v.face,
+      hot,
+      1 + v.q,
+      1 - v.q,
+      1,
+    );
+  }
+
+  private heldChip(g: CanvasRenderingContext2D, l: Layout, game: Game, t: number): void {
+    const h = game.held;
+    if (!h || game.phase === "resonance" || game.phase === "breach") return;
+    const x = l.boardX + (h.px + 0.5) * l.cell;
+    const y = game.phase === "drop" ? l.boardY + (h.py + 0.5) * l.cell : l.headY;
+
+    // trail while falling
+    if (game.phase === "drop") {
+      for (let i = 4; i >= 1; i--) {
+        const ty = y - i * l.cell * 0.28;
+        if (ty < l.boardY - l.cell) continue;
+        this.chip(g, l, x, ty, l.cell * 0.9, h.value, game.level.key, h.face, 0, 1, 1, 0.1 * (5 - i) * 0.4);
+      }
+    }
+
+    const breathe = game.phase === "aim" ? 1 + Math.sin(t * 4.5) * 0.018 : 1;
+    this.chip(
+      g,
+      l,
+      x,
+      y,
+      l.cell * 0.98 * breathe,
+      h.value,
+      game.level.key,
+      h.face,
+      game.previewCells.length > 0 ? 1 : 0.15,
+      1 + h.q,
+      1 - h.q,
+    );
+
+    if (game.phase === "aim") {
+      // the fuse timer: a ring that closes on the held chip. No numerals, no
+      // countdown text — it is a shape, so it never reflows the layout.
+      const p = game.aimRatio();
+      const rr = l.cell * 0.78;
+      g.save();
+      g.globalCompositeOperation = "lighter";
+      g.strokeStyle = rgb(p > 0.75 ? DANGER : CHARGE, 0.28 + p * 0.5);
+      g.lineWidth = Math.max(2, l.cell * 0.07);
+      g.lineCap = "round";
+      g.beginPath();
+      g.arc(x, y, rr, -Math.PI / 2, -Math.PI / 2 + (1 - p) * Math.PI * 2);
+      g.stroke();
+      g.restore();
+    }
+  }
+
+  private dying(g: CanvasRenderingContext2D, l: Layout, game: Game): void {
+    for (const d of game.dying) {
+      if (d.t < 0) continue;
+      const p = clamp01(d.t / d.dur);
+      const c = tierColor(d.tier);
+      const x = l.boardX + (d.c + 0.5) * l.cell;
+      const y = l.boardY + (d.r + 0.5) * l.cell;
+      const s =
+        d.kind === "fuse"
+          ? l.cell * 0.9 * (1 + ease.outQuint(p) * 0.9) * (1 - ease.inQuad(p))
+          : l.cell * 0.9 * (1 - ease.outCubic(p));
+      if (s <= 0.5) continue;
+      g.save();
+      g.globalCompositeOperation = "lighter";
+      const gl = this.sprites.glow(p > 0.4 ? HOT : c, 64);
+      const gs = l.cell * (2 + p * 2.4);
+      g.globalAlpha = (1 - p) * 0.9;
+      g.drawImage(gl as CanvasImageSource, x - gs / 2, y - gs / 2, gs, gs);
+      g.restore();
+      this.chip(g, l, x, y, s, d.value, game.level.key, { kind: "num" }, 1, 1, 1, (1 - p) ** 0.6);
+    }
+  }
+
+  private cores(g: CanvasRenderingContext2D, game: Game): void {
+    if (game.cores.length === 0) return;
+    g.save();
+    g.globalCompositeOperation = "lighter";
+    for (const c of game.cores) {
+      if (!c.alive) continue;
+      const p = game.corePos(c);
+      const size = 42 * p.s;
+      const gl = this.sprites.glow(c.color, 64);
+      g.globalAlpha = 0.95;
+      g.drawImage(gl as CanvasImageSource, p.x - size, p.y - size, size * 2, size * 2);
+      this.sprites.drawText(g, String(c.value), Math.max(11, 22 * p.s), HOT, p.x, p.y, 900, 1);
+    }
+    g.restore();
+    g.globalAlpha = 1;
+  }
+
+  /* ---------------- instruments ---------------- */
+
+  private hud(g: CanvasRenderingContext2D, l: Layout, game: Game, t: number): void {
+    const big = Math.max(24, Math.min(58, l.cell * 0.86));
+    const small = Math.max(10, Math.min(16, l.cell * 0.26));
+
+    // score
+    const sx = l.scoreX;
+    const shown = Math.round(game.shownScore);
+    if (l.scoreAlign === "left") {
+      const w = this.sprites.measure(String(shown), big);
+      this.sprites.drawText(g, String(shown), big, HOT, sx + w / 2, l.scoreY, 900);
+      const bw = this.sprites.measure(`BEST ${game.best}`, small);
+      this.sprites.drawText(
+        g,
+        `BEST ${game.best}`,
+        small,
+        game.newBest ? KEYC : ([120, 145, 200] as Rgb),
+        sx + bw / 2,
+        l.scoreY + big * 0.62,
+        700,
+      );
+    } else {
+      this.sprites.drawText(g, String(shown), big, HOT, sx, l.scoreY, 900);
+      this.sprites.drawText(
+        g,
+        `BEST ${game.best}`,
+        small,
+        game.newBest ? KEYC : ([120, 145, 200] as Rgb),
+        sx,
+        l.scoreY + big * 0.62,
+        700,
+      );
+    }
+
+    // chain readout, only while it means something
+    if (game.chainShown >= 2 && game.chainShownT < 1.1) {
+      const a = 1 - clamp01(game.chainShownT / 1.1);
+      const cs = big * (0.7 + (1 - a) * 0.1);
+      const cx = l.landscape ? l.scoreX : l.scoreX + this.sprites.measure(String(shown), big) / 2;
+      this.sprites.drawText(
+        g,
+        `${game.chainShown}${"×"} CHAIN`,
+        cs * 0.42,
+        HOT,
+        cx,
+        l.scoreY - big * 0.62,
+        900,
+        a,
+      );
+    }
+
+    this.reactor(g, l, game, t);
+
+    // level
+    const lv = `${game.levelN}`;
+    const lvSize = Math.max(14, Math.min(26, l.cell * 0.42));
+    const lx = l.landscape ? l.levelX : l.levelX - this.sprites.measure(lv, lvSize) / 2 - 12;
+    this.sprites.drawText(g, "LV", lvSize * 0.6, [120, 145, 200], lx - lvSize * 0.85, l.levelY, 800);
+    this.sprites.drawText(g, lv, lvSize, KEYC, lx, l.levelY, 900);
+
+    // incoming chips
+    const inc = game.peekUpcoming(3);
+    for (let i = 0; i < inc.length; i++) {
+      const v = inc[i] as number;
+      const x = l.incomingVertical ? l.incomingX : l.incomingX + i * l.incomingStep;
+      const y = l.incomingVertical ? l.incomingY + i * l.incomingStep : l.incomingY;
+      const s = l.chipSize * (i === 0 ? 1 : 0.82);
+      g.globalAlpha = 1 - i * 0.24;
+      this.chip(g, l, x, y, s, v, game.level.key, { kind: "num" }, 0, 1, 1, 1 - i * 0.24);
+      g.globalAlpha = 1;
+    }
+
+    this.soundButton(g, l, game);
+  }
+
+  private reactor(g: CanvasRenderingContext2D, l: Layout, game: Game, t: number): void {
+    const x = l.keyX;
+    const y = l.keyY;
+    const r = l.keyR;
+    const ready = game.charge >= 8;
+    const pulse = ready ? 1 + Math.sin(game.chargeReadyPulse * 9) * 0.05 : 1;
+
+    g.save();
+    g.globalCompositeOperation = "lighter";
+    const gl = this.sprites.glow(ready ? CHARGE : KEYC, 128);
+    const gs = r * (3.4 + (ready ? 0.9 : 0)) * pulse;
+    g.globalAlpha = 0.5 + (ready ? 0.3 : 0);
+    g.drawImage(gl as CanvasImageSource, x - gs / 2, y - gs / 2, gs, gs);
+    g.restore();
+
+    // level progress arc (outer)
+    g.save();
+    g.lineCap = "round";
+    g.strokeStyle = rgb([40, 56, 100], 0.9);
+    g.lineWidth = Math.max(3, r * 0.13);
+    g.beginPath();
+    g.arc(x, y, r * 1.34, 0, Math.PI * 2);
+    g.stroke();
+    g.strokeStyle = rgb(KEYC, 0.95);
+    g.beginPath();
+    g.arc(x, y, r * 1.34, -Math.PI / 2, -Math.PI / 2 + game.levelProgress() * Math.PI * 2);
+    g.stroke();
+
+    // charge arc (inner)
+    g.strokeStyle = rgb([26, 60, 60], 0.9);
+    g.lineWidth = Math.max(2, r * 0.1);
+    g.beginPath();
+    g.arc(x, y, r * 1.12, 0, Math.PI * 2);
+    g.stroke();
+    g.strokeStyle = rgb(CHARGE, ready ? 1 : 0.85);
+    g.beginPath();
+    g.arc(x, y, r * 1.12, -Math.PI / 2, -Math.PI / 2 + game.chargeRatio() * Math.PI * 2);
+    g.stroke();
+    g.restore();
+
+    // the KEY itself
+    const morph = game.keyMorph;
+    const scale = (1 + morph * 0.35) * pulse;
+    const pts = octAt(x, y, r * 1.62 * scale, r * 1.62 * scale);
+    g.fillStyle = rgb(shade(KEYC, 0.24));
+    sweptHull(g, pts, 0, r * 0.16);
+    tracePath(g, pts);
+    const fill = g.createLinearGradient(0, y - r, 0, y + r);
+    fill.addColorStop(0, rgb(shade(KEYC, 0.42)));
+    fill.addColorStop(1, rgb(shade(KEYC, 0.14)));
+    g.fillStyle = fill;
+    g.fill();
+    g.strokeStyle = rgb(ready ? CHARGE : KEYC, 1);
+    g.lineWidth = Math.max(2, r * 0.09);
+    g.stroke();
+
+    const label = String(game.level.key);
+    let px = Math.round(r * 0.92);
+    const mw = this.sprites.measure(label, px);
+    if (mw > r * 1.32) px = Math.round((px * r * 1.32) / mw);
+    this.sprites.drawText(g, label, px, ready ? CHARGE : HOT, x, y + r * 0.02, 900);
+    void t;
+  }
+
+  private soundButton(g: CanvasRenderingContext2D, l: Layout, game: Game): void {
+    const { soundX: x, soundY: y, soundR: r } = l;
+    g.save();
+    g.strokeStyle = rgb([90, 115, 170], 0.75);
+    g.lineWidth = 1.5;
+    chipPath(g, x - r, y - r, r * 2, r * 2, r * 0.4);
+    g.stroke();
+    g.strokeStyle = rgb(game.soundOn ? CHARGE : ([110, 125, 160] as Rgb), 1);
+    g.lineWidth = 2;
+    g.beginPath();
+    g.moveTo(x - r * 0.42, y - r * 0.22);
+    g.lineTo(x - r * 0.16, y - r * 0.22);
+    g.lineTo(x + r * 0.1, y - r * 0.5);
+    g.lineTo(x + r * 0.1, y + r * 0.5);
+    g.lineTo(x - r * 0.16, y + r * 0.22);
+    g.lineTo(x - r * 0.42, y + r * 0.22);
+    g.closePath();
+    g.stroke();
+    if (game.soundOn) {
+      g.beginPath();
+      g.arc(x + r * 0.2, y, r * 0.28, -0.9, 0.9);
+      g.stroke();
+      g.beginPath();
+      g.arc(x + r * 0.2, y, r * 0.5, -0.9, 0.9);
+      g.stroke();
+    } else {
+      g.beginPath();
+      g.moveTo(x + r * 0.24, y - r * 0.26);
+      g.lineTo(x + r * 0.6, y + r * 0.26);
+      g.moveTo(x + r * 0.6, y - r * 0.26);
+      g.lineTo(x + r * 0.24, y + r * 0.26);
+      g.stroke();
+    }
+    g.restore();
+  }
+
+  /* ---------------- overlays ---------------- */
+
+  private overlays(g: CanvasRenderingContext2D, l: Layout, game: Game, t: number): void {
+    if (game.phase === "boot") {
+      const p = clamp01(game.pt / 1.3);
+      const a = p < 0.62 ? 1 : 1 - (p - 0.62) / 0.38;
+      const s = Math.min(l.w * 0.24, l.h * 0.16) * (0.9 + ease.outBack(clamp01(p * 2.6)) * 0.1);
+      g.save();
+      g.globalCompositeOperation = "lighter";
+      this.sprites.drawText(g, "FUSE", s, HOT, l.w / 2, l.h * 0.42, 900, a);
+      g.restore();
+    }
+
+    if (game.phase === "levelup") {
+      const p = clamp01(game.pt / 1.45);
+      const a = p < 0.55 ? ease.outCubic(clamp01(p * 4)) : 1 - (p - 0.55) / 0.45;
+      const s = Math.max(16, Math.min(34, l.cell * 0.52));
+      this.sprites.drawText(g, `LEVEL ${game.levelN}`, s, KEYC, l.w / 2, l.boardY + l.boardH * 0.26, 900, a);
+    }
+
+    if (game.phase === "resonance") this.resonance(g, l, game, t);
+    if (game.phase === "breach") this.breach(g, l, game);
+  }
+
+  private resonance(g: CanvasRenderingContext2D, l: Layout, game: Game, t: number): void {
+    const r = game.res;
+    const inT = clamp01(game.pt / 0.32);
+    g.save();
+    g.fillStyle = `rgba(2,3,10,${0.66 * inT})`;
+    g.fillRect(0, 0, l.w, l.h);
+    g.restore();
+
+    // redraw the chips above the dim, pulsing, so they read as the answer bank
+    const pulse = 0.5 + Math.sin(t * 6) * 0.5;
+    for (let rr = ROWS - 1; rr >= 0; rr--) {
+      for (let c = 0; c < COLS; c++) {
+        const cell = game.board[idx(rr, c)];
+        if (!cell) continue;
+        const v = game.tiles.get(cell.id);
+        if (!v) continue;
+        const isPick = r.pickedCell && r.pickedCell.r === rr && r.pickedCell.c === c;
+        const hot = isPick ? 1 : pulse * 0.35;
+        const x = l.boardX + (v.px + 0.5) * l.cell;
+        const y = l.boardY + (v.py + 0.5) * l.cell;
+        this.chip(g, l, x, y, l.cell * 0.9, v.value, game.level.key, v.face, hot, 1 + v.q, 1 - v.q);
+      }
+    }
+
+    const accent = r.rescue ? DANGER : CHARGE;
+    const panelY = l.boardY + l.cell * 1.9;
+    const scale = ease.outBack(inT);
+    const size = Math.max(28, Math.min(78, l.cell * 1.25));
+    const q = r.question;
+    const prompt = q ? q.prompt : "";
+    let px = size;
+    const maxW = Math.min(l.w * 0.78, l.boardW * 1.5);
+    const mw = this.sprites.measure(prompt, px);
+    if (mw > maxW) px = Math.round((px * maxW) / mw);
+    const pw = Math.max(this.sprites.measure(prompt, px) + px * 1.5, l.boardW * 0.98);
+    const ph = px * 2.35;
+
+    g.save();
+    g.translate(l.w / 2, panelY);
+    g.scale(scale, scale);
+
+    // backing plate: the prompt must stay legible over a full well
+    g.save();
+    g.globalCompositeOperation = "lighter";
+    const gl = this.sprites.glow(accent, 128);
+    g.globalAlpha = 0.5;
+    g.drawImage(gl as CanvasImageSource, -pw * 0.75, -ph * 1.1, pw * 1.5, ph * 2.2);
+    g.restore();
+    tracePath(g, octPts(0, 0, pw, ph, px * 0.42));
+    g.fillStyle = "rgba(4,7,18,0.94)";
+    g.fill();
+    g.strokeStyle = rgb(accent, 0.95);
+    g.lineWidth = Math.max(2, px * 0.06);
+    g.stroke();
+
+    this.sprites.drawText(g, prompt, px, HOT, 0, -ph * 0.12, 900);
+    this.sprites.drawText(g, "= ?", px * 0.62, accent, 0, ph * 0.29, 900, 0.95);
+    g.restore();
+
+    // time bar under the plate — a shape, never a numeric countdown
+    if (r.result === "none") {
+      const p = 1 - clamp01(r.t / r.limit);
+      const bw = pw * scale;
+      const by = panelY + (ph * scale) / 2 + px * 0.4;
+      g.save();
+      g.fillStyle = rgb([30, 44, 82], 0.9);
+      g.fillRect(l.w / 2 - bw / 2, by, bw, Math.max(4, px * 0.11));
+      g.globalCompositeOperation = "lighter";
+      g.fillStyle = rgb(p < 0.28 ? DANGER : accent, 1);
+      g.fillRect(l.w / 2 - bw / 2, by, bw * p, Math.max(4, px * 0.11));
+      g.restore();
+    } else {
+      const a = clamp01(1 - r.resultT);
+      const txt = r.result === "hit" ? String(r.target) : String(r.target);
+      const col = r.result === "hit" ? HOT : DANGER;
+      const s = Math.max(30, l.cell * 1.2) * (1 + (1 - a) * 0.3);
+      this.sprites.drawText(g, txt, s, col, l.w / 2, l.boardY + l.boardH * 0.5, 900, a);
+    }
+  }
+
+  private breach(g: CanvasRenderingContext2D, l: Layout, game: Game): void {
+    const p = clamp01(game.pt / 1.5);
+    g.save();
+    g.fillStyle = `rgba(3,4,12,${0.72 * clamp01(game.pt / 0.5)})`;
+    g.fillRect(0, 0, l.w, l.h);
+    g.restore();
+
+    const cy = l.h * 0.4;
+    const a = clamp01((game.pt - 0.35) / 0.5);
+    if (a <= 0) return;
+
+    const big = Math.max(44, Math.min(112, l.cell * 1.9));
+    this.sprites.drawText(g, String(game.score), big, HOT, l.w / 2, cy, 900, a);
+    this.sprites.drawText(
+      g,
+      game.newBest ? `NEW BEST` : `BEST ${game.best}`,
+      Math.max(12, big * 0.2),
+      game.newBest ? KEYC : ([120, 145, 200] as Rgb),
+      l.w / 2,
+      cy + big * 0.62,
+      800,
+      a,
+    );
+
+    // replay button
+    const br = Math.max(30, Math.min(56, l.cell * 0.95));
+    const by = cy + big * 0.62 + br * 1.9;
+    const bob = 1 + Math.sin(game.pt * 3.4) * 0.03;
+    g.save();
+    g.globalAlpha = a;
+    g.globalCompositeOperation = "lighter";
+    const gl = this.sprites.glow(KEYC, 128);
+    g.drawImage(gl as CanvasImageSource, l.w / 2 - br * 2, by - br * 2, br * 4, br * 4);
+    g.restore();
+
+    g.save();
+    g.globalAlpha = a;
+    tracePath(g, octAt(l.w / 2, by, br * 2 * bob, br * 2 * bob));
+    g.fillStyle = rgb(shade(KEYC, 0.16));
+    g.fill();
+    g.strokeStyle = rgb(KEYC, 1);
+    g.lineWidth = Math.max(2, br * 0.08);
+    g.stroke();
+
+    // circular replay arrow, with the head tangent to the arc it ends on
+    const rr = br * 0.55;
+    const a0 = -Math.PI * 0.62;
+    const a1 = Math.PI * 1.15;
+    g.strokeStyle = rgb(HOT, 1);
+    g.lineWidth = Math.max(2.5, br * 0.12);
+    g.lineCap = "round";
+    g.beginPath();
+    g.arc(l.w / 2, by, rr, a0, a1);
+    g.stroke();
+    const ax = l.w / 2 + Math.cos(a0) * rr;
+    const ay = by + Math.sin(a0) * rr;
+    const tan = a0 - Math.PI / 2; // direction of travel at the head
+    const hw = br * 0.24;
+    g.beginPath();
+    g.moveTo(ax + Math.cos(tan) * hw * 1.5, ay + Math.sin(tan) * hw * 1.5);
+    g.lineTo(ax + Math.cos(tan + 2.4) * hw, ay + Math.sin(tan + 2.4) * hw);
+    g.lineTo(ax + Math.cos(tan - 2.4) * hw, ay + Math.sin(tan - 2.4) * hw);
+    g.closePath();
+    g.fillStyle = rgb(HOT, 1);
+    g.fill();
+    g.restore();
+    void p;
+  }
+}

--- a/dynawalla/games/merge/tsconfig.json
+++ b/dynawalla/games/merge/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/dynawalla/games/merge/vite.config.ts
+++ b/dynawalla/games/merge/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+  },
+  server: {
+    host: "127.0.0.1",
+    port: 5183,
+    strictPort: true,
+  },
+});


### PR DESCRIPTION
## One sentence

**Touching chips that add up to the KEY fuse.** No instructions, no tutorial —
the aim preview lights both chips the moment you hover the right column, and
that is the entire teaching mechanism.

A number drops into a magnetic containment well. Land it touching chips that
sum to the KEY (10 at first, 100 by the end) and they slam together, detonate,
and the sum flies out as a glowing core. Everything above falls, which makes new
pairs, which fuse. The well rises underneath you the whole time.

```
cd dynawalla/games/merge && npm install && npm run dev
```
`?seed=<text>` reproducible · `?debug=1` fps/particles/phase

## Why the math is not bolted on

Merging **is** addition — the merge is the sum, not a reward for one.

- **Complements**, the highest-value fact family in primary arithmetic, for
  eleven values of "ten": 10 → 12 → 15 → 20 → 24 → 25 → 30 → 40 → 50 → 60 → 75 → 100.
- **Chains** are repeated addition from the pieces that fell, at a rising
  multiplier and a rising pitch.
- **Expression faces** from level 3: a chip stops showing `7` and starts showing
  `15 − 8`. Still worth 7, still fuses with a 3 — but now you must evaluate it to
  aim. Same rules, same UI, deeper arithmetic, no new screen.
- **RESONANCE**: every fuse charges the reactor; full, it goes white and time
  drops to a crawl for one big question with every chip on the board as an
  answer button. It is also the rescue — when the well breaches you get exactly
  one, which is **math instead of an ad**, once per run, no scarcity games.

Guessing is available and guessing loses: the only currency is space, and the
well rises whether or not you were sure. Not a red X anywhere.

Every value, comparison and score is an integer. No float reaches `core/`.

## Pressure

An early build let a perfect player clear forever — the complement deck
guarantees a partner, so skill alone drained the well and the board sat empty
and lifeless. Fixed by making the well **rise**: a fresh row every 7 drops at
level 1 down to every 3 by level 9, two rows at a time from level 9, plus two
rows on every level-up and a seeded well at boot so the very first chip has
somewhere to land. A level-up also burns off every chip the new KEY can never
use, so advancing is relief rather than a dead board.

## Juice, specified and measured

Trauma-squared screen shake (decay 1.85/s) · hitstop `34 + 16×chain` ms ·
spring-damped camera punch (k=190, c=17, overshoots once) · slow-motion 0.42×
above chain 3 · per-chip squash springs with an impact ripple down the stack ·
1100-slot zero-allocation particle pool (streaks, additive dots, spinning
shards, ambient embers) · shockwave fronts whose alpha falls as (1−t)^2.6 ·
falling-chip afterimage trail · `outBack` / `outQuint` / `outCubic` /
`inOutCubic` easing by name · three-layer procedural audio (transient/body/tail,
±30 cents per trigger) climbing a pentatonic ladder so a nine-chain is a melody ·
haptics on land / fuse / chain / level-up / breach.

The 3D is real: every chip is an extruded octagonal prism swept toward a
vanishing point above the well, so edge chips show their sides. Not a shadow.

## Safety — enforced by tests, not intention

- Flashes hard-limited to **3 per second** and **alpha 0.34**, whatever the game
  asks for.
- `prefers-reduced-motion` zeroes shake, punch, rotation, slow-motion and all
  flashes; hitstop survives capped at 40 ms because it is timing, not motion.
  No information is lost.
- Both asserted in `src/fx/camera.test.ts`.
- Colour never carries meaning alone: the danger band is red **and** hatched,
  the fuse preview is a glow **and** a rim, a chip is a colour **and** a numeral.
- No streaks, no loss aversion, no variable-ratio rewards, no loot, no ads, no
  social pressure.

## Performance

Measured on a dense level-7 board at 2502×1822 device pixels (DPR 2):
**0.50 ms/frame idle, 1.63 ms/frame at saturation** (1100 live particles, ring
and pop pools full, camera thrashing every frame) — ~10% of a 16.7 ms budget.
One canvas, one RAF loop, no DOM work per frame, no `shadowBlur` or `filter` in
the hot path; glows/chips/numerals are cached bitmaps, background plasma renders
at 1/7 scale. The particle budget tracks measured fps, so a slow device loses
sparks rather than frames.

## How it was verified

- **69 tests**, Node's runner, no framework — rules, cascade, gravity, the rise,
  the deck's complement guarantee, exact question generation with real mal-rule
  distractors (`42 − 17 → 35`, `27 + 48 → 65`), camera safety limits, and layout
  across ten viewports from a 320-wide phone to a 1920 desktop.
- **Played it**, driven through a probe hook: a 472-move soak across 4 full
  runs (breach → restart → replay) reached level 10 and score 19,697 with **zero
  stuck states and zero errors**; 3,051 questions asked and 1,418 reports
  delivered to the host.
- **Screenshotted and looked at** at rest, aiming with a live fuse preview,
  mid-cascade, peak escalation (level 7, KEY 24, a well of expression chips),
  a resonance detonation, the danger state, and the breach screen. Several
  rounds of fixes came out of actually looking: octagon corner cuts that turned
  the well into a lozenge, 3D extrusion tails on instrument chips, hazard
  hatching escaping the well, an unreadable resonance prompt, and shockwaves
  that stacked into geometry instead of a blast.
- Touch drag-to-aim, mouse hover-aim, the full keyboard path, the reactor tap
  and the sound toggle each exercised through the real event handlers.

## Scope

Everything is inside `dynawalla/games/merge/`. Nothing else is touched. It
mounts through the shared `Host` contract kept at exactly the specified shape
(`src/contract.ts`); a local stub host makes it playable standalone today, and
an **optional, feature-detected** `focus({key, wanted})` extension lets a host
bias its question stream toward the chip values about to spawn — without it the
game simply shows fewer expression faces.

**Diff size**: ~201 kB, marginally over `adversarial-review`'s 200 kB truncation
threshold. A game is atomic and does not split into halves that build, so I cut
what I could: `package-lock.json` is deliberately untracked (documented in
`.gitignore`) precisely because it sorts before `src/` and would have pushed
30 kB of real source out of review. Reviewers should know the tail may truncate.

`dynawalla/games/**` is not covered by any `ci.yml` path filter, so this emits
coverage warnings and runs no CI job — by design; no fourth required context was
added, and no existing workflow was modified.
