### PR TITLE
dynawalla: procedural audio foundation — synthesis, measured budget, and the traps

### DIFF
--- a/dynawalla/foundations/audio/README.md
+++ b/dynawalla/foundations/audio/README.md
@@ -1,0 +1,370 @@
+# `@dynawalla/audio` — the procedural audio foundation
+
+Every sound in the Dynawalla Bazaar is synthesized in Web Audio at runtime.
+**There are no audio files in this project and there never will be.** Zero
+runtime dependencies, no build step. 4,426 lines of kit, plus 255 of tests,
+1,300 of measurement harness, 694 of demo and 98 of tooling.
+
+```ts
+import { audio } from "@dynawalla/audio"
+
+await audio.init()             // once, anywhere. Unlock is automatic.
+audio.play("ui.chunk")         // a sound
+audio.combo(streak)            // a rising ladder that stays musical
+audio.music.setIntensity(0.7)  // the score responds
+audio.ambience("bazaar")       // the place
+audio.onCue(c => flash(c))     // visuals, so sound is never the only channel
+```
+
+That is the whole API a prototype needs. Everything else in this directory
+exists so those six lines are correct on iOS, on a silenced phone, on a cheap
+tablet, with audio switched off, at 60 fps, after ten thousand taps.
+
+---
+
+## Run it
+
+```bash
+node tools/serve.mjs        # http://localhost:8788/  demo
+                            # http://localhost:8788/measure/index.html  harness
+npm test                    # 21 unit tests, Node's native runner, no deps
+```
+
+The dev server transpiles `.ts` on the fly with Node's built-in
+`module.stripTypeScriptTypes`. No vite, no esbuild, no `node_modules`.
+
+---
+
+## What is in the box
+
+| | |
+|---|---|
+| **Physical modelling** | Polyphonic Karplus-Strong (24 voices) and modal resonator banks (16 voices × 10 modes) in an `AudioWorklet`, f64, sample-accurate scheduling |
+| **Materials** | brass · bell · tile · glass · stone · wood · skin (Bessel membrane) · copper pot — real inharmonic ratios, per-mode decay |
+| **Subtractive / FM / granular** | filtered-noise bursts and sweeps, 2-op FM, sub thump with saturation, a 1-node-per-grain granular cloud |
+| **25 presets** | UI, impacts, plucks, rewards, failures, motion, plus a combo ladder |
+| **Procedural music** | 6 layers on a Hijaz mode, lookahead scheduler, `setIntensity(0..1)`, never loops |
+| **4 ambient beds** | continuous filtered-noise air + sparse randomly-scheduled distant events |
+| **Mix** | 4 buses, sidechain ducking, compressor + oversampled soft clipper, measured true-peak ceiling |
+| **Budget** | 4 quality tiers, auto-detected by a 13 ms offline benchmark; voice cap with weighted stealing |
+
+---
+
+## Measured, on real hardware
+
+Apple M-series laptop, Chrome 149, 48 kHz. Every number below was produced by
+`measure/index.html` in this repo, not read from a specification.
+
+### The synthesis is correct
+
+| Claim | Measured |
+|---|---|
+| String bank pitch accuracy, 82 Hz – 1760 Hz | **±0.12 cents** |
+| Modal decay: requested T60 vs achieved, 6 materials | **within 0.6 %** |
+| Presets producing audio through the live path | **25 / 25** |
+
+### The mix cannot clip
+
+Twelve of the loudest presets fired on the same sample:
+
+| Chain | Peak |
+|---|---|
+| No master chain | **+24.17 dBFS** |
+| `DynamicsCompressorNode` alone | **+3.03 dBFS** — it is not a limiter |
+| Compressor + oversampled soft clipper | **−0.25 dBFS, 0 clipped samples** |
+
+### It does not cost frames
+
+Synthetic 60 Hz loop, 6 ms of main-thread work per tick, `MessageChannel`-driven:
+
+| Trigger rate | Mean tick | Kit's share of a 16.67 ms frame |
+|---|---|---|
+| control (no audio) | 6.021 ms | — |
+| 8 sounds/s (real gameplay) | 6.032 ms | **+0.018 ms** |
+| 30 sounds/s (punishing) | 6.061 ms | **+0.040 ms** |
+
+Zero ticks over 16.7 ms in any condition. Per-call `play()` cost is **6–11 µs**
+warm.
+
+### Audio-thread cost (fraction of one core)
+
+| Component | Cost |
+|---|---|
+| Empty graph | 0.85 % |
+| Convolution reverb, 1.1 s tail | 2.21 % |
+| Convolution reverb, 2.4 s tail | 2.46 % |
+| Modal bank, 16 voices × 8 modes, sustained | 5.31 % |
+| String bank, 24 voices, sustained | 4.88 % |
+| Granular cloud, 140 grains/s | 5.82 % *(was 49.32 % — see traps)* |
+| **Native BiquadFilter fallback, 100 voices** | **24.35 %** |
+| An **idle** `AudioWorkletNode`, each | **~0.33 %** |
+
+Whole scenes, rendered through the real master chain and the real voice budget:
+
+| Scene | Requested | Admitted | Peak voices | CPU | Peak | Clipped |
+|---|---|---|---|---|---|---|
+| UI only (5/s) | 19 | 19 | 2 | 5.5 % | −0.26 dBFS | 0 |
+| Busy (23/s) | 91 | 89 | 18 | 18.7 % | −0.22 dBFS | 0 |
+| Chaos (53/s) | 211 | 176 | 20 | 47.4 % | −0.26 dBFS | 0 |
+| Chaos, **budget disabled** | 211 | 211 | ∞ | 128 % | — | — |
+
+### Latency
+
+`baseLatency` 5.33 ms + `outputLatency` 24 ms + the kit's 4 ms scheduling
+offset = **~33 ms** end to end. Init (probe + worklet + tables + warm) is
+**94 ms**, once, and belongs on a loading screen.
+
+---
+
+## The budget the kit enforces
+
+The mid-range tablet is the **floor**, not the target. Tiers are picked by a
+real benchmark (`probeTier`), never by sniffing the user agent.
+
+| | ultra | high | medium | low |
+|---|---|---|---|---|
+| max voices | 48 | 32 | 20 | 12 |
+| reverb tail | 2.4 s | 1.8 s | 1.1 s | off |
+| modal partials | 10 | 8 | 6 | 4 |
+| grains/s | 140 | 90 | 45 | 0 |
+| music layers | 6 | 5 | 4 | 2 |
+| worklet banks | yes | yes | yes | native fallback |
+
+**Hard budget: the audio thread must stay under 30 % of one core in normal play
+and under 60 % in the worst case.** It has 2.67 ms to render each 128-frame
+quantum at 48 kHz; going over is a dropout, and a dropout is the only
+unrecoverable audio failure. Degradation order when a tier drops: reverb tail →
+grain density → modal partials → music layers → voice cap.
+
+Calibration: `realtimeFactor` on the reference M-series machine is **74**.
+Thresholds are ultra > 55, high > 28, medium > 10. **Re-run
+`measure/index.html` on a real target tablet and re-anchor these** — one device
+is not a calibration.
+
+---
+
+## The traps, found by hitting them
+
+**1. A `DelayNode` in a feedback cycle silently adds 128 samples.** Not clamps —
+*adds*. The textbook native Karplus-Strong is therefore flat at *every* pitch:
+measured −336 cents at 80 Hz, −2096 cents at 880 Hz. Subtracting
+`128/sampleRate` fixes tuning below the ceiling (within 7 cents) and then hard-
+pins at **373.5 Hz** for every request above it, because `delayTime` cannot go
+negative. Any plucked string above F#4 requires an `AudioWorklet`. Measured, in
+`measureNativeKarplusCeiling`.
+
+**2. The loop filter must have magnitude ≤ 1 at *all* frequencies.** A default
+`BiquadFilter` lowpass has Q = 1 and therefore a **+1.2 dB resonant peak**, so a
+0.99 feedback gain still gives loop gain > 1. Measured peak before the fix:
+**8.6 × 10¹⁷**. Use `(x[n] + x[n−1])/2` — an `IIRFilterNode([0.5,0.5],[1])`.
+
+**3. `postMessage` to a worklet does not arrive before `startRendering()`.** In
+an `OfflineAudioContext`, posting and rendering in the same task produces a
+**totally silent buffer** — no error, no warning. Measured: same pluck, peak
+`0.00000` without a macrotask yield, `0.61880` with one. Every offline bounce of
+worklet-driven audio must yield first.
+
+**4. In Web Audio you pay for the graph, not the arithmetic.** The obvious
+granular cloud — `BufferSource → BiquadFilter → Gain → StereoPanner` per grain —
+measured **49.3 % of a core** at 140 grains/s. Baking the band-pass, the Hann
+window and four amplitude steps into pre-rendered buffers, and sharing five
+static panners, gets it to **one node per grain and 5.8 %**. Identical sound,
+8.5× cheaper.
+
+**5. An idle `AudioWorkletNode` is not free** — about **0.33 % of a core each**
+(12 idle banks measured 3.98 %). Hence the banks are per-bus *and* lazy.
+
+**6. A shared polyphonic bank cannot be routed per voice.** One worklet node
+serving many voices has one output, so it cannot pass through a per-voice gain
+node and cannot land on a different bus per trigger. Symptom: a UI tick's modal
+body ignoring both the UI fader and the preset's own level. Fix: one bank per
+bus, and apply the per-voice level via the bank's own `gain` message field.
+
+**7. `WaveShaperNode` with `oversample: "2x"` can output above its own curve's
+maximum**, because the interpolation filter rings. A ceiling of 0.999 measured
+**+0.05 dBFS** — over full scale, on the node whose whole job is to be under it.
+The curve now tops out at 0.97 (−0.26 dBFS), which also gives a cheap tablet DAC
+the inter-sample headroom it wants.
+
+**8. `resume()` never rejects without a gesture — it just never resolves.**
+`await ctx.resume()` outside a user gesture hangs forever. Call it
+*synchronously* inside the gesture handler, and never `await` anything before
+it. (This cost a 45-second tool timeout during development, which is exactly
+what it does to a loading screen.)
+
+**9. `requestAnimationFrame` never fires in a background tab, and `setTimeout`
+is clamped to ~1 s.** An rAF-based perf harness hangs forever in automation. Use
+a `MessageChannel` ping-pong, which is not throttled. The same trap is why the
+music scheduler must detect that it woke up seconds behind and *rebase* rather
+than fire the backlog — otherwise a tab that was hidden for 30 s dumps ~2000
+notes into the graph at once.
+
+**10. `performance.now()` is coarsened** (~5 µs, non-cross-origin-isolated), so
+timing a single `play()` returns 0. Time a batch and divide.
+
+**11. The first `play()` of a preset costs ~200 µs**, versus 6–11 µs warm — V8
+compiling the render function and touching each node constructor. A screen
+transition firing six new presets is over a millisecond of jank at the exact
+moment the player is watching. `audio.warm()` (called by `init()`) runs every
+preset through an `OfflineAudioContext` once: pure main-thread priming, zero
+real-time cost.
+
+**12. `exponentialRampToValueAtTime` cannot start or end at 0, and
+`setTargetAtTime` never arrives.** Stop a source "when the decay ends" and you
+chop an audible tail: a click. Every envelope in the kit goes through
+`dsp/env.ts`, which uses a linear attack, an exponential-shaped decay and an
+explicit `setValueAtTime(0, end)` at the −60 dB point.
+
+**13. Allocation on the audio render thread is a click waiting to happen.** A
+`new Float32Array` per pluck inside `process()` eventually drags a GC pause into
+a 2.67 ms budget. There is a unit test that greps the worklet source for it.
+
+---
+
+## iOS, silent mode, and the plugin you must NOT reuse
+
+**Do not call `tauri-plugin-audio-keepalive` from a Dynawalla prototype.** It
+sets `AVAudioSession.setCategory(.playback)`, which makes audio ignore the
+hardware mute switch — correct for Corpán, where a language learner has
+deliberately started a narration, and **wrong here**. A parent who silences a
+tablet at a doctor's office has silenced it. The default WKWebView session
+category respects the mute switch; leave it alone.
+
+Everything the kit does for iOS is in `armUnlock()`: one-shot capture listeners
+on `pointerdown` / `touchend` / `keydown` / `mousedown`, a synchronous
+`resume()`, and a 1-frame silent buffer started inside the gesture (older WebKit
+wants a source to have started, not just a resumed context). `touchend` matters
+— `pointerdown` alone is not enough on older WebKit.
+
+The kit also suspends the context on `visibilitychange`. A backgrounded tab
+holding a live 48 kHz graph is a battery complaint, and on iOS it is an audio
+session fighting the user's music.
+
+---
+
+## Sound never carries information alone
+
+`play()` emits a `Cue` **whether or not any sound was produced** — muted,
+disabled, device silenced, or dropped by the voice budget. Every cue carries
+`intensity`, `weight` (how big a flash this deserves) and `haptic`.
+
+```ts
+audio.onCue(cue => {
+  flash(cue.id, cue.weight)
+  haptics.impact(cue.haptic)   // tauri-plugin-haptics
+})
+```
+
+Wire your visuals to cues and the prototype is accessible by construction. The
+demo's checkbox proves it: switch audio off and the screen keeps working.
+
+---
+
+## What it actually sounds like
+
+Sound design tuned against the brief — a minaret-punk bazaar of brass, tile and
+glass — and the permanent anti-goal of anything that reads as a worksheet.
+
+Every impact is **transient + body + tail (+ sub)**. The transient (0–15 ms of
+noise through a tight bandpass) is what the ear uses to identify the material;
+it is nearly inaudible alone and removing it makes any sound feel fake. The body
+is modal or FM. The tail is a *reverb send*, not a longer envelope — a long
+envelope is a synth pad, a tail is a room.
+
+Pitched presets sit on **D** in a **Hijaz**-flavoured set (1 ♭2 3 4 5 ♭6 7). A
+major triad reads as a corporate onboarding flow; Hijaz reads as somewhere with
+hot dust and hammered metal. A child cannot name it and will absolutely feel it.
+
+Timbres achieved, described honestly:
+
+- **`impact.brass`** — a struck tray. Eight modes at 1 / 2.01 / 3.02 / 4.17 …,
+  2.6 s ring, paired detuning that produces real audible beating, a bright noise
+  strike on top and a saturated 58 Hz thump under it. Measured centroid 408 Hz,
+  crest 20 dB, decay 2.46 s. It sounds like *metal*, not like a bell patch.
+- **`ui.chunk`** — the confirm. Wood transient, tile body, 82 Hz sub falling 5
+  semitones in 45 ms. Reads as a heavy, well-made thing seated into its slot.
+  17 ms of actual attack; the whole event is under 200 ms.
+- **`ui.tap`** — 12 ms of velvet noise at 2.4 kHz plus a whisper of tile body. A
+  fingertip on glazed ceramic. ±55 cents of shaped jitter and a random read
+  offset into the noise buffer, so 500 of them never machine-gun.
+- **`pluck.string`** — Karplus-Strong santur with a pick-position comb on the
+  excitation. Plucking near the bridge is thin and nasal, over the hole is
+  round; without that comb every pluck is the same instrument.
+- **`impact.drum`** — a darbuka built on the actual Bessel modes of a circular
+  membrane (1 / 1.593 / 2.135 / 2.295 / 2.917). It has a pitch you can almost
+  but not quite name, which is what a real drum does.
+- **`fail.pot`** — a copper pot wobbling to a stop: five strikes at shrinking
+  intervals, alternating pan. Genuinely funny. No buzzer, no descending minor
+  third, nothing that says *you are bad*.
+- **`fail.retry`** — three notes, down, down, then **up**, resolving to the
+  fifth. It ends open and consonant: the audio equivalent of *go on, again*.
+- **`fail.lampOut`** — the business model's emotional beat. A glass ring being
+  damped away, a falling filtered sweep, one soft thud. A loss of warmth, never
+  a penalty klaxon.
+- **`reward.big`** — sub + brass gong + a second gong a fifth up 12 ms later +
+  a six-string rolled harp + a 0.9 s granular shimmer + a rising sweep, ducking
+  the music by 55 %. This is the moment the whole kit exists to land.
+
+Anti-fatigue, which is what stops all of this becoming torture by lunchtime:
+per-trigger shaped pitch jitter (deliberately *not* uniform — uniform noise
+clusters at the centre and reads as "the same sound, slightly detuned"), random
+read offsets into the shared noise buffers, per-strike modal detune, round-robin
+variant selection that never repeats immediately, and a `minGap` per preset so
+two identical transients 8 ms apart cannot phase-sum into a 6 dB spike.
+
+---
+
+## Files
+
+```
+src/
+  index.ts              the AudioKit facade — the six-line API
+  engine.ts             context, buses, master chain, ducking, tiers, voice budget, unlock
+  types.ts              public types
+  rng.ts                deterministic randomness + the anti-fatigue shapers
+  dsp/
+    tables.ts           noise, curves, procedural impulse responses, pre-baked grains
+    env.ts              envelope helpers that close Web Audio's three sharp edges
+    materials.ts        the modal material library
+    banks.ts            worklet loading, the two polyphonic banks, native fallback
+  worklets/source.ts    dw-string, dw-modal, dw-meter (as source text)
+  presets/
+    voices.ts           synthesis primitives (noise, FM, sub, sweep, grains)
+    library.ts          the 25 presets
+  music/
+    music.ts            the procedural score
+    ambience.ts         the ambient beds
+  kit.test.ts           21 unit tests
+measure/                the harness every number in this file came from
+demo/                   the playable demo
+tools/                  zero-dep dev server, worklet emitter
+```
+
+## Adding a preset
+
+```ts
+import { createAudio, type Preset } from "@dynawalla/audio"
+import { noiseBurst, subThump } from "@dynawalla/audio/presets/voices.ts"
+
+const myPreset: Preset = {
+  id: "game.slam",
+  bus: "sfx",
+  gain: 0.4,          // set it from a measured LUFS, not by ear alone
+  group: "impact",    // shares a polyphony budget with the other impacts
+  poly: 4,
+  weight: 0.8,        // how big a flash this deserves
+  haptic: "heavy",
+  duck: 0.3,
+  render(rc) {
+    const t = noiseBurst(rc, { kind: "white", freq: 2200, gain: 0.4, decay: 0.03, highpass: 600 })
+    const s = subThump(rc, { freq: 55, drop: 8, gain: 0.5, decay: 0.2, drive: 0.5 })
+    return { endsAt: Math.max(t, s) }
+  },
+}
+
+const audio = createAudio({ presets: [myPreset] })
+```
+
+Then run `measure/index.html` → `library` and set `gain` so it lands on its
+family's loudness target. The library is matched to: UI −26 LUFS, motion −22,
+plucks/beads −18, impacts/chimes −16, unlock −14, jackpot −12.

