### PR TITLE
dynawalla/games/guilty: GUILTY — a fixed-position arithmetic shooter in a bioluminescent trench

### DIFF
--- a/dynawalla/games/guilty/.gitignore
+++ b/dynawalla/games/guilty/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+dist-pack/
+
+# Playtest capture output: multi-MB PNGs, regenerated on demand.
+qa/shots
+qa/tmp
+
+# Not tracked, matching dynawalla/games/slice and .../merge. These prototypes
+# pin nothing beyond vite + typescript in devDependencies.
+package-lock.json

--- a/dynawalla/games/guilty/index.html
+++ b/dynawalla/games/guilty/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#03060c" />
+    <title>Guilty</title>
+    <link rel="stylesheet" href="/src/style.css" />
+  </head>
+  <body>
+    <div id="stage"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/guilty/package.json
+++ b/dynawalla/games/guilty/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@dynawalla/game-guilty",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Shoot the Guilty Number — a fixed-position arithmetic shooter in a bioluminescent trench.",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4179",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
+    "check": "npm run tsc && npm test"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "typescript": "~5.7.2",
+    "vite": "^6.0.7"
+  }
+}

--- a/dynawalla/games/guilty/src/audio/audio.ts
+++ b/dynawalla/games/guilty/src/audio/audio.ts
@@ -1,0 +1,382 @@
+/**
+ * Procedural audio. No files, no assets — every sound is oscillators, noise and
+ * envelopes, built the moment it is heard and thrown away.
+ *
+ * Three layers on every important sound, which is the reason it does not sound
+ * like a phone game: a *transient* (a few milliseconds of filtered noise that
+ * gives the ear the attack), a *body* (the pitched part that says what
+ * happened), and a *tail* (a send into a procedurally generated trench reverb
+ * that says where it happened). Pitch moves with the combo up a pentatonic
+ * ladder and jitters a few cents each shot, so a thousand shots never fatigue.
+ *
+ * Nothing here is ever the only carrier of information: every sound has a
+ * visual twin, and the whole engine can be muted with no loss of play.
+ */
+
+const PENTATONIC = [0, 3, 5, 7, 10];
+
+export type AudioEngine = {
+  ready(): boolean;
+  resume(): Promise<void>;
+  muted(): boolean;
+  setMuted(value: boolean): void;
+  /** 0..1 — pushes the drone's filter and the ping rate. */
+  setIntensity(value: number): void;
+  /** Drags the whole bed down under slow motion. */
+  setTimeScale(value: number): void;
+  shoot(step: number): void;
+  /** The gun settling — a tiny tick, the audible half of the sight snapping on. */
+  lock(): void;
+  hit(): void;
+  correct(combo: number): void;
+  wrong(): void;
+  hostileWake(): void;
+  breach(): void;
+  bossHit(stage: number): void;
+  bossDown(): void;
+  focus(on: boolean): void;
+  waveClear(combo: number): void;
+  gameOver(): void;
+  revive(): void;
+  tick(dt: number): void;
+  dispose(): void;
+};
+
+const noteHz = (semitone: number): number => 110 * Math.pow(2, semitone / 12);
+
+export function createAudio(rand: () => number): AudioEngine {
+  let ctx: AudioContext | null = null;
+  let master: GainNode | null = null;
+  let dry: GainNode | null = null;
+  let wet: GainNode | null = null;
+  let droneGain: GainNode | null = null;
+  let droneFilter: BiquadFilterNode | null = null;
+  let droneOscs: OscillatorNode[] = [];
+  let isMuted = false;
+  let intensity = 0;
+  let timeScale = 1;
+  let pingCooldown = 4;
+  let noiseBuffer: AudioBuffer | null = null;
+
+  const now = (): number => (ctx ? ctx.currentTime : 0);
+
+  function build(): void {
+    const Ctor: typeof AudioContext =
+      window.AudioContext ?? (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+    if (!Ctor) return;
+    ctx = new Ctor();
+
+    const comp = ctx.createDynamicsCompressor();
+    comp.threshold.value = -14;
+    comp.knee.value = 22;
+    comp.ratio.value = 5;
+    comp.attack.value = 0.004;
+    comp.release.value = 0.18;
+    comp.connect(ctx.destination);
+
+    master = ctx.createGain();
+    master.gain.value = isMuted ? 0 : 0.9;
+    master.connect(comp);
+
+    dry = ctx.createGain();
+    dry.gain.value = 1;
+    dry.connect(master);
+
+    // A trench: 2.4 seconds of exponentially decaying noise, darkened towards
+    // the tail so the reverb sounds like water rather than a cathedral.
+    const rate = ctx.sampleRate;
+    const len = Math.floor(rate * 2.4);
+    const ir = ctx.createBuffer(2, len, rate);
+    for (let ch = 0; ch < 2; ch++) {
+      const data = ir.getChannelData(ch);
+      let lp = 0;
+      for (let i = 0; i < len; i++) {
+        const t = i / len;
+        const decay = Math.pow(1 - t, 2.6);
+        const white = rand() * 2 - 1;
+        lp += (white - lp) * (0.5 - 0.42 * t);
+        data[i] = lp * decay * (i < rate * 0.01 ? i / (rate * 0.01) : 1);
+      }
+    }
+    const convolver = ctx.createConvolver();
+    convolver.buffer = ir;
+    const wetOut = ctx.createGain();
+    wetOut.gain.value = 0.5;
+    convolver.connect(wetOut);
+    wetOut.connect(master);
+    wet = ctx.createGain();
+    wet.gain.value = 1;
+    wet.connect(convolver);
+
+    // Shared noise source buffer (1s of white), sliced by every transient.
+    const nb = ctx.createBuffer(1, rate, rate);
+    const nd = nb.getChannelData(0);
+    for (let i = 0; i < rate; i++) nd[i] = rand() * 2 - 1;
+    noiseBuffer = nb;
+
+    // The bed: two detuned saws an octave apart under a slow filter sweep.
+    droneFilter = ctx.createBiquadFilter();
+    droneFilter.type = "lowpass";
+    droneFilter.frequency.value = 240;
+    droneFilter.Q.value = 4;
+    droneGain = ctx.createGain();
+    droneGain.gain.value = 0;
+    droneFilter.connect(droneGain);
+    droneGain.connect(dry);
+    droneGain.connect(wet);
+
+    for (const [freq, detune, type] of [
+      [55, -7, "sawtooth"],
+      [55.4, 6, "sawtooth"],
+      [110, 0, "triangle"],
+    ] as const) {
+      const osc = ctx.createOscillator();
+      osc.type = type;
+      osc.frequency.value = freq;
+      osc.detune.value = detune;
+      osc.connect(droneFilter);
+      osc.start();
+      droneOscs.push(osc);
+    }
+    const lfo = ctx.createOscillator();
+    lfo.frequency.value = 0.07;
+    const lfoGain = ctx.createGain();
+    lfoGain.gain.value = 90;
+    lfo.connect(lfoGain);
+    lfoGain.connect(droneFilter.frequency);
+    lfo.start();
+    droneOscs.push(lfo);
+
+    droneGain.gain.setTargetAtTime(0.055, ctx.currentTime, 2.5);
+  }
+
+  function noise(duration: number, gain: number, filterType: BiquadFilterType, freq: number, q = 1, sendWet = 0.2): void {
+    if (!ctx || !noiseBuffer || !dry || !wet) return;
+    const src = ctx.createBufferSource();
+    src.buffer = noiseBuffer;
+    src.playbackRate.value = 0.8 + rand() * 0.5;
+    const filter = ctx.createBiquadFilter();
+    filter.type = filterType;
+    filter.frequency.value = freq;
+    filter.Q.value = q;
+    const g = ctx.createGain();
+    const t = now();
+    g.gain.setValueAtTime(0.0001, t);
+    g.gain.exponentialRampToValueAtTime(Math.max(0.0002, gain), t + 0.004);
+    g.gain.exponentialRampToValueAtTime(0.0001, t + duration);
+    src.connect(filter);
+    filter.connect(g);
+    g.connect(dry);
+    if (sendWet > 0) {
+      const send = ctx.createGain();
+      send.gain.value = sendWet;
+      g.connect(send);
+      send.connect(wet);
+    }
+    src.start(t);
+    src.stop(t + duration + 0.05);
+  }
+
+  function tone(
+    type: OscillatorType,
+    from: number,
+    to: number,
+    duration: number,
+    gain: number,
+    sendWet = 0.2,
+    delay = 0,
+  ): void {
+    if (!ctx || !dry || !wet) return;
+    const osc = ctx.createOscillator();
+    osc.type = type;
+    const t = now() + delay;
+    osc.frequency.setValueAtTime(from, t);
+    if (to !== from) osc.frequency.exponentialRampToValueAtTime(Math.max(1, to), t + duration);
+    const g = ctx.createGain();
+    g.gain.setValueAtTime(0.0001, t);
+    g.gain.exponentialRampToValueAtTime(Math.max(0.0002, gain), t + Math.min(0.02, duration * 0.15));
+    g.gain.exponentialRampToValueAtTime(0.0001, t + duration);
+    osc.connect(g);
+    g.connect(dry);
+    if (sendWet > 0) {
+      const send = ctx.createGain();
+      send.gain.value = sendWet;
+      g.connect(send);
+      send.connect(wet);
+    }
+    osc.start(t);
+    osc.stop(t + duration + 0.05);
+  }
+
+  const engine: AudioEngine = {
+    ready: () => ctx !== null && ctx.state === "running",
+    async resume() {
+      if (!ctx) build();
+      if (ctx && ctx.state !== "running") {
+        try {
+          await ctx.resume();
+        } catch {
+          /* a blocked context simply stays silent */
+        }
+      }
+    },
+    muted: () => isMuted,
+    setMuted(value) {
+      isMuted = value;
+      if (master && ctx) master.gain.setTargetAtTime(value ? 0 : 0.9, ctx.currentTime, 0.05);
+    },
+    setIntensity(value) {
+      intensity = Math.max(0, Math.min(1, value));
+    },
+    setTimeScale(value) {
+      timeScale = value;
+      if (!ctx || !droneFilter) return;
+      for (const osc of droneOscs) osc.detune.setTargetAtTime((value - 1) * 700, ctx.currentTime, 0.12);
+    },
+    shoot(step) {
+      if (!ctx) return;
+      const base = noteHz(24 + (PENTATONIC[step % PENTATONIC.length] ?? 0));
+      const jitter = 1 + (rand() - 0.5) * 0.03;
+      tone("square", base * 2.1 * jitter, base * 0.72, 0.075, 0.055, 0.08);
+      noise(0.032, 0.035, "highpass", 2200, 0.8, 0.05);
+    },
+    lock() {
+      tone("sine", 1760, 2200, 0.05, 0.022, 0.15);
+      noise(0.02, 0.014, "highpass", 4200, 0.7, 0);
+    },
+    hit() {
+      noise(0.06, 0.06, "bandpass", 1400, 1.4, 0.14);
+      tone("triangle", 420, 180, 0.08, 0.05, 0.1);
+    },
+    correct(combo) {
+      const rung = Math.min(combo, 11);
+      const octave = Math.floor(rung / PENTATONIC.length);
+      const root = noteHz(36 + 12 * octave + (PENTATONIC[rung % PENTATONIC.length] ?? 0));
+      // Body: root, fifth, octave — a bell, not a beep.
+      tone("sine", root, root, 0.55, 0.1, 0.5);
+      tone("sine", root * 1.5, root * 1.5, 0.44, 0.06, 0.5);
+      tone("sine", root * 2, root * 2, 0.36, 0.045, 0.5, 0.012);
+      tone("triangle", root * 3.02, root * 3, 0.22, 0.02, 0.4, 0.02);
+      // Transient + sub.
+      noise(0.09, 0.07, "bandpass", 3200, 0.9, 0.3);
+      tone("sine", 96, 46, 0.24, 0.22, 0.1);
+    },
+    wrong() {
+      tone("sawtooth", 208, 150, 0.42, 0.075, 0.35);
+      tone("sawtooth", 292, 205, 0.42, 0.065, 0.35);
+      noise(0.14, 0.11, "lowpass", 900, 1.2, 0.3);
+      tone("sine", 120, 40, 0.3, 0.16, 0.1);
+    },
+    hostileWake() {
+      if (!ctx || !dry) return;
+      const osc = ctx.createOscillator();
+      osc.type = "sawtooth";
+      osc.frequency.value = 63;
+      const growl = ctx.createOscillator();
+      growl.type = "sine";
+      growl.frequency.value = 7.5;
+      const growlGain = ctx.createGain();
+      growlGain.gain.value = 14;
+      growl.connect(growlGain);
+      growlGain.connect(osc.frequency);
+      const filter = ctx.createBiquadFilter();
+      filter.type = "lowpass";
+      filter.frequency.value = 430;
+      const g = ctx.createGain();
+      const t = now();
+      g.gain.setValueAtTime(0.0001, t);
+      g.gain.exponentialRampToValueAtTime(0.17, t + 0.05);
+      g.gain.exponentialRampToValueAtTime(0.0001, t + 0.9);
+      osc.connect(filter);
+      filter.connect(g);
+      g.connect(dry);
+      if (wet) {
+        const send = ctx.createGain();
+        send.gain.value = 0.3;
+        g.connect(send);
+        send.connect(wet);
+      }
+      osc.start(t);
+      growl.start(t);
+      osc.stop(t + 1);
+      growl.stop(t + 1);
+    },
+    breach() {
+      tone("sine", 130, 32, 0.75, 0.32, 0.25);
+      noise(0.4, 0.16, "lowpass", 520, 0.8, 0.5);
+      tone("sawtooth", 90, 44, 0.3, 0.09, 0.3);
+    },
+    bossHit(stage) {
+      const root = noteHz(30 + stage * 3);
+      tone("sine", 70, 34, 0.5, 0.32, 0.3);
+      tone("square", root * 2, root, 0.3, 0.06, 0.5);
+      tone("triangle", root * 3.7, root * 2.4, 0.5, 0.045, 0.6);
+      noise(0.3, 0.15, "bandpass", 1800, 0.6, 0.6);
+    },
+    bossDown() {
+      for (let i = 0; i < 5; i++) {
+        tone("sine", noteHz(48 + (PENTATONIC[i] ?? 0)), noteHz(48 + (PENTATONIC[i] ?? 0)), 0.9, 0.075, 0.7, i * 0.075);
+      }
+      tone("sine", 90, 28, 1.2, 0.34, 0.4);
+      noise(0.9, 0.2, "lowpass", 900, 0.7, 0.8);
+    },
+    focus(on) {
+      if (on) {
+        noise(0.7, 0.1, "bandpass", 900, 0.6, 0.6);
+        tone("sine", 660, 180, 0.7, 0.07, 0.6);
+      } else {
+        tone("sine", 180, 700, 0.35, 0.05, 0.4);
+      }
+    },
+    waveClear(combo) {
+      const base = 48 + Math.min(12, combo);
+      for (let i = 0; i < 3; i++) {
+        const hz = noteHz(base + (PENTATONIC[i] ?? 0) + 12);
+        tone("triangle", hz, hz, 0.3, 0.04, 0.5, i * 0.055);
+      }
+    },
+    gameOver() {
+      tone("sine", 220, 55, 1.5, 0.16, 0.7);
+      tone("sawtooth", 110, 41, 1.3, 0.07, 0.6);
+      noise(1.1, 0.09, "lowpass", 400, 0.7, 0.8);
+    },
+    revive() {
+      tone("sine", 110, 660, 0.6, 0.12, 0.6);
+      for (let i = 0; i < 4; i++) {
+        const hz = noteHz(48 + (PENTATONIC[i] ?? 0));
+        tone("sine", hz, hz * 2, 0.5, 0.05, 0.6, i * 0.06);
+      }
+      noise(0.5, 0.1, "highpass", 2000, 0.7, 0.5);
+    },
+    tick(dt) {
+      if (!ctx || !droneGain || !droneFilter) return;
+      const t = ctx.currentTime;
+      droneFilter.frequency.setTargetAtTime(190 + intensity * 620 * timeScale, t, 0.4);
+      droneGain.gain.setTargetAtTime(0.05 + intensity * 0.055, t, 0.6);
+      // An occasional sonar ping keeps the bed from sitting still.
+      pingCooldown -= dt;
+      if (pingCooldown <= 0) {
+        pingCooldown = 5.5 + rand() * 7 - intensity * 2.2;
+        const hz = noteHz(60 + (PENTATONIC[Math.floor(rand() * PENTATONIC.length)] ?? 0));
+        tone("sine", hz, hz, 0.5, 0.03, 0.9);
+      }
+    },
+    dispose() {
+      for (const osc of droneOscs) {
+        try {
+          osc.stop();
+        } catch {
+          /* already stopped */
+        }
+      }
+      droneOscs = [];
+      if (ctx) void ctx.close().catch(() => undefined);
+      ctx = null;
+      master = dry = wet = droneGain = null;
+      droneFilter = null;
+      noiseBuffer = null;
+    },
+  };
+
+  return engine;
+}

--- a/dynawalla/games/guilty/src/contract.ts
+++ b/dynawalla/games/guilty/src/contract.ts
@@ -1,0 +1,30 @@
+/**
+ * The game <-> runtime contract.
+ *
+ * This is a verbatim local copy of the shape the shared Dynawalla package will
+ * export. Keep it EXACTLY this shape so the swap is a one-line import change.
+ * Nothing in this file may import anything.
+ */
+
+export type Question = {
+  id: string;
+  /** "15 − 8" — already formatted for display, using real math glyphs. */
+  prompt: string;
+  /** "7" — exact, canonical, string-compared. Never a float. */
+  answer: string;
+  /** Plausible wrong answers, ideally real mal-rule outputs. */
+  distractors: string[];
+  /** "add-sub" | "mul" | "div" | "two-step" | ... */
+  domain: string;
+  /** 0..1 */
+  difficulty: number;
+};
+
+export type Host = {
+  next(): Question;
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void;
+  haptic(kind: "light" | "medium" | "heavy" | "success" | "failure"): void;
+  prefersReducedMotion(): boolean;
+};
+
+export type GameHandle = { unmount(): void };

--- a/dynawalla/games/guilty/src/core/camera.ts
+++ b/dynawalla/games/guilty/src/core/camera.ts
@@ -1,0 +1,103 @@
+/**
+ * A real perspective camera, projected in software onto a 2D canvas.
+ *
+ * Everything in the trench has a z: the plankton drift far behind the play
+ * plane, husk debris is thrown *towards* the lens and grows as it comes, the
+ * seabed recedes. That is what makes a fixed-position shooter feel like a place
+ * rather than a chart. It costs two multiplies and a divide per point, which is
+ * why it is affordable at 60fps on a tablet where a WebGL pipeline would not
+ * have been worth the risk.
+ *
+ * Screen shake, roll and the z-punch all live on the camera, so every layer
+ * inherits them for free and nothing has to remember to shake.
+ */
+
+import { CAM_Z, VIEW_HALF_H } from "./config.ts";
+
+export type Camera = {
+  x: number;
+  y: number;
+  z: number;
+  roll: number;
+  /** Additive screen-space shake, in CSS pixels. */
+  shakeX: number;
+  shakeY: number;
+  /** Focal length in CSS pixels. */
+  f: number;
+  cx: number;
+  cy: number;
+  /** Half-width of the world the camera can see at z = 0. */
+  worldHalfW: number;
+  /** Half-width of the lane field. Never wider than a child's thumb reach. */
+  playHalfW: number;
+  cosRoll: number;
+  sinRoll: number;
+};
+
+export type Projected = { x: number; y: number; s: number; ok: boolean };
+
+export function makeCamera(): Camera {
+  return {
+    x: 0,
+    y: 0,
+    z: CAM_Z,
+    roll: 0,
+    shakeX: 0,
+    shakeY: 0,
+    f: 600,
+    cx: 0,
+    cy: 0,
+    worldHalfW: 100,
+    playHalfW: 90,
+    cosRoll: 1,
+    sinRoll: 0,
+  };
+}
+
+/** Re-fit after a resize. `w`/`h` are CSS pixels. */
+export function fitCamera(cam: Camera, w: number, h: number): void {
+  cam.cx = w / 2;
+  cam.cy = h / 2;
+  cam.f = (h / 2) * (CAM_Z / VIEW_HALF_H);
+  cam.worldHalfW = VIEW_HALF_H * (w / h);
+  cam.playHalfW = Math.max(52, Math.min(168, cam.worldHalfW * 0.84));
+}
+
+export function beginFrame(cam: Camera): void {
+  cam.cosRoll = Math.cos(cam.roll);
+  cam.sinRoll = Math.sin(cam.roll);
+}
+
+const scratch: Projected = { x: 0, y: 0, s: 1, ok: true };
+
+/** Projects into a shared scratch object — read it before the next call. */
+export function project(cam: Camera, wx: number, wy: number, wz: number): Projected {
+  const depth = cam.z - wz;
+  if (depth <= 12) {
+    scratch.ok = false;
+    scratch.x = 0;
+    scratch.y = 0;
+    scratch.s = 0;
+    return scratch;
+  }
+  const s = cam.f / depth;
+  const dx = (wx - cam.x) * s;
+  const dy = -(wy - cam.y) * s;
+  scratch.x = cam.cx + dx * cam.cosRoll - dy * cam.sinRoll + cam.shakeX;
+  scratch.y = cam.cy + dx * cam.sinRoll + dy * cam.cosRoll + cam.shakeY;
+  scratch.s = s;
+  scratch.ok = true;
+  return scratch;
+}
+
+/** Screen x (CSS px) -> world x on the play plane. Ignores shake, so a shaking
+ *  camera never fights the player's finger. */
+export function screenToWorldX(cam: Camera, sx: number): number {
+  const s = cam.f / cam.z;
+  return cam.x + (sx - cam.cx) / s;
+}
+
+/** World units per CSS pixel at the play plane — for sizing baked sprites. */
+export function planeScale(cam: Camera): number {
+  return cam.f / cam.z;
+}

--- a/dynawalla/games/guilty/src/core/config.ts
+++ b/dynawalla/games/guilty/src/core/config.ts
@@ -1,0 +1,62 @@
+/**
+ * Tuning. Every number a designer would want to touch lives here.
+ *
+ * World units, not pixels. The camera fits a constant 260 world units of
+ * *height* into whatever viewport it is given, so a phone in portrait gets a
+ * narrow, tall trench and a desktop gets a wide one — the descent always takes
+ * the same number of seconds, and the ship's traverse is the thing that scales.
+ */
+
+/** Half the world height the camera always shows. */
+export const VIEW_HALF_H = 130;
+export const CAM_Z = 300;
+
+export const SHIP_Y = -VIEW_HALF_H + 24;
+/** Cross this and a life is gone. Sits just above the ship. */
+export const GATE_Y = SHIP_Y + 14;
+/** Where the equation hangs, and where the husks are born. */
+export const EQUATION_Y = VIEW_HALF_H - 26;
+
+export const HUSK_R = 13.5;
+export const POD_R = 11;
+export const SHIP_HALF_W = 8.5;
+
+export const BULLET_SPEED = 560;
+export const BULLET_R = 2.6;
+export const FIRE_INTERVAL = 0.155;
+/** Above this lateral speed the gun sleeps — see `Ship.settled`. */
+export const FIRE_SPEED_GATE = 74;
+
+export const SHIP_MAX_SPEED = 460;
+export const SHIP_ACCEL = 2600;
+export const SHIP_FRICTION = 0.0016;
+
+export const BOLT_SPEED = 150;
+
+/** Waves. */
+export const BASE_DESCENT = 12.5;
+export const DESCENT_PER_WAVE = 0.45;
+export const MAX_DESCENT = 34;
+export const BOSS_EVERY = 6;
+/** How much faster the formation dives once it is inside the gate's shadow. */
+export const URGENCY_MULTIPLIER = 1.32;
+export const URGENCY_BAND = 62;
+
+export const START_LIVES = 3;
+export const MAX_LIVES = 4;
+
+/** Deep Focus — the slow-motion power the player earns by being right. */
+export const FOCUS_PER_SOLVE = 0.34;
+export const FOCUS_DURATION = 2.6;
+export const FOCUS_TIME_SCALE = 0.28;
+
+/** Particle ceilings. Pools are allocated once at these sizes and never grow. */
+export const MAX_PARTICLES = 720;
+export const MAX_BULLETS = 48;
+export const MAX_HUSKS = 14;
+
+/** Presentation timings, seconds. */
+export const HITSTOP_KILL = 0.075;
+export const HITSTOP_WRONG = 0.11;
+export const HITSTOP_BOSS = 0.15;
+export const WAVE_GAP = 0.62;

--- a/dynawalla/games/guilty/src/core/juice.ts
+++ b/dynawalla/games/guilty/src/core/juice.ts
@@ -1,0 +1,142 @@
+/**
+ * The feel layer. Trauma-based shake, hitstop, slow-motion, camera punch and a
+ * *rate-limited* screen flash.
+ *
+ * Shake is trauma-squared (Squirrel Eiserloh's model): trauma decays linearly,
+ * amplitude is trauma², so a small knock is barely there and a big one is
+ * violent, and every hit feels like a different size of hit rather than the
+ * same rattle at a different volume.
+ *
+ * The flash budget is not a nicety. This ships to children: a full-screen
+ * luminance jump is the exact stimulus that provokes photosensitive seizures,
+ * so bright flashes are hard-capped in amplitude, forced to decay over at least
+ * ~150ms, and rate-limited to well under three per second. `reduced` tightens
+ * every one of those numbers again.
+ */
+
+export type Juice = {
+  trauma: number;
+  /** Frozen frames, in real seconds. */
+  hitstop: number;
+  /** Multiplies world dt. 1 = normal. */
+  timeScale: number;
+  slowFor: number;
+  slowTo: number;
+  /** 0..1 white veil. */
+  flash: number;
+  flashColor: string;
+  /** Camera dolly kick, world units. */
+  punch: number;
+  punchVel: number;
+  /** Seconds since the last flash above the "significant" threshold. */
+  sinceBigFlash: number;
+  reduced: boolean;
+  /** Random source for shake — kept off Math.random so a replay is a replay. */
+  rand: () => number;
+  shakeSeed: number;
+};
+
+const SIGNIFICANT = 0.16;
+const MIN_FLASH_GAP = 0.34; // seconds; < 3 significant flashes per second
+const MAX_FLASH = 0.4;
+const MAX_FLASH_REDUCED = 0.09;
+
+export function makeJuice(reduced: boolean, rand: () => number): Juice {
+  return {
+    trauma: 0,
+    hitstop: 0,
+    timeScale: 1,
+    slowFor: 0,
+    slowTo: 1,
+    flash: 0,
+    flashColor: "#ffffff",
+    punch: 0,
+    punchVel: 0,
+    sinceBigFlash: 99,
+    reduced,
+    rand,
+    shakeSeed: 0,
+  };
+}
+
+export function addTrauma(j: Juice, amount: number): void {
+  if (j.reduced) amount *= 0.25;
+  j.trauma = Math.min(1, j.trauma + amount);
+}
+
+export function addHitstop(j: Juice, seconds: number): void {
+  if (j.reduced) seconds *= 0.35;
+  j.hitstop = Math.max(j.hitstop, seconds);
+}
+
+export function slowMotion(j: Juice, scale: number, seconds: number): void {
+  if (j.reduced) return;
+  j.slowTo = scale;
+  j.slowFor = Math.max(j.slowFor, seconds);
+}
+
+export function punch(j: Juice, amount: number): void {
+  j.punchVel += j.reduced ? amount * 0.3 : amount;
+}
+
+/**
+ * Request a screen flash. The budget decides what the player actually gets:
+ * amplitude is clamped, and a second bright flash inside the guard window is
+ * demoted to a dim one instead of being stacked on top of the first.
+ */
+export function flash(j: Juice, amount: number, color = "#ffffff"): void {
+  const ceiling = j.reduced ? MAX_FLASH_REDUCED : MAX_FLASH;
+  let a = Math.min(amount, ceiling);
+  if (a > SIGNIFICANT && j.sinceBigFlash < MIN_FLASH_GAP) a = SIGNIFICANT * 0.6;
+  if (a > SIGNIFICANT) j.sinceBigFlash = 0;
+  if (a > j.flash) {
+    j.flash = a;
+    j.flashColor = color;
+  }
+}
+
+/**
+ * Advances the juice on *real* time and returns the world dt the simulation
+ * should use. Returns 0 while hitstop is holding the frame.
+ */
+export function stepJuice(j: Juice, realDt: number): number {
+  j.sinceBigFlash += realDt;
+
+  // Flash decays with a floor on the fall time, so it can never strobe.
+  if (j.flash > 0) {
+    j.flash = Math.max(0, j.flash - realDt * (1 / 0.16));
+  }
+
+  if (j.hitstop > 0) {
+    j.hitstop = Math.max(0, j.hitstop - realDt);
+    // The camera keeps living during hitstop; that is what sells the freeze.
+    decayCamera(j, realDt);
+    return 0;
+  }
+
+  if (j.slowFor > 0) {
+    j.slowFor = Math.max(0, j.slowFor - realDt);
+    const target = j.slowFor > 0 ? j.slowTo : 1;
+    j.timeScale += (target - j.timeScale) * Math.min(1, realDt * 9);
+  } else {
+    j.timeScale += (1 - j.timeScale) * Math.min(1, realDt * 5);
+    if (j.timeScale > 0.995) j.timeScale = 1;
+  }
+
+  decayCamera(j, realDt);
+  return realDt * j.timeScale;
+}
+
+function decayCamera(j: Juice, dt: number): void {
+  j.trauma = Math.max(0, j.trauma - dt * 1.55);
+  // Spring the dolly kick back: stiff, slightly underdamped, so it overshoots
+  // once and settles. That single overshoot is most of the "punch".
+  j.punchVel += -j.punch * 210 * dt;
+  j.punchVel *= Math.pow(0.0012, dt);
+  j.punch += j.punchVel * dt;
+}
+
+/** Amplitude in CSS pixels for the current trauma. */
+export function shakeAmount(j: Juice): number {
+  return j.trauma * j.trauma;
+}

--- a/dynawalla/games/guilty/src/core/palette.ts
+++ b/dynawalla/games/guilty/src/core/palette.ts
@@ -1,0 +1,79 @@
+/**
+ * Abyssal neon. A bioluminescent trench: near-black water, cold light from an
+ * impossibly distant surface, and everything alive glowing its own colour.
+ *
+ * Note what is NOT in here: a colour for "guilty". Every husk looks identical
+ * until you do the arithmetic — that is the game. Colour only ever marks
+ * something the player has already learned about (a husk they shot wrongly, and
+ * that one also changes silhouette and motion, so the mark is never colour
+ * alone).
+ */
+
+export const C = {
+  void0: "#01030a",
+  void1: "#05131f",
+  void2: "#0a2d3a",
+  surface: "#123f4d",
+
+  /** Husks, the ship's sight line, most sparks. */
+  cyan: "#7CF3DC",
+  cyanDim: "#2b7f80",
+  cyanDeep: "#124b55",
+
+  /** The equation, and the score. Warm, so it never reads as a husk. */
+  amber: "#FFC46B",
+  amberDeep: "#8a5a1f",
+
+  /** A husk you shot by mistake. Also spiky, also diving. */
+  hostile: "#FF3D6E",
+  hostileDeep: "#7d1330",
+
+  ship: "#C3B0FF",
+  shipCore: "#F2ECFF",
+  thrust: "#7FA8FF",
+
+  white: "#FFFFFF",
+  plankton: "#59C8F0",
+
+  boss: "#FFA0D8",
+  bossDeep: "#6b1f52",
+} as const;
+
+/** rgba() from a #rrggbb and an alpha, without allocating a parser each call. */
+const cache = new Map<string, [number, number, number]>();
+export function rgba(hex: string, alpha: number): string {
+  let parts = cache.get(hex);
+  if (!parts) {
+    parts = [
+      parseInt(hex.slice(1, 3), 16),
+      parseInt(hex.slice(3, 5), 16),
+      parseInt(hex.slice(5, 7), 16),
+    ];
+    cache.set(hex, parts);
+  }
+  return `rgba(${parts[0]},${parts[1]},${parts[2]},${alpha < 0 ? 0 : alpha > 1 ? 1 : alpha})`;
+}
+
+export function mix(a: string, b: string, t: number): string {
+  const pa = parseHex(a);
+  const pb = parseHex(b);
+  const r = Math.round(pa[0] + (pb[0] - pa[0]) * t);
+  const g = Math.round(pa[1] + (pb[1] - pa[1]) * t);
+  const bl = Math.round(pa[2] + (pb[2] - pa[2]) * t);
+  return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${bl
+    .toString(16)
+    .padStart(2, "0")}`;
+}
+
+function parseHex(hex: string): [number, number, number] {
+  let parts = cache.get(hex);
+  if (!parts) {
+    parts = [
+      parseInt(hex.slice(1, 3), 16),
+      parseInt(hex.slice(3, 5), 16),
+      parseInt(hex.slice(5, 7), 16),
+    ];
+    cache.set(hex, parts);
+  }
+  return parts;
+}

--- a/dynawalla/games/guilty/src/devHost.ts
+++ b/dynawalla/games/guilty/src/devHost.ts
@@ -1,0 +1,58 @@
+/**
+ * The stub Host.
+ *
+ * It stands in for the Dynawalla runtime so the game is fully playable with
+ * `npm run dev`, and it is deliberately a *plausible* stand-in rather than a
+ * generous one: a real adaptive ladder that walks up on clean answers and drops
+ * hard on a miss, real mal-rule distractors, and a real reduced-motion query.
+ * A harness that is kinder than the runtime proves nothing.
+ */
+
+import type { Host, Question } from "./contract.ts";
+import { generate } from "./math/generate.ts";
+
+export type DevHostOptions = {
+  seed?: number;
+  /** Start further up the ladder — used by the QA driver to reach two-step work. */
+  difficulty?: number;
+  onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void;
+};
+
+export function createDevHost(options: DevHostOptions = {}): Host {
+  const seed = options.seed ?? (Date.now() & 0xffffffff);
+  let index = 0;
+  let difficulty = options.difficulty ?? 0.06;
+  const motion =
+    typeof matchMedia === "function" ? matchMedia("(prefers-reduced-motion: reduce)") : null;
+
+  return {
+    next(): Question {
+      return generate(seed, index++, difficulty);
+    },
+    report(r) {
+      // Up slowly, down fast — the shape every mastery ladder wants, and it
+      // keeps a struggling child out of two-step work.
+      if (r.correct) difficulty = Math.min(1, difficulty + (r.ms < 2500 ? 0.022 : 0.012));
+      else difficulty = Math.max(0, difficulty - 0.055);
+      options.onReport?.(r);
+    },
+    haptic(kind) {
+      if (typeof navigator === "undefined" || !navigator.vibrate) return;
+      const pattern: Record<typeof kind, number | number[]> = {
+        light: 8,
+        medium: 16,
+        heavy: 32,
+        success: [10, 26, 14],
+        failure: [26, 40, 26],
+      };
+      try {
+        navigator.vibrate(pattern[kind]);
+      } catch {
+        /* vibration is a courtesy, never a dependency */
+      }
+    },
+    prefersReducedMotion() {
+      return motion?.matches ?? false;
+    },
+  };
+}

--- a/dynawalla/games/guilty/src/game/boss.ts
+++ b/dynawalla/games/guilty/src/game/boss.ts
@@ -1,0 +1,113 @@
+/**
+ * The Arbiter. Every fifth wave.
+ *
+ * Three interlocking gimbal rings around a core, with the candidate pods in
+ * orbit. Its shield only breaks to a *correct* answer — bullets into the hull
+ * do nothing at all, which is the whole point: there is no way past it except
+ * arithmetic. Getting one wrong buys a volley.
+ */
+
+import { project } from "../core/camera.ts";
+import { C, rgba } from "../core/palette.ts";
+import { drawGlow } from "../render/bake.ts";
+import { ease } from "../render/draw.ts";
+import type { World } from "./world.ts";
+
+const SEGMENTS = 18;
+
+export function drawBoss(world: World): void {
+  const boss = world.boss;
+  if (!boss.active) return;
+  const { cam, batch, ctx } = world;
+  const dying = boss.dying > 0;
+  const collapse = dying ? ease.outCubic(Math.min(1, boss.dying / 1.1)) : 0;
+  // Never wider than the trench it is hunting in — a phone in portrait has a
+  // third of the lane width a laptop does.
+  const base = Math.min(40, cam.playHalfW * 0.62) * (1 - collapse * 0.6);
+  const flash = boss.flash;
+  const color = flash > 0.3 ? C.white : C.boss;
+
+  const rings: Array<[number, number, number, number, number, number, number]> = [
+    // ux,uy,uz, vx,vy,vz, radius
+    [1, 0, 0, 0, Math.cos(boss.spin * 1.0), Math.sin(boss.spin * 1.0), base],
+    [Math.cos(boss.spin * 1.4), 0, Math.sin(boss.spin * 1.4), 0, 1, 0, base * 0.78],
+    [Math.cos(-boss.spin * 0.8), Math.sin(-boss.spin * 0.8), 0, 0, 0, 1, base * 0.56],
+  ];
+
+  for (let r = 0; r < rings.length; r++) {
+    const ring = rings[r];
+    const radius = ring[6];
+    let prevX = 0;
+    let prevY = 0;
+    for (let i = 0; i <= SEGMENTS; i++) {
+      const a = (i / SEGMENTS) * Math.PI * 2;
+      const ca = Math.cos(a) * radius;
+      const sa = Math.sin(a) * radius;
+      const wx = boss.x + ring[0] * ca + ring[3] * sa;
+      const wy = boss.y + ring[1] * ca + ring[4] * sa;
+      const wz = ring[2] * ca + ring[5] * sa;
+      const p = project(cam, wx, wy, wz);
+      if (i > 0) {
+        // Rings nearer the lens are brighter — cheap depth cueing that makes
+        // three flat circles read as a gimbal.
+        const depth = 0.62 + (wz / (radius + 1)) * 0.3;
+        batch.push(
+          prevX,
+          prevY,
+          p.x,
+          p.y,
+          color,
+          (1.9 + flash * 2.4) * depth,
+          (0.75 + flash * 0.25 - collapse * 0.6) * depth,
+        );
+      }
+      prevX = p.x;
+      prevY = p.y;
+    }
+  }
+
+  const centre = project(cam, boss.x, boss.y, 0);
+  const cx = centre.x;
+  const cy = centre.y;
+  const s = centre.s;
+
+  // Shield: a hexagonal shell that shows how much of the fight is left.
+  if (boss.shield > 0.01 && !dying) {
+    const shieldR = base * 1.32;
+    let prevX = 0;
+    let prevY = 0;
+    for (let i = 0; i <= 6; i++) {
+      const a = (i / 6) * Math.PI * 2 + boss.spin * 0.3;
+      const p = project(cam, boss.x + Math.cos(a) * shieldR, boss.y + Math.sin(a) * shieldR * 0.9, 0);
+      if (i > 0) {
+        batch.push(prevX, prevY, p.x, p.y, C.boss, 2.4, boss.shield * 0.55);
+      }
+      prevX = p.x;
+      prevY = p.y;
+    }
+  }
+
+  ctx.globalCompositeOperation = "lighter";
+  const pulse = 0.5 + Math.sin(world.time * 2.4) * 0.12;
+  drawGlow(ctx, C.boss, cx, cy, base * s * 1.1 * (1 + flash), (0.24 + flash * 0.4) * pulse * (1 - collapse));
+  drawGlow(ctx, C.white, cx, cy, base * s * 0.22 * (1 + flash * 1.5), (0.12 + flash * 0.4) * (1 - collapse));
+  ctx.globalCompositeOperation = "source-over";
+
+  // Health, as filled cells under the crown — inside the trench, never clipped
+  // off the top of the viewport.
+  const cellY = boss.y - base * 1.35;
+  for (let i = 0; i < boss.maxHp; i++) {
+    const x = boss.x + (i - (boss.maxHp - 1) / 2) * 15;
+    const p = project(cam, x, cellY, 0);
+    const filled = i < boss.hp;
+    const r = 5 * p.s;
+    ctx.beginPath();
+    ctx.moveTo(p.x, p.y - r);
+    ctx.lineTo(p.x + r, p.y);
+    ctx.lineTo(p.x, p.y + r);
+    ctx.lineTo(p.x - r, p.y);
+    ctx.closePath();
+    ctx.fillStyle = rgba(C.boss, filled ? 0.85 : 0.14);
+    ctx.fill();
+  }
+}

--- a/dynawalla/games/guilty/src/game/fx.ts
+++ b/dynawalla/games/guilty/src/game/fx.ts
@@ -1,0 +1,237 @@
+/**
+ * Particles, debris and shockwave rings.
+ *
+ * Sparks are drawn as *streaks* along their own velocity rather than as dots —
+ * the single cheapest trick for making a burst read as fast rather than as
+ * confetti (Vlambeer's impact-effect rule: the effect should describe the
+ * direction the energy went). Debris keeps a real z velocity, so shards from a
+ * husk fly past the lens and grow as they come.
+ */
+
+import { project } from "../core/camera.ts";
+import { drawGlow } from "../render/bake.ts";
+import { PKind, type World } from "./world.ts";
+
+function alloc(world: World) {
+  const pool = world.particles;
+  for (let i = 0; i < pool.length; i++) {
+    const p = pool[i];
+    if (!p.active) return p;
+  }
+  return null;
+}
+
+/** Quality scales every count so a weak device thins the fireworks, not the game. */
+const budget = (world: World, n: number): number => Math.max(1, Math.round(n * world.quality));
+
+export function sparks(
+  world: World,
+  x: number,
+  y: number,
+  z: number,
+  count: number,
+  speed: number,
+  color: string,
+  opts: { life?: number; size?: number; spread?: number; dirX?: number; dirY?: number; drag?: number } = {},
+): void {
+  const rng = world.rng;
+  const n = budget(world, count);
+  const spread = opts.spread ?? Math.PI * 2;
+  const baseAngle = Math.atan2(opts.dirY ?? 0, opts.dirX ?? 1);
+  for (let i = 0; i < n; i++) {
+    const p = alloc(world);
+    if (!p) return;
+    const angle = spread >= Math.PI * 2 ? rng.range(0, Math.PI * 2) : baseAngle + rng.range(-spread / 2, spread / 2);
+    const v = speed * (0.35 + rng.nextFloat() * 0.9);
+    p.active = true;
+    p.kind = PKind.Spark;
+    p.x = x;
+    p.y = y;
+    p.z = z;
+    p.vx = Math.cos(angle) * v;
+    p.vy = Math.sin(angle) * v;
+    p.vz = rng.range(-0.35, 0.55) * v;
+    p.max = p.life = (opts.life ?? 0.5) * rng.range(0.6, 1.25);
+    p.size = opts.size ?? 1.6;
+    p.color = color;
+    p.drag = opts.drag ?? 2.4;
+    p.gravity = -6;
+    p.rot = 0;
+    p.rotV = 0;
+  }
+}
+
+/** Wireframe debris: the husk's own edges, thrown apart. */
+export function shards(
+  world: World,
+  x: number,
+  y: number,
+  z: number,
+  count: number,
+  speed: number,
+  color: string,
+  size: number,
+): void {
+  const rng = world.rng;
+  const n = budget(world, count);
+  for (let i = 0; i < n; i++) {
+    const p = alloc(world);
+    if (!p) return;
+    const angle = rng.range(0, Math.PI * 2);
+    const v = speed * rng.range(0.3, 1.1);
+    p.active = true;
+    p.kind = PKind.Shard;
+    p.x = x;
+    p.y = y;
+    p.z = z;
+    p.vx = Math.cos(angle) * v;
+    p.vy = Math.sin(angle) * v;
+    p.vz = rng.range(-0.6, 1.1) * v;
+    p.max = p.life = rng.range(0.7, 1.5);
+    p.size = size * rng.range(0.5, 1.1);
+    p.color = color;
+    p.drag = 0.85;
+    p.gravity = -14;
+    p.rot = rng.range(0, Math.PI);
+    p.rotV = rng.range(-7, 7);
+  }
+}
+
+/** Slow rising motes — the water remembers something died here. */
+export function embers(world: World, x: number, y: number, z: number, count: number, color: string): void {
+  const rng = world.rng;
+  const n = budget(world, count);
+  for (let i = 0; i < n; i++) {
+    const p = alloc(world);
+    if (!p) return;
+    p.active = true;
+    p.kind = PKind.Ember;
+    p.x = x + rng.range(-10, 10);
+    p.y = y + rng.range(-10, 10);
+    p.z = z + rng.range(-14, 14);
+    p.vx = rng.range(-7, 7);
+    p.vy = rng.range(4, 16);
+    p.vz = rng.range(-4, 4);
+    p.max = p.life = rng.range(1.1, 2.4);
+    p.size = rng.range(1.4, 3.4);
+    p.color = color;
+    p.drag = 0.5;
+    p.gravity = 5;
+    p.rot = 0;
+    p.rotV = 0;
+  }
+}
+
+export function ring(
+  world: World,
+  x: number,
+  y: number,
+  z: number,
+  color: string,
+  r0: number,
+  rv: number,
+  life: number,
+  width = 2.4,
+): void {
+  for (const r of world.rings) {
+    if (r.active) continue;
+    r.active = true;
+    r.x = x;
+    r.y = y;
+    r.z = z;
+    r.r = r0;
+    r.rv = rv;
+    r.max = r.life = life;
+    r.color = color;
+    r.width = width;
+    return;
+  }
+}
+
+export function stepParticles(world: World, dt: number): void {
+  for (const p of world.particles) {
+    if (!p.active) continue;
+    p.life -= dt;
+    if (p.life <= 0) {
+      p.active = false;
+      continue;
+    }
+    const d = Math.exp(-p.drag * dt);
+    p.vx *= d;
+    p.vy *= d;
+    p.vz *= d;
+    p.vy += p.gravity * dt;
+    p.x += p.vx * dt;
+    p.y += p.vy * dt;
+    p.z += p.vz * dt;
+    p.rot += p.rotV * dt;
+  }
+  for (const r of world.rings) {
+    if (!r.active) continue;
+    r.life -= dt;
+    if (r.life <= 0) {
+      r.active = false;
+      continue;
+    }
+    r.r += r.rv * dt;
+    r.rv *= Math.exp(-3.4 * dt);
+  }
+}
+
+/** Additive pass. Caller has already set `globalCompositeOperation = "lighter"`. */
+export function drawParticles(world: World): void {
+  const { cam, batch, ctx } = world;
+  for (const p of world.particles) {
+    if (!p.active) continue;
+    const t = p.life / p.max;
+    const a = t * t;
+    const head = project(cam, p.x, p.y, p.z);
+    if (!head.ok) continue;
+    const hx = head.x;
+    const hy = head.y;
+    const hs = head.s;
+
+    if (p.kind === PKind.Ember) {
+      drawGlow(ctx, p.color, hx, hy, p.size * hs * 1.9, a * 0.75);
+      continue;
+    }
+
+    let tx: number;
+    let ty: number;
+    let width: number;
+    if (p.kind === PKind.Spark) {
+      const k = 0.045;
+      const tail = project(cam, p.x - p.vx * k, p.y - p.vy * k, p.z - p.vz * k);
+      tx = tail.x;
+      ty = tail.y;
+      width = Math.max(0.7, p.size * hs * 0.45);
+    } else {
+      // Debris is a *sliver*: `size` is its length, never its thickness. A
+      // shard drawn as thick as it is long reads as confetti.
+      const len = p.size;
+      const dx = Math.cos(p.rot) * len;
+      const dy = Math.sin(p.rot) * len;
+      const tail = project(cam, p.x - dx, p.y - dy, p.z);
+      tx = tail.x;
+      ty = tail.y;
+      width = Math.max(0.7, hs * 0.55);
+    }
+    batch.push(tx, ty, hx, hy, p.color, width, a);
+  }
+
+  for (const r of world.rings) {
+    if (!r.active) continue;
+    const t = r.life / r.max;
+    const c = project(cam, r.x, r.y, r.z);
+    if (!c.ok) continue;
+    // Cubed, so the ring is a snap of light at the impact rather than a hoop
+    // that keeps expanding across the whole trench.
+    ctx.globalAlpha = t * t * t * 0.95;
+    ctx.strokeStyle = r.color;
+    ctx.lineWidth = Math.max(0.8, r.width * c.s * t);
+    ctx.beginPath();
+    ctx.ellipse(c.x, c.y, r.r * c.s, r.r * c.s * 0.92, 0, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+  ctx.globalAlpha = 1;
+}

--- a/dynawalla/games/guilty/src/game/game.ts
+++ b/dynawalla/games/guilty/src/game/game.ts
@@ -1,0 +1,1044 @@
+/**
+ * SHOOT THE GUILTY NUMBER.
+ *
+ * A problem hangs at the top of a trench. Candidate answers are thrown out of
+ * it and sink towards a gate you cannot let them cross. Destroy the one that is
+ * telling the truth; the rest scatter. Shoot an innocent and it turns on you.
+ *
+ * The loop, the phases, the collisions and the scoring all live here; the feel
+ * lives in `../core/juice.ts` and the look in `./husk.ts`, `./scene.ts` and
+ * `./ship.ts`.
+ */
+
+import type { GameHandle, Host, Question } from "../contract.ts";
+import { createAudio } from "../audio/audio.ts";
+import { beginFrame, fitCamera, makeCamera } from "../core/camera.ts";
+import {
+  BULLET_R,
+  CAM_Z,
+  EQUATION_Y,
+  FOCUS_DURATION,
+  FOCUS_PER_SOLVE,
+  FOCUS_TIME_SCALE,
+  GATE_Y,
+  HITSTOP_BOSS,
+  HITSTOP_KILL,
+  HITSTOP_WRONG,
+  HUSK_R,
+  MAX_LIVES,
+  SHIP_HALF_W,
+  SHIP_MAX_SPEED,
+  SHIP_Y,
+  START_LIVES,
+  URGENCY_BAND,
+  URGENCY_MULTIPLIER,
+  VIEW_HALF_H,
+  WAVE_GAP,
+} from "../core/config.ts";
+import {
+  addHitstop,
+  addTrauma,
+  flash,
+  makeJuice,
+  punch,
+  shakeAmount,
+  slowMotion,
+  stepJuice,
+} from "../core/juice.ts";
+import { C } from "../core/palette.ts";
+import { hashString, makeRng } from "../math/rng.ts";
+import { bakeVignette, clearGlyphCache } from "../render/bake.ts";
+import { clamp, damp, makeLineBatch } from "../render/draw.ts";
+import { drawBoss } from "./boss.ts";
+import { drawParticles, embers, ring, shards, sparks, stepParticles } from "./fx.ts";
+import { drawEquation, drawGameOver, drawHud, drawSecondWind, drawTitle, frameStats } from "./hud.ts";
+import { drawHusk, resetHusk, updateHusk } from "./husk.ts";
+import { attachInput } from "./input.ts";
+import { bakeScene, drawBackground, drawFloor, drawVignette, seedMotes } from "./scene.ts";
+import {
+  drawBullets,
+  drawShip,
+  drawSight,
+  findTarget,
+  fireBolt as fireBoltAt,
+  stepBullets,
+  updateShip,
+} from "./ship.ts";
+import { bannerFor, specFor } from "./waves.ts";
+import { Mode, Phase, freeHusk, makePools, type Husk, type World } from "./world.ts";
+
+const BEST_KEY = "dynawalla.guilty.best";
+
+/**
+ * Mounts the game. The return type is the contract's `GameHandle` plus a
+ * read-only `stats()` — extra structure a host may ignore entirely, and the
+ * only way the QA driver ever touches the running game.
+ */
+export function mount(
+  el: HTMLElement,
+  host: Host,
+): GameHandle & { stats(): ReturnType<typeof frameStats> } {
+  const canvas = document.createElement("canvas");
+  canvas.style.cssText = "display:block;width:100%;height:100%;touch-action:none;outline:none";
+  canvas.tabIndex = 0;
+  el.appendChild(canvas);
+  const ctx = canvas.getContext("2d", { alpha: false, desynchronized: true }) as CanvasRenderingContext2D;
+
+  const params = new URLSearchParams(typeof location === "undefined" ? "" : location.search);
+  const seed = Number(params.get("seed") ?? 0) || (Date.now() & 0xffffffff);
+  const rng = makeRng(seed);
+  const reduced = host.prefersReducedMotion();
+
+  const world: World = {
+    host,
+    audio: createAudio(() => rng.nextFloat()),
+    cam: makeCamera(),
+    juice: makeJuice(reduced, () => rng.nextFloat()),
+    batch: makeLineBatch(),
+    rng,
+    reduced,
+    ctx,
+    w: 1,
+    h: 1,
+    dpr: 1,
+    ...makePools(),
+    ship: {
+      x: 0,
+      targetX: 0,
+      vx: 0,
+      fireCd: 0,
+      recoil: 0,
+      bank: 0,
+      invuln: 0,
+      alive: true,
+      muzzle: 0,
+      settled: 1,
+    },
+    boss: {
+      active: false,
+      x: 0,
+      y: 0,
+      hp: 0,
+      maxHp: 3,
+      stage: 0,
+      flash: 0,
+      spin: 0,
+      shield: 1,
+      volleyCd: 0,
+      dying: 0,
+    },
+    motes: new Float32Array(0),
+    moteCount: 0,
+    phase: Phase.Title,
+    phaseT: 0,
+    time: 0,
+    wave: 1,
+    lives: START_LIVES,
+    score: 0,
+    displayScore: 0,
+    combo: 0,
+    bestCombo: 0,
+    best: loadBest(),
+    focus: 0,
+    focusT: 0,
+    question: null,
+    askedAt: 0,
+    firstWrong: null,
+    resolved: true,
+    perfectWave: true,
+    descent: 12,
+    swingAmp: 0,
+    swingFreq: 0.4,
+    swingPhase: 0,
+    swingPhaseX: 0,
+    formationY: EQUATION_Y,
+    usedSecondWind: false,
+    fireBolt: () => undefined,
+    shotStep: 0,
+    banner: "",
+    bannerSub: "",
+    bannerT: 0,
+    gateDanger: 0,
+    fpsSamples: [],
+    frameMs: 16,
+    quality: 1,
+    showStats: params.has("stats"),
+    paused: false,
+    touch: false,
+  };
+  world.fireBolt = (x, y) => fireBoltAt(world, x, y);
+
+  let vignette: HTMLCanvasElement | null = null;
+  let bossFinishing = false;
+
+  /* ---------------------------------------------------------------- layout */
+
+  function resize(): void {
+    const rect = el.getBoundingClientRect();
+    const w = Math.max(320, Math.round(rect.width || window.innerWidth));
+    const h = Math.max(360, Math.round(rect.height || window.innerHeight));
+    // Cap the backing store: a 3x phone canvas costs more fill than any of this
+    // is worth, and the look is all glow, which hides the resample.
+    const raw = Math.min(window.devicePixelRatio || 1, 2);
+    const dpr = w * h * raw * raw > 3_600_000 ? Math.max(1, raw * 0.75) : raw;
+    world.w = w;
+    world.h = h;
+    world.dpr = dpr;
+    canvas.width = Math.round(w * dpr);
+    canvas.height = Math.round(h * dpr);
+    canvas.style.width = `${w}px`;
+    canvas.style.height = `${h}px`;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    fitCamera(world.cam, w, h);
+    bakeScene(w, h);
+    vignette = bakeVignette(w, h);
+  }
+
+  const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(() => resize()) : null;
+  observer?.observe(el);
+  window.addEventListener("resize", resize);
+  resize();
+  seedMotes(world, 150);
+
+  /* ------------------------------------------------------------- questions */
+
+  function askQuestion(wanted: number, shroudChance: number, orbit: boolean): void {
+    // A phone in portrait has a third of the lane width a laptop does. Rather
+    // than let six cells overlap into an unreadable smear, the formation loses
+    // a lane and every cell shrinks to keep a real gap between the numerals.
+    const laneSpan = world.cam.playHalfW * 1.64;
+    const count = orbit ? wanted : Math.max(3, Math.min(wanted, Math.floor(laneSpan / 21) + 1));
+    const q: Question = host.next();
+    world.question = q;
+    world.askedAt = world.time;
+    world.firstWrong = null;
+    world.resolved = false;
+
+    const qrng = makeRng(hashString(q.id));
+    const labels: string[] = [q.answer];
+    for (const d of q.distractors) {
+      if (labels.length >= count) break;
+      if (!labels.includes(d)) labels.push(d);
+    }
+    while (labels.length < count) labels.push(String(Number(q.answer) + labels.length * 3 + 1));
+    qrng.shuffle(labels);
+
+    const spread = world.cam.playHalfW * 0.82;
+    const orbitR = Math.min(66, world.cam.playHalfW * 0.72);
+    const spacing = labels.length > 1 ? (spread * 2) / (labels.length - 1) : 999;
+    const cellR = clamp(spacing * 0.44, 8.5, HUSK_R);
+    for (let i = 0; i < labels.length; i++) {
+      const h = freeHusk(world);
+      if (!h) break;
+      resetHusk(h);
+      h.label = labels[i] as string;
+      h.guilty = h.label === q.answer;
+      h.lane = labels.length === 1 ? 0 : -spread + (spread * 2 * i) / (labels.length - 1);
+      h.row = (i % 2 === 0 ? 5 : -5) + (i % 3) * 1.5;
+      h.spin = qrng.range(0, Math.PI * 2);
+      h.spinV = qrng.range(0.5, 1.15) * (qrng.int(0, 1) ? 1 : -1);
+      h.tilt = qrng.range(-0.3, 0.3);
+      h.tiltV = qrng.range(-0.35, 0.35);
+      h.wob = qrng.range(0, 6);
+      h.shroud = qrng.nextFloat() < shroudChance ? 1 : 0;
+      if (orbit) {
+        h.mode = Mode.Orbit;
+        h.orbit = (i / labels.length) * Math.PI * 2;
+        h.orbitR = orbitR;
+        h.radius = Math.min(11.5, orbitR * 0.3);
+        h.x = world.boss.x + Math.cos(h.orbit) * orbitR;
+        h.y = world.boss.y + Math.sin(h.orbit) * orbitR * 0.44;
+      } else {
+        h.radius = cellR;
+        // Born out of the equation and thrown into formation. This fan-out is
+        // the whole tutorial: these numbers came from that problem.
+        h.x = qrng.range(-6, 6);
+        h.y = EQUATION_Y - 6;
+        h.vx = (h.lane - h.x) * 2.4 + qrng.range(-18, 18);
+        h.vy = qrng.range(-30, 8);
+        h.vz = qrng.range(-40, 40);
+      }
+      sparks(world, h.x, h.y, 0, 6, 60, C.amber, { life: 0.4, size: 1.3 });
+    }
+  }
+
+  function startWave(): void {
+    const spec = specFor(world.wave);
+    world.descent = spec.descent;
+    world.swingAmp = spec.swingAmp;
+    world.swingFreq = spec.swingFreq;
+    world.perfectWave = true;
+    // Well below the equation: the husks are *born* out of it and fall clear,
+    // so the problem never sits behind the answers.
+    world.formationY = EQUATION_Y - 62;
+    const [banner, sub] = bannerFor(world.wave);
+    if (banner) showBanner(banner, sub);
+
+    if (spec.boss) {
+      world.boss.active = true;
+      world.boss.hp = 3;
+      world.boss.maxHp = 3;
+      world.boss.x = 0;
+      world.boss.y = EQUATION_Y - 46;
+      world.boss.shield = 1;
+      world.boss.dying = 0;
+      world.boss.volleyCd = 3;
+      bossFinishing = false;
+      askQuestion(spec.candidates, 0, true);
+    } else {
+      world.boss.active = false;
+      askQuestion(spec.candidates, spec.shroud, false);
+    }
+    world.phase = Phase.Wave;
+    world.phaseT = 0;
+  }
+
+  function showBanner(text: string, sub: string): void {
+    world.banner = text;
+    world.bannerSub = sub;
+    world.bannerT = 1.5;
+  }
+
+  function resolveQuestion(correct: boolean): void {
+    if (world.resolved || !world.question) return;
+    world.resolved = true;
+    const clean = correct && world.firstWrong === null;
+    host.report({
+      questionId: world.question.id,
+      correct: clean,
+      ms: Math.round((world.time - world.askedAt) * 1000),
+      answered: world.firstWrong ?? (correct ? world.question.answer : ""),
+    });
+  }
+
+  /* --------------------------------------------------------------- outcomes */
+
+  function onCorrect(h: Husk): void {
+    resolveQuestion(true);
+    const seconds = world.time - world.askedAt;
+    world.combo += 1;
+    world.bestCombo = Math.max(world.bestCombo, world.combo);
+    const speedBonus = Math.round(100 * clamp(1 - (seconds - 0.9) / 4, 0, 1));
+    world.score += (100 + speedBonus) * world.combo;
+    world.focus = Math.min(1, world.focus + FOCUS_PER_SOLVE);
+
+    kill(h, true);
+    host.haptic("success");
+    world.audio.correct(world.combo);
+    addTrauma(world.juice, 0.5);
+    addHitstop(world.juice, HITSTOP_KILL);
+    punch(world.juice, 30);
+    flash(world.juice, 0.3, C.white);
+    // Slow motion is rationed: on every fifth link of a combo and on the boss,
+    // so it always means "that was a big one" and never becomes wallpaper.
+    if (world.combo % 5 === 0) slowMotion(world.juice, 0.32, 0.4);
+
+    if (world.boss.active) {
+      onBossDamaged();
+      return;
+    }
+    scatterInnocents(h);
+    if (world.perfectWave) {
+      world.score += 150;
+      world.audio.waveClear(world.combo);
+    }
+    world.phase = Phase.Clear;
+    world.phaseT = 0;
+  }
+
+  function onWrong(h: Husk): void {
+    if (world.firstWrong === null) world.firstWrong = h.label;
+    world.combo = 0;
+    world.perfectWave = false;
+    h.hostile = true;
+    h.hp = 3;
+    h.mode = Mode.Hostile;
+    h.vy = -6;
+    h.vx = (h.x < world.ship.x ? 1 : -1) * 14;
+    h.shroud = 0;
+    h.hitFlash = 1;
+    h.squash = 0.7;
+    // The rest of the formation takes it personally.
+    world.descent *= 1.14;
+
+    host.haptic("failure");
+    world.audio.wrong();
+    world.audio.hostileWake();
+    addTrauma(world.juice, 0.66);
+    addHitstop(world.juice, HITSTOP_WRONG);
+    punch(world.juice, -22);
+    flash(world.juice, 0.24, C.hostile);
+    ring(world, h.x, h.y, 0, C.hostile, h.radius, 150, 0.42, 3);
+    sparks(world, h.x, h.y, 0, 26, 130, C.hostile, { life: 0.6, size: 1.8 });
+    if (world.boss.active) bossVolley(3);
+  }
+
+  function kill(h: Husk, big: boolean): void {
+    h.mode = Mode.Dying;
+    h.dieT = 0;
+    h.vx = 0;
+    h.vy = 0;
+    const color = h.hostile ? C.hostile : C.cyan;
+    ring(world, h.x, h.y, 0, C.white, h.radius * 0.6, big ? 230 : 130, big ? 0.42 : 0.3, big ? 3.4 : 2);
+    shards(world, h.x, h.y, 0, big ? 20 : 12, big ? 150 : 90, color, big ? 9 : 6);
+    sparks(world, h.x, h.y, 0, big ? 42 : 20, big ? 220 : 130, big ? C.white : color, {
+      life: big ? 0.7 : 0.45,
+      size: big ? 2.1 : 1.4,
+    });
+    embers(world, h.x, h.y, 0, big ? 12 : 5, color);
+  }
+
+  /** The truth destroys the lies: a shockwave throws the innocents apart. */
+  function scatterInnocents(source: Husk): void {
+    for (const h of world.husks) {
+      if (!h.active || h === source || h.mode === Mode.Dying) continue;
+      const dx = h.x - source.x;
+      const dy = h.y - source.y;
+      const dist = Math.max(6, Math.hypot(dx, dy));
+      h.mode = Mode.Dying;
+      h.dieT = -dist * 0.0022;
+      h.vx = (dx / dist) * 130;
+      h.vy = (dy / dist) * 130 + 20;
+      h.hostile = false;
+      world.score += 10;
+      sparks(world, h.x, h.y, 0, 10, 90, C.cyan, { life: 0.5, size: 1.3 });
+    }
+  }
+
+  function dissolveAll(): void {
+    for (const h of world.husks) {
+      if (!h.active || h.mode === Mode.Dying) continue;
+      h.mode = Mode.Dying;
+      h.dieT = 0;
+      h.vx = world.rng.range(-40, 40);
+      h.vy = world.rng.range(-20, 40);
+      sparks(world, h.x, h.y, 0, 8, 70, h.hostile ? C.hostile : C.cyan, { life: 0.4 });
+    }
+  }
+
+  function onBreach(x: number): void {
+    resolveQuestion(false);
+    world.combo = 0;
+    host.haptic("heavy");
+    world.audio.breach();
+    addTrauma(world.juice, 1);
+    addHitstop(world.juice, 0.16);
+    punch(world.juice, 46);
+    flash(world.juice, 0.34, C.hostile);
+    ring(world, x, GATE_Y, 0, C.hostile, 6, 330, 0.6, 4);
+    sparks(world, x, GATE_Y, 0, 50, 260, C.hostile, { life: 0.8, size: 2.2, dirX: 0, dirY: 1, spread: 2.4 });
+    dissolveAll();
+    loseLife();
+    if (world.phase === Phase.Wave) {
+      world.phase = Phase.Breach;
+      world.phaseT = 0;
+    }
+  }
+
+  function onShipHit(): void {
+    const ship = world.ship;
+    if (ship.invuln > 0 || !ship.alive) return;
+    ship.invuln = 2.2;
+    world.combo = 0;
+    host.haptic("heavy");
+    world.audio.breach();
+    addTrauma(world.juice, 0.9);
+    addHitstop(world.juice, 0.14);
+    punch(world.juice, 38);
+    flash(world.juice, 0.3, C.hostile);
+    ring(world, ship.x, SHIP_Y, 0, C.hostile, 8, 280, 0.55, 3);
+    sparks(world, ship.x, SHIP_Y, 0, 40, 200, C.hostile, { life: 0.7, size: 2 });
+    loseLife();
+  }
+
+  function loseLife(): void {
+    world.lives -= 1;
+    if (world.lives > 0) return;
+    if (!world.usedSecondWind) startSecondWind();
+    else gameOver();
+  }
+
+  /* ------------------------------------------------------------ second wind */
+
+  function startSecondWind(): void {
+    world.usedSecondWind = true;
+    world.lives = 0;
+    dissolveAll();
+    for (const b of world.bullets) b.active = false;
+    world.boss.active = false;
+    world.phase = Phase.SecondWind;
+    world.phaseT = 0;
+    world.descent = 6.5;
+    world.swingAmp = 0;
+    world.formationY = EQUATION_Y - 62;
+    world.ship.invuln = 3;
+    world.audio.focus(true);
+    slowMotion(world.juice, 0.5, 0.6);
+    askQuestion(4, 0, false);
+  }
+
+  function onSecondWindWon(h: Husk): void {
+    resolveQuestion(true);
+    world.lives = 1;
+    world.combo = 0;
+    kill(h, true);
+    scatterInnocents(h);
+    world.audio.revive();
+    host.haptic("success");
+    addTrauma(world.juice, 0.7);
+    flash(world.juice, 0.34, C.white);
+    punch(world.juice, 44);
+    ring(world, 0, SHIP_Y, 0, C.white, 10, 400, 0.75, 4);
+    embers(world, 0, SHIP_Y + 20, 0, 24, C.ship);
+    showBanner("BACK", "");
+    world.phase = Phase.Clear;
+    world.phaseT = 0;
+  }
+
+  function gameOver(): void {
+    world.phase = Phase.Over;
+    world.phaseT = 0;
+    world.ship.alive = false;
+    world.audio.gameOver();
+    host.haptic("heavy");
+    addTrauma(world.juice, 1);
+    slowMotion(world.juice, 0.25, 1.2);
+    sparks(world, world.ship.x, SHIP_Y, 0, 60, 240, C.ship, { life: 1.1, size: 2.4 });
+    shards(world, world.ship.x, SHIP_Y, 0, 22, 170, C.ship, 10);
+    if (world.score > world.best) {
+      world.best = world.score;
+      saveBest(world.best);
+    }
+  }
+
+  /* -------------------------------------------------------------- the boss */
+
+  function onBossDamaged(): void {
+    const boss = world.boss;
+    boss.hp -= 1;
+    boss.flash = 1;
+    boss.shield = 0;
+    boss.y += 10;
+    addHitstop(world.juice, HITSTOP_BOSS);
+    addTrauma(world.juice, 0.85);
+    punch(world.juice, 52);
+    slowMotion(world.juice, 0.24, 0.55);
+    flash(world.juice, 0.36, C.white);
+    world.audio.bossHit(3 - boss.hp);
+    host.haptic("heavy");
+    ring(world, boss.x, boss.y, 0, C.boss, 20, 300, 0.65, 4);
+    sparks(world, boss.x, boss.y, 0, 60, 260, C.boss, { life: 0.9, size: 2.4 });
+    shards(world, boss.x, boss.y, 0, 24, 180, C.boss, 12);
+    dissolveAll();
+
+    if (boss.hp <= 0) {
+      bossFinishing = true;
+      boss.dying = 0.001;
+      world.score += 1200;
+      world.lives = Math.min(MAX_LIVES, world.lives + 1);
+      world.audio.bossDown();
+      showBanner("ARBITER DOWN", "");
+    }
+    world.phase = Phase.Clear;
+    world.phaseT = 0;
+  }
+
+  function bossVolley(count: number): void {
+    const boss = world.boss;
+    for (let i = 0; i < count; i++) {
+      const x = boss.x + (i - (count - 1) / 2) * 26;
+      fireBoltAt(world, x, boss.y - 30);
+    }
+    world.audio.hostileWake();
+  }
+
+  /* ------------------------------------------------------------ collisions */
+
+  function collide(): void {
+    const ship = world.ship;
+    for (const b of world.bullets) {
+      if (!b.active) continue;
+      if (b.enemy) {
+        if (
+          ship.alive &&
+          Math.abs(b.x - ship.x) < SHIP_HALF_W + 3 &&
+          Math.abs(b.y - SHIP_Y) < 11
+        ) {
+          b.active = false;
+          onShipHit();
+        }
+        continue;
+      }
+      for (const h of world.husks) {
+        if (!h.active || h.mode === Mode.Dying) continue;
+        const dx = b.x - h.x;
+        const dy = b.y - h.y;
+        const r = h.radius + BULLET_R;
+        if (dx * dx + dy * dy > r * r) continue;
+        b.active = false;
+        if (h.hostile) {
+          h.hp -= 1;
+          h.hitFlash = 1;
+          h.squash = 0.6;
+          world.audio.hit();
+          sparks(world, b.x, b.y, 0, 8, 110, C.hostile, { life: 0.3, size: 1.3 });
+          addTrauma(world.juice, 0.12);
+          if (h.hp <= 0) {
+            world.score += 25;
+            kill(h, false);
+            host.haptic("light");
+            addTrauma(world.juice, 0.3);
+            addHitstop(world.juice, 0.04);
+          }
+        } else if (h.guilty) {
+          if (world.phase === Phase.SecondWind) onSecondWindWon(h);
+          else onCorrect(h);
+        } else {
+          onWrong(h);
+        }
+        break;
+      }
+      if (!b.active) continue;
+      // The Arbiter's hull simply eats bullets. Only the truth gets through.
+      if (world.boss.active && world.boss.dying === 0) {
+        const dx = b.x - world.boss.x;
+        const dy = b.y - world.boss.y;
+        if (dx * dx + dy * dy < 46 * 46) {
+          b.active = false;
+          world.boss.shield = Math.min(1, world.boss.shield + 0.25);
+          sparks(world, b.x, b.y, 0, 5, 80, C.boss, { life: 0.25, size: 1.1 });
+          world.audio.hit();
+        }
+      }
+    }
+
+    // Hostiles ram the ship; anything that crosses the gate is a life.
+    let lowest = VIEW_HALF_H;
+    for (const h of world.husks) {
+      if (!h.active || h.mode === Mode.Dying) continue;
+      if (h.mode !== Mode.Orbit) lowest = Math.min(lowest, h.y);
+      if (
+        ship.alive &&
+        h.hostile &&
+        Math.abs(h.x - ship.x) < h.radius + SHIP_HALF_W &&
+        Math.abs(h.y - SHIP_Y) < h.radius + 9
+      ) {
+        kill(h, false);
+        onShipHit();
+        continue;
+      }
+      if (h.mode !== Mode.Orbit && h.y - h.radius * 0.35 < GATE_Y) {
+        onBreach(h.x);
+        return;
+      }
+    }
+    if (world.boss.active && world.boss.dying === 0 && world.boss.y - 44 < GATE_Y) {
+      world.boss.y = EQUATION_Y - 46;
+      onBreach(world.boss.x);
+      return;
+    }
+    const span = EQUATION_Y - GATE_Y;
+    world.gateDanger = clamp(1 - (lowest - GATE_Y) / (span * 0.42), 0, 1);
+  }
+
+  /* ------------------------------------------------------------ the update */
+
+  function update(realDt: number): void {
+    const dt = stepJuice(world.juice, realDt);
+    world.time += realDt;
+    world.phaseT += realDt;
+    world.bannerT = Math.max(0, world.bannerT - realDt);
+    world.displayScore = damp(world.displayScore, world.score, 9, realDt);
+    world.audio.tick(realDt);
+    world.audio.setTimeScale(world.juice.timeScale);
+    world.audio.setIntensity(
+      clamp(world.gateDanger * 0.6 + Math.min(1, world.wave / 14) * 0.4 + world.combo * 0.02, 0, 1),
+    );
+
+    if (world.focusT > 0) {
+      world.focusT = Math.max(0, world.focusT - realDt);
+      if (world.focusT === 0) world.audio.focus(false);
+    }
+
+    // Keyboard steering rides on top of the pointer target.
+    const axis = input.axis();
+    if (axis !== 0) {
+      world.ship.targetX = clamp(
+        world.ship.targetX + axis * SHIP_MAX_SPEED * realDt,
+        -world.cam.playHalfW - 6,
+        world.cam.playHalfW + 6,
+      );
+    }
+    if (bot) bot(realDt);
+
+    updateShip(world, dt, realDt);
+    stepBullets(world, dt);
+    stepParticles(world, dt);
+
+    const playing = world.phase === Phase.Wave || world.phase === Phase.SecondWind;
+
+    if (playing) {
+      // The last stretch is the fastest: once the formation is in the gate's
+      // shadow it dives. Every wave gets a heartbeat ending instead of a
+      // constant slide, and the player feels the deadline without a timer.
+      const urgent = world.formationY < GATE_Y + URGENCY_BAND;
+      world.formationY -= world.descent * (urgent ? URGENCY_MULTIPLIER : 1) * dt;
+      world.swingPhase += dt * world.swingFreq;
+      world.swingPhaseX = Math.sin(world.swingPhase * Math.PI * 2) * world.swingAmp;
+    }
+
+    if (world.boss.active) {
+      const boss = world.boss;
+      boss.spin += dt * 0.55;
+      boss.flash = Math.max(0, boss.flash - realDt * 2.6);
+      boss.shield = Math.min(1, boss.shield + dt * 0.35);
+      if (boss.dying > 0) {
+        boss.dying += realDt;
+        if (world.rng.nextFloat() < realDt * 22) {
+          sparks(
+            world,
+            boss.x + world.rng.range(-40, 40),
+            boss.y + world.rng.range(-30, 30),
+            world.rng.range(-20, 20),
+            6,
+            190,
+            C.boss,
+            { life: 0.8, size: 2 },
+          );
+        }
+      } else if (world.phase === Phase.Wave) {
+        boss.y -= 3.4 * dt;
+        boss.volleyCd -= dt;
+        if (boss.volleyCd <= 0) {
+          boss.volleyCd = 4.6;
+          bossVolley(2);
+        }
+      }
+    }
+
+    for (const h of world.husks) {
+      if (!h.active) continue;
+      updateHusk(world, h, dt);
+    }
+
+    if (playing) collide();
+
+    if (world.phase === Phase.Clear && world.phaseT > (bossFinishing ? 1.9 : WAVE_GAP)) {
+      advance();
+    }
+    if (world.phase === Phase.Breach && world.phaseT > 1) {
+      if (world.lives > 0) advance();
+    }
+    if (world.phase === Phase.Title) {
+      idleDrift(realDt);
+    }
+
+    // Adaptive quality: hold 60 by thinning the fireworks, never the game.
+    const ms = world.frameMs;
+    if (ms > 20.5 && world.quality > 0.45) world.quality = Math.max(0.45, world.quality - realDt * 0.9);
+    else if (ms < 14 && world.quality < 1) world.quality = Math.min(1, world.quality + realDt * 0.25);
+  }
+
+  function advance(): void {
+    if (bossFinishing) {
+      bossFinishing = false;
+      world.boss.active = false;
+      world.boss.dying = 0;
+      world.wave += 1;
+      startWave();
+      return;
+    }
+    if (world.boss.active && world.boss.hp > 0) {
+      askQuestion(specFor(world.wave).candidates, 0, true);
+      world.phase = Phase.Wave;
+      world.phaseT = 0;
+      return;
+    }
+    world.wave += 1;
+    startWave();
+  }
+
+  /** Attract mode: husks sink through the title and dissolve at the gate. */
+  let idleT = 0.2;
+  function idleDrift(dt: number): void {
+    idleT -= dt;
+    if (idleT <= 0) {
+      idleT = 1.15;
+      const h = freeHusk(world);
+      if (h) {
+        resetHusk(h);
+        h.mode = Mode.Drift;
+        h.label = String(world.rng.int(0, 99));
+        h.guilty = false;
+        h.lane = world.rng.range(-world.cam.playHalfW * 0.9, world.cam.playHalfW * 0.9);
+        h.row = 0;
+        h.spin = world.rng.range(0, 6.28);
+        h.spinV = world.rng.range(-1, 1);
+        h.tiltV = world.rng.range(-0.4, 0.4);
+        h.wob = world.rng.range(0, 6);
+        h.x = h.lane;
+        h.y = VIEW_HALF_H + 24;
+      }
+    }
+    for (const h of world.husks) {
+      if (h.active && h.mode === Mode.Drift && h.y < GATE_Y + 6) kill(h, false);
+    }
+  }
+
+  /* -------------------------------------------------------------- the draw */
+
+  const drawOrder: Husk[] = [];
+
+  function render(): void {
+    const { cam, juice } = world;
+    const amt = shakeAmount(juice);
+    // Smooth two-frequency shake instead of white noise: it reads as a camera
+    // on a boom being hit, not as a loose cable.
+    const t = world.time;
+    cam.shakeX = (Math.sin(t * 47.3) * 0.65 + Math.sin(t * 28.1) * 0.35) * amt * 30;
+    cam.shakeY = (Math.sin(t * 41.7 + 1.3) * 0.6 + Math.sin(t * 33.9) * 0.4) * amt * 24;
+    cam.roll = Math.sin(t * 25.1) * amt * 0.035;
+    cam.z = CAM_Z + juice.punch;
+    cam.x = damp(cam.x, world.ship.x * 0.12, 5, 1 / 60);
+    beginFrame(cam);
+
+    ctx.globalCompositeOperation = "source-over";
+    ctx.globalAlpha = 1;
+    drawBackground(world);
+    drawFloor(world);
+
+    world.batch.reset();
+    if (world.boss.active) drawBoss(world);
+    if (world.phase !== Phase.Title && world.phase !== Phase.Over) {
+      drawSight(world, world.ship.settled > 0.05 ? findTarget(world) : null);
+    }
+    drawBullets(world);
+
+    // Husks back to front so the wireframes overlap correctly. Insertion sort
+    // into a reused array: at most fourteen elements, already nearly ordered,
+    // and it allocates nothing.
+    let n = 0;
+    for (const h of world.husks) {
+      if (!h.active) continue;
+      let i = n++;
+      while (i > 0 && (drawOrder[i - 1] as Husk).z > h.z) {
+        drawOrder[i] = drawOrder[i - 1] as Husk;
+        i--;
+      }
+      drawOrder[i] = h;
+    }
+    for (let i = 0; i < n; i++) drawHusk(world, drawOrder[i] as Husk);
+    drawShip(world);
+
+    ctx.globalCompositeOperation = "lighter";
+    world.batch.flush(ctx);
+    drawParticles(world);
+    world.batch.flush(ctx);
+    ctx.globalCompositeOperation = "source-over";
+
+    if (world.phase !== Phase.Title && world.phase !== Phase.Over) drawEquation(world);
+    drawVignette(world, vignette);
+
+    if (juice.flash > 0.002) {
+      ctx.globalCompositeOperation = "lighter";
+      ctx.fillStyle = juice.flashColor;
+      ctx.globalAlpha = juice.flash;
+      ctx.fillRect(0, 0, world.w, world.h);
+      ctx.globalAlpha = 1;
+      ctx.globalCompositeOperation = "source-over";
+    }
+
+    if (world.phase === Phase.Title) drawTitle(world);
+    else if (world.phase === Phase.Over) drawGameOver(world);
+    else {
+      if (world.phase === Phase.SecondWind) drawSecondWind(world);
+      drawHud(world);
+    }
+  }
+
+  /* -------------------------------------------------------------- the loop */
+
+  let raf = 0;
+  let last = performance.now();
+  let running = true;
+
+  function frame(now: number): void {
+    if (!running) return;
+    raf = requestAnimationFrame(frame);
+    const realDt = Math.min(0.05, Math.max(0.0005, (now - last) / 1000));
+    last = now;
+    if (world.paused) return;
+
+    const t0 = performance.now();
+    update(realDt);
+    render();
+    // `frameMs` is the cost of *our* work, which is what quality should react
+    // to; `fpsSamples` is wall-clock delta between presented frames, which is
+    // what a player actually experiences. They are not the same number and the
+    // stats overlay reports the second one.
+    world.frameMs = world.frameMs * 0.88 + (performance.now() - t0) * 0.12;
+    world.fpsSamples.push(now - lastSample);
+    lastSample = now;
+    if (world.fpsSamples.length > 120) world.fpsSamples.shift();
+  }
+  let lastSample = performance.now();
+
+  /* ------------------------------------------------------------ start/stop */
+
+  function begin(): void {
+    void world.audio.resume();
+    if (world.phase === Phase.Title || world.phase === Phase.Over) {
+      for (const h of world.husks) h.active = false;
+      for (const b of world.bullets) b.active = false;
+      world.wave = 1;
+      world.lives = START_LIVES;
+      world.score = 0;
+      world.displayScore = 0;
+      world.combo = 0;
+      world.bestCombo = 0;
+      world.focus = 0;
+      world.focusT = 0;
+      world.usedSecondWind = false;
+      world.ship.alive = true;
+      world.ship.invuln = 1.2;
+      world.ship.x = 0;
+      world.ship.targetX = 0;
+      bossFinishing = false;
+      startWave();
+    }
+  }
+
+  function spendFocus(): void {
+    if (world.phase === Phase.Title || world.phase === Phase.Over) {
+      begin();
+      return;
+    }
+    if (world.focus < 1 || world.focusT > 0) return;
+    world.focus = 0;
+    world.focusT = FOCUS_DURATION;
+    slowMotion(world.juice, FOCUS_TIME_SCALE, FOCUS_DURATION);
+    world.audio.focus(true);
+    host.haptic("medium");
+    ring(world, world.ship.x, SHIP_Y, 0, C.plankton, 8, 460, 0.7, 3);
+    flash(world.juice, 0.16, C.plankton);
+    embers(world, world.ship.x, SHIP_Y, 0, 16, C.plankton);
+  }
+
+  const input = attachInput(canvas, world, {
+    onStart: begin,
+    onFocus: spendFocus,
+    onToggleMute: () => world.audio.setMuted(!world.audio.muted()),
+    onTogglePause: () => {
+      world.paused = !world.paused;
+      last = performance.now();
+    },
+    onToggleStats: () => {
+      world.showStats = !world.showStats;
+    },
+  });
+
+  /* --------------------------------------------------------------- the bot */
+
+  let bot: ((dt: number) => void) | null = null;
+  if (params.has("bot")) {
+    const skill = Number(params.get("bot")) || 1;
+    bot = makeBot(world, skill, begin, spendFocus);
+  }
+  if (params.has("wave")) {
+    world.wave = Math.max(1, Number(params.get("wave")) || 1);
+    begin();
+  }
+
+  raf = requestAnimationFrame(frame);
+
+  return {
+    stats: () => frameStats(world),
+    unmount() {
+      running = false;
+      cancelAnimationFrame(raf);
+      input.detach();
+      observer?.disconnect();
+      window.removeEventListener("resize", resize);
+      world.audio.dispose();
+      clearGlyphCache();
+      canvas.remove();
+    },
+  };
+}
+
+/* ------------------------------------------------------------------ helpers */
+
+function loadBest(): number {
+  try {
+    return Number(localStorage.getItem(BEST_KEY)) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+function saveBest(value: number): void {
+  try {
+    localStorage.setItem(BEST_KEY, String(value));
+  } catch {
+    /* private mode, or a sandboxed webview */
+  }
+}
+
+/**
+ * A deterministic autoplayer. It exists for QA — it drives the *real* input
+ * surface (a target x and the focus button), never a private hook, so anything
+ * it proves is true of a human playing.
+ */
+function makeBot(
+  world: World,
+  skill: number,
+  begin: () => void,
+  spendFocus: () => void,
+): (dt: number) => void {
+  let think = 0;
+  let started = false;
+  return (dt: number) => {
+    if (!started) {
+      started = true;
+      begin();
+    }
+    if (world.phase === Phase.Over) {
+      begin();
+      return;
+    }
+    think -= dt;
+    let target: Husk | null = null;
+    let threat: Husk | null = null;
+    for (const h of world.husks) {
+      if (!h.active || h.mode === Mode.Dying) continue;
+      if (h.hostile) {
+        if (!threat || h.y < threat.y) threat = h;
+      } else if (h.guilty) target = h;
+    }
+    // A deliberately imperfect bot: at skill < 1 it sometimes indicts a
+    // neighbour, which is how the failure states get exercised.
+    if (skill < 1 && think <= 0) {
+      think = 2.5;
+      if (world.rng.nextFloat() > skill) {
+        for (const h of world.husks) {
+          if (h.active && !h.guilty && !h.hostile && h.mode !== Mode.Dying) {
+            target = h;
+            break;
+          }
+        }
+      }
+    }
+    const aim = threat && threat.y < 20 ? threat : target;
+    if (aim) {
+      // Lead the shot. In formation a husk's x is driven by the swing, not by
+      // its own velocity, so the lead comes from the swing's derivative.
+      const swingV =
+        aim.mode === Mode.Formation
+          ? Math.cos(world.swingPhase * Math.PI * 2) * world.swingAmp * world.swingFreq * Math.PI * 2
+          : aim.vx;
+      const flight = Math.max(0, (aim.y - SHIP_Y) / 560);
+      world.ship.targetX = aim.x + swingV * flight;
+    }
+    if (world.focus >= 1 && world.rng.nextFloat() < dt * 0.6) spendFocus();
+  };
+}

--- a/dynawalla/games/guilty/src/game/hud.ts
+++ b/dynawalla/games/guilty/src/game/hud.ts
@@ -1,0 +1,254 @@
+/**
+ * Head-up display.
+ *
+ * The equation lives in the *world*, at the top of the trench, because the
+ * husks are born out of it — that fan-out is the entire tutorial. Everything
+ * else is deliberately tiny and in the corners: score, lives, and a focus bar
+ * one pixel thick along the bottom edge. Nothing explains anything.
+ */
+
+import { project } from "../core/camera.ts";
+import { EQUATION_Y, SHIP_Y } from "../core/config.ts";
+import { C, rgba } from "../core/palette.ts";
+import { drawGlow, drawGlyph, getGlyph } from "../render/bake.ts";
+import { clamp, ease } from "../render/draw.ts";
+import type { World } from "./world.ts";
+
+const UI_FONT = `700 %SIZE%px system-ui, -apple-system, "Segoe UI", "Helvetica Neue", Arial, sans-serif`;
+const font = (size: number): string => UI_FONT.replace("%SIZE%", String(Math.round(size)));
+
+export function drawEquation(world: World): void {
+  const q = world.question;
+  if (!q) return;
+  const { ctx, cam } = world;
+  const age = world.time - world.askedAt;
+  const pop = ease.outBack(clamp(age / 0.42, 0, 1));
+  const bob = Math.sin(world.time * 1.3) * 1.6;
+  const p = project(cam, 0, EQUATION_Y + bob, 0);
+  const glyphMetrics = getGlyph(q.prompt, C.amber, 800);
+  // A two-step prompt is three times the width of "8 + 5", so the type size
+  // fits the *sprite* to the viewport rather than trusting a constant.
+  const widthLimited = (world.w * 0.9 * 92) / glyphMetrics.w;
+  const size = Math.min(world.h * 0.085, widthLimited) * (0.55 + pop * 0.45);
+
+  ctx.globalCompositeOperation = "lighter";
+  drawGlow(ctx, C.amber, p.x, p.y, size * 2.2, 0.05 + (1 - clamp(age / 0.6, 0, 1)) * 0.14);
+  // A hair of chromatic split while it lands — two cheap blits of one sprite.
+  if (age < 0.3 && !world.reduced) {
+    const k = (1 - age / 0.3) * size * 0.07;
+    ctx.globalAlpha = 0.32;
+    drawGlyph(ctx, getGlyph(q.prompt, C.hostile, 800), p.x - k, p.y, size);
+    drawGlyph(ctx, getGlyph(q.prompt, C.plankton, 800), p.x + k, p.y, size);
+    ctx.globalAlpha = 1;
+  }
+  ctx.globalCompositeOperation = "source-over";
+  drawGlyph(ctx, glyphMetrics, p.x, p.y, size);
+}
+
+export function drawHud(world: World): void {
+  const { ctx, w, h } = world;
+  const pad = Math.max(14, Math.min(w, h) * 0.045);
+
+  // Lives — small ship silhouettes, top left.
+  for (let i = 0; i < world.lives; i++) {
+    const x = pad + i * 20;
+    const y = pad;
+    ctx.beginPath();
+    ctx.moveTo(x, y - 8);
+    ctx.lineTo(x + 6.5, y + 6);
+    ctx.lineTo(x, y + 2.5);
+    ctx.lineTo(x - 6.5, y + 6);
+    ctx.closePath();
+    ctx.fillStyle = rgba(C.ship, 0.92);
+    ctx.fill();
+  }
+
+  // Score — top right, warm, with a soft halo instead of a shadow pass.
+  const scoreText = String(Math.round(world.displayScore));
+  const size = Math.max(20, Math.min(w, h) * 0.052);
+  ctx.font = font(size);
+  ctx.textAlign = "right";
+  ctx.textBaseline = "middle";
+  ctx.globalCompositeOperation = "lighter";
+  drawGlow(ctx, C.amber, w - pad - ctx.measureText(scoreText).width / 2, pad, size * 1.5, 0.1);
+  ctx.globalCompositeOperation = "source-over";
+  ctx.fillStyle = C.amber;
+  ctx.fillText(scoreText, w - pad, pad);
+
+  // Wave, small and quiet beneath the score.
+  ctx.font = font(size * 0.42);
+  ctx.fillStyle = rgba(C.cyan, 0.55);
+  ctx.fillText(`WAVE ${world.wave}`, w - pad, pad + size * 0.85);
+
+  // Combo, beside the ship, only once it means something.
+  if (world.combo >= 2) {
+    const p = project(world.cam, world.ship.x, SHIP_Y + 30, 0);
+    const grow = 1 + Math.min(0.7, world.combo * 0.04);
+    const cs = Math.max(16, Math.min(w, h) * 0.036) * grow;
+    ctx.font = font(cs);
+    ctx.textAlign = "center";
+    ctx.fillStyle = rgba(C.cyan, 0.5 + Math.min(0.45, world.combo * 0.03));
+    ctx.fillText(`×${world.combo}`, p.x, p.y);
+  }
+
+  drawFocusBar(world);
+  drawBanner(world);
+  if (world.showStats) drawStats(world);
+  ctx.textAlign = "left";
+}
+
+function drawFocusBar(world: World): void {
+  const { ctx, w, h } = world;
+  const full = world.focus >= 1;
+  const barH = full ? 5 : 3;
+  const y = h - barH - 2;
+  const half = (w * 0.5 - 12) * clamp(world.focus, 0, 1);
+  ctx.fillStyle = rgba(full ? C.white : C.ship, full ? 0.55 + Math.sin(world.time * 8) * 0.3 : 0.42);
+  ctx.fillRect(w / 2 - half, y, half * 2, barH);
+  if (world.focusT > 0) {
+    // Burning down: the bar drains from the middle out, in the focus colour.
+    const t = clamp(world.focusT / 2.6, 0, 1);
+    ctx.fillStyle = rgba(C.plankton, 0.7);
+    ctx.fillRect(w / 2 - (w * 0.5 - 12) * t, y, (w - 24) * t, barH);
+  }
+}
+
+function drawBanner(world: World): void {
+  if (world.bannerT <= 0 || !world.banner) return;
+  const { ctx, w, h } = world;
+  const t = clamp(world.bannerT / 1.5, 0, 1);
+  const pop = ease.outCubic(clamp((1.5 - world.bannerT) / 0.3, 0, 1));
+  const size = Math.min(w * 0.1, h * 0.062) * (0.7 + pop * 0.3);
+  // Low in the frame: the top third is where the problem and the husks live,
+  // and a banner across them would hide the only thing that matters.
+  const y = h * 0.66;
+  ctx.globalAlpha = Math.min(1, t * 2) * 0.9;
+  ctx.globalCompositeOperation = "lighter";
+  drawGlow(ctx, C.cyan, w / 2, y, size * 3.4, 0.12);
+  ctx.globalCompositeOperation = "source-over";
+  ctx.font = font(size);
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillStyle = C.white;
+  ctx.fillText(world.banner, w / 2, y);
+  if (world.bannerSub) {
+    ctx.font = font(size * 0.4);
+    ctx.fillStyle = rgba(C.cyan, 0.75);
+    ctx.fillText(world.bannerSub, w / 2, y + size * 0.85);
+  }
+  ctx.globalAlpha = 1;
+}
+
+export function drawTitle(world: World): void {
+  const { ctx, w, h } = world;
+  const t = clamp(world.phaseT / 0.9, 0, 1);
+  const size = Math.min(w * 0.22, h * 0.16);
+  const y = h * 0.4;
+  ctx.globalAlpha = ease.outCubic(t);
+  ctx.globalCompositeOperation = "lighter";
+  drawGlow(ctx, C.amber, w / 2, y, size * 1.9, 0.09);
+  ctx.globalCompositeOperation = "source-over";
+  drawGlyph(ctx, getGlyph("GUILTY", C.amber, 900), w / 2, y, size * ease.outBack(clamp(t, 0, 1)));
+
+  ctx.font = font(Math.max(13, size * 0.13));
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillStyle = rgba(C.cyan, 0.5 + Math.sin(world.time * 3) * 0.28);
+  ctx.fillText(world.touch ? "TAP TO BEGIN" : "PRESS ANY KEY", w / 2, y + size * 0.72);
+  if (world.best > 0) {
+    ctx.fillStyle = rgba(C.amber, 0.45);
+    ctx.font = font(Math.max(11, size * 0.1));
+    ctx.fillText(`BEST ${world.best}`, w / 2, y + size * 0.95);
+  }
+  ctx.globalAlpha = 1;
+}
+
+export function drawGameOver(world: World): void {
+  const { ctx, w, h } = world;
+  const t = clamp(world.phaseT / 0.8, 0, 1);
+  ctx.fillStyle = rgba("#02060c", 0.55 * t);
+  ctx.fillRect(0, 0, w, h);
+  const size = Math.min(w * 0.16, h * 0.1);
+  const y = h * 0.38;
+  ctx.globalCompositeOperation = "lighter";
+  drawGlow(ctx, C.hostile, w / 2, y, size * 2.4, 0.12 * t);
+  ctx.globalCompositeOperation = "source-over";
+  ctx.font = font(size * 0.62);
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.globalAlpha = t;
+  ctx.fillStyle = rgba(C.hostile, 0.9);
+  ctx.fillText("THE TRENCH TAKES YOU", w / 2, y);
+
+  ctx.font = font(size * 1.1);
+  ctx.fillStyle = C.amber;
+  ctx.fillText(String(world.score), w / 2, y + size * 1.05);
+  ctx.font = font(size * 0.3);
+  ctx.fillStyle = rgba(C.cyan, 0.6);
+  ctx.fillText(
+    `BEST ${world.best}   ·   WAVE ${world.wave}   ·   BEST RUN ×${world.bestCombo}`,
+    w / 2,
+    y + size * 1.75,
+  );
+  ctx.fillStyle = rgba(C.white, 0.35 + Math.sin(world.time * 3) * 0.25);
+  ctx.font = font(size * 0.32);
+  ctx.fillText(world.touch ? "TAP TO DIVE AGAIN" : "PRESS ANY KEY", w / 2, y + size * 2.5);
+  ctx.globalAlpha = 1;
+}
+
+/** Second wind: the run is over unless one more answer lands. */
+export function drawSecondWind(world: World): void {
+  const { ctx, w, h } = world;
+  const t = clamp(world.phaseT / 0.6, 0, 1);
+  ctx.fillStyle = rgba("#01040a", 0.42 * t);
+  ctx.fillRect(0, 0, w, h);
+  const size = Math.min(w * 0.1, h * 0.06);
+  ctx.font = font(size * 0.5);
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillStyle = rgba(C.hostile, 0.6 + Math.sin(world.time * 4) * 0.3);
+  // Above the ship, under the action: the husks stay readable.
+  ctx.fillText("ONE MORE", w / 2, h * 0.8);
+}
+
+function drawStats(world: World): void {
+  const { ctx, h } = world;
+  const s = frameStats(world);
+  ctx.font = font(12);
+  ctx.textAlign = "left";
+  ctx.textBaseline = "bottom";
+  ctx.fillStyle = "rgba(140,255,220,0.75)";
+  ctx.fillText(
+    `${s.fps.toFixed(1)} fps · present ${s.present.toFixed(2)}ms (p95 ${s.p95.toFixed(1)}) · cost ${s.cost.toFixed(2)}ms · p${s.particles} · q${world.quality.toFixed(2)}`,
+    10,
+    h - 10,
+  );
+}
+
+/**
+ * `present` is wall-clock between presented frames — what a player feels, and
+ * meaningless in a backgrounded tab. `cost` is the time this game spends in
+ * update+render, which is the number the frame budget is actually about.
+ */
+export function frameStats(world: World): {
+  fps: number;
+  present: number;
+  p95: number;
+  cost: number;
+  particles: number;
+} {
+  const samples = [...world.fpsSamples].sort((a, b) => a - b);
+  let sum = 0;
+  for (const v of samples) sum += v;
+  const present = samples.length ? sum / samples.length : 0;
+  const p95 = samples.length ? (samples[Math.floor(samples.length * 0.95)] as number) : 0;
+  let live = 0;
+  for (const p of world.particles) if (p.active) live++;
+  return {
+    fps: present ? 1000 / present : 0,
+    present,
+    p95,
+    cost: world.frameMs,
+    particles: live,
+  };
+}

--- a/dynawalla/games/guilty/src/game/husk.ts
+++ b/dynawalla/games/guilty/src/game/husk.ts
@@ -1,0 +1,274 @@
+/**
+ * The husks: rotating octahedral cells with a numeral burning inside.
+ *
+ * Every candidate looks *identical* — same colour, same size, same motion.
+ * There is no tell but the arithmetic. The only husk that ever looks different
+ * is one the player already shot by mistake, and that one changes silhouette
+ * (it grows spikes), motion (it dives) and colour together, so the mark is
+ * never colour alone.
+ */
+
+import { project } from "../core/camera.ts";
+import { GATE_Y, HUSK_R } from "../core/config.ts";
+import { C, rgba } from "../core/palette.ts";
+import { drawGlow, drawGlyph, getGlyph } from "../render/bake.ts";
+import { clamp, ease } from "../render/draw.ts";
+import { Mode, type Husk, type World } from "./world.ts";
+
+const VERTS: ReadonlyArray<readonly [number, number, number]> = [
+  [1, 0, 0],
+  [0, 0, 1],
+  [-1, 0, 0],
+  [0, 0, -1],
+  [0, 1.18, 0],
+  [0, -1.18, 0],
+];
+
+const EDGES: ReadonlyArray<readonly [number, number]> = [
+  [0, 1],
+  [1, 2],
+  [2, 3],
+  [3, 0],
+  [4, 0],
+  [4, 1],
+  [4, 2],
+  [4, 3],
+  [5, 0],
+  [5, 1],
+  [5, 2],
+  [5, 3],
+];
+
+const sx = new Float32Array(6);
+const sy = new Float32Array(6);
+const ss = new Float32Array(6);
+
+export function resetHusk(h: Husk): void {
+  h.active = true;
+  h.hostile = false;
+  h.hp = 1;
+  h.hitFlash = 0;
+  h.squash = 0;
+  h.age = 0;
+  h.dieT = 0;
+  h.shroud = 0;
+  h.fireCd = 2.5;
+  h.vx = 0;
+  h.vy = 0;
+  h.vz = 0;
+  h.z = 0;
+  h.radius = HUSK_R;
+  h.mode = Mode.Entering;
+}
+
+export function updateHusk(world: World, h: Husk, dt: number): void {
+  h.age += dt;
+  h.spin += h.spinV * dt;
+  h.tilt += h.tiltV * dt;
+  h.hitFlash = Math.max(0, h.hitFlash - dt * 5.5);
+  h.squash += (0 - h.squash) * Math.min(1, dt * 11);
+  h.wob += dt;
+
+  switch (h.mode) {
+    case Mode.Entering: {
+      // A spring out of the equation into formation. Slightly underdamped, so
+      // the husks arrive with a flick rather than sliding to a stop.
+      const targetX = h.lane + world.swingPhaseX;
+      const targetY = world.formationY + h.row;
+      h.vx += (targetX - h.x) * 46 * dt;
+      h.vy += (targetY - h.y) * 46 * dt;
+      h.vz += (0 - h.z) * 30 * dt;
+      const d = Math.exp(-7.5 * dt);
+      h.vx *= d;
+      h.vy *= d;
+      h.vz *= d;
+      h.x += h.vx * dt;
+      h.y += h.vy * dt;
+      h.z += h.vz * dt;
+      if (h.age > 0.62) {
+        h.mode = Mode.Formation;
+        h.z = 0;
+      }
+      break;
+    }
+    case Mode.Formation: {
+      h.x = h.lane + world.swingPhaseX + Math.sin(h.wob * 1.7 + h.lane) * 1.7;
+      h.y = world.formationY + h.row + Math.sin(h.wob * 2.3 + h.row) * 0.9;
+      h.z = Math.sin(h.wob * 0.9 + h.lane * 0.1) * 5;
+      if (h.shroud > 0) {
+        // The shell cracks open as it descends — the closer it gets, the more
+        // the player can read, which is the pressure.
+        const openAt = GATE_Y + 96;
+        if (h.y < openAt) h.shroud = Math.max(0, h.shroud - dt * 1.6);
+      }
+      break;
+    }
+    case Mode.Drift: {
+      h.y -= 11 * dt;
+      h.x = h.lane + Math.sin(h.wob * 0.8) * 4;
+      h.z = Math.sin(h.wob * 0.5) * 18;
+      break;
+    }
+    case Mode.Orbit: {
+      h.orbit += dt * 0.85;
+      h.x = world.boss.x + Math.cos(h.orbit) * h.orbitR;
+      h.y = world.boss.y + Math.sin(h.orbit) * h.orbitR * 0.44;
+      h.z = Math.sin(h.orbit) * 26;
+      break;
+    }
+    case Mode.Hostile: {
+      // It wants the ship. It accelerates, it is bad at turning, and it is loud.
+      const toShip = world.ship.x - h.x;
+      h.vx += clamp(toShip, -60, 60) * 1.9 * dt;
+      h.vx *= Math.exp(-1.1 * dt);
+      h.vy -= (46 + world.wave * 1.4) * dt;
+      h.vy = Math.max(h.vy, -(72 + world.wave * 2.6));
+      h.x += h.vx * dt;
+      h.y += h.vy * dt;
+      h.z += (0 - h.z) * Math.min(1, dt * 4);
+      h.spin += dt * 5;
+      if (world.wave >= 7) {
+        h.fireCd -= dt;
+        if (h.fireCd <= 0 && h.y > GATE_Y + 24) {
+          h.fireCd = 1.5 + world.rng.range(0, 1.2);
+          world.fireBolt(h.x, h.y - h.radius);
+        }
+      }
+      break;
+    }
+    case Mode.Dying: {
+      h.dieT += dt;
+      h.x += h.vx * dt;
+      h.y += h.vy * dt;
+      h.vy -= 22 * dt;
+      h.spin += dt * 9;
+      if (h.dieT > 0.32) h.active = false;
+      break;
+    }
+  }
+}
+
+/** Fake-3D wireframe + membrane + billboarded numeral. */
+export function drawHusk(world: World, h: Husk): void {
+  const { cam, batch, ctx } = world;
+  const dying = h.mode === Mode.Dying;
+  // `dieT` starts negative for the innocents caught in a shockwave — they hold
+  // full size until the wave reaches them. Clamping is what keeps that from
+  // inflating them instead.
+  const collapse = dying ? ease.outCubic(clamp(h.dieT / 0.32, 0, 1)) : 0;
+  const born = h.mode === Mode.Entering ? ease.outBack(clamp(h.age / 0.45, 0, 1)) : 1;
+  const r = h.radius * born * (1 - collapse * 0.85) * (1 + h.squash * 0.55);
+  const ry = r * (1 - h.squash * 0.75);
+  if (r <= 0.2) return;
+
+  const cos = Math.cos(h.spin);
+  const sin = Math.sin(h.spin);
+  const cosT = Math.cos(h.tilt);
+  const sinT = Math.sin(h.tilt);
+
+  for (let i = 0; i < 6; i++) {
+    const v = VERTS[i];
+    let vx = v[0] * r;
+    const vyRaw = v[1] * ry;
+    let vz = v[2] * r;
+    // Rotate about Y, then about X.
+    const rx = vx * cos - vz * sin;
+    const rz = vx * sin + vz * cos;
+    const vy = vyRaw * cosT - rz * sinT;
+    vz = vyRaw * sinT + rz * cosT;
+    vx = rx;
+    const p = project(cam, h.x + vx, h.y + vy, h.z + vz);
+    sx[i] = p.x;
+    sy[i] = p.y;
+    ss[i] = p.s;
+  }
+
+  const centre = project(cam, h.x, h.y, h.z);
+  const cxp = centre.x;
+  const cyp = centre.y;
+  const scale = centre.s;
+
+  const hostile = h.hostile;
+  const edge = hostile ? C.hostile : C.cyan;
+  const flash = h.hitFlash;
+  const alpha = (1 - collapse) * (h.mode === Mode.Entering ? clamp(h.age / 0.18, 0, 1) : 1);
+
+  // Membrane — a dark skin over the equator quad. It is not decoration: it
+  // gives the numeral an opaque backing so a bright bloom behind the husk can
+  // never wash the digit out.
+  if (!dying) {
+    ctx.beginPath();
+    ctx.moveTo(sx[0], sy[0]);
+    ctx.lineTo(sx[1], sy[1]);
+    ctx.lineTo(sx[2], sy[2]);
+    ctx.lineTo(sx[3], sy[3]);
+    ctx.closePath();
+    ctx.fillStyle = `rgba(3,10,17,${0.72 * alpha})`;
+    ctx.fill();
+    if (world.quality > 0.7) {
+      ctx.fillStyle = rgba(hostile ? C.hostileDeep : C.cyanDeep, (0.34 + flash * 0.4) * alpha);
+      ctx.fill();
+    }
+  }
+
+  const width = Math.max(0.9, 1.5 * scale * (1 + flash * 1.6));
+  for (const e of EDGES) {
+    batch.push(
+      sx[e[0]],
+      sy[e[0]],
+      sx[e[1]],
+      sy[e[1]],
+      flash > 0.35 ? C.white : edge,
+      width,
+      alpha * (0.72 + flash * 0.28),
+    );
+  }
+
+  if (hostile) {
+    // Spikes: the silhouette changes, not just the colour.
+    for (let i = 0; i < 4; i++) {
+      const jitter = 1.55 + Math.sin(world.time * 22 + i) * 0.12;
+      const px = cxp + (sx[i] - cxp) * jitter;
+      const py = cyp + (sy[i] - cyp) * jitter;
+      batch.push(sx[i], sy[i], px, py, C.hostile, width * 1.1, alpha);
+    }
+  }
+
+  ctx.globalCompositeOperation = "lighter";
+  drawGlow(ctx, hostile ? C.hostile : C.cyan, cxp, cyp, r * scale * 2.2, (0.1 + flash * 0.45) * alpha);
+  if (flash > 0.02) drawGlow(ctx, C.white, cxp, cyp, r * scale * 1.9 * flash, flash * 0.45);
+  ctx.globalCompositeOperation = "source-over";
+
+  if (!dying) {
+    const shut = h.shroud > 0;
+    if (shut) {
+      // A shut shell: a second skin inside the cell, and the numeral behind it
+      // churning through digits. It is unreadable on purpose and it *looks*
+      // unreadable — a dim digit alone would just look like a dim digit.
+      for (let i = 0; i < 4; i++) {
+        const j = (i + 1) % 4;
+        const mx = cxp + (sx[i] - cxp) * 0.62;
+        const my = cyp + (sy[i] - cyp) * 0.62;
+        const nx = cxp + (sx[j] - cxp) * 0.62;
+        const ny = cyp + (sy[j] - cyp) * 0.62;
+        batch.push(mx, my, nx, ny, C.cyan, width * 0.8, alpha * 0.65);
+      }
+    }
+    const label = shut ? scrambled(world, h) : h.label;
+    const glyph = getGlyph(label, hostile ? C.hostile : C.cyan, 800);
+    // Fit a three-digit answer inside the cell instead of letting it spill:
+    // the drawn ink width is `inkW * size / 92`, so cap `size` by the cell.
+    const maxInk = r * scale * (shut ? 1 : 1.55);
+    const size = Math.min(r * scale * (shut ? 0.9 : 1.5), (maxInk * 92) / glyph.inkW);
+    drawGlyph(ctx, glyph, cxp, cyp, size, alpha * (shut ? 0.32 : 1));
+  }
+}
+
+const DIGITS = "0123456789";
+function scrambled(world: World, h: Husk): string {
+  const n = Math.max(1, h.label.length);
+  const tick = Math.floor(world.time * 14 + h.lane);
+  let out = "";
+  for (let i = 0; i < n; i++) out += DIGITS[(tick * 7 + i * 3) % 10];
+  return out;
+}

--- a/dynawalla/games/guilty/src/game/input.ts
+++ b/dynawalla/games/guilty/src/game/input.ts
@@ -1,0 +1,150 @@
+/**
+ * Two first-class control schemes, neither a port of the other.
+ *
+ * TOUCH — drag anywhere. The ship keeps its offset from the finger, so a child
+ * can steer from the bottom corner without their hand covering the thing they
+ * are aiming at, and the first touch never teleports the ship. A quick tap
+ * (short, still) spends Deep Focus.
+ *
+ * DESKTOP — the ship tracks the mouse's x directly, with no button held: the
+ * pointer *is* the ship. Arrow keys and A/D work at full speed for players who
+ * want them, space spends Deep Focus. Both schemes are live at once and either
+ * can take over mid-run.
+ */
+
+import { screenToWorldX } from "../core/camera.ts";
+import type { World } from "./world.ts";
+
+export type Input = {
+  /** -1..1 from the keyboard, 0 when nothing is held. */
+  axis(): number;
+  detach(): void;
+};
+
+export type InputHandlers = {
+  onStart(): void;
+  onFocus(): void;
+  onToggleMute(): void;
+  onTogglePause(): void;
+  onToggleStats(): void;
+};
+
+export function attachInput(canvas: HTMLCanvasElement, world: World, on: InputHandlers): Input {
+  let left = false;
+  let right = false;
+  let dragging = false;
+  let pointerId = -1;
+  let dragOffset = 0;
+  let downAt = 0;
+  let downX = 0;
+  let moved = 0;
+
+  const rectX = (): number => canvas.getBoundingClientRect().left;
+
+  const pointerDown = (e: PointerEvent): void => {
+    canvas.setPointerCapture?.(e.pointerId);
+    pointerId = e.pointerId;
+    dragging = true;
+    downAt = performance.now();
+    downX = e.clientX;
+    moved = 0;
+    if (e.pointerType === "touch") {
+      world.touch = true;
+      dragOffset = world.ship.x - screenToWorldX(world.cam, e.clientX - rectX());
+    } else {
+      dragOffset = 0;
+      world.ship.targetX = screenToWorldX(world.cam, e.clientX - rectX());
+    }
+    on.onStart();
+    e.preventDefault();
+  };
+
+  const pointerMove = (e: PointerEvent): void => {
+    if (e.pointerType === "mouse" && !dragging) {
+      world.ship.targetX = screenToWorldX(world.cam, e.clientX - rectX());
+      return;
+    }
+    if (!dragging || e.pointerId !== pointerId) return;
+    moved = Math.max(moved, Math.abs(e.clientX - downX));
+    world.ship.targetX = screenToWorldX(world.cam, e.clientX - rectX()) + dragOffset;
+    e.preventDefault();
+  };
+
+  const pointerUp = (e: PointerEvent): void => {
+    if (e.pointerId !== pointerId) return;
+    dragging = false;
+    pointerId = -1;
+    if (performance.now() - downAt < 230 && moved < 14) on.onFocus();
+  };
+
+  const keyDown = (e: KeyboardEvent): void => {
+    if (e.repeat) return;
+    switch (e.key) {
+      case "ArrowLeft":
+      case "a":
+      case "A":
+        left = true;
+        break;
+      case "ArrowRight":
+      case "d":
+      case "D":
+        right = true;
+        break;
+      case " ":
+      case "Spacebar":
+        on.onFocus();
+        e.preventDefault();
+        break;
+      case "m":
+      case "M":
+        on.onToggleMute();
+        break;
+      case "p":
+      case "P":
+        on.onTogglePause();
+        break;
+      case "`":
+        on.onToggleStats();
+        break;
+    }
+    on.onStart();
+  };
+
+  const keyUp = (e: KeyboardEvent): void => {
+    if (e.key === "ArrowLeft" || e.key === "a" || e.key === "A") left = false;
+    if (e.key === "ArrowRight" || e.key === "d" || e.key === "D") right = false;
+  };
+
+  const blur = (): void => {
+    left = false;
+    right = false;
+    dragging = false;
+  };
+
+  canvas.addEventListener("pointerdown", pointerDown);
+  canvas.addEventListener("pointermove", pointerMove);
+  window.addEventListener("pointerup", pointerUp);
+  window.addEventListener("pointercancel", pointerUp);
+  window.addEventListener("keydown", keyDown);
+  window.addEventListener("keyup", keyUp);
+  window.addEventListener("blur", blur);
+  canvas.addEventListener("contextmenu", preventDefault);
+
+  return {
+    axis: () => (left ? -1 : 0) + (right ? 1 : 0),
+    detach() {
+      canvas.removeEventListener("pointerdown", pointerDown);
+      canvas.removeEventListener("pointermove", pointerMove);
+      window.removeEventListener("pointerup", pointerUp);
+      window.removeEventListener("pointercancel", pointerUp);
+      window.removeEventListener("keydown", keyDown);
+      window.removeEventListener("keyup", keyUp);
+      window.removeEventListener("blur", blur);
+      canvas.removeEventListener("contextmenu", preventDefault);
+    },
+  };
+}
+
+function preventDefault(e: Event): void {
+  e.preventDefault();
+}

