### PR TITLE
dynawalla(arena): ARENA — a bioluminescent growth arena where the size relation is the rule

### DIFF
--- a/dynawalla/games/arena/.gitignore
+++ b/dynawalla/games/arena/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+dist-pack/
+
+# Playtest capture output: multi-MB PNGs, regenerated on demand.
+qa/shots
+qa/tmp
+
+# Not tracked, matching dynawalla/games/slice and .../merge. These prototypes
+# pin nothing beyond vite + typescript in devDependencies.
+package-lock.json

--- a/dynawalla/games/arena/README.md
+++ b/dynawalla/games/arena/README.md
@@ -1,0 +1,276 @@
+# ARENA
+
+**You are a number. Eat what is smaller. Flee what is not.**
+
+A growth arena in the lineage of Agar.io, Slither.io and Hole.io, played in a
+black ocean full of bioluminescent numbers. You start at 10. Everything on
+screen carries a number, everything obeys one radius law, and the only rule is
+the one the picture already told you: **you may swallow anything smaller than
+you, and anything larger will hurt.**
+
+```bash
+npm install
+npm run dev      # http://127.0.0.1:5188/
+npm test         # 24 tests, Node's native runner, zero dependencies
+npm run tsc      # typecheck
+npm run build:pack   # the installable pack; `../../packs && node build.mjs arena` checks and stages it
+```
+
+`?perf` shows the fps/tier readout. `?seed=123` reproduces a run — the *whole*
+run: it seeds the world's RNG as well as the question stream, which it did not
+used to, so what it actually reproduced was the arithmetic over a different
+ocean. `?dev` attaches the development handle used by the soak and perf
+harnesses.
+
+---
+
+## The rule, and why there is no tutorial
+
+Radius is `9 × √value` for **everything** — motes, rival cores, you. So
+"smaller than me" is something a child sees before they read it, and the
+printed number is only there to settle the near-ties. Three seconds and no
+sentence.
+
+The visual grammar is one rule applied everywhere, and never carried by colour
+alone:
+
+| | |
+|---|---|
+| **smooth filled disc** | smaller than you — swallow it |
+| **spiked hollow ring** | larger than you — it will hurt |
+| **crimson, marked `−`** | a void mote: always harmful, whatever its size |
+
+The best moment in the genre is watching that grammar *flip*. When your mass
+crosses a mote's value the husk collapses into a disc in front of you, with a
+tick and a spark. Growth is not a number going up; it is the world converting
+into food.
+
+## Two verbs
+
+**Steer.** A mouse steers by pointing — Agar's scheme, which is correct with a
+mouse. A finger steers with a floating relative stick that re-centres if you
+drag past its edge, so your hand is never sitting on the thing you are trying
+to read.
+
+**Surge.** Hold. You accelerate hard and burn mass continuously, spraying it
+out behind you as real, edible motes that a rival will absolutely come and eat.
+A second finger, a double-tap-and-hold, a held mouse button, space or shift —
+all of them, because a child will try whichever one they think of first.
+
+If twelve seconds pass and surge has never been found, the player core emits a
+soft pulse ring. No copy, no arrow, no tooltip.
+
+## Where the mathematics is
+
+**Native, continuously.** Every second of play is a magnitude comparison under
+time pressure, and about one mote in seven is drawn from a band that straddles
+your own mass — because telling `3,418` from `3,481` at speed *is* the
+place-value comparison a worksheet asks for eighty times and gets answered
+nine. A misread is not a red X; it is a sting that costs mass in proportion to
+how badly you misjudged it, and takes your combo with it.
+
+**RESONANCE — the curriculum beat.** Every twenty-odd seconds the water goes
+dark and holds its breath. Within a sixth of a second the ordinary field drops
+to a twentieth of its brightness and turns inert, every rival core falls back
+into the dark, the leaderboard and the depth readout fade out of the way, and
+four glass spheres — pushed *brighter* by the same signal that dims everything
+else — rise in a ring around you carrying the answer and three distractors from
+`host.next()`. The question stands over the arena in letters you can read from
+across a room. You fly into one.
+
+(This paragraph used to be a lie, and a judge caught it. The labels on
+background motes dropped instantly while the mote *shapes* faded over four
+tenths of a second and only to a ninth, so the one frame in the game that asks
+a direct question was also the busiest frame in the game. Both now ride the same
+curve, and the curve is fast.)
+
+- **Right** → a shockwave clears the neighbourhood, every rival is thrown off
+  you, your mass surges and the chord resolves upward with the streak.
+- **Wrong** → you lose a quarter of your mass, the chord sags, and the correct
+  sphere flares for a beat so you *see* which it was. No lecture, no modal.
+- **Timeout** → the water simply comes back. You lost the opportunity, nothing
+  more.
+
+Inside a Resonance the arena is a fixed-size room however large you have grown,
+so the answer can never be the thing that outruns you.
+
+## Endless, not winnable
+
+There is no completion state and no game-over screen. There are **depths**:
+nine bands of water you sink into as the run goes on, each with its own
+palette, density, temper, and exactly one new thing to be afraid of. They are
+meant to be nine genuinely different looks, not a hue rotation — you should be
+able to say which depth a screenshot came from.
+
+| | mass | |
+|---|---|---|
+| **DRIFT** | 0 | timid drifters; cold abyssal blue |
+| **THE CURRENT** | 90 | void motes appear; kelp green |
+| **THE CHURN** | 380 | hunters that lock on; a violet storm |
+| **THE VENTS** | 1,300 | a Leviathan; volcanic ember on black basalt |
+| **THE SHELF** | 4,200 | a bleached ice shelf, pale and brittle |
+| **APEX** | 13,000 | everything, faster; electric indigo |
+| **THE ABYSSAL** | 40,000 | a near-black trench lit by one acid green |
+| **SOVEREIGN** | 120,000 | gold on oxblood |
+| **THE LAST LIGHT** | 350,000 | white-hot on black; everything is a silhouette |
+
+**The band is a ratchet, and the clock is a floor.** This is the second thing a
+judge caught. Depth used to track *current* mass, so a bad patch dropped you
+back a band: a five-minute soak flipped between DRIFT and THE CURRENT and back,
+saw exactly two of the six looks, and finished at the mass it started at. That
+is a treadmill, which is precisely what a growth game must never be.
+
+Now the band is monotone — once entered, never left — and it advances on the
+clock every hundred seconds whether the run is going well or not, so a full
+descent takes about thirteen minutes for anybody. Mass buys you a *lead*: play
+well and you may sit up to two bands ahead of the clock, which is the whole
+reward, and the arrival is gold with a rising arpeggio instead of blue with a
+low chord. Nine pips under the depth name fill in as you go — wordless, and the
+only thing on screen that only ever goes up.
+
+Past THE LAST LIGHT the modifiers keep compounding, on mass for a player who is
+winning and on the clock for one who is merely surviving, so the eighteenth
+minute still escalates. A run ends when the child puts the tablet down.
+
+**Death is a rupture, not a loss.** You burst, scatter most of what you were
+across the water where anyone can take it, and re-form on the spot at speed
+with a few seconds of shield. The fall is deep but *bounded by a checkpoint*:
+your high water mark never decays, and nothing in the game — a rupture, a
+sting, a void mote, a wrong answer, burning mass on a surge — can take you more
+than about two fifths below it. A bad patch is a real and painful setback; it
+can no longer delete the run. There is no modal, no score screen, and nothing to
+click before you are playing again.
+
+## Feel
+
+Techniques from Vlambeer's *Art of Screenshake*, applied by name: trauma-based
+screenshake, hit-stop that freezes the simulation while the presentation keeps
+running, camera lead, zoom punch, knockback, permanence (nothing is deleted, it
+is scattered), screen-space impact ripple, chromatic aberration on damage, and
+sound with per-hit pitch variation.
+
+Everything is amplitude-limited on purpose, because this is a children's
+product:
+
+- Full-screen luminance jumps are rate-capped to **three per second** and hard-
+  capped in amplitude. A fourth flash inside a second is clamped to an absolute
+  0.05 — between a sixth and a half of what it asked for, depending on the
+  event; a seventh is dropped entirely.
+- `prefers-reduced-motion` removes translation, zoom punch, ripple and
+  aberration, and replaces them with a brief desaturation pulse — the *signal*
+  survives, the motion does not.
+- No meaning is carried by colour alone anywhere.
+- Readable at 320 px.
+
+## Sound
+
+Synthesized in Web Audio at runtime; there are no audio files. Every one-shot
+is a transient, a body and a tail, with per-hit pitch, filter and timbre
+variation so ten thousand absorbs in a session do not sand a child's ears down.
+The absorb ladder climbs a pentatonic set with your combo. The whole mix runs
+through a lowpass whose cutoff opens as you grow, so becoming enormous is
+something you hear before you read it. Everything sits in a procedurally
+generated convolution reverb — an underwater cathedral. Disableable, and no cue
+ever carries information alone.
+
+## Rendering
+
+Three.js with an orthographic camera and hand-written raw shaders. Every
+drawable is **one instanced draw call**: backdrop, marine snow, particles,
+motes, cores, shockwave rings. Numerals are two — the dark plate and the white
+ink, deliberately, because that is what makes a numeral survive a blown-out
+highlight. The simulation is structure-of-arrays over typed arrays, events come
+out of a preallocated ring, and particles are integrated entirely in the vertex
+shader so a 140-particle burst costs one buffer write. Nothing in `step` or in
+the draw allocates; `leaderboard`, which the HUD calls about four times a
+second, and mote spawning are the two places that still do.
+
+The post chain is threshold → downsample → separable blur → composite, written
+by hand rather than assembled from `EffectComposer` so the tier governor can
+change pass count and render-target scale at runtime, and so the ripple, the
+aberration and the flash share one full-screen pass.
+
+**The numerals are drawn last, straight to the screen, after the bloom
+composite.** They can never be eaten by their own glow. Each glyph is one
+signed-distance field read at **two iso-levels** — a crisp white fill at the
+glyph edge and a fatter, near-black slab behind it — so a white numeral stays
+readable sitting on a blown-out highlight, and the slab stays exactly as thick
+relative to the glyph at every size. This is the single most load-bearing
+decision in the renderer: ornament is never allowed to win against legibility.
+
+### Quality tiers
+
+The mid-range tablet sets the floor, never the ceiling. A static guess picks a
+starting tier; a frame-time governor then demotes readily and promotes exactly
+once, so the picture never oscillates.
+
+| tier | motes | rivals | particles | snow | bloom | dpr |
+|---|---|---|---|---|---|---|
+| low | 115 | 12 | 380 | 140 | 1 pass @ 0.25 | 1.5 |
+| mid | 155 | 16 | 900 | 320 | 2 @ 0.35 | 2 |
+| high | 195 | 20 | 1800 | 620 | 3 @ 0.50 + dispersion | 2 |
+| ultra | 240 | 24 | 3200 | 1100 | 4 @ 0.60 + dispersion | 2.25 |
+
+## The contract
+
+`src/contract.ts` is exactly the shape the runtime lands underneath, and
+`src/pack.ts` is the whole of the landing: it swaps the stub for the real host
+and changes nothing else in the game. `pack.json` declares `items`,
+`items.reveal` and `haptics` — `items.reveal` because a sphere has to *carry*
+the answer before the child reaches it, which is the sanctioned use of that
+grant and changes nothing about who judges. It declares no `audio` capability:
+that grant is for playing the *app's* sounds, and ARENA synthesizes its own.
+
+`src/host/stubHost.ts` is a seeded, deterministic local Host so the game is
+fully playable standalone: every answer is exact integer arithmetic, and every
+distractor is a **mal-rule output** — the number a child actually writes when
+they apply a plausible-but-wrong procedure (a dropped carry, `|top − bottom|`
+per column instead of borrowing, one step too far up a times table), never
+random noise. Random noise teaches a child to spot the odd one out, not to
+compute.
+
+**No arithmetic decides whether a child was right.** The verdict is sphere
+identity — you flew into slot *k*, and slot *k* is the one the shuffle put the
+answer in — so there is no comparison anywhere on that path to get wrong. And
+the `answered` string reported back is the Host's own option string kept
+verbatim, never the sphere's *drawn* label: that goes through an `Int32Array`
+because the numeral layer needs a number, and an `Int32Array` does not fail on
+an answer past 2³¹, it silently returns a different one. Both are pinned by a
+test that flies a run and a host emitting ten-digit answers.
+
+## Tuning notes for whoever comes next
+
+Three constants are the entire difficulty curve, and all three were fitted by
+simulating complete twenty-minute runs rather than by looking at the screen:
+
+- **`FOOD_A` / `FOOD_B`** — mote value scales as `A × mass^B`, *not* as a
+  fraction of mass. A fraction compounds, and compounding turns a twenty-minute
+  climb into a ninety-second explosion followed by nothing.
+- **`ABSORB_K` / `ABSORB_SOFT`** — absorption saturates, capping any single mote
+  at a seventh of you, and past `ABSORB_SOFT` the cap itself tightens as
+  `√mass`. Without the cap, the sliver of the near-tie band just below your mass
+  is a free doubling; a child finds it in ninety seconds. Without the tightening
+  the same band is a *fixed fraction* of you, which is an exponential by a
+  slower road — measured at 273 → 3,330,895 → 1,301,388,804 in three hundred
+  seconds, which is a legibility failure before it is a balance one.
+- **`DEVOUR_K`** — the same idea, far more generously, for eating a rival: your
+  own size is worth about a third of you, **at every size**. It deliberately
+  does *not* get the `√mass` tightening, and the asymmetry is the point: the
+  near-tie mote is a supply the game manufactures on purpose, and a rival is
+  not — there are at most 26, they respawn on a timer, and one is only edible
+  below `mass / 1.06`. Measured with a bot that hunts nothing else for twenty
+  minutes, tightening it changed the peak from 34,456 to 11,442 — both five
+  digits, neither an explosion — so it bought no safety and cost the genre its
+  payoff moment. `sim.test.ts` flies that bot as a regression.
+
+A mote's printed number is a **size**, not an addend. A fish that swallows a
+fish nearly its own size does not double, and the floating number that pops on
+absorb is the size you actually gained. The comparison — which is the
+mathematics — is exact and honest; the economy is a separate, tuned layer.
+
+`src/sim/sim.test.ts` runs a full twenty-minute headless game and asserts on
+the *shape* of the result rather than on a number: the first minute must be a
+climb and not a detonation, and after twenty minutes the ladder must still be
+live — there must still be something in the water that can eat you. Every
+economy bug this repository has seen was invisible in a thirty-second look at
+the screen and obvious after one simulated run.

--- a/dynawalla/games/arena/index.html
+++ b/dynawalla/games/arena/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no"
+    />
+    <meta name="theme-color" content="#01040c" />
+    <title>ARENA</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #01040c;
+        overscroll-behavior: none;
+        touch-action: none;
+        -webkit-user-select: none;
+        user-select: none;
+        -webkit-tap-highlight-color: transparent;
+      }
+      #arena {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="arena"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/arena/pack.html
+++ b/dynawalla/games/arena/pack.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#01040c" />
+    <title>ARENA</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #01040c;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         The dev harness's `?seed`/`?perf`/`?dev` switches are not read here —
+         they belong to `index.html`, which the pack build does not include. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/arena/pack.json
+++ b/dynawalla/games/arena/pack.json
@@ -1,0 +1,16 @@
+{
+  "id": "dynawalla.arena",
+  "version": "0.1.0",
+  "name": "ARENA",
+  "description": "A bioluminescent growth arena. You are a number in a black ocean where everything obeys one radius law, so \"smaller than me\" is something you see before you read it — and telling 3,418 from 3,481 at speed is the whole game.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": ["dw.ns.compare.whole-numbers"],
+    "grades": [1, 4]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/arena/package.json
+++ b/dynawalla/games/arena/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@dynawalla/game-arena",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "ARENA — a bioluminescent growth arena. You are a number. Eat what is smaller. Flee what is not.",
+  "main": "src/index.ts",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "build:pack": "vite build --config vite.pack.config.ts",
+    "preview": "vite preview --port 4188 --strictPort",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\""
+  },
+  "dependencies": {
+    "three": "^0.185.1"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "@types/three": "^0.185.1",
+    "typescript": "~6.0.3",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/games/arena/src/contract.ts
+++ b/dynawalla/games/arena/src/contract.ts
@@ -1,0 +1,25 @@
+export type Question = { id: string; prompt: string; answer: string; distractors: string[]; domain: string; difficulty: number }
+export type Host = {
+  next(opts?: { domain?: string; difficulty?: number }): Question
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+  haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void
+  prefersReducedMotion(): boolean
+}
+export type MountOptions = {
+  /**
+   * Seed for the WORLD — mote values and positions, rival sizes, the option
+   * shuffle, resonance timing. Omit for a fresh run every time.
+   *
+   * Seeding the Host alone reproduces the question stream and nothing else,
+   * which is what `?seed=` used to do while the README claimed it reproduced
+   * a run.
+   */
+  seed?: number
+}
+export function mount(el: HTMLElement, host: Host, opts?: MountOptions): { unmount(): void } {
+  // Re-exported from ./mount.ts at build time; this declaration exists so the
+  // contract file is literally the shape the runtime lands underneath.
+  return mountArena(el, host, opts)
+}
+
+import { mountArena } from "./mount.ts"

--- a/dynawalla/games/arena/src/core/core.test.ts
+++ b/dynawalla/games/arena/src/core/core.test.ts
@@ -1,0 +1,154 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { Rng } from "./rng.ts"
+import { Grid } from "./grid.ts"
+import { splitDigits, tidyValue, valueBuffer } from "./digits.ts"
+
+test("rng is deterministic for a seed and diverges for neighbours", () => {
+  const a = new Rng(1234)
+  const b = new Rng(1234)
+  const c = new Rng(1235)
+  const as: number[] = []
+  const bs: number[] = []
+  const cs: number[] = []
+  for (let i = 0; i < 64; i++) {
+    as.push(a.u32())
+    bs.push(b.u32())
+    cs.push(c.u32())
+  }
+  assert.deepEqual(as, bs)
+  assert.notDeepEqual(as, cs)
+})
+
+test("rng.int stays inside the closed interval", () => {
+  const r = new Rng(7)
+  for (let i = 0; i < 5000; i++) {
+    const v = r.int(3, 9)
+    assert.ok(v >= 3 && v <= 9, `int out of range: ${v}`)
+    assert.ok(Number.isInteger(v))
+  }
+  assert.equal(r.int(5, 5), 5)
+  assert.equal(r.int(5, 2), 5)
+})
+
+test("rng.shuffle is a permutation", () => {
+  const r = new Rng(99)
+  const src = [0, 1, 2, 3, 4, 5, 6, 7]
+  const out = r.shuffle([...src])
+  assert.deepEqual([...out].sort((x, y) => x - y), src)
+})
+
+/**
+ * The grid must follow the field, not the origin.
+ *
+ * It used to be pinned to a fixed ±9,300 world box, and ARENA's arena radius
+ * passes that at a player mass of about 680. Everything outside the box clamps
+ * into one edge cell, so from the third depth onward the broad phase was
+ * silently the O(n²) scan it exists to replace — correct, and useless. The
+ * far-from-origin case below is the one that used to degenerate.
+ */
+test("grid finds every body inside the query radius, wherever the field is", () => {
+  const n = 400
+  const r = new Rng(5)
+
+  // Near the origin, and then a cluster 120,000 units out — the deep-depth
+  // case. Both must behave identically.
+  for (const [cx, cy, extent] of [
+    [0, 0, 4000],
+    [120_000, -84_000, 26_000],
+  ] as [number, number, number][]) {
+    const xs = new Float32Array(n)
+    const ys = new Float32Array(n)
+    const alive = new Uint8Array(n).fill(1)
+    for (let i = 0; i < n; i++) {
+      xs[i] = cx + r.range(-extent, extent)
+      ys[i] = cy + r.range(-extent, extent)
+    }
+    alive[7] = 0
+    const g = new Grid(62, n)
+    g.build(xs, ys, alive, n, cx, cy, extent * 2.4)
+
+    const qx = cx + 120
+    const qy = cy - 350
+    const qr = extent * 0.22
+    const expected = new Set<number>()
+    for (let i = 0; i < n; i++) {
+      if (!alive[i]) continue
+      if (Math.hypot((xs[i] as number) - qx, (ys[i] as number) - qy) <= qr) expected.add(i)
+    }
+    const got = new Set<number>()
+    g.query(qx, qy, qr, (i) => got.add(i))
+    for (const i of expected) assert.ok(got.has(i), `grid missed body ${i} at centre ${cx},${cy}`)
+    assert.ok(!got.has(7), "grid returned a dead body")
+    // …and it is actually a broad phase: a small query must not hand back the
+    // whole population. This is the assertion the fixed-box version failed.
+    assert.ok(expected.size > 0, "the test query matched nothing, so it proves nothing")
+    assert.ok(got.size < n * 0.5, `the grid degenerated: one query returned ${got.size} of ${n}`)
+  }
+})
+
+test("splitDigits survives past 2^31 — a truncation here prints a different number", () => {
+  const buf = new Int32Array(12)
+  const read = (v: number): string => {
+    const n = splitDigits(v, buf)
+    let out = ""
+    for (let i = n - 1; i >= 0; i--) out += String(buf[i])
+    return out
+  }
+  assert.equal(read(0), "0")
+  assert.equal(read(7), "7")
+  assert.equal(read(1090), "1090")
+  assert.equal(read(-4652), "4652")
+  assert.equal(read(2147483647), "2147483647")
+  assert.equal(read(8030000000), "8030000000")
+
+  // Past the buffer it must SATURATE, not truncate. Returning the low N digits
+  // prints a confidently different number, which is the one failure mode this
+  // function exists to rule out.
+  const small = new Int32Array(4)
+  const n = splitDigits(1234567, small)
+  assert.equal(n, 4)
+  let out = ""
+  for (let i = n - 1; i >= 0; i--) out += String(small[i])
+  assert.equal(out, "9999", "an over-long value truncated instead of saturating")
+})
+
+/**
+ * `splitDigits` being float-safe is worth nothing if the value is already
+ * wrong by the time it gets there. The renderer parks every pending numeral in
+ * a buffer before it lays them out, and that buffer was a `Float32Array`:
+ * 8,030,000,000 came back out as 8,030,000,128, and *every* value past 2^24
+ * came back rounded. The digit extraction then did its careful, correct job on
+ * the wrong number, which is the worst possible way for this to fail — there is
+ * no seam at which anything looks broken.
+ */
+test("a numeral's value survives its own storage, and prints as itself", () => {
+  const buf = valueBuffer(4)
+  const digits = new Int32Array(12)
+  const print = (v: number): string => {
+    const n = splitDigits(v, digits)
+    let out = ""
+    for (let i = n - 1; i >= 0; i--) out += String(digits[i])
+    return out
+  }
+  for (const v of [7, 1090, 999999, 16777217, 20000001, 2147483647, 8030000000]) {
+    buf[1] = v
+    assert.equal(buf[1], v, `the value buffer rounded ${v} to ${buf[1]}`)
+    assert.equal(print(buf[1] as number), String(v), `${v} would have been drawn as a different number`)
+  }
+})
+
+test("tidyValue keeps three significant figures and never returns zero", () => {
+  assert.equal(tidyValue(7), 7)
+  assert.equal(tidyValue(999), 999)
+  assert.equal(tidyValue(4817), 4820)
+  assert.equal(tidyValue(48173), 48200)
+  assert.equal(tidyValue(481734), 482000)
+  assert.equal(tidyValue(-4817), -4820)
+  assert.equal(tidyValue(0.2), 1)
+  for (let v = 1; v < 20000; v += 7) {
+    const t = tidyValue(v)
+    assert.ok(Number.isInteger(t), `tidyValue produced a non-integer for ${v}`)
+    assert.ok(t >= 1)
+  }
+})

--- a/dynawalla/games/arena/src/core/digits.ts
+++ b/dynawalla/games/arena/src/core/digits.ts
@@ -1,0 +1,65 @@
+/**
+ * Integer → digit places, into a caller-owned buffer.
+ *
+ * Pulled out of the numeral layer so it can be tested without a GPU. The
+ * float-safe divide is deliberate: a run deep into overdrive passes 2^31, and
+ * an `| 0` truncation there prints a *different number* on a screen whose
+ * entire job is comparing numbers.
+ *
+ * Returns the digit count; `out[0]` is the ones place.
+ */
+export function splitDigits(value: number, out: Int32Array): number {
+  let n = Math.abs(Math.round(value))
+  if (!Number.isFinite(n)) n = 0
+  if (n === 0) {
+    out[0] = 0
+    return 1
+  }
+  let count = 0
+  while (n > 0 && count < out.length) {
+    out[count++] = n % 10
+    n = Math.floor(n / 10)
+  }
+  // Ran out of buffer. Returning here would print the LOW `out.length` digits —
+  // a different number, drawn with total confidence, which is the exact failure
+  // this function's float-safe divide exists to prevent. A row of `9`s is
+  // wrong in a way a child can see.
+  if (n > 0) {
+    for (let i = 0; i < out.length; i++) out[i] = 9
+    return out.length
+  }
+  return count
+}
+
+/**
+ * Storage for a numeral's VALUE, as opposed to its position or its size.
+ *
+ * It is `Float64Array` and that is the whole point of the function existing.
+ * `splitDigits` above goes to the trouble of being float-safe past 2^31, and a
+ * `Float32Array` holding the pending label values undoes that silently on the
+ * way in: 8,030,000,000 comes back out as 8,030,000,128, and anything past
+ * 2^24 at all comes back rounded. A *different number* then gets drawn, on a
+ * screen whose entire job is comparing numbers, with nothing anywhere to say
+ * so.
+ *
+ * Positions, cap heights and colours stay Float32 — a third of a pixel of drift
+ * is invisible. Values do not get that latitude.
+ */
+export function valueBuffer(n: number): Float64Array {
+  return new Float64Array(n)
+}
+
+/**
+ * Round a magnitude to about three significant figures once it is large.
+ *
+ * `4820` is a place-value comparison a child can win in half a second; `4817`
+ * is the same comparison with two digits of noise stapled to it. Small values
+ * pass through untouched, because at small magnitudes every digit matters.
+ */
+export function tidyValue(v: number): number {
+  const sign = v < 0 ? -1 : 1
+  const a = Math.abs(v)
+  if (a < 1000) return sign * Math.max(1, Math.round(a))
+  const step = a < 10000 ? 10 : a < 100000 ? 100 : a < 1000000 ? 1000 : 10000
+  return sign * Math.max(1, Math.round(a / step) * step)
+}

--- a/dynawalla/games/arena/src/core/grid.ts
+++ b/dynawalla/games/arena/src/core/grid.ts
@@ -1,0 +1,114 @@
+/**
+ * A uniform spatial hash, backed entirely by typed arrays. Rebuilt every frame
+ * with zero allocation after construction: a counting sort into a CSR-style
+ * (starts, items) pair.
+ *
+ * Broad-phase for ~250 bodies is cheap either way; this exists so the mote
+ * count can climb into the hundreds on ULTRA without the O(n²) pass showing up
+ * in a frame budget.
+ *
+ * **The grid moves and scales with the field it is indexing**, and that is not
+ * a refinement. It used to be pinned to world coordinates over a fixed
+ * ±9,300 box with everything outside clamped to an edge cell. ARENA's arena
+ * radius passes 9,300 at a player mass of about 680 — from THE CHURN onward —
+ * and reaches ~22,000 by THE SHELF, so from the third depth on, every body
+ * near the player fell into a single corner cell and the broad phase silently
+ * became the exact O(n²) scan it exists to avoid, at precisely the depths with
+ * the most in the water. `build()` takes the centre and the span it must
+ * cover; the cell size follows. The cell *count* is fixed at construction, so
+ * nothing allocates.
+ */
+export class Grid {
+  readonly cols: number
+  readonly rows: number
+  private cell = 1
+  private originX = 0
+  private originY = 0
+  private readonly counts: Int32Array
+  private readonly starts: Int32Array
+  private readonly cursor: Int32Array
+  private items: Int32Array
+
+  /** `cols` is the fixed grid resolution; the cell size is set per build. */
+  constructor(cols: number, capacity: number) {
+    this.cols = Math.max(3, Math.round(cols))
+    this.rows = this.cols
+    const n = this.cols * this.rows
+    this.counts = new Int32Array(n)
+    this.starts = new Int32Array(n + 1)
+    this.cursor = new Int32Array(n)
+    this.items = new Int32Array(capacity)
+  }
+
+  private cx(x: number): number {
+    const c = ((x - this.originX) / this.cell) | 0
+    return c < 0 ? 0 : c >= this.cols ? this.cols - 1 : c
+  }
+
+  private cy(y: number): number {
+    const c = ((y - this.originY) / this.cell) | 0
+    return c < 0 ? 0 : c >= this.rows ? this.rows - 1 : c
+  }
+
+  /**
+   * Rebuild from a packed position array. `xs`/`ys` are read at indices
+   * `0..count-1`; `alive` gates membership.
+   *
+   * `centreX`/`centreY`/`span` place the grid over the region that actually
+   * matters this frame. Anything outside still clamps to an edge cell — which
+   * is correct, just slow — so the caller should pass a span that covers the
+   * live field.
+   */
+  build(
+    xs: Float32Array,
+    ys: Float32Array,
+    alive: Uint8Array,
+    count: number,
+    centreX = 0,
+    centreY = 0,
+    span = 18000,
+  ): void {
+    this.cell = Math.max(1e-3, span / (this.cols - 2))
+    this.originX = centreX - span / 2 - this.cell
+    this.originY = centreY - span / 2 - this.cell
+    this.counts.fill(0)
+    if (this.items.length < count) this.items = new Int32Array(count * 2)
+    for (let i = 0; i < count; i++) {
+      if (!alive[i]) continue
+      const c = this.cy(ys[i] as number) * this.cols + this.cx(xs[i] as number)
+      this.counts[c]!++
+    }
+    let acc = 0
+    for (let c = 0; c < this.counts.length; c++) {
+      this.starts[c] = acc
+      this.cursor[c] = acc
+      acc += this.counts[c] as number
+    }
+    this.starts[this.counts.length] = acc
+    for (let i = 0; i < count; i++) {
+      if (!alive[i]) continue
+      const c = this.cy(ys[i] as number) * this.cols + this.cx(xs[i] as number)
+      this.items[this.cursor[c]!++] = i
+    }
+  }
+
+  /**
+   * Visit every index whose cell overlaps the disc (x, y, r). The callback may
+   * be called for bodies slightly outside r — the caller does the exact test.
+   */
+  query(x: number, y: number, r: number, fn: (i: number) => void): void {
+    const c0 = this.cx(x - r)
+    const c1 = this.cx(x + r)
+    const r0 = this.cy(y - r)
+    const r1 = this.cy(y + r)
+    for (let ry = r0; ry <= r1; ry++) {
+      const base = ry * this.cols
+      for (let rx = c0; rx <= c1; rx++) {
+        const c = base + rx
+        const s = this.starts[c] as number
+        const e = this.starts[c + 1] as number
+        for (let k = s; k < e; k++) fn(this.items[k] as number)
+      }
+    }
+  }
+}

--- a/dynawalla/games/arena/src/core/input.ts
+++ b/dynawalla/games/arena/src/core/input.ts
@@ -1,0 +1,188 @@
+/**
+ * Two verbs, no instructions.
+ *
+ *   steer  — a mouse steers by pointing (Agar's scheme, which is correct with
+ *            a mouse); a finger steers with a floating relative stick, so your
+ *            hand is never sitting on top of the thing you are trying to read.
+ *   surge  — hold. A second finger, a double-tap-and-hold, a held mouse
+ *            button, space or shift. All of them, because a child will try
+ *            whichever one they think of first and being wrong should not be a
+ *            thing that happens.
+ *
+ * Touch is primary. Desktop is deliberate, not a port.
+ */
+
+export type InputState = {
+  /** Unit direction the player wants to move, magnitude 0..1. */
+  dx: number
+  dy: number
+  /** Absolute screen aim, used by the mouse path. */
+  hasAbsolute: boolean
+  absX: number
+  absY: number
+  surge: boolean
+  /** True once the player has surged at least once; kills the discovery hint. */
+  everSurged: boolean
+  anyInput: boolean
+}
+
+const DEAD = 14
+const STICK = 84
+
+export class Input {
+  readonly state: InputState = {
+    dx: 0,
+    dy: 0,
+    hasAbsolute: false,
+    absX: 0,
+    absY: 0,
+    surge: false,
+    everSurged: false,
+    anyInput: false,
+  }
+
+  private el: HTMLElement
+  private primary = -1
+  private originX = 0
+  private originY = 0
+  private curX = 0
+  private curY = 0
+  private extraTouches = new Set<number>()
+  private keySurge = false
+  private mouseSurge = false
+  private lastTapAt = 0
+  private tapHoldSurge = false
+  private readonly onCtx = (e: Event): void => e.preventDefault()
+
+  constructor(el: HTMLElement) {
+    this.el = el
+    el.style.touchAction = "none"
+    el.addEventListener("pointerdown", this.onDown, { passive: false })
+    el.addEventListener("pointermove", this.onMove, { passive: false })
+    window.addEventListener("pointerup", this.onUp, { passive: false })
+    window.addEventListener("pointercancel", this.onUp, { passive: false })
+    window.addEventListener("keydown", this.onKey, { passive: false })
+    window.addEventListener("keyup", this.onKey, { passive: false })
+    window.addEventListener("blur", this.onBlur)
+    el.addEventListener("contextmenu", this.onCtx)
+  }
+
+  private readonly onDown = (e: PointerEvent): void => {
+    e.preventDefault()
+    this.state.anyInput = true
+    if (e.pointerType === "mouse") {
+      this.state.hasAbsolute = true
+      this.state.absX = e.clientX
+      this.state.absY = e.clientY
+      if (e.button === 0 || e.button === 2) this.mouseSurge = true
+      return
+    }
+    if (this.primary === -1) {
+      const now = performance.now()
+      // A double-tap that is held is the one-handed surge.
+      this.tapHoldSurge = now - this.lastTapAt < 280
+      this.lastTapAt = now
+      this.primary = e.pointerId
+      this.originX = e.clientX
+      this.originY = e.clientY
+      this.curX = e.clientX
+      this.curY = e.clientY
+      try {
+        this.el.setPointerCapture(e.pointerId)
+      } catch {
+        /* capture is a nicety, not a requirement */
+      }
+    } else {
+      this.extraTouches.add(e.pointerId)
+    }
+  }
+
+  private readonly onMove = (e: PointerEvent): void => {
+    if (e.pointerType === "mouse") {
+      this.state.hasAbsolute = true
+      this.state.absX = e.clientX
+      this.state.absY = e.clientY
+      this.state.anyInput = true
+      return
+    }
+    if (e.pointerId !== this.primary) return
+    e.preventDefault()
+    this.curX = e.clientX
+    this.curY = e.clientY
+    // The stick re-centres if you drag past its edge, so a long drag never
+    // runs out of travel and a small hand can still turn all the way round.
+    const dx = this.curX - this.originX
+    const dy = this.curY - this.originY
+    const d = Math.hypot(dx, dy)
+    if (d > STICK * 1.6) {
+      const s = (d - STICK * 1.6) / d
+      this.originX += dx * s
+      this.originY += dy * s
+    }
+  }
+
+  private readonly onUp = (e: PointerEvent): void => {
+    if (e.pointerType === "mouse") {
+      this.mouseSurge = false
+      return
+    }
+    if (e.pointerId === this.primary) {
+      this.primary = -1
+      this.tapHoldSurge = false
+    }
+    this.extraTouches.delete(e.pointerId)
+  }
+
+  private readonly onKey = (e: KeyboardEvent): void => {
+    const down = e.type === "keydown"
+    if (e.code === "Space" || e.code === "ShiftLeft" || e.code === "ShiftRight") {
+      e.preventDefault()
+      this.keySurge = down
+      this.state.anyInput = true
+    }
+  }
+
+  private readonly onBlur = (): void => {
+    this.keySurge = false
+    this.mouseSurge = false
+    this.primary = -1
+    this.extraTouches.clear()
+    this.tapHoldSurge = false
+  }
+
+  /** Resolve the frame's intent. Writes into the shared state object. */
+  sample(): InputState {
+    const s = this.state
+    if (this.primary !== -1) {
+      const dx = this.curX - this.originX
+      const dy = this.curY - this.originY
+      const d = Math.hypot(dx, dy)
+      if (d <= DEAD) {
+        s.dx = 0
+        s.dy = 0
+      } else {
+        const mag = Math.min(1, (d - DEAD) / (STICK - DEAD))
+        s.dx = (dx / d) * mag
+        s.dy = (dy / d) * mag
+      }
+      s.hasAbsolute = false
+    } else if (!s.hasAbsolute) {
+      s.dx = 0
+      s.dy = 0
+    }
+    s.surge = this.keySurge || this.mouseSurge || this.extraTouches.size > 0 || this.tapHoldSurge
+    if (s.surge) s.everSurged = true
+    return s
+  }
+
+  dispose(): void {
+    this.el.removeEventListener("pointerdown", this.onDown)
+    this.el.removeEventListener("pointermove", this.onMove)
+    window.removeEventListener("pointerup", this.onUp)
+    window.removeEventListener("pointercancel", this.onUp)
+    window.removeEventListener("keydown", this.onKey)
+    window.removeEventListener("keyup", this.onKey)
+    window.removeEventListener("blur", this.onBlur)
+    this.el.removeEventListener("contextmenu", this.onCtx)
+  }
+}

--- a/dynawalla/games/arena/src/core/rng.ts
+++ b/dynawalla/games/arena/src/core/rng.ts
@@ -1,0 +1,68 @@
+/**
+ * A small, fast, seeded PRNG. Deterministic across platforms because every
+ * operation is a 32-bit integer op — no floating point enters the state.
+ */
+export class Rng {
+  private s: number
+
+  constructor(seed: number) {
+    // Avoid a zero state; mix the seed so nearby seeds diverge immediately.
+    this.s = (seed | 0) === 0 ? 0x9e3779b9 : seed | 0
+    for (let i = 0; i < 4; i++) this.u32()
+  }
+
+  /** Uniform 32-bit unsigned integer. */
+  u32(): number {
+    // xorshift32 — integer only.
+    let x = this.s
+    x ^= x << 13
+    x |= 0
+    x ^= x >>> 17
+    x ^= x << 5
+    x |= 0
+    this.s = x
+    return x >>> 0
+  }
+
+  /** Uniform float in [0, 1). Only used for presentation/simulation, never for an answer. */
+  f(): number {
+    return this.u32() / 4294967296
+  }
+
+  /** Uniform float in [lo, hi). */
+  range(lo: number, hi: number): number {
+    return lo + this.f() * (hi - lo)
+  }
+
+  /** Uniform integer in [lo, hi] inclusive. Exact — no float rounding. */
+  int(lo: number, hi: number): number {
+    if (hi <= lo) return lo
+    const span = hi - lo + 1
+    return lo + (this.u32() % span)
+  }
+
+  /** True with probability p. */
+  chance(p: number): boolean {
+    return this.f() < p
+  }
+
+  pick<T>(arr: readonly T[]): T {
+    return arr[this.u32() % arr.length] as T
+  }
+
+  /** Fisher-Yates, in place. */
+  shuffle<T>(arr: T[]): T[] {
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = this.u32() % (i + 1)
+      const t = arr[i] as T
+      arr[i] = arr[j] as T
+      arr[j] = t
+    }
+    return arr
+  }
+
+  /** Signed value in [-a, a). */
+  sym(a: number): number {
+    return this.range(-a, a)
+  }
+}

--- a/dynawalla/games/arena/src/core/tier.ts
+++ b/dynawalla/games/arena/src/core/tier.ts
@@ -1,0 +1,182 @@
+/**
+ * Quality tiering.
+ *
+ * The mid-range tablet sets the FLOOR, never the ceiling. ULTRA is allowed to
+ * be genuinely staggering; LOW must hold 60fps on a 2019 iPad. We start from a
+ * static guess and then let a running frame-time governor demote (and, if the
+ * machine proves itself, promote once) so nobody ever plays a slideshow.
+ */
+
+export type TierName = "low" | "mid" | "high" | "ultra"
+
+export type TierSpec = {
+  name: TierName
+  /** Render-target scale for the bloom chain. */
+  bloomScale: number
+  /** Number of separable blur passes. 0 disables bloom entirely. */
+  bloomPasses: number
+  /** Max simultaneous particles. */
+  particles: number
+  /** Motes alive in the arena. */
+  motes: number
+  /** Rival cores. */
+  rivals: number
+  /** Marine-snow backdrop instances. */
+  snow: number
+  /** Device pixel ratio ceiling. */
+  dprCap: number
+  /** Volumetric god-rays + caustic layer. */
+  godrays: boolean
+  /** Per-core refraction rim + chromatic dispersion on the bloom composite. */
+  dispersion: boolean
+}
+
+const SPECS: Record<TierName, TierSpec> = {
+  low: {
+    name: "low",
+    bloomScale: 0.25,
+    bloomPasses: 1,
+    particles: 380,
+    motes: 115,
+    rivals: 12,
+    snow: 140,
+    dprCap: 1.5,
+    godrays: false,
+    dispersion: false,
+  },
+  mid: {
+    name: "mid",
+    bloomScale: 0.35,
+    bloomPasses: 2,
+    particles: 900,
+    motes: 155,
+    rivals: 16,
+    snow: 320,
+    dprCap: 2,
+    godrays: true,
+    dispersion: false,
+  },
+  high: {
+    name: "high",
+    bloomScale: 0.5,
+    bloomPasses: 3,
+    particles: 1800,
+    motes: 195,
+    rivals: 20,
+    snow: 620,
+    dprCap: 2,
+    godrays: true,
+    dispersion: true,
+  },
+  ultra: {
+    name: "ultra",
+    bloomScale: 0.6,
+    bloomPasses: 4,
+    particles: 3200,
+    motes: 240,
+    rivals: 24,
+    snow: 1100,
+    dprCap: 2.25,
+    godrays: true,
+    dispersion: true,
+  },
+}
+
+const ORDER: TierName[] = ["low", "mid", "high", "ultra"]
+
+export function specFor(name: TierName): TierSpec {
+  return SPECS[name]
+}
+
+/** A conservative static guess before we have any frame timings. */
+export function guessTier(): TierName {
+  const nav = navigator as Navigator & { deviceMemory?: number; hardwareConcurrency?: number }
+  const mem = nav.deviceMemory ?? 4
+  const cores = nav.hardwareConcurrency ?? 4
+  const coarse = matchMedia?.("(pointer: coarse)")?.matches ?? false
+  const px = window.screen.width * window.screen.height * (window.devicePixelRatio || 1)
+
+  // A phone or small tablet: start mid and let the governor promote.
+  if (coarse) {
+    if (mem >= 6 && cores >= 6 && px > 3_000_000) return "high"
+    if (mem >= 4 && cores >= 4) return "mid"
+    return "low"
+  }
+  if (mem >= 8 && cores >= 8) return "ultra"
+  if (cores >= 6) return "high"
+  return "mid"
+}
+
+/**
+ * Watches frame time and moves the tier. Demotes readily (a child must never
+ * see stutter); promotes exactly once, and only after a long clean stretch, so
+ * the picture never oscillates.
+ */
+export class TierGovernor {
+  spec: TierSpec
+  private idx: number
+  private acc = 0
+  private frames = 0
+  private badStreak = 0
+  private goodStreak = 0
+  private promotions = 0
+  private onChange: (s: TierSpec) => void
+  /** Rolling median-ish frame time in ms, for the readout. */
+  ms = 16.6
+  fps = 60
+
+  constructor(start: TierName, onChange: (s: TierSpec) => void) {
+    this.idx = ORDER.indexOf(start)
+    this.spec = SPECS[start]
+    this.onChange = onChange
+  }
+
+  /** Call once per frame with the raw dt in ms. */
+  sample(dtMs: number): void {
+    // Ignore obvious tab-switch spikes.
+    if (dtMs > 400) return
+    this.acc += dtMs
+    this.frames++
+    if (this.frames < 30) return
+
+    const avg = this.acc / this.frames
+    this.ms = this.ms * 0.6 + avg * 0.4
+    this.fps = 1000 / this.ms
+    this.acc = 0
+    this.frames = 0
+
+    if (avg > 21.5) {
+      this.badStreak++
+      this.goodStreak = 0
+    } else if (avg < 14.5) {
+      this.goodStreak++
+      this.badStreak = 0
+    } else {
+      this.badStreak = 0
+      this.goodStreak = 0
+    }
+
+    if (this.badStreak >= 2 && this.idx > 0) {
+      this.idx--
+      this.badStreak = 0
+      this.apply()
+    } else if (this.goodStreak >= 12 && this.idx < ORDER.length - 1 && this.promotions < 1) {
+      this.idx++
+      this.promotions++
+      this.goodStreak = 0
+      this.apply()
+    }
+  }
+
+  /** Force a tier — used by the perf harness and the dev overlay. */
+  force(name: TierName): void {
+    this.idx = ORDER.indexOf(name)
+    this.promotions = 99
+    this.apply()
+  }
+
+  private apply(): void {
+    this.spec = SPECS[ORDER[this.idx] as TierName]
+    this.onChange(this.spec)
+  }
+}

--- a/dynawalla/games/arena/src/feel/audio.ts
+++ b/dynawalla/games/arena/src/feel/audio.ts
@@ -1,0 +1,447 @@
+/**
+ * ARENA's sound, synthesized in Web Audio at runtime. No files, ever.
+ *
+ * Every one-shot is built the same way — a transient, a body and a tail — and
+ * every one-shot varies in pitch, filter and timbre per hit so that ten
+ * thousand absorbs in a session do not sand a child's ears down. The whole mix
+ * runs through a lowpass whose cutoff opens as you grow, so becoming enormous
+ * is something you hear before you read it.
+ *
+ * Sound never carries information alone: every cue here has a visual twin.
+ */
+
+type Voice = { stop(at: number): void }
+
+const NOTES = [0, 3, 5, 7, 10, 12, 15, 17, 19, 22, 24] // minor pentatonic + octaves
+
+export class Audio {
+  private ctx: AudioContext | null = null
+  private master!: GainNode
+  private tone!: BiquadFilterNode
+  private comp!: DynamicsCompressorNode
+  private wetSend!: GainNode
+  private musicBus!: GainNode
+  private sfxBus!: GainNode
+  private noiseBuf!: AudioBuffer
+  private voices = 0
+  private started = false
+  enabled = true
+  private lastAbsorb = 0
+  private lastFlip = 0
+  private musicTimer = 0
+  private musicStep = 0
+  private intensity = 0
+  private root = 55 // A1
+
+  /** Called on the first user gesture. Safe to call repeatedly. */
+  async init(): Promise<void> {
+    if (this.started) {
+      if (this.ctx?.state === "suspended") await this.ctx.resume().catch(() => {})
+      return
+    }
+    this.started = true
+    try {
+      const Ctor = window.AudioContext ?? (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
+      this.ctx = new Ctor({ latencyHint: "interactive" })
+    } catch (err) {
+      console.warn("[arena] no AudioContext; running silent", err)
+      this.ctx = null
+      return
+    }
+    const ctx = this.ctx
+
+    this.comp = ctx.createDynamicsCompressor()
+    this.comp.threshold.value = -14
+    this.comp.knee.value = 22
+    this.comp.ratio.value = 5
+    this.comp.attack.value = 0.004
+    this.comp.release.value = 0.18
+
+    this.master = ctx.createGain()
+    // Honour a mute that landed before the context existed. `setEnabled` can
+    // only reach a GainNode that has been built, so a child who taps the note
+    // as their very first gesture would otherwise be un-muted by this line.
+    this.master.gain.value = this.enabled ? 0.85 : 0
+
+    this.tone = ctx.createBiquadFilter()
+    this.tone.type = "lowpass"
+    this.tone.frequency.value = 1400
+    this.tone.Q.value = 0.6
+
+    this.sfxBus = ctx.createGain()
+    this.sfxBus.gain.value = 1
+    this.musicBus = ctx.createGain()
+    this.musicBus.gain.value = 0.34
+
+    // A procedurally generated impulse response: exponentially decaying noise
+    // with a darkening tilt. This is the "underwater cathedral" the whole game
+    // sits inside.
+    const len = Math.floor(ctx.sampleRate * 2.6)
+    const ir = ctx.createBuffer(2, len, ctx.sampleRate)
+    for (let c = 0; c < 2; c++) {
+      const d = ir.getChannelData(c)
+      let lp = 0
+      for (let i = 0; i < len; i++) {
+        const t = i / len
+        const env = Math.pow(1 - t, 2.6)
+        const n = Math.random() * 2 - 1
+        lp += (n - lp) * (0.06 + 0.30 * (1 - t))
+        d[i] = lp * env * (i < 200 ? i / 200 : 1)
+      }
+    }
+    const conv = ctx.createConvolver()
+    conv.buffer = ir
+    const wetGain = ctx.createGain()
+    wetGain.gain.value = 0.5
+    this.wetSend = ctx.createGain()
+    this.wetSend.gain.value = 1
+    this.wetSend.connect(conv)
+    conv.connect(wetGain)
+
+    this.sfxBus.connect(this.tone)
+    this.musicBus.connect(this.tone)
+    wetGain.connect(this.tone)
+    this.tone.connect(this.comp)
+    this.comp.connect(this.master)
+    this.master.connect(ctx.destination)
+
+    const nb = ctx.createBuffer(1, ctx.sampleRate, ctx.sampleRate)
+    const nd = nb.getChannelData(0)
+    for (let i = 0; i < nd.length; i++) nd[i] = Math.random() * 2 - 1
+    this.noiseBuf = nb
+
+    this.startBed()
+    if (ctx.state === "suspended") await ctx.resume().catch(() => {})
+  }
+
+  setEnabled(on: boolean): void {
+    this.enabled = on
+    if (this.master) this.master.gain.setTargetAtTime(on ? 0.85 : 0, this.now, 0.05)
+  }
+
+  private get now(): number {
+    return this.ctx ? this.ctx.currentTime : 0
+  }
+
+  /** Brightness follows mass; intensity drives the score. */
+  setState(mass: number, depthIndex: number, danger: number): void {
+    if (!this.ctx) return
+    const openness = Math.min(1, Math.log(1 + mass / 12) / Math.log(1 + 900 / 12))
+    const cut = 900 + openness * 8600 + danger * 1600
+    this.tone.frequency.setTargetAtTime(cut, this.now, 0.35)
+    this.intensity = Math.min(1, depthIndex * 0.18 + openness * 0.6 + danger * 0.3)
+  }
+
+  private noise(dur: number, type: BiquadFilterType, freq: number, q: number, gain: number, when = 0): Voice | null {
+    const ctx = this.ctx
+    if (!ctx || this.voices > 26) return null
+    const t = this.now + when
+    const src = ctx.createBufferSource()
+    src.buffer = this.noiseBuf
+    src.loop = true
+    src.playbackRate.value = 0.7 + Math.random() * 0.6
+    const f = ctx.createBiquadFilter()
+    f.type = type
+    f.frequency.value = freq
+    f.Q.value = q
+    const g = ctx.createGain()
+    g.gain.setValueAtTime(0, t)
+    g.gain.linearRampToValueAtTime(gain, t + 0.004)
+    g.gain.exponentialRampToValueAtTime(0.0001, t + dur)
+    src.connect(f)
+    f.connect(g)
+    g.connect(this.sfxBus)
+    g.connect(this.wetSend)
+    src.start(t)
+    src.stop(t + dur + 0.02)
+    this.voices++
+    src.onended = () => {
+      this.voices--
+      g.disconnect()
+      f.disconnect()
+    }
+    return { stop: (at) => src.stop(at) }
+  }
+
+  private osc(
+    type: OscillatorType,
+    f0: number,
+    f1: number,
+    dur: number,
+    gain: number,
+    when = 0,
+    dest?: AudioNode,
+  ): void {
+    const ctx = this.ctx
+    if (!ctx || this.voices > 26) return
+    const t = this.now + when
+    const o = ctx.createOscillator()
+    o.type = type
+    o.frequency.setValueAtTime(f0, t)
+    if (f1 !== f0) o.frequency.exponentialRampToValueAtTime(Math.max(20, f1), t + dur * 0.9)
+    const g = ctx.createGain()
+    g.gain.setValueAtTime(0, t)
+    g.gain.linearRampToValueAtTime(gain, t + Math.min(0.012, dur * 0.2))
+    g.gain.exponentialRampToValueAtTime(0.0001, t + dur)
+    o.connect(g)
+    g.connect(dest ?? this.sfxBus)
+    g.connect(this.wetSend)
+    o.start(t)
+    o.stop(t + dur + 0.02)
+    this.voices++
+    o.onended = () => {
+      this.voices--
+      g.disconnect()
+    }
+  }
+
+  // -- one-shots ------------------------------------------------------------
+
+  /** Absorb. Pitch climbs the pentatonic ladder with the combo, then resets. */
+  absorb(combo: number, value: number, mass: number): void {
+    if (!this.ctx) return
+    const t = this.now
+    if (t - this.lastAbsorb < 0.028) return
+    this.lastAbsorb = t
+    const step = NOTES[Math.min(NOTES.length - 1, combo % 11)] as number
+    const oct = 1 + Math.floor(Math.min(3, combo / 11))
+    const f = this.root * Math.pow(2, oct + step / 12)
+    // Bigger swallows sit lower and rounder; crumbs are bright ticks.
+    const size = Math.min(1, value / Math.max(1, mass))
+    this.osc("triangle", f * (1.4 - size * 0.45), f * (0.98 - size * 0.15), 0.10 + size * 0.16, 0.10 + size * 0.09)
+    this.noise(0.045, "bandpass", 2400 + Math.random() * 2600 - size * 900, 3.5, 0.055)
+  }
+
+  /** A rival went down. The genre's payoff moment gets a real chord. */
+  devour(mass: number, rivalMass: number): void {
+    if (!this.ctx) return
+    const scale = Math.min(1.6, rivalMass / Math.max(1, mass))
+    const f = this.root * Math.pow(2, 2 - scale * 0.4)
+    this.osc("sine", f * 0.5, f * 0.25, 0.75, 0.30)
+    this.osc("triangle", f, f * 1.5, 0.42, 0.16)
+    this.osc("triangle", f * 1.5, f * 2.0, 0.5, 0.11, 0.03)
+    this.osc("sine", f * 3.0, f * 4.0, 0.6, 0.07, 0.06)
+    this.noise(0.30, "lowpass", 900, 1.0, 0.20)
+    this.noise(0.5, "highpass", 5200, 0.8, 0.05, 0.02)
+  }
+
+  /** Something too big to swallow. Dissonant, short, unmistakable. */
+  sting(loss: number, mass: number): void {
+    if (!this.ctx) return
+    const hurt = Math.min(1, loss / Math.max(1, mass * 0.2))
+    const f = 190 - hurt * 60
+    this.osc("sawtooth", f, f * 0.55, 0.20, 0.16)
+    this.osc("square", f * 1.06, f * 0.6, 0.16, 0.09)
+    this.noise(0.14, "bandpass", 620, 1.4, 0.22)
+  }
+
+  /** Rupture. Sub, a long descending sweep, and the room falling in. */
+  rupture(): void {
+    if (!this.ctx) return
+    this.osc("sine", 120, 32, 1.4, 0.42)
+    this.osc("sawtooth", 300, 48, 0.95, 0.16)
+    this.osc("triangle", 640, 110, 0.7, 0.10)
+    this.noise(0.9, "lowpass", 1600, 0.9, 0.30)
+    this.noise(1.5, "bandpass", 260, 0.7, 0.16, 0.05)
+  }
+
+  /** A Resonance opens: the arena inhales. */
+  resonanceOpen(): void {
+    if (!this.ctx) return
+    const f = this.root * 2
+    for (let i = 0; i < 4; i++) {
+      this.osc("sine", f * Math.pow(2, (NOTES[i] as number) / 12), f * Math.pow(2, (NOTES[i] as number) / 12), 1.5, 0.055, i * 0.06)
+    }
+    this.osc("sine", f * 0.5, f * 0.5, 1.8, 0.14)
+    this.noise(1.2, "highpass", 3800, 0.7, 0.06)
+  }
+
+  /** Correct. A resolving major chord with a shimmer on top, rising with the streak. */
+  resonanceHit(combo: number): void {
+    if (!this.ctx) return
+    const lift = Math.min(5, combo) / 12
+    const f = this.root * Math.pow(2, 2 + lift)
+    const chord = [0, 4, 7, 11, 14]
+    for (let i = 0; i < chord.length; i++) {
+      const n = f * Math.pow(2, (chord[i] as number) / 12)
+      this.osc("triangle", n, n, 1.1 - i * 0.08, 0.11 - i * 0.014, i * 0.035)
+    }
+    this.osc("sine", f * 0.25, f * 0.25, 1.4, 0.34)
+    this.noise(0.7, "highpass", 6200, 0.8, 0.10)
+    this.noise(0.35, "bandpass", 1800, 2.0, 0.14)
+  }
+
+  /** Wrong. It sags — it does not buzz, and it never sounds like a school bell. */
+  resonanceMiss(): void {
+    if (!this.ctx) return
+    const f = this.root * 2
+    this.osc("triangle", f, f * 0.86, 0.55, 0.16)
+    this.osc("triangle", f * 1.19, f * 0.98, 0.5, 0.10, 0.02)
+    this.osc("sine", f * 0.5, f * 0.42, 0.8, 0.18)
+    this.noise(0.25, "lowpass", 700, 1.0, 0.12)
+  }
+
+  /** A depth boundary. A slow gong from far below. */
+  depth(index: number): void {
+    if (!this.ctx) return
+    const f = 44 * Math.pow(2, index * 0.14)
+    this.osc("sine", f, f * 0.9, 3.4, 0.40)
+    this.osc("triangle", f * 3.02, f * 2.9, 2.4, 0.07, 0.02)
+    this.osc("triangle", f * 4.51, f * 4.3, 1.8, 0.05, 0.05)
+    this.noise(2.2, "lowpass", 500, 0.8, 0.10)
+  }
+
+  /** The floor held. A short, warm, rising perfect fifth — a "no, that's enough". */
+  held(): void {
+    if (!this.ctx) return
+    const f = 196 * (0.97 + Math.random() * 0.06)
+    this.osc("triangle", f, f * 1.5, 0.55, 0.13)
+    this.osc("sine", f * 3, f * 4.5, 0.34, 0.05, 0.02)
+    this.noise(0.24, "bandpass", 1400, 1.6, 0.07)
+  }
+
+  /**
+   * A rung banked. Deliberately the only *rising* major arpeggio in the whole
+   * game — everything else here bends down or sits still — so it is
+   * unmistakable even with the screen not being looked at.
+   */
+  anchor(index: number): void {
+    if (!this.ctx) return
+    const root = 138.6 * Math.pow(2, (index % 5) * 0.0834)
+    const steps = [1, 1.25, 1.5, 2, 2.5]
+    for (let i = 0; i < steps.length; i++) {
+      const f = root * (steps[i] as number)
+      this.osc("triangle", f, f * 1.004, 1.5 - i * 0.14, 0.16 - i * 0.014, i * 0.075)
+      this.osc("sine", f * 2, f * 2, 0.9 - i * 0.08, 0.07, i * 0.075)
+    }
+    this.osc("sine", root * 0.5, root * 0.5, 3.0, 0.30)
+    this.noise(0.9, "highpass", 5200, 0.7, 0.09)
+    this.noise(1.8, "lowpass", 900, 0.8, 0.08, 0.06)
+  }
+
+  /** A mote just converted from threat to food. Tiny, rate-limited, delicious. */
+  flip(): void {
+    if (!this.ctx) return
+    const t = this.now
+    if (t - this.lastFlip < 0.09) return
+    this.lastFlip = t
+    const f = 1400 + Math.random() * 900
+    this.osc("sine", f, f * 1.5, 0.07, 0.035)
+  }
+
+  // -- the surge loop -------------------------------------------------------
+
+  private surgeSrc: AudioBufferSourceNode | null = null
+  private surgeGain: GainNode | null = null
+  private surgeFilter: BiquadFilterNode | null = null
+
+  surge(on: boolean, speed: number): void {
+    const ctx = this.ctx
+    if (!ctx) return
+    if (on && !this.surgeSrc) {
+      const src = ctx.createBufferSource()
+      src.buffer = this.noiseBuf
+      src.loop = true
+      const f = ctx.createBiquadFilter()
+      f.type = "bandpass"
+      f.frequency.value = 700
+      f.Q.value = 1.1
+      const g = ctx.createGain()
+      g.gain.value = 0
+      src.connect(f)
+      f.connect(g)
+      g.connect(this.sfxBus)
+      g.connect(this.wetSend)
+      src.start()
+      this.surgeSrc = src
+      this.surgeGain = g
+      this.surgeFilter = f
+    }
+    if (this.surgeGain && this.surgeFilter) {
+      const target = on ? 0.10 : 0
+      this.surgeGain.gain.setTargetAtTime(target, this.now, 0.05)
+      this.surgeFilter.frequency.setTargetAtTime(500 + Math.min(1, speed / 700) * 1500, this.now, 0.08)
+    }
+  }
+
+  // -- the bed and the score ------------------------------------------------
+
+  private startBed(): void {
+    const ctx = this.ctx
+    if (!ctx) return
+    // Two detuned sub oscillators plus filtered noise: the sound of a lot of
+    // very cold water in every direction.
+    const g = ctx.createGain()
+    g.gain.value = 0.16
+    const f = ctx.createBiquadFilter()
+    f.type = "lowpass"
+    f.frequency.value = 240
+    const lfo = ctx.createOscillator()
+    lfo.frequency.value = 0.06
+    const lfoG = ctx.createGain()
+    lfoG.gain.value = 90
+    lfo.connect(lfoG)
+    lfoG.connect(f.frequency)
+    lfo.start()
+    for (const d of [0, 0.6, -0.4]) {
+      const o = ctx.createOscillator()
+      o.type = "sine"
+      o.frequency.value = this.root * 0.5 + d
+      o.connect(f)
+      o.start()
+    }
+    const n = ctx.createBufferSource()
+    n.buffer = this.noiseBuf
+    n.loop = true
+    const nf = ctx.createBiquadFilter()
+    nf.type = "bandpass"
+    nf.frequency.value = 380
+    nf.Q.value = 0.5
+    const ng = ctx.createGain()
+    ng.gain.value = 0.05
+    n.connect(nf)
+    nf.connect(ng)
+    ng.connect(g)
+    n.start()
+    f.connect(g)
+    g.connect(this.musicBus)
+  }
+
+  /**
+   * The score: a slow arpeggio that gains voices and rhythm with intensity.
+   * It never loops — the step pattern advances through a pentatonic set with a
+   * drifting root, so a twenty-minute run never repeats a bar.
+   */
+  tick(dt: number): void {
+    if (!this.ctx || !this.enabled) return
+    this.musicTimer -= dt
+    if (this.musicTimer > 0) return
+    const beat = 0.62 - this.intensity * 0.22
+    this.musicTimer = beat
+    this.musicStep++
+
+    const density = 0.18 + this.intensity * 0.55
+    if (Math.random() > density) return
+    const n = NOTES[(this.musicStep * 3 + ((Math.random() * 3) | 0)) % NOTES.length] as number
+    const oct = 2 + ((this.musicStep >> 3) % 2)
+    const f = this.root * Math.pow(2, oct + n / 12)
+    const g = 0.045 + this.intensity * 0.03
+    this.osc("triangle", f, f, 0.9 + Math.random() * 0.5, g, 0, this.musicBus)
+    if (this.intensity > 0.45 && this.musicStep % 4 === 0) {
+      this.osc("sine", this.root * 2, this.root * 2, 0.5, 0.05, 0, this.musicBus)
+    }
+    if (this.intensity > 0.75 && this.musicStep % 8 === 4) {
+      this.osc("sine", this.root, this.root * 0.94, 1.2, 0.09, 0, this.musicBus)
+    }
+  }
+
+  dispose(): void {
+    try {
+      this.surgeSrc?.stop()
+    } catch {
+      /* already stopped */
+    }
+    this.ctx?.close().catch((e: unknown) => console.warn("[arena] audio close failed", e))
+    this.ctx = null
+  }
+}

--- a/dynawalla/games/arena/src/feel/camera.ts
+++ b/dynawalla/games/arena/src/feel/camera.ts
@@ -1,0 +1,165 @@
+/**
+ * The camera, and everything that happens *to* the picture.
+ *
+ * Techniques from Vlambeer's "Art of Screenshake", applied by name:
+ * trauma-based screenshake, hit-stop (sleep) on impact, camera lead, zoom
+ * punch, knockback, screen-space impact ripple, chromatic aberration on
+ * damage, and permanence (nothing is deleted, it is scattered).
+ *
+ * Everything here is amplitude-limited on purpose. This is a children's
+ * product: full-screen luminance jumps are rate-capped to WCAG's three per
+ * second, and `prefers-reduced-motion` collapses translation and zoom without
+ * removing a single piece of information — the ripple, the flash and the shake
+ * all have a non-motion counterpart in the HUD and in the audio.
+ */
+
+export class Camera {
+  x = 0
+  y = 0
+  span = 400
+  targetSpan = 400
+
+  private trauma = 0
+  private shakeT = 0
+  shakeX = 0
+  shakeY = 0
+
+  /** 0..1, added to the composite as a white-out. */
+  flash = 0
+  flashR = 1
+  flashG = 1
+  flashB = 1
+  private flashTimes: number[] = []
+
+  aberration = 0
+  desat = 0
+
+  rippleX = 0
+  rippleY = 0
+  rippleT = 1
+  rippleAmp = 0
+  private rippleSpeed = 1
+
+  /** Seconds of frozen simulation remaining. */
+  hitstop = 0
+
+  private punch = 0
+  reduced = false
+
+  lead = 0.16
+
+  addTrauma(t: number): void {
+    if (this.reduced) {
+      // Reduced motion keeps the *signal* (a brief desaturation pulse) and
+      // drops the translation.
+      this.desat = Math.min(0.5, this.desat + t * 0.5)
+      return
+    }
+    this.trauma = Math.min(1, this.trauma + t)
+  }
+
+  addFlash(amount: number, r = 1, g = 1, b = 1): void {
+    const now = performance.now()
+    while (this.flashTimes.length && now - (this.flashTimes[0] as number) > 1000) this.flashTimes.shift()
+    const recent = this.flashTimes.length
+    // Hard cap, then a much harder cap once three have already happened inside
+    // a second. A child's screen never strobes.
+    let amp = Math.min(amount, this.reduced ? 0.1 : 0.34)
+    if (recent >= 3) amp = Math.min(amp, 0.05)
+    if (recent >= 6) amp = 0
+    if (amp > 0.02) this.flashTimes.push(now)
+    this.flash = Math.max(this.flash, amp)
+    this.flashR = r
+    this.flashG = g
+    this.flashB = b
+  }
+
+  addRipple(x: number, y: number, amp: number, speed = 1): void {
+    if (this.reduced) return
+    this.rippleX = x
+    this.rippleY = y
+    this.rippleT = 0
+    this.rippleAmp = Math.min(1, amp)
+    this.rippleSpeed = speed
+  }
+
+  addPunch(p: number): void {
+    if (this.reduced) return
+    this.punch = Math.min(0.5, this.punch + p)
+  }
+
+  addHitstop(seconds: number): void {
+    this.hitstop = Math.max(this.hitstop, Math.min(0.14, seconds))
+  }
+
+  addAberration(a: number): void {
+    if (this.reduced) return
+    this.aberration = Math.min(0.012, this.aberration + a)
+  }
+
+  /** `dt` here is real time, never the frozen simulation time. */
+  update(dt: number, px: number, py: number, pvx: number, pvy: number, wantSpan: number): void {
+    this.targetSpan = wantSpan
+
+    const followK = 1 - Math.exp(-dt * (this.reduced ? 14 : 6.5))
+    const lx = px + pvx * this.lead
+    const ly = py + pvy * this.lead
+    this.x += (lx - this.x) * followK
+    this.y += (ly - this.y) * followK
+
+    // Zoom eases slower than the follow, which is what makes growing feel like
+    // the world receding rather than the sprite shrinking.
+    const zoomK = 1 - Math.exp(-dt * 2.6)
+    const punched = this.targetSpan * (1 - this.punch)
+    this.span += (punched - this.span) * zoomK
+    this.punch *= Math.exp(-dt * 7)
+
+    this.trauma = Math.max(0, this.trauma - dt * 1.9)
+    const s = this.trauma * this.trauma
+    this.shakeT += dt * 34
+    if (s > 0.0001) {
+      const amp = s * this.span * 0.055
+      this.shakeX = (noise1(this.shakeT) - 0.5) * 2 * amp
+      this.shakeY = (noise1(this.shakeT + 91.7) - 0.5) * 2 * amp
+    } else {
+      this.shakeX = 0
+      this.shakeY = 0
+    }
+
+    this.flash = Math.max(0, this.flash - dt * 3.4)
+    this.aberration *= Math.exp(-dt * 9)
+    if (this.aberration < 1e-5) this.aberration = 0
+    this.desat = Math.max(0, this.desat - dt * 1.6)
+    if (this.rippleT < 1) {
+      this.rippleT = Math.min(1, this.rippleT + dt * 1.5 * this.rippleSpeed)
+      this.rippleAmp *= Math.exp(-dt * 1.1)
+    } else {
+      this.rippleAmp = 0
+    }
+    this.hitstop = Math.max(0, this.hitstop - dt)
+  }
+
+  get viewX(): number {
+    return this.x + this.shakeX
+  }
+
+  get viewY(): number {
+    return this.y + this.shakeY
+  }
+}
+
+/** Cheap smooth 1-D value noise, so shake reads as a physical wobble. */
+function noise1(t: number): number {
+  const i = Math.floor(t)
+  const f = t - i
+  const u = f * f * (3 - 2 * f)
+  const a = hash1(i)
+  const b = hash1(i + 1)
+  return a + (b - a) * u
+}
+
+function hash1(n: number): number {
+  let x = Math.sin(n * 127.1) * 43758.5453
+  x = x - Math.floor(x)
+  return x
+}

--- a/dynawalla/games/arena/src/feel/floaters.ts
+++ b/dynawalla/games/arena/src/feel/floaters.ts
@@ -1,0 +1,69 @@
+/**
+ * Floating value pops. A fixed pool, drawn through the numeral layer so they
+ * inherit the same halo treatment and can never be washed out by the bloom.
+ */
+export type Floater = {
+  v: number
+  x: number
+  y: number
+  vx: number
+  vy: number
+  t: number
+  life: number
+  size: number
+  r: number
+  g: number
+  b: number
+}
+
+const CAP = 32
+
+export class Floaters {
+  readonly items: Floater[] = Array.from({ length: CAP }, () => ({
+    v: 0,
+    x: 0,
+    y: 0,
+    vx: 0,
+    vy: 0,
+    t: 0,
+    life: 0,
+    size: 0,
+    r: 1,
+    g: 1,
+    b: 1,
+  }))
+  private cursor = 0
+
+  push(v: number, x: number, y: number, size: number, r: number, g: number, b: number, life = 0.85): void {
+    const f = this.items[this.cursor] as Floater
+    this.cursor = (this.cursor + 1) % CAP
+    f.v = v
+    f.x = x
+    f.y = y
+    f.vx = (Math.random() - 0.5) * 40
+    f.vy = 90 + Math.random() * 50
+    f.t = 0
+    f.life = life
+    f.size = size
+    f.r = r
+    f.g = g
+    f.b = b
+  }
+
+  step(dt: number): void {
+    for (let i = 0; i < CAP; i++) {
+      const f = this.items[i] as Floater
+      if (f.life <= 0) continue
+      f.t += dt
+      if (f.t >= f.life) {
+        f.life = 0
+        continue
+      }
+      const decay = Math.exp(-dt * 2.2)
+      f.vx *= decay
+      f.vy *= decay
+      f.x += f.vx * dt
+      f.y += f.vy * dt
+    }
+  }
+}

--- a/dynawalla/games/arena/src/host/stubHost.test.ts
+++ b/dynawalla/games/arena/src/host/stubHost.test.ts
@@ -1,0 +1,123 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { createStubHost } from "./stubHost.ts"
+
+const DOMAINS = ["compare", "add", "multiply", "subtract", "multiples", "divide", "factors"]
+
+test("the stub host is deterministic for a seed", () => {
+  const a = createStubHost({ seed: 4242 })
+  const b = createStubHost({ seed: 4242 })
+  for (let i = 0; i < 200; i++) {
+    const qa = a.next({ difficulty: 1 + (i % 10) })
+    const qb = b.next({ difficulty: 1 + (i % 10) })
+    assert.deepEqual(qa, qb)
+  }
+})
+
+test("every answer is an exact integer and no float ever reaches a question", () => {
+  const h = createStubHost({ seed: 7 })
+  for (let i = 0; i < 4000; i++) {
+    const q = h.next({ difficulty: 1 + (i % 10) })
+    const n = Number(q.answer)
+    assert.ok(Number.isInteger(n), `answer "${q.answer}" is not an integer (${q.prompt})`)
+    assert.ok(n > 0, `answer "${q.answer}" is not positive (${q.prompt})`)
+    assert.equal(String(n), q.answer, "the answer string must be the canonical integer")
+    for (const d of q.distractors) {
+      const dn = Number(d)
+      assert.ok(Number.isInteger(dn), `distractor "${d}" is not an integer (${q.prompt})`)
+      assert.equal(String(dn), d)
+    }
+  }
+})
+
+test("a question always offers exactly three distinct wrong answers", () => {
+  const h = createStubHost({ seed: 11 })
+  for (let i = 0; i < 4000; i++) {
+    const q = h.next({ difficulty: 1 + (i % 10) })
+    assert.equal(q.distractors.length, 3, `wrong distractor count for ${q.prompt}`)
+    const set = new Set(q.distractors)
+    assert.equal(set.size, 3, `duplicate distractors for ${q.prompt}: ${q.distractors.join(",")}`)
+    assert.ok(!set.has(q.answer), `the answer appeared as a distractor for ${q.prompt}`)
+  }
+})
+
+test("the arithmetic in every prompt actually checks out", () => {
+  const h = createStubHost({ seed: 13 })
+  for (let i = 0; i < 4000; i++) {
+    const q = h.next({ difficulty: 1 + (i % 10) })
+    const a = Number(q.answer)
+    let m: RegExpMatchArray | null
+    if ((m = q.prompt.match(/^(\d+) × (\d+)$/))) {
+      assert.equal(a, Number(m[1]) * Number(m[2]), q.prompt)
+    } else if ((m = q.prompt.match(/^(\d+) \+ (\d+)$/))) {
+      assert.equal(a, Number(m[1]) + Number(m[2]), q.prompt)
+    } else if ((m = q.prompt.match(/^(\d+) − (\d+)$/))) {
+      assert.equal(a, Number(m[1]) - Number(m[2]), q.prompt)
+    } else if ((m = q.prompt.match(/^(\d+) ÷ (\d+)$/))) {
+      const x = Number(m[1])
+      const y = Number(m[2])
+      assert.equal(x % y, 0, `${q.prompt} is not an exact division`)
+      assert.equal(a, x / y, q.prompt)
+    } else if ((m = q.prompt.match(/^factor of (\d+)$/))) {
+      assert.equal(Number(m[1]) % a, 0, `${a} is not a factor of ${m[1]}`)
+      for (const d of q.distractors) {
+        assert.notEqual(Number(m[1]) % Number(d), 0, `${d} IS a factor of ${m[1]} but is a distractor`)
+      }
+    } else if ((m = q.prompt.match(/^multiple of (\d+)$/))) {
+      assert.equal(a % Number(m[1]), 0, `${a} is not a multiple of ${m[1]}`)
+      for (const d of q.distractors) {
+        assert.notEqual(Number(d) % Number(m[1]), 0, `${d} IS a multiple of ${m[1]} but is a distractor`)
+      }
+    } else if ((m = q.prompt.match(/^less than (\d+)$/))) {
+      assert.ok(a < Number(m[1]), `${a} is not less than ${m[1]}`)
+      for (const d of q.distractors) {
+        assert.ok(Number(d) >= Number(m[1]), `${d} IS less than ${m[1]} but is a distractor`)
+      }
+    } else {
+      assert.fail(`unrecognised prompt shape: ${q.prompt}`)
+    }
+  }
+})
+
+test("distractors are mal-rule outputs, not noise — they cluster near the answer", () => {
+  const h = createStubHost({ seed: 17 })
+  let near = 0
+  let total = 0
+  for (let i = 0; i < 2000; i++) {
+    const q = h.next({ difficulty: 5 })
+    const a = Number(q.answer)
+    for (const d of q.distractors) {
+      total++
+      // A real procedural bug lands in the neighbourhood of the right answer.
+      // Random noise does not.
+      if (Math.abs(Number(d) - a) <= Math.max(12, a * 0.6)) near++
+    }
+  }
+  assert.ok(near / total > 0.75, `only ${((near / total) * 100).toFixed(0)}% of distractors were plausible`)
+})
+
+test("difficulty widens the pool and is clamped to 1..10", () => {
+  const h = createStubHost({ seed: 23 })
+  const easy = new Set<string>()
+  const hard = new Set<string>()
+  for (let i = 0; i < 800; i++) easy.add(h.next({ difficulty: -99 }).domain)
+  for (let i = 0; i < 800; i++) hard.add(h.next({ difficulty: 999 }).domain)
+  assert.ok(easy.size < hard.size, "a higher difficulty should unlock more domains")
+  for (const d of hard) assert.ok(DOMAINS.includes(d), `unknown domain ${d}`)
+})
+
+test("a requested domain is honoured", () => {
+  const h = createStubHost({ seed: 29 })
+  for (const domain of DOMAINS) {
+    for (let i = 0; i < 60; i++) {
+      assert.equal(h.next({ domain, difficulty: 8 }).domain, domain)
+    }
+  }
+})
+
+test("haptics and reduced-motion are silent no-ops without a platform", () => {
+  const h = createStubHost({ seed: 31 })
+  assert.doesNotThrow(() => h.haptic("success"))
+  assert.doesNotThrow(() => h.haptic("failure"))
+  assert.equal(typeof h.prefersReducedMotion(), "boolean")
+})

--- a/dynawalla/games/arena/src/host/stubHost.ts
+++ b/dynawalla/games/arena/src/host/stubHost.ts
@@ -1,0 +1,247 @@
+import type { Host, Question } from "../contract.ts"
+import { Rng } from "../core/rng.ts"
+
+/**
+ * A local, seeded, deterministic stub Host so ARENA is playable standalone.
+ *
+ * Rules it obeys, because the real host will:
+ *  - Every answer and every comparison is exact integer arithmetic. No float
+ *    ever reaches an answer string; `0.1 + 0.2 !== 0.3` must never be able to
+ *    mark correct work wrong.
+ *  - Distractors are *mal-rule outputs*: the number a child actually writes
+ *    when they apply a plausible-but-wrong procedure. Never random noise —
+ *    random noise teaches a child to spot the odd one out, not to compute.
+ *  - Deterministic for a given seed, so a playtest is reproducible.
+ */
+
+type Gen = (r: Rng, d: number) => {
+  prompt: string
+  answer: number
+  wrong: number[]
+  /** For predicate prompts: is `v` a *wrong* answer? */
+  valid?: (v: number) => boolean
+}
+
+/**
+ * Deduplicate, drop the answer and any non-positive value, keep order.
+ *
+ * `valid` exists because the top-up path once handed back a *correct* option
+ * as a distractor: "which is a multiple of 2" offered 10 as a wrong answer.
+ * Any generator whose prompt is a predicate must supply that predicate here.
+ */
+function clean(answer: number, wrong: number[], r: Rng, valid?: (v: number) => boolean): string[] {
+  const out: number[] = []
+  for (const w of wrong) {
+    if (w === answer) continue
+    if (!Number.isInteger(w)) continue
+    if (w < 0) continue
+    if (out.includes(w)) continue
+    if (valid && !valid(w)) continue
+    out.push(w)
+  }
+  // Top up with near-miss values if a mal-rule collided with the answer.
+  let step = 1
+  while (out.length < 3) {
+    const cand = r.chance(0.5) ? answer + step : answer - step
+    if (cand > 0 && cand !== answer && !out.includes(cand) && (!valid || valid(cand))) out.push(cand)
+    step++
+    if (step > 400) break
+  }
+  return out.slice(0, 3).map((n) => String(n))
+}
+
+/** a × b — the mal-rules are off-by-one-multiple, add-instead-of-multiply, and a dropped carry. */
+const mul: Gen = (r, d) => {
+  const hi = d <= 2 ? 5 : d <= 4 ? 9 : d <= 6 ? 12 : 15
+  const lo = d <= 2 ? 2 : 3
+  const a = r.int(lo, hi)
+  const b = r.int(lo, hi)
+  const answer = a * b
+  return {
+    prompt: `${a} × ${b}`,
+    answer,
+    wrong: r.shuffle([
+      a * (b - 1), // skipped a step counting up
+      a * (b + 1), // one step too far
+      a + b, // wrong operation
+      answer - 10 * Math.floor(answer / 100), // dropped a carry into the tens
+    ]),
+  }
+}
+
+/** a + b, multi-digit — the mal-rule is the forgotten carry (add columns independently). */
+const add: Gen = (r, d) => {
+  const digits = d <= 2 ? 1 : d <= 5 ? 2 : 3
+  const lo = digits === 1 ? 2 : digits === 2 ? 12 : 120
+  const hi = digits === 1 ? 9 : digits === 2 ? 89 : 899
+  const a = r.int(lo, hi)
+  const b = r.int(lo, hi)
+  const answer = a + b
+  return {
+    prompt: `${a} + ${b}`,
+    answer,
+    wrong: r.shuffle([noCarryAdd(a, b), answer + 10, answer - 10, answer + 1]),
+  }
+}
+
+/** Column-wise addition with every carry dropped — the classic procedural bug. */
+function noCarryAdd(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    const s = ((x % 10) + (y % 10)) % 10
+    out += s * place
+    place *= 10
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return out
+}
+
+/** a − b — the mal-rule is "smaller from larger" in each column (the borrow bug). */
+const sub: Gen = (r, d) => {
+  const digits = d <= 2 ? 1 : d <= 5 ? 2 : 3
+  const hi = digits === 1 ? 9 : digits === 2 ? 95 : 950
+  const a = r.int(digits === 1 ? 4 : digits === 2 ? 30 : 300, hi)
+  const b = r.int(1, a - 1)
+  const answer = a - b
+  return {
+    prompt: `${a} − ${b}`,
+    answer,
+    wrong: r.shuffle([smallerFromLarger(a, b), answer + 10, answer - 1, a + b]),
+  }
+}
+
+/** Per column take |top − bottom| instead of borrowing. */
+function smallerFromLarger(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    const s = Math.abs((x % 10) - (y % 10))
+    out += s * place
+    place *= 10
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return out
+}
+
+/** a ÷ b, exact — built from the product so it is integer by construction. */
+const div: Gen = (r, d) => {
+  const hi = d <= 3 ? 6 : d <= 6 ? 10 : 12
+  const b = r.int(2, hi)
+  const answer = r.int(2, hi)
+  const a = b * answer
+  return {
+    prompt: `${a} ÷ ${b}`,
+    answer,
+    wrong: r.shuffle([answer + 1, answer - 1, a - b, b]),
+  }
+}
+
+/** "Which is a factor of N?" — the mal-rule is a near-miss that divides a neighbour of N. */
+const factor: Gen = (r, d) => {
+  const bases = d <= 3 ? [12, 16, 18, 20, 24] : d <= 6 ? [24, 30, 36, 40, 48] : [48, 60, 72, 84, 96]
+  const n = r.pick(bases)
+  const divisors: number[] = []
+  for (let i = 2; i < n; i++) if (n % i === 0) divisors.push(i)
+  const answer = r.pick(divisors.length ? divisors : [2])
+  const nonDivisors: number[] = []
+  for (let i = 2; i < n && nonDivisors.length < 12; i++) if (n % i !== 0) nonDivisors.push(i)
+  return {
+    prompt: `factor of ${n}`,
+    answer,
+    wrong: r.shuffle(nonDivisors).slice(0, 4),
+    valid: (v) => v > 1 && n % v !== 0,
+  }
+}
+
+/** "Which is a multiple of k?" — reads directly as the skip-counting ladder. */
+const multiple: Gen = (r, d) => {
+  const k = d <= 3 ? r.int(2, 5) : d <= 6 ? r.int(3, 9) : r.int(4, 12)
+  const m = r.int(3, d <= 3 ? 9 : 14)
+  const answer = k * m
+  return {
+    prompt: `multiple of ${k}`,
+    answer,
+    wrong: r.shuffle([answer + 1, answer - 1, answer + (k - 1), answer - (k - 1)]).filter((v) => v % k !== 0),
+    valid: (v) => v > 0 && v % k !== 0,
+  }
+}
+
+/** N less than a bound — pure magnitude, the arena's own rule stated as a question. */
+const compare: Gen = (r, d) => {
+  const mag = d <= 3 ? 100 : d <= 6 ? 1000 : 10000
+  const bound = r.int(Math.floor(mag / 3), mag)
+  const answer = r.int(2, bound - 1)
+  return {
+    prompt: `less than ${bound}`,
+    answer,
+    wrong: r.shuffle([bound + r.int(1, 9), bound + r.int(10, 99), bound + r.int(100, 400)]),
+    valid: (v) => v >= bound,
+  }
+}
+
+const GENS: { g: Gen; domain: string; minD: number }[] = [
+  { g: compare, domain: "compare", minD: 1 },
+  { g: add, domain: "add", minD: 1 },
+  { g: mul, domain: "multiply", minD: 1 },
+  { g: sub, domain: "subtract", minD: 2 },
+  { g: multiple, domain: "multiples", minD: 2 },
+  { g: div, domain: "divide", minD: 3 },
+  { g: factor, domain: "factors", minD: 3 },
+]
+
+export type StubHostOptions = {
+  seed?: number
+  onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void
+}
+
+export function createStubHost(opts: StubHostOptions = {}): Host {
+  const rng = new Rng(opts.seed ?? 0x5eed1e)
+  let n = 0
+  const reduced =
+    typeof matchMedia === "function" ? matchMedia("(prefers-reduced-motion: reduce)") : null
+
+  return {
+    next(o) {
+      const d = Math.max(1, Math.min(10, Math.round(o?.difficulty ?? 3)))
+      const pool = GENS.filter((x) => x.minD <= d && (!o?.domain || x.domain === o.domain))
+      const chosen = pool.length ? rng.pick(pool) : (GENS[0] as (typeof GENS)[number])
+      const { prompt, answer, wrong, valid } = chosen.g(rng, d)
+      const q: Question = {
+        id: `stub-${++n}`,
+        prompt,
+        answer: String(answer),
+        distractors: clean(answer, wrong, rng, valid),
+        domain: chosen.domain,
+        difficulty: d,
+      }
+      return q
+    },
+    report(r) {
+      // The stub keeps no mastery model — the real host will. It forwards so a
+      // harness can watch the answer stream.
+      opts.onReport?.(r)
+    },
+    haptic(k) {
+      // navigator.vibrate is absent on iOS Safari and on desktop — a silent no-op there.
+      const nav = navigator as Navigator & { vibrate?: (p: number | number[]) => boolean }
+      if (typeof nav.vibrate !== "function") return
+      const pattern =
+        k === "light" ? 8 : k === "medium" ? 18 : k === "heavy" ? 34 : k === "success" ? [10, 30, 16] : [30, 40, 30]
+      try {
+        nav.vibrate(pattern)
+      } catch {
+        console.warn("[arena] haptic failed")
+      }
+    },
+    prefersReducedMotion() {
+      return reduced?.matches ?? false
+    },
+  }
+}

--- a/dynawalla/games/arena/src/index.ts
+++ b/dynawalla/games/arena/src/index.ts
@@ -1,0 +1,3 @@
+export type { Host, MountOptions, Question } from "./contract.ts"
+export { mount } from "./contract.ts"
+export { createStubHost } from "./host/stubHost.ts"

--- a/dynawalla/games/arena/src/main.ts
+++ b/dynawalla/games/arena/src/main.ts
@@ -1,0 +1,28 @@
+import { mount } from "./contract.ts"
+import { createStubHost } from "./host/stubHost.ts"
+
+/**
+ * Standalone dev entry. The real runtime lands underneath `mount()`; until it
+ * does, the seeded stub Host makes the game fully playable with `npm run dev`.
+ *
+ *   ?seed=123   reproduce a run
+ *   ?perf       show the fps / tier readout
+ */
+
+const el = document.getElementById("arena")
+if (!el) throw new Error("[arena] #arena not found")
+
+const params = new URLSearchParams(location.search)
+const raw = params.get("seed")
+// `Number(x) || default` swallows `?seed=0`, which is a perfectly good seed
+// and the first one anybody types.
+const seed = raw !== null && raw !== "" && Number.isFinite(Number(raw)) ? Number(raw) : 0x5eed1e
+
+// Both halves, or the run is not reproducible: the Host seeds the questions,
+// the World seeds the water.
+const host = createStubHost({ seed })
+const handle = mount(el, host, { seed })
+
+// Vite HMR: tear down cleanly so a reload never leaves two loops running.
+const hot = (import.meta as unknown as { hot?: { dispose(cb: () => void): void } }).hot
+hot?.dispose(() => handle.unmount())

--- a/dynawalla/games/arena/src/mount.ts
+++ b/dynawalla/games/arena/src/mount.ts
@@ -1,0 +1,457 @@
+import type { Host, MountOptions } from "./contract.ts"
+import { Gfx } from "./render/gfx.ts"
+import { Hud } from "./ui/hud.ts"
+import { Input } from "./core/input.ts"
+import { Audio } from "./feel/audio.ts"
+import { Camera } from "./feel/camera.ts"
+import { Floaters } from "./feel/floaters.ts"
+import { guessTier, specFor, TierGovernor, type TierName } from "./core/tier.ts"
+import { R_K, viewSpanFor, World, type GameEvent } from "./sim/world.ts"
+
+const FIXED = 1 / 60
+const MAX_SUBSTEPS = 3
+
+/**
+ * A development handle. It exists so a soak/perf harness can drive the
+ * simulation and the renderer synchronously — the only way to get a truthful
+ * frame time on a machine where the tab is not reliably foregrounded, and the
+ * only way to fast-forward twenty minutes of escalation in a few seconds.
+ */
+type Debug = {
+  world: World
+  cam: Camera
+  gov: TierGovernor
+  gfx: Gfx
+  forceTier(t: TierName): void
+  fps(): number
+  /** Run one full frame outside the rAF loop, for the perf/soak harness. */
+  frameOnce(dt: number): void
+  /** Milliseconds from a Resonance opening to the answer being registered. */
+  lastAnswerMs: number
+}
+
+export function mountArena(el: HTMLElement, host: Host, opts?: MountOptions): { unmount(): void } {
+  const container = document.createElement("div")
+  container.style.position = "absolute"
+  container.style.inset = "0"
+  container.style.overflow = "hidden"
+  container.style.background = "#01040c"
+  container.style.contain = "strict"
+  el.appendChild(container)
+
+  const readReduced = (): boolean => {
+    try {
+      return host.prefersReducedMotion()
+    } catch (err) {
+      console.error("[arena] host.prefersReducedMotion threw", err)
+      return false
+    }
+  }
+  let reduced = readReduced()
+
+  // Sampled once at mount, the setting could only take effect on a remount —
+  // a child who turns motion down mid-session, which is exactly when they
+  // would, saw no change at all. Re-ask the Host whenever the OS setting
+  // moves; the Host stays the source of truth, this is only the trigger.
+  const motionQuery =
+    typeof matchMedia === "function" ? matchMedia("(prefers-reduced-motion: reduce)") : null
+  const onMotionChange = (): void => {
+    reduced = readReduced()
+    cam.reduced = reduced
+  }
+  motionQuery?.addEventListener("change", onMotionChange)
+
+  const startTier = guessTier()
+  const gfx = new Gfx(container, specFor(startTier))
+  const hud = new Hud(container, (on) => {
+    audio.setEnabled(on)
+    return on
+  })
+  const input = new Input(container)
+  const audio = new Audio()
+  const cam = new Camera()
+  cam.reduced = reduced
+  const floaters = new Floaters()
+  // The WORLD's seed, not the Host's. `?seed=` reproducing a run means this
+  // one; seeding only the question generator reproduces the arithmetic and
+  // leaves every mote, rival and spawn to the wall clock.
+  const worldSeed = opts?.seed ?? ((Date.now() ^ 0x9e3779b9) | 0)
+  const world = new World(host, specFor(startTier), worldSeed)
+
+  const gov = new TierGovernor(startTier, (spec) => {
+    gfx.applySpec(spec)
+    world.applySpec(spec)
+  })
+
+  cam.span = viewSpanFor(world.mass)
+  cam.x = world.px
+  cam.y = world.py
+
+  let running = true
+  let last = performance.now()
+  let acc = 0
+  let time = 0
+  let raf = 0
+  let hintTimer = 0
+  const showPerf = new URLSearchParams(location.search).has("perf")
+
+  // -- resize -------------------------------------------------------------
+  const ro = new ResizeObserver(() => {
+    const r = container.getBoundingClientRect()
+    gfx.resize(Math.max(1, r.width), Math.max(1, r.height))
+  })
+  ro.observe(container)
+  {
+    const r = container.getBoundingClientRect()
+    gfx.resize(Math.max(1, r.width || window.innerWidth), Math.max(1, r.height || window.innerHeight))
+  }
+
+  // -- audio unlock -------------------------------------------------------
+  const unlock = (): void => {
+    audio.init().catch((e: unknown) => console.warn("[arena] audio init failed", e))
+  }
+  container.addEventListener("pointerdown", unlock, { once: false })
+  window.addEventListener("keydown", unlock, { once: false })
+
+  const onVisibility = (): void => {
+    if (document.hidden) {
+      running = false
+    } else if (!running) {
+      running = true
+      last = performance.now()
+      acc = 0
+      raf = requestAnimationFrame(frame)
+    }
+  }
+  document.addEventListener("visibilitychange", onVisibility)
+
+  // -- screen <-> world ---------------------------------------------------
+  function screenToWorld(px: number, py: number, out: { x: number; y: number }): void {
+    const r = container.getBoundingClientRect()
+    const w = Math.max(1, r.width)
+    const h = Math.max(1, r.height)
+    const aspect = w / h
+    out.x = cam.viewX + ((px - r.left) / w - 0.5) * cam.span * aspect
+    out.y = cam.viewY + (0.5 - (py - r.top) / h) * cam.span
+  }
+  const aim = { x: 0, y: 0 }
+
+  // -- effects ------------------------------------------------------------
+  const pal = gfx.palette
+
+  function burst(
+    x: number,
+    y: number,
+    n: number,
+    speed: number,
+    life: number,
+    size: number,
+    r: number,
+    g: number,
+    b: number,
+    kind: number,
+    towardX?: number,
+    towardY?: number,
+  ): void {
+    const count = reduced ? Math.max(2, Math.round(n * 0.35)) : n
+    for (let i = 0; i < count; i++) {
+      const a = Math.random() * Math.PI * 2
+      const s = speed * (0.35 + Math.random() * 0.9)
+      let vx = Math.cos(a) * s
+      let vy = Math.sin(a) * s
+      if (towardX !== undefined && towardY !== undefined) {
+        // Bias the spray toward a point — absorbs suck inward, hits spray out.
+        const dx = towardX - x
+        const dy = towardY - y
+        const d = Math.hypot(dx, dy) || 1
+        vx = vx * 0.35 + (dx / d) * s * 1.1
+        vy = vy * 0.35 + (dy / d) * s * 1.1
+      }
+      gfx.particles.spawn(
+        x,
+        y,
+        vx,
+        vy,
+        life * (0.6 + Math.random() * 0.8),
+        size * (0.55 + Math.random() * 0.9),
+        r,
+        g,
+        b,
+        kind,
+        time,
+      )
+    }
+  }
+
+  function handle(e: GameEvent): void {
+    const pr = world.playerRTrue
+    switch (e.kind) {
+      case "absorb": {
+        const share = Math.min(1, e.a / Math.max(1, world.mass))
+        burst(e.x, e.y, 4 + Math.round(share * 16), 260 + share * 460, 0.34, pr * 0.16 + 4, pal.food[0] as number, pal.food[1] as number, pal.food[2] as number, 1, world.px, world.py)
+        cam.addPunch(0.006 + share * 0.05)
+        if (share > 0.22) {
+          cam.addTrauma(0.05 + share * 0.14)
+          cam.addHitstop(0.012 + share * 0.03)
+          gfx.rings.spawn(e.x, e.y, 8, 40 + share * 190, 0.42, 0.16, 0, pal.food[0] as number, pal.food[1] as number, pal.food[2] as number, time)
+        }
+        if (share > 0.1 || e.b % 5 === 0) {
+          floaters.push(e.a, e.x, e.y, Math.max(cam.span * 0.013, pr * 0.19), 0.75, 1, 0.9)
+        }
+        audio.absorb(e.b, e.a, world.mass)
+        break
+      }
+      case "sting": {
+        cam.addTrauma(0.34)
+        cam.addHitstop(0.05)
+        cam.addAberration(0.006)
+        cam.addFlash(0.10, 1, 0.25, 0.35)
+        cam.addRipple(e.x, e.y, 0.5, 1.6)
+        burst(e.x, e.y, 26, 520, 0.6, pr * 0.2 + 6, 1, 0.24, 0.34, 1)
+        gfx.rings.spawn(e.x, e.y, 10, 260, 0.5, 0.2, 1, 1, 0.3, 0.4, time)
+        floaters.push(-Math.round(e.a), e.x, e.y, Math.max(cam.span * 0.017, pr * 0.22), 1, 0.35, 0.42, 1.0)
+        audio.sting(e.a, world.mass)
+        break
+      }
+      case "kill": {
+        cam.addTrauma(0.6)
+        cam.addHitstop(0.085)
+        cam.addPunch(0.10)
+        cam.addFlash(0.20, pal.food[0] as number, pal.food[1] as number, pal.food[2] as number)
+        cam.addRipple(e.x, e.y, 0.85, 0.9)
+        burst(e.x, e.y, 54, 780, 0.9, pr * 0.22 + 8, pal.food[0] as number, pal.food[1] as number, pal.food[2] as number, 1, world.px, world.py)
+        burst(e.x, e.y, 22, 340, 1.4, pr * 0.14 + 5, 1, 1, 1, 0)
+        gfx.rings.spawn(e.x, e.y, 12, 420, 0.75, 0.20, 2, 1, 1, 1, time)
+        gfx.rings.spawn(e.x, e.y, 12, 260, 0.55, 0.34, 0, pal.food[0] as number, pal.food[1] as number, pal.food[2] as number, time)
+        floaters.push(Math.round(e.a), e.x, e.y, Math.max(cam.span * 0.025, pr * 0.33), 1, 1, 0.7, 1.3)
+        audio.devour(world.mass, e.a)
+        break
+      }
+      case "rupture": {
+        cam.addTrauma(1)
+        cam.addHitstop(0.13)
+        cam.addFlash(0.30, 1, 0.35, 0.4)
+        cam.addAberration(0.012)
+        cam.addRipple(e.x, e.y, 1, 0.7)
+        cam.desat = 0.55
+        burst(e.x, e.y, 110, 1000, 1.5, pr * 0.24 + 10, 1, 0.35, 0.45, 1)
+        burst(e.x, e.y, 40, 420, 2.2, pr * 0.16 + 6, 1, 0.85, 0.9, 0)
+        gfx.rings.spawn(e.x, e.y, 14, pr * 9, 1.1, 0.16, 2, 1, 0.4, 0.5, time)
+        gfx.rings.spawn(e.x, e.y, 14, pr * 5, 0.8, 0.3, 0, 1, 1, 1, time)
+        audio.rupture()
+        break
+      }
+      case "flip": {
+        if (!reduced && Math.random() < 0.5) {
+          burst(e.x, e.y, 3, 120, 0.4, e.a * 0.14 + 2, pal.food[0] as number, pal.food[1] as number, pal.food[2] as number, 0)
+        }
+        audio.flip()
+        break
+      }
+      case "depth": {
+        // A rung. This is the structural beat of the whole run — it is the only
+        // thing on screen that only ever goes one way — so it is the biggest
+        // non-fatal event in the game, and it settles rather than snaps.
+        // `e.b` says whether the run BOUGHT this band with mass or whether the
+        // clock simply delivered it; same rung, different colour, different
+        // chord, and a child can hear which one they got.
+        const bought = e.b > 0.5
+        const cr = bought ? 1 : (pal.shaft[0] as number)
+        const cg = bought ? 0.86 : (pal.shaft[1] as number)
+        const cb = bought ? 0.42 : (pal.shaft[2] as number)
+        cam.addTrauma(bought ? 0.55 : 0.34)
+        cam.addPunch(bought ? 0.13 : 0.06)
+        cam.addFlash(bought ? 0.22 : 0.16, cr, cg, cb)
+        cam.addRipple(world.px, world.py, bought ? 0.9 : 0.7, 0.48)
+        burst(world.px, world.py, bought ? 90 : 40, 620, 2.0, pr * 0.18 + 7, cr, cg, cb, 0)
+        burst(world.px, world.py, bought ? 34 : 16, 260, 3.0, pr * 0.12 + 5, 1, 0.98, 0.9, 0)
+        gfx.rings.spawn(world.px, world.py, pr, cam.span * 1.6, 1.7, 0.10, 2, cr, cg, cb, time)
+        gfx.rings.spawn(world.px, world.py, pr, cam.span * 1.1, 1.2, 0.20, 0, 1, 1, 1, time)
+        if (bought) gfx.rings.spawn(world.px, world.py, pr * 0.6, pr * 9, 1.5, 0.22, 1, 1, 0.94, 0.62, time)
+        hud.showVerdict(world.depth.name, bought ? "#ffd479" : "#9fe8ff")
+        if (bought) audio.anchor(world.depth.index)
+        else audio.depth(world.depth.index)
+        break
+      }
+      case "held": {
+        // Gold, brief, and it reads as the water refusing to take any more.
+        cam.addFlash(0.09, 1, 0.84, 0.40)
+        cam.addPunch(0.05)
+        gfx.rings.spawn(world.px, world.py, pr * 1.6, pr * 3.6, 0.7, 0.30, 1, 1, 0.86, 0.42, time)
+        gfx.rings.spawn(world.px, world.py, pr * 1.1, pr * 2.4, 0.5, 0.42, 0, 1, 0.96, 0.70, time)
+        burst(world.px, world.py, 22, 300, 0.9, pr * 0.10 + 4, 1, 0.86, 0.42, 0, world.px, world.py)
+        audio.held()
+        host.haptic("light")
+        break
+      }
+      case "resonance-open": {
+        // The one place a camera cue had no reduced-motion counterpart: this
+        // event fired only `addRipple`, which returns immediately under
+        // reduced motion, so the "the arena is about to ask you something"
+        // beat was silently dropped. A pale, low flash carries the same
+        // meaning with zero travel.
+        cam.addRipple(world.px, world.py, 0.55, 0.6)
+        cam.addFlash(0.08, 0.7, 0.92, 1)
+        gfx.rings.spawn(world.px, world.py, pr, e.a * 1.15, 0.9, 0.14, 2, 0.7, 0.92, 1, time)
+        audio.resonanceOpen()
+        break
+      }
+      case "resonance-hit": {
+        cam.addTrauma(0.85)
+        cam.addHitstop(0.11)
+        cam.addPunch(0.16)
+        cam.addFlash(0.32, 1, 0.98, 0.85)
+        cam.addRipple(world.px, world.py, 1, 0.55)
+        burst(world.px, world.py, 140, 1300, 1.6, pr * 0.2 + 8, 1, 0.95, 0.7, 1)
+        burst(world.px, world.py, 60, 500, 2.4, pr * 0.16 + 6, 0.6, 0.95, 1, 0)
+        gfx.rings.spawn(world.px, world.py, pr, pr * 9, 1.3, 0.075, 2, 1, 0.95, 0.75, time)
+        gfx.rings.spawn(world.px, world.py, pr, pr * 6, 0.95, 0.14, 0, 1, 1, 1, time)
+        gfx.rings.spawn(world.px, world.py, pr, pr * 13, 1.8, 0.045, 1, 0.6, 0.9, 1, time)
+        floaters.push(Math.round(e.a), world.px, world.py, Math.max(cam.span * 0.033, pr * 0.44), 1, 1, 0.75, 1.5)
+        hud.showVerdict(e.b >= 3 ? `RESONANT ×${e.b}` : "RESONANT", "#b9ffe4")
+        audio.resonanceHit(e.b)
+        break
+      }
+      case "resonance-miss": {
+        cam.addTrauma(0.5)
+        cam.addHitstop(0.07)
+        cam.addAberration(0.009)
+        cam.addFlash(0.12, 1, 0.4, 0.5)
+        burst(e.x, e.y, 44, 620, 0.9, pr * 0.18 + 6, 1, 0.4, 0.5, 1)
+        gfx.rings.spawn(e.x, e.y, 12, 340, 0.6, 0.24, 0, 1, 0.4, 0.5, time)
+        floaters.push(-Math.round(e.a), world.px, world.py, Math.max(cam.span * 0.019, pr * 0.28), 1, 0.5, 0.55, 1.1)
+        audio.resonanceMiss()
+        break
+      }
+      case "shockwave": {
+        gfx.rings.spawn(e.x, e.y, pr * 0.5, e.a, e.b === 2 ? 1.1 : 0.7, 0.07, e.b === 2 ? 2 : 0, 1, 1, 1, time)
+        break
+      }
+      case "rival-death": {
+        burst(e.x, e.y, e.b ? 60 : 18, 480, 0.8, R_K * Math.sqrt(e.a) * 0.2 + 4, pal.threat[0] as number, pal.threat[1] as number, pal.threat[2] as number, 1)
+        gfx.rings.spawn(e.x, e.y, 8, R_K * Math.sqrt(e.a) * 4, 0.5, 0.24, 0, pal.threat[0] as number, pal.threat[1] as number, pal.threat[2] as number, time)
+        break
+      }
+      case "resonance-fade":
+      default:
+        break
+    }
+  }
+
+  /**
+   * One complete frame: camera, simulation, every event turned into juice, and
+   * the draw. The rAF loop and the soak harness both go through here, so a
+   * headless run exercises exactly the code a child's frame does — there is no
+   * second, more forgiving path that only the tests ever see.
+   */
+  function advance(dtReal: number): void {
+    cam.update(dtReal, world.px, world.py, world.pvx, world.pvy, viewSpanFor(world.massVis))
+    floaters.step(dtReal)
+
+    // Hit-stop freezes the simulation, never the camera or the particles —
+    // that is the whole trick: the world stops, the *presentation* does not.
+    if (cam.hitstop <= 0) {
+      acc += dtReal
+      let steps = 0
+      while (acc >= FIXED && steps < MAX_SUBSTEPS) {
+        acc -= FIXED
+        steps++
+        world.step(FIXED)
+        for (let i = 0; i < world.eventLen; i++) handle(world.events[i] as GameEvent)
+      }
+      if (steps >= MAX_SUBSTEPS) acc = 0
+    }
+
+    time += dtReal
+    gfx.draw(world, cam, time, reduced, floaters)
+  }
+
+  // -- the loop -----------------------------------------------------------
+  function frame(now: number): void {
+    if (!running) return
+    raf = requestAnimationFrame(frame)
+
+    let dtReal = (now - last) / 1000
+    last = now
+    if (!Number.isFinite(dtReal) || dtReal < 0) dtReal = FIXED
+    gov.sample(dtReal * 1000)
+    dtReal = Math.min(dtReal, 0.1)
+
+    const st = input.sample()
+    if (st.hasAbsolute) {
+      screenToWorld(st.absX, st.absY, aim)
+      world.aimX = aim.x
+      world.aimY = aim.y
+    } else if (st.dx !== 0 || st.dy !== 0) {
+      world.aimX = world.px + st.dx * cam.span * 0.7
+      world.aimY = world.py - st.dy * cam.span * 0.7
+    } else {
+      world.aimX = world.px
+      world.aimY = world.py
+    }
+    world.surging = st.surge && !world.resonance.active
+
+    advance(dtReal)
+
+    audio.setState(world.mass, world.depth.index, Math.min(1, world.combo / 20 + (world.invuln > 0 ? 0.4 : 0)))
+    audio.surge(world.surging, Math.hypot(world.pvx, world.pvy))
+    audio.tick(dtReal)
+
+    // A wordless nudge toward the second verb, and only if it has never been
+    // found. No copy, no arrow, no tooltip — just a pulse where your thumb is.
+    if (!st.everSurged && world.time > 12) {
+      hintTimer -= dtReal
+      if (hintTimer <= 0) {
+        hintTimer = 2.2
+        gfx.rings.spawn(world.px, world.py, world.playerR * 1.2, world.playerR * 2.6, 1.1, 0.10, 0, 0.55, 0.9, 1, time)
+      }
+    }
+
+    hud.update(world, dtReal, gov.fps, gov.spec.name, showPerf)
+  }
+
+  raf = requestAnimationFrame(frame)
+
+  // The handle is a development affordance, not a shipped surface: anything on
+  // the page could otherwise drive a child's game. It attaches under Vite dev,
+  // or when explicitly asked for.
+  const wantDebug =
+    ((import.meta as unknown as { env?: { DEV?: boolean } }).env?.DEV ?? false) ||
+    new URLSearchParams(location.search).has("dev") ||
+    showPerf
+
+  const dbg: Debug = {
+    world,
+    cam,
+    gov,
+    gfx,
+    forceTier: (t) => gov.force(t),
+    fps: () => gov.fps,
+    frameOnce: (dt) => {
+      advance(dt)
+      hud.update(world, dt, gov.fps, gov.spec.name, showPerf)
+    },
+    get lastAnswerMs() {
+      return world.resonance.answerMs
+    },
+  }
+  if (wantDebug) (window as unknown as { __arena?: Debug }).__arena = dbg
+
+  return {
+    unmount() {
+      running = false
+      cancelAnimationFrame(raf)
+      ro.disconnect()
+      document.removeEventListener("visibilitychange", onVisibility)
+      motionQuery?.removeEventListener("change", onMotionChange)
+      container.removeEventListener("pointerdown", unlock)
+      window.removeEventListener("keydown", unlock)
+      input.dispose()
+      hud.dispose()
+      audio.dispose()
+      gfx.dispose()
+      container.remove()
+      if (wantDebug) delete (window as unknown as { __arena?: Debug }).__arena
+    },
+  }
+}

--- a/dynawalla/games/arena/src/pack.ts
+++ b/dynawalla/games/arena/src/pack.ts
@@ -1,0 +1,50 @@
+// ARENA, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous surface the `Host`
+// in `contract.ts` already describes — so the water, the rivals, the depth
+// ratchet and the tier governor are untouched.
+//
+// What crosses the boundary is the Resonance. Four glass spheres rise carrying
+// the answer and three mal-rule distractors the curriculum drew, and the game
+// never decides whether a child was right: it reports which sphere was flown
+// into, verbatim, and `items.answer` is the judge. That is also why
+// `items.reveal` is declared — a sphere has to carry the answer *before* the
+// child reaches it, which is the sanctioned use of the grant and changes
+// nothing about who judges.
+//
+// The arena's own mathematics — every second of play is a magnitude comparison
+// against your own mass — is not reported, because nobody asked it as a
+// question. It is the mechanic, not the assessment.
+//
+// No seed is passed: a pack run is a fresh ocean. `?seed=` belongs to
+// `index.html`, which the pack build does not include.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import { mount } from "./contract.ts"
+import type { Host } from "./contract.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("arena: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "compare" })
+  // Stocked before the first frame: the first Resonance opens sixteen seconds
+  // in, and four spheres with blank faces is the kind of thing that happens
+  // exactly once, on launch, in front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop, the WebGL
+  // context and the audio graph are torn down before the frame is, rather than
+  // a frame or two after it.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[arena] could not start", error)
+  renderNoHost(root, "ARENA")
+})

--- a/dynawalla/games/arena/src/render/atlas.ts
+++ b/dynawalla/games/arena/src/render/atlas.ts
@@ -1,0 +1,241 @@
+import * as THREE from "three"
+
+/**
+ * The numeral atlas — a signed distance field.
+ *
+ * Legibility is the one thing in this game that is not allowed to lose to
+ * ornament, and the first version of this file lost. It stamped a coverage
+ * bitmap into a canvas and let the GPU minify it. On a desktop that is fine.
+ * On a 390px phone the same glyph lands twenty pixels tall, the mip chain
+ * averages a two-texel stroke down to a grey smear, and what a child actually
+ * saw was a hairline ghost of a numeral floating on top of a blown-out bloom
+ * highlight. Screenshotted, measured, unarguable: in a game whose whole pitch
+ * is telling 3,418 from 3,481 at a glance, the numbers were unreadable on the
+ * primary target.
+ *
+ * A distance field does not have that failure mode. What is stored is not ink
+ * but *distance to the nearest edge*, which is a smooth, low-frequency signal:
+ * bilinear sampling of it at any scale reconstructs the same iso-contour, so
+ * the glyph keeps its exact weight and shape whether it is 120 pixels tall or
+ * twelve. The antialias width is computed analytically from the on-screen size
+ * rather than guessed, so there is no mip chain and no smear.
+ *
+ * The same field also gives us the dark plate for free. A plate is just the
+ * glyph dilated, and a dilated glyph is the *same distance field read at a
+ * different iso-level*. One channel, one texture fetch, two shapes: the white
+ * numeral at d = 0.5 and a near-black backing slab at d = PAD. That plate is
+ * what lets a white numeral survive sitting on a bloom-white core, and because
+ * it is derived from distance it stays exactly as thick, relative to the
+ * glyph, at every size.
+ */
+
+export const GLYPHS = "0123456789-×÷+?" as const
+/**
+ * Derived, not written down. It was hard-coded to 16 against a 15-character
+ * set, so the atlas carried one cell that was never rasterised into and
+ * `indexOf`'s fallback pointed straight at it: an unknown character rendered
+ * as a blank rather than as the `?` the set ends with.
+ */
+export const GLYPH_COUNT = GLYPHS.length
+
+const CELL_W = 136
+const CELL_H = 176
+const FONT_PX = 104
+/**
+ * Distance range encoded in the byte, in atlas pixels: the stored value is
+ * 0.5 at the glyph edge, 1.0 at SPREAD/2 inside, 0.0 at SPREAD/2 outside.
+ */
+const SPREAD = 44
+/** How far the dark plate is dilated past the glyph edge, in atlas pixels. */
+const PAD_PX = 10
+/**
+ * A second, wider and softer iso — separation from a very bright core.
+ *
+ * MUST stay comfortably inside SPREAD/2. At exactly SPREAD/2 the iso lands on
+ * 0.0, which is also the value the field clamps to everywhere outside the
+ * glyph, so `smoothstep` straddles it and the "aura" renders as a 50%-opaque
+ * grey RECTANGLE over the whole cell. Screenshotted at 390px: every numeral
+ * sat in a grey box and adjacent boxes double-darkened into a checkerboard.
+ */
+const AURA_PX = 15
+
+const FONT_STACK = `900 ${FONT_PX}px ui-rounded, "SF Pro Rounded", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif`
+
+export type Atlas = {
+  texture: THREE.Texture
+  /** Quad height in units of cap height — sizes are quoted as CAP HEIGHT. */
+  cellPerCap: number
+  /** Quad aspect, width over height. */
+  cellAspect: number
+  /** Tabular advance width, in units of cap height. */
+  advance: number
+  /** Iso value of the dark plate. */
+  padIso: number
+  /** Iso value of the wider, softer aura. */
+  auraIso: number
+  /**
+   * Atlas pixels per cell height, divided by the distance spread. Multiply by
+   * (1 / on-screen quad height in pixels) to get the exact antialias width in
+   * field units — no derivatives, no mip guessing.
+   */
+  aaK: number
+  indexOf(ch: string): number
+}
+
+// ---------------------------------------------------------------------------
+// Exact Euclidean distance transform (Felzenszwalb & Huttenlocher, O(n)).
+// ---------------------------------------------------------------------------
+
+/** Large but FINITE. An infinite seed makes the parabola test evaluate 0/0. */
+const FAR = 1e10
+
+function edt1d(f: Float64Array, d: Float64Array, v: Int32Array, z: Float64Array, n: number): void {
+  let k = 0
+  v[0] = 0
+  z[0] = -FAR
+  z[1] = FAR
+  for (let q = 1; q < n; q++) {
+    let s = 0
+    for (;;) {
+      const vk = v[k] as number
+      s = ((f[q] as number) + q * q - ((f[vk] as number) + vk * vk)) / (2 * q - 2 * vk)
+      if (k > 0 && s <= (z[k] as number)) k--
+      else break
+    }
+    k++
+    v[k] = q
+    z[k] = s
+    z[k + 1] = FAR
+  }
+  k = 0
+  for (let q = 0; q < n; q++) {
+    while ((z[k + 1] as number) < q) k++
+    const vk = v[k] as number
+    d[q] = (q - vk) * (q - vk) + (f[vk] as number)
+  }
+}
+
+/** Squared distance from every pixel to the nearest `mask` pixel. */
+function edt2d(mask: Uint8Array, w: number, h: number, out: Float64Array): void {
+  const n = Math.max(w, h)
+  const f = new Float64Array(n)
+  const d = new Float64Array(n)
+  const v = new Int32Array(n)
+  const z = new Float64Array(n + 1)
+
+  for (let p = 0; p < w * h; p++) out[p] = mask[p] ? 0 : FAR
+
+  for (let x = 0; x < w; x++) {
+    for (let y = 0; y < h; y++) f[y] = out[y * w + x] as number
+    edt1d(f, d, v, z, h)
+    for (let y = 0; y < h; y++) out[y * w + x] = d[y] as number
+  }
+  for (let y = 0; y < h; y++) {
+    const row = y * w
+    for (let x = 0; x < w; x++) f[x] = out[row + x] as number
+    edt1d(f, d, v, z, w)
+    for (let x = 0; x < w; x++) out[row + x] = d[x] as number
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+export function buildAtlas(): Atlas {
+  const w = CELL_W * GLYPH_COUNT
+  const h = CELL_H
+
+  const canvas = document.createElement("canvas")
+  canvas.width = w
+  canvas.height = h
+  const ctx = canvas.getContext("2d", { willReadFrequently: true })
+  if (!ctx) throw new Error("[arena] 2d context unavailable for the numeral atlas")
+  ctx.clearRect(0, 0, w, h)
+  ctx.font = FONT_STACK
+  ctx.textAlign = "center"
+  ctx.textBaseline = "alphabetic"
+  ctx.fillStyle = "#fff"
+
+  // Cap height is measured, not assumed: it is the unit every on-screen size in
+  // this game is quoted in, so a "14px numeral" really is fourteen pixels of
+  // ink and the minimum-size rule means what it says.
+  const probe = ctx.measureText("8")
+  const capPx = Math.max(1, probe.actualBoundingBoxAscent)
+  const advancePx = Math.max(probe.width, ctx.measureText("0").width)
+  const baseline = h / 2 + capPx / 2
+
+  for (let i = 0; i < GLYPHS.length; i++) {
+    ctx.fillText(GLYPHS[i] as string, i * CELL_W + CELL_W / 2, baseline)
+  }
+
+  const img = ctx.getImageData(0, 0, w, h).data
+  const np = w * h
+  const cov = new Float32Array(np)
+  const inside = new Uint8Array(np)
+  const outside = new Uint8Array(np)
+  for (let p = 0; p < np; p++) {
+    const a = (img[p * 4 + 3] as number) / 255
+    cov[p] = a
+    inside[p] = a > 0.5 ? 1 : 0
+    outside[p] = a > 0.5 ? 0 : 1
+  }
+
+  const dOut = new Float64Array(np) // distance to ink, for pixels outside
+  const dIn = new Float64Array(np) // distance to background, for pixels inside
+  edt2d(inside, w, h, dOut)
+  edt2d(outside, w, h, dIn)
+
+  const data = new Uint8Array(np * 4)
+  for (let p = 0; p < np; p++) {
+    const a = cov[p] as number
+    let sd: number
+    if (a > 0.02 && a < 0.98) {
+      // On an antialiased edge the coverage IS the sub-pixel distance, and it
+      // is far more accurate than a distance transform of a hard threshold.
+      sd = a - 0.5
+    } else if (a > 0.5) {
+      sd = Math.sqrt(dIn[p] as number) - 0.5
+    } else {
+      sd = -(Math.sqrt(dOut[p] as number) - 0.5)
+    }
+    const v = Math.round(255 * Math.max(0, Math.min(1, 0.5 + sd / SPREAD)))
+    const o = p * 4
+    data[o] = v
+    data[o + 1] = v
+    data[o + 2] = v
+    data[o + 3] = 255
+  }
+
+  const texture = new THREE.DataTexture(data, w, h, THREE.RGBAFormat, THREE.UnsignedByteType)
+  // No mip chain on purpose. A distance field is low-frequency; bilinear
+  // minification of it reconstructs the same edge, whereas a mip chain of a
+  // coverage bitmap is exactly the thing that ate these numerals on a phone.
+  texture.minFilter = THREE.LinearFilter
+  texture.magFilter = THREE.LinearFilter
+  texture.generateMipmaps = false
+  texture.wrapS = THREE.ClampToEdgeWrapping
+  texture.wrapT = THREE.ClampToEdgeWrapping
+  texture.colorSpace = THREE.NoColorSpace
+  texture.needsUpdate = true
+
+  const index = new Map<string, number>()
+  for (let i = 0; i < GLYPHS.length; i++) index.set(GLYPHS[i] as string, i)
+
+  return {
+    texture,
+    cellPerCap: CELL_H / capPx,
+    cellAspect: CELL_W / CELL_H,
+    // Tabular, with a hair of tracking. Tight enough that the plates of
+    // neighbouring digits merge into one continuous slab — which is exactly
+    // what a four-digit number wants behind it — and loose enough that the
+    // digits themselves never touch.
+    advance: (advancePx + FONT_PX * 0.10) / capPx,
+    padIso: 0.5 - PAD_PX / SPREAD,
+    auraIso: 0.5 - AURA_PX / SPREAD,
+    aaK: CELL_H / SPREAD,
+    indexOf(ch: string) {
+      // An unknown character is a `?`, which is what the glyph set ends with
+      // and the reason it is in there at all.
+      return index.get(ch) ?? index.get("?") ?? 0
+    },
+  }
+}

--- a/dynawalla/games/arena/src/render/gfx.ts
+++ b/dynawalla/games/arena/src/render/gfx.ts
@@ -1,0 +1,501 @@
+import * as THREE from "three"
+import { buildAtlas, type Atlas } from "./atlas.ts"
+import { Backdrop, Cores, Motes, Numerals, Particles, Rings, Snow } from "./layers.ts"
+import { Post } from "./post.ts"
+import { valueBuffer } from "../core/digits.ts"
+import type { TierSpec } from "../core/tier.ts"
+import { MK_ANSWER, MK_VOID, R_K, World } from "../sim/world.ts"
+import type { Camera } from "../feel/camera.ts"
+import type { Floaters } from "../feel/floaters.ts"
+
+const MAX_MOTE_INSTANCES = 360
+const MAX_CORE_INSTANCES = 40
+
+/**
+ * Numeral sizes are quoted in CSS pixels of CAP HEIGHT — the height of the ink
+ * a child actually has to resolve. `NUM_MIN_PX` is a floor that is never
+ * traded away: a numeral is either legible or it is not drawn at all, and a
+ * numeral that has to sit outside its own creature to be legible does so.
+ */
+const NUM_MIN_PX = 13
+const NUM_MAX_PX = 72
+/** Below this on-screen radius an entity is unambiguous by size alone. */
+const LABEL_MIN_RADIUS_PX = 7
+/**
+ * A number is printed only when it could change a decision — when the value is
+ * within this factor of your own mass, either way.
+ *
+ * The simulation spends 86% of the field on crumbs whose value grows as
+ * M^0.6, and the design has always said the numeral "is only there to settle
+ * the near-ties". The renderer did not say that: at mass 2,987 a phone frame
+ * carried thirty labels reading 76, 77, 80, 97, 103, 106 — every one of them a
+ * rounding error, all of them louder than the motes they sat on, and each one
+ * competing for the same pixels as the near-tie that actually mattered. The
+ * size grammar already says "smaller than you" without a single digit. So the
+ * digits are spent where the grammar runs out.
+ */
+const LABEL_NEAR_BAND = 6
+
+const LAB_CAP = 384
+/** A value nine times your mass, or a ninth of it, needs no number on it. */
+const LOG_SPAN = Math.log(9)
+
+function blend(a: readonly number[], b: readonly number[], out: [number, number, number], k: number): void {
+  out[0] = (a[0] as number) + ((b[0] as number) - (a[0] as number)) * k
+  out[1] = (a[1] as number) + ((b[1] as number) - (a[1] as number)) * k
+  out[2] = (a[2] as number) + ((b[2] as number) - (a[2] as number)) * k
+}
+
+export class Gfx {
+  readonly renderer: THREE.WebGLRenderer
+  readonly canvas: HTMLCanvasElement
+  readonly particles: Particles
+  readonly rings: Rings
+  private readonly scene = new THREE.Scene()
+  private readonly overlay = new THREE.Scene()
+  private readonly cam = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1)
+  private readonly backdrop: Backdrop
+  private readonly snow: Snow
+  private readonly motes: Motes
+  private readonly cores: Cores
+  private readonly numerals: Numerals
+  private readonly post: Post
+  private readonly atlas: Atlas
+
+  private w = 1
+  private h = 1
+  private dpr = 1
+  private spec: TierSpec
+
+  // Palette, smoothly blended between depths so a boundary is a slow tide
+  // rather than a hard cut.
+  private water: [number, number, number] = [0, 0, 0]
+  private shaft: [number, number, number] = [0, 0, 0]
+  private food: [number, number, number] = [0, 0, 0]
+  private threatC: [number, number, number] = [0, 0, 0]
+  private selfC: [number, number, number] = [0, 0, 0]
+  private paletteReady = false
+
+  // -- label placement ------------------------------------------------------
+  // Every numeral is a *candidate* until it has been given room. Four-digit
+  // values on adjacent cores used to print straight through each other —
+  // 1530/1486/760 overlapping, and the player's own mass sitting on top of a
+  // floating pop — in a game that asks you to tell 3,418 from 3,481. So labels
+  // are collected, ranked, and laid out with an overlap test, and the ones that
+  // lose are the ones whose number could not have changed a decision anyway.
+  private labN = 0
+  private readonly labX = new Float32Array(LAB_CAP)
+  private readonly labY = new Float32Array(LAB_CAP)
+  private readonly labCap = new Float32Array(LAB_CAP)
+  private readonly labHW = new Float32Array(LAB_CAP)
+  // Float64, not Float32, and `valueBuffer` says why: this array holds the
+  // number a child reads, and Float32 rounds one past 2^24 into a different
+  // number without a word.
+  private readonly labV = valueBuffer(LAB_CAP)
+  private readonly labR = new Float32Array(LAB_CAP)
+  private readonly labG = new Float32Array(LAB_CAP)
+  private readonly labB = new Float32Array(LAB_CAP)
+  private readonly labA = new Float32Array(LAB_CAP)
+  private readonly labPrio = new Float32Array(LAB_CAP)
+  private readonly labOrder = new Int32Array(LAB_CAP)
+  private readonly labKeep = new Int32Array(LAB_CAP)
+
+  // Palette scratch. Preallocated because `draw` runs sixty times a second and
+  // this file is not allowed to hand the collector anything.
+  private readonly tw: [number, number, number] = [0, 0, 0]
+  private readonly ts: [number, number, number] = [0, 0, 0]
+  private readonly tf: [number, number, number] = [0, 0, 0]
+  private readonly tt: [number, number, number] = [0, 0, 0]
+  private readonly tse: [number, number, number] = [0, 0, 0]
+
+  // Per-frame label sizing constants, set once at the top of `draw`.
+  private capMin = 1
+  private capMax = 1
+  private pMass = 1
+  private halfDiag = 1
+  private camX = 0
+  private camY = 0
+
+  constructor(container: HTMLElement, spec: TierSpec) {
+    this.spec = spec
+    this.renderer = new THREE.WebGLRenderer({
+      antialias: false,
+      alpha: false,
+      powerPreference: "high-performance",
+      stencil: false,
+      depth: false,
+    })
+    this.renderer.autoClear = false
+    this.renderer.setClearColor(0x000000, 1)
+    this.canvas = this.renderer.domElement
+    this.canvas.style.position = "absolute"
+    this.canvas.style.inset = "0"
+    this.canvas.style.width = "100%"
+    this.canvas.style.height = "100%"
+    this.canvas.style.display = "block"
+    container.appendChild(this.canvas)
+
+    this.atlas = buildAtlas()
+    this.backdrop = new Backdrop()
+    this.snow = new Snow(1100)
+    this.motes = new Motes(MAX_MOTE_INSTANCES)
+    this.cores = new Cores(MAX_CORE_INSTANCES)
+    this.particles = new Particles(3200)
+    this.rings = new Rings()
+    this.numerals = new Numerals(this.atlas)
+
+    this.scene.add(this.backdrop.mesh)
+    this.scene.add(this.snow.mesh)
+    this.scene.add(this.particles.mesh)
+    this.scene.add(this.motes.mesh)
+    this.scene.add(this.cores.mesh)
+    this.scene.add(this.rings.mesh)
+    this.overlay.add(this.numerals.plate)
+    this.overlay.add(this.numerals.mesh)
+
+    this.post = new Post(this.renderer)
+    this.applySpec(spec)
+  }
+
+  applySpec(spec: TierSpec): void {
+    this.spec = spec
+    this.snow.setCount(spec.snow)
+    this.particles.setCount(spec.particles)
+    this.post.passes = spec.bloomPasses
+    this.post.dispersion = spec.dispersion
+    this.post.setScale(spec.bloomScale)
+    this.resize(this.w, this.h, true)
+  }
+
+  resize(cssW: number, cssH: number, force = false): void {
+    if (!force && cssW === this.w && cssH === this.h) return
+    this.w = Math.max(1, cssW)
+    this.h = Math.max(1, cssH)
+    this.dpr = Math.min(window.devicePixelRatio || 1, this.spec.dprCap)
+    this.renderer.setPixelRatio(this.dpr)
+    this.renderer.setSize(this.w, this.h, false)
+    this.post.resize(this.w * this.dpr, this.h * this.dpr, this.spec.bloomScale)
+  }
+
+  get aspect(): number {
+    return this.w / this.h
+  }
+
+  /** World units per screen pixel, for sizing numerals in real terms. */
+  private worldPerPx(span: number): number {
+    return span / this.h
+  }
+
+  /** Cap height that keeps a value inside its own body where it can. */
+  private capFor(v: number, r: number, want: number): number {
+    const per = this.numerals.widthOf(v, 1)
+    const fit = (r * 1.72) / Math.max(0.5, per)
+    return Math.max(this.capMin, Math.min(this.capMax, Math.min(r * want, fit)))
+  }
+
+  /** Could this value's exact digits change what a child does about it? */
+  private decides(v: number): boolean {
+    const a = Math.abs(v)
+    return a * LABEL_NEAR_BAND >= this.pMass && a <= this.pMass * LABEL_NEAR_BAND
+  }
+
+  /** How near this value is to a decision — the only reason to print it. */
+  private nearness(v: number, x: number, y: number): number {
+    const rel = Math.abs(Math.log(Math.max(1, Math.abs(v)) / this.pMass)) / LOG_SPAN
+    const d = Math.hypot(x - this.camX, y - this.camY) / this.halfDiag
+    return 120 * (1 - Math.min(1, rel)) + 60 * (1 - Math.min(1, d))
+  }
+
+  private label(v: number, x: number, y: number, cap: number, r: number, g: number, b: number, a: number, prio: number): void {
+    if (this.labN >= LAB_CAP || a <= 0.01) return
+    const i = this.labN++
+    this.labX[i] = x
+    this.labY[i] = y
+    this.labCap[i] = cap
+    this.labHW[i] = this.numerals.widthOf(v, cap) * 0.5
+    this.labV[i] = v
+    this.labR[i] = r
+    this.labG[i] = g
+    this.labB[i] = b
+    this.labA[i] = a
+    this.labPrio[i] = prio
+  }
+
+  /**
+   * Rank by priority, then lay out greedily with an overlap test. The highest
+   * ranked label always wins its ground, so the one number a child is actually
+   * deciding on — their own mass, an answer sphere, the rival that is nearly
+   * their size — is never the one that gets dropped.
+   */
+  private placeLabels(): void {
+    const n = this.labN
+    const order = this.labOrder
+    for (let i = 0; i < n; i++) {
+      let j = i - 1
+      const v = i
+      const p = this.labPrio[i] as number
+      while (j >= 0 && (this.labPrio[order[j] as number] as number) < p) {
+        order[j + 1] = order[j] as number
+        j--
+      }
+      order[j + 1] = v
+    }
+
+    let kept = 0
+    for (let k = 0; k < n; k++) {
+      const i = order[k] as number
+      const xi = this.labX[i] as number
+      const yi = this.labY[i] as number
+      const hwi = this.labHW[i] as number
+      const hhi = (this.labCap[i] as number) * 0.72
+      let free = true
+      for (let m = 0; m < kept; m++) {
+        const j = this.labKeep[m] as number
+        if (Math.abs(xi - (this.labX[j] as number)) >= hwi + (this.labHW[j] as number)) continue
+        if (Math.abs(yi - (this.labY[j] as number)) >= hhi + (this.labCap[j] as number) * 0.72) continue
+        free = false
+        break
+      }
+      if (free) this.labKeep[kept++] = i
+    }
+
+    for (let m = 0; m < kept; m++) {
+      const i = this.labKeep[m] as number
+      this.numerals.number(
+        this.labV[i] as number,
+        this.labX[i] as number,
+        this.labY[i] as number,
+        this.labCap[i] as number,
+        this.labR[i] as number,
+        this.labG[i] as number,
+        this.labB[i] as number,
+        this.labA[i] as number,
+      )
+    }
+    this.labN = 0
+  }
+
+  draw(world: World, cam: Camera, time: number, reduced: boolean, floaters?: Floaters): void {
+    const span = cam.span
+    const cx = cam.viewX
+    const cy = cam.viewY
+    const aspect = this.aspect
+
+    // --- palette ----------------------------------------------------------
+    // Taken straight off the world so the picture can never disagree with the
+    // ratcheted band the simulation is actually running.
+    const depth = world.depth
+    const next = world.depthNext
+    const t = world.depthT
+    // Only the last third of a band bleeds into the next one, and it never
+    // bleeds all the way. A run whose mass has outrun the clock sits at t = 1
+    // for minutes, and at a full blend the picture became the NEXT depth
+    // entirely: the water went vent-amber while the label still said THE CHURN.
+    // Half a blend reads as "you can see the next depth coming", which is what
+    // this was always for.
+    const k = Math.min(0.45, Math.max(0, (t - 0.66) / 0.34) * 0.45)
+    const { tw, ts, tf, tt, tse } = this
+    blend(depth.water, next.water, tw, k)
+    blend(depth.shaft, next.shaft, ts, k)
+    blend(depth.food, next.food, tf, k)
+    blend(depth.threat, next.threat, tt, k)
+    blend(depth.self, next.self, tse, k)
+    const ease = this.paletteReady ? 0.035 : 1
+    this.paletteReady = true
+    for (let i = 0; i < 3; i++) {
+      this.water[i] = (this.water[i] as number) + ((tw[i] as number) - (this.water[i] as number)) * ease
+      this.shaft[i] = (this.shaft[i] as number) + ((ts[i] as number) - (this.shaft[i] as number)) * ease
+      this.food[i] = (this.food[i] as number) + ((tf[i] as number) - (this.food[i] as number)) * ease
+      this.threatC[i] = (this.threatC[i] as number) + ((tt[i] as number) - (this.threatC[i] as number)) * ease
+      this.selfC[i] = (this.selfC[i] as number) + ((tse[i] as number) - (this.selfC[i] as number)) * ease
+    }
+
+    const res = world.resonance
+    // The hush has to land almost instantly. A 0.4s ramp meant the frame in
+    // which the question appears was still the loudest frame in the game.
+    const calm = res.active ? Math.min(1, res.t * 6) * (res.phase >= 3 ? Math.max(0, 1 - (res.t - res.duration) * 2.6) : 1) : 0
+
+    // --- cull bounds ------------------------------------------------------
+    const halfH = span * 0.5
+    const halfW = halfH * aspect
+    const margin = 1.35
+    const minX = cx - halfW * margin
+    const maxX = cx + halfW * margin
+    const minY = cy - halfH * margin
+    const maxY = cy + halfH * margin
+
+    world.viewAspect = aspect
+    const wpp = this.worldPerPx(span)
+    const capMin = wpp * NUM_MIN_PX
+    const capMax = wpp * NUM_MAX_PX
+    const labelMinR = wpp * LABEL_MIN_RADIUS_PX
+    this.capMin = capMin
+    this.capMax = capMax
+    this.pMass = Math.max(1, world.mass)
+    this.halfDiag = Math.hypot(halfW, halfH)
+    this.camX = cx
+    this.camY = cy
+
+    // --- motes ------------------------------------------------------------
+    this.motes.begin()
+    this.numerals.begin()
+    for (let i = 0; i < world.mx.length; i++) {
+      if (!world.malive[i]) continue
+      const x = world.mx[i] as number
+      const y = world.my[i] as number
+      const r = world.mr[i] as number
+      if (x + r < minX || x - r > maxX || y + r < minY || y - r > maxY) continue
+      const kind = world.mkind[i] as number
+      const flip = world.mflip[i] as number
+      this.motes.push(x, y, r, flip, kind, world.mphase[i] as number, (i * 0.618034) % 1)
+
+      if (r < labelMinR) continue
+      const v = world.mval[i] as number
+      if (kind === MK_ANSWER) {
+        this.label(v, x, y, this.capFor(v, r, 0.78), 1, 1, 1, 1, 4000)
+        continue
+      }
+      // A void always carries its number: the minus sign IS the warning, and
+      // it is the one place where colour must not be doing the work alone.
+      if (kind !== MK_VOID && !this.decides(v)) continue
+      const a = Math.min(1, 0.62 + flip * 0.38) * (1 - calm * 0.9)
+      const prio = (kind === MK_VOID ? 620 : 300) + this.nearness(v, x, y)
+      this.label(v, x, y, this.capFor(v, r, 0.62), 1, 1, 1, a, prio)
+    }
+
+    // --- cores ------------------------------------------------------------
+    this.cores.begin()
+    for (let k2 = 0; k2 < world.rx.length; k2++) {
+      if (!world.ralive[k2]) continue
+      const x = world.rx[k2] as number
+      const y = world.ry[k2] as number
+      const m = world.rMassVis[k2] as number
+      const r = R_K * Math.sqrt(m)
+      if (x + r * 1.4 < minX || x - r * 1.4 > maxX || y + r * 1.4 < minY || y - r * 1.4 > maxY) continue
+      const threat = m > world.mass * 1.04 ? Math.min(1, (m / world.mass - 1) * 2.2) : 0
+      const hue = world.rhue[k2] as number
+      // Rivals are tinted around the depth's food/threat colours so the field
+      // stays coherent, with enough hue spread to tell individuals apart.
+      // Vary brightness and a single accent, never the channel ratios — a
+      // per-channel scramble turns a saturated palette into mud.
+      const base = threat > 0 ? this.threatC : this.food
+      const lift = 0.78 + hue * 0.42
+      const accent = ((hue * 7) % 1) * 0.22
+      const cr = (base[0] as number) * lift + accent * 0.5
+      const cg = (base[1] as number) * lift + accent
+      const cb = (base[2] as number) * lift + accent * 0.8
+      const lev = world.rleviathan[k2] === 1
+      this.cores.push(
+        x,
+        y,
+        r,
+        lev ? 1.0 : cr,
+        lev ? 0.45 : cg,
+        lev ? 0.12 : cb,
+        lev ? 1 : threat,
+        world.rsurge[k2] as number,
+        0,
+        hue * 6.28,
+      )
+      if (r >= labelMinR && this.decides(world.rmass[k2] as number)) {
+        const rv = Math.round(world.rmass[k2] as number)
+        this.label(rv, x, y, this.capFor(rv, r, 0.52), 1, 1, 1, 0.96 * (1 - calm * 0.9), 900 + this.nearness(rv, x, y))
+      }
+    }
+
+    // player last so it sits on top of the shoal
+    const pr = world.playerR
+    this.cores.push(
+      world.px,
+      world.py,
+      pr,
+      this.selfC[0] as number,
+      this.selfC[1] as number,
+      this.selfC[2] as number,
+      0,
+      world.surging ? 1 : 0,
+      1,
+      time * 0.7,
+    )
+    // Your own number is the one that must never be lost, at any size, under
+    // anything: it outranks every other label on the field.
+    const pv = Math.round(world.mass)
+    const pPer = this.numerals.widthOf(pv, 1)
+    const pcap = Math.max(capMin * 1.35, Math.min(capMax * 1.4, Math.min(pr * 0.62, (pr * 1.66) / Math.max(0.5, pPer))))
+    this.label(pv, world.px, world.py, pcap, 1, 1, 1, 1, 1e6)
+
+    // --- floating value pops ----------------------------------------------
+    if (floaters) {
+      for (let i = 0; i < floaters.items.length; i++) {
+        const f = floaters.items[i]!
+        if (f.life <= 0) continue
+        const u = f.t / f.life
+        // Overshoot out, then settle — the pop reads as a thing being thrown.
+        const scale = u < 0.16 ? 0.4 + (u / 0.16) * 0.85 : 1.25 - (u - 0.16) * 0.28
+        const a = u > 0.55 ? 1 - (u - 0.55) / 0.45 : 1
+        this.label(f.v, f.x, f.y, Math.max(capMin, f.size * scale), f.r, f.g, f.b, a, 5000 + i)
+      }
+    }
+
+    this.placeLabels()
+
+    this.motes.end()
+    this.cores.end()
+    this.numerals.end()
+
+    // --- uniforms ---------------------------------------------------------
+    const intensity = reduced ? 0.7 : 1
+    this.backdrop.set(time, this.water, this.shaft, cx, cy, span, aspect, this.spec.godrays, intensity, world.arenaR, calm)
+    this.snow.set(time, cx, cy, span, aspect, this.shaft, intensity)
+    this.motes.set(time, cx, cy, span, aspect, this.food, this.threatC, calm)
+    this.cores.set(time, cx, cy, span, aspect, Math.min(1, world.combo / 14), Math.min(1, world.invuln), calm)
+    this.rings.set(time, cx, cy, span, aspect)
+    this.particles.flush(time, cx, cy, span, aspect, reduced ? 0.35 : 1, calm)
+    // Device pixels, not CSS pixels: the antialias width is derived from the
+    // real framebuffer, so a 2x display gets a genuinely sharper glyph.
+    this.numerals.set(cx, cy, span, aspect, (this.h * this.dpr) / span)
+
+    const cu = this.post.composite.uniforms
+    ;(cu.uFlash as THREE.IUniform).value = cam.flash
+    ;(cu.uFlashColor as THREE.IUniform).value.set(cam.flashR, cam.flashG, cam.flashB)
+    ;(cu.uAberration as THREE.IUniform).value = cam.aberration
+    ;(cu.uDesat as THREE.IUniform).value = cam.desat
+    ;(cu.uIntensity as THREE.IUniform).value = this.spec.bloomPasses > 0 ? 0.95 : 0
+    const rx = (cam.rippleX - cx) / (span * 0.5) * 0.5
+    const ry = (cam.rippleY - cy) / (span * 0.5) * 0.5
+    ;(cu.uRipple as THREE.IUniform).value.set(rx, ry, cam.rippleT, cam.rippleAmp)
+
+    // --- render -----------------------------------------------------------
+    this.renderer.setRenderTarget(this.post.scene)
+    this.renderer.clear(true, false, false)
+    this.renderer.render(this.scene, this.cam)
+    this.post.run()
+    // Numerals go on last, straight to the screen, so bloom can never eat them.
+    this.renderer.setRenderTarget(null)
+    this.renderer.render(this.overlay, this.cam)
+  }
+
+  /** Colour the effects layer wants, without reaching into private state. */
+  get palette(): { food: readonly number[]; threat: readonly number[]; self: readonly number[]; shaft: readonly number[] } {
+    return { food: this.food, threat: this.threatC, self: this.selfC, shaft: this.shaft }
+  }
+
+  dispose(): void {
+    this.post.dispose()
+    this.scene.traverse((o) => {
+      const m = o as THREE.Mesh
+      if (m.geometry) m.geometry.dispose()
+      const mat = m.material as THREE.Material | undefined
+      if (mat) mat.dispose()
+    })
+    this.overlay.traverse((o) => {
+      const m = o as THREE.Mesh
+      if (m.geometry) m.geometry.dispose()
+      const mat = m.material as THREE.Material | undefined
+      if (mat) mat.dispose()
+    })
+    this.atlas.texture.dispose()
+    this.renderer.dispose()
+    this.canvas.remove()
+  }
+}

--- a/dynawalla/games/arena/src/render/layers.ts
+++ b/dynawalla/games/arena/src/render/layers.ts
@@ -1,0 +1,1039 @@
+import * as THREE from "three"
+import { GLYPH_COUNT, type Atlas } from "./atlas.ts"
+import { splitDigits } from "../core/digits.ts"
+
+/*
+ * Every drawable in ARENA is one instanced draw call with a hand-written
+ * shader. Nothing allocates after construction: the instance buffers are sized
+ * once at the ULTRA ceiling and the live count is moved with `instanceCount`.
+ *
+ * The visual grammar is deliberately one rule, applied to everything:
+ *
+ *    smooth disc  = smaller than you, you may swallow it
+ *    spiked ring  = larger than you, it will hurt
+ *
+ * Motes obey it. Rivals obey it. It is never carried by colour alone, and it
+ * changes the instant your mass crosses the threshold — which is why growth
+ * feels like the world converting rather than like a number going up.
+ */
+
+const QUAD = new Float32Array([-0.5, -0.5, 0.5, -0.5, 0.5, 0.5, -0.5, 0.5])
+const QUAD_IDX = new Uint16Array([0, 1, 2, 0, 2, 3])
+
+function quadGeometry(): THREE.InstancedBufferGeometry {
+  const g = new THREE.InstancedBufferGeometry()
+  g.setAttribute("position", new THREE.BufferAttribute(QUAD, 2))
+  g.setIndex(new THREE.BufferAttribute(QUAD_IDX, 1))
+  g.boundingSphere = new THREE.Sphere(new THREE.Vector3(), 1e9)
+  return g
+}
+
+/** Shared GLSL: cheap value noise + fbm. */
+const NOISE = /* glsl */ `
+float hash21(vec2 p){ p = fract(p*vec2(123.34, 456.21)); p += dot(p, p+34.56); return fract(p.x*p.y); }
+float vnoise(vec2 p){
+  vec2 i = floor(p), f = fract(p);
+  vec2 u = f*f*(3.0-2.0*f);
+  float a = hash21(i), b = hash21(i+vec2(1.0,0.0)), c = hash21(i+vec2(0.0,1.0)), d = hash21(i+vec2(1.0,1.0));
+  return mix(mix(a,b,u.x), mix(c,d,u.x), u.y);
+}
+float fbm(vec2 p){
+  float s = 0.0, a = 0.5;
+  for(int i=0;i<4;i++){ s += a*vnoise(p); p *= 2.03; a *= 0.5; }
+  return s;
+}
+`
+
+// ---------------------------------------------------------------------------
+// Backdrop — the water itself
+// ---------------------------------------------------------------------------
+
+export class Backdrop {
+  readonly mesh: THREE.Mesh
+  private readonly u: Record<string, THREE.IUniform>
+
+  constructor() {
+    const g = new THREE.BufferGeometry()
+    g.setAttribute("position", new THREE.BufferAttribute(new Float32Array([-1, -1, 3, -1, -1, 3]), 2))
+    g.boundingSphere = new THREE.Sphere(new THREE.Vector3(), 1e9)
+    this.u = {
+      uTime: { value: 0 },
+      uWater: { value: new THREE.Vector3(0.004, 0.014, 0.038) },
+      uShaft: { value: new THREE.Vector3(0.1, 0.42, 0.72) },
+      uCam: { value: new THREE.Vector2() },
+      uSpan: { value: 400 },
+      uAspect: { value: 1 },
+      uGodrays: { value: 1 },
+      uIntensity: { value: 1 },
+      uArenaR: { value: 1600 },
+      uCalm: { value: 0 },
+    }
+    const mat = new THREE.RawShaderMaterial({
+      uniforms: this.u,
+      depthTest: false,
+      depthWrite: false,
+      vertexShader: /* glsl */ `
+        attribute vec2 position;
+        varying vec2 vNdc;
+        void main(){ vNdc = position; gl_Position = vec4(position, 0.999, 1.0); }
+      `,
+      fragmentShader: /* glsl */ `
+        precision highp float;
+        varying vec2 vNdc;
+        uniform float uTime, uSpan, uAspect, uGodrays, uIntensity, uArenaR, uCalm;
+        uniform vec3 uWater, uShaft;
+        uniform vec2 uCam;
+        ${NOISE}
+        void main(){
+          vec2 ndc = vNdc;
+          vec2 world = uCam + vec2(ndc.x*uAspect, ndc.y) * uSpan * 0.5;
+
+          // Base water: a slow vertical gradient, darkest at the bottom, so the
+          // frame always has a floor and a "surface somewhere far above".
+          float g = clamp(0.5 - ndc.y*0.42, 0.0, 1.0);
+          vec3 col = uWater * (0.30 + g*1.10);
+
+          // Deep caustics — very low contrast, purely to keep the black alive.
+          float c1 = fbm(world*0.0016 + vec2(uTime*0.014, uTime*0.009));
+          float c2 = fbm(world*0.0041 - vec2(uTime*0.021, uTime*0.011));
+          float caustic = pow(max(0.0, c1*0.6 + c2*0.6 - 0.50), 3.2);
+          col += uShaft * caustic * 0.075 * uIntensity;
+
+          // Light shafts from an unreachable surface. Angular beams that drift.
+          if (uGodrays > 0.5) {
+            float a = ndc.x*uAspect*0.9 + 0.42;
+            float beams = 0.0;
+            beams += pow(max(0.0, sin(a*5.1 + uTime*0.05)), 22.0);
+            beams += pow(max(0.0, sin(a*8.3 - uTime*0.031 + 1.7)), 30.0)*0.7;
+            beams += pow(max(0.0, sin(a*3.2 + uTime*0.017 + 3.1)), 16.0)*0.5;
+            float fall = smoothstep(-1.05, 0.75, -ndc.y);
+            col += uShaft * beams * fall * 0.018 * uIntensity;
+          }
+
+          // The membrane. You can always see where the world ends.
+          float dr = length(world) - uArenaR;
+          float wall = exp(-abs(dr)*0.0055) * smoothstep(-260.0, 40.0, dr);
+          col += uShaft * wall * 0.55;
+          float grid = smoothstep(0.965, 1.0, abs(sin(atan(world.y, world.x)*46.0)));
+          col += uShaft * wall * grid * 0.5;
+
+          // Calm is raised during a Resonance: the water darkens and holds.
+          col *= mix(1.0, 0.20, uCalm);
+
+          // Vignette, then a whisper of grain so flat blacks never band.
+          float v = 1.0 - dot(ndc, ndc)*0.30;
+          col *= v;
+          col += (hash21(ndc*512.0 + uTime) - 0.5) * 0.0035;
+          gl_FragColor = vec4(max(col, 0.0), 1.0);
+        }
+      `,
+    })
+    this.mesh = new THREE.Mesh(g, mat)
+    this.mesh.frustumCulled = false
+    this.mesh.renderOrder = -100
+  }
+
+  set(
+    time: number,
+    water: readonly [number, number, number],
+    shaft: readonly [number, number, number],
+    camX: number,
+    camY: number,
+    span: number,
+    aspect: number,
+    godrays: boolean,
+    intensity: number,
+    arenaR: number,
+    calm: number,
+  ): void {
+    this.u.uTime!.value = time
+    ;(this.u.uWater!.value as THREE.Vector3).set(water[0], water[1], water[2])
+    ;(this.u.uShaft!.value as THREE.Vector3).set(shaft[0], shaft[1], shaft[2])
+    ;(this.u.uCam!.value as THREE.Vector2).set(camX, camY)
+    this.u.uSpan!.value = span
+    this.u.uAspect!.value = aspect
+    this.u.uGodrays!.value = godrays ? 1 : 0
+    this.u.uIntensity!.value = intensity
+    this.u.uArenaR!.value = arenaR
+    this.u.uCalm!.value = calm
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Marine snow — parallax drift, the thing that makes the water feel like water
+// ---------------------------------------------------------------------------
+
+export class Snow {
+  readonly mesh: THREE.Mesh
+  private readonly u: Record<string, THREE.IUniform>
+  private readonly cap: number
+
+  constructor(cap: number) {
+    this.cap = cap
+    const g = quadGeometry()
+    const seed = new Float32Array(cap * 4)
+    for (let i = 0; i < cap; i++) {
+      seed[i * 4] = Math.random()
+      seed[i * 4 + 1] = Math.random()
+      seed[i * 4 + 2] = 0.18 + Math.random() * 0.82 // parallax
+      seed[i * 4 + 3] = Math.random()
+    }
+    g.setAttribute("iSeed", new THREE.InstancedBufferAttribute(seed, 4))
+    g.instanceCount = cap
+    this.u = {
+      uTime: { value: 0 },
+      uCam: { value: new THREE.Vector2() },
+      uSpan: { value: 400 },
+      uAspect: { value: 1 },
+      uTint: { value: new THREE.Vector3(0.4, 0.8, 1) },
+      uIntensity: { value: 1 },
+    }
+    const mat = new THREE.RawShaderMaterial({
+      uniforms: this.u,
+      transparent: true,
+      blending: THREE.AdditiveBlending,
+      depthTest: false,
+      depthWrite: false,
+      vertexShader: /* glsl */ `
+        attribute vec2 position;
+        attribute vec4 iSeed;
+        varying vec2 vL; varying float vA; varying float vTw;
+        uniform float uTime, uSpan, uAspect;
+        uniform vec2 uCam;
+        void main(){
+          float par = iSeed.z;
+          // Tile the field in screen space so the drift is infinite and free.
+          vec2 base = iSeed.xy * 2.0 - 1.0;
+          vec2 drift = vec2(sin(uTime*0.045 + iSeed.w*31.0)*0.06, -uTime*0.012*par);
+          vec2 p = base + drift - (uCam / (uSpan*3.0)) * par;
+          p = fract((p + 1.0) * 0.5) * 2.0 - 1.0;
+          float s = (0.0022 + iSeed.w*0.0060) * mix(0.5, 1.35, par);
+          vL = position * 2.0;
+          vA = mix(0.10, 0.75, par) * (0.35 + iSeed.w*0.65);
+          vTw = 0.6 + 0.4*sin(uTime*1.7 + iSeed.w*44.0);
+          vec2 ndc = vec2(p.x, p.y) + position * s * vec2(1.0/uAspect, 1.0);
+          gl_Position = vec4(ndc, 0.99, 1.0);
+        }
+      `,
+      fragmentShader: /* glsl */ `
+        precision mediump float;
+        varying vec2 vL; varying float vA; varying float vTw;
+        uniform vec3 uTint; uniform float uIntensity;
+        void main(){
+          float d = length(vL);
+          float a = exp(-d*d*3.2);
+          gl_FragColor = vec4(uTint * a * vA * vTw * uIntensity, a);
+        }
+      `,
+    })
+    this.mesh = new THREE.Mesh(g, mat)
+    this.mesh.frustumCulled = false
+    this.mesh.renderOrder = -90
+  }
+
+  setCount(n: number): void {
+    ;(this.mesh.geometry as THREE.InstancedBufferGeometry).instanceCount = Math.min(n, this.cap)
+  }
+
+  set(time: number, camX: number, camY: number, span: number, aspect: number, tint: readonly [number, number, number], intensity: number): void {
+    this.u.uTime!.value = time
+    ;(this.u.uCam!.value as THREE.Vector2).set(camX, camY)
+    this.u.uSpan!.value = span
+    this.u.uAspect!.value = aspect
+    ;(this.u.uTint!.value as THREE.Vector3).set(tint[0], tint[1], tint[2])
+    this.u.uIntensity!.value = intensity
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Motes
+// ---------------------------------------------------------------------------
+
+export class Motes {
+  readonly mesh: THREE.Mesh
+  private readonly aPos: THREE.InstancedBufferAttribute
+  private readonly aData: THREE.InstancedBufferAttribute
+  private readonly u: Record<string, THREE.IUniform>
+  private n = 0
+
+  constructor(cap: number) {
+    const g = quadGeometry()
+    this.aPos = new THREE.InstancedBufferAttribute(new Float32Array(cap * 3), 3) // x, y, r
+    this.aData = new THREE.InstancedBufferAttribute(new Float32Array(cap * 4), 4) // flip, kind, phase, seed
+    this.aPos.setUsage(THREE.DynamicDrawUsage)
+    this.aData.setUsage(THREE.DynamicDrawUsage)
+    g.setAttribute("iPos", this.aPos)
+    g.setAttribute("iData", this.aData)
+    this.u = {
+      uTime: { value: 0 },
+      uCam: { value: new THREE.Vector2() },
+      uSpan: { value: 400 },
+      uAspect: { value: 1 },
+      uFood: { value: new THREE.Vector3(0.45, 0.9, 1) },
+      uThreat: { value: new THREE.Vector3(1, 0.42, 0.62) },
+      uCalm: { value: 0 },
+    }
+    const mat = new THREE.RawShaderMaterial({
+      uniforms: this.u,
+      transparent: true,
+      blending: THREE.AdditiveBlending,
+      depthTest: false,
+      depthWrite: false,
+      vertexShader: /* glsl */ `
+        attribute vec2 position;
+        attribute vec3 iPos;
+        attribute vec4 iData;
+        varying vec2 vL; varying float vFlip; varying float vKind; varying float vPhase; varying float vSeed;
+        uniform vec2 uCam; uniform float uSpan, uAspect;
+        void main(){
+          vL = position * 2.9;
+          vFlip = iData.x; vKind = iData.y; vPhase = iData.z; vSeed = iData.w;
+          vec2 world = iPos.xy + position * iPos.z * 2.9;
+          vec2 ndc = (world - uCam) / (uSpan*0.5);
+          ndc.x /= uAspect;
+          gl_Position = vec4(ndc, 0.5, 1.0);
+        }
+      `,
+      fragmentShader: /* glsl */ `
+        precision highp float;
+        varying vec2 vL; varying float vFlip; varying float vKind; varying float vPhase; varying float vSeed;
+        uniform vec3 uFood, uThreat;
+        uniform float uTime, uCalm;
+        ${NOISE}
+        void main(){
+          float d = length(vL);
+          float ang = atan(vL.y, vL.x);
+
+          // --- edible: a filled, breathing cell -------------------------------
+          float pulse = 1.0 + 0.045*sin(uTime*2.6 + vSeed*23.0);
+          float rr = d / pulse;
+          float body = smoothstep(1.02, 0.80, rr);
+          float rim  = exp(-pow((rr-0.95)*7.5, 2.0));
+          float nuc  = exp(-rr*rr*7.0);
+          float grain = fbm(vL*2.6 + vec2(uTime*0.25, vSeed*10.0));
+          vec3 foodCol = uFood * (body*(0.82 + grain*0.34) + rim*1.30 + nuc*1.05);
+          foodCol += vec3(0.80,0.95,1.0) * nuc*nuc * 0.30;
+
+          // --- threat: a spiked, hollow husk -----------------------------------
+          float spikes = 0.80 + 0.20*cos(ang*7.0 + vPhase*0.9);
+          float ring = exp(-pow((d - spikes)*7.0, 2.0));
+          float barb = exp(-pow((d - spikes*1.16)*6.2, 2.0)) * pow(max(0.0, cos(ang*7.0 + vPhase*0.9)), 3.0);
+          float hollow = smoothstep(0.80, 0.58, d) * 0.055;
+          vec3 threatCol = uThreat * (ring*1.7 + barb*1.35 + hollow*1.2);
+
+          vec3 col = mix(threatCol, foodCol, vFlip);
+
+          // --- void: an inward collapse, always hostile ------------------------
+          if (vKind > 0.5 && vKind < 1.5) {
+            float chev = exp(-pow((d - 0.86)*9.0, 2.0)) * (0.45 + 0.55*pow(max(0.0,-cos(ang*3.0 + uTime*1.6)), 2.0));
+            float core = exp(-d*d*10.0);
+            col = vec3(1.0, 0.10, 0.24) * (chev*1.5 + core*0.55);
+            col += vec3(0.35, 0.0, 0.12) * smoothstep(1.0, 0.5, d);
+          }
+
+          // --- shed: your own exhaust, cooler and softer -----------------------
+          if (vKind > 1.5 && vKind < 2.5) {
+            col = mix(col, uFood*vec3(0.7,1.0,0.85) * (body*0.5 + rim*1.0 + nuc*0.7), 0.75);
+          }
+
+          // --- answer sphere: glass, arcs, a hard bright edge ------------------
+          if (vKind > 2.5) {
+            float shell = exp(-pow((d - 0.94)*9.0, 2.0));
+            float inner = smoothstep(0.94, 0.20, d) * (0.10 + 0.10*fbm(vL*3.0 + uTime*0.4));
+            float arcs = 0.0;
+            for (int k=0;k<3;k++){
+              float ph = uTime*(0.9 + float(k)*0.45) + float(k)*2.1 + vSeed*7.0;
+              arcs += exp(-pow((d - (0.60 + float(k)*0.11))*30.0, 2.0)) * pow(max(0.0, cos(ang*2.0 - ph)), 6.0);
+            }
+            vec3 glass = vec3(0.72, 0.92, 1.0);
+            col = glass*(shell*2.0 + inner) + vec3(1.0,0.96,0.82)*arcs*0.9;
+            col += glass * exp(-d*2.6) * 0.10;
+          }
+
+          float glow = exp(-d*3.4) * 0.085;
+          col += mix(uThreat, uFood, vFlip) * glow;
+
+          float a = clamp(max(max(col.r,col.g), col.b), 0.0, 1.0);
+          // RESONANCE hush. The one moment the game asks a direct question used
+          // to be the busiest frame on screen: the labels snapped off but the
+          // SHAPES stayed lit, so four thin answer rings competed against a
+          // full-intensity field of hot stars. The field now drops to a twentieth
+          // — present, so you can still see where you are, inert, so nothing
+          // competes — and the four spheres are simultaneously pushed brighter.
+          float isField = step(vKind, 2.5);
+          col *= mix(1.0, 0.05, uCalm * isField);
+          col *= 1.0 + 0.55 * uCalm * (1.0 - isField);
+          gl_FragColor = vec4(col, a);
+        }
+      `,
+    })
+    this.mesh = new THREE.Mesh(g, mat)
+    this.mesh.frustumCulled = false
+    this.mesh.renderOrder = 10
+  }
+
+  begin(): void {
+    this.n = 0
+  }
+
+  push(x: number, y: number, r: number, flip: number, kind: number, phase: number, seed: number): void {
+    const cap = this.aPos.count
+    if (this.n >= cap) return
+    const i = this.n++
+    const p = this.aPos.array as Float32Array
+    const d = this.aData.array as Float32Array
+    p[i * 3] = x
+    p[i * 3 + 1] = y
+    p[i * 3 + 2] = r
+    d[i * 4] = flip
+    d[i * 4 + 1] = kind
+    d[i * 4 + 2] = phase
+    d[i * 4 + 3] = seed
+  }
+
+  end(): void {
+    ;(this.mesh.geometry as THREE.InstancedBufferGeometry).instanceCount = this.n
+    if (this.n === 0) return
+    this.aPos.addUpdateRange(0, this.n * 3)
+    this.aData.addUpdateRange(0, this.n * 4)
+    this.aPos.needsUpdate = true
+    this.aData.needsUpdate = true
+  }
+
+  set(time: number, camX: number, camY: number, span: number, aspect: number, food: readonly [number, number, number], threat: readonly [number, number, number], calm: number): void {
+    this.u.uTime!.value = time
+    ;(this.u.uCam!.value as THREE.Vector2).set(camX, camY)
+    this.u.uSpan!.value = span
+    this.u.uAspect!.value = aspect
+    ;(this.u.uFood!.value as THREE.Vector3).set(food[0], food[1], food[2])
+    ;(this.u.uThreat!.value as THREE.Vector3).set(threat[0], threat[1], threat[2])
+    this.u.uCalm!.value = calm
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cores — player and rivals, one shader, one grammar
+// ---------------------------------------------------------------------------
+
+export class Cores {
+  readonly mesh: THREE.Mesh
+  private readonly aPos: THREE.InstancedBufferAttribute
+  private readonly aCol: THREE.InstancedBufferAttribute
+  private readonly aData: THREE.InstancedBufferAttribute
+  private readonly u: Record<string, THREE.IUniform>
+  private n = 0
+
+  constructor(cap: number) {
+    const g = quadGeometry()
+    this.aPos = new THREE.InstancedBufferAttribute(new Float32Array(cap * 3), 3)
+    this.aCol = new THREE.InstancedBufferAttribute(new Float32Array(cap * 3), 3)
+    this.aData = new THREE.InstancedBufferAttribute(new Float32Array(cap * 4), 4) // threat, surge, self, phase
+    for (const a of [this.aPos, this.aCol, this.aData]) a.setUsage(THREE.DynamicDrawUsage)
+    g.setAttribute("iPos", this.aPos)
+    g.setAttribute("iCol", this.aCol)
+    g.setAttribute("iData", this.aData)
+    this.u = {
+      uTime: { value: 0 },
+      uCam: { value: new THREE.Vector2() },
+      uSpan: { value: 400 },
+      uAspect: { value: 1 },
+      uCombo: { value: 0 },
+      uInvuln: { value: 0 },
+      uCalm: { value: 0 },
+    }
+    const mat = new THREE.RawShaderMaterial({
+      uniforms: this.u,
+      transparent: true,
+      blending: THREE.AdditiveBlending,
+      depthTest: false,
+      depthWrite: false,
+      vertexShader: /* glsl */ `
+        attribute vec2 position;
+        attribute vec3 iPos;
+        attribute vec3 iCol;
+        attribute vec4 iData;
+        varying vec2 vL; varying vec3 vCol; varying vec4 vD;
+        uniform vec2 uCam; uniform float uSpan, uAspect;
+        void main(){
+          vL = position * 3.2;
+          vCol = iCol; vD = iData;
+          vec2 world = iPos.xy + position * iPos.z * 3.2;
+          vec2 ndc = (world - uCam) / (uSpan*0.5);
+          ndc.x /= uAspect;
+          gl_Position = vec4(ndc, 0.4, 1.0);
+        }
+      `,
+      fragmentShader: /* glsl */ `
+        precision highp float;
+        varying vec2 vL; varying vec3 vCol; varying vec4 vD;
+        uniform float uTime, uCombo, uInvuln, uCalm;
+        ${NOISE}
+        void main(){
+          float threat = vD.x, surge = vD.y, self = vD.z, phase = vD.w;
+          float d = length(vL);
+          float ang = atan(vL.y, vL.x);
+
+          // Membrane: a bright, thin, slightly wobbling edge. The wobble comes
+          // from the same noise as the interior so the cell reads as one body.
+          float wob = 1.0 + 0.028*sin(ang*5.0 + uTime*1.6 + phase) + 0.020*sin(ang*8.0 - uTime*1.1 + phase*2.0);
+          float rr = d / wob;
+          float membrane = exp(-pow((rr-0.97)*11.0, 2.0));
+          float interior = smoothstep(1.0, 0.30, rr);
+          float caustic = fbm(vL*2.2 + vec2(uTime*0.22 + phase, -uTime*0.16));
+          float nucleus = exp(-rr*rr*5.5);
+
+          // The shape grammar SNAPS. threat ramps from 0 over the band just
+          // above your mass, and hanging the hollowing and the barbs directly
+          // off it meant that at 1.05x your size — the near-tie the entire game
+          // is about — the spikes were at a tenth of their strength while the
+          // colour had already switched fully. Hue was doing the work alone in
+          // precisely the place the README promises it never does. Once a thing
+          // is a threat at all it LOOKS like one; threat then only says how
+          // much of one.
+          float threatK = threat > 0.005 ? (0.55 + 0.45*clamp(threat, 0.0, 1.0)) : 0.0;
+          float fill = mix(1.0, 0.30, threatK);
+          vec3 col = vCol * (membrane*(2.2 + threat*0.9) + interior*(0.16 + caustic*0.30)*fill + nucleus*0.55*fill);
+          if (self > 0.5) col += vCol * (interior*(0.42 + caustic*0.34) + nucleus*1.25);
+          col += vec3(1.0) * nucleus * nucleus * 0.55;
+
+          // The spiked husk: identical language to a mote too big to eat.
+          if (threat > 0.01) {
+            float sp = 0.98 + 0.16*cos(ang*9.0 + uTime*1.3 + phase);
+            float barb = exp(-pow((d - sp*1.14)*5.2, 2.0)) * pow(max(0.0, cos(ang*9.0 + uTime*1.3 + phase)), 4.0);
+            col += vCol * barb * 1.5 * threatK;
+            col += vec3(1.0,0.35,0.35) * barb * 0.55 * threatK;
+          }
+
+          // Surge corona — a hot forward-facing bloom while burning mass.
+          if (surge > 0.01) {
+            float corona = exp(-pow((d-1.06)*4.0, 2.0));
+            col += vCol * corona * surge * 1.5;
+            col += vec3(1.0,0.9,0.7) * corona * surge * 0.5;
+          }
+
+          // The player gets a combo halo and a shield while re-forming.
+          if (self > 0.5) {
+            float halo = exp(-pow((d - (1.16 + 0.05*sin(uTime*3.0)))*3.4, 2.0));
+            col += vCol * halo * (0.20 + uCombo*0.55);
+            float arc = 0.0;
+            arc += pow(max(0.0, cos(ang*2.0 - uTime*1.15)), 12.0) * exp(-pow((d-1.045)*13.0, 2.0));
+            arc += pow(max(0.0, cos(ang*3.0 + uTime*0.75 + 1.0)), 14.0) * exp(-pow((d-1.135)*15.0, 2.0));
+            col += vec3(1.0) * arc * 1.35;
+            col += vCol * arc * 1.1;
+            if (uInvuln > 0.001) {
+              float hex = abs(sin(ang*6.0 + uTime*2.0));
+              float shield = exp(-pow((d - 1.30)*7.0, 2.0)) * (0.45 + 0.55*hex);
+              col += vec3(0.7,0.95,1.0) * shield * uInvuln * 1.6;
+            }
+          }
+
+          float glow = exp(-d*2.8) * 0.10;
+          col += vCol * glow;
+
+          // During a Resonance every core but yours falls back into the dark,
+          // so the four spheres are the only thing left to look at.
+          col *= mix(1.0, 0.07 + self*0.80, uCalm);
+          float a = clamp(max(max(col.r,col.g), col.b), 0.0, 1.0);
+          gl_FragColor = vec4(col, a);
+        }
+      `,
+    })
+    this.mesh = new THREE.Mesh(g, mat)
+    this.mesh.frustumCulled = false
+    this.mesh.renderOrder = 20
+  }
+
+  begin(): void {
+    this.n = 0
+  }
+
+  push(x: number, y: number, r: number, cr: number, cg: number, cb: number, threat: number, surge: number, self: number, phase: number): void {
+    if (this.n >= this.aPos.count) return
+    const i = this.n++
+    const p = this.aPos.array as Float32Array
+    const c = this.aCol.array as Float32Array
+    const d = this.aData.array as Float32Array
+    p[i * 3] = x
+    p[i * 3 + 1] = y
+    p[i * 3 + 2] = r
+    c[i * 3] = cr
+    c[i * 3 + 1] = cg
+    c[i * 3 + 2] = cb
+    d[i * 4] = threat
+    d[i * 4 + 1] = surge
+    d[i * 4 + 2] = self
+    d[i * 4 + 3] = phase
+  }
+
+  end(): void {
+    ;(this.mesh.geometry as THREE.InstancedBufferGeometry).instanceCount = this.n
+    if (this.n === 0) return
+    this.aPos.addUpdateRange(0, this.n * 3)
+    this.aCol.addUpdateRange(0, this.n * 3)
+    this.aData.addUpdateRange(0, this.n * 4)
+    this.aPos.needsUpdate = true
+    this.aCol.needsUpdate = true
+    this.aData.needsUpdate = true
+  }
+
+  set(time: number, camX: number, camY: number, span: number, aspect: number, combo: number, invuln: number, calm: number): void {
+    this.u.uCalm!.value = calm
+    this.u.uTime!.value = time
+    ;(this.u.uCam!.value as THREE.Vector2).set(camX, camY)
+    this.u.uSpan!.value = span
+    this.u.uAspect!.value = aspect
+    this.u.uCombo!.value = combo
+    this.u.uInvuln!.value = invuln
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Particles — integrated entirely on the GPU, so a burst costs one buffer write
+// ---------------------------------------------------------------------------
+
+export class Particles {
+  readonly mesh: THREE.Mesh
+  private readonly aA: THREE.InstancedBufferAttribute // p0.xy, v0.xy
+  private readonly aB: THREE.InstancedBufferAttribute // t0, life, size, kind
+  private readonly aC: THREE.InstancedBufferAttribute // colour
+  private readonly u: Record<string, THREE.IUniform>
+  private readonly cap: number
+  private cursor = 0
+  private dirtyLo = Infinity
+  private dirtyHi = -Infinity
+  private live = 0
+
+  constructor(cap: number) {
+    this.cap = cap
+    const g = quadGeometry()
+    this.aA = new THREE.InstancedBufferAttribute(new Float32Array(cap * 4), 4)
+    this.aB = new THREE.InstancedBufferAttribute(new Float32Array(cap * 4), 4)
+    this.aC = new THREE.InstancedBufferAttribute(new Float32Array(cap * 3), 3)
+    for (const a of [this.aA, this.aB, this.aC]) a.setUsage(THREE.DynamicDrawUsage)
+    // life = 0 means "never spawned"; the vertex shader collapses those.
+    g.setAttribute("iA", this.aA)
+    g.setAttribute("iB", this.aB)
+    g.setAttribute("iC", this.aC)
+    g.instanceCount = cap
+    this.u = {
+      uTime: { value: 0 },
+      uCam: { value: new THREE.Vector2() },
+      uSpan: { value: 400 },
+      uAspect: { value: 1 },
+      uDrag: { value: 2.4 },
+      uMotion: { value: 1 },
+      uCalm: { value: 0 },
+    }
+    const mat = new THREE.RawShaderMaterial({
+      uniforms: this.u,
+      transparent: true,
+      blending: THREE.AdditiveBlending,
+      depthTest: false,
+      depthWrite: false,
+      vertexShader: /* glsl */ `
+        attribute vec2 position;
+        attribute vec4 iA; attribute vec4 iB; attribute vec3 iC;
+        varying vec2 vL; varying vec3 vCol; varying float vA; varying float vKind;
+        uniform vec2 uCam; uniform float uSpan, uAspect, uTime, uDrag, uMotion, uCalm;
+        void main(){
+          float life = iB.y;
+          float t = uTime - iB.x;
+          if (life <= 0.0 || t < 0.0 || t > life) { gl_Position = vec4(2.0,2.0,2.0,1.0); vA = 0.0; return; }
+          float k = uDrag;
+          vec2 p = iA.xy + iA.zw * ((1.0 - exp(-k*t)) / k) * uMotion;
+          float u01 = t / life;
+          // A quick pop out, then a long settle — the shape of a good spark.
+          float grow = smoothstep(0.0, 0.10, u01);
+          float fade = 1.0 - u01;
+          float s = iB.z * grow * (0.35 + fade*0.85);
+
+          // Elongate along travel so fast debris reads as motion, not as dots.
+          vec2 dir = normalize(iA.zw + vec2(1e-5));
+          float sp = length(iA.zw) * exp(-k*t);
+          float stretch = 1.0 + min(2.6, sp*0.0032) * step(0.5, iB.w) * uMotion;
+          vec2 local = position;
+          vec2 ax = dir, ay = vec2(-dir.y, dir.x);
+          vec2 off = (ax * local.x * stretch + ay * local.y) * s * 3.0;
+
+          vL = position * 3.0;
+          vCol = iC;
+          vA = pow(fade, 1.35) * mix(1.0, 0.10, uCalm);
+          vKind = iB.w;
+          vec2 world = p + off;
+          vec2 ndc = (world - uCam) / (uSpan*0.5);
+          ndc.x /= uAspect;
+          gl_Position = vec4(ndc, 0.3, 1.0);
+        }
+      `,
+      fragmentShader: /* glsl */ `
+        precision mediump float;
+        varying vec2 vL; varying vec3 vCol; varying float vA; varying float vKind;
+        void main(){
+          float d = length(vL);
+          float core = exp(-d*d*5.0);
+          float halo = exp(-d*2.2)*0.35;
+          vec3 col = vCol*(core*1.5 + halo) + vec3(1.0)*core*core*0.55;
+          gl_FragColor = vec4(col*vA, clamp((core+halo)*vA, 0.0, 1.0));
+        }
+      `,
+    })
+    this.mesh = new THREE.Mesh(g, mat)
+    this.mesh.frustumCulled = false
+    this.mesh.renderOrder = 15
+  }
+
+  setCount(n: number): void {
+    this.live = Math.min(n, this.cap)
+    ;(this.mesh.geometry as THREE.InstancedBufferGeometry).instanceCount = this.live
+  }
+
+  spawn(x: number, y: number, vx: number, vy: number, life: number, size: number, r: number, g: number, b: number, kind: number, now: number): void {
+    const cap = this.live || this.cap
+    const i = this.cursor % cap
+    this.cursor = (this.cursor + 1) % cap
+    const A = this.aA.array as Float32Array
+    const B = this.aB.array as Float32Array
+    const C = this.aC.array as Float32Array
+    A[i * 4] = x
+    A[i * 4 + 1] = y
+    A[i * 4 + 2] = vx
+    A[i * 4 + 3] = vy
+    B[i * 4] = now
+    B[i * 4 + 1] = life
+    B[i * 4 + 2] = size
+    B[i * 4 + 3] = kind
+    C[i * 3] = r
+    C[i * 3 + 1] = g
+    C[i * 3 + 2] = b
+    if (i < this.dirtyLo) this.dirtyLo = i
+    if (i > this.dirtyHi) this.dirtyHi = i
+  }
+
+  flush(time: number, camX: number, camY: number, span: number, aspect: number, motion: number, calm: number): void {
+    this.u.uCalm!.value = calm
+    this.u.uTime!.value = time
+    ;(this.u.uCam!.value as THREE.Vector2).set(camX, camY)
+    this.u.uSpan!.value = span
+    this.u.uAspect!.value = aspect
+    this.u.uMotion!.value = motion
+    if (this.dirtyHi >= this.dirtyLo) {
+      const lo = this.dirtyLo
+      const n = this.dirtyHi - lo + 1
+      this.aA.addUpdateRange(lo * 4, n * 4)
+      this.aB.addUpdateRange(lo * 4, n * 4)
+      this.aC.addUpdateRange(lo * 3, n * 3)
+      this.aA.needsUpdate = true
+      this.aB.needsUpdate = true
+      this.aC.needsUpdate = true
+      this.dirtyLo = Infinity
+      this.dirtyHi = -Infinity
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rings — shockwaves
+// ---------------------------------------------------------------------------
+
+const RING_CAP = 24
+
+export class Rings {
+  readonly mesh: THREE.Mesh
+  private readonly aA: THREE.InstancedBufferAttribute // x, y, r0, r1
+  private readonly aB: THREE.InstancedBufferAttribute // t0, life, width, kind
+  private readonly aC: THREE.InstancedBufferAttribute
+  private readonly u: Record<string, THREE.IUniform>
+  private cursor = 0
+
+  constructor() {
+    const g = quadGeometry()
+    this.aA = new THREE.InstancedBufferAttribute(new Float32Array(RING_CAP * 4), 4)
+    this.aB = new THREE.InstancedBufferAttribute(new Float32Array(RING_CAP * 4), 4)
+    this.aC = new THREE.InstancedBufferAttribute(new Float32Array(RING_CAP * 3), 3)
+    for (const a of [this.aA, this.aB, this.aC]) a.setUsage(THREE.DynamicDrawUsage)
+    g.setAttribute("iA", this.aA)
+    g.setAttribute("iB", this.aB)
+    g.setAttribute("iC", this.aC)
+    g.instanceCount = RING_CAP
+    this.u = {
+      uTime: { value: 0 },
+      uCam: { value: new THREE.Vector2() },
+      uSpan: { value: 400 },
+      uAspect: { value: 1 },
+    }
+    const mat = new THREE.RawShaderMaterial({
+      uniforms: this.u,
+      transparent: true,
+      blending: THREE.AdditiveBlending,
+      depthTest: false,
+      depthWrite: false,
+      vertexShader: /* glsl */ `
+        attribute vec2 position;
+        attribute vec4 iA; attribute vec4 iB; attribute vec3 iC;
+        varying vec2 vL; varying vec3 vCol; varying float vU; varying float vW; varying float vKind;
+        uniform vec2 uCam; uniform float uSpan, uAspect, uTime;
+        void main(){
+          float life = iB.y; float t = uTime - iB.x;
+          if (life <= 0.0 || t < 0.0 || t > life) { gl_Position = vec4(2.0,2.0,2.0,1.0); vU = 1.0; return; }
+          float u01 = t/life;
+          float e = 1.0 - pow(1.0 - u01, 3.0);           // out-cubic
+          float R = mix(iA.z, iA.w, e);
+          vL = position * 2.4;
+          vCol = iC; vU = u01; vW = iB.z; vKind = iB.w;
+          vec2 world = iA.xy + position * R * 2.4;
+          vec2 ndc = (world - uCam) / (uSpan*0.5);
+          ndc.x /= uAspect;
+          gl_Position = vec4(ndc, 0.35, 1.0);
+        }
+      `,
+      fragmentShader: /* glsl */ `
+        precision highp float;
+        varying vec2 vL; varying vec3 vCol; varying float vU; varying float vW; varying float vKind;
+        uniform float uTime;
+        void main(){
+          float d = length(vL);
+          float ang = atan(vL.y, vL.x);
+          float w = vW * (0.16 + (1.0-vU)*0.34);
+          float band = exp(-pow((d - 1.0)/max(0.008,w), 2.0));
+          // A second, faster inner edge gives the wave a leading crack of light.
+          float lead = exp(-pow((d - 0.972)/max(0.0025,w*0.28), 2.0));
+          float ripple = 1.0;
+          if (vKind > 1.5) ripple = 0.7 + 0.3*cos(ang*12.0 - vU*22.0);
+          float fade = pow(1.0 - vU, 1.6);
+          vec3 col = vCol * (band*1.15 + lead*1.9) * ripple * fade;
+          col += vec3(1.0) * lead * fade * 0.55;
+          gl_FragColor = vec4(col, clamp((band+lead)*fade, 0.0, 1.0));
+        }
+      `,
+    })
+    this.mesh = new THREE.Mesh(g, mat)
+    this.mesh.frustumCulled = false
+    this.mesh.renderOrder = 25
+  }
+
+  spawn(x: number, y: number, r0: number, r1: number, life: number, width: number, kind: number, r: number, g: number, b: number, now: number): void {
+    const i = this.cursor
+    this.cursor = (this.cursor + 1) % RING_CAP
+    const A = this.aA.array as Float32Array
+    const B = this.aB.array as Float32Array
+    const C = this.aC.array as Float32Array
+    A[i * 4] = x
+    A[i * 4 + 1] = y
+    A[i * 4 + 2] = r0
+    A[i * 4 + 3] = r1
+    B[i * 4] = now
+    B[i * 4 + 1] = life
+    B[i * 4 + 2] = width
+    B[i * 4 + 3] = kind
+    C[i * 3] = r
+    C[i * 3 + 1] = g
+    C[i * 3 + 2] = b
+    this.aA.needsUpdate = true
+    this.aB.needsUpdate = true
+    this.aC.needsUpdate = true
+  }
+
+  set(time: number, camX: number, camY: number, span: number, aspect: number): void {
+    this.u.uTime!.value = time
+    ;(this.u.uCam!.value as THREE.Vector2).set(camX, camY)
+    this.u.uSpan!.value = span
+    this.u.uAspect!.value = aspect
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Numerals — drawn last, over the bloom, never eaten by it
+// ---------------------------------------------------------------------------
+
+const NUM_CAP = 2400
+
+export class Numerals {
+  /** The dark backing slab. Drawn first, as its own pass — see below. */
+  readonly plate: THREE.Mesh
+  /** The white ink. */
+  readonly mesh: THREE.Mesh
+  readonly advance: number
+  private readonly aPos: THREE.InstancedBufferAttribute // x, y, capHeight, glyph
+  private readonly aCol: THREE.InstancedBufferAttribute // r, g, b, alpha
+  private readonly uPlate: Record<string, THREE.IUniform>
+  private readonly uInk: Record<string, THREE.IUniform>
+  /**
+   * Both uniform sets, as one preallocated pair.
+   *
+   * `set()` runs sixty times a second and used to iterate a `[this.uPlate,
+   * this.uInk]` literal, which is an array allocation per frame in a file whose
+   * stated contract is that nothing allocates after construction.
+   */
+  private readonly uBoth: Record<string, THREE.IUniform>[]
+  private n = 0
+  private readonly digits = new Int32Array(12)
+
+  constructor(atlas: Atlas) {
+    const g = quadGeometry()
+    this.advance = atlas.advance
+    this.aPos = new THREE.InstancedBufferAttribute(new Float32Array(NUM_CAP * 4), 4)
+    this.aCol = new THREE.InstancedBufferAttribute(new Float32Array(NUM_CAP * 4), 4)
+    for (const a of [this.aPos, this.aCol]) a.setUsage(THREE.DynamicDrawUsage)
+    g.setAttribute("iPos", this.aPos)
+    g.setAttribute("iCol", this.aCol)
+
+    // `iPos.z` is CAP HEIGHT in world units — the height of the ink itself,
+    // not of the atlas cell. Quoting sizes in ink makes the minimum-size rule
+    // in gfx.ts mean what it says: a 13px numeral has thirteen pixels of
+    // actual digit, which the old cell-height convention silently turned into
+    // about six.
+    const VERT = /* glsl */ `
+      attribute vec2 position;
+      attribute vec4 iPos;
+      attribute vec4 iCol;
+      varying vec2 vUv; varying vec4 vCol; varying float vAA;
+      uniform vec2 uCam; uniform float uSpan, uAspect, uCells, uCellPerCap, uCellAspect, uAAK, uPxPerWorld;
+      void main(){
+        vec2 uv = position + 0.5;
+        // DataTexture is not flipped on upload, so v is inverted here.
+        vUv = vec2((iPos.w + uv.x) / uCells, 1.0 - uv.y);
+        vCol = iCol;
+        float cell = iPos.z * uCellPerCap;
+        vec2 world = iPos.xy + position * cell * vec2(uCellAspect, 1.0);
+        // Antialias width, in field units, for exactly one screen pixel. The
+        // distance field is linear in atlas pixels, so this is arithmetic
+        // rather than a guess — and it is why the glyph is as crisp at twelve
+        // pixels as at a hundred.
+        vAA = clamp(uAAK / max(cell * uPxPerWorld, 0.0001) * 0.62, 0.006, 0.30);
+        vec2 ndc = (world - uCam) / (uSpan*0.5);
+        ndc.x /= uAspect;
+        gl_Position = vec4(ndc, 0.1, 1.0);
+      }
+    `
+    const FRAG = /* glsl */ `
+      precision highp float;
+      varying vec2 vUv; varying vec4 vCol; varying float vAA;
+      uniform sampler2D uAtlas;
+      uniform float uIso, uIso2, uPlate;
+      uniform vec3 uPlateCol;
+      void main(){
+        float d = texture2D(uAtlas, vUv).r;
+        float core = smoothstep(uIso - vAA, uIso + vAA, d);
+        if (uPlate > 0.5) {
+          // The plate is the same glyph read at a fatter iso-level, plus a
+          // wider, softer aura so a numeral still separates from a core that
+          // the bloom has blown to pure white.
+          float aura = smoothstep(uIso2 - vAA*2.2, uIso2 + vAA*2.2, d);
+          float a = max(core * 0.95, aura * 0.38) * vCol.a;
+          gl_FragColor = vec4(uPlateCol, a);
+          return;
+        }
+        gl_FragColor = vec4(vCol.rgb, core * vCol.a);
+      }
+    `
+
+    const shared = (): Record<string, THREE.IUniform> => ({
+      uAtlas: { value: atlas.texture },
+      uCam: { value: new THREE.Vector2() },
+      uSpan: { value: 400 },
+      uAspect: { value: 1 },
+      uCells: { value: GLYPH_COUNT },
+      uCellPerCap: { value: atlas.cellPerCap },
+      uCellAspect: { value: atlas.cellAspect },
+      uAAK: { value: atlas.aaK },
+      uPxPerWorld: { value: 1 },
+      uIso: { value: 0.5 },
+      uIso2: { value: atlas.auraIso },
+      uPlate: { value: 0 },
+      uPlateCol: { value: new THREE.Vector3(0.0, 0.012, 0.028) },
+    })
+
+    this.uPlate = shared()
+    this.uPlate.uIso!.value = atlas.padIso
+    this.uPlate.uPlate!.value = 1
+    this.uInk = shared()
+    this.uBoth = [this.uPlate, this.uInk]
+
+    const make = (u: Record<string, THREE.IUniform>): THREE.RawShaderMaterial =>
+      new THREE.RawShaderMaterial({
+        uniforms: u,
+        transparent: true,
+        blending: THREE.NormalBlending,
+        depthTest: false,
+        depthWrite: false,
+        vertexShader: VERT,
+        fragmentShader: FRAG,
+      })
+
+    // Two meshes over ONE instance buffer. Every plate lands before any ink
+    // does, which is the only way a four-digit number is safe: drawn glyph by
+    // glyph, digit n+1's plate would punch a hole in digit n's ink.
+    this.plate = new THREE.Mesh(g, make(this.uPlate))
+    this.plate.frustumCulled = false
+    this.plate.renderOrder = 190
+    this.mesh = new THREE.Mesh(g, make(this.uInk))
+    this.mesh.frustumCulled = false
+    this.mesh.renderOrder = 200
+  }
+
+  begin(): void {
+    this.n = 0
+  }
+
+  private glyph(x: number, y: number, cap: number, gi: number, r: number, g: number, b: number, a: number): void {
+    if (this.n >= NUM_CAP) return
+    const i = this.n++
+    const p = this.aPos.array as Float32Array
+    const c = this.aCol.array as Float32Array
+    p[i * 4] = x
+    p[i * 4 + 1] = y
+    p[i * 4 + 2] = cap
+    p[i * 4 + 3] = gi
+    c[i * 4] = r
+    c[i * 4 + 1] = g
+    c[i * 4 + 2] = b
+    c[i * 4 + 3] = a
+  }
+
+  /** Width of a signed integer at a given cap height, in world units. */
+  widthOf(v: number, cap: number): number {
+    const neg = v < 0
+    const count = splitDigits(v, this.digits)
+    return (count + (neg ? 1 : 0)) * cap * this.advance
+  }
+
+  /**
+   * Lay out a signed integer centred on (x, y) at cap height `cap`. Digits are
+   * extracted into a preallocated scratch array — no `String(n)` in the hot
+   * path.
+   */
+  number(v: number, x: number, y: number, cap: number, r: number, g: number, b: number, a: number): void {
+    if (a <= 0.004 || cap <= 0.0001) return
+    const neg = v < 0
+    const count = splitDigits(v, this.digits)
+    const total = count + (neg ? 1 : 0)
+    const step = cap * this.advance
+    let cx = x - ((total - 1) * step) / 2
+    if (neg) {
+      this.glyph(cx, y, cap, 10, r, g, b, a)
+      cx += step
+    }
+    for (let i = count - 1; i >= 0; i--) {
+      this.glyph(cx, y, cap, this.digits[i] as number, r, g, b, a)
+      cx += step
+    }
+  }
+
+  end(): void {
+    ;(this.mesh.geometry as THREE.InstancedBufferGeometry).instanceCount = this.n
+    if (this.n === 0) return
+    this.aPos.addUpdateRange(0, this.n * 4)
+    this.aCol.addUpdateRange(0, this.n * 4)
+    this.aPos.needsUpdate = true
+    this.aCol.needsUpdate = true
+  }
+
+  set(camX: number, camY: number, span: number, aspect: number, pxPerWorld: number): void {
+    for (const u of this.uBoth) {
+      ;(u.uCam!.value as THREE.Vector2).set(camX, camY)
+      u.uSpan!.value = span
+      u.uAspect!.value = aspect
+      u.uPxPerWorld!.value = pxPerWorld
+    }
+  }
+}

--- a/dynawalla/games/arena/src/render/post.ts
+++ b/dynawalla/games/arena/src/render/post.ts
@@ -1,0 +1,292 @@
+import * as THREE from "three"
+
+/**
+ * The post chain: threshold → downsample → separable blur → composite.
+ *
+ * Written by hand rather than assembled from `EffectComposer` because the tier
+ * governor needs to change the pass count and the render-target scale at
+ * runtime without rebuilding a pipeline, and because the composite is where
+ * three of the game's best effects live — the ripple, the aberration and the
+ * flash — and they want to share one full-screen pass, not three.
+ */
+
+const FS_TRI = new Float32Array([-1, -1, 3, -1, -1, 3])
+
+function fullscreen(material: THREE.Material): THREE.Mesh {
+  const g = new THREE.BufferGeometry()
+  g.setAttribute("position", new THREE.BufferAttribute(FS_TRI, 2))
+  g.boundingSphere = new THREE.Sphere(new THREE.Vector3(), 1e9)
+  const m = new THREE.Mesh(g, material)
+  m.frustumCulled = false
+  return m
+}
+
+const VS = /* glsl */ `
+attribute vec2 position;
+varying vec2 vUv;
+void main(){ vUv = position*0.5 + 0.5; gl_Position = vec4(position, 0.0, 1.0); }
+`
+
+export class Post {
+  private readonly renderer: THREE.WebGLRenderer
+  scene!: THREE.WebGLRenderTarget
+  private a!: THREE.WebGLRenderTarget
+  private b!: THREE.WebGLRenderTarget
+  private readonly quadScene = new THREE.Scene()
+  private readonly quadCam = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1)
+
+  private readonly thresholdMat: THREE.RawShaderMaterial
+  private readonly blurMat: THREE.RawShaderMaterial
+  private readonly compositeMat: THREE.RawShaderMaterial
+  private readonly quad: THREE.Mesh
+
+  private w = 2
+  private h = 2
+  private scale = 0.5
+  passes = 2
+  dispersion = true
+
+  constructor(renderer: THREE.WebGLRenderer) {
+    this.renderer = renderer
+    const half = renderer.capabilities.isWebGL2 ? THREE.HalfFloatType : THREE.UnsignedByteType
+
+    const mk = (w: number, h: number): THREE.WebGLRenderTarget =>
+      new THREE.WebGLRenderTarget(Math.max(1, w), Math.max(1, h), {
+        type: half,
+        minFilter: THREE.LinearFilter,
+        magFilter: THREE.LinearFilter,
+        depthBuffer: false,
+        stencilBuffer: false,
+        colorSpace: THREE.LinearSRGBColorSpace,
+      })
+    this.scene = mk(2, 2)
+    this.a = mk(2, 2)
+    this.b = mk(2, 2)
+
+    this.thresholdMat = new THREE.RawShaderMaterial({
+      uniforms: {
+        uTex: { value: null },
+        uThreshold: { value: 0.78 },
+        uKnee: { value: 0.30 },
+        uTexel: { value: new THREE.Vector2() },
+      },
+      vertexShader: VS,
+      fragmentShader: /* glsl */ `
+        precision highp float;
+        varying vec2 vUv;
+        uniform sampler2D uTex;
+        uniform float uThreshold, uKnee;
+        uniform vec2 uTexel;
+        vec3 tap(vec2 o){ return texture2D(uTex, vUv + o*uTexel).rgb; }
+        void main(){
+          // 4-tap box while downsampling: cheaper than a separate pass and it
+          // kills the shimmer you would otherwise get on a moving highlight.
+          vec3 c = (tap(vec2(-1.0,-1.0)) + tap(vec2(1.0,-1.0)) + tap(vec2(-1.0,1.0)) + tap(vec2(1.0,1.0))) * 0.25;
+          float l = max(c.r, max(c.g, c.b));
+          float s = max(0.0, l - uThreshold);
+          s = s*s / (s + uKnee);
+          gl_FragColor = vec4(c * (s / max(l, 1e-4)), 1.0);
+        }
+      `,
+      depthTest: false,
+      depthWrite: false,
+    })
+
+    this.blurMat = new THREE.RawShaderMaterial({
+      uniforms: {
+        uTex: { value: null },
+        uDir: { value: new THREE.Vector2(1, 0) },
+        uTexel: { value: new THREE.Vector2() },
+        uRadius: { value: 1 },
+      },
+      vertexShader: VS,
+      fragmentShader: /* glsl */ `
+        precision highp float;
+        varying vec2 vUv;
+        uniform sampler2D uTex;
+        uniform vec2 uDir, uTexel;
+        uniform float uRadius;
+        void main(){
+          // 9-tap gaussian with linear-sampling pairs — 5 fetches, 9 taps.
+          vec2 o = uDir * uTexel * uRadius;
+          vec3 c = texture2D(uTex, vUv).rgb * 0.227027;
+          c += (texture2D(uTex, vUv + o*1.3846).rgb + texture2D(uTex, vUv - o*1.3846).rgb) * 0.316216;
+          c += (texture2D(uTex, vUv + o*3.2308).rgb + texture2D(uTex, vUv - o*3.2308).rgb) * 0.070270;
+          gl_FragColor = vec4(c, 1.0);
+        }
+      `,
+      depthTest: false,
+      depthWrite: false,
+    })
+
+    this.compositeMat = new THREE.RawShaderMaterial({
+      uniforms: {
+        uScene: { value: null },
+        uBloom: { value: null },
+        uIntensity: { value: 1.15 },
+        uAberration: { value: 0 },
+        uFlash: { value: 0 },
+        uFlashColor: { value: new THREE.Vector3(1, 1, 1) },
+        uRipple: { value: new THREE.Vector4(0, 0, 0, 0) }, // cx, cy, t01, amp
+        uAspect: { value: 1 },
+        uVignette: { value: 0.34 },
+        uDispersion: { value: 1 },
+        uDesat: { value: 0 },
+      },
+      vertexShader: VS,
+      fragmentShader: /* glsl */ `
+        precision highp float;
+        varying vec2 vUv;
+        uniform sampler2D uScene, uBloom;
+        uniform float uIntensity, uAberration, uFlash, uAspect, uVignette, uDispersion, uDesat;
+        uniform vec3 uFlashColor;
+        uniform vec4 uRipple;
+
+        // Filmic-ish curve. Keeps the neon from clipping to flat white the
+        // moment three highlights overlap, which is what makes cheap bloom
+        // look cheap.
+        vec3 tonemap(vec3 x){
+          x *= 1.02;
+          vec3 a = x*(2.51*x + 0.03);
+          vec3 b = x*(2.43*x + 0.59) + 0.14;
+          return clamp(a/b, 0.0, 1.0);
+        }
+
+        void main(){
+          vec2 uv = vUv;
+          vec2 c = vec2((uv.x-0.5)*uAspect, uv.y-0.5);
+
+          // Shock ripple: a travelling annulus of refraction. One line of maths
+          // and it is the single most physical-feeling thing in the game.
+          if (uRipple.w > 0.0001) {
+            vec2 d = c - vec2(uRipple.x*uAspect, uRipple.y);
+            float r = length(d);
+            float front = uRipple.z;
+            float w = 0.12;
+            float band = exp(-pow((r - front)/w, 2.0));
+            uv += normalize(d + 1e-6) * band * uRipple.w * (1.0 - front) * 0.055;
+          }
+
+          float ab = uAberration;
+          vec3 col;
+          if (ab > 0.0005) {
+            vec2 dir = normalize(c + 1e-6) * ab;
+            col.r = texture2D(uScene, uv + dir*1.0).r;
+            col.g = texture2D(uScene, uv).g;
+            col.b = texture2D(uScene, uv - dir*1.0).b;
+          } else {
+            col = texture2D(uScene, uv).rgb;
+          }
+
+          vec3 bl;
+          if (uDispersion > 0.5) {
+            // Bloom fringing: the glow disperses outward slightly per channel.
+            vec2 dir = (uv - 0.5) * 0.0016;
+            bl.r = texture2D(uBloom, uv + dir).r;
+            bl.g = texture2D(uBloom, uv).g;
+            bl.b = texture2D(uBloom, uv - dir).b;
+          } else {
+            bl = texture2D(uBloom, uv).rgb;
+          }
+          col += bl * uIntensity;
+
+          col = mix(col, vec3(dot(col, vec3(0.299,0.587,0.114))), uDesat);
+          col += uFlashColor * uFlash;
+          col = tonemap(col);
+          // The filmic curve desaturates highlights, which is exactly wrong for
+          // bioluminescence. Put the chroma back after the curve, not before.
+          float lum = dot(col, vec3(0.2126, 0.7152, 0.0722));
+          col = clamp(mix(vec3(lum), col, 1.34), 0.0, 1.0);
+
+          float v = 1.0 - dot(c,c) * uVignette;
+          col *= clamp(v, 0.0, 1.0);
+
+          gl_FragColor = vec4(pow(max(col, 0.0), vec3(1.0/2.2)), 1.0);
+        }
+      `,
+      depthTest: false,
+      depthWrite: false,
+    })
+
+    this.quad = fullscreen(this.thresholdMat)
+    this.quadScene.add(this.quad)
+  }
+
+  resize(w: number, h: number, scale: number): void {
+    this.w = Math.max(2, Math.floor(w))
+    this.h = Math.max(2, Math.floor(h))
+    this.scale = scale
+    this.scene.setSize(this.w, this.h)
+    const bw = Math.max(2, Math.floor(this.w * scale))
+    const bh = Math.max(2, Math.floor(this.h * scale))
+    this.a.setSize(bw, bh)
+    this.b.setSize(bw, bh)
+    ;(this.compositeMat.uniforms.uAspect as THREE.IUniform).value = this.w / this.h
+  }
+
+  setScale(scale: number): void {
+    if (Math.abs(scale - this.scale) < 0.001) return
+    this.resize(this.w, this.h, scale)
+  }
+
+  get composite(): THREE.RawShaderMaterial {
+    return this.compositeMat
+  }
+
+  private draw(mat: THREE.Material, target: THREE.WebGLRenderTarget | null): void {
+    this.quad.material = mat
+    this.renderer.setRenderTarget(target)
+    this.renderer.render(this.quadScene, this.quadCam)
+  }
+
+  /** Runs the bloom chain and composites to the screen. */
+  run(): void {
+    const bw = this.a.width
+    const bh = this.a.height
+
+    if (this.passes <= 0) {
+      ;(this.compositeMat.uniforms.uBloom as THREE.IUniform).value = null
+      ;(this.compositeMat.uniforms.uScene as THREE.IUniform).value = this.scene.texture
+      ;(this.compositeMat.uniforms.uIntensity as THREE.IUniform).value = 0
+      this.draw(this.compositeMat, null)
+      return
+    }
+
+    const tu = this.thresholdMat.uniforms
+    ;(tu.uTex as THREE.IUniform).value = this.scene.texture
+    ;(tu.uTexel as THREE.IUniform).value.set(1 / this.w, 1 / this.h)
+    this.draw(this.thresholdMat, this.a)
+
+    const bu = this.blurMat.uniforms
+    ;(bu.uTexel as THREE.IUniform).value.set(1 / bw, 1 / bh)
+    // H then V leaves the result back in `src`, so each pass is self-contained
+    // and the two targets never need swapping — only the radius widens.
+    const src = this.a
+    const dst = this.b
+    for (let p = 0; p < this.passes; p++) {
+      ;(bu.uRadius as THREE.IUniform).value = 1 + p * 1.9
+      ;(bu.uTex as THREE.IUniform).value = src.texture
+      ;(bu.uDir as THREE.IUniform).value.set(1, 0)
+      this.draw(this.blurMat, dst)
+      ;(bu.uTex as THREE.IUniform).value = dst.texture
+      ;(bu.uDir as THREE.IUniform).value.set(0, 1)
+      this.draw(this.blurMat, src)
+    }
+
+    const cu = this.compositeMat.uniforms
+    ;(cu.uScene as THREE.IUniform).value = this.scene.texture
+    ;(cu.uBloom as THREE.IUniform).value = src.texture
+    ;(cu.uDispersion as THREE.IUniform).value = this.dispersion ? 1 : 0
+    this.draw(this.compositeMat, null)
+  }
+
+  dispose(): void {
+    this.scene.dispose()
+    this.a.dispose()
+    this.b.dispose()
+    this.thresholdMat.dispose()
+    this.blurMat.dispose()
+    this.compositeMat.dispose()
+    this.quad.geometry.dispose()
+  }
+}

--- a/dynawalla/games/arena/src/sim/depths.ts
+++ b/dynawalla/games/arena/src/sim/depths.ts
@@ -1,0 +1,261 @@
+/**
+ * The escalation spine.
+ *
+ * ARENA has no completion state. It has DEPTHS: bands of the water you sink
+ * into as the run goes on. Each depth changes the palette, the density, the
+ * temper of the rivals, and adds exactly one new thing to be afraid of.
+ *
+ * Two things about this file were wrong and were measured wrong. The band was
+ * chosen from CURRENT mass, so a bad patch dropped you back a depth: across a
+ * five-minute soak the water flipped between DRIFT and THE CURRENT and back,
+ * and the run oscillated instead of climbing — a treadmill, exactly what a
+ * growth game must never be. And there were only six bands with the first
+ * three set so far apart that a five-minute run saw TWO of them.
+ *
+ * So: nine bands, the index is monotone and never falls, and the clock is a
+ * FLOOR as well as a ceiling. Mass may run you two bands ahead of the clock —
+ * that is the reward for playing well — but the world sinks on its own whether
+ * you are winning or not, which is the Vampire Survivors bargain and the only
+ * honest way to make the twelfth minute different from the second.
+ */
+
+export type Depth = {
+  index: number
+  name: string
+  /** Mass at which this depth may be reached ahead of the clock. */
+  at: number
+  /** Water colour, linear RGB, deliberately near-black so numerals win. */
+  water: [number, number, number]
+  /** Ambient light seeping down from a surface you will never see. */
+  shaft: [number, number, number]
+  /** Player bioluminescence. */
+  self: [number, number, number]
+  /** Edible motes. */
+  food: [number, number, number]
+  /** Anything larger than you. */
+  threat: [number, number, number]
+  /** Density multiplier for motes. */
+  density: number
+  /** How hard rivals push. 0 = timid drifters, 1 = relentless. */
+  temper: number
+  /** Fraction of motes that carry a negative value. */
+  voidRate: number
+  /** Rivals that actively lock on and pursue. */
+  hunters: number
+  /** A single enormous slow core worth a fortune. */
+  leviathan: boolean
+  /** Question difficulty handed to the Host during a Resonance. */
+  difficulty: number
+}
+
+/**
+ * Nine looks, and they are meant to be nine looks — an arc, not a hue rotation.
+ * Cold blue, kelp green, a violet storm, volcanic ember, a bleached ice shelf,
+ * electric indigo, an almost totally black trench lit by one acid green, gold
+ * on oxblood, and finally white-hot on black where everything is a silhouette.
+ * A child should be able to say which depth a screenshot came from.
+ */
+export const DEPTHS: Depth[] = [
+  {
+    index: 0,
+    name: "DRIFT",
+    at: 0,
+    water: [0.004, 0.014, 0.038],
+    shaft: [0.10, 0.42, 0.72],
+    self: [0.62, 1.0, 0.80],
+    food: [0.16, 0.82, 1.0],
+    threat: [1.0, 0.14, 0.44],
+    density: 1.0,
+    temper: 0.22,
+    voidRate: 0,
+    hunters: 0,
+    leviathan: false,
+    difficulty: 2,
+  },
+  {
+    index: 1,
+    name: "THE CURRENT",
+    at: 90,
+    water: [0.004, 0.026, 0.030],
+    shaft: [0.10, 0.62, 0.54],
+    self: [0.86, 1.0, 0.62],
+    food: [0.22, 1.0, 0.58],
+    threat: [1.0, 0.10, 0.34],
+    density: 1.06,
+    temper: 0.34,
+    voidRate: 0.08,
+    hunters: 0,
+    leviathan: false,
+    difficulty: 3,
+  },
+  {
+    index: 2,
+    name: "THE CHURN",
+    at: 380,
+    water: [0.024, 0.008, 0.038],
+    shaft: [0.56, 0.24, 0.96],
+    self: [0.98, 0.82, 1.0],
+    food: [0.70, 0.44, 1.0],
+    threat: [1.0, 0.22, 0.28],
+    density: 1.08,
+    temper: 0.46,
+    voidRate: 0.12,
+    hunters: 1,
+    leviathan: false,
+    difficulty: 4,
+  },
+  {
+    index: 3,
+    name: "THE VENTS",
+    at: 1300,
+    water: [0.040, 0.010, 0.006],
+    shaft: [0.94, 0.32, 0.08],
+    self: [1.0, 0.86, 0.30],
+    food: [1.0, 0.48, 0.06],
+    threat: [1.0, 0.94, 0.42],
+    density: 1.02,
+    temper: 0.58,
+    voidRate: 0.15,
+    hunters: 2,
+    leviathan: true,
+    difficulty: 5,
+  },
+  {
+    index: 4,
+    name: "THE SHELF",
+    at: 4200,
+    water: [0.020, 0.027, 0.036],
+    shaft: [0.78, 0.90, 1.0],
+    self: [0.92, 0.99, 1.0],
+    food: [0.72, 0.96, 1.0],
+    threat: [1.0, 0.42, 0.06],
+    density: 1.0,
+    temper: 0.68,
+    voidRate: 0.16,
+    hunters: 2,
+    leviathan: false,
+    difficulty: 6,
+  },
+  {
+    index: 5,
+    name: "APEX",
+    at: 13000,
+    water: [0.020, 0.014, 0.052],
+    shaft: [0.62, 0.56, 1.0],
+    self: [1.0, 1.0, 1.0],
+    food: [0.50, 0.70, 1.0],
+    threat: [1.0, 0.20, 1.0],
+    density: 0.98,
+    temper: 0.78,
+    voidRate: 0.17,
+    hunters: 3,
+    leviathan: true,
+    difficulty: 7,
+  },
+  {
+    index: 6,
+    name: "THE ABYSSAL",
+    at: 40000,
+    water: [0.002, 0.007, 0.005],
+    shaft: [0.10, 0.36, 0.20],
+    self: [0.74, 1.0, 0.30],
+    food: [0.56, 1.0, 0.14],
+    threat: [1.0, 0.06, 0.16],
+    density: 0.94,
+    temper: 0.86,
+    voidRate: 0.18,
+    hunters: 4,
+    leviathan: true,
+    difficulty: 8,
+  },
+  {
+    index: 7,
+    name: "SOVEREIGN",
+    at: 120000,
+    water: [0.042, 0.008, 0.012],
+    shaft: [1.0, 0.62, 0.18],
+    self: [1.0, 0.94, 0.52],
+    food: [1.0, 0.76, 0.20],
+    threat: [0.30, 1.0, 1.0],
+    density: 0.90,
+    temper: 0.94,
+    voidRate: 0.19,
+    hunters: 5,
+    leviathan: true,
+    difficulty: 9,
+  },
+  {
+    index: 8,
+    name: "THE LAST LIGHT",
+    at: 350000,
+    water: [0.007, 0.006, 0.011],
+    shaft: [1.0, 0.98, 0.92],
+    self: [1.0, 1.0, 1.0],
+    food: [1.0, 1.0, 0.90],
+    threat: [1.0, 0.10, 0.62],
+    density: 0.86,
+    temper: 1.0,
+    voidRate: 0.20,
+    hunters: 6,
+    leviathan: true,
+    difficulty: 10,
+  },
+]
+
+/** Seconds of play after which the world sinks a band on its own. */
+export const DEPTH_CLOCK_SECONDS = 100
+
+/** The band a given mass has genuinely earned. */
+export function bandForMass(mass: number): number {
+  for (let k = DEPTHS.length - 1; k >= 0; k--) if (mass >= (DEPTHS[k] as Depth).at) return k
+  return 0
+}
+
+/**
+ * Band, plus how far through it we are (0..1) for palette blending.
+ *
+ * `floorBand` is the ratchet: pass the band you were in last frame and the
+ * water can never rise again. This is the fix for the oscillation — depth is a
+ * record of how deep the run has been, not a readout of how you are doing
+ * right now.
+ */
+export function depthFor(
+  mass: number,
+  seconds = Infinity,
+  floorBand = 0,
+): { depth: Depth; next: Depth; t: number } {
+  const byMass = bandForMass(mass)
+  let i = byMass
+  let tTime = 0
+  if (Number.isFinite(seconds)) {
+    const byClock = Math.floor(seconds / DEPTH_CLOCK_SECONDS)
+    // A run that is genuinely winning may sit two bands ahead of the clock.
+    // One was too mean — a measured optimal run had earned band seven inside
+    // ninety seconds and was still being shown band one — and unlimited would
+    // spend all nine looks in the first three minutes.
+    i = Math.max(byClock, Math.min(byMass, byClock + 2))
+    tTime = Math.min(1, Math.max(0, (seconds - i * DEPTH_CLOCK_SECONDS) / DEPTH_CLOCK_SECONDS))
+  }
+  i = Math.min(DEPTHS.length - 1, Math.max(i, floorBand))
+  const depth = DEPTHS[i] as Depth
+  const next = (DEPTHS[i + 1] ?? DEPTHS[DEPTHS.length - 1]) as Depth
+  const span = next.at - depth.at
+  const tMass = span > 0 ? Math.min(1, Math.max(0, (mass - depth.at) / span)) : 1
+  return { depth, next, t: Math.min(1, Math.max(tMass, tTime)) }
+}
+
+/**
+ * Past THE LAST LIGHT the named depths stop but the run does not. Everything
+ * keeps compounding — on mass for a player who is winning, on the clock for a
+ * player who is merely surviving — so the eighteenth minute still escalates.
+ */
+export function overdrive(mass: number, seconds = Infinity): number {
+  const last = DEPTHS[DEPTHS.length - 1] as Depth
+  const byMass = mass > last.at ? Math.log(mass / last.at) / Math.log(6) : 0
+  let byTime = 0
+  if (Number.isFinite(seconds)) {
+    const t0 = (DEPTHS.length - 1) * DEPTH_CLOCK_SECONDS
+    byTime = seconds > t0 ? (seconds - t0) / 260 : 0
+  }
+  return Math.min(1.6, Math.max(byMass, byTime))
+}

--- a/dynawalla/games/arena/src/sim/sim.test.ts
+++ b/dynawalla/games/arena/src/sim/sim.test.ts
@@ -1,0 +1,435 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { absorbGain, devourGain, radiusForValue, viewSpanFor, arenaRadiusFor, World, FLOOR_MASS } from "./world.ts"
+import { DEPTHS, depthFor, overdrive } from "./depths.ts"
+import { specFor } from "../core/tier.ts"
+import { createStubHost } from "../host/stubHost.ts"
+import type { Host, Question } from "../contract.ts"
+
+test("absorption saturates, and saturates harder as you grow", () => {
+  for (const mass of [10, 60, 500, 4000, 90000, 3_000_000]) {
+    let peak = 0
+    for (let v = 1; v <= mass; v = Math.max(v + 1, Math.round(v * 1.05))) {
+      const g = absorbGain(v, mass)
+      assert.ok(g >= 1, "a swallow always gives at least one")
+      assert.ok(Number.isInteger(g))
+      assert.ok(g <= v + 1, `gain ${g} exceeded the mote's own value ${v}`)
+      peak = Math.max(peak, g)
+    }
+    // mass/(1+K) with K = 6, plus a rounding unit.
+    assert.ok(peak <= mass / 7 + 1, `peak gain ${peak} broke the cap at mass ${mass}`)
+  }
+
+  // The early game must stay explosive: below the soft point the curve is
+  // within a few per cent of the flat-K one it replaced.
+  //
+  // This assertion used to read `absorbGain(10, 10) >= 10 / 7 * 0.92` and could
+  // never have passed, against either curve. `absorbGain` returns an INTEGER,
+  // and at the smallest mass in the game the rounding quantum is the whole
+  // quantity under test: the flat-K curve it names as its reference is
+  // round(10 / 7) = 1, not 1.43, so it was comparing a rounded number against
+  // an unrounded target and failing on the rounding rather than on the nerf it
+  // meant to catch. The property is real; it just has to be stated against the
+  // reference put through the same rounding, over the mass range the claim
+  // actually covers — the tens to low hundreds, which is the first two minutes.
+  const flatK = (value: number, mass: number): number =>
+    Math.max(1, Math.round(value / (1 + (6 * value) / Math.max(1, mass))))
+  for (const m of [10, 20, 40, 80, 120]) {
+    assert.ok(
+      absorbGain(m, m) >= flatK(m, m) * 0.92,
+      `the first minute was nerfed at mass ${m}: ${absorbGain(m, m)} vs ${flatK(m, m)}`,
+    )
+  }
+
+  // …and the late game must stop being an exponential. A near-tie is a fixed
+  // fraction of you only until it isn't; past that the fraction itself falls.
+  const frac = (m: number): number => absorbGain(Math.round(m * 0.98), m) / m
+  assert.ok(frac(1e4) < frac(1e2), "the near-tie fraction must fall with mass")
+  assert.ok(frac(1e7) < frac(1e4) * 0.5, "…and keep falling, or a bot finds the exponential")
+})
+
+/**
+ * The kill curve is deliberately mass-INVARIANT, unlike the mote curve, and the
+ * asymmetry is asserted here rather than left to a comment. See DEVOUR_K in
+ * world.ts: the near-tie mote is a manufactured, continuous supply and the
+ * rival is not, so the sqrt(mass) tightening belongs on one and not the other.
+ */
+test("devouring a rival is generous but still bounded", () => {
+  for (const mass of [10, 500, 90000]) {
+    const equal = devourGain(mass, mass)
+    assert.ok(equal > mass * 0.22, "eating your own size should feel enormous")
+    assert.ok(equal <= mass * 0.32 + 1, "…but it may never approach a doubling")
+    // Monotonic in the prey's size.
+    let prev = 0
+    for (let m = 1; m <= mass * 3; m = Math.max(m + 1, Math.round(m * 1.1))) {
+      const g = devourGain(m, mass)
+      assert.ok(g >= prev, "gain must never fall as prey grows")
+      prev = g
+    }
+  }
+})
+
+test("one radius law for everything, and the membrane always sits outside the frame", () => {
+  for (const v of [1, 4, 25, 900, 40000]) {
+    assert.ok(radiusForValue(v) > 0)
+  }
+  assert.ok(radiusForValue(900) > radiusForValue(100))
+  for (const m of [10, 120, 2200, 20000, 5_000_000]) {
+    assert.ok(
+      arenaRadiusFor(m) > viewSpanFor(m) * 1.5,
+      `the arena fell inside the view at mass ${m} — the player can see the void`,
+    )
+  }
+})
+
+test("depth bands are ordered, cover every mass, and escalate past the last one", () => {
+  for (let i = 1; i < DEPTHS.length; i++) {
+    assert.ok((DEPTHS[i] as { at: number }).at > (DEPTHS[i - 1] as { at: number }).at)
+    assert.ok((DEPTHS[i] as { temper: number }).temper >= (DEPTHS[i - 1] as { temper: number }).temper)
+  }
+  assert.equal(depthFor(0).depth.index, 0)
+  assert.equal(depthFor(1e9).depth.index, DEPTHS.length - 1)
+  for (const m of [1, 50, 500, 5000, 50000]) {
+    const { t } = depthFor(m)
+    assert.ok(t >= 0 && t <= 1)
+  }
+  // The clock caps how far ahead of itself a snowballing player can run, so
+  // the bands cannot all be spent in the first three minutes.
+  assert.equal(depthFor(1e9, 0).depth.index, 2)
+  assert.equal(depthFor(1e9, 60 * 3).depth.index, 3)
+  assert.ok(depthFor(1e9, 60 * 13).depth.index === DEPTHS.length - 1)
+  // The clock is also a FLOOR, and this assertion is the reversal of the one
+  // that used to live here. Judged: a five-minute soak saw exactly two depths,
+  // because the band tracked mass and a player who was not winning simply never
+  // moved. The world now sinks whether you are winning or not.
+  assert.ok(depthFor(10, 60 * 5).depth.index >= 3, "the world must escalate on the clock too")
+  assert.equal(depthFor(10, 60 * 60).depth.index, DEPTHS.length - 1)
+  // The ratchet: a band, once entered, can never be left.
+  for (let i = 0; i < DEPTHS.length; i++) {
+    assert.equal(depthFor(0, 0, i).depth.index, i, "floorBand must pin the band")
+    assert.ok(depthFor(0, 1, i).depth.index >= i)
+  }
+  assert.equal(overdrive(10), 0)
+  assert.ok(overdrive(500000) > overdrive(50000))
+  assert.ok(overdrive(1e12) <= 1.6, "overdrive must stay bounded or the tuning it scales runs away")
+})
+
+test("a run climbs: the band never falls and a banked rung cannot be taken back", () => {
+  const world = new World(createStubHost({ seed: 31 }), specFor("high"), 9)
+  let lowestSinceBand = Infinity
+  let band = 0
+  // Six minutes of a deliberately BAD player: never aims, never surges, walks
+  // into everything. This is the profile that used to oscillate 154 → 65 → 332
+  // → 122 → 152 and finish where it started.
+  for (let f = 0; f < 60 * 60 * 6; f++) {
+    world.aimX = Math.sin(f * 0.011) * 1400
+    world.aimY = Math.cos(f * 0.008) * 1400
+    world.step(1 / 60)
+    assert.ok(world.depth.index >= band, `band fell from ${band} to ${world.depth.index}`)
+    if (world.depth.index > band) {
+      band = world.depth.index
+      lowestSinceBand = Infinity
+    }
+    lowestSinceBand = Math.min(lowestSinceBand, world.mass)
+    assert.ok(
+      world.mass >= world.checkpoint - 1e-6,
+      `mass ${world.mass} fell through the banked checkpoint ${world.checkpoint}`,
+    )
+  }
+  assert.ok(band >= 3, `six minutes must show more than a couple of depths, saw ${band + 1}`)
+  assert.ok(lowestSinceBand >= FLOOR_MASS)
+})
+
+/**
+ * The regression that matters most, and the reason it asserts on *shape*
+ * rather than on a number.
+ *
+ * Three separate bugs each turned a twenty-minute climb into an exponential
+ * explosion — an uncapped near-tie mote, an uncapped rival kill, and a
+ * progress floor that let a rupture *pay* the player. Every one of them was
+ * invisible in a thirty-second look at the screen and obvious after one
+ * simulated run.
+ *
+ * What must hold is not "mass stays below N". Growth in this genre is
+ * deliberately proportional and deliberately endless. What must hold is that
+ * the *relative* experience survives: the first minute is a climb and not a
+ * detonation, and at the end of twenty minutes the ladder is still live —
+ * there are still things in the water that can eat you. An economy that has
+ * run away trivialises the arena, and that is the failure worth failing on.
+ */
+test("a twenty-minute run escalates without trivialising the arena", () => {
+  const answers: { correct: boolean }[] = []
+  const host = createStubHost({ seed: 0xa11ce, onReport: (r) => answers.push({ correct: r.correct }) })
+  const world = new World(host, specFor("mid"), 0xbeef)
+  let seen = -1
+  let sphere = -1
+  let peak = 0
+  let massAtOneMinute = 0
+
+  for (let f = 0; f < 60 * 60 * 20; f++) {
+    const res = world.resonance
+    if (res.active && res.phase === 2) {
+      if (seen !== res.openedAt) {
+        seen = res.openedAt
+        sphere = res.spheres[res.correctSlot] as number
+      }
+      if (sphere >= 0 && world.malive[sphere]) {
+        world.aimX = world.mx[sphere] as number
+        world.aimY = world.my[sphere] as number
+      }
+    } else {
+      seen = -1
+      let best = -1
+      let bestScore = -1
+      for (let i = 0; i < world.mx.length; i++) {
+        if (!world.malive[i] || world.mkind[i] === 3) continue
+        const v = world.mval[i] as number
+        if (v < 0 || v >= world.mass * 0.92) continue
+        const d = Math.hypot((world.mx[i] as number) - world.px, (world.my[i] as number) - world.py)
+        const s = (v + 6) / (d + 90)
+        if (s > bestScore) {
+          bestScore = s
+          best = i
+        }
+      }
+      if (best >= 0) {
+        world.aimX = world.mx[best] as number
+        world.aimY = world.my[best] as number
+      } else {
+        world.aimX = world.px + Math.cos(world.time) * 600
+        world.aimY = world.py + Math.sin(world.time * 0.8) * 600
+      }
+    }
+    world.step(1 / 60)
+    peak = Math.max(peak, world.mass)
+    if (f === 60 * 60) massAtOneMinute = world.mass
+
+    assert.ok(Number.isFinite(world.mass), `mass went non-finite at frame ${f}`)
+    assert.ok(world.mass >= FLOOR_MASS, `mass fell through the floor at frame ${f}`)
+  }
+
+  // The opening minute is a climb, not a detonation. Every economy bug this
+  // test has caught blew past 30,000 inside sixty seconds.
+  assert.ok(massAtOneMinute > 60, `no escalation in the first minute: ${Math.round(massAtOneMinute)}`)
+  assert.ok(massAtOneMinute < 30_000, `first minute detonated: ${Math.round(massAtOneMinute)}`)
+  assert.ok(peak > 400, `run never escalated; peak mass was only ${Math.round(peak)}`)
+
+  // The ladder is still live after twenty minutes: something out there can
+  // still eat you, and the board is still populated.
+  let bigger = 0
+  let alive = 0
+  for (let k = 0; k < world.rmass.length; k++) {
+    if (!world.ralive[k]) continue
+    alive++
+    if ((world.rmass[k] as number) > world.mass) bigger++
+  }
+  assert.ok(alive >= 8, `the arena emptied out: only ${alive} rivals left`)
+  assert.ok(bigger >= 1, "nothing in the water can eat the player any more — the economy ran away")
+
+  // The curriculum beat kept firing, and the host heard about every answer.
+  assert.ok(answers.length >= 15, `only ${answers.length} questions were answered in twenty minutes`)
+  assert.ok(world.time > 1190 && world.time < 1210)
+})
+
+/**
+ * The mathematics has to survive the round trip out to the renderer and back.
+ *
+ * A sphere's drawn label goes through `mval`, an Int32Array, because that is
+ * what the numeral layer consumes. What must NOT go through it is the answer
+ * reported to the Host, which is the child's work and drives a mastery model:
+ * it is the Host's own option string, byte for byte. And the verdict is slot
+ * identity, never a comparison of two numbers, so there is no arithmetic
+ * anywhere on the path that decides whether a child was right.
+ */
+test("the answer reported to the host is the host's own string, and slot identity decides", () => {
+  const reports: { questionId: string; correct: boolean; ms: number; answered: string }[] = []
+  const asked = new Map<string, Question>()
+  const stub = createStubHost({ seed: 5, onReport: (r) => reports.push(r) })
+  const host: Host = {
+    next: (o) => {
+      const q = stub.next(o)
+      asked.set(q.id, q)
+      return q
+    },
+    report: (r) => stub.report(r),
+    haptic: (k) => stub.haptic(k),
+    prefersReducedMotion: () => false,
+  }
+
+  const world = new World(host, specFor("low"), 77)
+  for (let f = 0; f < 60 * 60 * 6; f++) {
+    const res = world.resonance
+    if (res.active && res.phase === 2) {
+      // Alternate right and wrong on purpose, so both branches of the report
+      // are exercised and a verdict that is always `true` cannot pass.
+      const want = reports.length % 2 === 0 ? res.correctSlot : (res.correctSlot + 1) % 4
+      const i = res.spheres[want] as number
+      if (i >= 0 && world.malive[i]) {
+        world.aimX = world.mx[i] as number
+        world.aimY = world.my[i] as number
+      }
+    } else {
+      world.aimX = world.px + Math.cos(world.time * 0.7) * 500
+      world.aimY = world.py + Math.sin(world.time * 0.5) * 500
+    }
+    world.step(1 / 60)
+  }
+
+  assert.ok(reports.length >= 6, `only ${reports.length} answers were reported in six minutes`)
+  assert.ok(
+    reports.some((r) => r.correct) && reports.some((r) => !r.correct),
+    "the run never produced both a right and a wrong answer, so the verdict is untested",
+  )
+  for (const r of reports) {
+    const q = asked.get(r.questionId)
+    assert.ok(q, `a report arrived for a question the host never issued: ${r.questionId}`)
+    const options = [q.answer, ...q.distractors]
+    assert.ok(
+      options.includes(r.answered),
+      `answered "${r.answered}" is not one of the host's options ${JSON.stringify(options)}`,
+    )
+    // The verdict is decided by slot, the string is carried verbatim; if those
+    // two ever disagree the game is marking correct work wrong.
+    assert.equal(r.correct, r.answered === q.answer, `verdict and reported answer disagree on ${r.questionId}`)
+    assert.ok(r.ms >= 0 && Number.isFinite(r.ms), `latency was not a sane number: ${r.ms}`)
+  }
+
+  // The specific round trip that would be silent: an answer past 2^31, which
+  // an Int32Array wraps to a *different number* rather than to an error. The
+  // stub host never emits one; a real curriculum eventually will.
+  const big: string[] = ["8030000000", "8030000001", "8029999999", "8030000010"]
+  const bigReports: { correct: boolean; answered: string }[] = []
+  const bigHost: Host = {
+    next: () => ({
+      id: "big-1",
+      prompt: "big",
+      answer: big[0] as string,
+      distractors: big.slice(1),
+      domain: "compare",
+      difficulty: 5,
+    }),
+    report: (r) => bigReports.push({ correct: r.correct, answered: r.answered }),
+    haptic: () => {},
+    prefersReducedMotion: () => false,
+  }
+  const bw = new World(bigHost, specFor("low"), 21)
+  for (let f = 0; f < 60 * 60 * 2 && bigReports.length === 0; f++) {
+    const res = bw.resonance
+    if (res.active && res.phase === 2) {
+      const i = res.spheres[res.correctSlot] as number
+      if (i >= 0 && bw.malive[i]) {
+        bw.aimX = bw.mx[i] as number
+        bw.aimY = bw.my[i] as number
+      }
+    }
+    bw.step(1 / 60)
+  }
+  assert.equal(bigReports.length, 1, "the big-number resonance never resolved")
+  assert.equal((bigReports[0] as { correct: boolean }).correct, true)
+  assert.equal(
+    (bigReports[0] as { answered: string }).answered,
+    "8030000000",
+    "an answer past 2^31 came back as a different number — it went through the Int32Array",
+  )
+})
+
+/**
+ * The other exploit, and the one that decided the shape of `devourGain`.
+ *
+ * The twenty-minute test above flies a bot that eats motes. This one flies the
+ * bot a determined child actually becomes: it ignores food entirely and hunts
+ * nothing but the largest rival it is still legally allowed to swallow, which
+ * is the single highest-yield action in the game. If kills are an exponential
+ * route, this is the run that finds it.
+ *
+ * It asserts a *legibility* bound rather than a balance one. The premise of the
+ * whole game is telling 3,418 from 3,481 at speed, and that premise does not
+ * survive the player's own core reading 1,301,388,804 — which is what an
+ * earlier uncapped curve actually printed. Five or six digits after twenty
+ * minutes of the strongest possible play is the contract.
+ */
+test("hunting nothing but rivals for twenty minutes is not an exponential", () => {
+  const world = new World(createStubHost({ seed: 7 }), specFor("mid"), 4242)
+  let peak = 0
+
+  for (let f = 0; f < 60 * 60 * 20; f++) {
+    let best = -1
+    let bestScore = -1
+    for (let k = 0; k < world.rmass.length; k++) {
+      if (!world.ralive[k]) continue
+      const m = world.rmass[k] as number
+      // Only what the collision rule will actually let the player eat.
+      if (m >= world.mass / 1.07) continue
+      const d = Math.hypot((world.rx[k] as number) - world.px, (world.ry[k] as number) - world.py)
+      const s = m / (d + 200)
+      if (s > bestScore) {
+        bestScore = s
+        best = k
+      }
+    }
+    if (best >= 0) {
+      world.aimX = world.rx[best] as number
+      world.aimY = world.ry[best] as number
+    } else {
+      // Nothing edible on the board: fall back to food so the bot keeps growing
+      // into range rather than stalling and proving nothing.
+      let bm = -1
+      let bs = -1
+      for (let i = 0; i < world.mx.length; i++) {
+        if (!world.malive[i] || world.mkind[i] === 3) continue
+        const v = world.mval[i] as number
+        if (v < 0 || v >= world.mass * 0.95) continue
+        const d = Math.hypot((world.mx[i] as number) - world.px, (world.my[i] as number) - world.py)
+        const s = (v + 6) / (d + 90)
+        if (s > bs) {
+          bs = s
+          bm = i
+        }
+      }
+      if (bm >= 0) {
+        world.aimX = world.mx[bm] as number
+        world.aimY = world.my[bm] as number
+      }
+    }
+    world.step(1 / 60)
+    peak = Math.max(peak, world.mass)
+    assert.ok(Number.isFinite(world.mass), `mass went non-finite at frame ${f}`)
+  }
+
+  assert.ok(peak > 2000, `the kill bot never got going; peak was only ${Math.round(peak)}`)
+  assert.ok(peak < 1e6, `kills ran away: peak mass ${Math.round(peak)} is not a readable number`)
+
+  // …and it must not have eaten the world doing it.
+  let bigger = 0
+  let alive = 0
+  for (let k = 0; k < world.rmass.length; k++) {
+    if (!world.ralive[k]) continue
+    alive++
+    if ((world.rmass[k] as number) > world.mass) bigger++
+  }
+  assert.ok(alive >= 8, `the arena emptied out: only ${alive} rivals left`)
+  assert.ok(bigger >= 1, "nothing in the water can eat the player any more — the economy ran away")
+})
+
+test("a rupture costs real mass at your peak, and can never pay you", () => {
+  const host = createStubHost({ seed: 3 })
+  const world = new World(host, specFor("low"), 11)
+  const rupture = (world as unknown as { rupture(m: number): void }).rupture.bind(world)
+
+  // The ordinary case: at your high water mark a rupture hurts, a lot, and it
+  // stops at the checkpoint rather than deleting the run.
+  world.mass = 5000
+  world.bestMass = 5000
+  rupture(9999)
+  assert.ok(world.mass < 5000 * 0.95, `a rupture at your peak must hurt: 5000 -> ${world.mass}`)
+  assert.ok(world.mass >= world.checkpoint - 1e-6, "a rupture must never break the checkpoint")
+
+  // The pathological case that once printed six orders of magnitude of free
+  // mass: a high water mark sitting far ABOVE your current mass. It may cost
+  // nothing; it may never hand anything back.
+  world.mass = 5000
+  world.bestMass = 40000
+  rupture(9999)
+  assert.ok(world.mass <= 5000, `rupture paid the player: 5000 -> ${world.mass}`)
+  assert.ok(world.mass >= FLOOR_MASS)
+})

--- a/dynawalla/games/arena/src/sim/world.ts
+++ b/dynawalla/games/arena/src/sim/world.ts
@@ -1,0 +1,1786 @@
+import { Rng } from "../core/rng.ts"
+import { Grid } from "../core/grid.ts"
+import { tidyValue } from "../core/digits.ts"
+import { bandForMass, DEPTHS, depthFor, overdrive, type Depth } from "./depths.ts"
+import type { TierSpec } from "../core/tier.ts"
+import type { Host, Question } from "../contract.ts"
+
+/*
+ * ARENA — the simulation.
+ *
+ * One rule, stated by the picture rather than by a sentence: radius is
+ * sqrt(value) for absolutely everything on screen, so "smaller than me" is
+ * something you see before you read it, and the printed number is only there
+ * to settle the near-ties. That is the whole tutorial and it takes three
+ * seconds.
+ *
+ * Everything below is structure-of-arrays over typed arrays. After construction
+ * this file allocates nothing per frame: no object literals in `step`, no
+ * closures created in a loop, no array growth. Events are handed out of a
+ * preallocated ring.
+ */
+
+// ---------------------------------------------------------------------------
+// Tuning
+// ---------------------------------------------------------------------------
+
+/** radius = R_K * sqrt(value). One law for motes, rivals and the player. */
+export const R_K = 9
+export const MOTE_MIN_R = 16
+export const START_MASS = 10
+/** Mass below which you cannot fall. You always have something to play with. */
+export const FLOOR_MASS = 6
+
+const MAX_MOTES = 360
+
+/**
+ * Broad-phase resolution. The cell COUNT is fixed here; the cell SIZE is set
+ * per frame from `gridSpan`, so the grid costs the same 62×62 whether the
+ * player is at mass 10 or mass 350,000.
+ */
+const GRID_COLS = 62
+
+/**
+ * Food value scales as `FOOD_A * mass^FOOD_B`, not as a fraction of mass.
+ * A fraction compounds, and compounding turns a twenty-minute climb into a
+ * ninety-second explosion followed by nothing. These two numbers are the
+ * whole difficulty curve and they were fitted by simulating full runs.
+ */
+const FOOD_A = 0.62
+const FOOD_B = 0.60
+
+/**
+ * How much of a mote actually becomes you.
+ *
+ * A mote's printed number is a SIZE — the thing you compare against your own
+ * size, which is the entire mathematics of this game and is exact. It is not
+ * an addend: a fish that swallows a fish nearly its own size does not double.
+ * Absorption saturates, and the cap `mass / (1 + ABSORB_K)` means no single
+ * mote can ever be worth more than a seventh of you.
+ *
+ * Without this, the sliver of the near-tie band that sits just below your mass
+ * is a free doubling, a child finds it in ninety seconds, and a twenty-minute
+ * climb becomes an exponential explosion. Measured: it did, every run.
+ */
+const ABSORB_K = 6
+
+/**
+ * …and the mass at which that saturation itself starts to tighten.
+ *
+ * A constant K makes every near-tie worth a FIXED FRACTION of you, and a fixed
+ * fraction repeated is an exponential. Measured with a bot that simply always
+ * chased the largest thing it could still swallow — which is the obvious
+ * strategy in this genre and a child will find it — mass went 273 → 3,330,895
+ * → 1,301,388,804 across three hundred seconds. That is not a balance problem
+ * so much as a *legibility* problem: the entire premise of the game is telling
+ * 3,418 from 3,481, and it cannot survive the player's own core reading
+ * 1,301,388,804.
+ *
+ * So K grows as sqrt(mass) past this point, which turns dM/dt ∝ M into
+ * dM/dt ∝ sqrt(M): polynomial, not exponential, and a twenty-minute run of the
+ * strongest possible play now finishes in five or six digits instead of ten.
+ * Below SOFT it is within a hair of the old curve, so the first two minutes —
+ * the part that has to feel like an explosion — are untouched.
+ */
+const ABSORB_SOFT = 900
+
+export function absorbGain(value: number, mass: number): number {
+  if (value <= 0) return 0
+  const k = ABSORB_K * Math.sqrt(1 + Math.max(0, mass) / ABSORB_SOFT)
+  return Math.max(1, Math.round(value / (1 + (k * value) / Math.max(1, mass))))
+}
+
+/**
+ * Swallowing a rival is the payoff moment of the whole genre, so it saturates
+ * far more generously: taking down something your own size is worth about a
+ * third of you, at every size, forever. It still saturates, because uncapped it
+ * is a doubling, and a doubling that repeats is the same explosion by another
+ * route — measured at 216 kills and eight orders of magnitude in a twenty-
+ * minute run.
+ *
+ * It deliberately does NOT get the sqrt(mass) tightening ABSORB_SOFT applies,
+ * and the asymmetry is the point. The near-tie *mote* is an exploit because the
+ * game manufactures a continuous supply of them: about one mote in seven is
+ * drawn from a band straddling your own mass, on purpose, because that is where
+ * the place-value comparison lives. A *rival* is not a supply. There are at most
+ * MAX_RIVALS of them, they respawn on a timer, and one is only edible below
+ * `mass / 1.06`, so kills are rate-limited by the world rather than by the
+ * curve. Measured with a bot that hunts nothing but the largest legally edible
+ * rival for twenty minutes: flat K peaks at 34,456 and a tightened K at 11,442
+ * — both five digits, neither an explosion. The tightening bought no safety and
+ * cost the genre its payoff moment, so it is not taken.
+ */
+const DEVOUR_K = 2.6
+
+export function devourGain(rivalMass: number, mass: number): number {
+  if (rivalMass <= 0) return 0
+  return Math.max(1, Math.round(rivalMass / (1 + (DEVOUR_K * rivalMass) / Math.max(1, mass))))
+}
+const MAX_RIVALS = 26
+const MAX_EVENTS = 96
+
+/** World units of view across the smaller screen dimension. */
+export function viewSpanFor(mass: number): number {
+  return R_K * Math.sqrt(mass) * 11 + 150
+}
+
+export function radiusForValue(v: number): number {
+  return Math.max(MOTE_MIN_R, R_K * Math.sqrt(Math.abs(v)))
+}
+
+export function arenaRadiusFor(mass: number): number {
+  // The membrane must always sit well outside the frame. Tied to a constant it
+  // fell *inside* the view once you were large, and the picture became a lit
+  // disc floating in a black void with the player pinned to the edge.
+  return Math.max(2600, viewSpanFor(mass) * 3.4)
+}
+
+// Mote kinds.
+export const MK_FOOD = 0
+export const MK_VOID = 1
+export const MK_SHED = 2
+export const MK_ANSWER = 3
+
+// Rival behaviour states.
+export const RS_FEED = 0
+export const RS_FLEE = 1
+export const RS_HUNT = 2
+
+// ---------------------------------------------------------------------------
+// Events — the presentation layer's only input
+// ---------------------------------------------------------------------------
+
+export type EventKind =
+  | "absorb"
+  | "sting"
+  | "rupture"
+  | "kill"
+  | "flip"
+  | "depth"
+  | "held"
+  | "resonance-open"
+  | "resonance-hit"
+  | "resonance-miss"
+  | "resonance-fade"
+  | "shockwave"
+  | "rival-death"
+
+export type GameEvent = {
+  kind: EventKind
+  x: number
+  y: number
+  /** Magnitude — mass gained, mass lost, radius of a wave. */
+  a: number
+  /** Secondary — combo, value, depth index. */
+  b: number
+  r: number
+  g: number
+  bl: number
+}
+
+function blankEvent(): GameEvent {
+  return { kind: "absorb", x: 0, y: 0, a: 0, b: 0, r: 1, g: 1, bl: 1 }
+}
+
+// ---------------------------------------------------------------------------
+// Resonance — the curriculum beat
+// ---------------------------------------------------------------------------
+
+export type Resonance = {
+  active: boolean
+  /** 0 = closed, 1 = opening, 2 = live, 3 = resolving. */
+  phase: number
+  t: number
+  duration: number
+  question: Question | null
+  /** Indices into the mote arrays for the four spheres. */
+  spheres: Int32Array
+  /**
+   * The option string the Host handed us, per sphere, kept verbatim.
+   *
+   * The sphere's *drawn* label goes through `mval`, an Int32Array, because the
+   * renderer needs it as a number. What gets reported back to the Host must not
+   * take that round trip: `answered` is the child's answer and it is the Host's
+   * own string, byte for byte, never a value that has been through a typed
+   * array's range. The judgement itself is slot identity — `slot ===
+   * correctSlot` — so no arithmetic, exact or otherwise, decides whether a
+   * child was right.
+   */
+  labels: string[]
+  /** Which sphere index holds the answer. */
+  correctSlot: number
+  openedAt: number
+  /**
+   * Milliseconds from opening to the answer being registered, frozen at the
+   * moment of the answer. The harness used to recompute this from `openedAt`
+   * on every frame of the 0.9 s resolve, so the metric it reported was the
+   * answer latency plus however much of the celebration had played.
+   */
+  answerMs: number
+  /** Radius of the sphere ring — also sets the player's traversal speed. */
+  ringR: number
+  /** Set for the resolve animation. */
+  chosen: number
+  wasCorrect: boolean
+}
+
+// ---------------------------------------------------------------------------
+// World
+// ---------------------------------------------------------------------------
+
+export class World {
+  readonly rng: Rng
+  private readonly host: Host
+
+  // -- player -------------------------------------------------------------
+  px = 0
+  py = 0
+  pvx = 0
+  pvy = 0
+  mass = START_MASS
+  /** Smoothed mass used for radius/camera so absorbs read as growth, not a jump. */
+  massVis = START_MASS
+  invuln = 0
+  /** Short flinch after a sting, so a cluster costs one mistake, not five. */
+  stingGrace = 0
+  surging = false
+  combo = 0
+  bestMass = START_MASS
+  deepest = 0
+  ruptures = 0
+  absorbed = 0
+  /** Set by input each frame, in world space. */
+  aimX = 0
+  aimY = 120
+  /** Set by the renderer so spawns can land just outside the actual frame. */
+  viewAspect = 1.6
+
+  // -- motes (SoA) --------------------------------------------------------
+  readonly mx = new Float32Array(MAX_MOTES)
+  readonly my = new Float32Array(MAX_MOTES)
+  readonly mvx = new Float32Array(MAX_MOTES)
+  readonly mvy = new Float32Array(MAX_MOTES)
+  readonly mval = new Int32Array(MAX_MOTES)
+  readonly mr = new Float32Array(MAX_MOTES)
+  readonly mkind = new Uint8Array(MAX_MOTES)
+  readonly malive = new Uint8Array(MAX_MOTES)
+  readonly mphase = new Float32Array(MAX_MOTES)
+  /** 0 = threat, 1 = edible. Animated, so the flip is a visible event. */
+  readonly mflip = new Float32Array(MAX_MOTES)
+  readonly mborn = new Float32Array(MAX_MOTES)
+  moteCount = 0
+
+  // -- rivals (SoA) -------------------------------------------------------
+  readonly rx = new Float32Array(MAX_RIVALS)
+  readonly ry = new Float32Array(MAX_RIVALS)
+  readonly rvx = new Float32Array(MAX_RIVALS)
+  readonly rvy = new Float32Array(MAX_RIVALS)
+  readonly rmass = new Float32Array(MAX_RIVALS)
+  readonly rMassVis = new Float32Array(MAX_RIVALS)
+  readonly ralive = new Uint8Array(MAX_RIVALS)
+  readonly rstate = new Uint8Array(MAX_RIVALS)
+  readonly rhunter = new Uint8Array(MAX_RIVALS)
+  readonly rleviathan = new Uint8Array(MAX_RIVALS)
+  readonly rsurge = new Float32Array(MAX_RIVALS)
+  readonly rhue = new Float32Array(MAX_RIVALS)
+  readonly rwander = new Float32Array(MAX_RIVALS)
+  readonly rrespawn = new Float32Array(MAX_RIVALS)
+  readonly rname = new Int32Array(MAX_RIVALS)
+  readonly rdanger = new Float32Array(MAX_RIVALS)
+  /**
+   * Where this rival has decided to go. Perception runs on a six-frame
+   * stagger, so the decision has to outlive the frame that made it.
+   */
+  readonly rtx = new Float32Array(MAX_RIVALS)
+  readonly rty = new Float32Array(MAX_RIVALS)
+  rivalCount = 0
+
+  // -- environment --------------------------------------------------------
+  time = 0
+  arenaR = arenaRadiusFor(START_MASS)
+  depth: Depth = DEPTHS[0] as Depth
+  depthNext: Depth = (DEPTHS[1] ?? DEPTHS[0]) as Depth
+  depthT = 0
+  over = 0
+  spec: TierSpec
+
+  resonance: Resonance = {
+    active: false,
+    phase: 0,
+    t: 0,
+    duration: 0,
+    question: null,
+    spheres: new Int32Array(4).fill(-1),
+    labels: ["", "", "", ""],
+    correctSlot: 0,
+    openedAt: 0,
+    answerMs: 0,
+    ringR: 0,
+    chosen: -1,
+    wasCorrect: false,
+  }
+  private nextResonanceAt = 16
+  private resonanceCount = 0
+
+  // -- events -------------------------------------------------------------
+  private readonly eventPool: GameEvent[] = Array.from({ length: MAX_EVENTS }, blankEvent)
+  private eventCount = 0
+
+  private readonly grid: Grid
+
+  constructor(host: Host, spec: TierSpec, seed: number) {
+    this.host = host
+    this.spec = spec
+    this.rng = new Rng(seed)
+    // The grid is PLAYER-RELATIVE: `build()` is handed the player's position
+    // as the origin each frame. Tied to world coordinates it covered ±9,300
+    // while `arenaRadiusFor` passes that at mass ~680 — from THE CHURN onward
+    // every mote outside the box clamped into one edge cell and the broad
+    // phase quietly became the O(n²) scan it exists to avoid, at exactly the
+    // depths with the most in the water.
+    this.grid = new Grid(GRID_COLS, MAX_MOTES)
+    this.reset()
+  }
+
+  /**
+   * The square the live mote field occupies, centred on the player.
+   *
+   * `maintain` culls anything past 1.65 view spans, so the field is a disc of
+   * that radius: 3.3 spans across, plus a margin for the frame's motion.
+   */
+  private get gridSpan(): number {
+    return viewSpanFor(this.mass) * 3.6
+  }
+
+  get events(): readonly GameEvent[] {
+    return this.eventPool
+  }
+
+  get eventLen(): number {
+    return this.eventCount
+  }
+
+  private emit(
+    kind: EventKind,
+    x: number,
+    y: number,
+    a = 0,
+    b = 0,
+    r = 1,
+    g = 1,
+    bl = 1,
+  ): void {
+    if (this.eventCount >= MAX_EVENTS) return
+    const e = this.eventPool[this.eventCount++] as GameEvent
+    e.kind = kind
+    e.x = x
+    e.y = y
+    e.a = a
+    e.b = b
+    e.r = r
+    e.g = g
+    e.bl = bl
+  }
+
+  get playerR(): number {
+    return R_K * Math.sqrt(this.massVis)
+  }
+
+  get playerRTrue(): number {
+    return R_K * Math.sqrt(this.mass)
+  }
+
+  /**
+   * The checkpoint: mass you can no longer be taken below.
+   *
+   * This is the single change that turns ARENA from a treadmill into a climb.
+   * Measured before it existed, a five-minute soak went 154 → 65 → 332 → 122 →
+   * 152 and finished where it started — a child plays for five minutes and gets
+   * nowhere, which is the exact opposite of what a growth game is for. Now the
+   * high-water mark never decays and you can never be taken more than a bit
+   * over a third below it. A bad patch is still a real, painful setback; it is
+   * simply no longer able to delete the run.
+   *
+   * It is a fraction of your own peak rather than of a depth threshold on
+   * purpose: the clock hands out depths, and anything the clock can hand out is
+   * something the checkpoint must not be allowed to print.
+   */
+  get checkpoint(): number {
+    return Math.max(FLOOR_MASS, this.bestMass * 0.58)
+  }
+
+  /**
+   * Take mass away. Never, ever hands mass back: the floor is clamped to the
+   * mass you already had, because a high water mark that *pays* for being hit
+   * is the bug that once produced six orders of magnitude of free mass.
+   */
+  private damage(loss: number): number {
+    const before = this.mass
+    const floor = Math.min(before, this.checkpoint)
+    const raw = before - loss
+    this.mass = Math.max(floor, raw)
+    // The floor HELD. This is the one rule in the game a child cannot see, so
+    // the moment it saves them is the moment it gets shown: a gold pulse
+    // exactly where the hit landed, no words, no number, no modal. Rate-limited
+    // so a cluster of stings against the floor is one statement and not twelve.
+    if (raw < floor - 1e-6 && this.heldCool <= 0) {
+      this.heldCool = 1.1
+      this.emit("held", this.px, this.py, floor, before - this.mass)
+    }
+    return before - this.mass
+  }
+  private heldCool = 0
+
+  // -------------------------------------------------------------------------
+
+  reset(): void {
+    this.px = 0
+    this.py = 0
+    this.pvx = 0
+    this.pvy = 0
+    this.mass = START_MASS
+    this.massVis = START_MASS
+    this.invuln = 1.4
+    this.combo = 0
+    this.time = 0
+    this.moteCount = 0
+    this.rivalCount = 0
+    this.malive.fill(0)
+    this.ralive.fill(0)
+    this.resonance.active = false
+    this.resonance.phase = 0
+    this.nextResonanceAt = 16
+    this.resonanceCount = 0
+    this.bestMass = START_MASS
+    this.deepest = 0
+    this.depth = DEPTHS[0] as Depth
+    this.refreshDepth()
+    for (let i = 0; i < this.spec.motes; i++) this.spawnMote(true)
+    for (let i = 0; i < this.spec.rivals; i++) this.spawnRival(true)
+  }
+
+  applySpec(spec: TierSpec): void {
+    this.spec = spec
+    while (this.moteCount > spec.motes) {
+      // Retire the mote furthest from the player rather than a random one.
+      let worst = -1
+      let worstD = -1
+      for (let i = 0; i < MAX_MOTES; i++) {
+        if (!this.malive[i] || this.mkind[i] === MK_ANSWER) continue
+        const dx = (this.mx[i] as number) - this.px
+        const dy = (this.my[i] as number) - this.py
+        const d = dx * dx + dy * dy
+        if (d > worstD) {
+          worstD = d
+          worst = i
+        }
+      }
+      if (worst < 0) break
+      this.malive[worst] = 0
+      this.moteCount--
+    }
+    // Retire rivals down to the new budget. The unconditional `break` that used
+    // to sit at the bottom of this loop meant an ultra→low demotion (24 → 12)
+    // removed exactly one, and the tier the governor had just decided the
+    // machine could not afford stayed on screen.
+    while (this.rivalCount > spec.rivals) {
+      let victim = -1
+      for (let i = MAX_RIVALS - 1; i >= 0; i--) {
+        if (this.ralive[i] && !this.rleviathan[i]) {
+          victim = i
+          break
+        }
+      }
+      if (victim < 0) break
+      this.ralive[victim] = 0
+      this.rrespawn[victim] = 0
+      this.rivalCount--
+    }
+  }
+
+  private refreshDepth(): void {
+    const prev = this.depth.index
+    // bestMass, not mass, and floored by the band we are already in: the water
+    // is a record of how deep this run has been, never a readout of how the
+    // last ten seconds went.
+    const d = depthFor(this.bestMass, this.time, this.depth.index)
+    this.depth = d.depth
+    this.depthNext = d.next
+    this.depthT = d.t
+    this.over = overdrive(this.bestMass, this.time)
+    this.arenaR = arenaRadiusFor(this.mass)
+    if (this.depth.index > this.deepest) this.deepest = this.depth.index
+    if (this.depth.index !== prev) {
+      // Did the run BUY this band, or did the clock simply deliver it? Same
+      // rung either way, but the presentation is not the same, and a child
+      // should be able to hear the difference.
+      const bought = bandForMass(this.bestMass) >= this.depth.index ? 1 : 0
+      this.emit("depth", this.px, this.py, this.depth.index, bought)
+    }
+  }
+
+  // -- mote lifecycle -------------------------------------------------------
+
+  private freeMote(): number {
+    for (let i = 0; i < MAX_MOTES; i++) if (!this.malive[i]) return i
+    return -1
+  }
+
+  /**
+   * Value policy — this is where the mathematics actually lives.
+   *
+   * Nearly half of every field is deliberately drawn from a narrow band around
+   * the player's own mass. A mote at M-3 is a prize; a mote at M+3 is a
+   * mistake; and telling 3,418 from 3,481 at speed is the exact place-value
+   * comparison a worksheet asks for eighty times and gets answered nine times.
+   * The wide bands exist so the field still reads instantly at a glance.
+   */
+  /**
+   * Mote values.
+   *
+   * The band fractions are a legibility budget as much as a difficulty one.
+   * A near-tie or big-threat mote has a radius proportional to your own, so it
+   * covers a *fixed* fraction of the screen however large you get — twenty per
+   * cent of a 340-mote field turned APEX into forty overlapping five-digit
+   * numbers, which is not tension, it is noise. Ten per cent reads.
+   */
+  private rollValue(): { v: number; kind: number } {
+    const M = this.mass
+    const r = this.rng
+    if (r.chance(this.depth.voidRate)) {
+      const mag = Math.max(2, tidyValue(FOOD_A * Math.pow(M, FOOD_B) * r.range(1.0, 3.0)))
+      return { v: -mag, kind: MK_VOID }
+    }
+    const scale = Math.max(2, FOOD_A * Math.pow(M, FOOD_B))
+    const roll = r.f()
+    if (roll < 0.62) {
+      // Crumbs — where almost all of your food comes from. Their value grows
+      // with the square-ish root of your mass, so a crumb is a fifth of you at
+      // the start and a rounding error when you are enormous. That single
+      // choice is what makes the climb last.
+      return { v: tidyValue(r.int(1, Math.max(2, Math.round(scale)))), kind: MK_FOOD }
+    }
+    if (roll < 0.86) {
+      const lo = Math.max(1, Math.round(scale * 0.8))
+      const hi = Math.max(lo + 1, Math.round(scale * 2.6))
+      return { v: tidyValue(r.int(lo, Math.min(hi, Math.max(2, Math.round(M * 0.55))))), kind: MK_FOOD }
+    }
+    if (roll < 0.94) {
+      // The near-tie band, deliberately skewed *above* you. Most of it is a
+      // wall; the sliver below your mass is worth nearly doubling, and taking
+      // it is the bravest thing in the game. It has to be rare or it is the
+      // only thing anyone does.
+      const lo = Math.max(1, Math.round(M * 0.95))
+      const hi = Math.max(lo + 2, Math.round(M * 1.32))
+      return { v: tidyValue(r.int(lo, hi)), kind: MK_FOOD }
+    }
+    const lo = Math.max(2, Math.round(M * 1.5))
+    const hi = Math.max(lo + 2, Math.round(M * 3.1))
+    return { v: tidyValue(r.int(lo, hi)), kind: MK_FOOD }
+  }
+
+  private spawnMote(anywhere: boolean): number {
+    const i = this.freeMote()
+    if (i < 0) return -1
+    const r = this.rng
+    const { v, kind } = this.rollValue()
+    let x: number
+    let y: number
+    if (anywhere) {
+      const a = r.range(0, Math.PI * 2)
+      const d = Math.sqrt(r.f()) * this.arenaR * 0.96
+      x = Math.cos(a) * d
+      y = Math.sin(a) * d
+    } else {
+      // Uniform over the disc the player can reach, minus whatever is on
+      // screen right now. Uniform keeps the density even wherever you swim;
+      // the rejection keeps every mote's arrival off-camera, so nothing ever
+      // blinks into existence in front of a child's eyes.
+      const span = viewSpanFor(this.mass)
+      const halfH = span * 0.53
+      const halfW = halfH * this.viewAspect
+      const R = span * 1.5
+      let dx = 0
+      let dy = 0
+      for (let tries = 0; tries < 8; tries++) {
+        const a = r.range(0, Math.PI * 2)
+        const d = R * Math.sqrt(r.f())
+        dx = Math.cos(a) * d
+        dy = Math.sin(a) * d
+        if (Math.abs(dx) > halfW || Math.abs(dy) > halfH) break
+        if (tries === 7) {
+          const s2 = (halfW + halfH) / (Math.hypot(dx, dy) || 1)
+          dx *= s2
+          dy *= s2
+        }
+      }
+      x = this.px + dx
+      y = this.py + dy
+      const rad = Math.hypot(x, y)
+      if (rad > this.arenaR * 0.98) {
+        const s = (this.arenaR * 0.9) / rad
+        x *= s
+        y *= s
+      }
+    }
+    this.mx[i] = x
+    this.my[i] = y
+    const drift = 16 + this.depth.temper * 30
+    this.mvx[i] = r.sym(drift)
+    this.mvy[i] = r.sym(drift)
+    this.mval[i] = v
+    this.mr[i] = radiusForValue(v)
+    this.mkind[i] = kind
+    this.malive[i] = 1
+    this.mphase[i] = r.range(0, Math.PI * 2)
+    this.mflip[i] = kind === MK_VOID ? 0 : Math.abs(v) < this.mass ? 1 : 0
+    this.mborn[i] = this.time
+    this.moteCount++
+    return i
+  }
+
+  /** Scatter mass as motes — used by rupture, by rival death and by shedding. */
+  private scatter(x: number, y: number, total: number, chunks: number, speed: number, kind: number): void {
+    if (total < 1) return
+    const per = Math.max(1, Math.round(total / chunks))
+    for (let k = 0; k < chunks; k++) {
+      const i = this.freeMote()
+      if (i < 0) return
+      const a = this.rng.range(0, Math.PI * 2)
+      const sp = speed * this.rng.range(0.5, 1.35)
+      this.mx[i] = x + Math.cos(a) * 6
+      this.my[i] = y + Math.sin(a) * 6
+      this.mvx[i] = Math.cos(a) * sp
+      this.mvy[i] = Math.sin(a) * sp
+      this.mval[i] = per
+      this.mr[i] = radiusForValue(per)
+      this.mkind[i] = kind
+      this.malive[i] = 1
+      this.mphase[i] = this.rng.range(0, Math.PI * 2)
+      this.mflip[i] = per < this.mass ? 1 : 0
+      this.mborn[i] = this.time
+      this.moteCount++
+    }
+  }
+
+  // -- rival lifecycle ------------------------------------------------------
+
+  private freeRival(): number {
+    for (let i = 0; i < MAX_RIVALS; i++) if (!this.ralive[i] && (this.rrespawn[i] as number) <= 0) return i
+    return -1
+  }
+
+  private spawnRival(anywhere: boolean): number {
+    const i = this.freeRival()
+    if (i < 0) return -1
+    const r = this.rng
+    // Sized around the player so the field is always a live ladder: some you
+    // can eat right now, some you cannot, and a couple you must grow into.
+    const roll = r.f()
+    let m: number
+    // The plankton tier matters twice over. It is the fantasy — once you are
+    // the board, most of the board is beneath your notice — and it is the brake
+    // on the kill economy, because absorption saturates and something a
+    // twentieth your size is worth a twentieth of you however many you eat.
+    if (roll < 0.26) m = Math.max(4, this.mass * r.range(0.03, 0.20))
+    else if (roll < 0.48) m = Math.max(4, this.mass * r.range(0.30, 0.70))
+    else if (roll < 0.78) m = this.mass * r.range(0.80, 1.18)
+    else if (roll < 0.95) m = this.mass * r.range(1.3, 1.95)
+    else m = this.mass * r.range(1.95, 2.25)
+    m = Math.max(4, Math.round(m))
+
+    let x: number
+    let y: number
+    if (anywhere) {
+      const a = r.range(0, Math.PI * 2)
+      const d = Math.sqrt(r.f()) * this.arenaR * 0.9
+      x = Math.cos(a) * d
+      y = Math.sin(a) * d
+    } else {
+      const a = r.range(0, Math.PI * 2)
+      const d = viewSpanFor(this.mass) * r.range(1.15, 1.9)
+      x = this.px + Math.cos(a) * d
+      y = this.py + Math.sin(a) * d
+      const rad = Math.hypot(x, y)
+      if (rad > this.arenaR) {
+        const s = (this.arenaR * 0.88) / rad
+        x *= s
+        y *= s
+      }
+    }
+    this.rx[i] = x
+    this.ry[i] = y
+    this.rvx[i] = r.sym(30)
+    this.rvy[i] = r.sym(30)
+    this.rmass[i] = m
+    this.rMassVis[i] = m
+    this.ralive[i] = 1
+    this.rstate[i] = RS_FEED
+    this.rsurge[i] = 0
+    this.rhue[i] = r.f()
+    this.rwander[i] = r.range(0, Math.PI * 2)
+    this.rname[i] = r.int(0, 63)
+    this.rdanger[i] = 0
+    // Decide immediately rather than drifting for up to six frames with a
+    // target left over from whoever last occupied this slot.
+    this.decide(i, x, y, m, R_K * Math.sqrt(m))
+
+    const hunterBudget = this.depth.hunters
+    let hunters = 0
+    for (let k = 0; k < MAX_RIVALS; k++) if (this.ralive[k] && this.rhunter[k]) hunters++
+    this.rhunter[i] = hunters < hunterBudget && r.chance(0.5) ? 1 : 0
+    this.rleviathan[i] = 0
+    this.rivalCount++
+    return i
+  }
+
+  private spawnLeviathan(): void {
+    const i = this.freeRival()
+    if (i < 0) return
+    const r = this.rng
+    const a = r.range(0, Math.PI * 2)
+    const d = viewSpanFor(this.mass) * 2.4
+    this.rx[i] = this.px + Math.cos(a) * d
+    this.ry[i] = this.py + Math.sin(a) * d
+    const m = Math.round(this.mass * r.range(3.4, 5.2))
+    this.rmass[i] = m
+    this.rMassVis[i] = m
+    this.ralive[i] = 1
+    this.rstate[i] = RS_HUNT
+    this.rsurge[i] = 0
+    this.rhue[i] = 0.06
+    this.rwander[i] = 0
+    this.rname[i] = -1
+    this.rhunter[i] = 1
+    this.rleviathan[i] = 1
+    this.rdanger[i] = 0
+    this.rivalCount++
+  }
+
+  // -------------------------------------------------------------------------
+  // Step
+  // -------------------------------------------------------------------------
+
+  step(dt: number): void {
+    this.eventCount = 0
+    this.time += dt
+    this.invuln = Math.max(0, this.invuln - dt)
+    this.stingGrace = Math.max(0, this.stingGrace - dt)
+    this.heldCool = Math.max(0, this.heldCool - dt)
+
+    this.stepPlayer(dt)
+    this.stepMotes(dt)
+    this.stepRivals(dt)
+    this.collide(dt)
+    this.stepResonance(dt)
+    this.maintain(dt)
+
+    // Visual mass lags the true mass so growth is a swell, not a step.
+    const k = 1 - Math.exp(-dt * 9)
+    this.massVis += (this.mass - this.massVis) * k
+    for (let i = 0; i < MAX_RIVALS; i++) {
+      if (!this.ralive[i]) continue
+      this.rMassVis[i] = (this.rMassVis[i] as number) + ((this.rmass[i] as number) - (this.rMassVis[i] as number)) * k
+    }
+    if (this.mass > this.bestMass) this.bestMass = this.mass
+    this.refreshDepth()
+  }
+
+  private stepPlayer(dt: number): void {
+    const r = this.playerRTrue
+    // Agar's law: mass costs agility. Without this, growth has no downside and
+    // the whole genre collapses into a farming sim.
+    // Size buys momentum, not top speed denial: a leviathan crosses the water
+    // quickly and turns like a barge. Making size cost *agility* rather than
+    // *speed* is what keeps the twelfth minute from becoming a slow crawl
+    // across an empty screen, while still letting a minnow dance out of reach.
+    const base = 520
+    let speed = base * Math.pow(Math.max(18, r) / 28, 0.30)
+    // Inside a Resonance the arena is a fixed-size room however large you are.
+    // Distance to a sphere grows with your radius while ordinary speed only
+    // grows as r^0.30, so past a certain size the answer becomes physically
+    // unreachable inside the window — measured: nine of forty-eight questions
+    // answered in a twenty-minute run, and every miss was a timeout, not a
+    // mistake. The curriculum beat must never be the thing that gets outrun.
+    if (this.resonance.active && this.resonance.phase >= 1) {
+      speed = Math.max(speed, this.resonance.ringR / 1.35)
+    }
+    const surgeOn = this.surging && this.mass > FLOOR_MASS + 2 && !this.resonance.active
+    const mult = surgeOn ? 1.92 : 1
+
+    let tx = this.aimX
+    let ty = this.aimY
+    let dx = tx - this.px
+    let dy = ty - this.py
+    let d = Math.hypot(dx, dy)
+    if (d < 0.001) {
+      dx = 0
+      dy = 0
+      d = 1
+    }
+    // Inside a small dead-zone the core eases to a stop rather than jittering.
+    const grip = Math.min(1, d / Math.max(30, r * 0.55))
+    const desiredX = (dx / d) * speed * mult * grip
+    const desiredY = (dy / d) * speed * mult * grip
+
+    // Heavier cores turn slower. This is where "majestic" comes from.
+    const agility = 8.0 * Math.pow(30 / Math.max(24, r), 0.45)
+    const kk = 1 - Math.exp(-dt * agility)
+    this.pvx += (desiredX - this.pvx) * kk
+    this.pvy += (desiredY - this.pvy) * kk
+
+    this.px += this.pvx * dt
+    this.py += this.pvy * dt
+
+    if (surgeOn) {
+      // Surge is paid for in mass, sprayed out behind you as real, edible
+      // motes. The cost is visible, it is on the field, and a rival will
+      // absolutely come and eat your exhaust.
+      const burn = Math.max(0.9, this.mass * 0.11) * dt
+      // Surge is paid for down to the checkpoint and no further, so a child is
+      // never trapped without an escape — but the exhaust is real mass, so it
+      // stops being shed the moment there is nothing left to pay with. Without
+      // that guard a floored player is a free mote printer.
+      const paid = this.damage(burn) > burn * 0.5
+      const sp = Math.hypot(this.pvx, this.pvy)
+      if (paid && sp > 1 && this.rng.chance(Math.min(1, dt * 26))) {
+        const i = this.freeMote()
+        if (i >= 0) {
+          const v = Math.max(1, Math.round(this.mass * 0.035))
+          this.mx[i] = this.px - (this.pvx / sp) * r
+          this.my[i] = this.py - (this.pvy / sp) * r
+          this.mvx[i] = -(this.pvx / sp) * 150 + this.rng.sym(60)
+          this.mvy[i] = -(this.pvy / sp) * 150 + this.rng.sym(60)
+          this.mval[i] = v
+          this.mr[i] = radiusForValue(v)
+          this.mkind[i] = MK_SHED
+          this.malive[i] = 1
+          this.mphase[i] = this.rng.range(0, 6.28)
+          this.mflip[i] = 1
+          this.mborn[i] = this.time
+          this.moteCount++
+        }
+      }
+    }
+
+    // The membrane. A luminous wall that pushes, never a wall that kills.
+    const rad = Math.hypot(this.px, this.py)
+    const lim = this.arenaR - r
+    if (rad > lim) {
+      const push = (rad - lim) * 9
+      this.pvx -= (this.px / rad) * push * dt * 8
+      this.pvy -= (this.py / rad) * push * dt * 8
+      const s = lim / rad
+      this.px += (this.px * s - this.px) * Math.min(1, dt * 10)
+      this.py += (this.py * s - this.py) * Math.min(1, dt * 10)
+    }
+  }
+
+  private stepMotes(dt: number): void {
+    const drag = Math.exp(-dt * 1.05)
+    const M = this.mass
+    const pr = this.playerRTrue
+    // A large core drags the water with it. Once you are the board, the board
+    // comes to you — the single most satisfying thing about being enormous.
+    const pullR = pr * 3.4
+    const pullK = Math.min(1, Math.max(0, (M - 60) / 900)) * 260
+
+    for (let i = 0; i < MAX_MOTES; i++) {
+      if (!this.malive[i]) continue
+      let vx = this.mvx[i] as number
+      let vy = this.mvy[i] as number
+      vx *= drag
+      vy *= drag
+
+      const x = this.mx[i] as number
+      const y = this.my[i] as number
+
+      if (pullK > 0 && this.mkind[i] !== MK_ANSWER) {
+        const dx = this.px - x
+        const dy = this.py - y
+        const d2 = dx * dx + dy * dy
+        if (d2 < pullR * pullR && d2 > 1) {
+          const d = Math.sqrt(d2)
+          const f = (1 - d / pullR) * pullK
+          vx += (dx / d) * f * dt
+          vy += (dy / d) * f * dt
+        }
+      }
+
+      this.mvx[i] = vx
+      this.mvy[i] = vy
+      this.mx[i] = x + vx * dt
+      this.my[i] = y + vy * dt
+      this.mphase[i] = (this.mphase[i] as number) + dt * 1.6
+
+      // Keep them inside the membrane.
+      const rad = Math.hypot(this.mx[i] as number, this.my[i] as number)
+      if (rad > this.arenaR) {
+        const s = this.arenaR / rad
+        this.mx[i] = (this.mx[i] as number) * s
+        this.my[i] = (this.my[i] as number) * s
+        this.mvx[i] = -vx * 0.4
+        this.mvy[i] = -vy * 0.4
+      }
+
+      // The flip. When you grow past a mote it stops being a threat, and that
+      // conversion is animated rather than swapped, because watching the world
+      // turn into food is the reward the whole genre is built on.
+      if (this.mkind[i] !== MK_VOID && this.mkind[i] !== MK_ANSWER) {
+        const want = Math.abs(this.mval[i] as number) < M ? 1 : 0
+        const cur = this.mflip[i] as number
+        if (want === 1 && cur < 0.5) {
+          this.emit("flip", this.mx[i] as number, this.my[i] as number, this.mr[i] as number, this.mval[i] as number)
+        }
+        this.mflip[i] = cur + (want - cur) * Math.min(1, dt * 7)
+      }
+    }
+  }
+
+  private stepRivals(dt: number): void {
+    const frame = (this.time * 60) | 0
+    for (let i = 0; i < MAX_RIVALS; i++) {
+      if ((this.rrespawn[i] as number) > 0) {
+        this.rrespawn[i] = (this.rrespawn[i] as number) - dt
+        if ((this.rrespawn[i] as number) <= 0) {
+          this.rrespawn[i] = 0
+          if (this.rivalCount < this.spec.rivals) this.spawnRival(false)
+        }
+        continue
+      }
+      if (!this.ralive[i]) continue
+
+      const m = this.rmass[i] as number
+      const rr = R_K * Math.sqrt(m)
+      const x = this.rx[i] as number
+      const y = this.ry[i] as number
+
+      // Perception runs on a stagger — a rival re-decides five times a second,
+      // which is also why they read as deliberate rather than twitchy.
+      if ((frame + i) % 6 === 0) this.decide(i, x, y, m, rr)
+
+      const st = this.rstate[i] as number
+      const tx = this.rtx[i] as number
+      const ty = this.rty[i] as number
+
+      // Wander keeps a feeding rival from looking like a homing missile.
+      this.rwander[i] = (this.rwander[i] as number) + this.rng.sym(dt * 5)
+      const wob = (this.rwander[i] as number)
+
+      let dx = tx - x
+      let dy = ty - y
+      const d = Math.hypot(dx, dy) || 1
+      dx /= d
+      dy /= d
+      dx += Math.cos(wob) * 0.22
+      dy += Math.sin(wob) * 0.22
+
+      const temper = this.depth.temper + this.over * 0.2
+      const lev = this.rleviathan[i] === 1
+      const base = lev ? 330 : 470 + temper * 120
+      let speed = base * Math.pow(Math.max(18, rr) / 28, lev ? 0.22 : 0.30)
+
+      // Surging costs a rival mass exactly as it costs the player, so a long
+      // chase genuinely wears the hunter down and the leaderboard churns.
+      const wantSurge =
+        !lev && (st === RS_FLEE ? this.rdanger[i]! > 0.55 : st === RS_HUNT ? this.rdanger[i]! > 0.4 : false)
+      if (wantSurge && m > 8) {
+        speed *= 1.8
+        const burn = Math.max(0.35, m * 0.085) * dt
+        this.rmass[i] = Math.max(4, m - burn)
+        this.rsurge[i] = Math.min(1, (this.rsurge[i] as number) + dt * 5)
+      } else {
+        this.rsurge[i] = Math.max(0, (this.rsurge[i] as number) - dt * 3)
+      }
+
+      const nl = Math.hypot(dx, dy) || 1
+      const agility = (lev ? 2.2 : 6.4) * Math.pow(30 / Math.max(24, rr), 0.45)
+      const kk = 1 - Math.exp(-dt * agility)
+      this.rvx[i] = (this.rvx[i] as number) + ((dx / nl) * speed - (this.rvx[i] as number)) * kk
+      this.rvy[i] = (this.rvy[i] as number) + ((dy / nl) * speed - (this.rvy[i] as number)) * kk
+      this.rx[i] = x + (this.rvx[i] as number) * dt
+      this.ry[i] = y + (this.rvy[i] as number) * dt
+
+      const rad = Math.hypot(this.rx[i] as number, this.ry[i] as number)
+      const lim = this.arenaR - rr
+      if (rad > lim) {
+        const s = lim / rad
+        this.rx[i] = (this.rx[i] as number) * s
+        this.ry[i] = (this.ry[i] as number) * s
+        this.rvx[i] = -(this.rvx[i] as number) * 0.5
+        this.rvy[i] = -(this.rvy[i] as number) * 0.5
+      }
+    }
+  }
+
+  /**
+   * Rival decision. Writes the chosen target into `rtx[i]`/`rty[i]`, which is
+   * how the AI returns a vector without allocating one two hundred times a
+   * second.
+   *
+   * It used to write into three SHARED scratch fields with the comment "which
+   * the caller reads immediately". The caller does read immediately — but
+   * `decide` only runs for one rival in six per frame (`(frame + i) % 6`), and
+   * on the other five frames the guard `scratchI !== i` fired and the rival
+   * steered at ITSELF: zero direction vector, pure wander at full speed. Flee,
+   * juke, hunt, prey selection and the whole `depth.hunters` budget were
+   * diluted six to one, and THE CHURN's "hunters that lock on" barely locked
+   * on. A decision has to persist between the frames that make it.
+   */
+  private decide(i: number, x: number, y: number, m: number, rr: number): void {
+    const lev = this.rleviathan[i] === 1
+    const perception = rr * (lev ? 22 : 13) + 700 + R_K * Math.sqrt(this.mass) * 3
+
+    // 1. Is anything here big enough to eat me?
+    let fleeX = 0
+    let fleeY = 0
+    let fleeW = 0
+    let danger = 0
+
+    if (!lev) {
+      // The player counts as a rival in every calculation. Being feared is the
+      // point of getting big.
+      const pm = this.mass
+      const dxp = x - this.px
+      const dyp = y - this.py
+      const dp = Math.hypot(dxp, dyp)
+      if (pm > m * 1.06 && dp < perception && this.invuln <= 0) {
+        // You are seen from a distance proportional to how frightening you
+        // are. Being enormous should empty the water ahead of you.
+        const w = (1 - dp / perception) * (pm / m)
+        fleeX += (dxp / (dp || 1)) * w
+        fleeY += (dyp / (dp || 1)) * w
+        fleeW += w
+        danger = Math.max(danger, 1 - dp / Math.max(1, rr * 6 + 260))
+      }
+      for (let k = 0; k < MAX_RIVALS; k++) {
+        if (k === i || !this.ralive[k]) continue
+        const om = this.rmass[k] as number
+        if (om <= m * 1.06) continue
+        const dx = x - (this.rx[k] as number)
+        const dy = y - (this.ry[k] as number)
+        const d = Math.hypot(dx, dy)
+        if (d > perception) continue
+        const w = (1 - d / perception) * (om / m)
+        fleeX += (dx / (d || 1)) * w
+        fleeY += (dy / (d || 1)) * w
+        fleeW += w
+        danger = Math.max(danger, 1 - d / Math.max(1, rr * 6 + 260))
+      }
+    }
+
+    this.rdanger[i] = danger
+
+    if (fleeW > 0.35) {
+      this.rstate[i] = RS_FLEE
+      const n = Math.hypot(fleeX, fleeY) || 1
+      let fxn = fleeX / n
+      let fyn = fleeY / n
+      // Juke. Running in a straight line from something faster than you is
+      // just a slower death; weaving is what a small nimble thing actually
+      // does, and it is why chasing one is a skill rather than a formality.
+      const juke = Math.sin(this.time * 4.2 + i * 1.7) * 0.75
+      const px2 = -fyn
+      const py2 = fxn
+      fxn += px2 * juke
+      fyn += py2 * juke
+      const n2 = Math.hypot(fxn, fyn) || 1
+      this.rtx[i] = x + (fxn / n2) * 900
+      this.rty[i] = y + (fyn / n2) * 900
+      return
+    }
+
+    // 2. Is there prey worth chasing? Hunters and leviathans prefer the player.
+    let bestPrey = -1
+    let bestPreyScore = -1
+    const aggro = this.depth.temper + this.over * 0.25
+    const wantsPlayer = (this.rhunter[i] === 1 || lev) && this.mass < m * 0.94 && this.invuln <= 0
+    if (wantsPlayer) {
+      const d = Math.hypot(x - this.px, y - this.py)
+      if (d < perception * 1.6) {
+        this.rstate[i] = RS_HUNT
+        this.rtx[i] = this.px + this.pvx * 0.35
+        this.rty[i] = this.py + this.pvy * 0.35
+        this.rdanger[i] = Math.max(danger, 1 - d / Math.max(1, rr * 8 + 400))
+        return
+      }
+    }
+    if (!lev && aggro > 0.2) {
+      if (this.mass < m * 0.9 && this.invuln <= 0) {
+        const d = Math.hypot(x - this.px, y - this.py)
+        if (d < perception) {
+          const s = (aggro * (m / Math.max(1, this.mass))) / (d + 60)
+          if (s > bestPreyScore) {
+            bestPreyScore = s
+            bestPrey = -2
+          }
+        }
+      }
+      for (let k = 0; k < MAX_RIVALS; k++) {
+        if (k === i || !this.ralive[k]) continue
+        const om = this.rmass[k] as number
+        if (om > m * 0.9) continue
+        const d = Math.hypot(x - (this.rx[k] as number), y - (this.ry[k] as number))
+        if (d > perception) continue
+        const s = (aggro * om) / (d + 60)
+        if (s > bestPreyScore) {
+          bestPreyScore = s
+          bestPrey = k
+        }
+      }
+    }
+
+    // 3. Otherwise feed. Rivals obey exactly the rule the player obeys, and a
+    //    smart one will not swim into a number bigger than itself.
+    let bestMote = -1
+    let bestMoteScore = -1
+    for (let k = 0; k < MAX_MOTES; k++) {
+      if (!this.malive[k]) continue
+      const v = this.mval[k] as number
+      if (v < 0) continue
+      if (v >= m) continue
+      const dx = x - (this.mx[k] as number)
+      const dy = y - (this.my[k] as number)
+      const d2 = dx * dx + dy * dy
+      if (d2 > perception * perception) continue
+      const s = v / (Math.sqrt(d2) + 40)
+      if (s > bestMoteScore) {
+        bestMoteScore = s
+        bestMote = k
+      }
+    }
+
+    if (bestPrey !== -1 && bestPreyScore > bestMoteScore * 0.9) {
+      this.rstate[i] = RS_HUNT
+      if (bestPrey === -2) {
+        this.rtx[i] = this.px + this.pvx * 0.3
+        this.rty[i] = this.py + this.pvy * 0.3
+      } else {
+        this.rtx[i] = (this.rx[bestPrey] as number) + (this.rvx[bestPrey] as number) * 0.3
+        this.rty[i] = (this.ry[bestPrey] as number) + (this.rvy[bestPrey] as number) * 0.3
+      }
+      return
+    }
+
+    this.rstate[i] = RS_FEED
+    if (bestMote >= 0) {
+      this.rtx[i] = this.mx[bestMote] as number
+      this.rty[i] = this.my[bestMote] as number
+    } else {
+      const a = this.rwander[i] as number
+      this.rtx[i] = x + Math.cos(a) * 600
+      this.rty[i] = y + Math.sin(a) * 600
+    }
+  }
+
+  // -------------------------------------------------------------------------
+
+  private collide(dt: number): void {
+    void dt
+    this.grid.build(this.mx, this.my, this.malive, MAX_MOTES, this.px, this.py, this.gridSpan)
+
+    const pr = this.playerRTrue
+    const res = this.resonance
+
+    // --- player vs motes ---------------------------------------------------
+    this.grid.query(this.px, this.py, pr + 90, (i) => {
+      if (!this.malive[i]) return
+      const v = this.mval[i] as number
+      const mr = this.mr[i] as number
+      const dx = (this.mx[i] as number) - this.px
+      const dy = (this.my[i] as number) - this.py
+      const d = Math.hypot(dx, dy)
+
+      if (this.mkind[i] === MK_ANSWER) {
+        if (d > pr + mr * 0.45) return
+        this.resolveResonance(i)
+        return
+      }
+      // During a Resonance the ordinary field is inert — the arena is holding
+      // its breath, and nothing but the four spheres can touch you.
+      if (res.active && res.phase >= 1) return
+
+      if (v < 0) {
+        if (d > pr + mr * 0.2) return
+        if (this.stingGrace > 0) return
+        const loss = this.damage(Math.min(this.mass * 0.11, Math.abs(v)))
+        this.combo = 0
+        this.malive[i] = 0
+        this.moteCount--
+        this.pvx -= (dx / (d || 1)) * 260
+        this.pvy -= (dy / (d || 1)) * 260
+        this.stingGrace = 0.30
+        this.emit("sting", this.mx[i] as number, this.my[i] as number, loss, v)
+        this.host.haptic("failure")
+        return
+      }
+
+      if (v < this.mass) {
+        // Absorb once the mote is meaningfully inside you — the little bit of
+        // required overlap is what makes a near-miss feel like a near-miss.
+        if (d > pr - mr * 0.35) return
+        const gain = absorbGain(v, this.mass)
+        this.mass += gain
+        this.absorbed++
+        this.combo++
+        this.malive[i] = 0
+        this.moteCount--
+        this.emit("absorb", this.mx[i] as number, this.my[i] as number, gain, this.combo)
+        if (this.combo % 10 === 0) this.host.haptic("light")
+      } else if (this.stingGrace <= 0) {
+        // A number too big to swallow. It stings and it takes your combo, and
+        // the cost scales with how badly you misread it: brushing something a
+        // hair above you is a nick, ploughing into something three times your
+        // size is a wound. You are never killed by the field — only by a
+        // rival — but a dense field at a flat 19% ground a run to the floor
+        // without a single rupture, which read as the game cheating.
+        if (d > pr * 0.55 + mr * 0.45) return
+        const over = v / Math.max(1, this.mass) - 1
+        const rate = Math.min(0.13, 0.035 + over * 0.09)
+        const loss = this.damage(Math.min(this.mass * rate, Math.max(1, v * 0.34)))
+        this.combo = 0
+        this.malive[i] = 0
+        this.moteCount--
+        this.pvx -= (dx / (d || 1)) * 340
+        this.pvy -= (dy / (d || 1)) * 340
+        // A brief flinch, so drifting into a cluster costs one mistake and not
+        // five in the same tenth of a second.
+        this.stingGrace = 0.30
+        this.emit("sting", this.mx[i] as number, this.my[i] as number, loss, v)
+        this.host.haptic("medium")
+      }
+    })
+
+    // --- rivals vs motes ---------------------------------------------------
+    for (let k = 0; k < MAX_RIVALS; k++) {
+      if (!this.ralive[k]) continue
+      const m = this.rmass[k] as number
+      const rr = R_K * Math.sqrt(m)
+      const rxk = this.rx[k] as number
+      const ryk = this.ry[k] as number
+      this.grid.query(rxk, ryk, rr + 40, (i) => {
+        if (!this.malive[i]) return
+        if (this.mkind[i] === MK_ANSWER) return
+        const v = this.mval[i] as number
+        if (v < 0 || v >= m) return
+        const dx = (this.mx[i] as number) - rxk
+        const dy = (this.my[i] as number) - ryk
+        if (Math.hypot(dx, dy) > rr - (this.mr[i] as number) * 0.35) return
+        this.rmass[k] = m + absorbGain(v, m)
+        this.malive[i] = 0
+        this.moteCount--
+      })
+    }
+
+    // --- cores vs cores ----------------------------------------------------
+    if (!(res.active && res.phase >= 1)) {
+      for (let k = 0; k < MAX_RIVALS; k++) {
+        if (!this.ralive[k]) continue
+        const m = this.rmass[k] as number
+        const rr = R_K * Math.sqrt(m)
+        const dx = (this.rx[k] as number) - this.px
+        const dy = (this.ry[k] as number) - this.py
+        const d = Math.hypot(dx, dy)
+
+        if (d < Math.max(rr, pr) && this.invuln <= 0) {
+          if (this.mass > m * 1.06 && d < pr - rr * 0.5) {
+            // You ate a rival. This is the payoff moment of the genre.
+            this.mass += devourGain(m, this.mass)
+            this.combo++
+            this.killRival(k, false)
+            this.emit("kill", this.rx[k] as number, this.ry[k] as number, m, this.combo)
+            this.emit("shockwave", this.px, this.py, pr * 3.2, 1)
+            this.host.haptic("success")
+          } else if (m > this.mass * 1.16 && d < rr - pr * 0.8) {
+            this.rupture(m)
+          }
+        }
+
+        // rival vs rival — the world eats itself whether you watch or not
+        for (let j = k + 1; j < MAX_RIVALS; j++) {
+          if (!this.ralive[j]) continue
+          const m2 = this.rmass[j] as number
+          const rr2 = R_K * Math.sqrt(m2)
+          const ddx = (this.rx[j] as number) - (this.rx[k] as number)
+          const ddy = (this.ry[j] as number) - (this.ry[k] as number)
+          const dd = Math.hypot(ddx, ddy)
+          if (dd > Math.max(rr, rr2)) continue
+          if (m > m2 * 1.06 && dd < rr - rr2 * 0.72) {
+            this.rmass[k] = m + devourGain(m2, m)
+            this.killRival(j, true)
+          } else if (m2 > m * 1.06 && dd < rr2 - rr * 0.72) {
+            this.rmass[j] = m2 + devourGain(m, m2)
+            this.killRival(k, true)
+            break
+          }
+        }
+      }
+    }
+  }
+
+  private killRival(k: number, scatterSome: boolean): void {
+    const m = this.rmass[k] as number
+    this.emit("rival-death", this.rx[k] as number, this.ry[k] as number, m, this.rleviathan[k] as number)
+    if (scatterSome) {
+      this.scatter(this.rx[k] as number, this.ry[k] as number, m * 0.22, 5, 150, MK_SHED)
+    }
+    this.ralive[k] = 0
+    this.rleviathan[k] = 0
+    this.rhunter[k] = 0
+    this.rivalCount--
+    this.rrespawn[k] = this.rng.range(1.6, 4.2)
+  }
+
+  /**
+   * You did not lose. You burst, you scattered most of what you were across
+   * the water where anyone can take it, and you re-formed on the spot. There
+   * is no modal, no score screen and no menu — the only thing that stops a run
+   * is the child putting the tablet down.
+   */
+  private rupture(byMass: number): void {
+    // Growth in this game is the thing you own. A run that can be wiped to
+    // nothing by two unlucky seconds is a run a child stops trusting, and the
+    // measured failure mode was a death spiral: rupture, respawn next to the
+    // same predator, rupture again, and arrive back at the floor with twelve
+    // minutes of climbing gone. So the fall is deep but bounded, and the
+    // ceiling itself erodes a little each time so repeated carelessness still
+    // costs something real.
+    // `min(mass, ...)` is load-bearing: without it a high-water mark above your
+    // current mass makes a rupture *pay you*, which measured once as 136
+    // ruptures and six orders of magnitude of free mass in a single run.
+    const hard = Math.min(this.mass, this.checkpoint)
+    let target = Math.min(Math.max(hard, this.mass * 0.54), this.mass * 0.92)
+    target = Math.max(target, hard)
+    const lost = Math.max(0, this.mass - target)
+    this.mass = target
+    this.ruptures++
+    this.combo = 0
+    this.invuln = 4.2
+    this.scatter(this.px, this.py, lost * 0.7, 9, 260, MK_SHED)
+    // Re-forming throws you clear at speed, so the first thing you do after
+    // bursting is move, not sit still watching a predator turn around.
+    const a = this.rng.range(0, Math.PI * 2)
+    this.pvx = Math.cos(a) * 900
+    this.pvy = Math.sin(a) * 900
+    // Blow the neighbourhood clear. Without this the rival that ate you is
+    // still sitting on top of you when the invulnerability ends, and the run
+    // dies in a cascade a child can do nothing about.
+    for (let k = 0; k < MAX_RIVALS; k++) {
+      if (!this.ralive[k]) continue
+      const dx = (this.rx[k] as number) - this.px
+      const dy = (this.ry[k] as number) - this.py
+      const d = Math.hypot(dx, dy) || 1
+      const reach = this.playerRTrue * 9 + 500
+      if (d > reach) continue
+      this.rvx[k] = (dx / d) * 1100
+      this.rvy[k] = (dy / d) * 1100
+      this.rx[k] = this.px + (dx / d) * Math.max(d, reach * 0.55)
+      this.ry[k] = this.py + (dy / d) * Math.max(d, reach * 0.55)
+      this.rstate[k] = RS_FLEE
+      this.rdanger[k] = 0
+    }
+    this.emit("rupture", this.px, this.py, lost, byMass)
+    this.emit("shockwave", this.px, this.py, this.playerRTrue * 6, 0)
+    this.host.haptic("failure")
+    if (this.resonance.active) this.closeResonance()
+  }
+
+  // -------------------------------------------------------------------------
+  // Resonance
+  // -------------------------------------------------------------------------
+
+  private stepResonance(dt: number): void {
+    const res = this.resonance
+    if (!res.active) {
+      if (this.time > this.nextResonanceAt && this.invuln <= 0.4) this.openResonance()
+      return
+    }
+    res.t += dt
+    if (res.phase === 1 && res.t > 0.55) res.phase = 2
+    if (res.phase === 2 && res.t > res.duration) {
+      this.emit("resonance-fade", this.px, this.py, 0, 0)
+      this.closeResonance()
+      return
+    }
+    if (res.phase === 3 && res.t > res.duration + 0.9) {
+      this.closeResonance()
+      return
+    }
+
+    // The four spheres drift outward and orbit, so a hesitant answer costs
+    // distance and the decision has a clock without a countdown bar.
+    for (let s = 0; s < 4; s++) {
+      const i = res.spheres[s] as number
+      if (i < 0 || !this.malive[i]) continue
+      const dx = (this.mx[i] as number) - this.px
+      const dy = (this.my[i] as number) - this.py
+      const d = Math.hypot(dx, dy) || 1
+      const drift = res.phase === 2 ? 22 : 0
+      const tangent = 0.32
+      this.mvx[i] = (dx / d) * drift - (dy / d) * drift * tangent
+      this.mvy[i] = (dy / d) * drift + (dx / d) * drift * tangent
+      this.mx[i] = (this.mx[i] as number) + (this.mvx[i] as number) * dt
+      this.my[i] = (this.my[i] as number) + (this.mvy[i] as number) * dt
+      this.mphase[i] = (this.mphase[i] as number) + dt * 2.4
+    }
+  }
+
+  private openResonance(): void {
+    const res = this.resonance
+    const diff = Math.max(1, Math.min(10, Math.round(this.depth.difficulty + this.over * 2)))
+    let q: Question
+    try {
+      q = this.host.next({ difficulty: diff })
+    } catch (err) {
+      console.error("[arena] host.next failed", err)
+      this.nextResonanceAt = this.time + 20
+      return
+    }
+    // Four spheres, and the Host is not contractually obliged to supply three
+    // distractors. The padding used to be `answer + 1/2/3`, which is not a
+    // distractor: for a predicate prompt — "less than 1000", "a factor of 48",
+    // "a multiple of 5" — `answer + 1` is frequently ALSO a correct answer, so
+    // the game would fly a child into a right answer, call it wrong, and take a
+    // quarter of their mass for it. It could also duplicate a real distractor
+    // and put the same number on two spheres. A Resonance we cannot pose
+    // honestly is one we do not pose: the beat is skipped and comes back in
+    // twenty seconds.
+    const options = [q.answer]
+    for (const d of q.distractors) {
+      if (options.length >= 4) break
+      if (d !== q.answer && !options.includes(d)) options.push(d)
+    }
+    if (options.length < 4) {
+      this.nextResonanceAt = this.time + 20
+      return
+    }
+    // Claim all four spheres BEFORE committing to the beat.
+    //
+    // This used to allocate inside the placement loop and `continue` past a
+    // failed one — and the `if (slot === 0) res.correctSlot = s` assignment sat
+    // at the bottom of that same loop. So if the sphere carrying the answer was
+    // the one that could not be allocated, `correctSlot` silently kept the
+    // value from the PREVIOUS Resonance and a distractor was judged correct.
+    // With MAX_MOTES at 360 and a full field at 259 plus shed motes, rupture
+    // scatter and rival-death scatter, an exhausted pool is reachable.
+    for (let s = 0; s < 4; s++) {
+      const i = this.freeMote()
+      if (i < 0) {
+        for (let k = 0; k < s; k++) {
+          this.malive[res.spheres[k] as number] = 0
+          this.moteCount--
+        }
+        res.spheres.fill(-1)
+        this.nextResonanceAt = this.time + 20
+        return
+      }
+      // Claim it now so the next `freeMote()` cannot hand back the same slot.
+      this.malive[i] = 1
+      this.moteCount++
+      res.spheres[s] = i
+    }
+
+    const order = this.rng.shuffle([0, 1, 2, 3])
+
+    res.active = true
+    res.phase = 1
+    res.t = 0
+    res.duration = Math.max(6.5, 10.5 - this.resonanceCount * 0.16)
+    res.question = q
+    res.chosen = -1
+    res.openedAt = performance.now()
+    this.resonanceCount++
+
+    const ringR = Math.max(viewSpanFor(this.mass) * 0.30, this.playerRTrue * 3.4)
+    res.ringR = ringR
+    const base = this.rng.range(0, Math.PI * 2)
+    res.correctSlot = -1
+    for (let s = 0; s < 4; s++) {
+      const i = res.spheres[s] as number
+      const a = base + (s / 4) * Math.PI * 2
+      this.mx[i] = this.px + Math.cos(a) * ringR
+      this.my[i] = this.py + Math.sin(a) * ringR
+      this.mvx[i] = 0
+      this.mvy[i] = 0
+      const slot = order[s] as number
+      const text = options[slot] as string
+      res.labels[s] = text
+      // Drawn as a number, reported as `text`. Anything the renderer cannot
+      // draw as an int32 is drawn as 0 rather than silently wrapping to a
+      // different number, which is the one thing this game must never do.
+      const label = Number(text)
+      this.mval[i] = Number.isSafeInteger(label) && Math.abs(label) <= 2147483647 ? label : 0
+      // Spheres are all the same size — during a Resonance the size cue is
+      // deliberately switched off so the answer is the only thing that decides.
+      this.mr[i] = Math.max(this.playerRTrue * 0.82, 54)
+      this.mkind[i] = MK_ANSWER
+      this.mflip[i] = 1
+      this.mphase[i] = a
+      this.mborn[i] = this.time
+      if (slot === 0) res.correctSlot = s
+    }
+    this.emit("resonance-open", this.px, this.py, ringR, diff)
+    this.host.haptic("medium")
+  }
+
+  private resolveResonance(moteIndex: number): void {
+    const res = this.resonance
+    if (!res.active || res.phase !== 2 || !res.question) return
+    let slot = -1
+    for (let s = 0; s < 4; s++) if (res.spheres[s] === moteIndex) slot = s
+    if (slot < 0) return
+
+    const correct = slot === res.correctSlot
+    res.phase = 3
+    res.t = res.duration
+    res.chosen = slot
+    res.wasCorrect = correct
+    const ms = Math.round(performance.now() - res.openedAt)
+    res.answerMs = ms
+
+    try {
+      this.host.report({
+        questionId: res.question.id,
+        correct,
+        ms,
+        answered: res.labels[slot] ?? "",
+      })
+    } catch (err) {
+      console.error("[arena] host.report failed", err)
+    }
+
+    if (correct) {
+      this.combo++
+      const streak = Math.min(6, this.combo)
+      // Capped on purpose. The wave still clears the screen and throws every
+      // rival off you — it looks like the biggest thing in the game, because
+      // it is — but a right answer may never more than half-again your mass,
+      // or the twenty-minute curve collapses into one lucky question.
+      const before = this.mass
+      // Capped against the same sub-linear ceiling as everything else, or the
+      // curriculum beat quietly becomes the exponential the rest of the economy
+      // just stopped being.
+      const cap = Math.min(before * (0.30 + streak * 0.045), 26 * Math.sqrt(before) + 12)
+      let gained = cap * 0.55
+      const wave = this.playerRTrue * 7.5
+      for (let i = 0; i < MAX_MOTES; i++) {
+        if (!this.malive[i] || this.mkind[i] === MK_ANSWER) continue
+        const dx = (this.mx[i] as number) - this.px
+        const dy = (this.my[i] as number) - this.py
+        if (dx * dx + dy * dy > wave * wave) continue
+        const v = this.mval[i] as number
+        if (v > 0) gained = Math.min(cap, gained + v)
+        this.malive[i] = 0
+        this.moteCount--
+      }
+      const gain = gained
+      this.mass += gain
+      for (let k = 0; k < MAX_RIVALS; k++) {
+        if (!this.ralive[k]) continue
+        const dx = (this.rx[k] as number) - this.px
+        const dy = (this.ry[k] as number) - this.py
+        const d = Math.hypot(dx, dy) || 1
+        if (d > wave * 1.4) continue
+        this.rvx[k] = (dx / d) * 900
+        this.rvy[k] = (dy / d) * 900
+        this.rstate[k] = RS_FLEE
+      }
+      this.emit("resonance-hit", this.px, this.py, gain, this.combo)
+      this.emit("shockwave", this.px, this.py, wave, 2)
+      this.host.haptic("success")
+    } else {
+      const loss = this.damage(this.mass * 0.24)
+      this.combo = 0
+      this.emit("resonance-miss", this.mx[moteIndex] as number, this.my[moteIndex] as number, loss, res.correctSlot)
+      this.host.haptic("failure")
+    }
+
+    // Retire the three unchosen spheres immediately; the correct one lingers
+    // for a beat so a child who got it wrong SEES which it was, without ever
+    // being told off.
+    for (let s = 0; s < 4; s++) {
+      const i = res.spheres[s] as number
+      if (i < 0) continue
+      if (s === res.correctSlot && !correct) continue
+      if (s === slot) {
+        this.malive[i] = 0
+        this.moteCount--
+        res.spheres[s] = -1
+        continue
+      }
+      this.malive[i] = 0
+      this.moteCount--
+      res.spheres[s] = -1
+    }
+    this.nextResonanceAt = this.time + this.rng.range(21, 29)
+  }
+
+  private closeResonance(): void {
+    const res = this.resonance
+    for (let s = 0; s < 4; s++) {
+      const i = res.spheres[s] as number
+      if (i >= 0 && this.malive[i]) {
+        this.malive[i] = 0
+        this.moteCount--
+      }
+      res.spheres[s] = -1
+    }
+    res.active = false
+    res.phase = 0
+    res.question = null
+    if (this.nextResonanceAt <= this.time) this.nextResonanceAt = this.time + this.rng.range(21, 29)
+  }
+
+  // -------------------------------------------------------------------------
+
+  private maintain(dt: number): void {
+    void dt
+    const span = viewSpanFor(this.mass)
+    const cullR = span * 1.65
+
+    // Retire motes that have fallen far behind, and only then top up, so the
+    // population is stable and the field around the player is always fresh.
+    for (let i = 0; i < MAX_MOTES; i++) {
+      if (!this.malive[i] || this.mkind[i] === MK_ANSWER) continue
+      const dx = (this.mx[i] as number) - this.px
+      const dy = (this.my[i] as number) - this.py
+      if (dx * dx + dy * dy > cullR * cullR) {
+        this.malive[i] = 0
+        this.moteCount--
+        continue
+      }
+      // A shed mote is a temporary thing; it decays so the field cannot silt up.
+      if (this.mkind[i] === MK_SHED && this.time - (this.mborn[i] as number) > 14) {
+        this.malive[i] = 0
+        this.moteCount--
+      }
+    }
+
+    // Light mutual separation. Without it motes drift into stacks and the
+    // numerals — the one thing that must stay readable — pile on top of each
+    // other four deep.
+    this.grid.build(this.mx, this.my, this.malive, MAX_MOTES, this.px, this.py, this.gridSpan)
+    for (let i = 0; i < MAX_MOTES; i++) {
+      if (!this.malive[i] || this.mkind[i] === MK_ANSWER) continue
+      const xi = this.mx[i] as number
+      const yi = this.my[i] as number
+      const ri = this.mr[i] as number
+      this.grid.query(xi, yi, ri * 2.1, (j) => {
+        if (j <= i || !this.malive[j] || this.mkind[j] === MK_ANSWER) return
+        const dx = (this.mx[j] as number) - xi
+        const dy = (this.my[j] as number) - yi
+        const want = (ri + (this.mr[j] as number)) * 1.02
+        const d2 = dx * dx + dy * dy
+        if (d2 >= want * want || d2 < 1e-4) return
+        const d = Math.sqrt(d2)
+        const push = ((want - d) / want) * 34
+        const nx = dx / d
+        const ny = dy / d
+        this.mvx[i] = (this.mvx[i] as number) - nx * push
+        this.mvy[i] = (this.mvy[i] as number) - ny * push
+        this.mvx[j] = (this.mvx[j] as number) + nx * push
+        this.mvy[j] = (this.mvy[j] as number) + ny * push
+      })
+    }
+
+    const want = Math.round(this.spec.motes * this.depth.density)
+    let guard = 40
+    while (this.moteCount < want && guard-- > 0) this.spawnMote(false)
+
+    // Rivals that wander out of the world get recycled near you.
+    for (let k = 0; k < MAX_RIVALS; k++) {
+      if (!this.ralive[k]) continue
+      const dx = (this.rx[k] as number) - this.px
+      const dy = (this.ry[k] as number) - this.py
+      const far = span * (this.rleviathan[k] ? 3.4 : 2.5)
+      if (dx * dx + dy * dy > far * far) {
+        this.ralive[k] = 0
+        this.rleviathan[k] = 0
+        this.rhunter[k] = 0
+        this.rivalCount--
+        this.rrespawn[k] = this.rng.range(0.5, 1.8)
+      }
+      // A rival that outgrows the ladder leaves; otherwise one lucky bot
+      // snowballs off the top of the board and the run becomes unwinnable.
+      if (this.ralive[k] && !this.rleviathan[k] && (this.rmass[k] as number) > this.mass * 2.6) {
+        this.ralive[k] = 0
+        this.rhunter[k] = 0
+        this.rivalCount--
+        this.rrespawn[k] = this.rng.range(0.8, 2.0)
+        continue
+      }
+      // A rival that has been starved into irrelevance is recycled too.
+      if (this.ralive[k] && (this.rmass[k] as number) < this.mass * 0.06 && this.mass > 120) {
+        this.ralive[k] = 0
+        this.rivalCount--
+        this.rrespawn[k] = this.rng.range(1, 2.5)
+      }
+    }
+
+    if (this.rivalCount < this.spec.rivals) this.spawnRival(false)
+
+    if (this.depth.leviathan) {
+      let has = false
+      for (let k = 0; k < MAX_RIVALS; k++) if (this.ralive[k] && this.rleviathan[k]) has = true
+      if (!has && this.rng.chance(0.004)) this.spawnLeviathan()
+    }
+  }
+
+  /**
+   * The top `out.length` cores by mass, player included. Selection is a
+   * bounded insertion into an already-sorted window, so it is allocation-free
+   * and it is actually the *top* n — the first cut of this took the first n
+   * live rivals, and the board cheerfully disagreed with the rank readout
+   * sitting four inches away from it.
+   */
+  leaderboard(out: Int32Array, outMass: Float32Array): number {
+    const cap = out.length
+    let n = 0
+    const consider = (idx: number, mass: number): void => {
+      if (n < cap) {
+        let j = n - 1
+        while (j >= 0 && (outMass[j] as number) < mass) {
+          out[j + 1] = out[j] as number
+          outMass[j + 1] = outMass[j] as number
+          j--
+        }
+        out[j + 1] = idx
+        outMass[j + 1] = mass
+        n++
+        return
+      }
+      if (mass <= (outMass[cap - 1] as number)) return
+      let j = cap - 2
+      while (j >= 0 && (outMass[j] as number) < mass) {
+        out[j + 1] = out[j] as number
+        outMass[j + 1] = outMass[j] as number
+        j--
+      }
+      out[j + 1] = idx
+      outMass[j + 1] = mass
+    }
+    for (let k = 0; k < MAX_RIVALS; k++) {
+      if (!this.ralive[k]) continue
+      consider(k, this.rmass[k] as number)
+    }
+    consider(-1, this.mass)
+    return n
+  }
+
+  rank(): number {
+    let r = 1
+    for (let k = 0; k < MAX_RIVALS; k++) if (this.ralive[k] && (this.rmass[k] as number) > this.mass) r++
+    return r
+  }
+}
+
+export const RIVAL_NAMES = [
+  "VELA", "NYX", "ORRA", "SILT", "KELP", "MURK", "TIDE", "GLOW",
+  "HUSK", "BRINE", "PALE", "COIL", "DRIFT", "SPUR", "FATHOM", "REEF",
+  "LUMEN", "GYRE", "SHOAL", "TROUGH", "CRESS", "VENT", "ABYSS", "SALT",
+  "OBOL", "NEAP", "SWELL", "RIME", "CALM", "FLUKE", "GHOST", "SPUME",
+  "HALO", "NODE", "PRISM", "QUELL", "RUNE", "SABLE", "THORN", "UMBRA",
+  "VOLT", "WRACK", "XENON", "YARROW", "ZEPHYR", "ARGON", "BASALT", "CINDER",
+  "DELTA", "EMBER", "FLINT", "GRAIL", "HOLLOW", "IRIS", "JETSAM", "KRILL",
+  "LATCH", "MIRE", "NIMBUS", "ONYX", "PLUME", "QUARTZ", "RIPTIDE", "SIREN",
+]

--- a/dynawalla/games/arena/src/ui/hud.ts
+++ b/dynawalla/games/arena/src/ui/hud.ts
@@ -1,0 +1,287 @@
+import { RIVAL_NAMES, type World } from "../sim/world.ts"
+import { DEPTHS } from "../sim/depths.ts"
+
+const DEPTH_COUNT = DEPTHS.length
+
+/**
+ * The chrome. Deliberately almost nothing.
+ *
+ * There is no tutorial, no objective text, no status narration and no score
+ * screen, because the arena states its own rule with a picture and a child
+ * reads it in three seconds. What is left is the ladder — which is the reason
+ * to keep going — the depth you are in, and, during a Resonance, the question.
+ *
+ * Nothing here reflows per frame. Text nodes are written only when the value
+ * they show actually changes.
+ */
+
+const CSS = `
+.arena-hud{position:absolute;inset:0;pointer-events:none;font-family:ui-rounded,"SF Pro Rounded",system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;color:#cfefff;
+  -webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;overflow:hidden}
+.arena-hud *{box-sizing:border-box}
+.arena-depth{position:absolute;top:max(14px,env(safe-area-inset-top));left:max(14px,env(safe-area-inset-left));
+  font-size:clamp(11px,2.4vw,15px);letter-spacing:.30em;font-weight:800;opacity:.82;
+  text-shadow:0 0 18px rgba(80,220,255,.55),0 2px 6px rgba(0,0,0,.9)}
+.arena-depth b{display:block;font-size:clamp(9px,1.7vw,11px);letter-spacing:.22em;opacity:.55;font-weight:700;margin-top:3px}
+.arena-pips{display:flex;gap:3px;margin-top:6px}
+.arena-pip{width:9px;height:3px;border-radius:2px;background:rgba(160,225,255,.20);transition:background .5s,box-shadow .5s}
+.arena-pip.on{background:#ffd479;box-shadow:0 0 9px rgba(255,200,110,.85)}
+.arena-board{position:absolute;top:max(14px,env(safe-area-inset-top));right:max(14px,env(safe-area-inset-right));
+  min-width:112px;display:flex;flex-direction:column;gap:2px;align-items:stretch}
+.arena-row{display:flex;justify-content:space-between;gap:10px;font-size:clamp(10px,2.1vw,13px);
+  letter-spacing:.12em;font-weight:700;opacity:.5;font-variant-numeric:tabular-nums;
+  padding:2px 7px;border-radius:3px;transition:opacity .25s}
+.arena-row.me{opacity:1;background:linear-gradient(90deg,rgba(80,230,255,0),rgba(80,230,255,.20));
+  box-shadow:inset 0 0 0 1px rgba(140,240,255,.28);color:#eafcff}
+.arena-row .n{opacity:.72}
+.arena-row .v{font-weight:800}
+.arena-combo{position:absolute;left:50%;bottom:max(16px,env(safe-area-inset-bottom));transform:translate(-50%,0);
+  font-size:clamp(14px,4vw,26px);font-weight:900;letter-spacing:.10em;opacity:0;transition:opacity .18s;
+  text-shadow:0 0 26px rgba(120,255,220,.7),0 2px 8px rgba(0,0,0,.9);font-variant-numeric:tabular-nums}
+.arena-combo.on{opacity:.95}
+.arena-q{position:absolute;left:50%;top:max(52px,calc(env(safe-area-inset-top) + 42px));transform:translate(-50%,-14px);
+  opacity:0;transition:opacity .22s cubic-bezier(.2,.9,.2,1),transform .34s cubic-bezier(.2,.9,.2,1);
+  text-align:center;width:min(94vw,760px);text-wrap:balance}
+.arena-q.on{opacity:1;transform:translate(-50%,0)}
+.arena-q .p{font-size:clamp(26px,7.4vw,60px);font-weight:900;letter-spacing:.01em;color:#fff;line-height:1.05;
+  text-shadow:0 0 40px rgba(150,235,255,.85),0 0 90px rgba(90,180,255,.45),0 3px 12px rgba(0,0,0,.95)}
+/* During a Resonance the question owns the screen. The ladder used to sit
+   straight underneath a 60px prompt and the two printed through each other. */
+.arena-hud.asking .arena-board,.arena-hud.asking .arena-depth{opacity:.10}
+.arena-board,.arena-depth{transition:opacity .22s}
+.arena-q .k{font-size:clamp(9px,2.1vw,12px);letter-spacing:.42em;font-weight:800;opacity:.6;margin-bottom:6px}
+.arena-verdict{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%) scale(.86);opacity:0;
+  font-size:clamp(22px,7vw,52px);font-weight:900;letter-spacing:.16em;
+  transition:opacity .2s,transform .35s cubic-bezier(.16,1.2,.3,1);text-shadow:0 0 40px currentColor,0 2px 10px rgba(0,0,0,.9)}
+.arena-verdict.on{opacity:1;transform:translate(-50%,-50%) scale(1)}
+.arena-btns{position:absolute;left:max(12px,env(safe-area-inset-left));bottom:max(12px,env(safe-area-inset-bottom));
+  display:flex;gap:8px;pointer-events:auto}
+/* 44×44 of hit area around a 34×34 face. The only interactive control in the
+   game may not be smaller than a child's fingertip; the plate stays small so
+   the chrome stays almost nothing. */
+.arena-btn{width:44px;height:44px;padding:5px;border:0;background:none;cursor:pointer;
+  display:grid;place-items:center;transition:opacity .2s;opacity:.42}
+.arena-btn>i{width:34px;height:34px;border-radius:9px;border:1px solid rgba(140,235,255,.22);
+  background:rgba(6,20,34,.55);color:#bfeaff;font-size:13px;font-weight:800;font-style:normal;
+  display:grid;place-items:center;backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);
+  transition:transform .12s,border-color .2s}
+.arena-btn:hover,.arena-btn:focus-visible{opacity:1;outline:none}
+.arena-btn:hover>i,.arena-btn:focus-visible>i{border-color:rgba(140,235,255,.6)}
+.arena-btn:active>i{transform:scale(.92)}
+/* Muted is a STRUCK-THROUGH note, not a dimmer one. Opacity alone is meaning
+   carried by nothing a child can name, and this product does not do that. */
+.arena-btn.off{opacity:.32}
+.arena-btn.off>i{text-decoration:line-through;text-decoration-thickness:2px}
+.arena-perf{position:absolute;right:max(12px,env(safe-area-inset-right));bottom:max(12px,env(safe-area-inset-bottom));
+  font-size:10px;letter-spacing:.14em;opacity:.28;font-variant-numeric:tabular-nums;font-weight:700}
+@media (max-width:360px){.arena-board{min-width:92px}}
+@media (prefers-reduced-motion:reduce){.arena-q,.arena-verdict,.arena-combo,.arena-btn{transition-duration:.01ms}}
+`
+
+const ROWS = 6
+
+export class Hud {
+  readonly root: HTMLDivElement
+  private depthEl: HTMLDivElement
+  private depthSub: HTMLElement
+  private rows: { el: HTMLDivElement; name: HTMLSpanElement; val: HTMLSpanElement }[] = []
+  private comboEl: HTMLDivElement
+  private qEl: HTMLDivElement
+  private qPrompt: HTMLDivElement
+  private verdictEl: HTMLDivElement
+  private perfEl: HTMLDivElement
+  private muteBtn: HTMLButtonElement
+  private pips: HTMLSpanElement[] = []
+
+  private lastDepth = -1
+  private lastCombo = -1
+  private lastQ = ""
+  private lastEarned = -1
+  private asking = false
+  private lastRank = -1
+  private readonly boardIdx = new Int32Array(ROWS)
+  private readonly boardMass = new Float32Array(ROWS)
+  private readonly lastRowKey: string[] = new Array(ROWS).fill("")
+  private boardTimer = 0
+  private verdictTimer = 0
+
+  constructor(container: HTMLElement, onToggleSound: (on: boolean) => boolean) {
+    const style = document.createElement("style")
+    style.textContent = CSS
+    container.appendChild(style)
+
+    this.root = document.createElement("div")
+    this.root.className = "arena-hud"
+
+    this.depthEl = document.createElement("div")
+    this.depthEl.className = "arena-depth"
+    this.depthSub = document.createElement("b")
+    this.depthEl.appendChild(document.createTextNode(""))
+    this.depthEl.appendChild(this.depthSub)
+
+    // The rungs. Wordless, permanent, and the only thing on screen that only
+    // ever goes up — a child can see at a glance that five minutes of play
+    // actually went somewhere.
+    const pipRow = document.createElement("div")
+    pipRow.className = "arena-pips"
+    for (let i = 0; i < DEPTH_COUNT; i++) {
+      const pip = document.createElement("span")
+      pip.className = "arena-pip"
+      pipRow.appendChild(pip)
+      this.pips.push(pip)
+    }
+    this.depthEl.appendChild(pipRow)
+
+    const board = document.createElement("div")
+    board.className = "arena-board"
+    for (let i = 0; i < ROWS; i++) {
+      const el = document.createElement("div")
+      el.className = "arena-row"
+      const name = document.createElement("span")
+      name.className = "n"
+      const val = document.createElement("span")
+      val.className = "v"
+      el.appendChild(name)
+      el.appendChild(val)
+      board.appendChild(el)
+      this.rows.push({ el, name, val })
+    }
+
+    this.comboEl = document.createElement("div")
+    this.comboEl.className = "arena-combo"
+
+    this.qEl = document.createElement("div")
+    this.qEl.className = "arena-q"
+    const k = document.createElement("div")
+    k.className = "k"
+    k.textContent = "RESONANCE"
+    this.qPrompt = document.createElement("div")
+    this.qPrompt.className = "p"
+    this.qEl.appendChild(k)
+    this.qEl.appendChild(this.qPrompt)
+
+    this.verdictEl = document.createElement("div")
+    this.verdictEl.className = "arena-verdict"
+
+    const btns = document.createElement("div")
+    btns.className = "arena-btns"
+    this.muteBtn = document.createElement("button")
+    this.muteBtn.className = "arena-btn"
+    this.muteBtn.type = "button"
+    this.muteBtn.setAttribute("aria-label", "Sound")
+    this.muteBtn.setAttribute("aria-pressed", "true")
+    const note = document.createElement("i")
+    note.textContent = "♪"
+    this.muteBtn.appendChild(note)
+    this.muteBtn.addEventListener("click", () => {
+      const on = onToggleSound(this.muteBtn.classList.contains("off"))
+      this.muteBtn.classList.toggle("off", !on)
+      this.muteBtn.setAttribute("aria-pressed", String(on))
+    })
+    btns.appendChild(this.muteBtn)
+
+    this.perfEl = document.createElement("div")
+    this.perfEl.className = "arena-perf"
+
+    this.root.append(this.depthEl, board, this.comboEl, this.qEl, this.verdictEl, btns, this.perfEl)
+    container.appendChild(this.root)
+  }
+
+  private setRungs(band: number): void {
+    if (band === this.lastEarned) return
+    this.lastEarned = band
+    for (let i = 0; i < this.pips.length; i++) this.pips[i]!.classList.toggle("on", i <= band)
+  }
+
+  showVerdict(text: string, color: string): void {
+    this.verdictEl.textContent = text
+    this.verdictEl.style.color = color
+    this.verdictEl.classList.add("on")
+    this.verdictTimer = 1.1
+  }
+
+  update(world: World, dt: number, fps: number, tier: string, showPerf: boolean): void {
+    if (world.depth.index !== this.lastDepth) {
+      this.lastDepth = world.depth.index
+      this.depthEl.firstChild!.textContent = world.depth.name
+    }
+    const rank = world.rank()
+    if (rank !== this.lastRank) {
+      this.lastRank = rank
+      this.depthSub.textContent = `RANK ${rank}`
+    }
+
+    this.boardTimer -= dt
+    if (this.boardTimer <= 0) {
+      this.boardTimer = 0.22
+      const n = world.leaderboard(this.boardIdx, this.boardMass)
+      for (let i = 0; i < ROWS; i++) {
+        const row = this.rows[i]!
+        if (i >= n) {
+          if (this.lastRowKey[i] !== "") {
+            row.el.style.display = "none"
+            this.lastRowKey[i] = ""
+          }
+          continue
+        }
+        const idx = this.boardIdx[i] as number
+        const mass = Math.round(this.boardMass[i] as number)
+        const me = idx === -1
+        const nm = me ? "YOU" : (RIVAL_NAMES[world.rname[idx] as number] ?? "———")
+        const key = `${nm}|${mass}`
+        if (this.lastRowKey[i] !== key) {
+          this.lastRowKey[i] = key
+          row.el.style.display = ""
+          row.name.textContent = nm
+          row.val.textContent = String(mass)
+          row.el.classList.toggle("me", me)
+        }
+      }
+    }
+
+    const c = world.combo
+    if (c !== this.lastCombo) {
+      this.lastCombo = c
+      if (c >= 3) {
+        this.comboEl.textContent = `×${c}`
+        this.comboEl.classList.add("on")
+      } else {
+        this.comboEl.classList.remove("on")
+      }
+    }
+
+    this.setRungs(world.depth.index)
+
+    const res = world.resonance
+    const asking = res.active && res.phase >= 1
+    if (asking !== this.asking) {
+      this.asking = asking
+      this.root.classList.toggle("asking", asking)
+    }
+    const q = asking && res.question ? res.question.prompt : ""
+    if (q !== this.lastQ) {
+      this.lastQ = q
+      if (q) {
+        this.qPrompt.textContent = q
+        this.qEl.classList.add("on")
+      } else {
+        this.qEl.classList.remove("on")
+      }
+    }
+
+    if (this.verdictTimer > 0) {
+      this.verdictTimer -= dt
+      if (this.verdictTimer <= 0) this.verdictEl.classList.remove("on")
+    }
+
+    if (showPerf) {
+      this.perfEl.textContent = `${fps.toFixed(0)} FPS · ${tier.toUpperCase()}`
+    } else if (this.perfEl.textContent) {
+      this.perfEl.textContent = ""
+    }
+  }
+
+  dispose(): void {
+    this.root.remove()
+  }
+}

--- a/dynawalla/games/arena/tsconfig.json
+++ b/dynawalla/games/arena/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/dynawalla/games/arena/vite.config.ts
+++ b/dynawalla/games/arena/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite"
+
+export default defineConfig({
+  server: { port: 5188, strictPort: true, host: "127.0.0.1" },
+  preview: { port: 4188, strictPort: true, host: "127.0.0.1" },
+  build: { target: "es2022", outDir: "dist" },
+})

--- a/dynawalla/games/arena/vite.pack.config.ts
+++ b/dynawalla/games/arena/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produced a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})


### PR DESCRIPTION
## What

Finish ARENA — a bioluminescent growth arena where the size relation is the
rule — and make it an installable pack.

## Why

Two problems, both invisible from the PR as it stood:

**1. The newest work was never committed.** The branch carried ~1,024 lines
across 10 files that existed only as uncommitted files in a worktree — newest by
mtime, later than both the pushed commit and the local one. `git diff HEAD @{u}`
over the game directory was empty, so the pushed tip and the stale local commit
had identical trees and this WIP is a strict superset: nothing from the original
PR is lost. A `git worktree remove`, which the repo's own session hook
recommends after a merge, would have destroyed it with no reflog.

**2. The game shipped to nobody.** `dynawalla/packs/build.mjs` discovers a pack
by globbing for a directory under `games/` with a `pack.json` in it. ARENA had
none, so it was in the repo and invisible to the pack build, the catalog and the
app's game browser. This PR adds the pack seam.

## Blast radius

**Areas touched:** dynawalla (one game directory), 33 files, all under
`dynawalla/games/arena/`.

- [x] Scope verified: 0 files outside the game directory, 0 deletions.
- [x] Covered by the `dynawalla-packs · games + pack build` job.
- [x] **Capabilities: `items`, `items.reveal`, `haptics`.**
      `items.reveal` is **mandatory**, not a nicety: the shared host resolves an
      item's canonical value through it
      (`packs/shared/game-host/index.ts:149-167`), and without the grant
      `canonical` is `""`, every item is dropped and the question pool never
      fills — the pack mounts, warms and serves nothing, with no crash and no
      failing gate. ARENA needs it on its own terms too: a cell has to be worth
      its value before the child swims at it.
      `audio` is deliberately **not** declared — that capability is
      `feedback.sound` ("Play the app's sounds") and ARENA synthesises its own
      through `AudioContext`, as every shipped pack does. `items.answer` is not
      a capability at all.
- [x] **Curriculum.** No skill id renamed, reused or added. `covers.skills` is
      the single honest one: `dw.ns.compare.whole-numbers` — the game is
      comparison, and telling 3,418 from 3,481 at speed is the whole mechanic.
      Verified by hand against `packs/shared/curriculum/src/graph/domains/ns.ts`,
      because **`dw-pack check` does not validate skill ids** and a fictional id
      passes silently.
      **Stated limitation:** that row is `status: "draft"`. Only `add` has active
      rows (7 of 8); `ns`, `alg`, `div`, `frac` and `mul` are 100% draft.
      `ladder()` defaults to `activeNodes()` and `covers` is documented as "a
      request, not an instruction", so ARENA will be served the add ladder until
      `ns` is promoted. Relabelling it to add/sub ids would make the manifest
      lie to match a curriculum gap; promoting `ns` is curriculum work outside
      this blast radius.
- [x] **Pack back-compat.** New pack id `dynawalla.arena` at `0.1.0`. Nothing
      published changed in place, no catalog entry dropped.
- [x] **Native integrity.** No Rust, no `src-tauri` source, no `links =`.
- [x] **Strings.** Pack name/description in `pack.json`; `locales: ["en"]`
      declared honestly.
- [x] **No build artifacts.** `dist-pack/` and `src-tauri/packs/` are gitignored;
      confirmed absent from the diff.
- [x] **Secrets.** `gitleaks detect --log-opts="origin/main..HEAD"` → no leaks.

## Proof

The branch started at **19 pass / 2 fail** — which is the likeliest reason this
WIP was never committed. Now, five consecutive runs, because one green run is
not proof (a sibling game passed once then failed 3 of the next 5 from unseeded
`Math.random` in a test):

```
$ npm test        # in dynawalla/games/arena/, ×5
# pass 24 # fail 0   <- 1
# pass 24 # fail 0   <- 2
# pass 24 # fail 0   <- 3
# pass 24 # fail 0   <- 4
# pass 24 # fail 0   <- 5

$ npm run tsc
0 errors
```

The real pack builder — it builds, validates via `dw-pack check`, and stages:

```
$ node dynawalla/packs/build.mjs arena
dynawalla.arena@0.1.0 — ARENA
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       1 skills, grades 1–4
  on disk      3 files, 626367 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

```
$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
no leaks found

$ git diff --name-only origin/main...HEAD | grep -cv '^dynawalla/games/arena/'
0
$ git diff --diff-filter=D --name-only origin/main...HEAD | wc -l
0
```
