### PR TITLE
dynawalla/games/serpent: SERPENT — a deep-sea snake that eats only what satisfies the condition

### DIFF
--- a/dynawalla/games/serpent/.gitignore
+++ b/dynawalla/games/serpent/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+dist-pack/
+
+# Playtest capture output: multi-MB PNGs, regenerated on demand.
+qa/shots
+qa/tmp
+
+# Not tracked, matching dynawalla/games/slice and .../merge. These prototypes
+# pin nothing beyond vite + typescript in devDependencies.
+package-lock.json

--- a/dynawalla/games/serpent/index.html
+++ b/dynawalla/games/serpent/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no, maximum-scale=1"
+    />
+    <meta name="color-scheme" content="dark" />
+    <title>Serpent</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        background: #01060c;
+        overflow: hidden;
+        overscroll-behavior: none;
+        touch-action: none;
+        -webkit-user-select: none;
+        user-select: none;
+        -webkit-tap-highlight-color: transparent;
+      }
+      #stage {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="stage"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/serpent/package.json
+++ b/dynawalla/games/serpent/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@dynawalla/game-serpent",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Serpent — a bioluminescent deep-sea snake. Eat only the values that satisfy the live condition.",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 5291",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\""
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "typescript": "~6.0.3",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/games/serpent/src/contract.ts
+++ b/dynawalla/games/serpent/src/contract.ts
@@ -1,0 +1,40 @@
+/**
+ * The host contract.
+ *
+ * This is a verbatim local copy of the shape a shared `@dynawalla/game-contract`
+ * package will provide. Keep it EXACTLY this shape so the swap is a one-line
+ * import change. Nothing in this file may grow a Serpent-specific field.
+ */
+
+export type Question = {
+  id: string;
+  /** "15 − 8" — the condition, rendered huge on the arena floor. */
+  prompt: string;
+  /** "7" — exact, canonical. The value of one orb that satisfies `prompt`. */
+  answer: string;
+  /** Plausible wrong answers, ideally real mal-rule outputs. */
+  distractors: string[];
+  /** "add-sub" | "mult-div" | "multiples" | "fractions" | ... */
+  domain: string;
+  /** 0..1 */
+  difficulty: number;
+};
+
+export type Report = {
+  questionId: string;
+  correct: boolean;
+  ms: number;
+  answered: string;
+};
+
+export type Host = {
+  /** Pull the next question. */
+  next(): Question;
+  report(r: Report): void;
+  haptic(kind: "light" | "medium" | "heavy" | "success" | "failure"): void;
+  prefersReducedMotion(): boolean;
+};
+
+export type Mounted = { unmount(): void };
+
+export type MountFn = (el: HTMLElement, host: Host) => Mounted;

--- a/dynawalla/games/serpent/src/game/audio.ts
+++ b/dynawalla/games/serpent/src/game/audio.ts
@@ -1,0 +1,416 @@
+/**
+ * Procedural audio. No files, no network, nothing to load.
+ *
+ * Every sound is built the same way — transient, body, tail — because that is
+ * what stops a sound fatiguing after the two-hundredth pickup:
+ *   · transient: a few milliseconds of filtered noise. The "click" of contact.
+ *   · body:      a pitched oscillator. The identity of the event.
+ *   · tail:      a quiet, longer partial into a delay network. The room.
+ * Pitch moves with the combo and every event is detuned a few cents at random,
+ * so no two bites are acoustically identical.
+ *
+ * Nothing here ever carries information on its own: every sound has a visual
+ * twin (bloom, shard burst, ring, body length), and the whole system can be
+ * switched off without losing a single piece of game state.
+ */
+
+const STORE_KEY = "serpent.sound";
+
+/** Major pentatonic, ascending — the combo ladder. */
+const COMBO_SEMITONES = [0, 2, 4, 7, 9, 12, 14, 16, 19];
+const BASE_HZ = 349.228; // F4
+
+export type Audio = {
+  enabled: boolean;
+  ready: boolean;
+  resume(): void;
+  setEnabled(on: boolean): void;
+  eat(step: number): void;
+  wrong(): void;
+  wall(): void;
+  graze(): void;
+  depth(n: number): void;
+  mutate(): void;
+  shield(): void;
+  shieldBreak(): void;
+  death(): void;
+  setBoost(on: boolean): void;
+  ambient(on: boolean): void;
+  dispose(): void;
+};
+
+type Ctx = {
+  ac: AudioContext;
+  master: GainNode;
+  wet: GainNode;
+  noise: AudioBuffer;
+  boostGain: GainNode;
+  boostFilter: BiquadFilterNode;
+  droneGain: GainNode;
+  nodes: AudioNode[];
+};
+
+function readStored(): boolean {
+  try {
+    return localStorage.getItem(STORE_KEY) !== "off";
+  } catch {
+    return true;
+  }
+}
+
+export function createAudio(): Audio {
+  let ctx: Ctx | null = null;
+  let enabled = readStored();
+  let disposed = false;
+
+  function build(): Ctx | null {
+    if (disposed) return null;
+    const AC: typeof AudioContext | undefined =
+      typeof window === "undefined"
+        ? undefined
+        : window.AudioContext ??
+          (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AC) return null;
+    const ac = new AC();
+
+    const limiter = ac.createDynamicsCompressor();
+    limiter.threshold.value = -10;
+    limiter.knee.value = 12;
+    limiter.ratio.value = 8;
+    limiter.attack.value = 0.004;
+    limiter.release.value = 0.14;
+    limiter.connect(ac.destination);
+
+    const master = ac.createGain();
+    master.gain.value = 0.55;
+    master.connect(limiter);
+
+    // A two-tap feedback delay standing in for the water. Cheap, and it is what
+    // makes a 40ms blip sound like it happened somewhere rather than in a box.
+    const wet = ac.createGain();
+    wet.gain.value = 0.34;
+    const d1 = ac.createDelay(1);
+    d1.delayTime.value = 0.17;
+    const d2 = ac.createDelay(1);
+    d2.delayTime.value = 0.263;
+    const fb = ac.createGain();
+    fb.gain.value = 0.33;
+    const lp = ac.createBiquadFilter();
+    lp.type = "lowpass";
+    lp.frequency.value = 1500;
+    wet.connect(d1);
+    wet.connect(d2);
+    d1.connect(lp);
+    d2.connect(lp);
+    lp.connect(fb);
+    fb.connect(d1);
+    fb.connect(d2);
+    lp.connect(master);
+
+    const len = Math.floor(ac.sampleRate * 1.2);
+    const noise = ac.createBuffer(1, len, ac.sampleRate);
+    const ch = noise.getChannelData(0);
+    for (let i = 0; i < len; i++) ch[i] = Math.random() * 2 - 1;
+
+    // Boost: one long-running filtered noise source whose gain and cutoff are
+    // ramped. Starting a source per boost would click.
+    const boostSrc = ac.createBufferSource();
+    boostSrc.buffer = noise;
+    boostSrc.loop = true;
+    const boostFilter = ac.createBiquadFilter();
+    boostFilter.type = "bandpass";
+    boostFilter.frequency.value = 420;
+    boostFilter.Q.value = 0.8;
+    const boostGain = ac.createGain();
+    boostGain.gain.value = 0;
+    boostSrc.connect(boostFilter);
+    boostFilter.connect(boostGain);
+    boostGain.connect(master);
+    boostGain.connect(wet);
+    boostSrc.start();
+
+    const droneGain = ac.createGain();
+    droneGain.gain.value = 0;
+    droneGain.connect(master);
+    const droneNodes: AudioNode[] = [];
+    for (const [hz, detune] of [
+      [55, 0],
+      [82.5, 6],
+      [110, -8],
+    ] as Array<[number, number]>) {
+      const o = ac.createOscillator();
+      o.type = "sine";
+      o.frequency.value = hz;
+      o.detune.value = detune;
+      const g = ac.createGain();
+      g.gain.value = hz === 55 ? 0.5 : 0.22;
+      o.connect(g);
+      g.connect(droneGain);
+      o.start();
+      droneNodes.push(o, g);
+    }
+    // A slow swell so the drone never sits perfectly still.
+    const lfo = ac.createOscillator();
+    lfo.frequency.value = 0.06;
+    const lfoGain = ac.createGain();
+    lfoGain.gain.value = 0.05;
+    lfo.connect(lfoGain);
+    lfoGain.connect(droneGain.gain);
+    lfo.start();
+
+    return {
+      ac,
+      master,
+      wet,
+      noise,
+      boostGain,
+      boostFilter,
+      droneGain,
+      nodes: [boostSrc, lfo, lfoGain, ...droneNodes],
+    };
+  }
+
+  function live(): Ctx | null {
+    if (!enabled || disposed) return null;
+    if (!ctx) ctx = build();
+    if (ctx && ctx.ac.state === "suspended") void ctx.ac.resume();
+    return ctx;
+  }
+
+  function tone(
+    c: Ctx,
+    type: OscillatorType,
+    hz: number,
+    at: number,
+    dur: number,
+    gain: number,
+    detuneCents = 0,
+    wetSend = 0.5,
+  ): void {
+    const o = c.ac.createOscillator();
+    o.type = type;
+    o.frequency.setValueAtTime(hz, at);
+    o.detune.value = detuneCents;
+    const g = c.ac.createGain();
+    g.gain.setValueAtTime(0.0001, at);
+    g.gain.exponentialRampToValueAtTime(Math.max(gain, 0.0002), at + 0.006);
+    g.gain.exponentialRampToValueAtTime(0.0001, at + dur);
+    o.connect(g);
+    g.connect(c.master);
+    if (wetSend > 0) {
+      const w = c.ac.createGain();
+      w.gain.value = wetSend;
+      g.connect(w);
+      w.connect(c.wet);
+    }
+    o.start(at);
+    o.stop(at + dur + 0.05);
+  }
+
+  function sweep(
+    c: Ctx,
+    type: OscillatorType,
+    fromHz: number,
+    toHz: number,
+    at: number,
+    dur: number,
+    gain: number,
+  ): void {
+    const o = c.ac.createOscillator();
+    o.type = type;
+    o.frequency.setValueAtTime(fromHz, at);
+    o.frequency.exponentialRampToValueAtTime(Math.max(toHz, 20), at + dur);
+    const g = c.ac.createGain();
+    g.gain.setValueAtTime(0.0001, at);
+    g.gain.exponentialRampToValueAtTime(gain, at + 0.02);
+    g.gain.exponentialRampToValueAtTime(0.0001, at + dur);
+    o.connect(g);
+    g.connect(c.master);
+    const w = c.ac.createGain();
+    w.gain.value = 0.6;
+    g.connect(w);
+    w.connect(c.wet);
+    o.start(at);
+    o.stop(at + dur + 0.05);
+  }
+
+  function burst(
+    c: Ctx,
+    at: number,
+    dur: number,
+    gain: number,
+    filter: BiquadFilterType,
+    hz: number,
+    q: number,
+    hzEnd?: number,
+  ): void {
+    const s = c.ac.createBufferSource();
+    s.buffer = c.noise;
+    s.playbackRate.value = 0.8 + Math.random() * 0.5;
+    const f = c.ac.createBiquadFilter();
+    f.type = filter;
+    f.frequency.setValueAtTime(hz, at);
+    if (hzEnd !== undefined) f.frequency.exponentialRampToValueAtTime(Math.max(hzEnd, 30), at + dur);
+    f.Q.value = q;
+    const g = c.ac.createGain();
+    g.gain.setValueAtTime(gain, at);
+    g.gain.exponentialRampToValueAtTime(0.0001, at + dur);
+    s.connect(f);
+    f.connect(g);
+    g.connect(c.master);
+    const w = c.ac.createGain();
+    w.gain.value = 0.45;
+    g.connect(w);
+    w.connect(c.wet);
+    s.start(at);
+    s.stop(at + dur + 0.05);
+  }
+
+  const api: Audio = {
+    get enabled() {
+      return enabled;
+    },
+    get ready() {
+      return ctx !== null;
+    },
+
+    resume(): void {
+      live();
+    },
+
+    setEnabled(on: boolean): void {
+      enabled = on;
+      try {
+        localStorage.setItem(STORE_KEY, on ? "on" : "off");
+      } catch {
+        /* private mode is not an error */
+      }
+      if (!on && ctx) {
+        ctx.master.gain.value = 0;
+        ctx.droneGain.gain.value = 0;
+      } else if (on && ctx) {
+        ctx.master.gain.value = 0.55;
+      }
+    },
+
+    eat(step: number): void {
+      const c = live();
+      if (!c) return;
+      const t = c.ac.currentTime;
+      const semi = COMBO_SEMITONES[Math.min(step, COMBO_SEMITONES.length - 1)] as number;
+      const hz = BASE_HZ * 2 ** (semi / 12);
+      const cents = (Math.random() - 0.5) * 22;
+      burst(c, t, 0.035, 0.16, "bandpass", 2400 + Math.random() * 900, 1.6);
+      tone(c, "triangle", hz, t, 0.16, 0.24, cents, 0.35);
+      tone(c, "sine", hz * 2, t + 0.01, 0.34, 0.09, cents, 0.8);
+    },
+
+    wrong(): void {
+      const c = live();
+      if (!c) return;
+      const t = c.ac.currentTime;
+      burst(c, t, 0.14, 0.3, "lowpass", 900, 1, 160);
+      sweep(c, "sawtooth", 196, 116, t, 0.28, 0.16);
+      sweep(c, "sawtooth", 190, 112, t + 0.005, 0.3, 0.13);
+      tone(c, "sine", 62, t, 0.34, 0.22, 0, 0.3);
+    },
+
+    /** The vent wall: a stone thud with a mineral scrape over it. */
+    wall(): void {
+      const c = live();
+      if (!c) return;
+      const t = c.ac.currentTime;
+      burst(c, t, 0.18, 0.34, "lowpass", 420, 1.2, 90);
+      burst(c, t + 0.01, 0.22, 0.12, "bandpass", 2600, 3.4, 900);
+      sweep(c, "triangle", 150, 58, t, 0.3, 0.2);
+    },
+
+    graze(): void {
+      const c = live();
+      if (!c) return;
+      const t = c.ac.currentTime;
+      tone(c, "sine", 1760 + Math.random() * 260, t, 0.07, 0.045, 0, 0.7);
+    },
+
+    depth(n: number): void {
+      const c = live();
+      if (!c) return;
+      const t = c.ac.currentTime;
+      const root = BASE_HZ * 2 ** (((n % 5) * 2) / 12);
+      [0, 4, 7, 12].forEach((semi, i) => {
+        tone(c, "triangle", root * 2 ** (semi / 12), t + i * 0.075, 0.4, 0.15, (Math.random() - 0.5) * 14, 0.8);
+      });
+      burst(c, t, 0.5, 0.1, "highpass", 600, 0.7, 3000);
+    },
+
+    mutate(): void {
+      const c = live();
+      if (!c) return;
+      const t = c.ac.currentTime;
+      sweep(c, "sine", 620, 150, t, 0.4, 0.14);
+      burst(c, t + 0.06, 0.55, 0.16, "bandpass", 300, 0.9, 2600);
+      tone(c, "triangle", BASE_HZ * 1.5, t + 0.42, 0.5, 0.16, 0, 0.9);
+      tone(c, "sine", BASE_HZ * 3, t + 0.46, 0.6, 0.07, 0, 0.9);
+    },
+
+    shield(): void {
+      const c = live();
+      if (!c) return;
+      const t = c.ac.currentTime;
+      tone(c, "sine", 880, t, 0.55, 0.16, 0, 0.9);
+      tone(c, "sine", 1320, t + 0.02, 0.7, 0.1, 4, 0.9);
+      burst(c, t, 0.2, 0.08, "highpass", 2200, 0.6);
+    },
+
+    shieldBreak(): void {
+      const c = live();
+      if (!c) return;
+      const t = c.ac.currentTime;
+      burst(c, t, 0.26, 0.34, "bandpass", 3200, 2.2, 700);
+      sweep(c, "square", 700, 180, t, 0.24, 0.12);
+    },
+
+    death(): void {
+      const c = live();
+      if (!c) return;
+      const t = c.ac.currentTime;
+      sweep(c, "sawtooth", 320, 42, t, 1.1, 0.2);
+      sweep(c, "sine", 240, 36, t + 0.02, 1.3, 0.16);
+      burst(c, t, 1.0, 0.3, "lowpass", 2600, 0.9, 90);
+    },
+
+    setBoost(on: boolean): void {
+      const c = live();
+      if (!c) return;
+      const t = c.ac.currentTime;
+      c.boostGain.gain.cancelScheduledValues(t);
+      c.boostGain.gain.setTargetAtTime(on ? 0.1 : 0, t, on ? 0.03 : 0.09);
+      c.boostFilter.frequency.cancelScheduledValues(t);
+      c.boostFilter.frequency.setTargetAtTime(on ? 900 : 380, t, 0.08);
+    },
+
+    ambient(on: boolean): void {
+      const c = live();
+      if (!c) return;
+      c.droneGain.gain.setTargetAtTime(on ? 0.11 : 0, c.ac.currentTime, 0.6);
+    },
+
+    dispose(): void {
+      disposed = true;
+      if (ctx) {
+        try {
+          for (const n of ctx.nodes) {
+            const s = n as AudioScheduledSourceNode;
+            if (typeof s.stop === "function") s.stop();
+          }
+          void ctx.ac.close();
+        } catch {
+          /* closing an already-dead context is not an error */
+        }
+        ctx = null;
+      }
+    },
+  };
+
+  return api;
+}

--- a/dynawalla/games/serpent/src/game/fx/camera.ts
+++ b/dynawalla/games/serpent/src/game/fx/camera.ts
@@ -1,0 +1,131 @@
+/**
+ * The camera and the time base — where most of the "feel" actually lives.
+ *
+ * Four techniques from Vlambeer's *Art of Screenshake*, kept honest:
+ *   · trauma-based shake — shake = trauma², decaying linearly, so small hits
+ *     barely register and big ones slam. Squaring is what stops the screen
+ *     jittering constantly.
+ *   · hitstop — the *world* freezes for a few frames on impact while the
+ *     presentation keeps running. The single cheapest way to make a hit land.
+ *   · camera punch — a spring on zoom, not a lerp, so it overshoots and settles.
+ *   · slow motion — reserved for the two moments that deserve it.
+ *
+ * Reduced motion collapses shake, punch and slow-mo to nothing. Hitstop stays
+ * (at 60%): it is felt as responsiveness, not seen as movement.
+ */
+
+import { TUNE } from "../tuning.ts";
+import { clamp, noise1 } from "../num.ts";
+
+export type Camera = {
+  trauma: number;
+  shakeX: number;
+  shakeY: number;
+  zoom: number;
+  punch: number;
+  punchVel: number;
+  /** Multiplier applied to simulation dt. 1 = normal. */
+  timeScale: number;
+  slowmoLeft: number;
+  slowmoTotal: number;
+  slowmoScale: number;
+  hitstopLeft: number;
+  flashAlpha: number;
+  flashColor: string;
+  flashCooldown: number;
+  reduced: boolean;
+  t: number;
+};
+
+export function createCamera(reduced: boolean): Camera {
+  return {
+    trauma: 0,
+    shakeX: 0,
+    shakeY: 0,
+    zoom: 1,
+    punch: 0,
+    punchVel: 0,
+    timeScale: 1,
+    slowmoLeft: 0,
+    slowmoTotal: 0,
+    slowmoScale: 1,
+    hitstopLeft: 0,
+    flashAlpha: 0,
+    flashColor: "#ffffff",
+    flashCooldown: 0,
+    reduced,
+    t: 0,
+  };
+}
+
+export function addTrauma(cam: Camera, amount: number): void {
+  if (cam.reduced) return;
+  cam.trauma = clamp(cam.trauma + amount, 0, 1);
+}
+
+export function punch(cam: Camera, amount: number): void {
+  if (cam.reduced) return;
+  cam.punchVel += amount;
+}
+
+export function hitstop(cam: Camera, ms: number): void {
+  const scaled = cam.reduced ? ms * 0.6 : ms;
+  cam.hitstopLeft = Math.max(cam.hitstopLeft, scaled / 1000);
+}
+
+export function slowmo(cam: Camera, seconds: number, scale: number): void {
+  if (cam.reduced) return;
+  cam.slowmoLeft = Math.max(cam.slowmoLeft, seconds);
+  cam.slowmoTotal = Math.max(cam.slowmoTotal, seconds);
+  cam.slowmoScale = scale;
+}
+
+/**
+ * A full-screen tint. Hard-limited for photosensitivity: never more than one
+ * every 340ms, never above 0.22 alpha, never white-on-black. This is a
+ * children's product and three flashes a second is the published ceiling.
+ */
+export function flash(cam: Camera, color: string, alpha: number): void {
+  if (cam.reduced) return;
+  if (cam.flashCooldown > 0) return;
+  cam.flashColor = color;
+  cam.flashAlpha = Math.min(alpha, TUNE.flashMaxAlpha);
+  cam.flashCooldown = TUNE.flashCooldown;
+}
+
+/** Advance presentation state. Always called with *real* dt, never scaled. */
+export function updateCamera(cam: Camera, dt: number): void {
+  cam.t += dt;
+
+  if (cam.hitstopLeft > 0) cam.hitstopLeft = Math.max(0, cam.hitstopLeft - dt);
+
+  if (cam.slowmoLeft > 0) {
+    cam.slowmoLeft = Math.max(0, cam.slowmoLeft - dt);
+    const k = cam.slowmoTotal > 0 ? cam.slowmoLeft / cam.slowmoTotal : 0;
+    // Ease back to real time rather than snapping, or the return reads as a lag spike.
+    cam.timeScale = cam.slowmoScale + (1 - cam.slowmoScale) * (1 - k) ** 2;
+  } else {
+    cam.timeScale = 1;
+  }
+
+  cam.trauma = Math.max(0, cam.trauma - TUNE.traumaDecay * dt);
+  const shake = cam.trauma * cam.trauma * TUNE.shakeMax;
+  cam.shakeX = shake * noise1(cam.t * 22, 1.7);
+  cam.shakeY = shake * noise1(cam.t * 22, 9.3);
+
+  // Critically-damped-ish spring on zoom.
+  const stiffness = 190;
+  const damping = 19;
+  cam.punchVel += -stiffness * cam.punch * dt - damping * cam.punchVel * dt;
+  cam.punch += cam.punchVel * dt;
+  cam.zoom = 1 + cam.punch;
+
+  if (cam.flashCooldown > 0) cam.flashCooldown = Math.max(0, cam.flashCooldown - dt);
+  if (cam.flashAlpha > 0) cam.flashAlpha = Math.max(0, cam.flashAlpha - dt * 3.4);
+}
+
+/** Simulation dt for this frame: zero during hitstop, scaled during slow-mo. */
+export function simDelta(cam: Camera, dt: number): number {
+  if (cam.hitstopLeft > 0) return 0;
+  return dt * cam.timeScale;
+}

