### PR TITLE
dynawalla: the day pass — every game free, gated at a natural transition, never a timer

### DIFF
--- a/dynawalla/docs/ACCEPTANCE_CRITERIA.md
+++ b/dynawalla/docs/ACCEPTANCE_CRITERIA.md
@@ -497,13 +497,14 @@ See [PACK_SYSTEM.md](PACK_SYSTEM.md) and
       or SDKs; a parental gate on every link-out and purchase) are already Accepted as of
       2026-07-25 and are not what this item waits on.
       Evidence: UNMET
-- [ ] **G-02** `[founder]` The **packaging and pricing** of the monetization direction —
-      what the free tier includes, what the subscription unlocks, what it costs — is
-      decided and recorded in
-      [ADR-0013](DECISIONS/ADR-0013-monetization-model.md) before M9 completes. The
-      direction (generous free tier + subscription, offline-first, never block an offline
-      subscriber) is Accepted as of 2026-07-25; the packaging is not, and carries R-45.
-      Evidence: UNMET
+- [x] **G-02** `[founder]` The **packaging and pricing** are decided and recorded in
+      [ADR-0024](DECISIONS/ADR-0024-day-pass-not-subscription.md), which **supersedes**
+      ADR-0013's subscription. **Every game is free to play**; the boundary is a natural
+      transition inside a game, one per game per day, never a clock; the pass is
+      **$0.99 / day, $7.99 / month, $79.99 lifetime — the lifetime is the headline**.
+      Never-block-an-offline-subscriber is carried over verbatim.
+      Evidence: MET — founder's own words, 2026-07-26, quoted in ADR-0024. R-45 (the
+      model has no evidence behind it yet) is **not** closed by this and still stands.
 - [ ] **G-03** `[founder]` The repository license is decided and a `LICENSE` file
       exists ([ADR-0014](DECISIONS/ADR-0014-repository-license.md)).
       Evidence: UNMET

--- a/dynawalla/docs/DECISIONS.md
+++ b/dynawalla/docs/DECISIONS.md
@@ -52,7 +52,7 @@ saying what changed, so the history is readable without `git log`.
 | [0010](DECISIONS/ADR-0010-standards-alignment-claim.md) | Public standards-alignment claim | **Proposed — awaiting founder** (research in flight) |
 | [0011](DECISIONS/ADR-0011-native-workspace-and-patch-placement.md) | `native/` workspace, independent app roots, `[patch]` stays put | Accepted |
 | [0012](DECISIONS/ADR-0012-ota-curriculum-deferral.md) | Curriculum ships bundled; OTA deferred with a stated trigger | Accepted |
-| [0013](DECISIONS/ADR-0013-monetization-model.md) | Monetization model | Accepted (direction); packaging open |
+| [0013](DECISIONS/ADR-0013-monetization-model.md) | Monetization model | **Superseded by 0024** |
 | [0014](DECISIONS/ADR-0014-repository-license.md) | Repository license | **Proposed — awaiting founder** (research in flight) |
 | [0015](DECISIONS/ADR-0015-developer-account-topology.md) | Developer-account topology | Accepted |
 | [0016](DECISIONS/ADR-0016-app-store-product-name.md) | App Store product name | **Proposed — awaiting founder** (checks returned 2026-07-25; two counsel-grade collisions open) |
@@ -62,6 +62,7 @@ saying what changed, so the history is readable without `git log`.
 | [0020](DECISIONS/ADR-0020-content-packs-are-the-product.md) | Downloadable content packs are the product | Accepted |
 | [0021](DECISIONS/ADR-0021-pack-capabilities-are-per-pack.md) | Capability is per pack; the microphone stays closed | Accepted |
 | [0022](DECISIONS/ADR-0022-host-ships-no-content.md) | The host ships no content; packs are the product | Accepted |
+| [0024](DECISIONS/ADR-0024-day-pass-not-subscription.md) | The day pass replaces the subscription | Accepted |
 
 ## Reversed on 2026-07-26
 
@@ -95,10 +96,12 @@ Four ADRs closed in one pass, recorded from the founder's own words in each ADR:
 - **ADR-0015 Developer-account topology** — same Corpora accounts as Corpán. The founder
   said "same as Corpan I think"; the blast-radius cost was identified by the program and
   **was not put to him**, which the ADR now says in its header.
-- **ADR-0013 Monetization** — direction only: generous free tier plus a subscription for
-  unlimited exercises and full access; packaging and pricing still open, and the
-  founder's own "I'm not sure" and "hasn't worked in the slightest" are carried as R-45
-  rather than smoothed into a mandate.
+- **ADR-0024 The day pass** — supersedes ADR-0013's subscription. **Every game is free to
+  play**; the boundary is a *natural transition inside a game* rather than a quantity or a
+  clock, one per game per day; the pass is $0.99 / day, $7.99 / month, **$79.99 lifetime,
+  which is the headline**. This is a positive, priced, specific decision, unlike the
+  direction it replaces — and it dissolves the tension ADR-0013 deferred, because a
+  boundary that is a *place* cannot cut a willing child off mid-flow.
 - **ADR-0001 Kids Category** — the engineering constraints (no third-party ads,
   analytics or SDKs) are locked unconditionally; a parental-gate primitive is built and
   every link-out routes through it; the category election, **and the age band inside
@@ -113,7 +116,8 @@ which is exactly how one goes unnoticed. Do not re-enumerate them here.
 
 The short version, for orientation only: **ADR-0016** (name), **ADR-0002** (scope cut),
 **ADR-0014** (license) and **ADR-0010** (standards claim) are open at the ADR level; and
-two decisions live *inside* ADRs that are otherwise decided — **ADR-0001's category
-election and age band** (`G-01`) and **ADR-0013's packaging and pricing** (`G-02`). The
+and one decision lives *inside* an ADR that is otherwise decided — **ADR-0001's category
+election and age band** (`G-01`). **`G-02` (packaging and pricing) is closed** by
+ADR-0024. The
 **age-band choice is the newest and the least expected**: no V1 scope currently proposed
 fits a single Apple Kids band.

--- a/dynawalla/docs/DECISIONS/ADR-0013-monetization-model.md
+++ b/dynawalla/docs/DECISIONS/ADR-0013-monetization-model.md
@@ -1,7 +1,23 @@
 # ADR-0013 — Monetization model
 
-**Status:** Accepted (direction) — 2026-07-25. **Implementation deferred**; the packaging
-and pricing decision is not made and blocks launch if it is still open past M9 (`G-02`).
+**Status:** **Superseded by
+[ADR-0024](ADR-0024-day-pass-not-subscription.md)** — 2026-07-26. The founder replaced the
+subscription with a **day pass**: every game free to play, gated at a *natural transition*
+rather than by a quantity or a clock, one gate per game per day, and a pass priced at
+$0.99 / day, $7.99 / month, **$79.99 lifetime — the headline**.
+
+**Read ADR-0024 for the live decision.** This document is kept because two of its parts
+survive intact and are cited from there: the **never-block-an-offline-subscriber policy**
+(§3 below) and the **consequences that apply to any paid option** — the parental gate in
+front of every price display, no purchase surface adjacent to a failure, no purchased
+absolution, and local-only entitlements. What is superseded is the *shape* of the paid
+tier, not those constraints.
+
+Note also that the tension this ADR flagged and deferred — *"a daily exercise cap is a
+stopping mechanism imposed by billing rather than by the child"* — is what ADR-0024
+resolves, by making the boundary a place in a game rather than a quantity.
+
+Previously: Accepted (direction) — 2026-07-25, implementation deferred, `G-02` open.
 
 **How strong is this mandate: weak, and the status line should not be read as more.** The
 founder's answer opens *"I'm not sure about monetization really"* and describes the model

--- a/dynawalla/docs/DECISIONS/ADR-0024-day-pass-not-subscription.md
+++ b/dynawalla/docs/DECISIONS/ADR-0024-day-pass-not-subscription.md
@@ -1,0 +1,191 @@
+# ADR-0024 — The day pass replaces the subscription
+
+**Status:** Accepted — 2026-07-26. **Supersedes
+[ADR-0013](ADR-0013-monetization-model.md)** (`Accepted (direction)`, 2026-07-25), which
+recorded a generous-free-tier-plus-subscription model under explicit founder uncertainty.
+
+**How strong is this mandate: strong, and stronger than ADR-0013's was.** ADR-0013 opened
+with *"I'm not sure about monetization really"* and described the model as *"something
+like Corpan (although that hasn't worked in the slightest)"*. This one is a positive,
+specific, priced decision with a stated reason and a stated differentiator. It is not a
+direction to be filled in later.
+
+## The decision
+
+> "In the free tier **every game is available**. But, at a **natural end of the first
+> level or a natural transition (rather than a hard timer)**, they can't play again until
+> tomorrow. This way kids can experience all of the games and find one that they really
+> love, then on a natural transition we show them a 'pass' — simple, **no subscription, no
+> ads**, just **day pass $0.99 or month $7.99 or lifetime $79.99**. This is a
+> differentiator .. **like getting a pass to Six Flags or the arcade.**"
+
+Six properties, and each of them is load-bearing:
+
+1. **Every game is playable free.** Nothing is locked at the door, nothing is badged
+   "premium", and discovery is unlimited. A child can open all of them on their first
+   afternoon. `pass.test.ts` asserts that a cold device with nothing bought opens every
+   installed game.
+2. **The gate is a natural transition, never a clock.** A game says it reached a stopping
+   point — level cleared, run completed, boss down. **There is no timer in the product and
+   no timer UI anywhere**, which is also asserted mechanically: the sheet's module may not
+   contain `setInterval`, `requestAnimationFrame`, `performance.now` or `setTimeout`.
+3. **One gate per game per day.** FUSE ending does not end SIEGE. This is deliberate and
+   it is the mechanism by which a child finds the one game they love: unlimited breadth,
+   bounded repetition.
+4. **The offer appears once, at that transition, and is easy to dismiss.** One obvious tap,
+   plus Escape, from every stage.
+5. **Lifetime ($79.99) is the headline.** Parents hate subscriptions; a one-time purchase
+   is the differentiator, and it is listed first and framed largest.
+6. **No dark patterns.** Enumerated below, and tested.
+
+## Why this replaces the subscription rather than sitting beside it
+
+ADR-0013 named a tension it could not resolve and deferred it:
+
+> "*Unlimited exercises* implies the free tier has an exercise limit, and a daily exercise
+> cap is a stopping mechanism imposed by billing rather than by the child."
+
+[MISSION.md](../MISSION.md) forbids play-by-appointment and requires designed stopping
+points. A cap that cuts a willing child off mid-flow was already ruled an unacceptable
+shape. **The day pass dissolves the tension instead of arguing about it**: the free tier's
+boundary is not a quantity at all, it is a *place in the game* that the game itself picked,
+and the child arrives at it having just finished something. Nothing is interrupted, because
+by construction there is nothing in progress.
+
+It also fixes what ADR-0013 was most worried about — copying a model the founder judged to
+have *"not worked in the slightest."* A day pass is not that model. It is not a
+subscription, it prices a one-time purchase as the headline, and its free tier is bounded
+by breadth-per-day rather than by content, which is the resolution shape ADR-0013's own
+"tension nobody should discover at M9" section pointed at.
+
+## The mechanism
+
+**`session.transition`** — a new session method on the pack SDK, alongside
+`session.settings`, `session.progress` and `session.end`.
+
+```ts
+host.transition("level" | "run" | "boss", label?)
+```
+
+Three properties of its design, each chosen against an alternative:
+
+- **It is a session method, not a capability.** A pack cannot decline to declare it and
+  thereby decline ever to reach a stopping point. Had it been gated, the day pass would be
+  enforceable only by a clock — the thing this model exists to avoid.
+- **It returns nothing.** The host answers `null` whatever it decides. A pack that could
+  read the verdict could branch on whether the child has paid, and a game that plays
+  differently for a paying child is exactly what this is not. If the host puts something
+  over the frame, the pack learns it the ordinary way, through the `pause` event it
+  already handles.
+- **It may only follow something the child finished.** Never a defeat, never a failed run,
+  never a wrong answer, never a timer. ADR-0013 already forbids a purchase surface next to
+  a failure, and the negative example is on the record: reviewers logged 16 membership ads
+  in a 19-minute Prodigy session, which drew an FTC complaint alleging manipulative
+  upselling to children.
+
+Where the five shipped games send it:
+
+| Game | Stopping point | Why |
+|---|---|---|
+| FUSE (`merge`) | every level-up | The quota is met and the KEY changes. Literally "the natural end of the first level". |
+| SIEGE (`siege`) | every fifth wave held — the boss waves | A single wave is thirty seconds and is not an ending. A boss held is several minutes and the child is already celebrating. **Never on defeat.** |
+| FORGE (`forge`) | the quench | The prestige reset *is* the run, and the child chose it. |
+| MONUMENT (`stack`) | a new stratum, climbing | Eight floors of tower and the rock changes. Only on the way up. |
+| THE SPLIT (`slice`) | a market rush survived | The game has no levels and no ending; the settle after a rush is its only crest. |
+
+A game may send as many as it naturally reaches. The host acts on the first per game per
+day and ignores the rest, so no game has to ration them or know which one is special.
+
+## Entitlement, and the one asymmetry
+
+**A wrongly-open pass costs a dollar. A wrongly-closed pass tells a family that already
+paid that they did not.** Everything resolves towards open. The policy is copied from
+`corpan/corpan-app/src/store/entitlements.ts`, which was rebuilt to eliminate exactly this
+failure:
+
+- A **lifetime** pass is never re-examined. No expiry, no clock, no periodic revalidation.
+- A **month** pass survives its recorded expiry by a **48-hour grace window**, because a
+  renewal is a fact only the store knows and the store is not always reachable. Past the
+  grace it closes — an indefinite grace is a free subscription.
+- A **day** pass gets no grace, because none is needed: its expiry requires no round trip,
+  and extending it would make it a three-day pass.
+- **Only a definitive, online `not_owned` clears a pass.** A timeout, an offline device or
+  a rejected bridge is `unavailable`, which is logged loudly and changes nothing.
+
+**Entitlements stay local.** [STORE.md](../STORE.md) is explicit that a receipt-validation
+backend is one of exactly two things that would break Apple "Data Not Collected" and Play
+"nothing collected, nothing shared". There is no server, and this decision does not add one.
+
+**The rest ledger is device-scoped, not per learner.** Per-learner would turn "add a
+learner" into an extra play, which makes the profile switcher a hole in the model and
+teaches a child to game it. It holds one day at a time and is discarded at local midnight,
+so it does not accumulate and there is no history of a child's play to leak.
+
+## The parental gate
+
+Required by Kids Category rules in front of any purchase surface, and here it stands in
+front of the **price display** as well — a child at a stopping point sees no money at all.
+
+**The challenge is never arithmetic, and here that is not a preference.** Apple's canonical
+gate is a multiplication problem. This is a mathematics app for grades 1–6: the audience is
+being trained daily to defeat exactly that challenge, and a gate that teaches a child that
+solving sums opens the money screen is worse than no gate. Two forms, randomized and
+non-persistent:
+
+- **the current four-digit year**, and
+- **a thirteen-letter-or-longer, four-syllable, non-curricular word to transcribe.**
+
+Reading and typing load is the asymmetry that actually exists between a six-year-old and an
+adult. TELEVISION, UNIVERSITY, HELICOPTERS and WATERMELONS were in the first draft of the
+word list and were cut: a nine-year-old types all four without hesitating.
+
+## No dark patterns — the enumerated list
+
+Banned outright, and `pass.test.ts` holds the copy and the source against it:
+
+no countdown or timer of any kind · no "N plays left" · no fake scarcity · no "only today"
+· no guilt copy · no social pressure ("your friends are playing") · no interstitial that
+must be watched · no delay before the dismissal becomes usable · no pre-selected plan · no
+struck-through price · no "best value" badge · no copy that frames stopping as a loss · no
+padlock, dimming or "premium" badge on a game in the grid.
+
+A game that already ended today shows the word **Tomorrow** where **Play** would be, in the
+same small type as the version, with its name at full strength and its control working.
+That is a fact about the child's day, not a price.
+
+## Billing is a seam, not an implementation
+
+`src/pass/billing.ts` declares three methods — `products`, `buy`, `restore` — and ships
+`unwiredBilling`, which charges nobody and grants nothing, reporting `unavailable`. A stub
+that pretended to succeed would write a fake receipt into durable storage on a child's
+tablet, where the first real store query would have to argue with it.
+
+StoreKit 2 and Play Billing land behind `setBilling()`. The product ids are fixed here and
+are **immutable once submitted** — a renamed store SKU is a new product with no history and
+no restores, in both stores:
+
+| Pass | Product id | Fallback price |
+|---|---|---|
+| Day | `inc.corpora.dynawalla.pass.day` | $0.99 |
+| Month | `inc.corpora.dynawalla.pass.month` | $7.99 |
+| Lifetime | `inc.corpora.dynawalla.pass.lifetime` | $79.99 |
+
+Prices in the table are a **US fallback for a device with no store to ask**. A shipping
+build reads the localised price string from the store, because $7.99 is not what a family
+in Delhi is charged.
+
+## Consequences
+
+- **`G-02` (packaging and pricing open past M9) is closed.** Both are decided.
+- **The category election is now decidable.** [ADR-0001](ADR-0001-kids-category-posture.md)
+  deferred it until the purchase surface existed. It exists.
+- **IAP needs the explicit App ID and a non-wildcard provisioning profile**, which is
+  already how [STORE.md](../STORE.md) plans the signing identity. A **month** product is a
+  non-renewing or auto-renewing subscription in store terms even though the product is not
+  marketed as one; day and lifetime are non-consumables. That distinction is a store
+  configuration detail, not a change to anything above.
+- **"No purchased absolution" still holds.** A pass buys more play. It never undoes a wrong
+  answer, restores a lost thing, or skips work.
+- **R-45** (the monetization model has no evidence behind it) is not closed by this ADR. It
+  is a better-argued hypothesis with a real differentiator, and it still has to meet
+  parents.

--- a/dynawalla/docs/MISSION.md
+++ b/dynawalla/docs/MISSION.md
@@ -140,8 +140,10 @@ in their ADRs from his own words: human evaluation resourcing
 ([0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md) — one child evaluator, his
 10-year-old son; the founder is the art director), developer-account topology
 ([0015](DECISIONS/ADR-0015-developer-account-topology.md) — same accounts as Corpán),
-monetization direction ([0013](DECISIONS/ADR-0013-monetization-model.md) — generous free
-tier plus a subscription, packaging still open), and the Kids Category engineering
+monetization ([0024](DECISIONS/ADR-0024-day-pass-not-subscription.md) — a **day pass**,
+not a subscription; every game free to play, gated at a natural transition, priced
+$0.99 / $7.99 / $79.99-lifetime; supersedes [0013](DECISIONS/ADR-0013-monetization-model.md)),
+and the Kids Category engineering
 posture ([0001](DECISIONS/ADR-0001-kids-category-posture.md) — no third-party ads,
 analytics or SDKs, ever; a parental gate on every link-out; the category election itself
 deferred to submission).
@@ -151,7 +153,7 @@ previously carried three different counts, which is how a founder ends up not kn
 decision is waiting on him. **[STATUS.md](STATUS.md) is the single source of truth for
 which founder decisions are open and when each one bites** — including the ones that live
 *inside* an otherwise-decided ADR, such as the Kids Category election and age band
-(`G-01`) and monetization packaging (`G-02`). [DECISIONS.md](DECISIONS.md) indexes the
+(`G-01`). [DECISIONS.md](DECISIONS.md) indexes the
 ADRs; STATUS.md says what is outstanding.
 
 ## How this product is graded

--- a/dynawalla/docs/RISKS.md
+++ b/dynawalla/docs/RISKS.md
@@ -463,11 +463,12 @@ adopting it by default inherits the pricing and packaging assumptions that produ
 result along with the architecture that makes it cheap to run. It is a **direction, not a
 validated design**, and no evidence pass has been done on what a parent would actually
 pay for here.
-**Mitigation:** `G-02` requires packaging and pricing to be decided and recorded before
-M9 completes, separately from the direction; ADR-0013 records the tension between an
-"unlimited exercises" upsell and [MISSION.md](MISSION.md)'s ban on play-by-appointment
-and grinding gates, so a free-tier session cap is ruled out before launch pressure makes
-it look reasonable. **Residual:** nobody is currently assigned to do that evidence pass,
+**Mitigation:** `G-02` is **closed** — [ADR-0024](DECISIONS/ADR-0024-day-pass-not-subscription.md)
+decides packaging and pricing, replaces the subscription with a **day pass**, and dissolves
+the tension ADR-0013 recorded between an "unlimited exercises" upsell and
+[MISSION.md](MISSION.md)'s ban on play-by-appointment: the free tier's boundary is a
+*natural transition inside a game*, not a quantity, so it cannot cut a willing child off
+mid-flow. The residual below is unchanged, and is the part that matters. **Residual:** nobody is currently assigned to do that evidence pass,
 and low run-rate makes it easy to defer indefinitely — a free product with no revenue is
 not obviously failing, which is exactly how it stays undecided.
 

--- a/dynawalla/docs/STATUS.md
+++ b/dynawalla/docs/STATUS.md
@@ -170,7 +170,7 @@ Recorded 2026-07-25, from the founder's own words, in each ADR:
 |---|---|
 | [0017](DECISIONS/ADR-0017-human-evaluation-resourcing.md) | One child evaluator — the founder's 10-year-old son. The founder holds every adult role, including art director. |
 | [0015](DECISIONS/ADR-0015-developer-account-topology.md) | Same Corpora Apple team and Play account as Corpán; shared blast radius and nomination pool accepted. |
-| [0013](DECISIONS/ADR-0013-monetization-model.md) | Direction: generous free tier + subscription for unlimited exercises and full access; offline-first keeps marginal cost near zero. Packaging and pricing still open (R-45). |
+| [0024](DECISIONS/ADR-0024-day-pass-not-subscription.md) | **A day pass, not a subscription.** Every game free to play; the gate is a natural transition inside a game, one per game per day, never a clock. $0.99 day / $7.99 month / **$79.99 lifetime — the headline**. Supersedes [0013](DECISIONS/ADR-0013-monetization-model.md); never-block-an-offline-subscriber carried over. R-45 still stands. |
 | [0001](DECISIONS/ADR-0001-kids-category-posture.md) | No third-party ads, analytics or SDKs, unconditionally. Parental gate on every link-out. Category election deferred to submission. |
 
 Still open, ordered by when they bite:
@@ -183,7 +183,6 @@ Still open, ordered by when they bite:
 | [0014](DECISIONS/ADR-0014-repository-license.md) | Repository license (research in flight) | M0a (fork-PR posture) |
 | [0010](DECISIONS/ADR-0010-standards-alignment-claim.md) | Standards-alignment claim (research in flight) | first public marketing copy |
 | [0001](DECISIONS/ADR-0001-kids-category-posture.md) | The category election itself | M1, first store submission (`G-01`) |
-| [0013](DECISIONS/ADR-0013-monetization-model.md) | Packaging and pricing | M9 (`G-02`) |
 | — | Whether to add one younger evaluator for the grade 1–2 gap (R-46) | M9 at the latest |
 
 ## Roles

--- a/dynawalla/docs/STORE.md
+++ b/dynawalla/docs/STORE.md
@@ -83,8 +83,10 @@ package-name variable):
 - Beta groups and TestFlight distribution.
 - Store listings, screenshots, descriptions.
 - Play Data safety declaration.
