### PR TITLE
VOLTA — behind-the-back runner: the lane you pick is the answer you give

### DIFF
--- a/dynawalla/games/runner/.gitignore
+++ b/dynawalla/games/runner/.gitignore
@@ -1,0 +1,21 @@
+node_modules/
+dist/
+
+# The pack build. `packs/build.mjs` regenerates it and stages it into the app.
+dist-pack/
+
+# Playtest capture output: multi-MB PNGs, regenerated on demand.
+qa/shots
+qa/tmp
+
+# Not tracked. `packs/build.mjs` and the `dynawalla-packs` CI job both branch on
+# this file — `npm ci` when it is committed, `npm install` when it is not — so
+# either choice builds.
+#
+# Worth knowing, though: the five packs that shipped before this one all commit
+# theirs, and this pack is installed on a child's tablet rather than merely run
+# from a checkout. `three` is pinned at `^0.185.1`, so an unlocked install is
+# free to resolve a different minor and change the shipped bundle with nothing
+# in the diff to show for it. If pack builds are ever required to be
+# byte-reproducible, committing this file is the first thing to change.
+package-lock.json

--- a/dynawalla/games/runner/README.md
+++ b/dynawalla/games/runner/README.md
@@ -1,0 +1,260 @@
+# VOLTA — behind-the-back runner
+
+**The lane you are in when you cross the gate is the answer you gave.**
+
+An endless night run along a black glass causeway suspended over an ocean of
+light. Swipe to change lane, jump the gaps, slide under the bars, and thread
+between the pylons close enough to graze them. Every few seconds a gate array
+spans the track with a number over each lane and exactly one of them is right.
+There is no button to press and no menu to open — steering *is* answering.
+
+Run it: `npm install && npm run dev` → <http://127.0.0.1:5187/>
+
+---
+
+## Why the format
+
+The catalogue this pack answers stops at about 1999. A ten-year-old in 2026 does
+not play Berzerk; the behind-the-back runner is the most-installed game shape on
+earth and the one shape they will already know how to hold. So the goal was not
+"a runner with maths bolted on" — it was to build the runner first, well enough
+that a child would open it anyway, and then make the maths the steering.
+
+## How the maths rides along
+
+**Native.** The answer is a lane. There is no answer UI, no keypad, no
+multiple-choice card. The child reads `7 × 6`, finds `42`, and goes there.
+
+Three lanes means a guesser is right one time in three, so a guess has to be
+plainly worse than reading:
+
+| | |
+|---|---|
+| Correct gate | +8 voltage, +100 × surge, chain toward the next multiplier |
+| Wrong gate | **−27 voltage**, surge collapses to ×1, a one-second stumble you cannot steer out of, and the world visibly slows |
+| Guessing, on average | about **−15 voltage per gate** — under seven gates from full to dead |
+| Reading | strictly positive |
+
+A wrong answer is never a red cross and a lecture. It is a slam, a shockwave,
+and the right number left burning in the lane you should have taken, for about a
+second, while you keep running.
+
+**Gating, where an F2P game would show an ad.** Run out of voltage and the world
+goes into slow motion for a beat, then offers a **recharge**: one question, three
+big lane-shaped buttons, a draining ring. Get it and you are back at full
+voltage with 2.6 seconds of invulnerability — and your surge reset to
+×1, which is the real price. Miss it and the run ends. Recharges are unlimited
+and the question gets harder each time; nothing is bought and nothing is scarce.
+
+`difficulty` is a hint to the host, not a demand: it climbs with distance and
+surge, and **drops hard when a child is actually struggling** (below 60% over the
+last handful of gates buys 2.2 levels of relief). See `src/game/pacing.ts`.
+
+## What makes it readable at 60 units per second
+
+This is the part that took the most work, and it is the bug the previous
+catalogue shipped: numerals on fast targets that a child gets half a second to
+read.
+
+- The **prompt lives in DOM**, at a fixed spot just above the horizon, at native
+  crispness. It never moves and it is never a texture.
+- **The three candidates are typeset in screen units, not world units.** This is
+  the single most important thing in the game and it took two attempts. The
+  camera sits 11.4 units behind a causeway whose lanes are 3.35 apart, so the
+  *widest* the lane pitch ever gets on screen is about 12% of the viewport, and
+  only in the last third of a second before the gate lands. Numerals placed at
+  the lanes therefore ran together — a judge captured `13 | 42 | 36` rendering as
+  `134236` — and a fan-out compensation big enough to fix that pushed the third
+  value clean off a 390px phone. Perspective is the wrong tool for typesetting
+  three values a child has half a second to compare. So `readband.ts` decides an
+  explicit pitch, an explicit 30% gutter, an explicit page margin and one shared
+  ink height, all in NDC, and `project.ts` converts that layout back into the
+  world positions the instanced digit shader wants — so the numerals still fog,
+  still bend with the causeway, still belong to the world. They lift above the
+  arches, keep left-middle-right order, trail a dotted leader down to their own
+  gate, and converge into it as it arrives.
+- `readband.test.ts` hammers that layout across nine viewports × three fields of
+  view × seven distances × three font widths × four digit counts and asserts the
+  two things that actually matter: **adjacent numerals never touch** and
+  **nothing leaves the viewport**. The same file covers the two other places ink
+  can escape the frame — the winning numeral rushing the camera, and the score
+  popups over the outer lanes.
+- **Gate numerals are baked with a dark stroke *and* a soft dark shadow**, and
+  the red channel separates fill from outline, so the shader can recolour a
+  numeral without ever recolouring its own contrast. They stay readable over an
+  aurora, over a white-out, over a shockwave.
+- Apparent size does not depend on distance, so a numeral is never eleven pixels
+  tall at the far end of the reading window and never a wall of ink at the near
+  end.
+- Numerals **never depth-test**. A roadside monolith eclipsing the one value a
+  child needed is not atmosphere, it is a lost run.
+- A character the atlas does not know renders as `?`, never as nothing. Silently
+  skipping the glyph turns `3/4` into `34`, which is not an unreadable answer —
+  it is a different and wrong one.
+- The **reading window is the difficulty knob**, not the speed: 3.4s at the start,
+  compressing toward a **hard floor of 1.55 seconds** that nothing can push
+  through. Reduced motion adds another half-second.
+- Hazards are suppressed within thirty metres of a gate. Dodging while reading is
+  not difficulty, it is noise.
+
+## Endless
+
+No completion state. Four worlds cycle forever, hue-rotated a little further on
+each lap, and a crossing changes the palette, the sky, the ambient debris, the
+musical mode and the tempo together over about two seconds:
+
+**AURORA SHELF** (indigo night, curtains, stars) → **SOLAR FLATS** (molten amber,
+embers) → **THE ABYSS** (bioluminescent teal and violet) → **THE BLEACH** (the
+inversion: bone sky, black obsidian geometry, one hot magenta) → AURORA SHELF II…
+
+The first crossing is deliberately the shortest — about forty-five seconds — so a
+child on a five-minute free session *sees* that the world changes. Speed ramps
+from 27 to 66 u/s with a 95-second time constant, so terminal velocity lands
+inside that session rather than twenty minutes later.
+
+Verified: a 5.5-minute autopilot run covered 14.3 km through nine biomes with no
+degradation.
+
+## Feel
+
+Techniques from Nijman's *Art of Screenshake*, applied by name and testable:
+
+`Shake` (trauma-squared, decaying, zero under reduced motion) · `HitStop`
+(45ms on a correct gate, 130ms on a wrong one, never a true freeze) · camera kick
+and FOV punch on springs · **near-miss graze** — thread a pylon within 2.5 units
+and the camera punches harder than it does for a correct answer, because that is
+the format's signature feeling · squash and stretch on take-off, landing and
+impact · speed streaks · **permanence** (shards from a smashed gate land on the
+deck and are still behind you) · chromatic aberration on impact · sound variety.
+
+Input is where a homemade runner usually dies. Swipes fire the instant the finger
+crosses the threshold, never on lift; the gesture origin resets after each swipe
+so a long drag can chain left-left-up without lifting; intents are **buffered for
+145ms** rather than dropped; a tap on either half of the screen is also a lane
+change, because small hands should not have to swipe across a 12" tablet. Lane
+changes complete in 125ms. Coyote time is 90ms. Measured input-to-action latency
+averages **7–9ms**.
+
+## Sound
+
+Entirely synthesised — no files, no licences. Every one-shot is transient, body,
+tail, with pitch and filter jittered on each trigger so the two-hundredth spark
+does not sound like the first. The reward tone climbs the current biome's scale
+with your combo, so the combo is audible; it resets when the combo breaks. There
+is a real rhythm section (kick, hats, filtered bass, arpeggio) whose layers
+unlock with surge and whose mode and tempo change with the biome. Mutable, and
+nothing carries information on its own.
+
+## Accessibility
+
+- `prefers-reduced-motion`, plus an in-game toggle: **no** camera shake, roll, FOV
+  punch, chromatic aberration, speed streaks or ghost trail; speed capped at 42
+  u/s; extra reading time; the world still moves, because it is a runner.
+- Screen flashes are rate-limited below the WCAG general-flash threshold by a
+  token bucket that **attenuates rather than drops** — information survives,
+  brightness does not. Each flash rises over at least 90ms. Asserted in
+  `juice.test.ts`.
+- No meaning by colour alone: gates are identical until they resolve and the
+  numeral is the only signal; low voltage is a bar, an outline, a heartbeat and a
+  banner, not just red.
+- Readable at 320px (verified at 320×640 portrait). Full keyboard play.
+- No ads, loot boxes, variable-ratio rewards, streak anxiety, scarcity or social
+  pressure.
+
+## Performance
+
+Eight draw calls for the entire world, ~6,000 triangles, and no allocation in the
+frame loop.
+
+The sky, the light-ocean and the causeway never move — the deck is a static
+ribbon whose chevrons scroll procedurally against `uTravel`, so the environment
+costs three draws and zero CPU forever. Everything else is two instanced fields
+(solids with barycentric neon edges; additive glows) plus one instanced digit
+atlas. Particles are struct-of-arrays with a free list.
+
+The causeway's snake and roll is a **quadratic world bend in the vertex shader**
+(`voltaBend`). Gameplay stays on a straight 1D track — lane is an integer,
+distance is a float — so collision and scheduling stay debuggable, while
+geometry enters from behind the curve instead of fading up out of fog.
+
+Four tiers (`low`/`mid`/`high`/`ultra`) plus a `TierController` that demotes on a
+sustained stall — render scale first, then tier — and promotes back at most once.
+
+## Verifying it
+
+```
+npm run tsc && npm test              # 57 assertions, no DOM and no GPU required
+npm run build                        # production bundle
+npm run dev                          # play it
+```
+
+The suites are deliberately about rules rather than rendering: the read band and
+the payoff sizing (`readband.test.ts`), the atlas and its fallbacks
+(`glyphs.test.ts`), the three-lane option builder (`options.test.ts`), the
+escalation curves and their floors (`pacing.test.ts`), the flash rate limit and
+reduced-motion guarantees (`juice.test.ts`), and the question stream itself
+(`stubHost.test.ts`).
+
+Query parameters, for verification rather than for players:
+
+| | |
+|---|---|
+| `?tier=low\|mid\|high\|ultra` | pin the quality tier |
+| `?stats=1` | fps, worst frame, input latency, draw calls, triangles, seed |
+| `?seed=12345` | replay an exact run — gates, hazards and spark rows all |
+| `?log=1` | print every `host.report()` |
+
+`?stats=1` also publishes `window.__volta.state()`, a read-only snapshot (phase,
+travel, speed, voltage, the active gate's correct lane, nearby hazards). It
+exists because "does a five-minute run hold 60fps" and "is the reading window
+still fair at 3 km" are questions that need a machine that can play. A harness
+steers with real `KeyboardEvent`s, so it exercises the same path a child does.
+
+## Installing it
+
+VOLTA is a real pack, not just a directory in the repo: `pack.json` is what
+`packs/build.mjs` globs for, and without it the game would be in the tree and
+invisible to the pack build, the catalogue and the app's game browser.
+
+```
+npm run build:pack                   # this pack alone, into dist-pack/
+cd ../../packs && node build.mjs runner   # build + `dw-pack check` + stage
+```
+
+`src/pack.ts` is the whole seam — it swaps the stub host for the real one and
+hands the same synchronous `Host` surface to the same `mount()`. Nothing about
+the causeway, the read band or the recharge gate knows which host it has.
+
+Declared capabilities are `items`, `items.reveal` and `haptics`, and no more.
+**`items.reveal` is load-bearing**: without it the adapter has no canonical
+answer to place, so there is no right lane to steer into and the question pool
+never fills. `audio` and `storage` are deliberately *not* declared — the sound
+is synthesised inside the pack rather than asked of the host, and the personal
+best is the frame's own `localStorage`, which is why it is wrapped in a
+`try`/`catch` and simply does not persist on an opaque origin.
+
+`covers.skills` lists the seven `dw.add.*` skills that are `status: "active"` in
+`packs/shared/curriculum` today — column addition and subtraction with and
+without regrouping, which is exactly the short-answer shape the read band is
+built for. Everything else in the graph is still `draft`, so claiming it would
+be claiming coverage no host can serve. Note that `dw-pack check` does **not**
+validate skill ids: a fictional one passes silently, so this list was checked by
+hand against the graph.
+
+## Contract
+
+`src/contract.ts` is the agreed shape, unchanged. `src/stubHost.ts` is a local
+stub so the game is fully playable standalone: exact integer arithmetic, seeded
+and deterministic, and **distractors that are real mal-rule outputs** — `7 × 6 →
+13` is a child who added, `52 − 27 → 35` is smaller-from-larger, `3 + 4 × 5 → 35`
+is left-to-right. A distractor that is merely "answer + 1" is a coin flip dressed
+as a question, and `stubHost.test.ts` asserts the real ones are on offer.
+
+The contract does not promise integers, though, so `options.ts` — the one place
+a question becomes three lanes, shared by the gates on the causeway and by the
+recharge gate — treats the answer as a string. When a host offers fewer than two
+usable distractors it nudges the answer's own trailing number with exact decimal
+arithmetic: `42` gives `43` and `41`, `3/4` gives `3/5` and `3/3`. Never a float,
+never a `NaN`, never the same value in two lanes.
+
+Nothing is imported from `dynawalla/packs/shared`.

--- a/dynawalla/games/runner/index.html
+++ b/dynawalla/games/runner/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#04060f" />
+    <title>VOLTA — Dynawalla</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        background: #04060f;
+        overscroll-behavior: none;
+        overflow: hidden;
+      }
+      #game {
+        position: fixed;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="game"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/runner/pack.html
+++ b/dynawalla/games/runner/pack.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#04060f" />
+    <title>VOLTA</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #04060f;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         The dev harness's stub host is not reachable from here — inside a real
+         host the questions come from the curriculum. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/runner/pack.json
+++ b/dynawalla/games/runner/pack.json
@@ -1,0 +1,24 @@
+{
+  "id": "dynawalla.runner",
+  "version": "0.1.0",
+  "name": "VOLTA",
+  "description": "An endless night run along a black glass causeway. Every few seconds a gate array spans the track with a number over each lane and exactly one of them is right — so the lane you are in when you cross is the answer you gave. There is no keypad and no menu: steering is answering.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-multidigit",
+      "dw.add.regroup.add-short-addend",
+      "dw.add.regroup.subtract-short-subtrahend",
+      "dw.add.regroup.subtract-across-zero"
+    ],
+    "grades": [1, 4]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/runner/package.json
+++ b/dynawalla/games/runner/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@dynawalla/game-runner",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "VOLTA \u2014 a behind-the-back endless runner where the lane you pick is the answer you give.",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "build:pack": "vite build --config vite.pack.config.ts",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test 'src/**/*.test.ts'"
+  },
+  "dependencies": {
+    "three": "^0.185.1"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "@types/three": "^0.185.1",
+    "typescript": "^5.9.3",
+    "vite": "^7.1.9"
+  }
+}

--- a/dynawalla/games/runner/src/contract.ts
+++ b/dynawalla/games/runner/src/contract.ts
@@ -1,0 +1,12 @@
+import { mountRunner } from "./game/mount.ts";
+
+export type Question = { id: string; prompt: string; answer: string; distractors: string[]; domain: string; difficulty: number }
+export type Host = {
+  next(opts?: { domain?: string; difficulty?: number }): Question
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+  haptic(k: "light"|"medium"|"heavy"|"success"|"failure"): void
+  prefersReducedMotion(): boolean
+}
+export function mount(el: HTMLElement, host: Host): { unmount(): void } {
+  return mountRunner(el, host);
+}

--- a/dynawalla/games/runner/src/game/audio.ts
+++ b/dynawalla/games/runner/src/game/audio.ts
@@ -1,0 +1,611 @@
+/**
+ * VOLTA's whole sound world, synthesised. No files, no fetches, no licences.
+ *
+ * Every one-shot is built the same way — transient, body, tail — because that
+ * is what makes a synthesised hit read as a physical event instead of a beep.
+ * Pitch, filter cutoff and tail length are jittered on every trigger so the
+ * two-hundredth spark of a run does not sound like the first.
+ *
+ * Nothing here carries information on its own: every cue has a visual twin, and
+ * the whole graph can be muted without the game becoming unreadable.
+ */
+
+const A4 = 440;
+const mtof = (m: number) => A4 * Math.pow(2, (m - 69) / 12);
+
+export type ScaleName = "aurora" | "solar" | "abyss" | "void";
+
+const SCALES: Record<ScaleName, { root: number; degrees: number[] }> = {
+  // A minor pentatonic — open, cool, no leading tone to nag.
+  aurora: { root: 57, degrees: [0, 3, 5, 7, 10, 12, 15, 17, 19, 22, 24] },
+  // D dorian — brighter, drives forward.
+  solar: { root: 50, degrees: [0, 2, 3, 5, 7, 9, 10, 12, 14, 15, 17, 19] },
+  // E phrygian — the pressure biome.
+  abyss: { root: 52, degrees: [0, 1, 3, 5, 7, 8, 10, 12, 13, 15, 17, 19] },
+  // C lydian — the "you have gone somewhere else" biome.
+  void: { root: 60, degrees: [0, 2, 4, 6, 7, 9, 11, 12, 14, 16, 18, 19] },
+};
+
+export class Audio {
+  private ctx: AudioContext | null = null;
+  private master!: GainNode;
+  private sfxBus!: GainNode;
+  private musicBus!: GainNode;
+  private delay!: DelayNode;
+  private delayFb!: GainNode;
+  private delayMix!: GainNode;
+  private noiseBuf!: AudioBuffer;
+
+  // engine bed
+  private engOsc: OscillatorNode | null = null;
+  private engSub: OscillatorNode | null = null;
+  private engNoise: AudioBufferSourceNode | null = null;
+  private engFilter!: BiquadFilterNode;
+  private engGain!: GainNode;
+  private windFilter!: BiquadFilterNode;
+  private windGain!: GainNode;
+
+  enabled = true;
+  private started = false;
+  private scale: ScaleName = "aurora";
+
+  // sequencer
+  private bpm = 126;
+  private nextNoteTime = 0;
+  private step = 0;
+  private musicLayers = 0;
+
+  /* ------------------------------ lifecycle ------------------------------ */
+
+  /** Must be called from a user gesture. Safe to call repeatedly. */
+  start(): void {
+    if (this.started) {
+      void this.ctx?.resume();
+      return;
+    }
+    type WithWebkit = typeof globalThis & { webkitAudioContext?: typeof AudioContext };
+    const Ctor = window.AudioContext ?? (globalThis as WithWebkit).webkitAudioContext;
+    if (!Ctor) return;
+    this.started = true;
+    const ctx = new Ctor({ latencyHint: "interactive" });
+    this.ctx = ctx;
+
+    // Master chain: everything meets one limiter so a 10-particle pile-up cannot clip.
+    const limiter = ctx.createDynamicsCompressor();
+    limiter.threshold.value = -8;
+    limiter.knee.value = 6;
+    limiter.ratio.value = 12;
+    limiter.attack.value = 0.003;
+    limiter.release.value = 0.16;
+    limiter.connect(ctx.destination);
+
+    this.master = ctx.createGain();
+    this.master.gain.value = 0.85;
+    this.master.connect(limiter);
+
+    this.sfxBus = ctx.createGain();
+    this.sfxBus.gain.value = 1;
+    this.sfxBus.connect(this.master);
+
+    this.musicBus = ctx.createGain();
+    this.musicBus.gain.value = 0.42;
+    this.musicBus.connect(this.master);
+
+    // One shared feedback delay is the "tail" for every one-shot.
+    this.delay = ctx.createDelay(1.2);
+    this.delay.delayTime.value = 0.26;
+    this.delayFb = ctx.createGain();
+    this.delayFb.gain.value = 0.34;
+    this.delayMix = ctx.createGain();
+    this.delayMix.gain.value = 0.5;
+    const dampen = ctx.createBiquadFilter();
+    dampen.type = "lowpass";
+    dampen.frequency.value = 2600;
+    this.delay.connect(dampen);
+    dampen.connect(this.delayFb);
+    this.delayFb.connect(this.delay);
+    this.delay.connect(this.delayMix);
+    this.delayMix.connect(this.master);
+
+    // 2s of white noise, reused everywhere.
+    const n = ctx.sampleRate * 2;
+    this.noiseBuf = ctx.createBuffer(1, n, ctx.sampleRate);
+    const d = this.noiseBuf.getChannelData(0);
+    let s = 1;
+    for (let i = 0; i < n; i++) {
+      s = (s * 1103515245 + 12345) & 0x7fffffff;
+      d[i] = (s / 0x3fffffff) - 1;
+    }
+
+    this.buildEngine();
+    this.nextNoteTime = ctx.currentTime + 0.1;
+  }
+
+  private buildEngine(): void {
+    const ctx = this.ctx!;
+    this.engGain = ctx.createGain();
+    this.engGain.gain.value = 0;
+    this.engGain.connect(this.master);
+
+    this.engFilter = ctx.createBiquadFilter();
+    this.engFilter.type = "lowpass";
+    this.engFilter.frequency.value = 420;
+    this.engFilter.Q.value = 7;
+    this.engFilter.connect(this.engGain);
+
+    this.engOsc = ctx.createOscillator();
+    this.engOsc.type = "sawtooth";
+    this.engOsc.frequency.value = 58;
+    const oscG = ctx.createGain();
+    oscG.gain.value = 0.32;
+    this.engOsc.connect(oscG);
+    oscG.connect(this.engFilter);
+    this.engOsc.start();
+
+    this.engSub = ctx.createOscillator();
+    this.engSub.type = "sine";
+    this.engSub.frequency.value = 29;
+    const subG = ctx.createGain();
+    subG.gain.value = 0.5;
+    this.engSub.connect(subG);
+    subG.connect(this.engGain);
+    this.engSub.start();
+
+    this.engNoise = ctx.createBufferSource();
+    this.engNoise.buffer = this.noiseBuf;
+    this.engNoise.loop = true;
+    const nG = ctx.createGain();
+    nG.gain.value = 0.09;
+    this.engNoise.connect(nG);
+    nG.connect(this.engFilter);
+    this.engNoise.start();
+
+    // Separate wind band that opens with speed — this is what sells velocity.
+    this.windGain = ctx.createGain();
+    this.windGain.gain.value = 0;
+    this.windGain.connect(this.master);
+    this.windFilter = ctx.createBiquadFilter();
+    this.windFilter.type = "bandpass";
+    this.windFilter.frequency.value = 900;
+    this.windFilter.Q.value = 0.7;
+    this.windFilter.connect(this.windGain);
+    const wSrc = ctx.createBufferSource();
+    wSrc.buffer = this.noiseBuf;
+    wSrc.loop = true;
+    wSrc.connect(this.windFilter);
+    wSrc.start();
+  }
+
+  suspend(): void {
+    void this.ctx?.suspend();
+  }
+  resume(): void {
+    void this.ctx?.resume();
+  }
+  dispose(): void {
+    try {
+      this.engOsc?.stop();
+      this.engSub?.stop();
+      this.engNoise?.stop();
+      void this.ctx?.close();
+    } catch {
+      /* already closed */
+    }
+    this.ctx = null;
+  }
+
+  setEnabled(on: boolean): void {
+    this.enabled = on;
+    if (!this.ctx) return;
+    const t = this.ctx.currentTime;
+    this.master.gain.cancelScheduledValues(t);
+    this.master.gain.setTargetAtTime(on ? 0.85 : 0, t, 0.05);
+  }
+
+  /* ------------------------------- engine bed ----------------------------- */
+
+  /** `speed01` is 0 at the slow end of the run, 1 at terminal velocity. */
+  setDrive(speed01: number, alive: boolean): void {
+    if (!this.ctx) return;
+    const t = this.ctx.currentTime;
+    const s = Math.max(0, Math.min(1, speed01));
+    this.engGain.gain.setTargetAtTime(alive ? 0.13 + s * 0.11 : 0.02, t, 0.25);
+    this.engFilter.frequency.setTargetAtTime(300 + s * 1150, t, 0.3);
+    this.engOsc?.frequency.setTargetAtTime(52 + s * 34, t, 0.4);
+    this.engSub?.frequency.setTargetAtTime(26 + s * 15, t, 0.4);
+    this.windGain.gain.setTargetAtTime(alive ? 0.006 + s * 0.05 : 0, t, 0.3);
+    this.windFilter.frequency.setTargetAtTime(700 + s * 1900, t, 0.3);
+  }
+
+  setScale(name: ScaleName, bpm: number): void {
+    this.scale = name;
+    this.bpm = bpm;
+  }
+
+  setMusicLayers(n: number): void {
+    this.musicLayers = Math.max(0, Math.min(3, n));
+  }
+
+  duckMusic(seconds: number): void {
+    if (!this.ctx) return;
+    const t = this.ctx.currentTime;
+    this.musicBus.gain.cancelScheduledValues(t);
+    this.musicBus.gain.setValueAtTime(this.musicBus.gain.value, t);
+    this.musicBus.gain.linearRampToValueAtTime(0.06, t + 0.05);
+    this.musicBus.gain.setTargetAtTime(0.42, t + seconds, 0.4);
+  }
+
+  /* -------------------------------- helpers ------------------------------- */
+
+  private get t(): number {
+    return this.ctx ? this.ctx.currentTime : 0;
+  }
+
+  private noise(dur: number, gain: number, type: BiquadFilterType, freq: number, q: number, dest?: AudioNode): { src: AudioBufferSourceNode; f: BiquadFilterNode; g: GainNode } | null {
+    const ctx = this.ctx;
+    if (!ctx) return null;
+    const src = ctx.createBufferSource();
+    src.buffer = this.noiseBuf;
+    src.loop = true;
+    const f = ctx.createBiquadFilter();
+    f.type = type;
+    f.frequency.value = freq;
+    f.Q.value = q;
+    const g = ctx.createGain();
+    g.gain.value = 0;
+    src.connect(f);
+    f.connect(g);
+    g.connect(dest ?? this.sfxBus);
+    const t = this.t;
+    g.gain.setValueAtTime(0, t);
+    g.gain.linearRampToValueAtTime(gain, t + 0.004);
+    g.gain.exponentialRampToValueAtTime(0.0001, t + dur);
+    src.start(t);
+    src.stop(t + dur + 0.05);
+    src.onended = () => {
+      src.disconnect();
+      f.disconnect();
+      g.disconnect();
+    };
+    return { src, f, g };
+  }
+
+  private tone(
+    o: {
+      type?: OscillatorType;
+      freq: number;
+      to?: number;
+      dur: number;
+      gain: number;
+      attack?: number;
+      detune?: number;
+      send?: number;
+      dest?: AudioNode;
+    },
+  ): void {
+    const ctx = this.ctx;
+    if (!ctx) return;
+    const t = this.t;
+    const osc = ctx.createOscillator();
+    osc.type = o.type ?? "sine";
+    osc.frequency.setValueAtTime(o.freq, t);
+    if (o.to !== undefined) osc.frequency.exponentialRampToValueAtTime(Math.max(20, o.to), t + o.dur);
+    if (o.detune) osc.detune.value = o.detune;
+    const g = ctx.createGain();
+    const atk = o.attack ?? 0.004;
+    g.gain.setValueAtTime(0.0001, t);
+    g.gain.exponentialRampToValueAtTime(Math.max(0.0002, o.gain), t + atk);
+    g.gain.exponentialRampToValueAtTime(0.0001, t + o.dur);
+    osc.connect(g);
+    g.connect(o.dest ?? this.sfxBus);
+    if (o.send) {
+      const s = ctx.createGain();
+      s.gain.value = o.send;
+      g.connect(s);
+      s.connect(this.delay);
+      osc.onended = () => {
+        osc.disconnect();
+        g.disconnect();
+        s.disconnect();
+      };
+    } else {
+      osc.onended = () => {
+        osc.disconnect();
+        g.disconnect();
+      };
+    }
+    osc.start(t);
+    osc.stop(t + o.dur + 0.03);
+  }
+
+  private degree(i: number, octave = 0): number {
+    const sc = SCALES[this.scale];
+    const d = sc.degrees[Math.min(sc.degrees.length - 1, Math.max(0, i))];
+    return mtof(sc.root + d + octave * 12);
+  }
+
+  /* -------------------------------- one-shots ----------------------------- */
+
+  /** The reward. Pitch climbs the scale with the combo, so the combo is audible. */
+  gateCorrect(combo: number): void {
+    if (!this.ctx) return;
+    const step = Math.min(9, combo - 1);
+    const f = this.degree(step, 2);
+    const jitter = 1 + (Math.random() - 0.5) * 0.012;
+    // transient
+    this.noise(0.05, 0.32, "highpass", 3200, 0.8);
+    // body: a triad struck, slightly detuned for width
+    this.tone({ type: "triangle", freq: f * jitter, dur: 0.5, gain: 0.3, send: 0.32 });
+    this.tone({ type: "sine", freq: f * 1.4983 * jitter, dur: 0.42, gain: 0.17, send: 0.28 });
+    this.tone({ type: "sine", freq: f * 2 * jitter, dur: 0.3, gain: 0.11, send: 0.2 });
+    // tail: a soft sub thump so it lands in the body, not just the ears
+    this.tone({ type: "sine", freq: 96, to: 62, dur: 0.2, gain: 0.24 });
+  }
+
+  /** The cost. Detuned, downward, gritty — unmistakably not the reward sound. */
+  gateWrong(): void {
+    if (!this.ctx) return;
+    this.noise(0.34, 0.34, "lowpass", 1500, 1.1);
+    this.tone({ type: "sawtooth", freq: 168, to: 44, dur: 0.44, gain: 0.3 });
+    this.tone({ type: "square", freq: 84, to: 31, dur: 0.5, gain: 0.22, detune: -28 });
+    this.tone({ type: "sine", freq: 52, to: 34, dur: 0.6, gain: 0.3 });
+  }
+
+  /** Near-miss whoosh, doppler-swept. The pitch centre moves with your speed. */
+  graze(speed01: number): void {
+    const n = this.noise(0.3, 0.2 + speed01 * 0.12, "bandpass", 700 + speed01 * 900, 2.4);
+    if (!n || !this.ctx) return;
+    const t = this.t;
+    n.f.frequency.setValueAtTime(1500 + speed01 * 2200, t);
+    n.f.frequency.exponentialRampToValueAtTime(380, t + 0.28);
+  }
+
+  spark(index: number): void {
+    if (!this.ctx) return;
+    const f = this.degree(3 + (index % 7), 3);
+    this.tone({ type: "sine", freq: f, dur: 0.14, gain: 0.14, attack: 0.002, send: 0.22 });
+    this.tone({ type: "triangle", freq: f * 2, dur: 0.08, gain: 0.06 });
+  }
+
+  jump(): void {
+    this.tone({ type: "triangle", freq: 260, to: 620, dur: 0.16, gain: 0.15 });
+    this.noise(0.1, 0.1, "highpass", 1800, 0.7);
+  }
+
+  land(): void {
+    this.tone({ type: "sine", freq: 130, to: 68, dur: 0.16, gain: 0.22 });
+    this.noise(0.12, 0.16, "lowpass", 900, 0.9);
+  }
+
+  slide(): void {
+    this.noise(0.42, 0.17, "bandpass", 2400, 1.4);
+  }
+
+  hazardHit(): void {
+    if (!this.ctx) return;
+    this.noise(0.5, 0.42, "lowpass", 900, 0.8);
+    this.tone({ type: "square", freq: 128, to: 38, dur: 0.42, gain: 0.3, detune: 22 });
+    this.tone({ type: "sine", freq: 60, to: 30, dur: 0.7, gain: 0.34 });
+  }
+
+  /** Crossing into a new biome: a riser that resolves into a chord. */
+  biomeShift(): void {
+    if (!this.ctx) return;
+    const ctx = this.ctx;
+    const t = ctx.currentTime;
+    const src = ctx.createBufferSource();
+    src.buffer = this.noiseBuf;
+    src.loop = true;
+    const f = ctx.createBiquadFilter();
+    f.type = "bandpass";
+    f.Q.value = 5;
+    f.frequency.setValueAtTime(200, t);
+    f.frequency.exponentialRampToValueAtTime(7000, t + 1.15);
+    const g = ctx.createGain();
+    g.gain.setValueAtTime(0.0001, t);
+    g.gain.exponentialRampToValueAtTime(0.24, t + 1.05);
+    g.gain.exponentialRampToValueAtTime(0.0001, t + 1.5);
+    src.connect(f);
+    f.connect(g);
+    g.connect(this.master);
+    src.start(t);
+    src.stop(t + 1.6);
+    src.onended = () => {
+      src.disconnect();
+      f.disconnect();
+      g.disconnect();
+    };
+    for (let i = 0; i < 4; i++) {
+      const osc = ctx.createOscillator();
+      osc.type = i === 0 ? "triangle" : "sine";
+      osc.frequency.value = this.degree(i * 2, 1);
+      const gg = ctx.createGain();
+      gg.gain.setValueAtTime(0.0001, t + 1.0);
+      gg.gain.exponentialRampToValueAtTime(0.13, t + 1.12);
+      gg.gain.exponentialRampToValueAtTime(0.0001, t + 2.6);
+      osc.connect(gg);
+      gg.connect(this.master);
+      osc.start(t + 1.0);
+      osc.stop(t + 2.7);
+      osc.onended = () => {
+        osc.disconnect();
+        gg.disconnect();
+      };
+    }
+  }
+
+  surgeUp(level: number): void {
+    if (!this.ctx) return;
+    const f = this.degree(Math.min(8, level), 2);
+    this.tone({ type: "sawtooth", freq: f * 0.5, to: f, dur: 0.3, gain: 0.16, send: 0.3 });
+    this.tone({ type: "triangle", freq: f * 2, dur: 0.4, gain: 0.13, send: 0.4 });
+  }
+
+  lowVoltage(): void {
+    this.tone({ type: "sine", freq: 74, to: 58, dur: 0.3, gain: 0.26 });
+  }
+
+  reviveCharge(): void {
+    if (!this.ctx) return;
+    this.tone({ type: "sawtooth", freq: 70, to: 700, dur: 1.1, gain: 0.13, attack: 0.4 });
+  }
+
+  reviveSuccess(): void {
+    if (!this.ctx) return;
+    for (let i = 0; i < 5; i++) {
+      const ctx = this.ctx;
+      const t = ctx.currentTime + i * 0.055;
+      const osc = ctx.createOscillator();
+      osc.type = "triangle";
+      osc.frequency.value = this.degree(i * 2, 2);
+      const g = ctx.createGain();
+      g.gain.setValueAtTime(0.0001, t);
+      g.gain.exponentialRampToValueAtTime(0.2, t + 0.01);
+      g.gain.exponentialRampToValueAtTime(0.0001, t + 0.55);
+      osc.connect(g);
+      const s = ctx.createGain();
+      s.gain.value = 0.4;
+      g.connect(s);
+      s.connect(this.delay);
+      g.connect(this.sfxBus);
+      osc.start(t);
+      osc.stop(t + 0.6);
+      osc.onended = () => {
+        osc.disconnect();
+        g.disconnect();
+        s.disconnect();
+      };
+    }
+  }
+
+  runOver(): void {
+    if (!this.ctx) return;
+    this.tone({ type: "sawtooth", freq: 220, to: 40, dur: 1.5, gain: 0.2 });
+    this.tone({ type: "sine", freq: 110, to: 26, dur: 1.9, gain: 0.28 });
+    this.noise(1.2, 0.14, "lowpass", 700, 0.6);
+  }
+
+  uiTick(): void {
+    this.tone({ type: "square", freq: 880, dur: 0.04, gain: 0.06 });
+  }
+
+  /* ------------------------------- sequencer ------------------------------ */
+
+  /**
+   * Pulled from the render loop rather than a timer: one less thing to leak,
+   * and it stops dead when the tab is hidden. 0.14s of lookahead is enough to
+   * survive a long frame without audible drift.
+   */
+  tick(): void {
+    const ctx = this.ctx;
+    if (!ctx || this.musicLayers === 0) return;
+    const spb = 60 / this.bpm / 4; // sixteenths
+    while (this.nextNoteTime < ctx.currentTime + 0.14) {
+      this.schedule(this.step, this.nextNoteTime);
+      this.nextNoteTime += spb;
+      this.step = (this.step + 1) % 32;
+    }
+    if (this.nextNoteTime < ctx.currentTime) this.nextNoteTime = ctx.currentTime + 0.02;
+  }
+
+  private schedule(step: number, when: number): void {
+    const ctx = this.ctx!;
+    const L = this.musicLayers;
+    const beat = step % 4 === 0;
+
+    if (beat && (step % 8 === 0 || step % 16 === 12)) this.kick(when);
+    if (L >= 1 && step % 4 === 2) this.hat(when, 0.05);
+    if (L >= 2 && step % 2 === 1) this.hat(when, 0.028);
+
+    if (L >= 2 && step % 8 === 0) {
+      const osc = ctx.createOscillator();
+      osc.type = "sawtooth";
+      osc.frequency.value = this.degree(0, 0) * 0.5;
+      const f = ctx.createBiquadFilter();
+      f.type = "lowpass";
+      f.frequency.setValueAtTime(1400, when);
+      f.frequency.exponentialRampToValueAtTime(220, when + 0.28);
+      const g = ctx.createGain();
+      g.gain.setValueAtTime(0.0001, when);
+      g.gain.exponentialRampToValueAtTime(0.2, when + 0.01);
+      g.gain.exponentialRampToValueAtTime(0.0001, when + 0.3);
+      osc.connect(f);
+      f.connect(g);
+      g.connect(this.musicBus);
+      osc.start(when);
+      osc.stop(when + 0.34);
+      osc.onended = () => {
+        osc.disconnect();
+        f.disconnect();
+        g.disconnect();
+      };
+    }
+
+    if (L >= 3 && step % 2 === 0) {
+      const idx = [0, 2, 4, 2, 5, 4, 2, 0, 3, 5, 7, 5, 4, 2, 3, 0][(step / 2) % 16];
+      const osc = ctx.createOscillator();
+      osc.type = "triangle";
+      osc.frequency.value = this.degree(idx, 1);
+      const g = ctx.createGain();
+      g.gain.setValueAtTime(0.0001, when);
+      g.gain.exponentialRampToValueAtTime(0.085, when + 0.006);
+      g.gain.exponentialRampToValueAtTime(0.0001, when + 0.22);
+      osc.connect(g);
+      g.connect(this.musicBus);
+      const s = ctx.createGain();
+      s.gain.value = 0.3;
+      g.connect(s);
+      s.connect(this.delay);
+      osc.start(when);
+      osc.stop(when + 0.26);
+      osc.onended = () => {
+        osc.disconnect();
+        g.disconnect();
+        s.disconnect();
+      };
+    }
+  }
+
+  private kick(when: number): void {
+    const ctx = this.ctx!;
+    const osc = ctx.createOscillator();
+    osc.type = "sine";
+    osc.frequency.setValueAtTime(150, when);
+    osc.frequency.exponentialRampToValueAtTime(42, when + 0.09);
+    const g = ctx.createGain();
+    g.gain.setValueAtTime(0.0001, when);
+    g.gain.exponentialRampToValueAtTime(0.55, when + 0.004);
+    g.gain.exponentialRampToValueAtTime(0.0001, when + 0.3);
+    osc.connect(g);
+    g.connect(this.musicBus);
+    osc.start(when);
+    osc.stop(when + 0.34);
+    osc.onended = () => {
+      osc.disconnect();
+      g.disconnect();
+    };
+  }
+
+  private hat(when: number, gain: number): void {
+    const ctx = this.ctx!;
+    const src = ctx.createBufferSource();
+    src.buffer = this.noiseBuf;
+    src.loop = true;
+    const f = ctx.createBiquadFilter();
+    f.type = "highpass";
+    f.frequency.value = 7000 + Math.random() * 1200;
+    const g = ctx.createGain();
+    g.gain.setValueAtTime(gain, when);
+    g.gain.exponentialRampToValueAtTime(0.0001, when + 0.05);
+    src.connect(f);
+    f.connect(g);
+    g.connect(this.musicBus);
+    src.start(when);
+    src.stop(when + 0.07);
+    src.onended = () => {
+      src.disconnect();
+      f.disconnect();
+      g.disconnect();
+    };
+  }
+}

--- a/dynawalla/games/runner/src/game/biomes.ts
+++ b/dynawalla/games/runner/src/game/biomes.ts
@@ -1,0 +1,170 @@
+import * as THREE from "three";
+import type { ScaleName } from "./audio.ts";
+
+/**
+ * Four worlds, cycled forever, hue-rotated a little further on every lap.
+ *
+ * This is the answer to "must hold for twenty minutes". Speed alone does not
+ * hold a child for twenty minutes; the promise of *seeing the next place* does.
+ * A crossing is a real event — the whole palette, the sky, the ambient debris,
+ * the musical mode and the tempo all change at once, over about two seconds,
+ * with the sound and the light doing it together.
+ *
+ * AURORA and ABYSS are dark worlds with bright geometry. VOID inverts: a pale
+ * bone sky with black obsidian geometry. Inversion is the strongest visual card
+ * in the deck, so it is spent at the top of the cycle.
+ */
+
+export type AmbientKind = "dust" | "ember" | "mote" | "ash";
+
+export type Biome = {
+  id: string;
+  name: string;
+  skyTop: number;
+  skyBot: number;
+  fog: number;
+  deck: number;
+  accent: number;
+  accent2: number;
+  ocean: number;
+  fogDensity: number;
+  /** Pale world / dark geometry. Flips numeral and HUD contrast decisions. */
+  inverted: boolean;
+  ambient: AmbientKind;
+  ambientColor: number;
+  starDensity: number;
+  auroraStrength: number;
+  scale: ScaleName;
+  bpm: number;
+};
+
+const BASE: Biome[] = [
+  {
+    id: "aurora",
+    name: "AURORA SHELF",
+    skyTop: 0x02030c,
+    skyBot: 0x071230,
+    fog: 0x060a1c,
+    deck: 0x070a18,
+    accent: 0x37ecff,
+    accent2: 0xff44a8,
+    ocean: 0x081434,
+    fogDensity: 1 / 235,
+    inverted: false,
+    ambient: "dust",
+    ambientColor: 0x9fe8ff,
+    starDensity: 1,
+    auroraStrength: 1,
+    scale: "aurora",
+    bpm: 126,
+  },
+  {
+    id: "solar",
+    name: "SOLAR FLATS",
+    skyTop: 0x1a0403,
+    skyBot: 0x5c1405,
+    fog: 0x2a0a06,
+    deck: 0x150703,
+    accent: 0xffb024,
+    accent2: 0xff3a24,
+    ocean: 0x2e0d04,
+    fogDensity: 1 / 200,
+    inverted: false,
+    ambient: "ember",
+    ambientColor: 0xffb45a,
+    starDensity: 0.15,
+    auroraStrength: 0.35,
+    scale: "solar",
+    bpm: 134,
+  },
+  {
+    id: "abyss",
+    name: "THE ABYSS",
+    skyTop: 0x00060a,
+    skyBot: 0x032026,
+    fog: 0x02090f,
+    deck: 0x030a0e,
+    accent: 0x5effc9,
+    accent2: 0xa46bff,
+    ocean: 0x021a20,
+    fogDensity: 1 / 175,
+    inverted: false,
+    ambient: "mote",
+    ambientColor: 0x7effd8,
+    starDensity: 0.4,
+    auroraStrength: 0.7,
+    scale: "abyss",
+    bpm: 142,
+  },
+  {
+    id: "void",
+    name: "THE BLEACH",
+    skyTop: 0xe9e3d4,
+    skyBot: 0xfdfaf2,
+    fog: 0xece6d8,
+    deck: 0x0b0b0d,
+    accent: 0xff2f6d,
+    accent2: 0x1a1a20,
+    ocean: 0xc9c3b4,
+    // Far thinner fog than the dark biomes. Bone-coloured fog at 1/165 washes
+    // the near deck to sage and the whole point of the inverted world — black
+    // obsidian on white — disappears about forty metres out.
+    fogDensity: 1 / 330,
+    inverted: true,
+    ambient: "ash",
+    ambientColor: 0x2a2a34,
+    starDensity: 0,
+    auroraStrength: 0,
+    scale: "void",
+    bpm: 150,
+  },
+];
+
+const tmpHSL = { h: 0, s: 0, l: 0 };
+const tmpColor = new THREE.Color();
+
+function rotate(hex: number, turns: number): number {
+  if (turns === 0) return hex;
+  tmpColor.setHex(hex);
+  tmpColor.getHSL(tmpHSL);
+  // Small, deliberate drift. A full lap of four biomes shifts about 50 degrees,
+  // which is "somewhere new" without ever becoming a colour a child cannot name.
+  tmpColor.setHSL((tmpHSL.h + turns * 0.14) % 1, tmpHSL.s, tmpHSL.l);
+  return tmpColor.getHex();
+}
+
+/** Biome for the nth crossing. Endless: `index` is unbounded. */
+export function biomeAt(index: number): Biome {
+  const b = BASE[index % BASE.length];
+  const lap = Math.floor(index / BASE.length);
+  if (lap === 0) return b;
+  return {
+    ...b,
+    name: lap === 1 ? `${b.name} II` : `${b.name} ${romanish(lap + 1)}`,
+    skyTop: rotate(b.skyTop, lap),
+    skyBot: rotate(b.skyBot, lap),
+    fog: rotate(b.fog, lap),
+    accent: rotate(b.accent, lap),
+    accent2: rotate(b.accent2, lap),
+    ocean: rotate(b.ocean, lap),
+    ambientColor: rotate(b.ambientColor, lap),
+    bpm: Math.min(168, b.bpm + lap * 4),
+  };
+}
+
+function romanish(n: number): string {
+  const table = ["", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"];
+  return table[n] ?? `x${n}`;
+}
+
+/**
+ * Metres of causeway per biome.
+ *
+ * The first crossing is deliberately the shortest. A child on a five-minute
+ * free session has to *see* that the world changes, or the whole escalation
+ * promise is invisible to them — the first one lands around 45 seconds.
+ */
+export function biomeLength(index: number): number {
+  if (index === 0) return 1150;
+  return Math.max(1300, 2000 - index * 70);
+}

--- a/dynawalla/games/runner/src/game/digits.ts
+++ b/dynawalla/games/runner/src/game/digits.ts
@@ -1,0 +1,266 @@
+import * as THREE from "three";
+import { COMMON, type SharedUniforms } from "./shaders.ts";
+import { CHARS, COLS, ROWS, INK, TRACK, glyphIndex } from "./glyphs.ts";
+
+/**
+ * World-space numerals.
+ *
+ * The catalogue this game is answering shipped engraved serif numerals on
+ * fast-moving targets and a child got 0.45s to read them. That is the bug this
+ * file exists to not repeat. Every choice here is legibility:
+ *
+ *  - One heavy geometric sans, tabular, no ornament, no serifs.
+ *  - Each glyph is baked with a dark stroke *and* a soft dark shadow beyond it,
+ *    so a hot-white numeral stays readable over an aurora, over a white-out,
+ *    over another gate.
+ *  - The red channel separates fill from outline, so the shader can recolour
+ *    the numeral without ever recolouring its own contrast.
+ *  - Every numeral in the world is one draw call, so making them big and
+ *    plentiful costs nothing.
+ */
+
+/** The character set, the grid and the two metrics all live in `glyphs.ts`. */
+const CELL = 256;
+
+type Atlas = { texture: THREE.Texture; advance: number[] };
+
+function buildAtlas(): Atlas {
+  const canvas = document.createElement("canvas");
+  canvas.width = COLS * CELL;
+  canvas.height = ROWS * CELL;
+  const ctx = canvas.getContext("2d")!;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const size = Math.round(CELL * 0.74);
+  ctx.font = `800 ${size}px "Archivo Black", "Helvetica Neue", "Arial Black", system-ui, sans-serif`;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.lineJoin = "round";
+  ctx.miterLimit = 2;
+
+  const advance: number[] = [];
+  for (let i = 0; i < CHARS.length; i++) {
+    const ch = CHARS[i];
+    const cx = (i % COLS) * CELL + CELL / 2;
+    const cy = Math.floor(i / COLS) * CELL + CELL / 2 + size * 0.03;
+
+    // Shadow first: a soft dark bloom that survives any background.
+    ctx.save();
+    ctx.shadowColor = "rgba(0,0,0,0.92)";
+    ctx.shadowBlur = CELL * 0.1;
+    ctx.strokeStyle = "rgba(3,5,12,1)";
+    ctx.lineWidth = CELL * 0.115;
+    ctx.strokeText(ch, cx, cy);
+    ctx.strokeText(ch, cx, cy);
+    ctx.restore();
+
+    // Hard outline, then the fill. R=0 in the outline, R=1 in the fill.
+    ctx.strokeStyle = "rgba(4,6,16,1)";
+    ctx.lineWidth = CELL * 0.085;
+    ctx.strokeText(ch, cx, cy);
+    ctx.fillStyle = "#ffffff";
+    ctx.fillText(ch, cx, cy);
+
+    advance.push(ctx.measureText(ch).width / CELL);
+  }
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.minFilter = THREE.LinearMipmapLinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  texture.generateMipmaps = true;
+  texture.anisotropy = 8;
+  texture.needsUpdate = true;
+  return { texture, advance };
+}
+
+const VERT = /* glsl */ `
+${COMMON}
+attribute vec3 iPos;
+attribute vec2 iSize;
+attribute vec2 iUv;
+attribute vec3 iColor;
+attribute vec3 iParam; // x alpha, y glow, z tilt (radians about X)
+
+varying vec2 vUv;
+varying vec3 vColor;
+varying float vAlpha;
+varying float vGlow;
+varying float vFog;
+
+void main() {
+  vec3 local = vec3(position.x * iSize.x, position.y * iSize.y, 0.0);
+  float c = cos(iParam.z), s = sin(iParam.z);
+  local = vec3(local.x, local.y * c, local.y * s);
+  vec3 wp = iPos + local;
+  float depth = max(0.0, -iPos.z);
+  wp = voltaBend(wp);
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(wp, 1.0);
+  vUv = iUv + uv * vec2(${(1 / COLS).toFixed(6)}, ${(1 / ROWS).toFixed(6)});
+  vColor = iColor;
+  vAlpha = iParam.x;
+  vGlow = iParam.y;
+  vFog = voltaFog(depth);
+}
+`;
+
+const FRAG = /* glsl */ `
+${COMMON}
+uniform sampler2D uAtlas;
+uniform vec3 uOutline;
+varying vec2 vUv;
+varying vec3 vColor;
+varying float vAlpha;
+varying float vGlow;
+varying float vFog;
+
+void main() {
+  vec4 t = texture2D(uAtlas, vUv);
+  float a = t.a * vAlpha;
+  if (a <= 0.004) discard;
+  // t.r is 1 inside the glyph and ~0 in the baked outline/shadow.
+  //
+  // The base is deliberately close to 1.0 rather than 1.25. Anything above the
+  // bloom threshold gets a halo, the halo fattens the strokes, and fattened
+  // strokes on adjacent two-digit numerals is half of how "13 42 36" became
+  // "134236". Candidates a child is still reading carry almost no glow; only a
+  // *resolved* numeral, which nobody has to read any more, is allowed to blaze.
+  vec3 fill = vColor * (1.0 + vGlow * 2.4);
+  vec3 col = mix(uOutline, fill, t.r);
+  // Fog never eats the numeral's contrast, only its brightness.
+  col = mix(col, uFogColor * 0.7 + col * 0.3, vFog * 0.8);
+  gl_FragColor = vec4(col, a);
+}
+`;
+
+export class DigitField {
+  readonly mesh: THREE.Mesh;
+  readonly material: THREE.ShaderMaterial;
+  private geo: THREE.InstancedBufferGeometry;
+  private atlas: Atlas;
+  private capacity: number;
+  private n = 0;
+  private aPos: THREE.InstancedBufferAttribute;
+  private aSize: THREE.InstancedBufferAttribute;
+  private aUv: THREE.InstancedBufferAttribute;
+  private aColor: THREE.InstancedBufferAttribute;
+  private aParam: THREE.InstancedBufferAttribute;
+
+  constructor(capacity: number, shared: SharedUniforms) {
+    this.capacity = capacity;
+    this.atlas = buildAtlas();
+    const quad = new THREE.PlaneGeometry(1, 1);
+    const geo = new THREE.InstancedBufferGeometry();
+    geo.index = quad.index;
+    geo.setAttribute("position", quad.getAttribute("position"));
+    geo.setAttribute("uv", quad.getAttribute("uv"));
+    const mk = (s: number) => new THREE.InstancedBufferAttribute(new Float32Array(capacity * s), s);
+    this.aPos = mk(3);
+    this.aSize = mk(2);
+    this.aUv = mk(2);
+    this.aColor = mk(3);
+    this.aParam = mk(3);
+    geo.setAttribute("iPos", this.aPos);
+    geo.setAttribute("iSize", this.aSize);
+    geo.setAttribute("iUv", this.aUv);
+    geo.setAttribute("iColor", this.aColor);
+    geo.setAttribute("iParam", this.aParam);
+    geo.instanceCount = 0;
+    geo.boundingSphere = new THREE.Sphere(new THREE.Vector3(), 1e6);
+    this.geo = geo;
+
+    this.material = new THREE.ShaderMaterial({
+      uniforms: {
+        ...shared,
+        uAtlas: { value: this.atlas.texture },
+        // The baked stroke reads as a hard dark edge in the three dark biomes;
+        // in THE BLEACH the world is bone and the numeral flips to black ink on
+        // a pale halo instead. Contrast is never left to chance.
+        uOutline: { value: new THREE.Color(0.012, 0.018, 0.045) },
+      },
+      vertexShader: VERT,
+      fragmentShader: FRAG,
+      transparent: true,
+      depthWrite: false,
+      // Numerals are the information layer and always win. A roadside monolith
+      // eclipsing the one gate value a child needed is not atmosphere, it is a
+      // lost run, and only one gate is ever alive so nothing else can be hidden
+      // behind them.
+      depthTest: false,
+    });
+    this.mesh = new THREE.Mesh(geo, this.material);
+    this.mesh.frustumCulled = false;
+    this.mesh.matrixAutoUpdate = false;
+    this.mesh.renderOrder = 30;
+  }
+
+  begin(): void {
+    this.n = 0;
+  }
+
+  /** Colour of the baked stroke around every glyph. Flips with the biome. */
+  setOutline(r: number, g: number, b: number): void {
+    (this.material.uniforms.uOutline.value as THREE.Color).setRGB(r, g, b);
+  }
+
+  /** Width, in world units, that `text` occupies at ink height `h`. */
+  measure(text: string, h: number): number {
+    const cell = h / INK;
+    let w = 0;
+    for (let i = 0; i < text.length; i++) {
+      w += this.atlas.advance[glyphIndex(text[i])] * cell * TRACK;
+    }
+    return w;
+  }
+
+  /** Draw `text` centred on (x, y) with an ink height of `h` world units. */
+  addNumber(
+    text: string,
+    x: number, y: number, z: number,
+    h: number,
+    r: number, g: number, b: number,
+    alpha: number, glow: number,
+    tilt = 0,
+  ): void {
+    const total = this.measure(text, h);
+    const cell = h / INK;
+    let pen = x - total / 2;
+    const pos = this.aPos.array as Float32Array;
+    const size = this.aSize.array as Float32Array;
+    const uv = this.aUv.array as Float32Array;
+    const col = this.aColor.array as Float32Array;
+    const par = this.aParam.array as Float32Array;
+    for (let i = 0; i < text.length; i++) {
+      const idx = glyphIndex(text[i]);
+      const adv = this.atlas.advance[idx] * cell * TRACK;
+      const k = this.n;
+      if (k >= this.capacity) return;
+      pos[k * 3] = pen + adv / 2;
+      pos[k * 3 + 1] = y;
+      pos[k * 3 + 2] = z;
+      size[k * 2] = cell;
+      size[k * 2 + 1] = cell;
+      uv[k * 2] = (idx % COLS) / COLS;
+      uv[k * 2 + 1] = 1 - (Math.floor(idx / COLS) + 1) / ROWS;
+      col[k * 3] = r; col[k * 3 + 1] = g; col[k * 3 + 2] = b;
+      par[k * 3] = alpha; par[k * 3 + 1] = glow; par[k * 3 + 2] = tilt;
+      this.n = k + 1;
+      pen += adv;
+    }
+  }
+
+  end(): void {
+    this.geo.instanceCount = this.n;
+    if (this.n === 0) return;
+    this.aPos.needsUpdate = true;
+    this.aSize.needsUpdate = true;
+    this.aUv.needsUpdate = true;
+    this.aColor.needsUpdate = true;
+    this.aParam.needsUpdate = true;
+  }
+
+  dispose(): void {
+    this.geo.dispose();
+    this.material.dispose();
+    this.atlas.texture.dispose();
+  }
+}

--- a/dynawalla/games/runner/src/game/entities.ts
+++ b/dynawalla/games/runner/src/game/entities.ts
@@ -1,0 +1,523 @@
+import type { Question } from "../contract.ts";
+import type { SolidField, GlowField } from "./fields.ts";
+import type { DigitField } from "./digits.ts";
+import type { Rng } from "./rng.ts";
+import type { Projector } from "./project.ts";
+import { LANE_W, DECK_HALF } from "./world.ts";
+import { readBand, payoffHeight, keepInside } from "./readband.ts";
+import { laneOptions } from "./options.ts";
+import { clamp01, easeOutBack, easeOutCubic, easeOutQuint } from "./juice.ts";
+
+/**
+ * Gates, hazards, sparks and score popups.
+ *
+ * The design rule that everything else follows from: **the lane you are in when
+ * you cross the gate plane is the answer you gave.** There is no button, no
+ * menu, no pause. Answering is steering, and steering is the game.
+ *
+ * The second rule: a wrong answer must cost something a child can feel. It is
+ * a solid barrier — you slam it, you lose a third of your voltage, your surge
+ * multiplier collapses to one and you lose about a second of control. Three
+ * lanes means a guess pays off a third of the time, so the price of a guess has
+ * to be steep enough that reading is plainly the cheaper strategy.
+ *
+ * Everything here is a fixed-size pool addressed by index. Nothing is allocated
+ * during a run.
+ */
+
+export const GATE_PLANE = 0;
+
+export type GateState = "incoming" | "passed" | "hit";
+
+export type Gate = {
+  active: boolean;
+  z: number;
+  q: Question | null;
+  /** Text drawn in lane 0, 1, 2. */
+  values: [string, string, string];
+  correctLane: number;
+  chosenLane: number;
+  state: GateState;
+  /** performance.now() when the gate first became visible; latency baseline. */
+  shownAt: number;
+  /** 0 -> 1 arrival animation. */
+  intro: number;
+  /** Post-resolution animation clock. */
+  burst: number;
+  /** Reading window this gate was granted, in seconds. Reported for tuning. */
+  window: number;
+  /** Distance ahead the gate was spawned at; drives the read-band spread. */
+  spawn: number;
+  /** Where the three numerals last drew, in NDC, so the payoff can start there. */
+  ndcX: [number, number, number];
+  ndcY: number;
+  ndcH: number;
+};
+
+export type HazardKind = "pylon" | "lowbar" | "pit" | "sweeper";
+
+export type Hazard = {
+  active: boolean;
+  kind: HazardKind;
+  z: number;
+  lane: number;
+  /** Sweeper phase. */
+  phase: number;
+  span: number;
+  hit: boolean;
+  grazed: boolean;
+};
+
+export type Spark = {
+  active: boolean;
+  x: number;
+  y: number;
+  z: number;
+  taken: boolean;
+  bob: number;
+};
+
+export type Popup = {
+  active: boolean;
+  text: string;
+  x: number;
+  y: number;
+  z: number;
+  t: number;
+  life: number;
+  size: number;
+  r: number;
+  g: number;
+  b: number;
+};
+
+export const laneX = (lane: number): number => (lane - 1) * LANE_W;
+
+/** Scratch for the per-frame numeral measurement. Never allocate in a frame. */
+const TMP_UNITS: [number, number, number] = [1, 1, 1];
+
+export class Entities {
+  gates: Gate[] = [];
+  hazards: Hazard[] = [];
+  sparks: Spark[] = [];
+  popups: Popup[] = [];
+
+  constructor(gateCap = 3, hazardCap = 40, sparkCap = 120, popupCap = 28) {
+    for (let i = 0; i < gateCap; i++)
+      this.gates.push({
+        active: false, z: 0, q: null, values: ["", "", ""], correctLane: 1,
+        chosenLane: -1, state: "incoming", shownAt: 0, intro: 0, burst: 0, window: 0,
+        spawn: 100, ndcX: [-0.58, 0, 0.58], ndcY: 0.3, ndcH: 0.2,
+      });
+    for (let i = 0; i < hazardCap; i++)
+      this.hazards.push({ active: false, kind: "pylon", z: 0, lane: 1, phase: 0, span: 1, hit: false, grazed: false });
+    for (let i = 0; i < sparkCap; i++)
+      this.sparks.push({ active: false, x: 0, y: 0, z: 0, taken: false, bob: 0 });
+    for (let i = 0; i < popupCap; i++)
+      this.popups.push({ active: false, text: "", x: 0, y: 0, z: 0, t: 0, life: 1, size: 1, r: 1, g: 1, b: 1 });
+  }
+
+  reset(): void {
+    for (const g of this.gates) g.active = false;
+    for (const h of this.hazards) h.active = false;
+    for (const s of this.sparks) s.active = false;
+    for (const p of this.popups) p.active = false;
+  }
+
+  /* -------------------------------- spawning ------------------------------ */
+
+  spawnGate(q: Question, distance: number, window: number, rng: Rng): Gate | null {
+    const g = this.gates.find((x) => !x.active);
+    if (!g) return null;
+    const { values, correct } = laneOptions(q.answer, q.distractors, rng);
+    g.active = true;
+    g.z = -distance;
+    g.q = q;
+    g.correctLane = correct;
+    g.chosenLane = -1;
+    g.state = "incoming";
+    g.shownAt = performance.now();
+    g.intro = 0;
+    g.burst = 0;
+    g.window = window;
+    g.spawn = distance;
+    for (let i = 0; i < 3; i++) g.values[i] = values[i];
+    return g;
+  }
+
+  spawnHazard(kind: HazardKind, lane: number, distance: number, span = 1): Hazard | null {
+    const h = this.hazards.find((x) => !x.active);
+    if (!h) return null;
+    h.active = true;
+    h.kind = kind;
+    h.z = -distance;
+    h.lane = lane;
+    h.span = span;
+    h.phase = Math.random() * Math.PI * 2;
+    h.hit = false;
+    h.grazed = false;
+    return h;
+  }
+
+  spawnSpark(x: number, y: number, distance: number): void {
+    const s = this.sparks.find((v) => !v.active);
+    if (!s) return;
+    s.active = true;
+    s.x = x;
+    s.y = y;
+    s.z = -distance;
+    s.taken = false;
+    s.bob = Math.random() * Math.PI * 2;
+  }
+
+  popup(text: string, x: number, y: number, z: number, size: number, r: number, g: number, b: number, life = 1.05): void {
+    let p = this.popups.find((v) => !v.active);
+    if (!p) {
+      // Steal the oldest rather than drop the feedback.
+      p = this.popups.reduce((a, b) => (a.t > b.t ? a : b));
+    }
+    p.active = true;
+    p.text = text;
+    p.x = x;
+    p.y = y;
+    p.z = z;
+    p.t = 0;
+    p.life = life;
+    p.size = size;
+    p.r = r;
+    p.g = g;
+    p.b = b;
+  }
+
+  /* --------------------------------- update ------------------------------- */
+
+  update(dt: number, scroll: number): void {
+    for (const g of this.gates) {
+      if (!g.active) continue;
+      g.z += scroll;
+      g.intro = Math.min(1, g.intro + dt * 2.4);
+      if (g.state !== "incoming") {
+        g.burst += dt;
+        if (g.burst > 0.85) g.active = false;
+      } else if (g.z > 24) {
+        g.active = false;
+      }
+    }
+    for (const h of this.hazards) {
+      if (!h.active) continue;
+      h.z += scroll;
+      if (h.kind === "sweeper") h.phase += dt * 1.55;
+      if (h.z > 26) h.active = false;
+    }
+    for (const s of this.sparks) {
+      if (!s.active) continue;
+      s.z += scroll;
+      s.bob += dt * 4;
+      if (s.z > 24) s.active = false;
+    }
+    for (const p of this.popups) {
+      if (!p.active) continue;
+      p.t += dt;
+      p.z += scroll * 0.55; // popups lag the world slightly so they stay readable
+      p.y += dt * 3.2;
+      if (p.t >= p.life) p.active = false;
+    }
+  }
+
+  /** Current lane centre of a hazard, accounting for sweeper motion. */
+  hazardX(h: Hazard): number {
+    if (h.kind !== "sweeper") return laneX(h.lane);
+    return Math.sin(h.phase) * LANE_W;
+  }
+
+  /* ---------------------------------- draw -------------------------------- */
+
+  drawGates(
+    box: SolidField, glow: GlowField, digits: DigitField, proj: Projector,
+    ac: readonly [number, number, number],
+    hot: readonly [number, number, number],
+    bad: readonly [number, number, number],
+    good: readonly [number, number, number],
+    ink: readonly [number, number, number],
+    time: number,
+    revealed: boolean,
+  ): void {
+    for (const g of this.gates) {
+      if (!g.active) continue;
+      const intro = easeOutBack(g.intro);
+      const H = 4.9 * intro;
+      const resolving = g.state !== "incoming";
+      const bt = resolving ? clamp01(g.burst / 0.85) : 0;
+
+      for (let i = 0; i < 3; i++) {
+        const cx = laneX(i);
+        const isCorrect = i === g.correctLane;
+        // Before resolution every gate looks identical — the numeral is the
+        // only information. Colour never leaks the answer.
+        let cr = ac[0], cg = ac[1], cb = ac[2], glowAmt = 0.45;
+        if (resolving || revealed) {
+          const c = isCorrect ? good : bad;
+          cr = c[0]; cg = c[1]; cb = c[2];
+          glowAmt = isCorrect ? 3.4 : 1.2;
+        }
+        const chosen = resolving && i === g.chosenLane;
+        const shatter = resolving && isCorrect ? bt : 0;
+        const fall = resolving && !isCorrect && chosen ? bt : 0;
+
+        const openY = fall * 1.2;
+        const post = 0.24 + (chosen ? 0.12 : 0);
+        const alpha = resolving && isCorrect ? 1 - bt : 1;
+        if (alpha > 0.02) {
+          const spread = shatter * 2.6;
+          box.add(cx - LANE_W * 0.5 + 0.24 - spread, H * 0.5 - openY, g.z, post, H, 0.42, 0, cr, cg, cb, glowAmt, alpha);
+          box.add(cx + LANE_W * 0.5 - 0.24 + spread, H * 0.5 - openY, g.z, post, H, 0.42, 0, cr, cg, cb, glowAmt, alpha);
+          box.add(cx, H - openY, g.z, LANE_W - 0.42 + spread * 2, 0.3, 0.46, 0, cr, cg, cb, glowAmt * 1.3, alpha);
+        }
+
+        // The membrane you break. Pulses so the gate reads as "enterable".
+        const pulse = 0.5 + 0.5 * Math.sin(time * 3.4 + i * 1.1);
+        const memA = resolving ? (isCorrect ? (1 - bt) * 0.5 : 0.1) : (0.10 + pulse * 0.07) * intro;
+        if (memA > 0.01) {
+          glow.add(cx, H * 0.5, g.z, LANE_W - 0.5, memA, H / Math.max(0.001, LANE_W - 0.5), 3, cr, cg, cb);
+        }
+
+        if (resolving && isCorrect && bt < 1) {
+          glow.add(cx, H * 0.5, g.z, 2 + bt * 22, (1 - bt) * 0.9, 1, 1, hot[0], hot[1], hot[2]);
+        }
+      }
+
+      // The numerals. See `readband.ts` — they are laid out in screen units and
+      // converted back to world space, because perspective is the wrong tool for
+      // typesetting three values a child has half a second to compare.
+      if (resolving) this.drawPayoff(g, digits, glow, proj, good, bad, hot, bt);
+      else this.drawCandidates(g, digits, glow, proj, ink, ac, H);
+
+      // The overhead beam that says "this is the answer line".
+      const beamA = resolving ? Math.max(0, 1 - bt * 2) : intro * 0.85;
+      if (beamA > 0.02) {
+        glow.add(0, 5.9 * intro, g.z, DECK_HALF * 2.1, beamA * 0.5, 0.05, 3, ac[0], ac[1], ac[2]);
+      }
+    }
+  }
+
+  /**
+   * The three candidates, while the gate is still incoming.
+   *
+   * Laid out in NDC by `readBand` and converted straight back to world space, so
+   * they fog, bend and belong to the causeway while being typeset like a poster.
+   * Two passes: the first linearises the projection around the arch to find out
+   * where the row wants to sit, the second re-linearises around the row's own
+   * height. The camera is pitched about three degrees, and one refinement takes
+   * the residual well under a pixel.
+   */
+  private drawCandidates(
+    g: Gate, digits: DigitField, glow: GlowField, proj: Projector,
+    ink: readonly [number, number, number],
+    ac: readonly [number, number, number],
+    H: number,
+  ): void {
+    const dist = Math.max(0, -g.z);
+    const approach = clamp01(1 - dist / Math.max(1, g.spawn));
+
+    const u = TMP_UNITS;
+    proj.at(g.z, H);
+    const archTop = proj.ndcY(H);
+    for (let i = 0; i < 3; i++) u[i] = Math.max(1e-4, digits.measure(g.values[i], 1));
+
+    let band = readBand(u, proj.kx, proj.ky, approach, archTop);
+    proj.at(g.z, proj.worldY(band.y));
+    band = readBand(u, proj.kx, proj.ky, approach, archTop);
+
+    // The row is dealt outward from the vanishing point as the gate resolves out
+    // of the fog. Overshoot is deliberate — `readBand` keeps a 30% gutter, so a
+    // 13% back-ease can never close it.
+    const deal = clamp01(g.intro * 1.35);
+    const spread = easeOutBack(deal);
+    const scale = easeOutBack(clamp01(g.intro * 1.6));
+    const alpha = clamp01(g.intro * 2.4);
+    const hW = proj.worldFromNdcY(band.hNdc) * scale;
+    const yW = proj.worldY(band.y);
+
+    g.ndcY = band.y;
+    g.ndcH = band.hNdc * scale;
+
+    for (let i = 0; i < 3; i++) {
+      const nx = band.x[i] * spread;
+      g.ndcX[i] = nx;
+      const xW = proj.worldX(nx);
+
+      // A leader from the numeral down to the top of its own arch. Left-to-right
+      // order alone is enough to guess the mapping from; the leader means a
+      // child never has to guess it.
+      const ax = laneX(i);
+      const ay = H + 0.5;
+      for (let k = 1; k <= 5; k++) {
+        const t = k / 6;
+        const lt = t * t; // bunch the dots toward the arch, where the answer is
+        glow.add(
+          xW + (ax - xW) * lt, yW - hW * 0.62 + (ay - (yW - hW * 0.62)) * lt, g.z + 0.02,
+          hW * (0.16 + t * 0.1), alpha * (0.1 + t * 0.42), 1, 0,
+          ac[0], ac[1], ac[2],
+        );
+      }
+      // ...and a hard cap sitting on the arch, so the endpoint is unmissable.
+      glow.add(ax, ay, g.z + 0.02, LANE_W * 0.5, alpha * 0.5, 0.12, 3, ac[0], ac[1], ac[2]);
+
+      if (alpha > 0.02) {
+        digits.addNumber(g.values[i], xW, yW, g.z + 0.05, hW, ink[0], ink[1], ink[2], alpha, 0.05);
+      }
+    }
+  }
+
+  /**
+   * What happens the instant you cross.
+   *
+   * On a win the value you earned leaves the row, rushes the camera and fills
+   * the screen — the biggest single moment in the game, and it is allowed to
+   * blaze because nobody has to read it any more.
+   *
+   * On a miss it does *not*. A screen-filling green numeral after a wrong answer
+   * reads as praise. Instead the lane you actually took goes red and drops, and
+   * the value you should have taken is popped over its own lane by the caller,
+   * where the lane — not the number — is the lesson.
+   */
+  private drawPayoff(
+    g: Gate, digits: DigitField, glow: GlowField, proj: Projector,
+    good: readonly [number, number, number],
+    bad: readonly [number, number, number],
+    hot: readonly [number, number, number],
+    bt: number,
+  ): void {
+    const CZ = -14;
+    proj.at(CZ, 3);
+    const right = g.correctLane;
+    const won = g.state === "passed";
+
+    for (let i = 0; i < 3; i++) {
+      const isRight = i === right;
+      if (isRight && won) continue;
+      const chosen = i === g.chosenLane;
+      // The one you took hangs around long enough to be seen going red.
+      const a = chosen ? Math.max(0, 1 - bt * 1.7) : Math.max(0, 1 - bt * 3.2);
+      if (a <= 0.02) continue;
+      const drop = chosen ? bt * bt * 0.45 : bt * 0.2;
+      const shake = chosen ? Math.sin(bt * 46) * 0.05 * (1 - bt) : 0;
+      const c = chosen ? bad : isRight ? good : bad;
+      digits.addNumber(
+        g.values[i], proj.worldX(g.ndcX[i] + shake), proj.worldY(g.ndcY - drop), CZ + 0.05,
+        proj.worldFromNdcY(g.ndcH * (1 - bt * 0.35)),
+        c[0], c[1], c[2], a * (chosen ? 1 : 0.5), chosen ? 0.6 : 0.05,
+      );
+    }
+
+    if (!won) return;
+
+    const rush = easeOutQuint(bt);
+    const swell = easeOutCubic(Math.min(1, bt * 1.25));
+    const a = bt < 0.55 ? 1 : Math.max(0, 1 - (bt - 0.55) / 0.45);
+    if (a > 0.02) {
+      // How big the winning numeral is allowed to get. See `payoffHeight` —
+      // like the candidate row, it is decided in screen units and converted back.
+      const wPerH = digits.measure(g.values[right], 1) * (Math.abs(proj.kx) / Math.abs(proj.ky));
+      const hn = payoffHeight(wPerH, g.ndcH, swell);
+      const x = proj.worldX(g.ndcX[right] * (1 - rush));
+      const y = proj.worldY(g.ndcY + (0.02 - g.ndcY) * rush);
+      digits.addNumber(
+        g.values[right], x, y, CZ + 0.05, proj.worldFromNdcY(hn),
+        good[0], good[1], good[2], a, 2.4 + bt * 2.6,
+      );
+      // The ring the numeral punches through. Sized off the numeral rather than
+      // off a constant, so a phone gets the same composition as a laptop instead
+      // of a ring three screens wide around a numeral that had to stay small.
+      const rw = proj.worldFromNdcY(0.2 + swell * hn * 1.55);
+      glow.add(x, y, CZ + 0.1, rw, (1 - bt) * 0.85, 1, 1, hot[0], hot[1], hot[2]);
+      glow.add(x, y, CZ + 0.12, rw * 0.55, (1 - bt) * 0.5, 1, 0, good[0], good[1], good[2]);
+    }
+  }
+
+  drawHazards(
+    box: SolidField, glow: GlowField,
+    warn: readonly [number, number, number],
+    ac: readonly [number, number, number],
+    time: number,
+  ): void {
+    for (const h of this.hazards) {
+      if (!h.active || h.kind === "pit") continue;
+      const x = this.hazardX(h);
+      const pulse = 0.55 + 0.45 * Math.sin(time * 6 + h.phase);
+      if (h.kind === "pylon" || h.kind === "sweeper") {
+        const H = 2.75;
+        box.add(x, H * 0.5, h.z, LANE_W * 0.62, H, 0.85, 0, warn[0], warn[1], warn[2], 1.3 + pulse * 0.6, 1);
+        box.add(x, H + 0.22, h.z, LANE_W * 0.72, 0.24, 1.0, 0, warn[0], warn[1], warn[2], 2.4, 1);
+        glow.add(x, H * 0.5, h.z, LANE_W * 1.15, 0.30 * pulse, 1.6, 0, warn[0], warn[1], warn[2]);
+        if (h.kind === "sweeper") {
+          glow.add(x, 0.08, h.z, 4.2, 0.34, 0.3, 1, warn[0], warn[1], warn[2]);
+        }
+      } else {
+        // Low bar: you go under it. The gap below is lit so the affordance is
+        // shape, not memory.
+        const w = LANE_W * h.span;
+        box.add(x, 3.15, h.z, w, 1.5, 0.9, 0, warn[0], warn[1], warn[2], 1.5, 1);
+        box.add(x, 2.35, h.z, w, 0.16, 1.1, 0, warn[0], warn[1], warn[2], 2.6, 1);
+        glow.add(x, 1.15, h.z, w * 0.95, 0.16 * pulse, 0.55, 3, ac[0], ac[1], ac[2]);
+      }
+    }
+  }
+
+  drawPits(glow: GlowField, warn: readonly [number, number, number]): void {
+    for (const h of this.hazards) {
+      if (!h.active || h.kind !== "pit") continue;
+      const w = DECK_HALF * 2;
+      glow.add(0, 0.05, h.z - 3.2, w, 0.6, 0.06, 3, warn[0], warn[1], warn[2]);
+      glow.add(0, 0.05, h.z + 3.2, w, 0.6, 0.06, 3, warn[0], warn[1], warn[2]);
+    }
+  }
+
+  drawSparks(glow: GlowField, c: readonly [number, number, number], t: number): void {
+    for (const s of this.sparks) {
+      if (!s.active || s.taken) continue;
+      const y = s.y + Math.sin(s.bob) * 0.18;
+      glow.add(s.x, y, s.z, 0.95 + Math.sin(t * 6 + s.bob) * 0.12, 0.95, 1, 2, c[0], c[1], c[2]);
+      glow.add(s.x, y, s.z, 2.1, 0.16, 1, 0, c[0], c[1], c[2]);
+    }
+  }
+
+  /**
+   * The "+400" / surge numbers that fountain off a resolved gate.
+   *
+   * They are placed at the lane they belong to, which on a wide screen is well
+   * inside the frame and on a 390px phone is not: a "+100" over the outer lane
+   * used to hang half off the edge as a meaningless "00". So the text is nudged
+   * back inside the frame in screen units — it keeps its lane as long as the
+   * lane fits, and gives that up rather than be unreadable.
+   */
+  drawPopups(digits: DigitField, proj: Projector): void {
+    for (const p of this.popups) {
+      if (!p.active) continue;
+      const t = p.t / p.life;
+      const rise = easeOutCubic(Math.min(1, t * 2.1));
+      const a = t < 0.75 ? 1 : 1 - (t - 0.75) / 0.25;
+      const pop = t < 0.16 ? easeOutBack(t / 0.16) : 1;
+      const size = p.size * pop;
+      const y = p.y + rise * 2.2;
+
+      proj.at(p.z, y);
+      const halfW = (digits.measure(p.text, size) * Math.abs(proj.kx)) / 2;
+      const nx = proj.x0 + proj.kx * p.x;
+      const inside = keepInside(nx, halfW);
+      const x = inside === nx ? p.x : proj.worldX(inside);
+
+      digits.addNumber(p.text, x, y, p.z, size, p.r, p.g, p.b, a, 1.6);
+    }
+  }
+
+  /* -------------------------------- helpers ------------------------------- */
+
+  /** Is any pit currently spanning the player plane? */
+  pitAt(z: number): Hazard | null {
+    for (const h of this.hazards) {
+      if (h.active && h.kind === "pit" && Math.abs(h.z - z) < 3.6) return h;
+    }
+    return null;
+  }
+}

--- a/dynawalla/games/runner/src/game/fields.ts
+++ b/dynawalla/games/runner/src/game/fields.ts
@@ -1,0 +1,334 @@
+import * as THREE from "three";
+import { COMMON, EDGE_GLSL, type SharedUniforms, withBarycentric } from "./shaders.ts";
+
+/**
+ * Two instanced "fields" carry the entire world.
+ *
+ * Everything solid — monoliths, gate arches, hazards, the skiff, roadside
+ * debris — is one `SolidField` draw call per prototype geometry. Everything
+ * luminous — halos, particles, sparks, speed streaks, shockwave rings — is one
+ * `GlowField` draw call.
+ *
+ * Both write into pre-allocated Float32Arrays. There is no per-frame allocation
+ * anywhere in this file, and no `Object3D` is created after load, so a
+ * twenty-minute run never asks the collector for anything.
+ */
+
+/* ------------------------------- solid field ------------------------------ */
+
+const SOLID_VERT = /* glsl */ `
+${COMMON}
+attribute vec3 bary;
+attribute vec3 iPos;
+attribute vec3 iScale;
+attribute float iRot;
+attribute vec3 iColor;
+attribute float iGlow;
+attribute float iFade;
+
+varying vec3 vBary;
+varying vec3 vColor;
+varying float vGlow;
+varying float vFade;
+varying float vFog;
+varying vec3 vNormal;
+varying vec3 vViewDir;
+
+void main() {
+  vec3 p = position * iScale;
+  float c = cos(iRot), s = sin(iRot);
+  p = vec3(p.x * c + p.z * s, p.y, -p.x * s + p.z * c);
+  p += iPos;
+  float depth = max(0.0, -p.z);
+  p = voltaBend(p);
+
+  vec4 mv = modelViewMatrix * vec4(p, 1.0);
+  gl_Position = projectionMatrix * mv;
+
+  vec3 n = normal;
+  n = vec3(n.x * c + n.z * s, n.y, -n.x * s + n.z * c);
+  vNormal = n;
+  vViewDir = normalize(-mv.xyz);
+  vBary = bary;
+  vColor = iColor;
+  vGlow = iGlow;
+  vFade = iFade;
+  vFog = voltaFog(depth);
+}
+`;
+
+const SOLID_FRAG = /* glsl */ `
+${COMMON}
+${EDGE_GLSL}
+varying vec3 vBary;
+varying vec3 vColor;
+varying float vGlow;
+varying float vFade;
+varying float vFog;
+varying vec3 vNormal;
+varying vec3 vViewDir;
+
+uniform float uEdgeWidth;
+
+void main() {
+  if (vFade <= 0.004) discard;
+  vec3 n = normalize(vNormal);
+  float key = 0.30 + 0.70 * max(0.0, dot(n, normalize(vec3(0.35, 0.86, 0.36))));
+  float fill = 0.12 + 0.16 * max(0.0, dot(n, normalize(vec3(-0.5, 0.2, 0.84))));
+
+  // Fresnel rim: reads the silhouette even against a dark sky.
+  float rim = pow(1.0 - clamp(abs(dot(n, normalize(vViewDir))), 0.0, 1.0), 2.6);
+
+  vec3 body = uDeck * (key * 0.55 + fill) + vColor * rim * (0.35 + vGlow * 0.5);
+  float e = voltaEdge(vBary, uEdgeWidth);
+  vec3 neon = vColor * (1.15 + vGlow * 2.6);
+  vec3 col = mix(neon, body, e);
+
+  col = mix(col, uFogColor, vFog);
+  col += voltaDither(gl_FragCoord.xy);
+  gl_FragColor = vec4(col, vFade);
+}
+`;
+
+export class SolidField {
+  readonly mesh: THREE.Mesh;
+  readonly material: THREE.ShaderMaterial;
+  private geo: THREE.InstancedBufferGeometry;
+  private capacity: number;
+  private n = 0;
+  private aPos: THREE.InstancedBufferAttribute;
+  private aScale: THREE.InstancedBufferAttribute;
+  private aRot: THREE.InstancedBufferAttribute;
+  private aColor: THREE.InstancedBufferAttribute;
+  private aGlow: THREE.InstancedBufferAttribute;
+  private aFade: THREE.InstancedBufferAttribute;
+
+  constructor(base: THREE.BufferGeometry, capacity: number, shared: SharedUniforms, edgeWidth = 1.35) {
+    this.capacity = capacity;
+    const src = withBarycentric(base);
+    const geo = new THREE.InstancedBufferGeometry();
+    geo.index = src.index;
+    for (const key of ["position", "normal", "bary"]) {
+      const a = src.getAttribute(key);
+      if (a) geo.setAttribute(key, a);
+    }
+    const mk = (size: number) =>
+      new THREE.InstancedBufferAttribute(new Float32Array(capacity * size), size);
+    this.aPos = mk(3);
+    this.aScale = mk(3);
+    this.aRot = mk(1);
+    this.aColor = mk(3);
+    this.aGlow = mk(1);
+    this.aFade = mk(1);
+    geo.setAttribute("iPos", this.aPos);
+    geo.setAttribute("iScale", this.aScale);
+    geo.setAttribute("iRot", this.aRot);
+    geo.setAttribute("iColor", this.aColor);
+    geo.setAttribute("iGlow", this.aGlow);
+    geo.setAttribute("iFade", this.aFade);
+    geo.instanceCount = 0;
+    // Bounds are meaningless for a shader-bent instanced field; skip culling
+    // rather than let three cull the whole draw when the origin leaves frustum.
+    geo.boundingSphere = new THREE.Sphere(new THREE.Vector3(), 1e6);
+    this.geo = geo;
+
+    this.material = new THREE.ShaderMaterial({
+      uniforms: { ...shared, uEdgeWidth: { value: edgeWidth } },
+      vertexShader: SOLID_VERT,
+      fragmentShader: SOLID_FRAG,
+      transparent: true,
+      depthWrite: true,
+      side: THREE.DoubleSide,
+    });
+    this.mesh = new THREE.Mesh(geo, this.material);
+    this.mesh.frustumCulled = false;
+    this.mesh.matrixAutoUpdate = false;
+  }
+
+  begin(): void {
+    this.n = 0;
+  }
+
+  add(
+    x: number, y: number, z: number,
+    sx: number, sy: number, sz: number,
+    rot: number,
+    r: number, g: number, b: number,
+    glow: number, fade: number,
+  ): void {
+    const i = this.n;
+    if (i >= this.capacity) return;
+    const p = this.aPos.array as Float32Array;
+    const s = this.aScale.array as Float32Array;
+    const c = this.aColor.array as Float32Array;
+    p[i * 3] = x; p[i * 3 + 1] = y; p[i * 3 + 2] = z;
+    s[i * 3] = sx; s[i * 3 + 1] = sy; s[i * 3 + 2] = sz;
+    c[i * 3] = r; c[i * 3 + 1] = g; c[i * 3 + 2] = b;
+    (this.aRot.array as Float32Array)[i] = rot;
+    (this.aGlow.array as Float32Array)[i] = glow;
+    (this.aFade.array as Float32Array)[i] = fade;
+    this.n = i + 1;
+  }
+
+  end(): void {
+    this.geo.instanceCount = this.n;
+    if (this.n === 0) return;
+    this.aPos.needsUpdate = true;
+    this.aScale.needsUpdate = true;
+    this.aRot.needsUpdate = true;
+    this.aColor.needsUpdate = true;
+    this.aGlow.needsUpdate = true;
+    this.aFade.needsUpdate = true;
+  }
+
+  dispose(): void {
+    this.geo.dispose();
+    this.material.dispose();
+  }
+}
+
+/* ------------------------------- glow field ------------------------------- */
+
+const GLOW_VERT = /* glsl */ `
+${COMMON}
+attribute vec3 iPos;
+attribute vec3 iColor;
+attribute vec4 iParam;   // x size, y alpha, z stretch (y-axis), w kind
+
+varying vec2 vUv;
+varying vec3 vColor;
+varying float vAlpha;
+varying float vKind;
+varying float vFog;
+
+void main() {
+  vec3 wp = voltaBend(iPos);
+  vec4 mv = modelViewMatrix * vec4(wp, 1.0);
+  float depth = max(0.0, -iPos.z);
+  // Billboard in view space: cheap, always faces the camera, immune to roll.
+  mv.xy += position.xy * vec2(iParam.x, iParam.x * iParam.z);
+  gl_Position = projectionMatrix * mv;
+  vUv = uv;
+  vColor = iColor;
+  vAlpha = iParam.y;
+  vKind = iParam.w;
+  vFog = voltaFog(depth);
+}
+`;
+
+const GLOW_FRAG = /* glsl */ `
+${COMMON}
+varying vec2 vUv;
+varying vec3 vColor;
+varying float vAlpha;
+varying float vKind;
+varying float vFog;
+
+void main() {
+  vec2 d = vUv * 2.0 - 1.0;
+  float r = length(d);
+  float a;
+  if (vKind < 0.5) {
+    // Soft round glow with a hot core.
+    a = pow(max(0.0, 1.0 - r), 2.2) + pow(max(0.0, 1.0 - r), 12.0) * 0.9;
+  } else if (vKind < 1.5) {
+    // Ring / shockwave.
+    a = pow(max(0.0, 1.0 - abs(r - 0.82) * 7.0), 2.0);
+  } else if (vKind < 2.5) {
+    // Four-point star: reads as a collectible even at four pixels.
+    float cross = max(0.0, 1.0 - abs(d.x) * 9.0) + max(0.0, 1.0 - abs(d.y) * 9.0);
+    a = pow(max(0.0, 1.0 - r), 2.0) * (0.35 + cross * 0.8);
+  } else {
+    // Hard-edged bar: gate shards and deck slabs.
+    a = max(0.0, 1.0 - max(abs(d.x), abs(d.y)));
+    a = pow(a, 0.7);
+  }
+  a *= vAlpha * (1.0 - vFog * 0.92);
+  if (a <= 0.002) discard;
+  gl_FragColor = vec4(vColor * a, a);
+}
+`;
+
+export class GlowField {
+  readonly mesh: THREE.Mesh;
+  readonly material: THREE.ShaderMaterial;
+  private geo: THREE.InstancedBufferGeometry;
+  private capacity: number;
+  private n = 0;
+  private aPos: THREE.InstancedBufferAttribute;
+  private aColor: THREE.InstancedBufferAttribute;
+  private aParam: THREE.InstancedBufferAttribute;
+
+  constructor(capacity: number, shared: SharedUniforms, renderOrder = 10) {
+    this.capacity = capacity;
+    const quad = new THREE.PlaneGeometry(1, 1);
+    const geo = new THREE.InstancedBufferGeometry();
+    geo.index = quad.index;
+    geo.setAttribute("position", quad.getAttribute("position"));
+    geo.setAttribute("uv", quad.getAttribute("uv"));
+    this.aPos = new THREE.InstancedBufferAttribute(new Float32Array(capacity * 3), 3);
+    this.aColor = new THREE.InstancedBufferAttribute(new Float32Array(capacity * 3), 3);
+    this.aParam = new THREE.InstancedBufferAttribute(new Float32Array(capacity * 4), 4);
+    geo.setAttribute("iPos", this.aPos);
+    geo.setAttribute("iColor", this.aColor);
+    geo.setAttribute("iParam", this.aParam);
+    geo.instanceCount = 0;
+    geo.boundingSphere = new THREE.Sphere(new THREE.Vector3(), 1e6);
+    this.geo = geo;
+
+    this.material = new THREE.ShaderMaterial({
+      uniforms: { ...shared },
+      vertexShader: GLOW_VERT,
+      fragmentShader: GLOW_FRAG,
+      transparent: true,
+      depthWrite: false,
+      depthTest: true,
+      blending: THREE.AdditiveBlending,
+    });
+    this.mesh = new THREE.Mesh(geo, this.material);
+    this.mesh.frustumCulled = false;
+    this.mesh.matrixAutoUpdate = false;
+    this.mesh.renderOrder = renderOrder;
+  }
+
+  begin(): void {
+    this.n = 0;
+  }
+
+  /** kind: 0 soft, 1 ring, 2 star, 3 bar. */
+  add(
+    x: number, y: number, z: number,
+    size: number, alpha: number, stretch: number, kind: number,
+    r: number, g: number, b: number,
+  ): void {
+    const i = this.n;
+    if (i >= this.capacity) return;
+    const p = this.aPos.array as Float32Array;
+    const c = this.aColor.array as Float32Array;
+    const q = this.aParam.array as Float32Array;
+    p[i * 3] = x; p[i * 3 + 1] = y; p[i * 3 + 2] = z;
+    c[i * 3] = r; c[i * 3 + 1] = g; c[i * 3 + 2] = b;
+    q[i * 4] = size; q[i * 4 + 1] = alpha; q[i * 4 + 2] = stretch; q[i * 4 + 3] = kind;
+    this.n = i + 1;
+  }
+
+  get used(): number {
+    return this.n;
+  }
+  get free(): number {
+    return this.capacity - this.n;
+  }
+
+  end(): void {
+    this.geo.instanceCount = this.n;
+    if (this.n === 0) return;
+    this.aPos.needsUpdate = true;
+    this.aColor.needsUpdate = true;
+    this.aParam.needsUpdate = true;
+  }
+
+  dispose(): void {
+    this.geo.dispose();
+    this.material.dispose();
+  }
+}

--- a/dynawalla/games/runner/src/game/glyphs.test.ts
+++ b/dynawalla/games/runner/src/game/glyphs.test.ts
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { CHARS, COLS, ROWS, INK, TRACK, glyphIndex, fmt } from "./glyphs.ts";
+
+/**
+ * The atlas is the last thing between a correct answer and a child reading a
+ * different number than the one that was drawn.
+ */
+
+test("the character set exactly fills the atlas grid", () => {
+  assert.equal(CHARS.length, COLS * ROWS, `${CHARS.length} characters in a ${COLS}x${ROWS} atlas`);
+  assert.equal(new Set(CHARS).size, CHARS.length, "a character appears twice in the atlas");
+});
+
+test("every character an answer can contain has a cell", () => {
+  // The contract does not promise integers. `3/4`, `1.5` and `−7` are all
+  // legal answers, and every one has to survive the trip to the screen.
+  for (const ch of "0123456789/.−+×") {
+    assert.ok(CHARS.includes(ch), `"${ch}" has no glyph, so it would not be drawn`);
+  }
+});
+
+test("an unknown character is visibly wrong, never silently dropped", () => {
+  // This is the whole reason `glyphIndex` exists. Skipping the unknown glyph
+  // renders "3/4" as "34" — not an unreadable answer, a different one.
+  //
+  // The exotic cases are written as escapes rather than as literals: several are
+  // invisible in an editor, and a stray control character in a source file makes
+  // git treat the whole file as binary.
+  const q = glyphIndex("?");
+  assert.ok(q >= 0);
+  const strangers = [
+    "%",
+    "e",
+    "€", // euro sign
+    "\u0020", // plain space
+    "\u2009", // thin space — the stub host sets its prompts with these
+    "▢", // the missing-addend box
+    "÷", // division sign: it appears in prompts, which are DOM, not the atlas
+    "\u0000", // in case a host ever hands over a truncated string
+  ];
+  for (const ch of strangers) {
+    const cp = ch.codePointAt(0)!.toString(16).toUpperCase().padStart(4, "0");
+    assert.equal(glyphIndex(ch), q, `U+${cp} did not fall back to the question mark`);
+  }
+  for (let i = 0; i < CHARS.length; i++) {
+    assert.equal(glyphIndex(CHARS[i]), i, `"${CHARS[i]}" resolved to the wrong cell`);
+  }
+});
+
+test("the ink metrics are the ones the layout is tuned against", () => {
+  // `readband.test.ts` sweeps every viewport using these. If they drift, the
+  // legibility floors it asserts are floors on a font nobody ships.
+  assert.ok(INK > 0 && INK < 1, `INK ${INK} is not a fraction of a cell`);
+  assert.ok(TRACK >= 1 && TRACK < 1.5, `TRACK ${TRACK} is not gentle tracking`);
+});
+
+test("ASCII hyphen becomes the typographic minus the atlas has", () => {
+  assert.equal(fmt("-7"), "−7");
+  assert.equal(fmt("-1-2"), "−1−2");
+  assert.equal(fmt("42"), "42");
+  assert.equal(fmt(""), "");
+  // Already-typographic input must not be double-converted into nothing.
+  assert.equal(fmt("−7"), "−7");
+  for (const ch of fmt("-7")) assert.ok(CHARS.includes(ch), `fmt emitted "${ch}", which has no glyph`);
+});

--- a/dynawalla/games/runner/src/game/glyphs.ts
+++ b/dynawalla/games/runner/src/game/glyphs.ts
@@ -1,0 +1,62 @@
+/**
+ * The numeral character set, and the two metrics that turn a glyph into a size.
+ *
+ * This is a separate file from `digits.ts` for one reason: `digits.ts` builds
+ * its atlas on a `<canvas>`, so nothing in it can be imported by a test. The
+ * layout maths in `readband.ts` depends on these same two numbers, and a test
+ * that asserts legibility against a *copy* of them is a test that goes quiet the
+ * day someone retunes the real ones. So the constants live here, alone, with no
+ * imports at all, and both the renderer and the tests read them from here.
+ *
+ * `CHARS` is exactly `COLS × ROWS` cells of the atlas. Adding a character means
+ * enlarging the atlas grid, which is why the set is small and deliberate.
+ */
+
+/**
+ * Every character the world can draw, in atlas order.
+ *
+ * `/` and `.` are here because the contract lets a host answer with anything —
+ * `3/4`, `1.5` — and a numeral the atlas does not know used to be *silently
+ * skipped*: `3/4` rendered as `34`, which is not an unreadable answer, it is a
+ * different and wrong one. Anything still outside the set renders as `?`, which
+ * is visibly broken rather than quietly false.
+ */
+export const CHARS = "0123456789−+×?/.";
+
+/** The atlas grid. `CHARS.length` must equal `COLS * ROWS`. */
+export const COLS = 4;
+export const ROWS = 4;
+
+/**
+ * Fraction of a cell a digit's cap height actually occupies.
+ *
+ * The glyph is drawn at 0.74 of the cell and a digit's cap height is about 0.73
+ * of its font size, so the ink fills a little over half the quad. Without this
+ * factor every `h` in the renderer means "quad size" and a caller asking for a
+ * 2-unit numeral silently gets a 1.05-unit one — which is exactly how gate
+ * numerals ended up at eleven pixels. `h` means ink height, in world units.
+ */
+export const INK = 0.54;
+
+/** A whisker of tracking; tabular figures set solid are hard to scan at speed. */
+export const TRACK = 1.1;
+
+/** The cell index `?` occupies. Every unknown character falls back to it. */
+const UNKNOWN = CHARS.indexOf("?");
+
+/**
+ * Atlas cell for a character, never -1.
+ *
+ * A renderer that returns -1 has to decide what to do with it, and the cheap
+ * decision — skip the glyph — is the one that turns `3/4` into `34`. There is
+ * no such decision to make here.
+ */
+export function glyphIndex(ch: string): number {
+  const i = CHARS.indexOf(ch);
+  return i < 0 ? UNKNOWN : i;
+}
+
+/** Render ASCII hyphen-minus as the typographic minus the atlas actually has. */
+export function fmt(v: string): string {
+  return v.replace(/-/g, "−");
+}

--- a/dynawalla/games/runner/src/game/hud.ts
+++ b/dynawalla/games/runner/src/game/hud.ts
@@ -1,0 +1,363 @@
+/**
+ * The HUD, in DOM.
+ *
+ * The prompt is the single most-read thing in the game, so it is not a texture
+ * and not a billboard: it is text, at a fixed position, at whatever the
+ * device's native crispness is. It sits just above the horizon line so the eye
+ * travel between "what am I being asked" and "which lane says what" is short.
+ * Splitting those two across the screen is the difference between a game and an
+ * eye test.
+ *
+ * The register is instrument panel: hairlines, brackets, tabular figures, hard
+ * corners, uppercase. No cards, no gradients, no rounded boxes, nothing that
+ * reads as a worksheet or a settings app.
+ */
+
+const CSS = `
+.vt-root { position:absolute; inset:0; pointer-events:none; overflow:hidden;
+  font-family:"Archivo Black","Helvetica Neue","Arial Black","Segoe UI",system-ui,sans-serif;
+  font-weight:900; -webkit-font-smoothing:antialiased; text-transform:uppercase;
+  color:#eaf6ff; user-select:none; -webkit-user-select:none; }
+.vt-root * { box-sizing:border-box; }
+.vt-num { font-variant-numeric:tabular-nums; letter-spacing:0.01em; }
+
+/* ---- prompt ---- */
+.vt-prompt { position:absolute; left:50%; top:15%; transform:translate(-50%,0);
+  display:flex; align-items:center; gap:clamp(8px,2.2vw,18px); white-space:nowrap; }
+.vt-prompt-bar { width:clamp(10px,3vw,26px); height:clamp(3px,0.7vw,5px); background:currentColor;
+  opacity:0.55; }
+.vt-prompt-text { font-size:clamp(30px,7.4vw,72px); line-height:0.95; letter-spacing:0.005em;
+  text-shadow:0 0 22px rgba(0,0,0,0.85), 0 3px 0 rgba(0,0,0,0.55), 0 0 60px currentColor;
+  transform-origin:50% 50%; }
+.vt-prompt.vt-punch .vt-prompt-text { animation:vt-punch 0.34s cubic-bezier(.16,1.4,.4,1); }
+@keyframes vt-punch { 0%{transform:scale(1.55);opacity:0.25;} 45%{transform:scale(0.94);opacity:1;} 100%{transform:scale(1);} }
+
+/* ---- corners ---- */
+.vt-tl { position:absolute; left:clamp(10px,2.2vw,26px); top:clamp(10px,2.2vw,24px); }
+.vt-tr { position:absolute; right:clamp(10px,2.2vw,26px); top:clamp(10px,2.2vw,24px); text-align:right; }
+.vt-label { font-size:clamp(8px,1.5vw,11px); letter-spacing:0.28em; opacity:0.5; }
+/* Tracking adds a trailing space after the last letter, which right-aligned
+   text pushes off a narrow screen. Pull it back. */
+.vt-tr .vt-label { margin-right:-0.28em; }
+.vt-tr .vt-surge { margin-right:-0.02em; }
+.vt-score { font-size:clamp(24px,5.4vw,48px); line-height:1; text-shadow:0 2px 14px rgba(0,0,0,0.8); }
+.vt-dist { font-size:clamp(12px,2.4vw,19px); opacity:0.72; line-height:1.3; }
+
+.vt-surge { display:flex; align-items:baseline; justify-content:flex-end; gap:2px; }
+.vt-surge-x { font-size:clamp(14px,2.6vw,22px); opacity:0.6; }
+.vt-surge-n { font-size:clamp(28px,6.4vw,56px); line-height:1;
+  text-shadow:0 0 26px currentColor, 0 2px 12px rgba(0,0,0,0.85); }
+.vt-surge.vt-bump .vt-surge-n { animation:vt-bump 0.42s cubic-bezier(.16,1.5,.4,1); }
+@keyframes vt-bump { 0%{transform:scale(1.9) rotate(-5deg);} 60%{transform:scale(0.92);} 100%{transform:scale(1);} }
+.vt-chain { display:flex; gap:3px; justify-content:flex-end; margin-top:5px; }
+.vt-pip { width:clamp(7px,1.5vw,12px); height:clamp(3px,0.6vw,5px); background:currentColor; opacity:0.16; }
+.vt-pip.on { opacity:1; box-shadow:0 0 8px currentColor; }
+/* A committed read — already in the right lane before the gate came at you —
+   is worth two pips, and the meter says so. */
+.vt-chain.vt-clean .vt-pip { animation:vt-clean 0.5s ease-out; }
+@keyframes vt-clean { 0%{transform:scaleY(3.4); opacity:1;} 100%{transform:scaleY(1);} }
+
+/* ---- voltage ---- */
+.vt-volt { position:absolute; left:clamp(10px,2.2vw,26px); right:clamp(10px,2.2vw,26px);
+  bottom:clamp(12px,2.6vw,28px); height:clamp(9px,1.8vw,15px);
+  border:2px solid rgba(255,255,255,0.30); display:flex; align-items:stretch; padding:2px; }
+.vt-volt-fill { height:100%; width:100%; transform-origin:0 50%; transition:none;
+  box-shadow:0 0 18px currentColor; background:currentColor; }
+.vt-volt-ticks { position:absolute; inset:2px; display:flex; }
+.vt-volt-ticks i { flex:1; border-right:2px solid rgba(0,0,0,0.55); }
+.vt-volt-ticks i:last-child { border-right:0; }
+.vt-volt.vt-crit { animation:vt-crit 0.85s steps(2,end) infinite; }
+@keyframes vt-crit { 0%,60%{opacity:1;} 61%,100%{opacity:0.45;} }
+.vt-volt-label { position:absolute; left:0; bottom:calc(100% + 5px); font-size:clamp(8px,1.5vw,11px);
+  letter-spacing:0.28em; opacity:0.5; }
+
+/* ---- biome banner ---- */
+.vt-banner { position:absolute; left:0; right:0; top:38%; text-align:center; opacity:0;
+  font-size:clamp(20px,5.6vw,54px); letter-spacing:0.2em;
+  /* Paint-order stroke, not a glow: in the inverted biome the banner is dark
+     ink on bone and a same-colour glow just smears it. */
+  paint-order:stroke fill; -webkit-text-stroke:6px rgba(0,0,0,0.28);
+  text-shadow:0 0 40px currentColor; }
+.vt-banner.vt-show { animation:vt-banner 2.6s ease-out forwards; }
+@keyframes vt-banner {
+  0%{opacity:0; transform:scale(1.3) translateY(10px); letter-spacing:0.5em;}
+  14%{opacity:1; transform:scale(1); letter-spacing:0.2em;}
+  70%{opacity:1;} 100%{opacity:0; letter-spacing:0.34em;}
+}
+
+/* ---- overlays ---- */
+.vt-veil { position:absolute; inset:0; display:none; flex-direction:column; align-items:center;
+  justify-content:center; pointer-events:auto; padding:clamp(14px,4vw,40px);
+  background:radial-gradient(ellipse at 50% 45%, rgba(2,4,12,0.55) 0%, rgba(2,4,12,0.93) 72%); }
+.vt-veil.vt-on { display:flex; }
+.vt-title { font-size:clamp(38px,12vw,110px); line-height:0.86; letter-spacing:0.04em;
+  text-shadow:0 0 60px currentColor; }
+.vt-sub { font-size:clamp(11px,2.3vw,16px); letter-spacing:0.3em; opacity:0.62; margin-top:14px; text-align:center; }
+.vt-hint { font-size:clamp(10px,2vw,14px); letter-spacing:0.22em; opacity:0.45; margin-top:26px; text-align:center; line-height:2; }
+/* background:currentColor only works while color is still the inherited accent
+   — setting color on the button itself paints it black on black. The label
+   carries its own dark colour instead. */
+.vt-btn { pointer-events:auto; margin-top:26px; padding:clamp(12px,2.6vw,20px) clamp(26px,7vw,64px);
+  font:inherit; font-size:clamp(15px,3.4vw,26px); letter-spacing:0.18em; text-transform:uppercase;
+  background:currentColor; border:0; cursor:pointer; box-shadow:0 0 40px currentColor; }
+.vt-btn span { color:#04060f; }
+.vt-btn:active { transform:translateY(2px); }
+.vt-btn:focus-visible { outline:3px solid #fff; outline-offset:3px; }
+
+/* ---- recharge gate ----
+   This screen is where a child decides whether to keep playing, so it is the
+   last place in the game that should look like a dialog box. It used to drop to
+   a flat near-black panel and the run visibly died behind it. Now the causeway
+   keeps rushing past in full colour through a thin scrim, the whole rig is lit
+   in the current biome's accent, and the three answers are built out of the same
+   posts-and-lintel the gates out on the track are. It is a gate, indoors. */
+.vt-veil[data-v="revive"] {
+  background:
+    linear-gradient(180deg, rgba(3,7,18,0.82) 0%, rgba(3,7,18,0.16) 26%,
+                            rgba(3,7,18,0.16) 52%, rgba(3,7,18,0.88) 82%),
+    radial-gradient(ellipse at 50% 42%, rgba(0,0,0,0) 40%, rgba(2,5,14,0.55) 100%);
+  justify-content:flex-end; padding-bottom:clamp(20px,5vh,54px); }
+/* A charge front sweeping up the screen. Slow, wide, low-contrast: energy, not
+   a strobe — 4.2s per pass is far under any flash threshold. */
+.vt-veil[data-v="revive"]::before { content:""; position:absolute; left:0; right:0; height:36%;
+  background:linear-gradient(0deg, transparent, var(--vt-accent, #6cf) 55%, transparent);
+  opacity:0.13; animation:vt-charge 4.2s linear infinite; pointer-events:none; }
+@keyframes vt-charge { 0%{transform:translateY(120%);} 100%{transform:translateY(-160%);} }
+
+.vt-charge { display:flex; align-items:center; gap:clamp(10px,2.4vw,20px); margin-bottom:clamp(6px,1.4vh,14px); }
+.vt-charge-label { font-size:clamp(11px,2.3vw,16px); letter-spacing:0.34em; opacity:0.8;
+  color:var(--vt-accent, currentColor); text-shadow:0 0 22px currentColor; }
+.vt-revive-prompt { font-size:clamp(36px,9.6vw,88px); line-height:1; margin:2px 0 clamp(14px,2.4vh,28px);
+  paint-order:stroke fill; -webkit-text-stroke:8px rgba(2,5,14,0.6);
+  text-shadow:0 0 46px var(--vt-accent, currentColor); }
+
+.vt-lanes { display:flex; gap:clamp(10px,2.6vw,22px); width:100%; max-width:820px; }
+.vt-lane { pointer-events:auto; position:relative; flex:1; min-width:0; aspect-ratio:3/2.5;
+  border:0; border-left:clamp(4px,0.9vw,7px) solid var(--vt-accent, #6cf);
+  border-right:clamp(4px,0.9vw,7px) solid var(--vt-accent, #6cf);
+  background:linear-gradient(180deg, rgba(255,255,255,0.10), rgba(4,10,22,0.30) 55%, rgba(4,10,22,0.62));
+  color:inherit; font:inherit; cursor:pointer; overflow:hidden;
+  font-size:clamp(30px,8.6vw,66px); display:flex; align-items:center; justify-content:center;
+  font-variant-numeric:tabular-nums; letter-spacing:0.01em;
+  box-shadow:0 0 32px -6px var(--vt-accent, #6cf), inset 0 0 40px -14px var(--vt-accent, #6cf); }
+/* The lintel: the same overhead bar the gates on the causeway wear. */
+.vt-lane::before { content:""; position:absolute; left:calc(-1 * clamp(4px,0.9vw,7px));
+  right:calc(-1 * clamp(4px,0.9vw,7px)); top:0; height:clamp(7px,1.5vw,11px);
+  background:var(--vt-accent, #6cf); box-shadow:0 0 24px var(--vt-accent, #6cf); }
+.vt-lane::after { content:""; position:absolute; left:0; right:0; bottom:0; height:2px;
+  background:var(--vt-accent, #6cf); opacity:0.45; }
+.vt-lane span { position:relative; text-shadow:0 0 30px rgba(0,0,0,0.9), 0 3px 0 rgba(0,0,0,0.55); }
+.vt-lane:active { transform:translateY(3px); }
+.vt-lane:focus-visible { outline:3px solid #fff; outline-offset:4px; }
+.vt-lane.vt-right { background:var(--vt-accent, #6cf); box-shadow:0 0 70px var(--vt-accent, #6cf); }
+.vt-lane.vt-right span { color:#04060f; text-shadow:none; }
+.vt-lane.vt-wrong { opacity:0.22; }
+.vt-ring { width:clamp(52px,11vw,84px); height:clamp(52px,11vw,84px); }
+.vt-ring circle { fill:none; stroke-width:9; }
+.vt-ring .bg { stroke:rgba(255,255,255,0.16); }
+.vt-ring .fg { stroke:currentColor; stroke-linecap:butt; transform:rotate(-90deg); transform-origin:50% 50%;
+  filter:drop-shadow(0 0 10px currentColor); }
+
+/* ---- stats / summary ---- */
+.vt-stats { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:clamp(8px,2vw,20px) clamp(20px,6vw,64px);
+  margin-top:clamp(16px,3vw,30px); }
+.vt-stat { text-align:left; }
+.vt-stat b { display:block; font-size:clamp(20px,5vw,40px); line-height:1; font-variant-numeric:tabular-nums; }
+.vt-stat i { display:block; font-style:normal; font-size:clamp(8px,1.6vw,11px); letter-spacing:0.26em; opacity:0.5; margin-top:5px; }
+
+/* ---- settings ---- */
+.vt-tools { position:absolute; right:clamp(10px,2.2vw,26px); bottom:clamp(34px,6vw,58px);
+  display:flex; gap:6px; pointer-events:auto; }
+.vt-tool { width:clamp(30px,6vw,40px); height:clamp(30px,6vw,40px); border:2px solid rgba(255,255,255,0.28);
+  background:rgba(2,5,14,0.55); color:inherit; font:inherit; font-size:clamp(11px,2.2vw,14px);
+  cursor:pointer; display:flex; align-items:center; justify-content:center; padding:0; }
+.vt-tool[aria-pressed="true"] { background:currentColor; }
+.vt-tool[aria-pressed="true"] span { color:#04060f; }
+.vt-tool:focus-visible { outline:3px solid #fff; outline-offset:2px; }
+.vt-perf { position:absolute; left:clamp(10px,2.2vw,26px); bottom:clamp(58px,10vw,96px);
+  font-size:11px; letter-spacing:0.1em; opacity:0.6; white-space:pre; display:none;
+  font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-weight:400; text-transform:none; }
+.vt-perf.vt-on { display:block; }
+
+@keyframes vt-banner-rm { 0%{opacity:0;} 12%{opacity:1;} 72%{opacity:1;} 100%{opacity:0;} }
+/* Reduced motion, whether the OS asked or the in-game toggle did. Information
+   is preserved — the punch becomes a hold, the crit blink becomes an outline. */
+@media (prefers-reduced-motion: reduce) {
+  .vt-prompt.vt-punch .vt-prompt-text, .vt-surge.vt-bump .vt-surge-n { animation:none; }
+  .vt-banner.vt-show { animation:vt-banner-rm 2.6s ease-out forwards; }
+  .vt-volt.vt-crit { animation:none; outline:3px solid currentColor; outline-offset:3px; }
+  .vt-chain.vt-clean .vt-pip { animation:none; }
+  /* The sweep becomes a still wash: same "this rig is live" reading, no travel. */
+  .vt-veil[data-v="revive"]::before { animation:none; transform:translateY(-40%); opacity:0.1; }
+}
+/* An overlay owns the screen. The in-run prompt behind a revive gate is pure
+   collision — two different questions on top of each other. */
+.vt-root.vt-veiled .vt-prompt, .vt-root.vt-veiled .vt-tl, .vt-root.vt-veiled .vt-tr,
+.vt-root.vt-veiled .vt-volt, .vt-root.vt-veiled .vt-tools, .vt-root.vt-veiled .vt-banner {
+  opacity:0; transition:opacity 0.18s ease; }
+.vt-root.vt-rm .vt-prompt.vt-punch .vt-prompt-text,
+.vt-root.vt-rm .vt-surge.vt-bump .vt-surge-n { animation:none; }
+.vt-root.vt-rm .vt-banner.vt-show { animation:vt-banner-rm 2.6s ease-out forwards; }
+.vt-root.vt-rm .vt-volt.vt-crit { animation:none; outline:3px solid currentColor; outline-offset:3px; }
+.vt-root.vt-rm .vt-chain.vt-clean .vt-pip { animation:none; }
+.vt-root.vt-rm .vt-veil[data-v="revive"]::before { animation:none; transform:translateY(-40%); opacity:0.1; }
+`;
+
+export type HudRefs = {
+  root: HTMLDivElement;
+  /**
+   * The stylesheet, which is a *sibling* of `root` rather than a child.
+   *
+   * Handed back so `unmount()` can remove it. It used to be left behind, and a
+   * host that swaps packs would accumulate one dead `<style>` per mount — each
+   * still claiming every `.vt-root` rule, so the leftovers styled the next mount
+   * too.
+   */
+  style: HTMLStyleElement;
+  prompt: HTMLDivElement;
+  promptText: HTMLDivElement;
+  score: HTMLDivElement;
+  dist: HTMLDivElement;
+  surge: HTMLDivElement;
+  surgeN: HTMLDivElement;
+  chain: HTMLDivElement;
+  volt: HTMLDivElement;
+  voltFill: HTMLDivElement;
+  banner: HTMLDivElement;
+  start: HTMLDivElement;
+  revive: HTMLDivElement;
+  revivePrompt: HTMLDivElement;
+  reviveLanes: HTMLButtonElement[];
+  reviveRing: SVGCircleElement;
+  reviveCount: HTMLDivElement;
+  over: HTMLDivElement;
+  overStats: HTMLDivElement;
+  startBtn: HTMLButtonElement;
+  againBtn: HTMLButtonElement;
+  soundBtn: HTMLButtonElement;
+  motionBtn: HTMLButtonElement;
+  perf: HTMLDivElement;
+};
+
+const RING_R = 42;
+const RING_C = 2 * Math.PI * RING_R;
+
+export function buildHud(host: HTMLElement): HudRefs {
+  const style = document.createElement("style");
+  style.textContent = CSS;
+  host.appendChild(style);
+
+  const root = document.createElement("div");
+  root.className = "vt-root";
+  root.innerHTML = `
+    <div class="vt-prompt"><div class="vt-prompt-bar"></div><div class="vt-prompt-text vt-num">—</div><div class="vt-prompt-bar"></div></div>
+
+    <div class="vt-tl">
+      <div class="vt-label">Score</div>
+      <div class="vt-score vt-num">0</div>
+      <div class="vt-dist vt-num">0 m</div>
+    </div>
+
+    <div class="vt-tr">
+      <div class="vt-label">Surge</div>
+      <div class="vt-surge"><div class="vt-surge-x">&times;</div><div class="vt-surge-n vt-num">1</div></div>
+      <div class="vt-chain"></div>
+    </div>
+
+    <div class="vt-volt">
+      <div class="vt-volt-label">Voltage</div>
+      <div class="vt-volt-fill"></div>
+      <div class="vt-volt-ticks"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+    </div>
+
+    <div class="vt-banner"></div>
+
+    <div class="vt-tools">
+      <button class="vt-tool" data-a="sound" aria-pressed="true" title="Sound"><span>&#9835;</span></button>
+      <button class="vt-tool" data-a="motion" aria-pressed="false" title="Reduce motion"><span>&#8767;</span></button>
+    </div>
+    <div class="vt-perf"></div>
+
+    <div class="vt-veil" data-v="start">
+      <div class="vt-title">VOLTA</div>
+      <div class="vt-sub">Pick the lane that is right</div>
+      <button class="vt-btn" data-a="start"><span>Run</span></button>
+      <div class="vt-hint">Swipe or tap left / right to switch lane<br>Swipe up to jump &middot; swipe down to slide<br>Keyboard: arrows or W A S D</div>
+    </div>
+
+    <div class="vt-veil" data-v="revive">
+      <div class="vt-charge">
+        <svg class="vt-ring" viewBox="0 0 100 100" aria-hidden="true">
+          <circle class="bg" cx="50" cy="50" r="${RING_R}"></circle>
+          <circle class="fg" cx="50" cy="50" r="${RING_R}" stroke-dasharray="${RING_C}" stroke-dashoffset="0"></circle>
+        </svg>
+        <div class="vt-charge-label">Recharge</div>
+      </div>
+      <div class="vt-revive-prompt vt-num">—</div>
+      <div class="vt-lanes">
+        <button class="vt-lane" data-l="0"><span class="vt-num"></span></button>
+        <button class="vt-lane" data-l="1"><span class="vt-num"></span></button>
+        <button class="vt-lane" data-l="2"><span class="vt-num"></span></button>
+      </div>
+      <div class="vt-hint" data-v="revive-count"></div>
+    </div>
+
+    <div class="vt-veil" data-v="over">
+      <div class="vt-title">RUN OVER</div>
+      <div class="vt-stats"></div>
+      <button class="vt-btn" data-a="again"><span>Run again</span></button>
+    </div>
+  `;
+  host.appendChild(root);
+
+  const q = <T extends Element>(sel: string) => root.querySelector(sel) as T;
+  const chain = q<HTMLDivElement>(".vt-chain");
+  // Three pips: three clean gates buys the next multiplier. Short enough that a
+  // child sees the reward loop close inside the first twenty seconds.
+  for (let i = 0; i < 3; i++) {
+    const pip = document.createElement("div");
+    pip.className = "vt-pip";
+    chain.appendChild(pip);
+  }
+
+  return {
+    root,
+    style,
+    prompt: q(".vt-prompt"),
+    promptText: q(".vt-prompt-text"),
+    score: q(".vt-score"),
+    dist: q(".vt-dist"),
+    surge: q(".vt-surge"),
+    surgeN: q(".vt-surge-n"),
+    chain,
+    volt: q(".vt-volt"),
+    voltFill: q(".vt-volt-fill"),
+    banner: q(".vt-banner"),
+    start: q('[data-v="start"]'),
+    revive: q('[data-v="revive"]'),
+    revivePrompt: q(".vt-revive-prompt"),
+    reviveLanes: Array.from(root.querySelectorAll<HTMLButtonElement>(".vt-lane")),
+    reviveRing: q<SVGCircleElement>(".vt-ring .fg"),
+    reviveCount: q('[data-v="revive-count"]'),
+    over: q('[data-v="over"]'),
+    overStats: q(".vt-stats"),
+    startBtn: q('[data-a="start"]'),
+    againBtn: q('[data-a="again"]'),
+    soundBtn: q('[data-a="sound"]'),
+    motionBtn: q('[data-a="motion"]'),
+    perf: q(".vt-perf"),
+  };
+}
+
+export const ringCircumference = RING_C;
+
+/** 12345 -> "12 345". Thin spaces, not commas: locale-neutral and legible. */
+export function groupDigits(n: number): string {
+  const s = Math.round(n).toString();
+  let out = "";
+  for (let i = 0; i < s.length; i++) {
+    if (i > 0 && (s.length - i) % 3 === 0) out += " ";
+    out += s[i];
+  }
+  return out;
+}

--- a/dynawalla/games/runner/src/game/input.ts
+++ b/dynawalla/games/runner/src/game/input.ts
@@ -1,0 +1,188 @@
+/**
+ * Input.
+ *
+ * Two rules make a runner feel responsive, and both are about *when* an intent
+ * fires rather than what it does:
+ *
+ *  1. A swipe fires the instant the finger crosses the threshold — never on
+ *     lift. Waiting for pointerup adds ~120ms of pure lag and is the single
+ *     biggest reason a homemade runner feels wrong next to Subway Surfers.
+ *  2. Intents are *buffered*, not dropped. Pressing left again while a lane
+ *     change is still animating queues the second move instead of eating it.
+ *
+ * After a swipe fires, the gesture origin is reset to the current point, so a
+ * long drag can chain left-left-up without lifting the finger.
+ */
+
+export type Intent = "left" | "right" | "jump" | "slide";
+
+type Buffered = { intent: Intent; at: number };
+
+const KEY_MAP: Record<string, Intent> = {
+  ArrowLeft: "left",
+  KeyA: "left",
+  ArrowRight: "right",
+  KeyD: "right",
+  ArrowUp: "jump",
+  KeyW: "jump",
+  Space: "jump",
+  ArrowDown: "slide",
+  KeyS: "slide",
+};
+
+export class InputController {
+  /** How long an unconsumed intent stays valid. */
+  bufferMs = 145;
+  /**
+   * Milliseconds between the DOM event that expressed an intent and the frame
+   * that acted on it. This is the number that decides whether the game feels
+   * responsive, so it is measured rather than assumed.
+   */
+  lastLatencyMs = 0;
+
+  private el: HTMLElement;
+  private queue: Buffered[] = [];
+  private pool: Buffered[] = [];
+  private pointerId: number | null = null;
+  private ox = 0;
+  private oy = 0;
+  private startX = 0;
+  private startY = 0;
+  private startT = 0;
+  private threshold = 30;
+  private onAnyInput: () => void;
+  private disposed = false;
+  private paused = false;
+
+  /** Set true while a modal owns input; gestures are ignored but keys still reach the DOM. */
+  setPaused(v: boolean): void {
+    this.paused = v;
+    if (v) this.queue.length = 0;
+  }
+
+  constructor(el: HTMLElement, onAnyInput: () => void) {
+    this.el = el;
+    this.onAnyInput = onAnyInput;
+    this.recomputeThreshold();
+
+    el.addEventListener("pointerdown", this.down, { passive: false });
+    el.addEventListener("pointermove", this.move, { passive: false });
+    el.addEventListener("pointerup", this.up, { passive: false });
+    el.addEventListener("pointercancel", this.up, { passive: false });
+    window.addEventListener("keydown", this.key);
+    window.addEventListener("resize", this.recomputeThreshold);
+  }
+
+  private recomputeThreshold = (): void => {
+    // ~6% of the short edge, clamped. Small phones need a small threshold or
+    // every swipe becomes a drag; big tablets need a large one or every scroll
+    // becomes a swipe.
+    const min = Math.min(window.innerWidth, window.innerHeight);
+    this.threshold = Math.max(20, Math.min(52, min * 0.055));
+  };
+
+  private push(intent: Intent): void {
+    const b = this.pool.pop() ?? { intent, at: 0 };
+    b.intent = intent;
+    b.at = performance.now();
+    // Two of the same lane-move can legitimately queue (lane 0 -> 2). Cap the
+    // depth so a mashed key does not schedule a five-second automaton.
+    if (this.queue.length >= 2) this.pool.push(this.queue.shift()!);
+    this.queue.push(b);
+    this.onAnyInput();
+  }
+
+  private down = (e: PointerEvent): void => {
+    if (this.paused) return;
+    if (this.pointerId !== null) return;
+    this.pointerId = e.pointerId;
+    this.ox = this.startX = e.clientX;
+    this.oy = this.startY = e.clientY;
+    this.startT = performance.now();
+    this.el.setPointerCapture?.(e.pointerId);
+    e.preventDefault();
+    this.onAnyInput();
+  };
+
+  private move = (e: PointerEvent): void => {
+    if (this.paused || e.pointerId !== this.pointerId) return;
+    e.preventDefault();
+    const dx = e.clientX - this.ox;
+    const dy = e.clientY - this.oy;
+    const adx = Math.abs(dx);
+    const ady = Math.abs(dy);
+    if (adx < this.threshold && ady < this.threshold) return;
+    if (adx > ady) {
+      this.push(dx > 0 ? "right" : "left");
+    } else {
+      this.push(dy < 0 ? "jump" : "slide");
+    }
+    // Chain: the next swipe measures from here, no lift required.
+    this.ox = e.clientX;
+    this.oy = e.clientY;
+  };
+
+  private up = (e: PointerEvent): void => {
+    if (e.pointerId !== this.pointerId) return;
+    this.pointerId = null;
+    if (this.paused) return;
+    const dx = e.clientX - this.startX;
+    const dy = e.clientY - this.startY;
+    const dist = Math.hypot(dx, dy);
+    const dur = performance.now() - this.startT;
+    // A tap is a lane move toward the side you tapped. Small hands should never
+    // have to swipe across a 12" tablet.
+    if (dist < 14 && dur < 260) {
+      const r = this.el.getBoundingClientRect();
+      this.push(e.clientX - r.left < r.width * 0.5 ? "left" : "right");
+    }
+  };
+
+  private key = (e: KeyboardEvent): void => {
+    if (e.repeat) return;
+    const intent = KEY_MAP[e.code];
+    if (!intent) return;
+    if (e.code === "Space" || e.code.startsWith("Arrow")) e.preventDefault();
+    if (this.paused) {
+      // Modal screens read keys directly; still wake the audio context.
+      this.onAnyInput();
+      return;
+    }
+    this.push(intent);
+  };
+
+  /**
+   * Take the oldest still-valid intent matching `accept`, dropping anything
+   * that has aged out. Returns null when there is nothing to do.
+   */
+  consume(accept: (i: Intent) => boolean): Intent | null {
+    const now = performance.now();
+    while (this.queue.length) {
+      const head = this.queue[0];
+      if (now - head.at > this.bufferMs) {
+        this.pool.push(this.queue.shift()!);
+        continue;
+      }
+      if (!accept(head.intent)) return null;
+      this.lastLatencyMs = now - head.at;
+      this.pool.push(this.queue.shift()!);
+      return head.intent;
+    }
+    return null;
+  }
+
+  clear(): void {
+    while (this.queue.length) this.pool.push(this.queue.pop()!);
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.el.removeEventListener("pointerdown", this.down);
+    this.el.removeEventListener("pointermove", this.move);
+    this.el.removeEventListener("pointerup", this.up);
+    this.el.removeEventListener("pointercancel", this.up);
+    window.removeEventListener("keydown", this.key);
+    window.removeEventListener("resize", this.recomputeThreshold);
+  }
+}

--- a/dynawalla/games/runner/src/game/juice.test.ts
+++ b/dynawalla/games/runner/src/game/juice.test.ts
@@ -1,0 +1,133 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { FlashBus, Shake, HitStop, Springy, approach, clamp01, easeOutQuint } from "./juice.ts";
+
+/**
+ * The accessibility guarantees are behaviour, not documentation. A future
+ * change that makes the game flash faster than three times a second, or that
+ * lets screen shake survive `prefers-reduced-motion`, should fail here rather
+ * than in front of a child.
+ */
+
+/** Drive a bus at 60fps for `seconds`, requesting a full flash `hz` times/sec. */
+function driveFlash(hz: number, seconds: number, reduced = false) {
+  const bus = new FlashBus();
+  const dt = 1 / 60;
+  const samples: number[] = [];
+  let sinceFire = Infinity;
+  for (let i = 0; i < seconds * 60; i++) {
+    sinceFire += dt;
+    if (sinceFire >= 1 / hz) {
+      sinceFire = 0;
+      bus.fire(1, [1, 1, 1], reduced);
+    }
+    bus.update(dt);
+    samples.push(bus.value);
+  }
+  return samples;
+}
+
+test("flashes are rate-limited well under the photosensitivity threshold", () => {
+  // Count rising edges that cross a perceptible amplitude. WCAG's general flash
+  // threshold is three per second; anything at or above 0.25 full-screen
+  // luminance counts as one for our purposes.
+  const samples = driveFlash(20, 3);
+  let crossings = 0;
+  let above = false;
+  for (const v of samples) {
+    if (!above && v > 0.25) { crossings++; above = true; }
+    if (above && v < 0.12) above = false;
+  }
+  assert.ok(crossings <= 9, `${crossings} perceptible flashes in 3 seconds (limit 9)`);
+});
+
+test("a rapid burst is attenuated rather than dropped", () => {
+  // Information must survive; brightness need not. Fire ten times in a tenth of
+  // a second and the bus should still be lit, just quietly.
+  const bus = new FlashBus();
+  for (let i = 0; i < 10; i++) {
+    bus.fire(1, [1, 1, 1], false);
+    bus.update(1 / 600);
+  }
+  assert.ok(bus.value > 0, "a burst of events left the screen completely dark");
+  assert.ok(bus.value < 0.6, `burst reached ${bus.value.toFixed(2)}, which is a strobe`);
+});
+
+test("a flash rises over at least ~90ms, never as a single-frame stab", () => {
+  const bus = new FlashBus();
+  bus.fire(1, [1, 1, 1], false);
+  bus.update(1 / 60);
+  assert.ok(bus.value < 0.35, `one frame after firing the screen was at ${bus.value.toFixed(2)}`);
+});
+
+test("reduced motion halves flash amplitude", () => {
+  const normal = Math.max(...driveFlash(1, 1, false));
+  const reduced = Math.max(...driveFlash(1, 1, true));
+  assert.ok(reduced < normal * 0.6, `reduced ${reduced.toFixed(2)} vs normal ${normal.toFixed(2)}`);
+});
+
+test("screen shake is fully suppressed under reduced motion", () => {
+  const s = new Shake();
+  for (let i = 0; i < 40; i++) {
+    s.add(1);
+    s.update(1 / 60, true);
+    assert.equal(s.x, 0);
+    assert.equal(s.y, 0);
+    assert.equal(s.roll, 0);
+  }
+});
+
+test("screen shake decays to nothing and never runs away", () => {
+  const s = new Shake();
+  for (let i = 0; i < 200; i++) s.add(1); // absurd trauma
+  assert.ok(s.trauma <= 1, "trauma exceeded 1");
+  let maxOffset = 0;
+  for (let i = 0; i < 120; i++) {
+    s.update(1 / 60, false);
+    maxOffset = Math.max(maxOffset, Math.abs(s.x), Math.abs(s.y));
+  }
+  assert.ok(maxOffset < 1.2, `shake reached ${maxOffset.toFixed(2)} world units`);
+  assert.equal(s.trauma, 0, "shake never settled");
+});
+
+test("hitstop slows time briefly and always releases", () => {
+  const h = new HitStop();
+  h.hit(0.1, 0.06);
+  assert.ok(h.scale(1 / 60) < 0.2, "hitstop did not bite");
+  let frames = 0;
+  while (h.active && frames < 600) { h.scale(1 / 60); frames++; }
+  assert.ok(frames < 12, `hitstop lasted ${frames} frames`);
+  assert.equal(h.scale(1 / 60), 1, "time did not resume at full speed");
+});
+
+test("springs settle and survive a long frame without exploding", () => {
+  const s = new Springy(0, 150, 18);
+  s.target = 10;
+  for (let i = 0; i < 240; i++) s.update(1 / 60);
+  assert.ok(Math.abs(s.value - 10) < 0.05, `spring settled at ${s.value}`);
+
+  const rough = new Springy(0, 150, 18);
+  rough.target = 10;
+  rough.update(0.5); // a half-second hitch
+  assert.ok(Number.isFinite(rough.value) && Math.abs(rough.value) < 40, `spring blew up to ${rough.value}`);
+});
+
+test("easing and approach helpers stay in range", () => {
+  for (let t = 0; t <= 1.0001; t += 0.01) {
+    const v = easeOutQuint(t);
+    assert.ok(v >= -1e-9 && v <= 1 + 1e-9, `easeOutQuint(${t}) = ${v}`);
+  }
+  assert.equal(easeOutQuint(0), 0);
+  assert.equal(easeOutQuint(1), 1);
+  assert.equal(clamp01(-5), 0);
+  assert.equal(clamp01(5), 1);
+
+  let v = 0;
+  for (let i = 0; i < 600; i++) v = approach(v, 100, 8, 1 / 60);
+  assert.ok(Math.abs(v - 100) < 0.01);
+  // Frame-rate independence: the same elapsed time gets the same result.
+  let a = 0, b = 0;
+  for (let i = 0; i < 60; i++) a = approach(a, 100, 4, 1 / 60);
+  for (let i = 0; i < 10; i++) b = approach(b, 100, 4, 1 / 10);
+  assert.ok(Math.abs(a - b) < 1, `60fps ${a.toFixed(2)} vs 10fps ${b.toFixed(2)}`);
+});

--- a/dynawalla/games/runner/src/game/juice.ts
+++ b/dynawalla/games/runner/src/game/juice.ts
@@ -1,0 +1,198 @@
+/**
+ * Feel primitives, straight off Jan Willem Nijman's "Art of Screenshake" list.
+ * Named here so the technique is auditable rather than vibes:
+ *
+ *   screenshake (trauma-squared, decaying)  · camera kick   · sleep / hitstop
+ *   easing + tweening                       · squash&stretch· recoil
+ *   speed lines                             · permanence    · sound variety
+ *
+ * Everything here answers to `reduced`, which is not a dimmer switch: it
+ * removes camera motion entirely and routes the same information through
+ * colour-plus-shape overlays that do not move.
+ */
+
+/* ---------------------------------- easing --------------------------------- */
+
+export const clamp = (v: number, a: number, b: number) => (v < a ? a : v > b ? b : v);
+export const clamp01 = (v: number) => (v < 0 ? 0 : v > 1 ? 1 : v);
+export const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+export const easeOutQuint = (t: number) => 1 - Math.pow(1 - t, 5);
+export const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3);
+export const easeInCubic = (t: number) => t * t * t;
+export const easeOutBack = (t: number) => {
+  const c = 2.2;
+  const u = t - 1;
+  return 1 + (c + 1) * u * u * u + c * u * u;
+};
+export const easeOutElastic = (t: number) => {
+  if (t <= 0) return 0;
+  if (t >= 1) return 1;
+  const p = (2 * Math.PI) / 3;
+  return Math.pow(2, -9 * t) * Math.sin((t * 10 - 0.75) * p) + 1;
+};
+/** Frame-rate independent exponential approach. `rate` is roughly 1/seconds. */
+export const approach = (cur: number, target: number, rate: number, dt: number) =>
+  cur + (target - cur) * (1 - Math.exp(-rate * dt));
+
+/* ------------------------------- screenshake ------------------------------- */
+
+/** Cheap smooth pseudo-noise; three incommensurate sines beat a lookup table. */
+function wobble(t: number, seed: number): number {
+  return (
+    Math.sin(t * 27.3 + seed * 5.1) * 0.55 +
+    Math.sin(t * 11.9 + seed * 12.7) * 0.31 +
+    Math.sin(t * 47.1 + seed * 3.3) * 0.14
+  );
+}
+
+export class Shake {
+  /** 0..1. Shake amplitude is trauma^2 so small hits stay quiet. */
+  trauma = 0;
+  decay = 1.9;
+  x = 0;
+  y = 0;
+  roll = 0;
+  private t = 0;
+
+  add(amount: number): void {
+    this.trauma = clamp01(this.trauma + amount);
+  }
+
+  update(dt: number, reduced: boolean, intensity = 1): void {
+    this.t += dt;
+    this.trauma = Math.max(0, this.trauma - this.decay * dt);
+    if (reduced || this.trauma <= 0) {
+      this.x = 0;
+      this.y = 0;
+      this.roll = 0;
+      return;
+    }
+    const s = this.trauma * this.trauma * intensity;
+    this.x = wobble(this.t, 1) * s * 0.62;
+    this.y = wobble(this.t, 2) * s * 0.44;
+    this.roll = wobble(this.t, 3) * s * 0.075;
+  }
+}
+
+/* ---------------------------------- hitstop -------------------------------- */
+
+/**
+ * "Sleep": a few frames of near-freeze on impact. Never a true zero — a real
+ * zero reads as a dropped frame, a 6% crawl reads as weight.
+ */
+export class HitStop {
+  private remaining = 0;
+  private strength = 0.06;
+
+  hit(seconds: number, strength = 0.06): void {
+    this.remaining = Math.max(this.remaining, seconds);
+    this.strength = strength;
+  }
+
+  /** Returns the time-scale to apply this frame. */
+  scale(dt: number): number {
+    if (this.remaining <= 0) return 1;
+    this.remaining -= dt;
+    return this.strength;
+  }
+
+  get active(): boolean {
+    return this.remaining > 0;
+  }
+}
+
+/* ----------------------------------- flash --------------------------------- */
+
+export type FlashColor = readonly [number, number, number];
+
+/**
+ * Full-viewport luminance changes, rate-limited.
+ *
+ * This is a children's product, so the WCAG general-flash threshold is a hard
+ * ceiling and not a guideline: at most three flashes per second, each with a
+ * rise and fall of at least ~90ms, and amplitude is scaled *down* when requests
+ * arrive faster rather than being dropped (a dropped flash loses information;
+ * a quiet one does not).
+ */
+export class FlashBus {
+  private level = 0;
+  private target = 0;
+  private col: [number, number, number] = [1, 1, 1];
+  private stamps: number[] = [];
+  private now = 0;
+  /** Longest a single flash may take to rise, in seconds. */
+  private static RISE = 0.09;
+
+  fire(amount: number, color: FlashColor, reduced: boolean): void {
+    // Trim the 1s window.
+    while (this.stamps.length && this.now - this.stamps[0] > 1) this.stamps.shift();
+    const recent = this.stamps.length;
+    // 0 recent -> full, 1 -> 60%, 2 -> 35%, 3+ -> 18% and no further growth.
+    const allowance = recent === 0 ? 1 : recent === 1 ? 0.6 : recent === 2 ? 0.35 : 0.18;
+    const a = clamp01(amount) * allowance * (reduced ? 0.45 : 1);
+    if (a <= this.target) {
+      // Never let a weaker request cut a stronger one short.
+      this.col = [color[0], color[1], color[2]];
+      return;
+    }
+    this.stamps.push(this.now);
+    this.target = a;
+    this.col = [color[0], color[1], color[2]];
+  }
+
+  update(dt: number): void {
+    this.now += dt;
+    if (this.target > this.level) {
+      this.level = Math.min(this.target, this.level + dt / FlashBus.RISE);
+      if (this.level >= this.target) this.target = 0;
+    } else {
+      this.level = Math.max(0, this.level - dt * 3.4);
+      this.target = 0;
+    }
+  }
+
+  get value(): number {
+    return this.level;
+  }
+  get color(): readonly [number, number, number] {
+    return this.col;
+  }
+}
+
+/* --------------------------------- tweening -------------------------------- */
+
+/** A scalar that springs to its target. Used for FOV, HUD punch, camera lean. */
+export class Springy {
+  value: number;
+  target: number;
+  private vel = 0;
+  stiffness: number;
+  damping: number;
+
+  constructor(v: number, stiffness = 150, damping = 18) {
+    this.value = v;
+    this.target = v;
+    this.stiffness = stiffness;
+    this.damping = damping;
+  }
+
+  kick(v: number): void {
+    this.vel += v;
+  }
+
+  update(dt: number): number {
+    // Sub-step at a fixed 120Hz and cap the total simulated time. Capping the
+    // step *count* instead still hands the integrator an h of 0.125s after a
+    // half-second hitch, which diverges — a tab returning from the background
+    // would fling the camera across the world.
+    const total = Math.min(dt, 0.1);
+    const steps = Math.max(1, Math.ceil(total / (1 / 120)));
+    const h = total / steps;
+    for (let i = 0; i < steps; i++) {
+      const a = (this.target - this.value) * this.stiffness - this.vel * this.damping;
+      this.vel += a * h;
+      this.value += this.vel * h;
+    }
+    return this.value;
+  }
+}

--- a/dynawalla/games/runner/src/game/mount.ts
+++ b/dynawalla/games/runner/src/game/mount.ts
@@ -1,0 +1,1201 @@
+import * as THREE from "three";
+import type { Host, Question } from "../contract.ts";
+import { makeSharedUniforms } from "./shaders.ts";
+import { SolidField, GlowField } from "./fields.ts";
+import { DigitField } from "./digits.ts";
+import { Particles } from "./particles.ts";
+import { Scenery, colorOf } from "./scenery.ts";
+import { Entities, laneX, GATE_PLANE } from "./entities.ts";
+import type { Gate, HazardKind } from "./entities.ts";
+import { laneOptions } from "./options.ts";
+import { Player, skiffGeometry } from "./player.ts";
+import { makeSky, makeOcean, makeDeck, LANE_W } from "./world.ts";
+import { Post } from "./post.ts";
+import { Projector } from "./project.ts";
+import { Audio } from "./audio.ts";
+import { InputController } from "./input.ts";
+import { Rng } from "./rng.ts";
+import { biomeAt, biomeLength } from "./biomes.ts";
+import { detectTier, TierController, type TierName } from "./tiers.ts";
+import { buildHud, groupDigits, ringCircumference } from "./hud.ts";
+import { Shake, HitStop, FlashBus, Springy, clamp, clamp01, lerp, approach, easeOutCubic } from "./juice.ts";
+
+import {
+  V_START, V_TERMINAL, V_REDUCED_CAP, VOLT_MAX, COST_WRONG_GATE, COST_HAZARD,
+  GAIN_GATE, GAIN_SPARK, GAIN_GRAZE, VOLT_BLEED, CHAIN_PER_SURGE, SURGE_MAX,
+  STUMBLE_TIME, CLEAN_READ_SHARE, REVIVE_GRACE, speedAt, readWindow, breather, beatTime, difficultyFor,
+} from "./pacing.ts";
+
+type Phase = "idle" | "running" | "dying" | "revive" | "over";
+
+type RunStats = {
+  distance: number;
+  score: number;
+  gates: number;
+  gatesRight: number;
+  bestChain: number;
+  cleanReads: number;
+  sparks: number;
+  grazes: number;
+  revives: number;
+};
+
+// gitleaks:allow — a localStorage slot name for the furthest distance run, not
+// a credential. The dotted-and-versioned shape is what trips `generic-api-key`.
+const BEST_SLOT = "dynawalla.runner.best.v1";
+
+function readBest(): number {
+  try {
+    return Number(localStorage.getItem(BEST_SLOT) ?? 0) || 0;
+  } catch {
+    return 0;
+  }
+}
+function writeBest(v: number): void {
+  try {
+    localStorage.setItem(BEST_SLOT, String(Math.round(v)));
+  } catch {
+    /* private mode; a best score is not worth an exception */
+  }
+}
+
+export function mountRunner(el: HTMLElement, host: Host): { unmount(): void } {
+  /* ------------------------------ chrome -------------------------------- */
+
+  const params = new URLSearchParams(location.search);
+  el.style.position = el.style.position || "relative";
+  el.style.overflow = "hidden";
+  el.style.touchAction = "none";
+  el.style.background = "#04060f";
+
+  const canvas = document.createElement("canvas");
+  canvas.style.cssText = "position:absolute;inset:0;width:100%;height:100%;display:block;touch-action:none;";
+  el.appendChild(canvas);
+
+  const renderer = new THREE.WebGLRenderer({
+    canvas,
+    antialias: false,
+    alpha: false,
+    powerPreference: "high-performance",
+    stencil: false,
+    depth: true,
+  });
+  renderer.autoClear = true;
+  renderer.setClearColor(0x04060f, 1);
+
+  const hud = buildHud(el);
+
+  /* ------------------------------- tiers -------------------------------- */
+
+  const forced = params.get("tier") as TierName | null;
+  const detected = forced ?? detectTier(renderer.getContext());
+  const tiers = new TierController(detected, () => applyTier());
+
+  /* ------------------------------- scene -------------------------------- */
+
+  const shared = makeSharedUniforms();
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(74, 1, 0.35, tiers.settings.far);
+
+  const sky = makeSky(shared);
+  scene.add(sky.mesh);
+  let ocean = makeOcean(shared, tiers.settings.far);
+  scene.add(ocean);
+  const deck = makeDeck(shared, tiers.settings.deckSegments, tiers.settings.far);
+  scene.add(deck.mesh);
+
+  const shardField = new SolidField(new THREE.CylinderGeometry(0.42, 0.58, 1, 6, 1), tiers.settings.monoliths, shared, 2.4);
+  const boxField = new SolidField(new THREE.BoxGeometry(1, 1, 1), 300, shared, 1.9);
+  const skiffField = new SolidField(skiffGeometry(), 12, shared, 1.7);
+  const glow = new GlowField(Math.max(900, tiers.settings.particles + 700), shared, 12);
+  const digits = new DigitField(300, shared);
+  scene.add(shardField.mesh, boxField.mesh, skiffField.mesh, glow.mesh, digits.mesh);
+
+  const post = new Post(renderer);
+  post.passes = tiers.settings.bloomPasses;
+  post.hdr = tiers.settings.bloomPasses > 0;
+  const proj = new Projector();
+
+  /* ------------------------------- systems ------------------------------ */
+
+  const seed = Number(params.get("seed") ?? 0) || ((Math.random() * 0xffffffff) >>> 0);
+  const rng = new Rng(seed);
+  const parts = new Particles(tiers.settings.particles);
+  const scenery = new Scenery(tiers.settings.monoliths, tiers.settings.far, rng);
+  const ents = new Entities();
+  const player = new Player();
+  const audio = new Audio();
+  const shake = new Shake();
+  const hitstop = new HitStop();
+  const flash = new FlashBus();
+  const fovSpring = new Springy(74, 130, 15);
+  const pullSpring = new Springy(0, 90, 12);
+  const chromaSpring = new Springy(0, 70, 11);
+  const input = new InputController(canvas, () => audio.start());
+
+  /* -------------------------------- state ------------------------------- */
+
+  let phase: Phase = "idle";
+  let travel = 0;
+  let elapsed = 0;
+  let speed = V_START;
+  let score = 0;
+  let displayScore = 0;
+  let surge = 1;
+  let chain = 0;
+  let voltage = VOLT_MAX;
+  let stumble = 0;
+  let biomeIndex = 0;
+  let biome = biomeAt(0);
+  let prevBiome = biome;
+  let biomeMix = 1;
+  let nextBiomeAt = biomeLength(0);
+  let gateCooldown = 0.6;
+  let nextBeatAt = 60;
+  let activeGate: Gate | null = null;
+  let pendingQuestion: Question | null = null;
+  let reviveQ: Question | null = null;
+  let reviveTimer = 0;
+  let reviveLimit = 7;
+  let dyingT = 0;
+  let sfxOn = true;
+  let motionOverride = false;
+  let best = readBest();
+  let lowVoltWarned = false;
+  let lowVoltTick = 0;
+  /** `elapsed` at the last lane change. Distinguishes a read from a swerve. */
+  let laneSettledAt = 0;
+  const stats: RunStats = { distance: 0, score: 0, gates: 0, gatesRight: 0, bestChain: 0, cleanReads: 0, sparks: 0, grazes: 0, revives: 0 };
+
+  // Perf instrumentation, surfaced with ?stats=1.
+  let fpsAcc = 0, fpsFrames = 0, fps = 0, worstFrame = 0;
+  let latencySum = 0, latencyN = 0, latencyWorst = 0;
+  let sceneCalls = 0, sceneTris = 0;
+  const showPerf = params.get("stats") === "1";
+  if (showPerf) hud.perf.classList.add("vt-on");
+
+  const reduced = (): boolean => motionOverride || host.prefersReducedMotion();
+
+  /**
+   * Verification probe, published only under `?stats=1`.
+   *
+   * A runner cannot be checked by reading it — the questions that matter are
+   * "does a five-minute run stay at 60fps", "does the reading window still fit
+   * a child at 3 km", "does the fifth biome arrive". Those need a machine that
+   * can play. This exposes exactly enough read-only state for a harness to
+   * steer, and nothing that could change the game's behaviour. Input still goes
+   * through real KeyboardEvents, so the harness exercises the same path a
+   * player does.
+   */
+  if (showPerf) {
+    (window as unknown as Record<string, unknown>).__volta = {
+      state: () => ({
+        phase, travel: Math.round(travel), speed: +speed.toFixed(1),
+        voltage: +voltage.toFixed(1), surge, chain, score: Math.round(score), fps: +fps.toFixed(1),
+        biome: biome.name, tier: tiers.tier, particles: parts.count, worstMs: +(worstFrame * 1000).toFixed(1),
+        latency: { avg: latencyN ? +(latencySum / latencyN).toFixed(1) : 0, max: +latencyWorst.toFixed(1), n: latencyN },
+        gates: stats.gates, right: stats.gatesRight, clean: stats.cleanReads, grazes: stats.grazes, revives: stats.revives,
+        playerX: +player.x.toFixed(2), playerY: +player.y.toFixed(2), lane: player.lane,
+        gate: activeGate && activeGate.state === "incoming"
+          ? { z: +activeGate.z.toFixed(1), correctLane: activeGate.correctLane, values: activeGate.values.slice(), window: +activeGate.window.toFixed(2) }
+          : null,
+        hazards: ents.hazards
+          .filter((h) => h.active && h.z > -140)
+          .map((h) => ({ kind: h.kind, z: +h.z.toFixed(1), x: +ents.hazardX(h).toFixed(2), span: h.span }))
+          .sort((a, b) => b.z - a.z),
+        reviveLane: phase === "revive" ? reviveAnswerLane : -1,
+      }),
+    };
+  }
+
+  /* ------------------------------- palette ------------------------------ */
+
+  const tmpA = new THREE.Color();
+  const tmpB = new THREE.Color();
+  const numeralInk: [number, number, number] = [1, 1, 1];
+  function applyBiomeUniforms(): void {
+    const m = easeOutCubic(biomeMix);
+    const mixHex = (a: number, b: number, out: THREE.Color) => {
+      tmpA.setHex(a, THREE.SRGBColorSpace);
+      tmpB.setHex(b, THREE.SRGBColorSpace);
+      out.copy(tmpA).lerp(tmpB, m);
+    };
+    mixHex(prevBiome.skyTop, biome.skyTop, shared.uSkyTop.value);
+    mixHex(prevBiome.skyBot, biome.skyBot, shared.uSkyBot.value);
+    mixHex(prevBiome.fog, biome.fog, shared.uFogColor.value);
+    mixHex(prevBiome.deck, biome.deck, shared.uDeck.value);
+    mixHex(prevBiome.accent, biome.accent, shared.uAccent.value);
+    mixHex(prevBiome.accent2, biome.accent2, shared.uAccent2.value);
+    shared.uFogDensity.value = lerp(prevBiome.fogDensity, biome.fogDensity, m);
+    (sky.material.uniforms.uAurora as { value: number }).value = lerp(prevBiome.auroraStrength, biome.auroraStrength, m);
+    (sky.material.uniforms.uStars as { value: number }).value = lerp(prevBiome.starDensity, biome.starDensity, m);
+    const vig = post.composite.uniforms.uVignetteColor.value as THREE.Color;
+    vig.copy(shared.uFogColor.value).multiplyScalar(biome.inverted ? 1.1 : 0.55);
+    hud.root.style.color = biome.inverted ? "#12121a" : "#eaf6ff";
+    // The chrome borrows the world's accent, so the recharge gate is lit by the
+    // biome you died in rather than being a grey box bolted over the top of it.
+    hud.root.style.setProperty("--vt-accent", `#${shared.uAccent.value.getHexString()}`);
+    post.composite.uniforms.uExposure.value = biome.inverted ? 0.88 : 1.06;
+    // Candidate numerals are hot white ink with a black stroke in the dark
+    // worlds, and black ink with a bone stroke in THE BLEACH. Contrast is never
+    // left to whichever sky happens to be behind the row.
+    const flip = m > 0.5 ? biome.inverted : prevBiome.inverted;
+    if (flip) {
+      numeralInk[0] = 0.03; numeralInk[1] = 0.03; numeralInk[2] = 0.045;
+      digits.setOutline(0.94, 0.92, 0.86);
+    } else {
+      numeralInk[0] = 1; numeralInk[1] = 1; numeralInk[2] = 1;
+      digits.setOutline(0.012, 0.018, 0.045);
+    }
+  }
+
+  /* -------------------------------- sizing ------------------------------ */
+
+  let vw = 1, vh = 1;
+  function resize(): void {
+    const r = el.getBoundingClientRect();
+    vw = Math.max(1, Math.round(r.width));
+    vh = Math.max(1, Math.round(r.height));
+    const dpr = Math.min(window.devicePixelRatio || 1, tiers.settings.dprCap) * tiers.renderScale;
+    renderer.setPixelRatio(1);
+    const bw = Math.max(2, Math.round(vw * dpr));
+    const bh = Math.max(2, Math.round(vh * dpr));
+    renderer.setSize(bw, bh, false);
+    canvas.style.width = `${vw}px`;
+    canvas.style.height = `${vh}px`;
+    post.setSize(bw, bh);
+    camera.aspect = vw / vh;
+    camera.updateProjectionMatrix();
+  }
+
+  function applyTier(): void {
+    const s = tiers.settings;
+    camera.far = s.far;
+    camera.updateProjectionMatrix();
+    deck.rebuild(s.deckSegments, s.far);
+    scene.remove(ocean);
+    ocean.geometry.dispose();
+    (ocean.material as THREE.Material).dispose();
+    ocean = makeOcean(shared, s.far);
+    ocean.visible = s.ocean;
+    scene.add(ocean);
+    scenery.resize(s.monoliths, s.far);
+    post.passes = s.bloomPasses;
+    post.setHdr(s.bloomPasses > 0);
+    resize();
+  }
+
+  const ro = new ResizeObserver(() => resize());
+  ro.observe(el);
+  resize();
+  applyTier();
+  applyBiomeUniforms();
+
+  /* --------------------------------- HUD -------------------------------- */
+
+  function setPrompt(text: string): void {
+    hud.promptText.textContent = text;
+    hud.prompt.classList.remove("vt-punch");
+    void hud.prompt.offsetWidth;
+    hud.prompt.classList.add("vt-punch");
+  }
+
+  function refreshHud(): void {
+    hud.score.textContent = groupDigits(displayScore);
+    hud.dist.textContent = `${groupDigits(travel)} m`;
+    hud.surgeN.textContent = String(surge);
+    const pips = hud.chain.children;
+    for (let i = 0; i < pips.length; i++) {
+      (pips[i] as HTMLElement).classList.toggle("on", i < chain);
+    }
+    const v = clamp01(voltage / VOLT_MAX);
+    hud.voltFill.style.transform = `scaleX(${v})`;
+    hud.voltFill.style.color = v > 0.55 ? "#5effc9" : v > 0.28 ? "#ffc02a" : "#ff3a5e";
+    hud.volt.classList.toggle("vt-crit", v <= 0.28);
+  }
+
+  function showVeil(which: "start" | "revive" | "over" | null): void {
+    hud.start.classList.toggle("vt-on", which === "start");
+    hud.revive.classList.toggle("vt-on", which === "revive");
+    hud.over.classList.toggle("vt-on", which === "over");
+    hud.root.classList.toggle("vt-veiled", which !== null);
+    input.setPaused(which !== null);
+  }
+
+  function banner(text: string): void {
+    hud.banner.textContent = text;
+    hud.banner.classList.remove("vt-show");
+    void hud.banner.offsetWidth;
+    hud.banner.classList.add("vt-show");
+  }
+
+  /* ------------------------------ run control --------------------------- */
+
+  function resetRun(): void {
+    travel = 0;
+    elapsed = 0;
+    speed = V_START;
+    score = 0;
+    displayScore = 0;
+    surge = 1;
+    chain = 0;
+    voltage = VOLT_MAX;
+    stumble = 0;
+    biomeIndex = 0;
+    biome = prevBiome = biomeAt(0);
+    biomeMix = 1;
+    nextBiomeAt = biomeLength(0);
+    gateCooldown = 0.75;
+    nextBeatAt = 70;
+    activeGate = null;
+    pendingQuestion = null;
+    reviveLimit = 7;
+    lowVoltWarned = false;
+    stats.distance = 0; stats.score = 0; stats.gates = 0; stats.gatesRight = 0;
+    stats.bestChain = 0; stats.cleanReads = 0; stats.sparks = 0; stats.grazes = 0; stats.revives = 0;
+    ents.reset();
+    parts.clear();
+    player.reset();
+    shake.trauma = 0;
+    latencySum = 0; latencyN = 0; latencyWorst = 0;
+    shared.uTravel.value = 0;
+    applyBiomeUniforms();
+    refreshHud();
+    setPrompt("—");
+    banner(biome.name);
+  }
+
+  function startRun(): void {
+    audio.start();
+    audio.setScale(biome.scale, biome.bpm);
+    audio.setMusicLayers(1);
+    resetRun();
+    phase = "running";
+    showVeil(null);
+    input.clear();
+  }
+
+  function endRun(): void {
+    phase = "over";
+    audio.setMusicLayers(0);
+    audio.runOver();
+    host.haptic("failure");
+    if (travel > best) {
+      best = travel;
+      writeBest(best);
+    }
+    const acc = stats.gates ? Math.round((stats.gatesRight / stats.gates) * 100) : 0;
+    hud.overStats.innerHTML = `
+      <div class="vt-stat"><b class="vt-num">${groupDigits(travel)}</b><i>Metres</i></div>
+      <div class="vt-stat"><b class="vt-num">${groupDigits(score)}</b><i>Score</i></div>
+      <div class="vt-stat"><b class="vt-num">${acc}%</b><i>Gates right</i></div>
+      <div class="vt-stat"><b class="vt-num">&times;${stats.bestChain}</b><i>Best surge</i></div>
+    `;
+    showVeil("over");
+    hud.againBtn.focus();
+  }
+
+  /* --------------------------------- gates ------------------------------ */
+
+  const difficulty = (): number => difficultyFor(travel, surge, stats.gates, stats.gatesRight);
+
+  function requestGate(): void {
+    if (activeGate) return;
+    const q = pendingQuestion ?? host.next({ difficulty: difficulty() });
+    pendingQuestion = null;
+    const w = readWindow(travel, reduced());
+    const dist = clamp(speed * w, 68, tiers.settings.far * 0.84);
+    const g = ents.spawnGate(q, dist, dist / Math.max(1, speed), rng);
+    if (!g) {
+      pendingQuestion = q;
+      return;
+    }
+    activeGate = g;
+    setPrompt(q.prompt);
+    audio.uiTick();
+  }
+
+  function resolveGate(g: Gate): void {
+    const lane = clamp(Math.round(player.x / LANE_W) + 1, 0, 2);
+    const correct = lane === g.correctLane;
+    // How long the answer has been committed. A child who reads the row and
+    // steers once is doing the thing the game is for; one who sweeps the lanes
+    // and hopes is not, and the surge meter should be able to tell them apart.
+    const held = elapsed - laneSettledAt;
+    const cleanRead = correct && held >= g.window * CLEAN_READ_SHARE;
+    g.chosenLane = lane;
+    g.state = correct ? "passed" : "hit";
+    g.burst = 0;
+    activeGate = null;
+    gateCooldown = breather(travel);
+    stats.gates++;
+
+    const q = g.q!;
+    const t0 = performance.now();
+    host.report({
+      questionId: q.id,
+      correct,
+      ms: Math.round(t0 - g.shownAt),
+      answered: g.values[lane].replace(/−/g, "-"),
+    });
+
+    const ac = colorOf(biome.accent);
+    const gx = laneX(lane);
+
+    if (correct) {
+      stats.gatesRight++;
+      if (cleanRead) stats.cleanReads++;
+      chain += cleanRead ? 2 : 1;
+      while (chain >= CHAIN_PER_SURGE && surge < SURGE_MAX) {
+        chain -= CHAIN_PER_SURGE;
+        surge++;
+        audio.surgeUp(surge);
+        hud.surge.classList.remove("vt-bump");
+        void hud.surge.offsetWidth;
+        hud.surge.classList.add("vt-bump");
+        flash.fire(0.20, [ac[0], ac[1], ac[2]], reduced());
+        shake.add(0.30);
+        ents.popup(String(surge), gx, 4.2, 0.5, 1.5, 1, 1, 1, 1.3);
+        audio.setMusicLayers(surge >= 4 ? 3 : surge >= 2 ? 2 : 1);
+        if (surge === SURGE_MAX) {
+          banner("Overdrive");
+          flash.fire(0.3, [1, 1, 1], reduced());
+          host.haptic("heavy");
+        }
+      }
+      if (surge >= SURGE_MAX) chain = CHAIN_PER_SURGE;
+      stats.bestChain = Math.max(stats.bestChain, surge);
+      // At full surge every gate pays double. Twenty-seven consecutive correct
+      // answers is a real achievement and it should feel like one for as long as
+      // it is held, not just for the frame it was earned.
+      const gained = 100 * surge * (surge >= SURGE_MAX ? 2 : 1);
+      score += gained;
+      voltage = Math.min(VOLT_MAX, voltage + GAIN_GATE);
+      audio.gateCorrect(surge + chain);
+      host.haptic("success");
+      shake.add(reduced() ? 0 : 0.16 + surge * 0.012);
+      fovSpring.kick(reduced() ? 0 : 46 + (cleanRead ? 22 : 0));
+      chromaSpring.kick(reduced() ? 0 : 2.2);
+      hitstop.hit(reduced() ? 0.02 : (cleanRead ? 0.06 : 0.045), 0.14);
+      flash.fire(0.11, [ac[0], ac[1], ac[2]], reduced());
+      ents.popup(`+${gained}`, gx, 3.6, 0.4, 1.05, ac[0], ac[1], ac[2], 1.05);
+      if (cleanRead) {
+        hud.chain.classList.remove("vt-clean");
+        void hud.chain.offsetWidth;
+        hud.chain.classList.add("vt-clean");
+        audio.uiTick();
+      }
+
+      const hot = colorOf(0xffffff);
+      const boost = cleanRead ? 1.45 : 1;
+      parts.burst(gx, 2.3, 0.2, reduced() ? 10 : Math.round(34 * boost), 16, 0.55, 0.4, hot[0], hot[1], hot[2], 9);
+      parts.burst(gx, 2.3, 0.2, reduced() ? 8 : Math.round(26 * boost), 11, 0.8, 0.55, ac[0], ac[1], ac[2], 6);
+      parts.ring(gx, 2.4, 0.3, 3, 0.44, hot[0], hot[1], hot[2], 62);
+      if (cleanRead) parts.ring(gx, 2.4, 0.3, 1.6, 0.5, ac[0], ac[1], ac[2], 92);
+      parts.shards(gx, 2.4, 0.4, reduced() ? 4 : Math.round(14 * boost), 9, ac[0], ac[1], ac[2], 5);
+    } else {
+      const bad = colorOf(0xff2f52);
+      chain = 0;
+      surge = 1;
+      audio.setMusicLayers(1);
+      voltage -= COST_WRONG_GATE;
+      stumble = STUMBLE_TIME;
+      player.stumble();
+      audio.gateWrong();
+      audio.duckMusic(0.5);
+      host.haptic("failure");
+      shake.add(reduced() ? 0 : 0.85);
+      hitstop.hit(reduced() ? 0.05 : 0.13, 0.05);
+      fovSpring.kick(reduced() ? 0 : -110);
+      pullSpring.kick(reduced() ? 0 : 22);
+      chromaSpring.kick(reduced() ? 0 : 9);
+      flash.fire(0.22, [1, 0.16, 0.24], reduced());
+      // The right answer is shown on the gate you did not take. This is the
+      // whole teaching moment and it is one second long, not a lecture.
+      ents.popup(g.values[g.correctLane], laneX(g.correctLane), 3.0, 0.4, 1.35, 0.4, 1, 0.75, 1.6);
+      parts.burst(gx, 1.8, 0.2, reduced() ? 12 : 44, 19, 0.75, 0.5, bad[0], bad[1], bad[2], -4);
+      parts.shards(gx, 1.9, 0.3, reduced() ? 6 : 22, 13, bad[0], bad[1], bad[2], -2);
+      parts.ring(gx, 1.9, 0.3, 2, 0.5, bad[0], bad[1], bad[2], 40);
+    }
+    refreshHud();
+  }
+
+  /* ------------------------------- hazards ------------------------------- */
+
+  function pickHazard(): HazardKind {
+    const r = rng.next();
+    if (travel < 320) return "pylon";
+    if (travel < 850) return r < 0.72 ? "pylon" : "lowbar";
+    if (travel < 1700) return r < 0.5 ? "pylon" : r < 0.78 ? "lowbar" : "pit";
+    return r < 0.38 ? "pylon" : r < 0.62 ? "lowbar" : r < 0.8 ? "pit" : "sweeper";
+  }
+
+  function emitBeat(): void {
+    const spawnZ = tiers.settings.far * 0.88;
+    // Never put a hazard inside the reading window of a gate: the child would
+    // be dodging while reading, which is not difficulty, it is noise.
+    if (activeGate && Math.abs(-spawnZ - activeGate.z) < 30) return;
+
+    const roll = rng.next();
+    const hazardChance = clamp(0.42 + travel / 9000, 0.42, 0.78);
+    if (roll < hazardChance) {
+      const kind = pickHazard();
+      if (kind === "pit") {
+        ents.spawnHazard("pit", 1, spawnZ);
+        // Sparks arcing over the gap: the reward line *is* the instruction.
+        for (let i = 0; i < 5; i++) {
+          const t = i / 4;
+          ents.spawnSpark(0, 1.4 + Math.sin(t * Math.PI) * 2.4, spawnZ + 8 - i * 4);
+        }
+      } else if (kind === "lowbar") {
+        const span = travel > 2200 && rng.chance(0.45) ? 3 : 1;
+        const lane = span === 3 ? 1 : rng.int(0, 2);
+        ents.spawnHazard("lowbar", lane, spawnZ, span);
+      } else if (kind === "sweeper") {
+        ents.spawnHazard("sweeper", 1, spawnZ);
+      } else {
+        const lanes = [0, 1, 2];
+        rng.shuffle(lanes);
+        const n = travel > 1400 && rng.chance(0.42) ? 2 : 1;
+        for (let i = 0; i < n; i++) ents.spawnHazard("pylon", lanes[i], spawnZ - i * 0.01);
+        // Sparks in a surviving lane: a positive read of where to go.
+        if (rng.chance(0.6)) {
+          const safe = lanes[n];
+          for (let i = 0; i < 4; i++) ents.spawnSpark(laneX(safe), 1.25, spawnZ + 14 - i * 4.5);
+        }
+      }
+    } else if (roll < hazardChance + 0.38) {
+      const lane = rng.int(0, 2);
+      const n = rng.int(4, 8);
+      const wavy = rng.chance(0.4);
+      for (let i = 0; i < n; i++) {
+        const x = wavy ? laneX(lane) + Math.sin(i * 0.8) * LANE_W * 0.9 : laneX(lane);
+        ents.spawnSpark(clamp(x, -LANE_W, LANE_W), 1.25, spawnZ + 16 - i * 4.4);
+      }
+    }
+  }
+
+  /* ------------------------------ collisions ----------------------------- */
+
+  function hitHazard(x: number, cause: "hazard" | "pit"): void {
+    if (player.invuln > 0) return;
+    const bad = colorOf(0xff5a2a);
+    // Voltage is the world, surge is the maths. A pylon costs you charge and a
+    // second of control; it does not touch the multiplier a child earned by
+    // reading, because that multiplier is the only thing measuring the reading.
+    voltage -= COST_HAZARD;
+    stumble = STUMBLE_TIME * 0.8;
+    player.stumble();
+    player.invuln = 1.05;
+    audio.hazardHit();
+    host.haptic("heavy");
+    shake.add(reduced() ? 0 : 0.68);
+    hitstop.hit(reduced() ? 0.04 : 0.1, 0.05);
+    fovSpring.kick(reduced() ? 0 : -80);
+    chromaSpring.kick(reduced() ? 0 : 7);
+    flash.fire(0.24, [1, 0.32, 0.16], reduced());
+    parts.burst(x, cause === "pit" ? 0.4 : 1.6, 0.2, reduced() ? 10 : 36, 17, 0.7, 0.5, bad[0], bad[1], bad[2], -3);
+    parts.shards(x, 1.4, 0.3, reduced() ? 5 : 18, 11, bad[0], bad[1], bad[2], -2);
+    refreshHud();
+  }
+
+  function collide(): void {
+    const px = player.x;
+    const pBot = player.y;
+    const pTop = player.y + player.hitHalfH * 2;
+
+    for (const h of ents.hazards) {
+      if (!h.active || h.hit) continue;
+      if (h.kind === "pit") continue;
+      const depth = h.kind === "lowbar" ? 0.7 : 0.6;
+      if (Math.abs(h.z) > 1.5 + depth) continue;
+      const hx = ents.hazardX(h);
+      if (h.kind === "lowbar") {
+        const halfW = (LANE_W * h.span) / 2;
+        if (Math.abs(px - hx) < halfW + 0.7 && pTop > 1.6 && pBot < 3.2) {
+          h.hit = true;
+          hitHazard(px, "hazard");
+        }
+      } else {
+        if (Math.abs(px - hx) < 0.82 + LANE_W * 0.31 && pBot < 3.4) {
+          h.hit = true;
+          hitHazard(px, "hazard");
+        } else if (!h.grazed && Math.abs(px - hx) < 2.55) {
+          h.grazed = true;
+          onGraze(hx);
+        }
+      }
+    }
+
+    for (const s of ents.sparks) {
+      if (!s.active || s.taken) continue;
+      if (Math.abs(s.z) > 2.2) continue;
+      if (Math.abs(px - s.x) > 1.55) continue;
+      if (Math.abs(player.y + 0.85 - s.y) > 1.7) continue;
+      s.taken = true;
+      s.active = false;
+      stats.sparks++;
+      score += 10 * surge;
+      voltage = Math.min(VOLT_MAX, voltage + GAIN_SPARK);
+      audio.spark(stats.sparks);
+      const c = colorOf(biome.accent);
+      parts.burst(s.x, s.y, s.z, reduced() ? 3 : 9, 7, 0.34, 0.28, c[0], c[1], c[2], 6);
+      if (stats.sparks % 12 === 0) host.haptic("light");
+    }
+  }
+
+  function onGraze(hx: number): void {
+    stats.grazes++;
+    score += 25 * surge;
+    voltage = Math.min(VOLT_MAX, voltage + GAIN_GRAZE);
+    audio.graze(clamp01((speed - V_START) / (V_TERMINAL - V_START)));
+    host.haptic("light");
+    // The near-miss punch: this is the format's signature feeling and it is
+    // worth more juice than the reward for a correct gate.
+    shake.add(reduced() ? 0 : 0.20);
+    fovSpring.kick(reduced() ? 0 : 70);
+    hitstop.hit(reduced() ? 0 : 0.028, 0.2);
+    const c = colorOf(0xffffff);
+    parts.ring(hx, 1.4, 0.6, 2.4, 0.3, c[0], c[1], c[2], 34);
+    ents.popup("+" + 25 * surge, hx, 2.4, 0.6, 0.62, 1, 1, 1, 0.75);
+  }
+
+  /* -------------------------------- revive ------------------------------- */
+
+  function beginDying(): void {
+    phase = "dying";
+    dyingT = 0;
+    audio.setMusicLayers(0);
+    audio.reviveCharge();
+    shake.add(reduced() ? 0 : 1);
+    hitstop.hit(reduced() ? 0.08 : 0.22, 0.03);
+    flash.fire(0.4, [1, 0.2, 0.28], reduced());
+    host.haptic("heavy");
+    const bad = colorOf(0xff2f52);
+    parts.burst(player.x, 1.2, 0.2, reduced() ? 16 : 70, 24, 1.1, 0.7, bad[0], bad[1], bad[2], 0);
+    parts.shards(player.x, 1.2, 0.2, reduced() ? 8 : 30, 15, bad[0], bad[1], bad[2], 0);
+    parts.ring(player.x, 1.4, 0.4, 3, 0.9, 1, 1, 1, 70);
+  }
+
+  function openRevive(): void {
+    phase = "revive";
+    reviveQ = host.next({ difficulty: Math.max(0, difficulty() - 1) });
+    reviveLimit = Math.max(4.5, 7 - stats.revives * 0.6);
+    reviveTimer = reviveLimit;
+    hud.revivePrompt.textContent = reviveQ.prompt;
+    // Exactly the rules the gates out on the causeway use. A recharge question
+    // that offers a different quality of wrong answer is a different question.
+    const { values, correct } = laneOptions(reviveQ.answer, reviveQ.distractors, rng);
+    reviveAnswerLane = correct;
+    hud.reviveLanes.forEach((b, i) => {
+      b.className = "vt-lane";
+      b.disabled = false;
+      (b.firstElementChild as HTMLElement).textContent = values[i];
+    });
+    hud.reviveCount.textContent = stats.revives === 0 ? "" : `Recharge ${stats.revives + 1}`;
+    showVeil("revive");
+    hud.reviveLanes[1].focus();
+  }
+
+  let reviveAnswerLane = 0;
+  let reviveResolving = false;
+  /**
+   * The verdict beat between choosing a recharge lane and the run resuming.
+   *
+   * Held so `unmount()` can cancel it. A host that swaps packs while the beat is
+   * in flight would otherwise get a callback that starts audio, writes to a HUD
+   * that is no longer in the document and resurrects a disposed run — half a
+   * second after the game was told to go away.
+   */
+  let reviveVerdict = 0;
+
+  function answerRevive(lane: number): void {
+    if (reviveResolving || !reviveQ) return;
+    reviveResolving = true;
+    const correct = lane === reviveAnswerLane;
+    host.report({
+      questionId: reviveQ.id,
+      correct,
+      ms: Math.round((reviveLimit - reviveTimer) * 1000),
+      answered: lane < 0 ? "" : (hud.reviveLanes[lane].textContent ?? "").trim().replace(/−/g, "-"),
+    });
+    hud.reviveLanes.forEach((b, i) => {
+      b.disabled = true;
+      b.classList.add(i === reviveAnswerLane ? "vt-right" : "vt-wrong");
+    });
+    reviveVerdict = window.setTimeout(() => {
+      reviveVerdict = 0;
+      if (disposed) return;
+      reviveResolving = false;
+      if (correct) {
+        stats.revives++;
+        voltage = VOLT_MAX;
+        surge = 1;
+        chain = 0;
+        player.reset();
+        // After `reset()`, which zeroes it. You come back on the deck, centred,
+        // with a beat of grace before the world can touch you again.
+        player.invuln = REVIVE_GRACE;
+        stumble = 0;
+        ents.reset();
+        activeGate = null;
+        gateCooldown = 1.1;
+        phase = "running";
+        showVeil(null);
+        audio.reviveSuccess();
+        audio.setMusicLayers(1);
+        host.haptic("success");
+        flash.fire(0.45, [1, 1, 1], reduced());
+        shake.add(reduced() ? 0 : 0.5);
+        const c = colorOf(biome.accent);
+        parts.burst(player.x, 1.2, 0.2, reduced() ? 20 : 90, 26, 1.2, 0.8, c[0], c[1], c[2], 12);
+        parts.ring(player.x, 1.4, 0.4, 2, 0.8, 1, 1, 1, 90);
+        refreshHud();
+        banner("Recharged");
+      } else {
+        endRun();
+      }
+    }, correct ? 420 : 780);
+  }
+
+  /* ---------------------------------- loop ------------------------------- */
+
+  let raf = 0;
+  let last = performance.now();
+  let disposed = false;
+
+  function frame(now: number): void {
+    if (disposed) return;
+    raf = requestAnimationFrame(frame);
+    const rawDt = Math.min(0.05, (now - last) / 1000);
+    last = now;
+    if (rawDt <= 0) return;
+
+    fpsAcc += rawDt;
+    fpsFrames++;
+    if (rawDt > worstFrame) worstFrame = rawDt;
+    if (fpsAcc >= 0.5) {
+      fps = fpsFrames / fpsAcc;
+      fpsAcc = 0;
+      fpsFrames = 0;
+      if (showPerf) {
+        hud.perf.textContent =
+          `${fps.toFixed(0)} fps  worst ${(worstFrame * 1000).toFixed(1)}ms\n` +
+          `tier ${tiers.tier} x${tiers.renderScale.toFixed(2)}  ${vw}x${vh}\n` +
+          `input->act avg ${(latencyN ? latencySum / latencyN : 0).toFixed(1)}ms max ${latencyWorst.toFixed(1)}\n` +
+          `parts ${parts.count}  draws ${sceneCalls}  tris ${sceneTris}\n` +
+          `seed ${seed.toString(16)}`;
+        worstFrame = 0;
+      }
+    }
+    tiers.observe(rawDt);
+
+    const rm = reduced();
+    hud.root.classList.toggle("vt-rm", rm);
+    const dt = rawDt * hitstop.scale(rawDt);
+
+    audio.tick();
+    flash.update(rawDt);
+
+    if (phase === "running" || phase === "dying") step(dt, rawDt, rm);
+    else stepIdle(dt, rm);
+
+    render(rawDt, rm);
+  }
+
+  function stepIdle(dt: number, rm: boolean): void {
+    // The world keeps running behind every overlay. A frozen menu over a frozen
+    // game looks broken; a menu over a living world looks like a game.
+    elapsed += dt;
+    const drift = phase === "over" ? 9 : phase === "revive" ? 24 : 16;
+    shared.uTime.value += dt;
+    shared.uTravel.value += drift * dt;
+    const scroll = drift * dt;
+    scenery.update(dt, scroll, travel, biome, parts);
+    parts.update(dt, scroll);
+    ents.update(dt, scroll);
+    player.update(dt, true, rm);
+    if (phase === "revive") {
+      reviveTimer -= dt;
+      const f = clamp01(reviveTimer / reviveLimit);
+      hud.reviveRing.style.strokeDashoffset = String(ringCircumference * (1 - f));
+      hud.reviveRing.style.stroke = f > 0.4 ? "currentColor" : "#ff3a5e";
+      if (reviveTimer <= 0 && !reviveResolving) answerRevive(-1);
+    }
+  }
+
+  function step(dt: number, rawDt: number, rm: boolean): void {
+    elapsed += dt;
+
+    if (phase === "dying") {
+      dyingT += rawDt;
+      speed = approach(speed, 4, 2.4, dt);
+      pullSpring.target = 12;
+      if (dyingT > 1.15) {
+        pullSpring.target = 0;
+        openRevive();
+      }
+    } else {
+      const surgeBoost = 1 + Math.min(0.2, (surge - 1) * 0.026);
+      let want = speedAt(elapsed, rm) * surgeBoost;
+      if (rm) want = Math.min(want, V_REDUCED_CAP);
+      if (stumble > 0) {
+        stumble = Math.max(0, stumble - dt);
+        want *= 0.52;
+      }
+      speed = approach(speed, want, stumble > 0 ? 9 : 1.6, dt);
+    }
+
+    const scroll = speed * dt;
+    travel += scroll;
+    shared.uTime.value += dt;
+    shared.uTravel.value += scroll;
+    shared.uSpeed01.value = clamp01((speed - V_START) / (V_TERMINAL - V_START));
+    shared.uSurge.value = clamp01((surge - 1) / (SURGE_MAX - 1));
+    shared.uDanger.value = phase === "running" ? clamp01(1 - voltage / 32) : 0;
+
+    /* input */
+    if (phase === "running" && stumble <= 0) {
+      for (let guard = 0; guard < 2; guard++) {
+        const i = input.consume(() => true);
+        if (!i) break;
+        latencyN++;
+        latencySum += input.lastLatencyMs;
+        latencyWorst = Math.max(latencyWorst, input.lastLatencyMs);
+        if (i === "left") {
+          if (player.moveLane(-1)) laneMoved();
+        } else if (i === "right") {
+          if (player.moveLane(1)) laneMoved();
+        } else if (i === "jump") {
+          if (player.jump()) {
+            audio.jump();
+            host.haptic("light");
+            parts.burst(player.x, 0.2, 0.3, rm ? 3 : 10, 6, 0.3, 0.3, 1, 1, 1, 4);
+          }
+        } else if (player.slide()) {
+          audio.slide();
+          host.haptic("light");
+          parts.burst(player.x, 0.2, 0.4, rm ? 3 : 12, 8, 0.35, 0.34, 1, 1, 1, -3);
+        }
+      }
+    }
+
+    /* world bend */
+    const t = shared.uTime.value;
+    const amp = rm ? 0.5 : 1;
+    shared.uBend.value.set(
+      (Math.sin(t * 0.127) * 0.66 + Math.sin(t * 0.071 + 2.1) * 0.44) * 1.25e-4 * amp,
+      (Math.sin(t * 0.091 + 1.3) * 0.5 + Math.sin(t * 0.043) * 0.3) * 0.9e-4 * amp - 0.2e-4,
+    );
+
+    /* pit state: the deck is genuinely open, so falling is falling. Every
+       visible pit is cut, not just the one underfoot — a hole a child cannot
+       see coming is not a hazard, it is an ambush. */
+    const pit = ents.pitAt(0);
+    const pitsV = deck.material.uniforms.uPits.value as THREE.Vector4;
+    pitsV.set(1e9, 1e9, 1e9, 1e9);
+    let pitSlot = 0;
+    for (const h of ents.hazards) {
+      if (!h.active || h.kind !== "pit" || pitSlot > 3) continue;
+      pitsV.setComponent(pitSlot++, h.z);
+    }
+    (deck.material.uniforms.uPitHalf as { value: number }).value = 3.4;
+    (deck.material.uniforms.uPlayerX as { value: number }).value = player.x;
+
+    player.update(dt, !pit || player.invuln > 0, rm);
+    if (player.y < -3.5) {
+      player.y = 0;
+      player.vy = 0;
+      hitHazard(player.x, "pit");
+    }
+
+    scenery.update(dt, scroll, travel, biome, parts);
+    ents.update(dt, scroll);
+    parts.update(dt, scroll);
+    player.emitThrust(dt, parts, shared.uSpeed01.value, ...thrustColor(), rm ? 0.4 : 1);
+
+    if (phase === "running") {
+      collide();
+
+      if (activeGate && activeGate.z >= GATE_PLANE && activeGate.state === "incoming") {
+        resolveGate(activeGate);
+      }
+      if (!activeGate) {
+        gateCooldown -= dt;
+        if (gateCooldown <= 0) requestGate();
+      }
+
+      if (travel >= nextBeatAt) {
+        nextBeatAt = travel + speed * beatTime(travel);
+        emitBeat();
+      }
+
+      if (travel >= nextBiomeAt) {
+        biomeIndex++;
+        prevBiome = biome;
+        biome = biomeAt(biomeIndex);
+        biomeMix = 0;
+        nextBiomeAt = travel + biomeLength(biomeIndex);
+        audio.biomeShift();
+        audio.setScale(biome.scale, biome.bpm);
+        banner(biome.name);
+        flash.fire(0.32, [1, 1, 1], rm);
+        shake.add(rm ? 0 : 0.42);
+        fovSpring.kick(rm ? 0 : 90);
+        host.haptic("medium");
+      }
+
+      /* voltage */
+      voltage -= dt * VOLT_BLEED;
+      if (voltage <= 32 && !lowVoltWarned) {
+        lowVoltWarned = true;
+        banner("Low voltage");
+      }
+      if (voltage > 40) lowVoltWarned = false;
+      if (voltage <= 32) {
+        lowVoltTick -= dt;
+        if (lowVoltTick <= 0) {
+          lowVoltTick = 0.8;
+          audio.lowVoltage();
+          host.haptic("light");
+        }
+      }
+      if (voltage <= 0) {
+        voltage = 0;
+        beginDying();
+      }
+
+      score += scroll * 1;
+    }
+
+    if (biomeMix < 1) {
+      biomeMix = Math.min(1, biomeMix + dt / 1.6);
+      applyBiomeUniforms();
+    }
+    shared.uShift.value = biomeMix < 1 ? Math.sin(biomeMix * Math.PI) * 0.55 : 0;
+
+    displayScore = approach(displayScore, score, 7, rawDt);
+    refreshHud();
+    audio.setDrive(shared.uSpeed01.value, phase === "running");
+  }
+
+  function laneMoved(): void {
+    laneSettledAt = elapsed;
+    host.haptic("light");
+    const c = colorOf(biome.accent);
+    parts.puff(player.x, 0.9, 0.9, -player.vx * 0.35, 0.6, 6, 0.3, 0.5, 0.4, c[0], c[1], c[2], 1);
+    if (!reduced()) shake.add(0.045);
+  }
+
+  function thrustColor(): [number, number, number] {
+    const c = colorOf(biome.accent2);
+    return [c[0], c[1], c[2]];
+  }
+
+  /* --------------------------------- render ------------------------------ */
+
+  const camTarget = new THREE.Vector3();
+  function render(rawDt: number, rm: boolean): void {
+    shake.update(rawDt, rm, 1);
+
+    const speed01 = shared.uSpeed01.value;
+    fovSpring.target = 72 + speed01 * 12 + (surge - 1) * 0.9 + (vw < vh ? 6 : 0);
+    const fov = fovSpring.update(rawDt);
+    const pull = pullSpring.update(rawDt);
+    const chroma = Math.max(0, chromaSpring.update(rawDt));
+
+    camera.fov = clamp(fov, 58, 104);
+    camera.position.set(
+      player.x * 0.6 + shake.x,
+      4.45 + player.y * 0.42 - (player.sliding ? 0.85 : 0) + shake.y + pull * 0.32,
+      11.4 + pull,
+    );
+    camTarget.set(player.x * 0.3, 2.35 + player.y * 0.62, -26);
+    camera.lookAt(camTarget);
+    camera.rotation.z += shake.roll + player.roll * 0.55;
+    camera.updateProjectionMatrix();
+    sky.mesh.position.copy(camera.position);
+    sky.mesh.scale.setScalar(Math.max(60, camera.far * 0.9));
+
+    /* build the frame */
+    const ac = colorOf(biome.accent);
+    const ac2 = colorOf(biome.accent2);
+    const hot = colorOf(0xffffff);
+    const good = colorOf(0x6dffb0);
+    const bad = colorOf(0xff3355);
+    const warn = colorOf(biome.inverted ? 0xff2f6d : 0xff7a1f);
+
+    shardField.begin();
+    boxField.begin();
+    skiffField.begin();
+    glow.begin();
+    digits.begin();
+
+    proj.update(camera, shared.uBend.value.x, shared.uBend.value.y);
+
+    scenery.draw(shardField, boxField, biome, shared.uShift.value);
+    ents.drawGates(boxField, glow, digits, proj, ac, hot, bad, good, numeralInk, shared.uTime.value, false);
+    ents.drawHazards(boxField, glow, warn, ac, shared.uTime.value);
+    ents.drawPits(glow, warn);
+    ents.drawSparks(glow, ac2, shared.uTime.value);
+
+    // Speed streaks: near-camera additive slivers, length driven by velocity.
+    if (!rm && tiers.settings.streaks > 0) {
+      const n = Math.round(tiers.settings.streaks * (0.25 + speed01 * 0.75));
+      const seedT = shared.uTravel.value * 0.02;
+      for (let i = 0; i < n; i++) {
+        const a = i * 2.399963;
+        const rr = 6 + ((i * 7.13) % 26);
+        const zz = -4 - ((i * 3.7 + seedT * 40) % 46);
+        glow.add(
+          Math.cos(a) * rr, 3 + Math.sin(a) * rr * 0.55, zz,
+          0.12, 0.18 + speed01 * 0.3, 10 + speed01 * 26, 0,
+          ac[0], ac[1], ac[2],
+        );
+      }
+    }
+
+    parts.draw(glow, rm ? 0.75 : 1);
+    player.draw(skiffField, boxField, glow, ac[0], ac[1], ac[2], ac2[0], ac2[1], ac2[2], rm);
+    ents.drawPopups(digits, proj);
+
+    shardField.end();
+    boxField.end();
+    skiffField.end();
+    glow.end();
+    digits.end();
+
+    post.composite.uniforms.uChroma.value = rm ? 0 : Math.min(0.02, chroma * 0.0016 + speed01 * 0.0012);
+    post.composite.uniforms.uBloomStrength.value = biome.inverted ? 0.34 : 0.62;
+    post.composite.uniforms.uVignette.value = 0.52 + shared.uDanger.value * 0.3;
+    post.composite.uniforms.uFlash.value = flash.value;
+    (post.composite.uniforms.uFlashColor.value as THREE.Color).setRGB(flash.color[0], flash.color[1], flash.color[2]);
+    // The run summary is over and may fade. The recharge gate is not over — a
+    // desaturated world behind it is the game telling a child they already lost.
+    post.composite.uniforms.uDesat.value = phase === "over" ? 0.45 : 0;
+
+    renderer.setRenderTarget(post.target);
+    renderer.render(scene, camera);
+    sceneCalls = renderer.info.render.calls;
+    sceneTris = renderer.info.render.triangles;
+    post.present();
+    renderer.setRenderTarget(null);
+  }
+
+  /* -------------------------------- events ------------------------------- */
+
+  const onStart = (): void => startRun();
+  const onAgain = (): void => startRun();
+  const onSound = (): void => {
+    sfxOn = !sfxOn;
+    audio.start();
+    audio.setEnabled(sfxOn);
+    hud.soundBtn.setAttribute("aria-pressed", String(sfxOn));
+  };
+  const onMotion = (): void => {
+    motionOverride = !motionOverride;
+    hud.motionBtn.setAttribute("aria-pressed", String(motionOverride));
+  };
+  hud.startBtn.addEventListener("click", onStart);
+  hud.againBtn.addEventListener("click", onAgain);
+  hud.soundBtn.addEventListener("click", onSound);
+  hud.motionBtn.addEventListener("click", onMotion);
+  hud.reviveLanes.forEach((b, i) => b.addEventListener("click", () => answerRevive(i)));
+
+  const onKey = (e: KeyboardEvent): void => {
+    if (phase === "idle" && (e.code === "Space" || e.code === "Enter")) {
+      e.preventDefault();
+      startRun();
+    } else if (phase === "over" && (e.code === "Space" || e.code === "Enter")) {
+      e.preventDefault();
+      startRun();
+    } else if (phase === "revive" && !reviveResolving) {
+      const map: Record<string, number> = { ArrowLeft: 0, KeyA: 0, ArrowDown: 1, KeyS: 1, ArrowUp: 1, KeyW: 1, ArrowRight: 2, KeyD: 2, Digit1: 0, Digit2: 1, Digit3: 2 };
+      const lane = map[e.code];
+      if (lane !== undefined) {
+        e.preventDefault();
+        answerRevive(lane);
+      }
+    }
+  };
+  window.addEventListener("keydown", onKey);
+
+  const onVisibility = (): void => {
+    if (document.hidden) {
+      audio.suspend();
+    } else {
+      last = performance.now();
+      if (sfxOn) audio.resume();
+    }
+  };
+  document.addEventListener("visibilitychange", onVisibility);
+
+  /**
+   * The GPU took the context away.
+   *
+   * Stopping the loop is the whole point. Preventing the default and then
+   * carrying on schedules `render()` forever against a dead context: every draw
+   * is a silent no-op, so a child sees a frozen black canvas and the host is
+   * told nothing. Better to halt, say so loudly, and let the run end.
+   */
+  const onContextLost = (e: Event): void => {
+    e.preventDefault();
+    console.error("[runner] WebGL context lost — the run cannot continue.");
+    cancelAnimationFrame(raf);
+    raf = 0;
+    audio.suspend();
+    if (phase === "running" || phase === "dying") endRun();
+  };
+  canvas.addEventListener("webglcontextlost", onContextLost);
+
+  showVeil("start");
+  refreshHud();
+  hud.startBtn.focus({ preventScroll: true });
+  raf = requestAnimationFrame(frame);
+
+  /* -------------------------------- unmount ------------------------------ */
+
+  return {
+    unmount(): void {
+      if (disposed) return;
+      disposed = true;
+      cancelAnimationFrame(raf);
+      if (reviveVerdict) window.clearTimeout(reviveVerdict);
+      ro.disconnect();
+      window.removeEventListener("keydown", onKey);
+      document.removeEventListener("visibilitychange", onVisibility);
+      canvas.removeEventListener("webglcontextlost", onContextLost);
+      hud.startBtn.removeEventListener("click", onStart);
+      hud.againBtn.removeEventListener("click", onAgain);
+      hud.soundBtn.removeEventListener("click", onSound);
+      hud.motionBtn.removeEventListener("click", onMotion);
+      input.dispose();
+      audio.dispose();
+      post.dispose();
+      shardField.dispose();
+      boxField.dispose();
+      skiffField.dispose();
+      glow.dispose();
+      digits.dispose();
+      deck.mesh.geometry.dispose();
+      deck.material.dispose();
+      ocean.geometry.dispose();
+      (ocean.material as THREE.Material).dispose();
+      sky.mesh.geometry.dispose();
+      sky.material.dispose();
+      renderer.dispose();
+      // `dispose()` unbinds three's listeners and empties its caches; it does
+      // NOT release the GL context — `forceContextLoss()` is a separate call.
+      // A browser allows on the order of sixteen live contexts, so a host that
+      // swaps packs would eventually have one evicted underneath a running game.
+      renderer.forceContextLoss();
+      // The verification probe closes over the scene, the renderer and every
+      // pool. Leaving it on `window` pins all of that for the life of the page —
+      // and the harness that uses it is precisely the thing that mounts often.
+      if (showPerf) delete (window as unknown as Record<string, unknown>).__volta;
+      hud.style.remove();
+      el.querySelectorAll(".vt-root").forEach((n) => n.remove());
+      canvas.remove();
+    },
+  };
+}

--- a/dynawalla/games/runner/src/game/options.test.ts
+++ b/dynawalla/games/runner/src/game/options.test.ts
@@ -1,0 +1,92 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { laneOptions, nudge } from "./options.ts";
+import { CHARS } from "./glyphs.ts";
+import { Rng } from "./rng.ts";
+
+/**
+ * Three lanes means a guesser is right one time in three. Everything here is
+ * about making sure the other two lanes are worth reading — that they are never
+ * the answer, never each other, never `NaN`, and never a string the atlas would
+ * mangle into a different number on the way to the screen.
+ *
+ * The gates on the causeway and the recharge gate share this file, so these
+ * assertions cover both.
+ */
+
+const renderable = (s: string): boolean => s.length > 0 && [...s].every((c) => CHARS.includes(c));
+
+function check(answer: string, distractors: string[], seed: number): void {
+  const { values, correct } = laneOptions(answer, distractors, new Rng(seed));
+  assert.ok(correct >= 0 && correct <= 2, `correct lane ${correct} is not a lane`);
+  assert.equal(new Set(values).size, 3, `${answer} -> ${values.join(" | ")} repeats a lane`);
+  for (const v of values) {
+    assert.ok(renderable(v), `"${v}" contains a character the atlas cannot draw`);
+  }
+  assert.equal(values[correct].replace(/−/g, "-"), answer.replace(/−/g, "-"));
+}
+
+test("a well-supplied question uses the host's own mal-rule distractors", () => {
+  const { values, correct } = laneOptions("42", ["13", "35", "36"], new Rng(9));
+  assert.equal(values[correct], "42");
+  const wrong = values.filter((_, i) => i !== correct);
+  for (const w of wrong) assert.ok(["13", "35", "36"].includes(w), `invented "${w}" with real ones available`);
+});
+
+test("three lanes are always filled, distinct, and never leak the answer", () => {
+  const cases: Array<[string, string[]]> = [
+    ["42", ["13", "35", "36"]],
+    ["7", ["8"]],
+    ["7", []],
+    ["0", []],
+    ["0", ["0", "0"]],
+    ["-5", ["-6"]],
+    ["−5", []],
+    ["100", ["100", "100", "100"]],
+    ["3/4", []],
+    ["3/4", ["1/4"]],
+    ["1.5", []],
+    ["999", []],
+  ];
+  for (const [answer, distractors] of cases) {
+    for (let seed = 1; seed <= 40; seed++) check(answer, distractors, seed);
+  }
+});
+
+test("a host that offers nothing usable still produces a playable gate", () => {
+  // The old code did `String(Number(answer) + k)` here, which is the literal
+  // string "NaN" for any answer that is not a bare number — shown to a child,
+  // in a lane, as if it were a real option.
+  const { values } = laneOptions("3/4", [], new Rng(3));
+  for (const v of values) assert.ok(!v.includes("N"), `offered "${v}"`);
+  assert.deepEqual([...values].sort(), ["3/3", "3/4", "3/5"]);
+});
+
+test("duplicate and empty distractors are dropped rather than shown", () => {
+  const { values, correct } = laneOptions("12", ["12", "", "12", "13"], new Rng(5));
+  assert.equal(values[correct], "12");
+  assert.ok(values.includes("13"));
+  assert.equal(new Set(values).size, 3);
+});
+
+test("a seed lays out the same gate every time, and different seeds differ", () => {
+  const one = laneOptions("42", ["13", "35", "36"], new Rng(2024));
+  const two = laneOptions("42", ["13", "35", "36"], new Rng(2024));
+  assert.deepEqual(one, two);
+  const lanes = new Set<number>();
+  for (let s = 1; s <= 60; s++) lanes.add(laneOptions("42", ["13", "35", "36"], new Rng(s)).correct);
+  assert.equal(lanes.size, 3, "the answer never reached one of the three lanes");
+});
+
+test("the nudge is exact decimal arithmetic, never a float", () => {
+  assert.equal(nudge("42", 1), "43");
+  assert.equal(nudge("42", -1), "41");
+  assert.equal(nudge("999", 1), "1000");
+  assert.equal(nudge("0", -1), null, "a nudge must not invent a stray minus sign");
+  assert.equal(nudge("3/4", 1), "3/5");
+  assert.equal(nudge("1.5", 1), "1.6");
+  assert.equal(nudge("−5", 1), "−6");
+  assert.equal(nudge("?", 1), null);
+  // Past 2^53 a float nudge starts returning the number it was given.
+  assert.equal(nudge("9007199254740993", 1), "9007199254740994");
+});

--- a/dynawalla/games/runner/src/game/options.ts
+++ b/dynawalla/games/runner/src/game/options.ts
@@ -1,0 +1,100 @@
+import { fmt } from "./glyphs.ts";
+
+/**
+ * Turning a `Question` into three lanes.
+ *
+ * Both places a child ever chooses an answer go through this: the gate arrays
+ * out on the causeway and the recharge gate that opens when the voltage runs
+ * out. They used to build their options independently, and the two
+ * implementations disagreed in ways that mattered — the recharge gate backfilled
+ * with `String(Number(answer) + k)`, which is the literal string `NaN` the
+ * moment a host answers `3/4` and offers fewer than two distractors.
+ *
+ * The rules, in order:
+ *
+ *  1. Prefer the host's own distractors. They are mal-rule outputs — what a
+ *     child actually writes when they run the wrong procedure — and they are the
+ *     whole reason a wrong lane is not free to reject.
+ *  2. Failing that, nudge the answer's own trailing number. `42` gives `43`
+ *     and `41`; `3/4` gives `3/5` and `3/3`. Both stay in the shape of the
+ *     question rather than becoming a different kind of thing.
+ *  3. Failing even that, `?`. Unreachable with any sane host, and it is at least
+ *     honestly unanswerable rather than quietly duplicated.
+ *
+ * Nothing here is float arithmetic and nothing here parses the prompt: the
+ * nudge is a decimal-string increment on an integer run, so `999` gives `1000`
+ * and never `999.9999999999999`.
+ */
+
+/** Anything that can shuffle in place, deterministically. Satisfied by `Rng`. */
+export type Shuffler = { shuffle<T>(xs: T[]): T[]; int(lo: number, hi: number): number };
+
+export type LaneOptions = {
+  /** What is drawn in lane 0, 1, 2, already typographically normalised. */
+  values: [string, string, string];
+  /** Which of them is right. */
+  correct: number;
+};
+
+/** The trailing run of digits in `s`, or null when there is not one. */
+function trailingNumber(s: string): { head: string; digits: string } | null {
+  const m = /(\d+)$/.exec(s);
+  if (!m) return null;
+  return { head: s.slice(0, s.length - m[1].length), digits: m[1] };
+}
+
+/**
+ * `s` with its trailing number moved by `k`, or null if that is not possible.
+ *
+ * Kept as string arithmetic on a `BigInt` so an answer of any length nudges
+ * exactly. A 20-digit answer is not a thing this game asks for, but silently
+ * emitting `10000000000000000000` for `9999999999999999999 + 1` would be a lie,
+ * and lies are what this file exists to prevent.
+ */
+export function nudge(s: string, k: number): string | null {
+  const t = trailingNumber(s);
+  if (!t) return null;
+  const v = BigInt(t.digits) + BigInt(k);
+  if (v < 0n) return null;
+  return `${t.head}${v.toString()}`;
+}
+
+/**
+ * Three lane values for one question, with the answer in a random lane.
+ *
+ * @param answer      the true answer, as the host wrote it
+ * @param distractors the host's wrong answers, best first
+ * @param rng         seeded; the same seed lays out the same gate
+ */
+export function laneOptions(answer: string, distractors: readonly string[], rng: Shuffler): LaneOptions {
+  const right = fmt(answer);
+  const seen = new Set<string>([right]);
+  const wrong: string[] = [];
+
+  for (const d of rng.shuffle(distractors.slice())) {
+    const v = fmt(d);
+    if (v === "" || seen.has(v)) continue;
+    seen.add(v);
+    wrong.push(v);
+    if (wrong.length === 2) break;
+  }
+
+  for (let k = 1; wrong.length < 2 && k <= 40; k++) {
+    for (const cand of [nudge(right, k), nudge(right, -k)]) {
+      if (cand === null || seen.has(cand)) continue;
+      seen.add(cand);
+      wrong.push(cand);
+      if (wrong.length === 2) break;
+    }
+  }
+
+  // Distinct, so a child is never shown the same value in two lanes even in the
+  // branch no host should ever reach.
+  for (let k = 1; wrong.length < 2; k++) wrong.push("?".repeat(k));
+
+  const correct = rng.int(0, 2);
+  const values: [string, string, string] = ["", "", ""];
+  let w = 0;
+  for (let i = 0; i < 3; i++) values[i] = i === correct ? right : wrong[w++];
+  return { values, correct };
+}

--- a/dynawalla/games/runner/src/game/pacing.test.ts
+++ b/dynawalla/games/runner/src/game/pacing.test.ts
@@ -1,0 +1,132 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  speedAt, readWindow, breather, beatTime, difficultyFor,
+  READ_WINDOW_FLOOR, V_START, V_TERMINAL, V_REDUCED_CAP,
+  COST_WRONG_GATE, COST_HAZARD, GAIN_GATE, VOLT_BLEED, VOLT_MAX,
+} from "./pacing.ts";
+import { Rng } from "./rng.ts";
+
+/* --------------------------------- pacing --------------------------------- */
+
+test("speed rises monotonically and is bounded by terminal velocity", () => {
+  let prev = -1;
+  for (let t = 0; t <= 1800; t += 5) {
+    const v = speedAt(t, false);
+    assert.ok(v >= prev - 1e-9, `speed went backwards at ${t}s`);
+    assert.ok(v >= V_START - 1e-9 && v <= V_TERMINAL, `speed ${v} out of range at ${t}s`);
+    prev = v;
+  }
+});
+
+test("the run feels fast inside a five-minute free session", () => {
+  // The business model gives a child 5-10 minutes. If terminal velocity is not
+  // reached inside that, most players never see the game's top gear.
+  assert.ok(speedAt(90, false) > 48, `only ${speedAt(90, false).toFixed(1)} u/s at 90 seconds`);
+  assert.ok(speedAt(300, false) > 0.92 * V_TERMINAL, "not near terminal velocity at five minutes");
+});
+
+test("reduced motion caps speed without stopping the world", () => {
+  for (const t of [0, 60, 600]) {
+    const v = speedAt(t, true);
+    assert.ok(v <= V_REDUCED_CAP, `reduced motion hit ${v} u/s`);
+    assert.ok(v > 20, "reduced motion must still be a runner, not a slideshow");
+  }
+});
+
+test("the reading window shrinks but never below its floor", () => {
+  let prev = Infinity;
+  for (let m = 0; m <= 60000; m += 50) {
+    const w = readWindow(m, false);
+    assert.ok(w <= prev + 1e-9, `reading window grew at ${m}m`);
+    assert.ok(w >= READ_WINDOW_FLOOR - 1e-9, `reading window collapsed to ${w}s at ${m}m`);
+    prev = w;
+  }
+  assert.ok(readWindow(0, false) > 3, "the first gates must be generous");
+  assert.ok(readWindow(1e9, true) > readWindow(1e9, false), "reduced motion must buy extra reading time");
+});
+
+test("gate cadence and hazard beats stay positive and tighten with distance", () => {
+  for (const [fn, name] of [[breather, "breather"], [beatTime, "beat"]] as const) {
+    let prev = Infinity;
+    for (let m = 0; m <= 40000; m += 100) {
+      const v = fn(m);
+      assert.ok(v > 0.15, `${name} collapsed to ${v}s at ${m}m`);
+      assert.ok(v <= prev + 1e-9, `${name} grew at ${m}m`);
+      prev = v;
+    }
+  }
+});
+
+test("a twenty-minute run keeps escalating rather than plateauing into nothing", () => {
+  // Distance covered over twenty minutes, integrated at one-second steps.
+  let travel = 0;
+  for (let t = 0; t < 1200; t++) travel += speedAt(t, false);
+  assert.ok(travel > 60000, `only ${Math.round(travel)}m in twenty minutes`);
+  // The reading window at that distance is still at its floor, not below it.
+  assert.equal(readWindow(travel, false) >= READ_WINDOW_FLOOR, true);
+});
+
+/* ------------------------------- difficulty ------------------------------- */
+
+test("difficulty climbs with distance and is clamped", () => {
+  assert.ok(difficultyFor(0, 1, 0, 0) < difficultyFor(5000, 1, 0, 0));
+  assert.ok(difficultyFor(1e9, 9, 100, 100) <= 12);
+  assert.ok(difficultyFor(0, 1, 100, 0) >= 0, "difficulty must never go negative");
+});
+
+test("a child who is drowning gets relief, not more escalation", () => {
+  const struggling = difficultyFor(4000, 1, 10, 4); // 40% right
+  const cruising = difficultyFor(4000, 1, 10, 10);
+  assert.ok(struggling < cruising - 1.5, "a bad patch must visibly ease the questions");
+  // Fewer than four answered is not evidence of anything; do not punish it.
+  assert.equal(difficultyFor(4000, 1, 3, 0), difficultyFor(4000, 1, 0, 0));
+});
+
+/* --------------------------------- economy -------------------------------- */
+
+test("the damage economy survives mistakes but punishes guessing", () => {
+  // Three lanes means a guesser is right a third of the time. Guessing must be
+  // strictly worse than reading, and one mistake must not end a run.
+  assert.ok(VOLT_MAX / COST_WRONG_GATE > 3, "fewer than three wrong gates ends a run");
+  assert.ok(VOLT_MAX / COST_WRONG_GATE < 5, "wrong gates cost too little to matter");
+  const perGuess = (1 / 3) * GAIN_GATE - (2 / 3) * COST_WRONG_GATE;
+  assert.ok(perGuess < -10, `guessing nets ${perGuess.toFixed(1)} voltage per gate, which is survivable`);
+  const perRead = GAIN_GATE;
+  assert.ok(perRead > 0, "reading must be net positive");
+  assert.ok(COST_HAZARD < COST_WRONG_GATE, "a reflex slip must cost less than a maths mistake");
+});
+
+test("the passive bleed is pressure, not a countdown", () => {
+  // Doing nothing else, an untouched player survives well past the free tier's
+  // ten minutes; the bleed only matters alongside mistakes.
+  assert.ok(VOLT_MAX / VOLT_BLEED > 400, `bleed alone kills in ${(VOLT_MAX / VOLT_BLEED).toFixed(0)}s`);
+});
+
+/* ----------------------------------- rng ---------------------------------- */
+
+test("the rng is deterministic, bounded and uniform enough to trust", () => {
+  const a = new Rng(42), b = new Rng(42), c = new Rng(43);
+  const seqA = Array.from({ length: 500 }, () => a.next());
+  const seqB = Array.from({ length: 500 }, () => b.next());
+  assert.deepEqual(seqA, seqB);
+  assert.notDeepEqual(seqA, Array.from({ length: 500 }, () => c.next()));
+  for (const v of seqA) assert.ok(v >= 0 && v < 1);
+
+  const r = new Rng(7);
+  const buckets = new Array(3).fill(0);
+  for (let i = 0; i < 30000; i++) buckets[r.int(0, 2)]++;
+  for (const n of buckets) assert.ok(n > 9000 && n < 11000, `lane bias: ${buckets.join("/")}`);
+
+  // A zero seed must not collapse the generator to a constant.
+  const z = new Rng(0);
+  assert.notEqual(z.next(), z.next());
+});
+
+test("shuffle is a permutation, in place, and reproducible", () => {
+  const r1 = new Rng(11), r2 = new Rng(11);
+  const xs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  const out = r1.shuffle(xs.slice());
+  assert.deepEqual(out.slice().sort((a, b) => a - b), xs);
+  assert.deepEqual(out, r2.shuffle(xs.slice()));
+});

--- a/dynawalla/games/runner/src/game/pacing.ts
+++ b/dynawalla/games/runner/src/game/pacing.ts
@@ -1,0 +1,113 @@
+/**
+ * The escalation curves, in one testable place.
+ *
+ * These are the numbers that decide whether a run holds a child for twenty
+ * minutes or bores them in ninety seconds, and whether the game is hard or
+ * merely unfair. They live apart from `mount.ts` so they can be asserted
+ * without a WebGL context — the floors below are promises to a ten-year-old,
+ * not implementation details, and a test should notice if someone removes one.
+ */
+
+export const V_START = 27;
+export const V_TERMINAL = 66;
+/**
+ * Seconds to close ~63% of the gap to terminal velocity.
+ *
+ * The free tier gives a child five to ten minutes, so terminal velocity has to
+ * land *inside* that window: this reads 51 u/s at ninety seconds and 62 at four
+ * minutes. A curve tuned for a twenty-minute ramp is a curve most children
+ * never see the end of.
+ */
+export const V_TAU = 95;
+/** Reduced motion still runs, just never faster than a person can track calmly. */
+export const V_REDUCED_CAP = 42;
+
+export const VOLT_MAX = 100;
+export const COST_WRONG_GATE = 27;
+export const COST_HAZARD = 15;
+export const GAIN_GATE = 8;
+export const GAIN_SPARK = 1.4;
+export const GAIN_GRAZE = 3;
+/**
+ * Passive drain per second. Small on purpose: it exists so that dawdling is not
+ * a strategy, not as a countdown. A player answering correctly gains voltage; a
+ * player guessing loses it.
+ */
+export const VOLT_BLEED = 0.22;
+
+/**
+ * Pips needed for the next surge level.
+ *
+ * Surge is the reading meter and *only* the reading meter. It used to also be
+ * knocked down by every pylon clipped and every pit fallen into, which meant a
+ * player who answered 128 gates out of 128 correctly finished a five-minute run
+ * sitting at x2 — the multiplier that is supposed to be the reward for reading
+ * instead measured how well you dodged. So the two economies are now cleanly
+ * split: **voltage is the world, surge is the maths.** Crashing costs voltage
+ * and pushes you toward the recharge gate; only a wrong answer collapses surge.
+ */
+export const CHAIN_PER_SURGE = 3;
+export const SURGE_MAX = 9;
+export const STUMBLE_TIME = 0.85;
+
+/**
+ * The share of a gate's reading window you must already have been in the right
+ * lane for it to count as a read rather than a swerve. A committed read is worth
+ * two pips, so a child who actually reads climbs twice as fast as one who
+ * ping-pongs across the lanes hoping to land somewhere.
+ */
+export const CLEAN_READ_SHARE = 0.42;
+
+/**
+ * Seconds of invulnerability granted by a successful recharge.
+ *
+ * Long enough to read the deck and pick a lane before anything can hit you.
+ * Named because the README quotes it at a child, and a constant quoted in prose
+ * is a constant that drifts.
+ */
+export const REVIVE_GRACE = 2.6;
+
+/** Forward speed in units/second at `elapsed` seconds into a run. */
+export function speedAt(elapsed: number, reduced: boolean): number {
+  const v = V_TERMINAL - (V_TERMINAL - V_START) * Math.exp(-Math.max(0, elapsed) / V_TAU);
+  return reduced ? Math.min(v, V_REDUCED_CAP) : v;
+}
+
+/**
+ * Seconds between a gate becoming visible and reaching the answer plane.
+ *
+ * This — not speed — is the real difficulty knob: the run gets harder because
+ * the time you have to read compresses. The 1.55s floor is a hard promise. A
+ * gate that arrives faster than a child can read it is not difficulty.
+ */
+export const READ_WINDOW_FLOOR = 1.55;
+export function readWindow(travel: number, reduced: boolean): number {
+  const w = READ_WINDOW_FLOOR + 1.85 * Math.exp(-Math.max(0, travel) / 2600);
+  return reduced ? w + 0.5 : w;
+}
+
+/** Quiet seconds after a gate resolves before the next one is scheduled. */
+export function breather(travel: number): number {
+  return 0.22 + 0.34 * Math.exp(-Math.max(0, travel) / 2200);
+}
+
+/** Seconds between hazard beats. Keeps rhythm constant as the world speeds up. */
+export function beatTime(travel: number): number {
+  return 0.62 + 0.55 * Math.exp(-Math.max(0, travel) / 2400);
+}
+
+/**
+ * Difficulty hint handed to the host.
+ *
+ * Distance pushes it up, a hot surge pushes it up a little more, and a genuinely
+ * bad patch pulls it down hard. The host owns real adaptivity; this only makes
+ * sure the game never keeps escalating at a child who is drowning.
+ */
+export function difficultyFor(travel: number, surge: number, gates: number, right: number): number {
+  const fromDistance = 1 + Math.max(0, travel) / 900;
+  const fromSurge = (surge - 1) * 0.25;
+  const acc = gates >= 4 ? right / gates : 1;
+  const relief = acc < 0.6 ? 2.2 : acc < 0.78 ? 1.1 : 0;
+  const d = fromDistance + fromSurge - relief;
+  return d < 0 ? 0 : d > 12 ? 12 : d;
+}

--- a/dynawalla/games/runner/src/game/particles.ts
+++ b/dynawalla/games/runner/src/game/particles.ts
@@ -1,0 +1,227 @@
+import type { GlowField } from "./fields.ts";
+
+/**
+ * One pooled, struct-of-arrays particle system for the whole game.
+ *
+ * Fixed capacity, free-list, zero allocation after construction. Particles
+ * scroll with the world so debris genuinely travels past you rather than
+ * hanging in space, and shards that land on the deck *stick* — Nijman's
+ * "permanence": the wreckage of a mistake is still behind you when you look.
+ */
+
+const KIND_SOFT = 0;
+const KIND_RING = 1;
+const KIND_STAR = 2;
+const KIND_BAR = 3;
+
+export class Particles {
+  private cap: number;
+  private x: Float32Array;
+  private y: Float32Array;
+  private z: Float32Array;
+  private vx: Float32Array;
+  private vy: Float32Array;
+  private vz: Float32Array;
+  private life: Float32Array;
+  private max: Float32Array;
+  private size: Float32Array;
+  private grow: Float32Array;
+  private r: Float32Array;
+  private g: Float32Array;
+  private b: Float32Array;
+  private kind: Float32Array;
+  private drag: Float32Array;
+  private grav: Float32Array;
+  private stretch: Float32Array;
+  /** 1 = sticks to the deck on contact and scrolls away with the world. */
+  private stick: Float32Array;
+  private alive: Uint8Array;
+  private free: Int32Array;
+  private freeN: number;
+  private liveCount = 0;
+
+  constructor(capacity: number) {
+    this.cap = capacity;
+    const f = () => new Float32Array(capacity);
+    this.x = f(); this.y = f(); this.z = f();
+    this.vx = f(); this.vy = f(); this.vz = f();
+    this.life = f(); this.max = f(); this.size = f(); this.grow = f();
+    this.r = f(); this.g = f(); this.b = f();
+    this.kind = f(); this.drag = f(); this.grav = f(); this.stretch = f(); this.stick = f();
+    this.alive = new Uint8Array(capacity);
+    this.free = new Int32Array(capacity);
+    for (let i = 0; i < capacity; i++) this.free[i] = capacity - 1 - i;
+    this.freeN = capacity;
+  }
+
+  get count(): number {
+    return this.liveCount;
+  }
+
+  clear(): void {
+    this.alive.fill(0);
+    this.freeN = this.cap;
+    for (let i = 0; i < this.cap; i++) this.free[i] = this.cap - 1 - i;
+    this.liveCount = 0;
+  }
+
+  private spawn(): number {
+    if (this.freeN === 0) return -1;
+    const i = this.free[--this.freeN];
+    this.alive[i] = 1;
+    this.liveCount++;
+    return i;
+  }
+
+  private set(
+    i: number,
+    x: number, y: number, z: number,
+    vx: number, vy: number, vz: number,
+    life: number, size: number, grow: number,
+    r: number, g: number, b: number,
+    kind: number, drag: number, grav: number, stretch: number, stick: number,
+  ): void {
+    this.x[i] = x; this.y[i] = y; this.z[i] = z;
+    this.vx[i] = vx; this.vy[i] = vy; this.vz[i] = vz;
+    this.life[i] = life; this.max[i] = life;
+    this.size[i] = size; this.grow[i] = grow;
+    this.r[i] = r; this.g[i] = g; this.b[i] = b;
+    this.kind[i] = kind; this.drag[i] = drag; this.grav[i] = grav;
+    this.stretch[i] = stretch; this.stick[i] = stick;
+  }
+
+  /* -------------------------------- emitters ------------------------------ */
+
+  /** A hard omnidirectional burst. The bread and butter. */
+  burst(
+    x: number, y: number, z: number,
+    n: number, speed: number, life: number, size: number,
+    r: number, g: number, b: number,
+    forward = 0,
+  ): void {
+    for (let k = 0; k < n; k++) {
+      const i = this.spawn();
+      if (i < 0) return;
+      const th = Math.random() * Math.PI * 2;
+      const ph = Math.acos(2 * Math.random() - 1);
+      const sp = speed * (0.35 + Math.random() * 0.85);
+      this.set(
+        i, x, y, z,
+        Math.sin(ph) * Math.cos(th) * sp,
+        Math.abs(Math.sin(ph) * Math.sin(th)) * sp * 0.9,
+        Math.cos(ph) * sp * 0.6 + forward,
+        life * (0.6 + Math.random() * 0.7),
+        size * (0.5 + Math.random()), -0.55,
+        r, g, b, KIND_SOFT, 1.6, -7, 1, 0,
+      );
+    }
+  }
+
+  /** Angular shards that arc, fall, and stay where they land. */
+  shards(
+    x: number, y: number, z: number,
+    n: number, speed: number,
+    r: number, g: number, b: number,
+    forward = 0,
+  ): void {
+    for (let k = 0; k < n; k++) {
+      const i = this.spawn();
+      if (i < 0) return;
+      const th = Math.random() * Math.PI * 2;
+      const sp = speed * (0.4 + Math.random());
+      this.set(
+        i, x, y, z,
+        Math.cos(th) * sp, 2 + Math.random() * speed * 0.8, Math.sin(th) * sp * 0.5 + forward,
+        1.5 + Math.random() * 1.9,
+        0.22 + Math.random() * 0.5, -0.12,
+        r, g, b, KIND_BAR, 0.35, -26, 1.6, 1,
+      );
+    }
+  }
+
+  /** An expanding shockwave ring. Sells scale better than any number of dots. */
+  ring(x: number, y: number, z: number, size: number, life: number, r: number, g: number, b: number, grow = 46): void {
+    const i = this.spawn();
+    if (i < 0) return;
+    this.set(i, x, y, z, 0, 0, 0, life, size, grow, r, g, b, KIND_RING, 0, 0, 1, 0);
+  }
+
+  star(x: number, y: number, z: number, size: number, life: number, r: number, g: number, b: number): void {
+    const i = this.spawn();
+    if (i < 0) return;
+    this.set(i, x, y, z, 0, 0, 0, life, size, -size * 0.6, r, g, b, KIND_STAR, 0, 0, 1, 0);
+  }
+
+  /** A single soft puff with explicit velocity. Used for thruster trails. */
+  puff(
+    x: number, y: number, z: number,
+    vx: number, vy: number, vz: number,
+    life: number, size: number, grow: number,
+    r: number, g: number, b: number, stretch = 1,
+  ): void {
+    const i = this.spawn();
+    if (i < 0) return;
+    this.set(i, x, y, z, vx, vy, vz, life, size, grow, r, g, b, KIND_SOFT, 2.2, 0, stretch, 0);
+  }
+
+  /** A vertical light column, used for lane markers and gate pillars. */
+  bar(x: number, y: number, z: number, w: number, h: number, life: number, r: number, g: number, b: number): void {
+    const i = this.spawn();
+    if (i < 0) return;
+    this.set(i, x, y, z, 0, 0, 0, life, w, -w * 0.7, r, g, b, KIND_BAR, 0, 0, h / Math.max(0.001, w), 0);
+  }
+
+  /* --------------------------------- update ------------------------------- */
+
+  update(dt: number, scroll: number): void {
+    const x = this.x, y = this.y, z = this.z;
+    const vx = this.vx, vy = this.vy, vz = this.vz;
+    for (let i = 0; i < this.cap; i++) {
+      if (this.alive[i] === 0) continue;
+      const l = (this.life[i] -= dt);
+      if (l <= 0) {
+        this.alive[i] = 0;
+        this.free[this.freeN++] = i;
+        this.liveCount--;
+        continue;
+      }
+      if (this.stick[i] === 1 && y[i] <= 0.06 && vy[i] <= 0) {
+        // Landed. Freeze it and let the world carry it away.
+        vx[i] = 0; vy[i] = 0; vz[i] = 0;
+        y[i] = 0.06;
+        this.grav[i] = 0;
+        this.stick[i] = 2;
+      } else if (this.stick[i] !== 2) {
+        const d = 1 - Math.min(0.95, this.drag[i] * dt);
+        vx[i] *= d; vy[i] *= d; vz[i] *= d;
+        vy[i] += this.grav[i] * dt;
+        x[i] += vx[i] * dt;
+        y[i] += vy[i] * dt;
+      }
+      z[i] += vz[i] * dt + scroll;
+      this.size[i] = Math.max(0.01, this.size[i] + this.grow[i] * dt);
+      // Behind the camera: recycle immediately rather than pay for it.
+      if (z[i] > 26) {
+        this.alive[i] = 0;
+        this.free[this.freeN++] = i;
+        this.liveCount--;
+      }
+    }
+  }
+
+  draw(field: GlowField, dim: number): void {
+    for (let i = 0; i < this.cap; i++) {
+      if (this.alive[i] === 0) continue;
+      const t = this.life[i] / this.max[i];
+      // Bright and hard for the first third, then a long soft tail.
+      const a = (t > 0.7 ? 1 : t / 0.7) * (t < 0.35 ? t / 0.35 : 1) * dim;
+      if (a <= 0.004) continue;
+      field.add(
+        this.x[i], this.y[i], this.z[i],
+        this.size[i], a, this.stretch[i], this.kind[i],
+        this.r[i], this.g[i], this.b[i],
+      );
+      if (field.free <= 0) return;
+    }
+  }
+}

--- a/dynawalla/games/runner/src/game/player.ts
+++ b/dynawalla/games/runner/src/game/player.ts
@@ -1,0 +1,268 @@
+import * as THREE from "three";
+import type { SolidField } from "./fields.ts";
+import type { GlowField } from "./fields.ts";
+import type { Particles } from "./particles.ts";
+import { LANE_W } from "./world.ts";
+import { clamp, clamp01, easeOutQuint, approach } from "./juice.ts";
+
+/**
+ * The skiff.
+ *
+ * A dark faceted delta with hot edges and two thruster plumes. No face, no
+ * eyes, nothing to anthropomorphise — the register is "vehicle", and a vehicle
+ * can be thrown around without it reading as cruelty.
+ *
+ * The numbers below are the whole feel of the game:
+ *
+ *   LANE_TIME 0.125s  A lane change must complete inside two frames of thought.
+ *                     Anything above ~0.18s and the player out-runs their own
+ *                     craft at speed, which reads as unresponsive rather than
+ *                     heavy.
+ *   COYOTE 0.09s      You may still jump just after the deck ends.
+ *   Squash and stretch on take-off and landing, because a rigid object landing
+ *   has no weight.
+ */
+
+const LANE_TIME = 0.125;
+const GRAV = 54;
+const JUMP_V = 16.7;
+const SLIDE_TIME = 0.5;
+const COYOTE = 0.09;
+
+const GHOSTS = 5;
+
+/**
+ * A six-facet dart, built by hand rather than from a primitive: a cone with
+ * four radial segments looks like a squashed box from behind, and the
+ * silhouette is the only thing a player ever sees of their own craft.
+ *
+ *   N nose (forward, -z)   T dorsal spine   L/R wingtips   B keel
+ */
+export function skiffGeometry(): THREE.BufferGeometry {
+  const N = [0, 0.1, -1.8];
+  const T = [0, 0.62, 0.5];
+  const L = [-1.1, 0, 1.2];
+  const R = [1.1, 0, 1.2];
+  const B = [0, -0.3, 0.4];
+  const tris = [
+    N, L, T, // upper left
+    N, T, R, // upper right
+    N, B, L, // lower left
+    N, R, B, // lower right
+    T, L, R, // transom, upper
+    B, R, L, // transom, lower
+  ];
+  const pos = new Float32Array(tris.length * 3);
+  for (let i = 0; i < tris.length; i++) {
+    pos[i * 3] = tris[i][0];
+    pos[i * 3 + 1] = tris[i][1];
+    pos[i * 3 + 2] = tris[i][2];
+  }
+  const g = new THREE.BufferGeometry();
+  g.setAttribute("position", new THREE.BufferAttribute(pos, 3));
+  g.computeVertexNormals();
+  return g;
+}
+
+export class Player {
+  lane = 1;
+  x = 0;
+  y = 0;
+  vy = 0;
+  grounded = true;
+  slideT = 0;
+  invuln = 0;
+  roll = 0;
+  /** Lateral velocity in units/s; drives lean, camera and the graze test. */
+  vx = 0;
+
+  private fromX = 0;
+  private toX = 0;
+  private laneT = 1;
+  private airborneFor = 0;
+  private squash = 0;
+  private hist: Float32Array = new Float32Array(GHOSTS * 4);
+  private histHead = 0;
+  private histAcc = 0;
+  private thrustAcc = 0;
+  hitFlash = 0;
+
+  reset(): void {
+    this.lane = 1;
+    this.x = this.fromX = this.toX = 0;
+    this.laneT = 1;
+    this.y = 0;
+    this.vy = 0;
+    this.vx = 0;
+    this.grounded = true;
+    this.slideT = 0;
+    this.invuln = 0;
+    this.roll = 0;
+    this.squash = 0;
+    this.hitFlash = 0;
+    this.hist.fill(0);
+  }
+
+  get sliding(): boolean {
+    return this.slideT > 0;
+  }
+  get airborne(): boolean {
+    return this.y > 0.08;
+  }
+  /** Half-height of the collision box; sliding halves it. */
+  get hitHalfH(): number {
+    return this.sliding ? 0.42 : 0.95;
+  }
+
+  moveLane(dir: -1 | 1): boolean {
+    const next = clamp(this.lane + dir, 0, 2);
+    if (next === this.lane) return false;
+    this.lane = next;
+    this.fromX = this.x;
+    this.toX = (next - 1) * LANE_W;
+    this.laneT = 0;
+    return true;
+  }
+
+  jump(): boolean {
+    if (!this.grounded && this.airborneFor > COYOTE) return false;
+    this.vy = JUMP_V;
+    this.grounded = false;
+    this.airborneFor = COYOTE + 1;
+    this.slideT = 0;
+    this.squash = -0.55;
+    return true;
+  }
+
+  slide(): boolean {
+    if (this.slideT > 0.1) return false;
+    this.slideT = SLIDE_TIME;
+    if (this.airborne) {
+      // Slam down: a down-swipe in the air should end the jump, not queue.
+      this.vy = Math.min(this.vy, -18);
+    }
+    this.squash = 0.4;
+    return true;
+  }
+
+  /** Knock-back on a wrong gate or a hazard: a visible, physical stumble. */
+  stumble(): void {
+    this.squash = 0.85;
+    this.hitFlash = 1;
+    this.vy = Math.max(this.vy, 4.5);
+    this.grounded = false;
+  }
+
+  update(dt: number, hasDeck: boolean, reduced: boolean): void {
+    const prevX = this.x;
+
+    if (this.laneT < 1) {
+      this.laneT = Math.min(1, this.laneT + dt / LANE_TIME);
+      this.x = this.fromX + (this.toX - this.fromX) * easeOutQuint(this.laneT);
+    } else {
+      this.x = this.toX;
+    }
+    this.vx = dt > 0 ? (this.x - prevX) / dt : 0;
+
+    if (this.slideT > 0) this.slideT = Math.max(0, this.slideT - dt);
+
+    this.vy -= GRAV * dt;
+    this.y += this.vy * dt;
+    if (!hasDeck && this.y < -4) {
+      // Fell through a pit. The caller reads `y < -4` as a hazard hit and
+      // resets; nothing to do here but keep falling so it looks like falling.
+    } else if (this.y <= 0 && hasDeck) {
+      if (!this.grounded && this.vy < -6) this.squash = clamp01(-this.vy / 26) * 0.9;
+      this.y = 0;
+      this.vy = 0;
+      this.grounded = true;
+      this.airborneFor = 0;
+    } else if (this.y > 0) {
+      this.grounded = false;
+    }
+    if (!this.grounded) this.airborneFor += dt;
+
+    if (this.invuln > 0) this.invuln = Math.max(0, this.invuln - dt);
+    if (this.hitFlash > 0) this.hitFlash = Math.max(0, this.hitFlash - dt * 2.2);
+    this.squash = approach(this.squash, 0, 11, dt);
+
+    const targetRoll = reduced ? 0 : clamp(-this.vx * 0.022, -0.5, 0.5);
+    this.roll = approach(this.roll, targetRoll, 16, dt);
+
+    // Ghost trail sampling.
+    this.histAcc += dt;
+    while (this.histAcc >= 0.024) {
+      this.histAcc -= 0.024;
+      const i = (this.histHead = (this.histHead + 1) % GHOSTS) * 4;
+      this.hist[i] = this.x;
+      this.hist[i + 1] = this.y;
+      this.hist[i + 2] = this.roll;
+      this.hist[i + 3] = 1;
+    }
+  }
+
+  emitThrust(dt: number, parts: Particles, speed01: number, r: number, g: number, b: number, quality: number): void {
+    this.thrustAcc += dt * (34 + speed01 * 90) * quality;
+    while (this.thrustAcc >= 1) {
+      this.thrustAcc -= 1;
+      const side = Math.random() < 0.5 ? -0.52 : 0.52;
+      parts.puff(
+        this.x + side, this.y + 0.28, 1.35,
+        (Math.random() - 0.5) * 2.5, (Math.random() - 0.2) * 2.2, 16 + Math.random() * 22,
+        0.28 + Math.random() * 0.22,
+        0.34 + Math.random() * 0.3, 1.6,
+        r, g, b, 1.5,
+      );
+    }
+  }
+
+  draw(
+    field: SolidField, boxField: SolidField, glow: GlowField,
+    r: number, g: number, b: number,
+    hotR: number, hotG: number, hotB: number,
+    reduced: boolean,
+  ): void {
+    const sq = this.squash;
+    const sy = 1 - sq * 0.55;
+    const sx = 1 + sq * 0.4;
+    const hurt = this.hitFlash;
+    const cr = r + (1 - r) * hurt;
+    const cg = g * (1 - hurt * 0.75);
+    const cb = b * (1 - hurt * 0.75);
+
+    // Blink on invulnerability. Never colour alone: the skiff also shrinks to a
+    // wire outline, which reads at any contrast.
+    const blink = this.invuln > 0 ? (Math.sin(this.invuln * 34) > -0.2 ? 1 : 0.28) : 1;
+
+    if (!reduced) {
+      for (let i = 1; i <= GHOSTS; i++) {
+        const idx = ((this.histHead - i + GHOSTS * 2) % GHOSTS) * 4;
+        if (this.hist[idx + 3] === 0) continue;
+        const f = (1 - i / (GHOSTS + 1)) * 0.16 * blink;
+        field.add(
+          this.hist[idx], 0.72 + this.hist[idx + 1], 0.35 + i * 0.5,
+          sx * (1 - i * 0.06), sy * (1 - i * 0.06), 1 - i * 0.04,
+          0,
+          cr, cg, cb, 0.15, f,
+        );
+      }
+    }
+
+    field.add(this.x, 0.72 + this.y, 0, sx, sy, 1, 0, cr, cg, cb, 1.5 + hurt * 3, blink);
+
+    // Nacelles + the underglow strip.
+    const nz = 1.15;
+    boxField.add(this.x - 0.62, 0.62 + this.y, nz, 0.34, 0.3, 0.7, 0, hotR, hotG, hotB, 2.4, blink);
+    boxField.add(this.x + 0.62, 0.62 + this.y, nz, 0.34, 0.3, 0.7, 0, hotR, hotG, hotB, 2.4, blink);
+    boxField.add(this.x, 0.34 + this.y, 0.25, 1.5, 0.1, 2.1, 0, cr, cg, cb, 2.0, blink * 0.9);
+
+    // Thruster cones and a contact glow on the deck.
+    glow.add(this.x - 0.62, 0.62 + this.y, nz + 0.5, 1.15, 0.8 * blink, 1, 0, hotR, hotG, hotB);
+    glow.add(this.x + 0.62, 0.62 + this.y, nz + 0.5, 1.15, 0.8 * blink, 1, 0, hotR, hotG, hotB);
+    const alt = clamp01(1 - this.y / 4);
+    glow.add(this.x, 0.05, 0.2, 3.4 + alt * 1.2, 0.34 * alt * blink, 0.42, 0, r, g, b);
+    if (hurt > 0.02) {
+      glow.add(this.x, 0.9 + this.y, 0.2, 5 + hurt * 5, hurt * 0.9, 1, 1, 1, 0.25, 0.3);
+    }
+  }
+}

--- a/dynawalla/games/runner/src/game/post.ts
+++ b/dynawalla/games/runner/src/game/post.ts
@@ -1,0 +1,256 @@
+import * as THREE from "three";
+
+/**
+ * A small hand-rolled bloom + composite chain.
+ *
+ * Three's `UnrealBloomPass` is five render targets and a mip chain; on a
+ * mid-range tablet that is most of the frame. This does the same job in a
+ * bright-pass plus a couple of half-resolution ping-pongs, with the pass count
+ * driven by the quality tier so LOW can skip the whole thing and render
+ * straight to the canvas.
+ *
+ * The composite also owns chromatic aberration, the vignette and the screen
+ * flash, so at HIGH and above they cost nothing extra — one dependent texture
+ * read that was already happening.
+ */
+
+const TRI = /* glsl */ `
+varying vec2 vUv;
+void main() {
+  vUv = uv;
+  gl_Position = vec4(position.xy, 0.0, 1.0);
+}
+`;
+
+const BRIGHT = /* glsl */ `
+precision highp float;
+varying vec2 vUv;
+uniform sampler2D uSrc;
+uniform float uThreshold;
+uniform float uKnee;
+void main() {
+  vec3 c = texture2D(uSrc, vUv).rgb;
+  float l = max(c.r, max(c.g, c.b));
+  float s = clamp((l - uThreshold) / max(0.0001, uKnee), 0.0, 1.0);
+  gl_FragColor = vec4(c * s * s, 1.0);
+}
+`;
+
+const BLUR = /* glsl */ `
+precision highp float;
+varying vec2 vUv;
+uniform sampler2D uSrc;
+uniform vec2 uDir;
+void main() {
+  // 9-tap gaussian folded to 5 texture reads with linear sampling.
+  vec3 c = texture2D(uSrc, vUv).rgb * 0.227027;
+  c += texture2D(uSrc, vUv + uDir * 1.3846153846).rgb * 0.3162162162;
+  c += texture2D(uSrc, vUv - uDir * 1.3846153846).rgb * 0.3162162162;
+  c += texture2D(uSrc, vUv + uDir * 3.2307692308).rgb * 0.0702702703;
+  c += texture2D(uSrc, vUv - uDir * 3.2307692308).rgb * 0.0702702703;
+  gl_FragColor = vec4(c, 1.0);
+}
+`;
+
+const COMPOSITE = /* glsl */ `
+precision highp float;
+varying vec2 vUv;
+uniform sampler2D uScene;
+uniform sampler2D uBloom;
+uniform float uBloomStrength;
+uniform float uChroma;
+uniform float uVignette;
+uniform vec3 uVignetteColor;
+uniform float uFlash;
+uniform vec3 uFlashColor;
+uniform float uExposure;
+uniform float uDesat;
+
+void main() {
+  vec2 uv = vUv;
+  vec2 d = uv - 0.5;
+  float r2 = dot(d, d);
+
+  vec3 col;
+  if (uChroma > 0.0005) {
+    // Radial split, strongest at the edges where the eye tolerates it.
+    vec2 off = d * uChroma * (0.25 + r2 * 2.4);
+    col.r = texture2D(uScene, uv + off).r;
+    col.g = texture2D(uScene, uv).g;
+    col.b = texture2D(uScene, uv - off).b;
+  } else {
+    col = texture2D(uScene, uv).rgb;
+  }
+
+  col += texture2D(uBloom, uv).rgb * uBloomStrength;
+  col *= uExposure;
+
+  if (uDesat > 0.001) {
+    float l = dot(col, vec3(0.299, 0.587, 0.114));
+    col = mix(col, vec3(l), uDesat);
+  }
+
+  float v = 1.0 - smoothstep(0.18, 0.95, r2 * 2.0) * uVignette;
+  col = mix(uVignetteColor, col, clamp(v, 0.0, 1.0));
+
+  col = mix(col, uFlashColor, clamp(uFlash, 0.0, 1.0));
+
+  // Filmic-ish shoulder. Keeps the white-out biome from clipping to a flat
+  // sheet, which is both ugly and a photosensitivity hazard.
+  col = (col * (2.51 * col + 0.03)) / (col * (2.43 * col + 0.59) + 0.14);
+
+  // Explicit linear -> sRGB. A raw ShaderMaterial gets no colour-space chunk
+  // injected by three, so the encode has to happen here or the whole game
+  // renders crushed and over-saturated.
+  col = clamp(col, 0.0, 1.0);
+  col = mix(col * 12.92, 1.055 * pow(col, vec3(1.0 / 2.4)) - 0.055, step(vec3(0.0031308), col));
+  gl_FragColor = vec4(col, 1.0);
+}
+`;
+
+function fullscreenTriangle(): THREE.BufferGeometry {
+  const g = new THREE.BufferGeometry();
+  g.setAttribute("position", new THREE.BufferAttribute(new Float32Array([-1, -1, 0, 3, -1, 0, -1, 3, 0]), 3));
+  g.setAttribute("uv", new THREE.BufferAttribute(new Float32Array([0, 0, 2, 0, 0, 2]), 2));
+  return g;
+}
+
+export class Post {
+  private renderer: THREE.WebGLRenderer;
+  private scene = new THREE.Scene();
+  private cam = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+  private quad: THREE.Mesh;
+  private geo = fullscreenTriangle();
+
+  private sceneRT!: THREE.WebGLRenderTarget;
+  private rtA!: THREE.WebGLRenderTarget;
+  private rtB!: THREE.WebGLRenderTarget;
+
+  private bright: THREE.ShaderMaterial;
+  private blur: THREE.ShaderMaterial;
+  readonly composite: THREE.ShaderMaterial;
+
+  private w = 1;
+  private h = 1;
+  passes = 3;
+  enabled = true;
+
+  constructor(renderer: THREE.WebGLRenderer) {
+    this.renderer = renderer;
+    this.bright = new THREE.ShaderMaterial({
+      uniforms: { uSrc: { value: null }, uThreshold: { value: 1.05 }, uKnee: { value: 0.55 } },
+      vertexShader: TRI, fragmentShader: BRIGHT, depthTest: false, depthWrite: false,
+    });
+    this.blur = new THREE.ShaderMaterial({
+      uniforms: { uSrc: { value: null }, uDir: { value: new THREE.Vector2() } },
+      vertexShader: TRI, fragmentShader: BLUR, depthTest: false, depthWrite: false,
+    });
+    this.composite = new THREE.ShaderMaterial({
+      uniforms: {
+        uScene: { value: null },
+        uBloom: { value: null },
+        uBloomStrength: { value: 0.85 },
+        uChroma: { value: 0 },
+        uVignette: { value: 0.6 },
+        uVignetteColor: { value: new THREE.Color(0x000208) },
+        uFlash: { value: 0 },
+        uFlashColor: { value: new THREE.Color(0xffffff) },
+        uExposure: { value: 1.05 },
+        uDesat: { value: 0 },
+      },
+      vertexShader: TRI, fragmentShader: COMPOSITE, depthTest: false, depthWrite: false,
+    });
+    this.quad = new THREE.Mesh(this.geo, this.composite);
+    this.quad.frustumCulled = false;
+    this.scene.add(this.quad);
+    this.build(2, 2);
+  }
+
+  /** LOW runs the composite with zero bloom passes, so it needs no HDR buffer. */
+  hdr = true;
+
+  private build(w: number, h: number): void {
+    const type = this.hdr && this.renderer.capabilities.isWebGL2 ? THREE.HalfFloatType : THREE.UnsignedByteType;
+    const opts = { type, depthBuffer: true, stencilBuffer: false, samples: 0 };
+    this.sceneRT?.dispose();
+    this.rtA?.dispose();
+    this.rtB?.dispose();
+    this.sceneRT = new THREE.WebGLRenderTarget(w, h, opts);
+    const bw = Math.max(2, Math.floor(w / 2));
+    const bh = Math.max(2, Math.floor(h / 2));
+    this.rtA = new THREE.WebGLRenderTarget(bw, bh, { ...opts, depthBuffer: false });
+    this.rtB = new THREE.WebGLRenderTarget(bw, bh, { ...opts, depthBuffer: false });
+    for (const rt of [this.sceneRT, this.rtA, this.rtB]) {
+      rt.texture.minFilter = THREE.LinearFilter;
+      rt.texture.magFilter = THREE.LinearFilter;
+      rt.texture.generateMipmaps = false;
+      rt.texture.wrapS = THREE.ClampToEdgeWrapping;
+      rt.texture.wrapT = THREE.ClampToEdgeWrapping;
+    }
+    this.w = w;
+    this.h = h;
+  }
+
+  setSize(w: number, h: number): void {
+    if (w === this.w && h === this.h) return;
+    this.build(Math.max(2, w), Math.max(2, h));
+  }
+
+  setHdr(on: boolean): void {
+    if (on === this.hdr) return;
+    this.hdr = on;
+    this.build(this.w, this.h);
+  }
+
+  get target(): THREE.WebGLRenderTarget | null {
+    return this.enabled ? this.sceneRT : null;
+  }
+
+  private draw(mat: THREE.ShaderMaterial, target: THREE.WebGLRenderTarget | null): void {
+    this.quad.material = mat;
+    this.renderer.setRenderTarget(target);
+    this.renderer.render(this.scene, this.cam);
+  }
+
+  /** Runs the bloom chain and blits to the canvas. */
+  present(): void {
+    if (!this.enabled) return;
+    const r = this.renderer;
+    const auto = r.autoClear;
+    r.autoClear = true;
+
+    if (this.passes > 0) {
+      this.bright.uniforms.uSrc.value = this.sceneRT.texture;
+      this.draw(this.bright, this.rtA);
+      const bw = this.rtA.width;
+      const bh = this.rtA.height;
+      for (let i = 0; i < this.passes; i++) {
+        const spread = 1 + i * 1.35;
+        this.blur.uniforms.uSrc.value = this.rtA.texture;
+        (this.blur.uniforms.uDir.value as THREE.Vector2).set(spread / bw, 0);
+        this.draw(this.blur, this.rtB);
+        this.blur.uniforms.uSrc.value = this.rtB.texture;
+        (this.blur.uniforms.uDir.value as THREE.Vector2).set(0, spread / bh);
+        this.draw(this.blur, this.rtA);
+      }
+      this.composite.uniforms.uBloom.value = this.rtA.texture;
+    } else {
+      this.composite.uniforms.uBloom.value = null;
+      this.composite.uniforms.uBloomStrength.value = 0;
+    }
+
+    this.composite.uniforms.uScene.value = this.sceneRT.texture;
+    this.draw(this.composite, null);
+    r.autoClear = auto;
+  }
+
+  dispose(): void {
+    this.sceneRT.dispose();
+    this.rtA.dispose();
+    this.rtB.dispose();
+    this.bright.dispose();
+    this.blur.dispose();
+    this.composite.dispose();
+    this.geo.dispose();
+  }
+}

--- a/dynawalla/games/runner/src/game/project.ts
+++ b/dynawalla/games/runner/src/game/project.ts
@@ -1,0 +1,111 @@
+import * as THREE from "three";
+
+/**
+ * World space <-> screen space, at one depth on the causeway.
+ *
+ * This exists because of a bug that made the whole game unplayable, and the bug
+ * is worth writing down.
+ *
+ * The three gate candidates used to be placed in world space, at the lanes,
+ * fanned outward by a factor that grew with distance. That cannot work, and no
+ * amount of tuning makes it work: the camera sits 11.4 units behind a causeway
+ * whose lanes are 3.35 units apart, so the *widest* the lane pitch ever gets on
+ * screen is about 12% of the viewport — and only in the last third of a second
+ * before the gate arrives. For the whole reading window the three numerals were
+ * a few dozen pixels apart, and two-digit values ran together into one string:
+ * 13 | 42 | 36 read as "134236". On a 390px phone the fan-out compensation
+ * overshot the other way and pushed the third numeral off the right edge.
+ *
+ * Perspective is the wrong tool for laying out text a child has 0.45s to read.
+ * So the numerals are laid out in *screen* units — an explicit pitch, an
+ * explicit gutter, an explicit page margin — and this class converts that layout
+ * back into the world positions the instanced digit shader wants, so they still
+ * fog, still bend with the causeway, still belong to the world.
+ *
+ * `at()` linearises the projection around a depth. It is exact for the camera
+ * pointing straight down -z and a few tenths of a percent off under the small
+ * yaw the chase camera applies, which is far inside the gutter.
+ */
+export class Projector {
+  private vp = new THREE.Matrix4();
+  private v = new THREE.Vector3();
+  private bendX = 0;
+  private bendY = 0;
+
+  /** NDC x of pre-bend world x = 0, at the last `at()` depth. */
+  x0 = 0;
+  /** NDC x per world unit. */
+  kx = 1;
+  /** NDC y of world y = 0. */
+  y0 = 0;
+  /** NDC y per world unit. */
+  ky = 1;
+
+  /** Call once per frame, after the camera is posed. */
+  update(camera: THREE.PerspectiveCamera, bendX: number, bendY: number): void {
+    camera.updateMatrixWorld(true);
+    this.vp.multiplyMatrices(camera.projectionMatrix, camera.matrixWorldInverse);
+    this.bendX = bendX;
+    this.bendY = bendY;
+  }
+
+  /**
+   * Linearise at world depth `z`, referenced around height `yRef`.
+   *
+   * The baseline is deliberately wide (12 units, about the span the numeral row
+   * actually occupies) rather than a unit step, so the secant it measures is the
+   * one the layout will use instead of a tangent at the centre.
+   */
+  at(z: number, yRef: number): void {
+    const d = Math.max(0, -z);
+    const k = d * d;
+    const bx = this.bendX * k;
+    const by = this.bendY * k;
+    const B = 6;
+    const v = this.v;
+    const vp = this.vp;
+
+    v.set(bx, yRef + by, z).applyMatrix4(vp);
+    this.x0 = v.x;
+    const centreY = v.y;
+
+    v.set(B + bx, yRef + by, z).applyMatrix4(vp);
+    const right = v.x;
+    v.set(-B + bx, yRef + by, z).applyMatrix4(vp);
+    const left = v.x;
+    let kx = (right - left) / (2 * B);
+    if (!Number.isFinite(kx) || Math.abs(kx) < 1e-6) kx = 1e-6;
+    this.kx = kx;
+
+    v.set(bx, yRef + B + by, z).applyMatrix4(vp);
+    const up = v.y;
+    v.set(bx, yRef - B + by, z).applyMatrix4(vp);
+    const down = v.y;
+    let ky = (up - down) / (2 * B);
+    if (!Number.isFinite(ky) || Math.abs(ky) < 1e-6) ky = 1e-6;
+    this.ky = ky;
+
+    // Re-anchor to world y = 0 using the measured slope.
+    this.y0 = centreY - ky * yRef;
+  }
+
+  /** Pre-bend world x whose rendered position lands at NDC `ndcX`. */
+  worldX(ndcX: number): number {
+    return (ndcX - this.x0) / this.kx;
+  }
+
+  /** Pre-bend world y whose rendered position lands at NDC `ndcY`. */
+  worldY(ndcY: number): number {
+    return (ndcY - this.y0) / this.ky;
+  }
+
+  /** NDC y of a world height, at the current depth. */
+  ndcY(worldY: number): number {
+    return this.y0 + this.ky * worldY;
+  }
+
+  /** World size that renders `n` NDC units tall at the current depth. */
+  worldFromNdcY(n: number): number {
+    return n / Math.abs(this.ky);
+  }
+}

--- a/dynawalla/games/runner/src/game/readband.test.ts
+++ b/dynawalla/games/runner/src/game/readband.test.ts
@@ -1,0 +1,235 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { BAND, readBand, payoffHeight, keepInside, PAYOFF_EDGE, PAYOFF_MAX_H, POPUP_EDGE } from "./readband.ts";
+import { INK, TRACK } from "./glyphs.ts";
+
+/**
+ * The regression suite for the bug that made VOLTA unplayable.
+ *
+ * A judge played the shipped build and captured 13|42|36 rendering as
+ * "134236" and 82|92|72 as "829272", and on a 390px phone the third value was
+ * clipped off the right edge entirely. These tests exist so that can never
+ * return, on any device, for any answer the curriculum can produce.
+ *
+ * Nothing here needs a GPU: `readBand` is pure arithmetic over the projection's
+ * two scale factors, so the whole device matrix is a loop.
+ */
+
+/* The camera, mirrored from mount.ts so the numbers are the real ones. */
+const FOV_MIN = 58;
+const FOV_MAX = 104;
+const CAM_Z = 11.4;
+
+/** NDC-per-world-unit at a gate `dist` metres ahead, for a viewport and FOV. */
+function scales(w: number, h: number, fovDeg: number, dist: number): { kx: number; ky: number } {
+  const aspect = w / h;
+  const ky = 1 / Math.tan((fovDeg * Math.PI) / 360) / (dist + CAM_Z);
+  return { kx: ky / aspect, ky };
+}
+
+/**
+ * World width of a numeral at ink height 1.
+ *
+ * The atlas is built from whatever font the device actually resolves, so the
+ * per-digit advance is not a constant we control. This sweeps the whole
+ * plausible range — a condensed grotesque through Arial Black — so the layout
+ * has to hold for any of them.
+ *
+ * `INK` and `TRACK` come from `glyphs.ts` rather than being copied here: a floor
+ * asserted against a copy of the renderer's metrics is a floor on a font nobody
+ * ships.
+ */
+function unit(digits: number, advance: number): number {
+  return digits * advance * (1 / INK) * TRACK;
+}
+
+const VIEWPORTS: Array<[number, number, string]> = [
+  [320, 568, "320 phone portrait"],
+  [360, 640, "360 phone portrait"],
+  [390, 844, "390 phone portrait"],
+  [844, 390, "phone landscape"],
+  [768, 1024, "tablet portrait"],
+  [1024, 768, "tablet landscape"],
+  [1280, 800, "laptop"],
+  [1920, 1080, "desktop"],
+  [2560, 1080, "ultrawide"],
+];
+const ADVANCES = [0.36, 0.43, 0.5];
+const DIGIT_COUNTS = [1, 2, 3, 4];
+const DISTANCES = [4, 12, 30, 60, 100, 160, 240];
+const APPROACHES = [0, 0.25, 0.5, 0.75, 1];
+
+function forEachCase(fn: (b: ReturnType<typeof readBand>, ctx: string, w: number, h: number) => void): void {
+  for (const [vw, vh, label] of VIEWPORTS) {
+    for (const fov of [FOV_MIN, 74, FOV_MAX]) {
+      for (const dist of DISTANCES) {
+        const { kx, ky } = scales(vw, vh, fov, dist);
+        for (const adv of ADVANCES) {
+          for (const n of DIGIT_COUNTS) {
+            // Worst case for collision is every candidate at the widest size.
+            const u = unit(n, adv);
+            for (const a of APPROACHES) {
+              for (const archTop of [-0.4, 0, 0.2, 0.6, 1.4]) {
+                const band = readBand([u, u, u], kx, ky, a, archTop);
+                fn(band, `${label} fov${fov} d${dist} adv${adv} n${n} a${a} arch${archTop}`, vw, vh);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+test("adjacent candidates never touch", () => {
+  forEachCase((band, ctx) => {
+    const gap = band.pitch - band.wNdc;
+    assert.ok(
+      gap > 0.12,
+      `${ctx}: gutter ${gap.toFixed(3)} NDC is too small — numerals would read as one string`,
+    );
+  });
+});
+
+test("no candidate is clipped by the viewport", () => {
+  forEachCase((band, ctx) => {
+    const outer = Math.abs(band.x[2]) + band.wNdc / 2;
+    assert.ok(outer <= BAND.edge + 1e-9, `${ctx}: right candidate reaches ${outer.toFixed(3)} NDC`);
+    assert.ok(band.y - band.hNdc / 2 > -1, `${ctx}: row sinks off the bottom`);
+    assert.ok(band.y + band.hNdc / 2 < 1, `${ctx}: row rises off the top`);
+  });
+});
+
+test("the row never collides with the prompt", () => {
+  forEachCase((band, ctx) => {
+    assert.ok(band.y + band.hNdc / 2 <= BAND.top + 1e-9, `${ctx}: row overlaps the prompt line`);
+  });
+});
+
+test("numerals stay big enough to read on the smallest supported screen", () => {
+  // The floor is the smallest phone we claim to support, the widest font, and
+  // the most digits an answer realistically has.
+  const { kx, ky } = scales(320, 568, 74, 90);
+  const u = unit(3, 0.5);
+  const band = readBand([u, u, u], kx, ky, 0, 0.1);
+  const capPx = (band.hNdc / 2) * 568;
+  assert.ok(capPx >= 24, `three digits at 320px render at ${capPx.toFixed(1)}px cap height`);
+});
+
+test("two digits on a 390px phone are unmistakable", () => {
+  const { kx, ky } = scales(390, 844, 74, 90);
+  const u = unit(2, 0.43);
+  const band = readBand([u, u, u], kx, ky, 0, 0.1);
+  const capPx = (band.hNdc / 2) * 844;
+  const gapPx = ((band.pitch - band.wNdc) / 2) * 390;
+  assert.ok(capPx >= 44, `two digits at 390px render at ${capPx.toFixed(1)}px cap height`);
+  assert.ok(gapPx >= 24, `only ${gapPx.toFixed(1)}px of clear air between candidates at 390px`);
+});
+
+test("apparent size does not depend on how far away the gate is", () => {
+  // The old layout scaled with distance, so a numeral was eleven pixels tall
+  // when it mattered and a wall of ink when it no longer did.
+  const u = unit(2, 0.43);
+  const sizes = DISTANCES.map((d) => {
+    const { kx, ky } = scales(1280, 800, 74, d);
+    return readBand([u, u, u], kx, ky, 0, 0.1).hNdc;
+  });
+  for (const s of sizes) assert.ok(Math.abs(s - sizes[0]) < 1e-6, `sizes drift with distance: ${sizes.join(", ")}`);
+});
+
+test("a mixed-width gate sizes every candidate to the widest", () => {
+  const { kx, ky } = scales(1280, 800, 74, 60);
+  const wide = unit(3, 0.43);
+  const narrow = unit(1, 0.43);
+  const mixed = readBand([narrow, wide, narrow], kx, ky, 0.3, 0.1);
+  const allWide = readBand([wide, wide, wide], kx, ky, 0.3, 0.1);
+  assert.equal(mixed.hNdc, allWide.hNdc);
+});
+
+test("the row opens outward as the gate arrives", () => {
+  const u = unit(2, 0.43);
+  const { kx, ky } = scales(1280, 800, 74, 60);
+  const far = readBand([u, u, u], kx, ky, 0, 0.1);
+  const near = readBand([u, u, u], kx, ky, 1, 0.1);
+  assert.ok(near.pitch > far.pitch, "candidates should spread as the gate closes");
+});
+
+/* -------------------------------------------------------------------------- */
+/* The payoff, and the score popups.                                          */
+/* -------------------------------------------------------------------------- */
+
+/** NDC width per NDC of height, for `n` digits on a viewport. Mirrors the caller. */
+function widthPerHeight(n: number, advance: number, w: number, h: number, fovDeg: number): number {
+  const { kx, ky } = scales(w, h, fovDeg, 14);
+  return unit(n, advance) * (Math.abs(kx) / Math.abs(ky));
+}
+
+test("the winning numeral never rushes past the edge of the screen", () => {
+  // The best moment in the game used to swell to a flat 1.55 NDC *tall* with
+  // nothing looking at how wide that made it. On a 390px phone a two-digit
+  // answer came out 2.7 NDC wide against a 2.0 NDC screen: two green slabs.
+  for (const [vw, vh, label] of VIEWPORTS) {
+    for (const fov of [FOV_MIN, 74, FOV_MAX]) {
+      for (const adv of ADVANCES) {
+        for (const n of DIGIT_COUNTS) {
+          const wPerH = widthPerHeight(n, adv, vw, vh, fov);
+          for (const swell of [0, 0.25, 0.5, 0.75, 1]) {
+            const h = payoffHeight(wPerH, 0.2, swell);
+            const ctx = `${label} fov${fov} adv${adv} n${n} swell${swell}`;
+            assert.ok(h * wPerH <= 2 * PAYOFF_EDGE + 1e-9, `${ctx}: payoff is ${(h * wPerH).toFixed(2)} NDC wide`);
+            assert.ok(h <= PAYOFF_MAX_H + 1e-9, `${ctx}: payoff is ${h.toFixed(2)} NDC tall`);
+          }
+        }
+      }
+    }
+  }
+});
+
+test("the payoff grows out of the row and never shrinks back", () => {
+  const wPerH = widthPerHeight(2, 0.43, 1280, 800, 74);
+  let prev = -Infinity;
+  for (let s = 0; s <= 1.0001; s += 0.05) {
+    const h = payoffHeight(wPerH, 0.2, s);
+    assert.ok(h >= prev - 1e-12, `payoff shrank at swell ${s.toFixed(2)}`);
+    prev = h;
+  }
+  assert.equal(payoffHeight(wPerH, 0.2, 0), 0.2, "the payoff must start exactly where the row left off");
+});
+
+test("the swell is one-way even for a row the layout cannot currently produce", () => {
+  // `readBand` keeps every candidate well inside the payoff ceiling, so this
+  // input does not arise today. It is asserted anyway: a numeral that shrank on
+  // a win would read as the game reclaiming the prize, and that should be
+  // impossible by construction rather than by the row happening to be small.
+  const wPerH = widthPerHeight(4, 0.5, 320, 568, FOV_MAX);
+  const from = 1.4;
+  for (const s of [0, 0.5, 1]) {
+    assert.ok(payoffHeight(wPerH, from, s) >= from, `payoff dipped below ${from} at swell ${s}`);
+  }
+});
+
+test("the read band never hands the payoff a numeral that is already too wide", () => {
+  // The invariant the one-way swell above is standing in for. If this ever
+  // fails, the payoff ceiling has stopped being the binding constraint and the
+  // two functions need to be reconciled rather than both quietly clamping.
+  forEachCase((band, ctx) => {
+    // `scale` in `drawCandidates` is an easeOutBack, which overshoots ~10%.
+    assert.ok(band.wNdc * 1.1 <= 2 * PAYOFF_EDGE, `${ctx}: row is ${band.wNdc.toFixed(2)} NDC wide`);
+  });
+});
+
+test("a score popup gives up its lane rather than hang off the edge", () => {
+  // "+100" over the outer lane used to hang half off a 390px screen as "00".
+  for (const halfW of [0, 0.1, 0.4, 0.9, 1.4]) {
+    for (const nx of [-3, -0.9, -0.2, 0, 0.2, 0.9, 3]) {
+      const x = keepInside(nx, halfW);
+      assert.ok(Math.abs(x) + halfW <= POPUP_EDGE + 1e-9 || halfW >= POPUP_EDGE,
+        `half-width ${halfW} at ${nx} landed at ${x.toFixed(2)}`);
+      assert.ok(Math.abs(x) <= Math.abs(nx) + 1e-9, "clamping moved the popup outward");
+      assert.ok(x === 0 || Math.sign(x) === Math.sign(nx), "clamping flipped the popup to the other side");
+    }
+  }
+  // Something already inside is left exactly alone, so the common case is a
+  // no-op and the popup keeps its lane.
+  assert.equal(keepInside(0.3, 0.2), 0.3);
+});

--- a/dynawalla/games/runner/src/game/readband.ts
+++ b/dynawalla/games/runner/src/game/readband.ts
@@ -1,0 +1,171 @@
+/**
+ * Where the three gate candidates go, in screen units.
+ *
+ * The single most important function in this game, because it is the one that
+ * decides whether a child can read the question at all. It is pure arithmetic
+ * with no THREE in sight so that `readband.test.ts` can hammer it with every
+ * viewport and every candidate width the game can produce and assert the two
+ * properties that actually matter:
+ *
+ *   1. adjacent numerals never touch — there is always a gutter wider than a
+ *      digit stroke, so 13 | 42 | 36 can never render as "134236";
+ *   2. nothing leaves the viewport — including the third numeral on a 320px
+ *      phone, which used to be clipped clean off the right edge.
+ *
+ * Everything is NDC: x and y run -1..+1 across the viewport, so "0.5" means a
+ * quarter of the screen's width regardless of device, orientation or DPR. The
+ * caller converts back to world space with `Projector`.
+ */
+
+const clamp01 = (v: number) => (v < 0 ? 0 : v > 1 ? 1 : v);
+const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+
+export const BAND = {
+  /** NDC x between adjacent candidates while the gate is still distant. */
+  pitchFar: 0.58,
+  /** ...and by the time it arrives. The row opens out as it comes at you. */
+  pitchNear: 0.72,
+  /**
+   * The share of the pitch a numeral's ink may occupy. The remaining 30% is
+   * gutter, and it is the whole reason this file exists. Do not raise it.
+   */
+  fill: 0.7,
+  /** Ceiling on apparent size, in NDC y. A single digit would otherwise fill the screen. */
+  maxH: 0.3,
+  /** Hard page margin: no ink past |x| = this. */
+  edge: 0.94,
+  /** The row never rises past here — above it lives the prompt. */
+  top: 0.56,
+  /** ...nor sinks below here, which is roughly the horizon. */
+  bottom: 0.06,
+  /** Clear air between the numeral row and the top of its own gate arch. */
+  lift: 0.07,
+} as const;
+
+export type Band = {
+  /** Ink height, in NDC y. Multiply by `1/|ky|` for world units. */
+  hNdc: number;
+  /** NDC x of each candidate's centre, left to right. */
+  x: [number, number, number];
+  /** NDC y of the row's centre. */
+  y: number;
+  /** NDC x between adjacent centres. */
+  pitch: number;
+  /** NDC width of the widest candidate at `hNdc`. */
+  wNdc: number;
+};
+
+/**
+ * @param units    world width of each candidate at ink height 1, left to right
+ * @param kx       NDC x per world unit at the gate's depth (magnitude)
+ * @param ky       NDC y per world unit at the gate's depth (magnitude)
+ * @param approach 0 when the gate spawns, 1 when it reaches the answer plane
+ * @param archTop  NDC y of the top of the gate's arch
+ */
+export function readBand(
+  units: readonly [number, number, number],
+  kx: number,
+  ky: number,
+  approach: number,
+  archTop: number,
+): Band {
+  const ax = Math.max(1e-6, Math.abs(kx));
+  const ay = Math.max(1e-6, Math.abs(ky));
+  const t = clamp01(approach);
+
+  // One size for all three. Three different sizes on one row reads as three
+  // different kinds of thing, and the eye stops comparing them.
+  const widest = Math.max(units[0], units[1], units[2], 1e-6);
+
+  // The widest a numeral can ever be: the point where the gutter rule
+  // (w <= fill * pitch) and the page margin (pitch + w/2 <= edge) meet.
+  const wCeil = (BAND.fill * BAND.edge) / (1 + BAND.fill / 2);
+  // The width at which the apparent-size cap bites. On a narrow phone this is
+  // enormous, which is exactly why the pitch has to be free to open up: a
+  // three-digit answer on a 320px screen needs most of the width or it lands at
+  // twenty pixels, and twenty pixels is the bug we are here to kill.
+  const wWanted = (BAND.maxH * widest * ax) / ay;
+
+  let wNdc = Math.min(wCeil, wWanted);
+  // The row spreads as the gate closes, but never tighter than the gutter needs.
+  let pitch = Math.max(lerp(BAND.pitchFar, BAND.pitchNear, t), wNdc / BAND.fill);
+  const pitchCeil = BAND.edge - wNdc / 2;
+  if (pitch > pitchCeil) pitch = pitchCeil;
+  wNdc = Math.min(wNdc, BAND.fill * pitch);
+
+  const hNdc = (wNdc / (widest * ax)) * ay;
+
+  const half = hNdc / 2;
+  // Sit just clear of the arch, but never behind the prompt and never under the
+  // deck. When the two limits collide the top wins: off the bottom is invisible,
+  // slightly tight against the prompt is merely close.
+  const lo = BAND.bottom + half;
+  const hi = BAND.top - half;
+  let y = archTop + half + BAND.lift;
+  if (y < lo) y = lo;
+  if (y > hi) y = hi;
+
+  return { hNdc, x: [-pitch, 0, pitch], y, pitch, wNdc };
+}
+
+/* -------------------------------------------------------------------------- */
+/* The other two places ink can leave the frame.                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Half-width, in NDC, that the winning numeral may fill as it rushes the camera.
+ *
+ * Slightly inside the frame: the glyph is allowed to feel like it is bursting
+ * out of the screen, but a child has to be able to see *which number* won. Past
+ * about 0.96 a two-digit answer on a phone stops being a number and starts being
+ * a wall.
+ */
+export const PAYOFF_EDGE = 0.92;
+
+/** Ceiling on the payoff numeral's NDC height, whatever the aspect ratio. */
+export const PAYOFF_MAX_H = 1.55;
+
+/**
+ * How big the winning numeral is allowed to get, in NDC height.
+ *
+ * It used to swell to a flat 1.55 NDC *tall* and nothing looked at how wide that
+ * made it. On a laptop a two-digit answer just fits; on a 390px phone it is 2.7
+ * NDC wide against a 2.0 NDC screen, so the best moment in the game — the value
+ * you just earned rushing the camera — became two unrecognisable green slabs
+ * jammed against the left and right edges. Same rule as `readBand`: decide in
+ * screen units, then convert back.
+ *
+ * @param wPerH NDC width the text occupies per NDC of height (aspect-corrected)
+ * @param from  the numeral's NDC height when it left the row
+ * @param swell 0 at the moment of crossing, 1 when fully arrived
+ */
+export function payoffHeight(wPerH: number, from: number, swell: number): number {
+  const ceil = Math.min(PAYOFF_MAX_H, (2 * PAYOFF_EDGE) / Math.max(1e-4, wPerH));
+  // Belt and braces: the swell only ever runs upward. `readBand` already keeps
+  // every candidate under 0.54 NDC wide, well inside this ceiling, so `from` is
+  // never the larger of the two in practice — but a numeral that *shrank* on a
+  // win would read as the game taking the prize back, and that should be
+  // impossible by construction rather than by the row happening to be small.
+  const to = Math.max(from, ceil);
+  return from + (to - from) * clamp01(swell);
+}
+
+/** The margin a score popup is kept inside. Tighter than the payoff: it is chrome. */
+export const POPUP_EDGE = 0.93;
+
+/**
+ * Nudge a centre back inside the frame, in NDC.
+ *
+ * Score popups are placed at the lane they belong to, which on a wide screen is
+ * well inside the frame and on a 390px phone is not: a `+100` over the outer
+ * lane used to hang half off the edge as a meaningless `00`. Text keeps its lane
+ * as long as the lane fits, and gives that up rather than be unreadable.
+ *
+ * @param ndcX  where the text wants to be centred
+ * @param halfW half the text's NDC width
+ * @param edge  the hard page margin
+ */
+export function keepInside(ndcX: number, halfW: number, edge = POPUP_EDGE): number {
+  const lim = Math.max(0, edge - Math.max(0, halfW));
+  return ndcX < -lim ? -lim : ndcX > lim ? lim : ndcX;
+}

--- a/dynawalla/games/runner/src/game/rng.ts
+++ b/dynawalla/games/runner/src/game/rng.ts
@@ -1,0 +1,55 @@
+/**
+ * Deterministic, allocation-free PRNG (mulberry32 over a 32-bit state).
+ *
+ * Every stochastic decision in VOLTA routes through one of these so a seed
+ * reproduces a run exactly: same gates, same hazard cadence, same spark rows.
+ * That makes "it felt unfair at 4:20" a bug report someone can actually replay.
+ */
+export class Rng {
+  private s: number;
+
+  constructor(seed: number) {
+    // Avoid the degenerate zero state; keep it a uint32.
+    this.s = (seed >>> 0) || 0x9e3779b9;
+  }
+
+  /** Uniform in [0, 1). */
+  next(): number {
+    this.s = (this.s + 0x6d2b79f5) >>> 0;
+    let t = this.s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  }
+
+  /** Uniform integer in [lo, hi] inclusive. */
+  int(lo: number, hi: number): number {
+    return lo + Math.floor(this.next() * (hi - lo + 1));
+  }
+
+  /** Uniform float in [lo, hi). */
+  range(lo: number, hi: number): number {
+    return lo + this.next() * (hi - lo);
+  }
+
+  /** True with probability p. */
+  chance(p: number): boolean {
+    return this.next() < p;
+  }
+
+  /** Pick one element. Never called with an empty array in this game. */
+  pick<T>(xs: readonly T[]): T {
+    return xs[Math.floor(this.next() * xs.length)];
+  }
+
+  /** In-place Fisher-Yates. No allocation. */
+  shuffle<T>(xs: T[]): T[] {
+    for (let i = xs.length - 1; i > 0; i--) {
+      const j = Math.floor(this.next() * (i + 1));
+      const t = xs[i];
+      xs[i] = xs[j];
+      xs[j] = t;
+    }
+    return xs;
+  }
+}

--- a/dynawalla/games/runner/src/game/scenery.ts
+++ b/dynawalla/games/runner/src/game/scenery.ts
@@ -1,0 +1,176 @@
+import type { SolidField } from "./fields.ts";
+import type { Particles } from "./particles.ts";
+import type { Rng } from "./rng.ts";
+import type { Biome } from "./biomes.ts";
+import { DECK_HALF } from "./world.ts";
+
+/**
+ * Everything beside and above the causeway.
+ *
+ * Near-field parallax is the whole trick of a runner: the horizon barely moves,
+ * so speed is read almost entirely from objects passing close to the camera.
+ * The monolith band is therefore weighted *toward* the deck, and the overhead
+ * arches exist for one reason — to put geometry within four metres of the
+ * player's head twice every hundred metres.
+ *
+ * Flat arrays, fixed capacity, recycled in place.
+ */
+
+type Shards = {
+  x: Float32Array; y: Float32Array; z: Float32Array;
+  w: Float32Array; h: Float32Array; rot: Float32Array;
+  hue: Float32Array; glow: Float32Array;
+};
+
+export class Scenery {
+  private n: number;
+  private s: Shards;
+  private rng: Rng;
+  private far: number;
+
+  // Overhead arches
+  private archZ: Float32Array;
+  private archH: Float32Array;
+  private archN = 0;
+  private nextArch = -180;
+
+  private ambientAcc = 0;
+
+  constructor(capacity: number, far: number, rng: Rng) {
+    this.n = capacity;
+    this.far = far;
+    this.rng = rng;
+    const f = () => new Float32Array(capacity);
+    this.s = { x: f(), y: f(), z: f(), w: f(), h: f(), rot: f(), hue: f(), glow: f() };
+    this.archZ = new Float32Array(8);
+    this.archH = new Float32Array(8);
+    for (let i = 0; i < capacity; i++) this.reseed(i, -this.rng.range(20, far));
+  }
+
+  resize(capacity: number, far: number): void {
+    this.far = far;
+    if (capacity === this.n) return;
+    const old = this.s;
+    const oldN = this.n;
+    this.n = capacity;
+    const f = () => new Float32Array(capacity);
+    this.s = { x: f(), y: f(), z: f(), w: f(), h: f(), rot: f(), hue: f(), glow: f() };
+    const keep = Math.min(oldN, capacity);
+    for (const k of ["x", "y", "z", "w", "h", "rot", "hue", "glow"] as const) {
+      this.s[k].set(old[k].subarray(0, keep));
+    }
+    for (let i = keep; i < capacity; i++) this.reseed(i, -this.rng.range(20, far));
+  }
+
+  private reseed(i: number, z: number): void {
+    const s = this.s;
+    const rng = this.rng;
+    // Two bands: a dense near band that reads as speed, a sparse far band that
+    // reads as a city. 68/32 keeps the near band from becoming a picket fence.
+    const near = rng.chance(0.68);
+    const side = rng.chance(0.5) ? -1 : 1;
+    const dist = near ? rng.range(DECK_HALF + 2.0, DECK_HALF + 16) : rng.range(34, 132);
+    s.x[i] = side * dist;
+    s.w[i] = near ? rng.range(0.85, 3.1) : rng.range(4, 15);
+    s.h[i] = near ? rng.range(3.5, 26) : rng.range(24, 96);
+    s.y[i] = -rng.range(0.5, 7) + (near ? 0 : -8);
+    s.z[i] = z;
+    s.rot[i] = rng.range(0, Math.PI);
+    s.hue[i] = rng.next();
+    s.glow[i] = near ? rng.range(0.22, 1.05) : rng.range(0.05, 0.34);
+  }
+
+  update(dt: number, scroll: number, travel: number, biome: Biome, parts: Particles): void {
+    const s = this.s;
+    for (let i = 0; i < this.n; i++) {
+      s.z[i] += scroll;
+      if (s.z[i] > 34) this.reseed(i, s.z[i] - this.far - this.rng.range(0, 40));
+    }
+
+    // Arches. Cadence tightens a little with distance so late runs feel busier.
+    const spacing = Math.max(78, 128 - travel * 0.004);
+    this.archN = 0;
+    for (let i = 0; i < 8; i++) {
+      if (this.archZ[i] === 0) continue;
+      this.archZ[i] += scroll;
+      if (this.archZ[i] > 30) this.archZ[i] = 0;
+      else this.archN++;
+    }
+    if (travel > this.nextArch) {
+      this.nextArch = travel + spacing;
+      for (let i = 0; i < 8; i++) {
+        if (this.archZ[i] !== 0) continue;
+        this.archZ[i] = -this.far * 0.92;
+        this.archH[i] = this.rng.range(7.5, 13.5);
+        break;
+      }
+    }
+
+    // Ambient debris. Emitted in front and swept back by the world scroll.
+    this.ambientAcc += dt * (biome.ambient === "ember" ? 52 : biome.ambient === "ash" ? 40 : 30);
+    const c = colorOf(biome.ambientColor);
+    while (this.ambientAcc >= 1) {
+      this.ambientAcc -= 1;
+      const rng = this.rng;
+      const zz = -rng.range(20, this.far * 0.85);
+      const xx = rng.range(-46, 46);
+      if (biome.ambient === "ember") {
+        parts.puff(xx, rng.range(-6, 18), zz, rng.range(-1, 1), rng.range(1.5, 5), 0,
+          rng.range(1.2, 2.6), rng.range(0.1, 0.32), -0.05, c[0], c[1], c[2], 1);
+      } else if (biome.ambient === "ash") {
+        parts.puff(xx, rng.range(4, 30), zz, rng.range(-1.5, 1.5), rng.range(-3.4, -1.2), 0,
+          rng.range(1.4, 2.8), rng.range(0.12, 0.4), 0, c[0], c[1], c[2], 1);
+      } else if (biome.ambient === "mote") {
+        parts.puff(xx, rng.range(-8, 22), zz, rng.range(-0.6, 0.6), rng.range(-0.5, 0.9), 0,
+          rng.range(2.0, 3.6), rng.range(0.08, 0.24), 0.02, c[0], c[1], c[2], 1);
+      } else {
+        parts.puff(xx, rng.range(-4, 24), zz, rng.range(-2, 2), rng.range(-0.6, 0.6), 0,
+          rng.range(1.0, 2.2), rng.range(0.06, 0.2), 0, c[0], c[1], c[2], 1);
+      }
+    }
+  }
+
+  draw(shardField: SolidField, boxField: SolidField, biome: Biome, shift: number): void {
+    const a = colorOf(biome.accent);
+    const b = colorOf(biome.accent2);
+    const s = this.s;
+    for (let i = 0; i < this.n; i++) {
+      const t = s.hue[i];
+      const r = a[0] + (b[0] - a[0]) * t;
+      const g = a[1] + (b[1] - a[1]) * t;
+      const bl = a[2] + (b[2] - a[2]) * t;
+      const glow = s.glow[i] * (1 + shift * 2.5);
+      shardField.add(
+        s.x[i], s.y[i] + s.h[i] * 0.5, s.z[i],
+        s.w[i], s.h[i], s.w[i],
+        s.rot[i],
+        r, g, bl, glow, 1,
+      );
+    }
+
+    // Arches: two legs and a lintel, drawn from the box field.
+    for (let i = 0; i < 8; i++) {
+      const z = this.archZ[i];
+      if (z === 0) continue;
+      const h = this.archH[i];
+      const legX = DECK_HALF + 1.4;
+      boxField.add(-legX, h * 0.5, z, 0.85, h, 1.5, 0, a[0], a[1], a[2], 0.7, 1);
+      boxField.add(legX, h * 0.5, z, 0.85, h, 1.5, 0, a[0], a[1], a[2], 0.7, 1);
+      boxField.add(0, h, z, legX * 2 + 1.7, 1.05, 1.5, 0, b[0], b[1], b[2], 0.95, 1);
+      boxField.add(0, h - 1.0, z, legX * 2 - 2, 0.28, 0.9, 0, a[0], a[1], a[2], 1.6, 1);
+    }
+  }
+}
+
+const cache = new Map<number, [number, number, number]>();
+export function colorOf(hex: number): [number, number, number] {
+  let c = cache.get(hex);
+  if (!c) {
+    // sRGB -> linear, so additive blending and bloom behave.
+    const to = (v: number) => (v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4));
+    c = [to(((hex >> 16) & 255) / 255), to(((hex >> 8) & 255) / 255), to((hex & 255) / 255)];
+    if (cache.size > 512) cache.clear();
+    cache.set(hex, c);
+  }
+  return c;
+}

--- a/dynawalla/games/runner/src/game/shaders.ts
+++ b/dynawalla/games/runner/src/game/shaders.ts
@@ -1,0 +1,134 @@
+import * as THREE from "three";
+
+/**
+ * The shared GLSL every material in VOLTA includes, and the single uniform
+ * block they all point at.
+ *
+ * The load-bearing idea is `voltaBend`. Gameplay lives on a perfectly straight
+ * 1D track — lane is an integer, distance is a float, nothing curves — and the
+ * *shader* bends the world by a quadratic in view depth. That buys three things
+ * for about eight lines:
+ *
+ *   - The causeway visibly snakes and rolls, so a run does not read as a
+ *     treadmill after ninety seconds.
+ *   - Geometry enters from behind the curve instead of fading up out of fog, so
+ *     there is no pop-in to hide.
+ *   - Collision, lane logic and spawn scheduling stay one-dimensional and
+ *     therefore stay debuggable.
+ *
+ * Three.js also never has to move the deck: the deck is a static ribbon and the
+ * stripes scroll procedurally against `uTravel`, so the ground costs one draw
+ * call and zero CPU forever.
+ */
+
+export type SharedUniforms = {
+  uTime: { value: number };
+  uTravel: { value: number };
+  /** Quadratic bend coefficients: x sways, y rolls the horizon under/over you. */
+  uBend: { value: THREE.Vector2 };
+  uFogColor: { value: THREE.Color };
+  uFogDensity: { value: number };
+  uSkyTop: { value: THREE.Color };
+  uSkyBot: { value: THREE.Color };
+  uAccent: { value: THREE.Color };
+  uAccent2: { value: THREE.Color };
+  uDeck: { value: THREE.Color };
+  uSpeed01: { value: number };
+  uSurge: { value: number };
+  /** Rises 0 -> 1 across a biome crossing; drives the white-out and palette lerp. */
+  uShift: { value: number };
+  uDanger: { value: number };
+};
+
+export function makeSharedUniforms(): SharedUniforms {
+  return {
+    uTime: { value: 0 },
+    uTravel: { value: 0 },
+    uBend: { value: new THREE.Vector2(0, 0) },
+    uFogColor: { value: new THREE.Color(0x05070f) },
+    uFogDensity: { value: 1 / 240 },
+    uSkyTop: { value: new THREE.Color(0x03040c) },
+    uSkyBot: { value: new THREE.Color(0x0a1430) },
+    uAccent: { value: new THREE.Color(0x36e8ff) },
+    uAccent2: { value: new THREE.Color(0xff3fa4) },
+    uDeck: { value: new THREE.Color(0x070a16) },
+    uSpeed01: { value: 0 },
+    uSurge: { value: 0 },
+    uShift: { value: 0 },
+    uDanger: { value: 0 },
+  };
+}
+
+/** Declarations + helpers. Prepended to every vertex and fragment shader. */
+export const COMMON = /* glsl */ `
+precision highp float;
+uniform float uTime;
+uniform float uTravel;
+uniform vec2  uBend;
+uniform vec3  uFogColor;
+uniform float uFogDensity;
+uniform vec3  uSkyTop;
+uniform vec3  uSkyBot;
+uniform vec3  uAccent;
+uniform vec3  uAccent2;
+uniform vec3  uDeck;
+uniform float uSpeed01;
+uniform float uSurge;
+uniform float uShift;
+uniform float uDanger;
+
+// Quadratic world bend in view depth. p is world space; the camera sits at the
+// origin looking down -z, so -p.z is "distance ahead".
+vec3 voltaBend(vec3 p) {
+  float d = max(0.0, -p.z);
+  float k = d * d;
+  p.x += uBend.x * k;
+  p.y += uBend.y * k;
+  return p;
+}
+
+float voltaFog(float depth) {
+  float f = depth * uFogDensity;
+  return clamp(1.0 - exp(-f * f * 1.35), 0.0, 1.0);
+}
+
+// Ordered-ish hash dither. Gradients over a 300-unit draw distance band badly
+// on 8-bit displays and a child will read the bands as a graphical fault.
+float voltaDither(vec2 c) {
+  return (fract(sin(dot(c, vec2(12.9898, 78.233))) * 43758.5453) - 0.5) / 255.0;
+}
+
+float voltaHash(float n) { return fract(sin(n) * 43758.5453123); }
+`;
+
+/**
+ * Barycentric edge factor: 1 in a face's interior, 0 along its edges, with a
+ * screen-space-constant width. This is where the whole look comes from — solids
+ * are near-black obsidian, edges are hot neon, and both stay legible at 62 u/s
+ * because the edge width does not shrink with distance.
+ */
+export const EDGE_GLSL = /* glsl */ `
+float voltaEdge(vec3 bary, float width) {
+  vec3 d = fwidth(bary);
+  vec3 a = smoothstep(vec3(0.0), d * width, bary);
+  return min(min(a.x, a.y), a.z);
+}
+`;
+
+/**
+ * Convert an indexed geometry to non-indexed and attach a per-vertex
+ * barycentric attribute. Called once per prototype at load, never in a frame.
+ */
+export function withBarycentric(geo: THREE.BufferGeometry): THREE.BufferGeometry {
+  const g = geo.index ? geo.toNonIndexed() : geo;
+  const count = g.getAttribute("position").count;
+  const bary = new Float32Array(count * 3);
+  for (let i = 0; i < count; i += 3) {
+    bary[i * 3 + 0] = 1;
+    bary[(i + 1) * 3 + 1] = 1;
+    bary[(i + 2) * 3 + 2] = 1;
+  }
+  g.setAttribute("bary", new THREE.BufferAttribute(bary, 3));
+  if (g !== geo) geo.dispose();
+  return g;
+}

--- a/dynawalla/games/runner/src/game/tiers.ts
+++ b/dynawalla/games/runner/src/game/tiers.ts
@@ -1,0 +1,238 @@
+/**
+ * Quality tiers.
+ *
+ * The mid-range tablet sets the FLOOR, never the ceiling. LOW must hold 60fps
+ * on a 2019 Android tablet with a soldered GPU; ULTRA is allowed to be greedy.
+ *
+ * Tier is *guessed* from device signals and then *corrected* by the frame clock:
+ * `TierController.observe()` demotes after a sustained stall and (once only, to
+ * avoid oscillation) promotes back if the demotion left a lot of headroom.
+ */
+
+export type TierName = "low" | "mid" | "high" | "ultra";
+
+export type TierSettings = {
+  name: TierName;
+  /** Device-pixel-ratio ceiling. */
+  dprCap: number;
+  /** Off-screen composite: bloom + chromatic aberration. Costs two extra passes. */
+  post: boolean;
+  /** Bloom blur iterations (each is one downsampled ping-pong). */
+  bloomPasses: number;
+  /** Live particle ceiling. */
+  particles: number;
+  /** Speed-streak instance count around the camera. */
+  streaks: number;
+  /** Deck subdivisions along z — the world-bend needs vertices to bend. */
+  deckSegments: number;
+  /** How far the camera can see, in world units. */
+  far: number;
+  /** Roadside monolith instances alive at once. */
+  monoliths: number;
+  /** Reflected light-ocean under the causeway. */
+  ocean: boolean;
+  /** Per-object emissive halo sprites (the cheap neon that works everywhere). */
+  halos: boolean;
+  /** Shadow-ish contact darkening under the skiff. */
+  contactShadow: boolean;
+};
+
+const TIERS: Record<TierName, TierSettings> = {
+  low: {
+    name: "low",
+    dprCap: 1.25,
+    post: false,
+    bloomPasses: 0,
+    particles: 220,
+    streaks: 0,
+    deckSegments: 44,
+    far: 300,
+    monoliths: 26,
+    ocean: false,
+    halos: true,
+    contactShadow: false,
+  },
+  mid: {
+    name: "mid",
+    dprCap: 1.6,
+    post: true,
+    bloomPasses: 2,
+    particles: 620,
+    streaks: 64,
+    deckSegments: 84,
+    far: 380,
+    monoliths: 44,
+    ocean: true,
+    halos: true,
+    contactShadow: true,
+  },
+  high: {
+    name: "high",
+    dprCap: 2,
+    post: true,
+    bloomPasses: 3,
+    particles: 1200,
+    streaks: 128,
+    deckSegments: 120,
+    far: 440,
+    monoliths: 64,
+    ocean: true,
+    halos: true,
+    contactShadow: true,
+  },
+  ultra: {
+    name: "ultra",
+    dprCap: 2,
+    post: true,
+    bloomPasses: 4,
+    particles: 2400,
+    streaks: 220,
+    deckSegments: 168,
+    far: 520,
+    monoliths: 92,
+    ocean: true,
+    halos: true,
+    contactShadow: true,
+  },
+};
+
+const ORDER: TierName[] = ["low", "mid", "high", "ultra"];
+
+export function detectTier(gl: WebGL2RenderingContext | WebGLRenderingContext | null): TierName {
+  let score = 0;
+
+  const nav = navigator as Navigator & { deviceMemory?: number };
+  const mem = nav.deviceMemory ?? 0;
+  if (mem >= 8) score += 3;
+  else if (mem >= 4) score += 2;
+  else if (mem > 0) score += 0;
+  else score += 1; // unknown (Safari): assume middling rather than punishing it
+
+  const cores = navigator.hardwareConcurrency ?? 4;
+  if (cores >= 10) score += 3;
+  else if (cores >= 6) score += 2;
+  else if (cores >= 4) score += 1;
+
+  if (gl) {
+    const maxTex = gl.getParameter(gl.MAX_TEXTURE_SIZE) as number;
+    if (maxTex >= 16384) score += 2;
+    else if (maxTex >= 8192) score += 1;
+
+    const dbg = gl.getExtension("WEBGL_debug_renderer_info");
+    const renderer = dbg ? String(gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL) ?? "") : "";
+    const r = renderer.toLowerCase();
+    // Apple silicon and desktop discrete parts are known-good.
+    if (/apple (m\d|a1[5-9]|a2\d)/.test(r)) score += 3;
+    else if (/(rtx|radeon rx|geforce|arc a\d)/.test(r)) score += 3;
+    else if (/adreno \(tm\) (7\d\d|8\d\d)/.test(r)) score += 2;
+    else if (/(mali-g7|mali-g8|mali-g9|xclipse)/.test(r)) score += 1;
+    else if (/(swiftshader|llvmpipe|software)/.test(r)) score -= 6;
+  }
+
+  // A tiny viewport is usually a phone, and a phone is usually thermally capped.
+  const px = window.innerWidth * window.innerHeight * Math.min(window.devicePixelRatio || 1, 2);
+  if (px > 3_000_000) score -= 1;
+
+  if (score <= 2) return "low";
+  if (score <= 5) return "mid";
+  if (score <= 8) return "high";
+  return "ultra";
+}
+
+/**
+ * Watches the frame clock and moves the tier when reality disagrees with the
+ * guess. Demotion is aggressive (a child feeling 40fps is a real cost);
+ * promotion happens at most once, and only from a demoted state.
+ */
+export class TierController {
+  tier: TierName;
+  settings: TierSettings;
+  /** Extra render-scale multiplier applied on top of dprCap; 1 -> 0.72. */
+  renderScale = 1;
+
+  private acc = 0;
+  private frames = 0;
+  private slowStreak = 0;
+  private fastStreak = 0;
+  private demoted = false;
+  private promotedOnce = false;
+  private cooldown = 2.5;
+  private onChange: () => void;
+  lastFps = 60;
+
+  constructor(initial: TierName, onChange: () => void) {
+    this.tier = initial;
+    this.settings = TIERS[initial];
+    this.onChange = onChange;
+  }
+
+  force(name: TierName): void {
+    if (name === this.tier) return;
+    this.tier = name;
+    this.settings = TIERS[name];
+    this.renderScale = 1;
+    this.cooldown = 3;
+    this.demoted = false;
+    this.promotedOnce = true; // manual choice wins; stop auto-promoting
+    this.onChange();
+  }
+
+  observe(dt: number): void {
+    this.acc += dt;
+    this.frames++;
+    if (this.cooldown > 0) this.cooldown -= dt;
+    if (this.acc < 0.5) return;
+
+    const fps = this.frames / this.acc;
+    this.lastFps = fps;
+    this.acc = 0;
+    this.frames = 0;
+    if (this.cooldown > 0) return;
+
+    if (fps < 52) {
+      this.slowStreak++;
+      this.fastStreak = 0;
+    } else if (fps > 58) {
+      this.fastStreak++;
+      this.slowStreak = 0;
+    } else {
+      this.slowStreak = 0;
+      this.fastStreak = 0;
+    }
+
+    if (this.slowStreak >= 3) {
+      this.slowStreak = 0;
+      // Drop resolution first — it is invisible next to dropping the bloom.
+      if (this.renderScale > 0.74) {
+        this.renderScale = Math.max(0.72, this.renderScale - 0.14);
+        this.cooldown = 2.5;
+        this.demoted = true;
+        this.onChange();
+        return;
+      }
+      const i = ORDER.indexOf(this.tier);
+      if (i > 0) {
+        this.tier = ORDER[i - 1];
+        this.settings = TIERS[this.tier];
+        this.renderScale = 1;
+        this.cooldown = 4;
+        this.demoted = true;
+        this.onChange();
+      }
+    } else if (this.fastStreak >= 8 && this.demoted && !this.promotedOnce) {
+      this.fastStreak = 0;
+      this.promotedOnce = true;
+      if (this.renderScale < 1) {
+        this.renderScale = 1;
+      } else {
+        const i = ORDER.indexOf(this.tier);
+        if (i < ORDER.length - 1) {
+          this.tier = ORDER[i + 1];
+          this.settings = TIERS[this.tier];
+        }
+      }
+      this.cooldown = 6;
+      this.onChange();
+    }
+  }
+}

--- a/dynawalla/games/runner/src/game/world.ts
+++ b/dynawalla/games/runner/src/game/world.ts
@@ -1,0 +1,332 @@
+import * as THREE from "three";
+import { COMMON, type SharedUniforms } from "./shaders.ts";
+
+/**
+ * The sky, the light-ocean and the causeway.
+ *
+ * None of these three objects ever moves. The deck is a static ribbon and its
+ * chevrons scroll procedurally against `uTravel`; the ocean's caustics do the
+ * same; the sky is a shell parented to the camera. So the entire environment
+ * costs three draw calls and precisely zero CPU per frame, which is what leaves
+ * the budget for gates, hazards and two thousand particles.
+ *
+ * The one non-obvious detail is anti-aliasing. A high-contrast stripe scrolling
+ * toward the camera at 62 units/second will shimmer into moire the moment the
+ * pattern period drops below a pixel, and moire at speed genuinely hurts to
+ * look at. Every periodic term is therefore filtered with `fwidth` and faded to
+ * flat once it is undersampled.
+ */
+
+export const LANE_W = 3.35;
+export const DECK_HALF = LANE_W * 1.5 + 1.35;
+
+/* ----------------------------------- sky ---------------------------------- */
+
+const SKY_VERT = /* glsl */ `
+${COMMON}
+varying vec3 vDir;
+void main() {
+  vDir = normalize(position);
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  gl_Position.z = gl_Position.w; // always at the far plane
+}
+`;
+
+const SKY_FRAG = /* glsl */ `
+${COMMON}
+varying vec3 vDir;
+uniform float uAurora;
+uniform float uStars;
+
+float hash21(vec2 p) {
+  p = fract(p * vec2(233.34, 851.73));
+  p += dot(p, p + 23.45);
+  return fract(p.x * p.y);
+}
+
+// Cheap value noise; two octaves is enough for a curtain.
+float vnoise(vec2 p) {
+  vec2 i = floor(p), f = fract(p);
+  f = f * f * (3.0 - 2.0 * f);
+  float a = hash21(i), b = hash21(i + vec2(1.0, 0.0));
+  float c = hash21(i + vec2(0.0, 1.0)), d = hash21(i + vec2(1.0, 1.0));
+  return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
+}
+
+void main() {
+  vec3 d = normalize(vDir);
+  float h = clamp(d.y * 0.5 + 0.5, 0.0, 1.0);
+  vec3 col = mix(uSkyBot, uSkyTop, pow(h, 0.75));
+
+  // Horizon bloom, brightest straight ahead so the vanishing point pulls.
+  float fwd = clamp(-d.z, 0.0, 1.0);
+  float band = exp(-abs(d.y - 0.015) * 26.0);
+  col += mix(uAccent, uAccent2, 0.25) * band * fwd * 0.28;
+  col += uAccent * exp(-abs(d.y - 0.01) * 6.5) * fwd * 0.045;
+
+  // Stars: only above the horizon, only in dark biomes.
+  if (uStars > 0.01 && d.y > 0.02) {
+    vec2 sp = d.xz / max(0.08, d.y) * 3.0;
+    float s = hash21(floor(sp * 26.0));
+    float tw = 0.6 + 0.4 * sin(uTime * 2.2 + s * 40.0);
+    col += vec3(0.9, 0.95, 1.0) * step(0.9965, s) * tw * uStars * 1.5;
+  }
+
+  // Aurora curtains: two drifting sheets, vertically stretched, additive.
+  if (uAurora > 0.01) {
+    float y = d.y;
+    for (int i = 0; i < 2; i++) {
+      float fi = float(i);
+      float t = uTime * (0.045 + fi * 0.03) + uTravel * 0.0008;
+      float n = vnoise(vec2(d.x * 2.4 + t, d.z * 1.6 - t * 0.6 + fi * 7.0));
+      float n2 = vnoise(vec2(d.x * 7.0 - t * 2.0, d.z * 4.0 + fi * 3.0));
+      float curtain = smoothstep(0.42, 0.95, n * 0.7 + n2 * 0.3);
+      float vert = smoothstep(-0.02, 0.34, y) * smoothstep(0.95, 0.28, y);
+      vec3 tint = mix(uAccent, uAccent2, fi * 0.7 + n2 * 0.3);
+      col += tint * curtain * vert * (0.6 - fi * 0.2) * uAurora;
+    }
+  }
+
+  // A hot rim right at the biome crossing.
+  col = mix(col, vec3(1.0), uShift * 0.55);
+  col += voltaDither(gl_FragCoord.xy) * 2.0;
+  gl_FragColor = vec4(col, 1.0);
+}
+`;
+
+export function makeSky(shared: SharedUniforms): {
+  mesh: THREE.Mesh;
+  material: THREE.ShaderMaterial;
+} {
+  const geo = new THREE.SphereGeometry(1, 40, 24);
+  const material = new THREE.ShaderMaterial({
+    uniforms: { ...shared, uAurora: { value: 1 }, uStars: { value: 1 } },
+    vertexShader: SKY_VERT,
+    fragmentShader: SKY_FRAG,
+    side: THREE.BackSide,
+    depthWrite: false,
+    depthTest: false,
+  });
+  const mesh = new THREE.Mesh(geo, material);
+  mesh.frustumCulled = false;
+  mesh.renderOrder = -1000;
+  return { mesh, material };
+}
+
+/* ---------------------------------- ocean --------------------------------- */
+
+const OCEAN_VERT = /* glsl */ `
+${COMMON}
+varying vec3 vWorld;
+varying float vFog;
+void main() {
+  vec3 p = position;
+  float depth = max(0.0, -p.z);
+  vWorld = p;
+  vec3 bent = voltaBend(p);
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(bent, 1.0);
+  vFog = voltaFog(depth);
+}
+`;
+
+const OCEAN_FRAG = /* glsl */ `
+${COMMON}
+varying vec3 vWorld;
+varying float vFog;
+
+float band(float v, float period, float duty) {
+  float p = v / period;
+  float w = fwidth(p);
+  if (w > 0.45) return duty;            // undersampled: go flat, never moire
+  float f = abs(fract(p) - 0.5) * 2.0;
+  return smoothstep(duty + w * 2.0, duty - w * 2.0, f);
+}
+
+void main() {
+  float z = vWorld.z - uTravel;
+  float x = vWorld.x;
+
+  vec3 col = uSkyBot * 0.35;
+
+  // Long light ribbons under the causeway, drifting laterally.
+  float ribbons = 0.0;
+  for (int i = 0; i < 3; i++) {
+    float fi = float(i);
+    float off = sin(z * 0.004 + uTime * (0.11 + fi * 0.05) + fi * 2.1) * 22.0;
+    float d = abs(x - off - (fi - 1.0) * 26.0);
+    ribbons += exp(-d * 0.06) * (0.5 + 0.5 * sin(z * 0.02 + uTime * 1.6 + fi));
+  }
+  col += mix(uAccent, uAccent2, 0.35 + 0.35 * sin(uTime * 0.2)) * ribbons * 0.38;
+
+  // The causeway's own reflection, smeared.
+  float refl = exp(-abs(x) * 0.055) * (0.4 + 0.6 * band(z, 9.0, 0.42));
+  col += uAccent * refl * 0.6;
+
+  // Wave lines.
+  col += vec3(0.6, 0.75, 1.0) * band(z + sin(x * 0.05 + uTime * 0.5) * 6.0, 34.0, 0.06) * 0.05;
+
+  col = mix(col, uFogColor, vFog);
+  col += voltaDither(gl_FragCoord.xy);
+  gl_FragColor = vec4(col, 1.0);
+}
+`;
+
+export function makeOcean(shared: SharedUniforms, far: number): THREE.Mesh {
+  const geo = new THREE.PlaneGeometry(far * 3.2, far * 1.35, 1, 40);
+  geo.rotateX(-Math.PI / 2);
+  geo.translate(0, -15.5, -far * 0.55);
+  const mat = new THREE.ShaderMaterial({
+    uniforms: { ...shared },
+    vertexShader: OCEAN_VERT,
+    fragmentShader: OCEAN_FRAG,
+    depthWrite: false,
+    side: THREE.DoubleSide,
+  });
+  const mesh = new THREE.Mesh(geo, mat);
+  mesh.frustumCulled = false;
+  mesh.matrixAutoUpdate = false;
+  mesh.renderOrder = -900;
+  return mesh;
+}
+
+/* ----------------------------------- deck --------------------------------- */
+
+const DECK_VERT = /* glsl */ `
+${COMMON}
+varying vec3 vWorld;
+varying float vFog;
+void main() {
+  vec3 p = position;
+  float depth = max(0.0, -p.z);
+  vWorld = p;
+  vec3 bent = voltaBend(p);
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(bent, 1.0);
+  vFog = voltaFog(depth);
+}
+`;
+
+const DECK_FRAG = /* glsl */ `
+${COMMON}
+varying vec3 vWorld;
+varying float vFog;
+
+uniform float uLaneW;
+uniform float uHalf;
+uniform float uPlayerX;
+// Up to four open pits, by world z. Unrolled rather than indexed: GLSL ES 1.00
+// forbids dynamic indexing of a vector, and three compiles ShaderMaterial as
+// ES 1.00 even on a WebGL2 context.
+uniform vec4 uPits;
+uniform float uPitHalf;   // 0 disables
+
+// Filtered periodic bar. Returns 0..1, flat once undersampled.
+float bar(float v, float period, float duty) {
+  float p = v / period;
+  float w = fwidth(p);
+  if (w > 0.4) return duty * 0.55;
+  float f = abs(fract(p) - 0.5) * 2.0;
+  return smoothstep(duty + w * 2.5, duty - w * 2.5, f);
+}
+
+float line(float v, float halfWidth) {
+  float w = fwidth(v) * 1.5 + 0.0001;
+  return smoothstep(halfWidth + w, halfWidth - w, abs(v));
+}
+
+void main() {
+  float z = vWorld.z - uTravel;
+  float x = vWorld.x;
+
+  if (uPitHalf > 0.0 && abs(x) < uHalf - 0.55) {
+    float pd = min(min(abs(vWorld.z - uPits.x), abs(vWorld.z - uPits.y)),
+                   min(abs(vWorld.z - uPits.z), abs(vWorld.z - uPits.w)));
+    if (pd < uPitHalf) discard;
+  }
+
+  // Perspective makes a two-metre stripe fill half the screen when it is four
+  // metres away. Without this the near deck blows out to a white wedge and the
+  // gates lose the contrast fight to the floor.
+  float nearTame = smoothstep(-2.0, 26.0, -vWorld.z) * 0.72 + 0.28;
+
+  vec3 col = uDeck;
+
+  // Transverse ties: the primary speed cue, and the thing that tells a child
+  // how fast they are actually going. Loud on purpose.
+  float ties = bar(z, 8.0, 0.13);
+  col += mix(uAccent, uAccent2, 0.18) * ties * 0.5 * nearTame;
+
+  // Chevrons pointing the way you are going.
+  float chev = bar(z + abs(x) * 1.6, 24.0, 0.045);
+  col += mix(uAccent, vec3(1.0), 0.3) * chev * 0.62 * nearTame;
+
+  // Lane dividers: continuous, so lanes are legible even between ties.
+  float l1 = line(x + uLaneW * 0.5, 0.06);
+  float l2 = line(x - uLaneW * 0.5, 0.06);
+  col += uAccent * (l1 + l2) * 0.6 * nearTame;
+
+  // Which lane are you in. Not information (the skiff is), just weight.
+  float own = exp(-pow((x - uPlayerX) / (uLaneW * 0.5), 2.0));
+  col += uAccent * own * 0.22 * (0.65 + 0.35 * sin(uTime * 4.0));
+
+  // Edge beams and the drop-off.
+  float edge = smoothstep(uHalf - 0.66, uHalf - 0.16, abs(x));
+  col += mix(uAccent, vec3(1.0), 0.25) * edge * (0.5 + 0.4 * bar(z, 4.5, 0.3)) * 0.75 * nearTame;
+
+  // Surge: the deck lights up as the combo climbs.
+  col += uAccent * uSurge * 0.34 * (0.4 + 0.6 * bar(z, 12.0, 0.32)) * nearTame;
+
+  // Low voltage: a red pulse crawling the deck. Colour is never alone —
+  // the HUD bar and a heartbeat carry the same message.
+  float pulse = 0.5 + 0.5 * sin(uTime * 5.5 - z * 0.05);
+  col = mix(col, vec3(1.0, 0.16, 0.22) * (0.45 + pulse * 0.85), uDanger * 0.55);
+
+  col = mix(col, uFogColor, vFog);
+  col = mix(col, vec3(1.0), uShift * 0.4);
+  col += voltaDither(gl_FragCoord.xy);
+  gl_FragColor = vec4(col, 1.0);
+}
+`;
+
+export type Deck = {
+  mesh: THREE.Mesh;
+  material: THREE.ShaderMaterial;
+  rebuild(segments: number, far: number): void;
+};
+
+export function makeDeck(shared: SharedUniforms, segments: number, far: number): Deck {
+  const material = new THREE.ShaderMaterial({
+    uniforms: {
+      ...shared,
+      uLaneW: { value: LANE_W },
+      uHalf: { value: DECK_HALF },
+      uPlayerX: { value: 0 },
+      uPits: { value: new THREE.Vector4(1e9, 1e9, 1e9, 1e9) },
+      uPitHalf: { value: 0 },
+    },
+    vertexShader: DECK_VERT,
+    fragmentShader: DECK_FRAG,
+    side: THREE.DoubleSide,
+  });
+
+  const mesh = new THREE.Mesh(build(segments, far), material);
+  mesh.frustumCulled = false;
+  mesh.matrixAutoUpdate = false;
+
+  function build(seg: number, f: number): THREE.BufferGeometry {
+    const len = f + 60;
+    const g = new THREE.PlaneGeometry(DECK_HALF * 2, len, 4, seg);
+    g.rotateX(-Math.PI / 2);
+    g.translate(0, 0, -len / 2 + 40);
+    return g;
+  }
+
+  return {
+    mesh,
+    material,
+    rebuild(seg: number, f: number) {
+      const old = mesh.geometry;
+      mesh.geometry = build(seg, f);
+      old.dispose();
+    },
+  };
+}

--- a/dynawalla/games/runner/src/index.ts
+++ b/dynawalla/games/runner/src/index.ts
@@ -1,0 +1,3 @@
+export { mount } from "./contract.ts";
+export type { Host, Question } from "./contract.ts";
+export { createStubHost } from "./stubHost.ts";

--- a/dynawalla/games/runner/src/main.ts
+++ b/dynawalla/games/runner/src/main.ts
@@ -1,0 +1,35 @@
+/**
+ * Standalone dev entry.
+ *
+ * `npm run dev` gives a real, complete, playable game with no Dynawalla runtime
+ * underneath it — the stub host supplies the questions and swallows the
+ * reports. When the runtime lands, this file is the only thing that changes.
+ *
+ * Query parameters, for verification rather than for players:
+ *   ?tier=low|mid|high|ultra   pin the quality tier
+ *   ?stats=1                   fps, worst frame, input latency, draw calls
+ *   ?seed=12345                reproduce an exact run
+ */
+import { mount } from "./contract.ts";
+import { createStubHost } from "./stubHost.ts";
+
+const el = document.getElementById("game");
+if (!el) throw new Error("#game not found");
+
+const params = new URLSearchParams(location.search);
+const seedParam = Number(params.get("seed") ?? 0);
+const verbose = params.get("log") === "1";
+
+const host = createStubHost({
+  seed: seedParam || undefined,
+  onReport: verbose
+    ? (r) => console.info(`[host] ${r.questionId} ${r.correct ? "OK " : "MISS"} ${r.answered} (${r.ms}ms)`)
+    : undefined,
+});
+
+const instance = mount(el, host);
+
+// Vite HMR: tear the game down properly rather than stacking WebGL contexts.
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => instance.unmount());
+}

--- a/dynawalla/games/runner/src/pack.ts
+++ b/dynawalla/games/runner/src/pack.ts
@@ -1,0 +1,45 @@
+// VOLTA, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous `Host` surface that
+// `contract.ts` already describes — so the causeway, the read band, the tier
+// governor and the recharge gate are untouched.
+//
+// What crosses the boundary is a gate array. A question the curriculum drew
+// becomes three lane values through `options.ts`, exactly as it does under the
+// stub: the canonical answer in one lane and mal-rule distractors in the other
+// two. The game reports the value the child drove through and the host judges
+// it; the game's own idea of correct drives only the feel.
+//
+// `items.reveal` is not optional here, and it is declared in `pack.json` for
+// that reason. Without it the adapter has no canonical answer to place, so
+// there is no right lane to steer into and the pool never fills.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import { mount } from "./contract.ts"
+import type { Host } from "./contract.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("runner: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "add-sub" })
+  // Stocked before the first frame. The first gate is scheduled within a
+  // second of the run starting, and a gate with three blank lanes is the kind
+  // of thing that happens exactly once, on launch, in front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop, the WebGL
+  // context and the audio graph come down before the frame does rather than a
+  // frame or two after it.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[runner] could not start", error)
+  renderNoHost(root, "VOLTA")
+})

--- a/dynawalla/games/runner/src/stubHost.test.ts
+++ b/dynawalla/games/runner/src/stubHost.test.ts
@@ -1,0 +1,232 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createStubHost } from "./stubHost.ts";
+import type { Question } from "./contract.ts";
+
+/**
+ * The stub host is the thing that decides whether this game teaches anything.
+ * These assertions are the promises it makes to the real runtime that replaces
+ * it, so they are written against behaviour a child would notice, not against
+ * the implementation.
+ */
+
+// The host reads `navigator` and `window` for haptics and reduced motion; the
+// question generator does not. Stub the two globals the constructor touches.
+const g = globalThis as unknown as Record<string, unknown>;
+g.navigator ??= {};
+g.window ??= { matchMedia: () => ({ matches: false }) };
+
+function sample(seed: number, n: number, difficulty: number): Question[] {
+  const host = createStubHost({ seed });
+  const out: Question[] = [];
+  for (let i = 0; i < n; i++) out.push(host.next({ difficulty }));
+  return out;
+}
+
+test("every answer is an exact integer, never a float", () => {
+  for (let d = 0; d <= 12; d++) {
+    for (const q of sample(0xbeef + d, 200, d)) {
+      assert.match(q.answer, /^-?\d+$/, `answer "${q.answer}" in ${q.domain} is not an integer literal`);
+      const n = Number(q.answer);
+      assert.ok(Number.isSafeInteger(n), `answer ${q.answer} is not a safe integer`);
+      assert.equal(String(n), q.answer, "answer string is not canonical");
+    }
+  }
+});
+
+test("the prompt's arithmetic actually equals the answer", () => {
+  // Re-evaluate the printed expression independently of the generator that
+  // produced it. A generator that drifts from its own prompt teaches a lie.
+  const ops: Record<string, (a: number, b: number) => number> = {
+    "+": (a, b) => a + b,
+    "−": (a, b) => a - b,
+    "×": (a, b) => a * b,
+    // Integer division, explicitly. `divFact` builds `a = q * b` so the
+    // quotient is always exact, but writing `a / b` here means the invariant
+    // rests on that and nothing says so — one generator change away from
+    // silently comparing against a non-representable float.
+    "÷": (a, b) => (b !== 0 && a % b === 0 ? a / b : NaN),
+  };
+  let checked = 0;
+  for (let d = 0; d <= 12; d++) {
+    for (const q of sample(0x1234 + d, 300, d)) {
+      const m = q.prompt.match(/^(-?\d+)[\s ]*([+−×÷])[\s ]*(-?\d+)$/);
+      if (!m) continue; // compound forms are covered by their own cases below
+      const got = ops[m[2]](Number(m[1]), Number(m[3]));
+      assert.equal(String(got), q.answer, `"${q.prompt}" should be ${got}, host said ${q.answer}`);
+      checked++;
+    }
+  }
+  assert.ok(checked > 400, `expected plenty of simple binary prompts, checked ${checked}`);
+});
+
+test("order-of-operations prompts respect precedence", () => {
+  // Both branches. Only the `a + b x c` shape used to be checked here, and that
+  // is exactly why the `a*c - b x c` branch was free to emit negative answers in
+  // an unsigned domain without anything noticing.
+  let addChecked = 0;
+  let subChecked = 0;
+  for (const q of sample(0x77, 900, 9)) {
+    const add = q.prompt.match(/^(\d+)[\s ]*\+[\s ]*(\d+)[\s ]*×[\s ]*(\d+)$/);
+    if (add) {
+      const [a, b, c] = [Number(add[1]), Number(add[2]), Number(add[3])];
+      assert.equal(q.answer, String(a + b * c));
+      // The canonical mal-rule - left-to-right - must be on offer.
+      assert.ok(q.distractors.includes(String((a + b) * c)), "missing the left-to-right distractor");
+      addChecked++;
+      continue;
+    }
+    const sub = q.prompt.match(/^(\d+)[\s ]*−[\s ]*(\d+)[\s ]*×[\s ]*(\d+)$/);
+    if (sub) {
+      const [p, b, c] = [Number(sub[1]), Number(sub[2]), Number(sub[3])];
+      assert.equal(q.answer, String(p - b * c));
+      assert.ok(Number(q.answer) >= 0, `"${q.prompt}" answers ${q.answer} in an unsigned domain`);
+      // Left-to-right here means subtracting before multiplying.
+      assert.ok(q.distractors.includes(String((p - b) * c)), "missing the left-to-right distractor");
+      subChecked++;
+    }
+  }
+  assert.ok(addChecked > 0, "difficulty 9 never produced an `a + b x c` item");
+  assert.ok(subChecked > 0, "difficulty 9 never produced an `a*c - b x c` item");
+});
+
+test("distractors are usable: at least two, distinct, never the answer", () => {
+  for (let d = 0; d <= 12; d++) {
+    for (const q of sample(0xabc + d, 250, d)) {
+      assert.ok(q.distractors.length >= 2, `${q.prompt} offered ${q.distractors.length} distractors`);
+      const set = new Set(q.distractors);
+      assert.equal(set.size, q.distractors.length, `${q.prompt} repeated a distractor`);
+      assert.ok(!set.has(q.answer), `${q.prompt} offered its own answer as a distractor`);
+      for (const dd of q.distractors) {
+        assert.match(dd, /^-?\d+$/, `distractor "${dd}" is not an integer literal`);
+      }
+    }
+  }
+});
+
+test("distractors are mal-rule outputs, not noise around the answer", () => {
+  // 7 x 6: a child who adds writes 13; a child who skip-counts one step short
+  // writes 35 or 36. At least one such answer must be reachable, or the wrong
+  // lanes are free to reject and the question stops being a question.
+  let sawAddedInstead = false;
+  let sawSkipCount = false;
+  for (const q of sample(0x5150, 900, 3)) {
+    if (q.domain !== "mul.facts") continue;
+    const m = q.prompt.match(/^(\d+)[\s ]*×[\s ]*(\d+)$/);
+    if (!m) continue;
+    const a = Number(m[1]), b = Number(m[2]);
+    if (q.distractors.includes(String(a + b))) sawAddedInstead = true;
+    if (q.distractors.includes(String(a * b - a)) || q.distractors.includes(String(a * b - b))) sawSkipCount = true;
+  }
+  assert.ok(sawAddedInstead, "no multiplication item ever offered the added-instead-of-multiplied answer");
+  assert.ok(sawSkipCount, "no multiplication item ever offered a skip-count-short answer");
+});
+
+test("addition with a carry actually carries", () => {
+  // The sibling of the `sub.borrow` assertion below, which was missing — and in
+  // its absence 18% of `add.carry` items arrived with no carry in them (`43 +
+  // 20`). In exactly those items the dropped-the-carry mal-rule collapses onto
+  // the correct answer and gets deduped away, so the gate quietly loses a lane.
+  let seen = 0;
+  let malRule = 0;
+  // Difficulty 3, because that is a band `addCarry` is actually in — the ladder
+  // drops it after `until: 5`, and asking at 5 samples a band without it.
+  for (const q of sample(0xca447, 900, 3)) {
+    if (q.domain !== "add.carry") continue;
+    const m = q.prompt.match(/^(\d+)[\s ]*\+[\s ]*(\d+)$/);
+    assert.ok(m, `"${q.prompt}" is not a two-term addition`);
+    const a = Number(m![1]), b = Number(m![2]);
+    assert.ok((a % 10) + (b % 10) >= 10, `${q.prompt} does not actually require a carry`);
+    assert.notEqual(String(a + b - 10), q.answer, `${q.prompt}: the dropped-carry mal-rule collapsed onto the answer`);
+    // `build()` shuffles the mal-rules and keeps three of the four, so this one
+    // is frequent rather than universal — the same shape the borrow case below
+    // asserts. What matters is that it is *available*: before the fix it was
+    // identical to the answer on every carry-free item and deduped away.
+    if (q.distractors.includes(String(a + b - 10))) malRule++;
+    seen++;
+  }
+  assert.ok(seen > 20, `only ${seen} add.carry items appeared`);
+  assert.ok(malRule > seen / 2, `the dropped-carry answer was offered only ${malRule} times in ${seen} items`);
+});
+
+test("subtraction with a borrow offers smaller-from-larger", () => {
+  let seen = 0;
+  for (const q of sample(0x9001, 900, 5)) {
+    if (q.domain !== "sub.borrow") continue;
+    const m = q.prompt.match(/^(\d+)[\s ]*−[\s ]*(\d+)$/);
+    if (!m) continue;
+    const a = Number(m[1]), b = Number(m[2]);
+    assert.ok(a % 10 < b % 10, `${q.prompt} does not actually require a borrow`);
+    const malRule = Math.floor(a / 10) - Math.floor(b / 10);
+    const digits = malRule * 10 + Math.abs((a % 10) - (b % 10));
+    if (q.distractors.includes(String(digits))) seen++;
+  }
+  assert.ok(seen > 4, `smaller-from-larger appeared only ${seen} times`);
+});
+
+test("whole-number questions never offer a negative option", () => {
+  // In signed-integer work a negative option is the whole point — dropping the
+  // sign is the mal-rule. Everywhere else it is a free elimination.
+  //
+  // The **answer** is checked here as well as the distractors, and that is the
+  // half that was missing. Guarding only the distractors is worse than guarding
+  // neither: `build()` strips negative distractors from an unsigned domain, so a
+  // negative answer became the only negative among the four options and a child
+  // could take that lane on sight. `12 − 8 × 4 = −20` against `8`, `16` and `0`
+  // shipped for exactly that reason.
+  let sawSigned = false;
+  for (let d = 0; d <= 12; d++) {
+    for (const q of sample(0x33 + d, 300, d)) {
+      if (q.domain === "int.signed") { sawSigned = true; continue; }
+      assert.ok(
+        Number(q.answer) >= 0,
+        `${q.domain} answered "${q.prompt}" with ${q.answer}; in an unsigned domain the only negative on offer is a free elimination`,
+      );
+      for (const dd of q.distractors) {
+        assert.ok(Number(dd) >= 0, `${q.domain} offered ${dd}, which a child can reject without doing the maths`);
+      }
+    }
+  }
+  assert.ok(sawSigned, "signed-integer work never appeared, so its exemption is untested");
+});
+
+test("the same seed replays the same question stream", () => {
+  const a = sample(12345, 120, 6).map((q) => `${q.prompt}=${q.answer}|${q.distractors.join(",")}`);
+  const b = sample(12345, 120, 6).map((q) => `${q.prompt}=${q.answer}|${q.distractors.join(",")}`);
+  assert.deepEqual(a, b);
+  const c = sample(12346, 120, 6).map((q) => q.prompt);
+  assert.notDeepEqual(a.map((s) => s.split("=")[0]), c);
+});
+
+test("question ids are unique within a host", () => {
+  const host = createStubHost({ seed: 7 });
+  const ids = new Set<string>();
+  for (let i = 0; i < 500; i++) ids.add(host.next({ difficulty: i % 12 }).id);
+  assert.equal(ids.size, 500);
+});
+
+test("difficulty moves the domain mix, and out-of-range values are clamped", () => {
+  const easy = new Set(sample(4, 200, 0).map((q) => q.domain));
+  const hard = new Set(sample(4, 200, 11).map((q) => q.domain));
+  assert.ok(easy.has("add.within20"));
+  assert.ok(!easy.has("ops.order"), "difficulty 0 should never ask order of operations");
+  assert.ok(hard.has("ops.order") || hard.has("frac.of") || hard.has("int.signed"));
+
+  const host = createStubHost({ seed: 1 });
+  for (const d of [-40, NaN, 1e9]) {
+    const q = host.next({ difficulty: d });
+    assert.ok(Number.isFinite(q.difficulty) && q.difficulty >= 0 && q.difficulty <= 12, `difficulty ${d} escaped clamping`);
+    assert.match(q.answer, /^-?\d+$/);
+  }
+  assert.match(host.next().answer, /^-?\d+$/, "next() with no options must still work");
+});
+
+test("a prompt never repeats back to back", () => {
+  const host = createStubHost({ seed: 99 });
+  let prev = "";
+  for (let i = 0; i < 400; i++) {
+    const q = host.next({ difficulty: 1 });
+    assert.notEqual(q.prompt, prev, "the same prompt twice in a row reads as a bug to a player");
+    prev = q.prompt;
+  }
+});

--- a/dynawalla/games/runner/src/stubHost.ts
+++ b/dynawalla/games/runner/src/stubHost.ts
@@ -1,0 +1,352 @@
+import type { Host, Question } from "./contract.ts";
+import { Rng } from "./game/rng.ts";
+
+/**
+ * Local stub Host so `npm run dev` is a real, playable game with no runtime
+ * underneath it.
+ *
+ * Rules it holds itself to, because the real host will too:
+ *  - Exact integer arithmetic only. No float appears in an answer or in a
+ *    comparison; every answer is the decimal string of a JS safe integer.
+ *  - Seeded and deterministic. The same seed yields the same question stream.
+ *  - Distractors are *mal-rule outputs*: what a child actually writes when they
+ *    run the wrong procedure. `7 x 6 -> 13` is a child who added. `52 - 27 ->
+ *    35` is smaller-from-larger. A distractor that is merely "answer + 1" is a
+ *    coin flip dressed as a question.
+ */
+
+type Gen = (rng: Rng, d: number) => Raw;
+type Raw = { prompt: string; answer: number; wrong: number[]; domain: string; signed?: boolean };
+
+const NBSP = " "; // thin space: keeps "3 + 4" from wrapping mid-expression
+
+function ex(a: number, op: string, b: number): string {
+  return `${a}${NBSP}${op}${NBSP}${b}`;
+}
+
+/* ------------------------------------------------------------------ */
+/* Generators. Each returns the true answer plus the mal-rule outputs. */
+/* ------------------------------------------------------------------ */
+
+const addSmall: Gen = (rng, d) => {
+  const cap = d <= 0 ? 9 : 12 + d * 3;
+  const a = rng.int(2, cap);
+  const b = rng.int(2, cap);
+  return {
+    prompt: ex(a, "+", b),
+    answer: a + b,
+    // count-on-by-one slip; counted the first addend too (fencepost); doubled one side
+    wrong: [a + b - 1, a + b + 1, a + a, b + b, Math.abs(a - b)],
+    domain: "add.within20",
+  };
+};
+
+const addCarry: Gen = (rng, d) => {
+  // Build the digits directly rather than sampling and repairing.
+  //
+  // The repair approach — "nudge b until the units carry, then clamp it" — can
+  // undo its own fix when the nudge wraps past ten, and it did: **18% of
+  // `add.carry` items arrived with no carry in them at all**, like `43 + 20`.
+  // That is worse than a wasted question. In exactly those items the headline
+  // mal-rule (dropped the carry) equals the correct answer, so the dedupe in
+  // `build()` silently swallows it and the gate is left with one plausible
+  // option and one absurd three-digit one — effectively two lanes, in a game
+  // whose entire premise is that the third lane costs you something.
+  //
+  // This is the same trap the generator below it already fell into and fixed;
+  // see `subBorrow`. Sampling the digits makes the carry a fact of construction
+  // rather than something a later line can take away.
+  const aU = rng.int(1, 9);
+  const bU = rng.int(10 - aU, 9); // guarantees aU + bU >= 10, i.e. a real carry
+  const hiT = d >= 5 ? 8 : 4;
+  const aT = rng.int(1, hiT);
+  const bT = rng.int(1, hiT);
+  const a = aT * 10 + aU;
+  const b = bT * 10 + bU;
+  const sum = a + b;
+  const units = aU + bU; // always 10..18
+  const tens = aT + bT;
+  return {
+    prompt: ex(a, "+", b),
+    answer: sum,
+    wrong: [
+      // Dropped the carry: the tens column written as-is, the units column
+      // written mod ten. Because the carry is now guaranteed this is always
+      // exactly `sum - 10`, and always distinct from the answer.
+      tens * 10 + (units - 10),
+      sum + 10, // carried twice
+      sum - 1, // a slip counting the units column
+      tens * 100 + units, // wrote each column whole, side by side
+    ],
+    domain: "add.carry",
+  };
+};
+
+const subSmall: Gen = (rng, d) => {
+  const cap = d <= 0 ? 10 : 14 + d * 2;
+  const a = rng.int(5, cap);
+  const b = rng.int(1, a - 1);
+  return {
+    prompt: ex(a, "−", b),
+    answer: a - b,
+    wrong: [a - b + 1, a - b - 1, a + b, b],
+    domain: "sub.within20",
+  };
+};
+
+const subBorrow: Gen = (rng, d) => {
+  // Build the digits directly rather than sampling and repairing. The repair
+  // approach ("nudge b until it borrows, then clamp it below a") can undo its
+  // own fix on the clamp and quietly emit 88 - 70, which teaches nothing about
+  // borrowing and makes the classic mal-rule distractor meaningless.
+  const aT = rng.int(3, d >= 5 ? 9 : 6);
+  const bT = rng.int(1, aT - 1);
+  const aU = rng.int(0, 7);
+  const bU = rng.int(aU + 1, 9);
+  const a = aT * 10 + aU;
+  const b = bT * 10 + bU;
+  return {
+    prompt: ex(a, "−", b),
+    answer: a - b,
+    wrong: [
+      (aT - bT) * 10 + Math.abs(aU - bU), // smaller-from-larger, the classic
+      (aT - bT + 1) * 10 + (aU + 10 - bU), // borrowed but never decremented the tens
+      a - b + 10,
+      a - b - 10,
+    ],
+    domain: "sub.borrow",
+  };
+};
+
+const mulFact: Gen = (rng, d) => {
+  const hi = d <= 2 ? 6 : d <= 4 ? 9 : 12;
+  const a = rng.int(2, hi);
+  const b = rng.int(2, hi);
+  const p = a * b;
+  return {
+    prompt: ex(a, "×", b),
+    answer: p,
+    wrong: [
+      p - a, // skip-counted one step short
+      p + a, // one step long
+      p - b,
+      a + b, // added instead of multiplied
+    ],
+    domain: "mul.facts",
+  };
+};
+
+const mulTwoByOne: Gen = (rng, d) => {
+  const a = rng.int(d >= 7 ? 21 : 12, d >= 7 ? 89 : 39);
+  const b = rng.int(3, d >= 7 ? 9 : 6);
+  const aT = Math.floor(a / 10), aU = a % 10;
+  const carry = Math.floor((aU * b) / 10);
+  return {
+    prompt: ex(a, "×", b),
+    answer: a * b,
+    wrong: [
+      aT * b * 10 + (aU * b) % 10, // dropped the carry into the tens
+      (aT + carry) * b * 10 + ((aU * b) % 10), // added the carry before multiplying
+      a * b - a,
+      a * b + a,
+    ],
+    domain: "mul.multidigit",
+  };
+};
+
+const divFact: Gen = (rng, d) => {
+  const hi = d <= 4 ? 8 : 12;
+  const q = rng.int(2, hi);
+  const b = rng.int(2, hi);
+  const a = q * b;
+  return {
+    prompt: ex(a, "÷", b),
+    answer: q,
+    wrong: [
+      b, // handed back the divisor
+      q + 1,
+      q - 1,
+      a - b, // subtracted instead
+    ],
+    domain: "div.facts",
+  };
+};
+
+const missingAddend: Gen = (rng, d) => {
+  const total = rng.int(d >= 4 ? 25 : 11, d >= 4 ? 70 : 19);
+  const a = rng.int(3, total - 2);
+  return {
+    prompt: `${a}${NBSP}+${NBSP}▢${NBSP}=${NBSP}${total}`,
+    answer: total - a,
+    wrong: [total + a, a, total, total - a - 1],
+    domain: "add.missing",
+  };
+};
+
+const orderOfOps: Gen = (rng, d) => {
+  const hi = d >= 8 ? 9 : 6;
+  const c = rng.int(2, hi);
+  if (rng.chance(0.5)) {
+    const a = rng.int(2, 9);
+    const b = rng.int(2, hi);
+    return {
+      prompt: `${a}${NBSP}+${NBSP}${b}${NBSP}×${NBSP}${c}`,
+      answer: a + b * c,
+      wrong: [(a + b) * c, a + b + c, a * b + c],
+      domain: "ops.order",
+    };
+  }
+  // The subtraction branch, with `b` held strictly below `a`.
+  //
+  // `a` and `b` used to be sampled independently, so `a·c − b×c` went negative
+  // whenever b > a — **19% of `ops.order` items**, in a domain that is not
+  // marked `signed`. That combination is the worst of both: `build()` strips
+  // negative *distractors* from an unsigned domain but never checks the answer,
+  // so `12 − 8 × 4 = −20` shipped against `8`, `16` and `0`. The answer was the
+  // only negative on offer, and a child could take that lane without doing any
+  // arithmetic at all — which is precisely the free elimination this host exists
+  // to refuse. Signed work has its own generator and its own ladder band.
+  const a = rng.int(3, 9);
+  const b = rng.int(2, a - 1);
+  return {
+    prompt: `${a * c}${NBSP}−${NBSP}${b}${NBSP}×${NBSP}${c}`,
+    answer: (a - b) * c,
+    wrong: [(a * c - b) * c, a * c - b - c, a * c - b + c],
+    domain: "ops.order",
+  };
+};
+
+const fractionOf: Gen = (rng, d) => {
+  const den = rng.pick([2, 3, 4, 5]);
+  const num = rng.int(1, den - 1);
+  const whole = den * rng.int(2, d >= 8 ? 12 : 7);
+  return {
+    prompt: `${num}/${den}${NBSP}of${NBSP}${whole}`,
+    answer: (whole / den) * num,
+    wrong: [
+      whole / den, // divided and stopped
+      whole * num, // multiplied and stopped
+      whole - den,
+      (whole / den) * (den - num), // took the complement
+    ],
+    domain: "frac.of",
+  };
+};
+
+const signedAdd: Gen = (rng, d) => {
+  const a = rng.int(2, 9 + d);
+  const b = rng.int(2, 9 + d);
+  if (rng.chance(0.5)) {
+    return {
+      prompt: `−${a}${NBSP}+${NBSP}${b}`,
+      answer: b - a,
+      wrong: [a + b, -(a + b), a - b],
+      domain: "int.signed",
+      signed: true,
+    };
+  }
+  return {
+    prompt: `${a}${NBSP}−${NBSP}${a + b}`,
+    answer: -b,
+    wrong: [b, a + b, -(a + b)],
+    domain: "int.signed",
+    signed: true,
+  };
+};
+
+/** Difficulty band -> the generators that can fire in it. */
+const LADDER: { until: number; gens: Gen[] }[] = [
+  { until: 1, gens: [addSmall, subSmall] },
+  { until: 2, gens: [addSmall, subSmall, mulFact] },
+  { until: 3, gens: [addSmall, subSmall, mulFact, addCarry] },
+  { until: 4, gens: [mulFact, addCarry, subBorrow, divFact] },
+  { until: 5, gens: [mulFact, addCarry, subBorrow, divFact, missingAddend] },
+  { until: 6, gens: [mulFact, divFact, subBorrow, missingAddend, mulTwoByOne] },
+  { until: 7, gens: [mulFact, divFact, mulTwoByOne, orderOfOps, fractionOf] },
+  { until: 99, gens: [mulTwoByOne, orderOfOps, fractionOf, divFact, signedAdd] },
+];
+
+export type StubOptions = {
+  seed?: number;
+  /** Called on every report(); the dev page uses it to draw a live accuracy strip. */
+  onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void;
+};
+
+export function createStubHost(opts: StubOptions = {}): Host & { seed: number } {
+  const seed = opts.seed ?? 0xc0ffee;
+  const rng = new Rng(seed);
+  let n = 0;
+  let lastPrompt = "";
+
+  function build(difficulty: number): Question {
+    const band = LADDER.find((b) => difficulty < b.until) ?? LADDER[LADDER.length - 1];
+    let raw: Raw = rng.pick(band.gens)(rng, difficulty);
+    // Never ask the identical prompt twice in a row; it reads as a bug.
+    for (let guard = 0; guard < 6 && raw.prompt === lastPrompt; guard++) {
+      raw = rng.pick(band.gens)(rng, difficulty);
+    }
+    lastPrompt = raw.prompt;
+
+    const answer = raw.answer;
+    const seen = new Set<number>([answer]);
+    const picks: number[] = [];
+    for (const w of rng.shuffle(raw.wrong.slice())) {
+      if (!Number.isSafeInteger(w)) continue;
+      if (seen.has(w)) continue;
+      if (!raw.signed && w < 0) continue; // a negative option in a whole-number question is free to reject
+      if (Math.abs(w) > 99999) continue;
+      seen.add(w);
+      picks.push(w);
+      if (picks.length >= 3) break;
+    }
+    // Backfill, still deterministically, if the mal-rules collided.
+    for (let k = 1; picks.length < 3 && k < 40; k++) {
+      for (const cand of [answer + k, answer - k]) {
+        if (seen.has(cand)) continue;
+        if (!raw.signed && cand < 0) continue;
+        seen.add(cand);
+        picks.push(cand);
+        if (picks.length >= 3) break;
+      }
+    }
+
+    return {
+      id: `stub-${seed.toString(16)}-${n++}`,
+      prompt: raw.prompt,
+      answer: String(answer),
+      distractors: picks.map(String),
+      domain: raw.domain,
+      difficulty,
+    };
+  }
+
+  return {
+    seed,
+    next(o) {
+      // A NaN or Infinity from the host must not propagate into the ladder:
+      // `Math.round(NaN)` clamps to NaN, `LADDER.find` then misses every band
+      // and the question's own difficulty field becomes NaN on the way back.
+      const raw = Number(o?.difficulty ?? 2);
+      const d = Number.isFinite(raw) ? Math.max(0, Math.min(12, Math.round(raw))) : 2;
+      return build(d);
+    },
+    report(r) {
+      opts.onReport?.(r);
+    },
+    haptic(k) {
+      // Web fallback: the real host owns the native path. Silent no-op when absent.
+      const nav = navigator as Navigator & { vibrate?: (p: number | number[]) => boolean };
+      if (typeof nav.vibrate !== "function") return;
+      const ms =
+        k === "light" ? 8 : k === "medium" ? 16 : k === "heavy" ? 30 : k === "success" ? 12 : 40;
+      try {
+        nav.vibrate(k === "failure" ? [30, 40, 30] : ms);
+      } catch {
+        /* Some browsers throw on vibrate without a user gesture. Nothing to do. */
+      }
+    },
+    prefersReducedMotion() {
+      return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    },
+  };
+}

--- a/dynawalla/games/runner/tsconfig.json
+++ b/dynawalla/games/runner/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "exactOptionalPropertyTypes": false,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src"]
+}

--- a/dynawalla/games/runner/vite.config.ts
+++ b/dynawalla/games/runner/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    sourcemap: false,
+  },
+  server: {
+    host: "127.0.0.1",
+    port: 5187,
+  },
+});

--- a/dynawalla/games/runner/vite.pack.config.ts
+++ b/dynawalla/games/runner/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produced a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})


### PR DESCRIPTION
## What

Add `dynawalla/games/runner` — **VOLTA**, a behind-the-back endless runner where
the lane you are in when you cross a gate is the answer you gave.

An endless night run along a black glass causeway. Every few seconds a gate array
spans the track with a number over each lane and exactly one is right. There is
no answer UI, no keypad, no multiple-choice card — steering *is* answering, and a
wrong lane is a solid barrier you slam into. Swipe to change lane, jump the gaps,
slide under the bars, thread the pylons close enough to graze them.

Three lanes means a guesser is right one time in three, so the price of a guess
is steep enough that reading is plainly cheaper: **+8 voltage** for a correct
gate, **−27 and a one-second stumble** for a wrong one, which averages about −14
per gate for a guesser — four gates from full to dead. When the voltage runs out
the world goes slow and offers a **recharge**: one question, three lane-shaped
buttons, a draining ring. Unlimited, free, and priced in the surge multiplier
rather than in money.

## Why

The arcade canon this catalogue draws from stops at about 1999, and
`docs/catalog/ARCADE_CANON.md` names the gap directly: *"a ten-year-old in 2026
does not play Berzerk; they play a horde-survivor, a swipe-slicer, a
behind-the-back runner, a growth arena."* The third-person runner is the
most-installed game shape on earth and the one shape a child already knows how to
hold. So the goal was not "a runner with maths bolted on" — it was to build the
runner first, well enough that a child would open it anyway, and then make the
maths the steering.

The same document names the catalogue-wide failure this pack had to beat:
*"engraved serif numerals on tumbling, receding targets that a child has 0.45
seconds to read."* Most of the work below is about not being that.

### Finishing the read band

The first build shipped the numerals in world space, at the lanes, fanned outward
with distance. That cannot work and no amount of tuning makes it work: the camera
sits 11.4 units behind a causeway whose lanes are 3.35 apart, so the *widest* the
lane pitch ever gets on screen is about 12% of the viewport, and only in the last
third of a second before the gate lands. A judge playing that build captured
`13 | 42 | 36` rendering as **`134236`**, and a fan-out compensation big enough to
fix it pushed the third value clean off a 390px phone.

Perspective is the wrong tool for typesetting three values a child has half a
second to compare. `readband.ts` now decides an explicit pitch, an explicit 30%
gutter, an explicit page margin and one shared ink height, all in NDC, and
`project.ts` converts that layout back into the world positions the instanced
digit shader wants — so the numerals still fog, still bend with the causeway,
still belong to the world.

`readband.test.ts` hammers that across 9 viewports × 3 fields of view × 7
distances × 3 font widths × 4 digit counts × 5 approach phases × 5 arch heights
and asserts the two things that actually matter: **adjacent numerals never touch**
and **nothing leaves the viewport**.

### The rest of the polish in this PR

- **`glyphs.ts` (new)** — the character set and the two ink metrics, in one file
  with no imports, so `readband.test.ts` asserts its legibility floors against the
  renderer's real numbers rather than a copy that can silently drift. `/` and `.`
  join the atlas, which they exactly fill, and an unknown character renders as `?`
  instead of being skipped. Skipping it turned `3/4` into `34` — not an
  unreadable answer, a different and wrong one.
- **`options.ts` (new)** — the one place a question becomes three lanes, shared
  by the gates on the causeway and by the recharge gate. They had drifted apart,
  and the recharge gate backfilled with `String(Number(answer) + k)`: the literal
  string `NaN`, in a lane, the moment a host answers `3/4` with fewer than two
  distractors. The nudge is now exact decimal arithmetic (`BigInt`) on the
  answer's trailing number — `42` gives `43`/`41`, `3/4` gives `3/5`/`3/3`. Never
  a float, never a `NaN`, never the same value in two lanes.
- **`payoffHeight` / `keepInside`** moved into `readband.ts` — the two other
  places ink could leave the frame, now testable. The winning numeral used to
  swell to a flat 1.55 NDC *tall* with nothing checking how wide that made it; on
  a 390px phone the best moment in the game was two green slabs jammed against
  the edges.
- **Lifecycle** — two teardown leaks. The recharge verdict timer is now
  cancelled in `unmount()`; it would otherwise start audio and write to a HUD
  that had already left the document. And the HUD stylesheet is a *sibling* of
  `.vt-root`, which `unmount()` alone removed, so a host that swaps packs
  accumulated one dead `<style>` per mount — each still claiming every
  `.vt-root` rule, so the leftovers styled the next mount too.
- **Hygiene** — `BEST_KEY` → `BEST_SLOT` with a `gitleaks:allow` note (it is a
  `localStorage` slot name; the dotted-and-versioned shape trips
  `generic-api-key`); `typecheck` → `tsc` and the sibling games' test flags;
  `.gitignore` matches `horde`/`rhythm`; `package-lock.json` untracked.
- **README** — the numeral section still described the fan-out layout that
  `readband.ts` replaced, and the verification block named a script that no
  longer exists.
- **VOLTA is now an installable pack.** `packs/build.mjs` discovers packs by
  globbing for a `pack.json` under `games/`, and runner had none — so it would
  have merged, sat in the tree, and been invisible to the pack build, the
  catalogue and the app's game browser. It would have shipped to nobody. Added
  `pack.json`, `pack.html`, `src/pack.ts` (the seam only) and
  `vite.pack.config.ts`, after `games/slice`.
- **Two maths bugs in the generators**, found by adversarial self-review and both
  the same shape — a question answerable without doing the arithmetic. `add.carry`
  sampled two addends and then *repaired* them into a carry; the repair could
  wrap past ten and undo itself, so **18% of items carried nothing** (`43 + 20`),
  and in exactly those the dropped-the-carry mal-rule equals the answer and got
  deduped away, leaving a two-lane gate. `orderOfOps` emitted **negative answers
  19% of the time** in an unsigned domain — and since `build()` strips negative
  *distractors* but never checked the answer, `12 − 8 × 4 = −20` shipped against
  `8`, `16` and `0`, where the answer was the only negative and the correct lane
  could be taken on sight. Digits are now built directly (as `subBorrow` already
  did after the same trap) and `b` is held strictly below `a`.
- **`glyphs.test.ts` was binary.** A literal NUL byte — an invisible test case
  written as a character rather than an escape — made git classify the whole
  file as binary, which would have hidden it from every diff and from the
  adversarial-review gate. The unprintable cases are `\u….` escapes now, and
  `git diff --numstat origin/main...HEAD` reports no binary file in the branch.

## Blast radius

**Areas touched:** dynawalla — and *only* `dynawalla/games/runner/`, a new
directory. Verified below: zero files outside it, zero deletions.

**Three of these files were never tracked in git.** `src/game/project.ts`,
`src/game/readband.ts` and `src/game/readband.test.ts` existed only as untracked
working copies, alongside ~384 lines of uncommitted edits to five tracked files.
They were one `git clean` from gone. They are also the newest and most important
work in the game, so this PR verified they are genuinely wired in rather than
orphaned: `project.ts` is imported by `mount.ts` and `entities.ts`, `readband.ts`
by `entities.ts`, and both are on the render path for every incoming gate.
Nothing was dead and nothing was deleted — the work was finished instead.

- [x] Every touched path is under `dynawalla/`, covered by the `dynawalla` area
      filter in `ci.yml`.
- [x] **Pack back-compat.** New pack, so nothing to break: no published zip
      changed in place, no `voiceId` renamed, no existing catalog entry dropped
      or re-bounded. `dynawalla.runner` is *added* to the generated catalogue —
      a full `node build.mjs` goes from 5 packs to 6 and every pre-existing pack
      still builds and passes `dw-pack check`. Declared capabilities are
      `items`, `items.reveal`, `haptics` and no more; `host` is `0.1.0 … <1.0.0`,
      matching every shipped pack.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifest.
- [x] **Strings.** N/A — self-contained pack, no `corpan-app` locale directory
      touched.
- [x] **Curriculum.** No skill id renamed or reused. **No floats anywhere in an
      answer or an answer comparison**: the stub host emits only decimal strings
      of safe integers (asserted in `stubHost.test.ts`), and the distractor
      backfill in `options.ts` is `BigInt` string arithmetic, so `999 + 1` is
      `1000` and a 16-digit answer nudges exactly rather than snapping to the
      nearest double.
- [x] **Secrets.** None. `gitleaks` output below.

**On `covers.skills`:** `dw-pack check` does **not** validate skill ids — a
fictional one passes silently — so the seven declared ids were resolved from the
graph's own id constants in `packs/shared/curriculum/src/graph/domains/` and
checked by hand. They are exactly the ids whose nodes are `status: "active"`.
Everything else in the graph (`mul.*`, `div.*`, `frac.*`, `alg.*`, `ns.*`, and
`dw.add.regroup.subtract-tenths`) is still `draft`, so claiming it would be
claiming coverage no host can serve today. `grades: [1, 4]` is the span of those
seven nodes' own `gradeBand`.

## Proof

Real output at commit `8edc914`, rebased onto `496d2dbf1`.

```
$ npm run tsc
> @dynawalla/game-runner@0.1.0 tsc
> tsc --noEmit


$ npm run build
✓ 30 modules transformed.
✓ built in 596ms

$ npm run build:pack
✓ 36 modules transformed.
dist-pack/pack.html                  1.25 kB │ gzip:   0.65 kB
dist-pack/assets/pack-B2y2yLp1.js  614.70 kB │ gzip: 166.29 kB
✓ built in 587ms

$ grep -o '<script[^>]*>' dist-pack/pack.html
<script type="module" crossorigin src="./assets/pack-B2y2yLp1.js">
```

The real pack gate — this is the step that runs `dw-pack check`:

```
$ cd dynawalla/packs && node build.mjs runner
dynawalla.runner@0.1.0 — VOLTA
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 617093 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

A full `node build.mjs` builds 6 packs and `dynawalla.runner` appears in the
generated `catalog.json`. `dist-pack/` and `src-tauri/packs/` are gitignored;
no build artifact is in the diff.

The two generator fixes, re-verified behaviourally over 32,000 generated
questions:

```
add.carry without a carry:                   0 / 1697
ops.order with a negative answer:            0 / 3366
negative answer in ANY unsigned domain:      0
```

Five consecutive test runs, not one — a sibling game passed once and then failed
three of the next five from unseeded randomness in a test. This suite has none:
`Math.random` appears only in the game's visual ambience (particle jitter, audio
detune), never in a test and never in a rule.

```
$ for i in 1 2 3 4 5; do npm test; done
run 1: # tests 57 # pass 57 # fail 0
run 2: # tests 57 # pass 57 # fail 0
run 3: # tests 57 # pass 57 # fail 0
run 4: # tests 57 # pass 57 # fail 0
run 5: # tests 57 # pass 57 # fail 0
```

57 assertions across six suites, all about rules rather than rendering: the read
band and payoff sizing (`readband.test.ts`), the atlas and its fallbacks
(`glyphs.test.ts`), the three-lane option builder (`options.test.ts`), the
escalation curves and their floors (`pacing.test.ts`), the flash rate limit and
reduced-motion guarantees (`juice.test.ts`), and the question stream itself
(`stubHost.test.ts`). No DOM and no GPU required.

Secrets and scope, run at the repo root:

```
$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~292371 bytes (292.37 KB) in 54.7ms
INF no leaks found

$ git diff --name-only origin/main...HEAD | grep -v "^dynawalla/games/runner/"
(no output — nothing outside the game directory)

$ git diff --diff-filter=D --name-only origin/main...HEAD
(no output — nothing deleted)

$ git diff --unified=3 origin/main...HEAD | wc -c
  294727
```

On diff size: `adversarial_review.py` chunks rather than truncates — "Large
diffs are CHUNKED, never truncated... the concatenation of the chunks must equal
the diff exactly, before a single model call is made" — and the stale cap note
was expunged from the template in #577, which this branch is rebased onto.
