### PR TITLE
feat(dynawalla): SIEGE — a molten-forge tower defence bought with arithmetic

### DIFF
--- a/dynawalla/games/siege/.gitignore
+++ b/dynawalla/games/siege/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+qa/shots
+qa/tmp

--- a/dynawalla/games/siege/README.md
+++ b/dynawalla/games/siege/README.md
@@ -1,0 +1,132 @@
+# SIEGE
+
+**A river of lava runs through your forge. Things are walking up it. You buy the guns with
+arithmetic.**
+
+Tower defence, in the Kingdom Rush / Bloons line. Twenty machined sockets flank a molten
+channel; obsidian shards, armoured brutes, splitters, warded wraiths and bosses walk it toward
+the forge core. You place BOLT, MORTAR and CHAIN, you upgrade them five levels deep, and when
+the wave is about to break through you slam the overcharge.
+
+Embers are the only currency, and the only real source of embers is **the anvil**: a live
+arithmetic problem sitting under the board with four molten answer slugs. Strike it and embers
+arc up to the counter. Miss and the anvil goes cold for 1.15 seconds — which, mid-wave, is the
+difference between a tower and no tower.
+
+```
+npm install
+npm run dev        # http://localhost:4187
+npm test           # 19 tests, node's native runner, no dependencies
+node qa/playtest.mjs   # plays itself, screenshots, measures frames (needs playwright)
+```
+
+## Where the maths lives
+
+Four touchpoints, running from "the maths *is* the economy" to "the maths is the panic button".
+
+| | Beat | Tier |
+|---|---|---|
+| **The anvil** | A problem is always live. Correct → `6 + round(16 × difficulty)` embers fly to the counter, +9% overcharge. Wrong → the anvil quenches for 1.15 s: no lecture, no red ✗, just cold iron and lost income. | gating |
+| **Upgrades** | Tap a tower → the world drops to 0.42× speed and one harder problem fills the screen. Solve it and the machine blooms a level. Twenty pads × four levels = **eighty problems the player wants to solve.** | empowering |
+| **Overcharge** | The meter fills from correct answers. At 100% the lever goes hot. Slam it: time drops to 0.16×, one big problem, and the right answer is a shockwave that damages, stuns and throws the entire wave 150 units back down the channel. | empowering / emergency |
+| **The readout** | `HP IN 4173` sits beside `DPS 931`, and the palette prints cost against damage-per-second. Deciding between three BOLTs and one CHAIN *is* a rate comparison, out loud, in the HUD. | native |
+
+Thinking beats guessing because a wrong answer costs about one and a half problems' worth of
+income, and during a wave income is survival. No health is lost, no streak is broken, nothing is
+taken away — the wave just gets closer.
+
+## The look
+
+Hot forge on cold stone. Columnar basalt baked once into an offscreen canvas, a dark trench with
+a narrow molten bed and flow striations, machined chamfered sockets bolted into the rock. Your
+machines are white-hot iron that visibly cool between shots — **fire rate is legible as
+brightness, with no number attached**. The enemies are the only cold thing on the board:
+blue-black obsidian with rime edges, so you never mistake theirs for yours. Distinguished by
+silhouette first (diamond, chevron, plated hexagon, seamed sphere, warded ring, twelve-pointed
+boss) and colour second.
+
+## Juice, with the numbers
+
+Screen shake is a trauma model (`shake ∝ trauma²`, decay 1.75/s) with rotation, driven by wall
+time so a freeze never freezes the shake.
+
+| Event | Hitstop | Trauma | Other |
+|---|---|---|---|
+| mortar impact | 38 ms | 0.15 | 26 sparks, two shock rings |
+| heavy kill | 70 ms | 0.24 | 16 shards + smoke, 1.8% zoom punch |
+| boss down | 95 ms | 0.62 | 6% punch over 420 ms, 34 shards, 40 sparks, rate-limited flash |
+| core breach | 60 ms | 0.40 | `failure` haptic, 150-unit ring |
+| **overcharge** | 150 ms | 1.00 | `timeScale → 0.16` ramping back over ~1 s, 9% punch, five expanding rings, 120 sparks |
+
+Plus: tower recoil (scale +19% over 120 ms, kicked 7 units back along the shot vector),
+enemy spawn squash `easeOutBack` from (0.42, 1.6), a walking squash at 7.5 Hz, six-sample
+tapered projectile ribbons, homing bolts, mortars that lead their target, damage numbers on an
+arc, and embers that arc from the tapped slug to the counter on `cubic-bezier(0.5,-0.3,0.4,1)`
+with a rising tick per arrival.
+
+**Photosensitivity is a hard limit**: full-screen flashes are capped at 30% alpha and rate
+limited to one per 340 ms in `Camera.flash`, which silently refuses anything faster.
+
+`prefers-reduced-motion` is a branch, not a downgrade: shake, punch, slow-motion, hitstop, the
+lava flow animation and every DOM animation collapse, while damage numbers, health bars, the
+overcharge overlay and every piece of information survive untouched.
+
+## Audio
+
+Asset-free Web Audio, transient + body + tail on every voice, pitch jittered ±8–17% so a hundred
+bolt shots never fatigue. A brown-noise lava bed rides wave intensity. The correct-answer chime
+picks its pitch from a two-octave C pentatonic **by the difficulty of the problem, never by a
+streak**. Voices are capped at 26 and every sound has a minimum re-trigger gap. Muting loses
+nothing: every cue has a visual twin.
+
+## Performance
+
+Measured with `qa/playtest.mjs` on a fully built board (20 towers, level 3) at wave 20, with
+Chrome DevTools CPU throttling standing in for a cheaper device.
+
+| | median frame | p95 | at peak |
+|---|---|---|---|
+| 1× | 8.3 ms (120 fps) | 9.8 ms | 34 enemies, 483 particles |
+| **4× throttle** | **8.4 ms (119 fps)** | **16.4 ms (61 fps)** | 34 enemies, 448 particles |
+| 6× throttle | 15.2 ms (66 fps) | 24.9 ms | 34 enemies, 422 particles |
+
+Answer-path latency (`pointerdown` → verdict, synchronous): **p50 0.2 ms, p90 0.4 ms, max
+1.3 ms**. Nothing on the answer path awaits anything.
+
+How: the basalt, trench, striations and sockets are baked once into a 1400² offscreen canvas and
+blitted in one call. Every glow is a pre-rendered sprite blitted with `globalAlpha` — there is no
+`createRadialGradient` in the frame loop. Particles are a fixed struct-of-arrays pool with a hard
+ceiling of 1100 and no allocation after construction; enemies, shots and popups are pooled with
+alive flags. The simulation runs a fixed 1/60 step with a capped accumulator.
+
+## Shape of the code
+
+```
+src/contract.ts     the Host / Question / mount contract, verbatim
+src/stubHost.ts     seeded generator, twelve families, real mal-rule distractors
+src/core/           rng · easing · Clock (hitstop, slow-mo, fast-forward) · Camera (trauma, flash)
+src/audio/          the whole sound palette
+src/game/           constants (all balance) · path · board · waves · state + step
+src/render/         bake (static board) · particles · draw
+src/ui/             hud (DOM) · styles
+src/mount.ts        the controller: loop, input, sim events → light and noise
+```
+
+`src/game/state.ts` is pure of the DOM: `step(state, dt, effects)` calls into an `Effects` sink,
+which is why the whole simulation is unit-testable and why two of the tests play a headless siege
+to victory and to defeat.
+
+## Controls
+
+Touch and pointer are designed separately, not ported. **Touch**: tap a pad for a radial build
+menu, tap a tower to upgrade, big 2×2 answer slugs sized from the leftover screen height, a
+full-width overcharge bar. **Desktop**: a live tower palette with cost against dps — click to arm,
+then click pads to place, with the range previewing under the cursor. `1`–`4` answer, `Q`/`W`/`E`
+arm bolt/mortar/chain, `U` upgrade, `Space` overcharges or calls the wave in early for bonus
+embers, `F` fast-forwards, `Esc` closes.
+
+## Swapping in the real host
+
+`mount(el, host)` already matches the shared contract exactly. `createStubHost` adapts difficulty
+from `report()` — up on fast-correct, down on wrong — which is what the real engine will do, so
+the swap is one import and the game will not notice.

--- a/dynawalla/games/siege/index.html
+++ b/dynawalla/games/siege/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no"
+    />
+    <meta name="theme-color" content="#0a0608" />
+    <title>SIEGE</title>
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%230a0608'/%3E%3Cpath d='M16 5 L27 27 H5 Z' fill='none' stroke='%23ff8a2b' stroke-width='3'/%3E%3C/svg%3E"
+    />
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        background: #0a0608;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/siege/package-lock.json
+++ b/dynawalla/games/siege/package-lock.json
@@ -1,0 +1,905 @@
+{
+  "name": "@dynawalla/game-siege",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@dynawalla/game-siege",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^26.1.1",
+        "typescript": "~6.0.3",
+        "vite": "^8.1.5"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/dynawalla/games/siege/package.json
+++ b/dynawalla/games/siege/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@dynawalla/game-siege",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "SIEGE \u2014 a molten-forge tower defense where mental arithmetic is the forge that pays for the defense.",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4187",
+    "tsc": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test 'src/**/*.test.ts'"
+  },
+  "devDependencies": {
+    "typescript": "~6.0.3",
+    "vite": "^8.1.5",
+    "@types/node": "^26.1.1"
+  }
+}