-- IAP products and subscription groups, if
-  [ADR-0013](DECISIONS/ADR-0013-monetization-model.md) calls for them.
+- IAP products and subscription groups, per
+  [ADR-0024](DECISIONS/ADR-0024-day-pass-not-subscription.md): three products, ids fixed in
+  that ADR and **immutable once submitted**. Day and lifetime are non-consumables; the
+  month is a subscription in store terms even though the product is not marketed as one.
 - Build uploads, track promotion, release notes.
 
 **Not automatable — budget founder console time:**
@@ -206,8 +208,10 @@ against:
 
 1. **A third-party crash SDK** → a Diagnostics disclosure.
 2. **A receipt-validation backend** → a Purchases disclosure. This is the live one:
-   [ADR-0013](DECISIONS/ADR-0013-monetization-model.md) wires a subscription, so
-   **keep entitlements local** or the declaration changes.
+   [ADR-0024](DECISIONS/ADR-0024-day-pass-not-subscription.md) wires a day pass, so
+   **keep entitlements local** or the declaration changes. It does keep them local — the
+   pass lives in device storage and no server is involved — but the constraint binds any
+   future change to how a purchase is verified.
 
 ### Planned mechanical gates
 

--- a/dynawalla/dynawalla-app/src/app/strings.ts
+++ b/dynawalla/dynawalla-app/src/app/strings.ts
@@ -36,6 +36,8 @@ export const strings = {
     space: "Space used",
     /** The control on a pack row. What the row does, in one word. */
     play: "Play",
+    /** The same control on a game that already reached its ending today. */
+    tomorrow: "Tomorrow",
     /** Leaves a running pack. The only host chrome drawn over a game. */
     leave: "Leave",
     /** The pack was launched and is no longer on this device. */
@@ -80,6 +82,55 @@ export const strings = {
     plain: "Plain",
   },
 
+  /**
+   * The day pass. **Read this copy as a whole before changing a line of it.**
+   *
+   * Two audiences and two stages, and the split is the design: a child at a
+   * natural stopping point sees the first four strings and no money, no price,
+   * no offer and no reason to fetch a parent. Everything below `gate` is behind
+   * the parental gate and is written for an adult.
+   *
+   * What is deliberately absent, and must stay absent: any countdown, any
+   * quantity remaining, any "your friends", any "only today", any sentence
+   * that makes stopping sound like a loss. The child-facing copy points at the
+   * other games, because there are always other games and that is the honest
+   * thing to say.
+   */
+  pass: {
+    /** The whole child-facing message. Nothing is taken away; a thing ended. */
+    restTitle: "That's {{pack}} for today.",
+    restBody: "Every other game is still open.",
+    /** The way out, and the biggest control on the sheet. */
+    restLeave: "Choose another game",
+    /** Small, quiet, and the only route to a price. Never the primary control. */
+    forGrownUps: "Grown-ups",
+
+    /** The parental gate. Reading load, never arithmetic. */
+    gateTitle: "For a grown-up",
+    gateYear: "Type the current year, all four digits.",
+    gateWord: "Type this word:",
+    gateEntry: "Answer",
+    gateGo: "Continue",
+    gateWrong: "That's not it. Try again.",
+
+    offerTitle: "The Dynawalla Pass",
+    offerBody: "Every game, as often as you like. No subscription, no ads.",
+    lifetime: "Lifetime",
+    lifetimeNote: "Pay once. Yours for good.",
+    month: "One month",
+    monthNote: "Thirty days.",
+    day: "Day pass",
+    dayNote: "Today.",
+    restore: "Restore a pass",
+    /** Closes the sheet and changes nothing. Always one tap, always visible. */
+    notNow: "Not now",
+    /** No store is wired into this build, or the device could not reach one. */
+    storeUnavailable: "The store could not be reached.",
+    /** A pass is held. Shown where a price would otherwise be. */
+    held: "This device has a pass.",
+    /** Developer mode only, and not translated for that reason — see `dev`. */
+  },
+
   parents: {
     version: "Version",
     storage: "On this device",
@@ -104,6 +155,14 @@ export const dev = {
   browser: "Browser",
   grant: "Grant",
   key: "Key",
+  /** The pass, from the parent area, with developer mode on. */
+  pass: "Pass",
+  passNone: "None",
+  grantDayPass: "Grant a day pass (test)",
+  grantLifetime: "Grant a lifetime pass (test)",
+  clearPass: "Clear the pass (test)",
+  clearLedger: "Clear today's rest ledger (test)",
+  resting: "Resting today",
 } as const
 
 /**

--- a/dynawalla/dynawalla-app/src/packs/Stage.tsx
+++ b/dynawalla/dynawalla-app/src/packs/Stage.tsx
@@ -22,6 +22,8 @@ import type { Settings } from "../../../packs/sdk/src/index.ts"
 import { BUILD_VERSION } from "../app/platform.ts"
 import { strings } from "../app/strings.ts"
 import { useThemeStore } from "../app/theme.ts"
+import { PassSheet } from "../pass/PassSheet.tsx"
+import { usePass } from "../pass/store.ts"
 import { useProfiles } from "../profiles/store.ts"
 import { useSettings } from "../settings/store.ts"
 import { entryOf, useLibrary } from "./libraryStore.ts"
@@ -75,6 +77,29 @@ function Stage({ packId, onLeave }: { packId: string; onLeave: () => void }) {
   const [failure, setFailure] = useState<string | null>(null)
   const [progress, setProgress] = useState(0)
 
+  // The day pass, and the whole of its presence in this component.
+  //
+  // Two pieces of state, and keeping them apart is what makes the difference
+  // between the two situations feel right:
+  //
+  //   `restedBefore`  read **once**, at mount, and never again. The game was
+  //                   already finished today before the child pressed it, so
+  //                   it is not mounted at all — no entry document is fetched,
+  //                   no session begins, and there is no half-second of play
+  //                   followed by a sheet.
+  //   `offering`      the transition happened just now, in front of the child.
+  //                   The frame stays mounted and pauses, so what is behind the
+  //                   sheet is the thing they just finished rather than a
+  //                   screen that vanished under them.
+  //
+  // `restedBefore` is `useState` with a lazy initialiser and no setter — a
+  // value computed once, at mount, from the real clock, and then constant for
+  // the life of the session. A ref would say the same thing and would be read
+  // during render, which is the rule React actually enforces.
+  const reachTransition = usePass((state) => state.reachTransition)
+  const [restedBefore] = useState(() => !usePass.getState().mayOpen(packId))
+  const [offering, setOffering] = useState(false)
+
   // Built by the one function that knows how a host setting becomes a pack
   // setting, so the mapping cannot drift between the launch and the push.
   const forPack: Settings = useMemo(
@@ -90,6 +115,12 @@ function Stage({ packId, onLeave }: { packId: string; onLeave: () => void }) {
         onProgress: setProgress,
         onEnd: () => onLeave(),
         onMilestone: (name) => console.info(`[packs] ${packId} reached ${name}`),
+        onTransition: (kind, label) => {
+          console.info(`[packs] ${packId} reached a ${kind}${label ? ` (${label})` : ""}`)
+          // The store decides and records in one call, so two transitions
+          // arriving in the same frame cannot both be "the first one today".
+          if (reachTransition(packId) === "rest") setOffering(true)
+        },
       }),
     // One session per mount. `profileId` changing mid-game would be a different
     // child, which the profile switcher cannot do while the stage is up.
@@ -107,6 +138,9 @@ function Stage({ packId, onLeave }: { packId: string; onLeave: () => void }) {
   const manifestEntry = entry?.manifest.entry
   useEffect(() => {
     if (manifestEntry === undefined) return
+    // Nothing is fetched for a game that already ended today. The sheet is the
+    // whole screen and there is no document behind it to load.
+    if (restedBefore) return
     let live = true
     tauriNative
       .entryUrl(packId, manifestEntry)
@@ -120,10 +154,20 @@ function Stage({ packId, onLeave }: { packId: string; onLeave: () => void }) {
     return () => {
       live = false
     }
-  }, [packId, manifestEntry])
+  }, [packId, manifestEntry, restedBefore])
 
   if (!entry) return <Curtain message={strings.packs.missing} onLeave={onLeave} />
   if (failure !== null) return <Curtain message={failure} onLeave={onLeave} />
+
+  // Opened again on a day it already ended. The sheet opens on the same first
+  // stage it did the first time — a statement about a game, and no price.
+  if (restedBefore) {
+    return (
+      <div className="bg-ground-deep fixed inset-0 z-50">
+        <PassSheet packName={entry.name} onLeave={onLeave} />
+      </div>
+    )
+  }
 
   return (
     <div className="bg-ground-deep fixed inset-0 z-50">
@@ -136,6 +180,9 @@ function Stage({ packId, onLeave }: { packId: string; onLeave: () => void }) {
           hostVersion={BUILD_VERSION}
           title={entry.name}
           settings={forPack}
+          // The game stops its own loop while the sheet is up. Not unmounted:
+          // what is behind the sheet is the thing the child just finished.
+          paused={offering}
           onError={(reason) => setFailure(reason)}
         />
       )}
@@ -162,13 +209,21 @@ function Stage({ packId, onLeave }: { packId: string; onLeave: () => void }) {
         />
       </svg>
 
-      <button
-        type="button"
-        onClick={onLeave}
-        className="border-line-cut bg-ground/85 text-ink rounded-cut-sm absolute top-[max(var(--safe-top),0.5rem)] right-[max(var(--safe-right),0.5rem)] min-h-11 min-w-11 border px-4 text-sm backdrop-blur"
-      >
-        {strings.packs.leave}
-      </button>
+      {/* Hidden while the sheet is up: two ways out of one screen, one of them
+          unlabelled, is a child pressing the wrong one. */}
+      {offering ? null : (
+        <button
+          type="button"
+          onClick={onLeave}
+          className="border-line-cut bg-ground/85 text-ink rounded-cut-sm absolute top-[max(var(--safe-top),0.5rem)] right-[max(var(--safe-right),0.5rem)] min-h-11 min-w-11 border px-4 text-sm backdrop-blur"
+        >
+          {strings.packs.leave}
+        </button>
+      )}
+
+      {/* The stopping point, reached just now. Leaving is leaving the game:
+          this one is finished for today, and the other games are not. */}
+      {offering ? <PassSheet packName={entry.name} onLeave={onLeave} /> : null}
     </div>
   )
 }

