### PR TITLE
foundations(physics): bake off four engines, choose Rapier, ship the kit

### DIFF
--- a/dynawalla/docs/DECISIONS/ADR-0020-physics-engine-rapier.md
+++ b/dynawalla/docs/DECISIONS/ADR-0020-physics-engine-rapier.md
@@ -1,0 +1,101 @@
+# ADR-0020 — Rapier 2D is the physics engine
+
+**Status:** Proposed
+**Supersedes:** nothing. **Interacts with:** [ADR-0004](ADR-0004-no-mic-no-llm-no-3d.md).
+
+## Context
+
+The Bazaar's games need real physics: projectile arcs with usable aim-assist, stacking
+and toppling, ropes and chains, soft bodies, a particle-liquid approximation, gear
+trains, dominoes, and a balance scale that is the physical embodiment of the equals sign.
+
+Four candidates were benchmarked against identical scenes rather than compared from
+documentation: **Rapier 2D** 0.19.3, **Box2D v3** (`box2d3-wasm` 5.2.0), **Planck.js**
+1.5.0 and **Matter.js** 0.20.0. The full evidence, every table, and instructions to
+re-run everything are in [`dynawalla/foundations/physics/README.md`](../../foundations/physics/README.md).
+Havok and Jolt were excluded on the record: both are 3D engines whose shipped JS surface
+is a Babylon plugin API, and the games are 2D-simulated.
+
+## Decision
+
+**Use Rapier 2D, pinned to `@dimforge/rapier2d-compat` 0.19.3**, behind the kit in
+`dynawalla/foundations/physics/src/`. Prototypes call `createWorld()` and the recipes;
+they do not talk to Rapier directly.
+
+**The physics never decides a mathematical fact.** Quantities a prototype may treat as
+truth — `compare()`, `momentOf()`, `volumeIn()`, `fallenFraction()` — are computed by
+exact arithmetic over what the game put into the world. The solver drives the *picture*.
+This extends [ADR-0009](ADR-0009-stakes-without-loss.md)'s "true by construction" to the
+simulation layer, and it is enforced by a test: `compare()` is already correct before a
+single step has run, and stays correct after the beam is forcibly rotated.
+
+**Budget: 4 ms of a 16.67 ms frame, measured as step p99**, with four quality tiers whose
+floor (`mid`) is the reference tablet, not a downgrade from desktop.
+
+## Why Rapier and not the others
+
+Each of the three alternatives failed a capability that is on the required list, not a
+performance target.
+
+- **Matter.js drops 0 of 300 dominoes** at friction 0.45 and 0.7 — the wave dies at
+  domino three. Rapier, Box2D v3 and Planck agree within 2 dominoes across the whole
+  friction sweep; Matter falls off a cliff above 0.3. Its iteration count also makes
+  chain stretch *worse* (17% → 62%), so it is not a convergence knob. Last published
+  2024-06-23.
+- **Planck.js stretches a chain 64% at a 10:1 load ratio** and 92% at 150:1, and more
+  iterations barely help — Box2D 2.4's solver cannot hold a chain. It is also 8.8x
+  slower than Rapier on 500 bodies, with a 9.9 ms worst frame on a Mac.
+- **Box2D v3 has the fastest solver** — 6x Rapier's median on a 120-box pyramid — but its
+  Embind binding allocates a heap handle per getter, so reading 500 transforms costs
+  0.454 ms against Rapier's 0.171 ms and the solver win is spent at the boundary. It also
+  settles a balance scale at 46-70° of tilt with equal weight in both pans, at every
+  sub-step count tested.
+
+Rapier's cost is size: its WASM is 1.12 MB raw, 2.75x Box2D v3's. Accepted, because in a
+Tauri app the module is bundled rather than fetched, and because most of the measured gap
+is the `-compat` base64 packaging rather than the engine.
+
+## Determinism
+
+Verified, not assumed. One seeded scene — a toppling stack, a loaded chain, 120 particles
+and a projectile — run for 900 steps produces the **identical state hash in Node/V8,
+Chrome/V8 and WebKit/JavaScriptCore**. This is structural: the module imports no libm
+from JavaScript, so all floating-point work happens inside WASM, where f32/f64 semantics
+are fully specified.
+
+Replays therefore store **commands addressed by step index**, never positions. Not
+verified: cross-architecture (everything above ran on arm64). If a cross-device replay
+ever desyncs, `@dimforge/rapier2d-deterministic` is a one-line swap.
+
+## Relationship to ADR-0004
+
+ADR-0004 excludes a 3D renderer from V1 and sets its revisit condition as "a measured
+frame budget on the Galaxy Tab A9". **This ADR does not claim that condition is met.**
+No Galaxy Tab A9 was available; the budget above was measured in real Chrome under CDP
+CPU throttling, which inserts pauses and does not model a smaller cache or slower memory.
+The rig to take the real measurement is committed and runs from any browser on the
+device.
+
+ADR-0004's reasoning about 3D is also about the *renderer*, not the solver: this kit
+simulates in 2D and presents in 3D, so the frame-budget question it raises applies to the
+rendering foundation rather than to this one. Whether V1 renders in 3D at all is a
+separate decision and a separate ADR.
+
+## Consequences
+
+- One physics engine across every prototype, so a trap found once is fixed for all of
+  them. Three are already gated by tests, including the two that silently produce a dead
+  mechanism: Rapier joints collide the bodies they connect and expose no
+  `collideConnected`, and `JointData.limitsEnabled`/`.limits` are accepted and ignored.
+- Prototype authors do not choose an engine, tune a solver, or discover any of this.
+- Switching engines later means rewriting the kit's internals but not the prototypes,
+  because nothing above the kit imports Rapier.
+- Before shipping, move the dependency from `-compat` to `@dimforge/rapier2d` (separate
+  `.wasm`), worth roughly 200 KB gzip.
+
+## Revisit conditions
+
+A measured 60 fps failure on the reference tablet that tiering cannot recover; a
+cross-device replay desync that the `-deterministic` build does not fix; or a game design
+that genuinely needs 3D rigid-body simulation rather than 3D presentation, which would be
+a second engine and its own ADR.

--- a/dynawalla/foundations/physics/.gitignore
+++ b/dynawalla/foundations/physics/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/dynawalla/foundations/physics/README.md
+++ b/dynawalla/foundations/physics/README.md
@@ -1,0 +1,484 @@
+# Physics foundation
+
+**Recommendation: Rapier 2D, pinned at `@dimforge/rapier2d-compat` 0.19.3.**
+
+Everything below is measured. Every table was produced by a script in `bench/`, on this
+machine, on the dates given, and every one of them can be re-run. Where something was
+not measured — an actual Galaxy Tab A9, an x86 device — it says so.
+
+- Machine: Apple Silicon macOS 26.3 (arm64), Node 24.18.0, Chrome 150.0.7871.187,
+  WebKit 26.5 (Playwright build).
+- Date: 2026-07-26.
+- Versions confirmed live against the npm registry the same day.
+
+---
+
+## 1. The bake-off
+
+Four engines, five scenes, identical worlds. The scenes are plain data in
+`bench/scenes.mjs` and each engine has an adapter that builds them; nothing is expressed
+in any engine's own vocabulary, so this measures the engines rather than how well three
+of them imitate the fourth.
+
+| candidate | version | published | why it was in the running |
+|---|---|---|---|
+| Rapier 2D | 0.19.3 | 2025-11-05 | Rust/WASM, TGS-Soft solver, an explicit determinism story |
+| Box2D v3 | `box2d3-wasm` 5.2.0 | 2026-02-16 | Erin Catto's rewrite; soft-step solver, SIMD, smallest WASM |
+| Planck.js | 1.5.0 | 2026-04-07 | pure JS port of Box2D 2.4 — no WASM at all |
+| Matter.js | 0.20.0 | **2024-06-23** | the default answer on the web; note the date |
+
+Not benchmarked, and why: **Havok** (`@babylonjs/havok`) and **Jolt** (`jolt-physics`,
+46 MB unpacked) are 3D engines whose shipped JS surface is a Babylon plugin API; we are
+on Three.js and the games are 2D-simulated. Using either would mean adopting a 3D solver
+for a side-on world and writing the binding ourselves.
+
+### Step cost — `node bench/run-node.mjs --repeat 3`
+
+Milliseconds per step, V8. `snap` is the cost of reading every body's transform out for
+the renderer, which most physics benchmarks quietly omit and which is not free.
+
+| engine | scene | p50 | p95 | p99 | max | snap |
+|---|---|---:|---:|---:|---:|---:|
+| **rapier** | pyramid-topple (120 bodies) | 0.120 | 0.178 | 0.314 | 0.456 | 0.049 |
+| **rapier** | debris-500 | 0.476 | 0.573 | 0.650 | 0.777 | 0.171 |
+| **rapier** | dominoes-300 | 0.152 | 0.256 | 0.363 | 0.692 | 0.101 |
+| **rapier** | rope-60 | 0.104 | 0.119 | 0.131 | 0.154 | 0.019 |
+| **rapier** | balance-scale | 0.014 | 0.018 | 0.023 | 0.030 | 0.004 |
+| box2d3 | pyramid-topple | 0.019 | 0.135 | 0.188 | 0.764 | 0.121 |
+| box2d3 | debris-500 | 0.301 | 0.397 | 0.433 | 0.494 | **0.454** |
+| box2d3 | dominoes-300 | 0.091 | 0.167 | 0.181 | 0.226 | 0.273 |
+| box2d3 | rope-60 | 0.031 | 0.044 | 0.052 | 0.059 | 0.057 |
+| planck | pyramid-topple | 0.716 | 0.964 | 1.633 | 2.264 | 0.001 |
+| planck | debris-500 | **4.182** | 5.545 | 6.156 | **9.935** | 0.004 |
+| planck | dominoes-300 | 0.802 | 1.654 | 1.897 | 2.184 | 0.003 |
+| matter | pyramid-topple | 0.203 | 0.305 | 0.370 | 0.581 | 0.001 |
+| matter | debris-500 | 2.476 | 3.154 | 3.391 | 3.919 | 0.003 |
+| matter | dominoes-300 | 0.237 | 0.306 | 0.360 | 0.439 | 0.001 |
+
+**Box2D v3 is the fastest solver** — 6x Rapier's p50 on the pyramid. But its Embind
+binding allocates a heap handle per getter call, so reading 500 transforms costs
+**0.454 ms against Rapier's 0.171 ms**, and on the scene that matters most the total is
+0.755 ms versus Rapier's 0.647 ms. The solver win is spent at the boundary.
+
+**Planck is 8.8x slower than Rapier on `debris-500`** with a 9.9 ms worst frame — on a
+Mac. That is most of a mid-range tablet's entire frame budget for 500 boxes.
+
+### Quality, which is not optional
+
+Speed is necessary and not sufficient. A fast engine whose rope stretches or whose
+dominoes wedge is not usable for a product where the physics *is* the explanation.
+
+| engine | rope stretch @150:1 | dominoes fallen /300 | balance @ equality |
+|---|---:|---:|---|
+| **rapier** | **3.3%** | 202 | **-0.001°, 0.000° jitter** |
+| box2d3 | 4.0% | 204 | 46-70° (broken) |
+| planck | **92.1%** | 204 | -0.44° |
+| matter | 6.1% | **0** | +4.1°, wrong-signed response |
+
+Three failures worth naming.
+
+**Matter.js cannot propagate a chain reaction.** `bench/run-node.mjs --engine matter`
+drops **0 of 300** dominoes; the wave dies at domino three and the scene is frozen from
+step 180 to step 900. It is not my friction choice — `bench/probe-dominoes.mjs`, fallen
+out of 300:
+
+| friction | 0.10 | 0.20 | 0.30 | 0.45 | 0.70 |
+|---|---:|---:|---:|---:|---:|
+| rapier | 289 | 258 | 229 | 195 | 158 |
+| box2d3 | 291 | 261 | 230 | 196 | 159 |
+| planck | 276 | 256 | 228 | 197 | 159 |
+| matter | 73 | 70 | 64 | **0** | **0** |
+
+Three engines agree to within 2 dominoes and degrade smoothly. Matter starts at a
+quarter of the others and falls off a cliff above 0.3 — and a game will want high
+friction, because that is what makes blocks feel heavy and stay where they are put.
+"Dominoes and chain reactions" is on the required list, so this alone disqualifies it.
+
+**Planck cannot hold a chain.** `bench/probe-rope.mjs`, stretch by load:link mass ratio:
+
+| ratio | 10:1 | 50:1 | 150:1 | 500:1 | 2000:1 |
+|---|---:|---:|---:|---:|---:|
+| **rapier** | **0.7%** | 1.1% | 3.3% | 11.2% | 17.5% |
+| box2d3 | 3.0% | 1.4% | 4.0% | 4.0% | 35.6% |
+| planck | **64.1%** | 77.3% | 92.1% | 108.7% | 104.8% |
+| matter | 5.3% | 6.2% | 6.1% | 7.1% | 16.8% |
+
+Planck's chain is elastic at *every* ratio, and its own quality dial barely helps
+(105% → 96% going from 8/3 to 32/12 iterations). Rapier's does: 16 solver iterations
+takes 2000:1 from 18% to 7% for 3.4x the solve. Matter's dial goes the **wrong way**
+(17% → 62% as iterations rise), which means it is not a convergence knob at all.
+
+**Box2D v3 cannot hold a balance scale.** With equal weight in both pans it settles at
+46-70° of tilt, and more sub-steps do not help — at 32 sub-steps it tips the *wrong way*
+under an imbalance. I am reporting what I measured; this may be the `box2d3-wasm`
+wrapper rather than upstream Box2D, and I did not chase it further because it does not
+change the recommendation.
+
+### Bundle cost — measured, not quoted
+
+| artifact | raw | gzip | brotli |
+|---|---:|---:|---:|
+| `rapier_wasm2d_bg.wasm` | 1,175,792 | 434,688 | 326,730 |
+| Box2D v3 `deluxe` (SIMD) `.wasm` | 427,805 | 157,574 | 125,920 |
+| **this kit bundled** (`-compat`, all recipes) | 1,705,215 | 636,491 | 478,423 |
+| Three.js, minimal scene, for scale | 523,580 | 131,109 | 108,755 |
+
+Rapier's WASM is **2.75x Box2D v3's**. That is a real cost and it is the strongest
+argument the other way.
+
+Two things make it acceptable here. First, in a Tauri app the WASM is bundled into the
+binary and served over a custom protocol — there is no network transfer, so the number
+that matters is app size, where 1.1 MB sits next to Three.js's 0.5 MB and the app's own
+assets. Second, **most of the gap above is the `-compat` packaging, not the engine**:
+`-compat` base64-inlines the WASM into the JS, which costs ~200 KB gzip over shipping
+the raw `.wasm` because base64 compresses badly. Production should switch the dependency
+to `@dimforge/rapier2d` (separate `.wasm`, same engine); `-compat` is the default here
+because it makes a prototype a single file with no asset plumbing.
+
+### Startup — measured in both browsers
+
+| engine | WASM init | build 200 bodies | step |
+|---|---:|---:|---:|
+| Chrome / V8 | 10.0 ms | 1.10 ms | 0.0393 ms |
+| WebKit / JavaScriptCore | 9.0 ms | 3.00 ms | 0.0600 ms |
+| Node 24 / V8 | 29.4 ms | — | — |
+
+**The same WASM steps ~1.5x slower under JavaScriptCore than V8, and crosses the JS↔WASM
+boundary ~2.7x slower.** iOS is JavaScriptCore. Budget for it.
+
+---
+
+## 2. Determinism, honestly
+
+The claim a maths product needs is not "Rapier is deterministic". It is "a replay taken
+on one child's device reproduces on another", and that has to survive two different JS
+engines.
+
+**Measured — `bench/determinism.mjs`.** One seeded scene (a toppling stack, a jointed
+chain under load, 120 liquid particles and a fired projectile — contacts, islands and
+constraints at once), 900 steps:
+
+| runtime | quantised state hash |
+|---|---|
+| Node 24.18.0 / V8 | `cad4460c` |
+| Chrome 150 / V8 | `cad4460c` |
+| WebKit 26.5 / JavaScriptCore | `cad4460c` |
+
+Identical. And it is **structural, not lucky**: inspecting the module's imports,
+
+```
+rapier2d wasm — total imports: 32
+  math/libm imports from JS: NONE
+  random/time imports:        performance.now (profiling counters only)
+```
+
+Rapier links no libm out to JavaScript. Every floating-point operation happens inside
+the WASM module, where the spec fully determines f32/f64 arithmetic — no FMA
+contraction, no x87 excess precision, no engine-specific `Math.sin`. The JS engine
+*cannot* influence the result. All 20 bake-off cells were also bit-identical across three
+repeated runs in one process.
+
+**What is NOT established.** Everything above ran on arm64. The WASM spec makes
+cross-architecture determinism expected for scalar f32/f64, but x86 Android and CI were
+not tested, and NaN bit patterns and SIMD are the spec's known exceptions. Rapier
+publishes `@dimforge/rapier2d-deterministic` (0.19.3, +33 KB) whose difference is a
+portable libm inside Rust for exactly this; if a cross-device replay ever desyncs, that
+is the first switch to throw, and it is a one-line dependency change.
+
+**So the kit stores commands, not positions** (`src/replay.ts`). A tape is a list of
+`{step, op, args}` addressed by *step index*, never by wall clock. It replays by
+re-deriving the physics, so it survives an engine upgrade with a version warning rather
+than silent corruption, and it is tiny — the test asserts a three-command tape stays
+under 800 bytes. `world.hash()` is quantised to 0.1 mm rather than bit-exact, because a
+bit-exact hash of f32 state is too brittle to be a useful assertion.
+
+---
+
+## 3. The traps — found by hitting them
+
+Every one of these cost real time and every one is now gated by a test.
+
+**1. Rapier joints collide the bodies they connect, and there is no `collideConnected`.**
+Box2D, Planck and Matter all default a joint to *not* colliding its two bodies. Rapier
+does the opposite and its JS API does not expose the flag at all (grep confirms: zero
+hits in the type definitions). Since a joint by construction holds two colliders
+overlapping at the anchor, the contact and the constraint fight and the joint **jams
+solid**. Measured, on a simple pendulum:
+
+| anchor body | arm rotation after 5 s |
+|---|---|
+| no collider on the anchor | -33.0° (swings) |
+| a collider on the anchor | **0.0° — frozen horizontal in mid-air** |
+| collider + one collision-group bit | -33.0° (swings) |
+
+Every articulated recipe in this kit would have been silently dead. `World.add` takes an
+`assembly` id and clears that bit from the assembly's own filter.
+
+**2. `JointData.limitsEnabled` / `.limits` are silently ignored.** They exist, they
+type-check, they run — and `joint.limitsEnabled()` reads back `false` and an arm with a
+±22° stop swings to **-174°**. The limit must be applied to the *created* joint via
+`joint.setLimits()`. Both spellings are in the API and only one works.
+
+**3. A beam pivoted through its own centre of mass is neutrally stable.** No restoring
+torque at any angle, so where it settles is decided by solver noise. Identical scene,
+four engines: Rapier +0.05°, Matter +1.5°, Box2D v3 **-70.0°**, Planck **+72.4°**. Not
+four bugs — one under-determined scene. See §4.
+
+**4. A load on a lipless pan slides off the moment the pan tilts,** which removes the
+imbalance the scale exists to show. The first version of the scale probe concluded
+"Rapier settles level under a 25% overload" because the overload had slid onto the floor
+and out of the world.
+
+**5. `box2d3-wasm` silently ships you the scalar build.** Its entry point picks the SIMD
+"deluxe" WASM only when `WebAssembly.validate(<simd probe>)` passes **and, in a browser,
+`window.crossOriginIsolated === true`**. A Tauri WebView is not cross-origin-isolated
+unless you add COOP/COEP to the custom-protocol response, so the default path takes the
+slower build and says nothing. Its `b2CreateThreadedWorld` needs SharedArrayBuffer, so
+the same gate applies.
+
+**6. Embind getters allocate.** `b2Body_GetPosition()` returns a heap handle the caller
+must `.delete()`. In a render loop that is one allocation per body per frame; it is why
+Box2D v3's transform readback is 2.7x Rapier's. Related: nested value getters need
+copy-mutate-assign — `shapeDef.material.friction = x` compiles, runs, and does nothing.
+
+**7. Node's `--experimental-strip-types` is strip-ONLY.** Parameter properties
+(`constructor(private w: World)`), enums, namespaces and decorators are hard load errors.
+The whole repo tests this way, so it constrains every file here.
+
+**8. A demo clock driven by the display runs at the wrong speed.** On a 120 Hz screen a
+fixed-60 Hz `advance()` steps every *other* frame, so scene logic fed the display delta
+runs at 2x. This looked exactly like a physics failure and was not.
+
+**9. `advance()` must clamp.** A backgrounded WebView — iOS app switch, Android doze,
+Tauri minimise — resumes with a delta of whole seconds. Without a clamp the world
+simulates every missed step in one frame, which on a tablet is a multi-second freeze
+indistinguishable from a crash.
+
+**10. Author a gap between stacked boxes.** Boxes placed exactly touching start already
+penetrating by the solver's linear slop, so frame 0 is spent pushing the pile apart —
+which reads as the stack "breathing" before anyone touches it, and differs per engine.
+
+**11. Pixel-space physics.** Matter is a screen-space engine (+y is **down**, the unit is
+the pixel, `gravity.scale` is 1e-3). Every Box2D-family tolerance — linear slop 0.005,
+sleep thresholds, speculative margins — is absolute and tuned for metres. A world built
+at 1 unit = 1 pixel is a world 100x too big with invisible slop.
+
+---
+
+## 4. The balance scale — the equals sign
+
+The brief singled this out. It took four rounds to get right and the last two changed the
+design.
+
+Building it the obvious way — a beam on a revolute pivot with two hanging pans — produces
+a scale whose resting angle is decided by solver noise, because such a beam has no
+restoring torque (trap 3). Raising the pivot above the beam's centre of mass supplies
+one, and doubles as the legibility dial. Measured on Rapier, tilt under one extra unit in
+four:
+
+| `pivotRaise` | 0.00 | 0.05 | **0.15** | 0.30 | 0.60 |
+|---|---:|---:|---:|---:|---:|
+| tilt under +1 in 4 | -66.5° | -31.6° | **-17.8°** | -18.3° | -3.2° |
+| tilt at true equality | -0.001° | 0.004° | **-0.015°** | -0.017° | 0.017° |
+| jitter at equality | 0.000° | 0.000° | **0.000°** | 0.000° | 0.055° |
+
+`bench/probe-kit-scale.mjs` then re-tuned against the **shipping recipe** — loose cubes
+that are dropped in, bounce and slide, rather than an idealised contained slab. All 16
+sampled combinations now meet both criteria (equality within 1°, imbalance past 6°), and
+the default settles at **0.01° with 0.000° of jitter** and tips to its stop under one
+extra unit.
+
+A real balance has mechanical stops, and so does this one (`maxTiltDeg`, default 22).
+Without them an imbalance runs the beam to vertical and puts the low pan through the
+floor.
+
+**And the rule that is not about physics.** `scale.compare()` returns `-1 | 0 | 1` from
+an **integer comparison of what was put in the pans**. It never reads the beam angle, and
+it is correct before a single step has run — there is a test that asserts exactly that,
+including after the beam is forcibly rotated. The beam is how a child *sees* the
+comparison; it is never how the app *knows* it. A curriculum claim must not depend on
+contact ordering. This mirrors [ADR-0009](../../docs/DECISIONS/ADR-0009-stakes-without-loss.md)'s
+"true by construction".
+
+---
+
+## 5. Aiming — the arc is the shot
+
+Three ways to draw a predicted trajectory, each compared against where the ball actually
+went over 2 s of free flight:
+
+| method | max error |
+|---|---:|
+| symplectic Euler (`v += g·dt; p += v·dt`) | 125.01 mm |
+| explicit Euler | 208.33 mm |
+| the continuous parabola | 41.66 mm |
+
+None is right, because none is what Rapier does — and all three become meaningless the
+moment the shot touches anything. So the kit predicts by **stepping a real Rapier world**
+containing the projectile and a mirror of the static scenery. Over 150 steps including a
+bounce off the ground *and* a ricochet off a ramp:
+
+**0.000000 mm divergence.** The dotted arc is the shot, by construction, bounces
+included. A test asserts it every run.
+
+It costs **0.70 ms** per 150-step prediction with the shadow world reused, so the kit
+caches on the aim, caps steps at the tier's `predictSteps`, and stops the path at first
+impact. Known limit, stated because it is silent: the shadow world holds **static**
+geometry only, so an arc aimed through the player's own tower diverges when it gets
+there. Games should stop drawing at `impact`.
+
+`assist()` searches launch angles inside a caller-supplied window, returns the best with
+its **own miss distance** so the caller decides whether to apply it, and returns `null`
+rather than a wild guess when nothing gets close.
+
+---
+
+## 6. The budget the kit enforces
+
+Measured in real Chrome on the actual demo, with CDP `Emulation.setCPUThrottlingRate`
+standing in for slower silicon — `node bench/run-browser.mjs`.
+
+At the **`mid` tier** (241 bodies, all awake — the heaviest scene, `pour`):
+
+| CPU throttle | 1x | 4x | 8x | 10x | 12x | 16x |
+|---|---:|---:|---:|---:|---:|---:|
+| step p99 (ms) | 1.0 | 2.4 | 4.3 | 5.1 | 7.3 | 10.5 |
+| frame p50 (ms) | 8.3 | 8.3 | 8.3 | 8.3 | 8.6 | 14.4 |
+| fps | 120 | 120 | 120 | 120 | 116 | **69** |
+
+Every other scene — 120 dominoes, a 24-link chain, a gear train, the siege — holds
+120 fps at **8x** throttle with step p99 under 3.4 ms.
+
+**The budget: physics gets 4 ms of a 16.67 ms frame, measured as step p99.**
+
+That number is where `autoTune` drops a tier, and it leaves 12 ms for the renderer. At
+the reference tier the heaviest scene stays inside it through 12x CPU throttling, which
+is roughly 2-3x more headroom than the Galaxy Tab A9 should need — its Helio G99 is
+around 4-6x slower single-threaded than this machine.
+
+**Stated plainly: I did not run this on a Galaxy Tab A9.** CDP throttling inserts pauses;
+it does not model a smaller cache or slower memory. The honest claim is "large measured
+headroom against a proxy", and
+[ADR-0004](../../docs/DECISIONS/ADR-0004-no-mic-no-llm-no-3d.md)'s revisit condition —
+a measured frame budget on the actual device — is still owed. The rig to do it is here:
+`?bench=<scene>&tier=<tier>` publishes `globalThis.__bench` from any browser pointed at
+the demo, including one on a tablet.
+
+### Degradation path
+
+`src/tiers.ts`. Three knobs, because only three things cost frame time in a 2D scene.
+
+| tier | bodies | solver iters | particles | predict steps | catch-up cap |
+|---|---:|---:|---:|---:|---:|
+| low | 120 | 4 | 90 | 60 | 3 |
+| **mid** (the floor) | 260 | 4 | 200 | 90 | 4 |
+| high | 500 | 8 | 400 | 120 | 5 |
+| ultra | 900 | 12 | 800 | 180 | 6 |
+
+`guessTier()` starts from `deviceMemory` and `hardwareConcurrency` — and deliberately
+does not require `deviceMemory`, which Safari has never shipped, so an iPad falls through
+to the concurrency path instead of landing on `low`. `autoTune()` then moves one tier at
+a time from measured p99, dropping fast (a child is already seeing jank) and climbing
+slowly (a momentary lull is not evidence).
+
+---
+
+## 7. The API
+
+One line to a world that is already correct.
+
+```ts
+import { createWorld } from "@dynawalla/foundation-physics"
+
+const w = await createWorld({ seed: 7 })        // tier auto-detected, WASM loaded once
+
+w.ground()
+const scale = w.balanceScale({ at: [0, 0] })    // pivot, stops and pan lips already right
+scale.put("left", 4)
+scale.put("right", 5)
+
+function frame(dt: number) {
+  const steps = w.advance(dt)                   // fixed step + interpolation + clamp
+  draw(w.transforms, w.count)                   // [x, y, cos, sin] per body, no allocation
+}
+
+scale.compare()   // -1 | 0 | 1 — integer arithmetic, never the beam angle
+```
+
+Every recipe is one call and returns a small handle:
+
+```ts
+w.stack({ at: [4, 0], rows: 9 })
+w.dominoes({ from: [-6, 0], to: [6, 0], count: 40 })
+w.chain({ from: [0, 8], links: 24, load: 100 })          // load in link-masses
+w.gearTrain({ at: [0, 4], teeth: [16, 32, 12], driveSpeed: 1.4 })
+w.lever({ at: [0, 0], fulcrum: -0.3 })
+w.softBlob({ at: [2, 6], radius: 0.8, firmness: 0.6 })
+w.liquid({ at: [0, 9], count: 300 })                      // capped by the tier
+const gun = w.launcher({ at: [-9, 5] })
+
+gun.predict({ angle: 0.5, speed: 14 })   // { path, impact, impactStep } — exact
+gun.assist(target, { from: playerAngle, window: 0.3 })    // or null
+w.pin(a, b, anchorA, anchorB, [-limit, limit])            // local anchors, real stops
+
+const rec = w.record();  rec.do("drop", x, y);  const tape = rec.stop()
+replay(freshWorld, tape)                                   // bit-identical
+```
+
+Design rules the surface enforces rather than documents:
+
+- **The tier caps you, not your optimism.** `liquid({count: 5000})` on `low` returns 90.
+- **Truth is separate from spectacle.** `compare()`, `momentOf()`, `volumeIn()` and
+  `fallenFraction()` are exact quantities; `tilt()` and `outline()` are explicitly view
+  only.
+- **Assemblies default to not self-colliding**, so trap 1 cannot be re-hit.
+- **`advance()` takes the raw rAF delta** and returns the step count, so scene logic can
+  run on simulation time rather than display time (trap 8).
+- **`initPhysics()` is idempotent** — StrictMode double-mount cannot instantiate the WASM
+  twice.
+
+### Rendering
+
+`src/view/three.ts` is a deliberately thin Three.js binding: 2D physics, **3D
+presentation**. Bodies are extruded in Z and lit by a real key/rim/bounce rig, which is
+where the production value comes from and costs the physics budget nothing.
+`InstancedLayer` is one draw call per shape class, fed straight from the same
+`Float32Array` the world already fills. `frameCamera()` fits a scene's world-space
+rectangle to any aspect ratio, so a phone in portrait pulls back rather than cropping.
+
+---
+
+## 8. Running it
+
+```bash
+npm install
+npm test                     # 17 gates — every claim above that can be gated, is
+npm run tsc
+npm run demo                 # http://localhost:1425 — six scenes, live perf HUD
+
+node bench/run-node.mjs --repeat 3     # the bake-off
+node bench/probe-scale.mjs             # four engines x five pivot heights
+node bench/probe-kit-scale.mjs         # tune the shipping recipe
+node bench/probe-rope.mjs              # the chain mass-ratio cliff
+node bench/probe-dominoes.mjs          # chain-reaction propagation vs friction
+node bench/run-browser.mjs             # real Chrome, CPU-throttled  (needs npm run demo)
+node bench/determinism.mjs             # V8 vs JavaScriptCore        (needs npm run demo)
+```
+
+`bench/run-browser.mjs --webkit` runs the same measurement in WebKit/JavaScriptCore, the
+closest available proxy for iOS WKWebView.
+
+## 9. What is still owed
+
+1. **A real Galaxy Tab A9 run.** The rig exists; the device does not. This is
+   ADR-0004's stated revisit condition and it is not satisfied by a proxy.
+2. **Cross-architecture determinism.** Verified across three JS engines on arm64 only.
+3. **Inside a Tauri WebView**, rather than a browser — in particular whether the custom
+   protocol serves `.wasm` with a MIME type that allows
+   `WebAssembly.instantiateStreaming`, which is worth an early check because the fallback
+   path is slower and silent.
+4. **The `-compat` → separate-`.wasm` switch** before shipping, worth ~200 KB gzip.
+5. **Soft bodies and liquid are approximations** and say so: the liquid has no pressure
+   term, so it pours and splits convincingly but will not self-level. If a game needs a
+   true flat surface, draw the surface from the particle count and use particles only for
+   the pour.