--- a/dynawalla/games/guilty/src/game/scene.ts
+++ b/dynawalla/games/guilty/src/game/scene.ts
@@ -1,0 +1,177 @@
+/**
+ * The trench itself: water, light from a surface too far away to see, drifting
+ * plankton, a seabed grid receding into the dark, and the gate line the husks
+ * must never cross.
+ *
+ * All of it is projected through the same camera as the gameplay, so the world
+ * shakes as one thing. The gradient and the light shafts are baked at resize;
+ * per frame the background costs two blits, one grid of batched lines and a few
+ * hundred one-pixel plankton streaks.
+ */
+
+import { project, type Camera } from "../core/camera.ts";
+import { GATE_Y, VIEW_HALF_H } from "../core/config.ts";
+import { C, rgba } from "../core/palette.ts";
+import { drawGlow } from "../render/bake.ts";
+import type { World } from "./world.ts";
+
+const FLOOR_Y = -178;
+const FLOOR_NEAR = -34;
+const FLOOR_FAR = -268;
+
+let gradient: HTMLCanvasElement | null = null;
+let shaft: HTMLCanvasElement | null = null;
+
+export function bakeScene(w: number, h: number): void {
+  const g = document.createElement("canvas");
+  g.width = Math.max(1, Math.ceil(w));
+  g.height = Math.max(1, Math.ceil(h));
+  const gc = g.getContext("2d") as CanvasRenderingContext2D;
+  const grad = gc.createLinearGradient(0, 0, 0, h);
+  grad.addColorStop(0, "#02060d");
+  grad.addColorStop(0.2, "#02070e");
+  grad.addColorStop(0.6, "#030c15");
+  grad.addColorStop(0.88, "#05161f");
+  grad.addColorStop(1, "#020a11");
+  gc.fillStyle = grad;
+  gc.fillRect(0, 0, w, h);
+  // A cold sheen from the surface, far above and to one side.
+  const sheen = gc.createRadialGradient(w * 0.32, -h * 0.4, 0, w * 0.32, -h * 0.4, h * 0.95);
+  sheen.addColorStop(0, rgba(C.surface, 0.17));
+  sheen.addColorStop(1, rgba(C.surface, 0));
+  gc.fillStyle = sheen;
+  gc.fillRect(0, 0, w, h);
+  gradient = g;
+
+  const s = document.createElement("canvas");
+  s.width = 128;
+  s.height = 512;
+  const sc = s.getContext("2d") as CanvasRenderingContext2D;
+  const sg = sc.createLinearGradient(0, 0, 0, 512);
+  sg.addColorStop(0, rgba(C.plankton, 0.1));
+  sg.addColorStop(0.5, rgba(C.plankton, 0.032));
+  sg.addColorStop(1, rgba(C.plankton, 0));
+  sc.fillStyle = sg;
+  sc.beginPath();
+  sc.moveTo(46, 0);
+  sc.lineTo(82, 0);
+  sc.lineTo(126, 512);
+  sc.lineTo(2, 512);
+  sc.closePath();
+  sc.fill();
+  shaft = s;
+}
+
+export function seedMotes(world: World, count: number): void {
+  const data = new Float32Array(count * 4);
+  for (let i = 0; i < count; i++) {
+    data[i * 4] = world.rng.range(-260, 260);
+    data[i * 4 + 1] = world.rng.range(-190, 190);
+    data[i * 4 + 2] = world.rng.range(-250, -12);
+    data[i * 4 + 3] = world.rng.range(0, Math.PI * 2);
+  }
+  world.motes = data;
+  world.moteCount = count;
+}
+
+export function drawBackground(world: World): void {
+  const { ctx, w, h, time } = world;
+  if (gradient) ctx.drawImage(gradient, 0, 0, w, h);
+
+  ctx.globalCompositeOperation = "lighter";
+  if (shaft && world.quality > 0.55) {
+    const n = 3;
+    for (let i = 0; i < n; i++) {
+      const drift = Math.sin(time * 0.11 + i * 2.1) * w * 0.07;
+      const x = w * (0.2 + i * 0.3) + drift;
+      const scale = 0.8 + Math.sin(time * 0.17 + i) * 0.18;
+      ctx.globalAlpha = 0.42 + Math.sin(time * 0.23 + i * 1.7) * 0.16;
+      ctx.drawImage(shaft, x - w * 0.14 * scale, -h * 0.06, w * 0.28 * scale, h * 1.06);
+    }
+    ctx.globalAlpha = 1;
+  }
+
+  drawMotes(world);
+  ctx.globalCompositeOperation = "source-over";
+}
+
+function drawMotes(world: World): void {
+  const { motes, moteCount, cam, batch, time } = world;
+  for (let i = 0; i < moteCount; i++) {
+    const bx = motes[i * 4];
+    const by = motes[i * 4 + 1];
+    const bz = motes[i * 4 + 2];
+    const phase = motes[i * 4 + 3];
+    const y = ((by + time * (5 + (i % 7)) + 190) % 380) - 190;
+    const x = bx + Math.sin(time * 0.4 + phase) * 6;
+    const p = project(cam, x, y, bz);
+    if (!p.ok) continue;
+    const depth = 1 - Math.min(1, -bz / 260);
+    const alpha = 0.05 + depth * 0.22;
+    batch.push(p.x, p.y - 0.6 - depth, p.x, p.y + 0.6 + depth, C.plankton, 0.6 + depth * 1.2, alpha);
+  }
+  batch.flush(world.ctx);
+}
+
+/** Seabed grid + the gate. Drawn under everything alive. */
+export function drawFloor(world: World): void {
+  const { cam, batch, ctx, time } = world;
+  const halfW = Math.min(280, cam.worldHalfW * 1.6);
+  const rows = 9;
+  for (let i = 0; i <= rows; i++) {
+    const t = i / rows;
+    const z = FLOOR_NEAR + (FLOOR_FAR - FLOOR_NEAR) * t * t;
+    const a = project(cam, -halfW, FLOOR_Y, z);
+    const ax = a.x;
+    const ay = a.y;
+    const b = project(cam, halfW, FLOOR_Y, z);
+    batch.push(ax, ay, b.x, b.y, C.cyanDim, 1.1, 0.34 - t * 0.24);
+  }
+  const cols = 13;
+  for (let i = 0; i <= cols; i++) {
+    const x = -halfW + (halfW * 2 * i) / cols;
+    const a = project(cam, x, FLOOR_Y, FLOOR_NEAR);
+    const ax = a.x;
+    const ay = a.y;
+    const b = project(cam, x, FLOOR_Y, FLOOR_FAR);
+    batch.push(ax, ay, b.x, b.y, C.cyanDim, 1, 0.2);
+  }
+
+  // The gate: cross it and a life is gone. It breathes, and it flares when
+  // something is close — the pulse is the warning, not a word.
+  const danger = world.gateDanger;
+  const pulse = 0.42 + Math.sin(time * 2.1) * 0.08 + danger * 0.5;
+  const gw = cam.playHalfW + 14;
+  const a = project(cam, -gw, GATE_Y, 0);
+  const ax = a.x;
+  const ay = a.y;
+  const b = project(cam, gw, GATE_Y, 0);
+  const bx = b.x;
+  const by = b.y;
+  const color = danger > 0.35 ? C.hostile : C.cyan;
+  batch.push(ax, ay, bx, by, color, 1.6 + danger * 2.4, pulse);
+  for (let i = -6; i <= 6; i++) {
+    const x = (gw * i) / 6;
+    const t0 = project(cam, x, GATE_Y, 0);
+    const tx = t0.x;
+    const ty = t0.y;
+    const t1 = project(cam, x, GATE_Y - 4.5, 0);
+    batch.push(tx, ty, t1.x, t1.y, color, 1.2, pulse * 0.7);
+  }
+  batch.flush(ctx);
+
+  ctx.globalCompositeOperation = "lighter";
+  const mid = project(cam, 0, GATE_Y, 0);
+  drawGlow(ctx, color, mid.x, mid.y, (bx - ax) * 0.55, 0.1 + danger * 0.34);
+  ctx.globalCompositeOperation = "source-over";
+}
+
+/** Screen-space vignette, drawn last. */
+export function drawVignette(world: World, vignette: HTMLCanvasElement | null): void {
+  if (!vignette) return;
+  world.ctx.drawImage(vignette, 0, 0, world.w, world.h);
+}
+
+export function worldTop(cam: Camera): number {
+  return cam.y + VIEW_HALF_H;
+}