--- a/dynawalla/games/serpent/src/game/fx/particles.ts
+++ b/dynawalla/games/serpent/src/game/fx/particles.ts
@@ -1,0 +1,284 @@
+/**
+ * Pooled particles. Structure-of-arrays, swap-remove, fixed cap, zero
+ * allocation after construction — the budget is a hard number, not a hope.
+ *
+ * Four kinds, all drawn from four pre-rendered sprites, so the whole system is
+ * one `drawImage` per particle with `lighter` compositing and no per-frame
+ * gradient construction anywhere.
+ */
+
+import { TAU, randRange } from "../num.ts";
+
+export const PK_MOTE = 0;
+export const PK_SPARK = 1;
+export const PK_SHARD = 2;
+export const PK_BUBBLE = 3;
+
+export const PC_GOOD = 0;
+export const PC_BAD = 1;
+export const PC_SERPENT = 2;
+export const PC_WHITE = 3;
+export const PC_PLANKTON = 4;
+export const PC_HOT = 5;
+
+export type Particles = {
+  x: Float32Array;
+  y: Float32Array;
+  vx: Float32Array;
+  vy: Float32Array;
+  life: Float32Array;
+  maxLife: Float32Array;
+  size: Float32Array;
+  rot: Float32Array;
+  spin: Float32Array;
+  kind: Uint8Array;
+  color: Uint8Array;
+  count: number;
+  cap: number;
+  /** 0..1 multiplier on every spawn count. Reduced motion turns this down. */
+  density: number;
+};
+
+export function createParticles(cap: number, density = 1): Particles {
+  return {
+    x: new Float32Array(cap),
+    y: new Float32Array(cap),
+    vx: new Float32Array(cap),
+    vy: new Float32Array(cap),
+    life: new Float32Array(cap),
+    maxLife: new Float32Array(cap),
+    size: new Float32Array(cap),
+    rot: new Float32Array(cap),
+    spin: new Float32Array(cap),
+    kind: new Uint8Array(cap),
+    color: new Uint8Array(cap),
+    count: 0,
+    cap,
+    density,
+  };
+}
+
+export function clearParticles(p: Particles): void {
+  p.count = 0;
+}
+
+function spawn(
+  p: Particles,
+  x: number,
+  y: number,
+  vx: number,
+  vy: number,
+  life: number,
+  size: number,
+  kind: number,
+  color: number,
+): void {
+  if (p.count >= p.cap) return;
+  const i = p.count++;
+  p.x[i] = x;
+  p.y[i] = y;
+  p.vx[i] = vx;
+  p.vy[i] = vy;
+  p.life[i] = life;
+  p.maxLife[i] = life;
+  p.size[i] = size;
+  p.rot[i] = randRange(0, TAU);
+  p.spin[i] = randRange(-7, 7);
+  p.kind[i] = kind;
+  p.color[i] = color;
+}
+
+const scaled = (p: Particles, n: number): number => Math.max(1, Math.round(n * p.density));
+
+/** A correct bite: a tight gold bloom that reads instantly at any zoom. */
+export function burstEat(p: Particles, x: number, y: number, power: number): void {
+  const n = scaled(p, 14 + power * 8);
+  for (let i = 0; i < n; i++) {
+    const a = randRange(0, TAU);
+    const s = randRange(0.14, 0.5) * (0.8 + power * 0.5);
+    spawn(p, x, y, Math.cos(a) * s, Math.sin(a) * s, randRange(0.25, 0.6), randRange(0.006, 0.017), PK_SPARK, PC_GOOD);
+  }
+  for (let i = 0; i < scaled(p, 6); i++) {
+    const a = randRange(0, TAU);
+    const s = randRange(0.03, 0.14);
+    spawn(p, x, y, Math.cos(a) * s, Math.sin(a) * s, randRange(0.5, 1.1), randRange(0.02, 0.045), PK_MOTE, PC_GOOD);
+  }
+}
+
+/** A wrong bite: violet shards thrown outward, plus the length you coughed up. */
+export function burstBad(p: Particles, x: number, y: number): void {
+  const n = scaled(p, 20);
+  for (let i = 0; i < n; i++) {
+    const a = randRange(0, TAU);
+    const s = randRange(0.2, 0.72);
+    spawn(p, x, y, Math.cos(a) * s, Math.sin(a) * s, randRange(0.35, 0.85), randRange(0.01, 0.03), PK_SHARD, PC_BAD);
+  }
+  for (let i = 0; i < scaled(p, 8); i++) {
+    const a = randRange(0, TAU);
+    const s = randRange(0.02, 0.1);
+    spawn(p, x, y, Math.cos(a) * s, Math.sin(a) * s, randRange(0.6, 1.4), randRange(0.025, 0.06), PK_MOTE, PC_BAD);
+  }
+}
+
+/** Body you lost, spat out along the heading so the cost is legible. */
+export function burstDebris(p: Particles, x: number, y: number, heading: number, n: number): void {
+  for (let i = 0; i < scaled(p, n); i++) {
+    const a = heading + Math.PI + randRange(-0.7, 0.7);
+    const s = randRange(0.16, 0.44);
+    spawn(p, x, y, Math.cos(a) * s, Math.sin(a) * s, randRange(0.7, 1.5), randRange(0.014, 0.028), PK_MOTE, PC_SERPENT);
+  }
+}
+
+export function burstSpark(p: Particles, x: number, y: number, heading: number, color: number): void {
+  const a = heading + Math.PI + randRange(-0.5, 0.5);
+  const s = randRange(0.05, 0.22);
+  spawn(p, x, y, Math.cos(a) * s, Math.sin(a) * s, randRange(0.18, 0.42), randRange(0.005, 0.013), PK_SPARK, color);
+}
+
+export function burstDeath(p: Particles, x: number, y: number): void {
+  for (let i = 0; i < scaled(p, 46); i++) {
+    const a = randRange(0, TAU);
+    const s = randRange(0.1, 0.9);
+    spawn(p, x, y, Math.cos(a) * s, Math.sin(a) * s, randRange(0.8, 2.2), randRange(0.008, 0.03), PK_SPARK, PC_WHITE);
+  }
+  for (let i = 0; i < scaled(p, 24); i++) {
+    const a = randRange(0, TAU);
+    const s = randRange(0.04, 0.3);
+    spawn(p, x, y, Math.cos(a) * s, Math.sin(a) * s, randRange(1.2, 2.6), randRange(0.02, 0.055), PK_MOTE, PC_SERPENT);
+  }
+}
+
+export function burstBubbles(p: Particles, x: number, y: number, n: number): void {
+  for (let i = 0; i < scaled(p, n); i++) {
+    spawn(
+      p,
+      x + randRange(-0.03, 0.03),
+      y + randRange(-0.03, 0.03),
+      randRange(-0.03, 0.03),
+      randRange(-0.14, -0.05),
+      randRange(0.9, 1.8),
+      randRange(0.004, 0.011),
+      PK_BUBBLE,
+      PC_PLANKTON,
+    );
+  }
+}
+
+export function updateParticles(p: Particles, dt: number): void {
+  const drag = Math.exp(-2.1 * dt);
+  for (let i = 0; i < p.count; i++) {
+    const life = (p.life[i] as number) - dt;
+    if (life <= 0) {
+      const last = --p.count;
+      if (i !== last) {
+        p.x[i] = p.x[last] as number;
+        p.y[i] = p.y[last] as number;
+        p.vx[i] = p.vx[last] as number;
+        p.vy[i] = p.vy[last] as number;
+        p.life[i] = p.life[last] as number;
+        p.maxLife[i] = p.maxLife[last] as number;
+        p.size[i] = p.size[last] as number;
+        p.rot[i] = p.rot[last] as number;
+        p.spin[i] = p.spin[last] as number;
+        p.kind[i] = p.kind[last] as number;
+        p.color[i] = p.color[last] as number;
+      }
+      i--;
+      continue;
+    }
+    p.life[i] = life;
+    const k = p.kind[i] as number;
+    let vx = p.vx[i] as number;
+    let vy = p.vy[i] as number;
+    if (k === PK_BUBBLE) {
+      vy -= 0.05 * dt;
+      vx += Math.sin(life * 6 + (p.rot[i] as number)) * 0.02 * dt;
+    } else {
+      vx *= drag;
+      vy *= drag;
+    }
+    p.vx[i] = vx;
+    p.vy[i] = vy;
+    p.x[i] = (p.x[i] as number) + vx * dt;
+    p.y[i] = (p.y[i] as number) + vy * dt;
+    p.rot[i] = (p.rot[i] as number) + (p.spin[i] as number) * dt;
+  }
+}
+
+// ---------------------------------------------------------------- shockwaves
+
+export type Rings = {
+  x: Float32Array;
+  y: Float32Array;
+  life: Float32Array;
+  maxLife: Float32Array;
+  from: Float32Array;
+  to: Float32Array;
+  width: Float32Array;
+  color: Uint8Array;
+  count: number;
+  cap: number;
+};
+
+export function createRings(cap: number): Rings {
+  return {
+    x: new Float32Array(cap),
+    y: new Float32Array(cap),
+    life: new Float32Array(cap),
+    maxLife: new Float32Array(cap),
+    from: new Float32Array(cap),
+    to: new Float32Array(cap),
+    width: new Float32Array(cap),
+    color: new Uint8Array(cap),
+    count: 0,
+    cap,
+  };
+}
+
+export function ring(
+  r: Rings,
+  x: number,
+  y: number,
+  from: number,
+  to: number,
+  life: number,
+  width: number,
+  color: number,
+): void {
+  if (r.count >= r.cap) return;
+  const i = r.count++;
+  r.x[i] = x;
+  r.y[i] = y;
+  r.from[i] = from;
+  r.to[i] = to;
+  r.life[i] = life;
+  r.maxLife[i] = life;
+  r.width[i] = width;
+  r.color[i] = color;
+}
+
+export function updateRings(rg: Rings, dt: number): void {
+  for (let i = 0; i < rg.count; i++) {
+    const life = (rg.life[i] as number) - dt;
+    if (life <= 0) {
+      const last = --rg.count;
+      if (i !== last) {
+        rg.x[i] = rg.x[last] as number;
+        rg.y[i] = rg.y[last] as number;
+        rg.life[i] = rg.life[last] as number;
+        rg.maxLife[i] = rg.maxLife[last] as number;
+        rg.from[i] = rg.from[last] as number;
+        rg.to[i] = rg.to[last] as number;
+        rg.width[i] = rg.width[last] as number;
+        rg.color[i] = rg.color[last] as number;
+      }
+      i--;
+      continue;
+    }
+    rg.life[i] = life;
+  }
+}
+
+export function clearRings(r: Rings): void {
+  r.count = 0;
+}

--- a/dynawalla/games/serpent/src/game/input.ts
+++ b/dynawalla/games/serpent/src/game/input.ts
@@ -1,0 +1,253 @@
+/**
+ * Two control schemes, designed separately, both first class.
+ *
+ * Mouse: absolute aim. The head turns toward the cursor, always, with no click
+ * needed. Hold any button (or Space / Shift) to boost. A mouse has a cursor
+ * already on screen — pointing at where you want to go is the whole idea.
+ *
+ * Touch: a floating relative stick. Wherever the thumb lands becomes the
+ * origin; the serpent swims in the direction you drag. Absolute touch aiming
+ * would put your hand over the thing you are steering at, which is why every
+ * good mobile snake uses a relative stick. Shove the stick past 72% of its
+ * travel — or put a second finger down anywhere — to boost, so the whole game
+ * is one thumb.
+ *
+ * Keyboard: eight-way, for players who want it. It overrides the mouse while a
+ * key is held and hands control back when released.
+ */
+
+import { TAU, clamp } from "./num.ts";
+
+export type Pointer = {
+  active: boolean;
+  anchorX: number;
+  anchorY: number;
+  dx: number;
+  dy: number;
+  /** 0..1 how far the stick is pushed. */
+  push: number;
+};
+
+export type Input = {
+  /** Desired heading in radians, or null to hold the current one. */
+  heading: number | null;
+  boost: boolean;
+  pointer: Pointer;
+  /** True for one read after a confirm (tap / click / Space / Enter). */
+  takeConfirm(): boolean;
+  /** True for one read after the sound key. */
+  takeMute(): boolean;
+  takeDebug(): boolean;
+  takePause(): boolean;
+  /** Latest world-space cursor, used by the mouse scheme. */
+  setWorldCursor(x: number, y: number): void;
+  usingTouch: boolean;
+  dispose(): void;
+};
+
+const STICK_RADIUS = 96; // CSS px of travel for a full push
+const STICK_DEADZONE = 9;
+const BOOST_PUSH = 0.72;
+
+type Opts = {
+  /** Convert a client point to world units. */
+  toWorld(clientX: number, clientY: number): { x: number; y: number };
+  /** Current serpent head, world units — the mouse aims relative to it. */
+  headAt(): { x: number; y: number };
+};
+
+export function createInput(el: HTMLElement, opts: Opts): Input {
+  const pointer: Pointer = { active: false, anchorX: 0, anchorY: 0, dx: 0, dy: 0, push: 0 };
+  const keys = new Set<string>();
+  let confirm = false;
+  let mute = false;
+  let debug = false;
+  let pause = false;
+  let mouseHeading: number | null = null;
+  let mouseBoost = false;
+  let usingTouch = false;
+  let stickId = -1;
+  let extraTouches = 0;
+
+  const state: Input = {
+    heading: null,
+    boost: false,
+    pointer,
+    takeConfirm() {
+      const v = confirm;
+      confirm = false;
+      return v;
+    },
+    takeMute() {
+      const v = mute;
+      mute = false;
+      return v;
+    },
+    takeDebug() {
+      const v = debug;
+      debug = false;
+      return v;
+    },
+    takePause() {
+      const v = pause;
+      pause = false;
+      return v;
+    },
+    setWorldCursor(x: number, y: number) {
+      const h = opts.headAt();
+      const dx = x - h.x;
+      const dy = y - h.y;
+      if (dx * dx + dy * dy > 0.0009) mouseHeading = Math.atan2(dy, dx);
+    },
+    usingTouch: false,
+    dispose() {
+      el.removeEventListener("pointerdown", onDown);
+      el.removeEventListener("pointermove", onMove);
+      el.removeEventListener("pointerup", onUp);
+      el.removeEventListener("pointercancel", onUp);
+      el.removeEventListener("contextmenu", onContext);
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+      window.removeEventListener("blur", onBlur);
+    },
+  };
+
+  function recompute(): void {
+    // Keyboard wins while held: it is an explicit, deliberate input.
+    let kx = 0;
+    let ky = 0;
+    if (keys.has("ArrowLeft") || keys.has("KeyA")) kx -= 1;
+    if (keys.has("ArrowRight") || keys.has("KeyD")) kx += 1;
+    if (keys.has("ArrowUp") || keys.has("KeyW")) ky -= 1;
+    if (keys.has("ArrowDown") || keys.has("KeyS")) ky += 1;
+
+    if (kx !== 0 || ky !== 0) {
+      state.heading = Math.atan2(ky, kx);
+    } else if (usingTouch) {
+      state.heading = pointer.push > 0 ? Math.atan2(pointer.dy, pointer.dx) : null;
+    } else {
+      state.heading = mouseHeading;
+    }
+
+    state.boost =
+      keys.has("Space") ||
+      keys.has("ShiftLeft") ||
+      keys.has("ShiftRight") ||
+      mouseBoost ||
+      extraTouches > 0 ||
+      (usingTouch && pointer.push >= BOOST_PUSH);
+    state.usingTouch = usingTouch;
+  }
+
+  function onDown(e: PointerEvent): void {
+    confirm = true;
+    try {
+      // Throws if the pointer is not active — which a browser is entitled to
+      // decide mid-gesture. Losing capture must never lose the input.
+      el.setPointerCapture?.(e.pointerId);
+    } catch {
+      /* capture is an optimisation, not a requirement */
+    }
+    if (e.pointerType === "mouse") {
+      usingTouch = false;
+      mouseBoost = true;
+      const w = opts.toWorld(e.clientX, e.clientY);
+      state.setWorldCursor(w.x, w.y);
+    } else {
+      usingTouch = true;
+      if (stickId === -1) {
+        stickId = e.pointerId;
+        pointer.active = true;
+        pointer.anchorX = e.clientX;
+        pointer.anchorY = e.clientY;
+        pointer.dx = 0;
+        pointer.dy = 0;
+        pointer.push = 0;
+      } else {
+        extraTouches++;
+      }
+    }
+    recompute();
+  }
+
+  function onMove(e: PointerEvent): void {
+    if (e.pointerType === "mouse") {
+      usingTouch = false;
+      const w = opts.toWorld(e.clientX, e.clientY);
+      state.setWorldCursor(w.x, w.y);
+    } else if (e.pointerId === stickId) {
+      let dx = e.clientX - pointer.anchorX;
+      let dy = e.clientY - pointer.anchorY;
+      const len = Math.hypot(dx, dy);
+      if (len > STICK_RADIUS) {
+        // Drag the anchor along so a long swipe never runs out of travel.
+        pointer.anchorX += dx * (1 - STICK_RADIUS / len);
+        pointer.anchorY += dy * (1 - STICK_RADIUS / len);
+        dx *= STICK_RADIUS / len;
+        dy *= STICK_RADIUS / len;
+      }
+      pointer.dx = dx;
+      pointer.dy = dy;
+      pointer.push = len < STICK_DEADZONE ? 0 : clamp(Math.min(len, STICK_RADIUS) / STICK_RADIUS, 0, 1);
+    }
+    recompute();
+  }
+
+  function onUp(e: PointerEvent): void {
+    if (e.pointerType === "mouse") {
+      mouseBoost = false;
+    } else if (e.pointerId === stickId) {
+      stickId = -1;
+      pointer.active = false;
+      pointer.push = 0;
+    } else if (extraTouches > 0) {
+      extraTouches--;
+    }
+    recompute();
+  }
+
+  function onContext(e: Event): void {
+    e.preventDefault();
+  }
+
+  function onKeyDown(e: KeyboardEvent): void {
+    if (e.repeat) return;
+    if (e.code === "KeyM") mute = true;
+    if (e.code === "F3" || (e.code === "Backquote" && e.shiftKey)) debug = true;
+    if (e.code === "KeyP" || e.code === "Escape") pause = true;
+    if (e.code === "Space" || e.code === "Enter") confirm = true;
+    if (e.code === "Space" || e.code === "Tab") e.preventDefault();
+    keys.add(e.code);
+    recompute();
+  }
+
+  function onKeyUp(e: KeyboardEvent): void {
+    keys.delete(e.code);
+    recompute();
+  }
+
+  function onBlur(): void {
+    keys.clear();
+    mouseBoost = false;
+    extraTouches = 0;
+    stickId = -1;
+    pointer.active = false;
+    pointer.push = 0;
+    recompute();
+  }
+
+  el.addEventListener("pointerdown", onDown);
+  el.addEventListener("pointermove", onMove);
+  el.addEventListener("pointerup", onUp);
+  el.addEventListener("pointercancel", onUp);
+  el.addEventListener("contextmenu", onContext);
+  window.addEventListener("keydown", onKeyDown);
+  window.addEventListener("keyup", onKeyUp);
+  window.addEventListener("blur", onBlur);
+
+  return state;
+}
+
+export const stickRadiusPx = STICK_RADIUS;
+export const stickBoostPush = BOOST_PUSH;
+export const fullTurn = TAU;

--- a/dynawalla/games/serpent/src/game/mount.ts
+++ b/dynawalla/games/serpent/src/game/mount.ts
@@ -1,0 +1,179 @@
+/**
+ * Wiring: canvas, loop, lifecycle.
+ *
+ * The simulation runs on a fixed 1/120s step with an accumulator so that
+ * collision and turn rate are frame-rate independent; presentation runs on the
+ * real clock so shake, bloom and slow-motion keep moving during hitstop — which
+ * is the entire point of hitstop.
+ */
+
+import type { Host, Mounted } from "../contract.ts";
+import { createAudio } from "./audio.ts";
+import { createInput } from "./input.ts";
+import { simDelta, updateCamera } from "./fx/camera.ts";
+import { createRenderer, type View } from "./render/scene.ts";
+import { drawHud } from "./render/hud.ts";
+import { confirmPressed, createWorld, stepWorld, type World } from "./world.ts";
+import { clamp } from "./num.ts";
+
+const FIXED = 1 / 120;
+const MAX_STEPS = 6;
+
+export type SerpentHandle = Mounted & {
+  /** Test and tooling seam. Not used by the game itself. */
+  world: World;
+  view: View;
+  canvas: HTMLCanvasElement;
+  fps(): number;
+};
+
+export function mountSerpent(el: HTMLElement, host: Host): SerpentHandle {
+  const canvas = document.createElement("canvas");
+  canvas.style.display = "block";
+  canvas.style.width = "100%";
+  canvas.style.height = "100%";
+  canvas.style.touchAction = "none";
+  canvas.style.background = "#01060c";
+  el.appendChild(canvas);
+
+  const reduced = host.prefersReducedMotion();
+  const audio = createAudio();
+  const renderer = createRenderer(canvas);
+  const world = createWorld(host, audio, reduced);
+
+  let lastTapX = 0;
+  let lastTapY = 0;
+  const onTap = (e: PointerEvent): void => {
+    const rect = canvas.getBoundingClientRect();
+    lastTapX = e.clientX - rect.left;
+    lastTapY = e.clientY - rect.top;
+  };
+  canvas.addEventListener("pointerdown", onTap);
+
+  const input = createInput(canvas, {
+    toWorld: (x, y) => renderer.toWorld(x, y, canvas.getBoundingClientRect()),
+    headAt: () => ({ x: world.serpent.x, y: world.serpent.y }),
+  });
+
+  function layout(): void {
+    const rect = el.getBoundingClientRect();
+    const w = Math.max(200, Math.round(rect.width || window.innerWidth));
+    const h = Math.max(200, Math.round(rect.height || window.innerHeight));
+    renderer.resize(w, h, Math.min(window.devicePixelRatio || 1, 2.5));
+  }
+  layout();
+
+  const ro = typeof ResizeObserver !== "undefined" ? new ResizeObserver(() => layout()) : null;
+  ro?.observe(el);
+  window.addEventListener("resize", layout);
+  window.addEventListener("orientationchange", layout);
+
+  const onVisibility = (): void => {
+    if (document.hidden) {
+      if (world.phase === "play") world.paused = true;
+      audio.ambient(false);
+      audio.setBoost(false);
+    } else {
+      audio.ambient(world.phase !== "attract");
+    }
+  };
+  document.addEventListener("visibilitychange", onVisibility);
+
+  // --- frame timing
+  let raf = 0;
+  let last = 0;
+  let acc = 0;
+  const times: number[] = [];
+  let fps = 60;
+  let frameMs = 0;
+  let worstMs = 0;
+  let showDebug = false;
+  let disposed = false;
+
+  function soundHit(x: number, y: number): boolean {
+    const v = renderer.view;
+    const u = Math.min(v.w, v.h);
+    const pad = Math.max(14, u * 0.045);
+    const sr = Math.max(13, u * 0.032);
+    const cx = v.w - pad - sr;
+    const cy = v.h - pad - sr;
+    const box = Math.max(24, sr * 1.9);
+    return Math.abs(x - cx) < box && Math.abs(y - cy) < box;
+  }
+
+  function frame(t: number): void {
+    if (disposed) return;
+    raf = requestAnimationFrame(frame);
+    const start = performance.now();
+    if (last === 0) last = t;
+    const rawDt = clamp((t - last) / 1000, 0, 0.05);
+    last = t;
+
+    if (input.takeMute()) audio.setEnabled(!audio.enabled);
+    if (input.takeDebug()) showDebug = !showDebug;
+    if (input.takePause() && world.phase === "play") world.paused = !world.paused;
+    if (input.takeConfirm()) {
+      if (soundHit(lastTapX, lastTapY)) {
+        audio.setEnabled(!audio.enabled);
+        if (audio.enabled) audio.ambient(world.phase !== "attract");
+      } else if (world.paused) {
+        world.paused = false;
+      } else {
+        audio.resume();
+        confirmPressed(world);
+      }
+    }
+
+    updateCamera(world.cam, rawDt);
+    const sd = world.paused ? 0 : simDelta(world.cam, rawDt);
+    acc += sd;
+    let steps = 0;
+    while (acc >= FIXED && steps < MAX_STEPS) {
+      stepWorld(world, FIXED, { heading: input.heading, boost: input.boost });
+      acc -= FIXED;
+      steps++;
+    }
+    if (steps === MAX_STEPS) acc = 0;
+
+    renderer.draw(world, 0);
+    drawHud(canvas.getContext("2d") as CanvasRenderingContext2D, renderer.view, world, {
+      pointer: input.pointer,
+      usingTouch: input.usingTouch,
+      soundOn: audio.enabled,
+      showDebug,
+      fps,
+      frameMs,
+      worstMs,
+    });
+
+    const cost = performance.now() - start;
+    frameMs = frameMs * 0.9 + cost * 0.1;
+    times.push(rawDt);
+    if (times.length > 90) times.shift();
+    if (times.length > 10) {
+      const sum = times.reduce((a, b) => a + b, 0);
+      fps = times.length / sum;
+    }
+    if (world.phase === "play" && world.runTime > 1.5) worstMs = Math.max(worstMs, cost);
+  }
+  raf = requestAnimationFrame(frame);
+
+  return {
+    world,
+    view: renderer.view,
+    canvas,
+    fps: () => fps,
+    unmount(): void {
+      disposed = true;
+      cancelAnimationFrame(raf);
+      ro?.disconnect();
+      window.removeEventListener("resize", layout);
+      window.removeEventListener("orientationchange", layout);
+      document.removeEventListener("visibilitychange", onVisibility);
+      canvas.removeEventListener("pointerdown", onTap);
+      input.dispose();
+      audio.dispose();
+      canvas.remove();
+    },
+  };
+}

--- a/dynawalla/games/serpent/src/game/num.ts
+++ b/dynawalla/games/serpent/src/game/num.ts
@@ -1,0 +1,44 @@
+/** Small numeric helpers. Presentation only — never touches a graded value. */
+
+export const TAU = Math.PI * 2;
+
+export const clamp = (v: number, lo: number, hi: number): number => (v < lo ? lo : v > hi ? hi : v);
+
+export const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+
+/** Frame-rate independent exponential approach. `rate` is per second. */
+export const approach = (a: number, b: number, rate: number, dt: number): number =>
+  b + (a - b) * Math.exp(-rate * dt);
+
+export function angleDelta(from: number, to: number): number {
+  let d = (to - from) % TAU;
+  if (d > Math.PI) d -= TAU;
+  if (d < -Math.PI) d += TAU;
+  return d;
+}
+
+export const easeOutCubic = (t: number): number => 1 - (1 - t) ** 3;
+export const easeInCubic = (t: number): number => t * t * t;
+export const easeOutExpo = (t: number): number => (t >= 1 ? 1 : 1 - 2 ** (-10 * t));
+export const easeInOutQuad = (t: number): number => (t < 0.5 ? 2 * t * t : 1 - (-2 * t + 2) ** 2 / 2);
+export function easeOutBack(t: number): number {
+  const c1 = 1.70158;
+  const c3 = c1 + 1;
+  return 1 + c3 * (t - 1) ** 3 + c1 * (t - 1) ** 2;
+}
+
+/** Cheap smooth pseudo-noise for shake. Deterministic in `t`. */
+export function noise1(t: number, seed: number): number {
+  return (
+    Math.sin(t * 12.9898 + seed * 78.233) * 0.6 +
+    Math.sin(t * 31.7 + seed * 19.1) * 0.3 +
+    Math.sin(t * 71.3 + seed * 3.7) * 0.1
+  );
+}
+
+/** A visual-only RNG. Kept separate from the question stream on purpose. */
+export function fxRandom(): number {
+  return Math.random();
+}
+
+export const randRange = (lo: number, hi: number): number => lo + Math.random() * (hi - lo);

--- a/dynawalla/games/serpent/src/game/orbs.ts
+++ b/dynawalla/games/serpent/src/game/orbs.ts
@@ -1,0 +1,172 @@
+/**
+ * The orb field — plankton carrying numbers.
+ *
+ * Correctness is never encoded in an orb's appearance. Every orb is the same
+ * creature; the only thing that differs is the value printed on it. That is the
+ * point: the arena is dense with wrong answers you have to swim *through*, so
+ * reading the field is the same act as steering through it. The maze is the
+ * maths.
+ *
+ * Hunters (from depth 5) are a different creature, and they can be right or
+ * wrong — a hunter carrying the value you need, closing on you, is the best
+ * decision in the game.
+ */
+
+import { TAU, randRange } from "./num.ts";
+import { TUNE } from "./tuning.ts";
+
+export type Orb = {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  label: string;
+  good: boolean;
+  hunter: boolean;
+  phase: number;
+  /** 0..1 pop-in / molt-out envelope. */
+  scale: number;
+  /** >0 while molting: shrink to nothing, swap the label, grow back. */
+  moltT: number;
+  moltDur: number;
+  nextLabel: string;
+  nextGood: boolean;
+  bob: number;
+};
+
+export function createOrb(): Orb {
+  return {
+    x: 0,
+    y: 0,
+    vx: 0,
+    vy: 0,
+    label: "",
+    good: false,
+    hunter: false,
+    phase: 0,
+    scale: 0,
+    moltT: 0,
+    moltDur: 0,
+    nextLabel: "",
+    nextGood: false,
+    bob: 0,
+  };
+}
+
+/**
+ * Place an orb somewhere legal: inside the arena, clear of the serpent's head,
+ * and not on top of another orb. Falls back to the best of N tries rather than
+ * looping forever.
+ */
+export function placeOrb(orb: Orb, orbs: Orb[], arenaR: number, headX: number, headY: number): void {
+  let bestX = 0;
+  let bestY = 0;
+  let bestScore = -1;
+  const limit = arenaR - TUNE.orbRadius * 2.2;
+  for (let attempt = 0; attempt < 14; attempt++) {
+    const a = randRange(0, TAU);
+    const r = Math.sqrt(Math.random()) * limit;
+    const x = Math.cos(a) * r;
+    const y = Math.sin(a) * r;
+    const dHead = Math.hypot(x - headX, y - headY);
+    if (dHead < TUNE.spawnClearance && attempt < 10) continue;
+    let nearest = dHead;
+    for (const o of orbs) {
+      if (o === orb || o.scale <= 0) continue;
+      nearest = Math.min(nearest, Math.hypot(x - o.x, y - o.y) * 1.6);
+    }
+    if (nearest > bestScore) {
+      bestScore = nearest;
+      bestX = x;
+      bestY = y;
+    }
+    if (bestScore > TUNE.spawnClearance) break;
+  }
+  orb.x = bestX;
+  orb.y = bestY;
+  const a = randRange(0, TAU);
+  const s = randRange(0.3, 1) * TUNE.orbDrift;
+  orb.vx = Math.cos(a) * s;
+  orb.vy = Math.sin(a) * s;
+  orb.phase = randRange(0, TAU);
+  orb.bob = randRange(0.6, 1.5);
+  orb.scale = 0.001;
+  orb.moltT = 0;
+}
+
+export function molt(orb: Orb, label: string, good: boolean, dur: number): void {
+  orb.nextLabel = label;
+  orb.nextGood = good;
+  orb.moltT = dur;
+  orb.moltDur = dur;
+}
+
+export type OrbStepOptions = {
+  dt: number;
+  arenaR: number;
+  headX: number;
+  headY: number;
+  /** Rotating current, from depth 4. 0 disables it. */
+  current: number;
+  time: number;
+};
+
+export function stepOrbs(orbs: Orb[], o: OrbStepOptions): void {
+  const { dt } = o;
+  for (const orb of orbs) {
+    if (orb.moltT > 0) {
+      const before = orb.moltT;
+      orb.moltT = Math.max(0, orb.moltT - dt);
+      const half = orb.moltDur * 0.5;
+      if (before > half && orb.moltT <= half) {
+        orb.label = orb.nextLabel;
+        orb.good = orb.nextGood;
+      }
+      const k = orb.moltT / orb.moltDur;
+      orb.scale = Math.abs(k - 0.5) * 2;
+    } else if (orb.scale < 1) {
+      orb.scale = Math.min(1, orb.scale + dt * 3.4);
+    }
+
+    orb.phase += dt * orb.bob;
+
+    if (orb.hunter) {
+      const dx = o.headX - orb.x;
+      const dy = o.headY - orb.y;
+      const d = Math.hypot(dx, dy) || 1;
+      orb.vx += (dx / d) * TUNE.hunterSpeed * dt * 2.2;
+      orb.vy += (dy / d) * TUNE.hunterSpeed * dt * 2.2;
+      const sp = Math.hypot(orb.vx, orb.vy);
+      if (sp > TUNE.hunterSpeed) {
+        orb.vx = (orb.vx / sp) * TUNE.hunterSpeed;
+        orb.vy = (orb.vy / sp) * TUNE.hunterSpeed;
+      }
+    }
+
+    if (o.current !== 0) {
+      // A slow curl field. Orbs drift with the water; it makes the arena feel
+      // alive without taking the wheel out of the player's hands.
+      orb.vx += Math.sin(orb.y * 2.1 + o.time * 0.21) * o.current * dt;
+      orb.vy += Math.cos(orb.x * 2.3 - o.time * 0.17) * o.current * dt;
+    }
+
+    orb.x += orb.vx * dt;
+    orb.y += orb.vy * dt;
+
+    const d = Math.hypot(orb.x, orb.y);
+    const limit = o.arenaR - TUNE.orbRadius * 1.1;
+    if (d > limit && d > 0) {
+      const nx = orb.x / d;
+      const ny = orb.y / d;
+      orb.x = nx * limit;
+      orb.y = ny * limit;
+      const dot = orb.vx * nx + orb.vy * ny;
+      orb.vx -= 2 * dot * nx;
+      orb.vy -= 2 * dot * ny;
+    }
+  }
+}
+
+export function orbDrawRadius(orb: Orb): number {
+  return TUNE.orbRadius * orb.scale * (1 + Math.sin(orb.phase * 1.7) * 0.06);
+}

