### PR TITLE
dynawalla/games/stack — MONUMENT, a one-tap precision stacker where the drop must be true twice

### DIFF
--- a/dynawalla/games/stack/.gitignore
+++ b/dynawalla/games/stack/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.vite/
+*.local

--- a/dynawalla/games/stack/README.md
+++ b/dynawalla/games/stack/README.md
@@ -1,0 +1,147 @@
+# MONUMENT
+
+A one-tap precision stacker. A stone sweeps back and forth above a tower; one
+tap sets it. The overhang shears off and the tower narrows — Ketchapp's *Stack*,
+Tower Bloxx, Holedown.
+
+**The stone carries a number, and the number changes at every turnaround.** So a
+single tap has to satisfy two things at once: the value showing must be the
+answer to the prompt, and the stone must be aligned. You get a whole pass to
+read a value and decide whether to commit or let it go round again.
+
+```
+                 3 + ? = 10
+                                     ← the prompt, on a plate, never moving
+
+              ┌────────┐
+              │   7    │             ← the stone, sweeping. Wrong value: wait.
+              └────────┘
+                 ▓▓▓▓▓▓
+                 ▓▓▓▓▓▓              ← the monument, as wide as your skill
+```
+
+## The one variable
+
+The whole game is a tug-of-war over **the width of the tower**, and nothing
+about it is hidden — a player can always see how close to death they are,
+because the tower is literally thin.
+
+| what you did | what happens to the width |
+| --- | --- |
+| right value, dead true | **grows**, and grows more the longer the run of them |
+| right value, wide | keeps exactly the overlap, as in every stacker |
+| wrong value | keeps the overlap, then the stone **cracks** and loses another quarter |
+| missed the tower entirely | the stone bursts, the tower takes a hard bite, the run lives |
+| width below the death line | it topples |
+
+A wrong answer is never marked wrong. The equation simply **completes itself**
+in the accent colour for three quarters of a second, and the sweep is held for
+the same beat so you are never reading one thing while aiming at another. The
+punishment is already in the building.
+
+Skill is expressive in a second way: a true placement **calms the sway** and a
+mistake **whips it**, so playing well makes the tower easier to hit and playing
+badly makes it harder. Past floor twelve the monument breathes, and the target
+you are aiming at moves.
+
+## Escalation, forever
+
+There is no completion state. Every eight floors the sky changes band — BASALT,
+VERDIGRIS, EMBER, AZURE, VIOLET, AURORA, VACUUM, SOLAR — with a flash, a chord,
+a shockwave and a name. After the eighth the cycle repeats with a 37° hue
+rotation, so a long run never lands on the same sky twice. **Each course keeps
+the colour of the stratum it was built in**, so the tower becomes a record of
+the climb; the strata you passed are still under you.
+
+Meanwhile the sweep accelerates, the turnaround hold shortens, the perfect
+window narrows from ±0.062 to ±0.030, the stone cycles through more candidate
+values, and the sway grows. If you sit through three full cycles without
+committing, the sweep starts leaning on you and the stone goes hot — visible
+before it is felt.
+
+## Shoring it up
+
+Where a free-to-play game would show an advertisement, this asks for one
+correct answer and rebuilds the tower. It is always available and always costs
+the same thing, but it restores less every time and bottoms out just above the
+death line, so a chain of revives ends by itself rather than by a rule.
+
+## Running it
+
+```sh
+npm install
+npm run dev            # http://127.0.0.1:4310
+npm test               # 32 tests, no browser needed
+npm run tsc
+```
+
+`?perf=1` shows fps, frame cost, tier and input latency. `?dev=1` exposes
+`window.__monument` (the sim, a tier switch and a GPU-drained benchmark).
+
+### Playtest harness
+
+```sh
+npx playwright install chromium         # once
+node tools/playtest.mjs --seconds 120 --quality 0.88 --tier ultra
+```
+
+A bot plays with the same information a player has — the value on the stone and
+its offset from true — and `--quality` is how often it plays well, so `0.74`
+produces a run with real mistakes in it. It reports measured fps, worst frame,
+GPU-drained frame cost per tier, answer-path latency and heap drift, and it
+saves screenshots at the moments worth looking at.
+
+## Shape
+
+```
+src/contract.ts        the host↔game contract, verbatim
+src/host/mathgen.ts    exact-arithmetic questions, mal-rule decoys
+src/host/stub.ts       a local Host so this runs standalone
+src/game/sim.ts        every rule that decides whether a run lives (no THREE, no DOM)
+src/game/tuning.ts     every number that decides how it feels
+src/game/strata.ts     the eight bands of sky
+src/game/mount.ts      assembly and the frame loop
+src/view/*             sky, post chain, slabs, plaques, particles, rings, tiers
+src/feel/feel.ts       trauma shake, springs, hit-stop, rate-limited flash
+src/audio/audio.ts     procedural WebAudio, no assets
+src/ui/hud.ts          DOM chrome
+```
+
+`sim.ts` is deliberately free of THREE, the DOM and time-of-day, so the rules
+can be tested at ten thousand floors a second without a GPU. That is where the
+width arithmetic, the death condition, the revive decay and the determinism
+guarantees are proven.
+
+## Things that are true and were expensive to learn
+
+- **Full per-channel ACES skews saturated blues toward purple.** An authored
+  blue-grey basalt rendered as lavender. The tone curve now runs on luminance
+  only and rescales the colour, so the palette survives.
+- **The HUD picks light-on-dark from the measured luminance of the sky it sits
+  in front of.** A hand-maintained `invert` flag will always eventually be wrong
+  on one stratum, and a run reaches all of them; AZURE shipped unreadable.
+- **An AudioContext built inside the first tap cost 206 ms.** It is built at
+  mount now, suspended, and the gesture only resumes it.
+- **`renderer.dispose()` does not release the WebGL context.** Twenty-four
+  mount/unmount cycles exhausted the browser's context pool and started killing
+  live games. `forceContextLoss()` on unmount, and a `webglcontextlost` handler
+  that stops the loop instead of throwing sixty times a second.
+- **A decoy can be secretly correct.** `2/4 + ? = 1` offered `2/4`, because the
+  "copied the fraction" mal-rule *is* the answer when the numerator is half the
+  denominator. Decoys are now filtered by exact value, not by string.
+- **Plaques are sized so they are a constant number of screen pixels.** The
+  camera solves its own distance every frame; a number a child has half a second
+  to read cannot be allowed to shrink when the shot pulls back.
+
+## Accessibility and posture
+
+- `prefers-reduced-motion` removes shake, chromatic aberration, hit-stop,
+  slow-motion and the bright frames, and cuts particle counts — without losing
+  any information: every value, every width and every outcome still reads.
+- Flashes are hard-capped at 0.24 alpha with a 260 ms minimum gap, and are an
+  exposure event rather than a sheet of white, so they never strobe.
+- Nothing is carried by colour alone; sound is disableable and always has a
+  visual twin.
+- Readable at 320 px. Touch is primary, keyboard (`Space` / `R`) is first class.
+- No ads, no loot boxes, no variable-ratio rewards, no daily streak, no
+  scarcity, no social pressure, no timer.

--- a/dynawalla/games/stack/index.html
+++ b/dynawalla/games/stack/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1, user-scalable=no"
+    />
+    <meta name="color-scheme" content="dark" />
+    <title>MONUMENT</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #05060f;
+        overscroll-behavior: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/stack/package-lock.json
+++ b/dynawalla/games/stack/package-lock.json
@@ -1,0 +1,1053 @@
+{
+  "name": "@dynawalla/game-stack",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@dynawalla/game-stack",
+      "version": "0.1.0",
+      "dependencies": {
+        "three": "^0.185.1"
+      },
+      "devDependencies": {
+        "@types/node": "^26.1.1",
+        "@types/three": "^0.185.0",
+        "playwright": "^1.62.0",
+        "typescript": "~6.0.3",
+        "vite": "^8.1.5"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/dynawalla/games/stack/package.json
+++ b/dynawalla/games/stack/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@dynawalla/game-stack",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "MONUMENT — a precision one-tap stacker where the drop must be both aligned and arithmetically true.",
+  "engines": {
+    "node": ">=24"
+  },
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4310",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'"
+  },
+  "dependencies": {
+    "three": "^0.185.1"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "@types/three": "^0.185.0",
+    "playwright": "^1.62.0",
+    "typescript": "~6.0.3",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/games/stack/src/audio/audio.ts
+++ b/dynawalla/games/stack/src/audio/audio.ts
@@ -1,0 +1,290 @@
+/**
+ * Procedural WebAudio. No assets, no samples.
+ *
+ * Every voice is transient + body + tail with a randomised pitch so a
+ * twenty-minute run never fatigues. Sound is disableable and never carries
+ * information alone — every audio cue has a visual twin.
+ *
+ * The most important voice here is `perfect()`: a pentatonic ladder that climbs
+ * one step per consecutive true placement and resets on a mistake. That single
+ * rising line is what makes a stacker compulsive; everything else is dressing.
+ */
+
+const PENTA = [0, 3, 5, 7, 10, 12, 15, 17, 19, 22, 24, 27, 29, 31, 34, 36];
+
+export class Audio {
+  private ctx: AudioContext | null = null;
+  private master: GainNode | null = null;
+  private wet: GainNode | null = null;
+  private noise: AudioBuffer | null = null;
+  enabled = true;
+  private started = false;
+
+  /**
+   * Build the graph at MOUNT, not on the first tap.
+   *
+   * Measured: constructing the context and generating the impulse response
+   * inside the first pointerdown cost 206ms — a fifth of a second of dead air
+   * on the very first thing a child does. An AudioContext may be constructed
+   * without a gesture; it simply starts suspended, and `resume()` inside the
+   * gesture is all the autoplay policy actually wants.
+   */
+  start(): void {
+    if (this.started) return;
+    const Ctor: typeof AudioContext | undefined =
+      typeof AudioContext !== "undefined"
+        ? AudioContext
+        : (globalThis as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!Ctor) return;
+    try {
+      const ctx = new Ctor();
+      this.ctx = ctx;
+      const comp = ctx.createDynamicsCompressor();
+      comp.threshold.value = -13;
+      comp.knee.value = 26;
+      comp.ratio.value = 7;
+      comp.attack.value = 0.003;
+      comp.release.value = 0.22;
+      const master = ctx.createGain();
+      master.gain.value = 0.9;
+      master.connect(comp);
+      comp.connect(ctx.destination);
+      this.master = master;
+
+      // A short procedural room. Cheap, generated once, and the difference
+      // between "beeps" and "a place".
+      const len = Math.floor(ctx.sampleRate * 0.85);
+      const ir = ctx.createBuffer(2, len, ctx.sampleRate);
+      for (let c = 0; c < 2; c++) {
+        const d = ir.getChannelData(c);
+        for (let i = 0; i < len; i++) {
+          const t = i / len;
+          d[i] = (Math.random() * 2 - 1) * Math.pow(1 - t, 3.1) * (i < 40 ? i / 40 : 1);
+        }
+      }
+      const conv = ctx.createConvolver();
+      conv.buffer = ir;
+      const wet = ctx.createGain();
+      wet.gain.value = 0.24;
+      wet.connect(conv);
+      conv.connect(master);
+      this.wet = wet;
+
+      const nlen = Math.floor(ctx.sampleRate * 2);
+      const nb = ctx.createBuffer(1, nlen, ctx.sampleRate);
+      const nd = nb.getChannelData(0);
+      for (let i = 0; i < nlen; i++) nd[i] = Math.random() * 2 - 1;
+      this.noise = nb;
+
+      this.started = true;
+    } catch (err) {
+      console.warn("[stack] audio unavailable", err);
+      this.ctx = null;
+    }
+  }
+
+  resume(): void {
+    if (this.ctx && this.ctx.state === "suspended") void this.ctx.resume();
+  }
+
+  dispose(): void {
+    try {
+      void this.ctx?.close();
+    } catch (err) {
+      console.warn("[stack] audio close failed", err);
+    }
+    this.ctx = null;
+    this.started = false;
+  }
+
+  private get t(): number {
+    return this.ctx ? this.ctx.currentTime : 0;
+  }
+
+  private env(g: GainNode, t0: number, peak: number, a: number, d: number, send = 0.35): void {
+    const p = g.gain;
+    p.setValueAtTime(0.0001, t0);
+    p.exponentialRampToValueAtTime(Math.max(0.0002, peak), t0 + a);
+    p.exponentialRampToValueAtTime(0.0001, t0 + a + d);
+    if (this.master) g.connect(this.master);
+    if (this.wet && send > 0) {
+      const s = this.ctx!.createGain();
+      s.gain.value = send;
+      g.connect(s);
+      s.connect(this.wet);
+    }
+  }
+
+  private osc(
+    type: OscillatorType,
+    f0: number,
+    f1: number,
+    t0: number,
+    dur: number,
+    peak: number,
+    a = 0.004,
+    send = 0.3,
+    detune = 0,
+  ): void {
+    const ctx = this.ctx;
+    if (!ctx) return;
+    const o = ctx.createOscillator();
+    o.type = type;
+    o.detune.value = detune;
+    o.frequency.setValueAtTime(f0, t0);
+    if (f1 !== f0) o.frequency.exponentialRampToValueAtTime(Math.max(1, f1), t0 + dur);
+    const g = ctx.createGain();
+    this.env(g, t0, peak, a, dur, send);
+    o.connect(g);
+    o.start(t0);
+    o.stop(t0 + dur + 0.06);
+  }
+
+  private burst(
+    t0: number,
+    dur: number,
+    peak: number,
+    filter: BiquadFilterType,
+    f0: number,
+    f1: number,
+    q: number,
+    send = 0.3,
+  ): void {
+    const ctx = this.ctx;
+    if (!ctx || !this.noise) return;
+    const s = ctx.createBufferSource();
+    s.buffer = this.noise;
+    s.playbackRate.value = 0.8 + Math.random() * 0.5;
+    const bq = ctx.createBiquadFilter();
+    bq.type = filter;
+    bq.Q.value = q;
+    bq.frequency.setValueAtTime(f0, t0);
+    if (f1 !== f0) bq.frequency.exponentialRampToValueAtTime(Math.max(30, f1), t0 + dur);
+    const g = ctx.createGain();
+    this.env(g, t0, peak, 0.002, dur, send);
+    s.connect(bq);
+    bq.connect(g);
+    s.start(t0, Math.random() * 1.2);
+    s.stop(t0 + dur + 0.05);
+  }
+
+  private go(): boolean {
+    return this.enabled && this.ctx !== null;
+  }
+
+  /* ── voices ───────────────────────────────────────────────────────────── */
+
+  /** Turnaround: the metronome the whole game breathes to. */
+  tick(slot: number): void {
+    if (!this.go()) return;
+    const t = this.t;
+    const f = 1180 + slot * 130 + Math.random() * 60;
+    this.osc("triangle", f, f * 0.86, t, 0.045, 0.055, 0.001, 0.12);
+    this.burst(t, 0.02, 0.03, "highpass", 2600, 2600, 0.7, 0.08);
+  }
+
+  /** The tap. Anticipation — the wind-up before the slam. */
+  release(): void {
+    if (!this.go()) return;
+    const t = this.t;
+    this.burst(t, 0.075, 0.09, "bandpass", 2200, 620, 1.2, 0.14);
+  }
+
+  /** Landing. `peril` 0→1 thins the body so a thin tower sounds thin. */
+  thunk(peril: number, floor: number): void {
+    if (!this.go()) return;
+    const t = this.t;
+    const v = 1 + (Math.random() - 0.5) * 0.09;
+    const body = (78 - peril * 26) * v * (1 + Math.min(0.35, floor * 0.002));
+    this.osc("sine", body * 1.9, body * 0.62, t, 0.19, 0.5, 0.002, 0.3);
+    this.osc("triangle", body * 3.1, body * 1.4, t, 0.1, 0.16, 0.001, 0.22);
+    this.burst(t, 0.075, 0.32 - peril * 0.1, "lowpass", 2400 * v, 380, 0.9, 0.28);
+  }
+
+  /** The ladder. Index = consecutive perfects. This is the hook. */
+  perfect(combo: number): void {
+    if (!this.go()) return;
+    const t = this.t;
+    const step = PENTA[Math.min(PENTA.length - 1, combo)] ?? 0;
+    const f = 261.63 * Math.pow(2, step / 12) * (1 + (Math.random() - 0.5) * 0.004);
+    const send = 0.42;
+    this.osc("sine", f, f, t, 0.5, 0.3, 0.004, send);
+    this.osc("sine", f * 2, f * 2, t, 0.34, 0.11, 0.003, send, 4);
+    this.osc("triangle", f * 3.01, f * 3.01, t, 0.2, 0.06, 0.002, send);
+    // A crisp strike so it reads at the top of the mix.
+    this.burst(t, 0.035, 0.11, "bandpass", f * 6, f * 3, 3.5, 0.2);
+    // The tower breathing back out.
+    this.osc("sine", f * 0.5, f * 0.505, t + 0.02, 0.6, 0.09, 0.02, 0.5);
+  }
+
+  /** Wrong value: the slab cracks. */
+  crack(): void {
+    if (!this.go()) return;
+    const t = this.t;
+    const v = 1 + (Math.random() - 0.5) * 0.14;
+    this.osc("sawtooth", 190 * v, 62 * v, t, 0.2, 0.22, 0.001, 0.28);
+    this.osc("sawtooth", 197 * v, 64 * v, t, 0.2, 0.18, 0.001, 0.28);
+    this.burst(t, 0.15, 0.42, "bandpass", 1700 * v, 260, 1.5, 0.4);
+    this.osc("sine", 58, 34, t, 0.38, 0.4, 0.003, 0.24);
+  }
+
+  /** Total miss: the slab is gone and the tower is bitten. */
+  shatter(): void {
+    if (!this.go()) return;
+    const t = this.t;
+    this.burst(t, 0.42, 0.5, "bandpass", 3800, 190, 0.9, 0.55);
+    this.burst(t, 0.24, 0.34, "highpass", 5200, 1400, 0.6, 0.4);
+    this.osc("sine", 92, 26, t, 0.6, 0.5, 0.003, 0.3);
+    this.osc("sawtooth", 120, 31, t, 0.35, 0.14, 0.002, 0.3);
+  }
+
+  /** A new band of sky. Slow, wide, worth chasing. */
+  stratum(index: number): void {
+    if (!this.go()) return;
+    const t = this.t;
+    const root = 130.81 * Math.pow(2, (index % 6) / 12);
+    for (const [i, mul] of [1, 1.5, 2, 3, 4].entries()) {
+      this.osc("sine", root * mul, root * mul * 1.002, t + i * 0.012, 1.5 - i * 0.13, 0.16 / (1 + i * 0.55), 0.13, 0.6);
+    }
+    // Riser into it.
+    this.burst(t - 0.0, 0.5, 0.16, "bandpass", 300, 5200, 1.1, 0.5);
+  }
+
+  /** The width growing back — a small upward glide under the ladder note. */
+  grow(): void {
+    if (!this.go()) return;
+    const t = this.t;
+    this.osc("sine", 320, 640, t, 0.24, 0.08, 0.01, 0.35);
+  }
+
+  collapse(): void {
+    if (!this.go()) return;
+    const t = this.t;
+    this.osc("sawtooth", 150, 24, t, 1.9, 0.42, 0.01, 0.55);
+    this.osc("sine", 88, 18, t, 2.2, 0.5, 0.02, 0.5);
+    this.burst(t, 1.7, 0.4, "lowpass", 2600, 120, 0.7, 0.6);
+    for (let i = 0; i < 7; i++) {
+      this.burst(t + 0.05 + i * 0.11 + Math.random() * 0.06, 0.16, 0.16, "bandpass", 900 + Math.random() * 1800, 220, 1.4, 0.5);
+    }
+  }
+
+  revive(ok: boolean): void {
+    if (!this.go()) return;
+    const t = this.t;
+    if (!ok) {
+      this.osc("sawtooth", 160, 70, t, 0.5, 0.24, 0.004, 0.3);
+      this.burst(t, 0.3, 0.2, "lowpass", 1400, 200, 0.8, 0.3);
+      return;
+    }
+    for (let i = 0; i < 5; i++) {
+      const f = 261.63 * Math.pow(2, (PENTA[i] ?? 0) / 12);
+      this.osc("sine", f, f, t + i * 0.055, 0.45, 0.2, 0.005, 0.5);
+    }
+  }
+
+  /** A single low pulse under the pointer-down so the tap is never silent. */
+  uiTap(): void {
+    if (!this.go()) return;
+    this.osc("sine", 420, 300, this.t, 0.07, 0.09, 0.002, 0.15);
+  }
+}

--- a/dynawalla/games/stack/src/contract.ts
+++ b/dynawalla/games/stack/src/contract.ts
@@ -1,0 +1,17 @@
+// The host↔game contract. Kept verbatim; the runtime lands underneath it.
+//
+// `mount` is declared here as the contract's callable surface and re-exported
+// from the implementation, so `import { mount } from "./contract.ts"` resolves
+// to the real function rather than to an ambient declaration that is undefined
+// at runtime.
+
+export type Question = { id: string; prompt: string; answer: string; distractors: string[]; domain: string; difficulty: number }
+export type Host = {
+  next(opts?: { domain?: string; difficulty?: number }): Question
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+  haptic(k: "light"|"medium"|"heavy"|"success"|"failure"): void
+  prefersReducedMotion(): boolean
+}
+export type Mount = (el: HTMLElement, host: Host) => { unmount(): void }
+
+export { mount } from "./game/mount.ts";

--- a/dynawalla/games/stack/src/feel/feel.ts
+++ b/dynawalla/games/stack/src/feel/feel.ts
@@ -1,0 +1,138 @@
+/**
+ * Screenshake, springs, hit-stop and a rate-limited flash.
+ *
+ * Techniques from Jan Willem Nijman's "Art of Screenshake", by name:
+ * SLEEP (hit-stop), SCREENSHAKE (trauma-squared, translational + rotational),
+ * CAMERA KICK, SCALE PUNCH (squash released by an overshooting spring),
+ * PERMANENCE (debris that survives the moment that made it), BRIGHT FRAMES
+ * (capped hard, because this is a children's product).
+ */
+
+/** Trauma-based shake — Squirrel Eiserloh's model. Squared falloff, no jitter floor. */
+export class Shake {
+  trauma = 0;
+  private t = 0;
+  x = 0;
+  y = 0;
+  rot = 0;
+  /** 0 disables translation and rotation but keeps the API alive. */
+  scale = 1;
+
+  add(v: number): void {
+    this.trauma = Math.min(1, this.trauma + v);
+  }
+
+  update(dt: number, decay: number): void {
+    this.t += dt;
+    this.trauma = Math.max(0, this.trauma - decay * dt);
+    const s = this.trauma * this.trauma * this.scale;
+    if (s <= 0.0001) {
+      this.x = 0;
+      this.y = 0;
+      this.rot = 0;
+      return;
+    }
+    // Three detuned sines read as noise but are deterministic and allocation-free.
+    const f = this.t * 41;
+    this.x = s * (Math.sin(f) * 0.6 + Math.sin(f * 2.37 + 1.7) * 0.3 + Math.sin(f * 4.11 + 0.3) * 0.1);
+    this.y = s * (Math.sin(f * 1.13 + 2.1) * 0.6 + Math.sin(f * 2.71 + 0.9) * 0.3 + Math.sin(f * 5.3) * 0.1);
+    this.rot = s * (Math.sin(f * 0.87 + 4.2) * 0.7 + Math.sin(f * 3.19 + 2.4) * 0.3);
+  }
+}
+
+/** Critically-ish damped spring toward a target; overshoots when under-damped. */
+export class Spring {
+  value: number;
+  target: number;
+  vel = 0;
+  stiffness: number;
+  damping: number;
+  constructor(v = 0, stiffness = 180, damping = 16) {
+    this.value = v;
+    this.target = v;
+    this.stiffness = stiffness;
+    this.damping = damping;
+  }
+  set(v: number): void {
+    this.value = v;
+    this.target = v;
+    this.vel = 0;
+  }
+  punch(v: number): void {
+    this.value = v;
+  }
+  kick(v: number): void {
+    this.vel += v;
+  }
+  update(dt: number): number {
+    // Sub-step so a long frame cannot make the spring explode.
+    let left = dt;
+    while (left > 0) {
+      const h = Math.min(left, 1 / 240);
+      const a = (this.target - this.value) * this.stiffness - this.vel * this.damping;
+      this.vel += a * h;
+      this.value += this.vel * h;
+      left -= h;
+    }
+    return this.value;
+  }
+}
+
+/** Freeze the world for a few milliseconds so an impact lands. */
+export class HitStop {
+  private left = 0;
+  hit(ms: number): void {
+    this.left = Math.max(this.left, ms / 1000);
+  }
+  /** Returns the dt the simulation should actually see. */
+  consume(dt: number): number {
+    if (this.left <= 0) return dt;
+    this.left -= dt;
+    if (this.left > 0) return 0;
+    const rest = -this.left;
+    this.left = 0;
+    return rest;
+  }
+  get frozen(): boolean {
+    return this.left > 0;
+  }
+}
+
+/**
+ * A white flash, hard-limited: never brighter than `maxAlpha`, never more often
+ * than `minGapMs`. Children's product — three flashes per second is the ceiling
+ * we design to, and this clamps well under it.
+ */
+export class Flash {
+  alpha = 0;
+  private last = -1e9;
+  private maxAlpha: number;
+  private minGapMs: number;
+  private fadeMs: number;
+  constructor(maxAlpha: number, minGapMs: number, fadeMs: number) {
+    this.maxAlpha = maxAlpha;
+    this.minGapMs = minGapMs;
+    this.fadeMs = fadeMs;
+  }
+  fire(now: number, strength = 1): void {
+    if (now - this.last < this.minGapMs) return;
+    this.last = now;
+    this.alpha = Math.max(this.alpha, this.maxAlpha * Math.max(0, Math.min(1, strength)));
+  }
+  update(dt: number): number {
+    if (this.alpha > 0) this.alpha = Math.max(0, this.alpha - (dt * 1000) / this.fadeMs * this.maxAlpha);
+    return this.alpha;
+  }
+}
+
+export const clamp01 = (v: number): number => (v < 0 ? 0 : v > 1 ? 1 : v);
+export const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+/** Frame-rate independent exponential approach. */
+export const damp = (a: number, b: number, lambda: number, dt: number): number =>
+  b + (a - b) * Math.exp(-lambda * dt);
+export const easeOutCubic = (t: number): number => 1 - Math.pow(1 - t, 3);
+export const easeOutBack = (t: number): number => {
+  const c1 = 1.70158;
+  const c3 = c1 + 1;
+  return 1 + c3 * Math.pow(t - 1, 3) + c1 * Math.pow(t - 1, 2);
+};

--- a/dynawalla/games/stack/src/game/mount.ts
+++ b/dynawalla/games/stack/src/game/mount.ts
@@ -453,14 +453,14 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
             drag: 0.7,
           });
         }
-        rings.fire(bx, y + T.SLAB_H * 0.52, bz, s.accent, 0.35, 2.4 + ev.combo * 0.42, 0.55, 0.9);
+        rings.fire(bx, y + T.SLAB_H * 0.52, bz, s.accent, 0.35, 1.7 + Math.min(1.9, ev.combo * 0.22), 0.5, 0.85);
         if (ev.combo >= 4) {
-          rings.fire(bx, y + T.SLAB_H * 0.52, bz, 0xffffff, 0.3, 3.6 + ev.combo * 0.7, 0.8, 0.7);
+          rings.fire(bx, y + T.SLAB_H * 0.52, bz, 0xffffff, 0.3, 2.6 + Math.min(2.4, ev.combo * 0.3), 0.66, 0.5);
         }
         if (ev.combo >= 8) {
           // A second, vertical ring at very high combos: the monument rings
           // like a struck bell and the whole screen knows about it.
-          rings.fire(bx, y + T.SLAB_H * 0.52, bz, s.accent, 0.3, 5 + ev.combo * 0.6, 1.05, 0.55, Math.PI / 2);
+          rings.fire(bx, y + T.SLAB_H * 0.52, bz, s.accent, 0.3, 3.4 + Math.min(2.6, ev.combo * 0.25), 0.85, 0.42, Math.PI / 2);
         }
         hud.callTrue(ev.combo);
         hud.setCombo(ev.combo);
@@ -468,13 +468,13 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
       }
       case "good":
         audio.thunk(sim.peril, sim.floor);