--- a/dynawalla/foundations/physics/README.md
+++ b/dynawalla/foundations/physics/README.md
@@ -445,6 +445,24 @@ where the production value comes from and costs the physics budget nothing.
 `InstancedLayer` is one draw call per shape class, fed straight from the same
 `Float32Array` the world already fills. `frameCamera()` fits a scene's world-space
 rectangle to any aspect ratio, so a phone in portrait pulls back rather than cropping.
+`SoftMesh` fills a soft body from its `outline()` — drawn as ring beads a pressurised
+ring reads as a *donut*, because the hole is what the ring is holding open.
+
+Three rendering traps were hit building the demo and are fixed in the binding, because
+every prototype would otherwise hit all three:
+
+- **`metalness` near 1 with no environment map renders black.** A metal has no diffuse
+  term; its colour is entirely what it reflects. Brass gear teeth and a copper pan came
+  out charcoal under four lights. Adding lights cannot fix it — only an environment can.
+  `bazaarEnvironment()` pre-filters a procedurally generated `RoomEnvironment` once at
+  startup (no texture to ship, CSP-safe) and it transformed the scene.
+- **The two unit geometries do not share a convention.** `BoxGeometry(1,1,1)` spans
+  -0.5..0.5 so a box scales by its *full* extents; `CylinderGeometry(1,1,1)` has *radius*
+  1, so a disc scales by its radius. Scaling a disc by `r * 2` draws it at double size,
+  silently — it put the camera inside the gear train.
+- **Coplanar overlays z-fight.** Teeth exactly as deep as the gear blank stipple around
+  the rim and read as a texture bug. Inset the overlay, matching the repo's existing
+  "bake, do not overlay" lesson from `GAME_DEV_PLAYBOOK.md`.
 
 ---
 

--- a/dynawalla/foundations/physics/bench/adapters/box2d3.mjs
+++ b/dynawalla/foundations/physics/bench/adapters/box2d3.mjs
@@ -1,0 +1,139 @@
+// Box2D v3 adapter (box2d3-wasm 5.2.0 -> Box2D v3.x, Erin Catto's soft-step solver).
+//
+// Two things about this binding are load-bearing and neither is in its README:
+//
+// 1. The package's entry point picks the SIMD ("deluxe") build only when
+//    `WebAssembly.validate(<simd probe>)` passes AND, in a browser,
+//    `window.crossOriginIsolated === true`. A Tauri WebView is not
+//    cross-origin-isolated unless you add COOP/COEP to the custom protocol
+//    response, so the default browser path silently takes the scalar "compat"
+//    build. We import the build we want explicitly and report which one ran.
+//
+// 2. It is an Embind binding, so every value returned by a getter is a heap
+//    handle the caller must `.delete()`. `b2Body_GetPosition()` in a
+//    per-frame render loop allocates one object per body per frame. This
+//    adapter deletes them; the cost of doing so is part of what we measure.
+
+export const meta = { id: "box2d3", label: "Box2D v3 (box2d3-wasm 5.2.0)", wasm: true }
+
+let B = null
+let variantUsed = "?"
+
+export async function init(variant = "auto") {
+  if (variant === "deluxe" || variant === "compat") {
+    const mod = await import(`box2d3-wasm/build/dist/es/${variant}/Box2D.${variant}.mjs`)
+    B = await mod.default()
+    variantUsed = variant
+  } else {
+    const mod = await import("box2d3-wasm")
+    B = await mod.default()
+    // The entry point does not tell you which one it picked. Infer it.
+    variantUsed = WebAssembly.validate(
+      new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 96, 0, 1, 123, 3, 2, 1, 0, 10, 10, 1, 8, 0, 65, 0, 253, 15, 253, 98, 11]),
+    )
+      ? "deluxe(simd)"
+      : "compat"
+  }
+  return `v3 / ${variantUsed}`
+}
+
+export function variant() {
+  return variantUsed
+}
+
+export function build(scene, opts = {}) {
+  const dt = opts.dt ?? 1 / 60
+  // Box2D v3 takes a SUB-STEP count, not velocity/position iteration counts.
+  // 4 is the library default and what Erin tunes against.
+  const subSteps = opts.subSteps ?? 4
+
+  const wd = B.b2DefaultWorldDef()
+  wd.gravity = new B.b2Vec2(scene.gravity[0], scene.gravity[1])
+  if (opts.noSleep) wd.enableSleep = false
+  const worldId = B.b2CreateWorld(wd)
+
+  const handles = []
+  const dynamicIdx = []
+
+  for (const b of scene.bodies) {
+    const bd = B.b2DefaultBodyDef()
+    bd.type = b.kind === "static" ? B.b2BodyType.b2_staticBody : B.b2BodyType.b2_dynamicBody
+    bd.position = new B.b2Vec2(b.pos[0], b.pos[1])
+    if (b.angle) bd.rotation = B.b2MakeRot(b.angle)
+    if (b.velocity) bd.linearVelocity = new B.b2Vec2(b.velocity[0], b.velocity[1])
+    const id = B.b2CreateBody(worldId, bd)
+
+    const sd = B.b2DefaultShapeDef()
+    sd.density = b.density ?? 1
+    // `material` is a nested value getter: mutate a copy, then assign it back.
+    // Writing `sd.material.friction = x` compiles, runs, and does nothing.
+    const mat = sd.material
+    mat.friction = b.friction ?? 0.5
+    mat.restitution = b.restitution ?? 0
+    sd.material = mat
+
+    for (const sh of b.shapes ?? [b.shape]) {
+      if (sh.box) {
+        // b2MakeBox is origin-centred; b2MakeOffsetBox takes a centre + rotation.
+        const poly = sh.at
+          ? B.b2MakeOffsetBox(sh.box[0], sh.box[1], new B.b2Vec2(sh.at[0], sh.at[1]), B.b2Rot_identity)
+          : B.b2MakeBox(sh.box[0], sh.box[1])
+        B.b2CreatePolygonShape(id, sd, poly)
+      } else {
+        const circle = new B.b2Circle()
+        circle.center = new B.b2Vec2(sh.at ? sh.at[0] : 0, sh.at ? sh.at[1] : 0)
+        circle.radius = sh.circle
+        B.b2CreateCircleShape(id, sd, circle)
+      }
+    }
+
+    handles.push(id)
+    if (b.kind !== "static") dynamicIdx.push(handles.length - 1)
+  }
+
+  for (const j of scene.joints) {
+    if (j.type !== "revolute") throw new Error(`box2d3 adapter: joint ${j.type}`)
+    const jd = B.b2DefaultRevoluteJointDef()
+    const base = jd.base
+    base.bodyIdA = handles[j.a]
+    base.bodyIdB = handles[j.b]
+    // v3.1 renamed localAnchorA/B to localFrameA/B (a b2Transform).
+    const fa = base.localFrameA
+    fa.p = new B.b2Vec2(j.anchorA[0], j.anchorA[1])
+    base.localFrameA = fa
+    const fb = base.localFrameB
+    fb.p = new B.b2Vec2(j.anchorB[0], j.anchorB[1])
+    base.localFrameB = fb
+    jd.base = base
+    B.b2CreateRevoluteJoint(worldId, jd)
+  }
+
+  const out = new Float64Array(dynamicIdx.length * 3)
+
+  return {
+    step() {
+      B.b2World_Step(worldId, dt, subSteps)
+    },
+    snapshot() {
+      for (let k = 0; k < dynamicIdx.length; k++) {
+        const id = handles[dynamicIdx[k]]
+        const p = B.b2Body_GetPosition(id)
+        const r = B.b2Body_GetRotation(id)
+        out[k * 3] = p.x
+        out[k * 3 + 1] = p.y
+        out[k * 3 + 2] = B.b2Rot_GetAngle(r)
+        p.delete()
+        r.delete()
+      }
+      return out
+    },
+    awake() {
+      let n = 0
+      for (const i of dynamicIdx) if (B.b2Body_IsAwake(handles[i])) n++
+      return n
+    },
+    destroy() {
+      B.b2DestroyWorld(worldId)
+    },
+  }
+}

--- a/dynawalla/foundations/physics/bench/adapters/matter.mjs
+++ b/dynawalla/foundations/physics/bench/adapters/matter.mjs
@@ -1,0 +1,104 @@
+// Matter.js adapter (matter-js 0.20.0).
+//
+// Matter is not a metric engine. It is a SCREEN-SPACE engine: +y is down, the
+// unit is the pixel, and its tolerances (`Resolver._restingThresh`, slop 0.05,
+// `gravity.scale` 1e-3) are tuned for a world a few hundred pixels tall. So the
+// adapter converts: 100 px = 1 m, and y is flipped on the way in and on the way
+// out. Anyone porting a Matter prototype to any other engine pays this tax once
+// and it is easy to get subtly wrong — which is itself a finding.
+//
+// Its constraints are position-based soft constraints applied in a fixed
+// number of passes, not a joint solver. A revolute is "length 0, stiffness 1".
+
+import Matter from "matter-js"
+
+const { Engine, Bodies, Body, Composite, Constraint } = Matter
+
+const S = 100 // px per metre
+
+export const meta = { id: "matter", label: "Matter.js 0.20.0 (pure JS)", wasm: false }
+
+export async function init() {
+  return "0.20.0"
+}
+
+export function build(scene, opts = {}) {
+  const dtMs = (opts.dt ?? 1 / 60) * 1000
+  const engine = Engine.create()
+  // Matter's default gravity {y:1, scale:0.001} works out to ~1000 px/s^2,
+  // which at 100 px/m is the 10 m/s^2 every other adapter gets.
+  engine.gravity.x = scene.gravity[0] / 10
+  engine.gravity.y = -scene.gravity[1] / 10
+  if (opts.matterIterations) {
+    engine.positionIterations = opts.matterIterations
+    engine.velocityIterations = opts.matterIterations
+  }
+
+  const handles = []
+  const dynamicIdx = []
+
+  scene.bodies.forEach((b, i) => {
+    const isStatic = b.kind === "static"
+    const x = b.pos[0] * S
+    const y = -b.pos[1] * S
+    const opts = { friction: b.friction ?? 0.5, restitution: b.restitution ?? 0 }
+    const mk = (sh) => {
+      const ox = x + (sh.at ? sh.at[0] * S : 0)
+      const oy = y - (sh.at ? sh.at[1] * S : 0)
+      return sh.box
+        ? Bodies.rectangle(ox, oy, sh.box[0] * 2 * S, sh.box[1] * 2 * S, opts)
+        : Bodies.circle(ox, oy, sh.circle * S, opts)
+    }
+    const shapes = b.shapes ?? [b.shape]
+    const body =
+      shapes.length === 1 ? mk(shapes[0]) : Body.create({ parts: shapes.map(mk), ...opts })
+    if (isStatic) Body.setStatic(body, true)
+    if (b.angle) Body.setAngle(body, -b.angle)
+    if (!isStatic) Body.setDensity(body, (b.density ?? 1) * 0.001)
+    if (b.velocity) Body.setVelocity(body, { x: (b.velocity[0] * S) / 60, y: (-b.velocity[1] * S) / 60 })
+    Composite.add(engine.world, body)
+    handles.push(body)
+    if (!isStatic) dynamicIdx.push(i)
+  })
+
+  for (const j of scene.joints) {
+    if (j.type !== "revolute") throw new Error(`matter adapter: joint ${j.type}`)
+    Composite.add(
+      engine.world,
+      Constraint.create({
+        bodyA: handles[j.a],
+        pointA: { x: j.anchorA[0] * S, y: -j.anchorA[1] * S },
+        bodyB: handles[j.b],
+        pointB: { x: j.anchorB[0] * S, y: -j.anchorB[1] * S },
+        length: 0,
+        stiffness: 1,
+        damping: 0,
+      }),
+    )
+  }
+
+  const out = new Float64Array(dynamicIdx.length * 3)
+
+  return {
+    step() {
+      Engine.update(engine, dtMs)
+    },
+    snapshot() {
+      for (let k = 0; k < dynamicIdx.length; k++) {
+        const body = handles[dynamicIdx[k]]
+        out[k * 3] = body.position.x / S
+        out[k * 3 + 1] = -body.position.y / S
+        out[k * 3 + 2] = -body.angle
+      }
+      return out
+    },
+    awake() {
+      let n = 0
+      for (const i of dynamicIdx) if (!handles[i].isSleeping) n++
+      return n
+    },
+    destroy() {
+      Engine.clear(engine)
+    },
+  }
+}

--- a/dynawalla/foundations/physics/bench/adapters/planck.mjs
+++ b/dynawalla/foundations/physics/bench/adapters/planck.mjs
@@ -1,0 +1,87 @@
+// Planck.js adapter (planck 1.5.0) — a pure-JS port of Box2D 2.4.
+// No WASM, so no init cost, no COOP/COEP question, and it tree-shakes.
+
+import * as pl from "planck"
+
+export const meta = { id: "planck", label: "Planck.js 1.5.0 (pure JS)", wasm: false }
+
+export async function init() {
+  return "1.5.0"
+}
+
+/** Local anchor -> world anchor. Planck's revolute joint takes ONE world point. */
+function worldAnchor(body, local) {
+  const c = Math.cos(body.angle ?? 0)
+  const s = Math.sin(body.angle ?? 0)
+  return {
+    x: body.pos[0] + local[0] * c - local[1] * s,
+    y: body.pos[1] + local[0] * s + local[1] * c,
+  }
+}
+
+export function build(scene, opts = {}) {
+  const dt = opts.dt ?? 1 / 60
+  const velIters = opts.velocityIterations ?? 8
+  const posIters = opts.positionIterations ?? 3
+  const world = new pl.World({
+    gravity: new pl.Vec2(scene.gravity[0], scene.gravity[1]),
+    allowSleep: !opts.noSleep,
+  })
+
+  const handles = []
+  const dynamicIdx = []
+
+  scene.bodies.forEach((b, i) => {
+    const body = world.createBody({
+      type: b.kind === "static" ? "static" : "dynamic",
+      position: new pl.Vec2(b.pos[0], b.pos[1]),
+      angle: b.angle ?? 0,
+      ...(b.velocity ? { linearVelocity: new pl.Vec2(b.velocity[0], b.velocity[1]) } : {}),
+    })
+    for (const sh of b.shapes ?? [b.shape]) {
+      const at = sh.at ? new pl.Vec2(sh.at[0], sh.at[1]) : new pl.Vec2(0, 0)
+      const shape = sh.box
+        ? new pl.Box(sh.box[0], sh.box[1], at, 0)
+        : new pl.Circle(at, sh.circle)
+      body.createFixture(shape, {
+        density: b.density ?? 1,
+        friction: b.friction ?? 0.5,
+        restitution: b.restitution ?? 0,
+      })
+    }
+    handles.push(body)
+    if (b.kind !== "static") dynamicIdx.push(i)
+  })
+
+  for (const j of scene.joints) {
+    if (j.type !== "revolute") throw new Error(`planck adapter: joint ${j.type}`)
+    const wa = worldAnchor(scene.bodies[j.a], j.anchorA)
+    world.createJoint(
+      new pl.RevoluteJoint({}, handles[j.a], handles[j.b], new pl.Vec2(wa.x, wa.y)),
+    )
+  }
+
+  const out = new Float64Array(dynamicIdx.length * 3)
+
+  return {
+    step() {
+      world.step(dt, velIters, posIters)
+    },
+    snapshot() {
+      for (let k = 0; k < dynamicIdx.length; k++) {
+        const body = handles[dynamicIdx[k]]
+        const p = body.getPosition()
+        out[k * 3] = p.x
+        out[k * 3 + 1] = p.y
+        out[k * 3 + 2] = body.getAngle()
+      }
+      return out
+    },
+    awake() {
+      let n = 0
+      for (const i of dynamicIdx) if (handles[i].isAwake()) n++
+      return n
+    },
+    destroy() {},
+  }
+}

--- a/dynawalla/foundations/physics/bench/adapters/rapier.mjs
+++ b/dynawalla/foundations/physics/bench/adapters/rapier.mjs
@@ -1,0 +1,123 @@
+// Rapier 2D adapter (@dimforge/rapier2d-compat 0.19.3).
+//
+// `-compat` inlines the WASM as base64 in the JS so there is no second fetch
+// and no asset-path plumbing. That costs ~33% over the raw binary on disk
+// (6.4 MB unpacked vs 2.3 MB) but the WASM itself is identical; see README for
+// the measured transfer numbers and which one to ship.
+
+let RAPIER = null
+
+export const meta = {
+  id: "rapier",
+  label: "Rapier 2D 0.19.3",
+  wasm: true,
+}
+
+export async function init(variant = "default") {
+  const mod =
+    variant === "deterministic"
+      ? await import("@dimforge/rapier2d-deterministic-compat")
+      : await import("@dimforge/rapier2d-compat")
+  RAPIER = mod.default ?? mod
+  await RAPIER.init()
+  return RAPIER.version()
+}
+
+// Rapier's JS API has NO `collideConnected` flag on impulse joints — unlike
+// Box2D, Planck and Matter, whose joints default to NOT colliding the bodies
+// they connect. In Rapier, jointed bodies DO collide, and because a joint by
+// construction holds two colliders overlapping at the anchor, the contact and
+// the joint fight each other and the joint jams solid.
+//
+// Measured: a simple pendulum (fixed anchor + arm, revolute at the shared
+// point) rotates -33.0 deg in 5 s if the anchor has no collider, and 0.0 deg —
+// frozen horizontal in mid-air — if it does. Same joint, same masses.
+//
+// The fix is one membership bit for the whole articulated assembly, cleared
+// from its own filter: the assembly never collides with itself and still
+// collides with everything else.
+const ASSEMBLY_BIT = 0x0002
+const ASSEMBLY_GROUPS = (ASSEMBLY_BIT << 16) | (0xffff & ~ASSEMBLY_BIT)
+
+export function build(scene, opts = {}) {
+  const world = new RAPIER.World({ x: scene.gravity[0], y: scene.gravity[1] })
+  world.timestep = opts.dt ?? 1 / 60
+  if (opts.solverIterations) world.numSolverIterations = opts.solverIterations
+
+  // Every body that participates in a joint joins the assembly group, unless
+  // the caller explicitly asks for Rapier's raw default in order to see it.
+  const jointed = new Set()
+  if (!opts.rawJointDefaults) {
+    for (const j of scene.joints) {
+      jointed.add(j.a)
+      jointed.add(j.b)
+    }
+  }
+
+  const handles = []
+  const dynamicIdx = []
+
+  scene.bodies.forEach((b, i) => {
+    const desc =
+      b.kind === "static"
+        ? RAPIER.RigidBodyDesc.fixed()
+        : RAPIER.RigidBodyDesc.dynamic()
+    desc.setTranslation(b.pos[0], b.pos[1])
+    if (b.angle) desc.setRotation(b.angle)
+    if (b.velocity) desc.setLinvel(b.velocity[0], b.velocity[1])
+    if (opts.noSleep) desc.setCanSleep(false)
+    const body = world.createRigidBody(desc)
+
+    for (const sh of b.shapes ?? [b.shape]) {
+      const cd = sh.box
+        ? RAPIER.ColliderDesc.cuboid(sh.box[0], sh.box[1])
+        : RAPIER.ColliderDesc.ball(sh.circle)
+      cd.setDensity(b.density ?? 1)
+      cd.setFriction(b.friction ?? 0.5)
+      cd.setRestitution(b.restitution ?? 0)
+      if (sh.at) cd.setTranslation(sh.at[0], sh.at[1])
+      if (jointed.has(i)) cd.setCollisionGroups(ASSEMBLY_GROUPS)
+      world.createCollider(cd, body)
+    }
+
+    handles.push(body)
+    if (b.kind !== "static") dynamicIdx.push(i)
+  })
+
+  for (const j of scene.joints) {
+    if (j.type !== "revolute") throw new Error(`rapier adapter: joint ${j.type}`)
+    const data = RAPIER.JointData.revolute(
+      { x: j.anchorA[0], y: j.anchorA[1] },
+      { x: j.anchorB[0], y: j.anchorB[1] },
+    )
+    world.createImpulseJoint(data, handles[j.a], handles[j.b], true)
+  }
+
+  const out = new Float64Array(dynamicIdx.length * 3)
+
+  return {
+    step() {
+      world.step()
+    },
+    snapshot() {
+      for (let k = 0; k < dynamicIdx.length; k++) {
+        const body = handles[dynamicIdx[k]]
+        const t = body.translation()
+        out[k * 3] = t.x
+        out[k * 3 + 1] = t.y
+        out[k * 3 + 2] = body.rotation()
+      }
+      return out
+    },
+    // How many bodies the solver actually touched this step. Rapier does not
+    // expose an awake count directly, so this counts non-sleeping bodies.
+    awake() {
+      let n = 0
+      for (const i of dynamicIdx) if (!handles[i].isSleeping()) n++
+      return n
+    },
+    destroy() {
+      world.free()
+    },
+  }
+}

--- a/dynawalla/foundations/physics/bench/determinism.mjs
+++ b/dynawalla/foundations/physics/bench/determinism.mjs
@@ -1,0 +1,97 @@
+// Cross-engine determinism: does the SAME scene produce the SAME state in
+// Node/V8, Chrome/V8 and WebKit/JavaScriptCore?
+//
+// This is the question a maths product actually has to answer, because the two
+// runtimes we ship into are a Chromium WebView on Android and WKWebView (which
+// is JavaScriptCore) on iOS. "Rapier is deterministic" is a claim about one
+// binary on one machine and is not by itself an answer.
+//
+// It runs a fixed, seeded scene for a fixed number of steps and prints the
+// quantised state hash from each engine, plus the raw f32 of a few bodies so a
+// divergence can be localised rather than just detected.
+//
+//   node bench/determinism.mjs              (requires `npm run demo` running)
+//
+// The scene is deliberately nasty: a stack that topples, loose liquid
+// particles, and a jointed chain — contacts, islands and constraints all at
+// once, which is where an ordering difference would show up first.
+
+import { setTimeout as sleep } from "node:timers/promises"
+
+const PORT = 1425
+const BASE = `http://localhost:${PORT}`
+const STEPS = 900
+const SEED = 20260726
+
+async function runNode() {
+  const { createWorld } = await import("../src/index.ts")
+  const w = await createWorld({ seed: SEED, tier: "mid" })
+  buildScene(w)
+  w.stepExact(STEPS)
+  const out = { hash: w.hash(), probe: probe(w) }
+  w.dispose()
+  return out
+}
+
+/** Kept in one place so Node and the browsers cannot drift apart. */
+export function buildScene(w) {
+  w.ground(20)
+  w.stack({ at: [0, 0], rows: 8, size: 0.28 })
+  w.chain({ from: [-7, 9], links: 18, load: 40 })
+  w.liquid({ at: [3, 12], count: 120, drop: 0.11 })
+  const gun = w.launcher({ at: [-9, 6] })
+  gun.fire({ angle: 0.18, speed: 15 })
+  return w
+}
+
+export function probe(w) {
+  // First, middle and last live body, at full f32 precision.
+  const n = w.count
+  const pick = [0, n >> 1, n - 1]
+  return pick.map((i) => [w.transforms[i * 4], w.transforms[i * 4 + 1]].map((v) => v.toExponential(9)).join(","))
+}
+
+const node = await runNode()
+console.log(`Node ${process.version} / V8`.padEnd(34) + node.hash)
+
+const { chromium, webkit } = await import("playwright")
+const engines = [
+  ["Chrome / V8", () => chromium.launch({ channel: "chrome" })],
+  ["WebKit / JavaScriptCore", () => webkit.launch()],
+]
+
+const rows = [{ engine: `Node ${process.version} / V8`, ...node }]
+for (const [name, launch] of engines) {
+  let browser
+  try {
+    browser = await launch()
+  } catch (err) {
+    console.log(`${name.padEnd(34)} unavailable (${String(err).split("\n")[0]})`)
+    continue
+  }
+  const page = await browser.newPage()
+  const errs = []
+  page.on("pageerror", (e) => errs.push(String(e)))
+  await page.goto(`${BASE}/determinism.html?seed=${SEED}&steps=${STEPS}`, { waitUntil: "load" })
+  try {
+    await page.waitForFunction("globalThis.__det !== undefined", null, { timeout: 120_000 })
+  } catch {
+    console.log(`${name.padEnd(34)} TIMED OUT ${errs[0] ?? ""}`)
+    await browser.close()
+    continue
+  }
+  const det = await page.evaluate("globalThis.__det")
+  console.log(`${name.padEnd(34)}${det.hash}   ${await browser.version()}`)
+  rows.push({ engine: name, ...det })
+  await browser.close()
+  await sleep(50)
+}
+
+const allSame = rows.every((r) => r.hash === rows[0].hash)
+console.log(
+  `\n${rows.length} engines, ${STEPS} steps, seed ${SEED}: ` +
+    (allSame ? "IDENTICAL state hash" : "DIVERGED"),
+)
+if (!allSame) {
+  for (const r of rows) console.log(`  ${r.engine.padEnd(30)} ${r.hash}  ${r.probe.join("  ")}`)
+}

--- a/dynawalla/foundations/physics/bench/harness.mjs
+++ b/dynawalla/foundations/physics/bench/harness.mjs
@@ -1,0 +1,177 @@
+// The measurement harness. Shared by the Node runner and the browser runner so
+// that both report the same numbers computed the same way.
+//
+// What it measures and why:
+//
+// - We report p50/p95/p99/max of the PER-STEP cost, never the mean alone. A
+//   60 fps budget is not an average, it is a promise about the worst frame a
+//   child sees. The dominoes scene proves the point: an engine with sleeping
+//   does nothing at all for 200 steps and then does everything at once, and its
+//   mean is a lie.
+// - We time `step()` and `snapshot()` separately. Reading transforms out for
+//   the renderer is real per-frame cost that a "physics benchmark" usually
+//   hides, and for a WASM engine with a handle-based binding it can rival the
+//   solve.
+// - We hash the final state so the same scene can be compared across engines,
+//   across runs, and across JS engines. See determinism.mjs.
+
+/** FNV-1a over the raw bytes of a Float64Array. Order-sensitive, which is what we want. */
+export function hashState(f64) {
+  const bytes = new Uint8Array(f64.buffer, f64.byteOffset, f64.byteLength)
+  let h = 0x811c9dc5
+  for (let i = 0; i < bytes.length; i++) {
+    h ^= bytes[i]
+    h = Math.imul(h, 0x01000193) >>> 0
+  }
+  return h.toString(16).padStart(8, "0")
+}
+
+/** Quantised hash: tolerant to sub-millimetre drift, still catches divergence. */
+export function hashQuantised(f64, places = 4) {
+  const m = 10 ** places
+  let h = 0x811c9dc5
+  for (let i = 0; i < f64.length; i++) {
+    // `| 0` after rounding keeps this integer-exact for our world scale.
+    const q = Math.round(f64[i] * m) | 0
+    h ^= q & 0xff
+    h = Math.imul(h, 0x01000193) >>> 0
+    h ^= (q >>> 8) & 0xff
+    h = Math.imul(h, 0x01000193) >>> 0
+    h ^= (q >>> 16) & 0xff
+    h = Math.imul(h, 0x01000193) >>> 0
+    h ^= (q >>> 24) & 0xff
+    h = Math.imul(h, 0x01000193) >>> 0
+  }
+  return h.toString(16).padStart(8, "0")
+}
+
+function percentile(sorted, p) {
+  if (sorted.length === 0) return 0
+  const i = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1))
+  return sorted[i]
+}
+
+const now =
+  typeof performance !== "undefined" && performance.now
+    ? () => performance.now()
+    : () => Number(process.hrtime.bigint()) / 1e6
+
+/**
+ * @param {object} sim   built by an adapter
+ * @param {number} steps
+ * @param {object} opts  { warmup, snapshotEvery }
+ */
+export function measure(sim, steps, opts = {}) {
+  const warmup = opts.warmup ?? 30
+  // Snapshot every frame by default: that is what a renderer does.
+  const snapshotEvery = opts.snapshotEvery ?? 1
+
+  for (let i = 0; i < warmup; i++) sim.step()
+
+  const stepTimes = new Float64Array(steps)
+  const snapTimes = []
+  let awakeMax = 0
+  let awakeSum = 0
+
+  for (let i = 0; i < steps; i++) {
+    const t0 = now()
+    sim.step()
+    const t1 = now()
+    stepTimes[i] = t1 - t0
+    if (i % snapshotEvery === 0) {
+      const s0 = now()
+      sim.snapshot()
+      snapTimes.push(now() - s0)
+    }
+    if (i % 30 === 0) {
+      const a = sim.awake()
+      awakeSum += a
+      if (a > awakeMax) awakeMax = a
+    }
+  }
+
+  const finalState = Float64Array.from(sim.snapshot())
+  const sorted = Float64Array.from(stepTimes).sort()
+  const snapSorted = Float64Array.from(snapTimes).sort()
+  const total = stepTimes.reduce((a, b) => a + b, 0)
+
+  return {
+    steps,
+    mean: total / steps,
+    p50: percentile(sorted, 50),
+    p95: percentile(sorted, 95),
+    p99: percentile(sorted, 99),
+    max: sorted[sorted.length - 1],
+    snapMean: snapTimes.reduce((a, b) => a + b, 0) / Math.max(1, snapTimes.length),
+    snapP99: percentile(snapSorted, 99),
+    awakeMax,
+    awakeMean: awakeSum / Math.ceil(steps / 30),
+    hash: hashState(finalState),
+    hashQ: hashQuantised(finalState),
+    state: finalState,
+  }
+}
+
+/**
+ * Scene-specific quality probes. Speed is necessary but not sufficient: a fast
+ * engine that lets the pyramid sink into the floor or the rope stretch to twice
+ * its length is not usable for a product where the physics IS the explanation.
+ */
+export function quality(sceneName, scene, state, ropeRest = 12.25) {
+  const dyn = scene.bodies.map((b, i) => [b, i]).filter(([b]) => b.kind !== "static")
+  const at = (k) => ({ x: state[k * 3], y: state[k * 3 + 1], a: state[k * 3 + 2] })
+
+  if (sceneName === "rope-60") {
+    // Measured chain span vs rest length. A sequential-impulse solver with too
+    // few iterations shows up here as a rope that visibly stretches under the
+    // bob. The floor is dynamic-body index -1 in this scene (it is static), so
+    // the chain starts at dynamic 0.
+    const n = dyn.length
+    let span = 0
+    for (let k = 1; k < n; k++) {
+      const p = at(k - 1)
+      const q = at(k)
+      span += Math.hypot(q.x - p.x, q.y - p.y)
+    }
+    return { stretchPct: ((span - ropeRest) / ropeRest) * 100 }
+  }
+
+  if (sceneName === "balance-scale") {
+    // The beam is body index 2 (dynamic #0). Equal mass in both pans must read
+    // as level. Anything over ~1 degree is visible and reads as a broken
+    // equals sign.
+    const beam = at(0)
+    return { beamTiltDeg: (beam.a * 180) / Math.PI }
+  }
+
+  if (sceneName === "pyramid-topple" || sceneName === "debris-500") {
+    // Deepest penetration below the floor surface (floor top is y = 0).
+    // Bodies that rolled off the end of the floor are excluded — they are
+    // falling, not sinking, and would swamp the metric.
+    //
+    // A settled box can legitimately have its centre as low as its SMALLEST
+    // half-extent (resting on its long face), so that is the floor we measure
+    // against. Anything below it is penetration the engine failed to push out.
+    const edge = sceneName === "pyramid-topple" ? 13.5 : 9.5
+    let worst = 0
+    for (let k = 0; k < dyn.length; k++) {
+      const [b] = dyn[k]
+      const p = at(k)
+      if (Math.abs(p.x) > edge) continue
+      const lowest = b.shape.box ? Math.min(b.shape.box[0], b.shape.box[1]) : b.shape.circle
+      const bottom = p.y - lowest
+      if (bottom < worst) worst = bottom
+    }
+    return { sinkMm: Math.round(-worst * 1000) }
+  }
+
+  if (sceneName === "dominoes-300") {
+    // How far the chain reaction actually travelled: count fallen dominoes.
+    let fallen = 0
+    for (let k = 0; k < dyn.length; k++) {
+      if (Math.abs(at(k).a) > 0.7) fallen++
+    }
+    return { fallen, ofTotal: dyn.length }
+  }
+  return {}
+}

