### PR TITLE
dynawalla: the games run inside the app — packs built, installed, framed and fed by the curriculum

### DIFF
--- a/dynawalla/.gitignore
+++ b/dynawalla/.gitignore
@@ -1,0 +1,1 @@
+dist-packs/

--- a/dynawalla/docs/DECISIONS/ADR-0023-host-owns-the-mathematics.md
+++ b/dynawalla/docs/DECISIONS/ADR-0023-host-owns-the-mathematics.md
@@ -1,0 +1,85 @@
+# ADR-0023 — The host owns the mathematics; packs own the games
+
+**Status:** accepted
+**Date:** 2026-07-26
+**Amends:** ADR-0022 (the host ships no content), ADR-0020, ADR-0021
+
+## Context
+
+ADR-0022 stripped the host to a shell and put *everything* in packs, including
+the curriculum. `src/work/` was deleted, `boundary.test.ts` grew a guard that
+fails the build if anything under `dynawalla-app/src/` imports the curriculum,
+and the front door became the pack list.
+
+The pack contract that shipped alongside it says something different, and says
+it in the wire protocol rather than in prose:
+
+- `items.next` returns a question and **does not carry the answer**.
+- `items.answer` records the attempt and **then** returns the canonical value.
+- `items.reveal` is a separately declared capability, visible to the parent,
+  for the narrow case of a game that must place the correct target before the
+  child reaches it.
+
+That design exists for one reason, and it is the reason this is a mathematics
+product rather than a toy: *a game cannot be beaten by fiddling with the game*,
+because the thing that decides whether a child was right is not inside it.
+
+The two cannot both be true. A host with no arithmetic cannot answer
+`items.next`, cannot judge `items.answer`, and cannot produce a mal-rule
+distractor — so `HostServices` would be unimplementable, the `items` capability
+would be dead, and every pack would end up carrying its own generator and its
+own judge. That is precisely the outcome the protocol was designed to prevent,
+and it would arrive by omission rather than by decision.
+
+FUSE and SIEGE both landed on trunk with stub hosts that generated and judged
+their own questions. Two packs, two arithmetics, two sets of mal-rules. At a
+hundred packs that is a hundred.
+
+## Decision
+
+The split is not "content in packs, nothing in the host". It is:
+
+- **Packs own every game, world, screen, asset and sound.** All of it. The host
+  ships no exercise surface, no keypad, no worksheet. `src/work/` stays deleted.
+- **The host owns the mathematics**: which item a child is served, and whether
+  the answer was right. One curriculum, one judge, one set of mal-rules, for
+  every pack that will ever be installed.
+
+Concretely:
+
+- `dynawalla-app/src/packs/items.ts` is the item service — the ladder, the
+  ledger, and the judgement. It is built on `packs/shared/curriculum`.
+- `dynawalla-app/src/packs/curriculum.ts` is the only module that names the
+  curriculum. Everything else in the host reaches it through that one page.
+- `boundary.test.ts` keeps its guard and gains a second measured exemption
+  beside the SDK contract, with two properties asserted about it: the
+  curriculum re-exports nothing outside its own package, and it touches no DOM.
+  `dynawalla/curriculum/` and `dynawalla/engine/` remain out of bounds.
+- Exactly two host modules may name an exercise. The list is asserted, not
+  described.
+
+## Consequences
+
+**Good.** The `items` capability becomes real: a pack asks for a question, draws
+it however it likes, reports what a child did, and is told the verdict. Two
+games now share one arithmetic, one difficulty ladder and one learner record.
+Adding the ninety-eighth pack adds no mathematics.
+
+**Cost.** The host is no longer content-free in the strictest reading of
+ADR-0022, and the boundary is now a *rule about what kind of thing* rather than
+a rule about a directory. That is weaker, so it is compensated with the two
+structural assertions above rather than with a paragraph.
+
+**What this does not license.** A screen in the host that renders an exercise. A
+keypad. A component that decides an answer. Those are still refused, by a test,
+by name.
+
+## Alternatives rejected
+
+**Leave the curriculum to packs and let each judge itself.** Cheapest today.
+It makes the `items` capability decoration, puts the answer inside the game
+where a curious child can find it, and produces one arithmetic per pack.
+
+**Widen the SDK so a pack can post its own generator to the host.** A plugin
+inside a plugin, with the generator crossing a boundary that exists to keep
+untrusted code out. The reason to have the boundary is the reason not to.

--- a/dynawalla/dynawalla-app/README.md
+++ b/dynawalla/dynawalla-app/README.md
@@ -14,7 +14,8 @@ Node 24 (`.nvmrc`).
 | | |
 |---|---|
 | `npm run dev` | Vite dev server on `127.0.0.1:1423` (Corpán holds 1421) |
-| `npm run tauri dev` | the desktop app against that dev server |
+| **`npm run tauri dev`** | **the app, with every pack built and installed** |
+| `npm run packs` | build, validate and stage every pack (`../packs/build.mjs`) |
 | `npm test` | `node --experimental-strip-types --test` — no vitest |
 | `npm run tsc` | typecheck: the app, the tests, and the build's own config |
 | `npm run lint` | eslint |
@@ -31,6 +32,31 @@ not build project references and a `references` entry would check nothing.
 CI runs lint, test, tsc and build in the `dynawalla-app` job, which reports into
 `ci-gate`. There is **no cargo job for either app in `ci.yml`** — the Rust below
 is not compiled by any required check yet.
+
+## Running it, with the games in it
+
+```
+npm run tauri dev
+```
+
+That is the whole loop. `tauri.conf.json` runs `npm run packs` first, which
+builds every pack under `../games/`, validates each against the manifest schema
+with `dw-pack check`, and stages it into `src-tauri/packs/`. The Rust side
+installs those into the pack root before the first window exists, so the front
+door opens with FUSE and SIEGE on it — no network, no catalogue, no install
+step. A debug build re-installs them on every launch, so editing a game and
+restarting is the entire iteration.
+
+`src-tauri/packs/` and `../dist-packs/` are build output and are git-ignored.
+
+To open straight into a game while working on one:
+
+```
+VITE_DW_AUTOPLAY=dynawalla.fuse npm run tauri dev
+```
+
+which also prints a frame-rate line every two seconds. It is compiled out of any
+build where the variable is unset — see `src/packs/devPlay.ts`.
 
 ## Layout
 

--- a/dynawalla/dynawalla-app/package.json
+++ b/dynawalla/dynawalla-app/package.json
@@ -13,7 +13,8 @@
     "tauri": "tauri",
     "tsc": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json && tsc --noEmit -p tsconfig.node.json",
     "lint": "eslint .",
-    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'"
+    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'",
+    "packs": "node ../packs/build.mjs"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.11.1",

--- a/dynawalla/dynawalla-app/src-tauri/.gitignore
+++ b/dynawalla/dynawalla-app/src-tauri/.gitignore
@@ -51,3 +51,8 @@ target/
 # is part of the shipped build (ADR-0011 point 2): a store binary has to be
 # reproducible from the tag. Corpán's lock is tracked for the same reason.
 !Cargo.lock
+
+# Built pack bundles, staged here by `packs/build.mjs` and bundled as a Tauri
+# resource. Build output, never committed: `npm run packs` regenerates them and
+# `npm run tauri dev`/`build` runs it first.
+/packs/

--- a/dynawalla/dynawalla-app/src-tauri/build.rs
+++ b/dynawalla/dynawalla-app/src-tauri/build.rs
@@ -1,3 +1,27 @@
 fn main() {
+    // `bundle.resources` in tauri.conf.json names `packs` — the built pack
+    // bundles that `packs/build.mjs` stages here, so that `npm run tauri dev`
+    // starts with every game already installed and no network round trip.
+    //
+    // That directory is build output: gitignored, absent from a fresh
+    // checkout, and produced by a Node pipeline. `tauri_build::build()` copies
+    // every declared resource into the target directory UNCONDITIONALLY — on
+    // `cargo clippy` and `cargo check` as much as on `cargo build`, since all
+    // three run build scripts — and a resource path that does not exist is a
+    // hard error ("resource path `packs` doesn't exist"), not a warning.
+    //
+    // Without this line the crate therefore cannot be compiled or even linted
+    // until somebody has run `npm run packs` first, which is what made the
+    // Rust gate in CI fail: the `native` job installs a Rust toolchain and no
+    // Node one, so it hit a build-script error with zero clippy findings.
+    //
+    // Creating the directory empty decouples the two. Cargo alone always
+    // compiles; the real bundles still arrive exactly as before, because
+    // `beforeDevCommand` and `beforeBuildCommand` both run `npm run packs`
+    // ahead of cargo, and that script exits non-zero if it finds no pack to
+    // stage. So an empty `packs/` can never reach a bundle.
+    std::fs::create_dir_all("packs")
+        .expect("failed to create the src-tauri/packs bundle-resource directory");
+
     tauri_build::build()
 }

--- a/dynawalla/dynawalla-app/src-tauri/src/lib.rs
+++ b/dynawalla/dynawalla-app/src-tauri/src/lib.rs
@@ -24,6 +24,13 @@ mod packs;
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        // Packs that ship with this build are installed before the first window
+        // exists, so the front door is never empty on a first launch and a
+        // `npm run tauri dev` session always has the freshly built ones.
+        .setup(|app| {
+            packs::sync_bundled(app.handle());
+            Ok(())
+        })
         .register_uri_scheme_protocol(packs::PACK_SCHEME, |ctx, request| {
             packs::serve(ctx.app_handle(), &request)
         })

--- a/dynawalla/dynawalla-app/src-tauri/src/packs/mod.rs
+++ b/dynawalla/dynawalla-app/src-tauri/src/packs/mod.rs
@@ -682,5 +682,107 @@ fn extract_within(
     Ok(())
 }
 
