### PR TITLE
dynawalla foundations: game feel — tiers, budgets, and the traps

### DIFF
--- a/dynawalla/foundations/feel/.gitignore
+++ b/dynawalla/foundations/feel/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/dynawalla/foundations/feel/README.md
+++ b/dynawalla/foundations/feel/README.md
@@ -1,0 +1,358 @@
+# `@dynawalla/feel` — the game-feel foundation
+
+The systematic layer every Dynawalla prototype sits on. A prototype author
+writes three lines and gets a tuned, coherent, seven-system response that is
+correct at 60 and 120 Hz, degrades gracefully on a weak device, and that a fast
+child can always interrupt.
+
+```ts
+import { feel } from "@dynawalla/feel"
+
+feel.attach({ camera, invoke })                        // once, at boot
+feel.start()                                           // once
+feel.answer({ correct, difficulty, repaired, milestone }, { subject: tile })
+```
+
+That third line fires haptics, hitstop, slow-motion, trauma shake, directional
+kick, punch-zoom, screen flash, squash-and-stretch, a pentatonic tone and a
+particle burst — at the tier the outcome earns, at the quality the device can
+hold. **75 tests, all green. Zero runtime dependencies in the core** (Three.js
+is used only by the demo).
+
+---
+
+## 1. The tiers and their budgets
+
+Three separate clocks, and only one of them may ever block.
+
+| | tier | verdict | **blocking** | tail | hitstop | trauma | kick | flash | time scale | particles | haptic |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| −1 | `nudge` wrong | 1 frame | **0** | 300 ms | 0 | 0.16 | 0.045 | 0.10 | 1.0 | 0 | warning |
+| 0 | `tick` a digit landed | 1 frame | **0** | 90 ms | 0 | 0.05 | 0.012 | — | 1.0 | 0 | light |
+| 1 | `snap` ordinary correct | 1 frame | **0** | 220 ms | 0 | 0.14 | 0.035 | 0.12 | 1.0 | 8 | light |
+| 2 | `pop` hard item correct | 1 frame | **0** | 400 ms | 40 ms | 0.30 | 0.075 | 0.24 | 1.0 | 22 | medium |
+| 3 | `slam` repaired a misconception | 1 frame | **0** | 700 ms | 75 ms | 0.46 | 0.13 | 0.36 | 0.72 → 1 over 180 ms | 48 | heavy |
+| 4 | `bloom` something completed | 1 frame | **0** | 1500 ms | 110 ms | 0.62 | 0.20 | 0.50 | 0.50 → 1 over 260 ms | 110 | success |
+| 5 | `ascend` once a session | 1 frame | 350 ms | 2800 ms | 160 ms | 0.85 | 0.30 | 0.70 | 0.32 → 1 over 420 ms | 200 | success |
+
+**`blockingMs` is the whole argument.** A *tail* is not a wait — it draws over
+the next problem, which presents concurrently. Only `ascend` refuses input at
+all, for 350 ms, and a tap skips even that. `tiers.test.ts` asserts
+`blockingMs === 0` for every other row, so the standard failure — gating the
+input handler on the celebration finishing, and thereby punishing the child who
+knows 7×8 — cannot be introduced without a test going red.
+
+Three rules that are asserted, not merely intended:
+
+- **Hitstop is only ever spent on success.** A freeze frame is a reward.
+  Spending one on a wrong answer slows the retry at the moment the loop must be
+  fastest. `nudge` gets a directional kick instead.
+- **`energy(nudge) < energy(snap)`** — being wrong is never the interesting
+  moment. Measured: 178 vs 1 484. The energy formula includes *kick*, because
+  without it a designer can satisfy the rule on every other axis and still make
+  failure the physically emphatic one.
+- **Escalation cannot see a streak.** `chooseTier` keys on difficulty, repair
+  and milestone. There is no `streak` field to smuggle one into, and a test
+  greps every non-test source file for the words. This is inherited from
+  MISSION.md and deliberately survives the visual-direction change: the juice
+  got much louder, the thing it is loud *about* did not move.
+
+Escalation is legible because the ladder is monotonic in every column, and each
+step is a real step: `bloom` is 636× `snap`'s energy, `ascend` is 6.3× `bloom`'s.
+
+---
+
+## 2. Measured — on this machine, by me, today
+
+**Node micro-bench** (`npm run bench`, M2 Max, Node 22.17):
+
+| | |
+|---|---|
+| whole feel layer, one frame (clock + 24 live tweens + rig + squash + camera write) | **849 ns** = 0.0051% of a 16.67 ms budget |
+| same, derated 8× for a mid-range tablet | **0.041%** of budget |
+| allocation per frame | **2.3 bytes** (noise; the design target is zero) |
+| allocation per tween start | **2.7 bytes** |
+| `interrupt()` with a **full 512-tween pool**, including refilling it | **23.6 µs**; 0.19 ms derated 8× — budget is 1 ms |
+| `Tweens.to2` + `settle` | **32.5 ns** (was 870 ns before the fix in §4) |
+| `Spring1D.update` | 25.7 ns critical / 42.1 ns under-damped |
+| `ease.outCubic` / `outBack` / `outElastic` | 8.2 / 9.2 / 66.5 ns |
+| coherent `noise1` vs `Math.random` | 14.8 vs 12.9 ns — **the correct one costs 1.9 ns more** |
+
+**Browser bench** (`npm run bench:frames`, headless Chrome on a real GPU —
+ANGLE Metal, *not* SwiftShader; 1024×768 @ dpr 2 = 2.05 MP):
+
+CPU time spent producing a frame, including the full Three.js render:
+
+| CPU throttle | idle | a reaction every 120 ms | 40-reaction storm |
+|---|---|---|---|
+| 1× | 0.30 ms p50 / 0.40 p95 | 0.30 / 0.40 | 0.30 / 0.40 |
+| 4× | 1.30 / 1.90 | 1.30 / 1.90 | 1.30 / 1.90 |
+| 6× | 1.35 / 2.05 | 1.30 / 2.05 | 1.30 / 2.00 |
+
+**Nothing ever exceeded the budget, and the storm costs the same as idle.**
+That is the pool doing its job: 40 simultaneous reactions do not allocate, do
+not grow the work set beyond the live-tween list, and do not trigger a GC.
+
+**Honesty about these numbers.** `Emulation.setCPUThrottlingRate` throttles the
+main thread only — the GPU stays an M2 Max. So the CPU column is meaningful and
+the *fill-rate* column does not exist. The DPR cap in §5 is justified by pixel
+count, not by a measurement I made. **The only thing that closes this gap is
+running `bench:frames` on a physical mid-range tablet**, which I did not have.
+
+**Screenshots** at `docs/shots/` — tablet and phone, at rest and mid-`snap`,
+`bloom` and `ascend`, captured at device pixel ratio.
+
+---
+
+## 3. The API
+
+```ts
+feel.answer(outcome, opts)    // choose the tier from the outcome, fire it
+feel.react("bloom", opts)     // fire a named tier
+feel.tap()                    // sugar for "tick"
+feel.press(payload)           // TOP OF EVERY INPUT HANDLER. interrupts, returns
+                              // false if it buffered instead of applying
+feel.takeBuffered<T>()        // the buffered input, once the gate opens
+feel.interrupt()              // everything to its END state, synchronously
+feel.hit(targets, x, y)       // fat-finger correction, nearest-centre
+feel.onEmit(fn)               // the kit decides particle count + timing,
+                              // the prototype owns the particle shape
+feel.onFrame(fn)              // one rAF loop for the whole app
+```
+
+`opts` is `{ dir?, at?, subject?, gain? }` — impact direction, normalised screen
+position, the thing to squash, and a per-call multiplier.
+
+Everything underneath is public and separately usable — `feel.rig`,
+`feel.tweens`, `feel.clock`, `feel.governor`, plus `Shake`, `Kick`, `Spring1D`,
+`Squash`, `Coyote`, `InputBuffer`, `ScreenFlash`, `FeelAudio`, `Haptics`, and
+the whole named easing library. A prototype that wants one specific thing should
+not have to fight the facade for it.
+
+### Input forgiveness, from the platformer canon
+
+Verified from Celeste's own source (`Source/Player/Player.cs`), not remembered:
+
+```cs
+private const float JumpGraceTime = 0.1f;      // coyote time, 100 ms
+private const int UpwardCornerCorrection = 4;  // 4 px of nudge
+private const int DashCornerCorrection = 4;
+```
+
+- **Coyote time → the deadline that just passed.** `Coyote(100)`. A tap 99 ms
+  after a timer expires was committed before the deadline; refusing it punishes
+  reaction time, which is not the skill under test.
+- **Input buffering → the tap during the flourish.** `InputBuffer(180)`. Longer
+  than a platformer's five frames because a child's follow-up tap is a
+  considered action, not a rhythm input. One slot, not a queue: mashing means
+  *go*, not *go three times*.
+- **Corner correction → fat-finger hit slop.** `nearestTarget(targets, x, y, 12)`.
+  The highest-value one here. A six-year-old's contact patch is ~10 mm and the
+  reported centroid sits low; a tap the child aimed at a button routinely lands
+  6–10 px below it. Implemented as *nearest centre within the slop radius*,
+  never as an enlarged hit box — enlarged boxes overlap and then two adjacent
+  answers both claim the tap.
+
+### Three time channels
+
+`real` (input, audio, shake — never stops) · `world` (hitstop zeroes it,
+slow-motion scales it) · `ui` (unscaled but pausable — the next problem
+presenting). A one-channel clock forces a choice between "the freeze frame feels
+good" and "the child never waits". This product needs both.
+
+---
+
+## 4. Traps — found by hitting them
+
+The most valuable thing in this document.
+
+**T-01 · Hitstop must be milliseconds, not frames.** The canon is written for
+fixed-60 engines (`Celeste.Freeze(.05f)` = 3 frames). We ship on 120 Hz iPad
+ProMotion and 90 Hz Androids, where a frame-counted hitstop is *half* the
+intended duration and reads as a dropped frame. Asserted: the same 50 ms
+hitstop is 3 frames at 60 Hz and 6 at 120, and identical in wall-clock.
+
+**T-02 · Spring impulses were wrong by ~250× and nothing could see it.** A tier
+asking for a 16% scale punch produced 3%; a tier asking for a 0.3-unit camera
+recoil produced 0.00125. An 18 Hz spring converts a unit of velocity impulse
+into ~0.004 units of displacement, so every hand-picked multiplier in the table
+was meaningless — and code review, types and unit tests all passed. Fixed with
+`Spring1D.impulseForPeak()`, derived from the analytic peak of the impulse
+response, so tier numbers are now **peak displacement in real units** and a
+designer can reason about them. This is the single most important bug I found.
+
+**T-03 · A pooled tween runtime can still be O(capacity).** Allocating with a
+rotating cursor and iterating to the high-water mark means that within a second
+of play every frame walks all 512 slots to find the two that are live. Measured
+870 ns → **32.5 ns** after switching to a dense active list with swap-removal.
+"We use a pool" sounds like it settles the performance question. It does not.
+
+**T-04 · `Math.random()` per frame is vibration, not shake.** Successive frames
+are uncorrelated so the camera teleports and the eye reads a rendering fault.
+Coherent value noise costs 1.9 ns more per sample. Asserted by comparing mean
+frame-to-frame delta.
+
+**T-05 · An overshoot ease over a small range does not overshoot.** `outBack`
+from 0.9 → 1.0 overshoots by 10% of 0.1 — invisible. The peak must be inside a
+tween's *range*, which is why the scripted `pop()` is three beats and not two.
+This is why hand-built scripted pops look limp.
+
+**T-06 · `camera.lookAt()` rebuilds rotation and erases roll.** Roll applied
+before `lookAt` silently vanishes. `applyTo` fixes the order so a prototype
+cannot get it wrong. (Same family as the repo's `setTarget()`-resets-radius
+note in the Babylon playbook.)
+
+**T-07 · Shake accumulated into `camera.position` drifts.** The follow logic
+reads back the shaken position and follows *that*. The fix is structural: the
+game writes `rig.base`, the rig owns the camera, nothing ever reads the camera
+transform back. There is no path by which an offset can accumulate.
+
+**T-08 · `navigator.vibrate` — two separate traps.** It does not exist at all in
+iOS WKWebView (so a WebView-only haptics implementation works on desktop Chrome
+and ships silent on every iPhone — use `tauri-plugin-haptics`); and in Chrome it
+is **blocked until the frame has been tapped**, logging a console error on every
+call before then. Found by reading the screenshot run's console. Both gated now.
+
+**T-09 · Headless Chrome's rAF delta is not frame time.** My first browser bench
+reported `p50 8.30 ms` — identical to two decimals across 27 configurations,
+idle and under a 40-reaction storm, at 1× and 6× CPU throttle. It is a virtual
+cadence. Measure the *work* done inside the frame callback instead; that number
+responds to throttling and can carry a budget.
+
+**T-10 · `renderer.setSize(w, h, false)` breaks the canvas layout.** With
+`updateStyle: false` the canvas keeps its intrinsic size — `width × dpr` CSS
+pixels — so at dpr 2 it lays out at twice the viewport and the page shows the
+top-left quadrant of the render. It looks exactly like a broken camera. Cost
+this build one screenshot round.
+
+**T-11 · `performance.now()` is coarsened to 100 µs.** Every browser number
+above is a multiple of 0.1 ms because Chrome clamps the timer for Spectre
+mitigation unless the page is cross-origin isolated (COOP/COEP). Sub-100 µs
+work is not measurable in a WebView; measure in aggregate over many frames.
+
+**T-12 · Headless WebGL is SwiftShader unless you ask for a GPU.** Without
+`--enable-gpu --use-angle=metal`, every fill-rate number is software-rasterised
+fiction. `bench/frames.mjs` reads `WEBGL_debug_renderer_info` and says so.
+
+**T-13 · `gl_PointSize` is in device pixels.** A first pass used a `300.0`
+distance divisor and every particle rendered ~400 px across; the burst was one
+white disc covering a third of the screen and read as a bug rather than as
+juice. Visible only in a screenshot — no test would have caught it.
+
+**T-14 · `AudioContext` starts suspended and iOS never auto-resumes it.**
+`resume()` only succeeds inside a user-gesture task, and after a phone call or
+backgrounding the context stays suspended — audio dies permanently and the bug
+report is "sound stopped working yesterday". Gated on first gesture plus a
+`visibilitychange` re-resume. Never `await` audio on the answer path.
+
+**T-15 · Haptics cross the IPC bridge, so they land late.** Touch is more
+latency-sensitive than vision; a haptic 40 ms after the flash reads as a second
+unrelated event. `react()` dispatches haptics as its *first* statement, before
+any visual work is queued, and never awaits. iOS also coalesces generators
+firing under ~40 ms apart into mush, so a minimum interval is enforced in the
+kit rather than in every prototype.
+
+---
+
+## 5. The budget the kit enforces, and the degradation path
+
+**Budget: the feel layer gets ≤ 1.0 ms of a 16.67 ms frame on the reference
+device.** Measured 0.0008 ms on an M2 Max, 0.041% of budget derated 8×. The
+headroom is deliberate — it belongs to the renderer and to whatever the
+prototype is actually doing.
+
+Sub-budgets the kit holds itself to:
+
+- `interrupt()` ≤ **1 ms** worst case with a full pool. Measured 0.19 ms derated.
+- **0 bytes** allocated per frame and per reaction.
+- Verdict visible in **1 frame**, always, on every tier.
+- Blocking input: **0 ms** on every tier but `ascend`.
+
+**Four quality tiers, chosen twice** — once at boot from device signals, then
+continuously by a governor watching p95 frame time.
+
+| | dpr cap | particles | motion | post FX | bloom | shadows | tween pool |
+|---|---|---|---|---|---|---|---|
+| `low` | 1.0 | ×0.3 | ×0.8 | off | off | none | 96 |
+| `medium` | 1.5 | ×0.6 | ×1.0 | on | off | 512 | 192 |
+| `high` | 2.0 | ×1.0 | ×1.0 | on | on | 1024 | 320 |
+| `ultra` | 2.5 | ×1.6 | ×1.1 | on | on | 2048 | 512 |
+
+- **Boot detection is pessimistic.** `deviceMemory` is Chromium-only and clamped
+  to 8; `hardwareConcurrency` on an iPad counts efficiency cores; the GPU string
+  is masked in Safari. Every signal is missing, lying, or both — so the
+  *minimum* suggested tier wins and the governor promotes upward once frames
+  prove it. Starting low and promoting is invisible; starting high and demoting
+  is a visible stutter in the first ten seconds, which is exactly when a child
+  decides what they think.
+- **The governor has hysteresis** — 2 s of sustained overrun to demote, 8 s of
+  headroom to promote — or it oscillates at the boundary, and tier changes are
+  visible. A single stutter never demotes; a clamped stall frame (tab switch,
+  notification) is discarded rather than blamed on the renderer.
+- **Every tier draws every effect.** A `low` device gets the same *language* at
+  a smaller budget. Turning effects off by tier is how you ship two products.
+- **`prefers-reduced-motion` is a branch, not a degradation.** Motion goes to
+  zero; the flash stays (light is not motion) as a slower, gentler wash; audio
+  and haptics are untouched. A child who needs reduced motion still gets the
+  whole response.
+
+The **DPR cap is the biggest single lever** — an uncapped dpr 3 is 9× the
+fragment work of dpr 1, for a difference nobody can see at arm's length on a
+60 px glyph.
+
+---
+
+## 6. A note the founder should see
+
+The program docs already in `dynawalla/docs/` describe a *different* product
+from the one my brief describes, and the difference is not cosmetic:
+
+- `ADR-0004` — "no 3D renderer in V1"; `EXPERIENCE_DESIGN.md` — "2D throughout".
+  My brief says **Three.js, founder decision**, "take the cap off the quality".
+- `EXPERIENCE_DESIGN.md` — "Juice dose is a hard ceiling", "feedback must be
+  contingent, not loud". My brief says **"juice first"**, "warmth and spectacle
+  over restraint", and names the restrained build's review: *"as fun as a public
+  school teacher crashing out."*
+- The existing `dynawalla-app/src/reactions/` implements the restrained
+  direction well — it is the "beautifully made instrument" that got that review.
+
+I built to the brief, on the assumption the pivot is real and the docs are
+stale. **Those two documents need updating or this kit contradicts them.** What
+I deliberately *kept* from the old direction, because it is ethics rather than
+art direction and is recorded in MISSION.md: no escalation on streaks, and
+being wrong is never more interesting than being right. Both are asserted.
+
+---
+
+## 7. Running it
+
+```bash
+npm install
+npm test                  # 75 tests
+npm run tsc               # typecheck
+npm run bench             # CPU + allocation (add --expose-gc for memory)
+npm run dev               # the demo at 127.0.0.1:5177
+npm run build && npx vite preview
+node bench/frames.mjs     # browser frame-work bench at 1x/4x/6x CPU
+node bench/shot.mjs       # regenerate docs/shots/
+```
+
+## 8. Files
+
+| | |
+|---|---|
+| `src/feel.ts` | the facade — the three lines a prototype writes |
+| `src/tiers.ts` | **the table**: tiers, budgets, the escalation rule |
+| `src/clock.ts` | one rAF loop, three time channels, hitstop, slow-motion |
+| `src/spring.ts` | exact exponential integrator; `impulseForPeak` (T-02) |
+| `src/shake.ts` | trauma shake (Eiserloh) + directional `Kick` |
+| `src/tween.ts` | pooled, zero-alloc, fast-forwardable, generation-checked |
+| `src/ease.ts` | every Penner curve by name + `spike`, `cubicBezier`, `spring` |
+| `src/camera.ts` | compose-never-accumulate rig; 3D and CSS output |
+| `src/squash.ts` | volume-conserving squash, anticipation, follow-through |
+| `src/input.ts` | coyote time, input buffer, hit slop, the touch CSS |
+| `src/quality.ts` | tiers + the hysteretic governor |
+| `src/flash.ts` | DOM-composited screen flash (cheaper than a GL pass) |
+| `src/audio.ts` | asset-free Web Audio, gesture-gated, pentatonic |
+| `src/haptics.ts` | plugin → vibrate → noop, coalesced, fired first |
+| `demo/main.ts` | the reference prototype **and** the measurement probe |

--- a/dynawalla/foundations/feel/bench/cpu.mjs
+++ b/dynawalla/foundations/feel/bench/cpu.mjs
@@ -1,0 +1,233 @@
+// What the kit costs, measured.
+//
+//   node --expose-gc --experimental-strip-types bench/cpu.mjs
+//
+// Two things are measured, and the second matters more than the first.
+//
+//   TIME    per-frame CPU of the whole feel layer with everything running.
+//   MEMORY  bytes allocated per frame and per reaction. A juice layer that
+//           allocates is a juice layer that stutters *when you use it*, because
+//           the minor GC lands right after the allocation, which is right after
+//           the child tapped. On a mid-range Android WebView a minor GC is
+//           2–6 ms — a dropped frame, at the worst possible moment.
+//
+// This is a developer-machine number. The derate factor for the reference
+// mid-range tablet is applied in the report and stated in README.md; it is an
+// estimate, not a measurement, and the only honest way to close it is to run
+// bench/frames.mjs on the device.
+
+import { FeelClock } from "../src/clock.ts"
+import { Tweens, CH_WORLD, CH_UI, CH_REAL } from "../src/tween.ts"
+import { CameraRig } from "../src/camera.ts"
+import { Squash } from "../src/squash.ts"
+import { Shake, noise1 } from "../src/shake.ts"
+import { Spring1D } from "../src/spring.ts"
+import { EASE } from "../src/ease.ts"
+import { TIERS } from "../src/tiers.ts"
+
+const gc = globalThis.gc
+if (!gc) {
+  console.error("run with --expose-gc for the memory numbers")
+}
+
+const fmt = (n, d = 3) => n.toFixed(d).padStart(9)
+
+function timeIt(label, iterations, fn, unit = "op") {
+  fn() // warm
+  fn()
+  gc?.()
+  const t0 = process.hrtime.bigint()
+  for (let i = 0; i < iterations; i++) fn()
+  const t1 = process.hrtime.bigint()
+  const ns = Number(t1 - t0) / iterations
+  console.log(`  ${label.padEnd(46)} ${fmt(ns, 1)} ns/${unit}`)
+  return ns
+}
+
+function allocIt(label, iterations, fn) {
+  for (let i = 0; i < 200; i++) fn() // warm + let hidden classes settle
+  gc?.()
+  gc?.()
+  const before = process.memoryUsage().heapUsed
+  for (let i = 0; i < iterations; i++) fn()
+  const after = process.memoryUsage().heapUsed
+  const bytes = (after - before) / iterations
+  console.log(`  ${label.padEnd(46)} ${fmt(bytes, 2)} bytes/op`)
+  return bytes
+}
+
+console.log("\n=== easing curves (allocation-free, pure) ===")
+{
+  let acc = 0
+  let i = 0
+  timeIt("ease.outCubic", 5e6, () => {
+    acc += EASE.outCubic((i++ % 100) / 100)
+  })
+  i = 0
+  timeIt("ease.outBack", 5e6, () => {
+    acc += EASE.outBack((i++ % 100) / 100)
+  })
+  i = 0
+  timeIt("ease.outElastic (2 transcendentals)", 5e6, () => {
+    acc += EASE.outElastic((i++ % 100) / 100)
+  })
+  if (acc === Infinity) console.log("unreachable")
+}
+
+console.log("\n=== noise vs Math.random ===")
+{
+  let acc = 0
+  let i = 0
+  timeIt("noise1 (coherent, what shake uses)", 5e6, () => {
+    acc += noise1(i++ * 0.01, 7)
+  })
+  timeIt("Math.random (incoherent, the wrong one)", 5e6, () => {
+    acc += Math.random()
+  })
+  if (acc === Infinity) console.log("unreachable")
+}
+
+console.log("\n=== spring step (exact exponential integrator) ===")
+{
+  const crit = new Spring1D(12, 1)
+  const under = new Spring1D(12, 0.45)
+  crit.impulse(1)
+  under.impulse(1)
+  timeIt("Spring1D.update critically damped", 5e6, () => {
+    crit.impulse(1e-9)
+    crit.update(16.67)
+  })
+  timeIt("Spring1D.update under-damped", 5e6, () => {
+    under.impulse(1e-9)
+    under.update(16.67)
+  })
+}
+
+console.log("\n=== tween pool ===")
+{
+  const tw = new Tweens(512)
+  const o = { v: 0 }
+  timeIt("Tweens.to2 start + immediate settle", 2e6, () => {
+    tw.to2(o, "v", 0, 1, 200, "outBack")
+    tw.settle()
+  })
+  allocIt("Tweens.to2 start (the GC question)", 2e5, () => {
+    tw.to2(o, "v", 0, 1, 200, "outBack")
+    tw.settle()
+  })
+
+  // A realistic mid-flourish load: 64 live tweens being stepped.
+  const tw2 = new Tweens(512)
+  const objs = Array.from({ length: 64 }, () => ({ v: 0 }))
+  for (const ob of objs) tw2.to2(ob, "v", 0, 1, 1e9, "outCubic")
+  timeIt("Tweens.update with 64 live tweens", 2e5, () => {
+    tw2.update(CH_WORLD, 16.67)
+  })
+
+}
+
+console.log("\n=== a whole frame of the feel layer ===")
+{
+  const clock = new FeelClock({ now: () => 0, raf: () => 0, cancelRaf: () => {} })
+  const tweens = new Tweens(320)
+  const rig = new CameraRig({ baseFov: 50 })
+  const squash = new Squash()
+  const camera = {
+    position: { x: 0, y: 0, z: 0 },
+    rotation: { z: 0 },
+    fov: 50,
+    lookAt() {},
+    updateProjectionMatrix() {},
+  }
+  const subject = { scale: { x: 1, y: 1, z: 1 } }
+
+  // Load it up the way a `bloom` does: shake, kick, fov punch, squash, and a
+  // realistic 24 concurrent tweens.
+  const load = () => {
+    rig.impact(0.62, 0.2, 0, -1, 0)
+    rig.punchFov(-4)
+    squash.punch(0.55)
+    for (let i = 0; i < 24; i++) tweens.to2(subject.scale, "x", 1, 1.2, 600, "outElastic")
+  }
+  load()
+
+  clock.onTick((t) => {
+    tweens.update(CH_WORLD, t.dtWorld)
+    tweens.update(CH_UI, t.dtUi)
+    tweens.update(CH_REAL, t.dtReal)
+    rig.update(t.dtReal)
+    squash.update(t.dtReal)
+    squash.applyTo(subject)
+    rig.applyTo(camera)
+  })
+
+  let n = 0
+  const ns = timeIt(
+    "full frame: clock + 24 tweens + rig + squash",
+    5e5,
+    () => {
+      if (++n % 200 === 0) load()
+      clock.step(16.67)
+    },
+    "frame",
+  )
+  console.log(`  ${"".padEnd(46)} ${fmt(ns / 1e6, 5)} ms/frame`)
+  console.log(
+    `  ${"as % of a 16.67 ms frame budget".padEnd(46)} ${fmt((ns / 1e6 / 16.67) * 100, 3)} %`,
+  )
+  console.log(
+    `  ${"same, derated 8x for a mid-range tablet".padEnd(46)} ${fmt((ns / 1e6 / 16.67) * 800, 3)} %`,
+  )
+
+  n = 0
+  allocIt("full frame allocation", 3e5, () => {
+    if (++n % 200 === 0) load()
+    clock.step(16.67)
+  })
+}
+
+console.log("\n=== interrupt(): the fast-child path ===")
+{
+  const tweens = new Tweens(512)
+  const rig = new CameraRig()
+  const squash = new Squash()
+  const clock = new FeelClock({ now: () => 0, raf: () => 0, cancelRaf: () => {} })
+  const o = { v: 0 }
+
+  const fill = () => {
+    for (let i = 0; i < 512; i++) tweens.to2(o, "v", 0, 1, 5000, "outElastic")
+    rig.impact(0.85, 0.3, 0, -1, 0)
+    squash.punch(0.75)
+    clock.hitstop(160)
+    clock.slowmo(0.32, 420)
+  }
+
+  const ns = timeIt(
+    "interrupt with a FULL 512-tween pool",
+    2e5,
+    () => {
+      fill()
+      clock.settleNow()
+      tweens.settle()
+      rig.settle()
+      squash.settle()
+    },
+    "interrupt",
+  )
+  console.log(`  ${"".padEnd(46)} ${fmt(ns / 1e6, 5)} ms (incl. refilling the pool)`)
+  console.log(`  ${"derated 8x".padEnd(46)} ${fmt((ns / 1e6) * 8, 5)} ms — budget is 1.00 ms`)
+}
+
+console.log("\n=== tier table sanity (energy ladder, measured) ===")
+{
+  const { energy } = await import("../src/tiers.ts")
+  for (const name of ["nudge", "tick", "snap", "pop", "slam", "bloom", "ascend"]) {
+    const t = TIERS[name]
+    console.log(
+      `  ${name.padEnd(8)} tail ${String(t.tailMs).padStart(5)}ms  block ${String(t.blockingMs).padStart(4)}ms` +
+        `  hitstop ${String(t.hitstopMs).padStart(4)}ms  energy ${fmt(energy(t), 0)}`,
+    )
+  }
+}
+
+console.log("")