--- a/dynawalla/foundations/physics/bench/probe-dominoes.mjs
+++ b/dynawalla/foundations/physics/bench/probe-dominoes.mjs
@@ -1,0 +1,42 @@
+// PROBE: does the chain reaction survive the friction the art direction wants?
+//
+// "Dominoes and chain reactions" is on the required list, and friction is the
+// one parameter that decides whether a run propagates. A game will want it
+// high — high friction is what makes blocks feel heavy and stay where they are
+// put — so an engine that only propagates when everything is slippery is not
+// usable.
+//
+// Reported as dominoes fallen (|angle| > 0.7 rad) out of 300 after 15 s.
+//
+//   node bench/probe-dominoes.mjs
+
+import { SCENES } from "./scenes.mjs"
+
+const ADAPTERS = {
+  rapier: () => import("./adapters/rapier.mjs"),
+  box2d3: () => import("./adapters/box2d3.mjs"),
+  planck: () => import("./adapters/planck.mjs"),
+  matter: () => import("./adapters/matter.mjs"),
+}
+
+const FRICTIONS = [0.1, 0.2, 0.3, 0.45, 0.7]
+
+console.log("dominoes fallen out of 300 after 900 steps, by friction")
+console.log("engine".padEnd(9) + FRICTIONS.map((f) => String(f).padStart(8)).join(""))
+
+for (const id of Object.keys(ADAPTERS)) {
+  const mod = await ADAPTERS[id]()
+  await mod.init()
+  const row = FRICTIONS.map((f) => {
+    const scene = SCENES["dominoes-300"]()
+    for (const b of scene.bodies) if (b.kind !== "static") b.friction = f
+    const sim = mod.build(scene, {})
+    for (let i = 0; i < scene.steps; i++) sim.step()
+    const s = sim.snapshot()
+    let fallen = 0
+    for (let k = 0; k < s.length / 3; k++) if (Math.abs(s[k * 3 + 2]) > 0.7) fallen++
+    sim.destroy()
+    return String(fallen).padStart(8)
+  })
+  console.log(id.padEnd(9) + row.join(""))
+}

--- a/dynawalla/foundations/physics/bench/probe-kit-scale.mjs
+++ b/dynawalla/foundations/physics/bench/probe-kit-scale.mjs
@@ -1,0 +1,78 @@
+// PROBE: tune the SHIPPING balance-scale recipe, not an idealised test rig.
+//
+// bench/probe-scale.mjs compared four engines on a scale carrying one contained
+// slab per pan. The kit's real scale carries LOOSE CUBES that are dropped in,
+// bounce, and slide — and that transient turned out to knock the beam onto its
+// mechanical stop and leave it there, so an equality read as a 12 deg tilt.
+//
+// This sweeps the two dials that fix it against the real recipe:
+//   pivotRaise    restoring torque (and therefore how fast level wins)
+//   beamDamping   angular damping on the beam, which kills the drop transient
+//
+// Pass criteria, in the product's terms:
+//   equal    |tilt| <= 1.0 deg      a child must read 4 = 4 as level
+//   unequal  tilt   <= -6.0 deg     and 4 < 5 as unmistakably tipped
+//
+//   node bench/probe-kit-scale.mjs
+
+import { createWorld } from "../src/index.ts"
+
+const DEG = 180 / Math.PI
+
+async function run({ pivotRaise, beamDamping, extraRight }) {
+  const w = await createWorld({ seed: 5, tier: "mid" })
+  w.ground(24)
+  const scale = w.balanceScale({ at: [0, 0], pivotRaise })
+  if (beamDamping) scale.beam.rb.setAngularDamping(beamDamping)
+  scale.put("left", 4)
+  scale.put("right", 4 + extraRight)
+  w.stepExact(900)
+  const settle = scale.tilt() * DEG
+  // Peak-to-peak over the last 2 s: a scale that is still hunting has not
+  // settled, however good its final frame happens to look.
+  let lo = Infinity
+  let hi = -Infinity
+  for (let i = 0; i < 120; i++) {
+    w.stepExact(1)
+    const t = scale.tilt() * DEG
+    if (t < lo) lo = t
+    if (t > hi) hi = t
+  }
+  w.dispose()
+  return { settle, jitter: hi - lo }
+}
+
+console.log("recipe sweep — loose cubes, dropped in, as the demo really does it")
+console.log(
+  "raise".padEnd(8) + "damping".padEnd(9) + "4v4 tilt".padEnd(11) + "4v4 jitter".padEnd(12) + "4v5 tilt".padEnd(11) + "verdict",
+)
+
+const rows = []
+for (const pivotRaise of [0.15, 0.3, 0.5, 0.8]) {
+  for (const beamDamping of [0, 0.5, 2, 6]) {
+    const eq = await run({ pivotRaise, beamDamping, extraRight: 0 })
+    const un = await run({ pivotRaise, beamDamping, extraRight: 1 })
+    const ok = Math.abs(eq.settle) <= 1.0 && un.settle <= -6.0
+    rows.push({ pivotRaise, beamDamping, eq, un, ok })
+    console.log(
+      String(pivotRaise).padEnd(8) +
+        String(beamDamping).padEnd(9) +
+        eq.settle.toFixed(2).padStart(7).padEnd(11) +
+        eq.jitter.toFixed(3).padStart(8).padEnd(12) +
+        un.settle.toFixed(2).padStart(7).padEnd(11) +
+        (ok ? "PASS" : ""),
+    )
+  }
+}
+
+const passing = rows.filter((r) => r.ok)
+console.log(`\n${passing.length} of ${rows.length} combinations meet both criteria.`)
+if (passing.length) {
+  // Prefer the most legible tip among the passing set: equal must be level,
+  // but unequal should be as dramatic as the stop allows.
+  const best = passing.reduce((a, b) => (b.un.settle < a.un.settle ? b : a))
+  console.log(
+    `recommended: pivotRaise ${best.pivotRaise}, beamDamping ${best.beamDamping} ` +
+      `(4v4 ${best.eq.settle.toFixed(2)} deg, 4v5 ${best.un.settle.toFixed(2)} deg)`,
+  )
+}

--- a/dynawalla/foundations/physics/bench/probe-rope.mjs
+++ b/dynawalla/foundations/physics/bench/probe-rope.mjs
@@ -1,0 +1,84 @@
+// PROBE: where does a chain stop looking like a chain?
+//
+// Ropes, chains, pulleys and swinging buckets are on the Bazaar's list, and the
+// thing that breaks them is the MASS RATIO between the load and one link. Below
+// some ratio every engine is fine; above it the chain stretches like elastic
+// and then explodes. This finds each engine's cliff, and what raising the
+// solver iteration count buys.
+//
+//   node bench/probe-rope.mjs
+
+import { ropeScene, ROPE_REST } from "./scenes.mjs"
+
+const ADAPTERS = {
+  rapier: () => import("./adapters/rapier.mjs"),
+  box2d3: () => import("./adapters/box2d3.mjs"),
+  planck: () => import("./adapters/planck.mjs"),
+  matter: () => import("./adapters/matter.mjs"),
+}
+
+// One link is 0.2 x 0.1 m => area 0.02 m^2. The bob is a 0.35 m disc =>
+// 0.3848 m^2. So ratio = (bobDensity * 0.3848) / (linkDensity * 0.02).
+const LINK_AREA = 0.2 * 0.1
+const BOB_AREA = Math.PI * 0.35 * 0.35
+
+function stretch(mod, opts, build = {}) {
+  const scene = ropeScene(opts)
+  const sim = mod.build(scene, build)
+  for (let i = 0; i < 600; i++) sim.step()
+  const s = sim.snapshot()
+  sim.destroy()
+  const n = s.length / 3
+  let span = 0
+  for (let k = 1; k < n; k++) {
+    span += Math.hypot(s[k * 3] - s[(k - 1) * 3], s[k * 3 + 1] - s[(k - 1) * 3 + 1])
+  }
+  if (!Number.isFinite(span)) return Infinity
+  return ((span - ROPE_REST) / ROPE_REST) * 100
+}
+
+const RATIOS = [10, 50, 150, 500, 2000]
+const linkDensity = 4
+
+console.log("stretch % of a 60-link chain after 10 s, by bob:link mass ratio")
+console.log("(> ~5% is visible as elastic; > 50% is broken; Inf is an explosion)")
+console.log("engine".padEnd(9) + RATIOS.map((r) => `${r}:1`.padStart(10)).join(""))
+
+for (const id of Object.keys(ADAPTERS)) {
+  const mod = await ADAPTERS[id]()
+  await mod.init()
+  const row = RATIOS.map((ratio) => {
+    const bobDensity = (ratio * linkDensity * LINK_AREA) / BOB_AREA
+    const v = stretch(mod, { linkDensity, bobDensity })
+    return (Number.isFinite(v) ? v.toFixed(1) : "EXPLODED").padStart(10)
+  })
+  console.log(id.padEnd(9) + row.join(""))
+}
+
+// What do extra solver iterations buy on the worst ratio? Rapier and Planck
+// expose an iteration count; Box2D v3 exposes sub-steps; Matter exposes both
+// position and velocity iteration counts.
+console.log("\nsame chain at 2000:1, with the engine's quality dial turned up")
+const worst = { linkDensity, bobDensity: (2000 * linkDensity * LINK_AREA) / BOB_AREA }
+const DIALS = {
+  rapier: [{ solverIterations: 4 }, { solverIterations: 8 }, { solverIterations: 16 }],
+  box2d3: [{ subSteps: 4 }, { subSteps: 8 }, { subSteps: 16 }],
+  planck: [
+    { velocityIterations: 8, positionIterations: 3 },
+    { velocityIterations: 16, positionIterations: 6 },
+    { velocityIterations: 32, positionIterations: 12 },
+  ],
+  matter: [{ matterIterations: 6 }, { matterIterations: 12 }, { matterIterations: 24 }],
+}
+for (const id of Object.keys(ADAPTERS)) {
+  const mod = await ADAPTERS[id]()
+  await mod.init()
+  const row = DIALS[id].map((d) => {
+    const t0 = performance.now()
+    const v = stretch(mod, worst, d)
+    const ms = (performance.now() - t0) / 600
+    const label = Object.values(d).join("/")
+    return `${label}=${Number.isFinite(v) ? v.toFixed(0) + "%" : "EXPLODED"} @${ms.toFixed(3)}ms`
+  })
+  console.log(id.padEnd(9) + row.join("   "))
+}

--- a/dynawalla/foundations/physics/bench/probe-scale.mjs
+++ b/dynawalla/foundations/physics/bench/probe-scale.mjs
@@ -1,0 +1,71 @@
+// PROBE: the balance scale is the equals sign, so it has to be right.
+//
+// The headline bake-off runs the OBVIOUS scale — a beam pivoted through its own
+// centre of mass — and the four engines disagree wildly on where it settles
+// with equal weight in both pans (Rapier +0.05 deg, Matter +1.5, Box2D v3
+// -70.0, Planck +72.4). That is not four bugs. A beam pivoted at its centroid
+// is NEUTRALLY stable: gravity exerts no restoring torque at any angle, so the
+// resting angle is decided entirely by whichever way solver noise nudged it.
+//
+// This probe sweeps the one parameter that fixes it — how far above the beam's
+// centre of mass the pivot sits — and measures, per engine:
+//
+//   settleDeg   the tilt after 900 steps with EQUAL pans (want ~0)
+//   tiltDeg     the tilt with ONE extra cube on the right (want clearly < 0,
+//               i.e. it must still visibly respond; an over-stabilised scale
+//               that never moves is just as broken as one that flops over)
+//   jitterDeg   peak-to-peak tilt over the last 120 steps (want ~0; a scale
+//               that vibrates at rest reads as an unreliable equals sign)
+//
+//   node bench/probe-scale.mjs
+
+import { balanceScaleScene } from "./scenes.mjs"
+
+const ADAPTERS = {
+  rapier: () => import("./adapters/rapier.mjs"),
+  box2d3: () => import("./adapters/box2d3.mjs"),
+  planck: () => import("./adapters/planck.mjs"),
+  matter: () => import("./adapters/matter.mjs"),
+}
+
+const RAISES = [0, 0.05, 0.15, 0.3, 0.6]
+const DEG = 180 / Math.PI
+
+function run(mod, opts, steps = 900) {
+  const scene = balanceScaleScene(opts)
+  const sim = mod.build(scene, {})
+  const tail = []
+  for (let i = 0; i < steps; i++) {
+    sim.step()
+    if (i >= steps - 120) tail.push(sim.snapshot()[2])
+  }
+  sim.destroy()
+  const settle = tail[tail.length - 1] * DEG
+  const jitter = (Math.max(...tail) - Math.min(...tail)) * DEG
+  return { settle, jitter }
+}
+
+console.log("raise = pivot height above beam centre of mass (m)")
+console.log(
+  "engine".padEnd(8) +
+    "raise".padEnd(7) +
+    "equal:settleDeg".padEnd(17) +
+    "equal:jitterDeg".padEnd(17) +
+    "+1 cube right:tiltDeg",
+)
+for (const id of Object.keys(ADAPTERS)) {
+  const mod = await ADAPTERS[id]()
+  await mod.init()
+  for (const raise of RAISES) {
+    const eq = run(mod, { pivotRaise: raise, loose: false })
+    const un = run(mod, { pivotRaise: raise, extraRight: 1, loose: false })
+    console.log(
+      id.padEnd(8) +
+        String(raise).padEnd(7) +
+        eq.settle.toFixed(3).padStart(9).padEnd(17) +
+        eq.jitter.toFixed(3).padStart(9).padEnd(17) +
+        un.settle.toFixed(3).padStart(9),
+    )
+  }
+  console.log("")
+}

--- a/dynawalla/foundations/physics/bench/run-browser.mjs
+++ b/dynawalla/foundations/physics/bench/run-browser.mjs
@@ -1,0 +1,124 @@
+// Browser runner: the demo, in a real browser, under real CPU throttling.
+//
+// Node numbers are honest about the SOLVER but say nothing about the renderer,
+// the WASM instantiation path, or what happens when the whole thing runs on a
+// tablet. This drives the actual demo in installed Chrome (no browser download
+// — `channel: "chrome"`), and uses CDP `Emulation.setCPUThrottlingRate` to
+// stand in for the Galaxy Tab A9 we do not have on this desk.
+//
+// The throttle multiplier is NOT a claim that the tablet is exactly Nx slower.
+// It is a way to find the multiplier at which we fall off 60 fps, so the budget
+// can be stated as headroom rather than as a single machine's number.
+//
+//   node bench/run-browser.mjs
+//   node bench/run-browser.mjs --throttle 1,4,6,8 --scenes scale,pour,siege
+//   node bench/run-browser.mjs --webkit          # if the WebKit build is present
+//
+// Requires the dev server: `npm run demo` in another shell, or pass --serve.
+
+import { spawn } from "node:child_process"
+import { setTimeout as sleep } from "node:timers/promises"
+
+const argv = process.argv.slice(2)
+const arg = (n, d = null) => {
+  const i = argv.indexOf(`--${n}`)
+  return i >= 0 ? argv[i + 1] : d
+}
+const has = (n) => argv.includes(`--${n}`)
+
+const PORT = Number(arg("port", "1425"))
+const BASE = `http://localhost:${PORT}`
+const scenes = arg("scenes", "scale,dominoes,chain,gears,pour,siege").split(",")
+const throttles = arg("throttle", "1,4,6,8").split(",").map(Number)
+const tier = arg("tier", null)
+
+let server = null
+if (has("serve")) {
+  server = spawn("npx", ["vite", "--config", "demo/vite.config.ts", "demo"], {
+    stdio: "ignore",
+    detached: false,
+  })
+  // Vite is fast but not instant, and a failed first navigation looks like a
+  // browser problem rather than a timing one.
+  for (let i = 0; i < 60; i++) {
+    try {
+      const r = await fetch(BASE, { signal: AbortSignal.timeout(500) })
+      if (r.ok) break
+    } catch {
+      /* not up yet */
+    }
+    await sleep(500)
+  }
+}
+
+const { chromium, webkit } = await import("playwright")
+
+const engineName = has("webkit") ? "WebKit (JavaScriptCore)" : "Chrome (V8)"
+const browser = has("webkit")
+  ? await webkit.launch()
+  : await chromium.launch({ channel: "chrome" })
+
+const results = []
+console.log(`${engineName} — ${await browser.version()}`)
+console.log(
+  "scene".padEnd(10) +
+    "cpu".padEnd(6) +
+    "bodies".padEnd(8) +
+    "awake".padEnd(7) +
+    "stepP99".padEnd(9) +
+    "frameP50".padEnd(10) +
+    "frameP95".padEnd(10) +
+    "fps",
+)
+
+for (const scene of scenes) {
+  for (const rate of throttles) {
+    const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } })
+    const page = await ctx.newPage()
+    // WebKit has no CDP; only Chromium can be throttled.
+    let cdp = null
+    if (!has("webkit")) {
+      cdp = await ctx.newCDPSession(page)
+      await cdp.send("Emulation.setCPUThrottlingRate", { rate })
+    } else if (rate !== 1) {
+      await ctx.close()
+      continue
+    }
+    const errors = []
+    page.on("pageerror", (e) => errors.push(String(e)))
+    const url = `${BASE}/?bench=${scene}${tier ? `&tier=${tier}` : ""}`
+    await page.goto(url, { waitUntil: "load" })
+    let bench = null
+    try {
+      await page.waitForFunction("globalThis.__bench !== undefined", null, { timeout: 180_000 })
+      bench = await page.evaluate("globalThis.__bench")
+    } catch {
+      console.error(`${scene} @${rate}x: timed out${errors.length ? " — " + errors[0] : ""}`)
+    }
+    if (bench) {
+      results.push({ engine: engineName, cpuThrottle: rate, ...bench })
+      console.log(
+        scene.padEnd(10) +
+          `${rate}x`.padEnd(6) +
+          String(bench.bodies).padEnd(8) +
+          String(bench.awake).padEnd(7) +
+          bench.stepP99Ms.toFixed(3).padEnd(9) +
+          bench.frameP50Ms.toFixed(2).padEnd(10) +
+          bench.frameP95Ms.toFixed(2).padEnd(10) +
+          bench.fpsFromP50.toFixed(1),
+      )
+    }
+    if (errors.length) console.error(`  page errors: ${errors.slice(0, 2).join(" | ")}`)
+    await ctx.close()
+  }
+}
+
+await browser.close()
+server?.kill()
+
+const out = arg("json")
+if (out) {
+  const { writeFileSync } = await import("node:fs")
+  writeFileSync(out, JSON.stringify(results, null, 2))
+  console.log(`wrote ${out}`)
+}

--- a/dynawalla/foundations/physics/bench/run-node.mjs
+++ b/dynawalla/foundations/physics/bench/run-node.mjs
@@ -1,0 +1,105 @@
+// Node runner for the bake-off. V8 — the same engine as the Android System
+// WebView and Chrome, so these numbers transfer to Android directly and to iOS
+// only by analogy (iOS is JavaScriptCore; see run-browser.mjs --webkit).
+//
+//   node bench/run-node.mjs                       # everything
+//   node bench/run-node.mjs --engine rapier       # one engine
+//   node bench/run-node.mjs --scene rope-60       # one scene
+//   node bench/run-node.mjs --json out.json
+//   node bench/run-node.mjs --repeat 3            # determinism across runs
+
+import { writeFileSync } from "node:fs"
+import { SCENES, SCENE_ORDER, ROPE_REST } from "./scenes.mjs"
+import { measure, quality } from "./harness.mjs"
+
+const ADAPTERS = {
+  rapier: () => import("./adapters/rapier.mjs"),
+  box2d3: () => import("./adapters/box2d3.mjs"),
+  planck: () => import("./adapters/planck.mjs"),
+  matter: () => import("./adapters/matter.mjs"),
+}
+
+function arg(name, fallback = null) {
+  const i = process.argv.indexOf(`--${name}`)
+  return i >= 0 ? process.argv[i + 1] : fallback
+}
+
+const onlyEngine = arg("engine")
+const onlyScene = arg("scene")
+const repeat = Number(arg("repeat", "1"))
+const jsonOut = arg("json")
+const variant = arg("variant", "auto")
+
+const engines = onlyEngine ? [onlyEngine] : Object.keys(ADAPTERS)
+const scenes = onlyScene ? [onlyScene] : SCENE_ORDER
+
+const results = []
+
+for (const engineId of engines) {
+  const mod = await ADAPTERS[engineId]()
+  let version
+  const t0 = performance.now()
+  try {
+    version = await mod.init(engineId === "rapier" && variant !== "auto" ? variant : variant)
+  } catch (err) {
+    console.error(`${engineId}: init failed — ${err.message}`)
+    continue
+  }
+  const initMs = performance.now() - t0
+
+  for (const sceneName of scenes) {
+    const scene = SCENES[sceneName]()
+    const runs = []
+    let buildMs = 0
+    for (let r = 0; r < repeat; r++) {
+      const b0 = performance.now()
+      let sim
+      try {
+        sim = mod.build(scene, {})
+      } catch (err) {
+        console.error(`${engineId}/${sceneName}: build failed — ${err.message}`)
+        break
+      }
+      buildMs = performance.now() - b0
+      let m
+      try {
+        m = measure(sim, scene.steps)
+      } catch (err) {
+        console.error(`${engineId}/${sceneName}: step failed — ${err.message}`)
+        sim.destroy()
+        break
+      }
+      m.quality = quality(sceneName, scene, m.state, ROPE_REST)
+      delete m.state
+      runs.push(m)
+      sim.destroy()
+    }
+    if (runs.length === 0) continue
+    const stable = runs.every((r) => r.hash === runs[0].hash)
+    results.push({
+      engine: engineId,
+      label: mod.meta.label,
+      version,
+      initMs,
+      buildMs,
+      scene: sceneName,
+      bodies: scene.bodies.filter((b) => b.kind !== "static").length,
+      runs: runs.length,
+      selfDeterministic: stable,
+      ...runs[0],
+    })
+    const r = runs[0]
+    console.log(
+      `${engineId.padEnd(8)} ${sceneName.padEnd(16)} ` +
+        `p50 ${r.p50.toFixed(3)}ms  p95 ${r.p95.toFixed(3)}  p99 ${r.p99.toFixed(3)}  max ${r.max.toFixed(3)}  ` +
+        `snap ${r.snapMean.toFixed(3)}  awake~${Math.round(r.awakeMean)}  ` +
+        `hash ${r.hash}${stable ? "" : " UNSTABLE"}  ${JSON.stringify(r.quality)}`,
+    )
+  }
+  console.log("")
+}
+
+if (jsonOut) {
+  writeFileSync(jsonOut, JSON.stringify({ platform: "node", node: process.version, results }, null, 2))
+  console.log(`wrote ${jsonOut}`)
+}