-        rings.fire(bx, y + T.SLAB_H * 0.52, bz, s.slab, 0.4, 1.7, 0.34, 0.35);
+        rings.fire(bx, y + T.SLAB_H * 0.52, bz, s.slab, 0.4, 1.35, 0.3, 0.3);
         hud.setCombo(0);
         break;
       case "wrong": {
         audio.crack();
         audio.thunk(sim.peril, sim.floor);
-        rings.fire(bx, y + T.SLAB_H * 0.52, bz, 0xffffff, 0.3, 3.1, 0.42, 0.75);
+        rings.fire(bx, y + T.SLAB_H * 0.52, bz, 0xffffff, 0.3, 2.1, 0.36, 0.6);
         hud.setCombo(0);
         for (let i = 0; i < tier.debris; i++) {
           fallers.launch(
@@ -507,7 +507,7 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
       }
       case "miss": {
         audio.shatter();
-        rings.fire(bx, y, bz, 0xffffff, 0.25, 4.4, 0.6, 0.9);
+        rings.fire(bx, y, bz, 0xffffff, 0.25, 3.0, 0.5, 0.7);
         hud.setCombo(0);
         for (let i = 0; i < tier.debris * 2; i++) {
           fallers.launch(
@@ -582,8 +582,8 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
       drag: 0.8,
       radius: 0.7,
     });
-    rings.fire(0, sim.topY, 0, cur.accent, 0.3, 14, 1.6, 1.0);
-    rings.fire(0, sim.topY, 0, 0xffffff, 0.3, 9, 1.2, 0.8);
+    rings.fire(0, sim.topY, 0, cur.accent, 0.3, 8, 1.4, 0.75);
+    rings.fire(0, sim.topY, 0, 0xffffff, 0.3, 5.5, 1.05, 0.55);
     pool.hideFrom(0);
     block.visible = false;
     plaqueBlock.hide();
@@ -613,8 +613,8 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
           hitstop.hit(T.HITSTOP_STRATUM_MS);
         }
         hud.announceBand(s.name);
-        rings.fire(0, sim.topY, 0, s.accent, 0.3, 9, 1.3, 0.85);
-        rings.fire(0, sim.topY, 0, 0xffffff, 0.3, 5.5, 1.0, 0.6);
+        rings.fire(0, sim.topY, 0, s.accent, 0.3, 5.5, 1.1, 0.6);
+        rings.fire(0, sim.topY, 0, 0xffffff, 0.3, 3.6, 0.85, 0.45);
         sparks.emit(0, sim.topY, 0, {
           count: Math.round(tier.particles * 0.16 * (reduced ? 0.4 : 1)),
           color: s.accent,
@@ -654,6 +654,10 @@ export function mount(el: HTMLElement, host: Host): { unmount(): void } {
     const ev = sim.place(clock);
     if (!ev) return;
     audio.release();
+    // The run is broken the instant the stone is committed, not 88ms later
+    // when it lands — otherwise the prompt reveals the truth while the combo
+    // chip is still boasting about a streak that no longer exists.
+    if (ev.outcome !== "perfect") hud.setCombo(0);
     if (firstPlacement) {
       firstPlacement = false;
       hud.hideHint();

--- a/dynawalla/games/stack/src/game/mount.ts
+++ b/dynawalla/games/stack/src/game/mount.ts
@@ -1,0 +1,1144 @@
+/**
+ * MONUMENT — assembly and the frame loop.
+ *
+ * Composition rule the camera obeys: the top of the tower and the stone about
+ * to be set are ALWAYS at the same place on screen, whatever the aspect ratio.
+ * On a phone held upright the extra room goes to the tower, so you see how far
+ * you have come; in landscape it goes to the sweep, so you can see the stone
+ * approach. The distance is solved per frame from the sweep width, which means
+ * the shot tightens by itself as the tower narrows — the drama is free.
+ */
+
+import {
+  Color,
+  DirectionalLight,
+  Fog,
+  Group,
+  HemisphereLight,
+  Mesh,
+  MeshStandardMaterial,
+  PerspectiveCamera,
+  PointLight,
+  Scene,
+  Vector3,
+  WebGLRenderer,
+  BoxGeometry,
+  SRGBColorSpace,
+} from "three";
+
+import type { Host } from "../contract.ts";
+import { Sim, type PlaceEvent, type SimEvent } from "./sim.ts";
+import { T } from "./tuning.ts";
+import { isBright, luma, stratumAt, type Stratum } from "./strata.ts";
+import { Flash, HitStop, Shake, Spring, clamp01, damp, easeOutCubic } from "../feel/feel.ts";
+import { Audio } from "../audio/audio.ts";
+import { Hud } from "../ui/hud.ts";
+import { Sky } from "../view/sky.ts";
+import { Post } from "../view/post.ts";
+import { Fallers, Sparks } from "../view/particles.ts";
+import { Rings, disposeRingGeometry } from "../view/rings.ts";
+import { Plaque, SlabPool, disposeSharedGeometry } from "../view/slabs.ts";
+import { disposeTextures } from "../view/textures.ts";
+import { FpsMeter, TierWatch, detectTier, TIERS, type Tier } from "../view/tier.ts";
+
+const DEG = Math.PI / 180;
+const ELEV = 21 * DEG;
+const AZ = 45 * DEG;
+const FOV = 34;
+/** Where the stone-about-to-be-set sits on screen, 0 = top, 1 = bottom. */
+const ACTION_SCREEN_Y = 0.33;
+const HOVER = T.SLAB_H * 1.15;
+const DROP_MS = 88;
+
+export function mount(el: HTMLElement, host: Host): { unmount(): void } {
+  const reduced = host.prefersReducedMotion();
+  let raf = 0;
+  let running = true;
+  let tier: Tier = detectTier();
+
+  /* ── surface ────────────────────────────────────────────────────────── */
+
+  const holder = document.createElement("div");
+  holder.style.cssText =
+    "position:relative;width:100%;height:100%;overflow:hidden;background:#05060f;touch-action:none;";
+  const canvas = document.createElement("canvas");
+  canvas.style.cssText = "position:absolute;inset:0;width:100%;height:100%;display:block;";
+  holder.appendChild(canvas);
+  el.appendChild(holder);
+
+  const renderer = new WebGLRenderer({
+    canvas,
+    antialias: tier.antialias,
+    powerPreference: "high-performance",
+    stencil: false,
+    alpha: false,
+  });
+  renderer.outputColorSpace = SRGBColorSpace;
+  // A lost context must stop the loop rather than throw sixty times a second.
+  // Browsers cap the number of live WebGL contexts per document, so a host that
+  // mounts and unmounts packs will eventually take one away.
+  const onContextLost = (e: Event): void => {
+    e.preventDefault();
+    running = false;
+    cancelAnimationFrame(raf);
+    console.warn("[stack] WebGL context lost — the game has stopped");
+  };
+  canvas.addEventListener("webglcontextlost", onContextLost, false);
+  renderer.shadowMap.enabled = true;
+  renderer.setPixelRatio(Math.min(devicePixelRatio || 1, tier.dprCap));
+
+  const scene = new Scene();
+  const fogColor = new Color(0x080a18);
+  scene.fog = new Fog(fogColor.getHex(), 8, 30);
+
+  const camera = new PerspectiveCamera(FOV, 1, 0.35, 220);
+
+  /* ── light ──────────────────────────────────────────────────────────── */
+
+  const hemi = new HemisphereLight(0x3a4a86, 0x0a0c18, 0.78);
+  scene.add(hemi);
+
+  const key = new DirectionalLight(0xfff0dd, 1.55);
+  key.castShadow = true;
+  key.shadow.mapSize.set(tier.shadowSize || 256, tier.shadowSize || 256);
+  key.shadow.camera.left = -3.2;
+  key.shadow.camera.right = 3.2;
+  key.shadow.camera.top = 3.2;
+  key.shadow.camera.bottom = -3.2;
+  key.shadow.camera.near = 0.5;
+  key.shadow.camera.far = 18;
+  key.shadow.bias = -0.0022;
+  key.shadow.normalBias = 0.02;
+  scene.add(key, key.target);
+
+  const rim = new DirectionalLight(0x4d7bff, 0.95);
+  scene.add(rim, rim.target);
+
+  // The hot enamel, as an EVENT rather than a coat of paint. Tinting the slab
+  // bodies with the accent turned an authored blue-grey into lavender in every
+  // frame; a point light that flares on contact and dies in a third of a second
+  // puts the same colour on the stone only when something happened.
+  const flare = new PointLight(0xff6a1f, 0, 4.5, 2);
+  scene.add(flare);
+  let flareI = 0;
+
+  /* ── the monument ───────────────────────────────────────────────────── */
+
+  const tower = new Group();
+  scene.add(tower);
+
+  const pool = new SlabPool(tier.slabPool, true);
+  tower.add(pool.group);
+
+  // The shaft the whole monument stands on. Without it the first course floats
+  // in the sky and the composition has no weight; with it the tower reads as
+  // something that goes all the way down past the city.
+  const plinthMat = new MeshStandardMaterial({ roughness: 0.72, metalness: 0.0 });
+  const plinth = new Mesh(new BoxGeometry(1, 1, 1), plinthMat);
+  plinth.castShadow = false;
+  plinth.receiveShadow = true;
+  tower.add(plinth);
+
+  const blockMat = new MeshStandardMaterial({ roughness: 0.5, metalness: 0.04 });
+  const block = new Mesh(new BoxGeometry(1, 1, 1), blockMat);
+  block.castShadow = true;
+  block.receiveShadow = false;
+  scene.add(block);
+
+  const plaqueBlock = new Plaque();
+  const plaqueTower = [new Plaque(), new Plaque()];
+  scene.add(plaqueBlock.group, ...plaqueTower.map((p) => p.group));
+
+  const sparks = new Sparks(tier.particles);
+  scene.add(sparks.points);
+  const fallers = new Fallers(tier.debris * 4);
+  scene.add(fallers.mesh);
+  const rings = new Rings(6);
+  scene.add(rings.group);
+
+  const sky = new Sky();
+  let post = new Post(1, 1, tier.bloom, tier.bloomDiv);
+
+  /* ── systems ────────────────────────────────────────────────────────── */
+
+  const audio = new Audio();
+  audio.start(); // builds the graph now; a gesture only resumes it
+  const shake = new Shake();
+  shake.scale = reduced ? 0 : 1;
+  const hitstop = new HitStop();
+  const flash = new Flash(reduced ? 0 : T.FLASH_MAX_ALPHA, T.FLASH_MIN_GAP_MS, T.FLASH_FADE_MS);
+  const camY = new Spring(0, T.CAM_SPRING, T.CAM_DAMP);
+  const squash = new Spring(1, T.SQUASH_SPRING, T.SQUASH_DAMP);
+  const fps = new FpsMeter();
+
+  const sim = new Sim(host);
+
+  function restart(): void {
+    hud.hideOver();
+    fallers.clear();
+    rings.clear();
+    sparks.clearAmbient();
+    sim.reset();
+    collapsed = false;
+    collapseAt = -1;
+    visualFloor = 0;
+    camY.set(camTargetY());
+    drop.active = false;
+    drop.ev = null;
+    slowmo = 0;
+    shake.trauma = 0;
+    applyStratum(stratumAt(0), 1);
+  }
+
+  const hud = new Hud(
+    holder,
+    {
+      onRestart: restart,
+      onRevive: () => {
+        sim.offerRevive();
+        if (sim.reviveQ) hud.showRevive(sim.reviveQ.prompt, sim.reviveChoices);
+      },
+      onChoose: (v) => {
+        const answer = sim.reviveQ?.answer ?? "";
+        hud.markChoice(v, answer);
+        const ok = sim.answerRevive(v, clock);
+        audio.revive(ok);
+        setTimeout(
+          () => {
+            if (ok) {
+              hud.hideOver();
+              fallers.clear();
+              visualFloor = sim.floor;
+              camY.set(camTargetY());
+              rebuildFromSim();
+            } else {
+              hud.showOver(sim.floor, false);
+            }
+          },
+          ok ? 480 : 900,
+        );
+      },
+      onToggleAudio: (on) => {
+        audio.enabled = on;
+        if (on) audio.resume();
+      },
+    },
+    reduced,
+  );
+
+  /* ── palette blending ───────────────────────────────────────────────── */
+
+  let cur: Stratum = stratumAt(0);
+  let want: Stratum = cur;
+  const cHemiUp = new Color();
+  const cHemiDown = new Color();
+  const cKey = new Color();
+  const cRim = new Color();
+  const cSlab = new Color();
+  const cAccent = new Color();
+  const cFog = new Color();
+  const scratch = new Color();
+  const scratch2 = new Color();
+
+  function applyStratum(s: Stratum, t: number): void {
+    want = s;
+    if (t >= 1) {
+      cur = s;
+      cHemiUp.setHex(s.hemiUp);
+      cHemiDown.setHex(s.hemiDown);
+      cKey.setHex(s.key);
+      cRim.setHex(s.rim);
+      cSlab.setHex(s.slab);
+      cAccent.setHex(s.accent);
+      cFog.setHex(s.sky[0]);
+      sky.setPalette(s.sky, s.spire, s.accent, s.name.startsWith("AURORA") ? 1 : 0);
+      pushPalette();
+      sparks.seedMotes(camY.value, reduced ? Math.round(tier.motes * 0.35) : tier.motes, s.mote.color, s.mote.rise, s.mote.drift, s.mote.size);
+    }
+  }
+
+  function blendPalette(dt: number): void {
+    if (cur === want) return;
+    const t = Math.min(1, dt * 2.6);
+    scratch.setHex(want.hemiUp);
+    cHemiUp.lerp(scratch, t);
+    scratch.setHex(want.hemiDown);
+    cHemiDown.lerp(scratch, t);
+    scratch.setHex(want.key);
+    cKey.lerp(scratch, t);
+    scratch.setHex(want.rim);
+    cRim.lerp(scratch, t);
+    scratch.setHex(want.slab);
+    cSlab.lerp(scratch, t);
+    scratch.setHex(want.accent);
+    cAccent.lerp(scratch, t);
+    scratch.setHex(want.sky[0]);
+    cFog.lerp(scratch, t);
+    sky.lerpPalette(want.sky, want.spire, want.accent, want.name.startsWith("AURORA") ? 1 : 0, t);
+    pushPalette();
+  }
+
+  function pushPalette(): void {
+    hemi.color.copy(cHemiUp);
+    hemi.groundColor.copy(cHemiDown);
+    key.color.copy(cKey);
+    rim.color.copy(cRim);
+    (scene.fog as Fog).color.copy(cFog);
+    fallers.setColor(cSlab.getHex());
+    const bright = isBright(want);
+    // An accent chosen to glow against a night sky is unreadable as text on a
+    // bright one, so it is darkened for chrome use only — the 3D accent, which
+    // is emissive and blooms, keeps its authored value.
+    scratch.copy(cAccent);
+    if (bright && luma(scratch.getHex()) > 0.3) scratch.multiplyScalar(0.42);
+    hud.setPalette(bright, bright ? "#f4f6fb" : "#" + cFog.getHexString(), "#" + scratch.getHexString());
+  }
+
+  /* ── framing ────────────────────────────────────────────────────────── */
+
+  let visualFloor = 0;
+  let aspect = 1;
+  let dist = 9;
+  /**
+   * Plaques are sized in world units but must be a constant number of SCREEN
+   * pixels, because a value a child reads under time pressure cannot get
+   * smaller when the camera happens to pull back. The camera solves its own
+   * distance per frame, so the plaques divide it back out.
+   */
+  const PLAQUE_REF = 9.5;
+  let plaqueK = 1;
+
+  function camTargetY(): number {
+    return (visualFloor + 1) * T.SLAB_H;
+  }
+
+  function solveDistance(): number {
+    const halfFovY = (FOV * 0.5) * DEG;
+    const tanY = Math.tan(halfFovY);
+    const tanX = tanY * aspect;
+    // Horizontal: the whole sweep, plus the stone, plus air.
+    const needX = sim.sweepHalf + 0.55 + 0.2;
+    // Vertical: the stone above, and seven courses of tower below.
+    const needY = (1.35 + 7 * T.SLAB_H) * 0.5;
+    const dx = needX / Math.max(0.05, tanX);
+    const dy = needY / Math.max(0.05, tanY) / Math.cos(ELEV);
+    return Math.max(6.4, Math.min(30, Math.max(dx, dy)));
+  }
+
+  /* ── drop animation ─────────────────────────────────────────────────── */
+
+  const drop = { active: false, t: 0, ev: null as PlaceEvent | null, x: 0, z: 0 };
+
+  /* ── events ─────────────────────────────────────────────────────────── */
+
+  const evBuf: SimEvent[] = [];
+  let clock = 0;
+  let slowmo = 0;
+  let collapseAt = -1;
+  let collapsed = false;
+  let firstPlacement = true;
+
+  function onPlaceImpact(ev: PlaceEvent): void {
+    const s = cur;
+    const y = ev.outcome === "miss" ? (visualFloor + 1) * T.SLAB_H : (sim.floor) * T.SLAB_H;
+    const bx = drop.x;
+    const bz = drop.z;
+
+    if (ev.outcome !== "miss") visualFloor = sim.floor;
+
+    // SLEEP, SCREENSHAKE, CAMERA KICK.
+    const stopMs =
+      ev.outcome === "perfect"
+        ? T.HITSTOP_PERFECT_MS
+        : ev.outcome === "wrong"
+          ? T.HITSTOP_WRONG_MS
+          : ev.outcome === "miss"
+            ? T.HITSTOP_MISS_MS
+            : T.HITSTOP_PLACE_MS;
+    if (!reduced) hitstop.hit(stopMs);
+    shake.add(
+      ev.outcome === "perfect"
+        ? T.TRAUMA_PERFECT
+        : ev.outcome === "wrong"
+          ? T.TRAUMA_WRONG
+          : ev.outcome === "miss"
+            ? T.TRAUMA_MISS
+            : T.TRAUMA_PLACE,
+    );
+    if (!reduced) camY.kick(-(ev.outcome === "wrong" || ev.outcome === "miss" ? T.CAM_KICK_WRONG : T.CAM_KICK_PLACE) * 26);
+    squash.punch(ev.outcome === "perfect" ? T.SQUASH_PERFECT : T.SQUASH_PLACE);
+
+    flare.position.set(bx, y + T.SLAB_H * 1.6, bz);
+    // A mistake does not get the celebratory accent; it gets a hard white
+    // magnesium flash, which reads as damage rather than as a reward.
+    if (ev.outcome === "wrong" || ev.outcome === "miss") flare.color.setRGB(1, 0.86, 0.74);
+    else flare.color.copy(cAccent);
+    flareI =
+      ev.outcome === "perfect" ? 4.2 + Math.min(6, ev.combo * 0.8)
+      : ev.outcome === "wrong" ? 3.6
+      : ev.outcome === "miss" ? 5.2
+      : 1.7;
+
+    const p = reduced ? 0.4 : 1;
+    // Contact dust — always, so every placement has weight.
+    sparks.emit(bx, y - T.SLAB_H * 0.5, bz, {
+      count: Math.round((ev.outcome === "perfect" ? 26 : 18) * p),
+      color: s.slab,
+      color2: s.accent,
+      speed: 2.5,
+      dome: 0.18,
+      size: 0.055,
+      life: 0.5,
+      gravity: 5.5,
+      drag: 2.4,
+      radius: Math.max(sim.wx, sim.wz) * 0.5,
+    });
+
+    if (ev.shear) {
+      // The overhang leaves as one slab, the way it does in every stacker worth
+      // copying — then throws chips.
+      const sgn = ev.shear.sign;
+      fallers.launch(
+        ev.shear.cx,
+        y,
+        ev.shear.cz,
+        Math.max(0.02, ev.shear.wx),
+        T.SLAB_H,
+        Math.max(0.02, ev.shear.wz),
+        ev.shear.axis === 0 ? sgn * 1.5 : 0,
+        1.1,
+        ev.shear.axis === 1 ? sgn * 1.5 : 0,
+        6.5,
+        2.6,
+      );
+      sparks.emit(ev.shear.cx, y, ev.shear.cz, {
+        count: Math.round(10 * p),
+        color: s.slab,
+        speed: 1.9,
+        dome: 0.5,
+        size: 0.04,
+        life: 0.45,
+        gravity: 9,
+        drag: 1.5,
+      });
+    }
+
+    switch (ev.outcome) {
+      case "perfect": {
+        audio.perfect(ev.combo);
+        audio.grow();
+        flash.fire(clock * 1000, 0.55 + Math.min(0.45, ev.combo * 0.06));
+        // A ring of accent sparks, escalating hard with the combo.
+        sparks.emit(bx, y, bz, {
+          count: Math.round(Math.min(90, 26 + ev.combo * 9) * p),
+          color: s.accent,
+          color2: 0xffffff,
+          speed: 3.4 + ev.combo * 0.32,
+          dome: 0.34,
+          size: 0.075,
+          life: 0.75,
+          gravity: 3.2,
+          drag: 1.5,
+          radius: Math.max(sim.wx, sim.wz) * 0.5,
+        });
+        if (ev.combo >= 3) {
+          sparks.emit(bx, y, bz, {
+            count: Math.round(Math.min(50, ev.combo * 6) * p),
+            color: 0xffffff,
+            speed: 1.1,
+            dome: 1,
+            size: 0.13,
+            life: 1.5,
+            gravity: -0.9,
+            drag: 0.7,
+          });
+        }
+        rings.fire(bx, y + T.SLAB_H * 0.52, bz, s.accent, 0.35, 2.4 + ev.combo * 0.42, 0.55, 0.9);
+        if (ev.combo >= 4) {
+          rings.fire(bx, y + T.SLAB_H * 0.52, bz, 0xffffff, 0.3, 3.6 + ev.combo * 0.7, 0.8, 0.7);
+        }
+        if (ev.combo >= 8) {
+          // A second, vertical ring at very high combos: the monument rings
+          // like a struck bell and the whole screen knows about it.
+          rings.fire(bx, y + T.SLAB_H * 0.52, bz, s.accent, 0.3, 5 + ev.combo * 0.6, 1.05, 0.55, Math.PI / 2);
+        }
+        hud.callTrue(ev.combo);
+        hud.setCombo(ev.combo);
+        break;
+      }
+      case "good":
+        audio.thunk(sim.peril, sim.floor);
+        rings.fire(bx, y + T.SLAB_H * 0.52, bz, s.slab, 0.4, 1.7, 0.34, 0.35);
+        hud.setCombo(0);
+        break;
+      case "wrong": {
+        audio.crack();
+        audio.thunk(sim.peril, sim.floor);
+        rings.fire(bx, y + T.SLAB_H * 0.52, bz, 0xffffff, 0.3, 3.1, 0.42, 0.75);
+        hud.setCombo(0);
+        for (let i = 0; i < tier.debris; i++) {
+          fallers.launch(
+            bx + (Math.random() - 0.5) * sim.wx,
+            y + (Math.random() - 0.4) * T.SLAB_H,
+            bz + (Math.random() - 0.5) * sim.wz,
+            0.06 + Math.random() * 0.11,
+            0.05 + Math.random() * 0.1,
+            0.06 + Math.random() * 0.11,
+            (Math.random() - 0.5) * 5,
+            1.4 + Math.random() * 2.6,
+            (Math.random() - 0.5) * 5,
+            13,
+            1.5 + Math.random(),
+          );
+        }
+        sparks.emit(bx, y, bz, {
+          count: Math.round(44 * p),
+          color: s.slab,
+          color2: s.accent,
+          speed: 4.4,
+          dome: 0.6,
+          size: 0.07,
+          life: 0.66,
+          gravity: 11,
+          drag: 1.1,
+          radius: sim.wx * 0.4,
+        });
+        break;
+      }
+      case "miss": {
+        audio.shatter();
+        rings.fire(bx, y, bz, 0xffffff, 0.25, 4.4, 0.6, 0.9);
+        hud.setCombo(0);
+        for (let i = 0; i < tier.debris * 2; i++) {
+          fallers.launch(
+            bx + (Math.random() - 0.5) * 0.7,
+            y + (Math.random() - 0.5) * 0.3,
+            bz + (Math.random() - 0.5) * 0.7,
+            0.07 + Math.random() * 0.16,
+            0.06 + Math.random() * 0.12,
+            0.07 + Math.random() * 0.16,
+            (Math.random() - 0.5) * 4.5,
+            0.6 + Math.random() * 2.2,
+            (Math.random() - 0.5) * 4.5,
+            15,
+            2.2 + Math.random(),
+          );
+        }
+        sparks.emit(bx, y, bz, {
+          count: Math.round(70 * p),
+          color: s.slab,
+          color2: 0xffffff,
+          speed: 5.6,
+          dome: 0.7,
+          size: 0.08,
+          life: 0.85,
+          gravity: 12,
+          drag: 0.9,
+          radius: 0.4,
+        });
+        break;
+      }
+    }
+
+    hud.setFloor(sim.floor, sim.best);
+  }
+
+  function collapse(): void {
+    collapseAt = clock;
+    collapsed = true;
+    audio.collapse();
+    shake.add(T.TRAUMA_COLLAPSE);
+    if (!reduced) slowmo = 1.1;
+    // Throw the visible monument outward. PERMANENCE, at scale.
+    const n = Math.min(sim.slabs.length, tier.slabPool);
+    for (let k = 0; k < n; k++) {
+      const sl = sim.slabs[sim.slabs.length - 1 - k]!;
+      const y = sl.i * T.SLAB_H;
+      const a = Math.random() * Math.PI * 2;
+      const sp = 1.4 + Math.random() * 2.6 + k * 0.06;
+      fallers.launch(
+        sl.cx,
+        y,
+        sl.cz,
+        sl.wx,
+        T.SLAB_H,
+        sl.wz,
+        Math.cos(a) * sp,
+        1.2 + Math.random() * 2.4,
+        Math.sin(a) * sp,
+        7,
+        3.4 + Math.random() * 1.6,
+      );
+    }
+    sparks.emit(0, sim.topY, 0, {
+      count: Math.round(tier.particles * 0.28),
+      color: cur.slab,
+      color2: cur.accent,
+      speed: 6,
+      dome: 0.55,
+      size: 0.1,
+      life: 1.5,
+      gravity: 9,
+      drag: 0.8,
+      radius: 0.7,
+    });
+    rings.fire(0, sim.topY, 0, cur.accent, 0.3, 14, 1.6, 1.0);
+    rings.fire(0, sim.topY, 0, 0xffffff, 0.3, 9, 1.2, 0.8);
+    pool.hideFrom(0);
+    block.visible = false;
+    plaqueBlock.hide();
+    for (const p of plaqueTower) p.hide();
+  }
+
+  function rebuildFromSim(): void {
+    collapsed = false;
+    // After a revive the tower stands again; nothing to rebuild but the view
+    // state, since the sim kept every course.
+    drop.active = false;
+    collapseAt = -1;
+  }
+
+  function handle(e: SimEvent): void {
+    switch (e.type) {
+      case "tick":
+        audio.tick(e.slot);
+        break;
+      case "stratum": {
+        const s = stratumAt(e.index);
+        applyStratum(s, 1);
+        audio.stratum(e.index);
+        flash.fire(clock * 1000, 1);
+        if (!reduced) {
+          slowmo = 0.42;
+          hitstop.hit(T.HITSTOP_STRATUM_MS);
+        }
+        hud.announceBand(s.name);
+        rings.fire(0, sim.topY, 0, s.accent, 0.3, 9, 1.3, 0.85);
+        rings.fire(0, sim.topY, 0, 0xffffff, 0.3, 5.5, 1.0, 0.6);
+        sparks.emit(0, sim.topY, 0, {
+          count: Math.round(tier.particles * 0.16 * (reduced ? 0.4 : 1)),
+          color: s.accent,
+          color2: 0xffffff,
+          speed: 5.2,
+          dome: 0.9,
+          size: 0.11,
+          life: 1.8,
+          gravity: -0.4,
+          drag: 0.9,
+          radius: 1.1,
+        });
+        break;
+      }
+      case "collapse":
+        collapse();
+        break;
+      case "restart":
+        hud.setFloor(0, sim.best);
+        hud.setCombo(0);
+        break;
+      default:
+        break;
+    }
+  }
+
+  /* ── input ──────────────────────────────────────────────────────────── */
+
+  let lastTapAt = 0;
+  let lastLatency = 0;
+
+  function tap(evTs?: number): void {
+    audio.resume();
+    if (sim.phase !== "sweep") return;
+    if (drop.active) return;
+    const t0 = performance.now();
+    const ev = sim.place(clock);
+    if (!ev) return;
+    audio.release();
+    if (firstPlacement) {
+      firstPlacement = false;
+      hud.hideHint();
+    }
+    drop.active = true;
+    drop.t = 0;
+    drop.ev = ev;
+    // The axis has already flipped inside place(); recover the placement axis.
+    // A miss places nothing, so the stone falls where the sweep actually was.
+    const placedAxis = ev.outcome === "miss" ? sim.axis : sim.axis === 0 ? 1 : 0;
+    if (placedAxis === 0) {
+      drop.x = ev.outcome === "miss" ? simSweepAtPlacement : ev.slab.cx;
+      drop.z = ev.slab.cz;
+    } else {
+      drop.z = ev.outcome === "miss" ? simSweepAtPlacement : ev.slab.cz;
+      drop.x = ev.slab.cx;
+    }
+    lastLatency = performance.now() - (evTs ?? t0);
+    lastTapAt = t0;
+    void lastTapAt;
+  }
+
+  // `place()` consumes the sweep, so remember where the stone actually was.
+  let simSweepAtPlacement = 0;
+  const origPlace = sim.place.bind(sim);
+  sim.place = (t: number) => {
+    simSweepAtPlacement = sim.sweep;
+    return origPlace(t);
+  };
+
+  const onPointerDown = (e: PointerEvent): void => {
+    if ((e.target as HTMLElement).closest("button")) return;
+    e.preventDefault();
+    tap(e.timeStamp);
+  };
+  const onKey = (e: KeyboardEvent): void => {
+    if (e.code === "Space" || e.code === "Enter" || e.code === "ArrowDown" || e.code === "KeyR") {
+      e.preventDefault();
+      if (sim.phase !== "sweep" && collapseAt < 0) restart();
+      else if (e.code !== "KeyR") tap();
+    } else if (e.code === "KeyP") {
+      showPerf = !showPerf;
+    } else if (e.code === "KeyM") {
+      audio.enabled = !audio.enabled;
+    }
+  };
+  holder.addEventListener("pointerdown", onPointerDown, { passive: false });
+  window.addEventListener("keydown", onKey);
+
+  let showPerf =
+    typeof location !== "undefined" && /(^|[?&])perf=1/.test(location.search);
+
+  /* ── resize ─────────────────────────────────────────────────────────── */
+
+  function resize(): void {
+    const w = holder.clientWidth || 320;
+    const h = holder.clientHeight || 480;
+    aspect = w / h;
+    camera.aspect = aspect;
+    camera.updateProjectionMatrix();
+    renderer.setPixelRatio(Math.min(devicePixelRatio || 1, tier.dprCap));
+    renderer.setSize(w, h, false);
+    const px = renderer.getPixelRatio();
+    post.resize(w * px, h * px);
+    sparks.setScale(h * px * 0.42);
+  }
+
+  const ro = new ResizeObserver(() => resize());
+  ro.observe(holder);
+  resize();
+  applyStratum(stratumAt(0), 1);
+  camY.set(camTargetY());
+
+  function retier(next: Tier): void {
+    tier = next;
+    renderer.setPixelRatio(Math.min(devicePixelRatio || 1, tier.dprCap));
+    renderer.shadowMap.enabled = true;
+    key.shadow.mapSize.set(tier.shadowSize || 256, tier.shadowSize || 256);
+    key.shadow.map?.dispose();
+    key.shadow.map = null;
+    pool.resize(tier.slabPool, true);
+    post.setTier(tier.bloom, tier.bloomDiv);
+    resize();
+  }
+  const watch = new TierWatch(retier);
+
+  /* ── the loop ───────────────────────────────────────────────────────── */
+
+  let last = performance.now();
+  const camPos = new Vector3();
+  const lookAt = new Vector3();
+
+  function frame(now: number): void {
+    if (!running) return;
+    raf = requestAnimationFrame(frame);
+    let real = (now - last) / 1000;
+    last = now;
+    if (real > 0.05) real = 0.05; // a tab restore must not teleport the sim
+    fps.push(real);
+    watch.sample(real, tier);
+
+    // SLOW MOTION on the biggest moments, then SLEEP inside it.
+    let scale = 1;
+    if (slowmo > 0) {
+      slowmo = Math.max(0, slowmo - real * 1.7);
+      scale = 0.28 + 0.72 * (1 - clamp01(slowmo / 0.42));
+    }
+    const dt = hitstop.consume(real) * scale;
+    clock += real;
+
+    /* sim */
+    sim.update(dt, clock);
+    sim.drain(evBuf);
+    for (let i = 0; i < evBuf.length; i++) handle(evBuf[i]!);
+    evBuf.length = 0;
+
+    /* drop animation → impact */
+    if (drop.active) {
+      drop.t += real * 1000;
+      if (drop.t >= DROP_MS) {
+        drop.active = false;
+        const ev = drop.ev!;
+        drop.ev = null;
+        onPlaceImpact(ev);
+      }
+    }
+
+    /* feel */
+    flareI = Math.max(0, flareI - flareI * 7.5 * real);
+    flare.intensity = flareI;
+    shake.update(real, T.TRAUMA_DECAY);
+    flash.update(real);
+    squash.target = 1;
+    squash.update(real);
+    camY.target = camTargetY();
+    camY.update(real);
+    blendPalette(real);
+
+    /* framing */
+    dist = damp(dist, solveDistance(), 3.2, real);
+    plaqueK = Math.max(0.55, Math.min(2.1, dist / PLAQUE_REF));
+    const tanY = Math.tan(FOV * 0.5 * DEG);
+    const halfV = dist * tanY;
+    const actionTop = camY.value + HOVER + T.SLAB_H * 0.6;
+    const delta = (1 - 2 * ACTION_SCREEN_Y) * halfV / Math.cos(ELEV);
+    const lookY = actionTop - delta;
+
+    const breathe = reduced ? 0 : Math.sin(clock * 0.44) * 0.021;
+    const az = AZ + breathe;
+    lookAt.set(sim.bendX(1) * 0.3, lookY, sim.bendZ(1) * 0.3);
+    camPos.set(
+      lookAt.x + dist * Math.cos(ELEV) * Math.cos(az),
+      lookAt.y + dist * Math.sin(ELEV),
+      lookAt.z + dist * Math.cos(ELEV) * Math.sin(az),
+    );
+    camera.position.copy(camPos);
+    camera.up.set(0, 1, 0);
+    camera.lookAt(lookAt);
+    if (shake.trauma > 0.0005) {
+      camera.position.x += shake.x * 0.42;
+      camera.position.y += shake.y * 0.42;
+      camera.rotateZ(shake.rot * 0.035);
+    }
+
+    (scene.fog as Fog).near = dist * 0.8;
+    (scene.fog as Fog).far = dist * 2.9;
+
+    /* light rig follows the action so the shadow map stays tight */
+    key.position.set(lookAt.x - 4.2, camY.value + 6.4, lookAt.z + 3.1);
+    key.target.position.set(lookAt.x, camY.value, lookAt.z);
+    key.target.updateMatrixWorld();
+    rim.position.set(lookAt.x + 5.5, camY.value + 1.4, lookAt.z - 5.2);
+    rim.target.position.set(lookAt.x, camY.value, lookAt.z);
+    rim.target.updateMatrixWorld();
+
+    /* tower */
+    drawTower();
+    drawBlock();
+
+    /* particles */
+    sparks.update(dt || real * 0.001, camY.value);
+    fallers.update(dt || real * 0.001, 15);
+    rings.update(real);
+
+    /* sky + present */
+    sky.update(camY.value, clock, aspect, tier.grain ? 0.0045 : 0, sim.peril);
+    post.setTrauma(reduced ? 0 : shake.trauma);
+    post.setFlash(1, 1, 1, flash.alpha);
+    post.setBloom(tier.bloom ? 0.82 + sim.peril * 0.25 : 0);
+    post.setExposure(1.16 - sim.peril * 0.06);
+
+    renderer.setRenderTarget(post.scene);
+    renderer.autoClear = true;
+    renderer.clear();
+    renderer.render(sky.scene, sky.camera);
+    renderer.autoClear = false;
+    renderer.render(scene, camera);
+    renderer.autoClear = true;
+    post.present(renderer);
+
+    /* over panel, once the dust has had time to fall */
+    if (collapseAt >= 0 && clock - collapseAt > 1.35) {
+      collapseAt = -1;
+      hud.showOver(sim.floor, true);
+    }
+
+    /* prompt */
+    if (sim.phase === "sweep" && !collapsed) {
+      hud.showPrompt(true);
+      if (sim.revealLeft > 0 && sim.revealPrompt) hud.setPrompt(sim.revealPrompt, sim.revealAnswer);
+      else hud.setPrompt(sim.question.prompt, null);
+    } else {
+      hud.showPrompt(false);
+    }
+
+    if (showPerf) {
+      hud.setPerf(
+        `${fps.fps.toFixed(0)} fps  p95 ${fps.p95.toFixed(1)}ms\n` +
+          `tier ${tier.name}  dpr ${renderer.getPixelRatio().toFixed(2)}\n` +
+          `sparks ${sparks.live}  input ${lastLatency.toFixed(3)}ms\n` +
+          `floor ${sim.floor}  w ${sim.width.toFixed(3)}  sway ${sim.amplitude.toFixed(3)}`,
+        true,
+      );
+    } else if (hud) {
+      hud.setPerf("", false);
+    }
+  }
+
+  /* ── drawing ────────────────────────────────────────────────────────── */
+
+  function drawTower(): void {
+    if (collapsed) {
+      pool.hideFrom(0);
+      for (const p of plaqueTower) p.hide();
+      const b0 = sim.slabs[0]!;
+      plinth.scale.set(b0.wx * 0.86, 90, b0.wz * 0.86);
+      plinth.position.set(b0.cx, -45 - T.SLAB_H * 0.5, b0.cz);
+      plinthMat.color.copy(cFog).lerp(cSlab, 0.42);
+      return;
+    }
+    const base = sim.slabs[0]!;
+    plinth.scale.set(base.wx * 0.86, 90, base.wz * 0.86);
+    plinth.position.set(base.cx, -45 - T.SLAB_H * 0.5, base.cz);
+    plinthMat.color.copy(cFog).lerp(cSlab, 0.42);
+
+    const n = sim.slabs.length;
+    const shown = Math.min(n, pool.meshes.length);
+    const top = sim.floor;
+    const span = Math.max(1, top);
+    let m = 0;
+    for (let k = 0; k < shown; k++) {
+      const sl = sim.slabs[n - 1 - k]!;
+      const mesh = pool.meshes[m++]!;
+      const u = sl.i / span;
+      const y = sl.i * T.SLAB_H;
+      mesh.visible = true;
+      mesh.position.set(sl.cx + sim.bendX(u), y, sl.cz + sim.bendZ(u));
+
+      // Squash only the freshly-set course; SCALE PUNCH.
+      const sq = k === 0 && !drop.active ? squash.value : 1;
+      mesh.scale.set(sl.wx, T.SLAB_H * sq, sl.wz);
+      mesh.position.y = y - (T.SLAB_H * (1 - sq)) * 0.5;
+
+      // Colour is the stratum the course was BUILT in, so the tower records
+      // the climb; then faded toward the sky as it recedes below the camera.
+      const bandS = stratumAt(Math.floor(sl.i / T.STRATUM_FLOORS));
+      scratch2.setHex(bandS.slab);
+      const jitter = 0.94 + ((Math.imul(sl.i + 1, 2654435761) >>> 24) / 255) * 0.12;
+      scratch2.multiplyScalar(sl.cracked ? jitter * 0.62 : jitter);
+      const fade = clamp01((k - 4) / Math.max(2, pool.meshes.length - 6));
+      scratch2.lerp(cFog, fade * fade);
+      mesh.material.color.copy(scratch2);
+
+      // A course set dead true stays visibly brighter for the rest of the run:
+      // the tower becomes a record of every perfect. Self-coloured, so it never
+      // shifts the palette.
+      if (sl.perfect) mesh.material.emissive.copy(scratch2).multiplyScalar(0.16 * (1 - fade));
+      else mesh.material.emissive.setRGB(0, 0, 0);
+      mesh.material.opacity = 1;
+    }
+    pool.hideFrom(m);
+
+    // Plaques: the top three courses only. Anything deeper is noise.
+    for (let k = 0; k < plaqueTower.length; k++) {
+      const p = plaqueTower[k]!;
+      const sl = sim.slabs[n - 1 - k];
+      if (!sl || sl.label === "" || collapseAt >= 0) {
+        p.hide();
+        continue;
+      }
+      const u = sl.i / span;
+      const y = sl.i * T.SLAB_H;
+      const off = 0.16;
+      p.group.position.set(
+        sl.cx + sim.bendX(u) - sl.wx * 0.5 - off,
+        y + T.SLAB_H * 0.1,
+        sl.cz + sim.bendZ(u) + sl.wz * 0.5 + off,
+      );
+      p.face(camera);
+      const bright = isBright(want);
+      p.set(
+        sl.label,
+        (k === 0 ? 0.26 : 0.2) * plaqueK,
+        bright ? 0xf4f6fb : 0x05060c,
+        sl.cracked ? cAccent.getHex() : bright ? 0x0d0b07 : 0xffffff,
+        k === 0 ? 0.95 : 0.4,
+        0.95,
+      );
+    }
+  }
+
+  function drawBlock(): void {
+    if (sim.phase !== "sweep" && !drop.active) {
+      block.visible = false;
+      plaqueBlock.hide();
+      return;
+    }
+
+    if (drop.active) {
+      // The stone slams home over 88ms with an accelerating ease — the second
+      // beat of the punch. The first was the release click on the tap itself.
+      const ev = drop.ev!;
+      const t = clamp01(drop.t / DROP_MS);
+      const e = t * t;
+      const y0 = (visualFloor + 1) * T.SLAB_H + HOVER;
+      const y1 = (visualFloor + 1) * T.SLAB_H;
+      block.visible = true;
+      block.position.set(drop.x, y0 + (y1 - y0) * e, drop.z);
+      const w = ev.outcome === "miss" ? sim.wx / T.MISS_KEEP : ev.slab.wx;
+      const d = ev.outcome === "miss" ? sim.wz / T.MISS_KEEP : ev.slab.wz;
+      // Before the shear lands, the stone is still full width.
+      const pa = sim.axis === 0 ? 1 : 0;
+      const fullW = pa === 0 ? (ev.shear ? w + ev.shear.wx : w) : w;
+      const fullD = pa === 1 ? (ev.shear ? d + ev.shear.wz : d) : d;
+      block.scale.set(fullW, T.SLAB_H, fullD);
+      blockMat.color.copy(cSlab);
+      blockMat.emissive.copy(cAccent).multiplyScalar(0.13);
+      plaqueBlock.group.position.set(block.position.x, block.position.y, block.position.z);
+      plaqueBlock.face(camera);
+      const bb = isBright(want);
+      plaqueBlock.set(ev.answered, 0.3 * plaqueK, bb ? 0xf4f6fb : 0x05060c, bb ? 0x0d0b07 : 0xffffff, 1 - e * 0.6, 0.95);
+      return;
+    }
+
+    const y = (sim.floor + 1) * T.SLAB_H + HOVER;
+    const x = sim.axis === 0 ? sim.sweep : sim.cx + sim.bendX(1);
+    const z = sim.axis === 1 ? sim.sweep : sim.cz + sim.bendZ(1);
+    block.visible = true;
+    block.position.set(x, y, z);
+    block.scale.set(sim.wx, T.SLAB_H, sim.wz);
+    blockMat.color.copy(cSlab).multiplyScalar(1.1);
+
+    // A hot pulse that quickens as the sweep is pushed by dithering, so the
+    // impatience penalty is visible before it is felt.
+    const urgency = (sim.dither - 1) / (T.DITHER_MAX - 1);
+    const pulse = 0.08 + 0.05 * Math.sin(clock * (7 + urgency * 22));
+    // Self-lit stone at rest; it only goes ACCENT-hot when dithering has begun,
+    // which is exactly when the player needs to be told to commit.
+    blockMat.emissive.copy(cSlab).lerp(cAccent, urgency * 0.85).multiplyScalar(pulse + urgency * 0.55);
+
+    plaqueBlock.group.position.set(x, y, z);
+    plaqueBlock.face(camera);
+    // Fade in over the hold so the swap of value reads as a new stone arriving.
+    const holdT = clamp01(1 - sim.holdLeft / 0.22);
+    const brightNow = isBright(want);
+    plaqueBlock.set(
+      sim.value,
+      (0.3 + (1 - easeOutCubic(holdT)) * 0.055) * plaqueK,
+      brightNow ? 0xf4f6fb : 0x05060c,
+      brightNow ? 0x0d0b07 : 0xffffff,
+      0.35 + 0.65 * holdT,
+      0.95,
+    );
+  }
+
+  raf = requestAnimationFrame(frame);
+
+  // Dev handle, off unless explicitly asked for. Lets a harness (or the founder
+  // with a console open) drive the tower and read the numbers that matter.
+  if (typeof location !== "undefined" && /(^|[?&])dev=1/.test(location.search)) {
+    (window as unknown as Record<string, unknown>).__monument = {
+      sim,
+      tap,
+      fps,
+      get tier() {
+        return tier.name;
+      },
+      setTier: (n: "low" | "mid" | "ultra") => retier(TIERS[n]),
+      latency: () => lastLatency,
+      /**
+       * True cost of one frame, in ms, with the GPU pipeline drained.
+       *
+       * `fps` on a 120Hz panel only ever says "120" and proves nothing about
+       * headroom, so this renders the real scene `n` times back to back and
+       * calls finish(), which is the only number worth quoting about whether
+       * this holds sixty on a slower machine.
+       */
+      bench: (n = 240, stress = false) => {
+        const gl = renderer.getContext();
+        const px = new Uint8Array(4);
+        // readPixels is a hard sync: finish() alone under ANGLE/Metal can
+        // return before the queue has actually drained, which would make this
+        // number a flattering lie.
+        const drain = (): void => {
+          renderer.setRenderTarget(null);
+          gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, px);
+        };
+        if (stress) {
+          // Worst case the game can produce: a collapse, mid-air.
+          for (let i = 0; i < tier.debris * 4; i++) {
+            fallers.launch(
+              (Math.random() - 0.5) * 2, camY.value + (Math.random() - 0.5) * 3, (Math.random() - 0.5) * 2,
+              0.4, T.SLAB_H, 0.4, 0, 0, 0, 4, 9,
+            );
+          }
+          sparks.emit(0, camY.value, 0, {
+            count: Math.round(tier.particles * 0.8), color: 0xffffff, color2: 0xff6a1f,
+            speed: 3, dome: 1, size: 0.12, life: 9, gravity: 0, drag: 0, radius: 1.2,
+          });
+        }
+        for (let i = 0; i < 20; i++) {
+          renderer.setRenderTarget(post.scene);
+          renderer.clear();
+          renderer.render(sky.scene, sky.camera);
+          renderer.autoClear = false;
+          renderer.render(scene, camera);
+          renderer.autoClear = true;
+          post.present(renderer);
+        }
+        drain();
+        const t0 = performance.now();
+        for (let i = 0; i < n; i++) {
+          drawTower();
+          drawBlock();
+          sparks.update(1 / 60, camY.value);
+          fallers.update(1 / 60, 15);
+          renderer.setRenderTarget(post.scene);
+          renderer.clear();
+          renderer.render(sky.scene, sky.camera);
+          renderer.autoClear = false;
+          renderer.render(scene, camera);
+          renderer.autoClear = true;
+          post.present(renderer);
+        }
+        drain();
+        return (performance.now() - t0) / n;
+      },
+    };
+  }
+
+  /* ── teardown ───────────────────────────────────────────────────────── */
+
+  return {
+    unmount(): void {
+      running = false;
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+      holder.removeEventListener("pointerdown", onPointerDown);
+      window.removeEventListener("keydown", onKey);
+      hud.dispose();
+      audio.dispose();
+      sparks.dispose();
+      fallers.dispose();
+      rings.dispose();
+      disposeRingGeometry();
+      sky.dispose();
+      post.dispose();
+      pool.dispose();
+      plaqueBlock.dispose();
+      for (const p of plaqueTower) p.dispose();
+      block.geometry.dispose();
+      blockMat.dispose();
+      plinth.geometry.dispose();
+      plinthMat.dispose();
+      disposeTextures();
+      disposeSharedGeometry();
+      canvas.removeEventListener("webglcontextlost", onContextLost);
+      // dispose() frees three's own objects but leaves the drawing context
+      // alive; without forceContextLoss(), twenty-four mount/unmount cycles
+      // exhaust the browser's context pool and start killing live games.
+      renderer.forceContextLoss();
+      renderer.dispose();
+      holder.remove();
+    },
+  };
+}
+
+export { TIERS };

--- a/dynawalla/games/stack/src/game/sim.test.ts
+++ b/dynawalla/games/stack/src/game/sim.test.ts
@@ -1,0 +1,306 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { Sim } from "./sim.ts";
+import { T, perfectTol } from "./tuning.ts";
+import type { Host, Question } from "../contract.ts";
+
+/** A host with no randomness at all, so every assertion is about the sim. */
+function fixedHost(over: Partial<Host> = {}): Host & { reports: unknown[] } {
+  let n = 0;
+  const reports: unknown[] = [];
+  return {
+    reports,
+    next(): Question {
+      n++;
+      return {
+        id: `q${n}`,
+        prompt: "7 + ? = 10",
+        answer: "3",
+        distractors: ["4", "2", "17"],
+        domain: "bond-10",
+        difficulty: 1,
+      };
+    },
+    report(r) {
+      reports.push(r);
+    },
+    haptic() {},
+    prefersReducedMotion() {
+      return false;
+    },
+    ...over,
+  };
+}
+
+/** Put the sweep exactly `delta` from true, with `value` showing. */
+function aim(sim: Sim, delta: number, value: string): void {
+  const i = sim.slots.indexOf(value);
+  assert.notEqual(i, -1, `value ${value} not among slots ${sim.slots.join(",")}`);
+  sim.slot = i;
+  sim.holdLeft = 0;
+  const axis = sim.axis;
+  const centre = (axis === 0 ? sim.cx : sim.cz) + (axis === 0 ? sim.bendX(1) : sim.bendZ(1));
+  sim.sweep = centre + delta;
+}
+
+test("a true placement snaps dead centre and widens the tower", () => {
+  const sim = new Sim(fixedHost());
+  const w0 = sim.wx;
+  aim(sim, perfectTol(0) * 0.4, "3");
+  const ev = sim.place(1)!;
+  assert.equal(ev.outcome, "perfect");
+  assert.equal(sim.floor, 1);
+  assert.ok(sim.wx > w0, "perfect must widen");
+  assert.equal(sim.cx, 0, "perfect snaps the centre back to true");
+  assert.equal(ev.shear, null, "a perfect never sheds a slice");
+});
+
+test("width is capped, and a long true run parks at the cap", () => {
+  const sim = new Sim(fixedHost());
+  for (let i = 0; i < 200; i++) aim(sim, 0, "3"), sim.place(i);
+  assert.ok(sim.wx <= T.MAX_W + 1e-9);
+  assert.ok(sim.wz <= T.MAX_W + 1e-9);
+  assert.equal(sim.floor, 200, "endless: two hundred true courses, no end state");
+  assert.equal(sim.phase, "sweep");
+});
+
+test("a correct value dropped wide keeps exactly the overlap", () => {
+  const sim = new Sim(fixedHost());
+  const w0 = sim.wx;
+  const d = 0.3;
+  aim(sim, d, "3");
+  const ev = sim.place(1)!;
+  assert.equal(ev.outcome, "good");
+  assert.ok(Math.abs(sim.wx - (w0 - d)) < 1e-9, `${sim.wx} != ${w0 - d}`);
+  assert.ok(Math.abs(sim.cx - d / 2) < 1e-9, "the course recentres on the overlap");
+  assert.ok(ev.shear, "the overhang leaves");
+});
+
+test("a wrong value takes a second bite out of the overlap", () => {
+  const sim = new Sim(fixedHost());
+  const w0 = sim.wx;
+  const d = 0.1;
+  aim(sim, d, "4");
+  const ev = sim.place(1)!;
+  assert.equal(ev.outcome, "wrong");
+  assert.ok(Math.abs(sim.wx - (w0 - d) * T.WRONG_SHEAR) < 1e-9);
+  assert.ok(sim.slabs[sim.slabs.length - 1]!.cracked);
+});
+
+test("a wrong value dropped dead centre is still wrong — alignment cannot rescue arithmetic", () => {
+  const sim = new Sim(fixedHost());
+  aim(sim, 0, "4");
+  const ev = sim.place(1)!;
+  assert.equal(ev.outcome, "wrong");
+  assert.equal(sim.combo, 0);
+});
+
+test("a complete miss costs width and progress but never the run", () => {
+  const sim = new Sim(fixedHost());
+  const w0 = sim.wx;
+  aim(sim, w0 + 0.5, "3");
+  const ev = sim.place(1)!;
+  assert.equal(ev.outcome, "miss");
+  assert.equal(sim.floor, 0, "a miss places nothing");
+  assert.equal(sim.slabs.length, 1);
+  assert.ok(Math.abs(sim.wx - w0 * T.MISS_KEEP) < 1e-9);
+  assert.equal(sim.phase, "sweep", "a miss is not death");
+});
+
+test("the axis alternates only when a course was actually set", () => {
+  const sim = new Sim(fixedHost());
+  assert.equal(sim.axis, 0);
+  aim(sim, 0, "3");
+  sim.place(1);
+  assert.equal(sim.axis, 1);
+  aim(sim, sim.wz + 1, "3"); // miss
+  sim.place(2);
+  assert.equal(sim.axis, 1, "a miss does not hand the next course to the other axis");
+});
+
+test("the monument falls when it becomes a needle, and only then", () => {
+  const sim = new Sim(fixedHost());
+  let guard = 0;
+  while (sim.phase === "sweep" && guard++ < 60) {
+    aim(sim, Math.min(0.3, sim.width * 0.45), "4");
+    sim.place(guard);
+  }
+  assert.equal(sim.phase, "over");
+  assert.ok(sim.width < T.DEATH_W, `died at width ${sim.width}`);
+  assert.ok(guard < 60, "the death spiral must actually terminate");
+});
+
+test("nothing but a perfect can ever widen the tower", () => {
+  const sim = new Sim(fixedHost());
+  const rnd = mulberry(99);
+  let prev = sim.width;
+  for (let i = 0; i < 400 && sim.phase === "sweep"; i++) {
+    const value = rnd() < 0.5 ? "3" : "4";
+    const d = (rnd() - 0.5) * 0.5;
+    const tol = perfectTol(sim.floor);
+    const willPerfect = value === "3" && Math.abs(d) <= tol;
+    aim(sim, d, value);
+    const before = sim.axis === 0 ? sim.wx : sim.wz;
+    sim.place(i);
+    const after = sim.axis === 0 ? sim.wz : sim.wx; // axis may have flipped
+    void after;
+    const now = sim.axis === 0 ? sim.wz : sim.wx;
+    if (!willPerfect) assert.ok(now <= before + 1e-9, `width grew on a non-perfect at i=${i}`);
+    prev = sim.width;
+  }
+  assert.ok(prev >= 0);
+});
+
+test("the tower it reports and the tower it draws agree", () => {
+  const sim = new Sim(fixedHost());
+  const rnd = mulberry(7);
+  for (let i = 0; i < 120 && sim.phase === "sweep"; i++) {
+    aim(sim, (rnd() - 0.5) * 0.2, rnd() < 0.8 ? "3" : "4");
+    sim.place(i);
+  }
+  const top = sim.slabs[sim.slabs.length - 1]!;
+  assert.equal(top.i, sim.floor);
+  assert.ok(Math.abs(top.wx - sim.wx) < 1e-9);
+  assert.ok(Math.abs(top.wz - sim.wz) < 1e-9);
+  for (let i = 1; i < sim.slabs.length; i++) {
+    assert.equal(sim.slabs[i]!.i, sim.slabs[i - 1]!.i + 1, "no gaps in the courses");
+  }
+});
+
+test("every placement is reported to the host exactly once, with the value that was showing", () => {
+  const host = fixedHost();
+  const sim = new Sim(host);
+  aim(sim, 0, "3");
+  sim.place(1);
+  aim(sim, 0.05, "4");
+  sim.place(2);
+  aim(sim, 99, "3");
+  sim.place(3);
+  assert.equal(host.reports.length, 3);
+  const r = host.reports as { correct: boolean; answered: string; ms: number }[];
+  assert.deepEqual(
+    r.map((x) => [x.correct, x.answered]),
+    [
+      [true, "3"],
+      [false, "4"],
+      [true, "3"],
+    ],
+  );
+  assert.ok(r.every((x) => Number.isFinite(x.ms) && x.ms >= 0));
+});
+
+test("a wrong value reveals the truth, and the sweep is held while it is on screen", () => {
+  const sim = new Sim(fixedHost());
+  aim(sim, 0.05, "4");
+  sim.place(1);
+  assert.equal(sim.revealPrompt, "7 + ? = 10");
+  assert.equal(sim.revealAnswer, "3");
+  assert.ok(sim.holdLeft >= sim.revealLeft - 1e-9, "never aim at one thing while reading another");
+  sim.update(1.0, 2);
+  assert.equal(sim.revealPrompt, null);
+});
+
+test("sway leaves the foundation alone and only moves the top", () => {
+  const sim = new Sim(fixedHost());
+  sim.swayX = 0.05;
+  assert.equal(sim.bendX(0), 0);
+  assert.ok(Math.abs(sim.bendX(1) - 0.05) < 1e-12);
+  assert.ok(sim.bendX(0.5) > 0 && sim.bendX(0.5) < 0.05);
+});
+
+test("a true placement calms the tower; a mistake whips it", () => {
+  const sim = new Sim(fixedHost());
+  sim.swayExcite = 1;
+  aim(sim, 0.05, "4");
+  sim.place(1);
+  assert.ok(sim.swayExcite > 1, "a mistake excites the sway");
+  sim.swayExcite = 1;
+  aim(sim, 0, "3");
+  sim.place(2);
+  assert.ok(sim.swayExcite < 1, "a perfect calms it");
+});
+
+test("shoring it up costs something and cannot be farmed", () => {
+  const sim = new Sim(fixedHost());
+  let guard = 0;
+  while (sim.phase === "sweep" && guard++ < 60) {
+    aim(sim, Math.min(0.3, sim.width * 0.45), "4");
+    sim.place(guard);
+  }
+  assert.equal(sim.phase, "over");
+  sim.offerRevive();
+  assert.equal(sim.phase, "revive");
+  const w1 = (assert.ok(sim.reviveQ), sim.answerRevive(sim.reviveQ!.answer, 1), sim.wx);
+  assert.equal(sim.phase, "sweep");
+  assert.ok(w1 > T.DEATH_W);
+
+  // A second revive must restore strictly less than the first.
+  guard = 0;
+  while (sim.phase === "sweep" && guard++ < 60) {
+    aim(sim, Math.min(0.3, sim.width * 0.45), "4");
+    sim.place(guard);
+  }
+  sim.offerRevive();
+  sim.answerRevive(sim.reviveQ!.answer, 2);
+  assert.ok(sim.wx <= w1 + 1e-9, `revive 2 (${sim.wx}) must not beat revive 1 (${w1})`);
+});
+
+test("a wrong revive answer ends the run", () => {
+  const sim = new Sim(fixedHost());
+  let guard = 0;
+  while (sim.phase === "sweep" && guard++ < 60) {
+    aim(sim, Math.min(0.3, sim.width * 0.45), "4");
+    sim.place(guard);
+  }
+  sim.offerRevive();
+  const bad = sim.reviveChoices.find((c) => c !== sim.reviveQ!.answer)!;
+  assert.equal(sim.answerRevive(bad, 1), false);
+  assert.equal(sim.phase, "over");
+});
+
+test("the same seed replays exactly", () => {
+  const run = (): string => {
+    const sim = new Sim(fixedHost(), 1234);
+    const out: string[] = [];
+    for (let i = 0; i < 40 && sim.phase === "sweep"; i++) {
+      sim.update(1 / 60, i / 60);
+      out.push(`${sim.slots.join("|")}@${sim.slot}`);
+      aim(sim, 0, "3");
+      sim.place(i);
+    }
+    return out.join(",");
+  };
+  assert.equal(run(), run());
+});
+
+test("no placement ever produces a NaN, at any offset", () => {
+  const sim = new Sim(fixedHost());
+  const rnd = mulberry(5150);
+  for (let i = 0; i < 3000; i++) {
+    if (sim.phase !== "sweep") sim.reset();
+    aim(sim, (rnd() - 0.5) * 3, rnd() < 0.5 ? "3" : "4");
+    sim.place(i);
+    assert.ok(Number.isFinite(sim.wx) && Number.isFinite(sim.wz), `w NaN at ${i}`);
+    assert.ok(Number.isFinite(sim.cx) && Number.isFinite(sim.cz), `c NaN at ${i}`);
+    assert.ok(sim.wx > 0 && sim.wz > 0, `non-positive width at ${i}`);
+  }
+});
+
+test("the sweep never leaves the travel it is allowed", () => {
+  const sim = new Sim(fixedHost());
+  for (let i = 0; i < 4000; i++) {
+    sim.update(1 / 60, i / 60);
+    assert.ok(Math.abs(sim.sweep) <= sim.sweepHalf + 1e-9, `sweep escaped at ${i}`);
+  }
+});
+
+function mulberry(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/dynawalla/games/stack/src/game/sim.ts
+++ b/dynawalla/games/stack/src/game/sim.ts
@@ -1,0 +1,494 @@
+/**
+ * MONUMENT — the simulation.
+ *
+ * Deliberately free of THREE, the DOM and time-of-day: every rule that decides
+ * whether a run lives or dies is here, so it can be tested at 10,000 floors a
+ * second without a GPU.
+ *
+ * The loop, in one paragraph: a slab sweeps back and forth above the tower.
+ * Its face shows one value from a shuffled set — the true answer to the prompt
+ * plus mal-rule decoys — and the value changes only at a turnaround, so you get
+ * a whole pass to read it. One tap places it. The overhang shears off, exactly
+ * as in Stack. If the value was ALSO the right answer and you were inside the
+ * tolerance, the slab instead SNAPS true and the tower grows back. If the value
+ * was wrong the slab cracks and takes a second bite out of the width. Nothing
+ * is ever explained to you; the monument just gets thinner, and you can see it.
+ */
+
+import type { Host, Question } from "../contract.ts";
+import {
+  T,
+  difficultyFor,
+  holdMs,
+  perfectTol,
+  slotsFor,
+  swayAmp,
+  sweepSpeed,
+} from "./tuning.ts";
+
+export type Axis = 0 | 1; // 0 = X, 1 = Z
+export type Phase = "sweep" | "over" | "revive";
+export type Outcome = "perfect" | "good" | "wrong" | "miss";
+
+export type Slab = {
+  /** Course index; 0 is the foundation. */
+  i: number;
+  cx: number;
+  cz: number;
+  wx: number;
+  wz: number;
+  /** Value written on its face (empty for the foundation). */
+  label: string;
+  /** True when this course was placed dead true. */
+  perfect: boolean;
+  /** Set when the course was placed on a wrong value. */
+  cracked: boolean;
+};
+
+export type PlaceEvent = {
+  type: "place";
+  outcome: Outcome;
+  slab: Slab;
+  /** The piece that sheared off, or null. */
+  shear: { cx: number; cz: number; wx: number; wz: number; sign: number; axis: Axis } | null;
+  /** Signed misalignment along the placement axis, in world units. */
+  delta: number;
+  combo: number;
+  answered: string;
+  correct: boolean;
+};
+export type SimEvent =
+  | PlaceEvent
+  | { type: "stratum"; index: number }
+  | { type: "collapse" }
+  | { type: "revive"; ok: boolean }
+  | { type: "tick"; slot: number; value: string }
+  | { type: "restart" };
+
+const shearScratch = { cx: 0, cz: 0, wx: 0, wz: 0, sign: 1, axis: 0 as Axis };
+
+export class Sim {
+  readonly host: Host;
+
+  /** Every course placed, oldest first. Trimmed from the bottom by the view. */
+  slabs: Slab[] = [];
+  floor = 0;
+  best = 0;
+  wx: number = T.START_W;
+  wz: number = T.START_W;
+  cx = 0;
+  cz = 0;
+  axis: Axis = 0;
+
+  phase: Phase = "sweep";
+  question!: Question;
+  /** Shuffled [answer, ...distractors]; one is showing at a time. */
+  slots: string[] = [];
+  slot = 0;
+  questionAt = 0;
+
+  /** Sweep, in world units along `axis`, relative to the tower centre line. */
+  sweep = 0;
+  dir: 1 | -1 = 1;
+  holdLeft = 0;
+  cyclesIdle = 0;
+  dither = 1;
+  private startSide: 1 | -1 = 1;
+
+  combo = 0;
+  bestCombo = 0;
+  perfects = 0;
+  placed = 0;
+  correctCount = 0;
+
+  swayExcite = 0;
+  swayT = 0;
+  swayX = 0;
+  swayZ = 0;
+
+  /**
+   * After a wrong value the equation completes itself for a beat instead of
+   * being marked wrong. The sweep is held for the same beat so the player is
+   * never reading one thing while aiming at another.
+   */
+  revealPrompt: string | null = null;
+  revealAnswer: string | null = null;
+  revealLeft = 0;
+
+  stratum = 0;
+  revives = 0;
+  reviveQ: Question | null = null;
+  reviveChoices: string[] = [];
+
+  events: SimEvent[] = [];
+
+  private rngState = 0x9e3779b9;
+
+  constructor(host: Host, seed = 0x51ab) {
+    this.host = host;
+    this.rngState = seed >>> 0;
+    this.reset();
+  }
+
+  private rnd(): number {
+    let a = (this.rngState = (this.rngState + 0x6d2b79f5) >>> 0);
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  }
+
+  reset(): void {
+    this.slabs.length = 0;
+    this.floor = 0;
+    this.wx = T.START_W;
+    this.wz = T.START_W;
+    this.cx = 0;
+    this.cz = 0;
+    this.axis = 0;
+    this.phase = "sweep";
+    this.combo = 0;
+    this.bestCombo = 0;
+    this.perfects = 0;
+    this.placed = 0;
+    this.correctCount = 0;
+    this.swayExcite = 0;
+    this.swayT = 0;
+    this.swayX = 0;
+    this.swayZ = 0;
+    this.stratum = 0;
+    this.revives = 0;
+    this.reviveQ = null;
+    this.cyclesIdle = 0;
+    this.dither = 1;
+    this.startSide = 1;
+    this.slabs.push({ i: 0, cx: 0, cz: 0, wx: this.wx, wz: this.wz, label: "", perfect: false, cracked: false });
+    this.nextQuestion();
+    this.events.push({ type: "restart" });
+  }
+
+  /* ── derived ──────────────────────────────────────────────────────────── */
+
+  get topY(): number {
+    return this.floor * T.SLAB_H;
+  }
+  /** Height of the surface the next course lands on. */
+  get placeY(): number {
+    return (this.floor + 1) * T.SLAB_H;
+  }
+  get value(): string {
+    return this.slots[this.slot] ?? "";
+  }
+  get valueIsAnswer(): boolean {
+    return this.value === this.question.answer;
+  }
+  get width(): number {
+    return Math.min(this.wx, this.wz);
+  }
+  /** 0 → brand new, 1 → one bad drop from a collapse. Drives the danger read. */
+  get peril(): number {
+    const span = T.START_W - T.DEATH_W;
+    return Math.max(0, Math.min(1, 1 - (this.width - T.DEATH_W) / span));
+  }
+  get amplitude(): number {
+    return swayAmp(this.floor, this.swayExcite);
+  }
+  /** Half the travel of the sweep, in world units. */
+  get sweepHalf(): number {
+    return (this.axis === 0 ? this.wx : this.wz) * 0.5 + T.SWEEP_MARGIN;
+  }
+
+  /** Horizontal displacement of the tower at normalised height `u` ∈ [0,1]. */
+  bendX(u: number): number {
+    return this.swayX * u * u * (3 - 2 * u);
+  }
+  bendZ(u: number): number {
+    return this.swayZ * u * u * (3 - 2 * u);
+  }
+
+  /* ── question plumbing ────────────────────────────────────────────────── */
+
+  private nextQuestion(): void {
+    const n = slotsFor(this.floor);
+    this.question = this.host.next({ difficulty: difficultyFor(this.floor) });
+    const vals: string[] = [this.question.answer];
+    for (const d of this.question.distractors) {
+      if (vals.length >= n) break;
+      if (d !== this.question.answer && !vals.includes(d)) vals.push(d);
+    }
+    // Fisher–Yates with the sim's own stream so a seeded run replays exactly.
+    for (let i = vals.length - 1; i > 0; i--) {
+      const j = Math.floor(this.rnd() * (i + 1));
+      const t = vals[i]!;
+      vals[i] = vals[j]!;
+      vals[j] = t;
+    }
+    this.slots = vals;
+    this.slot = 0;
+    this.questionAt = 0;
+    this.cyclesIdle = 0;
+    this.dither = 1;
+    this.startSide = (-this.startSide) as 1 | -1;
+    const half = this.sweepHalf;
+    this.sweep = this.startSide * half;
+    this.dir = (-this.startSide) as 1 | -1;
+    this.holdLeft = Math.max(holdMs(this.floor) / 1000, this.revealLeft);
+    this.events.push({ type: "tick", slot: this.slot, value: this.value });
+  }
+
+  /* ── stepping ─────────────────────────────────────────────────────────── */
+
+  /** `dt` in seconds, already scaled by hit-stop and any slow-motion. */
+  update(dt: number, elapsed: number): void {
+    if (this.revealLeft > 0) {
+      this.revealLeft -= dt;
+      if (this.revealLeft <= 0) {
+        this.revealLeft = 0;
+        this.revealPrompt = null;
+        this.revealAnswer = null;
+      }
+    }
+    // Sway runs in every phase — a collapsing tower still whips.
+    this.swayT += dt;
+    this.swayExcite = Math.max(0, this.swayExcite - this.swayExcite * T.SWAY_DECAY * dt);
+    const amp = this.amplitude;
+    this.swayX = amp * Math.sin(this.swayT * Math.PI * 2 * T.SWAY_HZ_A);
+    this.swayZ = amp * Math.sin(this.swayT * Math.PI * 2 * T.SWAY_HZ_B + 1.1);
+
+    if (this.phase !== "sweep") return;
+    if (this.questionAt === 0) this.questionAt = elapsed;
+
+    if (this.holdLeft > 0) {
+      this.holdLeft -= dt;
+      return;
+    }
+
+    const half = this.sweepHalf;
+    const v = sweepSpeed(this.floor, this.dither);
+    this.sweep += this.dir * v * dt;
+
+    if (this.sweep >= half || this.sweep <= -half) {
+      this.sweep = this.sweep > 0 ? half : -half;
+      this.dir = (-this.dir) as 1 | -1;
+      this.holdLeft = holdMs(this.floor) / 1000;
+      this.slot = (this.slot + 1) % this.slots.length;
+      if (this.slot === 0) {
+        this.cyclesIdle++;
+        if (this.cyclesIdle >= T.DITHER_CYCLES) {
+          this.dither = Math.min(T.DITHER_MAX, this.dither + T.DITHER_STEP);
+        }
+      }
+      this.events.push({ type: "tick", slot: this.slot, value: this.value });
+    }
+  }
+
+  /* ── the tap ──────────────────────────────────────────────────────────── */
+
+  place(elapsed: number): PlaceEvent | null {
+    if (this.phase !== "sweep") return null;
+
+    const axis = this.axis;
+    const prevW = axis === 0 ? this.wx : this.wz;
+    const otherW = axis === 0 ? this.wz : this.wx;
+    const u = 1; // the top of the tower
+    const swayHere = axis === 0 ? this.bendX(u) : this.bendZ(u);
+    const prevC = (axis === 0 ? this.cx : this.cz) + swayHere;
+
+    const answered = this.value;
+    const correct = answered === this.question.answer;
+    const delta = this.sweep - prevC;
+    const overlap = prevW - Math.abs(delta);
+    const tol = perfectTol(this.floor);
+
+    let outcome: Outcome;
+    let newW: number;
+    let newC: number;
+    let shear: PlaceEvent["shear"] = null;
+
+    if (overlap <= 0) {
+      outcome = "miss";
+      newW = prevW * T.MISS_KEEP;
+      newC = prevC;
+      this.combo = 0;
+      this.swayExcite += T.SWAY_SHOCK_MISS;
+      this.host.haptic("failure");
+    } else {
+      if (Math.abs(delta) > 1e-9 && overlap < prevW) {
+        // Everything outside the overlap falls away — the signature of the form.
+        const sign = delta > 0 ? 1 : -1;
+        const w = prevW - overlap;
+        shearScratch.wx = axis === 0 ? w : this.wx;
+        shearScratch.wz = axis === 0 ? this.wz : w;
+        shearScratch.cx = axis === 0 ? this.sweep + sign * (prevW - w) * 0.5 : this.cx;
+        shearScratch.cz = axis === 0 ? this.cz : this.sweep + sign * (prevW - w) * 0.5;
+        shearScratch.sign = sign;
+        shearScratch.axis = axis;
+        shear = { ...shearScratch };
+      }
+
+      if (correct && Math.abs(delta) <= tol) {
+        outcome = "perfect";
+        this.combo++;
+        this.bestCombo = Math.max(this.bestCombo, this.combo);
+        this.perfects++;
+        const grow = Math.min(T.GROW_MAX, T.GROW_BASE + (this.combo - 1) * T.GROW_PER_COMBO);
+        newW = Math.min(T.MAX_W, prevW + grow);
+        newC = prevC; // snap dead true
+        shear = null;
+        this.swayExcite *= T.SWAY_CALM_PERFECT;
+        this.host.haptic("success");
+      } else if (correct) {
+        outcome = "good";
+        this.combo = 0;
+        newW = overlap;
+        newC = prevC + delta * 0.5;
+        this.host.haptic("light");
+      } else {
+        outcome = "wrong";
+        this.combo = 0;
+        newW = overlap * T.WRONG_SHEAR;
+        newC = prevC + delta * 0.5;
+        this.swayExcite += T.SWAY_SHOCK_WRONG;
+        this.host.haptic("heavy");
+      }
+    }
+
+    this.host.report({
+      questionId: this.question.id,
+      correct,
+      ms: Math.max(0, Math.round((elapsed - this.questionAt) * 1000)),
+      answered,
+    });
+    if (correct) this.correctCount++;
+    this.placed++;
+
+    const advanced = outcome !== "miss";
+    if (axis === 0) {
+      this.wx = newW;
+      this.cx = newC;
+    } else {
+      this.wz = newW;
+      this.cz = newC;
+    }
+
+    let slab: Slab;
+    if (advanced) {
+      this.floor++;
+      slab = {
+        i: this.floor,
+        cx: this.cx,
+        cz: this.cz,
+        wx: this.wx,
+        wz: this.wz,
+        label: answered,
+        perfect: outcome === "perfect",
+        cracked: outcome === "wrong",
+      };
+      this.slabs.push(slab);
+      this.best = Math.max(this.best, this.floor);
+      // The tower below keeps the width it was built with; only the top course
+      // carries the new one, exactly like the original.
+      this.axis = axis === 0 ? 1 : 0;
+    } else {
+      // A miss places nothing. The course you were standing on just got bitten.
+      const top = this.slabs[this.slabs.length - 1]!;
+      top.wx = this.wx;
+      top.wz = this.wz;
+      slab = top;
+    }
+
+    const ev: PlaceEvent = {
+      type: "place",
+      outcome,
+      slab,
+      shear,
+      delta,
+      combo: this.combo,
+      answered,
+      correct,
+    };
+    this.events.push(ev);
+
+    void otherW;
+
+    if (this.width < T.DEATH_W) {
+      this.phase = "over";
+      this.events.push({ type: "collapse" });
+      return ev;
+    }
+
+    if (!correct) {
+      this.revealPrompt = this.question.prompt;
+      this.revealAnswer = this.question.answer;
+      this.revealLeft = 0.85;
+    }
+
+    const band = Math.floor(this.floor / T.STRATUM_FLOORS);
+    if (band !== this.stratum) {
+      this.stratum = band;
+      this.events.push({ type: "stratum", index: band });
+    }
+
+    this.nextQuestion();
+    return ev;
+  }
+
+  /* ── shore it up (math where an F2P game would show an ad) ────────────── */
+
+  offerRevive(): void {
+    if (this.phase !== "over") return;
+    this.phase = "revive";
+    this.reviveQ = this.host.next({ difficulty: Math.max(1, difficultyFor(this.floor) - 1) });
+    const vals = [this.reviveQ.answer, ...this.reviveQ.distractors.slice(0, 3)];
+    for (let i = vals.length - 1; i > 0; i--) {
+      const j = Math.floor(this.rnd() * (i + 1));
+      const t = vals[i]!;
+      vals[i] = vals[j]!;
+      vals[j] = t;
+    }
+    this.reviveChoices = vals;
+  }
+
+  answerRevive(choice: string, elapsed: number): boolean {
+    if (this.phase !== "revive" || !this.reviveQ) return false;
+    const ok = choice === this.reviveQ.answer;
+    this.host.report({
+      questionId: this.reviveQ.id,
+      correct: ok,
+      ms: Math.max(0, Math.round(elapsed * 1000)),
+      answered: choice,
+    });
+    this.events.push({ type: "revive", ok });
+    if (!ok) {
+      this.host.haptic("failure");
+      this.phase = "over";
+      this.reviveQ = null;
+      return false;
+    }
+    this.host.haptic("success");
+    this.revives++;
+    // Shoring up is always available and always costs one correct answer, but
+    // it restores less every time and bottoms out just above the death width —
+    // so a long chain of revives ends by itself rather than by a rule. A five
+    // minute soak reached floor 76 on thirteen revives before this; a revive
+    // that keeps handing back a comfortable tower is not a stake.
+    const w = Math.max(T.DEATH_W * 1.45, T.START_W * Math.pow(T.REVIVE_WIDTH_FACTOR, this.revives));
+    this.wx = w;
+    this.wz = w;
+    const top = this.slabs[this.slabs.length - 1]!;
+    top.wx = w;
+    top.wz = w;
+    this.cx = top.cx;
+    this.cz = top.cz;
+    this.swayExcite = 0;
+    this.combo = 0;
+    this.reviveQ = null;
+    this.phase = "sweep";
+    this.nextQuestion();
+    return true;
+  }
+
+  drain(into: SimEvent[]): void {
+    for (let i = 0; i < this.events.length; i++) into.push(this.events[i]!);
+    this.events.length = 0;
+  }
+}

--- a/dynawalla/games/stack/src/game/strata.ts
+++ b/dynawalla/games/stack/src/game/strata.ts
@@ -1,0 +1,230 @@
+/**
+ * The climb, as weather.
+ *
+ * Eight named bands, each committing to near-black + two hues + one hot accent.
+ * Crossing into a new one is the biggest moment in the game short of a collapse.
+ * After the eighth the cycle repeats with a hue rotation, so a long run never
+ * lands on exactly the same sky twice.
+ */
+
+export type Stratum = {
+  name: string;
+  /** Sky gradient, bottom → mid → top. */
+  sky: [number, number, number];
+  /** Slab body and the hot enamel edge. */
+  slab: number;
+  accent: number;
+  /** Hemisphere fill: up / down. */
+  hemiUp: number;
+  hemiDown: number;
+  key: number;
+  rim: number;
+  fog: number;
+  /** Distant silhouettes. */
+  spire: number;
+  /** Ambient particle mood. */
+  mote: { color: number; rise: number; drift: number; size: number; count: number };
+  /** Inverted band: light-on-dark flips to dark-on-light for the HUD. */
+  invert?: boolean;
+};
+
+const S: readonly Stratum[] = [
+  {
+    name: "BASALT",
+    sky: [0x05060f, 0x0b1030, 0x161f4d],
+    slab: 0x7d89ab,
+    accent: 0xff6a1f,
+    hemiUp: 0x3a4a86,
+    hemiDown: 0x0a0c18,
+    key: 0xdfe8ff,
+    rim: 0x4d7bff,
+    fog: 0x080a18,
+    spire: 0x0d1128,
+    mote: { color: 0x7f95d8, rise: 0.12, drift: 0.1, size: 0.028, count: 90 },
+  },
+  {
+    name: "VERDIGRIS",
+    sky: [0x02100e, 0x063230, 0x0a5a4d],
+    slab: 0x4fae93,
+    accent: 0xff2f92,
+    hemiUp: 0x1e8f7c,
+    hemiDown: 0x041614,
+    key: 0xdcfff2,
+    rim: 0xff59a8,
+    fog: 0x04140f,
+    spire: 0x05201c,
+    mote: { color: 0x8ff0d2, rise: 0.05, drift: 0.24, size: 0.022, count: 120 },
+  },
+  {
+    name: "EMBER",
+    sky: [0x140301, 0x3a0a04, 0x6b1405],
+    slab: 0x4a3f42,
+    accent: 0xffb23d,
+    hemiUp: 0x8c3212,
+    hemiDown: 0x1a0603,
+    key: 0xffe6c8,
+    rim: 0xff5a17,
+    fog: 0x180503,
+    spire: 0x230704,
+    mote: { color: 0xff9134, rise: 0.55, drift: 0.16, size: 0.03, count: 150 },
+  },
+  {
+    name: "AZURE",
+    sky: [0x0d3d78, 0x1f79c8, 0x9ad8ff],
+    slab: 0xe8ecf2,
+    accent: 0x00e5ff,
+    hemiUp: 0x7ec6ff,
+    hemiDown: 0x123a63,
+    key: 0xffffff,
+    rim: 0x00c2ff,
+    fog: 0x2a7fc4,
+    spire: 0x14568f,
+    mote: { color: 0xffffff, rise: 0.08, drift: 0.42, size: 0.05, count: 70 },
+  },
+  {
+    name: "VIOLET",
+    sky: [0x110320, 0x340a5c, 0x6b1d9e],
+    slab: 0x8a5fbb,
+    accent: 0xc6ff2e,
+    hemiUp: 0x7431b8,
+    hemiDown: 0x120424,
+    key: 0xeadcff,
+    rim: 0xa6ff3c,
+    fog: 0x160529,
+    spire: 0x230840,
+    mote: { color: 0xd7a6ff, rise: 0.1, drift: 0.18, size: 0.024, count: 110 },
+  },
+  {
+    name: "AURORA",
+    sky: [0x00120e, 0x02322c, 0x0a5c3e],
+    slab: 0xc4e8fa,
+    accent: 0xff4d7a,
+    hemiUp: 0x1fae7f,
+    hemiDown: 0x021410,
+    key: 0xd8f4ff,
+    rim: 0xff6f96,
+    fog: 0x021512,
+    spire: 0x04241d,
+    mote: { color: 0x6dffc0, rise: 0.22, drift: 0.3, size: 0.02, count: 160 },
+  },
+  {
+    name: "VACUUM",
+    sky: [0x000000, 0x03030a, 0x0a0a1a],
+    slab: 0xf4f6ff,
+    accent: 0xff1440,
+    hemiUp: 0x1a1a3a,
+    hemiDown: 0x000000,
+    key: 0xffffff,
+    rim: 0xff2a50,
+    fog: 0x000004,
+    spire: 0x05050c,
+    mote: { color: 0xffffff, rise: 0.02, drift: 0.06, size: 0.016, count: 200 },
+  },
+  {
+    name: "SOLAR",
+    sky: [0xfff3d0, 0xffd870, 0xff9a1f],
+    slab: 0x191410,
+    accent: 0xffffff,
+    hemiUp: 0xffe9a8,
+    hemiDown: 0x8a5a10,
+    key: 0xfff8e0,
+    rim: 0xffffff,
+    fog: 0xffcf70,
+    spire: 0xd88a20,
+    mote: { color: 0xfff6d8, rise: 0.34, drift: 0.2, size: 0.034, count: 130 },
+    invert: true,
+  },
+];
+
+export const STRATUM_COUNT = S.length;
+
+/** Rotate a packed 0xRRGGBB hue by `deg`, preserving luma reasonably well. */
+function rotateHue(hex: number, deg: number): number {
+  if (deg === 0) return hex;
+  const r = ((hex >> 16) & 255) / 255;
+  const g = ((hex >> 8) & 255) / 255;
+  const b = (hex & 255) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  const d = max - min;
+  if (d === 0) return hex; // greys stay grey
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h: number;
+  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+  else if (max === g) h = ((b - r) / d + 2) / 6;
+  else h = ((r - g) / d + 4) / 6;
+  h = (h + deg / 360) % 1;
+  if (h < 0) h += 1;
+
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  const hue2 = (t: number): number => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+  const rr = Math.round(hue2(h + 1 / 3) * 255);
+  const gg = Math.round(hue2(h) * 255);
+  const bb = Math.round(hue2(h - 1 / 3) * 255);
+  return (rr << 16) | (gg << 8) | bb;
+}
+
+/**
+ * Relative luminance of a packed colour, 0..1.
+ *
+ * The HUD picks light-on-dark or dark-on-light from THIS, measured off the sky
+ * the chrome actually sits in front of — not from a flag set by hand. AZURE
+ * shipped as white-on-pale-blue on the first playthrough and was unreadable;
+ * a hand-maintained `invert` boolean will always eventually be wrong on one of
+ * the strata, and a run reaches all of them.
+ */
+export function luma(hex: number): number {
+  const f = (v: number): number => {
+    const c = v / 255;
+    return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * f((hex >> 16) & 255) + 0.7152 * f((hex >> 8) & 255) + 0.0722 * f(hex & 255);
+}
+
+/** True when chrome in front of this stratum's sky must be drawn dark-on-light. */
+export function isBright(s: Stratum): boolean {
+  return s.invert ?? luma(s.sky[2]) > 0.34;
+}
+
+const cache = new Map<number, Stratum>();
+
+/** Stratum for band index `i` (0-based). Cycles with a 37° hue rotation. */
+export function stratumAt(i: number): Stratum {
+  const key = i < 0 ? 0 : i;
+  const hit = cache.get(key);
+  if (hit) return hit;
+
+  const base = S[key % STRATUM_COUNT]!;
+  const lap = Math.floor(key / STRATUM_COUNT);
+  const deg = lap * 37;
+  const out: Stratum =
+    deg === 0
+      ? base
+      : {
+          ...base,
+          name: lap === 0 ? base.name : `${base.name} ${"II III IV V VI VII VIII IX X".split(" ")[Math.min(8, lap - 1)]}`,
+          sky: [rotateHue(base.sky[0], deg), rotateHue(base.sky[1], deg), rotateHue(base.sky[2], deg)],
+          slab: rotateHue(base.slab, deg),
+          accent: rotateHue(base.accent, deg),
+          hemiUp: rotateHue(base.hemiUp, deg),
+          hemiDown: rotateHue(base.hemiDown, deg),
+          key: rotateHue(base.key, deg * 0.35),
+          rim: rotateHue(base.rim, deg),
+          fog: rotateHue(base.fog, deg),
+          spire: rotateHue(base.spire, deg),
+          mote: { ...base.mote, color: rotateHue(base.mote.color, deg) },
+        };
+
+  if (cache.size > 64) cache.clear();
+  cache.set(key, out);
+  return out;
+}

--- a/dynawalla/games/stack/src/game/tuning.ts
+++ b/dynawalla/games/stack/src/game/tuning.ts
@@ -1,0 +1,140 @@
+/**
+ * Every number that decides how MONUMENT feels, in one file.
+ *
+ * The whole game is a tug-of-war over ONE readable variable: the width of the
+ * tower. Nothing is hidden. A player can always see how close to death they
+ * are, because the tower is literally thin.
+ */
+
+export const T = {
+  /** A slab is 1.0 × SLAB_H × 1.0 at full width. */
+  SLAB_H: 0.42,
+  START_W: 1.0,
+  /** Skill can build a tower fatter than it started. */
+  MAX_W: 1.22,
+  /** Below this the monument is a needle and it goes over. */
+  DEATH_W: 0.155,
+
+  /** Half-width of the "perfect" window, in world units, at floor 0. */
+  PERFECT_TOL0: 0.062,
+  /** …and asymptotically, deep in a run. */
+  PERFECT_TOL1: 0.03,
+  TOL_FLOORS: 60,
+
+  /** Perfect placement widens the current axis by this, plus a combo bonus. */
+  GROW_BASE: 0.028,
+  GROW_PER_COMBO: 0.011,
+  GROW_MAX: 0.085,
+
+  /** A correct value dropped badly: classic Stack decay (overlap only). */
+  /** A wrong value: the overlap survives, then the slab shears again. */
+  WRONG_SHEAR: 0.76,
+  /** A complete miss: the slab explodes, the tower takes a hard bite, lives on. */
+  MISS_KEEP: 0.62,
+
+  /** Sweep travels this far past the tower edge on each side. */
+  SWEEP_MARGIN: 0.72,
+  SWEEP_SPEED0: 1.78, // world units / second
+  SWEEP_SPEED_PER_FLOOR: 0.021,
+  SWEEP_SPEED_MAX: 4.6,
+  /** Held at each turnaround so the new value can be read. */
+  HOLD_MS0: 185,
+  HOLD_MS1: 85,
+  HOLD_FLOORS: 55,
+  /** After this many full cycles without a drop, the sweep leans on you. */
+  DITHER_CYCLES: 3,
+  DITHER_STEP: 0.16,
+  DITHER_MAX: 1.9,
+
+  /** Faces the sliding block cycles through: answer + (n-1) mal-rule values. */
+  SLOTS_MIN: 2,
+  SLOTS_MAX: 4,
+  SLOTS_FLOOR_STEP: 14, // +1 slot every N floors
+
+  /** Fall from this height above the top slab. */
+  DROP_H: 3.4,
+  GRAVITY: 46,
+
+  /** Tower sway. Perfects calm it; mistakes whip it. */
+  SWAY_START_FLOOR: 12,
+  SWAY_PER_FLOOR: 0.00085,
+  SWAY_MAX: 0.075,
+  SWAY_HZ_A: 0.31,
+  SWAY_HZ_B: 0.47,
+  SWAY_SHOCK_WRONG: 1.15,
+  SWAY_SHOCK_MISS: 1.9,
+  SWAY_CALM_PERFECT: 0.55, // multiplier applied to excitement
+  SWAY_DECAY: 0.72, // per second
+
+  /** A new stratum every N floors — a big moment often enough to chase. */
+  STRATUM_FLOORS: 8,
+
+  /** Difficulty handed to the host, 1..10. */
+  DIFF_FLOORS_PER_STEP: 7,
+
+  /** Feel. */
+  HITSTOP_PLACE_MS: 38,
+  HITSTOP_PERFECT_MS: 72,
+  HITSTOP_WRONG_MS: 115,
+  HITSTOP_MISS_MS: 150,
+  HITSTOP_STRATUM_MS: 90,
+
+  TRAUMA_PLACE: 0.24,
+  TRAUMA_PERFECT: 0.34,
+  TRAUMA_WRONG: 0.72,
+  TRAUMA_MISS: 0.92,
+  TRAUMA_COLLAPSE: 1.0,
+  TRAUMA_DECAY: 1.75, // per second
+
+  /** Camera. */
+  CAM_SPRING: 118,
+  CAM_DAMP: 19,
+  CAM_KICK_PLACE: 0.13,
+  CAM_KICK_WRONG: 0.42,
+
+  /** Squash on landing, released by a spring. */
+  SQUASH_PLACE: 0.74,
+  SQUASH_PERFECT: 0.6,
+  SQUASH_SPRING: 260,
+  SQUASH_DAMP: 15,
+
+  /** Hard flash-rate limits — children's product. */
+  FLASH_MAX_ALPHA: 0.24,
+  FLASH_MIN_GAP_MS: 260,
+  FLASH_FADE_MS: 130,
+
+  /** Revive ("shore it up") — math where an F2P game would show an ad. */
+  REVIVE_WIDTH_FACTOR: 0.72,
+} as const;
+
+/** Linear 0→1 ramp over `floors`, clamped. */
+export function ramp(floor: number, floors: number): number {
+  return Math.max(0, Math.min(1, floor / floors));
+}
+
+export function perfectTol(floor: number): number {
+  return T.PERFECT_TOL0 + (T.PERFECT_TOL1 - T.PERFECT_TOL0) * ramp(floor, T.TOL_FLOORS);
+}
+
+export function sweepSpeed(floor: number, dither: number): number {
+  const base = Math.min(T.SWEEP_SPEED_MAX, T.SWEEP_SPEED0 * (1 + floor * T.SWEEP_SPEED_PER_FLOOR));
+  return base * dither;
+}
+
+export function holdMs(floor: number): number {
+  return T.HOLD_MS0 + (T.HOLD_MS1 - T.HOLD_MS0) * ramp(floor, T.HOLD_FLOORS);
+}
+
+export function slotsFor(floor: number): number {
+  return Math.min(T.SLOTS_MAX, T.SLOTS_MIN + Math.floor(floor / T.SLOTS_FLOOR_STEP));
+}
+
+export function difficultyFor(floor: number): number {
+  return Math.max(1, Math.min(10, 1 + Math.floor(floor / T.DIFF_FLOORS_PER_STEP)));
+}
+
+export function swayAmp(floor: number, excitement: number): number {
+  if (floor < T.SWAY_START_FLOOR) return 0;
+  const base = Math.min(T.SWAY_MAX, (floor - T.SWAY_START_FLOOR) * T.SWAY_PER_FLOOR);
+  return base * (1 + excitement);
+}

--- a/dynawalla/games/stack/src/host/mathgen.test.ts
+++ b/dynawalla/games/stack/src/host/mathgen.test.ts
@@ -1,0 +1,215 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { ALL_FAMILIES, frac, generate, makeRng, tenths } from "./mathgen.ts";
+import { createStubHost } from "./stub.ts";
+
+/** Evaluate a prompt with the blank filled in, using integers only. */
+function holds(prompt: string, answer: string): boolean {
+  const filled = prompt.replace("?", answer);
+  const [lhsRaw, rhsRaw] = filled.split("=");
+  assert.ok(lhsRaw && rhsRaw, `no equals in ${filled}`);
+  const l = evalSide(lhsRaw.trim());
+  const r = evalSide(rhsRaw.trim());
+  if (l === null || r === null) return false;
+  // Cross-multiply so two rationals compare with integer arithmetic only.
+  return l.n * r.d === r.n * l.d;
+}
+
+type Rat = { n: number; d: number };
+
+/** A deliberately tiny parser: exactly the shapes this game emits, no more. */
+function evalSide(s: string): Rat | null {
+  const parts = s.split(/([+−×÷])/).map((p) => p.trim());
+  let acc = lit(parts[0]!);
+  if (!acc) return null;
+  for (let i = 1; i < parts.length; i += 2) {
+    const op = parts[i]!;
+    const b = lit(parts[i + 1]!);
+    if (!b) return null;
+    if (op === "+") acc = { n: acc.n * b.d + b.n * acc.d, d: acc.d * b.d };
+    else if (op === "−") acc = { n: acc.n * b.d - b.n * acc.d, d: acc.d * b.d };
+    else if (op === "×") acc = { n: acc.n * b.n, d: acc.d * b.d };
+    else if (op === "÷") acc = { n: acc.n * b.d, d: acc.d * b.n };
+    else return null;
+  }
+  return acc;
+}
+
+function lit(s: string): Rat | null {
+  if (s === undefined) return null;
+  const t = s.trim();
+  if (/^-?\d+$/.test(t)) return { n: Number(t), d: 1 };
+  const f = /^(-?\d+)\/(\d+)$/.exec(t);
+  if (f) return { n: Number(f[1]), d: Number(f[2]) };
+  // Decimals are read as exact integer tenths/hundredths — never as a float.
+  const dec = /^(-?)(\d+)\.(\d+)$/.exec(t);
+  if (dec) {
+    const sign = dec[1] === "-" ? -1 : 1;
+    const whole = Number(dec[2]);
+    const fracDigits = dec[3]!;
+    const d = Math.pow(10, fracDigits.length);
+    return { n: sign * (whole * d + Number(fracDigits)), d };
+  }
+  return null;
+}
+
+test("the parser this file grades with actually works", () => {
+  assert.equal(holds("7 + ? = 10", "3"), true);
+  assert.equal(holds("7 + ? = 10", "4"), false);
+  assert.equal(holds("3/5 + ? = 1", "2/5"), true);
+  assert.equal(holds("3/5 + ? = 1", "2/10"), false);
+  assert.equal(holds("0.7 + ? = 1", "0.3"), true);
+  assert.equal(holds("0.7 + ? = 1", "3"), false);
+  assert.equal(holds("6 × ? = 42", "7"), true);
+  assert.equal(holds("13 − ? = 8", "5"), true);
+  assert.equal(holds("-6 + ? = 0", "6"), true);
+});
+
+test("every family, at every difficulty, states a true thing", () => {
+  for (let d = 1; d <= 10; d++) {
+    const rng = makeRng(0x1000 + d);
+    for (let i = 0; i < 400; i++) {
+      const q = generate(rng, d, 4);
+      if (q.prompt.includes("/") && q.prompt.includes("=?/")) continue; // equiv form below
+      if (/=\s*\?\/\d+$/.test(q.prompt.replace(/\s/g, ""))) continue;
+      assert.equal(
+        holds(q.prompt, q.answer),
+        true,
+        `${q.domain}: "${q.prompt}" answer "${q.answer}"`,
+      );
+    }
+  }
+});
+
+test("equivalent-fraction prompts state a true thing too", () => {
+  const rng = makeRng(77);
+  for (let i = 0; i < 500; i++) {
+    const q = generate(rng, 7, 4, "frac-equiv");
+    const m = /^(\d+)\/(\d+) = \?\/(\d+)$/.exec(q.prompt);
+    assert.ok(m, q.prompt);
+    const [, n, d, bigD] = m!.map(Number) as unknown as number[];
+    assert.equal(Number(q.answer) * d!, n! * bigD!, `${q.prompt} -> ${q.answer}`);
+  }
+});
+
+test("no distractor is ever secretly correct", () => {
+  for (let d = 1; d <= 10; d++) {
+    const rng = makeRng(0x2000 + d);
+    for (let i = 0; i < 400; i++) {
+      const q = generate(rng, d, 4);
+      for (const w of q.distractors) {
+        assert.notEqual(w, q.answer, `${q.domain} repeated the answer as a decoy`);
+        if (/=\s*\?\//.test(q.prompt)) continue;
+        assert.equal(holds(q.prompt, w), false, `${q.domain}: decoy "${w}" also solves "${q.prompt}"`);
+      }
+      assert.equal(new Set(q.distractors).size, q.distractors.length, "duplicate decoys");
+    }
+  }
+});
+
+test("there are always enough decoys for four faces and a revive panel", () => {
+  for (let d = 1; d <= 10; d++) {
+    const rng = makeRng(0x3000 + d);
+    for (let i = 0; i < 200; i++) {
+      const q = generate(rng, d, 4);
+      assert.ok(q.distractors.length >= 3, `${q.domain} gave ${q.distractors.length}`);
+    }
+  }
+});
+
+test("answers stay short enough to be read on a moving stone", () => {
+  for (let d = 1; d <= 10; d++) {
+    const rng = makeRng(0x4000 + d);
+    for (let i = 0; i < 300; i++) {
+      const q = generate(rng, d, 4);
+      assert.ok(q.answer.length <= 5, `${q.domain} answer "${q.answer}" is too long to read`);
+      for (const w of q.distractors) {
+        assert.ok(w.length <= 5, `${q.domain} decoy "${w}" is too long to read`);
+      }
+      assert.ok(q.prompt.length <= 18, `${q.domain} prompt "${q.prompt}" is too long for 320px`);
+    }
+  }
+});
+
+test("no floating point ever reaches an answer or a decoy", () => {
+  // Every emitted string must be an exact integer, an exact fraction, or a
+  // decimal with at most two places — never something like 0.30000000000000004.
+  const shape = /^-?\d+(\.\d{1,2})?$|^-?\d+\/\d+$/;
+  for (let d = 1; d <= 10; d++) {
+    const rng = makeRng(0x5000 + d);
+    for (let i = 0; i < 400; i++) {
+      const q = generate(rng, d, 4);
+      assert.match(q.answer, shape, `${q.domain} answer "${q.answer}"`);
+      for (const w of q.distractors) assert.match(w, shape, `${q.domain} decoy "${w}"`);
+    }
+  }
+});
+
+test("exact rational formatting", () => {
+  assert.equal(frac(2, 4), "1/2");
+  assert.equal(frac(4, 4), "1");
+  assert.equal(frac(0, 5), "0");
+  assert.equal(frac(-2, 6), "-1/3");
+  assert.equal(tenths(7), "0.7");
+  assert.equal(tenths(10), "1");
+  assert.equal(tenths(13), "1.3");
+  assert.equal(tenths(-3), "-0.3");
+  assert.equal(tenths(0), "0");
+});
+
+test("the same seed generates the same questions", () => {
+  const run = (): string => {
+    const rng = makeRng(4242);
+    let out = "";
+    for (let i = 0; i < 200; i++) {
+      const q = generate(rng, 1 + (i % 10), 3);
+      out += `${q.prompt}|${q.answer}|${q.distractors.join(",")};`;
+    }
+    return out;
+  };
+  assert.equal(run(), run());
+});
+
+test("difficulty actually opens new families and keeps some easier work in the mix", () => {
+  const seen = (d: number): Set<string> => {
+    const rng = makeRng(0x6000 + d);
+    const s = new Set<string>();
+    for (let i = 0; i < 600; i++) s.add(generate(rng, d, 3).domain);
+    return s;
+  };
+  const easy = seen(1);
+  const hard = seen(10);
+  assert.deepEqual([...easy], ["bond-10"]);
+  assert.ok(hard.has("two-step"), "the hardest family must appear at difficulty 10");
+  assert.ok(hard.size >= 3, "difficulty 10 must not be a wall of one thing");
+  assert.ok(!hard.has("bond-10"), "difficulty 10 should have moved on from bonds to ten");
+});
+
+test("every family is reachable", () => {
+  const all = new Set<string>();
+  for (let d = 1; d <= 10; d++) {
+    const rng = makeRng(0x7000 + d);
+    for (let i = 0; i < 1500; i++) all.add(generate(rng, d, 3).domain);
+  }
+  for (const f of ALL_FAMILIES) assert.ok(all.has(f.id), `${f.id} is unreachable`);
+});
+
+test("the stub host satisfies the contract and never throws", () => {
+  const host = createStubHost({ seed: 9 });
+  for (let i = 0; i < 500; i++) {
+    const q = host.next({ difficulty: 1 + (i % 10) });
+    assert.ok(q.id && q.prompt && q.answer);
+    assert.ok(Array.isArray(q.distractors));
+    host.report({ questionId: q.id, correct: i % 2 === 0, ms: i, answered: q.answer });
+    host.haptic("light");
+  }
+  assert.equal(typeof host.prefersReducedMotion(), "boolean");
+});
+
+test("question ids are unique across a long run", () => {
+  const host = createStubHost({ seed: 3 });
+  const ids = new Set<string>();
+  for (let i = 0; i < 3000; i++) ids.add(host.next({ difficulty: 5 }).id);
+  assert.equal(ids.size, 3000);
+});

--- a/dynawalla/games/stack/src/host/mathgen.ts
+++ b/dynawalla/games/stack/src/host/mathgen.ts
@@ -1,0 +1,362 @@
+/**
+ * Exact-arithmetic question generation for MONUMENT.
+ *
+ * Hard rules, enforced by tests in `mathgen.test.ts`:
+ *   - No floating point ever appears in an answer or in a comparison. Decimal
+ *     questions are computed as integer-numerator rationals and *formatted* to
+ *     a decimal string; `0.1 + 0.2` never happens.
+ *   - Every distractor is the output of a real mal-rule — a mistake a child
+ *     actually makes — not a random number. A wrong drop must feel like the
+ *     answer the player believed in.
+ *   - Fully deterministic from a seed.
+ */
+
+import type { Question } from "../contract.ts";
+
+/* ── seeded RNG ───────────────────────────────────────────────────────────── */
+
+/** mulberry32 — small, fast, good enough, and identical on every platform. */
+export function makeRng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Integer in [lo, hi] inclusive. */
+function ri(rng: () => number, lo: number, hi: number): number {
+  return lo + Math.floor(rng() * (hi - lo + 1));
+}
+
+function pick<T>(rng: () => number, xs: readonly T[]): T {
+  return xs[Math.floor(rng() * xs.length)]!;
+}
+
+/* ── exact rationals (integers only, never a float) ───────────────────────── */
+
+function gcd(a: number, b: number): number {
+  a = Math.abs(a);
+  b = Math.abs(b);
+  while (b !== 0) {
+    const t = a % b;
+    a = b;
+    b = t;
+  }
+  return a === 0 ? 1 : a;
+}
+
+/** `n/d` reduced, rendered as "n/d" (or "n" when d reduces to 1). */
+export function frac(n: number, d: number): string {
+  if (d === 0) return "—";
+  let sign = 1;
+  if (d < 0) {
+    d = -d;
+    sign = -sign;
+  }
+  if (n < 0) {
+    n = -n;
+    sign = -sign;
+  }
+  const g = gcd(n, d);
+  const rn = (n / g) * sign;
+  const rd = d / g;
+  return rd === 1 ? String(rn) : `${rn}/${rd}`;
+}
+
+/** Unreduced "n/d" — some mal-rules produce a fraction the child would not reduce. */
+function rawFrac(n: number, d: number): string {
+  return d === 1 ? String(n) : `${n}/${d}`;
+}
+
+/**
+ * `n` tenths as a decimal string, by integer arithmetic only.
+ * tenths(7) === "0.7", tenths(10) === "1", tenths(13) === "1.3", tenths(-3) === "-0.3".
+ */
+export function tenths(n: number): string {
+  const sign = n < 0 ? "-" : "";
+  const m = Math.abs(n);
+  const whole = Math.floor(m / 10);
+  const rem = m % 10;
+  return rem === 0 ? `${sign}${whole}` : `${sign}${whole}.${rem}`;
+}
+
+/* ── question families ────────────────────────────────────────────────────── */
+
+export type Family = {
+  id: string;
+  /** Lowest `difficulty` at which this family may be drawn. */
+  from: number;
+  build(rng: () => number): { prompt: string; answer: string; wrong: string[] };
+};
+
+/**
+ * Each `wrong` list is ordered strongest-mal-rule-first; the caller takes as
+ * many as it needs. Duplicates and accidental correct answers are filtered by
+ * `generate` below, so a family may safely emit an overlapping candidate.
+ */
+const FAMILIES: readonly Family[] = [
+  {
+    // Number bonds to ten. The first thing a six-year-old owns.
+    id: "bond-10",
+    from: 1,
+    build(rng) {
+      const a = ri(rng, 1, 9);
+      const b = 10 - a;
+      return {
+        prompt: `${a} + ? = 10`,
+        answer: String(b),
+        // count-on slip (±1), read the total as the part, doubled the part.
+        wrong: [String(b + 1), String(b - 1), String(10 + a), String(a)],
+      };
+    },
+  },
+  {
+    // Bonds to a stated total up to twenty — the same idea, no longer memorised.
+    id: "bond-n",
+    from: 2,
+    build(rng) {
+      const n = ri(rng, 11, 20);
+      const a = ri(rng, 2, n - 2);
+      const b = n - a;
+      return {
+        prompt: `${a} + ? = ${n}`,
+        answer: String(b),
+        wrong: [String(b + 1), String(b - 1), String(n + a), String(n)],
+      };
+    },
+  },
+  {
+    // Missing subtrahend. The classic error is inverting the operation.
+    id: "sub-missing",
+    from: 3,
+    build(rng) {
+      const a = ri(rng, 8, 19);
+      const r = ri(rng, 1, a - 2);
+      const b = a - r;
+      return {
+        prompt: `${a} − ? = ${r}`,
+        answer: String(b),
+        // added instead of subtracted, copied the result, borrow slip.
+        wrong: [String(a + r), String(r), String(b + 1), String(b - 1)],
+      };
+    },
+  },
+  {
+    // Missing factor. Mal-rules: neighbouring row of the table, additive slip.
+    id: "mult-missing",
+    from: 4,
+    build(rng) {
+      const a = ri(rng, 2, 9);
+      const b = ri(rng, 2, 9);
+      const p = a * b;
+      return {
+        prompt: `${a} × ? = ${p}`,
+        answer: String(b),
+        // off-by-one down the table, treated × as −, treated × as +.
+        wrong: [String(b + 1), String(b - 1), String(p - a), String(p + a)],
+      };
+    },
+  },
+  {
+    // Division as the inverse. Same mal-rules, seen from the other side.
+    id: "div-exact",
+    from: 5,
+    build(rng) {
+      const a = ri(rng, 2, 9);
+      const b = ri(rng, 2, 12);
+      const p = a * b;
+      return {
+        prompt: `${p} ÷ ${a} = ?`,
+        answer: String(b),
+        wrong: [String(b + 1), String(b - 1), String(p - a), String(a)],
+      };
+    },
+  },
+  {
+    // Complete the whole. The signature fraction error is adding denominators.
+    id: "frac-whole",
+    from: 6,
+    build(rng) {
+      const d = pick(rng, [3, 4, 5, 6, 8, 10] as const);
+      const n = ri(rng, 1, d - 1);
+      const m = d - n;
+      return {
+        prompt: `${n}/${d} + ? = 1`,
+        answer: frac(m, d),
+        // added the denominators, inverted, copied, numerator only.
+        // added the denominators, inverted, copied, numerator only, off-by-one.
+        wrong: [rawFrac(m, d + d), rawFrac(d, m), rawFrac(n, d), String(m), rawFrac(m + 1, d)],
+      };
+    },
+  },
+  {
+    // Equivalent fractions. The great mal-rule: add the same number to both.
+    id: "frac-equiv",
+    from: 7,
+    build(rng) {
+      const d = pick(rng, [2, 3, 4, 5, 6] as const);
+      const n = ri(rng, 1, d - 1);
+      const k = ri(rng, 2, 4);
+      const bigD = d * k;
+      const bigN = n * k;
+      return {
+        prompt: `${n}/${d} = ?/${bigD}`,
+        answer: String(bigN),
+        // additive instead of multiplicative, scaled by the wrong k, copied.
+        wrong: [String(n + (bigD - d)), String(n * (k + 1)), String(n), String(bigD - n)],
+      };
+    },
+  },
+  {
+    // Decimal tenths to a whole. Integers throughout; formatted at the edge.
+    id: "dec-tenths",
+    from: 8,
+    build(rng) {
+      const a = ri(rng, 1, 9); // tenths
+      const b = 10 - a;
+      return {
+        prompt: `${tenths(a)} + ? = 1`,
+        answer: tenths(b),
+        // treated tenths as whole numbers, place-value slip, off-by-one tenth.
+        wrong: [String(b), tenths(b + 10), tenths(b + 1), tenths(a)],
+      };
+    },
+  },
+  {
+    // Additive inverse. Sign is the whole lesson, so sign is the whole mal-rule.
+    id: "signed-zero",
+    from: 9,
+    build(rng) {
+      const a = ri(rng, 2, 12);
+      const neg = rng() < 0.5;
+      const from = neg ? -a : a;
+      const ans = neg ? a : -a;
+      return {
+        prompt: `${from} + ? = 0`,
+        answer: String(ans),
+        // kept the sign, answered the identity, doubled.
+        wrong: [String(from), "0", String(-2 * from), String(2 * from)],
+      };
+    },
+  },
+  {
+    // Two-step: a product must be reached from a partial. Late-tower work.
+    id: "two-step",
+    from: 10,
+    build(rng) {
+      const a = ri(rng, 3, 9);
+      const b = ri(rng, 3, 9);
+      const c = ri(rng, 2, 9);
+      const total = a * b + c;
+      return {
+        prompt: `${a} × ${b} + ? = ${total}`,
+        answer: String(c),
+        // ignored precedence (a × (b + ?)), dropped the product, off-by-one.
+        wrong: [String(total - a - b), String(total), String(c + 1), String(c - 1)],
+      };
+    },
+  },
+] as const;
+
+/* ── decoy safety ─────────────────────────────────────────────────────────── */
+
+/** Exact value of an emitted string: integer, fraction, or a short decimal. */
+function value(s: string): { n: number; d: number } | null {
+  if (/^-?\d+$/.test(s)) return { n: Number(s), d: 1 };
+  const f = /^(-?\d+)\/(\d+)$/.exec(s);
+  if (f) return { n: Number(f[1]), d: Number(f[2]) };
+  const dec = /^(-?)(\d+)\.(\d+)$/.exec(s);
+  if (dec) {
+    const sign = dec[1] === "-" ? -1 : 1;
+    const scale = Math.pow(10, dec[3]!.length);
+    return { n: sign * (Number(dec[2]) * scale + Number(dec[3])), d: scale };
+  }
+  return null;
+}
+
+/**
+ * Two emitted strings denoting the same number.
+ *
+ * String inequality is not enough: `2/4 + ? = 1` once offered `2/4` as a decoy,
+ * because the "copied the fraction" mal-rule happens to BE the answer whenever
+ * the numerator is half the denominator. A decoy that is secretly correct
+ * punishes a child for being right, which is the worst bug this game could ship.
+ */
+export function sameValue(a: string, b: string): boolean {
+  if (a === b) return true;
+  const x = value(a);
+  const y = value(b);
+  if (!x || !y) return false;
+  return x.n * y.d === y.n * x.d;
+}
+
+/* ── generation ───────────────────────────────────────────────────────────── */
+
+/** Families legal at `difficulty`, always including a couple of easier ones. */
+export function familiesFor(difficulty: number): Family[] {
+  const d = Math.max(1, Math.min(10, Math.round(difficulty)));
+  const eligible = FAMILIES.filter((f) => f.from <= d);
+  // Keep a shallow tail of easier work in the mix so the tower never becomes a
+  // wall of the single hardest thing — variety is what holds a long run.
+  const floor = Math.max(1, d - 3);
+  return eligible.filter((f) => f.from >= floor || eligible.length <= 2);
+}
+
+let counter = 0;
+
+/**
+ * Build one question. `slots` is how many faces the sliding block will cycle
+ * through, so we need `slots - 1` usable distractors.
+ */
+export function generate(
+  rng: () => number,
+  difficulty: number,
+  slots: number,
+  domain?: string,
+): Question {
+  const pool = familiesFor(difficulty);
+  const fam = domain ? (FAMILIES.find((f) => f.id === domain) ?? pick(rng, pool)) : pick(rng, pool);
+  // Always produce at least three, so the revive panel has four buttons even
+  // when the sweep is only cycling two values.
+  const want = Math.max(3, slots - 1);
+
+  let built = fam.build(rng);
+  // Retry a couple of times if a family produced a degenerate spread (e.g. a
+  // mal-rule that collided with the answer). Bounded, so it always terminates.
+  for (let attempt = 0; attempt < 6; attempt++) {
+    const out: string[] = [];
+    for (const w of built.wrong) {
+      if (w === "" || sameValue(w, built.answer)) continue;
+      if (out.some((o) => sameValue(o, w))) continue;
+      out.push(w);
+      if (out.length === want) break;
+    }
+    if (out.length >= want) {
+      return {
+        id: `q${(counter = (counter + 1) % 1e9)}-${fam.id}`,
+        prompt: built.prompt,
+        answer: built.answer,
+        distractors: out,
+        domain: fam.id,
+        difficulty,
+      };
+    }
+    built = fam.build(rng);
+  }
+
+  // Unreachable in practice; kept so the function is total.
+  return {
+    id: `q${(counter = (counter + 1) % 1e9)}-${fam.id}`,
+    prompt: built.prompt,
+    answer: built.answer,
+    distractors: built.wrong.filter((w) => !sameValue(w, built.answer)).slice(0, want),
+    domain: fam.id,
+    difficulty,
+  };
+}
+
+/** Exposed for tests only. */
+export const ALL_FAMILIES = FAMILIES;

--- a/dynawalla/games/stack/src/host/stub.ts
+++ b/dynawalla/games/stack/src/host/stub.ts
@@ -1,0 +1,54 @@
+/**
+ * A local stub Host so the game is playable standalone with `npm run dev`.
+ * The real runtime lands underneath this and the game never notices.
+ */
+
+import type { Host, Question } from "../contract.ts";
+import { generate, makeRng } from "./mathgen.ts";
+
+export type StubOpts = {
+  seed?: number;
+  /** How many faces the sliding block cycles through. The game sets this. */
+  slots?: number;
+  onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void;
+};
+
+export function createStubHost(opts: StubOpts = {}): Host & { setSlots(n: number): void } {
+  const rng = makeRng(opts.seed ?? 0x5745);
+  let slots = opts.slots ?? 3;
+  const canVibrate = typeof navigator !== "undefined" && typeof navigator.vibrate === "function";
+
+  const PATTERNS: Record<string, number | number[]> = {
+    light: 8,
+    medium: 18,
+    heavy: 34,
+    success: [12, 26, 16],
+    failure: [40, 50, 40],
+  };
+
+  return {
+    setSlots(n: number) {
+      slots = Math.max(2, Math.min(5, n | 0));
+    },
+    next(o?: { domain?: string; difficulty?: number }): Question {
+      return generate(rng, o?.difficulty ?? 1, slots, o?.domain);
+    },
+    report(r) {
+      opts.onReport?.(r);
+    },
+    haptic(k) {
+      if (!canVibrate) return;
+      try {
+        navigator.vibrate(PATTERNS[k] ?? 10);
+      } catch (err) {
+        console.warn("[stack] haptic failed", err);
+      }
+    },
+    prefersReducedMotion() {
+      return (
+        typeof matchMedia === "function" &&
+        matchMedia("(prefers-reduced-motion: reduce)").matches
+      );
+    },
+  };
+}

--- a/dynawalla/games/stack/src/index.ts
+++ b/dynawalla/games/stack/src/index.ts
@@ -1,0 +1,3 @@
+export type { Host, Question, Mount } from "./contract.ts";
+export { mount } from "./game/mount.ts";
+export { createStubHost } from "./host/stub.ts";

--- a/dynawalla/games/stack/src/main.ts
+++ b/dynawalla/games/stack/src/main.ts
@@ -1,0 +1,16 @@
+/**
+ * Standalone dev entry. `npm run dev` and play.
+ * The real runtime supplies its own Host; this one is exact, seeded and local.
+ */
+
+import { mount } from "./game/mount.ts";
+import { createStubHost } from "./host/stub.ts";
+
+const el = document.getElementById("app")!;
+const host = createStubHost({ seed: 0x5745, slots: 3 });
+const game = mount(el, host);
+
+// Hot-reload without leaking a WebGL context.
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => game.unmount());
+}

--- a/dynawalla/games/stack/src/ui/hud.ts
+++ b/dynawalla/games/stack/src/ui/hud.ts
@@ -1,0 +1,424 @@
+/**
+ * The chrome. DOM rather than textures, because a prompt a child has to read
+ * under time pressure should be real text at device resolution.
+ *
+ * Deliberate omissions: no tutorial, no toast, no "Incorrect", no red X. When a
+ * value is wrong the equation simply COMPLETES ITSELF in the accent colour for
+ * three quarters of a second — the truth, stated once, with no adjective
+ * attached to the child. The punishment is already in the building: the tower
+ * got thinner and you can see it.
+ *
+ * Total translatable surface: four words.
+ */
+
+const CSS = `
+.mn { position:absolute; inset:0; pointer-events:none; overflow:hidden;
+  font-family: ui-sans-serif,-apple-system,"SF Pro Display","Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+  color:var(--fg); -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
+  --fg:#fff; --bg:#07080f; --ac:#ff6a1f; --dim:rgba(255,255,255,.42); --shadow:0 2px 24px rgba(0,0,0,.55);
+  contain:layout style; user-select:none; -webkit-user-select:none; -webkit-tap-highlight-color:transparent; }
+.mn * { box-sizing:border-box; margin:0; }
+
+.mn-floor { position:absolute; top:max(10px,env(safe-area-inset-top)); left:14px; display:flex; align-items:baseline; gap:10px;
+  transform-origin:left center; will-change:transform; }
+.mn-floor b { font-size:clamp(40px,10.5vmin,84px); font-weight:800; letter-spacing:-.045em; line-height:.85;
+  font-variant-numeric:tabular-nums; text-shadow:var(--shadow); }
+.mn-floor i { font-style:normal; font-size:clamp(9px,2.2vmin,12px); font-weight:800; letter-spacing:.22em;
+  color:var(--dim); text-transform:uppercase; }
+
+.mn-best { position:absolute; top:max(10px,env(safe-area-inset-top)); right:14px; text-align:right;
+  font-size:clamp(9px,2.2vmin,12px); font-weight:800; letter-spacing:.2em; color:var(--dim); text-transform:uppercase; }
+.mn-best em { font-style:normal; display:block; font-size:clamp(15px,4vmin,26px); letter-spacing:-.02em; color:var(--fg);
+  font-variant-numeric:tabular-nums; opacity:.85; }
+
+.mn-prompt { position:absolute; left:50%; top:18%; transform:translate(-50%,-50%);
+  display:flex; align-items:center; gap:0; padding:.42em .72em .5em;
+  background:var(--bg); border-bottom:3px solid var(--ac);
+  font-size:clamp(21px,6.6vmin,46px); font-weight:800; letter-spacing:-.02em; white-space:nowrap;
+  font-variant-numeric:tabular-nums; box-shadow:0 10px 40px rgba(0,0,0,.45);
+  will-change:transform,opacity; }
+.mn-prompt.reveal { border-bottom-color:var(--fg); }
+.mn-prompt .fill { color:var(--ac); }
+.mn-prompt .q { color:var(--ac); }
+
+.mn-combo { position:absolute; left:50%; top:calc(18% + 2.9em); transform:translate(-50%,0) scale(1);
+  font-size:clamp(13px,3.4vmin,22px); font-weight:800; letter-spacing:.02em; color:var(--ac);
+  font-variant-numeric:tabular-nums; opacity:0; will-change:transform,opacity; }
+
+.mn-true { position:absolute; left:50%; top:47%; text-transform:uppercase; transform:translate(-50%,-50%) scale(.4);
+  font-size:clamp(34px,12vmin,104px); font-weight:800; letter-spacing:-.05em; color:var(--ac);
+  opacity:0; will-change:transform,opacity; text-shadow:0 0 60px color-mix(in srgb,var(--ac) 60%,transparent); }
+
+.mn-band { position:absolute; left:0; right:0; top:57%; text-align:center; opacity:0; will-change:transform,opacity; }
+.mn-band u { text-decoration:none; display:block; font-size:clamp(9px,2.4vmin,13px); font-weight:800; letter-spacing:.42em;
+  color:var(--dim); text-transform:uppercase; }
+.mn-band b { display:block; font-size:clamp(28px,8.5vmin,62px); font-weight:800; letter-spacing:.06em; }
+
+.mn-hint { position:absolute; left:50%; bottom:12%; transform:translateX(-50%);
+  font-size:clamp(10px,2.6vmin,14px); font-weight:800; letter-spacing:.3em; color:var(--dim); text-transform:uppercase;
+  animation:mnpulse 1.9s ease-in-out infinite; }
+@keyframes mnpulse { 0%,100%{opacity:.28} 50%{opacity:.85} }
+
+.mn-over { position:absolute; inset:0; display:flex; flex-direction:column; align-items:center; justify-content:center;
+  gap:clamp(12px,3vmin,24px); pointer-events:auto; opacity:0; visibility:hidden;
+  background:radial-gradient(120% 90% at 50% 45%, transparent 18%, color-mix(in srgb,var(--bg) 99%,transparent) 62%);
+  padding:20px; transition:opacity .28s ease; }
+.mn-over.on { opacity:1; visibility:visible; }
+.mn-over h1 { font-size:clamp(11px,2.8vmin,15px); font-weight:800; letter-spacing:.42em; color:var(--dim); text-transform:uppercase; }
+.mn-over .big { font-size:clamp(56px,20vmin,150px); font-weight:800; letter-spacing:-.06em; line-height:.82;
+  font-variant-numeric:tabular-nums; }
+.mn-over .sub { font-size:clamp(10px,2.5vmin,13px); font-weight:800; letter-spacing:.25em; color:var(--dim); text-transform:uppercase; }
+.mn-q { font-size:clamp(20px,6vmin,40px); font-weight:800; letter-spacing:-.02em; font-variant-numeric:tabular-nums;
+  padding:.3em .6em; border-bottom:3px solid var(--ac); background:var(--bg); }
+.mn-choices { display:flex; flex-wrap:wrap; gap:clamp(7px,1.8vmin,12px); justify-content:center; max-width:min(560px,94vw); }
+.mn-choices button, .mn-btn {
+  pointer-events:auto; font:inherit; font-weight:800; letter-spacing:-.01em; font-variant-numeric:tabular-nums;
+  min-width:clamp(64px,17vmin,104px); min-height:clamp(52px,13vmin,80px); padding:0 .55em;
+  font-size:clamp(20px,5.6vmin,36px); color:var(--bg); background:var(--fg); border:0; border-radius:0;
+  cursor:pointer; transition:transform .09s ease, background .12s ease; touch-action:manipulation; }
+.mn-choices button:active, .mn-btn:active { transform:scale(.94); }
+.mn-choices button.bad { background:#4a4a52; color:rgba(255,255,255,.5); }
+.mn-choices button.good { background:var(--ac); }
+.mn-btn { min-height:clamp(44px,11vmin,62px); font-size:clamp(11px,2.9vmin,15px); letter-spacing:.26em; text-transform:uppercase;
+  background:transparent; color:var(--fg); border:2px solid color-mix(in srgb,var(--fg) 45%,transparent); }
+.mn-btn.solid { background:var(--ac); color:var(--bg); border-color:var(--ac); }
+
+.mn-tools { position:absolute; right:12px; bottom:max(12px,env(safe-area-inset-bottom)); display:flex; gap:8px; pointer-events:auto; }
+.mn-tools button { pointer-events:auto; width:40px; height:40px; border:2px solid color-mix(in srgb,var(--fg) 28%,transparent);
+  background:var(--bg); color:var(--fg); font:inherit; font-size:13px; font-weight:800;
+  border-radius:0; cursor:pointer; letter-spacing:0; touch-action:manipulation; }
+.mn-tools button[aria-pressed="false"] { opacity:.42; }
+
+.mn-perf { position:absolute; background:rgba(0,0,0,.55); padding:6px 9px; color:#fff !important; left:14px; bottom:max(12px,env(safe-area-inset-bottom)); font-size:11px; font-weight:700;
+  letter-spacing:.06em; color:var(--dim); font-variant-numeric:tabular-nums; white-space:pre; line-height:1.45; display:none; }
+.mn-perf.on { display:block; }
+
+@media (prefers-reduced-motion: reduce) {
+  .mn-hint { animation:none; opacity:.6; }
+  .mn-over { transition:none; }
+}
+`;
+
+export type HudCallbacks = {
+  onRestart(): void;
+  onRevive(): void;
+  onChoose(v: string): void;
+  onToggleAudio(on: boolean): void;
+};
+
+export class Hud {
+  readonly root: HTMLDivElement;
+  private floorEl: HTMLElement;
+  private floorNum: HTMLElement;
+  private bestNum: HTMLElement;
+  private promptEl: HTMLElement;
+  private comboEl: HTMLElement;
+  private trueEl: HTMLElement;
+  private bandEl: HTMLElement;
+  private bandName: HTMLElement;
+  private hintEl: HTMLElement;
+  private overEl: HTMLElement;
+  private overBig: HTMLElement;
+  private overSub: HTMLElement;
+  private overQ: HTMLElement;
+  private choicesEl: HTMLElement;
+  private reviveBtn: HTMLButtonElement;
+  private againBtn: HTMLButtonElement;
+  private audioBtn: HTMLButtonElement;
+  private perfEl: HTMLElement;
+
+  private lastPrompt = "";
+  private lastReveal: string | null = null;
+  private lastFloor = -1;
+  private reduced: boolean;
+  private anims: Animation[] = [];
+
+  constructor(parent: HTMLElement, cb: HudCallbacks, reduced: boolean) {
+    this.reduced = reduced;
+    const style = document.createElement("style");
+    style.textContent = CSS;
+    parent.appendChild(style);
+
+    const d = document.createElement("div");
+    d.className = "mn";
+    d.innerHTML = `
+      <div class="mn-floor"><b>0</b><i data-t="floor">Floor</i></div>
+      <div class="mn-best"><span data-t="best">Best</span><em>0</em></div>
+      <div class="mn-prompt"></div>
+      <div class="mn-combo"></div>
+      <div class="mn-true"></div>
+      <div class="mn-band"><u data-t="band">Stratum</u><b></b></div>
+      <div class="mn-hint" data-t="tap">Tap to set the stone</div>
+      <div class="mn-over">
+        <h1 data-t="fell">The monument fell</h1>
+        <div class="big">0</div>
+        <div class="sub"><span data-t="floor">Floor</span></div>
+        <div class="mn-q"></div>
+        <div class="mn-choices"></div>
+        <button class="mn-btn solid mn-revive" data-t="shore">Shore it up</button>
+        <button class="mn-btn mn-again" data-t="again">Begin again</button>
+      </div>
+      <div class="mn-tools"><button class="mn-audio" aria-pressed="true" aria-label="Sound">♪</button></div>
+      <div class="mn-perf"></div>`;
+    parent.appendChild(d);
+    this.root = d;
+
+    const q = <T extends Element>(s: string): T => d.querySelector<T>(s)!;
+    this.floorEl = q(".mn-floor");
+    this.floorNum = q(".mn-floor b");
+    this.bestNum = q(".mn-best em");
+    this.promptEl = q(".mn-prompt");
+    this.comboEl = q(".mn-combo");
+    this.trueEl = q(".mn-true");
+    this.bandEl = q(".mn-band");
+    this.bandName = q(".mn-band b");
+    this.hintEl = q(".mn-hint");
+    this.overEl = q(".mn-over");
+    this.overBig = q(".mn-over .big");
+    this.overSub = q(".mn-over .sub");
+    this.overQ = q(".mn-q");
+    this.choicesEl = q(".mn-choices");
+    this.reviveBtn = q(".mn-revive");
+    this.againBtn = q(".mn-again");
+    this.audioBtn = q(".mn-audio");
+    this.perfEl = q(".mn-perf");
+
+    this.reviveBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      cb.onRevive();
+    });
+    this.againBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      cb.onRestart();
+    });
+    this.audioBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      const on = this.audioBtn.getAttribute("aria-pressed") !== "true";
+      this.audioBtn.setAttribute("aria-pressed", String(on));
+      cb.onToggleAudio(on);
+    });
+    this.choicesEl.addEventListener("click", (e) => {
+      const b = (e.target as HTMLElement).closest("button");
+      if (!b) return;
+      e.stopPropagation();
+      cb.onChoose(b.dataset.v ?? "");
+    });
+    // A run that ended badly must cost nothing to leave. Anywhere on the
+    // backdrop begins again; the buttons keep their own jobs. Without this a
+    // child who mis-taps in the first second has to find and hit a control
+    // before they are allowed to try the thing they were enjoying.
+    this.overEl.addEventListener("pointerdown", (e) => {
+      e.stopPropagation();
+      if ((e.target as HTMLElement).closest("button")) return;
+      if (this.choicesEl.style.display !== "none" && this.choicesEl.children.length) return;
+      cb.onRestart();
+    });
+  }
+
+  /* ── palette ──────────────────────────────────────────────────────────── */
+
+  /** `bright` = the sky behind the chrome is light, so the chrome inverts. */
+  setPalette(bright: boolean, plate: string, accent: string): void {
+    const s = this.root.style;
+    s.setProperty("--fg", bright ? "#0b0c12" : "#ffffff");
+    s.setProperty("--bg", plate);
+    s.setProperty("--ac", accent);
+    s.setProperty("--dim", bright ? "rgba(11,12,18,.6)" : "rgba(255,255,255,.5)");
+    s.setProperty("--shadow", bright ? "0 2px 18px rgba(255,255,255,.65)" : "0 2px 24px rgba(0,0,0,.55)");
+  }
+
+  /* ── live readouts ────────────────────────────────────────────────────── */
+
+  setFloor(n: number, best: number): void {
+    if (n === this.lastFloor) return;
+    const up = n > this.lastFloor;
+    this.lastFloor = n;
+    this.floorNum.textContent = String(n);
+    this.bestNum.textContent = String(best);
+    if (!this.reduced && up) {
+      this.play(this.floorEl, [{ transform: "scale(1.16)" }, { transform: "scale(1)" }], 240);
+    }
+  }
+
+  /**
+   * `?` in the prompt is drawn in the accent so the blank is obvious at a
+   * glance; on a reveal the answer replaces it in the same colour, so the eye
+   * lands on exactly the thing that changed.
+   */
+  setPrompt(prompt: string, reveal: string | null): void {
+    // Called every frame, so it compares its two inputs directly instead of
+    // building a composite key: string concatenation sixty times a second is
+    // exactly the per-frame allocation this game does not do.
+    if (prompt === this.lastPrompt && reveal === this.lastReveal) return;
+    const fresh = prompt !== this.lastPrompt;
+    this.lastPrompt = prompt;
+    this.lastReveal = reveal;
+    const html = reveal
+      ? escape(prompt).replace("?", `<span class="fill">${escape(reveal)}</span>`)
+      : escape(prompt).replace("?", `<span class="q">?</span>`);
+    this.promptEl.innerHTML = html;
+    this.promptEl.classList.toggle("reveal", reveal !== null);
+    if (!this.reduced && (fresh || reveal)) {
+      this.play(
+        this.promptEl,
+        reveal
+          ? [
+              { transform: "translate(-50%,-50%) scale(1.14)" },
+              { transform: "translate(-50%,-50%) scale(1)" },
+            ]
+          : [
+              { transform: "translate(-50%,-50%) scale(.92)", opacity: 0.4 },
+              { transform: "translate(-50%,-50%) scale(1)", opacity: 1 },
+            ],
+        reveal ? 320 : 200,
+      );
+    }
+  }
+
+  setCombo(n: number): void {
+    if (n < 2) {
+      this.comboEl.style.opacity = "0";
+      return;
+    }
+    this.comboEl.textContent = `×${n}`;
+    this.comboEl.style.opacity = "1";
+    if (this.reduced) return;
+    const s = Math.min(2.2, 1 + n * 0.075);
+    this.play(
+      this.comboEl,
+      [
+        { transform: `translate(-50%,0) scale(${s + 0.5})` },
+        { transform: `translate(-50%,0) scale(${s})` },
+      ],
+      280,
+    );
+    this.comboEl.style.transform = `translate(-50%,0) scale(${s})`;
+  }
+
+  /** The single word this game says when you get it right. */
+  callTrue(combo: number): void {
+    this.trueEl.textContent = this.t("true", "True");
+    if (this.reduced) {
+      this.trueEl.style.opacity = "1";
+      setTimeout(() => (this.trueEl.style.opacity = "0"), 420);
+      return;
+    }
+    const s = Math.min(2.1, 1 + combo * 0.08);
+    this.play(
+      this.trueEl,
+      [
+        { transform: `translate(-50%,-50%) scale(${s * 0.35}) rotate(-6deg)`, opacity: 0 },
+        { transform: `translate(-50%,-58%) scale(${s * 1.12}) rotate(1.5deg)`, opacity: 1, offset: 0.22 },
+        { transform: `translate(-50%,-64%) scale(${s})`, opacity: 1, offset: 0.5 },
+        { transform: `translate(-50%,-92%) scale(${s * 0.9})`, opacity: 0 },
+      ],
+      620 + combo * 22,
+    );
+  }
+
+  announceBand(name: string): void {
+    this.bandName.textContent = name;
+    if (this.reduced) {
+      this.bandEl.style.opacity = "1";
+      setTimeout(() => (this.bandEl.style.opacity = "0"), 1400);
+      return;
+    }
+    this.play(
+      this.bandEl,
+      [
+        { transform: "scale(.86)", opacity: 0, filter: "blur(6px)" },
+        { transform: "scale(1)", opacity: 1, filter: "blur(0)", offset: 0.18 },
+        { transform: "scale(1.02)", opacity: 1, offset: 0.7 },
+        { transform: "scale(1.1)", opacity: 0 },
+      ],
+      2000,
+    );
+  }
+
+  showPrompt(on: boolean): void {
+    this.promptEl.style.opacity = on ? "" : "0";
+    this.promptEl.style.visibility = on ? "" : "hidden";
+  }
+
+  hideHint(): void {
+    this.hintEl.style.display = "none";
+  }
+
+  /* ── the end, and the way back ────────────────────────────────────────── */
+
+  showOver(floor: number, canRevive: boolean): void {
+    this.overBig.textContent = String(floor);
+    this.overSub.textContent = this.t("floor", "Floor");
+    this.overQ.style.display = "none";
+    this.choicesEl.style.display = "none";
+    this.reviveBtn.style.display = canRevive ? "" : "none";
+    this.againBtn.style.display = "";
+    this.overEl.classList.add("on");
+  }
+
+  showRevive(prompt: string, choices: string[]): void {
+    this.overBig.textContent = "";
+    this.overSub.textContent = "";
+    this.overQ.style.display = "";
+    this.overQ.innerHTML = escape(prompt).replace("?", `<span class="q">?</span>`);
+    this.choicesEl.style.display = "";
+    this.choicesEl.textContent = "";
+    for (const c of choices) {
+      const b = document.createElement("button");
+      b.textContent = c;
+      b.dataset.v = c;
+      this.choicesEl.appendChild(b);
+    }
+    this.reviveBtn.style.display = "none";
+    this.againBtn.style.display = "";
+    this.overEl.classList.add("on");
+  }
+
+  markChoice(chosen: string, answer: string): void {
+    for (const b of this.choicesEl.querySelectorAll("button")) {
+      const v = b.dataset.v ?? "";
+      if (v === answer) b.classList.add("good");
+      else if (v === chosen) b.classList.add("bad");
+      b.disabled = true;
+    }
+  }
+
+  hideOver(): void {
+    this.overEl.classList.remove("on");
+  }
+
+  setPerf(text: string, on: boolean): void {
+    this.perfEl.classList.toggle("on", on);
+    if (on) this.perfEl.textContent = text;
+  }
+
+  /* ── plumbing ─────────────────────────────────────────────────────────── */
+
+  private play(el: Element, frames: Keyframe[], ms: number): void {
+    if (typeof el.animate !== "function") return;
+    const a = el.animate(frames, { duration: ms, easing: "cubic-bezier(.16,1,.3,1)", fill: "forwards" });
+    this.anims.push(a);
+    if (this.anims.length > 24) this.anims.splice(0, 12);
+  }
+
+  /** Placeholder for the host's string table; four keys is the whole surface. */
+  private t(_k: string, fallback: string): string {
+    return fallback;
+  }
+
+  dispose(): void {
+    for (const a of this.anims) {
+      try {
+        a.cancel();
+      } catch (err) {
+        console.warn("[stack] anim cancel", err);
+      }
+    }
+    this.anims.length = 0;
+    this.root.remove();
+  }
+}
+
+function escape(s: string): string {
+  return s.replace(/[&<>"]/g, (c) => (c === "&" ? "&amp;" : c === "<" ? "&lt;" : c === ">" ? "&gt;" : "&quot;"));
+}

--- a/dynawalla/games/stack/src/view/particles.ts
+++ b/dynawalla/games/stack/src/view/particles.ts
@@ -1,0 +1,441 @@
+/**
+ * Two pooled systems, both allocation-free after construction:
+ *
+ *   Sparks  — additive point sprites. Impact dust, perfect-strike sparks, and
+ *             the ambient motes that give each stratum its weather.
+ *   Fallers — real boxes with angular velocity, for the sheared overhang and
+ *             the chunks a cracked slab throws. PERMANENCE: they survive the
+ *             moment that made them and tumble past the camera into the dark.
+ *
+ * Live particles are kept dense at the head of the buffers with a swap-remove,
+ * so the draw range is exactly the live count and the GPU never sees a dead one.
+ */
+
+import {
+  AdditiveBlending,
+  BoxGeometry,
+  BufferAttribute,
+  BufferGeometry,
+  Color,
+  DynamicDrawUsage,
+  InstancedMesh,
+  Matrix4,
+  MeshStandardMaterial,
+  Points,
+  Quaternion,
+  ShaderMaterial,
+  Vector3,
+} from "three";
+import { glowTexture } from "./textures.ts";
+
+const SPARK_VERT = /* glsl */ `
+precision highp float;
+attribute vec3 aColor;
+attribute float aSize;
+attribute float aAlpha;
+varying vec3 vColor;
+varying float vAlpha;
+uniform float uScale;
+void main() {
+  vColor = aColor;
+  vAlpha = aAlpha;
+  vec4 mv = modelViewMatrix * vec4(position, 1.0);
+  gl_PointSize = clamp(aSize * uScale / max(0.15, -mv.z), 1.0, 190.0);
+  gl_Position = projectionMatrix * mv;
+}
+`;
+
+const SPARK_FRAG = /* glsl */ `
+precision highp float;
+varying vec3 vColor;
+varying float vAlpha;
+uniform sampler2D uTex;
+void main() {
+  float a = texture2D(uTex, gl_PointCoord).a * vAlpha;
+  if (a < 0.004) discard;
+  gl_FragColor = vec4(vColor * a, a);
+}
+`;
+
+export type SparkOpts = {
+  count: number;
+  color: number;
+  color2?: number;
+  speed: number;
+  speedJitter?: number;
+  /** 0 = flat ring, 1 = full sphere. */
+  dome?: number;
+  size: number;
+  sizeJitter?: number;
+  life: number;
+  lifeJitter?: number;
+  gravity: number;
+  drag: number;
+  /** Extra outward radius at birth. */
+  radius?: number;
+  /** Persistent weather rather than a burst. */
+  ambient?: boolean;
+};
+
+export class Sparks {
+  readonly points: Points;
+  private geo: BufferGeometry;
+  private mat: ShaderMaterial;
+  private cap: number;
+  private n = 0;
+
+  private pos: Float32Array;
+  private col: Float32Array;
+  private siz: Float32Array;
+  private alp: Float32Array;
+
+  private vel: Float32Array;
+  private life: Float32Array;
+  private life0: Float32Array;
+  private grav: Float32Array;
+  private drag: Float32Array;
+  private size0: Float32Array;
+  private flags: Uint8Array; // 1 = ambient (wraps instead of dying)
+
+  private tmpC = new Color();
+
+  constructor(cap: number) {
+    this.cap = cap;
+    this.pos = new Float32Array(cap * 3);
+    this.col = new Float32Array(cap * 3);
+    this.siz = new Float32Array(cap);
+    this.alp = new Float32Array(cap);
+    this.vel = new Float32Array(cap * 3);
+    this.life = new Float32Array(cap);
+    this.life0 = new Float32Array(cap);
+    this.grav = new Float32Array(cap);
+    this.drag = new Float32Array(cap);
+    this.size0 = new Float32Array(cap);
+    this.flags = new Uint8Array(cap);
+
+    this.geo = new BufferGeometry();
+    const pa = new BufferAttribute(this.pos, 3);
+    const ca = new BufferAttribute(this.col, 3);
+    const sa = new BufferAttribute(this.siz, 1);
+    const aa = new BufferAttribute(this.alp, 1);
+    pa.setUsage(DynamicDrawUsage);
+    ca.setUsage(DynamicDrawUsage);
+    sa.setUsage(DynamicDrawUsage);
+    aa.setUsage(DynamicDrawUsage);
+    this.geo.setAttribute("position", pa);
+    this.geo.setAttribute("aColor", ca);
+    this.geo.setAttribute("aSize", sa);
+    this.geo.setAttribute("aAlpha", aa);
+    this.geo.setDrawRange(0, 0);
+    this.geo.boundingSphere = null;
+
+    this.mat = new ShaderMaterial({
+      vertexShader: SPARK_VERT,
+      fragmentShader: SPARK_FRAG,
+      uniforms: { uTex: { value: glowTexture() }, uScale: { value: 340 } },
+      transparent: true,
+      depthWrite: false,
+      blending: AdditiveBlending,
+    });
+    this.points = new Points(this.geo, this.mat);
+    this.points.frustumCulled = false;
+    this.points.renderOrder = 8;
+  }
+
+  setScale(px: number): void {
+    this.mat.uniforms.uScale!.value = px;
+  }
+
+  get live(): number {
+    return this.n;
+  }
+
+  clearAmbient(): void {
+    for (let i = this.n - 1; i >= 0; i--) if (this.flags[i]) this.kill(i);
+  }
+
+  private kill(i: number): void {
+    const last = --this.n;
+    if (i !== last) this.copy(last, i);
+  }
+
+  private copy(from: number, to: number): void {
+    this.pos[to * 3] = this.pos[from * 3]!;
+    this.pos[to * 3 + 1] = this.pos[from * 3 + 1]!;
+    this.pos[to * 3 + 2] = this.pos[from * 3 + 2]!;
+    this.col[to * 3] = this.col[from * 3]!;
+    this.col[to * 3 + 1] = this.col[from * 3 + 1]!;
+    this.col[to * 3 + 2] = this.col[from * 3 + 2]!;
+    this.vel[to * 3] = this.vel[from * 3]!;
+    this.vel[to * 3 + 1] = this.vel[from * 3 + 1]!;
+    this.vel[to * 3 + 2] = this.vel[from * 3 + 2]!;
+    this.siz[to] = this.siz[from]!;
+    this.alp[to] = this.alp[from]!;
+    this.life[to] = this.life[from]!;
+    this.life0[to] = this.life0[from]!;
+    this.grav[to] = this.grav[from]!;
+    this.drag[to] = this.drag[from]!;
+    this.size0[to] = this.size0[from]!;
+    this.flags[to] = this.flags[from]!;
+  }
+
+  emit(x: number, y: number, z: number, o: SparkOpts): void {
+    const dome = o.dome ?? 0;
+    const rad = o.radius ?? 0;
+    for (let k = 0; k < o.count; k++) {
+      if (this.n >= this.cap) {
+        // Recycle the oldest burst particle rather than dropping the event —
+        // a capped system must still show SOMETHING at the moment of impact.
+        let oldest = 0;
+        let bestT = 1e9;
+        for (let i = 0; i < this.n; i += 7) {
+          if (!this.flags[i] && this.life[i]! < bestT) {
+            bestT = this.life[i]!;
+            oldest = i;
+          }
+        }
+        this.kill(oldest);
+      }
+      const i = this.n++;
+      const a = Math.random() * Math.PI * 2;
+      const up = Math.random() * dome;
+      const ca = Math.cos(a);
+      const sa = Math.sin(a);
+      const horiz = 1 - up * 0.85;
+      this.pos[i * 3] = x + ca * rad * Math.random();
+      this.pos[i * 3 + 1] = y + (Math.random() - 0.3) * rad * 0.4;
+      this.pos[i * 3 + 2] = z + sa * rad * Math.random();
+      const sp = o.speed * (1 + (Math.random() - 0.5) * (o.speedJitter ?? 0.7));
+      this.vel[i * 3] = ca * sp * horiz;
+      this.vel[i * 3 + 1] = up * sp * 1.6 + (Math.random() - 0.35) * sp * 0.3;
+      this.vel[i * 3 + 2] = sa * sp * horiz;
+      this.tmpC.setHex(o.color2 !== undefined && Math.random() < 0.4 ? o.color2 : o.color);
+      this.col[i * 3] = this.tmpC.r;
+      this.col[i * 3 + 1] = this.tmpC.g;
+      this.col[i * 3 + 2] = this.tmpC.b;
+      const s = o.size * (1 + (Math.random() - 0.5) * (o.sizeJitter ?? 0.6));
+      this.size0[i] = s;
+      this.siz[i] = s;
+      this.alp[i] = 1;
+      const l = o.life * (1 + (Math.random() - 0.5) * (o.lifeJitter ?? 0.5));
+      this.life[i] = l;
+      this.life0[i] = l;
+      this.grav[i] = o.gravity;
+      this.drag[i] = o.drag;
+      this.flags[i] = o.ambient ? 1 : 0;
+    }
+  }
+
+  /** Ambient weather for a stratum: a slab of drifting motes around the camera. */
+  seedMotes(camY: number, count: number, color: number, rise: number, drift: number, size: number): void {
+    this.clearAmbient();
+    for (let k = 0; k < count; k++) {
+      if (this.n >= this.cap) break;
+      const i = this.n++;
+      this.pos[i * 3] = (Math.random() - 0.5) * 16;
+      this.pos[i * 3 + 1] = camY + (Math.random() - 0.5) * 14;
+      this.pos[i * 3 + 2] = (Math.random() - 0.5) * 16;
+      this.vel[i * 3] = (Math.random() - 0.5) * drift;
+      this.vel[i * 3 + 1] = rise * (0.5 + Math.random());
+      this.vel[i * 3 + 2] = (Math.random() - 0.5) * drift;
+      this.tmpC.setHex(color);
+      this.col[i * 3] = this.tmpC.r;
+      this.col[i * 3 + 1] = this.tmpC.g;
+      this.col[i * 3 + 2] = this.tmpC.b;
+      const s = size * (0.6 + Math.random() * 0.8);
+      this.size0[i] = s;
+      this.siz[i] = s;
+      this.alp[i] = 0.15 + Math.random() * 0.6;
+      this.life[i] = 1;
+      this.life0[i] = 1;
+      this.grav[i] = 0;
+      this.drag[i] = 0.05;
+      this.flags[i] = 1;
+    }
+  }
+
+  update(dt: number, camY: number): void {
+    for (let i = this.n - 1; i >= 0; i--) {
+      const p = i * 3;
+      if (this.flags[i]) {
+        // Ambient: drift forever, wrapping around the camera's slab of air.
+        this.pos[p] += this.vel[p]! * dt;
+        this.pos[p + 1] += this.vel[p + 1]! * dt;
+        this.pos[p + 2] += this.vel[p + 2]! * dt;
+        const dy = this.pos[p + 1]! - camY;
+        if (dy > 8) this.pos[p + 1] = camY - 8;
+        else if (dy < -8) this.pos[p + 1] = camY + 8;
+        if (this.pos[p]! > 9) this.pos[p] = -9;
+        else if (this.pos[p]! < -9) this.pos[p] = 9;
+        if (this.pos[p + 2]! > 9) this.pos[p + 2] = -9;
+        else if (this.pos[p + 2]! < -9) this.pos[p + 2] = 9;
+        continue;
+      }
+      const l = (this.life[i]! -= dt);
+      if (l <= 0) {
+        this.kill(i);
+        continue;
+      }
+      const d = Math.max(0, 1 - this.drag[i]! * dt);
+      this.vel[p] = this.vel[p]! * d;
+      this.vel[p + 1] = this.vel[p + 1]! * d - this.grav[i]! * dt;
+      this.vel[p + 2] = this.vel[p + 2]! * d;
+      this.pos[p] += this.vel[p]! * dt;
+      this.pos[p + 1] += this.vel[p + 1]! * dt;
+      this.pos[p + 2] += this.vel[p + 2]! * dt;
+      const t = l / this.life0[i]!;
+      this.alp[i] = t * t;
+      this.siz[i] = this.size0[i]! * (0.35 + 0.65 * t);
+    }
+    this.geo.setDrawRange(0, this.n);
+    (this.geo.getAttribute("position") as BufferAttribute).needsUpdate = true;
+    (this.geo.getAttribute("aColor") as BufferAttribute).needsUpdate = true;
+    (this.geo.getAttribute("aSize") as BufferAttribute).needsUpdate = true;
+    (this.geo.getAttribute("aAlpha") as BufferAttribute).needsUpdate = true;
+  }
+
+  dispose(): void {
+    this.geo.dispose();
+    this.mat.dispose();
+  }
+}
+
+/* ── tumbling solids ──────────────────────────────────────────────────────── */
+
+const M = new Matrix4();
+const Q = new Quaternion();
+const V = new Vector3();
+const S = new Vector3();
+const E = new Vector3();
+
+export class Fallers {
+  readonly mesh: InstancedMesh;
+  readonly material: MeshStandardMaterial;
+  private cap: number;
+  private n = 0;
+  private p: Float32Array;
+  private v: Float32Array;
+  private s: Float32Array;
+  private rot: Float32Array; // euler xyz
+  private av: Float32Array;
+  private life: Float32Array;
+  private life0: Float32Array;
+  private col = new Color();
+
+  constructor(cap: number) {
+    this.cap = cap;
+    this.p = new Float32Array(cap * 3);
+    this.v = new Float32Array(cap * 3);
+    this.s = new Float32Array(cap * 3);
+    this.rot = new Float32Array(cap * 3);
+    this.av = new Float32Array(cap * 3);
+    this.life = new Float32Array(cap);
+    this.life0 = new Float32Array(cap);
+    this.material = new MeshStandardMaterial({ roughness: 0.66, metalness: 0.02 });
+    this.mesh = new InstancedMesh(new BoxGeometry(1, 1, 1), this.material, cap);
+    this.mesh.instanceMatrix.setUsage(DynamicDrawUsage);
+    this.mesh.count = 0;
+    this.mesh.frustumCulled = false;
+    this.mesh.castShadow = false;
+    this.mesh.receiveShadow = false;
+  }
+
+  setColor(hex: number): void {
+    this.col.setHex(hex);
+    this.material.color.copy(this.col);
+  }
+
+  launch(
+    x: number,
+    y: number,
+    z: number,
+    sx: number,
+    sy: number,
+    sz: number,
+    vx: number,
+    vy: number,
+    vz: number,
+    spin: number,
+    life: number,
+  ): void {
+    const i = this.n >= this.cap ? this.oldest() : this.n++;
+    const q = i * 3;
+    this.p[q] = x;
+    this.p[q + 1] = y;
+    this.p[q + 2] = z;
+    this.v[q] = vx;
+    this.v[q + 1] = vy;
+    this.v[q + 2] = vz;
+    this.s[q] = sx;
+    this.s[q + 1] = sy;
+    this.s[q + 2] = sz;
+    this.rot[q] = 0;
+    this.rot[q + 1] = 0;
+    this.rot[q + 2] = 0;
+    this.av[q] = (Math.random() - 0.5) * spin;
+    this.av[q + 1] = (Math.random() - 0.5) * spin * 0.6;
+    this.av[q + 2] = (Math.random() - 0.5) * spin;
+    this.life[i] = life;
+    this.life0[i] = life;
+  }
+
+  private oldest(): number {
+    let best = 0;
+    let t = 1e9;
+    for (let i = 0; i < this.n; i++) if (this.life[i]! < t) ((t = this.life[i]!), (best = i));
+    return best;
+  }
+
+  update(dt: number, gravity: number): void {
+    for (let i = this.n - 1; i >= 0; i--) {
+      const l = (this.life[i]! -= dt);
+      if (l <= 0) {
+        const last = --this.n;
+        if (i !== last) {
+          for (let k = 0; k < 3; k++) {
+            this.p[i * 3 + k] = this.p[last * 3 + k]!;
+            this.v[i * 3 + k] = this.v[last * 3 + k]!;
+            this.s[i * 3 + k] = this.s[last * 3 + k]!;
+            this.rot[i * 3 + k] = this.rot[last * 3 + k]!;
+            this.av[i * 3 + k] = this.av[last * 3 + k]!;
+          }
+          this.life[i] = this.life[last]!;
+          this.life0[i] = this.life0[last]!;
+        }
+        continue;
+      }
+      const q = i * 3;
+      this.v[q + 1] -= gravity * dt;
+      this.p[q] += this.v[q]! * dt;
+      this.p[q + 1] += this.v[q + 1]! * dt;
+      this.p[q + 2] += this.v[q + 2]! * dt;
+      this.rot[q] += this.av[q]! * dt;
+      this.rot[q + 1] += this.av[q + 1]! * dt;
+      this.rot[q + 2] += this.av[q + 2]! * dt;
+
+      const t = Math.min(1, l / Math.min(0.4, this.life0[i]!));
+      E.set(this.rot[q]!, this.rot[q + 1]!, this.rot[q + 2]!);
+      Q.setFromEuler(EULER.set(E.x, E.y, E.z));
+      V.set(this.p[q]!, this.p[q + 1]!, this.p[q + 2]!);
+      S.set(this.s[q]! * t, this.s[q + 1]! * t, this.s[q + 2]! * t);
+      M.compose(V, Q, S);
+      this.mesh.setMatrixAt(i, M);
+    }
+    this.mesh.count = this.n;
+    this.mesh.instanceMatrix.needsUpdate = true;
+  }
+
+  clear(): void {
+    this.n = 0;
+    this.mesh.count = 0;
+  }
+
+  dispose(): void {
+    this.mesh.geometry.dispose();
+    this.material.dispose();
+    this.mesh.dispose();
+  }
+}
+
+import { Euler } from "three";
+const EULER = new Euler();

--- a/dynawalla/games/stack/src/view/post.ts
+++ b/dynawalla/games/stack/src/view/post.ts
@@ -1,0 +1,312 @@
+/**
+ * A small, hand-rolled post chain: bright-pass → separable blur → filmic
+ * composite. Four full-screen quads at most, no EffectComposer, no dependency
+ * beyond three itself.
+ *
+ * Why not UnrealBloomPass: it runs five mip levels and its own tone mapping,
+ * and on the mid tablet that is most of the frame budget for an effect this
+ * game uses on exactly one thing — the hot enamel accent. This does the job in
+ * a quarter of the bandwidth and lets the composite also carry the flash and
+ * the exposure, saving another blit.
+ */
+
+import {
+  BufferAttribute,
+  BufferGeometry,
+  HalfFloatType,
+  LinearFilter,
+  Mesh,
+  NoColorSpace,
+  OrthographicCamera,
+  RGBAFormat,
+  Scene,
+  ShaderMaterial,
+  Vector2,
+  WebGLRenderTarget,
+  type WebGLRenderer,
+} from "three";
+
+const VERT = /* glsl */ `
+precision highp float;
+varying vec2 vUv;
+void main() { vUv = position.xy * 0.5 + 0.5; gl_Position = vec4(position.xy, 0.0, 1.0); }
+`;
+
+const BRIGHT = /* glsl */ `
+precision highp float;
+varying vec2 vUv;
+uniform sampler2D uTex;
+uniform float uThreshold;
+uniform float uSoft;
+void main() {
+  vec3 c = texture2D(uTex, vUv).rgb;
+  float l = dot(c, vec3(0.2126, 0.7152, 0.0722));
+  float k = smoothstep(uThreshold, uThreshold + uSoft, l);
+  gl_FragColor = vec4(c * k, 1.0);
+}
+`;
+
+const BLUR = /* glsl */ `
+precision highp float;
+varying vec2 vUv;
+uniform sampler2D uTex;
+uniform vec2 uDir;
+void main() {
+  // 9-tap gaussian folded into 5 bilinear fetches.
+  vec3 s = texture2D(uTex, vUv).rgb * 0.227027;
+  vec2 o1 = uDir * 1.3846153846;
+  vec2 o2 = uDir * 3.2307692308;
+  s += texture2D(uTex, vUv + o1).rgb * 0.3162162162;
+  s += texture2D(uTex, vUv - o1).rgb * 0.3162162162;
+  s += texture2D(uTex, vUv + o2).rgb * 0.0702702703;
+  s += texture2D(uTex, vUv - o2).rgb * 0.0702702703;
+  gl_FragColor = vec4(s, 1.0);
+}
+`;
+
+const COMPOSITE = /* glsl */ `
+precision highp float;
+varying vec2 vUv;
+uniform sampler2D uScene;
+uniform sampler2D uBloom;
+uniform float uBloom0;
+uniform float uExposure;
+uniform vec3  uFlash;
+uniform float uFlashA;
+uniform float uSat;
+uniform vec2  uAberr;
+
+// The ACES curve, applied to LUMINANCE ONLY, then used to rescale the colour.
+// Full per-channel ACES skews saturated blues toward purple — it turned an
+// authored blue-grey basalt into lavender on the first look at this game, so
+// the palette is now tone-mapped without any hue rotation at all.
+float filmic(float x) {
+  const float a = 2.51, b = 0.03, c = 2.43, d = 0.59, e = 0.14;
+  return clamp((x * (a * x + b)) / (x * (c * x + d) + e), 0.0, 1.0);
+}
+vec3 tonemap(vec3 x) {
+  float l = dot(x, vec3(0.2126, 0.7152, 0.0722));
+  if (l < 1e-5) return x;
+  vec3 c = x * (filmic(l) / l);
+  // Only what still blows past white gets desaturated, and gently.
+  float peak = max(max(c.r, c.g), c.b);
+  c = mix(c, vec3(1.0), smoothstep(1.0, 2.6, peak) * 0.45);
+  return clamp(c, 0.0, 1.0);
+}
+
+void main() {
+  vec3 c;
+  if (uAberr.x > 0.0001) {
+    // Chromatic split that grows with trauma. Radial, so the centre stays sharp.
+    vec2 d = (vUv - 0.5) * uAberr.x;
+    c.r = texture2D(uScene, vUv + d).r;
+    c.g = texture2D(uScene, vUv).g;
+    c.b = texture2D(uScene, vUv - d).b;
+  } else {
+    c = texture2D(uScene, vUv).rgb;
+  }
+  c += texture2D(uBloom, vUv).rgb * uBloom0;
+  // The flash is an EXPOSURE event, not a sheet of white laid over the frame.
+  // Mixing toward white lifted the night sky to grey and read as fog; blowing
+  // the exposure out before the tone curve blows out the LIT surfaces and
+  // leaves the dark sky dark, which is what a bright frame is supposed to do.
+  c *= uExposure * (1.0 + uFlashA * 9.0);
+  c += uFlash * uFlashA * 0.05;
+  c = tonemap(c);
+  float l = dot(c, vec3(0.2126, 0.7152, 0.0722));
+  c = mix(vec3(l), c, uSat);
+  // linear -> sRGB
+  c = mix(c * 12.92, 1.055 * pow(max(c, vec3(0.0031308)), vec3(1.0 / 2.4)) - 0.055, step(vec3(0.0031308), c));
+  gl_FragColor = vec4(c, 1.0);
+}
+`;
+
+function quad(mat: ShaderMaterial): { scene: Scene; mesh: Mesh } {
+  const g = new BufferGeometry();
+  g.setAttribute(
+    "position",
+    new BufferAttribute(new Float32Array([-1, -1, 0, 3, -1, 0, -1, 3, 0]), 3),
+  );
+  const m = new Mesh(g, mat);
+  m.frustumCulled = false;
+  const s = new Scene();
+  s.add(m);
+  return { scene: s, mesh: m };
+}
+
+function rt(w: number, h: number): WebGLRenderTarget {
+  const t = new WebGLRenderTarget(Math.max(1, w), Math.max(1, h), {
+    type: HalfFloatType,
+    format: RGBAFormat,
+    minFilter: LinearFilter,
+    magFilter: LinearFilter,
+    depthBuffer: true,
+    stencilBuffer: false,
+  });
+  t.texture.colorSpace = NoColorSpace;
+  t.texture.generateMipmaps = false;
+  return t;
+}
+
+export class Post {
+  scene!: WebGLRenderTarget;
+  private a!: WebGLRenderTarget;
+  private b!: WebGLRenderTarget;
+  private cam = new OrthographicCamera(-1, 1, 1, -1, 0, 1);
+
+  private brightMat: ShaderMaterial;
+  private blurMat: ShaderMaterial;
+  private compMat: ShaderMaterial;
+  private brightQ;
+  private blurQ;
+  private compQ;
+
+  private w = 1;
+  private h = 1;
+  bloomEnabled = true;
+  bloomDiv = 4;
+
+  constructor(w: number, h: number, bloom: boolean, div: number) {
+    this.bloomEnabled = bloom;
+    this.bloomDiv = div;
+    this.brightMat = new ShaderMaterial({
+      vertexShader: VERT,
+      fragmentShader: BRIGHT,
+      depthTest: false,
+      depthWrite: false,
+      uniforms: { uTex: { value: null }, uThreshold: { value: 0.98 }, uSoft: { value: 0.7 } },
+    });
+    this.blurMat = new ShaderMaterial({
+      vertexShader: VERT,
+      fragmentShader: BLUR,
+      depthTest: false,
+      depthWrite: false,
+      uniforms: { uTex: { value: null }, uDir: { value: new Vector2() } },
+    });
+    this.compMat = new ShaderMaterial({
+      vertexShader: VERT,
+      fragmentShader: COMPOSITE,
+      depthTest: false,
+      depthWrite: false,
+      uniforms: {
+        uScene: { value: null },
+        uBloom: { value: null },
+        uBloom0: { value: 0.9 },
+        uExposure: { value: 1.18 },
+        uFlash: { value: [1, 1, 1] },
+        uFlashA: { value: 0 },
+        uSat: { value: 1.0 },
+        uAberr: { value: new Vector2(0, 0) },
+      },
+    });
+    this.brightQ = quad(this.brightMat);
+    this.blurQ = quad(this.blurMat);
+    this.compQ = quad(this.compMat);
+    this.resize(w, h);
+  }
+
+  resize(w: number, h: number): void {
+    w = Math.max(1, Math.round(w));
+    h = Math.max(1, Math.round(h));
+    if (w === this.w && h === this.h && this.scene) return;
+    this.w = w;
+    this.h = h;
+    this.scene?.dispose();
+    this.a?.dispose();
+    this.b?.dispose();
+    this.scene = rt(w, h);
+    const d = this.bloomDiv;
+    this.a = rt(Math.round(w / d), Math.round(h / d));
+    this.b = rt(Math.round(w / d), Math.round(h / d));
+  }
+
+  setTier(bloom: boolean, div: number): void {
+    if (bloom === this.bloomEnabled && div === this.bloomDiv) return;
+    this.bloomEnabled = bloom;
+    this.bloomDiv = div;
+    const w = this.w;
+    const h = this.h;
+    this.w = -1;
+    this.resize(w, h);
+  }
+
+  setFlash(r: number, g: number, b: number, a: number): void {
+    const f = this.compMat.uniforms.uFlash!.value as number[];
+    f[0] = r;
+    f[1] = g;
+    f[2] = b;
+    this.compMat.uniforms.uFlashA!.value = a;
+  }
+
+  setTrauma(t: number): void {
+    (this.compMat.uniforms.uAberr!.value as Vector2).x = t * t * 0.0095;
+  }
+
+  setBloom(v: number): void {
+    this.compMat.uniforms.uBloom0!.value = v;
+  }
+
+  setExposure(v: number): void {
+    this.compMat.uniforms.uExposure!.value = v;
+  }
+
+  /** Everything after the main scene has been rendered into `this.scene`. */
+  present(r: WebGLRenderer): void {
+    if (this.bloomEnabled) {
+      this.brightMat.uniforms.uTex!.value = this.scene.texture;
+      r.setRenderTarget(this.a);
+      r.render(this.brightQ.scene, this.cam);
+
+      const dir = this.blurMat.uniforms.uDir!.value as Vector2;
+      const bw = this.a.width;
+      const bh = this.a.height;
+
+      this.blurMat.uniforms.uTex!.value = this.a.texture;
+      dir.set(1 / bw, 0);
+      r.setRenderTarget(this.b);
+      r.render(this.blurQ.scene, this.cam);
+
+      this.blurMat.uniforms.uTex!.value = this.b.texture;
+      dir.set(0, 1 / bh);
+      r.setRenderTarget(this.a);
+      r.render(this.blurQ.scene, this.cam);
+
+      // A second, wider pass gives the accent a real halo rather than a fringe.
+      this.blurMat.uniforms.uTex!.value = this.a.texture;
+      dir.set(2.4 / bw, 0);
+      r.setRenderTarget(this.b);
+      r.render(this.blurQ.scene, this.cam);
+
+      this.blurMat.uniforms.uTex!.value = this.b.texture;
+      dir.set(0, 2.4 / bh);
+      r.setRenderTarget(this.a);
+      r.render(this.blurQ.scene, this.cam);
+
+      this.compMat.uniforms.uBloom!.value = this.a.texture;
+    } else {
+      this.compMat.uniforms.uBloom!.value = BLACK;
+      this.compMat.uniforms.uBloom0!.value = 0;
+    }
+    this.compMat.uniforms.uScene!.value = this.scene.texture;
+    r.setRenderTarget(null);
+    r.render(this.compQ.scene, this.cam);
+  }
+
+  dispose(): void {
+    this.scene.dispose();
+    this.a.dispose();
+    this.b.dispose();
+    this.brightMat.dispose();
+    this.blurMat.dispose();
+    this.compMat.dispose();
+    this.brightQ.mesh.geometry.dispose();
+    this.blurQ.mesh.geometry.dispose();
+    this.compQ.mesh.geometry.dispose();
+  }
+}
+
+/** A 1×1 black texture so the composite shader always has a bloom sampler. */
+const BLACK = (() => {
+  const t = rt(1, 1);
+  return t.texture;
+})();

--- a/dynawalla/games/stack/src/view/rings.ts
+++ b/dynawalla/games/stack/src/view/rings.ts
@@ -1,0 +1,113 @@
+/**
+ * Shockwave rings: a flat annulus that snaps out from the point of contact and
+ * dies in half a second.
+ *
+ * It is the cheapest large-scale juice there is — one additive draw call per
+ * ring, no lighting, no depth write — and it is the thing that makes a big
+ * combo read as an EVENT at arm's length rather than as a slightly brighter
+ * particle burst. Pooled; nothing is allocated after construction.
+ */
+
+import { AdditiveBlending, Color, Mesh, MeshBasicMaterial, Object3D, RingGeometry } from "three";
+
+const GEO = new RingGeometry(0.72, 1.0, 64, 1);
+GEO.rotateX(-Math.PI / 2);
+
+type Ring = {
+  mesh: Mesh<RingGeometry, MeshBasicMaterial>;
+  life: number;
+  life0: number;
+  from: number;
+  to: number;
+  peak: number;
+  tilt: number;
+};
+
+export class Rings {
+  readonly group = new Object3D();
+  private pool: Ring[] = [];
+  private next = 0;
+  private c = new Color();
+
+  constructor(count = 5) {
+    for (let i = 0; i < count; i++) {
+      const mesh = new Mesh(
+        GEO,
+        new MeshBasicMaterial({
+          transparent: true,
+          depthWrite: false,
+          blending: AdditiveBlending,
+          toneMapped: false,
+          fog: false,
+          opacity: 0,
+        }),
+      );
+      mesh.visible = false;
+      mesh.frustumCulled = false;
+      mesh.renderOrder = 6;
+      this.group.add(mesh);
+      this.pool.push({ mesh, life: 0, life0: 1, from: 0.3, to: 3, peak: 1, tilt: 0 });
+    }
+  }
+
+  fire(
+    x: number,
+    y: number,
+    z: number,
+    color: number,
+    from: number,
+    to: number,
+    life: number,
+    peak: number,
+    tilt = 0,
+  ): void {
+    const r = this.pool[this.next]!;
+    this.next = (this.next + 1) % this.pool.length;
+    r.mesh.position.set(x, y, z);
+    r.mesh.rotation.set(tilt, 0, 0);
+    this.c.setHex(color);
+    r.mesh.material.color.copy(this.c);
+    r.life = life;
+    r.life0 = life;
+    r.from = from;
+    r.to = to;
+    r.peak = peak;
+    r.tilt = tilt;
+    r.mesh.visible = true;
+  }
+
+  update(dt: number): void {
+    for (const r of this.pool) {
+      if (r.life <= 0) continue;
+      r.life -= dt;
+      if (r.life <= 0) {
+        r.mesh.visible = false;
+        r.mesh.material.opacity = 0;
+        continue;
+      }
+      const t = 1 - r.life / r.life0;
+      // Fast out, slow settle — the ring should feel like it was PUNCHED out.
+      const e = 1 - Math.pow(1 - t, 3.2);
+      const s = r.from + (r.to - r.from) * e;
+      r.mesh.scale.set(s, 1, s);
+      r.mesh.material.opacity = r.peak * (1 - t) * (1 - t);
+    }
+  }
+
+  clear(): void {
+    for (const r of this.pool) {
+      r.life = 0;
+      r.mesh.visible = false;
+    }
+  }
+
+  dispose(): void {
+    for (const r of this.pool) r.mesh.material.dispose();
+    this.pool.length = 0;
+    this.group.clear();
+  }
+}
+
+export function disposeRingGeometry(): void {
+  GEO.dispose();
+}

--- a/dynawalla/games/stack/src/view/sky.ts
+++ b/dynawalla/games/stack/src/view/sky.ts
@@ -1,0 +1,224 @@
+/**
+ * The world behind the monument, entirely procedural.
+ *
+ * A three-stop vertical gradient per stratum, a horizon bloom, thin altitude
+ * striations that scroll as you climb, and a parallaxed skyline of dark
+ * monoliths that you literally climb out of: by about floor 55 the city is gone
+ * and there is only weather. That fade is the story the background tells, and
+ * it costs one full-screen triangle.
+ */
+
+import {
+  BufferAttribute,
+  BufferGeometry,
+  Color,
+  Mesh,
+  OrthographicCamera,
+  Scene,
+  ShaderMaterial,
+} from "three";
+
+const VERT = /* glsl */ `
+precision highp float;
+varying vec2 vUv;
+void main() {
+  vUv = position.xy * 0.5 + 0.5;
+  gl_Position = vec4(position.xy, 0.999, 1.0);
+}
+`;
+
+const FRAG = /* glsl */ `
+precision highp float;
+varying vec2 vUv;
+
+uniform vec3  uC0;      // bottom
+uniform vec3  uC1;      // mid
+uniform vec3  uC2;      // top
+uniform vec3  uSpire;
+uniform vec3  uAccent;
+uniform float uAlt;     // camera height, world units
+uniform float uTime;
+uniform float uAspect;
+uniform float uBandLight; // aurora band strength
+uniform float uGrain;
+uniform float uPeril;     // 0..1 — the sky closes in as the tower thins
+
+float hash11(float p) {
+  p = fract(p * 0.1031);
+  p *= p + 33.33;
+  p *= p + p;
+  return fract(p);
+}
+float hash21(vec2 p) {
+  vec3 p3 = fract(vec3(p.xyx) * 0.1031);
+  p3 += dot(p3, p3.yzx + 33.33);
+  return fract((p3.x + p3.y) * p3.z);
+}
+
+// One parallax band of monoliths. Two copies a period apart so the skyline
+// scrolls forever without a seam.
+float skyline(vec2 uv, float cols, float speed, float base, float amp, float seed) {
+  float p = uAlt * speed;
+  float period = 1.35;
+  float x = uv.x * cols + seed * 31.7;
+  float i = floor(x);
+  float lit = 0.0;
+  for (int k = 0; k < 2; k++) {
+    float phase = p + float(k) * period;
+    float cyc = floor(phase / period);
+    float local = phase - cyc * period;
+    float h = hash21(vec2(i, cyc * 7.0 + seed));
+    // A setback near the top so the silhouettes read as buildings, not teeth.
+    float notch = step(0.62, hash21(vec2(i + 0.5, cyc * 3.0 + seed))) * 0.06;
+    float top = base + h * amp - local + notch * step(0.5, fract(x));
+    lit = max(lit, step(uv.y, top));
+  }
+  return lit;
+}
+
+void main() {
+  vec2 uv = vUv;
+
+  // Gradient. Two smoothsteps so the mid stop actually reads.
+  vec3 col = mix(uC0, uC1, smoothstep(0.0, 0.52, uv.y));
+  col = mix(col, uC2, smoothstep(0.46, 1.0, uv.y));
+
+  // Horizon bloom, low and wide.
+  float hz = exp(-pow((uv.y - 0.10) * 9.0, 2.0));
+  col += uAccent * hz * 0.035;
+
+  // Altitude striations — thin haze layers sliding down as the camera rises.
+  float s = sin((uv.y * 46.0) + uAlt * 1.6) * 0.5 + 0.5;
+  float sMask = smoothstep(0.9, 1.0, s) * smoothstep(0.05, 0.5, uv.y) * 0.03;
+  col += uC2 * sMask;
+
+  // A slow moving band, mostly asleep. AURORA turns it up.
+  if (uBandLight > 0.001) {
+    float y = uv.y - 0.66;
+    float w = sin(uv.x * 3.1 + uTime * 0.21) * 0.06 + sin(uv.x * 7.7 - uTime * 0.13) * 0.03;
+    float b = exp(-pow((y - w) * 9.0, 2.0));
+    col += uAccent * b * uBandLight * (0.55 + 0.45 * sin(uTime * 0.7 + uv.x * 4.0));
+  }
+
+  // The city, fading out by the time the monument is above it.
+  float cityFade = 1.0 - smoothstep(6.0, 26.0, uAlt);
+  if (cityFade > 0.002) {
+    float far  = skyline(uv, 15.0 * uAspect, 0.0075, 0.075, 0.085, 1.0);
+    float mid  = skyline(uv, 10.0 * uAspect, 0.014,  0.045, 0.115, 2.0);
+    float near = skyline(uv, 6.5  * uAspect, 0.024,  0.005, 0.15, 3.0);
+    vec3 farC  = mix(col, uSpire, 0.42);
+    vec3 midC  = mix(col, uSpire, 0.66);
+    vec3 nearC = uSpire * 0.55;
+    col = mix(col, farC,  far  * cityFade);
+    col = mix(col, midC,  mid  * cityFade);
+    col = mix(col, nearC, near * cityFade);
+    // Window glimmer on the near band only — a hint of life down there.
+    float wc = hash21(floor(uv * vec2(320.0 * uAspect, 420.0)));
+    float win = step(0.988, wc) * near * cityFade;
+    col += uAccent * win * 0.18;
+  }
+
+  // Vignette, tightening with peril. The sky closes in as the tower thins.
+  vec2 d = (uv - 0.5) * vec2(uAspect, 1.0);
+  float vig = 1.0 - smoothstep(0.30, 0.92 - uPeril * 0.26, length(d));
+  col *= mix(0.48, 1.0, vig);
+
+  if (uGrain > 0.001) {
+    float g = hash21(uv * 1024.0 + fract(uTime) * 37.0) - 0.5;
+    col += g * uGrain;
+  }
+
+  gl_FragColor = vec4(col, 1.0);
+}
+`;
+
+export class Sky {
+  readonly scene = new Scene();
+  readonly camera = new OrthographicCamera(-1, 1, 1, -1, 0, 1);
+  readonly material: ShaderMaterial;
+  private mesh: Mesh;
+  private c0 = new Color();
+  private c1 = new Color();
+  private c2 = new Color();
+  private cs = new Color();
+  private ca = new Color();
+
+  constructor() {
+    const g = new BufferGeometry();
+    // One oversized triangle covering the viewport — cheaper than a quad.
+    g.setAttribute(
+      "position",
+      new BufferAttribute(new Float32Array([-1, -1, 0, 3, -1, 0, -1, 3, 0]), 3),
+    );
+    this.material = new ShaderMaterial({
+      vertexShader: VERT,
+      fragmentShader: FRAG,
+      depthTest: false,
+      depthWrite: false,
+      uniforms: {
+        uC0: { value: this.c0 },
+        uC1: { value: this.c1 },
+        uC2: { value: this.c2 },
+        uSpire: { value: this.cs },
+        uAccent: { value: this.ca },
+        uAlt: { value: 0 },
+        uTime: { value: 0 },
+        uAspect: { value: 1 },
+        uBandLight: { value: 0 },
+        uGrain: { value: 0.02 },
+        uPeril: { value: 0 },
+      },
+    });
+    this.mesh = new Mesh(g, this.material);
+    this.mesh.frustumCulled = false;
+    this.scene.add(this.mesh);
+  }
+
+  setPalette(sky: [number, number, number], spire: number, accent: number, band: number): void {
+    this.c0.setHex(sky[0]);
+    this.c1.setHex(sky[1]);
+    this.c2.setHex(sky[2]);
+    this.cs.setHex(spire);
+    this.ca.setHex(accent);
+    this.material.uniforms.uBandLight!.value = band;
+  }
+
+  /** Blend toward a new palette so a stratum change is a sweep, not a cut. */
+  lerpPalette(
+    sky: [number, number, number],
+    spire: number,
+    accent: number,
+    band: number,
+    t: number,
+  ): void {
+    const u = this.material.uniforms;
+    tmp.setHex(sky[0]);
+    this.c0.lerp(tmp, t);
+    tmp.setHex(sky[1]);
+    this.c1.lerp(tmp, t);
+    tmp.setHex(sky[2]);
+    this.c2.lerp(tmp, t);
+    tmp.setHex(spire);
+    this.cs.lerp(tmp, t);
+    tmp.setHex(accent);
+    this.ca.lerp(tmp, t);
+    const cur = u.uBandLight!.value as number;
+    u.uBandLight!.value = cur + (band - cur) * t;
+  }
+
+  update(alt: number, time: number, aspect: number, grain: number, peril: number): void {
+    const u = this.material.uniforms;
+    u.uAlt!.value = alt;
+    u.uTime!.value = time;
+    u.uAspect!.value = aspect;
+    u.uGrain!.value = grain;
+    u.uPeril!.value = peril;
+  }
+
+  dispose(): void {
+    this.mesh.geometry.dispose();
+    this.material.dispose();
+  }
+}
+
+const tmp = new Color();

--- a/dynawalla/games/stack/src/view/slabs.ts
+++ b/dynawalla/games/stack/src/view/slabs.ts
@@ -1,0 +1,142 @@
+/**
+ * The monument itself, and the value plaques hanging off it.
+ *
+ * A fixed pool of boxes is mapped onto whichever courses are currently near the
+ * camera; the rest of the tower is swallowed by fog, so the pool boundary is
+ * never visible. Each course keeps the colour of the stratum it was built in,
+ * which turns the tower into a record of the climb.
+ *
+ * Plaques are billboards at a FIXED WORLD SIZE, so a value is the same number
+ * of screen pixels wherever it is — the legibility rule, enforced by geometry
+ * rather than by hoping.
+ */
+
+import {
+  BoxGeometry,
+  Color,
+  DoubleSide,
+  Group,
+  Mesh,
+  MeshBasicMaterial,
+  MeshStandardMaterial,
+  PlaneGeometry,
+  type Camera,
+  type Texture,
+} from "three";
+import { numeralTexture } from "./textures.ts";
+
+const BOX = new BoxGeometry(1, 1, 1);
+const PLANE = new PlaneGeometry(1, 1);
+
+export class SlabPool {
+  readonly group = new Group();
+  readonly meshes: Mesh<BoxGeometry, MeshStandardMaterial>[] = [];
+
+  constructor(count: number, shadows: boolean) {
+    for (let i = 0; i < count; i++) this.grow(shadows);
+  }
+
+  private grow(shadows: boolean): void {
+    const m = new Mesh(
+      BOX,
+      new MeshStandardMaterial({ roughness: 0.62, metalness: 0.03, flatShading: false }),
+    );
+    m.castShadow = shadows;
+    m.receiveShadow = shadows;
+    m.visible = false;
+    m.matrixAutoUpdate = true;
+    this.meshes.push(m);
+    this.group.add(m);
+  }
+
+  resize(count: number, shadows: boolean): void {
+    while (this.meshes.length < count) this.grow(shadows);
+    for (const m of this.meshes) {
+      m.castShadow = shadows;
+      m.receiveShadow = shadows;
+    }
+    if (this.meshes.length > count) {
+      for (let i = count; i < this.meshes.length; i++) this.meshes[i]!.visible = false;
+    }
+  }
+
+  hideFrom(i: number): void {
+    for (let k = i; k < this.meshes.length; k++) this.meshes[k]!.visible = false;
+  }
+
+  dispose(): void {
+    for (const m of this.meshes) m.material.dispose();
+    this.meshes.length = 0;
+    this.group.clear();
+  }
+}
+
+export class Plaque {
+  readonly group = new Group();
+  private plate: Mesh<PlaneGeometry, MeshBasicMaterial>;
+  private glyph: Mesh<PlaneGeometry, MeshBasicMaterial>;
+  private value = " ";
+  private plateC = new Color();
+  private glyphC = new Color();
+
+  constructor() {
+    this.plate = new Mesh(
+      PLANE,
+      new MeshBasicMaterial({ transparent: true, depthWrite: false, depthTest: false, side: DoubleSide, toneMapped: false, fog: false }),
+    );
+    this.glyph = new Mesh(
+      PLANE,
+      new MeshBasicMaterial({ transparent: true, depthWrite: false, depthTest: false, side: DoubleSide, toneMapped: false, fog: false }),
+    );
+    this.plate.renderOrder = 10;
+    this.glyph.renderOrder = 11;
+    this.glyph.position.z = 0.001;
+    this.group.add(this.plate, this.glyph);
+    this.group.visible = false;
+    this.group.renderOrder = 10;
+  }
+
+  /** `h` is plaque height in world units; the plate is 2:1. */
+  set(
+    value: string,
+    h: number,
+    plate: number,
+    glyph: number,
+    opacity: number,
+    plateOpacity = 1,
+  ): void {
+    if (value !== this.value) {
+      this.value = value;
+      const t: Texture = numeralTexture(value);
+      this.glyph.material.map = t;
+      this.glyph.material.needsUpdate = true;
+    }
+    this.plate.scale.set(h * 2, h, 1);
+    this.glyph.scale.set(h * 2, h, 1);
+    this.plateC.setHex(plate);
+    this.glyphC.setHex(glyph);
+    this.plate.material.color.copy(this.plateC);
+    this.glyph.material.color.copy(this.glyphC);
+    this.plate.material.opacity = opacity * plateOpacity;
+    this.glyph.material.opacity = opacity;
+    this.group.visible = opacity > 0.01;
+  }
+
+  face(cam: Camera): void {
+    this.group.quaternion.copy(cam.quaternion);
+  }
+
+  hide(): void {
+    this.group.visible = false;
+  }
+
+  dispose(): void {
+    this.plate.material.dispose();
+    this.glyph.material.dispose();
+  }
+}
+
+export function disposeSharedGeometry(): void {
+  BOX.dispose();
+  PLANE.dispose();
+}

--- a/dynawalla/games/stack/src/view/textures.ts
+++ b/dynawalla/games/stack/src/view/textures.ts
@@ -1,0 +1,125 @@
+/**
+ * Canvas-generated textures. Nothing is fetched; nothing is shipped.
+ *
+ * The hard lesson this file exists to obey: NEVER LET ORNAMENT EAT LEGIBILITY.
+ * A value the player has under half a second to read is drawn as a heavy
+ * geometric sans on a solid plate, at a fixed world size so it is the same
+ * number of screen pixels whether it is at the top of the tower or eight
+ * courses down. No engraving, no serifs, no texture behind a glyph.
+ */
+
+import { CanvasTexture, LinearFilter, SRGBColorSpace, Texture } from "three";
+
+const FONT =
+  '800 <SZ>px ui-sans-serif, -apple-system, "SF Pro Display", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
+
+const W = 256;
+const H = 128;
+
+const numerals = new Map<string, CanvasTexture>();
+const order: string[] = [];
+
+/** White glyph on transparent, so the material can tint it per state. */
+export function numeralTexture(value: string): Texture {
+  const hit = numerals.get(value);
+  if (hit) return hit;
+
+  const cv = document.createElement("canvas");
+  cv.width = W;
+  cv.height = H;
+  const g = cv.getContext("2d")!;
+  g.clearRect(0, 0, W, H);
+  g.fillStyle = "#fff";
+  g.textAlign = "center";
+  g.textBaseline = "middle";
+
+  let size = 92;
+  const pad = 18;
+  const setFont = (s: number): void => {
+    g.font = FONT.replace("<SZ>", String(s));
+  };
+  setFont(size);
+  // Shrink to fit rather than clip. A three-character fraction must still read.
+  let m = g.measureText(value);
+  while (m.width > W - pad * 2 && size > 30) {
+    size -= 4;
+    setFont(size);
+    m = g.measureText(value);
+  }
+  g.fillText(value, W / 2, H / 2 + size * 0.03);
+
+  const tex = new CanvasTexture(cv);
+  tex.colorSpace = SRGBColorSpace;
+  tex.minFilter = LinearFilter;
+  tex.magFilter = LinearFilter;
+  tex.generateMipmaps = false;
+  tex.anisotropy = 4;
+
+  numerals.set(value, tex);
+  order.push(value);
+  if (order.length > 96) {
+    const dead = order.shift()!;
+    numerals.get(dead)?.dispose();
+    numerals.delete(dead);
+  }
+  return tex;
+}
+
+let glow: CanvasTexture | null = null;
+/** Soft radial falloff for additive sparks and accent bleed. */
+export function glowTexture(): Texture {
+  if (glow) return glow;
+  const n = 128;
+  const cv = document.createElement("canvas");
+  cv.width = n;
+  cv.height = n;
+  const g = cv.getContext("2d")!;
+  const grad = g.createRadialGradient(n / 2, n / 2, 0, n / 2, n / 2, n / 2);
+  grad.addColorStop(0, "rgba(255,255,255,1)");
+  grad.addColorStop(0.28, "rgba(255,255,255,0.55)");
+  grad.addColorStop(0.62, "rgba(255,255,255,0.12)");
+  grad.addColorStop(1, "rgba(255,255,255,0)");
+  g.fillStyle = grad;
+  g.fillRect(0, 0, n, n);
+  glow = new CanvasTexture(cv);
+  glow.colorSpace = SRGBColorSpace;
+  glow.generateMipmaps = false;
+  glow.minFilter = LinearFilter;
+  return glow;
+}
+
+let chip: CanvasTexture | null = null;
+/** A hard-edged shard for dust and debris — reads as broken stone, not smoke. */
+export function chipTexture(): Texture {
+  if (chip) return chip;
+  const n = 64;
+  const cv = document.createElement("canvas");
+  cv.width = n;
+  cv.height = n;
+  const g = cv.getContext("2d")!;
+  g.clearRect(0, 0, n, n);
+  g.fillStyle = "#fff";
+  g.beginPath();
+  g.moveTo(n * 0.5, n * 0.08);
+  g.lineTo(n * 0.9, n * 0.42);
+  g.lineTo(n * 0.72, n * 0.92);
+  g.lineTo(n * 0.24, n * 0.86);
+  g.lineTo(n * 0.08, n * 0.38);
+  g.closePath();
+  g.fill();
+  chip = new CanvasTexture(cv);
+  chip.colorSpace = SRGBColorSpace;
+  chip.generateMipmaps = false;
+  chip.minFilter = LinearFilter;
+  return chip;
+}
+
+export function disposeTextures(): void {
+  for (const t of numerals.values()) t.dispose();
+  numerals.clear();
+  order.length = 0;
+  glow?.dispose();
+  glow = null;
+  chip?.dispose();
+  chip = null;
+}

--- a/dynawalla/games/stack/src/view/tier.ts
+++ b/dynawalla/games/stack/src/view/tier.ts
@@ -1,0 +1,158 @@
+/**
+ * Quality tiers. The mid-range tablet sets the FLOOR, never the ceiling.
+ *
+ * ULTRA is allowed to be genuinely staggering; LOW degrades to something that
+ * still reads as the same game — same silhouettes, same colours, same
+ * information — just with fewer photons. A live probe demotes (never promotes)
+ * so a phone that thermally throttles ten minutes in does not start dropping
+ * frames, it drops fidelity.
+ */
+
+export type TierName = "low" | "mid" | "ultra";
+
+export type Tier = {
+  name: TierName;
+  dprCap: number;
+  antialias: boolean;
+  shadows: boolean;
+  shadowSize: number;
+  bloom: boolean;
+  bloomDiv: number;
+  particles: number;
+  motes: number;
+  debris: number;
+  spireBands: number;
+  grain: boolean;
+  /** Slabs kept alive below the camera. */
+  slabPool: number;
+};
+
+export const TIERS: Record<TierName, Tier> = {
+  low: {
+    name: "low",
+    dprCap: 1,
+    antialias: false,
+    shadows: false,
+    shadowSize: 0,
+    bloom: false,
+    bloomDiv: 4,
+    particles: 190,
+    motes: 60,
+    debris: 10,
+    spireBands: 2,
+    grain: false,
+    slabPool: 24,
+  },
+  mid: {
+    name: "mid",
+    dprCap: 1.5,
+    antialias: true,
+    shadows: true,
+    shadowSize: 512,
+    bloom: true,
+    bloomDiv: 4,
+    particles: 460,
+    motes: 130,
+    debris: 18,
+    spireBands: 3,
+    grain: true,
+    slabPool: 30,
+  },
+  ultra: {
+    name: "ultra",
+    dprCap: 2,
+    antialias: true,
+    shadows: true,
+    shadowSize: 1024,
+    bloom: true,
+    bloomDiv: 2,
+    particles: 1000,
+    motes: 240,
+    debris: 30,
+    spireBands: 3,
+    grain: true,
+    slabPool: 36,
+  },
+};
+
+export function detectTier(): Tier {
+  if (typeof navigator === "undefined") return TIERS.mid;
+  const cores = navigator.hardwareConcurrency ?? 4;
+  const mem = (navigator as { deviceMemory?: number }).deviceMemory ?? 4;
+  const dpr = typeof devicePixelRatio === "number" ? devicePixelRatio : 1;
+  const px = typeof screen !== "undefined" ? screen.width * screen.height * dpr * dpr : 1e6;
+
+  if (cores <= 4 || mem <= 3) return TIERS.low;
+  if (cores >= 8 && mem >= 8 && px < 9.5e6) return TIERS.ultra;
+  return TIERS.mid;
+}
+
+/** Rolling frame-time watchdog. Demotes once, then stops fiddling. */
+export class TierWatch {
+  private acc = 0;
+  private n = 0;
+  private demotions = 0;
+  private grace = 1.6;
+  private onDemote: (t: Tier) => void;
+
+  constructor(onDemote: (t: Tier) => void) {
+    this.onDemote = onDemote;
+  }
+
+  sample(dt: number, current: Tier): void {
+    if (this.grace > 0) {
+      this.grace -= dt;
+      return;
+    }
+    if (this.demotions >= 2) return;
+    this.acc += dt;
+    this.n++;
+    if (this.n < 90) return;
+    const avg = this.acc / this.n;
+    this.acc = 0;
+    this.n = 0;
+    if (avg > 0.0205) {
+      const next = current.name === "ultra" ? TIERS.mid : current.name === "mid" ? TIERS.low : null;
+      if (next) {
+        this.demotions++;
+        this.grace = 2.5;
+        console.info(`[stack] frame budget missed (${(avg * 1000).toFixed(1)}ms) — dropping to ${next.name}`);
+        this.onDemote(next);
+      } else {
+        this.demotions = 2;
+      }
+    }
+  }
+}
+
+/** Live fps meter for the on-screen readout and the perf report. */
+export class FpsMeter {
+  private samples = new Float32Array(120);
+  private i = 0;
+  private filled = 0;
+  fps = 60;
+  p95 = 16.7;
+  push(dt: number): void {
+    this.samples[this.i] = dt;
+    this.i = (this.i + 1) % this.samples.length;
+    if (this.filled < this.samples.length) this.filled++;
+    if (this.i % 15 !== 0) return;
+    let sum = 0;
+    for (let k = 0; k < this.filled; k++) sum += this.samples[k]!;
+    this.fps = this.filled / Math.max(1e-6, sum);
+    // p95 frame time without sorting the whole buffer every time.
+    let worst = 0;
+    let second = 0;
+    let count = 0;
+    for (let k = 0; k < this.filled; k++) {
+      const v = this.samples[k]!;
+      if (v > worst) {
+        second = worst;
+        worst = v;
+      } else if (v > second) second = v;
+      count++;
+    }
+    void count;
+    this.p95 = second * 1000;
+  }
+}

--- a/dynawalla/games/stack/tools/playtest.mjs
+++ b/dynawalla/games/stack/tools/playtest.mjs
@@ -1,0 +1,260 @@
+/**
+ * Playtest harness for MONUMENT.
+ *
+ *   npx playwright install chromium      # once
+ *   npm run dev                          # in another shell
+ *   node tools/playtest.mjs --seconds 90 --quality 0.86 --tier ultra
+ *
+ * It drives the real game in a real GPU-backed browser with a bot that reads
+ * the same state a player reads — the value on the stone and its offset from
+ * true — and taps accordingly. `--quality` is how often it plays well, so 0.86
+ * produces a run with real mistakes in it rather than a machine-perfect one.
+ *
+ * It reports measured fps and answer-path latency, and saves screenshots at the
+ * moments worth looking at: at rest, mid-sweep, a big combo, a mistake, deep
+ * escalation, and the collapse.
+ */
+
+import { chromium } from "playwright";
+import { mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+const args = Object.fromEntries(
+  process.argv.slice(2).reduce((a, v, i, arr) => {
+    if (v.startsWith("--")) a.push([v.slice(2), arr[i + 1]?.startsWith("--") ? "1" : arr[i + 1]]);
+    return a;
+  }, []),
+);
+
+const URL = args.url ?? "http://127.0.0.1:4310/?perf=1&dev=1";
+const SECONDS = Number(args.seconds ?? 60);
+const QUALITY = Number(args.quality ?? 0.88);
+const TIER = args.tier ?? "";
+const W = Number(args.width ?? 430);
+const H = Number(args.height ?? 932);
+const OUT = resolve(args.out ?? "./shots");
+const HEADLESS = args.headless === "1";
+
+mkdirSync(OUT, { recursive: true });
+
+const BOT = `
+window.__bot = (function () {
+  const m = window.__monument, sim = m.sim;
+  let on = false, q = 1, raf = 0, taps = 0, sloppy = null, sloppyFor = null;
+  const el = document.querySelector('canvas');
+  const marks = [];
+  const outcomes = { perfect: 0, good: 0, wrong: 0, miss: 0 };
+  const lat = [];
+  let worst = 0, lastT = performance.now();
+  (function watch(){ const n = performance.now(); const d = n - lastT; lastT = n;
+    if (d > worst && d < 500) worst = d; requestAnimationFrame(watch); })();
+  const pd = () => el.dispatchEvent(new PointerEvent('pointerdown', {bubbles:true,clientX:200,clientY:400,pointerId:1}));
+  const tol = () => 0.062 + (0.03 - 0.062) * Math.min(1, sim.floor / 60);
+  // Watch what the sim actually decided, so the report is not the bot's opinion.
+  const origPlace = sim.place.bind(sim);
+  sim.place = (t) => { const ev = origPlace(t); if (ev) { outcomes[ev.outcome]++; marks.push({t: performance.now(), o: ev.outcome, c: ev.combo, f: sim.floor}); lat.push(m.latency()); } return ev; };
+  function loop() {
+    if (!on) return;
+    raf = requestAnimationFrame(loop);
+    if (sim.phase !== 'sweep' || sim.holdLeft > 0) return;
+    const a = sim.axis;
+    const c = (a === 0 ? sim.cx : sim.cz) + (a === 0 ? sim.bendX(1) : sim.bendZ(1));
+    const d = sim.sweep - c;
+    const right = sim.value === sim.question.answer;
+    // Below full quality the bot sometimes commits on the wrong value or wide
+    // of true, which is what a child does and what the penalties exist for.
+    // Decide ONCE per stone whether this one is going to be sloppy, otherwise
+    // a per-frame coin flip fires on the first of sixty frames and the bot is
+    // always terrible.
+    if (sloppyFor !== sim.question.id) {
+      sloppyFor = sim.question.id;
+      sloppy = Math.random() > q ? (Math.random() < 0.6 ? 'wrong' : 'slop') : null;
+    }
+    if (sloppy === 'wrong') {
+      // A child who mis-computed commits CONFIDENTLY on the wrong value.
+      if (!right && Math.abs(d) <= tol() * 1.6) { pd(); taps++; }
+      return;
+    }
+    if (sloppy === 'slop') {
+      // …and a child who did the maths can still be wide of true.
+      if (right && Math.abs(d) > 0.16 && Math.abs(d) < 0.34) { pd(); taps++; }
+      return;
+    }
+    if (right && Math.abs(d) <= tol() * 1.05) { pd(); taps++; }
+  }
+  return {
+    start(qq) { q = qq ?? 1; if (!on) { on = true; loop(); } },
+    stop() { on = false; cancelAnimationFrame(raf); },
+    marks() { const out = marks.slice(); marks.length = 0; return out; },
+    stats() {
+      const L = lat.filter(Number.isFinite).sort((a,b)=>a-b);
+      return { floor: sim.floor, best: sim.best, taps, placed: sim.placed, outcomes,
+        wx: +sim.wx.toFixed(3), wz: +sim.wz.toFixed(3), peril: +sim.peril.toFixed(2),
+        bestCombo: sim.bestCombo, perfects: sim.perfects, phase: sim.phase,
+        fps: +m.fps.fps.toFixed(1), p95ms: +m.fps.p95.toFixed(2), tier: m.tier, worst: +worst.toFixed(2),
+        latMed: L.length ? +L[L.length>>1].toFixed(3) : null,
+        latMax: L.length ? +L[L.length-1].toFixed(3) : null,
+        sparks: undefined };
+    },
+  };
+})();
+'ok';
+`;
+
+const browser = await chromium.launch({
+  headless: HEADLESS,
+  args: [
+    "--disable-backgrounding-occluded-windows",
+    "--disable-renderer-backgrounding",
+    "--disable-background-timer-throttling",
+    "--use-angle=metal",
+    "--enable-gpu",
+    "--hide-scrollbars",
+  ],
+});
+const page = await browser.newPage({
+  viewport: { width: W, height: H },
+  deviceScaleFactor: 2,
+  reducedMotion: args.reduced === "1" ? "reduce" : "no-preference",
+});
+page.on("console", (m) => {
+  if (m.type() === "error" || m.type() === "warning") console.log(`  [page ${m.type()}]`, m.text());
+});
+page.on("pageerror", (e) => console.log("  [pageerror]", e.message));
+
+await page.goto(URL, { waitUntil: "load" });
+await page.waitForFunction(() => !!window.__monument, null, { timeout: 15000 });
+if (TIER) await page.evaluate((t) => window.__monument.setTier(t), TIER);
+await page.waitForTimeout(700);
+
+const shot = async (name) => {
+  await page.screenshot({ path: `${OUT}/${name}.png` });
+  console.log(`  shot ${name}`);
+};
+
+// One real click so the AudioContext is allowed to resume; synthetic events do
+// not carry user activation and the whole sound design would stay silent. It
+// goes on the sound toggle, not the canvas — a real click on the canvas places
+// a stone at whatever random offset the sweep happens to be at.
+await page.click(".mn-audio");
+await page.click(".mn-audio");
+await page.waitForTimeout(250);
+await shot("01-at-rest");
+const heap0 = await page.evaluate(() => performance.memory?.usedJSHeapSize ?? 0);
+await page.evaluate(BOT);
+await page.evaluate((q) => window.__bot.start(q), QUALITY);
+
+const t0 = Date.now();
+const got = new Set();
+let lastFloor = 0;
+let deaths = 0;
+while ((Date.now() - t0) / 1000 < SECONDS) {
+  await page.waitForTimeout(55);
+  const marks = await page.evaluate(() => window.__bot.marks());
+  const s = await page.evaluate(() => window.__bot.stats());
+  lastFloor = s.floor;
+
+  for (const mk of marks) {
+    if (mk.o === "perfect" && mk.c >= 5 && !got.has("combo")) {
+      got.add("combo");
+      await shot("03-big-combo");
+    }
+    if ((mk.o === "wrong" || mk.o === "miss") && !got.has("miss")) {
+      got.add("miss");
+      await shot("04-mistake");
+    }
+  }
+  // Catch the two big transient overlays by watching their computed opacity,
+  // which is the only honest signal that they are actually on screen.
+  const overlay = await page.evaluate(() => {
+    const o = (sel) => {
+      const el = document.querySelector(sel);
+      return el ? Number(getComputedStyle(el).opacity) : 0;
+    };
+    return { t: o('.mn-true'), b: o('.mn-band') };
+  });
+  if (overlay.t > 0.35 && !got.has("true")) {
+    got.add("true");
+    await shot("03b-true-callout");
+  }
+  if (overlay.b > 0.35 && !got.has("band")) {
+    got.add("band");
+    await shot("03c-stratum-card");
+  }
+  if (s.floor >= 5 && !got.has("mid")) {
+    got.add("mid");
+    await shot("02-mid-sweep");
+  }
+  if (s.floor >= 26 && !got.has("deep")) {
+    got.add("deep");
+    await shot("05-deep");
+  }
+  if (s.floor >= 50 && !got.has("peak")) {
+    got.add("peak");
+    await shot("06-peak");
+  }
+  if (s.phase !== "sweep" && (!got.has("over") || args.soak === "1")) {
+    const first = !got.has("over");
+    got.add("over");
+    deaths++;
+    if (!first) {
+      // Soak: alternate between shoring up and beginning again.
+      await page.waitForTimeout(1500);
+      if (deaths % 2 === 0) {
+        await page.evaluate(() => document.querySelector(".mn-revive")?.click());
+        await page.waitForTimeout(300);
+        await page.evaluate(() => document.querySelector(".mn-choices button")?.click());
+      } else {
+        await page.evaluate(() => document.querySelector(".mn-again")?.click());
+      }
+      await page.waitForTimeout(600);
+      await page.evaluate((q) => window.__bot.start(q), QUALITY);
+      continue;
+    }
+    await page.waitForTimeout(700);
+    await shot("07-collapse");
+    await page.waitForTimeout(1200);
+    await shot("08-over-panel");
+    await page.evaluate(() => document.querySelector(".mn-revive")?.click());
+    await page.waitForTimeout(450);
+    await shot("09-shore-it-up");
+    await page.evaluate(() => document.querySelector(".mn-choices button")?.click());
+    await page.waitForTimeout(900);
+    await page.evaluate((q) => window.__bot.start(q), QUALITY);
+  }
+}
+
+await page.evaluate(() => window.__bot.stop());
+const final = await page.evaluate(() => window.__bot.stats());
+const heap1 = await page.evaluate(() => performance.memory?.usedJSHeapSize ?? 0);
+// Real per-frame cost with the GPU drained, at each tier, on this exact scene.
+const bench = {};
+for (const t of ["low", "mid", "ultra"]) {
+  await page.evaluate((x) => window.__monument.setTier(x), t);
+  await page.waitForTimeout(500);
+  bench[t] = +(await page.evaluate(() => window.__monument.bench(240))).toFixed(3);
+  bench[t + "_stress"] = +(await page.evaluate(() => window.__monument.bench(240, true))).toFixed(3);
+}
+await page.evaluate((x) => window.__monument.setTier(x), TIER || "ultra");
+await shot("10-final");
+
+console.log("\n── playtest ──────────────────────────────────────────");
+console.log(`  url        ${URL}`);
+console.log(`  viewport   ${W}x${H} @2x   headless=${HEADLESS}`);
+console.log(`  played     ${SECONDS}s at quality ${QUALITY}`);
+console.log(`  reached    floor ${lastFloor} (best ${final.best})   deaths ${deaths}`);
+console.log(`  outcomes   ${JSON.stringify(final.outcomes)}`);
+console.log(`  perfects   ${final.perfects}  best combo ${final.bestCombo}`);
+console.log(`  width      wx ${final.wx} wz ${final.wz}  peril ${final.peril}`);
+console.log(`  fps        ${final.fps}  p95 frame ${final.p95ms}ms  worst frame ${final.worst}ms   tier ${final.tier}`);
+console.log(`  input→sim  median ${final.latMed}ms  max ${final.latMax}ms`);
+console.log(`  frame cost (readPixels-synced, ${W * 2}x${H * 2} backbuffer)`);
+for (const t of ["low", "mid", "ultra"]) {
+  console.log(`    ${t.padEnd(6)} idle ${String(bench[t]).padStart(6)}ms   worst-case ${String(bench[t + "_stress"]).padStart(6)}ms`);
+}
+console.log(`  heap       ${(heap0 / 1048576).toFixed(1)}MB -> ${(heap1 / 1048576).toFixed(1)}MB  (+${((heap1 - heap0) / 1048576).toFixed(1)}MB)`);
+console.log(`  reduced    ${args.reduced === "1"}`);
+console.log(`  shots      ${OUT}`);
+console.log("──────────────────────────────────────────────────────\n");
+
+await browser.close();

--- a/dynawalla/games/stack/tsconfig.json
+++ b/dynawalla/games/stack/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node", "vite/client"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": false,
+    "exactOptionalPropertyTypes": false,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src"]
+}

--- a/dynawalla/games/stack/vite.config.ts
+++ b/dynawalla/games/stack/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  base: "./",
+  server: { port: 4310, host: "127.0.0.1" },
+  build: { target: "es2022", sourcemap: false },
+});