--- a/dynawalla/games/guilty/src/game/ship.ts
+++ b/dynawalla/games/guilty/src/game/ship.ts
@@ -1,0 +1,301 @@
+/**
+ * The ship, its gun, and the sight line.
+ *
+ * The sight line is the single most important piece of interface in the game
+ * and it is not text: a thin beam runs from the nose to whatever the next shot
+ * will hit, and brackets close around that husk. The gun fires on its own, so
+ * the player's whole job is *where to stand* — and the beam means they always
+ * know, exactly, which number they are about to destroy. Shooting an innocent
+ * is then a decision, never an accident, which is what earns the punishment.
+ */
+
+import { project } from "../core/camera.ts";
+import {
+  BULLET_R,
+  BULLET_SPEED,
+  FIRE_INTERVAL,
+  FIRE_SPEED_GATE,
+  SHIP_HALF_W,
+  SHIP_MAX_SPEED,
+  SHIP_Y,
+  VIEW_HALF_H,
+} from "../core/config.ts";
+import { C } from "../core/palette.ts";
+import { drawGlow } from "../render/bake.ts";
+import { clamp, damp, ease } from "../render/draw.ts";
+import { sparks } from "./fx.ts";
+import { Mode, type Husk, type World } from "./world.ts";
+
+const HULL: ReadonlyArray<readonly [number, number, number]> = [
+  [0, 13, 0],
+  [-9.5, -7, 0],
+  [0, -2.5, 0],
+  [9.5, -7, 0],
+  [0, -1, 8],
+];
+const HULL_EDGES: ReadonlyArray<readonly [number, number]> = [
+  [0, 1],
+  [1, 2],
+  [2, 3],
+  [3, 0],
+  [0, 4],
+  [4, 2],
+  [4, 1],
+  [4, 3],
+];
+
+const px = new Float32Array(5);
+const py = new Float32Array(5);
+
+export function updateShip(world: World, dt: number, realDt: number): void {
+  const ship = world.ship;
+  const limit = world.cam.playHalfW + 6;
+  ship.targetX = clamp(ship.targetX, -limit, limit);
+
+  // Position tracking is on *real* time: slow motion is a gift to the player,
+  // not a handicap on their own hands.
+  const dx = ship.targetX - ship.x;
+  const step = clamp(dx * 16, -SHIP_MAX_SPEED, SHIP_MAX_SPEED);
+  ship.vx = damp(ship.vx, step, 18, realDt);
+  ship.x = clamp(ship.x + ship.vx * realDt, -limit, limit);
+  ship.bank = damp(ship.bank, clamp(ship.vx / SHIP_MAX_SPEED, -1, 1), 9, realDt);
+  ship.recoil = damp(ship.recoil, 0, 16, realDt);
+  ship.muzzle = Math.max(0, ship.muzzle - realDt * 9);
+  ship.invuln = Math.max(0, ship.invuln - realDt);
+
+  if (!ship.alive) return;
+
+  // Settle gate. Cross the field freely; the gun wakes when you stop.
+  const moving = Math.abs(ship.vx) > FIRE_SPEED_GATE;
+  const was = ship.settled;
+  ship.settled = moving ? 0 : Math.min(1, ship.settled + realDt / 0.11);
+  if (was < 1 && ship.settled >= 1) world.audio.lock();
+  if (moving) {
+    ship.fireCd = Math.max(ship.fireCd, 0.05);
+  } else if (ship.settled >= 1) {
+    ship.fireCd -= realDt;
+    if (ship.fireCd <= 0) {
+      ship.fireCd += FIRE_INTERVAL;
+      fire(world);
+    }
+  }
+
+  // Thruster wake, on world time so it stretches beautifully in slow motion.
+  if (world.rng.nextFloat() < dt * 62) {
+    sparks(world, ship.x + world.rng.range(-4, 4), SHIP_Y - 8, 0, 1, 26, C.thrust, {
+      life: 0.3,
+      size: 1.1,
+      spread: 0.9,
+      dirX: 0,
+      dirY: -1,
+      drag: 5,
+    });
+  }
+}
+
+function fire(world: World): void {
+  const ship = world.ship;
+  for (const b of world.bullets) {
+    if (b.active) continue;
+    b.active = true;
+    b.enemy = false;
+    b.x = ship.x;
+    b.y = SHIP_Y + 13;
+    b.prevY = b.y;
+    b.z = 0;
+    b.vy = BULLET_SPEED;
+    b.vx = ship.vx * 0.06;
+    b.age = 0;
+    ship.recoil = 3.4;
+    ship.muzzle = 1;
+    world.audio.shoot(world.shotStep++);
+    sparks(world, ship.x, SHIP_Y + 14, 0, 3, 60, C.shipCore, { life: 0.16, size: 1.2, spread: 1.5, dirX: 0, dirY: 1 });
+    return;
+  }
+}
+
+export function fireBolt(world: World, x: number, y: number): void {
+  for (const b of world.bullets) {
+    if (b.active) continue;
+    b.active = true;
+    b.enemy = true;
+    b.x = x;
+    b.y = y;
+    b.prevY = y;
+    b.z = 0;
+    b.vy = -150;
+    b.vx = 0;
+    b.age = 0;
+    return;
+  }
+}
+
+export function stepBullets(world: World, dt: number): void {
+  const top = VIEW_HALF_H + 60;
+  for (const b of world.bullets) {
+    if (!b.active) continue;
+    b.prevY = b.y;
+    b.y += b.vy * dt;
+    b.x += b.vx * dt;
+    b.age += dt;
+    if (b.y > top || b.y < SHIP_Y - 30) b.active = false;
+  }
+}
+
+/** The husk the next shot will hit, or null. */
+export function findTarget(world: World): Husk | null {
+  let best: Husk | null = null;
+  for (const h of world.husks) {
+    if (!h.active || h.mode === Mode.Dying) continue;
+    if (h.y < SHIP_Y) continue;
+    if (Math.abs(h.x - world.ship.x) > h.radius + BULLET_R) continue;
+    if (!best || h.y < best.y) best = h;
+  }
+  return best;
+}
+
+export function drawSight(world: World, target: Husk | null): void {
+  const { cam, batch, ctx } = world;
+  const ship = world.ship;
+  const topY = target ? target.y : VIEW_HALF_H + 20;
+  const a = project(cam, ship.x, SHIP_Y + 14, 0);
+  const ax = a.x;
+  const ay = a.y;
+  const b = project(cam, ship.x, topY, 0);
+  const ready = ship.settled;
+  const locked = target !== null;
+  batch.push(
+    ax,
+    ay,
+    b.x,
+    b.y,
+    locked && ready >= 1 ? C.cyan : C.cyanDim,
+    locked ? 1 + ready * 0.6 : 1,
+    (locked ? 0.12 + ready * 0.2 : 0.06 + ready * 0.07),
+  );
+
+  if (!target) return;
+  // Brackets: four corners closing on the number that is about to die. They
+  // travel in as the gun settles, so "am I about to shoot" is a *shape*.
+  const r = target.radius * (2.3 - ready * 0.8);
+  const cxp = project(cam, target.x, target.y, 0);
+  const s = cxp.s;
+  const bx = cxp.x;
+  const by = cxp.y;
+  const k = r * s;
+  const arm = k * 0.42;
+  const pulse = (0.2 + ready * 0.45) + Math.sin(world.time * 9) * 0.12 * ready;
+  for (const [dx, dy] of [
+    [-1, -1],
+    [1, -1],
+    [-1, 1],
+    [1, 1],
+  ] as const) {
+    batch.push(bx + dx * k, by + dy * k, bx + dx * (k - arm), by + dy * k, C.cyan, 1.7, pulse);
+    batch.push(bx + dx * k, by + dy * k, bx + dx * k, by + dy * (k - arm), C.cyan, 1.7, pulse);
+  }
+  ctx.globalCompositeOperation = "lighter";
+  drawGlow(ctx, C.cyan, bx, by, k * 1.5, 0.07);
+  ctx.globalCompositeOperation = "source-over";
+}
+
+export function drawBullets(world: World): void {
+  const { cam, batch } = world;
+  for (const b of world.bullets) {
+    if (!b.active) continue;
+    const color = b.enemy ? C.hostile : C.cyan;
+    const tailY = b.enemy ? b.y + 5.5 : b.y - 8;
+    const head = project(cam, b.x, b.y, b.z);
+    const hx = head.x;
+    const hy = head.y;
+    const hs = head.s;
+    const tail = project(cam, b.x, tailY, b.z);
+    batch.push(tail.x, tail.y, hx, hy, color, 1.5 * hs, 0.4);
+    batch.push(tail.x, tail.y, hx, hy, C.white, 0.5 * hs, 0.9);
+    world.ctx.globalCompositeOperation = "lighter";
+    drawGlow(world.ctx, color, hx, hy, 5 * hs, 0.4);
+    world.ctx.globalCompositeOperation = "source-over";
+  }
+}
+
+export function drawShip(world: World): void {
+  const { cam, batch, ctx } = world;
+  const ship = world.ship;
+  if (!ship.alive) return;
+  const blink = ship.invuln > 0 && Math.floor(world.time * 14) % 2 === 0;
+  const alpha = blink ? 0.35 : 1;
+
+  const roll = ship.bank * 0.5;
+  const yaw = ship.bank * 0.55;
+  const cosY = Math.cos(yaw);
+  const sinY = Math.sin(yaw);
+  const cosR = Math.cos(roll);
+  const sinR = Math.sin(roll);
+  const baseY = SHIP_Y - ship.recoil;
+
+  for (let i = 0; i < HULL.length; i++) {
+    const v = HULL[i];
+    const x0 = v[0];
+    const y0 = v[1];
+    const z0 = v[2];
+    // Yaw about Y, then roll about Z.
+    const x1 = x0 * cosY - z0 * sinY;
+    const z1 = x0 * sinY + z0 * cosY;
+    const x2 = x1 * cosR - y0 * sinR;
+    const y2 = x1 * sinR + y0 * cosR;
+    const p = project(cam, ship.x + x2, baseY + y2, z1);
+    px[i] = p.x;
+    py[i] = p.y;
+  }
+
+  const centre = project(cam, ship.x, baseY + 2, 0);
+  const cxp = centre.x;
+  const cyp = centre.y;
+  const scale = centre.s;
+
+  ctx.beginPath();
+  ctx.moveTo(px[0], py[0]);
+  ctx.lineTo(px[1], py[1]);
+  ctx.lineTo(px[2], py[2]);
+  ctx.lineTo(px[3], py[3]);
+  ctx.closePath();
+  ctx.fillStyle = "rgba(20,14,48,0.82)";
+  ctx.globalAlpha = alpha;
+  ctx.fill();
+  ctx.globalAlpha = 1;
+
+  for (const e of HULL_EDGES) {
+    batch.push(px[e[0]], py[e[0]], px[e[1]], py[e[1]], C.ship, 1.9 * scale, alpha * 0.95);
+  }
+
+  ctx.globalCompositeOperation = "lighter";
+  const charged = world.focus >= 1 ? 1 : world.focus;
+  // The core is the gun's readiness: dark while you cross, blazing when settled.
+  const ready = ship.settled;
+  drawGlow(
+    ctx,
+    C.shipCore,
+    cxp,
+    cyp,
+    11 * scale * (0.55 + ready * 0.5 + charged * 0.6),
+    (0.1 + ready * 0.34 + charged * 0.3) * alpha,
+  );
+  if (ready >= 1) {
+    const nose = project(cam, ship.x, SHIP_Y + 13, 0);
+    drawGlow(ctx, C.cyan, nose.x, nose.y, 7 * scale, 0.35 * alpha);
+  }
+  if (ship.muzzle > 0) {
+    const m = ease.outCubic(ship.muzzle);
+    const nose = project(cam, ship.x, SHIP_Y + 15, 0);
+    drawGlow(ctx, C.white, nose.x, nose.y, 11 * scale * m, 0.5 * m * alpha);
+  }
+  // Thruster
+  const thrust = 0.6 + Math.sin(world.time * 33) * 0.16;
+  const back = project(cam, ship.x, baseY - 8, 0);
+  drawGlow(ctx, C.thrust, back.x, back.y, 9 * scale * thrust, 0.34 * alpha);
+  ctx.globalCompositeOperation = "source-over";
+}
+
+export function shipHalfWidth(): number {
+  return SHIP_HALF_W;
+}