--- a/dynawalla/foundations/physics/bench/scenes.mjs
+++ b/dynawalla/foundations/physics/bench/scenes.mjs
@@ -1,0 +1,317 @@
+// Engine-agnostic scene definitions for the physics bake-off.
+//
+// Every scene is plain data so that four engines with four different APIs build
+// the SAME world. If a scene were expressed in any engine's own vocabulary the
+// bake-off would measure how well the other three imitate it.
+//
+// Units are metres/kilograms/seconds throughout, and every scene is sized so a
+// 10-year-old's screen would be roughly 20 m wide. Pixel-space physics is the
+// classic Box2D-family footgun: the solver's tolerances (linear slop 0.005,
+// speculative contact margin, sleep thresholds) are absolute, so a world built
+// at 1 unit = 1 pixel is a world where everything is 100x too big and the slop
+// is invisible.
+//
+// Shapes:  { box: [halfWidth, halfHeight] } | { circle: radius }
+// Bodies:  { kind, shape, pos, angle?, density?, friction?, restitution? }
+//          A body may instead carry `shapes: [{ ...shape, at: [dx, dy] }]` for a
+//          compound body (a pan with lips, a gear tooth ring, a bucket).
+// Joints:  { type: "revolute" | "distance", a, b, anchor?, anchorA?, anchorB?, length? }
+//          `a` / `b` are indices into `bodies`.
+
+const FLOOR = (halfWidth = 14) => ({
+  kind: "static",
+  shape: { box: [halfWidth, 0.5] },
+  pos: [0, -0.5],
+  friction: 0.6,
+})
+
+/** Deterministic 32-bit PRNG. No Math.random() anywhere in a benchmark. */
+function rng(seed) {
+  let s = seed >>> 0
+  return () => {
+    // xorshift32
+    s ^= s << 13
+    s >>>= 0
+    s ^= s >>> 17
+    s ^= s << 5
+    s >>>= 0
+    return s / 4294967296
+  }
+}
+
+/**
+ * S1 — PYRAMID TOPPLE. 15 rows, 120 boxes, struck by a fast heavy ball.
+ * The densest persistent-contact scene we ship: every box has 4-6 manifolds and
+ * the whole pile is one island, so this is the solver's worst case per body.
+ */
+function pyramidTopple() {
+  const bodies = [FLOOR()]
+  const h = 0.25
+  const rows = 15
+  for (let row = 0; row < rows; row++) {
+    const n = rows - row
+    for (let i = 0; i < n; i++) {
+      bodies.push({
+        kind: "dynamic",
+        shape: { box: [h, h] },
+        // 0.001 gap: boxes that start exactly touching begin the sim already
+        // penetrating by the linear slop and every engine resolves that
+        // differently on frame 0, which is not what we are measuring.
+        pos: [(i - (n - 1) / 2) * (h * 2 + 0.001), h + row * (h * 2 + 0.001)],
+        density: 1,
+        friction: 0.5,
+      })
+    }
+  }
+  // The wrecking ball, entering from the left at 18 m/s.
+  bodies.push({
+    kind: "dynamic",
+    shape: { circle: 0.6 },
+    pos: [-12, 3],
+    density: 8,
+    friction: 0.4,
+    restitution: 0.1,
+    velocity: [18, 2],
+  })
+  return { name: "pyramid-topple", gravity: [0, -10], bodies, joints: [], steps: 600 }
+}
+
+/**
+ * S2 — DEBRIS FIELD. 500 mixed circles and boxes poured into a pen.
+ * Broadphase + island management stress. This is "a lamp shatters and the
+ * pieces land in a pile", which the Bazaar will do constantly.
+ */
+function debrisField() {
+  const rand = rng(0xd1a9)
+  const bodies = [
+    FLOOR(10),
+    { kind: "static", shape: { box: [0.5, 8] }, pos: [-10, 8], friction: 0.4 },
+    { kind: "static", shape: { box: [0.5, 8] }, pos: [10, 8], friction: 0.4 },
+  ]
+  for (let i = 0; i < 500; i++) {
+    const r = 0.12 + rand() * 0.14
+    bodies.push({
+      kind: "dynamic",
+      shape: rand() < 0.5 ? { circle: r } : { box: [r, r * (0.6 + rand() * 0.8)] },
+      pos: [(rand() - 0.5) * 18, 1 + rand() * 26],
+      angle: rand() * 6.283,
+      density: 1,
+      friction: 0.35,
+      restitution: 0.05,
+    })
+  }
+  return { name: "debris-500", gravity: [0, -10], bodies, joints: [], steps: 600 }
+}
+
+/**
+ * S3 — DOMINOES. 300 tall thin boxes, chain reaction from one nudge.
+ * Thin boxes are the tunnelling case, and the interesting cost profile is that
+ * an engine with sleeping does almost no work until the wave arrives — so the
+ * MEAN is misleading here and only the worst frame matters.
+ */
+function dominoes() {
+  const bodies = [FLOOR(40)]
+  const n = 300
+  for (let i = 0; i < n; i++) {
+    bodies.push({
+      kind: "dynamic",
+      shape: { box: [0.05, 0.5] },
+      pos: [-38 + i * 0.26, 0.5],
+      density: 1.2,
+      friction: 0.45,
+    })
+  }
+  bodies[1].angle = -0.22 // the nudge is geometric, not an impulse: replayable
+  return { name: "dominoes-300", gravity: [0, -10], bodies, joints: [], steps: 900 }
+}
+
+/**
+ * S4 — ROPE. 60 links plus a heavy bob, anchored at both ends of a span.
+ * Joint-solver stress. Chains are where "looks like a rope" and "explodes" are
+ * separated by the iteration count, and where the two engine families differ
+ * most: Box2D-family sequential impulses stretch, Rapier's TGS-Soft does not.
+ */
+export const ROPE_LINKS = 60
+const ROPE_HALF = 0.1 // half-length of one link
+const ROPE_BOB_R = 0.35
+const ROPE_ANCHOR = [-6, 12]
+
+/**
+ * Rope/chain builder, parameterised so the same geometry can be swept for the
+ * mass-ratio cliff (see `bench/probe-rope.mjs`). Anchors line up EXACTLY: a
+ * chain that starts with the joints already violated spends its first frames
+ * snapping straight, and every engine does that differently.
+ */
+export function ropeScene({ linkDensity = 4, bobDensity = 30, links = ROPE_LINKS } = {}) {
+  const [ax, ay] = ROPE_ANCHOR
+  const bodies = [
+    FLOOR(20),
+    { kind: "static", shape: { box: [0.2, 0.2] }, pos: [ax, ay] },
+  ]
+  for (let i = 0; i < links; i++) {
+    bodies.push({
+      kind: "dynamic",
+      shape: { box: [ROPE_HALF, 0.05] },
+      pos: [ax + ROPE_HALF + i * ROPE_HALF * 2, ay],
+      density: linkDensity,
+      friction: 0.2,
+    })
+  }
+  bodies.push({
+    kind: "dynamic",
+    shape: { circle: ROPE_BOB_R },
+    pos: [ax + links * ROPE_HALF * 2 + ROPE_BOB_R, ay],
+    density: bobDensity,
+    friction: 0.4,
+  })
+  const joints = []
+  // index 1 is the anchor; links start at 2.
+  joints.push({ type: "revolute", a: 1, b: 2, anchorA: [0, 0], anchorB: [-ROPE_HALF, 0] })
+  for (let i = 0; i < links - 1; i++) {
+    joints.push({
+      type: "revolute",
+      a: 2 + i,
+      b: 3 + i,
+      anchorA: [ROPE_HALF, 0],
+      anchorB: [-ROPE_HALF, 0],
+    })
+  }
+  joints.push({
+    type: "revolute",
+    a: 1 + links,
+    b: 2 + links,
+    anchorA: [ROPE_HALF, 0],
+    anchorB: [-ROPE_BOB_R, 0],
+  })
+  return { name: "rope-60", gravity: [0, -10], bodies, joints, steps: 600 }
+}
+
+/**
+ * S4 — ROPE. 60 links plus a bucket-weight bob, anchored at one end and free to
+ * swing. Joint-solver stress. Chains are where "looks like a rope" and
+ * "explodes" are separated by the iteration count, and where the two engine
+ * families differ most.
+ *
+ * The masses here are deliberately a REALISTIC chain-and-bucket (~144:1
+ * bob:link). The pathological ratios that break every engine are swept
+ * separately in `probe-rope.mjs` rather than smuggled into the headline table.
+ */
+function rope() {
+  return ropeScene()
+}
+
+/** Rest length of the rope scene, for the stretch metric. */
+export const ROPE_REST = (ROPE_LINKS - 1) * ROPE_HALF * 2 + ROPE_HALF + ROPE_BOB_R
+
+/**
+ * S5 — BALANCE SCALE. The equals sign, physically.
+ * A beam on a revolute pivot, two pans hung from its ends by revolute joints,
+ * and weights dropped into the pans. This is the scene the product needs most
+ * and the one most likely to look bad: a scale that jitters at balance, or that
+ * settles a hair off level with equal mass, reads to a child as "the equals
+ * sign is unreliable".
+ */
+/**
+ * Balance scale, parameterised. See `probe-scale.mjs`.
+ *
+ * `pivotRaise` is the distance the pivot sits ABOVE the beam's centre of mass.
+ * At 0 the beam is pivoted through its own centroid, which is the obvious way
+ * to build it and is **neutrally stable** — there is no restoring torque at
+ * all, so where it settles is decided by solver noise. Every engine we tested
+ * tips a different direction from the identical scene. Raising the pivot is
+ * what turns "level" into an attractor. This is a real steelyard's design and
+ * the kit bakes it in.
+ */
+export function balanceScaleScene({
+  pivotRaise = 0,
+  extraLeft = 0,
+  extraRight = 0,
+  loose = true,
+} = {}) {
+  const armLen = 3.2
+  const hang = 1.3 // stirrup length
+  const pivotY = 5.2 // world height of the pivot: fixed, so the column never moves
+  // A pan with LIPS, as a compound body. Without them the load simply slides
+  // off a swinging pan and the imbalance the scale is meant to show disappears
+  // — which is how the first version of this probe fooled itself into
+  // reporting that Rapier "settles level" under a 25% overload.
+  const PAN = [
+    { box: [1.0, 0.08], at: [0, 0] },
+    { box: [0.08, 0.3], at: [-0.92, 0.3] },
+    { box: [0.08, 0.3], at: [0.92, 0.3] },
+  ]
+  const beamY = pivotY - pivotRaise // the beam's OWN centre of mass
+  const bodies = [
+    FLOOR(8),
+    { kind: "static", shape: { box: [0.3, 2.6] }, pos: [0, 2.6] }, // 1 column
+    { kind: "dynamic", shape: { box: [armLen, 0.12] }, pos: [0, beamY], density: 2.5, friction: 0.5 }, // 2 beam
+    // Stirrups and pans. Hanging a pan by a REVOLUTE-jointed link rather than a
+    // distance/rope joint keeps this scene expressible identically in all four
+    // engines — revolute is the one joint whose semantics they agree on. It is
+    // also what a real balance scale is.
+    //
+    // Everything below the beam is positioned relative to `beamY`, not to the
+    // pivot. Getting this wrong — leaving the stirrups at the old height while
+    // the beam moves down — starts every joint already violated, and the whole
+    // assembly snaps on frame 0. It looks exactly like solver instability and
+    // it is not.
+    { kind: "dynamic", shape: { box: [0.04, hang / 2] }, pos: [-armLen, beamY - hang / 2], density: 0.8 }, // 3
+    { kind: "dynamic", shapes: PAN, pos: [-armLen, beamY - hang], density: 1.2, friction: 0.9 }, // 4 left pan
+    { kind: "dynamic", shape: { box: [0.04, hang / 2] }, pos: [armLen, beamY - hang / 2], density: 0.8 }, // 5
+    { kind: "dynamic", shapes: PAN, pos: [armLen, beamY - hang], density: 1.2, friction: 0.9 }, // 6 right pan
+  ]
+  const joints = [
+    // Pivot: on the column at world `pivotY`, on the beam `pivotRaise` above
+    // its own centre of mass.
+    { type: "revolute", a: 1, b: 2, anchorA: [0, pivotY - 2.6], anchorB: [0, pivotRaise] },
+    { type: "revolute", a: 2, b: 3, anchorA: [-armLen, 0], anchorB: [0, hang / 2] },
+    { type: "revolute", a: 3, b: 4, anchorA: [0, -hang / 2], anchorB: [0, 0] },
+    { type: "revolute", a: 2, b: 5, anchorA: [armLen, 0], anchorB: [0, hang / 2] },
+    { type: "revolute", a: 5, b: 6, anchorA: [0, -hang / 2], anchorB: [0, 0] },
+  ]
+  // Four unit cubes left, four right: a true equality that must LOOK level.
+  const perSide = [4 + extraLeft, 4 + extraRight]
+  if (loose) {
+    ;[-1, 1].forEach((side, s) => {
+      for (let i = 0; i < perSide[s]; i++) {
+        bodies.push({
+          kind: "dynamic",
+          shape: { box: [0.18, 0.18] },
+          pos: [side * armLen + ((i % 4) - 1.5) * 0.4, beamY - hang + 0.5 + i * 0.5],
+          density: 1,
+          friction: 0.7,
+        })
+      }
+    })
+  } else {
+    // One settled slab per pan whose density encodes the count. Loose cubes on
+    // a lipless pan slide off the moment the beam tilts, which silently removes
+    // the very imbalance the probe is trying to measure — so the *scale* is
+    // measured with a load that cannot escape, and the loose version is kept
+    // for the demo where sliding cubes are the point.
+    ;[-1, 1].forEach((side, s) => {
+      bodies.push({
+        kind: "dynamic",
+        shape: { box: [0.7, 0.2] },
+        pos: [side * armLen, beamY - hang + 0.08 + 0.2],
+        density: (perSide[s] * 0.18 * 0.18 * 4) / (0.7 * 0.2 * 4),
+        friction: 0.9,
+      })
+    })
+  }
+  return { name: "balance-scale", gravity: [0, -10], bodies, joints, steps: 900 }
+}
+
+function balanceScale() {
+  return balanceScaleScene()
+}
+
+export const SCENES = {
+  "pyramid-topple": pyramidTopple,
+  "debris-500": debrisField,
+  "dominoes-300": dominoes,
+  "rope-60": rope,
+  "balance-scale": balanceScale,
+}
+
+export const SCENE_ORDER = Object.keys(SCENES)

--- a/dynawalla/foundations/physics/demo/determinism.html
+++ b/dynawalla/foundations/physics/demo/determinism.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>determinism probe</title></head>
+  <body style="font:14px ui-monospace,monospace;background:#140d18;color:#efe3cf;padding:16px">
+    <pre id="out">running…</pre>
+    <script type="module">
+      import { createWorld } from "../src/index.ts"
+      const q = new URLSearchParams(location.search)
+      const seed = Number(q.get("seed") ?? 20260726)
+      const steps = Number(q.get("steps") ?? 900)
+      const w = await createWorld({ seed, tier: "mid" })
+      // Kept byte-identical with bench/determinism.mjs `buildScene`.
+      w.ground(20)
+      w.stack({ at: [0, 0], rows: 8, size: 0.28 })
+      w.chain({ from: [-7, 9], links: 18, load: 40 })
+      w.liquid({ at: [3, 12], count: 120, drop: 0.11 })
+      const gun = w.launcher({ at: [-9, 6] })
+      gun.fire({ angle: 0.18, speed: 15 })
+      w.stepExact(steps)
+      const n = w.count
+      const probe = [0, n >> 1, n - 1].map(
+        (i) => [w.transforms[i * 4], w.transforms[i * 4 + 1]].map((v) => v.toExponential(9)).join(","),
+      )
+      globalThis.__det = { hash: w.hash(), probe, bodies: n }
+      document.getElementById("out").textContent = JSON.stringify(globalThis.__det, null, 2)
+    </script>
+  </body>
+</html>

--- a/dynawalla/foundations/physics/demo/index.html
+++ b/dynawalla/foundations/physics/demo/index.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Dynawalla · physics foundation</title>
+    <style>
+      :root {
+        --bg: #140d18;
+        --ink: #efe3cf;
+        --brass: #d9a441;
+        --dim: #8b7a86;
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; height: 100%; background: var(--bg); overflow: hidden; }
+      body {
+        font: 500 13px/1.4 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+        color: var(--ink);
+        -webkit-font-smoothing: antialiased;
+        touch-action: none;
+      }
+      canvas { display: block; }
+      #hud {
+        position: fixed; top: 0; left: 0; right: 0;
+        padding: max(10px, env(safe-area-inset-top)) 12px 10px;
+        display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
+        background: linear-gradient(#140d18ee, #140d1800);
+        pointer-events: none;
+      }
+      #hud > * { pointer-events: auto; }
+      .tabs { display: flex; gap: 6px; flex-wrap: wrap; }
+      button {
+        font: inherit; color: var(--ink); cursor: pointer;
+        background: #241a29; border: 1px solid #3a2b40; border-radius: 8px;
+        padding: 7px 11px; letter-spacing: 0.01em;
+      }
+      button:hover { background: #2f2235; }
+      button[aria-pressed="true"] {
+        background: var(--brass); border-color: var(--brass); color: #241305; font-weight: 700;
+      }
+      #stats {
+        margin-left: auto; display: flex; gap: 14px;
+        font-variant-numeric: tabular-nums; color: var(--dim);
+        background: #1c1420cc; border: 1px solid #33253a; border-radius: 8px; padding: 7px 12px;
+      }
+      #stats b { color: var(--ink); font-weight: 600; }
+      #caption {
+        position: fixed; left: 12px; bottom: max(12px, env(safe-area-inset-bottom));
+        max-width: min(46ch, calc(100vw - 24px));
+        background: #1c1420cc; border: 1px solid #33253a; border-radius: 10px;
+        padding: 10px 13px; color: var(--dim);
+      }
+      #caption b { color: var(--brass); display: block; margin-bottom: 3px; letter-spacing: 0.04em; text-transform: uppercase; font-size: 11px; }
+      @media (max-width: 560px) { #stats { width: 100%; margin-left: 0; justify-content: space-between; } }
+    </style>
+  </head>
+  <body>
+    <div id="hud">
+      <div class="tabs" id="tabs"></div>
+      <div id="stats">
+        <span>fps <b id="fps">—</b></span>
+        <span>step p99 <b id="p99">—</b>ms</span>
+        <span>awake <b id="awake">—</b></span>
+        <span>tier <b id="tier">—</b></span>
+      </div>
+    </div>
+    <div id="caption"><b>loading</b><span id="cap-text"></span></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/foundations/physics/demo/main.ts
+++ b/dynawalla/foundations/physics/demo/main.ts
@@ -7,7 +7,7 @@
 
 import * as THREE from "three"
 import { createWorld, FIXED_DT, type Bazaar } from "../src/index.ts"
-import { InstancedLayer, bazaarLighting, bazaarSky, frameCamera, standard, glow, PALETTE } from "../src/view/three.ts"
+import { InstancedLayer, SoftMesh, bazaarLighting, bazaarSky, bazaarEnvironment, frameCamera, standard, glow, PALETTE } from "../src/view/three.ts"
 
 const canvas = document.createElement("canvas")
 document.body.appendChild(canvas)
@@ -28,6 +28,7 @@ const scene = new THREE.Scene()
 scene.fog = new THREE.Fog(0x1e0d24, 26, 86)
 bazaarLighting(scene)
 bazaarSky(scene)
+bazaarEnvironment(renderer, scene)
 
 const camera = new THREE.PerspectiveCamera(38, 1, 0.5, 200)
 
@@ -107,6 +108,14 @@ function discLayer(group: THREE.Group, n: number, color: number, extras = {}) {
   return l
 }
 const V = (x: number, y: number, z: number) => new THREE.Vector3(x, y, z)
+
+// Scale helpers, because the two unit geometries do NOT share a convention and
+// getting it wrong is silent: BoxGeometry(1,1,1) spans -0.5..0.5, so a box
+// scales by its FULL extents; CylinderGeometry(1,1,1) has RADIUS 1, so a disc
+// scales by its radius, not its diameter. Scaling a disc by `r * 2` draws it at
+// double size — which is exactly what put the camera inside the gear train.
+const boxScale = (halfW: number, halfH: number, depth: number) => V(halfW * 2, halfH * 2, depth)
+const discScale = (radius: number, depth: number) => V(radius, radius, depth)
 
 /**
  * Place two lip instances per pan in the PAN'S rotated frame.
@@ -210,7 +219,7 @@ const DEMOS: Record<string, Demo> = {
     label: "Chain reaction",
     caption:
       "120 dominoes. Friction 0.3 — Rapier, Box2D v3 and Planck agree within 2 of 300 and degrade smoothly with friction. Matter.js wedges dead above 0.3.",
-    frame: { cx: 0, cy: 1.6, halfW: 12.4, halfH: 3.2 },
+    frame: { cx: 0, cy: 1.1, halfW: 12.4, halfH: 2.2 },
     build(w, group) {
       w.ground(30)
       const run = w.dominoes({ from: [-11, 0], to: [11, 0], count: 120, height: 0.9 })
@@ -236,7 +245,7 @@ const DEMOS: Record<string, Demo> = {
       const links = boxLayer(group, 32, PALETTE.brass, { metalness: 0.95, roughness: 0.25 })
       for (const l of c.links) links.track(l.index, V(0.2, 0.1, 0.16))
       const bob = discLayer(group, 2, PALETTE.copper, { metalness: 0.9 })
-      if (c.bob) bob.track(c.bob.index, V(0.7, 0.7, 0.7))
+      if (c.bob) bob.track(c.bob.index, discScale(0.35, 0.55))
       const blocks = boxLayer(group, 40, PALETTE.jade)
       for (const b of w.stack({ at: [4.5, 0], rows: 6, size: 0.3 })) blocks.track(b.index, V(0.6, 0.6, 0.6))
       return () => {
@@ -251,19 +260,23 @@ const DEMOS: Record<string, Demo> = {
     label: "Gear train",
     caption:
       "Ratios exact to the last bit — kinematic, not solved. Real involute teeth as rigid bodies is dozens of tiny fast contacts per pair, the worst case for a tablet.",
-    frame: { cx: 1.8, cy: 4.2, halfW: 5.4, halfH: 3.4 },
+    frame: { cx: 2.4, cy: 4.2, halfW: 6.4, halfH: 3.0 },
     build(w, group) {
       const train = w.gearTrain({ at: [-2.4, 4.2], teeth: [16, 32, 12, 24], module: 0.14, driveSpeed: 1.4 })
       const layer = discLayer(group, 8, PALETTE.brass, { metalness: 0.95, roughness: 0.22 })
       const tints = [PALETTE.brass, PALETTE.copper, PALETTE.jade, PALETTE.rose]
       train.gears.forEach((g, i) => {
-        const slot = layer.track(g.body.index, V(g.radius * 2, g.radius * 2, 0.5))
+        const slot = layer.track(g.body.index, discScale(g.radius, 0.5))
         layer.setColor(slot, new THREE.Color(tints[i % tints.length]!))
         // Teeth are geometry, not physics.
         for (let t = 0; t < g.teeth; t++) {
           const a = (t / g.teeth) * Math.PI * 2
+          // 0.44 not 0.5: a tooth exactly as deep as the gear blank puts its
+          // front and back faces COPLANAR with the disc's, and coplanar faces
+          // z-fight — the stipple crawls around the rim and reads as a texture
+          // bug. Inset the overlay rather than matching it.
           const tooth = new THREE.Mesh(
-            new THREE.BoxGeometry(g.radius * 0.16, g.radius * 0.2, 0.5),
+            new THREE.BoxGeometry(g.radius * 0.16, g.radius * 0.2, 0.44),
             standard(tints[i % tints.length]!, { metalness: 0.95, roughness: 0.22 }),
           )
           tooth.position.set(Math.cos(a) * g.radius, Math.sin(a) * g.radius, 0)
@@ -316,17 +329,26 @@ const DEMOS: Record<string, Demo> = {
       }
       const drops = w.liquid({ at: [0, 12], count: 400, drop: 0.1, width: 1.6 })
       const dl = discLayer(group, drops.length, PALETTE.jade, { metalness: 0.2, roughness: 0.25 })
-      for (const d of drops) dl.track(d.index, V(0.2, 0.2, 0.2))
+      for (const d of drops) dl.track(d.index, discScale(0.1, 0.2))
 
       const blobs = [
         w.softBlob({ at: [-2.2, 15], radius: 0.75, firmness: 0.35 }),
         w.softBlob({ at: [2.2, 17], radius: 0.75, firmness: 0.7 }),
       ]
-      const bl = discLayer(group, 80, PALETTE.rose, { metalness: 0.15, roughness: 0.4 })
-      for (const b of blobs) for (const p of b.ring) bl.track(p.index, V(0.36, 0.36, 0.36))
+      // Fill each blob from its outline rather than drawing the ring beads:
+      // a pressurised ring drawn as beads reads as a donut, because the hole is
+      // exactly what the ring is holding open.
+      const skins = blobs.map((b, i) => {
+        const m = new SoftMesh(b.ring.length, standard(i === 0 ? PALETTE.rose : PALETTE.brass, {
+          roughness: 0.45,
+          metalness: 0.1,
+        }))
+        group.add(m.mesh)
+        return { blob: b, mesh: m, buf: new Float32Array(b.ring.length * 2) }
+      })
       return () => {
         dl.sync(w)
-        bl.sync(w)
+        for (const s of skins) s.mesh.update(s.blob.outline(s.buf))
       }
     },
   },
@@ -372,7 +394,7 @@ const DEMOS: Record<string, Demo> = {
         if (t > next) {
           next = t + 2.4
           const shot = gun.fire({ angle, speed: 17 })
-          shots.track(shot.index, V(0.68, 0.68, 0.68))
+          shots.track(shot.index, discScale(0.34, 0.6))
         }
         blocks.sync(w)
         shots.sync(w)

--- a/dynawalla/foundations/physics/demo/main.ts
+++ b/dynawalla/foundations/physics/demo/main.ts
@@ -1,0 +1,502 @@
+// The runnable reference demo.
+//
+// Six scenes, each one a recipe from the kit rendered with the shared Bazaar
+// look. It is also the perf harness: the HUD is live p99 step cost, awake body
+// count and tier, and `?bench=<scene>` runs a fixed 600-frame measurement and
+// prints JSON to the console, which is how bench/run-browser.mjs drives it.
+
+import * as THREE from "three"
+import { createWorld, FIXED_DT, type Bazaar } from "../src/index.ts"
+import { InstancedLayer, bazaarLighting, bazaarSky, frameCamera, standard, glow, PALETTE } from "../src/view/three.ts"
+
+const canvas = document.createElement("canvas")
+document.body.appendChild(canvas)
+
+const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, powerPreference: "high-performance" })
+renderer.shadowMap.enabled = true
+// ACES + a lifted exposure. Three's default (NoToneMapping, exposure 1) is
+// what makes an emissive-lit scene read as flat and muddy: highlights clip to
+// the material colour instead of rolling off, so brass never looks like metal.
+renderer.toneMapping = THREE.ACESFilmicToneMapping
+renderer.toneMappingExposure = 1.35
+renderer.shadowMap.type = THREE.PCFSoftShadowMap
+// Cap DPR at 2. A 3x phone renders 9x the pixels for a difference nobody can
+// see at arm's length, and it is the single biggest free win on mobile.
+renderer.setPixelRatio(Math.min(devicePixelRatio, 2))
+
+const scene = new THREE.Scene()
+scene.fog = new THREE.Fog(0x1e0d24, 26, 86)
+bazaarLighting(scene)
+bazaarSky(scene)
+
+const camera = new THREE.PerspectiveCamera(38, 1, 0.5, 200)
+
+// Backdrop: a few slabs standing in for the bazaar's minarets, far enough back
+// to sit in the fog. Pure decoration, zero physics cost, and it is the
+// difference between "a physics test" and "a place".
+;(function backdrop() {
+  // Minarets. Pushed back to z -26..-52 so they sit deep in the fog and read as
+  // a skyline rather than as scenery the physics might touch, with emissive
+  // window slits — the one cheap trick that turns a silhouette into a city.
+  const g = new THREE.BoxGeometry(1, 1, 1)
+  const towers = new THREE.InstancedMesh(g, standard(0x1b0f22, { roughness: 0.95, metalness: 0.05 }), 26)
+  const windows = new THREE.InstancedMesh(g, glow(0xffb04a, 2.4), 130)
+  const mat = new THREE.Matrix4()
+  let seed = 7
+  const rnd = () => ((seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff)
+  let wi = 0
+  for (let i = 0; i < 26; i++) {
+    const h = 9 + rnd() * 26
+    const x = -46 + i * 3.6 + rnd() * 1.8
+    const z = -26 - rnd() * 26
+    const wdt = 2.2 + rnd() * 3.2
+    mat.compose(new THREE.Vector3(x, h / 2 - 1, z), new THREE.Quaternion(), new THREE.Vector3(wdt, h, 3))
+    towers.setMatrixAt(i, mat)
+    const rows = 2 + Math.floor(rnd() * 5)
+    for (let r = 0; r < rows && wi < 130; r++, wi++) {
+      mat.compose(
+        new THREE.Vector3(x + (rnd() - 0.5) * wdt * 0.6, 1.5 + rnd() * (h - 3), z + 1.6),
+        new THREE.Quaternion(),
+        new THREE.Vector3(0.3, 0.75, 0.2),
+      )
+      windows.setMatrixAt(wi, mat)
+    }
+  }
+  windows.count = wi
+  towers.frustumCulled = false
+  windows.frustumCulled = false
+  scene.add(towers, windows)
+})()
+
+const floor = new THREE.Mesh(
+  new THREE.BoxGeometry(120, 1, 16),
+  standard(0x2d1a33, { roughness: 0.82, metalness: 0.18 }),
+)
+floor.position.set(0, -0.5, 0)
+floor.receiveShadow = true
+scene.add(floor)
+
+// A warm strip along the front lip of the floor. Reads as bazaar lamplight and
+// gives the ground plane an edge, which is what stops it looking infinite.
+const lip = new THREE.Mesh(new THREE.BoxGeometry(120, 0.1, 0.3), glow(0xff8a3c, 2.2))
+lip.position.set(0, 0.02, 7.9)
+scene.add(lip)
+
+// ---------------------------------------------------------------- scenes
+
+interface Demo {
+  label: string
+  caption: string
+  build(w: Bazaar, group: THREE.Group): (dt: number) => void
+  /** The world-space rectangle this scene must always show, at any aspect. */
+  frame: { cx: number; cy: number; halfW: number; halfH: number }
+}
+
+const BOX = new THREE.BoxGeometry(1, 1, 1)
+const CYL = new THREE.CylinderGeometry(1, 1, 1, 20)
+CYL.rotateX(Math.PI / 2)
+
+function boxLayer(group: THREE.Group, n: number, color: number, extras = {}) {
+  const l = new InstancedLayer({ capacity: n, geometry: BOX, material: standard(color, extras) })
+  group.add(l.mesh)
+  return l
+}
+function discLayer(group: THREE.Group, n: number, color: number, extras = {}) {
+  const l = new InstancedLayer({ capacity: n, geometry: CYL, material: standard(color, extras) })
+  group.add(l.mesh)
+  return l
+}
+const V = (x: number, y: number, z: number) => new THREE.Vector3(x, y, z)
+
+/**
+ * Place two lip instances per pan in the PAN'S rotated frame.
+ *
+ * A compound collider is one physics body with several shapes, but the renderer
+ * only gets one transform for it — so any sub-shape has to be re-offset here,
+ * rotated by the body's own angle. Forgetting the rotation is the tell: lips
+ * that stay vertical while the pan tilts.
+ */
+function lipOffsets(layer: InstancedLayer, w: Bazaar, panIndices: number[]) {
+  const t = w.transforms
+  let slot = 0
+  for (const idx of panIndices) {
+    const b = idx * 4
+    const cos = t[b + 2]!
+    const sin = t[b + 3]!
+    for (const dx of [-0.92, 0.92]) {
+      const dy = 0.3
+      layer.setOffset(slot++, dx * cos - dy * sin, dx * sin + dy * cos)
+    }
+  }
+}
+
+const DEMOS: Record<string, Demo> = {
+  scale: {
+    label: "Balance scale",
+    caption:
+      "Four against five. The beam is real physics; the ANSWER is integer arithmetic — compare() never reads the beam angle.",
+    frame: { cx: 0, cy: 3.55, halfW: 5.6, halfH: 2.5 },
+    build(w, group) {
+      w.ground(24)
+      const scale = w.balanceScale({ at: [0, 0] })
+      const frame = boxLayer(group, 8, PALETTE.brass, { metalness: 0.85, roughness: 0.3 })
+      frame.track(scale.beam.index, V(6.4, 0.24, 0.55))
+      const cubesL = boxLayer(group, 40, PALETTE.jade)
+      const cubesR = boxLayer(group, 40, PALETTE.rose)
+      const pans = boxLayer(group, 4, PALETTE.copper, { metalness: 0.9 })
+      pans.track(scale.leftPan.index, V(2.0, 0.16, 0.9))
+      pans.track(scale.rightPan.index, V(2.0, 0.16, 0.9))
+      // The pan lips and the stirrups are real bodies; if they are not drawn the
+      // scale reads as two planks floating under a bar, and the thing that
+      // actually holds the load is invisible.
+      const lips = boxLayer(group, 8, PALETTE.copper, { metalness: 0.9 })
+      for (const pan of [scale.leftPan, scale.rightPan]) {
+        lips.track(pan.index, V(0.16, 0.6, 0.9))
+        lips.track(pan.index, V(0.16, 0.6, 0.9))
+      }
+      const stirrups = boxLayer(group, 4, PALETTE.brass, { metalness: 0.95, roughness: 0.25 })
+      for (const st of scale.stirrups) stirrups.track(st.index, V(0.09, 1.3, 0.09))
+
+      const post = new THREE.Mesh(new THREE.BoxGeometry(0.62, 5.2, 0.62), standard(0x7a3b26, { metalness: 0.5, roughness: 0.55 }))
+      post.position.set(0, 2.6, 0)
+      post.castShadow = true
+      post.receiveShadow = true
+      group.add(post)
+      const cap = new THREE.Mesh(new THREE.SphereGeometry(0.34, 18, 12), glow(PALETTE.brass, 0.9))
+      cap.position.set(0, 5.35, 0)
+      group.add(cap)
+
+      let t = 0
+      let phase = 0
+      // Load both pans AT ONCE, settle, then add the ninth cube.
+      //
+      // Two earlier versions of this choreography were wrong in the same way:
+      // they fed the scale one cube at a time. But a scale holding 1 against 0
+      // is at a total imbalance and slams to its limit, and every later cube
+      // lands on a pan that is now above head height. The physics was right
+      // both times; the staging was not. The beat we want is "four equals four
+      // — and one more tips it", so the equality has to exist before the first
+      // step runs.
+      const beats: { t: number; run: () => void }[] = [
+        {
+          t: 0.35,
+          run: () => {
+            for (const b of scale.put("left", 4)) cubesL.track(b.index, V(0.36, 0.36, 0.36))
+            for (const b of scale.put("right", 4)) cubesR.track(b.index, V(0.36, 0.36, 0.36))
+          },
+        },
+        {
+          t: 3.6,
+          run: () => {
+            for (const b of scale.put("right", 1)) cubesR.track(b.index, V(0.36, 0.36, 0.36))
+          },
+        },
+      ]
+      return (dt) => {
+        t += dt
+        if (phase < beats.length && t > beats[phase]!.t) beats[phase++]!.run()
+        frame.sync(w)
+        cubesL.sync(w)
+        cubesR.sync(w)
+        pans.sync(w)
+        stirrups.sync(w)
+        // Lips ride the pans; offset them in the pan's own frame.
+        lipOffsets(lips, w, [scale.leftPan.index, scale.rightPan.index])
+      }
+    },
+  },
+
+  dominoes: {
+    label: "Chain reaction",
+    caption:
+      "120 dominoes. Friction 0.3 — Rapier, Box2D v3 and Planck agree within 2 of 300 and degrade smoothly with friction. Matter.js wedges dead above 0.3.",
+    frame: { cx: 0, cy: 1.6, halfW: 12.4, halfH: 3.2 },
+    build(w, group) {
+      w.ground(30)
+      const run = w.dominoes({ from: [-11, 0], to: [11, 0], count: 120, height: 0.9 })
+      const layer = boxLayer(group, 128, PALETTE.bone, { metalness: 0.1, roughness: 0.7 })
+      const hot = new THREE.Color(PALETTE.rose)
+      const cold = new THREE.Color(PALETTE.bone)
+      run.forEach((d, i) => {
+        const slot = layer.track(d.index, V(0.09, 0.9, 0.55))
+        layer.setColor(slot, cold.clone().lerp(hot, i / run.length))
+      })
+      return () => layer.sync(w)
+    },
+  },
+
+  chain: {
+    label: "Chain & swing",
+    caption:
+      "24 links carrying 100 link-masses. Measured stretch under load stays inside 12% — Planck stretches 64% at a ratio of ten to one.",
+    frame: { cx: 0.5, cy: 7.0, halfW: 9.0, halfH: 6.0 },
+    build(w, group) {
+      w.ground(24)
+      const c = w.chain({ from: [-5, 11], links: 24, load: 120 })
+      const links = boxLayer(group, 32, PALETTE.brass, { metalness: 0.95, roughness: 0.25 })
+      for (const l of c.links) links.track(l.index, V(0.2, 0.1, 0.16))
+      const bob = discLayer(group, 2, PALETTE.copper, { metalness: 0.9 })
+      if (c.bob) bob.track(c.bob.index, V(0.7, 0.7, 0.7))
+      const blocks = boxLayer(group, 40, PALETTE.jade)
+      for (const b of w.stack({ at: [4.5, 0], rows: 6, size: 0.3 })) blocks.track(b.index, V(0.6, 0.6, 0.6))
+      return () => {
+        links.sync(w)
+        bob.sync(w)
+        blocks.sync(w)
+      }
+    },
+  },
+
+  gears: {
+    label: "Gear train",
+    caption:
+      "Ratios exact to the last bit — kinematic, not solved. Real involute teeth as rigid bodies is dozens of tiny fast contacts per pair, the worst case for a tablet.",
+    frame: { cx: 1.8, cy: 4.2, halfW: 5.4, halfH: 3.4 },
+    build(w, group) {
+      const train = w.gearTrain({ at: [-2.4, 4.2], teeth: [16, 32, 12, 24], module: 0.14, driveSpeed: 1.4 })
+      const layer = discLayer(group, 8, PALETTE.brass, { metalness: 0.95, roughness: 0.22 })
+      const tints = [PALETTE.brass, PALETTE.copper, PALETTE.jade, PALETTE.rose]
+      train.gears.forEach((g, i) => {
+        const slot = layer.track(g.body.index, V(g.radius * 2, g.radius * 2, 0.5))
+        layer.setColor(slot, new THREE.Color(tints[i % tints.length]!))
+        // Teeth are geometry, not physics.
+        for (let t = 0; t < g.teeth; t++) {
+          const a = (t / g.teeth) * Math.PI * 2
+          const tooth = new THREE.Mesh(
+            new THREE.BoxGeometry(g.radius * 0.16, g.radius * 0.2, 0.5),
+            standard(tints[i % tints.length]!, { metalness: 0.95, roughness: 0.22 }),
+          )
+          tooth.position.set(Math.cos(a) * g.radius, Math.sin(a) * g.radius, 0)
+          tooth.rotation.z = a
+          tooth.castShadow = true
+          const hub = new THREE.Group()
+          hub.add(tooth)
+          hub.userData.gear = i
+          group.add(hub)
+          ;(group.userData.teeth ??= []).push({ hub, gear: i, base: a, r: g.radius, cx: g.body.position()[0], cy: g.body.position()[1] })
+        }
+      })
+      return (dt) => {
+        train.update(dt)
+        layer.sync(w)
+        for (const t of group.userData.teeth as { hub: THREE.Group; gear: number; base: number; r: number; cx: number; cy: number }[]) {
+          const a = t.base + train.angleOf(t.gear)
+          const m = t.hub.children[0] as THREE.Mesh
+          m.position.set(t.cx + Math.cos(a) * t.r, t.cy + Math.sin(a) * t.r, 0)
+          m.rotation.z = a
+        }
+      }
+    },
+  },
+
+  pour: {
+    label: "Pour & squash",
+    caption:
+      "Particle liquid plus pressurised-ring soft bodies. Not SPH — no pressure term, so it pours and splits convincingly but will not self-level.",
+    frame: { cx: 0, cy: 5.0, halfW: 6.4, halfH: 6.0 },
+    build(w, group) {
+      w.ground(24)
+      // A funnel and two vessels.
+      for (const [x, y, hw, hh, rot] of [
+        [-2.6, 6.2, 1.9, 0.12, -0.5],
+        [2.6, 6.2, 1.9, 0.12, 0.5],
+        [-3.2, 1.5, 0.14, 1.5, 0],
+        [-1.2, 1.5, 0.14, 1.5, 0],
+        [1.2, 1.5, 0.14, 1.5, 0],
+        [3.2, 1.5, 0.14, 1.5, 0],
+      ] as const) {
+        const b = w.add("static", { box: [hw, hh] }, [x, y], { friction: 0.1 })
+        b.rb.setRotation(rot, true)
+        const mesh = new THREE.Mesh(new THREE.BoxGeometry(hw * 2, hh * 2, 1.4), standard(PALETTE.ink, { roughness: 0.6 }))
+        mesh.position.set(x, y, 0)
+        mesh.rotation.z = rot
+        mesh.castShadow = true
+        mesh.receiveShadow = true
+        group.add(mesh)
+      }
+      const drops = w.liquid({ at: [0, 12], count: 400, drop: 0.1, width: 1.6 })
+      const dl = discLayer(group, drops.length, PALETTE.jade, { metalness: 0.2, roughness: 0.25 })
+      for (const d of drops) dl.track(d.index, V(0.2, 0.2, 0.2))
+
+      const blobs = [
+        w.softBlob({ at: [-2.2, 15], radius: 0.75, firmness: 0.35 }),
+        w.softBlob({ at: [2.2, 17], radius: 0.75, firmness: 0.7 }),
+      ]
+      const bl = discLayer(group, 80, PALETTE.rose, { metalness: 0.15, roughness: 0.4 })
+      for (const b of blobs) for (const p of b.ring) bl.track(p.index, V(0.36, 0.36, 0.36))
+      return () => {
+        dl.sync(w)
+        bl.sync(w)
+      }
+    },
+  },
+
+  siege: {
+    label: "Aim & topple",
+    caption:
+      "The dotted arc is not a parabola — it is the shot, simulated in a shadow world. Measured divergence over 150 steps including bounces: 0.000000 mm.",
+    frame: { cx: -1.0, cy: 4.2, halfW: 12.6, halfH: 5.4 },
+    build(w, group) {
+      w.ground(30)
+      const blocks = boxLayer(group, 140, PALETTE.bone, { metalness: 0.1, roughness: 0.7 })
+      for (const b of w.stack({ at: [7, 0], rows: 9, size: 0.34 })) blocks.track(b.index, V(0.68, 0.68, 0.68))
+      const gun = w.launcher({ at: [-11, 5], radius: 0.34, density: 6, restitution: 0.25 })
+      const shots = discLayer(group, 24, PALETTE.copper, { metalness: 0.95, roughness: 0.2 })
+
+      const dots = new THREE.InstancedMesh(
+        new THREE.SphereGeometry(0.09, 8, 6),
+        new THREE.MeshBasicMaterial({ color: PALETTE.brass }),
+        60,
+      )
+      dots.frustumCulled = false
+      group.add(dots)
+      const dm = new THREE.Matrix4()
+
+      let t = 0
+      let next = 0.9
+      let angle = 0.36
+      return (dt) => {
+        t += dt
+        angle = 0.3 + Math.sin(t * 0.55) * 0.22
+        const tr = gun.predict({ angle, speed: 17 }, 90)
+        const end = tr.impactStep >= 0 ? tr.impactStep : tr.steps
+        let n = 0
+        for (let i = 0; i < end && n < 60; i += 2, n++) {
+          dm.makeTranslation(tr.path[i * 2]!, tr.path[i * 2 + 1]!, 0)
+          dm.scale(new THREE.Vector3(1, 1, 1).multiplyScalar(1 - n / 90))
+          dots.setMatrixAt(n, dm)
+        }
+        dots.count = n
+        dots.instanceMatrix.needsUpdate = true
+
+        if (t > next) {
+          next = t + 2.4
+          const shot = gun.fire({ angle, speed: 17 })
+          shots.track(shot.index, V(0.68, 0.68, 0.68))
+        }
+        blocks.sync(w)
+        shots.sync(w)
+      }
+    },
+  },
+}
+
+// ---------------------------------------------------------------- shell
+
+let world: Bazaar | null = null
+let group = new THREE.Group()
+let tick: ((dt: number) => void) | null = null
+let current = ""
+let currentFrame = { cx: 0, cy: 4, halfW: 8, halfH: 5 }
+
+async function load(name: string) {
+  const demo = DEMOS[name]!
+  current = name
+  world?.dispose()
+  scene.remove(group)
+  group.traverse((o: THREE.Object3D) => {
+    const m = o as THREE.Mesh
+    m.geometry?.dispose?.()
+  })
+  group = new THREE.Group()
+  scene.add(group)
+
+  const params = new URLSearchParams(location.search)
+  const tier = params.get("tier") as "low" | "mid" | "high" | "ultra" | null
+  world = await createWorld({ seed: 20260726, ...(tier ? { tier } : {}) })
+  tick = demo.build(world, group)
+  currentFrame = demo.frame
+  frameCamera(camera, currentFrame, innerWidth / innerHeight)
+  document.getElementById("cap-text")!.textContent = demo.caption
+  document.querySelector("#caption b")!.textContent = demo.label
+  for (const b of document.querySelectorAll<HTMLButtonElement>("#tabs button")) {
+    b.setAttribute("aria-pressed", String(b.dataset.name === name))
+  }
+  ;(globalThis as Record<string, unknown>).__world = world
+}
+
+const tabs = document.getElementById("tabs")!
+for (const [name, d] of Object.entries(DEMOS)) {
+  const b = document.createElement("button")
+  b.textContent = d.label
+  b.dataset.name = name
+  b.onclick = () => void load(name)
+  tabs.appendChild(b)
+}
+
+function resize() {
+  const w = innerWidth
+  const h = innerHeight
+  renderer.setSize(w, h, false)
+  camera.aspect = w / h
+  camera.updateProjectionMatrix()
+  // Re-fit rather than crop: on a phone in portrait the camera pulls BACK so
+  // the whole mechanism stays on screen.
+  frameCamera(camera, currentFrame, w / h)
+}
+addEventListener("resize", resize)
+resize()
+
+const fpsEl = document.getElementById("fps")!
+const p99El = document.getElementById("p99")!
+const awakeEl = document.getElementById("awake")!
+const tierEl = document.getElementById("tier")!
+
+let last = performance.now()
+let frames = 0
+let acc = 0
+const frameTimes: number[] = []
+const benchScene = new URLSearchParams(location.search).get("bench")
+let benchFrames = 0
+
+renderer.setAnimationLoop(() => {
+  const now = performance.now()
+  const dt = Math.min((now - last) / 1000, 0.25)
+  last = now
+  if (world && tick) {
+    // Hand the scene SIMULATION time, not display time. On a 120 Hz display
+    // `advance` runs a fixed step every OTHER frame, so a scene clock driven by
+    // the display would run at double speed — which is exactly what made the
+    // balance-scale choreography fire its beats twice as fast as intended and
+    // look like a physics failure. It also keeps the gear train in lockstep
+    // with the bodies it meshes against.
+    const steps = world.advance(dt)
+    tick(steps * FIXED_DT)
+    frameTimes.push(dt * 1000)
+    if (frameTimes.length > 240) frameTimes.shift()
+  }
+  renderer.render(scene, camera)
+
+  frames++
+  acc += dt
+  if (acc >= 0.5 && world) {
+    fpsEl.textContent = String(Math.round(frames / acc))
+    p99El.textContent = world.p99StepMs().toFixed(2)
+    awakeEl.textContent = String(world.awakeCount())
+    tierEl.textContent = world.tier.name
+    frames = 0
+    acc = 0
+  }
+
+  if (benchScene && world) {
+    benchFrames++
+    if (benchFrames === 600) {
+      const sorted = [...frameTimes].sort((a, b) => a - b)
+      const pct = (p: number) => sorted[Math.min(sorted.length - 1, Math.floor((sorted.length * p) / 100))]!
+      ;(globalThis as Record<string, unknown>).__bench = {
+        scene: current,
+        tier: world.tier.name,
+        bodies: world.count,
+        awake: world.awakeCount(),
+        stepP99Ms: world.p99StepMs(),
+        frameP50Ms: pct(50),
+        frameP95Ms: pct(95),
+        frameP99Ms: pct(99),
+        fpsFromP50: 1000 / pct(50),
+      }
+      console.log("BENCH " + JSON.stringify((globalThis as Record<string, unknown>).__bench))
+    }
+  }
+})
+
+await load(benchScene && DEMOS[benchScene] ? benchScene : "scale")

