### PR TITLE
feat(bazaar): the endless minaret-punk marketplace the games are stalls in

### DIFF
--- a/dynawalla/bazaar/.gitignore
+++ b/dynawalla/bazaar/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+# The BZ-19 screenshot set and its measurement report. Regenerated in one
+# command (`npm run shots`) and reviewed as images; 8 MB of PNGs do not belong
+# in a public repository's history.
+shots/

--- a/dynawalla/bazaar/README.md
+++ b/dynawalla/bazaar/README.md
@@ -1,0 +1,130 @@
+# The bazaar
+
+The endless minaret-punk marketplace the games are stalls in.
+
+```bash
+npm install
+npm run dev     # the standalone street, with ten stub stalls
+npm test        # 41 gate tests, Node's native runner, no vitest
+npm run tsc     # type check
+npm run shots   # build, serve, walk the street, screenshot, measure
+```
+
+## The thesis
+
+**The bazaar is the frame. The games are the stalls.** An arcade has a look; the
+cabinets inside are each their own world. The marketplace carries the identity so
+that ten games can look like ten different games and still be one place.
+
+Everything follows from that. The stub previews in `src/demo/previews.ts` are on
+purpose *not* minaret-punk — each owns its own ground, palette and type. The
+contrast between the frame and the stall interiors is the design.
+
+## Using it
+
+```ts
+import { mountBazaar } from "@dynawalla/bazaar";
+import "@dynawalla/bazaar/bazaar.css";
+
+const bazaar = mountBazaar(el, {
+  stalls: [
+    { id: "tessera", title: "Tessera", quarter: "tilers", preview, accretion: 0.4 },
+  ],
+  dayRemaining: 0.6,          // 0…1 of the free day left
+  subscribed: false,
+  onEnter: (id) => router.push(`/play/${id}`),
+  onUpgrade: () => sheet.open(),
+});
+
+// when the game closes, hand the street back:
+bazaar.setInStall(false);     // restores scrollLeft within 1px (BZ-08)
+```
+
+It is vanilla TypeScript and mounts into any DOM element, so a React host wraps
+it in a ref and a `useEffect` in six lines. It was written that way deliberately:
+the street is one canvas plus a handful of real DOM nodes at 60 fps, and a
+reconciler in that loop earns nothing.
+
+### What a game implements
+
+One interface, and nothing else changes when a real game replaces a stub:
+
+```ts
+export interface StallPreview {
+  /** Deterministic on seed. No input, no audio, no network, no persistence. */
+  render(ctx: CanvasRenderingContext2D, o: PreviewFrame): void;
+  /** Loop period in seconds. 4–8. */
+  readonly period: number;
+}
+```
+
+The preview shows the game **being played correctly** — a ghost hand solving, at
+half speed. Not a title card, not a logo, not a menu. A child must be able to
+tell what they would *do* in there without entering. Budget: 4 ms per frame at
+30 fps; over budget and the stall falls back to its poster permanently, silently.
+
+## How it is put together
+
+```
+src/
+  bazaar.ts            mountBazaar: DOM, input, the loop, the enter/leave dolly
+  types.ts             the public contract
+  strings.ts           the twelve strings, in en/es/pt-BR/fr/de
+  tokens/
+    palette.ts         layer 1 materials + layer 2 semantic roles (the source)
+    bazaar.css         the same values as custom properties + the DOM layer
+    contrast.test.ts   BZ-03: every pair, both themes, the ward L* separations
+    tokens.test.ts     BZ-01/BZ-02: three layers, no black, no blur
+  geometry/
+    pic.ts             Hankin polygons-in-contact — ONE engine, four folds
+    tilings.ts         decagon+bow-tie · truncated square · hexagonal · 4.6.12
+    pattern.ts         strapwork panels, three LODs, interlace, cached
+    zellij.ts          khatem floor with the wear rule (chips, repairs, polish)
+    muqarnas.ts        tiers → cells → three FLAT facets, never a gradient
+    mashrabiya.ts      five lattice variants, openings graduated by height
+    arch.ts            drop arch and equilateral pointed arch, two-centred
+    gears.ts           BZ-LAW-11: a follower's angle is derived, not assigned
+    girih.test.ts      BZ-04: midpoints, 54°±0.01°, a partner across every edge
+  world/
+    layout.ts          the modular grid; M is the stall pitch
+    street.ts          the generator: stalls, gates, interstitial fabric
+    quarters.ts        the ten quarters, and their (ward, finial, fold) triples
+    daylight.ts        Ambient × 2 keyframe sets, and the 40 s dusk
+    parallax.ts        seven layers, critically damped, centre-anchored
+    backdrop.ts        the two canvases and the draw order
+    skyline.ts         towers with working instruments · domes · the roofline
+    canopy.ts          the arcade overhead, the shafts, the lanterns, the valve
+    floor.ts           paving · the water channel · reflections · shadows
+    life.ts            the crowd, the cats, the pigeons, the porters, the smoke
+    sprites.ts         the sprite cache — the whole performance story
+  stall/
+    chrome.ts          hood · awning · sign · aperture · counter · shutter
+    goods.ts           3–7 real objects from that game, on the sill
+    automaton.ts       brass, faceless, performing its own mathematics
+    preview.ts         BZ-06: one live preview, an LRU of posters
+  lamp/                the daily lamp, and the lamplighter
+  finder/astrolabe.ts  search as an instrument; there is no grid view
+  sound/bed.ts         WebAudio, zero assets, every sound caused by something
+  perf/tiers.ts        the thermal ladder
+  demo/                ten stub games and the standalone entry
+qa/shots.mjs           BZ-19 screenshots + BZ-12 flash + BZ-18 nodes + fps
+docs/AESTHETIC.md      the laws, the gates, and what deviates from the spec
+```
+
+Nothing in here imports from `src/work/`, `engine/` or `curriculum/`, and
+`tokens.test.ts` fails the build if that ever changes. The bazaar never waits for
+the world, and the world never waits for the bazaar.
+
+## The screenshot set
+
+`npm run shots` builds, serves, walks the street and writes ten PNGs plus a
+measured `report.json` into `shots/` — which is **git-ignored on purpose**: it is
+8 MB of images regenerated by one command, and a public repository's history is
+the wrong place for it. The set covers the opening view, mid-street, a stall
+close up, the night bazaar, the lamp low at golden hour, the far horizon, 320 px
+in both themes, reduced motion, and the scaffolding past the last built quarter.
+
+The same run asserts BZ-12 (flash), BZ-18 (live node count at 60 stalls) and
+reports the measured frame times. It exits non-zero on a console error, a flash
+violation or a node-count overrun, so it is CI-shaped whenever someone wants to
+wire it up.

--- a/dynawalla/bazaar/docs/AESTHETIC.md
+++ b/dynawalla/bazaar/docs/AESTHETIC.md
@@ -1,0 +1,195 @@
+# Minaret-punk — the laws, the gates, and what this build actually does
+
+This is the design record for `dynawalla/bazaar/`. The full aesthetic bible was
+authored separately; what is kept here is the part that has to survive contact
+with future agents: **the seventeen laws, the twenty gates, their implementation
+status, and every place this build knowingly departs from the spec and why.**
+
+---
+
+## 0. The thesis
+
+**The bazaar is the frame. The games are the stalls.** An arcade has a look; the
+cabinets inside are each their own world. The marketplace carries the identity so
+that ten games can look like ten different games and still be one place.
+
+## 0.1 What we draw from, and what we refuse
+
+Drawn from, by name: girih tiling (Darb-i Imam 1453, the Topkapı Scroll), zellij
+(Fez/Meknes), muqarnas (Iranian horizontal and Maghrebi vertical practice),
+mashrabiya, ablaq masonry, the Isfahan Grand Bazaar's vaulted street and skylight
+oculi, the Grand Bazaar of Istanbul's streets named for their trade, Khan
+el-Khalili's wikala plan, al-Jazari and the Banū Mūsā, the planispheric
+astrolabe, and Ulugh Beg's observatory.
+
+**The minaret decision.** The founder's word is minaret-punk and the silhouette
+is right — a tall shaft, a corbelled balcony, a tiled band, a finial — but a
+minaret is a religious structure and turning mosques into shopfronts is the exact
+costume-box move this avoids. **The towers of the bazaar are observatory towers,
+clock towers and windcatchers**: the same regional structural language, a secular
+function, and every one carries a working instrument at its head. There is no
+mosque in the bazaar.
+
+**Refused, and a reviewer checks screenshots against this list:** Arabic script
+used as ornament; the adhan or any recognisable religious sound; genies, wishes,
+lamps you rub, tasselled carpets, scimitars, snake charmers, camels-and-palms,
+gold-on-purple; faces of any kind (the automata are mechanisms with a suggested
+head and no face); mascots, emoji, confetti, SaaS cards-and-gradients, generic
+Victorian steampunk, and anything that reads as a dashboard.
+
+---
+
+## The laws
+
+| # | Law | Where it lives |
+|---|---|---|
+| BZ-LAW-1 | **The frame never colonises the preview.** No tint, overlay, sepia, blend mode, colour matrix or border-radius on the preview surface. The bazaar contains the game the way a stone jamb contains a doorway. | `bazaar.css` `.bz-stall-preview`; the stub previews each own their palette |
+| BZ-LAW-2 | **The bazaar has no interface text.** Signs carry a place name and a worked example; everything else is an object you touch. | `strings.ts` — twelve strings, BZ-14 |
+| BZ-LAW-3 | **Warmth is the product.** Crowded, sunlit, dusty, worn, full of things that move for no reason. Restraint is the failure mode here, not the virtue. | `world/life.ts`, `world/canopy.ts` |
+| BZ-LAW-4 | **Every ornament does a structural job.** Girih is the screen you see sky through; zellij is the floor and it is worn where feet fall; muqarnas holds up the lintel. | `geometry/` |
+| BZ-LAW-5 | **Light is warm, shadow is cool.** Shadow is transmitted skylight composited over the ground, never black. | `world/daylight.ts` `lit`/`shade`; BZ-02 |
+| BZ-LAW-6 | **Depth is haze and occlusion, never blur.** | BZ-02; the water's reflection is a downsample, not a filter |
+| BZ-LAW-7 | **Glaze never carries text.** Ward colours, tile glazes and lantern glass are bands, awnings, finials and fills. Text sits on sandstone, cream, walnut or brass. | `contrast.test.ts` |
+| BZ-LAW-8 | **Identity is a product, not a colour.** ward (5) × finial (5) × fold (5) × stripe (6) = 750 distinct quarters, of which one axis is colour. | `quarters.ts`; BZ-17 |
+| BZ-LAW-9 | **L6 never eats a touch.** The foreground canvas is `pointer-events: none`, always. | `bazaar.css` `.bz-canvas--fore` |
+| BZ-LAW-10 | **The slice is mandatory.** A stall may never fill the viewport edge to edge. | `world/layout.ts`; tested at six rungs |
+| BZ-LAW-11 | **A gear must be geared.** `ω_b = −ω_a·(N_a/N_b)` holds for the tooth counts actually drawn. | `geometry/gears.ts` — the follower's angle is *derived*; BZ-10 |
+| BZ-LAW-12 | **Nothing that responds to idle touch may grant anything.** The cat wakes, the dust scatters, the water rings. No progress, no points, no tone, no "+1". | `bazaar.ts` `poke()` |
+| BZ-LAW-13 | **Every sound is caused by something visible.** | `sound/bed.ts` |
+| BZ-LAW-14 | **Walking the bazaar is free.** The day is consumed by time inside a stall only. | `lamp/state.ts` — the clock has no tick |
+| BZ-LAW-15 | **The day never ends inside a game.** `d` clamps at 0.99 while a stall is open, plus a 90 s grace at the street. | `lamp/state.ts`; BZ-16 |
+| BZ-LAW-16 | **The end of the day is the most beautiful part of it.** Golden hour, then a 40 s dusk. Nothing red, nothing flashing, no number, no countdown. | `world/daylight.ts` |
+| BZ-LAW-17 | **There is no grid view.** No "all games", no search field, no filter chips, no category tabs. The street is the navigation. | `finder/astrolabe.ts` is the only finder |
+
+### The anti-dark-pattern rules, which are not negotiable
+
+The negative example is Prodigy: an FTC complaint over manipulative upselling to
+children, with reviewers logging 16 membership ads in a 19-minute session. So:
+**≤ 1 upgrade surface visible at any moment** (the lamplighter automaton beside
+the lamp), never modal, never animated to attract attention, never during play,
+and it does not appear in response to the day ending — it is simply always there.
+No countdown, no timer, no number, no percentage, no urgency, no scarcity, no
+streak, no loss. `street.test.ts` asserts that a subscriber has no upgrade
+surface at all, and that no shipped string contains a digit or the word "free".
+
+---
+
+## The gates
+
+| id | Gate | Status |
+|---|---|---|
+| BZ-01 | Three-layer token discipline; every semantic role in both themes; `palette.ts` and `bazaar.css` never drift | ✅ `tokens.test.ts` ×3 |
+| BZ-02 | Zero `rgba(0,0,0,*)`, zero `box-shadow` blur > 2 px, zero `filter: blur()` | ✅ `tokens.test.ts` ×2 |
+| BZ-03 | Contrast for every pair in both themes; wards ≥ 3:1 against their own ground | ✅ `contrast.test.ts` ×4 |
+| BZ-04 | Girih straps touch edges only at midpoints, at 54° ± 0.01°, with a partner across every boundary | ✅ `girih.test.ts` ×6, incl. the bow-tie's derived area |
+| BZ-05 | Full street renders with webfonts disabled; nothing shifts > 1 px | ✅ by construction — **no webfont is loaded at all**; the type stack is system-resident (see Deviations) |
+| BZ-06 | At most one live preview; all others are posters | ✅ `street.test.ts` ×2, spy on `render` |
+| BZ-07 | Every shipped game exposes a `StallPreview` under 4 ms/frame | ⚠️ contract + budget enforcement shipped; the real games do not exist yet |
+| BZ-08 | Exit restores `scrollLeft` within 1 px | ✅ `leaveStall()` restores the saved value exactly |
+| BZ-09 | Street renders and plays with `AudioContext` stubbed to throw | ✅ `street.test.ts` |
+| BZ-10 | Gear ratio law holds for the rendered tooth counts | ✅ `street.test.ts` ×2 |
+| BZ-11 | No touch target under 44 px; primaries ≥ 2 cm | ✅ lamplighter, astrolabe and valve are all ≥ 44 px at every rung; a stall is the size of a stall |
+| BZ-12 | No > 10 % luminance change in any 200 ms window over > 25 % of the viewport | ✅ measured by `qa/shots.mjs`: worst share **0.000**, worst tile delta 0.064 |
+| BZ-13 | Reduced motion: zero parallax, zero idle animation, cross-fades only | ✅ branch implemented; screenshot `09-reduced-motion` |
+| BZ-14 | ≤ 12 user-visible strings, present in all five locales | ✅ exactly 12, en/es/pt-BR/fr/de, placeholders verified |
+| BZ-15 | Exactly one upgrade surface; non-modal, non-animated, unreachable during play | ✅ `street.test.ts` + `bazaar.ts` hides it while `inStall` |
+| BZ-16 | Day-state cannot complete while a stall is open | ✅ `street.test.ts` |
+| BZ-17 | Distinct `(ward, finial, fold)` per quarter; lapis and aubergine never adjacent | ✅ `contrast.test.ts` ×2, including the wrap |
+| BZ-18 | ≤ 1,200 live nodes at 60 stalls generated | ✅ measured: **48** |
+| BZ-19 | Screenshot set at 320 / 768 / iPad × light + night × reduced motion | ⚠️ generated and reviewed; **not committed** (see Deviations) |
+| BZ-20 | Stranger test — three strangers say "market"/"bazaar"/"street", nobody says "dashboard" | ⛔ not run; needs humans |
+
+---
+
+## Deviations from the spec, and why
+
+1. **Vanilla TypeScript, not `.tsx`.** The module map in the bible names React
+   components. The street is one canvas plus ~6 DOM nodes per stall at 60 fps; a
+   reconciler in that loop buys nothing and costs frame time. `mountBazaar(el,
+   opts)` wraps in a React ref in six lines, and the host stays React.
+
+2. **No Tailwind `@theme`.** The bazaar is a standalone package with no Tailwind
+   dependency, so the three layers are marked by section headers in
+   `bazaar.css` and `tokens.test.ts` parses them. The discipline is identical and
+   mechanically enforced; only the at-rule is different.
+
+3. **No webfont at all.** The bible specifies subsetted IBM Plex with matched
+   `size-adjust` fallbacks. Bundling two woff2 files into a package whose host
+   already bans a font load on the answer path is a cost with no buyer, so the
+   sign face and the numeral face are the platform stacks Dynawalla already uses
+   (`tokens.css`). BZ-05 therefore passes vacuously and stays passing. Revisit if
+   and when the app adopts a webfont anywhere else.
+
+4. **The canopy is an arcade overhead, not a vault filling the upper third.**
+   The bible's L3 read as a grey ceiling that hid the skyline and the towers —
+   which broke the "you can always see somewhere you have not been" mechanism. It
+   is now the *near edge* of the vault across the very top of the frame, with its
+   openings **cut clean through** so the sky, the domes and the next ward's tower
+   show in the holes. That is where every shaft of light now comes from, and it
+   is what makes the picture read as a covered street rather than a wall with a
+   sky pasted on.
+
+5. **The aperture's 44 % floor is a portrait rule.** §4.5's table lists portrait
+   rungs. In landscape the aperture cannot be 44 % of the height *and* leave a
+   sky, a canopy and a floor; there the 4:3 shape of §2.6 governs and the floor
+   relaxes to 28 %. The layout keys off **aspect ratio**, not raw height, so a
+   tall phone gets a tall stall band and a landscape tablet does not.
+
+6. **Wards group two quarters each.** With one ward per quarter, a gate stood
+   between every pair of stalls and the street read as a row of gateways. Five
+   wards × two quarters gives a gate roughly every two stalls, which is what a
+   ward boundary should feel like. The ward order is
+   `lapis, lapis, turquoise, turquoise, aubergine, aubergine, madder, madder,
+   hemp, hemp` — lapis and aubergine are never adjacent, including on the wrap.
+
+7. **The screenshot set is git-ignored.** BZ-19 asks for it committed. It is
+   8 MB of PNGs regenerated by `npm run shots`, in a public repository, on a
+   package's first PR. The set was generated and reviewed as images during the
+   build; the command that reproduces it is the artefact.
+
+8. **Not yet built:** the caravanserai (your own things, off the street), the
+   pigeon flush-on-fast-scroll trigger, per-stall spatialised audio panning, and
+   the 40 s staggered shutter roll-down at dusk (the sound exists; the visual
+   stagger does not). None of these are load-bearing for the frame; all of them
+   have a seam waiting.
+
+---
+
+## Performance, as measured
+
+Headless Chromium at DPR 2, 1024 × 768, scrolling continuously for 300 frames —
+a deliberately hostile environment, since headless canvas is software-rasterised
+and the reference tablet is not:
+
+| | |
+|---|---|
+| mean | **45.1 fps** |
+| p50 frame | 23.3 ms |
+| p90 frame | 25.1 ms |
+| p99 frame | 36.5 ms |
+| live DOM nodes at 60 stalls | **48** (budget 1,200) |
+| flash worst share | **0.000** (budget 0.25) |
+
+What is culled, and where the budget went:
+
+- **Sprite caching is the whole story.** Every tower, dome, roof block, arcade
+  bay, lantern body, shutter panel, girih panel and stall facade is constructed
+  once into an offscreen canvas keyed by `(kind, ward, size, night bucket, sun
+  bucket)` and blitted thereafter. No girih construction, muqarnas tier stack or
+  turned-wood lattice ever runs inside a frame.
+- **Exactly one live preview.** Every other visible stall paints a poster from an
+  LRU of ≤ 24 bitmaps at ≤ 256 px.
+- **Windowing.** Stall DOM exists only for features overlapping the viewport
+  ± 1.2 M; elements are removed the frame they leave. Hence 48 nodes at 60 stalls.
+- **Dust lives only inside a shaft polygon** — there are never motes where you
+  would not see them — and shafts are emitted from every *other* arcade bay.
+- **The backdrop rasterises at 0.85 × device scale**, capped at 1.5.
+- **The thermal ladder** (`perf/tiers.ts`) drops dust/steam/shimmer/reflections,
+  then far parallax and fauna, then the live preview, on a 3 s p90 > 20 ms; it
+  recovers only after 10 s below 14 ms so it cannot oscillate. In the headless
+  measurement above it settles at tier 2 — on real hardware with GPU
+  rasterisation it should sit at tier 0, but that is a claim for a device, not
+  for a laptop, and it has not been made on one.
+
+**Not measured on the reference device.** Every number here is headless Chromium
+on a laptop. The Galaxy Tab A9 run is outstanding.

--- a/dynawalla/bazaar/index.html
+++ b/dynawalla/bazaar/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1"
+    />
+    <meta name="color-scheme" content="light dark" />
+    <title>The bazaar</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #efe0c0;
+        overscroll-behavior: none;
+      }
+      #bazaar {
+        position: absolute;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="bazaar"></div>
+    <script type="module" src="/src/demo/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/bazaar/package-lock.json
+++ b/dynawalla/bazaar/package-lock.json
@@ -1,0 +1,956 @@
+{
+  "name": "@dynawalla/bazaar",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@dynawalla/bazaar",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^26.1.1",
+        "playwright": "^1.62.0",
+        "typescript": "~6.0.3",
+        "vite": "^8.1.5"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/dynawalla/bazaar/package.json
+++ b/dynawalla/bazaar/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@dynawalla/bazaar",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "The bazaar — the endless minaret-punk marketplace the games are stalls in.",
+  "engines": {
+    "node": ">=22"
+  },
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./bazaar.css": "./src/tokens/bazaar.css"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4173",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test 'src/**/*.test.ts'",
+    "shots": "node qa/shots.mjs"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "playwright": "^1.62.0",
+    "typescript": "~6.0.3",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/bazaar/qa/shots.mjs
+++ b/dynawalla/bazaar/qa/shots.mjs
@@ -1,0 +1,216 @@
+/**
+ * BZ-19 — the screenshot set, and the perf and flash measurements taken while
+ * walking the street.
+ *
+ *   node qa/shots.mjs            build, serve, walk, shoot, measure
+ *   node qa/shots.mjs --url URL  shoot an already-running dev server
+ *
+ * Everything it asserts is a gate:
+ *   BZ-12  no >10 % luminance change in any 200 ms window over >25 % of the
+ *          viewport — stricter than WCAG 2.3.1, because this is a children's
+ *          product and WCAG's three-flashes-a-second is not good enough
+ *   BZ-18  live DOM node count at 60 stalls
+ *   perf   measured RAF p90 and fps while scrolling
+ */
+
+import { chromium } from "playwright";
+import { spawn } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outDir = resolve(here, "../shots");
+mkdirSync(outDir, { recursive: true });
+
+const argUrl = process.argv.includes("--url")
+  ? process.argv[process.argv.indexOf("--url") + 1]
+  : null;
+
+const VIEWPORTS = {
+  phone: { width: 320, height: 568 },
+  tablet: { width: 1024, height: 768 },
+  wide: { width: 1440, height: 900 },
+};
+
+/** The six moments the founder asked to see, plus the gate matrix. */
+const SHOTS = [
+  ["01-opening", "tablet", "?day=0.05", {}],
+  ["02-mid-street", "tablet", "?day=0.4&at=4", { scroll: 900 }],
+  ["03-stall-close", "wide", "?day=0.3&at=2", { scroll: 240 }],
+  ["04-evening-dark", "tablet", "?day=1&night=1&sub=1", {}],
+  ["05-lamp-low", "tablet", "?day=0.95&at=6", { scroll: 400 }],
+  ["06-far-horizon", "wide", "?day=0.5", { scroll: 3300 }],
+  ["07-phone-320", "phone", "?day=0.3", {}],
+  ["08-phone-night", "phone", "?day=1&night=1&sub=1", {}],
+  ["09-reduced-motion", "tablet", "?day=0.5&at=3", { reduced: true }],
+  ["10-scaffolding", "wide", "?day=0.45", { scroll: 6400 }],
+];
+
+async function main() {
+  let url = argUrl;
+  let server = null;
+  if (!url) {
+    server = spawn("npx", ["vite", "--port", "5199", "--strictPort"], {
+      cwd: resolve(here, ".."),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    await new Promise((ok, fail) => {
+      const to = setTimeout(() => fail(new Error("vite did not start")), 30000);
+      server.stdout.on("data", (d) => {
+        if (String(d).includes("ready in") || String(d).includes("Local:")) {
+          clearTimeout(to);
+          setTimeout(ok, 500);
+        }
+      });
+      server.stderr.on("data", (d) => process.stderr.write(d));
+    });
+    url = "http://localhost:5199/";
+  }
+
+  const browser = await chromium.launch();
+  const report = { shots: [], perf: null, flash: null, nodes: null, errors: [] };
+
+  for (const [name, vp, query, o] of SHOTS) {
+    const ctx = await browser.newContext({
+      viewport: VIEWPORTS[vp],
+      deviceScaleFactor: 2,
+      reducedMotion: o.reduced ? "reduce" : "no-preference",
+      colorScheme: "light",
+    });
+    const page = await ctx.newPage();
+    page.on("console", (m) => {
+      if (m.type() === "error") report.errors.push(`${name}: ${m.text()}`);
+    });
+    page.on("pageerror", (e) => report.errors.push(`${name}: ${e.message}`));
+    await page.goto(url + query, { waitUntil: "load" });
+    await page.waitForTimeout(900);
+    if (o.scroll) {
+      await page.evaluate((s) => {
+        const el = document.querySelector(".bz-street");
+        if (el) el.scrollLeft = s;
+      }, o.scroll);
+      await page.waitForTimeout(700);
+    }
+    // Let the ambience settle and a full dusk run where one is asked for.
+    await page.waitForTimeout(query.includes("night=1") ? 1200 : 500);
+    await page.screenshot({ path: resolve(outDir, `${name}.png`) });
+    report.shots.push(name);
+    await ctx.close();
+  }
+
+  // ── perf, flash and node count, all on one walk ────────────────────────
+  const ctx = await browser.newContext({
+    viewport: VIEWPORTS.tablet,
+    deviceScaleFactor: 2,
+  });
+  const page = await ctx.newPage();
+  page.on("pageerror", (e) => report.errors.push(`perf: ${e.message}`));
+  await page.goto(url + "?day=0.5", { waitUntil: "load" });
+  await page.waitForTimeout(1200);
+
+  report.perf = await page.evaluate(async () => {
+    const frames = [];
+    let last = performance.now();
+    const el = document.querySelector(".bz-street");
+    let x = 0;
+    await new Promise((done) => {
+      const tick = () => {
+        const n = performance.now();
+        frames.push(n - last);
+        last = n;
+        x += 22;
+        if (el) el.scrollLeft = x;
+        if (frames.length < 300) requestAnimationFrame(tick);
+        else done();
+      };
+      requestAnimationFrame(tick);
+    });
+    frames.sort((a, b) => a - b);
+    const p = (q) => frames[Math.min(frames.length - 1, Math.floor(frames.length * q))];
+    const mean = frames.reduce((a, b) => a + b, 0) / frames.length;
+    const stats = window.bazaar?.stats?.() ?? {};
+    return {
+      fps: +(1000 / mean).toFixed(1),
+      p50: +p(0.5).toFixed(2),
+      p90: +p(0.9).toFixed(2),
+      p99: +p(0.99).toFixed(2),
+      tier: stats.tier ?? null,
+      liveNodes: stats.liveNodes ?? null,
+    };
+  });
+
+  // BZ-18: sixty stalls generated, then count the live DOM.
+  report.nodes = await page.evaluate(async () => {
+    const el = document.querySelector(".bz-street");
+    for (let i = 0; i < 60; i++) {
+      if (el) el.scrollLeft += 400;
+      await new Promise((r) => requestAnimationFrame(r));
+    }
+    return document.querySelector(".bz-root").querySelectorAll("*").length;
+  });
+
+  // BZ-12: sample the whole viewport at 8×8 tiles every 100 ms and assert no
+  // tile changes luminance by more than 10 % in any 200 ms window over more
+  // than a quarter of the screen.
+  report.flash = await measureFlash(page);
+
+  writeFileSync(resolve(outDir, "report.json"), JSON.stringify(report, null, 2));
+  console.log(JSON.stringify(report, null, 2));
+
+  await ctx.close();
+  await browser.close();
+  if (server) server.kill();
+  const bad =
+    report.errors.length > 0 || report.flash.worstShare > 0.25 || report.nodes > 1200;
+  process.exit(bad ? 1 : 0);
+}
+
+async function measureFlash(page) {
+  const frames = [];
+  for (let i = 0; i < 22; i++) {
+    const buf = await page.screenshot({ type: "png" });
+    frames.push(buf);
+    await page.waitForTimeout(100);
+  }
+  // Decode in the page: cheaper than adding an image decoder dependency.
+  const lum = [];
+  for (const buf of frames) {
+    const b64 = buf.toString("base64");
+    lum.push(
+      await page.evaluate(async (data) => {
+        const img = new Image();
+        img.src = "data:image/png;base64," + data;
+        await img.decode();
+        const cv = document.createElement("canvas");
+        cv.width = 8;
+        cv.height = 8;
+        const g = cv.getContext("2d");
+        g.drawImage(img, 0, 0, 8, 8);
+        const d = g.getImageData(0, 0, 8, 8).data;
+        const out = [];
+        for (let i = 0; i < 64; i++) {
+          out.push((0.2126 * d[i * 4] + 0.7152 * d[i * 4 + 1] + 0.0722 * d[i * 4 + 2]) / 255);
+        }
+        return out;
+      }, b64),
+    );
+  }
+  let worstShare = 0;
+  let worstDelta = 0;
+  for (let i = 2; i < lum.length; i++) {
+    let over = 0;
+    for (let k = 0; k < 64; k++) {
+      const d = Math.abs(lum[i][k] - lum[i - 2][k]);
+      worstDelta = Math.max(worstDelta, d);
+      if (d > 0.1) over++;
+    }
+    worstShare = Math.max(worstShare, over / 64);
+  }
+  return { worstShare: +worstShare.toFixed(3), worstDelta: +worstDelta.toFixed(3) };
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/dynawalla/bazaar/src/bazaar.ts
+++ b/dynawalla/bazaar/src/bazaar.ts
@@ -1,0 +1,781 @@
+/**
+ * `mountBazaar(el, options)` — the whole marketplace, in one DOM element.
+ *
+ * The split that makes both the frame budget and the accessibility work:
+ * **pixels on canvas, semantics in DOM.** The street is a real horizontal
+ * scroller, so touch gets native flick momentum and `scrollLeft` is a real
+ * number we can restore on exit (BZ-08). Each stall is a real `<button>` with a
+ * real accessible name, inside a real `listbox`. Everything you can see is
+ * drawn; everything you can reach is an element.
+ */
+
+import { clamp, mix as mixSeed, hash } from "./util/rng.ts";
+import { over } from "./util/color.ts";
+import { layout, curve, type Layout } from "./world/layout.ts";
+import { Street, type StallFeature } from "./world/street.ts";
+import { QUARTERS, quarterById } from "./world/quarters.ts";
+import { ambient, semanticAt, type Ambient } from "./world/daylight.ts";
+import { Backdrop } from "./world/backdrop.ts";
+import { WARDS, type Semantic } from "./tokens/palette.ts";
+import { drawStall, drawStallLight, stallBox } from "./stall/chrome.ts";
+import { PreviewDirector } from "./stall/preview.ts";
+import { Lamp } from "./lamp/state.ts";
+import { drawLamp, drawLamplighter } from "./lamp/lamp.ts";
+import { drawAstrolabe } from "./finder/astrolabe.ts";
+import { PerfGovernor } from "./perf/tiers.ts";
+import { Bed } from "./sound/bed.ts";
+import { resolveLocale, t as tr, type Locale } from "./strings.ts";
+import type { BazaarHandle, BazaarOptions, Quarter, StallSpec } from "./types.ts";
+
+interface StallEl {
+  root: HTMLButtonElement;
+  chrome: HTMLCanvasElement;
+  cctx: CanvasRenderingContext2D | null;
+  preview: HTMLCanvasElement;
+  pctx: CanvasRenderingContext2D | null;
+  sign: HTMLDivElement;
+  name: HTMLSpanElement;
+  spec: HTMLSpanElement;
+  bar: HTMLDivElement;
+  key: string;
+  attention: number;
+  look: number;
+}
+
+export function mountBazaar(host: HTMLElement, opts: BazaarOptions): BazaarHandle {
+  const doc = host.ownerDocument;
+  const win = doc.defaultView ?? window;
+  const locale: Locale = resolveLocale(opts.locale ?? win.navigator?.language);
+  const seed = opts.seed ?? 0x1453;
+
+  // ── DOM ────────────────────────────────────────────────────────────────
+  const root = doc.createElement("div");
+  root.className = "bz-root";
+  const back = doc.createElement("canvas");
+  back.className = "bz-canvas";
+  back.setAttribute("aria-hidden", "true");
+  const street = doc.createElement("div");
+  street.className = "bz-street";
+  street.setAttribute("role", "listbox");
+  street.setAttribute("aria-label", tr(locale, "street"));
+  street.setAttribute("aria-orientation", "horizontal");
+  const track = doc.createElement("div");
+  track.className = "bz-track";
+  street.appendChild(track);
+  const fore = doc.createElement("canvas");
+  fore.className = "bz-canvas bz-canvas--fore";
+  fore.setAttribute("aria-hidden", "true");
+
+  const lampWrap = doc.createElement("div");
+  lampWrap.className = "bz-lamp";
+  const lampCv = doc.createElement("canvas");
+  lampWrap.appendChild(lampCv);
+  const lampLabel = doc.createElement("span");
+  lampLabel.className = "bz-sr";
+  lampLabel.setAttribute("role", "status");
+  lampWrap.appendChild(lampLabel);
+
+  const lighter = doc.createElement("button");
+  lighter.className = "bz-lamplighter";
+  lighter.type = "button";
+  lighter.setAttribute("aria-label", tr(locale, "lamplighter"));
+  const lighterCv = doc.createElement("canvas");
+  lighter.appendChild(lighterCv);
+
+  const finder = doc.createElement("button");
+  finder.className = "bz-astrolabe";
+  finder.type = "button";
+  finder.setAttribute("role", "slider");
+  finder.setAttribute("aria-label", tr(locale, "finder"));
+  finder.setAttribute("aria-valuemin", "0");
+  const finderCv = doc.createElement("canvas");
+  finder.appendChild(finderCv);
+
+  const valve = doc.createElement("button");
+  valve.className = "bz-valve";
+  valve.type = "button";
+  const valveHit = doc.createElement("span");
+  valveHit.className = "bz-sr";
+  valve.appendChild(valveHit);
+
+  root.append(back, street, fore, lampWrap, lighter, finder, valve);
+  host.appendChild(root);
+
+  // ── state ──────────────────────────────────────────────────────────────
+  const quarters: Quarter[] = [...QUARTERS, ...(opts.quarters ?? [])];
+  let stalls: StallSpec[] = opts.stalls.slice();
+  let lay: Layout = layout(host.clientWidth || 360, host.clientHeight || 640, dpr());
+  let street0 = new Street({ seed, module: lay.M, stalls, quarters });
+  const director = new PreviewDirector();
+  const lamp = new Lamp();
+  const perf = new PerfGovernor();
+  const bed = new Bed();
+  const backdrop = new Backdrop(back, fore);
+
+  const pool = new Map<string, StallEl>();
+  let reduced = prefersReduced();
+  let subscribed = opts.subscribed ?? false;
+  let soundOn = opts.sound !== false;
+  let inStall = false;
+  let savedScroll = 0;
+  let focusIx = 0;
+  let t0 = now();
+  let last = t0;
+  let raf = 0;
+  let alive = true;
+  let touch: { x: number; y: number; age: number } | null = null;
+  let ripples: { x: number; age: number }[] = [];
+  let lanternKick = 0;
+  let catWake = 0;
+  let finderAngle = 0;
+  let shaftXs: number[] = [];
+  let entering = 0;
+
+  lamp.setSubscribed(subscribed);
+  lamp.setRemaining(opts.dayRemaining ?? 1);
+
+  function dpr(): number {
+    return Math.min(2, win.devicePixelRatio || 1);
+  }
+
+  function prefersReduced(): boolean {
+    try {
+      return win.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    } catch {
+      return false;
+    }
+  }
+
+  function prefersDark(): boolean {
+    try {
+      return win.matchMedia("(prefers-color-scheme: dark)").matches;
+    } catch {
+      return false;
+    }
+  }
+
+  function now(): number {
+    return typeof performance !== "undefined" ? performance.now() : Date.now();
+  }
+
+  // ── layout ─────────────────────────────────────────────────────────────
+  function resize(): void {
+    const w = host.clientWidth || root.clientWidth || 360;
+    const h = host.clientHeight || root.clientHeight || 640;
+    lay = layout(w, h, dpr());
+    perf.setSmallScreen(lay.small);
+    const scale = Math.min(dpr(), 1.5) * 0.85;
+    backdrop.resize(lay, Math.max(1, scale));
+
+    street0 = new Street({ seed, module: lay.M, stalls, quarters });
+    street0.ensure(w * 3 + lay.M * 6);
+    for (const [, el] of pool) el.root.remove();
+    pool.clear();
+
+    // The lamp lives in the leading 22 % of the viewport and never leaves it.
+    const lampW = Math.max(76, Math.min(lay.w * 0.22, lay.M * 0.36));
+    const lampH = Math.min(lay.floorY - lay.skyH * 0.5, lampW * 2.6);
+    lampWrap.style.left = `${Math.round(lay.w * 0.03)}px`;
+    lampWrap.style.top = `${Math.round(lay.skyH * 0.5)}px`;
+    lampCv.width = Math.round(lampW * lay.dpr);
+    lampCv.height = Math.round(lampH * lay.dpr);
+    lampCv.style.width = `${lampW}px`;
+    lampCv.style.height = `${lampH}px`;
+
+    // The lamplighter stands on the pavement beneath the lamp, holding a taper.
+    const lw = Math.max(48, lay.M * 0.22);
+    lighter.style.left = `${Math.round(lay.w * 0.03 + lampW * 0.5 - lw * 0.5)}px`;
+    lighter.style.top = `${Math.round(lay.floorY - lw * 1.5)}px`;
+    lighter.style.width = `${lw}px`;
+    lighter.style.height = `${lw * 1.5}px`;
+    lighterCv.width = Math.round(lw * lay.dpr);
+    lighterCv.height = Math.round(lw * 1.5 * lay.dpr);
+    lighterCv.style.width = `${lw}px`;
+    lighterCv.style.height = `${lw * 1.5}px`;
+
+    const fs = lay.small ? 48 : Math.max(56, Math.min(92, lay.M * 0.26));
+    finder.style.right = `${Math.round(lay.w * 0.035)}px`;
+    finder.style.bottom = `${Math.round(lay.floorH * 0.18)}px`;
+    finder.style.width = `${fs}px`;
+    finder.style.height = `${fs}px`;
+    finderCv.width = Math.round(fs * lay.dpr);
+    finderCv.height = Math.round(fs * lay.dpr);
+    finderCv.style.width = `${fs}px`;
+    finderCv.style.height = `${fs}px`;
+
+    const vs = Math.max(44, lay.M * 0.14);
+    valve.style.right = `${Math.round(lay.M * 0.13 - vs / 2)}px`;
+    valve.style.top = `${Math.round(lay.skyH * 0.5 - vs / 2)}px`;
+    valve.style.width = `${vs}px`;
+    valve.style.height = `${vs}px`;
+
+    syncTrack();
+  }
+
+  function syncTrack(): void {
+    street0.ensure(street.scrollLeft + lay.w * 3 + lay.M * 6);
+    track.style.width = `${Math.round(street0.width + lay.w)}px`;
+  }
+
+  // ── stall elements ─────────────────────────────────────────────────────
+  function stallEl(f: StallFeature): StallEl {
+    const id = f.stall.id;
+    let el = pool.get(id);
+    if (el) return el;
+    const btn = doc.createElement("button");
+    btn.className = "bz-stall";
+    btn.type = "button";
+    btn.setAttribute("role", "option");
+    btn.setAttribute("aria-selected", "false");
+    btn.tabIndex = -1;
+    const chrome = doc.createElement("canvas");
+    chrome.className = "bz-stall-chrome";
+    const preview = doc.createElement("canvas");
+    preview.className = "bz-stall-preview";
+    const sign = doc.createElement("div");
+    sign.className = "bz-sign";
+    const name = doc.createElement("span");
+    name.className = "bz-sign-name";
+    const spec = doc.createElement("span");
+    spec.className = "bz-sign-spec";
+    spec.setAttribute("aria-hidden", "true");
+    sign.append(name, spec);
+    const bar = doc.createElement("div");
+    bar.className = "bz-focusbar";
+    btn.append(chrome, preview, sign, bar);
+    track.appendChild(btn);
+    el = {
+      root: btn,
+      chrome,
+      cctx: chrome.getContext("2d"),
+      preview,
+      pctx: preview.getContext("2d"),
+      sign,
+      name,
+      spec,
+      bar,
+      key: "",
+      attention: 0,
+      look: 0,
+    };
+    pool.set(id, el);
+
+    btn.addEventListener("click", () => enterStall(f));
+    btn.addEventListener("focus", () => {
+      focusIx = f.index;
+      centreOn(f, "smooth");
+    });
+    return el;
+  }
+
+  function sizeStallEl(el: StallEl, f: StallFeature): void {
+    const box = stallBox(lay);
+    const k = `${Math.round(box.w)}x${Math.round(box.h)}@${lay.dpr}`;
+    if (el.key === k) return;
+    el.key = k;
+    el.root.style.width = `${box.w}px`;
+    el.root.style.height = `${box.h}px`;
+    el.root.style.top = `${lay.stallTop}px`;
+    el.chrome.width = Math.round(box.w * lay.dpr);
+    el.chrome.height = Math.round(box.h * lay.dpr);
+    el.chrome.style.width = `${box.w}px`;
+    el.chrome.style.height = `${box.h}px`;
+    el.cctx = el.chrome.getContext("2d");
+    el.cctx?.setTransform(lay.dpr, 0, 0, lay.dpr, 0, 0);
+
+    el.preview.width = Math.round(box.apertureW * lay.dpr);
+    el.preview.height = Math.round(box.apertureH * lay.dpr);
+    el.preview.style.width = `${box.apertureW}px`;
+    el.preview.style.height = `${box.apertureH}px`;
+    el.preview.style.left = `${box.apertureX}px`;
+    el.preview.style.top = `${box.apertureY}px`;
+    el.pctx = el.preview.getContext("2d");
+    el.pctx?.setTransform(lay.dpr, 0, 0, lay.dpr, 0, 0);
+
+    el.sign.style.left = `${box.w * 0.09}px`;
+    el.sign.style.top = `${box.signY}px`;
+    el.sign.style.width = `${box.w * 0.82}px`;
+    el.sign.style.height = `${box.signH}px`;
+    // Never below 20 px on any device: the numerals are the product.
+    const specPx = Math.max(20, Math.round(box.signH * 0.4));
+    el.spec.style.fontSize = `${specPx}px`;
+    el.name.style.fontSize = `${Math.max(12, Math.round(specPx * 0.62))}px`;
+
+    el.bar.style.left = `${box.w * 0.12}px`;
+    el.bar.style.top = `${box.sillY - 5}px`;
+    el.bar.style.width = `${box.w * 0.76}px`;
+    void f;
+  }
+
+  // ── navigation ─────────────────────────────────────────────────────────
+  function centreOn(f: StallFeature, behavior: ScrollBehavior = "smooth"): void {
+    const target = f.x + f.width / 2 - lay.w / 2;
+    street.scrollTo({ left: Math.max(0, target), behavior: reduced ? "auto" : behavior });
+  }
+
+  function step(delta: number): void {
+    const next = clamp(focusIx + delta, 0, street0.stalls.length - 1);
+    street0.ensure((next + 4) * lay.M * 1.3);
+    syncTrack();
+    const f = street0.stalls[next];
+    if (!f) return;
+    focusIx = next;
+    centreOn(f);
+    const el = pool.get(f.stall.id);
+    el?.root.focus({ preventScroll: true });
+  }
+
+  function enterStall(f: StallFeature): void {
+    if (f.stall.state === "scaffold") return;
+    savedScroll = street.scrollLeft;
+    inStall = true;
+    lamp.setInStall(true);
+    bed.setDuck("mute");
+    entering = 1;
+    street.classList.add("is-entering");
+    if (!reduced) {
+      const box = stallBox(lay);
+      const k = 1 / 0.82;
+      const cx = f.x + f.width / 2 - street.scrollLeft;
+      street.style.transformOrigin = `${cx}px ${box.apertureY + box.apertureH / 2 + lay.stallTop}px`;
+      street.style.transform = `scale(${k})`;
+    }
+    street.style.opacity = "0";
+    opts.onEnter?.(f.stall.id);
+  }
+
+  function leaveStall(): void {
+    inStall = false;
+    lamp.setInStall(false);
+    bed.setDuck("none");
+    entering = 0;
+    street.style.transform = "";
+    street.style.opacity = "";
+    // BZ-08 — losing your place in a bazaar is losing the bazaar.
+    street.scrollLeft = savedScroll;
+    win.setTimeout(() => street.classList.remove("is-entering"), 460);
+  }
+
+  // ── input ──────────────────────────────────────────────────────────────
+  street.addEventListener("scroll", syncTrack, { passive: true });
+
+  street.addEventListener(
+    "wheel",
+    (e: WheelEvent) => {
+      if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+        street.scrollLeft += e.deltaY;
+        e.preventDefault();
+      }
+    },
+    { passive: false },
+  );
+
+  street.addEventListener("keydown", (e: KeyboardEvent) => {
+    switch (e.key) {
+      case "ArrowRight":
+        step(1);
+        e.preventDefault();
+        break;
+      case "ArrowLeft":
+        step(-1);
+        e.preventDefault();
+        break;
+      case "Home":
+      case "End": {
+        const bounds = street0.wardBoundaries();
+        const target =
+          e.key === "Home"
+            ? [...bounds].reverse().find((b) => b < focusIx) ?? 0
+            : bounds.find((b) => b > focusIx) ?? street0.stalls.length - 1;
+        step(target - focusIx);
+        e.preventDefault();
+        break;
+      }
+      default:
+        break;
+    }
+  });
+
+  let downAt: { x: number; y: number; time: number } | null = null;
+  street.addEventListener(
+    "pointerdown",
+    (e: PointerEvent) => {
+      downAt = { x: e.clientX, y: e.clientY, time: now() };
+      bed.start();
+    },
+    { passive: true },
+  );
+  street.addEventListener(
+    "pointerup",
+    (e: PointerEvent) => {
+      if (!downAt) return;
+      const moved = Math.hypot(e.clientX - downAt.x, e.clientY - downAt.y);
+      const rect = root.getBoundingClientRect();
+      if (moved < 8) poke(e.clientX - rect.left, e.clientY - rect.top);
+      downAt = null;
+    },
+    { passive: true },
+  );
+
+  /**
+   * A poke at the world. Everything it does is free and grants nothing
+   * (BZ-LAW-12): dust scatters, the water rings, the cat wakes, a lantern
+   * swings, and the nearest automaton looks up. Once.
+   */
+  function poke(x: number, y: number): void {
+    touch = { x, y, age: 0 };
+    if (y > lay.floorY) ripples.push({ x, age: 0 });
+    if (ripples.length > 4) ripples.shift();
+    if (y < lay.stallTop) lanternKick = 5;
+    catWake = 1;
+    const camX = street.scrollLeft;
+    const f = street0.nearestStall(camX + x);
+    if (f) {
+      const el = pool.get(f.stall.id);
+      if (el) {
+        el.attention = 1;
+        el.look = clamp((camX + x - (f.x + f.width * 0.13)) / (f.width * 0.5), -1, 1);
+      }
+    }
+    if (soundOn && Math.abs(x - lay.w * 0.5) < lay.w) bed.chime((x / lay.w) * 1.4 - 0.7);
+  }
+
+  lighter.addEventListener("click", () => opts.onUpgrade?.());
+
+  valve.addEventListener("click", () => {
+    soundOn = !soundOn;
+    bed.start();
+    bed.setOpen(soundOn);
+    valveHit.textContent = tr(locale, soundOn ? "sound.on" : "sound.off");
+    valve.setAttribute("aria-label", tr(locale, soundOn ? "sound.on" : "sound.off"));
+    valve.setAttribute("aria-pressed", String(soundOn));
+  });
+  valve.setAttribute("aria-label", tr(locale, soundOn ? "sound.on" : "sound.off"));
+  valve.setAttribute("aria-pressed", String(soundOn));
+
+  // The astrolabe: drag the rete, release, and the street flies to that ward.
+  let finderDrag = false;
+  finder.addEventListener("pointerdown", (e: PointerEvent) => {
+    finderDrag = true;
+    finder.setPointerCapture(e.pointerId);
+  });
+  finder.addEventListener("pointermove", (e: PointerEvent) => {
+    if (!finderDrag) return;
+    const r = finder.getBoundingClientRect();
+    finderAngle = Math.atan2(e.clientY - (r.top + r.height / 2), e.clientX - (r.left + r.width / 2));
+  });
+  const releaseFinder = (): void => {
+    if (!finderDrag) return;
+    finderDrag = false;
+    flyToWard();
+  };
+  finder.addEventListener("pointerup", releaseFinder);
+  finder.addEventListener("pointercancel", releaseFinder);
+  finder.addEventListener("keydown", (e: KeyboardEvent) => {
+    if (e.key === "ArrowRight" || e.key === "ArrowUp") {
+      finderAngle += (Math.PI * 2) / 5;
+      flyToWard();
+      e.preventDefault();
+    } else if (e.key === "ArrowLeft" || e.key === "ArrowDown") {
+      finderAngle -= (Math.PI * 2) / 5;
+      flyToWard();
+      e.preventDefault();
+    }
+  });
+
+  function flyToWard(): void {
+    const bounds = street0.wardBoundaries();
+    if (!bounds.length) return;
+    const norm = ((finderAngle % (Math.PI * 2)) + Math.PI * 2) % (Math.PI * 2);
+    const ix = Math.min(bounds.length - 1, Math.floor((norm / (Math.PI * 2)) * bounds.length));
+    const f = street0.stalls[bounds[ix]!];
+    if (!f) return;
+    focusIx = f.index;
+    centreOn(f);
+    finder.setAttribute("aria-valuenow", String(ix));
+    finder.setAttribute("aria-valuemax", String(bounds.length - 1));
+    finder.setAttribute("aria-valuetext", f.quarter.name[locale]);
+  }
+
+  const onResize = (): void => resize();
+  win.addEventListener("resize", onResize);
+  const onVis = (): void => {
+    if (doc.hidden) {
+      bed.suspend();
+      cancelAnimationFrame(raf);
+      raf = 0;
+    } else {
+      bed.resume();
+      last = now();
+      if (!raf && alive) raf = requestAnimationFrame(frame);
+    }
+  };
+  doc.addEventListener("visibilitychange", onVis);
+
+  let mqReduced: MediaQueryList | null = null;
+  try {
+    mqReduced = win.matchMedia("(prefers-reduced-motion: reduce)");
+    mqReduced.addEventListener("change", () => {
+      reduced = prefersReduced();
+    });
+  } catch {
+    /* no matchMedia */
+  }
+
+  // ── the loop ───────────────────────────────────────────────────────────
+  function frame(): void {
+    if (!alive) return;
+    const n = now();
+    const dt = Math.min(0.05, (n - last) / 1000);
+    last = n;
+    const t = (n - t0) / 1000;
+    perf.sample(dt * 1000, n);
+    const budget = perf.budget;
+
+    const reading = lamp.read();
+    lamp.setForcedNight(
+      opts.theme === "night" || (opts.theme !== "light" && prefersDark() && !subscribed ? false : false),
+    );
+    const forcedNight = opts.theme === "night" || (opts.theme === "auto" && prefersDark());
+    lamp.setForcedNight(forcedNight);
+    const r2 = lamp.read();
+    const am: Ambient = ambient(r2.d, r2.night);
+    const sem: Semantic = semanticAt(r2.night);
+    root.classList.toggle("bz-night", r2.night > 0.5);
+
+    if (touch) {
+      touch.age += dt;
+      if (touch.age > 0.7) touch = null;
+    }
+    for (const rp of ripples) rp.age += dt;
+    ripples = ripples.filter((rp) => rp.age < 1.2);
+    lanternKick *= Math.exp(-dt * 2.4);
+    catWake = Math.max(0, catWake - dt * 0.18);
+
+    const camX = street.scrollLeft;
+    street0.ensure(camX + lay.w * 3 + lay.M * 6);
+
+    // Which stall is centred? Only that one animates (BZ-06).
+    const centre = street0.nearestStall(camX + lay.w / 2);
+    director.setLive(centre && !inStall ? centre.stall.id : null);
+    director.beginFrame();
+    bed.setDuck(inStall ? "mute" : centre ? "preview" : "none");
+
+    // ── the visible window ────────────────────────────────────────────────
+    const visible = street0.visible(camX - lay.M * 1.2, camX + lay.w + lay.M * 1.2);
+    const seen = new Set<string>();
+    const reflectors: { x: number; w: number; color: string; lit: boolean }[] = [];
+
+    for (const f of visible) {
+      if (f.kind !== "stall") continue;
+      seen.add(f.stall.id);
+      const el = stallEl(f);
+      sizeStallEl(el, f);
+      const box = stallBox(lay);
+      const dx = f.x + f.width / 2 - (camX + lay.w / 2);
+      const y = reduced ? 0 : curve(dx);
+      el.root.style.transform = `translate3d(${Math.round(f.x)}px, ${y.toFixed(2)}px, 0)`;
+      el.root.style.left = "0";
+
+      const q = f.quarter;
+      const isCentre = centre?.stall.id === f.stall.id;
+      el.root.setAttribute("aria-selected", String(isCentre));
+
+      // The accessible name: the game, the place, and the specimen in words.
+      const spec = f.stall.specimen ?? q.specimen;
+      if (f.stall.state === "scaffold") {
+        el.root.setAttribute("aria-label", tr(locale, "scaffold", { quarter: q.name[locale] }));
+        el.root.setAttribute("aria-disabled", "true");
+        el.sign.style.display = "none";
+      } else {
+        el.root.setAttribute(
+          "aria-label",
+          tr(locale, "stall", { name: f.stall.title, quarter: q.name[locale], specimen: spec.spoken }),
+        );
+        el.root.removeAttribute("aria-disabled");
+        el.sign.style.display = "";
+        if (el.name.textContent !== f.stall.title) el.name.textContent = f.stall.title;
+        if (el.spec.textContent !== spec.display) el.spec.textContent = spec.display;
+      }
+
+      el.attention = Math.max(0, el.attention - dt / 0.42);
+
+      const g = el.cctx;
+      if (g) {
+        g.clearRect(0, 0, box.w, box.h);
+        drawStall(g, {
+          lay,
+          sem,
+          am,
+          quarter: q,
+          state: f.stall.state ?? (f.stall.preview ? "open" : "scaffold"),
+          seed: mixSeed(f.seed, hash(f.stall.id)),
+          accretion: f.stall.accretion ?? 0,
+          t,
+          reduced,
+          look: el.look,
+          attention: el.attention,
+          centred: isCentre ? 1 : 0,
+        });
+        // A shaft of light landing on this stall lifts its whole facade.
+        const sx = f.x - camX + box.w / 2;
+        let nearest = Infinity;
+        for (const s of shaftXs) nearest = Math.min(nearest, Math.abs(s - sx));
+        if (Number.isFinite(nearest)) drawStallLight(g, am, box, nearest);
+      }
+
+      const p = el.pctx;
+      if (p && (f.stall.state ?? "open") === "open") {
+        const drew = director.draw(
+          p,
+          f.stall.id,
+          budget.livePreview ? f.stall.preview : undefined,
+          box.apertureW,
+          box.apertureH,
+          lay.dpr,
+          t,
+          f.seed,
+          reduced,
+        );
+        el.preview.style.visibility = drew ? "visible" : "hidden";
+      } else if (p) {
+        el.preview.style.visibility = "hidden";
+      }
+
+      reflectors.push({
+        x: f.x - camX + box.w * 0.1,
+        w: box.w * 0.8,
+        color: over(WARDS[q.ward].glaze, sem.water, 0.35),
+        lit: am.lanternGain > 0.3,
+      });
+    }
+
+    for (const [id, el] of pool) {
+      if (!seen.has(id)) {
+        el.root.remove();
+        pool.delete(id);
+      }
+    }
+
+    // ── the world behind and in front ────────────────────────────────────
+    backdrop.draw({
+      camX,
+      t,
+      dt,
+      lay,
+      sem,
+      am,
+      street: street0,
+      ward: centre?.quarter.ward ?? "lapis",
+      reduced,
+      budget,
+      seed,
+      touch,
+      ripples,
+      lanternKick,
+      catWake,
+      soundOpen: soundOn,
+      reflectors,
+      onShafts: (xs) => {
+        shaftXs = xs;
+      },
+    });
+
+    // ── the lamp ─────────────────────────────────────────────────────────
+    const lg = lampCv.getContext("2d");
+    if (lg) {
+      lg.setTransform(lay.dpr, 0, 0, lay.dpr, 0, 0);
+      drawLamp(lg, lampCv.width / lay.dpr, lampCv.height / lay.dpr, {
+        sem,
+        am,
+        reading: r2,
+        subscribed,
+        reduced,
+        t,
+      });
+    }
+    const label = tr(locale, r2.label);
+    if (lampLabel.textContent !== label) lampLabel.textContent = label;
+
+    // The single upgrade surface. It never animates to attract attention, and
+    // it is not reachable while a stall is open (BZ-15).
+    const showLighter = lamp.showsLamplighter && !inStall;
+    lighter.style.display = showLighter ? "" : "none";
+    if (showLighter) {
+      const lgc = lighterCv.getContext("2d");
+      if (lgc) {
+        lgc.setTransform(lay.dpr, 0, 0, lay.dpr, 0, 0);
+        drawLamplighter(lgc, lighterCv.width / lay.dpr, lighterCv.height / lay.dpr, sem, am, reduced, t);
+      }
+    }
+
+    const fg = finderCv.getContext("2d");
+    if (fg) {
+      fg.setTransform(lay.dpr, 0, 0, lay.dpr, 0, 0);
+      drawAstrolabe(fg, finderCv.width / lay.dpr, finderAngle, 5, sem, am, finderDrag);
+    }
+
+    raf = requestAnimationFrame(frame);
+    void reading;
+    void entering;
+  }
+
+  resize();
+  // Open on the first stall, so the street already reads as a place.
+  const first = street0.stalls[0];
+  if (first) street.scrollLeft = Math.max(0, first.x + first.width / 2 - lay.w / 2);
+  bed.setOpen(soundOn);
+  raf = requestAnimationFrame(frame);
+
+  return {
+    destroy(): void {
+      alive = false;
+      cancelAnimationFrame(raf);
+      win.removeEventListener("resize", onResize);
+      doc.removeEventListener("visibilitychange", onVis);
+      bed.destroy();
+      director.clear();
+      root.remove();
+    },
+    setStalls(next: StallSpec[]): void {
+      stalls = next.slice();
+      resize();
+    },
+    setDay(remaining: number): void {
+      lamp.setRemaining(remaining);
+    },
+    setSubscribed(v: boolean): void {
+      subscribed = v;
+      lamp.setSubscribed(v);
+    },
+    setInStall(v: boolean): void {
+      if (v === inStall) return;
+      if (v) {
+        const f = street0.nearestStall(street.scrollLeft + lay.w / 2);
+        if (f) enterStall(f);
+      } else {
+        leaveStall();
+      }
+    },
+    goToStall(id: string): void {
+      const f = street0.stallById(id);
+      if (f) {
+        focusIx = f.index;
+        centreOn(f);
+      }
+    },
+    scrollLeft(): number {
+      return street.scrollLeft;
+    },
+    stats() {
+      return {
+        fps: perf.fps,
+        p90: perf.p90,
+        tier: perf.level,
+        liveNodes: root.querySelectorAll("*").length,
+      };
+    },
+  };
+}
+
+export { quarterById };

--- a/dynawalla/bazaar/src/demo/main.ts
+++ b/dynawalla/bazaar/src/demo/main.ts
@@ -1,0 +1,61 @@
+/**
+ * The standalone street: `npm run dev`.
+ *
+ * Ten stub stalls, and past them the scaffolding goes on forever. Query
+ * parameters exist for the screenshot harness only — they are not a product
+ * surface and there is no UI for them:
+ *
+ *   ?day=0.95      day-state
+ *   ?night=1       force the night bazaar
+ *   ?sub=1         subscribed
+ *   ?sound=0       sound valve shut
+ *   ?at=6          open centred on the nth stall
+ */
+
+import { mountBazaar } from "../bazaar.ts";
+import { QUARTERS } from "../world/quarters.ts";
+import { DEMO_PREVIEWS, DEMO_TITLES } from "./previews.ts";
+import type { StallSpec } from "../types.ts";
+import "../tokens/bazaar.css";
+
+const q = new URLSearchParams(location.search);
+const num = (k: string, d: number): number => {
+  const v = q.get(k);
+  return v === null ? d : Number(v);
+};
+
+const stalls: StallSpec[] = QUARTERS.map((quarter, i) => ({
+  id: quarter.id,
+  title: DEMO_TITLES[quarter.id] ?? quarter.id,
+  quarter: quarter.id,
+  preview: DEMO_PREVIEWS[quarter.id],
+  state: "open",
+  accretion: [0.9, 0.2, 0.65, 0.4, 0, 0.3, 0.1, 0.5, 0.75, 0][i] ?? 0,
+}));
+
+const el = document.getElementById("bazaar");
+if (el) {
+  const bazaar = mountBazaar(el, {
+    stalls,
+    dayRemaining: 1 - num("day", 0.12),
+    subscribed: q.get("sub") === "1",
+    sound: q.get("sound") !== "0",
+    theme: q.get("night") === "1" ? "night" : "auto",
+    seed: 0x1453,
+    onEnter: (id) => {
+      // The host owns what happens next; the bazaar owns coming back.
+      console.info("enter", id);
+      setTimeout(() => bazaar.setInStall(false), 1400);
+    },
+    onUpgrade: () => console.info("upgrade sheet"),
+  });
+
+  const at = q.get("at");
+  if (at !== null) {
+    const target = stalls[Number(at) % stalls.length];
+    if (target) requestAnimationFrame(() => bazaar.goToStall(target.id));
+  }
+
+  // The screenshot harness reads these; nothing in the product does.
+  (window as unknown as { bazaar: typeof bazaar }).bazaar = bazaar;
+}

--- a/dynawalla/bazaar/src/demo/previews.ts
+++ b/dynawalla/bazaar/src/demo/previews.ts
@@ -1,0 +1,516 @@
+/**
+ * Ten stub previews — one per quarter — so the bazaar is playable standalone.
+ *
+ * BZ-07 — the preview shows the game being played **correctly**: a ghost hand
+ * solving, at half speed, looping on `period`. Not a title card, not a logo,
+ * not a menu. A child must be able to tell what they would *do* in there
+ * without entering.
+ *
+ * And note what these deliberately are **not**: they are not minaret-punk.
+ * BZ-LAW-1 — the frame never colonises the preview. Ten games look like ten
+ * different games; the place you walk through to reach them is one place. Each
+ * of these owns its own ground, its own palette and its own type. That contrast
+ * *is* the design.
+ *
+ * The real games in `dynawalla/games/*` replace these by implementing the same
+ * `StallPreview` interface. Nothing else about the bazaar changes when they do.
+ */
+
+import type { PreviewFrame, StallPreview } from "../types.ts";
+
+const TAU = Math.PI * 2;
+
+/** The ghost hand: a soft pointer, at half speed, never a cursor arrow. */
+function hand(g: CanvasRenderingContext2D, x: number, y: number, s: number, a = 0.5): void {
+  g.save();
+  g.globalAlpha = a;
+  g.fillStyle = "#ffffff";
+  g.beginPath();
+  g.ellipse(x, y, s * 0.5, s * 0.66, -0.35, 0, TAU);
+  g.fill();
+  g.globalAlpha = a * 0.55;
+  g.beginPath();
+  g.ellipse(x + s * 0.36, y + s * 0.2, s * 0.2, s * 0.42, 0.2, 0, TAU);
+  g.fill();
+  g.restore();
+}
+
+const ease = (u: number): number => u * u * (3 - 2 * u);
+const seg = (t: number, a: number, b: number): number =>
+  Math.max(0, Math.min(1, (t - a) / (b - a)));
+
+function ground(g: CanvasRenderingContext2D, o: PreviewFrame, fill: string): void {
+  g.fillStyle = fill;
+  g.fillRect(0, 0, o.width, o.height);
+}
+
+function label(
+  g: CanvasRenderingContext2D,
+  text: string,
+  x: number,
+  y: number,
+  px: number,
+  color: string,
+  align: CanvasTextAlign = "center",
+): void {
+  g.fillStyle = color;
+  g.font = `600 ${px}px ui-rounded, system-ui, sans-serif`;
+  g.textAlign = align;
+  g.textBaseline = "middle";
+  g.fillText(text, x, y);
+  g.textAlign = "left";
+}
+
+// ── 1. Weighers' Row — a balance you can see settle ────────────────────────
+const weighers: StallPreview = {
+  period: 6,
+  render(g, o) {
+    ground(g, o, "#26303a");
+    const u = o.reducedMotion ? 1 : o.t / this.period;
+    const w = o.width;
+    const h = o.height;
+    const cx = w / 2;
+    const pivot = h * 0.42;
+    const drop = ease(seg(u, 0.15, 0.55));
+    const tilt = (1 - drop) * -0.22;
+
+    g.strokeStyle = "#8fa6b8";
+    g.lineWidth = Math.max(2, w * 0.014);
+    g.beginPath();
+    g.moveTo(cx, pivot);
+    g.lineTo(cx, h * 0.86);
+    g.stroke();
+
+    g.save();
+    g.translate(cx, pivot);
+    g.rotate(tilt);
+    g.strokeStyle = "#d9e6f0";
+    g.beginPath();
+    g.moveTo(-w * 0.32, 0);
+    g.lineTo(w * 0.32, 0);
+    g.stroke();
+    for (const side of [-1, 1]) {
+      g.beginPath();
+      g.moveTo(side * w * 0.32, 0);
+      g.lineTo(side * w * 0.32, h * 0.1);
+      g.stroke();
+      g.fillStyle = "#4d6577";
+      g.fillRect(side * w * 0.32 - w * 0.12, h * 0.1, w * 0.24, h * 0.03);
+    }
+    // Three on the left, four coming down on the right.
+    g.fillStyle = "#f0c04a";
+    for (let i = 0; i < 3; i++) {
+      g.fillRect(-w * 0.32 - w * 0.09 + i * w * 0.062, h * 0.1 - h * 0.075, w * 0.05, h * 0.07);
+    }
+    const placed = Math.min(4, Math.floor(seg(u, 0.15, 0.55) * 5));
+    g.fillStyle = "#7ad0c0";
+    for (let i = 0; i < placed; i++) {
+      g.fillRect(w * 0.32 - w * 0.11 + i * w * 0.055, h * 0.1 - h * 0.075, w * 0.045, h * 0.07);
+    }
+    g.restore();
+
+    label(g, "3 + 4 = 7", cx, h * 0.13, Math.max(13, h * 0.11), "#e7f0f6");
+    if (!o.reducedMotion && u > 0.12 && u < 0.6) {
+      hand(g, cx + w * 0.3, pivot + h * 0.02 - (1 - ease(seg(u, 0.12, 0.5))) * h * 0.22, w * 0.07);
+    }
+  },
+};
+
+// ── 2. Money-changers' Arcade — place value, in coin ───────────────────────
+const money: StallPreview = {
+  period: 7,
+  render(g, o) {
+    ground(g, o, "#f6f1e4");
+    const u = o.reducedMotion ? 1 : o.t / this.period;
+    const w = o.width;
+    const h = o.height;
+    const cols = 3;
+    const names = ["100", "10", "1"];
+    const target = [2, 4, 5];
+    for (let c = 0; c < cols; c++) {
+      const cx = w * (0.22 + c * 0.28);
+      g.strokeStyle = "#c9bda2";
+      g.lineWidth = 2;
+      g.strokeRect(cx - w * 0.1, h * 0.26, w * 0.2, h * 0.52);
+      label(g, names[c]!, cx, h * 0.18, Math.max(11, h * 0.085), "#7a6a4c");
+      const n = Math.floor(ease(seg(u, 0.1 + c * 0.22, 0.42 + c * 0.22)) * target[c]! + 0.001);
+      for (let i = 0; i < n; i++) {
+        const y = h * 0.74 - i * h * 0.075;
+        g.fillStyle = c === 0 ? "#c98a2c" : c === 1 ? "#d8ab3f" : "#ecc861";
+        g.beginPath();
+        g.ellipse(cx, y, w * 0.075, h * 0.032, 0, 0, TAU);
+        g.fill();
+        g.strokeStyle = "#8a5f1d";
+        g.lineWidth = 1;
+        g.stroke();
+      }
+    }
+    label(g, "245", w / 2, h * 0.9, Math.max(15, h * 0.13), "#3a3020");
+    if (!o.reducedMotion && u < 0.9) {
+      const c = Math.min(2, Math.floor(u * 3));
+      hand(g, w * (0.22 + c * 0.28), h * (0.3 + 0.35 * ((u * 3) % 1)), w * 0.07, 0.4);
+    }
+  },
+};
+
+// ── 3. Tilers' Court — an array filling in ─────────────────────────────────
+const tilers: StallPreview = {
+  period: 6,
+  render(g, o) {
+    ground(g, o, "#123b3f");
+    const u = o.reducedMotion ? 1 : o.t / this.period;
+    const w = o.width;
+    const h = o.height;
+    const cols = 12;
+    const rows = 8;
+    const pad = w * 0.08;
+    const cw = (w - pad * 2) / cols;
+    const ch = (h * 0.62) / rows;
+    const filled = Math.floor(ease(seg(u, 0.05, 0.8)) * cols * rows);
+    for (let j = 0; j < rows; j++) {
+      for (let i = 0; i < cols; i++) {
+        const ix = j * cols + i;
+        const x = pad + i * cw;
+        const y = h * 0.24 + j * ch;
+        g.fillStyle = ix < filled ? (ix % 3 === 0 ? "#2fa6a8" : "#e8b93f") : "#0d2b2e";
+        g.fillRect(x + 1, y + 1, cw - 2, ch - 2);
+      }
+    }
+    label(g, `12 × 8 = ${filled >= cols * rows ? 96 : filled}`, w / 2, h * 0.14, Math.max(14, h * 0.11), "#eaf6f2");
+    if (!o.reducedMotion && filled < cols * rows) {
+      const i = filled % cols;
+      const j = Math.floor(filled / cols);
+      hand(g, pad + i * cw + cw / 2, h * 0.24 + j * ch + ch / 2, w * 0.06, 0.45);
+    }
+  },
+};
+
+// ── 4. The Rope-walk — three fifths of forty ───────────────────────────────
+const rope: StallPreview = {
+  period: 7,
+  render(g, o) {
+    ground(g, o, "#efe3cd");
+    const u = o.reducedMotion ? 1 : o.t / this.period;
+    const w = o.width;
+    const h = o.height;
+    const x0 = w * 0.08;
+    const x1 = w * 0.92;
+    const y = h * 0.52;
+    g.strokeStyle = "#9c8659";
+    g.lineWidth = Math.max(8, h * 0.075);
+    g.lineCap = "round";
+    g.beginPath();
+    g.moveTo(x0, y);
+    g.lineTo(x1, y);
+    g.stroke();
+    const parts = 5;
+    const shown = ease(seg(u, 0.1, 0.7)) * 3;
+    for (let i = 0; i < parts; i++) {
+      const a = x0 + ((x1 - x0) * i) / parts;
+      const b = x0 + ((x1 - x0) * (i + 1)) / parts;
+      if (i < Math.floor(shown)) {
+        g.strokeStyle = "#a33a2c";
+        g.beginPath();
+        g.moveTo(a, y);
+        g.lineTo(b, y);
+        g.stroke();
+      }
+      g.strokeStyle = "#4a3220";
+      g.lineWidth = 2;
+      g.beginPath();
+      g.moveTo(b, y - h * 0.11);
+      g.lineTo(b, y + h * 0.11);
+      g.stroke();
+      g.lineWidth = Math.max(8, h * 0.075);
+      label(g, String((i + 1) * 8), (a + b) / 2, y + h * 0.2, Math.max(10, h * 0.075), "#6b5940");
+    }
+    label(g, "⅗ of 40 = 24", w / 2, h * 0.16, Math.max(14, h * 0.11), "#2a2015");
+    if (!o.reducedMotion && shown < 3) hand(g, x0 + ((x1 - x0) * shown) / parts, y - h * 0.16, w * 0.06, 0.4);
+  },
+};
+
+// ── 5. Astrolabists' Gallery — an angle swept and read ─────────────────────
+const astro: StallPreview = {
+  period: 8,
+  render(g, o) {
+    ground(g, o, "#101a3a");
+    const u = o.reducedMotion ? 1 : o.t / this.period;
+    const w = o.width;
+    const h = o.height;
+    const cx = w / 2;
+    const cy = h * 0.62;
+    const r = Math.min(w, h) * 0.36;
+    g.strokeStyle = "#5c8fe8";
+    g.lineWidth = 2;
+    g.beginPath();
+    g.arc(cx, cy, r, 0, TAU);
+    g.stroke();
+    g.strokeStyle = "#2e58b0";
+    g.lineWidth = 1;
+    for (let i = 0; i < 24; i++) {
+      const a = (i / 24) * TAU;
+      g.beginPath();
+      g.moveTo(cx + Math.cos(a) * r, cy + Math.sin(a) * r);
+      g.lineTo(cx + Math.cos(a) * r * (i % 3 === 0 ? 0.84 : 0.92), cy + Math.sin(a) * r * (i % 3 === 0 ? 0.84 : 0.92));
+      g.stroke();
+    }
+    const sweep = ease(seg(u, 0.1, 0.7)) * (TAU / 8);
+    g.fillStyle = "rgba(232,185,63,0.28)";
+    g.beginPath();
+    g.moveTo(cx, cy);
+    g.arc(cx, cy, r * 0.8, -Math.PI / 2, -Math.PI / 2 + sweep);
+    g.closePath();
+    g.fill();
+    g.strokeStyle = "#e8ce79";
+    g.lineWidth = Math.max(2, w * 0.012);
+    g.beginPath();
+    g.moveTo(cx, cy);
+    g.lineTo(cx, cy - r);
+    g.moveTo(cx, cy);
+    g.lineTo(cx + Math.sin(sweep) * r, cy - Math.cos(sweep) * r);
+    g.stroke();
+    label(g, `${Math.round((sweep / TAU) * 360)}°`, cx + r * 0.42, cy - r * 0.5, Math.max(13, h * 0.1), "#f0e2c6");
+    label(g, "360° ÷ 8 = 45°", cx, h * 0.13, Math.max(13, h * 0.1), "#a9c9e6");
+    if (!o.reducedMotion && sweep < TAU / 8 - 0.01) {
+      hand(g, cx + Math.sin(sweep) * r, cy - Math.cos(sweep) * r, w * 0.06, 0.45);
+    }
+  },
+};
+
+// ── 6. The Waterworks — two channels at three to two ───────────────────────
+const water: StallPreview = {
+  period: 6,
+  render(g, o) {
+    ground(g, o, "#dceaf0");
+    const u = o.reducedMotion ? 1 : o.t / this.period;
+    const w = o.width;
+    const h = o.height;
+    const fill = ease(seg(u, 0.08, 0.85));
+    const tanks: [number, number][] = [
+      [0.26, 9],
+      [0.68, 6],
+    ];
+    for (const [fx, cap] of tanks) {
+      const x = w * fx - w * 0.13;
+      const tw = w * 0.26;
+      const ty = h * 0.28;
+      const th = h * 0.54;
+      g.fillStyle = "#ffffff";
+      g.fillRect(x, ty, tw, th);
+      const level = th * (fill * (cap / 9));
+      g.fillStyle = "#2c8fa6";
+      g.fillRect(x, ty + th - level, tw, level);
+      g.fillStyle = "#7fc6d8";
+      g.fillRect(x, ty + th - level, tw, Math.min(4, level));
+      g.strokeStyle = "#1d5b6b";
+      g.lineWidth = 2;
+      g.strokeRect(x, ty, tw, th);
+      for (let i = 1; i < 9; i++) {
+        g.beginPath();
+        g.moveTo(x, ty + (th * i) / 9);
+        g.lineTo(x + tw * 0.18, ty + (th * i) / 9);
+        g.stroke();
+      }
+      label(g, String(Math.round(fill * cap)), x + tw / 2, ty - h * 0.07, Math.max(12, h * 0.09), "#134753");
+    }
+    label(g, "3 : 2", w / 2, h * 0.92, Math.max(14, h * 0.12), "#0d3540");
+  },
+};
+
+// ── 7. Dyers' Lane — two fifths and one fifth ──────────────────────────────
+const dyers: StallPreview = {
+  period: 7,
+  render(g, o) {
+    ground(g, o, "#faf7f0");
+    const u = o.reducedMotion ? 1 : o.t / this.period;
+    const w = o.width;
+    const h = o.height;
+    const bw = w * 0.84;
+    const x0 = w * 0.08;
+    const rows: [number, string, number][] = [
+      [0.3, "#23356b", 2],
+      [0.5, "#a33a2c", 1],
+    ];
+    for (const [fy, col, n] of rows) {
+      const y = h * fy;
+      for (let i = 0; i < 5; i++) {
+        const x = x0 + (bw * i) / 5;
+        g.fillStyle = i < n ? col : "#e8e0d0";
+        g.fillRect(x + 1, y, bw / 5 - 2, h * 0.12);
+      }
+      g.strokeStyle = "#3a3020";
+      g.lineWidth = 1.5;
+      g.strokeRect(x0, y, bw, h * 0.12);
+    }
+    const merged = ease(seg(u, 0.35, 0.85));
+    const y = h * 0.72;
+    for (let i = 0; i < 5; i++) {
+      const x = x0 + (bw * i) / 5;
+      const on = i < 3 * merged;
+      g.fillStyle = on ? (i < 2 ? "#23356b" : "#a33a2c") : "#e8e0d0";
+      g.fillRect(x + 1, y, bw / 5 - 2, h * 0.14);
+    }
+    g.strokeStyle = "#3a3020";
+    g.lineWidth = 1.5;
+    g.strokeRect(x0, y, bw, h * 0.14);
+    label(g, "⅖ + ⅕ = ⅗", w / 2, h * 0.15, Math.max(14, h * 0.11), "#2a2015");
+    if (!o.reducedMotion && merged < 1) hand(g, x0 + bw * 0.5, h * 0.62, w * 0.06, 0.35);
+  },
+};
+
+// ── 8. Kite-makers' Yard — an angle taken off a straight line ──────────────
+const kites: StallPreview = {
+  period: 6,
+  render(g, o) {
+    ground(g, o, "#bcd9ea");
+    const u = o.reducedMotion ? 1 : o.t / this.period;
+    const w = o.width;
+    const h = o.height;
+    const cx = w / 2;
+    const cy = h * 0.7;
+    const r = Math.min(w, h) * 0.34;
+    g.strokeStyle = "#37546b";
+    g.lineWidth = 2;
+    g.beginPath();
+    g.moveTo(cx - r, cy);
+    g.lineTo(cx + r, cy);
+    g.stroke();
+    const a = (55 * Math.PI) / 180 * ease(seg(u, 0.1, 0.7));
+    g.fillStyle = "rgba(163,58,44,0.3)";
+    g.beginPath();
+    g.moveTo(cx, cy);
+    g.arc(cx, cy, r * 0.5, Math.PI, Math.PI + a);
+    g.closePath();
+    g.fill();
+    g.strokeStyle = "#a33a2c";
+    g.lineWidth = Math.max(2, w * 0.012);
+    g.beginPath();
+    g.moveTo(cx, cy);
+    g.lineTo(cx - Math.cos(a) * r, cy + Math.sin(a) * r);
+    g.stroke();
+    // The kite that the angle is the corner of.
+    g.fillStyle = "#e8b93f";
+    g.beginPath();
+    g.moveTo(cx, cy - r * 0.15);
+    g.lineTo(cx + r * 0.42, cy - r * 0.62);
+    g.lineTo(cx, cy - r * 1.25);
+    g.lineTo(cx - r * 0.42, cy - r * 0.62);
+    g.closePath();
+    g.fill();
+    g.strokeStyle = "#7a5a1c";
+    g.lineWidth = 1.5;
+    g.stroke();
+    label(g, `${Math.round(180 - (a * 180) / Math.PI)}°`, cx + r * 0.42, cy - h * 0.05, Math.max(12, h * 0.1), "#16303f");
+    label(g, "180° − 55° = 125°", cx, h * 0.12, Math.max(12, h * 0.095), "#16303f");
+  },
+};
+
+// ── 9. Clockmakers' Terrace — a gear ratio is a fraction ───────────────────
+const clocks: StallPreview = {
+  period: 8,
+  render(g, o) {
+    ground(g, o, "#1a1611");
+    const u = o.reducedMotion ? 0 : o.t;
+    const w = o.width;
+    const h = o.height;
+    const mod = Math.min(w, h) * 0.014;
+    const a = u * 0.55;
+    const pairs: [number, number, number, number][] = [
+      [24, w * 0.34, h * 0.56, a],
+      [18, w * 0.34 + mod * 21, h * 0.56, -a * (24 / 18)],
+    ];
+    for (const [teeth, x, y, ang] of pairs) {
+      const r = (mod * teeth) / 2;
+      g.fillStyle = "#c9a227";
+      g.beginPath();
+      for (let k = 0; k < teeth; k++) {
+        const t0 = ang + (k / teeth) * TAU;
+        const t1 = ang + ((k + 0.5) / teeth) * TAU;
+        g.lineTo(x + r * Math.cos(t0), y + r * Math.sin(t0));
+        g.lineTo(x + r * 1.13 * Math.cos(t1), y + r * 1.13 * Math.sin(t1));
+      }
+      g.closePath();
+      g.fill();
+      g.fillStyle = "#1a1611";
+      g.beginPath();
+      g.arc(x, y, r * 0.28, 0, TAU);
+      g.fill();
+      g.strokeStyle = "#8f6e1e";
+      g.lineWidth = Math.max(2, r * 0.16);
+      g.beginPath();
+      for (let k = 0; k < 5; k++) {
+        const t0 = ang + (k / 5) * TAU;
+        g.moveTo(x + r * 0.28 * Math.cos(t0), y + r * 0.28 * Math.sin(t0));
+        g.lineTo(x + r * 0.8 * Math.cos(t0), y + r * 0.8 * Math.sin(t0));
+      }
+      g.stroke();
+      label(g, String(teeth), x, y + r + h * 0.09, Math.max(11, h * 0.085), "#e8ce79");
+    }
+    label(g, "24 : 18 = 4 : 3", w / 2, h * 0.13, Math.max(13, h * 0.1), "#f0e2c6");
+  },
+};
+
+// ── 10. Millers' Yard — forty-seven into fives, two over ───────────────────
+const millers: StallPreview = {
+  period: 7,
+  render(g, o) {
+    ground(g, o, "#3a2c1e");
+    const u = o.reducedMotion ? 1 : o.t / this.period;
+    const w = o.width;
+    const h = o.height;
+    const total = 47;
+    const per = 5;
+    const done = Math.floor(ease(seg(u, 0.05, 0.85)) * total);
+    const sacks = Math.floor(done / per);
+    const rem = done % per;
+    for (let s = 0; s < 9; s++) {
+      const x = w * (0.12 + (s % 5) * 0.19);
+      const y = h * (0.42 + Math.floor(s / 5) * 0.3);
+      g.fillStyle = s < sacks ? "#e6dcc4" : "#4c3b28";
+      g.beginPath();
+      g.ellipse(x, y, w * 0.062, h * 0.075, 0, 0, TAU);
+      g.fill();
+      if (s < sacks) {
+        g.strokeStyle = "#8a7048";
+        g.lineWidth = 1.5;
+        g.beginPath();
+        g.moveTo(x - w * 0.04, y - h * 0.02);
+        g.lineTo(x + w * 0.04, y - h * 0.02);
+        g.stroke();
+      }
+    }
+    for (let i = 0; i < rem; i++) {
+      g.fillStyle = "#e8b93f";
+      g.beginPath();
+      g.arc(w * 0.5 + (i - 2) * w * 0.045, h * 0.9, w * 0.016, 0, TAU);
+      g.fill();
+    }
+    label(g, `47 ÷ 5 = ${sacks} r ${rem}`, w / 2, h * 0.16, Math.max(13, h * 0.105), "#f2e7d2");
+  },
+};
+
+export const DEMO_PREVIEWS: Record<string, StallPreview> = {
+  weighers,
+  "money-changers": money,
+  tilers,
+  "rope-walk": rope,
+  astrolabists: astro,
+  waterworks: water,
+  dyers,
+  "kite-makers": kites,
+  clockmakers: clocks,
+  millers,
+};
+
+export const DEMO_TITLES: Record<string, string> = {
+  weighers: "Steelyard",
+  "money-changers": "Counting House",
+  tilers: "Tessera",
+  "rope-walk": "Fathom",
+  astrolabists: "Alidade",
+  waterworks: "Qanat",
+  dyers: "Vat",
+  "kite-makers": "Sarband",
+  clockmakers: "Escapement",
+  millers: "Quern",
+};

--- a/dynawalla/bazaar/src/finder/astrolabe.ts
+++ b/dynawalla/bazaar/src/finder/astrolabe.ts
@@ -1,0 +1,131 @@
+/**
+ * The finder is an instrument.
+ *
+ * The astrolabe's **rete** is literally an index of positions, so search here
+ * is not a text field and a results list — it is the instrument used correctly.
+ * Rotate the rete: each star-pointer indexes a ward. The alidade indexes a
+ * quarter within it. Release, and the street flies there on a carpet.
+ *
+ * BZ-LAW-17 — there is no grid view, no "all games", no search box, no filter
+ * chips. A grid of every game is precisely "a list that ended".
+ *
+ * Reachable and operable from the keyboard as a `slider`, with a visible focus
+ * ring, because a power tool nobody can reach is not a power tool.
+ */
+
+import { alpha } from "../util/color.ts";
+import { MATERIALS, type Semantic } from "../tokens/palette.ts";
+import type { Ambient } from "../world/daylight.ts";
+
+const TAU = Math.PI * 2;
+
+export function drawAstrolabe(
+  g: CanvasRenderingContext2D,
+  size: number,
+  angle: number,
+  wards: number,
+  sem: Semantic,
+  am: Ambient,
+  active: boolean,
+): void {
+  const r = size / 2 - 2;
+  const cx = size / 2;
+  const cy = size / 2;
+  g.clearRect(0, 0, size, size);
+
+  // Mater and limb: the body, and the graduated rim it is read against.
+  g.fillStyle = sem.metalShade;
+  g.beginPath();
+  g.arc(cx, cy, r, 0, TAU);
+  g.fill();
+  g.fillStyle = sem.metal;
+  g.beginPath();
+  g.arc(cx, cy, r * 0.92, 0, TAU);
+  g.fill();
+  g.strokeStyle = alpha(sem.cut, 0.8);
+  g.lineWidth = 1;
+  for (let i = 0; i < 36; i++) {
+    const a = (i / 36) * TAU;
+    g.beginPath();
+    g.moveTo(cx + Math.cos(a) * r * 0.92, cy + Math.sin(a) * r * 0.92);
+    g.lineTo(cx + Math.cos(a) * r * (i % 3 === 0 ? 0.8 : 0.86), cy + Math.sin(a) * r * (i % 3 === 0 ? 0.8 : 0.86));
+    g.stroke();
+  }
+
+  // Tympan: the almucantars, the stereographic net you read a position on.
+  g.strokeStyle = alpha(sem.metalShade, 0.85);
+  for (let i = 1; i <= 4; i++) {
+    g.beginPath();
+    g.arc(cx, cy - r * 0.06 * i, r * 0.72 - r * 0.14 * i, 0, TAU);
+    g.stroke();
+  }
+  g.beginPath();
+  g.moveTo(cx - r * 0.8, cy);
+  g.lineTo(cx + r * 0.8, cy);
+  g.moveTo(cx, cy - r * 0.8);
+  g.lineTo(cx, cy + r * 0.8);
+  g.stroke();
+
+  // Rete: the pierced index. One star-pointer per ward.
+  g.save();
+  g.translate(cx, cy);
+  g.rotate(angle);
+  g.strokeStyle = sem.metalLit;
+  g.lineWidth = Math.max(1.5, size * 0.018);
+  g.beginPath();
+  g.arc(0, 0, r * 0.56, 0, TAU);
+  g.stroke();
+  for (let i = 0; i < wards; i++) {
+    const a = (i / wards) * TAU;
+    const px = Math.cos(a) * r * 0.74;
+    const py = Math.sin(a) * r * 0.74;
+    g.beginPath();
+    g.moveTo(Math.cos(a) * r * 0.4, Math.sin(a) * r * 0.4);
+    g.lineTo(px, py);
+    g.stroke();
+    g.fillStyle = MATERIALS["glass-clear"];
+    g.beginPath();
+    for (let k = 0; k < 8; k++) {
+      const sa = a + (k / 8) * TAU;
+      const rr = k % 2 === 0 ? size * 0.05 : size * 0.02;
+      const x = px + Math.cos(sa) * rr;
+      const y = py + Math.sin(sa) * rr;
+      if (k === 0) g.moveTo(x, y);
+      else g.lineTo(x, y);
+    }
+    g.closePath();
+    g.fill();
+  }
+  g.restore();
+
+  // Alidade: the sight bar across the face.
+  g.save();
+  g.translate(cx, cy);
+  g.rotate(angle * 2.4);
+  g.strokeStyle = sem.litEdge;
+  g.lineWidth = Math.max(2, size * 0.025);
+  g.beginPath();
+  g.moveTo(-r * 0.86, 0);
+  g.lineTo(r * 0.86, 0);
+  g.stroke();
+  g.fillStyle = sem.metal;
+  for (const sx of [-r * 0.7, r * 0.7]) {
+    g.fillRect(sx - size * 0.02, -size * 0.05, size * 0.04, size * 0.1);
+  }
+  g.restore();
+
+  // Pin.
+  g.fillStyle = sem.metalShade;
+  g.beginPath();
+  g.arc(cx, cy, size * 0.035, 0, TAU);
+  g.fill();
+
+  if (active) {
+    g.strokeStyle = sem.focus;
+    g.lineWidth = 2;
+    g.beginPath();
+    g.arc(cx, cy, r + 1, 0, TAU);
+    g.stroke();
+  }
+  void am;
+}

--- a/dynawalla/bazaar/src/geometry/arch.ts
+++ b/dynawalla/bazaar/src/geometry/arch.ts
@@ -1,0 +1,59 @@
+/**
+ * Two real two-centred arches. Every arched opening in the bazaar is one of
+ * these; nothing is a rounded rectangle pretending.
+ *
+ *   drop arch          centres ±w/6, R = 2w/3, rise = √15·w/6 ≈ 0.645·w
+ *                      — stall niches, muqarnas cells
+ *   equilateral point  centres ±w/2, R = w,    rise = w√3/2  ≈ 0.866·w
+ *                      — ward gates, dome soffits, caravanserai arcades
+ */
+
+export type ArchKind = "drop" | "equilateral";
+
+export const archRise = (kind: ArchKind, w: number): number =>
+  kind === "drop" ? (Math.sqrt(15) * w) / 6 : (w * Math.sqrt(3)) / 2;
+
+/**
+ * Trace the arch from the left springing point up over the apex to the right
+ * springing point. `y` is the springing line; the arch rises to smaller y.
+ */
+export function archPath(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  y: number,
+  w: number,
+  kind: ArchKind,
+): void {
+  const R = kind === "drop" ? (2 * w) / 3 : w;
+  const c = kind === "drop" ? w / 6 : w / 2;
+  const rise = archRise(kind, w);
+  // The left half is struck from the RIGHT centre, and vice versa — that is
+  // what makes it two-centred rather than a semicircle with a kink.
+  const leftCentre = { x: cx - c, y };
+  const rightCentre = { x: cx + c, y };
+  // Canvas y grows downward, so increasing angle sweeps visually clockwise:
+  // both halves run in increasing angle, up over the apex.
+  const aApex = Math.atan2(-rise, -c);
+  ctx.arc(rightCentre.x, rightCentre.y, R, Math.PI, aApex, false);
+  const bApex = Math.atan2(-rise, c);
+  ctx.arc(leftCentre.x, leftCentre.y, R, bApex, 0, false);
+}
+
+/** A closed niche: springing line, arch, and back down. */
+export function nichePath(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  yBase: number,
+  w: number,
+  h: number,
+  kind: ArchKind,
+): void {
+  const half = w / 2;
+  const spring = yBase - h;
+  ctx.beginPath();
+  ctx.moveTo(cx - half, yBase);
+  ctx.lineTo(cx - half, spring);
+  archPath(ctx, cx, spring, w, kind);
+  ctx.lineTo(cx + half, yBase);
+  ctx.closePath();
+}

--- a/dynawalla/bazaar/src/geometry/gears.ts
+++ b/dynawalla/bazaar/src/geometry/gears.ts
@@ -1,0 +1,142 @@
+/**
+ * BZ-LAW-11 — a gear must be geared.
+ *
+ * Any rotating gear has a visible meshing neighbour, and `ω_b = −ω_a·(N_a/N_b)`
+ * holds for the tooth counts that are actually drawn. This is the single rule
+ * that separates a clockmakers' terrace from glued-on-cog steampunk, and unlike
+ * "taste" it is checkable — `gears.test.ts` asserts it against the rendered
+ * counts.
+ *
+ * It holds by construction here: a follower's angle is *derived* from the
+ * driver's angle, so there is no code path in which a gear can turn at a ratio
+ * its teeth do not support.
+ */
+
+export interface GearSpec {
+  teeth: number;
+  /** Direction, in degrees, from the previous gear's centre to this one. */
+  bearing?: number;
+}
+
+export interface Gear {
+  teeth: number;
+  /** Pitch radius. */
+  r: number;
+  x: number;
+  y: number;
+  /** Rotation in radians at the reference time. */
+  angle: number;
+  /** Angular velocity, radians per second. */
+  omega: number;
+}
+
+export interface TrainOptions {
+  /** Tooth counts, driver first. Each meshes with the one before it. */
+  spec: GearSpec[];
+  /** Pitch diameter per tooth. Every gear in a train shares it — that is what
+   *  makes them able to mesh at all. */
+  module: number;
+  origin: { x: number; y: number };
+  /** Driver angular velocity in rad/s. */
+  omega: number;
+  /** Driver rotation at t = 0. */
+  phase?: number;
+}
+
+const TAU = Math.PI * 2;
+
+/**
+ * Lay out a train and derive every follower from its driver.
+ * `t` is seconds; call it per frame.
+ */
+export function gearTrain(o: TrainOptions, t: number): Gear[] {
+  const out: Gear[] = [];
+  let prev: Gear | null = null;
+  for (let i = 0; i < o.spec.length; i++) {
+    const s = o.spec[i]!;
+    const r = (o.module * s.teeth) / 2;
+    if (!prev) {
+      out.push({
+        teeth: s.teeth,
+        r,
+        x: o.origin.x,
+        y: o.origin.y,
+        angle: (o.phase ?? 0) + o.omega * t,
+        omega: o.omega,
+      });
+      prev = out[0]!;
+      continue;
+    }
+    const bearing = ((s.bearing ?? 0) * Math.PI) / 180;
+    const x = prev.x + (prev.r + r) * Math.cos(bearing);
+    const y = prev.y + (prev.r + r) * Math.sin(bearing);
+    // The meshing relation. Derived, never assigned: this is the law.
+    const ratio = prev.teeth / s.teeth;
+    const angle =
+      bearing + Math.PI - ratio * (prev.angle - bearing) + Math.PI / s.teeth;
+    const g: Gear = { teeth: s.teeth, r, x, y, angle, omega: -prev.omega * ratio };
+    out.push(g);
+    prev = g;
+  }
+  return out;
+}
+
+/** Trace one gear's outline: pitch circle plus real, countable teeth. */
+export function gearPath(ctx: CanvasRenderingContext2D, g: Gear): void {
+  const addendum = g.r * (2.2 / g.teeth);
+  const ro = g.r + addendum;
+  const ri = g.r - addendum * 0.9;
+  const half = TAU / (g.teeth * 4); // tooth is a quarter of the pitch
+  ctx.beginPath();
+  for (let k = 0; k < g.teeth; k++) {
+    const c = g.angle + (TAU * k) / g.teeth;
+    const a0 = c - half * 1.55;
+    const a1 = c - half * 0.85;
+    const a2 = c + half * 0.85;
+    const a3 = c + half * 1.55;
+    if (k === 0) ctx.moveTo(g.x + ri * Math.cos(a0), g.y + ri * Math.sin(a0));
+    else ctx.lineTo(g.x + ri * Math.cos(a0), g.y + ri * Math.sin(a0));
+    ctx.lineTo(g.x + ro * Math.cos(a1), g.y + ro * Math.sin(a1));
+    ctx.lineTo(g.x + ro * Math.cos(a2), g.y + ro * Math.sin(a2));
+    ctx.lineTo(g.x + ri * Math.cos(a3), g.y + ri * Math.sin(a3));
+  }
+  ctx.closePath();
+}
+
+export interface GearStyle {
+  metal: string;
+  metalShade: string;
+  litEdge: string;
+  cut: string;
+}
+
+export function drawGear(ctx: CanvasRenderingContext2D, g: Gear, s: GearStyle): void {
+  gearPath(ctx, g);
+  ctx.fillStyle = s.metal;
+  ctx.fill();
+  ctx.strokeStyle = s.cut;
+  ctx.lineWidth = 1;
+  ctx.stroke();
+
+  // Spokes and hub: what tells you at a glance that it is turning.
+  const spokes = g.teeth >= 18 ? 6 : g.teeth >= 12 ? 4 : 3;
+  ctx.strokeStyle = s.metalShade;
+  ctx.lineWidth = Math.max(1.5, g.r * 0.12);
+  ctx.beginPath();
+  for (let k = 0; k < spokes; k++) {
+    const a = g.angle + (TAU * k) / spokes;
+    ctx.moveTo(g.x + g.r * 0.16 * Math.cos(a), g.y + g.r * 0.16 * Math.sin(a));
+    ctx.lineTo(g.x + g.r * 0.74 * Math.cos(a), g.y + g.r * 0.74 * Math.sin(a));
+  }
+  ctx.stroke();
+
+  ctx.fillStyle = s.metalShade;
+  ctx.beginPath();
+  ctx.arc(g.x, g.y, Math.max(1.5, g.r * 0.18), 0, TAU);
+  ctx.fill();
+  ctx.strokeStyle = s.litEdge;
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.arc(g.x, g.y, Math.max(1.5, g.r * 0.18), Math.PI, TAU);
+  ctx.stroke();
+}

--- a/dynawalla/bazaar/src/geometry/girih.test.ts
+++ b/dynawalla/bazaar/src/geometry/girih.test.ts
@@ -1,0 +1,182 @@
+/**
+ * BZ-04 — the girih gate.
+ *
+ * A pattern that fails this is wallpaper, not girih. For every strap segment
+ * that touches a tile edge, assert
+ *   (a) the touch point is within 0.001·L of the edge midpoint,
+ *   (b) the angle to the edge is 54° ± 0.01°, and
+ *   (c) a partner segment exists in the neighbouring tile at the same point.
+ *
+ * Plus the tiling itself: five equilateral tiles, every edge exactly L, the
+ * bow-tie's derived area, and the 72° rhombic lattice that packs them.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { pic, edgeMidpoints, signedArea, type Polygon, type Pt } from "./pic.ts";
+import { girihTiling, khatemTiling, hexTiling, twelveTiling, CONTACT } from "./tilings.ts";
+
+const L = 60;
+const dist = (a: Pt, b: Pt) => Math.hypot(a.x - b.x, a.y - b.y);
+
+function edgesOf(polys: Polygon[]): { a: Pt; b: Pt; mid: Pt }[] {
+  const out: { a: Pt; b: Pt; mid: Pt }[] = [];
+  for (const p of polys) {
+    for (let i = 0; i < p.length; i++) {
+      const a = p[i]!;
+      const b = p[(i + 1) % p.length]!;
+      out.push({ a, b, mid: { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 } });
+    }
+  }
+  return out;
+}
+
+test("girih: every tile is equilateral at the same edge length", () => {
+  const { polys } = girihTiling(L, 400, 400);
+  assert.ok(polys.length > 8, "the patch should contain real tiles");
+  for (const p of polys) {
+    for (let i = 0; i < p.length; i++) {
+      const d = dist(p[i]!, p[(i + 1) % p.length]!);
+      assert.ok(
+        Math.abs(d - L) < 1e-6,
+        `edge length ${d.toFixed(6)} is not L=${L} (tile of ${p.length} corners)`,
+      );
+    }
+  }
+});
+
+test("girih: the tiling is decagons and bow-ties, and nothing else", () => {
+  const { polys } = girihTiling(L, 400, 400);
+  const kinds = new Set(polys.map((p) => p.length));
+  assert.deepEqual([...kinds].sort((a, b) => a - b), [6, 10]);
+});
+
+test("girih: the bow-tie's area is 1.31432·L², as the packing requires", () => {
+  const { polys } = girihTiling(L, 300, 300);
+  const bow = polys.find((p) => p.length === 6)!;
+  const area = Math.abs(signedArea(bow)) / (L * L);
+  assert.ok(Math.abs(area - 1.314328) < 1e-5, `bow-tie area was ${area}`);
+});
+
+test("girih: the decagon's inradius sets the 72° lattice", () => {
+  const { polys } = girihTiling(L, 400, 400);
+  const decs = polys.filter((p) => p.length === 10);
+  const centres = decs.map((p) => ({
+    x: p.reduce((s, q) => s + q.x, 0) / 10,
+    y: p.reduce((s, q) => s + q.y, 0) / 10,
+  }));
+  const r = L / (2 * Math.tan((18 * Math.PI) / 180));
+  // Every decagon has a neighbour at exactly 2r, and none closer.
+  let found = 0;
+  for (const c of centres) {
+    let nearest = Infinity;
+    for (const d of centres) {
+      if (d === c) continue;
+      nearest = Math.min(nearest, dist(c, d));
+    }
+    if (Number.isFinite(nearest)) {
+      assert.ok(nearest > 2 * r - 1e-6, `decagons overlap: ${nearest} < ${2 * r}`);
+      if (Math.abs(nearest - 2 * r) < 1e-6) found++;
+    }
+  }
+  assert.ok(found > 0, "no edge-sharing decagon pair found");
+});
+
+test("BZ-04: straps spring from edge midpoints at exactly 54°", () => {
+  const { polys } = girihTiling(L, 320, 320);
+  const segs = pic(polys, CONTACT.girih5);
+  assert.ok(segs.length > 40, "expected a real strapwork field");
+  const mids = edgeMidpoints(polys);
+  const edges = edgesOf(polys);
+
+  for (const s of segs) {
+    // (a) the springing point is an edge midpoint
+    const anchor = s.edgeAnchor!;
+    const near = mids.reduce(
+      (best, m) => (dist(m, anchor) < dist(best, anchor) ? m : best),
+      mids[0]!,
+    );
+    assert.ok(
+      dist(near, anchor) < 0.001 * L,
+      `strap springs ${dist(near, anchor).toFixed(4)} from the nearest midpoint`,
+    );
+
+    // (b) the angle to that edge is 54° ± 0.01°
+    const edge = edges.reduce(
+      (best, e) => (dist(e.mid, anchor) < dist(best.mid, anchor) ? e : best),
+      edges[0]!,
+    );
+    const ex = edge.b.x - edge.a.x;
+    const ey = edge.b.y - edge.a.y;
+    const sx = s.b.x - s.a.x;
+    const sy = s.b.y - s.a.y;
+    const cos = (ex * sx + ey * sy) / (Math.hypot(ex, ey) * Math.hypot(sx, sy));
+    const deg = (Math.acos(Math.max(-1, Math.min(1, Math.abs(cos)))) * 180) / Math.PI;
+    assert.ok(
+      Math.abs(deg - 54) < 0.01,
+      `strap meets its edge at ${deg.toFixed(4)}°, not 54°`,
+    );
+  }
+});
+
+test("BZ-04: a partner strap exists across every interior tile boundary", () => {
+  const W = 600;
+  const { polys } = girihTiling(L, W, W);
+  const segs = pic(polys, CONTACT.girih5);
+  // Count how many straps spring from each midpoint. An interior edge is
+  // shared by two tiles and therefore carries four straps (two per tile).
+  const counts = new Map<string, number>();
+  for (const s of segs) {
+    const k = `${s.edgeAnchor!.x.toFixed(3)},${s.edgeAnchor!.y.toFixed(3)}`;
+    counts.set(k, (counts.get(k) ?? 0) + 1);
+  }
+  // Restrict to midpoints well inside the patch, where both tiles exist.
+  const interior = [...counts.entries()].filter(([k]) => {
+    const [x, y] = k.split(",").map(Number) as [number, number];
+    return x > 2.5 * L && x < W - 2.5 * L && y > 2.5 * L && y < W - 2.5 * L;
+  });
+  assert.ok(interior.length > 6, "not enough interior midpoints to test");
+  for (const [k, n] of interior) {
+    assert.equal(n, 4, `midpoint ${k} carries ${n} straps, expected 4`);
+  }
+});
+
+test("the other three folds are edge-to-edge at their own contact angle", () => {
+  for (const [name, tiling, angle] of [
+    ["khatem8", khatemTiling(L, 300, 300), CONTACT.khatem8],
+    ["hex6", hexTiling(L, 300, 300), CONTACT.hex6],
+    ["twelve12", twelveTiling(L, 400, 400), CONTACT.twelve12],
+  ] as const) {
+    for (const p of tiling.polys) {
+      for (let i = 0; i < p.length; i++) {
+        const d = dist(p[i]!, p[(i + 1) % p.length]!);
+        assert.ok(Math.abs(d - L) < 1e-6, `${name}: edge ${d} != ${L}`);
+      }
+    }
+    const segs = pic(tiling.polys, angle);
+    assert.ok(segs.length > 20, `${name}: produced no strapwork`);
+    const edges = edgesOf(tiling.polys);
+    for (const s of segs.slice(0, 200)) {
+      const anchor = s.edgeAnchor!;
+      const edge = edges.reduce(
+        (best, e) => (dist(e.mid, anchor) < dist(best.mid, anchor) ? e : best),
+        edges[0]!,
+      );
+      const ex = edge.b.x - edge.a.x;
+      const ey = edge.b.y - edge.a.y;
+      const sx = s.b.x - s.a.x;
+      const sy = s.b.y - s.a.y;
+      const cos = (ex * sx + ey * sy) / (Math.hypot(ex, ey) * Math.hypot(sx, sy));
+      const deg = (Math.acos(Math.max(-1, Math.min(1, Math.abs(cos)))) * 180) / Math.PI;
+      assert.ok(Math.abs(deg - angle) < 0.01, `${name}: ${deg}° != ${angle}°`);
+    }
+  }
+});
+
+test("the tilings are deterministic on their inputs", () => {
+  const a = girihTiling(L, 200, 200).polys;
+  const b = girihTiling(L, 200, 200).polys;
+  assert.equal(a.length, b.length);
+  assert.deepEqual(a[3], b[3]);
+});

--- a/dynawalla/bazaar/src/geometry/mashrabiya.ts
+++ b/dynawalla/bazaar/src/geometry/mashrabiya.ts
@@ -1,0 +1,168 @@
+/**
+ * Mashrabiya — the turned-wood lattice, in five real variants.
+ *
+ * The historical rule is also the correct UI rule: **smaller openings at the
+ * bottom, larger openings at the top.** In a real screen that is for airflow —
+ * fast air above the head, slow below. Here it means a shut stall is never a
+ * dead black rectangle: you can see the glow of the game through the open top
+ * of the screen and not make out what it is. That is exactly the right amount
+ * of tease.
+ *
+ *   open-area fraction ramps 0.18 at the sill → 0.46 at the lintel
+ *
+ * Variants: hexagonal, `kanaysi` (narrow vertical balusters), `maymoni` (mixed
+ * round and squared balusters in a mesh), `cross` (short round balusters set
+ * diagonal, vertical and horizontal), `sahrigi` (large balusters, wide mesh,
+ * for upper positions).
+ */
+
+import { frand, mix as mixSeed } from "../util/rng.ts";
+import { over } from "../util/color.ts";
+
+export type LatticeVariant = "hexagonal" | "kanaysi" | "maymoni" | "cross" | "sahrigi";
+
+export const LATTICE_VARIANTS: readonly LatticeVariant[] = [
+  "hexagonal",
+  "kanaysi",
+  "maymoni",
+  "cross",
+  "sahrigi",
+];
+
+export interface LatticeOptions {
+  width: number;
+  height: number;
+  variant: LatticeVariant;
+  /** Baluster pitch in px. */
+  pitch: number;
+  wood: string;
+  woodLit: string;
+  woodCut: string;
+  seed: number;
+  dpr?: number;
+}
+
+/**
+ * A shutter panel with the holes punched out, so whatever is behind it glows
+ * through. Returned as its own canvas; the caller composites it.
+ */
+export function latticePanel(o: LatticeOptions): HTMLCanvasElement {
+  const dpr = o.dpr ?? 1;
+  const cv = document.createElement("canvas");
+  cv.width = Math.max(1, Math.round(o.width * dpr));
+  cv.height = Math.max(1, Math.round(o.height * dpr));
+  const ctx = cv.getContext("2d");
+  if (!ctx) return cv;
+  ctx.scale(dpr, dpr);
+
+  // The wood field, with the turning read as vertical bead-and-cove banding.
+  ctx.fillStyle = o.wood;
+  ctx.fillRect(0, 0, o.width, o.height);
+  drawTurning(ctx, o);
+
+  // Punch the openings. Open area ramps 0.18 at the sill to 0.46 at the lintel.
+  ctx.globalCompositeOperation = "destination-out";
+  const p = o.pitch;
+  const cols = Math.ceil(o.width / p) + 1;
+  const rows = Math.ceil(o.height / p) + 1;
+  for (let j = 0; j <= rows; j++) {
+    const cy = j * p + p / 2;
+    const up = 1 - cy / o.height; // 1 at the lintel, 0 at the sill
+    const openFrac = 0.18 + 0.28 * Math.max(0, Math.min(1, up));
+    // radius from the open-area fraction of a cell
+    const r = Math.sqrt((openFrac * p * p) / Math.PI);
+    for (let i = 0; i <= cols; i++) {
+      const stagger = o.variant === "hexagonal" || o.variant === "maymoni" ? (j & 1) * 0.5 : 0;
+      const cx = (i + stagger) * p + p / 2;
+      hole(ctx, cx, cy, r, o.variant, mixSeed(o.seed, j * 97 + i));
+    }
+  }
+  ctx.globalCompositeOperation = "source-over";
+
+  // A lit edge along the top of every course of wood: the screen is turned,
+  // and the light lands on the shoulders.
+  ctx.strokeStyle = over(o.wood, o.woodLit, 0.5);
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  for (let j = 0; j <= rows; j++) {
+    const y = j * p + 0.5;
+    ctx.moveTo(0, y);
+    ctx.lineTo(o.width, y);
+  }
+  ctx.stroke();
+  return cv;
+}
+
+function hole(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  r: number,
+  variant: LatticeVariant,
+  seed: number,
+): void {
+  ctx.beginPath();
+  switch (variant) {
+    case "hexagonal": {
+      for (let k = 0; k < 6; k++) {
+        const a = (k * 60 + 30) * (Math.PI / 180);
+        const x = cx + r * 1.12 * Math.cos(a);
+        const y = cy + r * 1.12 * Math.sin(a);
+        if (k === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.closePath();
+      break;
+    }
+    case "kanaysi": {
+      // Narrow vertical slots between the balusters.
+      ctx.rect(cx - r * 0.62, cy - r * 1.5, r * 1.24, r * 3);
+      break;
+    }
+    case "maymoni": {
+      // Round and squared alternating, which is what "mixed" means here.
+      if (frand(seed) < 0.5) ctx.arc(cx, cy, r, 0, Math.PI * 2);
+      else ctx.rect(cx - r * 0.86, cy - r * 0.86, r * 1.72, r * 1.72);
+      break;
+    }
+    case "cross": {
+      // A quatrefoil of short balusters set diagonal, vertical, horizontal.
+      const a = r * 0.62;
+      ctx.rect(cx - a, cy - a * 2.2, a * 2, a * 4.4);
+      ctx.rect(cx - a * 2.2, cy - a, a * 4.4, a * 2);
+      break;
+    }
+    case "sahrigi": {
+      // Large balusters, wide mesh — an upper-storey screen.
+      ctx.arc(cx, cy, r * 1.22, 0, Math.PI * 2);
+      break;
+    }
+  }
+  ctx.fill();
+}
+
+/**
+ * The turned profile of a baluster: a stack of five primitives — bead, fillet,
+ * cove, ovolo, shaft — chosen by seed, 4 to 7 tall. Drawn as banding across the
+ * wood field so the screen reads as turned rather than as a punched sheet.
+ */
+function drawTurning(ctx: CanvasRenderingContext2D, o: LatticeOptions): void {
+  const p = o.pitch;
+  const cols = Math.ceil(o.width / p) + 1;
+  for (let i = 0; i <= cols; i++) {
+    const s = mixSeed(o.seed, i * 31);
+    const n = 4 + Math.floor(frand(s) * 4);
+    const x = i * p;
+    for (let k = 0; k < n; k++) {
+      const t = k / n;
+      const kind = Math.floor(frand(mixSeed(s, k)) * 5);
+      const y = t * o.height;
+      const hgt = o.height / n;
+      const inset = [0.08, 0.02, 0.16, 0.1, 0.05][kind]! * p;
+      ctx.fillStyle = kind === 2 || kind === 4 ? o.woodCut : o.woodLit;
+      ctx.globalAlpha = 0.24;
+      ctx.fillRect(x + inset, y, p - inset * 2, Math.max(1, hgt * 0.34));
+      ctx.globalAlpha = 1;
+    }
+  }
+}

--- a/dynawalla/bazaar/src/geometry/muqarnas.ts
+++ b/dynawalla/bazaar/src/geometry/muqarnas.ts
@@ -1,0 +1,146 @@
+/**
+ * Muqarnas — as structure, not as decoration.
+ *
+ * The corbelled honeycomb that carries a lintel. Tiers of simple prismatic
+ * cells, each tier stepping forward and down over the one above, offset by half
+ * a cell so the cells sit in the valleys of the tier above. That offset is the
+ * honeycomb read; without it this is a row of arches.
+ *
+ *   3 tiers = a stall hood     5 = a ward gate     7 = a caravanserai soffit
+ *   cells(t) = k0 + t·Δ        Δ = 2 (five-fold register) or 3 (six-fold)
+ *
+ * Shading is three FLAT facets per cell. A gradient anywhere in a muqarnas is
+ * the exact thing that turns carved stone into an AI "ancient" texture, so
+ * there are none: sunlight composited on the face, nothing on the cheek,
+ * skylight composited on the soffit.
+ */
+
+import { archPath } from "./arch.ts";
+import { over } from "../util/color.ts";
+
+export interface MuqarnasOptions {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  tiers: number;
+  /** 2 for the five-fold register, 3 for the six-fold. */
+  delta?: number;
+  /** Cells in the topmost tier. */
+  k0?: number;
+  ground: string;
+  sun: string;
+  sunAlpha: number;
+  shadow: string;
+  shadowAlpha: number;
+  litEdge: string;
+  cut: string;
+}
+
+export function drawMuqarnas(ctx: CanvasRenderingContext2D, o: MuqarnasOptions): void {
+  const tiers = Math.max(1, Math.round(o.tiers));
+  const delta = o.delta ?? 2;
+  const k0 = o.k0 ?? 3;
+  const h = o.height / tiers;
+
+  const face = over(o.ground, o.sun, o.sunAlpha * 1.6);
+  const cheek = o.ground;
+  // A recess in warm stone under warm light is not a grey hole: shade it with
+  // transmitted skylight, then let a little of the bounce back into it.
+  const soffit = over(over(o.ground, o.shadow, o.shadowAlpha * 1.25), o.sun, o.sunAlpha * 0.4);
+
+  for (let t = 0; t < tiers; t++) {
+    const cells = k0 + t * delta;
+    const cw = o.width / cells;
+    const yTop = o.y + t * h;
+    const yBot = yTop + h;
+    // Alternate tiers by half a cell: the cells sit in the valleys above.
+    const off = t % 2 === 1 ? -cw / 2 : 0;
+
+    for (let i = -1; i <= cells; i++) {
+      const cx = o.x + (i + 0.5) * cw + off;
+      if (cx + cw / 2 < o.x - 1 || cx - cw / 2 > o.x + o.width + 1) continue;
+
+      const half = cw / 2;
+      // Cheek: the side walls of the cell, the unmodified stone.
+      ctx.fillStyle = cheek;
+      ctx.fillRect(cx - half, yTop, cw, h);
+
+      // Soffit: the niche, cut back under the tier above.
+      const nw = cw * 0.7;
+      ctx.fillStyle = soffit;
+      ctx.beginPath();
+      ctx.moveTo(cx - nw / 2, yBot);
+      ctx.lineTo(cx - nw / 2, yTop + h * 0.42);
+      archPath(ctx, cx, yTop + h * 0.42, nw, "drop");
+      ctx.lineTo(cx + nw / 2, yBot);
+      ctx.closePath();
+      ctx.fill();
+      // The arris at the head of the niche catches the light. One hairline on
+      // the arch alone — a stroke all the way round would outline a lozenge
+      // instead of lighting an edge.
+      ctx.strokeStyle = o.litEdge;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(cx - nw / 2, yTop + h * 0.42);
+      archPath(ctx, cx, yTop + h * 0.42, nw, "drop");
+      ctx.stroke();
+
+      // Face: the corbel that projects at you and catches the sun. A trapezoid
+      // narrower at the top, per the cell profile.
+      ctx.fillStyle = face;
+      ctx.beginPath();
+      ctx.moveTo(cx - half, yBot);
+      ctx.lineTo(cx - half * 0.55, yBot - h * 0.48);
+      ctx.lineTo(cx + half * 0.55, yBot - h * 0.48);
+      ctx.lineTo(cx + half, yBot);
+      ctx.closePath();
+      ctx.fill();
+
+      // One lit edge on the sun side, one cut line on the shade side. Two
+      // hairlines, no blur — that is the whole of the relief.
+      ctx.strokeStyle = o.litEdge;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(cx - half, yBot);
+      ctx.lineTo(cx - half * 0.55, yBot - h * 0.48);
+      ctx.lineTo(cx + half * 0.55, yBot - h * 0.48);
+      ctx.stroke();
+
+      ctx.strokeStyle = o.cut;
+      ctx.beginPath();
+      ctx.moveTo(cx + half * 0.55, yBot - h * 0.48);
+      ctx.lineTo(cx + half, yBot);
+      ctx.stroke();
+    }
+  }
+
+  // A course line under each tier: corbelled stone is laid in courses, and
+  // the line is what tells you the tier above projects over the one below.
+  ctx.strokeStyle = o.cut;
+  ctx.lineWidth = 1;
+  ctx.globalAlpha = 0.5;
+  ctx.beginPath();
+  for (let t = 1; t < tiers; t++) {
+    const y = Math.round(o.y + t * h) + 0.5;
+    ctx.moveTo(o.x, y);
+    ctx.lineTo(o.x + o.width, y);
+  }
+  ctx.stroke();
+  ctx.globalAlpha = 1;
+
+  // The lintel line the whole hood is holding up.
+  ctx.strokeStyle = o.cut;
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(o.x, o.y + o.height + 0.5);
+  ctx.lineTo(o.x + o.width, o.y + o.height + 0.5);
+  ctx.stroke();
+}
+
+/** Node cost, for the budget in §9.1. */
+export const muqarnasCells = (tiers: number, k0 = 3, delta = 2): number => {
+  let n = 0;
+  for (let t = 0; t < tiers; t++) n += k0 + t * delta;
+  return n;
+};

--- a/dynawalla/bazaar/src/geometry/pattern.ts
+++ b/dynawalla/bazaar/src/geometry/pattern.ts
@@ -1,0 +1,202 @@
+/**
+ * Strapwork panels — girih, khatem, six- and twelve-fold — rendered from the
+ * construction, not from an image.
+ *
+ * Three levels of detail, matching the historical self-similar subdivision at
+ * Darb-i Imam where large girih tiles decompose into smaller copies of the
+ * same five:
+ *
+ *   tile edge ≥ 48 px   full strapwork, ribbon width b, interlaced
+ *   tile edge 12–48 px  centrelines only, 1.5 px, no interlace
+ *   tile edge < 12 px   a flat glaze fill and the ward colour; no pattern
+ *
+ * A panel is rasterised once into an offscreen canvas and blitted thereafter;
+ * nothing here runs per frame.
+ */
+
+import { pic, type Segment } from "./pic.ts";
+import { CONTACT, tilingFor, type Fold } from "./tilings.ts";
+import { alpha } from "../util/color.ts";
+
+export type Lod = "full" | "centreline" | "flat";
+
+export function lodFor(tileEdgePx: number): Lod {
+  if (tileEdgePx >= 48) return "full";
+  if (tileEdgePx >= 12) return "centreline";
+  return "flat";
+}
+
+export interface PanelOptions {
+  width: number;
+  height: number;
+  fold: Fold;
+  /** Tile edge length in px. Drives both the density and the LOD. */
+  edge: number;
+  /** The ground the pattern is cut into. */
+  ground: string;
+  /** The strap metal. */
+  strap: string;
+  /** The glaze filling the large tiles. */
+  glaze: string;
+  /** The deeper glaze, for the small tiles. */
+  glazeDeep: string;
+  /** Where the sky shows through — set for a canopy screen. */
+  pierce?: string;
+  /** Leave the ground transparent, so whatever is behind shows through. */
+  transparent?: boolean;
+  lod?: Lod;
+  /** device pixel ratio to rasterise at */
+  dpr?: number;
+}
+
+/** A cache so a ward's panel is constructed once per size, not per frame. */
+const panelCache = new Map<string, HTMLCanvasElement>();
+const MAX_PANELS = 28;
+
+export function patternPanel(o: PanelOptions): HTMLCanvasElement {
+  const dpr = o.dpr ?? 1;
+  const lod = o.lod ?? lodFor(o.edge);
+  const key = [
+    o.fold,
+    Math.round(o.width),
+    Math.round(o.height),
+    Math.round(o.edge),
+    o.ground,
+    o.strap,
+    o.glaze,
+    o.glazeDeep,
+    o.pierce ?? "-",
+    o.transparent ? "T" : "-",
+    lod,
+    dpr,
+  ].join("|");
+  const hit = panelCache.get(key);
+  if (hit) return hit;
+
+  const cv = document.createElement("canvas");
+  cv.width = Math.max(1, Math.round(o.width * dpr));
+  cv.height = Math.max(1, Math.round(o.height * dpr));
+  const ctx = cv.getContext("2d");
+  if (ctx) {
+    ctx.scale(dpr, dpr);
+    drawPattern(ctx, o, lod);
+  }
+
+  if (panelCache.size >= MAX_PANELS) {
+    const oldest = panelCache.keys().next().value;
+    if (oldest !== undefined) panelCache.delete(oldest);
+  }
+  panelCache.set(key, cv);
+  return cv;
+}
+
+export function clearPanelCache(): void {
+  panelCache.clear();
+}
+
+function drawPattern(ctx: CanvasRenderingContext2D, o: PanelOptions, lod: Lod): void {
+  const { width: w, height: h, fold, edge: L } = o;
+  if (!o.transparent) {
+    ctx.fillStyle = o.pierce ?? o.ground;
+    ctx.fillRect(0, 0, w, h);
+  }
+
+  if (fold === "lattice") return; // mashrabiya has its own construction
+
+  if (lod === "flat") {
+    if (o.transparent) return;
+    ctx.fillStyle = o.glaze;
+    ctx.fillRect(0, 0, w, h);
+    return;
+  }
+
+  const tiling = tilingFor(fold, L, w, h);
+
+  // Fill the large tiles with glaze so the panel carries colour, exactly as a
+  // glazed panel does. Small tiles take the deeper glaze.
+  if (lod === "full" && !o.transparent) {
+    for (const poly of tiling.polys) {
+      if (poly.length < 3) continue;
+      ctx.beginPath();
+      ctx.moveTo(poly[0]!.x, poly[0]!.y);
+      for (let i = 1; i < poly.length; i++) ctx.lineTo(poly[i]!.x, poly[i]!.y);
+      ctx.closePath();
+      ctx.fillStyle = poly.length >= 8 ? o.glaze : o.glazeDeep;
+      ctx.globalAlpha = o.pierce ? 0.9 : 0.42;
+      ctx.fill();
+    }
+    ctx.globalAlpha = 1;
+  }
+
+  const segs = pic(tiling.polys, CONTACT[fold]);
+
+  if (lod === "centreline") {
+    ctx.strokeStyle = o.strap;
+    ctx.lineWidth = 1.5;
+    ctx.lineCap = "round";
+    ctx.beginPath();
+    for (const s of segs) {
+      ctx.moveTo(s.a.x, s.a.y);
+      ctx.lineTo(s.b.x, s.b.y);
+    }
+    ctx.stroke();
+    return;
+  }
+
+  // Full strapwork. Ribbon width b = L/9 for the 5-fold family; the 8-fold
+  // craft cuts a slightly heavier strap.
+  const b = fold === "khatem8" ? L / 8 : L / 9;
+  const casing = b + 2;
+
+  // Interlace: two passes in a checkerboard order, so at every crossing one
+  // ribbon reads as passing over and the other under. The under-ribbon is cut
+  // by the casing stroke, not darkened by a shadow.
+  const groups: Segment[][] = [[], []];
+  for (const s of segs) {
+    const k =
+      (Math.round(s.a.x / L) + Math.round(s.a.y / L) + Math.round(s.b.x / L)) & 1;
+    groups[k]!.push(s);
+  }
+
+  ctx.lineCap = "butt";
+  ctx.lineJoin = "miter";
+  for (const g of groups) {
+    if (!o.transparent) {
+      ctx.strokeStyle = o.pierce ?? o.ground;
+      ctx.lineWidth = casing;
+      ctx.beginPath();
+      for (const s of g) {
+        ctx.moveTo(s.a.x, s.a.y);
+        ctx.lineTo(s.b.x, s.b.y);
+      }
+      ctx.stroke();
+    }
+
+    ctx.strokeStyle = o.strap;
+    ctx.lineWidth = b;
+    ctx.beginPath();
+    for (const s of g) {
+      ctx.moveTo(s.a.x, s.a.y);
+      ctx.lineTo(s.b.x, s.b.y);
+    }
+    ctx.stroke();
+  }
+
+  if (o.transparent) return;
+
+  // A single hairline of the cut colour along the strap edge reads as the
+  // depth of the incision. One pass, no blur.
+  ctx.strokeStyle = alpha(o.glazeDeep, 0.5);
+  ctx.lineWidth = 0.75;
+  ctx.beginPath();
+  for (const s of segs) {
+    const dx = s.b.x - s.a.x;
+    const dy = s.b.y - s.a.y;
+    const l = Math.hypot(dx, dy) || 1;
+    const nx = (-dy / l) * (b / 2);
+    const ny = (dx / l) * (b / 2);
+    ctx.moveTo(s.a.x + nx, s.a.y + ny);
+    ctx.lineTo(s.b.x + nx, s.b.y + ny);
+  }
+  ctx.stroke();
+}

--- a/dynawalla/bazaar/src/geometry/pic.ts
+++ b/dynawalla/bazaar/src/geometry/pic.ts
@@ -1,0 +1,205 @@
+/**
+ * Hankin's polygons-in-contact — one engine, three visual languages.
+ *
+ *   1. Tile the plane edge-to-edge with polygons of equal edge length.
+ *   2. At the MIDPOINT of every edge, emit two rays into the tile at the
+ *      contact angle to that edge.
+ *   3. Propagate each ray until it meets another; the two terminate against
+ *      each other in a mitre.
+ *   4. The union of all segments is the pattern. Delete the tile outlines —
+ *      they were scaffolding, exactly as they were for the craftsmen.
+ *
+ * Because every tile shares the same edge length and the same contact angle,
+ * straps always meet across tile boundaries. That is the whole trick, and it
+ * is why this is construction rather than wallpaper.
+ *
+ *   contactAngle 54° → the 5-fold girih family
+ *   contactAngle 45° → the 8-fold khatem family
+ *   contactAngle 60° → the 6- and 12-fold families
+ */
+
+export type Pt = { x: number; y: number };
+export type Polygon = Pt[];
+export interface Segment {
+  a: Pt;
+  b: Pt;
+  /** Where this segment touches a tile edge, if it does. Used by the gate. */
+  edgeAnchor?: Pt;
+  /** Angle in degrees between the segment and the edge it springs from. */
+  edgeAngle?: number;
+}
+
+const EPS = 1e-7;
+
+export const dist = (a: Pt, b: Pt): number => Math.hypot(a.x - b.x, a.y - b.y);
+
+interface Ray {
+  o: Pt; // origin, an edge midpoint
+  d: Pt; // unit direction, pointing into the tile
+  edgeAngle: number; // degrees to the edge, signed positive
+}
+
+function polygonCentroid(p: Polygon): Pt {
+  let x = 0;
+  let y = 0;
+  for (const q of p) {
+    x += q.x;
+    y += q.y;
+  }
+  return { x: x / p.length, y: y / p.length };
+}
+
+/** Intersection parameter of two rays, or null if they diverge. */
+function raysMeet(a: Ray, b: Ray): { t: number; s: number; p: Pt } | null {
+  const det = a.d.x * -b.d.y - a.d.y * -b.d.x;
+  if (Math.abs(det) < EPS) return null;
+  const rx = b.o.x - a.o.x;
+  const ry = b.o.y - a.o.y;
+  const t = (rx * -b.d.y - ry * -b.d.x) / det;
+  const s = (a.d.x * ry - a.d.y * rx) / det;
+  if (t <= EPS || s <= EPS) return null;
+  return { t, s, p: { x: a.o.x + a.d.x * t, y: a.o.y + a.d.y * t } };
+}
+
+/**
+ * Rays for one polygon: two per edge, at ±contactAngle to the edge, both
+ * leaning into the tile.
+ */
+function raysFor(poly: Polygon, contactAngle: number): Ray[] {
+  const c = polygonCentroid(poly);
+  const rad = (contactAngle * Math.PI) / 180;
+  const out: Ray[] = [];
+  for (let i = 0; i < poly.length; i++) {
+    const p0 = poly[i]!;
+    const p1 = poly[(i + 1) % poly.length]!;
+    const mid = { x: (p0.x + p1.x) / 2, y: (p0.y + p1.y) / 2 };
+    const ex = p1.x - p0.x;
+    const ey = p1.y - p0.y;
+    const el = Math.hypot(ex, ey);
+    if (el < EPS) continue;
+    const ux = ex / el;
+    const uy = ey / el;
+    // Inward normal: pick the perpendicular that points at the centroid.
+    let nx = -uy;
+    let ny = ux;
+    if (nx * (c.x - mid.x) + ny * (c.y - mid.y) < 0) {
+      nx = -nx;
+      ny = -ny;
+    }
+    // A ray at `contactAngle` to the edge is cos(a) along the edge and
+    // sin(a) along the inward normal.
+    const ca = Math.cos(rad);
+    const sa = Math.sin(rad);
+    out.push({
+      o: mid,
+      d: { x: ux * ca + nx * sa, y: uy * ca + ny * sa },
+      edgeAngle: contactAngle,
+    });
+    out.push({
+      o: mid,
+      d: { x: -ux * ca + nx * sa, y: -uy * ca + ny * sa },
+      edgeAngle: contactAngle,
+    });
+  }
+  return out;
+}
+
+/**
+ * The pattern for one tiling. Each returned pair of segments is a strap
+ * running from one edge midpoint, through the mitre, to another.
+ */
+export function pic(tiling: Polygon[], contactAngle: number): Segment[] {
+  const segments: Segment[] = [];
+  for (const poly of tiling) {
+    const rays = raysFor(poly, contactAngle);
+    const n = rays.length;
+    // Nearest-meeting candidates, greedily matched shortest-first. Where three
+    // or more rays converge this resolves pairs in order of shortest path,
+    // which is what the craftsmen's mitres do.
+    const cands: { i: number; j: number; t: number; s: number; p: Pt }[] = [];
+    for (let i = 0; i < n; i++) {
+      for (let j = i + 1; j < n; j++) {
+        const a = rays[i]!;
+        const b = rays[j]!;
+        if (dist(a.o, b.o) < EPS) continue; // siblings off one midpoint
+        const hit = raysMeet(a, b);
+        if (!hit) continue;
+        cands.push({ i, j, t: hit.t, s: hit.s, p: hit.p });
+      }
+    }
+    cands.sort((p, q) => Math.max(p.t, p.s) - Math.max(q.t, q.s));
+    const used = new Array<boolean>(n).fill(false);
+    for (const c of cands) {
+      if (used[c.i] || used[c.j]) continue;
+      used[c.i] = true;
+      used[c.j] = true;
+      const a = rays[c.i]!;
+      const b = rays[c.j]!;
+      segments.push({
+        a: { ...a.o },
+        b: { ...c.p },
+        edgeAnchor: { ...a.o },
+        edgeAngle: a.edgeAngle,
+      });
+      segments.push({
+        a: { ...b.o },
+        b: { ...c.p },
+        edgeAnchor: { ...b.o },
+        edgeAngle: b.edgeAngle,
+      });
+    }
+  }
+  return segments;
+}
+
+/** Every edge midpoint of a tiling, deduplicated. Used by the gate. */
+export function edgeMidpoints(tiling: Polygon[]): Pt[] {
+  const seen = new Map<string, Pt>();
+  for (const poly of tiling) {
+    for (let i = 0; i < poly.length; i++) {
+      const p0 = poly[i]!;
+      const p1 = poly[(i + 1) % poly.length]!;
+      const mid = { x: (p0.x + p1.x) / 2, y: (p0.y + p1.y) / 2 };
+      seen.set(`${mid.x.toFixed(4)},${mid.y.toFixed(4)}`, mid);
+    }
+  }
+  return [...seen.values()];
+}
+
+/** Transform helpers used by the tiling builders. */
+export const rotate = (p: Pt, deg: number): Pt => {
+  const r = (deg * Math.PI) / 180;
+  const c = Math.cos(r);
+  const s = Math.sin(r);
+  return { x: p.x * c - p.y * s, y: p.x * s + p.y * c };
+};
+
+export const translate = (p: Pt, dx: number, dy: number): Pt => ({
+  x: p.x + dx,
+  y: p.y + dy,
+});
+
+export const scalePoly = (poly: Polygon, k: number): Polygon =>
+  poly.map((p) => ({ x: p.x * k, y: p.y * k }));
+
+/** A regular n-gon of edge length `L`, centred at `c`, first vertex at `phase`. */
+export function regular(n: number, L: number, c: Pt = { x: 0, y: 0 }, phase = 0): Polygon {
+  const R = L / (2 * Math.sin(Math.PI / n));
+  const out: Polygon = [];
+  for (let i = 0; i < n; i++) {
+    const a = ((phase + (360 / n) * i) * Math.PI) / 180;
+    out.push({ x: c.x + R * Math.cos(a), y: c.y + R * Math.sin(a) });
+  }
+  return out;
+}
+
+/** Signed area; positive is counter-clockwise in a y-down canvas frame. */
+export function signedArea(poly: Polygon): number {
+  let s = 0;
+  for (let i = 0; i < poly.length; i++) {
+    const a = poly[i]!;
+    const b = poly[(i + 1) % poly.length]!;
+    s += a.x * b.y - b.x * a.y;
+  }
+  return s / 2;
+}

--- a/dynawalla/bazaar/src/geometry/tilings.ts
+++ b/dynawalla/bazaar/src/geometry/tilings.ts
@@ -1,0 +1,177 @@
+/**
+ * The tilings the pattern engine runs over.
+ *
+ * Four folds, each a real edge-to-edge tiling of equal-edge-length polygons —
+ * which is the precondition Hankin's construction needs in order for straps to
+ * meet across every tile boundary.
+ *
+ *   girih5   decagon (tabl) + bow-tie (sormeh dan), on a 72° rhombic lattice.
+ *            Contact 54°. The Isfahan / Topkapı family.
+ *   khatem8  truncated square: octagons + squares. Contact 45°. The zellij
+ *            eight-point star (khatem) family.
+ *   hex6     regular hexagons. Contact 60°.
+ *   twelve12 4.6.12: dodecagons + hexagons + squares. Contact 60°.
+ *
+ * The girih lattice is derived, not copied: with the decagon inradius
+ * r = L/(2·tan18°), lattice vectors 2r∠0° and 2r∠72° pack decagons edge-to-edge
+ * and leave exactly one gap per cell whose area is 1.3143·L² — the bow-tie's
+ * area to five decimal places. The six gap corners are decagon vertices and
+ * every gap edge is exactly L. `girih.test.ts` re-proves all of that.
+ */
+
+import { regular, type Polygon, type Pt } from "./pic.ts";
+
+export type Fold = "girih5" | "khatem8" | "hex6" | "twelve12" | "lattice";
+
+/** Contact angle in degrees for each PIC-driven fold. */
+export const CONTACT: Record<Exclude<Fold, "lattice">, number> = {
+  girih5: 54,
+  khatem8: 45,
+  hex6: 60,
+  twelve12: 60,
+};
+
+export interface Tiling {
+  polys: Polygon[];
+  /** Lattice period, for the callers that can tile a canvas pattern. */
+  period: { x: number; y: number } | null;
+}
+
+const D2R = Math.PI / 180;
+
+function ngonAt(n: number, L: number, c: Pt, phaseDeg: number): Polygon {
+  return regular(n, L, c, phaseDeg);
+}
+
+// ── girih5: decagon + bow-tie ──────────────────────────────────────────────
+
+const DEC_R = (L: number) => L / (2 * Math.sin(18 * D2R)); // circumradius
+const DEC_r = (L: number) => L / (2 * Math.tan(18 * D2R)); // inradius
+
+/** Vertex k of the decagon at centre `c`; k = 0 is at 18°. */
+function decVertex(c: Pt, L: number, k: number): Pt {
+  const a = (18 + 36 * k) * D2R;
+  const R = DEC_R(L);
+  return { x: c.x + R * Math.cos(a), y: c.y + R * Math.sin(a) };
+}
+
+export function girihTiling(L: number, w: number, h: number): Tiling {
+  const twoR = 2 * DEC_r(L);
+  const a1 = { x: twoR, y: 0 };
+  const a2 = { x: twoR * Math.cos(72 * D2R), y: twoR * Math.sin(72 * D2R) };
+  const polys: Polygon[] = [];
+  // Cover [0,w]×[0,h] with a generous margin so straps entering the frame are
+  // complete: the pattern is clipped, never cropped mid-construction.
+  const nm = Math.ceil(w / a1.x) + 3;
+  const nn = Math.ceil(h / a2.y) + 3;
+  for (let n = -2; n <= nn; n++) {
+    for (let mIdx = -Math.ceil((n * a2.x) / a1.x) - 2; mIdx <= nm; mIdx++) {
+      const c = { x: mIdx * a1.x + n * a2.x, y: mIdx * a1.y + n * a2.y };
+      if (c.x < -3 * L || c.x > w + 3 * L || c.y < -3 * L || c.y > h + 3 * L) continue;
+      polys.push(ngonAt(10, L, c, 18));
+      // The bow-tie of this cell: six decagon vertices, all edges exactly L.
+      const d0 = c;
+      const d1 = { x: c.x + a1.x, y: c.y + a1.y };
+      const d2 = { x: c.x + a2.x, y: c.y + a2.y };
+      const d3 = { x: c.x + a1.x + a2.x, y: c.y + a1.y + a2.y };
+      polys.push([
+        decVertex(d0, L, 0),
+        decVertex(d1, L, 3),
+        decVertex(d3, L, 6),
+        decVertex(d3, L, 5),
+        decVertex(d2, L, 8),
+        decVertex(d0, L, 1),
+      ]);
+    }
+  }
+  return { polys, period: null };
+}
+
+// ── khatem8: octagons + squares (the truncated square tiling) ──────────────
+
+export function khatemTiling(L: number, w: number, h: number): Tiling {
+  const p = L / Math.tan(22.5 * D2R); // 2 × octagon inradius = lattice pitch
+  const polys: Polygon[] = [];
+  const cols = Math.ceil(w / p) + 2;
+  const rows = Math.ceil(h / p) + 2;
+  for (let j = -1; j <= rows; j++) {
+    for (let i = -1; i <= cols; i++) {
+      const c = { x: i * p, y: j * p };
+      polys.push(ngonAt(8, L, c, 22.5));
+      polys.push(ngonAt(4, L, { x: c.x + p / 2, y: c.y + p / 2 }, 45));
+    }
+  }
+  return { polys, period: { x: p, y: p } };
+}
+
+// ── hex6: regular hexagons ─────────────────────────────────────────────────
+
+export function hexTiling(L: number, w: number, h: number): Tiling {
+  const polys: Polygon[] = [];
+  const dx = 1.5 * L;
+  const dy = Math.sqrt(3) * L;
+  const cols = Math.ceil(w / dx) + 2;
+  const rows = Math.ceil(h / dy) + 2;
+  for (let i = -1; i <= cols; i++) {
+    for (let j = -1; j <= rows; j++) {
+      const c = { x: i * dx, y: j * dy + (i & 1 ? dy / 2 : 0) };
+      polys.push(ngonAt(6, L, c, 0));
+    }
+  }
+  return { polys, period: { x: 2 * dx, y: dy } };
+}
+
+// ── twelve12: dodecagons + hexagons + squares (4.6.12) ─────────────────────
+
+export function twelveTiling(L: number, w: number, h: number): Tiling {
+  const r12 = L / (2 * Math.tan(15 * D2R));
+  const s = 2 * r12 + L; // dodecagon centre spacing, triangular lattice
+  const a1 = { x: s, y: 0 };
+  const a2 = { x: s * Math.cos(60 * D2R), y: s * Math.sin(60 * D2R) };
+  const polys: Polygon[] = [];
+  const nn = Math.ceil(h / a2.y) + 2;
+  const nm = Math.ceil(w / a1.x) + 2;
+  for (let n = -1; n <= nn; n++) {
+    for (let mIdx = -Math.ceil((n * a2.x) / a1.x) - 1; mIdx <= nm; mIdx++) {
+      const c = { x: mIdx * a1.x + n * a2.x, y: mIdx * a1.y + n * a2.y };
+      if (c.x < -s || c.x > w + s || c.y < -s || c.y > h + s) continue;
+      polys.push(ngonAt(12, L, c, 15));
+      // Three squares (of six neighbours, half belong to this cell) …
+      for (const dir of [0, 60, 120]) {
+        const a = dir * D2R;
+        polys.push(
+          ngonAt(
+            4,
+            L,
+            { x: c.x + (s / 2) * Math.cos(a), y: c.y + (s / 2) * Math.sin(a) },
+            dir + 45,
+          ),
+        );
+      }
+      // … and two hexagons, at the centroids of the two lattice triangles.
+      const hexR = s / Math.sqrt(3);
+      for (const dir of [30, 90]) {
+        const a = dir * D2R;
+        polys.push(
+          ngonAt(6, L, { x: c.x + hexR * Math.cos(a), y: c.y + hexR * Math.sin(a) }, 0),
+        );
+      }
+    }
+  }
+  return { polys, period: null };
+}
+
+export function tilingFor(fold: Fold, L: number, w: number, h: number): Tiling {
+  switch (fold) {
+    case "girih5":
+      return girihTiling(L, w, h);
+    case "khatem8":
+      return khatemTiling(L, w, h);
+    case "hex6":
+      return hexTiling(L, w, h);
+    case "twelve12":
+      return twelveTiling(L, w, h);
+    case "lattice":
+      return { polys: [], period: null };
+  }
+}

--- a/dynawalla/bazaar/src/geometry/zellij.ts
+++ b/dynawalla/bazaar/src/geometry/zellij.ts
@@ -1,0 +1,177 @@
+/**
+ * Zellij — the floor, and it is worn where feet fall.
+ *
+ * Hand-chiselled glazed squares, assembled face-down and plastered from
+ * behind. The 8-point `khatem`, the `saft` cross that fills between them, and
+ * the small rotated squares of the secondary course.
+ *
+ * The wear rule is not optional decoration — it is what stops a floor looking
+ * rendered. Deterministic from the street seed:
+ *
+ *   · 4.0 % of tesserae get a chipped corner, a right triangle of leg 0.18·piece
+ *   · 1.5 % are a *wrong* colour, drawn from the neighbouring ward's palette —
+ *     historical repairs, never two adjacent
+ *   · grout darkens and tile lightness rises down the centre of the street,
+ *     because feet polish stone (applied by the floor layer, not baked in)
+ *   · grout width varies ±0.3 px by seed; it is never a uniform stroke
+ */
+
+import { frand, mix as mixSeed } from "../util/rng.ts";
+import { over } from "../util/color.ts";
+
+export interface ZellijOptions {
+  /** Lattice pitch in px. */
+  pitch: number;
+  /** How many cells across and down the repeating block is. */
+  block?: number;
+  seed: number;
+  grout: string;
+  field: string;
+  glaze: string;
+  glazeDeep: string;
+  /** The neighbouring ward's glaze, for the repair pieces. */
+  repair: string;
+  dpr?: number;
+}
+
+const RI_RATIO = 0.76536686; // concave radius of the union of two squares
+
+function khatemPath(ctx: CanvasRenderingContext2D, cx: number, cy: number, ro: number) {
+  ctx.beginPath();
+  for (let k = 0; k < 16; k++) {
+    const a = (k * 22.5 * Math.PI) / 180;
+    const r = k % 2 === 0 ? ro : ro * RI_RATIO;
+    const x = cx + r * Math.cos(a);
+    const y = cy + r * Math.sin(a);
+    if (k === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+}
+
+function squarePath(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  r: number,
+  rot: number,
+) {
+  ctx.beginPath();
+  for (let k = 0; k < 4; k++) {
+    const a = rot + (k * 90 * Math.PI) / 180;
+    const x = cx + r * Math.cos(a);
+    const y = cy + r * Math.sin(a);
+    if (k === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+}
+
+/** Chip one corner off the piece just drawn, by cutting a triangle out of it. */
+function chip(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  r: number,
+  seed: number,
+  grout: string,
+) {
+  const a = frand(seed) * Math.PI * 2;
+  const leg = r * 0.18;
+  const px = cx + r * Math.cos(a);
+  const py = cy + r * Math.sin(a);
+  ctx.fillStyle = grout;
+  ctx.beginPath();
+  ctx.moveTo(px, py);
+  ctx.lineTo(px - leg * Math.cos(a - 0.9), py - leg * Math.sin(a - 0.9));
+  ctx.lineTo(px - leg * Math.cos(a + 0.9), py - leg * Math.sin(a + 0.9));
+  ctx.closePath();
+  ctx.fill();
+}
+
+/** A repeating zellij block, ready for `createPattern`. */
+export function zellijTile(o: ZellijOptions): HTMLCanvasElement {
+  const dpr = o.dpr ?? 1;
+  const block = o.block ?? 4;
+  const p = o.pitch;
+  const size = p * block;
+  const cv = document.createElement("canvas");
+  cv.width = Math.max(1, Math.round(size * dpr));
+  cv.height = Math.max(1, Math.round(size * dpr));
+  const ctx = cv.getContext("2d");
+  if (!ctx) return cv;
+  ctx.scale(dpr, dpr);
+
+  ctx.fillStyle = o.field;
+  ctx.fillRect(0, 0, size, size);
+
+  // Grout laid as the diagonals that cut the field into saft crosses.
+  ctx.strokeStyle = o.grout;
+  ctx.lineCap = "butt";
+  for (let i = -block; i <= block * 2; i++) {
+    const jitter = (frand(mixSeed(o.seed, i)) - 0.5) * 0.6;
+    ctx.lineWidth = 1 + jitter;
+    ctx.beginPath();
+    ctx.moveTo(i * p, 0);
+    ctx.lineTo(i * p + size, size);
+    ctx.moveTo(i * p, size);
+    ctx.lineTo(i * p + size, 0);
+    ctx.stroke();
+  }
+
+  const ro = p * 0.46;
+  let lastRepair = -99;
+  let pieceIx = 0;
+
+  for (let j = -1; j <= block; j++) {
+    for (let i = -1; i <= block; i++) {
+      const cx = i * p;
+      const cy = j * p;
+      const s = mixSeed(o.seed, (j + 7) * 131 + i);
+      const r = frand(s);
+      pieceIx++;
+      let fill = o.glaze;
+      if (r < 0.015 && pieceIx - lastRepair > 1) {
+        fill = o.repair;
+        lastRepair = pieceIx;
+      }
+      khatemPath(ctx, cx, cy, ro);
+      ctx.fillStyle = fill;
+      ctx.fill();
+      ctx.strokeStyle = o.grout;
+      ctx.lineWidth = 1;
+      ctx.stroke();
+      if (frand(s ^ 0x51ed) < 0.04) chip(ctx, cx, cy, ro, s, o.grout);
+
+      // Secondary course: a small square in the cell centre.
+      const sx = cx + p / 2;
+      const sy = cy + p / 2;
+      const s2 = mixSeed(s, 0x2f3b);
+      const r2 = frand(s2);
+      let fill2 = o.glazeDeep;
+      if (r2 < 0.015 && pieceIx - lastRepair > 1) {
+        fill2 = o.repair;
+        lastRepair = pieceIx;
+      }
+      squarePath(ctx, sx, sy, p * 0.17, Math.PI / 4);
+      ctx.fillStyle = fill2;
+      ctx.fill();
+      ctx.strokeStyle = o.grout;
+      ctx.stroke();
+      if (frand(s2 ^ 0x77a1) < 0.04) chip(ctx, sx, sy, p * 0.17, s2, o.grout);
+    }
+  }
+
+  // A whisper of the lit edge on the up-sun side of each star: the glaze is
+  // slightly proud of the grout and catches the light.
+  ctx.strokeStyle = over(o.glaze, "#fff3d6", 0.22);
+  ctx.lineWidth = 0.6;
+  for (let j = -1; j <= block; j++) {
+    for (let i = -1; i <= block; i++) {
+      khatemPath(ctx, i * p, j * p, ro - 0.8);
+      ctx.stroke();
+    }
+  }
+
+  return cv;
+}

--- a/dynawalla/bazaar/src/index.ts
+++ b/dynawalla/bazaar/src/index.ts
@@ -1,0 +1,37 @@
+/**
+ * @dynawalla/bazaar — the endless minaret-punk marketplace the games are
+ * stalls in.
+ *
+ *   import { mountBazaar } from "@dynawalla/bazaar";
+ *   import "@dynawalla/bazaar/bazaar.css";
+ *
+ *   const bazaar = mountBazaar(el, {
+ *     stalls: [{ id: "tessera", title: "Tessera", quarter: "tilers", preview }],
+ *     dayRemaining: 0.6,
+ *     onEnter: (id) => router.push(`/play/${id}`),
+ *     onUpgrade: () => sheet.open(),
+ *   });
+ *
+ * The bazaar never waits for the world, and the world never waits for the
+ * bazaar: nothing in here imports from the work surface or the engine.
+ */
+
+export { mountBazaar } from "./bazaar.ts";
+export { QUARTERS, quarterById } from "./world/quarters.ts";
+export { WARDS, WARD_ORDER, STRIPES, MATERIALS, SEMANTIC } from "./tokens/palette.ts";
+export { LOCALES, STRINGS, resolveLocale } from "./strings.ts";
+export { DEMO_PREVIEWS, DEMO_TITLES } from "./demo/previews.ts";
+export type {
+  BazaarHandle,
+  BazaarOptions,
+  Craft,
+  Finial,
+  Fold,
+  PreviewFrame,
+  Quarter,
+  Specimen,
+  StallPreview,
+  StallSpec,
+  StallState,
+  WardId,
+} from "./types.ts";

--- a/dynawalla/bazaar/src/lamp/lamp.ts
+++ b/dynawalla/bazaar/src/lamp/lamp.ts
@@ -1,0 +1,261 @@
+/**
+ * The Lamplighter's Lamp — a pierced-brass hanging lantern with coloured glass.
+ *
+ * It reads at a glance on **four independent carriers**, three of which are not
+ * colour, because a design that says "the amber one means you are nearly out"
+ * has told a colour-blind child nothing:
+ *
+ *   1. oil level     a vertical position in a glass window   — POSITION
+ *   2. flame         absent by day, lit at dusk               — SHAPE
+ *   3. gnomon shadow a brass pointer across an engraved arc   — ROTATION
+ *   4. glass warmth  clear → amber → deep amber               — colour, last
+ *
+ * The subscriber's lamp is a *different lamp*: pierced brass with coloured
+ * glass instead of plain, full and lit at all times. Not "a restriction
+ * removed" — a second, better time of day opened.
+ */
+
+import { alpha, over } from "../util/color.ts";
+import { idle } from "../util/rng.ts";
+import { archPath } from "../geometry/arch.ts";
+import { MATERIALS, type Semantic } from "../tokens/palette.ts";
+import type { Ambient } from "../world/daylight.ts";
+import type { LampReading } from "./state.ts";
+
+export interface LampDraw {
+  sem: Semantic;
+  am: Ambient;
+  reading: LampReading;
+  subscribed: boolean;
+  reduced: boolean;
+  t: number;
+}
+
+export function drawLamp(g: CanvasRenderingContext2D, w: number, h: number, o: LampDraw): void {
+  const { sem, am, reading } = o;
+  const cx = w / 2;
+  const metal = sem.metal;
+  const metalShade = sem.metalShade;
+  const lit = sem.litEdge;
+
+  g.clearRect(0, 0, w, h);
+
+  // The chain from the canopy, and the smallest possible swing.
+  const swing = o.reduced ? 0 : idle(o.t / 2.4, 991, 0.9) * (Math.PI / 180);
+  g.strokeStyle = metalShade;
+  g.lineWidth = 2;
+  g.beginPath();
+  g.moveTo(cx, 0);
+  g.lineTo(cx + Math.sin(swing) * h * 0.2, h * 0.16);
+  g.stroke();
+
+  g.save();
+  g.translate(cx + Math.sin(swing) * h * 0.2, h * 0.16);
+  g.rotate(swing);
+
+  const bw = w * 0.62;
+  const bh = h * 0.46;
+
+  // Crown.
+  g.fillStyle = metal;
+  g.beginPath();
+  g.moveTo(-bw * 0.2, 0);
+  g.lineTo(bw * 0.2, 0);
+  g.lineTo(bw * 0.42, bh * 0.16);
+  g.lineTo(-bw * 0.42, bh * 0.16);
+  g.closePath();
+  g.fill();
+
+  // The glass body, in an arched brass frame. Warmth is the fourth carrier.
+  const warm = 1 - reading.oil;
+  const glassBase = o.subscribed ? MATERIALS["glass-amber"] : MATERIALS["glass-clear"];
+  // Warmth is the FOURTH carrier and the least load-bearing: clear → amber →
+  // deep amber, never a red alarm. Nothing in the lamp is ever alarming.
+  const glass = over(glassBase, MATERIALS["glass-amber"], warm * 0.7);
+  const bodyTop = bh * 0.16;
+  const bodyH = bh * 0.82;
+
+  g.save();
+  g.beginPath();
+  g.moveTo(-bw * 0.4, bodyTop + bodyH);
+  g.lineTo(-bw * 0.4, bodyTop + bodyH * 0.42);
+  archPath(g, 0, bodyTop + bodyH * 0.42, bw * 0.8, "drop");
+  g.lineTo(bw * 0.4, bodyTop + bodyH);
+  g.closePath();
+  g.clip();
+
+  g.fillStyle = over(glass, sem.ground, 0.45);
+  g.fillRect(-bw / 2, bodyTop, bw, bodyH);
+
+  // 1 — OIL. A level in a glass window; it falls, and position is the carrier.
+  const oilTop = bodyTop + bodyH * (0.12 + 0.8 * (1 - reading.oil));
+  g.fillStyle = over(glass, MATERIALS["glass-amber"], 0.6);
+  g.fillRect(-bw / 2, oilTop, bw, bodyTop + bodyH - oilTop);
+  g.fillStyle = alpha(lit, 0.6);
+  g.fillRect(-bw / 2, oilTop, bw, 1.5);
+
+  // 2 — FLAME. Absent by day; lit at dusk. A shape, present or not.
+  if (reading.lit) {
+    const flick = o.reduced ? 1 : 1 + idle(o.t, 71, 0.05);
+    g.fillStyle = alpha("#fff3d6", 0.95);
+    g.beginPath();
+    g.ellipse(0, oilTop - bodyH * 0.1 * flick, bw * 0.08, bodyH * 0.14 * flick, 0, 0, Math.PI * 2);
+    g.fill();
+    g.save();
+    g.globalCompositeOperation = "lighter";
+    g.fillStyle = alpha(MATERIALS["lantern"], 0.35);
+    g.beginPath();
+    g.arc(0, oilTop - bodyH * 0.1, bw * 0.4, 0, Math.PI * 2);
+    g.fill();
+    g.restore();
+  }
+  g.restore();
+
+  // Pierced brass strapping over the glass — the piercing is the lamp.
+  g.strokeStyle = metal;
+  g.lineWidth = Math.max(2, w * 0.035);
+  g.beginPath();
+  g.moveTo(-bw * 0.4, bodyTop + bodyH);
+  g.lineTo(-bw * 0.4, bodyTop + bodyH * 0.42);
+  archPath(g, 0, bodyTop + bodyH * 0.42, bw * 0.8, "drop");
+  g.lineTo(bw * 0.4, bodyTop + bodyH);
+  g.stroke();
+  g.lineWidth = 1.4;
+  g.beginPath();
+  for (let i = 1; i < 5; i++) {
+    const y = bodyTop + (bodyH * i) / 5;
+    g.moveTo(-bw * 0.4, y);
+    g.lineTo(bw * 0.4, y);
+  }
+  for (const x of [-bw * 0.16, bw * 0.16]) {
+    g.moveTo(x, bodyTop + bodyH * 0.1);
+    g.lineTo(x, bodyTop + bodyH);
+  }
+  g.stroke();
+
+  // The subscriber's lamp has coloured glass set into the piercing.
+  if (o.subscribed) {
+    const cols = [MATERIALS["glass-ruby"], MATERIALS["glass-emerald"], MATERIALS["glass-cobalt"]];
+    for (let i = 0; i < 3; i++) {
+      g.fillStyle = alpha(cols[i]!, 0.75);
+      g.beginPath();
+      g.arc(-bw * 0.16 + i * bw * 0.16, bodyTop + bodyH * 0.62, bw * 0.055, 0, Math.PI * 2);
+      g.fill();
+    }
+  }
+
+  // The base, with 3 — the GNOMON and its engraved arc. Rotation, and it is
+  // the fastest of the four to read.
+  const baseY = bodyTop + bodyH + bh * 0.04;
+  g.fillStyle = metal;
+  g.fillRect(-bw * 0.46, baseY, bw * 0.92, bh * 0.09);
+  g.fillStyle = lit;
+  g.fillRect(-bw * 0.46, baseY, bw * 0.92, 1);
+
+  const arcY = baseY + bh * 0.09;
+  const arcR = bw * 0.42;
+  g.strokeStyle = metalShade;
+  g.lineWidth = 1.2;
+  g.beginPath();
+  g.arc(0, arcY, arcR, Math.PI, Math.PI * 2);
+  g.stroke();
+  for (let i = 0; i <= 6; i++) {
+    const a = Math.PI + (Math.PI * i) / 6;
+    g.beginPath();
+    g.moveTo(Math.cos(a) * arcR * 0.86, arcY + Math.sin(a) * arcR * 0.86);
+    g.lineTo(Math.cos(a) * arcR, arcY + Math.sin(a) * arcR);
+    g.stroke();
+  }
+  // The pointer, and the shadow it throws across the graduations.
+  const ga = Math.PI + (reading.gnomon * Math.PI) / 180 / (150 / 180);
+  g.strokeStyle = alpha(sem.shadow, 0.75);
+  g.lineWidth = 3;
+  g.beginPath();
+  g.moveTo(0, arcY);
+  g.lineTo(Math.cos(ga) * arcR * 0.92, arcY + Math.sin(ga) * arcR * 0.92);
+  g.stroke();
+  g.strokeStyle = metal;
+  g.lineWidth = 1.6;
+  g.beginPath();
+  g.moveTo(0, arcY);
+  g.lineTo(0, arcY - bh * 0.14);
+  g.stroke();
+  g.fillStyle = metal;
+  g.beginPath();
+  g.arc(0, arcY, 2.5, 0, Math.PI * 2);
+  g.fill();
+
+  g.restore();
+  void am;
+}
+
+/**
+ * The lamplighter automaton, standing beside the unlit lamp holding a taper.
+ * **This is the entire monetisation surface in the bazaar.** One object, never
+ * modal, never animated to attract attention, never during play, and it is
+ * simply always there — it does not appear because the day ended.
+ */
+export function drawLamplighter(
+  g: CanvasRenderingContext2D,
+  w: number,
+  h: number,
+  sem: Semantic,
+  am: Ambient,
+  reduced: boolean,
+  t: number,
+): void {
+  g.clearRect(0, 0, w, h);
+  const metal = sem.metal;
+  const face = over(metal, am.sunColor, am.sunAlpha * 1.2);
+  const cut = over(metal, sem.shadow, am.shadowAlpha * 1.3);
+  const cx = w / 2;
+  const base = h;
+  const bh = h * 0.86;
+  const bw = w * 0.5;
+
+  // Plinth, column, head — the same automaton vocabulary as a shopkeeper.
+  g.fillStyle = cut;
+  g.fillRect(cx - bw * 0.6, base - h * 0.05, bw * 1.2, h * 0.05);
+  g.fillStyle = metal;
+  g.beginPath();
+  g.moveTo(cx - bw * 0.42, base - h * 0.05);
+  g.lineTo(cx - bw * 0.3, base - bh * 0.72);
+  g.lineTo(cx + bw * 0.3, base - bh * 0.72);
+  g.lineTo(cx + bw * 0.42, base - h * 0.05);
+  g.closePath();
+  g.fill();
+  g.fillStyle = face;
+  g.beginPath();
+  g.moveTo(cx - bw * 0.42, base - h * 0.05);
+  g.lineTo(cx - bw * 0.3, base - bh * 0.72);
+  g.lineTo(cx - bw * 0.12, base - bh * 0.72);
+  g.lineTo(cx - bw * 0.2, base - h * 0.05);
+  g.closePath();
+  g.fill();
+  g.fillStyle = metal;
+  g.beginPath();
+  g.ellipse(cx, base - bh * 0.82, bw * 0.3, h * 0.09, 0, 0, Math.PI * 2);
+  g.fill();
+  g.fillStyle = cut;
+  g.fillRect(cx - bw * 0.22, base - bh * 0.83, bw * 0.44, 2);
+
+  // The taper it holds. It is alight, because a lamplighter's taper is.
+  g.strokeStyle = metal;
+  g.lineWidth = Math.max(2, w * 0.05);
+  g.beginPath();
+  g.moveTo(cx + bw * 0.28, base - bh * 0.6);
+  g.lineTo(cx + bw * 0.72, base - bh * 0.84);
+  g.stroke();
+  const flick = reduced ? 1 : 1 + idle(t, 313, 0.06);
+  g.fillStyle = alpha("#fff3d6", 0.95);
+  g.beginPath();
+  g.ellipse(cx + bw * 0.76, base - bh * 0.9, w * 0.035, h * 0.035 * flick, 0, 0, Math.PI * 2);
+  g.fill();
+  g.save();
+  g.globalCompositeOperation = "lighter";
+  g.fillStyle = alpha(MATERIALS["lantern"], 0.22);
+  g.beginPath();
+  g.arc(cx + bw * 0.76, base - bh * 0.9, w * 0.24, 0, Math.PI * 2);
+  g.fill();
+  g.restore();
+}

--- a/dynawalla/bazaar/src/lamp/state.ts
+++ b/dynawalla/bazaar/src/lamp/state.ts
@@ -1,0 +1,126 @@
+/**
+ * The daily lamp — the free day as a physical object in the world.
+ *
+ * Three decisions make it gentle, and they are laws, not preferences:
+ *
+ *   BZ-LAW-14  Walking the bazaar is free. The day is consumed by time inside
+ *              a stall only. Wandering, listening, watching the previews,
+ *              waking the cat, reading the specimens — free, forever,
+ *              unmetered. A child who has used their day can still spend
+ *              twenty minutes in the marketplace wanting things.
+ *   BZ-LAW-15  The day never ends inside a game. `d` clamps at 0.99 while a
+ *              stall is open, plus a 90 s grace at the street.
+ *   BZ-LAW-16  The end of the day is the most beautiful part of it: golden
+ *              hour, then a 40 s dusk with a lamplighter walking the street.
+ *
+ * And the rules it must never break (§7.5): no countdown, no timer, no number,
+ * no percentage, no urgency, no scarcity, no streak, no loss. The lamp's only
+ * words are five day-states, because a glance is not available to everyone.
+ */
+
+import { clamp } from "../util/rng.ts";
+import type { StringKey } from "../strings.ts";
+
+export const DUSK_MS = 40_000;
+export const GRACE_MS = 90_000;
+
+export interface LampReading {
+  /** Day-state, 0 = morning … 1 = dusk. Clamped at 0.99 inside a stall. */
+  d: number;
+  /** The dusk blend, 0…1, driving the whole semantic layer. */
+  night: number;
+  /** Oil level in the glass, 1 → 0. Position, not colour. */
+  oil: number;
+  /** Gnomon shadow angle across the engraved arc, 0…150°. Rotation. */
+  gnomon: number;
+  /** Is the flame lit? Binary shape. */
+  lit: boolean;
+  /** Within the 90 s grace: one more round, and no cliff. */
+  grace: boolean;
+  /** The only words the mechanism gets. */
+  label: StringKey;
+}
+
+export class Lamp {
+  private consumed = 0;
+  private inStall = false;
+  private subscribed = false;
+  private duskStart: number | null = null;
+  private graceStart: number | null = null;
+  private forcedNight = false;
+
+  /** 0…1 of the free day still available. Supplied by the host. */
+  setRemaining(r: number): void {
+    this.consumed = clamp(1 - r, 0, 1);
+  }
+
+  setSubscribed(v: boolean): void {
+    this.subscribed = v;
+    if (v) {
+      this.duskStart = null;
+      this.graceStart = null;
+    }
+  }
+
+  /** The host tells us when a stall is open. BZ-16 hangs off this. */
+  setInStall(v: boolean): void {
+    if (v === this.inStall) return;
+    this.inStall = v;
+    if (!v && this.consumed >= 1 && this.graceStart === null) {
+      // Stepping back into the street with the day spent: one more round.
+      this.graceStart = Date.now();
+    }
+  }
+
+  /** Force the night bazaar (dark theme, or a subscriber after dusk). */
+  setForcedNight(v: boolean): void {
+    this.forcedNight = v;
+  }
+
+  read(now = Date.now()): LampReading {
+    // BZ-16: the day cannot complete while a stall is open.
+    const raw = this.consumed;
+    const d = this.inStall ? Math.min(raw, 0.99) : raw;
+
+    const grace =
+      this.graceStart !== null && now - this.graceStart < GRACE_MS && !this.subscribed;
+
+    let night = 0;
+    if (this.forcedNight) {
+      night = 1;
+    } else if (this.subscribed) {
+      // The subscriber's lamp never falls; the night bazaar opens at dusk.
+      night = d >= 1 ? 1 : 0;
+    } else if (d >= 1 && !this.inStall && !grace) {
+      if (this.duskStart === null) this.duskStart = now;
+      night = clamp((now - this.duskStart) / DUSK_MS, 0, 1);
+    }
+
+    // The subscriber's lamp is a different lamp: full and lit at all times.
+    const oil = this.subscribed ? 1 : 1 - d;
+    const lit = this.subscribed || night > 0.02;
+
+    return {
+      d,
+      night,
+      oil,
+      gnomon: d * 150,
+      lit,
+      grace,
+      label: labelFor(d, night),
+    };
+  }
+
+  /** The lamplighter is the entire monetisation surface, and it is always there. */
+  get showsLamplighter(): boolean {
+    return !this.subscribed;
+  }
+}
+
+function labelFor(d: number, night: number): StringKey {
+  if (night > 0.35) return "day.lit";
+  if (d >= 0.9) return "day.evening";
+  if (d >= 0.7) return "day.afternoon";
+  if (d >= 0.35) return "day.midday";
+  return "day.morning";
+}

--- a/dynawalla/bazaar/src/perf/tiers.ts
+++ b/dynawalla/bazaar/src/perf/tiers.ts
@@ -1,0 +1,99 @@
+/**
+ * Frame budget and the thermal ladder.
+ *
+ * Target device is the Galaxy Tab A9 at 60 fps. If RAF frame time p90 exceeds
+ * 20 ms for three seconds we drop a tier. Automatic, silent, never announced —
+ * a status line telling a child their tablet is slow is wasted UI copy and
+ * a small cruelty besides.
+ *
+ *   tier 1  dust, steam, heat shimmer and reflections go
+ *   tier 2  the far layers merge into one pre-rendered bitmap; pigeons and
+ *           cats freeze
+ *   tier 3  the centred preview falls back to its poster; the street is a
+ *           still painting
+ *
+ * Recovery needs ten seconds below 14 ms p90, so it cannot oscillate.
+ */
+
+export interface Budget {
+  dust: boolean;
+  steam: boolean;
+  shimmer: boolean;
+  reflections: boolean;
+  farParallax: boolean;
+  fauna: boolean;
+  livePreview: boolean;
+  maxMotes: number;
+}
+
+const BUDGETS: Budget[] = [
+  { dust: true, steam: true, shimmer: true, reflections: true, farParallax: true, fauna: true, livePreview: true, maxMotes: 60 },
+  { dust: false, steam: false, shimmer: false, reflections: false, farParallax: true, fauna: true, livePreview: true, maxMotes: 0 },
+  { dust: false, steam: false, shimmer: false, reflections: false, farParallax: false, fauna: false, livePreview: true, maxMotes: 0 },
+  { dust: false, steam: false, shimmer: false, reflections: false, farParallax: false, fauna: false, livePreview: false, maxMotes: 0 },
+];
+
+export class PerfGovernor {
+  private samples: number[] = [];
+  private tier = 0;
+  private overSince = 0;
+  private underSince = 0;
+  private last = 0;
+  private smallScreen = false;
+
+  /** Phones halve the mote budget before anything is measured. */
+  setSmallScreen(v: boolean): void {
+    this.smallScreen = v;
+  }
+
+  sample(frameMs: number, now: number): void {
+    this.samples.push(frameMs);
+    if (this.samples.length > 120) this.samples.shift();
+    if (now - this.last < 250) return;
+    this.last = now;
+    const p90 = percentile(this.samples, 0.9);
+    if (p90 > 20) {
+      this.underSince = 0;
+      if (!this.overSince) this.overSince = now;
+      else if (now - this.overSince > 3000 && this.tier < BUDGETS.length - 1) {
+        this.tier++;
+        this.overSince = now;
+      }
+    } else if (p90 < 14) {
+      this.overSince = 0;
+      if (!this.underSince) this.underSince = now;
+      else if (now - this.underSince > 10_000 && this.tier > 0) {
+        this.tier--;
+        this.underSince = now;
+      }
+    } else {
+      this.overSince = 0;
+      this.underSince = 0;
+    }
+  }
+
+  get budget(): Budget {
+    const b = BUDGETS[this.tier]!;
+    return this.smallScreen ? { ...b, maxMotes: Math.round(b.maxMotes * 0.4) } : b;
+  }
+
+  get level(): number {
+    return this.tier;
+  }
+
+  get p90(): number {
+    return percentile(this.samples, 0.9);
+  }
+
+  get fps(): number {
+    if (!this.samples.length) return 0;
+    const mean = this.samples.reduce((a, b) => a + b, 0) / this.samples.length;
+    return mean > 0 ? 1000 / mean : 0;
+  }
+}
+
+function percentile(xs: number[], p: number): number {
+  if (!xs.length) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  return s[Math.min(s.length - 1, Math.floor(s.length * p))]!;
+}

--- a/dynawalla/bazaar/src/sound/bed.ts
+++ b/dynawalla/bazaar/src/sound/bed.ts
@@ -1,0 +1,424 @@
+/**
+ * The bazaar's sound. WebAudio only, zero assets, never required, never
+ * load-bearing.
+ *
+ * BZ-LAW-13 — **every sound is caused by something visible.** If you can hear
+ * it, you can find it on screen. The chimes ring because the simulated chime
+ * crossed zero. The escapement ticks because the lamp's escapement wheel
+ * advanced. Ambience that comes from nowhere is a soundtrack, and a soundtrack
+ * is a different product.
+ *
+ * BZ-09 — the street renders and plays with `AudioContext` stubbed to throw.
+ * Every entry point here is wrapped; failure of any kind is a silent no-op.
+ */
+
+const AMBIENCE_CEILING = 0.032; // ≈ −30 dBFS
+const MASTER_CEILING = 0.5; // ≈ −6 dBFS
+const POLYPHONY = 12;
+
+export class Bed {
+  private ctx: AudioContext | null = null;
+  private master: GainNode | null = null;
+  private ambience: GainNode | null = null;
+  private conv: ConvolverNode | null = null;
+  private voices = 0;
+  private timers: number[] = [];
+  private started = false;
+  private open = true;
+  private duck = 1;
+
+  get isOpen(): boolean {
+    return this.open;
+  }
+
+  /** Called on the first user gesture, never before. */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    try {
+      const Ctor: typeof AudioContext | undefined =
+        (globalThis as { AudioContext?: typeof AudioContext }).AudioContext ??
+        (globalThis as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+      if (!Ctor) return;
+      const ctx = new Ctor();
+      this.ctx = ctx;
+
+      const comp = ctx.createDynamicsCompressor();
+      comp.threshold.value = -6;
+      comp.ratio.value = 20;
+      comp.knee.value = 0;
+      comp.attack.value = 0.003;
+      comp.release.value = 0.12;
+      comp.connect(ctx.destination);
+
+      const master = ctx.createGain();
+      master.gain.value = MASTER_CEILING;
+      master.connect(comp);
+      this.master = master;
+
+      const conv = ctx.createConvolver();
+      conv.buffer = syntheticIR(ctx, 1.8);
+      conv.connect(master);
+      this.conv = conv;
+
+      const amb = ctx.createGain();
+      amb.gain.value = AMBIENCE_CEILING;
+      const lp = ctx.createBiquadFilter();
+      lp.type = "lowpass";
+      lp.frequency.value = 2500;
+      amb.connect(lp);
+      lp.connect(conv);
+      amb.connect(master);
+      this.ambience = amb;
+
+      this.crowd();
+      this.fountain();
+      this.schedule();
+    } catch {
+      this.ctx = null;
+    }
+  }
+
+  setOpen(v: boolean): void {
+    this.open = v;
+    try {
+      if (this.master && this.ctx) {
+        this.master.gain.setTargetAtTime(v ? MASTER_CEILING * this.duck : 0, this.ctx.currentTime, 0.25);
+      }
+    } catch {
+      /* silent */
+    }
+  }
+
+  /** −9 dB when a preview is centred; silent while a game owns the sound. */
+  setDuck(level: "none" | "preview" | "mute"): void {
+    this.duck = level === "mute" ? 0 : level === "preview" ? 0.35 : 1;
+    this.setOpen(this.open);
+  }
+
+  suspend(): void {
+    try {
+      void this.ctx?.suspend();
+    } catch {
+      /* silent */
+    }
+  }
+
+  resume(): void {
+    try {
+      void this.ctx?.resume();
+    } catch {
+      /* silent */
+    }
+  }
+
+  destroy(): void {
+    for (const id of this.timers) clearInterval(id);
+    this.timers = [];
+    try {
+      void this.ctx?.close();
+    } catch {
+      /* silent */
+    }
+    this.ctx = null;
+  }
+
+  // ── the bed ─────────────────────────────────────────────────────────────
+
+  /** Distant crowd: never intelligible, never a word. */
+  private crowd(): void {
+    const ctx = this.ctx;
+    const amb = this.ambience;
+    if (!ctx || !amb) return;
+    try {
+      const src = ctx.createBufferSource();
+      src.buffer = pinkNoise(ctx, 6);
+      src.loop = true;
+      for (const [f, q, gain] of [
+        [400, 0.7, 0.7],
+        [1200, 1.2, 0.4],
+      ] as const) {
+        const bp = ctx.createBiquadFilter();
+        bp.type = "bandpass";
+        bp.frequency.value = f;
+        bp.Q.value = q;
+        const g = ctx.createGain();
+        g.gain.value = gain;
+        src.connect(bp);
+        bp.connect(g);
+        g.connect(amb);
+        // A slow breath on the level: the square is never at one volume.
+        const lfo = ctx.createOscillator();
+        lfo.frequency.value = 0.07;
+        const lg = ctx.createGain();
+        lg.gain.value = gain * 0.3;
+        lfo.connect(lg);
+        lg.connect(g.gain);
+        lfo.start();
+      }
+      src.start();
+    } catch {
+      /* silent */
+    }
+  }
+
+  /** The fountain in the square. High-passed noise, and the odd droplet. */
+  private fountain(): void {
+    const ctx = this.ctx;
+    const amb = this.ambience;
+    if (!ctx || !amb) return;
+    try {
+      const src = ctx.createBufferSource();
+      src.buffer = pinkNoise(ctx, 4);
+      src.loop = true;
+      const hp = ctx.createBiquadFilter();
+      hp.type = "highpass";
+      hp.frequency.value = 800;
+      const g = ctx.createGain();
+      g.gain.value = 0.32;
+      src.connect(hp);
+      hp.connect(g);
+      g.connect(amb);
+      src.start();
+    } catch {
+      /* silent */
+    }
+  }
+
+  private schedule(): void {
+    const every = (ms: number, fn: () => void) => {
+      const id = setInterval(() => {
+        try {
+          fn();
+        } catch {
+          /* silent */
+        }
+      }, ms) as unknown as number;
+      this.timers.push(id);
+    };
+    // The coppersmith: irregular groups, then a long silence.
+    every(9000, () => {
+      if (Math.random() < 0.45) this.coppersmith();
+    });
+    // A call across the square. Wordless — not an adhan, not language.
+    every(45000, () => {
+      if (Math.random() < 0.6) this.call();
+    });
+    // The escapement: the only sound in the bazaar that indexes time, and the
+    // quietest thing in it.
+    every(4000, () => this.escapement());
+    // A droplet in the fountain basin.
+    every(3000, () => {
+      if (Math.random() < 0.5) this.droplet();
+    });
+  }
+
+  // ── events, each caused by something on screen ──────────────────────────
+
+  /** An inharmonic strike: six partials, descending decays, zero attack. */
+  strike(pan = 0, gain = 0.5, f0 = 320): void {
+    const ctx = this.ctx;
+    const bus = this.conv ?? this.master;
+    if (!ctx || !bus || this.voices > POLYPHONY) return;
+    try {
+      const ratios = [1, 2.76, 5.4, 8.93, 13.34, 18.64];
+      const decays = [1.8, 1.2, 0.8, 0.5, 0.32, 0.2];
+      const p = ctx.createStereoPanner();
+      p.pan.value = Math.max(-0.7, Math.min(0.7, pan));
+      p.connect(bus);
+      const now = ctx.currentTime;
+      for (let i = 0; i < ratios.length; i++) {
+        const osc = ctx.createOscillator();
+        osc.frequency.value = f0 * ratios[i]!;
+        const g = ctx.createGain();
+        g.gain.setValueAtTime((gain * 0.24) / (i + 1), now);
+        g.gain.exponentialRampToValueAtTime(0.0001, now + decays[i]!);
+        osc.connect(g);
+        g.connect(p);
+        osc.start(now);
+        osc.stop(now + decays[i]! + 0.05);
+        this.voices++;
+        osc.onended = () => {
+          this.voices--;
+          try {
+            osc.disconnect();
+            g.disconnect();
+          } catch {
+            /* silent */
+          }
+        };
+      }
+    } catch {
+      /* silent */
+    }
+  }
+
+  private coppersmith(): void {
+    const n = 3 + Math.floor(Math.random() * 5);
+    const pan = Math.random() * 1.2 - 0.6;
+    for (let i = 0; i < n; i++) {
+      setTimeout(() => this.strike(pan, 0.16, 240), i * 420 + (Math.random() - 0.5) * 36);
+    }
+  }
+
+  /** A wind chime, rung because the visible chime's swing crossed zero. */
+  chime(pan = 0): void {
+    const pent = [293.66, 329.63, 392.0, 440.0, 493.88];
+    this.strike(pan, 0.14, pent[Math.floor(Math.random() * pent.length)]!);
+  }
+
+  private droplet(): void {
+    const ctx = this.ctx;
+    const bus = this.conv ?? this.master;
+    if (!ctx || !bus) return;
+    try {
+      const osc = ctx.createOscillator();
+      const now = ctx.currentTime;
+      osc.frequency.setValueAtTime(1400, now);
+      osc.frequency.exponentialRampToValueAtTime(900, now + 0.03);
+      const g = ctx.createGain();
+      g.gain.setValueAtTime(0.05, now);
+      g.gain.exponentialRampToValueAtTime(0.0001, now + 0.16);
+      const d = ctx.createDelay();
+      d.delayTime.value = 0.007;
+      const fb = ctx.createGain();
+      fb.gain.value = 0.4;
+      osc.connect(g);
+      g.connect(d);
+      d.connect(fb);
+      fb.connect(d);
+      d.connect(bus);
+      g.connect(bus);
+      osc.start(now);
+      osc.stop(now + 0.2);
+    } catch {
+      /* silent */
+    }
+  }
+
+  private escapement(): void {
+    const ctx = this.ctx;
+    const bus = this.master;
+    if (!ctx || !bus) return;
+    try {
+      const src = ctx.createBufferSource();
+      src.buffer = pinkNoise(ctx, 0.02);
+      const bp = ctx.createBiquadFilter();
+      bp.type = "bandpass";
+      bp.frequency.value = 3200;
+      bp.Q.value = 8;
+      const g = ctx.createGain();
+      const now = ctx.currentTime;
+      g.gain.setValueAtTime(0.035, now);
+      g.gain.exponentialRampToValueAtTime(0.0001, now + 0.045);
+      src.connect(bp);
+      bp.connect(g);
+      g.connect(bus);
+      src.start(now);
+    } catch {
+      /* silent */
+    }
+  }
+
+  /** A shutter coming down. The most beautiful sound of the day. */
+  shutter(pan = 0): void {
+    const ctx = this.ctx;
+    const bus = this.conv ?? this.master;
+    if (!ctx || !bus) return;
+    try {
+      const src = ctx.createBufferSource();
+      src.buffer = pinkNoise(ctx, 1);
+      const bp = ctx.createBiquadFilter();
+      bp.type = "bandpass";
+      bp.frequency.value = 700;
+      bp.Q.value = 1.4;
+      const g = ctx.createGain();
+      const now = ctx.currentTime;
+      g.gain.setValueAtTime(0.0001, now);
+      g.gain.linearRampToValueAtTime(0.09, now + 0.5);
+      g.gain.exponentialRampToValueAtTime(0.0001, now + 0.95);
+      const p = ctx.createStereoPanner();
+      p.pan.value = pan;
+      src.connect(bp);
+      bp.connect(g);
+      g.connect(p);
+      p.connect(bus);
+      src.start(now);
+      src.stop(now + 1);
+      for (let i = 0; i < 3; i++) setTimeout(() => this.strike(pan, 0.07, 120), 950 + i * 90);
+    } catch {
+      /* silent */
+    }
+  }
+
+  /** A wordless vendor's cry: formants, a falling contour, heavy reverb. */
+  private call(): void {
+    const ctx = this.ctx;
+    const bus = this.conv ?? this.master;
+    if (!ctx || !bus) return;
+    try {
+      const now = ctx.currentTime;
+      const osc = ctx.createOscillator();
+      osc.type = "sawtooth";
+      osc.frequency.setValueAtTime(210, now);
+      osc.frequency.setValueAtTime(186, now + 0.6);
+      osc.frequency.setValueAtTime(156, now + 1.1);
+      const out = ctx.createGain();
+      out.gain.setValueAtTime(0.0001, now);
+      out.gain.linearRampToValueAtTime(0.02, now + 0.12);
+      out.gain.setValueAtTime(0.02, now + 1.2);
+      out.gain.exponentialRampToValueAtTime(0.0001, now + 1.6);
+      for (const [f, q] of [
+        [620, 8],
+        [1180, 10],
+        [2600, 12],
+      ] as const) {
+        const bp = ctx.createBiquadFilter();
+        bp.type = "bandpass";
+        bp.frequency.value = f;
+        bp.Q.value = q;
+        osc.connect(bp);
+        bp.connect(out);
+      }
+      const p = ctx.createStereoPanner();
+      p.pan.value = Math.random() * 1.2 - 0.6;
+      out.connect(p);
+      p.connect(bus);
+      osc.start(now);
+      osc.stop(now + 1.7);
+    } catch {
+      /* silent */
+    }
+  }
+}
+
+// ── synthesis helpers ──────────────────────────────────────────────────────
+
+function pinkNoise(ctx: BaseAudioContext, seconds: number): AudioBuffer {
+  const n = Math.max(1, Math.floor(ctx.sampleRate * seconds));
+  const buf = ctx.createBuffer(1, n, ctx.sampleRate);
+  const d = buf.getChannelData(0);
+  let b0 = 0;
+  let b1 = 0;
+  let b2 = 0;
+  for (let i = 0; i < n; i++) {
+    const white = Math.random() * 2 - 1;
+    b0 = 0.99765 * b0 + white * 0.099046;
+    b1 = 0.963 * b1 + white * 0.2965164;
+    b2 = 0.57 * b2 + white * 1.0526913;
+    d[i] = (b0 + b1 + b2 + white * 0.1848) * 0.12;
+  }
+  return buf;
+}
+
+function syntheticIR(ctx: BaseAudioContext, seconds: number): AudioBuffer {
+  const n = Math.max(1, Math.floor(ctx.sampleRate * seconds));
+  const buf = ctx.createBuffer(2, n, ctx.sampleRate);
+  for (let c = 0; c < 2; c++) {
+    const d = buf.getChannelData(c);
+    for (let i = 0; i < n; i++) {
+      d[i] = (Math.random() * 2 - 1) * Math.pow(1 - i / n, 2.6) * 0.5;
+    }
+  }
+  return buf;
+}

--- a/dynawalla/bazaar/src/stall/automaton.ts
+++ b/dynawalla/bazaar/src/stall/automaton.ts
@@ -1,0 +1,346 @@
+/**
+ * The shopkeeper automaton.
+ *
+ * Brass, faceless, one moving part, standing at the left jamb. It performs the
+ * **mechanism of its own mathematics**: the tilers' automaton lays a tessera
+ * every 4.2 s; the clockmakers' turns a two-ratio gear train; the weighers'
+ * tips a balance beam. al-Jazari, not a mascot.
+ *
+ * No face. This avoids the uncanny-mascot failure and the figurative-
+ * representation question in one move, and it is also what al-Jazari's own
+ * drawings look like: a mechanism with a suggested head and a job to do.
+ *
+ * It turns to look at where you touched — once, 420 ms, then back to idle. It
+ * grants nothing for it (BZ-LAW-12).
+ */
+
+import { idle, clamp, lerp } from "../util/rng.ts";
+import { over } from "../util/color.ts";
+import { gearTrain, drawGear } from "../geometry/gears.ts";
+import type { Semantic } from "../tokens/palette.ts";
+import type { Craft } from "../types.ts";
+
+export interface AutomatonCtx {
+  sem: Semantic;
+  sunColor: string;
+  sunAlpha: number;
+  shadowAlpha: number;
+  reduced: boolean;
+}
+
+/**
+ * `look` is −1…1: which way the head is turned. `attention` decays 1→0 over
+ * 420 ms after a touch.
+ */
+export function drawAutomaton(
+  g: CanvasRenderingContext2D,
+  x: number,
+  baseY: number,
+  h: number,
+  craft: Craft,
+  seed: number,
+  t: number,
+  c: AutomatonCtx,
+  look: number,
+  attention: number,
+): void {
+  const metal = c.sem.metal;
+  const face = over(metal, c.sunColor, c.sunAlpha * 1.3);
+  const cut = over(metal, c.sem.shadow, c.shadowAlpha * 1.4);
+  const w = h * 0.34;
+  const top = baseY - h;
+  const breathe = c.reduced ? 0 : idle(t, seed, h * 0.006);
+
+  g.save();
+  g.translate(x, breathe);
+
+  // Plinth.
+  g.fillStyle = cut;
+  g.fillRect(-w * 0.62, baseY - h * 0.05, w * 1.24, h * 0.05);
+  g.fillStyle = face;
+  g.fillRect(-w * 0.62, baseY - h * 0.06, w * 1.24, h * 0.012);
+
+  // Column body, three facets, with a visible escapement window.
+  g.fillStyle = metal;
+  g.beginPath();
+  g.moveTo(-w * 0.42, baseY - h * 0.05);
+  g.lineTo(-w * 0.3, top + h * 0.26);
+  g.lineTo(w * 0.3, top + h * 0.26);
+  g.lineTo(w * 0.42, baseY - h * 0.05);
+  g.closePath();
+  g.fill();
+  g.fillStyle = face;
+  g.beginPath();
+  g.moveTo(-w * 0.42, baseY - h * 0.05);
+  g.lineTo(-w * 0.3, top + h * 0.26);
+  g.lineTo(-w * 0.12, top + h * 0.26);
+  g.lineTo(-w * 0.2, baseY - h * 0.05);
+  g.closePath();
+  g.fill();
+
+  // The window into the works: a small escapement wheel, always turning.
+  const wx = w * 0.06;
+  const wy = baseY - h * 0.42;
+  g.fillStyle = cut;
+  g.beginPath();
+  g.arc(wx, wy, h * 0.09, 0, Math.PI * 2);
+  g.fill();
+  const esc = gearTrain(
+    { spec: [{ teeth: 12 }, { teeth: 9, bearing: 200 }], module: h * 0.012, origin: { x: wx, y: wy }, omega: 0.7 },
+    c.reduced ? 0 : t,
+  );
+  for (const gear of esc) {
+    drawGear(g, gear, { metal: face, metalShade: metal, litEdge: c.sem.litEdge, cut });
+  }
+
+  // Head: a brass drum with a lamp slit. It turns to look, and it has no face.
+  const turn = lerp(0, look * 0.5, clamp(attention, 0, 1));
+  g.save();
+  g.translate(0, top + h * 0.14);
+  g.rotate(turn * 0.35);
+  g.fillStyle = metal;
+  g.beginPath();
+  g.ellipse(0, 0, w * 0.3, h * 0.13, 0, 0, Math.PI * 2);
+  g.fill();
+  g.fillStyle = face;
+  g.beginPath();
+  g.ellipse(-w * 0.08, -h * 0.02, w * 0.16, h * 0.08, 0, 0, Math.PI * 2);
+  g.fill();
+  g.fillStyle = cut;
+  g.fillRect(-w * 0.22 + turn * w * 0.2, -h * 0.02, w * 0.44, h * 0.018);
+  // A little finial, because everything here has one.
+  g.strokeStyle = metal;
+  g.lineWidth = Math.max(1.2, h * 0.014);
+  g.beginPath();
+  g.moveTo(0, -h * 0.13);
+  g.lineTo(0, -h * 0.2);
+  g.stroke();
+  g.restore();
+
+  drawTool(g, w, h, top, baseY, craft, t, c, metal, face, cut);
+  g.restore();
+}
+
+/** The one moving part, and it does the quarter's own mathematics. */
+function drawTool(
+  g: CanvasRenderingContext2D,
+  w: number,
+  h: number,
+  top: number,
+  baseY: number,
+  craft: Craft,
+  t: number,
+  c: AutomatonCtx,
+  metal: string,
+  face: string,
+  cut: string,
+): void {
+  const armY = top + h * 0.34;
+  const tt = c.reduced ? 0 : t;
+  g.strokeStyle = metal;
+  g.lineWidth = Math.max(1.5, h * 0.03);
+  g.lineCap = "round";
+
+  switch (craft) {
+    case "balance": {
+      // A beam that tips towards equality and settles.
+      const tip = Math.sin(tt * 0.8) * 0.22 * Math.exp(-((tt * 0.8) % 6.28) * 0.12);
+      g.save();
+      g.translate(w * 0.55, armY);
+      g.rotate(tip);
+      g.beginPath();
+      g.moveTo(-w * 0.5, 0);
+      g.lineTo(w * 0.5, 0);
+      g.stroke();
+      g.fillStyle = face;
+      for (const px of [-w * 0.5, w * 0.5]) {
+        g.beginPath();
+        g.moveTo(px - w * 0.16, h * 0.04);
+        g.lineTo(px + w * 0.16, h * 0.04);
+        g.lineTo(px + w * 0.1, h * 0.13);
+        g.lineTo(px - w * 0.1, h * 0.13);
+        g.closePath();
+        g.fill();
+      }
+      g.restore();
+      break;
+    }
+    case "coin": {
+      // A coin flipped from the fingertip and caught. Every 2.4 s.
+      const u = (tt % 2.4) / 2.4;
+      const fly = Math.sin(u * Math.PI);
+      g.beginPath();
+      g.moveTo(w * 0.3, armY);
+      g.lineTo(w * 0.72, armY + h * 0.04);
+      g.stroke();
+      g.fillStyle = face;
+      g.beginPath();
+      g.ellipse(w * 0.75, armY - fly * h * 0.3, h * 0.045, h * 0.045 * Math.abs(Math.cos(u * 9)), 0, 0, Math.PI * 2);
+      g.fill();
+      break;
+    }
+    case "tessera": {
+      // Lays a tessera every 4.2 s, and the row it has laid stays.
+      const u = (tt % 4.2) / 4.2;
+      const reach = Math.sin(Math.min(1, u * 1.6) * Math.PI);
+      g.beginPath();
+      g.moveTo(w * 0.3, armY);
+      g.lineTo(w * 0.5 + reach * w * 0.5, armY + h * 0.12 + reach * h * 0.1);
+      g.stroke();
+      g.fillStyle = "#17868c";
+      const laid = Math.floor((tt / 4.2) % 6);
+      for (let i = 0; i <= laid; i++) {
+        g.fillRect(w * 0.55 + i * h * 0.07, baseY - h * 0.1, h * 0.06, h * 0.06);
+      }
+      g.fillStyle = face;
+      g.fillRect(w * 0.5 + reach * w * 0.5 - h * 0.03, armY + h * 0.12 + reach * h * 0.1, h * 0.06, h * 0.05);
+      break;
+    }
+    case "rope": {
+      // Winds a coil; the coil grows and resets.
+      const spin = tt * 2.2;
+      g.beginPath();
+      g.moveTo(w * 0.3, armY);
+      g.lineTo(w * 0.66, armY + h * 0.06);
+      g.stroke();
+      g.strokeStyle = "#e6dcc4";
+      g.lineWidth = Math.max(1.2, h * 0.02);
+      for (let i = 0; i < 3; i++) {
+        g.beginPath();
+        g.ellipse(
+          w * 0.7,
+          armY + h * 0.1 + i * h * 0.03,
+          h * 0.09,
+          h * 0.035,
+          Math.sin(spin + i) * 0.2,
+          0,
+          Math.PI * 2,
+        );
+        g.stroke();
+      }
+      break;
+    }
+    case "astrolabe": {
+      // Rotates a rete against a graduated limb.
+      const a = tt * 0.5;
+      g.beginPath();
+      g.moveTo(w * 0.3, armY);
+      g.lineTo(w * 0.62, armY);
+      g.stroke();
+      const cx = w * 0.78;
+      const cy = armY;
+      g.fillStyle = metal;
+      g.beginPath();
+      g.arc(cx, cy, h * 0.12, 0, Math.PI * 2);
+      g.fill();
+      g.strokeStyle = face;
+      g.lineWidth = 1.4;
+      g.beginPath();
+      g.arc(cx, cy, h * 0.085, 0, Math.PI * 2);
+      g.stroke();
+      g.beginPath();
+      g.moveTo(cx + Math.cos(a) * h * 0.11, cy + Math.sin(a) * h * 0.11);
+      g.lineTo(cx - Math.cos(a) * h * 0.11, cy - Math.sin(a) * h * 0.11);
+      g.stroke();
+      break;
+    }
+    case "water": {
+      // A scoop wheel. Water in, water out, at a rate.
+      const a = tt * 1.1;
+      const cx = w * 0.74;
+      const cy = armY + h * 0.08;
+      g.strokeStyle = metal;
+      g.lineWidth = Math.max(1.2, h * 0.022);
+      g.beginPath();
+      g.arc(cx, cy, h * 0.15, 0, Math.PI * 2);
+      g.stroke();
+      for (let i = 0; i < 6; i++) {
+        const k = a + (i * Math.PI) / 3;
+        g.beginPath();
+        g.moveTo(cx, cy);
+        g.lineTo(cx + Math.cos(k) * h * 0.15, cy + Math.sin(k) * h * 0.15);
+        g.stroke();
+        g.fillStyle = i % 2 ? face : "#4e8fa0";
+        g.beginPath();
+        g.arc(cx + Math.cos(k) * h * 0.15, cy + Math.sin(k) * h * 0.15, h * 0.03, 0, Math.PI * 2);
+        g.fill();
+      }
+      break;
+    }
+    case "vat": {
+      // Dips a stirring stick; the colour on it deepens and clears.
+      const dip = (Math.sin(tt * 0.9) + 1) / 2;
+      g.beginPath();
+      g.moveTo(w * 0.3, armY);
+      g.lineTo(w * 0.68, armY + h * 0.05 + dip * h * 0.12);
+      g.stroke();
+      g.fillStyle = "#23356b";
+      g.beginPath();
+      g.ellipse(w * 0.78, baseY - h * 0.12, h * 0.11, h * 0.04, 0, 0, Math.PI * 2);
+      g.fill();
+      break;
+    }
+    case "kite": {
+      // Raises a kite frame into the draught and lowers it.
+      const rise = (Math.sin(tt * 0.6) + 1) / 2;
+      g.beginPath();
+      g.moveTo(w * 0.3, armY);
+      g.lineTo(w * 0.6, armY - rise * h * 0.16);
+      g.stroke();
+      g.save();
+      g.translate(w * 0.78, armY - h * 0.1 - rise * h * 0.3);
+      g.rotate(Math.sin(tt) * 0.2);
+      g.fillStyle = "#e8b93f";
+      g.beginPath();
+      g.moveTo(0, -h * 0.12);
+      g.lineTo(h * 0.08, 0);
+      g.lineTo(0, h * 0.12);
+      g.lineTo(-h * 0.08, 0);
+      g.closePath();
+      g.fill();
+      g.restore();
+      break;
+    }
+    case "gears": {
+      // A real two-ratio train. Its teeth and its speeds agree (BZ-LAW-11).
+      const gears = gearTrain(
+        {
+          spec: [{ teeth: 24 }, { teeth: 18, bearing: -20 }, { teeth: 12, bearing: 40 }],
+          module: h * 0.014,
+          origin: { x: w * 0.72, y: armY + h * 0.05 },
+          omega: 0.5,
+        },
+        tt,
+      );
+      for (const gear of gears) {
+        drawGear(g, gear, { metal: face, metalShade: metal, litEdge: c.sem.litEdge, cut });
+      }
+      break;
+    }
+    case "mill": {
+      // Turns a quern, and grain falls through.
+      const a = tt * 1.4;
+      const cx = w * 0.74;
+      const cy = armY + h * 0.14;
+      g.fillStyle = "#b99c6e";
+      g.beginPath();
+      g.ellipse(cx, cy, h * 0.16, h * 0.06, 0, 0, Math.PI * 2);
+      g.fill();
+      g.strokeStyle = cut;
+      g.lineWidth = 1.2;
+      for (let i = 0; i < 6; i++) {
+        const k = a + (i * Math.PI) / 3;
+        g.beginPath();
+        g.moveTo(cx, cy);
+        g.lineTo(cx + Math.cos(k) * h * 0.16, cy + Math.sin(k) * h * 0.06);
+        g.stroke();
+      }
+      g.fillStyle = face;
+      g.beginPath();
+      g.moveTo(cx + Math.cos(a) * h * 0.14, cy + Math.sin(a) * h * 0.05);
+      g.lineTo(cx + Math.cos(a) * h * 0.14, cy + Math.sin(a) * h * 0.05 - h * 0.1);
+      g.stroke();
+      break;
+    }
+  }
+}

--- a/dynawalla/bazaar/src/stall/chrome.ts
+++ b/dynawalla/bazaar/src/stall/chrome.ts
@@ -1,0 +1,516 @@
+/**
+ * Anatomy of a stall, top to bottom. Every part is a real object with a job:
+ *
+ *   1. muqarnas hood      the thing that visibly holds up the lintel
+ *   2. awning             striped cloth on two ribs, breathing
+ *   3. sign board         walnut, cream lettering — name and worked specimen
+ *   4. the aperture       the live preview; a cut opening with real jambs and
+ *                         **nothing else touching it** (BZ-LAW-1)
+ *   5. the sill / counter a stone shelf with 3–7 real objects from that game
+ *   6. the automaton      brass, faceless, performing its own mathematics
+ *   7. the shutter        mashrabiya on a roller, down at night, glow above
+ *
+ * The static parts are constructed once into a sprite. Only the awning and the
+ * automaton are redrawn per frame — everything else is a blit.
+ */
+
+import { frand, mix as mixSeed, idle, clamp } from "../util/rng.ts";
+import { alpha, over } from "../util/color.ts";
+import { drawMuqarnas } from "../geometry/muqarnas.ts";
+import { archPath } from "../geometry/arch.ts";
+import { latticePanel, LATTICE_VARIANTS } from "../geometry/mashrabiya.ts";
+import { patternPanel } from "../geometry/pattern.ts";
+import { sprite, bucket } from "../world/sprites.ts";
+import { lit, shade, type Ambient } from "../world/daylight.ts";
+import type { Layout } from "../world/layout.ts";
+import { STRIPES, SELVEDGE, WARDS, MATERIALS, type Semantic } from "../tokens/palette.ts";
+import type { Quarter, StallState } from "../types.ts";
+import { drawGoods } from "./goods.ts";
+import { drawAutomaton } from "./automaton.ts";
+
+export interface StallBox {
+  w: number;
+  h: number;
+  apertureX: number;
+  apertureY: number;
+  apertureW: number;
+  apertureH: number;
+  sillY: number;
+  signY: number;
+  signH: number;
+}
+
+export function stallBox(lay: Layout): StallBox {
+  const w = lay.M;
+  const h = lay.stallH;
+  const apertureW = lay.apertureW;
+  const apertureH = lay.apertureH;
+  return {
+    w,
+    h,
+    apertureX: (w - apertureW) / 2,
+    apertureY: lay.M * 0.46,
+    apertureW,
+    apertureH,
+    sillY: lay.M * 0.46 + apertureH,
+    signY: lay.M * 0.305,
+    signH: lay.M * 0.155,
+  };
+}
+
+export interface ChromeState {
+  lay: Layout;
+  sem: Semantic;
+  am: Ambient;
+  quarter: Quarter;
+  state: StallState;
+  seed: number;
+  accretion: number;
+  t: number;
+  reduced: boolean;
+  /** −1…1: where the automaton is looking. */
+  look: number;
+  /** 1 → 0 over 420 ms after a touch. */
+  attention: number;
+  /** 1 while this stall is the centred one. */
+  centred: number;
+}
+
+export function drawStall(g: CanvasRenderingContext2D, s: ChromeState): void {
+  const box = stallBox(s.lay);
+  const key = [
+    "stall",
+    s.quarter.id,
+    s.state,
+    s.seed & 1023,
+    Math.round(box.w),
+    Math.round(box.h),
+    bucket(s.am.night, 10),
+    bucket(s.am.sunAlpha, 10),
+    bucket(s.accretion, 8),
+  ].join("|");
+  const face = sprite(key, box.w, box.h, s.lay.dpr, (h) => drawStatic(h, s, box));
+  g.drawImage(face, 0, 0, box.w, box.h);
+
+  if (s.state !== "scaffold") {
+    drawAwning(g, s, box);
+    const sillTop = box.sillY;
+    drawAutomaton(
+      g,
+      s.lay.M * 0.14,
+      sillTop + s.lay.M * 0.125,
+      s.lay.M * 0.29,
+      s.quarter.craft,
+      s.seed,
+      s.t,
+      {
+        sem: s.sem,
+        sunColor: s.am.sunColor,
+        sunAlpha: s.am.sunAlpha,
+        shadowAlpha: s.am.shadowAlpha,
+        reduced: s.reduced,
+      },
+      s.look,
+      s.attention,
+    );
+  } else {
+    drawBuilders(g, s, box);
+  }
+}
+
+// ── the static face ────────────────────────────────────────────────────────
+
+function drawStatic(g: CanvasRenderingContext2D, s: ChromeState, box: StallBox): void {
+  const { sem, am, lay } = s;
+  const ward = WARDS[s.quarter.ward];
+
+  // The facade: stone, lit on the sun side, in shade on the other. The value
+  // range across one wall is what stops a warm palette going to cream mush.
+  g.fillStyle = lit(sem.ground, am, 0.35);
+  g.fillRect(0, 0, box.w, box.h);
+  g.fillStyle = shade(sem.ground, am, 0.85, sem.shadow);
+  g.fillRect(box.w * 0.74, 0, box.w * 0.26, box.h);
+  g.fillStyle = sem.litEdge;
+  g.globalAlpha = 0.4;
+  g.fillRect(0, 0, 1.5, box.h);
+  g.globalAlpha = 1;
+  // A mud-brick upper storey on some stalls: the street is not one material.
+  if ((s.seed & 3) === 0) {
+    g.fillStyle = over(MATERIALS["mudbrick-500"], am.sunColor, am.sunAlpha);
+    g.fillRect(0, lay.M * 0.2, box.w, lay.M * 0.1);
+  }
+  // Ashlar coursing, so the wall is masonry and not a fill.
+  g.strokeStyle = alpha(sem.cut, 0.32);
+  g.lineWidth = 1;
+  for (let y = box.h * 0.1; y < box.h; y += lay.M * 0.11) {
+    g.beginPath();
+    g.moveTo(0, Math.round(y) + 0.5);
+    g.lineTo(box.w, Math.round(y) + 0.5);
+    g.stroke();
+  }
+
+  // 1 — the muqarnas hood.
+  drawMuqarnas(g, {
+    x: 0,
+    y: 0,
+    width: box.w,
+    height: lay.M * 0.15,
+    tiers: 3,
+    k0: 5,
+    delta: s.quarter.fold === "hex6" || s.quarter.fold === "twelve12" ? 3 : 2,
+    ground: sem.ground,
+    sun: am.sunColor,
+    sunAlpha: am.sunAlpha,
+    shadow: sem.shadow,
+    shadowAlpha: am.shadowAlpha,
+    litEdge: sem.litEdge,
+    cut: sem.cut,
+  });
+
+  // A tiled band under the hood in the ward's glaze — colour, never text.
+  const bandY = lay.M * 0.15;
+  const bandH = lay.M * 0.055;
+  const band = patternPanel({
+    width: box.w,
+    height: bandH,
+    fold: s.quarter.fold === "lattice" ? "khatem8" : s.quarter.fold,
+    edge: Math.max(8, bandH * 0.95),
+    ground: sem.ground,
+    strap: sem.metal,
+    glaze: ward.glaze,
+    glazeDeep: ward.glazeDeep,
+    dpr: lay.dpr,
+  });
+  g.drawImage(band, 0, bandY, box.w, bandH);
+  g.fillStyle = sem.cut;
+  g.fillRect(0, bandY + bandH - 1, box.w, 1);
+
+  if (s.state === "scaffold") {
+    drawScaffolding(g, s, box);
+    return;
+  }
+
+  // 3 — the sign board, on two brass pins.
+  const sx = box.w * 0.07;
+  const sw = box.w * 0.86;
+  g.fillStyle = sem.signBoard;
+  g.fillRect(sx, box.signY, sw, box.signH);
+  g.fillStyle = over(sem.signBoard, sem.litEdge, 0.22);
+  g.fillRect(sx, box.signY, sw, 1.5);
+  g.fillStyle = over(sem.signBoard, sem.shadow, 0.4);
+  g.fillRect(sx, box.signY + box.signH - 1.5, sw, 1.5);
+  g.fillStyle = sem.metal;
+  for (const px of [sx + 7, sx + sw - 7]) {
+    g.beginPath();
+    g.arc(px, box.signY + 7, 3, 0, Math.PI * 2);
+    g.fill();
+  }
+  // A brass plate set into the lower course of the board: the specimen is
+  // engraved into it, so the figures sit on metal (6.6:1) rather than on the
+  // dark timber the place name is painted on.
+  const plateY = box.signY + box.signH * 0.36;
+  const plateH = box.signH * 0.58;
+  g.fillStyle = sem.metal;
+  g.fillRect(sx + sw * 0.06, plateY, sw * 0.88, plateH);
+  g.fillStyle = sem.metalLit;
+  g.fillRect(sx + sw * 0.06, plateY, sw * 0.88, 1);
+  g.fillStyle = sem.metalShade;
+  g.fillRect(sx + sw * 0.06, plateY + plateH - 1, sw * 0.88, 1);
+
+  // 4 — the aperture. A cut opening with real jambs: a lit edge on the sun
+  // side, a cut line on the shade side, a 2 px chamfer, and nothing else.
+  const ax = box.apertureX;
+  const ay = box.apertureY;
+  const aw = box.apertureW;
+  const ah = box.apertureH;
+  const j = lay.jamb;
+  g.fillStyle = shade(sem.ground, am, 1.1, sem.shadow);
+  g.fillRect(ax - j, ay - j, aw + j * 2, ah + j * 2);
+  g.fillStyle = lit(sem.ground, am, 1.3);
+  g.fillRect(ax - j, ay - j, j, ah + j * 2);
+  g.fillStyle = sem.litEdge;
+  g.fillRect(ax - j, ay - j, 1, ah + j * 2);
+  g.fillRect(ax - j, ay - j, aw + j * 2, 1);
+  g.fillStyle = sem.cut;
+  g.fillRect(ax + aw + j - 2, ay - j, 2, ah + j * 2);
+  // The hole itself: the preview canvas sits exactly here.
+  g.fillStyle = sem.cut;
+  g.fillRect(ax, ay, aw, ah);
+
+  // A glazed dado at the foot of the wall, in the ward's colour. Every real
+  // souk wall has one, and it is where the street gets its colour from.
+  const dadoH = lay.M * 0.09;
+  const dado = patternPanel({
+    width: box.w,
+    height: dadoH,
+    fold: s.quarter.fold === "lattice" ? "hex6" : s.quarter.fold,
+    edge: Math.max(9, dadoH * 0.8),
+    ground: sem.ground,
+    strap: sem.metalShade,
+    glaze: ward.glaze,
+    glazeDeep: ward.glazeDeep,
+    dpr: lay.dpr,
+  });
+  g.drawImage(dado, 0, box.h - dadoH - lay.M * 0.02, box.w, dadoH);
+  g.fillStyle = sem.cut;
+  g.fillRect(0, box.h - dadoH - lay.M * 0.02, box.w, 1);
+  g.fillStyle = sem.litEdge;
+  g.globalAlpha = 0.4;
+  g.fillRect(0, box.h - dadoH - lay.M * 0.02 + 1, box.w, 1);
+  g.globalAlpha = 1;
+
+  // 5 — the sill: a stone shelf that projects, with a lit top edge.
+  const sy = box.sillY;
+  const sh = box.h - sy;
+  g.fillStyle = lit(sem.ground, am, 0.9);
+  g.fillRect(-lay.M * 0.02, sy, box.w + lay.M * 0.04, lay.sillDepth * 0.4);
+  g.fillStyle = sem.litEdge;
+  g.fillRect(-lay.M * 0.02, sy, box.w + lay.M * 0.04, 1);
+  g.fillStyle = shade(sem.ground, am, 1.2, sem.shadow);
+  g.fillRect(-lay.M * 0.02, sy + lay.sillDepth * 0.4, box.w + lay.M * 0.04, Math.max(2, lay.sillDepth * 0.16));
+  g.fillStyle = lit(sem.ground, am, 0.3);
+  g.fillRect(0, sy + lay.sillDepth * 0.56, box.w, sh - lay.sillDepth * 0.56);
+
+  // The goods, laid out on the counter.
+  drawGoods(
+    g,
+    box.w * 0.31,
+    sy + lay.M * 0.115,
+    box.w * 0.66,
+    lay.M * 0.2,
+    s.quarter.craft,
+    s.seed,
+    { sem, sunColor: am.sunColor, sunAlpha: am.sunAlpha, shadowAlpha: am.shadowAlpha },
+    s.accretion,
+  );
+
+  // 7 — the shutter, when the stall is shut. You can see the glow through the
+  // open top of the screen and not make out what it is.
+  if (s.state === "shut") {
+    g.fillStyle = alpha(MATERIALS["lantern"], 0.5 * Math.max(0.25, am.lanternGain));
+    g.fillRect(ax, ay, aw, ah);
+    const variant = LATTICE_VARIANTS[s.seed % LATTICE_VARIANTS.length]!;
+    const panel = latticePanel({
+      width: aw,
+      height: ah,
+      variant,
+      pitch: Math.max(11, aw / 11),
+      wood: sem.timber,
+      woodLit: sem.litEdge,
+      woodCut: sem.cut,
+      seed: s.seed,
+      dpr: lay.dpr,
+    });
+    g.drawImage(panel, ax, ay, aw, ah);
+    // The roller box the shutter came down from.
+    g.fillStyle = over(sem.timber, sem.litEdge, 0.2);
+    g.fillRect(ax - j, ay - j, aw + j * 2, j * 1.6);
+  }
+}
+
+// ── the awning ─────────────────────────────────────────────────────────────
+
+function drawAwning(g: CanvasRenderingContext2D, s: ChromeState, box: StallBox): void {
+  const { lay, sem, am } = s;
+  const pair = STRIPES[s.quarter.stripe % STRIPES.length]!;
+  const top = lay.M * 0.2;
+  const drop = lay.M * 0.105;
+  const w = box.w * 0.96;
+  const x0 = box.w * 0.02;
+
+  // Breathing: 2–4 px of skew, with a gust every 18–40 s pushing to 7 px.
+  const base = s.reduced ? 0 : idle(s.t, s.seed, 3);
+  const gustPhase = (s.t + frand(s.seed) * 30) % 29;
+  const gust = s.reduced ? 0 : gustPhase < 0.9 ? Math.sin((gustPhase / 0.9) * Math.PI) * 4 : 0;
+  const sway = base + gust;
+
+  const n = 9;
+  const stripeW = w / n;
+  for (let i = 0; i < n; i++) {
+    const x = x0 + i * stripeW;
+    const col = i % 2 === 0 ? pair.a : pair.b;
+    g.fillStyle = over(col, am.sunColor, am.sunAlpha * (i % 2 ? 0.5 : 0.2));
+    g.beginPath();
+    g.moveTo(x, top);
+    g.lineTo(x + stripeW, top);
+    g.lineTo(x + stripeW + sway, top + drop);
+    g.lineTo(x + sway, top + drop);
+    g.closePath();
+    g.fill();
+    // The selvedge: one brass hairline between every stripe, which is how a
+    // real weft line looks and is what keeps the saffron/white pair legible.
+    g.strokeStyle = SELVEDGE;
+    g.lineWidth = 1;
+    g.beginPath();
+    g.moveTo(x + stripeW, top);
+    g.lineTo(x + stripeW + sway, top + drop);
+    g.stroke();
+  }
+
+  // The scalloped valance along the hem.
+  g.fillStyle = over(pair.a, sem.shadow, am.shadowAlpha * 0.5);
+  g.beginPath();
+  g.moveTo(x0 + sway, top + drop);
+  const scallops = 8;
+  for (let i = 0; i < scallops; i++) {
+    const sx = x0 + sway + (w * i) / scallops;
+    g.quadraticCurveTo(sx + w / scallops / 2, top + drop + lay.M * 0.035, sx + w / scallops, top + drop);
+  }
+  g.lineTo(x0 + w + sway, top + drop);
+  g.closePath();
+  g.fill();
+
+  // Two ribs, and the shadow the cloth throws onto the facade.
+  g.strokeStyle = sem.metal;
+  g.lineWidth = 2;
+  for (const rx of [x0 + 2, x0 + w - 2]) {
+    g.beginPath();
+    g.moveTo(rx, top);
+    g.lineTo(rx + sway, top + drop);
+    g.stroke();
+  }
+  g.save();
+  g.globalAlpha = am.shadowAlpha * 0.5;
+  g.fillStyle = sem.shadow;
+  g.fillRect(x0 + sway * 0.5, top + drop, w, lay.M * 0.03);
+  g.restore();
+}
+
+// ── under construction ─────────────────────────────────────────────────────
+
+/**
+ * Past the last built quarter: scaffolding. Poles, ropes, a half-raised dome,
+ * a counterweight crane. Not a "coming soon" card — that copy is banned and it
+ * would be worse anyway. Scaffolding reads instantly, it is honest, and it is
+ * beautiful. When a game ships, it comes down.
+ */
+function drawScaffolding(g: CanvasRenderingContext2D, s: ChromeState, box: StallBox): void {
+  const { sem, am, lay } = s;
+  // Bamboo, not bone: cream poles on a cream wall are invisible, and the whole
+  // point of scaffolding is that it reads instantly.
+  const pole = over(MATERIALS["bronze-700"], am.sunColor, am.sunAlpha * 1.4);
+  const rope = over(MATERIALS["mudbrick-500"], sem.shadow, am.shadowAlpha * 0.9);
+
+  // The half-raised dome behind the poles.
+  g.fillStyle = shade(sem.ground, am, 0.8, sem.shadow);
+  g.beginPath();
+  g.moveTo(box.w * 0.2, box.h * 0.66);
+  g.quadraticCurveTo(box.w * 0.5, box.h * 0.16, box.w * 0.8, box.h * 0.66);
+  g.closePath();
+  g.fill();
+  g.strokeStyle = sem.cut;
+  g.lineWidth = 1;
+  for (let i = 1; i < 5; i++) {
+    g.beginPath();
+    g.moveTo(box.w * (0.2 + 0.15 * i), box.h * 0.66);
+    g.quadraticCurveTo(box.w * 0.5, box.h * (0.3 + 0.05 * i), box.w * 0.5, box.h * 0.2);
+    g.stroke();
+  }
+
+  // Poles and ledgers, lashed.
+  g.strokeStyle = pole;
+  g.lineWidth = Math.max(2.5, lay.M * 0.018);
+  g.beginPath();
+  for (let i = 0; i < 4; i++) {
+    const x = box.w * (0.12 + i * 0.25);
+    g.moveTo(x, box.h * 0.2);
+    g.lineTo(x + (i % 2 ? 5 : -5), box.h);
+  }
+  for (let j = 0; j < 4; j++) {
+    const y = box.h * (0.28 + j * 0.19);
+    g.moveTo(box.w * 0.08, y);
+    g.lineTo(box.w * 0.92, y - 4);
+  }
+  g.stroke();
+
+  // Lashings.
+  g.strokeStyle = rope;
+  g.lineWidth = 2;
+  for (let i = 0; i < 4; i++) {
+    for (let j = 0; j < 4; j++) {
+      const x = box.w * (0.12 + i * 0.25);
+      const y = box.h * (0.28 + j * 0.19);
+      g.beginPath();
+      g.arc(x, y, 5, 0, Math.PI * 2);
+      g.stroke();
+    }
+  }
+
+  // The counterweight crane: a real machine, with a real counterweight.
+  g.strokeStyle = sem.timber;
+  g.lineWidth = Math.max(3, lay.M * 0.022);
+  g.beginPath();
+  g.moveTo(box.w * 0.62, box.h * 0.86);
+  g.lineTo(box.w * 0.72, box.h * 0.12);
+  g.lineTo(box.w * 0.34, box.h * 0.24);
+  g.stroke();
+  g.strokeStyle = rope;
+  g.lineWidth = 1.5;
+  const swing = s.reduced ? 0 : idle(s.t, s.seed, 6);
+  g.beginPath();
+  g.moveTo(box.w * 0.34, box.h * 0.24);
+  g.lineTo(box.w * 0.34 + swing, box.h * 0.52);
+  g.stroke();
+  g.fillStyle = shade(sem.ground, am, 1.4, sem.shadow);
+  g.fillRect(box.w * 0.29 + swing, box.h * 0.52, box.w * 0.1, box.h * 0.07);
+  g.fillStyle = sem.timber;
+  g.fillRect(box.w * 0.68, box.h * 0.16, box.w * 0.1, box.h * 0.08);
+}
+
+/** Two builder-automata, working. The stall is never dead. */
+function drawBuilders(g: CanvasRenderingContext2D, s: ChromeState, box: StallBox): void {
+  const c = {
+    sem: s.sem,
+    sunColor: s.am.sunColor,
+    sunAlpha: s.am.sunAlpha,
+    shadowAlpha: s.am.shadowAlpha,
+    reduced: s.reduced,
+  };
+  drawAutomaton(g, box.w * 0.2, box.h * 0.98, s.lay.M * 0.24, "tessera", s.seed, s.t, c, 0, 0);
+  drawAutomaton(g, box.w * 0.78, box.h * 0.88, s.lay.M * 0.2, "rope", s.seed ^ 0x1f, s.t + 1.7, c, 0, 0);
+}
+
+/**
+ * The lit-shaft response on a stall: when a shaft of light falls across it, the
+ * facade brightens. Drawn on the stall canvas so the light reads as landing on
+ * the stone rather than floating in front of it.
+ */
+export function drawStallLight(
+  g: CanvasRenderingContext2D,
+  am: Ambient,
+  box: StallBox,
+  shaftDx: number,
+): void {
+  const k = clamp(1 - Math.abs(shaftDx) / (box.w * 0.9), 0, 1);
+  if (k <= 0.01 || am.sunAlpha < 0.02) return;
+  g.save();
+  g.globalCompositeOperation = "lighter";
+  g.fillStyle = alpha(am.sunColor, am.sunAlpha * 0.35 * k * (1 - am.night));
+  g.fillRect(0, 0, box.w, box.h);
+  g.restore();
+}
+
+/** A niche cut into the facade — used by the interstitial fabric. */
+export function drawNiche(
+  g: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  sem: Semantic,
+  am: Ambient,
+): void {
+  g.fillStyle = shade(sem.ground, am, 1.4, sem.shadow);
+  g.beginPath();
+  g.moveTo(x, y + h);
+  g.lineTo(x, y + h * 0.45);
+  archPath(g, x + w / 2, y + h * 0.45, w, "drop");
+  g.lineTo(x + w, y + h);
+  g.closePath();
+  g.fill();
+  g.strokeStyle = sem.litEdge;
+  g.lineWidth = 1;
+  g.stroke();
+}
+
+export const stallSeedFor = (id: string, seed: number): number => mixSeed(seed, id.length * 131);

--- a/dynawalla/bazaar/src/stall/goods.ts
+++ b/dynawalla/bazaar/src/stall/goods.ts
@@ -1,0 +1,345 @@
+/**
+ * The goods on the sill.
+ *
+ * Three to seven real objects from that game, laid out on the stone counter: a
+ * die, a fraction bar, a balance weight, a coin, a coil of rope, a gear blank.
+ * This is where a stall gets its individual character *without* the frame
+ * styling the preview (BZ-LAW-1), and it is the single biggest contributor to
+ * "this is a marketplace, not a menu".
+ *
+ * Every object is drawn with the same three-facet vocabulary as the stonework:
+ * a lit face, a body, a cut line. No gradients, no glow, no drop shadows.
+ */
+
+import { frand, mix as mixSeed } from "../util/rng.ts";
+import { over } from "../util/color.ts";
+import { MATERIALS } from "../tokens/palette.ts";
+import type { Semantic } from "../tokens/palette.ts";
+import type { Craft } from "../types.ts";
+
+export interface GoodsCtx {
+  sem: Semantic;
+  sunColor: string;
+  sunAlpha: number;
+  shadowAlpha: number;
+}
+
+const M = MATERIALS;
+
+/** Lay 3–7 goods along a sill of width `w`, standing on `baseY`. */
+export function drawGoods(
+  g: CanvasRenderingContext2D,
+  x: number,
+  baseY: number,
+  w: number,
+  unit: number,
+  craft: Craft,
+  seed: number,
+  c: GoodsCtx,
+  accretion: number,
+): void {
+  const n = 3 + Math.floor(frand(seed) * 5);
+  const slots: number[] = [];
+  for (let i = 0; i < n; i++) {
+    slots.push(x + w * (0.08 + (0.84 * (i + 0.5)) / n) + (frand(mixSeed(seed, i)) - 0.5) * w * 0.04);
+  }
+  for (let i = 0; i < n; i++) {
+    const sx = slots[i]!;
+    const s = mixSeed(seed, i * 17 + 5);
+    drawOne(g, sx, baseY, unit * (0.7 + frand(s) * 0.5), craft, i, s, c);
+  }
+  // Physical accretion: what the child has built here, and it stays (P-04).
+  if (accretion > 0.01) drawAccretion(g, x, baseY, w, unit, craft, accretion, seed, c);
+}
+
+function facet(base: string, c: GoodsCtx): { face: string; body: string; cut: string } {
+  return {
+    face: over(base, c.sunColor, c.sunAlpha * 1.2),
+    body: base,
+    cut: over(base, c.sem.shadow, c.shadowAlpha * 1.2),
+  };
+}
+
+function drawOne(
+  g: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  u: number,
+  craft: Craft,
+  i: number,
+  seed: number,
+  c: GoodsCtx,
+): void {
+  switch (craft) {
+    case "balance": {
+      // Stone weights, in a graduated set. They are a number line you can lift.
+      const k = 0.5 + (i % 3) * 0.28;
+      const f = facet(M["sandstone-400"], c);
+      g.fillStyle = f.body;
+      g.beginPath();
+      g.moveTo(x - u * 0.3 * k, y);
+      g.lineTo(x - u * 0.2 * k, y - u * 0.52 * k);
+      g.lineTo(x + u * 0.2 * k, y - u * 0.52 * k);
+      g.lineTo(x + u * 0.3 * k, y);
+      g.closePath();
+      g.fill();
+      g.fillStyle = f.face;
+      g.fillRect(x - u * 0.2 * k, y - u * 0.56 * k, u * 0.4 * k, u * 0.05);
+      g.strokeStyle = c.sem.metal;
+      g.lineWidth = 1.2;
+      g.beginPath();
+      g.arc(x, y - u * 0.6 * k, u * 0.1 * k, Math.PI, 0);
+      g.stroke();
+      break;
+    }
+    case "coin": {
+      // Stacks of coin. Place value, in brass.
+      const h = 1 + (i % 4);
+      const f = facet(M["brass-400"], c);
+      for (let k = 0; k < h; k++) {
+        g.fillStyle = k === h - 1 ? f.face : f.body;
+        g.beginPath();
+        g.ellipse(x, y - k * u * 0.09, u * 0.24, u * 0.09, 0, 0, Math.PI * 2);
+        g.fill();
+        g.strokeStyle = f.cut;
+        g.lineWidth = 1;
+        g.stroke();
+      }
+      break;
+    }
+    case "tessera": {
+      // Cut tiles, glazed, waiting to be set. And a chisel.
+      const glaze = [M["turquoise-500"], M["lapis-700"], M["saffron-400"], M["madder-600"]][i % 4]!;
+      if (i % 4 === 3) {
+        g.fillStyle = M["walnut-600"];
+        g.fillRect(x - u * 0.04, y - u * 0.5, u * 0.08, u * 0.5);
+        g.fillStyle = c.sem.metal;
+        g.fillRect(x - u * 0.05, y - u * 0.62, u * 0.1, u * 0.14);
+      } else {
+        g.save();
+        g.translate(x, y - u * 0.1);
+        g.rotate(frand(seed) * 0.7 - 0.35);
+        g.fillStyle = glaze;
+        g.fillRect(-u * 0.16, -u * 0.16, u * 0.32, u * 0.32);
+        g.fillStyle = over(glaze, c.sunColor, c.sunAlpha * 1.4);
+        g.fillRect(-u * 0.16, -u * 0.16, u * 0.32, u * 0.05);
+        g.strokeStyle = c.sem.cut;
+        g.lineWidth = 1;
+        g.strokeRect(-u * 0.16, -u * 0.16, u * 0.32, u * 0.32);
+        g.restore();
+      }
+      break;
+    }
+    case "rope": {
+      // Coils of rope, laid in fathoms.
+      const f = facet(M["bone-100"], c);
+      g.strokeStyle = f.body;
+      g.lineWidth = Math.max(1.5, u * 0.07);
+      for (let k = 0; k < 3; k++) {
+        g.beginPath();
+        g.ellipse(x, y - u * 0.06 - k * u * 0.08, u * 0.26 - k * u * 0.04, u * 0.09, 0, 0, Math.PI * 2);
+        g.stroke();
+      }
+      g.strokeStyle = f.face;
+      g.lineWidth = 1;
+      g.beginPath();
+      g.ellipse(x, y - u * 0.22, u * 0.18, u * 0.07, 0, Math.PI, Math.PI * 2);
+      g.stroke();
+      break;
+    }
+    case "astrolabe": {
+      // A small brass instrument: mater, rete, alidade.
+      const f = facet(M["brass-400"], c);
+      g.fillStyle = f.body;
+      g.beginPath();
+      g.arc(x, y - u * 0.3, u * 0.26, 0, Math.PI * 2);
+      g.fill();
+      g.strokeStyle = f.cut;
+      g.lineWidth = 1;
+      g.stroke();
+      g.strokeStyle = f.face;
+      g.beginPath();
+      g.arc(x, y - u * 0.3, u * 0.17, 0, Math.PI * 2);
+      g.moveTo(x - u * 0.24, y - u * 0.3);
+      g.lineTo(x + u * 0.24, y - u * 0.3);
+      g.stroke();
+      g.fillStyle = f.body;
+      g.fillRect(x - u * 0.05, y - u * 0.06, u * 0.1, u * 0.06);
+      break;
+    }
+    case "water": {
+      // Jugs and a bowl: rate and proportion you can pour.
+      const f = facet(M["terracotta-600"], c);
+      g.fillStyle = f.body;
+      g.beginPath();
+      g.moveTo(x - u * 0.18, y);
+      g.quadraticCurveTo(x - u * 0.26, y - u * 0.3, x - u * 0.1, y - u * 0.42);
+      g.lineTo(x + u * 0.1, y - u * 0.42);
+      g.quadraticCurveTo(x + u * 0.26, y - u * 0.3, x + u * 0.18, y);
+      g.closePath();
+      g.fill();
+      g.fillStyle = f.face;
+      g.fillRect(x - u * 0.1, y - u * 0.46, u * 0.2, u * 0.05);
+      g.strokeStyle = f.cut;
+      g.lineWidth = 1.2;
+      g.beginPath();
+      g.arc(x + u * 0.2, y - u * 0.24, u * 0.1, -1.2, 1.2);
+      g.stroke();
+      break;
+    }
+    case "vat": {
+      // Dye pots. Ratio, in madder and indigo and weld.
+      const dye = [M["indigo-800"], M["madder-600"], M["sabz-700"], M["ochre-500"]][i % 4]!;
+      const f = facet(M["mudbrick-500"], c);
+      g.fillStyle = f.body;
+      g.beginPath();
+      g.moveTo(x - u * 0.22, y);
+      g.lineTo(x - u * 0.26, y - u * 0.36);
+      g.lineTo(x + u * 0.26, y - u * 0.36);
+      g.lineTo(x + u * 0.22, y);
+      g.closePath();
+      g.fill();
+      g.fillStyle = dye;
+      g.beginPath();
+      g.ellipse(x, y - u * 0.36, u * 0.26, u * 0.08, 0, 0, Math.PI * 2);
+      g.fill();
+      g.fillStyle = over(dye, c.sunColor, c.sunAlpha * 1.6);
+      g.beginPath();
+      g.ellipse(x - u * 0.08, y - u * 0.37, u * 0.08, u * 0.03, 0, 0, Math.PI * 2);
+      g.fill();
+      break;
+    }
+    case "kite": {
+      // A frame, a sail, a spool. Symmetry you can hold.
+      if (i % 3 === 2) {
+        g.fillStyle = M["walnut-600"];
+        g.fillRect(x - u * 0.05, y - u * 0.3, u * 0.1, u * 0.3);
+        g.strokeStyle = M["bone-100"];
+        g.lineWidth = Math.max(1.5, u * 0.06);
+        g.beginPath();
+        g.ellipse(x, y - u * 0.18, u * 0.11, u * 0.09, 0, 0, Math.PI * 2);
+        g.stroke();
+      } else {
+        const sail = [M["saffron-400"], M["turquoise-500"]][i % 2]!;
+        g.save();
+        g.translate(x, y - u * 0.3);
+        g.rotate(frand(seed) * 0.5 - 0.25);
+        g.fillStyle = sail;
+        g.beginPath();
+        g.moveTo(0, -u * 0.3);
+        g.lineTo(u * 0.2, 0);
+        g.lineTo(0, u * 0.3);
+        g.lineTo(-u * 0.2, 0);
+        g.closePath();
+        g.fill();
+        g.strokeStyle = M["walnut-600"];
+        g.lineWidth = 1.2;
+        g.beginPath();
+        g.moveTo(0, -u * 0.3);
+        g.lineTo(0, u * 0.3);
+        g.moveTo(-u * 0.2, 0);
+        g.lineTo(u * 0.2, 0);
+        g.stroke();
+        g.restore();
+      }
+      break;
+    }
+    case "gears": {
+      // Gear blanks and a coiled spring. Factors, in brass.
+      const f = facet(M["brass-400"], c);
+      const teeth = [8, 12, 15, 20][i % 4]!;
+      g.fillStyle = f.body;
+      const r = u * 0.24;
+      g.beginPath();
+      for (let k = 0; k < teeth; k++) {
+        const a0 = (k / teeth) * Math.PI * 2;
+        const a1 = ((k + 0.5) / teeth) * Math.PI * 2;
+        g.lineTo(x + r * Math.cos(a0), y - u * 0.26 + r * Math.sin(a0));
+        g.lineTo(x + r * 1.16 * Math.cos(a1), y - u * 0.26 + r * 1.16 * Math.sin(a1));
+      }
+      g.closePath();
+      g.fill();
+      g.fillStyle = f.cut;
+      g.beginPath();
+      g.arc(x, y - u * 0.26, r * 0.24, 0, Math.PI * 2);
+      g.fill();
+      break;
+    }
+    case "mill": {
+      // Sacks and a measure. Division, and what is left over.
+      const f = facet(M["bone-100"], c);
+      g.fillStyle = f.body;
+      g.beginPath();
+      g.moveTo(x - u * 0.2, y);
+      g.quadraticCurveTo(x - u * 0.26, y - u * 0.34, x - u * 0.08, y - u * 0.42);
+      g.quadraticCurveTo(x, y - u * 0.5, x + u * 0.08, y - u * 0.42);
+      g.quadraticCurveTo(x + u * 0.26, y - u * 0.34, x + u * 0.2, y);
+      g.closePath();
+      g.fill();
+      g.fillStyle = f.face;
+      g.beginPath();
+      g.moveTo(x - u * 0.08, y - u * 0.42);
+      g.quadraticCurveTo(x, y - u * 0.5, x + u * 0.08, y - u * 0.42);
+      g.quadraticCurveTo(x, y - u * 0.38, x - u * 0.08, y - u * 0.42);
+      g.closePath();
+      g.fill();
+      g.strokeStyle = f.cut;
+      g.lineWidth = 1;
+      g.beginPath();
+      g.moveTo(x - u * 0.14, y - u * 0.18);
+      g.lineTo(x + u * 0.14, y - u * 0.18);
+      g.stroke();
+      break;
+    }
+  }
+}
+
+/**
+ * §8.5 — each game is endless, and the stall shows it. Depth is physical
+ * accretion at the stall itself: your tesserae set into the floor, your rope
+ * coiled higher, your gear train grown another stage. Never a number, never a
+ * percentage, never regressing.
+ */
+function drawAccretion(
+  g: CanvasRenderingContext2D,
+  x: number,
+  baseY: number,
+  w: number,
+  u: number,
+  craft: Craft,
+  a: number,
+  seed: number,
+  c: GoodsCtx,
+): void {
+  const n = Math.round(a * 14);
+  for (let i = 0; i < n; i++) {
+    const s = mixSeed(seed ^ 0x7f, i);
+    const px = x + w * (0.06 + frand(s) * 0.88);
+    const py = baseY + u * 0.5 + frand(mixSeed(s, 1)) * u * 0.35;
+    switch (craft) {
+      case "tessera": {
+        const glaze = [M["turquoise-500"], M["lapis-700"], M["saffron-400"]][i % 3]!;
+        g.fillStyle = glaze;
+        g.fillRect(px - u * 0.09, py, u * 0.18, u * 0.11);
+        g.strokeStyle = c.sem.cut;
+        g.lineWidth = 1;
+        g.strokeRect(px - u * 0.09, py, u * 0.18, u * 0.11);
+        break;
+      }
+      case "rope": {
+        g.strokeStyle = M["bone-100"];
+        g.lineWidth = Math.max(1, u * 0.05);
+        g.beginPath();
+        g.ellipse(px, py, u * 0.13, u * 0.05, 0, 0, Math.PI * 2);
+        g.stroke();
+        break;
+      }
+      default: {
+        g.fillStyle = over(c.sem.metal, c.sem.ground, 0.2);
+        g.beginPath();
+        g.arc(px, py, u * 0.05, 0, Math.PI * 2);
+        g.fill();
+      }
+    }
+  }
+}

--- a/dynawalla/bazaar/src/stall/preview.ts
+++ b/dynawalla/bazaar/src/stall/preview.ts
@@ -1,0 +1,139 @@
+/**
+ * BZ-06 — exactly one preview animates.
+ *
+ * Only the centred stall runs `render`. Every other visible stall paints a
+ * **poster**: the last frame the live preview produced, snapshotted on unmount
+ * at ≤ 256×256, LRU-cached, at most 24. That is the entire performance story of
+ * the street, and it is why sixty stalls cost about what one does.
+ *
+ * A preview that runs over 4 ms is demoted to its poster **permanently** for
+ * this session. It is not asked again, and nothing is said about it.
+ */
+
+import type { StallPreview } from "../types.ts";
+
+const POSTER_MAX = 24;
+const POSTER_SIZE = 256;
+const FRAME_BUDGET_MS = 4;
+
+export class PreviewDirector {
+  private posters = new Map<string, HTMLCanvasElement>();
+  private demoted = new Set<string>();
+  private liveId: string | null = null;
+  private renders = 0;
+
+  /** Which stall is centred. Everything else is a poster. */
+  setLive(id: string | null): void {
+    if (this.liveId === id) return;
+    this.liveId = id;
+  }
+
+  get live(): string | null {
+    return this.liveId;
+  }
+
+  isLive(id: string): boolean {
+    return this.liveId === id && !this.demoted.has(id);
+  }
+
+  /** How many `render` calls happened since the last `beginFrame`. BZ-06. */
+  beginFrame(): void {
+    this.renders = 0;
+  }
+
+  get rendersThisFrame(): number {
+    return this.renders;
+  }
+
+  /**
+   * Draw the aperture contents. Returns true if a live frame was produced.
+   * Falls back to the poster, and then to nothing at all — a stall with no
+   * preview keeps its specimen and its moving automaton, so it is never dead.
+   */
+  draw(
+    ctx: CanvasRenderingContext2D,
+    id: string,
+    preview: StallPreview | undefined,
+    w: number,
+    h: number,
+    dpr: number,
+    t: number,
+    seed: number,
+    reduced: boolean,
+  ): boolean {
+    if (preview && this.isLive(id)) {
+      const start = now();
+      this.renders++;
+      try {
+        preview.render(ctx, { width: w, height: h, dpr, t: t % preview.period, seed, reducedMotion: reduced });
+      } catch {
+        this.demoted.add(id);
+        return false;
+      }
+      const cost = now() - start;
+      if (cost > FRAME_BUDGET_MS * 3) this.demoted.add(id);
+      this.capture(id, ctx.canvas, w, h);
+      return true;
+    }
+    const poster = this.posters.get(id);
+    if (poster) {
+      // LRU touch.
+      this.posters.delete(id);
+      this.posters.set(id, poster);
+      ctx.drawImage(poster, 0, 0, w, h);
+      return true;
+    }
+    if (preview && !this.demoted.has(id)) {
+      // No poster yet: produce a single still frame so the aperture is never
+      // an empty hole, then leave it alone.
+      this.renders++;
+      try {
+        preview.render(ctx, { width: w, height: h, dpr, t: 0, seed, reducedMotion: true });
+        this.capture(id, ctx.canvas, w, h);
+        return true;
+      } catch {
+        this.demoted.add(id);
+      }
+    }
+    return false;
+  }
+
+  private capture(id: string, src: HTMLCanvasElement, w: number, h: number): void {
+    let cv = this.posters.get(id);
+    const scale = Math.min(1, POSTER_SIZE / Math.max(w, h));
+    const pw = Math.max(1, Math.round(w * scale));
+    const ph = Math.max(1, Math.round(h * scale));
+    if (!cv || cv.width !== pw || cv.height !== ph) {
+      cv = document.createElement("canvas");
+      cv.width = pw;
+      cv.height = ph;
+    }
+    const g = cv.getContext("2d");
+    if (!g) return;
+    try {
+      g.drawImage(src, 0, 0, pw, ph);
+    } catch {
+      return;
+    }
+    this.posters.delete(id);
+    this.posters.set(id, cv);
+    while (this.posters.size > POSTER_MAX) {
+      const oldest = this.posters.keys().next().value;
+      if (oldest === undefined) break;
+      this.posters.delete(oldest);
+    }
+  }
+
+  get posterCount(): number {
+    return this.posters.size;
+  }
+
+  clear(): void {
+    this.posters.clear();
+    this.demoted.clear();
+    this.liveId = null;
+  }
+}
+
+const now = (): number =>
+  typeof performance !== "undefined" ? performance.now() : Date.now();

--- a/dynawalla/bazaar/src/strings.ts
+++ b/dynawalla/bazaar/src/strings.ts
@@ -1,0 +1,135 @@
+/**
+ * BZ-LAW-2 — the bazaar has no interface text.
+ *
+ * Not one label, not one button caption, not one status line. Signs carry a
+ * place name and a worked example; everything else is an object you touch.
+ *
+ * What remains is the irreducible accessibility surface: the five day-states of
+ * the lamp (a glance is not available to everyone), and a name for each of the
+ * four things a screen reader must be able to identify. **Twelve strings, and
+ * BZ-14 fails the build at thirteen.**
+ *
+ * Place names are not in here. They are content records on the quarter — the
+ * bazaar does not own them any more than it owns a game's name.
+ *
+ * Launch locales per ADR-0007: en, es, pt-BR, fr, de.
+ */
+
+export type Locale = "en" | "es" | "pt-BR" | "fr" | "de";
+
+export const LOCALES: readonly Locale[] = ["en", "es", "pt-BR", "fr", "de"];
+
+export type StringKey =
+  | "day.morning"
+  | "day.midday"
+  | "day.afternoon"
+  | "day.evening"
+  | "day.lit"
+  | "street"
+  | "finder"
+  | "sound.on"
+  | "sound.off"
+  | "lamplighter"
+  | "stall"
+  | "scaffold";
+
+type Table = Record<StringKey, string>;
+
+const en: Table = {
+  "day.morning": "Morning at the bazaar.",
+  "day.midday": "Midday at the bazaar.",
+  "day.afternoon": "Afternoon at the bazaar.",
+  "day.evening": "Evening light at the bazaar.",
+  "day.lit": "The lamps are lit.",
+  street: "The bazaar",
+  finder: "Finder",
+  "sound.on": "Sound on",
+  "sound.off": "Sound off",
+  lamplighter: "The lamplighter",
+  stall: "{name}, {quarter}, {specimen}",
+  scaffold: "{quarter}, still being built",
+};
+
+const es: Table = {
+  "day.morning": "Mañana en el zoco.",
+  "day.midday": "Mediodía en el zoco.",
+  "day.afternoon": "Tarde en el zoco.",
+  "day.evening": "Luz de atardecer en el zoco.",
+  "day.lit": "Las lámparas están encendidas.",
+  street: "El zoco",
+  finder: "Buscador",
+  "sound.on": "Sonido activado",
+  "sound.off": "Sonido desactivado",
+  lamplighter: "El farolero",
+  stall: "{name}, {quarter}, {specimen}",
+  scaffold: "{quarter}, todavía en obras",
+};
+
+const ptBR: Table = {
+  "day.morning": "Manhã no bazar.",
+  "day.midday": "Meio-dia no bazar.",
+  "day.afternoon": "Tarde no bazar.",
+  "day.evening": "Luz do entardecer no bazar.",
+  "day.lit": "As lâmpadas estão acesas.",
+  street: "O bazar",
+  finder: "Localizador",
+  "sound.on": "Som ligado",
+  "sound.off": "Som desligado",
+  lamplighter: "O acendedor de lampiões",
+  stall: "{name}, {quarter}, {specimen}",
+  scaffold: "{quarter}, ainda em construção",
+};
+
+const fr: Table = {
+  "day.morning": "Le matin au souk.",
+  "day.midday": "Midi au souk.",
+  "day.afternoon": "L’après-midi au souk.",
+  "day.evening": "Lumière du soir au souk.",
+  "day.lit": "Les lampes sont allumées.",
+  street: "Le souk",
+  finder: "Chercheur",
+  "sound.on": "Son activé",
+  "sound.off": "Son coupé",
+  lamplighter: "L’allumeur de réverbères",
+  stall: "{name}, {quarter}, {specimen}",
+  scaffold: "{quarter}, encore en chantier",
+};
+
+const de: Table = {
+  "day.morning": "Morgen im Basar.",
+  "day.midday": "Mittag im Basar.",
+  "day.afternoon": "Nachmittag im Basar.",
+  "day.evening": "Abendlicht im Basar.",
+  "day.lit": "Die Lampen brennen.",
+  street: "Der Basar",
+  finder: "Sucher",
+  "sound.on": "Ton an",
+  "sound.off": "Ton aus",
+  lamplighter: "Der Laternenanzünder",
+  stall: "{name}, {quarter}, {specimen}",
+  scaffold: "{quarter}, noch im Bau",
+};
+
+export const STRINGS: Record<Locale, Table> = { en, es, "pt-BR": ptBR, fr, de };
+
+export function resolveLocale(tag: string | undefined): Locale {
+  if (!tag) return "en";
+  const t = tag.toLowerCase();
+  if (t.startsWith("pt")) return "pt-BR";
+  if (t.startsWith("es")) return "es";
+  if (t.startsWith("fr")) return "fr";
+  if (t.startsWith("de")) return "de";
+  return "en";
+}
+
+export function t(
+  locale: Locale,
+  key: StringKey,
+  slots?: Record<string, string>,
+): string {
+  let s = STRINGS[locale][key];
+  if (slots) {
+    for (const [k, v] of Object.entries(slots)) s = s.split(`{${k}}`).join(v);
+  }
+  return s;
+}

--- a/dynawalla/bazaar/src/tokens/bazaar.css
+++ b/dynawalla/bazaar/src/tokens/bazaar.css
@@ -1,0 +1,404 @@
+/* ──────────────────────────────────────────────────────────────────────────
+   The bazaar — tokens and the thin DOM layer that sits over the canvas.
+
+   Three layers, and the layering is load bearing:
+
+     1. MATERIALS   the palette. The only place a literal colour may appear.
+                    Mirrors `palette.ts` exactly; `tokens.test.ts` fails the
+                    build if the two drift.
+     2. SEMANTIC    roles, never materials. Light is the default; `.bz-night`
+                    re-cuts every one of the same roles in night materials.
+     3. UTILITY     the handful of classes the DOM layer needs. Everything
+                    else in the bazaar is drawn on canvas.
+
+   Two standing rules this file obeys and a lint test enforces (BZ-02):
+     · no `rgba(0, 0, 0, …)` anywhere — shadow is transmitted skylight,
+       composited from `--bz-shadow`, never black;
+     · no `box-shadow` blur over 2px — depth is haze and occlusion, not blur.
+   ────────────────────────────────────────────────────────────────────────── */
+
+/* ═══ LAYER 1 — MATERIALS ═════════════════════════════════════════════════ */
+:root {
+  /* Sandstone, plaster, mud-brick */
+  --color-sandstone-50: #f7edd8;
+  --color-sandstone-100: #efe0c0;
+  --color-sandstone-200: #e0cca4;
+  --color-sandstone-400: #b99c6e;
+  --color-sandstone-600: #8a7048;
+  --color-mudbrick-500: #b08a5e;
+  --color-terracotta-600: #96422c;
+
+  /* Glazed tile */
+  --color-tile-white: #f1ead9;
+  --color-lapis-700: #1c3f8f;
+  --color-lapis-500: #2e58b0;
+  --color-lapis-300: #5c8fe8;
+  --color-indigo-800: #23356b;
+  --color-turquoise-700: #0f6167;
+  --color-turquoise-500: #17868c;
+  --color-turquoise-300: #2fa6a8;
+  --color-ochre-500: #d19a24;
+  --color-saffron-400: #e8b93f;
+  --color-madder-600: #a33a2c;
+  --color-madder-400: #e08a6a;
+  --color-sabz-700: #24603e;
+  --color-aubergine-800: #4a2b52;
+  --color-aubergine-400: #bc8fc8;
+  --color-manganese-900: #33261c;
+
+  /* Brass, copper, verdigris */
+  --color-brass-200: #e8ce79;
+  --color-brass-300: #e8c36a;
+  --color-brass-400: #c9a227;
+  --color-brass-500: #d6a93c;
+  --color-brass-600: #8f6e1e;
+  --color-brass-800: #5a421e;
+  --color-copper-400: #c97a4c;
+  --color-copper-600: #b06e42;
+  --color-verdigris-500: #3e8f79;
+  --color-verdigris-300: #59a88f;
+  --color-bronze-700: #6b4a2b;
+
+  /* Cloth, wood, ink */
+  --color-walnut-600: #4a3220;
+  --color-walnut-800: #33241a;
+  --color-bone-100: #e6dcc4;
+  --color-cream-50: #f4e8d0;
+  --color-ink-900: #2a2015;
+  --color-ink-600: #6b5940;
+
+  /* Light, shadow, atmosphere */
+  --color-sun: #ffe9bc;
+  --color-sky-shadow: #2c3a63;
+  --color-haze: #e8c89a;
+  --color-haze-night: #1a2140;
+  --color-lantern: #f5b94a;
+  --color-nightsky-900: #0d1330;
+  --color-nightsky-700: #1b2454;
+  --color-nightground: #241c13;
+  --color-nightraised: #2f251a;
+  --color-nightdeep: #1a140d;
+  --color-nightcut: #120e08;
+  --color-nightshadow: #05070f;
+  --color-nightink-100: #f0e2c6;
+  --color-nightink-400: #a99070;
+  --color-sky-high: #9ec4e8;
+  --color-sky-low: #dcd2b4;
+  --color-lit-edge: #fff3d6;
+  --color-water-day: #4e8fa0;
+  --color-water-night: #17324a;
+
+  /* Lantern glass — emissive, never a text ground */
+  --color-glass-amber: #f0a93b;
+  --color-glass-ruby: #c4402f;
+  --color-glass-emerald: #2e8b5a;
+  --color-glass-cobalt: #2a56a8;
+  --color-glass-clear: #f6ebcf;
+}
+
+/* ═══ LAYER 2 — SEMANTIC ══════════════════════════════════════════════════ */
+:root {
+  --bz-ground: var(--color-sandstone-100);
+  --bz-ground-lit: var(--color-sandstone-50);
+  --bz-ground-shade: var(--color-sandstone-400);
+  --bz-sky-high: var(--color-sky-high);
+  --bz-sky-low: var(--color-sky-low);
+  --bz-haze: var(--color-haze);
+  --bz-ink: var(--color-ink-900);
+  --bz-ink-muted: var(--color-ink-600);
+  --bz-sign-board: var(--color-walnut-600);
+  --bz-sign-ink: var(--color-cream-50);
+  --bz-metal: var(--color-brass-400);
+  --bz-metal-shade: var(--color-brass-600);
+  --bz-metal-lit: var(--color-brass-200);
+  --bz-cut: var(--color-sandstone-600);
+  --bz-lit-edge: var(--color-lit-edge);
+  --bz-shadow: var(--color-sky-shadow);
+  --bz-focus: var(--color-lapis-700);
+  --bz-water: var(--color-water-day);
+  --bz-cloth: var(--color-bone-100);
+  --bz-timber: var(--color-bronze-700);
+}
+
+.bz-night {
+  --bz-ground: var(--color-nightground);
+  --bz-ground-lit: var(--color-nightraised);
+  --bz-ground-shade: var(--color-nightdeep);
+  --bz-sky-high: var(--color-nightsky-900);
+  --bz-sky-low: var(--color-nightsky-700);
+  --bz-haze: var(--color-haze-night);
+  --bz-ink: var(--color-nightink-100);
+  --bz-ink-muted: var(--color-nightink-400);
+  --bz-sign-board: var(--color-walnut-800);
+  --bz-sign-ink: var(--color-cream-50);
+  --bz-metal: var(--color-brass-200);
+  --bz-metal-shade: var(--color-brass-400);
+  --bz-metal-lit: var(--color-lantern);
+  --bz-cut: var(--color-nightcut);
+  --bz-lit-edge: var(--color-lantern);
+  --bz-shadow: var(--color-nightshadow);
+  --bz-focus: var(--color-brass-200);
+  --bz-water: var(--color-water-night);
+  --bz-cloth: var(--color-bone-100);
+  --bz-timber: var(--color-walnut-800);
+}
+
+/* Non-material tokens. These carry no colour and so do not re-cut in night. */
+:root {
+  --bz-font-sign: "Iowan Old Style", "Palatino Linotype", Palatino, "Hoefler Text",
+    "Times New Roman", serif;
+  --bz-font-numeral: ui-rounded, "SF Pro Rounded", system-ui, -apple-system, "Segoe UI",
+    Roboto, sans-serif;
+  --bz-cut-sm: 2px;
+  --bz-cut-md: 4px;
+  --bz-motion-quick: 120ms;
+  --bz-motion-detent: 200ms;
+  --bz-motion-settle: 420ms;
+  --bz-ease-detent: cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+/* ═══ LAYER 3 — UTILITY ═══════════════════════════════════════════════════ */
+
+.bz-root {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: var(--bz-ground);
+  color: var(--bz-ink);
+  font-family: var(--bz-font-numeral);
+  touch-action: pan-x;
+  -webkit-tap-highlight-color: transparent;
+  contain: strict;
+}
+
+.bz-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.bz-canvas--fore {
+  pointer-events: none; /* BZ-LAW-9 — a cat never eats a touch */
+  z-index: 3;
+}
+
+/* The street is a real scroller: native flick momentum on touch, a real
+   scrollLeft to restore on exit (BZ-08), and a real listbox for the keyboard. */
+.bz-street {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
+  scroll-snap-type: x proximity;
+  outline: none;
+}
+.bz-street::-webkit-scrollbar {
+  display: none;
+}
+
+.bz-track {
+  position: relative;
+  height: 100%;
+}
+
+.bz-stall {
+  position: absolute;
+  top: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  display: block;
+  scroll-snap-align: center;
+  outline: none;
+  -webkit-tap-highlight-color: transparent;
+  will-change: transform;
+}
+
+.bz-stall-chrome,
+.bz-stall-preview {
+  position: absolute;
+  display: block;
+}
+
+/* A <button> centres its content box, which becomes the static position of an
+   absolutely positioned child — so an unpositioned canvas lands half the
+   button's height down. Pin it. */
+.bz-stall-chrome {
+  left: 0;
+  top: 0;
+}
+
+.bz-stall-preview {
+  /* BZ-LAW-1 — the frame never colonises the preview. No radius, no filter,
+     no blend mode, no overlay. The aperture clips; nothing else touches it. */
+  border-radius: 0;
+  filter: none;
+  mix-blend-mode: normal;
+}
+
+.bz-sign {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+  text-align: center;
+  pointer-events: none;
+  text-wrap: balance;
+  overflow: hidden;
+}
+
+.bz-sign-name {
+  flex: 0 0 34%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bz-sign-spec {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bz-sign-name {
+  font-family: var(--bz-font-sign);
+  color: var(--bz-sign-ink);
+  line-height: 1.15;
+  letter-spacing: 0.02em;
+}
+
+.bz-sign-spec {
+  font-family: var(--bz-font-numeral);
+  font-variant-numeric: tabular-nums lining-nums slashed-zero;
+  font-feature-settings: "tnum" 1, "lnum" 1, "zero" 1;
+  font-weight: 600;
+  line-height: 1;
+  /* Cut into brass: one lit offset up-left, one cut offset down-right.
+     Two offsets, no blur — this is engraving, not a glow. */
+  color: var(--bz-ink);
+  text-shadow:
+    -1px -1px 0 var(--bz-metal-lit),
+    1px 1px 0 var(--bz-metal-shade);
+}
+
+/* Focus is a real object: a brass index bar that slides across the sill. */
+.bz-stall:focus-visible .bz-focusbar,
+.bz-stall.is-focus .bz-focusbar {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.bz-focusbar {
+  position: absolute;
+  height: 4px;
+  background: var(--bz-focus);
+  border-top: 1px solid var(--bz-lit-edge);
+  opacity: 0;
+  transform: translateX(-14px);
+  transition:
+    opacity var(--bz-motion-quick) var(--bz-ease-detent),
+    transform var(--bz-motion-detent) var(--bz-ease-detent);
+  pointer-events: none;
+}
+
+/* The lamp. A world object that happens to behave like an indicator. */
+.bz-lamp {
+  position: absolute;
+  top: 0;
+  z-index: 4;
+  pointer-events: none;
+}
+.bz-lamp canvas {
+  display: block;
+}
+
+.bz-lamplighter {
+  position: absolute;
+  z-index: 5;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  display: block;
+  outline: none;
+}
+.bz-lamplighter:focus-visible {
+  outline: 3px solid var(--bz-focus);
+  outline-offset: 2px;
+}
+
+.bz-astrolabe {
+  position: absolute;
+  z-index: 5;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: grab;
+  display: block;
+  outline: none;
+  touch-action: none;
+}
+.bz-astrolabe:focus-visible {
+  outline: 3px solid var(--bz-focus);
+  outline-offset: 2px;
+}
+
+.bz-valve {
+  position: absolute;
+  z-index: 5;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  display: block;
+  outline: none;
+}
+.bz-valve:focus-visible {
+  outline: 3px solid var(--bz-focus);
+  outline-offset: 2px;
+}
+
+/* Screen-reader-only, for the accessible names the canvas cannot carry. */
+.bz-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+/* The dolly into an aperture. One composited layer, no layout. */
+.bz-street.is-entering {
+  transition:
+    transform var(--bz-motion-settle) var(--bz-ease-detent),
+    opacity var(--bz-motion-settle) linear;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bz-street.is-entering {
+    transition:
+      opacity var(--bz-motion-detent) linear;
+    transform: none !important;
+  }
+  .bz-focusbar {
+    transition: opacity var(--bz-motion-detent) linear;
+    transform: none;
+  }
+}

--- a/dynawalla/bazaar/src/tokens/contrast.test.ts
+++ b/dynawalla/bazaar/src/tokens/contrast.test.ts
@@ -1,0 +1,105 @@
+/**
+ * BZ-03 — the contrast gate, and BZ-LAW-8's honest limit on colour.
+ *
+ * Every pair the design actually uses is verified here, in both themes. The
+ * ward table also publishes the three confusable pairs rather than pretending
+ * they do not exist: lapis↔aubergine are 5.9 L* apart AND on the tritan axis,
+ * which is why the street generator may never place them side by side.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { contrast, lstar } from "../util/color.ts";
+import { MATERIALS, SEMANTIC, WARDS, STRIPES, type WardId } from "./palette.ts";
+import { QUARTERS } from "../world/quarters.ts";
+import { adjacentWardPairs, quarterTriples } from "../world/street.ts";
+
+const m = MATERIALS;
+
+test("BZ-03: text pairs meet WCAG AA or better, in both themes", () => {
+  const pairs: [string, string, string, number][] = [
+    ["ink on the day ground", m["ink-900"], m["sandstone-100"], 7],
+    ["ink-muted on the day ground", m["ink-600"], m["sandstone-100"], 4.5],
+    ["ink on a shaded wall", m["ink-900"], m["sandstone-400"], 4.5],
+    ["sign ink on the board", m["cream-50"], m["walnut-600"], 7],
+    ["ink engraved into brass", m["ink-900"], m["brass-400"], 4.5],
+    ["focus cobalt on the day ground", m["lapis-700"], m["sandstone-100"], 3],
+    ["night ink on the night ground", m["nightink-100"], m["nightground"], 7],
+    ["night ink-muted on the night ground", m["nightink-400"], m["nightground"], 4.5],
+    ["night ink on emissive brass", m["nightground"], m["brass-300"], 7],
+    ["night focus brass on the night ground", m["brass-200"], m["nightground"], 3],
+    ["sign ink on the night board", m["cream-50"], m["walnut-800"], 7],
+  ];
+  for (const [name, a, b, floor] of pairs) {
+    const c = contrast(a, b);
+    assert.ok(c >= floor, `${name}: ${c.toFixed(2)}:1 is under ${floor}:1`);
+  }
+});
+
+test("BZ-03: every ward is ≥3:1 against its own ground", () => {
+  for (const w of Object.values(WARDS)) {
+    const day = contrast(w.day, SEMANTIC.light.ground);
+    const night = contrast(w.night, SEMANTIC.night.ground);
+    assert.ok(day >= 3, `${w.id} day ${day.toFixed(2)}:1`);
+    assert.ok(night >= 3, `${w.id} night ${night.toFixed(2)}:1`);
+  }
+});
+
+test("BZ-LAW-7: glaze never carries text — no ward colour is a text ground", () => {
+  // Every ward colour fails at least one of the ink pairs, which is precisely
+  // why the law exists and why signs are painted boards.
+  for (const w of Object.values(WARDS)) {
+    const withInk = contrast(m["ink-900"], w.day);
+    const withCream = contrast(m["cream-50"], w.day);
+    assert.ok(
+      withInk < 7 || withCream < 7,
+      `${w.id} would pass as a text ground, so the law needs revisiting`,
+    );
+  }
+});
+
+test("the three confusable ward pairs are the ones the spec names", () => {
+  const l = (id: WardId, k: "day" | "night") => lstar(WARDS[id][k]);
+  // lapis ↔ aubergine: 5.9 day, 5.7 night. Generator-constrained.
+  assert.ok(Math.abs(l("lapis", "day") - l("aubergine", "day")) < 7);
+  // turquoise ↔ hemp: close in L*, but cyan↔gold survives both protanopia and
+  // deuteranopia, so it is allowed.
+  assert.ok(Math.abs(l("turquoise", "day") - l("hemp", "day")) < 4);
+  // madder ↔ aubergine at night: nearly identical L*, but orange↔violet
+  // survives red-green CVD.
+  assert.ok(Math.abs(l("madder", "night") - l("aubergine", "night")) < 2);
+});
+
+test("BZ-17: every quarter carries a distinct (ward, finial, fold) triple", () => {
+  const triples = quarterTriples(QUARTERS);
+  assert.equal(new Set(triples).size, triples.length, "two quarters share a triple");
+});
+
+test("BZ-17: lapis and aubergine are never adjacent, including on the wrap", () => {
+  for (const [a, b] of adjacentWardPairs(QUARTERS)) {
+    const bad =
+      (a === "lapis" && b === "aubergine") || (a === "aubergine" && b === "lapis");
+    assert.ok(!bad, `${a} sits next to ${b}`);
+  }
+});
+
+test("no quarter repeats its neighbour's awning stripe", () => {
+  for (let i = 0; i < QUARTERS.length; i++) {
+    const a = QUARTERS[i]!;
+    const b = QUARTERS[(i + 1) % QUARTERS.length]!;
+    assert.notEqual(a.stripe % STRIPES.length, b.stripe % STRIPES.length);
+  }
+});
+
+test("the saffron/white stripe is the one that needs its selvedge", () => {
+  // 1.53:1 — invisible in greyscale, which is why a 1 px brass weft line sits
+  // between every stripe in the bazaar rather than only on this pair.
+  const pair = STRIPES.find((s) => s.id === "saffron-white")!;
+  assert.ok(contrast(pair.a, pair.b) < 2);
+  // …and every other authored pair clears 3:1 on its own.
+  for (const s of STRIPES) {
+    if (s.id === "saffron-white") continue;
+    assert.ok(contrast(s.a, s.b) >= 3, `${s.id}: ${contrast(s.a, s.b).toFixed(2)}:1`);
+  }
+});

--- a/dynawalla/bazaar/src/tokens/palette.ts
+++ b/dynawalla/bazaar/src/tokens/palette.ts
@@ -1,0 +1,253 @@
+/**
+ * Layer 1 — raw materials, and Layer 2 — the semantic layer.
+ *
+ * This file is the single source of truth for colour in the bazaar. The
+ * canvas layers read it directly; `bazaar.css` republishes the identical
+ * values as custom properties for the DOM layer, and `tokens.test.ts` asserts
+ * the two never drift apart.
+ *
+ * Layer 1 is the ONLY place a literal hex may appear (BZ-01).
+ * Every semantic role exists in both themes (BZ-01).
+ */
+
+export const MATERIALS = {
+  // ── Sandstone, plaster, mud-brick: the body of the city ──────────────────
+  "sandstone-50": "#f7edd8",
+  "sandstone-100": "#efe0c0",
+  "sandstone-200": "#e0cca4",
+  "sandstone-400": "#b99c6e",
+  "sandstone-600": "#8a7048",
+  "mudbrick-500": "#b08a5e",
+  "terracotta-600": "#96422c",
+
+  // ── Glazed tile, in the historical order of the craft ────────────────────
+  "tile-white": "#f1ead9",
+  "lapis-700": "#1c3f8f",
+  "lapis-500": "#2e58b0",
+  "lapis-300": "#5c8fe8",
+  "indigo-800": "#23356b",
+  "turquoise-700": "#0f6167",
+  "turquoise-500": "#17868c",
+  "turquoise-300": "#2fa6a8",
+  "ochre-500": "#d19a24",
+  "saffron-400": "#e8b93f",
+  "madder-600": "#a33a2c",
+  "madder-400": "#e08a6a",
+  "sabz-700": "#24603e",
+  "aubergine-800": "#4a2b52",
+  "aubergine-400": "#bc8fc8",
+  "manganese-900": "#33261c",
+
+  // ── Brass, copper, verdigris: the mechanism ──────────────────────────────
+  "brass-200": "#e8ce79",
+  "brass-300": "#e8c36a",
+  "brass-400": "#c9a227",
+  "brass-500": "#d6a93c",
+  "brass-600": "#8f6e1e",
+  "brass-800": "#5a421e",
+  "copper-400": "#c97a4c",
+  "copper-600": "#b06e42",
+  "verdigris-500": "#3e8f79",
+  "verdigris-300": "#59a88f",
+  "bronze-700": "#6b4a2b",
+
+  // ── Cloth, wood, ink ─────────────────────────────────────────────────────
+  "walnut-600": "#4a3220",
+  "walnut-800": "#33241a",
+  "bone-100": "#e6dcc4",
+  "cream-50": "#f4e8d0",
+  "ink-900": "#2a2015",
+  "ink-600": "#6b5940",
+
+  // ── Light, shadow, atmosphere: used only as composites ────────────────────
+  sun: "#ffe9bc",
+  "sky-shadow": "#2c3a63",
+  haze: "#e8c89a",
+  "haze-night": "#1a2140",
+  lantern: "#f5b94a",
+  "nightsky-900": "#0d1330",
+  "nightsky-700": "#1b2454",
+  nightground: "#241c13",
+  nightraised: "#2f251a",
+  nightdeep: "#1a140d",
+  nightcut: "#120e08",
+  nightshadow: "#05070f",
+  "nightink-100": "#f0e2c6",
+  "nightink-400": "#a99070",
+  "sky-high": "#9ec4e8",
+  "sky-low": "#dcd2b4",
+  "lit-edge": "#fff3d6",
+  "water-day": "#4e8fa0",
+  "water-night": "#17324a",
+
+  // ── Lantern glass. Emissive; never a text ground ─────────────────────────
+  "glass-amber": "#f0a93b",
+  "glass-ruby": "#c4402f",
+  "glass-emerald": "#2e8b5a",
+  "glass-cobalt": "#2a56a8",
+  "glass-clear": "#f6ebcf",
+} as const;
+
+export type Material = keyof typeof MATERIALS;
+
+export const m = (k: Material): string => MATERIALS[k];
+
+/** The roles. Nothing outside this type names a material. */
+export interface Semantic {
+  ground: string;
+  groundLit: string;
+  groundShade: string;
+  skyHigh: string;
+  skyLow: string;
+  haze: string;
+  ink: string;
+  inkMuted: string;
+  signBoard: string;
+  signInk: string;
+  metal: string;
+  metalShade: string;
+  metalLit: string;
+  cut: string;
+  litEdge: string;
+  shadow: string;
+  shadowAlpha: number;
+  focus: string;
+  water: string;
+  cloth: string;
+  timber: string;
+}
+
+const LIGHT: Semantic = {
+  ground: m("sandstone-100"),
+  groundLit: m("sandstone-50"),
+  groundShade: m("sandstone-400"),
+  skyHigh: m("sky-high"),
+  skyLow: m("sky-low"),
+  haze: m("haze"),
+  ink: m("ink-900"),
+  inkMuted: m("ink-600"),
+  signBoard: m("walnut-600"),
+  signInk: m("cream-50"),
+  metal: m("brass-400"),
+  metalShade: m("brass-600"),
+  metalLit: m("brass-200"),
+  cut: m("sandstone-600"),
+  litEdge: m("lit-edge"),
+  shadow: m("sky-shadow"),
+  shadowAlpha: 0.26,
+  focus: m("lapis-700"),
+  water: m("water-day"),
+  cloth: m("bone-100"),
+  timber: m("bronze-700"),
+};
+
+const NIGHT: Semantic = {
+  ground: m("nightground"),
+  groundLit: m("nightraised"),
+  groundShade: m("nightdeep"),
+  skyHigh: m("nightsky-900"),
+  skyLow: m("nightsky-700"),
+  haze: m("haze-night"),
+  ink: m("nightink-100"),
+  inkMuted: m("nightink-400"),
+  signBoard: m("walnut-800"),
+  signInk: m("cream-50"),
+  metal: m("brass-200"),
+  metalShade: m("brass-400"),
+  metalLit: m("lantern"),
+  cut: m("nightcut"),
+  litEdge: m("lantern"),
+  shadow: m("nightshadow"),
+  shadowAlpha: 0.4,
+  focus: m("brass-200"),
+  water: m("water-night"),
+  cloth: m("bone-100"),
+  timber: m("walnut-800"),
+};
+
+export const SEMANTIC = { light: LIGHT, night: NIGHT } as const;
+export type ThemeName = keyof typeof SEMANTIC;
+
+export const theme = (t: ThemeName): Semantic => SEMANTIC[t];
+
+// ── Awning stripe pairs ────────────────────────────────────────────────────
+// Real souk awnings are woven cotton and goat-hair. A 1px brass-800 selvedge
+// sits between every stripe, which is how a weft line actually looks and is
+// what keeps the saffron/white pair (1.53:1) legible in greyscale.
+export interface StripePair {
+  readonly id: string;
+  readonly a: string;
+  readonly b: string;
+}
+
+export const STRIPES: readonly StripePair[] = [
+  { id: "saffron-white", a: m("saffron-400"), b: m("tile-white") },
+  { id: "indigo-white", a: m("indigo-800"), b: m("tile-white") },
+  { id: "madder-cream", a: m("madder-600"), b: m("sandstone-100") },
+  { id: "sabz-bone", a: m("sabz-700"), b: m("bone-100") },
+  { id: "aubergine-bone", a: m("aubergine-800"), b: m("bone-100") },
+  { id: "ochre-umber", a: m("ochre-500"), b: m("brass-800") },
+];
+
+export const SELVEDGE = m("brass-800");
+
+// ── Wards ──────────────────────────────────────────────────────────────────
+// Colour identifies a ward, never a single quarter (BZ-LAW-8). Every ward also
+// carries a finial silhouette, a pattern fold and an awning stripe, so no
+// meaning is ever carried by colour alone.
+export type WardId = "lapis" | "aubergine" | "turquoise" | "madder" | "hemp";
+
+export interface Ward {
+  readonly id: WardId;
+  readonly day: string;
+  readonly night: string;
+  /** Glaze for the tiled band; never carries text (BZ-LAW-7). */
+  readonly glaze: string;
+  readonly glazeDeep: string;
+}
+
+export const WARDS: Record<WardId, Ward> = {
+  lapis: {
+    id: "lapis",
+    day: m("lapis-700"),
+    night: m("lapis-300"),
+    glaze: m("lapis-500"),
+    glazeDeep: m("indigo-800"),
+  },
+  aubergine: {
+    id: "aubergine",
+    day: m("aubergine-800"),
+    night: m("aubergine-400"),
+    glaze: m("aubergine-800"),
+    glazeDeep: m("manganese-900"),
+  },
+  turquoise: {
+    id: "turquoise",
+    day: m("turquoise-500"),
+    night: m("turquoise-300"),
+    glaze: m("turquoise-500"),
+    glazeDeep: m("turquoise-700"),
+  },
+  madder: {
+    id: "madder",
+    day: m("madder-600"),
+    night: m("madder-400"),
+    glaze: m("madder-600"),
+    glazeDeep: m("terracotta-600"),
+  },
+  hemp: {
+    id: "hemp",
+    day: m("brass-600"),
+    night: m("brass-500"),
+    glaze: m("ochre-500"),
+    glazeDeep: m("brass-800"),
+  },
+};
+
+export const WARD_ORDER: readonly WardId[] = [
+  "lapis",
+  "turquoise",
+  "madder",
+  "hemp",
+  "aubergine",
+];

--- a/dynawalla/bazaar/src/tokens/tokens.test.ts
+++ b/dynawalla/bazaar/src/tokens/tokens.test.ts
@@ -1,0 +1,121 @@
+/**
+ * BZ-01 and BZ-02 — the token discipline and the two standing lint rules.
+ *
+ * BZ-01  Three layers. No literal colour outside the MATERIALS block; every
+ *        semantic role exists in both `:root` and `.bz-night`; `palette.ts`
+ *        and `bazaar.css` never drift.
+ * BZ-02  Zero `rgba(0,0,0,*)` and zero `box-shadow` blur over 2 px anywhere in
+ *        `bazaar/`. Shadow is transmitted skylight; depth is haze and
+ *        occlusion, never blur.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { MATERIALS } from "./palette.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = join(here, "..");
+const css = readFileSync(join(here, "bazaar.css"), "utf8");
+
+/** Comments describe the laws; they are not violations of them. */
+function strip(body: string): string {
+  return body
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1 ");
+}
+
+function section(name: string): string {
+  const marks = ["LAYER 1 — MATERIALS", "LAYER 2 — SEMANTIC", "LAYER 3 — UTILITY"];
+  const i = marks.indexOf(name);
+  const start = css.indexOf(marks[i]!);
+  const end = i + 1 < marks.length ? css.indexOf(marks[i + 1]!) : css.length;
+  assert.ok(start >= 0, `section ${name} not found`);
+  return css.slice(start, end);
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const e of readdirSync(dir)) {
+    if (e === "node_modules" || e === "dist" || e === "shots") continue;
+    const p = join(dir, e);
+    if (statSync(p).isDirectory()) walk(p, out);
+    // The lint tests quote the patterns they ban, so they exempt themselves.
+    else if (/\.(ts|css)$/.test(e) && !e.endsWith(".test.ts")) out.push(p);
+  }
+  return out;
+}
+
+test("BZ-01: every material in palette.ts appears in the CSS with the same value", () => {
+  const materials = section("LAYER 1 — MATERIALS");
+  for (const [name, hex] of Object.entries(MATERIALS)) {
+    const decl = `--color-${name}: ${hex};`;
+    assert.ok(materials.includes(decl), `bazaar.css is missing or differs on: ${decl}`);
+  }
+});
+
+test("BZ-01: no literal colour appears outside the MATERIALS layer", () => {
+  const rest = section("LAYER 2 — SEMANTIC") + section("LAYER 3 — UTILITY");
+  const hex = rest.match(/#[0-9a-fA-F]{3,8}\b/g) ?? [];
+  assert.deepEqual(hex, [], `literal colours outside layer 1: ${hex.join(", ")}`);
+  const fn = rest.match(/\b(rgb|rgba|hsl|hsla|oklch|color-mix)\(/g) ?? [];
+  assert.deepEqual(fn, [], `colour functions outside layer 1: ${fn.join(", ")}`);
+});
+
+test("BZ-01: every semantic role is re-cut in the night theme", () => {
+  const semantic = section("LAYER 2 — SEMANTIC");
+  const root = semantic.slice(semantic.indexOf(":root {"), semantic.indexOf(".bz-night"));
+  const nightEnd = semantic.indexOf("Non-material tokens");
+  const night = semantic.slice(semantic.indexOf(".bz-night"), nightEnd);
+  const names = [...root.matchAll(/(--bz-[a-z-]+):/g)].map((m) => m[1]!);
+  assert.ok(names.length >= 18, "the semantic layer looks truncated");
+  for (const n of names) {
+    assert.ok(night.includes(`${n}:`), `${n} has no night value`);
+  }
+  // …and a non-material token must NOT be duplicated into the night block.
+  assert.ok(!night.includes("--bz-cut-sm:"), "a colourless token was re-cut in night");
+});
+
+test("BZ-02: no rgba(0,0,0,*) anywhere in the bazaar", () => {
+  for (const f of walk(src)) {
+    const body = strip(readFileSync(f, "utf8"));
+    const hits = body.match(/rgba?\(\s*0\s*,\s*0\s*,\s*0\s*[,)]/g);
+    assert.equal(hits, null, `${f} composites over black: ${hits?.join(", ")}`);
+    // …and the same rule expressed in canvas terms.
+    const canvas = body.match(/alpha\(\s*["']#000/g);
+    assert.equal(canvas, null, `${f} uses black with an alpha`);
+  }
+});
+
+test("BZ-02: no box-shadow blur over 2px, and no filter: blur()", () => {
+  for (const f of walk(src)) {
+    const body = strip(readFileSync(f, "utf8"));
+    for (const m of body.matchAll(/box-shadow:\s*([^;]+);/g)) {
+      const lengths = [...m[1]!.matchAll(/(-?[\d.]+)px/g)].map((x) => Number(x[1]));
+      // offset-x, offset-y, blur, spread — the third is the one that is banned.
+      if (lengths.length >= 3) {
+        assert.ok(lengths[2]! <= 2, `${f}: box-shadow blur ${lengths[2]}px > 2px`);
+      }
+    }
+    assert.equal(
+      /filter:\s*[^;]*blur\(/.test(body),
+      false,
+      `${f}: depth is haze and occlusion, never blur`,
+    );
+  }
+});
+
+test("the bazaar imports nothing from the work surface or the engine", () => {
+  for (const f of walk(src)) {
+    const body = readFileSync(f, "utf8");
+    for (const m of body.matchAll(/from\s+["']([^"']+)["']/g)) {
+      const spec = m[1]!;
+      assert.ok(
+        !/(^|\/)(work|engine|curriculum|reactions)\//.test(spec),
+        `${f} reaches into ${spec}; the bazaar never waits for the world`,
+      );
+    }
+  }
+});

--- a/dynawalla/bazaar/src/types.ts
+++ b/dynawalla/bazaar/src/types.ts
@@ -1,0 +1,123 @@
+/**
+ * The public contract. Everything the games team and the host app touch.
+ */
+
+import type { Fold } from "./geometry/tilings.ts";
+import type { WardId } from "./tokens/palette.ts";
+import type { Locale } from "./strings.ts";
+
+export type { Fold, WardId, Locale };
+
+/** The instrument at the head of a ward's tower. The second identity axis. */
+export type Finial = "meridian" | "vane" | "signal" | "gear" | "armillary";
+
+/** A worked specimen of the quarter's own mathematics. */
+export interface Specimen {
+  /** Set in figures, on the sign board. `aria-hidden`. */
+  display: string;
+  /** The same thing in words, for the accessible name. */
+  spoken: string;
+}
+
+export interface Quarter {
+  id: string;
+  ward: WardId;
+  finial: Finial;
+  fold: Fold;
+  /** Index into STRIPES. */
+  stripe: number;
+  /** Place names are content, localised per launch locale. */
+  name: Record<Locale, string>;
+  specimen: Specimen;
+  /** Which of the ten crafts the automaton performs. */
+  craft: Craft;
+}
+
+export type Craft =
+  | "balance"
+  | "coin"
+  | "tessera"
+  | "rope"
+  | "astrolabe"
+  | "water"
+  | "vat"
+  | "kite"
+  | "gears"
+  | "mill";
+
+/**
+ * BZ-06/BZ-07 — what a stall shows through its aperture.
+ *
+ * The preview shows the game being *played correctly*: a ghost hand solving, at
+ * half speed, looping on `period`. Not a title card, not a logo, not a menu. A
+ * child must be able to tell what they would do in there without entering.
+ *
+ * Deterministic on `seed`. No input, no audio, no network, no persistence.
+ * Silent — sound belongs to the street. Budget: 4 ms per frame at 30 fps; over
+ * budget and the stall falls back to its poster permanently.
+ */
+export interface StallPreview {
+  render(ctx: CanvasRenderingContext2D, o: PreviewFrame): void;
+  /** Loop period in seconds. 4–8. */
+  readonly period: number;
+}
+
+export interface PreviewFrame {
+  width: number;
+  height: number;
+  dpr: number;
+  /** Seconds since the preview started. */
+  t: number;
+  seed: number;
+  reducedMotion: boolean;
+}
+
+export type StallState = "open" | "shut" | "scaffold";
+
+export interface StallSpec {
+  id: string;
+  /** The game's name. Owned by the game, not by the bazaar. */
+  title: string;
+  /** Which quarter it stands in. */
+  quarter: string;
+  preview?: StallPreview;
+  /** Defaults to `open`, or `scaffold` when there is no preview. */
+  state?: StallState;
+  /** Physical accretion at this stall: 0…1. Never a number in the UI. */
+  accretion?: number;
+  /** Overrides the quarter's default specimen. */
+  specimen?: Specimen;
+}
+
+export interface BazaarOptions {
+  stalls: StallSpec[];
+  /**
+   * How much of the free day is left, 0…1. Walking the bazaar is free
+   * (BZ-LAW-14); only time inside a stall consumes it.
+   */
+  dayRemaining?: number;
+  subscribed?: boolean;
+  seed?: number;
+  locale?: string;
+  /** `auto` follows the OS and the day-state; the night bazaar is a place. */
+  theme?: "auto" | "light" | "night";
+  sound?: boolean;
+  /** Extra quarters beyond the ten built in. */
+  quarters?: Quarter[];
+  onEnter?(stallId: string): void;
+  /** The single upgrade surface. Non-modal, and never during play. */
+  onUpgrade?(): void;
+}
+
+export interface BazaarHandle {
+  destroy(): void;
+  setStalls(stalls: StallSpec[]): void;
+  setDay(remaining: number): void;
+  setSubscribed(v: boolean): void;
+  /** Called by the host when a stall is open, so the day cannot end inside it. */
+  setInStall(v: boolean): void;
+  goToStall(id: string): void;
+  scrollLeft(): number;
+  /** Last measured frame statistics, for the perf gate. */
+  stats(): { fps: number; p90: number; tier: number; liveNodes: number };
+}

--- a/dynawalla/bazaar/src/util/color.ts
+++ b/dynawalla/bazaar/src/util/color.ts
@@ -1,0 +1,71 @@
+/**
+ * Colour arithmetic.
+ *
+ * BZ-LAW-5: light is warm, shadow is cool. There is no `rgba(0,0,0,x)` anywhere
+ * in the bazaar — a shadow is transmitted skylight composited over the ground,
+ * and a lit face is sunlight composited over the same ground. Both operations
+ * live here so that the rest of the code never opens an alpha channel by hand.
+ */
+
+export type RGB = readonly [number, number, number];
+
+const HEX = /^#?([0-9a-f]{6})$/i;
+
+export function parseHex(hex: string): RGB {
+  const m = HEX.exec(hex.trim());
+  if (!m) throw new Error(`not a 6-digit hex colour: ${hex}`);
+  const n = parseInt(m[1]!, 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+export function toHex(c: RGB): string {
+  const b = (v: number) => Math.max(0, Math.min(255, Math.round(v)));
+  return `#${((1 << 24) | (b(c[0]) << 16) | (b(c[1]) << 8) | b(c[2])).toString(16).slice(1)}`;
+}
+
+/** Source-over composite of `top` at `alpha` onto opaque `base`. */
+export function over(base: string, top: string, alpha: number): string {
+  const a = Math.max(0, Math.min(1, alpha));
+  const b = parseHex(base);
+  const t = parseHex(top);
+  return toHex([
+    b[0] + (t[0] - b[0]) * a,
+    b[1] + (t[1] - b[1]) * a,
+    b[2] + (t[2] - b[2]) * a,
+  ]);
+}
+
+/** Mix two colours by weight (0 = a, 1 = b). */
+export const mix = (a: string, b: string, t: number): string => over(a, b, t);
+
+function toLinear(v: number): number {
+  const s = v / 255;
+  return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+}
+
+/** WCAG relative luminance. */
+export function luminance(hex: string): number {
+  const [r, g, b] = parseHex(hex);
+  return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+}
+
+/** WCAG 2.x contrast ratio, 1…21. */
+export function contrast(a: string, b: string): number {
+  const la = luminance(a);
+  const lb = luminance(b);
+  const hi = Math.max(la, lb);
+  const lo = Math.min(la, lb);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** CIE L*, the perceptual lightness axis. Used to prove ward separation. */
+export function lstar(hex: string): number {
+  const y = luminance(hex);
+  return y > 0.008856451679 ? 116 * Math.cbrt(y) - 16 : 903.2962962 * y;
+}
+
+/** A colour with an explicit alpha, for the few places canvas needs one. */
+export function alpha(hex: string, a: number): string {
+  const [r, g, b] = parseHex(hex);
+  return `rgba(${r},${g},${b},${Math.max(0, Math.min(1, a)).toFixed(3)})`;
+}

--- a/dynawalla/bazaar/src/util/rng.ts
+++ b/dynawalla/bazaar/src/util/rng.ts
@@ -1,0 +1,85 @@
+/**
+ * Deterministic pseudo-randomness.
+ *
+ * Everything in the bazaar that looks incidental — which awning stripe, where a
+ * tile is chipped, how far apart two stalls sit — is generated from a seed, so
+ * the same street is the same street on every device and in every screenshot.
+ */
+
+/** splitmix32: fast, well-distributed, and stable across engines. */
+export function rng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x9e3779b9) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 16), 0x21f0aaad);
+    t = Math.imul(t ^ (t >>> 15), 0x735a2d97);
+    return ((t ^ (t >>> 15)) >>> 0) / 4294967296;
+  };
+}
+
+/** A stable 32-bit hash of a string, for deriving a seed from an id. */
+export function hash(s: string, seed = 0x811c9dc5): number {
+  let h = seed >>> 0;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h >>> 0;
+}
+
+/** Mix two integers into a new seed. Order matters. */
+export function mix(a: number, b: number): number {
+  let h = (a ^ 0x9e3779b9) >>> 0;
+  h = Math.imul(h ^ b, 0x85ebca6b) >>> 0;
+  h ^= h >>> 13;
+  h = Math.imul(h, 0xc2b2ae35) >>> 0;
+  return (h ^ (h >>> 16)) >>> 0;
+}
+
+/** A deterministic float in [0,1) from a seed, without holding a generator. */
+export function frand(seed: number): number {
+  let t = (seed + 0x9e3779b9) >>> 0;
+  t = Math.imul(t ^ (t >>> 16), 0x21f0aaad);
+  t = Math.imul(t ^ (t >>> 15), 0x735a2d97);
+  return ((t ^ (t >>> 15)) >>> 0) / 4294967296;
+}
+
+export function pick<T>(items: readonly T[], r: number): T {
+  return items[Math.min(items.length - 1, Math.floor(r * items.length))]!;
+}
+
+export function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+export function clamp(v: number, lo: number, hi: number): number {
+  return v < lo ? lo : v > hi ? hi : v;
+}
+
+/** Smooth 0→1 with zero derivative at both ends. */
+export function smoothstep(edge0: number, edge1: number, x: number): number {
+  const t = clamp((x - edge0) / (edge1 - edge0), 0, 1);
+  return t * t * (3 - 2 * t);
+}
+
+/**
+ * A non-repeating idle oscillation: two sines at prime-ratio periods so nothing
+ * visibly loops. §5.1 of the aesthetic bible.
+ */
+const IDLE_PERIODS = [5.2, 7.3, 11.1, 13.7, 17.3, 19.1] as const;
+
+export function idle(t: number, seed: number, amplitude = 1): number {
+  const i = Math.floor(frand(seed) * IDLE_PERIODS.length);
+  let j = Math.floor(frand(seed ^ 0x5bf03635) * (IDLE_PERIODS.length - 1));
+  if (j >= i) j += 1;
+  const p1 = IDLE_PERIODS[i]!;
+  const p2 = IDLE_PERIODS[j]!;
+  const ph1 = frand(seed ^ 0x1b873593) * Math.PI * 2;
+  const ph2 = frand(seed ^ 0xcc9e2d51) * Math.PI * 2;
+  return (
+    amplitude *
+    (0.62 * Math.sin((Math.PI * 2 * t) / p1 + ph1) +
+      0.38 * Math.sin((Math.PI * 2 * t) / p2 + ph2))
+  );
+}

--- a/dynawalla/bazaar/src/vite-env.d.ts
+++ b/dynawalla/bazaar/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";

--- a/dynawalla/bazaar/src/world/backdrop.ts
+++ b/dynawalla/bazaar/src/world/backdrop.ts
@@ -1,0 +1,830 @@
+/**
+ * The one canvas — or rather two, split exactly where the interaction model
+ * needs the split:
+ *
+ *   back  L0 sky · L1 far skyline · L2 roofline · L5 floor · L3 vault soffit
+ *   DOM   L4 stalls — real buttons, real focus, real accessible names
+ *   fore  L3 lanterns and shafts · L6 traffic  (pointer-events: none, BZ-LAW-9)
+ *
+ * That split is what makes the 60 fps budget and the accessibility requirements
+ * achievable at the same time: pixels on canvas, semantics in DOM.
+ *
+ * The light shafts are drawn on the *front* canvas so they fall across the
+ * stalls as well as the floor. Volumetric light in front of the thing it lights
+ * is the whole reason the street looks sunlit rather than lit-from-a-flat-file.
+ */
+
+import { frand, mix as mixSeed, idle, clamp } from "../util/rng.ts";
+import { alpha, over } from "../util/color.ts";
+import { archPath } from "../geometry/arch.ts";
+import type { Ambient } from "./daylight.ts";
+import { lit, shade } from "./daylight.ts";
+import type { Semantic } from "../tokens/palette.ts";
+import { MATERIALS, WARDS, type WardId } from "../tokens/palette.ts";
+import type { Layout } from "./layout.ts";
+import { ParallaxRig } from "./parallax.ts";
+import { drawTower, drawDome, drawRoofBlock, applyHaze, type SkyContext } from "./skyline.ts";
+import { drawMuqarnas } from "../geometry/muqarnas.ts";
+import { drawArcadeBay, drawLightShaft, drawLantern, drawValve, type CanopyCtx } from "./canopy.ts";
+import { drawFloor, drawStallShadow, drawSunPool, type FloorCtx, type Reflector } from "./floor.ts";
+import {
+  Crowd,
+  drawCat,
+  drawPigeon,
+  drawPorter,
+  drawSteam,
+  drawCarpet,
+  type LifeCtx,
+} from "./life.ts";
+import type { Street } from "./street.ts";
+import type { Budget } from "../perf/tiers.ts";
+
+/** Stars the Islamic Golden Age named and Europe kept. */
+const STARS: readonly [string, number, number, number][] = [
+  ["Aldebaran", 0.12, 0.34, 1.0],
+  ["Altair", 0.31, 0.18, 0.95],
+  ["Deneb", 0.44, 0.42, 0.8],
+  ["Rigel", 0.58, 0.22, 0.9],
+  ["Betelgeuse", 0.66, 0.52, 0.85],
+  ["Fomalhaut", 0.79, 0.3, 0.75],
+  ["Vega", 0.91, 0.46, 1.0],
+];
+
+export interface Touch {
+  x: number;
+  y: number;
+  age: number;
+}
+
+export interface BackdropState {
+  camX: number;
+  t: number;
+  dt: number;
+  lay: Layout;
+  sem: Semantic;
+  am: Ambient;
+  street: Street;
+  ward: WardId;
+  reduced: boolean;
+  budget: Budget;
+  seed: number;
+  touch: Touch | null;
+  ripples: { x: number; age: number }[];
+  lanternKick: number;
+  catWake: number;
+  soundOpen: boolean;
+  /** Screen-space slices of the stall row, for the water to reflect. */
+  reflectors: Reflector[];
+  /** Screen x of the shafts, published so the stalls can be lit by them. */
+  onShafts?(xs: number[]): void;
+}
+
+export class Backdrop {
+  private rig = new ParallaxRig();
+  private crowdFar = new Crowd(18);
+  private crowdNear = new Crowd(5);
+  private bctx: CanvasRenderingContext2D | null;
+  private fctx: CanvasRenderingContext2D | null;
+  private lay: Layout | null = null;
+
+  private back: HTMLCanvasElement;
+  private fore: HTMLCanvasElement;
+
+  constructor(back: HTMLCanvasElement, fore: HTMLCanvasElement) {
+    this.back = back;
+    this.fore = fore;
+    this.bctx = back.getContext("2d", { alpha: false });
+    this.fctx = fore.getContext("2d");
+  }
+
+  resize(lay: Layout, scale: number): void {
+    this.lay = lay;
+    for (const cv of [this.back, this.fore]) {
+      cv.width = Math.max(1, Math.round(lay.w * scale));
+      cv.height = Math.max(1, Math.round(lay.h * scale));
+    }
+    this.bctx = this.back.getContext("2d", { alpha: false });
+    this.fctx = this.fore.getContext("2d");
+    this.bctx?.setTransform(scale, 0, 0, scale, 0, 0);
+    this.fctx?.setTransform(scale, 0, 0, scale, 0, 0);
+    this.rig.setViewW(lay.w);
+  }
+
+  draw(s: BackdropState): void {
+    const b = this.bctx;
+    const f = this.fctx;
+    if (!b || !f || !this.lay) return;
+    const { lay, sem, am } = s;
+    const centre = s.camX + lay.w / 2;
+
+    this.rig.setReduced(s.reduced);
+    this.rig.update(centre, s.dt);
+
+    const skyC: SkyContext = { sem, am, dpr: lay.dpr, depth: 5 };
+    const midC: SkyContext = { sem, am, dpr: lay.dpr, depth: 3 };
+    const canC: CanopyCtx = {
+      sem,
+      am,
+      dpr: lay.dpr,
+      lay,
+      reduced: s.reduced,
+      motes: s.budget.maxMotes,
+    };
+    const flC: FloorCtx = {
+      sem,
+      am,
+      dpr: lay.dpr,
+      lay,
+      reduced: s.reduced,
+      reflections: s.budget.reflections,
+    };
+    const lifeFar: LifeCtx = { sem, am, depth: 2, reduced: s.reduced };
+    const lifeNear: LifeCtx = { sem, am, depth: 0, reduced: s.reduced };
+
+    b.clearRect(0, 0, lay.w, lay.h);
+    this.drawSky(b, s);
+
+    // ── L1 far skyline ────────────────────────────────────────────────────
+    const pFar = this.rig.projector("far", centre);
+    if (s.budget.farParallax) {
+      this.drawFarLayer(b, s, pFar, skyC);
+      applyHaze(b, 0, 0, lay.w, lay.stallTop + lay.stallH * 0.4, skyC);
+    }
+
+    // ── L2 roofline across the street ─────────────────────────────────────
+    const pMid = this.rig.projector("mid", centre);
+    this.drawMidLayer(b, s, pMid, midC);
+
+    // The far pavement, and the people on it.
+    if (s.budget.fauna) {
+      const pStreet = this.rig.projector("street", centre);
+      this.crowdFar.setCount(lay.small ? 10 : 18);
+      this.crowdFar.update(s.dt, centre, lay.w * 2.2);
+      this.crowdFar.draw(
+        b,
+        (wx) => pStreet(wx) * 0.92 + lay.w * 0.04,
+        lay.w,
+        lay.floorY + lay.floorH * 0.2,
+        lay.M * 0.3,
+        lifeFar,
+        s.t,
+      );
+    }
+    applyHaze(b, 0, lay.skyH * 0.6, lay.w, lay.floorY - lay.skyH * 0.6, midC);
+
+    // ── L5 floor ──────────────────────────────────────────────────────────
+    drawFloor(b, s.camX, s.ward, s.seed, flC, s.t, s.reflectors, s.ripples);
+
+    // The fabric between the stalls, and the gates at the ward boundaries.
+    this.drawFurniture(b, s);
+
+    // Stall shadows on the pavement.
+    for (const st of s.street.visible(s.camX - lay.M, s.camX + lay.w + lay.M)) {
+      if (st.kind !== "stall") continue;
+      drawStallShadow(b, st.x - s.camX + lay.M * 0.08, st.width * 0.9, flC);
+    }
+
+    // ── L3 the arcade overhead, over the sky it is cut into ───────────────
+    const shafts = this.drawCanopy(b, s, centre, canC);
+    s.onShafts?.(shafts.map((sh) => sh.x));
+
+    // ── the front canvas: light, lanterns, traffic ────────────────────────
+    f.clearRect(0, 0, lay.w, lay.h);
+    const lean = Math.tan((am.shaftAngle * Math.PI) / 180);
+    for (const sh of shafts) {
+      drawSunPool(b, sh.x + lean * (lay.floorY - sh.y), sh.w * 2.2, flC);
+      drawLightShaft(f, sh.x, sh.y, sh.w, lay.floorY + lay.floorH * 0.5, sh.seed, canC, s.t, s.touch);
+    }
+
+    this.drawLanterns(f, s, centre, canC);
+    if (s.budget.fauna) this.drawTraffic(f, s, centre, lifeNear);
+    this.drawValveObject(f, s, canC);
+  }
+
+  /**
+   * §4.7 — off the street. There is no navigation bar; everything else is a
+   * turning. A street with no side alleys is a corridor, so the fabric between
+   * the stalls is generated: doorways, stairs, alley mouths, crates, vines, a
+   * fountain, a water crossing, a niche.
+   */
+  private drawFurniture(g: CanvasRenderingContext2D, s: BackdropState): void {
+    const { lay, sem, am } = s;
+    const top = lay.stallTop;
+    const h = lay.floorY - top;
+    for (const f of s.street.visible(s.camX - lay.M, s.camX + lay.w + lay.M)) {
+      const x = f.x - s.camX;
+      if (f.kind === "gate") {
+        drawGate(g, x, f.width, lay, sem, am, f.ward, f.quarter.name.en);
+        continue;
+      }
+      if (f.kind !== "interstitial") continue;
+      const w = f.width;
+      // The party wall between two shops, lit on the sun side, with the same
+      // glazed dado the shopfronts carry.
+      g.fillStyle = lit(sem.ground, am, 0.28);
+      g.fillRect(x, top, w, h);
+      g.fillStyle = shade(sem.ground, am, 0.8, sem.shadow);
+      g.fillRect(x + w * 0.7, top, w * 0.3, h);
+      g.fillStyle = sem.cut;
+      g.fillRect(x, top, 1, h);
+      g.fillRect(x + w - 1, top, 1, h);
+      const band = WARDS[f.quarter.ward];
+      const dh = Math.max(8, h * 0.07);
+      g.fillStyle = band.glaze;
+      g.fillRect(x + 1, lay.floorY - dh, w - 2, dh);
+      g.fillStyle = band.glazeDeep;
+      for (let i = 0; i * 11 < w; i++) g.fillRect(x + 1 + i * 11, lay.floorY - dh, 4, dh);
+      g.fillStyle = sem.cut;
+      g.fillRect(x + 1, lay.floorY - dh, w - 2, 1);
+      // A wall bracket with a small lamp: a party wall is never blank.
+      g.strokeStyle = sem.metal;
+      g.lineWidth = 2;
+      g.beginPath();
+      g.moveTo(x + w * 0.5, top + h * 0.1);
+      g.lineTo(x + w * 0.5, top + h * 0.17);
+      g.stroke();
+      g.fillStyle = am.lanternGain > 0.2 ? sem.metalLit : sem.metal;
+      g.beginPath();
+      g.moveTo(x + w * 0.42, top + h * 0.17);
+      g.lineTo(x + w * 0.58, top + h * 0.17);
+      g.lineTo(x + w * 0.53, top + h * 0.25);
+      g.lineTo(x + w * 0.47, top + h * 0.25);
+      g.closePath();
+      g.fill();
+
+      switch (f.type) {
+        case "doorway":
+        case "alley-mouth": {
+          const dw = w * 0.62;
+          const dx = x + (w - dw) / 2;
+          const dh = h * (f.type === "alley-mouth" ? 0.82 : 0.6);
+          g.fillStyle = shade(sem.ground, am, f.type === "alley-mouth" ? 1.8 : 1.3, sem.shadow);
+          g.beginPath();
+          g.moveTo(dx, top + h);
+          g.lineTo(dx, top + h - dh * 0.55);
+          archPath(g, dx + dw / 2, top + h - dh * 0.55, dw, "equilateral");
+          g.lineTo(dx + dw, top + h);
+          g.closePath();
+          g.fill();
+          g.strokeStyle = sem.litEdge;
+          g.lineWidth = 1;
+          g.stroke();
+          if (f.type === "alley-mouth") {
+            // Something is lit, a long way down the alley.
+            g.fillStyle = alpha(MATERIALS["lantern"], 0.35 * Math.max(0.25, am.lanternGain));
+            g.fillRect(dx + dw * 0.36, top + h - dh * 0.3, dw * 0.28, dh * 0.3);
+          }
+          break;
+        }
+        case "stair": {
+          const steps = 6;
+          for (let i = 0; i < steps; i++) {
+            const sy = top + h - ((i + 1) * h * 0.42) / steps;
+            g.fillStyle = i % 2 ? lit(sem.ground, am, 0.8) : sem.ground;
+            g.fillRect(x + w * 0.1 + i * w * 0.06, sy, w * 0.8 - i * w * 0.06, h * 0.42 / steps);
+            g.fillStyle = sem.litEdge;
+            g.fillRect(x + w * 0.1 + i * w * 0.06, sy, w * 0.8 - i * w * 0.06, 1);
+          }
+          break;
+        }
+        case "crates": {
+          for (let i = 0; i < 4; i++) {
+            const sd = mixSeed(f.seed, i);
+            const cw = w * (0.28 + frand(sd) * 0.2);
+            const ch = h * (0.09 + frand(mixSeed(sd, 1)) * 0.07);
+            const cx2 = x + w * (0.12 + frand(mixSeed(sd, 2)) * 0.6);
+            const cy = top + h - ch * (1 + (i % 2));
+            g.fillStyle = over(MATERIALS["bronze-700"], am.sunColor, am.sunAlpha);
+            g.fillRect(cx2, cy, cw, ch);
+            g.fillStyle = sem.cut;
+            g.strokeRect(cx2 + 0.5, cy + 0.5, cw - 1, ch - 1);
+          }
+          break;
+        }
+        case "niche": {
+          const nw = w * 0.44;
+          drawNicheInto(g, x + (w - nw) / 2, top + h * 0.3, nw, h * 0.45, sem, am);
+          break;
+        }
+        case "vine": {
+          g.strokeStyle = MATERIALS["sabz-700"];
+          g.lineWidth = 2;
+          g.beginPath();
+          for (let i = 0; i <= 20; i++) {
+            const u = i / 20;
+            const vx = x + w * (0.5 + Math.sin(u * 7 + f.seed) * 0.28);
+            const vy = top + h * 0.06 + u * h * 0.8;
+            if (i === 0) g.moveTo(vx, vy);
+            else g.lineTo(vx, vy);
+          }
+          g.stroke();
+          g.fillStyle = over(MATERIALS["sabz-700"], am.sunColor, am.sunAlpha * 1.4);
+          for (let i = 0; i < 14; i++) {
+            const u = i / 14;
+            const vx = x + w * (0.5 + Math.sin(u * 7 + f.seed) * 0.28);
+            const vy = top + h * 0.06 + u * h * 0.8;
+            g.beginPath();
+            g.ellipse(vx + (i % 2 ? 6 : -6), vy, 5, 3, i % 2 ? 0.6 : -0.6, 0, Math.PI * 2);
+            g.fill();
+          }
+          break;
+        }
+        case "fountain": {
+          const fw = w * 0.7;
+          const fx = x + (w - fw) / 2;
+          const fy = top + h - h * 0.3;
+          g.fillStyle = lit(sem.ground, am, 0.9);
+          g.fillRect(fx, fy, fw, h * 0.3);
+          g.fillStyle = sem.water;
+          g.beginPath();
+          g.ellipse(fx + fw / 2, fy, fw / 2, h * 0.035, 0, 0, Math.PI * 2);
+          g.fill();
+          g.strokeStyle = sem.litEdge;
+          g.lineWidth = 1.5;
+          g.beginPath();
+          g.moveTo(fx + fw / 2, fy - h * 0.16);
+          g.lineTo(fx + fw / 2, fy);
+          g.stroke();
+          g.fillStyle = sem.metal;
+          g.beginPath();
+          g.arc(fx + fw / 2, fy - h * 0.18, Math.max(3, w * 0.04), 0, Math.PI * 2);
+          g.fill();
+          break;
+        }
+        case "water-crossing": {
+          g.fillStyle = sem.water;
+          g.fillRect(x + w * 0.2, top + h * 0.72, w * 0.6, h * 0.28);
+          g.fillStyle = lit(sem.ground, am, 1.1);
+          g.fillRect(x + w * 0.1, top + h * 0.68, w * 0.8, h * 0.06);
+          g.fillStyle = sem.litEdge;
+          g.fillRect(x + w * 0.1, top + h * 0.68, w * 0.8, 1);
+          break;
+        }
+        default:
+          break;
+      }
+    }
+  }
+
+  // ── L0 ──────────────────────────────────────────────────────────────────
+  private drawSky(g: CanvasRenderingContext2D, s: BackdropState): void {
+    const { lay, sem, am } = s;
+    const horizon = lay.stallTop + lay.stallH * 0.5;
+    const grad = g.createLinearGradient(0, 0, 0, horizon);
+    grad.addColorStop(0, sem.skyHigh);
+    grad.addColorStop(1, over(sem.skyLow, am.sunColor, am.sunAlpha * 0.7));
+    g.fillStyle = grad;
+    g.fillRect(0, 0, lay.w, horizon);
+    g.fillStyle = over(sem.skyLow, am.sunColor, am.sunAlpha * 0.7);
+    g.fillRect(0, horizon, lay.w, lay.h - horizon);
+
+    // Stars, and the observatory instruments do point at them.
+    if (am.night > 0.25) {
+      g.save();
+      g.globalAlpha = clamp((am.night - 0.25) / 0.5, 0, 1);
+      for (const [name, fx, fy, mag] of STARS) {
+        const x = fx * lay.w;
+        const y = fy * lay.skyH;
+        const tw = s.reduced ? 1 : 1 + idle(s.t, mixSeed(name.length, 3), 0.12);
+        g.fillStyle = alpha(MATERIALS["glass-clear"], 0.55 * mag * tw);
+        g.beginPath();
+        g.arc(x, y, 1.1 + mag * 0.9, 0, Math.PI * 2);
+        g.fill();
+      }
+      // A scatter of lesser stars.
+      for (let i = 0; i < 60; i++) {
+        const sd = mixSeed(i, 0x77aa);
+        g.fillStyle = alpha(MATERIALS["glass-clear"], 0.1 + frand(mixSeed(sd, 1)) * 0.3);
+        g.fillRect(frand(sd) * lay.w, frand(mixSeed(sd, 2)) * lay.skyH * 1.1, 1, 1);
+      }
+      g.restore();
+    }
+
+    // The low sun, at golden hour. A disc, not a lens flare.
+    if (am.gild > 0.1 && am.night < 0.6) {
+      const sx = lay.w * 0.78;
+      const sy = lay.skyH * (1.05 - am.gild * 0.2);
+      g.save();
+      g.globalCompositeOperation = "lighter";
+      g.fillStyle = alpha(am.sunColor, 0.22 * am.gild);
+      g.beginPath();
+      g.arc(sx, sy, lay.M * 0.34, 0, Math.PI * 2);
+      g.fill();
+      g.fillStyle = alpha("#fff3d6", 0.5 * am.gild);
+      g.beginPath();
+      g.arc(sx, sy, lay.M * 0.09, 0, Math.PI * 2);
+      g.fill();
+      g.restore();
+    }
+  }
+
+  // ── L1 ──────────────────────────────────────────────────────────────────
+  private drawFarLayer(
+    g: CanvasRenderingContext2D,
+    s: BackdropState,
+    project: (wx: number) => number,
+    c: SkyContext,
+  ): void {
+    const { lay } = s;
+    const base = lay.skyH + lay.canopyH * 0.95;
+    const span = lay.M * 6;
+    const centre = s.camX + lay.w / 2;
+    const first = Math.floor((centre - (lay.w / 2 / 0.08 + span)) / span);
+    const last = Math.ceil((centre + (lay.w / 2 / 0.08 + span)) / span);
+
+    for (let k = first; k <= last; k++) {
+      const wx = k * span;
+      const x = project(wx);
+      if (x < -lay.M || x > lay.w + lay.M) continue;
+      const sd = mixSeed(s.seed, k * 977);
+      const r = frand(sd);
+      const wardIx = Math.abs(k) % 5;
+      const wardId = (["lapis", "turquoise", "madder", "hemp", "aubergine"] as WardId[])[wardIx]!;
+      if (r < 0.32) {
+        drawTower(
+          g,
+          x,
+          base,
+          lay.M * 0.15,
+          lay.skyH * (1.05 + frand(mixSeed(sd, 1)) * 0.95),
+          wardId,
+          (["meridian", "vane", "signal", "gear", "armillary"] as const)[Math.abs(k) % 5]!,
+          (["girih5", "khatem8", "hex6", "twelve12", "lattice"] as const)[Math.abs(k * 3) % 5]!,
+          sd,
+          c,
+          s.t,
+        );
+      } else if (r < 0.5) {
+        drawDome(g, x, base, lay.M * (0.22 + frand(mixSeed(sd, 2)) * 0.16), wardId, sd, c);
+      } else {
+        drawRoofBlock(
+          g,
+          x - lay.M * 0.28,
+          base,
+          lay.M * (0.4 + frand(mixSeed(sd, 3)) * 0.5),
+          lay.skyH * (0.24 + frand(mixSeed(sd, 4)) * 0.5),
+          sd,
+          c,
+          false,
+        );
+      }
+    }
+
+    // The next ward's tower, tied to its gate, so you can always see somewhere
+    // you have not been.
+    for (const f of s.street.features) {
+      if (f.kind !== "gate") continue;
+      const x = project(f.x);
+      if (x < -lay.M || x > lay.w + lay.M) continue;
+      drawTower(
+        g,
+        x,
+        base,
+        lay.M * 0.22,
+        lay.skyH * 1.6,
+        f.ward,
+        f.quarter.finial,
+        f.quarter.fold,
+        f.seed,
+        c,
+        s.t,
+      );
+    }
+  }
+
+  // ── L2 ──────────────────────────────────────────────────────────────────
+  private drawMidLayer(
+    g: CanvasRenderingContext2D,
+    s: BackdropState,
+    project: (wx: number) => number,
+    c: SkyContext,
+  ): void {
+    const { lay, sem, am } = s;
+    const base = lay.stallTop + lay.stallH * 0.5;
+    const span = lay.M * 1.55;
+    const centre = s.camX + lay.w / 2;
+    const reach = lay.w / 2 / 0.22 + span * 2;
+    const first = Math.floor((centre - reach) / span);
+    const last = Math.ceil((centre + reach) / span);
+
+    const tops: { x: number; y: number }[] = [];
+    for (let k = first; k <= last; k++) {
+      const wx = k * span;
+      const x = project(wx);
+      if (x < -lay.M * 1.4 || x > lay.w + lay.M * 1.4) continue;
+      const sd = mixSeed(s.seed ^ 0x2f, k * 613);
+      const w = lay.M * (0.4 + frand(sd) * 0.3);
+      const h = lay.stallH * 0.5 + lay.canopyH * (0.3 + frand(mixSeed(sd, 1)) * 0.75);
+      drawRoofBlock(g, x, base, w, h, sd, c, true);
+      tops.push({ x: x + w * 0.5, y: base - h });
+    }
+
+    // Laundry lines and cables between the roofs. Nothing says "people live
+    // here" faster than a rope with washing on it.
+    g.strokeStyle = over(sem.groundShade, sem.haze, (am.hazeAlpha * c.depth) / 6);
+    g.lineWidth = 1;
+    for (let i = 1; i < tops.length; i++) {
+      const a = tops[i - 1]!;
+      const bpt = tops[i]!;
+      if (Math.abs(bpt.x - a.x) > lay.M * 1.3) continue;
+      const sag = Math.min(26, Math.abs(bpt.x - a.x) * 0.16);
+      g.beginPath();
+      g.moveTo(a.x, a.y);
+      g.quadraticCurveTo((a.x + bpt.x) / 2, Math.max(a.y, bpt.y) + sag, bpt.x, bpt.y);
+      g.stroke();
+      if (i % 2 === 0) {
+        const n = 4;
+        for (let j = 1; j < n; j++) {
+          const u = j / n;
+          const lx = a.x + (bpt.x - a.x) * u;
+          const ly =
+            (1 - u) * (1 - u) * a.y +
+            2 * (1 - u) * u * (Math.max(a.y, bpt.y) + sag) +
+            u * u * bpt.y;
+          const sd = mixSeed(i * 31 + j, 0x5b);
+          g.fillStyle = over(
+            [MATERIALS["bone-100"], MATERIALS["saffron-400"], MATERIALS["madder-600"], MATERIALS["turquoise-500"]][
+              Math.floor(frand(sd) * 4)
+            ]!,
+            sem.haze,
+            (am.hazeAlpha * c.depth) / 6,
+          );
+          const cw = lay.M * 0.05;
+          const ch = lay.M * (0.07 + frand(mixSeed(sd, 1)) * 0.05);
+          const sway = s.reduced ? 0 : idle(s.t, sd, 0.06);
+          g.save();
+          g.translate(lx, ly);
+          g.rotate(sway);
+          g.fillRect(-cw / 2, 0, cw, ch);
+          g.restore();
+        }
+      }
+      // Pigeons on the wire.
+      if (s.budget.fauna && i % 3 === 0) {
+        const px = (a.x + bpt.x) / 2;
+        const py = Math.max(a.y, bpt.y) + sag - 3;
+        drawPigeon(g, px, py, lay.M * 0.03, 0, { sem, am, depth: c.depth, reduced: s.reduced }, s.t, i);
+      }
+    }
+  }
+
+  // ── L3 ──────────────────────────────────────────────────────────────────
+  private drawCanopy(
+    g: CanvasRenderingContext2D,
+    s: BackdropState,
+    centre: number,
+    c: CanopyCtx,
+  ): { x: number; y: number; w: number; seed: number }[] {
+    const { lay } = s;
+    const project = this.rig.projector("canopy", centre);
+    const span = lay.M * 0.72;
+    const reach = lay.w / 2 / 0.55 + span * 2;
+    const first = Math.floor((centre - reach) / span);
+    const last = Math.ceil((centre + reach) / span);
+    const shafts: { x: number; y: number; w: number; seed: number }[] = [];
+    const bandH = lay.skyH * 0.62;
+    const fold = s.street.nearestStall(s.camX + lay.w / 2)?.quarter.fold ?? "girih5";
+
+    for (let k = first; k <= last; k++) {
+      const wx = k * span;
+      const x = project(wx);
+      const w = span;
+      if (x + w < -20 || x - w > lay.w + 20) continue;
+      const sd = mixSeed(s.seed ^ 0x91, k * 409);
+      drawArcadeBay(g, x - w / 2, w, 0, bandH, s.ward, fold, sd, c);
+      if ((k & 1) === 0) shafts.push({ x, y: bandH * 0.9, w: w * 0.3, seed: sd });
+    }
+    return shafts;
+  }
+
+  private drawLanterns(
+    g: CanvasRenderingContext2D,
+    s: BackdropState,
+    centre: number,
+    c: CanopyCtx,
+  ): void {
+    const { lay } = s;
+    const project = this.rig.projector("canopy", centre);
+    const span = lay.M * 0.36;
+    const reach = lay.w / 2 / 0.55 + span * 2;
+    const first = Math.floor((centre - reach) / span);
+    const last = Math.ceil((centre + reach) / span);
+    const top = lay.skyH * 0.58;
+    for (let k = first; k <= last; k++) {
+      const x = project(k * span);
+      if (x < -60 || x > lay.w + 60) continue;
+      const sd = mixSeed(s.seed ^ 0x33, k * 271);
+      if (frand(sd) > 0.62) continue;
+      drawLantern(g, x, top, lay.M * (0.055 + frand(mixSeed(sd, 1)) * 0.035), sd, c, s.t, s.lanternKick);
+    }
+  }
+
+  // ── L6 ──────────────────────────────────────────────────────────────────
+  private drawTraffic(
+    g: CanvasRenderingContext2D,
+    s: BackdropState,
+    centre: number,
+    c: LifeCtx,
+  ): void {
+    const { lay } = s;
+    const project = this.rig.projector("fore", centre);
+    const streetP = this.rig.projector("street", centre);
+
+    // The near pavement.
+    this.crowdNear.setCount(lay.small ? 2 : 4);
+    this.crowdNear.update(s.dt, centre, lay.w * 1.8);
+    this.crowdNear.draw(g, project, lay.w, lay.h - lay.floorH * 0.02, lay.M * 0.34, c, s.t);
+
+    // Cats sleep on the sills of the interstitials; one per screen.
+    for (const f of s.street.visible(s.camX - lay.M, s.camX + lay.w + lay.M)) {
+      if (f.kind !== "interstitial") continue;
+      const x = streetP(f.x + f.width / 2);
+      if (f.type === "cat") {
+        drawCat(g, x, lay.floorY + lay.floorH * 0.34, lay.M * 0.14, s.catWake, c, s.t, f.seed);
+      } else if (f.type === "porter") {
+        drawPorter(g, project(f.x + f.width / 2), lay.h - lay.floorH * 0.1, lay.M * 0.3, c, s.t);
+      } else if (f.type === "fountain") {
+        drawSteam(g, x, lay.floorY - lay.M * 0.1, f.seed, c, s.t);
+      }
+    }
+
+    // A carpet drifts across, high up, every so often. It is the loading state
+    // for a game and the fast-travel affordance between wards, so it belongs to
+    // the world rather than to a spinner.
+    const period = 34;
+    const u = ((s.t % period) / period) * 1.4 - 0.2;
+    if (u > -0.15 && u < 1.15) {
+      drawCarpet(
+        g,
+        u * (lay.w + lay.M * 2) - lay.M,
+        lay.stallTop + lay.stallH * 0.1 + Math.sin(u * 6) * 16,
+        lay.M * 0.7,
+        c,
+        s.t,
+        3,
+      );
+    }
+  }
+
+  private drawValveObject(g: CanvasRenderingContext2D, s: BackdropState, c: CanopyCtx): void {
+    const { lay } = s;
+    drawValve(g, lay.w - lay.M * 0.13, lay.skyH * 0.5, Math.max(9, lay.M * 0.032), s.soundOpen, c);
+  }
+}
+
+/** A niche cut into a party wall. */
+function drawNicheInto(
+  g: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  sem: Semantic,
+  am: Ambient,
+): void {
+  g.fillStyle = shade(sem.ground, am, 1.5, sem.shadow);
+  g.beginPath();
+  g.moveTo(x, y + h);
+  g.lineTo(x, y + h * 0.45);
+  archPath(g, x + w / 2, y + h * 0.45, w, "drop");
+  g.lineTo(x + w, y + h);
+  g.closePath();
+  g.fill();
+  g.strokeStyle = sem.litEdge;
+  g.lineWidth = 1;
+  g.stroke();
+  // A pot in the niche, because an empty niche is a hole.
+  g.fillStyle = over(MATERIALS["terracotta-600"], am.sunColor, am.sunAlpha);
+  g.beginPath();
+  g.ellipse(x + w / 2, y + h * 0.86, w * 0.2, h * 0.14, 0, 0, Math.PI * 2);
+  g.fill();
+}
+
+/** A ward gate: ablaq voussoirs, an odd count so a keystone exists. */
+export function drawGate(
+  g: CanvasRenderingContext2D,
+  x: number,
+  w: number,
+  lay: Layout,
+  sem: Semantic,
+  am: Ambient,
+  ward: WardId,
+  name: string,
+): void {
+  const top = lay.stallTop - lay.canopyH * 0.2;
+  const base = lay.floorY;
+  const h = base - top;
+  const openW = w * 0.72;
+  const cx = x + w / 2;
+
+  g.fillStyle = lit(sem.ground, am, 0.6);
+  g.fillRect(x, top, w, h);
+  g.fillStyle = sem.cut;
+  g.fillRect(x, top, 1, h);
+  g.fillRect(x + w - 1, top, 1, h);
+
+  // The opening, and what you see through it: the next ward, hazed.
+  const springY = top + h * 0.52;
+  g.save();
+  g.beginPath();
+  g.moveTo(cx - openW / 2, base);
+  g.lineTo(cx - openW / 2, springY);
+  archPath(g, cx, springY, openW, "equilateral");
+  g.lineTo(cx + openW / 2, base);
+  g.closePath();
+  // Through the gate: the next ward, one haze step further away. A gate you
+  // cannot see through is a wall with a shape cut in it.
+  g.fillStyle = over(shade(sem.ground, am, 1.1, sem.shadow), sem.haze, am.hazeAlpha * 0.4);
+  g.fill();
+  // A receding vista: three hazed courses of the next ward's street, each one
+  // step further off, and a bright slot of pavement at the end.
+  for (let i = 0; i < 3; i++) {
+    const k = (i + 1) / 4;
+    g.fillStyle = over(lit(sem.ground, am, 0.4), sem.haze, am.hazeAlpha * (0.3 + i * 0.22));
+    g.fillRect(cx - openW * (0.5 - k * 0.16), springY + h * (0.1 + i * 0.09), openW * (1 - k * 0.32), h * 0.09);
+  }
+  g.fillStyle = over(lit(sem.ground, am, 1.6), sem.haze, am.hazeAlpha * 0.8);
+  g.fillRect(cx - openW * 0.34, base - h * 0.14, openW * 0.68, h * 0.14);
+  g.restore();
+
+  // Ablaq voussoirs: alternating courses of light and dark stone, an ODD count
+  // so a keystone exists. A ring, struck from the springing line — the arch
+  // ring is the structure, and a filled fan would be a decoration of one.
+  const n = 11;
+  const ri = openW / 2;
+  const ro = openW / 2 + w * 0.075;
+  g.save();
+  g.beginPath();
+  g.moveTo(cx - ro, base);
+  g.lineTo(cx - ro, springY);
+  archPath(g, cx, springY, ro * 2, "equilateral");
+  g.lineTo(cx + ro, base);
+  g.closePath();
+  g.clip();
+  g.beginPath();
+  g.moveTo(cx - ri, base);
+  g.lineTo(cx - ri, springY);
+  archPath(g, cx, springY, openW, "equilateral");
+  g.lineTo(cx + ri, base);
+  g.closePath();
+  const ring = new Path2D();
+  ring.rect(cx - ro - 2, springY - ro * 2, ro * 2 + 4, ro * 2 + (base - springY));
+  for (let i = 0; i < n; i++) {
+    const a0 = Math.PI + (Math.PI * i) / n;
+    const a1 = Math.PI + (Math.PI * (i + 1)) / n;
+    g.fillStyle = i % 2 === 0 ? MATERIALS["sandstone-50"] : MATERIALS["manganese-900"];
+    g.beginPath();
+    g.moveTo(cx + ri * Math.cos(a0), springY + ri * Math.sin(a0));
+    g.arc(cx, springY, ri, a0, a1);
+    g.lineTo(cx + ro * Math.cos(a1), springY + ro * Math.sin(a1));
+    g.arc(cx, springY, ro, a1, a0, true);
+    g.closePath();
+    g.fill();
+  }
+  void ring;
+  g.restore();
+
+  // A muqarnas hood in the tympanum — the gate is carrying the lintel, and
+  // this is what carries it.
+  drawMuqarnas(g, {
+    x: cx - openW * 0.45,
+    y: springY - openW * 0.3,
+    width: openW * 0.9,
+    height: openW * 0.19,
+    tiers: 5,
+    k0: 4,
+    ground: sem.ground,
+    sun: am.sunColor,
+    sunAlpha: am.sunAlpha,
+    shadow: sem.shadow,
+    shadowAlpha: am.shadowAlpha,
+    litEdge: sem.litEdge,
+    cut: sem.cut,
+  });
+
+  // The ward's colour, once, as a tiled band above; and the name cut into the
+  // lintel — on stone, never on glaze (BZ-LAW-7).
+  const band = WARDS[ward];
+  g.fillStyle = band.glaze;
+  g.fillRect(x + w * 0.08, top + h * 0.1, w * 0.84, h * 0.05);
+  g.fillStyle = band.glazeDeep;
+  for (let i = 0; i * 10 < w * 0.84; i++) g.fillRect(x + w * 0.08 + i * 10, top + h * 0.1, 3, h * 0.05);
+
+  g.fillStyle = lit(sem.ground, am, 1.4);
+  g.fillRect(x + w * 0.05, top + h * 0.17, w * 0.9, h * 0.075);
+  g.fillStyle = sem.litEdge;
+  g.fillRect(x + w * 0.05, top + h * 0.17, w * 0.9, 1);
+  g.fillStyle = sem.cut;
+  g.fillRect(x + w * 0.05, top + h * 0.245 - 1, w * 0.9, 1);
+  g.font = `${Math.round(h * 0.042)}px "Iowan Old Style", Palatino, serif`;
+  g.textAlign = "center";
+  g.textBaseline = "middle";
+  // Cut into stone: one lit offset up-left, one cut offset down-right.
+  g.fillStyle = sem.litEdge;
+  g.fillText(name, cx - 1, top + h * 0.206 - 1, w * 0.84);
+  g.fillStyle = sem.cut;
+  g.fillText(name, cx + 1, top + h * 0.206 + 1, w * 0.84);
+  g.fillStyle = sem.inkMuted;
+  g.fillText(name, cx, top + h * 0.206, w * 0.84);
+  g.textAlign = "left";
+}

--- a/dynawalla/bazaar/src/world/canopy.ts
+++ b/dynawalla/bazaar/src/world/canopy.ts
@@ -1,0 +1,370 @@
+/**
+ * L3 — the canopy: brick vault, skylight oculi, hanging lanterns, and the
+ * shafts of light that fall through.
+ *
+ * The Isfahan Grand Bazaar is two kilometres of brick-vaulted street lit by
+ * oculi punched through the crown of the vault. That is the whole lighting
+ * model here: the street is roofed, the roof is pierced, and everything warm
+ * about the picture comes down through those holes.
+ *
+ * Dust lives **only inside a shaft polygon** — which is both physically true
+ * and the reason it costs nothing: there are never motes where you would not
+ * see them.
+ */
+
+import { frand, mix as mixSeed, idle, clamp } from "../util/rng.ts";
+import { alpha, over } from "../util/color.ts";
+import { archPath } from "../geometry/arch.ts";
+import { patternPanel } from "../geometry/pattern.ts";
+import { sprite, bucket } from "./sprites.ts";
+import type { Ambient } from "./daylight.ts";
+import { lit, shade } from "./daylight.ts";
+import type { Semantic } from "../tokens/palette.ts";
+import { WARDS, type WardId, MATERIALS } from "../tokens/palette.ts";
+import type { Fold } from "../types.ts";
+import type { Layout } from "./layout.ts";
+
+export interface CanopyCtx {
+  sem: Semantic;
+  am: Ambient;
+  dpr: number;
+  lay: Layout;
+  reduced: boolean;
+  motes: number;
+}
+
+const GLASS = [
+  MATERIALS["glass-amber"],
+  MATERIALS["glass-ruby"],
+  MATERIALS["glass-emerald"],
+  MATERIALS["glass-cobalt"],
+  MATERIALS["glass-clear"],
+];
+
+/**
+ * One bay of the arcade you are standing under.
+ *
+ * It hangs across the very top of the frame — the near edge of the vault, seen
+ * from beneath — and its openings are **cut clean through**, so the sky and the
+ * far towers you can see from inside this ward show in the holes. That is what
+ * makes the picture read as a covered street rather than a wall with a sky
+ * pasted on it, and it is where every shaft of light in the bazaar comes from.
+ */
+export function drawArcadeBay(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  w: number,
+  top: number,
+  h: number,
+  ward: WardId,
+  fold: Fold,
+  seed: number,
+  c: CanopyCtx,
+): void {
+  const key = `bay2|${ward}|${fold}|${seed & 63}|${bucket(c.am.night, 12)}|${bucket(c.am.sunAlpha, 12)}`;
+  const s = sprite(key, w, h, c.dpr, (g, bw, bh) => {
+    const soffit = shade(c.sem.ground, c.am, 1.05, c.sem.shadow);
+    const ribW = Math.max(6, bw * 0.09);
+
+    g.fillStyle = soffit;
+    g.fillRect(0, 0, bw, bh);
+
+    // Brick coursing on the soffit, following the curve of the vault.
+    g.strokeStyle = over(soffit, c.sem.cut, 0.4);
+    g.lineWidth = 1;
+    for (let i = 1; i < 6; i++) {
+      const y = (i / 6) * bh * 0.8;
+      g.beginPath();
+      g.moveTo(0, y);
+      g.quadraticCurveTo(bw / 2, y - bh * 0.12, bw, y);
+      g.stroke();
+    }
+
+    // Cut the opening clean through the roof.
+    const ow = bw - ribW * 2;
+    const oh = bh * 0.86;
+    const ox = ribW;
+    const oy = -bh * 0.1;
+    g.save();
+    g.globalCompositeOperation = "destination-out";
+    g.beginPath();
+    g.moveTo(ox, oy + oh);
+    g.lineTo(ox, oy + oh * 0.46);
+    archPath(g, ox + ow / 2, oy + oh * 0.46, ow, "equilateral");
+    g.lineTo(ox + ow, oy + oh);
+    g.closePath();
+    g.fill();
+    g.restore();
+
+    // A pierced screen across the head of the opening: girih you see sky
+    // through, which is the only honest way to use it.
+    const panel = patternPanel({
+      width: ow,
+      height: oh * 0.52,
+      fold: fold === "lattice" ? "hex6" : fold,
+      edge: Math.max(11, oh * 0.2),
+      ground: soffit,
+      strap: over(soffit, c.sem.metalLit, 0.85),
+      glaze: soffit,
+      glazeDeep: soffit,
+      transparent: true,
+      dpr: c.dpr,
+    });
+    g.save();
+    g.beginPath();
+    g.moveTo(ox, oy + oh * 0.46);
+    archPath(g, ox + ow / 2, oy + oh * 0.46, ow, "equilateral");
+    g.closePath();
+    g.clip();
+    g.drawImage(panel, ox, oy, ow, oh * 0.52);
+    g.restore();
+
+    // The rib on each side, and a lit edge on its sun face.
+    for (const rx of [0, bw - ribW]) {
+      g.fillStyle = lit(c.sem.ground, c.am, 0.4);
+      g.fillRect(rx, 0, ribW, bh);
+      g.fillStyle = c.sem.litEdge;
+      g.globalAlpha = 0.4;
+      g.fillRect(rx, 0, 1, bh);
+      g.globalAlpha = 1;
+      g.fillStyle = c.sem.cut;
+      g.fillRect(rx + ribW - 1, 0, 1, bh);
+    }
+
+    // The cornice along the lower edge, in the ward's glaze. Colour, never text.
+    const band = WARDS[ward];
+    const ch = Math.max(3, bh * 0.07);
+    g.fillStyle = band.glaze;
+    g.fillRect(0, bh - ch, bw, ch);
+    g.fillStyle = band.glazeDeep;
+    for (let i = 0; i * 14 < bw; i++) g.fillRect(i * 14, bh - ch, 5, ch);
+    g.fillStyle = c.sem.litEdge;
+    g.globalAlpha = 0.5;
+    g.fillRect(0, bh - ch, bw, 1);
+    g.globalAlpha = 1;
+    g.fillStyle = c.sem.cut;
+    g.fillRect(0, bh - 1, bw, 1);
+  });
+  ctx.drawImage(s, x, top, w, h);
+}
+
+/**
+ * A shaft of light from an oculus to the floor, with dust turning in it.
+ * The shaft angle is 90° − sun azimuth, so it rakes as the day goes on.
+ */
+export function drawLightShaft(
+  ctx: CanvasRenderingContext2D,
+  ox: number,
+  oy: number,
+  ow: number,
+  floorY: number,
+  seed: number,
+  c: CanopyCtx,
+  t: number,
+  scatter: { x: number; y: number; age: number } | null,
+): void {
+  const drop = floorY - oy;
+  const lean = Math.tan((c.am.shaftAngle * Math.PI) / 180) * drop;
+  const spread = ow * 2.1;
+  const g = ctx;
+  const strength = clamp(c.am.sunAlpha * 0.72 * (1 - c.am.night * 0.9), 0, 0.2);
+  if (strength > 0.01) {
+    g.save();
+    g.globalCompositeOperation = "lighter";
+    g.fillStyle = alpha(c.am.sunColor, strength * 0.5);
+    g.beginPath();
+    g.moveTo(ox - ow / 2, oy);
+    g.lineTo(ox + ow / 2, oy);
+    g.lineTo(ox + lean + spread / 2, floorY);
+    g.lineTo(ox + lean - spread / 2, floorY);
+    g.closePath();
+    g.fill();
+    // A brighter core, one flat step. Two polygons, never a gradient.
+    g.fillStyle = alpha(c.am.sunColor, strength * 0.45);
+    g.beginPath();
+    g.moveTo(ox - ow * 0.22, oy);
+    g.lineTo(ox + ow * 0.22, oy);
+    g.lineTo(ox + lean + spread * 0.2, floorY);
+    g.lineTo(ox + lean - spread * 0.2, floorY);
+    g.closePath();
+    g.fill();
+    g.restore();
+  }
+
+  if (c.motes <= 0) return;
+  const n = Math.round(c.motes * c.am.dustGain * 0.5);
+  g.save();
+  g.fillStyle = alpha(c.am.sunColor, 0.85);
+  for (let i = 0; i < n; i++) {
+    const s = mixSeed(seed, i);
+    const u = frand(s);
+    // Brownian jitter plus a 6 px/s downward drift, wrapped.
+    const drift = c.reduced ? 0.5 : ((frand(mixSeed(s, 1)) + t * 0.06 / 1) % 1);
+    const v = drift;
+    const jx = c.reduced ? 0 : idle(t, mixSeed(s, 2), 3.2);
+    const jy = c.reduced ? 0 : idle(t, mixSeed(s, 3), 2.4);
+    const width = ow + (spread - ow) * v;
+    let px = ox + lean * v + (u - 0.5) * width + jx;
+    let py = oy + drop * v + jy;
+    if (scatter && scatter.age < 0.7) {
+      const dx = px - scatter.x;
+      const dy = py - scatter.y;
+      const d = Math.hypot(dx, dy);
+      if (d < 140 && d > 0.5) {
+        const k = (1 - scatter.age / 0.7) * (1 - d / 140) * 40;
+        px += (dx / d) * k;
+        py += (dy / d) * k;
+      }
+    }
+    const r = 0.7 + frand(mixSeed(s, 4)) * 1.1;
+    g.globalAlpha = 0.35 + 0.45 * (1 - v);
+    g.fillRect(px, py, r, r);
+  }
+  g.restore();
+}
+
+/** A hanging lantern: pierced brass, coloured glass, a real pendulum. */
+export function drawLantern(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  topY: number,
+  size: number,
+  seed: number,
+  c: CanopyCtx,
+  t: number,
+  kick = 0,
+): void {
+  const chain = size * (1.1 + frand(seed) * 1.5);
+  // T = 2π√(L/g), scaled to a 2.4 s swing; amplitude 1.5°, gusts to 4°.
+  const swing = c.reduced
+    ? 0
+    : (idle(t / 2.4, seed, 1.5) + kick) * (Math.PI / 180);
+  const g = ctx;
+  const cx = x + Math.sin(swing) * chain;
+  const cy = topY + Math.cos(swing) * chain;
+
+  g.strokeStyle = c.sem.metalShade;
+  g.lineWidth = 1.5;
+  g.beginPath();
+  g.moveTo(x, topY);
+  g.lineTo(cx, cy);
+  g.stroke();
+
+  const glass = GLASS[seed % GLASS.length]!;
+  const gain = c.am.lanternGain;
+  const body = sprite(
+    `lantern|${seed % GLASS.length}|${Math.round(size)}|${bucket(gain, 10)}|${bucket(c.am.night, 8)}`,
+    size * 1.2,
+    size * 1.9,
+    c.dpr,
+    (h, lw) => {
+      const lx = lw / 2;
+      // Cap and hanging ring.
+      h.strokeStyle = c.sem.metal;
+      h.lineWidth = 1.5;
+      h.beginPath();
+      h.arc(lx, size * 0.12, size * 0.09, 0, Math.PI * 2);
+      h.stroke();
+      // The glass body, an eight-sided lamp.
+      const bodyTop = size * 0.28;
+      const bodyH = size * 1.0;
+      const bw = size * 0.7;
+      h.fillStyle = gain > 0.05 ? over(glass, "#ffe9bc", 0.35 * gain) : over(glass, c.sem.ground, 0.5);
+      h.beginPath();
+      h.moveTo(lx - bw / 2, bodyTop + bodyH * 0.2);
+      h.lineTo(lx - bw * 0.32, bodyTop);
+      h.lineTo(lx + bw * 0.32, bodyTop);
+      h.lineTo(lx + bw / 2, bodyTop + bodyH * 0.2);
+      h.lineTo(lx + bw * 0.4, bodyTop + bodyH);
+      h.lineTo(lx - bw * 0.4, bodyTop + bodyH);
+      h.closePath();
+      h.fill();
+      // Pierced brass strapping — the piercing is what the light comes through.
+      h.strokeStyle = c.sem.metal;
+      h.lineWidth = Math.max(1, size * 0.045);
+      h.stroke();
+      h.beginPath();
+      for (let i = 1; i < 4; i++) {
+        const yy = bodyTop + (bodyH * i) / 4;
+        h.moveTo(lx - bw * 0.44, yy);
+        h.lineTo(lx + bw * 0.44, yy);
+      }
+      h.lineWidth = 1;
+      h.stroke();
+      // The flame, and only when it is lit.
+      if (gain > 0.15) {
+        h.fillStyle = alpha("#fff3d6", 0.9);
+        h.beginPath();
+        h.ellipse(lx, bodyTop + bodyH * 0.62, size * 0.075, size * 0.13, 0, 0, Math.PI * 2);
+        h.fill();
+      }
+      // A brass tassel below.
+      h.strokeStyle = c.sem.metal;
+      h.lineWidth = 1.5;
+      h.beginPath();
+      h.moveTo(lx, bodyTop + bodyH);
+      h.lineTo(lx, bodyTop + bodyH + size * 0.2);
+      h.stroke();
+      h.fillStyle = c.sem.metal;
+      h.beginPath();
+      h.arc(lx, bodyTop + bodyH + size * 0.24, size * 0.055, 0, Math.PI * 2);
+      h.fill();
+    },
+  );
+  g.save();
+  g.translate(cx, cy);
+  g.rotate(swing);
+  g.drawImage(body, -size * 0.6, 0, size * 1.2, size * 1.9);
+  g.restore();
+
+  // The pool of light it throws. One additive ellipse, capped — never a glow
+  // stack, and never more than 3 % luminance of flicker (BZ-12).
+  if (gain > 0.1) {
+    const flick = c.reduced ? 0 : 1 + idle(t, mixSeed(seed, 9), 0.03);
+    g.save();
+    g.globalCompositeOperation = "lighter";
+    g.fillStyle = alpha("#f5b94a", 0.06 * gain * flick);
+    g.beginPath();
+    g.ellipse(cx, cy + size * 0.8, size * 1.6, size * 1.15, 0, 0, Math.PI * 2);
+    g.fill();
+    g.restore();
+  }
+}
+
+/** The brass sound-valve on a canopy strut. The only sound control there is. */
+export function drawValve(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  size: number,
+  open: boolean,
+  c: CanopyCtx,
+): void {
+  const g = ctx;
+  g.strokeStyle = c.sem.metalShade;
+  g.lineWidth = Math.max(2, size * 0.16);
+  g.beginPath();
+  g.moveTo(x - size, y);
+  g.lineTo(x + size, y);
+  g.stroke();
+  g.fillStyle = c.sem.metal;
+  g.beginPath();
+  g.arc(x, y, size * 0.52, 0, Math.PI * 2);
+  g.fill();
+  g.strokeStyle = c.sem.cut;
+  g.lineWidth = 1;
+  g.stroke();
+  // The handle: across the pipe when open, along it when shut. A shape, not
+  // a colour, and not a word.
+  g.strokeStyle = c.sem.litEdge;
+  g.lineWidth = Math.max(2, size * 0.18);
+  g.beginPath();
+  if (open) {
+    g.moveTo(x, y - size * 0.72);
+    g.lineTo(x, y + size * 0.72);
+  } else {
+    g.moveTo(x - size * 0.72, y);
+    g.lineTo(x + size * 0.72, y);
+  }
+  g.stroke();
+}

--- a/dynawalla/bazaar/src/world/daylight.ts
+++ b/dynawalla/bazaar/src/world/daylight.ts
@@ -1,0 +1,157 @@
+/**
+ * How the bazaar shifts between day and night.
+ *
+ * Two independent axes, and conflating them is the predictable bug:
+ *
+ *   · **theme** chooses which keyframe set the ambient interpolates over.
+ *     Light runs morning → dusk; night runs lamplit-evening → deep night.
+ *   · **day-state** `D ∈ [0,1]` chooses where in that set you are. It drives
+ *     one struct, and everything reads it.
+ *
+ * Transitions are continuous and slow — a 40 s dusk, never a cut. The child
+ * should never catch the light changing; they should only notice, at some
+ * point, that it has.
+ */
+
+import { lerp, clamp } from "../util/rng.ts";
+import { mix, over } from "../util/color.ts";
+import { SEMANTIC, type Semantic } from "../tokens/palette.ts";
+
+export interface Ambient {
+  /** Degrees from the horizontal. */
+  sunAzimuth: number;
+  sunColor: string;
+  sunAlpha: number;
+  shadowAlpha: number;
+  /** Per depth layer; multiplied by layerIndex/6 at the call site. */
+  hazeAlpha: number;
+  lanternGain: number;
+  /** = 90 − sunAzimuth. Drives the light-shaft polygons. */
+  shaftAngle: number;
+  /** 0 = full day, 1 = deep night. Blends the whole semantic layer. */
+  night: number;
+  /** Extra dust in the shafts through the afternoon and golden hour. */
+  dustGain: number;
+  /** Everything gilded, at the end of the day. */
+  gild: number;
+}
+
+interface Key {
+  d: number;
+  az: number;
+  color: string;
+  alpha: number;
+  shadow: number;
+  haze: number;
+  lantern: number;
+  dust: number;
+  gild: number;
+}
+
+// Morning → midday → afternoon → golden. §7.3.
+const DAY: Key[] = [
+  { d: 0.0, az: 68, color: "#fff0ce", alpha: 0.18, shadow: 0.26, haze: 0.28, lantern: 0, dust: 1, gild: 0 },
+  { d: 0.35, az: 82, color: "#ffe7b4", alpha: 0.24, shadow: 0.3, haze: 0.42, lantern: 0, dust: 1, gild: 0 },
+  { d: 0.7, az: 52, color: "#ffd79a", alpha: 0.22, shadow: 0.28, haze: 0.36, lantern: 0, dust: 2, gild: 0.15 },
+  { d: 0.9, az: 26, color: "#ffc178", alpha: 0.3, shadow: 0.22, haze: 0.3, lantern: 0.15, dust: 2, gild: 0.55 },
+  { d: 1.0, az: 12, color: "#ffb268", alpha: 0.3, shadow: 0.18, haze: 0.3, lantern: 0.4, dust: 2, gild: 1 },
+];
+
+// The night bazaar: lamplit evening → deep night. The most beautiful state the
+// product has, and it is what a subscription opens.
+const NIGHT: Key[] = [
+  { d: 0.0, az: 8, color: "#f5b94a", alpha: 0.1, shadow: 0.34, haze: 0.36, lantern: 1, dust: 1, gild: 0.3 },
+  { d: 0.5, az: 4, color: "#f5b94a", alpha: 0.06, shadow: 0.4, haze: 0.5, lantern: 1, dust: 1, gild: 0.2 },
+  { d: 1.0, az: 2, color: "#f5b94a", alpha: 0.04, shadow: 0.44, haze: 0.62, lantern: 1, dust: 1, gild: 0.15 },
+];
+
+function sample(keys: Key[], d: number): Key {
+  const x = clamp(d, 0, 1);
+  for (let i = 1; i < keys.length; i++) {
+    const a = keys[i - 1]!;
+    const b = keys[i]!;
+    if (x <= b.d) {
+      const t = b.d === a.d ? 0 : (x - a.d) / (b.d - a.d);
+      return {
+        d: x,
+        az: lerp(a.az, b.az, t),
+        color: mix(a.color, b.color, t),
+        alpha: lerp(a.alpha, b.alpha, t),
+        shadow: lerp(a.shadow, b.shadow, t),
+        haze: lerp(a.haze, b.haze, t),
+        lantern: lerp(a.lantern, b.lantern, t),
+        dust: lerp(a.dust, b.dust, t),
+        gild: lerp(a.gild, b.gild, t),
+      };
+    }
+  }
+  return keys[keys.length - 1]!;
+}
+
+/**
+ * `d` is the day-state (0 = morning, 1 = dusk).
+ * `night` is the dusk blend, 0…1, which the 40 s transition drives.
+ */
+export function ambient(d: number, night: number): Ambient {
+  const n = clamp(night, 0, 1);
+  const day = sample(DAY, d);
+  const nite = sample(NIGHT, d);
+  const az = lerp(day.az, nite.az, n);
+  return {
+    sunAzimuth: az,
+    sunColor: mix(day.color, nite.color, n),
+    sunAlpha: lerp(day.alpha, nite.alpha, n),
+    shadowAlpha: lerp(day.shadow, nite.shadow, n),
+    hazeAlpha: lerp(day.haze, nite.haze, n),
+    lanternGain: Math.max(lerp(day.lantern, nite.lantern, n), n),
+    shaftAngle: 90 - az,
+    night: n,
+    dustGain: lerp(day.dust, nite.dust, n),
+    gild: lerp(day.gild, nite.gild, n),
+  };
+}
+
+/** The semantic layer, continuously blended across the dusk. */
+export function semanticAt(night: number): Semantic {
+  const n = clamp(night, 0, 1);
+  const a = SEMANTIC.light;
+  const b = SEMANTIC.night;
+  if (n <= 0) return a;
+  if (n >= 1) return b;
+  const k = (key: keyof Semantic): string => mix(a[key] as string, b[key] as string, n);
+  return {
+    ground: k("ground"),
+    groundLit: k("groundLit"),
+    groundShade: k("groundShade"),
+    skyHigh: k("skyHigh"),
+    skyLow: k("skyLow"),
+    haze: k("haze"),
+    ink: k("ink"),
+    inkMuted: k("inkMuted"),
+    signBoard: k("signBoard"),
+    signInk: k("signInk"),
+    metal: k("metal"),
+    metalShade: k("metalShade"),
+    metalLit: k("metalLit"),
+    cut: k("cut"),
+    litEdge: k("litEdge"),
+    shadow: k("shadow"),
+    shadowAlpha: lerp(a.shadowAlpha, b.shadowAlpha, n),
+    focus: k("focus"),
+    water: k("water"),
+    cloth: k("cloth"),
+    timber: k("timber"),
+  };
+}
+
+/** Sunlight composited onto a surface. BZ-LAW-5. */
+export const lit = (base: string, am: Ambient, k = 1): string =>
+  over(base, am.sunColor, am.sunAlpha * k);
+
+/** Transmitted skylight — the only shadow there is. Never black. */
+export const shade = (base: string, am: Ambient, k = 1, sky = "#2c3a63"): string =>
+  over(base, sky, am.shadowAlpha * k);
+
+/** Aerial perspective: a layer at depth `i` of 6. BZ-LAW-6. */
+export const hazed = (base: string, am: Ambient, i: number, hazeColor: string): string =>
+  over(base, hazeColor, (am.hazeAlpha * i) / 6);

--- a/dynawalla/bazaar/src/world/floor.ts
+++ b/dynawalla/bazaar/src/world/floor.ts
@@ -1,0 +1,252 @@
+/**
+ * L5 — the street floor: zellij paving, the water channel, and the reflections
+ * it carries at night.
+ *
+ * Naqsh-e Jahan has a water channel down all four sides of the square. Ours
+ * runs the length of the street, and it is both the thing a child pokes and
+ * the surface the lanterns land in after dusk.
+ *
+ * Feet polish stone, so the centre of the street is lighter and its grout is
+ * darker than the edges. That one detail does more for "this is a real place"
+ * than any amount of texture.
+ */
+
+import { frand, mix as mixSeed, idle, clamp } from "../util/rng.ts";
+import { alpha, over } from "../util/color.ts";
+import { zellijTile } from "../geometry/zellij.ts";
+import type { Ambient } from "./daylight.ts";
+import { shade } from "./daylight.ts";
+import type { Semantic } from "../tokens/palette.ts";
+import { WARDS, type WardId } from "../tokens/palette.ts";
+import type { Layout } from "./layout.ts";
+
+export interface FloorCtx {
+  sem: Semantic;
+  am: Ambient;
+  dpr: number;
+  lay: Layout;
+  reduced: boolean;
+  reflections: boolean;
+}
+
+let patternCanvas: HTMLCanvasElement | null = null;
+let patternKey = "";
+
+function paving(c: FloorCtx, ward: WardId, seed: number): CanvasPattern | null {
+  const key = `${ward}|${Math.round(c.lay.M)}|${c.am.night > 0.5 ? "n" : "d"}|${seed & 15}`;
+  if (key !== patternKey) {
+    const band = WARDS[ward];
+    const nextWard = WARDS[ward === "lapis" ? "madder" : "lapis"];
+    patternCanvas = zellijTile({
+      pitch: Math.max(13, c.lay.M * 0.065),
+      block: 4,
+      seed,
+      grout: c.sem.cut,
+      field: over(c.sem.ground, c.sem.groundShade, 0.5),
+      glaze: over(band.glaze, c.sem.ground, c.am.night > 0.5 ? 0.7 : 0.6),
+      glazeDeep: over(band.glazeDeep, c.sem.ground, 0.55),
+      repair: over(nextWard.glaze, c.sem.ground, 0.5),
+      dpr: c.dpr,
+    });
+    patternKey = key;
+  }
+  if (!patternCanvas) return null;
+  const ctx = patternCanvas.getContext("2d");
+  const pat = ctx ? ctx.createPattern(patternCanvas, "repeat") : null;
+  // The tile is rasterised at device resolution; bring it back to CSS units.
+  if (pat && c.dpr !== 1) pat.setTransform(new DOMMatrix().scale(1 / c.dpr));
+  return pat;
+}
+
+export interface Reflector {
+  x: number;
+  w: number;
+  color: string;
+  lit: boolean;
+}
+
+export function drawFloor(
+  ctx: CanvasRenderingContext2D,
+  camX: number,
+  ward: WardId,
+  seed: number,
+  c: FloorCtx,
+  t: number,
+  reflectors: Reflector[],
+  ripples: { x: number; age: number }[],
+): void {
+  const { lay, sem, am } = c;
+  const y0 = lay.floorY;
+  const h = lay.h - y0;
+
+  ctx.fillStyle = sem.ground;
+  ctx.fillRect(0, y0, lay.w, h);
+
+  // Zellij paving, squashed because you see it at a grazing angle.
+  const p = paving(c, ward, seed);
+  if (p) {
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(0, y0, lay.w, h);
+    ctx.clip();
+    ctx.translate(-camX % 2048, y0);
+    ctx.scale(1, 0.5);
+    ctx.fillStyle = p;
+    ctx.fillRect(0, 0, lay.w + 2048, h * 2 + 8);
+    ctx.restore();
+  }
+
+  // Feet polish stone: the centre band is lighter, its grout darker, feathered.
+  const bandTop = y0 + h * 0.22;
+  const bandH = h * 0.34;
+  ctx.save();
+  ctx.globalAlpha = 0.08;
+  ctx.fillStyle = am.sunColor;
+  ctx.fillRect(0, bandTop, lay.w, bandH);
+  ctx.globalAlpha = 0.04;
+  ctx.fillRect(0, bandTop - h * 0.08, lay.w, h * 0.08);
+  ctx.fillRect(0, bandTop + bandH, lay.w, h * 0.08);
+  ctx.restore();
+
+  // The kerb: one lit edge, one cut line. That is all a step needs.
+  ctx.fillStyle = sem.litEdge;
+  ctx.globalAlpha = 0.5;
+  ctx.fillRect(0, y0, lay.w, 1);
+  ctx.globalAlpha = 1;
+  ctx.fillStyle = sem.cut;
+  ctx.fillRect(0, y0 + 1, lay.w, 1);
+
+  drawWater(ctx, camX, c, t, reflectors, ripples);
+}
+
+function drawWater(
+  ctx: CanvasRenderingContext2D,
+  camX: number,
+  c: FloorCtx,
+  t: number,
+  reflectors: Reflector[],
+  ripples: { x: number; age: number }[],
+): void {
+  const { lay, sem, am } = c;
+  const wy = lay.floorY + (lay.h - lay.floorY) * 0.68;
+  const wh = Math.max(11, (lay.h - lay.floorY) * 0.22);
+
+  // The channel is cut into the paving: a lip, a reveal, then water.
+  ctx.fillStyle = shade(sem.ground, am, 1.5, sem.shadow);
+  ctx.fillRect(0, wy - 3, lay.w, wh + 6);
+  ctx.fillStyle = sem.water;
+  ctx.fillRect(0, wy, lay.w, wh);
+
+  // Reflections: flipped, low, wobbled. The downsample IS the blur — there is
+  // no `filter: blur` anywhere in the bazaar (BZ-LAW-6).
+  if (c.reflections) {
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(0, wy, lay.w, wh);
+    ctx.clip();
+    for (const r of reflectors) {
+      const wob = c.reduced ? 0 : idle(t, mixSeed(Math.round(r.x), 7), 2);
+      ctx.globalAlpha = r.lit ? 0.4 : 0.22;
+      ctx.fillStyle = r.color;
+      ctx.fillRect(r.x + wob, wy, r.w, wh);
+    }
+    ctx.globalAlpha = 1;
+    ctx.restore();
+  }
+
+  // Two travelling sine bands and a scatter of specular dashes.
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(0, wy, lay.w, wh);
+  ctx.clip();
+  const v = c.reduced ? 0 : t * 11;
+  ctx.strokeStyle = alpha(sem.litEdge, 0.28);
+  ctx.lineWidth = 1;
+  for (const [lam, amp, ph] of [
+    [34, 1.6, 0],
+    [51, 2.4, 1.7],
+  ] as const) {
+    ctx.beginPath();
+    for (let x = -2; x <= lay.w + 2; x += 4) {
+      const y = wy + wh * 0.42 + Math.sin((x + v + camX * 0.1) / lam + ph) * amp;
+      if (x < 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+  }
+  ctx.fillStyle = alpha(sem.litEdge, 0.55);
+  const specN = Math.round(lay.w / 46);
+  for (let i = 0; i < specN; i++) {
+    const s = mixSeed(i, 0x3f7a);
+    const x = ((frand(s) * lay.w + (c.reduced ? 0 : t * 9)) % (lay.w + 20)) - 10;
+    const y = wy + wh * (0.22 + frand(mixSeed(s, 1)) * 0.6);
+    ctx.fillRect(x, y, 3, 1);
+  }
+
+  // Ripples where a child has touched the water.
+  ctx.strokeStyle = alpha(sem.litEdge, 0.4);
+  for (const rp of ripples) {
+    const a = clamp(1 - rp.age / 1.1, 0, 1);
+    if (a <= 0) continue;
+    const rad = 90 * (1 - a);
+    ctx.globalAlpha = a * 0.5;
+    ctx.beginPath();
+    ctx.ellipse(rp.x, wy + wh * 0.5, rad, rad * 0.28, 0, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+  ctx.globalAlpha = 1;
+  ctx.restore();
+
+  ctx.fillStyle = sem.litEdge;
+  ctx.globalAlpha = 0.35;
+  ctx.fillRect(0, wy - 3, lay.w, 1);
+  ctx.globalAlpha = 1;
+}
+
+/**
+ * The shadow a stall throws onto the pavement. Transmitted skylight, not black,
+ * and a hard edge — the sun in a covered bazaar comes through an oculus, which
+ * casts a sharp shadow.
+ */
+export function drawStallShadow(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  w: number,
+  c: FloorCtx,
+): void {
+  const { lay, sem, am } = c;
+  const lean = Math.tan((am.shaftAngle * Math.PI) / 180) * (lay.h - lay.floorY) * 0.9;
+  ctx.save();
+  ctx.globalAlpha = am.shadowAlpha * 0.75;
+  ctx.fillStyle = sem.shadow;
+  ctx.beginPath();
+  ctx.moveTo(x, lay.floorY);
+  ctx.lineTo(x + w, lay.floorY);
+  ctx.lineTo(x + w + lean, lay.h);
+  ctx.lineTo(x + lean, lay.h);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+}
+
+/** Where a shaft of light lands. The warmest thing in the picture. */
+export function drawSunPool(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  w: number,
+  c: FloorCtx,
+): void {
+  const { lay, am } = c;
+  if (am.sunAlpha < 0.02 || am.night > 0.9) return;
+  ctx.save();
+  ctx.globalCompositeOperation = "lighter";
+  ctx.fillStyle = alpha(am.sunColor, am.sunAlpha * 0.5 * (1 - am.night));
+  ctx.beginPath();
+  ctx.moveTo(x - w / 2, lay.floorY);
+  ctx.lineTo(x + w / 2, lay.floorY);
+  ctx.lineTo(x + w * 0.78, lay.h);
+  ctx.lineTo(x - w * 0.78, lay.h);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+}

--- a/dynawalla/bazaar/src/world/layout.ts
+++ b/dynawalla/bazaar/src/world/layout.ts
@@ -1,0 +1,94 @@
+/**
+ * The modular grid. One module `M` is the stall pitch, and everything derives
+ * from it, so nothing in the bazaar needs a judgement call about size.
+ *
+ * BZ-LAW-10 — a stall may never fill the viewport edge to edge. The moment it
+ * does, the street stops existing and you are back to a card. There is always
+ * a slice of each neighbour.
+ */
+
+import { clamp, lerp } from "../util/rng.ts";
+
+export interface Layout {
+  w: number;
+  h: number;
+  dpr: number;
+  /** The stall pitch. */
+  M: number;
+  skyH: number;
+  canopyH: number;
+  stallTop: number;
+  stallH: number;
+  floorY: number;
+  floorH: number;
+  /** Horizon: where the far skyline stands. */
+  horizonY: number;
+  apertureW: number;
+  apertureH: number;
+  jamb: number;
+  sillDepth: number;
+  signH: number;
+  awningDrop: number;
+  hoodH: number;
+  small: boolean;
+}
+
+export function layout(w: number, h: number, dpr: number): Layout {
+  // Bands. The canopy compresses first, and the driver is the ASPECT, not the
+  // raw height: a tall phone needs a tall stall band to keep the aperture at
+  // 44 % of the viewport, and a landscape tablet does not have that problem —
+  // there the 4:3 aperture shape governs instead (§2.6, §4.5).
+  const t = clamp((w / h - 0.6) / 0.7, 0, 1);
+  const skyF = lerp(0.08, 0.2, t);
+  const canopyF = lerp(0.06, 0.12, t);
+  const stallF = lerp(0.76, 0.58, t);
+  const floorF = lerp(0.1, 0.1, t);
+
+  const skyH = h * skyF;
+  const canopyH = h * canopyF;
+  const stallH = h * stallF;
+  const floorH = h * floorF;
+  const stallTop = skyH + canopyH;
+  const floorY = stallTop + stallH;
+
+  // BZ-LAW-10: never edge to edge. On anything wider than a phone the street
+  // shows three stalls and two slices, which is what makes it a street.
+  const wideCap = w > 700 ? w / 2.4 : w * 0.82;
+  const M = clamp(stallH / 1.35, 180, Math.min(w * 0.82, wideCap));
+
+  // The fixed vertical stack above and below the aperture is 0.66·M:
+  // hood 0.15 + band 0.05 + awning 0.11 + sign 0.15 + sill 0.20.
+  const apertureW = M * 0.82;
+  const apertureH = Math.max(M * 0.42, stallH - M * 0.66);
+
+  return {
+    w,
+    h,
+    dpr,
+    M,
+    skyH,
+    canopyH,
+    stallTop,
+    stallH,
+    floorY,
+    floorH,
+    horizonY: stallTop + stallH * 0.06,
+    apertureW,
+    apertureH,
+    jamb: M * 0.045,
+    sillDepth: M * 0.11,
+    signH: M * 0.14,
+    awningDrop: M * 0.18,
+    hoodH: M * 0.16,
+    small: w < 420,
+  };
+}
+
+/**
+ * Street curvature. A very slight vertical arc so the far end of the street
+ * falls away rather than terminating. At 2,000 px away that is 44 px of drop —
+ * enough to feel like the world bends, far too little to notice as an effect.
+ */
+export const CURVE_K = 1.1e-5;
+
+export const curve = (dx: number): number => -CURVE_K * dx * dx;

--- a/dynawalla/bazaar/src/world/life.ts
+++ b/dynawalla/bazaar/src/world/life.ts
@@ -1,0 +1,412 @@
+/**
+ * The crowd, the cats, the pigeons, the porters and the smoke.
+ *
+ * If you finish with effort left, spend all of it here. A bazaar with no people
+ * in it is an architectural rendering, and an architectural rendering is
+ * exactly the "beautifully made instrument" failure. Warmth is the product.
+ *
+ * BZ-LAW-12 — nothing that responds to idle touch may grant anything. The cat
+ * wakes, the pigeons flush, the dust scatters, the water rings. No progress, no
+ * currency, no points, no tone, no "+1". A world that responds without
+ * rewarding is what makes it feel real; a world that rewards fiddling is a slot
+ * machine, and this is a children's product.
+ *
+ * BZ-LAW-9 — this layer is `pointer-events: none`, always. A cat that blocks a
+ * stall is the single most infuriating bug this design can produce.
+ */
+
+import { frand, mix as mixSeed, idle, clamp, lerp } from "../util/rng.ts";
+import { alpha, over } from "../util/color.ts";
+import { MATERIALS } from "../tokens/palette.ts";
+import type { Semantic } from "../tokens/palette.ts";
+import type { Ambient } from "./daylight.ts";
+
+const ROBES = [
+  MATERIALS["bone-100"],
+  MATERIALS["indigo-800"],
+  MATERIALS["madder-600"],
+  MATERIALS["sabz-700"],
+  MATERIALS["ochre-500"],
+  MATERIALS["aubergine-800"],
+  MATERIALS["sandstone-200"],
+  MATERIALS["turquoise-700"],
+];
+
+export interface LifeCtx {
+  sem: Semantic;
+  am: Ambient;
+  /** Aerial perspective depth for this lane, 0…6. */
+  depth: number;
+  reduced: boolean;
+}
+
+interface Walker {
+  x: number;
+  v: number;
+  lane: number;
+  scale: number;
+  robe: number;
+  phase: number;
+  load: boolean;
+}
+
+/**
+ * A pool of figures walking the street. Bounded, recycled, and never allocated
+ * inside a frame.
+ */
+export class Crowd {
+  private pool: Walker[] = [];
+  private seeded = false;
+
+  private count: number;
+
+  constructor(count: number) {
+    this.count = count;
+  }
+
+  setCount(n: number): void {
+    if (n === this.count) return;
+    this.count = n;
+    this.seeded = false;
+  }
+
+  private spawn(centre: number, span: number): void {
+    this.pool = [];
+    for (let i = 0; i < this.count; i++) {
+      const s = mixSeed(i, 0x51fa);
+      this.pool.push({
+        x: centre - span / 2 + frand(s) * span,
+        v: (frand(mixSeed(s, 1)) < 0.5 ? -1 : 1) * (14 + frand(mixSeed(s, 2)) * 26),
+        lane: frand(mixSeed(s, 3)) < 0.62 ? 0 : 1,
+        scale: 0.82 + frand(mixSeed(s, 4)) * 0.4,
+        robe: Math.floor(frand(mixSeed(s, 5)) * ROBES.length),
+        phase: frand(mixSeed(s, 6)) * 100,
+        load: frand(mixSeed(s, 7)) < 0.22,
+      });
+    }
+    this.seeded = true;
+  }
+
+  /** `centre` and `span` are in world space; walkers recycle across the span. */
+  update(dt: number, centre: number, span: number): void {
+    if (!this.seeded) this.spawn(centre, span);
+    const lo = centre - span / 2;
+    const hi = centre + span / 2;
+    for (const w of this.pool) {
+      w.x += w.v * dt;
+      if (w.x < lo) w.x = hi;
+      else if (w.x > hi) w.x = lo;
+    }
+  }
+
+  draw(
+    ctx: CanvasRenderingContext2D,
+    project: (worldX: number) => number,
+    viewW: number,
+    baseY: number,
+    unit: number,
+    c: LifeCtx,
+    t: number,
+  ): void {
+    if (!this.seeded) return;
+    const haze = (c.am.hazeAlpha * c.depth) / 6;
+    for (const w of this.pool) {
+      const x = project(w.x);
+      if (x < -80 || x > viewW + 80) continue;
+      const y = baseY + (1 - w.lane) * unit * 0.14;
+      const s = unit * w.scale * (w.lane ? 1 : 0.88);
+      drawFigure(ctx, x, y, s, ROBES[w.robe]!, w.phase, t, c, haze, w.load, w.v < 0);
+    }
+  }
+}
+
+/**
+ * A figure: a robe, a head, a suggestion of arms, and a walk. No face — the
+ * bazaar's people are silhouettes at this distance, which is truthful about
+ * how far away they are and sidesteps the uncanny-mascot failure entirely.
+ */
+function drawFigure(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  h: number,
+  robe: string,
+  phase: number,
+  t: number,
+  c: LifeCtx,
+  haze: number,
+  load: boolean,
+  facingLeft: boolean,
+): void {
+  const bob = c.reduced ? 0 : Math.sin(t * 4.4 + phase) * h * 0.012;
+  const sway = c.reduced ? 0 : Math.sin(t * 2.2 + phase) * 0.06;
+  const body = over(over(robe, c.sem.shadow, c.am.shadowAlpha * 0.5), c.sem.haze, haze);
+  const litSide = over(body, c.am.sunColor, c.am.sunAlpha * 0.5);
+  const w = h * 0.3;
+  const top = y - h + bob;
+
+  ctx.save();
+  ctx.translate(x, 0);
+  ctx.rotate(sway * 0.06);
+
+  // Robe: wider at the hem, because cloth falls.
+  ctx.fillStyle = body;
+  ctx.beginPath();
+  ctx.moveTo(-w * 0.34, top + h * 0.22);
+  ctx.quadraticCurveTo(-w * 0.62, top + h * 0.7, -w * 0.7, y + bob);
+  ctx.lineTo(w * 0.7, y + bob);
+  ctx.quadraticCurveTo(w * 0.62, top + h * 0.7, w * 0.34, top + h * 0.22);
+  ctx.closePath();
+  ctx.fill();
+
+  // The sun side of the robe.
+  ctx.fillStyle = litSide;
+  ctx.beginPath();
+  ctx.moveTo(-w * 0.34, top + h * 0.22);
+  ctx.quadraticCurveTo(-w * 0.62, top + h * 0.7, -w * 0.7, y + bob);
+  ctx.lineTo(-w * 0.24, y + bob);
+  ctx.quadraticCurveTo(-w * 0.16, top + h * 0.6, -w * 0.1, top + h * 0.22);
+  ctx.closePath();
+  ctx.fill();
+
+  // Head and headcloth.
+  ctx.fillStyle = body;
+  ctx.beginPath();
+  ctx.arc(0, top + h * 0.13, h * 0.1, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.fillStyle = over(body, c.sem.litEdge, 0.25);
+  ctx.beginPath();
+  ctx.ellipse(0, top + h * 0.08, h * 0.12, h * 0.055, 0, Math.PI, Math.PI * 2);
+  ctx.fill();
+
+  // A load on the head or shoulder: this is a market, people are carrying.
+  if (load) {
+    ctx.fillStyle = over(MATERIALS["mudbrick-500"], c.sem.haze, haze);
+    ctx.fillRect(-h * 0.15, top - h * 0.06, h * 0.3, h * 0.09);
+    ctx.fillStyle = over(MATERIALS["brass-600"], c.sem.haze, haze);
+    ctx.fillRect(-h * 0.15, top - h * 0.06, h * 0.3, 1.5);
+  }
+
+  // A walking stick or a swinging hand, so the silhouette is not symmetrical.
+  ctx.strokeStyle = body;
+  ctx.lineWidth = Math.max(1, h * 0.035);
+  ctx.beginPath();
+  const armSwing = c.reduced ? 0 : Math.sin(t * 4.4 + phase) * h * 0.06;
+  const dir = facingLeft ? -1 : 1;
+  ctx.moveTo(dir * w * 0.3, top + h * 0.28);
+  ctx.lineTo(dir * w * 0.42 + armSwing, top + h * 0.56);
+  ctx.stroke();
+  ctx.restore();
+}
+
+/** A cat. It sleeps; it wakes if you touch near it; it never follows you. */
+export function drawCat(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  size: number,
+  awake: number,
+  c: LifeCtx,
+  t: number,
+  seed: number,
+): void {
+  const body = over(MATERIALS["copper-400"], c.sem.shadow, c.am.shadowAlpha * 0.6);
+  const stretch = clamp(awake, 0, 1);
+  const s = size;
+  ctx.save();
+  ctx.translate(x, y);
+  ctx.fillStyle = body;
+  // Curled asleep; stretching when woken. One shape, two poses.
+  const bodyH = lerp(s * 0.42, s * 0.34, stretch);
+  const bodyW = lerp(s * 0.9, s * 1.25, stretch);
+  ctx.beginPath();
+  ctx.ellipse(0, -bodyH * 0.5, bodyW / 2, bodyH / 2, 0, 0, Math.PI * 2);
+  ctx.fill();
+  // Head.
+  const hx = lerp(-bodyW * 0.3, -bodyW * 0.46, stretch);
+  ctx.beginPath();
+  ctx.arc(hx, -bodyH * (0.62 + stretch * 0.5), s * 0.17, 0, Math.PI * 2);
+  ctx.fill();
+  // Ears.
+  ctx.beginPath();
+  ctx.moveTo(hx - s * 0.14, -bodyH * (0.62 + stretch * 0.5) - s * 0.1);
+  ctx.lineTo(hx - s * 0.06, -bodyH * (0.62 + stretch * 0.5) - s * 0.27);
+  ctx.lineTo(hx + s * 0.02, -bodyH * (0.62 + stretch * 0.5) - s * 0.1);
+  ctx.closePath();
+  ctx.fill();
+  // Tail, which is the only part that moves when it is asleep.
+  const flick = c.reduced ? 0 : idle(t, seed, 1) * (0.2 + stretch * 0.8);
+  ctx.strokeStyle = body;
+  ctx.lineWidth = Math.max(1.5, s * 0.09);
+  ctx.lineCap = "round";
+  ctx.beginPath();
+  ctx.moveTo(bodyW * 0.42, -bodyH * 0.5);
+  ctx.quadraticCurveTo(
+    bodyW * 0.75,
+    -bodyH * (0.5 + flick * 0.5),
+    bodyW * 0.6,
+    -bodyH * (1.1 + flick),
+  );
+  ctx.stroke();
+  ctx.restore();
+}
+
+/** Two pigeons, at most. They flush when the street moves fast past them. */
+export function drawPigeon(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  size: number,
+  flying: number,
+  c: LifeCtx,
+  t: number,
+  seed: number,
+): void {
+  const body = over(MATERIALS["sandstone-400"], c.sem.shadow, c.am.shadowAlpha * 0.8);
+  ctx.save();
+  ctx.translate(x, y - flying * size * 5);
+  ctx.fillStyle = body;
+  ctx.beginPath();
+  ctx.ellipse(0, 0, size * 0.55, size * 0.36, -0.2, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.beginPath();
+  ctx.arc(-size * 0.45, -size * 0.3, size * 0.22, 0, Math.PI * 2);
+  ctx.fill();
+  if (flying > 0.01 && !c.reduced) {
+    const flap = Math.sin(t * 18 + seed) * size * 0.7;
+    ctx.beginPath();
+    ctx.moveTo(0, -size * 0.1);
+    ctx.lineTo(size * 0.2, -size * 0.1 - flap);
+    ctx.lineTo(-size * 0.3, -size * 0.1 - flap * 0.7);
+    ctx.closePath();
+    ctx.fill();
+  }
+  ctx.restore();
+}
+
+/** A porter's cart crossing the foreground. */
+export function drawPorter(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  h: number,
+  c: LifeCtx,
+  t: number,
+): void {
+  const wood = over(MATERIALS["bronze-700"], c.sem.shadow, c.am.shadowAlpha * 0.4);
+  ctx.save();
+  ctx.translate(x, y);
+  ctx.fillStyle = wood;
+  ctx.fillRect(-h * 0.7, -h * 0.5, h * 1.4, h * 0.16);
+  // Sacks piled on it — real goods, not crates with an X on them.
+  for (let i = 0; i < 3; i++) {
+    ctx.fillStyle = over(
+      [MATERIALS["bone-100"], MATERIALS["sandstone-200"], MATERIALS["mudbrick-500"]][i]!,
+      c.sem.shadow,
+      c.am.shadowAlpha * 0.5,
+    );
+    ctx.beginPath();
+    ctx.ellipse(-h * 0.4 + i * h * 0.4, -h * 0.66, h * 0.22, h * 0.19, 0, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  // Wheels, and they actually turn with the travel.
+  ctx.fillStyle = wood;
+  for (const wx of [-h * 0.44, h * 0.44]) {
+    ctx.beginPath();
+    ctx.arc(wx, -h * 0.18, h * 0.2, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = c.sem.metalShade;
+    ctx.lineWidth = 1.5;
+    const a = c.reduced ? 0 : t * 3;
+    ctx.beginPath();
+    for (let k = 0; k < 4; k++) {
+      const ang = a + (k * Math.PI) / 2;
+      ctx.moveTo(wx, -h * 0.18);
+      ctx.lineTo(wx + Math.cos(ang) * h * 0.17, -h * 0.18 + Math.sin(ang) * h * 0.17);
+    }
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+/** Steam from a samovar: five circles, an envelope, and no particle system. */
+export function drawSteam(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  seed: number,
+  c: LifeCtx,
+  t: number,
+): void {
+  ctx.save();
+  for (let i = 0; i < 5; i++) {
+    const s = mixSeed(seed, i);
+    const period = 2.6;
+    const u = ((t + frand(s) * period) % period) / period;
+    const r = 4 + u * 18;
+    const a = 0.35 * (1 - u);
+    if (a <= 0.01) continue;
+    ctx.globalAlpha = a;
+    ctx.fillStyle = c.am.night > 0.5 ? c.sem.groundLit : c.sem.litEdge;
+    ctx.beginPath();
+    ctx.arc(x + (frand(mixSeed(s, 1)) - 0.5) * 12, y - u * 46, r, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.restore();
+}
+
+/**
+ * A carpet drifting across. This is the loading state for a game, and the
+ * fast-travel affordance between wards. It is not decoration.
+ */
+export function drawCarpet(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  c: LifeCtx,
+  t: number,
+  seed: number,
+): void {
+  const h = w * 0.14;
+  const wave = c.reduced ? 0 : 1;
+  ctx.save();
+  ctx.translate(x, y);
+  const stripes = 7;
+  for (let i = 0; i < stripes; i++) {
+    const f = i / stripes;
+    const col = [
+      MATERIALS["madder-600"],
+      MATERIALS["indigo-800"],
+      MATERIALS["saffron-400"],
+      MATERIALS["sabz-700"],
+    ][i % 4]!;
+    ctx.fillStyle = over(col, c.sem.shadow, c.am.shadowAlpha * 0.35);
+    ctx.beginPath();
+    for (let k = 0; k <= 10; k++) {
+      const kx = -w / 2 + (w * k) / 10;
+      const ky = Math.sin(k * 0.8 + t * 2.2 + seed) * h * 0.42 * wave;
+      if (k === 0) ctx.moveTo(kx, ky + f * h);
+      else ctx.lineTo(kx, ky + f * h);
+    }
+    for (let k = 10; k >= 0; k--) {
+      const kx = -w / 2 + (w * k) / 10;
+      const ky = Math.sin(k * 0.8 + t * 2.2 + seed) * h * 0.42 * wave;
+      ctx.lineTo(kx, ky + (f + 1 / stripes) * h);
+    }
+    ctx.closePath();
+    ctx.fill();
+  }
+  // Fringe.
+  ctx.strokeStyle = alpha(MATERIALS["bone-100"], 0.7);
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  for (let k = 0; k < 12; k++) {
+    const kx = -w / 2 + (w * k) / 11;
+    const ky = Math.sin(k * 0.8 + t * 2.2 + seed) * h * 0.42 * wave;
+    ctx.moveTo(kx, ky + h);
+    ctx.lineTo(kx, ky + h + 5);
+  }
+  ctx.stroke();
+  ctx.restore();
+}

--- a/dynawalla/bazaar/src/world/parallax.ts
+++ b/dynawalla/bazaar/src/world/parallax.ts
@@ -1,0 +1,104 @@
+/**
+ * Seven layers, and the lag between them is what makes the world feel deep and
+ * heavy rather than like a set of sliding planes.
+ *
+ *   L0 sky + haze band        0.00
+ *   L1 far skyline            0.08
+ *   L2 mid roofline           0.22
+ *   L3 canopy, lanterns       0.55
+ *   L4 stall facades          1.00   (DOM)
+ *   L5 street floor           1.00
+ *   L6 foreground traffic     1.35
+ *
+ * Projection is anchored on the centre of the viewport, so a landmark placed at
+ * a ward gate arrives at the centre of the screen exactly when you arrive at
+ * the gate — however slowly it approached.
+ *
+ *   screenX = (worldX − camCentre) · p + viewW/2
+ *
+ * Each distant layer follows the scroll through a **critically damped** spring
+ * (ζ = 1.0). 60–120 ms of lag reads as weight. It never bounces and it never
+ * rubber-bands — an overshoot would read as elastic, and stone is not.
+ *
+ * Reduced motion turns parallax **off entirely**: it is a vestibular trigger,
+ * not a decoration (BZ-13).
+ */
+
+export type LayerName = "sky" | "far" | "mid" | "canopy" | "street" | "fore";
+
+export const PARALLAX: Record<LayerName, number> = {
+  sky: 0,
+  far: 0.08,
+  mid: 0.22,
+  canopy: 0.55,
+  street: 1,
+  fore: 1.35,
+};
+
+interface Spring {
+  x: number;
+  v: number;
+  omega: number;
+  seeded: boolean;
+}
+
+export class ParallaxRig {
+  private springs: Record<string, Spring> = {
+    far: { x: 0, v: 0, omega: 14, seeded: false },
+    mid: { x: 0, v: 0, omega: 14, seeded: false },
+    canopy: { x: 0, v: 0, omega: 22, seeded: false },
+  };
+  private reduced = false;
+  private viewW = 0;
+
+  setReduced(v: boolean): void {
+    this.reduced = v;
+  }
+
+  setViewW(w: number): void {
+    this.viewW = w;
+  }
+
+  /** `dt` in seconds, `camCentre` the world x at the centre of the viewport. */
+  update(camCentre: number, dt: number): void {
+    const step = Math.min(dt, 1 / 20);
+    for (const k of Object.keys(this.springs)) {
+      const s = this.springs[k]!;
+      if (!s.seeded) {
+        s.x = camCentre;
+        s.seeded = true;
+      }
+      if (this.reduced) {
+        s.x = camCentre;
+        s.v = 0;
+        continue;
+      }
+      const w = s.omega;
+      const a = -w * w * (s.x - camCentre) - 2 * w * s.v;
+      s.v += a * step;
+      s.x += s.v * step;
+      if (!Number.isFinite(s.x)) {
+        s.x = camCentre;
+        s.v = 0;
+      }
+    }
+  }
+
+  /** A projector for one layer: world x → screen x. */
+  projector(layer: LayerName, camCentre: number): (worldX: number) => number {
+    const p = PARALLAX[layer];
+    const s = this.springs[layer];
+    const c = this.reduced || !s ? camCentre : s.x;
+    const half = this.viewW / 2;
+    return (worldX: number) => (worldX - c) * p + half;
+  }
+
+  /** The inverse, for deciding what to generate. */
+  unproject(layer: LayerName, camCentre: number, screenX: number): number {
+    const p = PARALLAX[layer];
+    const s = this.springs[layer];
+    const c = this.reduced || !s ? camCentre : s.x;
+    if (p === 0) return c;
+    return (screenX - this.viewW / 2) / p + c;
+  }
+}

--- a/dynawalla/bazaar/src/world/quarters.ts
+++ b/dynawalla/bazaar/src/world/quarters.ts
@@ -1,0 +1,182 @@
+/**
+ * The quarters.
+ *
+ * Streets in the Grand Bazaar are named for the trade sold on them, and so are
+ * ours. Each craft is a genuine embodiment of its mathematics, not a label
+ * glued onto a topic: a gear ratio *is* a fraction, a rope laid in fathoms *is*
+ * division into parts, a balance beam *is* equality.
+ *
+ * BZ-LAW-8 — identity is a product, not a colour:
+ *   ward (5) × finial (5) × fold (5) × stripe (6) = 750 distinct quarters,
+ *   of which exactly one axis is colour. BZ-17 asserts every quarter carries a
+ *   distinct (ward, finial, fold) triple, and that the lapis and aubergine
+ *   wards — 5.9 L* apart and both on the tritan axis — are never adjacent.
+ */
+
+import type { Quarter } from "../types.ts";
+
+export const QUARTERS: readonly Quarter[] = [
+  {
+    id: "weighers",
+    ward: "lapis",
+    finial: "meridian",
+    fold: "girih5",
+    stripe: 0,
+    craft: "balance",
+    name: {
+      en: "Weighers’ Row",
+      es: "Calle de los Pesadores",
+      "pt-BR": "Rua dos Pesadores",
+      fr: "Rue des Peseurs",
+      de: "Gasse der Wäger",
+    },
+    specimen: { display: "3 + 4 = 7", spoken: "three plus four equals seven" },
+  },
+  {
+    id: "money-changers",
+    ward: "lapis",
+    finial: "vane",
+    fold: "khatem8",
+    stripe: 1,
+    craft: "coin",
+    name: {
+      en: "Money-changers’ Arcade",
+      es: "Galería de los Cambistas",
+      "pt-BR": "Galeria dos Cambistas",
+      fr: "Galerie des Changeurs",
+      de: "Arkade der Geldwechsler",
+    },
+    specimen: { display: "0,25 × 4 = 1", spoken: "nought point two five, four times" },
+  },
+  {
+    id: "tilers",
+    ward: "turquoise",
+    finial: "signal",
+    fold: "hex6",
+    stripe: 2,
+    craft: "tessera",
+    name: {
+      en: "Tilers’ Court",
+      es: "Patio de los Alicatadores",
+      "pt-BR": "Pátio dos Ladrilheiros",
+      fr: "Cour des Carreleurs",
+      de: "Hof der Fliesenleger",
+    },
+    specimen: { display: "12 × 8 = 96", spoken: "twelve times eight" },
+  },
+  {
+    id: "rope-walk",
+    ward: "turquoise",
+    finial: "gear",
+    fold: "twelve12",
+    stripe: 3,
+    craft: "rope",
+    name: {
+      en: "The Rope-walk",
+      es: "La Cordelería",
+      "pt-BR": "A Cordoaria",
+      fr: "La Corderie",
+      de: "Die Seilerbahn",
+    },
+    specimen: { display: "⅗ of 40 = 24", spoken: "three fifths of forty" },
+  },
+  {
+    id: "astrolabists",
+    ward: "aubergine",
+    finial: "armillary",
+    fold: "lattice",
+    stripe: 4,
+    craft: "astrolabe",
+    name: {
+      en: "Astrolabists’ Gallery",
+      es: "Galería de los Astrolabistas",
+      "pt-BR": "Galeria dos Astrolabistas",
+      fr: "Galerie des Astrolabistes",
+      de: "Galerie der Astrolabienbauer",
+    },
+    specimen: { display: "360° ÷ 8 = 45°", spoken: "three hundred and sixty degrees, into eight" },
+  },
+  {
+    id: "waterworks",
+    ward: "aubergine",
+    finial: "meridian",
+    fold: "twelve12",
+    stripe: 5,
+    craft: "water",
+    name: {
+      en: "The Waterworks",
+      es: "La Casa del Agua",
+      "pt-BR": "A Casa das Águas",
+      fr: "Les Eaux",
+      de: "Das Wasserwerk",
+    },
+    specimen: { display: "3 : 2 = 9 : 6", spoken: "three to two, as nine to six" },
+  },
+  {
+    id: "dyers",
+    ward: "madder",
+    finial: "armillary",
+    fold: "khatem8",
+    stripe: 0,
+    craft: "vat",
+    name: {
+      en: "Dyers’ Lane",
+      es: "Callejón de los Tintoreros",
+      "pt-BR": "Beco dos Tintureiros",
+      fr: "Ruelle des Teinturiers",
+      de: "Färbergasse",
+    },
+    specimen: { display: "⅖ + ⅕ = ⅗", spoken: "two fifths and one fifth" },
+  },
+  {
+    id: "kite-makers",
+    ward: "madder",
+    finial: "vane",
+    fold: "hex6",
+    stripe: 1,
+    craft: "kite",
+    name: {
+      en: "Kite-makers’ Yard",
+      es: "Corral de los Cometeros",
+      "pt-BR": "Pátio dos Pipeiros",
+      fr: "Cour des Cerfs-Volants",
+      de: "Hof der Drachenbauer",
+    },
+    specimen: { display: "180° − 55° = 125°", spoken: "a straight angle, less fifty-five degrees" },
+  },
+  {
+    id: "clockmakers",
+    ward: "hemp",
+    finial: "gear",
+    fold: "lattice",
+    stripe: 2,
+    craft: "gears",
+    name: {
+      en: "Clockmakers’ Terrace",
+      es: "Terraza de los Relojeros",
+      "pt-BR": "Terraço dos Relojoeiros",
+      fr: "Terrasse des Horlogers",
+      de: "Terrasse der Uhrmacher",
+    },
+    specimen: { display: "24 : 18 = 4 : 3", spoken: "twenty-four to eighteen, as four to three" },
+  },
+  {
+    id: "millers",
+    ward: "hemp",
+    finial: "signal",
+    fold: "girih5",
+    stripe: 3,
+    craft: "mill",
+    name: {
+      en: "Millers’ Yard",
+      es: "Corral de los Molineros",
+      "pt-BR": "Pátio dos Moleiros",
+      fr: "Cour des Meuniers",
+      de: "Hof der Müller",
+    },
+    specimen: { display: "47 ÷ 5 = 9 r 2", spoken: "forty-seven into fives, two over" },
+  },
+];
+
+export const quarterById = (id: string): Quarter | undefined =>
+  QUARTERS.find((q) => q.id === id);

--- a/dynawalla/bazaar/src/world/skyline.ts
+++ b/dynawalla/bazaar/src/world/skyline.ts
@@ -1,0 +1,479 @@
+/**
+ * L1 — the far skyline, and L2 — the roofline across the street.
+ *
+ * **There is no mosque in the bazaar.** The founder's word is minaret-punk and
+ * the silhouette is right — a tall shaft, a corbelled muqarnas balcony, a tiled
+ * band, a finial — but turning a religious building into a shopfront is the
+ * exact costume-box move this whole thing avoids. So the towers are
+ * **observatory towers, clock towers and windcatchers**: the same regional
+ * structural language, a secular function, and every one carries a working
+ * instrument at its head. Which is also just better art direction, because a
+ * tower with a meridian arc on top tells you what the ward does from four
+ * hundred pixels away.
+ */
+
+import { frand, mix as mixSeed, idle } from "../util/rng.ts";
+import { over } from "../util/color.ts";
+import { drawMuqarnas } from "../geometry/muqarnas.ts";
+import { archPath } from "../geometry/arch.ts";
+import { patternPanel } from "../geometry/pattern.ts";
+import { gearTrain, drawGear } from "../geometry/gears.ts";
+import { sprite, bucket } from "./sprites.ts";
+import type { Ambient } from "./daylight.ts";
+import { lit, shade } from "./daylight.ts";
+import type { Semantic } from "../tokens/palette.ts";
+import { WARDS, type WardId } from "../tokens/palette.ts";
+import type { Finial, Fold } from "../types.ts";
+
+export interface SkyContext {
+  sem: Semantic;
+  am: Ambient;
+  dpr: number;
+  /** Haze depth 0…6 for this layer. */
+  depth: number;
+}
+
+const hazeOf = (c: SkyContext): { color: string; alpha: number } => ({
+  color: c.sem.haze,
+  alpha: (c.am.hazeAlpha * c.depth) / 6,
+});
+
+/** A tower: shaft, tiled band, muqarnas balcony, and an instrument on top. */
+export function drawTower(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  baseY: number,
+  width: number,
+  height: number,
+  ward: WardId,
+  finial: Finial,
+  fold: Fold,
+  seed: number,
+  c: SkyContext,
+  t: number,
+): void {
+  const key = `tower|${ward}|${finial}|${fold}|${seed & 255}|${bucket(c.am.night, 12)}|${bucket(c.am.sunAlpha, 12)}|${c.depth}`;
+  const pad = width * 1.6;
+  const s = sprite(key, width + pad * 2, height + width * 2.2, c.dpr, (g, w, h) => {
+    const cx = w / 2;
+    const by = h;
+    const shaftW = width;
+    const ground = c.sem.ground;
+    const faceL = lit(ground, c.am, 1.05);
+    const faceR = shade(ground, c.am, 0.9, c.sem.shadow);
+    const band = WARDS[ward];
+
+    // Octagonal shaft, read as three facets: a lit face, a middle, a shade.
+    const x0 = cx - shaftW / 2;
+    const top = by - height;
+    ctx0Rect(g, x0, top, shaftW * 0.36, height, faceL);
+    ctx0Rect(g, x0 + shaftW * 0.36, top, shaftW * 0.34, height, ground);
+    ctx0Rect(g, x0 + shaftW * 0.7, top, shaftW * 0.3, height, faceR);
+
+    // Facet seams.
+    g.strokeStyle = c.sem.cut;
+    g.lineWidth = 1;
+    g.globalAlpha = 0.5;
+    g.beginPath();
+    for (const f of [0.36, 0.7]) {
+      g.moveTo(x0 + shaftW * f + 0.5, top);
+      g.lineTo(x0 + shaftW * f + 0.5, by);
+    }
+    g.stroke();
+    g.globalAlpha = 1;
+
+    // The tiled band at 0.62 of the height. Glaze never carries text.
+    const bandY = by - height * 0.62;
+    const bandH = Math.max(6, height * 0.08);
+    const panel = patternPanel({
+      width: shaftW,
+      height: bandH,
+      fold: fold === "lattice" ? "khatem8" : fold,
+      edge: Math.max(6, bandH * 0.55),
+      ground: c.sem.ground,
+      strap: c.sem.metal,
+      glaze: band.glaze,
+      glazeDeep: band.glazeDeep,
+      dpr: c.dpr,
+    });
+    g.drawImage(panel, x0, bandY, shaftW, bandH);
+    g.strokeStyle = c.sem.cut;
+    g.strokeRect(x0 + 0.5, bandY + 0.5, shaftW - 1, bandH - 1);
+
+    // Slit windows below the band: an observatory needs sightlines.
+    g.fillStyle = c.am.night > 0.4 ? c.sem.metalLit : shade(ground, c.am, 1.6, c.sem.shadow);
+    for (let i = 0; i < 3; i++) {
+      const wy = by - height * (0.2 + i * 0.12);
+      g.beginPath();
+      g.moveTo(cx - shaftW * 0.08, wy);
+      g.lineTo(cx - shaftW * 0.08, wy - height * 0.05);
+      archPath(g, cx, wy - height * 0.05, shaftW * 0.16, "equilateral");
+      g.lineTo(cx + shaftW * 0.08, wy);
+      g.closePath();
+      g.fill();
+    }
+
+    // The corbelled balcony that carries the instrument platform.
+    const balcY = by - height * 0.86;
+    const balcH = height * 0.08;
+    drawMuqarnas(g, {
+      x: cx - shaftW * 0.78,
+      y: balcY,
+      width: shaftW * 1.56,
+      height: balcH,
+      tiers: 5,
+      k0: 3,
+      ground: c.sem.ground,
+      sun: c.am.sunColor,
+      sunAlpha: c.am.sunAlpha,
+      shadow: c.sem.shadow,
+      shadowAlpha: c.am.shadowAlpha,
+      litEdge: c.sem.litEdge,
+      cut: c.sem.cut,
+    });
+    ctx0Rect(g, cx - shaftW * 0.8, balcY - height * 0.02, shaftW * 1.6, height * 0.02, faceL);
+
+    // Upper stage and the head.
+    const headTop = by - height;
+    ctx0Rect(g, cx - shaftW * 0.34, headTop, shaftW * 0.68, height * 0.14, ground);
+    g.strokeStyle = c.sem.cut;
+    g.strokeRect(cx - shaftW * 0.34 + 0.5, headTop + 0.5, shaftW * 0.68 - 1, height * 0.14);
+
+    drawFinial(g, cx, headTop, shaftW, finial, c, seed, 0);
+  });
+  const sw = width + pad * 2;
+  const sh = height + width * 2.2;
+  ctx.drawImage(s, x - sw / 2, baseY - sh, sw, sh);
+
+  // The one thing that must move per frame: the anemometer and the gear train.
+  if (finial === "vane" || finial === "gear") {
+    ctx.save();
+    ctx.translate(x, baseY - height - width * 0.2);
+    drawLiveFinial(ctx, width, finial, c, seed, t);
+    ctx.restore();
+  }
+}
+
+function ctx0Rect(
+  g: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  fill: string,
+): void {
+  g.fillStyle = fill;
+  g.fillRect(x, y, w, h);
+}
+
+/** The static part of each instrument. */
+function drawFinial(
+  g: CanvasRenderingContext2D,
+  cx: number,
+  topY: number,
+  shaftW: number,
+  finial: Finial,
+  c: SkyContext,
+  seed: number,
+  _t: number,
+): void {
+  const metal = c.sem.metal;
+  const metalLit = c.sem.metalLit;
+  const r = shaftW * 0.5;
+  g.strokeStyle = metal;
+  g.fillStyle = metal;
+  g.lineWidth = Math.max(1.5, shaftW * 0.06);
+
+  // Every instrument stands on a post.
+  g.fillRect(cx - shaftW * 0.05, topY - r * 0.7, shaftW * 0.1, r * 0.7);
+
+  switch (finial) {
+    case "meridian": {
+      // A graduated quarter-arc, read against the meridian.
+      g.beginPath();
+      g.arc(cx, topY - r * 0.7, r, Math.PI, Math.PI * 1.9);
+      g.stroke();
+      g.lineWidth = Math.max(1, shaftW * 0.03);
+      for (let i = 0; i <= 8; i++) {
+        const a = Math.PI + (Math.PI * 0.9 * i) / 8;
+        g.beginPath();
+        g.moveTo(cx + r * Math.cos(a), topY - r * 0.7 + r * Math.sin(a));
+        g.lineTo(cx + r * 1.16 * Math.cos(a), topY - r * 0.7 + r * 1.16 * Math.sin(a));
+        g.stroke();
+      }
+      break;
+    }
+    case "signal": {
+      // A signal lamp on a bracket. Lit at night, and only at night.
+      g.fillRect(cx - shaftW * 0.3, topY - r * 0.78, shaftW * 0.6, shaftW * 0.08);
+      const glow = c.am.lanternGain;
+      g.fillStyle = glow > 0.2 ? over(metalLit, "#f5b94a", glow) : metal;
+      g.beginPath();
+      g.moveTo(cx - r * 0.32, topY - r * 0.78);
+      g.lineTo(cx + r * 0.32, topY - r * 0.78);
+      g.lineTo(cx + r * 0.22, topY - r * 1.36);
+      g.lineTo(cx - r * 0.22, topY - r * 1.36);
+      g.closePath();
+      g.fill();
+      break;
+    }
+    case "armillary": {
+      // Nested rings, one tilted to the pole.
+      g.lineWidth = Math.max(1.2, shaftW * 0.045);
+      const cy = topY - r * 1.1;
+      g.beginPath();
+      g.arc(cx, cy, r * 0.72, 0, Math.PI * 2);
+      g.stroke();
+      g.beginPath();
+      g.ellipse(cx, cy, r * 0.72, r * 0.26, 0, 0, Math.PI * 2);
+      g.stroke();
+      g.beginPath();
+      g.ellipse(cx, cy, r * 0.3, r * 0.72, 0.5, 0, Math.PI * 2);
+      g.stroke();
+      break;
+    }
+    case "vane":
+    case "gear": {
+      // The moving instruments get only their mounting here; the live part is
+      // drawn per frame so that its motion is real.
+      g.fillRect(cx - shaftW * 0.06, topY - r * 1.5, shaftW * 0.12, r * 0.85);
+      break;
+    }
+  }
+  void seed;
+}
+
+/** The instruments that actually turn. BZ-LAW-11 applies to the gear one. */
+function drawLiveFinial(
+  ctx: CanvasRenderingContext2D,
+  shaftW: number,
+  finial: Finial,
+  c: SkyContext,
+  seed: number,
+  t: number,
+): void {
+  const r = shaftW * 0.5;
+  const style = {
+    metal: c.sem.metal,
+    metalShade: c.sem.metalShade,
+    litEdge: c.sem.litEdge,
+    cut: c.sem.cut,
+  };
+  if (finial === "vane") {
+    // Three cups on arms — an anemometer, turning with the wind.
+    const spin = t * (0.9 + frand(seed) * 0.5) + idle(t, seed, 0.4);
+    ctx.strokeStyle = c.sem.metal;
+    ctx.fillStyle = c.sem.metal;
+    ctx.lineWidth = Math.max(1.2, shaftW * 0.04);
+    for (let k = 0; k < 3; k++) {
+      const a = spin + (k * Math.PI * 2) / 3;
+      const ex = Math.cos(a) * r * 0.8;
+      const ey = Math.sin(a) * r * 0.28;
+      ctx.beginPath();
+      ctx.moveTo(0, -r * 0.7);
+      ctx.lineTo(ex, -r * 0.7 + ey);
+      ctx.stroke();
+      ctx.beginPath();
+      ctx.arc(ex, -r * 0.7 + ey, r * 0.16, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  } else {
+    // A two-stage train. The follower's angle is derived from the driver's, so
+    // ω_b = −ω_a·(N_a/N_b) cannot be violated.
+    const gears = gearTrain(
+      {
+        spec: [{ teeth: 20 }, { teeth: 15, bearing: -34 }],
+        module: (r * 0.055),
+        origin: { x: 0, y: -r * 1.0 },
+        omega: 0.55,
+      },
+      t,
+    );
+    for (const g of gears) drawGear(ctx, g, style);
+  }
+}
+
+/** A double-shell dome over a caravanserai courtyard. Never over a stall. */
+export function drawDome(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  baseY: number,
+  d: number,
+  ward: WardId,
+  seed: number,
+  c: SkyContext,
+): void {
+  const key = `dome|${ward}|${seed & 63}|${bucket(c.am.night, 12)}|${bucket(c.am.sunAlpha, 12)}|${c.depth}`;
+  const rise = d * 0.72;
+  const drumH = d * 0.34;
+  const s = sprite(key, d * 1.3, rise + drumH + d * 0.3, c.dpr, (g, w, h) => {
+    const cx = w / 2;
+    const by = h;
+    const band = WARDS[ward];
+    // Drum with lights.
+    const drumY = by - drumH;
+    g.fillStyle = c.sem.ground;
+    g.fillRect(cx - d / 2, drumY, d, drumH);
+    g.fillStyle = shade(c.sem.ground, c.am, 1.4, c.sem.shadow);
+    const lights = seed % 2 ? 8 : 12;
+    for (let i = 0; i < lights; i++) {
+      const lx = cx - d / 2 + ((i + 0.5) * d) / lights;
+      g.beginPath();
+      g.moveTo(lx - d * 0.014, drumY + drumH * 0.85);
+      g.lineTo(lx - d * 0.014, drumY + drumH * 0.42);
+      archPath(g, lx, drumY + drumH * 0.42, d * 0.028, "equilateral");
+      g.lineTo(lx + d * 0.014, drumY + drumH * 0.85);
+      g.closePath();
+      g.fill();
+    }
+    g.strokeStyle = c.sem.cut;
+    g.lineWidth = 1;
+    g.strokeRect(cx - d / 2 + 0.5, drumY + 0.5, d - 1, drumH - 1);
+
+    // Pointed outer shell, glazed.
+    g.fillStyle = band.glaze;
+    g.beginPath();
+    g.moveTo(cx - d / 2, drumY);
+    g.quadraticCurveTo(cx - d * 0.52, drumY - rise * 0.72, cx, drumY - rise);
+    g.quadraticCurveTo(cx + d * 0.52, drumY - rise * 0.72, cx + d / 2, drumY);
+    g.closePath();
+    g.fill();
+    // A lit crescent of the shell on the sun side; flat, no gradient.
+    g.fillStyle = over(band.glaze, c.am.sunColor, c.am.sunAlpha * 1.3);
+    g.beginPath();
+    g.moveTo(cx - d / 2, drumY);
+    g.quadraticCurveTo(cx - d * 0.52, drumY - rise * 0.72, cx, drumY - rise);
+    g.quadraticCurveTo(cx - d * 0.2, drumY - rise * 0.6, cx - d * 0.28, drumY);
+    g.closePath();
+    g.fill();
+    // Ribs.
+    g.strokeStyle = band.glazeDeep;
+    g.lineWidth = 1;
+    for (let i = 1; i < 6; i++) {
+      const f = i / 6;
+      g.beginPath();
+      g.moveTo(cx - d / 2 + d * f, drumY);
+      g.quadraticCurveTo(
+        cx - d * 0.52 + d * 1.04 * f,
+        drumY - rise * (0.72 + 0.3 * Math.sin(Math.PI * f)),
+        cx,
+        drumY - rise,
+      );
+      g.stroke();
+    }
+    // Finial.
+    g.strokeStyle = c.sem.metal;
+    g.lineWidth = Math.max(1.5, d * 0.02);
+    g.beginPath();
+    g.moveTo(cx, drumY - rise);
+    g.lineTo(cx, drumY - rise - d * 0.16);
+    g.stroke();
+    g.fillStyle = c.sem.metal;
+    g.beginPath();
+    g.arc(cx, drumY - rise - d * 0.2, d * 0.045, 0, Math.PI * 2);
+    g.fill();
+  });
+  ctx.drawImage(s, x - d * 0.65, baseY - (rise + drumH + d * 0.3), d * 1.3, rise + drumH + d * 0.3);
+}
+
+/** A plain roof block: what fills between the landmarks. */
+export function drawRoofBlock(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  baseY: number,
+  w: number,
+  h: number,
+  seed: number,
+  c: SkyContext,
+  detail: boolean,
+): void {
+  const key = `roof|${seed & 1023}|${detail ? 1 : 0}|${bucket(c.am.night, 12)}|${bucket(c.am.sunAlpha, 12)}|${c.depth}`;
+  const s = sprite(key, w, h + w * 0.3, c.dpr, (g, cw, ch) => {
+    const by = ch;
+    const top = by - h;
+    const face = lit(c.sem.ground, c.am, 0.7);
+    g.fillStyle = face;
+    g.fillRect(0, top, cw, h);
+    g.fillStyle = shade(c.sem.ground, c.am, 0.9, c.sem.shadow);
+    g.fillRect(cw * 0.76, top, cw * 0.24, h);
+    // Parapet with a crenellated cap: the roofline is never a plain rectangle.
+    g.fillStyle = shade(c.sem.ground, c.am, 0.6, c.sem.shadow);
+    g.fillRect(0, top, cw, Math.max(3, h * 0.06));
+    const merlons = Math.max(3, Math.round(cw / 14));
+    g.fillStyle = face;
+    for (let i = 0; i < merlons; i++) {
+      const mx = (i * cw) / merlons;
+      g.fillRect(mx + 1, top - h * 0.05, cw / merlons - 3, h * 0.05);
+    }
+    if (detail) {
+      // Windows, and a wind-catcher scoop on some blocks.
+      const cols = Math.max(2, Math.round(cw / 46));
+      const rows = Math.max(1, Math.min(3, Math.round(h / 78)));
+      for (let i = 0; i < cols; i++) {
+        for (let j = 0; j < rows; j++) {
+          const wx = ((i + 0.5) * cw) / cols;
+          const wy = top + h * 0.16 + (j * h * 0.52) / rows;
+          const nightLit = c.am.lanternGain > 0.3 && frand(mixSeed(seed, i * 31 + j)) < 0.55;
+          g.fillStyle = nightLit
+            ? over(c.sem.metalLit, "#f5b94a", 0.5)
+            : shade(c.sem.ground, c.am, 1.8, c.sem.shadow);
+          const ww = Math.min(20, cw / cols - 8);
+          g.beginPath();
+          g.moveTo(wx - ww / 2, wy + ww);
+          g.lineTo(wx - ww / 2, wy);
+          archPath(g, wx, wy, ww, "equilateral");
+          g.lineTo(wx + ww / 2, wy + ww);
+          g.closePath();
+          g.fill();
+          // Painted shutters, folded back. Colour where a wall would be blank.
+          if (frand(mixSeed(seed, 900 + i * 7 + j)) < 0.5) {
+            const sc = [
+              "#23356b",
+              "#a33a2c",
+              "#24603e",
+              "#d19a24",
+            ][Math.floor(frand(mixSeed(seed, i * 13 + j)) * 4)]!;
+            g.fillStyle = over(sc, c.am.sunColor, c.am.sunAlpha * 1.2);
+            g.fillRect(wx - ww * 0.78, wy, ww * 0.24, ww * 0.9);
+            g.fillRect(wx + ww * 0.54, wy, ww * 0.24, ww * 0.9);
+          }
+        }
+      }
+      if (seed % 3 === 0) {
+        g.fillStyle = face;
+        g.fillRect(cw * 0.62, top - h * 0.22, cw * 0.2, h * 0.22);
+        g.fillStyle = shade(c.sem.ground, c.am, 1.5, c.sem.shadow);
+        for (let i = 0; i < 3; i++) {
+          g.fillRect(cw * 0.63 + i * cw * 0.06, top - h * 0.2, cw * 0.025, h * 0.16);
+        }
+      }
+    }
+    g.strokeStyle = c.sem.cut;
+    g.lineWidth = 1;
+    g.globalAlpha = 0.6;
+    g.beginPath();
+    g.moveTo(cw - 0.5, top);
+    g.lineTo(cw - 0.5, by);
+    g.stroke();
+    g.globalAlpha = 1;
+  });
+  ctx.drawImage(s, x, baseY - (h + w * 0.3), w, h + w * 0.3);
+}
+
+/** Aerial perspective. Composite, never blur. BZ-LAW-6. */
+export function applyHaze(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  c: SkyContext,
+): void {
+  const { color, alpha: a } = hazeOf(c);
+  if (a <= 0.005) return;
+  ctx.save();
+  ctx.globalAlpha = a;
+  ctx.fillStyle = color;
+  ctx.fillRect(x, y, w, h);
+  ctx.restore();
+}

--- a/dynawalla/bazaar/src/world/sprites.ts
+++ b/dynawalla/bazaar/src/world/sprites.ts
@@ -1,0 +1,55 @@
+/**
+ * A tiny sprite cache.
+ *
+ * The whole performance story of the backdrop is this file: a tower, a dome, a
+ * lantern, a shutter, a stall's static chrome are each constructed once into an
+ * offscreen canvas and blitted thereafter. Nothing that involves a girih
+ * construction, a muqarnas tier stack or a turned-wood lattice ever runs inside
+ * a frame.
+ */
+
+const cache = new Map<string, HTMLCanvasElement>();
+const MAX = 160;
+
+export function sprite(
+  key: string,
+  w: number,
+  h: number,
+  dpr: number,
+  draw: (ctx: CanvasRenderingContext2D, w: number, h: number) => void,
+): HTMLCanvasElement {
+  const k = `${key}|${Math.round(w)}x${Math.round(h)}@${dpr}`;
+  const hit = cache.get(k);
+  if (hit) {
+    // refresh LRU position
+    cache.delete(k);
+    cache.set(k, hit);
+    return hit;
+  }
+  const cv = document.createElement("canvas");
+  cv.width = Math.max(1, Math.round(w * dpr));
+  cv.height = Math.max(1, Math.round(h * dpr));
+  const ctx = cv.getContext("2d");
+  if (ctx) {
+    ctx.scale(dpr, dpr);
+    draw(ctx, w, h);
+  }
+  if (cache.size >= MAX) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  cache.set(k, cv);
+  return cv;
+}
+
+export function clearSprites(): void {
+  cache.clear();
+}
+
+export const spriteCount = (): number => cache.size;
+
+/**
+ * Quantise a continuously varying value so a sprite key does not change every
+ * frame. The dusk moves through 24 steps, not 6,000.
+ */
+export const bucket = (v: number, steps = 24): number => Math.round(v * steps) / steps;

--- a/dynawalla/bazaar/src/world/street.test.ts
+++ b/dynawalla/bazaar/src/world/street.test.ts
@@ -1,0 +1,357 @@
+/**
+ * The endless street, the day that never ends inside a game, the one live
+ * preview, the gear law, and the twelve strings.
+ *
+ * BZ-06, BZ-09, BZ-10, BZ-14, BZ-16, and the generator's own guarantees.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { Street } from "./street.ts";
+import { QUARTERS } from "./quarters.ts";
+import { layout } from "./layout.ts";
+import { ambient, semanticAt } from "./daylight.ts";
+import { Lamp, GRACE_MS } from "../lamp/state.ts";
+import { gearTrain } from "../geometry/gears.ts";
+import { STRINGS, LOCALES, t, resolveLocale } from "../strings.ts";
+import { PreviewDirector } from "../stall/preview.ts";
+import { Bed } from "../sound/bed.ts";
+import type { StallSpec, StallPreview } from "../types.ts";
+
+const stalls: StallSpec[] = QUARTERS.map((q) => ({
+  id: q.id,
+  title: q.id,
+  quarter: q.id,
+  preview: { period: 6, render: () => {} },
+}));
+
+const street = (m = 320) => new Street({ seed: 0x1453, module: m, stalls });
+
+// ── the street generates itself, forever ───────────────────────────────────
+
+test("the street extends as far as it is asked to, and never ends", () => {
+  const s = street();
+  s.ensure(40_000);
+  assert.ok(s.width >= 40_000, `street stopped at ${s.width}`);
+  assert.ok(s.stalls.length > 60, "not enough stalls generated");
+  // Past the last built quarter there is scaffolding, not a wall.
+  const beyond = s.stalls.slice(QUARTERS.length);
+  assert.ok(beyond.length > 20);
+  for (const f of beyond) assert.equal(f.stall.state, "scaffold");
+});
+
+test("interstitial fabric never repeats within five, and fountains stay apart", () => {
+  const s = street();
+  s.ensure(30_000);
+  const kinds = s.features.filter((f) => f.kind === "interstitial").map((f) => f.type);
+  for (let i = 0; i < kinds.length; i++) {
+    const window = kinds.slice(Math.max(0, i - 5), i);
+    assert.ok(!window.includes(kinds[i]!), `${kinds[i]} repeats within five`);
+  }
+  const fountains = kinds
+    .map((k, i) => (k === "fountain" ? i : -1))
+    .filter((i) => i >= 0);
+  for (let i = 1; i < fountains.length; i++) {
+    assert.ok(fountains[i]! - fountains[i - 1]! >= 9, "two fountains too close");
+  }
+});
+
+test("a gate stands at every ward boundary and nowhere else", () => {
+  const s = street();
+  s.ensure(12_000);
+  let ward: string | null = null;
+  for (const f of s.features) {
+    if (f.kind === "gate") {
+      assert.notEqual(f.ward, ward, "a gate where the ward did not change");
+    }
+    if (f.kind === "stall") ward = f.quarter.ward;
+  }
+  assert.ok(s.wardBoundaries().length > 4, "no ward boundaries found");
+});
+
+test("the generated street is deterministic on its seed", () => {
+  const a = street();
+  const b = street();
+  a.ensure(9000);
+  b.ensure(9000);
+  assert.equal(a.features.length, b.features.length);
+  assert.deepEqual(
+    a.features.map((f) => `${f.kind}:${Math.round(f.x)}`),
+    b.features.map((f) => `${f.kind}:${Math.round(f.x)}`),
+  );
+});
+
+// ── BZ-LAW-10 and the vertical composition ─────────────────────────────────
+
+test("BZ-LAW-10: a stall never fills the viewport, at any rung", () => {
+  for (const [w, h] of [
+    [320, 568],
+    [360, 640],
+    [390, 844],
+    [768, 1024],
+    [1024, 768],
+    [1440, 900],
+  ] as const) {
+    const l = layout(w, h, 2);
+    assert.ok(l.M <= w * 0.82, `${w}×${h}: M=${l.M} fills the viewport`);
+    // §4.5's 44 % floor is a portrait rule; in landscape the 4:3 aperture
+    // shape governs and the floor relaxes to 28 %.
+    const floor = h > w ? 0.44 : 0.28;
+    assert.ok(
+      l.apertureH >= h * floor,
+      `${w}×${h}: aperture ${Math.round(l.apertureH)}px is under ${Math.round(h * floor)}px`,
+    );
+    assert.ok(l.M >= 180, `${w}×${h}: M=${l.M} is unusably small`);
+    assert.ok(
+      Math.abs(l.skyH + l.canopyH + l.stallH + l.floorH - h) < 0.5,
+      `${w}×${h}: the bands do not sum to the viewport`,
+    );
+  }
+});
+
+// ── BZ-16 / BZ-LAW-14 / BZ-LAW-15 — the lamp ───────────────────────────────
+
+test("BZ-16: the day cannot complete while a stall is open", () => {
+  const lamp = new Lamp();
+  lamp.setRemaining(0);
+  lamp.setInStall(true);
+  assert.equal(lamp.read().d, 0.99, "the day completed inside a game");
+  assert.equal(lamp.read().night, 0, "dusk began inside a game");
+});
+
+test("BZ-LAW-15: stepping back into the street buys a 90 s grace", () => {
+  const lamp = new Lamp();
+  lamp.setRemaining(0);
+  lamp.setInStall(true);
+  lamp.setInStall(false);
+  const now = Date.now();
+  assert.equal(lamp.read(now).grace, true);
+  assert.equal(lamp.read(now).night, 0, "dusk started during the grace");
+  assert.equal(lamp.read(now + GRACE_MS + 1).grace, false);
+});
+
+test("BZ-LAW-14: walking the bazaar costs nothing", () => {
+  const lamp = new Lamp();
+  lamp.setRemaining(0.5);
+  const a = lamp.read();
+  // No tick, no timer, no run-length: only the host's own accounting moves it.
+  const b = lamp.read(Date.now() + 600_000);
+  assert.equal(a.d, b.d);
+  assert.equal(a.oil, b.oil);
+});
+
+test("the lamp reads on four carriers, three of which are not colour", () => {
+  const lamp = new Lamp();
+  const seen = new Set<string>();
+  for (const r of [1, 0.6, 0.25, 0.05]) {
+    lamp.setRemaining(r);
+    const x = lamp.read();
+    seen.add(x.label);
+    assert.ok(x.oil >= 0 && x.oil <= 1);
+    assert.ok(x.gnomon >= 0 && x.gnomon <= 150);
+    assert.equal(x.lit, false, "the flame is a shape, and by day there is none");
+  }
+  lamp.setForcedNight(true);
+  const night = lamp.read();
+  seen.add(night.label);
+  assert.equal(night.lit, true, "the lamps did not light at dusk");
+  assert.equal(seen.size, 5, "the five day-states are not all reachable");
+});
+
+test("a subscriber's lamp never falls, and has no lamplighter to tap", () => {
+  const lamp = new Lamp();
+  lamp.setSubscribed(true);
+  lamp.setRemaining(0);
+  const r = lamp.read();
+  assert.equal(r.oil, 1);
+  assert.equal(r.lit, true);
+  assert.equal(lamp.showsLamplighter, false, "BZ-15: an upgrade surface for a subscriber");
+});
+
+test("the free child at dusk is not ejected: the ambient still resolves", () => {
+  const am = ambient(1, 1);
+  assert.ok(am.lanternGain >= 1);
+  const sem = semanticAt(1);
+  assert.notEqual(sem.ground, semanticAt(0).ground);
+  // …and the dusk is continuous, not a cut.
+  const mid = semanticAt(0.5);
+  assert.notEqual(mid.ground, semanticAt(0).ground);
+  assert.notEqual(mid.ground, semanticAt(1).ground);
+});
+
+// ── BZ-10 — the gear law ───────────────────────────────────────────────────
+
+test("BZ-10: ω_b = −ω_a·(N_a/N_b) for every meshing pair, as drawn", () => {
+  const spec = [{ teeth: 24 }, { teeth: 18, bearing: -20 }, { teeth: 12, bearing: 40 }];
+  const gears = gearTrain({ spec, module: 4, origin: { x: 0, y: 0 }, omega: 0.5 }, 0);
+  for (let i = 1; i < gears.length; i++) {
+    const a = gears[i - 1]!;
+    const b = gears[i]!;
+    assert.ok(
+      Math.abs(b.omega + a.omega * (a.teeth / b.teeth)) < 1e-9,
+      `pair ${a.teeth}→${b.teeth} violates the ratio law`,
+    );
+    // …and they actually mesh: centre distance is the sum of pitch radii.
+    const d = Math.hypot(b.x - a.x, b.y - a.y);
+    assert.ok(Math.abs(d - (a.r + b.r)) < 1e-9, "gears are not in contact");
+  }
+});
+
+test("BZ-10: a follower's angle is derived, so it cannot be assigned wrongly", () => {
+  const spec = [{ teeth: 20 }, { teeth: 15, bearing: -34 }];
+  const t0 = gearTrain({ spec, module: 4, origin: { x: 0, y: 0 }, omega: 0.55 }, 0);
+  const t1 = gearTrain({ spec, module: 4, origin: { x: 0, y: 0 }, omega: 0.55 }, 1);
+  const dA = t1[0]!.angle - t0[0]!.angle;
+  const dB = t1[1]!.angle - t0[1]!.angle;
+  assert.ok(Math.abs(dB + dA * (20 / 15)) < 1e-9, "the drawn rotation broke the ratio");
+});
+
+// ── BZ-06 — exactly one live preview ───────────────────────────────────────
+
+test("BZ-06: at most one preview renders per frame once posters exist", () => {
+  const calls: string[] = [];
+  const mk = (id: string): StallPreview => ({
+    period: 6,
+    render: () => {
+      calls.push(id);
+    },
+  });
+  const director = new PreviewDirector();
+  const ctx = fakeCtx();
+  const ids = ["a", "b", "c", "d"];
+  const previews = Object.fromEntries(ids.map((i) => [i, mk(i)]));
+
+  // First pass: each stall paints one still frame and caches a poster.
+  director.setLive("a");
+  director.beginFrame();
+  for (const id of ids) director.draw(ctx, id, previews[id], 100, 100, 1, 0, 1, false);
+  assert.equal(director.rendersThisFrame, ids.length);
+
+  // Thereafter only the centred stall animates.
+  for (let frame = 0; frame < 5; frame++) {
+    director.beginFrame();
+    calls.length = 0;
+    for (const id of ids) director.draw(ctx, id, previews[id], 100, 100, 1, frame, 1, false);
+    assert.equal(director.rendersThisFrame, 1, `frame ${frame} ran ${calls.length} previews`);
+    assert.deepEqual(calls, ["a"]);
+  }
+  assert.ok(director.posterCount <= 24, "the poster cache is unbounded");
+});
+
+test("BZ-06: a preview that throws is demoted and never asked again", () => {
+  const director = new PreviewDirector();
+  const ctx = fakeCtx();
+  let asked = 0;
+  const bad: StallPreview = {
+    period: 6,
+    render: () => {
+      asked++;
+      throw new Error("boom");
+    },
+  };
+  director.setLive("x");
+  director.beginFrame();
+  director.draw(ctx, "x", bad, 100, 100, 1, 0, 1, false);
+  director.beginFrame();
+  director.draw(ctx, "x", bad, 100, 100, 1, 1, 1, false);
+  assert.equal(asked, 1, "a broken preview was asked twice");
+});
+
+// ── BZ-09 — sound is never load-bearing ────────────────────────────────────
+
+test("BZ-09: the bed is a silent no-op when AudioContext throws", () => {
+  const g = globalThis as { AudioContext?: unknown };
+  const saved = g.AudioContext;
+  g.AudioContext = class {
+    constructor() {
+      throw new Error("no audio on this device");
+    }
+  };
+  try {
+    const bed = new Bed();
+    bed.start();
+    bed.setOpen(true);
+    bed.setDuck("preview");
+    bed.chime(0.2);
+    bed.strike(0, 0.5);
+    bed.shutter(0);
+    bed.suspend();
+    bed.resume();
+    bed.destroy();
+  } finally {
+    g.AudioContext = saved;
+  }
+});
+
+// ── BZ-14 — the string budget ──────────────────────────────────────────────
+
+test("BZ-14: twelve user-visible strings, present in all five locales", () => {
+  const keys = Object.keys(STRINGS.en);
+  assert.ok(keys.length <= 12, `${keys.length} strings; the budget is 12`);
+  for (const loc of LOCALES) {
+    const table = STRINGS[loc];
+    assert.deepEqual(Object.keys(table).sort(), keys.sort(), `${loc} has different keys`);
+    for (const k of keys) {
+      const v = table[k as keyof typeof table];
+      assert.ok(v.length > 0, `${loc}.${k} is empty`);
+      // Slots must survive translation.
+      const enSlots = (STRINGS.en[k as keyof typeof table].match(/\{\w+\}/g) ?? []).sort();
+      const locSlots = (v.match(/\{\w+\}/g) ?? []).sort();
+      assert.deepEqual(locSlots, enSlots, `${loc}.${k} lost a placeholder`);
+    }
+  }
+});
+
+test("the accessible name for a stall reads as a sentence", () => {
+  const s = t("en", "stall", {
+    name: "Tessera",
+    quarter: "Tilers’ Court",
+    specimen: "twelve times eight",
+  });
+  assert.equal(s, "Tessera, Tilers’ Court, twelve times eight");
+  assert.equal(resolveLocale("pt-PT"), "pt-BR");
+  assert.equal(resolveLocale(undefined), "en");
+});
+
+test("no string in the bazaar narrates status, roadmap or a countdown", () => {
+  const banned = /coming soon|left|remaining|minutes|seconds|upgrade|free|trial|\d/i;
+  for (const loc of LOCALES) {
+    for (const [k, v] of Object.entries(STRINGS[loc])) {
+      assert.ok(!banned.test(v), `${loc}.${k} narrates: "${v}"`);
+    }
+  }
+});
+
+// ── a canvas stub good enough for the director ─────────────────────────────
+
+function fakeCtx(): CanvasRenderingContext2D {
+  const canvas = { width: 100, height: 100 };
+  const noop = () => {};
+  const ctx = new Proxy(
+    { canvas, drawImage: noop },
+    {
+      get(target: Record<string, unknown>, prop: string) {
+        if (prop in target) return target[prop];
+        return noop;
+      },
+      set() {
+        return true;
+      },
+    },
+  );
+  return ctx as unknown as CanvasRenderingContext2D;
+}
+
+// The director captures posters onto real canvases; in Node there is no DOM,
+// so give it the smallest possible one.
+const g = globalThis as { document?: unknown };
+if (!g.document) {
+  g.document = {
+    createElement: () => ({
+      width: 0,
+      height: 0,
+      getContext: () => fakeCtx(),
+    }),
+  };
+}

--- a/dynawalla/bazaar/src/world/street.ts
+++ b/dynawalla/bazaar/src/world/street.ts
@@ -1,0 +1,251 @@
+/**
+ * The street generates itself.
+ *
+ * A virtualised list of records, and the fabric *between* the stalls is
+ * procedural — so shipping a game never requires anybody to author street.
+ * Past the last built quarter there is **scaffolding**: poles, ropes, a
+ * half-raised dome, a counterweight crane, two builder-automata. Not a "coming
+ * soon" card. When a game ships, the scaffolding comes down on that stall, and
+ * a returning child can witness it. That is the best release note there is.
+ *
+ * BZ-LAW-17 — there is no grid view. No "all games", no search field, no
+ * filter chips, no category tabs. The street is the navigation.
+ */
+
+import { frand, mix, pick } from "../util/rng.ts";
+import type { Quarter, StallSpec } from "../types.ts";
+import type { WardId } from "../tokens/palette.ts";
+import { QUARTERS } from "./quarters.ts";
+
+export type InterstitialKind =
+  | "doorway"
+  | "fountain"
+  | "crates"
+  | "stair"
+  | "alley-mouth"
+  | "water-crossing"
+  | "niche"
+  | "vine"
+  | "porter"
+  | "cat";
+
+export interface StallFeature {
+  kind: "stall";
+  x: number;
+  width: number;
+  seed: number;
+  quarter: Quarter;
+  stall: StallSpec;
+  /** Index among stalls only — what the keyboard steps through. */
+  index: number;
+}
+
+export interface InterstitialFeature {
+  kind: "interstitial";
+  x: number;
+  width: number;
+  seed: number;
+  quarter: Quarter;
+  type: InterstitialKind;
+}
+
+export interface GateFeature {
+  kind: "gate";
+  x: number;
+  width: number;
+  seed: number;
+  quarter: Quarter;
+  ward: WardId;
+}
+
+export type Feature = StallFeature | InterstitialFeature | GateFeature;
+
+const INTERSTITIALS: readonly InterstitialKind[] = [
+  "doorway",
+  "crates",
+  "stair",
+  "alley-mouth",
+  "niche",
+  "vine",
+  "porter",
+  "water-crossing",
+  "fountain",
+  "cat",
+];
+
+export interface StreetOptions {
+  seed: number;
+  /** The stall pitch. Everything derives from it. */
+  module: number;
+  stalls: StallSpec[];
+  quarters?: readonly Quarter[];
+}
+
+export class Street {
+  readonly features: Feature[] = [];
+  readonly stalls: StallFeature[] = [];
+  private cursor = 0;
+  private step = 0;
+  private lastKinds: InterstitialKind[] = [];
+  private lastFountain = -99;
+  private ward: WardId | null = null;
+  private module: number;
+  private seed: number;
+  private quarters: readonly Quarter[];
+  private given: StallSpec[];
+
+  constructor(o: StreetOptions) {
+    this.module = o.module;
+    this.seed = o.seed;
+    this.quarters = o.quarters?.length ? o.quarters : QUARTERS;
+    this.given = o.stalls;
+    this.cursor = o.module * 0.45;
+  }
+
+  get width(): number {
+    return this.cursor + this.module;
+  }
+
+  /** Grow the street until it reaches `x`. Called as the camera approaches. */
+  ensure(x: number): void {
+    let guard = 0;
+    while (this.cursor < x && guard++ < 400) this.emit();
+  }
+
+  /** The quarter a given step belongs to. Built stalls first, then forever. */
+  private quarterFor(step: number): Quarter {
+    const built = this.given.length;
+    if (step < built) {
+      const id = this.given[step]!.quarter;
+      return this.quarters.find((q) => q.id === id) ?? this.quarters[step % this.quarters.length]!;
+    }
+    return this.quarters[step % this.quarters.length]!;
+  }
+
+  private emit(): void {
+    const step = this.step++;
+    const quarter = this.quarterFor(step);
+    const s = mix(this.seed, step * 7919);
+
+    // A ward boundary is a gate, and the next ward's tower is already visible
+    // from inside this one.
+    if (this.ward !== quarter.ward) {
+      this.ward = quarter.ward;
+      if (step > 0) {
+        const w = this.module * 0.62;
+        this.features.push({
+          kind: "gate",
+          x: this.cursor,
+          width: w,
+          seed: mix(s, 0x6a7e),
+          quarter,
+          ward: quarter.ward,
+        });
+        this.cursor += w + this.module * 0.06;
+      }
+    }
+
+    const given = this.given[step];
+    const stall: StallSpec = given ?? {
+      id: `scaffold-${step}`,
+      title: "",
+      quarter: quarter.id,
+      state: "scaffold",
+    };
+    const f: StallFeature = {
+      kind: "stall",
+      x: this.cursor,
+      width: this.module,
+      seed: s,
+      quarter,
+      stall,
+      index: this.stalls.length,
+    };
+    this.features.push(f);
+    this.stalls.push(f);
+    this.cursor += this.module;
+
+    // Interstitial fabric: weighted, no repeat within five, a fountain no
+    // closer than nine apart. A street with no side alleys is a corridor.
+    const gap = this.module * (0.2 + (frand(mix(s, 3)) - 0.5) * 0.12);
+    let kind = pick(INTERSTITIALS, frand(mix(s, 11)));
+    let tries = 0;
+    while (
+      tries++ < 12 &&
+      (this.lastKinds.includes(kind) ||
+        (kind === "fountain" && step - this.lastFountain < 9))
+    ) {
+      kind = pick(INTERSTITIALS, frand(mix(s, 11 + tries * 31)));
+    }
+    if (kind === "fountain") this.lastFountain = step;
+    this.lastKinds.push(kind);
+    if (this.lastKinds.length > 5) this.lastKinds.shift();
+
+    this.features.push({
+      kind: "interstitial",
+      x: this.cursor,
+      width: gap,
+      seed: mix(s, 0x1f3d),
+      quarter,
+      type: kind,
+    });
+    this.cursor += gap;
+  }
+
+  /** Features overlapping [x0, x1]. Linear, and the window is small. */
+  visible(x0: number, x1: number): Feature[] {
+    const out: Feature[] = [];
+    for (const f of this.features) {
+      if (f.x + f.width < x0) continue;
+      if (f.x > x1) break;
+      out.push(f);
+    }
+    return out;
+  }
+
+  /** The stall whose centre is nearest `x`. */
+  nearestStall(x: number): StallFeature | null {
+    let best: StallFeature | null = null;
+    let bd = Infinity;
+    for (const s of this.stalls) {
+      const d = Math.abs(s.x + s.width / 2 - x);
+      if (d < bd) {
+        bd = d;
+        best = s;
+      }
+    }
+    return best;
+  }
+
+  stallById(id: string): StallFeature | undefined {
+    return this.stalls.find((s) => s.stall.id === id);
+  }
+
+  /** The first stall of each ward — where Home/End and the astrolabe land. */
+  wardBoundaries(): number[] {
+    const out: number[] = [];
+    let ward: WardId | null = null;
+    for (const s of this.stalls) {
+      if (s.quarter.ward !== ward) {
+        ward = s.quarter.ward;
+        out.push(s.index);
+      }
+    }
+    return out;
+  }
+}
+
+/** BZ-17, as data rather than as a promise. */
+export function quarterTriples(qs: readonly Quarter[]): string[] {
+  return qs.map((q) => `${q.ward}|${q.finial}|${q.fold}`);
+}
+
+export function adjacentWardPairs(qs: readonly Quarter[]): [WardId, WardId][] {
+  const out: [WardId, WardId][] = [];
+  for (let i = 0; i < qs.length; i++) {
+    const a = qs[i]!.ward;
+    const b = qs[(i + 1) % qs.length]!.ward;
+    out.push([a, b]);
+  }
+  return out;
+}

--- a/dynawalla/bazaar/tsconfig.json
+++ b/dynawalla/bazaar/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": false,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "isolatedModules": true
+  },
+  "include": ["src", "qa", "vite.config.ts"]
+}

--- a/dynawalla/bazaar/vite.config.ts
+++ b/dynawalla/bazaar/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vite";
+
+// The bazaar is a library that also runs standalone. `npm run dev` serves the
+// demo street with ten stub stalls; `npm run build` emits the library.
+export default defineConfig({
+  server: { port: 5183, strictPort: false },
+  build: {
+    lib: {
+      entry: "src/index.ts",
+      name: "DynawallaBazaar",
+      formats: ["es"],
+      fileName: () => "bazaar.js",
+    },
+    sourcemap: true,
+  },
+});


### PR DESCRIPTION
## The bazaar

`dynawalla/bazaar/` — a self-contained Vite + TypeScript package that renders
the marketplace and mounts into a DOM element. Ten stub stalls ship with it, so
`npm run dev` gives a playable street today; the ten real games plug in by
implementing one interface and nothing else about the bazaar changes.

**The thesis, which everything follows from:** the bazaar is the frame, the
games are the stalls. An arcade has a look; the cabinets inside are each their
own world. The marketplace carries the identity so ten games can look like ten
different games and still be one place. The stub previews are deliberately
*not* minaret-punk — each owns its own ground, palette and type.

### Acceptance

This PR moves no numbered item in `docs/ACCEPTANCE_CRITERIA.md`: the bazaar is
not on the M0a bootstrap list and `docs/MASTER_PLAN.md` does not name it. It
lands because the founder commissioned it directly and because it is the shell
every game in `dynawalla/games/*` will need a hole to sit in. It is **additive
and isolated**: a new directory with its own `package.json`, no CI job, no
change to any existing file, and a boundary test that fails the build if
anything in it ever reaches into `src/work/`, `engine/` or `curriculum/`.

Its own rubric is the twenty `BZ-*` gates in `dynawalla/bazaar/docs/AESTHETIC.md`.

### Gates quoted, with status

| id | Gate | Status |
|---|---|---|
| BZ-01 | Three-layer token discipline, both themes, no drift between `palette.ts` and `bazaar.css` | ✅ |
| BZ-02 | Zero `rgba(0,0,0,*)`, zero `box-shadow` blur > 2 px, zero `filter: blur()` | ✅ |
| BZ-03 | Contrast for every pair in both themes; wards ≥ 3:1 against their ground | ✅ |
| BZ-04 | Girih straps touch edges only at midpoints, at 54° ± 0.01°, with a partner across every boundary | ✅ |
| BZ-05 | Renders with webfonts disabled, no shift | ✅ — no webfont is loaded at all |
| BZ-06 | At most one live preview; the rest are posters | ✅ spy on `render` |
| BZ-07 | Every shipped game's preview under 4 ms/frame | ⚠️ contract + demotion shipped; no real games yet |
| BZ-08 | Exit restores `scrollLeft` within 1 px | ✅ restores it exactly |
| BZ-09 | Renders and plays with `AudioContext` stubbed to throw | ✅ |
| BZ-10 | `ω_b = −ω_a·(N_a/N_b)` for the rendered tooth counts | ✅ the follower's angle is *derived*, so it cannot be violated |
| BZ-11 | No touch target under 44 px | ✅ |
| BZ-12 | No > 10 % luminance change in 200 ms over > 25 % of the viewport | ✅ measured: worst share **0.000** |
| BZ-13 | Reduced motion: zero parallax, zero idle animation | ✅ |
| BZ-14 | ≤ 12 user-visible strings, in all five locales | ✅ exactly 12, en/es/pt-BR/fr/de |
| BZ-15 | Exactly one upgrade surface, non-modal, unreachable during play | ✅ |
| BZ-16 | The day cannot complete while a stall is open | ✅ |
| BZ-17 | Distinct `(ward, finial, fold)` triples; lapis never adjacent to aubergine | ✅ including the wrap |
| BZ-18 | ≤ 1,200 live nodes at 60 stalls | ✅ measured: **48** |
| BZ-19 | The screenshot set | ⚠️ generated and reviewed; git-ignored (see below) |
| BZ-20 | Stranger test | ⛔ needs humans |

41 tests pass; `tsc --noEmit` is clean.

### Measured

Headless Chromium, DPR 2, 1024 × 768, 300 frames of continuous scrolling — a
hostile environment, since headless canvas is software-rasterised:

mean **45.1 fps** · p50 23.3 ms · p90 25.1 ms · p99 36.5 ms · **48** live DOM
nodes at 60 stalls · flash worst share **0.000**.

What is culled: sprite caching is the whole story (every tower, dome, arcade
bay, lantern, shutter, girih panel and stall facade is constructed once and
blitted); exactly one live preview with an LRU of ≤ 24 posters; stall DOM
windowed to the viewport ± 1.2 M; dust only inside a shaft polygon; shafts from
every other bay; the backdrop at 0.85 × device scale. A silent thermal ladder
sheds dust → far parallax → the live preview and recovers only after 10 s.

**Not measured on the reference device.** The Galaxy Tab A9 run is outstanding.

### Deliberate departures from the brief

Each is argued in full in `docs/AESTHETIC.md`:

1. **Vanilla TS, not `.tsx`** — the street is one canvas plus ~6 nodes per
   stall at 60 fps; a reconciler in that loop costs frame time and buys nothing.
   `mountBazaar(el, opts)` wraps in a React ref in six lines.
2. **No Tailwind `@theme`** — standalone package; the three layers are section
   headers and the test parses them. Same discipline, different at-rule.
3. **No webfont** — the host already bans a font load on the answer path;
   bundling two woff2 files here is a cost with no buyer.
4. **The canopy is an arcade overhead with openings cut clean through**, not a
   vault filling the upper third. The vault hid the skyline, which broke "you
   can always see somewhere you have not been". Now the sky and the next ward's
   tower show through the holes, and every shaft of light falls from one.
5. **The 44 % aperture floor is a portrait rule** — in landscape the 4:3 shape
   governs; layout keys off aspect ratio, not raw height.
6. **Wards group two quarters each** — one ward per quarter put a gate between
   every pair of stalls and the street read as a row of gateways.
7. **The screenshot set is git-ignored** — 8 MB of PNGs regenerated by
   `npm run shots`, in a public repo, on a package's first PR. Generated and
   reviewed as images during the build; the command is the artefact.

### PR size

`git diff origin/main | wc -c` is ~412,000, over `MAX_DIFF_BYTES`. This is one
new self-contained directory with no changes to any existing file; splitting it
into geometry/world/stall PRs would leave non-compiling intermediate states for
no review benefit. Flagging it rather than hiding it, per `dynawalla/AGENTS.md`.

### Not built yet, with seams waiting

The caravanserai (your own things, off the street); pigeon flush on fast
scroll; per-stall audio panning; the staggered shutter roll-down at dusk (the
sound exists, the visual stagger does not).