--- a/dynawalla/games/serpent/src/game/render/glyphs.ts
+++ b/dynawalla/games/serpent/src/game/render/glyphs.ts
@@ -1,0 +1,171 @@
+/**
+ * Cached text.
+ *
+ * Numbers are the most important pixels in this game, so they get their own
+ * pipeline: every label is rasterised once into a small canvas — dark outline
+ * under a bright fill, so it stays readable over a bloom, a body, or the rim —
+ * and then blitted. `a/b` is drawn as a real stacked fraction with a bar,
+ * because `3/4` written inline is the notation of a spreadsheet, not of maths.
+ */
+
+import { FONT_STACK } from "../tuning.ts";
+
+type Cached = { canvas: HTMLCanvasElement; w: number; h: number; dpr: number };
+
+const cache = new Map<string, Cached>();
+const MAX_ENTRIES = 420;
+
+let measurer: CanvasRenderingContext2D | null = null;
+
+function measureCtx(): CanvasRenderingContext2D {
+  if (measurer) return measurer;
+  const c = document.createElement("canvas");
+  c.width = 8;
+  c.height = 8;
+  const g = c.getContext("2d");
+  if (!g) throw new Error("no 2d context");
+  measurer = g;
+  return g;
+}
+
+const FRACTION = /^(-?\d+)\/(\d+)$/;
+
+export type LabelStyle = {
+  /** Cap height in CSS pixels. */
+  size: number;
+  fill: string;
+  outline: string;
+  outlineWidth: number;
+  weight: number;
+  tracking: number;
+};
+
+function font(style: LabelStyle, size: number): string {
+  return `${style.weight} ${size}px ${FONT_STACK}`;
+}
+
+function render(text: string, style: LabelStyle, dpr: number): Cached {
+  const m = measureCtx();
+  const frac = FRACTION.exec(text);
+  const pad = Math.ceil(style.outlineWidth * 2 + style.size * 0.28);
+
+  let w: number;
+  let h: number;
+  let partSize = style.size;
+
+  if (frac) {
+    partSize = style.size * 0.62;
+    m.font = font(style, partSize);
+    const top = m.measureText(frac[1] as string).width;
+    const bot = m.measureText(frac[2] as string).width;
+    w = Math.max(top, bot) * 1.5 + pad * 2;
+    h = partSize * 2.35 + pad * 2;
+  } else {
+    m.font = font(style, style.size);
+    const tw = m.measureText(text).width + style.tracking * Math.max(0, text.length - 1);
+    w = tw + pad * 2;
+    h = style.size * 1.34 + pad * 2;
+  }
+
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.max(2, Math.ceil(w * dpr));
+  canvas.height = Math.max(2, Math.ceil(h * dpr));
+  const g = canvas.getContext("2d");
+  if (!g) throw new Error("no 2d context");
+  g.scale(dpr, dpr);
+  g.textAlign = "center";
+  g.textBaseline = "middle";
+  g.lineJoin = "round";
+  g.miterLimit = 2;
+
+  const cx = w / 2;
+  const cy = h / 2;
+
+  const stroke = (s: string, x: number, y: number): void => {
+    if (style.outlineWidth > 0) {
+      g.lineWidth = style.outlineWidth * 2;
+      g.strokeStyle = style.outline;
+      g.strokeText(s, x, y);
+    }
+    g.fillStyle = style.fill;
+    g.fillText(s, x, y);
+  };
+
+  if (frac) {
+    g.font = font(style, partSize);
+    const barW = w - pad * 1.4;
+    stroke(frac[1] as string, cx, cy - partSize * 0.66);
+    stroke(frac[2] as string, cx, cy + partSize * 0.72);
+    if (style.outlineWidth > 0) {
+      g.strokeStyle = style.outline;
+      g.lineWidth = Math.max(2, partSize * 0.13) + style.outlineWidth * 2;
+      g.beginPath();
+      g.moveTo(cx - barW / 2, cy);
+      g.lineTo(cx + barW / 2, cy);
+      g.stroke();
+    }
+    g.strokeStyle = style.fill;
+    g.lineCap = "round";
+    g.lineWidth = Math.max(1.6, partSize * 0.11);
+    g.beginPath();
+    g.moveTo(cx - barW / 2, cy);
+    g.lineTo(cx + barW / 2, cy);
+    g.stroke();
+  } else if (style.tracking !== 0) {
+    g.font = font(style, style.size);
+    const total = m.measureText(text).width + style.tracking * (text.length - 1);
+    let x = cx - total / 2;
+    for (const ch of text) {
+      const cw = m.measureText(ch).width;
+      stroke(ch, x + cw / 2, cy);
+      x += cw + style.tracking;
+    }
+  } else {
+    g.font = font(style, style.size);
+    stroke(text, cx, cy);
+  }
+
+  return { canvas, w, h, dpr };
+}
+
+export function label(text: string, style: LabelStyle, dpr: number): Cached {
+  const key = `${text}|${Math.round(style.size * 2)}|${style.fill}|${style.outline}|${style.outlineWidth}|${style.weight}|${style.tracking}|${dpr}`;
+  const hit = cache.get(key);
+  if (hit) return hit;
+  if (cache.size > MAX_ENTRIES) {
+    const first = cache.keys().next();
+    if (!first.done) cache.delete(first.value);
+  }
+  const made = render(text, style, dpr);
+  cache.set(key, made);
+  return made;
+}
+
+/** Draw a cached label centred on (x, y), optionally scaled and faded. */
+export function drawLabel(
+  g: CanvasRenderingContext2D,
+  text: string,
+  style: LabelStyle,
+  x: number,
+  y: number,
+  dpr: number,
+  scale = 1,
+  alpha = 1,
+): void {
+  if (alpha <= 0.004) return;
+  const c = label(text, style, dpr);
+  const w = c.w * scale;
+  const h = c.h * scale;
+  const prev = g.globalAlpha;
+  g.globalAlpha = prev * alpha;
+  g.drawImage(c.canvas, x - w / 2, y - h / 2, w, h);
+  g.globalAlpha = prev;
+}
+
+export function labelWidth(text: string, style: LabelStyle, dpr: number): number {
+  return label(text, style, dpr).w;
+}
+
+export function clearGlyphCache(): void {
+  cache.clear();
+}

--- a/dynawalla/games/serpent/src/game/render/hud.ts
+++ b/dynawalla/games/serpent/src/game/render/hud.ts
@@ -1,0 +1,329 @@
+/**
+ * Screen-space chrome. Deliberately almost nothing.
+ *
+ * The real HUD is the arena floor — the condition is written in the water where
+ * the player is already looking. Up here there is a depth, a score, a combo
+ * gauge and a sound switch, and that is the entire text budget of the game.
+ * Nothing narrates state that the world already shows.
+ */
+
+import { TAU, clamp, easeOutCubic } from "../num.ts";
+import { COLORS, TUNE } from "../tuning.ts";
+import { stickBoostPush, stickRadiusPx, type Pointer } from "../input.ts";
+import type { World } from "../world.ts";
+import { drawLabel, type LabelStyle } from "./glyphs.ts";
+import type { View } from "./scene.ts";
+
+export type HudOptions = {
+  pointer: Pointer;
+  usingTouch: boolean;
+  soundOn: boolean;
+  showDebug: boolean;
+  fps: number;
+  frameMs: number;
+  worstMs: number;
+};
+
+const base: LabelStyle = {
+  size: 16,
+  fill: COLORS.ink,
+  outline: "rgba(0,8,14,0.75)",
+  outlineWidth: 3,
+  weight: 800,
+  tracking: 0,
+};
+
+const styled = (over: Partial<LabelStyle>): LabelStyle => ({ ...base, ...over });
+
+export function drawHud(g: CanvasRenderingContext2D, view: View, w: World, o: HudOptions): void {
+  const u = Math.min(view.w, view.h);
+  const pad = Math.max(14, u * 0.045);
+  const dpr = view.dpr;
+
+  // --- depth, top left ----------------------------------------------------
+  const depthSize = Math.max(24, u * 0.062);
+  const dp = easeOutCubic(w.depthPulse);
+  g.save();
+  g.globalAlpha = 0.9;
+  g.fillStyle = COLORS.rim;
+  const tri = depthSize * 0.3;
+  const tx = pad + tri * 0.6;
+  const ty = pad + depthSize * 0.62;
+  g.beginPath();
+  g.moveTo(tx - tri * 0.62, ty - tri * 0.45);
+  g.lineTo(tx + tri * 0.62, ty - tri * 0.45);
+  g.lineTo(tx, ty + tri * 0.62);
+  g.closePath();
+  g.fill();
+  g.restore();
+  drawLabel(
+    g,
+    String(w.depth),
+    styled({ size: depthSize, fill: dp > 0.02 ? "#ffffff" : COLORS.rim }),
+    tx + tri * 1.6 + depthSize * 0.22,
+    ty,
+    dpr,
+    1 + dp * 0.35,
+    0.95,
+  );
+
+  const lengthSize = Math.max(11, u * 0.028);
+  drawLabel(
+    g,
+    `${Math.round(w.serpent.targetSegments)}`,
+    styled({ size: lengthSize, fill: "rgba(143,233,255,0.75)" }),
+    tx + tri * 1.6 + depthSize * 0.22,
+    ty + depthSize * 0.72,
+    dpr,
+    1,
+    0.9,
+  );
+
+  // --- score, top centre --------------------------------------------------
+  const scoreSize = Math.max(26, u * 0.075);
+  const sp = easeOutCubic(w.scorePulse);
+  drawLabel(
+    g,
+    String(w.score),
+    styled({ size: scoreSize, fill: "#ffffff" }),
+    view.cx,
+    pad + scoreSize * 0.6,
+    dpr,
+    1 + sp * 0.12,
+    0.97,
+  );
+  if (w.best > 0) {
+    drawLabel(
+      g,
+      String(w.best),
+      styled({ size: Math.max(10, u * 0.026), fill: "rgba(255,215,106,0.7)" }),
+      view.cx,
+      pad + scoreSize * 1.28,
+      dpr,
+      1,
+      0.9,
+    );
+  }
+
+  // --- combo gauge, top right ---------------------------------------------
+  const gaugeR = Math.max(15, u * 0.042);
+  const gx = view.w - pad - gaugeR;
+  const gy = pad + gaugeR;
+  const frac = w.combo / TUNE.comboMax;
+  g.save();
+  g.lineCap = "round";
+  g.strokeStyle = "rgba(143,233,255,0.16)";
+  g.lineWidth = Math.max(2.5, gaugeR * 0.2);
+  g.beginPath();
+  g.arc(gx, gy, gaugeR, 0, TAU);
+  g.stroke();
+  if (frac > 0) {
+    g.strokeStyle = COLORS.good;
+    g.globalAlpha = 0.9;
+    g.lineWidth = Math.max(3, gaugeR * 0.26) * (1 + easeOutCubic(w.comboPulse) * 0.3);
+    g.beginPath();
+    g.arc(gx, gy, gaugeR, -Math.PI / 2, -Math.PI / 2 + TAU * frac);
+    g.stroke();
+  }
+  g.restore();
+  drawLabel(
+    g,
+    `${w.combo}`,
+    styled({ size: gaugeR * 1.02, fill: w.combo > 0 ? COLORS.good : "rgba(143,233,255,0.35)" }),
+    gx,
+    gy,
+    dpr,
+    1 + easeOutCubic(w.comboPulse) * 0.2,
+    1,
+  );
+  if (w.serpent.shield) {
+    g.save();
+    g.globalAlpha = 0.85;
+    g.strokeStyle = COLORS.lantern;
+    g.lineWidth = Math.max(2, gaugeR * 0.16);
+    g.beginPath();
+    g.arc(gx, gy, gaugeR * 1.5, 0, TAU);
+    g.stroke();
+    g.restore();
+  }
+
+  // --- sound switch, bottom right -----------------------------------------
+  const sr = Math.max(13, u * 0.032);
+  const sx = view.w - pad - sr;
+  const sy = view.h - pad - sr;
+  g.save();
+  g.globalAlpha = o.soundOn ? 0.55 : 0.3;
+  g.fillStyle = COLORS.ink;
+  g.beginPath();
+  g.moveTo(sx - sr * 0.5, sy - sr * 0.25);
+  g.lineTo(sx - sr * 0.16, sy - sr * 0.25);
+  g.lineTo(sx + sr * 0.24, sy - sr * 0.62);
+  g.lineTo(sx + sr * 0.24, sy + sr * 0.62);
+  g.lineTo(sx - sr * 0.16, sy + sr * 0.25);
+  g.lineTo(sx - sr * 0.5, sy + sr * 0.25);
+  g.closePath();
+  g.fill();
+  g.strokeStyle = COLORS.ink;
+  g.lineWidth = Math.max(1.6, sr * 0.14);
+  g.lineCap = "round";
+  if (o.soundOn) {
+    for (let i = 1; i <= 2; i++) {
+      g.beginPath();
+      g.arc(sx + sr * 0.28, sy, sr * (0.22 + i * 0.3), -0.9, 0.9);
+      g.stroke();
+    }
+  } else {
+    g.beginPath();
+    g.moveTo(sx + sr * 0.5, sy - sr * 0.34);
+    g.lineTo(sx + sr * 1.06, sy + sr * 0.34);
+    g.moveTo(sx + sr * 1.06, sy - sr * 0.34);
+    g.lineTo(sx + sr * 0.5, sy + sr * 0.34);
+    g.stroke();
+  }
+  g.restore();
+
+  // --- the thumb stick ----------------------------------------------------
+  if (o.usingTouch && o.pointer.active) {
+    const ax = o.pointer.anchorX;
+    const ay = o.pointer.anchorY;
+    const boosting = o.pointer.push >= stickBoostPush;
+    g.save();
+    g.globalAlpha = 0.22;
+    g.strokeStyle = boosting ? COLORS.good : COLORS.plankton;
+    g.lineWidth = 2;
+    g.beginPath();
+    g.arc(ax, ay, stickRadiusPx, 0, TAU);
+    g.stroke();
+    g.globalAlpha = 0.13;
+    g.beginPath();
+    g.arc(ax, ay, stickRadiusPx * stickBoostPush, 0, TAU);
+    g.stroke();
+    g.globalAlpha = 0.5;
+    g.fillStyle = boosting ? COLORS.good : COLORS.plankton;
+    g.beginPath();
+    g.arc(ax + o.pointer.dx, ay + o.pointer.dy, Math.max(9, stickRadiusPx * 0.16), 0, TAU);
+    g.fill();
+    g.restore();
+  }
+
+  // --- overlays -----------------------------------------------------------
+  if (w.phase === "attract") drawAttract(g, view, w, o);
+  else if (w.phase === "dead") drawGameOver(g, view, w, o);
+  else if (w.paused) drawPaused(g, view);
+
+  if (o.showDebug) drawDebug(g, view, w, o);
+}
+
+function scrim(g: CanvasRenderingContext2D, view: View, alpha: number): void {
+  const grad = g.createRadialGradient(view.cx, view.cy, 0, view.cx, view.cy, Math.max(view.w, view.h) * 0.72);
+  grad.addColorStop(0, `rgba(0,6,12,${alpha})`);
+  grad.addColorStop(1, `rgba(0,2,6,${Math.min(0.94, alpha + 0.28)})`);
+  g.fillStyle = grad;
+  g.fillRect(0, 0, view.w, view.h);
+}
+
+function drawAttract(g: CanvasRenderingContext2D, view: View, w: World, o: HudOptions): void {
+  const u = Math.min(view.w, view.h);
+  scrim(g, view, 0.42);
+  const titleSize = Math.max(34, u * 0.13);
+  drawLabel(
+    g,
+    "SERPENT",
+    styled({ size: titleSize, fill: "#eafcff", tracking: titleSize * 0.16, outlineWidth: 6 }),
+    view.cx,
+    view.cy - u * 0.1,
+    view.dpr,
+    1,
+    0.97,
+  );
+  const pulse = 0.55 + 0.45 * (0.5 + 0.5 * Math.sin(w.cam.t * 2.6));
+  drawLabel(
+    g,
+    o.usingTouch ? "TAP TO DIVE" : "CLICK TO DIVE",
+    styled({ size: Math.max(14, u * 0.036), fill: COLORS.rim, tracking: u * 0.008 }),
+    view.cx,
+    view.cy + u * 0.12,
+    view.dpr,
+    1,
+    pulse,
+  );
+}
+
+function drawGameOver(g: CanvasRenderingContext2D, view: View, w: World, o: HudOptions): void {
+  const u = Math.min(view.w, view.h);
+  const k = clamp(w.deathT / 0.7, 0, 1);
+  scrim(g, view, 0.5 * k);
+  const e = easeOutCubic(k);
+  const bigSize = Math.max(40, u * 0.15);
+  drawLabel(
+    g,
+    String(w.score),
+    styled({ size: bigSize, fill: "#ffffff", outlineWidth: 5 }),
+    view.cx,
+    view.cy - u * 0.06,
+    view.dpr,
+    0.86 + e * 0.14,
+    e,
+  );
+  drawLabel(
+    g,
+    `DEPTH ${w.depth}   BEST ${w.best}`,
+    styled({ size: Math.max(12, u * 0.032), fill: "rgba(255,215,106,0.85)", tracking: u * 0.004 }),
+    view.cx,
+    view.cy + u * 0.045,
+    view.dpr,
+    1,
+    e,
+  );
+  if (w.deathT > 0.55) {
+    const pulse = 0.5 + 0.5 * (0.5 + 0.5 * Math.sin(w.cam.t * 2.8));
+    drawLabel(
+      g,
+      o.usingTouch ? "TAP TO DIVE AGAIN" : "CLICK TO DIVE AGAIN",
+      styled({ size: Math.max(13, u * 0.033), fill: COLORS.rim, tracking: u * 0.006 }),
+      view.cx,
+      view.cy + u * 0.15,
+      view.dpr,
+      1,
+      pulse,
+    );
+  }
+}
+
+function drawPaused(g: CanvasRenderingContext2D, view: View): void {
+  const u = Math.min(view.w, view.h);
+  scrim(g, view, 0.5);
+  drawLabel(
+    g,
+    "PAUSED",
+    styled({ size: Math.max(22, u * 0.07), fill: "#eafcff", tracking: u * 0.012 }),
+    view.cx,
+    view.cy,
+    view.dpr,
+    1,
+    0.95,
+  );
+}
+
+function drawDebug(g: CanvasRenderingContext2D, view: View, w: World, o: HudOptions): void {
+  const lines = [
+    `${o.fps.toFixed(0)} fps   frame ${o.frameMs.toFixed(2)}ms   worst ${o.worstMs.toFixed(2)}ms`,
+    `body ${w.serpent.bodyCount}   orbs ${w.orbs.length}   particles ${w.particles.count}   rings ${w.rings.count}`,
+    `answer ${w.lastAnswerMs}ms   depth ${w.depth}   arena ${w.arenaR.toFixed(3)}   ${w.prompt}`,
+  ];
+  const size = Math.max(10, Math.min(view.w, view.h) * 0.022);
+  let y = view.h - size * 3.6;
+  for (const line of lines) {
+    drawLabel(
+      g,
+      line,
+      styled({ size, fill: "rgba(180,255,230,0.85)", weight: 600, outlineWidth: 3 }),
+      view.w / 2,
+      y,
+      view.dpr,
+      1,
+      0.9,
+    );
+    y += size * 1.35;
+  }
+}