--- a/dynawalla/foundations/physics/demo/vite.config.ts
+++ b/dynawalla/foundations/physics/demo/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite"
+
+// The demo is served from this directory, which sits BELOW the package root, so
+// `fs.allow` has to reach up one level to see `src/` and `node_modules/`.
+// 1425 keeps out of the way of Corpán (1421) and the Dynawalla app (1423).
+export default defineConfig({
+  server: { port: 1425, strictPort: true, fs: { allow: [".."] } },
+  build: { target: "es2020" },
+})

--- a/dynawalla/foundations/physics/package-lock.json
+++ b/dynawalla/foundations/physics/package-lock.json
@@ -1,0 +1,1068 @@
+{
+  "name": "@dynawalla/foundation-physics",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@dynawalla/foundation-physics",
+      "version": "0.0.0",
+      "dependencies": {
+        "@dimforge/rapier2d-compat": "0.19.3",
+        "three": "^0.185.1"
+      },
+      "devDependencies": {
+        "@dimforge/rapier2d-deterministic-compat": "0.19.3",
+        "@types/node": "^26.1.1",
+        "@types/three": "^0.185.1",
+        "box2d3-wasm": "^5.2.0",
+        "matter-js": "^0.20.0",
+        "planck": "^1.5.0",
+        "playwright": "^1.62.0",
+        "typescript": "^6.0.0",
+        "vite": "^8.1.5"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
+    "node_modules/@dimforge/rapier2d-compat": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier2d-compat/-/rapier2d-compat-0.19.3.tgz",
+      "integrity": "sha512-5HZUgiSpu9Uba3He+4SCPVte3h2vgxcodkxWThRjd3X/zgq/Z4OyRUKpNEOsOR6AC+OfulPkkZ5asZGzRMpcwA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@dimforge/rapier2d-deterministic-compat": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier2d-deterministic-compat/-/rapier2d-deterministic-compat-0.19.3.tgz",
+      "integrity": "sha512-1NEi9rcsscmG5cv5SmC+bR0CrPK55zW5zvCUWXv7U4TBPA3Iv7lAR+IrbZhQU8AqipPW+8J47zb+BxX+owdvWA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/box2d3-wasm": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/box2d3-wasm/-/box2d3-wasm-5.2.0.tgz",
+      "integrity": "sha512-kiOahwg3ZwwC3XCvLb9kSoze2BMzpLQO6ZxSG0q/NsLoU4yc22sOVEFtGbnSmDljJgjEQwd8j/AxCxDnNi+yog==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/matter-js": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/matter-js/-/matter-js-0.20.0.tgz",
+      "integrity": "sha512-iC9fYR7zVT3HppNnsFsp9XOoQdQN2tUyfaKg4CHLH8bN+j6GT4Gw7IH2rP0tflAebrHFw730RR3DkVSZRX8hwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/planck": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/planck/-/planck-1.5.0.tgz",
+      "integrity": "sha512-dlvqJE+FscZgrGUXJ5ybd0o5bvZ5XXyZNbm08xGsXp9WjXeAyWSFT6n9s/1PQcUBo4546fDXA5RMA4wbDyZw6g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=24.0"
+      },
+      "peerDependencies": {
+        "stage-js": "^1.0.0-alpha.12"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    }
+  }
+}

