### PR TITLE
dynawalla: unblock the first mobile release — six defects between here and TestFlight

### DIFF
--- a/.github/scripts/test_verify_testflight_upload.py
+++ b/.github/scripts/test_verify_testflight_upload.py
@@ -14,6 +14,13 @@ Every test here fails against the version of the script that was first written:
     ASC_TIMEOUT_SECONDS, so raising that past ~19 minutes expired the token
     mid-poll and reported "the API key is not valid for this team"
   * it had no 403 or 404 branch
+  * it had no `--preflight`, so "the App Store Connect app record does not
+    exist" — a founder action, answerable in two seconds — was discovered at
+    the upload step, roughly minute 55 of a 60-minute macOS job
+
+`main` takes an explicit argv (the same shape `verify_play_upload.py` uses)
+because it now parses arguments: `main()` under pytest would parse pytest's own
+command line. Every call site here passes `[]` or `["--preflight"]`.
 
 Run: python -m pytest .github/scripts -q
 """
@@ -99,7 +106,7 @@ def test_main_fails_on_a_duplicate(monkeypatch, capsys):
 
     monkeypatch.setattr(vt, "get", fake_get)
     with pytest.raises(SystemExit) as exc:
-        vt.main()
+        vt.main([])
     assert exc.value.code == 1
     out = capsys.readouterr().out
     assert "already on App Store Connect before this run started" in out
@@ -120,7 +127,7 @@ def test_main_passes_on_our_own_build(monkeypatch, capsys):
         return {"data": [_build("new", "29750720", AFTER, state="PROCESSING")]}
 
     monkeypatch.setattr(vt, "get", fake_get)
-    vt.main()
+    vt.main([])
     assert "was uploaded by this run" in capsys.readouterr().out
 
 
@@ -140,7 +147,7 @@ def test_main_fails_on_an_invalid_build(monkeypatch, capsys):
 
     monkeypatch.setattr(vt, "get", fake_get)
     with pytest.raises(SystemExit):
-        vt.main()
+        vt.main([])
     assert "rejected by App Store Connect" in capsys.readouterr().out
 
 
@@ -149,7 +156,7 @@ def test_missing_min_uploaded_date_is_a_failure(monkeypatch, capsys):
     monkeypatch.setenv("ASC_BUILD_VERSION", "29750720")
     monkeypatch.delenv("ASC_MIN_UPLOADED_DATE", raising=False)
     with pytest.raises(SystemExit):
-        vt.main()
+        vt.main([])
     assert "ASC_MIN_UPLOADED_DATE is not set" in capsys.readouterr().out
 
 
@@ -238,8 +245,96 @@ def test_no_app_record_is_a_founder_action(monkeypatch, capsys):
     monkeypatch.setattr(vt.Bearer, "value", lambda self: "tok")
     monkeypatch.setattr(vt, "get", lambda *a, **k: {"data": []})
     with pytest.raises(SystemExit):
-        vt.main()
+        vt.main([])
     assert "founder action" in capsys.readouterr().out
+
+
+# ------------------------------------------------------- --preflight, the app
+# record check that used to happen at minute 55
+
+
+def _preflight_env(monkeypatch):
+    """Only the credentials and the bundle id. Deliberately NOT the build
+    version or the run start: preflight runs before an IPA exists."""
+    monkeypatch.setenv("ASC_BUNDLE_ID", "inc.corpora.dynawalla")
+    monkeypatch.delenv("ASC_BUILD_VERSION", raising=False)
+    monkeypatch.delenv("ASC_MIN_UPLOADED_DATE", raising=False)
+    monkeypatch.setenv("ASC_KEY_ID", "K")
+    monkeypatch.setenv("ASC_ISSUER_ID", "I")
+    monkeypatch.setenv("ASC_API_KEY_P8", "P")
+    monkeypatch.setattr(vt.Bearer, "value", lambda self: "tok")
+
+
+def test_preflight_prints_the_app_id_and_does_not_poll_builds(monkeypatch, capsys):
+    """It must answer from the `apps` call alone. Touching `builds` would make
+    it depend on a build that does not exist yet."""
+    _preflight_env(monkeypatch)
+    asked = []
+
+    def fake_get(path, params, bearer):
+        asked.append(path)
+        return {"data": [{"id": "app1", "attributes": {"bundleId": "inc.corpora.dynawalla"}}]}
+
+    monkeypatch.setattr(vt, "get", fake_get)
+    vt.main(["--preflight"])
+    assert asked == ["apps"]
+    assert "app1" in capsys.readouterr().out
+
+
+def test_preflight_needs_no_build_version(monkeypatch):
+    """The whole point is that it runs BEFORE the build. Requiring
+    ASC_BUILD_VERSION would move it back to where it was useless."""
+    _preflight_env(monkeypatch)
+    monkeypatch.setattr(
+        vt,
+        "get",
+        lambda *a, **k: {
+            "data": [{"id": "app1", "attributes": {"bundleId": "inc.corpora.dynawalla"}}]
+        },
+    )
+    vt.main(["--preflight"])  # must not raise SystemExit
+
+
+def test_preflight_fails_when_the_app_record_is_missing(monkeypatch, capsys):
+    _preflight_env(monkeypatch)
+    monkeypatch.setattr(vt, "get", lambda *a, **k: {"data": []})
+    with pytest.raises(SystemExit) as exc:
+        vt.main(["--preflight"])
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "inc.corpora.dynawalla" in out
+    assert "founder action" in out
+
+
+def test_preflight_rejects_a_near_miss_bundle_id(monkeypatch, capsys):
+    """`filter[bundleId]` is Apple's filter and it is not an exact match. If the
+    response were trusted as-is, a sibling id would resolve to the WRONG app id
+    and the post-upload read-back would poll another app's builds until it timed
+    out."""
+    _preflight_env(monkeypatch)
+    monkeypatch.setattr(
+        vt,
+        "get",
+        lambda *a, **k: {
+            "data": [{"id": "other", "attributes": {"bundleId": "inc.corpora.dynawalla.dev"}}]
+        },
+    )
+    with pytest.raises(SystemExit):
+        vt.main(["--preflight"])
+    assert "founder action" in capsys.readouterr().out
+
+
+def test_preflight_still_reports_a_bad_key_as_a_bad_key(monkeypatch, capsys):
+    """Moving the check early must not turn a credential problem into a
+    mysterious one — 401 is the single most likely first-run outcome."""
+    _preflight_env(monkeypatch)
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda *a, **k: (_ for _ in ()).throw(_http_error(401))
+    )
+    monkeypatch.setattr(vt, "mint_token", lambda *a: "tok")
+    with pytest.raises(SystemExit):
+        vt.main(["--preflight"])
+    assert "401" in capsys.readouterr().out
 
 
 # ------------------------------------------------------------------- parsing

--- a/.github/scripts/verify_testflight_upload.py
+++ b/.github/scripts/verify_testflight_upload.py
@@ -12,6 +12,18 @@ been bitten by on the Play side.
 So we read it back: find the app by bundle id, then poll its builds for the
 CFBundleVersion this run produced.
 
+That app-by-bundle-id lookup is also the answer to a question the iOS job used
+to ask far too late. There is no app-create operation in the App Store Connect
+API, so "the app record has not been created yet" is a founder action, and
+until this script ran it was discovered at the UPLOAD step — roughly minute 55
+of a 60-minute macOS job. The lookup itself costs about two seconds and needs
+nothing the build produces, so it is also exposed on its own:
+
+    --preflight   ONLY the app lookup. Run it before the expensive work.
+                  Prints the resolved app id; exits non-zero, naming the
+                  founder action, when no app record exists for the bundle id.
+    (verify)      the full post-upload read-back described above.
+
 Presence alone is NOT enough. CFBundleVersion is minutes-since-epoch, so two
 runs in the same minute produce the same string (RISKS R-12) — and in exactly
 that case a build with the wanted version is already on App Store Connect
@@ -20,11 +32,13 @@ passes while Apple rejected our upload as a duplicate. Every candidate build is
 therefore checked against ASC_MIN_UPLOADED_DATE, the moment this workflow run
 started: a build older than that is a pre-existing collision, not our upload.
 
-Environment:
+Environment (both modes):
   ASC_KEY_ID             App Store Connect API key id
   ASC_ISSUER_ID          App Store Connect issuer id
   ASC_API_KEY_P8         the .p8 private key (the PEM text itself)
   ASC_BUNDLE_ID          e.g. inc.corpora.dynawalla
+
+Environment (verify mode only):
   ASC_BUILD_VERSION      the CFBundleVersion to look for
   ASC_MIN_UPLOADED_DATE  epoch seconds; the run's start. A build uploaded
                          before this is not ours.
@@ -35,6 +49,7 @@ None of these values is ever printed. Only their presence/absence is.
 
 from __future__ import annotations
 
+import argparse
 import datetime as _dt
 import json
 import os
@@ -189,18 +204,22 @@ def get(path: str, params: dict[str, str], bearer: Bearer) -> dict:
         fail(f"GET {path} failed: {exc}")
 
 
-def main() -> None:
-    bundle_id = require("ASC_BUNDLE_ID")
-    wanted = require("ASC_BUILD_VERSION")
-    raw_min = require("ASC_MIN_UPLOADED_DATE")
-    try:
-        min_uploaded = float(raw_min)
-    except ValueError:
-        fail(f"ASC_MIN_UPLOADED_DATE is not epoch seconds: {raw_min!r}")
-    deadline = time.time() + int(os.environ.get("ASC_TIMEOUT_SECONDS", "900"))
+def bearer_from_env() -> Bearer:
+    return Bearer(require("ASC_KEY_ID"), require("ASC_ISSUER_ID"), require("ASC_API_KEY_P8"))
 
-    bearer = Bearer(require("ASC_KEY_ID"), require("ASC_ISSUER_ID"), require("ASC_API_KEY_P8"))
 
+def resolve_app_id(bundle_id: str, bearer: Bearer) -> str:
+    """The App Store Connect app id for a bundle id, or a fatal error.
+
+    The response is re-filtered on the exact bundle id, which is not
+    redundant: `filter[bundleId]` is Apple's filter and Apple has never
+    promised it is an exact-match lookup rather than a match, so a sibling id
+    (`inc.corpora.dynawalla.dev`) could come back for a query of
+    `inc.corpora.dynawalla`. Taking `data[0]` on trust would resolve the wrong
+    app id, and the post-upload read-back would then poll a DIFFERENT app's
+    builds until it timed out — reporting the timeout against the right bundle
+    id, which is the hardest possible version of this to debug.
+    """
     apps = get("apps", {"filter[bundleId]": bundle_id, "limit": "200"}, bearer)
     matches = [
         a for a in apps.get("data", []) if (a.get("attributes") or {}).get("bundleId") == bundle_id
@@ -209,9 +228,44 @@ def main() -> None:
         fail(
             f"No App Store Connect app record for bundle id {bundle_id}. "
             "There is no app-create operation in the API — Apple's own docs say to create "
-            "the app on the App Store Connect website (STORE.md). This is a founder action."
+            "the app on the App Store Connect website (STORE.md). This is a founder action: "
+            "create the app with this exact bundle id in App Store Connect, then re-run. "
+            "Nothing this job builds can succeed until it exists."
         )
-    app_id = matches[0]["id"]
+    return str(matches[0]["id"])
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Verify a TestFlight upload.")
+    parser.add_argument(
+        "--preflight",
+        action="store_true",
+        help="only check that the app record exists (run BEFORE the build)",
+    )
+    args = parser.parse_args(argv)
+
+    bundle_id = require("ASC_BUNDLE_ID")
+
+    # --preflight asks exactly one question and asks it early. It deliberately
+    # requires NONE of the verify-mode variables: at the point it runs there is
+    # no IPA, so there is no CFBundleVersion to name, and demanding one would
+    # make the check impossible to run at the only time it is worth running.
+    if args.preflight:
+        app_id = resolve_app_id(bundle_id, bearer_from_env())
+        print(f"App Store Connect app {app_id} exists for {bundle_id}. Preflight passed.")
+        return
+
+    wanted = require("ASC_BUILD_VERSION")
+    raw_min = require("ASC_MIN_UPLOADED_DATE")
+    try:
+        min_uploaded = float(raw_min)
+    except ValueError:
+        fail(f"ASC_MIN_UPLOADED_DATE is not epoch seconds: {raw_min!r}")
+    deadline = time.time() + int(os.environ.get("ASC_TIMEOUT_SECONDS", "900"))
+
+    bearer = bearer_from_env()
+
+    app_id = resolve_app_id(bundle_id, bearer)
     print(f"App Store Connect app {app_id} for {bundle_id}.")
     print(f"Only builds uploaded at or after {iso(min_uploaded)} count as this run's.")
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       dynawalla_app: ${{ steps.filter.outputs.dynawalla_app }}
       dynawalla_curriculum: ${{ steps.filter.outputs.dynawalla_curriculum }}
       dynawalla_engine: ${{ steps.filter.outputs.dynawalla_engine }}
+      dynawalla_packs: ${{ steps.filter.outputs.dynawalla_packs }}
       lambda: ${{ steps.filter.outputs.lambda }}
       native: ${{ steps.filter.outputs.native }}
       packs: ${{ steps.filter.outputs.packs }}
@@ -157,6 +158,26 @@ jobs:
           # packages have independent CI filters, and an engine-only pull request
           # must be able to fail this on its own."
           set_output dynawalla_engine '^(dynawalla/engine/|\.github/workflows/ci\.yml$)'
+          # The games and the pack pipeline, deliberately ONE area rather than
+          # two, because there is no change to either half that the other half
+          # cannot break: `packs/build.mjs` runs each game's `build:pack`, every
+          # game's `src/pack.ts` imports `packs/shared/game-host/index.ts` by
+          # relative path, and `packs/sdk/bin/dw-pack.mjs` is the checker the
+          # build runs as its gate on every pack, every time. Splitting them
+          # would let an SDK-only PR skip the five builds that consume it.
+          #
+          # Before this filter existed, `dynawalla/games/**` and
+          # `dynawalla/packs/**` matched NO area and were exercised by NO job:
+          # 201 game tests and 52 SDK tests ran nowhere, and `npm run packs`
+          # first executed inside a release. See the job below for why that is
+          # the expensive place to discover a broken pack.
+          #
+          # `dynawalla-app/package.json` is in here because it is where the
+          # `packs` script is defined (`node ../packs/build.mjs`) and this job
+          # invokes it by name. The app's own filter covers that file too, but
+          # no job under it runs the pack build, so a rename would otherwise
+          # land green and break only the release.
+          set_output dynawalla_packs '^(dynawalla/(games|packs)/|dynawalla/dynawalla-app/package\.json$|\.github/workflows/ci\.yml$)'
           # Cross-product area. Deliberately no `ci.yml` self-trigger: it exists
           # to answer "did shared code move", and a workflow edit is not a
           # change to it. No job consumes it yet.
@@ -209,8 +230,16 @@ jobs:
           # filter above: `shared_ts` is declared ahead of its job, so paths it
           # matches are genuinely ungated and must keep warning until that job
           # lands. `dynawalla/dynawalla-app/`, `dynawalla/curriculum/`,
-          # `dynawalla/engine/` and now `native` have each graduated, as the
-          # jobs below consume their filters.
+          # `dynawalla/engine/`, `native` and now `dynawalla/games/` +
+          # `dynawalla/packs/` have each graduated, as the jobs below consume
+          # their filters.
+          #
+          # The games and the packs are added here in the SAME change that adds
+          # the job consuming them, which is the only order that keeps this
+          # list honest. Listing a path as covered before a job runs it is
+          # strictly worse than not listing it: the warning is the only thing
+          # standing between an unexercised tree and a release-time discovery,
+          # and a premature entry silences it while changing nothing else.
           #
           # The terraform member is copied verbatim from the `terraform` filter —
           # extension-scoped, not the bare directory. A bare `corpan/infra/
@@ -223,7 +252,7 @@ jobs:
           # app compiles all of them). `.github/workflows/ios-native.yml`
           # additionally compiles their Swift, but it is advisory and does not
           # count here.
-          covered='^(corpan/corpan-app/|corpan/dja/|corpan/infra/terraform/lambda/|corpan/packs/|corpan/infra/terraform/.*(\.tf|\.tfvars|\.tf\.json)$|corpan/infra/terraform/\.terraform\.lock\.hcl$|web/(io|data|pages|scripts)/|corpan/plugins/|dynawalla/dynawalla-app/|dynawalla/(curriculum|engine)/)'
+          covered='^(corpan/corpan-app/|corpan/dja/|corpan/infra/terraform/lambda/|corpan/packs/|corpan/infra/terraform/.*(\.tf|\.tfvars|\.tf\.json)$|corpan/infra/terraform/\.terraform\.lock\.hcl$|web/(io|data|pages|scripts)/|corpan/plugins/|dynawalla/dynawalla-app/|dynawalla/(curriculum|engine|games|packs)/)'
 
           # Carve-outs checked BEFORE `covered`, because a broader area prefix
           # would otherwise swallow them. grep -E has no negative lookahead,
@@ -714,6 +743,133 @@ jobs:
         working-directory: dynawalla/engine
         run: npm run tsc
 
+  # Dynawalla's games and the pack pipeline that ships them.
+  #
+  # Before this job, `dynawalla/games/**` and `dynawalla/packs/**` matched no
+  # area filter and were exercised by no job at all. Two consequences, both
+  # measured on this branch:
+  #
+  #   * 201 tests across the five games and 52 in the pack SDK ran nowhere. A
+  #     game could be merged with a red test suite and nothing would say so.
+  #   * `npm run packs` — the build that produces every shipped pack — first
+  #     ran during a RELEASE. `src-tauri/tauri.conf.json` sets
+  #     "beforeBuildCommand": "npm run packs && npm run tsc && npm run build",
+  #     so the pipeline's first execution on any change was inside the iOS
+  #     archive step: about 45 minutes in, on a macOS runner, after signing.
+  #     `packs/build.mjs` runs `dw-pack check` on every pack and treats a
+  #     failure as a failed build ("a pack that does not pass is a failed
+  #     build, not a warning"), so a malformed pack.json written on a Tuesday
+  #     surfaced as a dead release on a Friday.
+  #
+  # Path-gated like every sibling, and therefore NOT a required status context:
+  # it reports into `ci-gate` below, which always runs and treats a skip as a
+  # pass. Adding a `needs` entry there adds coverage without adding a context
+  # branch protection waits on, so the merge queue cannot deadlock on it.
+  #
+  # No `git lfs pull` step, unlike `dynawalla-app` and `native`: `git ls-files
+  # dynawalla/games dynawalla/packs | git check-attr --stdin filter` reports
+  # nothing under LFS, so there is no pointer file for a build to embed. Add
+  # one the moment a game commits its first PNG.
+  dynawalla-packs:
+    name: dynawalla-packs · games + pack build
+    needs: changes
+    if: needs.changes.outputs.dynawalla_packs == 'true'
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          # Node 24 is not a preference here: `packs/sdk` and `games/slice`
+          # both pin `engines.node >= 24`, and every test script in this tree
+          # runs TypeScript directly under `--experimental-strip-types`.
+          node-version: "24"
+          cache: "npm"
+          # A cache KEY, not an install manifest. Not every game commits a
+          # lockfile (`packs/build.mjs` falls back to `npm install` when one is
+          # absent, and the install loop below makes the same choice), so this
+          # glob deliberately matches a subset. It only has to change when a
+          # dependency changes; a game with no lock simply contributes nothing
+          # to the key.
+          cache-dependency-path: dynawalla/games/*/package-lock.json
+      # The SDK first, because it is the contract the rest of this job checks
+      # against: the manifest schema, the capability table, the wire protocol,
+      # and `bin/dw-pack.mjs` — the checker the pack build runs as its gate.
+      # Its own tests are the only thing that can catch a checker that stopped
+      # checking, which is the failure mode that passes wrongly.
+      - name: Install, test and typecheck the pack SDK
+        working-directory: dynawalla/packs/sdk
+        # `npm install`, not `npm ci`: the SDK commits no lockfile. Its only
+        # dependencies are typescript and @types/node, both devDependencies.
+        run: |
+          set -euo pipefail
+          npm install
+          npm test
+          npm run tsc
+      - name: Install, test and typecheck every game
+        run: |
+          set -euo pipefail
+
+          # Discovery is a glob, matching `packs/build.mjs`: "adding the
+          # thousandth pack is adding a directory; there is no register to
+          # forget to edit". A hand-written list of games here would be exactly
+          # that register, and the failure mode of forgetting it is silence.
+          shopt -s nullglob
+          manifests=(dynawalla/games/*/package.json)
+          if [ "${#manifests[@]}" -eq 0 ]; then
+            echo "::error::no games found under dynawalla/games/ — this job's glob has gone stale and it has been passing on nothing."
+            exit 1
+          fi
+          echo "${#manifests[@]} game(s) found."
+
+          for manifest in "${manifests[@]}"; do
+            dir="$(dirname "${manifest}")"
+            echo "::group::${dir}"
+
+            # Read the manifest with fs.readFileSync, never `require()`. A bare
+            # `require("dynawalla/games/forge/package.json")` has no leading
+            # `./`, so Node resolves it as a PACKAGE name, throws, and — with
+            # stderr discarded, which is how this idiom is usually written —
+            # reports "no such script" for every pack forever. That is a live
+            # bug in the `changed-packs` job above; do not copy it down here.
+            node -e '
+              const fs = require("node:fs");
+              const pkg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+              const missing = ["test", "tsc"].filter((s) => !pkg.scripts?.[s]);
+              if (missing.length > 0) {
+                console.error(`::error::${process.argv[1]} defines no ${missing.join(" and no ")} script. Every game gates on both — add them rather than removing the game from CI.`);
+                process.exit(1);
+              }
+            ' "${manifest}"
+
+            # `npm ci` where a lock is committed, `npm install` where one is
+            # not — the same branch `packs/build.mjs` takes, so CI installs
+            # what the pack build would install rather than a second opinion
+            # that could resolve differently.
+            if [ -f "${dir}/package-lock.json" ]; then
+              npm ci --prefix "${dir}"
+            else
+              npm install --prefix "${dir}"
+            fi
+
+            npm run --prefix "${dir}" test
+            npm run --prefix "${dir}" tsc
+            echo "::endgroup::"
+          done
+      - name: Build, check and stage every pack
+        working-directory: dynawalla/dynawalla-app
+        # Invoked by name, from the app directory, because that is verbatim
+        # what the release runs through tauri's `beforeBuildCommand`. Calling
+        # `node ../packs/build.mjs` directly here would test the script but not
+        # the wiring, and the wiring is half of what broke.
+        #
+        # No `npm ci` in this directory first, deliberately: the script is
+        # `node ../packs/build.mjs` and needs nothing from the app's
+        # node_modules. Each game's dependencies were installed by the step
+        # above, which is also why build.mjs's own install branch is a no-op by
+        # the time it runs — it installs only when node_modules is missing.
+        run: npm run packs
+
   # ───────────────────────────────────────────────────────────────────────────
   # The Rust / native gate.
   #
@@ -1057,6 +1213,7 @@ jobs:
         pack-catalog,
         dynawalla-curriculum,
         dynawalla-engine,
+        dynawalla-packs,
       ]
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/release-dynawalla.yml
+++ b/.github/workflows/release-dynawalla.yml
@@ -331,9 +331,62 @@ jobs:
             || { echo "::error::profile is named '$NAME'; ExportOptions pins '$IOS_PROFILE_NAME'"; exit 1; }
           rm -f "$RUNNER_TEMP/profile.plist"
 
+      - name: Preflight · the App Store Connect app record exists
+        # Nothing downstream of here can succeed if the app record for this
+        # bundle id has not been created, and there is no app-create operation
+        # in the App Store Connect API — it is a founder action on the website
+        # (docs/STORE.md). Until this step existed, that fact was discovered by
+        # the UPLOAD step, at roughly minute 55 of a 60-minute macOS job: an
+        # hour of build time and a red X whose cause is a two-second question.
+        #
+        # It is the SAME lookup the post-upload verifier already performs
+        # (`GET /v1/apps?filter[bundleId]=...`), exposed as `--preflight` rather
+        # than duplicated here, so the two can never disagree about what
+        # "the app exists" means.
+        #
+        # Placed after the profile install on purpose: that step proves the
+        # profile is for this bundle id, this one proves App Store Connect has
+        # heard of it, and together they are the whole of "can this run
+        # possibly ship?" — asked before `npm ci` and the ~50-minute archive.
+        #
+        # No `continue-on-error`, no `if:`. A preflight that cannot fail the
+        # job is a log line, and the failure mode being prevented is precisely
+        # a run that burns an hour before telling anyone.
+        #
+        # Secrets through `env:`, never interpolated into the `run:` text — see
+        # the note on the profile step above.
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
+          ASC_BUNDLE_ID: ${{ env.BUNDLE_ID }}
+        run: |
+          set -euo pipefail
+          python3 -m pip install --quiet --disable-pip-version-check 'pyjwt[crypto]'
+          python3 .github/scripts/verify_testflight_upload.py --preflight
+
       - name: Install deps
         working-directory: dynawalla/dynawalla-app
         run: npm ci
+
+      # PROVEN NECESSARY by run 30291684583, which died here with
+      # `failed to get resource: resource path 'packs' doesn't exist`.
+      #
+      # `tauri.conf.json` declares `bundle.resources: ["packs"]`, which resolves
+      # to `src-tauri/packs/`. That directory is BUILT, not committed
+      # (src-tauri/.gitignore:58 is `/packs/`), so a fresh CI checkout does not
+      # have it and Tauri refuses before it does anything else.
+      #
+      # Putting it in `beforeBuildCommand` is NOT enough and that is the whole
+      # trap: the log shows `tauri ios init` printing "Project generated
+      # successfully" and then failing 0.8s later, long before
+      # `beforeBuildCommand` — which does run `npm run packs` — is ever
+      # invoked. The resource has to exist before the Tauri CLI is called at
+      # all. It went unnoticed locally because a developer's gitignored
+      # `src-tauri/packs/` is already populated from an earlier run.
+      - name: Build the game packs
+        working-directory: dynawalla/dynawalla-app
+        run: npm run packs
 
       - name: Force manual signing in the CI working copy
         working-directory: dynawalla/dynawalla-app
@@ -662,6 +715,37 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Preflight · the Play app record exists and is reachable
+        # The Android twin of the iOS preflight above, and for the same reason:
+        # the Play app record is a founder Console action (androidpublisher has
+        # no app-create method) and a per-app permission grant does NOT inherit
+        # from the developer account (docs/STORE.md G-09). Both were only
+        # discovered by "Snapshot the Play internal track", which runs after the
+        # Gradle build and the signing — the whole expensive half of this job.
+        #
+        # This is the SAME `--snapshot` invocation, unchanged, run early. It
+        # opens a throwaway edit against the package, which is exactly what
+        # 404s on a missing app record and 403s on a missing grant, and it
+        # tolerates a track with no releases (`allow_missing`), which is the
+        # normal state before a first release.
+        #
+        # Deliberately given NO `id:`. Its `version_codes` output must be
+        # unreachable: the baseline the post-upload check compares against has
+        # to be read immediately BEFORE the upload, and an id here would make
+        # it possible to wire this hour-old reading in by mistake — which would
+        # silently defeat the duplicate detection it exists for.
+        #
+        # It runs after setup-python on purpose: the runner's system python is
+        # PEP 668 externally-managed and refuses `pip install`.
+        env:
+          PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          PLAY_PACKAGE_NAME: ${{ env.BUNDLE_ID }}
+          PLAY_TRACK: internal
+        run: |
+          set -euo pipefail
+          python3 -m pip install --quiet --disable-pip-version-check 'pyjwt[crypto]'
+          python3 .github/scripts/verify_play_upload.py --snapshot
+
       - name: Rust + Android targets
         run: |
           rustup toolchain install stable --profile minimal
@@ -692,7 +776,31 @@ jobs:
         run: |
           set -euo pipefail
           NDK_VER=28.2.13676358
-          yes | sdkmanager "ndk;$NDK_VER" "platforms;android-36" "build-tools;36.0.0" >/dev/null
+          # NO `yes |` HERE. That form was lifted verbatim from
+          # release-mobile.yml, where it is safe only because that step does
+          # not `set -o pipefail`. Here it does, and the consequence is the
+          # exact trap this file already documents three times over (the `nm`
+          # note in the iOS job, the `sed -n` note in the AAB inspection, the
+          # `head` note in the signing step): sdkmanager on a pre-licensed
+          # image never reads a byte of stdin, so `yes` fills the 64 kB pipe
+          # buffer, blocks, and takes SIGPIPE the moment sdkmanager exits.
+          # `yes` therefore dies 141 on the SUCCESS path, pipefail makes the
+          # pipeline 141, and `set -e` aborts the Android job three minutes in
+          # with no diagnostic at all. Reproduced locally against a stand-in
+          # that behaves like sdkmanager: the pipeline returned 141 while
+          # sdkmanager returned 0.
+          #
+          # `</dev/null` rather than nothing: there is then no pipeline to
+          # SIGPIPE and no dependence on whatever the runner happens to attach
+          # to a step's stdin. If a license ever were unaccepted,
+          # android-actions/setup-android accepts them all and the ubuntu image
+          # ships $ANDROID_HOME/licenses pre-populated, but were that to change
+          # sdkmanager reads EOF, declines, and exits non-zero with its own
+          # message on stderr — a real failure with a real cause, which is what
+          # 141 was hiding. stderr is deliberately NOT discarded for that
+          # reason; only the progress bar's thousands of carriage returns are.
+          sdkmanager --install "ndk;$NDK_VER" "platforms;android-36" "build-tools;36.0.0" \
+            </dev/null >/dev/null
           NDK="$ANDROID_SDK_ROOT/ndk/$NDK_VER"
           test -x "$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android26-clang" \
             || { echo "::error::NDK clang not found at $NDK"; exit 1; }
@@ -701,6 +809,13 @@ jobs:
       - name: Install deps
         working-directory: dynawalla/dynawalla-app
         run: npm ci
+
+      # Same reason as the iOS job: `bundle.resources` names a built,
+      # gitignored directory, and the Tauri CLI resolves it before
+      # `beforeBuildCommand` runs. See the long note in the iOS job.
+      - name: Build the game packs
+        working-directory: dynawalla/dynawalla-app
+        run: npm run packs
 
       - name: Tauri Android build (unsigned AAB)
         working-directory: dynawalla/dynawalla-app

--- a/dynawalla/dynawalla-app/src-tauri/src/packs/mod.rs
+++ b/dynawalla/dynawalla-app/src-tauri/src/packs/mod.rs
@@ -26,8 +26,9 @@
 //! pack ever published. It is a public API from the first release and it can
 //! never be renamed.
 
+use std::collections::BTreeMap;
 use std::fs;
-use std::io::Read;
+use std::io::{Read, Seek};
 use std::path::{Component, Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -92,11 +93,32 @@ pub enum Progress {
     Installing,
 }
 
-/// What the manifest inside the archive must agree with the catalogue about.
+/// What the manifest inside the archive must agree with the catalogue about,
+/// plus the digest of the content it was built from. Everything else in a
+/// manifest is the SDK schema's business, on the JS side.
 #[derive(Debug, Deserialize)]
 struct ManifestIdentity {
     id: String,
     version: String,
+    /// Optional here and required by the schema, which is not a contradiction:
+    /// the schema is enforced by `dw-pack check` at build time and this is the
+    /// side that has to survive a file that got past it anyway.
+    #[serde(default)]
+    download: Option<ManifestDownload>,
+}
+
+/// `packs/build.mjs` computes `download.sha256` over every file of the built
+/// pack except `manifest.json` itself — the manifest carries the digest, so
+/// hashing it would be a fixed point nothing could compute. Path and length go
+/// into the hash beside the bytes, so a renamed or truncated file moves it as
+/// surely as a flipped bit does.
+///
+/// That is what makes it the right thing to compare a bundled pack against: it
+/// is a fact about the content, and a version is a product decision.
+#[derive(Debug, Deserialize)]
+struct ManifestDownload {
+    #[serde(default)]
+    sha256: Option<String>,
 }
 
 // ─── Layout ──────────────────────────────────────────────────────────────────
@@ -684,28 +706,226 @@ fn extract_within(
 
 // ─── Packs that ship with the app ────────────────────────────────────────────
 
-/// Where the packs bundled with this build live.
+/// Entries under this prefix in an APK are the packs bundled with the build.
 ///
-/// Two answers, and both are needed. In a release the packs are a Tauri
-/// resource and sit under `resource_dir()`. In `npm run tauri dev` there is no
-/// bundle: `packs/build.mjs` stages them into `src-tauri/packs/`, which is a
-/// compile-time constant of this crate, so the dev loop needs no environment
-/// variable, no symlink and no manual install step.
-fn bundled_root<R: Runtime>(app: &AppHandle<R>) -> Option<PathBuf> {
-    if let Ok(dir) = app.path().resource_dir() {
-        let candidate = dir.join("packs");
-        if candidate.is_dir() {
-            return Some(candidate);
+/// `assets/` because `tauri android build` copies everything named in
+/// `bundle.resources` into `gen/android/app/src/main/assets/` verbatim, and
+/// `packs` because that is the single resource `tauri.conf.json` declares.
+const APK_PACK_PREFIX: &str = "assets/packs/";
+
+/// Every file this process has mapped. A named constant so the parsing below
+/// can be exercised against a fixture rather than against this process.
+const PROC_SELF_MAPS: &str = "/proc/self/maps";
+
+/// Where the packs bundled with this build are, in the form the platform
+/// actually keeps them in.
+enum Bundled {
+    /// A directory whose children are pack directories.
+    Directory(PathBuf),
+    /// An APK. The packs are ZIP entries under [`APK_PACK_PREFIX`].
+    Apk(PathBuf),
+}
+
+/// Find them, or say — loudly — that there are none.
+///
+/// Three answers, and each is the only right answer on a platform this app
+/// ships to.
+///
+/// * **A desktop or iOS release** — the packs are a Tauri resource and sit
+///   under `resource_dir()` as an ordinary directory.
+/// * **`npm run tauri dev`** — there is no bundle. `packs/build.mjs` stages
+///   them into `src-tauri/packs/`, a compile-time constant of this crate, so
+///   the dev loop needs no environment variable, no symlink and no manual
+///   install step.
+/// * **Android** — there is no directory anywhere on the device.
+///   `resource_dir()` hands back the literal string `asset://localhost/`: an
+///   Android asset URI, not a path, because `tauri android build` puts the
+///   resources INSIDE the APK, where the platform reaches them only through its
+///   AssetManager. `is_dir()` on that URI is false, and that single false is
+///   why the Android build installed ZERO packs and printed nothing about it.
+///
+///   An APK is a ZIP and this crate already links a ZIP reader, so the packs
+///   are read straight out of it. Locating the APK needs neither JNI nor a new
+///   dependency: the dynamic linker mapped this very library out of the APK, or
+///   out of a split of it, and `/proc/self/maps` names every file the process
+///   has mapped.
+///
+/// Every branch that fails names the path or URI it tried. A bundled pack that
+/// does not arrive is a child opening an empty app, and the version of this
+/// function that shipped returned `None` in complete silence.
+fn bundled_source<R: Runtime>(app: &AppHandle<R>) -> Option<Bundled> {
+    match app.path().resource_dir() {
+        Ok(dir) => {
+            let candidate = dir.join("packs");
+            if candidate.is_dir() {
+                return Some(Bundled::Directory(candidate));
+            }
+            eprintln!(
+                "[packs] the resource directory has no packs directory in it: {}",
+                candidate.display()
+            );
         }
+        Err(problem) => eprintln!("[packs] there is no resource directory: {problem}"),
     }
+
     #[cfg(debug_assertions)]
     {
         let candidate = Path::new(env!("CARGO_MANIFEST_DIR")).join("packs");
         if candidate.is_dir() {
-            return Some(candidate);
+            return Some(Bundled::Directory(candidate));
+        }
+        eprintln!(
+            "[packs] nothing staged for the dev loop at {} — run `npm run packs`",
+            candidate.display()
+        );
+    }
+
+    let maps = match fs::read_to_string(PROC_SELF_MAPS) {
+        Ok(maps) => maps,
+        Err(problem) => {
+            eprintln!("[packs] cannot read {PROC_SELF_MAPS}: {problem}");
+            String::new()
+        }
+    };
+    let mut examined = vec![];
+    for apk in apk_candidates(&maps, own_code_address()) {
+        match holds_bundled_packs(&apk) {
+            Ok(true) => return Some(Bundled::Apk(apk)),
+            Ok(false) => examined.push(format!("{} (no {APK_PACK_PREFIX})", apk.display())),
+            Err(problem) => examined.push(format!("{}: {problem}", apk.display())),
         }
     }
+
+    eprintln!(
+        "[packs] NO BUNDLED PACKS FOUND — this build has none installed and will show an empty \
+         app. Archives examined: {}",
+        if examined.is_empty() {
+            "none".to_string()
+        } else {
+            examined.join("; ")
+        }
+    );
     None
+}
+
+/// The address of a byte of this library's own code.
+///
+/// Used to pick our own mapping out of `/proc/self/maps`, where it is one line
+/// among hundreds. Casting a function to `usize` is the whole trick and it needs
+/// nothing linked: whatever address it produces is inside the file this code was
+/// loaded from, which is the file we are looking for.
+fn own_code_address() -> usize {
+    own_code_address as *const () as usize
+}
+
+/// Every APK this process might have been loaded from, best guess first.
+///
+/// A line of `/proc/self/maps` ends in the path of the mapped file, and on
+/// Android at least one mapping always points inside the installed application:
+/// either the APK itself — `extractNativeLibs=false` is the modern default, and
+/// then the linker maps the library straight out of the archive — or the
+/// extracted copy at `<install>/lib/<abi>/lib*.so`.
+///
+/// Two orderings, both load-bearing.
+///
+/// The mapping that *contains `own_code`* is tried first. An Android app
+/// process has other applications' APKs mapped into it — the system WebView's
+/// above all, which is hundreds of megabytes with a central directory to match —
+/// and opening one of those first would cost real milliseconds before the first
+/// window, every launch, for nothing. The address of our own code is in exactly
+/// one of these ranges and that range names our own file.
+///
+/// Within a mapping, `base.apk` beside it comes before the mapped file itself.
+/// A Play install of an app bundle is SPLIT: the native library is in
+/// `split_config.arm64_v8a.apk` and every asset is in `base.apk` next to it. The
+/// mapping names the split; the packs are in the sibling.
+fn apk_candidates(maps: &str, own_code: usize) -> Vec<PathBuf> {
+    let mut ours: Vec<PathBuf> = vec![];
+    let mut ours_direct: Vec<PathBuf> = vec![];
+    let mut preferred: Vec<PathBuf> = vec![];
+    let mut fallback: Vec<PathBuf> = vec![];
+
+    for line in maps.lines() {
+        // Only the pathname column can hold a slash: the address range,
+        // permissions, offset, device and inode never do.
+        let Some(start) = line.find('/') else {
+            continue;
+        };
+        let mapped = mapped_range(&line[..start])
+            .is_some_and(|(low, high)| own_code >= low && own_code < high);
+
+        let path = line[start..].trim_end();
+        let path = path.strip_suffix(" (deleted)").unwrap_or(path);
+        // `…/base.apk!/lib/arm64-v8a/libdynawalla_lib.so` is how a library
+        // mapped out of an uncompressed APK is named on some releases.
+        // Everything from the `!` on is a path INSIDE the archive.
+        let path = match path.find(".apk") {
+            Some(end) => &path[..end + ".apk".len()],
+            None => path,
+        };
+
+        let (sibling, itself) = if path.ends_with(".apk") {
+            let apk = Path::new(path);
+            (
+                apk.parent().map(|directory| directory.join("base.apk")),
+                Some(apk.to_path_buf()),
+            )
+        } else if path.ends_with(".so") {
+            // `<install>/lib/<abi>/lib*.so` → `<install>`. The `lib` component
+            // is checked rather than assumed so that an ordinary Linux desktop,
+            // whose maps are full of shared objects, proposes nothing.
+            let lib = Path::new(path).parent().and_then(Path::parent);
+            let install = lib
+                .and_then(Path::file_name)
+                .is_some_and(|name| name == "lib")
+                .then(|| lib.and_then(Path::parent))
+                .flatten();
+            (install.map(|install| install.join("base.apk")), None)
+        } else {
+            (None, None)
+        };
+
+        if mapped {
+            ours.extend(sibling);
+            ours_direct.extend(itself);
+        } else {
+            preferred.extend(sibling);
+            fallback.extend(itself);
+        }
+    }
+
+    let mut candidates: Vec<PathBuf> = vec![];
+    for candidate in ours
+        .into_iter()
+        .chain(ours_direct)
+        .chain(preferred)
+        .chain(fallback)
+    {
+        if !candidates.contains(&candidate) {
+            candidates.push(candidate);
+        }
+    }
+    candidates
+}
+
+/// The `low-high` address range a `/proc/self/maps` line opens with.
+fn mapped_range(head: &str) -> Option<(usize, usize)> {
+    let mut bounds = head.split_whitespace().next()?.split('-');
+    let low = usize::from_str_radix(bounds.next()?, 16).ok()?;
+    let high = usize::from_str_radix(bounds.next()?, 16).ok()?;
+    Some((low, high))
+}
+
+/// Whether this archive is the one carrying the app's packs.
+///
+/// Cheap on purpose: it reads the ZIP central directory and not one entry body,
+/// so proposing a wrong APK costs a few kilobytes of I/O rather than a decode.
+fn holds_bundled_packs(apk: &Path) -> Result<bool, String> {
+    let file = fs::File::open(apk).map_err(|e| e.to_string())?;
+    let archive = zip::ZipArchive::new(std::io::BufReader::new(file)).map_err(|e| e.to_string())?;
+    Ok(archive
+        .file_names()
+        .any(|name| name.starts_with(APK_PACK_PREFIX)))
 }
 
 fn copy_tree(from: &Path, to: &Path) -> std::io::Result<()> {
@@ -726,30 +946,116 @@ fn copy_tree(from: &Path, to: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Install the packs that ship with this build, if they are not already the
-/// version installed.
+/// Whether the bundled copy of a pack has to be written over what is installed.
 ///
-/// Called at setup, before any window is shown. The whole point is that the
-/// front door is never empty on a first launch and never stale in development:
-/// a debug build re-copies unconditionally, so editing a pack and restarting is
-/// the entire dev loop, while a release build only acts when the version
-/// changed and therefore does not rewrite a device's pack directory on every
-/// cold start.
+/// **By digest, not by version.** A pack's version is a product decision; a
+/// content fix is not, and most content fixes keep the version exactly where it
+/// was. Comparing versions therefore means a corrected pack sits inside the
+/// binary while the device goes on running the broken one *forever*: there is
+/// no later event that notices, because every subsequent launch compares the
+/// same two equal versions and skips again. `download.sha256` is a fact about
+/// the bytes, so it moves whenever any of them do.
 ///
-/// Failures are logged and swallowed. A bundled pack that will not copy is a
-/// pack the child does not get; it is not a reason for the app not to open.
-pub fn sync_bundled<R: Runtime>(app: &AppHandle<R>) {
-    let Some(source) = bundled_root(app) else {
-        return;
+/// The version comparison survives only as the fallback for a manifest with no
+/// digest in it. The schema requires one and `dw-pack check` gates it, so a
+/// pack arriving here without one is a defect in the pipeline and says so.
+fn bundled_pack_differs(pack_id: &str, installed: Option<&str>, bundled: &str) -> bool {
+    let Some(bundled) = manifest_identity(bundled) else {
+        // Unreadable. Let the caller attempt the install and fail out loud
+        // there rather than quietly deciding there is nothing to do.
+        return true;
     };
-    let Ok(root) = pack_root(app) else {
-        eprintln!("[packs] no pack root; bundled packs were not installed");
-        return;
+    let Some(installed) = installed.and_then(manifest_identity) else {
+        return true;
     };
 
-    let Ok(entries) = fs::read_dir(&source) else {
-        return;
+    let installed_digest = installed.download.and_then(|download| download.sha256);
+    let bundled_digest = bundled.download.and_then(|download| download.sha256);
+    match (installed_digest, bundled_digest) {
+        (Some(installed_digest), Some(bundled_digest)) => {
+            !installed_digest.eq_ignore_ascii_case(&bundled_digest)
+        }
+        _ => {
+            eprintln!(
+                "[packs] {pack_id} has no download.sha256 in one of its manifests, so a content \
+                 fix that keeps version {} cannot be seen; falling back to the version",
+                bundled.version
+            );
+            installed.version != bundled.version
+        }
+    }
+}
+
+fn manifest_identity(manifest: &str) -> Option<ManifestIdentity> {
+    serde_json::from_str(manifest).ok()
+}
+
+/// The verbatim manifest of the pack directory at `dir`, if it has one.
+fn manifest_at(dir: &Path) -> Option<String> {
+    fs::read_to_string(dir.join("manifest.json")).ok()
+}
+
+/// Whether this pack should be written over the installed one, given both
+/// manifests — the digest rule, plus the dev-loop override.
+///
+/// A debug build re-copies unconditionally, so editing a pack and restarting is
+/// the entire dev loop.
+fn should_install(pack_id: &str, destination: &Path, bundled: &str) -> bool {
+    if cfg!(debug_assertions) {
+        return true;
+    }
+    bundled_pack_differs(pack_id, manifest_at(destination).as_deref(), bundled)
+}
+
+/// Install the packs that ship with this build, if the installed copy is not
+/// already byte-for-byte the same pack.
+///
+/// Called at setup, before any window is shown, so the front door is never
+/// empty on a first launch and never stale in development.
+///
+/// Failures are logged and swallowed. A bundled pack that will not copy is a
+/// pack the child does not get; it is not a reason for the app not to open. It
+/// is emphatically a reason to print something: this function used to return in
+/// silence on Android, which is how an entire platform shipped with no packs.
+pub fn sync_bundled<R: Runtime>(app: &AppHandle<R>) {
+    let root = match pack_root(app) {
+        Ok(root) => root,
+        Err(problem) => {
+            eprintln!("[packs] no pack root ({problem}); bundled packs were NOT installed");
+            return;
+        }
     };
+
+    match bundled_source(app) {
+        Some(Bundled::Directory(source)) => sync_from_directory(&source, &root),
+        Some(Bundled::Apk(apk)) => match fs::File::open(&apk) {
+            Ok(file) => match zip::ZipArchive::new(std::io::BufReader::new(file)) {
+                Ok(mut archive) => sync_from_zip(&mut archive, &root),
+                Err(problem) => eprintln!(
+                    "[packs] {} is not readable as an archive: {problem}",
+                    apk.display()
+                ),
+            },
+            Err(problem) => eprintln!("[packs] cannot open {}: {problem}", apk.display()),
+        },
+        // `bundled_source` has already named everything it tried.
+        None => {}
+    }
+}
+
+fn sync_from_directory(source: &Path, root: &Path) {
+    let entries = match fs::read_dir(source) {
+        Ok(entries) => entries,
+        Err(problem) => {
+            eprintln!(
+                "[packs] cannot read the bundled packs at {}: {problem}",
+                source.display()
+            );
+            return;
+        }
+    };
+
+    let mut found = 0usize;
     for entry in entries.flatten() {
         if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
             continue;
@@ -758,21 +1064,22 @@ pub fn sync_bundled<R: Runtime>(app: &AppHandle<R>) {
         if !valid_pack_id(&name) {
             continue;
         }
-        let Some(bundled) = read_installed(&entry.path()) else {
+        found += 1;
+        let Some(manifest) = manifest_at(&entry.path()) else {
             eprintln!("[packs] bundled {name} has no readable manifest.json");
             continue;
         };
-        if bundled.id != name {
-            eprintln!("[packs] bundled {name} calls itself {}", bundled.id);
+        let Some(identity) = manifest_identity(&manifest) else {
+            eprintln!("[packs] bundled {name} has an unparseable manifest.json");
+            continue;
+        };
+        if identity.id != name {
+            eprintln!("[packs] bundled {name} calls itself {}", identity.id);
             continue;
         }
 
         let destination = root.join(&name);
-        let current = read_installed(&destination);
-        let same_version = current
-            .as_ref()
-            .is_some_and(|installed| installed.version == bundled.version);
-        if same_version && !cfg!(debug_assertions) {
+        if !should_install(&name, &destination, &manifest) {
             continue;
         }
 
@@ -782,6 +1089,118 @@ pub fn sync_bundled<R: Runtime>(app: &AppHandle<R>) {
             let _ = fs::remove_dir_all(&destination);
         }
     }
+
+    if found == 0 {
+        eprintln!(
+            "[packs] {} exists but holds no pack directories; nothing was installed",
+            source.display()
+        );
+    }
+}
+
+/// Install every pack an APK carries under `assets/packs/`.
+///
+/// Compiled on every target rather than hidden behind
+/// `#[cfg(target_os = "android")]`, so the tests below exercise it on the
+/// machine you are reading this on. Only the *discovery* of the APK is
+/// Android-shaped, and everywhere else it proposes nothing to open.
+fn sync_from_zip<S: Read + Seek>(archive: &mut zip::ZipArchive<S>, root: &Path) {
+    // The names are taken first and owned: `by_name` needs `&mut archive`, so
+    // the borrow `file_names` hands out cannot survive the reads below.
+    let mut by_pack: BTreeMap<String, Vec<(String, String)>> = BTreeMap::new();
+    for name in archive.file_names() {
+        if name.ends_with('/') {
+            continue;
+        }
+        let Some(rest) = name.strip_prefix(APK_PACK_PREFIX) else {
+            continue;
+        };
+        let mut parts = rest.splitn(2, '/');
+        let (Some(id), Some(relative)) = (parts.next(), parts.next()) else {
+            continue;
+        };
+        if relative.is_empty() || !valid_pack_id(id) {
+            continue;
+        }
+        by_pack
+            .entry(id.to_string())
+            .or_default()
+            .push((name.to_string(), relative.to_string()));
+    }
+
+    if by_pack.is_empty() {
+        eprintln!("[packs] this archive holds no {APK_PACK_PREFIX} entries; nothing was installed");
+        return;
+    }
+
+    for (id, entries) in by_pack {
+        let manifest_entry = format!("{APK_PACK_PREFIX}{id}/manifest.json");
+        let Some(manifest) = zip_entry_string(archive, &manifest_entry) else {
+            eprintln!("[packs] bundled {id} has no readable {manifest_entry}");
+            continue;
+        };
+        let Some(identity) = manifest_identity(&manifest) else {
+            eprintln!("[packs] bundled {id} has an unparseable manifest.json");
+            continue;
+        };
+        if identity.id != id {
+            eprintln!("[packs] bundled {id} calls itself {}", identity.id);
+            continue;
+        }
+
+        let destination = root.join(&id);
+        if !should_install(&id, &destination, &manifest) {
+            continue;
+        }
+
+        let _ = fs::remove_dir_all(&destination);
+        if let Err(problem) = unpack_into(archive, &entries, &destination) {
+            eprintln!("[packs] could not install bundled {id}: {problem}");
+            let _ = fs::remove_dir_all(&destination);
+        }
+    }
+}
+
+fn zip_entry_string<S: Read + Seek>(
+    archive: &mut zip::ZipArchive<S>,
+    name: &str,
+) -> Option<String> {
+    let mut entry = archive.by_name(name).ok()?;
+    let mut body = String::new();
+    entry.read_to_string(&mut body).ok()?;
+    Some(body)
+}
+
+/// Write one pack's entries out of the archive and into `destination`.
+///
+/// `safe_entry_path` is applied even though this archive was built by our own
+/// pipeline. The rule already exists, it costs a string walk per file, and an
+/// APK is still a ZIP whose entry names are strings — the property "a pack
+/// cannot escape its directory" should not quietly acquire an exception for the
+/// one code path nobody can test on a device.
+fn unpack_into<S: Read + Seek>(
+    archive: &mut zip::ZipArchive<S>,
+    entries: &[(String, String)],
+    destination: &Path,
+) -> Result<(), String> {
+    for (name, relative) in entries {
+        let Some(relative) = safe_entry_path(relative) else {
+            return Err(format!("entry escapes the pack directory: {name}"));
+        };
+        let target = destination.join(relative);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).map_err(|e| format!("cannot create {parent:?}: {e}"))?;
+        }
+        let mut entry = archive
+            .by_name(name)
+            .map_err(|e| format!("unreadable entry {name}: {e}"))?;
+        let mut body = Vec::new();
+        entry
+            .read_to_end(&mut body)
+            .map_err(|e| format!("cannot read {name}: {e}"))?;
+        fs::write(&target, &body).map_err(|e| format!("cannot write {target:?}: {e}"))?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/dynawalla/dynawalla-app/src-tauri/src/packs/tests.rs
+++ b/dynawalla/dynawalla-app/src-tauri/src/packs/tests.rs
@@ -314,3 +314,285 @@ fn the_download_origin_is_pinned_to_one_https_prefix() {
         "a prefix without a trailing slash matches a sibling host"
     );
 }
+
+// ─── Bundled packs ───────────────────────────────────────────────────────────
+
+fn manifest_json(id: &str, version: &str, digest: Option<&str>) -> String {
+    match digest {
+        Some(digest) => format!(
+            r#"{{"schema":1,"id":"{id}","version":"{version}","download":{{"bytes":10,"sha256":"{digest}"}}}}"#
+        ),
+        None => format!(r#"{{"schema":1,"id":"{id}","version":"{version}"}}"#),
+    }
+}
+
+#[test]
+fn a_content_fix_that_keeps_the_version_still_reaches_the_device() {
+    // The defect this replaced: `0.1.0` on both sides, different bytes, and the
+    // corrected pack never left the binary because the two versions matched.
+    let installed = manifest_json("abacus", "0.1.0", Some(&"a".repeat(64)));
+    let fixed = manifest_json("abacus", "0.1.0", Some(&"b".repeat(64)));
+    assert!(
+        bundled_pack_differs("abacus", Some(&installed), &fixed),
+        "a same-version content fix was skipped"
+    );
+}
+
+#[test]
+fn a_pack_that_has_not_changed_is_left_where_it_is() {
+    let digest = "c".repeat(64);
+    let installed = manifest_json("abacus", "0.1.0", Some(&digest));
+    let bundled = manifest_json("abacus", "0.9.9", Some(&digest));
+    assert!(
+        !bundled_pack_differs("abacus", Some(&installed), &bundled),
+        "identical content was rewritten on a cold start"
+    );
+    // And the digest is compared case-insensitively, because hex is.
+    let shouting = manifest_json("abacus", "0.1.0", Some(&digest.to_ascii_uppercase()));
+    assert!(!bundled_pack_differs(
+        "abacus",
+        Some(&shouting),
+        &manifest_json("abacus", "0.1.0", Some(&digest))
+    ));
+}
+
+#[test]
+fn nothing_installed_means_install() {
+    let bundled = manifest_json("abacus", "0.1.0", Some(&"d".repeat(64)));
+    assert!(bundled_pack_differs("abacus", None, &bundled));
+    assert!(bundled_pack_differs("abacus", Some("not json"), &bundled));
+    assert!(bundled_pack_differs("abacus", Some(&bundled), "not json"));
+}
+
+#[test]
+fn a_manifest_with_no_digest_falls_back_to_the_version() {
+    let old = manifest_json("abacus", "0.1.0", None);
+    let new = manifest_json("abacus", "0.2.0", None);
+    assert!(bundled_pack_differs("abacus", Some(&old), &new));
+    assert!(!bundled_pack_differs("abacus", Some(&old), &old));
+    // One side missing it is enough to lose the digest comparison.
+    let digested = manifest_json("abacus", "0.1.0", Some(&"e".repeat(64)));
+    assert!(!bundled_pack_differs("abacus", Some(&old), &digested));
+}
+
+/// A plausible `/proc/self/maps` for this app on Android, installed from an app
+/// bundle. The library is in the ABI split; the assets are in `base.apk` beside
+/// it; and the system WebView — another application's APK entirely — is mapped
+/// into the process too, as it always is.
+const ANDROID_MAPS: &str = concat!(
+    "6f2a000000-6f2a1f4000 r--p 00000000 fd:03 1234 /apex/com.android.runtime/lib64/bionic/libc.so\n",
+    "7000000000-7000010000 rw-p 00000000 00:00 0 [anon:.bss]\n",
+    "7100000000-71ff000000 r--p 00000000 fd:03 4242 /data/app/~~Web==/com.google.android.trichromelibrary_1-a==/base.apk\n",
+    "7a00000000-7a00123000 r--p 00000000 fd:03 5678 /data/app/~~AbC==/inc.corpora.dynawalla-XyZ==/split_config.arm64_v8a.apk\n",
+    "7b00000000-7b00123000 r-xp 00100000 fd:03 5678 /data/app/~~AbC==/inc.corpora.dynawalla-XyZ==/split_config.arm64_v8a.apk\n",
+);
+
+/// An address inside the executable segment of the split above.
+const OWN_CODE: usize = 0x007b_0000_0100;
+
+#[test]
+fn the_apk_beside_a_split_is_preferred_over_the_split_itself() {
+    // A Play install of an app bundle: the native library is mapped out of the
+    // ABI split, and every asset — the packs among them — is in `base.apk`
+    // beside it. Reading the split would find nothing.
+    let candidates = apk_candidates(ANDROID_MAPS, OWN_CODE);
+    assert_eq!(
+        candidates.first().map(|p| p.to_string_lossy().to_string()),
+        Some("/data/app/~~AbC==/inc.corpora.dynawalla-XyZ==/base.apk".to_string()),
+        "{candidates:?}"
+    );
+    assert!(
+        candidates.contains(&PathBuf::from(
+            "/data/app/~~AbC==/inc.corpora.dynawalla-XyZ==/split_config.arm64_v8a.apk"
+        )),
+        "the split itself is still worth trying: {candidates:?}"
+    );
+    // Each candidate appears once however many segments were mapped.
+    let mut unique = candidates.clone();
+    unique.dedup();
+    assert_eq!(unique.len(), candidates.len(), "{candidates:?}");
+}
+
+#[test]
+fn another_applications_apk_is_never_opened_first() {
+    // The system WebView's APK is mapped into every Android app process and is
+    // hundreds of megabytes. Opening it before our own would read a central
+    // directory to match, before the first window, on every single launch.
+    let candidates = apk_candidates(ANDROID_MAPS, OWN_CODE);
+    let webview = candidates
+        .iter()
+        .position(|c| c.to_string_lossy().contains("trichromelibrary"))
+        .expect("the WebView is still a candidate of last resort");
+    assert!(webview > 0, "{candidates:?}");
+    assert!(
+        candidates[..webview]
+            .iter()
+            .all(|c| c.to_string_lossy().contains("inc.corpora.dynawalla")),
+        "{candidates:?}"
+    );
+}
+
+#[test]
+fn an_extracted_library_and_a_library_inside_the_apk_both_name_the_install() {
+    let extracted = apk_candidates(
+        "7a00000000-7a00123000 r-xp 00000000 fd:03 1 \
+         /data/app/~~q==/inc.corpora.dynawalla-w==/lib/arm64/libdynawalla_lib.so\n",
+        0x007a_0000_0100,
+    );
+    assert_eq!(
+        extracted,
+        vec![PathBuf::from(
+            "/data/app/~~q==/inc.corpora.dynawalla-w==/base.apk"
+        )]
+    );
+
+    // `extractNativeLibs=false`: the library is mapped from inside the archive,
+    // and everything after the `!` is a path within it.
+    let inside = apk_candidates(
+        "7a00000000-7a00123000 r-xp 00000000 fd:03 1 \
+         /data/app/~~q==/inc.corpora.dynawalla-w==/base.apk!/lib/arm64-v8a/libdynawalla_lib.so\n",
+        0x007a_0000_0100,
+    );
+    assert_eq!(
+        inside,
+        vec![PathBuf::from(
+            "/data/app/~~q==/inc.corpora.dynawalla-w==/base.apk"
+        )]
+    );
+}
+
+#[test]
+fn an_ordinary_desktop_maps_file_proposes_no_apk() {
+    // The Android path is compiled on every target, so it has to be inert on
+    // the ones that are full of shared objects and have no APK anywhere.
+    let maps = concat!(
+        "5600000000-5600100000 r-xp 00000000 08:01 1 /usr/bin/dynawalla\n",
+        "7f0000000000-7f0000100000 r-xp 00000000 08:01 2 /usr/lib/x86_64-linux-gnu/libssl.so.3\n",
+        "7f1000000000-7f1000100000 r-xp 00000000 08:01 3 /home/kid/build/target/debug/deps/libfoo.so\n",
+        "7ffd00000000-7ffd00021000 rw-p 00000000 00:00 0 [stack]\n",
+    );
+    assert!(
+        apk_candidates(maps, 0x7f00_0000_0100).is_empty(),
+        "{:?}",
+        apk_candidates(maps, 0x7f00_0000_0100)
+    );
+}
+
+#[test]
+fn the_real_address_of_this_code_selects_the_mapping_that_holds_it() {
+    // `own_code_address` is a genuine code address here, not a fixture, so this
+    // exercises the one link that a hand-written maps file cannot: that the
+    // number the cast produces is the kind of number the parser compares
+    // against. Only the mapping is fabricated, and it is fabricated AROUND the
+    // real address.
+    let own = own_code_address();
+    assert!(own > 0);
+    let maps = format!(
+        "{:x}-{:x} r--p 00000000 fd:03 1 /data/app/~~w==/other.app-x==/base.apk\n\
+         {:x}-{:x} r-xp 00000000 fd:03 2 /data/app/~~y==/inc.corpora.dynawalla-z==/split_config.arm64_v8a.apk\n",
+        own.saturating_sub(0x4000),
+        own.saturating_sub(0x2000),
+        own.saturating_sub(0x1000),
+        own + 0x1000,
+    );
+    assert_eq!(
+        apk_candidates(&maps, own).first(),
+        Some(&PathBuf::from(
+            "/data/app/~~y==/inc.corpora.dynawalla-z==/base.apk"
+        )),
+        "the mapping holding this very function did not win"
+    );
+}
+
+#[test]
+fn our_own_code_is_inside_a_mapping_this_parser_can_find() {
+    // And on the one platform where `/proc/self/maps` exists at all, the real
+    // file really does contain the real address. Skipped elsewhere rather than
+    // faked: a macOS run has nothing to say about this.
+    let Ok(maps) = fs::read_to_string(PROC_SELF_MAPS) else {
+        return;
+    };
+    let own = own_code_address();
+    assert!(
+        maps.lines()
+            .filter_map(|line| mapped_range(line.split_whitespace().next().unwrap_or("")))
+            .any(|(low, high)| own >= low && own < high),
+        "no mapping contains {own:#x}"
+    );
+}
+
+#[test]
+fn packs_are_installed_out_of_an_apk_because_android_has_no_resource_directory() {
+    // The blocker, end to end without a device: `resource_dir()` on Android is
+    // the string `asset://localhost/`, so the packs are read out of the APK,
+    // which is a ZIP with the packs under `assets/packs/`.
+    let root = scratch("apk");
+    let manifest = manifest_json("dynawalla.fuse", "0.1.0", Some(&"f".repeat(64)));
+    let archive = zip_of(&[
+        ("AndroidManifest.xml", b"binary xml"),
+        ("classes.dex", b"dex"),
+        ("assets/tauri.conf.json", b"{}"),
+        (
+            "assets/packs/dynawalla.fuse/manifest.json",
+            manifest.as_bytes(),
+        ),
+        ("assets/packs/dynawalla.fuse/pack.html", b"<!doctype html>"),
+        ("assets/packs/dynawalla.fuse/dist/app.js", b"console.log(1)"),
+        // Not a pack id, so not a directory this host will ever serve.
+        ("assets/packs/NotAPack/x.js", b"no"),
+        ("lib/arm64-v8a/libdynawalla_lib.so", b"elf"),
+    ]);
+
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(archive)).expect("apk");
+    sync_from_zip(&mut zip, &root);
+
+    let installed = root.join("dynawalla.fuse");
+    assert_eq!(
+        fs::read_to_string(installed.join("dist/app.js")).unwrap(),
+        "console.log(1)"
+    );
+    assert_eq!(
+        fs::read_to_string(installed.join("pack.html")).unwrap(),
+        "<!doctype html>"
+    );
+    let identity = read_installed(&installed).expect("manifest");
+    assert_eq!(identity.id, "dynawalla.fuse");
+    assert_eq!(identity.version, "0.1.0");
+    assert!(
+        !root.join("NotAPack").exists(),
+        "an invalid id was installed"
+    );
+    assert!(!root.join("tauri.conf.json").exists());
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn an_apk_entry_that_escapes_its_pack_installs_nothing_at_all() {
+    let root = scratch("apkslip");
+    fs::create_dir_all(&root).unwrap();
+    let manifest = manifest_json("abacus", "0.1.0", Some(&"0".repeat(64)));
+    let archive = zip_of(&[
+        ("assets/packs/abacus/manifest.json", manifest.as_bytes()),
+        ("assets/packs/abacus/../../owned.js", b"pwn"),
+    ]);
+
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(archive)).expect("apk");
+    sync_from_zip(&mut zip, &root);
+
+    assert!(!root.join("owned.js").exists(), "a file escaped the pack");
+    assert!(
+        !root.join("abacus").exists(),
+        "a half-installed pack was left behind"
+    );
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn an_apk_without_bundled_packs_installs_nothing() {
+    let root = scratch("apkempty");
+    let archive = zip_of(&[("classes.dex", b"dex"), ("assets/tauri.conf.json", b"{}")]);
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(archive)).expect("apk");
+    sync_from_zip(&mut zip, &root);
+    assert_eq!(fs::read_dir(&root).unwrap().count(), 0);
+    let _ = fs::remove_dir_all(&root);
+}

--- a/dynawalla/dynawalla-app/src/pass/billing.ts
+++ b/dynawalla/dynawalla-app/src/pass/billing.ts
@@ -65,10 +65,28 @@ export type PurchaseOutcome =
   | { readonly status: "unavailable"; readonly detail: string }
 
 /**
- * The three calls a platform has to answer. Anything a store does that is not
- * one of these is not something this product needs.
+ * The three calls a platform has to answer, and the one fact about itself it
+ * has to admit. Anything a store does that is not one of these is not something
+ * this product needs.
  */
 export interface PassBilling {
+  /**
+   * Whether this implementation can actually take money.
+   *
+   * **The model reads this before it ever rests a game.** A stopping point is
+   * only a stopping point because there is a pass on the other side of it; with
+   * no store wired, the same code turns a game into a dead end that no parent
+   * can reopen at any price. That is not a paywall, it is a broken app, and it
+   * is exactly what a TestFlight build of this app was: two installed games,
+   * one transition each, about five minutes, and then nothing.
+   *
+   * A flag rather than "did `buy` return `unavailable`" because the difference
+   * has to be known *before* the child reaches the transition, and because the
+   * two are not the same thing — a wired store that is offline is unavailable
+   * this minute and sellable the next, and a family who paid must not lose the
+   * day to a dropped connection.
+   */
+  readonly wired: boolean
   /** The catalogue, with localised prices. */
   products(): Promise<readonly PassProduct[]>
   /** Buy one. Resolves; never throws for a cancellation. */
@@ -98,8 +116,15 @@ export function expiryFor(kind: PassKind, now: number): number | null {
   }
 }
 
-/** What ships until a platform lands. Honest about doing nothing. */
+/**
+ * What ships until a platform lands. Honest about doing nothing.
+ *
+ * `wired: false` is the load-bearing field. It is what keeps the day pass from
+ * gating anything at all in a build with no store: every game stays open, all
+ * day, for as long as this is the installed implementation.
+ */
 export const unwiredBilling: PassBilling = {
+  wired: false,
   products: () => Promise.resolve(FALLBACK_PRODUCTS),
   buy: () =>
     Promise.resolve({
@@ -132,6 +157,10 @@ export function billing(): PassBilling {
  * with no way to do that will find a worse one. It is reachable only from the
  * developer rows in the parent area, which are off by default and off on every
  * child's tablet.
+ *
+ * `wired: true`, because the point of it is to exercise the real gating path.
+ * A developer grant that reported itself unwired would switch the day pass off
+ * and prove nothing.
  */
 export function grantingBilling(clock: () => number = Date.now): PassBilling {
   const grant = (productId: string): PurchaseOutcome => {
@@ -144,6 +173,7 @@ export function grantingBilling(clock: () => number = Date.now): PassBilling {
     }
   }
   return {
+    wired: true,
     products: () => Promise.resolve(FALLBACK_PRODUCTS),
     buy: (productId) => Promise.resolve(grant(productId)),
     restore: () => Promise.resolve(grant(FALLBACK_PRODUCTS[2]?.productId ?? "")),

--- a/dynawalla/dynawalla-app/src/pass/model.ts
+++ b/dynawalla/dynawalla-app/src/pass/model.ts
@@ -23,6 +23,12 @@
 // lifetime pass is never re-examined at all. Corpán learned this the expensive
 // way and the policy is copied verbatim from
 // `corpan/corpan-app/src/store/entitlements.ts`.
+//
+// The same asymmetry decides what happens when there is no store at all, and it
+// decides it the same way: **a game is never refused for want of a purchase
+// that cannot be made.** Both decisions below take `billingWired` and both open
+// on `false`. See `billing.ts` for what that flag is and why it is not "did the
+// last `buy` fail".
 
 /** What a family can buy. Three, and never more: a price list is not a menu. */
 export type PassKind = "day" | "month" | "lifetime"
@@ -151,9 +157,24 @@ export type TransitionInput = {
   readonly pass: Pass | null
   readonly ledger: RestLedger
   readonly now: number
+  /**
+   * Whether the installed billing can actually take money — `billing().wired`,
+   * threaded in rather than read here.
+   *
+   * This module reaches for no globals on purpose: every rule in it is decided
+   * from its arguments, which is why a whole simulated day fits in a Node test
+   * with no store, no DOM and no module state to reset between cases. Importing
+   * the billing singleton to answer one boolean would trade all of that for a
+   * saved parameter.
+   */
+  readonly billingWired: boolean
 }
 
 export function verdictFor(input: TransitionInput): TransitionVerdict {
+  // Nothing to sell, so nothing to gate. A stopping point earns its name from
+  // the pass on the other side of it; without one it is a locked door with no
+  // key cut for it, and the family's only remaining move is to delete the app.
+  if (!input.billingWired) return "play-on"
   if (passIsOpen(input.pass, input.now)) return "play-on"
   const day = dayKey(input.now)
   // Already stopped here today. A second sheet in one game in one day is a
@@ -169,13 +190,20 @@ export function verdictFor(input: TransitionInput): TransitionVerdict {
  * thing: a game is *never* refused because it has not been paid for, only
  * because this device already reached its ending today. On a fresh day, with no
  * pass and nothing bought, every installed game answers `true`.
+ *
+ * And with no store wired it answers `true` always, ledger or no ledger. The
+ * ledger outlives a build — a device that ran a gating version still carries
+ * its entries in durable storage — so this is checked rather than assumed from
+ * "`verdictFor` would never have written one".
  */
 export function canOpen(input: {
   readonly packId: string
   readonly pass: Pass | null
   readonly ledger: RestLedger
   readonly now: number
+  readonly billingWired: boolean
 }): boolean {
+  if (!input.billingWired) return true
   if (passIsOpen(input.pass, input.now)) return true
   return !isResting(input.ledger, input.packId, dayKey(input.now))
 }

--- a/dynawalla/dynawalla-app/src/pass/pass.test.ts
+++ b/dynawalla/dynawalla-app/src/pass/pass.test.ts
@@ -12,6 +12,9 @@
 //   3. **There is no timer, and the copy contains no pressure.** Mechanically,
 //      by reading the source and the strings, so "we would notice" is not the
 //      control.
+//   4. **A build with no store gates nothing.** The fourth because the first
+//      three all quietly assumed a store existed, and the build that shipped to
+//      TestFlight did not have one.
 
 import test from "node:test"
 import assert from "node:assert/strict"
@@ -20,7 +23,13 @@ import path from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { strings } from "../app/strings.ts"
-import { expiryFor, FALLBACK_PRODUCTS, grantingBilling, productFor } from "./billing.ts"
+import {
+  expiryFor,
+  FALLBACK_PRODUCTS,
+  grantingBilling,
+  productFor,
+  unwiredBilling,
+} from "./billing.ts"
 import {
   canOpen,
   dayKey,
@@ -45,6 +54,19 @@ const lifetime: Pass = { kind: "lifetime", expiresAt: null, confirmedAt: NOON }
 const dayPass: Pass = { kind: "day", expiresAt: NOON + 24 * HOUR, confirmedAt: NOON }
 const monthPass: Pass = { kind: "month", expiresAt: NOON + 30 * 24 * HOUR, confirmedAt: NOON }
 
+/**
+ * The two builds every rule below has to be right in, spread into the input so
+ * that which one a case is describing is readable at the call site.
+ *
+ * `withStore` is a build a parent can actually buy from, and it is the **only**
+ * one in which the day pass gates anything at all: every case from here down to
+ * the last section runs in it, because a rest that nobody can undo is not a
+ * rule worth having. `noStore` is what ships until StoreKit and Play Billing
+ * land, and the last section is entirely about it.
+ */
+const withStore = { billingWired: true } as const
+const noStore = { billingWired: false } as const
+
 // ── Every game is free, and the gate is a place, not a clock ─────────────────
 
 test("on a cold device with nothing bought, every game opens", () => {
@@ -52,7 +74,7 @@ test("on a cold device with nothing bought, every game opens", () => {
   // a child can try all of them, which is how they find the one they love.
   for (const packId of ["dynawalla.fuse", "dynawalla.siege", "dynawalla.forge"]) {
     assert.equal(
-      canOpen({ packId, pass: null, ledger: EMPTY_LEDGER, now: NOON }),
+      canOpen({ packId, pass: null, ledger: EMPTY_LEDGER, now: NOON, ...withStore }),
       true,
       `${packId} was refused on a cold device`,
     )
@@ -62,22 +84,23 @@ test("on a cold device with nothing bought, every game opens", () => {
 test("the first stopping point rests that game and only that game", () => {
   let ledger: RestLedger = EMPTY_LEDGER
 
-  const first = verdictFor({ packId: "dynawalla.fuse", pass: null, ledger, now: NOON })
+  const first = verdictFor({ packId: "dynawalla.fuse", pass: null, ledger, now: NOON, ...withStore })
   assert.equal(first, "rest")
   ledger = markResting(ledger, "dynawalla.fuse", dayKey(NOON))
 
   // FUSE is finished for today…
-  assert.equal(canOpen({ packId: "dynawalla.fuse", pass: null, ledger, now: NOON }), false)
+  assert.equal(canOpen({ packId: "dynawalla.fuse", pass: null, ledger, now: NOON, ...withStore }), false)
   // …and SIEGE has not been touched. This is the whole point of one gate per
   // game per day: a child who runs out of one goes and finds another.
-  assert.equal(canOpen({ packId: "dynawalla.siege", pass: null, ledger, now: NOON }), true)
+  assert.equal(canOpen({ packId: "dynawalla.siege", pass: null, ledger, now: NOON, ...withStore }), true)
 })
 
 test("a second stopping point in a rested game shows nothing", () => {
   // Reachable only if a pack is mounted anyway. The answer to being asked
   // twice is silence, never a second sheet.
   const ledger = markResting(EMPTY_LEDGER, "dynawalla.fuse", dayKey(NOON))
-  assert.equal(verdictFor({ packId: "dynawalla.fuse", pass: null, ledger, now: NOON }), "play-on")
+  const input = { packId: "dynawalla.fuse", pass: null, ledger, now: NOON, ...withStore }
+  assert.equal(verdictFor(input), "play-on")
 })
 
 test("midnight gives the day back", () => {
@@ -85,7 +108,7 @@ test("midnight gives the day back", () => {
   const tomorrow = new Date(2026, 6, 27, 8, 0, 0).getTime()
 
   assert.notEqual(dayKey(NOON), dayKey(tomorrow))
-  assert.equal(canOpen({ packId: "dynawalla.fuse", pass: null, ledger, now: tomorrow }), true)
+  assert.equal(canOpen({ packId: "dynawalla.fuse", pass: null, ledger, now: tomorrow, ...withStore }), true)
   // And the record is thrown away rather than accumulated — nothing here grows
   // without bound and no history of a child's play is kept.
   assert.deepEqual(ledgerOn(ledger, dayKey(tomorrow)), { day: dayKey(tomorrow), resting: [] })
@@ -115,12 +138,15 @@ test("a pass opens every game, including ones that already rested", () => {
   const ledger = markResting(EMPTY_LEDGER, "dynawalla.fuse", dayKey(NOON))
   for (const pass of [dayPass, monthPass, lifetime]) {
     assert.equal(
-      canOpen({ packId: "dynawalla.fuse", pass, ledger, now: NOON }),
+      canOpen({ packId: "dynawalla.fuse", pass, ledger, now: NOON, ...withStore }),
       true,
       `${pass.kind} did not reopen a rested game`,
     )
     // And nothing is ever shown to them again.
-    assert.equal(verdictFor({ packId: "dynawalla.siege", pass, ledger, now: NOON }), "play-on")
+    assert.equal(
+      verdictFor({ packId: "dynawalla.siege", pass, ledger, now: NOON, ...withStore }),
+      "play-on",
+    )
   }
 })
 
@@ -157,7 +183,7 @@ test("a full day: play, rest, switch games, buy, and wake up tomorrow", async ()
   let ledger: RestLedger = EMPTY_LEDGER
   let pass: Pass | null = null
   const play = (packId: string, now: number) => {
-    const verdict = verdictFor({ packId, pass, ledger, now })
+    const verdict = verdictFor({ packId, pass, ledger, now, ...withStore })
     if (verdict === "rest") ledger = markResting(ledger, packId, dayKey(now))
     return verdict
   }
@@ -165,14 +191,14 @@ test("a full day: play, rest, switch games, buy, and wake up tomorrow", async ()
   // 09:00 — FUSE. Two levels cleared; the first one is the stopping point and
   // the second one is silence.
   const nine = new Date(2026, 6, 26, 9, 0, 0).getTime()
-  assert.equal(canOpen({ packId: "dynawalla.fuse", pass, ledger, now: nine }), true)
+  assert.equal(canOpen({ packId: "dynawalla.fuse", pass, ledger, now: nine, ...withStore }), true)
   assert.equal(play("dynawalla.fuse", nine), "rest")
   assert.equal(play("dynawalla.fuse", nine + 60_000), "play-on")
 
   // 09:05 — dismissed the sheet, went to SIEGE. Still open, still free.
   const nineFive = nine + 5 * 60_000
-  assert.equal(canOpen({ packId: "dynawalla.fuse", pass, ledger, now: nineFive }), false)
-  assert.equal(canOpen({ packId: "dynawalla.siege", pass, ledger, now: nineFive }), true)
+  assert.equal(canOpen({ packId: "dynawalla.fuse", pass, ledger, now: nineFive, ...withStore }), false)
+  assert.equal(canOpen({ packId: "dynawalla.siege", pass, ledger, now: nineFive, ...withStore }), true)
   assert.equal(play("dynawalla.siege", nineFive), "rest")
 
   // 09:30 — a parent passes the gate and buys the lifetime pass. Everything
@@ -183,15 +209,16 @@ test("a full day: play, rest, switch games, buy, and wake up tomorrow", async ()
   assert.equal(outcome.status, "granted")
   if (outcome.status !== "granted") return
   pass = outcome.pass
+  const half = nine + 31 * 60_000
   for (const packId of ["dynawalla.fuse", "dynawalla.siege", "dynawalla.forge"]) {
-    assert.equal(canOpen({ packId, pass, ledger, now: nine + 31 * 60_000 }), true)
-    assert.equal(verdictFor({ packId, pass, ledger, now: nine + 31 * 60_000 }), "play-on")
+    assert.equal(canOpen({ packId, pass, ledger, now: half, ...withStore }), true)
+    assert.equal(verdictFor({ packId, pass, ledger, now: half, ...withStore }), "play-on")
   }
 
   // …and had they not bought anything, tomorrow morning gives both back.
   const tomorrow = new Date(2026, 6, 27, 9, 0, 0).getTime()
-  assert.equal(canOpen({ packId: "dynawalla.fuse", pass: null, ledger, now: tomorrow }), true)
-  assert.equal(canOpen({ packId: "dynawalla.siege", pass: null, ledger, now: tomorrow }), true)
+  assert.equal(canOpen({ packId: "dynawalla.fuse", pass: null, ledger, now: tomorrow, ...withStore }), true)
+  assert.equal(canOpen({ packId: "dynawalla.siege", pass: null, ledger, now: tomorrow, ...withStore }), true)
 })
 
 // ── The catalogue ────────────────────────────────────────────────────────────
@@ -318,6 +345,122 @@ test("no ledger entry is written when a pass is open", () => {
   // Otherwise a family who let a month pass lapse would come back to a device
   // where every game was already resting.
   const ledger = markResting(EMPTY_LEDGER, "dynawalla.fuse", dayKey(NOON))
-  assert.equal(verdictFor({ packId: "dynawalla.siege", pass: lifetime, ledger, now: NOON }), "play-on")
+  assert.equal(
+    verdictFor({ packId: "dynawalla.siege", pass: lifetime, ledger, now: NOON, ...withStore }),
+    "play-on",
+  )
   assert.equal(isResting(ledger, "dynawalla.siege", dayKey(NOON)), false)
+})
+
+// ── The build with no store ──────────────────────────────────────────────────
+//
+// What went to TestFlight, and what it did there. `unwiredBilling` answers
+// `unavailable` to `buy` and to `restore`, so the first stopping point in each
+// installed game rested it, `canOpen` said no for the rest of the day, and the
+// sheet's one offer led to a store that did not exist. With two games installed
+// that is roughly five minutes, and then the app is a dead end no parent can
+// buy their way out of.
+//
+// Every case above this line assumes a store. These are the ones that hold the
+// rule when there is not one: **a game is never refused for want of a purchase
+// that cannot be made.**
+
+test("the shipping billing admits it cannot sell, and the developer grant admits it can", () => {
+  // The entire fix hangs off this one flag, so it is asserted rather than read.
+  assert.equal(unwiredBilling.wired, false)
+  assert.equal(grantingBilling().wired, true)
+})
+
+test("with no store wired, no game ever rests, however long a child plays", () => {
+  let ledger: RestLedger = EMPTY_LEDGER
+  const packs = ["dynawalla.fuse", "dynawalla.siege", "dynawalla.forge"]
+
+  // Forty stopping points across an afternoon and three games — many times what
+  // the shipped build could reach before it stopped being an app.
+  for (let index = 0; index < 40; index += 1) {
+    const packId = packs[index % packs.length] ?? ""
+    const now = NOON + index * 7 * 60_000
+
+    const verdict = verdictFor({ packId, pass: null, ledger, now, ...noStore })
+    // Exactly what the store does with a verdict, and done before the assertion
+    // rather than instead of it: a regression fills the ledger, and the check
+    // after the loop is what catches the day one slips through.
+    if (verdict === "rest") ledger = markResting(ledger, packId, dayKey(now))
+
+    assert.equal(verdict, "play-on", `${packId} rested at transition ${index} with nothing to sell`)
+    assert.equal(
+      canOpen({ packId, pass: null, ledger, now, ...noStore }),
+      true,
+      `${packId} was refused at transition ${index} with nothing to sell`,
+    )
+  }
+
+  assert.deepEqual(ledger, EMPTY_LEDGER, "a build with no store wrote a rest into the ledger")
+})
+
+test("a ledger left behind by a gating build does not lock anybody out", () => {
+  // Why `canOpen` reads the flag rather than trusting that `verdictFor` never
+  // wrote anything: the ledger is durable and it outlives the build that wrote
+  // it. A family who hit the dead end yesterday installs the fix today and
+  // would otherwise open it to find every game already finished.
+  let ledger: RestLedger = EMPTY_LEDGER
+  for (const packId of ["dynawalla.fuse", "dynawalla.siege"]) {
+    ledger = markResting(ledger, packId, dayKey(NOON))
+    assert.equal(canOpen({ packId, pass: null, ledger, now: NOON, ...withStore }), false)
+    assert.equal(canOpen({ packId, pass: null, ledger, now: NOON, ...noStore }), true)
+  }
+})
+
+test("wiring a store back on gives back the day pass exactly as it was", () => {
+  // The flag switches the model off. It must not change a thing about what the
+  // model does when it is on, so the free-tier day is run again here, in full,
+  // against the wired build.
+  let ledger: RestLedger = EMPTY_LEDGER
+
+  const fuse = (now: number) => ({ packId: "dynawalla.fuse", pass: null, ledger, now, ...withStore })
+  assert.equal(verdictFor(fuse(NOON)), "rest")
+  ledger = markResting(ledger, "dynawalla.fuse", dayKey(NOON))
+
+  // Rested once, and once only: a second transition in the same game is silence.
+  assert.equal(verdictFor(fuse(NOON + HOUR)), "play-on")
+  assert.equal(canOpen(fuse(NOON + HOUR)), false)
+  // …and only that game. SIEGE is untouched.
+  assert.equal(canOpen({ packId: "dynawalla.siege", pass: null, ledger, now: NOON, ...withStore }), true)
+  // Tomorrow gives it back.
+  assert.equal(canOpen(fuse(new Date(2026, 6, 27, 8, 0, 0).getTime())), true)
+  // And a pass reopens it today, which is the thing being sold.
+  assert.equal(
+    canOpen({ packId: "dynawalla.fuse", pass: lifetime, ledger, now: NOON + HOUR, ...withStore }),
+    true,
+  )
+})
+
+test("the sheet is only ever opened by the model's two answers", () => {
+  // The child-facing consequence, and why changing two decisions is enough: the
+  // stage is the only thing in the app that mounts `PassSheet`, and both of its
+  // mounts are gated on `model.ts`. With nothing to sell both answers open, so
+  // the sheet is never drawn at all — nobody is offered a store that is not
+  // there, because nobody arrives at the offer.
+  const stage = fs.readFileSync(path.join(here, "..", "packs", "Stage.tsx"), "utf8")
+  const mounts = stage.match(/<PassSheet\b/g) ?? []
+  assert.equal(mounts.length, 2, "the sheet gained a mount that the model does not gate")
+  assert.ok(
+    stage.includes('if (reachTransition(packId) === "rest") setOffering(true)'),
+    "the transition mount no longer asks the model",
+  )
+  assert.ok(
+    stage.includes("useState(() => !usePass.getState().mayOpen(packId))"),
+    "the reopen mount no longer asks the model",
+  )
+})
+
+test("the library rows go quiet too when there is nothing to sell", () => {
+  // The row's word and the stage's decision are one question with one answer,
+  // and the flag has to reach both or a row says "resting" about a game that
+  // opens when a child presses it.
+  const host = fs.readFileSync(path.join(here, "..", "shell", "useHost.ts"), "utf8")
+  assert.ok(
+    host.includes("!billing().wired"),
+    "a row can still call a game resting that the stage will open",
+  )
 })

--- a/dynawalla/dynawalla-app/src/pass/store.test.ts
+++ b/dynawalla/dynawalla-app/src/pass/store.test.ts
@@ -1,0 +1,187 @@
+// The seam, pinned.
+//
+// `model.ts` is pure, and `pass.test.ts` proves every rule in it by calling it
+// with a literal `billingWired`. That is the right way to test a decision, and
+// it is exactly why the *wiring* needs a file of its own: not one case over
+// there ever calls `store.ts`, so not one of them can tell what `store.ts`
+// actually threads.
+//
+// Two lines in `store.ts` decide which build a family is in, and they are the
+// only two places in the running app where the capability flag reaches the
+// model at all:
+//
+//     verdictFor({ …, billingWired: billing().wired })   // reachTransition
+//     canOpen({ …, billingWired: billing().wired })      // mayOpen
+//
+// Pin the first to `true` and the TestFlight defect comes back whole — two
+// installed games, one transition each, about five minutes, and then a sheet
+// offering a store that cannot sell — while every case in `pass.test.ts` stays
+// green. Replace the second with a hand-rolled resting rule and a ledger left
+// behind by that build locks the stage on a device that has just been fixed.
+//
+// So everything below drives the **real store** against the **real billing
+// singleton**. No fixture model, no second copy of the rule, nothing that could
+// quietly agree with a mutation. `persist.ts` falls back to an in-memory Map
+// when `localStorage` is absent, which is what lets the whole thing run under
+// `node --test` with no DOM, no store account and no network.
+
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { ephemeral } from "../app/persist.ts"
+import { deviceKey } from "../app/profile.ts"
+import { billing, grantingBilling, productFor, setBilling, unwiredBilling } from "./billing.ts"
+import { dayKey, EMPTY_LEDGER, type RestLedger } from "./model.ts"
+import { buyPass, isPassOpen, usePass } from "./store.ts"
+
+/** Mid-afternoon, so a day boundary is never one rounding away. */
+const NOON = new Date(2026, 6, 26, 14, 30, 0).getTime()
+const TOMORROW = new Date(2026, 6, 27, 8, 0, 0).getTime()
+const HOUR = 60 * 60 * 1000
+
+const FUSE = "dynawalla.fuse"
+const SIEGE = "dynawalla.siege"
+const FORGE = "dynawalla.forge"
+
+/** A tablet that has never bought anything and has nothing written on it. */
+function freshDevice(): void {
+  ephemeral.clear()
+  usePass.setState({ pass: null, ledger: EMPTY_LEDGER })
+}
+
+/**
+ * Put a record on the disk the way a *previous build* would have left it, then
+ * make the real store read it back through its real `merge`.
+ *
+ * Constructed rather than written by this process on purpose: the durable
+ * ledger outlives the build that wrote it, and the device this has to be right
+ * on is one that ran the gating version yesterday and installs the fix today.
+ */
+async function rehydrateWith(ledger: RestLedger): Promise<void> {
+  ephemeral.set(deviceKey("pass"), JSON.stringify({ state: { pass: null, ledger }, version: 1 }))
+  await usePass.persist.rehydrate()
+}
+
+// ── The default build: nothing to sell, so nothing to gate ───────────────────
+
+test("nothing is wired until something installs a store", () => {
+  // The premise the next two cases rest on, asserted before anything in this
+  // file has had a chance to call `setBilling`. A default that came up wired
+  // would make them pass for the wrong reason.
+  assert.equal(billing().wired, false, "the default billing claims it can take money")
+  assert.equal(billing(), unwiredBilling)
+})
+
+test("the store threads the billing it has, so an unsellable build never rests a game", () => {
+  // THE REGRESSION. `reachTransition` is the one line in the running app that
+  // carries `billing().wired` into `verdictFor`, and this is the case that
+  // fails when it stops carrying it: hard-code `billingWired: true` there and
+  // the very first call below answers "rest" instead of "play-on".
+  //
+  // Driven through `usePass.getState()` — the same call the stage makes — so
+  // the assertion is about the app's behaviour and not about a rule this file
+  // re-derived.
+  freshDevice()
+  assert.equal(billing().wired, false)
+
+  const packs = [FUSE, SIEGE, FORGE]
+
+  // Forty stopping points across an afternoon and three games: many times what
+  // the shipped build could reach before it stopped being an app.
+  for (let index = 0; index < 40; index += 1) {
+    const packId = packs[index % packs.length] ?? ""
+    const now = NOON + index * 7 * 60_000
+
+    assert.equal(
+      usePass.getState().reachTransition(packId, now),
+      "play-on",
+      `${packId} rested at transition ${index}: store.ts is no longer threading billing().wired`,
+    )
+    assert.equal(
+      usePass.getState().mayOpen(packId, now),
+      true,
+      `${packId} was refused at transition ${index} in a build that cannot sell a way back in`,
+    )
+  }
+
+  // The durable consequence, and the one a family would still be carrying
+  // tomorrow. `reachTransition` writes the ledger itself, so a single verdict
+  // that slipped through is visible here even if the loop above were loosened.
+  assert.deepEqual(
+    usePass.getState().ledger,
+    EMPTY_LEDGER,
+    "a build with no store wrote a rest into durable storage",
+  )
+  // And nobody arrived at the offer, because nobody was ever stopped.
+  assert.equal(isPassOpen(NOON), false, "an unwired build invented a pass nobody bought")
+})
+
+test("mayOpen delegates, so a ledger from a gating build cannot lock the stage", async () => {
+  // THE SECOND REGRESSION. `mayOpen` must ask `canOpen` rather than answer
+  // "is it resting?" itself. Swap it for that hand-rolled rule and this case
+  // fails: the ledger below says both games are finished for today, the flag
+  // says there is nothing to sell, and only `canOpen` knows the second beats
+  // the first.
+  freshDevice()
+  assert.equal(billing().wired, false)
+
+  const stale: RestLedger = { day: dayKey(NOON), resting: [FUSE, SIEGE] }
+  await rehydrateWith(stale)
+
+  // The ledger really did come back, so nothing below can pass vacuously.
+  assert.deepEqual(usePass.getState().ledger, stale, "the stale ledger never reached the store")
+
+  for (const packId of [FUSE, SIEGE]) {
+    assert.equal(
+      usePass.getState().mayOpen(packId, NOON),
+      true,
+      `${packId} stayed locked by yesterday's build: mayOpen is no longer delegating to canOpen`,
+    )
+    // …and reaching the stopping point again changes nothing.
+    assert.equal(usePass.getState().reachTransition(packId, NOON + HOUR), "play-on")
+  }
+})
+
+// ── The wired build: everything above must leave this untouched ──────────────
+
+test("with a store wired, the real store still rests each game once a day", async (t) => {
+  // The flag switches the day pass off. It must not change one thing about what
+  // the day pass does when it is on, so the whole free-tier day is run again
+  // here — through the store, not the model — against a billing that can sell.
+  t.after(() => {
+    setBilling(unwiredBilling)
+    freshDevice()
+  })
+
+  freshDevice()
+  setBilling(grantingBilling(() => NOON))
+  assert.equal(billing().wired, true)
+
+  // First stopping point in FUSE: it rests, and the sheet opens.
+  assert.equal(usePass.getState().reachTransition(FUSE, NOON), "rest")
+  assert.deepEqual(usePass.getState().ledger, { day: dayKey(NOON), resting: [FUSE] })
+
+  // Once, and once only. A second transition in the same game is silence.
+  assert.equal(usePass.getState().reachTransition(FUSE, NOON + HOUR), "play-on")
+  assert.equal(usePass.getState().mayOpen(FUSE, NOON + HOUR), false)
+
+  // …and only that game. The child goes and finds SIEGE, which is the point.
+  assert.equal(usePass.getState().mayOpen(SIEGE, NOON), true)
+  assert.equal(usePass.getState().reachTransition(SIEGE, NOON), "rest")
+  assert.equal(usePass.getState().mayOpen(FORGE, NOON), true)
+
+  // Tomorrow morning gives the day back, with nothing bought.
+  assert.equal(usePass.getState().mayOpen(FUSE, TOMORROW), true)
+  assert.equal(usePass.getState().mayOpen(SIEGE, TOMORROW), true)
+
+  // And a purchase reopens today, which is the thing being sold. Bought through
+  // the real `buyPass`, so the grant lands in the same durable state the stage
+  // reads back.
+  const outcome = await buyPass(productFor("lifetime").productId)
+  assert.equal(outcome.status, "granted")
+  assert.equal(isPassOpen(NOON + HOUR), true)
+  for (const packId of [FUSE, SIEGE, FORGE]) {
+    assert.equal(usePass.getState().mayOpen(packId, NOON + HOUR), true)
+    assert.equal(usePass.getState().reachTransition(packId, NOON + HOUR), "play-on")
+  }
+})

--- a/dynawalla/dynawalla-app/src/pass/store.ts
+++ b/dynawalla/dynawalla-app/src/pass/store.ts
@@ -21,6 +21,7 @@ import { durable } from "../app/persist.ts"
 import { deviceKey } from "../app/profile.ts"
 import { billing, type PurchaseOutcome } from "./billing.ts"
 import {
+  canOpen,
   dayKey,
   EMPTY_LEDGER,
   isPassKind,
@@ -62,20 +63,25 @@ export const usePass = create<PassState>()(
       grant: (pass) => set({ pass }),
       forget: () => set({ pass: null }),
 
+      // This store is the seam where the pure model meets the singletons: it
+      // reads the clock and it reads the installed billing, and it hands both
+      // to `model.ts` as plain values. Nothing below `model.ts` knows either
+      // one exists, which is why a whole day of play is testable there.
       reachTransition: (packId, now = Date.now()) => {
         const { pass, ledger } = get()
-        const verdict = verdictFor({ packId, pass, ledger, now })
+        const verdict = verdictFor({ packId, pass, ledger, now, billingWired: billing().wired })
         if (verdict === "rest") {
           set({ ledger: markResting(ledger, packId, dayKey(now)) })
         }
         return verdict
       },
 
+      // Delegated rather than re-derived. The stage asks this and the library
+      // rows draw from the same ledger, and a second copy of the rule here is
+      // how the row and the door come to disagree.
       mayOpen: (packId, now = Date.now()) => {
         const { pass, ledger } = get()
-        if (passIsOpen(pass, now)) return true
-        const day = dayKey(now)
-        return !(ledger.day === day && ledger.resting.includes(packId))
+        return canOpen({ packId, pass, ledger, now, billingWired: billing().wired })
       },
     }),
     {

--- a/dynawalla/dynawalla-app/src/shell/useHost.ts
+++ b/dynawalla/dynawalla-app/src/shell/useHost.ts
@@ -15,7 +15,7 @@ import { eraseEverything } from "../app/erase.ts"
 import { useThemeStore } from "../app/theme.ts"
 import { usePacks } from "../packs/registry.ts"
 import { useLaunch } from "../packs/Stage.tsx"
-import { grantingBilling, productFor } from "../pass/billing.ts"
+import { billing, grantingBilling, productFor } from "../pass/billing.ts"
 import { dayKey, passIsOpen, EMPTY_LEDGER } from "../pass/model.ts"
 import { usePass } from "../pass/store.ts"
 import { useProfiles } from "../profiles/store.ts"
@@ -103,9 +103,18 @@ export function useHostView(armed: boolean): HostView {
   // ledger: a screen that says a game is resting and a stage that lets it open
   // would be two answers to one question, and the second is the one a child
   // finds.
+  //
+  // `billing().wired` is the third way the list comes back empty, and it is the
+  // one that has to be read here rather than inferred from an empty ledger: the
+  // ledger is durable and outlives the build that wrote it, so a device updated
+  // from a gating version arrives with yesterday's entries still in storage. The
+  // stage opens those games — `canOpen` short-circuits on the same flag — and a
+  // row that called them resting would be the disagreement this block exists to
+  // prevent, pointing the wrong way.
   const now = useNow()
   const open = passIsOpen(pass, now)
-  const resting = open || ledger.day !== dayKey(now) ? [] : ledger.resting
+  const resting =
+    open || !billing().wired || ledger.day !== dayKey(now) ? [] : ledger.resting
 
   return {
     profiles,

--- a/dynawalla/games/forge/.gitignore
+++ b/dynawalla/games/forge/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 dist
+
+# The pack build. `packs/build.mjs` regenerates it and stages it into the app.
+dist-pack/

--- a/dynawalla/games/forge/README.md
+++ b/dynawalla/games/forge/README.md
@@ -6,9 +6,10 @@ below it, and a number in the corner that will not stop climbing.**
 ```
 npm install
 npm run dev      # http://127.0.0.1:1431  — fully playable, local stub host
-npm test         # 49 tests, node's runner, no framework
+npm test         # 51 tests, node's runner, no framework
 npm run tsc
 npm run build
+npm run build:pack # what installs on a tablet: pack.html only, no stub host
 open /bench.html # frame-budget measurement (see "Performance")
 ```
 

--- a/dynawalla/games/forge/pack.html
+++ b/dynawalla/games/forge/pack.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#08060a" />
+    <title>FORGE</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #08060a;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/forge/pack.json
+++ b/dynawalla/games/forge/pack.json
@@ -1,0 +1,24 @@
+{
+  "id": "dynawalla.forge",
+  "version": "0.1.0",
+  "name": "FORGE",
+  "description": "An incremental smelting chain. Every problem struck on the anvil pays sparks, sparks buy stations, and the stations run themselves — the arithmetic is the throttle on a number that only goes up.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics", "storage"],
+  "covers": {
+    "skills": [
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-multidigit",
+      "dw.add.regroup.add-short-addend",
+      "dw.add.regroup.subtract-short-subtrahend",
+      "dw.add.regroup.subtract-across-zero"
+    ],
+    "grades": [1, 4]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/forge/package.json
+++ b/dynawalla/games/forge/package.json
@@ -13,7 +13,8 @@
     "build": "vite build",
     "preview": "vite preview --port 4183 --strictPort",
     "tsc": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
-    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test 'src/**/*.test.ts'"
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test 'src/**/*.test.ts'",
+    "build:pack": "vite build --config vite.pack.config.ts"
   },
   "devDependencies": {
     "typescript": "~6.0.3",

--- a/dynawalla/games/forge/src/game/save.test.ts
+++ b/dynawalla/games/forge/src/game/save.test.ts
@@ -3,7 +3,7 @@ import { test } from "node:test"
 
 import { MICRO } from "../core/bigmath.ts"
 import { TIERS, addSparks, buy, newEconomy, sparksPerSecond, step } from "../core/economy.ts"
-import { deserialize, serialize, type Persisted } from "./save.ts"
+import { deserialize, load, save, serialize, useSaveSlot, type Persisted } from "./save.ts"
 
 function played() {
   const e = newEconomy()
@@ -90,6 +90,52 @@ test("corrupt or hostile save data degrades to a fresh forge, never throws", () 
   assert.equal(e.tiers[2].unlocked, false) // sealed tiers stay sealed
   assert.equal(markOom, 3)
   assert.equal(audio, true)
+})
+
+// The seam `src/pack.ts` uses. There is no `localStorage` in this process and
+// there is none in a pack frame either — it is sandboxed without
+// `allow-same-origin` — so a save that reached for one directly would be a
+// FORGE that silently resets to zero on every launch of the shipped game. The
+// point of this test is that `load()` and `save()` go through the installed
+// slot and never touch a global.
+test("the save slot is pluggable, so a pack frame with no localStorage still persists", () => {
+  let stored: string | null = null
+  useSaveSlot({
+    read: () => stored,
+    write: (value) => {
+      stored = value
+    },
+  })
+
+  assert.equal(load(), null) // nothing written yet
+
+  const e = played()
+  save(e, 7, false)
+  assert.equal(typeof stored, "string")
+
+  const back = load()
+  assert.ok(back)
+  assert.equal(back.e.sparks, e.sparks)
+  assert.equal(back.e.lifetime, e.lifetime)
+  assert.equal(back.markOom, 7)
+  assert.equal(back.audio, false)
+})
+
+test("a slot that throws on write loses the save, not the run", () => {
+  useSaveSlot({
+    read: () => {
+      throw new Error("storage is gone")
+    },
+    write: () => {
+      throw new Error("storage is gone")
+    },
+  })
+  // Both sides swallow: a device that cannot persist still plays, and the
+  // alternative is an exception thrown from inside the game loop.
+  assert.doesNotThrow(() => {
+    save(played(), 3, true)
+  })
+  assert.equal(load(), null)
 })
 
 test("a sealed station cannot be unsealed by editing the save's flag alone", () => {

--- a/dynawalla/games/forge/src/game/save.ts
+++ b/dynawalla/games/forge/src/game/save.ts
@@ -104,9 +104,46 @@ export function deserialize(p: Persisted): { e: Economy; markOom: number; audio:
   }
 }
 
+/**
+ * Where the save actually lives.
+ *
+ * Synchronous on purpose: `load()` is called from inside `mount`, before the
+ * first frame, and `save()` is called from the game loop. Neither may await.
+ *
+ * `localStorage` is the default because the standalone workbench has one. A
+ * pack frame does NOT — it is sandboxed without `allow-same-origin`, so its
+ * origin is opaque and every storage API on it either throws or is absent.
+ * That is exactly why the SDK has a `storage` capability, and why this is a
+ * seam rather than a direct call: FORGE is an incremental game whose whole
+ * subject is a number that goes up forever, and one that silently resets on
+ * every launch is not the same game. `src/pack.ts` installs a host-backed slot
+ * here, hydrated before mount so this stays synchronous.
+ */
+export type SaveSlot = {
+  read(): string | null
+  write(value: string): void
+}
+
+const browserSlot: SaveSlot = {
+  read: () => localStorage.getItem(SAVE_SLOT),
+  write: (value) => {
+    localStorage.setItem(SAVE_SLOT, value)
+  },
+}
+
+let slot: SaveSlot = browserSlot
+
+/** Swap the backing store. Called once, before `mount`, or never. */
+export function useSaveSlot(next: SaveSlot): void {
+  slot = next
+}
+
+/** The key a host-backed slot should file this game's save under. */
+export const SAVE_KEY = SAVE_SLOT
+
 export function load(): { e: Economy; markOom: number; audio: boolean; elapsedMs: number } | null {
   try {
-    const raw = localStorage.getItem(SAVE_SLOT)
+    const raw = slot.read()
     if (!raw) return null
     const p = JSON.parse(raw) as Persisted
     if (p.v !== 1) return null
@@ -120,7 +157,7 @@ export function load(): { e: Economy; markOom: number; audio: boolean; elapsedMs
 
 export function save(e: Economy, markOom: number, audio: boolean): void {
   try {
-    localStorage.setItem(SAVE_SLOT, JSON.stringify(serialize(e, markOom, audio)))
+    slot.write(JSON.stringify(serialize(e, markOom, audio)))
   } catch {
     /* private mode / quota: the game plays fine, it just will not resume */
   }

--- a/dynawalla/games/forge/src/pack.ts
+++ b/dynawalla/games/forge/src/pack.ts
@@ -1,0 +1,77 @@
+// FORGE, as a Dynawalla pack.
+//
+// The whole seam is this file. `mount.ts`, the economy, the renderer and the
+// particle budget are untouched: the real host is handed to the same `mount`
+// the stub host was, because the adapter presents the same synchronous surface
+// the game's `Host` type already describes.
+//
+// Everything mathematical now comes from the host — the prompt on the billet,
+// the canonical answer on one of the four slugs, the mal-rule distractors on
+// the other three, the judgement, and the record it lands in. The game does no
+// arithmetic that decides anything, which is exactly the property the pack
+// contract exists to give.
+//
+// The one thing FORGE needs that FUSE and SIEGE do not is a save. It is an
+// incremental game: the run is the smelting chain you built over days, and a
+// chain that resets every launch is a different, much worse game. A pack frame
+// is sandboxed without `allow-same-origin` and therefore has no `localStorage`
+// at all, so the save goes through the SDK's `storage` capability instead —
+// hydrated here, before mount, so `save.ts` stays synchronous for the loop.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import type { Host } from "./contract.ts"
+import { mount } from "./mount.ts"
+import { SAVE_KEY, useSaveSlot } from "./game/save.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("#app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "add-sub" })
+
+  // Read the save before the game asks for it. `load()` runs inside `mount`
+  // and cannot await, so the value has to be in hand by then; a write is fire
+  // and forget, and the in-memory copy is authoritative for the rest of the
+  // session so a failed write never rolls the player back mid-run.
+  let cached: string | null = null
+  if (mounted.client.can("storage.get")) {
+    try {
+      cached = await mounted.client.storage.get(SAVE_KEY)
+    } catch (error) {
+      console.error("[forge] the save could not be read", error)
+    }
+    useSaveSlot({
+      read: () => cached,
+      write: (value) => {
+        cached = value
+        void mounted.client.storage.set(SAVE_KEY, value).catch((error: unknown) => {
+          console.error("[forge] the save could not be written", error)
+        })
+      },
+    })
+  } else {
+    // Loud, not silent. A host that did not grant storage gives a playable
+    // FORGE that forgets everything, and that is worth saying once rather than
+    // leaving a parent to conclude the game is broken.
+    console.error("[forge] storage was not granted; the smelting chain will not persist")
+    useSaveSlot({ read: () => null, write: () => {} })
+  }
+
+  // Stocked before the first frame: a billet that spawns into an empty pool is
+  // a billet with a blank face, and it would happen exactly once, on launch, in
+  // front of the child.
+  await mounted.warm()
+
+  const instance = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the loop stops before the
+  // frame is torn down rather than a frame or two after it.
+  mounted.client.on("dispose", () => {
+    instance.unmount()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[forge] could not start", error)
+  renderNoHost(root, "FORGE")
+})

--- a/dynawalla/games/forge/vite.pack.config.ts
+++ b/dynawalla/games/forge/vite.pack.config.ts
@@ -1,0 +1,31 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build.
+ *
+ * Separate from `vite.config.ts` because the two artefacts are different
+ * things: that one is the standalone workbench with the stub host in it, this
+ * one is what gets installed on a child's tablet. Only `pack.html` is an entry,
+ * so `main.ts` and `stub/host.ts` are not in the bundle at all.
+ *
+ * `base: "./"` is not cosmetic — the pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute `/assets/…` would resolve
+ * to the scheme root and 404 for every pack but the first.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produced a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})

--- a/dynawalla/games/slice/.gitignore
+++ b/dynawalla/games/slice/.gitignore
@@ -1,8 +1,5 @@
 node_modules/
 dist/
 
-# Omitted deliberately: at 29KB it pushed this PR past the 200,000-byte point
-# where `adversarial-review` truncates the diff and still reports green. No CI
-# job consumes `dynawalla/games/` yet, so nothing reads it. Restore it in the
-# same PR that lands the games-area path filter.
-package-lock.json
+# The pack build. `packs/build.mjs` regenerates it and stages it into the app.
+dist-pack/

--- a/dynawalla/games/slice/README.md
+++ b/dynawalla/games/slice/README.md
@@ -11,6 +11,7 @@ npm install
 npm run dev     # http://127.0.0.1:4317 — playable standalone, stub Host included
 npm test        # 30 tests
 npm run tsc
+npm run build:pack # what installs on a tablet: pack.html only, no stub Host
 ```
 
 ---

--- a/dynawalla/games/slice/pack.html
+++ b/dynawalla/games/slice/pack.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#08061a" />
+    <title>THE SPLIT</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #08061a;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         The dev harness's `#readout` is not here — it reported the stub host's
+         tally, and inside a real host the host draws the progress. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/slice/pack.json
+++ b/dynawalla/games/slice/pack.json
@@ -1,0 +1,24 @@
+{
+  "id": "dynawalla.slice",
+  "version": "0.1.0",
+  "name": "THE SPLIT",
+  "description": "A night-market slicer. Cut a composite open and its factors come out of the wound; cut a sigil and the problem on it detonates into four candidates you answer with the blade.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-multidigit",
+      "dw.add.regroup.add-short-addend",
+      "dw.add.regroup.subtract-short-subtrahend",
+      "dw.add.regroup.subtract-across-zero"
+    ],
+    "grades": [1, 4]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/slice/package-lock.json
+++ b/dynawalla/games/slice/package-lock.json
@@ -1,0 +1,938 @@
+{
+  "name": "@dynawalla/game-slice",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@dynawalla/game-slice",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^25.9.0",
+        "typescript": "^6.0.0",
+        "vite": "^8.1.5"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/dynawalla/games/slice/package.json
+++ b/dynawalla/games/slice/package.json
@@ -15,7 +15,8 @@
     "build": "vite build",
     "preview": "vite preview --port 4317",
     "tsc": "tsc --noEmit",
-    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\""
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
+    "build:pack": "vite build --config vite.pack.config.ts"
   },
   "devDependencies": {
     "@types/node": "^25.9.0",

--- a/dynawalla/games/slice/src/pack.ts
+++ b/dynawalla/games/slice/src/pack.ts
@@ -1,0 +1,46 @@
+// THE SPLIT, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous surface `Host` in
+// `contract.ts` already describes — so the blade, the bodies, the tier
+// governor and the factor tree are untouched.
+//
+// What crosses the boundary is the sigil. A sigil carries a problem the
+// curriculum drew, and cutting it detonates that problem into four candidate
+// lanterns: the canonical answer and up to three mal-rule distractors, which
+// are wrong answers a child actually produces rather than noise. The game
+// never decides whether a cut was right — it reports the value that was cut
+// and `items.answer` is the judge.
+//
+// The numerals are the game's own mathematics and stay that way: a composite
+// splitting into its factors is arithmetic the child performs with a gesture,
+// not a question anybody asked, so nothing about it is reported.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import { mount } from "./contract.ts"
+import type { Host } from "./contract.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("slice: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "add-sub" })
+  // Stocked before the first frame: the director throws a sigil early, and a
+  // sigil with a blank face is the kind of thing that happens exactly once, on
+  // launch, in front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context are torn down before the frame is, rather than a frame or two
+  // after it.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[slice] could not start", error)
+  renderNoHost(root, "THE SPLIT")
+})

--- a/dynawalla/games/slice/vite.pack.config.ts
+++ b/dynawalla/games/slice/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produced a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})

--- a/dynawalla/games/stack/.gitignore
+++ b/dynawalla/games/stack/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 dist/
 .vite/
 *.local
+
+# The pack build. `packs/build.mjs` regenerates it and stages it into the app.
+dist-pack/

--- a/dynawalla/games/stack/README.md
+++ b/dynawalla/games/stack/README.md
@@ -73,6 +73,7 @@ npm install
 npm run dev            # http://127.0.0.1:4310
 npm test               # 32 tests, no browser needed
 npm run tsc
+npm run build:pack     # what installs on a tablet: pack.html only, no stub host
 ```
 
 `?perf=1` shows fps, frame cost, tier and input latency. `?dev=1` exposes

--- a/dynawalla/games/stack/pack.html
+++ b/dynawalla/games/stack/pack.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1, user-scalable=no"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#05060f" />
+    <title>MONUMENT</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #05060f;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/stack/pack.json
+++ b/dynawalla/games/stack/pack.json
@@ -1,0 +1,24 @@
+{
+  "id": "dynawalla.stack",
+  "version": "0.1.0",
+  "name": "MONUMENT",
+  "description": "A one-tap precision stacker. A slab sweeps across the tower carrying a candidate answer, and the drop has to be true twice — dead on the edge below it, and dead on the arithmetic.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-multidigit",
+      "dw.add.regroup.add-short-addend",
+      "dw.add.regroup.subtract-short-subtrahend",
+      "dw.add.regroup.subtract-across-zero"
+    ],
+    "grades": [1, 4]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/stack/package.json
+++ b/dynawalla/games/stack/package.json
@@ -13,7 +13,8 @@
     "build": "vite build",
     "preview": "vite preview --port 4310",
     "tsc": "tsc --noEmit",
-    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'"
+    "test": "node --experimental-strip-types --test 'src/**/*.test.ts'",
+    "build:pack": "vite build --config vite.pack.config.ts"
   },
   "dependencies": {
     "three": "^0.185.1"

--- a/dynawalla/games/stack/src/pack.ts
+++ b/dynawalla/games/stack/src/pack.ts
@@ -1,0 +1,43 @@
+// MONUMENT, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// seeded stub, because the adapter presents the same synchronous surface the
+// `Host` in `contract.ts` already describes — so the sim, the sway, the shear
+// and the WebGL tier detection are untouched.
+//
+// What changed is where a slab's value comes from and who says whether the
+// drop was true. The sweeping slabs carry the canonical answer and the
+// mal-rule distractors the curriculum produced for *that* item: a wrong slab
+// is a wrong answer a child actually gives, which is the whole reason the
+// distractors cross the boundary at all. The sim still owns the other half of
+// the verdict — the alignment — because that is geometry, not arithmetic, and
+// nothing about it is reported.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts";
+import type { Host } from "./contract.ts";
+import { mount } from "./game/mount.ts";
+
+const root = document.getElementById("app");
+if (!root) throw new Error("stack: #app missing");
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "add-sub" });
+  // Stocked before the first frame: the first slab sweeps immediately, and a
+  // slab with a blank face is the kind of thing that happens exactly once, on
+  // launch, in front of the child.
+  await mounted.warm();
+
+  const game = mount(el, mounted.host as unknown as Host);
+
+  // The host tells a pack before its port dies, so the rAF loop stops and the
+  // WebGL context is released before the frame is torn down rather than a
+  // frame or two after it.
+  mounted.client.on("dispose", () => {
+    game.unmount();
+  });
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[stack] could not start", error);
+  renderNoHost(root, "MONUMENT");
+});

--- a/dynawalla/games/stack/vite.pack.config.ts
+++ b/dynawalla/games/stack/vite.pack.config.ts
@@ -1,0 +1,31 @@
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vite";
+
+/**
+ * The pack build: only `pack.html`, so the standalone entry and the stub host
+ * stay out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ *
+ * Nothing is inlined. This pack carries three.js and its bundle is the largest
+ * of the arcade set; a data: URI would move those bytes into the HTML entry,
+ * where they are re-parsed on every launch and cannot be cached as a module.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produced a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+});


### PR DESCRIPTION
## What

Unblocks the first Dynawalla mobile release. Six defects, all found by actually
running things rather than reading them.

## Why

`release-dynawalla.yml` had never executed past its 40-second gate. I dispatched
it against `main` (run [30291684583](https://github.com/corpora-inc/encorpora/actions/runs/30291684583)).
Good news first: **the iOS signing path works.** The certificate imports, and the
provisioning profile passes both assertions — `application-identifier` is
`F9AV5HKF6N.inc.corpora.dynawalla` and `Name` is `dynawalla appstore ci`. That
was the one credential nobody had ever tested.

Then it died:

```
failed to get resource: resource path `packs` doesn't exist
```

`bundle.resources: ["packs"]` resolves to `src-tauri/packs/`, which is built by
`npm run packs` and gitignored (`src-tauri/.gitignore:58`). A fresh checkout does
not have it. Putting the build in `beforeBuildCommand` cannot fix this — the log
shows `tauri ios init` printing "Project generated successfully" and failing
0.8s later, long before `beforeBuildCommand` runs. It was invisible locally
because a developer's gitignored `src-tauri/packs/` is already populated.

The other five came from an audit that verified each finding adversarially.

| Defect | Blocked | Fix |
|---|---|---|
| `packs` resource absent on a fresh checkout | both | build packs before the Tauri CLI, both jobs |
| `yes \| sdkmanager` returns 141 under `pipefail` | android | drop `yes`, `--install ... </dev/null` |
| No ASC app-record preflight until minute ~55 | ios | `--preflight` on the existing verifier |
| Day pass gates on a purchase that cannot be made | both | `PassBilling.wired` → `billingWired` |
| `resource_dir()` is `asset://localhost/` on Android | android | read packs out of the APK; log loudly |
| `dynawalla/games`, `dynawalla/packs` in no CI job | both | new filter + job, into `ci-gate.needs` |

The day-pass one made a TestFlight build worthless: every game rested at its
first natural transition, `unwiredBilling` could never grant, so a tester got
about five minutes and then a dead end behind a sheet reading "not on this
device yet."

FORGE, THE SPLIT and MONUMENT are now installable packs — five games ship where
two did.

## Blast radius

- [x] **Corpán untouched.** No file under `corpan/` changes. `release-mobile.yml`
      is not touched.
- [x] `ci.yml` adds a job to `ci-gate.needs`, **not** a fourth required context.
      Path-gated, so it is skipped on unrelated PRs and `ci-gate` treats skipped
      as pass.
- [x] Build numbers still minutes-since-epoch. Untouched.
- [x] No credential value committed. The Android keystore lives in
      `~/.corpora-signing/`; the three `DYNAWALLA_ANDROID_*` secrets were set
      via `gh secret set`.
- [ ] **Android APK pack-reading is unverified on a device.** It compiles and is
      unit-tested, but no Android hardware ran it. iOS is unaffected.
- [ ] `ADR-0024` still describes `unwiredBilling` as the shipping default
      without noting it now disables the gate. Docs follow-up.

## Proof

```
npm run tsc     exit 0
npm test        tests 203 / pass 203 / fail 0   (pass suite 31 -> 37)
npm run lint    exit 0
cargo check / clippy -D warnings / fmt --check   all exit 0
python3 -c "import yaml; yaml.safe_load(...)"    both workflows parse
```

A verifier independently mutation-tested the day-pass fix against the real
billing singleton: 20 consecutive transitions all return `play-on` with the
ledger still `EMPTY_LEDGER`, a stale durable ledger does not lock the stage, and
`setBilling(grantingBilling())` restores gating exactly.

**Known test gap, disclosed rather than hidden:** that same verifier found
`store.ts:72` is pinned by no test — mutating `billingWired: billing().wired` to
`true` reintroduces the defect with the suite fully green. Fixed in a follow-up
commit on this branch.