--- a/dynawalla/games/guilty/src/game/waves.ts
+++ b/dynawalla/games/guilty/src/game/waves.ts
@@ -1,0 +1,57 @@
+/**
+ * The escalation curve.
+ *
+ * Tuned for a twenty-minute session, not a ninety-second demo: something new
+ * arrives every couple of waves for the first fifteen, and after that the
+ * numbers keep climbing towards a ceiling that a very good player can still
+ * survive. Nothing here is announced in words — a wider formation, a swing, a
+ * shell that hides the numeral until it is close. The player finds out by
+ * meeting it.
+ */
+
+import { BASE_DESCENT, BOSS_EVERY, DESCENT_PER_WAVE, MAX_DESCENT } from "../core/config.ts";
+
+export type WaveSpec = {
+  boss: boolean;
+  candidates: number;
+  descent: number;
+  swingAmp: number;
+  swingFreq: number;
+  /** Probability a given husk starts with its numeral hidden. */
+  shroud: number;
+  /** Hostiles created by a mistake start shooting back at this wave. */
+  bolts: boolean;
+};
+
+/**
+ * One wave is one problem, and a competent player answers in three or four
+ * seconds — so "wave 40" is about three minutes in, not an hour. The ramps
+ * below are stretched to match that: they keep introducing something new for
+ * the whole of a five-to-ten minute sitting, rather than emptying the toybox in
+ * ninety seconds and then just going faster.
+ */
+export function specFor(wave: number): WaveSpec {
+  const boss = wave % BOSS_EVERY === 0;
+  const candidates = Math.min(6, 3 + Math.floor((wave - 1) / 6));
+  const descent = Math.min(MAX_DESCENT, BASE_DESCENT + (wave - 1) * DESCENT_PER_WAVE);
+  const swingAmp = wave < 4 ? 0 : Math.min(32, (wave - 3) * 1.5);
+  const swingFreq = 0.36 + Math.min(0.5, wave * 0.008);
+  const shroud = wave < 12 ? 0 : Math.min(0.55, (wave - 11) * 0.045);
+  return {
+    boss,
+    candidates: boss ? Math.min(5, candidates) : candidates,
+    descent,
+    swingAmp,
+    swingFreq,
+    shroud,
+    bolts: wave >= 10,
+  };
+}
+
+/** The banner a wave earns, if any. Empty means no banner at all. */
+export function bannerFor(wave: number): [string, string] {
+  if (wave % BOSS_EVERY === 0) return ["THE ARBITER", "IT ONLY BREAKS TO THE TRUTH"];
+  if (wave === 12) return ["SHUT SHELLS", ""];
+  if (wave % 25 === 0) return [`WAVE ${wave}`, ""];
+  return ["", ""];
+}