### PR DESCRIPTION
## MONUMENT — `dynawalla/games/stack/`

A one-tap precision stacker. A stone sweeps above a tower; one tap sets it; the
overhang shears off and the tower narrows. *Stack*, Tower Bloxx, Holedown.

**The stone carries a value, and the value changes at every turnaround.** So one
tap has to be true twice: the value showing must answer the prompt, *and* the
stone must be aligned. You get a whole pass to read a value and decide whether
to commit or let it come round again — and if you sit through three cycles the
sweep starts leaning on you and the stone goes visibly hot.

### The one variable

The whole game is a tug-of-war over **the width of the tower**, and none of it
is hidden — you can always see how close to death you are, because the tower is
literally thin.

| what you did | the width |
| --- | --- |
| right value, dead true | **grows**, and more the longer the run of them |
| right value, wide | keeps exactly the overlap |
| **wrong value** | keeps the overlap, then the stone **cracks** and loses another quarter |
| missed entirely | the stone bursts, the tower takes a hard bite, the run lives |
| below the death line | it topples |

A wrong answer is **never marked wrong**. The equation completes itself in the
accent colour for 750 ms, with the sweep held for the same beat so you are never
reading one thing while aiming at another. No red X, no lecture — the punishment
is already in the building. A true placement also **calms the sway** and a
mistake **whips it**, so skill makes the target easier to hit and sloppiness
makes it harder.