--- a/dynawalla/games/serpent/src/game/render/scene.ts
+++ b/dynawalla/games/serpent/src/game/render/scene.ts
@@ -1,0 +1,682 @@
+/**
+ * The look: a bioluminescent abyss.
+ *
+ * Everything is lit from inside — the serpent glows, the plankton glow, the
+ * vent rim glows — against near-black water crossed by slow shafts of light and
+ * drifting marine snow. It is not a neon-vector arcade look and it is not a
+ * worksheet: it is a place, and the numbers live in it.
+ *
+ * Two rules the art follows without exception:
+ *   · An orb's appearance never tells you whether it is the right answer. The
+ *     printed value is the only signal. Colour arrives *after* the bite.
+ *   · Nothing means anything by colour alone. A correct bite is gold *and* a
+ *     rising chime *and* growth *and* a bulge travelling down the body.
+ */
+
+import { TAU, clamp, easeOutBack, easeOutCubic, easeOutExpo } from "../num.ts";
+import { COLORS, TUNE } from "../tuning.ts";
+import { bolusTintAt } from "../serpent.ts";
+import { orbDrawRadius } from "../orbs.ts";
+import type { World } from "../world.ts";
+import { GLOW_PX, MOTE_PX, sprites } from "./sprites.ts";
+import { drawLabel, labelWidth, type LabelStyle } from "./glyphs.ts";
+import { PK_BUBBLE, PK_MOTE, PK_SHARD } from "../fx/particles.ts";
+
+export type View = { cx: number; cy: number; scale: number; w: number; h: number; dpr: number };
+
+type Snow = { x: number; y: number; r: number; vy: number; vx: number; a: number; phase: number };
+
+export type Renderer = {
+  view: View;
+  resize(w: number, h: number, dpr: number): void;
+  draw(world: World, stickAlpha: number): void;
+  toWorld(clientX: number, clientY: number, rect: DOMRect): { x: number; y: number };
+};
+
+const ORB_LABEL: LabelStyle = {
+  size: 20,
+  fill: "#f2feff",
+  outline: "rgba(2,14,22,0.92)",
+  outlineWidth: 3,
+  weight: 800,
+  tracking: 0,
+};
+
+const PROMPT_LABEL: LabelStyle = {
+  size: 200,
+  fill: "#a9f4ff",
+  outline: "rgba(0,0,0,0)",
+  outlineWidth: 0,
+  weight: 800,
+  tracking: 2,
+};
+
+export function createRenderer(canvas: HTMLCanvasElement): Renderer {
+  const ctx = canvas.getContext("2d", { alpha: false });
+  if (!ctx) throw new Error("no 2d context");
+  const g: CanvasRenderingContext2D = ctx;
+  const sp = sprites();
+
+  const view: View = { cx: 0, cy: 0, scale: 1, w: 1, h: 1, dpr: 1 };
+  let bg: HTMLCanvasElement | null = null;
+  const snowFar: Snow[] = [];
+  const snowNear: Snow[] = [];
+  let shownPrompt = "";
+  let outgoingPrompt = "";
+  let promptT = 1;
+  let lastTime = 0;
+
+  // Scratch buffers for the body outline. Allocated once.
+  const nx = new Float32Array(TUNE.maxSegments + 2);
+  const ny = new Float32Array(TUNE.maxSegments + 2);
+  const bx = new Float32Array(TUNE.maxSegments + 2);
+  const by = new Float32Array(TUNE.maxSegments + 2);
+  const swim = new Float32Array(TUNE.maxSegments + 2);
+
+  function buildBackground(): void {
+    const c = document.createElement("canvas");
+    c.width = Math.max(1, Math.floor(view.w * view.dpr));
+    c.height = Math.max(1, Math.floor(view.h * view.dpr));
+    const bgx = c.getContext("2d");
+    if (!bgx) return;
+    bgx.scale(view.dpr, view.dpr);
+
+    const top = bgx.createLinearGradient(0, 0, 0, view.h);
+    top.addColorStop(0, COLORS.deepTop);
+    top.addColorStop(0.55, COLORS.deepBottom);
+    top.addColorStop(1, COLORS.abyss);
+    bgx.fillStyle = top;
+    bgx.fillRect(0, 0, view.w, view.h);
+
+    const pool = bgx.createRadialGradient(view.cx, view.cy, 0, view.cx, view.cy, view.scale * 1.9);
+    pool.addColorStop(0, "rgba(24,92,116,0.34)");
+    pool.addColorStop(0.5, "rgba(10,48,66,0.16)");
+    pool.addColorStop(1, "rgba(0,0,0,0)");
+    bgx.fillStyle = pool;
+    bgx.fillRect(0, 0, view.w, view.h);
+
+    const vig = bgx.createRadialGradient(view.cx, view.cy, view.scale * 0.9, view.cx, view.cy, view.scale * 2.4);
+    vig.addColorStop(0, "rgba(0,0,0,0)");
+    vig.addColorStop(1, "rgba(0,0,0,0.72)");
+    bgx.fillStyle = vig;
+    bgx.fillRect(0, 0, view.w, view.h);
+
+    bg = c;
+  }
+
+  function seedSnow(): void {
+    snowFar.length = 0;
+    snowNear.length = 0;
+    const area = (view.w * view.h) / (900 * 700);
+    const far = Math.round(clamp(120 * area, 40, 190));
+    const near = Math.round(clamp(34 * area, 12, 56));
+    for (let i = 0; i < far; i++) {
+      snowFar.push({
+        x: Math.random() * view.w,
+        y: Math.random() * view.h,
+        r: 0.6 + Math.random() * 1.5,
+        vy: 3 + Math.random() * 8,
+        vx: -3 + Math.random() * 6,
+        a: 0.1 + Math.random() * 0.24,
+        phase: Math.random() * TAU,
+      });
+    }
+    for (let i = 0; i < near; i++) {
+      snowNear.push({
+        x: Math.random() * view.w,
+        y: Math.random() * view.h,
+        r: 1.6 + Math.random() * 3.4,
+        vy: 9 + Math.random() * 16,
+        vx: -7 + Math.random() * 14,
+        a: 0.06 + Math.random() * 0.14,
+        phase: Math.random() * TAU,
+      });
+    }
+  }
+
+  function resize(w: number, h: number, dpr: number): void {
+    view.w = w;
+    view.h = h;
+    view.dpr = dpr;
+    view.cx = w / 2;
+    view.cy = h / 2;
+    view.scale = Math.min(w, h) * 0.44;
+    canvas.width = Math.max(1, Math.floor(w * dpr));
+    canvas.height = Math.max(1, Math.floor(h * dpr));
+    canvas.style.width = `${w}px`;
+    canvas.style.height = `${h}px`;
+    buildBackground();
+    seedSnow();
+  }
+
+  function stepSnow(list: Snow[], dt: number, drift: number): void {
+    for (const s of list) {
+      s.y += s.vy * dt;
+      s.x += (s.vx + Math.sin(s.phase + s.y * 0.01) * drift) * dt;
+      if (s.y > view.h + 6) {
+        s.y = -6;
+        s.x = Math.random() * view.w;
+      }
+      if (s.x < -8) s.x = view.w + 8;
+      if (s.x > view.w + 8) s.x = -8;
+    }
+  }
+
+  function drawSnow(list: Snow[], boost: number): void {
+    g.globalCompositeOperation = "lighter";
+    for (const s of list) {
+      const d = sp.mote[4];
+      if (!d) continue;
+      const size = s.r * 4 * (1 + boost);
+      g.globalAlpha = s.a * (1 + boost * 0.6);
+      g.drawImage(d, s.x - size / 2, s.y - size / 2, size, size);
+    }
+    g.globalAlpha = 1;
+    g.globalCompositeOperation = "source-over";
+  }
+
+  function draw(w: World, stickAlpha: number): void {
+    const dt = lastTime === 0 ? 0.016 : clamp(w.cam.t - lastTime, 0, 0.05);
+    lastTime = w.cam.t;
+
+    const cam = w.cam;
+    const S = view.scale * cam.zoom;
+    const ox = view.cx + cam.shakeX * view.scale;
+    const oy = view.cy + cam.shakeY * view.scale;
+    const X = (x: number): number => ox + x * S;
+    const Y = (y: number): number => oy + y * S;
+
+    g.setTransform(view.dpr, 0, 0, view.dpr, 0, 0);
+    if (bg) g.drawImage(bg, 0, 0, view.w, view.h);
+
+    // --- shafts of light -------------------------------------------------
+    g.globalCompositeOperation = "lighter";
+    for (let i = 0; i < 4; i++) {
+      const t = w.cam.t * 0.05 + i * 2.1;
+      const x = view.w * (0.18 + 0.23 * i) + Math.sin(t) * view.w * 0.06;
+      const rot = Math.sin(t * 0.7) * 0.09 + 0.1;
+      const hh = view.h * 1.35;
+      const ww = view.w * (0.34 + 0.08 * Math.sin(t * 1.3));
+      g.save();
+      g.translate(x, -view.h * 0.16);
+      g.rotate(rot);
+      g.globalAlpha = 0.2 + 0.08 * Math.sin(t * 0.9);
+      g.drawImage(sp.ray, -ww / 2, 0, ww, hh);
+      g.restore();
+    }
+    g.globalAlpha = 1;
+    g.globalCompositeOperation = "source-over";
+
+    const boostGlow = w.serpent.boostBlend;
+    if (!w.reduced) {
+      stepSnow(snowFar, dt, 4);
+      stepSnow(snowNear, dt, 9);
+    }
+    drawSnow(snowFar, 0);
+
+    // --- the arena floor --------------------------------------------------
+    const aR = w.arenaR * S;
+    g.save();
+    g.beginPath();
+    g.arc(X(0), Y(0), aR, 0, TAU);
+    g.clip();
+
+    const floor = g.createRadialGradient(X(0), Y(0), 0, X(0), Y(0), aR);
+    floor.addColorStop(0, "rgba(34,124,150,0.7)");
+    floor.addColorStop(0.45, "rgba(14,72,104,0.56)");
+    floor.addColorStop(0.82, "rgba(6,36,62,0.4)");
+    floor.addColorStop(1, "rgba(2,14,28,0.16)");
+    g.fillStyle = floor;
+    g.fillRect(X(0) - aR, Y(0) - aR, aR * 2, aR * 2);
+
+    // The vent itself: a slow amber heart. Teal water against a warm centre is
+    // the only complementary pair in the palette, and without it the whole
+    // screen is one hue and reads flat however bright you make it.
+    const ventGlow = sp.glow[0];
+    if (ventGlow) {
+      const vs = aR * (1.15 + 0.05 * Math.sin(w.cam.t * 0.55));
+      g.globalCompositeOperation = "lighter";
+      g.globalAlpha = 0.13 + 0.03 * Math.sin(w.cam.t * 0.8) + w.depthPulse * 0.16;
+      g.drawImage(ventGlow, X(0) - vs / 2, Y(0) - vs / 2, vs, vs);
+      g.globalAlpha = 1;
+      g.globalCompositeOperation = "source-over";
+    }
+
+    // --- the condition, written on the water ------------------------------
+    if (w.prompt !== shownPrompt) {
+      outgoingPrompt = shownPrompt;
+      shownPrompt = w.prompt;
+      promptT = 0;
+    }
+    promptT = Math.min(1, promptT + dt * 1.9);
+    const promptSize = Math.max(56, view.scale * 0.52);
+    const style: LabelStyle = { ...PROMPT_LABEL, size: promptSize };
+    const breathe = 1 + Math.sin(w.cam.t * 0.9) * 0.012;
+    // Additive, so the condition is *light in the water* — it can never read as
+    // a dark smudge whatever is behind it, and the serpent swims through it.
+    g.globalCompositeOperation = "lighter";
+    if (outgoingPrompt && promptT < 1) {
+      const k = easeOutCubic(promptT);
+      drawLabel(g, outgoingPrompt, style, X(0), Y(0), view.dpr, (1 + k * 0.55) * breathe, (1 - k) * 0.2);
+    }
+    const inK = easeOutBack(Math.min(1, promptT * 1.25));
+    const inA = Math.min(1, promptT * 2.2);
+    drawLabel(g, shownPrompt, style, X(0), Y(0), view.dpr, (0.74 + 0.26 * inK) * breathe * 1.08, 0.1 * inA);
+    drawLabel(g, shownPrompt, style, X(0), Y(0), view.dpr, (0.74 + 0.26 * inK) * breathe, 0.26 * inA);
+    g.globalCompositeOperation = "source-over";
+    g.restore();
+
+    // --- shockwaves -------------------------------------------------------
+    g.globalCompositeOperation = "lighter";
+    for (let i = 0; i < w.rings.count; i++) {
+      const life = (w.rings.life[i] as number) / (w.rings.maxLife[i] as number);
+      const k = easeOutExpo(1 - life);
+      const r = ((w.rings.from[i] as number) + ((w.rings.to[i] as number) - (w.rings.from[i] as number)) * k) * S;
+      const img = sp.softRing[w.rings.color[i] as number];
+      if (!img || r <= 0) continue;
+      const size = r * 2 * 1.28;
+      g.globalAlpha = life * life * 0.9;
+      g.drawImage(img, X(w.rings.x[i] as number) - size / 2, Y(w.rings.y[i] as number) - size / 2, size, size);
+    }
+    g.globalAlpha = 1;
+    g.globalCompositeOperation = "source-over";
+
+    // --- orbs -------------------------------------------------------------
+    const orbLabelSize = Math.max(11, view.scale * 0.082);
+    const orbStyle: LabelStyle = { ...ORB_LABEL, size: orbLabelSize };
+    for (const o of w.orbs) {
+      const r = orbDrawRadius(o) * S;
+      if (r <= 0.4) continue;
+      const px = X(o.x);
+      const py = Y(o.y);
+      const bob = Math.sin(o.phase * 1.6) * r * 0.08;
+
+      g.globalCompositeOperation = "lighter";
+      const glow = sp.glow[o.hunter ? 5 : 4];
+      if (glow) {
+        const gs = r * 4.4;
+        g.globalAlpha = 0.34 + 0.12 * Math.sin(o.phase * 2.1);
+        g.drawImage(glow, px - gs / 2, py + bob - gs / 2, gs, gs);
+      }
+      g.globalAlpha = 1;
+      g.globalCompositeOperation = "source-over";
+
+      g.save();
+      g.translate(px, py + bob);
+      g.rotate(Math.sin(o.phase * 0.9) * 0.14 + (o.hunter ? o.phase * 0.6 : 0));
+      const bs = r * 3.3;
+      g.drawImage(o.hunter ? sp.hunter : sp.bell, -bs / 2, -bs / 2, bs, bs);
+      g.restore();
+
+      // The numeral has to live *inside* the bell, so it is fitted to it. An
+      // expression loses its spaces on the way to the screen — `7+5` reads as
+      // fast as `7 + 5` and takes 30% less width on a 40px creature.
+      const shown = o.label.replace(/ /g, "");
+      const fit = Math.min(1, (r * 1.72) / labelWidth(shown, orbStyle, view.dpr));
+      drawLabel(g, shown, orbStyle, px, py + bob, view.dpr, o.scale * cam.zoom * fit, Math.min(1, o.scale * 1.4));
+    }
+
+    // --- the serpent ------------------------------------------------------
+    drawSerpent(w, X, Y, S);
+
+    // --- particles --------------------------------------------------------
+    const p = w.particles;
+    g.globalCompositeOperation = "lighter";
+    for (let i = 0; i < p.count; i++) {
+      const life = (p.life[i] as number) / (p.maxLife[i] as number);
+      const kind = p.kind[i] as number;
+      const col = p.color[i] as number;
+      const img = kind === PK_SHARD ? sp.shard[col] : kind === PK_BUBBLE ? sp.bubble : sp.mote[col];
+      if (!img) continue;
+      const grow = kind === PK_MOTE ? 1 + (1 - life) * 1.4 : 1;
+      const size = (p.size[i] as number) * S * (kind === PK_SHARD ? 5 : 4.2) * grow;
+      g.globalAlpha = kind === PK_MOTE ? life * life * 0.85 : Math.min(1, life * 1.6);
+      const px = X(p.x[i] as number);
+      const py = Y(p.y[i] as number);
+      if (kind === PK_SHARD) {
+        g.save();
+        g.translate(px, py);
+        g.rotate(p.rot[i] as number);
+        g.drawImage(img, -size / 2, (-size / 2) * 0.35, size, size * 0.35);
+        g.restore();
+      } else {
+        g.drawImage(img, px - size / 2, py - size / 2, size, size);
+      }
+    }
+    g.globalAlpha = 1;
+    g.globalCompositeOperation = "source-over";
+
+    // --- the vent rim -----------------------------------------------------
+    drawRim(w, X, Y, S, aR);
+
+    // --- floating score ---------------------------------------------------
+    const floatStyle: LabelStyle = {
+      size: Math.max(13, view.scale * 0.075),
+      fill: "#ffffff",
+      outline: "rgba(2,12,20,0.85)",
+      outlineWidth: 3,
+      weight: 800,
+      tracking: 0,
+    };
+    for (const f of w.floaters) {
+      const k = 1 - f.life / f.maxLife;
+      const style2: LabelStyle = {
+        ...floatStyle,
+        fill: f.tone === 0 ? COLORS.good : f.tone === 1 ? COLORS.bad : COLORS.ink,
+      };
+      drawLabel(g, f.text, style2, X(f.x), Y(f.y), view.dpr, 0.8 + easeOutCubic(k) * 0.5, 1 - k * k);
+    }
+
+    drawSnow(snowNear, boostGlow * 0.8);
+    void stickAlpha;
+
+    if (cam.flashAlpha > 0.004) {
+      g.globalCompositeOperation = "lighter";
+      g.globalAlpha = cam.flashAlpha;
+      g.fillStyle = cam.flashColor;
+      g.fillRect(0, 0, view.w, view.h);
+      g.globalAlpha = 1;
+      g.globalCompositeOperation = "source-over";
+    }
+  }
+
+  function drawSerpent(w: World, X: (x: number) => number, Y: (y: number) => number, S: number): void {
+    const s = w.serpent;
+    const n = s.bodyCount;
+    if (n < 2) return;
+    const fade = w.phase === "dead" ? clamp(1 - w.deathT * 1.6, 0, 1) : 1;
+    if (fade <= 0.01) return;
+
+    // Per-point normals, computed once and reused by every pass.
+    //
+    // The body is also displaced sideways by a travelling sine — an eel swims,
+    // it does not slide along a rail, and following the recorded path exactly
+    // is what made this read as a dropped ribbon. The amplitude grows toward
+    // the tail (the head leads, the tail whips) and speeds up when boosting.
+    // Purely cosmetic: collision still uses the true path, so what you can hit
+    // is never what you can see wobbling.
+    const swimAmp = TUNE.bodyRadius * (w.reduced ? 0.12 : 0.42);
+    const swimPhase = w.cam.t * (5.4 + s.boostBlend * 4.5);
+    for (let i = 0; i < n; i++) {
+      const a = i === 0 ? 0 : i - 1;
+      const b = i === n - 1 ? n - 1 : i + 1;
+      const dx = (s.bodyX[b] as number) - (s.bodyX[a] as number);
+      const dy = (s.bodyY[b] as number) - (s.bodyY[a] as number);
+      const d = Math.hypot(dx, dy) || 1;
+      nx[i] = -dy / d;
+      ny[i] = dx / d;
+      const grow = Math.min(1, i / 12);
+      swim[i] = Math.sin(i * 0.34 - swimPhase) * swimAmp * grow;
+      bx[i] = (s.bodyX[i] as number) + (nx[i] as number) * (swim[i] as number);
+      by[i] = (s.bodyY[i] as number) + (ny[i] as number) * (swim[i] as number);
+    }
+
+    const outline = (k: number): void => {
+      g.beginPath();
+      for (let i = 0; i < n; i++) {
+        const r = (s.bodyR[i] as number) * k;
+        const px = X((bx[i] as number) + (nx[i] as number) * r);
+        const py = Y((by[i] as number) + (ny[i] as number) * r);
+        if (i === 0) g.moveTo(px, py);
+        else g.lineTo(px, py);
+      }
+      // A round cap so the tail is a stub, not a knife edge.
+      const tr = (s.bodyR[n - 1] as number) * k * S;
+      g.arc(
+        X(bx[n - 1] as number),
+        Y(by[n - 1] as number),
+        tr,
+        Math.atan2(ny[n - 1] as number, nx[n - 1] as number),
+        Math.atan2(-(ny[n - 1] as number), -(nx[n - 1] as number)),
+        true,
+      );
+      for (let i = n - 1; i >= 0; i--) {
+        const r = (s.bodyR[i] as number) * k;
+        g.lineTo(X((bx[i] as number) - (nx[i] as number) * r), Y((by[i] as number) - (ny[i] as number) * r));
+      }
+      g.closePath();
+    };
+
+    // Bloom under the body — tight, or it stacks into a nebula.
+    g.globalCompositeOperation = "lighter";
+    const glow = sp.glow[2];
+    if (glow) {
+      const step = n > 110 ? 4 : 3;
+      for (let i = 0; i < n; i += step) {
+        const size = (s.bodyR[i] as number) * S * 4.6;
+        g.globalAlpha = 0.1 * fade * (1 + s.boostBlend * 0.9);
+        g.drawImage(glow, X(bx[i] as number) - size / 2, Y(by[i] as number) - size / 2, size, size);
+      }
+    }
+    g.globalAlpha = 1;
+    g.globalCompositeOperation = "source-over";
+
+    g.globalAlpha = fade;
+    outline(1);
+    g.fillStyle = "#02181f";
+    g.fill();
+
+    outline(0.82);
+    g.fillStyle = "#0b5f7a";
+    g.fill();
+
+    outline(0.56);
+    g.fillStyle = "#159fc0";
+    g.fill();
+
+    // A narrow brilliant filament, not a wash — the light is *inside* the animal.
+    g.globalCompositeOperation = "lighter";
+    outline(0.24);
+    g.fillStyle = `rgba(126,255,236,${0.85 + s.boostBlend * 0.15})`;
+    g.fill();
+    g.globalCompositeOperation = "source-over";
+
+    // Counting bands: every fifth segment is marked, so the body is a number
+    // line you can read at a glance.
+    g.globalCompositeOperation = "lighter";
+    for (let i = 5; i < n; i += 5) {
+      const r = (s.bodyR[i] as number) * S;
+      const px = X(bx[i] as number);
+      const py = Y(by[i] as number);
+      const big = i % 25 === 0;
+      const back = i + 2 < n ? i + 2 : i;
+      const ax = X(bx[back] as number) - px;
+      const ay = Y(by[back] as number) - py;
+      const al = Math.hypot(ax, ay) || 1;
+      g.globalAlpha = (big ? 0.55 : 0.3) * fade;
+      g.strokeStyle = big ? "#ffffff" : COLORS.lantern;
+      g.lineWidth = Math.max(1, r * (big ? 0.4 : 0.24));
+      g.lineJoin = "round";
+      g.beginPath();
+      g.moveTo(px + (nx[i] as number) * r * 0.72, py + (ny[i] as number) * r * 0.72);
+      g.lineTo(px + (ax / al) * r * 0.5, py + (ay / al) * r * 0.5);
+      g.lineTo(px - (nx[i] as number) * r * 0.72, py - (ny[i] as number) * r * 0.72);
+      g.stroke();
+    }
+
+    // A wrong bite travels down the body as a violet swelling.
+    for (let i = 0; i < n; i += 2) {
+      const tint = bolusTintAt(s, i);
+      if (tint < 0.05) continue;
+      const size = (s.bodyR[i] as number) * S * 5;
+      const img = sp.glow[1];
+      if (!img) continue;
+      g.globalAlpha = tint * 0.55 * fade;
+      g.drawImage(img, X(bx[i] as number) - size / 2, Y(by[i] as number) - size / 2, size, size);
+    }
+    g.globalAlpha = 1;
+    g.globalCompositeOperation = "source-over";
+
+    // --- head
+    const hx = X(s.x);
+    const hy = Y(s.y);
+    const hr = TUNE.headRadius * S;
+    const stretch = 1 + s.boostBlend * 0.24;
+    const squash = 1 - s.boostBlend * 0.12;
+
+    g.save();
+    g.translate(hx, hy);
+    g.rotate(s.heading);
+    g.globalAlpha = fade;
+
+    // lantern stalk
+    g.strokeStyle = "#0d7590";
+    g.lineWidth = Math.max(1.4, hr * 0.22);
+    g.lineCap = "round";
+    g.beginPath();
+    g.moveTo(-hr * 0.1, -hr * 0.5);
+    g.quadraticCurveTo(hr * 1.1, -hr * 1.7, hr * 2.1, -hr * 0.75);
+    g.stroke();
+
+    g.fillStyle = "#05303f";
+    g.beginPath();
+    g.ellipse(0, 0, hr * 1.34 * stretch, hr * 1.02 * squash, 0, 0, TAU);
+    g.fill();
+    g.fillStyle = "#0f8aa6";
+    g.beginPath();
+    g.ellipse(hr * 0.06, 0, hr * 1.1 * stretch, hr * 0.78 * squash, 0, 0, TAU);
+    g.fill();
+
+    // jaw — opens on the frame a bite lands
+    const fresh = freshBolus(w);
+    if (fresh > 0.02) {
+      g.fillStyle = "rgba(2,12,20,0.85)";
+      g.beginPath();
+      g.moveTo(hr * 0.35, 0);
+      g.arc(hr * 0.35, 0, hr * 1.05, -0.5 * fresh, 0.5 * fresh);
+      g.closePath();
+      g.fill();
+    }
+
+    g.globalCompositeOperation = "lighter";
+    g.fillStyle = COLORS.serpentCore;
+    for (const side of [-1, 1]) {
+      g.beginPath();
+      g.ellipse(hr * 0.42, side * hr * 0.42, hr * 0.2, hr * 0.16, 0, 0, TAU);
+      g.fill();
+    }
+    const lantern = sp.glow[4];
+    if (lantern) {
+      const ls = hr * (7 + Math.sin(w.cam.t * 2.3) * 0.5);
+      g.globalAlpha = 0.5 * fade;
+      g.drawImage(lantern, hr * 2.1 - ls / 2, -hr * 0.75 - ls / 2, ls, ls);
+      g.globalAlpha = fade;
+    }
+    g.fillStyle = "#ffffff";
+    g.beginPath();
+    g.arc(hr * 2.1, -hr * 0.75, hr * 0.3, 0, TAU);
+    g.fill();
+    g.globalCompositeOperation = "source-over";
+    g.restore();
+
+    // --- shield
+    if (s.shield || w.shieldPulse > 0.02) {
+      const alpha = s.shield ? 0.5 + 0.2 * Math.sin(w.cam.t * 3.4) : w.shieldPulse;
+      g.globalCompositeOperation = "lighter";
+      g.strokeStyle = COLORS.lantern;
+      g.globalAlpha = alpha * fade;
+      g.lineWidth = Math.max(1.2, hr * 0.14);
+      g.beginPath();
+      g.arc(hx, hy, hr * 2.3, 0, TAU);
+      g.stroke();
+      const spark = sp.mote[4];
+      if (spark && s.shield) {
+        for (let i = 0; i < 3; i++) {
+          const a = s.shieldSpin + (i / 3) * TAU;
+          const size = hr * 1.5;
+          g.globalAlpha = fade * 0.9;
+          g.drawImage(
+            spark,
+            hx + Math.cos(a) * hr * 2.3 - size / 2,
+            hy + Math.sin(a) * hr * 2.3 - size / 2,
+            size,
+            size,
+          );
+        }
+      }
+      g.globalAlpha = 1;
+      g.globalCompositeOperation = "source-over";
+    }
+    g.globalAlpha = 1;
+  }
+
+  function freshBolus(w: World): number {
+    const s = w.serpent;
+    let best = 0;
+    for (let b = 0; b < s.bolusCount; b++) {
+      const v = 1 - clamp((s.bolusS[b] as number) / 0.09, 0, 1);
+      if (v > best) best = v;
+    }
+    return best;
+  }
+
+  function drawRim(
+    w: World,
+    X: (x: number) => number,
+    Y: (y: number) => number,
+    S: number,
+    aR: number,
+  ): void {
+    const cx = X(0);
+    const cy = Y(0);
+    const headA = Math.atan2(w.serpent.y, w.serpent.x);
+    const segs = 72;
+
+    g.globalCompositeOperation = "lighter";
+    const halo = sp.softRing[w.grazeGlow > 0.4 ? 5 : 2];
+    if (halo) {
+      const size = aR * 2 * 1.14;
+      g.globalAlpha = 0.5 + w.grazeGlow * 0.4 + w.depthPulse * 0.35;
+      g.drawImage(halo, cx - size / 2, cy - size / 2, size, size);
+    }
+
+    g.lineCap = "butt";
+    for (let i = 0; i < segs; i++) {
+      const a0 = (i / segs) * TAU;
+      const a1 = ((i + 1) / segs) * TAU;
+      let d = Math.abs(((a0 + a1) / 2 - headA + Math.PI * 3) % TAU) - Math.PI;
+      d = Math.abs(d);
+      const heat = w.grazeGlow * clamp(1 - d / 0.55, 0, 1);
+      const pulse = 0.72 + 0.16 * Math.sin(w.cam.t * 1.7 + i * 0.4) + w.depthPulse * 0.4;
+      g.globalAlpha = clamp(pulse * (0.7 + heat), 0, 1);
+      g.strokeStyle = heat > 0.05 ? COLORS.rimHot : COLORS.rim;
+      g.lineWidth = Math.max(2.5, S * (0.014 + heat * 0.016));
+      g.beginPath();
+      g.arc(cx, cy, aR, a0, a1);
+      g.stroke();
+      // A thin white-hot lip just inside, so the edge is a hard line the eye
+      // can trust rather than a soft glow you can misjudge at speed.
+      g.globalAlpha = clamp(pulse * (0.5 + heat * 0.8), 0, 1);
+      g.strokeStyle = heat > 0.05 ? "#ffd9c4" : "#d6fbff";
+      g.lineWidth = Math.max(1, S * 0.004);
+      g.beginPath();
+      g.arc(cx, cy, aR - S * 0.009, a0, a1);
+      g.stroke();
+    }
+
+    // Polyps: a living edge rather than a drawn circle.
+    const polyps = 40;
+    const dot = sp.mote[4];
+    if (dot) {
+      for (let i = 0; i < polyps; i++) {
+        const a = (i / polyps) * TAU + w.cam.t * 0.03;
+        const wob = 1 + Math.sin(w.cam.t * 1.3 + i) * 0.012;
+        const size = S * 0.016 * (1 + 0.4 * Math.sin(w.cam.t * 2 + i * 1.7));
+        g.globalAlpha = 0.5;
+        g.drawImage(dot, cx + Math.cos(a) * aR * wob - size / 2, cy + Math.sin(a) * aR * wob - size / 2, size, size);
+      }
+    }
+    g.globalAlpha = 1;
+    g.globalCompositeOperation = "source-over";
+  }
+
+  function toWorld(clientX: number, clientY: number, rect: DOMRect): { x: number; y: number } {
+    const sx = clientX - rect.left;
+    const sy = clientY - rect.top;
+    return { x: (sx - view.cx) / view.scale, y: (sy - view.cy) / view.scale };
+  }
+
+  return { view, resize, draw, toWorld };
+}
+
+export const spriteSizes = { GLOW_PX, MOTE_PX };