--- a/dynawalla/games/guilty/src/game/world.ts
+++ b/dynawalla/games/guilty/src/game/world.ts
@@ -1,0 +1,321 @@
+/**
+ * The world: every pool, every counter, one object.
+ *
+ * Pools are allocated once at their configured ceiling and never grow. A husk,
+ * a bullet and a particle are plain mutable records with an `active` flag —
+ * there is no allocation and no garbage in a steady-state frame, which is the
+ * difference between a solid 60 and a stutter every few seconds on a mid-range
+ * tablet.
+ */
+
+import type { Host, Question } from "../contract.ts";
+import type { AudioEngine } from "../audio/audio.ts";
+import type { Camera } from "../core/camera.ts";
+import type { Juice } from "../core/juice.ts";
+import type { LineBatch } from "../render/draw.ts";
+import type { Rng } from "../math/rng.ts";
+import { MAX_BULLETS, MAX_HUSKS, MAX_PARTICLES } from "../core/config.ts";
+
+export const enum Mode {
+  Entering = 0,
+  Formation = 1,
+  Hostile = 2,
+  Dying = 3,
+  Orbit = 4,
+  /** Attract mode only: sinks on its own, hurts nobody. */
+  Drift = 5,
+}
+
+export type Husk = {
+  active: boolean;
+  x: number;
+  y: number;
+  z: number;
+  vx: number;
+  vy: number;
+  vz: number;
+  lane: number;
+  row: number;
+  label: string;
+  guilty: boolean;
+  hostile: boolean;
+  hp: number;
+  hitFlash: number;
+  spin: number;
+  spinV: number;
+  tilt: number;
+  tiltV: number;
+  squash: number;
+  age: number;
+  mode: Mode;
+  dieT: number;
+  /** 1 = the numeral is hidden inside a closed shell. */
+  shroud: number;
+  fireCd: number;
+  wob: number;
+  orbit: number;
+  orbitR: number;
+  radius: number;
+};
+
+export type Bullet = {
+  active: boolean;
+  x: number;
+  y: number;
+  z: number;
+  vy: number;
+  vx: number;
+  /** Enemy bolts travel down and hurt the ship. */
+  enemy: boolean;
+  age: number;
+  prevY: number;
+};
+
+export const enum PKind {
+  Spark = 0,
+  Shard = 1,
+  Ember = 2,
+}
+
+export type Particle = {
+  active: boolean;
+  kind: PKind;
+  x: number;
+  y: number;
+  z: number;
+  vx: number;
+  vy: number;
+  vz: number;
+  life: number;
+  max: number;
+  size: number;
+  color: string;
+  drag: number;
+  rot: number;
+  rotV: number;
+  gravity: number;
+};
+
+export type Ring = {
+  active: boolean;
+  x: number;
+  y: number;
+  z: number;
+  r: number;
+  rv: number;
+  life: number;
+  max: number;
+  color: string;
+  width: number;
+};
+
+export type Ship = {
+  x: number;
+  targetX: number;
+  vx: number;
+  fireCd: number;
+  recoil: number;
+  bank: number;
+  invuln: number;
+  alive: boolean;
+  muzzle: number;
+  /**
+   * The gun only fires from a standstill. That is the rule that makes a
+   * fixed-position shooter with auto-fire *fair*: crossing the field to reach
+   * the guilty number can never cost you an innocent, because you are not
+   * shooting while you cross. It also gives the loop its rhythm — dash, settle,
+   * fire — and it is taught entirely by the nose lighting up.
+   */
+  settled: number;
+};
+
+export const enum Phase {
+  Title = 0,
+  Wave = 1,
+  Clear = 2,
+  Breach = 3,
+  SecondWind = 4,
+  Over = 5,
+}
+
+export type Boss = {
+  active: boolean;
+  x: number;
+  y: number;
+  hp: number;
+  maxHp: number;
+  stage: number;
+  flash: number;
+  spin: number;
+  shield: number;
+  volleyCd: number;
+  dying: number;
+};
+
+export type World = {
+  host: Host;
+  audio: AudioEngine;
+  cam: Camera;
+  juice: Juice;
+  batch: LineBatch;
+  rng: Rng;
+  reduced: boolean;
+
+  ctx: CanvasRenderingContext2D;
+  w: number;
+  h: number;
+  dpr: number;
+
+  husks: Husk[];
+  bullets: Bullet[];
+  particles: Particle[];
+  rings: Ring[];
+  ship: Ship;
+  boss: Boss;
+
+  motes: Float32Array;
+  moteCount: number;
+
+  phase: Phase;
+  phaseT: number;
+  time: number;
+
+  wave: number;
+  lives: number;
+  score: number;
+  displayScore: number;
+  combo: number;
+  bestCombo: number;
+  best: number;
+  focus: number;
+  focusT: number;
+
+  question: Question | null;
+  askedAt: number;
+  firstWrong: string | null;
+  resolved: boolean;
+  perfectWave: boolean;
+  /** Formation descent, world units per second. */
+  descent: number;
+  swingAmp: number;
+  swingFreq: number;
+  swingPhase: number;
+  /** Current lateral offset of the whole formation. */
+  swingPhaseX: number;
+  formationY: number;
+  usedSecondWind: boolean;
+
+  /** Set by the game loop so entities can shoot without importing it. */
+  fireBolt: (x: number, y: number) => void;
+  /** Walks the pentatonic ladder so a thousand shots never sound the same. */
+  shotStep: number;
+
+  banner: string;
+  bannerSub: string;
+  bannerT: number;
+  /** 0..1 — how close the nearest husk is to the gate. Drives the gate flare. */
+  gateDanger: number;
+
+  /** Rolling render statistics, surfaced to the QA overlay. */
+  fpsSamples: number[];
+  frameMs: number;
+  quality: number;
+  showStats: boolean;
+  paused: boolean;
+  /** True once a touch pointer has been seen — only changes prompt wording. */
+  touch: boolean;
+};
+
+const husk = (): Husk => ({
+  active: false,
+  x: 0,
+  y: 0,
+  z: 0,
+  vx: 0,
+  vy: 0,
+  vz: 0,
+  lane: 0,
+  row: 0,
+  label: "",
+  guilty: false,
+  hostile: false,
+  hp: 1,
+  hitFlash: 0,
+  spin: 0,
+  spinV: 0,
+  tilt: 0,
+  tiltV: 0,
+  squash: 0,
+  age: 0,
+  mode: Mode.Entering,
+  dieT: 0,
+  shroud: 0,
+  fireCd: 0,
+  wob: 0,
+  orbit: 0,
+  orbitR: 0,
+  radius: 13.5,
+});
+
+const bullet = (): Bullet => ({
+  active: false,
+  x: 0,
+  y: 0,
+  z: 0,
+  vy: 0,
+  vx: 0,
+  enemy: false,
+  age: 0,
+  prevY: 0,
+});
+
+const particle = (): Particle => ({
+  active: false,
+  kind: PKind.Spark,
+  x: 0,
+  y: 0,
+  z: 0,
+  vx: 0,
+  vy: 0,
+  vz: 0,
+  life: 0,
+  max: 1,
+  size: 1,
+  color: "#fff",
+  drag: 1,
+  rot: 0,
+  rotV: 0,
+  gravity: 0,
+});
+
+const ring = (): Ring => ({
+  active: false,
+  x: 0,
+  y: 0,
+  z: 0,
+  r: 0,
+  rv: 0,
+  life: 0,
+  max: 1,
+  color: "#fff",
+  width: 2,
+});
+
+export function makePools(): Pick<World, "husks" | "bullets" | "particles" | "rings"> {
+  return {
+    husks: Array.from({ length: MAX_HUSKS }, husk),
+    bullets: Array.from({ length: MAX_BULLETS }, bullet),
+    particles: Array.from({ length: MAX_PARTICLES }, particle),
+    rings: Array.from({ length: 24 }, ring),
+  };
+}
+
+export function freeHusk(world: World): Husk | null {
+  for (const h of world.husks) if (!h.active) return h;
+  return null;
+}
+
+export function freeBullet(world: World): Bullet | null {
+  for (const b of world.bullets) if (!b.active) return b;
+  return null;
+}