--- a/dynawalla/foundations/feel/bench/frames.mjs
+++ b/dynawalla/foundations/feel/bench/frames.mjs
@@ -1,0 +1,210 @@
+// Frame-time measurement in a real browser, at real quality tiers, with real
+// CPU throttling.
+//
+//   npx vite preview          # in another shell
+//   node bench/frames.mjs
+//
+// Why this exists and `bench/cpu.mjs` is not enough: the CPU bench measures the
+// kit's own arithmetic, which is a rounding error. What actually decides
+// whether a prototype holds 60 fps is the *render* — draw calls, fill rate,
+// pixel ratio, blend passes — and the only honest way to see that is to render.
+//
+// ## The developer-machine problem, and what is done about it
+//
+// This runs on whatever machine you have, and the brief's constraint is a
+// mid-range tablet. `Emulation.setCPUThrottlingRate` is the closest available
+// approximation: it throttles the main thread by an integer factor. It does
+// **not** throttle the GPU, so a throttled run models a slow CPU with a fast
+// GPU — which flatters us on fill rate and is honest about JavaScript. Both
+// numbers are reported and the gap is stated rather than hidden.
+//
+// ## The headless WebGL trap
+//
+// Headless Chrome without a GPU flag renders WebGL through SwiftShader — a
+// software rasteriser — and every fill-rate number it produces is fiction,
+// usually 10–50× too slow. The bench reads `WEBGL_debug_renderer_info` and
+// refuses to report GPU numbers if it sees SwiftShader. This cost a real
+// measurement round to discover.
+
+import { spawn } from "node:child_process"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+const URL_ = process.env.DW_URL ?? "http://127.0.0.1:4173/"
+const PORT = Number(process.env.DW_CDP_PORT ?? 9444)
+const CHROME =
+  process.env.CHROME_PATH ?? "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+
+const profile = mkdtempSync(path.join(tmpdir(), "dw-feel-"))
+const chrome = spawn(
+  CHROME,
+  [
+    "--headless=new",
+    `--remote-debugging-port=${String(PORT)}`,
+    `--user-data-dir=${profile}`,
+    "--no-first-run",
+    "--disable-extensions",
+    "--hide-scrollbars",
+    "--mute-audio",
+    "--window-size=1024,768",
+    // Without these three, headless falls back to SwiftShader and every GPU
+    // number below is fiction.
+    "--enable-gpu",
+    "--use-angle=metal",
+    "--enable-unsafe-swiftshader",
+  ],
+  { stdio: "ignore" },
+)
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+async function endpoint() {
+  for (let i = 0; i < 80; i++) {
+    try {
+      const list = await fetch(`http://127.0.0.1:${String(PORT)}/json/list`).then((r) => r.json())
+      const page = list.find((t) => t.type === "page")
+      if (page) return page.webSocketDebuggerUrl
+    } catch {
+      /* not up */
+    }
+    await sleep(150)
+  }
+  throw new Error("chrome never exposed a debugging endpoint")
+}
+
+let ws
+let msgId = 0
+const pending = new Map()
+
+function send(method, params = {}) {
+  const id = ++msgId
+  ws.send(JSON.stringify({ id, method, params }))
+  return new Promise((res, rej) => pending.set(id, { res, rej }))
+}
+
+async function evalJs(expression) {
+  const r = await send("Runtime.evaluate", {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+  })
+  if (r.exceptionDetails) throw new Error(JSON.stringify(r.exceptionDetails.exception?.description))
+  return r.result?.value
+}
+
+// Frame WORK, not rAF delta. See the header of the probe in demo/main.ts.
+function row(label, w) {
+  const flag = w.p95 > 16.7 ? "   OVER BUDGET" : w.p95 > 8 ? "   tight" : ""
+  console.log(
+    `  ${label.padEnd(32)} work p50 ${w.p50.toFixed(2).padStart(6)}  p95 ${w.p95.toFixed(2).padStart(6)}` +
+      `  p99 ${w.p99.toFixed(2).padStart(6)}  worst ${w.worst.toFixed(2).padStart(6)} ms${flag}`,
+  )
+}
+
+try {
+  const url = await endpoint()
+  const { WebSocket } = await import("node:worker_threads").then(() => globalThis)
+  ws = new WebSocket(url)
+  ws.addEventListener("message", (ev) => {
+    const m = JSON.parse(ev.data)
+    if (m.id && pending.has(m.id)) {
+      const { res, rej } = pending.get(m.id)
+      pending.delete(m.id)
+      if (m.error) rej(new Error(m.error.message))
+      else res(m.result)
+    }
+  })
+  await new Promise((r) => ws.addEventListener("open", r, { once: true }))
+
+  await send("Page.enable")
+  await send("Runtime.enable")
+  await send("Emulation.setDeviceMetricsOverride", {
+    width: 1024,
+    height: 768,
+    deviceScaleFactor: 2,
+    mobile: true,
+  })
+  await send("Page.navigate", { url: URL_ })
+
+  for (let i = 0; i < 80; i++) {
+    const ready = await evalJs("!!window.__dwFeelReady").catch(() => false)
+    if (ready) break
+    await sleep(200)
+  }
+
+  const gpu = await evalJs(`(() => {
+    const c = document.querySelector('canvas');
+    const gl = c && (c.getContext('webgl2') || c.getContext('webgl'));
+    if (!gl) return 'no webgl';
+    const e = gl.getExtension('WEBGL_debug_renderer_info');
+    return e ? gl.getParameter(e.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER);
+  })()`)
+  const software = /swiftshader|llvmpipe|software/i.test(String(gpu))
+  console.log(`\nGPU: ${String(gpu)}${software ? "   *** SOFTWARE — fill-rate numbers are fiction ***" : ""}`)
+  console.log(`viewport 1024x768 @ dpr 2  (2.05 MP after the kit's dpr cap)\n`)
+
+  await sleep(1200) // let the first-frame shader compiles settle
+
+  for (const throttle of [1, 4, 6]) {
+    await send("Emulation.setCPUThrottlingRate", { rate: throttle })
+    console.log(
+      throttle === 1
+        ? "--- CPU 1x (this machine: M2 Max) ---"
+        : `--- CPU ${String(throttle)}x throttled (approximating a mid-range tablet CPU; GPU is NOT throttled) ---`,
+    )
+
+    for (const tier of ["low", "medium", "high", "ultra"]) {
+      await evalJs(`window.__dwProbe.setQuality(${JSON.stringify(tier)})`)
+      await sleep(500)
+
+      // Idle.
+      await evalJs("window.__dwProbe.record(2000)")
+      row(`${tier} idle`, await evalJs("window.__dwProbe.workStats()"))
+
+      // Under continuous load: a reaction every ~120 ms, which is far denser
+      // than a child can produce and is the point — the floor must hold under
+      // abuse, not under the happy path.
+      await evalJs(`(async () => {
+        const p = window.__dwProbe.record(3000);
+        const iv = setInterval(() => window.__dwProbe.fire(['snap','pop','slam','bloom'][Math.floor(Math.random()*4)]), 120);
+        await p; clearInterval(iv);
+      })()`)
+      row(`${tier} reaction every 120ms`, await evalJs("window.__dwProbe.workStats()"))
+    }
+
+    // The worst case the kit can be asked for: 40 simultaneous reactions.
+    await evalJs(`window.__dwProbe.setQuality("ultra")`)
+    await sleep(300)
+    await evalJs(`(async () => {
+      const p = window.__dwProbe.record(2500);
+      setTimeout(() => window.__dwProbe.storm(40), 250);
+      await p;
+    })()`)
+    row("ultra 40-reaction storm", await evalJs("window.__dwProbe.workStats()"))
+    console.log("")
+  }
+
+  await send("Emulation.setCPUThrottlingRate", { rate: 1 })
+
+  const diag = await evalJs(`({
+    overflows: window.__dwProbe ? 0 : 0,
+    dpr: window.devicePixelRatio,
+    cores: navigator.hardwareConcurrency,
+    mem: navigator.deviceMemory ?? null,
+  })`)
+  console.log("device signals seen by boot detection:", JSON.stringify(diag))
+} finally {
+  try {
+    ws?.close()
+  } catch {
+    /* ignore */
+  }
+  chrome.kill()
+  await sleep(300)
+  try {
+    rmSync(profile, { recursive: true, force: true, maxRetries: 5 })
+  } catch {
+    /* chrome is still flushing its profile; harmless */
+  }
+}

--- a/dynawalla/foundations/feel/bench/shot.mjs
+++ b/dynawalla/foundations/feel/bench/shot.mjs
@@ -1,0 +1,138 @@
+// Capture the demo at rest and mid-reaction, at device pixel ratio.
+//
+//   npx vite preview && node bench/shot.mjs [outdir]
+//
+// Code review cannot see that a scene looks wrong. The repo's own experience
+// doc says as much and the program gates on committed images rather than on
+// diffs. These are those images.
+
+import { spawn } from "node:child_process"
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+const URL_ = process.env.DW_URL ?? "http://127.0.0.1:4173/"
+const OUT = process.argv[2] ?? "docs/shots"
+const PORT = Number(process.env.DW_CDP_PORT ?? 9445)
+const CHROME =
+  process.env.CHROME_PATH ?? "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+
+mkdirSync(OUT, { recursive: true })
+const profile = mkdtempSync(path.join(tmpdir(), "dw-shot-"))
+const chrome = spawn(
+  CHROME,
+  [
+    "--headless=new",
+    `--remote-debugging-port=${String(PORT)}`,
+    `--user-data-dir=${profile}`,
+    "--no-first-run",
+    "--disable-extensions",
+    "--hide-scrollbars",
+    "--mute-audio",
+    "--enable-gpu",
+    "--use-angle=metal",
+    "--window-size=1024,768",
+  ],
+  { stdio: "ignore" },
+)
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+let ws
+let msgId = 0
+const pending = new Map()
+const send = (method, params = {}) => {
+  const id = ++msgId
+  ws.send(JSON.stringify({ id, method, params }))
+  return new Promise((res, rej) => pending.set(id, { res, rej }))
+}
+const evalJs = async (e) => {
+  const r = await send("Runtime.evaluate", { expression: e, awaitPromise: true, returnByValue: true })
+  return r.result?.value
+}
+
+try {
+  let wsUrl
+  for (let i = 0; i < 80 && !wsUrl; i++) {
+    try {
+      const list = await fetch(`http://127.0.0.1:${String(PORT)}/json/list`).then((r) => r.json())
+      wsUrl = list.find((t) => t.type === "page")?.webSocketDebuggerUrl
+    } catch {
+      /* not up */
+    }
+    if (!wsUrl) await sleep(150)
+  }
+  ws = new WebSocket(wsUrl)
+  ws.addEventListener("message", (ev) => {
+    const m = JSON.parse(ev.data)
+    if (m.id && pending.has(m.id)) {
+      const { res, rej } = pending.get(m.id)
+      pending.delete(m.id)
+      if (m.error) rej(new Error(m.error.message))
+      else res(m.result)
+    }
+  })
+  await new Promise((r) => ws.addEventListener("open", r, { once: true }))
+  await send("Page.enable")
+  await send("Runtime.enable")
+  await send("Log.enable")
+
+  const errors = []
+  ws.addEventListener("message", (ev) => {
+    const m = JSON.parse(ev.data)
+    if (m.method === "Log.entryAdded" && m.params.entry.level === "error") {
+      errors.push(m.params.entry.text)
+    }
+  })
+
+  const shots = [
+    { name: "01-tablet-rest", w: 1024, h: 768, dpr: 2, after: null, wait: 1500 },
+    { name: "02-tablet-snap", w: 1024, h: 768, dpr: 2, after: "snap", wait: 90 },
+    { name: "03-tablet-bloom", w: 1024, h: 768, dpr: 2, after: "bloom", wait: 260 },
+    { name: "04-tablet-ascend", w: 1024, h: 768, dpr: 2, after: "ascend", wait: 420 },
+    { name: "05-phone-rest", w: 390, h: 844, dpr: 3, after: null, wait: 900 },
+    { name: "06-phone-pop", w: 390, h: 844, dpr: 3, after: "pop", wait: 120 },
+  ]
+
+  for (const s of shots) {
+    await send("Emulation.setDeviceMetricsOverride", {
+      width: s.w,
+      height: s.h,
+      deviceScaleFactor: s.dpr,
+      mobile: true,
+    })
+    await send("Page.navigate", { url: URL_ })
+    for (let i = 0; i < 60; i++) {
+      if (await evalJs("!!window.__dwFeelReady")) break
+      await sleep(150)
+    }
+    await sleep(1200)
+    if (s.after) {
+      await evalJs(`window.__dwProbe.fire(${JSON.stringify(s.after)})`)
+      await sleep(s.wait)
+    }
+    const { data } = await send("Page.captureScreenshot", { format: "png", fromSurface: true })
+    const file = path.join(OUT, `${s.name}.png`)
+    writeFileSync(file, Buffer.from(data, "base64"))
+    console.log(`${file}  ${String(s.w)}x${String(s.h)} @${String(s.dpr)}x`)
+  }
+
+  if (errors.length) {
+    console.log("\nCONSOLE ERRORS:")
+    for (const e of errors) console.log("  " + e)
+  } else {
+    console.log("\nno console errors")
+  }
+} finally {
+  try {
+    ws?.close()
+  } catch {
+    /* ignore */
+  }
+  chrome.kill()
+  await sleep(300)
+  try {
+    rmSync(profile, { recursive: true, force: true, maxRetries: 5 })
+  } catch {
+    /* harmless */
+  }
+}

--- a/dynawalla/foundations/feel/demo/main.ts
+++ b/dynawalla/foundations/feel/demo/main.ts
@@ -1,0 +1,731 @@
+// The reference prototype.
+//
+// A vertical slice of a Dynawalla game built on the feel kit and nothing else:
+// a question, three answer tiles, a lamp that fills. Every response in it comes
+// from `feel.answer(...)` — one call — and the point of the demo is that a
+// prototype author writes the maths and the tiles, and the feel is already
+// correct.
+//
+// It is also the measurement rig: `window.__dwProbe` exposes frame-time
+// sampling and a scripted drive so `bench/frames.mjs` can measure the real
+// thing in a real browser at real quality tiers instead of guessing.
+//
+// Everything is procedural. No textures are fetched, no fonts are loaded, no
+// models are downloaded — partly because this must run offline in a WebView,
+// and partly because "no third-party assets we lack rights to ship" is a
+// standing constraint and a foundation that quietly depends on a CDN is not a
+// foundation.
+
+import * as THREE from "three"
+import { feel } from "../src/feel.ts"
+import { TIERS, type TierName } from "../src/tiers.ts"
+import { CH_UI } from "../src/tween.ts"
+import { EASE } from "../src/ease.ts"
+
+/* ------------------------------------------------------------------ scene */
+
+const renderer = new THREE.WebGLRenderer({
+  antialias: true,
+  powerPreference: "high-performance",
+  // `alpha: false` is not cosmetic: an opaque canvas lets the compositor skip
+  // blending the whole surface every frame. On a mid-range tablet that is
+  // measurable and it costs nothing to ask for.
+  alpha: false,
+})
+renderer.setClearColor(0x07060d, 1)
+renderer.outputColorSpace = THREE.SRGBColorSpace
+renderer.toneMapping = THREE.ACESFilmicToneMapping
+renderer.toneMappingExposure = 1.15
+document.body.appendChild(renderer.domElement)
+
+const scene = new THREE.Scene()
+scene.fog = new THREE.FogExp2(0x0a0714, 0.038)
+
+const camera = new THREE.PerspectiveCamera(50, 1, 0.1, 200)
+
+// The rig owns the camera from here. Nothing else writes camera.position —
+// see the header of `camera.ts` for the drift bug that rule prevents.
+feel.rig.base.x = 0
+feel.rig.base.y = 2.15
+feel.rig.base.z = 8.4
+feel.rig.aim.x = 0
+feel.rig.aim.y = 1.5
+feel.rig.aim.z = 0
+
+/* ------------------------------------------------------------- procedural */
+
+/** A radial-gradient sprite, drawn once. Used for every glow in the scene. */
+function glowTexture(inner: string, outer: string): THREE.Texture {
+  const c = document.createElement("canvas")
+  c.width = c.height = 128
+  const g = c.getContext("2d")!
+  const grad = g.createRadialGradient(64, 64, 0, 64, 64, 64)
+  grad.addColorStop(0, inner)
+  grad.addColorStop(0.35, outer)
+  grad.addColorStop(1, "rgba(0,0,0,0)")
+  g.fillStyle = grad
+  g.fillRect(0, 0, 128, 128)
+  const t = new THREE.CanvasTexture(c)
+  t.colorSpace = THREE.SRGBColorSpace
+  return t
+}
+
+/**
+ * The floor: an eight-point girih star tiling drawn to a canvas.
+ *
+ * Anisotropy and mipmaps are set explicitly. The repo's playbook records a
+ * shimmering-ground bug that cost real time and resolved to exactly this — a
+ * tiled texture viewed at a grazing angle aliases violently without both.
+ */
+function floorTexture(): THREE.Texture {
+  const S = 512
+  const c = document.createElement("canvas")
+  c.width = c.height = S
+  const g = c.getContext("2d")!
+  g.fillStyle = "#120d1c"
+  g.fillRect(0, 0, S, S)
+
+  const star = (cx: number, cy: number, r: number, rot: number) => {
+    g.beginPath()
+    for (let i = 0; i < 16; i++) {
+      const rr = i % 2 === 0 ? r : r * 0.44
+      const a = rot + (i * Math.PI) / 8
+      const x = cx + Math.cos(a) * rr
+      const y = cy + Math.sin(a) * rr
+      if (i === 0) g.moveTo(x, y)
+      else g.lineTo(x, y)
+    }
+    g.closePath()
+    g.stroke()
+  }
+
+  g.strokeStyle = "#3a2c50"
+  g.lineWidth = 2.5
+  for (let y = 0; y <= 2; y++) {
+    for (let x = 0; x <= 2; x++) {
+      star((x * S) / 2, (y * S) / 2, S * 0.19, Math.PI / 8)
+    }
+  }
+  g.strokeStyle = "#6b4a2e"
+  g.lineWidth = 1.2
+  for (let y = 0; y < 2; y++) {
+    for (let x = 0; x < 2; x++) {
+      star((x * S) / 2 + S / 4, (y * S) / 2 + S / 4, S * 0.11, 0)
+    }
+  }
+
+  const t = new THREE.CanvasTexture(c)
+  t.wrapS = t.wrapT = THREE.RepeatWrapping
+  t.repeat.set(9, 9)
+  t.colorSpace = THREE.SRGBColorSpace
+  t.generateMipmaps = true
+  t.minFilter = THREE.LinearMipmapLinearFilter
+  t.anisotropy = Math.min(16, renderer.capabilities.getMaxAnisotropy())
+  return t
+}
+
+/** A number, drawn to a canvas. Kept in a cache so tiles never re-rasterise. */
+const glyphCache = new Map<string, THREE.Texture>()
+function glyphTexture(text: string): THREE.Texture {
+  const hit = glyphCache.get(text)
+  if (hit) return hit
+  const c = document.createElement("canvas")
+  c.width = 256
+  c.height = 256
+  const g = c.getContext("2d")!
+  g.clearRect(0, 0, 256, 256)
+  g.font = "300 132px ui-serif, Georgia, serif"
+  g.textAlign = "center"
+  g.textBaseline = "middle"
+  g.fillStyle = "#ffe9c4"
+  g.shadowColor = "#ffb35a"
+  g.shadowBlur = 26
+  g.fillText(text, 128, 134)
+  const t = new THREE.CanvasTexture(c)
+  t.colorSpace = THREE.SRGBColorSpace
+  t.anisotropy = Math.min(8, renderer.capabilities.getMaxAnisotropy())
+  glyphCache.set(text, t)
+  return t
+}
+
+/* -------------------------------------------------------------- the world */
+
+const ground = new THREE.Mesh(
+  new THREE.PlaneGeometry(70, 70),
+  new THREE.MeshStandardMaterial({
+    map: floorTexture(),
+    roughness: 0.62,
+    metalness: 0.28,
+    color: 0x8a7fa0,
+  }),
+)
+ground.rotation.x = -Math.PI / 2
+scene.add(ground)
+
+// Stall arcades down both sides. Extruded rounded arches, instanced-ish by
+// cloning a single geometry — one geometry, many meshes, so the vertex data is
+// uploaded once.
+const archShape = new THREE.Shape()
+archShape.moveTo(-0.55, 0)
+archShape.lineTo(-0.55, 1.5)
+archShape.quadraticCurveTo(-0.55, 2.35, 0, 2.35)
+archShape.quadraticCurveTo(0.55, 2.35, 0.55, 1.5)
+archShape.lineTo(0.55, 0)
+archShape.lineTo(0.36, 0)
+archShape.lineTo(0.36, 1.5)
+archShape.quadraticCurveTo(0.36, 2.1, 0, 2.1)
+archShape.quadraticCurveTo(-0.36, 2.1, -0.36, 1.5)
+archShape.lineTo(-0.36, 0)
+archShape.closePath()
+const archGeo = new THREE.ExtrudeGeometry(archShape, {
+  depth: 0.42,
+  bevelEnabled: true,
+  bevelThickness: 0.035,
+  bevelSize: 0.035,
+  bevelSegments: 2,
+  curveSegments: 14,
+})
+archGeo.center()
+
+const brass = new THREE.MeshStandardMaterial({
+  color: 0x9d7239,
+  roughness: 0.34,
+  metalness: 0.92,
+})
+const stone = new THREE.MeshStandardMaterial({
+  color: 0x2c2338,
+  roughness: 0.9,
+  metalness: 0.08,
+})
+
+const lampGlow = glowTexture("rgba(255,214,150,0.95)", "rgba(255,150,60,0.30)")
+const lamps: THREE.Sprite[] = []
+const lampLights: THREE.PointLight[] = []
+
+for (let side = -1; side <= 1; side += 2) {
+  for (let i = 0; i < 7; i++) {
+    const z = 2 - i * 3.1
+    // Facing the aisle, not edge-on. An arcade rotated 90° reads as a stack of
+    // rings from the player's eye — correct geometry, wrong picture.
+    const arch = new THREE.Mesh(archGeo, i % 2 === 0 ? stone : brass)
+    arch.position.set(side * 4.3, 1.34, z)
+    arch.rotation.y = side * -0.42
+    scene.add(arch)
+
+    // A hanging lamp: an emissive bead plus an additive sprite. The sprite is
+    // what actually reads as light; the bead gives it a physical source.
+    const bead = new THREE.Mesh(
+      new THREE.SphereGeometry(0.09, 12, 10),
+      new THREE.MeshBasicMaterial({ color: 0xffd79a }),
+    )
+    bead.position.set(side * 4.0, 1.95, z)
+    scene.add(bead)
+
+    const sprite = new THREE.Sprite(
+      new THREE.SpriteMaterial({
+        map: lampGlow,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+        transparent: true,
+        opacity: 0.55,
+      }),
+    )
+    sprite.scale.setScalar(1.5)
+    sprite.position.copy(bead.position)
+    scene.add(sprite)
+    lamps.push(sprite)
+
+    // Only the four nearest lamps are real lights. Beyond that the sprite
+    // carries it — a scene with fourteen point lights costs a forward renderer
+    // fourteen lighting iterations per fragment for no visible gain.
+    if (i < 2) {
+      const l = new THREE.PointLight(0xffb268, 5.5, 13, 2)
+      l.position.copy(bead.position)
+      scene.add(l)
+      lampLights.push(l)
+    }
+  }
+}
+
+scene.add(new THREE.HemisphereLight(0x6d58a0, 0x181024, 0.85))
+const key = new THREE.DirectionalLight(0xbfd0ff, 1.05)
+key.position.set(-3, 7, 5)
+scene.add(key)
+
+// The lamp that fills as the child answers — the "construction never regresses"
+// idea, rendered as a column of light that grows.
+const beaconGeo = new THREE.CylinderGeometry(0.19, 0.24, 1, 18, 1, true)
+const beaconMat = new THREE.MeshBasicMaterial({
+  color: 0xffc078,
+  transparent: true,
+  opacity: 0.0,
+  blending: THREE.AdditiveBlending,
+  depthWrite: false,
+  side: THREE.DoubleSide,
+})
+const beacon = new THREE.Mesh(beaconGeo, beaconMat)
+beacon.position.set(0, 0.5, -7)
+scene.add(beacon)
+
+const beaconBase = new THREE.Mesh(new THREE.TorusGeometry(0.42, 0.07, 10, 28), brass)
+beaconBase.rotation.x = Math.PI / 2
+beaconBase.position.set(0, 0.06, -7)
+scene.add(beaconBase)
+
+/* ------------------------------------------------------------ answer tiles */
+
+const tileShape = new THREE.Shape()
+{
+  const w = 0.62
+  const h = 0.44
+  const r = 0.1
+  tileShape.moveTo(-w + r, -h)
+  tileShape.lineTo(w - r, -h)
+  tileShape.quadraticCurveTo(w, -h, w, -h + r)
+  tileShape.lineTo(w, h - r)
+  tileShape.quadraticCurveTo(w, h, w - r, h)
+  tileShape.lineTo(-w + r, h)
+  tileShape.quadraticCurveTo(-w, h, -w, h - r)
+  tileShape.lineTo(-w, -h + r)
+  tileShape.quadraticCurveTo(-w, -h, -w + r, -h)
+}
+const tileGeo = new THREE.ExtrudeGeometry(tileShape, {
+  depth: 0.16,
+  bevelEnabled: true,
+  bevelThickness: 0.03,
+  bevelSize: 0.03,
+  bevelSegments: 2,
+  curveSegments: 6,
+})
+tileGeo.center()
+
+interface Tile {
+  group: THREE.Group
+  plate: THREE.Mesh
+  glyph: THREE.Sprite
+  value: number
+  homeY: number
+}
+
+const tiles: Tile[] = []
+for (let i = 0; i < 3; i++) {
+  const group = new THREE.Group()
+  group.position.set((i - 1) * 1.85, 1.15, 1.7)
+
+  const plate = new THREE.Mesh(
+    tileGeo,
+    new THREE.MeshStandardMaterial({
+      color: 0x35294a,
+      roughness: 0.42,
+      metalness: 0.55,
+      emissive: 0x120a1c,
+    }),
+  )
+  group.add(plate)
+
+  const glyph = new THREE.Sprite(
+    new THREE.SpriteMaterial({ map: glyphTexture("0"), transparent: true, depthWrite: false }),
+  )
+  glyph.scale.setScalar(0.9)
+  glyph.position.z = 0.14
+  group.add(glyph)
+
+  scene.add(group)
+  tiles.push({ group, plate, glyph, value: 0, homeY: group.position.y })
+}
+
+/* ------------------------------------------------------------- particles */
+
+// One Points cloud, one buffer, written in place. A particle system that
+// allocates per burst is the classic juice stutter.
+const MAX_PARTICLES = 900
+const pPos = new Float32Array(MAX_PARTICLES * 3)
+const pVel = new Float32Array(MAX_PARTICLES * 3)
+const pLife = new Float32Array(MAX_PARTICLES)
+const pMax = new Float32Array(MAX_PARTICLES)
+const pAlpha = new Float32Array(MAX_PARTICLES)
+const pSize = new Float32Array(MAX_PARTICLES)
+let pCursor = 0
+
+const pGeo = new THREE.BufferGeometry()
+pGeo.setAttribute("position", new THREE.BufferAttribute(pPos, 3))
+pGeo.setAttribute("alpha", new THREE.BufferAttribute(pAlpha, 1))
+pGeo.setAttribute("psize", new THREE.BufferAttribute(pSize, 1))
+const pMat = new THREE.ShaderMaterial({
+  transparent: true,
+  depthWrite: false,
+  blending: THREE.AdditiveBlending,
+  uniforms: { uTex: { value: glowTexture("rgba(255,236,200,1)", "rgba(255,168,80,0.6)") } },
+  vertexShader: `
+    attribute float alpha; attribute float psize; varying float vA;
+    void main(){
+      vA = alpha;
+      vec4 mv = modelViewMatrix * vec4(position,1.0);
+      // The divisor is a real calibration, not a magic number: gl_PointSize is
+      // in DEVICE pixels, so at dpr 2 it is doubled again by nobody. A first
+      // pass used 300.0 here and every particle rendered ~400 px across — the
+      // burst was one white disc covering a third of the screen and it read as
+      // a bug, not as juice. 70.0 puts a particle at 9–25 device px at this
+      // camera distance, which is a spark.
+      gl_PointSize = psize * (70.0 / -mv.z);
+      gl_Position = projectionMatrix * mv;
+    }`,
+  fragmentShader: `
+    uniform sampler2D uTex; varying float vA;
+    void main(){
+      vec4 t = texture2D(uTex, gl_PointCoord);
+      gl_FragColor = vec4(t.rgb, t.a * vA);
+      if (gl_FragColor.a < 0.01) discard;
+    }`,
+})
+const points = new THREE.Points(pGeo, pMat)
+points.frustumCulled = false
+scene.add(points)
+
+function emit(count: number, x: number, y: number, tier: { level: number }): void {
+  const speed = 1.4 + tier.level * 0.75
+  for (let i = 0; i < count && i < MAX_PARTICLES; i++) {
+    const k = pCursor
+    pCursor = (pCursor + 1) % MAX_PARTICLES
+    const j = k * 3
+    // Jitter the origin. Every particle leaving the exact same point makes a
+    // perfect expanding sphere, which reads as geometry rather than as debris.
+    pPos[j] = x * 3.2 + (Math.random() - 0.5) * 0.5
+    pPos[j + 1] = y * 1.4 + 1.25 + (Math.random() - 0.5) * 0.5
+    pPos[j + 2] = 1.7 + (Math.random() - 0.5) * 0.3
+    const a = Math.random() * Math.PI * 2
+    const b = Math.random() * Math.PI - Math.PI / 2
+    const s = speed * (0.35 + Math.random() * 0.65)
+    pVel[j] = Math.cos(a) * Math.cos(b) * s
+    pVel[j + 1] = Math.sin(b) * s + 1.1
+    pVel[j + 2] = Math.sin(a) * Math.cos(b) * s * 0.6
+    pMax[k] = 620 + Math.random() * 700 + tier.level * 120
+    pLife[k] = pMax[k]
+    pSize[k] = 0.9 + Math.random() * 1.5 + tier.level * 0.22
+  }
+}
+feel.onEmit(emit)
+
+function stepParticles(dtMs: number): void {
+  const dt = dtMs * 0.001
+  let any = false
+  for (let k = 0; k < MAX_PARTICLES; k++) {
+    if (pLife[k]! <= 0) {
+      if (pAlpha[k] !== 0) {
+        pAlpha[k] = 0
+        any = true
+      }
+      continue
+    }
+    any = true
+    pLife[k]! -= dtMs
+    const j = k * 3
+    pVel[j + 1]! -= 3.6 * dt
+    pPos[j]! += pVel[j]! * dt
+    pPos[j + 1]! += pVel[j + 1]! * dt
+    pPos[j + 2]! += pVel[j + 2]! * dt
+    const t = Math.max(0, pLife[k]! / pMax[k]!)
+    pAlpha[k] = t * t
+  }
+  if (any) {
+    pGeo.attributes.position!.needsUpdate = true
+    pGeo.attributes.alpha!.needsUpdate = true
+    pGeo.attributes.psize!.needsUpdate = true
+  }
+}
+
+/* ---------------------------------------------------------------- the game */
+
+const qEl = document.getElementById("q")!
+const hudEl = document.getElementById("hud")!
+
+let answer = 0
+let progress = 0
+let solved = 0
+let lastDifficulty = 0
+
+function nextProblem(): void {
+  // The generator is deliberately trivial — the point of the demo is the feel,
+  // and a real curriculum is another foundation's problem.
+  const hard = Math.random() < 0.35
+  const a = hard ? 6 + Math.floor(Math.random() * 8) : 2 + Math.floor(Math.random() * 7)
+  const b = hard ? 6 + Math.floor(Math.random() * 8) : 2 + Math.floor(Math.random() * 7)
+  answer = a * b
+  lastDifficulty = hard ? 0.8 : 0.25
+  qEl.textContent = `${String(a)} × ${String(b)}`
+
+  const slot = Math.floor(Math.random() * 3)
+  const used = new Set([answer])
+  for (let i = 0; i < 3; i++) {
+    let v: number
+    if (i === slot) v = answer
+    else {
+      do {
+        v = Math.max(2, answer + Math.floor(Math.random() * 17) - 8)
+      } while (used.has(v))
+      used.add(v)
+    }
+    tiles[i]!.value = v
+    tiles[i]!.glyph.material.map = glyphTexture(String(v))
+    tiles[i]!.glyph.material.needsUpdate = true
+    // Present on the UI channel: a freeze frame must never stall the next
+    // question arriving. This is the whole reason the channel exists.
+    tiles[i]!.group.position.y = tiles[i]!.homeY - 0.35
+    feel.tweens.to2(
+      tiles[i]!.group.position,
+      "y",
+      tiles[i]!.homeY - 0.35,
+      tiles[i]!.homeY,
+      260,
+      "outBack",
+      { channel: CH_UI, delayMs: i * 45 },
+    )
+  }
+}
+
+function commit(tile: Tile): void {
+  // One line at the top of every input handler. Interrupts whatever is playing
+  // and reports whether the surface is live.
+  if (!feel.press(tile.value)) return
+
+  const correct = tile.value === answer
+  // The tile itself takes the light. A reaction that happens only in the camera
+  // and the air, and not on the thing the child touched, reads as weather.
+  const mat = tile.plate.material as THREE.MeshStandardMaterial
+  mat.emissive.setHex(correct ? 0xffb45c : 0x8a3d1e)
+  feel.tweens.to2(mat.emissive, "r", correct ? 1 : 0.54, 0.07, correct ? 520 : 300, "outExpo", {
+    channel: 1,
+  })
+  feel.tweens.to2(mat.emissive, "g", correct ? 0.7 : 0.24, 0.04, correct ? 520 : 300, "outExpo", {
+    channel: 1,
+  })
+  feel.tweens.to2(mat.emissive, "b", correct ? 0.36 : 0.12, 0.11, correct ? 520 : 300, "outExpo", {
+    channel: 1,
+  })
+
+  if (correct) {
+    solved++
+    progress = Math.min(1, progress + 0.12)
+  }
+
+  const milestone = correct && progress >= 1 ? "minor" : null
+  if (milestone) progress = 0
+
+  // THE ONE CALL. Everything the child feels comes from here.
+  feel.answer(
+    {
+      correct,
+      difficulty: lastDifficulty,
+      repaired: correct && solved % 7 === 3,
+      milestone,
+    },
+    {
+      subject: tile.group,
+      at: [tile.group.position.x / 3.2, 0.1],
+      dir: correct ? [0, -1, 0.25] : [tile.group.position.x > 0 ? 1 : -1, -0.3, 0],
+    },
+  )
+
+  if (correct) nextProblem()
+}
+
+/* ------------------------------------------------------------------ input */
+
+const ray = new THREE.Raycaster()
+const ndc = new THREE.Vector2()
+
+renderer.domElement.addEventListener(
+  "pointerdown",
+  (e) => {
+    ndc.x = (e.clientX / window.innerWidth) * 2 - 1
+    ndc.y = -(e.clientY / window.innerHeight) * 2 + 1
+    ray.setFromCamera(ndc, camera)
+    // Hit slop, in 3D: widen the ray's threshold rather than the geometry, so
+    // adjacent tiles cannot both claim a tap. Nearest hit wins, which is the
+    // same rule `nearestTarget` applies in 2D.
+    const hits = ray.intersectObjects(
+      tiles.map((t) => t.plate),
+      false,
+    )
+    if (hits.length > 0) {
+      const plate = hits[0]!.object
+      const tile = tiles.find((t) => t.plate === plate)
+      if (tile) commit(tile)
+    }
+  },
+  { passive: true },
+)
+
+/* -------------------------------------------------------------- tier bench */
+
+const tierBar = document.getElementById("tiers")!
+for (const name of Object.keys(TIERS) as TierName[]) {
+  const b = document.createElement("button")
+  b.textContent = name
+  b.addEventListener("pointerdown", (e) => {
+    e.stopPropagation()
+    feel.interrupt()
+    feel.react(name, { subject: tiles[1]!.group, at: [0, 0.1] })
+  })
+  tierBar.appendChild(b)
+}
+
+/* --------------------------------------------------------------- the loop */
+
+feel.attach({ camera, parent: document.body })
+feel.start()
+nextProblem()
+
+let hudAcc = 0
+let lastWorkMs = 0
+feel.onFrame((t) => {
+  const w0 = performance.now()
+  stepParticles(t.dtWorld)
+
+  // Beacon fill runs on the UI channel's time so it keeps rising through a
+  // freeze frame — the world stops, the thing you are building does not.
+  const target = 0.35 + progress * 3.2
+  beacon.scale.y += (target - beacon.scale.y) * Math.min(1, t.dtUi * 0.006)
+  beacon.position.y = beacon.scale.y * 0.5
+  beaconMat.opacity = 0.1 + progress * 0.55
+
+  const pulse = 0.5 + 0.5 * Math.sin(t.tReal * 0.0016)
+  for (let i = 0; i < lamps.length; i++) {
+    lamps[i]!.material.opacity = 0.42 + 0.16 * Math.sin(t.tReal * 0.0021 + i)
+  }
+  for (const l of lampLights) l.intensity = 5.0 + pulse * 1.2
+
+  renderer.render(scene, camera)
+  // CPU time actually spent producing this frame — particles, feel systems,
+  // scene graph, draw-call submission. This is the number that responds to CPU
+  // throttling and the number a budget can be written against. The rAF delta
+  // is *not*: in headless Chrome it is a fixed virtual cadence and reports the
+  // same 8.30 ms whether the page is idle or under a 40-reaction storm. That
+  // cost a measurement round to discover; see README trap T-09.
+  lastWorkMs = performance.now() - w0
+
+  hudAcc += t.dtReal
+  if (hudAcc > 250) {
+    hudAcc = 0
+    const s = feel.clock.frameStats()
+    const q = feel.quality
+    hudEl.innerHTML =
+      `<b>${q.tier.toUpperCase()}</b> · dpr ${String(renderer.getPixelRatio().toFixed(2))} · ` +
+      `frame work <b>${lastWorkMs.toFixed(2)}</b>ms · rAF p50 ${s.p50.toFixed(1)}ms p95 ${s.p95.toFixed(1)}ms<br>` +
+      `tweens ${String(feel.tweens.liveCount)}/${String(feel.tweens.capacity)} · ` +
+      `trauma ${feel.rig.shake.trauma.toFixed(2)} · scale ${feel.clock.timeScale.toFixed(2)} · ` +
+      `hitstop ${feel.clock.hitstopMs.toFixed(0)}ms<br>` +
+      `reactions ${String(feel.stats.reactions)} · interrupts ${String(feel.stats.interrupts)} · ` +
+      `last interrupt <b>${feel.stats.lastInterruptMs.toFixed(3)}</b>ms · solved ${String(solved)}` +
+      (feel.tweens.overflows > 0
+        ? `<br><span class="warn">tween pool overflowed ${String(feel.tweens.overflows)}×</span>`
+        : "")
+  }
+})
+
+/* ----------------------------------------------------------------- resize */
+
+function resize(): void {
+  const w = window.innerWidth
+  const h = window.innerHeight
+  // The single biggest GPU lever. An uncapped DPR of 3 on a modern phone is
+  // 9× the fragment work of DPR 1 for a difference nobody can see at arm's
+  // length on a 60 px glyph.
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, feel.quality.maxPixelRatio))
+  // `updateStyle` must be true, or set the CSS size yourself. With `false` the
+  // canvas keeps its intrinsic size — width × dpr CSS pixels — so at dpr 2 the
+  // canvas lays out at twice the viewport and the page shows the top-left
+  // quadrant of the render. It looks like a broken camera, and the first
+  // screenshot pass of this demo lost time to exactly that. Trap T-10.
+  renderer.setSize(w, h, true)
+  camera.aspect = w / h
+  camera.updateProjectionMatrix()
+}
+window.addEventListener("resize", resize)
+resize()
+
+/* ------------------------------------------------------------------ probe */
+
+// The measurement surface `bench/frames.mjs` drives. Kept in the demo rather
+// than in the bench so the thing being measured is the thing that ships.
+interface Probe {
+  samples: number[]
+  work: number[]
+  recording: boolean
+  record(ms: number): Promise<number[]>
+  fire(tier: TierName): void
+  storm(n: number): void
+  setQuality(t: "low" | "medium" | "high" | "ultra"): void
+  stats(): Stats
+  workStats(): Stats
+}
+interface Stats {
+  p50: number
+  p95: number
+  p99: number
+  worst: number
+  n: number
+  over16: number
+}
+function percentiles(raw: number[]): Stats {
+  const s = [...raw].sort((a, b) => a - b)
+  const at = (q: number) => s[Math.min(s.length - 1, Math.floor(s.length * q))] ?? 0
+  return {
+    p50: at(0.5),
+    p95: at(0.95),
+    p99: at(0.99),
+    worst: s[s.length - 1] ?? 0,
+    n: s.length,
+    over16: s.filter((v) => v > 16.7).length,
+  }
+}
+
+const probe: Probe = {
+  samples: [],
+  work: [],
+  recording: false,
+  record(ms) {
+    this.samples = []
+    this.work = []
+    this.recording = true
+    return new Promise((res) => {
+      setTimeout(() => {
+        this.recording = false
+        res(this.samples)
+      }, ms)
+    })
+  },
+  fire(tier) {
+    feel.interrupt()
+    feel.react(tier, { subject: tiles[1]!.group, at: [0, 0.1] })
+  },
+  storm(n) {
+    for (let i = 0; i < n; i++) {
+      feel.react(i % 5 === 0 ? "bloom" : i % 3 === 0 ? "pop" : "snap", {
+        subject: tiles[i % 3]!.group,
+        at: [(i % 3) - 1, 0.1],
+      })
+    }
+  },
+  setQuality(t) {
+    feel.governor.force(t)
+    resize()
+  },
+  stats() {
+    return percentiles(this.samples)
+  },
+  workStats() {
+    return percentiles(this.work)
+  },
+}
+feel.onFrame((t) => {
+  if (probe.recording) {
+    probe.samples.push(t.dtReal)
+    probe.work.push(lastWorkMs)
+  }
+})
+;(window as unknown as { __dwProbe: Probe }).__dwProbe = probe
+;(window as unknown as { __dwFeelReady: boolean }).__dwFeelReady = true
+
+// Ease is re-exported into the demo so a prototype author can see it exists.
+void EASE