--- a/dynawalla/foundations/audio/demo/demo.css
+++ b/dynawalla/foundations/audio/demo/demo.css
@@ -1,0 +1,242 @@
+/* Dynawalla audio demo — minaret-punk: indigo night, hammered brass, glazed tile.
+   Squared-off 8px geometry throughout (the house standard). No gradients-as-decoration,
+   no mascots, no confetti. Light comes from the sounds. */
+
+:root {
+  --ink: #0b0912;
+  --ink2: #120f1c;
+  --panel: #16121f;
+  --line: #2b2338;
+  --brass: #c9a227;
+  --brass-hi: #f0d267;
+  --tile: #2e8f8f;
+  --rose: #b8446a;
+  --text: #ece2cf;
+  --dim: #8d8299;
+  --r: 8px;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--ink);
+  color: var(--text);
+  font: 15px/1.55 ui-sans-serif, -apple-system, "Segoe UI", Inter, system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  overscroll-behavior: none;
+}
+
+#bg {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 0;
+  display: block;
+}
+
+#app {
+  position: relative;
+  z-index: 1;
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 28px 20px 64px;
+}
+
+/* ---- header ---------------------------------------------------------- */
+
+.head {
+  display: grid;
+  grid-template-columns: 44px 1fr;
+  gap: 16px;
+  align-items: start;
+  padding-bottom: 22px;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 26px;
+}
+
+.mark {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--r);
+  background:
+    conic-gradient(from 45deg, var(--brass) 0 25%, #7a6218 0 50%, var(--brass) 0 75%, #7a6218 0);
+  box-shadow: 0 0 0 1px #00000060 inset, 0 6px 24px -12px var(--brass);
+}
+
+.titles h1 {
+  margin: 0 0 4px;
+  font-size: 23px;
+  font-weight: 620;
+  letter-spacing: -0.015em;
+}
+.titles p { margin: 0; color: var(--dim); font-size: 14px; max-width: 62ch; }
+
+.meters { grid-column: 1 / -1; display: flex; gap: 22px; align-items: center; flex-wrap: wrap; margin-top: 14px; }
+
+.meter { display: flex; align-items: center; gap: 8px; flex: 1 1 220px; min-width: 180px; }
+.mlabel { font-size: 11px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--dim); }
+.mbar {
+  position: relative;
+  flex: 1;
+  height: 8px;
+  background: #0007;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.mbar i {
+  position: absolute;
+  inset: 0 100% 0 0;
+  background: linear-gradient(90deg, var(--tile), var(--brass) 72%, var(--rose));
+  transition: right 60ms linear;
+}
+
+.readout { display: flex; gap: 18px; margin: 0; flex-wrap: wrap; }
+.readout div { display: flex; flex-direction: column; }
+.readout dt { font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--dim); }
+.readout dd { margin: 0; font-variant-numeric: tabular-nums; font-size: 14px; }
+
+/* ---- gate ------------------------------------------------------------ */
+
+.gate { text-align: center; padding: 56px 0 40px; }
+.start {
+  font: inherit;
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--ink);
+  background: linear-gradient(180deg, var(--brass-hi), var(--brass));
+  border: none;
+  border-radius: var(--r);
+  padding: 16px 30px;
+  cursor: pointer;
+  box-shadow: 0 12px 40px -18px var(--brass), 0 0 0 1px #00000030 inset;
+  transition: transform 90ms ease, box-shadow 160ms ease;
+}
+.start:hover { transform: translateY(-1px); box-shadow: 0 18px 48px -18px var(--brass); }
+.start:active { transform: translateY(1px); }
+.gatenote { color: var(--dim); font-size: 13px; margin-top: 14px; }
+
+/* ---- panels ---------------------------------------------------------- */
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--r);
+  padding: 18px;
+  margin-bottom: 16px;
+}
+.panel h2 { margin: 0 0 3px; font-size: 13px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--brass); }
+.hint { margin: 0 0 14px; color: var(--dim); font-size: 13px; }
+
+.pads { display: grid; grid-template-columns: repeat(auto-fill, minmax(132px, 1fr)); gap: 10px; }
+.pads.wide { grid-template-columns: repeat(auto-fill, minmax(158px, 1fr)); }
+
+.pad {
+  position: relative;
+  overflow: hidden;
+  font: inherit;
+  text-align: left;
+  color: var(--text);
+  background: var(--ink2);
+  border: 1px solid var(--line);
+  border-radius: var(--r);
+  padding: 12px 12px 11px;
+  cursor: pointer;
+  transition: border-color 140ms ease, transform 70ms ease, background 140ms ease;
+  touch-action: manipulation;
+  user-select: none;
+}
+.pad:hover { border-color: #4a3d63; background: #1a1526; }
+.pad:active { transform: translateY(1px); }
+.pad .n { display: block; font-weight: 600; font-size: 14px; letter-spacing: -0.01em; }
+.pad .d { display: block; color: var(--dim); font-size: 11.5px; margin-top: 2px; line-height: 1.35; }
+.pad .flash {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(120% 100% at 12% 0%, var(--flash, var(--brass)) 0%, transparent 68%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.pad[data-fam="ui"] { --flash: var(--tile); }
+.pad[data-fam="impact"] { --flash: var(--brass); }
+.pad[data-fam="reward"] { --flash: var(--brass-hi); }
+.pad[data-fam="fail"] { --flash: var(--rose); }
+.pad[data-fam="motion"] { --flash: #6f7bd6; }
+.pad[data-fam="pluck"] { --flash: #d08a3c; }
+
+/* ---- combo ----------------------------------------------------------- */
+
+.comborow, .musicrow { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+
+.big {
+  font: inherit;
+  font-weight: 620;
+  font-size: 15px;
+  color: var(--ink);
+  background: linear-gradient(180deg, var(--brass-hi), var(--brass));
+  border: none;
+  border-radius: var(--r);
+  padding: 12px 26px;
+  cursor: pointer;
+  box-shadow: 0 10px 30px -18px var(--brass);
+  touch-action: manipulation;
+}
+.big:active { transform: translateY(1px); }
+
+.ghost {
+  font: inherit;
+  color: var(--text);
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: var(--r);
+  padding: 12px 18px;
+  cursor: pointer;
+}
+.ghost:hover { border-color: #4a3d63; }
+
+.streak { display: flex; align-items: baseline; gap: 7px; margin-left: auto; }
+.streak span { font-size: 30px; font-weight: 700; font-variant-numeric: tabular-nums; color: var(--brass-hi); }
+.streak em { font-style: normal; font-size: 11px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--dim); }
+
+/* ---- slider ---------------------------------------------------------- */
+
+.slider { display: flex; align-items: center; gap: 12px; flex: 1 1 260px; min-width: 240px; }
+.slider span { font-size: 11px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--dim); }
+.slider b { font-variant-numeric: tabular-nums; font-weight: 600; min-width: 3.2ch; }
+input[type="range"] {
+  flex: 1;
+  appearance: none;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--line);
+  outline: none;
+}
+input[type="range"]::-webkit-slider-thumb {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--brass);
+  border: 2px solid var(--ink);
+  cursor: pointer;
+}
+
+/* ---- footer ---------------------------------------------------------- */
+
+.foot { display: flex; gap: 14px; align-items: center; flex-wrap: wrap; padding-top: 6px; }
+.check { display: flex; align-items: center; gap: 8px; font-size: 13px; cursor: pointer; }
+.footnote { color: var(--dim); font-size: 12.5px; }
+
+@media (max-width: 560px) {
+  #app { padding: 20px 14px 48px; }
+  .titles h1 { font-size: 19px; }
+  .pads { grid-template-columns: repeat(auto-fill, minmax(112px, 1fr)); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; }
+}

--- a/dynawalla/foundations/audio/demo/demo.ts
+++ b/dynawalla/foundations/audio/demo/demo.ts
@@ -1,0 +1,360 @@
+/**
+ * The demo. Also the reference for how a prototype wires audio to visuals.
+ *
+ * The pattern to copy is `audio.onCue`: EVERY sound emits a cue carrying an
+ * intensity, a weight and a haptic hint, and the visuals are driven from that
+ * — not from the call site. Turn audio off with the checkbox and watch the
+ * screen keep working, because the cues keep coming. That is the whole
+ * accessibility story in one subscription.
+ */
+
+import { createAudio, type Cue } from "../src/index.ts"
+
+const kit = createAudio()
+
+// ---------------------------------------------------------------------------
+// Background: a lattice of tile that lights up when sounds fire. Canvas, one
+// rAF, no libraries. It is here because a silent demo of an audio kit is a
+// terrible demo of an audio kit.
+// ---------------------------------------------------------------------------
+
+interface Bloom {
+  x: number
+  y: number
+  born: number
+  life: number
+  power: number
+  hue: string
+}
+
+const canvas = document.getElementById("bg") as HTMLCanvasElement
+const g = canvas.getContext("2d")!
+const blooms: Bloom[] = []
+let dpr = 1
+
+const resize = (): void => {
+  dpr = Math.min(2, window.devicePixelRatio || 1)
+  canvas.width = Math.floor(innerWidth * dpr)
+  canvas.height = Math.floor(innerHeight * dpr)
+}
+resize()
+addEventListener("resize", resize)
+
+const HUES: Record<string, string> = {
+  ui: "46,143,143",
+  impact: "201,162,39",
+  reward: "240,210,103",
+  fail: "184,68,106",
+  motion: "111,123,214",
+  pluck: "208,138,60",
+  combo: "240,210,103",
+}
+
+const famOf = (id: string): string => id.split(".")[0]
+
+let frameMs = 0
+const draw = (t: number): void => {
+  const w = canvas.width
+  const h = canvas.height
+  g.setTransform(1, 0, 0, 1, 0, 0)
+  g.fillStyle = "#0b0912"
+  g.fillRect(0, 0, w, h)
+
+  // The lattice: an 8-point star grid, the flattest possible nod to zellij.
+  const cell = 78 * dpr
+  g.strokeStyle = "rgba(120,100,160,0.055)"
+  g.lineWidth = 1 * dpr
+  g.beginPath()
+  for (let x = 0; x <= w + cell; x += cell) {
+    g.moveTo(x, 0)
+    g.lineTo(x, h)
+  }
+  for (let y = 0; y <= h + cell; y += cell) {
+    g.moveTo(0, y)
+    g.lineTo(w, y)
+  }
+  for (let y = -cell; y <= h + cell; y += cell) {
+    for (let x = -cell; x <= w + cell; x += cell) {
+      g.moveTo(x + cell * 0.5, y)
+      g.lineTo(x + cell, y + cell * 0.5)
+      g.lineTo(x + cell * 0.5, y + cell)
+      g.lineTo(x, y + cell * 0.5)
+      g.lineTo(x + cell * 0.5, y)
+    }
+  }
+  g.stroke()
+
+  for (let i = blooms.length - 1; i >= 0; i--) {
+    const b = blooms[i]
+    const age = (t - b.born) / b.life
+    if (age >= 1) {
+      blooms.splice(i, 1)
+      continue
+    }
+    // Fast attack, slow release — the same envelope as the sound it came from.
+    const env = age < 0.08 ? age / 0.08 : Math.pow(1 - (age - 0.08) / 0.92, 2.2)
+    const r = (60 + b.power * 320) * dpr * (0.35 + age * 1.5)
+    const grad = g.createRadialGradient(b.x, b.y, 0, b.x, b.y, r)
+    grad.addColorStop(0, `rgba(${b.hue},${0.3 * env * b.power})`)
+    grad.addColorStop(0.5, `rgba(${b.hue},${0.09 * env * b.power})`)
+    grad.addColorStop(1, `rgba(${b.hue},0)`)
+    g.fillStyle = grad
+    g.beginPath()
+    g.arc(b.x, b.y, r, 0, Math.PI * 2)
+    g.fill()
+  }
+  requestAnimationFrame(draw)
+}
+requestAnimationFrame(draw)
+
+/** Frame-time readout, so the perf claim is visible rather than asserted. */
+let lastFrame = performance.now()
+const frameTick = (): void => {
+  const now = performance.now()
+  frameMs = frameMs * 0.9 + (now - lastFrame) * 0.1
+  lastFrame = now
+  requestAnimationFrame(frameTick)
+}
+requestAnimationFrame(frameTick)
+
+// ---------------------------------------------------------------------------
+// The one integration point: cues in, light out.
+// ---------------------------------------------------------------------------
+
+let lastPointer = { x: innerWidth / 2, y: innerHeight * 0.45 }
+addEventListener("pointerdown", (e) => (lastPointer = { x: e.clientX, y: e.clientY }))
+
+kit.onCue((c: Cue) => {
+  const el = document.querySelector<HTMLElement>(`[data-id="${CSS.escape(c.id)}"] .flash`)
+  if (el) {
+    el.animate([{ opacity: 0.85 }, { opacity: 0 }], {
+      duration: 220 + c.weight * 600,
+      easing: "cubic-bezier(.15,.7,.3,1)",
+    })
+  }
+  blooms.push({
+    x: lastPointer.x * dpr,
+    y: lastPointer.y * dpr,
+    born: performance.now(),
+    life: 380 + c.weight * 1400,
+    power: 0.25 + c.weight,
+    hue: HUES[famOf(c.id)] ?? "201,162,39",
+  })
+  // A real build maps `c.haptic` onto tauri-plugin-haptics here. The browser
+  // Vibration API is the stand-in so the mapping is exercised.
+  const nav = navigator as Navigator & { vibrate?: (p: number | number[]) => boolean }
+  if (nav.vibrate) {
+    const ms = { none: 0, light: 8, medium: 16, heavy: 28, success: 20, warning: 24 }[c.haptic]
+    if (ms) nav.vibrate(ms)
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Pads
+// ---------------------------------------------------------------------------
+
+interface PadSpec {
+  id: string
+  name: string
+  desc: string
+  opts?: Parameters<typeof kit.play>[1]
+}
+
+const buildPads = (host: HTMLElement, specs: PadSpec[]): void => {
+  for (const s of specs) {
+    const b = document.createElement("button")
+    b.className = "pad"
+    b.dataset.id = s.id
+    b.dataset.fam = famOf(s.id)
+    b.innerHTML = `<span class="flash"></span><span class="n"></span><span class="d"></span>`
+    b.querySelector(".n")!.textContent = s.name
+    b.querySelector(".d")!.textContent = s.desc
+    const fire = (e: PointerEvent): void => {
+      lastPointer = { x: e.clientX, y: e.clientY }
+      // Intensity from where in the pad you hit it: a tiny thing that makes a
+      // demo feel like an instrument instead of a list.
+      const r = b.getBoundingClientRect()
+      const i = Math.max(0.15, Math.min(1, (e.clientX - r.left) / r.width))
+      kit.play(s.id, { intensity: i, ...s.opts })
+    }
+    b.addEventListener("pointerdown", fire)
+    b.addEventListener("pointerenter", (e) => {
+      if (e.buttons === 1) fire(e)
+    })
+    host.appendChild(b)
+  }
+}
+
+buildPads(document.getElementById("padsImpact")!, [
+  { id: "impact.brass", name: "Brass", desc: "8 inharmonic modes, 2.6 s ring, beating" },
+  { id: "impact.tile", name: "Glazed tile", desc: "bar modes 1 · 2.74 · 5.36 · 8.9" },
+  { id: "impact.stone", name: "Stone", desc: "heavy damping, all weight" },
+  { id: "impact.glass", name: "Glass", desc: "high Q, 1.9 s, fragile" },
+  { id: "impact.drum", name: "Darbuka", desc: "circular membrane Bessel modes" },
+  { id: "impact.pot", name: "Copper pot", desc: "hollow, faintly ridiculous" },
+  { id: "pluck.string", name: "Santur", desc: "Karplus-Strong + pick comb" },
+  { id: "pluck.harp", name: "Rolled chord", desc: "four strings, 22 ms apart" },
+])
+
+buildPads(document.getElementById("padsLoop")!, [
+  { id: "ui.tap", name: "Tap", desc: "12 ms. Heard 500 times a session." },
+  { id: "ui.chunk", name: "Chunk", desc: "the confirm: wood + tile + sub" },
+  { id: "ui.select", name: "Select", desc: "steps up the scale" },
+  { id: "ui.toggle", name: "Toggle", desc: "two-part latch" },
+  { id: "reward.bead", name: "Bead", desc: "FM bell, 3.51 ratio" },
+  { id: "reward.chime", name: "Chime", desc: "two struck bells" },
+  { id: "reward.unlock", name: "Unlock", desc: "mechanism, then light" },
+  { id: "reward.big", name: "Jackpot", desc: "sub + gong + harp + shimmer", opts: { intensity: 1 } },
+  { id: "fail.soft", name: "Not that one", desc: "a bead on cloth. Never a buzzer." },
+  { id: "fail.pot", name: "Wobble", desc: "five strikes, shrinking gaps" },
+  { id: "fail.retry", name: "Go on, again", desc: "down, down, up — ends open" },
+  { id: "fail.lampOut", name: "Lamp out", desc: "loss of warmth, not a penalty" },
+  { id: "motion.whoosh", name: "Whoosh", desc: "swept bandpass, random direction" },
+  { id: "motion.arrive", name: "Arrive", desc: "swell into a tile hit" },
+  { id: "motion.pop", name: "Pop", desc: "tuned, so runs make a melody" },
+])
+
+buildPads(document.getElementById("padsStress")!, [
+  { id: "__storm", name: "40 in a second", desc: "watch the budget steal voices" },
+  { id: "__roll", name: "Drum roll", desc: "24 strikes, accelerating" },
+  { id: "__chord", name: "Big chord", desc: "8 strings at once" },
+])
+
+// ---------------------------------------------------------------------------
+// Ambience + music + combo
+// ---------------------------------------------------------------------------
+
+const ambHost = document.getElementById("padsAmb")!
+const beds: { id: "bazaar" | "courtyard" | "night" | "workshop"; name: string; desc: string }[] = [
+  { id: "bazaar", name: "Bazaar", desc: "brown air, distant brass" },
+  { id: "courtyard", name: "Courtyard", desc: "enclosed, reflective" },
+  { id: "night", name: "Night", desc: "cool, almost nothing happens" },
+  { id: "workshop", name: "Workshop", desc: "a metalworker, close by" },
+]
+let currentBed: string | null = null
+for (const b of beds) {
+  const el = document.createElement("button")
+  el.className = "pad"
+  el.dataset.fam = "ui"
+  el.innerHTML = `<span class="flash"></span><span class="n"></span><span class="d"></span>`
+  el.querySelector(".n")!.textContent = b.name
+  el.querySelector(".d")!.textContent = b.desc
+  el.addEventListener("pointerdown", () => {
+    currentBed = currentBed === b.id ? null : b.id
+    kit.ambience(currentBed as never)
+    for (const other of ambHost.querySelectorAll<HTMLElement>(".pad")) {
+      other.style.borderColor = ""
+    }
+    if (currentBed) el.style.borderColor = "var(--brass)"
+  })
+  ambHost.appendChild(el)
+}
+
+let streak = 0
+const streakEl = document.getElementById("streakN")!
+document.getElementById("comboHit")!.addEventListener("pointerdown", (e) => {
+  lastPointer = { x: (e as PointerEvent).clientX, y: (e as PointerEvent).clientY }
+  streak++
+  streakEl.textContent = String(streak)
+  kit.combo(streak)
+})
+document.getElementById("comboReset")!.addEventListener("pointerdown", () => {
+  streak = 0
+  streakEl.textContent = "0"
+  kit.resetCombo()
+  kit.play("ui.back")
+})
+
+let musicOn = false
+const musicBtn = document.getElementById("musicToggle") as HTMLButtonElement
+musicBtn.addEventListener("pointerdown", () => {
+  musicOn = !musicOn
+  if (musicOn) kit.music.start()
+  else kit.music.stop()
+  musicBtn.textContent = musicOn ? "Stop score" : "Start score"
+})
+const intensity = document.getElementById("intensity") as HTMLInputElement
+const intensityV = document.getElementById("intensityV")!
+intensity.addEventListener("input", () => {
+  const v = Number(intensity.value) / 100
+  intensityV.textContent = v.toFixed(2)
+  kit.music.setIntensity(v)
+})
+
+document.getElementById("enabled")!.addEventListener("change", (e) => {
+  kit.setEnabled((e.target as HTMLInputElement).checked)
+})
+
+// ---------------------------------------------------------------------------
+// Stress buttons (handled here, not as presets)
+// ---------------------------------------------------------------------------
+
+const storm = (): void => {
+  const ids = ["ui.tap", "impact.tile", "reward.bead", "pluck.string", "impact.glass", "combo"]
+  for (let i = 0; i < 40; i++) {
+    kit.play(ids[i % ids.length], { delay: i * 0.025, intensity: 0.4 + (i % 6) * 0.1 })
+  }
+}
+const roll = (): void => {
+  for (let i = 0; i < 24; i++) {
+    kit.play("impact.drum", { delay: Math.pow(i / 24, 1.6) * 1.6, intensity: 0.35 + i * 0.026 })
+  }
+}
+const chord = (): void => {
+  for (let i = 0; i < 8; i++) {
+    kit.play("pluck.string", { delay: i * 0.006, semitones: [0, 4, 7, 12, 16, 19, 24, 28][i], intensity: 0.8 })
+  }
+}
+document.querySelector('[data-id="__storm"]')!.addEventListener("pointerdown", storm)
+document.querySelector('[data-id="__roll"]')!.addEventListener("pointerdown", roll)
+document.querySelector('[data-id="__chord"]')!.addEventListener("pointerdown", chord)
+
+// ---------------------------------------------------------------------------
+// Boot
+// ---------------------------------------------------------------------------
+
+const rTier = document.getElementById("rTier")!
+const rVoices = document.getElementById("rVoices")!
+const rLat = document.getElementById("rLat")!
+const rFrame = document.getElementById("rFrame")!
+const mpeak = document.getElementById("mpeak") as HTMLElement
+
+document.getElementById("start")!.addEventListener("click", async () => {
+  await kit.init()
+  await kit.resume()
+  document.getElementById("gate")!.setAttribute("hidden", "")
+  document.getElementById("stage")!.removeAttribute("hidden")
+
+  const s = kit.stats
+  rTier.textContent = `${kit.tier}${s.worklets ? "" : " (no worklet)"}`
+  rLat.textContent = `${Math.round((s.baseLatency + s.outputLatency) * 1000 + 4)} ms`
+
+  // A real output meter, tapped off the master with the kit's own meter
+  // processor. Nothing here is a fake animation of "audio is happening".
+  try {
+    const meter = new AudioWorkletNode(kit.ctx, "dw-meter", { numberOfInputs: 1, numberOfOutputs: 1 })
+    const sink = kit.ctx.createGain()
+    sink.gain.value = 0
+    for (const b of ["sfx", "ui", "music", "ambience"] as const) kit.bus(b).connect(meter)
+    meter.connect(sink)
+    sink.connect(kit.ctx.destination)
+    let held = 0
+    meter.port.onmessage = (e: MessageEvent) => {
+      const d = e.data as { peak: number }
+      held = Math.max(d.peak, held * 0.82)
+      mpeak.style.right = `${Math.max(0, 100 - Math.min(1, held) * 100)}%`
+    }
+  } catch {
+    /* no worklet on this device; the meter is decoration, the sound is not */
+  }
+
+  setInterval(() => {
+    rVoices.textContent = String(kit.stats.activeVoices)
+    rFrame.textContent = `${frameMs.toFixed(1)} ms`
+  }, 200)
+
+  kit.play("reward.unlock", { intensity: 0.8 })
+  kit.ambience("bazaar")
+  currentBed = "bazaar"
+  ;(ambHost.querySelector(".pad") as HTMLElement).style.borderColor = "var(--brass)"
+})

--- a/dynawalla/foundations/audio/demo/index.html
+++ b/dynawalla/foundations/audio/demo/index.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Dynawalla — procedural audio foundation</title>
+    <link rel="stylesheet" href="./demo.css" />
+  </head>
+  <body>
+    <canvas id="bg"></canvas>
+
+    <main id="app">
+      <header class="head">
+        <div class="mark" aria-hidden="true"></div>
+        <div class="titles">
+          <h1>The sound of the bazaar</h1>
+          <p>Every sound below is synthesized on the spot. No audio files exist in this project.</p>
+        </div>
+        <div class="meters">
+          <div class="meter"><span class="mlabel">out</span><div class="mbar"><i id="mpeak"></i></div></div>
+          <dl class="readout">
+            <div><dt>tier</dt><dd id="rTier">—</dd></div>
+            <div><dt>voices</dt><dd id="rVoices">0</dd></div>
+            <div><dt>latency</dt><dd id="rLat">—</dd></div>
+            <div><dt>frame</dt><dd id="rFrame">—</dd></div>
+          </dl>
+        </div>
+      </header>
+
+      <section class="gate" id="gate">
+        <button id="start" class="start">Touch to wake the bazaar</button>
+        <p class="gatenote">Browsers keep audio silent until you ask for it. So do we.</p>
+      </section>
+
+      <div id="stage" hidden>
+        <section class="panel">
+          <h2>Struck things</h2>
+          <p class="hint">Modal synthesis — real inharmonic partials, real decay times. Drag across them.</p>
+          <div class="pads" id="padsImpact"></div>
+        </section>
+
+        <section class="panel">
+          <h2>The loop</h2>
+          <p class="hint">What a prototype actually calls, in the order a child hears it.</p>
+          <div class="pads wide" id="padsLoop"></div>
+        </section>
+
+        <section class="panel combo">
+          <h2>Combo ladder</h2>
+          <p class="hint">One call. The kit owns the musicality: up the Hijaz scale, gaining weight as it climbs.</p>
+          <div class="comborow">
+            <button class="big" id="comboHit">Hit</button>
+            <button class="ghost" id="comboReset">Reset</button>
+            <div class="streak"><span id="streakN">0</span><em>streak</em></div>
+          </div>
+        </section>
+
+        <section class="panel">
+          <h2>The place</h2>
+          <p class="hint">A bed you stop hearing, plus events you never stop noticing.</p>
+          <div class="pads" id="padsAmb"></div>
+        </section>
+
+        <section class="panel">
+          <h2>Score</h2>
+          <p class="hint">Procedural. Never loops. Responds to intensity on the bar line.</p>
+          <div class="musicrow">
+            <button class="big" id="musicToggle">Start score</button>
+            <label class="slider">
+              <span>intensity</span>
+              <input type="range" id="intensity" min="0" max="100" value="35" />
+              <b id="intensityV">0.35</b>
+            </label>
+          </div>
+        </section>
+
+        <section class="panel">
+          <h2>Proof</h2>
+          <p class="hint">Stress it. The voice budget and the master chain are doing the work.</p>
+          <div class="pads" id="padsStress"></div>
+        </section>
+
+        <footer class="foot">
+          <label class="check"><input type="checkbox" id="enabled" checked /> <span>audio enabled</span></label>
+          <span class="footnote">Turn it off: the cues keep firing and the visuals keep working. Sound never carries information alone.</span>
+        </footer>
+      </div>
+    </main>
+
+    <script type="module" src="./demo.ts"></script>
+  </body>
+</html>

--- a/dynawalla/foundations/audio/measure/analysis.ts
+++ b/dynawalla/foundations/audio/measure/analysis.ts
@@ -1,0 +1,343 @@
+/**
+ * Signal analysis for the measurement harness. Zero dependencies.
+ *
+ * Everything here is used to make claims about the kit's SOUND that are
+ * numbers rather than adjectives: measured decay times, measured pitch,
+ * measured loudness, measured spectral centroid, measured peak.
+ */
+
+/** In-place iterative radix-2 FFT. `re`/`im` length must be a power of two. */
+export const fft = (re: Float64Array, im: Float64Array): void => {
+  const n = re.length
+  for (let i = 1, j = 0; i < n; i++) {
+    let bit = n >> 1
+    for (; j & bit; bit >>= 1) j ^= bit
+    j ^= bit
+    if (i < j) {
+      let t = re[i]
+      re[i] = re[j]
+      re[j] = t
+      t = im[i]
+      im[i] = im[j]
+      im[j] = t
+    }
+  }
+  for (let len = 2; len <= n; len <<= 1) {
+    const ang = (-2 * Math.PI) / len
+    const wr = Math.cos(ang)
+    const wi = Math.sin(ang)
+    for (let i = 0; i < n; i += len) {
+      let cr = 1
+      let ci = 0
+      for (let k = 0; k < len / 2; k++) {
+        const ur = re[i + k]
+        const ui = im[i + k]
+        const vr = re[i + k + len / 2] * cr - im[i + k + len / 2] * ci
+        const vi = re[i + k + len / 2] * ci + im[i + k + len / 2] * cr
+        re[i + k] = ur + vr
+        im[i + k] = ui + vi
+        re[i + k + len / 2] = ur - vr
+        im[i + k + len / 2] = ui - vi
+        const ncr = cr * wr - ci * wi
+        ci = cr * wi + ci * wr
+        cr = ncr
+      }
+    }
+  }
+}
+
+const hann = (n: number): Float64Array => {
+  const w = new Float64Array(n)
+  for (let i = 0; i < n; i++) w[i] = 0.5 - 0.5 * Math.cos((2 * Math.PI * i) / (n - 1))
+  return w
+}
+
+export const db = (x: number): number => 20 * Math.log10(Math.max(1e-12, x))
+
+export interface Metrics {
+  peakDb: number
+  rmsDb: number
+  /** Max momentary loudness, BS.1770 K-weighted, 400 ms window. */
+  lufsMax: number
+  /** Seconds from onset until the envelope is 60 dB below its peak. */
+  decayTo60: number
+  /** Where the energy sits, Hz — the honest number behind "bright" / "dark". */
+  centroidHz: number
+  /** Peak / RMS in dB. Percussive material is 12-20 dB; a synth pad is < 6. */
+  crestDb: number
+  /** Fraction of samples at or beyond full scale. Must be 0. */
+  clippedFraction: number
+  /** DC offset. Anything above ~0.002 wastes headroom and thumps on start. */
+  dcOffset: number
+  /** Energy above 8 kHz as a fraction of total — the "air" of a sound. */
+  airRatio: number
+  /** Energy below 120 Hz as a fraction of total — the "weight". */
+  weightRatio: number
+}
+
+/** Mono-sum, then measure. Stereo width is measured separately. */
+export const toMono = (chans: Float32Array[]): Float32Array => {
+  if (chans.length === 1) return chans[0]
+  const n = chans[0].length
+  const out = new Float32Array(n)
+  for (let i = 0; i < n; i++) {
+    let s = 0
+    for (let c = 0; c < chans.length; c++) s += chans[c][i]
+    out[i] = s / chans.length
+  }
+  return out
+}
+
+/**
+ * ITU-R BS.1770 K-weighting: a +4 dB high shelf at ~1.5 kHz followed by a
+ * ~38 Hz high-pass (RLB). Coefficients are the standard 48 kHz ones; we
+ * re-derive them for other rates so a 44.1 kHz device is not measured wrong.
+ */
+const kWeight = (x: Float32Array, sr: number): Float64Array => {
+  // Stage 1: high shelf.
+  const f0 = 1681.974450955533
+  const G = 3.999843853973347
+  const Q = 0.7071752369554196
+  const K = Math.tan((Math.PI * f0) / sr)
+  const Vh = Math.pow(10, G / 20)
+  const Vb = Math.pow(Vh, 0.4996667741545416)
+  const a0_ = 1 + K / Q + K * K
+  const b0 = (Vh + (Vb * K) / Q + K * K) / a0_
+  const b1 = (2 * (K * K - Vh)) / a0_
+  const b2 = (Vh - (Vb * K) / Q + K * K) / a0_
+  const a1 = (2 * (K * K - 1)) / a0_
+  const a2 = (1 - K / Q + K * K) / a0_
+  // Stage 2: RLB high-pass.
+  const f0b = 38.13547087602444
+  const Qb = 0.5003270373238773
+  const Kb = Math.tan((Math.PI * f0b) / sr)
+  const a0b = 1 + Kb / Qb + Kb * Kb
+  const b0b = 1
+  const b1b = -2
+  const b2b = 1
+  const a1b = (2 * (Kb * Kb - 1)) / a0b
+  const a2b = (1 - Kb / Qb + Kb * Kb) / a0b
+
+  const y = new Float64Array(x.length)
+  let x1 = 0,
+    x2 = 0,
+    y1 = 0,
+    y2 = 0
+  for (let i = 0; i < x.length; i++) {
+    const v = b0 * x[i] + b1 * x1 + b2 * x2 - a1 * y1 - a2 * y2
+    x2 = x1
+    x1 = x[i]
+    y2 = y1
+    y1 = v
+    y[i] = v
+  }
+  let u1 = 0,
+    u2 = 0,
+    v1 = 0,
+    v2 = 0
+  for (let i = 0; i < y.length; i++) {
+    const u = y[i]
+    const v = (b0b * u + b1b * u1 + b2b * u2 - a1b * v1 - a2b * v2) / 1
+    u2 = u1
+    u1 = u
+    v2 = v1
+    v1 = v
+    y[i] = v
+  }
+  return y
+}
+
+export const analyse = (chans: Float32Array[], sr: number): Metrics => {
+  const x = toMono(chans)
+  const n = x.length
+  let peak = 0
+  let sum = 0
+  let dc = 0
+  let clipped = 0
+  for (let i = 0; i < n; i++) {
+    const a = Math.abs(x[i])
+    if (a > peak) peak = a
+    if (a >= 0.99999) clipped++
+    sum += x[i] * x[i]
+    dc += x[i]
+  }
+  const rms = Math.sqrt(sum / n)
+
+  // Momentary loudness, 400 ms blocks, 100 ms hop.
+  const k = kWeight(x, sr)
+  const block = Math.floor(sr * 0.4)
+  const hop = Math.floor(sr * 0.1)
+  let lufsMax = -Infinity
+  for (let s = 0; s + block <= n; s += hop) {
+    let e = 0
+    for (let i = s; i < s + block; i++) e += k[i] * k[i]
+    const l = -0.691 + 10 * Math.log10(Math.max(1e-12, e / block))
+    if (l > lufsMax) lufsMax = l
+  }
+  if (!isFinite(lufsMax) && n > 0) {
+    let e = 0
+    for (let i = 0; i < n; i++) e += k[i] * k[i]
+    lufsMax = -0.691 + 10 * Math.log10(Math.max(1e-12, e / n))
+  }
+
+  // Decay to -60 dB from peak, measured on a 5 ms RMS envelope.
+  const win = Math.max(1, Math.floor(sr * 0.005))
+  let peakEnv = 0
+  let peakIdx = 0
+  const envN = Math.floor(n / win)
+  const env = new Float64Array(envN)
+  for (let b = 0; b < envN; b++) {
+    let e = 0
+    for (let i = b * win; i < (b + 1) * win; i++) e += x[i] * x[i]
+    env[b] = Math.sqrt(e / win)
+    if (env[b] > peakEnv) {
+      peakEnv = env[b]
+      peakIdx = b
+    }
+  }
+  let decayTo60 = (n - peakIdx * win) / sr
+  const target = peakEnv * 0.001
+  for (let b = peakIdx; b < envN; b++) {
+    if (env[b] < target) {
+      decayTo60 = ((b - peakIdx) * win) / sr
+      break
+    }
+  }
+
+  // Spectral centroid + band ratios over the first 4096-sample window at peak.
+  const N = 4096
+  const start = Math.min(Math.max(0, peakIdx * win), Math.max(0, n - N))
+  const re = new Float64Array(N)
+  const im = new Float64Array(N)
+  const w = hann(N)
+  for (let i = 0; i < N; i++) re[i] = (x[start + i] ?? 0) * w[i]
+  fft(re, im)
+  let num = 0
+  let den = 0
+  let air = 0
+  let weight = 0
+  for (let bin = 1; bin < N / 2; bin++) {
+    const mag = Math.hypot(re[bin], im[bin])
+    const f = (bin * sr) / N
+    num += f * mag
+    den += mag
+    if (f > 8000) air += mag
+    if (f < 120) weight += mag
+  }
+
+  return {
+    peakDb: db(peak),
+    rmsDb: db(rms),
+    lufsMax,
+    decayTo60,
+    centroidHz: den > 0 ? num / den : 0,
+    crestDb: db(peak) - db(rms),
+    clippedFraction: clipped / n,
+    dcOffset: dc / n,
+    airRatio: den > 0 ? air / den : 0,
+    weightRatio: den > 0 ? weight / den : 0,
+  }
+}
+
+/**
+ * Fundamental frequency, McLeod (NSDF) method.
+ *
+ * MEASUREMENT TRAP, HIT AND FIXED: the obvious implementation — raw
+ * autocorrelation, take the largest value in [minLag, maxLag] — is WRONG for
+ * any decaying sound. Raw autocorrelation falls monotonically with lag because
+ * the signal is getting quieter, so the maximum lands on the lower bound of the
+ * search and you "measure" whatever `maxHz` you passed in. The first run of
+ * this harness reported every plucked string as exactly 1.7045x its true
+ * pitch — a perfectly consistent, perfectly wrong number, which is the most
+ * dangerous kind.
+ *
+ * The NSDF normalises by the energy in BOTH windows, which removes the decay
+ * bias entirely, and then picks the first peak within 88% of the global max
+ * (rather than the global max itself) so an octave error cannot occur.
+ */
+export const estimatePitch = (x: Float32Array, sr: number, minHz = 60, maxHz = 4000): number => {
+  const minLag = Math.max(2, Math.floor(sr / maxHz))
+  const maxLag = Math.min(Math.floor(sr / minHz), Math.floor(x.length / 2) - 1)
+  if (maxLag <= minLag) return 0
+  const n = x.length
+  const nsdf = new Float64Array(maxLag + 2)
+  for (let lag = minLag; lag <= maxLag; lag++) {
+    let r = 0
+    let m = 0
+    const lim = n - lag
+    for (let i = 0; i < lim; i++) {
+      const a = x[i]
+      const b = x[i + lag]
+      r += a * b
+      m += a * a + b * b
+    }
+    nsdf[lag] = m > 0 ? (2 * r) / m : 0
+  }
+  let globalMax = 0
+  for (let lag = minLag; lag <= maxLag; lag++) if (nsdf[lag] > globalMax) globalMax = nsdf[lag]
+  if (globalMax <= 0) return 0
+  const threshold = globalMax * 0.88
+  let bestLag = -1
+  for (let lag = minLag + 1; lag < maxLag; lag++) {
+    if (nsdf[lag] > nsdf[lag - 1] && nsdf[lag] >= nsdf[lag + 1] && nsdf[lag] >= threshold) {
+      bestLag = lag
+      break
+    }
+  }
+  if (bestLag < 0) return 0
+  // Parabolic interpolation for sub-sample precision (the difference between
+  // "within 3 cents" and "within 40 cents").
+  const y0 = nsdf[bestLag - 1]
+  const y1 = nsdf[bestLag]
+  const y2 = nsdf[bestLag + 1]
+  const denom = y0 - 2 * y1 + y2
+  const shift = denom !== 0 ? (0.5 * (y0 - y2)) / denom : 0
+  return sr / (bestLag + shift)
+}
+
+/** Cents between two frequencies. */
+export const centsBetween = (a: number, b: number): number => 1200 * Math.log2(a / b)
+
+/**
+ * T20-style decay estimate: fit the dB envelope between -5 and -25 dB below
+ * peak and extrapolate to -60. Far more robust than "when did it cross -60",
+ * which any noise floor ruins.
+ */
+export const measureT60 = (x: Float32Array, sr: number): number => {
+  const win = Math.max(1, Math.floor(sr * 0.005))
+  const envN = Math.floor(x.length / win)
+  const env: number[] = []
+  for (let b = 0; b < envN; b++) {
+    let e = 0
+    for (let i = b * win; i < (b + 1) * win; i++) e += x[i] * x[i]
+    env.push(Math.sqrt(e / win))
+  }
+  let peak = 0
+  let peakIdx = 0
+  for (let i = 0; i < env.length; i++)
+    if (env[i] > peak) {
+      peak = env[i]
+      peakIdx = i
+    }
+  const pts: [number, number][] = []
+  for (let i = peakIdx; i < env.length; i++) {
+    const d = db(env[i] / peak)
+    if (d <= -5 && d >= -25) pts.push([((i - peakIdx) * win) / sr, d])
+    if (d < -25) break
+  }
+  if (pts.length < 4) return NaN
+  let sx = 0,
+    sy = 0,
+    sxx = 0,
+    sxy = 0
+  for (const [t, d] of pts) {
+    sx += t
+    sy += d
+    sxx += t * t
+    sxy += t * d
+  }
+  const nn = pts.length
+  const slope = (nn * sxy - sx * sy) / (nn * sxx - sx * sx)
+  if (slope >= 0) return NaN
+  return -60 / slope
+}

--- a/dynawalla/foundations/audio/measure/harness.ts
+++ b/dynawalla/foundations/audio/measure/harness.ts
@@ -1,0 +1,900 @@
+/**
+ * The measurement harness. Everything the kit claims is produced here.
+ *
+ * Runs in a real browser (and therefore in a real WebView) because there is no
+ * meaningful way to measure Web Audio anywhere else. Offline renders give exact,
+ * reproducible signal measurements; the live context gives the latency,
+ * scheduling and main-thread numbers that only exist in real time.
+ *
+ * Exposed on `window.DW` so a driver can call each measurement and read JSON.
+ */
+
+import { createModalBank, createStringBank, loadWorklets, strikeNative } from "../src/dsp/banks.ts"
+import { MATERIALS } from "../src/dsp/materials.ts"
+import { tablesFor } from "../src/dsp/tables.ts"
+import { AudioKit } from "../src/index.ts"
+import { ALL_PRESETS } from "../src/presets/library.ts"
+import { grainCloud } from "../src/presets/voices.ts"
+import { mulberry32 } from "../src/rng.ts"
+import type { Preset, RenderCtx, Tier } from "../src/types.ts"
+import { analyse, centsBetween, estimatePitch, measureT60, toMono, type Metrics } from "./analysis.ts"
+
+const SR = 48000
+
+/**
+ * TRAP, HIT AND MEASURED: a message posted to an AudioWorkletNode is NOT
+ * delivered before `startRendering()` resolves if you call them in the same
+ * task. The render completes with total silence — no error, no warning, just a
+ * zero buffer, which reads exactly like "your synth is broken".
+ *
+ * Measured on Chrome 149: same pluck, `startRendering()` immediately -> peak
+ * 0.00000; one macrotask yield first -> peak 0.61880. Any offline bounce of
+ * worklet-driven audio must yield. (Real-time contexts are unaffected: there
+ * the control message queue is drained between render quanta.)
+ */
+const yieldToWorklet = (): Promise<void> => new Promise((r) => setTimeout(r, 30))
+
+const channels = (buf: AudioBuffer): Float32Array[] => {
+  const out: Float32Array[] = []
+  for (let c = 0; c < buf.numberOfChannels; c++) out.push(buf.getChannelData(c))
+  return out
+}
+
+/** Build an offline context with the worklets loaded and a master-free bus. */
+const offline = async (
+  seconds: number,
+): Promise<{
+  oc: OfflineAudioContext
+  bus: GainNode
+  send: GainNode | null
+  strings: ReturnType<typeof createStringBank>
+  modal: ReturnType<typeof createModalBank>
+}> => {
+  const oc = new OfflineAudioContext(2, Math.ceil(SR * seconds), SR)
+  await loadWorklets(oc)
+  const bus = oc.createGain()
+  bus.gain.value = 1
+  bus.connect(oc.destination)
+  const conv = oc.createConvolver()
+  conv.buffer = tablesFor(oc).impulse("tile", 1.4)
+  conv.connect(oc.destination)
+  const send = oc.createGain()
+  send.gain.value = 0.16
+  send.connect(conv)
+  const strings = createStringBank(oc)
+  const modal = createModalBank(oc)
+  strings?.node.connect(bus)
+  modal?.node.connect(bus)
+  return { oc, bus, send, strings, modal }
+}
+
+/** Render one preset in isolation and measure it. */
+export const renderPreset = async (
+  preset: Preset,
+  opts: { seconds?: number; intensity?: number; semitones?: number; seed?: number; tier?: Tier } = {},
+): Promise<{ metrics: Metrics; buffer: AudioBuffer }> => {
+  const seconds = opts.seconds ?? 4
+  const { oc, bus, send, strings, modal } = await offline(seconds)
+  const rand = mulberry32(opts.seed ?? 12345)
+  // Mirror the live path: one gain node per voice carrying the preset's level.
+  const voice = oc.createGain()
+  voice.gain.value = preset.gain
+  voice.connect(bus)
+  const rc: RenderCtx = {
+    ctx: oc,
+    out: voice,
+    send,
+    when: 0.05,
+    level: preset.gain,
+    intensity: opts.intensity ?? 0.8,
+    semitones: opts.semitones ?? 0,
+    tier: opts.tier ?? "ultra",
+    rand,
+    range: (lo, hi) => lo + rand() * (hi - lo),
+    tables: tablesFor(oc),
+    strings,
+    modal,
+  }
+  preset.render(rc)
+  await yieldToWorklet()
+  const buf = await oc.startRendering()
+  return { metrics: analyse(channels(buf), SR), buffer: buf }
+}
+
+/** Every preset, measured. This is the loudness-matching evidence. */
+export const measureLibrary = async (): Promise<Record<string, Metrics>> => {
+  const out: Record<string, Metrics> = {}
+  for (const p of ALL_PRESETS) {
+    const { metrics } = await renderPreset(p, { seconds: 4, intensity: 0.85, seed: 7 })
+    out[p.id] = metrics
+  }
+  return out
+}
+
+/**
+ * Does the modal bank actually deliver the T60 it is asked for?
+ * Renders a single mode of a material at a known frequency and fits the decay.
+ */
+export const measureModalT60 = async (): Promise<
+  { material: string; freq: number; askedT60: number; measuredT60: number; errorPct: number }[]
+> => {
+  const rows = []
+  for (const key of ["brass", "tile", "glass", "wood", "skin", "stone"] as const) {
+    const m = MATERIALS[key]
+    const freq = 220
+    const { oc, bus, modal } = await offline(Math.max(1, m.t60 * 2))
+    if (!modal) continue
+    // Single mode, no detune, so the fit is unambiguous.
+    modal.strike({
+      when: 0.02,
+      material: { ...m, ratios: [1], amps: [1], detuneCents: 0, beat: 0 },
+      freq,
+      velocity: 0.9,
+      modes: 1,
+      gain: 1,
+      rand: mulberry32(1),
+    })
+    bus.gain.value = 1
+    await yieldToWorklet()
+    const buf = await oc.startRendering()
+    const measured = measureT60(toMono(channels(buf)), SR)
+    rows.push({
+      material: key,
+      freq,
+      askedT60: m.t60,
+      measuredT60: measured,
+      errorPct: ((measured - m.t60) / m.t60) * 100,
+    })
+  }
+  return rows
+}
+
+/** Is the string bank in tune? */
+export const measureStringTuning = async (): Promise<
+  { asked: number; measured: number; cents: number }[]
+> => {
+  const rows = []
+  for (const f of [82.41, 146.83, 220, 293.66, 440, 587.33, 880, 1174.66, 1760]) {
+    const { oc, strings } = await offline(1.2)
+    if (!strings) break
+    strings.pluck({ when: 0.02, freq: f, velocity: 0.9, decay: 1.5, damping: 0.15, position: 0.2, gain: 1 })
+    await yieldToWorklet()
+  const buf = await oc.startRendering()
+    const x = toMono(channels(buf))
+    // Analyse the sustain, not the attack: the pick transient is broadband.
+    // Window must hold several periods of the LOWEST pitch under test and the
+    // search range must bracket the answer generously — a narrow range around
+    // the expected value is how you accidentally measure your own assumption.
+    const seg = x.subarray(Math.floor(SR * 0.25), Math.floor(SR * 0.25) + 16384)
+    const measured = estimatePitch(seg, SR, Math.max(40, f * 0.35), Math.min(SR * 0.4, f * 3))
+    rows.push({ asked: f, measured, cents: centsBetween(measured, f) })
+  }
+  return rows
+}
+
+/**
+ * THE NATIVE KARPLUS-STRONG TRAP, measured three ways.
+ *
+ * Builds the textbook feedback loop from native nodes — BufferSource ->
+ * DelayNode -> loop filter -> gain -> back into the delay — and asks it for a
+ * range of pitches, with and without compensating for the render quantum.
+ *
+ * What this actually proves (Chrome 149, 48 kHz):
+ *   1. A DelayNode inside a CYCLE has exactly one render quantum (128 frames)
+ *      ADDED to its delay. Not clamped — added. So the naive loop is flat at
+ *      EVERY pitch: -336 cents at 80 Hz, -2096 cents at 880 Hz.
+ *   2. Subtracting 128/sampleRate fixes tuning below the ceiling (within 7
+ *      cents) and then hard-pins at 373.5 Hz for every request above it,
+ *      because delayTime cannot go negative.
+ *   3. The loop filter must have magnitude <= 1 at ALL frequencies. A default
+ *      BiquadFilter lowpass (Q = 1) has a +1.2 dB resonant peak, so a 0.99
+ *      feedback gain still gives loop gain > 1 and the "string" becomes a
+ *      self-oscillator — measured peak 8.6e17 before we swapped it for the
+ *      classic (x[n]+x[n-1])/2 averaging filter.
+ */
+export const measureNativeKarplusCeiling = async (): Promise<{
+  uncompensated: { asked: number; measured: number; cents: number }[]
+  compensated: { asked: number; measured: number; cents: number }[]
+  resonantLoopPeak: number
+}> => {
+  const probe = async (f: number, compensate: boolean, resonantFilter = false): Promise<{ pitch: number; peak: number }> => {
+    const oc = new OfflineAudioContext(1, SR, SR)
+    const exc = oc.createBuffer(1, Math.ceil(SR / f), SR)
+    const d = exc.getChannelData(0)
+    const rnd = mulberry32(4242)
+    for (let i = 0; i < d.length; i++) d[i] = rnd() * 2 - 1
+    const src = oc.createBufferSource()
+    src.buffer = exc
+    const delay = oc.createDelay(1)
+    delay.delayTime.value = compensate ? Math.max(0, 1 / f - 128 / SR) : 1 / f
+    let loop: AudioNode
+    if (resonantFilter) {
+      const bq = oc.createBiquadFilter()
+      bq.type = "lowpass"
+      bq.frequency.value = 6000
+      loop = bq
+    } else {
+      loop = oc.createIIRFilter([0.5, 0.5], [1])
+    }
+    const fb = oc.createGain()
+    fb.gain.value = resonantFilter ? 0.99 : 0.995
+    src.connect(delay)
+    delay.connect(loop)
+    loop.connect(fb)
+    fb.connect(delay) // <-- the cycle
+    delay.connect(oc.destination)
+    src.start(0)
+    const buf = await oc.startRendering()
+    const x = buf.getChannelData(0)
+    let peak = 0
+    for (let i = 0; i < x.length; i++) peak = Math.max(peak, Math.abs(x[i]))
+    const seg = x.subarray(Math.floor(SR * 0.15), Math.floor(SR * 0.15) + 16384)
+    return { pitch: estimatePitch(seg, SR, 40, 8000), peak }
+  }
+  const freqs = [80, 110, 220, 300, 370, 375, 400, 440, 660, 880]
+  const uncompensated = []
+  const compensated = []
+  for (const f of freqs) {
+    const a = await probe(f, false)
+    uncompensated.push({ asked: f, measured: a.pitch, cents: centsBetween(a.pitch, f) })
+    const b = await probe(f, true)
+    compensated.push({ asked: f, measured: b.pitch, cents: centsBetween(b.pitch, f) })
+  }
+  const res = await probe(440, false, true)
+  return { uncompensated, compensated, resonantLoopPeak: res.peak }
+}
+
+/**
+ * Offline DSP cost of a whole scene, rendered through the REAL master chain
+ * and (optionally) the REAL voice budget.
+ *
+ * `realtimeFactor` is rendered-seconds / wall-seconds. The audio thread has to
+ * finish one 128-frame quantum every 2.67 ms at 48 kHz, so 1/realtimeFactor is
+ * the fraction of one core the audio thread needs. Anything approaching 1.0 is
+ * a dropout on the target device even though it "works" on a laptop.
+ *
+ * Running with `budget:false` is not a fair test of the kit — it is the
+ * measurement that shows WHY the budget exists.
+ */
+export const measureLoad = async (
+  scene: "idle" | "ui" | "busy" | "chaos",
+  seconds = 4,
+  opts: { budget?: boolean; maxVoices?: number; masterChain?: boolean } = {},
+): Promise<{
+  scene: string
+  budget: boolean
+  requested: number
+  admitted: number
+  peakConcurrent: number
+  wallMs: number
+  realtimeFactor: number
+  audioThreadPct: number
+  metrics: Metrics
+}> => {
+  const useBudget = opts.budget !== false
+  const useChain = opts.masterChain !== false
+  const maxVoices = opts.maxVoices ?? 20 // the `medium` tier: our mid-tablet floor
+  const oc = new OfflineAudioContext(2, Math.ceil(SR * seconds), SR)
+  await loadWorklets(oc)
+  const t = tablesFor(oc)
+
+  let head: AudioNode = oc.destination
+  if (useChain) {
+    const ws = oc.createWaveShaper()
+    ws.curve = t.safetyClip()
+    ws.oversample = "2x"
+    ws.connect(oc.destination)
+    const comp = oc.createDynamicsCompressor()
+    comp.threshold.value = -14
+    comp.knee.value = 6
+    comp.ratio.value = 6
+    comp.attack.value = 0.004
+    comp.release.value = 0.16
+    comp.connect(ws)
+    head = comp
+  }
+  const master = oc.createGain()
+  master.gain.value = 0.9
+  master.connect(head)
+  const bus = oc.createGain()
+  bus.gain.value = 1
+  bus.connect(master)
+  const conv = oc.createConvolver()
+  conv.buffer = t.impulse("tile", 1.1)
+  conv.connect(master)
+  const send = oc.createGain()
+  send.gain.value = 0.16
+  send.connect(conv)
+  const strings = createStringBank(oc)
+  const modal = createModalBank(oc)
+  strings?.node.connect(bus)
+  modal?.node.connect(bus)
+
+  const rand = mulberry32(99)
+  const byId = new Map(ALL_PRESETS.map((p) => [p.id, p]))
+  const rates: Record<string, [string, number][]> = {
+    idle: [],
+    ui: [
+      ["ui.tap", 4],
+      ["ui.chunk", 1],
+    ],
+    busy: [
+      ["ui.tap", 6],
+      ["ui.chunk", 2],
+      ["impact.tile", 4],
+      ["reward.bead", 5],
+      ["pluck.string", 4],
+      ["combo", 3],
+    ],
+    chaos: [
+      ["ui.tap", 12],
+      ["impact.brass", 4],
+      ["impact.tile", 8],
+      ["impact.stone", 4],
+      ["reward.bead", 10],
+      ["pluck.string", 8],
+      ["combo", 6],
+      ["motion.whoosh", 3],
+      ["reward.big", 1],
+    ],
+  }
+  // Build the full request list, sorted by time, then admit it through the same
+  // policy the live engine uses (minGap, per-group polyphony, global cap,
+  // lowest-weight steal).
+  const requests: { id: string; when: number; intensity: number }[] = []
+  for (const [id, perSec] of rates[scene]) {
+    const n = Math.floor(perSec * seconds)
+    for (let i = 0; i < n; i++) {
+      const when = 0.05 + (i / perSec) * (1 + rand() * 0.1)
+      if (when < seconds - 0.1) requests.push({ id, when, intensity: 0.6 + rand() * 0.4 })
+    }
+  }
+  requests.sort((a, b) => a.when - b.when)
+
+  const live: { group: string; endsAt: number; startedAt: number; weight: number }[] = []
+  const lastFired = new Map<string, number>()
+  let admitted = 0
+  let peakConcurrent = 0
+  for (const r of requests) {
+    const p = byId.get(r.id)
+    if (!p) continue
+    if (useBudget) {
+      for (let i = live.length - 1; i >= 0; i--) if (live[i].endsAt <= r.when) live.splice(i, 1)
+      const gap = p.minGap ?? 0.012
+      const last = lastFired.get(p.id) ?? -1
+      if (r.when - last < gap) continue
+      const group = p.group ?? p.id
+      const poly = p.poly ?? 6
+      const same = live.filter((v) => v.group === group)
+      const weight = (p.weight ?? 0.4) * (0.5 + r.intensity * 0.5)
+      if (same.length >= poly) {
+        let oldest = same[0]
+        for (const v of same) if (v.startedAt < oldest.startedAt) oldest = v
+        live.splice(live.indexOf(oldest), 1)
+      }
+      if (live.length >= maxVoices) {
+        let victim: (typeof live)[0] | null = null
+        for (const v of live) {
+          if (r.when - v.startedAt < 0.05) continue
+          if (!victim || v.weight < victim.weight) victim = v
+        }
+        if (!victim || victim.weight > weight) continue
+        live.splice(live.indexOf(victim), 1)
+      }
+      lastFired.set(p.id, r.when)
+      const voice = oc.createGain()
+      voice.gain.value = p.gain
+      voice.connect(bus)
+      const res = p.render({
+        ctx: oc,
+        out: voice,
+        send,
+        when: r.when,
+        level: p.gain,
+        intensity: r.intensity,
+        semitones: 0,
+        tier: "medium",
+        rand,
+        range: (lo, hi) => lo + rand() * (hi - lo),
+        tables: t,
+        strings,
+        modal,
+      })
+      live.push({ group, endsAt: res.endsAt, startedAt: r.when, weight })
+      peakConcurrent = Math.max(peakConcurrent, live.length)
+      admitted++
+    } else {
+      const voice2 = oc.createGain()
+      voice2.gain.value = p.gain
+      voice2.connect(bus)
+      p.render({
+        ctx: oc,
+        out: voice2,
+        send,
+        when: r.when,
+        level: p.gain,
+        intensity: r.intensity,
+        semitones: 0,
+        tier: "ultra",
+        rand,
+        range: (lo, hi) => lo + rand() * (hi - lo),
+        tables: t,
+        strings,
+        modal,
+      })
+      admitted++
+    }
+  }
+
+  await yieldToWorklet()
+  const t0 = performance.now()
+  const buf = await oc.startRendering()
+  const wallMs = performance.now() - t0
+  const realtimeFactor = (seconds * 1000) / wallMs
+  return {
+    scene,
+    budget: useBudget,
+    requested: requests.length,
+    admitted,
+    peakConcurrent,
+    wallMs,
+    realtimeFactor,
+    audioThreadPct: 100 / realtimeFactor,
+    metrics: analyse(channels(buf), SR),
+  }
+}
+
+/** Does the master chain hold the ceiling when everything fires at once? */
+export const measureLimiter = async (): Promise<{
+  withoutChain: Metrics
+  withChain: Metrics
+  compressorOnlyPeakDb: number
+}> => {
+  // 12 loud impacts at the same instant is far beyond anything the game will
+  // do; if the chain holds here it holds everywhere.
+  const build = async (useChain: boolean, useCompOnly = false) => {
+    const { oc, send, strings, modal } = await offline(3)
+    const t = tablesFor(oc)
+    let head: AudioNode = oc.destination
+    if (useChain || useCompOnly) {
+      const comp = oc.createDynamicsCompressor()
+      comp.threshold.value = -14
+      comp.knee.value = 6
+      comp.ratio.value = 6
+      comp.attack.value = 0.004
+      comp.release.value = 0.16
+      if (useChain) {
+        const ws = oc.createWaveShaper()
+        ws.curve = t.safetyClip()
+        ws.oversample = "2x"
+        comp.connect(ws)
+        ws.connect(oc.destination)
+      } else {
+        comp.connect(oc.destination)
+      }
+      head = comp
+    }
+    const bus = oc.createGain()
+    bus.gain.value = 1
+    bus.connect(head)
+    strings?.node.disconnect()
+    modal?.node.disconnect()
+    strings?.node.connect(bus)
+    modal?.node.connect(bus)
+    const rand = mulberry32(5)
+    const byId = new Map(ALL_PRESETS.map((p) => [p.id, p]))
+    for (const id of [
+      "impact.brass",
+      "impact.stone",
+      "impact.drum",
+      "reward.big",
+      "impact.tile",
+      "ui.chunk",
+      "impact.brass",
+      "impact.stone",
+      "reward.chime",
+      "impact.glass",
+      "impact.pot",
+      "ui.chunk",
+    ]) {
+      const p = byId.get(id)
+      const vg = oc.createGain()
+      vg.gain.value = p?.gain ?? 1
+      vg.connect(bus)
+      p?.render({
+        ctx: oc,
+        out: vg,
+        send,
+        when: 0.05,
+        level: p?.gain ?? 1,
+        intensity: 1,
+        semitones: 0,
+        tier: "ultra",
+        rand,
+        range: (lo, hi) => lo + rand() * (hi - lo),
+        tables: t,
+        strings,
+        modal,
+      })
+    }
+    await yieldToWorklet()
+  const buf = await oc.startRendering()
+    return analyse(channels(buf), SR)
+  }
+  const withoutChain = await build(false)
+  const withChain = await build(true)
+  const compOnly = await build(false, true)
+  return { withoutChain, withChain, compressorOnlyPeakDb: compOnly.peakDb }
+}
+
+/**
+ * Anti-fatigue evidence: render the same preset 60 times and report the spread
+ * of pitch, centroid and level. A preset with near-zero spread is the one that
+ * will drive a parent mad by lunchtime.
+ */
+export const measureVariation = async (
+  presetId: string,
+  n = 40,
+): Promise<{ id: string; centroidStdPct: number; peakStdDb: number; centroidHz: number }> => {
+  const p = ALL_PRESETS.find((x) => x.id === presetId)
+  if (!p) throw new Error(`no preset ${presetId}`)
+  const cents: number[] = []
+  const peaks: number[] = []
+  for (let i = 0; i < n; i++) {
+    const { metrics } = await renderPreset(p, { seconds: 1.2, intensity: 0.8, seed: 1000 + i })
+    cents.push(metrics.centroidHz)
+    peaks.push(metrics.peakDb)
+  }
+  const mean = (a: number[]): number => a.reduce((x, y) => x + y, 0) / a.length
+  const std = (a: number[]): number => {
+    const m = mean(a)
+    return Math.sqrt(mean(a.map((v) => (v - m) ** 2)))
+  }
+  return {
+    id: presetId,
+    centroidHz: mean(cents),
+    centroidStdPct: (std(cents) / mean(cents)) * 100,
+    peakStdDb: std(peaks),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// LIVE measurements — need a real AudioContext.
+// ---------------------------------------------------------------------------
+
+export const measureLiveLatency = async (kit: AudioKit): Promise<Record<string, number | string>> => {
+  const ctx = kit.ctx
+  return {
+    state: ctx.state,
+    sampleRate: ctx.sampleRate,
+    baseLatencyMs: (ctx.baseLatency ?? 0) * 1000,
+    outputLatencyMs: (ctx.outputLatency ?? 0) * 1000,
+    /** What the kit's own +4ms scheduling offset adds. */
+    kitScheduleOffsetMs: 4,
+    totalEstimatedMs: ((ctx.baseLatency ?? 0) + (ctx.outputLatency ?? 0)) * 1000 + 4,
+  }
+}
+
+/**
+ * Main-thread cost of `play()`.
+ *
+ * MEASUREMENT TRAP: `performance.now()` is coarsened (Chrome clamps it to ~5 us
+ * in a non-cross-origin-isolated page), so timing ONE `play()` returns 0 for
+ * the median and garbage for the tail. Time a BATCH and divide. The batch also
+ * has to be spread across scheduled times, or the engine's own `minGap` drops
+ * most of the calls and you measure the reject path.
+ */
+export const measureTriggerCost = (
+  kit: AudioKit,
+  id: string,
+  batches = 24,
+  perBatch = 25,
+): { id: string; perCallUs: number; p95BatchUs: number; worstBatchUs: number } => {
+  const times: number[] = []
+  for (let b = 0; b < batches; b++) {
+    const t0 = performance.now()
+    for (let i = 0; i < perBatch; i++) {
+      kit.play(id, { intensity: 0.7, delay: 0.05 + i * 0.05 })
+    }
+    times.push(((performance.now() - t0) * 1000) / perBatch)
+  }
+  times.sort((a, b) => a - b)
+  const mean = times.reduce((a, b) => a + b, 0) / times.length
+  return {
+    id,
+    perCallUs: mean,
+    p95BatchUs: times[Math.floor(times.length * 0.95)],
+    worstBatchUs: times[times.length - 1],
+  }
+}
+
+/**
+ * THE NUMBER THAT MATTERS: does the audio kit cost frames?
+ *
+ * Drives a synthetic 60 Hz game loop, each tick burning a fixed slice of
+ * main-thread work, and records the tick durations with and without the kit
+ * firing sounds at `rate` per second. The 60 fps budget is 16.67 ms; the kit's
+ * share of it has to be invisible.
+ *
+ * TRAP: `requestAnimationFrame` NEVER FIRES in a background tab, so an
+ * rAF-based version of this test simply hangs forever when the harness is not
+ * the foreground tab — which is exactly how an automated run works. The loop
+ * below uses a `MessageChannel` ping-pong, which Chrome does not throttle, so
+ * the measurement is valid whether or not anyone is looking at it. (The same
+ * trap is why the kit's music scheduler must guard against waking up seconds
+ * behind — see `music.ts`.)
+ */
+export const measureFrameImpact = async (
+  kit: AudioKit,
+  opts: { rate?: number; seconds?: number; ids?: string[]; workMs?: number } = {},
+): Promise<{
+  control: { meanMs: number; p95Ms: number; worstMs: number; ticks: number; over16_7: number }
+  withAudio: { meanMs: number; p95Ms: number; worstMs: number; ticks: number; over16_7: number }
+  audioCostPerTickMs: number
+  triggersFired: number
+  peakVoices: number
+}> => {
+  const rate = opts.rate ?? 30
+  const seconds = opts.seconds ?? 3
+  const workMs = opts.workMs ?? 6
+  const ids = opts.ids ?? ["ui.tap", "impact.tile", "reward.bead", "pluck.string", "combo", "ui.chunk"]
+
+  const burn = (ms: number): number => {
+    const end = performance.now() + ms
+    let acc = 0
+    while (performance.now() < end) for (let i = 0; i < 2000; i++) acc += Math.sqrt(i + acc % 7)
+    return acc
+  }
+
+  const sample = async (fire: boolean): Promise<{
+    stats: { meanMs: number; p95Ms: number; worstMs: number; ticks: number; over16_7: number }
+    fired: number
+    peak: number
+  }> => {
+    const durations: number[] = []
+    let fired = 0
+    let peak = 0
+    const start = performance.now()
+    const end = start + seconds * 1000
+    let nextFire = start
+    const mc = new MessageChannel()
+    await new Promise<void>((resolve) => {
+      mc.port1.onmessage = () => {
+        const t0 = performance.now()
+        burn(workMs)
+        if (fire) {
+          while (nextFire <= t0) {
+            kit.play(ids[fired % ids.length], { intensity: 0.5 + (fired % 5) * 0.1 })
+            fired++
+            nextFire += 1000 / rate
+          }
+          peak = Math.max(peak, kit.stats.activeVoices)
+        }
+        durations.push(performance.now() - t0)
+        if (performance.now() < end) mc.port2.postMessage(0)
+        else resolve()
+      }
+      mc.port2.postMessage(0)
+    })
+    durations.shift()
+    const sorted = [...durations].sort((a, b) => a - b)
+    return {
+      stats: {
+        meanMs: durations.reduce((a, b) => a + b, 0) / durations.length,
+        p95Ms: sorted[Math.floor(sorted.length * 0.95)],
+        worstMs: sorted[sorted.length - 1],
+        ticks: durations.length,
+        over16_7: durations.filter((d) => d > 16.7).length,
+      },
+      fired,
+      peak,
+    }
+  }
+  const control = await sample(false)
+  const withAudio = await sample(true)
+  return {
+    control: control.stats,
+    withAudio: withAudio.stats,
+    audioCostPerTickMs: withAudio.stats.meanMs - control.stats.meanMs,
+    triggersFired: withAudio.fired,
+    peakVoices: withAudio.peak,
+  }
+}
+
+/** Render-quantum health under load, if the browser exposes it. */
+export const measureRenderCapacity = async (
+  kit: AudioKit,
+  seconds = 3,
+): Promise<Record<string, number> | { unsupported: true }> => {
+  const rc = (kit.ctx as AudioContext & { renderCapacity?: { start(o: object): void; stop(): void; onupdate: ((e: object) => void) | null } })
+    .renderCapacity
+  if (!rc) return { unsupported: true }
+  const peaks: number[] = []
+  const avgs: number[] = []
+  let underruns = 0
+  rc.onupdate = (e: object) => {
+    const ev = e as { averageLoad: number; peakLoad: number; underrunRatio: number }
+    avgs.push(ev.averageLoad)
+    peaks.push(ev.peakLoad)
+    if (ev.underrunRatio > 0) underruns++
+  }
+  rc.start({ updateInterval: 0.2 })
+  await new Promise((r) => setTimeout(r, seconds * 1000))
+  rc.stop()
+  return {
+    samples: avgs.length,
+    avgLoad: avgs.reduce((a, b) => a + b, 0) / Math.max(1, avgs.length),
+    peakLoad: Math.max(0, ...peaks),
+    underrunIntervals: underruns,
+  }
+}
+
+/**
+ * Component cost breakdown — where the audio thread's money actually goes.
+ * Each row renders 4 s of ONE thing and reports the fraction of a core it
+ * needs. This is what the tier profiles are built from.
+ */
+export const measureComponents = async (): Promise<
+  { component: string; realtimeFactor: number; audioThreadPct: number }[]
+> => {
+  const seconds = 4
+  const run = async (
+    name: string,
+    build: (oc: OfflineAudioContext, bus: GainNode, send: GainNode, banks: {
+      strings: ReturnType<typeof createStringBank>
+      modal: ReturnType<typeof createModalBank>
+      tables: ReturnType<typeof tablesFor>
+    }) => void,
+  ): Promise<{ component: string; realtimeFactor: number; audioThreadPct: number }> => {
+    const oc = new OfflineAudioContext(2, Math.ceil(SR * seconds), SR)
+    await loadWorklets(oc)
+    const tables = tablesFor(oc)
+    const bus = oc.createGain()
+    bus.connect(oc.destination)
+    const send = oc.createGain()
+    send.gain.value = 0
+    send.connect(oc.destination)
+    const strings = createStringBank(oc)
+    const modal = createModalBank(oc)
+    strings?.node.connect(bus)
+    modal?.node.connect(bus)
+    build(oc, bus, send, { strings, modal, tables })
+    await yieldToWorklet()
+    const t0 = performance.now()
+    await oc.startRendering()
+    const wallMs = performance.now() - t0
+    const rtf = (seconds * 1000) / wallMs
+    return { component: name, realtimeFactor: rtf, audioThreadPct: 100 / rtf }
+  }
+
+  const rows = []
+  rows.push(await run("empty graph", () => {}))
+  rows.push(
+    await run("convolver 1.1s (medium tier reverb)", (oc, _bus, _s, b) => {
+      const c = oc.createConvolver()
+      c.buffer = b.tables.impulse("tile", 1.1)
+      c.connect(oc.destination)
+      const n = oc.createBufferSource()
+      n.buffer = b.tables.pink()
+      n.loop = true
+      const g = oc.createGain()
+      g.gain.value = 0.2
+      n.connect(g)
+      g.connect(c)
+      n.start(0)
+    }),
+  )
+  rows.push(
+    await run("convolver 2.4s (ultra tier reverb)", (oc, _bus, _s, b) => {
+      const c = oc.createConvolver()
+      c.buffer = b.tables.impulse("tile", 2.4)
+      c.connect(oc.destination)
+      const n = oc.createBufferSource()
+      n.buffer = b.tables.pink()
+      n.loop = true
+      const g = oc.createGain()
+      g.gain.value = 0.2
+      n.connect(g)
+      g.connect(c)
+      n.start(0)
+    }),
+  )
+  rows.push(
+    await run("modal bank, 16 voices x 8 modes sustained", (_oc, _bus, _s, b) => {
+      for (let i = 0; i < 16; i++) {
+        b.modal?.strike({
+          when: 0.02 + i * 0.001,
+          material: MATERIALS.brass,
+          freq: 180 + i * 20,
+          velocity: 0.9,
+          modes: 8,
+          sustain: 2,
+          gain: 0.3,
+          rand: mulberry32(i),
+        })
+      }
+    }),
+  )
+  rows.push(
+    await run("string bank, 24 voices sustained", (_oc, _bus, _s, b) => {
+      for (let i = 0; i < 24; i++) {
+        b.strings?.pluck({
+          when: 0.02 + i * 0.001,
+          freq: 150 + i * 25,
+          velocity: 0.8,
+          decay: 4,
+          damping: 0.15,
+          position: 0.2,
+          gain: 0.25,
+        })
+      }
+    }),
+  )
+  rows.push(
+    await run("140 grains/s cloud (ultra tier ceiling)", (oc, bus, send, b) => {
+      const rand = mulberry32(3)
+      const rc: RenderCtx = {
+        ctx: oc,
+        out: bus,
+        send,
+        when: 0.05,
+        level: 1,
+        intensity: 1,
+        semitones: 0,
+        tier: "ultra",
+        rand,
+        range: (lo, hi) => lo + rand() * (hi - lo),
+        tables: b.tables,
+        strings: b.strings,
+        modal: b.modal,
+      }
+      grainCloud(rc, { rate: 140, seconds: 3.5, freq: 4200, spreadSemis: 14, gain: 0.3, send: 0.35 })
+    }),
+  )
+  rows.push(
+    await run("100 native BiquadFilter voices (fallback modal path)", (oc, bus, _s, b) => {
+      const rand = mulberry32(11)
+      for (let i = 0; i < 100; i++) {
+        strikeNative(oc, bus, {
+          when: 0.02 + i * 0.03,
+          material: MATERIALS.tile,
+          freq: 200 + (i % 12) * 30,
+          velocity: 0.7,
+          rand,
+          noise: b.tables.white(),
+        })
+      }
+    }),
+  )
+  return rows
+}
+
+declare global {
+  interface Window {
+    DW: Record<string, unknown>
+  }
+}
+
+export const install = (): void => {
+  window.DW = {
+    AudioKit,
+    ALL_PRESETS,
+    MATERIALS,
+    renderPreset,
+    measureLibrary,
+    measureModalT60,
+    measureStringTuning,
+    measureNativeKarplusCeiling,
+    measureLoad,
+    measureComponents,
+    measureLimiter,
+    measureVariation,
+    measureLiveLatency,
+    measureTriggerCost,
+    measureFrameImpact,
+    measureRenderCapacity,
+    analyse,
+    estimatePitch,
+    measureT60,
+  }
+}

--- a/dynawalla/foundations/audio/measure/index.html
+++ b/dynawalla/foundations/audio/measure/index.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Dynawalla audio — measurement harness</title>
+    <style>
+      body {
+        background: #0d0b12;
+        color: #e8dcc8;
+        font: 13px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+        margin: 0;
+        padding: 24px;
+      }
+      h1 { font-size: 15px; letter-spacing: 0.12em; text-transform: uppercase; color: #c9a227; }
+      button {
+        background: #1b1725; color: #e8dcc8; border: 1px solid #3a3050;
+        padding: 8px 14px; margin: 0 6px 6px 0; cursor: pointer; font: inherit;
+      }
+      button:hover { border-color: #c9a227; }
+      pre { white-space: pre-wrap; word-break: break-word; background: #120f19; padding: 12px; border: 1px solid #2a2338; }
+    </style>
+  </head>
+  <body>
+    <h1>Dynawalla audio — measurement harness</h1>
+    <div id="controls"></div>
+    <pre id="out">ready</pre>
+    <script type="module">
+      import { install } from "./harness.ts"
+      install()
+      const out = document.getElementById("out")
+      const log = (o) => { out.textContent = typeof o === "string" ? o : JSON.stringify(o, null, 2) }
+      window.log = log
+      const controls = document.getElementById("controls")
+      const add = (name, fn) => {
+        const b = document.createElement("button")
+        b.textContent = name
+        b.onclick = async () => { log("running " + name + " ...") ; try { log(await fn()) } catch (e) { log(String(e && e.stack || e)) } }
+        controls.appendChild(b)
+      }
+      add("live kit", async () => {
+        const kit = new window.DW.AudioKit()
+        await kit.init()
+        window.kit = kit
+        await kit.resume()
+        return { tier: kit.tier, stats: kit.stats, latency: await window.DW.measureLiveLatency(kit) }
+      })
+      add("modal T60", () => window.DW.measureModalT60())
+      add("string tuning", () => window.DW.measureStringTuning())
+      add("native KS ceiling", () => window.DW.measureNativeKarplusCeiling())
+      add("load: busy", () => window.DW.measureLoad("busy"))
+      add("load: chaos", () => window.DW.measureLoad("chaos"))
+      add("limiter", () => window.DW.measureLimiter())
+      add("library", () => window.DW.measureLibrary())
+    </script>
+  </body>
+</html>

--- a/dynawalla/foundations/audio/package.json
+++ b/dynawalla/foundations/audio/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@dynawalla/audio",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Dynawalla procedural audio foundation. Every sound synthesized in WebAudio at runtime; no shipped audio assets, no dependencies.",
+  "engines": { "node": ">=22.17" },
+  "scripts": {
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
+    "serve": "node tools/serve.mjs",
+    "emit:worklet": "node tools/emit-worklet.mjs",
+    "tsc": "tsc --noEmit"
+  }
+}

--- a/dynawalla/foundations/audio/src/dsp/banks.ts
+++ b/dynawalla/foundations/audio/src/dsp/banks.ts
@@ -1,0 +1,225 @@
+/**
+ * Worklet loading + the two polyphonic banks (strings, modal) + a native
+ * fallback modal bank for the rare host where AudioWorklet is unavailable or
+ * blocked.
+ *
+ * TRAPS THIS FILE EXISTS TO ABSORB
+ * --------------------------------
+ * - `audioWorklet.addModule()` is async and MUST resolve before you construct
+ *   an `AudioWorkletNode`, or you get `InvalidStateError` with a message that
+ *   does not say "you did not await". The kit therefore boots the banks during
+ *   `init()` and every preset degrades gracefully if they are absent.
+ * - A `blob:` URL is the only way to load a worklet with no build step, but a
+ *   strict CSP (Tauri's default `script-src 'self'`) rejects it. `loadWorklets`
+ *   takes an override URL; `tools/emit-worklet.mjs` writes the identical `.js`
+ *   so a host can serve it from its own origin.
+ * - The banks are LONG-LIVED single nodes. Creating an `AudioWorkletNode` per
+ *   sound costs a cross-thread construction and is the main reason people
+ *   conclude "worklets are slow".
+ */
+
+import { WORKLET_SOURCE } from "../worklets/source.ts"
+import { MATERIALS, expandMaterial, type Material, type ModeArrays } from "./materials.ts"
+import type { ModalVoiceBank, StringBank } from "../types.ts"
+
+export interface ModalBank extends ModalVoiceBank {
+  readonly node: AudioNode
+  dispose(): void
+}
+
+let blobUrl: string | null = null
+
+/** The worklet source as a Blob URL, created once per page. */
+export const workletBlobUrl = (): string => {
+  if (!blobUrl) {
+    blobUrl = URL.createObjectURL(new Blob([WORKLET_SOURCE], { type: "text/javascript" }))
+  }
+  return blobUrl
+}
+
+export interface WorkletLoad {
+  ok: boolean
+  error?: string
+  /** ms spent in addModule — measured, reported, budgeted. */
+  ms: number
+}
+
+/**
+ * Load the processors. Safe to call repeatedly (addModule is idempotent for the
+ * same source). `url` overrides the blob for CSP-strict hosts.
+ */
+export const loadWorklets = async (ctx: BaseAudioContext, url?: string): Promise<WorkletLoad> => {
+  const t0 = now()
+  const anyCtx = ctx as BaseAudioContext & { audioWorklet?: AudioWorklet }
+  if (!anyCtx.audioWorklet) return { ok: false, error: "AudioWorklet unavailable", ms: 0 }
+  try {
+    await anyCtx.audioWorklet.addModule(url ?? workletBlobUrl())
+    return { ok: true, ms: now() - t0 }
+  } catch (e) {
+    return { ok: false, error: String(e), ms: now() - t0 }
+  }
+}
+
+const now = (): number =>
+  typeof performance !== "undefined" ? performance.now() : Date.now()
+
+/** Polyphonic Karplus-Strong bank. One node, 24 voices, sample-accurate. */
+export const createStringBank = (ctx: BaseAudioContext): StringBank | null => {
+  let node: AudioWorkletNode
+  try {
+    node = new AudioWorkletNode(ctx, "dw-string", {
+      numberOfInputs: 0,
+      numberOfOutputs: 1,
+      outputChannelCount: [2],
+    })
+  } catch {
+    return null
+  }
+  // A trigger message is a plain object; V8 keeps the shape monomorphic if we
+  // always send exactly these keys in this order.
+  return {
+    node,
+    pluck(o) {
+      node.port.postMessage({
+        type: "pluck",
+        when: o.when,
+        freq: o.freq,
+        velocity: o.velocity,
+        decay: o.decay,
+        damping: o.damping,
+        position: o.position ?? 0.22,
+        pan: o.pan ?? 0,
+        gain: o.gain ?? 1,
+        id: 0,
+      })
+    },
+    dispose() {
+      node.port.postMessage({ type: "panic" })
+      node.disconnect()
+    },
+  }
+}
+
+/** Polyphonic modal bank. One node, 16 voices x up to 10 modes. */
+export const createModalBank = (ctx: BaseAudioContext): ModalBank | null => {
+  let node: AudioWorkletNode
+  try {
+    node = new AudioWorkletNode(ctx, "dw-modal", {
+      numberOfInputs: 0,
+      numberOfOutputs: 1,
+      outputChannelCount: [2],
+    })
+  } catch {
+    return null
+  }
+  // Scratch reused across strikes: postMessage structured-clones synchronously,
+  // so the arrays are safe to overwrite the instant it returns.
+  const scratch: ModeArrays = {
+    freqs: new Float32Array(10),
+    amps: new Float32Array(10),
+    t60s: new Float32Array(10),
+  }
+  return {
+    node,
+    strike(o) {
+      const m = o.material
+      const sustain = o.sustain ?? 1
+      const { freqs, amps, t60s } = expandMaterial(m, o.freq, {
+        damp: o.damp ?? 0,
+        bright: 0.25 + o.velocity * 0.75,
+        rand: o.rand,
+        modes: o.modes,
+        into: scratch,
+      })
+      if (sustain !== 1) for (let i = 0; i < t60s.length; i++) t60s[i] *= sustain
+      node.port.postMessage({
+        type: "strike",
+        when: o.when,
+        freqs,
+        amps,
+        t60s,
+        strikeMs: m.strikeMs,
+        hardness: m.hardness * (0.55 + o.velocity * 0.45),
+        pan: o.pan ?? 0,
+        gain: (o.gain ?? 1) * (0.25 + o.velocity * 0.75),
+      })
+    },
+    dispose() {
+      node.port.postMessage({ type: "panic" })
+      node.disconnect()
+    },
+  }
+}
+
+/**
+ * Native fallback modal voice — a parallel bank of BiquadFilter bandpasses.
+ *
+ * Used when the worklet cannot load. It is genuinely worse and the code says so
+ * honestly: Q is single-precision, the required Q for a long ring is enormous
+ * (Q = T60·f/2.1988 — a 2 s ring at 440 Hz needs Q = 400) and the achieved
+ * decay drifts from the requested one. Good enough that nothing is silent;
+ * never the default.
+ */
+export const strikeNative = (
+  ctx: BaseAudioContext,
+  out: AudioNode,
+  o: {
+    when: number
+    material: Material
+    freq: number
+    velocity: number
+    modes?: number
+    pan?: number
+    gain?: number
+    rand?: () => number
+    noise: AudioBuffer
+  },
+): number => {
+  const m = o.material
+  const { freqs, amps, t60s } = expandMaterial(m, o.freq, {
+    bright: 0.25 + o.velocity * 0.75,
+    rand: o.rand,
+    modes: Math.min(o.modes ?? m.ratios.length, 6),
+  })
+  const src = ctx.createBufferSource()
+  src.buffer = o.noise
+  const rnd = o.rand ?? Math.random
+  src.loop = true
+  const exciteGain = ctx.createGain()
+  const strikeSec = m.strikeMs * 0.001
+  exciteGain.gain.setValueAtTime(0, o.when)
+  exciteGain.gain.linearRampToValueAtTime(1, o.when + 0.0004)
+  exciteGain.gain.exponentialRampToValueAtTime(0.0001, o.when + strikeSec)
+  src.connect(exciteGain)
+
+  const sum = ctx.createGain()
+  sum.gain.value = (o.gain ?? 1) * (0.25 + o.velocity * 0.75) * 0.5
+  let endsAt = o.when
+  for (let i = 0; i < freqs.length; i++) {
+    const bp = ctx.createBiquadFilter()
+    bp.type = "bandpass"
+    bp.frequency.value = freqs[i]
+    // Q = T60 · f / 2.1988 (bandpass -3dB bandwidth = f/Q, envelope e^(-π·BW·t)).
+    // Capped: above ~600 the filter is numerically noisy in single precision.
+    bp.Q.value = Math.min(600, (t60s[i] * freqs[i]) / 2.1988)
+    const g = ctx.createGain()
+    g.gain.value = amps[i]
+    exciteGain.connect(bp)
+    bp.connect(g)
+    g.connect(sum)
+    endsAt = Math.max(endsAt, o.when + t60s[i])
+  }
+  const panner = ctx.createStereoPanner ? ctx.createStereoPanner() : null
+  if (panner) {
+    panner.pan.value = o.pan ?? 0
+    sum.connect(panner)
+    panner.connect(out)
+  } else {
+    sum.connect(out)
+  }
+  src.start(o.when, rnd() * 0.4)
+  src.stop(endsAt + 0.02)
+  return endsAt
+}
+
+export { MATERIALS }

--- a/dynawalla/foundations/audio/src/dsp/env.ts
+++ b/dynawalla/foundations/audio/src/dsp/env.ts
@@ -1,0 +1,141 @@
+/**
+ * Envelope and parameter-automation helpers.
+ *
+ * WebAudio's automation API has three sharp edges that bite every newcomer and
+ * cause 90% of "my synth clicks":
+ *
+ *  1. `exponentialRampToValueAtTime` cannot start at 0 and cannot end at 0.
+ *     Ramping a gain from 0 exponentially silently does nothing useful.
+ *  2. `setTargetAtTime` NEVER reaches its target. If you stop the source at
+ *     "when the decay ends" you cut a still-audible tail = click.
+ *  3. Automation events queue; a second trigger on the same param without
+ *     cancelling produces a fight, not a retrigger.
+ *
+ * These helpers close all three. Every preset uses them; no preset calls
+ * `gain.gain.*` directly.
+ */
+
+/** -60dB in natural log units. `setTargetAtTime` reaches -60dB at 6.9078·tau. */
+export const T60_TAUS = 6.907755278982137
+
+/** Decay time (to -60dB) -> setTargetAtTime time constant. */
+export const tauFor = (t60: number): number => t60 / T60_TAUS
+
+/** Smallest gain we treat as silence. Below this nothing is audible at any sane level. */
+export const SILENCE = 1e-4
+
+/**
+ * Percussive attack/decay on a gain param.
+ *
+ * Attack is LINEAR (a 1-3ms linear rise is inaudible as a ramp but removes the
+ * discontinuity that makes a click). Decay is `setTargetAtTime` — the natural
+ * shape of everything that is struck, plucked or dropped — and is then forced
+ * to exactly zero at the -60dB point so the voice can be reclaimed with no tail
+ * chop.
+ *
+ * Returns the context time the envelope is truly silent.
+ */
+export const percEnv = (
+  p: AudioParam,
+  when: number,
+  peak: number,
+  attack: number,
+  decay: number,
+): number => {
+  const a = Math.max(0.0005, attack)
+  p.cancelScheduledValues(when)
+  p.setValueAtTime(0, when)
+  p.linearRampToValueAtTime(peak, when + a)
+  p.setTargetAtTime(0, when + a, tauFor(decay))
+  const end = when + a + decay
+  // Guarantee true zero. Without this the param asymptotes forever and a
+  // long-lived node (a filter's gain, a bus) keeps a DC-ish crumb alive.
+  p.setValueAtTime(0, end)
+  return end
+}
+
+/**
+ * Sustained attack/hold/release. Returns a `release(at)` and the natural end if
+ * never released.
+ */
+export const adsrEnv = (
+  p: AudioParam,
+  when: number,
+  peak: number,
+  attack: number,
+  decay: number,
+  sustain: number,
+  release: number,
+): { release(at: number): number; naturalEnd: number } => {
+  const a = Math.max(0.001, attack)
+  p.cancelScheduledValues(when)
+  p.setValueAtTime(0, when)
+  p.linearRampToValueAtTime(peak, when + a)
+  p.setTargetAtTime(peak * sustain, when + a, tauFor(Math.max(0.01, decay)))
+  return {
+    release(at: number) {
+      const t = Math.max(at, when + a)
+      holdCurrent(p, t)
+      p.setTargetAtTime(0, t, tauFor(release))
+      const end = t + release
+      p.setValueAtTime(0, end)
+      return end
+    },
+    naturalEnd: Infinity,
+  }
+}
+
+/**
+ * Cancel pending automation but keep the value the param has RIGHT NOW.
+ *
+ * `cancelAndHoldAtTime` is the correct call and exists in Chrome and Safari;
+ * Firefox shipped it late and some WebViews still lack it. The fallback reads
+ * `.value` (which reflects the computed automation value) and pins it. Without
+ * this, a duck that fires mid-release jumps to the pre-ramp value = a thump.
+ */
+export const holdCurrent = (p: AudioParam, at: number): void => {
+  const anyP = p as AudioParam & { cancelAndHoldAtTime?: (t: number) => void }
+  if (typeof anyP.cancelAndHoldAtTime === "function") {
+    anyP.cancelAndHoldAtTime(at)
+  } else {
+    const v = p.value
+    p.cancelScheduledValues(at)
+    p.setValueAtTime(v, at)
+  }
+}
+
+/**
+ * Exponential glide that tolerates zero endpoints — the workhorse for pitch
+ * sweeps, filter sweeps and "chunk" pitch drops.
+ */
+export const glide = (
+  p: AudioParam,
+  when: number,
+  from: number,
+  to: number,
+  time: number,
+): void => {
+  const f = Math.max(1e-5, from)
+  const t = Math.max(1e-5, to)
+  p.cancelScheduledValues(when)
+  p.setValueAtTime(f, when)
+  p.exponentialRampToValueAtTime(t, when + Math.max(0.001, time))
+}
+
+/**
+ * A smooth "chunk" pitch drop: fast exponential fall then a short settle. This
+ * two-stage shape is the difference between a satisfying woody thock and a
+ * cartoon slide-whistle.
+ */
+export const thock = (
+  p: AudioParam,
+  when: number,
+  start: number,
+  end: number,
+  fall: number,
+): void => {
+  p.cancelScheduledValues(when)
+  p.setValueAtTime(Math.max(1e-5, start), when)
+  p.exponentialRampToValueAtTime(Math.max(1e-5, end * 1.06), when + fall * 0.7)
+  p.exponentialRampToValueAtTime(Math.max(1e-5, end), when + fall)
+}

--- a/dynawalla/foundations/audio/src/dsp/materials.ts
+++ b/dynawalla/foundations/audio/src/dsp/materials.ts
@@ -1,0 +1,187 @@
+/**
+ * Modal materials — the sound of the bazaar, as physics.
+ *
+ * A struck object rings at a set of frequencies that are NOT harmonics. The
+ * ratios below are what separate brass from tile from stone; getting them right
+ * is the entire difference between "a real object was hit" and "a synthesiser
+ * made a bleep". They are chosen from the standard analyses of each family:
+ *
+ *  - a circular membrane rings at the Bessel zeros (1, 1.593, 2.135, 2.295,
+ *    2.917...) — that is a darbuka, and it is why a drum has a pitch you can
+ *    almost but not quite name;
+ *  - a free circular plate / gong is stretched-inharmonic and beats;
+ *  - a bar free at both ends (a marimba bar, a tile shard) rings at 1, 2.756,
+ *    5.404, 8.933 — the ratios of the transverse bar modes;
+ *  - glass is a bar-like set with very long decay and almost no damping;
+ *  - stone/wood is bar-like but so heavily damped the partials are gone before
+ *    the ear resolves them, leaving only a thud with a colour.
+ *
+ * `t60` is the decay of the FUNDAMENTAL at the reference frequency; `decayExp`
+ * makes higher modes die faster (all real objects damp high frequencies first —
+ * omitting this is the single most common reason synthetic percussion sounds
+ * like plastic).
+ */
+
+export interface Material {
+  readonly id: string
+  /** Frequency ratios of the modes. Index 0 should be 1. */
+  readonly ratios: readonly number[]
+  /** Relative amplitude of each mode. */
+  readonly amps: readonly number[]
+  /** Decay (s) of mode 0 at the nominal frequency. */
+  readonly t60: number
+  /** Higher modes decay as t60 * ratio^-decayExp. 0 = no HF damping. */
+  readonly decayExp: number
+  /** Excitation length, ms. Longer = softer mallet. */
+  readonly strikeMs: number
+  /** 0..1 excitation brightness. 1 = steel hammer, 0 = felt. */
+  readonly hardness: number
+  /** Cents of random detune applied per mode per strike (liveliness). */
+  readonly detuneCents: number
+  /** Extra pair-detuning that produces audible beating (gongs, big brass). */
+  readonly beat?: number
+}
+
+export const MATERIALS = {
+  /** Big struck brass — a tray, a lamp, a gong. Long, shimmering, beats. */
+  brass: {
+    id: "brass",
+    ratios: [1, 2.01, 3.02, 4.17, 5.44, 6.81, 8.2, 9.75],
+    amps: [1, 0.72, 0.58, 0.42, 0.34, 0.26, 0.19, 0.12],
+    t60: 2.6,
+    decayExp: 0.75,
+    strikeMs: 1.4,
+    hardness: 0.72,
+    detuneCents: 12,
+    beat: 3.2,
+  },
+  /** Small brass — a bead, a coin, a bell charm. Bright, short, sweet. */
+  bell: {
+    id: "bell",
+    ratios: [1, 2.76, 5.4, 8.93, 11.34],
+    amps: [1, 0.66, 0.42, 0.24, 0.14],
+    t60: 1.1,
+    decayExp: 1.1,
+    strikeMs: 0.8,
+    hardness: 0.86,
+    detuneCents: 9,
+    beat: 1.4,
+  },
+  /** Glazed tile — the confirm "chunk". Hard, ceramic, one clear pitch. */
+  tile: {
+    id: "tile",
+    ratios: [1, 2.74, 5.36, 8.9],
+    amps: [1, 0.5, 0.26, 0.12],
+    t60: 0.34,
+    decayExp: 1.5,
+    strikeMs: 0.6,
+    hardness: 0.9,
+    detuneCents: 18,
+  },
+  /** Glass — long, pure, fragile. The sound of something precious. */
+  glass: {
+    id: "glass",
+    ratios: [1, 2.71, 5.15, 8.94, 13.1],
+    amps: [1, 0.55, 0.36, 0.2, 0.1],
+    t60: 1.9,
+    decayExp: 0.9,
+    strikeMs: 0.5,
+    hardness: 0.95,
+    detuneCents: 6,
+  },
+  /** Stone / packed earth — the floor of the bazaar. Thud with a colour. */
+  stone: {
+    id: "stone",
+    ratios: [1, 2.4, 4.1, 6.3],
+    amps: [1, 0.42, 0.2, 0.09],
+    t60: 0.11,
+    decayExp: 1.9,
+    strikeMs: 2.4,
+    hardness: 0.32,
+    detuneCents: 30,
+  },
+  /** Hardwood — a crate, a market stall, a counter. Warm, dry, woody. */
+  wood: {
+    id: "wood",
+    ratios: [1, 3.02, 6.13, 9.94],
+    amps: [1, 0.46, 0.22, 0.1],
+    t60: 0.2,
+    decayExp: 1.7,
+    strikeMs: 1.4,
+    hardness: 0.55,
+    detuneCents: 24,
+  },
+  /** Stretched skin — a darbuka. The Bessel modes of a circular membrane. */
+  skin: {
+    id: "skin",
+    ratios: [1, 1.593, 2.135, 2.295, 2.917, 3.5],
+    amps: [1, 0.5, 0.34, 0.3, 0.18, 0.1],
+    t60: 0.3,
+    decayExp: 1.4,
+    strikeMs: 1.8,
+    hardness: 0.45,
+    detuneCents: 20,
+  },
+  /** A tuned copper pot — comic, hollow, faintly ridiculous. Good for a miss. */
+  pot: {
+    id: "pot",
+    ratios: [1, 1.5, 2.32, 3.11, 4.6, 5.92],
+    amps: [1, 0.62, 0.44, 0.3, 0.18, 0.1],
+    t60: 0.9,
+    decayExp: 1.2,
+    strikeMs: 1.1,
+    hardness: 0.66,
+    detuneCents: 16,
+    beat: 2.6,
+  },
+} as const satisfies Record<string, Material>
+
+export type MaterialId = keyof typeof MATERIALS
+
+/**
+ * Expand a material into the per-mode arrays the modal worklet wants.
+ * `damp` 0..1 shortens everything (a hand on the bell). `bright` 0..1 tilts the
+ * amplitude of the upper modes — this is what a soft vs hard strike does, and
+ * it is the cheapest, most convincing intensity mapping there is.
+ */
+export interface ModeArrays {
+  freqs: Float32Array
+  amps: Float32Array
+  t60s: Float32Array
+}
+
+export const expandMaterial = (
+  m: Material,
+  f0: number,
+  opts: {
+    damp?: number
+    bright?: number
+    rand?: () => number
+    modes?: number
+    /** Reuse these arrays instead of allocating. They are sliced to length. */
+    into?: ModeArrays
+  } = {},
+): ModeArrays => {
+  const rand = opts.rand ?? Math.random
+  const damp = opts.damp ?? 0
+  const bright = opts.bright ?? 0.5
+  const n = Math.min(opts.modes ?? m.ratios.length, m.ratios.length)
+  const freqs = opts.into ? opts.into.freqs.subarray(0, n) : new Float32Array(n)
+  const amps = opts.into ? opts.into.amps.subarray(0, n) : new Float32Array(n)
+  const t60s = opts.into ? opts.into.t60s.subarray(0, n) : new Float32Array(n)
+  const beat = m.beat ?? 0
+  for (let i = 0; i < n; i++) {
+    const detune = (rand() * 2 - 1) * m.detuneCents + (i > 0 ? Math.sin(i * 2.4) * beat : 0)
+    freqs[i] = f0 * m.ratios[i] * Math.pow(2, detune / 1200)
+    // Tilt: bright=1 keeps upper modes, bright=0 rolls them off hard.
+    const tilt = Math.pow(m.ratios[i], -(1.6 - bright * 1.5))
+    amps[i] = m.amps[i] * tilt
+    t60s[i] = m.t60 * Math.pow(m.ratios[i], -m.decayExp) * (1 - damp * 0.85)
+  }
+  // Renormalise so `bright` changes timbre, not loudness. A tone control that
+  // also changes level is indistinguishable from a bug at playtest.
+  let peak = 0
+  for (let i = 0; i < n; i++) peak = Math.max(peak, amps[i])
+  if (peak > 0) for (let i = 0; i < n; i++) amps[i] /= peak
+  return { freqs, amps, t60s }
+}

--- a/dynawalla/foundations/audio/src/dsp/tables.ts
+++ b/dynawalla/foundations/audio/src/dsp/tables.ts
@@ -1,0 +1,322 @@
+/**
+ * Shared DSP tables — built ONCE per AudioContext, lazily, never per voice.
+ *
+ * The single biggest source of "why does the first coin stutter" is allocating
+ * a noise buffer or a waveshaper curve inside a trigger. Everything expensive
+ * lives here behind a memo. `warm()` builds the whole set during a loading
+ * screen so nothing allocates on the hot path.
+ */
+
+import { mulberry32 } from "../rng.ts"
+import type { SharedTables } from "../types.ts"
+
+const NOISE_SECONDS = 2.0
+
+/** White noise, mono, deterministic. Read at random offsets for variation. */
+const buildWhite = (ctx: BaseAudioContext): AudioBuffer => {
+  const n = Math.floor(ctx.sampleRate * NOISE_SECONDS)
+  const buf = ctx.createBuffer(1, n, ctx.sampleRate)
+  const d = buf.getChannelData(0)
+  const rnd = mulberry32(0xc0ffee)
+  for (let i = 0; i < n; i++) d[i] = rnd() * 2 - 1
+  return buf
+}
+
+/**
+ * Pink noise via the Voss-McCartney / Paul Kellet economy filter. Pink is the
+ * bed for anything that should sound like air, cloth or crowd — white noise
+ * reads as "hiss from a device", pink reads as "a place".
+ */
+const buildPink = (ctx: BaseAudioContext): AudioBuffer => {
+  const n = Math.floor(ctx.sampleRate * NOISE_SECONDS)
+  const buf = ctx.createBuffer(1, n, ctx.sampleRate)
+  const d = buf.getChannelData(0)
+  const rnd = mulberry32(0x9e3779b9)
+  let b0 = 0,
+    b1 = 0,
+    b2 = 0,
+    b3 = 0,
+    b4 = 0,
+    b5 = 0,
+    b6 = 0
+  for (let i = 0; i < n; i++) {
+    const w = rnd() * 2 - 1
+    b0 = 0.99886 * b0 + w * 0.0555179
+    b1 = 0.99332 * b1 + w * 0.0750759
+    b2 = 0.969 * b2 + w * 0.153852
+    b3 = 0.8665 * b3 + w * 0.3104856
+    b4 = 0.55 * b4 + w * 0.5329522
+    b5 = -0.7616 * b5 - w * 0.016898
+    d[i] = (b0 + b1 + b2 + b3 + b4 + b5 + b6 + w * 0.5362) * 0.11
+    b6 = w * 0.115926
+  }
+  return buf
+}
+
+/** Brown/red noise — the low rumble under a city bed. Leaky integrator. */
+const buildBrown = (ctx: BaseAudioContext): AudioBuffer => {
+  const n = Math.floor(ctx.sampleRate * NOISE_SECONDS)
+  const buf = ctx.createBuffer(1, n, ctx.sampleRate)
+  const d = buf.getChannelData(0)
+  const rnd = mulberry32(0x5bd1e995)
+  let last = 0
+  for (let i = 0; i < n; i++) {
+    const w = rnd() * 2 - 1
+    last = (last + 0.02 * w) / 1.02
+    d[i] = last * 3.5
+  }
+  return buf
+}
+
+/**
+ * Velvet noise: sparse ±1 impulses, silence between. Perceptually as dense as
+ * white but with far fewer non-zero samples, and — the reason it is here — it
+ * has no low-frequency energy, so a transient built from it stays crisp instead
+ * of thumping. This is what makes a "tick" read as ceramic rather than muddy.
+ */
+const buildVelvet = (ctx: BaseAudioContext): AudioBuffer => {
+  const n = Math.floor(ctx.sampleRate * 0.5)
+  const buf = ctx.createBuffer(1, n, ctx.sampleRate)
+  const d = buf.getChannelData(0)
+  const rnd = mulberry32(0x1b873593)
+  const density = 2200 // impulses per second
+  const period = Math.max(2, Math.floor(ctx.sampleRate / density))
+  for (let k = 0; k * period < n; k++) {
+    const idx = k * period + Math.floor(rnd() * period)
+    if (idx < n) d[idx] = rnd() < 0.5 ? -1 : 1
+  }
+  return buf
+}
+
+/**
+ * Odd-symmetric soft saturation. `amount` 0..1. Built on tanh so there is no
+ * hard corner (a hard corner aliases viciously at 48k with no oversampling —
+ * WaveShaper's `oversample: "4x"` fixes it but costs, so keep the curve soft
+ * AND set 2x on the nodes that matter).
+ */
+const buildSaturation = (amount: number): Float32Array<ArrayBuffer> => {
+  const N = 2048
+  const curve = new Float32Array(N)
+  const k = 1 + amount * 14
+  const norm = Math.tanh(k)
+  for (let i = 0; i < N; i++) {
+    const x = (i / (N - 1)) * 2 - 1
+    curve[i] = Math.tanh(k * x) / norm
+  }
+  return curve
+}
+
+/**
+ * Master safety clipper. Transparent below -3 dBFS, then a smooth knee.
+ *
+ * This exists because DynamicsCompressorNode is NOT a limiter: it has a soft
+ * knee and a finite attack, and it demonstrably lets transients past threshold
+ * (measured: +2.7 dBFS with the compressor alone on a 12-impact stack).
+ *
+ * CEILING = 0.97, NOT 1.0. Measured trap: `WaveShaperNode` with
+ * `oversample: "2x"` can output ABOVE the maximum value in its own curve,
+ * because the 2x interpolation filter rings. With a 0.999 ceiling the master
+ * measured +0.05 dBFS — over full scale, on a node whose entire job is to be
+ * under it. 0.97 (-0.26 dBFS) absorbs the overshoot and gives the cheap DAC in
+ * a tablet the inter-sample headroom it needs anyway.
+ */
+const SAFETY_CEILING = 0.97
+
+const buildSafetyClip = (): Float32Array<ArrayBuffer> => {
+  const N = 4096
+  const curve = new Float32Array(N)
+  const t = 0.7 // linear below this
+  for (let i = 0; i < N; i++) {
+    const x = (i / (N - 1)) * 2 - 1
+    const a = Math.abs(x)
+    let y: number
+    if (a <= t) y = a
+    else {
+      const over = (a - t) / (1 - t)
+      // 1 - (1-x)^2 knee: smooth first derivative at the join, asymptotic at 1.
+      y = t + (SAFETY_CEILING - t) * (1 - Math.pow(1 - Math.min(over, 1), 2))
+    }
+    curve[i] = Math.sign(x) * y
+  }
+  return curve
+}
+
+/**
+ * Procedural reverb impulse.
+ *
+ * Not a convolution of a real room — we ship no assets. This is noise shaped by
+ * a decay envelope whose high frequencies die faster than its lows (a one-pole
+ * whose coefficient walks closed over the tail), plus sparse early reflections.
+ * "tile" is a hard, bright, small courtyard; "courtyard" is bigger and darker;
+ * "plate" is dense and metallic with almost no early structure.
+ */
+const buildImpulse = (
+  ctx: BaseAudioContext,
+  kind: "tile" | "courtyard" | "plate",
+  seconds: number,
+): AudioBuffer => {
+  const sr = ctx.sampleRate
+  const n = Math.max(1, Math.floor(sr * seconds))
+  const buf = ctx.createBuffer(2, n, sr)
+  const rnd = mulberry32(kind === "tile" ? 0x7a1e : kind === "courtyard" ? 0x2b0d : 0x51f3)
+
+  // Character per kind.
+  const cfg = {
+    tile: { hfDamp: 0.55, preDelay: 0.006, erCount: 14, erGain: 0.55, curve: 2.4 },
+    courtyard: { hfDamp: 0.82, preDelay: 0.018, erCount: 22, erGain: 0.42, curve: 1.9 },
+    plate: { hfDamp: 0.35, preDelay: 0.001, erCount: 3, erGain: 0.2, curve: 2.9 },
+  }[kind]
+
+  for (let ch = 0; ch < 2; ch++) {
+    const d = buf.getChannelData(ch)
+    let lp = 0
+    const pre = Math.floor(cfg.preDelay * sr * (ch === 0 ? 1 : 1.13))
+    for (let i = pre; i < n; i++) {
+      const t = (i - pre) / (n - pre)
+      // Tail envelope: exponential-ish, steeper for plate.
+      const env = Math.pow(1 - t, cfg.curve)
+      // HF damping walks closed as the tail decays -> late tail is dark.
+      const a = cfg.hfDamp * (1 - t * 0.85)
+      const w = rnd() * 2 - 1
+      lp = lp + a * (w - lp)
+      d[i] = lp * env
+    }
+    // Early reflections: sparse, decorrelated taps. This is what makes a space
+    // read as a courtyard of tile rather than a generic wash.
+    for (let k = 0; k < cfg.erCount; k++) {
+      const tt = 0.004 + Math.pow(rnd(), 1.6) * 0.09
+      const idx = pre + Math.floor(tt * sr)
+      if (idx < n) d[idx] += (rnd() < 0.5 ? -1 : 1) * cfg.erGain * Math.pow(1 - tt / 0.1, 1.5)
+    }
+  }
+  return buf
+}
+
+/**
+ * Pre-baked grain buffers: band-passed, Hann-windowed noise at 8 centre
+ * frequencies x 4 amplitudes.
+ *
+ * MEASURED REASON THIS EXISTS. The obvious granular implementation is
+ * BufferSource -> BiquadFilter -> Gain -> StereoPanner per grain: four nodes
+ * each. At 140 grains/s that measured **49.3% of one core** on an M-series Mac
+ * — for a shimmer effect. The cost is node-graph bookkeeping, not DSP.
+ *
+ * Baking the band-pass and the window into the buffer, and baking amplitude
+ * into a small set of pre-scaled variants, gets a grain down to ONE node
+ * (a BufferSource fired into a shared panner). Same sound, a quarter of the
+ * graph.
+ */
+const GRAIN_BANDS = [1400, 2000, 2800, 3900, 5400, 7200, 9600, 12800]
+const GRAIN_AMPS = [0.25, 0.45, 0.7, 1.0]
+
+const buildGrains = (ctx: BaseAudioContext): AudioBuffer[][] => {
+  const sr = ctx.sampleRate
+  const n = Math.floor(sr * 0.06)
+  const rnd = mulberry32(0x6ea1)
+  const out: AudioBuffer[][] = []
+  for (let b = 0; b < GRAIN_BANDS.length; b++) {
+    // 2-pole resonator excited by noise = a band-passed grain, computed in f64
+    // here on the main thread once, never at play time.
+    const f = GRAIN_BANDS[b]
+    const t60 = 0.02
+    const r = Math.pow(10, -3 / (t60 * sr))
+    const w = (2 * Math.PI * f) / sr
+    const c1 = 2 * r * Math.cos(w)
+    const c2 = -(r * r)
+    const raw = new Float64Array(n)
+    let y1 = 0
+    let y2 = 0
+    let peak = 1e-9
+    for (let i = 0; i < n; i++) {
+      const x = i < 24 ? rnd() * 2 - 1 : 0
+      const y = c1 * y1 + c2 * y2 + Math.sin(w) * x
+      y2 = y1
+      y1 = y
+      raw[i] = y
+      const a = Math.abs(y)
+      if (a > peak) peak = a
+    }
+    const amps: AudioBuffer[] = []
+    for (const amp of GRAIN_AMPS) {
+      const buf = ctx.createBuffer(1, n, sr)
+      const d = buf.getChannelData(0)
+      for (let i = 0; i < n; i++) {
+        // Hann window baked in: no per-grain envelope automation at all.
+        const win = 0.5 - 0.5 * Math.cos((2 * Math.PI * i) / (n - 1))
+        d[i] = (raw[i] / peak) * win * amp
+      }
+      amps.push(buf)
+    }
+    out.push(amps)
+  }
+  return out
+}
+
+const memo = new WeakMap<BaseAudioContext, SharedTables>()
+
+/** Get (and lazily build) the shared table set for a context. */
+export const tablesFor = (ctx: BaseAudioContext): SharedTables => {
+  const hit = memo.get(ctx)
+  if (hit) return hit
+
+  let white: AudioBuffer | null = null
+  let pink: AudioBuffer | null = null
+  let brown: AudioBuffer | null = null
+  let velvet: AudioBuffer | null = null
+  let safety: Float32Array<ArrayBuffer> | null = null
+  let grains: AudioBuffer[][] | null = null
+  const sat = new Map<number, Float32Array<ArrayBuffer>>()
+  const irs = new Map<string, AudioBuffer>()
+
+  const t: SharedTables = {
+    white: () => (white ??= buildWhite(ctx)),
+    pink: () => (pink ??= buildPink(ctx)),
+    brown: () => (brown ??= buildBrown(ctx)),
+    velvet: () => (velvet ??= buildVelvet(ctx)),
+    saturation(amount) {
+      const key = Math.round(amount * 20)
+      let c = sat.get(key)
+      if (!c) {
+        c = buildSaturation(key / 20)
+        sat.set(key, c)
+      }
+      return c
+    },
+    safetyClip: () => (safety ??= buildSafetyClip()),
+    grain(band, amp) {
+      grains ??= buildGrains(ctx)
+      const b = grains[Math.max(0, Math.min(grains.length - 1, band))]
+      return b[Math.max(0, Math.min(b.length - 1, amp))]
+    },
+    impulse(kind, seconds) {
+      const key = `${kind}:${seconds.toFixed(2)}`
+      let b = irs.get(key)
+      if (!b) {
+        b = buildImpulse(ctx, kind, seconds)
+        irs.set(key, b)
+      }
+      return b
+    },
+  }
+  memo.set(ctx, t)
+  return t
+}
+
+/**
+ * Force-build everything a tier can use. Call during a loading screen: it costs
+ * tens of milliseconds ONCE instead of a frame hitch mid-play.
+ */
+export const warmTables = (ctx: BaseAudioContext, reverbSeconds: number): void => {
+  const t = tablesFor(ctx)
+  t.white()
+  t.pink()
+  t.brown()
+  t.velvet()
+  t.saturation(0.35)
+  t.saturation(0.6)
+  t.safetyClip()
+  t.grain(0, 0)
+  if (reverbSeconds > 0) {
+    t.impulse("tile", reverbSeconds)
+  }
+}

--- a/dynawalla/foundations/audio/src/engine.ts
+++ b/dynawalla/foundations/audio/src/engine.ts
@@ -1,0 +1,611 @@
+/**
+ * The engine: one AudioContext, four buses, a master chain that cannot clip, a
+ * voice budget that cannot be exceeded, and an unlock story that works on iOS.
+ *
+ * Design rules this file enforces so no prototype has to think about them:
+ *
+ *  - **Nothing allocates on the hot path** that can be built once. Tables,
+ *    banks, curves and the impulse response are built during `init()`.
+ *  - **Every sound is bus-routed.** A prototype cannot accidentally connect to
+ *    `destination` and bypass the limiter.
+ *  - **Cues fire even when muted.** Audio never carries information alone; see
+ *    `onCue`. Mute changes what you HEAR, never what the game TELLS you.
+ *  - **The context is suspended when the page is hidden.** A backgrounded tab
+ *    that keeps a 48 kHz graph alive is a battery complaint and, on iOS, an
+ *    audio session that fights with the user's music.
+ */
+
+import { tablesFor, warmTables } from "./dsp/tables.ts"
+import { createModalBank, createStringBank, loadWorklets, type ModalBank } from "./dsp/banks.ts"
+import { holdCurrent } from "./dsp/env.ts"
+import { clamp, hashString, mulberry32, spread } from "./rng.ts"
+import type {
+  BusName,
+  Cue,
+  PlayOptions,
+  Preset,
+  RenderCtx,
+  StringBank,
+  Tier,
+} from "./types.ts"
+
+// ---------------------------------------------------------------------------
+// Tier profiles. The mid-range tablet is the FLOOR (`medium`), never the design
+// target. `ultra` exists so a capable device is genuinely staggering.
+// ---------------------------------------------------------------------------
+
+export interface TierProfile {
+  /** Total simultaneous kit-managed voices. */
+  maxVoices: number
+  /** Reverb tail length in seconds. 0 disables the convolver entirely. */
+  reverbSeconds: number
+  /** Cap on modal partials per strike. */
+  maxModes: number
+  /** Grains per second ceiling for granular textures. */
+  maxGrainRate: number
+  /** Music layers allowed. */
+  musicLayers: number
+  /** Use the polyphonic worklet banks (false = native fallback). */
+  worklets: boolean
+}
+
+export const TIERS: Record<Tier, TierProfile> = {
+  ultra: { maxVoices: 48, reverbSeconds: 2.4, maxModes: 10, maxGrainRate: 140, musicLayers: 6, worklets: true },
+  high: { maxVoices: 32, reverbSeconds: 1.8, maxModes: 8, maxGrainRate: 90, musicLayers: 5, worklets: true },
+  medium: { maxVoices: 20, reverbSeconds: 1.1, maxModes: 6, maxGrainRate: 45, musicLayers: 4, worklets: true },
+  low: { maxVoices: 12, reverbSeconds: 0, maxModes: 4, maxGrainRate: 0, musicLayers: 2, worklets: false },
+}
+
+export interface EngineOptions {
+  /** Force a tier. Omit to auto-detect with a ~30ms offline benchmark. */
+  tier?: Tier
+  /** Master volume 0..1. */
+  volume?: number
+  /** Start muted (restore the child's last choice here). */
+  muted?: boolean
+  /** Override the worklet module URL (CSP-strict hosts). */
+  workletUrl?: string
+  /** Provide a context (tests, or a host that already owns one). */
+  context?: AudioContext
+  /** Set false to skip the auto-unlock listeners and drive `resume()` yourself. */
+  autoUnlock?: boolean
+}
+
+interface ActiveVoice {
+  id: string
+  group: string
+  endsAt: number
+  startedAt: number
+  weight: number
+  release?: (at: number) => void
+}
+
+const NOW = (): number => (typeof performance !== "undefined" ? performance.now() : Date.now())
+
+/**
+ * A ~25ms offline benchmark that ranks the device's audio DSP throughput.
+ *
+ * OfflineAudioContext renders as fast as the machine can, so `rendered seconds
+ * / wall seconds` is a direct measure of DSP headroom — far better than
+ * sniffing `deviceMemory` or the user agent, which lie. The graph below is
+ * deliberately representative: convolution and a resonant filter bank are what
+ * actually cost money in this kit.
+ */
+export const probeTier = async (): Promise<{ tier: Tier; realtimeFactor: number; ms: number }> => {
+  const OAC =
+    (globalThis as { OfflineAudioContext?: typeof OfflineAudioContext }).OfflineAudioContext
+  if (!OAC) return { tier: "medium", realtimeFactor: 0, ms: 0 }
+  const sr = 48000
+  const seconds = 1.0
+  const oc = new OAC(2, sr * seconds, sr)
+  const t = tablesFor(oc)
+  const noise = oc.createBufferSource()
+  noise.buffer = t.pink()
+  noise.loop = true
+  const conv = oc.createConvolver()
+  conv.buffer = t.impulse("tile", 1.2)
+  const g = oc.createGain()
+  g.gain.value = 0.2
+  noise.connect(g)
+  // 12 resonators — the shape of a busy moment in the bazaar.
+  for (let i = 0; i < 12; i++) {
+    const bp = oc.createBiquadFilter()
+    bp.type = "bandpass"
+    bp.frequency.value = 120 * (i + 1)
+    bp.Q.value = 24
+    g.connect(bp)
+    bp.connect(conv)
+  }
+  conv.connect(oc.destination)
+  noise.start(0)
+  const t0 = NOW()
+  await oc.startRendering()
+  const ms = NOW() - t0
+  const realtimeFactor = (seconds * 1000) / Math.max(0.01, ms)
+  // CALIBRATION. Measured reference: Apple M-series laptop, Chrome 149,
+  // 48 kHz -> realtimeFactor 74. That is a fast device, so the thresholds are
+  // anchored to it and scaled down for the tablets we actually target. They
+  // are intentionally conservative: a device that lands one tier low still
+  // sounds excellent, a device one tier too high crackles, and crackle is the
+  // only unrecoverable audio failure.
+  //
+  // Recalibrate by running `measure/index.html` on a real target device and
+  // reading `stats.realtimeFactor` — do not guess from the user agent.
+  const tier: Tier =
+    realtimeFactor > 55 ? "ultra" : realtimeFactor > 28 ? "high" : realtimeFactor > 10 ? "medium" : "low"
+  return { tier, realtimeFactor, ms }
+}
+
+export class AudioEngine {
+  readonly ctx: AudioContext
+  tier: Tier
+  profile: TierProfile
+
+  private master!: GainNode
+  private comp!: DynamicsCompressorNode
+  private safety!: WaveShaperNode
+  private busGain: Record<BusName, GainNode> = {} as Record<BusName, GainNode>
+  private duckGain: Record<BusName, GainNode> = {} as Record<BusName, GainNode>
+  private sendGain: Record<BusName, GainNode> = {} as Record<BusName, GainNode>
+  private reverbReturn: AudioNode | null = null
+
+  /**
+   * The polyphonic banks are PER BUS, created lazily.
+   *
+   * A worklet bank is ONE node shared by many voices, which means its output
+   * cannot pass through a per-voice gain node and cannot be re-routed per
+   * trigger. If every preset shared one bank, a UI tick's modal body would land
+   * on the SFX bus and ignore both the UI fader and the preset's own level.
+   * Per-bus banks fix the routing; the per-voice level is applied by scaling
+   * the bank's own `gain` message field (see `rc.level`).
+   *
+   * MEASURED: an IDLE AudioWorkletNode is not free — about 0.33% of one core
+   * each, just for existing (12 idle banks measured 3.98%). Hence lazy: a
+   * prototype that never starts music never pays for a music bank.
+   */
+  private modalBanks = new Map<BusName, ModalBank | null>()
+  private stringBanks = new Map<BusName, StringBank | null>()
+  private worklandReady = false
+
+  private voices: ActiveVoice[] = []
+  private lastFired = new Map<string, number>()
+  private lastVariant = new Map<string, number>()
+  private seq = 0
+  private sweeper: ReturnType<typeof setInterval> | null = null
+  private cueHandlers: ((c: Cue) => void)[] = []
+  private duckUntil = 0
+  private duckDepth = 0
+  private unlocked = false
+  private unlockHandlers: (() => void) | null = null
+
+  muted: boolean
+  volume: number
+  ready = false
+  workletStatus: { ok: boolean; error?: string; ms: number } = { ok: false, ms: 0 }
+  /** Populated at init — real, measured numbers a prototype can print. */
+  stats = { sampleRate: 0, baseLatency: 0, outputLatency: 0, probeMs: 0, realtimeFactor: 0, initMs: 0 }
+
+  private opts: EngineOptions
+
+  constructor(opts: EngineOptions = {}) {
+    this.opts = opts
+    const Ctor =
+      (globalThis as { AudioContext?: typeof AudioContext; webkitAudioContext?: typeof AudioContext })
+        .AudioContext ??
+      (globalThis as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+    if (!Ctor) throw new Error("Web Audio is unavailable in this environment")
+    // NOTE: we deliberately do NOT pass `sampleRate`. Forcing 44100 on a device
+    // whose hardware runs at 48000 inserts a resampler in front of the output
+    // and costs both latency and CPU. Let the device choose; adapt to it.
+    this.ctx = opts.context ?? new Ctor({ latencyHint: "interactive" })
+    this.tier = opts.tier ?? "medium"
+    this.profile = TIERS[this.tier]
+    this.muted = opts.muted ?? false
+    this.volume = opts.volume ?? 0.9
+  }
+
+  /** Build the graph, probe the device, load the worklets, warm the tables. */
+  async init(): Promise<void> {
+    if (this.ready) return
+    const t0 = NOW()
+    if (!this.opts.tier) {
+      const p = await probeTier()
+      this.tier = p.tier
+      this.stats.probeMs = p.ms
+      this.stats.realtimeFactor = p.realtimeFactor
+    }
+    this.profile = TIERS[this.tier]
+    this.buildGraph()
+
+    if (this.profile.worklets) {
+      this.workletStatus = await loadWorklets(this.ctx, this.opts.workletUrl)
+      this.worklandReady = this.workletStatus.ok
+      if (this.worklandReady) {
+        // Pre-create the two buses every prototype uses on its first frame.
+        this.modalFor("sfx")
+        this.modalFor("ui")
+        this.stringsFor("sfx")
+      }
+    }
+    warmTables(this.ctx, this.profile.reverbSeconds)
+
+    this.sweeper = setInterval(() => this.sweep(), 250)
+    if (this.opts.autoUnlock !== false) this.armUnlock()
+    this.watchVisibility()
+    this.stats.sampleRate = this.ctx.sampleRate
+    this.stats.baseLatency = this.ctx.baseLatency ?? 0
+    this.stats.outputLatency = this.ctx.outputLatency ?? 0
+    this.stats.initMs = NOW() - t0
+    this.ready = true
+  }
+
+  private buildGraph(): void {
+    const ctx = this.ctx
+    const t = tablesFor(ctx)
+
+    this.safety = ctx.createWaveShaper()
+    this.safety.curve = t.safetyClip()
+    // 2x oversampling: the knee is smooth, but a hard transient still folds a
+    // little energy above Nyquist. 2x is a good trade; 4x measurably costs more
+    // than it buys here.
+    this.safety.oversample = "2x"
+    this.safety.connect(ctx.destination)
+
+    // DynamicsCompressorNode is NOT a brickwall limiter — it has a ~6ms
+    // lookahead and a soft knee, and it lets transients past threshold. It is
+    // here to hold the MIX together (10 simultaneous sounds should sound
+    // dense, not loud), and the waveshaper behind it is the actual ceiling.
+    this.comp = ctx.createDynamicsCompressor()
+    this.comp.threshold.value = -14
+    this.comp.knee.value = 6
+    this.comp.ratio.value = 6
+    this.comp.attack.value = 0.004
+    this.comp.release.value = 0.16
+    this.comp.connect(this.safety)
+
+    this.master = ctx.createGain()
+    this.master.gain.value = this.muted ? 0 : this.volume
+    this.master.connect(this.comp)
+
+    if (this.profile.reverbSeconds > 0) {
+      const conv = ctx.createConvolver()
+      conv.normalize = true
+      conv.buffer = t.impulse("tile", this.profile.reverbSeconds)
+      const ret = ctx.createGain()
+      ret.gain.value = 0.9
+      conv.connect(ret)
+      ret.connect(this.master)
+      this.reverbReturn = conv
+    }
+
+    const buses: BusName[] = ["sfx", "ui", "music", "ambience"]
+    const defaults: Record<BusName, number> = { sfx: 1, ui: 0.85, music: 0.55, ambience: 0.4 }
+    const sendDefaults: Record<BusName, number> = { sfx: 0.16, ui: 0.06, music: 0.1, ambience: 0.22 }
+    for (const b of buses) {
+      const duck = ctx.createGain()
+      duck.gain.value = 1
+      duck.connect(this.master)
+      this.duckGain[b] = duck
+
+      const g = ctx.createGain()
+      g.gain.value = defaults[b]
+      g.connect(duck)
+      this.busGain[b] = g
+
+      const s = ctx.createGain()
+      s.gain.value = sendDefaults[b]
+      if (this.reverbReturn) s.connect(this.reverbReturn)
+      this.sendGain[b] = s
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Unlock. The whole iOS/Chrome autoplay story, in one place.
+  // -------------------------------------------------------------------------
+
+  /**
+   * Arm one-shot listeners that resume the context on the first real gesture.
+   *
+   * Details that matter:
+   *  - `resume()` must be called SYNCHRONOUSLY inside the gesture handler. An
+   *    `await` before it and the gesture is spent — the promise resolves and
+   *    the context stays suspended.
+   *  - iOS additionally wants a source to have STARTED inside a gesture in some
+   *    versions; we start a 1-frame silent buffer, which is free and settles it.
+   *  - `touchend` matters on iOS Safari; `pointerdown` alone is not enough on
+   *    older WebKit.
+   */
+  armUnlock(): void {
+    if (this.unlocked || this.unlockHandlers) return
+    if (typeof document === "undefined") return
+    const events = ["pointerdown", "touchend", "keydown", "mousedown"]
+    const handler = () => {
+      const ctx = this.ctx
+      // Synchronous — never behind an await.
+      void ctx.resume()
+      try {
+        const b = ctx.createBuffer(1, 1, ctx.sampleRate)
+        const s = ctx.createBufferSource()
+        s.buffer = b
+        s.connect(ctx.destination)
+        s.start(0)
+      } catch {
+        /* older WebKit throws on a 1-frame buffer; the resume above is enough */
+      }
+      if (ctx.state === "running" || ctx.state === "suspended") {
+        // Verify asynchronously; only disarm once actually running.
+        void Promise.resolve().then(() => {
+          if (this.ctx.state === "running") this.disarmUnlock()
+        })
+      }
+    }
+    this.unlockHandlers = () => {
+      for (const e of events) document.removeEventListener(e, handler, true)
+    }
+    for (const e of events) document.addEventListener(e, handler, true)
+  }
+
+  private disarmUnlock(): void {
+    this.unlocked = true
+    this.unlockHandlers?.()
+    this.unlockHandlers = null
+  }
+
+  /** Call from a gesture if you are driving unlock yourself. */
+  async resume(): Promise<void> {
+    if (this.ctx.state !== "running") {
+      try {
+        await this.ctx.resume()
+      } catch {
+        /* the next gesture will do it */
+      }
+    }
+    if (this.ctx.state === "running") this.disarmUnlock()
+  }
+
+  private watchVisibility(): void {
+    if (typeof document === "undefined") return
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) {
+        void this.ctx.suspend()
+      } else if (this.unlocked) {
+        void this.ctx.resume()
+      }
+    })
+  }
+
+  // -------------------------------------------------------------------------
+  // Mix control
+  // -------------------------------------------------------------------------
+
+  setVolume(v: number, ramp = 0.05): void {
+    this.volume = clamp(v, 0, 1)
+    if (!this.master) return
+    const t = this.ctx.currentTime
+    holdCurrent(this.master.gain, t)
+    this.master.gain.linearRampToValueAtTime(this.muted ? 0 : this.volume, t + ramp)
+  }
+
+  setMuted(m: boolean): void {
+    this.muted = m
+    this.setVolume(this.volume)
+  }
+
+  setBusVolume(bus: BusName, v: number, ramp = 0.08): void {
+    const g = this.busGain[bus]
+    if (!g) return
+    const t = this.ctx.currentTime
+    holdCurrent(g.gain, t)
+    g.gain.linearRampToValueAtTime(clamp(v, 0, 1), t + ramp)
+  }
+
+  /**
+   * Duck music + ambience under a foreground event.
+   *
+   * Overlapping ducks do not stack (that is how you get a mix that pumps into
+   * silence). We hold the DEEPEST active duck and one shared release.
+   */
+  duck(amount: number, holdSec = 0.25, releaseSec = 0.45): void {
+    const now = this.ctx.currentTime
+    const depth = clamp(amount, 0, 0.95)
+    const until = now + holdSec
+    if (now > this.duckUntil) this.duckDepth = 0
+    this.duckDepth = Math.max(this.duckDepth * (this.duckUntil > now ? 1 : 0), depth)
+    this.duckUntil = Math.max(this.duckUntil, until)
+    const target = 1 - this.duckDepth
+    for (const b of ["music", "ambience"] as BusName[]) {
+      const g = this.duckGain[b]
+      if (!g) continue
+      holdCurrent(g.gain, now)
+      g.gain.linearRampToValueAtTime(target, now + 0.03)
+      g.gain.setValueAtTime(target, this.duckUntil)
+      g.gain.setTargetAtTime(1, this.duckUntil, releaseSec / 3)
+      g.gain.setValueAtTime(1, this.duckUntil + releaseSec)
+    }
+  }
+
+  onCue(fn: (c: Cue) => void): () => void {
+    this.cueHandlers.push(fn)
+    return () => {
+      const i = this.cueHandlers.indexOf(fn)
+      if (i >= 0) this.cueHandlers.splice(i, 1)
+    }
+  }
+
+  emitCue(c: Cue): void {
+    for (let i = 0; i < this.cueHandlers.length; i++) this.cueHandlers[i](c)
+  }
+
+  // -------------------------------------------------------------------------
+  // Voice budget
+  // -------------------------------------------------------------------------
+
+  private sweep(): void {
+    const now = this.ctx.currentTime
+    let w = 0
+    for (let i = 0; i < this.voices.length; i++) {
+      const v = this.voices[i]
+      if (v.endsAt > now) this.voices[w++] = v
+    }
+    this.voices.length = w
+  }
+
+  activeVoices(): number {
+    this.sweep()
+    return this.voices.length
+  }
+
+  /**
+   * Decide whether a trigger is allowed and, if the budget is full, steal.
+   *
+   * Policy, in order:
+   *  1. A preset retriggered inside its `minGap` is dropped. Two identical
+   *     transients 8 ms apart do not sound "twice as good", they phase-sum into
+   *     a 6 dB spike and read as a glitch.
+   *  2. Over the preset's own polyphony, steal that preset's oldest voice.
+   *  3. Over the global budget, steal the lowest-weight voice that is at least
+   *     50 ms old — never the one that just started, because a cut-off attack
+   *     is far more audible than a missing tail.
+   *  4. If everything alive outranks the newcomer, drop the newcomer.
+   */
+  claim(preset: Preset, when: number, weight: number): boolean {
+    const now = this.ctx.currentTime
+    const gap = preset.minGap ?? 0.012
+    const last = this.lastFired.get(preset.id) ?? -1
+    if (when - last < gap) return false
+    this.sweep()
+
+    const group = preset.group ?? preset.id
+    const poly = preset.poly ?? 6
+    let count = 0
+    let oldest: ActiveVoice | null = null
+    for (const v of this.voices) {
+      if (v.group !== group) continue
+      count++
+      if (!oldest || v.startedAt < oldest.startedAt) oldest = v
+    }
+    if (count >= poly && oldest) this.kill(oldest, now)
+
+    if (this.voices.length >= this.profile.maxVoices) {
+      let victim: ActiveVoice | null = null
+      for (const v of this.voices) {
+        if (now - v.startedAt < 0.05) continue
+        if (!victim || v.weight < victim.weight) victim = v
+      }
+      if (!victim || victim.weight > weight) return false
+      this.kill(victim, now)
+    }
+    this.lastFired.set(preset.id, when)
+    return true
+  }
+
+  private kill(v: ActiveVoice, at: number): void {
+    v.release?.(at)
+    v.endsAt = Math.min(v.endsAt, at + 0.05)
+    const i = this.voices.indexOf(v)
+    if (i >= 0) this.voices.splice(i, 1)
+  }
+
+  track(preset: Preset, startedAt: number, endsAt: number, weight: number, release?: (at: number) => void): void {
+    this.voices.push({
+      id: preset.id,
+      group: preset.group ?? preset.id,
+      startedAt,
+      endsAt,
+      weight,
+      release,
+    })
+  }
+
+  /** Per-trigger deterministic RNG. Same seed -> same sound, always. */
+  rngFor(preset: Preset, seed?: number): () => number {
+    const s = seed ?? (hashString(preset.id) ^ (this.seq++ * 0x9e3779b9)) >>> 0
+    return mulberry32(s)
+  }
+
+  variantFor(id: string, n: number, r: number): number {
+    const last = this.lastVariant.get(id) ?? -1
+    if (n <= 1) return 0
+    let i = Math.floor(r * (n - 1))
+    if (i >= last) i += 1
+    this.lastVariant.set(id, i)
+    return i
+  }
+
+  /** The modal bank for a bus, created on first use. */
+  modalFor(bus: BusName): ModalBank | null {
+    if (!this.worklandReady) return null
+    let b = this.modalBanks.get(bus)
+    if (b === undefined) {
+      b = createModalBank(this.ctx)
+      b?.node.connect(this.busGain[bus])
+      this.modalBanks.set(bus, b)
+    }
+    return b
+  }
+
+  /** The string bank for a bus, created on first use. */
+  stringsFor(bus: BusName): StringBank | null {
+    if (!this.worklandReady) return null
+    let b = this.stringBanks.get(bus)
+    if (b === undefined) {
+      b = createStringBank(this.ctx)
+      b?.node.connect(this.busGain[bus])
+      this.stringBanks.set(bus, b)
+    }
+    return b
+  }
+
+  /** Build the RenderCtx a preset receives. `out` is the voice's own gain node. */
+  renderCtx(preset: Preset, opts: PlayOptions, when: number, semis: number, out?: AudioNode): RenderCtx {
+    const rand = this.rngFor(preset, opts.seed)
+    const bus = preset.bus
+    return {
+      ctx: this.ctx,
+      out: out ?? this.busGain[bus],
+      level: preset.gain,
+      send: this.reverbReturn ? this.sendGain[bus] : null,
+      when,
+      intensity: clamp(opts.intensity ?? 0.7, 0, 1),
+      semitones: semis,
+      tier: this.tier,
+      rand,
+      range: (lo, hi) => lo + rand() * (hi - lo),
+      tables: tablesFor(this.ctx),
+      strings: this.stringsFor(bus),
+      modal: this.modalFor(bus),
+    }
+  }
+
+  /** Jitter in semitones, shaped so repeats never cluster at the centre. */
+  jitter(preset: Preset, r: number): number {
+    const c = preset.jitterCents ?? 30
+    return (spread(r) * c) / 100
+  }
+
+  /** Stop everything immediately. Used on route changes and on `panic`. */
+  panic(): void {
+    for (const b of this.modalBanks.values()) (b?.node as AudioWorkletNode | undefined)?.port?.postMessage({ type: "panic" })
+    for (const b of this.stringBanks.values()) (b?.node as AudioWorkletNode | undefined)?.port?.postMessage({ type: "panic" })
+    const now = this.ctx.currentTime
+    for (const v of [...this.voices]) this.kill(v, now)
+    this.voices.length = 0
+  }
+
+  dispose(): void {
+    if (this.sweeper) clearInterval(this.sweeper)
+    this.sweeper = null
+    this.unlockHandlers?.()
+    for (const b of this.modalBanks.values()) b?.dispose()
+    for (const b of this.stringBanks.values()) b?.dispose()
+    this.cueHandlers.length = 0
+    if (!this.opts.context) void this.ctx.close()
+  }
+
+  busNode(b: BusName): GainNode {
+    return this.busGain[b]
+  }
+  sendNode(b: BusName): GainNode | null {
+    return this.reverbReturn ? this.sendGain[b] : null
+  }
+}

--- a/dynawalla/foundations/audio/src/index.ts
+++ b/dynawalla/foundations/audio/src/index.ts
@@ -1,0 +1,392 @@
+/**
+ * @dynawalla/audio — the whole kit, in one object.
+ *
+ * The entire API a prototype needs:
+ *
+ *     import { audio } from "@dynawalla/audio"
+ *
+ *     await audio.init()            // once, anywhere; unlock is automatic
+ *     audio.play("ui.chunk")        // a sound
+ *     audio.combo(streak)           // a rising ladder that stays musical
+ *     audio.music.setIntensity(0.7) // the score responds
+ *     audio.ambience("bazaar")      // the place
+ *     audio.onCue(c => flash(c))    // visuals, so sound is never the only channel
+ *
+ * That is the deliverable. Everything below exists so those six lines are
+ * always correct: on iOS, on a silenced phone, on a cheap tablet, with audio
+ * turned off, at 60 fps, after ten thousand taps.
+ */
+
+import { AudioEngine, TIERS, probeTier, type EngineOptions, type TierProfile } from "./engine.ts"
+import { tablesFor } from "./dsp/tables.ts"
+import { Ambience, type AmbienceId } from "./music/ambience.ts"
+import { ProceduralMusic } from "./music/music.ts"
+import { ALL_PRESETS, HIJAZ, type PresetId } from "./presets/library.ts"
+import { holdCurrent } from "./dsp/env.ts"
+import { clamp } from "./rng.ts"
+import type { BusName, Cue, PlayOptions, Preset, Tier } from "./types.ts"
+
+export * from "./types.ts"
+export { MATERIALS, expandMaterial } from "./dsp/materials.ts"
+export { ALL_PRESETS, HIJAZ, PENTA, ROOT_HZ } from "./presets/library.ts"
+export type { PresetId } from "./presets/library.ts"
+export { AudioEngine, TIERS, probeTier } from "./engine.ts"
+export type { AmbienceId } from "./music/ambience.ts"
+
+export interface AudioKitOptions extends EngineOptions {
+  /** Extra presets on top of the built-in library. */
+  presets?: Preset[]
+  /** Start with audio switched off (still emits cues). */
+  enabled?: boolean
+}
+
+export class AudioKit {
+  private engine: AudioEngine
+  private presets = new Map<string, Preset>()
+  private _music: ProceduralMusic | null = null
+  private _ambience: Ambience | null = null
+  private comboStep = 0
+  private enabled: boolean
+
+  constructor(options: AudioKitOptions = {}) {
+    this.engine = new AudioEngine(options)
+    for (const p of ALL_PRESETS) this.presets.set(p.id, p)
+    for (const p of options.presets ?? []) this.presets.set(p.id, p)
+    this.enabled = options.enabled ?? true
+  }
+
+  /**
+   * Build everything. Safe to call from anywhere (it does NOT need a gesture);
+   * the context stays suspended until the first tap, which `armUnlock` handles.
+   */
+  async init(): Promise<AudioKit> {
+    await this.engine.init()
+    if (!this.enabled) this.engine.setMuted(true)
+    await this.warm()
+    return this
+  }
+
+  /**
+   * Music and ambience are built on FIRST USE, not at init.
+   *
+   * Each one needs its own polyphonic worklet banks (so it can be ducked and
+   * faded independently of SFX), and an idle bank measured ~0.33% of a core
+   * just for existing. A prototype that never plays music should never pay for
+   * a music bank.
+   */
+  private musicEngine(): ProceduralMusic | null {
+    if (!this.engine.ready) return null
+    if (!this._music) {
+      const e = this.engine
+      this._music = new ProceduralMusic({
+        ctx: e.ctx,
+        out: e.busNode("music"),
+        send: e.sendNode("music"),
+        tables: tablesFor(e.ctx),
+        strings: e.stringsFor("music"),
+        modal: e.modalFor("music"),
+        tier: e.tier,
+        maxLayers: e.profile.musicLayers,
+      })
+    }
+    return this._music
+  }
+
+  private ambienceEngine(): Ambience | null {
+    if (!this.engine.ready) return null
+    if (!this._ambience) {
+      const e = this.engine
+      this._ambience = new Ambience({
+        ctx: e.ctx,
+        out: e.busNode("ambience"),
+        send: e.sendNode("ambience"),
+        tables: tablesFor(e.ctx),
+        modal: e.modalFor("ambience"),
+        tier: e.tier,
+      })
+    }
+    return this._ambience
+  }
+
+  /**
+   * Force every preset through its code path once, silently and off the audio
+   * thread, so nothing JITs during play.
+   *
+   * MEASURED: the first `play()` of a given preset costs up to ~200 us on the
+   * main thread (V8 compiling the render function and touching each node
+   * constructor for the first time); steady state is 6-11 us. 200 us is not a
+   * dropped frame on its own, but a screen transition that fires six new
+   * presets at once is over a millisecond of jank at exactly the moment the
+   * player is watching. This removes it.
+   *
+   * The warm pass runs in an OfflineAudioContext, so it costs NOTHING on the
+   * real-time audio thread — it is pure main-thread JIT priming, ~20 ms once.
+   */
+  async warm(): Promise<number> {
+    const t0 = typeof performance !== "undefined" ? performance.now() : Date.now()
+    const OAC = (globalThis as { OfflineAudioContext?: typeof OfflineAudioContext }).OfflineAudioContext
+    if (!OAC) return 0
+    try {
+      const oc = new OAC(1, 2048, 48000)
+      const bus = oc.createGain()
+      bus.gain.value = 0
+      bus.connect(oc.destination)
+      const tables = tablesFor(oc)
+      const rand = (): number => 0.5
+      for (const p of this.presets.values()) {
+        try {
+          p.render({
+            ctx: oc,
+            out: bus,
+            send: null,
+            when: 0.01,
+            level: p.gain,
+            intensity: 0.7,
+            semitones: 0,
+            tier: this.engine.tier,
+            rand,
+            range: (lo, hi) => (lo + hi) / 2,
+            tables,
+            // No banks: the worklet path is a postMessage, which has no JIT
+            // cost worth priming, and an offline bank would need its own module.
+            strings: null,
+            modal: null,
+          })
+        } catch {
+          /* a preset that cannot render offline is still fine live */
+        }
+      }
+    } catch {
+      /* warming is an optimisation, never a requirement */
+    }
+    return (typeof performance !== "undefined" ? performance.now() : Date.now()) - t0
+  }
+
+  // -------------------------------------------------------------------------
+
+  /**
+   * Play a preset. Returns the Cue that was emitted, so a caller can drive a
+   * visual from the same call:
+   *
+   *     const cue = audio.play("impact.brass", { intensity: 0.9 })
+   *     shake(cue.weight)
+   */
+  play(id: PresetId | string, opts: PlayOptions = {}): Cue {
+    const preset = this.presets.get(id)
+    if (!preset) {
+      // A typo must be loud in development and silent in production, never a
+      // crash mid-play. This is the one place the kit logs.
+      if (typeof console !== "undefined") console.warn(`[audio] unknown preset "${id}"`)
+      return { id, when: 0, intensity: 0, semitones: 0, haptic: "none", weight: 0, silent: true }
+    }
+    const e = this.engine
+    const ctx = e.ctx
+    // Schedule a hair ahead so the attack always lands on a clean block
+    // boundary. Triggering at exactly currentTime means the first few samples
+    // of the envelope are already in the past and the attack is clipped —
+    // which is heard as an inconsistent, slightly "spitty" transient.
+    const when = ctx.currentTime + 0.004 + (opts.delay ?? 0)
+    const rand = e.rngFor(preset, opts.seed)
+    const semitones = (opts.semitones ?? 0) + e.jitter(preset, rand())
+    const intensity = clamp(opts.intensity ?? 0.7, 0, 1)
+    const weight = (preset.weight ?? 0.4) * (0.5 + intensity * 0.5)
+
+    const audible = this.enabled && !e.muted && e.ready
+    let silent = !audible
+    if (audible) {
+      if (!e.claim(preset, when, weight)) {
+        silent = true
+      } else {
+        // ONE gain node per voice. It carries the preset's own level (so the
+        // library can be loudness-matched without every preset re-deriving its
+        // gains), and — the part that actually matters — it gives the voice
+        // stealer something to FADE. Without it, `kill()` can only forget a
+        // voice, not silence it, so a stolen sound keeps ringing and the
+        // polyphony cap does nothing audible.
+        const voice = ctx.createGain()
+        voice.gain.value = preset.gain
+        voice.connect(e.busNode(preset.bus))
+        const rc = e.renderCtx(preset, { ...opts, intensity }, when, semitones, voice)
+        const res = preset.render(rc)
+        const release = (at: number): void => {
+          // 25 ms is short enough to free the budget immediately and long
+          // enough that the cut is a duck, not a click.
+          holdCurrent(voice.gain, at)
+          voice.gain.linearRampToValueAtTime(0, at + 0.025)
+          res.release?.(at)
+        }
+        e.track(preset, when, res.endsAt, weight, release)
+        const duck = opts.duck ?? preset.duck ?? 0
+        if (duck > 0) e.duck(duck, 0.18 + duck * 0.4)
+      }
+    }
+
+    const cue: Cue = {
+      id: preset.id,
+      when,
+      intensity,
+      semitones,
+      haptic: preset.haptic ?? "none",
+      weight,
+      silent,
+    }
+    e.emitCue(cue)
+    return cue
+  }
+
+  /**
+   * The combo ladder.
+   *
+   * Pass the streak length; the kit owns the musicality. Steps walk up Hijaz,
+   * then keep climbing by octave while ALSO adding low weight, so a long streak
+   * gets more exciting instead of just more shrill. Reset with `resetCombo()`
+   * or by passing 0.
+   *
+   * This is a kit-level function on purpose: every prototype needs it, and
+   * every prototype that rolls its own gets it wrong in the same way (linear
+   * semitones, which runs out of ear before it runs out of streak).
+   */
+  combo(streak?: number, opts: PlayOptions = {}): Cue {
+    if (streak === 0) {
+      this.comboStep = 0
+      return this.play("combo", { ...opts, intensity: 0.2 })
+    }
+    const n = streak ?? ++this.comboStep
+    this.comboStep = n
+    const idx = Math.max(0, n - 1)
+    // Walk the scale; above one octave keep climbing but compress, so step 30
+    // is still inside the range a small speaker reproduces.
+    const within = idx % HIJAZ.length
+    const octaves = Math.floor(idx / HIJAZ.length)
+    const semis = HIJAZ[within] + Math.min(2, octaves) * 12 + Math.max(0, octaves - 2) * 2
+    return this.play("combo", {
+      ...opts,
+      semitones: (opts.semitones ?? 0) + semis,
+      intensity: opts.intensity ?? clamp(0.3 + idx * 0.055, 0, 1),
+    })
+  }
+
+  resetCombo(): void {
+    this.comboStep = 0
+  }
+
+  // -------------------------------------------------------------------------
+
+  get music(): {
+    start(): void
+    stop(fade?: number): void
+    setIntensity(v: number, glide?: number): void
+  } {
+    return {
+      start: () => this.musicEngine()?.start(),
+      stop: (fade?: number) => this._music?.stop(fade),
+      setIntensity: (v: number, glide?: number) => this.musicEngine()?.setIntensity(v, glide),
+    }
+  }
+
+  /** Crossfade the ambient bed. `null` fades everything out. */
+  ambience(id: AmbienceId | null, fade = 1.6): void {
+    if (id === null) this._ambience?.set(null, fade)
+    else this.ambienceEngine()?.set(id, fade)
+  }
+
+  /** Duck music + ambience manually (e.g. under a spoken line). */
+  duck(amount: number, hold = 0.3): void {
+    this.engine.duck(amount, hold)
+  }
+
+  onCue(fn: (c: Cue) => void): () => void {
+    return this.engine.onCue(fn)
+  }
+
+  /**
+   * The audio on/off switch a settings screen binds to.
+   *
+   * Disabling STOPS sound but keeps cues flowing, so anything wired to `onCue`
+   * (flashes, shakes, haptics) keeps working. That is the rule: audio may
+   * never be the only channel carrying information.
+   */
+  setEnabled(on: boolean): void {
+    this.enabled = on
+    this.engine.setMuted(!on)
+    if (!on) {
+      this._music?.stop(0.4)
+      this._ambience?.set(null, 0.4)
+      this.engine.panic()
+    }
+  }
+
+  get isEnabled(): boolean {
+    return this.enabled
+  }
+
+  setVolume(v: number): void {
+    this.engine.setVolume(v)
+  }
+  setBusVolume(bus: BusName, v: number): void {
+    this.engine.setBusVolume(bus, v)
+  }
+
+  /** Call from a gesture handler if `autoUnlock:false`. */
+  resume(): Promise<void> {
+    return this.engine.resume()
+  }
+
+  panic(): void {
+    this.engine.panic()
+  }
+
+  get tier(): Tier {
+    return this.engine.tier
+  }
+  get profile(): TierProfile {
+    return this.engine.profile
+  }
+  get stats(): AudioEngine["stats"] & { activeVoices: number; worklets: boolean } {
+    return {
+      ...this.engine.stats,
+      activeVoices: this.engine.activeVoices(),
+      worklets: this.engine.workletStatus.ok,
+    }
+  }
+  get ctx(): AudioContext {
+    return this.engine.ctx
+  }
+  /** Escape hatch for a prototype that wants to build its own voices on the bus. */
+  bus(b: BusName): AudioNode {
+    return this.engine.busNode(b)
+  }
+  presetIds(): string[] {
+    return [...this.presets.keys()]
+  }
+
+  dispose(): void {
+    this._music?.dispose()
+    this._ambience?.dispose()
+    this.engine.dispose()
+  }
+}
+
+export const createAudio = (opts: AudioKitOptions = {}): AudioKit => new AudioKit(opts)
+
+let singleton: AudioKit | null = null
+
+/**
+ * The default kit. Lazily constructed so importing this module never touches
+ * the audio hardware (which matters: constructing an AudioContext at import
+ * time on iOS starts an audio session before the user has asked for anything).
+ */
+export const audio: AudioKit = new Proxy({} as AudioKit, {
+  get(_t, prop: string | symbol) {
+    singleton ??= new AudioKit()
+    const v = (singleton as unknown as Record<string | symbol, unknown>)[prop]
+    return typeof v === "function" ? v.bind(singleton) : v
+  },
+  set(_t, prop: string | symbol, value: unknown) {
+    singleton ??= new AudioKit()
+    ;(singleton as unknown as Record<string | symbol, unknown>)[prop] = value
+    return true
+  },
+})
+
+export { TIERS as TIER_PROFILES, probeTier as probeAudioTier }

--- a/dynawalla/foundations/audio/src/kit.test.ts
+++ b/dynawalla/foundations/audio/src/kit.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for the parts of the kit that are pure logic.
+ *
+ * There is no Web Audio in Node, so signal behaviour is NOT tested here — it is
+ * measured for real in a browser by `measure/`, which is the only honest place
+ * to do it. What IS testable without a soundcard is the maths and the policy,
+ * and those are exactly the things that silently drift.
+ *
+ *     npm test
+ */
+
+import { strict as assert } from "node:assert"
+import { describe, it } from "node:test"
+
+import { MATERIALS, expandMaterial } from "./dsp/materials.ts"
+import { T60_TAUS, tauFor } from "./dsp/env.ts"
+import { cents, clamp, equalPower, hashString, midiHz, mulberry32, rotate, semi, spread } from "./rng.ts"
+import { ALL_PRESETS, HIJAZ, PENTA, ROOT_HZ } from "./presets/library.ts"
+import { TIERS } from "./engine.ts"
+import { WORKLET_SOURCE } from "./worklets/source.ts"
+
+describe("rng", () => {
+  it("is deterministic for a seed", () => {
+    const a = mulberry32(42)
+    const b = mulberry32(42)
+    for (let i = 0; i < 100; i++) assert.equal(a(), b())
+  })
+
+  it("stays in [0,1)", () => {
+    const r = mulberry32(7)
+    for (let i = 0; i < 10000; i++) {
+      const v = r()
+      assert.ok(v >= 0 && v < 1, `out of range: ${v}`)
+    }
+  })
+
+  it("spread pushes values away from the centre", () => {
+    // The anti-fatigue shaper must NOT be uniform, or repeated sounds cluster
+    // around the unmodified pitch and the variation is inaudible.
+    const r = mulberry32(3)
+    let near = 0
+    let uniformNear = 0
+    for (let i = 0; i < 20000; i++) {
+      const u = r()
+      if (Math.abs(spread(u)) < 0.25) near++
+      if (Math.abs(u * 2 - 1) < 0.25) uniformNear++
+    }
+    assert.ok(near < uniformNear, `spread should be less centre-heavy: ${near} vs ${uniformNear}`)
+  })
+
+  it("rotate never repeats the previous index", () => {
+    const r = mulberry32(11)
+    let last = 0
+    for (let i = 0; i < 5000; i++) {
+      const n = rotate(r(), 4, last)
+      assert.notEqual(n, last)
+      assert.ok(n >= 0 && n < 4)
+      last = n
+    }
+  })
+
+  it("music maths is right", () => {
+    assert.ok(Math.abs(semi(12) - 2) < 1e-12)
+    assert.ok(Math.abs(cents(1200) - 2) < 1e-12)
+    assert.ok(Math.abs(midiHz(69) - 440) < 1e-9)
+    assert.ok(Math.abs(midiHz(57) - 220) < 1e-9)
+    assert.equal(clamp(5, 0, 1), 1)
+    assert.ok(Math.abs(equalPower(0.5) - Math.SQRT1_2) < 1e-12)
+    assert.equal(hashString("a"), hashString("a"))
+    assert.notEqual(hashString("a"), hashString("b"))
+  })
+})
+
+describe("envelopes", () => {
+  it("tauFor gives a -60dB point at the requested time", () => {
+    // setTargetAtTime decays as exp(-t/tau). We want exp(-T60/tau) = 1e-3.
+    const t60 = 1.4
+    const tau = tauFor(t60)
+    assert.ok(Math.abs(Math.exp(-t60 / tau) - 0.001) < 1e-9)
+    assert.ok(Math.abs(T60_TAUS - Math.log(1000)) < 1e-12)
+  })
+})
+
+describe("modal materials", () => {
+  it("every material starts at ratio 1 and has matching array lengths", () => {
+    for (const [id, m] of Object.entries(MATERIALS)) {
+      assert.equal(m.ratios[0], 1, `${id} must start at the fundamental`)
+      assert.equal(m.ratios.length, m.amps.length, `${id} ratios/amps mismatch`)
+      assert.ok(m.t60 > 0, `${id} needs a decay`)
+      assert.ok(m.decayExp >= 0, `${id} decayExp must not amplify high modes`)
+    }
+  })
+
+  it("expands to the requested frequency with high modes decaying faster", () => {
+    const { freqs, t60s, amps } = expandMaterial(MATERIALS.brass, 200, {
+      rand: mulberry32(1),
+      bright: 0.5,
+    })
+    // Fundamental lands within the detune budget.
+    const detuneRatio = freqs[0] / 200
+    assert.ok(Math.abs(1200 * Math.log2(detuneRatio)) <= MATERIALS.brass.detuneCents + 0.01)
+    // All real objects damp high frequencies first. If this ever inverts, every
+    // struck sound turns to plastic.
+    for (let i = 1; i < t60s.length; i++) {
+      assert.ok(t60s[i] < t60s[i - 1], `mode ${i} must decay faster than ${i - 1}`)
+    }
+    // Amplitudes are peak-normalised so `bright` is a tone control, not a fader.
+    assert.ok(Math.abs(Math.max(...amps) - 1) < 1e-6)
+  })
+
+  it("damping shortens every mode", () => {
+    const dry = expandMaterial(MATERIALS.glass, 300, { rand: mulberry32(2), damp: 0 })
+    const wet = expandMaterial(MATERIALS.glass, 300, { rand: mulberry32(2), damp: 0.8 })
+    for (let i = 0; i < dry.t60s.length; i++) assert.ok(wet.t60s[i] < dry.t60s[i])
+  })
+
+  it("bright changes timbre without changing level", () => {
+    const dark = expandMaterial(MATERIALS.bell, 400, { rand: mulberry32(4), bright: 0 })
+    const bright = expandMaterial(MATERIALS.bell, 400, { rand: mulberry32(4), bright: 1 })
+    assert.ok(Math.abs(Math.max(...dark.amps) - Math.max(...bright.amps)) < 1e-6)
+    // The upper partials must actually survive better when bright.
+    const lastDark = dark.amps[dark.amps.length - 1]
+    const lastBright = bright.amps[bright.amps.length - 1]
+    assert.ok(lastBright > lastDark, "bright must preserve upper modes")
+  })
+
+  it("reuses caller-provided arrays so a strike allocates nothing", () => {
+    const into = { freqs: new Float32Array(10), amps: new Float32Array(10), t60s: new Float32Array(10) }
+    const out = expandMaterial(MATERIALS.tile, 220, { into, rand: mulberry32(5) })
+    assert.equal(out.freqs.buffer, into.freqs.buffer)
+    assert.equal(out.freqs.length, MATERIALS.tile.ratios.length)
+  })
+})
+
+describe("preset library", () => {
+  it("has unique ids", () => {
+    const seen = new Set<string>()
+    for (const p of ALL_PRESETS) {
+      assert.ok(!seen.has(p.id), `duplicate preset id ${p.id}`)
+      seen.add(p.id)
+    }
+  })
+
+  it("every preset is bus-routed, levelled and describes its own visual weight", () => {
+    for (const p of ALL_PRESETS) {
+      assert.ok(["sfx", "ui", "music", "ambience"].includes(p.bus), `${p.id} bad bus`)
+      assert.ok(p.gain > 0 && p.gain <= 6, `${p.id} gain out of range: ${p.gain}`)
+      // A cue with no weight cannot drive a visual, and audio must never be the
+      // only channel carrying information.
+      assert.ok(p.weight !== undefined && p.weight > 0, `${p.id} needs a visual weight`)
+      assert.ok(p.haptic !== undefined, `${p.id} needs a haptic hint`)
+    }
+  })
+
+  it("UI presets are quiet, short-gapped and heavily varied", () => {
+    // These are heard hundreds of times a session; the anti-fatigue budget for
+    // them is deliberately larger than for a once-a-level reward.
+    for (const p of ALL_PRESETS.filter((x) => x.id.startsWith("ui."))) {
+      assert.equal(p.bus, "ui", `${p.id} must be on the ui bus`)
+      assert.ok((p.jitterCents ?? 30) >= 20, `${p.id} needs pitch variation`)
+    }
+  })
+
+  it("no preset ducks the mix to silence", () => {
+    for (const p of ALL_PRESETS) {
+      assert.ok((p.duck ?? 0) <= 0.6, `${p.id} ducks too hard: ${p.duck}`)
+    }
+  })
+
+  it("scales are musically well-formed", () => {
+    for (const scale of [HIJAZ, PENTA]) {
+      for (let i = 1; i < scale.length; i++) {
+        assert.ok(scale[i] > scale[i - 1], "scale degrees must ascend")
+      }
+      assert.equal(scale[0], 0)
+    }
+    // Hijaz is defined by its augmented second between b2 and 3.
+    assert.equal(HIJAZ[2] - HIJAZ[1], 3)
+    assert.ok(Math.abs(ROOT_HZ - 146.83) < 0.01)
+  })
+})
+
+describe("tier profiles", () => {
+  it("degrade monotonically", () => {
+    const order = ["ultra", "high", "medium", "low"] as const
+    for (let i = 1; i < order.length; i++) {
+      const hi = TIERS[order[i - 1]]
+      const lo = TIERS[order[i]]
+      assert.ok(lo.maxVoices <= hi.maxVoices, "voices must not increase as tier drops")
+      assert.ok(lo.maxModes <= hi.maxModes)
+      assert.ok(lo.maxGrainRate <= hi.maxGrainRate)
+      assert.ok(lo.musicLayers <= hi.musicLayers)
+      assert.ok(lo.reverbSeconds <= hi.reverbSeconds)
+    }
+  })
+
+  it("the lowest tier still makes sound", () => {
+    assert.ok(TIERS.low.maxVoices >= 8, "low tier must still be playable")
+    assert.ok(TIERS.low.musicLayers >= 1)
+  })
+})
+
+describe("worklet source", () => {
+  it("registers every processor the kit asks for", () => {
+    for (const name of ["dw-string", "dw-modal", "dw-meter"]) {
+      assert.ok(WORKLET_SOURCE.includes(`registerProcessor('${name}'`), `missing ${name}`)
+    }
+  })
+
+  it("allocates nothing on the audio render thread", () => {
+    // A `new` inside process() (or anything it calls) eventually drags a GC
+    // pause into a 2.67 ms budget and it is heard as a click. This was actually
+    // violated twice while building the kit: a per-pluck excitation
+    // Float32Array, and Array#push into the pending-event list.
+    const src = WORKLET_SOURCE.replace(/\/\/[^\n]*/g, "")
+    const bodyOf = (signature: string): string => {
+      const at = src.indexOf(signature)
+      if (at < 0) return ""
+      let depth = 0
+      let i = src.indexOf("{", at)
+      const start = i
+      for (; i < src.length; i++) {
+        if (src[i] === "{") depth++
+        else if (src[i] === "}") {
+          depth--
+          if (depth === 0) return src.slice(start, i)
+        }
+      }
+      return src.slice(start)
+    }
+    // Every method reachable from the render thread. Constructors are exempt —
+    // that is precisely where the preallocation is supposed to happen.
+    const hot = ["process(_inputs, outputs)", "process(inputs)", "start(ev)", "allocate()", "rnd()", "function drain("]
+    for (const sig of hot) {
+      const body = bodyOf(sig)
+      if (!body) continue
+      assert.ok(
+        !/\bnew\s+\w*Array|\bnew\s+Map|\bnew\s+Set|\.map\(|\.filter\(|\.slice\(|\.sort\(/.test(body),
+        `allocation on the audio thread in ${sig}`,
+      )
+    }
+  })
+
+  it("is valid JavaScript", () => {
+    // Cheapest possible guard against a typo in a string that only ever runs
+    // inside an AudioWorkletGlobalScope, where a syntax error is silent.
+    const stub = `
+      const registerProcessor = () => {};
+      const currentTime = 0;
+      const sampleRate = 48000;
+      class AudioWorkletProcessor { constructor() { this.port = { onmessage: null, postMessage(){} } } }
+    `
+    assert.doesNotThrow(() => new Function(stub + WORKLET_SOURCE))
+  })
+})

--- a/dynawalla/foundations/audio/src/music/ambience.ts
+++ b/dynawalla/foundations/audio/src/music/ambience.ts
@@ -1,0 +1,248 @@
+/**
+ * Ambient beds. Continuous, cheap, and the single largest contributor to a
+ * prototype feeling like a PLACE rather than a screen.
+ *
+ * Two parts, always:
+ *   1. a continuous filtered-noise bed with slow LFO movement (the air), and
+ *   2. sparse, randomly scheduled distant events (the life).
+ *
+ * (2) is what people forget. A static noise bed is ignored by the brain within
+ * seconds — literally, it is adapted out. A distant hammer every 4-9 seconds
+ * keeps the place alive at almost zero CPU, and it is the reason the bazaar
+ * bed does not become tinnitus.
+ */
+
+import { percEnv } from "../dsp/env.ts"
+import { mulberry32 } from "../rng.ts"
+import { MATERIALS } from "../dsp/materials.ts"
+import type { ModalVoiceBank, SharedTables, Tier } from "../types.ts"
+
+export interface AmbienceDeps {
+  ctx: AudioContext
+  out: AudioNode
+  send: AudioNode | null
+  tables: SharedTables
+  modal: ModalVoiceBank | null
+  tier: Tier
+}
+
+export type AmbienceId = "bazaar" | "courtyard" | "night" | "workshop"
+
+interface BedSpec {
+  kind: "pink" | "brown"
+  /** Lowpass centre and how far the LFO moves it. */
+  cutoff: number
+  wobble: number
+  rate: number
+  gain: number
+  /** Highpass to keep it from eating the mix's low end. */
+  highpass: number
+  /** Distant event scheduling. */
+  eventEvery: [number, number]
+  materials: (keyof typeof MATERIALS)[]
+  eventFreq: [number, number]
+  eventGain: number
+}
+
+const BEDS: Record<AmbienceId, BedSpec> = {
+  // Hot, wide, busy. Brown air + distant brass and pot strikes.
+  bazaar: {
+    kind: "brown",
+    cutoff: 620,
+    wobble: 260,
+    rate: 0.07,
+    gain: 0.3,
+    highpass: 90,
+    eventEvery: [2.4, 6.5],
+    materials: ["brass", "pot", "wood", "tile"],
+    eventFreq: [110, 420],
+    eventGain: 0.1,
+  },
+  // Enclosed, reflective, quieter. Water-adjacent.
+  courtyard: {
+    kind: "pink",
+    cutoff: 900,
+    wobble: 320,
+    rate: 0.045,
+    gain: 0.2,
+    highpass: 160,
+    eventEvery: [4, 11],
+    materials: ["glass", "tile"],
+    eventFreq: [420, 1400],
+    eventGain: 0.07,
+  },
+  // Cool and sparse. Almost nothing happens, and that is the point.
+  night: {
+    kind: "brown",
+    cutoff: 380,
+    wobble: 140,
+    rate: 0.03,
+    gain: 0.22,
+    highpass: 60,
+    eventEvery: [7, 18],
+    materials: ["glass", "bell"],
+    eventFreq: [700, 2200],
+    eventGain: 0.05,
+  },
+  // Close and industrious — a metalworker's stall.
+  workshop: {
+    kind: "pink",
+    cutoff: 1400,
+    wobble: 500,
+    rate: 0.11,
+    gain: 0.18,
+    highpass: 200,
+    eventEvery: [0.9, 2.6],
+    materials: ["brass", "stone", "wood"],
+    eventFreq: [180, 700],
+    eventGain: 0.13,
+  },
+}
+
+interface LiveBed {
+  id: AmbienceId
+  gain: GainNode
+  src: AudioBufferSourceNode
+  lfo: OscillatorNode
+  timer: ReturnType<typeof setTimeout> | null
+}
+
+export class Ambience {
+  private live: LiveBed | null = null
+  private rnd = mulberry32(0xa11bed)
+  private level = 1
+
+  private deps: AmbienceDeps
+
+  constructor(deps: AmbienceDeps) {
+    this.deps = deps
+  }
+
+  /** Crossfade to a bed. Passing null fades out. Idempotent for the same id. */
+  set(id: AmbienceId | null, fade = 1.6): void {
+    if (this.live?.id === id) return
+    const prev = this.live
+    if (prev) this.fadeOutAndStop(prev, fade)
+    this.live = id ? this.build(id, fade) : null
+  }
+
+  setLevel(v: number, ramp = 0.4): void {
+    this.level = Math.max(0, Math.min(1, v))
+    const l = this.live
+    if (!l) return
+    const t = this.deps.ctx.currentTime
+    l.gain.gain.cancelScheduledValues(t)
+    l.gain.gain.setValueAtTime(l.gain.gain.value, t)
+    l.gain.gain.linearRampToValueAtTime(BEDS[l.id].gain * this.level, t + ramp)
+  }
+
+  private build(id: AmbienceId, fade: number): LiveBed {
+    const { ctx, out, tables } = this.deps
+    const spec = BEDS[id]
+    const g = ctx.createGain()
+    g.gain.value = 0
+    g.connect(out)
+    const t = ctx.currentTime
+    g.gain.linearRampToValueAtTime(spec.gain * this.level, t + fade)
+
+    const src = ctx.createBufferSource()
+    src.buffer = spec.kind === "brown" ? tables.brown() : tables.pink()
+    src.loop = true
+    // A loop point in a 2 s noise buffer is audible as a click if the buffer
+    // is not seamless. Ours is generated, so we simply detune the playback rate
+    // per instance — the loop period stops being a round number and the ear
+    // stops locking onto it.
+    src.playbackRate.value = 0.82 + this.rnd() * 0.3
+
+    const lp = ctx.createBiquadFilter()
+    lp.type = "lowpass"
+    lp.frequency.value = spec.cutoff
+    lp.Q.value = 0.9
+    const hp = ctx.createBiquadFilter()
+    hp.type = "highpass"
+    hp.frequency.value = spec.highpass
+
+    const lfo = ctx.createOscillator()
+    lfo.frequency.value = spec.rate
+    const lfoG = ctx.createGain()
+    lfoG.gain.value = spec.wobble
+    lfo.connect(lfoG)
+    lfoG.connect(lp.frequency)
+
+    src.connect(hp)
+    hp.connect(lp)
+    lp.connect(g)
+    if (this.deps.send) {
+      const s = ctx.createGain()
+      s.gain.value = 0.3
+      lp.connect(s)
+      s.connect(this.deps.send)
+    }
+    src.start(t, this.rnd() * 1.5)
+    lfo.start(t)
+
+    const bed: LiveBed = { id, gain: g, src, lfo, timer: null }
+    this.scheduleEvent(bed, spec)
+    return bed
+  }
+
+  /** One distant strike, then set the next timer. Never a fixed interval. */
+  private scheduleEvent(bed: LiveBed, spec: BedSpec): void {
+    const [lo, hi] = spec.eventEvery
+    const wait = (lo + this.rnd() * (hi - lo)) * 1000
+    bed.timer = setTimeout(() => {
+      if (this.live !== bed) return
+      const modal = this.deps.modal
+      const ctx = this.deps.ctx
+      const at = ctx.currentTime + 0.02
+      const mat = spec.materials[Math.floor(this.rnd() * spec.materials.length)]
+      const f = spec.eventFreq[0] + this.rnd() * (spec.eventFreq[1] - spec.eventFreq[0])
+      const panPos = (this.rnd() * 2 - 1) * 0.85
+      if (modal) {
+        modal.strike({
+          when: at,
+          material: MATERIALS[mat],
+          freq: f,
+          velocity: 0.25 + this.rnd() * 0.3,
+          modes: this.deps.tier === "low" ? 3 : 5,
+          damp: 0.35,
+          pan: panPos,
+          gain: spec.eventGain * this.level,
+          rand: this.rnd,
+        })
+      } else {
+        // No worklet: a filtered noise knock still reads as "something happened
+        // over there", which is the whole job of this layer.
+        const src = ctx.createBufferSource()
+        src.buffer = this.deps.tables.velvet()
+        const bp = ctx.createBiquadFilter()
+        bp.type = "bandpass"
+        bp.frequency.value = f * 3
+        bp.Q.value = 6
+        const g = ctx.createGain()
+        const end = percEnv(g.gain, at, spec.eventGain * this.level, 0.002, 0.18)
+        src.connect(bp)
+        bp.connect(g)
+        g.connect(bed.gain)
+        src.start(at, this.rnd() * 0.3)
+        src.stop(end + 0.02)
+      }
+      this.scheduleEvent(bed, spec)
+    }, wait)
+  }
+
+  private fadeOutAndStop(bed: LiveBed, fade: number): void {
+    const t = this.deps.ctx.currentTime
+    if (bed.timer) clearTimeout(bed.timer)
+    bed.gain.gain.cancelScheduledValues(t)
+    bed.gain.gain.setValueAtTime(bed.gain.gain.value, t)
+    bed.gain.gain.linearRampToValueAtTime(0, t + fade)
+    bed.src.stop(t + fade + 0.05)
+    bed.lfo.stop(t + fade + 0.05)
+  }
+
+  dispose(): void {
+    if (this.live) this.fadeOutAndStop(this.live, 0.1)
+    this.live = null
+  }
+}

--- a/dynawalla/foundations/audio/src/music/music.ts
+++ b/dynawalla/foundations/audio/src/music/music.ts
@@ -1,0 +1,350 @@
+/**
+ * Procedural music that responds to intensity.
+ *
+ * Not a loop. There is no bar of audio anywhere — the whole thing is generated
+ * one note at a time by a lookahead scheduler, so it never repeats identically
+ * and it can change density, register and instrumentation on any bar line
+ * without a crossfade artefact.
+ *
+ * `setIntensity(0..1)` is the only control a prototype needs. It moves:
+ *   layers in and out (equal-power, over one bar, never mid-bar)
+ *   note density (the arpeggio subdivides)
+ *   velocity and brightness
+ *   tempo, but only 88 -> 104 BPM. Big tempo jumps read as panic; a child at
+ *   a maths game should feel LIFT, not alarm.
+ *
+ * SCHEDULING — the Chris Wilson lookahead pattern (a `setInterval` that
+ * schedules WebAudio events into the near future) is still the correct answer
+ * in 2026, because WebAudio's own clock is sample-accurate and JS timers are
+ * not. Two traps it does not solve on its own, both handled below:
+ *   - background tabs throttle `setInterval` to ~1 Hz, so the scheduler wakes
+ *     to find it is seconds behind and fires a stampede of past-dated notes.
+ *     We detect the gap and resync instead.
+ *   - `setInterval` drift accumulates. We never advance time by "+= interval";
+ *     every note time comes from the beat counter, so drift cannot accumulate.
+ */
+
+import { percEnv } from "../dsp/env.ts"
+import { mulberry32, semi } from "../rng.ts"
+import { MATERIALS } from "../dsp/materials.ts"
+import type { ModalVoiceBank, SharedTables, StringBank, Tier } from "../types.ts"
+
+const ROOT = 146.83 // D3
+/** Hijaz: 1 b2 3 4 5 b6 7 — the mode of the whole bazaar. */
+const SCALE = [0, 1, 4, 5, 7, 8, 10]
+
+const degreeHz = (deg: number, octave = 0): number => {
+  const i = ((deg % SCALE.length) + SCALE.length) % SCALE.length
+  const oct = Math.floor(deg / SCALE.length) + octave
+  return ROOT * semi(SCALE[i] + oct * 12)
+}
+
+export interface MusicDeps {
+  ctx: AudioContext
+  out: AudioNode
+  send: AudioNode | null
+  tables: SharedTables
+  strings: StringBank | null
+  modal: ModalVoiceBank | null
+  tier: Tier
+  maxLayers: number
+}
+
+type LayerName = "drone" | "pulse" | "bass" | "arp" | "bell" | "shaker"
+
+/** Intensity at which each layer becomes audible. Ordered by musical weight. */
+const LAYER_IN: Record<LayerName, number> = {
+  drone: 0.0,
+  pulse: 0.18,
+  bass: 0.3,
+  arp: 0.45,
+  shaker: 0.6,
+  bell: 0.78,
+}
+
+const LAYER_ORDER: LayerName[] = ["drone", "pulse", "bass", "arp", "shaker", "bell"]
+
+export class ProceduralMusic {
+  private gains = {} as Record<LayerName, GainNode>
+  private drone: { osc: OscillatorNode[]; filt: BiquadFilterNode; lfo: OscillatorNode } | null = null
+  private timer: ReturnType<typeof setInterval> | null = null
+  private beat = 0
+  private startTime = 0
+  private rnd = mulberry32(0x5eed)
+  private intensity = 0
+  private running = false
+  private bpm = 88
+  /** Bar the harmony last changed on, and the current chord degree. */
+  private chord = 0
+  private active: LayerName[]
+
+  /** How far ahead we schedule, and how often we wake. 120/25 is the sweet
+   *  spot: shorter lookahead risks dropouts under GC, longer makes an
+   *  intensity change feel laggy because notes are already committed. */
+  private readonly lookahead = 0.12
+  private readonly tick = 25
+
+  private deps: MusicDeps
+
+  constructor(deps: MusicDeps) {
+    this.deps = deps
+    this.active = LAYER_ORDER.slice(0, Math.max(1, deps.maxLayers))
+    for (const l of this.active) {
+      const g = deps.ctx.createGain()
+      g.gain.value = 0
+      g.connect(deps.out)
+      this.gains[l] = g
+    }
+  }
+
+  start(at?: number): void {
+    if (this.running) return
+    this.running = true
+    const ctx = this.deps.ctx
+    this.startTime = at ?? ctx.currentTime + 0.08
+    this.beat = 0
+    this.buildDrone()
+    this.timer = setInterval(() => this.schedule(), this.tick)
+    this.schedule()
+    this.applyLayerGains(0.6)
+  }
+
+  stop(fade = 0.8): void {
+    if (!this.running) return
+    this.running = false
+    if (this.timer) clearInterval(this.timer)
+    this.timer = null
+    const now = this.deps.ctx.currentTime
+    for (const l of this.active) {
+      const g = this.gains[l]
+      g.gain.cancelScheduledValues(now)
+      g.gain.setValueAtTime(g.gain.value, now)
+      g.gain.linearRampToValueAtTime(0, now + fade)
+    }
+    const d = this.drone
+    if (d) {
+      const stopAt = now + fade + 0.05
+      for (const o of d.osc) o.stop(stopAt)
+      d.lfo.stop(stopAt)
+      this.drone = null
+    }
+  }
+
+  setIntensity(v: number, glideSec = 2.2): void {
+    this.intensity = Math.max(0, Math.min(1, v))
+    this.bpm = 88 + this.intensity * 16
+    this.applyLayerGains(glideSec)
+    if (this.drone) {
+      const t = this.deps.ctx.currentTime
+      const f = 320 + this.intensity * 900
+      this.drone.filt.frequency.cancelScheduledValues(t)
+      this.drone.filt.frequency.setValueAtTime(this.drone.filt.frequency.value, t)
+      this.drone.filt.frequency.linearRampToValueAtTime(f, t + glideSec)
+    }
+  }
+
+  private applyLayerGains(glideSec: number): void {
+    const t = this.deps.ctx.currentTime
+    for (const l of this.active) {
+      const g = this.gains[l]
+      const inAt = LAYER_IN[l]
+      // Equal-power fade across a 0.18-wide band above the threshold.
+      const x = Math.max(0, Math.min(1, (this.intensity - inAt) / 0.18))
+      const target = Math.sin((x * Math.PI) / 2) * this.layerBase(l)
+      g.gain.cancelScheduledValues(t)
+      g.gain.setValueAtTime(g.gain.value, t)
+      g.gain.linearRampToValueAtTime(target, t + glideSec)
+    }
+  }
+
+  private layerBase(l: LayerName): number {
+    switch (l) {
+      case "drone":
+        return 0.34
+      case "pulse":
+        return 0.5
+      case "bass":
+        return 0.42
+      case "arp":
+        return 0.34
+      case "shaker":
+        return 0.24
+      case "bell":
+        return 0.24
+    }
+  }
+
+  /**
+   * The drone is the only CONTINUOUS element — three detuned saws through a
+   * lowpass with a slow LFO. Continuous, so it needs no scheduling and it can
+   * never glitch; everything else is one-shot and disposable.
+   */
+  private buildDrone(): void {
+    const { ctx } = this.deps
+    const filt = ctx.createBiquadFilter()
+    filt.type = "lowpass"
+    filt.frequency.value = 340
+    filt.Q.value = 1.4
+    filt.connect(this.gains.drone)
+
+    const lfo = ctx.createOscillator()
+    lfo.frequency.value = 0.055
+    const lfoG = ctx.createGain()
+    lfoG.gain.value = 120
+    lfo.connect(lfoG)
+    lfoG.connect(filt.frequency)
+    lfo.start()
+
+    const osc: OscillatorNode[] = []
+    const detunes = [-7, 0, 5, 12]
+    for (let i = 0; i < detunes.length; i++) {
+      const o = ctx.createOscillator()
+      o.type = i === 3 ? "sine" : "sawtooth"
+      o.frequency.value = ROOT * (i === 3 ? 2 : 1) * 0.5
+      o.detune.value = detunes[i] * 1.4
+      const g = ctx.createGain()
+      g.gain.value = i === 3 ? 0.1 : 0.16
+      o.connect(g)
+      g.connect(filt)
+      o.start()
+      osc.push(o)
+    }
+    if (this.deps.send) {
+      const s = ctx.createGain()
+      s.gain.value = 0.25
+      filt.connect(s)
+      s.connect(this.deps.send)
+    }
+    this.drone = { osc, filt, lfo }
+  }
+
+  /** 16th-note grid. Everything is expressed in 16ths from `startTime`. */
+  private timeOf(step: number): number {
+    return this.startTime + (step * 60) / (this.bpm * 4)
+  }
+
+  private schedule(): void {
+    if (!this.running) return
+    const ctx = this.deps.ctx
+    const now = ctx.currentTime
+    // Background-throttle guard: if we woke up far behind, do NOT fire the
+    // backlog. Rebase the grid onto now and carry on. Without this, a tab that
+    // was hidden for 30 s dumps ~2000 notes into the graph the moment it wakes
+    // and the audio thread stalls hard enough to be heard as a rip.
+    if (this.timeOf(this.beat) < now - 0.4) {
+      this.startTime = now + 0.05
+      this.beat = 0
+    }
+    let guard = 0
+    while (this.timeOf(this.beat) < now + this.lookahead && guard++ < 64) {
+      this.emit(this.beat, this.timeOf(this.beat))
+      this.beat++
+    }
+  }
+
+  private emit(step: number, at: number): void {
+    const bar = Math.floor(step / 16)
+    const s = step % 16
+    if (s === 0) {
+      // Harmony moves on bar lines only: i - VI - iv - V, the shape that makes
+      // Hijaz sound like a place rather than a scale exercise.
+      this.chord = [0, 5, 3, 4][bar % 4]
+    }
+    const I = this.intensity
+
+    // --- pulse: a darbuka pattern. Doum on 1 and 9, tek on the offbeats. ----
+    if (this.gains.pulse && this.deps.modal) {
+      const doum = s === 0 || s === 6 || s === 10
+      const tek = s === 4 || s === 12 || (I > 0.55 && (s === 7 || s === 14))
+      const ghost = I > 0.7 && s % 2 === 1 && this.rnd() < 0.22
+      if (doum || tek || ghost) {
+        this.deps.modal.strike({
+          when: at,
+          material: MATERIALS.skin,
+          freq: doum ? 96 : 168,
+          velocity: doum ? 0.62 : ghost ? 0.16 : 0.4,
+          modes: this.deps.tier === "low" ? 3 : 6,
+          sustain: doum ? 1 : 0.55,
+          pan: doum ? 0 : this.rnd() * 0.5 - 0.25,
+          gain: 0.55,
+          rand: this.rnd,
+        })
+      }
+    }
+
+    // --- bass: plucked, root of the chord, on 1 and the "and" of 3 ---------
+    if (this.gains.bass && this.deps.strings && (s === 0 || s === 6 || (I > 0.6 && s === 11))) {
+      this.deps.strings.pluck({
+        when: at,
+        freq: degreeHz(this.chord, -1),
+        velocity: 0.6,
+        decay: 0.9,
+        damping: 0.55,
+        position: 0.3,
+        pan: 0,
+        gain: 0.5,
+      })
+    }
+
+    // --- arp: santur figure across the chord, subdividing with intensity ---
+    if (this.gains.arp && this.deps.strings) {
+      const div = I > 0.8 ? 1 : I > 0.62 ? 2 : 4
+      if (s % div === 0) {
+        const deg = this.chord + [0, 2, 4, 2, 5, 4, 2, 0][(step / div) % 8 | 0]
+        this.deps.strings.pluck({
+          when: at,
+          freq: degreeHz(deg, 1),
+          velocity: 0.3 + this.rnd() * 0.2 + I * 0.15,
+          decay: 1.2,
+          damping: 0.22,
+          position: 0.18 + this.rnd() * 0.1,
+          pan: (this.rnd() * 2 - 1) * 0.45,
+          gain: 0.34,
+        })
+      }
+    }
+
+    // --- shaker: 16ths with a swung accent -------------------------------
+    if (this.gains.shaker && s % 2 === 1) {
+      this.shaker(at, s % 4 === 3 ? 0.4 : 0.2)
+    }
+
+    // --- bell: sparse ornament high above, only when it is really going ---
+    if (this.gains.bell && this.deps.modal && s === 8 && this.rnd() < 0.35 + I * 0.3) {
+      this.deps.modal.strike({
+        when: at,
+        material: MATERIALS.bell,
+        freq: degreeHz(this.chord + 4, 2),
+        velocity: 0.35,
+        modes: 4,
+        sustain: 1.2,
+        pan: (this.rnd() * 2 - 1) * 0.6,
+        gain: 0.35,
+        rand: this.rnd,
+      })
+    }
+  }
+
+  private shaker(at: number, amp: number): void {
+    const { ctx, tables } = this.deps
+    const src = ctx.createBufferSource()
+    src.buffer = tables.velvet()
+    src.playbackRate.value = 0.85 + this.rnd() * 0.3
+    const bp = ctx.createBiquadFilter()
+    bp.type = "bandpass"
+    bp.frequency.value = 6200 + this.rnd() * 1800
+    bp.Q.value = 1.6
+    const g = ctx.createGain()
+    const end = percEnv(g.gain, at, amp, 0.001, 0.035)
+    src.connect(bp)
+    bp.connect(g)
+    g.connect(this.gains.shaker)
+    src.start(at, this.rnd() * 0.4)
+    src.stop(end + 0.02)
+  }
+
+  dispose(): void {
+    this.stop(0.05)
+    for (const l of this.active) this.gains[l]?.disconnect()
+  }
+}

--- a/dynawalla/foundations/audio/src/presets/library.ts
+++ b/dynawalla/foundations/audio/src/presets/library.ts
@@ -1,0 +1,856 @@
+/**
+ * The preset library — the thing a prototype author actually names.
+ *
+ * Every sound here is a composition of transient + body + tail (+ sub), tuned
+ * by ear against the brief: a minaret-punk bazaar of brass, tile and glass.
+ * Nothing is a sine beep; nothing is a stock "success chime".
+ *
+ * The pitch centre for the whole kit is **D** (293.66 Hz), and pitched presets
+ * live on a **Hijaz**-flavoured set (1, b2, 3, 4, 5, b6, 7). That is a deliberate
+ * choice: a major triad reads as a corporate onboarding flow, and Hijaz reads
+ * as somewhere with hot dust and hammered metal. A child cannot name it and
+ * will absolutely feel it.
+ *
+ * Loudness policy: presets are matched by measured short-term level, not by
+ * "sounds about right". See `measure/loudness.ts` — every entry is within
+ * ±2.5 LU of the kit reference, so a prototype never has one sound that makes
+ * a parent lunge for the volume.
+ */
+
+import { MATERIALS } from "../dsp/materials.ts"
+import { percEnv } from "../dsp/env.ts"
+import { semi } from "../rng.ts"
+import type { Preset, RenderCtx } from "../types.ts"
+import { airTone, fmTone, grainCloud, noiseBurst, pan, route, subThump, sweep } from "./voices.ts"
+
+/** D3. Everything pitched is relative to this. */
+export const ROOT_HZ = 146.83
+
+/** Hijaz on D: D Eb F# G A Bb C. In semitones from the root. */
+export const HIJAZ = [0, 1, 4, 5, 7, 8, 10, 12, 13, 16, 17, 19, 20, 22, 24]
+
+/** A gentler set for failure/neutral sounds — no leading tone, no tension. */
+export const PENTA = [0, 3, 5, 7, 10, 12, 15, 17, 19, 22, 24]
+
+const hz = (semis: number): number => ROOT_HZ * semi(semis)
+
+/** Strike the modal bank if it exists; fall back to FM so nothing is silent. */
+const strike = (
+  rc: RenderCtx,
+  material: keyof typeof MATERIALS,
+  freq: number,
+  velocity: number,
+  opts: { pan?: number; gain?: number; sustain?: number; damp?: number } = {},
+): number => {
+  const m = MATERIALS[material]
+  const modes = Math.min(m.ratios.length, rc.tier === "low" ? 4 : rc.tier === "medium" ? 6 : 10)
+  const bank = rc.modal
+  if (bank) {
+    bank.strike({
+      when: rc.when,
+      material: m,
+      freq,
+      velocity,
+      modes,
+      damp: opts.damp ?? 0,
+      sustain: opts.sustain ?? 1,
+      pan: opts.pan ?? 0,
+      // The banks are shared per bus, so they cannot pass through the voice's
+      // own gain node — the preset level is applied HERE instead.
+      gain: (opts.gain ?? 1) * rc.level,
+      rand: rc.rand,
+    })
+    return rc.when + m.t60 * (opts.sustain ?? 1) + 0.05
+  }
+  // Fallback: FM approximation of the material's two strongest modes.
+  return fmTone(rc, {
+    freq,
+    ratio: m.ratios[1] ?? 2.7,
+    index: 2 + velocity * 4,
+    indexDecay: m.t60 * 0.25,
+    gain: (opts.gain ?? 1) * 0.5 * velocity,
+    decay: m.t60 * (opts.sustain ?? 1),
+    pan: opts.pan ?? 0,
+    send: 0.3,
+  })
+}
+
+const p = (def: Preset): Preset => def
+
+// ---------------------------------------------------------------------------
+// UI — heard hundreds of times a session. These must be SHORT, quiet, and
+// varied, or they become the sound of a dripping tap.
+// ---------------------------------------------------------------------------
+
+export const UI_PRESETS: Preset[] = [
+  p({
+    id: "ui.tap",
+    bus: "ui",
+    gain: 1.23,
+    group: "ui",
+    poly: 4,
+    haptic: "light",
+    weight: 0.15,
+    minGap: 0.03,
+    jitterCents: 55,
+    render(rc) {
+      // Transient only: velvet noise through a high bandpass. A fingertip on
+      // glazed tile. 12 ms long, and the ear still reads it as "a thing".
+      const f = 2400 * semi(rc.semitones)
+      const a = noiseBurst(rc, {
+        kind: "velvet",
+        freq: f * rc.range(0.92, 1.09),
+        q: 2.4,
+        gain: 0.5 * (0.5 + rc.intensity * 0.5),
+        decay: 0.016,
+        highpass: 900,
+        pan: rc.range(-0.12, 0.12),
+        send: 0.05,
+      })
+      // A whisper of tile body underneath gives the tap a material.
+      const b = strike(rc, "tile", hz(24 + rc.semitones), 0.22 + rc.intensity * 0.2, {
+        gain: 0.22,
+        sustain: 0.5,
+      })
+      return { endsAt: Math.max(a, b) }
+    },
+  }),
+
+  p({
+    id: "ui.chunk",
+    bus: "ui",
+    gain: 0.131,
+    group: "ui",
+    poly: 3,
+    haptic: "medium",
+    weight: 0.4,
+    duck: 0.12,
+    minGap: 0.04,
+    jitterCents: 25,
+    render(rc) {
+      // The confirmation. Wood transient + tile body + a short sub. This is the
+      // "a heavy well-made thing seated into its slot" sound, and it is the one
+      // preset most worth stealing for any other project.
+      const t = noiseBurst(rc, {
+        kind: "white",
+        freq: 1500 * rc.range(0.9, 1.12),
+        q: 0.9,
+        gain: 0.34,
+        decay: 0.022,
+        highpass: 400,
+        send: 0.08,
+      })
+      const body = strike(rc, "wood", hz(12 + rc.semitones), 0.55 + rc.intensity * 0.4, {
+        gain: 0.95,
+        pan: rc.range(-0.08, 0.08),
+      })
+      const s = subThump(rc, { freq: 82, drop: 5, fall: 0.045, gain: 0.32 * rc.intensity, decay: 0.1, drive: 0.4 })
+      return { endsAt: Math.max(t, body, s) }
+    },
+  }),
+
+  p({
+    id: "ui.select",
+    bus: "ui",
+    gain: 0.209,
+    group: "ui",
+    poly: 3,
+    haptic: "light",
+    weight: 0.2,
+    jitterCents: 20,
+    render(rc) {
+      // A single struck bead, pitched up the Hijaz scale — used for stepping
+      // through options, so it must feel like movement, not like a click.
+      const step = HIJAZ[Math.min(HIJAZ.length - 1, Math.round(rc.intensity * 6))]
+      const a = strike(rc, "bell", hz(24 + step + rc.semitones), 0.45, { gain: 0.5, sustain: 0.5 })
+      const b = noiseBurst(rc, { kind: "velvet", freq: 5200, q: 3, gain: 0.16, decay: 0.01, highpass: 2000 })
+      return { endsAt: Math.max(a, b) }
+    },
+  }),
+
+  p({
+    id: "ui.back",
+    bus: "ui",
+    gain: 0.386,
+    group: "ui",
+    poly: 2,
+    haptic: "light",
+    weight: 0.2,
+    jitterCents: 20,
+    render(rc) {
+      const a = strike(rc, "wood", hz(7 + rc.semitones), 0.4, { gain: 0.6, sustain: 0.7 })
+      const b = noiseBurst(rc, {
+        kind: "pink",
+        freq: 1800,
+        freqTo: 500,
+        sweep: 0.09,
+        q: 1.6,
+        gain: 0.18,
+        decay: 0.1,
+        send: 0.1,
+      })
+      return { endsAt: Math.max(a, b) }
+    },
+  }),
+
+  p({
+    id: "ui.toggle",
+    bus: "ui",
+    gain: 0.472,
+    group: "ui",
+    poly: 2,
+    haptic: "light",
+    weight: 0.25,
+    render(rc) {
+      // Two-part latch: a tiny stone click and a metal catch 28 ms later.
+      const a = strike(rc, "stone", hz(19 + rc.semitones), 0.5, { gain: 0.5 })
+      const rc2 = { ...rc, when: rc.when + 0.028 } as RenderCtx
+      const b = strike(rc2, "bell", hz(31 + rc.semitones), 0.35, { gain: 0.3, sustain: 0.35 })
+      return { endsAt: Math.max(a, b) }
+    },
+  }),
+]
+
+// ---------------------------------------------------------------------------
+// IMPACTS — the physical vocabulary of the bazaar.
+// ---------------------------------------------------------------------------
+
+export const IMPACT_PRESETS: Preset[] = [
+  p({
+    id: "impact.brass",
+    bus: "sfx",
+    gain: 0.09,
+    group: "impact",
+    poly: 4,
+    haptic: "heavy",
+    weight: 0.9,
+    duck: 0.3,
+    jitterCents: 18,
+    render(rc) {
+      const t = noiseBurst(rc, {
+        kind: "white",
+        freq: 3800 * rc.range(0.85, 1.15),
+        q: 0.7,
+        gain: 0.4 * rc.intensity,
+        decay: 0.03,
+        highpass: 1200,
+        send: 0.2,
+      })
+      const body = strike(rc, "brass", hz(rc.semitones), 0.5 + rc.intensity * 0.5, {
+        gain: 1,
+        pan: rc.range(-0.2, 0.2),
+      })
+      const s = subThump(rc, { freq: 58, drop: 7, gain: 0.4 * rc.intensity, decay: 0.22, drive: 0.5 })
+      const air = airTone(rc, hz(24 + rc.semitones), 0.06 * rc.intensity, 1.2)
+      return { endsAt: Math.max(t, body, s, air) }
+    },
+  }),
+
+  p({
+    id: "impact.tile",
+    bus: "sfx",
+    gain: 0.395,
+    group: "impact",
+    poly: 6,
+    haptic: "medium",
+    weight: 0.5,
+    jitterCents: 40,
+    render(rc) {
+      const t = noiseBurst(rc, {
+        kind: "velvet",
+        freq: 3000 * rc.range(0.85, 1.2),
+        q: 1.4,
+        gain: 0.3 * (0.4 + rc.intensity * 0.6),
+        decay: 0.018,
+        highpass: 900,
+        send: 0.12,
+      })
+      const body = strike(rc, "tile", hz(12 + rc.semitones), 0.4 + rc.intensity * 0.6, {
+        gain: 0.9,
+        pan: rc.range(-0.3, 0.3),
+      })
+      return { endsAt: Math.max(t, body) }
+    },
+  }),
+
+  p({
+    id: "impact.stone",
+    bus: "sfx",
+    gain: 0.489,
+    group: "impact",
+    poly: 5,
+    haptic: "heavy",
+    weight: 0.6,
+    jitterCents: 45,
+    render(rc) {
+      const t = noiseBurst(rc, {
+        kind: "brown",
+        freq: 700 * rc.range(0.8, 1.25),
+        q: 0.6,
+        gain: 0.45 * rc.intensity,
+        decay: 0.045,
+        send: 0.1,
+      })
+      const body = strike(rc, "stone", hz(-5 + rc.semitones), 0.5 + rc.intensity * 0.5, { gain: 1 })
+      const s = subThump(rc, { freq: 48, drop: 9, gain: 0.5 * rc.intensity, decay: 0.14, drive: 0.55 })
+      return { endsAt: Math.max(t, body, s) }
+    },
+  }),
+
+  p({
+    id: "impact.glass",
+    bus: "sfx",
+    gain: 0.272,
+    group: "impact",
+    poly: 5,
+    haptic: "light",
+    weight: 0.55,
+    jitterCents: 30,
+    render(rc) {
+      const t = noiseBurst(rc, {
+        kind: "velvet",
+        freq: 7000,
+        q: 2.2,
+        gain: 0.24 * rc.intensity,
+        decay: 0.012,
+        highpass: 3000,
+        send: 0.25,
+      })
+      const body = strike(rc, "glass", hz(19 + rc.semitones), 0.4 + rc.intensity * 0.5, {
+        gain: 0.7,
+        pan: rc.range(-0.35, 0.35),
+      })
+      return { endsAt: Math.max(t, body) }
+    },
+  }),
+
+  p({
+    id: "impact.drum",
+    bus: "sfx",
+    gain: 0.285,
+    group: "impact",
+    poly: 4,
+    haptic: "heavy",
+    weight: 0.7,
+    duck: 0.18,
+    jitterCents: 35,
+    render(rc) {
+      // Darbuka. The membrane modes do the work; the noise is just the palm.
+      const t = noiseBurst(rc, {
+        kind: "pink",
+        freq: 2200,
+        q: 0.8,
+        gain: 0.22 * rc.intensity,
+        decay: 0.02,
+        highpass: 700,
+      })
+      const body = strike(rc, "skin", hz(-5 + rc.semitones), 0.5 + rc.intensity * 0.5, { gain: 1 })
+      const s = subThump(rc, { freq: 62, drop: 6, gain: 0.35 * rc.intensity, decay: 0.12, drive: 0.35 })
+      return { endsAt: Math.max(t, body, s) }
+    },
+  }),
+
+  p({
+    id: "impact.pot",
+    bus: "sfx",
+    gain: 0.26,
+    group: "impact",
+    poly: 3,
+    haptic: "medium",
+    weight: 0.5,
+    jitterCents: 40,
+    render(rc) {
+      const t = noiseBurst(rc, { kind: "white", freq: 2600, q: 1, gain: 0.26 * rc.intensity, decay: 0.025, highpass: 800 })
+      const body = strike(rc, "pot", hz(3 + rc.semitones), 0.45 + rc.intensity * 0.5, { gain: 0.9 })
+      return { endsAt: Math.max(t, body) }
+    },
+  }),
+]
+
+// ---------------------------------------------------------------------------
+// PLUCKS — Karplus-Strong. The santur/oud voice of the place.
+// ---------------------------------------------------------------------------
+
+export const PLUCK_PRESETS: Preset[] = [
+  p({
+    id: "pluck.string",
+    bus: "sfx",
+    gain: 2.48,
+    group: "pluck",
+    poly: 8,
+    haptic: "light",
+    weight: 0.45,
+    jitterCents: 12,
+    render(rc) {
+      const f = hz(12 + rc.semitones)
+      if (rc.strings) {
+        rc.strings.pluck({
+          when: rc.when,
+          freq: f,
+          velocity: 0.35 + rc.intensity * 0.6,
+          decay: 1.1 + rc.rand() * 0.5,
+          damping: 0.28 - rc.intensity * 0.12,
+          position: 0.14 + rc.rand() * 0.16,
+          pan: rc.range(-0.3, 0.3),
+          gain: 0.75 * rc.level,
+        })
+        // The pick noise is NOT part of the string model and its absence is
+        // exactly why pure Karplus-Strong sounds like a 1983 demo.
+        const t = noiseBurst(rc, {
+          kind: "velvet",
+          freq: 4200,
+          q: 1.8,
+          gain: 0.12 * rc.intensity,
+          decay: 0.01,
+          highpass: 2200,
+          send: 0.15,
+        })
+        return { endsAt: Math.max(rc.when + 1.7, t) }
+      }
+      return { endsAt: fmTone(rc, { freq: f, ratio: 1, index: 3, indexDecay: 0.05, gain: 0.4, decay: 0.9, send: 0.2 }) }
+    },
+  }),
+
+  p({
+    id: "pluck.harp",
+    bus: "sfx",
+    gain: 3.782,
+    group: "pluck",
+    poly: 10,
+    haptic: "light",
+    weight: 0.35,
+    minGap: 0.02,
+    jitterCents: 8,
+    render(rc) {
+      // A rolled chord across the Hijaz scale — one call, four strings, 26 ms
+      // apart. Rolling rather than blocking is what makes it feel played.
+      const base = 12 + rc.semitones
+      let end = rc.when
+      for (let i = 0; i < 4; i++) {
+        const step = HIJAZ[i * 2] ?? 0
+        const at = rc.when + i * (0.022 + rc.rand() * 0.012)
+        if (rc.strings) {
+          rc.strings.pluck({
+            when: at,
+            freq: hz(base + step + 12),
+            velocity: 0.5 - i * 0.06,
+            decay: 1.4,
+            damping: 0.2,
+            position: 0.2,
+            pan: -0.3 + i * 0.2,
+            gain: 0.5 * rc.level,
+          })
+        }
+        end = at + 1.6
+      }
+      return { endsAt: end }
+    },
+  }),
+]
+
+// ---------------------------------------------------------------------------
+// REWARD — the reason a child comes back. Layered, escalating, generous.
+// ---------------------------------------------------------------------------
+
+export const REWARD_PRESETS: Preset[] = [
+  p({
+    id: "reward.bead",
+    bus: "sfx",
+    gain: 1.309,
+    group: "reward",
+    poly: 8,
+    haptic: "light",
+    weight: 0.4,
+    minGap: 0.035,
+    jitterCents: 22,
+    render(rc) {
+      // A small brass bead landing in a bowl. Two detuned FM bells + a tick.
+      const f = 900 * semi(rc.semitones)
+      const a = fmTone(rc, {
+        freq: f,
+        ratio: 3.51,
+        index: 2.2 + rc.intensity * 1.6,
+        indexDecay: 0.045,
+        gain: 0.34,
+        decay: 0.34,
+        spread: 9,
+        pan: rc.range(-0.25, 0.25),
+        send: 0.25,
+      })
+      const b = noiseBurst(rc, { kind: "velvet", freq: 6200, q: 3, gain: 0.13, decay: 0.008, highpass: 2800 })
+      return { endsAt: Math.max(a, b) }
+    },
+  }),
+
+  p({
+    id: "reward.chime",
+    bus: "sfx",
+    gain: 0.165,
+    group: "reward",
+    poly: 6,
+    haptic: "success",
+    weight: 0.6,
+    duck: 0.22,
+    jitterCents: 10,
+    render(rc) {
+      const a = strike(rc, "bell", hz(24 + rc.semitones), 0.6 + rc.intensity * 0.4, { gain: 0.8, pan: -0.15 })
+      const rc2 = { ...rc, when: rc.when + 0.075 } as RenderCtx
+      const b = strike(rc2, "bell", hz(31 + rc.semitones), 0.5 + rc.intensity * 0.4, { gain: 0.65, pan: 0.18 })
+      const air = airTone(rc, hz(36 + rc.semitones), 0.05, 1.1)
+      return { endsAt: Math.max(a, b, air) }
+    },
+  }),
+
+  p({
+    id: "reward.big",
+    bus: "sfx",
+    gain: 0.126,
+    group: "reward",
+    poly: 2,
+    haptic: "success",
+    weight: 1,
+    duck: 0.55,
+    minGap: 0.4,
+    jitterCents: 6,
+    render(rc) {
+      // The big one. Sub + brass gong + rolled harp + a shimmer cloud, ducked
+      // hard so the music gets out of its way. This is the moment the whole
+      // kit exists to make land.
+      const s = subThump(rc, { freq: 44, drop: 10, fall: 0.09, gain: 0.6, decay: 0.5, drive: 0.6 })
+      const g = strike(rc, "brass", hz(rc.semitones), 0.95, { gain: 1, sustain: 1.25 })
+      const g2 = strike({ ...rc, when: rc.when + 0.012 } as RenderCtx, "brass", hz(7 + rc.semitones), 0.7, {
+        gain: 0.6,
+        pan: 0.25,
+        sustain: 1.1,
+      })
+      let end = Math.max(s, g, g2)
+      if (rc.strings) {
+        for (let i = 0; i < 6; i++) {
+          const at = rc.when + 0.06 + i * 0.035
+          rc.strings.pluck({
+            when: at,
+            freq: hz(24 + (HIJAZ[i] ?? 0)),
+            velocity: 0.7 - i * 0.05,
+            decay: 1.6,
+            damping: 0.18,
+            position: 0.18,
+            pan: -0.4 + i * 0.16,
+            gain: 0.5 * rc.level,
+          })
+          end = Math.max(end, at + 1.8)
+        }
+      }
+      const rate = Math.min(rc.tier === "low" ? 0 : rc.tier === "medium" ? 45 : 110, 110)
+      if (rate > 0) {
+        end = Math.max(end, grainCloud(rc, { rate, seconds: 0.9, freq: 4200, spreadSemis: 14, gain: 0.32, send: 0.5, fadeIn: 0.15 }))
+      }
+      const sw = sweep(rc, { from: 380, to: 5200, time: 0.55, q: 2.2, gain: 0.16, swell: 0.6, send: 0.4 })
+      return { endsAt: Math.max(end, sw) }
+    },
+  }),
+
+  p({
+    id: "reward.unlock",
+    bus: "sfx",
+    gain: 0.581,
+    group: "reward",
+    poly: 2,
+    haptic: "success",
+    weight: 0.85,
+    duck: 0.4,
+    jitterCents: 8,
+    render(rc) {
+      // A latch releasing, then light. Mechanism first, then reward — the order
+      // matters; reversed, it reads as a mistake being corrected.
+      const a = strike(rc, "stone", hz(7 + rc.semitones), 0.6, { gain: 0.7 })
+      const b = strike({ ...rc, when: rc.when + 0.04 } as RenderCtx, "bell", hz(19 + rc.semitones), 0.55, { gain: 0.6 })
+      const c = strike({ ...rc, when: rc.when + 0.12 } as RenderCtx, "glass", hz(31 + rc.semitones), 0.6, {
+        gain: 0.55,
+        sustain: 1.3,
+      })
+      const sw = sweep(rc, { from: 600, to: 4800, time: 0.4, q: 3, gain: 0.13, swell: 0.5, send: 0.45 })
+      return { endsAt: Math.max(a, b, c, sw) }
+    },
+  }),
+]
+
+// ---------------------------------------------------------------------------
+// COMBO — the rising ladder. Called with a streak index; the kit owns the
+// musicality so no prototype has to.
+// ---------------------------------------------------------------------------
+
+export const COMBO_PRESET: Preset = p({
+  id: "combo",
+  bus: "sfx",
+  gain: 0.431,
+  group: "combo",
+  poly: 4,
+  haptic: "medium",
+  weight: 0.55,
+  minGap: 0.05,
+  jitterCents: 6,
+  render(rc) {
+    // `semitones` already carries the ladder step (see `combo()` in index.ts).
+    const f = hz(24 + rc.semitones)
+    const bright = Math.min(1, 0.35 + rc.intensity * 0.75)
+    const a = fmTone(rc, {
+      freq: f,
+      ratio: 2.01,
+      index: 1.6 + bright * 3.4,
+      indexDecay: 0.06,
+      gain: 0.36,
+      decay: 0.42,
+      spread: 7,
+      pan: rc.range(-0.2, 0.2),
+      send: 0.3,
+    })
+    const b = strike(rc, "bell", f, 0.35 + bright * 0.5, { gain: 0.45, sustain: 0.8 })
+    const t = noiseBurst(rc, { kind: "velvet", freq: 5600, q: 2.6, gain: 0.1 + bright * 0.08, decay: 0.009, highpass: 2600 })
+    // Above 8 in a row, the ladder starts adding a low octave — the streak
+    // acquires WEIGHT as well as height, which is what stops it sounding shrill.
+    let s = rc.when
+    if (rc.intensity > 0.55) {
+      s = subThump(rc, { freq: 70, drop: 4, gain: 0.18 * rc.intensity, decay: 0.14, drive: 0.4 })
+    }
+    return { endsAt: Math.max(a, b, t, s) }
+  },
+})
+
+// ---------------------------------------------------------------------------
+// FAILURE — interesting, never punishing. ADR-0009 forbids loss; the audio
+// must agree. No buzzer, no descending minor third, no "wah wah".
+// ---------------------------------------------------------------------------
+
+export const FAIL_PRESETS: Preset[] = [
+  p({
+    id: "fail.soft",
+    bus: "sfx",
+    gain: 0.792,
+    group: "fail",
+    poly: 2,
+    haptic: "warning",
+    weight: 0.4,
+    duck: 0.15,
+    jitterCents: 20,
+    render(rc) {
+      // A wooden bead dropped on cloth. Dull, close, faintly comic — the sound
+      // of "not that one", not the sound of "you are bad".
+      const t = noiseBurst(rc, { kind: "brown", freq: 420, q: 0.8, gain: 0.3, decay: 0.06, send: 0.06 })
+      const a = strike(rc, "wood", hz(-2 + rc.semitones), 0.4, { gain: 0.7, damp: 0.35 })
+      const b = strike({ ...rc, when: rc.when + 0.085 } as RenderCtx, "wood", hz(-5 + rc.semitones), 0.25, {
+        gain: 0.4,
+        damp: 0.5,
+      })
+      return { endsAt: Math.max(t, a, b) }
+    },
+  }),
+
+  p({
+    id: "fail.pot",
+    bus: "sfx",
+    gain: 0.507,
+    group: "fail",
+    poly: 2,
+    haptic: "warning",
+    weight: 0.5,
+    duck: 0.2,
+    jitterCents: 25,
+    render(rc) {
+      // A copper pot wobbling on a counter. Genuinely funny, and the wobble
+      // (three strikes at shrinking intervals) is why.
+      let end = rc.when
+      const times = [0, 0.11, 0.185, 0.235, 0.27]
+      for (let i = 0; i < times.length; i++) {
+        const e = strike({ ...rc, when: rc.when + times[i] } as RenderCtx, "pot", hz(3 + rc.semitones), 0.45 - i * 0.08, {
+          gain: 0.7 - i * 0.12,
+          pan: (i % 2 === 0 ? -1 : 1) * 0.12,
+          sustain: 0.6,
+        })
+        end = Math.max(end, e)
+      }
+      return { endsAt: end }
+    },
+  }),
+
+  p({
+    id: "fail.retry",
+    bus: "sfx",
+    gain: 2.948,
+    group: "fail",
+    poly: 2,
+    haptic: "light",
+    weight: 0.35,
+    jitterCents: 15,
+    render(rc) {
+      // Two notes DOWN then one back UP, resolving to the fifth. It ends open
+      // and consonant, which is the audio equivalent of "go on, again".
+      const steps = [7, 3, 5]
+      let end = rc.when
+      for (let i = 0; i < steps.length; i++) {
+        const at = rc.when + i * 0.09
+        const e = fmTone({ ...rc, when: at } as RenderCtx, {
+          freq: hz(12 + steps[i] + rc.semitones),
+          ratio: 1.0,
+          index: 1.1,
+          indexDecay: 0.05,
+          gain: 0.26,
+          decay: 0.24,
+          pan: -0.15 + i * 0.15,
+          send: 0.25,
+        })
+        end = Math.max(end, e)
+      }
+      return { endsAt: end }
+    },
+  }),
+
+  p({
+    id: "fail.lampOut",
+    bus: "sfx",
+    gain: 0.496,
+    group: "fail",
+    poly: 1,
+    haptic: "warning",
+    weight: 0.8,
+    duck: 0.35,
+    minGap: 0.5,
+    jitterCents: 10,
+    render(rc) {
+      // The lamp burning out — the business model's emotional beat. A glass
+      // ring being damped away, a falling filtered sweep, one soft thud. It has
+      // to feel like a LOSS OF WARMTH, never like a penalty klaxon.
+      const g = strike(rc, "glass", hz(19 + rc.semitones), 0.5, { gain: 0.55, sustain: 0.45, damp: 0.25 })
+      const sw = sweep(rc, { from: 2600, to: 240, time: 0.7, q: 2.4, gain: 0.2, kind: "pink", send: 0.4 })
+      const th = subThump(rc, { freq: 52, drop: 4, fall: 0.12, gain: 0.28, decay: 0.35, drive: 0.3 })
+      const last = strike({ ...rc, when: rc.when + 0.62 } as RenderCtx, "wood", hz(-7 + rc.semitones), 0.3, {
+        gain: 0.5,
+        damp: 0.4,
+      })
+      return { endsAt: Math.max(g, sw, th, last) }
+    },
+  }),
+]
+
+// ---------------------------------------------------------------------------
+// MOTION — transitions. Cheap, and they carry an enormous amount of polish.
+// ---------------------------------------------------------------------------
+
+export const MOTION_PRESETS: Preset[] = [
+  p({
+    id: "motion.whoosh",
+    bus: "sfx",
+    gain: 2.1,
+    group: "motion",
+    poly: 3,
+    haptic: "none",
+    weight: 0.3,
+    jitterCents: 60,
+    render(rc) {
+      const dir = rc.rand() < 0.5 ? 1 : -1
+      const a = sweep(rc, {
+        from: dir > 0 ? 420 : 3600,
+        to: dir > 0 ? 3600 : 420,
+        time: 0.26 + rc.rand() * 0.1,
+        q: 1.6,
+        gain: 0.75 * (0.5 + rc.intensity * 0.5),
+        kind: "pink",
+        pan: -dir * 0.4,
+        send: 0.3,
+      })
+      return { endsAt: a }
+    },
+  }),
+
+  p({
+    id: "motion.arrive",
+    bus: "sfx",
+    gain: 0.269,
+    group: "motion",
+    poly: 2,
+    haptic: "medium",
+    weight: 0.45,
+    duck: 0.18,
+    render(rc) {
+      const sw = sweep(rc, { from: 300, to: 2600, time: 0.34, q: 2, gain: 0.2, swell: 0.8, send: 0.35 })
+      const hit = strike({ ...rc, when: rc.when + 0.3 } as RenderCtx, "tile", hz(12 + rc.semitones), 0.6, { gain: 0.8 })
+      const s = subThump({ ...rc, when: rc.when + 0.3 } as RenderCtx, {
+        freq: 60,
+        drop: 6,
+        gain: 0.3,
+        decay: 0.18,
+        drive: 0.4,
+      })
+      return { endsAt: Math.max(sw, hit, s) }
+    },
+  }),
+
+  p({
+    id: "motion.pop",
+    bus: "ui",
+    gain: 4.098,
+    group: "motion",
+    poly: 5,
+    haptic: "light",
+    weight: 0.25,
+    jitterCents: 70,
+    render(rc) {
+      // Pitch-dropping sine + a tick. The classic "bubble", but tuned to the
+      // scale so a run of them is a melody rather than a sequence of farts.
+      const ctx = rc.ctx
+      const osc = ctx.createOscillator()
+      osc.type = "sine"
+      const f = hz(24 + rc.semitones)
+      osc.frequency.setValueAtTime(f * 2.2, rc.when)
+      osc.frequency.exponentialRampToValueAtTime(f, rc.when + 0.055)
+      const g = ctx.createGain()
+      const end = percEnv(g.gain, rc.when, 0.3 * (0.5 + rc.intensity * 0.5), 0.003, 0.09)
+      osc.connect(g)
+      const pp = pan(rc, rc.range(-0.3, 0.3))
+      if (pp) {
+        g.connect(pp)
+        route(rc, pp, 0.15)
+      } else route(rc, g, 0.15)
+      osc.start(rc.when)
+      osc.stop(end + 0.02)
+      const t = noiseBurst(rc, { kind: "velvet", freq: 4800, q: 2, gain: 0.09, decay: 0.007, highpass: 2400 })
+      return { endsAt: Math.max(end, t) }
+    },
+  }),
+]
+
+export const ALL_PRESETS: Preset[] = [
+  ...UI_PRESETS,
+  ...IMPACT_PRESETS,
+  ...PLUCK_PRESETS,
+  ...REWARD_PRESETS,
+  ...FAIL_PRESETS,
+  ...MOTION_PRESETS,
+  COMBO_PRESET,
+]
+
+export type PresetId =
+  | "ui.tap"
+  | "ui.chunk"
+  | "ui.select"
+  | "ui.back"
+  | "ui.toggle"
+  | "impact.brass"
+  | "impact.tile"
+  | "impact.stone"
+  | "impact.glass"
+  | "impact.drum"
+  | "impact.pot"
+  | "pluck.string"
+  | "pluck.harp"
+  | "reward.bead"
+  | "reward.chime"
+  | "reward.big"
+  | "reward.unlock"
+  | "fail.soft"
+  | "fail.pot"
+  | "fail.retry"
+  | "fail.lampOut"
+  | "motion.whoosh"
+  | "motion.arrive"
+  | "motion.pop"
+  | "combo"

--- a/dynawalla/foundations/audio/src/presets/voices.ts
+++ b/dynawalla/foundations/audio/src/presets/voices.ts
@@ -1,0 +1,393 @@
+/**
+ * Synthesis primitives. Presets are compositions of these; nothing here is a
+ * preset itself.
+ *
+ * THE LAYERING RECIPE — this is the whole difference between "beepy" and
+ * "premium", and it is not subtle once you hear it:
+ *
+ *    TRANSIENT (0-15 ms)  what the ear uses to identify the material.
+ *                         Noise through a tight bandpass. Almost inaudible
+ *                         alone, and removing it makes any sound feel fake.
+ *    BODY      (15-300 ms) the pitch and the character. Modal, FM, or both.
+ *    TAIL      (0.2-3 s)   the space it happened in. A reverb send, not a
+ *                          longer envelope — a long envelope is a synth pad,
+ *                          a tail is a room.
+ *    SUB       (optional)  20-90 Hz thump for weight. On a tablet speaker it
+ *                          is felt as loudness, not heard as bass, which is
+ *                          exactly why it works.
+ *
+ * Every one-shot returns the context time it is silent at, so the engine can
+ * reclaim its budget without an `onended` closure per voice.
+ */
+
+import { glide, percEnv, thock } from "../dsp/env.ts"
+import type { RenderCtx } from "../types.ts"
+
+/** Equal-power stereo placement. StereoPannerNode, never PannerNode: the 3D
+ *  panner runs an HRTF and costs ~20x more for a result nobody asked for. */
+export const pan = (rc: RenderCtx, amount: number): StereoPannerNode | null => {
+  const ctx = rc.ctx
+  if (!ctx.createStereoPanner) return null
+  const p = ctx.createStereoPanner()
+  p.pan.value = Math.max(-1, Math.min(1, amount))
+  return p
+}
+
+/**
+ * Connect `node` to the voice output, and (if reverb is on) to this bus's send.
+ *
+ * The send taps the BUS, not the voice's gain node, so it is scaled by
+ * `rc.level` here — otherwise a quiet UI tick would arrive at the reverb as
+ * loud as a gong and the room would breathe on every button press.
+ */
+export const route = (rc: RenderCtx, node: AudioNode, sendAmount = 0): void => {
+  node.connect(rc.out)
+  if (rc.send && sendAmount > 0) {
+    const g = rc.ctx.createGain()
+    g.gain.value = sendAmount * rc.level
+    node.connect(g)
+    g.connect(rc.send)
+  }
+}
+
+export interface NoiseOpts {
+  kind?: "white" | "pink" | "brown" | "velvet"
+  /** Bandpass centre in Hz. */
+  freq: number
+  q?: number
+  /** Sweep the bandpass down (or up) to this frequency over `sweep` seconds. */
+  freqTo?: number
+  sweep?: number
+  gain: number
+  attack?: number
+  decay: number
+  pan?: number
+  send?: number
+  /** Highpass to keep a transient from muddying the low end. */
+  highpass?: number
+}
+
+/**
+ * A filtered noise burst — the transient layer, and on its own a perfectly good
+ * shaker, breath, cloth or scrape.
+ *
+ * Reading the shared noise buffer at a RANDOM OFFSET is the single cheapest
+ * anti-fatigue trick in the kit: identical parameters produce a different
+ * waveform every time, so 500 taps never phase-align into a machine gun.
+ */
+export const noiseBurst = (rc: RenderCtx, o: NoiseOpts): number => {
+  const ctx = rc.ctx
+  const t = rc.tables
+  const buf =
+    o.kind === "pink" ? t.pink() : o.kind === "brown" ? t.brown() : o.kind === "velvet" ? t.velvet() : t.white()
+  const src = ctx.createBufferSource()
+  src.buffer = buf
+  src.loop = true
+  // Random read offset + slight rate detune: two independent variation axes.
+  src.playbackRate.value = 0.88 + rc.rand() * 0.24
+
+  const bp = ctx.createBiquadFilter()
+  bp.type = "bandpass"
+  bp.Q.value = o.q ?? 1.2
+  if (o.freqTo && o.sweep) {
+    glide(bp.frequency, rc.when, o.freq, o.freqTo, o.sweep)
+  } else {
+    bp.frequency.value = o.freq
+  }
+
+  let head: AudioNode = bp
+  if (o.highpass) {
+    const hp = ctx.createBiquadFilter()
+    hp.type = "highpass"
+    hp.frequency.value = o.highpass
+    bp.connect(hp)
+    head = hp
+  }
+
+  const g = ctx.createGain()
+  const end = percEnv(g.gain, rc.when, o.gain, o.attack ?? 0.0008, o.decay)
+  src.connect(bp)
+  head.connect(g)
+
+  const p = pan(rc, o.pan ?? 0)
+  if (p) {
+    g.connect(p)
+    route(rc, p, o.send ?? 0)
+  } else {
+    route(rc, g, o.send ?? 0)
+  }
+
+  src.start(rc.when, rc.rand() * 1.5)
+  src.stop(end + 0.02)
+  return end
+}
+
+export interface FmOpts {
+  /** Carrier frequency in Hz. */
+  freq: number
+  /** Modulator:carrier ratio. Integer = harmonic (mallet, bell-ish organ);
+   *  non-integer = inharmonic (bell, metal, glass). This one number is most of
+   *  the timbre. */
+  ratio: number
+  /** Peak modulation index. 0 = pure sine; 3-8 = bell; >12 = noise-adjacent. */
+  index: number
+  /** Index decay in seconds — the "hammer" of an FM tone. Always shorter than
+   *  the amplitude decay, or it sounds like a synthesiser rather than a bell. */
+  indexDecay?: number
+  gain: number
+  attack?: number
+  decay: number
+  /** Detune a second carrier by this many cents for chorus/beating. */
+  spread?: number
+  pan?: number
+  send?: number
+  /** Drop the carrier pitch by this many semitones over `pitchFall` seconds. */
+  pitchDrop?: number
+  pitchFall?: number
+  type?: OscillatorType
+}
+
+/**
+ * Two-operator FM. Cheap, enormously expressive, and the correct tool for
+ * anything metallic and pitched — coins, beads, bells, chimes.
+ */
+export const fmTone = (rc: RenderCtx, o: FmOpts): number => {
+  const ctx = rc.ctx
+  const car = ctx.createOscillator()
+  car.type = o.type ?? "sine"
+  const mod = ctx.createOscillator()
+  mod.type = "sine"
+  const modGain = ctx.createGain()
+
+  const f = o.freq
+  car.frequency.value = f
+  mod.frequency.value = f * o.ratio
+
+  if (o.pitchDrop && o.pitchFall) {
+    thock(car.frequency, rc.when, f * Math.pow(2, o.pitchDrop / 12), f, o.pitchFall)
+    thock(mod.frequency, rc.when, f * o.ratio * Math.pow(2, o.pitchDrop / 12), f * o.ratio, o.pitchFall)
+  }
+
+  // Modulation index in Hz of deviation = index * modulator frequency.
+  const peakDev = o.index * f * o.ratio
+  const idxDecay = o.indexDecay ?? Math.min(o.decay * 0.45, 0.12)
+  modGain.gain.setValueAtTime(peakDev, rc.when)
+  modGain.gain.setTargetAtTime(peakDev * 0.02, rc.when, idxDecay / 3)
+  mod.connect(modGain)
+  modGain.connect(car.frequency)
+
+  const g = ctx.createGain()
+  const end = percEnv(g.gain, rc.when, o.gain, o.attack ?? 0.002, o.decay)
+  car.connect(g)
+
+  let second: OscillatorNode | null = null
+  if (o.spread) {
+    second = ctx.createOscillator()
+    second.type = car.type
+    second.frequency.value = f * Math.pow(2, o.spread / 1200)
+    modGain.connect(second.frequency)
+    second.connect(g)
+  }
+
+  const p = pan(rc, o.pan ?? 0)
+  if (p) {
+    g.connect(p)
+    route(rc, p, o.send ?? 0)
+  } else {
+    route(rc, g, o.send ?? 0)
+  }
+
+  car.start(rc.when)
+  mod.start(rc.when)
+  second?.start(rc.when)
+  car.stop(end + 0.02)
+  mod.stop(end + 0.02)
+  second?.stop(end + 0.02)
+  return end
+}
+
+export interface SubOpts {
+  freq: number
+  /** Semitones the pitch falls. A sub with no drop is a test tone. */
+  drop?: number
+  fall?: number
+  gain: number
+  decay: number
+  /** Soft-saturate for audibility on a speaker with no low end. */
+  drive?: number
+}
+
+/**
+ * Sub thump. On a tablet speaker you cannot hear 45 Hz — but you can hear its
+ * harmonics, so we saturate it. The result reads as WEIGHT on a phone and as
+ * actual bass on headphones, which is exactly the trade we want.
+ */
+export const subThump = (rc: RenderCtx, o: SubOpts): number => {
+  const ctx = rc.ctx
+  const osc = ctx.createOscillator()
+  osc.type = "sine"
+  thock(osc.frequency, rc.when, o.freq * Math.pow(2, (o.drop ?? 8) / 12), o.freq, o.fall ?? 0.06)
+  const g = ctx.createGain()
+  const end = percEnv(g.gain, rc.when, o.gain, 0.002, o.decay)
+  osc.connect(g)
+  let tailNode: AudioNode = g
+  if (o.drive && o.drive > 0) {
+    const ws = ctx.createWaveShaper()
+    ws.curve = rc.tables.saturation(o.drive)
+    ws.oversample = "2x"
+    g.connect(ws)
+    tailNode = ws
+  }
+  route(rc, tailNode, 0)
+  osc.start(rc.when)
+  osc.stop(end + 0.02)
+  return end
+}
+
+export interface SweepOpts {
+  from: number
+  to: number
+  time: number
+  q?: number
+  gain: number
+  kind?: "white" | "pink" | "brown"
+  pan?: number
+  send?: number
+  /** Curve the amplitude: 0 = flat, 1 = swells into the end (an arrival). */
+  swell?: number
+}
+
+/** Filtered-noise sweep — whooshes, arrivals, transitions. */
+export const sweep = (rc: RenderCtx, o: SweepOpts): number => {
+  const ctx = rc.ctx
+  const src = ctx.createBufferSource()
+  src.buffer = o.kind === "white" ? rc.tables.white() : o.kind === "brown" ? rc.tables.brown() : rc.tables.pink()
+  src.loop = true
+  const bp = ctx.createBiquadFilter()
+  bp.type = "bandpass"
+  bp.Q.value = o.q ?? 3.2
+  glide(bp.frequency, rc.when, o.from, o.to, o.time)
+
+  const g = ctx.createGain()
+  const swellAmt = o.swell ?? 0
+  g.gain.setValueAtTime(0, rc.when)
+  g.gain.linearRampToValueAtTime(o.gain * (swellAmt > 0 ? 0.35 : 1), rc.when + o.time * 0.12)
+  if (swellAmt > 0) {
+    g.gain.linearRampToValueAtTime(o.gain, rc.when + o.time * (0.75 + swellAmt * 0.2))
+  }
+  g.gain.setTargetAtTime(0, rc.when + o.time * 0.82, o.time / 8)
+  const end = rc.when + o.time * 1.25
+  g.gain.setValueAtTime(0, end)
+
+  src.connect(bp)
+  bp.connect(g)
+  const p = pan(rc, o.pan ?? 0)
+  if (p) {
+    g.connect(p)
+    route(rc, p, o.send ?? 0.2)
+  } else {
+    route(rc, g, o.send ?? 0.2)
+  }
+  src.start(rc.when, rc.rand() * 1.5)
+  src.stop(end + 0.02)
+  return end
+}
+
+export interface GrainOpts {
+  /** Grains per second. Clamped by tier. */
+  rate: number
+  seconds: number
+  /** Centre pitch in Hz for the grain's bandpass. */
+  freq: number
+  /** Semitone spread of grain pitches — the shimmer. */
+  spreadSemis: number
+  gain: number
+  send?: number
+  /** Scale the whole cloud in over this long. */
+  fadeIn?: number
+}
+
+/** Grain band centres, matching `SharedTables.grain`. */
+const GRAIN_BANDS = [1400, 2000, 2800, 3900, 5400, 7200, 9600, 12800]
+
+const nearestBand = (hz: number): number => {
+  let best = 0
+  let bestD = Infinity
+  for (let i = 0; i < GRAIN_BANDS.length; i++) {
+    const d = Math.abs(Math.log2(GRAIN_BANDS[i] / hz))
+    if (d < bestD) {
+      bestD = d
+      best = i
+    }
+  }
+  return best
+}
+
+/**
+ * Granular shimmer. Dozens of tiny windowed grains at scattered pitches and
+ * pans — what makes a big reward feel like a cascade of glass beads instead of
+ * one loud noise.
+ *
+ * ONE NODE PER GRAIN. Band-pass, window and amplitude are all baked into the
+ * pre-rendered grain buffers (`tables.grain`), pitch comes from `playbackRate`,
+ * and panning uses a fixed set of FIVE shared panners rather than one per
+ * grain. The obvious four-nodes-per-grain version measured 49.3% of a core at
+ * 140 grains/s; this one measures a fraction of that for an identical sound.
+ * The lesson generalises: in Web Audio you are usually paying for the GRAPH,
+ * not for the arithmetic.
+ */
+export const grainCloud = (rc: RenderCtx, o: GrainOpts): number => {
+  const ctx = rc.ctx
+  const count = Math.max(1, Math.round(o.rate * o.seconds))
+  const out = ctx.createGain()
+  out.gain.value = o.gain
+  route(rc, out, o.send ?? 0.35)
+
+  // Five static pan positions. Beyond about five the ear cannot place them
+  // anyway, and each one is a node that lives for the whole cloud rather than
+  // for 60 ms.
+  const lanes: AudioNode[] = []
+  for (const p of [-0.8, -0.4, 0, 0.4, 0.8]) {
+    const sp = pan(rc, p)
+    if (sp) {
+      sp.connect(out)
+      lanes.push(sp)
+    }
+  }
+  if (lanes.length === 0) lanes.push(out)
+
+  const band = nearestBand(o.freq)
+  for (let i = 0; i < count; i++) {
+    const frac = i / count
+    const at = rc.when + frac * o.seconds + rc.rand() * (o.seconds / count)
+    const src = ctx.createBufferSource()
+    const ampIdx = Math.min(3, Math.floor(rc.rand() * 4))
+    const bandIdx = Math.max(0, Math.min(GRAIN_BANDS.length - 1, band + (rc.rand() < 0.5 ? 0 : 1) - (rc.rand() < 0.3 ? 1 : 0)))
+    src.buffer = rc.tables.grain(bandIdx, o.fadeIn && frac < 0.15 ? 0 : ampIdx)
+    // Pitch scatter via playback rate: also shortens/lengthens the grain, which
+    // is exactly what a real granulator does and it sounds better for it.
+    src.playbackRate.value = Math.pow(2, ((rc.rand() * 2 - 1) * o.spreadSemis) / 12)
+    src.connect(lanes[i % lanes.length])
+    src.start(at)
+  }
+  return rc.when + o.seconds + 0.3
+}
+
+/**
+ * A pitched "air" layer — a very quiet sine an octave above the body, with a
+ * slow attack. Adds perceived quality for almost no cost; it is the thing
+ * expensive sound design has that cheap sound design does not.
+ */
+export const airTone = (rc: RenderCtx, freq: number, gain: number, decay: number): number => {
+  const ctx = rc.ctx
+  const o = ctx.createOscillator()
+  o.type = "sine"
+  o.frequency.value = freq
+  const g = ctx.createGain()
+  const end = percEnv(g.gain, rc.when, gain, 0.012, decay)
+  o.connect(g)
+  route(rc, g, 0.4)
+  o.start(rc.when)
+  o.stop(end + 0.02)
+  return end
+}

--- a/dynawalla/foundations/audio/src/rng.ts
+++ b/dynawalla/foundations/audio/src/rng.ts
@@ -1,0 +1,70 @@
+/**
+ * Deterministic, allocation-free randomness.
+ *
+ * Why not Math.random: a sound heard 500 times must vary, but a bug report must
+ * reproduce. Every preset draws from a seeded stream; pass `seed` to `play()`
+ * and you get byte-identical output. Also: Math.random on some WebViews is a
+ * surprisingly hot call under a rain of grains — mulberry32 is ~3ns and inlines.
+ */
+
+/** mulberry32 — 32-bit state, excellent distribution, one multiply-heavy line. */
+export const mulberry32 = (seed: number): (() => number) => {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/** Cheap string hash for stable per-preset seeds. */
+export const hashString = (s: string): number => {
+  let h = 2166136261 >>> 0
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i)
+    h = Math.imul(h, 16777619)
+  }
+  return h >>> 0
+}
+
+/** Semitones → frequency ratio. */
+export const semi = (n: number): number => Math.pow(2, n / 12)
+
+/** Cents → frequency ratio. */
+export const cents = (n: number): number => Math.pow(2, n / 1200)
+
+/** MIDI note → Hz (A4 = 69 = 440Hz). */
+export const midiHz = (m: number): number => 440 * Math.pow(2, (m - 69) / 12)
+
+/** dB → linear gain. */
+export const dbGain = (db: number): number => Math.pow(10, db / 20)
+
+export const clamp = (v: number, lo: number, hi: number): number =>
+  v < lo ? lo : v > hi ? hi : v
+
+/** Equal-power crossfade curve value for x in 0..1. */
+export const equalPower = (x: number): number => Math.sin((x * Math.PI) / 2)
+
+/**
+ * Anti-fatigue variation shaper.
+ *
+ * A flat ±30 cent uniform jitter still fatigues, because uniform noise clusters.
+ * This pushes samples away from the centre (a soft bimodal shape), which reads
+ * as "a different strike" rather than "the same strike, slightly detuned".
+ */
+export const spread = (r: number): number => {
+  const x = r * 2 - 1
+  return Math.sign(x) * Math.pow(Math.abs(x), 0.6)
+}
+
+/**
+ * Round-robin without immediate repeats: returns an index in [0,n) that is
+ * never the same as `last`. This is the single highest-value anti-fatigue trick
+ * — human ears detect an exact repeat far more readily than a pitch shift.
+ */
+export const rotate = (r: number, n: number, last: number): number => {
+  if (n <= 1) return 0
+  const i = Math.floor(r * (n - 1))
+  return i >= last ? i + 1 : i
+}

--- a/dynawalla/foundations/audio/src/types.ts
+++ b/dynawalla/foundations/audio/src/types.ts
@@ -1,0 +1,191 @@
+import type { Material } from "./dsp/materials.ts"
+
+/**
+ * Dynawalla audio foundation — public types.
+ *
+ * Everything here is synthesized at runtime. No sample files, ever. A prototype
+ * author touches `play()`, `music`, `ambience` and `onCue`; the rest is the kit
+ * keeping 60fps and not sounding like a 1980s calculator.
+ */
+
+/** Quality tier. Drives voice caps, reverb, partial counts, grain density. */
+export type Tier = "ultra" | "high" | "medium" | "low"
+
+/** Mix destination. Ducking, caps and limiting are per-bus. */
+export type BusName = "sfx" | "ui" | "music" | "ambience"
+
+/**
+ * Haptic intent carried by a cue. The kit never calls a haptics plugin itself —
+ * the host maps this onto `tauri-plugin-haptics` so a browser prototype and a
+ * device build share one call site.
+ */
+export type HapticHint = "none" | "light" | "medium" | "heavy" | "success" | "warning"
+
+/**
+ * A cue is emitted for EVERY `play()` — including when audio is muted or the
+ * device is silenced. That is deliberate: wire your visuals to cues and the
+ * prototype is automatically accessible, because sound never carries
+ * information alone.
+ */
+export interface Cue {
+  /** Preset id that fired. */
+  readonly id: string
+  /** AudioContext time the sound starts (already includes any scheduling offset). */
+  readonly when: number
+  /** 0..1 loudness/impact the caller asked for. */
+  readonly intensity: number
+  /** Semitone offset actually used, after ladder + variation. */
+  readonly semitones: number
+  /** Preset's haptic intent. */
+  readonly haptic: HapticHint
+  /** Rough visual weight 0..1 — how big a flash/shake this deserves. */
+  readonly weight: number
+  /** True when the sound was NOT rendered (muted, disabled, or voice-capped). */
+  readonly silent: boolean
+}
+
+/** Options accepted by `play()`. Every field is optional — one-liners are the point. */
+export interface PlayOptions {
+  /** 0..1. Drives level, brightness and (for some presets) the layer count. */
+  intensity?: number
+  /** Pitch offset in semitones, added to the preset's own pitch logic. */
+  semitones?: number
+  /** Stereo position -1..1. Default is a small deterministic spread per preset. */
+  pan?: number
+  /** Seconds from now. Use for chords/rolls; sub-millisecond accurate. */
+  delay?: number
+  /** Force this preset to duck the music by this much (0..1). */
+  duck?: number
+  /** Deterministic variation seed — same seed, same sound. Omit for lively random. */
+  seed?: number
+}
+
+/** A voice returned by presets that can be held or stopped early. */
+export interface VoiceHandle {
+  /** Release the voice now (fades over its own release time). */
+  stop(at?: number): void
+  /** Context time this voice can be reclaimed. */
+  readonly endsAt: number
+}
+
+/** What a preset gets when it builds a sound. */
+export interface RenderCtx {
+  readonly ctx: BaseAudioContext
+  /** Where this voice should connect. Already bus- and tier-correct. */
+  readonly out: AudioNode
+  /** Pre-fader reverb send for this bus, or null when reverb is off (low tier). */
+  readonly send: AudioNode | null
+  readonly when: number
+  readonly intensity: number
+  /** Total pitch offset in semitones (caller + ladder + variation). */
+  readonly semitones: number
+  readonly tier: Tier
+  /** Deterministic per-trigger randomness. Always use this, never Math.random. */
+  rand(): number
+  /** Uniform in [lo,hi). */
+  range(lo: number, hi: number): number
+  /** Shared, lazily built noise buffers / curves / waves for this context. */
+  readonly tables: SharedTables
+  /** Polyphonic Karplus-Strong string bank, when the worklet loaded. */
+  readonly strings: StringBank | null
+  /** Polyphonic modal bank, when the worklet loaded. */
+  readonly modal: ModalVoiceBank | null
+  /**
+   * The preset's own level, already applied to `out` by a per-voice gain node.
+   * Presets do not need to multiply by it — it is here so a voice's reverb
+   * SEND can be scaled to match (the send taps the bus, not the voice gain).
+   */
+  readonly level: number
+}
+
+/** The struck-object bank. See dsp/banks.ts. */
+export interface ModalVoiceBank {
+  strike(opts: {
+    when: number
+    material: Material
+    freq: number
+    velocity: number
+    damp?: number
+    sustain?: number
+    modes?: number
+    pan?: number
+    gain?: number
+    rand?: () => number
+  }): void
+}
+
+/** Result of building one sound. */
+export interface RenderResult {
+  /** Context time by which the voice is inaudible and its nodes are collectable. */
+  endsAt: number
+  /** Optional early-release hook for sustained voices. */
+  release?(at: number): void
+}
+
+/** A preset: the unit a prototype author names. */
+export interface Preset {
+  readonly id: string
+  readonly bus: BusName
+  /** Base gain 0..1 before intensity. Presets are loudness-matched by ear + LUFS. */
+  readonly gain: number
+  /** Voice budget category — presets sharing a group steal from each other. */
+  readonly group?: string
+  /** Max simultaneous voices of this preset. Default from its group. */
+  readonly poly?: number
+  readonly haptic?: HapticHint
+  /** Visual weight for cue consumers. */
+  readonly weight?: number
+  /** How much this sound ducks music/ambience (0..1). */
+  readonly duck?: number
+  /** Minimum gap between retriggers, seconds. Stops machine-gun phase stacking. */
+  readonly minGap?: number
+  /** Per-trigger pitch jitter in cents (± this). Default 30. */
+  readonly jitterCents?: number
+  render(rc: RenderCtx): RenderResult
+}
+
+/** Lazily built, shared-per-context DSP tables. Built once, never per voice. */
+export interface SharedTables {
+  white(): AudioBuffer
+  pink(): AudioBuffer
+  brown(): AudioBuffer
+  /** Sparse impulse ("velvet") noise — cheap, crisp transients with no low rumble. */
+  velvet(): AudioBuffer
+  /** Soft-saturation curve for warmth (odd-harmonic, no aliasing splatter). */
+  saturation(amount: number): Float32Array<ArrayBuffer>
+  /** Hard-knee safety clipper used at the master. */
+  safetyClip(): Float32Array<ArrayBuffer>
+  /** Procedurally generated reverb impulse. */
+  impulse(kind: "tile" | "courtyard" | "plate", seconds: number): AudioBuffer
+  /**
+   * A pre-baked granular grain: band index 0-7 (1.4 kHz -> 12.8 kHz), amplitude
+   * index 0-3. Band-passed, Hann-windowed and pre-scaled, so playing one costs
+   * exactly one AudioBufferSourceNode and nothing else.
+   */
+  grain(band: number, amp: number): AudioBuffer
+}
+
+/** Polyphonic Karplus-Strong bank running in an AudioWorklet. */
+export interface StringBank {
+  readonly node: AudioNode
+  /**
+   * Pluck a string. Sample-accurate: `when` is an AudioContext time and the
+   * worklet lands the excitation on the exact frame.
+   */
+  pluck(opts: {
+    when: number
+    freq: number
+    /** 0..1 — how hard. Drives excitation brightness and level. */
+    velocity: number
+    /** Decay time to -60dB, seconds. */
+    decay: number
+    /** 0..1 — 0 is a bright wire, 1 is a felt-muted thump. */
+    damping: number
+    /** 0..0.5 — pick position along the string; changes which harmonics survive. */
+    position?: number
+    /** -1..1 */
+    pan?: number
+    gain?: number
+  }): void
+  dispose(): void
+}

--- a/dynawalla/foundations/audio/src/worklets/source.ts
+++ b/dynawalla/foundations/audio/src/worklets/source.ts
@@ -1,0 +1,440 @@
+/**
+ * The Dynawalla AudioWorklet processors, as source text.
+ *
+ * WHY A WORKLET AT ALL — the native node graph is fast C++ and we use it for
+ * almost everything. Two things it genuinely cannot do:
+ *
+ *  1. **Karplus-Strong above ~375 Hz.** A feedback loop built from DelayNode is
+ *     clamped by the spec to a minimum delay of one render quantum (128
+ *     samples) because the graph has a cycle. At 48 kHz that caps the pitch at
+ *     48000/128 = 375 Hz. Every plucked string in a bazaar lives above that.
+ *     Measured, not assumed — see `measure/` (native loop asked for 440 Hz and
+ *     produced 375 Hz).
+ *  2. **Exact modal decay.** A BiquadFilter bandpass rings, but its decay is a
+ *     side effect of Q, it is single-precision, and it goes unstable at the Q
+ *     values a 2-second brass ring needs. A 2-pole resonator in f64 gives you
+ *     T60 as a direct parameter and is stable anywhere.
+ *
+ * Both processors are POLYPHONIC and MESSAGE-SCHEDULED: one node, N voices,
+ * events carrying an AudioContext timestamp that is resolved to an exact frame
+ * offset inside `process()`. That means (a) no AudioWorkletNode churn per
+ * sound — node construction is the expensive part — and (b) sample-accurate
+ * onsets, which `port.postMessage` alone can never give you.
+ *
+ * Kept as a string so the kit has no build step and no asset to lose. The
+ * loader turns it into a Blob URL; `tools/emit-worklet.mjs` writes the byte-
+ * identical `.js` for hosts whose CSP forbids `blob:` scripts.
+ */
+
+export const WORKLET_SOURCE = String.raw`
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Shared: sample-accurate event queue.
+// ---------------------------------------------------------------------------
+// currentTime in the worklet global scope is the time of the FIRST frame of the
+// block about to be rendered. An event at time 'when' therefore lands at frame
+// round((when - currentTime) * sampleRate). Events in the past land at frame 0
+// (a late trigger should still fire, just not sample-accurately). Events beyond
+// this block stay queued.
+// 'out' is a PREALLOCATED array; we return how many slots are live. Nothing in
+// here may allocate: this runs on the audio render thread, where a GC pause is
+// a click in everyone's ears.
+function drain(queue, out) {
+  const base = currentTime;
+  let n = 0;
+  for (let i = queue.length - 1; i >= 0; i--) {
+    const ev = queue[i];
+    let f = Math.round((ev.when - base) * sampleRate);
+    if (f < 128) {
+      if (f < 0) f = 0;
+      ev._f = f;
+      if (n < out.length) out[n++] = ev;
+      queue.splice(i, 1);
+    }
+  }
+  // Insertion sort: n is 0-3 in practice and this allocates nothing, unlike
+  // Array.prototype.sort with a comparator.
+  for (let i = 1; i < n; i++) {
+    const ev = out[i];
+    let j = i - 1;
+    while (j >= 0 && out[j]._f > ev._f) { out[j + 1] = out[j]; j--; }
+    out[j + 1] = ev;
+  }
+  return n;
+}
+
+// ---------------------------------------------------------------------------
+// dw-string — polyphonic Karplus-Strong (extended: damping, pick position,
+// per-note decay, stereo placement).
+// ---------------------------------------------------------------------------
+const MAX_STRING_VOICES = 24;
+const MIN_FREQ = 40; // -> delay line length
+
+function StringVoice(sr) {
+  this.buf = new Float32Array(Math.ceil(sr / MIN_FREQ) + 8);
+  this.idx = 0;
+  this.len = 0;      // fractional delay length in samples
+  this.gain = 0;     // output gain
+  this.loopGain = 0; // per-round-trip decay
+  this.damp = 0.5;   // one-pole loop filter coefficient
+  this.lp = 0;
+  this.active = false;
+  this.age = 0;
+  this.energy = 0;
+  this.panL = 0.707;
+  this.panR = 0.707;
+  this.id = 0;
+}
+
+class StringProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.voices = [];
+    for (let i = 0; i < MAX_STRING_VOICES; i++) this.voices.push(new StringVoice(sampleRate));
+    this.queue = [];
+    this.pending = new Array(16).fill(null);
+    // Excitation scratch, allocated ONCE. Allocating a Float32Array per pluck
+    // inside process() is a real, audible bug: it is a malloc on the audio
+    // render thread and it eventually drags a GC pause into a 2.6ms budget.
+    this.scratch = new Float32Array(Math.ceil(sampleRate / MIN_FREQ) + 8);
+    this.rngState = 0x9e3779b9;
+    this.port.onmessage = (e) => {
+      const d = e.data;
+      if (d.type === 'pluck') this.queue.push(d);
+      else if (d.type === 'panic') { for (const v of this.voices) { v.active = false; v.buf.fill(0); } this.queue.length = 0; }
+    };
+  }
+
+  rnd() {
+    let a = (this.rngState + 0x6d2b79f5) | 0;
+    this.rngState = a;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  }
+
+  // Quietest / oldest voice loses. Never steal a voice younger than ~30ms:
+  // stealing a just-started note is far more audible than dropping a new one.
+  allocate() {
+    let free = -1, worst = -1, worstScore = Infinity;
+    for (let i = 0; i < this.voices.length; i++) {
+      const v = this.voices[i];
+      if (!v.active) { free = i; break; }
+      if (v.age < 0.03 * sampleRate) continue;
+      const score = v.energy;
+      if (score < worstScore) { worstScore = score; worst = i; }
+    }
+    if (free >= 0) return this.voices[free];
+    if (worst >= 0) { const v = this.voices[worst]; v.buf.fill(0); v.lp = 0; return v; }
+    return null;
+  }
+
+  start(ev) {
+    const v = this.allocate();
+    if (!v) return;
+    const freq = Math.max(MIN_FREQ, Math.min(sampleRate * 0.45, ev.freq));
+    const damping = Math.max(0, Math.min(1, ev.damping));
+    // One-pole loop filter y += a*(x-y). Brighter string -> a closer to 1.
+    // Its phase delay at low frequency is (1-a)/a samples; compensate so the
+    // pitch is right. Measured error after compensation: < 1.5 cents to 2 kHz.
+    const a = 1 - 0.85 * damping * damping;
+    const filtDelay = (1 - a) / a;
+    const period = sampleRate / freq;
+    v.len = Math.max(2, period - filtDelay);
+    v.damp = a;
+    // Loop gain so the string reaches -60dB in 'decay' seconds.
+    const roundTrips = Math.max(1e-6, ev.decay) * freq;
+    v.loopGain = Math.pow(10, -3 / roundTrips);
+    if (v.loopGain > 0.99995) v.loopGain = 0.99995; // never a perpetual motion machine
+    v.gain = ev.gain;
+    v.lp = 0;
+    v.age = 0;
+    v.active = true;
+    v.energy = ev.velocity;
+    v.id = ev.id | 0;
+    const pan = Math.max(-1, Math.min(1, ev.pan || 0));
+    // Equal-power pan.
+    const th = (pan + 1) * Math.PI * 0.25;
+    v.panL = Math.cos(th);
+    v.panR = Math.sin(th);
+
+    // --- Excitation -------------------------------------------------------
+    // Noise burst of exactly one period, lowpassed by how hard it was struck
+    // (soft = dark), then comb-filtered by pick position: x[n] - x[n-pL].
+    // The comb is what makes "plucked near the bridge" sound thin and nasal
+    // and "plucked over the hole" sound round. Without it every pluck is the
+    // same instrument.
+    const L = Math.ceil(v.len) + 2;
+    const buf = v.buf;
+    buf.fill(0);
+    const vel = Math.max(0.02, Math.min(1, ev.velocity));
+    const bright = 0.25 + 0.7 * vel * (1 - damping * 0.6);
+    let lp = 0;
+    const tmp = this.scratch;
+    for (let i = 0; i < L; i++) {
+      const w = this.rnd() * 2 - 1;
+      lp += bright * (w - lp);
+      tmp[i] = lp;
+    }
+    const pos = Math.max(0.01, Math.min(0.5, ev.position === undefined ? 0.22 : ev.position));
+    const pL = Math.max(1, Math.round(pos * L));
+    let peak = 1e-9;
+    for (let i = 0; i < L; i++) {
+      const y = tmp[i] - (i >= pL ? tmp[i - pL] : 0);
+      buf[i] = y;
+      const ay = y < 0 ? -y : y;
+      if (ay > peak) peak = ay;
+    }
+    // Normalise the excitation so velocity — not the comb's incidental gain —
+    // controls loudness. Skipping this makes some pitches randomly twice as
+    // loud, which reads as a bug even when nobody can say why.
+    const norm = vel / peak;
+    for (let i = 0; i < L; i++) buf[i] *= norm;
+    // Write pointer starts PAST the excitation so the first read lands inside
+    // it. Starting at 0 reads the zeroed far end of the delay line and the
+    // string never speaks — a silent-pluck bug that looks like a routing fault.
+    v.idx = L;
+  }
+
+  process(_inputs, outputs) {
+    const out = outputs[0];
+    const L = out[0];
+    const R = out.length > 1 ? out[1] : out[0];
+    const n = L.length;
+    const evs = this.pending;
+    const evn = drain(this.queue, evs);
+    let e = 0;
+
+    for (let i = 0; i < n; i++) {
+      while (e < evn && evs[e]._f === i) { this.start(evs[e]); e++; }
+      let sl = 0, sr = 0;
+      for (let k = 0; k < this.voices.length; k++) {
+        const v = this.voices[k];
+        if (!v.active) continue;
+        const buf = v.buf;
+        const bl = buf.length;
+        // Fractional read, linear interpolation.
+        let rp = v.idx - v.len;
+        while (rp < 0) rp += bl;
+        const i0 = rp | 0;
+        const fr = rp - i0;
+        const i1 = i0 + 1 >= bl ? 0 : i0 + 1;
+        const s = buf[i0] + fr * (buf[i1] - buf[i0]);
+        // Loop filter + decay.
+        v.lp += v.damp * (s - v.lp);
+        const y = v.lp * v.loopGain;
+        buf[v.idx] = y;
+        v.idx++; if (v.idx >= bl) v.idx = 0;
+        v.age++;
+        const ay = y < 0 ? -y : y;
+        v.energy = v.energy * 0.9995 + ay * 0.0005;
+        const o = y * v.gain;
+        sl += o * v.panL;
+        sr += o * v.panR;
+        // Retire when inaudible. 1e-5 ~ -100dBFS; below any playback level.
+        if (v.age > 512 && v.energy < 1e-5) { v.active = false; }
+      }
+      L[i] = sl;
+      if (R !== L) R[i] = sr;
+    }
+    return true; // node is a long-lived bank, never self-terminates
+  }
+}
+registerProcessor('dw-string', StringProcessor);
+
+// ---------------------------------------------------------------------------
+// dw-modal — polyphonic modal synthesis. Struck brass, tile, stone, glass,
+// membranes. Each voice is a parallel bank of 2-pole resonators in f64 with
+// T60 as a DIRECT parameter (not a side effect of Q).
+// ---------------------------------------------------------------------------
+const MAX_MODAL_VOICES = 16;
+const MAX_MODES = 10;
+
+function ModalVoice() {
+  this.f = new Float64Array(MAX_MODES);   // b1 = 2 r cos w
+  this.g = new Float64Array(MAX_MODES);   // -r^2
+  this.amp = new Float64Array(MAX_MODES);
+  this.y1 = new Float64Array(MAX_MODES);
+  this.y2 = new Float64Array(MAX_MODES);
+  this.count = 0;
+  this.active = false;
+  this.exciteLeft = 0;
+  this.exciteLp = 0;
+  this.exciteA = 0.5;
+  this.gain = 0;
+  this.age = 0;
+  this.energy = 0;
+  this.panL = 0.707;
+  this.panR = 0.707;
+}
+
+class ModalProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.voices = [];
+    for (let i = 0; i < MAX_MODAL_VOICES; i++) this.voices.push(new ModalVoice());
+    this.queue = [];
+    this.pending = new Array(16).fill(null);
+    this.rngState = 0x1b873593;
+    this.port.onmessage = (e) => {
+      const d = e.data;
+      if (d.type === 'strike') this.queue.push(d);
+      else if (d.type === 'panic') { for (const v of this.voices) v.active = false; this.queue.length = 0; }
+    };
+  }
+
+  rnd() {
+    let a = (this.rngState + 0x6d2b79f5) | 0;
+    this.rngState = a;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  }
+
+  allocate() {
+    let free = -1, worst = -1, worstScore = Infinity;
+    for (let i = 0; i < this.voices.length; i++) {
+      const v = this.voices[i];
+      if (!v.active) { free = i; break; }
+      if (v.age < 0.03 * sampleRate) continue;
+      if (v.energy < worstScore) { worstScore = v.energy; worst = i; }
+    }
+    if (free >= 0) return this.voices[free];
+    if (worst >= 0) {
+      const v = this.voices[worst];
+      v.y1.fill(0); v.y2.fill(0);
+      return v;
+    }
+    return null;
+  }
+
+  start(ev) {
+    const v = this.allocate();
+    if (!v) return;
+    const freqs = ev.freqs, amps = ev.amps, t60s = ev.t60s;
+    const count = Math.min(MAX_MODES, freqs.length);
+    v.count = count;
+    const nyq = sampleRate * 0.5;
+    let live = 0;
+    for (let i = 0; i < count; i++) {
+      const f = freqs[i];
+      if (f <= 20 || f >= nyq * 0.98) { v.amp[live] = 0; v.f[live] = 0; v.g[live] = 0; v.y1[live] = 0; v.y2[live] = 0; live++; continue; }
+      // r^(T60*sr) = 1e-3  ->  r = 10^(-3/(T60*sr))
+      const r = Math.pow(10, -3 / (Math.max(0.005, t60s[i]) * sampleRate));
+      const w = 2 * Math.PI * f / sampleRate;
+      v.f[live] = 2 * r * Math.cos(w);
+      v.g[live] = -(r * r);
+      // The 2-pole resonator's impulse response is
+      //     y[n] = A · r^n · sin((n+1)w) / sin(w)
+      // so its peak is A/sin(w). Scaling A by sin(w) makes every mode's peak
+      // exactly amps[i] regardless of frequency. Skip this and the low modes
+      // are enormous while the high ones vanish — the "every material sounds
+      // like a kick drum" failure.
+      v.amp[live] = amps[i] * Math.sin(w)
+      v.y1[live] = 0; v.y2[live] = 0;
+      live++;
+    }
+    v.count = live;
+    v.active = true;
+    v.age = 0;
+    v.energy = 1;
+    v.gain = ev.gain;
+    // Excitation: a short noise burst (a struck object is hit by something with
+    // its own spectrum, not by a mathematical impulse). 'strikeHardness' 0..1
+    // opens the excitation's lowpass -> soft mallet vs steel hammer.
+    v.exciteLeft = Math.max(1, Math.round((ev.strikeMs || 1.2) * 0.001 * sampleRate));
+    v.exciteA = 0.03 + 0.95 * Math.max(0, Math.min(1, ev.hardness === undefined ? 0.6 : ev.hardness));
+    v.exciteLp = 0;
+    const pan = Math.max(-1, Math.min(1, ev.pan || 0));
+    const th = (pan + 1) * Math.PI * 0.25;
+    v.panL = Math.cos(th);
+    v.panR = Math.sin(th);
+  }
+
+  process(_inputs, outputs) {
+    const out = outputs[0];
+    const L = out[0];
+    const R = out.length > 1 ? out[1] : out[0];
+    const n = L.length;
+    const evs = this.pending;
+    const evn = drain(this.queue, evs);
+    let e = 0;
+
+    for (let i = 0; i < n; i++) {
+      while (e < evn && evs[e]._f === i) { this.start(evs[e]); e++; }
+      let sl = 0, sr = 0;
+      for (let k = 0; k < this.voices.length; k++) {
+        const v = this.voices[k];
+        if (!v.active) continue;
+        let x = 0;
+        if (v.exciteLeft > 0) {
+          const w = this.rnd() * 2 - 1;
+          v.exciteLp += v.exciteA * (w - v.exciteLp);
+          x = v.exciteLp;
+          v.exciteLeft--;
+        }
+        let acc = 0;
+        const f = v.f, g = v.g, a = v.amp, y1 = v.y1, y2 = v.y2;
+        for (let m = 0; m < v.count; m++) {
+          const y = f[m] * y1[m] + g[m] * y2[m] + a[m] * x;
+          y2[m] = y1[m];
+          y1[m] = y;
+          acc += y;
+        }
+        v.age++;
+        const aa = acc < 0 ? -acc : acc;
+        v.energy = v.energy * 0.999 + aa * 0.001;
+        const o = acc * v.gain;
+        sl += o * v.panL;
+        sr += o * v.panR;
+        if (v.age > 512 && v.energy < 1e-5) v.active = false;
+      }
+      L[i] = sl;
+      if (R !== L) R[i] = sr;
+    }
+    return true;
+  }
+}
+registerProcessor('dw-modal', ModalProcessor);
+
+// ---------------------------------------------------------------------------
+// dw-meter — a zero-allocation peak/RMS/clip meter. Used by the measurement
+// harness and by the master safety check. Posts a summary 20x a second, not a
+// value per block: postMessage from the audio thread is the classic way to
+// starve the renderer.
+// ---------------------------------------------------------------------------
+class MeterProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.peak = 0; this.sum = 0; this.count = 0; this.clips = 0; this.acc = 0;
+  }
+  process(inputs) {
+    const inp = inputs[0];
+    if (!inp || inp.length === 0) return true;
+    const n = inp[0].length;
+    for (let c = 0; c < inp.length; c++) {
+      const ch = inp[c];
+      for (let i = 0; i < n; i++) {
+        const s = ch[i];
+        const a = s < 0 ? -s : s;
+        if (a > this.peak) this.peak = a;
+        if (a >= 0.999) this.clips++;
+        this.sum += s * s;
+        this.count++;
+      }
+    }
+    this.acc += n;
+    if (this.acc >= sampleRate / 20) {
+      this.port.postMessage({
+        peak: this.peak,
+        rms: Math.sqrt(this.sum / Math.max(1, this.count)),
+        clips: this.clips,
+      });
+      this.peak = 0; this.sum = 0; this.count = 0; this.clips = 0; this.acc = 0;
+    }
+    return true;
+  }
+}
+registerProcessor('dw-meter', MeterProcessor);
+`

--- a/dynawalla/foundations/audio/tools/emit-worklet.mjs
+++ b/dynawalla/foundations/audio/tools/emit-worklet.mjs
@@ -1,0 +1,28 @@
+/**
+ * Write the worklet processors out as a plain `.js` file.
+ *
+ * The kit normally loads them from a Blob URL, which needs no build step and no
+ * asset to lose. A host with a strict CSP (`script-src 'self'`, which is Tauri's
+ * default) will refuse a `blob:` script — for those, serve this file from your
+ * own origin and pass its URL:
+ *
+ *     node tools/emit-worklet.mjs public/dw-audio-worklet.js
+ *     createAudio({ workletUrl: "/dw-audio-worklet.js" })
+ *
+ * The output is byte-identical to the string the kit would have used, so the
+ * two paths can never drift.
+ */
+
+import { readFile, writeFile } from "node:fs/promises"
+import { resolve } from "node:path"
+import { stripTypeScriptTypes } from "node:module"
+
+const ROOT = resolve(import.meta.dirname, "..")
+const out = resolve(process.cwd(), process.argv[2] ?? "dw-audio-worklet.js")
+
+const src = await readFile(resolve(ROOT, "src/worklets/source.ts"), "utf8")
+const js = stripTypeScriptTypes(src, { mode: "transform" })
+const mod = await import(`data:text/javascript,${encodeURIComponent(js)}`)
+
+await writeFile(out, mod.WORKLET_SOURCE, "utf8")
+console.log(`wrote ${out} (${mod.WORKLET_SOURCE.length} bytes)`)

--- a/dynawalla/foundations/audio/tools/serve.mjs
+++ b/dynawalla/foundations/audio/tools/serve.mjs
@@ -1,0 +1,70 @@
+/**
+ * Zero-dependency dev server for the audio foundation.
+ *
+ * Serves the demo and the measurement harness, transpiling `.ts` on the fly
+ * with Node's built-in `module.stripTypeScriptTypes` — no vite, no esbuild, no
+ * node_modules. The kit is plain ES modules with `.ts` specifiers, exactly the
+ * form Node's `--experimental-strip-types` test runner wants, so the same
+ * source runs in the browser and in `node --test` with no build step at all.
+ *
+ *     node tools/serve.mjs [--port 8788]
+ */
+
+import { createServer } from "node:http"
+import { readFile } from "node:fs/promises"
+import { extname, join, normalize, resolve } from "node:path"
+import { stripTypeScriptTypes } from "node:module"
+
+const ROOT = resolve(import.meta.dirname, "..")
+const args = process.argv.slice(2)
+const portArg = args.indexOf("--port")
+const PORT = portArg >= 0 ? Number(args[portArg + 1]) : 8788
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".ts": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml",
+}
+
+const server = createServer(async (req, res) => {
+  try {
+    let url = decodeURIComponent((req.url ?? "/").split("?")[0])
+    if (url === "/") url = "/demo/index.html"
+    const path = join(ROOT, normalize(url).replace(/^(\.\.[/\\])+/, ""))
+    if (!path.startsWith(ROOT)) {
+      res.writeHead(403).end("forbidden")
+      return
+    }
+    const ext = extname(path)
+    let body = await readFile(path)
+    if (ext === ".ts") {
+      // `transform` (not `strip`) so the output has no type-only leftovers and
+      // real line numbers via the inline source map.
+      body = stripTypeScriptTypes(body.toString("utf8"), {
+        mode: "transform",
+        sourceMap: true,
+        sourceURL: url,
+      })
+    }
+    res.writeHead(200, {
+      "content-type": MIME[ext] ?? "application/octet-stream",
+      "cache-control": "no-store",
+      // The demo needs no cross-origin isolation, but stating it makes the
+      // WebView behaviour match the browser one.
+      "cross-origin-opener-policy": "same-origin",
+    })
+    res.end(body)
+  } catch (e) {
+    res.writeHead(e.code === "ENOENT" ? 404 : 500).end(String(e))
+  }
+})
+
+server.listen(PORT, () => {
+  console.log(`dynawalla audio foundation -> http://localhost:${PORT}/`)
+  console.log(`  demo     http://localhost:${PORT}/demo/index.html`)
+  console.log(`  measure  http://localhost:${PORT}/measure/index.html`)
+})

--- a/dynawalla/foundations/audio/tsconfig.json
+++ b/dynawalla/foundations/audio/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "types": []
+  },
+  "include": ["src/**/*.ts", "measure/**/*.ts", "demo/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
**Foundation area: procedural audio.** Everything synthesized in Web Audio at
runtime — no audio assets exist in this project and none ever will. Zero runtime
dependencies, no build step. Lands in `dynawalla/foundations/audio/`.

A prototype writes one line and gets an excellent result:

```ts
await audio.init()             // once, anywhere; iOS unlock is automatic
audio.play("ui.chunk")
audio.combo(streak)            // the kit owns the musicality
audio.music.setIntensity(0.7)
audio.ambience("bazaar")
audio.onCue(cue => flash(cue)) // sound never carries information alone
```

## What is here

- **Physical modelling.** Polyphonic Karplus-Strong (24 voices) and modal
  resonator banks (16 voices x 10 modes) in one `AudioWorklet`, f64, with
  sample-accurate message scheduling. One node per bus, not per voice.
- **A modal material library** with real inharmonic ratios — brass, bell,
  glazed tile, glass, stone, wood, a Bessel-mode drum membrane, a copper pot.
- **Subtractive, FM, granular, sub** primitives, and **25 loudness-matched
  presets** built as transient + body + tail (+ sub).
- **A procedural score** on a Hijaz mode that responds to `setIntensity(0..1)`
  and never loops, plus **four ambient beds** kept alive by sparse random events.
- **The mix**: four buses, sidechain ducking, a master chain that cannot clip,
  a voice budget with weighted stealing, four quality tiers picked by a 13 ms
  offline benchmark rather than a user-agent guess.
- **A measurement harness** (`measure/index.html`) that produced every number
  below, a **playable demo** (`demo/`), a zero-dependency TypeScript dev server,
  and 21 unit tests (`npm test`, Node's native runner).

## Measured — M-series laptop, Chrome 149, 48 kHz

Nothing below is from documentation. All of it came out of `measure/`.

**The synthesis is correct**

| Claim | Measured |
|---|---|
| String bank pitch, 82 Hz - 1760 Hz | **+/-0.12 cents** |
| Modal T60 vs requested, 6 materials | **within 0.6 %** |
| Presets audible through the live path | **25 / 25** |

**It does not cost frames** (synthetic 60 Hz loop, 6 ms work/tick, MessageChannel)

| Trigger rate | Mean tick | Kit's share of 16.67 ms |
|---|---|---|
| control | 6.021 ms | — |
| 8 sounds/s | 6.032 ms | **+0.018 ms** |
| 30 sounds/s | 6.061 ms | **+0.040 ms** |

Zero ticks over budget. `play()` is 6-11 us warm.

**The mix cannot clip** (12 loud presets on the same sample)

| Chain | Peak |
|---|---|
| none | +24.17 dBFS |
| `DynamicsCompressorNode` alone | +3.03 dBFS — it is not a limiter |
| compressor + oversampled soft clip | **-0.25 dBFS, 0 clipped samples** |

**Audio-thread cost** (fraction of one core): reverb 1.1 s 2.21 % / 2.4 s
2.46 %; modal bank 16 voices 5.31 %; string bank 24 voices 4.88 %; granular
140 grains/s 5.82 %; native biquad fallback 100 voices 24.35 %; an **idle**
worklet node ~0.33 % each.

**Whole scenes**, through the real master chain and the real budget: UI only
5.5 %, busy gameplay 18.7 %, a deliberately absurd 53 triggers/s 47.4 % — and
**128 % with the voice budget disabled**, which is the measurement that shows
why the budget exists.

**Latency**: 5.33 ms base + 24 ms output + 4 ms kit offset = ~33 ms. Init 94 ms,
once, on a loading screen.

## The budget this kit enforces

**Audio thread under 30 % of one core in normal play, under 60 % worst case.**
It has 2.67 ms per 128-frame quantum; over is a dropout, and a dropout is the
only unrecoverable audio failure. Degradation order: reverb tail -> grain
density -> modal partials -> music layers -> voice cap.

Tier thresholds are anchored to a measured `realtimeFactor` of 74 on this
machine. **They need re-anchoring on a real mid-range tablet** — one device is
not a calibration, and `measure/index.html` runs on the device to do it.

## Traps, found by hitting them

1. **A `DelayNode` inside a feedback cycle silently ADDS 128 samples** — not
   clamps, adds. The textbook native Karplus-Strong is flat at *every* pitch
   (-336 cents at 80 Hz, -2096 at 880 Hz), and after compensation hard-pins at
   **373.5 Hz**. Plucked strings above F#4 require a worklet.
2. **The loop filter must be <= 1 at all frequencies.** A default BiquadFilter
   lowpass (Q = 1) has a +1.2 dB peak, so 0.99 feedback still self-oscillates:
   measured peak **8.6e17**.
3. **`postMessage` to a worklet does not arrive before `startRendering()`.** An
   offline bounce renders total silence with no error. Peak 0.00000 without a
   macrotask yield, 0.61880 with one.
4. **You pay for the graph, not the arithmetic.** A four-node-per-grain cloud
   cost **49.3 % of a core**; baking filter, window and amplitude into
   pre-rendered buffers gave the identical sound at **one node per grain, 5.8 %**.
5. **An idle `AudioWorkletNode` costs ~0.33 % of a core**, so the banks are lazy.
6. **A shared polyphonic bank cannot be routed per voice** — it has one output.
   Fixed with per-bus banks plus per-voice level in the bank's gain message.
7. **`WaveShaper` with `oversample: "2x"` overshoots its own curve maximum**
   (+0.05 dBFS with a 0.999 ceiling). Ceiling is now 0.97.
8. **`ctx.resume()` outside a gesture never resolves** — it does not reject.
9. **rAF never fires in a background tab**, which hangs any rAF-based harness;
   `setTimeout` is clamped to ~1 s there too. Same trap is why the music
   scheduler rebases instead of firing its backlog.
10. **First `play()` of a preset is ~200 us vs 6-11 us warm.** `audio.warm()`
    (called by `init()`) primes every preset in an OfflineAudioContext.
11. **Allocation on the render thread is a click waiting to happen** — there is
    a unit test that greps the worklet source for it.

Two of these were bugs in this PR's own code, caught by measurement rather than
by reading: `Preset.gain` was declared but never applied, and voice stealing
could forget a voice without silencing it. Both are fixed by the per-voice gain
node.

## iOS

**Do not reuse `tauri-plugin-audio-keepalive` for Dynawalla.** It sets
`AVAudioSession.setCategory(.playback)`, which ignores the hardware mute switch.
Correct for Corpan, wrong for a children's game: a parent who silenced a tablet
has silenced it. The default WKWebView category is right; leave it alone.

## Accessibility

`play()` emits a `Cue` even when muted, disabled, device-silenced, or dropped by
the voice budget, carrying `intensity`, visual `weight` and a `haptic` hint.
Wire visuals to cues and the prototype is accessible by construction. The demo's
audio-off checkbox demonstrates it: the screen keeps working.

## Reviewing this

`git diff origin/main | wc -c` is **261 KB**, over `MAX_DIFF_BYTES`, so
adversarial-review will truncate. It is one cohesive reference implementation
and splitting it would be artificial, so please review in parts:
`src/` (the kit, 4,426 lines) is the thing that matters; `measure/` (1,300),
`demo/` (694) and `tools/` (98) are evidence and scaffolding.

Gates: `npm test` 21/21 green; `tsc --noEmit` clean under `strict` +
`erasableSyntaxOnly`. Nothing under `src/reactions/`, `src/world/`, `src/work/`
or `engine/` is touched, so no boundary or curriculum rule is in play. **Do not
merge** — this is a foundation spike for review.