--- a/dynawalla/games/guilty/src/main.ts
+++ b/dynawalla/games/guilty/src/main.ts
@@ -1,0 +1,39 @@
+/**
+ * Dev harness entry point. The shipped runtime will call `mount(el, host)`
+ * itself; this file only exists so `npm run dev` gives a real, playable game.
+ *
+ * Query parameters, all QA-only:
+ *   ?seed=N        deterministic presentation RNG
+ *   ?stats         frame-time overlay (also toggled with `)
+ *   ?bot=0.9       autoplay at the given accuracy, for screenshots and soak
+ *   ?wave=12       start at a wave, to reach escalation without playing there
+ *   ?d=0.8         start the question ladder at this difficulty
+ */
+
+import { createDevHost } from "./devHost.ts";
+import { mount } from "./game/game.ts";
+
+const params = new URLSearchParams(location.search);
+const el = document.getElementById("stage");
+if (!el) throw new Error("#stage missing");
+
+const reports: Array<{ questionId: string; correct: boolean; ms: number; answered: string }> = [];
+const host = createDevHost({
+  seed: Number(params.get("seed")) || undefined,
+  difficulty: Number(params.get("d")) || undefined,
+  onReport: (r) => {
+    reports.push(r);
+    if (reports.length > 200) reports.shift();
+  },
+});
+
+const handle = mount(el, host);
+
+// A tiny surface for the QA driver: no gameplay hook, just read-only telemetry.
+Object.assign(window as unknown as Record<string, unknown>, {
+  __guilty: {
+    reports: () => reports,
+    stats: () => handle.stats(),
+    unmount: () => handle.unmount(),
+  },
+});