--- a/dynawalla/games/serpent/src/game/render/sprites.ts
+++ b/dynawalla/games/serpent/src/game/render/sprites.ts
@@ -1,0 +1,310 @@
+/**
+ * Every soft-edged thing in the game is a pre-rendered sprite.
+ *
+ * Building a radial gradient costs roughly as much as filling one, so doing it
+ * per particle per frame is the classic way to lose a Canvas2D frame budget.
+ * These are built once at start-up and then it is `drawImage` all the way down:
+ * a particle, a body glow, a god ray and a shockwave are all the same call.
+ */
+
+export type Sprite = HTMLCanvasElement | OffscreenCanvas;
+
+type Ctx2D = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+
+function makeCanvas(w: number, h: number): { c: Sprite; g: Ctx2D } {
+  if (typeof OffscreenCanvas !== "undefined") {
+    const c = new OffscreenCanvas(w, h);
+    const g = c.getContext("2d");
+    if (!g) throw new Error("no 2d context");
+    return { c, g };
+  }
+  const c = document.createElement("canvas");
+  c.width = w;
+  c.height = h;
+  const g = c.getContext("2d");
+  if (!g) throw new Error("no 2d context");
+  return { c, g };
+}
+
+export type RGB = readonly [number, number, number];
+
+export const PALETTE: RGB[] = [
+  [255, 215, 106], // good  — gold
+  [196, 107, 255], // bad   — violet
+  [79, 240, 214], // serpent — teal
+  [232, 250, 255], // white
+  [143, 233, 255], // plankton
+  [255, 122, 92], // hot   — rim heat
+];
+
+const rgba = (c: RGB, a: number): string => `rgba(${c[0]},${c[1]},${c[2]},${a})`;
+
+export type SpriteSet = {
+  glow: Sprite[];
+  mote: Sprite[];
+  shard: Sprite[];
+  bubble: Sprite;
+  ray: Sprite;
+  bell: Sprite;
+  hunter: Sprite;
+  softRing: Sprite[];
+};
+
+const GLOW_SIZE = 128;
+const MOTE_SIZE = 64;
+
+function buildGlow(c: RGB): Sprite {
+  const { c: cv, g } = makeCanvas(GLOW_SIZE, GLOW_SIZE);
+  const r = GLOW_SIZE / 2;
+  const grad = g.createRadialGradient(r, r, 0, r, r, r);
+  grad.addColorStop(0, rgba(c, 0.95));
+  grad.addColorStop(0.12, rgba(c, 0.62));
+  grad.addColorStop(0.32, rgba(c, 0.24));
+  grad.addColorStop(0.62, rgba(c, 0.06));
+  grad.addColorStop(1, rgba(c, 0));
+  g.fillStyle = grad;
+  g.fillRect(0, 0, GLOW_SIZE, GLOW_SIZE);
+  return cv;
+}
+
+function buildMote(c: RGB): Sprite {
+  const { c: cv, g } = makeCanvas(MOTE_SIZE, MOTE_SIZE);
+  const r = MOTE_SIZE / 2;
+  const grad = g.createRadialGradient(r, r, 0, r, r, r);
+  grad.addColorStop(0, "rgba(255,255,255,1)");
+  grad.addColorStop(0.16, rgba(c, 0.95));
+  grad.addColorStop(0.44, rgba(c, 0.28));
+  grad.addColorStop(1, rgba(c, 0));
+  g.fillStyle = grad;
+  g.fillRect(0, 0, MOTE_SIZE, MOTE_SIZE);
+  return cv;
+}
+
+function buildShard(c: RGB): Sprite {
+  const { c: cv, g } = makeCanvas(MOTE_SIZE, MOTE_SIZE);
+  const r = MOTE_SIZE / 2;
+  g.translate(r, r);
+  const grad = g.createLinearGradient(-r, 0, r, 0);
+  grad.addColorStop(0, rgba(c, 0));
+  grad.addColorStop(0.42, rgba(c, 0.9));
+  grad.addColorStop(0.55, "rgba(255,255,255,0.95)");
+  grad.addColorStop(1, rgba(c, 0));
+  g.fillStyle = grad;
+  g.beginPath();
+  g.moveTo(-r, 0);
+  g.lineTo(0, -r * 0.24);
+  g.lineTo(r, 0);
+  g.lineTo(0, r * 0.24);
+  g.closePath();
+  g.fill();
+  return cv;
+}
+
+function buildBubble(): Sprite {
+  const { c: cv, g } = makeCanvas(MOTE_SIZE, MOTE_SIZE);
+  const r = MOTE_SIZE / 2;
+  g.strokeStyle = "rgba(180,240,255,0.6)";
+  g.lineWidth = 3;
+  g.beginPath();
+  g.arc(r, r, r * 0.62, 0, Math.PI * 2);
+  g.stroke();
+  g.fillStyle = "rgba(220,250,255,0.85)";
+  g.beginPath();
+  g.arc(r * 0.72, r * 0.68, r * 0.14, 0, Math.PI * 2);
+  g.fill();
+  return cv;
+}
+
+function buildRay(): Sprite {
+  const W = 220;
+  const H = 700;
+  const { c: cv, g } = makeCanvas(W, H);
+  const grad = g.createLinearGradient(0, 0, 0, H);
+  grad.addColorStop(0, "rgba(150,235,255,0.30)");
+  grad.addColorStop(0.35, "rgba(120,220,255,0.12)");
+  grad.addColorStop(1, "rgba(90,200,255,0)");
+  g.fillStyle = grad;
+  g.beginPath();
+  g.moveTo(W * 0.42, 0);
+  g.lineTo(W * 0.58, 0);
+  g.lineTo(W, H);
+  g.lineTo(0, H);
+  g.closePath();
+  g.fill();
+  // Soften the hard sides by feathering with a horizontal mask.
+  g.globalCompositeOperation = "destination-in";
+  const mask = g.createLinearGradient(0, 0, W, 0);
+  mask.addColorStop(0, "rgba(0,0,0,0)");
+  mask.addColorStop(0.5, "rgba(0,0,0,1)");
+  mask.addColorStop(1, "rgba(0,0,0,0)");
+  g.fillStyle = mask;
+  g.fillRect(0, 0, W, H);
+  return cv;
+}
+
+/**
+ * The plankton bell. Deliberately identical whatever the orb is worth — the
+ * number on it is the only thing that tells you anything, which is the game.
+ */
+function buildBell(): Sprite {
+  const S = 200;
+  const { c: cv, g } = makeCanvas(S, S);
+  const r = S / 2;
+  g.translate(r, r);
+
+  // Outer bioluminescence — the halo that makes it a creature in water.
+  const halo = g.createRadialGradient(0, 0, r * 0.4, 0, 0, r);
+  halo.addColorStop(0, "rgba(96,214,255,0.5)");
+  halo.addColorStop(0.45, "rgba(58,168,224,0.2)");
+  halo.addColorStop(1, "rgba(30,110,180,0)");
+  g.fillStyle = halo;
+  g.fillRect(-r, -r, S, S);
+
+  // tendrils
+  g.strokeStyle = "rgba(150,235,255,0.6)";
+  g.lineCap = "round";
+  for (let i = 0; i < 5; i++) {
+    const a = Math.PI / 2 + (i - 2) * 0.3;
+    g.lineWidth = 4.6 - Math.abs(i - 2) * 0.8;
+    g.beginPath();
+    g.moveTo(Math.cos(a) * r * 0.4, Math.sin(a) * r * 0.4);
+    g.quadraticCurveTo(
+      Math.cos(a) * r * 0.66 + (i - 2) * 9,
+      Math.sin(a) * r * 0.66,
+      Math.cos(a) * r * 0.94 + (i - 2) * 15,
+      Math.sin(a) * r * 0.9,
+    );
+    g.stroke();
+  }
+
+  // The bell itself: opaque enough to be an object, lit from the top.
+  const body = g.createRadialGradient(0, -r * 0.2, r * 0.04, 0, 0, r * 0.62);
+  body.addColorStop(0, "rgba(214,250,255,0.98)");
+  body.addColorStop(0.35, "rgba(120,214,244,0.93)");
+  body.addColorStop(0.7, "rgba(36,132,182,0.9)");
+  body.addColorStop(0.95, "rgba(14,72,116,0.86)");
+  body.addColorStop(1, "rgba(10,54,92,0.3)");
+  g.fillStyle = body;
+  g.beginPath();
+  g.arc(0, 0, r * 0.62, 0, Math.PI * 2);
+  g.fill();
+
+  // A darker chamber in the middle so the numeral always has contrast to sit on.
+  const core = g.createRadialGradient(0, 0, 0, 0, 0, r * 0.46);
+  core.addColorStop(0, "rgba(4,20,34,0.82)");
+  core.addColorStop(0.72, "rgba(5,26,44,0.6)");
+  core.addColorStop(1, "rgba(8,40,66,0)");
+  g.fillStyle = core;
+  g.beginPath();
+  g.arc(0, 0, r * 0.5, 0, Math.PI * 2);
+  g.fill();
+
+  g.strokeStyle = "rgba(190,248,255,0.95)";
+  g.lineWidth = 3.6;
+  g.beginPath();
+  g.arc(0, 0, r * 0.6, 0, Math.PI * 2);
+  g.stroke();
+  g.strokeStyle = "rgba(120,222,255,0.4)";
+  g.lineWidth = 1.8;
+  g.beginPath();
+  g.arc(0, 0, r * 0.5, 0, Math.PI * 2);
+  g.stroke();
+
+  return cv;
+}
+
+/** The hunter: a different animal. It can be carrying the value you want. */
+function buildHunter(): Sprite {
+  const S = 210;
+  const { c: cv, g } = makeCanvas(S, S);
+  const r = S / 2;
+  g.translate(r, r);
+
+  const halo = g.createRadialGradient(0, 0, r * 0.36, 0, 0, r);
+  halo.addColorStop(0, "rgba(255,132,96,0.42)");
+  halo.addColorStop(0.5, "rgba(190,64,72,0.16)");
+  halo.addColorStop(1, "rgba(90,20,40,0)");
+  g.fillStyle = halo;
+  g.fillRect(-r, -r, S, S);
+
+  g.strokeStyle = "rgba(255,164,124,0.72)";
+  g.lineWidth = 3.4;
+  g.lineCap = "round";
+  for (let i = 0; i < 9; i++) {
+    const a = (i / 9) * Math.PI * 2;
+    const len = r * (0.68 + (i % 2) * 0.24);
+    g.beginPath();
+    g.moveTo(Math.cos(a) * r * 0.44, Math.sin(a) * r * 0.44);
+    g.lineTo(Math.cos(a) * len, Math.sin(a) * len);
+    g.stroke();
+  }
+
+  const body = g.createRadialGradient(0, -r * 0.16, r * 0.04, 0, 0, r * 0.58);
+  body.addColorStop(0, "rgba(255,226,206,0.98)");
+  body.addColorStop(0.36, "rgba(238,124,92,0.94)");
+  body.addColorStop(0.78, "rgba(126,38,54,0.9)");
+  body.addColorStop(1, "rgba(58,14,34,0.5)");
+  g.fillStyle = body;
+  g.beginPath();
+  g.arc(0, 0, r * 0.58, 0, Math.PI * 2);
+  g.fill();
+
+  const core = g.createRadialGradient(0, 0, 0, 0, 0, r * 0.46);
+  core.addColorStop(0, "rgba(18,4,10,0.85)");
+  core.addColorStop(0.74, "rgba(30,8,16,0.6)");
+  core.addColorStop(1, "rgba(40,10,20,0)");
+  g.fillStyle = core;
+  g.beginPath();
+  g.arc(0, 0, r * 0.5, 0, Math.PI * 2);
+  g.fill();
+
+  g.strokeStyle = "rgba(255,196,168,0.95)";
+  g.lineWidth = 3;
+  g.beginPath();
+  for (let i = 0; i <= 12; i++) {
+    const a = (i / 12) * Math.PI * 2;
+    const rr = r * (i % 2 === 0 ? 0.58 : 0.48);
+    const x = Math.cos(a) * rr;
+    const y = Math.sin(a) * rr;
+    if (i === 0) g.moveTo(x, y);
+    else g.lineTo(x, y);
+  }
+  g.closePath();
+  g.stroke();
+
+  return cv;
+}
+
+function buildSoftRing(c: RGB): Sprite {
+  const S = 160;
+  const { c: cv, g } = makeCanvas(S, S);
+  const r = S / 2;
+  const grad = g.createRadialGradient(r, r, r * 0.62, r, r, r);
+  grad.addColorStop(0, rgba(c, 0));
+  grad.addColorStop(0.55, rgba(c, 0.55));
+  grad.addColorStop(0.8, rgba(c, 0.95));
+  grad.addColorStop(1, rgba(c, 0));
+  g.fillStyle = grad;
+  g.fillRect(0, 0, S, S);
+  return cv;
+}
+
+let cache: SpriteSet | null = null;
+
+export function sprites(): SpriteSet {
+  if (cache) return cache;
+  cache = {
+    glow: PALETTE.map(buildGlow),
+    mote: PALETTE.map(buildMote),
+    shard: PALETTE.map(buildShard),
+    bubble: buildBubble(),
+    ray: buildRay(),
+    bell: buildBell(),
+    hunter: buildHunter(),
+    softRing: PALETTE.map(buildSoftRing),
+  };
+  return cache;
+}
+
+export const GLOW_PX = GLOW_SIZE;
+export const MOTE_PX = MOTE_SIZE;

--- a/dynawalla/games/serpent/src/game/serpent.ts
+++ b/dynawalla/games/serpent/src/game/serpent.ts
@@ -1,0 +1,289 @@
+/**
+ * The serpent.
+ *
+ * The body is not a queue of grid cells — it is a *path*. The head writes into
+ * a ring buffer of positions and the segments are resampled along that path at
+ * fixed arc-length intervals every frame. That is the whole reason a modern
+ * snake feels like an animal rather than a train: the body follows exactly
+ * where the head went, at any angle, at any speed, and the turn radius is a
+ * consequence of an angular velocity limit rather than a grid.
+ *
+ * Swallowing is modelled as a *bolus*: a bump in radius that travels down the
+ * body from head to tail after every bite. It costs one Gaussian per segment
+ * and it is the single most satisfying thing in the game.
+ */
+
+import { TUNE } from "./tuning.ts";
+import { angleDelta, clamp } from "./num.ts";
+
+const PATH_CAP = 2600;
+const MAX_BOLUS = 24;
+const BOLUS_SPEED = 1.35;
+const BOLUS_WIDTH = 0.055;
+
+export const BOLUS_GOOD = 0;
+export const BOLUS_BAD = 1;
+
+export type Serpent = {
+  x: number;
+  y: number;
+  heading: number;
+  targetHeading: number;
+  speed: number;
+  boosting: boolean;
+  /** 0..1, how much of the boost visual is engaged. Smoothed. */
+  boostBlend: number;
+
+  pathX: Float32Array;
+  pathY: Float32Array;
+  pathHead: number;
+  pathCount: number;
+
+  segments: number;
+  targetSegments: number;
+
+  bodyX: Float32Array;
+  bodyY: Float32Array;
+  bodyR: Float32Array;
+  bodyCount: number;
+
+  bolusS: Float32Array;
+  bolusKind: Uint8Array;
+  bolusCount: number;
+
+  shield: boolean;
+  shieldSpin: number;
+  alive: boolean;
+};
+
+export function createSerpent(): Serpent {
+  const s: Serpent = {
+    x: 0,
+    y: 0,
+    heading: 0,
+    targetHeading: 0,
+    speed: TUNE.baseSpeed,
+    boosting: false,
+    boostBlend: 0,
+    pathX: new Float32Array(PATH_CAP),
+    pathY: new Float32Array(PATH_CAP),
+    pathHead: 0,
+    pathCount: 0,
+    segments: TUNE.startSegments,
+    targetSegments: TUNE.startSegments,
+    bodyX: new Float32Array(TUNE.maxSegments + 2),
+    bodyY: new Float32Array(TUNE.maxSegments + 2),
+    bodyR: new Float32Array(TUNE.maxSegments + 2),
+    bodyCount: 0,
+    bolusS: new Float32Array(MAX_BOLUS),
+    bolusKind: new Uint8Array(MAX_BOLUS),
+    bolusCount: 0,
+    shield: false,
+    shieldSpin: 0,
+    alive: true,
+  };
+  resetSerpent(s, 0, 0, 0);
+  return s;
+}
+
+export function resetSerpent(s: Serpent, x: number, y: number, heading: number): void {
+  s.x = x;
+  s.y = y;
+  s.heading = heading;
+  s.targetHeading = heading;
+  s.speed = TUNE.baseSpeed;
+  s.boosting = false;
+  s.boostBlend = 0;
+  s.segments = TUNE.startSegments;
+  s.targetSegments = TUNE.startSegments;
+  s.bolusCount = 0;
+  s.shield = false;
+  s.alive = true;
+
+  // Seed the path with a straight tail so the serpent starts whole rather than
+  // sprouting out of a point.
+  s.pathHead = 0;
+  s.pathCount = 0;
+  const back = TUNE.pathResolution;
+  const n = Math.ceil((TUNE.maxSegments * TUNE.segmentSpacing) / back) + 4;
+  for (let i = n; i >= 0; i--) {
+    pushPath(s, x - Math.cos(heading) * back * i, y - Math.sin(heading) * back * i);
+  }
+  rebuildBody(s);
+}
+
+function pushPath(s: Serpent, x: number, y: number): void {
+  s.pathHead = (s.pathHead + 1) % PATH_CAP;
+  s.pathX[s.pathHead] = x;
+  s.pathY[s.pathHead] = y;
+  if (s.pathCount < PATH_CAP) s.pathCount++;
+}
+
+export function grow(s: Serpent, n: number): void {
+  s.targetSegments = clamp(s.targetSegments + n, TUNE.minSegments, TUNE.maxSegments);
+}
+
+export function addBolus(s: Serpent, kind: number): void {
+  if (s.bolusCount >= MAX_BOLUS) {
+    // Drop the oldest rather than the newest: the newest is the one the player
+    // just earned and expects to see.
+    for (let i = 1; i < s.bolusCount; i++) {
+      s.bolusS[i - 1] = s.bolusS[i] as number;
+      s.bolusKind[i - 1] = s.bolusKind[i] as number;
+    }
+    s.bolusCount--;
+  }
+  const i = s.bolusCount++;
+  s.bolusS[i] = 0;
+  s.bolusKind[i] = kind;
+}
+
+export type StepOptions = {
+  desiredHeading: number | null;
+  wantBoost: boolean;
+  depth: number;
+  onBoostSpark(x: number, y: number, heading: number): void;
+};
+
+export function stepSerpent(s: Serpent, dt: number, o: StepOptions): void {
+  const canBoost = o.wantBoost && s.targetSegments > TUNE.boostMinSegments;
+  s.boosting = canBoost;
+  s.boostBlend = clamp(s.boostBlend + (canBoost ? dt * 7 : -dt * 6), 0, 1);
+
+  if (o.desiredHeading !== null) s.targetHeading = o.desiredHeading;
+
+  const turnRate = TUNE.turnRate + (TUNE.boostTurnRate - TUNE.turnRate) * s.boostBlend;
+  const d = angleDelta(s.heading, s.targetHeading);
+  const maxTurn = turnRate * dt;
+  s.heading += clamp(d, -maxTurn, maxTurn);
+
+  const base = Math.min(TUNE.baseSpeed + TUNE.speedPerDepth * o.depth, TUNE.maxSpeed);
+  s.speed = base * (1 + (TUNE.boostFactor - 1) * s.boostBlend);
+
+  const step = s.speed * dt;
+  s.x += Math.cos(s.heading) * step;
+  s.y += Math.sin(s.heading) * step;
+
+  const lx = s.pathX[s.pathHead] as number;
+  const ly = s.pathY[s.pathHead] as number;
+  if ((s.x - lx) ** 2 + (s.y - ly) ** 2 >= TUNE.pathResolution * TUNE.pathResolution) {
+    pushPath(s, s.x, s.y);
+  }
+
+  if (canBoost) {
+    s.targetSegments = Math.max(TUNE.minSegments, s.targetSegments - TUNE.boostDrain * dt);
+    const tail = s.bodyCount > 0 ? s.bodyCount - 1 : 0;
+    o.onBoostSpark(s.bodyX[tail] as number, s.bodyY[tail] as number, s.heading);
+  }
+
+  // The visible length chases the target so growth is a swell, not a jump.
+  const diff = s.targetSegments - s.segments;
+  const maxDelta = TUNE.growRate * dt;
+  s.segments += clamp(diff, -maxDelta, maxDelta);
+
+  for (let i = 0; i < s.bolusCount; i++) {
+    const next = (s.bolusS[i] as number) + BOLUS_SPEED * dt;
+    if (next > s.segments * TUNE.segmentSpacing + BOLUS_WIDTH * 2) {
+      const last = --s.bolusCount;
+      s.bolusS[i] = s.bolusS[last] as number;
+      s.bolusKind[i] = s.bolusKind[last] as number;
+      i--;
+      continue;
+    }
+    s.bolusS[i] = next;
+  }
+
+  s.shieldSpin += dt * 2.4;
+  rebuildBody(s);
+}
+
+/**
+ * Resample the path into evenly spaced body points, newest first. One pass over
+ * the path, no allocation. This is the hot loop; at 210 segments it walks about
+ * 470 path points.
+ */
+export function rebuildBody(s: Serpent): void {
+  const spacing = TUNE.segmentSpacing;
+  const want = Math.min(TUNE.maxSegments, Math.max(2, Math.round(s.segments)));
+
+  s.bodyX[0] = s.x;
+  s.bodyY[0] = s.y;
+  let out = 1;
+
+  let px = s.x;
+  let py = s.y;
+  let acc = 0;
+  let need = spacing;
+
+  for (let k = 0; k < s.pathCount && out < want; k++) {
+    const idx = (s.pathHead - k + PATH_CAP) % PATH_CAP;
+    const cx = s.pathX[idx] as number;
+    const cy = s.pathY[idx] as number;
+    let dx = cx - px;
+    let dy = cy - py;
+    const d = Math.hypot(dx, dy);
+    if (d <= 1e-9) continue;
+    dx /= d;
+    dy /= d;
+    while (acc + d >= need && out < want) {
+      const t = need - acc;
+      s.bodyX[out] = px + dx * t;
+      s.bodyY[out] = py + dy * t;
+      out++;
+      need += spacing;
+    }
+    acc += d;
+    px = cx;
+    py = cy;
+  }
+
+  // Ran out of recorded path (only possible in the first frames): extend
+  // straight back so the body never collapses to a stub.
+  while (out < want) {
+    s.bodyX[out] = px - Math.cos(s.heading) * spacing * (out - 1);
+    s.bodyY[out] = py - Math.sin(s.heading) * spacing * (out - 1);
+    out++;
+  }
+  s.bodyCount = out;
+
+  // Radius profile: a thick neck, a long taper, and a Gaussian bump per bolus.
+  const inv = 1 / Math.max(1, out - 1);
+  for (let i = 0; i < out; i++) {
+    const u = i * inv;
+    // Near-uniform down the length with a rounded stub for a tail. Tapering
+    // smoothly to a point is what made this read as a dart instead of an eel —
+    // a snake is a tube, and the silhouette has to say so.
+    const taper = u < 0.8 ? 1 - 0.1 * u : 0.92 - 0.36 * ((u - 0.8) / 0.2) ** 1.5;
+    const neck = 1 + 0.2 * Math.exp(-((u / 0.07) ** 2));
+    let r = TUNE.bodyRadius * taper * neck;
+    const si = i * spacing;
+    for (let b = 0; b < s.bolusCount; b++) {
+      const z = (si - (s.bolusS[b] as number)) / BOLUS_WIDTH;
+      if (z > -3 && z < 3) r += TUNE.bodyRadius * 0.85 * Math.exp(-z * z);
+    }
+    s.bodyR[i] = r;
+  }
+}
+
+/** Distance from the head to the nearest body point that can kill it. */
+export function selfHit(s: Serpent): boolean {
+  const lethal = TUNE.headRadius * TUNE.selfHitFactor;
+  const r2 = lethal * lethal;
+  for (let i = TUNE.neckSegments; i < s.bodyCount; i++) {
+    const dx = (s.bodyX[i] as number) - s.x;
+    const dy = (s.bodyY[i] as number) - s.y;
+    if (dx * dx + dy * dy < r2) return true;
+  }
+  return false;
+}
+
+export function bolusTintAt(s: Serpent, i: number): number {
+  const si = i * TUNE.segmentSpacing;
+  let bad = 0;
+  for (let b = 0; b < s.bolusCount; b++) {
+    if (s.bolusKind[b] !== BOLUS_BAD) continue;
+    const z = (si - (s.bolusS[b] as number)) / (BOLUS_WIDTH * 1.6);
+    if (z > -3 && z < 3) bad = Math.max(bad, Math.exp(-z * z));
+  }
+  return bad;
+}

--- a/dynawalla/games/serpent/src/game/tuning.ts
+++ b/dynawalla/games/serpent/src/game/tuning.ts
@@ -1,0 +1,138 @@
+/**
+ * Every number that decides how Serpent feels, in one file.
+ *
+ * The world is normalised: the arena starts at radius 1.0 and everything is
+ * expressed as a fraction of it. One unit is multiplied by `scale` at draw time,
+ * so the game plays identically on a 360px phone and a 27" monitor — the same
+ * turn radius relative to the board, the same number of body lengths across.
+ *
+ * Times are seconds unless the name says ms.
+ */
+
+export const TUNE = {
+  // ---- serpent -----------------------------------------------------------
+  headRadius: 0.046,
+  bodyRadius: 0.044,
+  segmentSpacing: 0.018,
+  pathResolution: 0.007,
+  startSegments: 34,
+  minSegments: 14,
+  maxSegments: 150,
+  /** Segments added per correct orb, and the rate the body actually catches up. */
+  growPerCorrect: 5,
+  shrinkPerWrong: 6,
+  shrinkPerWall: 5,
+  growRate: 34,
+
+  baseSpeed: 0.42,
+  speedPerDepth: 0.016,
+  maxSpeed: 0.72,
+  boostFactor: 1.85,
+  boostDrain: 2.4,
+  boostMinSegments: 16,
+
+  turnRate: 5.1,
+  boostTurnRate: 3.1,
+
+  /** Body points nearer the head than this can never kill you. */
+  neckSegments: 17,
+  selfHitFactor: 0.55,
+
+  // ---- arena -------------------------------------------------------------
+  arenaStart: 1.0,
+  arenaFloor: 0.62,
+  arenaShrinkPerDepth: 0.03,
+  arenaShrinkTime: 1.1,
+  grazeBand: 0.075,
+  grazeInterval: 0.22,
+
+  // ---- orbs --------------------------------------------------------------
+  orbRadius: 0.062,
+  /**
+   * You bite the *chamber*, not the halo. Measured: with the whole bell live,
+   * a competent pilot swallowed 58 wrong orbs a minute against 17 right ones —
+   * the field covered a quarter of the arena and could not be threaded. The
+   * drawn creature stays big and readable; the mouthful is the dark middle,
+   * which is exactly what the art already says.
+   */
+  orbCoreFactor: 0.62,
+  headBiteFactor: 0.45,
+  /**
+   * The mouth is at the *front*. Biting from the head's centre meant brushing
+   * an orb with your cheek ate it, so threading a dense field was impossible
+   * and two thirds of everything swallowed was wrong. Offsetting the bite point
+   * forward turns a side-swipe into a near miss, which is what it looks like.
+   */
+  biteOffset: 0.78,
+  orbBaseCount: 10,
+  orbPerDepth: 1,
+  orbMaxCount: 20,
+  goodBase: 3,
+  goodMax: 5,
+  orbDrift: 0.022,
+  hunterFromDepth: 5,
+  hunterChance: 0.22,
+  hunterSpeed: 0.06,
+  spawnClearance: 0.34,
+
+  // ---- progression -------------------------------------------------------
+  correctPerDepth: 9,
+  comboMax: 9,
+  shieldAtCombo: 6,
+
+  // ---- juice (all measured; see README) -----------------------------------
+  hitstopEatMs: 28,
+  hitstopWrongMs: 110,
+  hitstopWallMs: 95,
+  hitstopShieldMs: 180,
+  hitstopDeathMs: 260,
+
+  traumaEat: 0.1,
+  traumaWrong: 0.45,
+  traumaWall: 0.55,
+  traumaDepth: 0.25,
+  traumaShield: 0.5,
+  traumaDeath: 0.9,
+  traumaDecay: 1.7,
+  shakeMax: 0.055,
+
+  punchEat: 0.035,
+  punchWrong: 0.085,
+  punchDepth: 0.05,
+  punchDeath: 0.14,
+
+  slowmoMutateTime: 0.9,
+  slowmoMutateScale: 0.36,
+  slowmoDeathTime: 1.25,
+  slowmoDeathScale: 0.28,
+
+  /** Photosensitivity: never more often than this, never brighter than this. */
+  flashCooldown: 0.34,
+  flashMaxAlpha: 0.22,
+
+  particleCap: 900,
+  particleCapReduced: 220,
+  ringCap: 24,
+
+  mutateTime: 0.9,
+} as const;
+
+export const COLORS = {
+  deepTop: "#031a26",
+  deepBottom: "#00070f",
+  abyss: "#000308",
+  serpent: "#4ff0d6",
+  serpentDeep: "#0b5f74",
+  serpentCore: "#d8fff8",
+  lantern: "#9df6ff",
+  good: "#ffd76a",
+  goodDeep: "#c97b17",
+  bad: "#c46bff",
+  badDeep: "#4a1670",
+  plankton: "#8fe9ff",
+  rim: "#3fe4ff",
+  rimHot: "#ff7a5c",
+  ink: "#dff6ff",
+} as const;
+
+export const FONT_STACK = `ui-rounded, "SF Pro Rounded", "Avenir Next", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif`;