+// ─── Packs that ship with the app ────────────────────────────────────────────
+
+/// Where the packs bundled with this build live.
+///
+/// Two answers, and both are needed. In a release the packs are a Tauri
+/// resource and sit under `resource_dir()`. In `npm run tauri dev` there is no
+/// bundle: `packs/build.mjs` stages them into `src-tauri/packs/`, which is a
+/// compile-time constant of this crate, so the dev loop needs no environment
+/// variable, no symlink and no manual install step.
+fn bundled_root<R: Runtime>(app: &AppHandle<R>) -> Option<PathBuf> {
+    if let Ok(dir) = app.path().resource_dir() {
+        let candidate = dir.join("packs");
+        if candidate.is_dir() {
+            return Some(candidate);
+        }
+    }
+    #[cfg(debug_assertions)]
+    {
+        let candidate = Path::new(env!("CARGO_MANIFEST_DIR")).join("packs");
+        if candidate.is_dir() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn copy_tree(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(to)?;
+    for entry in fs::read_dir(from)? {
+        let entry = entry?;
+        let kind = entry.file_type()?;
+        let target = to.join(entry.file_name());
+        if kind.is_dir() {
+            copy_tree(&entry.path(), &target)?;
+        } else if kind.is_file() {
+            fs::copy(entry.path(), &target)?;
+        }
+        // Symlinks are skipped rather than followed: a bundled pack is built by
+        // this repository's own pipeline, and a link in one is a mistake at
+        // best.
+    }
+    Ok(())
+}
+
+/// Install the packs that ship with this build, if they are not already the
+/// version installed.
+///
+/// Called at setup, before any window is shown. The whole point is that the
+/// front door is never empty on a first launch and never stale in development:
+/// a debug build re-copies unconditionally, so editing a pack and restarting is
+/// the entire dev loop, while a release build only acts when the version
+/// changed and therefore does not rewrite a device's pack directory on every
+/// cold start.
+///
+/// Failures are logged and swallowed. A bundled pack that will not copy is a
+/// pack the child does not get; it is not a reason for the app not to open.
+pub fn sync_bundled<R: Runtime>(app: &AppHandle<R>) {
+    let Some(source) = bundled_root(app) else {
+        return;
+    };
+    let Ok(root) = pack_root(app) else {
+        eprintln!("[packs] no pack root; bundled packs were not installed");
+        return;
+    };
+
+    let Ok(entries) = fs::read_dir(&source) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !valid_pack_id(&name) {
+            continue;
+        }
+        let Some(bundled) = read_installed(&entry.path()) else {
+            eprintln!("[packs] bundled {name} has no readable manifest.json");
+            continue;
+        };
+        if bundled.id != name {
+            eprintln!("[packs] bundled {name} calls itself {}", bundled.id);
+            continue;
+        }
+
+        let destination = root.join(&name);
+        let current = read_installed(&destination);
+        let same_version = current
+            .as_ref()
+            .is_some_and(|installed| installed.version == bundled.version);
+        if same_version && !cfg!(debug_assertions) {
+            continue;
+        }
+
+        let _ = fs::remove_dir_all(&destination);
+        if let Err(problem) = copy_tree(&entry.path(), &destination) {
+            eprintln!("[packs] could not install bundled {name}: {problem}");
+            let _ = fs::remove_dir_all(&destination);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests;

--- a/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
+++ b/dynawalla/dynawalla-app/src-tauri/tauri.conf.json
@@ -4,9 +4,9 @@
   "version": "0.1.0",
   "identifier": "inc.corpora.dynawalla",
   "build": {
-    "beforeDevCommand": "npm run dev",
+    "beforeDevCommand": "npm run packs && npm run dev",
     "devUrl": "http://127.0.0.1:1423",
-    "beforeBuildCommand": "npm run tsc && npm run build",
+    "beforeBuildCommand": "npm run packs && npm run tsc && npm run build",
     "frontendDist": "../dist"
   },
   "app": {
@@ -27,7 +27,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "icon": ["icons/icon.png"],
+    "icon": [
+      "icons/icon.png"
+    ],
     "iOS": {
       "minimumSystemVersion": "16.0",
       "developmentTeam": "F9AV5HKF6N",
@@ -35,6 +37,9 @@
     },
     "android": {
       "minSdkVersion": 26
-    }
+    },
+    "resources": [
+      "packs"
+    ]
   }
 }

--- a/dynawalla/dynawalla-app/src/app/Shell.tsx
+++ b/dynawalla/dynawalla-app/src/app/Shell.tsx
@@ -1,6 +1,7 @@
 import { Link, Outlet } from "react-router"
 
 import { Strapwork } from "../design/Strapwork.tsx"
+import { PackStage } from "../packs/Stage.tsx"
 import { Nav } from "./Nav.tsx"
 import { strings } from "./strings.ts"
 
@@ -47,6 +48,9 @@ export function Shell() {
         <Outlet />
       </main>
       <Nav />
+      {/* The stage is a sibling of the chrome, not a child of the surface: a
+          launched pack takes the window, including the navigation. */}
+      <PackStage />
     </div>
   )
 }

--- a/dynawalla/dynawalla-app/src/app/boundary.test.ts
+++ b/dynawalla/dynawalla-app/src/app/boundary.test.ts
@@ -59,6 +59,46 @@ const modules = files(src)
 const SDK_ENTRY = path.resolve(src, "../../packs/sdk/src/index.ts")
 
 /**
+ * The second, and last, module outside `src/` the host may import: the
+ * curriculum's public entry point.
+ *
+ * This is a **reversal of part of ADR-0022, recorded in ADR-0023**, and it is
+ * worth stating why rather than quietly widening a guard.
+ *
+ * The pack contract this repository shipped makes the host the judge, and says
+ * so in the protocol itself: `items.next` does not carry the answer, and
+ * `items.answer` records the attempt *before* it returns the canonical value.
+ * That is what makes "a mathematics game cannot be beaten by fiddling with the
+ * game" a property rather than a hope. A host with no arithmetic cannot honour
+ * it — it can only hand the whole item contract back to the pack, which is the
+ * thing the contract exists to prevent.
+ *
+ * So the split is not "content in packs, nothing in the host". It is:
+ *
+ *   * **packs** own every game, world, asset, screen and sound. All of it.
+ *   * **the host** owns the mathematics: which item, and whether it was right.
+ *
+ * `packs/shared/curriculum` is the second of those. It has no DOM, no assets,
+ * no screens and no game in it — it is exact rational arithmetic, seeded
+ * generators and executable mal-rules. `dynawalla/curriculum/` and
+ * `dynawalla/engine/` remain out of bounds, and the scan below still says so.
+ *
+ * Like the SDK exemption this is one file, and the walk below holds it to
+ * re-exporting nothing outside its own package, so it cannot become a tunnel.
+ */
+const CURRICULUM_ENTRY = path.resolve(src, "../../packs/shared/curriculum/src/index.ts")
+
+/**
+ * The only modules in the host that may know what an exercise is: the page that
+ * names the curriculum, and the service built on it.
+ *
+ * The exemption is a *file*, not a rule about words, because that is what keeps
+ * it reviewable: everything the host believes about arithmetic is on one page,
+ * and a second page acquiring an opinion fails this suite.
+ */
+const ARITHMETIC_MODULES = ["packs/curriculum.ts", "packs/items.ts"]
+
+/**
  * A module's source with its comments removed.
  *
  * Every scan in this file is a regular expression over source text, and a
@@ -105,6 +145,14 @@ test("the host imports no curriculum and no content of any kind", () => {
       // The contract, and only the contract. Every other path out of `src/` is
       // still an offence, including another file in the same SDK directory.
       if (resolved === SDK_ENTRY) continue
+      if (resolved === CURRICULUM_ENTRY) {
+        // `packs/curriculum.ts` is the single module that names it. Every other
+        // module in the host reaches the curriculum through that one page, so
+        // "what does the host use out of it" is a file you can read.
+        if (path.relative(src, file) === "packs/curriculum.ts") continue
+        offenders.push(`${path.relative(src, file)} -> ${specifier}`)
+        continue
+      }
       const outside = resolved === null ? specifier : path.relative(src, resolved)
       if (/(^|\/)(curriculum|engine)(\/|$)/.test(outside) || outside.startsWith("..")) {
         offenders.push(`${path.relative(src, file)} -> ${specifier}`)
@@ -114,7 +162,7 @@ test("the host imports no curriculum and no content of any kind", () => {
   assert.deepEqual(offenders, [], "the host reached outside itself for content")
 })
 
-test("the one import that leaves src/ is the contract, and it carries no content", () => {
+test("the imports that leave src/ are the contract and the curriculum, and nothing else", () => {
   // The exemption above is safe only while it names a real file that re-exports
   // nothing but the SDK's own modules. One `export * from "../shared/curriculum"`
   // in the entry point would put every generator back inside the host through a
@@ -145,17 +193,64 @@ test("the one import that leaves src/ is the contract, and it carries no content
   assert.deepEqual(escapes, [], "the pack contract reaches outside itself")
 })
 
-test("no exercise, problem generator or answer judge lives in the host", () => {
-  // Named for what they were when they shipped in the app: a keypad, a judge,
-  // a mal-rule diagnosis, a deck of problems. The host has no opinion about
-  // arithmetic any more — it does not know what an exercise is, only that a
-  // pack reported an outcome (`packs/host.ts`).
-  const banned = /\b(exercise|malRule|misconception|keypad|numerator|denominator|regroup|minuend|subtrahend)\b/i
-  const offenders: string[] = []
-  for (const file of modules) {
-    if (banned.test(code(file))) offenders.push(path.relative(src, file))
+test("the curriculum the host imports is arithmetic, and only arithmetic", () => {
+  // The same measurement applied to the second exemption. A curriculum entry
+  // that re-exported a renderer, an asset loader or anything with a DOM in it
+  // would put content back in the host through a door the offender scan waves
+  // past, with the whole suite still green.
+  assert.ok(fs.existsSync(CURRICULUM_ENTRY), "the exempted curriculum does not exist")
+
+  const pkg = path.resolve(path.dirname(CURRICULUM_ENTRY), "..")
+  const escapes: string[] = []
+  const dom: string[] = []
+  const seen = new Set<string>()
+
+  const walk = (file: string): void => {
+    if (seen.has(file)) return
+    seen.add(file)
+    // No DOM and no Node builtin: the curriculum runs identically in the host,
+    // in a Node test and (one day) in a worker, and anything that reaches for a
+    // document is a renderer wearing a generator's name.
+    if (/\b(document|window|localStorage|HTMLElement)\b/.test(code(file))) {
+      dom.push(path.relative(pkg, file))
+    }
+    for (const specifier of specifiers(file)) {
+      const target = specifier.startsWith(".")
+        ? path.resolve(path.dirname(file), specifier)
+        : null
+      if (target === null || path.relative(pkg, target).startsWith("..")) {
+        escapes.push(`${path.relative(pkg, file)} -> ${specifier}`)
+        continue
+      }
+      walk(target)
+    }
   }
-  assert.deepEqual(offenders, [], "content in the host")
+  walk(CURRICULUM_ENTRY)
+
+  assert.deepEqual(escapes, [], "the curriculum reaches outside itself")
+  assert.deepEqual(dom, [], "the curriculum touches the DOM")
+})
+
+test("exactly one module in the host knows what an exercise is", () => {
+  // Named for what they were when they shipped in the app: a keypad, a judge,
+  // a mal-rule diagnosis, a deck of problems. The host serves and judges items
+  // again (ADR-0023) — but through `packs/items.ts` and nowhere else, so this
+  // is now an exact list rather than an empty one. A screen, a store or a
+  // component acquiring an opinion about arithmetic fails here.
+  //
+  // `keypad` stays banned outright: a work surface is a pack's, always. The
+  // host deleted `src/work/` and is not getting it back through a component
+  // that happens to draw ten buttons.
+  const banned = /\b(exercise|malRule|misconception|numerator|denominator|regroup|minuend|subtrahend)\b/i
+  const offenders: string[] = []
+  const keypads: string[] = []
+  for (const file of modules) {
+    const source = code(file)
+    if (/\bkeypad\b/i.test(source)) keypads.push(path.relative(src, file))
+    if (banned.test(source)) offenders.push(path.relative(src, file))
+  }
+  assert.deepEqual(keypads, [], "a work surface belongs to a pack")
+  assert.deepEqual(offenders.sort(), ARITHMETIC_MODULES, "arithmetic outside the item service")
 })
 
 test("the arrow only points one way — there is no import cycle in src/", () => {

--- a/dynawalla/dynawalla-app/src/app/strings.ts
+++ b/dynawalla/dynawalla-app/src/app/strings.ts
@@ -34,6 +34,14 @@ export const strings = {
   packs: {
     installed: "Installed",
     space: "Space used",
+    /** The control on a pack row. What the row does, in one word. */
+    play: "Play",
+    /** Leaves a running pack. The only host chrome drawn over a game. */
+    leave: "Leave",
+    /** The pack was launched and is no longer on this device. */
+    missing: "This pack is not installed.",
+    /** The frame refused, or the runtime could not name the entry document. */
+    failed: "This pack could not be opened.",
   },
 
   progress: {

--- a/dynawalla/dynawalla-app/src/main.tsx
+++ b/dynawalla/dynawalla-app/src/main.tsx
@@ -11,6 +11,17 @@ import "./settings/store.ts"
 import "./index.css"
 
 import { router } from "./app/router.tsx"
+import { useLibrary } from "./packs/libraryStore.ts"
+import { startAutoplay } from "./packs/devPlay.ts"
+
+// What is on disk, read once, before the first paint asks for it. The front
+// door is the pack list, so an empty first frame is the whole app looking
+// broken; this is fired here rather than in an effect so the read is already in
+// flight while React is still mounting.
+void useLibrary.getState().refresh()
+
+// Developer-only, and compiled out when the variable is unset. See devPlay.ts.
+startAutoplay()
 
 const root = document.getElementById("root")
 if (!root) throw new Error("missing #root")

--- a/dynawalla/dynawalla-app/src/packs/Stage.tsx
+++ b/dynawalla/dynawalla-app/src/packs/Stage.tsx
@@ -1,0 +1,215 @@
+// The stage a pack is played on: the whole window, and one way out.
+//
+// A launched pack takes the screen. Not a card, not a panel inside the shell's
+// two-column measure — a game that is worth playing is worth the device, and a
+// child holding a tablet sideways should see the game and the game only.
+//
+// The one piece of host chrome over it is the way back, and it is drawn on top
+// of the frame rather than above it, because a bar above the frame is a bar
+// that resizes the game every time the safe area changes. It is a real button
+// with a real accessible name at a real target size; everything else here is
+// the frame.
+//
+// An overlay rather than a route: the shell's five destinations are the whole
+// route table (ADR-0005) and a sixth with a parameter would be a screen in the
+// navigation that nothing navigates to. What is launched is app state, and
+// leaving it is one action.
+
+import { useEffect, useMemo, useState } from "react"
+import { create } from "zustand"
+
+import type { Settings } from "../../../packs/sdk/src/index.ts"
+import { BUILD_VERSION } from "../app/platform.ts"
+import { strings } from "../app/strings.ts"
+import { useThemeStore } from "../app/theme.ts"
+import { useProfiles } from "../profiles/store.ts"
+import { useSettings } from "../settings/store.ts"
+import { entryOf, useLibrary } from "./libraryStore.ts"
+import { tauriNative } from "./native.ts"
+import { PackFrame } from "./PackFrame.tsx"
+import { createServices, packSettings } from "./services.ts"
+
+export interface LaunchState {
+  /** The pack on the stage, or nothing. */
+  readonly packId: string | null
+  play: (packId: string) => void
+  leave: () => void
+}
+
+export const useLaunch = create<LaunchState>()((set) => ({
+  packId: null,
+  play: (packId) => set({ packId }),
+  leave: () => set({ packId: null }),
+}))
+
+/** `prefers-color-scheme`, live, because a pack is told the scheme it must draw in. */
+function useSystemDark(): boolean {
+  const [dark, setDark] = useState(
+    () => typeof matchMedia === "function" && matchMedia("(prefers-color-scheme: dark)").matches,
+  )
+  useEffect(() => {
+    if (typeof matchMedia !== "function") return
+    const query = matchMedia("(prefers-color-scheme: dark)")
+    const onChange = () => setDark(query.matches)
+    query.addEventListener("change", onChange)
+    return () => query.removeEventListener("change", onChange)
+  }, [])
+  return dark
+}
+
+/**
+ * One pack, mounted.
+ *
+ * Split out so the services, the ledger and the ladder are made once per
+ * launch: this component's identity IS the session, and React unmounting it is
+ * what ends one.
+ */
+function Stage({ packId, onLeave }: { packId: string; onLeave: () => void }) {
+  const entry = useLibrary((state) => state.entries.find((e) => e.manifest.id === packId))
+  const profileId = useProfiles((state) => state.currentId)
+  const settings = useSettings((state) => state)
+  const themeMode = useThemeStore((state) => state.mode)
+  const systemDark = useSystemDark()
+
+  const [entryUrl, setEntryUrl] = useState<string | null>(null)
+  const [failure, setFailure] = useState<string | null>(null)
+  const [progress, setProgress] = useState(0)
+
+  // Built by the one function that knows how a host setting becomes a pack
+  // setting, so the mapping cannot drift between the launch and the push.
+  const forPack: Settings = useMemo(
+    () => packSettings({ settings, theme: themeMode, systemPrefersDark: systemDark }),
+    [settings, themeMode, systemDark],
+  )
+
+  const launch = useMemo(
+    () =>
+      createServices({
+        profileId,
+        settings: forPack,
+        onProgress: setProgress,
+        onEnd: () => onLeave(),
+        onMilestone: (name) => console.info(`[packs] ${packId} reached ${name}`),
+      }),
+    // One session per mount. `profileId` changing mid-game would be a different
+    // child, which the profile switcher cannot do while the stage is up.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [packId],
+  )
+
+  // Pushed to the live session rather than folded into the memo above, so a
+  // setting changed while a game is running reaches the pack without restarting
+  // the child's run.
+  useEffect(() => {
+    launch.push(forPack)
+  }, [launch, forPack])
+
+  const manifestEntry = entry?.manifest.entry
+  useEffect(() => {
+    if (manifestEntry === undefined) return
+    let live = true
+    tauriNative
+      .entryUrl(packId, manifestEntry)
+      .then((url) => {
+        if (live) setEntryUrl(url)
+      })
+      .catch((error: unknown) => {
+        console.error(`[packs] ${packId} has no entry url`, error)
+        if (live) setFailure(strings.packs.failed)
+      })
+    return () => {
+      live = false
+    }
+  }, [packId, manifestEntry])
+
+  if (!entry) return <Curtain message={strings.packs.missing} onLeave={onLeave} />
+  if (failure !== null) return <Curtain message={failure} onLeave={onLeave} />
+
+  return (
+    <div className="bg-ground-deep fixed inset-0 z-50">
+      {entryUrl === null ? null : (
+        <PackFrame
+          packId={packId}
+          entryUrl={entryUrl}
+          granted={entry.granted}
+          services={launch.services}
+          hostVersion={BUILD_VERSION}
+          title={entry.name}
+          settings={forPack}
+          onError={(reason) => setFailure(reason)}
+        />
+      )}
+
+      {/* The host draws the progress, the pack does not — a hairline across the
+          top edge, which is the one place no game puts anything.
+
+          An SVG with a `width` *attribute* rather than a styled element: the
+          app's CSP is `style-src 'self'`, so a `style` prop is thrown away
+          silently in the shipped build while working perfectly in `vite dev`.
+          A presentation attribute is not CSS and is not subject to it. */}
+      <svg
+        className="pointer-events-none absolute inset-x-0 top-0 h-[3px] w-full"
+        viewBox="0 0 100 1"
+        preserveAspectRatio="none"
+        aria-hidden="true"
+      >
+        <rect
+          className="fill-index"
+          x="0"
+          y="0"
+          height="1"
+          width={Math.max(0, Math.min(1, progress)) * 100}
+        />
+      </svg>
+
+      <button
+        type="button"
+        onClick={onLeave}
+        className="border-line-cut bg-ground/85 text-ink rounded-cut-sm absolute top-[max(var(--safe-top),0.5rem)] right-[max(var(--safe-right),0.5rem)] min-h-11 min-w-11 border px-4 text-sm backdrop-blur"
+      >
+        {strings.packs.leave}
+      </button>
+    </div>
+  )
+}
+
+/** What is drawn when there is no pack to draw. Never a blank rectangle. */
+function Curtain({ message, onLeave }: { message: string; onLeave: () => void }) {
+  return (
+    <div className="bg-ground fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 p-8">
+      <p className="inscription text-ink max-w-sm text-center text-lg tracking-wide">{message}</p>
+      <button
+        type="button"
+        onClick={onLeave}
+        className="border-line-cut text-ink rounded-cut-sm min-h-11 border px-4 text-sm"
+      >
+        {strings.packs.leave}
+      </button>
+    </div>
+  )
+}
+
+/** Mounted once, beside the shell. Renders nothing until a pack is launched. */
+export function PackStage() {
+  const packId = useLaunch((state) => state.packId)
+  const leave = useLaunch((state) => state.leave)
+
+  // Escape leaves, on every platform that has a keyboard. A game that takes the
+  // whole window with no keyboard path out is a trap.
+  useEffect(() => {
+    if (packId === null) return
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") leave()
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [packId, leave])
+
+  if (packId === null) return null
+  return <Stage key={packId} packId={packId} onLeave={leave} />
+}
+
+/** Whether a pack id names something installed. Used by the surface model. */
+export function isLaunchable(packId: string): boolean {
+  return entryOf(packId) !== undefined
+}

--- a/dynawalla/dynawalla-app/src/packs/curriculum.ts
+++ b/dynawalla/dynawalla-app/src/packs/curriculum.ts
@@ -1,0 +1,34 @@
+// The one place the host reaches across into `packs/shared/curriculum`.
+//
+// The path is deep and it is a directory boundary, so it is written once. Two
+// consequences worth keeping: `vite.config.ts` has a note about what serving a
+// sibling package costs, and moving the curriculum to a real package name is a
+// change to this file and nothing else.
+//
+// Re-exported rather than aliased so the import graph is greppable: everything
+// the host uses out of the curriculum is on this page.
+
+export {
+  activeNodes,
+  allNodes,
+  createRng,
+  familyById,
+  FORM_FREE_ENTRY,
+  generatorFamilies,
+  nodeById,
+  PROMPT_KEY_ADD,
+  PROMPT_KEY_SUB,
+  rational,
+  seedFrom,
+  SLOT_BOTTOM,
+  SLOT_TOP,
+} from "../../../packs/shared/curriculum/src/index.ts"
+
+export type {
+  AnswerValue,
+  AnyGeneratorFamily,
+  Exercise,
+  PromptSlot,
+  Rational,
+  SkillNode,
+} from "../../../packs/shared/curriculum/src/index.ts"

--- a/dynawalla/dynawalla-app/src/packs/devPlay.ts
+++ b/dynawalla/dynawalla-app/src/packs/devPlay.ts
@@ -1,0 +1,87 @@
+// Open straight into a pack, and say how fast it is running.
+//
+//     VITE_DW_AUTOPLAY=dynawalla.fuse npm run tauri dev
+//
+// Two things, both only for whoever is building the app.
+//
+// **The launch.** Iterating on a game means restarting the app, and two taps
+// per restart is two taps too many when the loop is fifty restarts long. It
+// waits for the library to be read rather than firing blind, so it works on a
+// cold device where the pack was installed by the bundled sync moments earlier.
+//
+// **The frame rate.** The pack and the host share one web process in every
+// WebView this app ships to, so the host's own animation callback stalls
+// exactly when the game does. Sampling it is a measurement of the game, taken
+// from outside the sandbox, with nothing added to the pack contract to get it.
+//
+// `import.meta.env.VITE_*` is substituted at build time. With the variable
+// unset — which is every build that is not a developer's own — the constant
+// below is `undefined`, the guard is false, and none of this is reachable.
+
+import { useLibrary } from "./libraryStore.ts"
+import { useLaunch } from "./Stage.tsx"
+
+const AUTOPLAY: string | undefined = import.meta.env["VITE_DW_AUTOPLAY"] as string | undefined
+
+/** How often the frame-rate line is printed, in milliseconds. */
+const REPORT_MS = 2000
+
+function sampleFrameRate(): void {
+  let frames = 0
+  let worst = 0
+  let last = performance.now()
+  let since = last
+
+  const tick = (now: number) => {
+    const delta = now - last
+    last = now
+    frames += 1
+    if (delta > worst) worst = delta
+    if (now - since >= REPORT_MS) {
+      const fps = (frames * 1000) / (now - since)
+      // `console.error`, deliberately: Vite's dev client forwards errors to the
+      // terminal and nothing else, and a frame-rate line nobody can read from
+      // outside the WebView is a frame-rate line nobody reads. This path is
+      // only reachable with the variable set.
+      console.error(
+        `[packs] ${fps.toFixed(1)} fps over ${String(frames)} frames, worst frame ${worst.toFixed(1)}ms`,
+      )
+      frames = 0
+      worst = 0
+      since = now
+    }
+    requestAnimationFrame(tick)
+  }
+  requestAnimationFrame(tick)
+}
+
+/**
+ * Wire the developer's launch, if one was asked for.
+ *
+ * Called from `main.tsx` unconditionally; it returns immediately unless the
+ * variable is set.
+ */
+export function startAutoplay(): void {
+  if (!AUTOPLAY) return
+
+  const open = () => {
+    const found = useLibrary.getState().entries.some((entry) => entry.manifest.id === AUTOPLAY)
+    if (!found) {
+      console.error(`[packs] VITE_DW_AUTOPLAY=${AUTOPLAY} is not installed`)
+      return
+    }
+    console.error(`[packs] autoplay: ${AUTOPLAY}`)
+    useLaunch.getState().play(AUTOPLAY)
+    sampleFrameRate()
+  }
+
+  if (useLibrary.getState().ready) {
+    open()
+    return
+  }
+  const stop = useLibrary.subscribe((state) => {
+    if (!state.ready) return
+    stop()
+    open()
+  })
+}

--- a/dynawalla/dynawalla-app/src/packs/items.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.test.ts
@@ -1,0 +1,208 @@
+// The host's half of the item contract, held to the four promises it makes.
+//
+// This is where "a mathematics game cannot be beaten by fiddling with the game"
+// stops being an architecture note. If `items.next` carried the answer, or
+// `judge` accepted whatever a pack said was right, or the same seed produced
+// two different questions, the boundary would still typecheck and the property
+// would be gone.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { createItemService, ladder, choicesFor } from "./items.ts"
+import { familyById, FORM_FREE_ENTRY, activeNodes } from "./curriculum.ts"
+
+const noRecord = () => {}
+
+test("the ladder is every generatable binding, easiest first, and it is not empty", () => {
+  const rungs = ladder()
+  assert.ok(rungs.length > 0, "the shipped graph generates nothing at all")
+  for (const rung of rungs) {
+    assert.ok(rung.level >= 0)
+    assert.equal(rung.family.family, rung.node.generator.family)
+  }
+  // Every active node with a registered family is represented, so a pack asking
+  // for a skill the graph ships can always be served.
+  const covered = new Set(rungs.map((rung) => rung.node.id))
+  for (const node of activeNodes()) {
+    if (familyById(node.generator.family)) {
+      assert.ok(covered.has(node.id), `${node.id} is in the graph and not on the ladder`)
+    }
+  }
+})
+
+test("an item carries the question and never the answer", () => {
+  const service = createItemService({ profileId: "p1", record: noRecord })
+  const item = service.next({ packId: "dynawalla.fuse" })
+  assert.ok(item, "no item was served")
+
+  // The whole payload, enumerated. A field added here that happens to contain
+  // the canonical value is the failure this asserts against.
+  const canonical = service.reveal(item.id)
+  assert.ok(canonical.length > 0)
+  const serialised = JSON.stringify({ ...item, choices: undefined })
+  assert.ok(
+    !serialised.includes(`"${canonical}"`),
+    "the served item names the canonical answer outside its choice list",
+  )
+
+  assert.equal(item.operands.length, 2)
+  assert.ok(item.prompt.includes(item.operands[0] ?? "!"))
+  assert.ok(item.operator === "+" || item.operator === "-")
+  assert.equal(item.answerKind, "integer")
+})
+
+test("a closed list is a choice: four options, the answer among them", () => {
+  const service = createItemService({ profileId: "p1", record: noRecord })
+  for (let i = 0; i < 40; i++) {
+    const item = service.next({ packId: "dynawalla.siege" })
+    assert.ok(item)
+    const canonical = service.reveal(item.id)
+    const texts = (item.choices ?? []).map((choice) => choice.text)
+    assert.equal(texts.length, 4, `${String(texts.length)} option(s) for ${item.prompt}`)
+    assert.ok(texts.includes(canonical), `${item.prompt} does not offer ${canonical}`)
+    assert.equal(new Set(texts).size, texts.length, "a repeated option is not a distractor")
+    for (const text of texts) assert.match(text, /^\d+(\.\d+)?$/)
+  }
+})
+
+test("the curriculum judges, and the attempt is recorded before the answer comes back", () => {
+  const recorded: { packId: string; correct: boolean }[] = []
+  const service = createItemService({
+    profileId: "p1",
+    record: (outcome) => recorded.push(outcome),
+  })
+
+  const right = service.next({ packId: "dynawalla.siege" })
+  assert.ok(right)
+  const canonical = service.reveal(right.id)
+  const verdict = service.judge({
+    packId: "dynawalla.siege",
+    itemId: right.id,
+    response: canonical,
+    latencyMs: 1200,
+  })
+  assert.equal(verdict.correct, true)
+  assert.equal(verdict.canonical, canonical)
+  assert.deepEqual(recorded, [{ packId: "dynawalla.siege", correct: true }])
+
+  const wrong = service.next({ packId: "dynawalla.siege" })
+  assert.ok(wrong)
+  const wrongVerdict = service.judge({
+    packId: "dynawalla.siege",
+    itemId: wrong.id,
+    response: "999999",
+    latencyMs: 900,
+  })
+  assert.equal(wrongVerdict.correct, false)
+  assert.equal(wrongVerdict.canonical, service.reveal(wrong.id))
+  assert.equal(recorded.length, 2)
+  assert.equal(recorded[1]?.correct, false)
+
+  // Reporting the same item twice does not record it twice. A pack that
+  // double-reports a chip would otherwise inflate a child's record, and the
+  // record only ever rises.
+  service.judge({ packId: "dynawalla.siege", itemId: wrong.id, response: "1", latencyMs: 5 })
+  assert.equal(recorded.length, 2)
+})
+
+test("a choice id answers as the value it carries", () => {
+  const service = createItemService({ profileId: "p1", record: noRecord })
+  const item = service.next({ packId: "dynawalla.siege" })
+  assert.ok(item)
+  const canonical = service.reveal(item.id)
+  const choice = (item.choices ?? []).find((entry) => entry.text === canonical)
+  assert.ok(choice, "the canonical value is not among the choices")
+  const verdict = service.judge({
+    packId: "dynawalla.siege",
+    itemId: item.id,
+    response: choice.id,
+    latencyMs: 700,
+  })
+  assert.equal(verdict.correct, true)
+})
+
+test("an unparseable response is wrong, not a crash", () => {
+  const service = createItemService({ profileId: "p1", record: noRecord })
+  const item = service.next({ packId: "dynawalla.fuse" })
+  assert.ok(item)
+  const verdict = service.judge({
+    packId: "dynawalla.fuse",
+    itemId: item.id,
+    response: "  ",
+    latencyMs: 10,
+  })
+  assert.equal(verdict.correct, false)
+})
+
+test("two learners get two streams; one learner gets the same stream twice", () => {
+  const first = createItemService({ profileId: "p1", record: noRecord })
+  const again = createItemService({ profileId: "p1", record: noRecord })
+  const other = createItemService({ profileId: "p2", record: noRecord })
+
+  const a = first.next({ packId: "dynawalla.fuse" })
+  const b = again.next({ packId: "dynawalla.fuse" })
+  const c = other.next({ packId: "dynawalla.fuse" })
+  assert.ok(a && b && c)
+  assert.equal(a.prompt, b.prompt, "the same learner and pack must be reproducible")
+  assert.notEqual(a.prompt, c.prompt, "two learners are sharing a stream")
+})
+
+test("the ladder climbs on a fast correct answer and steps down on a wrong one", () => {
+  const service = createItemService({ profileId: "p1", record: noRecord })
+  assert.equal(service.position(), 0)
+
+  for (let i = 0; i < 3; i++) {
+    const item = service.next({ packId: "dynawalla.fuse" })
+    assert.ok(item)
+    service.judge({
+      packId: "dynawalla.fuse",
+      itemId: item.id,
+      response: service.reveal(item.id),
+      latencyMs: 800,
+    })
+  }
+  const climbed = service.position()
+  assert.ok(climbed > 0, "three fast correct answers did not move the ladder")
+
+  const item = service.next({ packId: "dynawalla.fuse" })
+  assert.ok(item)
+  service.judge({ packId: "dynawalla.fuse", itemId: item.id, response: "0", latencyMs: 200 })
+  assert.equal(service.position(), climbed - 1)
+})
+
+test("a pack may ask for a skill it covers, and an unknown one is not an error", () => {
+  const service = createItemService({ profileId: "p1", record: noRecord })
+  const named = service.next({ packId: "dynawalla.fuse", skillId: "dw.add.regroup.add-multidigit" })
+  assert.ok(named)
+  assert.equal(named.skillId, "dw.add.regroup.add-multidigit")
+  assert.equal(named.operator, "+")
+
+  const unknown = service.next({ packId: "dynawalla.fuse", skillId: "dw.not.a.skill" })
+  assert.ok(unknown, "an unknown skill must fall back to the ladder, not fail")
+})
+
+test("judging or revealing an item nobody served is refused", () => {
+  const service = createItemService({ profileId: "p1", record: noRecord })
+  assert.throws(() => service.reveal("made-up"))
+  assert.throws(() =>
+    service.judge({ packId: "x", itemId: "made-up", response: "1", latencyMs: 1 }),
+  )
+})
+
+test("choices are stable for an exercise, so a redraw does not move the right slab", () => {
+  const node = activeNodes()[0]
+  assert.ok(node)
+  const family = familyById(node.generator.family)
+  assert.ok(family)
+  const params = family.paramSchema.validate(node.generator.params[0])
+  assert.ok(params.ok)
+  const exercise = family.generate({
+    skillId: node.id,
+    level: 0,
+    seed: 4242,
+    params: params.value,
+    forms: [FORM_FREE_ENTRY],
+  })
+  assert.deepEqual(choicesFor(exercise, 0), choicesFor(exercise, 0))
+})

--- a/dynawalla/dynawalla-app/src/packs/items.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.ts
@@ -114,13 +114,34 @@ function formsFor(rung: Rung): readonly string[] {
   return declared.includes(FORM_FREE_ENTRY) ? [FORM_FREE_ENTRY] : declared
 }
 
+/** A prompt slot as a child reads it.
+ *
+ * A `switch` over `kind` rather than a chain ending in a fall-through, so that
+ * the next slot kind the curriculum grows fails to compile HERE — at the
+ * renderer that has to learn how to draw it — instead of silently landing in
+ * whichever branch happened to be last. That is not hypothetical: the
+ * `fraction` kind arrived exactly that way. */
 function slotText(slot: PromptSlot | undefined): string {
   if (slot === undefined) return ""
-  if (slot.kind === "number") {
-    return rational.toDecimalString(slot.value, slot.decimalPlaces) ?? rational.toString(slot.value)
+  switch (slot.kind) {
+    case "number":
+      return (
+        rational.toDecimalString(slot.value, slot.decimalPlaces) ?? rational.toString(slot.value)
+      )
+    case "count":
+      return String(slot.value)
+    case "term":
+      return slot.key
+    case "fraction": {
+      // As written, never reduced: `2/4` and `1/2` are the same number and
+      // different problems, and the generator chose which one it asked. The
+      // whole part is drawn only when there is one, so a plain fraction reads
+      // `1/2` rather than `0 1/2`.
+      const written = `${slot.num.toString()}/${slot.den.toString()}`
+      if (slot.whole === undefined || slot.whole === 0n) return written
+      return `${slot.whole.toString()} ${written}`
+    }
   }
-  if (slot.kind === "count") return String(slot.value)
-  return slot.key
 }
 
 /** An answer value as a child would write it. Never a float, never rounded. */

--- a/dynawalla/dynawalla-app/src/packs/items.ts
+++ b/dynawalla/dynawalla-app/src/packs/items.ts
@@ -1,0 +1,381 @@
+// Where a question comes from, and who says whether it was right.
+//
+// `bridge.ts` is deliberately ignorant of what an item is; this is the module
+// it is ignorant of. Everything here is `@dynawalla/curriculum` — the skill
+// graph, the generator families, the executable mal-rules — and nothing here
+// does arithmetic of its own. That is the whole point of ADR-0022 read from the
+// host's side: the pack draws, the curriculum decides, and a game that wanted
+// to be beaten by fiddling with what it renders has nothing to fiddle with.
+//
+// Three properties, each of them a reason this file exists rather than the
+// equivalent living in a pack:
+//
+//   * **Exact.** Every operand, every answer and every distractor is a
+//     `Rational` rendered to a decimal string. No `number` is ever parsed out
+//     of one and no float is ever compared.
+//   * **Seeded.** An item is a pure function of (profile, pack, sequence). The
+//     same learner on the same pack on two devices gets the same ladder.
+//   * **Judged here.** `nextItem` does not carry the answer. `judge` records
+//     the attempt and *then* returns the canonical value, so `reveal` — which
+//     a game that must place the correct target before the child reaches it
+//     genuinely needs — is a declared capability rather than a hole.
+//
+// **What a rung is.** The curriculum ships one generator family so far
+// (`gen.arith.column-op`) bound to four active skills at four levels each. The
+// rungs are those bindings, sorted by the difficulty the node itself declares,
+// and the ladder walks them: a fast correct answer climbs, a wrong one steps
+// down. That is not the FSRS scheduler (ADR-0008) — it is the smallest honest
+// thing that makes a pack's stream get harder — and it is confined to this file
+// so replacing it does not touch the boundary.
+
+import type {
+  Item,
+  ItemChoice,
+  Judgement,
+  LearnerSummary,
+} from "../../../packs/sdk/src/index.ts"
+import type {
+  AnswerValue,
+  AnyGeneratorFamily,
+  Exercise,
+  PromptSlot,
+  Rational,
+  SkillNode,
+} from "./curriculum.ts"
+import {
+  activeNodes,
+  familyById,
+  FORM_FREE_ENTRY,
+  PROMPT_KEY_SUB,
+  rational,
+  seedFrom,
+  createRng,
+  SLOT_BOTTOM,
+  SLOT_TOP,
+} from "./curriculum.ts"
+
+/** U+2212. A hyphen is not a minus sign, and at 40px a child can tell. */
+const MINUS = "−"
+
+/** Items kept addressable for `judge` and `reveal`. Oldest evicted first. */
+const LEDGER_LIMIT = 512
+
+/** Faster than this and the ladder climbs. Half the slowest node's p50. */
+const QUICK_MS = 6_000
+
+/**
+ * Options on a closed list: the canonical answer and three wrong ones.
+ *
+ * Four because that is what a two-by-two grid holds, and a game that draws its
+ * options as a grid draws an empty cell for a missing one.
+ */
+const CHOICE_COUNT = 4
+
+export type Rung = {
+  readonly node: SkillNode
+  readonly family: AnyGeneratorFamily
+  readonly params: unknown
+  readonly level: number
+}
+
+/**
+ * Every (skill, level) the shipped graph can generate, easiest first.
+ *
+ * Ordered by the node's own declared difficulty for the level, which is a
+ * `Rational` — so the sort is exact and does not depend on how two coefficients
+ * round. A binding whose family is not registered, or whose parameters do not
+ * validate, is dropped rather than throwing: an unusable rung is a curriculum
+ * bug, and it must not be a blank screen in a child's game.
+ */
+export function ladder(nodes: readonly SkillNode[] = activeNodes()): readonly Rung[] {
+  const rungs: { rung: Rung; b: Rational }[] = []
+  for (const node of nodes) {
+    const family = familyById(node.generator.family)
+    if (!family) continue
+    node.generator.params.forEach((raw, level) => {
+      const parsed = family.paramSchema.validate(raw)
+      if (!parsed.ok) return
+      const own = node.difficulty.levels[level]
+      if (own === undefined) return
+      rungs.push({
+        rung: { node, family, params: parsed.value, level },
+        b: rational.add(node.difficulty.b, own),
+      })
+    })
+  }
+  rungs.sort((a, b) => rational.cmp(a.b, b.b))
+  return rungs.map((entry) => entry.rung)
+}
+
+/** The forms a rung may serve. Free entry when it has one: a pack owns its own
+    surface, and the column scaffold is a host-drawn worksheet by another name. */
+function formsFor(rung: Rung): readonly string[] {
+  const declared = rung.node.generator.forms
+  return declared.includes(FORM_FREE_ENTRY) ? [FORM_FREE_ENTRY] : declared
+}
+
+function slotText(slot: PromptSlot | undefined): string {
+  if (slot === undefined) return ""
+  if (slot.kind === "number") {
+    return rational.toDecimalString(slot.value, slot.decimalPlaces) ?? rational.toString(slot.value)
+  }
+  if (slot.kind === "count") return String(slot.value)
+  return slot.key
+}
+
+/** An answer value as a child would write it. Never a float, never rounded. */
+export function answerText(value: AnswerValue, decimalPlaces: number): string | null {
+  if (value.kind === "integer" || value.kind === "columnAlgorithm") {
+    return rational.toDecimalString(value.value, decimalPlaces)
+  }
+  return null
+}
+
+function decimalPlacesOf(exercise: Exercise): number {
+  const schema = exercise.schema
+  return schema.kind === "integer" || schema.kind === "columnAlgorithm" ? schema.decimalPlaces : 0
+}
+
+function digitsOf(exercise: Exercise): number | undefined {
+  const schema = exercise.schema
+  if (schema.kind === "integer") return schema.digits
+  if (schema.kind === "columnAlgorithm") return schema.cols
+  return undefined
+}
+
+/**
+ * The closed list a pack may offer, canonical included, deterministically
+ * shuffled.
+ *
+ * Offered on every item rather than only on a choice-schema one: a tower
+ * defence that puts three slabs on a wall needs two wrong answers a child would
+ * actually produce, and the mal-rules are the only place those exist. A pack
+ * that wants free entry ignores the list; `judge` accepts either the value text
+ * or a choice id, so neither presentation changes who decides.
+ */
+export function choicesFor(exercise: Exercise, places: number): readonly ItemChoice[] {
+  const canonical = answerText(exercise.answer.canonical, places)
+  if (canonical === null) return []
+  const texts: string[] = [canonical]
+  for (const distractor of exercise.distractors) {
+    const text = answerText(distractor.value, places)
+    if (text === null || texts.includes(text)) continue
+    texts.push(text)
+    if (texts.length === CHOICE_COUNT) break
+  }
+
+  // A mal-rule only fires when the item can provoke it, so a clean two-digit
+  // sum offers one wrong answer and a three-way choice would be a coin toss.
+  // The padding is place-value near-misses — off by one, off by ten — computed
+  // in exact rationals like everything else here. They are not diagnoses and
+  // are never reported as one; they exist so a closed list is a choice.
+  //
+  // Four, not three: a game that lays its options out in a grid draws an empty
+  // slab for a missing one, and an empty slab is a wrong answer a child cannot
+  // read.
+  const exact = exercise.answer.canonical
+  if (exact.kind === "integer" || exact.kind === "columnAlgorithm") {
+    for (const offset of [1n, -1n, 10n, -10n, 100n, -100n, 9n, 11n]) {
+      if (texts.length >= CHOICE_COUNT) break
+      const shifted = rational.add(exact.value, rational.rational(offset))
+      if (rational.sign(shifted) < 0) continue
+      const text = rational.toDecimalString(shifted, places)
+      if (text === null || texts.includes(text)) continue
+      texts.push(text)
+    }
+  }
+  const rng = createRng(seedFrom(exercise.exerciseId, "choices"))
+  // Fisher–Yates over the integer stream, so the order is stable per exercise
+  // and the right answer is not always the first slab on the wall.
+  for (let i = texts.length - 1; i > 0; i--) {
+    const j = rng.nextInt(0, i)
+    const a = texts[i] as string
+    const b = texts[j] as string
+    texts[i] = b
+    texts[j] = a
+  }
+  return texts.map((text, index) => ({ id: `c${String(index)}`, text }))
+}
+
+type Served = {
+  readonly exercise: Exercise
+  readonly rung: Rung
+  readonly places: number
+  readonly choices: readonly ItemChoice[]
+  answered: boolean
+}
+
+export type ItemServiceDeps = {
+  /** Namespaces the seed, so two learners do not share a stream. */
+  readonly profileId: string
+  /** Recorded against the learner. The host's only inbound write. */
+  readonly record: (outcome: { packId: string; correct: boolean }) => void
+  readonly rungs?: readonly Rung[]
+}
+
+export type ItemService = {
+  next(input: { packId: string; skillId?: string }): Item | null
+  judge(input: {
+    packId: string
+    itemId: string
+    response: string
+    latencyMs: number
+  }): Judgement
+  reveal(itemId: string): string
+  skip(itemId: string): void
+  summary(): LearnerSummary
+  /** The rung the ladder is standing on. Read by the developer surface. */
+  readonly position: () => number
+}
+
+/**
+ * Everything the bridge's item methods are, as one object.
+ *
+ * Synchronous: nothing here touches IO. `services.ts` is what wraps it in the
+ * promises `HostServices` asks for, which keeps every decision in this file
+ * testable in Node with no DOM, no Tauri and no frame.
+ */
+export function createItemService(deps: ItemServiceDeps): ItemService {
+  const rungs = deps.rungs ?? ladder()
+  const ledger = new Map<string, Served>()
+  const order: string[] = []
+  const practised = new Set<string>()
+  let position = 0
+  let sequence = 0
+
+  const remember = (id: string, served: Served) => {
+    ledger.set(id, served)
+    order.push(id)
+    while (order.length > LEDGER_LIMIT) {
+      const evicted = order.shift()
+      if (evicted !== undefined) ledger.delete(evicted)
+    }
+  }
+
+  const rungAt = (index: number): Rung | null => {
+    if (rungs.length === 0) return null
+    const clamped = Math.max(0, Math.min(rungs.length - 1, index))
+    return rungs[clamped] ?? null
+  }
+
+  return {
+    position: () => position,
+
+    next: ({ packId, skillId }) => {
+      // A pack may name a skill it covers. It is a request, not an instruction:
+      // an unknown id falls back to the ladder rather than failing, because a
+      // pack built against a later curriculum must still be playable.
+      const wanted =
+        skillId === undefined ? null : (rungs.find((rung) => rung.node.id === skillId) ?? null)
+      const rung = wanted ?? rungAt(position)
+      if (!rung) return null
+
+      sequence += 1
+      const seed = seedFrom(deps.profileId, packId, String(sequence))
+      let exercise: Exercise
+      try {
+        exercise = rung.family.generate({
+          skillId: rung.node.id,
+          level: rung.level,
+          seed,
+          params: rung.params,
+          forms: formsFor(rung),
+        })
+      } catch (error) {
+        // A generator that cannot draw is a curriculum bug and is loud, but it
+        // is not a crash in a child's game: the pack is told there is nothing.
+        console.error(`[packs] ${rung.node.id} could not generate`, error)
+        return null
+      }
+
+      const places = decimalPlacesOf(exercise)
+      const choices = choicesFor(exercise, places)
+      const id = `${exercise.exerciseId}#${String(sequence)}`
+      remember(id, { exercise, rung, places, choices, answered: false })
+      practised.add(rung.node.id)
+
+      const top = slotText(exercise.prompt.slots[SLOT_TOP])
+      const bottom = slotText(exercise.prompt.slots[SLOT_BOTTOM])
+      const subtract = exercise.prompt.key === PROMPT_KEY_SUB
+      const digits = digitsOf(exercise)
+
+      return {
+        id,
+        skillId: rung.node.id,
+        level: rung.level,
+        form: "binary-op",
+        operator: subtract ? "-" : "+",
+        operands: [top, bottom],
+        prompt: `${top} ${subtract ? MINUS : "+"} ${bottom}`,
+        choices,
+        answerKind: "integer",
+        ...(digits === undefined ? {} : { digits }),
+      }
+    },
+
+    judge: ({ packId, itemId, response, latencyMs }) => {
+      const served = ledger.get(itemId)
+      if (!served) throw new RangeError(`no such item: ${itemId}`)
+
+      const canonical = answerText(served.exercise.answer.canonical, served.places) ?? ""
+      // A pack may answer with the value or with the id of a choice it drew.
+      // Both are the same act; a pack should not have to reformat a slab it
+      // was handed to report that a child touched it.
+      const chosen = served.choices.find((choice) => choice.id === response)
+      const text = chosen?.text ?? response
+
+      let submitted: AnswerValue | null = null
+      try {
+        submitted = { kind: "integer", value: rational.parseRational(text) }
+      } catch {
+        // Not a number a child could have written. Wrong, not a crash: a pack
+        // is free to report whatever a stray tap produced.
+      }
+
+      const verdict =
+        submitted === null
+          ? ({ correct: false } as const)
+          : served.rung.family.check(served.exercise, submitted)
+
+      // Recorded before the canonical value goes back, which is what makes it
+      // safe to return one at all: there is no way to read the answer without
+      // spending the attempt.
+      if (!served.answered) {
+        served.answered = true
+        deps.record({ packId, correct: verdict.correct })
+        // The ladder moves on what actually happened. Up only when it was both
+        // right and quick, down on any miss — a child who is guessing does not
+        // climb, and a child who is struggling is not held there.
+        if (verdict.correct && latencyMs <= QUICK_MS) position = Math.min(rungs.length - 1, position + 1)
+        else if (!verdict.correct) position = Math.max(0, position - 1)
+      }
+
+      return {
+        correct: verdict.correct,
+        canonical,
+        ...(verdict.correct || verdict.misconception === undefined
+          ? {}
+          : { diagnosis: verdict.misconception }),
+        advance: verdict.correct,
+      }
+    },
+
+    reveal: (itemId) => {
+      const served = ledger.get(itemId)
+      if (!served) throw new RangeError(`no such item: ${itemId}`)
+      return answerText(served.exercise.answer.canonical, served.places) ?? ""
+    },
+
+    skip: (itemId) => {
+      const served = ledger.get(itemId)
+      if (served) served.answered = true
+    },
+
+    summary: () => ({
+      skills: rungs
+        .map((rung) => rung.node.id)
+        .filter((id, index, all) => all.indexOf(id) === index)
+        .map((id) => ({ id, level: practised.has(id) ? ("practiced" as const) : ("new" as const) })),
+    }),
+  }
+}

--- a/dynawalla/dynawalla-app/src/packs/library.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/library.test.ts
@@ -1,0 +1,114 @@
+// What the front door is allowed to show.
+//
+// The library is the join between three things that each have their own
+// failure: what Rust found on disk, what the manifest schema accepts, and what
+// this build of the app can still run. A pack that fails any of them must be
+// *reported*, not dropped — it is occupying disk, and a parent who cannot see
+// it cannot remove it.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { HOST_SUPPORTS, hostProfile, readLibrary } from "./library.ts"
+import type { InstalledPackRow, PackNative } from "./native.ts"
+
+const manifest = (over: Record<string, unknown> = {}) => ({
+  schema: 1,
+  id: "dynawalla.fuse",
+  version: "1.0.0",
+  name: "FUSE",
+  description: "Chips that add to the key number fuse.",
+  sdk: "1.0.0",
+  host: { min: "0.1.0", max: "1.0.0" },
+  entry: "pack.html",
+  capabilities: ["items", "items.reveal", "haptics"],
+  covers: { skills: ["dw.add.regroup.add-multidigit"], grades: [1, 4] },
+  locales: ["en"],
+  assets: { files: 3, bytes: 80000 },
+  download: { bytes: 70000, sha256: "a".repeat(64) },
+  ...over,
+})
+
+const rowFor = (raw: unknown, id = "dynawalla.fuse"): InstalledPackRow => ({
+  id,
+  version: "1.0.0",
+  manifest: JSON.stringify(raw),
+  bytes: 71878,
+})
+
+const nativeWith = (rows: InstalledPackRow[]): PackNative => ({
+  list: () => Promise.resolve(rows),
+  catalog: () => Promise.resolve("{}"),
+  install: () => Promise.reject(new Error("not in this test")),
+  remove: () => Promise.resolve(),
+  entryUrl: (packId, entry) => Promise.resolve(`dynawalla-pack://localhost/${packId}/${entry}`),
+})
+
+test("an installed pack becomes a launchable entry with a grant set", async () => {
+  const { entries, problems } = await readLibrary({
+    native: nativeWith([rowFor(manifest())]),
+    host: hostProfile("0.1.0"),
+  })
+  assert.deepEqual(problems, [])
+  assert.equal(entries.length, 1)
+  const entry = entries[0]
+  assert.ok(entry)
+  assert.equal(entry.name, "FUSE")
+  assert.equal(entry.bytes, 71878)
+  assert.deepEqual([...entry.granted], ["items", "items.reveal", "haptics"])
+})
+
+test("the grant is the intersection, not what the pack asked for", async () => {
+  // A build that cannot vibrate must not hand out `haptics`, whatever the
+  // manifest says — the pack was installed before the capability was removed
+  // and is not allowed to keep it.
+  const { entries } = await readLibrary({
+    native: nativeWith([rowFor(manifest())]),
+    host: { version: "0.1.0", supports: ["items", "items.reveal"] },
+  })
+  assert.deepEqual([...(entries[0]?.granted ?? [])], ["items", "items.reveal"])
+})
+
+test("a pack this build has grown past is refused, with a reason, not hidden", async () => {
+  const { entries, problems } = await readLibrary({
+    native: nativeWith([rowFor(manifest({ host: { min: "9.0.0" } }))]),
+    host: hostProfile("0.1.0"),
+  })
+  assert.deepEqual(entries, [])
+  assert.equal(problems.length, 1)
+  assert.equal(problems[0]?.refusal.code, "host_version")
+})
+
+test("a damaged pack is reported rather than dropped", async () => {
+  const rows = [
+    { id: "broken", version: "1.0.0", manifest: "{ not json", bytes: 10 },
+    rowFor(manifest()),
+  ]
+  const { entries, problems } = await readLibrary({
+    native: nativeWith(rows),
+    host: hostProfile("0.1.0"),
+  })
+  assert.equal(entries.length, 1, "one bad pack must not hide the others")
+  assert.equal(problems.length, 1)
+  assert.equal(problems[0]?.id, "broken")
+})
+
+test("the localised name is what a child is shown", async () => {
+  const { entries } = await readLibrary({
+    native: nativeWith([rowFor(manifest({ nameLocalized: { es: "FUSIÓN" } }))]),
+    host: hostProfile("0.1.0"),
+    locale: "es-MX",
+  })
+  assert.equal(entries[0]?.name, "FUSIÓN")
+})
+
+test("this build supports every capability the SDK defines", () => {
+  // A capability in the table that no build honours is a capability a pack can
+  // declare, be refused for, and never find out why. If one is ever genuinely
+  // unsupported it belongs here as a deliberate omission with a note, not as an
+  // oversight.
+  assert.deepEqual(
+    [...HOST_SUPPORTS].sort(),
+    ["audio", "haptics", "items", "items.reveal", "learner.read", "milestones", "storage"],
+  )
+})

--- a/dynawalla/dynawalla-app/src/packs/library.ts
+++ b/dynawalla/dynawalla-app/src/packs/library.ts
@@ -1,0 +1,98 @@
+// What is on this device, read from disk, gated, and made launchable.
+//
+// `registry.ts` is the persisted *record* — a list a parent can read with no
+// native runtime present. This is the live truth: `packs_list` walks the pack
+// root, every manifest goes through `gateRun` (which is re-asked every launch,
+// because the app is what changes underneath an installed pack), and what
+// survives is a pack that can be framed right now.
+//
+// Everything here is pure over its dependencies, so the whole decision — a
+// damaged manifest, a pack this build has grown past, a capability that was
+// removed underneath one — is a Node test. `libraryStore.ts` is the thin part
+// that wires it to Tauri and to React.
+
+import type { Capability, PackManifest } from "../../../packs/sdk/src/index.ts"
+import { localizedDescription, localizedName } from "../../../packs/sdk/src/index.ts"
+import { gateRun, type HostProfile, type Refusal } from "./gate.ts"
+import { readInstalled } from "./install.ts"
+import type { PackNative } from "./native.ts"
+
+/** Everything this build can honour. A pack asking for more is refused. */
+export const HOST_SUPPORTS: readonly Capability[] = [
+  "items",
+  "items.reveal",
+  "learner.read",
+  "haptics",
+  "audio",
+  "milestones",
+  "storage",
+]
+
+/**
+ * This build, as a pack sees it.
+ *
+ * The version is passed in rather than read from `platform.ts`: that module
+ * evaluates a Vite-defined constant at import, which does not exist under
+ * `node --test`, and this file has to stay reachable from a Node test with no
+ * DOM and no bundler. `libraryStore.ts` is what supplies the real one.
+ */
+export function hostProfile(version: string): HostProfile {
+  return { version, supports: HOST_SUPPORTS }
+}
+
+/** One pack, ready to launch. */
+export type LibraryEntry = {
+  readonly manifest: PackManifest
+  readonly bytes: number
+  /** The intersection of what it declared and what this build can do. */
+  readonly granted: readonly Capability[]
+  readonly name: string
+  readonly description: string
+}
+
+export type LibraryProblem = {
+  readonly id: string
+  readonly refusal: Refusal
+}
+
+export type LibraryDeps = {
+  readonly native: PackNative
+  readonly host: HostProfile
+  readonly locale?: string
+}
+
+/**
+ * Read the pack root and decide what may run.
+ *
+ * Pure over its dependencies so the whole decision — a damaged manifest, a pack
+ * this build has grown past, a capability that was removed — is a Node test.
+ */
+export async function readLibrary(
+  deps: LibraryDeps,
+): Promise<{ entries: LibraryEntry[]; problems: LibraryProblem[] }> {
+  const { packs, damaged } = await readInstalled(deps.native)
+  const entries: LibraryEntry[] = []
+  const problems: LibraryProblem[] = damaged.map((entry) => ({
+    id: entry.id,
+    refusal: { code: "manifest", message: "This pack is damaged.", problems: entry.problems },
+  }))
+
+  for (const installed of packs) {
+    const verdict = gateRun({ raw: installed.manifest, host: deps.host })
+    if (!verdict.ok) {
+      problems.push({ id: installed.manifest.id, refusal: verdict.refusal })
+      continue
+    }
+    const locale = deps.locale ?? "en"
+    entries.push({
+      manifest: verdict.manifest,
+      bytes: installed.bytes,
+      granted: verdict.granted,
+      name: localizedName(verdict.manifest, locale),
+      description: localizedDescription(verdict.manifest, locale),
+    })
+  }
+
+  entries.sort((a, b) => a.name.localeCompare(b.name))
+  return { entries, problems }
+}

--- a/dynawalla/dynawalla-app/src/packs/libraryStore.ts
+++ b/dynawalla/dynawalla-app/src/packs/libraryStore.ts
@@ -1,0 +1,74 @@
+// The library, as app state.
+//
+// Everything that decides anything is in `library.ts` and is tested in Node.
+// This is the part that cannot be: the Tauri call, the build version, and the
+// store a screen subscribes to.
+//
+// It runs once at launch and can be re-run. In a plain browser — `npm run dev`
+// with no Tauri — there is no pack root and the library is empty, which is the
+// honest answer rather than a mocked one.
+
+import { create } from "zustand"
+
+import { BUILD_VERSION, isNative } from "../app/platform.ts"
+import { hostProfile, readLibrary, type LibraryEntry, type LibraryProblem } from "./library.ts"
+import { tauriNative } from "./native.ts"
+import { usePacks } from "./registry.ts"
+
+export interface LibraryState {
+  readonly ready: boolean
+  readonly entries: readonly LibraryEntry[]
+  /** Installed but not runnable here, with the reason a parent can act on. */
+  readonly problems: readonly LibraryProblem[]
+  refresh: () => Promise<void>
+}
+
+export const useLibrary = create<LibraryState>()((set) => ({
+  ready: false,
+  entries: [],
+  problems: [],
+  refresh: async () => {
+    if (!isNative) {
+      // A browser has no pack root. Saying so once, loudly, is what stops the
+      // next person wondering why the front door is empty in `npm run dev`.
+      console.warn("[packs] not running natively — no packs are installed in a browser tab")
+      set({ ready: true, entries: [], problems: [] })
+      return
+    }
+    try {
+      const { entries, problems } = await readLibrary({
+        native: tauriNative,
+        host: hostProfile(BUILD_VERSION),
+      })
+      set({ ready: true, entries, problems })
+      // Mirror into the persisted record, which is what the parent-facing
+      // counts read. Written from the manifest rather than from a second
+      // source, so the two cannot disagree about a version.
+      const record = usePacks.getState().record
+      for (const entry of entries) {
+        record({
+          id: entry.manifest.id,
+          name: entry.name,
+          version: entry.manifest.version,
+          bytes: entry.bytes,
+          sha256: entry.manifest.download.sha256,
+          installedAt: Date.now(),
+        })
+      }
+      const live = new Set(entries.map((entry) => entry.manifest.id))
+      for (const stored of usePacks.getState().installed) {
+        if (!live.has(stored.id)) usePacks.getState().forget(stored.id)
+      }
+      for (const problem of problems) {
+        console.error(`[packs] ${problem.id}: ${problem.refusal.message}`, problem.refusal.problems ?? "")
+      }
+    } catch (error) {
+      console.error("[packs] could not read the pack root", error)
+      set({ ready: true })
+    }
+  },
+}))
+
+export function entryOf(id: string): LibraryEntry | undefined {
+  return useLibrary.getState().entries.find((entry) => entry.manifest.id === id)
+}

--- a/dynawalla/dynawalla-app/src/packs/services.ts
+++ b/dynawalla/dynawalla-app/src/packs/services.ts
@@ -1,0 +1,216 @@
+// `HostServices`, implemented. The other end of every method a pack can call.
+//
+// `bridge.ts` validates, gates and rate-limits; this is what it dispatches to
+// once a message has earned the right to be dispatched. The split is the point:
+// the boundary knows nothing about mathematics, and this knows nothing about
+// message shapes.
+//
+// Everything is built per launch, from the stores, and holds no store: a
+// session is a session, and a pack that is mounted twice gets two ledgers, two
+// ladders and two sets of counters rather than one that remembers the last
+// child who played.
+
+import type { HapticCue, Item, Settings, SoundCue } from "../../../packs/sdk/src/index.ts"
+import type { HostServices } from "./bridge.ts"
+import { createItemService, type ItemService } from "./items.ts"
+import { report } from "./host.ts"
+import { packStorageFor } from "./storage.ts"
+import { resolveTheme, type ThemeMode } from "../app/theme.ts"
+import type { Quality, Settings as HostSettings, TextSize } from "../settings/store.ts"
+
+/** The type scale a pack multiplies its own base size by. */
+const TEXT_SCALE: Readonly<Record<TextSize, number>> = {
+  normal: 1,
+  large: 1.15,
+  largest: 1.3,
+}
+
+/**
+ * The renderer tier.
+ *
+ * Set from the device's declared setting, never guessed from a frame rate: a
+ * pack that measures its own fps and drops quality mid-run is a pack whose
+ * appearance changes while a child is looking at it.
+ */
+const QUALITY: Readonly<Record<Quality, Settings["quality"]>> = {
+  full: "high",
+  plain: "low",
+}
+
+export type SettingsInput = {
+  readonly settings: HostSettings
+  readonly theme: ThemeMode
+  readonly systemPrefersDark: boolean
+  /** BCP-47. One locale until the i18n runtime lands; a pack must not guess. */
+  readonly locale?: string
+}
+
+/** The device facts a pack is handed. No name, no birthday, no identifier. */
+export function packSettings(input: SettingsInput): Settings {
+  const { settings } = input
+  return {
+    locale: input.locale ?? "en",
+    reducedMotion: settings.reduceMotion,
+    quality: QUALITY[settings.quality],
+    textScale: TEXT_SCALE[settings.textSize],
+    colorScheme: resolveTheme(input.theme, input.systemPrefersDark),
+    sound: settings.sound,
+    haptics: settings.haptics,
+  }
+}
+
+/**
+ * The named haptics, as durations.
+ *
+ * Named rather than parameterised so a pack cannot invent a waveform: four
+ * cues, four patterns, and a device with no vibration motor simply does
+ * nothing. `navigator.vibrate` is a no-op on iOS Safari and on desktop, which
+ * is correct — a missing motor is not an error a child should hear about.
+ */
+const HAPTIC_PATTERN: Readonly<Record<HapticCue, number | readonly number[]>> = {
+  tick: 8,
+  seat: 18,
+  settle: [12, 40, 12],
+  refuse: [40, 30, 60],
+}
+
+/** Frequency and length for each named cue. The host owns the palette. */
+const SOUND_CUE: Readonly<Record<SoundCue, { hz: number; ms: number }>> = {
+  tick: { hz: 880, ms: 40 },
+  seat: { hz: 520, ms: 70 },
+  settle: { hz: 660, ms: 140 },
+  refuse: { hz: 180, ms: 160 },
+  arrive: { hz: 990, ms: 200 },
+}
+
+type Audio = { context: AudioContext | null }
+
+/**
+ * One short tone.
+ *
+ * The context is made on the first cue, not at launch: a WebView will not start
+ * one before a gesture, and a suspended context created at mount is a context
+ * that never plays anything. Every failure is swallowed *loudly* — a device
+ * that refuses audio must not take a game down with it.
+ */
+function playCue(audio: Audio, cue: SoundCue): void {
+  try {
+    const Ctor: typeof AudioContext | undefined =
+      typeof AudioContext === "function" ? AudioContext : undefined
+    if (!Ctor) return
+    audio.context ??= new Ctor()
+    const context = audio.context
+    if (context.state === "suspended") void context.resume()
+    const { hz, ms } = SOUND_CUE[cue]
+    const now = context.currentTime
+    const osc = context.createOscillator()
+    const gain = context.createGain()
+    osc.type = "triangle"
+    osc.frequency.value = hz
+    gain.gain.setValueAtTime(0.0001, now)
+    gain.gain.exponentialRampToValueAtTime(0.12, now + 0.008)
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + ms / 1000)
+    osc.connect(gain).connect(context.destination)
+    osc.start(now)
+    osc.stop(now + ms / 1000 + 0.02)
+  } catch (error) {
+    console.error("[packs] a sound cue failed", error)
+  }
+}
+
+export type ServicesDeps = {
+  readonly profileId: string
+  /** The device facts at launch. `push` replaces them without a remount. */
+  readonly settings: Settings
+  readonly onProgress?: (fraction: number) => void
+  readonly onEnd?: (reason: "finished" | "quit") => void
+  readonly onMilestone?: (name: string) => void
+}
+
+export type LaunchServices = {
+  readonly services: HostServices
+  readonly items: ItemService
+  /**
+   * Replace the settings a running pack is told about.
+   *
+   * The mutation lives here rather than in the component because a session is
+   * a ledger and a ladder: rebuilding the services to change a text size would
+   * restart a child's run to change a colour.
+   */
+  push: (settings: Settings) => void
+}
+
+/**
+ * Everything a mounted pack can reach, for one launch.
+ *
+ * Async because the interface is: the bridge awaits every dispatch. Nothing
+ * here actually waits for anything, which is deliberate — a question a child is
+ * waiting for must not be behind a promise chain that can stall.
+ */
+export function createServices(deps: ServicesDeps): LaunchServices {
+  const items = createItemService({ profileId: deps.profileId, record: report })
+  const store = packStorageFor(deps.profileId)
+  const audio: Audio = { context: null }
+  let current = deps.settings
+
+  const keysOf = (packId: string): string[] =>
+    Object.keys(store.getState().packs[packId] ?? {}).sort()
+
+  const services: HostServices = {
+    nextItem: (input) =>
+      Promise.resolve(
+        items.next(input.skillId === undefined ? { packId: input.packId } : input) as Item | null,
+      ),
+    judge: (input) => Promise.resolve(items.judge(input)),
+    skip: (input) => {
+      items.skip(input.itemId)
+      return Promise.resolve()
+    },
+    reveal: (input) => Promise.resolve(items.reveal(input.itemId)),
+    learnerSummary: () => Promise.resolve(items.summary()),
+
+    haptic: (input) => {
+      if (current.haptics && typeof navigator !== "undefined" && navigator.vibrate) {
+        try {
+          navigator.vibrate(HAPTIC_PATTERN[input.cue] as number | number[])
+        } catch (error) {
+          console.error("[packs] a haptic cue failed", error)
+        }
+      }
+      return Promise.resolve()
+    },
+    sound: (input) => {
+      if (current.sound) playCue(audio, input.cue)
+      return Promise.resolve()
+    },
+    milestone: (input) => {
+      deps.onMilestone?.(input.name)
+      return Promise.resolve()
+    },
+
+    storage: {
+      get: (input) => Promise.resolve(store.getState().packs[input.packId]?.[input.key] ?? null),
+      set: (input) => {
+        store.getState().set(input.packId, input.key, input.value)
+        return Promise.resolve()
+      },
+      remove: (input) => {
+        store.getState().remove(input.packId, input.key)
+        return Promise.resolve()
+      },
+      keys: (input) => Promise.resolve(keysOf(input.packId)),
+    },
+
+    progress: (input) => deps.onProgress?.(input.fraction),
+    end: (input) => deps.onEnd?.(input.reason),
+    settings: () => current,
+  }
+
+  return {
+    services,
+    items,
+    push: (settings) => {
+      current = settings
+    },
+  }
+}

--- a/dynawalla/dynawalla-app/src/packs/storage.ts
+++ b/dynawalla/dynawalla-app/src/packs/storage.ts
@@ -1,0 +1,89 @@
+// The keys a pack keeps, kept for it.
+//
+// A pack frame is sandboxed without `allow-same-origin`, so it has no
+// `localStorage`, no IndexedDB and no cookies — which is the point, and which
+// is why the `storage` capability exists. This is the other end of it: a small
+// map, per learner, per pack, written through the same durable adapter as every
+// other store in the app so a parent's "erase everything" reaches it.
+//
+// Per learner rather than per device: a level a child reached is theirs, and
+// two siblings sharing a tablet must not share a save.
+//
+// The budget (`MAX_STORAGE_KEYS`, `MAX_STORAGE_VALUE_LENGTH`) is enforced in
+// `bridge.ts`, not here. This module is storage; the boundary is the boundary.
+
+import { create, type StoreApi, type UseBoundStore } from "zustand"
+import { persist } from "zustand/middleware"
+
+import { durable } from "../app/persist.ts"
+import { storageKey } from "../app/profile.ts"
+
+export type PackKeys = Readonly<Record<string, string>>
+
+export interface PackStorageState {
+  /** `packId` → its own keys. Absent until the pack writes something. */
+  readonly packs: Readonly<Record<string, PackKeys>>
+  set: (packId: string, key: string, value: string) => void
+  remove: (packId: string, key: string) => void
+}
+
+export type PackStorageStore = UseBoundStore<StoreApi<PackStorageState>>
+
+const stores = new Map<string, PackStorageStore>()
+
+function createPackStorage(profileId: string): PackStorageStore {
+  return create<PackStorageState>()(
+    persist(
+      (set) => ({
+        packs: {},
+        set: (packId, key, value) =>
+          set((state) => ({
+            packs: { ...state.packs, [packId]: { ...(state.packs[packId] ?? {}), [key]: value } },
+          })),
+        remove: (packId, key) =>
+          set((state) => {
+            const existing = state.packs[packId]
+            if (!existing || !(key in existing)) return state
+            const next: Record<string, string> = { ...existing }
+            delete next[key]
+            return { packs: { ...state.packs, [packId]: next } }
+          }),
+      }),
+      {
+        name: storageKey(profileId, "packdata"),
+        version: 1,
+        storage: durable,
+        partialize: ({ packs }) => ({ packs }),
+        merge: (persisted, current) => {
+          // Written by an older build, or half-written: every value has to be a
+          // string, because that is what the pack will be handed back.
+          const stored = (persisted as Partial<PackStorageState> | undefined)?.packs
+          const packs: Record<string, PackKeys> = {}
+          for (const [packId, keys] of Object.entries(stored ?? {})) {
+            if (typeof keys !== "object" || keys === null) continue
+            const clean: Record<string, string> = {}
+            for (const [key, value] of Object.entries(keys)) {
+              if (typeof value === "string") clean[key] = value
+            }
+            packs[packId] = clean
+          }
+          return { ...current, packs }
+        },
+      },
+    ),
+  )
+}
+
+/** One store per learner, made on first use and cached for the session. */
+export function packStorageFor(profileId: string): PackStorageStore {
+  const existing = stores.get(profileId)
+  if (existing) return existing
+  const made = createPackStorage(profileId)
+  stores.set(profileId, made)
+  return made
+}
+
+/** Drop the cache after storage was erased underneath it. */
+export function forgetPackStorage(): void {
+  stores.clear()
+}

--- a/dynawalla/dynawalla-app/src/shell/Surface.tsx
+++ b/dynawalla/dynawalla-app/src/shell/Surface.tsx
@@ -8,6 +8,15 @@ import { surfaceOf, type Row } from "./surfaces.ts"
 import { useHostActions, useHostView } from "./useHost.ts"
 
 /**
+ * A row's fields without its key.
+ *
+ * The key belongs to the `<li>` that lists the row, not to the component that
+ * draws it: spreading a row wholesale puts `key` on the child, where React logs
+ * an error on every render and the key does nothing at all.
+ */
+type Keyless<K extends Row["kind"]> = Omit<Extract<Row, { kind: K }>, "key">
+
+/**
  * One renderer for every destination.
  *
  * The screens of this host are all the same object — a course of inscribed
@@ -42,7 +51,7 @@ function Choice({
   value,
   options,
   choose,
-}: Extract<Row, { kind: "choice" }>) {
+}: Keyless<"choice">) {
   return (
     <fieldset className="min-h-16 py-3">
       <legend className="inscription mb-2 text-lg tracking-wide">{name}</legend>
@@ -71,7 +80,7 @@ function Choice({
   )
 }
 
-function Action({ name, tone, run }: Extract<Row, { kind: "action" }>) {
+function Action({ name, tone, run }: Keyless<"action">) {
   return (
     <button
       type="button"
@@ -97,7 +106,7 @@ function Action({ name, tone, run }: Extract<Row, { kind: "action" }>) {
  * single most consequential piece of state in this app, and none of the three
  * is a colour.
  */
-function Learner({ name, given, current, use, rename, remove }: Extract<Row, { kind: "learner" }>) {
+function Learner({ name, given, current, use, rename, remove }: Keyless<"learner">) {
   return (
     <div
       className="flex min-h-16 items-center gap-3 py-3"
@@ -142,7 +151,7 @@ function Learner({ name, given, current, use, rename, remove }: Extract<Row, { k
  * which is what keeps `src/world/` a drawing of a number and not a part of the
  * app's copy.
  */
-function Figure({ value, label }: Extract<Row, { kind: "figure" }>) {
+function Figure({ value, label }: Keyless<"figure">) {
   return (
     <div className="py-3">
       <WorldScreen placed={value} label={label} className="mx-auto block h-auto w-full max-w-sm" />
@@ -150,18 +159,76 @@ function Figure({ value, label }: Extract<Row, { kind: "figure" }>) {
   )
 }
 
+/**
+ * A pack, as the whole row is the button.
+ *
+ * The only plate in this shell that is taller than a course: it is the front
+ * door and the thing the app is for, and a game should not be a line of small
+ * type between two settings. The name is the label, the version and the size
+ * are the small print, and the whole rectangle is the target — a child aiming
+ * at a word is a child missing.
+ */
+function Pack({ name, version, size, play }: Keyless<"pack">) {
+  return (
+    <button
+      type="button"
+      onClick={play}
+      className={[
+        "group flex min-h-24 w-full items-center gap-4 py-4 text-left",
+        "transition-colors duration-[var(--dw-motion-quick)] hover:bg-ground-sunk",
+      ].join(" ")}
+    >
+      <IndexMark className="text-index shrink-0 opacity-40 transition-opacity duration-[var(--dw-motion-quick)] group-hover:opacity-100 group-focus-visible:opacity-100" />
+      <span className="min-w-0 flex-1">
+        <span className="inscription text-ink block truncate text-2xl tracking-wide">{name}</span>
+        <span className="numeral text-ink-muted block text-xs">
+          {version} · {size}
+        </span>
+      </span>
+      <span className="border-line-cut rounded-cut-sm text-ink-muted shrink-0 border px-3 py-2 text-sm">
+        {strings.packs.play}
+      </span>
+    </button>
+  )
+}
+
+/**
+ * One row, drawn.
+ *
+ * Written out rather than spread: a `Row` carries its own `key`, and
+ * `<Fact {...row} />` puts that key on the child element, where React logs an
+ * error on every render and the key does nothing. The `<li>` above owns the
+ * key; the component gets the fields it draws.
+ */
 function RowView({ row }: { row: Row }) {
   switch (row.kind) {
     case "fact":
-      return <Fact {...row} />
-    case "choice":
-      return <Choice {...row} />
-    case "action":
-      return <Action {...row} />
-    case "learner":
-      return <Learner {...row} />
-    case "figure":
-      return <Figure {...row} />
+      return <Fact name={row.name} value={row.value} />
+    case "choice": {
+      const { key, ...rest } = row
+      void key
+      return <Choice {...rest} />
+    }
+    case "action": {
+      const { key, ...rest } = row
+      void key
+      return <Action {...rest} />
+    }
+    case "learner": {
+      const { key, ...rest } = row
+      void key
+      return <Learner {...rest} />
+    }
+    case "pack": {
+      const { key, ...rest } = row
+      void key
+      return <Pack {...rest} />
+    }
+    case "figure": {
+      const { key, ...rest } = row
+      void key
+      return <Figure {...rest} />
+    }
   }
 }
 

--- a/dynawalla/dynawalla-app/src/shell/surfaces.test.ts
+++ b/dynawalla/dynawalla-app/src/shell/surfaces.test.ts
@@ -62,6 +62,7 @@ function recorder() {
     removeProfile: () => calls.push("removeProfile"),
     armErase: () => calls.push("armErase"),
     erase: () => calls.push("erase"),
+    launchPack: () => calls.push("launchPack"),
   }
   return { calls, actions }
 }
@@ -99,6 +100,12 @@ function assertCarries(row: Row, where: string): void {
       // The stored name may be empty — that is the state of a new learner —
       // but what is *drawn* never is.
       assert.ok(row.name.trim().length > 0, `${where}: a learner with nothing to call them`)
+      break
+    case "pack":
+      assert.ok(row.name.trim().length > 0, `${where}: a pack with no name`)
+      assert.ok(row.version.trim().length > 0, `${where}: ${row.name} has no version`)
+      assert.ok(row.size.trim().length > 0, `${where}: ${row.name} has no size`)
+      assert.equal(typeof row.play, "function", `${where}: ${row.name} cannot be played`)
       break
     case "figure":
       assert.ok(
@@ -233,8 +240,20 @@ test("the packs surface shows every installed pack, and says so when there are n
       },
     ],
   })
-  assert.ok(one.some((row) => row.kind === "fact" && row.name === "Example"))
-  assert.ok(one.some((row) => row.kind === "fact" && row.value === "2.1.0"))
+  // An installed pack is not a line of small print about a pack: it is the way
+  // into the pack, and pressing it is what the whole app is for.
+  const pack = one.find((row) => row.kind === "pack")
+  assert.ok(pack, "an installed pack must be launchable from the front door")
+  assert.equal(pack.kind === "pack" ? pack.name : "", "Example")
+  assert.equal(pack.kind === "pack" ? pack.version : "", "2.1.0")
+
+  const { calls, actions } = recorder()
+  const rows = surfaceOf("packs", { ...coldHost, packs: [
+    { id: "inc.corpora.pack.example", name: "Example", version: "2.1.0", bytes: 1024, sha256: "", installedAt: 0 },
+  ] }, actions).flatMap((section) => [...section.rows])
+  const launch = rows.find((row) => row.kind === "pack")
+  if (launch?.kind === "pack") launch.play()
+  assert.deepEqual(calls, ["launchPack"], "the pack row does not launch the pack")
 })
 
 test("the last learner cannot be removed", () => {

--- a/dynawalla/dynawalla-app/src/shell/surfaces.ts
+++ b/dynawalla/dynawalla-app/src/shell/surfaces.ts
@@ -77,6 +77,18 @@ export type Row =
       /** `null` for the last learner: there is no state of this app with none. */
       readonly remove: (() => void) | null
     }
+  /** An installed pack, and the way into it. The front door's whole content. */
+  | {
+      readonly kind: "pack"
+      readonly key: string
+      readonly id: string
+      readonly name: string
+      readonly version: string
+      /** What it occupies, already formatted. Never a bare byte count. */
+      readonly size: string
+      /** Launches it onto the stage. Never null: an unplayable pack is not a row. */
+      readonly play: () => void
+    }
   /** Something drawn. `label` is its text alternative and is never empty. */
   | {
       readonly kind: "figure"
@@ -118,6 +130,8 @@ export interface HostActions {
   readonly removeProfile: (id: string) => void
   readonly armErase: () => void
   readonly erase: () => void
+  /** Put a pack on the stage. The one action the front door exists for. */
+  readonly launchPack: (packId: string) => void
 }
 
 // The option sets, written once. `satisfies` is what keeps a label and a value
@@ -175,18 +189,35 @@ export function learnerName(profile: Profile, index: number): string {
   return trimmed.length > 0 ? trimmed : fill(strings.profiles.learner, { n: index + 1 })
 }
 
-function packsSurface(view: HostView): readonly Section[] {
+/**
+ * The front door.
+ *
+ * Packs first, and packs as *plates you press* — the app is its packs, and the
+ * first thing on the first screen has to be the way into one. The device counts
+ * are underneath, where a parent looks for them and a child does not.
+ */
+function packsSurface(view: HostView, act: HostActions): readonly Section[] {
   return [
+    {
+      key: "installed",
+      rows: view.packs.map(
+        (pack): Row => ({
+          kind: "pack",
+          key: pack.id,
+          id: pack.id,
+          name: pack.name,
+          version: pack.version,
+          size: formatBytes(pack.bytes),
+          play: () => act.launchPack(pack.id),
+        }),
+      ),
+    },
     {
       key: "device",
       rows: [
         fact("count", strings.packs.installed, String(view.packs.length)),
         fact("bytes", strings.packs.space, formatBytes(packBytes(view.packs))),
       ],
-    },
-    {
-      key: "installed",
-      rows: view.packs.map((pack) => fact(pack.id, pack.name, pack.version)),
     },
   ]
 }
@@ -393,7 +424,7 @@ function sectionsOf(
 ): readonly Section[] {
   switch (destination) {
     case "packs":
-      return packsSurface(view)
+      return packsSurface(view, act)
     case "progress":
       return progressSurface(view)
     case "profiles":

--- a/dynawalla/dynawalla-app/src/shell/useHost.ts
+++ b/dynawalla/dynawalla-app/src/shell/useHost.ts
@@ -14,6 +14,7 @@ import { recordFor, worldFor } from "../app/stores.ts"
 import { eraseEverything } from "../app/erase.ts"
 import { useThemeStore } from "../app/theme.ts"
 import { usePacks } from "../packs/registry.ts"
+import { useLaunch } from "../packs/Stage.tsx"
 import { useProfiles } from "../profiles/store.ts"
 import { useSettings } from "../settings/store.ts"
 import type { HostActions, HostView } from "./surfaces.ts"
@@ -85,6 +86,7 @@ export function useHostActions(arm: (armed: boolean) => void): HostActions {
   const select = useProfiles((state) => state.select)
   const rename = useProfiles((state) => state.rename)
   const remove = useProfiles((state) => state.remove)
+  const play = useLaunch((state) => state.play)
 
   return {
     setTheme,
@@ -101,5 +103,6 @@ export function useHostActions(arm: (armed: boolean) => void): HostActions {
       eraseEverything()
       arm(false)
     },
+    launchPack: play,
   }
 }

--- a/dynawalla/games/merge/.gitignore
+++ b/dynawalla/games/merge/.gitignore
@@ -6,3 +6,6 @@ dist/
 # would push that much real source out of review for zero reviewer value.
 # Whoever adds the CI job should commit it in the same PR.
 package-lock.json
+
+# The pack build. `packs/build.mjs` regenerates it and stages it into the app.
+dist-pack/

--- a/dynawalla/games/merge/pack.html
+++ b/dynawalla/games/merge/pack.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no, maximum-scale=1"
+    />
+    <meta name="theme-color" content="#04050d" />
+    <title>FUSE</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        background: #04050d;
+        overflow: hidden;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #root {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` has no 'unsafe-inline'
+         and the document is framed on an opaque origin, so every URL here is
+         relative and resolves against the pack scheme. -->
+    <div id="root"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/merge/pack.json
+++ b/dynawalla/games/merge/pack.json
@@ -1,0 +1,21 @@
+{
+  "id": "dynawalla.fuse",
+  "version": "0.1.0",
+  "name": "FUSE",
+  "description": "Drop chips into the reactor well. Chips that touch and add to the key number fuse into one.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.add.regroup.subtract-multidigit",
+      "dw.add.regroup.subtract-across-zero",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-tenths"
+    ],
+    "grades": [1, 4]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/merge/package.json
+++ b/dynawalla/games/merge/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
-  "description": "FUSE — a fusion-reactor merge game. Touching tiles that add to the KEY fuse.",
+  "description": "FUSE \u2014 a fusion-reactor merge game. Touching tiles that add to the KEY fuse.",
   "engines": {
     "node": ">=22.12"
   },
@@ -13,7 +13,8 @@
     "build": "vite build",
     "preview": "vite preview --port 4173",
     "tsc": "tsc --noEmit",
-    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'"
+    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'",
+    "build:pack": "vite build --config vite.pack.config.ts"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/dynawalla/games/merge/src/pack.ts
+++ b/dynawalla/games/merge/src/pack.ts
@@ -1,0 +1,38 @@
+// FUSE, as a Dynawalla pack.
+//
+// The whole seam is this file. `mount.ts`, the game, the renderer and the
+// particle budget are untouched: the real host is handed to the same `mount`
+// the stub host was, because the adapter presents the same synchronous surface.
+//
+// Everything mathematical now comes from the host — the questions, the
+// canonical answer on a chip's face, the mal-rule distractors, the judgement,
+// and the record it lands in. The game does no arithmetic that decides
+// anything, which is exactly the property the pack contract exists to give.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts";
+import type { FocusableHost } from "./contract.ts";
+import { mount } from "./mount.ts";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("#root missing");
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "add-sub" });
+  // Stocked before the first frame: a chip that spawns into an empty pool is a
+  // chip with a blank face, and it would happen exactly once, on launch, in
+  // front of the child.
+  await mounted.warm();
+
+  const instance = mount(el, mounted.host as unknown as FocusableHost);
+
+  // The host tells a pack before its port dies, so the loop stops before the
+  // frame is torn down rather than a frame or two after it.
+  mounted.client.on("dispose", () => {
+    instance.unmount();
+  });
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[fuse] could not start", error);
+  renderNoHost(root, "FUSE");
+});

--- a/dynawalla/games/merge/vite.pack.config.ts
+++ b/dynawalla/games/merge/vite.pack.config.ts
@@ -1,0 +1,31 @@
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vite";
+
+/**
+ * The pack build.
+ *
+ * Separate from `vite.config.ts` because the two artefacts are different
+ * things: that one is the standalone workbench with the stub host in it, this
+ * one is what gets installed on a child's tablet. Only `pack.html` is an entry,
+ * so `main.ts` and the stub host are not in the bundle at all.
+ *
+ * `base: "./"` is not cosmetic — the pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute `/assets/…` would resolve
+ * to the scheme root and 404 for every pack but the first.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produced a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+});

--- a/dynawalla/games/siege/.gitignore
+++ b/dynawalla/games/siege/.gitignore
@@ -2,3 +2,6 @@ node_modules
 dist
 qa/shots
 qa/tmp
+
+# The pack build. `packs/build.mjs` regenerates it and stages it into the app.
+dist-pack/

--- a/dynawalla/games/siege/pack.html
+++ b/dynawalla/games/siege/pack.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no"
+    />
+    <meta name="theme-color" content="#0a0608" />
+    <title>SIEGE</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        background: #0a0608;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- No inline script and no remote URL: the pack CSP admits the pack scheme
+         and nothing else, and the frame's origin is opaque so `'self'` would
+         match nothing at all. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/siege/pack.json
+++ b/dynawalla/games/siege/pack.json
@@ -1,0 +1,21 @@
+{
+  "id": "dynawalla.siege",
+  "version": "0.1.0",
+  "name": "SIEGE",
+  "description": "A molten-forge tower defence. The anvil mints embers for every problem you strike, and embers are the only thing that holds the line.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.add.regroup.subtract-multidigit",
+      "dw.add.regroup.subtract-across-zero",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-tenths"
+    ],
+    "grades": [1, 4]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/siege/package.json
+++ b/dynawalla/games/siege/package.json
@@ -10,7 +10,8 @@
     "build": "vite build",
     "preview": "vite preview --port 4187",
     "tsc": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
-    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test 'src/**/*.test.ts'"
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test 'src/**/*.test.ts'",
+    "build:pack": "vite build --config vite.pack.config.ts"
   },
   "devDependencies": {
     "typescript": "~6.0.3",

--- a/dynawalla/games/siege/src/pack.ts
+++ b/dynawalla/games/siege/src/pack.ts
@@ -1,0 +1,34 @@
+// SIEGE, as a Dynawalla pack.
+//
+// The seam and nothing else. `Siege` is constructed with the same `Host` shape
+// the stub host presented, so the forge, the waves, the anvil and the
+// overcharge are untouched — what changed is where a problem comes from and
+// who says whether the child was right.
+//
+// The three slabs a child strikes are the canonical answer and the mal-rule
+// distractors the curriculum produced for *that* item. A wrong slab is a wrong
+// answer a child actually gives, not noise, which is the whole reason the
+// distractors cross the boundary at all.
+
+import "./ui/styles.css";
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts";
+import type { Host } from "./contract.ts";
+import { Siege } from "./mount.ts";
+
+const root = document.getElementById("app");
+if (!root) throw new Error("#app missing");
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "add-sub" });
+  await mounted.warm();
+
+  const game = new Siege(el, mounted.host as unknown as Host);
+  mounted.client.on("dispose", () => {
+    game.destroy();
+  });
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[siege] could not start", error);
+  renderNoHost(root, "SIEGE");
+});

--- a/dynawalla/games/siege/vite.pack.config.ts
+++ b/dynawalla/games/siege/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vite";
+
+/**
+ * The pack build: only `pack.html`, so the standalone entry and the stub host
+ * stay out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 100000,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produced a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+});

--- a/dynawalla/packs/README.md
+++ b/dynawalla/packs/README.md
@@ -1,0 +1,122 @@
+# Packs — the SDK, the shared code, and the pipeline
+
+Packs are the product. This directory is everything both sides of that agree
+on, plus the one command that turns a game into something installed on a
+tablet.
+
+```
+packs/
+  sdk/                  the host↔pack contract, imported by both sides
+  shared/curriculum/    exact-rational, seeded mathematics — the HOST imports this
+  shared/game-host/     the guest-side adapter arcade packs mount against
+  build.mjs             build + validate + stage every pack
+```
+
+---
+
+## The one command
+
+```
+cd dynawalla-app && npm run packs
+```
+
+It discovers every pack, builds it, generates its manifest, runs the gate, and
+stages it. **`npm run tauri dev` runs it first**, so the founder's loop is:
+
+```
+cd dynawalla/dynawalla-app && npm run tauri dev
+```
+
+and every game is installed and playable when the window opens. No network, no
+catalogue, no install step, no download.
+
+What "discovers" means: a pack is **any directory under `games/` with a
+`pack.json`**. There is no register to add to. That is the property that has to
+hold at a thousand packs, so it holds at two.
+
+### What a pack author writes
+
+`games/<name>/pack.json` — only the things a builder cannot know:
+
+```json
+{
+  "id": "dynawalla.fuse",
+  "version": "0.1.0",
+  "name": "FUSE",
+  "description": "…",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": { "skills": ["dw.add.regroup.subtract-multidigit"], "grades": [1, 4] },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}
+```
+
+`assets.files`, `assets.bytes` and the integrity digest are **generated**. They
+are facts about built output, and a hand-maintained copy of a fact goes stale.
+
+### Where the output goes
+
+| path | what it is |
+| --- | --- |
+| `dynawalla-app/src-tauri/packs/<id>/` | what the app installs. Bundled as a Tauri resource; the Rust side syncs it into the pack root at launch. Git-ignored build output. |
+| `dist-packs/<id>/` + `dist-packs/catalog.json` | the publishable form. |
+
+A debug build re-copies every bundled pack on every launch, so editing a pack
+and restarting is the whole dev loop. A release build only copies when the
+version changed.
+
+### What is not here yet: publishing
+
+`dist-packs/` is not uploaded anywhere. `PACK_ORIGIN` in
+`src-tauri/src/packs/mod.rs` is pinned at
+`https://encorpora.io/dynawalla/packs/` and has nothing on it, so the generated
+catalogue carries no `download.url` — which is exactly what the manifest schema
+means by "a pack that ships with the app". Turning `dist-packs/` into archives,
+uploading them and publishing a catalogue is a release step, and it is the next
+one.
+
+---
+
+## Writing an arcade pack
+
+A game that wants questions mounts `shared/game-host`:
+
+```ts
+import { createGameHost } from "../../../packs/shared/game-host/index.ts"
+
+const mounted = await createGameHost({ domain: "add-sub" })
+await mounted.warm()          // stocked before the first frame
+const game = mount(root, mounted.host)
+mounted.client.on("dispose", () => game.unmount())
+```
+
+`mounted.host` is **synchronous** — `next()` returns a question inside a
+`requestAnimationFrame` loop, from a pool the adapter keeps stocked over the
+`MessagePort`. That is the whole reason the adapter exists: the SDK is
+asynchronous and a game loop is not.
+
+Three things it does that a game should not do itself:
+
+- **Reports once per item.** A double-reported chip would inflate a child's
+  record, and the record only ever rises.
+- **Never compares a response to an answer.** `items.answer` is the judge.
+  `answer` on a `Question` is the host's `items.reveal`, which is a declared,
+  parent-visible capability for placing a target — not a way to score.
+- **Reports session progress**, so the host can draw the hairline.
+
+### The gap worth knowing about
+
+FUSE asks for a chip worth *exactly* a given value so it can print an
+expression on its face (`focus({ key, wanted })`). The host cannot generate to a
+target answer — the curriculum ships one generator family
+(`gen.arith.column-op`, 2–4 digit column add/sub), and `items.next` takes a
+skill, not a value. The adapter therefore satisfies `focus` opportunistically,
+out of the pool, and FUSE draws a numeral when nothing matches. The game is
+fully playable either way; expression faces are more common at higher KEYs,
+where the wanted range overlaps what the curriculum produces.
+
+Closing it properly means more generator families — small-number
+add/sub/multiply — not a change to the boundary.

--- a/dynawalla/packs/build.mjs
+++ b/dynawalla/packs/build.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+// One command that builds and validates every pack in this repository.
+//
+//     node packs/build.mjs            build them all
+//     node packs/build.mjs fuse       build the ones whose id or directory matches
+//
+// This is the pipeline. It is written for a thousand packs rather than for two,
+// which means exactly three things:
+//
+//   1. **Discovery is a glob, not a list.** A pack is any directory under
+//      `games/` with a `pack.json` in it. Adding the thousandth pack is adding a
+//      directory; there is no register to forget to edit.
+//   2. **The manifest is generated, never hand-written.** `assets.files`,
+//      `assets.bytes` and the integrity digest are facts about the built output,
+//      and a hand-maintained copy of a fact is a copy that goes stale. What a
+//      pack author writes is `pack.json` — the things the builder cannot know.
+//   3. **`dw-pack check` is the gate, and it runs on every pack, every time.**
+//      A pack that does not pass is a failed build, not a warning.
+//
+// The output goes to two places, on purpose:
+//
+//   * `dynawalla-app/src-tauri/packs/<id>/` — where the app finds them. Tauri
+//     bundles that directory as a resource, and the Rust side syncs it into the
+//     pack root at launch, so `npm run tauri dev` has every pack installed with
+//     no network round trip and no manual install step.
+//   * `dist-packs/` — the publishable form, plus `catalog.json`.
+//
+// **What is deliberately not here: publishing.** Turning `dist-packs/` into
+// signed archives at `https://encorpora.io/dynawalla/packs/` is a release step
+// against an origin that has nothing on it yet. The catalogue written here has
+// no `download.url` for that reason, which is exactly what the schema means by
+// "a pack that ships with the app".
+
+import { execFileSync } from "node:child_process"
+import crypto from "node:crypto"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const root = path.resolve(here, "..")
+const GAMES = path.join(root, "games")
+const STAGE = path.join(root, "dynawalla-app", "src-tauri", "packs")
+const DIST = path.join(root, "dist-packs")
+const CHECK = path.join(here, "sdk", "bin", "dw-pack.mjs")
+
+const filters = process.argv.slice(2)
+
+/** Every file under `dir`, relative and sorted. Sorted so a digest is stable. */
+function walk(dir, base = dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => (a.name < b.name ? -1 : 1))) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) walk(full, base, out)
+    else if (entry.isFile()) out.push(path.relative(base, full).split(path.sep).join("/"))
+  }
+  return out.sort()
+}
+
+function copyTree(from, to) {
+  fs.rmSync(to, { recursive: true, force: true })
+  fs.mkdirSync(to, { recursive: true })
+  fs.cpSync(from, to, { recursive: true })
+}
+
+/**
+ * The integrity digest of a built pack.
+ *
+ * Over the content, with `manifest.json` excluded — the manifest carries the
+ * digest, so including it would be a fixed point nothing can compute. Path and
+ * length go into the hash alongside the bytes, so a file renamed or truncated
+ * changes it as surely as a byte flipped.
+ */
+function digestOf(dir, files) {
+  const hash = crypto.createHash("sha256")
+  for (const file of files) {
+    if (file === "manifest.json") continue
+    const bytes = fs.readFileSync(path.join(dir, file))
+    hash.update(`${file}\0${bytes.length}\0`)
+    hash.update(bytes)
+  }
+  return hash.digest("hex")
+}
+
+function bytesOf(dir, files) {
+  return files.reduce((total, file) => total + fs.statSync(path.join(dir, file)).size, 0)
+}
+
+function run(command, args, cwd) {
+  execFileSync(command, args, { cwd, stdio: "inherit" })
+}
+
+function discover() {
+  if (!fs.existsSync(GAMES)) return []
+  const packs = []
+  for (const entry of fs.readdirSync(GAMES, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const dir = path.join(GAMES, entry.name)
+    const meta = path.join(dir, "pack.json")
+    if (!fs.existsSync(meta)) continue
+    const source = JSON.parse(fs.readFileSync(meta, "utf8"))
+    if (filters.length > 0 && !filters.some((f) => entry.name.includes(f) || source.id.includes(f))) {
+      continue
+    }
+    packs.push({ dir, name: entry.name, source })
+  }
+  return packs.sort((a, b) => (a.source.id < b.source.id ? -1 : 1))
+}
+
+function buildOne(pack) {
+  const { dir, name, source } = pack
+  console.log(`\n── ${source.id}@${source.version}  (games/${name})`)
+
+  if (!fs.existsSync(path.join(dir, "node_modules"))) {
+    console.log("   installing dependencies")
+    run("npm", [fs.existsSync(path.join(dir, "package-lock.json")) ? "ci" : "install"], dir)
+  }
+
+  run("npm", ["run", "build:pack"], dir)
+
+  const built = path.join(dir, source.build?.out ?? "dist-pack")
+  if (!fs.existsSync(path.join(built, source.entry))) {
+    throw new Error(`${source.id}: the build produced no ${source.entry} in ${built}`)
+  }
+
+  const staged = path.join(STAGE, source.id)
+  copyTree(built, staged)
+
+  // Two passes: the manifest is itself a file in the directory it measures, so
+  // its own size has to be inside the totals it declares. `assets.bytes` is
+  // rounded up to the next kilobyte, which the schema permits (it is a ceiling
+  // shown to a parent, and `dw-pack check` fails only when the directory is
+  // *bigger* than declared) and which keeps a one-byte edit from failing a
+  // build for a reason nobody would guess.
+  const content = walk(staged)
+  const contentBytes = bytesOf(staged, content)
+  const manifest = {
+    schema: 1,
+    id: source.id,
+    version: source.version,
+    name: source.name,
+    description: source.description,
+    ...(source.nameLocalized ? { nameLocalized: source.nameLocalized } : {}),
+    ...(source.descriptionLocalized ? { descriptionLocalized: source.descriptionLocalized } : {}),
+    sdk: source.sdk,
+    host: source.host,
+    entry: source.entry,
+    capabilities: source.capabilities,
+    covers: source.covers,
+    locales: source.locales,
+    assets: {
+      files: content.length + 1,
+      bytes: Math.ceil((contentBytes + 4096) / 1024) * 1024,
+    },
+    download: {
+      bytes: Math.max(1, contentBytes),
+      sha256: digestOf(staged, content),
+    },
+  }
+  fs.writeFileSync(path.join(staged, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`)
+
+  // The gate. Not advisory: a pack that does not pass does not ship, and the
+  // build stops here rather than staging something the host would refuse.
+  run(process.execPath, ["--experimental-strip-types", "--no-warnings=ExperimentalWarning", CHECK, "check", staged], root)
+
+  copyTree(staged, path.join(DIST, source.id))
+  return manifest
+}
+
+fs.rmSync(DIST, { recursive: true, force: true })
+fs.mkdirSync(DIST, { recursive: true })
+fs.mkdirSync(STAGE, { recursive: true })
+
+const packs = discover()
+if (packs.length === 0) {
+  console.error("no packs found — a pack is a directory under games/ with a pack.json")
+  process.exit(1)
+}
+
+const manifests = []
+for (const pack of packs) manifests.push(buildOne(pack))
+
+// Anything staged that is no longer a pack is removed, so a renamed id does not
+// leave the old one installed on every device that ever ran a dev build.
+const live = new Set(manifests.map((manifest) => manifest.id))
+for (const entry of fs.readdirSync(STAGE, { withFileTypes: true })) {
+  if (entry.isDirectory() && !live.has(entry.name) && filters.length === 0) {
+    fs.rmSync(path.join(STAGE, entry.name), { recursive: true, force: true })
+  }
+}
+
+fs.writeFileSync(
+  path.join(DIST, "catalog.json"),
+  `${JSON.stringify({ schema: 1, packs: manifests }, null, 2)}\n`,
+)
+
+console.log(`\n${String(manifests.length)} pack(s) built, checked and staged into src-tauri/packs/`)

--- a/dynawalla/packs/sdk/bin/dw-pack.mjs
+++ b/dynawalla/packs/sdk/bin/dw-pack.mjs
@@ -160,7 +160,19 @@ function serve(dir, port) {
   const server = http.createServer((request, response) => {
     const url = new URL(request.url ?? "/", "http://localhost")
     const send = (status, type, body, extra = {}) => {
-      response.writeHead(status, { "Content-Type": type, "X-Content-Type-Options": "nosniff", ...extra })
+      // The frame is sandboxed without `allow-same-origin`, so its origin is
+      // opaque and every subresource it loads — including its own module
+      // script, which Vite emits with `crossorigin` — is a cross-origin
+      // request. Without this the pack's code is fetched and then discarded by
+      // CORS, and the document renders its background and nothing else.
+      // `packs/mod.rs` sets the same two headers for the same reason.
+      response.writeHead(status, {
+        "Content-Type": type,
+        "X-Content-Type-Options": "nosniff",
+        "Access-Control-Allow-Origin": "*",
+        "Cross-Origin-Resource-Policy": "cross-origin",
+        ...extra,
+      })
       response.end(body)
     }
 

--- a/dynawalla/packs/shared/game-host/index.ts
+++ b/dynawalla/packs/shared/game-host/index.ts
@@ -1,0 +1,273 @@
+// The adapter every arcade pack mounts against: a synchronous `Host` on the
+// outside, the asynchronous pack SDK on the inside.
+//
+// **Why an adapter and not a rewrite.** FUSE and SIEGE both want a question the
+// instant a tile spawns or a slab lands — inside a `requestAnimationFrame`
+// loop, where there is no `await`. The SDK is a `MessagePort`, so every method
+// on it is a promise. Bridging that in each game would mean two copies of a
+// prefetch buffer written by two people at two times, and the game code would
+// grow a loading state in its hot path.
+//
+// So this keeps a stocked pool, filled ahead of demand and topped up in the
+// background, and hands it out synchronously. The games' own `Host` type is
+// untouched, which is the point: the swap from the stub host to the real one is
+// a change of two lines in an entry file and nothing in the game.
+//
+// **Why `items.reveal` is declared.** Both games have to *place the answer*
+// before the child reaches it — SIEGE puts it on one of three slabs, FUSE makes
+// a chip's face an expression worth exactly that chip's value. That is the
+// sanctioned use of the capability, and it changes nothing about who judges: an
+// attempt is still reported through `items.answer`, still recorded before the
+// canonical value comes back, and the host's verdict is the one that counts.
+// This module never compares a response to an answer.
+//
+// **Reporting is once per item.** An id that has already been reported, or that
+// this module did not serve, is dropped. A pack that double-reports a chip
+// would otherwise inflate a child's record, and the record only ever rises.
+
+import type { Capability, HostClient, Item } from "../../sdk/src/index.ts"
+import { connect } from "../../sdk/src/index.ts"
+
+/** The shape both games declare locally. Kept structurally identical. */
+export type Question = {
+  id: string
+  /** "15 − 8" */
+  prompt: string
+  /** "7" — exact, canonical, and never computed here. */
+  answer: string
+  distractors: string[]
+  domain: string
+  /** 0..1 */
+  difficulty: number
+}
+
+export type HapticKind = "light" | "medium" | "heavy" | "success" | "failure"
+
+export type GameHost = {
+  next(): Question
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+  haptic(kind: HapticKind): void
+  prefersReducedMotion(): boolean
+  /** Optional host extension FUSE feature-detects: bias the stream by value. */
+  focus(spec: { key: number; wanted: number[] }): void
+}
+
+/** Named cues. The game says what happened; the host owns the waveform. */
+const HAPTIC: Record<HapticKind, "tick" | "seat" | "settle" | "refuse"> = {
+  light: "tick",
+  medium: "seat",
+  heavy: "settle",
+  success: "settle",
+  failure: "refuse",
+}
+
+/**
+ * How many questions to keep ahead of the game.
+ *
+ * FUSE pumps ten at a time when a level turns over, so the pool has to absorb a
+ * burst without the loop ever seeing an empty one. Two round trips per question
+ * (`items.next` then `items.reveal`) at 120 requests per second is far more
+ * headroom than 64 items need.
+ */
+const POOL_TARGET = 64
+const POOL_FLOOR = 32
+
+/** A pack that has not seen a question in this long has been left running. */
+const IDLE_MS = 5 * 60 * 1000
+
+/** Answered questions that count as one sitting, for the progress hairline. */
+const SESSION_ITEMS = 40
+
+export type GameHostOptions = {
+  /** Domain label the game shows or logs. Cosmetic; the host owns the skill. */
+  readonly domain?: string
+  /** Called with 0..1 whenever the game's own progress is known. */
+  readonly onProgress?: (fraction: number) => void
+}
+
+export type MountedHost = {
+  readonly host: GameHost
+  readonly client: HostClient
+  /** Awaited once before the game mounts, so `next()` is never empty. */
+  warm(): Promise<void>
+  dispose(): void
+}
+
+function questionFrom(item: Item, canonical: string, domain: string): Question {
+  const distractors = (item.choices ?? [])
+    .map((choice) => choice.text)
+    .filter((text) => text !== canonical)
+  return {
+    id: item.id,
+    prompt: item.prompt,
+    answer: canonical,
+    distractors,
+    domain,
+    // A level index the host chose, squashed into the 0..1 the games read for
+    // pacing. Not a claim about difficulty; a monotone reading of the ladder.
+    difficulty: Math.max(0, Math.min(1, item.level / 8)),
+  }
+}
+
+/**
+ * Connect to the host and build a synchronous game host over it.
+ *
+ * Rejects when there is no host — a pack opened directly in a browser tab
+ * should say so on its own surface rather than showing a frozen loading state
+ * forever, and the games' entry files render that message.
+ */
+export async function createGameHost(options: GameHostOptions = {}): Promise<MountedHost> {
+  const client = await connect()
+  const domain = options.domain ?? "arith"
+  const granted = new Set<Capability>(client.granted)
+
+  const pool: Question[] = []
+  /** Ids this module served and has not yet reported. */
+  const live = new Set<string>()
+  let wanted: number[] = []
+  let filling = false
+  let disposed = false
+  let lastServed: Question | null = null
+  let lastAsk = Date.now()
+  let reported = 0
+
+  const canReveal = granted.has("items.reveal")
+
+  const fill = () => {
+    if (filling || disposed) return
+    filling = true
+    void (async () => {
+      try {
+        while (!disposed && pool.length < POOL_TARGET) {
+          if (Date.now() - lastAsk > IDLE_MS) break
+          const item = await client.nextItem()
+          if (item === null) break
+          const canonical = canReveal ? await client.reveal(item.id) : ""
+          if (canonical === "") {
+            // No reveal grant means no placeable answer. Both games need one,
+            // so this is loud rather than a silently duller game.
+            console.error("[pack] items.reveal was not granted; questions cannot be placed")
+            break
+          }
+          pool.push(questionFrom(item, canonical, domain))
+          live.add(item.id)
+        }
+      } catch (error) {
+        console.error("[pack] could not fill the question pool", error)
+      } finally {
+        filling = false
+      }
+    })()
+  }
+
+  const take = (): Question => {
+    lastAsk = Date.now()
+    // A value the game said it needs, if the pool happens to hold one: FUSE
+    // asks for a chip worth exactly 7 and can then print an expression on it.
+    // When nothing matches, the game gets the next question and draws a
+    // numeral instead — which is what `focus` being optional means.
+    if (wanted.length > 0) {
+      const index = pool.findIndex((question) => wanted.includes(Number(question.answer)))
+      if (index >= 0) {
+        const [picked] = pool.splice(index, 1)
+        if (picked) {
+          lastServed = picked
+          if (pool.length < POOL_FLOOR) fill()
+          return picked
+        }
+      }
+    }
+    const next = pool.shift()
+    if (pool.length < POOL_FLOOR) fill()
+    if (next) {
+      lastServed = next
+      return next
+    }
+    // The pool ran dry. The game gets something drawable with no id, so the
+    // report it produces is dropped rather than answering a served item twice.
+    console.warn("[pack] the question pool ran dry")
+    return lastServed
+      ? { ...lastServed, id: "" }
+      : { id: "", prompt: "", answer: "0", distractors: [], domain, difficulty: 0 }
+  }
+
+  const host: GameHost = {
+    next: take,
+
+    report: ({ questionId, correct, ms, answered }) => {
+      if (questionId === "" || !live.has(questionId)) return
+      live.delete(questionId)
+      // The host draws the progress and the pack does not, so what a pack owes
+      // it is a fraction. "How far into this sitting" is the only one a game
+      // with no ending can honestly report, and it is the one a parent glancing
+      // at a tablet wants: forty answered questions is a session.
+      reported += 1
+      void client.progress(Math.min(1, reported / SESSION_ITEMS)).catch(() => {})
+      options.onProgress?.(Math.min(1, reported / SESSION_ITEMS))
+      // The host judges. `correct` is what the game believes; it is not sent,
+      // and it is not what is recorded.
+      void client
+        .answer({ itemId: questionId, response: answered, latencyMs: Math.max(0, Math.round(ms)) })
+        .catch((error: unknown) => {
+          console.error("[pack] an answer could not be reported", error)
+        })
+      void correct
+    },
+
+    haptic: (kind) => {
+      if (!granted.has("haptics")) return
+      void client.haptic(HAPTIC[kind]).catch(() => {
+        // A device with no motor is not an error a child should hear about,
+        // and the host has already logged anything that is.
+      })
+    },
+
+    prefersReducedMotion: () => client.settings.reducedMotion,
+
+    focus: ({ wanted: values }) => {
+      wanted = values.slice(0, 32)
+      if (pool.length < POOL_TARGET) fill()
+    },
+  }
+
+  return {
+    host,
+    client,
+    warm: async () => {
+      // Awaited so the first frame the child sees is already stocked. Filling
+      // in the background and hoping is how a game shows a blank chip once.
+      for (let i = 0; i < POOL_FLOOR && !disposed; i++) {
+        const item = await client.nextItem()
+        if (item === null) break
+        const canonical = canReveal ? await client.reveal(item.id) : ""
+        if (canonical === "") break
+        pool.push(questionFrom(item, canonical, domain))
+        live.add(item.id)
+      }
+      fill()
+    },
+    dispose: () => {
+      disposed = true
+      client.dispose()
+    },
+  }
+}
+
+/**
+ * The message a pack draws when it is not inside a host.
+ *
+ * Every pack needs one and none of them should invent it: opening `index.html`
+ * from a file manager, or leaving a stale tab open after the host is gone, are
+ * both states a child can reach, and a frozen loading screen is the worst
+ * possible answer to either.
+ */
+export function renderNoHost(root: HTMLElement, name: string): void {
+  root.innerHTML = ""
+  const panel = document.createElement("div")
+  panel.setAttribute("role", "status")
+  panel.style.cssText =
+    "position:absolute;inset:0;display:flex;align-items:center;justify-content:center;" +
+    "padding:2rem;text-align:center;font:500 1rem/1.5 system-ui,sans-serif;color:#e8e2d6"
+  panel.textContent = `${name} runs inside Dynawalla.`
+  root.appendChild(panel)
+}


### PR DESCRIPTION
FUSE and SIEGE were on trunk with stub hosts: fully playable in a browser tab,
wired to nothing. `npm run tauri dev` opened a front door with no packs on it.

This is the end-to-end fix. A pack is now built, validated, installed, framed,
fed questions by the curriculum, and its answers land in the learner's record.

---

## Verified in the real Tauri window

`npm run tauri dev`, both games launched from the front door, played, and left.

| | |
|---|---|
| front door | FUSE and SIEGE listed, sized, launchable |
| FUSE in the frame | played to 280 points, chips fused |
| SIEGE in the frame | `43 + 38 =` with 80 / 71 / 82 / **81** — `71` is `mis.add.carry-dropped` |
| leaving | back to the front door, frame torn down |
| the record | **Answered 9, Correct 4** across the two games |
| frame rate | **60.0 fps** steady, worst frame 18–19 ms |

The record is the proof the loop is closed: those answers were generated by the
curriculum, drawn by two different games, judged by the host, and written to one
learner.

## The decision this rests on — ADR-0023

The pack protocol makes the host the judge, and says so in the wire rather than
in prose: `items.next` does not carry the answer, and `items.answer` records the
attempt *before* it returns the canonical value. That is what makes "a
mathematics game cannot be beaten by fiddling with the game" a property.

ADR-0022 put the curriculum in packs and `boundary.test.ts` enforced it. The two
cannot both hold: a host with no arithmetic cannot answer `items.next`, cannot
judge, and cannot produce a mal-rule distractor — it can only hand the whole item
contract back to the pack, which is the thing the contract exists to prevent, and
it arrives by omission rather than by decision. Both stub hosts had already grown
their own arithmetic and their own mal-rules. At a hundred packs that is a
hundred.

So the split is now:

* **packs** own every game, world, screen, asset and sound;
* **the host** owns the mathematics: which item, and whether it was right.

`boundary.test.ts` keeps its guard and gains one measured exemption beside the
SDK contract, with two properties asserted about it — the curriculum re-exports
nothing outside its own package, and it touches no DOM. `dynawalla/curriculum/`
and `dynawalla/engine/` stay out of bounds, `keypad` stays banned outright, and
exactly two host modules may name an exercise (asserted as a list, not described).

## What landed

**Host.** `packs/items.ts` — the ladder over the shipped skill graph, seeded per
(learner, pack, sequence), the ledger, the judgement, the mal-rule distractors.
`packs/services.ts` — `HostServices`: items, haptics, sound, per-learner
per-pack storage, progress, end. `packs/library.ts` / `libraryStore.ts` — reads
the pack root, re-gates every manifest at launch, hands out the intersection of
what a pack declared and what this build supports. `packs/Stage.tsx` — a
launched pack takes the window; one button and Escape leave it.

**Front door.** Packs are plates you press, not a line of small type.

**Pack side.** `packs/shared/game-host/` is the adapter both games mount
against: a pool stocked ahead of demand behind a synchronous `next()`, because a
`requestAnimationFrame` loop has no `await`. It reports once per item, never
compares a response to an answer, and reports session progress. Neither game's
internals changed — each gained `pack.html`, `src/pack.ts` and `pack.json`.

**One command.** `packs/build.mjs` discovers any directory under `games/` with a
`pack.json` — no register to forget — builds it, generates `assets.files`,
`assets.bytes` and the integrity digest from the built output, runs
`dw-pack check` as a gate, and stages it into `src-tauri/packs/` and
`dist-packs/`. `npm run tauri dev` runs it first, and Rust installs the staged
packs before the first window exists. No network, no catalogue, no install step.

## Two bugs the running app found

* **A bare relative `rollupOptions.input`** produced a `pack.html` with the
  source script stripped and nothing put back — a document that loads, paints
  its background colour, and runs no code at all. Fixed with an absolute entry;
  this is the entire reason the first three `tauri dev` runs were black.
* **`dw-pack serve` sent no `Access-Control-Allow-Origin`.** A pack is framed on
  an opaque origin, so its own module script — which Vite emits with
  `crossorigin` — is a cross-origin request. `packs/mod.rs` sets the header; the
  workbench did not, so the code was fetched and discarded.

## What remains, plainly

* **The bazaar is not the surface yet.** `dynawalla/bazaar/` still runs on stub
  stalls. Binding its stalls to the installed library is the next PR; the packs
  surface is functional in the meantime.
* **Publishing.** `dist-packs/` is not uploaded anywhere and the generated
  catalogue carries no `download.url` — which is what the schema means by "a
  pack that ships with the app". Archives, upload and a live catalogue at the
  pinned origin are a release step against an origin that has nothing on it.
* **FUSE's expression faces are sparse.** FUSE asks for a chip worth *exactly* a
  given value; the host cannot generate to a target answer, because the
  curriculum ships one generator family (2–4 digit column add/sub) and
  `items.next` takes a skill, not a value. The adapter satisfies `focus`
  opportunistically out of the pool and FUSE draws a numeral when nothing
  matches — fully playable either way. Closing it means more generator families,
  not a change to the boundary.
* **`dw-pack serve` still does not render FUSE** even with the CORS fix, while
  the shipped runtime does. The workbench is the SDK's own tool and not a
  shipping path; it is worth a look before the next pack author hits it.
* No CI job builds packs yet — `npm run packs` is not in any workflow.

## Checks

`npm run tsc`, `npm run lint`, 166 app tests, 52 SDK tests, 69 FUSE tests,
19 SIEGE tests, 15 Rust tests — all green.