--- a/dynawalla/games/guilty/src/math/generate.test.ts
+++ b/dynawalla/games/guilty/src/math/generate.test.ts
@@ -1,0 +1,126 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { generate, distractorsFor } from "./generate.ts";
+
+/**
+ * An independent, precedence-aware integer evaluator for the *displayed*
+ * prompt. Nothing in `generate.ts` is reused here on purpose: if the prompt and
+ * the stored answer ever drift apart, this is what catches it, and a shared
+ * helper would drift with them.
+ */
+function evaluatePrompt(prompt: string): number {
+  const tokens = prompt.trim().split(/\s+/);
+  const values: number[] = [];
+  const ops: string[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i] as string;
+    if (i % 2 === 0) {
+      assert.match(token, /^\d+$/, `operand expected, got ${token} in "${prompt}"`);
+      values.push(Number(token));
+    } else {
+      assert.ok(["+", "−", "×", "÷"].includes(token), `operator expected, got ${token}`);
+      ops.push(token);
+    }
+  }
+  // × and ÷ first, left to right, then + and −.
+  for (let i = 0; i < ops.length; ) {
+    const op = ops[i] as string;
+    if (op === "×" || op === "÷") {
+      const a = values[i] as number;
+      const b = values[i + 1] as number;
+      const out = op === "×" ? a * b : a / b;
+      assert.ok(Number.isInteger(out), `non-integer division in "${prompt}"`);
+      values.splice(i, 2, out);
+      ops.splice(i, 1);
+    } else i++;
+  }
+  let total = values[0] as number;
+  for (let i = 0; i < ops.length; i++) {
+    total = ops[i] === "+" ? total + (values[i + 1] as number) : total - (values[i + 1] as number);
+  }
+  return total;
+}
+
+const DIFFICULTIES = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1];
+
+test("every generated question's prompt evaluates to its own answer", () => {
+  for (const difficulty of DIFFICULTIES) {
+    for (let i = 0; i < 300; i++) {
+      const q = generate(0xc0ffee, i, difficulty);
+      assert.equal(
+        String(evaluatePrompt(q.prompt)),
+        q.answer,
+        `${q.prompt} should be ${q.answer}`,
+      );
+    }
+  }
+});
+
+test("answers are non-negative integers written canonically", () => {
+  for (const difficulty of DIFFICULTIES) {
+    for (let i = 0; i < 200; i++) {
+      const q = generate(7, i, difficulty);
+      assert.match(q.answer, /^(0|[1-9]\d*)$/, `bad answer "${q.answer}" for ${q.prompt}`);
+      assert.ok(Number(q.answer) >= 0);
+    }
+  }
+});
+
+test("distractors are plentiful, distinct, non-negative and never the answer", () => {
+  for (const difficulty of DIFFICULTIES) {
+    for (let i = 0; i < 300; i++) {
+      const q = generate(99, i, difficulty);
+      assert.ok(q.distractors.length >= 5, `${q.prompt} gave ${q.distractors.length}`);
+      const seen = new Set(q.distractors);
+      assert.equal(seen.size, q.distractors.length, `duplicate distractor in ${q.prompt}`);
+      assert.ok(!seen.has(q.answer), `${q.prompt} listed its own answer as a distractor`);
+      for (const d of q.distractors) {
+        assert.match(d, /^(0|[1-9]\d*)$/, `bad distractor "${d}" for ${q.prompt}`);
+      }
+    }
+  }
+});
+
+test("most distractors share the answer's digit count, so silhouette is not a tell", () => {
+  let sameWidth = 0;
+  let total = 0;
+  for (const difficulty of DIFFICULTIES) {
+    for (let i = 0; i < 200; i++) {
+      const q = generate(1234, i, difficulty);
+      // The game only ever shows four of them.
+      for (const d of q.distractors.slice(0, 4)) {
+        total++;
+        if (d.length === q.answer.length) sameWidth++;
+      }
+    }
+  }
+  assert.ok(sameWidth / total > 0.9, `only ${((sameWidth / total) * 100).toFixed(1)}% matched`);
+});
+
+test("generation is deterministic and seed-dependent", () => {
+  const a = generate(42, 3, 0.5);
+  const b = generate(42, 3, 0.5);
+  assert.deepEqual(a, b);
+  const c = generate(43, 3, 0.5);
+  assert.notDeepEqual(a, c);
+});
+
+test("distractorsFor pads to six even when every mal-rule collides", () => {
+  const out = distractorsFor(7, [7, 7, 7, -3, 1.5]);
+  assert.equal(out.length, 6);
+  assert.equal(new Set(out).size, 6);
+  assert.ok(!out.includes("7"));
+});
+
+test("difficulty selects harder shapes", () => {
+  const easy = new Set<string>();
+  const hard = new Set<string>();
+  for (let i = 0; i < 60; i++) {
+    easy.add(generate(5, i, 0.05).domain);
+    hard.add(generate(5, i, 0.95).domain);
+  }
+  assert.deepEqual([...easy], ["add-sub"]);
+  assert.ok(hard.has("two-step"));
+  assert.ok(!hard.has("add-sub"));
+});

--- a/dynawalla/games/guilty/src/math/generate.ts
+++ b/dynawalla/games/guilty/src/math/generate.ts
@@ -1,0 +1,295 @@
+/**
+ * Question generation for the stub host.
+ *
+ * Seeded and deterministic: `generate(seed, index, difficulty)` is a pure
+ * function, so a run replays exactly. Every value is an integer and every
+ * answer is the decimal string of one — a comparison is `===` on strings, never
+ * a float subtraction with an epsilon.
+ *
+ * Distractors come from `malrules.ts` first, and only fall back to near-misses
+ * when a mal-rule collides with the answer or with another rule. Same-length
+ * candidates are preferred so a descending husk can never be ruled out on its
+ * silhouette alone — the player has to actually do the arithmetic.
+ */
+
+import type { Question } from "../contract.ts";
+import { makeRng, type Rng } from "./rng.ts";
+import {
+  addedInstead,
+  borrowNotPaid,
+  carryDropped,
+  carryWrittenInline,
+  digitsReversed,
+  droppedStep,
+  leftToRight,
+  offByOne,
+  remainderAsQuotient,
+  smallerFromLarger,
+  tableSlip,
+} from "./malrules.ts";
+
+export const MINUS = "−";
+export const TIMES = "×";
+export const DIVIDE = "÷";
+
+type Draft = {
+  prompt: string;
+  answer: number;
+  domain: string;
+  /** Mal-rule outputs, best first. May contain junk; the caller filters. */
+  wrong: number[];
+};
+
+/** Which shapes are legal at this difficulty, widest band last. */
+function shapesFor(difficulty: number): string[] {
+  if (difficulty < 0.16) return ["add10", "sub10"];
+  if (difficulty < 0.3) return ["add20", "sub20", "add10", "sub10"];
+  if (difficulty < 0.44) return ["add2d", "sub2d", "add20", "sub20"];
+  if (difficulty < 0.56) return ["mul", "mul", "add2d", "sub2d"];
+  if (difficulty < 0.68) return ["div", "mul", "mul", "sub2d"];
+  if (difficulty < 0.82) return ["mul2d", "div", "mul", "twoStep"];
+  return ["twoStep", "twoStep", "mul2d", "div"];
+}
+
+function draft(shape: string, rng: Rng): Draft {
+  switch (shape) {
+    case "add10": {
+      const a = rng.int(1, 8);
+      const b = rng.int(1, 9 - a);
+      return {
+        prompt: `${a} + ${b}`,
+        answer: a + b,
+        domain: "add-sub",
+        wrong: [offByOne(a + b, 1), offByOne(a + b, -1), Math.abs(a - b), a + b + 2],
+      };
+    }
+    case "sub10": {
+      const a = rng.int(3, 10);
+      const b = rng.int(1, a - 1);
+      return {
+        prompt: `${a} ${MINUS} ${b}`,
+        answer: a - b,
+        domain: "add-sub",
+        wrong: [offByOne(a - b, 1), offByOne(a - b, -1), a + b, b],
+      };
+    }
+    case "add20": {
+      // Bridging ten is the point, so force a carry out of the units column.
+      const a = rng.int(4, 9);
+      const b = rng.int(11 - a, 9);
+      return {
+        prompt: `${a} + ${b}`,
+        answer: a + b,
+        domain: "add-sub",
+        wrong: [carryDropped(a, b), offByOne(a + b, -1), offByOne(a + b, 1), Math.abs(a - b)],
+      };
+    }
+    case "sub20": {
+      // Force a borrow: minuend in the teens, subtrahend bigger than its units.
+      const a = rng.int(11, 18);
+      const units = a % 10;
+      const b = rng.int(units + 1, 9);
+      return {
+        prompt: `${a} ${MINUS} ${b}`,
+        answer: a - b,
+        domain: "add-sub",
+        wrong: [
+          smallerFromLarger(a, b),
+          borrowNotPaid(a, b),
+          offByOne(a - b, 1),
+          offByOne(a - b, -1),
+        ],
+      };
+    }
+    case "add2d": {
+      const a = rng.int(14, 79);
+      const b = rng.int(14, 79);
+      return {
+        prompt: `${a} + ${b}`,
+        answer: a + b,
+        domain: "add-sub",
+        wrong: [
+          carryDropped(a, b),
+          offByOne(a + b, -1),
+          carryWrittenInline(a, b),
+          Math.abs(a - b),
+          offByOne(a + b, 10),
+        ],
+      };
+    }
+    case "sub2d": {
+      // Guarantee a regroup so smaller-from-larger has something to be wrong about.
+      const a = rng.int(31, 98);
+      const units = a % 10;
+      const b = rng.int(10 + units + 1, a - 1);
+      return {
+        prompt: `${a} ${MINUS} ${b}`,
+        answer: a - b,
+        domain: "add-sub",
+        wrong: [
+          smallerFromLarger(a, b),
+          borrowNotPaid(a, b),
+          offByOne(a - b, -1),
+          offByOne(a - b, 10),
+          addedInstead(a, b),
+        ],
+      };
+    }
+    case "mul": {
+      const a = rng.int(2, 9);
+      const b = rng.int(2, 9);
+      return {
+        prompt: `${a} ${TIMES} ${b}`,
+        answer: a * b,
+        domain: "mul",
+        wrong: [
+          tableSlip(a, b, -1),
+          tableSlip(a, b, 1),
+          addedInstead(a, b),
+          tableSlip(b, a, -1),
+          offByOne(a * b, 1),
+        ],
+      };
+    }
+    case "mul2d": {
+      const a = rng.int(12, 29);
+      const b = rng.int(3, 9);
+      return {
+        prompt: `${a} ${TIMES} ${b}`,
+        answer: a * b,
+        domain: "mul",
+        wrong: [
+          // The classic: multiply the units, multiply the tens, never carry.
+          (Math.trunc(a / 10) * b) * 10 + ((a % 10) * b) % 10,
+          tableSlip(b, a, -1),
+          tableSlip(b, a, 1),
+          addedInstead(a, b),
+          offByOne(a * b, 10),
+        ],
+      };
+    }
+    case "div": {
+      const q = rng.int(2, 9);
+      const b = rng.int(2, 9);
+      const a = q * b;
+      return {
+        prompt: `${a} ${DIVIDE} ${b}`,
+        answer: q,
+        domain: "div",
+        wrong: [
+          offByOne(q, 1),
+          offByOne(q, -1),
+          remainderAsQuotient(a, b),
+          a - b,
+          b,
+        ],
+      };
+    }
+    default: {
+      // twoStep — precedence is the whole point, so the second operator is
+      // always ×, and `leftToRight` is a genuinely different number.
+      const c = rng.int(2, 6);
+      const b = rng.int(2, 6);
+      const product = b * c;
+      const subtractive = rng.int(0, 1) === 1;
+
+      if (subtractive) {
+        // Non-negative by construction: the minuend is built above the product.
+        const a = product + rng.int(1, 14);
+        return {
+          prompt: `${a} ${MINUS} ${b} ${TIMES} ${c}`,
+          answer: a - product,
+          domain: "two-step",
+          wrong: [
+            leftToRight(a, "-", b, "*", c),
+            droppedStep(a, "-", b),
+            product,
+            offByOne(a - product, -1),
+            a - b - c,
+          ],
+        };
+      }
+      const a = rng.int(2, 14);
+      return {
+        prompt: `${a} + ${b} ${TIMES} ${c}`,
+        answer: a + product,
+        domain: "two-step",
+        wrong: [
+          leftToRight(a, "+", b, "*", c),
+          droppedStep(a, "+", b),
+          product,
+          offByOne(a + product, -1),
+          a + b + c,
+        ],
+      };
+    }
+  }
+}
+
+/** Near-misses used only when the mal-rules could not supply enough. */
+function fallbacks(answer: number): number[] {
+  const out = [answer + 1, answer - 1, answer + 10, answer - 10, answer + 2, answer - 2];
+  if (answer >= 10) out.push(digitsReversed(answer));
+  return out;
+}
+
+function acceptable(value: number, answer: number, taken: Set<number>): boolean {
+  if (!Number.isInteger(value)) return false;
+  if (value < 0) return false;
+  if (value === answer) return false;
+  if (taken.has(value)) return false;
+  if (value > 9999) return false;
+  return true;
+}
+
+/**
+ * Six distractors, best first. Same digit-length as the answer is preferred, so
+ * the player cannot shortcut the arithmetic by counting digits — but a
+ * different-length mal-rule output is still allowed in rather than dropping to
+ * a meaningless near-miss.
+ */
+export function distractorsFor(answer: number, wrong: readonly number[]): string[] {
+  const taken = new Set<number>();
+  const sameLength: number[] = [];
+  const other: number[] = [];
+  const width = String(answer).length;
+
+  for (const value of wrong) {
+    if (!acceptable(value, answer, taken)) continue;
+    taken.add(value);
+    (String(value).length === width ? sameLength : other).push(value);
+  }
+  for (const value of fallbacks(answer)) {
+    if (!acceptable(value, answer, taken)) continue;
+    taken.add(value);
+    (String(value).length === width ? sameLength : other).push(value);
+  }
+  // Last resort: walk outwards until there are enough. Cannot loop forever —
+  // every step produces a new integer and `acceptable` only rejects duplicates.
+  let step = 3;
+  while (sameLength.length + other.length < 6 && step < 40) {
+    for (const value of [answer + step, answer - step]) {
+      if (!acceptable(value, answer, taken)) continue;
+      taken.add(value);
+      (String(value).length === width ? sameLength : other).push(value);
+    }
+    step++;
+  }
+  return [...sameLength, ...other].slice(0, 6).map(String);
+}
+
+export function generate(seed: number, index: number, difficulty: number): Question {
+  const rng = makeRng((seed ^ Math.imul(index + 1, 0x9e3779b1)) >>> 0);
+  const clamped = Math.max(0, Math.min(1, difficulty));
+  const shapes = shapesFor(clamped);
+  const shape = shapes[rng.int(0, shapes.length - 1)] as string;
+  const d = draft(shape, rng);
+  return {
+    id: `q${index}-${shape}-${rng.state().toString(36)}`,
+    prompt: d.prompt,
+    answer: String(d.answer),
+    distractors: distractorsFor(d.answer, d.wrong),
+    domain: d.domain,
+    difficulty: clamped,
+  };
+}