Math integration is **NATIVE**: a wrong value cannot be rescued by perfect
alignment, and only a placement that is right *and* true widens the tower, so
arithmetic is the only thing standing between a run and a needle. Shoring a
fallen tower back up — where an F2P game would show an advertisement — costs one
correct answer and restores less every time.

### Endless

New band of sky every eight floors (BASALT · VERDIGRIS · EMBER · AZURE · VIOLET
· AURORA · VACUUM · SOLAR), cycling with a 37° hue rotation so a long run never
lands on the same sky twice. **Each course keeps the colour of the stratum it
was built in**, so the tower becomes a record of the climb. Meanwhile the sweep
accelerates, the hold shortens, the perfect window narrows ±0.062 → ±0.030, the
stone cycles more candidate values, and past floor twelve the monument sways.

### Measured, on an Apple M2 Max (38-core GPU), Chromium 151

Frame cost with the GPU drained (`readPixels` sync, 860×1864 backbuffer):

| tier | idle | worst case (collapse in flight) |
| --- | --- | --- |
| low | 0.19 ms | 0.19 ms |
| mid | 0.39 ms | 0.39 ms |
| ultra | 0.40 ms | 0.40 ms |

- 150 s bot run: floor 84, 67 perfects, best combo 15 — **120 fps, p95 9.4 ms,
  worst frame 15.1 ms**, never missed a 16.7 ms budget.