--- a/dynawalla/foundations/physics/package.json
+++ b/dynawalla/foundations/physics/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@dynawalla/foundation-physics",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Dynawalla physics foundation: engine bake-off, the kit, and a runnable reference demo.",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "scripts": {
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
+    "tsc": "tsc --noEmit",
+    "bench": "node --experimental-strip-types --no-warnings=ExperimentalWarning bench/run-node.mjs",
+    "bench:browser": "node bench/run-browser.mjs",
+    "demo": "vite --config demo/vite.config.ts demo"
+  },
+  "dependencies": {
+    "@dimforge/rapier2d-compat": "0.19.3",
+    "three": "^0.185.1"
+  },
+  "devDependencies": {
+    "@dimforge/rapier2d-deterministic-compat": "0.19.3",
+    "@types/node": "^26.1.1",
+    "@types/three": "^0.185.1",
+    "box2d3-wasm": "^5.2.0",
+    "matter-js": "^0.20.0",
+    "planck": "^1.5.0",
+    "playwright": "^1.62.0",
+    "typescript": "^6.0.0",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/foundations/physics/src/aim.ts
+++ b/dynawalla/foundations/physics/src/aim.ts
@@ -1,0 +1,224 @@
+// Aiming: trajectories that are TRUE, and assist that is honest about helping.
+//
+// The measurement that decided this file: fire a ball with gravity -10 and read
+// its position every step for 2 s, then compare three ways of predicting it.
+//
+//   symplectic Euler  (v += g·dt; p += v·dt)   125.01 mm off
+//   explicit Euler    (p += v·dt; v += g·dt)   208.33 mm off
+//   the continuous parabola  y = y0+vy·t-½gt²   41.66 mm off
+//
+// None of them is right, because none of them is what Rapier actually does.
+// Drawing any of them as the dotted aiming arc means drawing a lie — and the
+// moment the shot touches ANYTHING the error stops being millimetres, because
+// no closed form knows about the bounce.
+//
+// So we predict by stepping a real Rapier world containing the projectile and
+// the static scenery. Measured over 150 steps including a bounce off the ground
+// AND a ricochet off a ramp: **0.000000 mm** divergence from the real shot. The
+// arc a child sees is the arc, by construction.
+//
+// Cost, measured: 0.70 ms per 150-step prediction with the shadow world reused
+// (M-series Mac, Node/V8). That is real money against a 16.67 ms frame, so the
+// rules the kit enforces are: predict only when the aim CHANGES, cap the step
+// count at the tier's `predictSteps`, and stop early on impact.
+
+import RAPIER from "@dimforge/rapier2d-compat"
+import { FIXED_DT, type World, type Vec2 } from "./world.ts"
+
+export interface Trajectory {
+  /** [x, y] pairs, one per simulated step. Length is `steps * 2`. */
+  path: Float32Array
+  steps: number
+  /** Where it first touched something, if it did. */
+  impact: Vec2 | null
+  /** Step index of the impact. */
+  impactStep: number
+}
+
+export interface LauncherOpts {
+  at: Vec2
+  /** Projectile radius. */
+  radius?: number
+  density?: number
+  restitution?: number
+  /** Continuous collision detection. On by default: a fast small ball tunnels. */
+  bullet?: boolean
+}
+
+export interface Launcher {
+  readonly at: Vec2
+  /** The exact flight path for this aim. Cached until the aim changes. */
+  predict(aim: { angle: number; speed: number }, steps?: number): Trajectory
+  /** Fire for real into the live world. */
+  fire(aim: { angle: number; speed: number }): ReturnType<World["add"]>
+  /**
+   * Aim assist. Searches launch angles for the one that lands nearest `target`
+   * and returns it with the miss distance, so the caller decides whether to
+   * apply it. Returns null if nothing in the search window gets close.
+   */
+  assist(target: Vec2, opts?: AssistOpts): { angle: number; speed: number; missM: number } | null
+  dispose(): void
+}
+
+export interface AssistOpts {
+  speed?: number
+  /** Only assist if the player's own aim was already within this many radians. */
+  window?: number
+  /** Give up if the best candidate still misses by more than this. */
+  toleranceM?: number
+  /** The player's current angle, so assist can stay inside `window` of it. */
+  from?: number
+  /** Candidate angles to try across the window. More = better fit, more cost. */
+  samples?: number
+}
+
+/**
+ * Build a launcher bound to `world`.
+ *
+ * The shadow world is a SEPARATE Rapier world holding copies of the static
+ * scenery only. It has to be separate: predicting inside the live world would
+ * advance the live world, and Rapier's `takeSnapshot`/`restoreSnapshot` round
+ * trip serialises every body in the scene, which at 500 bodies costs far more
+ * than the prediction itself.
+ *
+ * The consequence, stated plainly because it will bite someone: the prediction
+ * knows about STATIC geometry only. A shot aimed through a swinging bucket or a
+ * tower of blocks will diverge at the moment it reaches them. That is the
+ * correct trade — the arc is exact over the free-flight and terrain-bounce part
+ * a player is actually aiming with, and games should stop drawing the arc at
+ * `impact` rather than pretending to know what happens after it hits the
+ * player's own tower.
+ */
+export function launcher(world: World, o: LauncherOpts): Launcher {
+  const radius = o.radius ?? 0.25
+  const density = o.density ?? 2
+  const restitution = o.restitution ?? 0.35
+  const bullet = o.bullet ?? true
+
+  const shadow = new RAPIER.World(world.rapier.gravity)
+  shadow.timestep = FIXED_DT
+  shadow.numSolverIterations = world.tier.solverIterations
+  mirrorStatics(world, shadow)
+
+  let cacheKey = ""
+  let cached: Trajectory | null = null
+
+  function simulate(angle: number, speed: number, steps: number): Trajectory {
+    const rb = shadow.createRigidBody(
+      RAPIER.RigidBodyDesc.dynamic()
+        .setTranslation(o.at[0], o.at[1])
+        .setLinvel(Math.cos(angle) * speed, Math.sin(angle) * speed)
+        .setCcdEnabled(bullet),
+    )
+    shadow.createCollider(
+      RAPIER.ColliderDesc.ball(radius).setDensity(density).setRestitution(restitution).setFriction(0.4),
+      rb,
+    )
+    const path = new Float32Array(steps * 2)
+    let impact: Vec2 | null = null
+    let impactStep = -1
+    let n = 0
+    let lastV = speed
+    for (let i = 0; i < steps; i++) {
+      shadow.step()
+      const t = rb.translation()
+      path[i * 2] = t.x
+      path[i * 2 + 1] = t.y
+      n = i + 1
+      if (impact === null) {
+        const v = rb.linvel()
+        const sp = Math.hypot(v.x, v.y)
+        // A contact is the only thing that can remove speed faster than
+        // gravity adds it. 0.55 is loose enough to survive a grazing hit and
+        // tight enough not to fire on a fast apex.
+        if (sp < lastV * 0.55) {
+          impact = [t.x, t.y]
+          impactStep = i
+        }
+        lastV = Math.max(sp, 0.001)
+      }
+    }
+    shadow.removeRigidBody(rb)
+    return { path, steps: n, impact, impactStep }
+  }
+
+  return {
+    at: o.at,
+    predict(aim, steps) {
+      const n = Math.min(steps ?? world.tier.predictSteps, 600)
+      const key = `${aim.angle.toFixed(5)}|${aim.speed.toFixed(4)}|${n}`
+      if (key === cacheKey && cached) return cached
+      cacheKey = key
+      cached = simulate(aim.angle, aim.speed, n)
+      return cached
+    },
+    fire(aim) {
+      const shot = world.add("dynamic", { circle: radius }, o.at, {
+        density,
+        restitution,
+        friction: 0.4,
+        bullet,
+        tag: "shot",
+      })
+      // The launch velocity must be set with the SAME expression the predictor
+      // used, or the arc and the shot diverge — which is exactly the bug the
+      // test `aim: the predicted arc IS the flight path` exists to catch. It
+      // caught it.
+      shot.setVelocity([Math.cos(aim.angle) * aim.speed, Math.sin(aim.angle) * aim.speed])
+      return shot
+    },
+    assist(target, opts = {}) {
+      const speed = opts.speed ?? 12
+      const window = opts.window ?? 0.28
+      const tolerance = opts.toleranceM ?? 1.2
+      const samples = opts.samples ?? 9
+      const centre = opts.from ?? Math.atan2(target[1] - o.at[1], target[0] - o.at[0])
+      let best: { angle: number; missM: number } | null = null
+      for (let i = 0; i < samples; i++) {
+        const angle = centre + (samples === 1 ? 0 : (i / (samples - 1) - 0.5) * 2 * window)
+        const tr = simulate(angle, speed, world.tier.predictSteps)
+        let miss = Infinity
+        for (let s = 0; s < tr.steps; s++) {
+          const d = Math.hypot(tr.path[s * 2]! - target[0], tr.path[s * 2 + 1]! - target[1])
+          if (d < miss) miss = d
+        }
+        if (!best || miss < best.missM) best = { angle, missM: miss }
+      }
+      if (!best || best.missM > tolerance) return null
+      return { angle: best.angle, speed, missM: best.missM }
+    },
+    dispose() {
+      shadow.free()
+    },
+  }
+}
+
+/**
+ * Copy every static collider from the live world into the shadow world.
+ *
+ * Only cuboids and balls are mirrored, which covers every static shape the kit
+ * builds. If a game adds its own static geometry with another shape it must
+ * rebuild the launcher, or the arc will fly straight through it — a failure
+ * mode worth knowing about because it is silent and looks like a physics bug.
+ */
+function mirrorStatics(world: World, shadow: RAPIER.World) {
+  world.rapier.forEachCollider((c) => {
+    const parent = c.parent()
+    if (!parent || !parent.isFixed()) return
+    const t = c.translation()
+    const rb = shadow.createRigidBody(
+      RAPIER.RigidBodyDesc.fixed().setTranslation(t.x, t.y).setRotation(c.rotation()),
+    )
+    const shape = c.shape
+    let desc: RAPIER.ColliderDesc | null = null
+    if (shape.type === RAPIER.ShapeType.Cuboid) {
+      const h = (shape as RAPIER.Cuboid).halfExtents
+      desc = RAPIER.ColliderDesc.cuboid(h.x, h.y)
+    } else if (shape.type === RAPIER.ShapeType.Ball) {
+      desc = RAPIER.ColliderDesc.ball((shape as RAPIER.Ball).radius)
+    }
+    if (!desc) return
+    desc.setFriction(c.friction()).setRestitution(c.restitution())
+    shadow.createCollider(desc, rb)
+  })
+}

--- a/dynawalla/foundations/physics/src/index.ts
+++ b/dynawalla/foundations/physics/src/index.ts
@@ -1,0 +1,102 @@
+// @dynawalla/physics — the physics foundation for the Dynawalla Bazaar.
+//
+// The whole surface a prototype author needs:
+//
+//   import { createWorld } from "@dynawalla/physics"
+//
+//   const w = await createWorld({ seed: 7 })       // tier auto-detected
+//   w.ground()
+//   const scale = w.balanceScale({ at: [0, 0] })
+//   scale.put("left", 4); scale.put("right", 5)
+//
+//   function frame(dtSeconds: number) {
+//     w.advance(dtSeconds)      // fixed step + interpolation, handled
+//     draw(w.transforms, w.count)   // [x, y, cos, sin] per body
+//   }
+//
+//   scale.compare()   // -1 | 0 | 1 — exact integers, never the beam angle
+//
+// Read ../README.md before changing a default. Every one of them is a measured
+// number, and several of them are the difference between working and silently
+// not working.
+
+import { World, initPhysics, pin, type WorldOpts, type Vec2 } from "./world.ts"
+import { balanceScale, type BalanceScaleOpts } from "./recipes/balanceScale.ts"
+import { chain, gearTrain, lever, type ChainOpts, type GearTrainOpts, type LeverOpts } from "./recipes/mechanisms.ts"
+import { ground, stack, dominoes, fallenFraction, type StackOpts, type DominoOpts } from "./recipes/piles.ts"
+import { softBlob, liquid, volumeIn, type SoftBlobOpts, type LiquidOpts } from "./recipes/soft.ts"
+import { launcher, type LauncherOpts } from "./aim.ts"
+import { Recorder, replay, type Tape } from "./replay.ts"
+
+export * from "./world.ts"
+export * from "./tiers.ts"
+export * from "./rng.ts"
+export * from "./aim.ts"
+export * from "./replay.ts"
+export { fallenFraction, volumeIn }
+export type { BalanceScale } from "./recipes/balanceScale.ts"
+export type { Chain, GearTrain } from "./recipes/mechanisms.ts"
+export type { SoftBlob } from "./recipes/soft.ts"
+
+/** A world with every recipe bound to it, so authors never pass `world` twice. */
+export interface Bazaar extends World {
+  ground(halfWidth?: number, opts?: { friction?: number }): ReturnType<typeof ground>
+  balanceScale(o?: BalanceScaleOpts): ReturnType<typeof balanceScale>
+  chain(o: ChainOpts): ReturnType<typeof chain>
+  gearTrain(o: GearTrainOpts): ReturnType<typeof gearTrain>
+  lever(o: LeverOpts): ReturnType<typeof lever>
+  stack(o: StackOpts): ReturnType<typeof stack>
+  dominoes(o: DominoOpts): ReturnType<typeof dominoes>
+  softBlob(o: SoftBlobOpts): ReturnType<typeof softBlob>
+  liquid(o: LiquidOpts): ReturnType<typeof liquid>
+  launcher(o: LauncherOpts): ReturnType<typeof launcher>
+  pin(
+    a: Parameters<typeof pin>[1],
+    b: Parameters<typeof pin>[2],
+    anchorA: Vec2,
+    anchorB: Vec2,
+    limit?: readonly [number, number],
+  ): ReturnType<typeof pin>
+  record(): Recorder
+  replay(tape: Tape): Bazaar
+}
+
+/**
+ * The one-liner. Loads the WASM once per process (idempotent under StrictMode),
+ * picks a quality tier, and returns a world with every recipe already bound.
+ */
+export async function createWorld(opts: WorldOpts = {}): Promise<Bazaar> {
+  await initPhysics()
+  const w = new World({
+    ...opts,
+    deviceHints: opts.deviceHints ?? readDeviceHints(),
+  }) as Bazaar
+
+  w.ground = (halfWidth, o) => ground(w, halfWidth, o)
+  w.balanceScale = (o) => balanceScale(w, o)
+  w.chain = (o) => chain(w, o)
+  w.gearTrain = (o) => gearTrain(w, o)
+  w.lever = (o) => lever(w, o)
+  w.stack = (o) => stack(w, o)
+  w.dominoes = (o) => dominoes(w, o)
+  w.softBlob = (o) => softBlob(w, o)
+  w.liquid = (o) => liquid(w, o)
+  w.launcher = (o) => launcher(w, o)
+  w.pin = (a, b, anchorA, anchorB, limit) => pin(w, a, b, anchorA, anchorB, limit)
+  w.record = () => new Recorder(w)
+  w.replay = (tape) => replay(w, tape)
+  return w
+}
+
+function readDeviceHints() {
+  if (typeof navigator === "undefined") return {}
+  const nav = navigator as Navigator & { deviceMemory?: number }
+  return {
+    deviceMemoryGb: nav.deviceMemory,
+    hardwareConcurrency: nav.hardwareConcurrency,
+    screenPx:
+      typeof screen !== "undefined"
+        ? Math.min(screen.width, screen.height) * (globalThis.devicePixelRatio ?? 1)
+        : undefined,
+  }
+}

--- a/dynawalla/foundations/physics/src/physics.test.ts
+++ b/dynawalla/foundations/physics/src/physics.test.ts
@@ -1,0 +1,278 @@
+// Gates for the physics kit.
+//
+// These are not "does Rapier work" tests. Each one pins a claim the README
+// makes or a trap the bake-off found, so that a future change which quietly
+// undoes it fails here instead of on a child's tablet.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { createWorld, FIXED_DT } from "./index.ts"
+import { makeRng } from "./rng.ts"
+import { guessTier, autoTune, TIERS } from "./tiers.ts"
+import { defineCommand, replay, verify } from "./replay.ts"
+
+const DEG = 180 / Math.PI
+
+test("rng: same seed, same stream; different seeds, different streams", () => {
+  const a = makeRng(42)
+  const b = makeRng(42)
+  const c = makeRng(43)
+  const sa = Array.from({ length: 64 }, () => a())
+  const sb = Array.from({ length: 64 }, () => b())
+  const sc = Array.from({ length: 64 }, () => c())
+  assert.deepEqual(sa, sb)
+  assert.notDeepEqual(sa, sc)
+  // Adjacent seeds must not be correlated — the classic bad-seeding failure.
+  const corr = sa.reduce((acc, v, i) => acc + Math.abs(v - sc[i]!), 0) / 64
+  assert.ok(corr > 0.2, `adjacent seeds look correlated (mean |diff| ${corr})`)
+  assert.ok(sa.every((v) => v >= 0 && v < 1))
+})
+
+test("tiers: mid is the floor, and autoTune drops fast and climbs slowly", () => {
+  assert.equal(guessTier({ deviceMemoryGb: 4 }), "mid")
+  assert.equal(guessTier({ deviceMemoryGb: 2 }), "low")
+  // iOS never reports deviceMemory. It must not fall through to "low".
+  assert.equal(guessTier({ hardwareConcurrency: 8 }), "ultra")
+  assert.equal(guessTier({ hardwareConcurrency: 4 }), "mid")
+  // Over budget -> down one. Far under -> up one. In between -> hold.
+  assert.equal(autoTune("high", 9, 4), "mid")
+  assert.equal(autoTune("mid", 0.5, 4), "high")
+  assert.equal(autoTune("mid", 3, 4), "mid")
+  assert.equal(autoTune("low", 99, 4), "low")
+  assert.equal(autoTune("ultra", 0.001, 4), "ultra")
+})
+
+test("THE EQUALS SIGN: equal pans settle level, and stay level", async () => {
+  const w = await createWorld({ seed: 1, tier: "mid" })
+  w.ground()
+  const scale = w.balanceScale({ at: [0, 0] })
+  scale.put("left", 4)
+  scale.put("right", 4)
+  w.stepExact(900)
+  const tiltDeg = Math.abs(scale.tilt() * DEG)
+  assert.ok(tiltDeg < 1.5, `equal pans must read level; got ${tiltDeg.toFixed(3)} deg`)
+  assert.equal(scale.compare(), 0)
+  assert.ok(scale.settled(), "an equal scale must come to rest")
+  w.dispose()
+})
+
+test("THE EQUALS SIGN: an imbalance tips the right way, visibly", async () => {
+  const w = await createWorld({ seed: 1, tier: "mid" })
+  w.ground()
+  const scale = w.balanceScale({ at: [0, 0] })
+  scale.put("left", 4)
+  scale.put("right", 5)
+  w.stepExact(900)
+  // Negative tilt = the right-hand pan went down.
+  const tiltDeg = scale.tilt() * DEG
+  assert.ok(tiltDeg < -4, `heavier right pan must visibly drop; got ${tiltDeg.toFixed(2)} deg`)
+  assert.equal(scale.compare(), 1)
+  w.dispose()
+})
+
+test("THE EQUALS SIGN: compare() is arithmetic, not the solver", async () => {
+  const w = await createWorld({ seed: 1, tier: "mid" })
+  w.ground()
+  const scale = w.balanceScale({ at: [0, 0] })
+  scale.put("left", 3)
+  scale.put("right", 3)
+  // Before a single step has run — no physics has happened at all — the
+  // comparison is already correct. That is the whole point.
+  assert.equal(scale.compare(), 0)
+  scale.put("right", 1)
+  assert.equal(scale.compare(), 1)
+  assert.equal(scale.left, 3)
+  assert.equal(scale.right, 4)
+  // And knocking the beam about must not change the answer.
+  scale.beam.rb.setRotation(0.6, true)
+  w.stepExact(30)
+  assert.equal(scale.compare(), 1)
+  w.dispose()
+})
+
+test("articulated assemblies do not collide with themselves", async () => {
+  // The Rapier trap. Without assembly collision groups this pendulum is frozen
+  // at 0.0 deg; with them it swings. Measured in bench/, gated here.
+  const w = await createWorld({ seed: 1, tier: "mid" })
+  const asm = w.newAssembly()
+  const anchor = w.add("static", { box: [0.1, 0.1] }, [0, 10], { assembly: asm })
+  const arm = w.add("dynamic", { box: [1, 0.05] }, [1, 10], { assembly: asm, density: 5 })
+  w.pin(anchor, arm, [0, 0], [-1, 0])
+  w.stepExact(300)
+  assert.ok(
+    Math.abs(arm.angle()) > 0.2,
+    `pendulum did not swing (${(arm.angle() * DEG).toFixed(2)} deg) — assembly groups regressed`,
+  )
+  w.dispose()
+})
+
+test("a joint limit set on JointData is ignored — pin() must apply it to the joint", async () => {
+  // The trap, gated. Rapier accepts `JointData.limitsEnabled` / `.limits` for a
+  // revolute joint, type-checks them, and silently ignores them; measured, an
+  // arm with a +/-22 deg stop set that way swings to -174 deg. Only
+  // `joint.setLimits()` on the created joint works.
+  const w = await createWorld({ seed: 1, tier: "mid" })
+  const asm = w.newAssembly()
+  const post = w.add("static", { box: [0.1, 0.1] }, [0, 5], { assembly: asm })
+  const arm = w.add("dynamic", { box: [1, 0.1] }, [1, 5], { assembly: asm, density: 5 })
+  const stop = (22 * Math.PI) / 180
+  w.pin(post, arm, [0, 0], [-1, 0], [-stop, stop])
+  w.stepExact(400)
+  const deg = arm.angle() * DEG
+  assert.ok(Math.abs(deg) <= 22.5, `joint limit not applied: arm reached ${deg.toFixed(2)} deg`)
+  assert.ok(Math.abs(deg) > 20, `arm should be resting ON the stop, not at ${deg.toFixed(2)} deg`)
+  w.dispose()
+})
+
+test("aim: the predicted arc IS the flight path, bounces included", async () => {
+  const w = await createWorld({ seed: 1, tier: "high" })
+  w.ground(30)
+  w.add("static", { box: [2, 0.2] }, [9, 1], { restitution: 0.35 })
+  const gun = w.launcher({ at: [-8, 4] })
+  const aim = { angle: 0.55, speed: 13 }
+  const predicted = gun.predict(aim, 150)
+
+  const shot = gun.fire(aim)
+  let worst = 0
+  for (let i = 0; i < predicted.steps; i++) {
+    w.stepExact(1)
+    const p = shot.position()
+    worst = Math.max(worst, Math.hypot(p[0] - predicted.path[i * 2]!, p[1] - predicted.path[i * 2 + 1]!))
+  }
+  // Sub-millimetre over 150 steps and at least one bounce.
+  assert.ok(worst < 0.001, `prediction diverged by ${(worst * 1000).toFixed(4)} mm`)
+  gun.dispose()
+  w.dispose()
+})
+
+test("aim assist stays inside its window and reports its own miss", async () => {
+  const w = await createWorld({ seed: 1, tier: "mid" })
+  w.ground(30)
+  const gun = w.launcher({ at: [-8, 2] })
+  const target: [number, number] = [6, 0.4]
+  const from = Math.atan2(target[1] - 2, target[0] + 8)
+  const a = gun.assist(target, { from, window: 0.3, speed: 13, toleranceM: 3 })
+  assert.ok(a, "assist should find a shot at a reachable target")
+  assert.ok(Math.abs(a!.angle - from) <= 0.3 + 1e-9, "assist must stay inside its window")
+  assert.ok(a!.missM <= 3)
+  // An unreachable target must return null rather than a wild guess.
+  assert.equal(gun.assist([500, 400], { window: 0.3, speed: 13, toleranceM: 1 }), null)
+  gun.dispose()
+  w.dispose()
+})
+
+test("chain holds its length under a realistic load", async () => {
+  const w = await createWorld({ seed: 1, tier: "mid" })
+  const c = w.chain({ from: [-4, 10], links: 24, load: 100 })
+  w.stepExact(600)
+  const s = Math.abs(c.stretchPct())
+  assert.ok(s < 12, `chain stretched ${s.toFixed(1)}% — should read as a chain, not elastic`)
+  w.dispose()
+})
+
+test("gear train meshes exactly and reverses each stage", async () => {
+  const w = await createWorld({ seed: 1, tier: "mid" })
+  const t = w.gearTrain({ at: [0, 4], teeth: [12, 24, 8], driveSpeed: 2 })
+  for (let i = 0; i < 60; i++) t.update(FIXED_DT)
+  const a0 = t.angleOf(0)
+  const a1 = t.angleOf(1)
+  const a2 = t.angleOf(2)
+  // Meshed gears counter-rotate, and arc length at the pitch circle is shared:
+  // theta1 / theta0 == -teeth0 / teeth1, exactly.
+  assert.ok(Math.abs(a1 / a0 - -12 / 24) < 1e-12, "stage 1 ratio is not exact")
+  assert.ok(Math.abs(a2 / a0 - 12 / 8) < 1e-12, "stage 2 ratio is not exact")
+  assert.ok(a0 * a1 < 0, "meshed gears must counter-rotate")
+  assert.ok(a1 * a2 < 0, "meshed gears must counter-rotate")
+  w.dispose()
+})
+
+test("dominoes propagate", async () => {
+  const w = await createWorld({ seed: 1, tier: "mid" })
+  w.ground(40)
+  const run = w.dominoes({ from: [-6, 0], to: [6, 0], count: 30 })
+  w.stepExact(900)
+  const { fallenFraction } = await import("./recipes/piles.ts")
+  assert.ok(fallenFraction(run) > 0.8, `only ${(fallenFraction(run) * 100) | 0}% of the run fell`)
+  w.dispose()
+})
+
+test("soft blob squashes and recovers rather than inverting", async () => {
+  const w = await createWorld({ seed: 1, tier: "high" })
+  w.ground(20)
+  const blob = w.softBlob({ at: [0, 6], radius: 0.8, firmness: 0.6 })
+  w.stepExact(30)
+  const airborne = blob.roundness()
+  w.stepExact(60) // impact
+  w.stepExact(240) // settle
+  const settled = blob.roundness()
+  assert.ok(airborne > 0.75, `blob deformed in free fall (${airborne.toFixed(2)})`)
+  assert.ok(settled > 0.45, `blob collapsed or inverted on landing (${settled.toFixed(2)})`)
+  w.dispose()
+})
+
+test("liquid is capped by the tier, not by the caller's optimism", async () => {
+  const w = await createWorld({ seed: 1, tier: "low" })
+  w.ground(10)
+  const drops = w.liquid({ at: [0, 8], count: 5000 })
+  assert.equal(drops.length, TIERS.low.particles)
+  w.dispose()
+})
+
+test("advance() clamps a backgrounded tab instead of freezing on catch-up", async () => {
+  const w = await createWorld({ seed: 1, tier: "mid" })
+  w.ground()
+  w.stack({ at: [0, 0], rows: 4 })
+  // 12 seconds of missed time, as if the app had been backgrounded.
+  const steps = w.advance(12)
+  assert.ok(steps <= TIERS.mid.maxCatchUpSteps, `ran ${steps} steps for one frame`)
+  w.dispose()
+})
+
+test("replay: a command tape reproduces the run bit for bit", async () => {
+  defineCommand("drop", (world, [x, y]) => {
+    world.add("dynamic", { box: [0.2, 0.2] }, [x as number, y as number], { density: 1 })
+  })
+
+  const build = async () => {
+    const w = await createWorld({ seed: 99, tier: "mid" })
+    w.ground()
+    w.stack({ at: [0, 0], rows: 3 })
+    return w
+  }
+
+  const a = await build()
+  const rec = a.record()
+  for (let i = 0; i < 120; i++) {
+    if (i === 10) rec.do("drop", -1.5, 6)
+    if (i === 40) rec.do("drop", 0.7, 7)
+    if (i === 80) rec.do("drop", 1.9, 8)
+    a.stepExact(1)
+  }
+  const tape = rec.stop()
+
+  const b = await build()
+  replay(b, tape)
+
+  assert.equal(b.hash(), a.hash(), "replay diverged from the recorded run")
+  assert.ok(verify(b, tape))
+  assert.equal(tape.commands.length, 3)
+  // The tape stores commands, not positions.
+  assert.ok(JSON.stringify(tape).length < 800, "a tape should be tiny")
+  a.dispose()
+  b.dispose()
+})
+
+test("the same seed and the same steps give the same world twice", async () => {
+  const run = async () => {
+    const w = await createWorld({ seed: 2026, tier: "mid" })
+    w.ground(12)
+    w.stack({ at: [0, 0], rows: 6 })
+    w.liquid({ at: [0, 9], count: 60 })
+    w.stepExact(400)
+    const h = w.hash()
+    w.dispose()
+    return h
+  }
+  assert.equal(await run(), await run())
+})

--- a/dynawalla/foundations/physics/src/recipes/balanceScale.ts
+++ b/dynawalla/foundations/physics/src/recipes/balanceScale.ts
@@ -1,0 +1,187 @@
+// THE BALANCE SCALE — the physical embodiment of the equals sign.
+//
+// This is the most important object in the kit, so it is the one with the most
+// evidence behind it. `bench/probe-scale.mjs` builds the identical scale in four
+// engines at five pivot heights; the results are in ../../README.md. Three
+// things came out of it and all three are baked in here:
+//
+// 1. THE ASSEMBLY MUST NOT COLLIDE WITH ITSELF.
+//    Rapier joints collide the bodies they connect and expose no
+//    `collideConnected`. A scale built the obvious way is a scale whose beam
+//    cannot rotate: measured 0.0 deg of travel under a 100% overload. With one
+//    collision-group bit it swings -66 deg under a 25% overload. This is not a
+//    tuning preference, it is the difference between working and not.
+//
+// 2. THE PIVOT SITS ABOVE THE BEAM'S CENTRE OF MASS.
+//    A beam pivoted through its own centroid is NEUTRALLY stable: there is no
+//    restoring torque at any angle, so where it settles is decided by solver
+//    noise. `pivotRaise` turns "level" into an attractor, and doubles as the
+//    sensitivity dial. Measured on Rapier, tilt under one extra unit in four:
+//      raise 0.00 -> -66.5 deg   (dramatic, and slow to settle)
+//      raise 0.05 -> -31.6 deg
+//      raise 0.15 -> -17.8 deg   <- default: legible across a tablet, settles fast
+//      raise 0.30 -> -18.3 deg
+//      raise 0.60 ->  -3.2 deg   (too subtle to read)
+//    At equality every one of those settles to within 0.02 deg with 0.000 deg
+//    of jitter, which is what "the equals sign is reliable" has to mean.
+//
+// 3. THE PANS HAVE LIPS.
+//    Not decoration. A load on a lipless pan slides off the moment the beam
+//    tilts, which silently removes the imbalance — the first version of the
+//    probe concluded Rapier "settles level under a 25% overload" because the
+//    overload had slid onto the floor.
+//
+// And the rule that is not about physics at all:
+//
+// 4. `compare()` IS INTEGER ARITHMETIC, NEVER THE BEAM ANGLE.
+//    The beam is how the child SEES the comparison. It is never how the app
+//    KNOWS it. Reading a mastery signal off a float that a solver produced
+//    would make a curriculum claim depend on contact ordering. This mirrors
+//    ADR-0009's "true by construction" — the visual can be beautiful and
+//    approximate; the answer must be exact.
+
+import { pin, type World, type Vec2, type BodyHandle } from "../world.ts"
+
+export interface BalanceScaleOpts {
+  at?: Vec2
+  /** Half the distance between the pans. */
+  armLength?: number
+  /** Pivot height above the beam's centre of mass. See note 2. */
+  pivotRaise?: number
+  /** Mass of one unit weight, in kilograms of the world's own scale. */
+  unitMass?: number
+  /**
+   * Mechanical stop, in degrees either side of level. A real balance has one;
+   * without it an imbalance runs the beam to vertical and puts the low pan
+   * through the floor, which is both ugly and unreadable. 22 deg is enough to
+   * be unmistakable across a tablet and small enough that the pans stay level
+   * enough to hold their load.
+   */
+  maxTiltDeg?: number
+}
+
+export interface BalanceScale {
+  readonly beam: BodyHandle
+  readonly leftPan: BodyHandle
+  readonly rightPan: BodyHandle
+  /** The two hanging links, exposed so a view can draw them. */
+  readonly stirrups: readonly [BodyHandle, BodyHandle]
+  /** Drop `n` unit weights into a pan. They are real bodies and really land. */
+  put(side: "left" | "right", n?: number): BodyHandle[]
+  /** Take one back off. Returns false if that pan is empty. */
+  take(side: "left" | "right"): boolean
+  readonly left: number
+  readonly right: number
+  /**
+   * The truth: -1 left is heavier, 0 equal, +1 right is heavier.
+   * Exact integer comparison of what was put in. Never the beam angle.
+   */
+  compare(): -1 | 0 | 1
+  /** Beam tilt in radians, for the view only. */
+  tilt(): number
+  /** Tilt as a fraction of the mechanical stop, -1..+1. View only. */
+  tiltFraction(): number
+  /** True once the beam has stopped moving — for "wait for it to settle" UX. */
+  settled(): boolean
+}
+
+const PAN_HALF_W = 1.0
+const LIP_H = 0.3
+
+export function balanceScale(w: World, o: BalanceScaleOpts = {}): BalanceScale {
+  const [ox, oy] = o.at ?? [0, 0]
+  const armLength = o.armLength ?? 3.2
+  const pivotRaise = o.pivotRaise ?? 0.15
+  const unitMass = o.unitMass ?? 1
+  const maxTilt = ((o.maxTiltDeg ?? 22) * Math.PI) / 180
+  const hang = 1.3
+
+  // ONE assembly id for every part of the scale. Note 1.
+  const asm = w.newAssembly()
+  const part = { assembly: asm, friction: 0.6 } as const
+
+  const pivotY = oy + 5.2
+  const beamY = pivotY - pivotRaise
+
+  const column = w.add("static", { box: [0.3, 2.6] }, [ox, oy + 2.6], part)
+  const beam = w.add("dynamic", { box: [armLength, 0.12] }, [ox, beamY], { ...part, density: 2.5 })
+
+  const makeSide = (sign: -1 | 1) => {
+    const x = ox + sign * armLength
+    const stirrup = w.add("dynamic", { box: [0.04, hang / 2] }, [x, beamY - hang / 2], {
+      ...part,
+      density: 0.8,
+    })
+    // Note 3 — a pan is a compound body: floor plus two lips.
+    const pan = w.add(
+      "dynamic",
+      [
+        { box: [PAN_HALF_W, 0.08] },
+        { box: [0.08, LIP_H], at: [-(PAN_HALF_W - 0.08), LIP_H] },
+        { box: [0.08, LIP_H], at: [PAN_HALF_W - 0.08, LIP_H] },
+      ],
+      [x, beamY - hang],
+      { ...part, density: 1.2, friction: 0.9, tag: sign < 0 ? "pan-left" : "pan-right" },
+    )
+    return { stirrup, pan, x }
+  }
+
+  const L = makeSide(-1)
+  const R = makeSide(1)
+
+  pin(w, column, beam, [0, pivotY - (oy + 2.6)], [0, pivotRaise], [-maxTilt, maxTilt])
+  pin(w, beam, L.stirrup, [-armLength, 0], [0, hang / 2])
+  pin(w, L.stirrup, L.pan, [0, -hang / 2], [0, 0])
+  pin(w, beam, R.stirrup, [armLength, 0], [0, hang / 2])
+  pin(w, R.stirrup, R.pan, [0, -hang / 2], [0, 0])
+
+  const held: Record<"left" | "right", BodyHandle[]> = { left: [], right: [] }
+
+  const api: BalanceScale = {
+    beam,
+    leftPan: L.pan,
+    rightPan: R.pan,
+    stirrups: [L.stirrup, R.stirrup],
+    put(side, n = 1) {
+      const made: BodyHandle[] = []
+      const pan = side === "left" ? L : R
+      for (let i = 0; i < n; i++) {
+        const k = held[side].length
+        // Deterministic drop positions: no Math.random, and a replay of the
+        // same command log stacks the cubes the same way every time.
+        const lane = k % 4
+        const cube = w.add(
+          "dynamic",
+          { box: [0.18, 0.18] },
+          [pan.x + (lane - 1.5) * 0.42, beamY - hang + 0.6 + Math.floor(k / 4) * 0.42 + i * 0.02],
+          { density: unitMass / (0.36 * 0.36), friction: 0.7, tag: `unit-${side}` },
+        )
+        held[side].push(cube)
+        made.push(cube)
+      }
+      return made
+    },
+    take(side) {
+      const b = held[side].pop()
+      if (!b) return false
+      b.remove()
+      return true
+    },
+    get left() {
+      return held.left.length
+    },
+    get right() {
+      return held.right.length
+    },
+    compare() {
+      // Note 4. Integers in, integer out. The solver is not consulted.
+      const d = held.left.length - held.right.length
+      return d === 0 ? 0 : d > 0 ? -1 : 1
+    },
+    tilt: () => beam.angle(),
+    /** -1..+1, tilt as a fraction of the mechanical stop. Handy for the view. */
+    tiltFraction: () => Math.max(-1, Math.min(1, beam.angle() / maxTilt)),
+    settled: () => Math.abs(beam.rb.angvel()) < 0.02,
+  }
+  return api
+}

--- a/dynawalla/foundations/physics/src/recipes/mechanisms.ts
+++ b/dynawalla/foundations/physics/src/recipes/mechanisms.ts
@@ -1,0 +1,212 @@
+// Chains, levers and gear trains.
+
+import RAPIER from "@dimforge/rapier2d-compat"
+import { pin, type World, type Vec2, type BodyHandle } from "../world.ts"
+
+export interface ChainOpts {
+  from: Vec2
+  links?: number
+  /** Metres per link. */
+  linkLength?: number
+  /** Mass hung on the free end, in multiples of one link's mass. */
+  load?: number
+  /** Pin the far end too, for a hanging banner or a rope bridge. */
+  to?: Vec2
+}
+
+export interface Chain {
+  readonly links: BodyHandle[]
+  readonly bob: BodyHandle | null
+  /** Measured length / rest length - 1, as a percentage. Cheap; use it in tests. */
+  stretchPct(): number
+}
+
+/**
+ * A chain that behaves like a chain.
+ *
+ * `bench/probe-rope.mjs` swept the load:link mass ratio across four engines.
+ * Rapier at its default 4 solver iterations holds 0.7% stretch at 10:1, 3.3% at
+ * 150:1 and 17.5% at 2000:1; 16 iterations brings 2000:1 down to 7% for 3.4x
+ * the solve cost. (For contrast, Planck stretches 64% at 10:1 and more
+ * iterations barely help — Box2D 2.4's solver simply cannot hold a chain.)
+ *
+ * So the guidance encoded here is: keep `load` at or under ~150 link-masses and
+ * the default tier is fine. Above that, raise the tier rather than the link
+ * count — a longer chain of lighter links is cheaper AND more stable than a
+ * short chain fighting a boulder.
+ */
+export function chain(w: World, o: ChainOpts): Chain {
+  const links = o.links ?? 20
+  const half = (o.linkLength ?? 0.2) / 2
+  const asm = w.newAssembly()
+  const [ax, ay] = o.from
+
+  const anchor = w.add("static", { box: [0.08, 0.08] }, [ax, ay], { assembly: asm })
+  const made: BodyHandle[] = []
+  for (let i = 0; i < links; i++) {
+    const link = w.add("dynamic", { box: [half, half * 0.5] }, [ax + half + i * half * 2, ay], {
+      assembly: asm,
+      density: 4,
+      friction: 0.2,
+    })
+    // Damping is not a cheat, it is the air resistance and inter-link friction
+    // a real chain has. Without it a chain released from horizontal swings
+    // forever, and the peak tension at the bottom of every swing keeps the
+    // measured stretch high long after it should have settled — which is what
+    // made the first version of the chain gate fail at 30% on a load the probe
+    // said should sit near 3%.
+    link.rb.setLinearDamping(0.15)
+    link.rb.setAngularDamping(0.25)
+    made.push(link)
+  }
+
+  pin(w, anchor, made[0]!, [0, 0], [-half, 0])
+  for (let i = 0; i < links - 1; i++) pin(w, made[i]!, made[i + 1]!, [half, 0], [-half, 0])
+
+  let bob: BodyHandle | null = null
+  if (o.load) {
+    const r = 0.35
+    // density chosen so the bob is `load` x one link's mass
+    const linkMass = 4 * (half * 2) * half
+    const density = (o.load * linkMass) / (Math.PI * r * r)
+    bob = w.add("dynamic", { circle: r }, [ax + links * half * 2 + r, ay], {
+      assembly: asm,
+      density,
+      friction: 0.4,
+    })
+    bob.rb.setLinearDamping(0.15)
+    pin(w, made[links - 1]!, bob, [half, 0], [-r, 0])
+  } else if (o.to) {
+    const far = w.add("static", { box: [0.08, 0.08] }, o.to, { assembly: asm })
+    pin(w, made[links - 1]!, far, [half, 0], [0, 0])
+  }
+
+  const rest = (links - 1) * half * 2 + (bob ? half + 0.35 : 0)
+  return {
+    links: made,
+    bob,
+    stretchPct() {
+      const pts = [...made, ...(bob ? [bob] : [])]
+      let span = 0
+      for (let i = 1; i < pts.length; i++) {
+        const a = pts[i - 1]!.position()
+        const b = pts[i]!.position()
+        span += Math.hypot(b[0] - a[0], b[1] - a[1])
+      }
+      return rest === 0 ? 0 : ((span - rest) / rest) * 100
+    },
+  }
+}
+
+export interface GearTrainOpts {
+  at: Vec2
+  /** Tooth counts, left to right. Radius is derived so the teeth mesh. */
+  teeth: number[]
+  /** Metres per tooth. 0.12 reads well on a tablet. */
+  module?: number
+  /** Radians per second on gear 0. */
+  driveSpeed?: number
+}
+
+export interface GearTrain {
+  readonly gears: { body: BodyHandle; teeth: number; radius: number; ratio: number }[]
+  /** Advance the train. Call once per fixed step. */
+  update(dt: number): void
+  /** Exact angle of gear i, in radians. */
+  angleOf(i: number): number
+  setSpeed(radPerSec: number): void
+}
+
+/**
+ * A gear train whose teeth mesh EXACTLY, by construction.
+ *
+ * Deliberately kinematic, not dynamic. Simulating real involute teeth as
+ * colliding rigid bodies is the textbook way to get a gear train that jitters,
+ * backlashes, climbs out of mesh and costs a fortune in contacts — dozens of
+ * tiny high-speed manifolds per pair, which is exactly the contact profile a
+ * mid-range tablet is worst at. Rapier's JS API has no gear joint (fixed,
+ * revolute, prismatic, rope and spring are the whole set), so a dynamic train
+ * would have to be faked with friction anyway.
+ *
+ * Driving the angles from one exact ratio chain gives perfect mesh for free,
+ * costs nothing per frame, and is deterministic. The teeth are a rendering
+ * concern. If a game needs a gear to be BLOCKED by something, put a dynamic
+ * body in its path and check the contact — do not ask the solver to do the
+ * meshing.
+ */
+export function gearTrain(w: World, o: GearTrainOpts): GearTrain {
+  const module_ = o.module ?? 0.12
+  const asm = w.newAssembly()
+  const gears: GearTrain["gears"] = []
+  let x = o.at[0]
+  let ratio = 1
+  o.teeth.forEach((teeth, i) => {
+    const radius = (teeth * module_) / 2
+    if (i > 0) {
+      x += gears[i - 1]!.radius + radius
+      // Meshed gears turn opposite ways, at the inverse ratio of their teeth.
+      ratio = -gears[i - 1]!.ratio * (gears[i - 1]!.teeth / teeth)
+    }
+    const body = w.add("kinematic", { circle: radius }, [x, o.at[1]], {
+      assembly: asm,
+      friction: 0.9,
+      tag: `gear-${i}`,
+    })
+    gears.push({ body, teeth, radius, ratio })
+  })
+
+  let speed = o.driveSpeed ?? 1
+  let angle = 0
+  return {
+    gears,
+    setSpeed: (s) => {
+      speed = s
+    },
+    angleOf: (i) => angle * gears[i]!.ratio,
+    update(dt) {
+      angle += speed * dt
+      for (const g of gears) {
+        g.body.rb.setNextKinematicRotation(angle * g.ratio)
+      }
+    },
+  }
+}
+
+export interface LeverOpts {
+  at: Vec2
+  length?: number
+  /** Fulcrum position along the beam, -1 (left end) .. +1 (right end). */
+  fulcrum?: number
+}
+
+/**
+ * A lever: the same mechanism as the balance scale but with a LOAD SURFACE
+ * rather than hanging pans, so things placed on it can slide and fall off.
+ * That is the point — a lever teaches moments, and a moment depends on where
+ * the weight sits, which a hanging pan deliberately hides.
+ */
+export function lever(w: World, o: LeverOpts) {
+  const length = o.length ?? 4
+  const f = o.fulcrum ?? 0
+  const asm = w.newAssembly()
+  const [ox, oy] = o.at
+  const fulcrumX = ox + f * length
+  const post = w.add("static", { box: [0.25, 0.5] }, [fulcrumX, oy + 0.5], { assembly: asm })
+  const plank = w.add("dynamic", { box: [length, 0.1] }, [ox, oy + 1.1], {
+    assembly: asm,
+    density: 2,
+    friction: 0.8,
+  })
+  pin(w, post, plank, [0, 0.5], [f * length, 0])
+  return {
+    plank,
+    /** Signed moment about the fulcrum, in N·m — the exact quantity, for the UI. */
+    momentOf(b: BodyHandle) {
+      const [bx] = b.position()
+      return (bx - fulcrumX) * b.rb.mass() * 10
+    },
+    tilt: () => plank.angle(),
+  }
+}
+
+export { RAPIER }

--- a/dynawalla/foundations/physics/src/recipes/piles.ts
+++ b/dynawalla/foundations/physics/src/recipes/piles.ts
@@ -1,0 +1,110 @@
+// Ground, stacks, dominoes — everything that is "a lot of boxes touching".
+
+import type { World, Vec2, BodyHandle } from "../world.ts"
+
+export function ground(w: World, halfWidth = 20, opts: { friction?: number } = {}): BodyHandle {
+  return w.add("static", { box: [halfWidth, 0.5] }, [0, -0.5], {
+    friction: opts.friction ?? 0.6,
+    tag: "ground",
+  })
+}
+
+export interface StackOpts {
+  at: Vec2
+  rows?: number
+  /** Half-extent of one block. */
+  size?: number
+  /** "pyramid" is stable and topples beautifully; "tower" is the fragile one. */
+  shape?: "pyramid" | "tower"
+  friction?: number
+}
+
+/**
+ * A stack that stands still until something hits it.
+ *
+ * The 1 mm gap is not a typo. Boxes authored exactly touching start the
+ * simulation already penetrating by the solver's linear slop, so frame 0 is
+ * spent pushing the whole pile apart — which reads as the stack "breathing"
+ * before anyone touches it, and differs between engines. Author the gap.
+ */
+export function stack(w: World, o: StackOpts): BodyHandle[] {
+  const rows = o.rows ?? 10
+  const h = o.size ?? 0.25
+  const gap = 0.001
+  const out: BodyHandle[] = []
+  const [ox, oy] = o.at
+  for (let row = 0; row < rows; row++) {
+    const n = o.shape === "tower" ? 2 : rows - row
+    for (let i = 0; i < n; i++) {
+      out.push(
+        w.add(
+          "dynamic",
+          { box: [h, h] },
+          [ox + (i - (n - 1) / 2) * (h * 2 + gap), oy + h + row * (h * 2 + gap)],
+          { density: 1, friction: o.friction ?? 0.5, tag: "block" },
+        ),
+      )
+    }
+  }
+  return out
+}
+
+export interface DominoOpts {
+  from: Vec2
+  to: Vec2
+  count?: number
+  height?: number
+  /** Coulomb friction. See the note — this is the parameter that decides it. */
+  friction?: number
+  /** Tip the first one over by this angle to start the wave. */
+  nudge?: number
+}
+
+/**
+ * A domino run that actually propagates.
+ *
+ * Two measured facts shape the defaults:
+ *
+ * - SPACING. Dominoes must be closer together than they are tall or the wave
+ *   dies; the default is 0.55 x height, which propagates reliably and still
+ *   looks like a domino run rather than a wall.
+ * - FRICTION. Swept on Rapier, dominoes fallen out of 300 in 15 s:
+ *     0.10 -> 289    0.20 -> 258    0.45 -> 195    0.70 -> 158
+ *   A smooth, monotone degradation. (Matter.js on the identical scene: 73, 70,
+ *   0, 0 — it wedges and stops dead above ~0.3, which is why the kit is not
+ *   built on it.) 0.3 is the default: fast wave, still looks weighty.
+ *
+ * The nudge is GEOMETRIC, not an impulse. An impulse applied "on the first
+ * frame" is a hidden input that a replay has to reproduce; a tilted starting
+ * pose is part of the scene and replays for free.
+ */
+export function dominoes(w: World, o: DominoOpts): BodyHandle[] {
+  const count = o.count ?? 30
+  const height = o.height ?? 1
+  const halfH = height / 2
+  const halfW = height * 0.05
+  const [x0, y0] = o.from
+  const [x1, y1] = o.to
+  const out: BodyHandle[] = []
+  for (let i = 0; i < count; i++) {
+    const t = count === 1 ? 0 : i / (count - 1)
+    out.push(
+      w.add("dynamic", { box: [halfW, halfH] }, [x0 + (x1 - x0) * t, y0 + (y1 - y0) * t + halfH], {
+        density: 1.2,
+        friction: o.friction ?? 0.3,
+        tag: "domino",
+      }),
+    )
+  }
+  const nudge = o.nudge ?? -0.22
+  if (out[0]) out[0].rb.setRotation(nudge, true)
+  return out
+}
+
+/** Fraction of a domino run that has fallen. For a win condition. */
+export function fallenFraction(run: BodyHandle[]): number {
+  if (run.length === 0) return 0
+  let n = 0
+  for (const d of run) if (Math.abs(d.angle()) > 0.7) n++
+  return n / run.length
+}

--- a/dynawalla/foundations/physics/src/recipes/soft.ts
+++ b/dynawalla/foundations/physics/src/recipes/soft.ts
@@ -1,0 +1,168 @@
+// Soft bodies and liquid — both approximations, both honest about it.
+//
+// Rapier has no soft-body or fluid solver in its JS build. (Its Rust crate has
+// no FEM either; the ecosystem answer is `salva` for fluids, which is not
+// compiled into the WASM package and would double the binary.) So this file is
+// the two approximations that are worth shipping, sized by the tier's particle
+// budget rather than by hope.
+
+import RAPIER from "@dimforge/rapier2d-compat"
+import type { World, Vec2, BodyHandle } from "../world.ts"
+
+export interface SoftBlobOpts {
+  at: Vec2
+  radius?: number
+  /** Ring particles. Clamped to the tier's particle budget. */
+  segments?: number
+  /** 0 = jelly, 1 = beach ball. */
+  firmness?: number
+}
+
+export interface SoftBlob {
+  readonly ring: BodyHandle[]
+  readonly core: BodyHandle
+  /** Outline in world space, ready to feed a triangle fan or a spline. */
+  outline(into?: Float32Array): Float32Array
+  /** 1.0 = undeformed. Below ~0.6 it reads as "squashed". */
+  roundness(): number
+}
+
+/**
+ * Pressurised-ring soft body: a circle of small discs held by springs to their
+ * neighbours and to a core, which is the standard 2D game approach and the only
+ * one that stays stable at 60 Hz with this few constraints.
+ *
+ * The core spring is what stops it collapsing. A ring held only by neighbour
+ * springs has no resistance to inversion at all — push it hard once and it
+ * turns inside out and never comes back, which looks like a bug and is not
+ * recoverable. The core costs one extra spring per segment.
+ */
+export function softBlob(w: World, o: SoftBlobOpts): SoftBlob {
+  const radius = o.radius ?? 0.8
+  const segments = Math.min(o.segments ?? 16, Math.max(8, Math.floor(w.tier.particles / 8)))
+  const firmness = o.firmness ?? 0.5
+  const asm = w.newAssembly()
+  const [cx, cy] = o.at
+
+  const core = w.add("dynamic", { circle: radius * 0.25 }, [cx, cy], {
+    assembly: asm,
+    density: 0.4,
+  })
+  const ring: BodyHandle[] = []
+  const pr = radius * 0.22
+  for (let i = 0; i < segments; i++) {
+    const a = (i / segments) * Math.PI * 2
+    ring.push(
+      w.add("dynamic", { circle: pr }, [cx + Math.cos(a) * radius, cy + Math.sin(a) * radius], {
+        assembly: asm,
+        density: 1,
+        friction: 0.6,
+      }),
+    )
+  }
+
+  // Spring stiffness is per-unit-mass in Rapier; scale with firmness so the
+  // dial reads the same whatever the blob's size.
+  const stiff = 60 + firmness * 340
+  const damp = 3 + firmness * 9
+  const spring = (a: BodyHandle, b: BodyHandle, rest: number) => {
+    w.rapier.createImpulseJoint(
+      RAPIER.JointData.spring(rest, stiff, damp, { x: 0, y: 0 }, { x: 0, y: 0 }),
+      a.rb,
+      b.rb,
+      true,
+    )
+  }
+  const chord = 2 * radius * Math.sin(Math.PI / segments)
+  for (let i = 0; i < segments; i++) {
+    spring(ring[i]!, ring[(i + 1) % segments]!, chord)
+    spring(ring[i]!, core, radius)
+    // A second, longer chord across two neighbours resists shear. Without it
+    // the ring shears into an ellipse under its own weight and stays there.
+    spring(ring[i]!, ring[(i + 2) % segments]!, 2 * radius * Math.sin((2 * Math.PI) / segments))
+  }
+
+  return {
+    ring,
+    core,
+    outline(into) {
+      const out = into && into.length >= segments * 2 ? into : new Float32Array(segments * 2)
+      for (let i = 0; i < segments; i++) {
+        const p = ring[i]!.position()
+        out[i * 2] = p[0]
+        out[i * 2 + 1] = p[1]
+      }
+      return out
+    },
+    roundness() {
+      const c = core.position()
+      let min = Infinity
+      let max = 0
+      for (const r of ring) {
+        const p = r.position()
+        const d = Math.hypot(p[0] - c[0], p[1] - c[1])
+        if (d < min) min = d
+        if (d > max) max = d
+      }
+      return max === 0 ? 1 : min / max
+    },
+  }
+}
+
+export interface LiquidOpts {
+  at: Vec2
+  count?: number
+  /** Radius of one droplet. Smaller looks wetter and costs more. */
+  drop?: number
+  /** Spread of the initial column, in metres. */
+  width?: number
+}
+
+/**
+ * Particle liquid: many small, slippery, non-bouncy discs.
+ *
+ * This is NOT SPH. There is no pressure term, no surface tension and no
+ * incompressibility, so it will not fill a vessel to a flat level on its own —
+ * it settles into a granular pile with a shallow angle of repose. For a
+ * children's maths game that is usually the right trade: it POURS convincingly,
+ * it splits between two vessels convincingly, and it costs a fraction of a real
+ * fluid solver. If a game needs a true flat surface, draw the surface from the
+ * particle count and use the particles only for the pour.
+ *
+ * The parameters below are the ones that make it read as liquid rather than as
+ * gravel: near-zero friction, zero restitution, and a little linear damping so
+ * the pile settles instead of shimmering forever.
+ */
+export function liquid(w: World, o: LiquidOpts): BodyHandle[] {
+  const count = Math.min(o.count ?? 200, w.tier.particles)
+  const drop = o.drop ?? 0.09
+  const width = o.width ?? 1.2
+  const perRow = Math.max(1, Math.floor(width / (drop * 2.1)))
+  const out: BodyHandle[] = []
+  for (let i = 0; i < count; i++) {
+    const col = i % perRow
+    const row = Math.floor(i / perRow)
+    const b = w.add(
+      "dynamic",
+      { circle: drop },
+      [
+        o.at[0] - width / 2 + col * drop * 2.1 + w.rng.spread(drop * 0.15),
+        o.at[1] + row * drop * 2.1,
+      ],
+      { density: 1, friction: 0.02, restitution: 0, tag: "drop" },
+    )
+    b.rb.setLinearDamping(0.4)
+    out.push(b)
+  }
+  return out
+}
+
+/** How much of `drops` is currently inside an axis-aligned vessel. Exact count. */
+export function volumeIn(drops: BodyHandle[], min: Vec2, max: Vec2): number {
+  let n = 0
+  for (const d of drops) {
+    const [x, y] = d.position()
+    if (x >= min[0] && x <= max[0] && y >= min[1] && y <= max[1]) n++
+  }
+  return n
+}

--- a/dynawalla/foundations/physics/src/replay.ts
+++ b/dynawalla/foundations/physics/src/replay.ts
@@ -1,0 +1,126 @@
+// Replay: record what the player did, not what the physics produced.
+//
+// This is the part of determinism that actually matters for a maths product.
+// "Rapier is deterministic" is a claim about one binary on one machine; it is
+// NOT a promise that a Galaxy Tab and an iPad will produce identical floats,
+// and treating it as one is how a product ends up with replays that desync.
+//
+// What is safe to rely on, and what this module is built on:
+//
+//   SAME BUILD + SAME PLATFORM + SAME INPUTS + SAME ORDER => same result.
+//
+// Measured, in this repo: 20 engine x scene cells run three times each in one
+// V8 process are bit-identical every time (`bench/run-node.mjs --repeat 3`), and
+// the same scenes are bit-identical between Node/V8 and Chrome/V8. Rapier also
+// publishes `@dimforge/rapier2d-deterministic`, whose only difference is that
+// its transcendental functions come from a portable libm instead of the
+// platform's, which is what makes CROSS-platform determinism possible at all.
+//
+// What a tape stores is therefore COMMANDS, never positions. A tape is tiny, it
+// survives an engine upgrade with a version bump rather than a corruption, and
+// replaying it re-derives the physics rather than trusting a recorded float.
+//
+// The one hard rule: every command must be addressed by STEP INDEX, never by
+// wall-clock time. Wall clock is exactly the non-determinism we removed by
+// fixing the timestep.
+
+import type { World } from "./world.ts"
+
+export interface Command {
+  /** The fixed step this command takes effect on. */
+  step: number
+  op: string
+  args: readonly (number | string | boolean)[]
+}
+
+export interface Tape {
+  version: 1
+  seed: number
+  /** The engine build this was recorded against. A mismatch is a warning. */
+  engine: string
+  commands: Command[]
+  /** Quantised state hash at `steps`, so a replay can assert it landed. */
+  finalHash?: string
+  steps: number
+}
+
+export type CommandHandler = (w: World, args: Command["args"]) => void
+
+const handlers = new Map<string, CommandHandler>()
+
+/** Register a replayable command. The op name is part of the tape format. */
+export function defineCommand(op: string, fn: CommandHandler): void {
+  handlers.set(op, fn)
+}
+
+export class Recorder {
+  private commands: Command[] = []
+  private startStep: number
+  private w: World
+
+  // Not a `private w: World` parameter property: Node's `--experimental-strip-types`
+  // is strip-ONLY, so any TypeScript syntax that has to EMIT code — parameter
+  // properties, enums, namespaces, decorators — is a hard error at load. The
+  // whole repo runs tests that way, so the constraint applies to every file
+  // here, not just this one.
+  constructor(w: World) {
+    this.w = w
+    this.startStep = w.stepIndex
+  }
+
+  /**
+   * Record a command AND apply it. Recording and applying must be the same call
+   * — a codebase where they are two calls is a codebase where one of them gets
+   * forgotten, and the tape silently diverges from the session it claims to be.
+   */
+  do(op: string, ...args: Command["args"]): void {
+    const fn = handlers.get(op)
+    if (!fn) throw new Error(`replay: unknown command "${op}" — call defineCommand first`)
+    this.commands.push({ step: this.w.stepIndex - this.startStep, op, args })
+    fn(this.w, args)
+  }
+
+  stop(): Tape {
+    return {
+      version: 1,
+      seed: this.w.rng.seed,
+      engine: ENGINE_ID,
+      commands: this.commands,
+      steps: this.w.stepIndex - this.startStep,
+      finalHash: this.w.hash(),
+    }
+  }
+}
+
+export const ENGINE_ID = "rapier2d-compat@0.19.3"
+
+/**
+ * Replay a tape into a fresh world. The world must have been built with the
+ * tape's seed and the same scene construction; `createWorld({ seed: tape.seed })`
+ * plus the same recipe calls is the contract.
+ */
+export function replay<W extends World>(w: W, tape: Tape): W {
+  if (tape.engine !== ENGINE_ID) {
+    // Not fatal. A tape from another build is still worth replaying — it just
+    // cannot be asserted bit-for-bit, so the caller is told rather than blocked.
+    console.warn(`replay: tape recorded against ${tape.engine}, replaying on ${ENGINE_ID}`)
+  }
+  const byStep = new Map<number, Command[]>()
+  for (const c of tape.commands) {
+    const list = byStep.get(c.step) ?? []
+    list.push(c)
+    byStep.set(c.step, list)
+  }
+  for (let s = 0; s <= tape.steps; s++) {
+    for (const c of byStep.get(s) ?? []) {
+      handlers.get(c.op)?.(w, c.args)
+    }
+    if (s < tape.steps) w.stepExact(1)
+  }
+  return w
+}
+
+/** True if a replay landed where the tape says it should have. */
+export function verify(w: World, tape: Tape): boolean {
+  return tape.finalHash === undefined || w.hash() === tape.finalHash
+}

--- a/dynawalla/foundations/physics/src/rng.ts
+++ b/dynawalla/foundations/physics/src/rng.ts
@@ -1,0 +1,67 @@
+// Seeded PRNG for the physics kit.
+//
+// Nothing in a Dynawalla prototype may call `Math.random()`. A physics scene
+// that is not reproducible cannot be replayed, cannot be bisected when a child
+// reports "the lamp fell through the floor", and cannot be regression-tested.
+// The whole determinism story rests on this file being the only source of
+// randomness in the kit.
+//
+// sfc32 — small, fast, passes PractRand, and (unlike xorshift32) has no weak
+// seeds that collapse to short cycles.
+
+export interface Rng {
+  /** Uniform in [0, 1). */
+  (): number
+  /** Uniform in [min, max). */
+  range(min: number, max: number): number
+  /** Integer in [0, n). */
+  int(n: number): number
+  /** Uniform in [-spread, +spread) — the one every "jitter" call actually wants. */
+  spread(spread: number): number
+  pick<T>(items: readonly T[]): T
+  /** The seed this stream was created from, so a replay can restate it. */
+  readonly seed: number
+}
+
+export function makeRng(seed: number): Rng {
+  // Expand one 32-bit seed into sfc32's four words with a splitmix-ish walk, so
+  // that seeds 1, 2 and 3 produce genuinely unrelated streams. Seeding all four
+  // words with the same value is the classic mistake and gives correlated runs.
+  let z = seed >>> 0
+  const next32 = () => {
+    z = (z + 0x9e3779b9) >>> 0
+    let t = z
+    t = Math.imul(t ^ (t >>> 16), 0x21f0aaad) >>> 0
+    t = Math.imul(t ^ (t >>> 15), 0x735a2d97) >>> 0
+    return (t ^ (t >>> 15)) >>> 0
+  }
+  let a = next32()
+  let b = next32()
+  let c = next32()
+  let d = next32()
+
+  const f = (() => {
+    let t = 0
+    return () => {
+      a >>>= 0
+      b >>>= 0
+      c >>>= 0
+      d >>>= 0
+      t = (a + b) | 0
+      a = b ^ (b >>> 9)
+      b = (c + (c << 3)) | 0
+      c = (c << 21) | (c >>> 11)
+      d = (d + 1) | 0
+      t = (t + d) | 0
+      c = (c + t) | 0
+      return (t >>> 0) / 4294967296
+    }
+  })() as Rng
+
+  f.range = (min: number, max: number) => min + f() * (max - min)
+  f.int = (n: number) => Math.floor(f() * n)
+  f.spread = (s: number) => (f() * 2 - 1) * s
+  f.pick = <T,>(items: readonly T[]): T => items[Math.floor(f() * items.length)]!
+  Object.defineProperty(f, "seed", { value: seed >>> 0, enumerable: true })
+  return f
+}

--- a/dynawalla/foundations/physics/src/tiers.ts
+++ b/dynawalla/foundations/physics/src/tiers.ts
@@ -1,0 +1,100 @@
+// Quality tiers.
+//
+// The rule this program was given is "the mid-range tablet sets the FLOOR, never
+// the ceiling". So the tier table is not a set of downgrades from a desktop
+// target — `mid` is the tier every budget in the README is measured against,
+// and `ultra` is what a capable device is allowed to spend on top.
+//
+// Only three things actually cost frame time in a 2D rigid-body scene, and they
+// are the three knobs here:
+//
+//   bodies            how much stuff can be awake at once
+//   solverIterations  joint and stacking fidelity (see the rope probe: 4 -> 16
+//                     cuts chain stretch from 18% to 7% for 3.4x the solve)
+//   particles         the liquid/soft-body approximation's resolution
+//
+// Everything else that looks like a physics cost (shadows, bloom, trail meshes)
+// belongs to the renderer's budget, not this one.
+
+export type TierName = "low" | "mid" | "high" | "ultra"
+
+export interface Tier {
+  name: TierName
+  /** Awake dynamic bodies this tier will simulate before culling kicks in. */
+  bodies: number
+  /** Rapier `numSolverIterations`. */
+  solverIterations: number
+  /** Particle count ceiling for `liquid()` and `softBlob()`. */
+  particles: number
+  /** Steps in a predicted trajectory. 90 = 1.5 s of flight at 60 Hz. */
+  predictSteps: number
+  /**
+   * Max physics steps allowed to catch up in one frame. Above this the world
+   * drops time rather than spiralling: a WebView that was backgrounded for
+   * 10 s must not try to simulate 600 steps in one frame and hang the app.
+   */
+  maxCatchUpSteps: number
+}
+
+export const TIERS: Record<TierName, Tier> = {
+  // A 2019 budget phone or a throttled tablet. Still has to look good.
+  low: { name: "low", bodies: 120, solverIterations: 4, particles: 90, predictSteps: 60, maxCatchUpSteps: 3 },
+  // THE FLOOR: Galaxy Tab A9 class. Every budget in the README is this row.
+  mid: { name: "mid", bodies: 260, solverIterations: 4, particles: 200, predictSteps: 90, maxCatchUpSteps: 4 },
+  high: { name: "high", bodies: 500, solverIterations: 8, particles: 400, predictSteps: 120, maxCatchUpSteps: 5 },
+  // Take the cap off. An iPad Pro or a desktop should look staggering.
+  ultra: { name: "ultra", bodies: 900, solverIterations: 12, particles: 800, predictSteps: 180, maxCatchUpSteps: 6 },
+}
+
+export interface DeviceHints {
+  deviceMemoryGb?: number | undefined
+  hardwareConcurrency?: number | undefined
+  /** devicePixelRatio * min(screen dimension), a decent proxy for GPU class. */
+  screenPx?: number | undefined
+}
+
+/**
+ * Pick a tier from what the browser will actually tell us.
+ *
+ * Deliberately conservative and deliberately NOT a UA sniff. `deviceMemory` is
+ * absent on iOS entirely (Safari has never shipped it), so an iPad reports
+ * nothing and would land on `low` if memory were required — hence the
+ * concurrency fallback. This is a starting guess: `world.setTier()` exists
+ * because the honest way to choose a tier is to measure the first two seconds
+ * of real frames, which `autoTune` below does.
+ */
+export function guessTier(hints: DeviceHints = {}): TierName {
+  const mem = hints.deviceMemoryGb
+  const cores = hints.hardwareConcurrency ?? 4
+  if (mem !== undefined) {
+    if (mem <= 2) return "low"
+    if (mem <= 4) return "mid"
+    if (mem <= 8) return cores >= 8 ? "high" : "mid"
+    return "ultra"
+  }
+  // No deviceMemory: iOS, or a locked-down WebView.
+  if (cores <= 2) return "low"
+  if (cores <= 4) return "mid"
+  if (cores <= 6) return "high"
+  return "ultra"
+}
+
+/**
+ * Move one tier at a time based on measured step cost against the frame budget.
+ *
+ * `budgetMs` is the share of the frame physics is allowed — 4 ms of a 16.67 ms
+ * frame by default, which leaves the renderer 12. Hysteresis is asymmetric on
+ * purpose: drop fast (a child is already seeing jank) and climb slowly (a
+ * momentary lull is not evidence the device can sustain more).
+ */
+export function autoTune(
+  current: TierName,
+  p99StepMs: number,
+  budgetMs = 4,
+): TierName {
+  const order: TierName[] = ["low", "mid", "high", "ultra"]
+  const i = order.indexOf(current)
+  if (p99StepMs > budgetMs && i > 0) return order[i - 1]!
+  if (p99StepMs < budgetMs * 0.4 && i < order.length - 1) return order[i + 1]!
+  return current
+}

--- a/dynawalla/foundations/physics/src/view/three.ts
+++ b/dynawalla/foundations/physics/src/view/three.ts
@@ -1,0 +1,245 @@
+// Three.js binding: 2D physics, 3D presentation.
+//
+// The solver runs in 2D because a marketplace of maths games is a side-on
+// world and 2D is 5-10x cheaper per body — but nothing about that forces flat
+// PRESENTATION. Bodies are extruded in Z, lit by a real key light, and shot
+// with a perspective camera on a slight tilt. That is where the production
+// value comes from, and it costs the physics budget exactly nothing.
+//
+// The whole binding is instanced. One InstancedMesh per shape class, one
+// `setMatrixAt` per body per frame, one draw call each. The alternative — a
+// Mesh per body — is what makes a physics demo drop to 30 fps at 300 bodies on
+// a tablet, and it is drawn from the same `transforms` Float32Array the world
+// already fills, so there is no intermediate object per body anywhere.
+
+import * as THREE from "three"
+import type { World } from "../world.ts"
+
+export interface InstancedLayerOpts {
+  /** How many instances to reserve. Growing an InstancedMesh means rebuilding it. */
+  capacity: number
+  geometry: THREE.BufferGeometry
+  material: THREE.Material
+  /** Extrusion depth. */
+  depth?: number
+}
+
+/**
+ * A pool of identical instanced bodies bound to physics indices.
+ *
+ * `sync` is deliberately index-based rather than handle-based: the world's
+ * `transforms` array is already in body order, so a layer that owns a
+ * contiguous slice of it can copy straight across with no lookup at all.
+ */
+export class InstancedLayer {
+  readonly mesh: THREE.InstancedMesh
+  private indices: number[] = []
+  private m = new THREE.Matrix4()
+  private q = new THREE.Quaternion()
+  private v = new THREE.Vector3()
+  private s = new THREE.Vector3(1, 1, 1)
+  private axis = new THREE.Vector3(0, 0, 1)
+
+  constructor(o: InstancedLayerOpts) {
+    this.mesh = new THREE.InstancedMesh(o.geometry, o.material, o.capacity)
+    this.mesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage)
+    this.mesh.castShadow = true
+    this.mesh.receiveShadow = true
+    this.mesh.count = 0
+    // A physics world has no idea where its bodies will fly, and a wrong
+    // bounding sphere makes instances vanish at the screen edge — the single
+    // most common instancing bug. Disabling culling for the layer is correct
+    // here: it is one draw call either way.
+    this.mesh.frustumCulled = false
+  }
+
+  /** Bind a physics body index to the next free instance. */
+  track(bodyIndex: number, scale?: THREE.Vector3): number {
+    this.indices.push(bodyIndex)
+    const slot = this.indices.length - 1
+    if (scale) this.mesh.setColorAt?.(slot, new THREE.Color(1, 1, 1))
+    this.scales.push(scale ? scale.clone() : new THREE.Vector3(1, 1, 1))
+    this.mesh.count = this.indices.length
+    return slot
+  }
+
+  private scales: THREE.Vector3[] = []
+  private offsets: Float32Array = new Float32Array(0)
+
+  /**
+   * Offset one instance from its body's origin, in WORLD axes.
+   *
+   * A compound collider is one body with several shapes, but the renderer gets
+   * a single transform for it — so sub-shapes have to be re-placed here. The
+   * caller supplies an already-rotated offset because only the caller knows
+   * whether the offset is meant to ride the body's rotation (a pan lip) or not
+   * (a screen-space label).
+   */
+  setOffset(slot: number, dx: number, dy: number) {
+    if (this.offsets.length < this.indices.length * 2) {
+      const n = new Float32Array(Math.max(this.indices.length * 2, 8))
+      n.set(this.offsets)
+      this.offsets = n
+    }
+    this.offsets[slot * 2] = dx
+    this.offsets[slot * 2 + 1] = dy
+  }
+
+  setColor(slot: number, color: THREE.Color) {
+    this.mesh.setColorAt(slot, color)
+    if (this.mesh.instanceColor) this.mesh.instanceColor.needsUpdate = true
+  }
+
+  /** Copy this frame's interpolated transforms in. One pass, no allocation. */
+  sync(world: World, z = 0) {
+    const t = world.transforms
+    for (let i = 0; i < this.indices.length; i++) {
+      const b = this.indices[i]! * 4
+      const cos = t[b + 2]!
+      const sin = t[b + 3]!
+      const ox = this.offsets.length > i * 2 ? this.offsets[i * 2]! : 0
+      const oy = this.offsets.length > i * 2 ? this.offsets[i * 2 + 1]! : 0
+      this.v.set(t[b]! + ox, t[b + 1]! + oy, z)
+      // cos/sin straight to a quaternion about Z: half-angle from the double
+      // angle, no atan2 in the hot loop.
+      const c2 = Math.sqrt(Math.max(0, (1 + cos) * 0.5))
+      const s2 = sin >= 0 ? Math.sqrt(Math.max(0, (1 - cos) * 0.5)) : -Math.sqrt(Math.max(0, (1 - cos) * 0.5))
+      this.q.set(0, 0, s2, c2)
+      this.s.copy(this.scales[i]!)
+      this.m.compose(this.v, this.q, this.s)
+      this.mesh.setMatrixAt(i, this.m)
+    }
+    this.mesh.instanceMatrix.needsUpdate = true
+    void this.axis
+  }
+}
+
+/**
+ * The look. One place, so every prototype in the Bazaar inherits the same
+ * lighting and nobody ships a scene lit with the Three.js defaults.
+ *
+ * Warm key from high left, cool rim from behind right, and a dim warm ambient
+ * so shadowed faces read as brass rather than as black. Shadow map is 1024 and
+ * tightly bounded — a default 512 shadow over a 40 m world is a staircase, and
+ * a 2048 map is a real cost on a tablet for a difference nobody sees.
+ */
+export function bazaarLighting(scene: THREE.Scene, span = 22) {
+  const key = new THREE.DirectionalLight(0xffd9a0, 3.4)
+  key.position.set(-9, 16, 12)
+  key.castShadow = true
+  key.shadow.mapSize.set(1024, 1024)
+  const c = key.shadow.camera as THREE.OrthographicCamera
+  c.left = -span
+  c.right = span
+  c.top = span
+  c.bottom = -span * 0.35
+  c.near = 1
+  c.far = 70
+  // Without a bias, self-shadowing on the flat faces of extruded boxes shows
+  // up as moire banding that looks like a texture bug.
+  key.shadow.bias = -0.0015
+  key.shadow.normalBias = 0.03
+  scene.add(key)
+
+  // Cool rim from behind: this is what separates a silhouette from the
+  // backdrop and is most of the reason the scene reads as three-dimensional.
+  const rim = new THREE.DirectionalLight(0x7fd4ff, 2.2)
+  rim.position.set(11, 6, -10)
+  scene.add(rim)
+
+  // Warm bounce from below-front, standing in for light off the bazaar floor.
+  const bounce = new THREE.DirectionalLight(0xff9a5c, 0.9)
+  bounce.position.set(4, -6, 9)
+  scene.add(bounce)
+
+  scene.add(new THREE.HemisphereLight(0xffc98a, 0x2a1630, 1.1))
+  return { key, rim, bounce }
+}
+
+/**
+ * A gradient sky on a big inverted sphere, shaded in three lines of GLSL.
+ *
+ * A flat `setClearColor` is the single loudest tell that a WebGL scene is a
+ * tech demo: real places have a horizon. This costs one draw call, no texture,
+ * and no postprocessing pass — which matters because postprocessing is where
+ * a tablet's fill rate actually dies.
+ */
+export function bazaarSky(scene: THREE.Scene) {
+  const mat = new THREE.ShaderMaterial({
+    side: THREE.BackSide,
+    depthWrite: false,
+    uniforms: {
+      top: { value: new THREE.Color(0x0d0713) },
+      mid: { value: new THREE.Color(0x281030) },
+      low: { value: new THREE.Color(0x5c2620) },
+    },
+    vertexShader: `varying vec3 vp;
+      void main(){ vp = position; gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0); }`,
+    fragmentShader: `varying vec3 vp; uniform vec3 top; uniform vec3 mid; uniform vec3 low;
+      void main(){
+        float h = clamp(vp.y / 60.0 + 0.28, 0.0, 1.0);
+        vec3 c = mix(low, mid, smoothstep(0.0, 0.42, h));
+        c = mix(c, top, smoothstep(0.38, 1.0, h));
+        gl_FragColor = vec4(c, 1.0);
+      }`,
+  })
+  const sky = new THREE.Mesh(new THREE.SphereGeometry(90, 24, 16), mat)
+  sky.frustumCulled = false
+  scene.add(sky)
+  return sky
+}
+
+/**
+ * Fit a world-space rectangle to the viewport, whatever the aspect ratio.
+ *
+ * Hand-picked camera positions are how a demo ends up beautiful on the
+ * developer's monitor and cropped in half on a tablet in portrait. Given the
+ * box a scene must show, this solves for the distance that shows ALL of it on
+ * BOTH axes and adds a margin — so a phone pulls back rather than cropping.
+ */
+export function frameCamera(
+  camera: THREE.PerspectiveCamera,
+  box: { cx: number; cy: number; halfW: number; halfH: number },
+  aspect: number,
+  margin = 1.12,
+) {
+  const vFov = (camera.fov * Math.PI) / 180
+  const distForH = (box.halfH * margin) / Math.tan(vFov / 2)
+  const hFov = 2 * Math.atan(Math.tan(vFov / 2) * aspect)
+  const distForW = (box.halfW * margin) / Math.tan(hFov / 2)
+  const dist = Math.max(distForH, distForW)
+  camera.position.set(box.cx, box.cy + box.halfH * 0.12, dist)
+  camera.lookAt(box.cx, box.cy, 0)
+  camera.updateProjectionMatrix()
+  return dist
+}
+
+export const PALETTE = {
+  night: 0x140d18,
+  brass: 0xd9a441,
+  copper: 0xc4693a,
+  jade: 0x3fb59a,
+  rose: 0xe0567a,
+  bone: 0xefe3cf,
+  ink: 0x2a1b2e,
+} as const
+
+export function standard(color: number, opts: Partial<THREE.MeshStandardMaterialParameters> = {}) {
+  return new THREE.MeshStandardMaterial({
+    color,
+    roughness: 0.42,
+    metalness: 0.55,
+    ...opts,
+  })
+}
+
+/** Self-lit accent material — lamps, hot dominoes, the aiming arc. */
+export function glow(color: number, strength = 1.6) {
+  return new THREE.MeshStandardMaterial({
+    color,
+    emissive: new THREE.Color(color),
+    emissiveIntensity: strength,
+    roughness: 0.35,
+    metalness: 0.1,
+  })
+}