--- a/dynawalla/games/serpent/src/game/world.test.ts
+++ b/dynawalla/games/serpent/src/game/world.test.ts
@@ -1,0 +1,367 @@
+/**
+ * The run, driven headlessly.
+ *
+ * `world.ts` has no DOM and no audio of its own, so the whole rule set can be
+ * played thousands of times faster than real time. These tests play twenty
+ * simulated minutes and assert what a screenshot can never show: that the
+ * escalation actually arrives, that the pools stay inside their budgets, and
+ * that the learner model is never told the same thing twice.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createWorld, confirmPressed, stepWorld, startRun, type World } from "./world.ts";
+import { createStubHost } from "../stub/host.ts";
+import { TUNE } from "./tuning.ts";
+import { angleDelta } from "./num.ts";
+import { parseLabel, satisfies, type Predicate } from "../stub/exact.ts";
+import type { Audio } from "./audio.ts";
+import type { Host, Question, Report } from "../contract.ts";
+
+const FIXED = 1 / 120;
+
+const silentAudio = (): Audio => ({
+  enabled: false,
+  ready: false,
+  resume() {},
+  setEnabled() {},
+  eat() {},
+  wrong() {},
+  wall() {},
+  graze() {},
+  depth() {},
+  mutate() {},
+  shield() {},
+  shieldBreak() {},
+  death() {},
+  setBoost() {},
+  ambient() {},
+  dispose() {},
+});
+
+type Instrumented = {
+  host: Host;
+  served: Question[];
+  reports: Report[];
+};
+
+function instrument(seed: string, startLevel?: number): Instrumented {
+  const served: Question[] = [];
+  const reports: Report[] = [];
+  const inner = createStubHost(startLevel === undefined ? { seed } : { seed, startLevel });
+  const host: Host = {
+    next() {
+      const q = inner.next();
+      served.push(q);
+      return q;
+    },
+    report(r) {
+      reports.push(r);
+      inner.report(r);
+    },
+    haptic() {},
+    prefersReducedMotion: () => false,
+  };
+  return { host, served, reports };
+}
+
+/**
+ * A pilot good enough to be worth measuring: it prefers targets it can turn
+ * toward, and it looks ahead along its own arc rather than only pushing away
+ * from body points it is already touching. A dumb bot makes a game look harder
+ * than it is, and then you tune the wrong thing.
+ */
+function pilotHeading(w: World, skill: number): number | null {
+  const s = w.serpent;
+  const rim = Math.hypot(s.x, s.y);
+
+  let best: { x: number; y: number } | null = null;
+  let bestCost = Infinity;
+  for (const o of w.orbs) {
+    if (o.scale < 0.7 || o.moltT > 0) continue;
+    const want = o.good ? Math.random() < skill : Math.random() > skill;
+    if (!want) continue;
+    const dx = o.x - s.x;
+    const dy = o.y - s.y;
+    const d = Math.hypot(dx, dy);
+    const turn = Math.abs(angleDelta(s.heading, Math.atan2(dy, dx)));
+    const cost = d + turn * 0.34; // a target behind you is worth less
+    if (cost < bestCost) {
+      bestCost = cost;
+      best = o;
+    }
+  }
+
+  let ax = best ? best.x - s.x : -s.x;
+  let ay = best ? best.y - s.y : -s.y;
+  if (rim > w.arenaR - 0.3) {
+    ax -= s.x * 5;
+    ay -= s.y * 5;
+  }
+  // Look ahead: sample where the head will be and steer off anything there.
+  for (const lead of [0.14, 0.26]) {
+    const px = s.x + Math.cos(s.heading) * lead;
+    const py = s.y + Math.sin(s.heading) * lead;
+    for (let i = TUNE.neckSegments; i < s.bodyCount; i += 2) {
+      const dx = (s.bodyX[i] as number) - px;
+      const dy = (s.bodyY[i] as number) - py;
+      const dd = dx * dx + dy * dy;
+      if (dd < 0.05 && dd > 1e-6) {
+        ax -= (dx / dd) * 0.012;
+        ay -= (dy / dd) * 0.012;
+      }
+    }
+  }
+  for (const o of w.orbs) {
+    if (o.good) continue;
+    const dx = o.x - s.x;
+    const dy = o.y - s.y;
+    const dd = dx * dx + dy * dy;
+    if (dd < 0.06 && dd > 1e-6) {
+      ax -= (dx / dd) * 0.004;
+      ay -= (dy / dd) * 0.004;
+    }
+  }
+  return Math.atan2(ay, ax);
+}
+
+function play(w: World, seconds: number, skill: number, boost = false): void {
+  const steps = Math.round(seconds / FIXED);
+  for (let i = 0; i < steps; i++) {
+    if (w.phase === "dead" && w.deathT > 0.6) confirmPressed(w);
+    stepWorld(w, FIXED, { heading: pilotHeading(w, skill), boost });
+  }
+}
+
+test("a question is never reported twice, and every report names a served question", () => {
+  const { host, served, reports } = instrument("no-double");
+  const w = createWorld(host, silentAudio(), false);
+  startRun(w);
+  play(w, 240, 0.9);
+
+  const ids = new Set(served.map((q) => q.id));
+  const seen = new Set<string>();
+  for (const r of reports) {
+    assert.ok(ids.has(r.questionId), `reported an id that was never served: ${r.questionId}`);
+    assert.ok(!seen.has(r.questionId), `reported ${r.questionId} twice`);
+    seen.add(r.questionId);
+  }
+  assert.ok(reports.length > 40, `four minutes of play produced only ${reports.length} reports`);
+  assert.ok(reports.length <= served.length);
+});
+
+test("a report's verdict is exactly what the arithmetic says", () => {
+  // Independent check: take the report's `answered` label, parse it, and judge
+  // it against the condition the prompt names. The game must never call an orb
+  // correct that the predicate rejects.
+  const { host, served, reports } = instrument("verdict");
+  const w = createWorld(host, silentAudio(), false);
+  startRun(w);
+  play(w, 300, 0.75);
+
+  const promptOf = new Map(served.map((q) => [q.id, q.prompt]));
+  let checked = 0;
+  for (const r of reports) {
+    const prompt = promptOf.get(r.questionId);
+    assert.ok(prompt);
+    const p = predicateFromPrompt(prompt);
+    if (!p) continue;
+    const v = parseLabel(r.answered);
+    assert.ok(v !== null, `report carried an unparsable label ${JSON.stringify(r.answered)}`);
+    assert.equal(satisfies(p, v), r.correct, `${r.answered} vs ${prompt}: reported ${r.correct}`);
+    checked++;
+  }
+  assert.ok(checked > 40, `only ${checked} reports were checkable`);
+});
+
+function predicateFromPrompt(prompt: string): Predicate | null {
+  let m = /^= (-?\d+)$/.exec(prompt);
+  if (m) return { kind: "eq", target: { n: Number(m[1]), d: 1 } };
+  m = /^(\d+) × \?$/.exec(prompt);
+  if (m) return { kind: "multiple", base: Number(m[1]) };
+  m = /^([<>]) (\d+)\/(\d+)$/.exec(prompt);
+  if (m) {
+    const ref = { n: Number(m[2]), d: Number(m[3]) };
+    return m[1] === ">" ? { kind: "gt", ref } : { kind: "lt", ref };
+  }
+  return null;
+}
+
+test("twenty minutes of play escalates and never leaves its budgets", () => {
+  const { host, reports } = instrument("long-haul");
+  const w = createWorld(host, silentAudio(), false);
+  startRun(w);
+
+  let maxParticles = 0;
+  let maxOrbs = 0;
+  let maxBody = 0;
+  let deepest = 1;
+  let smallestArena = 1;
+  const steps = Math.round(20 * 60 / FIXED);
+  for (let i = 0; i < steps; i++) {
+    if (w.phase === "dead" && w.deathT > 0.6) confirmPressed(w);
+    stepWorld(w, FIXED, { heading: pilotHeading(w, 0.97), boost: i % 900 < 120 });
+    maxParticles = Math.max(maxParticles, w.particles.count);
+    maxOrbs = Math.max(maxOrbs, w.orbs.length);
+    maxBody = Math.max(maxBody, w.serpent.bodyCount);
+    deepest = Math.max(deepest, w.depth);
+    smallestArena = Math.min(smallestArena, w.arenaR);
+  }
+
+  assert.ok(deepest >= 8, `only reached depth ${deepest} in twenty minutes`);
+  assert.ok(smallestArena <= TUNE.arenaStart - TUNE.arenaShrinkPerDepth * 3, `arena barely closed: ${smallestArena}`);
+  assert.ok(smallestArena >= TUNE.arenaFloor - 1e-6, `arena shrank past its floor: ${smallestArena}`);
+  assert.ok(maxParticles <= w.particles.cap, `particle cap breached: ${maxParticles}`);
+  assert.ok(maxOrbs <= TUNE.orbMaxCount, `orb cap breached: ${maxOrbs}`);
+  assert.ok(maxBody <= TUNE.maxSegments, `segment cap breached: ${maxBody}`);
+  assert.ok(w.rings.count <= w.rings.cap);
+  assert.ok(reports.length > 200, `twenty minutes produced only ${reports.length} answers`);
+  assert.ok(Number.isFinite(w.score) && w.score >= 0);
+  assert.ok(Number.isFinite(w.serpent.x) && Number.isFinite(w.serpent.y));
+});
+
+test("the arena always holds enough correct answers to be playable", () => {
+  const { host } = instrument("supply");
+  const w = createWorld(host, silentAudio(), false);
+  startRun(w);
+  let starved = 0;
+  const steps = Math.round(180 / FIXED);
+  for (let i = 0; i < steps; i++) {
+    stepWorld(w, FIXED, { heading: pilotHeading(w, 0.95), boost: false });
+    if (w.phase !== "play") continue;
+    // Allow one frame of slack around a bite and a mutation's molt.
+    if (w.mutateT > 0) continue;
+    const good = w.orbs.filter((o) => o.good).length;
+    if (good < 1) starved++;
+  }
+  assert.equal(starved, 0, `the field ran out of correct answers on ${starved} frames`);
+});
+
+test("eating wrong costs length; eating right pays it back", () => {
+  const { host } = instrument("stakes");
+  const w = createWorld(host, silentAudio(), false);
+  startRun(w);
+  const start = w.serpent.targetSegments;
+  play(w, 90, 0); // a pilot that eats only wrong answers
+  assert.ok(w.wrongEats > 4, `expected the bad pilot to eat wrong things, got ${w.wrongEats}`);
+  assert.ok(w.serpent.targetSegments < start || w.phase === "dead", "wrong answers must cost something");
+  assert.ok(w.serpent.targetSegments >= TUNE.minSegments, "the serpent must never shrink below its floor");
+  assert.equal(w.combo, 0);
+});
+
+test("the wall costs length and throws you back — it never ends the run", () => {
+  // Twenty measured minutes said every single death was the wall and none was
+  // the serpent's own body. Dying while reading a number is the least
+  // interesting death a snake can have, so the rim became a cost.
+  const { host } = instrument("wall");
+  const w = createWorld(host, silentAudio(), false);
+  startRun(w);
+  const before = w.serpent.targetSegments;
+  let hits = 0;
+  for (let i = 0; i < 2400 && hits === 0; i++) {
+    stepWorld(w, FIXED, { heading: 0, boost: false });
+    if (w.wallT > 0) hits++;
+  }
+  assert.equal(hits, 1, "driving straight at the wall must register a wall hit");
+  assert.equal(w.phase, "play", "the rim must not end the run");
+  assert.ok(w.serpent.targetSegments < before, "the rim must cost length");
+  assert.ok(Math.hypot(w.serpent.x, w.serpent.y) < w.arenaR, "the serpent must be put back inside the arena");
+  assert.equal(w.combo, 0, "the rim must break the combo");
+  // And the deflection must not aim the head back down its own body.
+  const away = Math.cos(w.serpent.heading) * w.serpent.x + Math.sin(w.serpent.heading) * w.serpent.y;
+  assert.ok(away < 0, "the deflection must send the serpent inward, not along the wall forever");
+});
+
+test("outgrowing your own turning circle is what ends a run", () => {
+  const { host } = instrument("selfdeath");
+  const w = createWorld(host, silentAudio(), false);
+  startRun(w);
+  w.serpent.targetSegments = 120;
+  w.serpent.segments = 120;
+  // Hold a hard turn: the head comes round into its own flank.
+  for (let i = 0; i < 4000 && w.phase === "play"; i++) {
+    stepWorld(w, FIXED, { heading: w.serpent.heading + 1.4, boost: false });
+  }
+  assert.equal(w.phase, "dead", "a tight coil must be lethal");
+  assert.ok(w.best >= 0);
+  for (let i = 0; i < 80; i++) stepWorld(w, FIXED, { heading: 0, boost: false });
+  confirmPressed(w);
+  assert.equal(w.phase, "play");
+  assert.equal(w.depth, 1);
+  assert.equal(w.score, 0);
+  assert.ok(w.serpent.alive);
+});
+
+test("a shield is earned by a combo and spends itself on the next death", () => {
+  const { host } = instrument("shield");
+  const w = createWorld(host, silentAudio(), false);
+  startRun(w);
+  let restarts = 0;
+  for (let i = 0; i < 90000 && !w.serpent.shield; i++) {
+    if (w.phase === "dead" && w.deathT > 0.6) {
+      restarts++;
+      confirmPressed(w);
+    }
+    stepWorld(w, FIXED, { heading: pilotHeading(w, 1), boost: false });
+  }
+  assert.ok(w.serpent.shield, "a perfect pilot never earned a shield");
+  assert.ok(w.combo >= TUNE.shieldAtCombo);
+
+  w.serpent.targetSegments = 120;
+  w.serpent.segments = 120;
+  for (let i = 0; i < 6000 && w.serpent.shield && w.phase === "play"; i++) {
+    stepWorld(w, FIXED, { heading: w.serpent.heading + 1.4, boost: false });
+  }
+  assert.equal(w.phase, "play", "the shield must absorb the hit, not merely delay it");
+  assert.equal(w.serpent.shield, false);
+});
+
+test("reduced motion drops the motion and keeps the game", () => {
+  const { host, reports } = instrument("reduced");
+  const w = createWorld(host, silentAudio(), true);
+  startRun(w);
+  play(w, 120, 0.85);
+  assert.equal(w.cam.trauma, 0, "reduced motion must never accumulate shake");
+  assert.equal(w.cam.shakeX, 0);
+  assert.equal(w.cam.zoom, 1, "reduced motion must never punch the camera");
+  assert.equal(w.cam.flashAlpha, 0);
+  assert.ok(w.particles.cap <= TUNE.particleCapReduced);
+  assert.ok(reports.length > 20, "reduced motion must not stop the game being playable");
+  assert.ok(w.correctEats > 10);
+});
+
+test("the same seed serves the same questions to the same run", () => {
+  const a = instrument("repeat", 3);
+  const b = instrument("repeat", 3);
+  const wa = createWorld(a.host, silentAudio(), false);
+  const wb = createWorld(b.host, silentAudio(), false);
+  startRun(wa);
+  startRun(wb);
+  play(wa, 60, 0.9);
+  play(wb, 60, 0.4);
+  const n = Math.min(a.served.length, b.served.length, 30);
+  assert.ok(n >= 10);
+  for (let i = 0; i < n; i++) {
+    assert.equal((a.served[i] as Question).prompt, (b.served[i] as Question).prompt);
+    assert.equal((a.served[i] as Question).answer, (b.served[i] as Question).answer);
+  }
+});
+
+test("the simulation step stays far inside a 60fps budget", () => {
+  const { host } = instrument("bench");
+  const w = createWorld(host, silentAudio(), false);
+  startRun(w);
+  // Warm up to a heavy state: long body, full field, particles in flight.
+  play(w, 240, 0.98);
+  const heavy = w.serpent.bodyCount;
+
+  const N = 24000; // 200 seconds of simulation
+  const t0 = performance.now();
+  for (let i = 0; i < N; i++) {
+    stepWorld(w, FIXED, { heading: pilotHeading(w, 0.98), boost: true });
+  }
+  const perStep = (performance.now() - t0) / N;
+  // Two sim steps per rendered frame at 60fps. The whole simulation must be a
+  // rounding error next to the 16.7ms frame, leaving the budget for drawing.
+  assert.ok(perStep < 0.35, `sim step cost ${perStep.toFixed(3)}ms at body ${heavy}`);
+});

--- a/dynawalla/games/serpent/src/game/world.test.ts
+++ b/dynawalla/games/serpent/src/game/world.test.ts
@@ -18,6 +18,30 @@ import { parseLabel, satisfies, type Predicate } from "../stub/exact.ts";
 import type { Audio } from "./audio.ts";
 import type { Host, Question, Report } from "../contract.ts";
 