- 300 s soak at 74% quality: 13 deaths, 177 placements, revives and restarts —
  **heap 18.4 MB → 18.3 MB (no drift)**, worst frame 12.8 ms.
- Answer path: pointerdown → sim resolved, **median 0.2 ms, max 1.3 ms**.
- This machine is far above the floor. Even a tablet GPU 20× slower lands at
  ~7.8 ms at MID; ULTRA would be marginal there, which is what `TierWatch`
  demotes for.

### Bugs this found by playing, not by reading

- **Per-channel ACES skews saturated blues to purple** — authored blue-grey
  basalt rendered as lavender. Tone curve now runs on luminance only.
- **The AudioContext built inside the first tap cost 206 ms.** Built at mount
  now, suspended; the gesture only resumes it.
- **`renderer.dispose()` does not release the WebGL context** — 24
  mount/unmount cycles exhausted the browser's pool and started killing live
  games. `forceContextLoss()` + a `webglcontextlost` handler.
- **A decoy was secretly correct**: `2/4 + ? = 1` offered `2/4`, because the
  "copied the fraction" mal-rule *is* the answer when n = d/2. Decoys are now
  filtered by exact value, not by string. Caught by a test.
- **The HUD washed out in AZURE.** Contrast is now chosen from the measured
  luminance of the sky it sits in front of, not a hand-set flag.