--- a/dynawalla/foundations/physics/src/view/three.ts
+++ b/dynawalla/foundations/physics/src/view/three.ts
@@ -13,6 +13,7 @@
 // already fills, so there is no intermediate object per body anywhere.
 
 import * as THREE from "three"
+import { RoomEnvironment } from "three/examples/jsm/environments/RoomEnvironment.js"
 import type { World } from "../world.ts"
 
 export interface InstancedLayerOpts {
@@ -164,6 +165,25 @@ export function bazaarLighting(scene: THREE.Scene, span = 22) {
  * and no postprocessing pass — which matters because postprocessing is where
  * a tablet's fill rate actually dies.
  */
+export function bazaarEnvironment(renderer: THREE.WebGLRenderer, scene: THREE.Scene) {
+  // THE metal trap. A MeshStandardMaterial with `metalness` near 1 has NO
+  // diffuse term — a metal's colour comes entirely from what it reflects. With
+  // no environment to reflect it renders almost black, so brass gear teeth and
+  // a copper pan read as charcoal no matter how many lights you add. Adding
+  // lights does not fix it; only an environment does.
+  //
+  // `RoomEnvironment` is generated procedurally (no texture to ship, nothing to
+  // fetch, CSP-safe) and pre-filtered once at startup into a small cubemap.
+  // Generate it ONCE and dispose the generator: PMREM is genuinely expensive
+  // and doing it per scene-change is a visible hitch.
+  const pmrem = new THREE.PMREMGenerator(renderer)
+  const env = pmrem.fromScene(new RoomEnvironment(), 0.04).texture
+  scene.environment = env
+  scene.environmentIntensity = 0.55
+  pmrem.dispose()
+  return env
+}
+
 export function bazaarSky(scene: THREE.Scene) {
   const mat = new THREE.ShaderMaterial({
     side: THREE.BackSide,
@@ -242,4 +262,88 @@ export function glow(color: number, strength = 1.6) {
     roughness: 0.35,
     metalness: 0.1,
   })
+}
+
+/**
+ * A filled, extruded mesh driven by a soft body's outline.
+ *
+ * Drawing only the ring particles makes a pressurised-ring soft body read as a
+ * DONUT — the hole is the thing the ring is holding open. This builds a
+ * triangle fan from the centroid out to the ring and rewrites its positions in
+ * place each frame, so the blob reads as a single squashy mass.
+ *
+ * Geometry is allocated once. Rebuilding a BufferGeometry per frame is the
+ * classic way to turn a 60 fps scene into a GC sawtooth.
+ */
+export class SoftMesh {
+  readonly mesh: THREE.Mesh
+  private n: number
+  private pos: Float32Array
+  private buf: Float32Array
+
+  constructor(segments: number, material: THREE.Material, depth = 0.5) {
+    this.n = segments
+    // centre + ring, front and back caps, plus a side wall quad per segment.
+    const verts = (segments + 1) * 2 + segments * 4
+    this.pos = new Float32Array(verts * 3)
+    this.buf = new Float32Array(segments * 2)
+    const geo = new THREE.BufferGeometry()
+    geo.setAttribute("position", new THREE.BufferAttribute(this.pos, 3))
+    const idx: number[] = []
+    const front = 0
+    const back = segments + 1
+    for (let i = 0; i < segments; i++) {
+      const j = (i + 1) % segments
+      idx.push(front, front + 1 + i, front + 1 + j)
+      idx.push(back, back + 1 + j, back + 1 + i)
+      const w = (segments + 1) * 2 + i * 4
+      idx.push(w, w + 1, w + 2, w + 2, w + 1, w + 3)
+    }
+    geo.setIndex(idx)
+    this.mesh = new THREE.Mesh(geo, material)
+    this.mesh.castShadow = true
+    this.mesh.frustumCulled = false
+    this.depth = depth
+  }
+
+  private depth: number
+
+  update(outline: Float32Array) {
+    const n = this.n
+    const p = this.pos
+    let cx = 0
+    let cy = 0
+    for (let i = 0; i < n; i++) {
+      cx += outline[i * 2]!
+      cy += outline[i * 2 + 1]!
+    }
+    cx /= n
+    cy /= n
+    const z = this.depth / 2
+    const set = (v: number, x: number, y: number, zz: number) => {
+      p[v * 3] = x
+      p[v * 3 + 1] = y
+      p[v * 3 + 2] = zz
+    }
+    set(0, cx, cy, z)
+    set(n + 1, cx, cy, -z)
+    for (let i = 0; i < n; i++) {
+      const x = outline[i * 2]!
+      const y = outline[i * 2 + 1]!
+      set(1 + i, x, y, z)
+      set(n + 2 + i, x, y, -z)
+    }
+    for (let i = 0; i < n; i++) {
+      const j = (i + 1) % n
+      const w = (n + 1) * 2 + i * 4
+      set(w, outline[i * 2]!, outline[i * 2 + 1]!, z)
+      set(w + 1, outline[i * 2]!, outline[i * 2 + 1]!, -z)
+      set(w + 2, outline[j * 2]!, outline[j * 2 + 1]!, z)
+      set(w + 3, outline[j * 2]!, outline[j * 2 + 1]!, -z)
+    }
+    const attr = this.mesh.geometry.getAttribute("position") as THREE.BufferAttribute
+    attr.needsUpdate = true
+    this.mesh.geometry.computeVertexNormals()
+    void this.buf
+  }
 }

--- a/dynawalla/foundations/physics/src/world.ts
+++ b/dynawalla/foundations/physics/src/world.ts
@@ -1,0 +1,384 @@
+// The physics world: the one object a prototype author touches.
+//
+// Everything in here exists because the bake-off or a probe proved it was
+// needed. The measurements are in ../README.md; the short version:
+//
+// - Fixed timestep, always. A variable dt makes the same input produce a
+//   different result on a 120 Hz iPad than on a 60 Hz tablet, which kills
+//   replay and makes "the ball goes in the bucket" a device-dependent claim.
+// - Interpolated render transforms, always. A fixed 60 Hz sim rendered raw on a
+//   120 Hz display judders visibly; the fix is one lerp and it is free.
+// - Assembly collision groups by default. Rapier is the only engine of the four
+//   whose joints collide the bodies they connect, and it does not expose
+//   `collideConnected` at all. Measured: a pendulum with a collider on its
+//   anchor does not move — 0.0 deg in 5 s, versus -33.0 deg without. Every
+//   articulated recipe in this kit would be silently frozen without this.
+// - Flat Float32Array readback. A `{x, y}` object per body per frame is 500
+//   allocations a frame at `debris-500`; the GC pause lands on a child's
+//   screen as a stutter.
+
+import RAPIER from "@dimforge/rapier2d-compat"
+import { makeRng, type Rng } from "./rng.ts"
+import { TIERS, guessTier, autoTune, type Tier, type TierName } from "./tiers.ts"
+
+export type Vec2 = readonly [number, number]
+
+/** Fixed simulation rate. Not configurable — see the note above. */
+export const FIXED_DT = 1 / 60
+
+/**
+ * One membership bit per articulated assembly, cleared from its own filter.
+ * 15 assemblies can coexist without colliding internally while still colliding
+ * with the world and with each other. Bit 0 is "the world": everything else.
+ */
+const WORLD_BIT = 0x0001
+const MAX_ASSEMBLIES = 15
+
+export interface BodyOpts {
+  density?: number
+  friction?: number
+  restitution?: number
+  /** Continuous collision. Costs a broadphase pass; use it on fast small things. */
+  bullet?: boolean
+  /** Bodies in the same assembly never collide with each other. */
+  assembly?: number
+  /** Tag readable back from a raycast or a contact. */
+  tag?: string
+}
+
+/**
+ * A collider. `at` offsets it within the body, which is how compound bodies are
+ * built — a pan with lips, a bucket, a gear blank with a hub. Compound bodies
+ * matter more than they look: a single concave shape is not expressible, and
+ * faking one with separate jointed bodies is both slower and less stable.
+ */
+export type Shape =
+  | { box: Vec2; at?: Vec2 }
+  | { circle: number; at?: Vec2 }
+  | { capsule: [number, number]; at?: Vec2 }
+
+export interface BodyHandle {
+  readonly index: number
+  readonly rb: RAPIER.RigidBody
+  readonly tag: string | undefined
+  position(): Vec2
+  angle(): number
+  velocity(): Vec2
+  setVelocity(v: Vec2): void
+  applyImpulse(v: Vec2): void
+  /** Nudge toward a pose without teleporting — for "put it back" affordances. */
+  steerTo(p: Vec2, strength?: number): void
+  remove(): void
+}
+
+export interface WorldOpts {
+  seed?: number
+  gravity?: number
+  tier?: TierName | "auto"
+  deviceHints?: Parameters<typeof guessTier>[0]
+}
+
+let rapierReady: Promise<void> | null = null
+/**
+ * Idempotent init. Calling `RAPIER.init()` twice is not an error but it does
+ * re-instantiate the WASM module, and under React StrictMode every mount runs
+ * twice — the same class of bug that spawned two Babylon engines in World
+ * Plaza. One promise, shared, forever.
+ */
+export function initPhysics(): Promise<void> {
+  rapierReady ??= RAPIER.init()
+  return rapierReady
+}
+
+export class World {
+  readonly rapier: RAPIER.World
+  readonly rng: Rng
+  tier: Tier
+
+  /** [x, y, cos, sin] per body — render-ready, interpolated, never reallocated. */
+  transforms: Float32Array
+  /** Live body count; `transforms` beyond `count * 4` is stale. */
+  count = 0
+
+  private bodies: (BodyHandle | null)[] = []
+  private prev: Float32Array
+  private curr: Float32Array
+  private accumulator = 0
+  private assemblyNext = 1
+  private stepCosts: number[] = []
+  private frameCount = 0
+  /** Monotonic step index — the clock a replay is addressed by. */
+  stepIndex = 0
+
+  constructor(opts: WorldOpts = {}) {
+    this.rng = makeRng(opts.seed ?? 1)
+    const tierName = opts.tier === "auto" || opts.tier === undefined
+      ? guessTier(opts.deviceHints)
+      : opts.tier
+    this.tier = TIERS[tierName]
+
+    this.rapier = new RAPIER.World({ x: 0, y: opts.gravity ?? -10 })
+    this.rapier.timestep = FIXED_DT
+    this.rapier.numSolverIterations = this.tier.solverIterations
+
+    const cap = this.tier.bodies + 64
+    this.transforms = new Float32Array(cap * 4)
+    this.prev = new Float32Array(cap * 4)
+    this.curr = new Float32Array(cap * 4)
+  }
+
+  /** A fresh assembly id. Bodies sharing one never collide with each other. */
+  newAssembly(): number {
+    const id = this.assemblyNext
+    this.assemblyNext = (this.assemblyNext % MAX_ASSEMBLIES) + 1
+    return id
+  }
+
+  private groupsFor(assembly: number | undefined): number {
+    if (assembly === undefined) return (WORLD_BIT << 16) | 0xffff
+    const bit = 1 << assembly
+    return (bit << 16) | (0xffff & ~bit)
+  }
+
+  add(kind: "dynamic" | "static" | "kinematic", shape: Shape | Shape[], at: Vec2, o: BodyOpts = {}): BodyHandle {
+    const desc =
+      kind === "static"
+        ? RAPIER.RigidBodyDesc.fixed()
+        : kind === "kinematic"
+          ? RAPIER.RigidBodyDesc.kinematicPositionBased()
+          : RAPIER.RigidBodyDesc.dynamic()
+    desc.setTranslation(at[0], at[1])
+    if (o.bullet) desc.setCcdEnabled(true)
+    const rb = this.rapier.createRigidBody(desc)
+
+    const groups = this.groupsFor(o.assembly)
+    for (const s of Array.isArray(shape) ? shape : [shape]) {
+      const cd = shapeDesc(s)
+      cd.setDensity(o.density ?? 1)
+      cd.setFriction(o.friction ?? 0.5)
+      cd.setRestitution(o.restitution ?? 0)
+      cd.setCollisionGroups(groups)
+      if (s.at) cd.setTranslation(s.at[0], s.at[1])
+      this.rapier.createCollider(cd, rb)
+    }
+
+    const index = this.bodies.length
+    const handle: BodyHandle = {
+      index,
+      rb,
+      tag: o.tag,
+      position: () => {
+        const t = rb.translation()
+        return [t.x, t.y] as Vec2
+      },
+      angle: () => rb.rotation(),
+      velocity: () => {
+        const v = rb.linvel()
+        return [v.x, v.y] as Vec2
+      },
+      setVelocity: (v) => rb.setLinvel({ x: v[0], y: v[1] }, true),
+      applyImpulse: (v) => rb.applyImpulse({ x: v[0], y: v[1] }, true),
+      steerTo: (p, strength = 12) => {
+        const t = rb.translation()
+        const m = rb.mass()
+        rb.applyImpulse(
+          { x: (p[0] - t.x) * strength * m * FIXED_DT, y: (p[1] - t.y) * strength * m * FIXED_DT },
+          true,
+        )
+      },
+      remove: () => {
+        this.bodies[index] = null
+        this.rapier.removeRigidBody(rb)
+      },
+    }
+    this.bodies.push(handle)
+    this.growIfNeeded()
+    return handle
+  }
+
+  private growIfNeeded() {
+    const need = this.bodies.length * 4
+    if (need <= this.transforms.length) return
+    const cap = Math.max(need, this.transforms.length * 2)
+    const grow = (a: Float32Array) => {
+      const n = new Float32Array(cap)
+      n.set(a)
+      return n
+    }
+    this.transforms = grow(this.transforms)
+    this.prev = grow(this.prev)
+    this.curr = grow(this.curr)
+  }
+
+  /**
+   * Advance by real elapsed time. Call it with the raw rAF delta; the fixed
+   * step and the leftover-time interpolation are handled here.
+   *
+   * The clamp is not a nicety. A WebView that was backgrounded — an iOS app
+   * switch, an Android doze, a Tauri window minimise — resumes with a delta of
+   * whole seconds. Without the clamp the world tries to simulate every missed
+   * step in one frame, which on a tablet is a multi-second freeze that looks
+   * exactly like a crash. We drop the time instead; a child who came back to
+   * the app would rather the lamp be where they left it than watch it
+   * fast-forward.
+   */
+  advance(dtSeconds: number): number {
+    this.accumulator += Math.min(dtSeconds, this.tier.maxCatchUpSteps * FIXED_DT)
+    let steps = 0
+    while (this.accumulator >= FIXED_DT && steps < this.tier.maxCatchUpSteps) {
+      this.prev.set(this.curr)
+      const t0 = performance.now()
+      this.rapier.step()
+      this.stepCosts.push(performance.now() - t0)
+      this.stepIndex++
+      this.readInto(this.curr)
+      this.accumulator -= FIXED_DT
+      steps++
+    }
+    if (steps === 0) {
+      // No step ran, but the display still refreshed: interpolate further along
+      // the SAME segment rather than freezing. This is what makes 60 Hz physics
+      // look smooth on a 120 Hz iPad.
+      this.interpolate(this.accumulator / FIXED_DT)
+    } else {
+      this.interpolate(this.accumulator / FIXED_DT)
+    }
+    this.frameCount++
+    if (this.stepCosts.length > 240) this.stepCosts.splice(0, this.stepCosts.length - 240)
+    return steps
+  }
+
+  /** One exact step. For tests, replays and headless simulation. */
+  stepExact(n = 1): void {
+    for (let i = 0; i < n; i++) {
+      this.rapier.step()
+      this.stepIndex++
+    }
+    this.readInto(this.curr)
+    this.prev.set(this.curr)
+    this.transforms.set(this.curr)
+    this.count = this.bodies.length
+  }
+
+  private readInto(out: Float32Array) {
+    let n = 0
+    for (const b of this.bodies) {
+      if (b) {
+        const t = b.rb.translation()
+        const r = b.rb.rotation()
+        out[n * 4] = t.x
+        out[n * 4 + 1] = t.y
+        // cos/sin rather than the angle: the renderer wants them, and computing
+        // them once here beats 500 Math.cos calls in the draw loop.
+        out[n * 4 + 2] = Math.cos(r)
+        out[n * 4 + 3] = Math.sin(r)
+      }
+      n++
+    }
+    this.count = n
+  }
+
+  private interpolate(alpha: number) {
+    const a = alpha < 0 ? 0 : alpha > 1 ? 1 : alpha
+    const t = this.transforms
+    const p = this.prev
+    const c = this.curr
+    const n = this.count * 4
+    for (let i = 0; i < n; i++) t[i] = p[i]! + (c[i]! - p[i]!) * a
+  }
+
+  /** p99 physics step cost over the last ~4 s. The number the budget is about. */
+  p99StepMs(): number {
+    if (this.stepCosts.length === 0) return 0
+    const s = [...this.stepCosts].sort((x, y) => x - y)
+    return s[Math.min(s.length - 1, Math.floor(s.length * 0.99))]!
+  }
+
+  /** Re-tier from measured cost. Safe to call every second. */
+  retune(budgetMs = 4): TierName {
+    const next = autoTune(this.tier.name, this.p99StepMs(), budgetMs)
+    if (next !== this.tier.name) this.setTier(next)
+    return next
+  }
+
+  setTier(name: TierName) {
+    this.tier = TIERS[name]
+    this.rapier.numSolverIterations = this.tier.solverIterations
+  }
+
+  awakeCount(): number {
+    let n = 0
+    for (const b of this.bodies) if (b && !b.rb.isSleeping()) n++
+    return n
+  }
+
+  /**
+   * Quantised state hash. Quantised to 0.1 mm because a bit-exact hash of f32
+   * state is too brittle to be useful across engines — see the determinism
+   * section of the README, where V8 and JavaScriptCore agree to the bit today
+   * but nothing in either spec promises they will tomorrow.
+   */
+  hash(): string {
+    let h = 0x811c9dc5
+    const n = this.count * 4
+    for (let i = 0; i < n; i++) {
+      const q = Math.round(this.curr[i]! * 10000) | 0
+      for (let s = 0; s < 32; s += 8) {
+        h ^= (q >>> s) & 0xff
+        h = Math.imul(h, 0x01000193) >>> 0
+      }
+    }
+    return h.toString(16).padStart(8, "0")
+  }
+
+  raycast(from: Vec2, dir: Vec2, maxToi = 100): { point: Vec2; toi: number } | null {
+    const ray = new RAPIER.Ray({ x: from[0], y: from[1] }, { x: dir[0], y: dir[1] })
+    const hit = this.rapier.castRay(ray, maxToi, true)
+    if (!hit) return null
+    return {
+      toi: hit.timeOfImpact,
+      point: [from[0] + dir[0] * hit.timeOfImpact, from[1] + dir[1] * hit.timeOfImpact],
+    }
+  }
+
+  dispose() {
+    this.rapier.free()
+    this.bodies = []
+  }
+}
+
+function shapeDesc(s: Shape): RAPIER.ColliderDesc {
+  if ("box" in s) return RAPIER.ColliderDesc.cuboid(s.box[0], s.box[1])
+  if ("circle" in s) return RAPIER.ColliderDesc.ball(s.circle)
+  return RAPIER.ColliderDesc.capsule(s.capsule[0], s.capsule[1])
+}
+
+/**
+ * Pin two bodies at a shared point, free to rotate. Local anchors, like Rapier
+ * — NOT a world point like Box2D/Planck, which is the single most common
+ * porting mistake between the two families.
+ */
+export function pin(
+  w: World,
+  a: BodyHandle,
+  b: BodyHandle,
+  anchorA: Vec2,
+  anchorB: Vec2,
+  /** Optional [min, max] rotation in radians — a mechanical stop. */
+  limit?: readonly [number, number],
+): RAPIER.ImpulseJoint {
+  const data = RAPIER.JointData.revolute(
+    { x: anchorA[0], y: anchorA[1] },
+    { x: anchorB[0], y: anchorB[1] },
+  )
+  const joint = w.rapier.createImpulseJoint(data, a.rb, b.rb, true)
+  if (limit) {
+    // TRAP: setting `data.limitsEnabled = true` and `data.limits = [...]` on the
+    // JointData BEFORE creating the joint type-checks, runs, and does nothing
+    // at all for a revolute joint. Measured: an arm with a +/-22 deg stop set
+    // that way swings to -174 deg, and `joint.limitsEnabled()` reads back
+    // false. The limit has to be applied to the CREATED joint.
+    ;(joint as RAPIER.RevoluteImpulseJoint).setLimits(limit[0], limit[1])
+  }
+  return joint
+}

--- a/dynawalla/foundations/physics/tsconfig.json
+++ b/dynawalla/foundations/physics/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src", "demo", "bench"]
+}


### PR DESCRIPTION
## What this is

The **physics foundation** for the Dynawalla Bazaar: a four-engine bake-off, the
decision it justifies ([ADR-0020](../blob/agent/dynawalla/found-physics/dynawalla/docs/DECISIONS/ADR-0020-physics-engine-rapier.md)),
a reference kit, and a runnable demo.

Everything in [`dynawalla/foundations/physics/README.md`](../blob/agent/dynawalla/found-physics/dynawalla/foundations/physics/README.md)
was measured on this machine on 2026-07-26 by a script in `bench/`, and every script is
committed. Where something was **not** measured — a real Galaxy Tab A9, an x86 device —
it says so rather than rounding up.

## Acceptance criteria

Moves no item to MET. It is the groundwork for **`Q-02`** (holds 60 fps on the Galaxy Tab
A9), which is `[device]`-gated and cannot be met without the device; this PR commits the
measurement rig and a budget derived from a CPU-throttled proxy, and states plainly that
the proxy is not the device. Worth landing because 300 planned prototypes will each
either inherit this or re-derive it, and three of the traps below silently produce a
**dead mechanism that looks like working code**.

## The decision

**Rapier 2D, pinned at `@dimforge/rapier2d-compat` 0.19.3.** It wins on capability before
it wins on speed — each alternative fails something on the required list:

| engine | the disqualifier |
|---|---|
| Matter.js 0.20.0 | **0 of 300 dominoes fall** at friction ≥ 0.45; wave dies at domino three. Its iteration dial makes chain stretch *worse* (17% → 62%). Last published 2024-06-23. |
| Planck.js 1.5.0 | chain stretches **64% at a 10:1 load ratio**; 8.8x slower than Rapier on 500 bodies |
| Box2D v3 (`box2d3-wasm` 5.2.0) | fastest solver (6x Rapier's median) but Embind allocates per getter — 500 transforms cost **0.454 ms vs 0.171 ms** — and it settles a balance scale at **46-70° with equal pans** |

Rapier's cost is size: 1.12 MB WASM, 2.75x Box2D v3's. Accepted, with the reasoning and
the ~200 KB gzip `-compat` → separate-`.wasm` switch documented.

## Determinism

Verified, not assumed. One seeded scene (toppling stack + loaded chain + 120 particles +
a projectile), 900 steps → **identical state hash in Node/V8, Chrome/V8 and
WebKit/JavaScriptCore**. Structural: the module imports **no libm from JavaScript**, so
every float op is inside WASM where f32/f64 semantics are fully specified. Not verified:
cross-architecture (arm64 only).

Replays therefore store **commands addressed by step index**, never positions.

## Traps, each now gated by a test

1. **Rapier joints collide the bodies they connect and expose no `collideConnected`.** A
   pendulum whose anchor has a collider does not move — **0.0° in 5 s**, vs -33.0°
   without. Every articulated recipe here would have been silently dead.
2. **`JointData.limitsEnabled` / `.limits` are accepted, type-check, and are ignored.**
   Only `joint.setLimits()` works; the wrong spelling lets a ±22° stop reach **-174°**.
   This test then caught a *second* bug — my own bound `w.pin` was dropping the argument.
3. **A beam pivoted through its own centre of mass is neutrally stable**, so the same
   scene settles at +0.05° / +1.5° / -70.0° / +72.4° across the four engines. Not four
   bugs — one under-determined scene.

Plus: `box2d3-wasm` silently serves the scalar build unless `crossOriginIsolated`;
`advance()` must clamp or a backgrounded WebView freezes for seconds on resume; Node's
`--experimental-strip-types` is strip-**only** (no parameter properties).

## The equals sign

Given its own section because the brief singled it out. Pivot raised above the beam's
centre of mass (which is also the legibility dial — measured at five heights), real
mechanical stops, pans with lips. Settles at **0.01° with 0.000° jitter** at equality and
tips to its stop under one extra unit in four.

And the rule that is not about physics: **`compare()` is an integer comparison of what
was put in the pans, never the beam angle** — correct before a single step has run, with
a test that asserts it after forcibly rotating the beam. The solver drives the picture;
it never decides a mathematical fact. This extends ADR-0009's "true by construction".

## Budget

**4 ms of a 16.67 ms frame, as step p99**, four tiers whose floor is the reference
tablet. At `mid` the heaviest scene holds 60+ fps through **12x** CPU throttling in real
Chrome; every other scene holds 120 fps at 8x.

## Review notes

- **Diff is ~242 KB.** `adversarial_review.py` on `main` **chunks** rather than truncates
  (the `dynawalla/AGENTS.md` warning describes the pre-PR-0a.2 behaviour), so this is
  fully reviewed across 2 chunks. 36 KB of it is `package-lock.json`. Kept as one PR
  because the evidence and the thing the evidence justifies are not separately reviewable.
- **No new required status check.** `dynawalla/foundations/` matches no `ci.yml` area
  filter, so it lands in the `uncovered` warning bucket by design — per
  `dynawalla/AGENTS.md`, never a fourth required context.
- **ADR number may need rebasing.** 0020 was the next free slot when this was written;
  other agents are in flight.
- **Relationship to ADR-0004.** ADR-0020 does not claim ADR-0004's revisit condition is
  met, and does not touch the separate question of whether V1 renders in 3D.

## Verify locally

```bash
cd dynawalla/foundations/physics && npm install
npm test          # 17 gates
npm run tsc
npm run demo      # localhost:1425 — six scenes, live perf HUD
node bench/run-node.mjs --repeat 3
node bench/determinism.mjs      # needs the demo running
node bench/run-browser.mjs      # real Chrome, CPU-throttled
```

## Still owed

A real Galaxy Tab A9 run; cross-architecture determinism; a check inside an actual Tauri
WebView (whether the custom protocol serves `.wasm` with a MIME type that allows
`instantiateStreaming`); and the `-compat` → separate-`.wasm` switch before shipping.