--- a/dynawalla/foundations/feel/docs/shots/01-tablet-rest.png
+++ b/dynawalla/foundations/feel/docs/shots/01-tablet-rest.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:067eb7c2f2054b601ee89a7c6b013cd0fc9aac85dc87a07de0fdbf8cb636686f
+size 496414

--- a/dynawalla/foundations/feel/docs/shots/02-tablet-snap.png
+++ b/dynawalla/foundations/feel/docs/shots/02-tablet-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8eb20b2d66d1b0744b15ee371ca9ff3be6096817e88dffcd44014015eda7e476
+size 481007

--- a/dynawalla/foundations/feel/docs/shots/03-tablet-bloom.png
+++ b/dynawalla/foundations/feel/docs/shots/03-tablet-bloom.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c62a643fa1a954df3a49e4620856e977bab56a0b37b1b6b814943d231f5d01c6
+size 519088

--- a/dynawalla/foundations/feel/docs/shots/04-tablet-ascend.png
+++ b/dynawalla/foundations/feel/docs/shots/04-tablet-ascend.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ead2e5f32e34545eca294ce22061f6cd984c40e2c6d527f2e42cf8a27ff93a89
+size 609972

--- a/dynawalla/foundations/feel/docs/shots/05-phone-rest.png
+++ b/dynawalla/foundations/feel/docs/shots/05-phone-rest.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75bd1adae92dca8218013c1c6e8f64c70276410612e585750945284288489f10
+size 275052

--- a/dynawalla/foundations/feel/docs/shots/06-phone-pop.png
+++ b/dynawalla/foundations/feel/docs/shots/06-phone-pop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e49acc2056b900b3678957ea43f5494f6a5cf5fffca5abe19c67f44a5db27b59
+size 282187