+/**
+ * The world's ambience — which label an orb wears, whether a hunter spawns,
+ * how many sparks a burst throws — runs on `Math.random` by design: `num.ts`
+ * calls it "a visual-only RNG, kept separate from the question stream", and the
+ * question stream itself is exact and separately seeded. That is the right
+ * choice for play and the wrong one for a test. Driven by the real
+ * `Math.random`, this file failed about two runs in five, in three different
+ * tests, because the bot and the spawner both drew from it.
+ *
+ * Pin it to a seeded stream for the whole file so a failure here always means a
+ * rule changed, never that the dice landed badly. The game itself is untouched.
+ */
+const seededRandom = (seed: number): (() => number) => {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+Math.random = seededRandom(0x5e12e17);
+
 const FIXED = 1 / 120;
 
 const silentAudio = (): Audio => ({

--- a/dynawalla/games/serpent/src/game/world.ts
+++ b/dynawalla/games/serpent/src/game/world.ts
@@ -1,0 +1,693 @@
+/**
+ * The run: state, rules, and every consequence.
+ *
+ * Shape of the loop — the arena floor says what to eat (`= 12`, `6 × ?`,
+ * `> 3/4`), the water is full of numbers, and the wrong ones are not merely
+ * inedible: they are the obstacle course. Eat right and you grow; eat wrong and
+ * you cough up length. The board closes in as you go deeper.
+ *
+ * Reporting is one report per served question, always. A *trial* is resolved by
+ * the next orb the player eats, whichever orb that is — which is the honest
+ * question anyway: given this condition, did they take a value that satisfies
+ * it? Because every question in an epoch shares one condition, the labels are
+ * interchangeable and this stays exact.
+ */
+
+import type { Host, Question } from "../contract.ts";
+import { TUNE } from "./tuning.ts";
+import { clamp, randRange, TAU } from "./num.ts";
+import {
+  addTrauma,
+  createCamera,
+  flash,
+  hitstop,
+  punch,
+  slowmo,
+  type Camera,
+} from "./fx/camera.ts";
+import {
+  PC_HOT,
+  PC_SERPENT,
+  burstBad,
+  burstBubbles,
+  burstDeath,
+  burstDebris,
+  burstEat,
+  burstSpark,
+  clearParticles,
+  clearRings,
+  createParticles,
+  createRings,
+  ring,
+  updateParticles,
+  updateRings,
+  type Particles,
+  type Rings,
+} from "./fx/particles.ts";
+import {
+  BOLUS_BAD,
+  BOLUS_GOOD,
+  addBolus,
+  createSerpent,
+  grow,
+  resetSerpent,
+  selfHit,
+  stepSerpent,
+  type Serpent,
+} from "./serpent.ts";
+import { createOrb, molt, orbDrawRadius, placeOrb, stepOrbs, type Orb } from "./orbs.ts";
+import type { Audio } from "./audio.ts";
+
+const BEST_KEY = "serpent.best";
+
+export type Phase = "attract" | "play" | "dead";
+
+type Trial = { q: Question; servedAtMs: number };
+
+export type Floater = {
+  x: number;
+  y: number;
+  vy: number;
+  life: number;
+  maxLife: number;
+  text: string;
+  tone: 0 | 1 | 2;
+};
+
+export type World = {
+  host: Host;
+  audio: Audio;
+  cam: Camera;
+  serpent: Serpent;
+  orbs: Orb[];
+  particles: Particles;
+  rings: Rings;
+  floaters: Floater[];
+
+  phase: Phase;
+  paused: boolean;
+  reduced: boolean;
+  time: number;
+  runTime: number;
+
+  depth: number;
+  score: number;
+  best: number;
+  combo: number;
+  bestCombo: number;
+  correctEats: number;
+  wrongEats: number;
+
+  arenaR: number;
+  arenaTargetR: number;
+
+  prompt: string;
+  pending: Trial[];
+  goodPool: string[];
+  badPool: string[];
+
+  mutateT: number;
+  mutateDur: number;
+  depthPulse: number;
+  scorePulse: number;
+  comboPulse: number;
+  grazeT: number;
+  grazeGlow: number;
+  invulnT: number;
+  wallT: number;
+  deathT: number;
+  shieldPulse: number;
+
+  /** Latency of the most recent answer, for the debug overlay. */
+  lastAnswerMs: number;
+};
+
+const nowMs = (): number => (typeof performance !== "undefined" ? performance.now() : Date.now());
+
+function readBest(): number {
+  try {
+    const v = Number(localStorage.getItem(BEST_KEY));
+    return Number.isFinite(v) && v > 0 ? Math.floor(v) : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function writeBest(v: number): void {
+  try {
+    localStorage.setItem(BEST_KEY, String(Math.floor(v)));
+  } catch {
+    /* private mode is not an error */
+  }
+}
+
+export function createWorld(host: Host, audio: Audio, reduced: boolean): World {
+  const w: World = {
+    host,
+    audio,
+    cam: createCamera(reduced),
+    serpent: createSerpent(),
+    orbs: [],
+    particles: createParticles(reduced ? TUNE.particleCapReduced : TUNE.particleCap, reduced ? 0.28 : 1),
+    rings: createRings(TUNE.ringCap),
+    floaters: [],
+
+    phase: "attract",
+    paused: false,
+    reduced,
+    time: 0,
+    runTime: 0,
+
+    depth: 1,
+    score: 0,
+    best: readBest(),
+    combo: 0,
+    bestCombo: 0,
+    correctEats: 0,
+    wrongEats: 0,
+
+    arenaR: TUNE.arenaStart,
+    arenaTargetR: TUNE.arenaStart,
+
+    prompt: "",
+    pending: [],
+    goodPool: [],
+    badPool: [],
+
+    mutateT: 0,
+    mutateDur: TUNE.mutateTime,
+    depthPulse: 0,
+    scorePulse: 0,
+    comboPulse: 0,
+    grazeT: 0,
+    grazeGlow: 0,
+    invulnT: 0,
+    wallT: 0,
+    deathT: 0,
+    shieldPulse: 0,
+
+    lastAnswerMs: 0,
+  };
+  resetRun(w, "attract");
+  return w;
+}
+
+// ------------------------------------------------------------------ content
+
+function pushPool(pool: string[], label: string, cap: number): void {
+  if (!pool.includes(label)) pool.push(label);
+  while (pool.length > cap) pool.shift();
+}
+
+function adoptCondition(w: World, q: Question): void {
+  w.prompt = q.prompt;
+  w.pending = [{ q, servedAtMs: nowMs() }];
+  w.goodPool = [q.answer];
+  w.badPool = q.distractors.slice();
+}
+
+/**
+ * Pull one question. A prompt change is the world mutating — that decision
+ * belongs to the host, which is the side that will one day know the learner.
+ */
+function pullQuestion(w: World): boolean {
+  const q = w.host.next();
+  if (q.prompt !== w.prompt) {
+    beginMutation(w, q);
+    return true;
+  }
+  w.pending.push({ q, servedAtMs: nowMs() });
+  pushPool(w.goodPool, q.answer, 10);
+  for (const d of q.distractors) pushPool(w.badPool, d, 26);
+  return false;
+}
+
+function fieldTargets(w: World): { count: number; good: number } {
+  return {
+    count: Math.min(TUNE.orbMaxCount, TUNE.orbBaseCount + (w.depth - 1) * TUNE.orbPerDepth),
+    good: Math.min(TUNE.goodMax, TUNE.goodBase + Math.floor((w.depth - 1) / 3)),
+  };
+}
+
+function pickLabel(w: World, good: boolean): string {
+  const pool = good ? w.goodPool : w.badPool;
+  if (pool.length === 0) return good ? "?" : "?";
+  // Prefer something not already on the field, so the arena reads as varied.
+  for (let i = 0; i < 8; i++) {
+    const label = pool[Math.floor(Math.random() * pool.length)] as string;
+    if (!w.orbs.some((o) => o.label === label)) return label;
+  }
+  return pool[Math.floor(Math.random() * pool.length)] as string;
+}
+
+function addOrb(w: World, good: boolean): Orb {
+  const orb = createOrb();
+  orb.label = pickLabel(w, good);
+  orb.good = good;
+  orb.hunter = w.depth >= TUNE.hunterFromDepth && Math.random() < TUNE.hunterChance;
+  placeOrb(orb, w.orbs, w.arenaR, w.serpent.x, w.serpent.y);
+  w.orbs.push(orb);
+  return orb;
+}
+
+function ensureField(w: World): void {
+  const t = fieldTargets(w);
+  let guard = 0;
+  while (w.pending.length < t.good + 1 && guard++ < 6) {
+    if (pullQuestion(w)) break;
+  }
+  let good = w.orbs.filter((o) => o.good).length;
+  while (w.orbs.length < t.count) {
+    const wantGood = good < t.good;
+    addOrb(w, wantGood);
+    if (wantGood) good++;
+  }
+  // Safety net: if the quota is short and the field is full, an orb changes its
+  // mind. The molt animation makes that legible rather than a silent swap.
+  if (good < t.good && w.mutateT <= 0) {
+    let best: Orb | null = null;
+    let bestD = -1;
+    for (const o of w.orbs) {
+      if (o.good || o.moltT > 0) continue;
+      const d = Math.hypot(o.x - w.serpent.x, o.y - w.serpent.y);
+      if (d > bestD) {
+        bestD = d;
+        best = o;
+      }
+    }
+    if (best) molt(best, pickLabel(w, true), true, 0.45);
+  }
+}
+
+function beginMutation(w: World, q: Question): void {
+  adoptCondition(w, q);
+  w.mutateT = TUNE.mutateTime;
+  w.mutateDur = TUNE.mutateTime;
+
+  const t = fieldTargets(w);
+  let good = 0;
+  for (const o of w.orbs) {
+    const wantGood = good < t.good;
+    if (wantGood) good++;
+    molt(o, pickLabel(w, wantGood), wantGood, TUNE.mutateTime * 0.8);
+  }
+  slowmo(w.cam, TUNE.slowmoMutateTime, TUNE.slowmoMutateScale);
+  addTrauma(w.cam, 0.18);
+  flash(w.cam, "#4ff0d6", 0.1);
+  ring(w.rings, 0, 0, w.arenaR * 0.05, w.arenaR * 0.9, 0.7, 0.02, 2);
+  w.audio.mutate();
+  if (w.phase === "play") w.host.haptic("medium");
+}
+
+// --------------------------------------------------------------------- run
+
+export function resetRun(w: World, phase: Phase): void {
+  w.phase = phase;
+  w.paused = false;
+  w.runTime = 0;
+  w.depth = 1;
+  w.score = 0;
+  w.combo = 0;
+  w.bestCombo = 0;
+  w.correctEats = 0;
+  w.wrongEats = 0;
+  w.arenaR = TUNE.arenaStart;
+  w.arenaTargetR = TUNE.arenaStart;
+  w.orbs = [];
+  w.pending = [];
+  w.goodPool = [];
+  w.badPool = [];
+  w.prompt = "";
+  w.mutateT = 0;
+  w.grazeT = 0;
+  w.grazeGlow = 0;
+  w.invulnT = 0;
+  w.wallT = 0;
+  w.deathT = 0;
+  w.floaters.length = 0;
+  clearParticles(w.particles);
+  clearRings(w.rings);
+  resetSerpent(w.serpent, 0, 0, randRange(0, TAU));
+
+  adoptCondition(w, w.host.next());
+  ensureField(w);
+  for (const o of w.orbs) o.scale = 1;
+}
+
+export function startRun(w: World): void {
+  resetRun(w, "play");
+  w.audio.resume();
+  w.audio.ambient(true);
+  w.host.haptic("light");
+  punch(w.cam, 0.05);
+  ring(w.rings, 0, 0, 0.02, 0.4, 0.5, 0.014, 2);
+}
+
+// ------------------------------------------------------------------ events
+
+function floater(w: World, x: number, y: number, text: string, tone: 0 | 1 | 2): void {
+  if (w.floaters.length > 22) w.floaters.shift();
+  w.floaters.push({ x, y, vy: -0.16, life: 0.9, maxLife: 0.9, text, tone });
+}
+
+function eatOrb(w: World, index: number): void {
+  const orb = w.orbs[index];
+  if (!orb) return;
+  const correct = orb.good;
+  const s = w.serpent;
+
+  if (w.phase === "play") {
+    const trial = w.pending.shift() ?? { q: w.host.next(), servedAtMs: nowMs() };
+    const ms = Math.max(0, Math.round(nowMs() - trial.servedAtMs));
+    w.lastAnswerMs = ms;
+    w.host.report({ questionId: trial.q.id, correct, ms, answered: orb.label });
+    // The next trial goes live the moment this one is answered — in a
+    // continuous game the clock that matters is "how long since the last bite",
+    // not "how long since the question was generated".
+    const t0 = nowMs();
+    for (const p of w.pending) p.servedAtMs = t0;
+  }
+
+  if (correct) {
+    w.combo = Math.min(TUNE.comboMax, w.combo + 1);
+    w.bestCombo = Math.max(w.bestCombo, w.combo);
+    w.correctEats++;
+    const gain = 10 * w.combo;
+    w.score += gain;
+    w.scorePulse = 1;
+    w.comboPulse = 1;
+
+    grow(s, TUNE.growPerCorrect);
+    addBolus(s, BOLUS_GOOD);
+    burstEat(w.particles, orb.x, orb.y, w.combo / TUNE.comboMax);
+    ring(w.rings, orb.x, orb.y, TUNE.orbRadius * 0.6, TUNE.orbRadius * 3.4, 0.34, 0.008, 0);
+    floater(w, orb.x, orb.y, `+${gain}`, 0);
+    hitstop(w.cam, TUNE.hitstopEatMs);
+    addTrauma(w.cam, TUNE.traumaEat);
+    punch(w.cam, TUNE.punchEat);
+    w.audio.eat(w.combo - 1);
+    if (w.phase === "play") w.host.haptic("light");
+
+    if (!s.shield && w.combo > 0 && w.combo % TUNE.shieldAtCombo === 0) {
+      s.shield = true;
+      w.shieldPulse = 1;
+      ring(w.rings, s.x, s.y, TUNE.headRadius, TUNE.headRadius * 7, 0.5, 0.01, 3);
+      w.audio.shield();
+      if (w.phase === "play") w.host.haptic("success");
+    }
+
+    if (w.correctEats > 0 && w.correctEats % TUNE.correctPerDepth === 0) descend(w);
+  } else {
+    w.wrongEats++;
+    w.combo = 0;
+    grow(s, -TUNE.shrinkPerWrong);
+    addBolus(s, BOLUS_BAD);
+    burstBad(w.particles, orb.x, orb.y);
+    burstDebris(w.particles, s.x, s.y, s.heading, TUNE.shrinkPerWrong);
+    ring(w.rings, orb.x, orb.y, TUNE.orbRadius * 0.4, TUNE.orbRadius * 5, 0.45, 0.014, 1);
+    floater(w, orb.x, orb.y, `−${TUNE.shrinkPerWrong}`, 1);
+    hitstop(w.cam, TUNE.hitstopWrongMs);
+    addTrauma(w.cam, TUNE.traumaWrong);
+    punch(w.cam, TUNE.punchWrong);
+    flash(w.cam, "#c46bff", 0.16);
+    w.audio.wrong();
+    if (w.phase === "play") w.host.haptic("heavy");
+  }
+
+  w.orbs.splice(index, 1);
+  const t = fieldTargets(w);
+  const good = w.orbs.filter((o) => o.good).length;
+  addOrb(w, good < t.good);
+  ensureField(w);
+}
+
+function descend(w: World): void {
+  w.depth++;
+  w.depthPulse = 1;
+  w.arenaTargetR = Math.max(TUNE.arenaFloor, w.arenaTargetR - TUNE.arenaShrinkPerDepth);
+  w.score += 50 * w.depth;
+  w.scorePulse = 1;
+  addTrauma(w.cam, TUNE.traumaDepth);
+  punch(w.cam, TUNE.punchDepth);
+  ring(w.rings, 0, 0, w.arenaR * 1.02, w.arenaR * 0.55, 0.75, 0.02, 4);
+  burstBubbles(w.particles, w.serpent.x, w.serpent.y, 12);
+  w.audio.depth(w.depth);
+  if (w.phase === "play") w.host.haptic("medium");
+  ensureField(w);
+}
+
+/** Slam into the vent wall: bounce inward, pay for it, keep the run. */
+function hitWall(w: World, dist: number): void {
+  const s = w.serpent;
+  const d = dist || 1;
+  const nx = s.x / d;
+  const ny = s.y / d;
+  const px = nx * w.arenaR;
+  const py = ny * w.arenaR;
+
+  // Deflect along the wall, never *reflect* off it. A mirror bounce at normal
+  // incidence turns the head through 180° and drives it straight back into its
+  // own neck — an instant death handed out for touching a wall, which is the
+  // opposite of the point. Sliding picks the tangent the serpent was already
+  // closest to and adds a little inward drift.
+  const inside = w.arenaR - TUNE.headRadius * 1.6;
+  s.x = nx * inside;
+  s.y = ny * inside;
+  const hx = Math.cos(s.heading);
+  const hy = Math.sin(s.heading);
+  const sign = hx * -ny + hy * nx >= 0 ? 1 : -1;
+  const tx = -ny * sign;
+  const ty = nx * sign;
+  s.heading = Math.atan2(ty * 0.7 - ny * 0.72, tx * 0.7 - nx * 0.72);
+  s.targetHeading = s.heading;
+
+  w.wallT = 0.55;
+  // The recovery must not be punished by a self-hit the player could not avoid.
+  w.invulnT = Math.max(w.invulnT, 0.28);
+  w.combo = 0;
+  grow(s, -TUNE.shrinkPerWall);
+  burstDebris(w.particles, px, py, Math.atan2(ny, nx), TUNE.shrinkPerWall);
+  burstBad(w.particles, px, py);
+  ring(w.rings, px, py, 0.01, 0.34, 0.5, 0.016, 5);
+  floater(w, px * 0.92, py * 0.92, `−${TUNE.shrinkPerWall}`, 1);
+  hitstop(w.cam, TUNE.hitstopWallMs);
+  addTrauma(w.cam, TUNE.traumaWall);
+  punch(w.cam, TUNE.punchWrong);
+  flash(w.cam, "#ff7a5c", 0.14);
+  w.grazeGlow = 1;
+  w.audio.wall();
+  if (w.phase === "play") w.host.haptic("heavy");
+}
+
+function die(w: World, x: number, y: number): void {
+  const s = w.serpent;
+  if (s.shield) {
+    s.shield = false;
+    w.invulnT = 0.95;
+    w.shieldPulse = 1;
+    hitstop(w.cam, TUNE.hitstopShieldMs);
+    addTrauma(w.cam, TUNE.traumaShield);
+    punch(w.cam, TUNE.punchWrong);
+    flash(w.cam, "#9df6ff", 0.14);
+    ring(w.rings, s.x, s.y, TUNE.headRadius, TUNE.headRadius * 12, 0.6, 0.016, 3);
+    burstDebris(w.particles, s.x, s.y, s.heading, 10);
+    w.audio.shieldBreak();
+    if (w.phase === "play") w.host.haptic("heavy");
+    // Shove the head back toward open water so the shield actually buys time.
+    const d = Math.hypot(s.x, s.y) || 1;
+    s.heading = Math.atan2(-s.y / d, -s.x / d) + randRange(-0.5, 0.5);
+    s.targetHeading = s.heading;
+    return;
+  }
+
+  s.alive = false;
+  w.deathT = 0;
+  burstDeath(w.particles, x, y);
+  for (let i = 0; i < s.bodyCount; i += 3) {
+    burstDebris(w.particles, s.bodyX[i] as number, s.bodyY[i] as number, s.heading + randRange(-3, 3), 1);
+  }
+  ring(w.rings, x, y, 0.02, 0.8, 0.9, 0.02, 3);
+  hitstop(w.cam, TUNE.hitstopDeathMs);
+  addTrauma(w.cam, TUNE.traumaDeath);
+  punch(w.cam, TUNE.punchDeath);
+  slowmo(w.cam, TUNE.slowmoDeathTime, TUNE.slowmoDeathScale);
+  flash(w.cam, "#ff7a5c", 0.18);
+  w.audio.setBoost(false);
+  w.audio.death();
+
+  if (w.phase === "play") {
+    w.host.haptic("failure");
+    if (w.score > w.best) {
+      w.best = w.score;
+      writeBest(w.best);
+    }
+    w.phase = "dead";
+  } else {
+    // The attract loop never stops: it just starts over.
+    resetRun(w, "attract");
+  }
+}
+
+// -------------------------------------------------------------------- step
+
+/** Attract-mode pilot. It plays the game so the player never reads a rule. */
+function autoHeading(w: World): number {
+  const s = w.serpent;
+  const d = Math.hypot(s.x, s.y);
+  // Turn away from the rim before anything else.
+  if (d > w.arenaR - TUNE.headRadius * 7) return Math.atan2(-s.y, -s.x) + Math.sin(w.time * 0.7) * 0.5;
+  let best: Orb | null = null;
+  let bestD = Infinity;
+  for (const o of w.orbs) {
+    if (!o.good || o.scale < 0.6) continue;
+    const dist = Math.hypot(o.x - s.x, o.y - s.y);
+    if (dist < bestD) {
+      bestD = dist;
+      best = o;
+    }
+  }
+  if (!best) return s.heading;
+  // Nudge around its own body rather than driving straight through it.
+  let ax = best.x - s.x;
+  let ay = best.y - s.y;
+  for (let i = TUNE.neckSegments; i < s.bodyCount; i += 4) {
+    const bx = (s.bodyX[i] as number) - s.x;
+    const by = (s.bodyY[i] as number) - s.y;
+    const dd = bx * bx + by * by;
+    if (dd < 0.05 && dd > 1e-6) {
+      ax -= (bx / dd) * 0.004;
+      ay -= (by / dd) * 0.004;
+    }
+  }
+  return Math.atan2(ay, ax);
+}
+
+export type StepInput = {
+  heading: number | null;
+  boost: boolean;
+};
+
+export function stepWorld(w: World, dt: number, input: StepInput): void {
+  w.time += dt;
+  const s = w.serpent;
+
+  if (w.mutateT > 0) w.mutateT = Math.max(0, w.mutateT - dt);
+  w.depthPulse = Math.max(0, w.depthPulse - dt * 1.6);
+  w.scorePulse = Math.max(0, w.scorePulse - dt * 3.2);
+  w.comboPulse = Math.max(0, w.comboPulse - dt * 2.6);
+  w.shieldPulse = Math.max(0, w.shieldPulse - dt * 1.8);
+  w.invulnT = Math.max(0, w.invulnT - dt);
+  w.arenaR += (w.arenaTargetR - w.arenaR) * Math.min(1, dt / TUNE.arenaShrinkTime);
+
+  updateParticles(w.particles, dt);
+  updateRings(w.rings, dt);
+  for (let i = w.floaters.length - 1; i >= 0; i--) {
+    const f = w.floaters[i] as Floater;
+    f.life -= dt;
+    f.y += f.vy * dt;
+    f.vy *= Math.exp(-2.4 * dt);
+    if (f.life <= 0) w.floaters.splice(i, 1);
+  }
+
+  if (w.phase === "dead") {
+    w.deathT += dt;
+    stepOrbs(w.orbs, {
+      dt,
+      arenaR: w.arenaR,
+      headX: s.x,
+      headY: s.y,
+      current: 0,
+      time: w.time,
+    });
+    return;
+  }
+
+  w.runTime += dt;
+
+  const attract = w.phase === "attract";
+  const heading = attract ? autoHeading(w) : input.heading;
+  const boost = attract ? false : input.boost;
+
+  stepSerpent(s, dt, {
+    desiredHeading: heading,
+    wantBoost: boost,
+    depth: w.depth,
+    onBoostSpark: (x, y, h) => {
+      if (Math.random() < 0.65) burstSpark(w.particles, x, y, h, PC_SERPENT);
+    },
+  });
+  w.audio.setBoost(s.boosting);
+
+  stepOrbs(w.orbs, {
+    dt,
+    arenaR: w.arenaR,
+    headX: s.x,
+    headY: s.y,
+    current: w.depth >= 4 ? 0.03 : 0,
+    time: w.time,
+  });
+
+  // --- eating, from a mouth that faces forward
+  const biteX = s.x + Math.cos(s.heading) * TUNE.headRadius * TUNE.biteOffset;
+  const biteY = s.y + Math.sin(s.heading) * TUNE.headRadius * TUNE.biteOffset;
+  for (let i = w.orbs.length - 1; i >= 0; i--) {
+    const o = w.orbs[i] as Orb;
+    const r = orbDrawRadius(o);
+    // A transforming orb is not food. Without this, an orb that still carries
+    // its old label for the first half of a molt can be eaten and judged
+    // against the *new* condition — reporting `18` as correct for `= 79`.
+    if (o.moltT > 0) continue;
+    if (r < TUNE.orbRadius * 0.35) continue;
+    const reach = r * TUNE.orbCoreFactor + TUNE.headRadius * TUNE.headBiteFactor;
+    if ((o.x - biteX) ** 2 + (o.y - biteY) ** 2 <= reach * reach) {
+      eatOrb(w, i);
+      break; // one bite per frame keeps every bite legible
+    }
+  }
+
+  // --- grazing the rim, which is worth points precisely because it is stupid
+  const dist = Math.hypot(s.x, s.y);
+  const grazing = dist > w.arenaR - TUNE.grazeBand;
+  w.grazeGlow = clamp(w.grazeGlow + (grazing ? dt * 6 : -dt * 3), 0, 1);
+  if (grazing && s.alive) {
+    w.grazeT += dt;
+    if (w.grazeT >= TUNE.grazeInterval) {
+      w.grazeT = 0;
+      w.score += 3;
+      burstSpark(w.particles, s.x, s.y, s.heading + Math.PI / 2, PC_HOT);
+      w.audio.graze();
+    }
+  } else {
+    w.grazeT = 0;
+  }
+
+  // --- the rim hurts; your own body kills
+  //
+  // Measured over twenty simulated minutes of a competent pilot: 58 deaths,
+  // 58 of them on the wall and none on the serpent's own body. The wall was
+  // the entire failure mode — you die while reading a number, which is the
+  // least interesting death a snake game can offer. So the rim now costs
+  // length and throws you back, and the only thing that can end a run is
+  // outgrowing your own turning circle. That is also what makes the arena
+  // closing in mean something: it squeezes you into yourself.
+  w.wallT = Math.max(0, w.wallT - dt);
+  if (dist > w.arenaR - TUNE.headRadius * 0.75 && w.wallT <= 0) {
+    hitWall(w, dist);
+  } else if (w.invulnT <= 0 && selfHit(s)) {
+    die(w, s.x, s.y);
+  }
+
+  if (Math.random() < dt * 2.4) {
+    const a = randRange(0, TAU);
+    const r = Math.sqrt(Math.random()) * w.arenaR;
+    burstBubbles(w.particles, Math.cos(a) * r, Math.sin(a) * r, 1);
+  }
+}
+
+export function confirmPressed(w: World): void {
+  if (w.phase === "attract") {
+    startRun(w);
+  } else if (w.phase === "dead" && w.deathT > 0.55) {
+    startRun(w);
+  }
+}

--- a/dynawalla/games/serpent/src/index.ts
+++ b/dynawalla/games/serpent/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Serpent — the package entry point.
+ *
+ * `mount(el, host)` is the whole public surface. Everything else is internal
+ * and will keep moving.
+ */
+
+import type { Host, Mounted } from "./contract.ts";
+import { mountSerpent } from "./game/mount.ts";
+
+export function mount(el: HTMLElement, host: Host): Mounted {
+  return mountSerpent(el, host);
+}
+
+export type { Host, Question, Report, Mounted } from "./contract.ts";
+export { createStubHost } from "./stub/host.ts";

--- a/dynawalla/games/serpent/src/main.ts
+++ b/dynawalla/games/serpent/src/main.ts
@@ -1,0 +1,46 @@
+/**
+ * Standalone dev entry. `npm run dev` and play.
+ *
+ * URL knobs, for playtesting rather than for players:
+ *   ?seed=abc     reproduce a run's arithmetic exactly
+ *   ?level=5      start the question ladder high instead of at single digits
+ *   ?reduced=1    force the reduced-motion path without touching OS settings
+ */
+
+import { createStubHost } from "./stub/host.ts";
+import { mountSerpent } from "./game/mount.ts";
+import type { Report } from "./contract.ts";
+
+const params = new URLSearchParams(location.search);
+const el = document.getElementById("stage");
+if (!el) throw new Error("no #stage");
+
+const reports: Report[] = [];
+const forceReduced = params.get("reduced") === "1";
+
+const host = createStubHost({
+  ...(params.get("seed") ? { seed: params.get("seed") as string } : {}),
+  ...(params.get("level") ? { startLevel: Number(params.get("level")) } : {}),
+  onReport: (r) => {
+    reports.push(r);
+    if (reports.length > 400) reports.shift();
+  },
+});
+
+const patched = forceReduced ? { ...host, prefersReducedMotion: () => true } : host;
+const handle = mountSerpent(el, patched);
+
+// A seam for automated playtesting: drive the real game, read the real state.
+Object.defineProperty(window, "__serpent", {
+  value: {
+    handle,
+    host,
+    reports,
+    stats: () => host.stats(),
+    accuracy: () => {
+      if (reports.length === 0) return 1;
+      return reports.filter((r) => r.correct).length / reports.length;
+    },
+  },
+  configurable: true,
+});

--- a/dynawalla/games/serpent/src/stub/exact.test.ts
+++ b/dynawalla/games/serpent/src/stub/exact.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { cmp, eq, frac, fracLabel, int, parseLabel, predicateKey, promptFor, satisfies } from "./exact.ts";
+
+test("fractions are stored reduced with a positive denominator", () => {
+  assert.deepEqual(frac(6, 8), { n: 3, d: 4 });
+  assert.deepEqual(frac(2, -4), { n: -1, d: 2 });
+  assert.deepEqual(frac(5, 1), { n: 5, d: 1 });
+});
+
+test("comparison is exact where floating point is not", () => {
+  // 0.1 + 0.2 !== 0.3 in binary floating point. Here it is exactly equal, and
+  // the equality holds for every representation of the same rational.
+  const tenth = frac(1, 10);
+  const fifth = frac(1, 5);
+  const threeTenths = frac(3, 10);
+  assert.equal(cmp({ n: tenth.n * fifth.d + fifth.n * tenth.d, d: tenth.d * fifth.d }, threeTenths), 0);
+  assert.ok(eq(frac(2, 4), frac(1, 2)));
+  assert.equal(cmp(frac(5, 8), frac(3, 4)), -1);
+  assert.equal(cmp(frac(7, 9), frac(3, 4)), 1);
+  assert.equal(cmp(frac(1, 3), frac(2, 6)), 0);
+});
+
+test("labels parse back to their exact value", () => {
+  assert.deepEqual(parseLabel("12"), { n: 12, d: 1 });
+  assert.deepEqual(parseLabel("7 + 5"), { n: 12, d: 1 });
+  assert.deepEqual(parseLabel("20 − 8"), { n: 12, d: 1 });
+  assert.deepEqual(parseLabel("3 × 4"), { n: 12, d: 1 });
+  assert.deepEqual(parseLabel("48 ÷ 4"), { n: 12, d: 1 });
+  assert.deepEqual(parseLabel("3/4"), { n: 3, d: 4 });
+  assert.deepEqual(parseLabel("6/8"), { n: 3, d: 4 });
+});
+
+test("the parser refuses what it does not fully understand", () => {
+  for (const bad of ["", "  ", "7 +", "7 + 5 + 1", "seven", "1/0", "3 - 4", "x × 2"]) {
+    assert.equal(parseLabel(bad), null, `expected null for ${JSON.stringify(bad)}`);
+  }
+});
+
+test("predicates accept exactly what their prompt says", () => {
+  const twelve = { kind: "eq", target: int(12) } as const;
+  assert.ok(satisfies(twelve, int(12)));
+  assert.ok(!satisfies(twelve, int(13)));
+  assert.ok(!satisfies(twelve, frac(23, 2)));
+  assert.equal(promptFor(twelve), "= 12");
+
+  const sixes = { kind: "multiple", base: 6 } as const;
+  assert.ok(satisfies(sixes, int(18)));
+  assert.ok(!satisfies(sixes, int(20)));
+  assert.ok(!satisfies(sixes, frac(18, 5)));
+  assert.ok(!satisfies(sixes, int(0)), "zero is not an interesting multiple and never spawns");
+  assert.equal(promptFor(sixes), "6 × ?");
+
+  const overThreeQuarters = { kind: "gt", ref: frac(3, 4) } as const;
+  assert.ok(satisfies(overThreeQuarters, frac(7, 8)));
+  assert.ok(!satisfies(overThreeQuarters, frac(6, 8)), "equal is not greater");
+  assert.ok(!satisfies(overThreeQuarters, frac(5, 8)));
+  assert.equal(promptFor(overThreeQuarters), "> 3/4");
+
+  const underHalf = { kind: "lt", ref: frac(1, 2) } as const;
+  assert.ok(satisfies(underHalf, frac(5, 11)));
+  assert.ok(!satisfies(underHalf, frac(6, 11)));
+  assert.ok(!satisfies(underHalf, frac(2, 4)), "equal is not less");
+});
+
+test("predicate keys and labels are stable identities", () => {
+  assert.equal(predicateKey({ kind: "eq", target: int(12) }), "eq:12/1");
+  assert.equal(predicateKey({ kind: "multiple", base: 7 }), "mul:7");
+  assert.equal(predicateKey({ kind: "gt", ref: frac(3, 4) }), "gt:3/4");
+  assert.equal(fracLabel(frac(4, 2)), "2");
+});

--- a/dynawalla/games/serpent/src/stub/exact.ts
+++ b/dynawalla/games/serpent/src/stub/exact.ts
@@ -1,0 +1,158 @@
+/**
+ * Exact arithmetic for everything a child is graded on.
+ *
+ * There is no floating point in this file and there must never be one: every
+ * value is an integer numerator over a positive integer denominator, every
+ * comparison is an integer cross-multiplication. `0.1 + 0.2 !== 0.3` would mark
+ * correct decimal work wrong *deterministically*, which is worse than flaky.
+ *
+ * Labels are the strings that appear on an orb. They are generated together
+ * with their exact value — the parser below exists so that tests can check the
+ * generator by an independent path, and so a hand-written label can never drift
+ * from what the game believes it is worth.
+ */
+
+export type Frac = { n: number; d: number };
+
+const MINUS = "−"; // − U+2212 MINUS SIGN, not a hyphen
+const TIMES = "×"; // ×
+const DIVIDE = "÷"; // ÷
+
+export const GLYPH = { minus: MINUS, times: TIMES, divide: DIVIDE } as const;
+
+function gcd(a: number, b: number): number {
+  let x = Math.abs(a);
+  let y = Math.abs(b);
+  while (y !== 0) {
+    const t = x % y;
+    x = y;
+    y = t;
+  }
+  return x;
+}
+
+export function frac(n: number, d: number): Frac {
+  if (d === 0) throw new Error("zero denominator");
+  if (!Number.isInteger(n) || !Number.isInteger(d)) throw new Error("non-integer fraction part");
+  let nn = n;
+  let dd = d;
+  if (dd < 0) {
+    nn = -nn;
+    dd = -dd;
+  }
+  const g = gcd(nn, dd) || 1;
+  return { n: nn / g, d: dd / g };
+}
+
+export const int = (n: number): Frac => ({ n, d: 1 });
+
+/** Sign of a − b. Integer arithmetic only. */
+export function cmp(a: Frac, b: Frac): number {
+  const l = a.n * b.d;
+  const r = b.n * a.d;
+  return l < r ? -1 : l > r ? 1 : 0;
+}
+
+export const eq = (a: Frac, b: Frac): boolean => cmp(a, b) === 0;
+
+export function add(a: Frac, b: Frac): Frac {
+  return frac(a.n * b.d + b.n * a.d, a.d * b.d);
+}
+
+export function isIntegerFrac(a: Frac): boolean {
+  return a.d === 1;
+}
+
+/**
+ * Parse an orb label back to its exact value. Accepts:
+ *   `12`  `7 + 5`  `20 − 8`  `3 × 4`  `48 ÷ 4`  `3/4`
+ * `/` is always a fraction bar; division is always `÷`. Returns null for
+ * anything it does not fully understand, so a test can assert on null rather
+ * than silently trusting a bad parse.
+ */
+export function parseLabel(label: string): Frac | null {
+  const s = label.trim();
+
+  const fracMatch = /^(-?\d+)\/(\d+)$/.exec(s);
+  if (fracMatch) {
+    const n = Number(fracMatch[1]);
+    const d = Number(fracMatch[2]);
+    if (d === 0) return null;
+    return frac(n, d);
+  }
+
+  const intMatch = /^-?\d+$/.exec(s);
+  if (intMatch) return int(Number(s));
+
+  const opMatch = new RegExp(`^(-?\\d+)\\s*([+${MINUS}${TIMES}${DIVIDE}])\\s*(-?\\d+)$`).exec(s);
+  if (!opMatch) return null;
+  const a = Number(opMatch[1]);
+  const op = opMatch[2];
+  const b = Number(opMatch[3]);
+  switch (op) {
+    case "+":
+      return int(a + b);
+    case MINUS:
+      return int(a - b);
+    case TIMES:
+      return int(a * b);
+    case DIVIDE:
+      if (b === 0) return null;
+      return frac(a, b);
+    default:
+      return null;
+  }
+}
+
+/** How a condition is written on the arena floor, and what it accepts. */
+export type Predicate =
+  | { kind: "eq"; target: Frac }
+  | { kind: "multiple"; base: number }
+  | { kind: "gt"; ref: Frac }
+  | { kind: "lt"; ref: Frac };
+
+export function satisfies(p: Predicate, v: Frac): boolean {
+  switch (p.kind) {
+    case "eq":
+      return eq(v, p.target);
+    case "multiple":
+      // Exact: v must be a whole number and a whole multiple of base.
+      return v.d === 1 && v.n !== 0 && v.n % p.base === 0;
+    case "gt":
+      return cmp(v, p.ref) > 0;
+    case "lt":
+      return cmp(v, p.ref) < 0;
+  }
+}
+
+/** The prompt string, which is also what the floor renders. */
+export function promptFor(p: Predicate): string {
+  switch (p.kind) {
+    case "eq":
+      return `= ${fracLabel(p.target)}`;
+    case "multiple":
+      return `${p.base} ${TIMES} ?`;
+    case "gt":
+      return `> ${fracLabel(p.ref)}`;
+    case "lt":
+      return `< ${fracLabel(p.ref)}`;
+  }
+}
+
+/** A stable identity for a predicate — the game uses it to detect a mutation. */
+export function predicateKey(p: Predicate): string {
+  switch (p.kind) {
+    case "eq":
+      return `eq:${p.target.n}/${p.target.d}`;
+    case "multiple":
+      return `mul:${p.base}`;
+    case "gt":
+      return `gt:${p.ref.n}/${p.ref.d}`;
+    case "lt":
+      return `lt:${p.ref.n}/${p.ref.d}`;
+  }
+}
+
+export function fracLabel(f: Frac): string {
+  return f.d === 1 ? String(f.n) : `${f.n}/${f.d}`;
+}

--- a/dynawalla/games/serpent/src/stub/generators.test.ts
+++ b/dynawalla/games/serpent/src/stub/generators.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { makeCondition } from "./generators.ts";
+import { fracLabel, parseLabel, satisfies } from "./exact.ts";
+import { makeRng } from "./rng.ts";
+
+const LEVELS = [0, 1, 2, 3, 4, 5, 6];
+
+test("every generated label is exactly on the side of the condition it claims", () => {
+  // Checked by an independent path: the generator builds labels from known
+  // values, the parser recovers the value from the string, and the predicate
+  // judges it. A generator bug and a parser bug would have to agree to hide.
+  for (const level of LEVELS) {
+    const rng = makeRng(`labels-${level}`);
+    for (let i = 0; i < 300; i++) {
+      const c = makeCondition(rng, level);
+      for (const label of c.satisfying) {
+        const v = parseLabel(label);
+        assert.ok(v !== null, `unparsable satisfying label ${JSON.stringify(label)} (${c.prompt})`);
+        assert.ok(satisfies(c.predicate, v), `${label} should satisfy ${c.prompt}`);
+      }
+      for (const label of c.failing) {
+        const v = parseLabel(label);
+        assert.ok(v !== null, `unparsable failing label ${JSON.stringify(label)} (${c.prompt})`);
+        assert.ok(!satisfies(c.predicate, v), `${label} must NOT satisfy ${c.prompt}`);
+      }
+    }
+  }
+});
+
+test("pools are big enough to fill an arena and hold no duplicates", () => {
+  for (const level of LEVELS) {
+    const rng = makeRng(`pools-${level}`);
+    for (let i = 0; i < 200; i++) {
+      const c = makeCondition(rng, level);
+      assert.ok(c.satisfying.length >= 4, `${c.prompt} had ${c.satisfying.length} satisfying`);
+      assert.ok(c.failing.length >= 8, `${c.prompt} had ${c.failing.length} failing`);
+      assert.equal(new Set(c.satisfying).size, c.satisfying.length, `${c.prompt} repeats a satisfying label`);
+      assert.equal(new Set(c.failing).size, c.failing.length, `${c.prompt} repeats a failing label`);
+      for (const s of c.satisfying) assert.ok(!c.failing.includes(s), `${s} is in both pools of ${c.prompt}`);
+    }
+  }
+});
+
+test("wrong answers are near misses, not obvious rubbish", () => {
+  // A distractor you can reject without arithmetic makes the round free. For
+  // `= N`, at least half of the wrong values sit within 4 of the target.
+  const rng = makeRng("nearness");
+  let checked = 0;
+  for (let i = 0; i < 400; i++) {
+    const c = makeCondition(rng, 3);
+    if (c.predicate.kind !== "eq") continue;
+    checked++;
+    const target = c.predicate.target.n;
+    const near = c.failing.filter((l) => {
+      const v = parseLabel(l);
+      return v !== null && v.d === 1 && Math.abs(v.n - target) <= 4;
+    });
+    assert.ok(near.length * 2 >= c.failing.length, `${c.prompt}: only ${near.length}/${c.failing.length} near misses`);
+  }
+  assert.ok(checked > 20, "expected the equality family to appear at level 3");
+});
+
+test("multiples rounds never offer a multiple as a wrong answer", () => {
+  const rng = makeRng("multiples");
+  let seen = 0;
+  for (let i = 0; i < 600; i++) {
+    const c = makeCondition(rng, 5);
+    if (c.predicate.kind !== "multiple") continue;
+    seen++;
+    const base = c.predicate.base;
+    for (const l of c.failing) {
+      const v = parseLabel(l);
+      assert.ok(v !== null && v.d === 1);
+      assert.notEqual(v.n % base, 0, `${l} is a multiple of ${base} but is listed as wrong`);
+    }
+  }
+  assert.ok(seen > 20, "expected the multiples family at level 5");
+});
+
+test("fraction rounds ship the equal-value trap", () => {
+  // `2/4` is not greater than `1/2`. That single orb is the point of the round.
+  const rng = makeRng("fractions");
+  let withTrap = 0;
+  let total = 0;
+  for (let i = 0; i < 800; i++) {
+    const c = makeCondition(rng, 6);
+    if (c.predicate.kind !== "gt" && c.predicate.kind !== "lt") continue;
+    total++;
+    const ref = c.predicate.ref;
+    // Specifically an *unreduced* equal-value label: the string is not in
+    // lowest terms, but its exact value is the reference itself.
+    if (
+      c.failing.some((l) => {
+        const v = parseLabel(l);
+        return v !== null && v.n * ref.d === ref.n * v.d && l !== fracLabel(v);
+      })
+    ) {
+      withTrap++;
+    }
+  }
+  assert.ok(total > 20, "expected fraction conditions at level 6");
+  assert.ok(withTrap * 2 > total, `only ${withTrap}/${total} fraction rounds carried an equal-value trap`);
+});
+
+test("the same seed generates the same conditions", () => {
+  const a = makeRng("determinism");
+  const b = makeRng("determinism");
+  for (let i = 0; i < 100; i++) {
+    const ca = makeCondition(a, i % 7);
+    const cb = makeCondition(b, i % 7);
+    assert.equal(ca.key, cb.key);
+    assert.deepEqual(ca.satisfying, cb.satisfying);
+    assert.deepEqual(ca.failing, cb.failing);
+  }
+});
+
+test("a mutation always changes the condition", () => {
+  const rng = makeRng("avoid");
+  let prev = makeCondition(rng, 4);
+  for (let i = 0; i < 400; i++) {
+    const next = makeCondition(rng, 4, prev.key);
+    assert.notEqual(next.key, prev.key);
+    prev = next;
+  }
+});

--- a/dynawalla/games/serpent/src/stub/generators.ts
+++ b/dynawalla/games/serpent/src/stub/generators.ts
@@ -1,0 +1,309 @@
+/**
+ * Condition generators.
+ *
+ * A *condition* is what the arena floor says — `= 12`, `6 × ?`, `> 3/4`. It
+ * comes with two label pools: things that satisfy it and things that do not.
+ * The wrong ones are the maze the child has to swim through, so they are built
+ * to be *near misses* — off-by-one, borrow slips, place-value slips, times-table
+ * neighbours, "bigger denominator so it must be bigger". A wrong answer you can
+ * spot without arithmetic teaches nothing and, worse, is boring.
+ *
+ * Every label is produced together with its exact value. Nothing is parsed at
+ * runtime and nothing is a float.
+ */
+
+import type { Rng } from "./rng.ts";
+import type { Frac, Predicate } from "./exact.ts";
+import { GLYPH, cmp, frac, fracLabel, int, predicateKey, promptFor, satisfies } from "./exact.ts";
+
+export type Condition = {
+  predicate: Predicate;
+  key: string;
+  prompt: string;
+  domain: string;
+  difficulty: number;
+  satisfying: string[];
+  failing: string[];
+};
+
+const { minus: M, times: X, divide: D } = GLYPH;
+
+/** Unique-preserving push. Labels must be distinct or two orbs read the same. */
+function put(into: string[], seen: Set<string>, label: string): void {
+  if (seen.has(label)) return;
+  seen.add(label);
+  into.push(label);
+}
+
+// ---------------------------------------------------------------- equal-to
+
+function factorPairs(t: number): Array<[number, number]> {
+  const out: Array<[number, number]> = [];
+  for (let a = 2; a * a <= t; a++) {
+    if (t % a === 0) out.push([a, t / a]);
+  }
+  return out;
+}
+
+/** Expressions whose exact value is `v`, in shapes a child of this level meets. */
+function expressionsFor(v: number, level: number, rng: Rng, want: number): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  let guard = 0;
+  while (out.length < want && guard++ < 60) {
+    const roll = rng.next();
+    if (roll < 0.4 && v >= 2) {
+      const a = rng.int(1, v - 1);
+      put(out, seen, `${a} + ${v - a}`);
+    } else if (roll < 0.72 && level >= 1) {
+      const b = rng.int(1, level >= 3 ? 12 : 6);
+      put(out, seen, `${v + b} ${M} ${b}`);
+    } else if (roll < 0.9 && level >= 3) {
+      const pairs = factorPairs(v);
+      if (pairs.length > 0) {
+        const p = rng.pick(pairs);
+        put(out, seen, rng.chance(0.5) ? `${p[0]} ${X} ${p[1]}` : `${p[1]} ${X} ${p[0]}`);
+      }
+    } else if (level >= 4 && v >= 2) {
+      const b = rng.int(2, 6);
+      put(out, seen, `${v * b} ${D} ${b}`);
+    }
+  }
+  return out;
+}
+
+function eqCondition(rng: Rng, level: number): Condition {
+  const bands: Array<[number, number]> = [
+    [4, 10],
+    [8, 18],
+    [10, 30],
+    [12, 45],
+    [15, 60],
+    [18, 80],
+    [20, 99],
+  ];
+  const band = bands[Math.min(level, bands.length - 1)] as [number, number];
+  const target = rng.int(band[0], band[1]);
+
+  const satisfying: string[] = [];
+  const sSeen = new Set<string>();
+  put(satisfying, sSeen, String(target));
+  for (const e of expressionsFor(target, level, rng, 7)) put(satisfying, sSeen, e);
+
+  // Near misses. ±1..4 are counting and borrow slips and they dominate the
+  // pool on purpose: a wrong answer you can reject without arithmetic makes the
+  // round free. ±9..11 are place-value slips, which only mean anything once the
+  // number is big enough to have a tens column worth dropping — they are capped
+  // to a minority so most of the field still has to be computed.
+  const failing: string[] = [];
+  const fSeen = new Set<string>();
+  for (const d of rng.shuffle([1, -1, 2, -2, 3, -3, 4, -4])) {
+    const v = target + d;
+    if (v < 1) continue;
+    put(failing, fSeen, String(v));
+    for (const e of expressionsFor(v, level, rng, 2)) put(failing, fSeen, e);
+  }
+  if (target >= 20) {
+    const farBudget = Math.floor(failing.length / 3);
+    const before = failing.length;
+    for (const d of rng.shuffle([9, -9, 10, -10, 11, -11])) {
+      if (failing.length - before >= farBudget) break;
+      const v = target + d;
+      if (v < 1) continue;
+      put(failing, fSeen, String(v));
+      for (const e of expressionsFor(v, level, rng, 1)) put(failing, fSeen, e);
+    }
+  }
+
+  const predicate: Predicate = { kind: "eq", target: int(target) };
+  return {
+    predicate,
+    key: predicateKey(predicate),
+    prompt: promptFor(predicate),
+    domain: level >= 3 ? "mult-div" : "add-sub",
+    difficulty: Math.min(1, level / 6),
+    satisfying,
+    failing,
+  };
+}
+
+// ---------------------------------------------------------------- multiples
+
+function multipleCondition(rng: Rng, level: number): Condition {
+  const pools: number[][] = [
+    [2, 5],
+    [2, 5, 10],
+    [2, 3, 4, 5],
+    [3, 4, 5, 6],
+    [4, 6, 7, 8],
+    [6, 7, 8, 9],
+    [6, 7, 8, 9, 11, 12],
+  ];
+  const base = rng.pick(pools[Math.min(level, pools.length - 1)] as number[]);
+  const maxK = Math.min(12, 5 + level * 2);
+
+  const satisfying: string[] = [];
+  const sSeen = new Set<string>();
+  for (const k of rng.shuffle(Array.from({ length: maxK - 1 }, (_, i) => i + 2))) {
+    put(satisfying, sSeen, String(base * k));
+    if (satisfying.length >= 8) break;
+  }
+  // At higher levels a couple of orbs make you do the multiplication *first*
+  // and then decide whether the result is in the table. Two steps, one bite.
+  if (level >= 3) {
+    for (let i = 0; i < 2; i++) {
+      const k = rng.int(2, Math.min(9, maxK));
+      const a = rng.int(2, 6);
+      const v = base * k;
+      if (v % a === 0) put(satisfying, sSeen, `${a} ${X} ${v / a}`);
+    }
+  }
+
+  const failing: string[] = [];
+  const fSeen = new Set<string>();
+  let guard = 0;
+  while (failing.length < 18 && guard++ < 200) {
+    const k = rng.int(1, maxK);
+    const off = rng.pick([1, -1, 2, -2, 3, -3]);
+    const v = base * k + off;
+    if (v < 2) continue;
+    if (v % base === 0) continue; // would satisfy — never a distractor
+    put(failing, fSeen, String(v));
+  }
+  // Neighbouring times-tables: the classic "I recited the wrong one" error.
+  for (const nb of [base - 1, base + 1]) {
+    if (nb < 2) continue;
+    for (let k = 2; k <= 7; k++) {
+      const v = nb * k;
+      if (v % base !== 0) put(failing, fSeen, String(v));
+    }
+  }
+
+  const predicate: Predicate = { kind: "multiple", base };
+  return {
+    predicate,
+    key: predicateKey(predicate),
+    prompt: promptFor(predicate),
+    domain: "multiples",
+    difficulty: Math.min(1, level / 6),
+    satisfying,
+    failing,
+  };
+}
+
+// ---------------------------------------------------------------- fractions
+
+const REF_BY_LEVEL: Frac[][] = [
+  [frac(1, 2)],
+  [frac(1, 2)],
+  [frac(1, 2), frac(1, 4)],
+  [frac(1, 2), frac(1, 4), frac(3, 4)],
+  [frac(1, 2), frac(1, 3), frac(2, 3), frac(3, 4)],
+  [frac(1, 3), frac(2, 3), frac(3, 4), frac(2, 5), frac(3, 5)],
+  [frac(2, 3), frac(3, 4), frac(3, 5), frac(5, 8), frac(5, 6)],
+];
+
+function candidateFractions(maxD: number): Frac[] {
+  const out: Frac[] = [];
+  const seen = new Set<string>();
+  for (let d = 2; d <= maxD; d++) {
+    for (let n = 1; n <= d + 1; n++) {
+      const f = frac(n, d);
+      const key = `${f.n}/${f.d}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(f);
+    }
+  }
+  return out;
+}
+
+/** |x − ref| vs |y − ref|, by integer cross-multiplication only. */
+function nearer(ref: Frac): (x: Frac, y: Frac) => number {
+  return (x, y) => {
+    const dx = Math.abs(x.n * ref.d - ref.n * x.d);
+    const dy = Math.abs(y.n * ref.d - ref.n * y.d);
+    return dx * y.d - dy * x.d;
+  };
+}
+
+function fracCondition(rng: Rng, level: number): Condition {
+  const ref = rng.pick(REF_BY_LEVEL[Math.min(level, REF_BY_LEVEL.length - 1)] as Frac[]);
+  const dir: "gt" | "lt" = rng.chance(0.5) ? "gt" : "lt";
+  const predicate: Predicate = dir === "gt" ? { kind: "gt", ref } : { kind: "lt", ref };
+  const maxD = level <= 3 ? 8 : level <= 5 ? 10 : 12;
+
+  const all = candidateFractions(maxD);
+  const near = nearer(ref);
+  const pass = all.filter((f) => satisfies(predicate, f)).sort(near);
+  const fail = all.filter((f) => !satisfies(predicate, f)).sort(near);
+
+  const satisfying = rng.shuffle(pass.slice(0, 12).map(fracLabel)).slice(0, 9);
+  const failing = rng.shuffle(fail.slice(0, 16).map(fracLabel)).slice(0, 14);
+
+  // The equal-value trap always ships: for `> 1/2`, `2/4` is not greater. It is
+  // the single most instructive orb in the round, and it only exists as an
+  // *unreduced* label — every other label in the pools is in lowest terms.
+  for (let k = 2; k <= 4; k++) {
+    if (ref.d * k > maxD) break;
+    const trap = `${ref.n * k}/${ref.d * k}`;
+    if (!failing.includes(trap)) {
+      failing.unshift(trap);
+      break;
+    }
+  }
+
+  // Unreduced satisfying labels at the top of the ladder: `4/6` and `2/3` are
+  // the same orb, and knowing that is the whole skill.
+  if (level >= 5) {
+    for (const f of pass.slice(0, 6)) {
+      const k = 2;
+      if (f.d * k > maxD) continue;
+      const label = `${f.n * k}/${f.d * k}`;
+      if (!satisfying.includes(label) && cmp(frac(f.n * k, f.d * k), ref) !== 0) {
+        satisfying.push(label);
+        break;
+      }
+    }
+  }
+
+  return {
+    predicate,
+    key: predicateKey(predicate),
+    prompt: promptFor(predicate),
+    domain: "fractions",
+    difficulty: Math.min(1, 0.4 + level / 10),
+    satisfying,
+    failing,
+  };
+}
+
+// ---------------------------------------------------------------- selection
+
+type Family = "eq" | "multiple" | "fraction";
+
+const FAMILIES_BY_LEVEL: Family[][] = [
+  ["eq"],
+  ["eq", "eq", "multiple"],
+  ["eq", "multiple"],
+  ["eq", "multiple", "multiple"],
+  ["eq", "multiple", "fraction"],
+  ["eq", "multiple", "fraction", "fraction"],
+  ["eq", "multiple", "fraction", "fraction"],
+];
+
+export function makeCondition(rng: Rng, level: number, avoidKey?: string): Condition {
+  const lv = Math.max(0, Math.min(6, Math.floor(level)));
+  const families = FAMILIES_BY_LEVEL[lv] as Family[];
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const family = rng.pick(families);
+    const c =
+      family === "eq"
+        ? eqCondition(rng, lv)
+        : family === "multiple"
+          ? multipleCondition(rng, lv)
+          : fracCondition(rng, lv);
+    if (c.key !== avoidKey && c.satisfying.length >= 4 && c.failing.length >= 8) return c;
+  }
+  return eqCondition(rng, lv);
+}

--- a/dynawalla/games/serpent/src/stub/host.test.ts
+++ b/dynawalla/games/serpent/src/stub/host.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createStubHost } from "./host.ts";
+import { parseLabel } from "./exact.ts";
+
+test("a seed reproduces a run's arithmetic exactly", () => {
+  const a = createStubHost({ seed: "run-1" });
+  const b = createStubHost({ seed: "run-1" });
+  for (let i = 0; i < 120; i++) {
+    const qa = a.next();
+    const qb = b.next();
+    assert.deepEqual(qa, qb);
+  }
+});
+
+test("different seeds diverge", () => {
+  const a = createStubHost({ seed: "run-1" });
+  const b = createStubHost({ seed: "run-2" });
+  const seqA = Array.from({ length: 40 }, () => a.next().answer).join("|");
+  const seqB = Array.from({ length: 40 }, () => b.next().answer).join("|");
+  assert.notEqual(seqA, seqB);
+});
+
+test("a question never lists its own answer as a distractor", () => {
+  const h = createStubHost({ seed: "distinct" });
+  for (let i = 0; i < 400; i++) {
+    const q = h.next();
+    assert.ok(q.distractors.length >= 3, `${q.prompt} produced ${q.distractors.length} distractors`);
+    assert.ok(!q.distractors.includes(q.answer));
+    assert.equal(new Set(q.distractors).size, q.distractors.length);
+    assert.ok(parseLabel(q.answer) !== null, `unparsable answer ${q.answer}`);
+    assert.ok(q.id.length > 0);
+    assert.ok(q.difficulty >= 0 && q.difficulty <= 1);
+  }
+});
+
+test("questions arrive in epochs that share a condition, then rotate", () => {
+  const h = createStubHost({ seed: "epochs", epochMin: 4, epochMax: 7 });
+  const prompts = Array.from({ length: 200 }, () => h.next().prompt);
+  let runs = 0;
+  let runLen = 1;
+  const lengths: number[] = [];
+  for (let i = 1; i < prompts.length; i++) {
+    if (prompts[i] === prompts[i - 1]) {
+      runLen++;
+    } else {
+      lengths.push(runLen);
+      runLen = 1;
+      runs++;
+    }
+  }
+  assert.ok(runs > 20, `expected many rotations, saw ${runs}`);
+  for (const l of lengths) {
+    assert.ok(l >= 4 && l <= 7, `epoch length ${l} outside [4,7]`);
+  }
+});
+
+test("the run gets harder as it goes", () => {
+  const h = createStubHost({ seed: "ramp" });
+  for (let i = 0; i < 6; i++) h.next();
+  const early = h.stats().level;
+  for (let i = 0; i < 60; i++) {
+    const q = h.next();
+    h.report({ questionId: q.id, correct: true, ms: 900, answered: q.answer });
+  }
+  const late = h.stats().level;
+  assert.ok(late > early, `level did not rise: ${early} -> ${late}`);
+  assert.equal(h.stats().level, 6, "a perfect run should reach the top band");
+});
+
+test("a struggling learner is not pushed as fast", () => {
+  const good = createStubHost({ seed: "band" });
+  const bad = createStubHost({ seed: "band" });
+  for (let i = 0; i < 40; i++) {
+    const qg = good.next();
+    good.report({ questionId: qg.id, correct: true, ms: 700, answered: qg.answer });
+    const qb = bad.next();
+    bad.report({ questionId: qb.id, correct: false, ms: 3000, answered: "0" });
+  }
+  assert.ok(bad.stats().level < good.stats().level, "accuracy must move the band");
+});
+
+test("haptics and reduced motion degrade silently with no browser", () => {
+  const h = createStubHost({ seed: "degrade" });
+  h.haptic("light");
+  h.haptic("failure");
+  assert.equal(h.prefersReducedMotion(), false);
+});

--- a/dynawalla/games/serpent/src/stub/host.ts
+++ b/dynawalla/games/serpent/src/stub/host.ts
@@ -1,0 +1,117 @@
+/**
+ * The local stub Host.
+ *
+ * It exists so Serpent is fully playable on its own with `npm run dev`, and it
+ * behaves the way a real adaptive host will: it serves a *run* of questions
+ * sharing one condition, then rotates. The game reads a prompt change as a
+ * mutation of the world, so the host — not the game — decides when the arena
+ * transforms. That keeps the interesting decision on the side that will one day
+ * know the learner model.
+ */
+
+import type { Host, Question, Report } from "../contract.ts";
+import { makeCondition, type Condition } from "./generators.ts";
+import { makeRng, type Rng } from "./rng.ts";
+
+export type StubOptions = {
+  seed?: string;
+  startLevel?: number;
+  /** Questions per condition before the arena mutates. */
+  epochMin?: number;
+  epochMax?: number;
+  distractorsPerQuestion?: number;
+  onReport?: (r: Report) => void;
+};
+
+export type StubHost = Host & {
+  /** Diagnostics for the dev overlay. Never read by game logic. */
+  stats(): { served: number; level: number; accuracy: number; domain: string };
+};
+
+function vibrate(kind: Parameters<Host["haptic"]>[0]): void {
+  const nav = typeof navigator === "undefined" ? undefined : navigator;
+  if (!nav || typeof nav.vibrate !== "function") return;
+  const pattern: Record<typeof kind, number | number[]> = {
+    light: 8,
+    medium: 18,
+    heavy: 34,
+    success: [10, 26, 16],
+    failure: [30, 40, 30],
+  };
+  try {
+    nav.vibrate(pattern[kind]);
+  } catch {
+    /* a browser that refuses haptics is not an error */
+  }
+}
+
+export function createStubHost(options: StubOptions = {}): StubHost {
+  const seed = options.seed ?? `serpent-${Date.now()}`;
+  const rng: Rng = makeRng(seed);
+  const epochMin = options.epochMin ?? 4;
+  const epochMax = options.epochMax ?? 7;
+  const nDistractors = options.distractorsPerQuestion ?? 5;
+
+  let level = options.startLevel ?? 0;
+  let baseLevel = options.startLevel ?? 0;
+  let served = 0;
+  let condition: Condition = makeCondition(rng, level);
+  let epochLeft = rng.int(epochMin, epochMax);
+  const recent: boolean[] = [];
+
+  const reduced = (): boolean => {
+    if (typeof window === "undefined" || !window.matchMedia) return false;
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  };
+
+  function rotate(): void {
+    baseLevel = Math.min(6, Math.floor(served / 6));
+    const acc = recent.length >= 8 ? recent.filter(Boolean).length / recent.length : 0.7;
+    const bump = acc > 0.85 ? 1 : acc < 0.55 ? -1 : 0;
+    level = Math.max(0, Math.min(6, baseLevel + bump));
+    condition = makeCondition(rng, level, condition.key);
+    epochLeft = rng.int(epochMin, epochMax);
+  }
+
+  return {
+    next(): Question {
+      if (epochLeft <= 0) rotate();
+      epochLeft -= 1;
+      served += 1;
+
+      const answer = rng.pick(condition.satisfying);
+      const pool = rng.shuffle(condition.failing.slice());
+      const distractors: string[] = [];
+      for (const d of pool) {
+        if (d === answer) continue;
+        if (distractors.includes(d)) continue;
+        distractors.push(d);
+        if (distractors.length >= nDistractors) break;
+      }
+
+      return {
+        id: `q${served}`,
+        prompt: condition.prompt,
+        answer,
+        distractors,
+        domain: condition.domain,
+        difficulty: condition.difficulty,
+      };
+    },
+
+    report(r: Report): void {
+      recent.push(r.correct);
+      if (recent.length > 12) recent.shift();
+      options.onReport?.(r);
+    },
+
+    haptic: vibrate,
+
+    prefersReducedMotion: reduced,
+
+    stats() {
+      const acc = recent.length === 0 ? 1 : recent.filter(Boolean).length / recent.length;
+      return { served, level, accuracy: acc, domain: condition.domain };
+    },
+  };
+}

--- a/dynawalla/games/serpent/src/stub/rng.ts
+++ b/dynawalla/games/serpent/src/stub/rng.ts
@@ -1,0 +1,80 @@
+/**
+ * Seeded, deterministic RNG. sfc32 with an xmur3 string-hash seeding step.
+ *
+ * Every question in a Serpent run comes from here, so a seed reproduces a run's
+ * arithmetic exactly. Presentation randomness (particles, drift) uses its own
+ * stream so that a visual tweak can never shift the maths.
+ */
+
+function xmur3(str: string): () => number {
+  let h = 1779033703 ^ str.length;
+  for (let i = 0; i < str.length; i++) {
+    h = Math.imul(h ^ str.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+  return () => {
+    h = Math.imul(h ^ (h >>> 16), 2246822507);
+    h = Math.imul(h ^ (h >>> 13), 3266489909);
+    h ^= h >>> 16;
+    return h >>> 0;
+  };
+}
+
+export type Rng = {
+  /** [0, 1) */
+  next(): number;
+  /** integer in [lo, hi] inclusive */
+  int(lo: number, hi: number): number;
+  pick<T>(xs: readonly T[]): T;
+  /** Fisher–Yates, in place, returns the same array. */
+  shuffle<T>(xs: T[]): T[];
+  chance(p: number): boolean;
+};
+
+export function makeRng(seed: string): Rng {
+  const h = xmur3(seed);
+  let a = h();
+  let b = h();
+  let c = h();
+  let d = h();
+
+  const next = (): number => {
+    a >>>= 0;
+    b >>>= 0;
+    c >>>= 0;
+    d >>>= 0;
+    let t = (a + b) | 0;
+    a = b ^ (b >>> 9);
+    b = (c + (c << 3)) | 0;
+    c = (c << 21) | (c >>> 11);
+    d = (d + 1) | 0;
+    t = (t + d) | 0;
+    c = (c + t) | 0;
+    return (t >>> 0) / 4294967296;
+  };
+
+  const int = (lo: number, hi: number): number => lo + Math.floor(next() * (hi - lo + 1));
+
+  return {
+    next,
+    int,
+    pick<T>(xs: readonly T[]): T {
+      const v = xs[int(0, xs.length - 1)];
+      if (v === undefined) throw new Error("pick from empty array");
+      return v;
+    },
+    shuffle<T>(xs: T[]): T[] {
+      for (let i = xs.length - 1; i > 0; i--) {
+        const j = int(0, i);
+        const xi = xs[i] as T;
+        const xj = xs[j] as T;
+        xs[i] = xj;
+        xs[j] = xi;
+      }
+      return xs;
+    },
+    chance(p: number): boolean {
+      return next() < p;
+    },
+  };
+}

--- a/dynawalla/games/serpent/tsconfig.json
+++ b/dynawalla/games/serpent/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "lib": ["es2023", "dom", "dom.iterable"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": false,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "vite.config.ts"]
+}

--- a/dynawalla/games/serpent/vite.config.ts
+++ b/dynawalla/games/serpent/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  server: { port: 5291, strictPort: true },
+  build: {
+    target: "es2022",
+    lib: {
+      entry: "src/index.ts",
+      name: "DynawallaSerpent",
+      formats: ["es"],
+      fileName: () => "serpent.js",
+    },
+    rollupOptions: { output: { inlineDynamicImports: true } },
+  },
+});


### PR DESCRIPTION
## What

Commit `dynawalla/games/serpent` — COUNTERPOISE, a brass serpent where the scale physically is the equals sign.

## Why

This prototype existed **only as untracked files in a worktree**. It appeared in
zero git refs: `git log --all -- dynawalla/games/serpent` returned no commits. It was
never committed, never branched, never pushed. Pruning that worktree — which the
repo's own session hook recommends doing after a merge — would have destroyed it
with no reflog and no dangling object to recover from.

Ten sibling prototypes were in the same state. This PR is one of that set.

## Blast radius

**Areas touched:** dynawalla (new directory only)

- [x] Additive only. Every path is new under `dynawalla/games/serpent/`; no existing
      file is modified or deleted. Nothing imports it yet.
- [ ] **Every touched path is covered by a `ci.yml` area filter** — **NO, and
      stated deliberately.** `dynawalla/games/` is absent from the `covered`
      regex (`ci.yml:226`), so the `uncovered` step will warn. This is
      pre-existing: the five games already on `main` have no CI either. No job
      builds, type-checks or tests any game. The gates below were therefore run
      locally, by hand. A games-area filter is the correct follow-up and is
      called out rather than silently bundled here.
- [x] **Pack back-compat.** No published pack zip, `voiceId` or catalog entry
      touched. App floor 0.20.6 unaffected.
- [x] **Native integrity.** No Rust, no `src-tauri`, no `links =`, no `[patch]`.
- [x] **Strings.** No `corpan-app` locale keys added; this pack does not use the
      Corpán i18n catalog.
- [x] **Curriculum.** No skill id renamed or reused, no grade metadata changed,
      no generator binding altered.
- [x] **Secrets.** No `.p8`, keystore, service-account JSON, issuer id, key id or
      token. Verified the diff is source, config and `index.html` only.

`package-lock.json` and `qa/shots` are gitignored, matching
`dynawalla/games/slice` and `.../siege`.

## Proof

Run in `dynawalla/games/serpent/` after `npm install`:

```
$ npm test
# tests 31 # pass 31 # fail 0 

$ npm run tsc          # tsc --noEmit
0 errors

$ npm run build
✓ built in 24ms
```

Scope check — the branch adds this game and nothing else:

```
$ git diff --name-only origin/main...HEAD | grep -cv '^dynawalla/games/serpent/'
0
$ git diff --diff-filter=D --name-only origin/main...HEAD | wc -l
0
```