--- a/dynawalla/games/siege/qa/playtest.mjs
+++ b/dynawalla/games/siege/qa/playtest.mjs
@@ -1,0 +1,311 @@
+/**
+ * Plays SIEGE for real and reports what it measured.
+ *
+ *   npm run dev            # in another shell
+ *   node qa/playtest.mjs   # needs playwright + chromium available locally
+ *
+ * Phase 1 drives the actual DOM: clicks the palette, clicks pads, clicks answer
+ * slugs. Phase 2 hands over to the in-game auto-player to reach the late waves
+ * where the frame budget is actually under pressure. Screenshots land in
+ * qa/shots/.
+ */
+import { chromium } from "playwright";
+import { mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SHOTS = join(HERE, "shots");
+const URL = process.env.SIEGE_URL ?? "http://localhost:4187/";
+mkdirSync(SHOTS, { recursive: true });
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const shot = async (page, name) => {
+  await page.screenshot({ path: join(SHOTS, `${name}.png`) });
+  console.log(`  shot: ${name}.png`);
+};
+
+const dbg = (page) => page.evaluate(() => window.__siege.debug());
+
+/** click the answer the child would give: correct, unless we asked for a slip */
+async function answer(page, slip = false) {
+  const idx = await page.evaluate((s) => {
+    const g = window.__siege;
+    if (!g || g.coldUntil > 0 || g.answering || g.focus) return -1;
+    const c = g.order.indexOf(0);
+    return s ? (c + 1) % 4 : c;
+  }, slip);
+  if (idx < 0) return false;
+  await page.locator(".sg-slugs .sg-slug").nth(idx).click({ force: true, timeout: 2000 });
+  return true;
+}
+
+async function main() {
+  const browser = await chromium.launch({
+    headless: false,
+    args: ["--autoplay-policy=no-user-gesture-required", "--mute-audio"],
+  });
+
+  // ---------------------------------------------------------------- desktop
+  const page = await browser.newPage({
+    viewport: { width: 1440, height: 900 },
+    deviceScaleFactor: 2,
+  });
+  const errors = [];
+  page.on("pageerror", (e) => errors.push(String(e)));
+  page.on("console", (m) => {
+    if (m.type() === "error") errors.push(m.text());
+  });
+
+  await page.goto(URL, { waitUntil: "load" });
+  await sleep(900);
+  await shot(page, "01-at-rest");
+
+  // instrument frame times in the page itself
+  await page.evaluate(() => {
+    window.__frames = [];
+    let last = performance.now();
+    const tick = (t) => {
+      window.__frames.push(t - last);
+      last = t;
+      requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  });
+
+  // -- phase 1: play it like a person --------------------------------------
+  console.log("phase 1 — hand-played");
+  await page.locator(".sg-card").first().click(); // arm BOLT
+  const box = await page.locator(".sg-board canvas").boundingBox();
+  const padAt = (fx, fy) => ({ x: box.x + box.width * fx, y: box.y + box.height * fy });
+  for (const [fx, fy] of [
+    [0.28, 0.16],
+    [0.5, 0.16],
+    [0.72, 0.16],
+    [0.28, 0.41],
+  ]) {
+    const p = padAt(fx, fy);
+    await page.mouse.click(p.x, p.y);
+    await sleep(120);
+  }
+  await sleep(400);
+  await shot(page, "02-towers-placed");
+
+  // answer-path latency: synchronous handler cost, measured in page
+  const latency = await page.evaluate(() => {
+    const g = window.__siege;
+    const out = [];
+    for (let i = 0; i < 24; i++) {
+      const t0 = performance.now();
+      g.answer(g.order.indexOf(0));
+      out.push(performance.now() - t0);
+      g.coldUntil = 0;
+      g.answering = false;
+      g.nextQuestion();
+    }
+    out.sort((a, b) => a - b);
+    return { p50: out[12], p90: out[21], max: out[23] };
+  });
+
+  await page.locator(".sg-chip").first().click(); // call the wave early
+  for (let i = 0; i < 26; i++) {
+    await answer(page, i % 9 === 8);
+    await sleep(420);
+  }
+  await shot(page, "03-mid-wave");
+
+  // -- phase 2a: a child's cadence -----------------------------------------
+  // roughly one answer every 2.3 s with a one-in-eight slip, which is what a
+  // competent ten-year-old actually does on these facts.
+  console.log("phase 2a — human cadence (2.3s/answer)");
+  const samples = [];
+  let overShot = false;
+  let deathShot = false;
+  let peakShot = false;
+  let lastAnswer = 0;
+  const humanUntil = Date.now() + 150000;
+  while (Date.now() < humanUntil) {
+    const now = Date.now();
+    if (now - lastAnswer > 2300) {
+      lastAnswer = now;
+      await page.evaluate(() => window.__siege.autoAnswer(0.125));
+    }
+    await page.evaluate(() => window.__siege.autoSpend());
+    await sleep(320);
+    const d = await dbg(page);
+    samples.push(d);
+    if (!overShot && (await page.locator(".sg-oc").count()) > 0) {
+      overShot = true;
+      await shot(page, "04-overcharge");
+    }
+    if (d.phase === "defeat") break;
+  }
+  const human = samples[samples.length - 1] ?? {};
+  console.log(`  human pace reached wave ${human.wave}, core ${human.coreHp}/20, embers ${human.embers}`);
+  await shot(page, "03b-human-pace");
+
+  // -- phase 2b: stress. fast-forward + perfect answers, until the forge falls
+  console.log("phase 2b — stress to failure");
+  await page.evaluate(() => window.__siege.setSpeedForTest(2));
+  const t0 = Date.now();
+  while (Date.now() - t0 < 190000) {
+    await page.evaluate(() => window.__siege.autoTick(0.04));
+    await sleep(110);
+    const d = await dbg(page);
+    samples.push(d);
+    if (!peakShot && d.enemies > 22) {
+      peakShot = true;
+      await shot(page, "06-peak-escalation");
+    }
+    if (d.phase === "defeat") {
+      if (!deathShot) {
+        deathShot = true;
+        await sleep(1100);
+        await shot(page, "05-forge-cold");
+      }
+      break;
+    }
+  }
+  const last = samples[samples.length - 1] ?? {};
+  if (!peakShot) await shot(page, "06-peak-escalation");
+  if (!deathShot) await shot(page, "05-late-game");
+
+  const frames = await page.evaluate(() => {
+    const f = window.__frames.slice(60).sort((a, b) => a - b);
+    const q = (p) => f[Math.floor(f.length * p)];
+    return {
+      n: f.length,
+      medianMs: +q(0.5).toFixed(2),
+      p95Ms: +q(0.95).toFixed(2),
+      p99Ms: +q(0.99).toFixed(2),
+      worstMs: +f[f.length - 1].toFixed(2),
+      fpsFromMedian: +(1000 / q(0.5)).toFixed(1),
+    };
+  });
+
+  const peak = samples.reduce(
+    (a, s) => ({
+      wave: Math.max(a.wave, s.wave),
+      enemies: Math.max(a.enemies, s.enemies),
+      particles: Math.max(a.particles, s.particles),
+      towers: Math.max(a.towers, s.towers),
+      fpsMin: Math.min(a.fpsMin, s.fps || 999),
+    }),
+    { wave: 0, enemies: 0, particles: 0, towers: 0, fpsMin: 999 },
+  );
+
+  console.log("\n== DESKTOP 1440x900 @2x ==");
+  console.log("frames  ", JSON.stringify(frames));
+  console.log("peak    ", JSON.stringify(peak));
+  console.log("last    ", JSON.stringify(last));
+  console.log("latency ", JSON.stringify(latency), "ms (synchronous answer handler)");
+
+  // -- phase 2c: the honest frame budget -----------------------------------
+  // This machine is not a mid-range tablet. Throttle the CPU 4x, seed a fully
+  // built board at a late wave, and measure that instead.
+  for (const rate of [1, 4, 6]) {
+    const pp = await browser.newPage({ viewport: { width: 1280, height: 800 }, deviceScaleFactor: 2 });
+    const cdp = await pp.context().newCDPSession(pp);
+    await pp.goto(URL, { waitUntil: "load" });
+    await sleep(700);
+    await cdp.send("Emulation.setCPUThrottlingRate", { rate });
+    await pp.evaluate(() => {
+      window.__siege.seedHeavy(20, 2);
+      window.__frames = [];
+      let last = performance.now();
+      const tick = (t) => {
+        window.__frames.push(t - last);
+        last = t;
+        requestAnimationFrame(tick);
+      };
+      requestAnimationFrame(tick);
+    });
+    const until = Date.now() + 26000;
+    let worst = { enemies: 0, particles: 0 };
+    while (Date.now() < until) {
+      await pp.evaluate(() => window.__siege.autoAnswer(0.1));
+      await sleep(500);
+      const d = await pp.evaluate(() => window.__siege.debug());
+      worst = {
+        enemies: Math.max(worst.enemies, d.enemies),
+        particles: Math.max(worst.particles, d.particles),
+      };
+      if (d.phase === "defeat") break;
+    }
+    const f = await pp.evaluate(() => {
+      const a = window.__frames.slice(40).sort((x, y) => x - y);
+      const q = (p) => a[Math.floor(a.length * p)];
+      return {
+        n: a.length,
+        medianMs: +q(0.5).toFixed(2),
+        p95Ms: +q(0.95).toFixed(2),
+        p99Ms: +q(0.99).toFixed(2),
+        fps: +(1000 / q(0.5)).toFixed(1),
+        fpsAtP95: +(1000 / q(0.95)).toFixed(1),
+      };
+    });
+    console.log(`cpu ${rate}x  ${JSON.stringify(f)}  peak ${JSON.stringify(worst)}`);
+    if (rate === 4) await shot(pp, "10-throttled-4x");
+    await cdp.send("Emulation.setCPUThrottlingRate", { rate: 1 });
+    await pp.close();
+  }
+
+  // -- phase 3: touch layouts ----------------------------------------------
+  for (const [name, viewport] of [
+    ["07-tablet-portrait", { width: 820, height: 1180 }],
+    ["08-phone-portrait", { width: 390, height: 844 }],
+  ]) {
+    const p2 = await browser.newPage({ viewport, deviceScaleFactor: 2, isMobile: true, hasTouch: true });
+    await p2.goto(URL, { waitUntil: "load" });
+    await sleep(700);
+    await p2.evaluate(() => {
+      const g = window.__siege;
+      for (let i = 0; i < 22; i++) {
+        g.state.embers += 60;
+        g.autoTick(0);
+      }
+      g.state.intermissionT = 0;
+    });
+    await sleep(2600);
+    await shot(p2, name);
+    const overflow = await p2.evaluate(() => ({
+      scrollW: document.documentElement.scrollWidth,
+      clientW: document.documentElement.clientWidth,
+    }));
+    console.log(`${name}: ${JSON.stringify(overflow)}`);
+    await p2.close();
+  }
+
+  // reduced motion
+  const p3 = await browser.newPage({
+    viewport: { width: 1440, height: 900 },
+    deviceScaleFactor: 2,
+    reducedMotion: "reduce",
+  });
+  await p3.goto(URL, { waitUntil: "load" });
+  await sleep(600);
+  await p3.evaluate(() => {
+    const g = window.__siege;
+    for (let i = 0; i < 18; i++) {
+      g.state.embers += 60;
+      g.autoTick(0);
+    }
+    g.state.intermissionT = 0;
+  });
+  await sleep(2600);
+  await shot(p3, "09-reduced-motion");
+  console.log(
+    "reducedMotion honoured:",
+    await p3.evaluate(() => window.__siege.cam.reducedMotion),
+  );
+  await p3.close();
+
+  console.log("\nerrors:", errors.length ? errors.slice(0, 8) : "none");
+  await browser.close();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/dynawalla/games/siege/src/audio/audio.ts
+++ b/dynawalla/games/siege/src/audio/audio.ts
@@ -1,0 +1,288 @@
+/**
+ * Asset-free Web Audio. Every sound is transient + body + tail, and every one
+ * takes a pitch jitter so a hundred bolt shots in ten seconds never fatigue.
+ *
+ * Audio never carries information alone — every cue it makes has a visual twin.
+ */
+
+const NOISE_SECONDS = 2;
+
+export class Audio {
+  private ctx: AudioContext | null = null;
+  private master!: GainNode;
+  private comp!: DynamicsCompressorNode;
+  private noise!: AudioBuffer;
+  private rumbleGain!: GainNode;
+  private started = false;
+  enabled = true;
+  private lastAt = new Map<string, number>();
+  private voices = 0;
+
+  /** must be called from a user gesture on iOS */
+  async start(): Promise<void> {
+    if (this.started) return;
+    const Ctor: typeof AudioContext | undefined =
+      (globalThis as { AudioContext?: typeof AudioContext }).AudioContext ??
+      (globalThis as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!Ctor) return;
+    this.started = true;
+    const ctx = new Ctor({ latencyHint: "interactive" });
+    this.ctx = ctx;
+
+    this.comp = ctx.createDynamicsCompressor();
+    this.comp.threshold.value = -18;
+    this.comp.knee.value = 24;
+    this.comp.ratio.value = 8;
+    this.comp.attack.value = 0.003;
+    this.comp.release.value = 0.2;
+
+    this.master = ctx.createGain();
+    this.master.gain.value = 0.75;
+    this.master.connect(this.comp);
+    this.comp.connect(ctx.destination);
+
+    // one shared noise buffer — allocating per shot is how you drop frames
+    const len = Math.floor(ctx.sampleRate * NOISE_SECONDS);
+    const buf = ctx.createBuffer(1, len, ctx.sampleRate);
+    const d = buf.getChannelData(0);
+    let brown = 0;
+    for (let i = 0; i < len; i++) {
+      const white = Math.random() * 2 - 1;
+      brown = (brown + white * 0.02) / 1.02;
+      d[i] = white * 0.7 + brown * 3.2;
+    }
+    this.noise = buf;
+
+    this.startRumble();
+    if (ctx.state === "suspended") await ctx.resume().catch(() => {});
+  }
+
+  resume(): void {
+    void this.ctx?.resume().catch(() => {});
+  }
+
+  setEnabled(on: boolean): void {
+    this.enabled = on;
+    if (this.master) this.master.gain.value = on ? 0.75 : 0;
+  }
+
+  /** the lava bed — gain rides wave intensity so the room gets tense on its own */
+  private startRumble(): void {
+    const ctx = this.ctx;
+    if (!ctx) return;
+    const src = ctx.createBufferSource();
+    src.buffer = this.noise;
+    src.loop = true;
+    const lp = ctx.createBiquadFilter();
+    lp.type = "lowpass";
+    lp.frequency.value = 96;
+    lp.Q.value = 0.7;
+    const g = ctx.createGain();
+    g.gain.value = 0.0;
+    src.connect(lp);
+    lp.connect(g);
+    g.connect(this.master);
+    src.start();
+    this.rumbleGain = g;
+  }
+
+  setIntensity(v: number): void {
+    if (!this.rumbleGain || !this.ctx) return;
+    const target = 0.05 + Math.min(1, Math.max(0, v)) * 0.16;
+    this.rumbleGain.gain.setTargetAtTime(target, this.ctx.currentTime, 0.5);
+  }
+
+  private ok(key: string, minGap: number): boolean {
+    if (!this.ctx || !this.enabled) return false;
+    if (this.voices > 26) return false;
+    const now = this.ctx.currentTime;
+    const last = this.lastAt.get(key) ?? -1;
+    if (now - last < minGap) return false;
+    this.lastAt.set(key, now);
+    return true;
+  }
+
+  private track(node: AudioScheduledSourceNode, dur: number): void {
+    this.voices++;
+    node.onended = () => {
+      this.voices--;
+    };
+    node.stop(this.ctx!.currentTime + dur);
+  }
+
+  private env(gain: number, attack: number, decay: number): GainNode {
+    const ctx = this.ctx!;
+    const g = ctx.createGain();
+    const t = ctx.currentTime;
+    g.gain.setValueAtTime(0.0001, t);
+    g.gain.exponentialRampToValueAtTime(Math.max(0.0002, gain), t + attack);
+    g.gain.exponentialRampToValueAtTime(0.0001, t + attack + decay);
+    return g;
+  }
+
+  private tone(
+    type: OscillatorType,
+    f0: number,
+    f1: number,
+    dur: number,
+    gain: number,
+    dest: AudioNode,
+  ): void {
+    const ctx = this.ctx!;
+    const o = ctx.createOscillator();
+    o.type = type;
+    const t = ctx.currentTime;
+    o.frequency.setValueAtTime(f0, t);
+    if (f1 !== f0) o.frequency.exponentialRampToValueAtTime(Math.max(20, f1), t + dur);
+    const g = this.env(gain, 0.004, dur);
+    o.connect(g);
+    g.connect(dest);
+    o.start();
+    this.track(o, dur + 0.06);
+  }
+
+  private hiss(
+    dur: number,
+    gain: number,
+    type: BiquadFilterType,
+    f0: number,
+    f1: number,
+    dest: AudioNode,
+  ): void {
+    const ctx = this.ctx!;
+    const s = ctx.createBufferSource();
+    s.buffer = this.noise;
+    s.loop = true;
+    const t = ctx.currentTime;
+    const bp = ctx.createBiquadFilter();
+    bp.type = type;
+    bp.frequency.setValueAtTime(f0, t);
+    if (f1 !== f0) bp.frequency.exponentialRampToValueAtTime(Math.max(40, f1), t + dur);
+    bp.Q.value = 1.1;
+    const g = this.env(gain, 0.002, dur);
+    s.connect(bp);
+    bp.connect(g);
+    g.connect(dest);
+    s.start(t + Math.random() * 0.4);
+    this.track(s, dur + 0.06);
+  }
+
+  // -- the palette ----------------------------------------------------------
+
+  /** bolt tower: a tight metallic snap */
+  bolt(): void {
+    if (!this.ok("bolt", 0.022)) return;
+    const j = 1 + (Math.random() - 0.5) * 0.22;
+    this.hiss(0.05, 0.1, "bandpass", 2600 * j, 1100 * j, this.master);
+    this.tone("square", 620 * j, 300 * j, 0.06, 0.05, this.master);
+  }
+
+  /** mortar: a chest thump with a real sub */
+  mortar(): void {
+    if (!this.ok("mortar", 0.05)) return;
+    const j = 1 + (Math.random() - 0.5) * 0.16;
+    this.tone("sine", 140 * j, 38, 0.34, 0.34, this.master);
+    this.hiss(0.2, 0.16, "lowpass", 900 * j, 180, this.master);
+  }
+
+  /** chain lightning arc */
+  arc(): void {
+    if (!this.ok("arc", 0.03)) return;
+    const j = 1 + (Math.random() - 0.5) * 0.3;
+    this.hiss(0.13, 0.11, "highpass", 1500 * j, 5200 * j, this.master);
+    this.tone("sawtooth", 900 * j, 2100 * j, 0.09, 0.03, this.master);
+  }
+
+  /** obsidian cracking — the pop that makes killing feel like popping bubble wrap */
+  shatter(size = 1): void {
+    if (!this.ok("shatter", 0.016)) return;
+    const j = (1 + (Math.random() - 0.5) * 0.34) / size;
+    this.hiss(0.1 * size, 0.13, "bandpass", 3400 * j, 700 * j, this.master);
+    this.tone("triangle", 420 * j, 120 * j, 0.09 * size, 0.07, this.master);
+  }
+
+  /** boss down: everything drops an octave and the floor gives way */
+  bossDown(): void {
+    if (!this.ok("boss", 0.4)) return;
+    this.tone("sine", 190, 26, 1.1, 0.42, this.master);
+    this.hiss(0.85, 0.24, "lowpass", 2600, 120, this.master);
+    this.tone("triangle", 300, 74, 0.6, 0.12, this.master);
+  }
+
+  /** a struck bell for a correct answer — pitch tracks difficulty, never a streak */
+  forgeStrike(difficulty: number): void {
+    if (!this.ok("strike", 0.02)) return;
+    // C-major pentatonic over two octaves, indexed by how hard the problem was
+    const scale = [523.25, 587.33, 659.25, 783.99, 880.0, 1046.5, 1174.66, 1318.51];
+    const idx = Math.min(scale.length - 1, Math.floor(difficulty * scale.length));
+    const f = scale[idx] as number;
+    this.hiss(0.05, 0.16, "bandpass", 4200, 1800, this.master); // hammer transient
+    this.tone("sine", f, f, 0.5, 0.16, this.master); // body
+    this.tone("triangle", f * 2.01, f * 2.0, 0.32, 0.05, this.master); // shimmer
+    this.tone("sine", f * 0.5, f * 0.5, 0.7, 0.06, this.master); // tail
+  }
+
+  /** a wrong answer: the anvil goes cold. Dull, not cruel. */
+  quench(): void {
+    if (!this.ok("quench", 0.1)) return;
+    this.hiss(0.5, 0.15, "lowpass", 1400, 220, this.master);
+    this.tone("sine", 150, 92, 0.28, 0.11, this.master);
+  }
+
+  /** a coin arriving at the counter */
+  tick(i: number): void {
+    if (!this.ok(`tick${i % 3}`, 0.012)) return;
+    const f = 1300 + i * 90 + Math.random() * 60;
+    this.tone("sine", f, f * 1.4, 0.05, 0.035, this.master);
+  }
+
+  /** tower placed */
+  build(): void {
+    if (!this.ok("build", 0.06)) return;
+    this.tone("sine", 90, 220, 0.24, 0.2, this.master);
+    this.hiss(0.22, 0.1, "bandpass", 700, 2400, this.master);
+  }
+
+  /** upgrade bloom */
+  upgrade(): void {
+    if (!this.ok("upg", 0.1)) return;
+    this.tone("sine", 330, 990, 0.42, 0.16, this.master);
+    this.tone("triangle", 660, 1320, 0.3, 0.07, this.master);
+    this.hiss(0.34, 0.11, "highpass", 900, 4800, this.master);
+  }
+
+  /** the overcharge: sub drop plus a rising sweep, the biggest sound in the game */
+  overcharge(): void {
+    if (!this.ok("over", 0.5)) return;
+    this.tone("sawtooth", 60, 900, 0.85, 0.12, this.master);
+    this.tone("sine", 300, 32, 1.2, 0.4, this.master);
+    this.hiss(1.0, 0.3, "lowpass", 260, 5200, this.master);
+  }
+
+  /** time bending into slow motion */
+  slowIn(): void {
+    if (!this.ok("slow", 0.3)) return;
+    this.tone("sine", 900, 200, 0.55, 0.1, this.master);
+  }
+
+  /** the core takes a hit */
+  breach(): void {
+    if (!this.ok("breach", 0.14)) return;
+    this.tone("sawtooth", 220, 60, 0.4, 0.2, this.master);
+    this.hiss(0.4, 0.2, "lowpass", 1800, 200, this.master);
+  }
+
+  /** the rift opens for a new wave */
+  waveHorn(pitch: number): void {
+    if (!this.ok("horn", 0.5)) return;
+    this.tone("sawtooth", 70 * pitch, 104 * pitch, 1.0, 0.1, this.master);
+    this.tone("sine", 140 * pitch, 208 * pitch, 0.8, 0.07, this.master);
+  }
+
+  /** the forge goes cold */
+  defeat(): void {
+    if (!this.ok("defeat", 1)) return;
+    this.tone("sine", 260, 40, 2.2, 0.3, this.master);
+    this.hiss(2.0, 0.2, "lowpass", 1200, 90, this.master);
+  }
+}

--- a/dynawalla/games/siege/src/contract.ts
+++ b/dynawalla/games/siege/src/contract.ts
@@ -1,0 +1,26 @@
+/**
+ * The game <-> runtime contract.
+ *
+ * A shared package will replace this file. Keep the shape EXACTLY as written so
+ * the swap is a one-line import change.
+ */
+
+export type Question = {
+  id: string;
+  prompt: string; // "15 − 8"
+  answer: string; // "7"  — exact, canonical
+  distractors: string[]; // plausible wrong answers, ideally real mal-rule outputs
+  domain: string; // "add-sub" | "fractions" | ...
+  difficulty: number; // 0..1
+};
+
+export type Host = {
+  next(): Question; // pull the next question
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void;
+  haptic(kind: "light" | "medium" | "heavy" | "success" | "failure"): void;
+  prefersReducedMotion(): boolean;
+};
+
+export function mountSignature(_el: HTMLElement, _host: Host): { unmount(): void } {
+  throw new Error("see ./index.ts — this file only declares the contract");
+}

--- a/dynawalla/games/siege/src/core/camera.ts
+++ b/dynawalla/games/siege/src/core/camera.ts
@@ -1,0 +1,98 @@
+/**
+ * Screen shake (trauma model), zoom punch, and the photosensitivity-safe flash.
+ *
+ * Trauma, not offset: callers add trauma, shake is trauma² so small hits barely
+ * register and big ones are violent, and it decays on its own. Rotation is
+ * included because pure translation reads as a glitch, not a punch.
+ */
+import { clamp01, easeOutQuint } from "./easing.ts";
+import { makeRng } from "./rng.ts";
+
+/** Hard ceiling: no more than 3 full-screen luminance flashes per second. */
+const FLASH_MIN_INTERVAL = 0.34;
+const FLASH_MAX_ALPHA = 0.3;
+
+export class Camera {
+  trauma = 0;
+  shakeX = 0;
+  shakeY = 0;
+  shakeRot = 0;
+  /** multiplicative zoom, 1 = neutral */
+  zoom = 1;
+  private punch = 0;
+  private punchT = 1;
+  private punchDur = 0.26;
+  flashAlpha = 0;
+  private flashPeak = 0;
+  private flashT = 1;
+  private lastFlashAt = -10;
+  private t = 0;
+  private rng = makeRng(0x1a2b3c);
+  reducedMotion = false;
+
+  addTrauma(v: number): void {
+    if (this.reducedMotion) return;
+    this.trauma = clamp01(this.trauma + v);
+  }
+
+  /** zoom punch: snaps to 1+amount then eases back with easeOutQuint */
+  addPunch(amount: number, durationSec = 0.26): void {
+    if (this.reducedMotion) return;
+    if (amount <= this.punch && this.punchT < 0.4) return;
+    this.punch = amount;
+    this.punchDur = durationSec;
+    this.punchT = 0;
+  }
+
+  /** rate-limited full-screen flash. Silently refused if it would exceed 3 Hz. */
+  flash(alpha: number, now: number): void {
+    if (this.reducedMotion) return;
+    if (now - this.lastFlashAt < FLASH_MIN_INTERVAL) return;
+    this.lastFlashAt = now;
+    this.flashPeak = Math.min(FLASH_MAX_ALPHA, alpha);
+    this.flashT = 0;
+  }
+
+  reset(): void {
+    this.trauma = 0;
+    this.shakeX = this.shakeY = this.shakeRot = 0;
+    this.zoom = 1;
+    this.punch = 0;
+    this.punchT = 1;
+    this.flashAlpha = 0;
+    this.flashT = 1;
+    this.lastFlashAt = -10;
+  }
+
+  /** driven by WALL time so a hitstop does not freeze the shake — that is the point */
+  update(dt: number): void {
+    this.t += dt;
+    this.trauma = Math.max(0, this.trauma - 1.75 * dt);
+
+    const s = this.trauma * this.trauma;
+    if (s > 0.00001) {
+      // two out-of-phase sinusoids per axis reads as physical, pure random reads as noise
+      const f = 34;
+      this.shakeX = (Math.sin(this.t * f) * 0.6 + this.rng.r(-0.4, 0.4)) * s * 26;
+      this.shakeY = (Math.cos(this.t * f * 1.17) * 0.6 + this.rng.r(-0.4, 0.4)) * s * 26;
+      this.shakeRot = Math.sin(this.t * f * 0.83) * s * 0.022;
+    } else {
+      this.shakeX = this.shakeY = this.shakeRot = 0;
+    }
+
+    if (this.punchT < 1) {
+      this.punchT = Math.min(1, this.punchT + dt / this.punchDur);
+      this.zoom = 1 + this.punch * (1 - easeOutQuint(this.punchT));
+    } else {
+      this.zoom = 1;
+    }
+
+    if (this.flashT < 1) {
+      this.flashT = Math.min(1, this.flashT + dt / 0.19);
+      // ease out fast — a lingering white sheet is what triggers people
+      this.flashAlpha = this.flashPeak * (1 - this.flashT) * (1 - this.flashT);
+    } else {
+      this.flashAlpha = 0;
+    }
+  }
+}

--- a/dynawalla/games/siege/src/core/easing.ts
+++ b/dynawalla/games/siege/src/core/easing.ts
@@ -1,0 +1,51 @@
+/** Named easing curves. Referenced by name in the juice spec so feel is auditable. */
+
+export const linear = (t: number): number => t;
+
+export const easeOutQuad = (t: number): number => 1 - (1 - t) * (1 - t);
+
+export const easeOutCubic = (t: number): number => 1 - Math.pow(1 - t, 3);
+
+export const easeOutQuint = (t: number): number => 1 - Math.pow(1 - t, 5);
+
+export const easeInCubic = (t: number): number => t * t * t;
+
+export const easeInOutCubic = (t: number): number =>
+  t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+
+export const easeOutBack = (t: number): number => {
+  const c1 = 1.70158;
+  const c3 = c1 + 1;
+  return 1 + c3 * Math.pow(t - 1, 3) + c1 * Math.pow(t - 1, 2);
+};
+
+export const easeInBack = (t: number): number => {
+  const c1 = 1.70158;
+  const c3 = c1 + 1;
+  return c3 * t * t * t - c1 * t * t;
+};
+
+export const easeOutElastic = (t: number): number => {
+  if (t <= 0) return 0;
+  if (t >= 1) return 1;
+  const c4 = (2 * Math.PI) / 3;
+  return Math.pow(2, -10 * t) * Math.sin((t * 10 - 0.75) * c4) + 1;
+};
+
+/** Overshoots to `peak` then settles at 1 — the squash/stretch settle curve. */
+export const easeOutOvershoot = (t: number, peak = 1.24): number => {
+  if (t >= 1) return 1;
+  const e = easeOutCubic(t);
+  return e + (peak - 1) * Math.sin(Math.PI * Math.min(1, t * 1.35)) * (1 - t);
+};
+
+export const clamp = (v: number, lo: number, hi: number): number =>
+  v < lo ? lo : v > hi ? hi : v;
+
+export const clamp01 = (v: number): number => clamp(v, 0, 1);
+
+export const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+
+/** Framerate-independent exponential approach. `rate` = fraction closed per second. */
+export const damp = (a: number, b: number, rate: number, dt: number): number =>
+  b + (a - b) * Math.exp(-rate * dt);

--- a/dynawalla/games/siege/src/core/rng.ts
+++ b/dynawalla/games/siege/src/core/rng.ts
@@ -1,0 +1,67 @@
+/** Deterministic, seedable RNG. sfc32 — fast, good distribution, 128-bit state. */
+export type Rng = {
+  /** float in [0, 1) */
+  f(): number;
+  /** integer in [lo, hi] inclusive */
+  i(lo: number, hi: number): number;
+  /** float in [lo, hi) */
+  r(lo: number, hi: number): number;
+  /** picks an element; never called on an empty array */
+  pick<T>(xs: readonly T[]): T;
+  /** true with probability p */
+  chance(p: number): boolean;
+  /** Fisher-Yates, in place, returns the same array */
+  shuffle<T>(xs: T[]): T[];
+};
+
+export function hashSeed(str: string): number {
+  let h = 2166136261 >>> 0;
+  for (let k = 0; k < str.length; k++) {
+    h ^= str.charCodeAt(k);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  return h >>> 0;
+}
+
+export function makeRng(seed: number): Rng {
+  let a = (seed ^ 0x9e3779b9) >>> 0;
+  let b = (seed ^ 0x243f6a88) >>> 0;
+  let c = (seed ^ 0xb7e15162) >>> 0;
+  let d = 1;
+
+  const f = (): number => {
+    a >>>= 0;
+    b >>>= 0;
+    c >>>= 0;
+    d >>>= 0;
+    let t = (a + b) | 0;
+    a = b ^ (b >>> 9);
+    b = (c + (c << 3)) | 0;
+    c = (c << 21) | (c >>> 11);
+    d = (d + 1) | 0;
+    t = (t + d) | 0;
+    c = (c + t) | 0;
+    return (t >>> 0) / 4294967296;
+  };
+
+  // warm up so nearby seeds diverge immediately
+  for (let k = 0; k < 12; k++) f();
+
+  const i = (lo: number, hi: number): number => lo + Math.floor(f() * (hi - lo + 1));
+  return {
+    f,
+    i,
+    r: (lo, hi) => lo + f() * (hi - lo),
+    pick: <T>(xs: readonly T[]): T => xs[i(0, xs.length - 1)] as T,
+    chance: (p) => f() < p,
+    shuffle: <T>(xs: T[]): T[] => {
+      for (let k = xs.length - 1; k > 0; k--) {
+        const j = i(0, k);
+        const tmp = xs[k] as T;
+        xs[k] = xs[j] as T;
+        xs[j] = tmp;
+      }
+      return xs;
+    },
+  };
+}

--- a/dynawalla/games/siege/src/core/time.ts
+++ b/dynawalla/games/siege/src/core/time.ts
@@ -1,0 +1,77 @@
+/**
+ * The clock. Owns hitstop, slow-motion and the player's fast-forward, and hands
+ * the simulation a fixed step so physics never depends on frame rate.
+ */
+import { clamp, damp } from "./easing.ts";
+
+export const FIXED_DT = 1 / 60;
+
+export class Clock {
+  /** wall-clock seconds since start — animations that must not freeze use this */
+  wall = 0;
+  /** simulation seconds — hitstop and slow-mo bend this */
+  sim = 0;
+  /** player fast-forward, 1 or 2 */
+  speed = 1;
+  /** externally driven slow-motion target (1 = normal) */
+  slowTarget = 1;
+  /** smoothed slow-motion, so the ramp back out is felt, not switched */
+  private slow = 1;
+  /** remaining freeze in WALL seconds — render keeps running, sim does not */
+  private stopFor = 0;
+  private accumulator = 0;
+  /** true while the sim is frozen; the renderer uses it to punch harder */
+  frozen = false;
+
+  /** freeze the simulation for `ms` — the single most valuable juice primitive */
+  hitstop(ms: number): void {
+    const s = ms / 1000;
+    if (s > this.stopFor) this.stopFor = s;
+  }
+
+  reset(): void {
+    this.wall = 0;
+    this.sim = 0;
+    this.speed = 1;
+    this.slowTarget = 1;
+    this.slow = 1;
+    this.stopFor = 0;
+    this.accumulator = 0;
+    this.frozen = false;
+  }
+
+  /**
+   * Advance by a real frame delta. Returns how many fixed sim steps to run.
+   * Caps the accumulator so a backgrounded tab does not spiral on return.
+   */
+  advance(rawDt: number): number {
+    const dt = clamp(rawDt, 0, 0.05);
+    this.wall += dt;
+
+    if (this.stopFor > 0) {
+      this.stopFor -= dt;
+      this.frozen = true;
+      return 0;
+    }
+    this.frozen = false;
+
+    this.slow = damp(this.slow, this.slowTarget, 6.5, dt);
+    if (Math.abs(this.slow - this.slowTarget) < 0.004) this.slow = this.slowTarget;
+
+    this.accumulator += dt * this.slow * this.speed;
+    if (this.accumulator > 0.25) this.accumulator = 0.25;
+
+    let steps = 0;
+    while (this.accumulator >= FIXED_DT && steps < 8) {
+      this.accumulator -= FIXED_DT;
+      steps++;
+    }
+    this.sim += steps * FIXED_DT;
+    return steps;
+  }
+
+  /** current effective rate, for audio pitch and UI tinting */
+  get scale(): number {
+    return this.frozen ? 0 : this.slow * this.speed;
+  }
+}

--- a/dynawalla/games/siege/src/env.d.ts
+++ b/dynawalla/games/siege/src/env.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";

--- a/dynawalla/games/siege/src/game/board.ts
+++ b/dynawalla/games/siege/src/game/board.ts
@@ -1,0 +1,54 @@
+/** Buildable pads, derived from the grid and the channel. Deterministic. */
+import { CELL, GRID } from "./constants.ts";
+import type { PathData } from "./path.ts";
+import { makeRng } from "../core/rng.ts";
+
+export type Plot = {
+  id: number;
+  x: number;
+  y: number;
+  /** cosmetic jitter so 30 identical squares do not read as a spreadsheet */
+  rot: number;
+  size: number;
+  towerId: number; // -1 when empty
+  /** how much of the channel this pad can reach with a 215-unit tower — used for the hint pulse */
+  value: number;
+};
+
+const CLEARANCE = 74;
+
+/**
+ * Every other column, so the pads are big enough to be a real decision instead
+ * of a spreadsheet. Twenty-odd sockets, each one worth thinking about.
+ */
+export function buildPlots(path: PathData): Plot[] {
+  const rng = makeRng(0xb0a2d);
+  const plots: Plot[] = [];
+  let id = 0;
+  for (let row = 1; row < GRID; row += 2) {
+    for (let col = 0; col < GRID; col += 2) {
+      const x = (col + 0.5) * CELL + rng.r(-11, 11);
+      const y = (row + 0.5) * CELL + rng.r(-9, 9);
+      if (path.distanceTo(x, y) < CLEARANCE) continue;
+
+      // how many sampled channel points fall inside a starter tower's reach
+      let hits = 0;
+      const samples = 220;
+      const p = { x: 0, y: 0 };
+      for (let k = 0; k < samples; k++) {
+        path.at((k / samples) * path.length, p);
+        if (Math.hypot(p.x - x, p.y - y) <= 215) hits++;
+      }
+      plots.push({
+        id: id++,
+        x,
+        y,
+        rot: rng.r(-0.035, 0.035),
+        size: CELL * rng.r(0.93, 1.0),
+        towerId: -1,
+        value: hits / samples,
+      });
+    }
+  }
+  return plots;
+}

--- a/dynawalla/games/siege/src/game/constants.ts
+++ b/dynawalla/games/siege/src/game/constants.ts
@@ -1,0 +1,211 @@
+/**
+ * Balance and palette. Everything a designer would want to tune lives here.
+ *
+ * Money, damage, armour and health are INTEGERS everywhere. Positions, speeds
+ * and timers are floats — they are physics, not answers.
+ */
+
+/** Virtual board is a square; the view fit-contains it, so every device sees the same fight. */
+export const BOARD = 1000;
+export const GRID = 9;
+export const CELL = BOARD / GRID;
+
+export const CORE_MAX_HP = 20;
+
+// -- palette: hot forge against cold obsidian --------------------------------
+export const C = {
+  void: "#0a0608",
+  basalt: "#181114",
+  basaltHi: "#241a1e",
+  crack: "#4a2a20",
+  crustDark: "#2a1210",
+  lava0: "#ff4d12",
+  lava1: "#ff9a2e",
+  lava2: "#ffd06a",
+  whiteHot: "#fff2d2",
+  ember: "#ff8a2b",
+  gold: "#ffcf5c",
+  steel: "#c8b8a8",
+  // enemies are cold on purpose — you never mistake theirs for yours
+  obsidian: "#1d2430",
+  obsidianHi: "#39465c",
+  rime: "#8fb4d8",
+  shield: "#6fe3ff",
+  danger: "#ff3d2e",
+  text: "#f6e9d8",
+  dim: "#9b8878",
+} as const;
+
+// -- towers ------------------------------------------------------------------
+export type TowerKind = "bolt" | "mortar" | "chain";
+
+export type TowerSpec = {
+  kind: TowerKind;
+  name: string;
+  cost: number;
+  /** level-1 values; every level above is derived, so the curve is one number */
+  dmg: number;
+  rate: number; // shots per second
+  range: number;
+  splash?: number; // mortar only
+  links?: number; // chain only
+  blurb: string;
+};
+
+export const TOWERS: Record<TowerKind, TowerSpec> = {
+  bolt: {
+    kind: "bolt",
+    name: "BOLT",
+    cost: 22,
+    dmg: 7,
+    rate: 2.2,
+    range: 215,
+    blurb: "fast · single",
+  },
+  mortar: {
+    kind: "mortar",
+    name: "MORTAR",
+    cost: 55,
+    dmg: 26,
+    rate: 0.62,
+    range: 330,
+    splash: 92,
+    blurb: "slow · splash",
+  },
+  chain: {
+    kind: "chain",
+    name: "CHAIN",
+    cost: 95,
+    dmg: 18,
+    rate: 1.05,
+    range: 252,
+    links: 3,
+    blurb: "arcs · many",
+  },
+};
+
+/**
+ * Five levels, and each one has to be paid for with an answer. Twenty pads times
+ * four upgrades is eighty problems the player *wants* to solve — which is the
+ * whole trick: the maths is the thing standing between them and a bigger gun.
+ */
+export const MAX_LEVEL = 4;
+
+const DMG_GROWTH = 1.85;
+const RATE_GROWTH = 0.14;
+const RANGE_GROWTH = 0.05;
+const COST_GROWTH = 2.15;
+
+export const towerDamage = (kind: TowerKind, level: number): number =>
+  Math.round(TOWERS[kind].dmg * Math.pow(DMG_GROWTH, level));
+
+export const towerRate = (kind: TowerKind, level: number): number =>
+  TOWERS[kind].rate * (1 + RATE_GROWTH * level);
+
+export const towerRange = (kind: TowerKind, level: number): number =>
+  TOWERS[kind].range * (1 + RANGE_GROWTH * level);
+
+export const towerSplash = (kind: TowerKind, level: number): number =>
+  (TOWERS[kind].splash ?? 0) * (1 + 0.07 * level);
+
+export const towerLinks = (kind: TowerKind, level: number): number =>
+  TOWERS[kind].links ? (TOWERS[kind].links as number) + Math.floor(level / 2) : 1;
+
+/** integer ember cost of the next level, or null at the top */
+export const towerUpgradeCost = (kind: TowerKind, level: number): number | null =>
+  level >= MAX_LEVEL ? null : Math.round(TOWERS[kind].cost * 1.9 * Math.pow(COST_GROWTH, level));
+
+/** each link past the first deals this fraction, floored, never below 1 */
+export const CHAIN_FALLOFF = 0.6;
+
+// -- enemies -----------------------------------------------------------------
+export type EnemyKind = "shard" | "runner" | "brute" | "splitter" | "warden" | "boss";
+
+export type EnemySpec = {
+  kind: EnemyKind;
+  hp: number;
+  speed: number; // board units per second
+  armor: number; // flat reduction per hit, damage never below 1
+  bounty: number; // embers
+  radius: number;
+  leak: number; // core damage on reaching the forge
+  /** shielded: single-target fire is heavily blunted, splash and arcs are not */
+  warded?: boolean;
+  splits?: number;
+};
+
+export const ENEMIES: Record<EnemyKind, EnemySpec> = {
+  shard: { kind: "shard", hp: 10, speed: 108, armor: 0, bounty: 2, radius: 21, leak: 1 },
+  runner: { kind: "runner", hp: 7, speed: 208, armor: 0, bounty: 2, radius: 17, leak: 1 },
+  brute: { kind: "brute", hp: 34, speed: 74, armor: 6, bounty: 5, radius: 32, leak: 2 },
+  splitter: {
+    kind: "splitter",
+    hp: 22,
+    speed: 96,
+    armor: 1,
+    bounty: 3,
+    radius: 27,
+    leak: 1,
+    splits: 2,
+  },
+  warden: {
+    kind: "warden",
+    hp: 28,
+    speed: 88,
+    armor: 3,
+    bounty: 6,
+    radius: 27,
+    leak: 2,
+    warded: true,
+  },
+  boss: { kind: "boss", hp: 300, speed: 62, armor: 10, bounty: 60, radius: 62, leak: 8 },
+};
+
+/** damage a single-target shot lands on a warded enemy, as a percentage */
+export const WARD_REDUCTION_PCT = 20;
+
+// -- economy -----------------------------------------------------------------
+export const START_EMBERS = 50;
+/** embers for a correct answer: base + difficulty bonus, both integers */
+export const EMBER_BASE = 6;
+export const EMBER_DIFF_BONUS = 16;
+/** the anvil stays dark this long after a wrong answer */
+export const QUENCH_SECONDS = 1.15;
+/** each correct answer adds this much overcharge, in percent */
+export const OVERCHARGE_PER_ANSWER = 9;
+export const OVERCHARGE_MAX = 100;
+/** seconds you get to answer the overcharge problem */
+export const OVERCHARGE_WINDOW = 7;
+/** how far back along the path the shockwave throws survivors */
+export const OVERCHARGE_KNOCKBACK = 150;
+export const OVERCHARGE_STUN = 1.4;
+
+// -- pacing ------------------------------------------------------------------
+export const INTERMISSION = 7;
+/** embers per unused intermission second when you call the wave early */
+export const EARLY_CALL_BONUS = 4;
+
+// -- juice dials (all in ms unless noted) ------------------------------------
+export const JUICE = {
+  hitstopMortar: 38,
+  hitstopBigKill: 70,
+  hitstopBoss: 95,
+  hitstopOvercharge: 150,
+  hitstopBreach: 60,
+  traumaMortar: 0.15,
+  traumaKill: 0.05,
+  traumaBigKill: 0.24,
+  traumaBoss: 0.62,
+  traumaOvercharge: 1.0,
+  traumaBreach: 0.4,
+  punchKill: 0.018,
+  punchBoss: 0.06,
+  punchOvercharge: 0.09,
+  slowmoOvercharge: 0.16,
+  towerRecoil: 0.19, // scale added on fire
+  towerRecoilMs: 120,
+} as const;
+
+/** hard particle ceiling; the pool never grows past it */
+export const MAX_PARTICLES = 1100;
+export const MAX_POPUPS = 90;

--- a/dynawalla/games/siege/src/game/path.ts
+++ b/dynawalla/games/siege/src/game/path.ts
@@ -1,0 +1,146 @@
+/**
+ * The lava channel. A serpentine polyline with rounded corners, resampled to a
+ * dense arc-length table so an enemy's position is a single array lookup.
+ *
+ * Lanes sit on odd grid rows; the rows between them are the buildable plots, so
+ * a well-placed tower covers the lane above AND the lane below. That is the
+ * whole placement decision and it is legible without a word of tutorial.
+ */
+import { BOARD, CELL } from "./constants.ts";
+
+export type Vec = { x: number; y: number };
+
+const R = 62; // corner radius
+
+/** lane rows 0,2,4,6,8 → y centres; connectors at column 7.5 / 1.5 alternating */
+function waypoints(): Vec[] {
+  const y = (row: number) => (row + 0.5) * CELL;
+  const x = (col: number) => (col + 0.5) * CELL;
+  return [
+    { x: -70, y: y(0) },
+    { x: x(7), y: y(0) },
+    { x: x(7), y: y(2) },
+    { x: x(1), y: y(2) },
+    { x: x(1), y: y(4) },
+    { x: x(7), y: y(4) },
+    { x: x(7), y: y(6) },
+    { x: x(1), y: y(6) },
+    { x: x(1), y: y(8) },
+    { x: BOARD / 2, y: y(8) },
+  ];
+}
+
+function roundCorners(pts: Vec[], radius: number): Vec[] {
+  const out: Vec[] = [pts[0] as Vec];
+  for (let i = 1; i < pts.length - 1; i++) {
+    const p = pts[i] as Vec;
+    const a = pts[i - 1] as Vec;
+    const b = pts[i + 1] as Vec;
+    const d1 = Math.hypot(p.x - a.x, p.y - a.y);
+    const d2 = Math.hypot(b.x - p.x, b.y - p.y);
+    const r = Math.min(radius, d1 / 2, d2 / 2);
+    const u1 = { x: (a.x - p.x) / d1, y: (a.y - p.y) / d1 };
+    const u2 = { x: (b.x - p.x) / d2, y: (b.y - p.y) / d2 };
+    const s = { x: p.x + u1.x * r, y: p.y + u1.y * r };
+    const e = { x: p.x + u2.x * r, y: p.y + u2.y * r };
+    out.push(s);
+    const STEPS = 9;
+    for (let k = 1; k < STEPS; k++) {
+      const t = k / STEPS;
+      const mt = 1 - t;
+      out.push({
+        x: mt * mt * s.x + 2 * mt * t * p.x + t * t * e.x,
+        y: mt * mt * s.y + 2 * mt * t * p.y + t * t * e.y,
+      });
+    }
+    out.push(e);
+  }
+  out.push(pts[pts.length - 1] as Vec);
+  return out;
+}
+
+export type PathData = {
+  pts: readonly Vec[];
+  /** cumulative arc length at each point */
+  cum: readonly number[];
+  length: number;
+  /** where the forge core sits */
+  core: Vec;
+  /** where the rift spits enemies out */
+  rift: Vec;
+  at(s: number, out: Vec): Vec;
+  /** unit tangent at arc length s */
+  dirAt(s: number, out: Vec): Vec;
+  /** shortest distance from a point to the channel centre line */
+  distanceTo(x: number, y: number): number;
+};
+
+export function buildPath(): PathData {
+  const pts = roundCorners(waypoints(), R);
+  const cum: number[] = [0];
+  for (let i = 1; i < pts.length; i++) {
+    const a = pts[i - 1] as Vec;
+    const b = pts[i] as Vec;
+    cum.push((cum[i - 1] as number) + Math.hypot(b.x - a.x, b.y - a.y));
+  }
+  const length = cum[cum.length - 1] as number;
+
+  const seek = (s: number): number => {
+    // binary search the cumulative table
+    let lo = 0;
+    let hi = cum.length - 1;
+    while (lo < hi - 1) {
+      const mid = (lo + hi) >> 1;
+      if ((cum[mid] as number) <= s) lo = mid;
+      else hi = mid;
+    }
+    return lo;
+  };
+
+  const at = (s: number, out: Vec): Vec => {
+    const c = Math.max(0, Math.min(length, s));
+    const i = seek(c);
+    const a = pts[i] as Vec;
+    const b = (pts[i + 1] ?? a) as Vec;
+    const seg = (cum[i + 1] ?? (cum[i] as number)) - (cum[i] as number);
+    const t = seg > 0 ? (c - (cum[i] as number)) / seg : 0;
+    out.x = a.x + (b.x - a.x) * t;
+    out.y = a.y + (b.y - a.y) * t;
+    return out;
+  };
+
+  const dirAt = (s: number, out: Vec): Vec => {
+    const c = Math.max(0, Math.min(length - 0.01, s));
+    const i = seek(c);
+    const a = pts[i] as Vec;
+    const b = (pts[i + 1] ?? a) as Vec;
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const m = Math.hypot(dx, dy) || 1;
+    out.x = dx / m;
+    out.y = dy / m;
+    return out;
+  };
+
+  const distanceTo = (x: number, y: number): number => {
+    let best = Infinity;
+    for (let i = 0; i < pts.length - 1; i++) {
+      const a = pts[i] as Vec;
+      const b = pts[i + 1] as Vec;
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      const l2 = dx * dx + dy * dy;
+      let t = l2 > 0 ? ((x - a.x) * dx + (y - a.y) * dy) / l2 : 0;
+      t = t < 0 ? 0 : t > 1 ? 1 : t;
+      const px = a.x + dx * t;
+      const py = a.y + dy * t;
+      const d = Math.hypot(x - px, y - py);
+      if (d < best) best = d;
+    }
+    return best;
+  };
+
+  const core = pts[pts.length - 1] as Vec;
+  const rift = pts[0] as Vec;
+  return { pts, cum, length, core, rift, at, dirAt, distanceTo };
+}

--- a/dynawalla/games/siege/src/game/state.ts
+++ b/dynawalla/games/siege/src/game/state.ts
@@ -1,0 +1,737 @@
+/**
+ * The whole world, and the pure-ish step that advances it.
+ *
+ * The simulation knows nothing about canvases, DOM or audio: it calls into an
+ * `Effects` sink. That is what makes it testable and what keeps the render
+ * layer free to be as loud as it likes.
+ */
+import {
+  BOARD,
+  CHAIN_FALLOFF,
+  CORE_MAX_HP,
+  ENEMIES,
+  EMBER_BASE,
+  EMBER_DIFF_BONUS,
+  INTERMISSION,
+  OVERCHARGE_KNOCKBACK,
+  OVERCHARGE_STUN,
+  START_EMBERS,
+  TOWERS,
+  MAX_LEVEL,
+  towerDamage,
+  towerLinks,
+  towerRange,
+  towerRate,
+  towerSplash,
+  towerUpgradeCost,
+  WARD_REDUCTION_PCT,
+  type EnemyKind,
+  type TowerKind,
+} from "./constants.ts";
+import { buildPath, type PathData, type Vec } from "./path.ts";
+import { buildPlots, type Plot } from "./board.ts";
+import { buildWave, mathFloor, type WaveSpec } from "./waves.ts";
+import { makeRng, type Rng } from "../core/rng.ts";
+
+export type Phase = "intermission" | "wave" | "defeat";
+
+export type Enemy = {
+  alive: boolean;
+  kind: EnemyKind;
+  hp: number;
+  maxHp: number;
+  s: number;
+  x: number;
+  y: number;
+  dirX: number;
+  dirY: number;
+  speed: number;
+  armor: number;
+  bounty: number;
+  radius: number;
+  leak: number;
+  warded: boolean;
+  splits: number;
+  stun: number;
+  hitFlash: number;
+  born: number;
+  phase: number;
+  /** damage since the last number popped, so fast towers do not stack a column */
+  popAcc: number;
+  popAt: number;
+};
+
+export type Tower = {
+  id: number;
+  plotId: number;
+  kind: TowerKind;
+  level: number;
+  x: number;
+  y: number;
+  cooldown: number;
+  /** 0..1 charge, drawn as heat — the fire rate is visible without a number */
+  heat: number;
+  recoil: number;
+  angle: number;
+  shots: number;
+  bornAt: number;
+};
+
+export type Shot = {
+  alive: boolean;
+  kind: TowerKind;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  tx: number;
+  ty: number;
+  dmg: number;
+  splash: number;
+  life: number;
+  target: Enemy | null;
+  /** ring buffer of the last 6 positions, for the ribbon trail */
+  trail: Float32Array;
+  trailN: number;
+};
+
+export type Arc = { pts: number[]; life: number; maxLife: number; dmg: number };
+
+export type Popup = {
+  alive: boolean;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  maxLife: number;
+  text: string;
+  tone: 0 | 1 | 2; // 0 damage, 1 embers, 2 breach
+  big: boolean;
+};
+
+export type Effects = {
+  fire(t: Tower, angle: number): void;
+  impact(x: number, y: number, kind: TowerKind, dmg: number, splash: number): void;
+  hurt(e: Enemy, dmg: number, x: number, y: number): void;
+  kill(e: Enemy): void;
+  leak(e: Enemy): void;
+  build(t: Tower): void;
+  upgrade(t: Tower): void;
+  earn(amount: number, worldX: number, worldY: number): void;
+  waveStart(spec: WaveSpec): void;
+  waveClear(n: number): void;
+  overchargeBlast(x: number, y: number, dmg: number): void;
+  defeat(wave: number): void;
+};
+
+export const NO_EFFECTS: Effects = {
+  fire: () => {},
+  impact: () => {},
+  hurt: () => {},
+  kill: () => {},
+  leak: () => {},
+  build: () => {},
+  upgrade: () => {},
+  earn: () => {},
+  waveStart: () => {},
+  waveClear: () => {},
+  overchargeBlast: () => {},
+  defeat: () => {},
+};
+
+export type State = {
+  seed: number;
+  rng: Rng;
+  path: PathData;
+  plots: Plot[];
+  enemies: Enemy[];
+  towers: Tower[];
+  shots: Shot[];
+  arcs: Arc[];
+  popups: Popup[];
+  phase: Phase;
+  wave: number;
+  spec: WaveSpec;
+  /** seconds into the current wave */
+  waveT: number;
+  spawnIdx: number;
+  intermissionT: number;
+  embers: number;
+  coreHp: number;
+  coreFlash: number;
+  overcharge: number;
+  /** integers, for the run summary */
+  stats: { kills: number; leaked: number; earned: number; correct: number; wrong: number };
+  t: number;
+  nextTowerId: number;
+  /** cumulative HP left to arrive this wave, for the throughput readout */
+  hpRemaining: number;
+};
+
+const tmp: Vec = { x: 0, y: 0 };
+const tmp2: Vec = { x: 0, y: 0 };
+
+export function createState(seed: number): State {
+  const path = buildPath();
+  const plots = buildPlots(path);
+  const spec = buildWave(1, seed);
+  return {
+    seed,
+    rng: makeRng(seed ^ 0x51e6e),
+    path,
+    plots,
+    enemies: [],
+    towers: [],
+    shots: [],
+    arcs: [],
+    popups: [],
+    phase: "intermission",
+    wave: 1,
+    spec,
+    waveT: 0,
+    spawnIdx: 0,
+    intermissionT: INTERMISSION,
+    embers: START_EMBERS,
+    coreHp: CORE_MAX_HP,
+    coreFlash: 0,
+    overcharge: 0,
+    stats: { kills: 0, leaked: 0, earned: 0, correct: 0, wrong: 0 },
+    t: 0,
+    nextTowerId: 1,
+    hpRemaining: spec.totalHp,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// queries
+// ---------------------------------------------------------------------------
+
+export function towerDps(t: Tower): number {
+  const dmg = towerDamage(t.kind, t.level);
+  const rate = towerRate(t.kind, t.level);
+  const links = towerLinks(t.kind, t.level);
+  // chain's later links are weaker; count them at falloff so the readout is honest
+  let mult = 1;
+  if (links > 1) {
+    mult = 0;
+    for (let i = 0; i < links; i++) mult += Math.pow(CHAIN_FALLOFF, i);
+  }
+  return Math.round(dmg * rate * mult);
+}
+
+export function totalDps(s: State): number {
+  let d = 0;
+  for (const t of s.towers) d += towerDps(t);
+  return d;
+}
+
+export function towerAt(s: State, plotId: number): Tower | null {
+  const p = s.plots[plotId];
+  if (!p || p.towerId < 0) return null;
+  return s.towers.find((t) => t.id === p.towerId) ?? null;
+}
+
+export function upgradeCost(t: Tower): number | null {
+  return towerUpgradeCost(t.kind, t.level);
+}
+
+export function emberReward(difficulty: number): number {
+  return EMBER_BASE + Math.round(EMBER_DIFF_BONUS * Math.max(0, Math.min(1, difficulty)));
+}
+
+// ---------------------------------------------------------------------------
+// mutations
+// ---------------------------------------------------------------------------
+
+export function tryBuild(s: State, plotId: number, kind: TowerKind, fx: Effects): boolean {
+  const plot = s.plots[plotId];
+  if (!plot || plot.towerId >= 0) return false;
+  const spec = TOWERS[kind];
+  if (s.embers < spec.cost) return false;
+  s.embers -= spec.cost;
+  const t: Tower = {
+    id: s.nextTowerId++,
+    plotId,
+    kind,
+    level: 0,
+    x: plot.x,
+    y: plot.y,
+    cooldown: 0.35,
+    heat: 0,
+    recoil: 0,
+    angle: -Math.PI / 2,
+    shots: 0,
+    bornAt: s.t,
+  };
+  s.towers.push(t);
+  plot.towerId = t.id;
+  fx.build(t);
+  return true;
+}
+
+export function applyUpgrade(s: State, tower: Tower, fx: Effects): boolean {
+  const cost = upgradeCost(tower);
+  if (cost === null || s.embers < cost || tower.level >= MAX_LEVEL) return false;
+  s.embers -= cost;
+  tower.level++;
+  fx.upgrade(tower);
+  return true;
+}
+
+export function grantEmbers(s: State, amount: number, x: number, y: number, fx: Effects): void {
+  s.embers += amount;
+  s.stats.earned += amount;
+  fx.earn(amount, x, y);
+}
+
+export function callWaveEarly(s: State): number {
+  if (s.phase !== "intermission") return 0;
+  const bonus = Math.max(0, Math.floor(s.intermissionT));
+  s.intermissionT = 0;
+  return bonus;
+}
+
+// ---------------------------------------------------------------------------
+// damage
+// ---------------------------------------------------------------------------
+
+/** exact integer damage: armour is flat, wards are a percentage, floor is 1 */
+export function computeDamage(base: number, e: Enemy, singleTarget: boolean): number {
+  let d = base - e.armor;
+  if (singleTarget && e.warded) d = Math.floor((d * WARD_REDUCTION_PCT) / 100);
+  return d < 1 ? 1 : d;
+}
+
+function pushPopup(s: State, x: number, y: number, text: string, tone: 0 | 1 | 2, big: boolean): void {
+  let p = s.popups.find((q) => !q.alive);
+  if (!p) {
+    if (s.popups.length >= 90) return;
+    p = {
+      alive: false,
+      x: 0,
+      y: 0,
+      vx: 0,
+      vy: 0,
+      life: 0,
+      maxLife: 0,
+      text: "",
+      tone: 0,
+      big: false,
+    };
+    s.popups.push(p);
+  }
+  p.alive = true;
+  p.x = x;
+  p.y = y;
+  p.vx = s.rng.r(-44, 44);
+  p.vy = -64 - s.rng.f() * 34;
+  p.maxLife = big ? 1.0 : 0.7;
+  p.life = p.maxLife;
+  p.text = text;
+  p.tone = tone;
+  p.big = big;
+}
+
+export function damageEnemy(
+  s: State,
+  e: Enemy,
+  base: number,
+  singleTarget: boolean,
+  fx: Effects,
+  showNumber = true,
+): void {
+  if (!e.alive) return;
+  const d = computeDamage(base, e, singleTarget);
+  e.hp -= d;
+  e.hitFlash = 0.11;
+  if (showNumber) {
+    // batch: six shots a second from four towers is a column of unreadable
+    // numbers. One bigger number every 140 ms says more and costs less.
+    e.popAcc += d;
+    if (s.t - e.popAt >= 0.14) {
+      pushPopup(s, e.x, e.y - e.radius, String(e.popAcc), 0, e.kind === "boss");
+      e.popAcc = 0;
+      e.popAt = s.t;
+    }
+  }
+  fx.hurt(e, d, e.x, e.y);
+  if (e.hp <= 0) killEnemy(s, e, fx);
+}
+
+export function killEnemy(s: State, e: Enemy, fx: Effects): void {
+  if (!e.alive) return;
+  e.alive = false;
+  if (e.popAcc > 0) {
+    pushPopup(s, e.x, e.y - e.radius, String(e.popAcc), 0, e.kind === "boss");
+    e.popAcc = 0;
+  }
+  s.stats.kills++;
+  s.embers += e.bounty;
+  s.stats.earned += e.bounty;
+  pushPopup(s, e.x, e.y - e.radius - 10, `+${e.bounty}`, 1, false);
+  fx.kill(e);
+  if (e.splits > 0) {
+    for (let i = 0; i < e.splits; i++) {
+      const child = spawnEnemy(s, "shard", Math.max(1, Math.round(e.maxHp * 0.3)));
+      child.s = Math.max(0, e.s - 8 - i * 16);
+      child.speed *= 1.16;
+      refreshPosition(s, child);
+    }
+  }
+}
+
+export function spawnEnemy(s: State, kind: EnemyKind, hp: number): Enemy {
+  const base = ENEMIES[kind];
+  let e = s.enemies.find((q) => !q.alive);
+  if (!e) {
+    e = {
+      alive: false,
+      kind,
+      hp: 0,
+      maxHp: 0,
+      s: 0,
+      x: 0,
+      y: 0,
+      dirX: 1,
+      dirY: 0,
+      speed: 0,
+      armor: 0,
+      bounty: 0,
+      radius: 0,
+      leak: 0,
+      warded: false,
+      splits: 0,
+      stun: 0,
+      hitFlash: 0,
+      born: 0,
+      phase: 0,
+      popAcc: 0,
+      popAt: 0,
+    };
+    s.enemies.push(e);
+  }
+  e.alive = true;
+  e.kind = kind;
+  e.hp = hp;
+  e.maxHp = hp;
+  e.s = 0;
+  e.speed = base.speed;
+  e.armor = base.armor;
+  e.bounty = base.bounty;
+  e.radius = base.radius;
+  e.leak = base.leak;
+  e.warded = base.warded ?? false;
+  e.splits = base.splits ?? 0;
+  e.stun = 0;
+  e.hitFlash = 0;
+  e.born = s.t;
+  e.phase = s.rng.r(0, Math.PI * 2);
+  e.popAcc = 0;
+  e.popAt = 0;
+  refreshPosition(s, e);
+  return e;
+}
+
+function refreshPosition(s: State, e: Enemy): void {
+  s.path.at(e.s, tmp);
+  s.path.dirAt(e.s, tmp2);
+  e.x = tmp.x;
+  e.y = tmp.y;
+  e.dirX = tmp2.x;
+  e.dirY = tmp2.y;
+}
+
+// ---------------------------------------------------------------------------
+// the step
+// ---------------------------------------------------------------------------
+
+function acquire(s: State, t: Tower): Enemy | null {
+  const range = towerRange(t.kind, t.level);
+  const r2 = range * range;
+  let best: Enemy | null = null;
+  let bestS = -1;
+  for (const e of s.enemies) {
+    if (!e.alive) continue;
+    const dx = e.x - t.x;
+    const dy = e.y - t.y;
+    if (dx * dx + dy * dy > r2) continue;
+    if (e.s > bestS) {
+      bestS = e.s;
+      best = e;
+    }
+  }
+  return best;
+}
+
+function makeShot(s: State): Shot {
+  let sh = s.shots.find((q) => !q.alive);
+  if (!sh) {
+    sh = {
+      alive: false,
+      kind: "bolt",
+      x: 0,
+      y: 0,
+      vx: 0,
+      vy: 0,
+      tx: 0,
+      ty: 0,
+      dmg: 0,
+      splash: 0,
+      life: 0,
+      target: null,
+      trail: new Float32Array(12),
+      trailN: 0,
+    };
+    s.shots.push(sh);
+  }
+  sh.trailN = 0;
+  return sh;
+}
+
+function fireTower(s: State, t: Tower, target: Enemy, fx: Effects): void {
+  const dmg = towerDamage(t.kind, t.level);
+  const angle = Math.atan2(target.y - t.y, target.x - t.x);
+  t.angle = angle;
+  t.recoil = 1;
+  t.shots++;
+  fx.fire(t, angle);
+
+  if (t.kind === "chain") {
+    // instant arc: hop to the nearest un-hit enemy each link, damage falls off
+    const links = towerLinks(t.kind, t.level);
+    const hit: Enemy[] = [];
+    let cur: Enemy | null = target;
+    let d = dmg;
+    const pts: number[] = [t.x, t.y];
+    while (cur && hit.length < links) {
+      hit.push(cur);
+      pts.push(cur.x, cur.y);
+      damageEnemy(s, cur, d, false, fx);
+      d = Math.max(1, Math.floor(d * CHAIN_FALLOFF));
+      let nx: Enemy | null = null;
+      let nd = 190 * 190;
+      for (const e of s.enemies) {
+        if (!e.alive || hit.includes(e)) continue;
+        const ddx = e.x - cur.x;
+        const ddy = e.y - cur.y;
+        const q = ddx * ddx + ddy * ddy;
+        if (q < nd) {
+          nd = q;
+          nx = e;
+        }
+      }
+      cur = nx;
+    }
+    s.arcs.push({ pts, life: 0.19, maxLife: 0.19, dmg });
+    if (s.arcs.length > 26) s.arcs.shift();
+    return;
+  }
+
+  const sh = makeShot(s);
+  sh.alive = true;
+  sh.kind = t.kind;
+  sh.x = t.x + Math.cos(angle) * 22;
+  sh.y = t.y + Math.sin(angle) * 22;
+  sh.dmg = dmg;
+  sh.splash = t.kind === "mortar" ? towerSplash(t.kind, t.level) : 0;
+  sh.target = t.kind === "bolt" ? target : null;
+
+  if (t.kind === "bolt") {
+    const sp = 820;
+    sh.vx = Math.cos(angle) * sp;
+    sh.vy = Math.sin(angle) * sp;
+    sh.life = 1.1;
+  } else {
+    // mortar leads the target: aim where it will be when the shell lands
+    const flight = Math.hypot(target.x - t.x, target.y - t.y) / 430;
+    sh.tx = target.x + target.dirX * target.speed * flight;
+    sh.ty = target.y + target.dirY * target.speed * flight;
+    const d = Math.hypot(sh.tx - sh.x, sh.ty - sh.y) || 1;
+    sh.vx = ((sh.tx - sh.x) / d) * 430;
+    sh.vy = ((sh.ty - sh.y) / d) * 430;
+    sh.life = d / 430;
+  }
+}
+
+function splashAt(s: State, x: number, y: number, radius: number, dmg: number, fx: Effects): void {
+  const r2 = radius * radius;
+  for (const e of s.enemies) {
+    if (!e.alive) continue;
+    const dx = e.x - x;
+    const dy = e.y - y;
+    const q = dx * dx + dy * dy;
+    if (q > r2) continue;
+    // full damage at the centre, two thirds at the rim — integers throughout
+    const falloff = 100 - Math.round((Math.sqrt(q) / radius) * 34);
+    damageEnemy(s, e, Math.max(1, Math.floor((dmg * falloff) / 100)), false, fx);
+  }
+}
+
+export function detonateOvercharge(s: State, fx: Effects): number {
+  const dmg = 60 + s.wave * 14;
+  const cx = s.path.core.x;
+  const cy = s.path.core.y;
+  for (const e of s.enemies) {
+    if (!e.alive) continue;
+    e.stun = OVERCHARGE_STUN;
+    e.s = Math.max(0, e.s - OVERCHARGE_KNOCKBACK);
+    refreshPosition(s, e);
+    damageEnemy(s, e, dmg, false, fx, false);
+  }
+  fx.overchargeBlast(cx, cy, dmg);
+  return dmg;
+}
+
+export function step(s: State, dt: number, fx: Effects): void {
+  s.t += dt;
+  s.coreFlash = Math.max(0, s.coreFlash - dt * 2.4);
+
+  // -- phase ---------------------------------------------------------------
+  if (s.phase === "intermission") {
+    s.intermissionT -= dt;
+    if (s.intermissionT <= 0) {
+      s.phase = "wave";
+      s.waveT = 0;
+      s.spawnIdx = 0;
+      s.hpRemaining = s.spec.totalHp;
+      fx.waveStart(s.spec);
+    }
+  } else if (s.phase === "wave") {
+    s.waveT += dt;
+    while (s.spawnIdx < s.spec.orders.length) {
+      const o = s.spec.orders[s.spawnIdx];
+      if (!o || o.at > s.waveT) break;
+      spawnEnemy(s, o.kind, o.hp);
+      s.spawnIdx++;
+    }
+    const anyAlive = s.enemies.some((e) => e.alive);
+    if (s.spawnIdx >= s.spec.orders.length && !anyAlive) {
+      fx.waveClear(s.wave);
+      s.wave++;
+      s.spec = buildWave(s.wave, s.seed);
+      s.phase = "intermission";
+      s.intermissionT = INTERMISSION;
+    }
+  }
+
+  // -- enemies -------------------------------------------------------------
+  let liveHp = 0;
+  for (const e of s.enemies) {
+    if (!e.alive) continue;
+    e.hitFlash = Math.max(0, e.hitFlash - dt);
+    if (e.stun > 0) {
+      e.stun -= dt;
+    } else {
+      e.s += e.speed * dt;
+    }
+    if (e.s >= s.path.length) {
+      e.alive = false;
+      s.stats.leaked++;
+      s.coreHp -= e.leak;
+      s.coreFlash = 1;
+      fx.leak(e);
+      if (s.coreHp <= 0 && s.phase !== "defeat") {
+        s.coreHp = 0;
+        s.phase = "defeat";
+        fx.defeat(s.wave);
+      }
+      continue;
+    }
+    refreshPosition(s, e);
+    liveHp += e.hp;
+  }
+  // health still to arrive, so the throughput readout means something
+  let pending = 0;
+  for (let i = s.spawnIdx; i < s.spec.orders.length; i++) pending += s.spec.orders[i]?.hp ?? 0;
+  s.hpRemaining = liveHp + (s.phase === "wave" ? pending : s.spec.totalHp);
+
+  if (s.phase === "defeat") return;
+
+  // -- towers --------------------------------------------------------------
+  for (const t of s.towers) {
+    const rate = towerRate(t.kind, t.level);
+    t.recoil = Math.max(0, t.recoil - dt / 0.12);
+    if (t.cooldown > 0) t.cooldown -= dt;
+    t.heat = t.cooldown <= 0 ? 1 : 1 - t.cooldown * rate;
+    if (t.cooldown > 0) continue;
+    const target = acquire(s, t);
+    if (!target) continue;
+    t.cooldown = 1 / rate;
+    fireTower(s, t, target, fx);
+  }
+
+  // -- shots ---------------------------------------------------------------
+  for (const sh of s.shots) {
+    if (!sh.alive) continue;
+    // trail ring buffer, newest first
+    for (let i = 10; i >= 0; i -= 2) {
+      sh.trail[i + 2] = sh.trail[i] as number;
+      sh.trail[i + 3] = sh.trail[i + 1] as number;
+    }
+    sh.trail[0] = sh.x;
+    sh.trail[1] = sh.y;
+    if (sh.trailN < 6) sh.trailN++;
+
+    if (sh.kind === "bolt") {
+      const tgt = sh.target;
+      if (tgt && tgt.alive) {
+        // light homing: reads as a guided bolt, never as a missed shot
+        const a = Math.atan2(tgt.y - sh.y, tgt.x - sh.x);
+        const cur = Math.atan2(sh.vy, sh.vx);
+        let d = a - cur;
+        while (d > Math.PI) d -= Math.PI * 2;
+        while (d < -Math.PI) d += Math.PI * 2;
+        const na = cur + Math.max(-9 * dt, Math.min(9 * dt, d));
+        sh.vx = Math.cos(na) * 820;
+        sh.vy = Math.sin(na) * 820;
+      }
+      sh.x += sh.vx * dt;
+      sh.y += sh.vy * dt;
+      sh.life -= dt;
+      if (tgt && tgt.alive) {
+        const dx = tgt.x - sh.x;
+        const dy = tgt.y - sh.y;
+        if (dx * dx + dy * dy < (tgt.radius + 9) * (tgt.radius + 9)) {
+          fx.impact(sh.x, sh.y, "bolt", sh.dmg, 0);
+          damageEnemy(s, tgt, sh.dmg, true, fx);
+          sh.alive = false;
+          continue;
+        }
+      }
+      if (sh.life <= 0 || sh.x < -80 || sh.x > BOARD + 80 || sh.y < -80 || sh.y > BOARD + 80) {
+        sh.alive = false;
+      }
+    } else {
+      sh.x += sh.vx * dt;
+      sh.y += sh.vy * dt;
+      sh.life -= dt;
+      if (sh.life <= 0) {
+        fx.impact(sh.tx, sh.ty, "mortar", sh.dmg, sh.splash);
+        splashAt(s, sh.tx, sh.ty, sh.splash, sh.dmg, fx);
+        sh.alive = false;
+      }
+    }
+  }
+
+  // -- arcs and popups -----------------------------------------------------
+  for (let i = s.arcs.length - 1; i >= 0; i--) {
+    const a = s.arcs[i] as Arc;
+    a.life -= dt;
+    if (a.life <= 0) s.arcs.splice(i, 1);
+  }
+  for (const p of s.popups) {
+    if (!p.alive) continue;
+    p.life -= dt;
+    p.x += p.vx * dt;
+    p.y += p.vy * dt;
+    p.vy += 130 * dt;
+    if (p.life <= 0) p.alive = false;
+  }
+}
+
+export function mathFloorFor(wave: number): number {
+  return mathFloor(wave);
+}
+
+export { INTERMISSION };

--- a/dynawalla/games/siege/src/game/waves.ts
+++ b/dynawalla/games/siege/src/game/waves.ts
@@ -1,0 +1,125 @@
+/**
+ * Wave generation. Seeded and deterministic: the same seed plays the same siege
+ * every time, which is what makes a run comparable and a bug reproducible.
+ *
+ * The curve is deliberately superlinear. Wave 1 is eight shards. Wave 20 is a
+ * flood you can hear coming.
+ */
+import { ENEMIES, type EnemyKind } from "./constants.ts";
+import { makeRng } from "../core/rng.ts";
+
+export type SpawnOrder = { kind: EnemyKind; hp: number; at: number };
+
+export type WaveSpec = {
+  n: number;
+  orders: SpawnOrder[];
+  /** integer — shown in the banner so the player can do the throughput sum */
+  totalHp: number;
+  count: number;
+  duration: number;
+  hasBoss: boolean;
+};
+
+/**
+ * Superlinear health growth — integers only, so damage maths stays exact.
+ * Wave 1 is eight shards you could sneeze at. Wave 20 shards have 430 health
+ * each and there are forty-five of them.
+ */
+export function hpScale(n: number): number {
+  const k = n - 1;
+  return 1 + 0.55 * k + 0.115 * k * k;
+}
+
+export function scaledHp(kind: EnemyKind, n: number): number {
+  return Math.max(1, Math.round((ENEMIES[kind]?.hp ?? 10) * hpScale(n)));
+}
+
+function unlocked(n: number): EnemyKind[] {
+  const ks: EnemyKind[] = ["shard"];
+  if (n >= 3) ks.push("runner");
+  if (n >= 5) ks.push("brute");
+  if (n >= 8) ks.push("splitter");
+  if (n >= 11) ks.push("warden");
+  return ks;
+}
+
+/** weight shifts toward the heavy stuff as the siege wears on */
+function weight(kind: EnemyKind, n: number): number {
+  switch (kind) {
+    case "shard":
+      return Math.max(1, 10 - n * 0.4);
+    case "runner":
+      return Math.min(6, 1 + (n - 3) * 0.5);
+    case "brute":
+      return Math.min(6, 1 + (n - 5) * 0.5);
+    case "splitter":
+      return Math.min(5, 1 + (n - 8) * 0.45);
+    case "warden":
+      return Math.min(5, 1 + (n - 11) * 0.45);
+    default:
+      return 0;
+  }
+}
+
+export function buildWave(n: number, seed: number): WaveSpec {
+  const rng = makeRng(seed ^ (n * 0x9e3779b1));
+  const kinds = unlocked(n);
+  const count = Math.min(90, 7 + Math.floor(n * 1.9));
+  const gap = Math.max(0.13, 0.7 - 0.021 * n);
+  const hasBoss = n % 5 === 0;
+
+  // allocate the roster by weight, then group into packs so waves have texture
+  const totals = new Map<EnemyKind, number>();
+  const weights = kinds.map((k) => weight(k, n));
+  const sum = weights.reduce((a, b) => a + b, 0);
+  let assigned = 0;
+  kinds.forEach((k, i) => {
+    const share = i === kinds.length - 1 ? count - assigned : Math.round((count * (weights[i] as number)) / sum);
+    const c = Math.max(0, share);
+    assigned += c;
+    if (c > 0) totals.set(k, c);
+  });
+
+  const packs: { kind: EnemyKind; count: number }[] = [];
+  for (const [kind, c] of totals) {
+    let left = c;
+    while (left > 0) {
+      const take = Math.min(left, rng.i(3, 8));
+      packs.push({ kind, count: take });
+      left -= take;
+    }
+  }
+  rng.shuffle(packs);
+
+  const orders: SpawnOrder[] = [];
+  let t = 0;
+  for (const pack of packs) {
+    const packGap = gap * (pack.kind === "runner" ? 0.6 : 1);
+    for (let i = 0; i < pack.count; i++) {
+      orders.push({ kind: pack.kind, hp: scaledHp(pack.kind, n), at: t });
+      t += packGap * rng.r(0.86, 1.14);
+    }
+    t += gap * rng.r(0.9, 2.1); // breath between packs
+  }
+
+  if (hasBoss) {
+    const bossHp = Math.max(1, Math.round(ENEMIES.boss.hp * hpScale(n) * 0.62));
+    orders.push({ kind: "boss", hp: bossHp, at: t * 0.55 });
+  }
+
+  orders.sort((a, b) => a.at - b.at);
+  const totalHp = orders.reduce((acc, o) => acc + o.hp, 0);
+  return {
+    n,
+    orders,
+    totalHp,
+    count: orders.length,
+    duration: orders.length > 0 ? (orders[orders.length - 1] as SpawnOrder).at : 0,
+    hasBoss,
+  };
+}
+
+/** the maths floor the wave number justifies — never lowers where the child already is */
+export function mathFloor(n: number): number {
+  return Math.min(0.72, 0.035 * (n - 1));
+}

--- a/dynawalla/games/siege/src/index.ts
+++ b/dynawalla/games/siege/src/index.ts
@@ -1,0 +1,20 @@
+/**
+ * SIEGE — a molten-forge tower defence.
+ *
+ * You never buy a tower with gold you were given. You buy it with arithmetic:
+ * the anvil at the bottom of the screen mints embers for every problem you
+ * strike, and embers are the only thing that holds the line. Upgrades cost a
+ * harder problem. When the wave is about to break through, the overcharge asks
+ * one big question and answers it with a shockwave.
+ */
+import "./ui/styles.css";
+import type { Host } from "./contract.ts";
+import { Siege } from "./mount.ts";
+
+export type { Host, Question } from "./contract.ts";
+export { createStubHost } from "./stubHost.ts";
+
+export function mount(el: HTMLElement, host: Host): { unmount(): void } {
+  const game = new Siege(el, host);
+  return { unmount: () => game.destroy() };
+}

--- a/dynawalla/games/siege/src/main.ts
+++ b/dynawalla/games/siege/src/main.ts
@@ -1,0 +1,12 @@
+/** Standalone dev entry: the local stub Host, mounted into #app. */
+import { mount } from "./index.ts";
+import { createStubHost } from "./stubHost.ts";
+
+const app = document.getElementById("app");
+if (!app) throw new Error("#app missing");
+
+const host = createStubHost({ seed: 0xf0a9e, difficulty: 0.12 });
+const game = mount(app, host);
+
+(globalThis as unknown as { __siegeHost?: unknown }).__siegeHost = host;
+(globalThis as unknown as { __siegeMount?: unknown }).__siegeMount = game;

--- a/dynawalla/games/siege/src/mount.ts
+++ b/dynawalla/games/siege/src/mount.ts
@@ -1,0 +1,836 @@
+/**
+ * The controller. Owns the loop, the input, and the translation from simulation
+ * events into noise, light and shaking.
+ *
+ * Every juice number in here is named in JUICE (constants.ts) so the feel can be
+ * tuned without reading the code.
+ */
+import type { Host, Question } from "./contract.ts";
+import { Clock, FIXED_DT } from "./core/time.ts";
+import { Camera } from "./core/camera.ts";
+import { makeRng, hashSeed, type Rng } from "./core/rng.ts";
+import { clamp01 } from "./core/easing.ts";
+import { Audio } from "./audio/audio.ts";
+import { Particles, burstSparks, burstShatter, ring, emberMote } from "./render/particles.ts";
+import { bakeBoard } from "./render/bake.ts";
+import { Renderer, computeView, screenToBoard, boardToScreen, type View } from "./render/draw.ts";
+import { Hud } from "./ui/hud.ts";
+import {
+  CORE_MAX_HP,
+  JUICE,
+  OVERCHARGE_MAX,
+  OVERCHARGE_PER_ANSWER,
+  OVERCHARGE_WINDOW,
+  QUENCH_SECONDS,
+  TOWERS,
+  EARLY_CALL_BONUS,
+  type TowerKind,
+} from "./game/constants.ts";
+import {
+  createState,
+  step,
+  tryBuild,
+  applyUpgrade,
+  grantEmbers,
+  callWaveEarly,
+  detonateOvercharge,
+  emberReward,
+  totalDps,
+  towerAt,
+  towerDps,
+  upgradeCost,
+  type Effects,
+  type Enemy,
+  type State,
+  type Tower,
+} from "./game/state.ts";
+import { buildWave, mathFloor, type WaveSpec } from "./game/waves.ts";
+
+/** level-1 throughput for each tower, computed once from the same maths the sim uses */
+const BASE_DPS: Record<TowerKind, number> = {
+  bolt: towerDps({ kind: "bolt", level: 0 } as Tower),
+  mortar: towerDps({ kind: "mortar", level: 0 } as Tower),
+  chain: towerDps({ kind: "chain", level: 0 } as Tower),
+};
+
+type FocusMode =
+  | null
+  | { kind: "overcharge"; q: Question; order: number[]; left: number }
+  | { kind: "upgrade"; q: Question; order: number[]; tower: Tower };
+
+export class Siege {
+  private host: Host;
+  private hud: Hud;
+  private ctx: CanvasRenderingContext2D;
+  private clock = new Clock();
+  private cam = new Camera();
+  private parts = new Particles();
+  private renderer = new Renderer();
+  private audio = new Audio();
+  private rng: Rng;
+  private state: State;
+  private view: View;
+  private ro: ResizeObserver | null = null;
+  private raf = 0;
+  private lastT = 0;
+  private destroyed = false;
+
+  private q: Question | null = null;
+  private order: number[] = [0, 1, 2, 3];
+  private askedAt = 0;
+  private coldUntil = 0;
+  private focus: FocusMode = null;
+  private answering = false;
+
+  private hoverPlot = -1;
+  private selectedPlot = -1;
+  private buildPreview: TowerKind | null = null;
+  private armed: TowerKind | null = null;
+  private hint = 1;
+  private prevEmbers = 0;
+  private prevCoreHp = CORE_MAX_HP;
+  private soundOn = true;
+  private seed: number;
+
+  // instrumentation the playtest reads
+  private frames = 0;
+  private frameAcc = 0;
+  fps = 0;
+  worstFrame = 0;
+
+  private fx: Effects;
+
+  constructor(host: HTMLElement, gameHost: Host) {
+    this.host = gameHost;
+    this.seed = hashSeed(`siege-${Math.floor(Date.now() / 86400000)}`);
+    this.rng = makeRng(this.seed);
+    this.state = createState(this.seed);
+
+    this.hud = new Hud(host, {
+      onAnswer: (i) => this.answer(i),
+      onFocusAnswer: (i) => this.focusAnswer(i),
+      onFocusCancel: () => this.cancelFocus(),
+      onOvercharge: () => this.openOvercharge(),
+      onSpeed: () => this.toggleSpeed(),
+      onSound: () => this.toggleSound(),
+      onRestart: () => this.restart(),
+      onBuy: (k) => this.build(k),
+      onArm: (k) => this.arm(k),
+      onUpgrade: () => this.openUpgrade(),
+      onCallWave: () => this.callWave(),
+    });
+
+    const c = this.hud.canvas.getContext("2d", { alpha: false });
+    if (!c) throw new Error("SIEGE needs a 2d canvas context");
+    this.ctx = c;
+
+    this.cam.reducedMotion = this.host.prefersReducedMotion();
+    this.hud.setReducedMotion(this.cam.reducedMotion);
+
+    this.renderer.setBaked(bakeBoard(this.state.plots, this.state.path));
+    this.view = computeView(1, 1, 1);
+    this.resize();
+
+    this.fx = this.makeEffects();
+
+    if (typeof ResizeObserver !== "undefined") {
+      this.ro = new ResizeObserver(() => this.resize());
+      this.ro.observe(this.hud.board);
+    }
+    window.addEventListener("resize", this.onResize);
+    this.hud.canvas.addEventListener("pointerdown", this.onPointerDown);
+    this.hud.canvas.addEventListener("pointermove", this.onPointerMove);
+    this.hud.canvas.addEventListener("pointerleave", this.onPointerLeave);
+    window.addEventListener("keydown", this.onKey);
+    this.hud.root.addEventListener("pointerdown", this.firstGesture, { once: true });
+
+    this.nextQuestion();
+    this.hud.showBanner("SIEGE", "HOLD THE FORGE");
+    this.syncHud(true);
+
+    (globalThis as unknown as { __siege?: unknown }).__siege = this;
+
+    this.lastT = performance.now();
+    this.raf = requestAnimationFrame(this.frame);
+  }
+
+  // -- lifecycle -----------------------------------------------------------
+
+  private firstGesture = (): void => {
+    void this.audio.start();
+  };
+
+  destroy(): void {
+    this.destroyed = true;
+    cancelAnimationFrame(this.raf);
+    this.ro?.disconnect();
+    window.removeEventListener("resize", this.onResize);
+    window.removeEventListener("keydown", this.onKey);
+    this.hud.destroy();
+    if ((globalThis as unknown as { __siege?: unknown }).__siege === this) {
+      delete (globalThis as unknown as { __siege?: unknown }).__siege;
+    }
+  }
+
+  private onResize = (): void => this.resize();
+
+  private resize(): void {
+    const b = this.hud.board;
+    const w = Math.max(1, b.clientWidth);
+    const h = Math.max(1, b.clientHeight);
+    const dpr = Math.min(2, window.devicePixelRatio || 1);
+    this.hud.canvas.width = Math.round(w * dpr);
+    this.hud.canvas.height = Math.round(h * dpr);
+    this.view = computeView(w, h, dpr);
+  }
+
+  restart(): void {
+    this.state = createState(this.seed + 1);
+    this.seed += 1;
+    this.renderer.setBaked(bakeBoard(this.state.plots, this.state.path));
+    this.parts.clear();
+    this.clock.reset();
+    this.cam.reset();
+    this.hint = 1;
+    this.selectedPlot = -1;
+    this.hoverPlot = -1;
+    this.focus = null;
+    this.coldUntil = 0;
+    this.prevCoreHp = CORE_MAX_HP;
+    this.hud.hideEnd();
+    this.hud.hideFocus();
+    this.hud.hidePop();
+    this.hud.setCold(false);
+    this.hud.setSpeed(1);
+    this.nextQuestion();
+    this.hud.showBanner("RELIT", "HOLD THE FORGE");
+    this.syncHud(true);
+  }
+
+  // -- effects sink --------------------------------------------------------
+
+  private makeEffects(): Effects {
+    const rand = () => this.rng.f();
+    return {
+      fire: (t, angle) => {
+        const bx = t.x + Math.cos(angle) * 26;
+        const by = t.y + Math.sin(angle) * 26;
+        if (t.kind === "bolt") {
+          this.audio.bolt();
+          burstSparks(this.parts, bx, by, 3, 120, rand);
+        } else if (t.kind === "mortar") {
+          this.audio.mortar();
+          burstSparks(this.parts, bx, by, 9, 220, rand);
+          ring(this.parts, bx, by, 46, 0.24, 0.4);
+          this.cam.addTrauma(0.045);
+        } else {
+          this.audio.arc();
+          burstSparks(this.parts, bx, by, 5, 160, rand);
+        }
+      },
+      impact: (x, y, kind, _dmg, splash) => {
+        if (kind === "mortar") {
+          this.clock.hitstop(JUICE.hitstopMortar);
+          this.cam.addTrauma(JUICE.traumaMortar);
+          burstSparks(this.parts, x, y, 26, 400, rand);
+          ring(this.parts, x, y, Math.max(70, splash), 0.4, 0.8);
+          ring(this.parts, x, y, Math.max(70, splash) * 0.6, 0.28, 0.2);
+        } else {
+          burstSparks(this.parts, x, y, 5, 180, rand);
+        }
+      },
+      hurt: (e, _dmg, x, y) => {
+        burstSparks(this.parts, x, y, 2, 130, rand);
+        void e;
+      },
+      kill: (e) => {
+        const big = e.kind === "boss";
+        const heavy = big || e.kind === "brute" || e.radius > 20;
+        burstShatter(this.parts, e.x, e.y, big ? 34 : heavy ? 16 : 9, big ? 460 : 280, e.radius, rand);
+        burstSparks(this.parts, e.x, e.y, big ? 40 : heavy ? 14 : 7, big ? 520 : 260, rand);
+        ring(this.parts, e.x, e.y, big ? 260 : e.radius * 4, big ? 0.75 : 0.34, 0.6);
+        if (big) {
+          this.audio.bossDown();
+          this.clock.hitstop(JUICE.hitstopBoss);
+          this.cam.addTrauma(JUICE.traumaBoss);
+          this.cam.addPunch(JUICE.punchBoss, 0.42);
+          this.cam.flash(0.2, this.clock.wall);
+          this.host.haptic("heavy");
+        } else {
+          this.audio.shatter(heavy ? 1.5 : 1);
+          this.cam.addTrauma(heavy ? JUICE.traumaBigKill : JUICE.traumaKill);
+          if (heavy) {
+            this.clock.hitstop(JUICE.hitstopBigKill);
+            this.cam.addPunch(JUICE.punchKill, 0.24);
+          }
+        }
+      },
+      leak: (e) => {
+        this.audio.breach();
+        this.clock.hitstop(JUICE.hitstopBreach);
+        this.cam.addTrauma(JUICE.traumaBreach);
+        burstSparks(this.parts, e.x, e.y, 22, 340, rand);
+        ring(this.parts, e.x, e.y, 150, 0.5, 0);
+        this.host.haptic("failure");
+      },
+      build: (t) => {
+        this.audio.build();
+        ring(this.parts, t.x, t.y, 110, 0.42, 0.7);
+        burstSparks(this.parts, t.x, t.y, 20, 260, rand);
+        this.cam.addTrauma(0.07);
+        this.host.haptic("medium");
+      },
+      upgrade: (t) => {
+        this.audio.upgrade();
+        ring(this.parts, t.x, t.y, 170, 0.6, 1);
+        ring(this.parts, t.x, t.y, 110, 0.42, 0.4);
+        burstSparks(this.parts, t.x, t.y, 40, 380, rand);
+        for (let i = 0; i < 10; i++) emberMote(this.parts, t.x, t.y, rand);
+        this.cam.addTrauma(0.14);
+        this.cam.addPunch(0.03, 0.3);
+        this.host.haptic("success");
+      },
+      earn: () => {},
+      waveStart: (spec: WaveSpec) => {
+        const raise = (this.host as { raiseFloor?: (v: number) => void }).raiseFloor;
+        if (typeof raise === "function") raise.call(this.host, mathFloor(spec.n));
+        this.audio.waveHorn(spec.hasBoss ? 0.6 : 1);
+        this.audio.setIntensity(Math.min(1, spec.n / 16));
+        this.hud.showBanner(
+          spec.hasBoss ? `WAVE ${spec.n}` : `WAVE ${spec.n}`,
+          spec.hasBoss
+            ? `${spec.totalHp} HP · A BOSS COMES`
+            : `${spec.totalHp} HP INCOMING · YOUR DPS ${totalDps(this.state)}`,
+        );
+        this.cam.addTrauma(spec.hasBoss ? 0.3 : 0.12);
+      },
+      waveClear: (n) => {
+        this.audio.forgeStrike(0.8);
+        this.hud.showBanner(`WAVE ${n} HELD`, "THE CHANNEL COOLS");
+        for (let i = 0; i < 30; i++) {
+          emberMote(this.parts, this.state.path.core.x + this.rng.r(-70, 70), this.state.path.core.y, rand);
+        }
+        this.host.haptic("success");
+      },
+      overchargeBlast: (x, y, _dmg) => {
+        this.audio.overcharge();
+        this.clock.hitstop(JUICE.hitstopOvercharge);
+        this.cam.addTrauma(JUICE.traumaOvercharge);
+        this.cam.addPunch(JUICE.punchOvercharge, 0.55);
+        this.cam.flash(0.28, this.clock.wall);
+        for (let i = 0; i < 5; i++) ring(this.parts, x, y, 320 + i * 220, 0.7 + i * 0.14, 0.9);
+        burstSparks(this.parts, x, y, 120, 900, rand);
+        this.host.haptic("heavy");
+      },
+      defeat: (wave) => {
+        this.audio.defeat();
+        this.cam.addTrauma(0.8);
+        this.hud.showEnd(wave, [
+          `${this.state.stats.kills} SLAIN`,
+          `${this.state.stats.correct} STRUCK`,
+          `${this.state.stats.earned} EMBERS`,
+        ]);
+      },
+    };
+  }
+
+  // -- the loop ------------------------------------------------------------
+
+  private frame = (now: number): void => {
+    if (this.destroyed) return;
+    this.raf = requestAnimationFrame(this.frame);
+    const raw = (now - this.lastT) / 1000;
+    this.lastT = now;
+
+    this.frames++;
+    this.frameAcc += raw;
+    if (raw > this.worstFrame && this.frames > 30) this.worstFrame = raw;
+    if (this.frameAcc >= 0.5) {
+      this.fps = this.frames / this.frameAcc;
+      this.frames = 0;
+      this.frameAcc = 0;
+    }
+
+    const steps = this.clock.advance(raw);
+    for (let i = 0; i < steps; i++) step(this.state, FIXED_DT, this.fx);
+    if (steps > 0) this.parts.update(steps * FIXED_DT);
+    this.cam.update(Math.min(0.05, raw));
+
+    const wantHint =
+      this.state.phase !== "defeat" && (this.state.towers.length === 0 || this.armed !== null);
+    this.hint = wantHint
+      ? Math.min(1, this.hint + raw / 0.35)
+      : Math.max(0, this.hint - raw / 0.5);
+
+    if (this.focus?.kind === "overcharge") {
+      this.focus.left -= raw;
+      this.hud.setFocusTimer(this.focus.left / OVERCHARGE_WINDOW);
+      if (this.focus.left <= 0) this.failFocus();
+    }
+
+    if (this.coldUntil > 0 && this.clock.wall >= this.coldUntil) {
+      this.coldUntil = 0;
+      this.hud.setCold(false);
+      this.nextQuestion();
+    }
+
+    this.syncHud(false);
+    this.render();
+  };
+
+  private render(): void {
+    this.renderer.draw(this.ctx, this.view, this.state, this.parts, {
+      hoverPlot: this.hoverPlot,
+      selectedPlot: this.selectedPlot,
+      buildPreview: this.buildPreview,
+      reducedMotion: this.cam.reducedMotion,
+      wallT: this.clock.wall,
+      hint: this.hint,
+      shakeX: this.cam.shakeX,
+      shakeY: this.cam.shakeY,
+      shakeRot: this.cam.shakeRot,
+      zoom: this.cam.zoom,
+      flash: this.cam.flashAlpha,
+      frozen: this.clock.frozen,
+    });
+  }
+
+  private syncHud(force: boolean): void {
+    const s = this.state;
+    if (force || s.embers !== this.prevEmbers) {
+      this.hud.setEmbers(s.embers, false);
+      this.prevEmbers = s.embers;
+    }
+    this.hud.setDps(totalDps(s));
+    this.hud.setWave(s.wave);
+    this.hud.setThreat(s.hpRemaining);
+    const hurt = s.coreHp < this.prevCoreHp;
+    if (force || hurt || s.coreHp !== this.prevCoreHp) {
+      this.hud.setCore(s.coreHp, CORE_MAX_HP, hurt);
+      this.prevCoreHp = s.coreHp;
+    }
+    this.hud.setOvercharge(s.overcharge, s.overcharge >= OVERCHARGE_MAX && !this.focus);
+    this.hud.setPalette(s.embers, this.armed, BASE_DPS);
+    if (s.phase === "intermission" && s.wave > 0) {
+      this.hud.setCall(`${Math.max(0, Math.ceil(s.intermissionT))}s ▶`, true);
+    } else {
+      this.hud.setCall("", false);
+    }
+  }
+
+  // -- questions -----------------------------------------------------------
+
+  private nextQuestion(): void {
+    this.q = this.host.next();
+    // deterministic shuffle of the four slots
+    this.order = this.rng.shuffle([0, 1, 2, 3]);
+    this.askedAt = performance.now();
+    this.answering = false;
+    this.hud.setQuestion(this.q, this.order, emberReward(this.q.difficulty));
+  }
+
+  private optionAt(q: Question, slot: number): string {
+    const options = [q.answer, ...q.distractors];
+    return options[this.order[slot] ?? slot] ?? "";
+  }
+
+  private correctSlot(): number {
+    return this.order.indexOf(0);
+  }
+
+  private answer(slot: number): void {
+    if (!this.q || this.answering || this.coldUntil > 0 || this.focus) return;
+    if (this.state.phase === "defeat") return;
+    this.answering = true;
+    const chosen = this.optionAt(this.q, slot);
+    const correct = chosen === this.q.answer;
+    const ms = Math.round(performance.now() - this.askedAt);
+    const difficulty = this.q.difficulty;
+    this.host.report({ questionId: this.q.id, correct, ms, answered: chosen });
+    this.hud.markAnswer(slot, correct, this.correctSlot());
+
+    if (correct) {
+      this.state.stats.correct++;
+      const reward = emberReward(difficulty);
+      const from = this.hud.slugCenter(slot);
+      this.audio.forgeStrike(difficulty);
+      this.host.haptic("success");
+      this.state.overcharge = Math.min(OVERCHARGE_MAX, this.state.overcharge + OVERCHARGE_PER_ANSWER);
+      // sparks off the anvil, in board space beneath the core
+      this.strikeSparks();
+      this.hud.flyEmbers(reward, from.x, from.y, (i) => {
+        this.audio.tick(i);
+        this.hud.setEmbers(this.state.embers, true);
+      });
+      grantEmbers(this.state, reward, this.state.path.core.x, this.state.path.core.y, this.fx);
+      this.cam.addTrauma(0.03);
+      setTimeout(() => {
+        if (!this.destroyed && this.coldUntil === 0 && !this.focus) this.nextQuestion();
+      }, 190);
+    } else {
+      this.state.stats.wrong++;
+      this.audio.quench();
+      this.host.haptic("failure");
+      this.coldUntil = this.clock.wall + QUENCH_SECONDS;
+      this.hud.setCold(true);
+      this.cam.addTrauma(0.05);
+    }
+  }
+
+  private strikeSparks(): void {
+    const rand = () => this.rng.f();
+    const c = this.state.path.core;
+    for (let i = 0; i < 14; i++) emberMote(this.parts, c.x + this.rng.r(-40, 40), c.y - 10, rand);
+  }
+
+  // -- focus overlay -------------------------------------------------------
+
+  private openOvercharge(): void {
+    if (this.state.overcharge < OVERCHARGE_MAX || this.focus) return;
+    const q = this.host.next();
+    const order = this.rng.shuffle([0, 1, 2, 3]);
+    this.focus = { kind: "overcharge", q, order, left: OVERCHARGE_WINDOW };
+    this.order = order;
+    this.q = q;
+    this.askedAt = performance.now();
+    this.clock.slowTarget = JUICE.slowmoOvercharge;
+    this.audio.slowIn();
+    this.hud.hidePop();
+    this.hud.showFocus("OVERCHARGE", q, order, true);
+    this.hud.setFocusTimer(1);
+    this.host.haptic("medium");
+  }
+
+  private openUpgrade(): void {
+    const tower = towerAt(this.state, this.selectedPlot);
+    if (!tower || this.focus) return;
+    const cost = upgradeCost(tower);
+    if (cost === null || this.state.embers < cost) return;
+    const q = this.host.next();
+    const order = this.rng.shuffle([0, 1, 2, 3]);
+    this.focus = { kind: "upgrade", q, order, tower };
+    this.order = order;
+    this.q = q;
+    this.askedAt = performance.now();
+    this.clock.slowTarget = 0.42;
+    this.audio.slowIn();
+    this.hud.hidePop();
+    this.hud.showFocus(`UPGRADE · ${cost} EMBERS`, q, order, false);
+  }
+
+  private focusAnswer(slot: number): void {
+    const f = this.focus;
+    if (!f || !this.q) return;
+    const chosen = this.optionAt(this.q, slot);
+    const correct = chosen === this.q.answer;
+    const ms = Math.round(performance.now() - this.askedAt);
+    this.host.report({ questionId: this.q.id, correct, ms, answered: chosen });
+    this.hud.markFocus(slot, correct, this.correctSlot());
+
+    if (correct) {
+      this.state.stats.correct++;
+      if (f.kind === "overcharge") {
+        this.state.overcharge = 0;
+        detonateOvercharge(this.state, this.fx);
+      } else {
+        applyUpgrade(this.state, f.tower, this.fx);
+      }
+      setTimeout(() => this.closeFocus(), 260);
+    } else {
+      this.state.stats.wrong++;
+      this.state.stats.wrong += 0;
+      this.audio.quench();
+      this.host.haptic("failure");
+      if (f.kind === "overcharge") this.state.overcharge = 40;
+      this.coldUntil = this.clock.wall + QUENCH_SECONDS;
+      this.hud.setCold(true);
+      setTimeout(() => this.closeFocus(), 520);
+    }
+  }
+
+  private failFocus(): void {
+    if (!this.focus) return;
+    if (this.focus.kind === "overcharge") this.state.overcharge = 40;
+    this.audio.quench();
+    this.closeFocus();
+  }
+
+  private cancelFocus(): void {
+    if (this.focus?.kind !== "upgrade") return;
+    this.closeFocus();
+  }
+
+  private closeFocus(): void {
+    this.focus = null;
+    this.clock.slowTarget = 1;
+    this.hud.hideFocus();
+    if (this.coldUntil === 0) this.nextQuestion();
+  }
+
+  // -- input ---------------------------------------------------------------
+
+  private plotUnder(sx: number, sy: number): number {
+    const b = screenToBoard(this.view, sx, sy);
+    let best = -1;
+    let bestD = Infinity;
+    for (const p of this.state.plots) {
+      const dx = Math.abs(b.x - p.x);
+      const dy = Math.abs(b.y - p.y);
+      const h = p.size / 2 + 8;
+      if (dx > h || dy > h) continue;
+      const d = dx + dy;
+      if (d < bestD) {
+        bestD = d;
+        best = p.id;
+      }
+    }
+    return best;
+  }
+
+  private onPointerDown = (ev: PointerEvent): void => {
+    if (this.state.phase === "defeat" || this.focus) return;
+    this.audio.resume();
+    const rect = this.hud.canvas.getBoundingClientRect();
+    const sx = ev.clientX - rect.left;
+    const sy = ev.clientY - rect.top;
+    const id = this.plotUnder(sx, sy);
+    if (id < 0) {
+      this.selectedPlot = -1;
+      this.buildPreview = null;
+      this.hud.hidePop();
+      return;
+    }
+    this.select(id);
+  };
+
+  private arm(kind: TowerKind): void {
+    this.armed = this.armed === kind ? null : kind;
+    this.buildPreview = this.armed;
+    this.hud.hidePop();
+    this.host.haptic("light");
+  }
+
+  private select(id: number): void {
+    this.selectedPlot = id;
+    const plot = this.state.plots[id];
+    if (!plot) return;
+    const scr = boardToScreen(this.view, plot.x, plot.y);
+    const tower = towerAt(this.state, id);
+    this.host.haptic("light");
+    if (!tower && this.armed) {
+      // armed palette: pads become one-tap placement, the way a TD veteran plays
+      const kind = this.armed;
+      if (this.state.embers >= TOWERS[kind].cost) {
+        this.build(kind);
+        this.selectedPlot = -1;
+        if (this.state.embers < TOWERS[kind].cost) this.armed = null;
+        this.buildPreview = this.armed;
+        return;
+      }
+    }
+    if (tower) {
+      this.buildPreview = null;
+      const cost = upgradeCost(tower);
+      this.hud.showTower(
+        scr.x,
+        scr.y - plot.size * this.view.scale * 0.5,
+        {
+          name: TOWERS[tower.kind].name,
+          level: tower.level,
+          dps: towerDps(tower),
+          cost,
+          affordable: cost !== null && this.state.embers >= cost,
+        },
+        () => this.openUpgrade(),
+      );
+    } else {
+      this.hud.showBuild(scr.x, scr.y - plot.size * this.view.scale * 0.5, this.state.embers, (k) =>
+        this.build(k),
+      );
+      this.buildPreview = "bolt";
+    }
+  }
+
+  private build(kind: TowerKind): void {
+    if (this.selectedPlot < 0) return;
+    if (tryBuild(this.state, this.selectedPlot, kind, this.fx)) {
+      this.hud.hidePop();
+      this.buildPreview = null;
+      this.selectedPlot = -1;
+      this.hud.setEmbers(this.state.embers, true);
+    }
+  }
+
+  private onPointerMove = (ev: PointerEvent): void => {
+    if (ev.pointerType === "touch") return;
+    const rect = this.hud.canvas.getBoundingClientRect();
+    this.hoverPlot = this.plotUnder(ev.clientX - rect.left, ev.clientY - rect.top);
+  };
+
+  private onPointerLeave = (): void => {
+    this.hoverPlot = -1;
+  };
+
+  private onKey = (ev: KeyboardEvent): void => {
+    const k = ev.key;
+    if (k >= "1" && k <= "4") {
+      const i = Number(k) - 1;
+      if (this.focus) this.focusAnswer(i);
+      else this.answer(i);
+      ev.preventDefault();
+      return;
+    }
+    if (k === "Escape") {
+      this.hud.hidePop();
+      this.selectedPlot = -1;
+      this.cancelFocus();
+      return;
+    }
+    if (!this.focus) {
+      const armKey: Record<string, TowerKind> = { q: "bolt", w: "mortar", e: "chain" };
+      const kind = armKey[k.toLowerCase()];
+      if (kind) {
+        if (this.selectedPlot >= 0 && !towerAt(this.state, this.selectedPlot)) this.build(kind);
+        else this.arm(kind);
+      }
+      if ((k === "u" || k === "U") && this.selectedPlot >= 0) this.openUpgrade();
+    }
+    if (k === " ") {
+      ev.preventDefault();
+      if (this.state.overcharge >= OVERCHARGE_MAX && !this.focus) this.openOvercharge();
+      else this.callWave();
+    }
+    if (k === "f" || k === "F") this.toggleSpeed();
+  };
+
+  private toggleSpeed(): void {
+    this.clock.speed = this.clock.speed === 1 ? 2 : 1;
+    this.hud.setSpeed(this.clock.speed);
+  }
+
+  private toggleSound(): void {
+    this.soundOn = !this.soundOn;
+    this.audio.setEnabled(this.soundOn);
+    this.hud.setSound(this.soundOn);
+  }
+
+  private callWave(): void {
+    const bonus = callWaveEarly(this.state);
+    if (bonus <= 0) return;
+    const embers = bonus * EARLY_CALL_BONUS;
+    grantEmbers(this.state, embers, this.state.path.core.x, this.state.path.core.y, this.fx);
+    this.hud.setEmbers(this.state.embers, true);
+    this.audio.forgeStrike(0.5);
+    this.host.haptic("medium");
+  }
+
+  // -- exposed for the playtest harness -------------------------------------
+
+  debug(): {
+    fps: number;
+    worstFrameMs: number;
+    particles: number;
+    enemies: number;
+    towers: number;
+    wave: number;
+    embers: number;
+    coreHp: number;
+    phase: string;
+  } {
+    let live = 0;
+    for (const e of this.state.enemies) if (e.alive) live++;
+    return {
+      fps: Math.round(this.fps),
+      worstFrameMs: Math.round(this.worstFrame * 1000),
+      particles: this.parts.count,
+      enemies: live,
+      towers: this.state.towers.length,
+      wave: this.state.wave,
+      embers: this.state.embers,
+      coreHp: this.state.coreHp,
+      phase: this.state.phase,
+    };
+  }
+
+  /** harness: strike the anvil once, correctly unless we asked for a slip */
+  autoAnswer(mistakeRate = 0): boolean {
+    if (this.state.phase === "defeat") return false;
+    const slip = this.rng.f() < mistakeRate;
+    const slot = slip ? (this.correctSlot() + 1) % 4 : this.correctSlot();
+    if (this.focus) {
+      this.focusAnswer(slot);
+      return true;
+    }
+    if (this.coldUntil > 0 || this.answering) return false;
+    this.answer(slot);
+    return true;
+  }
+
+  /** harness: spend like a competent player — fill the best pads, then upgrade */
+  autoSpend(): void {
+    const s = this.state;
+    if (s.phase === "defeat" || this.focus) return;
+    if (s.overcharge >= OVERCHARGE_MAX && s.coreHp < CORE_MAX_HP) {
+      this.openOvercharge();
+      return;
+    }
+    const empty = s.plots.filter((p) => p.towerId < 0).sort((a, b) => b.value - a.value);
+    const wantMortar = s.wave >= 5 && s.towers.filter((t) => t.kind === "mortar").length < 5;
+    const wantChain = s.wave >= 9 && s.towers.filter((t) => t.kind === "chain").length < 4;
+    const pick: TowerKind =
+      s.towers.length < 4 ? "bolt" : wantChain && this.rng.chance(0.4) ? "chain" : wantMortar ? "mortar" : "bolt";
+    const first = empty[0];
+    if (first && s.embers >= TOWERS[pick].cost) {
+      this.selectedPlot = first.id;
+      this.build(pick);
+      return;
+    }
+    // pads full: pour everything into levels
+    const target = s.towers
+      .filter((t) => {
+        const c = upgradeCost(t);
+        return c !== null && s.embers >= c;
+      })
+      .sort((a, b) => a.level - b.level)[0];
+    if (target) {
+      this.selectedPlot = target.plotId;
+      this.openUpgrade();
+    }
+  }
+
+  autoTick(mistakeRate = 0): void {
+    this.autoAnswer(mistakeRate);
+    this.autoSpend();
+  }
+
+  setSpeedForTest(mult: 1 | 2): void {
+    this.clock.speed = mult;
+    this.hud.setSpeed(mult);
+  }
+
+  /** harness: jump straight to a fully-built board at a late wave, for perf work */
+  seedHeavy(wave: number, level: number): void {
+    const kinds: TowerKind[] = ["bolt", "mortar", "chain"];
+    this.state.embers = 9_999_999;
+    this.state.plots.forEach((p, i) => {
+      if (p.towerId < 0) tryBuild(this.state, p.id, kinds[i % 3] as TowerKind, this.fx);
+    });
+    for (const t of this.state.towers) {
+      while (t.level < level && applyUpgrade(this.state, t, this.fx)) {
+        /* climb */
+      }
+    }
+    this.state.wave = wave;
+    this.state.spec = buildWave(wave, this.state.seed);
+    this.state.phase = "intermission";
+    this.state.intermissionT = 0.2;
+    this.state.embers = 600;
+  }
+
+  get live(): State {
+    return this.state;
+  }
+}
+
+export type { Enemy, Tower };
+export { clamp01 };

--- a/dynawalla/games/siege/src/render/bake.ts
+++ b/dynawalla/games/siege/src/render/bake.ts
@@ -1,0 +1,276 @@
+/**
+ * The static half of the board, baked once into an offscreen canvas: columnar
+ * basalt, the cooled crust of the channel, and the buildable slabs. One
+ * drawImage per frame instead of two thousand path ops.
+ */
+import { BOARD } from "../game/constants.ts";
+import type { PathData } from "../game/path.ts";
+import type { Plot } from "../game/board.ts";
+import { makeRng } from "../core/rng.ts";
+
+export const BAKE_SIZE = 1400;
+
+function channelPath(ctx: CanvasRenderingContext2D, path: PathData): void {
+  ctx.beginPath();
+  const p0 = path.pts[0];
+  if (!p0) return;
+  ctx.moveTo(p0.x, p0.y);
+  for (let i = 1; i < path.pts.length; i++) {
+    const p = path.pts[i];
+    if (p) ctx.lineTo(p.x, p.y);
+  }
+}
+
+export function bakeBoard(plots: readonly Plot[], path: PathData): HTMLCanvasElement {
+  const cv = document.createElement("canvas");
+  cv.width = BAKE_SIZE;
+  cv.height = BAKE_SIZE;
+  const ctx = cv.getContext("2d") as CanvasRenderingContext2D;
+  const k = BAKE_SIZE / BOARD;
+  ctx.scale(k, k);
+  const rng = makeRng(0xba5a17);
+
+  // -- ground --------------------------------------------------------------
+  const g = ctx.createRadialGradient(BOARD * 0.5, BOARD * 0.42, 40, BOARD * 0.5, BOARD * 0.5, BOARD * 0.78);
+  g.addColorStop(0, "#120d0f");
+  g.addColorStop(0.62, "#0d090b");
+  g.addColorStop(1, "#060405");
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, BOARD, BOARD);
+
+  // -- columnar basalt: jittered hex cells ---------------------------------
+  const R = 25;
+  const dx = R * 1.732;
+  const dy = R * 1.5;
+  const tones = ["#100c0e", "#151013", "#0d090b", "#181114", "#0b0809"];
+  ctx.lineWidth = 1.1;
+  for (let row = -1; row * dy < BOARD + R; row++) {
+    for (let col = -1; col * dx < BOARD + dx; col++) {
+      const cx = col * dx + (row % 2 ? dx / 2 : 0) + rng.r(-3.5, 3.5);
+      const cy = row * dy + rng.r(-3.5, 3.5);
+      ctx.beginPath();
+      for (let i = 0; i < 6; i++) {
+        const a = (Math.PI / 3) * i - Math.PI / 6;
+        const rr = R * rng.r(0.86, 1.02);
+        const px = cx + Math.cos(a) * rr;
+        const py = cy + Math.sin(a) * rr;
+        if (i === 0) ctx.moveTo(px, py);
+        else ctx.lineTo(px, py);
+      }
+      ctx.closePath();
+      ctx.fillStyle = tones[rng.i(0, tones.length - 1)] as string;
+      ctx.fill();
+      ctx.strokeStyle = "rgba(0,0,0,0.55)";
+      ctx.stroke();
+      if (rng.chance(0.07)) {
+        ctx.strokeStyle = "rgba(120,66,40,0.16)";
+        ctx.stroke();
+      }
+    }
+  }
+
+  // -- cooling cracks bleeding heat ----------------------------------------
+  ctx.globalCompositeOperation = "lighter";
+  for (let i = 0; i < 26; i++) {
+    let x = rng.r(0, BOARD);
+    let y = rng.r(0, BOARD);
+    let a = rng.r(0, Math.PI * 2);
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+    const segs = rng.i(4, 11);
+    for (let sgi = 0; sgi < segs; sgi++) {
+      a += rng.r(-0.8, 0.8);
+      const len = rng.r(18, 62);
+      x += Math.cos(a) * len;
+      y += Math.sin(a) * len;
+      ctx.lineTo(x, y);
+    }
+    ctx.strokeStyle = `rgba(190,72,22,${rng.r(0.05, 0.15).toFixed(3)})`;
+    ctx.lineWidth = rng.r(1, 3.4);
+    ctx.stroke();
+  }
+  ctx.globalCompositeOperation = "source-over";
+
+  // -- the channel: a dark trench with a narrow molten bed ------------------
+  ctx.lineJoin = "round";
+  ctx.lineCap = "round";
+  const bands: [number, string][] = [
+    [94, "#050303"], // the trench swallows light at its lip
+    [78, "#120a09"],
+    [60, "#1c0c09"],
+    [42, "#2c0f06"],
+    [24, "#4a1404"],
+  ];
+  for (const [w, col] of bands) {
+    channelPath(ctx, path);
+    ctx.strokeStyle = col;
+    ctx.lineWidth = w;
+    ctx.stroke();
+  }
+
+  // flow banding: striations along the current, so the bed reads as moving rock
+  // rather than a lit tube
+  {
+    const q = { x: 0, y: 0 };
+    const dd = { x: 0, y: 0 };
+    ctx.globalCompositeOperation = "lighter";
+    ctx.lineCap = "round";
+    for (let i = 0; i < 900; i++) {
+      const s0 = rng.r(0, path.length);
+      path.at(s0, q);
+      path.dirAt(s0, dd);
+      const nx = -dd.y;
+      const ny = dd.x;
+      const off = rng.r(-26, 26);
+      const bright = 1 - Math.abs(off) / 26;
+      const len = rng.r(8, 46);
+      ctx.beginPath();
+      ctx.moveTo(q.x + nx * off, q.y + ny * off);
+      ctx.lineTo(q.x + nx * off + dd.x * len, q.y + ny * off + dd.y * len);
+      ctx.strokeStyle = `rgba(255,${Math.round(120 + bright * 110)},${Math.round(28 + bright * 90)},${(0.05 + bright * 0.16).toFixed(3)})`;
+      ctx.lineWidth = rng.r(1, 3.6);
+      ctx.stroke();
+    }
+    ctx.globalCompositeOperation = "source-over";
+  }
+
+  // crust plates riding the surface — the reason it reads as rock, not neon
+  const p = { x: 0, y: 0 };
+  const d = { x: 0, y: 0 };
+  for (let i = 0; i < 520; i++) {
+    const s = rng.r(0, path.length);
+    path.at(s, p);
+    path.dirAt(s, d);
+    const nx = -d.y;
+    const ny = d.x;
+    const off = rng.r(-34, 34);
+    const cx = p.x + nx * off;
+    const cy = p.y + ny * off;
+    const w = rng.r(6, 18);
+    const h = rng.r(4, 10);
+    ctx.save();
+    ctx.translate(cx, cy);
+    ctx.rotate(Math.atan2(d.y, d.x) + rng.r(-0.5, 0.5));
+    ctx.beginPath();
+    ctx.moveTo(-w / 2, 0);
+    ctx.lineTo(-w * 0.2, -h / 2);
+    ctx.lineTo(w / 2, -h * 0.3);
+    ctx.lineTo(w * 0.3, h / 2);
+    ctx.closePath();
+    const near = Math.abs(off) / 34;
+    ctx.fillStyle = `rgba(${12 + Math.round(near * 8)},${6 + Math.round(near * 4)},${6},${rng.r(0.7, 0.98).toFixed(2)})`;
+    ctx.fill();
+    ctx.strokeStyle = "rgba(255,120,36,0.09)";
+    ctx.lineWidth = 1;
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  // -- buildable slabs: machined sockets bolted into the rock ---------------
+  const chamfer = (c: CanvasRenderingContext2D, h: number, cut: number): void => {
+    c.beginPath();
+    c.moveTo(-h + cut, -h);
+    c.lineTo(h - cut, -h);
+    c.lineTo(h, -h + cut);
+    c.lineTo(h, h - cut);
+    c.lineTo(h - cut, h);
+    c.lineTo(-h + cut, h);
+    c.lineTo(-h, h - cut);
+    c.lineTo(-h, -h + cut);
+    c.closePath();
+  };
+
+  for (const plot of plots) {
+    ctx.save();
+    ctx.translate(plot.x, plot.y);
+    ctx.rotate(plot.rot);
+    const h = plot.size / 2;
+    const cut = h * 0.3;
+
+    ctx.translate(3, 5);
+    chamfer(ctx, h, cut);
+    ctx.fillStyle = "rgba(0,0,0,0.6)";
+    ctx.fill();
+    ctx.translate(-3, -5);
+
+    chamfer(ctx, h, cut);
+    const gg = ctx.createLinearGradient(-h, -h, h, h);
+    gg.addColorStop(0, "#2b2024");
+    gg.addColorStop(0.55, "#1b1417");
+    gg.addColorStop(1, "#100b0d");
+    ctx.fillStyle = gg;
+    ctx.fill();
+    ctx.strokeStyle = "rgba(0,0,0,0.85)";
+    ctx.lineWidth = 2;
+    ctx.stroke();
+
+    // brushed metal grain
+    ctx.save();
+    chamfer(ctx, h, cut);
+    ctx.clip();
+    ctx.strokeStyle = "rgba(255,200,150,0.035)";
+    ctx.lineWidth = 1;
+    for (let i = -14; i < 14; i++) {
+      ctx.beginPath();
+      ctx.moveTo(-h, i * 4 + rng.r(-1, 1));
+      ctx.lineTo(h, i * 4 + rng.r(-1, 1));
+      ctx.stroke();
+    }
+    ctx.restore();
+
+    // top bevel catches the light from the channel
+    chamfer(ctx, h - 3, cut * 0.82);
+    ctx.strokeStyle = "rgba(255,170,90,0.13)";
+    ctx.lineWidth = 1.6;
+    ctx.stroke();
+
+    // recessed socket — where a tower will seat
+    const sr = h * 0.44;
+    ctx.beginPath();
+    ctx.arc(0, 0, sr, 0, 6.284);
+    ctx.fillStyle = "#0a0708";
+    ctx.fill();
+    const sg = ctx.createRadialGradient(0, sr * 0.3, 1, 0, 0, sr);
+    sg.addColorStop(0, "rgba(255,120,40,0.16)");
+    sg.addColorStop(1, "rgba(255,80,20,0)");
+    ctx.fillStyle = sg;
+    ctx.fill();
+    ctx.strokeStyle = "rgba(255,160,80,0.20)";
+    ctx.lineWidth = 1.6;
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(0, 0, sr * 0.55, 0, 6.284);
+    ctx.strokeStyle = "rgba(0,0,0,0.6)";
+    ctx.lineWidth = 2;
+    ctx.stroke();
+
+    // bolt heads
+    for (const [sx, sy] of [
+      [-1, -1],
+      [1, -1],
+      [-1, 1],
+      [1, 1],
+    ] as const) {
+      const bx = sx * (h - cut * 0.62);
+      const by = sy * (h - cut * 0.62);
+      ctx.beginPath();
+      ctx.arc(bx, by, 3.2, 0, 6.284);
+      ctx.fillStyle = "#3a2c2c";
+      ctx.fill();
+      ctx.beginPath();
+      ctx.arc(bx - 0.7, by - 0.7, 1.5, 0, 6.284);
+      ctx.fillStyle = "rgba(255,200,150,0.28)";
+      ctx.fill();
+    }
+    ctx.restore();
+  }
+
+  // -- vignette so the fight sits in the middle of the eye -----------------
+  const vg = ctx.createRadialGradient(BOARD / 2, BOARD / 2, BOARD * 0.36, BOARD / 2, BOARD / 2, BOARD * 0.78);
+  vg.addColorStop(0, "rgba(0,0,0,0)");
+  vg.addColorStop(1, "rgba(0,0,0,0.52)");
+  ctx.fillStyle = vg;
+  ctx.fillRect(0, 0, BOARD, BOARD);
+
+  return cv;
+}

--- a/dynawalla/games/siege/src/render/draw.ts
+++ b/dynawalla/games/siege/src/render/draw.ts
@@ -1,0 +1,941 @@
+/**
+ * The live renderer. Everything hot, everything animated, one canvas.
+ *
+ * Draw order is fixed: baked ground, flowing lava, plots, ranges, enemies,
+ * towers, ordnance (additive), particles (two passes), numbers, flash.
+ */
+import { BOARD, C, TOWERS, towerRange, type TowerKind } from "../game/constants.ts";
+import type { State } from "../game/state.ts";
+import { PKind, type Particles } from "./particles.ts";
+import { clamp01, easeOutBack, easeOutCubic } from "../core/easing.ts";
+
+export type View = {
+  w: number;
+  h: number;
+  dpr: number;
+  scale: number;
+  ox: number;
+  oy: number;
+};
+
+export function computeView(cssW: number, cssH: number, dpr: number): View {
+  const pad = 6;
+  const scale = Math.min((cssW - pad * 2) / BOARD, (cssH - pad * 2) / BOARD);
+  return {
+    w: cssW,
+    h: cssH,
+    dpr,
+    scale,
+    ox: (cssW - BOARD * scale) / 2,
+    oy: (cssH - BOARD * scale) / 2,
+  };
+}
+
+export function screenToBoard(v: View, sx: number, sy: number): { x: number; y: number } {
+  return { x: (sx - v.ox) / v.scale, y: (sy - v.oy) / v.scale };
+}
+
+export function boardToScreen(v: View, x: number, y: number): { x: number; y: number } {
+  return { x: v.ox + x * v.scale, y: v.oy + y * v.scale };
+}
+
+const FONT = `800 1px system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif`;
+const font = (px: number): string => FONT.replace("1px", `${px}px`);
+
+/**
+ * Baked glow sprites. `createRadialGradient` per particle per frame is the
+ * single most expensive thing a 2d canvas game can do; one drawImage of a
+ * pre-rendered blob is an order of magnitude cheaper and looks softer.
+ */
+function makeGlow(r: number, g: number, b: number): HTMLCanvasElement {
+  const S = 96;
+  const c = document.createElement("canvas");
+  c.width = S;
+  c.height = S;
+  const x = c.getContext("2d") as CanvasRenderingContext2D;
+  const grad = x.createRadialGradient(S / 2, S / 2, 0, S / 2, S / 2, S / 2);
+  grad.addColorStop(0, `rgba(${r},${g},${b},1)`);
+  grad.addColorStop(0.26, `rgba(${r},${g},${b},0.62)`);
+  grad.addColorStop(0.62, `rgba(${r},${g},${b},0.16)`);
+  grad.addColorStop(1, `rgba(${r},${g},${b},0)`);
+  x.fillStyle = grad;
+  x.fillRect(0, 0, S, S);
+  return c;
+}
+
+let RIFT: HTMLCanvasElement | null = null;
+function riftGlow(): HTMLCanvasElement {
+  if (!RIFT) RIFT = makeGlow(150, 214, 255);
+  return RIFT;
+}
+
+let GLOW: { white: HTMLCanvasElement; hot: HTMLCanvasElement; deep: HTMLCanvasElement } | null = null;
+function glows(): { white: HTMLCanvasElement; hot: HTMLCanvasElement; deep: HTMLCanvasElement } {
+  if (!GLOW) {
+    GLOW = {
+      white: makeGlow(255, 244, 214),
+      hot: makeGlow(255, 152, 52),
+      deep: makeGlow(255, 78, 18),
+    };
+  }
+  return GLOW;
+}
+
+const hex = (c: string): [number, number, number] => [
+  parseInt(c.slice(1, 3), 16),
+  parseInt(c.slice(3, 5), 16),
+  parseInt(c.slice(5, 7), 16),
+];
+
+/** blend two #rrggbb colours; used for hit flashes so silhouettes survive */
+function mix(a: string, b: string, t: number): string {
+  const [r1, g1, b1] = hex(a);
+  const [r2, g2, b2] = hex(b);
+  return `rgb(${Math.round(r1 + (r2 - r1) * t)},${Math.round(g1 + (g2 - g1) * t)},${Math.round(b1 + (b2 - b1) * t)})`;
+}
+
+function blob(
+  ctx: CanvasRenderingContext2D,
+  sprite: HTMLCanvasElement,
+  x: number,
+  y: number,
+  radius: number,
+  alpha: number,
+): void {
+  ctx.globalAlpha = alpha;
+  ctx.drawImage(sprite, x - radius, y - radius, radius * 2, radius * 2);
+  ctx.globalAlpha = 1;
+}
+
+// ---------------------------------------------------------------------------
+
+export type DrawOpts = {
+  hoverPlot: number;
+  selectedPlot: number;
+  buildPreview: TowerKind | null;
+  reducedMotion: boolean;
+  wallT: number;
+  /** 0..1 hint pulse for the first-tower nudge */
+  hint: number;
+  shakeX: number;
+  shakeY: number;
+  shakeRot: number;
+  zoom: number;
+  flash: number;
+  frozen: boolean;
+};
+
+export class Renderer {
+  private baked: HTMLCanvasElement | null = null;
+  private amb: CanvasGradient | null = null;
+  private ambKey = "";
+
+  setBaked(c: HTMLCanvasElement): void {
+    this.baked = c;
+  }
+
+  private ambient(ctx: CanvasRenderingContext2D, v: View): CanvasGradient {
+    const key = `${v.w}x${v.h}`;
+    if (this.amb && this.ambKey === key) return this.amb;
+    const g = ctx.createRadialGradient(
+      v.w / 2,
+      v.h * 0.52,
+      10,
+      v.w / 2,
+      v.h * 0.52,
+      Math.max(v.w, v.h) * 0.75,
+    );
+    g.addColorStop(0, "#160e10");
+    g.addColorStop(1, "#070405");
+    this.amb = g;
+    this.ambKey = key;
+    return g;
+  }
+
+  draw(
+    ctx: CanvasRenderingContext2D,
+    v: View,
+    s: State,
+    p: Particles,
+    o: DrawOpts,
+  ): void {
+    const t = o.wallT;
+    ctx.save();
+    ctx.setTransform(v.dpr, 0, 0, v.dpr, 0, 0);
+
+    // ambient beyond the board: the cavern the forge sits in
+    ctx.fillStyle = this.ambient(ctx, v);
+    ctx.fillRect(0, 0, v.w, v.h);
+
+    // camera
+    ctx.translate(v.w / 2 + o.shakeX, v.h / 2 + o.shakeY);
+    ctx.rotate(o.shakeRot);
+    ctx.scale(o.zoom, o.zoom);
+    ctx.translate(-v.w / 2, -v.h / 2);
+    ctx.translate(v.ox, v.oy);
+    ctx.scale(v.scale, v.scale);
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(0, 0, BOARD, BOARD);
+    ctx.clip();
+
+    if (this.baked) ctx.drawImage(this.baked, 0, 0, BOARD, BOARD);
+
+    this.drawLava(ctx, s, t, o.reducedMotion);
+    this.drawRift(ctx, s, t, o.reducedMotion);
+    this.drawPlots(ctx, s, o, t);
+    this.drawRanges(ctx, s, o);
+    this.drawCore(ctx, s, t, o.reducedMotion);
+
+    this.drawParticles(ctx, p, false);
+    this.drawEnemies(ctx, s, t, o.reducedMotion);
+    this.drawTowers(ctx, s, t, o);
+    this.drawOrdnance(ctx, s);
+    this.drawParticles(ctx, p, true);
+    this.drawPopups(ctx, s);
+
+    ctx.restore();
+
+    // board frame — a hot seam that makes the play area feel forged
+    ctx.strokeStyle = "rgba(255,140,60,0.22)";
+    ctx.lineWidth = 2 / v.scale;
+    ctx.strokeRect(0, 0, BOARD, BOARD);
+
+    ctx.restore();
+
+    if (o.flash > 0.001) {
+      ctx.save();
+      ctx.setTransform(v.dpr, 0, 0, v.dpr, 0, 0);
+      ctx.fillStyle = `rgba(255,226,180,${o.flash})`;
+      ctx.fillRect(0, 0, v.w, v.h);
+      ctx.restore();
+    }
+  }
+
+  // -- layers --------------------------------------------------------------
+
+  private drawLava(ctx: CanvasRenderingContext2D, s: State, t: number, reduced: boolean): void {
+    const path = s.path;
+    ctx.save();
+    ctx.lineJoin = "round";
+    ctx.lineCap = "round";
+    ctx.beginPath();
+    const p0 = path.pts[0];
+    if (p0) {
+      ctx.moveTo(p0.x, p0.y);
+      for (let i = 1; i < path.pts.length; i++) {
+        const q = path.pts[i];
+        if (q) ctx.lineTo(q.x, q.y);
+      }
+    }
+    const pulse = reduced ? 0 : Math.sin(t * 1.7) * 0.5 + 0.5;
+
+    ctx.globalCompositeOperation = "lighter";
+    ctx.strokeStyle = `rgba(255,58,10,${0.07 + pulse * 0.025})`;
+    ctx.lineWidth = 44;
+    ctx.stroke();
+    ctx.strokeStyle = `rgba(255,104,22,${0.09 + pulse * 0.03})`;
+    ctx.lineWidth = 26;
+    ctx.stroke();
+    ctx.strokeStyle = `rgba(255,180,84,${0.13 + pulse * 0.05})`;
+    ctx.lineWidth = 11;
+    ctx.stroke();
+
+    // flow: bright fissures crawling toward the core, thin enough to read as cracks
+    if (!reduced) {
+      ctx.setLineDash([48, 210]);
+      ctx.lineDashOffset = -((t * 66) % 258);
+      ctx.strokeStyle = "rgba(255,224,160,0.24)";
+      ctx.lineWidth = 5;
+      ctx.stroke();
+      ctx.setLineDash([16, 360]);
+      ctx.lineDashOffset = -((t * 124) % 376);
+      ctx.strokeStyle = "rgba(255,252,225,0.34)";
+      ctx.lineWidth = 2.2;
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+    ctx.restore();
+  }
+
+  private drawRift(ctx: CanvasRenderingContext2D, s: State, t: number, reduced: boolean): void {
+    const { x, y } = s.path.rift;
+    const rx = Math.max(6, x + 74);
+    ctx.save();
+    ctx.globalCompositeOperation = "lighter";
+    const pulse = reduced ? 0.5 : Math.sin(t * 2.6) * 0.5 + 0.5;
+    for (let i = 0; i < 3; i++) {
+      ctx.beginPath();
+      ctx.ellipse(rx - 40, y, 22 + i * 16 + pulse * 6, 62 + i * 20 + pulse * 8, 0, 0, 6.284);
+      ctx.strokeStyle = `rgba(150,210,255,${0.2 - i * 0.05})`;
+      ctx.lineWidth = 5 - i;
+      ctx.stroke();
+    }
+    blob(ctx, riftGlow(), rx - 46, y, 96, 0.4 + pulse * 0.18);
+    ctx.restore();
+  }
+
+  private drawPlots(ctx: CanvasRenderingContext2D, s: State, o: DrawOpts, t: number): void {
+    for (const plot of s.plots) {
+      const isHover = plot.id === o.hoverPlot;
+      const isSel = plot.id === o.selectedPlot;
+      const empty = plot.towerId < 0;
+      if (!isHover && !isSel && (!empty || o.hint <= 0)) continue;
+
+      ctx.save();
+      ctx.translate(plot.x, plot.y);
+      ctx.rotate(plot.rot);
+      const h = plot.size / 2;
+
+      if (empty && o.hint > 0 && !isSel) {
+        // the only tutorial in the game: good pads breathe until you use one
+        const bp = o.reducedMotion ? 0.5 : Math.sin(t * 3 + plot.id) * 0.5 + 0.5;
+        const a = o.hint * (0.12 + bp * 0.3) * (0.4 + plot.value * 3.4);
+        ctx.strokeStyle = `rgba(255,196,110,${Math.min(0.75, a).toFixed(3)})`;
+        ctx.lineWidth = 3;
+        ctx.strokeRect(-h + 2, -h + 2, plot.size - 4, plot.size - 4);
+      }
+      if (isHover || isSel) {
+        ctx.fillStyle = isSel ? "rgba(255,180,90,0.22)" : "rgba(255,180,90,0.10)";
+        ctx.fillRect(-h, -h, plot.size, plot.size);
+        ctx.strokeStyle = isSel ? C.gold : "rgba(255,206,120,0.7)";
+        ctx.lineWidth = isSel ? 4 : 2.5;
+        ctx.strokeRect(-h + 2, -h + 2, plot.size - 4, plot.size - 4);
+        // corner brackets — reads as a targeting reticle, not a table cell
+        const L = 14;
+        ctx.lineWidth = 4;
+        ctx.strokeStyle = C.whiteHot;
+        for (const [sx, sy] of [
+          [-1, -1],
+          [1, -1],
+          [-1, 1],
+          [1, 1],
+        ] as const) {
+          ctx.beginPath();
+          ctx.moveTo(sx * h - sx * L, sy * h);
+          ctx.lineTo(sx * h, sy * h);
+          ctx.lineTo(sx * h, sy * h - sy * L);
+          ctx.stroke();
+        }
+      }
+      ctx.restore();
+    }
+  }
+
+  private drawRanges(ctx: CanvasRenderingContext2D, s: State, o: DrawOpts): void {
+    // an armed tower previews on whatever pad the cursor is over; otherwise the
+    // selected pad wins
+    const id =
+      o.selectedPlot >= 0 ? o.selectedPlot : o.buildPreview ? o.hoverPlot : -1;
+    const plot = s.plots[id];
+    if (!plot) return;
+    let range = 0;
+    if (plot.towerId >= 0) {
+      const tw = s.towers.find((q) => q.id === plot.towerId);
+      if (tw) range = towerRange(tw.kind, tw.level);
+    } else if (o.buildPreview) {
+      range = towerRange(o.buildPreview, 0);
+    }
+    if (range <= 0) return;
+    ctx.save();
+    ctx.beginPath();
+    ctx.arc(plot.x, plot.y, range, 0, 6.284);
+    ctx.fillStyle = "rgba(255,170,70,0.07)";
+    ctx.fill();
+    ctx.setLineDash([12, 10]);
+    ctx.strokeStyle = "rgba(255,206,120,0.55)";
+    ctx.lineWidth = 2.5;
+    ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.restore();
+  }
+
+  private drawCore(ctx: CanvasRenderingContext2D, s: State, t: number, reduced: boolean): void {
+    const { x, y } = s.path.core;
+    const frac = s.coreHp / 20;
+    const pulse = reduced ? 0.5 : Math.sin(t * 2.2) * 0.5 + 0.5;
+    ctx.save();
+    ctx.translate(x, y);
+
+    ctx.globalCompositeOperation = "lighter";
+    const heat = 0.3 + frac * 0.45 + pulse * 0.1 + s.coreFlash * 0.4;
+    blob(ctx, glows().deep, 0, 0, 150, heat * 0.8);
+    blob(ctx, glows().white, 0, 0, 62, heat * 0.5);
+    ctx.globalCompositeOperation = "source-over";
+
+    // furnace housing
+    const R = 54;
+    ctx.beginPath();
+    for (let i = 0; i < 8; i++) {
+      const a = (Math.PI / 4) * i + Math.PI / 8;
+      const px = Math.cos(a) * R;
+      const py = Math.sin(a) * R;
+      if (i === 0) ctx.moveTo(px, py);
+      else ctx.lineTo(px, py);
+    }
+    ctx.closePath();
+    ctx.fillStyle = "#1a1215";
+    ctx.fill();
+    ctx.strokeStyle = s.coreFlash > 0.05 ? C.danger : "rgba(255,170,80,0.6)";
+    ctx.lineWidth = 4 + s.coreFlash * 5;
+    ctx.stroke();
+
+    // grate bars, glowing hotter the healthier the forge
+    ctx.strokeStyle = `rgba(255,${Math.round(90 + frac * 130)},${Math.round(20 + frac * 60)},${0.5 + frac * 0.4})`;
+    ctx.lineWidth = 6;
+    for (let i = -2; i <= 2; i++) {
+      ctx.beginPath();
+      ctx.moveTo(-34, i * 15);
+      ctx.lineTo(34, i * 15);
+      ctx.stroke();
+    }
+
+    // damage: the housing fractures, visibly and permanently
+    const cracks = Math.round((1 - frac) * 7);
+    ctx.strokeStyle = "rgba(10,6,7,0.9)";
+    ctx.lineWidth = 3.5;
+    for (let i = 0; i < cracks; i++) {
+      const a = (i / 7) * 6.284 + 0.6;
+      ctx.beginPath();
+      ctx.moveTo(Math.cos(a) * 18, Math.sin(a) * 18);
+      ctx.lineTo(Math.cos(a + 0.3) * R, Math.sin(a + 0.3) * R);
+      ctx.stroke();
+    }
+    ctx.restore();
+  }
+
+  private drawEnemies(ctx: CanvasRenderingContext2D, s: State, t: number, reduced: boolean): void {
+    for (const e of s.enemies) {
+      if (!e.alive) continue;
+      const age = t - e.born;
+      // spawn squash: elastic settle, the cheapest and most valuable feel win
+      let sx = 1;
+      let sy = 1;
+      if (age < 0.34 && !reduced) {
+        const k = easeOutBack(clamp01(age / 0.34));
+        sx = 0.42 + 0.58 * k + (1 - k) * 0.5;
+        sy = 1.6 - 0.6 * k - (1 - k) * 0.5;
+      }
+      const ang = Math.atan2(e.dirY, e.dirX);
+      // a walking squash: the single cheapest thing that stops them reading as
+      // stickers sliding down a track
+      if (!reduced && e.stun <= 0) {
+        const bob = Math.sin(t * 7.5 + e.phase);
+        sx *= 1 + bob * 0.06;
+        sy *= 1 - bob * 0.06;
+      }
+
+      ctx.save();
+      ctx.translate(e.x, e.y);
+
+      // contact shadow grounds the piece; without it everything floats
+      ctx.fillStyle = "rgba(0,0,0,0.45)";
+      ctx.beginPath();
+      ctx.ellipse(2, e.radius * 0.55, e.radius * 0.95, e.radius * 0.38, 0, 0, 6.284);
+      ctx.fill();
+
+      ctx.rotate(ang);
+      ctx.scale(sx, sy);
+
+      // a hit lightens the stone toward ice, it does not blank it to white —
+      // under heavy fire a pure-white flash erases every silhouette on screen
+      const f = Math.min(1, e.hitFlash / 0.11) * 0.72;
+      const body = f > 0.02 ? mix(C.obsidian, "#dcefff", f) : C.obsidian;
+      const facet = f > 0.02 ? mix(C.obsidianHi, "#ffffff", f) : C.obsidianHi;
+      const edge = f > 0.02 ? "#ffffff" : C.rime;
+
+      switch (e.kind) {
+        case "runner":
+          this.chevron(ctx, e.radius, body, facet, edge);
+          break;
+        case "brute":
+          this.hex(ctx, e.radius, body, facet, edge, true);
+          break;
+        case "splitter":
+          this.seamed(ctx, e.radius, body, facet, edge);
+          break;
+        case "warden":
+          this.diamond(ctx, e.radius, body, facet, edge);
+          break;
+        case "boss":
+          this.bossBody(ctx, e.radius, body, facet, edge, reduced ? 0 : t);
+          break;
+        default:
+          this.diamond(ctx, e.radius, body, facet, edge);
+      }
+      ctx.restore();
+
+      // the ward is a separate, obviously-different ring so it never reads as colour alone
+      if (e.warded) {
+        ctx.save();
+        ctx.translate(e.x, e.y);
+        ctx.rotate(reduced ? 0 : t * 2.2 + e.phase);
+        ctx.strokeStyle = "rgba(111,227,255,0.85)";
+        ctx.lineWidth = 3;
+        for (let i = 0; i < 3; i++) {
+          ctx.beginPath();
+          ctx.arc(0, 0, e.radius + 8, (i * 6.284) / 3, (i * 6.284) / 3 + 1.3);
+          ctx.stroke();
+        }
+        ctx.restore();
+      }
+      if (e.stun > 0) {
+        ctx.save();
+        ctx.translate(e.x, e.y - e.radius - 14);
+        ctx.strokeStyle = "rgba(255,240,200,0.85)";
+        ctx.lineWidth = 2.5;
+        for (let i = 0; i < 3; i++) {
+          const a = t * 6 + (i * 6.284) / 3;
+          ctx.beginPath();
+          ctx.arc(Math.cos(a) * 9, Math.sin(a) * 4, 2.6, 0, 6.284);
+          ctx.stroke();
+        }
+        ctx.restore();
+      }
+
+      // health: a bar only once hurt, so a fresh wave is not a wall of UI
+      if (e.hp < e.maxHp) {
+        const w = e.kind === "boss" ? 110 : Math.max(24, e.radius * 2.2);
+        const frac = clamp01(e.hp / e.maxHp);
+        const yy = e.y - e.radius - (e.kind === "boss" ? 26 : 12);
+        ctx.fillStyle = "rgba(0,0,0,0.65)";
+        ctx.fillRect(e.x - w / 2 - 1, yy - 1, w + 2, 6);
+        ctx.fillStyle = frac > 0.5 ? "#8fb4d8" : frac > 0.22 ? "#ffb648" : C.danger;
+        ctx.fillRect(e.x - w / 2, yy, w * frac, 4);
+      }
+    }
+  }
+
+  private diamond(ctx: CanvasRenderingContext2D, r: number, body: string, facet: string, edge: string): void {
+    ctx.beginPath();
+    ctx.moveTo(r, 0);
+    ctx.lineTo(0, r * 0.82);
+    ctx.lineTo(-r, 0);
+    ctx.lineTo(0, -r * 0.82);
+    ctx.closePath();
+    ctx.fillStyle = body;
+    ctx.fill();
+    ctx.beginPath();
+    ctx.moveTo(r, 0);
+    ctx.lineTo(0, -r * 0.82);
+    ctx.lineTo(-r * 0.3, -r * 0.2);
+    ctx.closePath();
+    ctx.fillStyle = facet;
+    ctx.fill();
+    ctx.strokeStyle = edge;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(r, 0);
+    ctx.lineTo(0, r * 0.82);
+    ctx.lineTo(-r, 0);
+    ctx.lineTo(0, -r * 0.82);
+    ctx.closePath();
+    ctx.stroke();
+  }
+
+  private chevron(ctx: CanvasRenderingContext2D, r: number, body: string, facet: string, edge: string): void {
+    ctx.beginPath();
+    ctx.moveTo(r * 1.5, 0);
+    ctx.lineTo(-r * 0.6, r * 0.85);
+    ctx.lineTo(-r * 0.1, 0);
+    ctx.lineTo(-r * 0.6, -r * 0.85);
+    ctx.closePath();
+    ctx.fillStyle = body;
+    ctx.fill();
+    ctx.strokeStyle = edge;
+    ctx.lineWidth = 2;
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(r * 1.5, 0);
+    ctx.lineTo(-r * 0.6, -r * 0.85);
+    ctx.lineTo(-r * 0.1, 0);
+    ctx.closePath();
+    ctx.fillStyle = facet;
+    ctx.fill();
+  }
+
+  private hex(
+    ctx: CanvasRenderingContext2D,
+    r: number,
+    body: string,
+    facet: string,
+    edge: string,
+    plated: boolean,
+  ): void {
+    ctx.beginPath();
+    for (let i = 0; i < 6; i++) {
+      const a = (Math.PI / 3) * i;
+      const px = Math.cos(a) * r;
+      const py = Math.sin(a) * r * 0.9;
+      if (i === 0) ctx.moveTo(px, py);
+      else ctx.lineTo(px, py);
+    }
+    ctx.closePath();
+    ctx.fillStyle = body;
+    ctx.fill();
+    ctx.strokeStyle = edge;
+    ctx.lineWidth = 3;
+    ctx.stroke();
+    if (plated) {
+      // armour plating: the visual reason a bolt tower is useless here
+      ctx.strokeStyle = facet;
+      ctx.lineWidth = 3;
+      for (let i = -1; i <= 1; i++) {
+        ctx.beginPath();
+        ctx.moveTo(i * r * 0.42, -r * 0.55);
+        ctx.lineTo(i * r * 0.42, r * 0.55);
+        ctx.stroke();
+      }
+    }
+  }
+
+  private seamed(ctx: CanvasRenderingContext2D, r: number, body: string, facet: string, edge: string): void {
+    ctx.beginPath();
+    ctx.arc(0, 0, r, 0, 6.284);
+    ctx.fillStyle = body;
+    ctx.fill();
+    ctx.strokeStyle = edge;
+    ctx.lineWidth = 2.5;
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(0, -r);
+    ctx.lineTo(0, r);
+    ctx.strokeStyle = facet;
+    ctx.lineWidth = 4;
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(0, 0, r * 0.44, 0, 6.284);
+    ctx.strokeStyle = facet;
+    ctx.lineWidth = 2;
+    ctx.stroke();
+  }
+
+  private bossBody(
+    ctx: CanvasRenderingContext2D,
+    r: number,
+    body: string,
+    facet: string,
+    edge: string,
+    t: number,
+  ): void {
+    ctx.save();
+    ctx.rotate(t * 0.4);
+    ctx.beginPath();
+    for (let i = 0; i < 12; i++) {
+      const a = (6.284 / 12) * i;
+      const rr = i % 2 === 0 ? r : r * 0.62;
+      const px = Math.cos(a) * rr;
+      const py = Math.sin(a) * rr;
+      if (i === 0) ctx.moveTo(px, py);
+      else ctx.lineTo(px, py);
+    }
+    ctx.closePath();
+    ctx.fillStyle = body;
+    ctx.fill();
+    ctx.strokeStyle = edge;
+    ctx.lineWidth = 4;
+    ctx.stroke();
+    ctx.restore();
+    ctx.beginPath();
+    ctx.arc(0, 0, r * 0.42, 0, 6.284);
+    ctx.fillStyle = facet;
+    ctx.fill();
+    ctx.beginPath();
+    ctx.arc(0, 0, r * 0.42, 0, 6.284);
+    ctx.strokeStyle = edge;
+    ctx.lineWidth = 3;
+    ctx.stroke();
+  }
+
+  private drawTowers(ctx: CanvasRenderingContext2D, s: State, t: number, o: DrawOpts): void {
+    for (const tw of s.towers) {
+      const age = t - tw.bornAt;
+      const pop = age < 0.4 ? easeOutBack(clamp01(age / 0.4)) : 1;
+      const kick = tw.recoil * tw.recoil;
+      ctx.save();
+      ctx.translate(tw.x - Math.cos(tw.angle) * kick * 7, tw.y - Math.sin(tw.angle) * kick * 7);
+      const sc = pop * (1 + kick * 0.19);
+      ctx.scale(sc, sc);
+
+      // heat halo: charge is visible, so fire rate needs no label
+      const heat = clamp01(tw.heat);
+      ctx.globalCompositeOperation = "lighter";
+      blob(ctx, glows().hot, 0, 0, 54, 0.14 + heat * 0.42);
+      ctx.globalCompositeOperation = "source-over";
+
+      // a seated base ring gives the machine weight and hides the socket edge
+      ctx.beginPath();
+      ctx.arc(0, 0, 27, 0, 6.284);
+      ctx.fillStyle = "#150e11";
+      ctx.fill();
+      ctx.strokeStyle = "rgba(255,166,80,0.28)";
+      ctx.lineWidth = 2.5;
+      ctx.stroke();
+
+      ctx.rotate(tw.angle + Math.PI / 2);
+      const hot = `rgb(${Math.round(120 + heat * 135)},${Math.round(44 + heat * 190)},${Math.round(16 + heat * 190)})`;
+
+      if (tw.kind === "bolt") this.boltBody(ctx, tw.level, hot);
+      else if (tw.kind === "mortar") this.mortarBody(ctx, tw.level, hot);
+      else this.chainBody(ctx, tw.level, hot, o.reducedMotion ? 0 : t);
+
+      ctx.restore();
+
+      // level pips read as count, not colour
+      if (tw.level > 0) {
+        ctx.save();
+        ctx.translate(tw.x, tw.y + 36);
+        for (let i = 0; i <= tw.level; i++) {
+          ctx.beginPath();
+          ctx.arc((i - tw.level / 2) * 9, 0, 3, 0, 6.284);
+          ctx.fillStyle = C.gold;
+          ctx.fill();
+        }
+        ctx.restore();
+      }
+    }
+  }
+
+  /**
+   * Three machines with fixed silhouettes. Level never changes the outline —
+   * it lights the core and adds pips — because a board of twenty towers has to
+   * stay readable at a glance, and a growing shape overruns its pad.
+   */
+  private boltBody(ctx: CanvasRenderingContext2D, level: number, hot: string): void {
+    const glow = 0.4 + level * 0.15;
+    ctx.fillStyle = "#241a1b";
+    ctx.beginPath();
+    ctx.moveTo(-13, 11);
+    ctx.lineTo(13, 11);
+    ctx.lineTo(9, -7);
+    ctx.lineTo(-9, -7);
+    ctx.closePath();
+    ctx.fill();
+    ctx.strokeStyle = `rgba(255,180,96,${glow.toFixed(2)})`;
+    ctx.lineWidth = 1.8;
+    ctx.stroke();
+
+    ctx.fillStyle = "#120d0e";
+    ctx.fillRect(-4, -29, 8, 24);
+    ctx.strokeStyle = hot;
+    ctx.lineWidth = 2;
+    ctx.strokeRect(-4, -29, 8, 24);
+
+    ctx.beginPath();
+    ctx.arc(0, -29, 4.2, 0, 6.284);
+    ctx.fillStyle = hot;
+    ctx.fill();
+
+    // fins: the only thing that changes with level, and it is a count
+    ctx.strokeStyle = hot;
+    ctx.lineWidth = 2.4;
+    for (let i = 0; i < Math.min(3, 1 + Math.floor(level / 2)); i++) {
+      const y = 2 - i * 6;
+      ctx.beginPath();
+      ctx.moveTo(-14 - i, y);
+      ctx.lineTo(-9, y);
+      ctx.moveTo(14 + i, y);
+      ctx.lineTo(9, y);
+      ctx.stroke();
+    }
+  }
+
+  private mortarBody(ctx: CanvasRenderingContext2D, level: number, hot: string): void {
+    const glow = 0.4 + level * 0.15;
+    // treads
+    ctx.fillStyle = "#191213";
+    ctx.fillRect(-21, -6, 6, 24);
+    ctx.fillRect(15, -6, 6, 24);
+    ctx.strokeStyle = `rgba(255,180,96,${(glow * 0.7).toFixed(2)})`;
+    ctx.lineWidth = 1.4;
+    ctx.strokeRect(-21, -6, 6, 24);
+    ctx.strokeRect(15, -6, 6, 24);
+
+    ctx.fillStyle = "#241a1b";
+    ctx.fillRect(-15, -8, 30, 24);
+    ctx.strokeStyle = `rgba(255,180,96,${glow.toFixed(2)})`;
+    ctx.lineWidth = 1.8;
+    ctx.strokeRect(-15, -8, 30, 24);
+
+    // a fat stubby barrel — reads as heavy from any distance
+    ctx.beginPath();
+    ctx.moveTo(-8, -6);
+    ctx.lineTo(8, -6);
+    ctx.lineTo(7, -26);
+    ctx.lineTo(-7, -26);
+    ctx.closePath();
+    ctx.fillStyle = "#120d0e";
+    ctx.fill();
+    ctx.strokeStyle = hot;
+    ctx.lineWidth = 2.4;
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.arc(0, -26, 6.5, 0, 6.284);
+    ctx.strokeStyle = hot;
+    ctx.lineWidth = 3;
+    ctx.stroke();
+
+    for (let i = 0; i < Math.min(4, level + 1); i++) {
+      ctx.fillStyle = hot;
+      ctx.fillRect(-12 + i * 7, 8, 4, 5);
+    }
+  }
+
+  private chainBody(ctx: CanvasRenderingContext2D, level: number, hot: string, t: number): void {
+    const glow = 0.4 + level * 0.15;
+    const r = 18;
+    ctx.beginPath();
+    for (let i = 0; i < 6; i++) {
+      const a = (Math.PI / 3) * i;
+      const px = Math.cos(a) * r;
+      const py = Math.sin(a) * r;
+      if (i === 0) ctx.moveTo(px, py);
+      else ctx.lineTo(px, py);
+    }
+    ctx.closePath();
+    ctx.fillStyle = "#241a1b";
+    ctx.fill();
+    ctx.strokeStyle = `rgba(255,180,96,${glow.toFixed(2)})`;
+    ctx.lineWidth = 1.8;
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.arc(0, 0, 9, 0, 6.284);
+    ctx.strokeStyle = hot;
+    ctx.lineWidth = 2.4;
+    ctx.stroke();
+
+    const nodes = 3 + Math.floor(level / 2);
+    ctx.save();
+    ctx.rotate(t * 1.5);
+    for (let i = 0; i < nodes; i++) {
+      const a = (6.284 / nodes) * i;
+      const nx = Math.cos(a) * 14;
+      const ny = Math.sin(a) * 14;
+      ctx.beginPath();
+      ctx.arc(nx, ny, 3.4, 0, 6.284);
+      ctx.fillStyle = hot;
+      ctx.fill();
+    }
+    ctx.restore();
+  }
+
+  private drawOrdnance(ctx: CanvasRenderingContext2D, s: State): void {
+    ctx.save();
+    ctx.globalCompositeOperation = "lighter";
+    ctx.lineCap = "round";
+
+    for (const sh of s.shots) {
+      if (!sh.alive) continue;
+      // tapered ribbon from the position history
+      for (let i = sh.trailN - 1; i > 0; i--) {
+        const x0 = sh.trail[i * 2] as number;
+        const y0 = sh.trail[i * 2 + 1] as number;
+        const x1 = sh.trail[(i - 1) * 2] as number;
+        const y1 = sh.trail[(i - 1) * 2 + 1] as number;
+        const a = (1 - i / sh.trailN) * 0.55;
+        ctx.strokeStyle = sh.kind === "bolt" ? `rgba(255,206,120,${a})` : `rgba(255,140,50,${a})`;
+        ctx.lineWidth = (sh.kind === "bolt" ? 5 : 9) * (1 - i / sh.trailN);
+        ctx.beginPath();
+        ctx.moveTo(x0, y0);
+        ctx.lineTo(x1, y1);
+        ctx.stroke();
+      }
+      ctx.beginPath();
+      ctx.arc(sh.x, sh.y, sh.kind === "bolt" ? 4.6 : 8, 0, 6.284);
+      ctx.fillStyle = C.whiteHot;
+      ctx.fill();
+      blob(ctx, glows().hot, sh.x, sh.y, sh.kind === "bolt" ? 16 : 28, 0.5);
+    }
+
+    for (const a of s.arcs) {
+      const k = a.life / a.maxLife;
+      ctx.strokeStyle = `rgba(190,236,255,${(k * 0.9).toFixed(3)})`;
+      ctx.lineWidth = 2 + k * 5;
+      ctx.beginPath();
+      for (let i = 0; i + 1 < a.pts.length; i += 2) {
+        const x = a.pts[i] as number;
+        const y = a.pts[i + 1] as number;
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.stroke();
+      ctx.strokeStyle = `rgba(255,255,255,${(k * 0.8).toFixed(3)})`;
+      ctx.lineWidth = 1 + k * 2;
+      ctx.stroke();
+    }
+    ctx.restore();
+  }
+
+  private drawParticles(ctx: CanvasRenderingContext2D, p: Particles, additive: boolean): void {
+    ctx.save();
+    ctx.globalCompositeOperation = additive ? "lighter" : "source-over";
+    const n = p.count;
+    for (let i = 0; i < n; i++) {
+      const kind = p.kind[i] as number;
+      const isAdd = kind === PKind.Spark || kind === PKind.Ring || kind === PKind.Ember || kind === PKind.Bolt;
+      if (isAdd !== additive) continue;
+      const life = (p.life[i] as number) / (p.maxLife[i] as number);
+      const x = p.x[i] as number;
+      const y = p.y[i] as number;
+      const sz = p.size[i] as number;
+      const hue = p.hue[i] as number;
+
+      if (kind === PKind.Spark) {
+        // three discrete sprites read as a cooling ember, and cost one blit each
+        const g = glows();
+        const sprite = life > 0.62 ? g.white : life > 0.3 ? g.hot : g.deep;
+        blob(ctx, sprite, x, y, sz * (0.9 + life * 1.5), life * life);
+      } else if (kind === PKind.Ember) {
+        blob(ctx, hue > 0.5 ? glows().white : glows().hot, x, y, sz * 2.4, life * 0.6);
+      } else if (kind === PKind.Ring) {
+        const grow = 1 - life;
+        ctx.strokeStyle = `rgba(255,${Math.round(190 + hue * 50)},${Math.round(140 + hue * 80)},${(life * life * 0.8).toFixed(3)})`;
+        ctx.lineWidth = 2 + life * 9;
+        ctx.beginPath();
+        ctx.arc(x, y, sz * easeOutCubic(grow), 0, 6.284);
+        ctx.stroke();
+      } else if (kind === PKind.Shard) {
+        ctx.save();
+        ctx.translate(x, y);
+        ctx.rotate(p.rot[i] as number);
+        ctx.fillStyle = `rgba(${Math.round(40 + hue * 40)},${Math.round(56 + hue * 40)},${Math.round(76 + hue * 40)},${clamp01(life * 1.5).toFixed(3)})`;
+        ctx.fillRect(-sz / 2, -sz / 2, sz, sz * 0.7);
+        ctx.restore();
+      } else if (kind === PKind.Smoke) {
+        const grow = 1 + (1 - life) * 1.5;
+        ctx.fillStyle = `rgba(${Math.round(24 + hue * 20)},${Math.round(18 + hue * 14)},${Math.round(20 + hue * 14)},${(life * 0.34).toFixed(3)})`;
+        ctx.beginPath();
+        ctx.arc(x, y, sz * grow, 0, 6.284);
+        ctx.fill();
+      }
+    }
+    ctx.restore();
+  }
+
+  private drawPopups(ctx: CanvasRenderingContext2D, s: State): void {
+    ctx.save();
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    for (const p of s.popups) {
+      if (!p.alive) continue;
+      const k = p.life / p.maxLife;
+      const size = (p.big ? 42 : 26) * (1 + (1 - k) * 0.18);
+      ctx.font = font(size);
+      ctx.globalAlpha = clamp01(k * 1.6);
+      ctx.lineWidth = 5;
+      ctx.strokeStyle = "rgba(0,0,0,0.75)";
+      ctx.strokeText(p.text, p.x, p.y);
+      ctx.fillStyle = p.tone === 1 ? C.gold : p.tone === 2 ? C.danger : "#ffe4bb";
+      ctx.fillText(p.text, p.x, p.y);
+    }
+    ctx.globalAlpha = 1;
+    ctx.restore();
+  }
+}
+
+export function towerLabel(kind: TowerKind): string {
+  return TOWERS[kind].name;
+}

--- a/dynawalla/games/siege/src/render/particles.ts
+++ b/dynawalla/games/siege/src/render/particles.ts
@@ -1,0 +1,202 @@
+/**
+ * Pooled particle system. Fixed-size struct-of-arrays, zero allocation after
+ * construction, hard ceiling. When the pool is full the oldest particle is
+ * recycled — the burst you just asked for always lands, the frame budget never
+ * moves.
+ */
+import { MAX_PARTICLES } from "../game/constants.ts";
+
+export const enum PKind {
+  Spark = 0, // additive hot streak, gravity, shrinks
+  Shard = 1, // cold obsidian debris, tumbles, opaque
+  Smoke = 2, // dark soft puff, rises, big
+  Ring = 3, // expanding shock ring
+  Ember = 4, // slow drifting mote
+  Bolt = 5, // straight bright line segment
+}
+
+export class Particles {
+  private n = 0;
+  private head = 0;
+  readonly kind = new Uint8Array(MAX_PARTICLES);
+  readonly x = new Float32Array(MAX_PARTICLES);
+  readonly y = new Float32Array(MAX_PARTICLES);
+  readonly vx = new Float32Array(MAX_PARTICLES);
+  readonly vy = new Float32Array(MAX_PARTICLES);
+  readonly life = new Float32Array(MAX_PARTICLES);
+  readonly maxLife = new Float32Array(MAX_PARTICLES);
+  readonly size = new Float32Array(MAX_PARTICLES);
+  readonly rot = new Float32Array(MAX_PARTICLES);
+  readonly spin = new Float32Array(MAX_PARTICLES);
+  readonly hue = new Float32Array(MAX_PARTICLES); // 0..1 lerps within a kind's ramp
+  readonly drag = new Float32Array(MAX_PARTICLES);
+  readonly grav = new Float32Array(MAX_PARTICLES);
+
+  get count(): number {
+    return this.n;
+  }
+
+  clear(): void {
+    this.n = 0;
+    this.head = 0;
+  }
+
+  private slot(): number {
+    if (this.n < MAX_PARTICLES) return this.n++;
+    const i = this.head;
+    this.head = (this.head + 1) % MAX_PARTICLES;
+    return i;
+  }
+
+  spawn(
+    kind: PKind,
+    x: number,
+    y: number,
+    vx: number,
+    vy: number,
+    life: number,
+    size: number,
+    hue: number,
+    grav = 0,
+    drag = 1.6,
+    spin = 0,
+  ): void {
+    const i = this.slot();
+    this.kind[i] = kind;
+    this.x[i] = x;
+    this.y[i] = y;
+    this.vx[i] = vx;
+    this.vy[i] = vy;
+    this.life[i] = life;
+    this.maxLife[i] = life;
+    this.size[i] = size;
+    this.hue[i] = hue;
+    this.grav[i] = grav;
+    this.drag[i] = drag;
+    this.rot[i] = 0;
+    this.spin[i] = spin;
+  }
+
+  update(dt: number): void {
+    let w = 0;
+    for (let i = 0; i < this.n; i++) {
+      const l = (this.life[i] as number) - dt;
+      if (l <= 0) continue;
+      const d = Math.exp(-(this.drag[i] as number) * dt);
+      const nvx = (this.vx[i] as number) * d;
+      const nvy = (this.vy[i] as number) * d + (this.grav[i] as number) * dt;
+      const nx = (this.x[i] as number) + nvx * dt;
+      const ny = (this.y[i] as number) + nvy * dt;
+      if (w !== i) {
+        this.kind[w] = this.kind[i] as number;
+        this.maxLife[w] = this.maxLife[i] as number;
+        this.size[w] = this.size[i] as number;
+        this.hue[w] = this.hue[i] as number;
+        this.grav[w] = this.grav[i] as number;
+        this.drag[w] = this.drag[i] as number;
+        this.spin[w] = this.spin[i] as number;
+      }
+      this.life[w] = l;
+      this.vx[w] = nvx;
+      this.vy[w] = nvy;
+      this.x[w] = nx;
+      this.y[w] = ny;
+      this.rot[w] = (this.rot[i] as number) + (this.spin[i] as number) * dt;
+      w++;
+    }
+    this.n = w;
+    this.head = 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// burst recipes — the vocabulary the game speaks in
+// ---------------------------------------------------------------------------
+
+export function burstSparks(
+  p: Particles,
+  x: number,
+  y: number,
+  n: number,
+  power: number,
+  rand: () => number,
+): void {
+  for (let i = 0; i < n; i++) {
+    const a = rand() * Math.PI * 2;
+    const sp = power * (0.35 + rand() * 0.9);
+    p.spawn(
+      PKind.Spark,
+      x,
+      y,
+      Math.cos(a) * sp,
+      Math.sin(a) * sp,
+      0.22 + rand() * 0.4,
+      2 + rand() * 3.4,
+      rand(),
+      260,
+      2.4,
+    );
+  }
+}
+
+export function burstShatter(
+  p: Particles,
+  x: number,
+  y: number,
+  n: number,
+  power: number,
+  radius: number,
+  rand: () => number,
+): void {
+  for (let i = 0; i < n; i++) {
+    const a = rand() * Math.PI * 2;
+    const sp = power * (0.4 + rand() * 1.0);
+    p.spawn(
+      PKind.Shard,
+      x,
+      y,
+      Math.cos(a) * sp,
+      Math.sin(a) * sp,
+      0.45 + rand() * 0.55,
+      radius * (0.18 + rand() * 0.3),
+      rand(),
+      420,
+      1.1,
+      (rand() - 0.5) * 22,
+    );
+  }
+  for (let i = 0; i < Math.ceil(n / 3); i++) {
+    const a = rand() * Math.PI * 2;
+    p.spawn(
+      PKind.Smoke,
+      x,
+      y,
+      Math.cos(a) * power * 0.2,
+      Math.sin(a) * power * 0.2 - 14,
+      0.6 + rand() * 0.6,
+      radius * (0.5 + rand() * 0.7),
+      rand(),
+      -8,
+      1.5,
+    );
+  }
+}
+
+export function ring(p: Particles, x: number, y: number, size: number, life: number, hue: number): void {
+  p.spawn(PKind.Ring, x, y, 0, 0, life, size, hue, 0, 0);
+}
+
+export function emberMote(p: Particles, x: number, y: number, rand: () => number): void {
+  p.spawn(
+    PKind.Ember,
+    x,
+    y,
+    (rand() - 0.5) * 26,
+    -14 - rand() * 30,
+    1.2 + rand() * 1.4,
+    1.4 + rand() * 2.2,
+    rand(),
+    -6,
+    0.5,
+  );
+}

--- a/dynawalla/games/siege/src/siege.test.ts
+++ b/dynawalla/games/siege/src/siege.test.ts
@@ -1,0 +1,323 @@
+/**
+ * The guarantees that must not rot: exact integers, determinism, mal-rule
+ * distractors, no run-length reward, and a wave curve that actually escalates.
+ *
+ *   npm test
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { createStubHost, malSmallerFromLarger, malDroppedCarry, malNoCarryMul } from "./stubHost.ts";
+import { makeRng } from "./core/rng.ts";
+import { buildWave, hpScale, scaledHp, mathFloor } from "./game/waves.ts";
+import { buildPath } from "./game/path.ts";
+import { buildPlots } from "./game/board.ts";
+import {
+  ENEMIES,
+  MAX_LEVEL,
+  towerDamage,
+  towerUpgradeCost,
+  TOWERS,
+  CORE_MAX_HP,
+} from "./game/constants.ts";
+import {
+  computeDamage,
+  createState,
+  emberReward,
+  step,
+  tryBuild,
+  NO_EFFECTS,
+  type Enemy,
+} from "./game/state.ts";
+
+const enemy = (over: Partial<Enemy> = {}): Enemy =>
+  ({
+    alive: true,
+    kind: "shard",
+    hp: 100,
+    maxHp: 100,
+    s: 0,
+    x: 0,
+    y: 0,
+    dirX: 1,
+    dirY: 0,
+    speed: 100,
+    armor: 0,
+    bounty: 1,
+    radius: 10,
+    leak: 1,
+    warded: false,
+    splits: 0,
+    stun: 0,
+    hitFlash: 0,
+    born: 0,
+    phase: 0,
+    popAcc: 0,
+    popAt: 0,
+    ...over,
+  }) as Enemy;
+
+// ---------------------------------------------------------------------------
+// exactness
+// ---------------------------------------------------------------------------
+
+test("every generated answer is an exact integer string", () => {
+  for (const seed of [1, 7, 99, 12345]) {
+    const host = createStubHost({ seed, difficulty: 0 });
+    for (let d = 0; d <= 20; d++) {
+      host.raiseFloor(d / 20);
+      for (let i = 0; i < 40; i++) {
+        const q = host.next();
+        assert.match(q.answer, /^-?\d+$/, `answer not an integer: ${q.prompt} -> ${q.answer}`);
+        assert.equal(String(Number(q.answer)), q.answer);
+        for (const w of q.distractors) {
+          assert.match(w, /^\d+$/, `distractor not an integer: ${w}`);
+          assert.notEqual(w, q.answer, `distractor equals the answer for ${q.prompt}`);
+        }
+      }
+    }
+  }
+});
+
+test("a question always offers exactly three distinct distractors", () => {
+  const host = createStubHost({ seed: 4242, difficulty: 0.5 });
+  for (let i = 0; i < 400; i++) {
+    const q = host.next();
+    assert.equal(q.distractors.length, 3, `only ${q.distractors.length} for ${q.prompt}`);
+    assert.equal(new Set(q.distractors).size, 3, `duplicate distractors for ${q.prompt}`);
+  }
+});
+
+test("prompts state their own truth", () => {
+  const host = createStubHost({ seed: 88, difficulty: 0.5 });
+  const ops: Record<string, (a: number, b: number) => number> = {
+    "+": (a, b) => a + b,
+    "−": (a, b) => a - b,
+    "×": (a, b) => a * b,
+    "÷": (a, b) => a / b,
+  };
+  for (let i = 0; i < 600; i++) {
+    const q = host.next();
+    const parts = q.prompt.split(" ");
+    if (parts.length === 3) {
+      const [a, op, b] = parts as [string, string, string];
+      const f = ops[op];
+      if (!f) {
+        assert.fail(`unknown operator ${op} in ${q.prompt}`);
+        return;
+      }
+      assert.equal(String(f(Number(a), Number(b))), q.answer, q.prompt);
+    } else if (parts.length === 5) {
+      // rate family: a × b ± c, precedence first
+      const [a, , b, op2, c] = parts as [string, string, string, string, string];
+      const prod = Number(a) * Number(b);
+      const total = op2 === "+" ? prod + Number(c) : prod - Number(c);
+      assert.equal(String(total), q.answer, q.prompt);
+    } else {
+      assert.fail(`unparseable prompt: ${q.prompt}`);
+    }
+  }
+});
+
+test("mal-rules reproduce the classic wrong answers", () => {
+  // "take the smaller digit from the larger, column by column"
+  assert.equal(malSmallerFromLarger(52, 38), 26);
+  assert.equal(malSmallerFromLarger(71, 29), 58);
+  // "add the columns, write the units, lose the carry"
+  assert.equal(malDroppedCarry(28, 34), 52);
+  assert.equal(malDroppedCarry(47, 38), 75);
+  // "multiply every digit, never carry"
+  assert.equal(malNoCarryMul(23, 4), 82);
+});
+
+test("ember reward is an integer at every difficulty", () => {
+  for (let i = 0; i <= 100; i++) {
+    const r = emberReward(i / 100);
+    assert.ok(Number.isInteger(r), `${r} is not an integer`);
+    assert.ok(r > 0);
+  }
+});
+
+test("damage is a positive integer after armour and wards", () => {
+  for (const base of [1, 6, 7, 26, 104, 999]) {
+    for (const armor of [0, 3, 6, 10, 5000]) {
+      for (const warded of [false, true]) {
+        for (const single of [false, true]) {
+          const d = computeDamage(base, enemy({ armor, warded }), single);
+          assert.ok(Number.isInteger(d), `${d} not integer`);
+          assert.ok(d >= 1, `${d} below the floor of 1`);
+        }
+      }
+    }
+  }
+});
+
+test("a ward blunts single-target fire and not splash", () => {
+  const w = enemy({ warded: true });
+  assert.ok(computeDamage(100, w, true) < computeDamage(100, w, false));
+  const plain = enemy({});
+  assert.equal(computeDamage(100, plain, true), computeDamage(100, plain, false));
+});
+
+test("tower damage and upgrade costs are integers, and top out", () => {
+  for (const kind of ["bolt", "mortar", "chain"] as const) {
+    for (let l = 0; l <= MAX_LEVEL; l++) {
+      assert.ok(Number.isInteger(towerDamage(kind, l)));
+      const c = towerUpgradeCost(kind, l);
+      if (l === MAX_LEVEL) assert.equal(c, null);
+      else {
+        assert.ok(Number.isInteger(c as number));
+        assert.ok((c as number) > TOWERS[kind].cost);
+      }
+    }
+    // strictly increasing damage, so an upgrade is never a downgrade
+    for (let l = 1; l <= MAX_LEVEL; l++) {
+      assert.ok(towerDamage(kind, l) > towerDamage(kind, l - 1));
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// determinism
+// ---------------------------------------------------------------------------
+
+test("the same seed plays the same siege", () => {
+  const a = buildWave(9, 1234);
+  const b = buildWave(9, 1234);
+  assert.deepEqual(a, b);
+  const c = buildWave(9, 1235);
+  assert.notDeepEqual(a.orders, c.orders);
+});
+
+test("the rng is stable across runs and diverges on nearby seeds", () => {
+  const a = Array.from({ length: 8 }, (_, i) => makeRng(7).i(0, 1000) + i * 0);
+  const b = Array.from({ length: 8 }, () => makeRng(7).i(0, 1000));
+  assert.deepEqual(a, b);
+  assert.notEqual(makeRng(7).i(0, 1e9), makeRng(8).i(0, 1e9));
+});
+
+test("the board is deterministic and every pad can reach the channel", () => {
+  const p = buildPath();
+  const plots = buildPlots(p);
+  assert.deepEqual(
+    plots.map((q) => [Math.round(q.x), Math.round(q.y)]),
+    buildPlots(buildPath()).map((q) => [Math.round(q.x), Math.round(q.y)]),
+  );
+  assert.ok(plots.length >= 16 && plots.length <= 26, `${plots.length} pads`);
+  for (const plot of plots) {
+    assert.ok(plot.value > 0.02, `pad ${plot.id} covers almost none of the channel`);
+    assert.ok(p.distanceTo(plot.x, plot.y) >= 70, `pad ${plot.id} sits in the lava`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// escalation
+// ---------------------------------------------------------------------------
+
+test("waves escalate superlinearly, and boss waves spike above their neighbours", () => {
+  let prevHp = 0;
+  let prevCount = 0;
+  for (let n = 1; n <= 30; n++) {
+    const w = buildWave(n, 99);
+    assert.ok(w.count >= prevCount, `wave ${n} has fewer enemies than ${n - 1}`);
+    assert.ok(Number.isInteger(w.totalHp));
+    if (!w.hasBoss) {
+      // the ordinary curve only ever rises; boss waves are a deliberate saw-tooth
+      assert.ok(w.totalHp > prevHp, `wave ${n} is not bigger than the last ordinary wave`);
+      prevHp = w.totalHp;
+    } else {
+      assert.ok(
+        w.totalHp > buildWave(n + 1, 99).totalHp,
+        `boss wave ${n} does not spike above wave ${n + 1}`,
+      );
+    }
+    prevCount = w.count;
+  }
+  // the curve must bend upward, not just rise
+  const d10 = buildWave(12, 99).totalHp - buildWave(11, 99).totalHp;
+  const d25 = buildWave(27, 99).totalHp - buildWave(26, 99).totalHp;
+  assert.ok(d25 > d10 * 4, `escalation is too flat: ${d10} then ${d25}`);
+});
+
+test("every enemy health value is a positive integer", () => {
+  for (let n = 1; n <= 40; n++) {
+    for (const kind of Object.keys(ENEMIES) as (keyof typeof ENEMIES)[]) {
+      const hp = scaledHp(kind, n);
+      assert.ok(Number.isInteger(hp) && hp >= 1);
+    }
+    for (const o of buildWave(n, 5).orders) {
+      assert.ok(Number.isInteger(o.hp) && o.hp >= 1);
+    }
+  }
+  assert.equal(hpScale(1), 1);
+});
+
+test("bosses arrive every fifth wave and only then", () => {
+  for (let n = 1; n <= 25; n++) {
+    assert.equal(buildWave(n, 3).hasBoss, n % 5 === 0, `wave ${n}`);
+  }
+});
+
+test("the maths floor rises with the siege but never runs away", () => {
+  assert.equal(mathFloor(1), 0);
+  assert.ok(mathFloor(10) > mathFloor(5));
+  assert.ok(mathFloor(200) <= 0.72);
+});
+
+// ---------------------------------------------------------------------------
+// the ethics line
+// ---------------------------------------------------------------------------
+
+test("difficulty answers to correctness, never to a streak", () => {
+  const host = createStubHost({ seed: 2, difficulty: 0.5 });
+  // report takes no run length; the only lever is the answer and the time
+  assert.equal(host.report.length, 1);
+  const before = host.difficulty();
+  host.report({ questionId: "x", correct: false, ms: 900, answered: "0" });
+  assert.ok(host.difficulty() < before, "a wrong answer must ease off");
+  const dip = host.difficulty();
+  host.report({ questionId: "y", correct: true, ms: 900, answered: "0" });
+  assert.ok(host.difficulty() > dip, "a right answer must push up");
+});
+
+test("a wrong answer costs nothing but time — no health, no embers", () => {
+  const s = createState(1);
+  const embers = s.embers;
+  const core = s.coreHp;
+  // the anvil is the only place a wrong answer lands, and the sim never sees it
+  step(s, 1 / 60, NO_EFFECTS);
+  assert.equal(s.embers, embers);
+  assert.equal(s.coreHp, core);
+  assert.equal(s.coreHp, CORE_MAX_HP);
+});
+
+// ---------------------------------------------------------------------------
+// the loop actually runs
+// ---------------------------------------------------------------------------
+
+test("a headless siege spawns, fights and clears wave one", () => {
+  const s = createState(31337);
+  s.embers += 200; // this test is about the loop, not the opening economy
+  const plots = s.plots.slice().sort((a, b) => b.value - a.value);
+  for (let i = 0; i < 3; i++) {
+    assert.ok(tryBuild(s, (plots[i] as { id: number }).id, "bolt", NO_EFFECTS));
+  }
+  assert.equal(s.towers.length, 3);
+  let killed = 0;
+  const fx = { ...NO_EFFECTS, kill: () => killed++ };
+  for (let i = 0; i < 60 * 240 && s.wave === 1; i++) step(s, 1 / 60, fx);
+  assert.ok(killed > 0, "nothing died");
+  assert.equal(s.wave, 2, "wave one never cleared");
+  assert.ok(s.embers > 0);
+});
+
+test("leaks damage the forge and the forge can go cold", () => {
+  const s = createState(7);
+  let defeated = -1;
+  const fx = { ...NO_EFFECTS, defeat: (w: number) => (defeated = w) };
+  // no towers at all: every wave walks straight through
+  for (let i = 0; i < 60 * 900 && s.phase !== "defeat"; i++) step(s, 1 / 60, fx);
+  assert.equal(s.phase, "defeat");
+  assert.equal(s.coreHp, 0);
+  assert.ok(defeated >= 1);
+});

--- a/dynawalla/games/siege/src/stubHost.ts
+++ b/dynawalla/games/siege/src/stubHost.ts
@@ -1,0 +1,367 @@
+/**
+ * Local stub Host so SIEGE is playable standalone.
+ *
+ * Everything here is exact integer arithmetic — no float ever reaches an answer
+ * or a comparison. Distractors are real mal-rule outputs (the wrong answer a
+ * child actually produces when a specific procedure breaks), not random noise.
+ *
+ * Difficulty is *adaptive*: it rises when answers are correct and fast, falls
+ * when they are wrong. That is what the real host will do, so the swap changes
+ * nothing about how the game feels.
+ */
+import type { Host, Question } from "./contract.ts";
+import { makeRng, type Rng } from "./core/rng.ts";
+import { clamp01 } from "./core/easing.ts";
+
+// ---------------------------------------------------------------------------
+// mal-rules
+// ---------------------------------------------------------------------------
+
+/** Column subtraction with the "always take the smaller digit from the larger" bug. */
+export function malSmallerFromLarger(a: number, b: number): number {
+  const as = String(a);
+  const bs = String(b).padStart(as.length, "0");
+  let out = "";
+  for (let i = 0; i < as.length; i++) {
+    const da = Number(as[i]);
+    const db = Number(bs[i]);
+    out += String(Math.abs(da - db));
+  }
+  const n = Number(out);
+  return Number.isFinite(n) ? n : a - b;
+}
+
+/** Column subtraction that borrows but forgets to decrement the next column. */
+export function malForgotDecrement(a: number, b: number): number {
+  const as = String(a).split("").map(Number);
+  const bs = String(b).padStart(as.length, "0").split("").map(Number);
+  const out: number[] = [];
+  for (let i = as.length - 1; i >= 0; i--) {
+    const da = as[i] as number;
+    const db = bs[i] as number;
+    out.unshift(da >= db ? da - db : da + 10 - db); // borrows, never pays it back
+  }
+  return Number(out.join(""));
+}
+
+/** Column addition that writes the full column sum's units but drops the carry. */
+export function malDroppedCarry(a: number, b: number): number {
+  const as = String(a).split("").map(Number);
+  const bs = String(b).split("").map(Number);
+  const len = Math.max(as.length, bs.length);
+  while (as.length < len) as.unshift(0);
+  while (bs.length < len) bs.unshift(0);
+  const out: number[] = [];
+  for (let i = len - 1; i >= 0; i--) {
+    out.unshift(((as[i] as number) + (bs[i] as number)) % 10);
+  }
+  return Number(out.join(""));
+}
+
+/** Short multiplication that multiplies each digit but never carries. */
+export function malNoCarryMul(a: number, m: number): number {
+  const as = String(a).split("").map(Number);
+  const out: number[] = [];
+  for (let i = as.length - 1; i >= 0; i--) out.unshift(((as[i] as number) * m) % 10);
+  return Number(out.join(""));
+}
+
+// ---------------------------------------------------------------------------
+// question families
+// ---------------------------------------------------------------------------
+
+type Built = { prompt: string; answer: number; wrong: number[]; domain: string };
+
+const MINUS = "−"; // U+2212 MINUS SIGN — reads as arithmetic, not a hyphen
+const TIMES = "×";
+const DIVIDE = "÷";
+
+function addSmall(rng: Rng): Built {
+  const a = rng.i(2, 9);
+  const b = rng.i(2, 9);
+  return {
+    prompt: `${a} + ${b}`,
+    answer: a + b,
+    wrong: [a + b + 1, a + b - 1, a + b + 10],
+    domain: "add-sub",
+  };
+}
+
+function subSmall(rng: Rng): Built {
+  const a = rng.i(6, 18);
+  const b = rng.i(2, Math.min(9, a - 1));
+  return {
+    prompt: `${a} ${MINUS} ${b}`,
+    answer: a - b,
+    wrong: [a - b + 1, a - b - 1, a + b],
+    domain: "add-sub",
+  };
+}
+
+function addTwoDigit(rng: Rng): Built {
+  const a = rng.i(14, 89);
+  const b = rng.i(14, 89);
+  return {
+    prompt: `${a} + ${b}`,
+    answer: a + b,
+    wrong: [malDroppedCarry(a, b), a + b - 10, a + b + 10],
+    domain: "add-sub",
+  };
+}
+
+function subTwoDigit(rng: Rng): Built {
+  // force a regroup so the mal-rule is live
+  const bOnes = rng.i(4, 9);
+  const aOnes = rng.i(0, bOnes - 1);
+  const aTens = rng.i(3, 9);
+  const bTens = rng.i(1, aTens - 1);
+  const a = aTens * 10 + aOnes;
+  const b = bTens * 10 + bOnes;
+  return {
+    prompt: `${a} ${MINUS} ${b}`,
+    answer: a - b,
+    wrong: [malSmallerFromLarger(a, b), malForgotDecrement(a, b), a - b + 10],
+    domain: "add-sub",
+  };
+}
+
+function subThreeDigit(rng: Rng): Built {
+  const a = rng.i(302, 950);
+  const b = rng.i(108, a - 60);
+  return {
+    prompt: `${a} ${MINUS} ${b}`,
+    answer: a - b,
+    wrong: [malSmallerFromLarger(a, b), malForgotDecrement(a, b), a - b + 100],
+    domain: "add-sub",
+  };
+}
+
+function table(rng: Rng, lo: number, hi: number): Built {
+  const a = rng.i(lo, hi);
+  const b = rng.i(2, 9);
+  const p = a * b;
+  return {
+    prompt: `${a} ${TIMES} ${b}`,
+    answer: p,
+    wrong: [p - a, p + a, a + b],
+    domain: "mul-div",
+  };
+}
+
+function bigTable(rng: Rng): Built {
+  const a = rng.i(6, 12);
+  const b = rng.i(6, 12);
+  const p = a * b;
+  return {
+    prompt: `${a} ${TIMES} ${b}`,
+    answer: p,
+    wrong: [p - a, p + b, p - b],
+    domain: "mul-div",
+  };
+}
+
+function shortMul(rng: Rng): Built {
+  const a = rng.i(13, 49);
+  const m = rng.i(3, 9);
+  const p = a * m;
+  return {
+    prompt: `${a} ${TIMES} ${m}`,
+    answer: p,
+    wrong: [malNoCarryMul(a, m), p - m, p + 10],
+    domain: "mul-div",
+  };
+}
+
+function divFact(rng: Rng): Built {
+  const b = rng.i(3, 12);
+  const q = rng.i(3, 12);
+  const a = b * q;
+  return {
+    prompt: `${a} ${DIVIDE} ${b}`,
+    answer: q,
+    wrong: [q + 1, q - 1, b],
+    domain: "mul-div",
+  };
+}
+
+/** Rate maths, which is what a tower defence player is actually doing. */
+function rateStep(rng: Rng): Built {
+  const dmg = rng.i(4, 12);
+  const shots = rng.i(3, 9);
+  const bonus = rng.i(2, 20);
+  const plus = rng.chance(0.6);
+  const total = plus ? dmg * shots + bonus : dmg * shots - bonus;
+  return {
+    prompt: plus
+      ? `${dmg} ${TIMES} ${shots} + ${bonus}`
+      : `${dmg} ${TIMES} ${shots} ${MINUS} ${bonus}`,
+    answer: total,
+    // order-of-operations mal-rule: left-to-right regardless of precedence
+    wrong: [
+      plus ? dmg * (shots + bonus) : dmg * (shots - bonus),
+      total + dmg,
+      total - shots,
+    ],
+    domain: "rate",
+  };
+}
+
+function doubleDigitMul(rng: Rng): Built {
+  const a = rng.i(11, 29);
+  const b = rng.i(11, 25);
+  const p = a * b;
+  const at = Math.floor(a / 10) * 10;
+  const ao = a % 10;
+  const bt = Math.floor(b / 10) * 10;
+  const bo = b % 10;
+  return {
+    prompt: `${a} ${TIMES} ${b}`,
+    answer: p,
+    // the classic "multiply the tens, multiply the ones, add" cross-term omission
+    wrong: [at * bt + ao * bo, p - a, p + b],
+    domain: "mul-div",
+  };
+}
+
+type Family = { build: (r: Rng) => Built; lo: number; hi: number };
+
+/** Each family is live over a difficulty band; bands overlap so the mix breathes. */
+const FAMILIES: readonly Family[] = [
+  { build: addSmall, lo: 0.0, hi: 0.26 },
+  { build: subSmall, lo: 0.0, hi: 0.34 },
+  { build: (r) => table(r, 2, 5), lo: 0.14, hi: 0.46 },
+  { build: addTwoDigit, lo: 0.2, hi: 0.6 },
+  { build: subTwoDigit, lo: 0.26, hi: 0.72 },
+  { build: (r) => table(r, 3, 9), lo: 0.3, hi: 0.66 },
+  { build: divFact, lo: 0.4, hi: 0.82 },
+  { build: bigTable, lo: 0.46, hi: 0.86 },
+  { build: shortMul, lo: 0.58, hi: 1.01 },
+  { build: subThreeDigit, lo: 0.64, hi: 1.01 },
+  { build: rateStep, lo: 0.7, hi: 1.01 },
+  { build: doubleDigitMul, lo: 0.84, hi: 1.01 },
+];
+
+// ---------------------------------------------------------------------------
+// the host
+// ---------------------------------------------------------------------------
+
+export type StubHostOptions = {
+  seed?: number;
+  /** starting difficulty, 0..1 */
+  difficulty?: number;
+  /** called on every report — the game uses it for telemetry/HUD */
+  onReport?: (r: {
+    questionId: string;
+    correct: boolean;
+    ms: number;
+    answered: string;
+    difficulty: number;
+  }) => void;
+};
+
+export type StubHost = Host & {
+  /** current adaptive difficulty, 0..1 — read-only view for the HUD */
+  difficulty(): number;
+  /** the game nudges the floor up as waves escalate; never lowers the child's level */
+  raiseFloor(v: number): void;
+};
+
+export function createStubHost(opts: StubHostOptions = {}): StubHost {
+  const rng = makeRng(opts.seed ?? 0x5e1e6e);
+  let difficulty = clamp01(opts.difficulty ?? 0.1);
+  let floor = 0;
+  let n = 0;
+  const recent: string[] = [];
+
+  const buildOne = (): Built => {
+    const eligible = FAMILIES.filter((f) => difficulty >= f.lo && difficulty < f.hi);
+    const pool = eligible.length > 0 ? eligible : [FAMILIES[0] as Family];
+    // 24 attempts to avoid repeating a prompt we just showed
+    for (let attempt = 0; attempt < 24; attempt++) {
+      const built = rng.pick(pool).build(rng);
+      if (!recent.includes(built.prompt)) return built;
+    }
+    return rng.pick(pool).build(rng);
+  };
+
+  const next = (): Question => {
+    const built = buildOne();
+    recent.push(built.prompt);
+    if (recent.length > 9) recent.shift();
+
+    const seen = new Set<number>([built.answer]);
+    const distractors: string[] = [];
+    for (const w of built.wrong) {
+      if (w < 0 || !Number.isInteger(w) || seen.has(w)) continue;
+      seen.add(w);
+      distractors.push(String(w));
+    }
+    // top up deterministically if a mal-rule collided with the answer
+    let bump = 1;
+    while (distractors.length < 3) {
+      for (const cand of [built.answer + bump, built.answer - bump, built.answer + bump * 10]) {
+        if (distractors.length >= 3) break;
+        if (cand < 0 || seen.has(cand)) continue;
+        seen.add(cand);
+        distractors.push(String(cand));
+      }
+      bump++;
+      if (bump > 40) break;
+    }
+
+    n++;
+    return {
+      id: `s${n}`,
+      prompt: built.prompt,
+      answer: String(built.answer),
+      distractors,
+      domain: built.domain,
+      difficulty,
+    };
+  };
+
+  const canVibrate =
+    typeof navigator !== "undefined" && typeof navigator.vibrate === "function";
+
+  const PATTERNS: Record<string, number | number[]> = {
+    light: 8,
+    medium: 18,
+    heavy: 40,
+    success: [10, 30, 22],
+    failure: [26, 40, 26],
+  };
+
+  return {
+    next,
+    report(r) {
+      // fast + right pushes up, slowly; wrong pulls down harder than right pushes up
+      // ~70 clean answers to cross the whole range: a child should feel the
+      // ground move under them over a session, not inside two minutes
+      if (r.correct) {
+        const fast = r.ms < 2600 ? 1 : r.ms < 5200 ? 0.55 : 0.2;
+        difficulty = clamp01(difficulty + 0.014 * fast);
+      } else {
+        difficulty = clamp01(difficulty - 0.045);
+      }
+      if (difficulty < floor) difficulty = floor;
+      opts.onReport?.({ ...r, difficulty });
+    },
+    haptic(kind) {
+      if (!canVibrate) return;
+      try {
+        navigator.vibrate(PATTERNS[kind] ?? 10);
+      } catch {
+        /* a browser that rejects vibrate is not an error worth surfacing */
+      }
+    },
+    prefersReducedMotion() {
+      if (typeof matchMedia !== "function") return false;
+      return matchMedia("(prefers-reduced-motion: reduce)").matches;
+    },
+    difficulty: () => difficulty,
+    raiseFloor(v) {
+      floor = clamp01(Math.max(floor, v));
+      if (difficulty < floor) difficulty = floor;
+    },
+  };
+}

--- a/dynawalla/games/siege/src/ui/hud.ts
+++ b/dynawalla/games/siege/src/ui/hud.ts
@@ -1,0 +1,600 @@
+/**
+ * The DOM chrome: the anvil, the build menus, the focus overlay and the banners.
+ *
+ * Text lives in the DOM because canvas text at three device pixel ratios is a
+ * losing fight, and because the numbers are the one thing that must be perfectly
+ * crisp on every device.
+ */
+import { TOWERS, type TowerKind } from "../game/constants.ts";
+import type { Question } from "../contract.ts";
+
+export type HudCallbacks = {
+  onAnswer(index: number): void;
+  onFocusAnswer(index: number): void;
+  onFocusCancel(): void;
+  onOvercharge(): void;
+  onSpeed(): void;
+  onSound(): void;
+  onRestart(): void;
+  onBuy(kind: TowerKind): void;
+  onArm(kind: TowerKind): void;
+  onUpgrade(): void;
+  onCallWave(): void;
+};
+
+const el = <K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  cls?: string,
+  text?: string,
+): HTMLElementTagNameMap[K] => {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text !== undefined) n.textContent = text;
+  return n;
+};
+
+/** tiny inline silhouettes so the build menu reads at a glance, no emoji */
+function towerGlyph(kind: TowerKind): SVGSVGElement {
+  const ns = "http://www.w3.org/2000/svg";
+  const svg = document.createElementNS(ns, "svg");
+  svg.setAttribute("width", "26");
+  svg.setAttribute("height", "26");
+  svg.setAttribute("viewBox", "0 0 26 26");
+  const p = document.createElementNS(ns, "path");
+  const d =
+    kind === "bolt"
+      ? "M13 2 L23 22 L3 22 Z"
+      : kind === "mortar"
+        ? "M4 9 h18 v13 h-18 z M10 2 h6 v7 h-6 z"
+        : "M13 2 L23 8 L23 18 L13 24 L3 18 L3 8 Z";
+  p.setAttribute("d", d);
+  p.setAttribute("fill", "none");
+  p.setAttribute("stroke", "#ffcf5c");
+  p.setAttribute("stroke-width", "2.2");
+  p.setAttribute("stroke-linejoin", "round");
+  svg.appendChild(p);
+  return svg;
+}
+
+function speakerGlyph(): SVGSVGElement {
+  const ns = "http://www.w3.org/2000/svg";
+  const svg = document.createElementNS(ns, "svg");
+  svg.setAttribute("width", "17");
+  svg.setAttribute("height", "17");
+  svg.setAttribute("viewBox", "0 0 17 17");
+  const body = document.createElementNS(ns, "path");
+  body.setAttribute("d", "M3 6.5 h2.6 L9 3.5 v10 L5.6 10.5 H3 Z");
+  body.setAttribute("fill", "none");
+  body.setAttribute("stroke", "#9b8878");
+  body.setAttribute("stroke-width", "1.6");
+  body.setAttribute("stroke-linejoin", "round");
+  svg.appendChild(body);
+  for (const [r, o] of [
+    [2.6, 0.9],
+    [4.6, 0.55],
+  ] as const) {
+    const a = document.createElementNS(ns, "path");
+    a.setAttribute("d", `M11 ${8.5 - r * 0.72} A ${r} ${r} 0 0 1 11 ${8.5 + r * 0.72}`);
+    a.setAttribute("fill", "none");
+    a.setAttribute("stroke", "#9b8878");
+    a.setAttribute("stroke-width", "1.5");
+    a.setAttribute("stroke-linecap", "round");
+    a.setAttribute("opacity", String(o));
+    a.setAttribute("class", "wave");
+    svg.appendChild(a);
+  }
+  return svg;
+}
+
+export class Hud {
+  readonly root: HTMLDivElement;
+  readonly board: HTMLDivElement;
+  readonly canvas: HTMLCanvasElement;
+
+  private embersEl: HTMLDivElement;
+  private embersWrap: HTMLDivElement;
+  private dpsEl: HTMLDivElement;
+  private waveEl: HTMLDivElement;
+  private threatEl: HTMLDivElement;
+  private coreEl: HTMLDivElement;
+  private pips: HTMLDivElement[] = [];
+  private speedChip: HTMLButtonElement;
+  private soundChip: HTMLButtonElement;
+  private callChip: HTMLButtonElement;
+
+  private anvil: HTMLDivElement;
+  private palette!: HTMLDivElement;
+  private cards: Partial<Record<TowerKind, { card: HTMLButtonElement; dps: HTMLDivElement }>> = {};
+  private promptEl: HTMLDivElement;
+  private payEl!: HTMLSpanElement;
+  private slugs: HTMLButtonElement[] = [];
+  private overBtn: HTMLButtonElement;
+  private overFill: HTMLDivElement;
+  private overPct: HTMLDivElement;
+
+  private pop: HTMLDivElement | null = null;
+  private banner: HTMLDivElement | null = null;
+  private focus: HTMLDivElement | null = null;
+  private focusSlugs: HTMLButtonElement[] = [];
+  private focusTimer: HTMLElement | null = null;
+  private end: HTMLDivElement | null = null;
+
+  private flyPool: HTMLDivElement[] = [];
+  private cb: HTMLCallbacksShim;
+
+  constructor(host: HTMLElement, cb: HudCallbacks) {
+    this.cb = cb as HTMLCallbacksShim;
+    const root = el("div", "sg");
+    this.root = root;
+
+    // -- top bar -----------------------------------------------------------
+    const top = el("div", "sg-top");
+
+    const mkStat = (k: string, cls = ""): { wrap: HTMLDivElement; v: HTMLDivElement } => {
+      const wrap = el("div", `sg-stat ${cls}`);
+      wrap.appendChild(el("div", "sg-stat-k", k));
+      const v = el("div", "sg-stat-v", "0");
+      wrap.appendChild(v);
+      return { wrap, v };
+    };
+
+    const embers = mkStat("embers", "sg-embers");
+    this.embersWrap = embers.wrap;
+    this.embersEl = embers.v;
+    const dps = mkStat("dps");
+    this.dpsEl = dps.v;
+    const wave = mkStat("wave");
+    this.waveEl = wave.v;
+    const threat = mkStat("hp in");
+    this.threatEl = threat.v;
+
+    this.coreEl = el("div", "sg-core");
+    for (let i = 0; i < 20; i++) {
+      const pip = el("div", "sg-pip");
+      this.pips.push(pip);
+      this.coreEl.appendChild(pip);
+    }
+
+    this.callChip = el("button", "sg-chip", "");
+    this.callChip.onclick = () => cb.onCallWave();
+    this.speedChip = el("button", "sg-chip", "1×");
+    this.speedChip.onclick = () => cb.onSpeed();
+    this.soundChip = el("button", "sg-chip on");
+    this.soundChip.setAttribute("aria-label", "sound");
+    this.soundChip.appendChild(speakerGlyph());
+    this.soundChip.onclick = () => cb.onSound();
+
+    top.append(
+      embers.wrap,
+      dps.wrap,
+      wave.wrap,
+      threat.wrap,
+      el("div", "sg-spacer"),
+      this.coreEl,
+      this.callChip,
+      this.speedChip,
+      this.soundChip,
+    );
+
+    // -- board -------------------------------------------------------------
+    this.board = el("div", "sg-board");
+    this.canvas = el("canvas");
+    this.board.appendChild(this.canvas);
+
+    // -- anvil -------------------------------------------------------------
+    this.anvil = el("div", "sg-anvil");
+
+    // desktop palette: arm a tower, then click pads. Costs and dps side by side
+    // is the cost-benefit sum made visible without a word of explanation.
+    this.palette = el("div", "sg-pal");
+    for (const kind of ["bolt", "mortar", "chain"] as const) {
+      const spec = TOWERS[kind];
+      const card = el("button", "sg-card");
+      card.appendChild(towerGlyph(kind));
+      const meta = el("div", "meta");
+      meta.appendChild(el("div", "n", spec.name));
+      meta.appendChild(el("div", "d", spec.blurb));
+      card.appendChild(meta);
+      const nums = el("div", "nums");
+      const cost = el("div", "cost", String(spec.cost));
+      nums.appendChild(cost);
+      const dps = el("div", "dps", "");
+      nums.appendChild(dps);
+      card.appendChild(nums);
+      card.onclick = () => cb.onArm(kind);
+      this.cards[kind] = { card, dps };
+      this.palette.appendChild(card);
+    }
+
+    const work = el("div", "sg-work");
+    const head = el("div", "sg-head");
+    head.appendChild(el("span", "", "ANVIL"));
+    this.payEl = el("span", "pay", "+0");
+    head.appendChild(this.payEl);
+    this.promptEl = el("div", "sg-prompt");
+    const slugRow = el("div", "sg-slugs");
+    for (let i = 0; i < 4; i++) {
+      const b = el("button", "sg-slug");
+      b.onpointerdown = (ev) => {
+        ev.preventDefault();
+        cb.onAnswer(i);
+      };
+      this.slugs.push(b);
+      slugRow.appendChild(b);
+    }
+    work.append(head, this.promptEl, slugRow);
+
+    this.overBtn = el("button", "sg-over");
+    this.overFill = el("div", "fill");
+    this.overFill.style.height = "0%";
+    this.overPct = el("div", "pct", "0");
+    this.overBtn.append(this.overFill, el("div", "lab", "OVERCHARGE"), this.overPct);
+    this.overBtn.onclick = () => cb.onOvercharge();
+
+    this.anvil.append(this.palette, work, this.overBtn);
+
+    root.append(top, this.board, this.anvil);
+    host.appendChild(root);
+  }
+
+  // -- stats ---------------------------------------------------------------
+
+  setEmbers(n: number, bump: boolean): void {
+    this.embersEl.textContent = String(n);
+    if (bump) {
+      this.embersWrap.classList.remove("bump");
+      void this.embersWrap.offsetWidth;
+      this.embersWrap.classList.add("bump");
+    }
+  }
+
+  setDps(n: number): void {
+    this.dpsEl.textContent = String(n);
+  }
+
+  setWave(n: number): void {
+    this.waveEl.textContent = String(n);
+  }
+
+  setThreat(n: number): void {
+    this.threatEl.textContent = n >= 10000 ? `${Math.round(n / 1000)}k` : String(n);
+  }
+
+  setCore(hp: number, max: number, hurt: boolean): void {
+    for (let i = 0; i < this.pips.length; i++) {
+      const p = this.pips[i];
+      if (!p) continue;
+      p.style.display = i < max ? "" : "none";
+      p.classList.toggle("out", i >= hp);
+    }
+    if (hurt) {
+      this.coreEl.classList.remove("hurt");
+      void this.coreEl.offsetWidth;
+      this.coreEl.classList.add("hurt");
+    }
+  }
+
+  setCall(text: string, active: boolean): void {
+    this.callChip.textContent = text;
+    this.callChip.style.display = text ? "" : "none";
+    this.callChip.classList.toggle("on", active);
+  }
+
+  /** dps values come from the sim so the palette can never drift from the truth */
+  setPalette(embers: number, armed: TowerKind | null, dps: Record<TowerKind, number>): void {
+    for (const kind of ["bolt", "mortar", "chain"] as const) {
+      const c = this.cards[kind];
+      if (!c) continue;
+      c.card.classList.toggle("armed", armed === kind);
+      c.card.classList.toggle("poor", embers < TOWERS[kind].cost);
+      const v = `${dps[kind]} dps`;
+      if (c.dps.textContent !== v) c.dps.textContent = v;
+    }
+  }
+
+  setSpeed(mult: number): void {
+    this.speedChip.textContent = `${mult}×`;
+    this.speedChip.classList.toggle("on", mult > 1);
+  }
+
+  setSound(on: boolean): void {
+    this.soundChip.classList.toggle("on", on);
+    for (const w of this.soundChip.querySelectorAll(".wave")) {
+      (w as SVGElement).style.display = on ? "" : "none";
+    }
+  }
+
+  setReducedMotion(on: boolean): void {
+    this.root.classList.toggle("rm", on);
+  }
+
+  // -- anvil ---------------------------------------------------------------
+
+  setQuestion(q: Question, order: number[], pays: number): void {
+    this.payEl.textContent = `+${pays}`;
+    this.promptEl.classList.remove("dark");
+    this.promptEl.replaceChildren(
+      document.createTextNode(q.prompt),
+      Object.assign(el("span", "eq"), { textContent: "=" }),
+    );
+    const options = [q.answer, ...q.distractors];
+    for (let i = 0; i < 4; i++) {
+      const b = this.slugs[i];
+      if (!b) continue;
+      b.className = "sg-slug";
+      b.textContent = options[order[i] ?? i] ?? "";
+      b.disabled = false;
+    }
+  }
+
+  markAnswer(idx: number, correct: boolean, correctIdx: number): void {
+    const b = this.slugs[idx];
+    if (b) b.classList.add(correct ? "right" : "wrong");
+    if (!correct) {
+      const c = this.slugs[correctIdx];
+      if (c) c.classList.add("reveal");
+    }
+  }
+
+  /** centre of an answer slug in root-relative pixels — the ember flight origin */
+  slugCenter(idx: number): { x: number; y: number } {
+    const b = this.slugs[idx];
+    const rootBox = this.root.getBoundingClientRect();
+    if (!b) return { x: rootBox.width / 2, y: rootBox.height - 60 };
+    const r = b.getBoundingClientRect();
+    return { x: r.left + r.width / 2 - rootBox.left, y: r.top + r.height / 2 - rootBox.top };
+  }
+
+  focusSlugCenter(idx: number): { x: number; y: number } {
+    const b = this.focusSlugs[idx];
+    const rootBox = this.root.getBoundingClientRect();
+    if (!b) return { x: rootBox.width / 2, y: rootBox.height / 2 };
+    const r = b.getBoundingClientRect();
+    return { x: r.left + r.width / 2 - rootBox.left, y: r.top + r.height / 2 - rootBox.top };
+  }
+
+  setCold(cold: boolean): void {
+    this.anvil.classList.toggle("cold", cold);
+    this.promptEl.classList.toggle("dark", cold);
+  }
+
+  setOvercharge(pct: number, ready: boolean): void {
+    this.overFill.style.height = `${Math.min(100, pct)}%`;
+    this.overPct.textContent = ready ? "GO" : String(Math.floor(pct));
+    this.overBtn.classList.toggle("ready", ready);
+    this.overBtn.disabled = !ready;
+  }
+
+  /** embers arcing from the anvil to the counter — the money-go-up beat */
+  flyEmbers(n: number, fromX: number, fromY: number, onArrive: (i: number) => void): void {
+    const tgt = this.embersWrap.getBoundingClientRect();
+    const rootBox = this.root.getBoundingClientRect();
+    const tx = tgt.left + tgt.width / 2 - rootBox.left;
+    const ty = tgt.top + tgt.height / 2 - rootBox.top;
+    const count = Math.min(9, Math.max(4, Math.round(n / 3)));
+    for (let i = 0; i < count; i++) {
+      let d = this.flyPool.pop();
+      if (!d) {
+        d = el("div");
+        d.style.cssText =
+          "position:absolute;width:11px;height:11px;pointer-events:none;z-index:9;" +
+          "background:radial-gradient(circle,#fff5d8,#ff8a2b 60%,rgba(255,80,10,0));";
+      }
+      d.style.left = `${fromX - 5}px`;
+      d.style.top = `${fromY - 5}px`;
+      d.style.opacity = "1";
+      this.root.appendChild(d);
+      const spread = 90;
+      const a = d.animate(
+        [
+          { transform: "translate(0,0) scale(0.5)", opacity: 1 },
+          {
+            transform: `translate(${(Math.random() - 0.5) * spread}px, ${-30 - Math.random() * 50}px) scale(1.35)`,
+            opacity: 1,
+            offset: 0.3,
+          },
+          { transform: `translate(${tx - fromX}px, ${ty - fromY}px) scale(0.55)`, opacity: 0.9 },
+        ],
+        {
+          duration: 430 + i * 44,
+          easing: "cubic-bezier(0.5, -0.3, 0.4, 1)",
+          fill: "forwards",
+        },
+      );
+      const node = d;
+      a.onfinish = () => {
+        node.remove();
+        if (this.flyPool.length < 24) this.flyPool.push(node);
+        onArrive(i);
+      };
+    }
+  }
+
+  // -- build / upgrade popup ------------------------------------------------
+
+  showBuild(x: number, y: number, embers: number, onPick: (k: TowerKind) => void): void {
+    this.hidePop();
+    const p = el("div", "sg-pop");
+    for (const kind of ["bolt", "mortar", "chain"] as const) {
+      const spec = TOWERS[kind];
+      const b = el("button", "sg-buy");
+      b.appendChild(towerGlyph(kind));
+      b.appendChild(el("div", "n", spec.name));
+      b.appendChild(el("div", "c", String(spec.cost)));
+      b.appendChild(el("div", "d", spec.blurb));
+      b.disabled = embers < spec.cost;
+      b.onpointerdown = (ev) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        onPick(kind);
+      };
+      p.appendChild(b);
+    }
+    this.placePop(p, x, y);
+  }
+
+  showTower(
+    x: number,
+    y: number,
+    info: { name: string; level: number; dps: number; cost: number | null; affordable: boolean },
+    onUpgrade: () => void,
+  ): void {
+    this.hidePop();
+    const p = el("div", "sg-pop");
+    const b = el("button", "sg-buy");
+    b.style.width = "116px";
+    b.appendChild(el("div", "n", `${info.name} L${info.level + 1}`));
+    b.appendChild(el("div", "c", info.cost === null ? "MAX" : `${info.cost}`));
+    b.appendChild(el("div", "d", info.cost === null ? `${info.dps} dps` : `upgrade · solve`));
+    b.disabled = info.cost === null || !info.affordable;
+    b.onpointerdown = (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      onUpgrade();
+    };
+    p.appendChild(b);
+    const stat = el("div", "sg-buy");
+    stat.style.width = "84px";
+    stat.appendChild(el("div", "n", "DPS"));
+    stat.appendChild(el("div", "c", String(info.dps)));
+    stat.appendChild(el("div", "d", "per second"));
+    p.appendChild(stat);
+    this.placePop(p, x, y);
+  }
+
+  private placePop(p: HTMLDivElement, x: number, y: number): void {
+    p.style.visibility = "hidden";
+    this.board.appendChild(p);
+    const w = p.offsetWidth;
+    const h = p.offsetHeight;
+    const bw = this.board.clientWidth;
+    const bh = this.board.clientHeight;
+    let left = x - w / 2;
+    let top = y - h - 44;
+    if (top < 4) top = Math.min(bh - h - 4, y + 44);
+    left = Math.max(4, Math.min(bw - w - 4, left));
+    p.style.left = `${left}px`;
+    p.style.top = `${top}px`;
+    p.style.visibility = "";
+    this.pop = p;
+  }
+
+  hidePop(): void {
+    this.pop?.remove();
+    this.pop = null;
+  }
+
+  get popOpen(): boolean {
+    return this.pop !== null;
+  }
+
+  // -- banner --------------------------------------------------------------
+
+  showBanner(big: string, sub: string): void {
+    if (this.focus) return; // never stack a banner under the focus overlay
+    this.banner?.remove();
+    const b = el("div", "sg-banner in");
+    b.appendChild(el("div", "big", big));
+    b.appendChild(el("div", "sub", sub));
+    this.board.appendChild(b);
+    this.banner = b;
+    const node = b;
+    setTimeout(() => {
+      if (this.banner === node) {
+        node.remove();
+        this.banner = null;
+      }
+    }, 2200);
+  }
+
+  // -- focus overlay (overcharge + upgrade) ---------------------------------
+
+  showFocus(tag: string, q: Question, order: number[], withTimer: boolean): void {
+    this.hideFocus();
+    // a wave banner behind a translucent overlay is unreadable soup
+    this.banner?.remove();
+    this.banner = null;
+    const f = el("div", "sg-oc");
+    f.appendChild(el("div", "tag", tag));
+    f.appendChild(el("div", "q", `${q.prompt} =`));
+    const grid = el("div", "grid");
+    const options = [q.answer, ...q.distractors];
+    this.focusSlugs = [];
+    for (let i = 0; i < 4; i++) {
+      const b = el("button", "sg-slug");
+      b.textContent = options[order[i] ?? i] ?? "";
+      b.onpointerdown = (ev) => {
+        ev.preventDefault();
+        this.cb.onFocusAnswer(i);
+      };
+      this.focusSlugs.push(b);
+      grid.appendChild(b);
+    }
+    f.appendChild(grid);
+    if (withTimer) {
+      const t = el("div", "timer");
+      const i = el("i");
+      t.appendChild(i);
+      f.appendChild(t);
+      this.focusTimer = i;
+    } else {
+      this.focusTimer = null;
+    }
+    f.onpointerdown = (ev) => {
+      if (ev.target === f) this.cb.onFocusCancel();
+    };
+    this.root.appendChild(f);
+    this.focus = f;
+  }
+
+  setFocusTimer(frac: number): void {
+    if (this.focusTimer) this.focusTimer.style.transform = `scaleX(${Math.max(0, frac)})`;
+  }
+
+  markFocus(idx: number, correct: boolean, correctIdx: number): void {
+    const b = this.focusSlugs[idx];
+    if (b) b.classList.add(correct ? "right" : "wrong");
+    if (!correct) this.focusSlugs[correctIdx]?.classList.add("reveal");
+    for (const s of this.focusSlugs) s.disabled = true;
+  }
+
+  hideFocus(): void {
+    this.focus?.remove();
+    this.focus = null;
+    this.focusSlugs = [];
+    this.focusTimer = null;
+  }
+
+  get focusOpen(): boolean {
+    return this.focus !== null;
+  }
+
+  // -- end -----------------------------------------------------------------
+
+  showEnd(wave: number, lines: string[]): void {
+    this.hideEnd();
+    const e = el("div", "sg-end");
+    e.appendChild(el("div", "t", "THE FORGE WENT COLD"));
+    e.appendChild(el("div", "w", String(wave)));
+    e.appendChild(el("div", "s", "WAVES HELD"));
+    const s = el("div", "s", lines.join("   ·   "));
+    s.style.marginTop = "10px";
+    e.appendChild(s);
+    const b = el("button", "again", "RELIGHT");
+    b.onclick = () => this.cb.onRestart();
+    e.appendChild(b);
+    this.root.appendChild(e);
+    this.end = e;
+  }
+
+  hideEnd(): void {
+    this.end?.remove();
+    this.end = null;
+  }
+
+  destroy(): void {
+    this.root.remove();
+  }
+}
+
+type HTMLCallbacksShim = HudCallbacks;

--- a/dynawalla/games/siege/src/ui/styles.css
+++ b/dynawalla/games/siege/src/ui/styles.css
@@ -1,0 +1,764 @@
+/* SIEGE — hot forge on cold stone. Squared-off metal, tabular numerals, no cards. */
+
+.sg {
+  --hot: #ff8a2b;
+  --hotter: #ffcf5c;
+  --white-hot: #fff2d2;
+  --cold: #8fb4d8;
+  --ward: #6fe3ff;
+  --danger: #ff3d2e;
+  --ink: #f6e9d8;
+  --dim: #9b8878;
+  --panel: #140e11;
+  --panel-2: #1d1418;
+  --seam: rgba(255, 138, 43, 0.28);
+
+  position: absolute;
+  inset: 0;
+  display: grid;
+  /* minmax(0, …) everywhere: a long prompt or a wide top bar must clip, never
+     push the canvas out of the viewport. That bug cropped the whole board. */
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr);
+  background: #0a0608;
+  color: var(--ink);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+  font-variant-numeric: tabular-nums;
+  overflow: hidden;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+}
+
+.sg * {
+  box-sizing: border-box;
+}
+
+.sg button {
+  font: inherit;
+  font-variant-numeric: tabular-nums;
+  color: inherit;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+/* ------------------------------------------------------------------ top bar */
+
+.sg-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  overflow: hidden;
+  padding: 8px 10px calc(8px) 10px;
+  padding-top: max(8px, env(safe-area-inset-top));
+  background: linear-gradient(#170f12, #100a0d);
+  border-bottom: 1px solid var(--seam);
+}
+
+.sg-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 0 0 auto;
+}
+
+.sg-stat-k {
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  color: var(--dim);
+  text-transform: uppercase;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.sg-stat-v {
+  font-size: 22px;
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  white-space: nowrap;
+}
+
+.sg-embers .sg-stat-v {
+  color: var(--hotter);
+  text-shadow: 0 0 18px rgba(255, 176, 60, 0.55);
+}
+
+.sg-embers { padding-right: 6px; }
+
+.sg-embers .sg-stat-v {
+  transform-origin: left center;
+}
+
+.sg-embers.bump .sg-stat-v {
+  animation: sg-bump 0.34s cubic-bezier(0.16, 1.4, 0.4, 1);
+}
+
+@keyframes sg-bump {
+  0% { transform: scale(1); }
+  35% { transform: scale(1.17); color: #fff; }
+  100% { transform: scale(1); }
+}
+
+.sg-spacer { flex: 1 1 0; min-width: 4px; }
+
+/* core health: pips, so damage is countable and never colour alone */
+.sg-core {
+  display: flex;
+  gap: 2px;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+.sg-pip {
+  flex: 0 0 auto;
+  width: clamp(3px, 0.7vw, 7px);
+  height: 18px;
+  background: linear-gradient(#ffb04a, #ff5a12);
+  box-shadow: 0 0 8px rgba(255, 130, 40, 0.6);
+}
+
+.sg-pip.out {
+  background: #2a1d20;
+  box-shadow: none;
+}
+
+.sg-core.hurt {
+  animation: sg-corehurt 0.4s;
+}
+
+@keyframes sg-corehurt {
+  0%, 100% { transform: translateX(0); }
+  20% { transform: translateX(-5px); }
+  55% { transform: translateX(4px); }
+}
+
+.sg-chip {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  padding: 7px 10px;
+  min-height: 34px;
+  background: var(--panel-2);
+  border: 1px solid rgba(255, 138, 43, 0.22);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  color: var(--dim);
+  white-space: nowrap;
+}
+
+.sg-chip.on {
+  color: #0a0608;
+  background: var(--hotter);
+  border-color: var(--hotter);
+}
+
+.sg-chip svg { display: block; }
+.sg-chip.on svg path,
+.sg-chip.on svg line { stroke: #0a0608; }
+
+/* narrow: the fight keeps every pixel it can get */
+@media (max-width: 700px) {
+  .sg-top { gap: 9px; padding-left: 8px; padding-right: 8px; }
+  .sg-stat-v { font-size: 19px; }
+  .sg-stat-k { font-size: 8px; letter-spacing: 0.1em; }
+  .sg-core { gap: 1px; }
+  .sg-pip { width: 3px; height: 14px; }
+  .sg-chip { padding: 6px 8px; font-size: 11px; min-height: 30px; }
+}
+
+/* -------------------------------------------------------------------- board */
+
+.sg-board {
+  position: relative;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.sg-board canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+/* ------------------------------------------------------------- floating menu */
+
+.sg-pop {
+  position: absolute;
+  z-index: 6;
+  display: flex;
+  gap: 6px;
+  padding: 6px;
+  background: rgba(14, 9, 11, 0.94);
+  border: 1px solid var(--seam);
+  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.7), inset 0 1px 0 rgba(255, 190, 120, 0.14);
+  transform-origin: 50% 100%;
+  animation: sg-pop-in 0.19s cubic-bezier(0.16, 1.3, 0.4, 1);
+}
+
+@keyframes sg-pop-in {
+  from { transform: scale(0.7) translateY(8px); opacity: 0; }
+  to { transform: scale(1) translateY(0); opacity: 1; }
+}
+
+.sg-buy {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  width: 74px;
+  padding: 8px 4px 7px;
+  background: linear-gradient(#241a1e, #171013);
+  border: 1px solid rgba(255, 190, 120, 0.18);
+}
+
+.sg-buy:active { transform: scale(0.94); }
+
+.sg-buy[disabled] {
+  opacity: 0.34;
+  cursor: default;
+}
+
+.sg-buy .n {
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+}
+
+.sg-buy .c {
+  font-size: 17px;
+  font-weight: 800;
+  color: var(--hotter);
+}
+
+.sg-buy .d {
+  font-size: 9px;
+  color: var(--dim);
+  letter-spacing: 0.04em;
+}
+
+.sg-buy svg { display: block; }
+
+.sg-sell {
+  width: 40px;
+  display: grid;
+  place-items: center;
+  font-size: 18px;
+  font-weight: 800;
+  color: var(--dim);
+  background: #171013;
+  border: 1px solid rgba(255, 190, 120, 0.14);
+}
+
+/* -------------------------------------------------------------------- anvil */
+
+/* Portrait is the default shape: a full-width console under a square board.
+   A phone screen is tall, the board can only be as wide as the screen, so the
+   space left over belongs to the maths. */
+.sg-anvil {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: auto auto;
+  gap: 10px;
+  align-items: center;
+  padding: 10px;
+  padding-bottom: max(10px, env(safe-area-inset-bottom));
+  background: linear-gradient(#150e11, #0d0709);
+  border-top: 1px solid var(--seam);
+}
+
+.sg-anvil::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--hot), transparent);
+  opacity: 0.7;
+}
+
+.sg-pal {
+  display: none;
+  grid-auto-flow: row;
+  gap: 6px;
+  align-content: start;
+}
+
+.sg-card {
+  display: grid;
+  grid-template-columns: 30px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  text-align: left;
+  background: linear-gradient(#1f1519, #140e11);
+  border: 1px solid rgba(255, 138, 43, 0.16);
+  transition: transform 0.08s, border-color 0.14s;
+}
+
+.sg-card:active { transform: scale(0.985); }
+
+.sg-card .n {
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+}
+
+.sg-card .d {
+  font-size: 10px;
+  color: var(--dim);
+  letter-spacing: 0.04em;
+}
+
+.sg-card .nums { text-align: right; }
+
+.sg-card .cost {
+  font-size: 19px;
+  font-weight: 800;
+  color: var(--hotter);
+  line-height: 1;
+}
+
+.sg-card .dps {
+  font-size: 10px;
+  color: var(--dim);
+}
+
+.sg-card.armed {
+  border-color: var(--hotter);
+  background: linear-gradient(#43220f, #1e1114);
+  box-shadow: inset 0 0 24px rgba(255, 160, 60, 0.25);
+}
+
+.sg-card.poor { opacity: 0.38; }
+
+.sg-work {
+  display: grid;
+  grid-template-rows: auto auto auto;
+  gap: 8px;
+  min-width: 0;
+}
+
+.sg-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.26em;
+  color: var(--dim);
+}
+
+.sg-head .pay {
+  letter-spacing: 0;
+  font-size: 15px;
+  color: var(--hotter);
+  text-shadow: 0 0 14px rgba(255, 176, 60, 0.5);
+}
+
+.sg-prompt {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  font-size: clamp(28px, 7vw, 46px);
+  font-weight: 800;
+  letter-spacing: 0.01em;
+  line-height: 1;
+  color: var(--white-hot);
+  text-shadow: 0 0 26px rgba(255, 170, 70, 0.4);
+  white-space: nowrap;
+}
+
+.sg-prompt .eq {
+  color: var(--hot);
+  opacity: 0.7;
+}
+
+.sg-prompt.dark {
+  color: #5c4a44;
+  text-shadow: none;
+}
+
+.sg-slugs {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+}
+
+.sg-slug {
+  position: relative;
+  /* The board is a square fit to the narrower axis, so on a tall screen the
+     leftover height is exactly (100vh - 100vw). Spend it on touch targets. */
+  height: clamp(54px, calc((100vh - 100vw) * 0.19), 100px);
+  font-size: clamp(24px, 6vw, 38px);
+  font-weight: 800;
+  color: #fffaf0;
+  text-shadow: 0 1px 0 rgba(90, 26, 0, 0.8), 0 0 18px rgba(255, 170, 70, 0.5);
+  background: linear-gradient(#75371a, #46200f 46%, #2a1209);
+  border: 1px solid rgba(255, 176, 80, 0.42);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 226, 170, 0.4),
+    inset 0 -8px 14px rgba(0, 0, 0, 0.45),
+    0 6px 0 #180c07,
+    0 9px 22px rgba(0, 0, 0, 0.65);
+  overflow: hidden;
+  transition: transform 0.07s;
+}
+
+.sg-slug::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(130% 80% at 50% -10%, rgba(255, 216, 150, 0.42), transparent 62%),
+    linear-gradient(90deg, rgba(255, 120, 30, 0.14), transparent 40%, rgba(255, 120, 30, 0.14));
+  pointer-events: none;
+}
+
+.sg-slug:active,
+.sg-slug.press {
+  transform: translateY(5px);
+  box-shadow: inset 0 1px 0 rgba(255, 200, 140, 0.2), 0 1px 0 #150b09;
+}
+
+.sg-slug.right {
+  animation: sg-right 0.42s ease-out;
+}
+
+@keyframes sg-right {
+  0% { background: #fffaf0; color: #2a1409; transform: scale(1.12); box-shadow: 0 0 44px rgba(255, 210, 130, 0.9); }
+  100% { background: linear-gradient(#75371a, #46200f 46%, #2a1209); color: #fffaf0; transform: scale(1); }
+}
+
+.sg-slug.wrong {
+  animation: sg-wrong 0.4s ease-out;
+}
+
+@keyframes sg-wrong {
+  0% { transform: translateX(0); filter: brightness(0.4); }
+  25% { transform: translateX(-7px) rotate(-2deg); }
+  55% { transform: translateX(6px) rotate(2deg); }
+  100% { transform: translateX(0); filter: brightness(0.4); }
+}
+
+.sg-slug.reveal {
+  outline: 3px solid var(--hotter);
+  outline-offset: -3px;
+}
+
+.sg-anvil.cold .sg-slug {
+  filter: grayscale(0.8) brightness(0.45);
+  pointer-events: none;
+}
+
+.sg-anvil.cold::before { opacity: 0.15; }
+
+/* the overcharge lever */
+
+.sg-over {
+  position: relative;
+  width: 100%;
+  min-height: 56px;
+  display: grid;
+  grid-auto-flow: column;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 18px;
+  gap: 2px;
+  background: linear-gradient(#1d1216, #120b0e);
+  border: 1px solid rgba(255, 138, 43, 0.24);
+  overflow: hidden;
+}
+
+.sg-over .fill {
+  position: absolute;
+  inset: auto 0 0 0;
+  background: linear-gradient(#ff5a12, #7a1c05);
+  opacity: 0.45;
+  transition: height 0.24s cubic-bezier(0.2, 0.9, 0.3, 1);
+}
+
+.sg-over .lab {
+  position: relative;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  white-space: nowrap;
+  color: var(--dim);
+}
+
+.sg-over .pct {
+  position: relative;
+  font-size: 26px;
+  font-weight: 800;
+  color: var(--ink);
+}
+
+.sg-over.ready {
+  border-color: var(--hotter);
+  animation: sg-ready 1.2s ease-in-out infinite;
+}
+
+.sg-over.ready .lab,
+.sg-over.ready .pct { color: var(--white-hot); }
+
+.sg-over.ready .fill { opacity: 0.85; }
+
+@keyframes sg-ready {
+  0%, 100% { box-shadow: 0 0 0 rgba(255, 160, 60, 0); }
+  50% { box-shadow: 0 0 30px rgba(255, 160, 60, 0.7), inset 0 0 30px rgba(255, 160, 60, 0.35); }
+}
+
+.sg-over[disabled] { cursor: default; }
+
+/* ------------------------------------------------------------------ banners */
+
+.sg-banner {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 16%;
+  z-index: 8;
+  display: grid;
+  justify-items: center;
+  gap: 4px;
+  pointer-events: none;
+}
+
+.sg-banner .big {
+  font-size: clamp(38px, 11vw, 84px);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  line-height: 0.9;
+  color: var(--white-hot);
+  text-shadow: 0 0 40px rgba(255, 130, 40, 0.75), 0 6px 0 rgba(0, 0, 0, 0.55);
+}
+
+.sg-banner .sub {
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.22em;
+  color: var(--hot);
+}
+
+.sg-banner.in {
+  animation: sg-slam 2.1s cubic-bezier(0.16, 1.5, 0.3, 1) forwards;
+}
+
+@keyframes sg-slam {
+  0% { transform: scale(2.4) translateY(-14px); opacity: 0; filter: blur(6px); }
+  12% { transform: scale(1) translateY(0); opacity: 1; filter: blur(0); }
+  76% { transform: scale(1); opacity: 1; }
+  100% { transform: scale(0.86) translateY(-24px); opacity: 0; }
+}
+
+/* -------------------------------------------------------- overcharge overlay */
+
+.sg-oc {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  gap: 16px;
+  padding: 20px;
+  background: radial-gradient(circle at 50% 46%, rgba(60, 12, 4, 0.72), rgba(6, 3, 4, 0.94));
+  backdrop-filter: blur(3px);
+  animation: sg-oc-in 0.24s ease-out;
+}
+
+@keyframes sg-oc-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.sg-oc .tag {
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.34em;
+  color: var(--hotter);
+}
+
+.sg-oc .q {
+  font-size: clamp(46px, 13vw, 104px);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--white-hot);
+  text-shadow: 0 0 60px rgba(255, 150, 50, 0.8);
+  animation: sg-oc-q 0.5s cubic-bezier(0.16, 1.4, 0.4, 1);
+}
+
+@keyframes sg-oc-q {
+  from { transform: scale(0.5) rotate(-4deg); opacity: 0; }
+  to { transform: scale(1) rotate(0); opacity: 1; }
+}
+
+.sg-oc .grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(120px, 1fr));
+  gap: 12px;
+  width: min(560px, 92vw);
+}
+
+.sg-oc .sg-slug {
+  height: clamp(72px, 13vh, 104px);
+  font-size: clamp(28px, 7vw, 44px);
+}
+
+.sg-oc .timer {
+  width: min(560px, 92vw);
+  height: 8px;
+  background: #2a1512;
+  overflow: hidden;
+}
+
+.sg-oc .timer i {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, var(--hotter), var(--danger));
+  transform-origin: left;
+}
+
+/* ------------------------------------------------------------------- defeat */
+
+.sg-end {
+  position: absolute;
+  inset: 0;
+  z-index: 12;
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  gap: 10px;
+  background: rgba(5, 3, 4, 0.9);
+  animation: sg-oc-in 0.6s ease-out;
+}
+
+.sg-end .t {
+  font-size: clamp(32px, 8vw, 62px);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: #6f5a52;
+}
+
+.sg-end .w {
+  font-size: clamp(60px, 18vw, 140px);
+  font-weight: 800;
+  line-height: 0.9;
+  color: var(--hotter);
+  text-shadow: 0 0 50px rgba(255, 160, 60, 0.5);
+}
+
+.sg-end .s {
+  font-size: 13px;
+  letter-spacing: 0.16em;
+  color: var(--dim);
+  text-align: center;
+}
+
+.sg-end .again {
+  margin-top: 14px;
+  padding: 16px 40px;
+  font-size: 18px;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  color: #1a0d08;
+  background: linear-gradient(var(--hotter), var(--hot));
+  box-shadow: 0 6px 0 #7a3a10;
+}
+
+.sg-end .again:active { transform: translateY(4px); box-shadow: 0 2px 0 #7a3a10; }
+
+/* A short viewport — landscape phone, small desktop window — cannot afford a
+   stacked console. Height is the real constraint, so key off it, not on
+   `orientation`, which does not answer the question being asked. */
+@media (max-height: 619px) {
+  .sg-anvil {
+    grid-template-columns: minmax(0, 1fr) 116px;
+    grid-template-rows: auto;
+    gap: 8px;
+    padding: 8px;
+  }
+  .sg-slugs { grid-template-columns: repeat(4, 1fr); gap: 7px; }
+  .sg-slug { height: clamp(42px, 13vh, 68px); font-size: clamp(18px, 3.2vw, 26px); }
+  .sg-prompt { font-size: clamp(22px, 4.4vw, 36px); }
+  .sg-head { font-size: 9px; }
+  .sg-over {
+    grid-auto-flow: row;
+    justify-content: center;
+    place-items: center;
+    padding: 6px;
+    min-height: 0;
+    height: 100%;
+  }
+  .sg-over .lab { font-size: 9px; letter-spacing: 0.1em; }
+  .sg-over .pct { font-size: 22px; }
+}
+
+/* --------------------------------------------------------------- wide layout */
+
+@media (min-width: 900px) and (min-height: 620px) {
+  .sg {
+    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) 360px;
+  }
+  .sg-top { grid-column: 1 / -1; }
+  .sg-anvil {
+    grid-row: 2;
+    grid-column: 2;
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr auto;
+    align-content: stretch;
+    border-top: 0;
+    border-left: 1px solid var(--seam);
+    gap: 14px;
+    padding: 14px;
+  }
+  .sg-pal { display: grid; }
+  .sg-anvil::before {
+    inset: 0 auto 0 0;
+    width: 2px;
+    height: auto;
+    background: linear-gradient(180deg, transparent, var(--hot), transparent);
+  }
+  .sg-work { align-content: center; }
+  .sg-slug { height: 84px; font-size: clamp(24px, 2.6vw, 34px); }
+  .sg-over { min-height: 92px; }
+  .sg-over .lab { font-size: 12px; }
+  .sg-over .pct { font-size: 34px; }
+}
+
+/* ------------------------------------------------------------ reduced motion */
+
+.sg.rm *,
+.sg.rm *::before,
+.sg.rm *::after {
+  animation-duration: 0.001s !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.06s !important;
+}
+
+.sg.rm .sg-banner.in { animation: sg-fade 2s linear forwards; }
+
+@keyframes sg-fade {
+  0%, 80% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sg *,
+  .sg *::before,
+  .sg *::after {
+    animation-duration: 0.001s !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/dynawalla/games/siege/tsconfig.json
+++ b/dynawalla/games/siege/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": [],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": false,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src", "vite.config.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/dynawalla/games/siege/tsconfig.test.json
+++ b/dynawalla/games/siege/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src/**/*.test.ts", "src"],
+  "exclude": []
+}

--- a/dynawalla/games/siege/vite.config.ts
+++ b/dynawalla/games/siege/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  base: "./",
+  server: { port: 4187, strictPort: false },
+  build: { target: "es2022", assetsInlineLimit: 100000 },
+});


### PR DESCRIPTION
## SIEGE — a molten-forge tower defence you pay for with arithmetic

> A river of lava runs through your forge. Things are walking up it. You buy the guns with mental maths.

Tower defence in the Kingdom Rush / Bloons line, living entirely in `dynawalla/games/siege/`.
Twenty machined sockets flank a molten channel; obsidian shards, fast runners, armoured brutes,
splitters, warded wraiths and every-fifth-wave bosses walk it toward the forge core. Three tower
families, five levels deep.

**Embers are the only currency, and the anvil is the only real source of them.** A live
arithmetic problem sits under the board with four molten answer slugs. Strike it and embers arc
up to the counter. Miss and the anvil goes cold for 1.15 s — mid-wave, that is the difference
between a tower and no tower.

### One sentence, at the shoot-the-guilty bar

Numbers walk up a lava river toward your forge; you buy the guns that kill them by answering
sums, and when they are about to break through you answer one big one and blow the whole wave
backwards.

### Where the maths lives

| Beat | Tier | What it is |
|---|---|---|
| **Anvil** | gating | Always live. Correct → `6 + round(16 × difficulty)` embers + 9% overcharge. Wrong → quench 1.15 s. No lecture, no red ✗. |
| **Upgrades** | empowering | Tap a tower → world drops to 0.42× → one harder problem. 20 pads × 4 levels = **80 problems the player wants to solve**. |
| **Overcharge** | emergency | Meter fills from correct answers. At 100%: `timeScale → 0.16`, one big problem, and the right answer is a shockwave that damages, stuns and throws the wave 150 units back. |
| **The readout** | native | `HP IN 4173` beside `DPS 931`; the palette prints cost against dps. Three BOLTs vs one CHAIN *is* a rate comparison. |

Guessing loses because a slip costs roughly one and a half problems of income, and during a wave
income is survival. Nothing is confiscated — the wave just gets closer.

### Verified, not asserted

`node qa/playtest.mjs` launches Chromium, clicks the real palette, real pads and real answer
slugs, then hands over to an in-game auto-player. It screenshots nine moments and reports frame
percentiles. Findings it caught and I fixed:

- the top bar overflowed on a 390 px phone and **dragged the canvas out of the viewport**, cropping
  the board (fixed with `minmax(0, …)` grid tracks + a responsive top bar)
- a short-viewport media block sat *before* the base rules, so equal specificity silently reverted
  it and a landscape phone got a 54 px board
- the wave banner rendered *under* the translucent focus overlay
- the economy had no late sink: 16 k spare embers by wave 15 (fixed by extending towers to five
  levels, each gated by a solve)
- fast towers stacked an unreadable column of damage numbers (now batched to one per 140 ms)
- pure-white hit flashes erased every silhouette under heavy fire

**Perf**, fully built board at wave 20, Chrome CPU throttling standing in for a cheaper device:

| | median | p95 | live at peak |
|---|---|---|---|
| 1× | 8.3 ms (120 fps) | 9.9 ms | 34 enemies, 483 particles |
| **4×** | **8.6 ms (116 fps)** | **17.2 ms (58 fps)** | 34 enemies, 448 particles |
| 6× | 16.0 ms (63 fps) | 25.5 ms | 34 enemies, 422 particles |

Answer-path latency (pointerdown → verdict, synchronous): p50 **0.2 ms**, p90 0.4 ms, max 4.4 ms.
Nothing on the answer path awaits anything. No console errors; no horizontal overflow at 390,
820, 844×390 or 1440.

Achieved by baking the static board into one 1400² offscreen blit, replacing **every** per-frame
`createRadialGradient` with pre-rendered glow sprites, and pooling particles / enemies / shots /
popups with a hard 1100-particle ceiling and no allocation in the loop.

### Safety

Full-screen flashes capped at 30% alpha and rate limited to one per 340 ms in `Camera.flash`,
which silently refuses anything faster — this is a children's product. `prefers-reduced-motion` is
a branch, not a downgrade: shake, punch, slow-motion, hitstop and every DOM animation collapse
while damage numbers, health bars and the overcharge overlay survive intact. No streak reward
anywhere — a test asserts the difficulty signal takes no run-length argument. No ads, no loot
boxes, no variable-ratio schedules, no scarcity.

### Tests

`npm test` — 19 tests, node's native runner, zero dependencies. Exact-integer answers and damage
at every difficulty and armour value, mal-rule distractors (`52 − 38 → 26`, `28 + 34 → 52`,
`23 × 4 → 82`), seed determinism, superlinear escalation with a deliberate boss saw-tooth, and
two headless sieges played to a win and to a loss. `npm run tsc` and `npm run build` are clean.

### Notes for the reviewer

- **This PR is ~250 KB of diff, above `MAX_DIFF_BYTES` (200 000), so `adversarial-review` will
  truncate.** It is one indivisible self-contained game in one directory and cannot be split along
  the "one generator family per PR" line, which addresses `curriculum/`. Flagging it explicitly
  rather than letting it look reviewed. `package-lock.json` is 29 KB of it.
- Touches nothing outside `dynawalla/games/siege/`. Imports nothing from `curriculum/` or
  `engine/` — it carries its own verbatim copy of the `Host` / `Question` / `mount` contract plus a
  seeded stub host, so the eventual swap is one import line.
- Screenshots are gitignored rather than committed, to keep the diff reviewable; regenerate them
  with `npm run dev` then `node qa/playtest.mjs`.
- Acceptance criteria: this moves no existing `docs/ACCEPTANCE_CRITERIA.md` item — it is one of the
  ten parallel game builds commissioned under the new "juice first, diverse aesthetics" direction,
  which supersedes the single-Dynawalla-look constraint for `games/`.