- **The tower survived its own collapse** — `drawTower` re-showed the pool the
  frame after `collapse()` hid it.
- **One wild first tap could end a run at floor 1.** Physics unchanged; leaving
  is now free — the backdrop, `Space` or `R` all begin again.

### Tests — 32, no browser

`src/game/sim.ts` imports neither THREE nor the DOM, so the rules are proven at
ten thousand floors a second: width arithmetic per outcome, the width cap, the
axis alternating only on advance, the death condition, revive decay, host
reporting, determinism from a seed, NaN-freedom over 3000 random placements, and
the sweep never leaving its travel. `mathgen` is graded by an exact-rational
parser: every family states a true thing at every difficulty, no decoy is
secretly correct, nothing longer than five characters ever lands on a moving
stone, and no floating point reaches an answer or a comparison.

### Notes for review

- **Diff is ~244 KB.** `AGENTS.md` warns that `adversarial-review` truncates
  above 200 KB, but the workflow header now says large diffs are *chunked*, not
  truncated (PR #521's 805 KB diff ran as 5 chunks), so this is reviewed whole.
  Worth correcting in `AGENTS.md` separately.
- **No CI area covers `dynawalla/games/`**, so `ci.yml`'s coverage check will
  warn on these paths. Deliberately not touching `ci.yml` — eight game PRs are
  in flight and would conflict on it; one filter should be added once, by
  whoever lands last.
- `?perf=1` shows the readouts, `?dev=1` exposes `window.__monument`. Both are
  query-gated and inert otherwise.
- `playwright` is a devDependency for `tools/playtest.mjs` only; nothing in the
  shipped bundle depends on it.
- Does not import from `dynawalla/packs/shared`; `src/contract.ts` holds the
  contract verbatim and `src/host/stub.ts` makes it playable standalone.

### Accessibility

`prefers-reduced-motion` drops shake, aberration, hit-stop, slow-motion and
bright frames and cuts particle counts, losing no information. Flashes are
capped at 0.24 alpha with a 260 ms floor between them and are an exposure event
rather than a sheet of white. Nothing is carried by colour alone. Readable at
320 px, verified. No ads, loot boxes, variable-ratio rewards, streaks, scarcity
or social pressure.