--- a/dynawalla/games/guilty/src/math/malrules.test.ts
+++ b/dynawalla/games/guilty/src/math/malrules.test.ts
@@ -1,0 +1,67 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import {
+  addedInstead,
+  borrowNotPaid,
+  carryDropped,
+  carryWrittenInline,
+  digitsReversed,
+  droppedStep,
+  leftToRight,
+  offByOne,
+  remainderAsQuotient,
+  smallerFromLarger,
+  tableSlip,
+} from "./malrules.ts";
+
+test("smaller-from-larger takes each column the easy way round", () => {
+  assert.equal(smallerFromLarger(52, 27), 35);
+  assert.equal(smallerFromLarger(5001, 2798), 3797); // the curriculum's own example
+  assert.equal(smallerFromLarger(83, 46), 43);
+});
+
+test("borrow-not-paid adds the ten and never gives it back", () => {
+  // 52 − 27: 12−7=5, then 5−2=3 because the 5 was never decremented.
+  assert.equal(borrowNotPaid(52, 27), 35);
+  // Three digits separate it from smaller-from-larger.
+  assert.equal(borrowNotPaid(413, 168), 355);
+  assert.equal(smallerFromLarger(413, 168), 355);
+  assert.equal(borrowNotPaid(302, 147), 265);
+  assert.equal(smallerFromLarger(302, 147), 245);
+});
+
+test("borrow-not-paid never disagrees with correct subtraction when no column borrows", () => {
+  for (let a = 10; a < 100; a++) {
+    for (let b = 0; b <= a; b++) {
+      if (a % 10 >= b % 10) assert.equal(borrowNotPaid(a, b), a - b);
+    }
+  }
+});
+
+test("carry-dropped keeps every column under ten", () => {
+  assert.equal(carryDropped(27, 45), 62);
+  assert.equal(carryDropped(8, 7), 5);
+  assert.equal(carryDropped(66, 66), 22);
+});
+
+test("carry-written-inline spills the tens digit sideways", () => {
+  assert.equal(carryWrittenInline(27, 45), 612);
+  assert.equal(carryWrittenInline(8, 7), 15);
+});
+
+test("table-slip is one rung of the times table away", () => {
+  assert.equal(tableSlip(7, 6, -1), 35);
+  assert.equal(tableSlip(7, 6, 1), 49);
+  assert.equal(tableSlip(9, 4, -1), 27);
+});
+
+test("assorted rules", () => {
+  assert.equal(addedInstead(7, 6), 13);
+  assert.equal(offByOne(42, -1), 41);
+  assert.equal(remainderAsQuotient(45, 9), 36);
+  assert.equal(remainderAsQuotient(47, 9), 2);
+  assert.equal(leftToRight(2, "+", 3, "*", 4), 20);
+  assert.equal(droppedStep(2, "+", 3), 5);
+  assert.equal(digitsReversed(71), 17);
+});

--- a/dynawalla/games/guilty/src/math/malrules.ts
+++ b/dynawalla/games/guilty/src/math/malrules.ts
@@ -1,0 +1,145 @@
+/**
+ * Mal-rules: the wrong answers children actually produce.
+ *
+ * Every rule here *runs the buggy procedure* instead of computing a shortcut
+ * from the correct answer. That is the house rule in `dynawalla/curriculum`
+ * (see `malrules/columnOp.ts`) and it matters for the same reason: a shortcut
+ * happens to agree with the procedure on the cases you thought of, and silently
+ * stops agreeing the moment the borrow chain has a different shape.
+ *
+ * Everything is integer arithmetic. No float ever reaches an answer or a
+ * comparison — that is what makes "is this the guilty one" a `===` on strings.
+ */
+
+const digitsOf = (n: number, cols: number): number[] => {
+  const out: number[] = [];
+  let rest = Math.abs(n);
+  for (let i = 0; i < cols; i++) {
+    out.push(rest % 10);
+    rest = Math.trunc(rest / 10);
+  }
+  return out;
+};
+
+const fromDigits = (digits: readonly number[]): number => {
+  let value = 0;
+  for (let i = digits.length - 1; i >= 0; i--) value = value * 10 + (digits[i] ?? 0);
+  return value;
+};
+
+const columnCount = (...values: number[]): number => {
+  let cols = 1;
+  for (const v of values) cols = Math.max(cols, String(Math.abs(v)).length);
+  return cols;
+};
+
+/**
+ * `mis.sub.smaller-from-larger` — the single most common subtraction bug. In
+ * every column the child takes the smaller digit from the larger, whichever way
+ * round it sits, and never regroups. 52 − 27 → |2−7| |5−2| → 35.
+ */
+export function smallerFromLarger(a: number, b: number): number {
+  const cols = columnCount(a, b);
+  const top = digitsOf(a, cols);
+  const bot = digitsOf(b, cols);
+  const out: number[] = [];
+  for (let i = 0; i < cols; i++) out.push(Math.abs((top[i] ?? 0) - (bot[i] ?? 0)));
+  return fromDigits(out);
+}
+
+/**
+ * `mis.sub.borrow-not-paid` — the child *does* add ten to the top digit but
+ * never decrements the column it borrowed from. 52 − 27 → 12−7=5, 5−2=3 → 35.
+ * (It collides with smaller-from-larger on many two-digit pairs; callers
+ * de-duplicate, and on three digits the two separate cleanly.)
+ */
+export function borrowNotPaid(a: number, b: number): number {
+  const cols = columnCount(a, b);
+  const top = digitsOf(a, cols);
+  const bot = digitsOf(b, cols);
+  const out: number[] = [];
+  for (let i = 0; i < cols; i++) {
+    const t = top[i] ?? 0;
+    const s = bot[i] ?? 0;
+    out.push(t < s ? t + 10 - s : t - s);
+  }
+  return fromDigits(out);
+}
+
+/**
+ * `mis.add.carry-dropped` — columns summed independently, the carry written
+ * nowhere. 27 + 45 → (7+5) mod 10 = 2, (2+4) mod 10 = 6 → 62.
+ */
+export function carryDropped(a: number, b: number): number {
+  const cols = columnCount(a, b) + 1;
+  const top = digitsOf(a, cols);
+  const bot = digitsOf(b, cols);
+  const out: number[] = [];
+  for (let i = 0; i < cols; i++) out.push(((top[i] ?? 0) + (bot[i] ?? 0)) % 10);
+  return fromDigits(out);
+}
+
+/**
+ * `mis.add.carry-written-inline` — the carry is not carried, it is written into
+ * the same column, so the tens digit of a column sum lands beside its units.
+ * 27 + 45 → 7+5 = 12, 2+4 = 6 → 612. Wildly wrong, and children do it.
+ */
+export function carryWrittenInline(a: number, b: number): number {
+  const cols = columnCount(a, b);
+  const top = digitsOf(a, cols);
+  const bot = digitsOf(b, cols);
+  let text = "";
+  for (let i = cols - 1; i >= 0; i--) text += String((top[i] ?? 0) + (bot[i] ?? 0));
+  return Number(text);
+}
+
+/**
+ * `mis.mul.table-slip` — the times table recited one step short or one step
+ * long. 7 × 6 → 36 or 48. `step` is the number of rungs missed (signed).
+ */
+export function tableSlip(a: number, b: number, step: number): number {
+  return a * (b + step);
+}
+
+/** `mis.mul.added-instead` — the operator was read but not obeyed. */
+export const addedInstead = (a: number, b: number): number => a + b;
+
+/** `mis.arith.off-by-one` — a counting-on error, one short or one long. */
+export const offByOne = (value: number, step: number): number => value + step;
+
+/**
+ * `mis.div.remainder-as-quotient` — the child divides, finds it does not go
+ * evenly at the digit they tried, and reports what is left over instead.
+ */
+export function remainderAsQuotient(a: number, b: number): number {
+  if (b === 0) return 0;
+  return a % b === 0 ? a - b : a % b;
+}
+
+/**
+ * `mis.arith.left-to-right` — precedence ignored, the expression evaluated
+ * strictly left to right. 2 + 3 × 4 → 20. A real and very durable bug.
+ */
+export type Op = "+" | "-" | "*";
+
+export function leftToRight(a: number, op1: Op, b: number, op2: Op, c: number): number {
+  const step = apply(a, op1, b);
+  return apply(step, op2, c);
+}
+
+/**
+ * `mis.arith.dropped-step` — the last operation of a two-step problem is never
+ * performed; the intermediate value is handed in as the answer.
+ */
+export function droppedStep(a: number, op1: Op, b: number): number {
+  return apply(a, op1, b);
+}
+
+function apply(a: number, op: Op, b: number): number {
+  return op === "+" ? a + b : op === "-" ? a - b : a * b;
+}
+
+/** Digits reversed on the way onto the page. 71 → 17. */
+export function digitsReversed(value: number): number {
+  return Number(String(value).split("").reverse().join(""));
+}

--- a/dynawalla/games/guilty/src/math/rng.ts
+++ b/dynawalla/games/guilty/src/math/rng.ts
@@ -1,0 +1,77 @@
+/**
+ * Seeded, deterministic PRNG. mulberry32 — 32-bit state, fast, good enough for
+ * particles and question selection, and identical on every device.
+ *
+ * `nextFloat` exists for *presentation* randomness only (spark angles, pitch
+ * jitter). Anything that decides a question, an answer or a comparison uses the
+ * integer paths, so no answer path ever touches a float.
+ */
+export type Rng = {
+  /** Uniform 32-bit unsigned integer. */
+  nextUint(): number;
+  /** Uniform float in [0,1). Presentation only. */
+  nextFloat(): number;
+  /** Uniform integer in [lo, hi] inclusive. */
+  int(lo: number, hi: number): number;
+  /** Uniform float in [lo, hi). Presentation only. */
+  range(lo: number, hi: number): number;
+  pick<T>(items: readonly T[]): T;
+  /** In-place Fisher-Yates. Returns the same array. */
+  shuffle<T>(items: T[]): T[];
+  /** Current raw state, so a run can be resumed or logged. */
+  state(): number;
+};
+
+export function makeRng(seed: number): Rng {
+  let s = seed >>> 0;
+  if (s === 0) s = 0x9e3779b9;
+
+  const nextUint = (): number => {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return (t ^ (t >>> 14)) >>> 0;
+  };
+
+  const nextFloat = (): number => nextUint() / 4294967296;
+
+  const int = (lo: number, hi: number): number => {
+    if (hi <= lo) return lo;
+    const span = hi - lo + 1;
+    return lo + (nextUint() % span);
+  };
+
+  return {
+    nextUint,
+    nextFloat,
+    int,
+    range: (lo, hi) => lo + nextFloat() * (hi - lo),
+    pick: <T,>(items: readonly T[]): T => {
+      const v = items[int(0, items.length - 1)];
+      if (v === undefined) throw new Error("pick from empty array");
+      return v;
+    },
+    shuffle: <T,>(items: T[]): T[] => {
+      for (let i = items.length - 1; i > 0; i--) {
+        const j = int(0, i);
+        const a = items[i] as T;
+        const b = items[j] as T;
+        items[i] = b;
+        items[j] = a;
+      }
+      return items;
+    },
+    state: () => s >>> 0,
+  };
+}
+
+/** FNV-1a over a string — turns a question id into a stable presentation seed. */
+export function hashString(text: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < text.length; i++) {
+    h ^= text.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}

--- a/dynawalla/games/guilty/src/render/bake.ts
+++ b/dynawalla/games/guilty/src/render/bake.ts
@@ -1,0 +1,162 @@
+/**
+ * Everything expensive is drawn once into an offscreen canvas and then blitted.
+ *
+ * `ctx.shadowBlur` is the only cheap way to get a real glow in Canvas2D and it
+ * is far too slow to use per-frame — so it is used exactly here, at bake time,
+ * and the frame loop only ever calls `drawImage`. That is the whole reason this
+ * game holds 60fps with a few hundred glowing things on screen.
+ */
+
+import { mix, rgba } from "../core/palette.ts";
+
+export type Glyph = {
+  canvas: HTMLCanvasElement;
+  /** Width/height of the baked bitmap in bake pixels. */
+  w: number;
+  h: number;
+  /** Advance width of the glyph itself, for layout. */
+  inkW: number;
+};
+
+const BAKE_PX = 92;
+const FONT_STACK = `system-ui, -apple-system, "Segoe UI", "Helvetica Neue", Arial, sans-serif`;
+
+const glyphs = new Map<string, Glyph>();
+const glows = new Map<string, HTMLCanvasElement>();
+
+function makeCanvas(w: number, h: number): HTMLCanvasElement {
+  const c = document.createElement("canvas");
+  c.width = Math.max(1, Math.ceil(w));
+  c.height = Math.max(1, Math.ceil(h));
+  return c;
+}
+
+/**
+ * A numeral (or a whole equation) with its bloom baked in: two wide coloured
+ * passes for the halo, one tight pass for the edge, and a near-white core so it
+ * reads at any size against the black water.
+ */
+export function getGlyph(text: string, color: string, weight = 800, px = BAKE_PX): Glyph {
+  const key = `${text}|${color}|${weight}|${px}`;
+  const hit = glyphs.get(key);
+  if (hit) return hit;
+  // Equations are unbounded strings over a long session; the ten numerals and a
+  // handful of words are what actually recur, so a bounded cache with a hard
+  // reset is enough and can never leak.
+  if (glyphs.size > 160) glyphs.clear();
+
+  const probe = makeCanvas(8, 8).getContext("2d") as CanvasRenderingContext2D;
+  const font = `${weight} ${px}px ${FONT_STACK}`;
+  probe.font = font;
+  const inkW = probe.measureText(text).width;
+
+  const pad = px * 0.62;
+  const w = inkW + pad * 2;
+  const h = px * 1.28 + pad * 2;
+  const canvas = makeCanvas(w, h);
+  const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
+  ctx.font = font;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  const cx = w / 2;
+  const cy = h / 2;
+
+  // Halo, edge, body. The body is a *tint* of the colour rather than white:
+  // a white core blooms out to a shapeless blob the moment two glows overlap,
+  // and legibility of the numeral is the entire game.
+  ctx.shadowColor = color;
+  ctx.fillStyle = rgba(color, 0.34);
+  ctx.shadowBlur = px * 0.46;
+  ctx.fillText(text, cx, cy);
+  ctx.shadowBlur = px * 0.16;
+  ctx.fillStyle = rgba(color, 0.8);
+  ctx.fillText(text, cx, cy);
+  ctx.shadowBlur = 0;
+  ctx.fillStyle = mix(color, "#ffffff", 0.62);
+  ctx.fillText(text, cx, cy);
+
+  const glyph: Glyph = { canvas, w, h, inkW };
+  glyphs.set(key, glyph);
+  return glyph;
+}
+
+/** Blits a baked glyph centred on (x, y), scaled so its cap height is `size`. */
+export function drawGlyph(
+  ctx: CanvasRenderingContext2D,
+  glyph: Glyph,
+  x: number,
+  y: number,
+  size: number,
+  alpha = 1,
+): void {
+  if (alpha <= 0.004) return;
+  const k = size / BAKE_PX;
+  const w = glyph.w * k;
+  const h = glyph.h * k;
+  const prev = ctx.globalAlpha;
+  ctx.globalAlpha = prev * alpha;
+  ctx.drawImage(glyph.canvas, x - w / 2, y - h / 2, w, h);
+  ctx.globalAlpha = prev;
+}
+
+/**
+ * A soft additive blob. One per colour, 128px, drawn scaled. Under `lighter`
+ * these stack into the bloom that carries the whole look.
+ */
+export function getGlow(color: string): HTMLCanvasElement {
+  const hit = glows.get(color);
+  if (hit) return hit;
+  const size = 128;
+  const canvas = makeCanvas(size, size);
+  const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
+  const g = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+  g.addColorStop(0, rgba(color, 1));
+  g.addColorStop(0.22, rgba(color, 0.55));
+  g.addColorStop(0.55, rgba(color, 0.14));
+  g.addColorStop(1, rgba(color, 0));
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, size, size);
+  glows.set(color, canvas);
+  return canvas;
+}
+
+export function drawGlow(
+  ctx: CanvasRenderingContext2D,
+  color: string,
+  x: number,
+  y: number,
+  radius: number,
+  alpha: number,
+): void {
+  if (alpha <= 0.004 || radius <= 0.2) return;
+  const sprite = getGlow(color);
+  const prev = ctx.globalAlpha;
+  ctx.globalAlpha = prev * Math.min(1, alpha);
+  ctx.drawImage(sprite, x - radius, y - radius, radius * 2, radius * 2);
+  ctx.globalAlpha = prev;
+}
+
+/** Corner darkening, baked at every resize. One blit, no per-frame gradient. */
+export function bakeVignette(w: number, h: number): HTMLCanvasElement {
+  const canvas = makeCanvas(w, h);
+  const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
+  const g = ctx.createRadialGradient(
+    w / 2,
+    h * 0.52,
+    Math.min(w, h) * 0.24,
+    w / 2,
+    h * 0.52,
+    Math.max(w, h) * 0.78,
+  );
+  g.addColorStop(0, "rgba(0,0,0,0)");
+  g.addColorStop(0.62, "rgba(0,0,0,0.18)");
+  g.addColorStop(1, "rgba(0,0,0,0.72)");
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, w, h);
+  return canvas;
+}
+
+/** Free the glyph cache when the run ends — equations are unbounded strings. */
+export function clearGlyphCache(): void {
+  glyphs.clear();
+}

--- a/dynawalla/games/guilty/src/render/draw.ts
+++ b/dynawalla/games/guilty/src/render/draw.ts
@@ -1,0 +1,93 @@
+/**
+ * Line batching.
+ *
+ * Canvas2D's cost is dominated by state changes and by the number of
+ * `stroke()` calls, not by the number of segments inside one path. A wireframe
+ * husk is 18 edges; eight husks plus debris plus the seabed is several hundred
+ * segments a frame. Pushed one at a time that is several hundred strokes and
+ * the frame budget is gone; bucketed by (colour, width, alpha) it is a dozen.
+ *
+ * Buckets are reused across frames — `reset()` sets lengths to 0 rather than
+ * dropping the arrays, so a steady-state frame allocates nothing.
+ */
+
+export type LineBatch = {
+  push(x1: number, y1: number, x2: number, y2: number, color: string, width: number, alpha: number): void;
+  flush(ctx: CanvasRenderingContext2D): void;
+  reset(): void;
+};
+
+type Bucket = { color: string; width: number; alpha: number; pts: number[]; n: number };
+
+export function makeLineBatch(): LineBatch {
+  const buckets = new Map<string, Bucket>();
+  const order: Bucket[] = [];
+
+  return {
+    push(x1, y1, x2, y2, color, width, alpha) {
+      if (alpha <= 0.01) return;
+      // Quantise alpha so a fading particle does not create a bucket per frame.
+      const qa = Math.round(alpha * 12) / 12;
+      if (qa <= 0) return;
+      const qw = Math.round(width * 2) / 2;
+      const key = `${color}|${qw}|${qa}`;
+      let bucket = buckets.get(key);
+      if (!bucket) {
+        bucket = { color, width: qw, alpha: qa, pts: [], n: 0 };
+        buckets.set(key, bucket);
+        order.push(bucket);
+      }
+      const p = bucket.pts;
+      p[bucket.n++] = x1;
+      p[bucket.n++] = y1;
+      p[bucket.n++] = x2;
+      p[bucket.n++] = y2;
+    },
+    flush(ctx) {
+      ctx.lineCap = "round";
+      for (const bucket of order) {
+        if (bucket.n === 0) continue;
+        ctx.globalAlpha = bucket.alpha;
+        ctx.strokeStyle = bucket.color;
+        ctx.lineWidth = bucket.width;
+        ctx.beginPath();
+        const p = bucket.pts;
+        for (let i = 0; i < bucket.n; i += 4) {
+          ctx.moveTo(p[i], p[i + 1]);
+          ctx.lineTo(p[i + 2], p[i + 3]);
+        }
+        ctx.stroke();
+        bucket.n = 0;
+      }
+      ctx.globalAlpha = 1;
+    },
+    reset() {
+      for (const bucket of order) bucket.n = 0;
+    },
+  };
+}
+
+/** Easing, by name, so the tuning is readable. */
+export const ease = {
+  outCubic: (t: number) => 1 - Math.pow(1 - t, 3),
+  outQuint: (t: number) => 1 - Math.pow(1 - t, 5),
+  inQuad: (t: number) => t * t,
+  outBack: (t: number) => {
+    const c = 2.2;
+    return 1 + (c + 1) * Math.pow(t - 1, 3) + c * Math.pow(t - 1, 2);
+  },
+  outElastic: (t: number) => {
+    if (t <= 0) return 0;
+    if (t >= 1) return 1;
+    const p = 0.34;
+    return Math.pow(2, -9 * t) * Math.sin(((t - p / 4) * (Math.PI * 2)) / p) + 1;
+  },
+  inOutSine: (t: number) => -(Math.cos(Math.PI * t) - 1) / 2,
+};
+
+export const clamp = (v: number, lo: number, hi: number): number =>
+  v < lo ? lo : v > hi ? hi : v;
+
+/** Frame-rate independent exponential approach. */
+export const damp = (current: number, target: number, lambda: number, dt: number): number =>
+  target + (current - target) * Math.exp(-lambda * dt);

--- a/dynawalla/games/guilty/src/style.css
+++ b/dynawalla/games/guilty/src/style.css
@@ -1,0 +1,20 @@
+/* Dev-harness chrome only. The game itself paints one <canvas> and nothing else,
+   so it drops into any host container without dragging styles along. */
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: #03060c;
+  overflow: hidden;
+  overscroll-behavior: none;
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+#stage {
+  position: fixed;
+  inset: 0;
+}

--- a/dynawalla/games/guilty/tsconfig.json
+++ b/dynawalla/games/guilty/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": false,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/dynawalla/games/guilty/vite.config.ts
+++ b/dynawalla/games/guilty/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  base: "./",
+  server: { port: 4178, strictPort: false },
+  build: { target: "es2022", assetsInlineLimit: 0 },
+});


### PR DESCRIPTION
## What

Commit `dynawalla/games/guilty` — GUILTY, a fixed-position arithmetic shooter in a bioluminescent trench.

## Why

This prototype existed **only as untracked files in a worktree**. It appeared in
zero git refs: `git log --all -- dynawalla/games/guilty` returned no commits. It was
never committed, never branched, never pushed. Pruning that worktree — which the
repo's own session hook recommends doing after a merge — would have destroyed it
with no reflog and no dangling object to recover from.

Ten sibling prototypes were in the same state. This PR is one of that set.

## Blast radius

**Areas touched:** dynawalla (new directory only)

- [x] Additive only. Every path is new under `dynawalla/games/guilty/`; no existing
      file is modified or deleted. Nothing imports it yet.
- [ ] **Every touched path is covered by a `ci.yml` area filter** — **NO, and
      stated deliberately.** `dynawalla/games/` is absent from the `covered`
      regex (`ci.yml:226`), so the `uncovered` step will warn. This is
      pre-existing: the five games already on `main` have no CI either. No job
      builds, type-checks or tests any game. The gates below were therefore run
      locally, by hand. A games-area filter is the correct follow-up and is
      called out rather than silently bundled here.
- [x] **Pack back-compat.** No published pack zip, `voiceId` or catalog entry
      touched. App floor 0.20.6 unaffected.
- [x] **Native integrity.** No Rust, no `src-tauri`, no `links =`, no `[patch]`.
- [x] **Strings.** No `corpan-app` locale keys added; this pack does not use the
      Corpán i18n catalog.
- [x] **Curriculum.** No skill id renamed or reused, no grade metadata changed,
      no generator binding altered.
- [x] **Secrets.** No `.p8`, keystore, service-account JSON, issuer id, key id or
      token. Verified the diff is source, config and `index.html` only.

`package-lock.json` and `qa/shots` are gitignored, matching
`dynawalla/games/slice` and `.../siege`.

## Proof

Run in `dynawalla/games/guilty/` after `npm install`:

```
$ npm test
# tests 14 # pass 14 # fail 0 

$ npm run tsc          # tsc --noEmit
0 errors

$ npm run build
✓ built in 169ms
```

Scope check — the branch adds this game and nothing else:

```
$ git diff --name-only origin/main...HEAD | grep -cv '^dynawalla/games/guilty/'
0
$ git diff --diff-filter=D --name-only origin/main...HEAD | wc -l
0
```