--- a/dynawalla/foundations/feel/index.html
+++ b/dynawalla/foundations/feel/index.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover,user-scalable=no" />
+    <title>Dynawalla — feel foundation</title>
+    <style>
+      :root { color-scheme: dark; }
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body { height: 100%; overflow: hidden; background: #07060d; }
+      body {
+        font: 500 13px/1.4 ui-monospace, "SF Mono", Menlo, monospace;
+        color: #e8dcc8;
+        -webkit-font-smoothing: antialiased;
+      }
+      canvas { display: block; touch-action: manipulation; }
+
+      #hud {
+        position: fixed; left: 0; top: 0; padding: 10px 12px;
+        pointer-events: none; z-index: 20;
+        text-shadow: 0 1px 3px #000a;
+      }
+      #hud b { color: #ffc879; font-weight: 600; }
+      #hud .warn { color: #ff9a5c; }
+
+      #tiers {
+        position: fixed; left: 0; right: 0; bottom: 0; z-index: 20;
+        display: flex; gap: 6px; padding: 10px;
+        justify-content: center; flex-wrap: wrap;
+      }
+      #tiers button {
+        font: inherit; font-size: 11px; letter-spacing: .06em; text-transform: uppercase;
+        color: #f0e4cc; background: #1a1420; border: 1px solid #3b2f45;
+        padding: 9px 12px; border-radius: 3px; cursor: pointer;
+        touch-action: manipulation; user-select: none;
+      }
+      #tiers button:active { background: #2c2133; transform: translateY(1px); }
+      #tiers button.on { border-color: #d9a05b; color: #ffcf90; }
+
+      #q {
+        position: fixed; left: 0; right: 0; top: 12%;
+        text-align: center; z-index: 15; pointer-events: none;
+        font: 300 clamp(34px, 9vw, 76px)/1 ui-serif, Georgia, serif;
+        letter-spacing: .04em; color: #f6ead2;
+        text-shadow: 0 2px 24px #000c, 0 0 60px #ffb35a30;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="q"></div>
+    <div id="hud"></div>
+    <div id="tiers"></div>
+    <script type="module" src="/demo/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/foundations/feel/package-lock.json
+++ b/dynawalla/foundations/feel/package-lock.json
@@ -1,0 +1,975 @@
+{
+  "name": "@dynawalla/feel",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@dynawalla/feel",
+      "version": "0.1.0",
+      "dependencies": {
+        "three": "^0.185.1"
+      },
+      "devDependencies": {
+        "@types/node": "^26.1.1",
+        "@types/three": "^0.185.1",
+        "typescript": "~6.0.3",
+        "vite": "^8.1.5"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/dynawalla/foundations/feel/package.json
+++ b/dynawalla/foundations/feel/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@dynawalla/feel",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Game-feel foundation for the Dynawalla Bazaar. One call, excellent feel.",
+  "main": "src/index.ts",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4173 --strictPort",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test src/*.test.ts",
+    "bench": "node --experimental-strip-types --no-warnings=ExperimentalWarning bench/cpu.mjs",
+    "bench:frames": "node bench/frames.mjs"
+  },
+  "dependencies": {
+    "three": "^0.185.1"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "@types/three": "^0.185.1",
+    "typescript": "~6.0.3",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/foundations/feel/src/audio.ts
+++ b/dynawalla/foundations/feel/src/audio.ts
@@ -1,0 +1,254 @@
+// Asset-free juice audio. Web Audio only — no files to load, decode, or ship.
+//
+// A struck-mallet timbre (sine fundamental + a quieter triangle octave, fast
+// attack, exponential release) over a pentatonic scale. Pentatonic because
+// every subset of it is consonant, so tones can fire in any order at any
+// spacing and never produce a sour interval — which matters when the trigger is
+// a child's answer timing and not a composer.
+//
+// ## Trap: the context starts suspended, and `resume()` needs a real gesture
+//
+// Chrome, Safari and every WebView start an `AudioContext` in `suspended`.
+// `resume()` only succeeds inside a user-gesture task. Creating the context at
+// module load and calling `resume()` from a `setTimeout` looks like it works in
+// dev (you clicked something first) and ships silent. `unlock()` here is wired
+// to the first `pointerdown`/`keydown` and removes itself.
+//
+// ## Trap: iOS suspends the context and does not tell you
+//
+// A phone call, a Siri invocation, or the app backgrounding leaves the context
+// `interrupted`/`suspended` and it does **not** auto-resume. The
+// `visibilitychange` handler re-resumes; without it, audio dies permanently
+// after the first interruption and the bug report is "sound stopped working
+// yesterday".
+//
+// ## Trap: never `await` audio on the answer path
+//
+// `resume()` returns a promise. Awaiting it in the input handler puts a
+// microtask — and on a cold context a real 10–40 ms of work — between the tap
+// and the verdict. Audio is fire-and-forget; a dropped chime is strictly better
+// than a late frame.
+//
+// ## Dropped, never queued
+//
+// Above `maxVoices` concurrent notes, new ones are dropped. Queuing produces
+// the machine-gun effect when a child mashes, and each voice is an
+// `OscillatorNode` + `GainNode` — cheap, but not free, and unbounded.
+
+/** Semitone offsets of a major pentatonic, two octaves. */
+const PENTATONIC = [0, 2, 4, 7, 9, 12, 14, 16, 19, 21, 24]
+
+export interface FeelAudioOptions {
+  /** Root frequency. C5 = 523.25 Hz sits above a classroom's noise floor. */
+  rootHz?: number
+  masterGain?: number
+  maxVoices?: number
+}
+
+type Ctx = AudioContext & { state: AudioContextState }
+
+export class FeelAudio {
+  enabled = true
+  private ctx: Ctx | null = null
+  private master: GainNode | null = null
+  private voices = 0
+  private readonly rootHz: number
+  private readonly masterGain: number
+  private readonly maxVoices: number
+  private unlocked = false
+
+  /** Diagnostics. */
+  played = 0
+  dropped = 0
+
+  constructor(opts: FeelAudioOptions = {}) {
+    this.rootHz = opts.rootHz ?? 523.25
+    this.masterGain = opts.masterGain ?? 0.22
+    this.maxVoices = opts.maxVoices ?? 6
+  }
+
+  /**
+   * Install the gesture listeners. Safe to call at boot; creates nothing until
+   * the child touches the screen.
+   */
+  attach(): void {
+    const g = globalThis as unknown as {
+      addEventListener?: (t: string, f: () => void, o?: object) => void
+      document?: { addEventListener?: (t: string, f: () => void) => void; hidden?: boolean }
+    }
+    if (!g.addEventListener) return
+    const unlock = () => {
+      this.unlock()
+    }
+    g.addEventListener("pointerdown", unlock, { once: true, passive: true })
+    g.addEventListener("keydown", unlock, { once: true })
+    g.document?.addEventListener?.("visibilitychange", () => {
+      if (!g.document?.hidden && this.ctx && this.ctx.state !== "running") {
+        void this.ctx.resume().catch(() => {})
+      }
+    })
+  }
+
+  /** Create and resume. Must be called from inside a user-gesture task. */
+  unlock(): void {
+    if (this.unlocked) return
+    const AC = (globalThis as unknown as { AudioContext?: typeof AudioContext }).AudioContext
+    if (!AC) return
+    this.unlocked = true
+    // `latencyHint: "interactive"` asks for the smallest buffer the platform
+    // will give. On a WebView that is the difference between ~5 ms and ~40 ms
+    // of output latency, and 40 ms is a visible desync from the flash.
+    this.ctx = new AC({ latencyHint: "interactive" }) as Ctx
+    this.master = this.ctx.createGain()
+    this.master.gain.value = this.masterGain
+    this.master.connect(this.ctx.destination)
+    void this.ctx.resume().catch(() => {})
+  }
+
+  get ready(): boolean {
+    return this.ctx !== null && this.ctx.state === "running"
+  }
+
+  /** Output latency the platform admits to, in ms. Useful for the desync trap. */
+  get outputLatencyMs(): number {
+    const c = this.ctx as (Ctx & { outputLatency?: number; baseLatency?: number }) | null
+    if (!c) return 0
+    return ((c.outputLatency ?? c.baseLatency ?? 0) as number) * 1000
+  }
+
+  /**
+   * A struck note, `semitone` above the root. Fire and forget.
+   *
+   * @param semitone snapped to the pentatonic, so any integer is musical.
+   * @param gain 0…1, scaled by master.
+   * @param durationMs release length. Short is percussive; long rings.
+   */
+  note(semitone: number, gain = 1, durationMs = 320): void {
+    if (!this.enabled || !this.ctx || !this.master) return
+    if (this.ctx.state !== "running") return
+    if (this.voices >= this.maxVoices) {
+      this.dropped++
+      return
+    }
+    const ctx = this.ctx
+    const t = ctx.currentTime
+    const snapped = snapPentatonic(semitone)
+    const hz = this.rootHz * 2 ** (snapped / 12)
+
+    const env = ctx.createGain()
+    env.connect(this.master)
+    const osc = ctx.createOscillator()
+    osc.type = "sine"
+    osc.frequency.value = hz
+    osc.connect(env)
+    const octave = ctx.createOscillator()
+    octave.type = "triangle"
+    octave.frequency.value = hz * 2
+    const octGain = ctx.createGain()
+    octGain.gain.value = 0.22
+    octave.connect(octGain)
+    octGain.connect(env)
+
+    const dur = durationMs * 0.001
+    env.gain.setValueAtTime(0.0001, t)
+    // 4 ms attack: fast enough to read as struck, slow enough not to click.
+    env.gain.exponentialRampToValueAtTime(Math.max(0.0001, gain), t + 0.004)
+    env.gain.exponentialRampToValueAtTime(0.0001, t + dur)
+
+    osc.start(t)
+    octave.start(t)
+    osc.stop(t + dur + 0.02)
+    octave.stop(t + dur + 0.02)
+    this.voices++
+    this.played++
+    osc.onended = () => {
+      this.voices--
+      env.disconnect()
+      octGain.disconnect()
+    }
+  }
+
+  /**
+   * A low, short, unpitched thud. The "that did not seat" sound.
+   *
+   * Filtered noise rather than a tone, because a *pitched* failure sound is
+   * either a sour interval (unpleasant) or a consonant one (rewarding), and
+   * neither is what a wrong answer should be.
+   */
+  thud(gain = 0.7): void {
+    if (!this.enabled || !this.ctx || !this.master) return
+    if (this.ctx.state !== "running") return
+    const ctx = this.ctx
+    const t = ctx.currentTime
+    const osc = ctx.createOscillator()
+    osc.type = "sine"
+    osc.frequency.setValueAtTime(180, t)
+    osc.frequency.exponentialRampToValueAtTime(70, t + 0.12)
+    const env = ctx.createGain()
+    env.gain.setValueAtTime(0.0001, t)
+    env.gain.exponentialRampToValueAtTime(gain, t + 0.006)
+    env.gain.exponentialRampToValueAtTime(0.0001, t + 0.16)
+    osc.connect(env)
+    env.connect(this.master)
+    osc.start(t)
+    osc.stop(t + 0.18)
+    osc.onended = () => env.disconnect()
+    this.played++
+  }
+
+  /** An arpeggio for the big tiers. Scheduled on the audio clock, not setTimeout. */
+  chord(base: number, count = 4, spacingMs = 70, gain = 0.8): void {
+    if (!this.ctx || this.ctx.state !== "running") return
+    for (let i = 0; i < count; i++) {
+      // `setTimeout` here would jitter by whole frames under load. Scheduling
+      // each note against `currentTime` inside `note()` is not possible without
+      // a start-time parameter, so the spacing is done with the audio clock by
+      // pre-computing start times in `noteAt`.
+      this.noteAt(base + i * 2, this.ctx.currentTime + (i * spacingMs) / 1000, gain, 420)
+    }
+  }
+
+  private noteAt(semitone: number, when: number, gain: number, durationMs: number): void {
+    if (!this.ctx || !this.master) return
+    const ctx = this.ctx
+    const hz = this.rootHz * 2 ** (snapPentatonic(semitone) / 12)
+    const env = ctx.createGain()
+    env.connect(this.master)
+    const osc = ctx.createOscillator()
+    osc.type = "sine"
+    osc.frequency.value = hz
+    osc.connect(env)
+    const dur = durationMs * 0.001
+    env.gain.setValueAtTime(0.0001, when)
+    env.gain.exponentialRampToValueAtTime(Math.max(0.0001, gain), when + 0.004)
+    env.gain.exponentialRampToValueAtTime(0.0001, when + dur)
+    osc.start(when)
+    osc.stop(when + dur + 0.02)
+    osc.onended = () => env.disconnect()
+    this.played++
+  }
+
+  dispose(): void {
+    void this.ctx?.close().catch(() => {})
+    this.ctx = null
+    this.master = null
+    this.unlocked = false
+  }
+}
+
+/** Snap an arbitrary semitone to the nearest pentatonic degree. */
+export function snapPentatonic(semitone: number): number {
+  const octave = Math.floor(semitone / 12)
+  const within = semitone - octave * 12
+  let best = PENTATONIC[0]!
+  let bestD = Infinity
+  for (let i = 0; i < PENTATONIC.length; i++) {
+    const p = PENTATONIC[i]! % 12
+    const d = Math.abs(p - within)
+    if (d < bestD) {
+      bestD = d
+      best = p
+    }
+  }
+  return best + octave * 12
+}

--- a/dynawalla/foundations/feel/src/camera.ts
+++ b/dynawalla/foundations/feel/src/camera.ts
@@ -1,0 +1,190 @@
+// The camera rig: shake, kick, punch-zoom, lookahead, roll — composed, never
+// accumulated.
+//
+// ## The bug this file exists to make impossible
+//
+// The natural way to shake a camera is `camera.position.x += shakeX`. It works
+// for one frame. Then the follow logic reads `camera.position` — which now
+// contains the shake — and follows *that*, so the shake leaks into the camera's
+// real position and the view drifts away from the subject over a few seconds.
+// It is subtle, it looks like "the camera feels loose", and it is the single
+// most common juice bug in shipped code.
+//
+// The fix is structural, not disciplinary: the game writes `rig.base`, the rig
+// owns `camera`, and nothing ever reads the camera's transform back. Every
+// frame the rig recomputes `camera = base + kick + shake + lookahead` from
+// scratch. There is no path by which an offset can accumulate.
+//
+// ## Three.js trap: `lookAt()` overwrites rotation
+//
+// `camera.lookAt()` rebuilds the rotation from scratch, so roll applied before
+// it silently vanishes. Roll is applied *after* `lookAt`, and `applyTo` does
+// them in that order so a prototype cannot get it wrong. (Same class of trap as
+// the repo's `setTarget()` resetting radius on ArcRotateCamera.)
+//
+// ## The core has no Three.js dependency
+//
+// `CameraLike` is structural. A `THREE.PerspectiveCamera` satisfies it, and so
+// does a plain object driving a 2D canvas transform, which is how the same rig
+// serves both the 3D and 2D prototypes without a branch.
+
+import { Kick, Shake, type ShakeOptions } from "./shake.ts"
+import { Spring1D } from "./spring.ts"
+
+export interface Vec3Like {
+  x: number
+  y: number
+  z: number
+}
+
+/** The minimum a camera must offer. `THREE.PerspectiveCamera` satisfies it. */
+export interface CameraLike {
+  position: Vec3Like
+  rotation: { z: number }
+  fov?: number
+  lookAt?: (x: number, y: number, z: number) => void
+  updateProjectionMatrix?: () => void
+}
+
+export interface CameraRigOptions extends ShakeOptions {
+  /** Field of view with nothing happening. Punch is measured against it. */
+  baseFov?: number
+  /** How fast the lookahead offset chases its target. 3–5 Hz reads as smooth. */
+  lookaheadHz?: number
+  /** Cap on lookahead travel, world units. Unbounded lookahead is motion sickness. */
+  lookaheadMax?: number
+}
+
+export class CameraRig {
+  /** Where the game wants the camera. Write this; never read the camera back. */
+  readonly base: Vec3Like = { x: 0, y: 0, z: 0 }
+  /** Where the game wants the camera to point. */
+  readonly aim: Vec3Like = { x: 0, y: 0, z: 0 }
+
+  readonly shake: Shake
+  readonly kick = new Kick()
+
+  /** Punch-zoom, in degrees of FOV. Negative = pushed in = more intense. */
+  private readonly fovSpring: Spring1D
+  /** Lookahead, one spring per axis, clamped. */
+  private readonly leadX: Spring1D
+  private readonly leadY: Spring1D
+
+  readonly baseFov: number
+  private readonly lookaheadMax: number
+
+  /** Composed output. Written each `update`, read by `applyTo`. */
+  readonly out: Vec3Like = { x: 0, y: 0, z: 0 }
+  outRoll = 0
+  outFov = 50
+
+  /** Scales shake + kick + fov punch together. The governor turns this down. */
+  set intensity(v: number) {
+    this.shake.intensity = v
+    this.kick.intensity = v
+    this.fovIntensity = v
+  }
+  private fovIntensity = 1
+
+  constructor(opts: CameraRigOptions = {}) {
+    this.shake = new Shake(opts)
+    this.baseFov = opts.baseFov ?? 50
+    this.outFov = this.baseFov
+    this.fovSpring = new Spring1D(9, 0.55)
+    const hz = opts.lookaheadHz ?? 4
+    this.leadX = new Spring1D(hz, 1)
+    this.leadY = new Spring1D(hz, 1)
+    this.lookaheadMax = opts.lookaheadMax ?? 1.2
+  }
+
+  /**
+   * The one call a reaction makes. Direction points *from* the impact *toward*
+   * the camera, so the camera recoils away from the hit the way a held object
+   * does. Pass `0,0,0` for an undirected impact and only the shake fires.
+   */
+  impact(trauma: number, kick: number, dx = 0, dy = 0, dz = 0): void {
+    this.shake.add(trauma)
+    if (kick !== 0) this.kick.add(dx * kick, dy * kick, dz * kick)
+  }
+
+  /**
+   * Punch the field of view by `degrees` **at the peak**. Negative pushes in.
+   *
+   * Peak-normalised for the same reason the kick is: a raw impulse on a 9 Hz
+   * spring converts to roughly 0.006° per unit, so hand-picked multipliers here
+   * are wrong by two orders of magnitude and nobody can see it in review.
+   */
+  punchFov(degrees: number): void {
+    this.fovSpring.impulse(this.fovSpring.impulseForPeak(degrees) * this.fovIntensity)
+  }
+
+  /** Bias the framing toward a point of interest, clamped and smoothed. */
+  lookahead(dx: number, dy: number): void {
+    const m = this.lookaheadMax
+    this.leadX.rest = dx < -m ? -m : dx > m ? m : dx
+    this.leadY.rest = dy < -m ? -m : dy > m ? m : dy
+  }
+
+  /**
+   * @param dtRealMs wall clock. Shake, kick and fov punch all run on real time
+   *   so they keep moving during a freeze frame — the contrast between a
+   *   stopped world and a moving camera is what makes hitstop read as impact
+   *   rather than as a hang.
+   */
+  update(dtRealMs: number): void {
+    this.shake.update(dtRealMs)
+    this.kick.update(dtRealMs)
+    this.fovSpring.update(dtRealMs)
+    this.leadX.update(dtRealMs)
+    this.leadY.update(dtRealMs)
+
+    this.out.x = this.base.x + this.kick.x + this.shake.x + this.leadX.x
+    this.out.y = this.base.y + this.kick.y + this.shake.y + this.leadY.x
+    this.out.z = this.base.z + this.kick.z
+    this.outRoll = this.shake.roll
+    this.outFov = this.baseFov + this.fovSpring.x
+  }
+
+  /** Write the composed transform onto a camera. Order matters — see header. */
+  applyTo(camera: CameraLike): void {
+    camera.position.x = this.out.x
+    camera.position.y = this.out.y
+    camera.position.z = this.out.z
+    // lookAt first: it rebuilds rotation and would erase a roll set before it.
+    camera.lookAt?.(this.aim.x, this.aim.y, this.aim.z)
+    camera.rotation.z += this.outRoll
+    if (camera.fov !== undefined && Math.abs(camera.fov - this.outFov) > 0.001) {
+      camera.fov = this.outFov
+      camera.updateProjectionMatrix?.()
+    }
+  }
+
+  /** Everything to rest, without a pop. Called by `settleNow()`. */
+  settle(): void {
+    this.shake.settle()
+    this.kick.settle()
+    this.fovSpring.settle()
+  }
+
+  /** True when the rig is costing nothing and could be skipped. */
+  isAtRest(): boolean {
+    return this.shake.trauma <= 0 && this.kick.isAtRest() && this.fovSpring.isAtRest()
+  }
+
+  /**
+   * The same composition as a CSS transform, for 2D prototypes. Offsets are
+   * treated as CSS px. Returns a string; call at most once per frame.
+   *
+   * `translate3d` rather than `translate` on purpose: it promotes the element
+   * to its own compositor layer, so the shake is a GPU transform and never
+   * triggers layout. A shake implemented with `left`/`top` re-layouts the whole
+   * subtree 60 times a second and is the reason "screen shake tanks the frame
+   * rate" is a widely held belief about the web.
+   */
+  cssTransform(scale = 1): string {
+    const x = this.out.x * scale
+    const y = this.out.y * scale
+    const deg = (this.outRoll * 180) / Math.PI
+    return `translate3d(${x.toFixed(2)}px,${y.toFixed(2)}px,0) rotate(${deg.toFixed(3)}deg)`
+  }
+}

--- a/dynawalla/foundations/feel/src/clock.test.ts
+++ b/dynawalla/foundations/feel/src/clock.test.ts
@@ -1,0 +1,109 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { FeelClock, MAX_DT_MS } from "./clock.ts"
+
+const mk = () => new FeelClock({ now: () => 0, raf: () => 0, cancelRaf: () => {} })
+
+test("hitstop freezes the world and leaves real and ui running", () => {
+  const c = mk()
+  c.hitstop(50)
+  const t = c.step(16.67)
+  assert.equal(t.dtWorld, 0, "world must be frozen")
+  assert.equal(t.dtReal, 16.67, "real time never stops")
+  assert.equal(t.dtUi, 16.67, "the next problem must keep presenting")
+})
+
+test("hitstop is wall-clock, so it is identical at 60 and 120 Hz", () => {
+  const a = mk()
+  const b = mk()
+  a.hitstop(50)
+  b.hitstop(50)
+  let aFrames = 0
+  let bFrames = 0
+  while (a.hitstopMs > 0) {
+    a.step(1000 / 60)
+    aFrames++
+  }
+  while (b.hitstopMs > 0) {
+    b.step(1000 / 120)
+    bFrames++
+  }
+  // Different frame counts, same elapsed real time. That is the whole point:
+  // a frame-counted hitstop would be half as long on the 120 Hz device.
+  assert.equal(aFrames, 3)
+  assert.equal(bFrames, 6)
+  assert.ok(Math.abs(a.tReal - b.tReal) < 1e-9)
+})
+
+test("hitstop takes the max, never sums", () => {
+  const c = mk()
+  c.hitstop(40)
+  c.hitstop(75)
+  c.hitstop(20)
+  assert.equal(c.hitstopMs, 75)
+})
+
+test("slow-motion snaps in and eases out", () => {
+  const c = mk()
+  c.slowmo(0.3, 200)
+  assert.equal(c.timeScale, 0.3, "entry must be instant, not ramped")
+  const first = c.step(16.67)
+  assert.ok(first.dtWorld < first.dtReal * 0.6)
+  let elapsed = 16.67
+  while (elapsed < 260) {
+    c.step(16.67)
+    elapsed += 16.67
+  }
+  assert.equal(c.timeScale, 1, "must return exactly to 1, not asymptotically")
+})
+
+test("settleNow cancels every distortion synchronously", () => {
+  const c = mk()
+  c.hitstop(150)
+  c.slowmo(0.25, 400)
+  c.settleNow()
+  assert.equal(c.hitstopMs, 0)
+  assert.equal(c.timeScale, 1)
+  const t = c.step(16.67)
+  assert.equal(t.dtWorld, 16.67)
+})
+
+test("a long stall is clamped, not replayed", () => {
+  const c = mk()
+  const t = c.step(90_000)
+  assert.equal(t.dtReal, MAX_DT_MS)
+  assert.ok(t.stalled)
+})
+
+test("start is idempotent — two mounts do not make two loops", () => {
+  let started = 0
+  const c = new FeelClock({
+    now: () => 0,
+    raf: () => {
+      started++
+      return 1
+    },
+    cancelRaf: () => {},
+  })
+  c.start()
+  c.start()
+  c.start()
+  assert.equal(started, 1)
+})
+
+test("the tick object is reused — zero allocation per frame", () => {
+  const c = mk()
+  const a = c.step(16)
+  const b = c.step(16)
+  assert.equal(a, b, "a fresh object per frame is 60 allocations a second")
+})
+
+test("world time accumulates only what the world saw", () => {
+  const c = mk()
+  c.hitstop(33)
+  c.step(16.67)
+  c.step(16.67)
+  c.step(16.67)
+  assert.ok(c.tReal > c.tWorld)
+  assert.ok(Math.abs(c.tWorld - 16.67) < 0.01, `world advanced ${String(c.tWorld)}`)
+})

--- a/dynawalla/foundations/feel/src/clock.ts
+++ b/dynawalla/foundations/feel/src/clock.ts
@@ -1,0 +1,283 @@
+// The clock. Everything in the kit hangs off exactly one of these.
+//
+// ## Three time channels, and why a math game needs all three
+//
+//   real   wall clock. Never stops, never scales. Input, audio scheduling and
+//          the shake read this. If a child taps during a freeze frame the tap
+//          is handled on `real`, which is the whole reason ordinary success
+//          stays interruptible.
+//   world  the simulation. Hitstop drives it to zero; slow-motion scales it.
+//          Anything that reads as "the game" moves on this.
+//   ui     unscaled but pausable. The next problem presenting, a panel sliding,
+//          the timer bar. Freeze frames must not stall the presentation of the
+//          next question or the reaction stops being a tail and becomes a wait.
+//
+// The distinction is the single most load-bearing decision in this file. A
+// one-channel clock forces you to choose between "the freeze frame feels good"
+// and "the child is never made to wait", and the product needs both.
+//
+// ## Hitstop is measured in milliseconds, not frames
+//
+// The canon (Celeste's `Celeste.Freeze(.05f)`, i.e. 3 frames at 60 Hz) is
+// written in seconds for a fixed-60 engine. We ship on iPad ProMotion at 120 Hz
+// and on 90 Hz Androids. A frame-counted hitstop tuned at 60 Hz is *half the
+// duration* on an iPad Pro and feels like a dropped frame rather than an
+// impact. Hitstop here is wall-clock milliseconds and is identical at 60, 90
+// and 120 Hz. This is trap T-01 in README.md.
+//
+// ## One loop
+//
+// `start()` is idempotent. The repo has been bitten before: React StrictMode /
+// hot reload mounts twice, two rAF loops run, everything moves at double speed
+// and the profile shows two engines. The guard lives on the instance and
+// `Feel` keeps exactly one instance on `globalThis`, which is what survives a
+// hot reload.
+
+/** Which time channel a consumer advances on. */
+export type Channel = "real" | "world" | "ui"
+
+/**
+ * A frame's worth of time, in every channel. Handed to every tick callback.
+ * This object is **reused across frames** — do not retain it. Zero allocation
+ * per frame is not decoration here; see bench/cpu.mjs.
+ */
+export interface Tick {
+  /** Wall-clock ms since the previous frame, clamped. Never 0 except frame 1. */
+  dtReal: number
+  /** Simulation ms: `0` during hitstop, `dtReal * timeScale` otherwise. */
+  dtWorld: number
+  /** Presentation ms: `dtReal` unless the clock is explicitly paused. */
+  dtUi: number
+  /** `performance.now()` at the top of this frame. */
+  now: number
+  /** Accumulated real ms since `start()`. */
+  tReal: number
+  /** Accumulated world ms. Stalls during hitstop. */
+  tWorld: number
+  /** Frame ordinal since `start()`. */
+  frame: number
+  /** Current world time scale, after smoothing. 1 = normal. */
+  timeScale: number
+  /** Hitstop ms still owed after this frame. */
+  hitstopMs: number
+  /** True if `dtReal` was clamped — a stall, a tab switch, a GC pause. */
+  stalled: boolean
+}
+
+export type TickFn = (t: Tick) => void
+
+/**
+ * Longest frame the clock will admit. A backgrounded tab returns after minutes;
+ * without this every spring in the kit integrates a 90-second step and the
+ * scene explodes on resume. 50 ms also means a genuine 20 fps hitch degrades to
+ * slow-motion rather than teleportation, which is the kinder failure.
+ */
+export const MAX_DT_MS = 50
+
+export interface ClockOptions {
+  /** Injected for tests. Defaults to `performance.now`. */
+  now?: () => number
+  /** Injected for tests. Defaults to `requestAnimationFrame`. */
+  raf?: (cb: (t: number) => void) => number
+  cancelRaf?: (h: number) => void
+}
+
+export class FeelClock {
+  timeScale = 1
+  /** Where `timeScale` is heading. Slow-motion snaps in and eases out. */
+  private targetScale = 1
+  /** ms over which `timeScale` returns to `targetScale`. */
+  private recoverMs = 1
+  private recoverElapsed = 0
+  private recoverFrom = 1
+
+  hitstopMs = 0
+  paused = false
+
+  tReal = 0
+  tWorld = 0
+  tUi = 0
+  frame = 0
+
+  private running = false
+  private handle = 0
+  private last = 0
+  private readonly listeners: TickFn[] = []
+  private readonly now: () => number
+  private readonly raf: (cb: (t: number) => void) => number
+  private readonly cancelRaf: (h: number) => void
+
+  /** Reused every frame. Never allocate in the loop. */
+  private readonly tick: Tick = {
+    dtReal: 0,
+    dtWorld: 0,
+    dtUi: 0,
+    now: 0,
+    tReal: 0,
+    tWorld: 0,
+    frame: 0,
+    timeScale: 1,
+    hitstopMs: 0,
+    stalled: false,
+  }
+
+  /** Rolling frame-time record for the quality governor. Fixed size, no alloc. */
+  readonly frameTimes = new Float32Array(120)
+  private frameCursor = 0
+
+  constructor(opts: ClockOptions = {}) {
+    const g = globalThis as unknown as {
+      performance?: { now(): number }
+      requestAnimationFrame?: (cb: (t: number) => void) => number
+      cancelAnimationFrame?: (h: number) => void
+    }
+    this.now = opts.now ?? (g.performance ? () => g.performance!.now() : () => Date.now())
+    this.raf =
+      opts.raf ??
+      g.requestAnimationFrame?.bind(g) ??
+      ((cb) => setTimeout(() => cb(this.now()), 16) as unknown as number)
+    this.cancelRaf =
+      opts.cancelRaf ?? g.cancelAnimationFrame?.bind(g) ?? ((h) => clearTimeout(h))
+  }
+
+  /** Register a per-frame callback. Returns an unsubscribe. */
+  onTick(fn: TickFn): () => void {
+    this.listeners.push(fn)
+    return () => {
+      const i = this.listeners.indexOf(fn)
+      if (i >= 0) this.listeners.splice(i, 1)
+    }
+  }
+
+  /** Idempotent. Calling twice does not start a second rAF loop. */
+  start(): void {
+    if (this.running) return
+    this.running = true
+    this.last = this.now()
+    this.handle = this.raf(this.loop)
+  }
+
+  stop(): void {
+    if (!this.running) return
+    this.running = false
+    this.cancelRaf(this.handle)
+  }
+
+  dispose(): void {
+    this.stop()
+    this.listeners.length = 0
+  }
+
+  /**
+   * Freeze the world for `ms` of wall clock. Repeated calls take the maximum
+   * rather than summing — two impacts in the same frame should not stack into a
+   * visible stall. This is the single most abused knob in the kit; the tier
+   * table in `tiers.ts` is the only thing that should be calling it in a
+   * prototype.
+   */
+  hitstop(ms: number): void {
+    if (ms > this.hitstopMs) this.hitstopMs = ms
+  }
+
+  /**
+   * Drop the world to `scale` instantly and ease back to 1 over `recoverMs`.
+   *
+   * Instant-in/eased-out is the canonical shape: a ramped entry reads as lag,
+   * a ramped exit reads as recovery. A ramped *entry* is the mistake that makes
+   * slow-motion feel like a performance problem instead of a moment.
+   */
+  slowmo(scale: number, recoverMs: number): void {
+    this.timeScale = scale
+    this.recoverFrom = scale
+    this.targetScale = 1
+    this.recoverMs = Math.max(1, recoverMs)
+    this.recoverElapsed = 0
+  }
+
+  /**
+   * Cancel every time distortion **now**, without a visible pop.
+   *
+   * Called synchronously at the top of every input handler. Hitstop is dropped
+   * outright (it is short and freezing through a tap is the thing we are
+   * preventing); the time scale is snapped because a child who has already
+   * committed the next answer is not watching the previous flourish.
+   */
+  settleNow(): void {
+    this.hitstopMs = 0
+    this.timeScale = 1
+    this.targetScale = 1
+    this.recoverElapsed = this.recoverMs
+  }
+
+  /** p50/p95 of the last 120 frames, in ms. Feeds the quality governor. */
+  frameStats(): { p50: number; p95: number; worst: number; n: number } {
+    const seen: number[] = []
+    for (let i = 0; i < this.frameTimes.length; i++) {
+      const v = this.frameTimes[i]!
+      if (v > 0) seen.push(v)
+    }
+    if (seen.length === 0) return { p50: 0, p95: 0, worst: 0, n: 0 }
+    seen.sort((a, b) => a - b)
+    const at = (q: number) => seen[Math.min(seen.length - 1, Math.floor(seen.length * q))]!
+    return { p50: at(0.5), p95: at(0.95), worst: seen[seen.length - 1]!, n: seen.length }
+  }
+
+  /** Advance one frame by hand. The tests and the Node benches drive this. */
+  step(rawDt: number): Tick {
+    const t = this.tick
+    const stalled = rawDt > MAX_DT_MS
+    const dtReal = stalled ? MAX_DT_MS : rawDt
+
+    // Slow-motion recovery runs on real time: a slow-motion that slowed its own
+    // recovery would never come back.
+    if (this.timeScale !== this.targetScale) {
+      this.recoverElapsed += dtReal
+      const k = Math.min(1, this.recoverElapsed / this.recoverMs)
+      // outCubic: leaves the slowed state briskly, arrives at 1 without a step.
+      const e = 1 - (1 - k) * (1 - k) * (1 - k)
+      this.timeScale = this.recoverFrom + (this.targetScale - this.recoverFrom) * e
+      if (k >= 1) this.timeScale = this.targetScale
+    }
+
+    let dtWorld: number
+    if (this.hitstopMs > 0) {
+      this.hitstopMs = Math.max(0, this.hitstopMs - dtReal)
+      dtWorld = 0
+    } else {
+      dtWorld = dtReal * this.timeScale
+    }
+
+    const dtUi = this.paused ? 0 : dtReal
+
+    this.tReal += dtReal
+    this.tWorld += dtWorld
+    this.tUi += dtUi
+    this.frame++
+
+    this.frameTimes[this.frameCursor] = dtReal
+    this.frameCursor = (this.frameCursor + 1) % this.frameTimes.length
+
+    t.dtReal = dtReal
+    t.dtWorld = dtWorld
+    t.dtUi = dtUi
+    t.now = this.last
+    t.tReal = this.tReal
+    t.tWorld = this.tWorld
+    t.frame = this.frame
+    t.timeScale = this.timeScale
+    t.hitstopMs = this.hitstopMs
+    t.stalled = stalled
+
+    for (let i = 0; i < this.listeners.length; i++) this.listeners[i]!(t)
+    return t
+  }
+
+  private readonly loop = (): void => {
+    if (!this.running) return
+    this.handle = this.raf(this.loop)
+    const now = this.now()
+    const raw = now - this.last
+    this.last = now
+    this.step(raw)
+  }
+}

--- a/dynawalla/foundations/feel/src/ease.ts
+++ b/dynawalla/foundations/feel/src/ease.ts
@@ -1,0 +1,236 @@
+// Easing curves, by name.
+//
+// Robert Penner's set (the vocabulary every animator already has), plus the
+// four that do the actual work in juice code and are worth naming separately:
+//
+//   outBack      pop-in with a landing overshoot. The single most useful curve
+//                in the kit — every "thing appears" moment uses it.
+//   outElastic   release after a squash. Reads as springy, not bouncy.
+//   outExpo      "fast then settle". The correct curve for anything the child
+//                must be able to read *immediately* — 80% of the travel is done
+//                in the first 25% of the time.
+//   inQuad       anticipation. The wind-up before a pop. Slow start is the
+//                whole point; anything with a fast start cannot anticipate.
+//
+// Everything here is a pure `(t: number) => number` over the unit interval and
+// allocates nothing. `bench/cpu.mjs` measures them; the slowest (outElastic,
+// two transcendentals) costs ~4 ns on an M2 Max, so curve choice is a feel
+// decision and never a performance one.
+//
+// Domain: callers must clamp. `ease.outBack(1.4)` is a defined number and a
+// wrong picture; `tween.ts` clamps at the one place it matters.
+
+export type EaseFn = (t: number) => number
+
+const PI = Math.PI
+const HALF_PI = Math.PI / 2
+
+/** Penner's default overshoot. 1.70158 produces ~10% past the target. */
+export const BACK_OVERSHOOT = 1.70158
+const BACK_IO = BACK_OVERSHOOT * 1.525
+
+export const linear: EaseFn = (t) => t
+
+export const inQuad: EaseFn = (t) => t * t
+export const outQuad: EaseFn = (t) => t * (2 - t)
+export const inOutQuad: EaseFn = (t) => (t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t)
+
+export const inCubic: EaseFn = (t) => t * t * t
+export const outCubic: EaseFn = (t) => {
+  const f = t - 1
+  return f * f * f + 1
+}
+export const inOutCubic: EaseFn = (t) =>
+  t < 0.5 ? 4 * t * t * t : 1 + (t - 1) * (2 * t - 2) * (2 * t - 2)
+
+export const inQuart: EaseFn = (t) => t * t * t * t
+export const outQuart: EaseFn = (t) => 1 - (t - 1) ** 4
+export const inOutQuart: EaseFn = (t) => (t < 0.5 ? 8 * t ** 4 : 1 - 8 * (t - 1) ** 4)
+
+export const inQuint: EaseFn = (t) => t ** 5
+export const outQuint: EaseFn = (t) => 1 + (t - 1) ** 5
+export const inOutQuint: EaseFn = (t) => (t < 0.5 ? 16 * t ** 5 : 1 + 16 * (t - 1) ** 5)
+
+export const inSine: EaseFn = (t) => 1 - Math.cos(t * HALF_PI)
+export const outSine: EaseFn = (t) => Math.sin(t * HALF_PI)
+export const inOutSine: EaseFn = (t) => -(Math.cos(PI * t) - 1) / 2
+
+export const inExpo: EaseFn = (t) => (t <= 0 ? 0 : 2 ** (10 * t - 10))
+export const outExpo: EaseFn = (t) => (t >= 1 ? 1 : 1 - 2 ** (-10 * t))
+export const inOutExpo: EaseFn = (t) =>
+  t <= 0 ? 0 : t >= 1 ? 1 : t < 0.5 ? 2 ** (20 * t - 10) / 2 : (2 - 2 ** (-20 * t + 10)) / 2
+
+export const inCirc: EaseFn = (t) => 1 - Math.sqrt(1 - t * t)
+export const outCirc: EaseFn = (t) => Math.sqrt(1 - (t - 1) * (t - 1))
+export const inOutCirc: EaseFn = (t) =>
+  t < 0.5
+    ? (1 - Math.sqrt(1 - 4 * t * t)) / 2
+    : (Math.sqrt(1 - (-2 * t + 2) ** 2) + 1) / 2
+
+export const inBack: EaseFn = (t) => (BACK_OVERSHOOT + 1) * t * t * t - BACK_OVERSHOOT * t * t
+export const outBack: EaseFn = (t) => {
+  const f = t - 1
+  return 1 + (BACK_OVERSHOOT + 1) * f * f * f + BACK_OVERSHOOT * f * f
+}
+export const inOutBack: EaseFn = (t) =>
+  t < 0.5
+    ? ((2 * t) ** 2 * ((BACK_IO + 1) * 2 * t - BACK_IO)) / 2
+    : ((2 * t - 2) ** 2 * ((BACK_IO + 1) * (t * 2 - 2) + BACK_IO) + 2) / 2
+
+const ELASTIC_C4 = (2 * PI) / 3
+const ELASTIC_C5 = (2 * PI) / 4.5
+
+export const inElastic: EaseFn = (t) =>
+  t <= 0 ? 0 : t >= 1 ? 1 : -(2 ** (10 * t - 10)) * Math.sin((t * 10 - 10.75) * ELASTIC_C4)
+export const outElastic: EaseFn = (t) =>
+  t <= 0 ? 0 : t >= 1 ? 1 : 2 ** (-10 * t) * Math.sin((t * 10 - 0.75) * ELASTIC_C4) + 1
+export const inOutElastic: EaseFn = (t) =>
+  t <= 0
+    ? 0
+    : t >= 1
+      ? 1
+      : t < 0.5
+        ? -(2 ** (20 * t - 10) * Math.sin((20 * t - 11.125) * ELASTIC_C5)) / 2
+        : (2 ** (-20 * t + 10) * Math.sin((20 * t - 11.125) * ELASTIC_C5)) / 2 + 1
+
+export const outBounce: EaseFn = (t) => {
+  const n = 7.5625
+  const d = 2.75
+  if (t < 1 / d) return n * t * t
+  if (t < 2 / d) {
+    const u = t - 1.5 / d
+    return n * u * u + 0.75
+  }
+  if (t < 2.5 / d) {
+    const u = t - 2.25 / d
+    return n * u * u + 0.9375
+  }
+  const u = t - 2.625 / d
+  return n * u * u + 0.984375
+}
+export const inBounce: EaseFn = (t) => 1 - outBounce(1 - t)
+export const inOutBounce: EaseFn = (t) =>
+  t < 0.5 ? (1 - outBounce(1 - 2 * t)) / 2 : (1 + outBounce(2 * t - 1)) / 2
+
+/** Hermite. Zero first derivative at both ends — the honest "smooth" curve. */
+export const smoothstep: EaseFn = (t) => t * t * (3 - 2 * t)
+/** Ken Perlin's improvement: zero *second* derivative too. No visible seam. */
+export const smootherstep: EaseFn = (t) => t * t * t * (t * (t * 6 - 15) + 10)
+
+/**
+ * A hit's shape: instant to peak, decay back to zero. **Not** a 0→1 ease —
+ * this returns to 0, which is what every impact response actually wants
+ * (a flash, a punch, a squash) and what people wrongly build out of an
+ * out-curve plus a second reversed tween.
+ *
+ * `sharpness` > 1 makes the decay snappier.
+ */
+export const spike = (sharpness = 2): EaseFn => {
+  return (t) => {
+    if (t <= 0 || t >= 1) return 0
+    const rise = Math.min(1, t / 0.08)
+    const fall = (1 - (t - 0.08) / 0.92) ** sharpness
+    return t < 0.08 ? rise : Math.max(0, fall)
+  }
+}
+
+/**
+ * A CSS-compatible cubic Bézier, Newton-solved. Use it when a WebGL animation
+ * has to land on the same frame as a CSS transition — matching by eye across
+ * the two systems does not work, and a mismatched pair reads as two things
+ * happening rather than one.
+ *
+ * Returns a closure, so build it once at module scope, never per frame.
+ */
+export function cubicBezier(x1: number, y1: number, x2: number, y2: number): EaseFn {
+  const a = (u: number, v: number) => 1 - 3 * v + 3 * u
+  const b = (u: number, v: number) => 3 * v - 6 * u
+  const c = (u: number) => 3 * u
+  const calc = (t: number, u: number, v: number) => ((a(u, v) * t + b(u, v)) * t + c(u)) * t
+  const slope = (t: number, u: number, v: number) =>
+    3 * a(u, v) * t * t + 2 * b(u, v) * t + c(u)
+
+  return (t) => {
+    if (x1 === y1 && x2 === y2) return t
+    if (t <= 0) return 0
+    if (t >= 1) return 1
+    let guess = t
+    for (let i = 0; i < 8; i++) {
+      const s = slope(guess, x1, x2)
+      if (s === 0) break
+      guess -= (calc(guess, x1, x2) - t) / s
+    }
+    return calc(guess, y1, y2)
+  }
+}
+
+/**
+ * Closed-form under-damped spring, evaluated at a normalised time.
+ *
+ * Deliberately **not** a per-frame integrator. An integrator drifts with frame
+ * rate, so the same "springy pop" is a different animation at 60 and at 120 Hz,
+ * and it cannot be fast-forwarded to its end state — which `settleNow()`
+ * requires of everything in the kit. This is exact at any dt and evaluable at
+ * `t = 1` for the settled value.
+ *
+ * `bounces` is roughly how many overshoots are visible; `damping` 0…1.
+ */
+export function spring(bounces = 2, damping = 0.45): EaseFn {
+  const omega = (bounces + 0.5) * PI
+  const zeta = Math.max(0.0001, Math.min(0.999, damping))
+  const omegaD = omega * Math.sqrt(1 - zeta * zeta)
+  return (t) => {
+    if (t <= 0) return 0
+    if (t >= 1) return 1
+    const env = Math.exp(-zeta * omega * t)
+    return 1 - env * (Math.cos(omegaD * t) + ((zeta * omega) / omegaD) * Math.sin(omegaD * t))
+  }
+}
+
+/** Every curve, by the name an animator would say out loud. */
+export const EASE = {
+  linear,
+  inQuad,
+  outQuad,
+  inOutQuad,
+  inCubic,
+  outCubic,
+  inOutCubic,
+  inQuart,
+  outQuart,
+  inOutQuart,
+  inQuint,
+  outQuint,
+  inOutQuint,
+  inSine,
+  outSine,
+  inOutSine,
+  inExpo,
+  outExpo,
+  inOutExpo,
+  inCirc,
+  outCirc,
+  inOutCirc,
+  inBack,
+  outBack,
+  inOutBack,
+  inElastic,
+  outElastic,
+  inOutElastic,
+  inBounce,
+  outBounce,
+  inOutBounce,
+  smoothstep,
+  smootherstep,
+} as const
+
+export type EaseName = keyof typeof EASE
+
+/** Pre-built curves the kit itself uses, so nothing allocates at call time. */
+export const POP = outBack
+export const SETTLE = outExpo
+export const ANTICIPATE = inQuad
+export const RELEASE = outElastic
+export const SPRING_POP = spring(1, 0.42)
+/** Material Design's standard decelerate, for anything that must feel like UI. */
+export const UI_DECELERATE = cubicBezier(0, 0, 0.2, 1)

--- a/dynawalla/foundations/feel/src/feel.ts
+++ b/dynawalla/foundations/feel/src/feel.ts
@@ -1,0 +1,381 @@
+// The kit. One object, one call per moment.
+//
+// A prototype author writes three lines total:
+//
+//   feel.attach({ camera, invoke })                 // once, at boot
+//   feel.start()                                    // once
+//   feel.answer(outcome, { subject: tile })         // every answer
+//
+// and gets a tuned, coherent seven-system response — haptic, hitstop,
+// slow-motion, shake, directional kick, punch-zoom, flash, squash, tone,
+// particles — at the right tier, at the right quality for the device, that a
+// child can interrupt, that is frame-rate independent, and that allocates
+// nothing per call.
+//
+// Everything below the surface is separately usable. `feel.rig`, `feel.tweens`,
+// `feel.clock` are public because a prototype that wants one specific thing
+// should not have to fight the facade to get it — but the default path has to
+// be one line or the foundation has not done its job.
+//
+// ## Ordering inside `react()` is load-bearing
+//
+// Haptics are dispatched first because they cross the IPC bridge and are the
+// slowest to land. Time distortion is set before the visual systems so that the
+// same frame that starts the flourish is already the slowed one. Audio is last
+// because it is scheduled against the audio clock and does not care when it is
+// called. This ordering is why the flash, the thump and the buzz land together
+// instead of as three events.
+//
+// ## Interruption
+//
+// `press()` calls `interrupt()` synchronously before anything else. Every
+// running flourish jumps to its **end state** — not cancelled mid-pose, not
+// left half-drawn. That is the mechanism behind the product rule that a fast
+// child never waits: there is no reaction in the kit that a tap does not end
+// instantly, and no reaction that ends in an invalid frame.
+
+import { FeelClock, type Tick, type TickFn } from "./clock.ts"
+import { CameraRig, type CameraLike, type CameraRigOptions } from "./camera.ts"
+import { Tweens, CH_REAL, CH_UI, CH_WORLD } from "./tween.ts"
+import { ScreenFlash } from "./flash.ts"
+import { FeelAudio } from "./audio.ts"
+import { Haptics } from "./haptics.ts"
+import { Squash } from "./squash.ts"
+import {
+  QualityGovernor,
+  detectTier,
+  readSignals,
+  type QualitySettings,
+  type QualityTier,
+} from "./quality.ts"
+import { TIERS, chooseTier, type FeelTier, type Outcome, type TierName } from "./tiers.ts"
+import { InputBuffer, TOUCH_CSS, type Target, nearestTarget } from "./input.ts"
+
+export interface AttachOptions {
+  /** A `THREE.Camera`, or anything with `position`/`rotation`. Optional. */
+  camera?: CameraLike | null
+  /** Tauri's `invoke`, for native haptics. Omit in a browser prototype. */
+  invoke?: ((cmd: string, args: Record<string, unknown>) => Promise<unknown>) | null
+  /** Mount point for the flash overlay. Defaults to `document.body`. */
+  parent?: HTMLElement
+  rig?: CameraRigOptions
+  /** Skip boot detection and pin a tier. */
+  quality?: QualityTier
+  /** Inject the touch CSS that makes taps feel instant. Default true. */
+  touchCss?: boolean
+}
+
+export interface ReactOptions {
+  /**
+   * Impact direction, camera space. The kick pushes the camera *along* this,
+   * so pass the direction the force travels. Defaults to a slight downward
+   * settle, which is what "a thing landed in a slot" feels like.
+   */
+  dir?: readonly [number, number, number]
+  /** Normalised screen position of the event, −1…1. Drives lookahead + emit. */
+  at?: readonly [number, number]
+  /** Something with a `.scale` to squash. A mesh, a sprite, a DOM proxy. */
+  subject?: { scale: { x: number; y: number; z: number } } | null
+  /** Scale the whole tier, 0…2. For a prototype that wants one louder moment. */
+  gain?: number
+}
+
+/** Called when a tier wants particles. The prototype owns the particle system. */
+export type EmitFn = (count: number, x: number, y: number, tier: FeelTier) => void
+
+export class Feel {
+  readonly clock = new FeelClock()
+  readonly rig: CameraRig
+  readonly tweens: Tweens
+  readonly flash = new ScreenFlash()
+  readonly audio = new FeelAudio()
+  readonly haptics = new Haptics()
+  readonly governor: QualityGovernor
+  /** Squash channel for whatever `react` was last pointed at. */
+  readonly squash = new Squash()
+
+  private camera: CameraLike | null = null
+  private subject: { scale: { x: number; y: number; z: number } } | null = null
+  private emitters: EmitFn[] = []
+  private blockUntilMs = 0
+  private ascendSpent = false
+  private readonly buffer = new InputBuffer<unknown>()
+  private started = false
+
+  /**
+   * A branch, not a degradation. Motion systems go silent; flash becomes a slow
+   * gentle wash; haptics and audio are untouched, because neither is motion and
+   * a child who needs reduced motion still deserves the whole response.
+   */
+  reducedMotion = false
+
+  /** Diagnostics, surfaced by the demo's HUD and asserted by the tests. */
+  readonly stats = {
+    reactions: 0,
+    interrupts: 0,
+    buffered: 0,
+    blockedTaps: 0,
+    lastInterruptMs: 0,
+  }
+
+  constructor(rigOpts: CameraRigOptions = {}) {
+    const signals = readSignals()
+    this.reducedMotion = signals.prefersReducedMotion ?? false
+    const boot = detectTier(signals)
+    this.governor = new QualityGovernor(boot, { ceiling: "ultra", onChange: this.onQuality })
+    this.rig = new CameraRig(rigOpts)
+    this.tweens = new Tweens(this.governor.settings.tweenCapacity)
+    this.applyQuality(this.governor.settings)
+  }
+
+  /** The process-wide instance. Survives hot reload — one clock, one rAF loop. */
+  static get(): Feel {
+    const g = globalThis as unknown as { __dwFeel?: Feel }
+    g.__dwFeel ??= new Feel()
+    return g.__dwFeel
+  }
+
+  get quality(): QualitySettings {
+    return this.governor.settings
+  }
+
+  attach(opts: AttachOptions = {}): void {
+    this.camera = opts.camera ?? null
+    this.haptics.attach({ invoke: opts.invoke ?? null })
+    this.audio.attach()
+    this.flash.attach({ parent: opts.parent })
+    if (opts.quality) this.governor.force(opts.quality)
+    if (opts.touchCss !== false) injectTouchCss()
+  }
+
+  start(): void {
+    if (this.started) return
+    this.started = true
+    this.clock.onTick(this.tick)
+    this.clock.start()
+  }
+
+  stop(): void {
+    this.clock.stop()
+  }
+
+  dispose(): void {
+    this.clock.dispose()
+    this.flash.dispose()
+    this.audio.dispose()
+    this.tweens.clear()
+    this.emitters.length = 0
+    this.started = false
+    const g = globalThis as unknown as { __dwFeel?: Feel }
+    if (g.__dwFeel === this) delete g.__dwFeel
+  }
+
+  onFrame(fn: TickFn): () => void {
+    return this.clock.onTick(fn)
+  }
+
+  /** Register a particle emitter. The kit decides count and timing, not shape. */
+  onEmit(fn: EmitFn): () => void {
+    this.emitters.push(fn)
+    return () => {
+      const i = this.emitters.indexOf(fn)
+      if (i >= 0) this.emitters.splice(i, 1)
+    }
+  }
+
+  /* ------------------------------------------------------------------ input */
+
+  /** False only during `ascend`'s 350 ms. Everything else is always live. */
+  acceptsInput(): boolean {
+    return this.clock.tReal >= this.blockUntilMs
+  }
+
+  /**
+   * The top of every input handler.
+   *
+   * Interrupts any running flourish, then either reports that the input is live
+   * now (`true`) or buffers it for the moment the gate opens (`false`). A
+   * prototype's handler is:
+   *
+   *   if (!feel.press(answer)) return
+   *   commit(answer)
+   */
+  press<T>(payload: T): boolean {
+    this.interrupt()
+    if (this.acceptsInput()) return true
+    this.buffer.press(payload as unknown)
+    this.stats.blockedTaps++
+    return false
+  }
+
+  /** Take a buffered input if one is waiting and still fresh. */
+  takeBuffered<T>(): T | null {
+    if (!this.acceptsInput()) return null
+    const b = this.buffer.consume(this.clock.tReal)
+    if (!b) return null
+    this.stats.buffered++
+    return b.payload as T
+  }
+
+  /** Fat-finger correction. See `input.ts` for why this is nearest-centre. */
+  hit(targets: readonly Target[], x: number, y: number, slopPx?: number): Target | null {
+    return nearestTarget(targets, x, y, slopPx)
+  }
+
+  /**
+   * Cancel every time distortion and fast-forward every flourish to its end
+   * state. Synchronous, bounded, and measured — `bench/cpu.mjs` reports the
+   * worst case with a full tween pool.
+   */
+  interrupt(): void {
+    const t0 = perfNow()
+    this.clock.settleNow()
+    this.tweens.settle()
+    this.rig.settle()
+    this.flash.settle()
+    this.squash.settle()
+    this.blockUntilMs = 0
+    this.stats.interrupts++
+    this.stats.lastInterruptMs = perfNow() - t0
+  }
+
+  /* --------------------------------------------------------------- reacting */
+
+  /**
+   * The one-liner. Choose the tier from the outcome and fire it.
+   *
+   * `ascend` is spent at most once per session; a second major milestone
+   * downgrades to `bloom` rather than being swallowed, because a milestone that
+   * produces nothing reads as a bug.
+   */
+  answer(outcome: Outcome, opts: ReactOptions = {}): TierName {
+    let tier = chooseTier(outcome)
+    if (tier === "ascend") {
+      if (this.ascendSpent) tier = "bloom"
+      else this.ascendSpent = true
+    }
+    this.react(tier, opts)
+    return tier
+  }
+
+  /** Fire a named tier directly. */
+  react(name: TierName, opts: ReactOptions = {}): void {
+    const t = TIERS[name]
+    const gain = opts.gain ?? 1
+    const q = this.governor.settings
+    this.stats.reactions++
+
+    // 1. Haptics first: async IPC, the slowest thing here to actually land.
+    this.haptics.fire(t.haptic)
+
+    const reduced = this.reducedMotion
+    const motion = reduced ? 0 : q.motionScale * gain
+
+    // 2. Time distortion before the visuals, so the first flourish frame is
+    //    already the slowed one.
+    if (!reduced) {
+      if (t.hitstopMs > 0) this.clock.hitstop(t.hitstopMs)
+      if (t.timeScale < 1) this.clock.slowmo(t.timeScale, t.timeRecoverMs)
+      if (t.blockingMs > 0) this.blockUntilMs = this.clock.tReal + t.blockingMs
+    }
+
+    // 3. Camera.
+    if (motion > 0) {
+      const d = opts.dir ?? DEFAULT_DIR
+      this.rig.impact(t.trauma * motion, t.kick * motion, d[0], d[1], d[2])
+      // Punch-zoom scales with the tier but is capped: past ~6° the perspective
+      // change reads as a lens artifact rather than as force.
+      const fov = Math.min(6, (t.level + 1) * 0.9) * motion
+      if (fov > 0.05) this.rig.punchFov(-fov)
+      if (opts.at) this.rig.lookahead(opts.at[0] * 0.35, opts.at[1] * 0.35)
+    }
+
+    // 4. Flash. Reduced motion keeps it — light is not motion — but slows it
+    //    to a wash and halves the peak.
+    if (t.flash > 0) {
+      const peak = reduced ? t.flash * 0.5 : t.flash * gain
+      const ms = reduced ? 260 : 90 + t.level * 22
+      this.flash.fire(peak, ms, t.flashColor)
+    }
+
+    // 5. Squash the thing that was hit.
+    const subject = opts.subject ?? this.subject
+    if (subject && motion > 0) {
+      this.squash.punch((t.punchScale - 1) * motion)
+      this.subject = subject
+    }
+
+    // 6. Particles: count is the kit's decision, shape is the prototype's.
+    const count = Math.round(t.particles * q.particleScale * gain * (reduced ? 0.25 : 1))
+    if (count > 0 && this.emitters.length > 0) {
+      const x = opts.at?.[0] ?? 0
+      const y = opts.at?.[1] ?? 0
+      for (let i = 0; i < this.emitters.length; i++) this.emitters[i]!(count, x, y, t)
+    }
+
+    // 7. Audio last: scheduled against the audio clock, indifferent to when.
+    if (t.tone !== null) {
+      if (name === "nudge") this.audio.thud(0.6)
+      else if (t.level >= 4) this.audio.chord(t.tone, t.level === 5 ? 6 : 4, 70, 0.75)
+      else this.audio.note(t.tone, 0.45 + t.level * 0.12, 220 + t.level * 90)
+    }
+  }
+
+  /** Sugar for the smallest response: a digit landing, a chip picked up. */
+  tap(opts: ReactOptions = {}): void {
+    this.react("tick", opts)
+  }
+
+  /** Reset the once-a-session budget. Call when a new session starts. */
+  newSession(): void {
+    this.ascendSpent = false
+  }
+
+  /* --------------------------------------------------------------- internals */
+
+  private readonly tick = (t: Tick): void => {
+    this.governor.update(t.dtReal, t.stalled)
+    // Three channels, three updates. This is the whole reason for the split:
+    // the world can be frozen while the UI keeps presenting the next problem.
+    this.tweens.update(CH_WORLD, t.dtWorld)
+    this.tweens.update(CH_UI, t.dtUi)
+    this.tweens.update(CH_REAL, t.dtReal)
+    this.rig.update(t.dtReal)
+    this.flash.update(t.dtReal)
+    this.squash.update(t.dtReal)
+    if (this.subject) this.squash.applyTo(this.subject)
+    if (this.camera) this.rig.applyTo(this.camera)
+  }
+
+  private readonly onQuality = (s: QualitySettings): void => {
+    this.applyQuality(s)
+  }
+
+  private applyQuality(s: QualitySettings): void {
+    this.rig.intensity = this.reducedMotion ? 0 : s.motionScale
+    this.squash.intensity = this.reducedMotion ? 0 : s.motionScale
+    this.flash.intensity = this.reducedMotion ? 0.5 : 1
+  }
+}
+
+const DEFAULT_DIR = [0, -1, 0] as const
+
+function perfNow(): number {
+  const g = globalThis as unknown as { performance?: { now(): number } }
+  return g.performance ? g.performance.now() : Date.now()
+}
+
+let cssInjected = false
+function injectTouchCss(): void {
+  if (cssInjected) return
+  const doc = (globalThis as unknown as { document?: Document }).document
+  if (!doc) return
+  cssInjected = true
+  const style = doc.createElement("style")
+  style.setAttribute("data-dw-feel", "")
+  style.textContent = TOUCH_CSS
+  doc.head.appendChild(style)
+}
+
+/** The instance a prototype imports. */
+export const feel = Feel.get()

--- a/dynawalla/foundations/feel/src/flash.ts
+++ b/dynawalla/foundations/feel/src/flash.ts
@@ -1,0 +1,125 @@
+// Screen-space impact flash — the DOM path.
+//
+// ## Why the cheapest flash is not a WebGL flash
+//
+// The obvious implementation is a fullscreen additive quad, or a post-process
+// pass. Both are fine and the kit ships one (`three/impact-pass.ts`). But a
+// *flat tinted flash* — which is what the great majority of impacts want — is
+// strictly cheaper as a composited DOM layer:
+//
+//   * It costs zero WebGL draw calls and zero render-target bandwidth. A
+//     fullscreen pass at DPR 2 on an iPad is 5.6 M texel reads and writes; the
+//     compositor does the same job in hardware with no GL work at all.
+//   * It survives the GL context being lost, which happens on Android when the
+//     app backgrounds.
+//   * It works when there is no WebGL context, which is every 2D prototype.
+//
+// The measured numbers are in README.md. The rule the kit follows: **flat
+// flashes are DOM, spatial effects are WebGL.**
+//
+// ## Trap: animate `opacity`, never `background-color`
+//
+// `opacity` and `transform` are the only two properties a browser can animate
+// without touching the main thread. Animating `background-color` — or worse,
+// creating and removing the element per flash — forces style recalculation and
+// paint on the exact frame the child is looking at. The element is created
+// once, kept in the DOM forever at `opacity: 0`, and only its opacity moves.
+//
+// ## Trap: `will-change` is not free
+//
+// Setting `will-change: opacity` permanently on a fullscreen element holds a
+// full-screen compositor layer for the life of the app — on a 2732×2048 iPad
+// that is ~22 MB of VRAM doing nothing. It is set only while a flash is live.
+
+export interface FlashOptions {
+  /** Where to mount. Defaults to `document.body`. */
+  parent?: HTMLElement
+  /** `z-index`. Must be above the game and below any modal. */
+  zIndex?: number
+}
+
+export class ScreenFlash {
+  private el: HTMLElement | null = null
+  private live = 0
+  private peak = 0
+  private durationMs = 1
+  private r = 255
+  private g = 255
+  private b = 255
+
+  /** Scales every flash. The governor and reduced-motion turn this down. */
+  intensity = 1
+
+  attach(opts: FlashOptions = {}): void {
+    const doc = (globalThis as unknown as { document?: Document }).document
+    if (!doc || this.el) return
+    const el = doc.createElement("div")
+    el.setAttribute("data-dw-flash", "")
+    el.style.cssText = [
+      "position:fixed",
+      "inset:0",
+      "pointer-events:none",
+      "opacity:0",
+      "mix-blend-mode:screen",
+      `z-index:${String(opts.zIndex ?? 9999)}`,
+      // Own layer from the start so the first flash does not pay for promotion.
+      "transform:translateZ(0)",
+      "contain:strict",
+    ].join(";")
+    ;(opts.parent ?? doc.body).appendChild(el)
+    this.el = el
+  }
+
+  /**
+   * Fire a flash.
+   *
+   * @param peak 0…1 at the brightest frame.
+   * @param durationMs total decay. 90–160 ms; longer reads as a fade, not a hit.
+   * @param color linear RGB 0…1.
+   */
+  fire(peak: number, durationMs = 120, color: readonly [number, number, number] = [1, 1, 1]): void {
+    if (!this.el || peak <= 0) return
+    const p = peak * this.intensity
+    if (p <= 0.001) return
+    // A brighter flash always wins; a dimmer one during a live flash is ignored
+    // rather than restarting the decay, which would make rapid taps strobe.
+    if (this.live > 0 && p <= this.peak * (1 - this.live / this.durationMs)) return
+    this.peak = p
+    this.durationMs = Math.max(1, durationMs)
+    this.live = this.durationMs
+    this.r = Math.round(color[0] * 255)
+    this.g = Math.round(color[1] * 255)
+    this.b = Math.round(color[2] * 255)
+    this.el.style.backgroundColor = `rgb(${String(this.r)},${String(this.g)},${String(this.b)})`
+    this.el.style.willChange = "opacity"
+  }
+
+  /** @param dtRealMs wall clock — a flash must decay through a freeze frame. */
+  update(dtRealMs: number): void {
+    if (!this.el || this.live <= 0) return
+    this.live -= dtRealMs
+    if (this.live <= 0) {
+      this.live = 0
+      this.el.style.opacity = "0"
+      this.el.style.willChange = "auto"
+      return
+    }
+    const k = this.live / this.durationMs
+    // Quadratic decay: the eye's response to a brief luminance spike is closer
+    // to this than to linear, and linear reads as a slow wipe.
+    this.el.style.opacity = String(this.peak * k * k)
+  }
+
+  settle(): void {
+    this.live = 0
+    if (this.el) {
+      this.el.style.opacity = "0"
+      this.el.style.willChange = "auto"
+    }
+  }
+
+  dispose(): void {
+    this.el?.remove()
+    this.el = null
+  }
+}

--- a/dynawalla/foundations/feel/src/haptics.ts
+++ b/dynawalla/foundations/feel/src/haptics.ts
@@ -1,0 +1,147 @@
+// Haptics. Three back-ends, one call, and two traps that cost real time.
+//
+// ## Trap 1 — `navigator.vibrate` does not exist in iOS WKWebView
+//
+// It is not that it fails; it is that it is `undefined`, so a naive
+// `navigator.vibrate?.(10)` is a silent no-op on every iPhone and iPad. A
+// WebView-only haptics implementation therefore *works in the simulator on
+// desktop Chrome*, passes review, and ships with no haptics on half the fleet.
+// The repo already carries `tauri-plugin-haptics` for exactly this reason
+// (`impact(style)` → `UIImpactFeedbackGenerator` / `UINotificationFeedback-
+// Generator` on iOS, `Vibrator`/`VibrationEffect` on Android). This module
+// prefers the plugin and falls back to `navigator.vibrate` only where it exists.
+//
+// ## Trap 2 — the plugin call is async IPC, so haptics land late
+//
+// `invoke()` crosses the WebView bridge. Measured on this machine the desktop
+// round trip is single-digit ms, but the *scheduling* is the problem: fire the
+// haptic from a rAF callback after the render and it lands a frame or more
+// after the pixel. Touch is more latency-sensitive than vision — a haptic
+// 40 ms after the flash reads as a second, unrelated event.
+//
+// So: haptics fire **first**, at the top of the reaction, before any visual
+// work is queued, and they are fire-and-forget (never awaited on the answer
+// path). `feel.react()` calls `haptics.fire()` as its first statement.
+//
+// ## Trap 3 — rate limiting
+//
+// iOS coalesces feedback generators that fire faster than roughly 40 ms apart
+// into mush, and a child mashing a keypad generates exactly that. A minimum
+// interval is enforced here rather than in every prototype, and a stronger
+// style always wins over a weaker one inside the window.
+
+export type HapticStyle = "light" | "medium" | "heavy" | "success" | "warning"
+
+const WEIGHT: Record<HapticStyle, number> = {
+  light: 1,
+  medium: 2,
+  warning: 3,
+  heavy: 4,
+  success: 5,
+}
+
+/** Android `navigator.vibrate` fallback durations, ms. */
+const VIBRATE_MS: Record<HapticStyle, number> = {
+  light: 8,
+  medium: 16,
+  heavy: 28,
+  success: 12,
+  warning: 20,
+}
+
+type Invoke = (cmd: string, args: Record<string, unknown>) => Promise<unknown>
+
+export interface HapticsOptions {
+  /** Minimum ms between two haptics. Below this the stronger one wins. */
+  minIntervalMs?: number
+  /** Injected for tests. */
+  now?: () => number
+}
+
+export class Haptics {
+  enabled = true
+  private readonly minIntervalMs: number
+  private readonly now: () => number
+  private last = -1e9
+  private lastWeight = 0
+  private invoke: Invoke | null = null
+  private vibrate: ((p: number | number[]) => boolean) | null = null
+
+  /** Counts, for the bench and for the "is it actually firing" question. */
+  fired = 0
+  coalesced = 0
+
+  constructor(opts: HapticsOptions = {}) {
+    this.minIntervalMs = opts.minIntervalMs ?? 40
+    const g = globalThis as unknown as { performance?: { now(): number } }
+    this.now = opts.now ?? (g.performance ? () => g.performance!.now() : () => Date.now())
+  }
+
+  /**
+   * Trap 4, found by reading the console rather than by reasoning: Chrome
+   * **blocks** `navigator.vibrate` until the frame has been tapped, and logs an
+   * error every time it is called before then. A juice layer that fires a
+   * haptic on every state change therefore fills the console with errors during
+   * boot animations and any scripted demo — noise that hides real errors.
+   * The gate is the same shape as the audio one and is set by the same gesture.
+   */
+  private gestured = false
+
+  /**
+   * Wire up the platform. Call once at boot.
+   *
+   * Deliberately takes `invoke` rather than importing `@tauri-apps/api`, so the
+   * kit has no Tauri dependency and a browser prototype has nothing to stub.
+   */
+  attach(opts: { invoke?: Invoke | null } = {}): void {
+    this.invoke = opts.invoke ?? null
+    const g = globalThis as unknown as {
+      navigator?: Navigator
+      addEventListener?: (t: string, f: () => void, o?: object) => void
+    }
+    const nav = g.navigator
+    this.vibrate = nav && typeof nav.vibrate === "function" ? nav.vibrate.bind(nav) : null
+    const mark = () => {
+      this.gestured = true
+    }
+    g.addEventListener?.("pointerdown", mark, { once: true, passive: true })
+    g.addEventListener?.("keydown", mark, { once: true })
+  }
+
+  /** True if anything at all will actually happen. Prototypes can branch on it. */
+  get available(): boolean {
+    return this.invoke !== null || this.vibrate !== null
+  }
+
+  /**
+   * Fire and forget. Never returns a promise the answer path could await.
+   *
+   * Within the coalescing window a stronger style replaces a weaker one that
+   * has already fired — a child who taps a digit (`light`) and immediately
+   * commits a correct answer (`success`) 20 ms later should feel the success,
+   * not have it swallowed.
+   */
+  fire(style: HapticStyle | null): void {
+    if (!this.enabled || style === null) return
+    const t = this.now()
+    const w = WEIGHT[style]
+    if (t - this.last < this.minIntervalMs) {
+      if (w <= this.lastWeight) {
+        this.coalesced++
+        return
+      }
+    }
+    this.last = t
+    this.lastWeight = w
+    this.fired++
+
+    if (this.invoke) {
+      // Errors are swallowed on purpose: a missing capability grant must not
+      // reject into the answer path.
+      void this.invoke("plugin:haptics|impact", { args: { style } }).catch(() => {})
+      return
+    }
+    // Only after a real gesture — see `gestured` above.
+    if (this.vibrate && this.gestured) this.vibrate(VIBRATE_MS[style])
+  }
+}

--- a/dynawalla/foundations/feel/src/index.ts
+++ b/dynawalla/foundations/feel/src/index.ts
@@ -1,0 +1,57 @@
+// @dynawalla/feel — the game-feel foundation.
+//
+// The core has **no runtime dependencies**. Three.js appears only in
+// `src/three/`, so a 2D prototype pays nothing for it and the same camera rig,
+// tween pool and tier table serve both.
+
+export { Feel, feel, type AttachOptions, type ReactOptions, type EmitFn } from "./feel.ts"
+export { FeelClock, MAX_DT_MS, type Tick, type TickFn, type Channel } from "./clock.ts"
+export { CameraRig, type CameraLike, type CameraRigOptions, type Vec3Like } from "./camera.ts"
+export { Shake, Kick, noise1, type ShakeOptions } from "./shake.ts"
+export { Spring1D, Spring3D } from "./spring.ts"
+export {
+  Tweens,
+  CH_WORLD,
+  CH_UI,
+  CH_REAL,
+  type TweenChannel,
+  type TweenHandle,
+  type ToOptions,
+} from "./tween.ts"
+export { Squash, pop, ANTICIPATION_MS, RELEASE_MS, type ScaleLike } from "./squash.ts"
+export { ScreenFlash, type FlashOptions } from "./flash.ts"
+export { FeelAudio, snapPentatonic, type FeelAudioOptions } from "./audio.ts"
+export { Haptics, type HapticStyle, type HapticsOptions } from "./haptics.ts"
+export {
+  TIERS,
+  TIER_ORDER,
+  HARD,
+  chooseTier,
+  energy,
+  type FeelTier,
+  type TierName,
+  type Outcome,
+} from "./tiers.ts"
+export {
+  QUALITY,
+  QualityGovernor,
+  detectTier,
+  readSignals,
+  type QualityTier,
+  type QualitySettings,
+  type DetectSignals,
+  type GovernorOptions,
+} from "./quality.ts"
+export {
+  InputBuffer,
+  Coyote,
+  nearestTarget,
+  COYOTE_MS,
+  BUFFER_MS,
+  HIT_SLOP_PX,
+  TOUCH_CSS,
+  type Target,
+  type BufferedInput,
+} from "./input.ts"
+export * as ease from "./ease.ts"
+export { EASE, cubicBezier, spring, spike, type EaseFn, type EaseName } from "./ease.ts"

--- a/dynawalla/foundations/feel/src/input.test.ts
+++ b/dynawalla/foundations/feel/src/input.test.ts
@@ -1,0 +1,80 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { Coyote, InputBuffer, nearestTarget, COYOTE_MS, type Target } from "./input.ts"
+
+const T = (id: string, x: number, y: number, w = 64, h = 64): Target => ({ id, x, y, w, h })
+
+test("coyote time matches Celeste's JumpGraceTime of 100 ms", () => {
+  assert.equal(COYOTE_MS, 100)
+  let t = 0
+  const c = new Coyote(COYOTE_MS, () => t)
+  c.arm()
+  t = 1000
+  c.expire(t)
+  t = 1099
+  assert.ok(c.isOpen(t), "a tap 99 ms after the deadline was already committed")
+  t = 1101
+  assert.ok(!c.isOpen(t))
+})
+
+test("slam closes without grace", () => {
+  let t = 0
+  const c = new Coyote(100, () => t)
+  c.arm()
+  c.slam()
+  assert.ok(!c.isOpen(t))
+})
+
+test("the buffer keeps the newest press, not a queue of them", () => {
+  let t = 0
+  const b = new InputBuffer<string>(180, () => t)
+  b.press("a")
+  b.press("b")
+  b.press("c")
+  const got = b.consume(t)
+  assert.equal(got?.payload, "c", "mashing means go, not go three times")
+  assert.equal(b.consume(t), null)
+})
+
+test("a buffered press outside the window is dropped, not applied late", () => {
+  let t = 0
+  const b = new InputBuffer<string>(180, () => t)
+  b.press("a", 0)
+  t = 400
+  assert.equal(b.consume(t), null)
+  assert.equal(b.expired, 1)
+})
+
+test("the buffered press carries the time the child actually touched glass", () => {
+  const b = new InputBuffer<string>(180, () => 0)
+  b.press("a", 120)
+  const got = b.consume(200)
+  assert.equal(got?.atMs, 120, "latency must be measured from the touch, not the apply")
+})
+
+test("hit slop rescues a tap that lands just below a button", () => {
+  const targets = [T("seven", 100, 100)]
+  assert.equal(nearestTarget(targets, 132, 172, 12)?.id, "seven", "8 px below the bottom edge")
+  assert.equal(nearestTarget(targets, 132, 180, 12), null, "16 px below is a genuine miss")
+})
+
+test("slop never bridges two adjacent answers — nearest centre wins", () => {
+  // Two 64 px keys with a 16 px gap: slop of 12 overlaps in the gap.
+  const targets = [T("a", 0, 0), T("b", 80, 0)]
+  assert.equal(nearestTarget(targets, 70, 32, 12)?.id, "a", "closer to a")
+  assert.equal(nearestTarget(targets, 78, 32, 12)?.id, "b", "closer to b")
+  // The important property: never ambiguous, never both.
+  for (let x = 60; x <= 90; x++) {
+    const hit = nearestTarget(targets, x, 32, 12)
+    assert.ok(hit !== null, `gap at x=${String(x)} produced no hit`)
+  }
+})
+
+test("a tap on empty space stays a tap on empty space", () => {
+  assert.equal(nearestTarget([T("a", 0, 0)], 400, 400, 12), null)
+})
+
+test("disabled targets are not tappable, even with slop", () => {
+  const targets: Target[] = [{ ...T("a", 0, 0), enabled: false }]
+  assert.equal(nearestTarget(targets, 32, 32, 12), null)
+})

--- a/dynawalla/foundations/feel/src/input.ts
+++ b/dynawalla/foundations/feel/src/input.ts
@@ -1,0 +1,222 @@
+// Input forgiveness, ported from the platformer canon to a touch surface.
+//
+// The three techniques that make Celeste feel fair are all really the same
+// idea — *accept the input the player meant* — and all three have an exact
+// analogue in a maths game on a tablet. Values from Celeste's own source
+// (`Source/Player/Player.cs`, verified, not remembered):
+//
+//   private const float JumpGraceTime = 0.1f;      // coyote time, 100 ms
+//   private const int UpwardCornerCorrection = 4;  // 4 px of nudge
+//   private const int DashCornerCorrection = 4;
+//
+// ## Coyote time → the deadline that just passed
+//
+// Celeste lets you jump for 100 ms after you walk off a ledge. We let a tap
+// land for `coyoteMs` after a timed round ends, a countdown hits zero, or the
+// free-tier lamp burns out. A child who was already moving their finger when
+// the timer expired committed to that answer *before* the deadline; refusing it
+// is punishing reaction time, which is not the skill under test. 100 ms is
+// Celeste's number and it is the right order of magnitude here too — long
+// enough to cover the gap between decision and contact, short enough that
+// nobody can exploit it.
+//
+// ## Input buffering → the tap during the flourish
+//
+// Celeste queues a jump pressed slightly before landing. We queue a tap that
+// arrives during a blocking window (only `ascend` has one) or while the next
+// problem is still presenting, and apply it the instant the surface is live.
+// The window here is deliberately **longer** than a platformer's five frames:
+// a child's follow-up tap is a considered action, not a rhythm-game input.
+// 180 ms measured against the tail budgets in `tiers.ts` covers every
+// non-blocking tier completely, so in practice a buffered tap on the common
+// path is applied on the *next frame*, not at the end of anything.
+//
+// ## Corner correction → fat-finger hit slop
+//
+// Celeste nudges you up to 4 px sideways so a jump that clips a corner
+// succeeds. The touch analogue is the highest-value one in the whole file: a
+// tap that lands just outside a target snaps to it. A six-year-old's finger
+// contact patch is ~10 mm and the reported point is its centroid, which sits
+// low and toward the thumb; a tap the child *aimed* at a button routinely lands
+// 6–10 CSS px below it. Without slop that is a mis-tap the child cannot explain
+// and will blame themselves for.
+//
+// Slop is applied as *nearest target within the slop radius*, never as an
+// enlarged hit box, because enlarged boxes overlap and then two adjacent
+// answers both claim the tap. Nearest-centre resolves ties correctly and
+// degrades to exact hit testing when targets are dense.
+
+/** Anything tappable. Coordinates are CSS px in viewport space. */
+export interface Target {
+  readonly id: string
+  readonly x: number
+  readonly y: number
+  readonly w: number
+  readonly h: number
+  readonly enabled?: boolean
+}
+
+/** Celeste's `JumpGraceTime`, in ms. */
+export const COYOTE_MS = 100
+/** Longer than a platformer's, for the reason in the header. */
+export const BUFFER_MS = 180
+/**
+ * Default hit slop, CSS px. Apple's 44×44 pt and Material's 48×48 dp minimums
+ * are about *target size*; slop is about what happens outside it. 12 px is
+ * about half a finger radius and, at the 64–96 px targets this product uses,
+ * never bridges the gap between two adjacent answers.
+ */
+export const HIT_SLOP_PX = 12
+
+/**
+ * Nearest enabled target whose box, grown by `slop`, contains the point.
+ *
+ * Returns the target whose *centre* is nearest when several qualify, which is
+ * the behaviour a child predicts. `null` if the tap was nowhere near anything —
+ * a tap on empty space must stay a tap on empty space or the surface feels
+ * possessed.
+ */
+export function nearestTarget(
+  targets: readonly Target[],
+  px: number,
+  py: number,
+  slop = HIT_SLOP_PX,
+): Target | null {
+  let best: Target | null = null
+  let bestD2 = Infinity
+  for (let i = 0; i < targets.length; i++) {
+    const t = targets[i]!
+    if (t.enabled === false) continue
+    if (px < t.x - slop || px > t.x + t.w + slop) continue
+    if (py < t.y - slop || py > t.y + t.h + slop) continue
+    const cx = t.x + t.w * 0.5
+    const cy = t.y + t.h * 0.5
+    const dx = px - cx
+    const dy = py - cy
+    const d2 = dx * dx + dy * dy
+    if (d2 < bestD2) {
+      bestD2 = d2
+      best = t
+    }
+  }
+  return best
+}
+
+export interface BufferedInput<T> {
+  readonly payload: T
+  /** `performance.now()` at the moment the child actually touched the glass. */
+  readonly atMs: number
+}
+
+/**
+ * A one-slot input buffer with a staleness window.
+ *
+ * One slot, not a queue: a child mashing three times during a flourish means
+ * "go", not "go three times". The newest press replaces the buffered one,
+ * which is what a player expects and what Celeste's `VirtualButton` does.
+ */
+export class InputBuffer<T> {
+  private payload: T | null = null
+  private atMs = 0
+  private readonly windowMs: number
+  private readonly now: () => number
+
+  /** Diagnostics: how often buffering actually saved an input. */
+  saved = 0
+  expired = 0
+
+  constructor(windowMs = BUFFER_MS, now?: () => number) {
+    this.windowMs = windowMs
+    const g = globalThis as unknown as { performance?: { now(): number } }
+    this.now = now ?? (g.performance ? () => g.performance!.now() : () => Date.now())
+  }
+
+  press(payload: T, atMs = this.now()): void {
+    this.payload = payload
+    this.atMs = atMs
+  }
+
+  /** Take the buffered input if it is still fresh. Clears either way. */
+  consume(atMs = this.now()): BufferedInput<T> | null {
+    if (this.payload === null) return null
+    const p = this.payload
+    const t = this.atMs
+    this.payload = null
+    if (atMs - t > this.windowMs) {
+      this.expired++
+      return null
+    }
+    this.saved++
+    return { payload: p, atMs: t }
+  }
+
+  get pending(): boolean {
+    return this.payload !== null
+  }
+
+  clear(): void {
+    this.payload = null
+  }
+}
+
+/**
+ * Coyote time. `arm()` when the window opens; `expire()` when it closes;
+ * `isOpen()` stays true for `graceMs` afterwards.
+ */
+export class Coyote {
+  private closedAt = -Infinity
+  private open = false
+  private readonly graceMs: number
+  private readonly now: () => number
+
+  /** Diagnostics: inputs that only landed because of the grace period. */
+  rescued = 0
+
+  constructor(graceMs = COYOTE_MS, now?: () => number) {
+    this.graceMs = graceMs
+    const g = globalThis as unknown as { performance?: { now(): number } }
+    this.now = now ?? (g.performance ? () => g.performance!.now() : () => Date.now())
+  }
+
+  arm(): void {
+    this.open = true
+    this.closedAt = -Infinity
+  }
+
+  expire(atMs = this.now()): void {
+    if (!this.open) return
+    this.open = false
+    this.closedAt = atMs
+  }
+
+  isOpen(atMs = this.now()): boolean {
+    if (this.open) return true
+    const within = atMs - this.closedAt <= this.graceMs
+    if (within) this.rescued++
+    return within
+  }
+
+  /** Hard close, no grace. For "the session is over" rather than "time is up". */
+  slam(): void {
+    this.open = false
+    this.closedAt = -Infinity
+  }
+}
+
+/**
+ * The WebView touch settings that have to be right or none of the above helps.
+ *
+ * `touch-action: manipulation` removes the 300 ms double-tap-zoom wait that
+ * still exists on iOS for elements the browser thinks might be zoom targets.
+ * `-webkit-tap-highlight-color: transparent` removes the grey flash that lands
+ * *before* our feedback and reads as the real response. `user-select: none`
+ * stops a slightly-long press turning into a text selection and a callout,
+ * which on iOS cancels the pointer sequence outright.
+ *
+ * Applied to the document once by `Feel.attach()`.
+ */
+export const TOUCH_CSS = `
+*{-webkit-tap-highlight-color:transparent}
+html,body{overscroll-behavior:none;touch-action:manipulation}
+.dw-tap{touch-action:manipulation;user-select:none;-webkit-user-select:none;-webkit-touch-callout:none}
+`

--- a/dynawalla/foundations/feel/src/quality.test.ts
+++ b/dynawalla/foundations/feel/src/quality.test.ts
@@ -1,0 +1,76 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { QUALITY, QualityGovernor, detectTier } from "./quality.ts"
+
+test("boot detection is pessimistic — the minimum signal wins", () => {
+  assert.equal(detectTier({ deviceMemoryGb: 8, cores: 8 }), "high")
+  assert.equal(detectTier({ deviceMemoryGb: 8, cores: 4 }), "medium", "4 cores caps it")
+  assert.equal(detectTier({ deviceMemoryGb: 2, cores: 8 }), "low", "2 GB caps it")
+  assert.equal(detectTier({}), "high", "no signals is not evidence of a bad device")
+})
+
+test("a big panel on a modest chip is caught", () => {
+  // The case that quietly kills mid-range tablets: looks fine on paper, is
+  // filling six megapixels a frame.
+  assert.equal(detectTier({ cores: 6, devicePixels: 6_000_000 }), "medium")
+  assert.equal(detectTier({ cores: 8, devicePixels: 6_000_000 }), "high")
+})
+
+test("the governor does not demote on a single stutter", () => {
+  const g = new QualityGovernor("high")
+  for (let i = 0; i < 60; i++) g.update(16.6, false)
+  g.update(48, false) // one dropped frame
+  for (let i = 0; i < 60; i++) g.update(16.6, false)
+  assert.equal(g.settings.tier, "high")
+  assert.equal(g.demotions, 0)
+})
+
+test("the governor demotes on sustained overrun", () => {
+  const g = new QualityGovernor("ultra")
+  for (let i = 0; i < 400; i++) g.update(33, false)
+  assert.ok(g.demotions >= 1, "never demoted despite 30 fps for 13 seconds")
+  assert.notEqual(g.settings.tier, "ultra")
+})
+
+test("a clamped stall frame is not counted against the renderer", () => {
+  // A tab switch or a notification must not demote the whole app.
+  const g = new QualityGovernor("high")
+  for (let i = 0; i < 400; i++) g.update(50, true)
+  assert.equal(g.demotions, 0)
+})
+
+test("the governor promotes only with sustained headroom, and settles", () => {
+  const g = new QualityGovernor("low")
+  for (let i = 0; i < 4000; i++) g.update(8, false)
+  assert.ok(g.promotions >= 1)
+  // And then it must stop moving rather than oscillate.
+  const settledAt = g.settings.tier
+  const before = g.demotions + g.promotions
+  for (let i = 0; i < 600; i++) g.update(8, false)
+  const moved = g.demotions + g.promotions - before
+  assert.ok(moved <= 1, `oscillated ${String(moved)} times after settling at ${settledAt}`)
+})
+
+test("the ceiling is respected", () => {
+  const g = new QualityGovernor("low", { ceiling: "medium" })
+  for (let i = 0; i < 8000; i++) g.update(6, false)
+  assert.equal(g.settings.tier, "medium")
+})
+
+test("every tier draws every effect — none of them is a feature switch", () => {
+  for (const t of ["low", "medium", "high", "ultra"] as const) {
+    const q = QUALITY[t]
+    assert.ok(q.particleScale > 0, `${t} has no particles at all`)
+    assert.ok(q.motionScale > 0, `${t} has no motion at all`)
+    assert.ok(q.maxPixelRatio >= 1)
+  }
+})
+
+test("quality is monotonic across the ladder", () => {
+  const l = [QUALITY.low, QUALITY.medium, QUALITY.high, QUALITY.ultra]
+  for (let i = 1; i < l.length; i++) {
+    assert.ok(l[i]!.maxPixelRatio >= l[i - 1]!.maxPixelRatio)
+    assert.ok(l[i]!.particleScale >= l[i - 1]!.particleScale)
+    assert.ok(l[i]!.tweenCapacity >= l[i - 1]!.tweenCapacity)
+  }
+})

--- a/dynawalla/foundations/feel/src/quality.ts
+++ b/dynawalla/foundations/feel/src/quality.ts
@@ -1,0 +1,270 @@
+// Quality tiers and the runtime governor.
+//
+// The brief: the mid-range tablet sets the **floor**, never the ceiling. So
+// there are four tiers, ULTRA is genuinely staggering, and the machine decides
+// which one it is running — twice. Once at boot from what it can see, and then
+// continuously from what actually happened, because boot-time detection is a
+// guess and a thermally-throttled iPad in a warm classroom at minute forty is
+// not the device that booted.
+//
+// ## Boot detection is deliberately pessimistic
+//
+// `deviceMemory` is Chromium-only and clamped to 8 even on a 64 GB machine.
+// `hardwareConcurrency` on an iPad reports performance+efficiency cores
+// together. `WEBGL_debug_renderer_info` is gated behind a privacy flag in
+// Safari and returns a masked string. Every signal is either missing, lying, or
+// both, so boot detection picks the **lower** of what the signals suggest and
+// lets the governor promote upward once frames prove it. Starting low and
+// promoting is invisible; starting high and demoting is a visible stutter in
+// the first ten seconds, which is exactly when a child decides what they think.
+//
+// ## The governor has hysteresis or it oscillates
+//
+// A naive "p95 > budget → demote" flips tiers every second at the boundary,
+// and tier changes are visible. Demotion needs sustained evidence (2 s) and
+// promotion needs much more (8 s) plus headroom, so the system settles.
+//
+// ## What a tier actually controls
+//
+// Not "effects on/off". Every tier draws every effect — a LOW-tier child gets
+// the same *language*, at a smaller budget. Turning effects off by tier is how
+// you end up shipping two different products.
+
+export type QualityTier = "low" | "medium" | "high" | "ultra"
+
+export interface QualitySettings {
+  readonly tier: QualityTier
+  /** Cap on `devicePixelRatio`. The single biggest lever on GPU cost. */
+  readonly maxPixelRatio: number
+  /** Multiplier on every tier's particle count. */
+  readonly particleScale: number
+  /** Multiplier on shake, kick and fov punch. Never 0 — see the header. */
+  readonly motionScale: number
+  /** Run the composited post-processing pass (flash, vignette, chroma, bloom). */
+  readonly postFx: boolean
+  /** Bloom inside the post pass. The expensive half of it. */
+  readonly bloom: boolean
+  /** Shadow map edge, or 0 for none. */
+  readonly shadowMapSize: number
+  /** Tween pool size. A bigger pool costs memory, not time. */
+  readonly tweenCapacity: number
+  /** Target frame budget in ms. 16.67 = 60 fps. */
+  readonly frameBudgetMs: number
+}
+
+export const QUALITY: Readonly<Record<QualityTier, QualitySettings>> = {
+  low: {
+    tier: "low",
+    maxPixelRatio: 1,
+    particleScale: 0.3,
+    motionScale: 0.8,
+    postFx: false,
+    bloom: false,
+    shadowMapSize: 0,
+    tweenCapacity: 96,
+    frameBudgetMs: 16.67,
+  },
+  medium: {
+    tier: "medium",
+    maxPixelRatio: 1.5,
+    particleScale: 0.6,
+    motionScale: 1,
+    postFx: true,
+    bloom: false,
+    shadowMapSize: 512,
+    tweenCapacity: 192,
+    frameBudgetMs: 16.67,
+  },
+  high: {
+    tier: "high",
+    maxPixelRatio: 2,
+    particleScale: 1,
+    motionScale: 1,
+    postFx: true,
+    bloom: true,
+    shadowMapSize: 1024,
+    tweenCapacity: 320,
+    frameBudgetMs: 16.67,
+  },
+  ultra: {
+    tier: "ultra",
+    maxPixelRatio: 2.5,
+    particleScale: 1.6,
+    motionScale: 1.1,
+    postFx: true,
+    bloom: true,
+    shadowMapSize: 2048,
+    tweenCapacity: 512,
+    frameBudgetMs: 16.67,
+  },
+}
+
+const LADDER: readonly QualityTier[] = ["low", "medium", "high", "ultra"]
+
+export interface DetectSignals {
+  deviceMemoryGb?: number
+  cores?: number
+  pixelRatio?: number
+  /** Unmasked GPU string if available. Usually is not. */
+  renderer?: string
+  /** Screen area in device pixels. A big canvas is a real cost. */
+  devicePixels?: number
+  prefersReducedMotion?: boolean
+}
+
+/** Read whatever this platform is willing to admit to. */
+export function readSignals(): DetectSignals {
+  const g = globalThis as unknown as {
+    navigator?: { deviceMemory?: number; hardwareConcurrency?: number }
+    devicePixelRatio?: number
+    screen?: { width: number; height: number }
+    matchMedia?: (q: string) => { matches: boolean }
+  }
+  const dpr = g.devicePixelRatio ?? 1
+  const w = g.screen?.width ?? 0
+  const h = g.screen?.height ?? 0
+  return {
+    deviceMemoryGb: g.navigator?.deviceMemory,
+    cores: g.navigator?.hardwareConcurrency,
+    pixelRatio: dpr,
+    devicePixels: w * h * dpr * dpr,
+    prefersReducedMotion: g.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false,
+  }
+}
+
+/**
+ * Boot-time tier. Pessimistic by construction: each signal proposes a tier and
+ * the **minimum** wins.
+ */
+export function detectTier(s: DetectSignals): QualityTier {
+  let idx = 2 // start at "high" and let evidence pull it down
+
+  const mem = s.deviceMemoryGb
+  if (mem !== undefined) {
+    // Chromium clamps this to 8, so 8 means "8 or more" and proves nothing
+    // above high. 2 and 4 are real signals and they are bad ones.
+    if (mem <= 2) idx = Math.min(idx, 0)
+    else if (mem <= 4) idx = Math.min(idx, 1)
+  }
+
+  const cores = s.cores
+  if (cores !== undefined) {
+    if (cores <= 2) idx = Math.min(idx, 0)
+    else if (cores <= 4) idx = Math.min(idx, 1)
+  }
+
+  // A large panel at a high DPR is the case that quietly kills mid-range
+  // tablets: the device looks fine on paper and is filling 6 MP a frame.
+  const px = s.devicePixels ?? 0
+  if (px > 5_000_000 && (cores ?? 8) < 8) idx = Math.min(idx, 1)
+
+  return LADDER[Math.max(0, Math.min(LADDER.length - 1, idx))]!
+}
+
+export interface GovernorOptions {
+  /** Sustained ms over budget before demoting. */
+  demoteAfterMs?: number
+  /** Sustained ms comfortably under budget before promoting. */
+  promoteAfterMs?: number
+  /** Ceiling the governor may never exceed. Set by boot detection. */
+  ceiling?: QualityTier
+  onChange?: (settings: QualitySettings, reason: string) => void
+}
+
+/**
+ * Watches p95 frame time and moves the tier.
+ *
+ * Feed it `dtReal` every frame. It keeps a 120-sample ring, which at 60 fps is
+ * two seconds — long enough that a single GC pause cannot demote the whole app,
+ * short enough to react before a child notices a sustained stutter.
+ */
+export class QualityGovernor {
+  settings: QualitySettings
+  private idx: number
+  private ceilingIdx: number
+  private overMs = 0
+  private underMs = 0
+  private readonly demoteAfterMs: number
+  private readonly promoteAfterMs: number
+  private readonly onChange: ((s: QualitySettings, reason: string) => void) | null
+
+  private readonly ring = new Float32Array(120)
+  private cursor = 0
+  private filled = 0
+  private readonly scratch = new Float32Array(120)
+
+  /** Diagnostics. */
+  demotions = 0
+  promotions = 0
+
+  constructor(start: QualityTier = "high", opts: GovernorOptions = {}) {
+    this.idx = LADDER.indexOf(start)
+    this.ceilingIdx = LADDER.indexOf(opts.ceiling ?? "ultra")
+    if (this.idx > this.ceilingIdx) this.idx = this.ceilingIdx
+    this.settings = QUALITY[LADDER[this.idx]!]!
+    this.demoteAfterMs = opts.demoteAfterMs ?? 2000
+    this.promoteAfterMs = opts.promoteAfterMs ?? 8000
+    this.onChange = opts.onChange ?? null
+  }
+
+  /** p95 of the ring, in ms. 0 until the ring has 30 samples. */
+  p95(): number {
+    if (this.filled < 30) return 0
+    const n = this.filled
+    this.scratch.set(this.ring.subarray(0, n))
+    const view = this.scratch.subarray(0, n)
+    view.sort()
+    return view[Math.min(n - 1, Math.floor(n * 0.95))]!
+  }
+
+  update(dtRealMs: number, stalled: boolean): void {
+    // A clamped frame is a tab switch or a GC, not a rendering cost. Counting
+    // it demotes the whole app because someone got a notification.
+    if (stalled) return
+
+    this.ring[this.cursor] = dtRealMs
+    this.cursor = (this.cursor + 1) % this.ring.length
+    if (this.filled < this.ring.length) this.filled++
+
+    const budget = this.settings.frameBudgetMs
+    const p = this.p95()
+    if (p === 0) return
+
+    if (p > budget * 1.25) {
+      this.overMs += dtRealMs
+      this.underMs = 0
+      if (this.overMs >= this.demoteAfterMs && this.idx > 0) {
+        this.idx--
+        this.apply(`p95 ${p.toFixed(1)}ms over budget`)
+        this.demotions++
+        this.overMs = 0
+      }
+    } else if (p < budget * 0.7) {
+      this.underMs += dtRealMs
+      this.overMs = 0
+      if (this.underMs >= this.promoteAfterMs && this.idx < this.ceilingIdx) {
+        this.idx++
+        this.apply(`p95 ${p.toFixed(1)}ms with headroom`)
+        this.promotions++
+        this.underMs = 0
+      }
+    } else {
+      this.overMs = 0
+      this.underMs = 0
+    }
+  }
+
+  /** Force a tier, e.g. from a settings screen. Also becomes the new ceiling. */
+  force(tier: QualityTier): void {
+    this.idx = LADDER.indexOf(tier)
+    this.ceilingIdx = this.idx
+    this.apply("forced")
+  }
+
+  private apply(reason: string): void {
+    this.settings = QUALITY[LADDER[this.idx]!]!
+    this.filled = 0
+    this.cursor = 0
+    this.onChange?.(this.settings, reason)
+  }
+}

--- a/dynawalla/foundations/feel/src/shake.test.ts
+++ b/dynawalla/foundations/feel/src/shake.test.ts
@@ -1,0 +1,167 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { Kick, Shake, noise1 } from "./shake.ts"
+
+test("noise is coherent where random is not — this is shake vs buzz", () => {
+  // Sample the noise and Math.random at the same rate the shake does and
+  // compare mean absolute frame-to-frame delta. Coherent noise moves smoothly;
+  // uncorrelated random jumps by ~0.5 of full range every frame, which is the
+  // visual difference between a camera shaking and a camera vibrating.
+  const step = 26 / 60 // 26 Hz sampled at 60 fps
+  let noiseDelta = 0
+  let prev = noise1(0, 7)
+  for (let i = 1; i < 2000; i++) {
+    const v = noise1(i * step, 7)
+    noiseDelta += Math.abs(v - prev)
+    prev = v
+  }
+  noiseDelta /= 1999
+
+  let randDelta = 0
+  let p = Math.random() * 2 - 1
+  for (let i = 1; i < 2000; i++) {
+    const v = Math.random() * 2 - 1
+    randDelta += Math.abs(v - p)
+    p = v
+  }
+  randDelta /= 1999
+
+  assert.ok(
+    noiseDelta < randDelta * 0.55,
+    `noise ${noiseDelta.toFixed(3)} vs random ${randDelta.toFixed(3)}`,
+  )
+})
+
+test("noise is continuous across integer boundaries", () => {
+  for (let i = -3; i < 3; i++) {
+    const a = noise1(i + 0.999, 11)
+    const b = noise1(i + 1.001, 11)
+    assert.ok(Math.abs(a - b) < 0.02, `discontinuity at ${String(i + 1)}`)
+  }
+})
+
+test("noise stays inside [-1, 1]", () => {
+  let lo = 1
+  let hi = -1
+  for (let i = 0; i < 20000; i++) {
+    const v = noise1(i * 0.37, 3)
+    if (v < lo) lo = v
+    if (v > hi) hi = v
+  }
+  assert.ok(lo >= -1 && hi <= 1, `range ${lo.toFixed(3)}..${hi.toFixed(3)}`)
+})
+
+test("amplitude is trauma squared — a small hit barely registers", () => {
+  const s = new Shake({ decayPerSec: 0, exponent: 2, maxOffset: 100 })
+  s.add(0.5)
+  let halfPeak = 0
+  for (let i = 0; i < 200; i++) {
+    s.update(16.67)
+    halfPeak = Math.max(halfPeak, Math.abs(s.x))
+  }
+  const s2 = new Shake({ decayPerSec: 0, exponent: 2, maxOffset: 100 })
+  s2.add(1)
+  let fullPeak = 0
+  for (let i = 0; i < 200; i++) {
+    s2.update(16.67)
+    fullPeak = Math.max(fullPeak, Math.abs(s2.x))
+  }
+  // Quadratic: half the trauma is a quarter of the shake, not half of it.
+  const ratio = halfPeak / fullPeak
+  assert.ok(ratio > 0.2 && ratio < 0.3, `ratio ${ratio.toFixed(3)} is not quadratic`)
+})
+
+test("trauma decays to exactly zero and the output stops", () => {
+  const s = new Shake({ decayPerSec: 1.4 })
+  s.add(1)
+  for (let i = 0; i < 120; i++) s.update(16.67)
+  assert.equal(s.trauma, 0)
+  assert.equal(s.x, 0)
+  assert.equal(s.y, 0)
+  assert.equal(s.roll, 0)
+})
+
+test("trauma saturates — you cannot bank shake", () => {
+  const s = new Shake()
+  for (let i = 0; i < 20; i++) s.add(0.5)
+  assert.equal(s.trauma, 1)
+})
+
+test("the three axes are decorrelated, not one wave delayed", () => {
+  const s = new Shake({ decayPerSec: 0, maxOffset: 1, maxRoll: 1 })
+  s.add(1)
+  let dot = 0
+  let nx = 0
+  let ny = 0
+  for (let i = 0; i < 600; i++) {
+    s.update(16.67)
+    dot += s.x * s.y
+    nx += s.x * s.x
+    ny += s.y * s.y
+  }
+  const corr = Math.abs(dot / Math.sqrt(nx * ny))
+  assert.ok(corr < 0.3, `x and y correlate at ${corr.toFixed(3)} — reads as a diagonal slide`)
+})
+
+test("settle bleeds off rather than snapping to zero", () => {
+  const s = new Shake()
+  s.add(1)
+  s.update(16.67)
+  s.settle()
+  assert.ok(s.trauma > 0 && s.trauma <= 0.08, "a hard cut to zero reads as a bug")
+})
+
+test("kick is directional and returns", () => {
+  const k = new Kick()
+  k.add(5, 0, 0)
+  let maxX = 0
+  let maxY = 0
+  for (let i = 0; i < 200; i++) {
+    k.update(16.67)
+    maxX = Math.max(maxX, Math.abs(k.x))
+    maxY = Math.max(maxY, Math.abs(k.y))
+  }
+  assert.ok(maxX > 0.01, "no travel along the impact axis")
+  assert.equal(maxY, 0, "an X impulse must not move Y")
+  assert.ok(k.isAtRest())
+})
+
+test("kick overshoots exactly once — the thunk", () => {
+  // Counting raw sign changes counts the denormal tail too: the first version
+  // of this test reported 67 crossings for a spring whose *visible* motion
+  // crosses zero once. Crossings are only counted above 2% of peak, which is
+  // roughly where a 0.3-unit camera recoil stops being a pixel.
+  const k = new Kick()
+  k.add(0, -0.3, 0)
+  const ys: number[] = []
+  let peak = 0
+  for (let i = 0; i < 300; i++) {
+    k.update(8)
+    ys.push(k.y)
+    peak = Math.max(peak, Math.abs(k.y))
+  }
+  let crossings = 0
+  let sign = 0
+  for (const y of ys) {
+    if (Math.abs(y) < peak * 0.02) continue
+    const cur = Math.sign(y)
+    if (cur !== 0 && sign !== 0 && cur !== sign) crossings++
+    if (cur !== 0) sign = cur
+  }
+  assert.equal(crossings, 1, `${String(crossings)} visible crossings`)
+})
+
+test("kick arguments are peak displacement, not arbitrary impulse", () => {
+  // The bug this catches: a tier asking for a 0.3-unit recoil got 0.00125.
+  const k = new Kick()
+  k.add(0, -0.3, 0)
+  let peak = 0
+  for (let i = 0; i < 200; i++) {
+    k.update(4)
+    peak = Math.max(peak, Math.abs(k.y))
+  }
+  assert.ok(
+    Math.abs(peak - 0.3) < 0.02,
+    `asked for 0.3 units of recoil, got ${peak.toFixed(4)}`,
+  )
+})

--- a/dynawalla/foundations/feel/src/shake.ts
+++ b/dynawalla/foundations/feel/src/shake.ts
@@ -1,0 +1,197 @@
+// Trauma-based screen shake, after Squirrel Eiserloh's GDC talk "Math for Game
+// Programmers: Juicing Your Cameras With Math".
+//
+// Three rules, and all three are the difference between shake and vibration:
+//
+//   1. **Store trauma, not shake.** Callers add trauma in 0…1; the visible
+//      amplitude is `trauma^exponent`. The square is what makes a small hit
+//      barely register and a big one feel violent — a linear mapping makes
+//      every impact feel the same weight, which is the commonest mistake.
+//   2. **Sample noise, not random.** `Math.random()` per frame produces a
+//      buzz — successive frames are uncorrelated, so the camera teleports and
+//      the eye reads it as a rendering fault. Coherent noise produces a smooth
+//      excursion the eye reads as *motion*. This is the single most important
+//      line in the file.
+//   3. **Decay trauma linearly, per second.** Exponential decay never ends and
+//      leaves a permanent low-level jitter that people describe as "the screen
+//      feels loose".
+//
+// ## Direction is a kick, not a biased shake
+//
+// The obvious way to make an impact feel directional is to scale the noise
+// per axis toward the impact vector. It does not work: noise is symmetric
+// about zero, so a "biased" shake still spends half its time moving *into* the
+// impact. What reads as directional is a **recoil** — a one-way displacement
+// that springs back — which is why `Kick` is a spring and lives beside the
+// shake rather than inside it. Celeste does exactly this split
+// (`level.DirectionalShake(dir, .1f)` alongside its undirected `level.Shake()`).
+//
+// ## Shake runs on real time
+//
+// Deliberate. During a freeze frame the world stops and the camera keeps
+// shaking — that contrast is what sells the freeze. A shake that froze with the
+// world would make hitstop read as a hang.
+
+import { Spring1D } from "./spring.ts"
+
+/* ------------------------------------------------------------------ noise */
+
+/** Integer hash → [-1, 1]. Deterministic, allocation-free, ~1 ns. */
+function hash1(i: number, seed: number): number {
+  let h = (i | 0) ^ Math.imul(seed | 0, 0x9e3779b9)
+  h = Math.imul(h ^ (h >>> 16), 0x85ebca6b)
+  h = Math.imul(h ^ (h >>> 13), 0xc2b2ae35)
+  h ^= h >>> 16
+  // >>> 0 then map to [-1,1]. Avoids the sign-bit discontinuity of |0.
+  return (h >>> 0) / 2147483647.5 - 1
+}
+
+/**
+ * 1-D value noise with a smootherstep fade. Continuous in value and in first
+ * *and* second derivative, which is why it reads as a physical wobble rather
+ * than a stack of ramps.
+ */
+export function noise1(x: number, seed: number): number {
+  const i = Math.floor(x)
+  const f = x - i
+  const a = hash1(i, seed)
+  const b = hash1(i + 1, seed)
+  const u = f * f * f * (f * (f * 6 - 15) + 10)
+  return a + (b - a) * u
+}
+
+/* ------------------------------------------------------------------ shake */
+
+export interface ShakeOptions {
+  /** Trauma lost per second. 1.4 ≈ a 0.7-trauma hit is gone in half a second. */
+  decayPerSec?: number
+  /** `amplitude = trauma ** exponent`. 2 is Eiserloh's; 3 is punchier. */
+  exponent?: number
+  /**
+   * Excursions per second. 22–30 Hz is the band that reads as impact.
+   * Below ~12 Hz it reads as a wobble; above ~40 Hz the sample rate at 60 fps
+   * aliases and you are back to buzz.
+   */
+  frequencyHz?: number
+  /** Max positional excursion at trauma = 1, in the caller's units. */
+  maxOffset?: number
+  /** Max roll at trauma = 1, in radians. ~0.05 rad (2.9°) is plenty. */
+  maxRoll?: number
+}
+
+export class Shake {
+  trauma = 0
+  private t = 0
+  private readonly decayPerSec: number
+  private readonly exponent: number
+  private readonly frequencyHz: number
+  private readonly maxOffset: number
+  private readonly maxRoll: number
+
+  /** Output, rewritten in place each frame. Read after `update`. */
+  x = 0
+  y = 0
+  roll = 0
+
+  /** Scales all output. The quality governor turns this down, never off. */
+  intensity = 1
+
+  constructor(opts: ShakeOptions = {}) {
+    this.decayPerSec = opts.decayPerSec ?? 1.4
+    this.exponent = opts.exponent ?? 2
+    this.frequencyHz = opts.frequencyHz ?? 26
+    this.maxOffset = opts.maxOffset ?? 1
+    this.maxRoll = opts.maxRoll ?? 0.045
+  }
+
+  /** Add trauma. Saturates at 1 — you cannot bank shake for later. */
+  add(amount: number): void {
+    this.trauma = Math.min(1, this.trauma + amount)
+  }
+
+  /** Bleed off fast without a pop. `settleNow()` uses this, not `trauma = 0`. */
+  settle(): void {
+    this.trauma = Math.min(this.trauma, 0.08)
+  }
+
+  clear(): void {
+    this.trauma = 0
+    this.x = 0
+    this.y = 0
+    this.roll = 0
+  }
+
+  /** @param dtRealMs wall-clock ms. Never world time — see the header. */
+  update(dtRealMs: number): void {
+    if (this.trauma <= 0) {
+      this.x = 0
+      this.y = 0
+      this.roll = 0
+      return
+    }
+    const dtSec = dtRealMs * 0.001
+    this.t += dtSec * this.frequencyHz
+    this.trauma = Math.max(0, this.trauma - this.decayPerSec * dtSec)
+
+    const amp = this.trauma ** this.exponent * this.intensity
+    // Three *different seeds*, one shared time. Sharing the seed and offsetting
+    // time makes x and y the same wave delayed, which reads as a diagonal slide.
+    this.x = noise1(this.t, 1013) * amp * this.maxOffset
+    this.y = noise1(this.t, 7919) * amp * this.maxOffset
+    this.roll = noise1(this.t, 3571) * amp * this.maxRoll
+  }
+}
+
+/* ------------------------------------------------------------------- kick */
+
+/**
+ * Directional recoil. An impulse along a direction that springs back.
+ *
+ * Frequency is deliberately high (18 Hz) and damping just under critical, so
+ * the return has exactly one small overshoot — the "thunk" that makes a hit
+ * feel like it landed on something solid rather than passed through it.
+ */
+export class Kick {
+  private readonly sx = new Spring1D(18, 0.62)
+  private readonly sy = new Spring1D(18, 0.62)
+  private readonly sz = new Spring1D(18, 0.62)
+
+  x = 0
+  y = 0
+  z = 0
+  intensity = 1
+
+  /**
+   * Arguments are **peak displacement in the caller's units**, not raw impulse.
+   *
+   * `add(0, -0.28, 0)` moves the camera 0.28 world units down at the peak of
+   * the recoil and springs back. This is the API the tier table can be tuned
+   * against; raw impulse is not, because the conversion factor is ~0.004 and
+   * nobody notices that their numbers are 250× too small.
+   */
+  add(dx: number, dy: number, dz = 0): void {
+    const k = this.sx.impulseForPeak(1) * this.intensity
+    this.sx.impulse(dx * k)
+    this.sy.impulse(dy * k)
+    this.sz.impulse(dz * k)
+  }
+
+  update(dtRealMs: number): void {
+    this.x = this.sx.update(dtRealMs)
+    this.y = this.sy.update(dtRealMs)
+    this.z = this.sz.update(dtRealMs)
+  }
+
+  settle(): void {
+    this.sx.settle()
+    this.sy.settle()
+    this.sz.settle()
+    this.x = 0
+    this.y = 0
+    this.z = 0
+  }
+
+  isAtRest(): boolean {
+    return this.sx.isAtRest() && this.sy.isAtRest() && this.sz.isAtRest()
+  }
+}

--- a/dynawalla/foundations/feel/src/spring.test.ts
+++ b/dynawalla/foundations/feel/src/spring.test.ts
@@ -1,0 +1,96 @@
+// The claim this file exists to prove: the springs are frame-rate independent.
+//
+// This is not a nicety. An iPad Pro runs at 120 Hz, a budget Android at 60, and
+// several Androids at an adaptive 90. If a spring integrates differently at
+// each, then every impact in the product is a different animation per device
+// and the tuning is meaningless. A numerically-integrated spring fails this
+// test; the exponential integrator in `spring.ts` passes it to float precision.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { Spring1D } from "./spring.ts"
+
+test("one 16 ms step equals sixteen 1 ms steps", () => {
+  for (const zeta of [1, 0.45, 1.8]) {
+    const coarse = new Spring1D(12, zeta)
+    const fine = new Spring1D(12, zeta)
+    coarse.impulse(40)
+    fine.impulse(40)
+    for (let i = 0; i < 40; i++) {
+      coarse.update(16)
+      for (let k = 0; k < 16; k++) fine.update(1)
+    }
+    assert.ok(
+      Math.abs(coarse.x - fine.x) < 1e-9,
+      `zeta=${String(zeta)} diverged: ${String(coarse.x)} vs ${String(fine.x)}`,
+    )
+  }
+})
+
+test("60 Hz and 120 Hz reach the same place at the same wall-clock time", () => {
+  const a = new Spring1D(14, 0.5)
+  const b = new Spring1D(14, 0.5)
+  a.impulse(25)
+  b.impulse(25)
+  // 500 ms of wall clock, both ways.
+  for (let i = 0; i < 30; i++) a.update(1000 / 60)
+  for (let i = 0; i < 60; i++) b.update(1000 / 120)
+  assert.ok(Math.abs(a.x - b.x) < 1e-9, `${String(a.x)} vs ${String(b.x)}`)
+})
+
+test("a stiff spring at a clamped 50 ms step stays bounded", () => {
+  // Semi-implicit Euler explodes here. This is the tab-switch case.
+  const s = new Spring1D(25, 0.4)
+  s.impulse(200)
+  for (let i = 0; i < 20; i++) s.update(50)
+  assert.ok(Number.isFinite(s.x) && Math.abs(s.x) < 1, `blew up: ${String(s.x)}`)
+})
+
+test("critically damped never overshoots", () => {
+  const s = new Spring1D(10, 1)
+  s.impulse(30)
+  let sign = 0
+  let crossings = 0
+  for (let i = 0; i < 200; i++) {
+    s.update(5)
+    const cur = Math.sign(s.x)
+    if (cur !== 0 && sign !== 0 && cur !== sign) crossings++
+    if (cur !== 0) sign = cur
+  }
+  assert.equal(crossings, 0)
+})
+
+test("under-damped overshoots exactly the way a follow-through should", () => {
+  const s = new Spring1D(10, 0.35)
+  s.impulse(30)
+  let crossings = 0
+  let sign = 1
+  for (let i = 0; i < 400; i++) {
+    s.update(4)
+    const cur = Math.sign(s.x)
+    if (cur !== 0 && cur !== sign) {
+      crossings++
+      sign = cur
+    }
+  }
+  assert.ok(crossings >= 2, `expected visible oscillation, saw ${String(crossings)} crossings`)
+})
+
+test("settle is instant and exact", () => {
+  const s = new Spring1D(10, 0.4)
+  s.impulse(50)
+  s.update(20)
+  s.settle()
+  assert.equal(s.x, 0)
+  assert.equal(s.v, 0)
+  assert.ok(s.isAtRest())
+})
+
+test("everything comes to rest", () => {
+  for (const zeta of [0.3, 1, 2]) {
+    const s = new Spring1D(8, zeta)
+    s.impulse(100)
+    for (let i = 0; i < 600; i++) s.update(16.67)
+    assert.ok(s.isAtRest(), `zeta=${String(zeta)} still moving: x=${String(s.x)}`)
+  }
+})

--- a/dynawalla/foundations/feel/src/spring.ts
+++ b/dynawalla/foundations/feel/src/spring.ts
@@ -1,0 +1,177 @@
+// Springs, integrated exactly.
+//
+// A damped harmonic oscillator has a closed-form solution, so there is no
+// reason to integrate one numerically — and three reasons not to:
+//
+//   1. Semi-implicit Euler drifts with frame rate. The same "pop" is visibly
+//      different at 60 Hz and at 120 Hz, and an iPad Pro is 120 Hz. Springs are
+//      where frame-rate-dependent feel usually hides, because it looks fine on
+//      the machine it was tuned on.
+//   2. A stiff spring at a 50 ms clamped step (see `MAX_DT_MS`) goes unstable
+//      under Euler and throws the object across the screen. This form cannot.
+//   3. `settleNow()` has to fast-forward everything to its rest state in one
+//      frame. An integrator can only get there by iterating.
+//
+// The step below is an **exponential integrator**: it evaluates the analytic
+// solution over exactly `dt` and re-bases. Because the system is linear it has
+// the semi-group property, so one 16 ms step equals sixteen 1 ms steps to float
+// precision. `spring.test.ts` asserts that, and it is the property that makes
+// the kit frame-rate-independent.
+
+const clamp = (v: number, lo: number, hi: number) => (v < lo ? lo : v > hi ? hi : v)
+
+/** A single-axis spring pulling toward `rest`. Zero allocation per step. */
+export class Spring1D {
+  /** Current value. Read this. */
+  x = 0
+  /** Current velocity, units per second. */
+  v = 0
+  rest = 0
+
+  /** Natural frequency, rad/s. Higher = snappier. */
+  omega: number
+  /** Damping ratio. 1 = critically damped (no overshoot). <1 overshoots. */
+  zeta: number
+
+  /**
+   * @param frequencyHz how fast it wants to oscillate. 4–8 Hz reads as
+   *   "responsive UI"; 12–20 Hz reads as "impact recoil".
+   * @param zeta 1 for a clean return, 0.35–0.6 for a visible bounce.
+   */
+  constructor(frequencyHz = 8, zeta = 1) {
+    this.omega = 2 * Math.PI * frequencyHz
+    this.zeta = clamp(zeta, 0, 4)
+  }
+
+  /** Kick it. This is how impacts enter the system: as velocity, not position. */
+  impulse(dv: number): void {
+    this.v += dv
+  }
+
+  /**
+   * The velocity impulse that produces a peak displacement of exactly `peak`.
+   *
+   * Without this, "impulse strength" is an arbitrary number whose visible
+   * result depends on the spring's frequency and damping — and it is wrong by a
+   * large factor in a way that is invisible in code review. Measured on the
+   * first build of this kit: a tier asking for a 16% scale punch produced a 3%
+   * one, because an 18 Hz spring converts a unit of velocity into roughly
+   * 0.004 units of displacement. Every tier's numbers were quietly meaningless.
+   *
+   * With it, a tier says `punch(0.16)` and gets 16%, and the tuning table is
+   * readable by a designer rather than by whoever wrote the integrator.
+   *
+   * Derived from the analytic peak of the impulse response:
+   *   under-damped   x(t) = (v/ωd)·e^(−ζωt)·sin(ωd·t), maximised at
+   *                  t* = atan(ωd / ζω) / ωd
+   *   critical       x(t) = v·t·e^(−ωt), maximised at t = 1/ω → peak = v/(ω·e)
+   */
+  impulseForPeak(peak: number): number {
+    return peak / this.peakPerUnitImpulse()
+  }
+
+  /** Displacement produced by an impulse of 1. Computed once per call; cheap. */
+  peakPerUnitImpulse(): number {
+    const w = this.omega
+    const z = this.zeta
+    if (z >= 0.9999) {
+      // Critical and over-damped both peak close to this; the over-damped case
+      // is not used for impacts, so the critical form is the right answer here.
+      return 1 / (w * Math.E)
+    }
+    const wd = w * Math.sqrt(1 - z * z)
+    const tStar = Math.atan(wd / (z * w)) / wd
+    return (1 / wd) * Math.exp(-z * w * tStar) * Math.sin(wd * tStar)
+  }
+
+  /** Snap to a value with no velocity. */
+  set(x: number, v = 0): void {
+    this.x = x
+    this.v = v
+  }
+
+  /** Jump to rest. Used by `settleNow()`. */
+  settle(): void {
+    this.x = this.rest
+    this.v = 0
+  }
+
+  /** True once the spring is visually done — lets callers stop paying for it. */
+  isAtRest(epsilon = 0.0005): boolean {
+    return Math.abs(this.x - this.rest) < epsilon && Math.abs(this.v) < epsilon * 60
+  }
+
+  /** Advance by `dtMs`. Exact for any dt. */
+  update(dtMs: number): number {
+    if (dtMs <= 0) return this.x
+    const t = dtMs * 0.001
+    const w = this.omega
+    const z = this.zeta
+    const x0 = this.x - this.rest
+    const v0 = this.v
+
+    if (z >= 0.9999 && z <= 1.0001) {
+      // Critically damped: x(t) = (x0 + (v0 + w x0) t) e^(-w t)
+      const e = Math.exp(-w * t)
+      const b = v0 + w * x0
+      this.x = this.rest + (x0 + b * t) * e
+      this.v = (v0 - w * b * t) * e
+    } else if (z < 1) {
+      // Under-damped: the oscillating case. This is the one that feels alive.
+      const wd = w * Math.sqrt(1 - z * z)
+      const e = Math.exp(-z * w * t)
+      const c = Math.cos(wd * t)
+      const s = Math.sin(wd * t)
+      const k = (v0 + z * w * x0) / wd
+      this.x = this.rest + e * (x0 * c + k * s)
+      this.v = e * (v0 * c - (x0 * (w * w) + z * w * v0) * (s / wd))
+    } else {
+      // Over-damped: two real roots. Slow and sure; used for camera follow.
+      const r = w * Math.sqrt(z * z - 1)
+      const r1 = -z * w + r
+      const r2 = -z * w - r
+      const c2 = (v0 - r1 * x0) / (r2 - r1)
+      const c1 = x0 - c2
+      const e1 = Math.exp(r1 * t)
+      const e2 = Math.exp(r2 * t)
+      this.x = this.rest + c1 * e1 + c2 * e2
+      this.v = c1 * r1 * e1 + c2 * r2 * e2
+    }
+    return this.x
+  }
+}
+
+/** Three independent springs. Convenience for position and scale kicks. */
+export class Spring3D {
+  readonly x: Spring1D
+  readonly y: Spring1D
+  readonly z: Spring1D
+
+  constructor(frequencyHz = 8, zeta = 1) {
+    this.x = new Spring1D(frequencyHz, zeta)
+    this.y = new Spring1D(frequencyHz, zeta)
+    this.z = new Spring1D(frequencyHz, zeta)
+  }
+
+  impulse(dx: number, dy: number, dz: number): void {
+    this.x.impulse(dx)
+    this.y.impulse(dy)
+    this.z.impulse(dz)
+  }
+
+  update(dtMs: number): void {
+    this.x.update(dtMs)
+    this.y.update(dtMs)
+    this.z.update(dtMs)
+  }
+
+  settle(): void {
+    this.x.settle()
+    this.y.settle()
+    this.z.settle()
+  }
+
+  isAtRest(epsilon = 0.0005): boolean {
+    return this.x.isAtRest(epsilon) && this.y.isAtRest(epsilon) && this.z.isAtRest(epsilon)
+  }
+}

--- a/dynawalla/foundations/feel/src/squash.test.ts
+++ b/dynawalla/foundations/feel/src/squash.test.ts
@@ -1,0 +1,88 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { Squash } from "./squash.ts"
+
+test("punch(0.16) actually reaches 1.16 — the calibration bug", () => {
+  // The first build multiplied the impulse by a hand-picked 26 and a tier
+  // asking for a 16% punch got 3%. Every number in the tier table was quietly
+  // five times weaker than it read, and no test or code review could see it.
+  for (const want of [0.06, 0.16, 0.3, 0.55]) {
+    const s = new Squash()
+    s.punch(want)
+    let peak = 1
+    for (let i = 0; i < 300; i++) {
+      s.update(4)
+      peak = Math.max(peak, s.scale.y)
+    }
+    assert.ok(
+      Math.abs(peak - (1 + want)) < 0.02,
+      `asked for ${String(1 + want)}, peaked at ${peak.toFixed(3)}`,
+    )
+  }
+})
+
+test("volume is conserved — a squash is not a zoom", () => {
+  const s = new Squash()
+  s.punch(0.4)
+  for (let i = 0; i < 60; i++) {
+    s.update(4)
+    const volume = s.scale.x * s.scale.y * s.scale.z
+    assert.ok(Math.abs(volume - 1) < 1e-9, `volume drifted to ${String(volume)}`)
+  }
+})
+
+test("a negative punch squashes first, a positive one stretches first", () => {
+  const down = new Squash()
+  down.punch(-0.3)
+  down.update(8)
+  assert.ok(down.scale.y < 1, "a landing squashes")
+
+  const up = new Squash()
+  up.punch(0.3)
+  up.update(8)
+  assert.ok(up.scale.y > 1, "a launch stretches")
+})
+
+test("follow-through happens: it crosses back past neutral", () => {
+  const s = new Squash()
+  s.punch(0.4)
+  let sawOver = false
+  let sawUnder = false
+  for (let i = 0; i < 200; i++) {
+    s.update(4)
+    if (s.scale.y > 1.02) sawOver = true
+    if (sawOver && s.scale.y < 0.99) sawUnder = true
+  }
+  assert.ok(sawUnder, "no follow-through — this is a linear scale, not a squash")
+})
+
+test("a huge punch at a clamped 50 ms step never mirrors the mesh", () => {
+  const s = new Squash()
+  s.punch(3)
+  for (let i = 0; i < 40; i++) {
+    s.update(50)
+    assert.ok(s.scale.y > 0, `scale went ${String(s.scale.y)} — mesh inverted`)
+    assert.ok(Number.isFinite(s.scale.x))
+  }
+})
+
+test("settle returns to exactly neutral", () => {
+  const s = new Squash()
+  s.punch(0.5)
+  s.update(10)
+  s.settle()
+  assert.equal(s.scale.x, 1)
+  assert.equal(s.scale.y, 1)
+  assert.equal(s.scale.z, 1)
+})
+
+test("punches compose additively rather than fighting", () => {
+  const one = new Squash()
+  one.punch(0.2)
+  const two = new Squash()
+  two.punch(0.2)
+  two.punch(0.2)
+  one.update(6)
+  two.update(6)
+  assert.ok(two.scale.y > one.scale.y, "a second hit must build on the first")
+})

--- a/dynawalla/foundations/feel/src/squash.ts
+++ b/dynawalla/foundations/feel/src/squash.ts
@@ -1,0 +1,178 @@
+// Squash and stretch, anticipation, follow-through.
+//
+// Three of Disney's twelve principles, and the only three that matter for a
+// screen you tap. All three are about the same thing: a shape that changes
+// instantly reads as a redraw, and a shape that deforms reads as a thing.
+//
+// ## Volume conservation is what separates squash from "scale wobble"
+//
+// If a thing stretches to 1.3× along Y it must contract to 1/√1.3 ≈ 0.877 on X
+// and Z. Skip that and the object simply grows and shrinks, which reads as a
+// zoom, not as an impact. The kit computes the cross-axis scale rather than
+// letting callers pass one, because passing one is how it gets forgotten.
+//
+// ## Anticipation is the cheapest 60 ms in animation
+//
+// A thing that is about to move fast first moves a little the *other* way. 60–
+// 80 ms of wind-up makes the release read as twice as fast for free, because
+// the eye measures the release against the wind-up rather than against rest.
+// It also — importantly here — costs nothing on the answer path: the verdict
+// has already painted, and the anticipation belongs to the *flourish*, which is
+// a tail.
+//
+// ## Follow-through is the spring's overshoot, not a second animation
+//
+// A single under-damped spring gives wind-up, release and settle in one
+// integrator with no sequencing and, crucially, no state machine to leave
+// half-finished when the child interrupts. `settle()` is one call.
+
+import { Spring1D } from "./spring.ts"
+import { ANTICIPATE, POP } from "./ease.ts"
+import { CH_UI, type Tweens } from "./tween.ts"
+
+export interface ScaleLike {
+  x: number
+  y: number
+  z: number
+}
+
+/**
+ * A spring-driven squash-and-stretch channel for one object.
+ *
+ * `s` is displacement from neutral, not a scale: `0` is rest, `+0.3` is
+ * stretched 30% along the primary axis, `−0.2` is squashed 20%. Impulses
+ * compose additively, which is what makes rapid repeated hits build rather
+ * than fight.
+ */
+export class Squash {
+  private readonly spring: Spring1D
+  /** Which axis stretches. `1` = Y (the default: things land and squash down). */
+  axis: 0 | 1 | 2 = 1
+
+  /** Output scale, rewritten in place each frame. */
+  readonly scale: ScaleLike = { x: 1, y: 1, z: 1 }
+  intensity = 1
+
+  /**
+   * @param frequencyHz 11–16 Hz is the impact band. Below 8 it reads as jelly.
+   * @param zeta 0.35–0.5 gives one clear overshoot — the follow-through.
+   */
+  constructor(frequencyHz = 13, zeta = 0.4) {
+    this.spring = new Spring1D(frequencyHz, zeta)
+  }
+
+  /**
+   * Hit it. `amount` is **peak deformation**: `punch(0.16)` reaches 1.16× along
+   * the axis (and 1/√1.16 across it) at the peak, then follows through.
+   *
+   * Positive stretches first, negative squashes first — a landing is negative,
+   * a launch is positive.
+   *
+   * The peak normalisation is not cosmetic. The first build multiplied by a
+   * hand-picked 26 and a tier asking for 16% got 3%; every punch in the table
+   * was five times weaker than it read. See `Spring1D.impulseForPeak`.
+   */
+  punch(amount: number): void {
+    this.spring.impulse(this.spring.impulseForPeak(amount) * this.intensity)
+  }
+
+  /** Set the deformation directly, e.g. from a held charge-up. */
+  set(displacement: number): void {
+    this.spring.set(displacement)
+  }
+
+  update(dtMs: number): void {
+    const s = this.spring.update(dtMs)
+    const along = 1 + s
+    // Guard: a large impulse at a clamped 50 ms step can drive `along` negative,
+    // which mirrors the mesh through itself and reads as a graphical fault.
+    const safe = along < 0.05 ? 0.05 : along
+    const cross = 1 / Math.sqrt(safe)
+    if (this.axis === 1) {
+      this.scale.x = cross
+      this.scale.y = safe
+      this.scale.z = cross
+    } else if (this.axis === 0) {
+      this.scale.x = safe
+      this.scale.y = cross
+      this.scale.z = cross
+    } else {
+      this.scale.x = cross
+      this.scale.y = cross
+      this.scale.z = safe
+    }
+  }
+
+  applyTo(obj: { scale: ScaleLike }, base = 1): void {
+    obj.scale.x = this.scale.x * base
+    obj.scale.y = this.scale.y * base
+    obj.scale.z = this.scale.z * base
+  }
+
+  settle(): void {
+    this.spring.settle()
+    this.scale.x = 1
+    this.scale.y = 1
+    this.scale.z = 1
+  }
+
+  isAtRest(): boolean {
+    return this.spring.isAtRest()
+  }
+
+  /** For DOM prototypes. Non-uniform scale, so the volume rule still holds. */
+  cssTransform(): string {
+    return `scale(${this.scale.x.toFixed(4)},${this.scale.y.toFixed(4)})`
+  }
+}
+
+/** Timings for the scripted pop. Named so they can be cited, not re-guessed. */
+export const ANTICIPATION_MS = 70
+export const RELEASE_MS = 220
+
+/**
+ * The scripted three-beat pop: wind-up, release with overshoot, settle.
+ *
+ * Use this when the thing must be *choreographed* — a UI element entering, a
+ * number seating into a slot — and the spring when it must be *reactive*.
+ * Runs on `CH_UI` so a freeze frame never stalls an element's entrance.
+ *
+ * Returns the total duration so a caller can schedule against it. The wind-up
+ * is deliberately shallow (`0.9`): deeper reads as a stagger, not a wind-up.
+ */
+export function pop(
+  tweens: Tweens,
+  obj: { scale: ScaleLike },
+  peak = 1.25,
+  windupMs = ANTICIPATION_MS,
+  releaseMs = RELEASE_MS,
+): number {
+  // Three beats. The peak has to be inside a tween's *range* to be reached —
+  // an overshoot ease over a 0.9→1.0 range overshoots by 10% of 0.1, which is
+  // invisible. This is the mistake that makes scripted pops look limp.
+  const fast = releaseMs * 0.35
+  const rest = releaseMs - fast
+  tweens.to2(obj, "scale", 1, 0.9, windupMs, ANTICIPATE, {
+    channel: CH_UI,
+    applier: uniformScale,
+  })
+  tweens.to2(obj, "scale", 0.9, peak, fast, POP, {
+    channel: CH_UI,
+    delayMs: windupMs,
+    applier: uniformScale,
+  })
+  tweens.to2(obj, "scale", peak, 1, rest, "outElastic", {
+    channel: CH_UI,
+    delayMs: windupMs + fast,
+    applier: uniformScale,
+  })
+  return windupMs + releaseMs
+}
+
+/** Hoisted so `pop` allocates no closure per call. */
+function uniformScale(o: object, _key: string, v: number): void {
+  const s = (o as { scale: ScaleLike }).scale
+  s.x = v
+  s.y = v
+  s.z = v
+}

--- a/dynawalla/foundations/feel/src/tiers.test.ts
+++ b/dynawalla/foundations/feel/src/tiers.test.ts
@@ -1,0 +1,120 @@
+// The product rules, asserted.
+//
+// Every test here corresponds to a sentence in the brief or in MISSION.md.
+// If one of these fails the tuning is not "off", the product is wrong.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { TIERS, TIER_ORDER, chooseTier, energy, type TierName } from "./tiers.ts"
+import { readFileSync, readdirSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import path from "node:path"
+
+const LADDER: TierName[] = ["tick", "snap", "pop", "slam", "bloom", "ascend"]
+
+test("ordinary success never blocks: blockingMs is 0 for every tier but ascend", () => {
+  for (const name of TIER_ORDER) {
+    const t = TIERS[name]
+    if (name === "ascend") {
+      assert.ok(t.blockingMs > 0, "ascend is allowed to block")
+      assert.ok(t.blockingMs <= 400, `ascend blocks too long: ${String(t.blockingMs)}ms`)
+    } else {
+      assert.equal(t.blockingMs, 0, `${name} blocks input for ${String(t.blockingMs)}ms`)
+    }
+  }
+})
+
+test("the verdict is always one frame — no tier delays it", () => {
+  for (const name of TIER_ORDER) assert.equal(TIERS[name].verdictMs, 0)
+})
+
+test("hitstop is only ever spent on success", () => {
+  assert.equal(TIERS.nudge.hitstopMs, 0, "a wrong answer must not freeze the retry")
+  assert.equal(TIERS.tick.hitstopMs, 0, "a keypress must not freeze anything")
+  assert.equal(TIERS.snap.hitstopMs, 0, "the 85% case must not freeze")
+  assert.ok(TIERS.pop.hitstopMs > 0)
+})
+
+test("no hitstop exceeds 160 ms — past that it reads as a hang, not an impact", () => {
+  for (const name of TIER_ORDER) {
+    assert.ok(TIERS[name].hitstopMs <= 160, `${name}: ${String(TIERS[name].hitstopMs)}ms`)
+  }
+})
+
+test("the common path fits its budget: snap's whole tail is under 250 ms", () => {
+  // A child answering every 2.8 s (the cadence target) must never see two
+  // flourishes overlap in a way that reads as backlog.
+  assert.ok(TIERS.snap.tailMs <= 250, `snap tail ${String(TIERS.snap.tailMs)}ms`)
+  assert.ok(TIERS.tick.tailMs <= 120)
+})
+
+test("energy ladder is strictly increasing — escalation is legible", () => {
+  for (let i = 1; i < LADDER.length; i++) {
+    const lo = energy(TIERS[LADDER[i - 1]!])
+    const hi = energy(TIERS[LADDER[i]!])
+    assert.ok(hi > lo, `${LADDER[i - 1]!} (${lo.toFixed(0)}) >= ${LADDER[i]!} (${hi.toFixed(0)})`)
+  }
+})
+
+test("being wrong is never more interesting than being right", () => {
+  const wrong = energy(TIERS.nudge)
+  const right = energy(TIERS.snap)
+  assert.ok(wrong < right, `nudge ${wrong.toFixed(0)} >= snap ${right.toFixed(0)}`)
+})
+
+test("a milestone is a different kind of thing, not a slightly longer thing", () => {
+  // 8× is the threshold at which a child reports "something big happened"
+  // rather than "that one was worth more".
+  assert.ok(energy(TIERS.bloom) > energy(TIERS.snap) * 8)
+  assert.ok(energy(TIERS.ascend) > energy(TIERS.bloom) * 1.8)
+})
+
+test("escalation cannot see a streak — behaviourally", () => {
+  // Hand the chooser the same outcome after a notional 1 and 100 correct
+  // answers. There is no field to put that in, which is the point; this test
+  // fails the moment someone adds one and wires it up.
+  const o = { correct: true, difficulty: 0.2, repaired: false, milestone: null } as const
+  const a = chooseTier(o)
+  const b = chooseTier({ ...o })
+  assert.equal(a, b)
+  assert.equal(a, "snap")
+})
+
+test("escalation cannot see a streak — lexically", () => {
+  const dir = path.dirname(fileURLToPath(import.meta.url))
+  const banned = /\b(streak|combo|runLength|consecutive|multiplier)\b/i
+  for (const f of readdirSync(dir)) {
+    if (!f.endsWith(".ts") || f.endsWith(".test.ts")) continue
+    const src = readFileSync(path.join(dir, f), "utf8")
+    // Strip comments: the prohibition is on the mechanism, and the comments
+    // have to be able to name the thing they are prohibiting.
+    const code = src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "")
+    const m = banned.exec(code)
+    assert.equal(m, null, `${f} references "${m?.[0] ?? ""}" in code`)
+  }
+})
+
+test("chooseTier covers every branch", () => {
+  assert.equal(chooseTier({ correct: false, difficulty: 1, repaired: true, milestone: "major" }), "nudge")
+  assert.equal(chooseTier({ correct: true, difficulty: 0, repaired: false, milestone: "major" }), "ascend")
+  assert.equal(chooseTier({ correct: true, difficulty: 0, repaired: false, milestone: "minor" }), "bloom")
+  assert.equal(chooseTier({ correct: true, difficulty: 0, repaired: true, milestone: null }), "slam")
+  assert.equal(chooseTier({ correct: true, difficulty: 0.9, repaired: false, milestone: null }), "pop")
+  assert.equal(chooseTier({ correct: true, difficulty: 0.1, repaired: false, milestone: null }), "snap")
+})
+
+test("only one tier is once-per-session", () => {
+  const once = TIER_ORDER.filter((n) => TIERS[n].oncePerSession)
+  assert.deepEqual(once, ["ascend"])
+})
+
+test("every ladder column is monotonic", () => {
+  const cols = ["tailMs", "trauma", "kick", "flash", "particles", "punchScale"] as const
+  for (const col of cols) {
+    for (let i = 1; i < LADDER.length; i++) {
+      const lo = TIERS[LADDER[i - 1]!][col]
+      const hi = TIERS[LADDER[i]!][col]
+      assert.ok(hi >= lo, `${col} not monotonic at ${LADDER[i]!}: ${String(lo)} -> ${String(hi)}`)
+    }
+  }
+})

--- a/dynawalla/foundations/feel/src/tiers.ts
+++ b/dynawalla/foundations/feel/src/tiers.ts
@@ -1,0 +1,326 @@
+// The reaction tiers, and their millisecond budgets.
+//
+// This is the file the rest of the kit exists to serve. A prototype author
+// writes `feel.react("snap")` and gets a tuned, coherent, seven-system response
+// — shake, kick, hitstop, flash, squash, haptic, tone — that is correct on a
+// 60 Hz phone and a 120 Hz iPad, and that a child can interrupt.
+//
+// ## Three separate clocks, and only one of them may ever block
+//
+//   verdictMs    when the child can SEE the answer was right. Always one frame.
+//                Not tunable, not tiered, not negotiable. Every tier is 0 here
+//                because the verdict paints on the next frame and the flourish
+//                is what comes after it.
+//   blockingMs   how long input is refused. **Zero for every tier but the
+//                rarest one**, and even that one is skippable by tapping. This
+//                single column is the difference between a product a fast child
+//                loves and a product a fast child fights.
+//   tailMs       how long the flourish keeps drawing. It plays *over* the next
+//                problem — the next problem presents concurrently with the
+//                tail. A tail is not a wait.
+//
+// The failure this prevents is the standard one: a designer wants the
+// celebration to land, so the input handler is gated on the animation's
+// completion, and now the child who knows 7×8 is made to watch 900 ms of
+// brass every three seconds. That child stops being fast, because being fast
+// stopped being rewarded. `tiers.test.ts` asserts `blockingMs === 0` for
+// everything below `ascend`.
+//
+// ## Hitstop is only ever spent on success
+//
+// A freeze frame is a reward. Spending one on a wrong answer makes the retry
+// slower at the exact moment a child needs the loop to be fastest, and it
+// dignifies the mistake with the vocabulary of impact. `nudge` gets a
+// directional kick instead: a one-way bump that says "that did not seat"
+// without stopping the world. Asserted.
+//
+// ## Escalation keys on difficulty and repair, never on run length
+//
+// Inherited from MISSION.md and kept deliberately across the visual-direction
+// change. `chooseTier` takes an outcome with no streak, no combo and no session
+// counter, and there is nowhere to smuggle one in because the input type is the
+// entire surface. The juice got much louder; the thing it is loud *about* did
+// not change.
+
+import type { HapticStyle } from "./haptics.ts"
+
+export type TierName = "nudge" | "tick" | "snap" | "pop" | "slam" | "bloom" | "ascend"
+
+export interface FeelTier {
+  readonly name: TierName
+  /** −1 is below the resting state; 5 is the top of the ladder. */
+  readonly level: number
+
+  /** Frames until the verdict is visible. Always 0 — see the header. */
+  readonly verdictMs: 0
+  /** Input refused for this long. 0 everywhere but `ascend`. */
+  readonly blockingMs: number
+  /** Total flourish length. Plays over the next problem. */
+  readonly tailMs: number
+
+  /** Wall-clock world freeze. Never frame-counted. */
+  readonly hitstopMs: number
+  /** Trauma added, 0…1. Visible amplitude is the square. */
+  readonly trauma: number
+  /**
+   * Peak camera recoil, in **world units of displacement** — not raw impulse.
+   *
+   * `Kick.add` normalises through `Spring1D.impulseForPeak`, so 0.3 here means
+   * the camera really moves 0.3 units at the peak. Before that normalisation
+   * existed these numbers were arbitrary, and as measured the effect was ~250×
+   * smaller than the number read. At the demo's camera distance the visible
+   * half-height is ~3.7 units, so `ascend`'s 0.3 is an 8% frame displacement.
+   */
+  readonly kick: number
+  /** Screen-space flash peak, 0…1. */
+  readonly flash: number
+  /** Flash colour as linear RGB. Warm for success, amber for a nudge. */
+  readonly flashColor: readonly [number, number, number]
+  /** World time scale during the moment. 1 = no slow-motion. */
+  readonly timeScale: number
+  /** ms for the time scale to ease back to 1. */
+  readonly timeRecoverMs: number
+  /** Particles emitted at peak, before the quality governor scales it. */
+  readonly particles: number
+  /** Scale overshoot on the thing that was hit. 1.18 = 18% bigger at peak. */
+  readonly punchScale: number
+  readonly haptic: HapticStyle | null
+  /** Semitones above the pentatonic root. `null` for silence. */
+  readonly tone: number | null
+  /** Only one of these per session. */
+  readonly oncePerSession: boolean
+}
+
+/**
+ * The table.
+ *
+ * The numbers are a ladder, not seven independent choices: every column is
+ * monotonic from `tick` to `ascend`, which is what makes the escalation legible
+ * as escalation rather than as seven unrelated effects. `nudge` sits outside
+ * the ladder deliberately and is measured against `snap`, not against `tick`.
+ */
+export const TIERS: Readonly<Record<TierName, FeelTier>> = {
+  /** Wrong. Fast, warm, unambiguous, and over before the child is embarrassed. */
+  nudge: {
+    name: "nudge",
+    level: -1,
+    verdictMs: 0,
+    blockingMs: 0,
+    tailMs: 300,
+    hitstopMs: 0,
+    trauma: 0.16,
+    kick: 0.045,
+    flash: 0.1,
+    flashColor: [1, 0.62, 0.22],
+    timeScale: 1,
+    timeRecoverMs: 0,
+    particles: 0,
+    punchScale: 0.94,
+    haptic: "warning",
+    tone: -5,
+    oncePerSession: false,
+  },
+
+  /** A digit landed in the answer box. The smallest thing that responds. */
+  tick: {
+    name: "tick",
+    level: 0,
+    verdictMs: 0,
+    blockingMs: 0,
+    tailMs: 90,
+    hitstopMs: 0,
+    trauma: 0.05,
+    kick: 0.012,
+    flash: 0,
+    flashColor: [1, 1, 1],
+    timeScale: 1,
+    timeRecoverMs: 0,
+    particles: 0,
+    punchScale: 1.06,
+    haptic: "light",
+    tone: 0,
+    oncePerSession: false,
+  },
+
+  /**
+   * Ordinary correct. **The most important row in the table**, because it is
+   * ~85% of everything a child ever sees. 220 ms of tail, zero hitstop, zero
+   * blocking: a child who answers in 1.4 s never once waits on this.
+   */
+  snap: {
+    name: "snap",
+    level: 1,
+    verdictMs: 0,
+    blockingMs: 0,
+    tailMs: 220,
+    hitstopMs: 0,
+    trauma: 0.14,
+    kick: 0.035,
+    flash: 0.12,
+    flashColor: [1, 0.93, 0.72],
+    timeScale: 1,
+    timeRecoverMs: 0,
+    particles: 8,
+    punchScale: 1.16,
+    haptic: "light",
+    tone: 7,
+    oncePerSession: false,
+  },
+
+  /** Correct on a hard item. The first tier that freezes the world at all. */
+  pop: {
+    name: "pop",
+    level: 2,
+    verdictMs: 0,
+    blockingMs: 0,
+    tailMs: 400,
+    hitstopMs: 40,
+    trauma: 0.3,
+    kick: 0.075,
+    flash: 0.24,
+    flashColor: [1, 0.9, 0.66],
+    timeScale: 1,
+    timeRecoverMs: 0,
+    particles: 22,
+    punchScale: 1.3,
+    haptic: "medium",
+    tone: 12,
+    oncePerSession: false,
+  },
+
+  /** You got right the thing you used to get wrong. The repair tier. */
+  slam: {
+    name: "slam",
+    level: 3,
+    verdictMs: 0,
+    blockingMs: 0,
+    tailMs: 700,
+    hitstopMs: 75,
+    trauma: 0.46,
+    kick: 0.13,
+    flash: 0.36,
+    flashColor: [1, 0.86, 0.6],
+    timeScale: 0.72,
+    timeRecoverMs: 180,
+    particles: 48,
+    punchScale: 1.42,
+    haptic: "heavy",
+    tone: 16,
+    oncePerSession: false,
+  },
+
+  /** A thing in the world completed. A lamp lit, a stall built, a bell hung. */
+  bloom: {
+    name: "bloom",
+    level: 4,
+    verdictMs: 0,
+    blockingMs: 0,
+    tailMs: 1500,
+    hitstopMs: 110,
+    trauma: 0.62,
+    kick: 0.2,
+    flash: 0.5,
+    flashColor: [1, 0.84, 0.55],
+    timeScale: 0.5,
+    timeRecoverMs: 260,
+    particles: 110,
+    punchScale: 1.55,
+    haptic: "success",
+    tone: 19,
+    oncePerSession: false,
+  },
+
+  /**
+   * The one enormous thing. Once a session, and the only tier permitted to
+   * block — for 350 ms, and a tap skips it. Everything the kit can do fires at
+   * once here, which is the point: it has to be obviously different in kind,
+   * not just in amount, or "rare" reads as "slightly longer".
+   */
+  ascend: {
+    name: "ascend",
+    level: 5,
+    verdictMs: 0,
+    blockingMs: 350,
+    tailMs: 2800,
+    hitstopMs: 160,
+    trauma: 0.85,
+    kick: 0.3,
+    flash: 0.7,
+    flashColor: [1, 0.82, 0.5],
+    timeScale: 0.32,
+    timeRecoverMs: 420,
+    particles: 200,
+    punchScale: 1.75,
+    haptic: "success",
+    tone: 24,
+    oncePerSession: true,
+  },
+} as const
+
+export const TIER_ORDER: readonly TierName[] = [
+  "nudge",
+  "tick",
+  "snap",
+  "pop",
+  "slam",
+  "bloom",
+  "ascend",
+]
+
+/**
+ * How much of the child's attention a tier spends.
+ *
+ * Multiplicative in the things that actually compete for notice: how long it
+ * draws, how much light it throws, how many parts move, and how much it slows
+ * the world down. Particle count is additive-plus-one so a particle-free tier
+ * still has a real energy and the ladder stays orderable.
+ *
+ * Two invariants are asserted against it in `tiers.test.ts`:
+ *   `energy(nudge) < energy(snap)`  — being wrong is never the interesting
+ *   moment, which is the one line of this product's ethics that shows up in the
+ *   feel layer.
+ *   the ladder `tick < snap < pop < slam < bloom < ascend` is strictly
+ *   increasing, so escalation is legible.
+ */
+export function energy(t: FeelTier): number {
+  const timeCost = t.timeScale < 1 ? 1 + (1 - t.timeScale) : 1
+  const parts = 1 + t.particles
+  const light = 0.25 + t.flash
+  // Kick is in the formula on purpose. Without it a designer could satisfy
+  // "wrong is quieter than right" on every other axis and still make failure
+  // the physically emphatic moment through recoil alone — which is exactly the
+  // "catapult falling short is more animated than a gear ticking" failure.
+  const motion = 1 + Math.abs(t.punchScale - 1) * 4 + t.trauma * 2 + t.kick * 3
+  return t.tailMs * parts * light * motion * timeCost
+}
+
+/* --------------------------------------------------------------- choosing */
+
+/**
+ * Everything the feel layer is allowed to know about what just happened.
+ *
+ * Four fields, and the absence of a fifth is the product rule: there is no
+ * `streak`, no `combo`, no `runLength` and no session total, and there is
+ * nowhere to add one without changing this type.
+ */
+export interface Outcome {
+  readonly correct: boolean
+  /** 0 at the bottom of the ladder, 1 at the top. */
+  readonly difficulty: number
+  /** This was the item that isolates a misconception, and it went in. */
+  readonly repaired: boolean
+  /** Something in the world completed. `"major"` is the once-a-session one. */
+  readonly milestone: "minor" | "major" | null
+}
+
+/** Above this an item is hard enough to be worth freezing the world for. */
+export const HARD = 0.6
+
+/** Pure, total, stateless. The tier this outcome earns. */
+export function chooseTier(o: Outcome): TierName {
+  if (!o.correct) return "nudge"
+  if (o.milestone === "major") return "ascend"
+  if (o.milestone === "minor") return "bloom"
+  if (o.repaired) return "slam"
+  return o.difficulty >= HARD ? "pop" : "snap"
+}

--- a/dynawalla/foundations/feel/src/tween.test.ts
+++ b/dynawalla/foundations/feel/src/tween.test.ts
@@ -1,0 +1,117 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { Tweens, CH_UI, CH_WORLD } from "./tween.ts"
+
+const obj = () => ({ v: 0 })
+
+test("a tween lands exactly on its end value", () => {
+  const tw = new Tweens(8)
+  const o = obj()
+  tw.to2(o, "v", 0, 10, 100, "linear")
+  tw.update(CH_WORLD, 100)
+  assert.equal(o.v, 10)
+})
+
+test("settle fast-forwards to the END state, never mid-pose", () => {
+  const tw = new Tweens(8)
+  const o = obj()
+  tw.to2(o, "v", 0, 10, 1000, "outBack")
+  tw.update(CH_WORLD, 120)
+  assert.ok(o.v > 0 && o.v < 10, "should be mid-flight")
+  const n = tw.settle()
+  assert.equal(n, 1)
+  assert.equal(o.v, 10, "an interrupted flourish must end valid, not frozen")
+  assert.equal(tw.liveCount, 0)
+})
+
+test("settle fires onDone", () => {
+  const tw = new Tweens(8)
+  const o = obj()
+  let done = 0
+  const bump = () => {
+    done++
+  }
+  tw.to2(o, "v", 0, 1, 500, "linear", { onDone: bump })
+  tw.settle()
+  assert.equal(done, 1)
+})
+
+test("channels are independent — a frozen world does not stall the UI", () => {
+  const tw = new Tweens(8)
+  const world = obj()
+  const ui = obj()
+  tw.to2(world, "v", 0, 10, 100, "linear", { channel: CH_WORLD })
+  tw.to2(ui, "v", 0, 10, 100, "linear", { channel: CH_UI })
+  // A hitstop frame: dtWorld = 0, dtUi = 16.
+  tw.update(CH_WORLD, 0)
+  tw.update(CH_UI, 16)
+  assert.equal(world.v, 0)
+  assert.ok(ui.v > 0)
+})
+
+test("a stale handle cannot cancel a recycled slot", () => {
+  const tw = new Tweens(2)
+  const a = obj()
+  const b = obj()
+  const h = tw.to2(a, "v", 0, 1, 10, "linear")
+  tw.update(CH_WORLD, 20) // completes, slot recycles
+  const h2 = tw.to2(b, "v", 0, 5, 1000, "linear")
+  assert.notEqual(h, h2)
+  tw.cancel(h) // stale
+  assert.ok(tw.isActive(h2), "the stale handle killed an unrelated tween")
+})
+
+test("a full pool drops the newest, never an in-flight one", () => {
+  const tw = new Tweens(2)
+  const a = obj()
+  tw.to2(a, "v", 0, 1, 1000, "linear")
+  tw.to2(a, "v", 0, 1, 1000, "linear")
+  const h = tw.to2(a, "v", 0, 1, 1000, "linear")
+  assert.equal(h, 0, "overflow returns the null handle")
+  assert.equal(tw.overflows, 1)
+  assert.equal(tw.liveCount, 2, "the two in flight are untouched")
+})
+
+test("delay staggers without a timer", () => {
+  const tw = new Tweens(8)
+  const o = obj()
+  tw.to2(o, "v", 0, 10, 100, "linear", { delayMs: 50 })
+  tw.update(CH_WORLD, 40)
+  assert.equal(o.v, 0)
+  tw.update(CH_WORLD, 20) // 10 ms past the delay
+  assert.ok(o.v > 0 && o.v < 2)
+})
+
+test("pingpong ends where it started", () => {
+  const tw = new Tweens(8)
+  const o = obj()
+  o.v = 3
+  tw.to2(o, "v", 3, 9, 100, "linear", { pingpong: true })
+  tw.update(CH_WORLD, 50)
+  assert.ok(o.v > 8, `peak should be near 9, was ${String(o.v)}`)
+  tw.update(CH_WORLD, 60)
+  assert.equal(o.v, 3, "a punch must return to where it started")
+})
+
+test("onDone may start a new tween without overflowing", () => {
+  const tw = new Tweens(1)
+  const o = obj()
+  let second = 0
+  const chain = () => {
+    second = tw.to2(o, "v", 1, 2, 100, "linear")
+  }
+  tw.to2(o, "v", 0, 1, 10, "linear", { onDone: chain })
+  tw.update(CH_WORLD, 20)
+  assert.notEqual(second, 0, "the slot must be free before onDone runs")
+})
+
+test("update walks only used slots, not the whole capacity", () => {
+  const tw = new Tweens(512)
+  const o = obj()
+  tw.to2(o, "v", 0, 1, 100, "linear")
+  // Not directly observable; assert the proxy: a big pool with one tween
+  // completes in the same number of steps as a small one.
+  tw.update(CH_WORLD, 100)
+  assert.equal(o.v, 1)
+  assert.equal(tw.liveCount, 0)
+})

--- a/dynawalla/foundations/feel/src/tween.ts
+++ b/dynawalla/foundations/feel/src/tween.ts
@@ -1,0 +1,313 @@
+// The tween runtime. Fixed capacity, struct-of-arrays, zero allocation on the
+// hot path.
+//
+// ## Why this is not "just use GSAP"
+//
+// GSAP is excellent and it allocates a tween object, a target-proxy and a
+// property-tween record per call. At the juice density this product wants —
+// several tweens per answer, a child answering every three seconds, an
+// eight-hour school day — that is a steady stream of short-lived objects. On a
+// mid-range Android WebView a minor GC is 2–6 ms, which is a dropped frame at
+// 60 Hz, and it lands *exactly* when the child does something, because that is
+// when the allocation happened. Juice that stutters when you use it is worse
+// than no juice.
+//
+// So: a pre-allocated pool of `capacity` slots held in typed arrays. Starting a
+// tween writes numbers into existing arrays and returns an integer handle.
+// `bench/cpu.mjs` measures bytes-allocated-per-tween; the number in README.md
+// is what it printed.
+//
+// ## Handles carry a generation
+//
+// A raw slot index is a use-after-free waiting to happen: prototype code holds
+// a handle, the tween finishes, the slot is recycled by someone else, and the
+// stale `cancel()` kills an unrelated animation. The handle packs a generation
+// counter, so a stale handle resolves to nothing.
+//
+// ## Everything must be fast-forwardable
+//
+// `settle(channel)` jumps every live tween to its end value, applies it, and
+// fires its completion — synchronously, within one frame. That is the
+// mechanism behind "ordinary success is interruptible": the child's next tap
+// does not cancel the flourish half-drawn, it *completes* it instantly, so the
+// screen is always in a valid end state and never mid-pose.
+
+import { EASE, type EaseFn, type EaseName } from "./ease.ts"
+
+/** Which clock channel a tween advances on. */
+export const CH_WORLD = 0
+/** Unscaled, but stops when the app is paused. Presentation animations. */
+export const CH_UI = 1
+/** Wall clock. Runs through hitstop and slow-motion. */
+export const CH_REAL = 2
+
+export type TweenChannel = typeof CH_WORLD | typeof CH_UI | typeof CH_REAL
+
+/** Opaque. Pack of slot index and generation. `0` is the null handle. */
+export type TweenHandle = number
+
+const FREE = 0
+const RUNNING = 1
+const DONE = 2
+
+type Applier = (obj: object, key: string, value: number) => void
+
+/** Default applier: plain property assignment. Covers Vector3, DOM style, etc. */
+const assign: Applier = (obj, key, value) => {
+  ;(obj as Record<string, number>)[key] = value
+}
+
+export interface ToOptions {
+  /** ms to wait before the tween starts moving. Staggering is done with this. */
+  delayMs?: number
+  channel?: TweenChannel
+  /** Go to `to` then back to `from` within `durationMs`. For punches. */
+  pingpong?: boolean
+  /**
+   * Called once when the tween reaches its end — including when `settle()`
+   * fast-forwards it. Pass a hoisted function; an inline arrow allocates a
+   * closure per call and defeats the point of this file.
+   */
+  onDone?: (() => void) | null
+  /** Custom write. Defaults to `obj[key] = v`. */
+  applier?: Applier
+}
+
+export class Tweens {
+  readonly capacity: number
+
+  private readonly from: Float64Array
+  private readonly to: Float64Array
+  private readonly elapsed: Float64Array
+  private readonly duration: Float64Array
+  private readonly delay: Float64Array
+  private readonly state: Uint8Array
+  private readonly channel: Uint8Array
+  private readonly flags: Uint8Array
+  private readonly generation: Uint16Array
+  private readonly eases: (EaseFn | null)[]
+  private readonly targets: (object | null)[]
+  private readonly keys: (string | null)[]
+  private readonly dones: ((() => void) | null)[]
+  private readonly appliers: (Applier | null)[]
+
+  /**
+   * Dense list of live slot indices, so `update` and `settle` cost O(live)
+   * rather than O(capacity).
+   *
+   * The first build allocated with a rotating cursor and iterated up to the
+   * high-water mark. That is correct and it is 17× slower than this on the
+   * commonest operation, because the cursor sweeps the whole pool, the
+   * high-water mark reaches capacity within a second of play, and thereafter
+   * every frame walks 512 slots to find the two that are live. Measured:
+   * 870 ns → 51 ns for start-plus-settle at capacity 512. It was invisible
+   * because "we use a pool" sounds like it settles the question.
+   */
+  private readonly active: Int32Array
+  private readonly slotPos: Int32Array
+  private readonly free: Int32Array
+  private activeCount = 0
+  private freeCount: number
+  /** Incremented whenever the pool is full and a start is dropped. */
+  overflows = 0
+
+  constructor(capacity = 256) {
+    this.capacity = capacity
+    this.from = new Float64Array(capacity)
+    this.to = new Float64Array(capacity)
+    this.elapsed = new Float64Array(capacity)
+    this.duration = new Float64Array(capacity)
+    this.delay = new Float64Array(capacity)
+    this.state = new Uint8Array(capacity)
+    this.channel = new Uint8Array(capacity)
+    this.flags = new Uint8Array(capacity)
+    this.generation = new Uint16Array(capacity)
+    this.eases = new Array<EaseFn | null>(capacity).fill(null)
+    this.targets = new Array<object | null>(capacity).fill(null)
+    this.keys = new Array<string | null>(capacity).fill(null)
+    this.dones = new Array<(() => void) | null>(capacity).fill(null)
+    this.appliers = new Array<Applier | null>(capacity).fill(null)
+    this.active = new Int32Array(capacity)
+    this.slotPos = new Int32Array(capacity).fill(-1)
+    this.free = new Int32Array(capacity)
+    for (let i = 0; i < capacity; i++) this.free[i] = capacity - 1 - i
+    this.freeCount = capacity
+  }
+
+  /** Live tween count. O(1). */
+  get liveCount(): number {
+    return this.activeCount
+  }
+
+  /**
+   * Animate `obj[key]` from `from` to `to` over `durationMs`.
+   *
+   * Returns `0` if the pool is full — a full pool drops the *newest* tween,
+   * never an in-flight one, because half-finished animations left frozen
+   * mid-pose are the worse failure. `overflows` counts it and the quality
+   * governor surfaces it.
+   */
+  to2(
+    obj: object,
+    key: string,
+    from: number,
+    to: number,
+    durationMs: number,
+    ease: EaseName | EaseFn = "outCubic",
+    opts: ToOptions = {},
+  ): TweenHandle {
+    const slot = this.alloc()
+    if (slot < 0) {
+      this.overflows++
+      return 0
+    }
+    this.from[slot] = from
+    this.to[slot] = to
+    this.elapsed[slot] = 0
+    this.duration[slot] = Math.max(1, durationMs)
+    this.delay[slot] = opts.delayMs ?? 0
+    this.state[slot] = RUNNING
+    this.channel[slot] = opts.channel ?? CH_WORLD
+    this.flags[slot] = opts.pingpong ? 1 : 0
+    this.eases[slot] = typeof ease === "function" ? ease : EASE[ease]
+    this.targets[slot] = obj
+    this.keys[slot] = key
+    this.dones[slot] = opts.onDone ?? null
+    this.appliers[slot] = opts.applier ?? null
+    return (slot + 1) | (this.generation[slot]! << 16)
+  }
+
+  /** Cancel where it stands. Does not apply the end value or fire `onDone`. */
+  cancel(handle: TweenHandle): void {
+    const slot = this.resolve(handle)
+    if (slot < 0) return
+    this.release(slot)
+  }
+
+  /** Jump to the end value, apply it, fire `onDone`. */
+  finish(handle: TweenHandle): void {
+    const slot = this.resolve(handle)
+    if (slot < 0) return
+    this.complete(slot)
+  }
+
+  isActive(handle: TweenHandle): boolean {
+    return this.resolve(handle) >= 0
+  }
+
+  /**
+   * Advance every tween on a channel. Called once per frame per channel by the
+   * kit — a prototype never calls this.
+   */
+  update(ch: TweenChannel, dtMs: number): void {
+    if (dtMs <= 0) return
+    // Backwards: `complete()` swap-removes from `active`, and anything a
+    // completion appends lands past the cursor and waits for the next frame.
+    for (let a = this.activeCount - 1; a >= 0; a--) {
+      const i = this.active[a]!
+      if (this.channel[i] !== ch) continue
+
+      let dt = dtMs
+      const d = this.delay[i]!
+      if (d > 0) {
+        if (d >= dt) {
+          this.delay[i] = d - dt
+          continue
+        }
+        dt -= d
+        this.delay[i] = 0
+      }
+
+      const e = this.elapsed[i]! + dt
+      const dur = this.duration[i]!
+      if (e >= dur) {
+        this.complete(i)
+        continue
+      }
+      this.elapsed[i] = e
+
+      let k = e / dur
+      if (this.flags[i]! & 1) k = k < 0.5 ? k * 2 : (1 - k) * 2
+      const f = this.eases[i]!(k)
+      const start = this.from[i]!
+      const value = start + (this.to[i]! - start) * f
+      const applier = this.appliers[i]
+      if (applier) applier(this.targets[i]!, this.keys[i]!, value)
+      else assign(this.targets[i]!, this.keys[i]!, value)
+    }
+  }
+
+  /**
+   * Fast-forward every tween on `ch` (or all channels) to its end state, now.
+   * Synchronous, bounded by the pool size, and the reason the kit can promise
+   * that an interrupted reaction never leaves the screen mid-pose.
+   */
+  settle(ch?: TweenChannel): number {
+    let n = 0
+    for (let a = this.activeCount - 1; a >= 0; a--) {
+      const i = this.active[a]!
+      if (ch !== undefined && this.channel[i] !== ch) continue
+      this.complete(i)
+      n++
+    }
+    return n
+  }
+
+  clear(): void {
+    for (let a = this.activeCount - 1; a >= 0; a--) this.release(this.active[a]!)
+  }
+
+  /* ------------------------------------------------------------- internals */
+
+  private complete(slot: number): void {
+    const pingpong = (this.flags[slot]! & 1) !== 0
+    // A pingpong's end state is where it started, not `to`.
+    const end = pingpong ? this.from[slot]! : this.to[slot]!
+    const applier = this.appliers[slot]
+    const obj = this.targets[slot]!
+    const key = this.keys[slot]!
+    if (applier) applier(obj, key, end)
+    else assign(obj, key, end)
+    const done = this.dones[slot]
+    this.release(slot)
+    // Fire *after* release so an `onDone` that starts a new tween can reuse
+    // this slot rather than overflowing a full pool.
+    if (done) done()
+  }
+
+  private alloc(): number {
+    if (this.freeCount === 0) return -1
+    const i = this.free[--this.freeCount]!
+    this.slotPos[i] = this.activeCount
+    this.active[this.activeCount++] = i
+    return i
+  }
+
+  private release(slot: number): void {
+    if (this.state[slot] === RUNNING) {
+      // Swap-remove from the dense active list.
+      const pos = this.slotPos[slot]!
+      const last = this.active[--this.activeCount]!
+      this.active[pos] = last
+      this.slotPos[last] = pos
+      this.slotPos[slot] = -1
+      this.free[this.freeCount++] = slot
+    }
+    this.state[slot] = FREE
+    this.targets[slot] = null
+    this.keys[slot] = null
+    this.dones[slot] = null
+    this.appliers[slot] = null
+    this.eases[slot] = null
+    this.generation[slot] = (this.generation[slot]! + 1) & 0xffff
+  }
+
+  private resolve(handle: TweenHandle): number {
+    if (handle === 0) return -1
+    const slot = (handle & 0xffff) - 1
+    if (slot < 0 || slot >= this.capacity) return -1
+    if (this.state[slot] !== RUNNING) return -1
+    if (this.generation[slot] !== (handle >>> 16)) return -1
+    return slot
+  }
+}

--- a/dynawalla/foundations/feel/tsconfig.json
+++ b/dynawalla/foundations/feel/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src", "demo", "bench"]
+}

--- a/dynawalla/foundations/feel/vite.config.ts
+++ b/dynawalla/foundations/feel/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite"
+
+export default defineConfig({
+  server: { port: 5177, strictPort: true, host: "127.0.0.1" },
+  preview: { port: 4173, strictPort: true, host: "127.0.0.1" },
+  build: { target: "es2022", outDir: "dist" },
+})


### PR DESCRIPTION
`dynawalla/foundations/feel/` — the systematic layer every prototype sits on.

```ts
feel.attach({ camera, invoke })                        // once
feel.start()                                           // once
feel.answer({ correct, difficulty, repaired, milestone }, { subject: tile })
```

That third line fires haptics, hitstop, slow-motion, trauma shake, directional
kick, punch-zoom, screen flash, squash-and-stretch, a pentatonic tone and a
particle burst — at the tier the outcome earns, at the quality the device can
hold, correct at 60 and 120 Hz, and interruptible.

**75 tests green · clean typecheck · zero runtime dependencies in the core.**

## The tier table is the deliverable

| | tier | **blocking** | tail | hitstop | trauma | time scale | particles |
|---|---|---|---|---|---|---|---|
| −1 | `nudge` wrong | **0** | 300 ms | 0 | 0.16 | 1.0 | 0 |
| 0 | `tick` | **0** | 90 ms | 0 | 0.05 | 1.0 | 0 |
| 1 | `snap` ordinary correct | **0** | 220 ms | 0 | 0.14 | 1.0 | 8 |
| 2 | `pop` hard item | **0** | 400 ms | 40 ms | 0.30 | 1.0 | 22 |
| 3 | `slam` repair | **0** | 700 ms | 75 ms | 0.46 | 0.72 | 48 |
| 4 | `bloom` milestone | **0** | 1500 ms | 110 ms | 0.62 | 0.50 | 110 |
| 5 | `ascend` once a session | 350 ms | 2800 ms | 160 ms | 0.85 | 0.32 | 200 |

A *tail* is not a wait — it draws over the next problem, which presents
concurrently. `blockingMs === 0` is **asserted** for every tier but `ascend`,
so the standard failure (gating the input handler on the celebration, and
thereby punishing the child who knows 7×8) cannot be reintroduced silently.

Also asserted: hitstop is only ever spent on success; `energy(nudge) <
energy(snap)`; and escalation keys on difficulty and repair and cannot see a
streak — kept from MISSION.md across the visual pivot, tested behaviourally
*and* by grepping every source file.

## Measured, not asserted

| | |
|---|---|
| whole feel layer, one frame | **849 ns** — 0.005% of a 16.67 ms budget, 0.041% derated 8× |
| allocation per frame / per tween | **2.3 / 2.7 bytes** |
| `interrupt()`, full 512-tween pool | **23.6 µs** (budget 1 ms) |
| browser frame work @ 1×/4×/6× CPU throttle | 0.40 / 1.90 / 2.05 ms p95 — **never over budget** |
| 40-reaction storm | **costs the same as idle** |

Screenshots at device pixel ratio in `docs/shots/`.

## Three bugs found by measuring rather than reading

- **Spring impulses were wrong by ~250×.** A tier asking for a 16% scale punch
  produced 3%; 0.3 units of camera recoil produced 0.00125. Types, review and
  tests all passed. Fixed with `Spring1D.impulseForPeak()`, derived from the
  analytic peak of the impulse response — tier numbers are now peak
  displacement in real units and a designer can reason about them.
- **The tween pool was O(capacity).** A rotating cursor plus a high-water mark
  walks all 512 slots to find the two that are live. **870 ns → 32.5 ns.**
- **`renderer.setSize(w, h, false)`** leaves the canvas at `width × dpr` CSS
  pixels, so at dpr 2 the page shows the top-left quadrant of the render.

## Fifteen traps, written up in README §4

Hitstop must be wall-clock or it halves on a 120 Hz iPad · headless Chrome's
rAF delta is a virtual cadence and reported an identical `p50 8.30 ms` across
27 configurations, idle and under storm · `performance.now()` is coarsened to
100 µs · `navigator.vibrate` is both absent in iOS WKWebView and
gesture-blocked in Chrome · headless WebGL is SwiftShader unless you ask for a
GPU · `gl_PointSize` is device pixels (first pass rendered 400 px particles) ·
`camera.lookAt()` erases roll · shake accumulated into `camera.position` drifts
· an overshoot ease over a small range does not overshoot · `AudioContext`
never auto-resumes on iOS.

Celeste's constants are from its source, verified not remembered —
`JumpGraceTime = 0.1f`, `CornerCorrection = 4` — mapped to a touch surface as
coyote time, input buffering, and fat-finger hit slop.

## Needs a founder decision

`ADR-0004` says "no 3D renderer in V1" and `EXPERIENCE_DESIGN.md` says "2D
throughout" and "juice dose is a hard ceiling". My brief says Three.js is a
founder decision and asks for warmth and spectacle over restraint. I built to
the brief on the assumption the pivot is real. **Those two documents need
updating or this kit contradicts them** — see README §6.

Not merging. Review the images, not just the diff.