--- a/dynawalla/dynawalla-app/src/packs/bridge.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/bridge.test.ts
@@ -59,6 +59,7 @@ function services(calls: Calls, overrides: Partial<HostServices> = {}): HostServ
     },
     progress: (input) => void record("progress", undefined)(input),
     end: (input) => void record("end", undefined)(input),
+    transition: (input) => void record("transition", undefined)(input),
     settings: () => ({
       locale: "en",
       reducedMotion: false,
@@ -115,7 +116,13 @@ test("session methods work with no grants at all", async () => {
   const bridge = bridgeWith([], calls)
   for (const method of SESSION_METHODS) {
     const params =
-      method === "session.progress" ? { fraction: 0.5 } : method === "session.end" ? { reason: "quit" } : {}
+      method === "session.progress"
+        ? { fraction: 0.5 }
+        : method === "session.end"
+          ? { reason: "quit" }
+          : method === "session.transition"
+            ? { kind: "level" }
+            : {}
     const response = await bridge.handle({ id: 1, method, params })
     assert.ok(response?.ok, `${method} was refused`)
   }
@@ -156,6 +163,7 @@ test("the whole method table is reachable when everything is granted", async () 
     cue: "seat",
     fraction: 0.5,
     reason: "quit",
+    kind: "level",
   }
   for (const method of METHODS) {
     const response = await bridge.handle({ id: 1, method, params })
@@ -214,6 +222,7 @@ test("parameters are checked, and a wrong one is invalid_params rather than a cr
     ["milestone.reach", {}],
     ["session.progress", { fraction: "half" }],
     ["session.end", { reason: "crashed" }],
+    ["session.transition", { kind: "defeat" }],
     ["storage.get", {}],
     ["storage.set", { key: "k" }],
     ["storage.set", { key: "k", value: 7 }],

--- a/dynawalla/dynawalla-app/src/packs/bridge.ts
+++ b/dynawalla/dynawalla-app/src/packs/bridge.ts
@@ -31,9 +31,11 @@ import type {
   Response,
   Settings,
   SoundCue,
+  TransitionKind,
 } from "../../../packs/sdk/src/index.ts"
 import {
   MAX_REQUESTS_PER_SECOND,
+  isTransitionKind,
   numberParam,
   parseRequest,
   permits,
@@ -84,6 +86,11 @@ export type HostServices = {
   }
   progress(input: { packId: string; fraction: number }): void
   end(input: { packId: string; reason: "finished" | "quit" }): void
+  /**
+   * A natural stopping point the pack reached. The host decides what, if
+   * anything, happens next; the pack is told nothing.
+   */
+  transition(input: { packId: string; kind: TransitionKind; label?: string }): void
   settings(): Settings
 }
 
@@ -152,6 +159,22 @@ export function createBridge(options: BridgeOptions): Bridge {
           return err(id, "invalid_params", "reason must be finished or quit")
         }
         services.end({ packId, reason })
+        return ok(id, null)
+      }
+
+      case "session.transition": {
+        const kind = params["kind"]
+        if (!isTransitionKind(kind)) {
+          return err(id, "invalid_params", "kind must be level, run or boss")
+        }
+        // Optional, short, and for a log rather than for a screen: nothing the
+        // host draws comes from a pack, because a pack's string is not
+        // translated and is not the host's copy.
+        const label = stringParam(params, "label", 64)
+        services.transition(label === null ? { packId, kind } : { packId, kind, label })
+        // Deliberately answered `null`. A pack that could read the verdict
+        // could branch on whether the child has paid, and a game that plays
+        // differently for a paying child is the thing this model is not.
         return ok(id, null)
       }
 

--- a/dynawalla/dynawalla-app/src/packs/frame.test.ts
+++ b/dynawalla/dynawalla-app/src/packs/frame.test.ts
@@ -41,6 +41,7 @@ const services = (): HostServices => ({
   },
   progress: () => {},
   end: () => {},
+  transition: () => {},
   settings: () => SETTINGS,
 })
 

--- a/dynawalla/dynawalla-app/src/packs/services.ts
+++ b/dynawalla/dynawalla-app/src/packs/services.ts
@@ -10,7 +10,13 @@
 // ladders and two sets of counters rather than one that remembers the last
 // child who played.
 
-import type { HapticCue, Item, Settings, SoundCue } from "../../../packs/sdk/src/index.ts"
+import type {
+  HapticCue,
+  Item,
+  Settings,
+  SoundCue,
+  TransitionKind,
+} from "../../../packs/sdk/src/index.ts"
 import type { HostServices } from "./bridge.ts"
 import { createItemService, type ItemService } from "./items.ts"
 import { report } from "./host.ts"
@@ -125,6 +131,12 @@ export type ServicesDeps = {
   readonly onProgress?: (fraction: number) => void
   readonly onEnd?: (reason: "finished" | "quit") => void
   readonly onMilestone?: (name: string) => void
+  /**
+   * The pack reached a natural stopping point. What happens next is the day
+   * pass's business and is decided by the stage, not here: this module knows
+   * nothing about entitlement, and the pack learns nothing about the answer.
+   */
+  readonly onTransition?: (kind: TransitionKind, label?: string) => void
 }
 
 export type LaunchServices = {
@@ -203,6 +215,7 @@ export function createServices(deps: ServicesDeps): LaunchServices {
 
     progress: (input) => deps.onProgress?.(input.fraction),
     end: (input) => deps.onEnd?.(input.reason),
+    transition: (input) => deps.onTransition?.(input.kind, input.label),
     settings: () => current,
   }
 

--- a/dynawalla/dynawalla-app/src/pass/PassSheet.tsx
+++ b/dynawalla/dynawalla-app/src/pass/PassSheet.tsx
@@ -1,0 +1,388 @@
+// The one purchase surface in the app, and the sheet a child sees when a game
+// reaches its stopping point. Three stages, and which stage you are on decides
+// who is being spoken to.
+//
+//   rest   a child. A game ended. There is no price on this screen, no offer,
+//          no money, and no reason to go and find an adult. The biggest control
+//          takes them back to the other games, which are all still open.
+//   gate   an adult, proving it. Reading load, never arithmetic — this is a
+//          maths app and a multiplication problem is a gate the audience is
+//          being trained to defeat (see `parentalGate.ts`).
+//   offer  an adult. Three prices, no subscription, no scarcity, no countdown,
+//          no default selected, and "Not now" is one tap from anywhere.
+//
+// ── What is banned here, permanently ─────────────────────────────────────────
+// No timer or countdown of any kind. No "N plays left". No "your friends are
+// playing". No "today only". No interstitial that must be watched. No
+// pre-selected plan. No copy that frames stopping as a loss. `pass.test.ts`
+// holds the copy against a word list so the ban is mechanical rather than
+// remembered.
+//
+// The CSP is `style-src 'self'`, so there is no `style` prop anywhere below —
+// an inline style works in `vite dev` and is silently dropped in the shipped
+// build, which is the worst failure mode available.
+
+import { useEffect, useMemo, useRef, useState } from "react"
+
+import { fill, strings } from "../app/strings.ts"
+import { IndexMark } from "../design/IndexMark.tsx"
+import { billing, FALLBACK_PRODUCTS, type PassProduct } from "./billing.ts"
+import { makeChallenge, passes, type Challenge } from "./parentalGate.ts"
+import { buyPass, restorePasses } from "./store.ts"
+
+type Stage = "rest" | "gate" | "offer"
+
+export type PassSheetProps = {
+  /** The game that just ended, by its own name. Never an id. */
+  readonly packName: string
+  /** Close the sheet and go back to the other games. Always one tap away. */
+  readonly onLeave: () => void
+}
+
+/** The panel every stage is drawn in. One shape, so the sheet does not jump. */
+function Panel({
+  labelId,
+  children,
+}: {
+  readonly labelId: string
+  readonly children: React.ReactNode
+}) {
+  return (
+    <div className="bg-ground-deep/85 fixed inset-0 z-[var(--z-modal)] flex items-center justify-center p-[var(--dw-frame-pad)] backdrop-blur-sm">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={labelId}
+        className="bg-ground border-line-strong rounded-cut-lg max-h-[var(--dialog-max-h)] w-full max-w-md overflow-y-auto border p-[var(--dw-surface-pad)]"
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Stage one. A child reads this and nothing else.
+ *
+ * "That's FUSE for today" is a statement about a game that ended, not about
+ * what has been withheld. The second line is the important one and it is true:
+ * every other game is open, and the child is being pointed at them rather than
+ * at a shop.
+ */
+function Rest({
+  packName,
+  onLeave,
+  onGrownUps,
+}: {
+  readonly packName: string
+  readonly onLeave: () => void
+  readonly onGrownUps: () => void
+}) {
+  const leave = useRef<HTMLButtonElement | null>(null)
+  useEffect(() => leave.current?.focus(), [])
+
+  return (
+    <Panel labelId="pass-rest-title">
+      <h2
+        id="pass-rest-title"
+        className="inscription text-ink text-2xl tracking-wide text-balance"
+      >
+        {fill(strings.pass.restTitle, { pack: packName })}
+      </h2>
+      <p className="text-ink-muted mt-2 text-base">{strings.pass.restBody}</p>
+
+      <button
+        ref={leave}
+        type="button"
+        onClick={onLeave}
+        className="border-line-cut bg-ground-raised text-ink rounded-cut-md hover:bg-ground-sunk mt-[var(--dw-stack-gap)] flex min-h-16 w-full items-center justify-center gap-3 border text-lg transition-colors duration-[var(--dw-motion-quick)]"
+      >
+        <IndexMark className="text-index" />
+        <span className="inscription tracking-wide">{strings.pass.restLeave}</span>
+      </button>
+
+      {/* Small, plain, and at the bottom. A child is not being sent for a
+          grown-up; an adult who wants the prices knows where they are. */}
+      <button
+        type="button"
+        onClick={onGrownUps}
+        className="text-ink-muted mt-[var(--dw-stack-gap-tight)] min-h-11 w-full text-sm underline underline-offset-4"
+      >
+        {strings.pass.forGrownUps}
+      </button>
+    </Panel>
+  )
+}
+
+/** Stage two. Nothing about a price is rendered until this returns true. */
+function Gate({
+  onPassed,
+  onCancel,
+}: {
+  readonly onPassed: () => void
+  readonly onCancel: () => void
+}) {
+  // One challenge per mounting, made once. Regenerating it on every keystroke
+  // would move the question while an adult is answering it.
+  const [challenge, setChallenge] = useState<Challenge>(() => makeChallenge())
+  const [typed, setTyped] = useState("")
+  const [wrong, setWrong] = useState(false)
+  const field = useRef<HTMLInputElement | null>(null)
+  useEffect(() => field.current?.focus(), [])
+
+  const submit = (event: React.FormEvent) => {
+    event.preventDefault()
+    if (passes(challenge, typed)) {
+      onPassed()
+      return
+    }
+    // A new challenge on every miss: repeating the same one turns the gate into
+    // something a child defeats by guessing twice.
+    setWrong(true)
+    setTyped("")
+    setChallenge(makeChallenge())
+  }
+
+  return (
+    <Panel labelId="pass-gate-title">
+      <h2 id="pass-gate-title" className="inscription text-ink text-xl tracking-wide">
+        {strings.pass.gateTitle}
+      </h2>
+
+      <form onSubmit={submit} className="mt-[var(--dw-stack-gap-tight)]">
+        <label htmlFor="pass-gate-entry" className="text-ink block text-base">
+          {challenge.kind === "year" ? strings.pass.gateYear : strings.pass.gateWord}
+        </label>
+        {challenge.kind === "word" ? (
+          <p className="inscription text-ink mt-2 text-3xl tracking-[0.12em] break-all">
+            {challenge.word}
+          </p>
+        ) : null}
+
+        <input
+          id="pass-gate-entry"
+          ref={field}
+          type="text"
+          value={typed}
+          onChange={(event) => setTyped(event.target.value)}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="characters"
+          spellCheck={false}
+          aria-label={strings.pass.gateEntry}
+          aria-invalid={wrong}
+          className="numeral border-line-cut bg-ground-raised text-ink rounded-cut-sm mt-[var(--dw-stack-gap-tight)] min-h-16 w-full border px-4 text-2xl tracking-widest"
+        />
+
+        {wrong ? (
+          <p role="alert" className="text-strike mt-2 text-sm">
+            {strings.pass.gateWrong}
+          </p>
+        ) : null}
+
+        <button
+          type="submit"
+          className="border-line-cut bg-ground-raised text-ink rounded-cut-md hover:bg-ground-sunk mt-[var(--dw-stack-gap-tight)] min-h-16 w-full border text-lg transition-colors duration-[var(--dw-motion-quick)]"
+        >
+          <span className="inscription tracking-wide">{strings.pass.gateGo}</span>
+        </button>
+      </form>
+
+      <button
+        type="button"
+        onClick={onCancel}
+        className="text-ink-muted mt-[var(--dw-stack-gap-tight)] min-h-11 w-full text-sm underline underline-offset-4"
+      >
+        {strings.pass.notNow}
+      </button>
+    </Panel>
+  )
+}
+
+/** One pass, as a plate. The lifetime plate is the loud one; nothing else is. */
+function Plate({
+  name,
+  note,
+  price,
+  headline,
+  onBuy,
+}: {
+  readonly name: string
+  readonly note: string
+  readonly price: string
+  readonly headline: boolean
+  readonly onBuy: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onBuy}
+      className={[
+        "rounded-cut-md flex min-h-20 w-full items-center gap-4 border p-4 text-left",
+        "transition-colors duration-[var(--dw-motion-quick)] hover:bg-ground-sunk",
+        // The headline is carried by the frame and the type size, not by a
+        // badge, a banner, a "best value" flag or a struck-through price.
+        headline
+          ? "border-index bg-ground-raised border-2"
+          : "border-line-cut bg-ground",
+      ].join(" ")}
+    >
+      <span className="min-w-0 flex-1">
+        <span
+          className={[
+            "inscription text-ink block tracking-wide",
+            headline ? "text-2xl" : "text-lg",
+          ].join(" ")}
+        >
+          {name}
+        </span>
+        <span className="text-ink-muted block text-sm">{note}</span>
+      </span>
+      <span
+        className={[
+          "numeral text-ink shrink-0",
+          headline ? "text-2xl" : "text-lg",
+        ].join(" ")}
+      >
+        {price}
+      </span>
+    </button>
+  )
+}
+
+/** Stage three. An adult, three prices, and no pressure of any kind. */
+function Offer({ onClose }: { readonly onClose: () => void }) {
+  const [products, setProducts] = useState<readonly PassProduct[]>(FALLBACK_PRODUCTS)
+  const [failed, setFailed] = useState(false)
+  const [held, setHeld] = useState(false)
+
+  useEffect(() => {
+    let live = true
+    billing()
+      .products()
+      .then((list) => {
+        if (live && list.length > 0) setProducts(list)
+      })
+      .catch((error: unknown) => {
+        console.error("[pass] the product list could not be read", error)
+      })
+    return () => {
+      live = false
+    }
+  }, [])
+
+  const by = useMemo(
+    () => new Map(products.map((product) => [product.kind, product])),
+    [products],
+  )
+
+  const buy = (productId: string | undefined) => {
+    if (productId === undefined) return
+    setFailed(false)
+    void buyPass(productId).then((outcome) => {
+      if (outcome.status === "granted") {
+        setHeld(true)
+        onClose()
+        return
+      }
+      // A cancellation is a parent changing their mind, which is not a failure
+      // and is never reported as one.
+      if (outcome.status !== "cancelled") setFailed(true)
+    })
+  }
+
+  return (
+    <Panel labelId="pass-offer-title">
+      <h2 id="pass-offer-title" className="inscription text-ink text-2xl tracking-wide">
+        {strings.pass.offerTitle}
+      </h2>
+      <p className="text-ink-muted mt-2 text-base">{strings.pass.offerBody}</p>
+
+      {/* Lifetime first and largest. It is the one-time purchase, it is the
+          cheapest way to own this outright, and a parent who hates
+          subscriptions should not have to scroll past two of them to find it. */}
+      <div className="mt-[var(--dw-stack-gap)] flex flex-col gap-[var(--dw-stack-gap-tight)]">
+        <Plate
+          headline
+          name={strings.pass.lifetime}
+          note={strings.pass.lifetimeNote}
+          price={by.get("lifetime")?.price ?? ""}
+          onBuy={() => buy(by.get("lifetime")?.productId)}
+        />
+        <Plate
+          headline={false}
+          name={strings.pass.month}
+          note={strings.pass.monthNote}
+          price={by.get("month")?.price ?? ""}
+          onBuy={() => buy(by.get("month")?.productId)}
+        />
+        <Plate
+          headline={false}
+          name={strings.pass.day}
+          note={strings.pass.dayNote}
+          price={by.get("day")?.price ?? ""}
+          onBuy={() => buy(by.get("day")?.productId)}
+        />
+      </div>
+
+      {failed ? (
+        <p role="alert" className="text-strike mt-[var(--dw-stack-gap-tight)] text-sm">
+          {strings.pass.storeUnavailable}
+        </p>
+      ) : null}
+      {held ? (
+        <p className="text-seat mt-[var(--dw-stack-gap-tight)] text-sm">{strings.pass.held}</p>
+      ) : null}
+
+      <div className="mt-[var(--dw-stack-gap)] flex flex-wrap items-center justify-between gap-3">
+        <button
+          type="button"
+          onClick={() => {
+            setFailed(false)
+            void restorePasses().then((outcome) => {
+              if (outcome.status === "granted") {
+                setHeld(true)
+                onClose()
+              } else if (outcome.status !== "cancelled") setFailed(true)
+            })
+          }}
+          className="text-ink-muted min-h-11 text-sm underline underline-offset-4"
+        >
+          {strings.pass.restore}
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="border-line-cut text-ink rounded-cut-sm min-h-11 border px-4 text-sm"
+        >
+          {strings.pass.notNow}
+        </button>
+      </div>
+    </Panel>
+  )
+}
+
+/**
+ * The sheet.
+ *
+ * Escape closes it from any stage, the same as "Not now" and the same as
+ * "Choose another game": there is no stage of this thing a person can be stuck
+ * in, and no stage where the way out is hidden behind a delay.
+ */
+export function PassSheet({ packName, onLeave }: PassSheetProps) {
+  const [stage, setStage] = useState<Stage>("rest")
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onLeave()
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [onLeave])
+
+  if (stage === "gate") {
+    return <Gate onPassed={() => setStage("offer")} onCancel={onLeave} />
+  }
+  if (stage === "offer") return <Offer onClose={onLeave} />
+  return <Rest packName={packName} onLeave={onLeave} onGrownUps={() => setStage("gate")} />
+}

--- a/dynawalla/dynawalla-app/src/pass/billing.ts
+++ b/dynawalla/dynawalla-app/src/pass/billing.ts
@@ -1,0 +1,151 @@
+// The seam StoreKit and Play Billing will land behind. **No billing is
+// implemented here and none is faked.**
+//
+// Everything above this file — the sheet, the parental gate, the ledger, the
+// entitlement — is finished and testable without a store account, a signing
+// identity or a network. Everything below it is one implementation of one
+// interface with three methods. That is the whole point of the split: the
+// product decision (a day pass, not a subscription) is settled and shipped,
+// and the platform work is a swap of `setBilling`.
+//
+// **The default implementation charges nobody and grants nothing.** It reports
+// `unavailable`, which the sheet renders as "not on this device yet". A stub
+// that pretended to succeed would put a fake receipt into durable storage on a
+// child's tablet, and the first real store query would then have to argue with
+// it.
+//
+// Prices are here as a **fallback catalogue only**. A shipping build reads the
+// localised price string from the store, because $7.99 is not what a family in
+// Delhi is charged and is not what their store shows them. The strings below
+// are what the sheet draws when there is no store to ask — a US default, and
+// visibly the founder's list rather than a computation.
+
+import type { Pass, PassKind } from "./model.ts"
+import { DAY_PASS_MS, MONTH_PASS_MS } from "./model.ts"
+
+/**
+ * One thing a family can buy.
+ *
+ * `productId` is the store SKU and it is **immutable once submitted** — a
+ * renamed product id is a new product with no history and no restores, in both
+ * stores. Written here once so nothing derives one from a display string.
+ */
+export type PassProduct = {
+  readonly kind: PassKind
+  readonly productId: string
+  /** Localised, from the store. The fallback below is a US default. */
+  readonly price: string
+}
+
+/** The founder's list. Three prices, no tiers, no trial, no introductory rate. */
+export const FALLBACK_PRODUCTS: readonly PassProduct[] = [
+  { kind: "day", productId: "inc.corpora.dynawalla.pass.day", price: "$0.99" },
+  { kind: "month", productId: "inc.corpora.dynawalla.pass.month", price: "$7.99" },
+  { kind: "lifetime", productId: "inc.corpora.dynawalla.pass.lifetime", price: "$79.99" },
+]
+
+export function productFor(kind: PassKind): PassProduct {
+  const found = FALLBACK_PRODUCTS.find((product) => product.kind === kind)
+  if (!found) throw new RangeError(`no product for pass kind ${kind}`)
+  return found
+}
+
+export type PurchaseOutcome =
+  /** The store confirmed it. `pass` is what goes into durable storage. */
+  | { readonly status: "granted"; readonly pass: Pass }
+  /** The parent closed the store sheet. Not an error, and never reported as one. */
+  | { readonly status: "cancelled" }
+  /**
+   * The store said, online and unambiguously, that this device owns nothing.
+   * **The only thing that may ever take a pass away.** Anything inconclusive —
+   * a timeout, an offline device, a rejected bridge — is `unavailable`.
+   */
+  | { readonly status: "not_owned" }
+  /** Could not ask. Keeps whatever is already held; never downgrades. */
+  | { readonly status: "unavailable"; readonly detail: string }
+
+/**
+ * The three calls a platform has to answer. Anything a store does that is not
+ * one of these is not something this product needs.
+ */
+export interface PassBilling {
+  /** The catalogue, with localised prices. */
+  products(): Promise<readonly PassProduct[]>
+  /** Buy one. Resolves; never throws for a cancellation. */
+  buy(productId: string): Promise<PurchaseOutcome>
+  /**
+   * Restore. Required by both stores for a non-consumable, and the thing a
+   * parent reaches for on a second tablet.
+   */
+  restore(): Promise<PurchaseOutcome>
+}
+
+/**
+ * The expiry a pass of this kind would have, bought now.
+ *
+ * Used **only** by a billing implementation that has no store expiry to quote —
+ * the developer grant below, and nothing else. A real receipt carries its own
+ * date and that date wins.
+ */
+export function expiryFor(kind: PassKind, now: number): number | null {
+  switch (kind) {
+    case "lifetime":
+      return null
+    case "day":
+      return now + DAY_PASS_MS
+    case "month":
+      return now + MONTH_PASS_MS
+  }
+}
+
+/** What ships until a platform lands. Honest about doing nothing. */
+export const unwiredBilling: PassBilling = {
+  products: () => Promise.resolve(FALLBACK_PRODUCTS),
+  buy: () =>
+    Promise.resolve({
+      status: "unavailable",
+      detail: "no store is wired into this build",
+    } as const),
+  restore: () =>
+    Promise.resolve({
+      status: "unavailable",
+      detail: "no store is wired into this build",
+    } as const),
+}
+
+let current: PassBilling = unwiredBilling
+
+/** Install a platform. Called once, at launch, by whoever owns the native side. */
+export function setBilling(billing: PassBilling): void {
+  current = billing
+}
+
+export function billing(): PassBilling {
+  return current
+}
+
+/**
+ * A billing that grants without charging, for developer mode and for tests.
+ *
+ * Exported rather than hidden: verifying "a purchase unlocks everything, and
+ * midnight does not take it away" needs a way to hold a pass, and a developer
+ * with no way to do that will find a worse one. It is reachable only from the
+ * developer rows in the parent area, which are off by default and off on every
+ * child's tablet.
+ */
+export function grantingBilling(clock: () => number = Date.now): PassBilling {
+  const grant = (productId: string): PurchaseOutcome => {
+    const product = FALLBACK_PRODUCTS.find((entry) => entry.productId === productId)
+    if (!product) return { status: "unavailable", detail: `no such product ${productId}` }
+    const now = clock()
+    return {
+      status: "granted",
+      pass: { kind: product.kind, expiresAt: expiryFor(product.kind, now), confirmedAt: now },
+    }
+  }
+  return {
+    products: () => Promise.resolve(FALLBACK_PRODUCTS),
+    buy: (productId) => Promise.resolve(grant(productId)),
+    restore: () => Promise.resolve(grant(FALLBACK_PRODUCTS[2]?.productId ?? "")),
+  }
+}

--- a/dynawalla/dynawalla-app/src/pass/model.ts
+++ b/dynawalla/dynawalla-app/src/pass/model.ts
@@ -1,0 +1,181 @@
+// The day pass, as arithmetic on a clock and a list. No store, no React, no
+// DOM — every rule below is decided in a Node test.
+//
+// The model, in one paragraph. **Every game is free to play.** Nothing is
+// locked, nothing is badged, and no game is ever refused at the door on a
+// first visit. When a game reaches a *natural stopping point* it says so
+// (`session.transition`), and the first time that happens for a given game on
+// a given day, that game rests until tomorrow. One gate per game per day, so a
+// child who runs out of FUSE can go and find SIEGE — which is the entire point
+// of the shape: unlimited discovery, bounded repetition, and the boundary is a
+// place in the game rather than a number of minutes.
+//
+// **There is no timer in this file and there is none anywhere else.** A
+// countdown is the mechanism this model exists to replace: it interrupts, it is
+// visible, it makes a child watch a clock instead of a game, and it turns the
+// stopping point into something imposed rather than something reached.
+//
+// ── The one asymmetry that matters ───────────────────────────────────────────
+// A wrongly-open pass costs a dollar. A wrongly-closed pass tells a family that
+// already paid that they did not. Everything below resolves ties towards open:
+// a month pass survives its recorded expiry by a grace window because a renewal
+// is a fact only the store knows and the store is not always reachable, and a
+// lifetime pass is never re-examined at all. Corpán learned this the expensive
+// way and the policy is copied verbatim from
+// `corpan/corpan-app/src/store/entitlements.ts`.
+
+/** What a family can buy. Three, and never more: a price list is not a menu. */
+export type PassKind = "day" | "month" | "lifetime"
+
+export const PASS_KINDS: readonly PassKind[] = ["day", "month", "lifetime"]
+
+export function isPassKind(value: unknown): value is PassKind {
+  return value === "day" || value === "month" || value === "lifetime"
+}
+
+/**
+ * A pass this device holds.
+ *
+ * `expiresAt` is what the *store* said, not what this app computed, for
+ * everything except the fallback below: an app that decides its own expiry is
+ * an app whose clock is the thing a family has to be right about.
+ */
+export type Pass = {
+  readonly kind: PassKind
+  /** Epoch ms. `null` means it does not expire — a lifetime pass. */
+  readonly expiresAt: number | null
+  /** Epoch ms of the last time a store confirmed this. A hint, never a gate. */
+  readonly confirmedAt: number
+}
+
+/**
+ * How long past its recorded expiry a **month** pass keeps working.
+ *
+ * A monthly renewal happens at the store, and this app finds out about it by
+ * asking — on a tablet in a car, in a house with the router off, on a plane.
+ * Forty-eight hours of slack is the difference between "we could not check" and
+ * "you did not pay", and only one of those is a thing to tell a child.
+ *
+ * A **day** pass gets none of this. Its expiry needs no round trip — it was
+ * bought once, for one day, and extending it would make it a three-day pass.
+ */
+export const RENEWAL_GRACE_MS = 48 * 60 * 60 * 1000
+
+/** Milliseconds a day pass runs for, when the seam has to compute one itself. */
+export const DAY_PASS_MS = 24 * 60 * 60 * 1000
+/** Milliseconds a month pass runs for, likewise. */
+export const MONTH_PASS_MS = 30 * DAY_PASS_MS
+
+/**
+ * Whether a pass is open right now.
+ *
+ * Total and pure. The only place in the app that answers this question, so
+ * "did they pay" has one implementation rather than one per surface.
+ */
+export function passIsOpen(pass: Pass | null | undefined, now: number): boolean {
+  if (!pass) return false
+  // Bought once. Never re-examined, never expired, never quietly withdrawn by
+  // a clock. Only a definitive, online "you do not own this" clears it, and
+  // that decision lives in the billing seam rather than here.
+  if (pass.kind === "lifetime") return true
+  if (pass.expiresAt === null) return true
+  const grace = pass.kind === "month" ? RENEWAL_GRACE_MS : 0
+  return now < pass.expiresAt + grace
+}
+
+// ── The day, and what rested in it ───────────────────────────────────────────
+
+/**
+ * The calendar day, in the device's own timezone, as `YYYY-MM-DD`.
+ *
+ * Local rather than UTC on purpose: "tomorrow" means the next time this child
+ * wakes up, and a UTC boundary puts that at 4pm for a family in California and
+ * at 8am for one in Delhi. A device whose clock is wrong gets the day its owner
+ * believes it is, which is the answer that will not confuse anybody.
+ */
+export function dayKey(now: number): string {
+  const date = new Date(now)
+  const month = `${date.getMonth() + 1}`.padStart(2, "0")
+  const day = `${date.getDate()}`.padStart(2, "0")
+  return `${date.getFullYear()}-${month}-${day}`
+}
+
+/**
+ * Which games have already had their stopping point today.
+ *
+ * One day at a time: the record is thrown away and rebuilt at the boundary
+ * rather than accumulating, so nothing here grows without bound and there is
+ * no history of a child's play to leak. Yesterday is not interesting and is
+ * not kept.
+ */
+export type RestLedger = {
+  readonly day: string
+  /** Pack ids that reached a stopping point on `day`. Sorted, unique. */
+  readonly resting: readonly string[]
+}
+
+export const EMPTY_LEDGER: RestLedger = { day: "", resting: [] }
+
+/** The ledger as of `day`, cleared if the day turned over. Midnight, exactly. */
+export function ledgerOn(ledger: RestLedger, day: string): RestLedger {
+  return ledger.day === day ? ledger : { day, resting: [] }
+}
+
+export function isResting(ledger: RestLedger, packId: string, day: string): boolean {
+  return ledger.day === day && ledger.resting.includes(packId)
+}
+
+export function markResting(ledger: RestLedger, packId: string, day: string): RestLedger {
+  const today = ledgerOn(ledger, day)
+  if (today.resting.includes(packId)) return today
+  return { day, resting: [...today.resting, packId].sort() }
+}
+
+// ── The decision ─────────────────────────────────────────────────────────────
+
+/**
+ * What the host does when a pack says it reached a natural stopping point.
+ *
+ * `play-on` is the overwhelmingly common answer and it is the one that costs
+ * nothing: a family with a pass, and a child who already stopped somewhere in
+ * this game today, both keep playing with nothing on the screen.
+ */
+export type TransitionVerdict =
+  /** Nothing happens. The game keeps running and the child sees no interruption. */
+  | "play-on"
+  /** First stopping point today for this game: it rests, and the sheet opens. */
+  | "rest"
+
+export type TransitionInput = {
+  readonly packId: string
+  readonly pass: Pass | null
+  readonly ledger: RestLedger
+  readonly now: number
+}
+
+export function verdictFor(input: TransitionInput): TransitionVerdict {
+  if (passIsOpen(input.pass, input.now)) return "play-on"
+  const day = dayKey(input.now)
+  // Already stopped here today. A second sheet in one game in one day is a
+  // pack asking twice, and the answer to being asked twice is silence.
+  if (isResting(input.ledger, input.packId, day)) return "play-on"
+  return "rest"
+}
+
+/**
+ * Whether this game may be started at all right now.
+ *
+ * Distinct from the verdict above, and the difference is the whole feel of the
+ * thing: a game is *never* refused because it has not been paid for, only
+ * because this device already reached its ending today. On a fresh day, with no
+ * pass and nothing bought, every installed game answers `true`.
+ */
+export function canOpen(input: {
+  readonly packId: string
+  readonly pass: Pass | null
+  readonly ledger: RestLedger
+  readonly now: number
+}): boolean {
+  if (passIsOpen(input.pass, input.now)) return true
+  return !isResting(input.ledger, input.packId, dayKey(input.now))
+}

--- a/dynawalla/dynawalla-app/src/pass/parentalGate.test.ts
+++ b/dynawalla/dynawalla-app/src/pass/parentalGate.test.ts
@@ -1,0 +1,92 @@
+// The parental gate, and the one property that makes it a gate *here*.
+//
+// Apple's canonical gate is a multiplication problem. This is a mathematics
+// app for grades 1–6, so the audience is being trained daily to defeat exactly
+// that challenge — a grade-4 child beats their parent to `6 × 7` and the gate
+// has taught them that solving sums opens the money screen. `no arithmetic` is
+// therefore a test, not a comment.
+
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { GATE_WORDS, makeChallenge, passes } from "./parentalGate.ts"
+
+/** A generator that walks a fixed sequence, so a test is a test not a coin toss. */
+function sequence(values: readonly number[]): () => number {
+  let index = 0
+  return () => values[index++ % values.length] ?? 0
+}
+
+test("the challenge is never arithmetic", () => {
+  // Every challenge this thing can produce, checked for anything a child could
+  // solve by doing sums: an operator, an equals sign, a pair of operands.
+  for (let i = 0; i < 200; i++) {
+    const challenge = makeChallenge()
+    const shown = challenge.kind === "word" ? challenge.word : challenge.answer
+    assert.ok(!/[+\-×÷*/=]/.test(shown), `the gate showed an operator: ${shown}`)
+  }
+})
+
+test("the year challenge asks for the current year", () => {
+  const now = new Date(2026, 6, 26).getTime()
+  const challenge = makeChallenge(sequence([0.1]), now)
+  assert.equal(challenge.kind, "year")
+  assert.equal(challenge.answer, "2026")
+})
+
+test("the word challenge shows the word it wants", () => {
+  const challenge = makeChallenge(sequence([0.9, 0]))
+  assert.equal(challenge.kind, "word")
+  if (challenge.kind !== "word") return
+  assert.equal(challenge.answer, challenge.word)
+})
+
+test("every gate word is long, uppercase and not curricular", () => {
+  for (const word of GATE_WORDS) {
+    // Reading and typing load is the whole barrier, and short words do not
+    // carry it: TELEVISION was in the first draft of this list and a
+    // nine-year-old types it without hesitating. Thirteen letters is the floor.
+    assert.ok(word.length >= 13, `${word} is too short to be a barrier`)
+    assert.equal(word, word.toUpperCase(), `${word} is not uppercase`)
+    assert.ok(/^[A-Z]+$/.test(word), `${word} is not plain letters`)
+    // Nothing a maths app has been teaching: no number names, no shapes.
+    assert.ok(
+      !/^(ONE|TWO|THREE|FOUR|FIVE|SIX|SEVEN|EIGHT|NINE|TEN|HUNDRED|THOUSAND|TRIANGLE|RECTANGLE|MULTIPLY|SUBTRACT|FRACTION)$/.test(
+        word,
+      ),
+      `${word} is curriculum`,
+    )
+  }
+  assert.equal(new Set(GATE_WORDS).size, GATE_WORDS.length, "a word is repeated")
+})
+
+test("an adult who types it in lower case is let through", () => {
+  // They have demonstrated everything the gate exists to demonstrate.
+  // Rejecting them teaches nobody anything and sends them to the app store.
+  const challenge = makeChallenge(sequence([0.9, 0]))
+  if (challenge.kind !== "word") return
+  assert.equal(passes(challenge, challenge.word.toLowerCase()), true)
+  assert.equal(passes(challenge, `  ${challenge.word}  `), true)
+})
+
+test("a near miss does not pass", () => {
+  const challenge = makeChallenge(sequence([0.1]), new Date(2026, 0, 1).getTime())
+  assert.equal(passes(challenge, "2025"), false)
+  assert.equal(passes(challenge, ""), false)
+  assert.equal(passes(challenge, "20 26"), false)
+})
+
+test("both forms are reachable", () => {
+  // A single fixed form is a single thing to memorise.
+  const kinds = new Set<string>()
+  for (let i = 0; i < 400; i++) kinds.add(makeChallenge().kind)
+  assert.deepEqual([...kinds].sort(), ["word", "year"])
+})
+
+test("nothing about a challenge is persisted", () => {
+  // Two calls, two challenges. There is no module state to leak a passed gate
+  // into the next sheet, and a tablet left unlocked does not stay unlocked.
+  const first = makeChallenge(sequence([0.9, 0.1]))
+  const second = makeChallenge(sequence([0.9, 0.6]))
+  assert.notDeepEqual(first, second)
+})

--- a/dynawalla/dynawalla-app/src/pass/parentalGate.ts
+++ b/dynawalla/dynawalla-app/src/pass/parentalGate.ts
@@ -1,0 +1,96 @@
+// The parental gate: the challenge, generated and checked. No DOM.
+//
+// Apple's Kids Category and Play's Families Policy both require one in front of
+// a purchase flow, and this product needs one in front of the **price display**
+// as well (ADR-0013) — a child at a natural stopping point sees no money at
+// all until an adult is holding the tablet.
+//
+// **The challenge is never arithmetic, and here that is not a preference.**
+// Apple's canonical gate is a multiplication problem. This is a mathematics app
+// for grades 1–6. A child who has been practising `6 × 7` for a week beats
+// their parent to it, and a gate the audience is being trained to defeat is not
+// a gate. `noArithmetic` below is a test, not a comment.
+//
+// What is left is **reading and typing load**, which is the real asymmetry
+// between a six-year-old and an adult:
+//
+//   * `year`   — "Enter the current four-digit year." Requires knowing it.
+//   * `word`   — a long, ordinary, multi-syllable word to copy out. Requires
+//                reading and typing thirteen letters without losing the place.
+//
+// Randomized per presentation and **never persisted**: nothing about a passed
+// gate survives the sheet closing, so a child cannot learn one answer, and a
+// tablet left unlocked does not stay unlocked.
+
+export type Challenge =
+  | { readonly kind: "year"; readonly answer: string }
+  | { readonly kind: "word"; readonly word: string; readonly answer: string }
+
+/**
+ * The words.
+ *
+ * Every one is **thirteen letters or more, four syllables or more, and not a
+ * word a primary-school child has any reason to have typed before.** That
+ * combination is the barrier, and each part of it is doing work: length makes
+ * it a transcription task rather than a recognition one, and unfamiliarity
+ * means it cannot be typed from memory after the first glance.
+ *
+ * Rejected as too easy, and worth recording so they do not come back:
+ * TELEVISION, UNIVERSITY, HELICOPTERS, WATERMELONS. A nine-year-old reads and
+ * types all four without hesitating, which makes them decoration.
+ *
+ * Deliberately **not** curricular — no number words, no shape names, no
+ * operations, nothing a maths app has spent a week teaching.
+ */
+export const GATE_WORDS: readonly string[] = [
+  "ACCOMMODATION",
+  "ADMINISTRATIVE",
+  "CIRCUMSTANTIAL",
+  "CORRESPONDENCE",
+  "DETERMINATION",
+  "EXTRAORDINARY",
+  "INFRASTRUCTURE",
+  "INTERNATIONAL",
+  "JURISDICTIONAL",
+  "MANUFACTURING",
+  "PARTICIPATION",
+  "PHILOSOPHICAL",
+  "PROFESSIONALLY",
+  "RECONSTRUCTED",
+  "REPRESENTATIVE",
+  "THERMODYNAMICS",
+  "TRANSPORTATION",
+  "UNPRECEDENTED",
+]
+
+/**
+ * Build a challenge.
+ *
+ * `random` and `now` are injected so the test is a test rather than a coin
+ * toss. In the app both are the real ones.
+ */
+export function makeChallenge(
+  random: () => number = Math.random,
+  now: number = Date.now(),
+): Challenge {
+  // Two forms, roughly evenly. Two rather than one because a single fixed form
+  // is a single thing to memorise, and the year is the one an adult answers
+  // instantly while being the one a young child is least likely to know.
+  if (random() < 0.5) {
+    return { kind: "year", answer: String(new Date(now).getFullYear()) }
+  }
+  const index = Math.min(GATE_WORDS.length - 1, Math.floor(random() * GATE_WORDS.length))
+  const word = GATE_WORDS[index] ?? GATE_WORDS[0] ?? "TRANSMISSION"
+  return { kind: "word", word, answer: word }
+}
+
+/**
+ * Whether what was typed passes.
+ *
+ * Case-insensitive and whitespace-trimmed: an adult who types `refrigerator`
+ * into a field showing `REFRIGERATOR` has demonstrated everything the gate is
+ * there to demonstrate, and rejecting them teaches nobody anything.
+ */
+export function passes(challenge: Challenge, typed: string): boolean {
+  return typed.trim().toUpperCase() === challenge.answer.toUpperCase()
+}

--- a/dynawalla/dynawalla-app/src/pass/pass.test.ts
+++ b/dynawalla/dynawalla-app/src/pass/pass.test.ts
@@ -1,0 +1,323 @@
+// The day pass, proved rather than described.
+//
+// Three things are held here and they are the three that would be expensive to
+// get wrong on a family's tablet:
+//
+//   1. **A full day, simulated.** Play a game to its stopping point, see the
+//      sheet, dismiss it, play a different game, confirm the first rests and
+//      the second does not, buy a pass, confirm everything opens, and roll the
+//      clock past midnight and confirm the free day comes back.
+//   2. **Nobody who paid is ever blocked.** Including offline, including with a
+//      renewal this app could not verify.
+//   3. **There is no timer, and the copy contains no pressure.** Mechanically,
+//      by reading the source and the strings, so "we would notice" is not the
+//      control.
+
+import test from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { strings } from "../app/strings.ts"
+import { expiryFor, FALLBACK_PRODUCTS, grantingBilling, productFor } from "./billing.ts"
+import {
+  canOpen,
+  dayKey,
+  EMPTY_LEDGER,
+  isResting,
+  ledgerOn,
+  markResting,
+  passIsOpen,
+  RENEWAL_GRACE_MS,
+  verdictFor,
+  type Pass,
+  type RestLedger,
+} from "./model.ts"
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+
+/** A fixed instant, mid-afternoon, so a day boundary is never a rounding away. */
+const NOON = new Date(2026, 6, 26, 14, 30, 0).getTime()
+const HOUR = 60 * 60 * 1000
+
+const lifetime: Pass = { kind: "lifetime", expiresAt: null, confirmedAt: NOON }
+const dayPass: Pass = { kind: "day", expiresAt: NOON + 24 * HOUR, confirmedAt: NOON }
+const monthPass: Pass = { kind: "month", expiresAt: NOON + 30 * 24 * HOUR, confirmedAt: NOON }
+
+// ── Every game is free, and the gate is a place, not a clock ─────────────────
+
+test("on a cold device with nothing bought, every game opens", () => {
+  // The single most important property of the model. Discovery is unlimited:
+  // a child can try all of them, which is how they find the one they love.
+  for (const packId of ["dynawalla.fuse", "dynawalla.siege", "dynawalla.forge"]) {
+    assert.equal(
+      canOpen({ packId, pass: null, ledger: EMPTY_LEDGER, now: NOON }),
+      true,
+      `${packId} was refused on a cold device`,
+    )
+  }
+})
+
+test("the first stopping point rests that game and only that game", () => {
+  let ledger: RestLedger = EMPTY_LEDGER
+
+  const first = verdictFor({ packId: "dynawalla.fuse", pass: null, ledger, now: NOON })
+  assert.equal(first, "rest")
+  ledger = markResting(ledger, "dynawalla.fuse", dayKey(NOON))
+
+  // FUSE is finished for today…
+  assert.equal(canOpen({ packId: "dynawalla.fuse", pass: null, ledger, now: NOON }), false)
+  // …and SIEGE has not been touched. This is the whole point of one gate per
+  // game per day: a child who runs out of one goes and finds another.
+  assert.equal(canOpen({ packId: "dynawalla.siege", pass: null, ledger, now: NOON }), true)
+})
+
+test("a second stopping point in a rested game shows nothing", () => {
+  // Reachable only if a pack is mounted anyway. The answer to being asked
+  // twice is silence, never a second sheet.
+  const ledger = markResting(EMPTY_LEDGER, "dynawalla.fuse", dayKey(NOON))
+  assert.equal(verdictFor({ packId: "dynawalla.fuse", pass: null, ledger, now: NOON }), "play-on")
+})
+
+test("midnight gives the day back", () => {
+  const ledger = markResting(EMPTY_LEDGER, "dynawalla.fuse", dayKey(NOON))
+  const tomorrow = new Date(2026, 6, 27, 8, 0, 0).getTime()
+
+  assert.notEqual(dayKey(NOON), dayKey(tomorrow))
+  assert.equal(canOpen({ packId: "dynawalla.fuse", pass: null, ledger, now: tomorrow }), true)
+  // And the record is thrown away rather than accumulated — nothing here grows
+  // without bound and no history of a child's play is kept.
+  assert.deepEqual(ledgerOn(ledger, dayKey(tomorrow)), { day: dayKey(tomorrow), resting: [] })
+})
+
+test("the day boundary is local midnight, not UTC", () => {
+  // A UTC boundary puts "tomorrow" at 4pm for a family in California. The key
+  // is built from the device's own calendar fields, so 23:59 and 00:01 on the
+  // same night are two different days wherever the tablet is.
+  const lateTonight = new Date(2026, 6, 26, 23, 59, 0).getTime()
+  const justAfter = new Date(2026, 6, 27, 0, 1, 0).getTime()
+  assert.equal(dayKey(lateTonight), "2026-07-26")
+  assert.equal(dayKey(justAfter), "2026-07-27")
+})
+
+test("marking is idempotent and keeps the list sorted and unique", () => {
+  const day = dayKey(NOON)
+  let ledger = markResting(EMPTY_LEDGER, "dynawalla.siege", day)
+  ledger = markResting(ledger, "dynawalla.fuse", day)
+  ledger = markResting(ledger, "dynawalla.fuse", day)
+  assert.deepEqual(ledger.resting, ["dynawalla.fuse", "dynawalla.siege"])
+})
+
+// ── Nobody who paid is blocked ───────────────────────────────────────────────
+
+test("a pass opens every game, including ones that already rested", () => {
+  const ledger = markResting(EMPTY_LEDGER, "dynawalla.fuse", dayKey(NOON))
+  for (const pass of [dayPass, monthPass, lifetime]) {
+    assert.equal(
+      canOpen({ packId: "dynawalla.fuse", pass, ledger, now: NOON }),
+      true,
+      `${pass.kind} did not reopen a rested game`,
+    )
+    // And nothing is ever shown to them again.
+    assert.equal(verdictFor({ packId: "dynawalla.siege", pass, ledger, now: NOON }), "play-on")
+  }
+})
+
+test("a lifetime pass never expires, at any distance from the purchase", () => {
+  const tenYears = NOON + 10 * 365 * 24 * HOUR
+  assert.equal(passIsOpen(lifetime, tenYears), true)
+})
+
+test("a month pass survives a renewal this app could not verify", () => {
+  // The failure being prevented: a family on a plane, a renewal that happened
+  // at the store, and an app that decides on its own that they stopped paying.
+  const justPast = (monthPass.expiresAt ?? 0) + HOUR
+  assert.equal(passIsOpen(monthPass, justPast), true)
+  assert.equal(passIsOpen(monthPass, (monthPass.expiresAt ?? 0) + RENEWAL_GRACE_MS - 1), true)
+  // Past the grace it does close — an indefinite grace is a free subscription.
+  assert.equal(passIsOpen(monthPass, (monthPass.expiresAt ?? 0) + RENEWAL_GRACE_MS + 1), false)
+})
+
+test("a day pass gets no grace, because none is needed", () => {
+  // Its expiry needs no round trip. Extending it would make it a three-day pass.
+  assert.equal(passIsOpen(dayPass, (dayPass.expiresAt ?? 0) - 1), true)
+  assert.equal(passIsOpen(dayPass, (dayPass.expiresAt ?? 0) + 1), false)
+})
+
+test("no pass at all is not an error, it is the free tier", () => {
+  assert.equal(passIsOpen(null, NOON), false)
+  assert.equal(passIsOpen(undefined, NOON), false)
+})
+
+// ── A whole day, end to end ──────────────────────────────────────────────────
+
+test("a full day: play, rest, switch games, buy, and wake up tomorrow", async () => {
+  // The scenario in the brief, run against the same functions the app runs.
+  let ledger: RestLedger = EMPTY_LEDGER
+  let pass: Pass | null = null
+  const play = (packId: string, now: number) => {
+    const verdict = verdictFor({ packId, pass, ledger, now })
+    if (verdict === "rest") ledger = markResting(ledger, packId, dayKey(now))
+    return verdict
+  }
+
+  // 09:00 — FUSE. Two levels cleared; the first one is the stopping point and
+  // the second one is silence.
+  const nine = new Date(2026, 6, 26, 9, 0, 0).getTime()
+  assert.equal(canOpen({ packId: "dynawalla.fuse", pass, ledger, now: nine }), true)
+  assert.equal(play("dynawalla.fuse", nine), "rest")
+  assert.equal(play("dynawalla.fuse", nine + 60_000), "play-on")
+
+  // 09:05 — dismissed the sheet, went to SIEGE. Still open, still free.
+  const nineFive = nine + 5 * 60_000
+  assert.equal(canOpen({ packId: "dynawalla.fuse", pass, ledger, now: nineFive }), false)
+  assert.equal(canOpen({ packId: "dynawalla.siege", pass, ledger, now: nineFive }), true)
+  assert.equal(play("dynawalla.siege", nineFive), "rest")
+
+  // 09:30 — a parent passes the gate and buys the lifetime pass. Everything
+  // opens, including the two games that were resting a moment ago.
+  const outcome = await grantingBilling(() => nine + 30 * 60_000).buy(
+    productFor("lifetime").productId,
+  )
+  assert.equal(outcome.status, "granted")
+  if (outcome.status !== "granted") return
+  pass = outcome.pass
+  for (const packId of ["dynawalla.fuse", "dynawalla.siege", "dynawalla.forge"]) {
+    assert.equal(canOpen({ packId, pass, ledger, now: nine + 31 * 60_000 }), true)
+    assert.equal(verdictFor({ packId, pass, ledger, now: nine + 31 * 60_000 }), "play-on")
+  }
+
+  // …and had they not bought anything, tomorrow morning gives both back.
+  const tomorrow = new Date(2026, 6, 27, 9, 0, 0).getTime()
+  assert.equal(canOpen({ packId: "dynawalla.fuse", pass: null, ledger, now: tomorrow }), true)
+  assert.equal(canOpen({ packId: "dynawalla.siege", pass: null, ledger, now: tomorrow }), true)
+})
+
+// ── The catalogue ────────────────────────────────────────────────────────────
+
+test("three passes, at the founder's prices, and no fourth", () => {
+  assert.deepEqual(
+    FALLBACK_PRODUCTS.map((product) => [product.kind, product.price]),
+    [
+      ["day", "$0.99"],
+      ["month", "$7.99"],
+      ["lifetime", "$79.99"],
+    ],
+  )
+})
+
+test("a lifetime purchase carries no expiry at all", () => {
+  assert.equal(expiryFor("lifetime", NOON), null)
+  assert.equal(expiryFor("day", NOON), NOON + 24 * HOUR)
+})
+
+test("product ids are distinct and namespaced to this app", () => {
+  const ids = FALLBACK_PRODUCTS.map((product) => product.productId)
+  assert.equal(new Set(ids).size, ids.length)
+  for (const id of ids) assert.ok(id.startsWith("inc.corpora.dynawalla."), id)
+})
+
+// ── No timer, and no pressure ────────────────────────────────────────────────
+
+const source = (file: string): string => fs.readFileSync(path.join(here, file), "utf8")
+
+test("there is no timer anywhere in the day pass", () => {
+  // The mechanism this model replaces. A countdown, an interval, an elapsed
+  // reading of the wall clock during play — none of them may reappear here by
+  // somebody solving a problem the quick way.
+  for (const file of ["PassSheet.tsx", "model.ts", "store.ts", "billing.ts"]) {
+    const text = source(file)
+    for (const banned of ["setInterval", "requestAnimationFrame", "performance.now"]) {
+      assert.ok(!text.includes(banned), `${file} uses ${banned}`)
+    }
+  }
+  // `setTimeout` is a delay and a delay before a control becomes usable is the
+  // un-dismissable interstitial, which is banned outright.
+  assert.ok(!source("PassSheet.tsx").includes("setTimeout"), "the sheet delays something")
+})
+
+test("the copy carries no pressure of any kind", () => {
+  const copy = Object.values(strings.pass).join(" ").toLowerCase()
+  const banned = [
+    "hurry",
+    "only today",
+    "last chance",
+    "limited",
+    "expires",
+    "running out",
+    "left today",
+    "friends",
+    "everyone",
+    "don't miss",
+    "unlock",
+    "locked",
+    "premium",
+    "upgrade",
+    "free trial",
+    "minutes",
+    "seconds",
+    "timer",
+  ]
+  for (const phrase of banned) {
+    assert.ok(!copy.includes(phrase), `the pass copy says "${phrase}"`)
+  }
+})
+
+test("the child-facing copy contains no money", () => {
+  // A child at a stopping point sees these four strings and nothing else. No
+  // price, no offer, no reason to go and find an adult.
+  const childFacing = [
+    strings.pass.restTitle,
+    strings.pass.restBody,
+    strings.pass.restLeave,
+    strings.pass.forGrownUps,
+  ].join(" ")
+  assert.ok(!/[$£€]|\d/.test(childFacing), `a price reached the child: ${childFacing}`)
+  assert.ok(!/pass|buy|pay/i.test(childFacing), `the child was sold something: ${childFacing}`)
+})
+
+test("the way out is always one control", () => {
+  // Every stage of the sheet has a plain, labelled, always-visible dismissal.
+  assert.ok(strings.pass.restLeave.length > 0)
+  assert.ok(strings.pass.notNow.length > 0)
+  const sheet = source("PassSheet.tsx")
+  // Escape closes it from every stage, so there is no stage a person is stuck in.
+  assert.ok(sheet.includes('event.key === "Escape"'), "Escape does not close the sheet")
+})
+
+test("no price is rendered until the parental gate has been passed", () => {
+  // Structural, not a habit: the sheet only ever reaches its `Offer` stage
+  // through `Gate`'s success callback, and `Offer` is the only thing that
+  // renders a `price`.
+  const sheet = source("PassSheet.tsx")
+  assert.ok(sheet.includes('onPassed={() => setStage("offer")}'), "the gate does not lead to the offer")
+  assert.ok(
+    !/setStage\("offer"\)/.test(sheet.replace('onPassed={() => setStage("offer")}', "")),
+    "something other than the parental gate opens the offer",
+  )
+})
+
+test("the ledger is device-scoped, which closes the profile-switch hole", () => {
+  // A per-learner ledger would make "add a learner" into an extra play, and a
+  // child would find that in an afternoon. The store's key says so.
+  const text = source("store.ts")
+  assert.ok(text.includes('deviceKey("pass")'), "the pass is not device-scoped")
+  assert.ok(!text.includes("storageKey("), "the pass is namespaced per learner")
+})
+
+test("only a definitive not_owned clears a pass", () => {
+  const text = source("store.ts")
+  assert.ok(text.includes('outcome.status === "not_owned"'), "no definitive-downgrade branch")
+  // An unavailable store is logged and changes nothing.
+  const unavailable = text.slice(text.indexOf('outcome.status === "unavailable"'))
+  assert.ok(!unavailable.includes("forget()"), "an unreachable store downgrades a paying family")
+})
+
+test("no ledger entry is written when a pass is open", () => {
+  // Otherwise a family who let a month pass lapse would come back to a device
+  // where every game was already resting.
+  const ledger = markResting(EMPTY_LEDGER, "dynawalla.fuse", dayKey(NOON))
+  assert.equal(verdictFor({ packId: "dynawalla.siege", pass: lifetime, ledger, now: NOON }), "play-on")
+  assert.equal(isResting(ledger, "dynawalla.siege", dayKey(NOON)), false)
+})

--- a/dynawalla/dynawalla-app/src/pass/store.ts
+++ b/dynawalla/dynawalla-app/src/pass/store.ts
@@ -1,0 +1,163 @@
+// The durable side of the day pass: what was bought, and what rested today.
+//
+// Device-scoped, not per learner, and both halves for a reason:
+//
+//   * A **pass is a purchase**, and a purchase belongs to the family that made
+//     it. A second child on the same tablet does not buy it again.
+//   * The **rest ledger** is device-scoped too, and that is the deliberate
+//     one — per-learner would make "add a profile" into an extra play, which
+//     turns the profile switcher into a hole in the model and teaches a child
+//     to game it.
+//
+// The pass survives everything: it is written on a confirmed purchase and read
+// on every launch, before anything asks a store whether it is still true. There
+// is no launch during which a paying family is treated as not paying, which is
+// the failure Corpán's `entitlements.ts` was rebuilt to eliminate.
+
+import { create } from "zustand"
+import { persist } from "zustand/middleware"
+
+import { durable } from "../app/persist.ts"
+import { deviceKey } from "../app/profile.ts"
+import { billing, type PurchaseOutcome } from "./billing.ts"
+import {
+  dayKey,
+  EMPTY_LEDGER,
+  isPassKind,
+  markResting,
+  passIsOpen,
+  verdictFor,
+  type Pass,
+  type RestLedger,
+  type TransitionVerdict,
+} from "./model.ts"
+
+export interface PassState {
+  /** What this device holds. `null` means nothing has ever been bought. */
+  readonly pass: Pass | null
+  readonly ledger: RestLedger
+
+  /** A store confirmed a purchase. The one way a pass is ever written. */
+  grant: (pass: Pass) => void
+  /**
+   * A store said, online and definitively, that this device owns nothing.
+   *
+   * **The only path that removes a pass.** Not called on a timeout, not on an
+   * offline device, not on a rejected bridge — see `reconcile`.
+   */
+  forget: () => void
+  /** Record that `packId` reached its stopping point today, and say what to do. */
+  reachTransition: (packId: string, now?: number) => TransitionVerdict
+  /** Whether this game may be started right now. */
+  mayOpen: (packId: string, now?: number) => boolean
+}
+
+const initial = { pass: null as Pass | null, ledger: EMPTY_LEDGER }
+
+export const usePass = create<PassState>()(
+  persist(
+    (set, get) => ({
+      ...initial,
+
+      grant: (pass) => set({ pass }),
+      forget: () => set({ pass: null }),
+
+      reachTransition: (packId, now = Date.now()) => {
+        const { pass, ledger } = get()
+        const verdict = verdictFor({ packId, pass, ledger, now })
+        if (verdict === "rest") {
+          set({ ledger: markResting(ledger, packId, dayKey(now)) })
+        }
+        return verdict
+      },
+
+      mayOpen: (packId, now = Date.now()) => {
+        const { pass, ledger } = get()
+        if (passIsOpen(pass, now)) return true
+        const day = dayKey(now)
+        return !(ledger.day === day && ledger.resting.includes(packId))
+      },
+    }),
+    {
+      name: deviceKey("pass"),
+      version: 1,
+      storage: durable,
+      partialize: ({ pass, ledger }) => ({ pass, ledger }),
+      // Rehydration is where a wrongly-shaped record from a future build could
+      // silently become "no pass". It is read defensively field by field, and
+      // **anything unreadable in the pass is kept as no pass but anything
+      // unreadable in the ledger is kept as an empty ledger** — the two
+      // failures are not symmetric, and the second one hands a free day back
+      // rather than taking one away.
+      merge: (persisted, current) => {
+        const stored = persisted as { pass?: unknown; ledger?: unknown } | undefined
+        return { ...current, pass: readPass(stored?.pass), ledger: readLedger(stored?.ledger) }
+      },
+    },
+  ),
+)
+
+function readPass(value: unknown): Pass | null {
+  if (typeof value !== "object" || value === null) return null
+  const record = value as Record<string, unknown>
+  if (!isPassKind(record["kind"])) return null
+  const expiresAt = record["expiresAt"]
+  const confirmedAt = record["confirmedAt"]
+  return {
+    kind: record["kind"],
+    expiresAt: typeof expiresAt === "number" && Number.isFinite(expiresAt) ? expiresAt : null,
+    confirmedAt: typeof confirmedAt === "number" && Number.isFinite(confirmedAt) ? confirmedAt : 0,
+  }
+}
+
+function readLedger(value: unknown): RestLedger {
+  if (typeof value !== "object" || value === null) return EMPTY_LEDGER
+  const record = value as Record<string, unknown>
+  const day = record["day"]
+  const resting = record["resting"]
+  if (typeof day !== "string" || !Array.isArray(resting)) return EMPTY_LEDGER
+  return { day, resting: resting.filter((id): id is string => typeof id === "string") }
+}
+
+/** Whether the family is currently entitled. The one read every surface uses. */
+export function isPassOpen(now: number = Date.now()): boolean {
+  return passIsOpen(usePass.getState().pass, now)
+}
+
+/**
+ * Buy one, and fold the outcome into durable state.
+ *
+ * The asymmetry is the whole function: `granted` writes, `not_owned` clears,
+ * and **everything else leaves what is held exactly as it was**. A parent on a
+ * plane who taps a pass they already own is not downgraded by the failure to
+ * reach a store.
+ */
+export async function buyPass(productId: string): Promise<PurchaseOutcome> {
+  const outcome = await billing().buy(productId)
+  applyOutcome(outcome)
+  return outcome
+}
+
+export async function restorePasses(): Promise<PurchaseOutcome> {
+  const outcome = await billing().restore()
+  applyOutcome(outcome)
+  return outcome
+}
+
+function applyOutcome(outcome: PurchaseOutcome): void {
+  if (outcome.status === "granted") {
+    usePass.getState().grant(outcome.pass)
+    return
+  }
+  if (outcome.status === "not_owned") {
+    // Definitive, online, unambiguous. Everything else is silence.
+    console.warn("[pass] the store reports this device owns nothing; clearing the pass")
+    usePass.getState().forget()
+    return
+  }
+  if (outcome.status === "unavailable") {
+    // Loud, because a silent failure here is a family who tapped Buy and saw
+    // nothing at all happen.
+    console.error(`[pass] the store could not be reached: ${outcome.detail}`)
+  }
+}

--- a/dynawalla/dynawalla-app/src/shell/Surface.tsx
+++ b/dynawalla/dynawalla-app/src/shell/Surface.tsx
@@ -168,7 +168,7 @@ function Figure({ value, label }: Keyless<"figure">) {
  * are the small print, and the whole rectangle is the target — a child aiming
  * at a word is a child missing.
  */
-function Pack({ name, version, size, play }: Keyless<"pack">) {
+function Pack({ name, version, size, play, resting }: Keyless<"pack">) {
   return (
     <button
       type="button"
@@ -185,8 +185,12 @@ function Pack({ name, version, size, play }: Keyless<"pack">) {
           {version} · {size}
         </span>
       </span>
+      {/* A game that already ended today says so, in the same small type as the
+          version, and keeps its full-strength name and its working control. It
+          is not dimmed, not badged, not padlocked and not sorted to the bottom:
+          nothing about this row is a price, and nothing about it is a lock. */}
       <span className="border-line-cut rounded-cut-sm text-ink-muted shrink-0 border px-3 py-2 text-sm">
-        {strings.packs.play}
+        {resting ? strings.packs.tomorrow : strings.packs.play}
       </span>
     </button>
   )

--- a/dynawalla/dynawalla-app/src/shell/surfaces.test.ts
+++ b/dynawalla/dynawalla-app/src/shell/surfaces.test.ts
@@ -48,6 +48,10 @@ const coldHost: HostView = {
   version: "0.1.0",
   native: false,
   armed: false,
+  // Nothing has been bought and nothing has been played, which is the state
+  // that matters most: on a cold device **every game is open**.
+  pass: "none",
+  resting: [],
 }
 
 /** Counts what a caller asked for; asserts nothing on its own. */
@@ -63,6 +67,9 @@ function recorder() {
     armErase: () => calls.push("armErase"),
     erase: () => calls.push("erase"),
     launchPack: () => calls.push("launchPack"),
+    grantTestPass: () => calls.push("grantTestPass"),
+    clearTestPass: () => calls.push("clearTestPass"),
+    clearRestLedger: () => calls.push("clearRestLedger"),
   }
   return { calls, actions }
 }

--- a/dynawalla/dynawalla-app/src/shell/surfaces.ts
+++ b/dynawalla/dynawalla-app/src/shell/surfaces.ts
@@ -88,6 +88,15 @@ export type Row =
       readonly size: string
       /** Launches it onto the stage. Never null: an unplayable pack is not a row. */
       readonly play: () => void
+      /**
+       * This game already reached its stopping point today.
+       *
+       * **Not a lock and never drawn as one.** No padlock, no "premium", no
+       * dimming that makes it look broken, and the row still opens — what it
+       * opens is the sheet that says so. A child scanning the grid is told
+       * where they got to today, which is a fact about them, not a price.
+       */
+      readonly resting: boolean
     }
   /** Something drawn. `label` is its text alternative and is never empty. */
   | {
@@ -119,6 +128,10 @@ export interface HostView {
   readonly native: boolean
   /** Has the parent already pressed "erase everything" once? */
   readonly armed: boolean
+  /** The pass this device holds, described in one word. Never a price. */
+  readonly pass: string
+  /** Pack ids that reached their stopping point today. Usually empty. */
+  readonly resting: readonly string[]
 }
 
 export interface HostActions {
@@ -132,6 +145,17 @@ export interface HostActions {
   readonly erase: () => void
   /** Put a pack on the stage. The one action the front door exists for. */
   readonly launchPack: (packId: string) => void
+  /**
+   * Developer mode only, and off on every child's tablet.
+   *
+   * Verifying "a purchase unlocks everything" and "midnight gives the day
+   * back" needs a way to hold a pass and a way to give one back, and a
+   * developer with no way to do that will invent a worse one — usually by
+   * editing `localStorage` by hand and getting the shape subtly wrong.
+   */
+  readonly grantTestPass: (kind: "day" | "lifetime") => void
+  readonly clearTestPass: () => void
+  readonly clearRestLedger: () => void
 }
 
 // The option sets, written once. `satisfies` is what keeps a label and a value
@@ -209,6 +233,7 @@ function packsSurface(view: HostView, act: HostActions): readonly Section[] {
           version: pack.version,
           size: formatBytes(pack.bytes),
           play: () => act.launchPack(pack.id),
+          resting: view.resting.includes(pack.id),
         }),
       ),
     },
@@ -390,6 +415,46 @@ function parentsSurface(view: HostView, act: HostActions): readonly Section[] {
           (call): Row => fact(callId(call), grantOf(call), `${call.module}.${call.fn}`),
         ),
         ...view.storage.map((entry): Row => fact(entry.key, entry.key, formatBytes(entry.bytes))),
+      ],
+    })
+
+    // The day pass, and the four levers that make a full day simulable in one
+    // sitting. No price is shown and no store is called: `grantingBilling`
+    // writes the same record a confirmed purchase would, so what is being
+    // exercised is the entitlement, not a payment.
+    sections.push({
+      key: "pass",
+      rows: [
+        fact("pass", dev.pass, view.pass),
+        fact("resting", dev.resting, view.resting.length === 0 ? "—" : view.resting.join(", ")),
+        {
+          kind: "action",
+          key: "grant-day",
+          name: dev.grantDayPass,
+          tone: "plain",
+          run: () => act.grantTestPass("day"),
+        },
+        {
+          kind: "action",
+          key: "grant-lifetime",
+          name: dev.grantLifetime,
+          tone: "plain",
+          run: () => act.grantTestPass("lifetime"),
+        },
+        {
+          kind: "action",
+          key: "clear-pass",
+          name: dev.clearPass,
+          tone: "plain",
+          run: act.clearTestPass,
+        },
+        {
+          kind: "action",
+          key: "clear-ledger",
+          name: dev.clearLedger,
+          tone: "plain",
+          run: act.clearRestLedger,
+        },
       ],
     })
   }

--- a/dynawalla/dynawalla-app/src/shell/useHost.ts
+++ b/dynawalla/dynawalla-app/src/shell/useHost.ts
@@ -15,6 +15,9 @@ import { eraseEverything } from "../app/erase.ts"
 import { useThemeStore } from "../app/theme.ts"
 import { usePacks } from "../packs/registry.ts"
 import { useLaunch } from "../packs/Stage.tsx"
+import { grantingBilling, productFor } from "../pass/billing.ts"
+import { dayKey, passIsOpen, EMPTY_LEDGER } from "../pass/model.ts"
+import { usePass } from "../pass/store.ts"
 import { useProfiles } from "../profiles/store.ts"
 import { useSettings } from "../settings/store.ts"
 import type { HostActions, HostView } from "./surfaces.ts"
@@ -49,6 +52,40 @@ function useVersion(): string {
   return version
 }
 
+/**
+ * The instant these screens are describing.
+ *
+ * Held in state and refreshed on the events that actually move a family across
+ * midnight — the app coming back to the foreground, the window regaining focus,
+ * and a game closing — rather than read fresh on every render, which is not a
+ * pure render and which React's rules forbid for exactly the reason that bites
+ * here: two renders in one frame would disagree about the day.
+ *
+ * **There is no interval.** Nothing in this app counts. The authoritative
+ * question — "may this game open right now" — is asked by the stage against the
+ * real clock at the moment a child presses a game, so the worst this can be is
+ * a stale word on a row for as long as an app sits untouched in the foreground.
+ */
+function useNow(): number {
+  const [now, setNow] = useState(() => Date.now())
+  // The game on the stage, or nothing. Leaving one is the most likely moment
+  // for the day to have turned over while the app was busy.
+  const staged = useLaunch((state) => state.packId)
+
+  useEffect(() => {
+    const check = () => setNow(Date.now())
+    check()
+    if (typeof document !== "undefined") document.addEventListener("visibilitychange", check)
+    if (typeof window !== "undefined") window.addEventListener("focus", check)
+    return () => {
+      if (typeof document !== "undefined") document.removeEventListener("visibilitychange", check)
+      if (typeof window !== "undefined") window.removeEventListener("focus", check)
+    }
+  }, [staged])
+
+  return now
+}
+
 export function useHostView(armed: boolean): HostView {
   const profiles = useProfiles((state) => state.profiles)
   const currentId = useProfiles((state) => state.currentId)
@@ -59,6 +96,16 @@ export function useHostView(armed: boolean): HostView {
   const answered = recordFor(currentId)((state) => state.answered)
   const correct = recordFor(currentId)((state) => state.correct)
   const version = useVersion()
+  const pass = usePass((state) => state.pass)
+  const ledger = usePass((state) => state.ledger)
+
+  // The row's word and the stage's decision are the same function of the same
+  // ledger: a screen that says a game is resting and a stage that lets it open
+  // would be two answers to one question, and the second is the one a child
+  // finds.
+  const now = useNow()
+  const open = passIsOpen(pass, now)
+  const resting = open || ledger.day !== dayKey(now) ? [] : ledger.resting
 
   return {
     profiles,
@@ -76,6 +123,8 @@ export function useHostView(armed: boolean): HostView {
     version,
     native: isNative,
     armed,
+    pass: pass === null ? "none" : pass.kind,
+    resting,
   }
 }
 
@@ -104,5 +153,18 @@ export function useHostActions(arm: (armed: boolean) => void): HostActions {
       arm(false)
     },
     launchPack: play,
+
+    // Developer mode only. `grantingBilling` produces exactly the record a
+    // confirmed store purchase would, so what these exercise is the
+    // entitlement path rather than a shortcut around it.
+    grantTestPass: (kind) => {
+      void grantingBilling()
+        .buy(productFor(kind).productId)
+        .then((outcome) => {
+          if (outcome.status === "granted") usePass.getState().grant(outcome.pass)
+        })
+    },
+    clearTestPass: () => usePass.getState().forget(),
+    clearRestLedger: () => usePass.setState({ ledger: EMPTY_LEDGER }),
   }
 }

--- a/dynawalla/games/forge/src/contract.ts
+++ b/dynawalla/games/forge/src/contract.ts
@@ -15,6 +15,20 @@ export type Host = {
   report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
   haptic(kind: "light" | "medium" | "heavy" | "success" | "failure"): void
   prefersReducedMotion(): boolean
+
+  /**
+   * A natural stopping point the child *reached*: a level cleared, a run
+   * completed, a boss down.
+   *
+   * OPTIONAL and feature-detected — a stub host does not implement it and the
+   * game must not care. Fire and forget: nothing is returned, nothing may be
+   * awaited, and the game must not branch on it.
+   *
+   * **Never after a failure.** Not a defeat, not a breach, not a wrong answer,
+   * not a timer. This is the call the host may put a sheet on top of, and a
+   * purchase surface next to a failure is the thing that is forbidden outright.
+   */
+  transition?(kind: "level" | "run" | "boss", label?: string): void
 }
 
 export type Mounted = { unmount(): void }

--- a/dynawalla/games/forge/src/game/forge.ts
+++ b/dynawalla/games/forge/src/game/forge.ts
@@ -549,6 +549,14 @@ export function mount(el: HTMLElement, host: Host): Mounted {
 
   function plunge(): void {
     const L = g.layout
+    // The quench IS the run: everything is cashed in and the forge starts
+    // cold again. FORGE's one natural ending, and the child chose it — which
+    // is exactly the property a stopping point has to have.
+    try {
+      host.transition?.("run", "quench")
+    } catch {
+      /* a host that throws on a stopping point must not kill the run */
+    }
     quench(economy)
     g.quenchPhase = "steam"
     g.quenchT = 0

--- a/dynawalla/games/merge/src/contract.ts
+++ b/dynawalla/games/merge/src/contract.ts
@@ -25,6 +25,20 @@ export type Host = {
   report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void;
   haptic(kind: "light" | "medium" | "heavy" | "success" | "failure"): void;
   prefersReducedMotion(): boolean;
+
+  /**
+   * A natural stopping point the child *reached*: a level cleared, a run
+   * completed, a boss down.
+   *
+   * OPTIONAL and feature-detected — a stub host does not implement it and the
+   * game must not care. Fire and forget: nothing is returned, nothing may be
+   * awaited, and the game must not branch on it.
+   *
+   * **Never after a failure.** Not a defeat, not a breach, not a wrong answer,
+   * not a timer. This is the call the host may put a sheet on top of, and a
+   * purchase surface next to a failure is the thing that is forbidden outright.
+   */
+  transition?(kind: "level" | "run" | "boss", label?: string): void;
 };
 
 export function mount(_el: HTMLElement, _host: Host): { unmount(): void } {

--- a/dynawalla/games/merge/src/game.ts
+++ b/dynawalla/games/merge/src/game.ts
@@ -584,6 +584,16 @@ export class Game {
   }
 
   private enterLevelUp(): void {
+    // The quota is met and the KEY is about to change: the child finished a
+    // level. FUSE's natural stopping point, and the one the day pass reads.
+    // Reported on every level-up rather than only the first — the host acts on
+    // the first one it hears in a day and ignores the rest, so this does not
+    // have to know which of them is special.
+    try {
+      this.host.transition?.("level", `level ${this.levelN}`);
+    } catch {
+      /* a host that throws on a stopping point must not kill the run */
+    }
     this.phase = "levelup";
     this.pt = 0;
     this.levelSeeded = false;

--- a/dynawalla/games/siege/src/contract.ts
+++ b/dynawalla/games/siege/src/contract.ts
@@ -19,6 +19,20 @@ export type Host = {
   report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void;
   haptic(kind: "light" | "medium" | "heavy" | "success" | "failure"): void;
   prefersReducedMotion(): boolean;
+
+  /**
+   * A natural stopping point the child *reached*: a level cleared, a run
+   * completed, a boss down.
+   *
+   * OPTIONAL and feature-detected — a stub host does not implement it and the
+   * game must not care. Fire and forget: nothing is returned, nothing may be
+   * awaited, and the game must not branch on it.
+   *
+   * **Never after a failure.** Not a defeat, not a breach, not a wrong answer,
+   * not a timer. This is the call the host may put a sheet on top of, and a
+   * purchase surface next to a failure is the thing that is forbidden outright.
+   */
+  transition?(kind: "level" | "run" | "boss", label?: string): void;
 };
 
 export function mountSignature(_el: HTMLElement, _host: Host): { unmount(): void } {

--- a/dynawalla/games/siege/src/mount.ts
+++ b/dynawalla/games/siege/src/mount.ts
@@ -311,6 +311,20 @@ export class Siege {
           emberMote(this.parts, this.state.path.core.x + this.rng.r(-70, 70), this.state.path.core.y, rand);
         }
         this.host.haptic("success");
+        // Boss waves only — every fifth. A single wave is thirty seconds and
+        // is not an ending; a boss held is several minutes of work and it is
+        // the moment the child is already celebrating. That is where a
+        // stopping point belongs, and it is the only place SIEGE has one.
+        //
+        // Never on `defeat`. A run that ended badly is a failure, and nothing
+        // may be shown next to one.
+        if (n % 5 === 0) {
+          try {
+            this.host.transition?.("boss", `wave ${n}`);
+          } catch {
+            /* a host that throws on a stopping point must not kill the run */
+          }
+        }
       },
       overchargeBlast: (x, y, _dmg) => {
         this.audio.overcharge();

--- a/dynawalla/games/slice/src/contract.ts
+++ b/dynawalla/games/slice/src/contract.ts
@@ -20,6 +20,20 @@ export type Host = {
   report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
   haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void
   prefersReducedMotion(): boolean
+
+  /**
+   * A natural stopping point the child *reached*: a level cleared, a run
+   * completed, a boss down.
+   *
+   * OPTIONAL and feature-detected — a stub host does not implement it and the
+   * game must not care. Fire and forget: nothing is returned, nothing may be
+   * awaited, and the game must not branch on it.
+   *
+   * **Never after a failure.** Not a defeat, not a breach, not a wrong answer,
+   * not a timer. This is the call the host may put a sheet on top of, and a
+   * purchase surface next to a failure is the thing that is forbidden outright.
+   */
+  transition?(kind: "level" | "run" | "boss", label?: string): void
 }
 
 export function mount(el: HTMLElement, host: Host): { unmount(): void } {

--- a/dynawalla/games/slice/src/mount.ts
+++ b/dynawalla/games/slice/src/mount.ts
@@ -937,6 +937,17 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
       showBanner("MARKET RUSH", "no bombs — cut everything", MOTE_HOT, 1.8)
     }
 
+    if (director.rushJustEnded) {
+      director.rushJustEnded = false
+      // A rush survived. THE SPLIT's natural stopping point — never `over`,
+      // which is a failure, and nothing may be shown after one.
+      try {
+        host.transition?.("run", "market rush")
+      } catch {
+        /* a host that throws on a stopping point must not kill the run */
+      }
+    }
+
     if (!over) {
       director.quiet = liveQ !== null
       const n = director.step(dtS, throwBuf)

--- a/dynawalla/games/slice/src/sim/director.ts
+++ b/dynawalla/games/slice/src/sim/director.ts
@@ -136,7 +136,13 @@ export class Director {
     this.elapsed += dt
     let n = 0
 
-    if (this.rushLeft > 0) this.rushLeft -= dt
+    if (this.rushLeft > 0) {
+      this.rushLeft -= dt
+      // The crest passed and the board is coming down. THE SPLIT has no
+      // levels and no ending, so the settle after a rush is the only place in
+      // it a child is finished with something rather than interrupted.
+      if (this.rushLeft <= 0) this.rushJustEnded = true
+    }
 
     // Release anything whose stagger has elapsed.
     for (let i = 0; i < this.queue.length; i++) {
@@ -199,4 +205,6 @@ export class Director {
 
   /** Set on the frame a rush starts; the caller reads and clears it. */
   rushJustStarted = false
+  /** Set on the frame a rush finishes. Read and cleared the same way. */
+  rushJustEnded = false
 }

--- a/dynawalla/games/stack/src/contract.ts
+++ b/dynawalla/games/stack/src/contract.ts
@@ -11,6 +11,20 @@ export type Host = {
   report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
   haptic(k: "light"|"medium"|"heavy"|"success"|"failure"): void
   prefersReducedMotion(): boolean
+
+  /**
+   * A natural stopping point the child *reached*: a level cleared, a run
+   * completed, a boss down.
+   *
+   * OPTIONAL and feature-detected — a stub host does not implement it and the
+   * game must not care. Fire and forget: nothing is returned, nothing may be
+   * awaited, and the game must not branch on it.
+   *
+   * **Never after a failure.** Not a defeat, not a breach, not a wrong answer,
+   * not a timer. This is the call the host may put a sheet on top of, and a
+   * purchase surface next to a failure is the thing that is forbidden outright.
+   */
+  transition?(kind: "level" | "run" | "boss", label?: string): void
 }
 export type Mount = (el: HTMLElement, host: Host) => { unmount(): void }
 

--- a/dynawalla/games/stack/src/game/sim.ts
+++ b/dynawalla/games/stack/src/game/sim.ts
@@ -424,8 +424,19 @@ export class Sim {
 
     const band = Math.floor(this.floor / T.STRATUM_FLOORS);
     if (band !== this.stratum) {
+      const climbing = band > this.stratum;
       this.stratum = band;
       this.events.push({ type: "stratum", index: band });
+      // Eight floors of tower, and the rock under it changes. MONUMENT's
+      // chapter break. Only on the way UP: a stratum lost is not an ending
+      // a child reached, and nothing may be shown after one.
+      if (climbing) {
+        try {
+          this.host.transition?.("level", `stratum ${band}`);
+        } catch {
+          /* a host that throws on a stopping point must not kill the run */
+        }
+      }
     }
 
     this.nextQuestion();

--- a/dynawalla/packs/README.md
+++ b/dynawalla/packs/README.md
@@ -106,6 +106,10 @@ Three things it does that a game should not do itself:
   `answer` on a `Question` is the host's `items.reveal`, which is a declared,
   parent-visible capability for placing a target — not a way to score.
 - **Reports session progress**, so the host can draw the hairline.
+- **Forwards `transition`**, the game's own "the child just finished something"
+  signal. Games call `host.transition("level")` synchronously from inside their
+  loop; the adapter makes the round trip and swallows any failure. See the SDK
+  README, and note the one rule: **never after a failure**.
 
 ### The gap worth knowing about
 

--- a/dynawalla/packs/sdk/README.md
+++ b/dynawalla/packs/sdk/README.md
@@ -144,8 +144,32 @@ locally in the client, without a round trip.
 | `milestones`   | `host.milestone("tower.built")`                         |
 | `storage`      | 200 keys, 16 KB per value, scoped to your pack          |
 
-`host.progress(fraction)` and `host.end(reason)` need no capability: they are
-how a session is a session.
+`host.progress(fraction)`, `host.end(reason)` and `host.transition(kind)` need
+no capability: they are how a session is a session.
+
+### `host.transition` — say when your game reached a natural ending
+
+```ts
+host.transition("level", "level 3")   // or "run", or "boss"
+```
+
+**Call it whenever the child *finishes* something** — a level cleared, a run
+completed, a boss down. Fire and forget: it resolves immediately, tells you
+nothing, and you must not await it, branch on it, or pause for it. If the host
+puts something over your frame you will hear about it through the `pause` event
+you already handle.
+
+**Never call it after a failure.** Not a defeat, not a breach, not a wrong
+answer, not a timer running out. The host may show a purchase surface at a
+transition, and a purchase surface next to a failure is forbidden outright
+([ADR-0013](../../docs/DECISIONS/ADR-0013-monetization-model.md)).
+
+Call it as often as your game naturally reaches one — the host acts on the first
+per game per day and ignores the rest, so you do not have to ration them or work
+out which is special. This is what the day pass
+([ADR-0024](../../docs/DECISIONS/ADR-0024-day-pass-not-subscription.md)) is
+built on, and it is the reason **there is no timer anywhere in this product**:
+a child stops at a place they reached, not at a number.
 
 Read `host.granted` and hide the surfaces you cannot drive. `host.settings`
 carries the locale, `prefers-reduced-motion`, a quality tier, the text scale and

--- a/dynawalla/packs/sdk/src/capabilities.ts
+++ b/dynawalla/packs/sdk/src/capabilities.ts
@@ -18,9 +18,21 @@
 // `session` is not in the list because it is not a grant: settings, progress
 // and end are how the frame is a frame at all, and a pack that could not
 // report a session ending would leak one.
+//
+// `session.transition` is in that same set for the same reason, and the reason
+// is worth writing down: it is the only place the host can learn that a child
+// has *finished something*. Gating it behind a capability would let a pack
+// decline to declare it and thereby decline ever to reach a stopping point —
+// the day pass would then be enforceable only by a clock, which is the thing
+// this product does not do.
 
 /** Methods every pack may call, with no declaration and no grant. */
-export const SESSION_METHODS = ["session.settings", "session.progress", "session.end"] as const
+export const SESSION_METHODS = [
+  "session.settings",
+  "session.progress",
+  "session.end",
+  "session.transition",
+] as const
 
 export const CAPABILITIES = [
   {

--- a/dynawalla/packs/sdk/src/guest.ts
+++ b/dynawalla/packs/sdk/src/guest.ts
@@ -30,6 +30,7 @@ import type {
   LearnerSummary,
   Settings,
   SoundCue,
+  TransitionKind,
 } from "./protocol.ts"
 import { isConnect, isResponse, PROTOCOL_VERSION } from "./protocol.ts"
 
@@ -86,6 +87,17 @@ export type HostClient = {
   /** Fraction in 0–1. The host draws the progress, the pack does not. */
   progress(fraction: number): Promise<void>
   end(reason: "finished" | "quit"): Promise<void>
+  /**
+   * Something ended by itself: a level cleared, a run completed, a boss down.
+   *
+   * Call it and keep going — the promise resolves immediately and the pack is
+   * not told what the host did with it. What the host may do is put something
+   * over the frame, in which case the pack receives `pause` through `on` in the
+   * usual way, so a game that already handles `pause` handles this too.
+   *
+   * **Never send one after a failure.** See `TransitionKind`.
+   */
+  transition(kind: TransitionKind, label?: string): Promise<void>
 
   on(event: HostEventName, listener: (data: unknown) => void): () => void
   dispose(): void
@@ -246,6 +258,9 @@ function makeClient(connectMessage: Connect, port: MessagePort): HostClient {
     },
     end: async (reason) => {
       await call("session.end", { reason })
+    },
+    transition: async (kind, label) => {
+      await call("session.transition", label === undefined ? { kind } : { kind, label })
     },
 
     on: (event, listener) => {

--- a/dynawalla/packs/sdk/src/index.ts
+++ b/dynawalla/packs/sdk/src/index.ts
@@ -35,9 +35,11 @@ export {
   MAX_REQUESTS_PER_SECOND,
   PROTOCOL_VERSION,
   SDK_VERSION,
+  TRANSITION_KINDS,
   isConnect,
   isHostEvent,
   isResponse,
+  isTransitionKind,
   numberParam,
   parseRequest,
   stringParam,
@@ -57,6 +59,7 @@ export type {
   Response,
   Settings,
   SoundCue,
+  TransitionKind,
 } from "./protocol.ts"
 
 export { compareSemver, compareVersions, isSemver, parseSemver, satisfies, sdkCompatible } from "./semver.ts"

--- a/dynawalla/packs/sdk/src/protocol.ts
+++ b/dynawalla/packs/sdk/src/protocol.ts
@@ -164,6 +164,35 @@ export type LearnerSummary = {
 export type HapticCue = "tick" | "seat" | "settle" | "refuse"
 export type SoundCue = "tick" | "seat" | "settle" | "refuse" | "arrive"
 
+/**
+ * A natural stopping point, named by the pack that reached it.
+ *
+ * **This is the whole of the day pass's mechanism, and it is a place rather
+ * than a duration.** The host never counts minutes and never shows a clock; it
+ * waits to be told that something ended by itself. Which of these a game sends
+ * is the game's judgement about its own shape — the host treats all three the
+ * same and only ever acts on the first one it hears in a day.
+ *
+ * The rule a pack author has to keep: **a transition is a thing the child
+ * finished, never a thing that beat them.** A defeat, a failed run, a wrong
+ * answer, a timer running out — none of those is a transition, because a
+ * purchase surface must never sit next to a failure (ADR-0013). Send one after
+ * a level is cleared, a run is completed, a boss is down.
+ */
+export type TransitionKind =
+  /** A level, stage or chapter was cleared. */
+  | "level"
+  /** A complete run reached its own end. */
+  | "run"
+  /** A named set piece — a boss, a final wave — was beaten. */
+  | "boss"
+
+export const TRANSITION_KINDS: readonly TransitionKind[] = ["level", "run", "boss"]
+
+export function isTransitionKind(value: unknown): value is TransitionKind {
+  return value === "level" || value === "run" || value === "boss"
+}
+
 // ─── Guards ──────────────────────────────────────────────────────────────────
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>

--- a/dynawalla/packs/shared/game-host/index.ts
+++ b/dynawalla/packs/shared/game-host/index.ts
@@ -25,7 +25,7 @@
 // this module did not serve, is dropped. A pack that double-reports a chip
 // would otherwise inflate a child's record, and the record only ever rises.
 
-import type { Capability, HostClient, Item } from "../../sdk/src/index.ts"
+import type { Capability, HostClient, Item, TransitionKind } from "../../sdk/src/index.ts"
 import { connect } from "../../sdk/src/index.ts"
 
 /** The shape both games declare locally. Kept structurally identical. */
@@ -50,6 +50,21 @@ export type GameHost = {
   prefersReducedMotion(): boolean
   /** Optional host extension FUSE feature-detects: bias the stream by value. */
   focus(spec: { key: number; wanted: number[] }): void
+  /**
+   * A natural stopping point just happened: a level cleared, a run completed,
+   * a boss down. Fire and forget — the game is told nothing back and must not
+   * wait, branch or pause on it. If the host does anything, the game finds out
+   * the ordinary way, through the `pause` it already handles.
+   *
+   * **Only ever after something the child finished.** Never after a defeat, a
+   * failed run, a wrong answer or a timer — a purchase surface must never sit
+   * next to a failure (ADR-0013), and this is the call that can put one there.
+   *
+   * Call it as often as the game naturally reaches one. The host acts on the
+   * first per game per day and ignores the rest, so a game with short levels
+   * does not have to ration them.
+   */
+  transition(kind: TransitionKind, label?: string): void
 }
 
 /** Named cues. The game says what happened; the host owns the waveform. */
@@ -227,6 +242,15 @@ export async function createGameHost(options: GameHostOptions = {}): Promise<Mou
     focus: ({ wanted: values }) => {
       wanted = values.slice(0, 32)
       if (pool.length < POOL_TARGET) fill()
+    },
+
+    transition: (kind, label) => {
+      // Synchronous on the outside, because it is called from inside a game
+      // loop where there is no `await`, and swallowed on the inside: a host
+      // that could not take a stopping point must not take the game down.
+      void client.transition(kind, label).catch((error: unknown) => {
+        console.error("[pack] a stopping point could not be reported", error)
+      })
     },
   }
 


### PR DESCRIPTION
## The day pass

Founder decision, 2026-07-26. **Every game is free to play.** When a game reaches a
*natural stopping point* — a level cleared, a boss down, a run completed — that game rests
until tomorrow. **One gate per game per day**, which is the mechanism by which a child
finds the one game they love: unlimited breadth, bounded repetition. A pass opens
everything: **$0.99 day · $7.99 month · $79.99 lifetime, and the lifetime is the headline.**

[ADR-0024](../blob/agent/dynawalla/day-pass/dynawalla/docs/DECISIONS/ADR-0024-day-pass-not-subscription.md)
supersedes ADR-0013. `G-02` (packaging and pricing) closes.

**There was no 5–10 minute timer to delete** — none was ever built. There is none now, and
`pass.test.ts` fails the build if `setInterval`, `setTimeout`, `requestAnimationFrame` or
`performance.now` appears in the sheet.

### What the child sees

> ### That's FUSE for today.
> Every other game is still open.
>
> **[ ◆ Choose another game ]**
>
> <sub>Grown-ups</sub>

No price, no money, no lock, no reason to go and find an adult. The biggest control takes
them back to the other games, which are all still open. "Grown-ups" is small and at the
bottom.

### What an adult sees, after the parental gate

> ### The Dynawalla Pass
> Every game, as often as you like. No subscription, no ads.
>
> | | |
> |---|--:|
> | **Lifetime** — Pay once. Yours for good. | **$79.99** |
> | One month — Thirty days. | $7.99 |
> | Day pass — Today. | $0.99 |
>
> <sub>Restore a pass</sub> · **[ Not now ]**

Lifetime first and framed in brass. No badge, no strike-through, no "best value", no
pre-selected plan, no countdown, no scarcity. "Not now" is one tap from every stage, and so
is Escape.

## `session.transition` — the host↔pack contract

A new **session method**, alongside `session.settings` / `progress` / `end`.

```ts
host.transition("level" | "run" | "boss", label?)
```

Three deliberate properties:

- **Not a capability.** A pack cannot decline to declare it and thereby decline ever to
  reach a stopping point — gated, the day pass would be enforceable only by a clock.
- **Returns nothing.** A pack that could read the verdict could branch on whether the child
  has paid, and a game that plays differently for a paying child is what this is not. If
  the host puts something over the frame, the pack hears it as the `pause` it already handles.
- **Never after a failure.** ADR-0013 already forbids a purchase surface next to one.

Wired in all five games, at each one's own boundary:

| Game | Where | Why |
|---|---|---|
| FUSE | every level-up | The quota is met and the KEY changes — literally "the end of the first level". |
| SIEGE | every fifth wave (the boss waves) | One wave is 30 seconds and is not an ending. **Never on `defeat`.** |
| FORGE | the quench | The prestige reset *is* the run, and the child chose it. |
| MONUMENT | a stratum, climbing only | Eight floors and the rock changes. |
| THE SPLIT | a market rush survived | No levels, no ending; the settle after a rush is its only crest. |

Each game's `Host` contract gets an **optional, feature-detected** `transition?`, the same
shape FUSE's `focus?` already uses, so stub hosts and existing call sites are untouched.

## Entitlement

Copied from `corpan/corpan-app/src/store/entitlements.ts`, because the asymmetry is real: a
wrongly-open pass costs a dollar, a wrongly-closed one tells a family that already paid
that they did not.

- **Lifetime** — never re-examined, no expiry, no revalidation.
- **Month** — survives its recorded expiry by **48 hours**, because a renewal is a fact only
  the store knows and the store is not always reachable. Past that it closes; an indefinite
  grace is a free subscription.
- **Day** — no grace, because none is needed. Extending it would make it a three-day pass.
- **Only a definitive, online `not_owned` clears anything.** A timeout, an offline device or
  a rejected bridge is `unavailable`: logged loudly, changes nothing.

The rest ledger is **device-scoped**, not per learner — per-learner would turn "add a
learner" into an extra play, and a child would find that in an afternoon. It holds one day
and is discarded at **local** midnight (UTC would put "tomorrow" at 4pm in California).

## The parental gate

In front of the **price display**, not just the purchase. **Never arithmetic** — this is a
maths app and the audience is being trained daily to defeat exactly that challenge. Two
randomized, non-persistent forms: the current four-digit year, or a **thirteen-letter,
four-syllable, non-curricular word** to transcribe. TELEVISION, UNIVERSITY, HELICOPTERS and
WATERMELONS were in the first draft and were cut — a nine-year-old types all four without
hesitating.

## Billing is a seam. Nothing is implemented and nothing is faked.

`src/pass/billing.ts` — three methods (`products`, `buy`, `restore`). The shipped
implementation charges nobody and grants nothing, returning `unavailable`. A stub that
pretended to succeed would write a fake receipt into durable storage on a child's tablet,
where the first real store query would have to argue with it. StoreKit 2 / Play Billing land
behind `setBilling()`. Product ids are fixed in the ADR and are **immutable once submitted**.

Developer mode gains four rows in the parent area — grant a day pass, grant a lifetime pass,
clear the pass, clear today's ledger — so a full day is simulable in one sitting without
hand-editing `localStorage` and getting the shape subtly wrong.

## Verification

- `dynawalla-app`: **197 tests pass** (was 166), `tsc` clean across all three projects, `eslint` clean.
- `packs/sdk`: **52 tests pass**.
- All five games: `tsc` clean, **199 tests pass** across them.
- `node packs/build.mjs`: both packs build, check and stage. `npm run build`: clean.
- The sheet was rendered in a browser at every stage, in **both themes**, and looked at.

31 of the new tests are the day pass. They include a **full simulated day** — play FUSE to
its transition, see the verdict, switch to SIEGE, confirm the first rests and the second
does not, buy a pass, confirm everything reopens, roll past midnight and confirm the free
day comes back — plus mechanical bans on pressure copy, on money in the child-facing
strings, and on any route to a price that does not go through the parental gate.

## Two things worth a reviewer's attention

1. **The `resting` marker on a pack row** is a one-word change (`Play` → `Tomorrow`) in
   `Surface.tsx` and one field on the pack row. If the store-grid PR lands first this is the
   only place that conflicts, and it is a three-line merge.
2. **`--dw-strike` in dark** (`copper-700` on `basalt-800`) is low-contrast, which shows on
   the gate's "That's not it" line. Pre-existing app-wide token, used by the erase row too,
   so I did not change it here — but it is worth a token pass. The meaning is not carried by
   that colour alone (`role="alert"`, `aria-invalid`, and a fresh challenge all say it too).
