### PR TITLE
dynawalla/games/trebuchet: TREBUCHET — a siege where the range dial is the answer

### DIFF
--- a/dynawalla/games/trebuchet/.gitignore
+++ b/dynawalla/games/trebuchet/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+dist-pack/
+
+# Playtest capture output: multi-MB PNGs, regenerated on demand.
+qa/shots
+qa/tmp
+
+# Not tracked, matching dynawalla/games/slice and .../merge. These prototypes
+# pin nothing beyond vite + typescript in devDependencies.
+package-lock.json

--- a/dynawalla/games/trebuchet/index.html
+++ b/dynawalla/games/trebuchet/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no" />
+    <meta name="color-scheme" content="dark" />
+    <title>Trebuchet</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        background: #03050d;
+        overflow: hidden;
+        overscroll-behavior: none;
+        -webkit-user-select: none;
+        user-select: none;
+        -webkit-tap-highlight-color: transparent;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/trebuchet/package.json
+++ b/dynawalla/games/trebuchet/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@dynawalla/game-trebuchet",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Trebuchet — a siege where the range dial is the answer.",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4183",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test 'src/**/*.test.ts'"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "typescript": "~6.0.3",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/games/trebuchet/qa/shotserver.mjs
+++ b/dynawalla/games/trebuchet/qa/shotserver.mjs
@@ -1,0 +1,50 @@
+/**
+ * QA capture sink. `node qa/shotserver.mjs` then POST {name, dataUrl} to :4199.
+ *
+ * Exists because a browser tab that Chrome has backgrounded renders zero frames,
+ * so the only way to look at this game honestly is to drive it with a synthetic
+ * clock and pull the canvas out ourselves. Dev tool, never shipped, localhost only.
+ */
+
+import { createServer } from 'node:http'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const OUT = resolve(here, 'shots')
+mkdirSync(OUT, { recursive: true })
+
+createServer((req, res) => {
+  res.setHeader('access-control-allow-origin', '*')
+  res.setHeader('access-control-allow-headers', 'content-type')
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204)
+    res.end()
+    return
+  }
+  if (req.method !== 'POST') {
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end('shotserver up\n')
+    return
+  }
+  let body = ''
+  req.on('data', (c) => {
+    body += c
+  })
+  req.on('end', () => {
+    try {
+      const { name, dataUrl } = JSON.parse(body)
+      const safe = String(name).replace(/[^a-z0-9._-]/gi, '_')
+      const b64 = String(dataUrl).split(',')[1] ?? ''
+      const file = join(OUT, safe.endsWith('.png') ? safe : `${safe}.png`)
+      writeFileSync(file, Buffer.from(b64, 'base64'))
+      process.stdout.write(`wrote ${file} (${Math.round(b64.length / 1024)} KB)\n`)
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ ok: true, file }))
+    } catch (e) {
+      res.writeHead(400)
+      res.end(String(e))
+    }
+  })
+}).listen(4199, '127.0.0.1', () => process.stdout.write('shotserver on http://127.0.0.1:4199\n'))

--- a/dynawalla/games/trebuchet/src/audio/audio.ts
+++ b/dynawalla/games/trebuchet/src/audio/audio.ts
@@ -1,0 +1,389 @@
+/**
+ * Procedural audio. No assets, ever.
+ *
+ * Every impact is built in three layers — TRANSIENT (the click that tells your ear
+ * where it happened), BODY (the pitched thump that gives it mass) and TAIL (the
+ * valley answering back). Pitch and timing jitter on every call so a hundred shots
+ * do not fatigue. Sound is a garnish: mute loses nothing but pleasure.
+ */
+
+type Ctx = AudioContext
+
+const rand = (a: number, b: number): number => a + Math.random() * (b - a)
+
+export class Audio {
+  private ctx: Ctx | null = null
+  private master: GainNode | null = null
+  private verb: ConvolverNode | null = null
+  private send: GainNode | null = null
+  private noiseBuf: AudioBuffer | null = null
+  private flightOsc: OscillatorNode | null = null
+  private flightGain: GainNode | null = null
+  private flightFilt: BiquadFilterNode | null = null
+  enabled = true
+
+  /** Must be called from a user gesture. Safe to call repeatedly. */
+  resume(): void {
+    if (!this.ctx) {
+      const AC: typeof AudioContext =
+        window.AudioContext ?? (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
+      if (!AC) return
+      this.ctx = new AC()
+      const c = this.ctx
+      this.master = c.createGain()
+      this.master.gain.value = 0.62
+      const comp = c.createDynamicsCompressor()
+      comp.threshold.value = -14
+      comp.knee.value = 22
+      comp.ratio.value = 5
+      comp.attack.value = 0.004
+      comp.release.value = 0.16
+      this.master.connect(comp)
+      comp.connect(c.destination)
+
+      // Generated impulse response: a stone valley. Synthesis, not an asset.
+      const len = Math.floor(c.sampleRate * 1.7)
+      const ir = c.createBuffer(2, len, c.sampleRate)
+      for (let ch = 0; ch < 2; ch++) {
+        const d = ir.getChannelData(ch)
+        for (let i = 0; i < len; i++) {
+          const t = i / len
+          d[i] = (Math.random() * 2 - 1) * Math.pow(1 - t, 3.1) * (1 - t * 0.2)
+        }
+      }
+      this.verb = c.createConvolver()
+      this.verb.buffer = ir
+      this.send = c.createGain()
+      this.send.gain.value = 0.34
+      this.send.connect(this.verb)
+      this.verb.connect(this.master)
+
+      const nlen = Math.floor(c.sampleRate * 2)
+      this.noiseBuf = c.createBuffer(1, nlen, c.sampleRate)
+      const nd = this.noiseBuf.getChannelData(0)
+      for (let i = 0; i < nlen; i++) nd[i] = Math.random() * 2 - 1
+    }
+    if (this.ctx.state === 'suspended') void this.ctx.resume()
+  }
+
+  private get t(): number {
+    return this.ctx ? this.ctx.currentTime : 0
+  }
+
+  private ok(): boolean {
+    return this.enabled && !!this.ctx && !!this.master
+  }
+
+  private noise(dur: number): AudioBufferSourceNode | null {
+    if (!this.ctx || !this.noiseBuf) return null
+    const s = this.ctx.createBufferSource()
+    s.buffer = this.noiseBuf
+    s.loop = true
+    s.start(this.t, rand(0, 1))
+    s.stop(this.t + dur + 0.05)
+    return s
+  }
+
+  private env(gain: GainNode, peak: number, attack: number, decay: number, at = this.t): void {
+    gain.gain.setValueAtTime(0.0001, at)
+    gain.gain.exponentialRampToValueAtTime(Math.max(0.0002, peak), at + attack)
+    gain.gain.exponentialRampToValueAtTime(0.0001, at + attack + decay)
+  }
+
+  private toOut(node: AudioNode, sendAmt: number): void {
+    if (!this.master || !this.send) return
+    node.connect(this.master)
+    if (sendAmt > 0) {
+      const g = this.ctx!.createGain()
+      g.gain.value = sendAmt
+      node.connect(g)
+      g.connect(this.send)
+    }
+  }
+
+  /** Winch ratchet — one click per notch, pitch climbing with the dial. */
+  tick(power01: number): void {
+    if (!this.ok()) return
+    const c = this.ctx!
+    const src = this.noise(0.05)
+    if (!src) return
+    const bp = c.createBiquadFilter()
+    bp.type = 'bandpass'
+    bp.frequency.value = 900 + power01 * 1500 * rand(0.96, 1.04)
+    bp.Q.value = 6
+    const g = c.createGain()
+    this.env(g, 0.16, 0.002, 0.04)
+    src.connect(bp)
+    bp.connect(g)
+    this.toOut(g, 0.05)
+  }
+
+  /** The loft lever — a woodier, lower detent. */
+  detent(): void {
+    if (!this.ok()) return
+    const c = this.ctx!
+    const o = c.createOscillator()
+    o.type = 'triangle'
+    o.frequency.setValueAtTime(rand(300, 330), this.t)
+    o.frequency.exponentialRampToValueAtTime(150, this.t + 0.06)
+    const g = c.createGain()
+    this.env(g, 0.12, 0.003, 0.07)
+    o.connect(g)
+    this.toOut(g, 0.1)
+    o.start(this.t)
+    o.stop(this.t + 0.14)
+  }
+
+  /** Counterweight drops, rope sings, arm whips. */
+  launch(power01: number): void {
+    if (!this.ok()) return
+    const c = this.ctx!
+    const t0 = this.t
+    // body: the counterweight
+    const o = c.createOscillator()
+    o.type = 'sine'
+    o.frequency.setValueAtTime(rand(150, 168), t0)
+    o.frequency.exponentialRampToValueAtTime(46, t0 + 0.3)
+    const og = c.createGain()
+    this.env(og, 0.55, 0.006, 0.34, t0)
+    o.connect(og)
+    this.toOut(og, 0.22)
+    o.start(t0)
+    o.stop(t0 + 0.5)
+    // transient + rope whoosh
+    const src = this.noise(0.42)
+    if (src) {
+      const bp = c.createBiquadFilter()
+      bp.type = 'bandpass'
+      bp.Q.value = 1.4
+      bp.frequency.setValueAtTime(420, t0)
+      bp.frequency.exponentialRampToValueAtTime(2600 + power01 * 1400, t0 + 0.26)
+      const g = c.createGain()
+      this.env(g, 0.3, 0.02, 0.3, t0)
+      src.connect(bp)
+      bp.connect(g)
+      this.toOut(g, 0.3)
+    }
+  }
+
+  /** Continuous flight whistle. Pitch tracks speed; volume tracks height. */
+  flightStart(): void {
+    if (!this.ok()) return
+    const c = this.ctx!
+    this.flightStop()
+    const o = c.createOscillator()
+    o.type = 'sine'
+    o.frequency.value = 520
+    const f = c.createBiquadFilter()
+    f.type = 'lowpass'
+    f.frequency.value = 2200
+    const g = c.createGain()
+    g.gain.value = 0.0001
+    o.connect(f)
+    f.connect(g)
+    this.toOut(g, 0.2)
+    o.start()
+    this.flightOsc = o
+    this.flightGain = g
+    this.flightFilt = f
+  }
+
+  flightUpdate(speed01: number, height01: number): void {
+    if (!this.flightOsc || !this.flightGain || !this.ctx) return
+    const t = this.t
+    this.flightOsc.frequency.setTargetAtTime(300 + speed01 * 900, t, 0.05)
+    this.flightGain.gain.setTargetAtTime(0.03 + height01 * 0.075, t, 0.08)
+    this.flightFilt?.frequency.setTargetAtTime(900 + speed01 * 2600, t, 0.08)
+  }
+
+  flightStop(): void {
+    if (this.flightOsc && this.flightGain && this.ctx) {
+      const t = this.t
+      this.flightGain.gain.setTargetAtTime(0.0001, t, 0.03)
+      const o = this.flightOsc
+      try {
+        o.stop(t + 0.2)
+      } catch {
+        /* already stopped */
+      }
+    }
+    this.flightOsc = null
+    this.flightGain = null
+    this.flightFilt = null
+  }
+
+  /** Ground impact: dirt transient, low body, valley tail. `mass` 0..1 */
+  impactDirt(mass: number): void {
+    if (!this.ok()) return
+    const c = this.ctx!
+    const t0 = this.t
+    const o = c.createOscillator()
+    o.type = 'sine'
+    o.frequency.setValueAtTime(rand(96, 116), t0)
+    o.frequency.exponentialRampToValueAtTime(34, t0 + 0.22)
+    const og = c.createGain()
+    this.env(og, 0.35 + mass * 0.4, 0.004, 0.3, t0)
+    o.connect(og)
+    this.toOut(og, 0.3)
+    o.start(t0)
+    o.stop(t0 + 0.5)
+    const src = this.noise(0.3)
+    if (src) {
+      const lp = c.createBiquadFilter()
+      lp.type = 'lowpass'
+      lp.frequency.setValueAtTime(2400, t0)
+      lp.frequency.exponentialRampToValueAtTime(320, t0 + 0.24)
+      const g = c.createGain()
+      this.env(g, 0.28 + mass * 0.2, 0.003, 0.26, t0)
+      src.connect(lp)
+      lp.connect(g)
+      this.toOut(g, 0.4)
+    }
+  }
+
+  /** Stone impact: a crack on top of the dirt. */
+  impactStone(mass: number): void {
+    if (!this.ok()) return
+    this.impactDirt(mass)
+    const c = this.ctx!
+    const t0 = this.t
+    for (let i = 0; i < 3; i++) {
+      const src = this.noise(0.14)
+      if (!src) continue
+      const bp = c.createBiquadFilter()
+      bp.type = 'bandpass'
+      bp.Q.value = 2.2
+      bp.frequency.value = rand(1400, 3600)
+      const g = c.createGain()
+      this.env(g, 0.2, 0.001, 0.1, t0 + i * rand(0.005, 0.03))
+      src.connect(bp)
+      bp.connect(g)
+      this.toOut(g, 0.35)
+    }
+  }
+
+  /** A tower coming apart — staggered crunches over ~700 ms. */
+  collapse(): void {
+    if (!this.ok()) return
+    const c = this.ctx!
+    const t0 = this.t
+    for (let i = 0; i < 7; i++) {
+      const at = t0 + i * rand(0.04, 0.12)
+      const src = this.noise(0.3)
+      if (!src) continue
+      const lp = c.createBiquadFilter()
+      lp.type = 'lowpass'
+      lp.frequency.value = rand(500, 1800)
+      const g = c.createGain()
+      this.env(g, rand(0.1, 0.26), 0.004, rand(0.12, 0.34), at)
+      src.connect(lp)
+      lp.connect(g)
+      this.toOut(g, 0.45)
+    }
+    const o = c.createOscillator()
+    o.type = 'sine'
+    o.frequency.setValueAtTime(60, t0)
+    o.frequency.exponentialRampToValueAtTime(26, t0 + 0.9)
+    const og = c.createGain()
+    this.env(og, 0.5, 0.02, 0.9, t0)
+    o.connect(og)
+    this.toOut(og, 0.2)
+    o.start(t0)
+    o.stop(t0 + 1.1)
+  }
+
+  /** The reward. Rises a step per chain link, then rolls over — never a slot machine. */
+  fanfare(chain: number): void {
+    if (!this.ok()) return
+    const c = this.ctx!
+    const pent = [0, 2, 4, 7, 9, 12, 14, 16, 19, 21]
+    const base = 392 * Math.pow(2, Math.min(chain, 8) / 12)
+    const t0 = this.t
+    for (let i = 0; i < 5; i++) {
+      const o = c.createOscillator()
+      o.type = i % 2 === 0 ? 'triangle' : 'sine'
+      o.frequency.value = base * Math.pow(2, pent[i] / 12) * rand(0.997, 1.003)
+      const g = c.createGain()
+      this.env(g, 0.14, 0.006, 0.34, t0 + i * 0.055)
+      o.connect(g)
+      this.toOut(g, 0.5)
+      o.start(t0 + i * 0.055)
+      o.stop(t0 + i * 0.055 + 0.5)
+    }
+  }
+
+  /** Struck the wrong keep: a horn, sour but not a buzzer. Never a punishment noise. */
+  wrongHorn(): void {
+    if (!this.ok()) return
+    const c = this.ctx!
+    const t0 = this.t
+    for (const [f, det] of [
+      [174, 1],
+      [184, 1.004],
+    ] as Array<[number, number]>) {
+      const o = c.createOscillator()
+      o.type = 'sawtooth'
+      o.frequency.value = f * det
+      const lp = c.createBiquadFilter()
+      lp.type = 'lowpass'
+      lp.frequency.setValueAtTime(1400, t0)
+      lp.frequency.exponentialRampToValueAtTime(340, t0 + 0.7)
+      const g = c.createGain()
+      this.env(g, 0.16, 0.05, 0.6, t0)
+      o.connect(lp)
+      lp.connect(g)
+      this.toOut(g, 0.4)
+      o.start(t0)
+      o.stop(t0 + 0.9)
+    }
+  }
+
+  /** Incoming counter-fire. Doppler down, then a hit on your platform. */
+  incoming(delay: number): void {
+    if (!this.ok()) return
+    const c = this.ctx!
+    const t0 = this.t
+    const o = c.createOscillator()
+    o.type = 'sine'
+    o.frequency.setValueAtTime(1500, t0)
+    o.frequency.exponentialRampToValueAtTime(260, t0 + delay)
+    const g = c.createGain()
+    g.gain.setValueAtTime(0.0001, t0)
+    g.gain.exponentialRampToValueAtTime(0.1, t0 + delay * 0.7)
+    g.gain.exponentialRampToValueAtTime(0.0001, t0 + delay)
+    o.connect(g)
+    this.toOut(g, 0.3)
+    o.start(t0)
+    o.stop(t0 + delay + 0.1)
+  }
+
+  /** Wave horn — low, ceremonial, once per wave. */
+  horn(up: boolean): void {
+    if (!this.ok()) return
+    const c = this.ctx!
+    const t0 = this.t
+    for (const mult of [1, 1.5, 2.02]) {
+      const o = c.createOscillator()
+      o.type = 'sawtooth'
+      o.frequency.setValueAtTime(110 * mult, t0)
+      o.frequency.linearRampToValueAtTime(110 * mult * (up ? 1.06 : 0.94), t0 + 0.8)
+      const lp = c.createBiquadFilter()
+      lp.type = 'lowpass'
+      lp.frequency.value = 900
+      const g = c.createGain()
+      this.env(g, 0.1, 0.14, 0.8, t0)
+      o.connect(lp)
+      lp.connect(g)
+      this.toOut(g, 0.6)
+      o.start(t0)
+      o.stop(t0 + 1.2)
+    }
+  }
+
+  dispose(): void {
+    this.flightStop()
+    if (this.ctx) void this.ctx.close()
+    this.ctx = null
+    this.master = null
+  }
+}

--- a/dynawalla/games/trebuchet/src/contract.ts
+++ b/dynawalla/games/trebuchet/src/contract.ts
@@ -1,0 +1,25 @@
+/**
+ * The game <-> host contract.
+ *
+ * This file is a placeholder for a shared package that will replace it. Keep the
+ * shape EXACTLY as written so the swap is mechanical: delete this file, change the
+ * import specifier, done. Nothing else in this game may add a field to these types.
+ */
+
+export type Question = {
+  id: string
+  prompt: string /* "15 − 8" */
+  answer: string /* "7"  — exact, canonical */
+  distractors: string[] /* plausible wrong answers, ideally real mal-rule outputs */
+  domain: string /* "add-sub" | "fractions" | ... */
+  difficulty: number /* 0..1 */
+}
+
+export type Host = {
+  next(): Question
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+  haptic(kind: 'light' | 'medium' | 'heavy' | 'success' | 'failure'): void
+  prefersReducedMotion(): boolean
+}
+
+export type Mounted = { unmount(): void }

--- a/dynawalla/games/trebuchet/src/core/camera.ts
+++ b/dynawalla/games/trebuchet/src/core/camera.ts
@@ -1,0 +1,131 @@
+/**
+ * Camera: world metres -> screen pixels, plus the three things that make an impact
+ * feel like an impact — trauma shake (decaying, squared), zoom punch (elastic), and
+ * a lead that pans ahead of the shot instead of chasing it.
+ */
+
+import { approach, clamp, easeOutElastic, noise1 } from './ease.ts'
+
+export type Viewport = { w: number; h: number }
+
+export class Camera {
+  /** world-space centre */
+  x = 50
+  y = 22
+  /** pixels per metre */
+  ppm = 9
+  /** where the camera wants to be; the real one eases toward it */
+  wantX = 50
+  wantY = 22
+  wantPpm = 9
+
+  /** 0..1, decays; shake magnitude is trauma^2 (Nijman) so small hits stay small */
+  trauma = 0
+  private shakeT = 0
+  private punchT = 999
+  private punchAmount = 0
+  private rollT = 0
+
+  /** motion scaling for prefers-reduced-motion; 0 disables shake and punch */
+  motion = 1
+
+  /** hard ceilings so a chain of impacts cannot stack into a seizure risk */
+  static readonly MAX_SHAKE_PX = 26
+  static readonly MAX_ROLL_RAD = 0.028
+
+  snap(): void {
+    this.x = this.wantX
+    this.y = this.wantY
+    this.ppm = this.wantPpm
+  }
+
+  addTrauma(amount: number): void {
+    this.trauma = clamp(this.trauma + amount * this.motion, 0, 1)
+  }
+
+  punch(amount: number): void {
+    this.punchAmount = amount * this.motion
+    this.punchT = 0
+  }
+
+  /**
+   * Frame a set of world points, and put the ground line at a fixed fraction of
+   * the screen height so the composition never drifts: sky above, a sliver of
+   * earth below, the siege on the line between them.
+   */
+  frame(
+    pts: Array<{ x: number; y: number }>,
+    vp: Viewport,
+    opts: { minSpanX: number; padPx: number; padTopPx?: number; groundFrac?: number },
+  ): void {
+    let minX = Infinity
+    let maxX = -Infinity
+    let maxY = 12
+    for (const p of pts) {
+      if (p.x < minX) minX = p.x
+      if (p.x > maxX) maxX = p.x
+      if (p.y > maxY) maxY = p.y
+    }
+    if (!Number.isFinite(minX)) return
+    const gf = opts.groundFrac ?? 0.8
+    const spanX = Math.max(maxX - minX, opts.minSpanX)
+    const usableW = Math.max(80, vp.w - opts.padPx * 2)
+    // The tallest point must sit under the top pad given the ground is pinned at gf.
+    const headroom = Math.max(60, gf * vp.h - (opts.padTopPx ?? opts.padPx))
+    this.wantPpm = Math.min(usableW / spanX, headroom / Math.max(8, maxY))
+    this.wantX = (minX + maxX) / 2
+    this.wantY = (gf - 0.5) * (vp.h / this.wantPpm)
+  }
+
+  update(dt: number): void {
+    // Pan/zoom are exponential approaches: no overshoot, frame-rate independent.
+    this.x = approach(this.x, this.wantX, 7.5, dt)
+    this.y = approach(this.y, this.wantY, 7.5, dt)
+    this.ppm = approach(this.ppm, this.wantPpm, 6.0, dt)
+    this.shakeT += dt
+    this.rollT += dt
+    // decay ~ 1.9/s: a big hit rings for about half a second
+    this.trauma = Math.max(0, this.trauma - 1.9 * dt)
+    if (this.punchT < 1) this.punchT += dt / 0.55
+  }
+
+  /** Effective zoom including the elastic punch. */
+  get zoom(): number {
+    if (this.punchT >= 1) return 1
+    // easeOutElastic settles back to 1 with two visible ring-outs
+    return 1 + this.punchAmount * (1 - easeOutElastic(this.punchT))
+  }
+
+  get shakeX(): number {
+    const s = this.trauma * this.trauma
+    return noise1(this.shakeT * 34, 1) * Camera.MAX_SHAKE_PX * s
+  }
+
+  get shakeY(): number {
+    const s = this.trauma * this.trauma
+    return noise1(this.shakeT * 31, 2) * Camera.MAX_SHAKE_PX * s * 0.72
+  }
+
+  get roll(): number {
+    const s = this.trauma * this.trauma
+    return noise1(this.rollT * 19, 3) * Camera.MAX_ROLL_RAD * s
+  }
+
+  /** Apply the view transform. Caller must ctx.save() first. */
+  applyTransform(ctx: CanvasRenderingContext2D, vp: Viewport): void {
+    ctx.translate(vp.w / 2 + this.shakeX, vp.h / 2 + this.shakeY)
+    if (this.roll !== 0) ctx.rotate(this.roll)
+    const s = this.ppm * this.zoom
+    ctx.scale(s, -s)
+    ctx.translate(-this.x, -this.y)
+  }
+
+  /** World -> unshaken screen pixel (for HUD anchors). */
+  toScreen(wx: number, wy: number, vp: Viewport): { x: number; y: number } {
+    const s = this.ppm * this.zoom
+    return {
+      x: vp.w / 2 + this.shakeX + (wx - this.x) * s,
+      y: vp.h / 2 + this.shakeY - (wy - this.y) * s,
+    }
+  }
+}

--- a/dynawalla/games/trebuchet/src/core/ease.ts
+++ b/dynawalla/games/trebuchet/src/core/ease.ts
@@ -1,0 +1,61 @@
+/** Easing, by name. Every animation in this game names the curve it uses. */
+
+export const clamp = (v: number, lo: number, hi: number): number => (v < lo ? lo : v > hi ? hi : v)
+export const clamp01 = (v: number): number => clamp(v, 0, 1)
+export const lerp = (a: number, b: number, t: number): number => a + (b - a) * t
+
+/** Frame-rate independent approach. `rate` = fraction of the gap closed per second. */
+export const approach = (a: number, b: number, rate: number, dt: number): number =>
+  b + (a - b) * Math.exp(-rate * dt)
+
+export const easeOutCubic = (t: number): number => 1 - Math.pow(1 - t, 3)
+export const easeInCubic = (t: number): number => t * t * t
+export const easeInQuad = (t: number): number => t * t
+export const easeOutQuad = (t: number): number => 1 - (1 - t) * (1 - t)
+export const easeInOutCubic = (t: number): number =>
+  t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2
+export const easeOutExpo = (t: number): number => (t >= 1 ? 1 : 1 - Math.pow(2, -10 * t))
+
+export function easeOutBack(t: number, overshoot = 1.7): number {
+  const c3 = overshoot + 1
+  const p = t - 1
+  return 1 + c3 * p * p * p + overshoot * p * p
+}
+
+export function easeOutElastic(t: number, period = 0.34): number {
+  if (t <= 0) return 0
+  if (t >= 1) return 1
+  const c4 = (2 * Math.PI) / period
+  return Math.pow(2, -10 * t) * Math.sin((t * 10 - 0.75) * c4) + 1
+}
+
+export function easeOutBounce(t: number): number {
+  const n1 = 7.5625
+  const d1 = 2.75
+  if (t < 1 / d1) return n1 * t * t
+  if (t < 2 / d1) {
+    const p = t - 1.5 / d1
+    return n1 * p * p + 0.75
+  }
+  if (t < 2.5 / d1) {
+    const p = t - 2.25 / d1
+    return n1 * p * p + 0.9375
+  }
+  const p = t - 2.625 / d1
+  return n1 * p * p + 0.984375
+}
+
+/** Smooth, cheap value noise for shake — deterministic per channel. */
+export function noise1(x: number, channel: number): number {
+  const i = Math.floor(x)
+  const f = x - i
+  const h = (n: number): number => {
+    let t = (n * 1103515245 + channel * 12345 + 0x9e3779b9) >>> 0
+    t ^= t >>> 15
+    t = Math.imul(t, 0x85ebca6b)
+    t ^= t >>> 13
+    return ((t >>> 0) / 4294967296) * 2 - 1
+  }
+  const u = f * f * (3 - 2 * f)
+  return lerp(h(i), h(i + 1), u)
+}

--- a/dynawalla/games/trebuchet/src/core/rng.ts
+++ b/dynawalla/games/trebuchet/src/core/rng.ts
@@ -1,0 +1,58 @@
+/** Seeded, deterministic PRNG. Same seed -> same run, forever. */
+
+export type Rng = {
+  /** float in [0,1) — cosmetics only, never a correctness decision */
+  next(): number
+  /** integer in [lo, hi] inclusive */
+  int(lo: number, hi: number): number
+  pick<T>(xs: readonly T[]): T
+  /** float in [lo, hi) */
+  range(lo: number, hi: number): number
+  chance(p: number): boolean
+  /** a fresh independent stream, deterministically derived */
+  fork(tag: string): Rng
+  readonly seed: number
+}
+
+export function hashString(s: string): number {
+  let h = 0x811c9dc5
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return h >>> 0
+}
+
+/** mulberry32 — small, fast, good enough, and identical on every platform. */
+export function makeRng(seed: number): Rng {
+  let a = seed >>> 0
+  const next = (): number => {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+  const rng: Rng = {
+    seed,
+    next,
+    int: (lo, hi) => lo + Math.floor(next() * (hi - lo + 1)),
+    range: (lo, hi) => lo + next() * (hi - lo),
+    pick: (xs) => xs[Math.floor(next() * xs.length)],
+    chance: (p) => next() < p,
+    fork: (tag) => makeRng((seed ^ hashString(tag)) >>> 0),
+  }
+  return rng
+}
+
+/** Deterministic shuffle (Fisher-Yates) — returns a new array. */
+export function shuffled<T>(xs: readonly T[], rng: Rng): T[] {
+  const out = xs.slice()
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = rng.int(0, i)
+    const tmp = out[i]
+    out[i] = out[j]
+    out[j] = tmp
+  }
+  return out
+}

--- a/dynawalla/games/trebuchet/src/fx/flash.test.ts
+++ b/dynawalla/games/trebuchet/src/fx/flash.test.ts
@@ -1,0 +1,92 @@
+/**
+ * The photosensitivity budget is a safety property, so it is a test, not a habit.
+ */
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { Flash } from './flash.ts'
+
+test('no more than three bright events in any one second', () => {
+  const f = new Flash()
+  let allowed = 0
+  for (let i = 0; i < 40; i++) {
+    if (f.add(1, 0.2)) allowed++
+    f.update(1 / 60)
+  }
+  // 40 frames at 60fps is 0.66 s
+  assert.equal(allowed, Flash.MAX_PER_SEC)
+})
+
+test('the budget refills, it does not lock out forever', () => {
+  const f = new Flash()
+  for (let i = 0; i < 5; i++) f.add(1, 0.2)
+  for (let i = 0; i < 70; i++) f.update(1 / 60)
+  assert.equal(f.add(1, 0.2), true)
+})
+
+test('a strobe is impossible: every event lasts at least MIN_LIFE', () => {
+  const f = new Flash()
+  assert.ok(Flash.MIN_LIFE >= 0.1, 'anything under ~8 Hz is the danger band')
+  f.add(1, 0.001)
+  // it must still be alive after a couple of frames
+  f.update(1 / 60)
+  f.update(1 / 60)
+  const calls = countFills(f, 800, 600)
+  assert.ok(calls > 0, 'a sub-frame flash must be stretched, not dropped')
+})
+
+test('reduced motion scales brightness down and never up', () => {
+  const f = new Flash()
+  f.motion = 0.25
+  f.add(1, 0.3)
+  f.update(0.1)
+  const a1 = peakAlpha(f)
+  const g = new Flash()
+  g.add(1, 0.3)
+  g.update(0.1)
+  const a2 = peakAlpha(g)
+  assert.ok(a1 < a2)
+})
+
+test('total brightness is clamped no matter how much is stacked', () => {
+  const f = new Flash()
+  for (let i = 0; i < 3; i++) f.add(1, 0.3)
+  f.update(0.05)
+  assert.ok(peakAlpha(f) <= Flash.MAX_ALPHA + 1e-9)
+})
+
+/* --- a canvas stub good enough to observe what the compositor was asked to do --- */
+
+type Rec = { alpha: number; fills: number }
+
+function fakeCtx(rec: Rec): CanvasRenderingContext2D {
+  const grad = { addColorStop(): void {} }
+  const c = {
+    globalAlpha: 1,
+    globalCompositeOperation: 'source-over',
+    fillStyle: '',
+    save(): void {},
+    restore(): void {},
+    createRadialGradient(): unknown {
+      return grad
+    },
+    fillRect(): void {
+      rec.fills++
+      rec.alpha = Math.max(rec.alpha, (c as unknown as { globalAlpha: number }).globalAlpha)
+    },
+  }
+  return c as unknown as CanvasRenderingContext2D
+}
+
+function peakAlpha(f: Flash): number {
+  const rec: Rec = { alpha: 0, fills: 0 }
+  f.draw(fakeCtx(rec), 800, 600, 'rgba(255,255,255,1)')
+  return rec.alpha
+}
+
+function countFills(f: Flash, w: number, h: number): number {
+  const rec: Rec = { alpha: 0, fills: 0 }
+  f.draw(fakeCtx(rec), w, h, 'rgba(255,255,255,1)')
+  return rec.fills
+}

--- a/dynawalla/games/trebuchet/src/fx/flash.ts
+++ b/dynawalla/games/trebuchet/src/fx/flash.ts
@@ -1,0 +1,89 @@
+/**
+ * Screen light — and the one place that decides how bright the world is allowed to
+ * get, how often.
+ *
+ * This is a children's product. Photosensitive epilepsy is triggered by *rate* and
+ * *contrast*, so both are capped here rather than at each call site: no more than
+ * `MAX_PER_SEC` bright events per second, never above `MAX_ALPHA`, and every event
+ * ramps rather than steps. A big hit during a lightning strike does not add up to a
+ * white frame — the budget is shared.
+ */
+
+import { clamp01, easeOutCubic } from '../core/ease.ts'
+
+export class Flash {
+  private events: Array<{ t: number; life: number; amp: number; x: number; y: number; r: number }> = []
+  private recent: number[] = []
+  private now = 0
+  motion = 1
+
+  static readonly MAX_PER_SEC = 3
+  static readonly MAX_ALPHA = 0.34
+  /** shortest a bright event may last — a hard strobe is never allowed */
+  static readonly MIN_LIFE = 0.13
+
+  /** @returns whether the flash was allowed */
+  add(amp: number, life: number, x = 0.5, y = 0.5, r = 1): boolean {
+    this.recent = this.recent.filter((t) => this.now - t < 1)
+    if (this.recent.length >= Flash.MAX_PER_SEC) return false
+    this.recent.push(this.now)
+    const life2 = Math.max(Flash.MIN_LIFE, life)
+    this.events.push({
+      t: 0,
+      life: life2,
+      amp: clamp01(amp) * this.motion,
+      x,
+      y,
+      r,
+    })
+    return true
+  }
+
+  update(dt: number): void {
+    this.now += dt
+    for (let i = this.events.length - 1; i >= 0; i--) {
+      const e = this.events[i]
+      e.t += dt
+      if (e.t >= e.life) this.events.splice(i, 1)
+    }
+  }
+
+  /** Composite every live event, clamped in total. Screen space. */
+  draw(ctx: CanvasRenderingContext2D, w: number, h: number, tint: string): void {
+    if (!this.events.length) return
+    let total = 0
+    for (const e of this.events) {
+      const k = clamp01(e.t / e.life)
+      // fast rise, slow fall — never a square edge
+      const env = k < 0.18 ? easeOutCubic(k / 0.18) : 1 - easeOutCubic((k - 0.18) / 0.82)
+      total += e.amp * env
+    }
+    if (total <= 0.001) return
+    const a = Math.min(Flash.MAX_ALPHA, total)
+    // Use the brightest event's position for the falloff centre.
+    let best = this.events[0]
+    let bestAmp = -1
+    for (const e of this.events) {
+      if (e.amp > bestAmp) {
+        bestAmp = e.amp
+        best = e
+      }
+    }
+    const cx = best.x * w
+    const cy = best.y * h
+    const rad = best.r * Math.max(w, h)
+    ctx.save()
+    ctx.globalCompositeOperation = 'lighter'
+    const g = ctx.createRadialGradient(cx, cy, 0, cx, cy, rad)
+    g.addColorStop(0, tint)
+    g.addColorStop(1, 'rgba(0,0,0,0)')
+    ctx.globalAlpha = a
+    ctx.fillStyle = g
+    ctx.fillRect(0, 0, w, h)
+    ctx.restore()
+  }
+
+  clear(): void {
+    this.events.length = 0
+  }
+}

--- a/dynawalla/games/trebuchet/src/fx/particles.ts
+++ b/dynawalla/games/trebuchet/src/fx/particles.ts
@@ -1,0 +1,284 @@
+/**
+ * Pooled particle system. Fixed allocation, swap-remove, hard caps.
+ *
+ * Everything is drawn with at most a handful of canvas calls per kind: sparks are
+ * one stroked path, dust is one filled path per alpha bucket, embers are a
+ * pre-rendered glow sprite via drawImage. No shadowBlur anywhere — it is the single
+ * most expensive thing you can put in a 2D canvas frame.
+ */
+
+export type Kind = 0 | 1 | 2 | 3 | 4
+export const SPARK: Kind = 0
+export const DUST: Kind = 1
+export const EMBER: Kind = 2
+export const DEBRIS: Kind = 3
+export const SHARD: Kind = 4
+
+type P = {
+  kind: Kind
+  x: number
+  y: number
+  vx: number
+  vy: number
+  life: number
+  maxLife: number
+  size: number
+  rot: number
+  spin: number
+  drag: number
+  grav: number
+  /** 0..2 colour bucket within the kind */
+  tone: number
+  bounce: number
+  w: number
+  h: number
+}
+
+const make = (): P => ({
+  kind: SPARK,
+  x: 0,
+  y: 0,
+  vx: 0,
+  vy: 0,
+  life: 0,
+  maxLife: 1,
+  size: 1,
+  rot: 0,
+  spin: 0,
+  drag: 0,
+  grav: 0,
+  tone: 0,
+  bounce: 0,
+  w: 1,
+  h: 1,
+})
+
+export class Particles {
+  private pool: P[]
+  private n = 0
+  readonly cap: number
+  /** scaled down under prefers-reduced-motion and on weak frames */
+  budget = 1
+
+  constructor(cap = 1500) {
+    this.cap = cap
+    this.pool = new Array(cap)
+    for (let i = 0; i < cap; i++) this.pool[i] = make()
+  }
+
+  get count(): number {
+    return this.n
+  }
+
+  clear(): void {
+    this.n = 0
+  }
+
+  private recycle = 0
+
+  private spawn(): P | null {
+    if (this.n >= this.cap) {
+      // Recycle rather than drop: an impact must never look thin because the
+      // rain happened to be busy. Round-robin so we never eat the same slot.
+      this.recycle = (this.recycle + 1) % this.cap
+      return this.pool[this.recycle]
+    }
+    return this.pool[this.n++]
+  }
+
+  emit(
+    kind: Kind,
+    x: number,
+    y: number,
+    vx: number,
+    vy: number,
+    opts: Partial<Omit<P, 'kind' | 'x' | 'y' | 'vx' | 'vy'>> = {},
+  ): void {
+    const p = this.spawn()
+    if (!p) return
+    p.kind = kind
+    p.x = x
+    p.y = y
+    p.vx = vx
+    p.vy = vy
+    p.maxLife = opts.maxLife ?? 0.6
+    p.life = p.maxLife
+    p.size = opts.size ?? 0.35
+    p.rot = opts.rot ?? 0
+    p.spin = opts.spin ?? 0
+    p.drag = opts.drag ?? 0.6
+    p.grav = opts.grav ?? 0
+    p.tone = opts.tone ?? 0
+    p.bounce = opts.bounce ?? 0
+    p.w = opts.w ?? p.size
+    p.h = opts.h ?? p.size
+  }
+
+  update(dt: number, groundY: number): void {
+    const pool = this.pool
+    for (let i = 0; i < this.n; i++) {
+      const p = pool[i]
+      p.life -= dt
+      if (p.life <= 0) {
+        const last = pool[this.n - 1]
+        pool[this.n - 1] = p
+        pool[i] = last
+        this.n--
+        i--
+        continue
+      }
+      p.vy -= p.grav * dt
+      const d = Math.exp(-p.drag * dt)
+      p.vx *= d
+      p.vy *= d
+      p.x += p.vx * dt
+      p.y += p.vy * dt
+      p.rot += p.spin * dt
+      if (p.bounce > 0 && p.y < groundY + p.size * 0.5) {
+        p.y = groundY + p.size * 0.5
+        p.vy = -p.vy * p.bounce
+        p.vx *= 0.72
+        p.spin *= 0.6
+        if (Math.abs(p.vy) < 0.6) {
+          p.vy = 0
+          p.bounce = 0
+          p.grav = 0
+          p.vx *= 0.2
+        }
+      }
+    }
+  }
+
+  /**
+   * @param s pixels per metre (for line widths)
+   */
+  draw(
+    ctx: CanvasRenderingContext2D,
+    s: number,
+    glow: CanvasImageSource,
+    puff: CanvasImageSource,
+    pal: Palette,
+  ): void {
+    const pool = this.pool
+    const n = this.n
+
+    // --- dust & smoke: a soft pre-rendered puff, so a cloud reads as a cloud
+    // and not as a union of hard circles ------------------------------------
+    for (let i = 0; i < n; i++) {
+      const p = pool[i]
+      if (p.kind !== DUST) continue
+      const t = p.life / p.maxLife
+      const r = p.size * (1 + (1 - t) * 2.6)
+      ctx.globalAlpha = t * t * 0.5
+      ctx.drawImage(puff, p.x - r, p.y - r, r * 2, r * 2)
+    }
+    ctx.globalAlpha = 1
+
+    // --- debris & shards: rotated quads, grouped by tone ------------------
+    for (let tone = 0; tone < 3; tone++) {
+      let began = false
+      for (let i = 0; i < n; i++) {
+        const p = pool[i]
+        if ((p.kind !== DEBRIS && p.kind !== SHARD) || p.tone !== tone) continue
+        if (!began) {
+          ctx.beginPath()
+          began = true
+        }
+        const c = Math.cos(p.rot)
+        const sn = Math.sin(p.rot)
+        const hw = p.w * 0.5
+        const hh = p.h * 0.5
+        const x1 = c * hw
+        const y1 = sn * hw
+        const x2 = -sn * hh
+        const y2 = c * hh
+        ctx.moveTo(p.x - x1 - x2, p.y - y1 - y2)
+        ctx.lineTo(p.x + x1 - x2, p.y + y1 - y2)
+        ctx.lineTo(p.x + x1 + x2, p.y + y1 + y2)
+        ctx.lineTo(p.x - x1 + x2, p.y - y1 + y2)
+        ctx.closePath()
+      }
+      if (began) {
+        ctx.fillStyle = pal.debris[tone]
+        ctx.fill()
+      }
+    }
+
+    // --- embers: additive glow sprite -------------------------------------
+    ctx.globalCompositeOperation = 'lighter'
+    for (let i = 0; i < n; i++) {
+      const p = pool[i]
+      if (p.kind !== EMBER) continue
+      const t = p.life / p.maxLife
+      const r = p.size * (0.5 + t * 1.4)
+      ctx.globalAlpha = Math.min(1, t * 1.6) * 0.9
+      ctx.drawImage(glow, p.x - r, p.y - r, r * 2, r * 2)
+    }
+    ctx.globalAlpha = 1
+
+    // --- sparks: velocity-aligned streaks, one path per tone --------------
+    ctx.lineCap = 'round'
+    for (let tone = 0; tone < 3; tone++) {
+      let began = false
+      for (let i = 0; i < n; i++) {
+        const p = pool[i]
+        if (p.kind !== SPARK || p.tone !== tone) continue
+        if (!began) {
+          ctx.beginPath()
+          began = true
+        }
+        const t = p.life / p.maxLife
+        const len = Math.min(2.2, Math.hypot(p.vx, p.vy) * 0.032) * (0.4 + t)
+        const m = Math.hypot(p.vx, p.vy) || 1
+        ctx.moveTo(p.x, p.y)
+        ctx.lineTo(p.x - (p.vx / m) * len, p.y - (p.vy / m) * len)
+      }
+      if (began) {
+        ctx.strokeStyle = pal.spark[tone]
+        ctx.lineWidth = (tone === 0 ? 2.6 : 1.7) / s
+        ctx.globalAlpha = 0.95
+        ctx.stroke()
+      }
+    }
+    ctx.globalAlpha = 1
+    ctx.globalCompositeOperation = 'source-over'
+  }
+}
+
+export type Palette = {
+  dust: string
+  debris: [string, string, string]
+  spark: [string, string, string]
+}
+
+/** A soft dark puff for smoke and dust. Same trick, opposite job. */
+export function makePuffSprite(size = 96, color = '74,59,70'): HTMLCanvasElement {
+  const c = document.createElement('canvas')
+  c.width = size
+  c.height = size
+  const g = c.getContext('2d')
+  if (!g) return c
+  const grad = g.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2)
+  grad.addColorStop(0, `rgba(${color},0.85)`)
+  grad.addColorStop(0.45, `rgba(${color},0.45)`)
+  grad.addColorStop(1, `rgba(${color},0)`)
+  g.fillStyle = grad
+  g.fillRect(0, 0, size, size)
+  return c
+}
+
+/** Pre-render a soft radial glow once. drawImage of this is ~20x cheaper than a gradient fill. */
+export function makeGlowSprite(size = 96, inner = '#fff5d8', outer = '#ff6a1e'): HTMLCanvasElement {
+  const c = document.createElement('canvas')
+  c.width = size
+  c.height = size
+  const g = c.getContext('2d')
+  if (!g) return c
+  const grad = g.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2)
+  grad.addColorStop(0, inner)
+  grad.addColorStop(0.28, outer)
+  grad.addColorStop(1, 'rgba(0,0,0,0)')
+  g.fillStyle = grad
+  g.fillRect(0, 0, size, size)
+  return c
+}

--- a/dynawalla/games/trebuchet/src/fx/rings.ts
+++ b/dynawalla/games/trebuchet/src/fx/rings.ts
@@ -1,0 +1,86 @@
+/**
+ * Shockwave rings — the single most legible way to say "something just happened
+ * HERE, and it was this big". Expanding, thinning, easing out; a ground-hugging
+ * variant that flattens into a dust wave rolling along the plain.
+ */
+
+import { clamp01, easeOutCubic } from '../core/ease.ts'
+
+type Ring = {
+  x: number
+  y: number
+  t: number
+  life: number
+  r0: number
+  r1: number
+  wide: number
+  flat: number
+  color: string
+  live: boolean
+}
+
+export class Rings {
+  private pool: Ring[] = []
+
+  constructor(cap = 16) {
+    for (let i = 0; i < cap; i++) {
+      this.pool.push({ x: 0, y: 0, t: 0, life: 1, r0: 0, r1: 1, wide: 1, flat: 1, color: '#fff', live: false })
+    }
+  }
+
+  add(
+    x: number,
+    y: number,
+    r0: number,
+    r1: number,
+    life: number,
+    color: string,
+    wide = 3,
+    flat = 1,
+  ): void {
+    let r = this.pool.find((p) => !p.live)
+    if (!r) r = this.pool[0]
+    r.x = x
+    r.y = y
+    r.t = 0
+    r.life = life
+    r.r0 = r0
+    r.r1 = r1
+    r.wide = wide
+    r.flat = flat
+    r.color = color
+    r.live = true
+  }
+
+  clear(): void {
+    for (const r of this.pool) r.live = false
+  }
+
+  update(dt: number): void {
+    for (const r of this.pool) {
+      if (!r.live) continue
+      r.t += dt
+      if (r.t >= r.life) r.live = false
+    }
+  }
+
+  draw(ctx: CanvasRenderingContext2D, s: number): void {
+    ctx.save()
+    ctx.globalCompositeOperation = 'lighter'
+    for (const r of this.pool) {
+      if (!r.live) continue
+      const k = clamp01(r.t / r.life)
+      const e = easeOutCubic(k)
+      const rad = r.r0 + (r.r1 - r.r0) * e
+      const a = (1 - k) * (1 - k)
+      ctx.beginPath()
+      ctx.ellipse(r.x, r.y, rad, rad * r.flat, 0, 0, Math.PI * 2)
+      ctx.strokeStyle = r.color
+      ctx.globalAlpha = a * 0.85
+      ctx.lineWidth = (r.wide * (1 - e * 0.85)) / s
+      ctx.stroke()
+    }
+    ctx.restore()
+    ctx.globalAlpha = 1
+  }
+}

--- a/dynawalla/games/trebuchet/src/fx/trail.ts
+++ b/dynawalla/games/trebuchet/src/fx/trail.ts
@@ -1,0 +1,78 @@
+/**
+ * A tapering ribbon trail. One filled polygon, one stroked core — two draw calls
+ * for the whole tail, regardless of length.
+ */
+
+export class Trail {
+  private xs: Float32Array
+  private ys: Float32Array
+  private n = 0
+  private head = 0
+  readonly cap: number
+
+  constructor(cap = 34) {
+    this.cap = cap
+    this.xs = new Float32Array(cap)
+    this.ys = new Float32Array(cap)
+  }
+
+  clear(): void {
+    this.n = 0
+    this.head = 0
+  }
+
+  push(x: number, y: number): void {
+    this.xs[this.head] = x
+    this.ys[this.head] = y
+    this.head = (this.head + 1) % this.cap
+    if (this.n < this.cap) this.n++
+  }
+
+  /** oldest -> newest */
+  private at(i: number): [number, number] {
+    const idx = (this.head - this.n + i + this.cap * 2) % this.cap
+    return [this.xs[idx], this.ys[idx]]
+  }
+
+  draw(ctx: CanvasRenderingContext2D, s: number, widthPx: number, fill: string, core: string): void {
+    if (this.n < 3) return
+    const n = this.n
+    const w = widthPx / s
+    const left: Array<[number, number]> = []
+    const right: Array<[number, number]> = []
+    for (let i = 0; i < n; i++) {
+      const [x, y] = this.at(i)
+      const [px, py] = this.at(Math.max(0, i - 1))
+      const [nx, ny] = this.at(Math.min(n - 1, i + 1))
+      let dx = nx - px
+      let dy = ny - py
+      const m = Math.hypot(dx, dy) || 1
+      dx /= m
+      dy /= m
+      const t = i / (n - 1)
+      const hw = w * t * t * 0.5
+      left.push([x - dy * hw, y + dx * hw])
+      right.push([x + dy * hw, y - dx * hw])
+    }
+    ctx.beginPath()
+    ctx.moveTo(left[0][0], left[0][1])
+    for (let i = 1; i < n; i++) ctx.lineTo(left[i][0], left[i][1])
+    for (let i = n - 1; i >= 0; i--) ctx.lineTo(right[i][0], right[i][1])
+    ctx.closePath()
+    ctx.globalCompositeOperation = 'lighter'
+    ctx.fillStyle = fill
+    ctx.fill()
+    ctx.beginPath()
+    const [x0, y0] = this.at(Math.max(0, n - 8))
+    ctx.moveTo(x0, y0)
+    for (let i = Math.max(0, n - 8) + 1; i < n; i++) {
+      const [x, y] = this.at(i)
+      ctx.lineTo(x, y)
+    }
+    ctx.strokeStyle = core
+    ctx.lineWidth = (widthPx * 0.34) / s
+    ctx.lineCap = 'round'
+    ctx.stroke()
+    ctx.globalCompositeOperation = 'source-over'
+  }
+}

--- a/dynawalla/games/trebuchet/src/game.ts
+++ b/dynawalla/games/trebuchet/src/game.ts
@@ -1,0 +1,1361 @@
+/**
+ * TREBUCHET — the range dial is the answer.
+ *
+ * A keep stands at 56 metres. Your boulder is stamped `7 × 8`. Dial 56, let go,
+ * watch it come apart. Dial 54 and the shot lands two metres short: the crater says
+ * 54, the keep leans, and you can *see* how wrong you were. That is the whole idea —
+ * arithmetic error expressed as distance, which no answer box can do.
+ */
+
+import type { Host } from './contract.ts'
+import { Audio } from './audio/audio.ts'
+import { Camera } from './core/camera.ts'
+import { approach, clamp, clamp01, easeInQuad, easeOutBack, lerp } from './core/ease.ts'
+import { makeRng, type Rng } from './core/rng.ts'
+import { Flash } from './fx/flash.ts'
+import {
+  DEBRIS,
+  DUST,
+  EMBER,
+  makeGlowSprite,
+  makePuffSprite,
+  Particles,
+  SHARD,
+  SPARK,
+  type Palette,
+} from './fx/particles.ts'
+import { Rings } from './fx/rings.ts'
+import { Trail } from './fx/trail.ts'
+import { Backdrop } from './render/backdrop.ts'
+import { drawHud, hitBtn, hudButtons, rackLayout, type Btn, type HudState } from './render/hud.ts'
+import {
+  ARMED_DEG,
+  RELEASE_DEG,
+  armTip,
+  drawBoulder,
+  drawCraterLabels,
+  drawGhosts,
+  drawGround,
+  drawMilestones,
+  drawRam,
+  drawTower,
+  drawTrebuchet,
+  drawWall,
+} from './render/pieces.ts'
+import { C, font, worldText, type Frame } from './render/theme.ts'
+import {
+  G,
+  LAUNCH_H,
+  posAt,
+  resolve,
+  samplePath,
+  shotScore,
+  solve,
+  type Outcome,
+  type Solved,
+} from './sim/ballistics.ts'
+import {
+  buildTower,
+  FIELD_MAX,
+  LAUNCH_X,
+  layoutTowerValues,
+  pullQuestions,
+  shatter,
+  stepBlocks,
+  waveConfig,
+  worldX,
+  type Boulder,
+  type Crater,
+  type Ghost,
+  type Ram,
+  type Tower,
+  type WaveConfig,
+} from './sim/world.ts'
+
+const MIN_GAP = 8
+const DIAL_MIN = 8
+const DIAL_MAX = FIELD_MAX
+const LOFTS = [30, 38, 46, 55, 65]
+const DEFAULT_LOFT = 2
+
+type Phase = 'intro' | 'aim' | 'windup' | 'flight' | 'impact' | 'settle' | 'clear'
+
+const PAL: Palette = {
+  dust: C.dust,
+  debris: [C.stone, C.stoneLit, '#0d1222'],
+  spark: [C.fire0, C.fire1, C.fire2],
+}
+
+export type DebugStats = {
+  fps: number
+  frameMsP95: number
+  particles: number
+  phase: string
+  wave: number
+  dial: number
+  answer: number
+  score: number
+}
+
+export class TrebuchetGame {
+  private el: HTMLElement
+  private host: Host
+  private canvas: HTMLCanvasElement
+  private ctx: CanvasRenderingContext2D
+  private cam = new Camera()
+  private parts = new Particles(1500)
+  private trail = new Trail(46)
+  private rings = new Rings(18)
+  private flash = new Flash()
+  private audio = new Audio()
+  private backdrop: Backdrop
+  private glow: HTMLCanvasElement
+  private puff: HTMLCanvasElement
+  private rng: Rng
+  private cosmetic: Rng
+
+  private raf = 0
+  private last = 0
+  private time = 0
+  private wallTime = 0
+  private running = true
+  private dpr = 1
+  private w = 0
+  private h = 0
+  private unit = 60
+  private reduced = false
+
+  // frame timing
+  private frameTimes: number[] = []
+  private fps = 60
+  private fpsAccum = 0
+  private fpsFrames = 0
+
+  // wave state
+  private wave = 1
+  private cfg: WaveConfig = waveConfig(1)
+  private towers: Tower[] = []
+  private rack: Boulder[] = []
+  private activeIdx = 0
+  private wind = 0
+  private ram: Ram | null = null
+  private wall: { x: number; h: number } | null = null
+  private scrub = new Float32Array(0)
+  private craters: Crater[] = []
+  private ghosts: Ghost[] = []
+
+  // aim
+  private dial = 30
+  private loftIdx = DEFAULT_LOFT
+  private dialPop = 1
+  private aimEmphasis = 0
+
+  // shot
+  private phase: Phase = 'intro'
+  private phaseT = 0
+  private shot: Solved | null = null
+  private shotT = 0
+  /**
+   * Decided the moment the boulder leaves the sling, from integers alone. A keep
+   * standing between you and your target is scenery the shot flies over — only the
+   * metre it comes down on can be right or wrong. Anything else would punish
+   * correct arithmetic, which is the one thing this game may never do.
+   */
+  private pending: Outcome<Tower> | null = null
+  private proj = { x: 0, y: 0 }
+  private armDeg = ARMED_DEG
+  private recoil = 0
+  private freeze = 0
+  private timeScale = 1
+  private wantTimeScale = 1
+  private questionShownAt = 0
+
+  // score
+  private score = 0
+  private combo = 0
+  private scorePop = 0
+  private hitsThisWave = 0
+  private platformDamage = 0
+  private revealT = 0
+
+  // hud
+  private btns: Btn[] = []
+  private clearT = -1
+  private introT = 0
+  private muted = false
+
+  // input
+  private dragging = false
+  private dragAnchorPx = 0
+  private dragAnchorDial = 0
+  private pointerDownOnField = false
+  private tickAccum = 0
+  private held: { id: string; t: number; accum: number } | null = null
+
+  // counter-fire is scheduled on the game clock, never on a wall-clock timer:
+  // a background tab must not be able to strand an explosion in the future
+  private counterIn = -1
+  private manual = false
+  private lastFrameMs = 0
+
+  private onKeyDown: (e: KeyboardEvent) => void
+  private onKeyUp: (e: KeyboardEvent) => void
+  private onResize: () => void
+  private ro: ResizeObserver | null = null
+
+  constructor(el: HTMLElement, host: Host, seed = 0xb01de) {
+    this.el = el
+    this.host = host
+    this.rng = makeRng(seed)
+    this.cosmetic = makeRng(seed ^ 0x51e6e)
+    this.reduced = host.prefersReducedMotion()
+
+    const canvas = document.createElement('canvas')
+    canvas.style.cssText = 'display:block;width:100%;height:100%;touch-action:none;cursor:crosshair'
+    el.appendChild(canvas)
+    this.canvas = canvas
+    const ctx = canvas.getContext('2d', { alpha: false })
+    if (!ctx) throw new Error('2d context unavailable')
+    this.ctx = ctx
+    this.glow = makeGlowSprite(96, '#fff8e2', '#ff7a24')
+    this.puff = makePuffSprite(96)
+    this.backdrop = new Backdrop(seed ^ 0xbeef)
+
+    this.cam.motion = this.reduced ? 0.18 : 1
+    this.flash.motion = this.reduced ? 0.25 : 1
+
+    canvas.addEventListener('pointerdown', this.onPointerDown)
+    canvas.addEventListener('pointermove', this.onPointerMove)
+    window.addEventListener('pointerup', this.onPointerUp)
+    canvas.addEventListener('wheel', this.onWheel, { passive: false })
+    this.onKeyDown = (e) => this.key(e, true)
+    this.onKeyUp = (e) => this.key(e, false)
+    window.addEventListener('keydown', this.onKeyDown)
+    window.addEventListener('keyup', this.onKeyUp)
+    this.onResize = () => this.resize()
+    window.addEventListener('resize', this.onResize)
+    if (typeof ResizeObserver !== 'undefined') {
+      this.ro = new ResizeObserver(() => this.resize())
+      this.ro.observe(el)
+    }
+
+    this.resize()
+    this.startWave(1)
+    this.cam.snap()
+    this.last = performance.now()
+    this.raf = requestAnimationFrame(this.frame)
+  }
+
+  /* ------------------------------------------------------------ lifecycle */
+
+  unmount(): void {
+    this.running = false
+    cancelAnimationFrame(this.raf)
+    this.canvas.removeEventListener('pointerdown', this.onPointerDown)
+    this.canvas.removeEventListener('pointermove', this.onPointerMove)
+    window.removeEventListener('pointerup', this.onPointerUp)
+    this.canvas.removeEventListener('wheel', this.onWheel)
+    window.removeEventListener('keydown', this.onKeyDown)
+    window.removeEventListener('keyup', this.onKeyUp)
+    window.removeEventListener('resize', this.onResize)
+    this.ro?.disconnect()
+    this.audio.dispose()
+    this.canvas.remove()
+  }
+
+  private resize(): void {
+    const r = this.el.getBoundingClientRect()
+    const w = Math.max(320, Math.round(r.width))
+    const h = Math.max(240, Math.round(r.height))
+    this.dpr = Math.min(2, window.devicePixelRatio || 1)
+    this.w = w
+    this.h = h
+    this.canvas.width = Math.round(w * this.dpr)
+    this.canvas.height = Math.round(h * this.dpr)
+    this.unit = clamp(Math.min(w, h) * 0.115, 42, 82)
+    this.backdrop.resize(w, h, this.dpr)
+    this.btns = hudButtons(w, h, this.unit, this.cfg.loft)
+  }
+
+  /* ---------------------------------------------------------------- waves */
+
+  private startWave(n: number): void {
+    this.wave = n
+    const cfg = waveConfig(n)
+    this.cfg = cfg
+    const anyHost = this.host as Host & {
+      setDifficulty?: (d: number) => void
+      setDistractorCount?: (k: number) => void
+    }
+    anyHost.setDifficulty?.(cfg.difficulty)
+    anyHost.setDistractorCount?.(Math.max(2, cfg.extraTowers + 1))
+
+    const { boulders, pools } = pullQuestions(
+      () => this.host.next(),
+      cfg.ammo,
+      MIN_GAP,
+      DIAL_MIN + 6,
+      DIAL_MAX - 4,
+    )
+    this.rack = boulders
+    this.activeIdx = 0
+
+    const values = layoutTowerValues(
+      boulders.map((b) => b.answer),
+      pools,
+      cfg.extraTowers,
+      MIN_GAP,
+      DIAL_MIN + 6,
+      DIAL_MAX - 4,
+      this.rng,
+    )
+    this.towers = values.map((v, i) => buildTower(i, v, this.rng, cfg.volley && i % 2 === 0))
+    this.markWanted()
+
+    this.wind = cfg.wind ? this.rollWind() : 0
+    this.wall = null
+    if (cfg.wall) {
+      const nearest = Math.min(...values)
+      const wx = Math.max(14, Math.round(nearest * 0.46))
+      // Size it so a mid loft clears and the flattest does not: always solvable.
+      const probe = solve(nearest, LOFTS[1], 0)
+      const clearH = posAt(probe, timeAtXApprox(probe, wx)).y
+      this.wall = { x: worldX(wx), h: Math.max(6, clearH * 0.78) }
+    }
+    this.ram = cfg.ram
+      ? { range: FIELD_MAX - 4, speed: 1.5 + cfg.difficulty * 1.6, alive: true, wheel: 0, hp: 1, bob: 0 }
+      : null
+
+    this.craters = []
+    this.ghosts = []
+    this.parts.clear()
+    this.rings.clear()
+    this.hitsThisWave = 0
+    this.dial = clamp(Math.round(values[0] * 0.8), DIAL_MIN, DIAL_MAX)
+    this.loftIdx = DEFAULT_LOFT
+    this.phase = 'intro'
+    this.phaseT = 0
+    this.introT = 0
+    this.clearT = -1
+    this.armDeg = ARMED_DEG
+    this.questionShownAt = performance.now()
+
+    const sc: number[] = []
+    for (let i = 0; i < 170; i++) {
+      sc.push(this.cosmetic.range(-20, worldX(FIELD_MAX) + 20), this.cosmetic.range(0.3, 1.1))
+    }
+    this.scrub = new Float32Array(sc)
+    this.btns = hudButtons(this.w, this.h, this.unit, cfg.loft)
+    this.audio.horn(true)
+    if (!this.reduced && n % 3 === 0 && this.flash.add(0.16, 0.22, 0.5, 0.2, 1.2)) {
+      this.backdrop.strike(this.cosmetic)
+    }
+  }
+
+  private rollWind(): number {
+    const cap = this.cfg.wind
+    if (!cap) return 0
+    let v = 0
+    // never 0 — a wind chip showing 0 is a lie about the mechanic being on
+    while (v === 0) v = this.rng.int(-cap, cap)
+    return v
+  }
+
+  private markWanted(): void {
+    const wanted = new Set(this.rack.filter((b) => !b.spent).map((b) => b.answer))
+    for (const t of this.towers) t.wanted = wanted.has(t.value)
+  }
+
+  private get activeBoulder(): Boulder | null {
+    return this.rack[this.activeIdx] ?? null
+  }
+
+  /* ---------------------------------------------------------------- input */
+
+  private pointerPos(e: PointerEvent): { x: number; y: number } {
+    const r = this.canvas.getBoundingClientRect()
+    return { x: e.clientX - r.left, y: e.clientY - r.top }
+  }
+
+  private onPointerDown = (e: PointerEvent): void => {
+    this.audio.resume()
+    const p = this.pointerPos(e)
+    const b = hitBtn(this.btns, p.x, p.y)
+    if (b) {
+      this.canvas.setPointerCapture?.(e.pointerId)
+      this.held = { id: b.id, t: 0, accum: 0 }
+      this.pressBtn(b, p)
+      return
+    }
+    // tapping a rack stone loads that boulder
+    const ri = this.rackHit(p.x, p.y)
+    if (ri >= 0 && !this.rack[ri].spent) {
+      this.activeIdx = ri
+      this.audio.detent()
+      this.host.haptic('light')
+      this.questionShownAt = performance.now()
+      return
+    }
+    if (this.phase !== 'aim' && this.phase !== 'intro') return
+    this.canvas.setPointerCapture?.(e.pointerId)
+    this.dragging = true
+    this.pointerDownOnField = true
+    // coarse: the dial jumps to the metre under the finger
+    const wx = this.screenToWorldX(p.x, p.y)
+    this.setDial(Math.round(wx - LAUNCH_X))
+    this.dragAnchorPx = p.x
+    this.dragAnchorDial = this.dial
+  }
+
+  private onPointerMove = (e: PointerEvent): void => {
+    if (!this.dragging || !this.pointerDownOnField) return
+    const p = this.pointerPos(e)
+    // fine: 0.42 gain, so a fingertip sweep is worth a couple of dozen metres
+    const dm = ((p.x - this.dragAnchorPx) / (this.cam.ppm * this.cam.zoom)) * 0.42
+    this.setDial(Math.round(this.dragAnchorDial + dm))
+  }
+
+  private onPointerUp = (): void => {
+    this.dragging = false
+    this.pointerDownOnField = false
+    this.held = null
+  }
+
+  private onWheel = (e: WheelEvent): void => {
+    e.preventDefault()
+    this.setDial(this.dial + (e.deltaY > 0 ? -1 : 1))
+  }
+
+  private key(e: KeyboardEvent, down: boolean): void {
+    if (!down) return
+    const big = e.shiftKey ? 10 : 1
+    switch (e.key) {
+      case 'ArrowLeft':
+        this.setDial(this.dial - big)
+        e.preventDefault()
+        break
+      case 'ArrowRight':
+        this.setDial(this.dial + big)
+        e.preventDefault()
+        break
+      case 'ArrowUp':
+        this.setLoft(this.loftIdx + 1)
+        e.preventDefault()
+        break
+      case 'ArrowDown':
+        this.setLoft(this.loftIdx - 1)
+        e.preventDefault()
+        break
+      case ' ':
+      case 'Enter':
+        this.audio.resume()
+        this.fire()
+        e.preventDefault()
+        break
+      case 'm':
+      case 'M':
+        this.toggleMute()
+        break
+      default:
+        if (/^[1-5]$/.test(e.key)) {
+          const i = Number(e.key) - 1
+          if (this.rack[i] && !this.rack[i].spent) {
+            this.activeIdx = i
+            this.audio.detent()
+          }
+        }
+    }
+  }
+
+  private pressBtn(b: Btn, p: { x: number; y: number }): void {
+    switch (b.id) {
+      case 'fire':
+        this.fire()
+        break
+      case 'plus':
+        this.setDial(this.dial + 1)
+        break
+      case 'minus':
+        this.setDial(this.dial - 1)
+        break
+      case 'mute':
+        this.toggleMute()
+        break
+      case 'loft': {
+        const rel = 1 - clamp01((p.y - b.y) / b.h)
+        this.setLoft(Math.round(rel * (LOFTS.length - 1)))
+        break
+      }
+    }
+  }
+
+  private toggleMute(): void {
+    this.muted = !this.muted
+    this.audio.enabled = !this.muted
+  }
+
+  /** @returns the index into `this.rack`, or -1 */
+  private rackHit(x: number, y: number): number {
+    const st = this.hudState()
+    const slots = rackLayout(st)
+    for (let i = 0; i < slots.length; i++) {
+      const s = slots[i]
+      if (x >= s.x - 6 && x <= s.x + s.w + 6 && y >= s.y - 8 && y <= s.y + s.h + 8) {
+        return this.liveIdx[i] ?? -1
+      }
+    }
+    return -1
+  }
+
+  private liveIdx: number[] = []
+
+  private hudState(): HudState {
+    const live = this.rack.map((r, i) => ({ r, i })).filter((x) => !x.r.spent)
+    this.liveIdx = live.map((x) => x.i)
+    const b = this.activeBoulder
+    return {
+      w: this.w,
+      h: this.h,
+      unit: this.unit,
+      equation: b ? b.q.prompt : '',
+      rack: live.map((x) => x.r.q.prompt),
+      rackActive: live.findIndex((x) => x.i === this.activeIdx),
+      wave: this.wave,
+      score: this.score,
+      scorePop: this.scorePop,
+      combo: this.combo,
+      wind: this.wind,
+      showWind: this.wind !== 0,
+      loftUnlocked: this.cfg.loft,
+      loftIndex: this.loftIdx,
+      loftCount: LOFTS.length,
+      muted: this.muted,
+      introT: this.introT,
+      clearT: this.clearT,
+      clearHits: this.hitsThisWave,
+      clearOf: this.rack.length,
+      dialPop: this.dialPop,
+      canFire: this.phase === 'aim' || this.phase === 'intro',
+    }
+  }
+
+  private screenToWorldX(px: number, py: number): number {
+    const s = this.cam.ppm * this.cam.zoom
+    void py
+    return this.cam.x + (px - this.w / 2 - this.cam.shakeX) / s
+  }
+
+  private setDial(v: number): void {
+    const nv = clamp(Math.round(v), DIAL_MIN, DIAL_MAX)
+    if (nv === this.dial) return
+    const delta = Math.abs(nv - this.dial)
+    this.dial = nv
+    this.dialPop = 0
+    this.aimEmphasis = 1
+    this.tickAccum += delta
+    if (this.tickAccum >= 1) {
+      this.tickAccum = 0
+      this.audio.tick(clamp01((this.dial - DIAL_MIN) / (DIAL_MAX - DIAL_MIN)))
+      if (delta >= 1) this.host.haptic('light')
+    }
+  }
+
+  private setLoft(i: number): void {
+    const ni = clamp(Math.round(i), 0, LOFTS.length - 1)
+    if (ni === this.loftIdx || !this.cfg.loft) return
+    this.loftIdx = ni
+    this.audio.detent()
+    this.host.haptic('light')
+  }
+
+  /* ----------------------------------------------------------------- fire */
+
+  private fire(): void {
+    if (this.phase !== 'aim' && this.phase !== 'intro') return
+    const b = this.activeBoulder
+    if (!b || b.spent) return
+    this.phase = 'windup'
+    this.phaseT = 0
+    this.audio.resume()
+    this.host.haptic('medium')
+  }
+
+  private release(): void {
+    const b = this.activeBoulder
+    if (!b) return
+    const shot = solve(this.dial, LOFTS[this.loftIdx], this.wind, LAUNCH_H)
+    this.shot = shot
+    this.pending = resolve(shot.landing, this.towers)
+    this.shotT = 0
+    this.proj = posAt(shot, 0)
+    this.proj.x += LAUNCH_X
+    this.trail.clear()
+    this.phase = 'flight'
+    this.phaseT = 0
+    this.recoil = 1
+    this.cam.addTrauma(0.22)
+    this.cam.punch(0.05)
+    this.audio.launch(clamp01(this.dial / DIAL_MAX))
+    this.audio.flightStart()
+    this.host.haptic('heavy')
+    // launch smoke + sparks at the sling
+    const tip = armTip(RELEASE_DEG)
+    for (let i = 0; i < (this.reduced ? 8 : 26); i++) {
+      const a = this.cosmetic.range(-0.6, 1.4)
+      const sp = this.cosmetic.range(4, 16)
+      this.parts.emit(SPARK, tip.x, tip.y, Math.cos(a) * sp, Math.sin(a) * sp, {
+        maxLife: this.cosmetic.range(0.2, 0.5),
+        tone: this.cosmetic.int(0, 2),
+        drag: 2.2,
+        grav: 8,
+      })
+    }
+    for (let i = 0; i < (this.reduced ? 4 : 12); i++) {
+      this.parts.emit(
+        DUST,
+        tip.x + this.cosmetic.range(-1, 1),
+        tip.y + this.cosmetic.range(-1, 1),
+        this.cosmetic.range(-3, 3),
+        this.cosmetic.range(0, 4),
+        { maxLife: this.cosmetic.range(0.5, 1.1), size: this.cosmetic.range(0.6, 1.4), drag: 1.4 },
+      )
+    }
+  }
+
+  /* -------------------------------------------------------------- impact */
+
+  private impact(x: number, y: number, hit: Tower | null, kind: 'ground' | 'tower' | 'wall' | 'ram'): void {
+    const b = this.activeBoulder
+    if (!b || !this.shot) return
+    const landing = this.shot.landing
+    const out = this.pending ?? resolve(landing, this.towers)
+    const struck = kind === 'tower' ? hit : out.target
+    const correct = !!struck && struck.value === b.answer && (out.quality === 'direct' || out.quality === 'solid')
+    const graze = !!struck && out.quality === 'graze' && struck.value === b.answer
+
+    this.audio.flightStop()
+    this.phase = 'impact'
+    this.phaseT = 0
+
+    const big = correct || kind === 'ram'
+    // hitstop: the single cheapest way to make a hit feel like it weighs something
+    this.freeze = this.reduced ? 0 : correct ? 0.1 : kind === 'ground' ? 0.035 : 0.06
+    this.wantTimeScale = this.reduced ? 1 : correct ? 0.26 : 1
+    this.cam.addTrauma(correct ? 0.86 : kind === 'ground' ? 0.34 : 0.55)
+    this.cam.punch(correct ? 0.1 : 0.04)
+    this.flash.add(correct ? 0.3 : 0.12, correct ? 0.34 : 0.18, x / Math.max(1, worldX(FIELD_MAX)), 0.62, 0.55)
+
+    // shockwave: one fast bright ring, one slow ground-hugging dust wave
+    const ry = Math.max(0.6, y)
+    this.rings.add(x, ry, 0.5, correct ? 11 : 7, correct ? 0.4 : 0.3, C.fire0, correct ? 5 : 3.2, 1)
+    this.rings.add(x, 0.5, 1.2, correct ? 19 : 12, correct ? 0.6 : 0.45, C.fire2, 3, 0.16)
+    if (correct) this.rings.add(x, ry, 0.4, 17, 0.62, C.stoneRim, 2, 0.7)
+
+    // --- particles ----------------------------------------------------
+    const n = this.reduced ? 0.28 : 1
+    const heavy = big ? 1.7 : 1
+    for (let i = 0; i < Math.round(58 * n * heavy); i++) {
+      const a = this.cosmetic.range(-0.2, Math.PI + 0.2)
+      const sp = this.cosmetic.range(6, 40) * heavy
+      this.parts.emit(SPARK, x, Math.max(0.3, y), Math.cos(a) * sp, Math.sin(a) * sp, {
+        maxLife: this.cosmetic.range(0.18, 0.6),
+        tone: this.cosmetic.int(0, 2),
+        drag: 1.6,
+        grav: 14,
+      })
+    }
+    for (let i = 0; i < Math.round(16 * n * heavy); i++) {
+      const a = this.cosmetic.range(-0.35, Math.PI + 0.35)
+      const sp = this.cosmetic.range(9, 34) * heavy
+      this.parts.emit(EMBER, x, Math.max(0.3, y), Math.cos(a) * sp, Math.sin(a) * sp, {
+        maxLife: this.cosmetic.range(0.35, 1.1),
+        size: this.cosmetic.range(0.3, 1.1),
+        drag: 2.1,
+        grav: 7,
+      })
+    }
+    for (let i = 0; i < Math.round(30 * n * heavy); i++) {
+      const a = this.cosmetic.range(-0.1, Math.PI + 0.1)
+      const sp = this.cosmetic.range(1, 11)
+      this.parts.emit(DUST, x, Math.max(0.4, y), Math.cos(a) * sp, Math.sin(a) * sp * 0.7, {
+        maxLife: this.cosmetic.range(0.8, 2.2),
+        size: this.cosmetic.range(0.7, 2.3),
+        drag: 1.1,
+      })
+    }
+    for (let i = 0; i < Math.round(14 * n * heavy); i++) {
+      const a = this.cosmetic.range(-0.3, Math.PI + 0.3)
+      const sp = this.cosmetic.range(5, 22)
+      this.parts.emit(DEBRIS, x, Math.max(0.4, y), Math.cos(a) * sp, Math.sin(a) * sp, {
+        maxLife: this.cosmetic.range(1.2, 2.6),
+        w: this.cosmetic.range(0.3, 0.9),
+        h: this.cosmetic.range(0.25, 0.7),
+        tone: this.cosmetic.int(0, 2),
+        spin: this.cosmetic.range(-9, 9),
+        grav: 24,
+        drag: 0.1,
+        bounce: 0.32,
+      })
+    }
+
+    // --- sound --------------------------------------------------------
+    if (kind === 'ground') this.audio.impactDirt(clamp01(this.dial / 120))
+    else this.audio.impactStone(0.8)
+
+    // --- structural ---------------------------------------------------
+    let destroyed = false
+    if (struck) {
+      struck.flash = 1
+      if (correct || kind === 'ram') {
+        const freed = shatter(struck, x, y, 2.6, this.cosmetic, true)
+        void freed
+        struck.alive = false
+        destroyed = true
+        this.audio.collapse()
+        this.audio.fanfare(this.combo)
+        this.host.haptic('success')
+        this.cam.addTrauma(0.4)
+        this.flash.add(0.24, 0.4, x / Math.max(1, worldX(FIELD_MAX)), 0.55, 0.8)
+        // the number itself comes apart
+        this.burstNumber(struck)
+      } else if (out.quality === 'graze' || !correct) {
+        struck.damage = clamp01(struck.damage + (out.quality === 'graze' ? 0.34 : 0.6))
+        struck.lean = (x < worldX(struck.range) ? 1 : -1) * 0.07
+        struck.leanV = 0
+        // a rival keep is cracked, never levelled: being wrong must stay quieter
+        // than being right, and a keep with no masonry left reads as destroyed
+        shatter(struck, x, y, out.quality === 'graze' ? 0.2 : 0.34, this.cosmetic, false, out.quality === 'graze' ? 2 : 5)
+        if (!correct && out.quality !== 'graze') {
+          this.audio.wrongHorn()
+          this.host.haptic('failure')
+          this.counterFire(struck)
+        }
+      }
+    } else if (kind === 'ground' || kind === 'wall') {
+      this.host.haptic('light')
+    }
+
+    // --- record -------------------------------------------------------
+    this.craters.push({
+      x,
+      r: correct ? 3.4 : 2.4,
+      depth: 1,
+      age: 0,
+      label: landing,
+      correct,
+    })
+    if (this.craters.length > 14) this.craters.shift()
+    if (this.shot) {
+      this.ghosts.push({
+        pts: samplePath(this.shot, 30).map((p) => ({ x: p.x + LAUNCH_X, y: p.y })),
+        landing,
+        age: 0,
+        hit: correct,
+      })
+      if (this.ghosts.length > 4) this.ghosts.shift()
+    }
+
+    // --- score & host report -------------------------------------------
+    const ms = Math.max(1, Math.round(performance.now() - this.questionShownAt))
+    this.host.report({
+      questionId: b.q.id,
+      correct,
+      ms,
+      answered: struck ? String(struck.value) : String(landing),
+    })
+    if (correct) {
+      this.combo += 1
+      const gained = shotScore(out.quality, this.combo, this.cfg.difficulty)
+      this.score += gained
+      this.scorePop = 0
+      this.hitsThisWave += 1
+      b.hit = true
+    } else {
+      this.combo = 0
+      this.revealT = 1.6
+    }
+    if (!graze) {
+      b.spent = true
+    } else {
+      // a graze on the right keep still costs the boulder — but it says so with a lean
+      b.spent = true
+    }
+    void destroyed
+    this.markWanted()
+  }
+
+  /** The struck keep's number blows apart into shards. */
+  private burstNumber(t: Tower): void {
+    const bx = worldX(t.range)
+    const top = t.heightM + 2.6
+    const digits = String(t.value).length
+    for (let i = 0; i < (this.reduced ? 6 : 22); i++) {
+      const a = this.cosmetic.range(0, Math.PI * 2)
+      const sp = this.cosmetic.range(3, 18)
+      this.parts.emit(
+        SHARD,
+        bx + this.cosmetic.range(-1, 1) * digits,
+        top + this.cosmetic.range(-1, 1),
+        Math.cos(a) * sp,
+        Math.abs(Math.sin(a)) * sp + 4,
+        {
+          maxLife: this.cosmetic.range(0.9, 2),
+          w: this.cosmetic.range(0.4, 1.3),
+          h: this.cosmetic.range(0.3, 0.8),
+          tone: 1,
+          spin: this.cosmetic.range(-12, 12),
+          grav: 22,
+          drag: 0.2,
+          bounce: 0.3,
+        },
+      )
+    }
+  }
+
+  /** Struck the wrong keep: its garrison answers. Costly, never fatal. */
+  private counterFire(from: Tower): void {
+    this.audio.incoming(1.1)
+    this.counterIn = 1.05
+    void from
+  }
+
+  private counterLand(): void {
+    {
+      this.cam.addTrauma(0.62)
+      this.cam.punch(0.05)
+      this.platformDamage = clamp01(this.platformDamage + 0.16)
+      this.audio.impactStone(0.6)
+      this.host.haptic('heavy')
+      this.flash.add(0.14, 0.2, 0.08, 0.6, 0.4)
+      for (let i = 0; i < (this.reduced ? 8 : 34); i++) {
+        const a = this.cosmetic.range(-0.4, Math.PI + 0.4)
+        const sp = this.cosmetic.range(4, 26)
+        this.parts.emit(SPARK, LAUNCH_X - 2, 6, Math.cos(a) * sp, Math.sin(a) * sp, {
+          maxLife: this.cosmetic.range(0.2, 0.6),
+          tone: this.cosmetic.int(0, 2),
+          drag: 1.7,
+          grav: 16,
+        })
+      }
+      for (let i = 0; i < (this.reduced ? 4 : 16); i++) {
+        this.parts.emit(DUST, LAUNCH_X - 2, 6, this.cosmetic.range(-6, 6), this.cosmetic.range(0, 7), {
+          maxLife: this.cosmetic.range(0.6, 1.6),
+          size: this.cosmetic.range(0.6, 1.8),
+          drag: 1.2,
+        })
+      }
+    }
+  }
+
+  /* ------------------------------------------------------------ the loop */
+
+  private frame = (now: number): void => {
+    if (!this.running) return
+    this.raf = requestAnimationFrame(this.frame)
+    if (this.manual) return
+    this.tick(now)
+  }
+
+  private tick(now: number): void {
+    const t0 = performance.now()
+    let dt = (now - this.last) / 1000
+    this.last = now
+    if (!Number.isFinite(dt)) dt = 1 / 60
+    dt = Math.min(dt, 1 / 20)
+    this.wallTime += dt
+
+    // fps window
+    this.fpsAccum += dt
+    this.fpsFrames++
+    if (this.fpsAccum >= 0.5) {
+      this.fps = this.fpsFrames / this.fpsAccum
+      this.fpsAccum = 0
+      this.fpsFrames = 0
+    }
+
+    // hitstop then slow-mo, easing back with cubic
+    let simDt = dt
+    if (this.freeze > 0) {
+      this.freeze -= dt
+      simDt = 0
+    }
+    this.timeScale = approach(this.timeScale, this.wantTimeScale, 6, dt)
+    simDt *= this.timeScale
+    this.time += simDt
+
+    this.update(simDt, dt)
+    this.render()
+
+    const ms = performance.now() - t0
+    this.frameTimes.push(ms)
+    this.lastFrameMs = ms
+    if (this.frameTimes.length > 240) this.frameTimes.shift()
+  }
+
+  private update(dt: number, rawDt: number): void {
+    this.phaseT += rawDt
+    this.dialPop = Math.min(1, this.dialPop + rawDt / 0.16)
+    this.scorePop = Math.min(1, this.scorePop + rawDt / 0.5)
+    this.aimEmphasis = approach(this.aimEmphasis, this.phase === 'aim' || this.phase === 'intro' ? 1 : 0, 4, rawDt)
+    this.introT = Math.min(1, this.introT + rawDt / 0.5)
+    this.recoil = approach(this.recoil, 0, 6, rawDt)
+    this.revealT = Math.max(0, this.revealT - rawDt)
+    this.flash.update(rawDt)
+    this.backdrop.update(rawDt)
+    this.parts.update(dt, 0)
+    this.rings.update(dt)
+    this.cam.update(rawDt)
+
+    for (const cr of this.craters) cr.age += rawDt
+    for (const g of this.ghosts) g.age += rawDt
+    for (const t of this.towers) {
+      t.flash = Math.max(0, t.flash - rawDt * 3)
+      if (t.wanted && this.revealT > 0) t.reveal = Math.min(1, t.reveal + rawDt * 4)
+      else t.reveal = Math.max(0, t.reveal - rawDt * 3)
+      stepBlocks(t, dt)
+    }
+
+    // Held +/- repeat. The accumulator matters: the dial is an integer, so adding
+    // a fraction of a metre per frame and rounding would move nothing at all.
+    if (this.held && (this.held.id === 'plus' || this.held.id === 'minus')) {
+      this.held.t += rawDt
+      if (this.held.t > 0.32) {
+        this.held.accum += rawDt * (this.held.t > 1.3 ? 26 : 9)
+        const whole = Math.floor(this.held.accum)
+        if (whole >= 1) {
+          this.held.accum -= whole
+          this.setDial(this.dial + (this.held.id === 'plus' ? whole : -whole))
+        }
+      }
+    }
+
+    switch (this.phase) {
+      case 'intro':
+        if (this.phaseT > 0.9) {
+          this.phase = 'aim'
+          this.phaseT = 0
+          this.questionShownAt = performance.now()
+        }
+        break
+      case 'aim':
+        this.armDeg = approach(this.armDeg, ARMED_DEG, 6, rawDt)
+        break
+      case 'windup': {
+        const k = clamp01(this.phaseT / 0.42)
+        // draw back a touch further, then whip through — anticipation, then release
+        const back = ARMED_DEG + 14 * Math.sin(k * Math.PI)
+        this.armDeg = lerp(back, RELEASE_DEG, easeInQuad(clamp01((k - 0.55) / 0.45)))
+        if (k >= 1) this.release()
+        break
+      }
+      case 'flight': {
+        if (!this.shot) break
+        const sub = 1 / 240
+        let acc = dt
+        while (acc > 0 && this.phase === 'flight') {
+          const step = Math.min(sub, acc)
+          acc -= step
+          this.shotT += step
+          const p = posAt(this.shot, this.shotT)
+          this.proj.x = p.x + LAUNCH_X
+          this.proj.y = p.y
+          if (!this.reduced && this.cosmetic.chance(0.22)) {
+            this.parts.emit(
+              EMBER,
+              this.proj.x,
+              this.proj.y,
+              this.cosmetic.range(-3, 3),
+              this.cosmetic.range(-2, 2),
+              { maxLife: this.cosmetic.range(0.25, 0.7), size: this.cosmetic.range(0.3, 0.9), drag: 1.6 },
+            )
+          }
+          // wall
+          if (this.wall && Math.abs(this.proj.x - this.wall.x) < 1.3 && this.proj.y < this.wall.h) {
+            this.impact(this.proj.x, this.proj.y, null, 'wall')
+            break
+          }
+          // ram
+          if (this.ram?.alive && Math.abs(this.proj.x - worldX(this.ram.range)) < 3.4 && this.proj.y < 3.6) {
+            this.ram.alive = false
+            this.score += 90
+            this.scorePop = 0
+            this.impact(this.proj.x, Math.max(1, this.proj.y), null, 'ram')
+            break
+          }
+          // Only the keep the shot is actually coming down on can catch it.
+          const tgt = this.pending && this.pending.errorM <= 2 ? this.pending.target : null
+          if (tgt && tgt.alive) {
+            const bx = worldX(tgt.range)
+            if (Math.abs(this.proj.x - bx) < tgt.widthM / 2 + 0.55 && this.proj.y < tgt.heightM) {
+              this.impact(this.proj.x, this.proj.y, tgt, 'tower')
+              break
+            }
+          }
+          if (this.proj.y <= 0.2 || this.shotT >= this.shot.T) {
+            this.impact(worldX(this.shot.landing), 0.2, null, 'ground')
+            break
+          }
+        }
+        if (this.phase === 'flight' && this.shot) {
+          this.trail.push(this.proj.x, this.proj.y)
+          const v = Math.hypot(this.shot.vx, this.shot.vy - G * this.shotT)
+          this.audio.flightUpdate(clamp01(v / 70), clamp01(this.proj.y / 45))
+        }
+        break
+      }
+      case 'impact':
+        if (this.phaseT > 0.42) {
+          this.wantTimeScale = 1
+          this.phase = 'settle'
+          this.phaseT = 0
+        }
+        break
+      case 'settle': {
+        this.armDeg = approach(this.armDeg, ARMED_DEG, 4.2, rawDt)
+        const stillMoving = this.towers.some((t) => t.blocks.some((b) => b.loose && !b.settled))
+        if (this.phaseT > (stillMoving ? 1.3 : 0.72)) {
+          const nextIdx = this.rack.findIndex((b) => !b.spent)
+          if (nextIdx < 0) {
+            this.phase = 'clear'
+            this.phaseT = 0
+            this.clearT = 0
+            this.audio.horn(this.hitsThisWave === this.rack.length)
+          } else {
+            this.activeIdx = nextIdx
+            this.phase = 'aim'
+            this.phaseT = 0
+            this.questionShownAt = performance.now()
+            if (this.cfg.gusty) this.wind = this.rollWind()
+          }
+        }
+        break
+      }
+      case 'clear':
+        this.clearT = clamp01(this.phaseT / 2.1)
+        if (this.phaseT > 2.1) {
+          this.startWave(this.wave + 1)
+        }
+        break
+    }
+
+    if (this.counterIn > 0) {
+      this.counterIn -= rawDt
+      if (this.counterIn <= 0) this.counterLand()
+    }
+
+    // the ram never stops
+    if (this.ram?.alive && this.phase !== 'impact') {
+      this.ram.range -= this.ram.speed * dt
+      this.ram.wheel += dt * 4
+      if (this.ram.range <= 6) {
+        this.ram.alive = false
+        this.cam.addTrauma(0.7)
+        this.cam.punch(0.06)
+        this.platformDamage = clamp01(this.platformDamage + 0.2)
+        this.combo = 0
+        this.audio.impactStone(1)
+        this.host.haptic('heavy')
+        for (let i = 0; i < (this.reduced ? 8 : 36); i++) {
+          const a = this.cosmetic.range(-0.4, Math.PI + 0.4)
+          const sp = this.cosmetic.range(4, 24)
+          this.parts.emit(SPARK, LAUNCH_X + 2, 5, Math.cos(a) * sp, Math.sin(a) * sp, {
+            maxLife: this.cosmetic.range(0.2, 0.6),
+            tone: this.cosmetic.int(0, 2),
+            drag: 1.8,
+            grav: 16,
+          })
+        }
+      }
+    }
+
+    this.updateCamera(rawDt)
+  }
+
+  private updateCamera(dt: number): void {
+    void dt
+    const vp = { w: this.w, h: this.h }
+    const wide = this.w / this.h >= 1.25
+    const pts: Array<{ x: number; y: number }> = []
+    // Keep the field clear of the two things pinned to the glass: the equation
+    // at the top and the firing controls at the bottom right.
+    const padTop = this.unit * 2.5
+    const strip = this.unit * 2.5
+    const gf = clamp(1 - strip / this.h - 0.02, 0.58, 0.84)
+    if (this.phase === 'flight' && this.shot) {
+      // follow with lead: look where the shot is going, not where it is
+      const lead = 0.18
+      const p = posAt(this.shot, Math.min(this.shot.T, this.shotT + lead))
+      pts.push({ x: p.x + LAUNCH_X, y: Math.max(14, p.y + 6) })
+      pts.push({ x: this.proj.x, y: this.proj.y })
+      pts.push({ x: worldX(this.shot.landing), y: 0 })
+      this.cam.frame(pts, vp, {
+        minSpanX: wide ? 52 : 38,
+        padPx: this.unit * 1.0,
+        padTopPx: padTop,
+        groundFrac: gf,
+      })
+    } else if (this.phase === 'impact') {
+      pts.push({ x: this.proj.x - 15, y: 0 })
+      pts.push({ x: this.proj.x + 15, y: 22 })
+      this.cam.frame(pts, vp, {
+        minSpanX: wide ? 44 : 32,
+        padPx: this.unit * 0.7,
+        padTopPx: padTop,
+        groundFrac: gf,
+      })
+    } else {
+      pts.push({ x: -9, y: 20 })
+      pts.push({ x: worldX(this.dial) + 5, y: 0 })
+      for (const t of this.towers) {
+        if (!wide && Math.abs(t.range - this.dial) > 40) continue
+        pts.push({ x: worldX(t.range), y: t.heightM + 7 })
+      }
+      if (this.ram?.alive) pts.push({ x: worldX(this.ram.range), y: 6 })
+      this.cam.frame(pts, vp, {
+        minSpanX: wide ? 46 : 40,
+        padPx: this.unit * 0.9,
+        padTopPx: padTop,
+        groundFrac: gf,
+      })
+    }
+  }
+
+  /* --------------------------------------------------------------- render */
+
+  private render(): void {
+    const ctx = this.ctx
+    const { w, h } = this
+    ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0)
+    ctx.clearRect(0, 0, w, h)
+
+    const horizon = this.cam.toScreen(0, 0, { w, h }).y
+    this.backdrop.draw(
+      ctx,
+      this.wallTime,
+      this.cam.x,
+      horizon,
+      Math.sign(this.wind) || 1,
+      this.reduced ? 0.25 : clamp01(0.25 + this.cfg.difficulty * 0.75),
+    )
+
+    ctx.save()
+    this.cam.applyTransform(ctx, { w, h })
+    const s = this.cam.ppm * this.cam.zoom
+    const f: Frame = { ctx, w, h, s, t: this.time, dt: 0, reduced: this.reduced }
+
+    drawGround(ctx, s, FIELD_MAX, this.craters, this.scrub)
+    drawMilestones(ctx, s, FIELD_MAX, this.aimEmphasis * 0.6 + 0.4)
+    drawGhosts(ctx, s, this.ghosts)
+    // The boulder is drawn BEFORE the keeps: at eight metres apart no arc can
+    // clear the far shoulder of the keep in front of its target, so instead of
+    // fighting the geometry the shot passes *behind* it — which reads as depth,
+    // and the blast still blooms in front because particles are drawn last.
+    if (this.phase === 'flight' && this.shot) {
+      this.trail.draw(ctx, s, 18, 'rgba(255,116,26,0.26)', C.fire1)
+      const spd = Math.hypot(this.shot.vx, this.shot.vy - G * this.shotT)
+      const stretch = 1 + clamp01(spd / 90) * 0.55
+      ctx.save()
+      ctx.translate(this.proj.x, this.proj.y)
+      const ang = Math.atan2(this.shot.vy - G * this.shotT, this.shot.vx + this.shot.ax * this.shotT)
+      ctx.rotate(ang)
+      ctx.scale(stretch, 1 / Math.sqrt(stretch))
+      ctx.globalCompositeOperation = 'lighter'
+      ctx.drawImage(this.glow, -3.2, -3.2, 6.4, 6.4)
+      ctx.globalCompositeOperation = 'source-over'
+      drawBoulder(ctx, 0, 0, 1.05, 1)
+      ctx.restore()
+      // light pool on the ground under the shot
+      ctx.globalCompositeOperation = 'lighter'
+      ctx.globalAlpha = clamp01(1 - this.proj.y / 60) * 0.5
+      ctx.drawImage(this.glow, this.proj.x - 7, -2.6, 14, 5.2)
+      ctx.globalAlpha = 1
+      ctx.globalCompositeOperation = 'source-over'
+    }
+
+    if (this.wall) drawWall(ctx, s, this.wall.x, this.wall.h)
+    for (const t of this.towers) {
+      drawTower(ctx, s, t, this.cfg.banners, t.wanted && this.revealT > 0, this.time)
+    }
+    if (this.ram?.alive) drawRam(ctx, s, this.ram, this.time)
+    drawCraterLabels(ctx, s, this.craters)
+
+    // aim marker + the dial numeral, right where the eye already is
+    if (this.phase === 'aim' || this.phase === 'intro' || this.phase === 'windup') {
+      this.drawAim(ctx, s)
+    }
+
+    drawTrebuchet(
+      ctx,
+      s,
+      this.armDeg,
+      this.recoil,
+      this.platformDamage,
+      this.phase === 'aim' || this.phase === 'intro' || this.phase === 'windup',
+      1.05,
+    )
+
+    this.rings.draw(ctx, s)
+    this.parts.draw(ctx, s, this.glow, this.puff, PAL)
+    ctx.restore()
+    void f
+
+    this.flash.draw(ctx, w, h, 'rgba(255,196,130,1)')
+
+    // vignette — one gradient, cached would be nicer but it is 1 fill
+    ctx.save()
+    const vg = ctx.createRadialGradient(w / 2, h * 0.52, Math.min(w, h) * 0.32, w / 2, h * 0.52, Math.max(w, h) * 0.78)
+    vg.addColorStop(0, 'rgba(0,0,0,0)')
+    vg.addColorStop(1, 'rgba(0,0,0,0.55)')
+    ctx.fillStyle = vg
+    ctx.fillRect(0, 0, w, h)
+    ctx.restore()
+
+    drawHud(ctx, this.hudState(), this.btns, this.wallTime)
+  }
+
+  private drawAim(ctx: CanvasRenderingContext2D, s: number): void {
+    const x = worldX(this.dial)
+    const a = this.aimEmphasis
+    if (a < 0.02) return
+    ctx.save()
+    ctx.globalAlpha = a
+    // a column of light standing on the metre you have dialled
+    ctx.beginPath()
+    ctx.moveTo(x, 0)
+    ctx.lineTo(x, 9)
+    ctx.strokeStyle = C.steel
+    ctx.globalAlpha = a * 0.5
+    ctx.lineWidth = 2 / s
+    ctx.stroke()
+    ctx.globalAlpha = a
+    // caret
+    ctx.beginPath()
+    ctx.moveTo(x, 0.2)
+    ctx.lineTo(x - 1.1, 2.2)
+    ctx.lineTo(x + 1.1, 2.2)
+    ctx.closePath()
+    ctx.fillStyle = C.steel
+    ctx.fill()
+
+    // The loft stub — the first slice of the arc — only once the lever exists to
+    // change it. Before that it would be decoration teaching nothing.
+    if (this.cfg.loft) {
+      const st = solve(this.dial, LOFTS[this.loftIdx], this.wind, LAUNCH_H)
+      ctx.beginPath()
+      const pts = samplePath(st, 14, st.T * 0.34)
+      for (let i = 0; i < pts.length; i++) {
+        const p = pts[i]
+        if (i === 0) ctx.moveTo(p.x + LAUNCH_X, p.y)
+        else ctx.lineTo(p.x + LAUNCH_X, p.y)
+      }
+      ctx.strokeStyle = C.steel
+      ctx.globalAlpha = a * 0.45
+      ctx.lineWidth = 2 / s
+      ctx.setLineDash([1.4, 1.4])
+      ctx.stroke()
+      ctx.setLineDash([])
+      ctx.globalAlpha = a
+    }
+
+    // the dial numeral rides the marker
+    const pop = 1 + (1 - easeOutBack(clamp01(this.dialPop))) * 0.24
+    worldText(ctx, s, x, 3.2, (c) => {
+      const size = Math.max(20, Math.min(46, s * 3.4))
+      c.font = font(size, 900)
+      c.textAlign = 'center'
+      c.textBaseline = 'bottom'
+      c.save()
+      c.scale(pop, pop)
+      c.lineWidth = 4
+      c.strokeStyle = 'rgba(3,5,13,0.85)'
+      c.strokeText(String(this.dial), 0, 0)
+      c.fillStyle = C.steel
+      c.fillText(String(this.dial), 0, 0)
+      c.restore()
+    })
+    ctx.restore()
+  }
+
+  /* ---------------------------------------------------------------- debug */
+
+  stats(): DebugStats {
+    const sorted = this.frameTimes.slice().sort((a, b) => a - b)
+    const p95 = sorted.length ? sorted[Math.floor(sorted.length * 0.95)] : 0
+    return {
+      fps: Math.round(this.fps * 10) / 10,
+      frameMsP95: Math.round(p95 * 100) / 100,
+      particles: this.parts.count,
+      phase: this.phase,
+      wave: this.wave,
+      dial: this.dial,
+      answer: this.activeBoulder?.answer ?? -1,
+      score: this.score,
+    }
+  }
+
+  /**
+   * Harness driving. `manualDrive()` stops the rAF loop and lets a caller advance
+   * the clock by hand; `stepFrames` then runs the EXACT same `tick` the browser
+   * runs, so nothing about the game is bypassed — only the clock is. This is how
+   * the QA capture measures frame cost and takes screenshots at chosen moments in
+   * a tab that Chrome has throttled to zero.
+   */
+  manualDrive(on = true): void {
+    this.manual = on
+    this.last = performance.now()
+  }
+
+  /** @returns { meanMs, p95Ms, maxMs } for the frames it just ran */
+  stepFrames(n: number, dtMs = 1000 / 60): { meanMs: number; p95Ms: number; maxMs: number } {
+    const times: number[] = []
+    for (let i = 0; i < n; i++) {
+      this.last = this.syntheticClock
+      this.syntheticClock += dtMs
+      this.tick(this.syntheticClock)
+      times.push(this.lastFrameMs)
+    }
+    times.sort((a, b) => a - b)
+    const mean = times.reduce((a, b) => a + b, 0) / Math.max(1, times.length)
+    return {
+      meanMs: Math.round(mean * 100) / 100,
+      p95Ms: Math.round(times[Math.floor(times.length * 0.95)] * 100) / 100,
+      maxMs: Math.round(times[times.length - 1] * 100) / 100,
+    }
+  }
+
+  private syntheticClock = 0
+
+  /** Used by the harness to reach late waves without playing twenty minutes. */
+  jumpToWave(n: number): void {
+    this.startWave(n)
+  }
+
+  get currentPhase(): string {
+    return this.phase
+  }
+
+  towerRanges(): number[] {
+    return this.towers.filter((t) => t.alive).map((t) => t.range)
+  }
+
+  aimAt(v: number): void {
+    this.setDial(v)
+  }
+
+  fireNow(): void {
+    this.fire()
+  }
+
+  currentAnswer(): number {
+    return this.activeBoulder?.answer ?? -1
+  }
+
+  currentWind(): number {
+    return this.wind
+  }
+}
+
+/** Cheap x->t inversion used only when sizing the wall (no wind at that point). */
+function timeAtXApprox(s: Solved, x: number): number {
+  return x / s.vx
+}

--- a/dynawalla/games/trebuchet/src/index.ts
+++ b/dynawalla/games/trebuchet/src/index.ts
@@ -1,0 +1,23 @@
+/**
+ * The mount point the runtime will call. Everything else in this package is
+ * private to the game.
+ */
+
+import type { Host, Mounted } from './contract.ts'
+import { TrebuchetGame } from './game.ts'
+
+export type { Host, Question, Mounted } from './contract.ts'
+
+export function mount(el: HTMLElement, host: Host): Mounted {
+  const game = new TrebuchetGame(el, host)
+  // The harness reads frame stats and drives shots through the real input path.
+  ;(el as HTMLElement & { __trebuchet?: TrebuchetGame }).__trebuchet = game
+  return {
+    unmount(): void {
+      game.unmount()
+      delete (el as HTMLElement & { __trebuchet?: TrebuchetGame }).__trebuchet
+    },
+  }
+}
+
+export { TrebuchetGame }

--- a/dynawalla/games/trebuchet/src/main.ts
+++ b/dynawalla/games/trebuchet/src/main.ts
@@ -1,0 +1,19 @@
+/** Standalone dev entry: the game plus the local stub host. `npm run dev`. */
+
+import { mount } from './index.ts'
+import { createStubHost } from './stubHost.ts'
+
+const el = document.getElementById('app')
+if (!el) throw new Error('#app missing')
+
+const host = createStubHost({ seed: 0xc0ffee })
+const handle = mount(el, host)
+
+declare global {
+  interface Window {
+    __trebHost?: ReturnType<typeof createStubHost>
+    __trebUnmount?: () => void
+  }
+}
+window.__trebHost = host
+window.__trebUnmount = handle.unmount

--- a/dynawalla/games/trebuchet/src/render/backdrop.ts
+++ b/dynawalla/games/trebuchet/src/render/backdrop.ts
@@ -1,0 +1,263 @@
+/**
+ * Sky, weather and the three ridge layers.
+ *
+ * Everything expensive is pre-rendered once per resize into an offscreen canvas:
+ * the whole backdrop costs four drawImage calls and three fills per frame, no
+ * gradients, no shadows. Parallax is applied in screen space so the ridges keep
+ * their silhouette no matter how far the camera zooms.
+ */
+
+import { clamp01 } from '../core/ease.ts'
+import { makeRng, type Rng } from '../core/rng.ts'
+import { C } from './theme.ts'
+
+type Layer = { pts: number[]; scale: number; fill: string; parallax: number; base: number }
+
+export class Backdrop {
+  private sky: HTMLCanvasElement | null = null
+  private cloud: HTMLCanvasElement | null = null
+  private sun: HTMLCanvasElement | null = null
+  private w = 0
+  private h = 0
+  private layers: Layer[] = []
+  private drops: Float32Array = new Float32Array(0)
+  private nDrops = 0
+  private bolt: Array<{ x: number; y: number }> = []
+  private boltT = 999
+  private starSeed = 1
+
+  constructor(seed: number) {
+    const rng = makeRng(seed)
+    this.starSeed = seed
+    this.layers = [
+      this.makeRidge(rng, 0.16, C.ridgeFar, 0.055, 0.5),
+      this.makeRidge(rng, 0.26, C.ridgeMid, 0.14, 0.58),
+      this.makeRidge(rng, 0.42, C.ridgeNear, 0.3, 0.68),
+    ]
+  }
+
+  /**
+   * Mountains, not a bar chart. Three octaves of smooth wave plus a little noise;
+   * the occasional broad shoulder rather than a needle.
+   */
+  private makeRidge(rng: Rng, amp: number, fill: string, parallax: number, base: number): Layer {
+    const n = 64
+    const p1 = rng.range(0, 6.28)
+    const p2 = rng.range(0, 6.28)
+    const p3 = rng.range(0, 6.28)
+    const pts: number[] = []
+    for (let i = 0; i <= n; i++) {
+      const u = (i / n) * Math.PI * 2
+      const v =
+        0.46 +
+        0.26 * Math.sin(u * 1 + p1) +
+        0.16 * Math.sin(u * 2.3 + p2) +
+        0.09 * Math.sin(u * 4.7 + p3) +
+        rng.range(-0.04, 0.04)
+      pts.push(clamp01(v))
+    }
+    pts[n] = pts[0] // seamless tile
+    return { pts, scale: amp, fill, parallax, base }
+  }
+
+  resize(w: number, h: number, dpr: number): void {
+    this.w = w
+    this.h = h
+    const sky = document.createElement('canvas')
+    sky.width = Math.max(2, Math.ceil(w * 0.25))
+    sky.height = Math.max(2, Math.ceil(h))
+    const sc = sky.getContext('2d')
+    if (sc) {
+      const g = sc.createLinearGradient(0, 0, 0, sky.height)
+      for (const [p, col] of C.skyStops) g.addColorStop(p, col)
+      sc.fillStyle = g
+      sc.fillRect(0, 0, sky.width, sky.height)
+      // stars in the upper third
+      const rng = makeRng(this.starSeed ^ 0xa5a5)
+      sc.globalAlpha = 0.6
+      for (let i = 0; i < 90; i++) {
+        const x = rng.next() * sky.width
+        const y = rng.next() * sky.height * 0.4
+        const a = rng.range(0.1, 0.7) * (1 - y / (sky.height * 0.4))
+        sc.fillStyle = `rgba(200,220,255,${a.toFixed(3)})`
+        sc.fillRect(x, y, 1, 1)
+      }
+      sc.globalAlpha = 1
+    }
+    this.sky = sky
+
+    const cw = 512
+    const ch = 256
+    const cl = document.createElement('canvas')
+    cl.width = cw
+    cl.height = ch
+    const cc = cl.getContext('2d')
+    if (cc) {
+      const rng = makeRng(this.starSeed ^ 0x1234)
+      for (let i = 0; i < 26; i++) {
+        const x = rng.next() * cw
+        const y = rng.range(0.15, 0.9) * ch
+        const r = rng.range(30, 120)
+        const g = cc.createRadialGradient(x, y, 0, x, y, r)
+        const a = rng.range(0.05, 0.16)
+        g.addColorStop(0, `rgba(24,18,40,${a})`)
+        g.addColorStop(1, 'rgba(24,18,40,0)')
+        cc.fillStyle = g
+        cc.beginPath()
+        cc.ellipse(x, y, r, r * 0.42, 0, 0, Math.PI * 2)
+        cc.fill()
+      }
+    }
+    this.cloud = cl
+
+    const sn = document.createElement('canvas')
+    sn.width = 256
+    sn.height = 96
+    const snc = sn.getContext('2d')
+    if (snc) {
+      const g = snc.createRadialGradient(128, 84, 0, 128, 84, 120)
+      g.addColorStop(0, 'rgba(255,190,120,0.55)')
+      g.addColorStop(0.35, 'rgba(220,110,60,0.22)')
+      g.addColorStop(1, 'rgba(120,40,40,0)')
+      snc.fillStyle = g
+      snc.fillRect(0, 0, 256, 96)
+    }
+    this.sun = sn
+
+    const target = Math.min(240, Math.floor((w * h) / 5200))
+    this.drops = new Float32Array(target * 4)
+    this.nDrops = target
+    const rng = makeRng(0xd00d)
+    for (let i = 0; i < target; i++) {
+      this.drops[i * 4] = rng.next() * w
+      this.drops[i * 4 + 1] = rng.next() * h
+      this.drops[i * 4 + 2] = rng.range(0.55, 1)
+      this.drops[i * 4 + 3] = rng.range(0.4, 1)
+    }
+    void dpr
+  }
+
+  strike(rng: Rng): void {
+    const x = rng.range(this.w * 0.15, this.w * 0.9)
+    const pts: Array<{ x: number; y: number }> = [{ x, y: -10 }]
+    let cx = x
+    let cy = -10
+    const end = this.h * 0.42
+    while (cy < end) {
+      cy += rng.range(18, 46)
+      cx += rng.range(-34, 34)
+      pts.push({ x: cx, y: cy })
+    }
+    this.bolt = pts
+    this.boltT = 0
+  }
+
+  /**
+   * @param camX camera world x, for parallax
+   * @param horizonY screen y of the world ground line
+   */
+  draw(
+    ctx: CanvasRenderingContext2D,
+    t: number,
+    camX: number,
+    horizonY: number,
+    windDir: number,
+    rainAmt: number,
+  ): void {
+    const { w, h } = this
+    // The gradient is anchored to the horizon, so the ember band always sits
+    // exactly behind the ridge line however the camera is framed.
+    const hy = Math.max(40, Math.min(h, horizonY))
+    if (this.sky) ctx.drawImage(this.sky, 0, 0, w, hy)
+    ctx.fillStyle = C.ground
+    ctx.fillRect(0, hy - 1, w, h - hy + 1)
+    // a slit of low sun burning through, additive and stationary-ish
+    if (this.sun) {
+      const sx = w * 0.72 - ((camX * 1.6) % (w * 0.2))
+      ctx.save()
+      ctx.globalCompositeOperation = 'lighter'
+      ctx.globalAlpha = 0.55
+      const sw = w * 0.9
+      ctx.drawImage(this.sun, sx - sw / 2, hy - sw * 0.24, sw, sw * 0.34)
+      ctx.restore()
+    }
+
+    if (this.cloud) {
+      ctx.globalAlpha = 0.85
+      for (let i = 0; i < 3; i++) {
+        const sp = 6 + i * 9
+        const off = ((t * sp + camX * (0.02 + i * 0.02) * 8) % (w + 512)) - 512
+        const y = h * (0.06 + i * 0.11)
+        ctx.drawImage(this.cloud, -off, y, w + 512, h * 0.3)
+        ctx.drawImage(this.cloud, -off + w + 512, y, w + 512, h * 0.3)
+      }
+      ctx.globalAlpha = 1
+    }
+
+    // lightning bolt (rate limited by the Flash budget at the call site)
+    if (this.boltT < 0.22 && this.bolt.length > 1) {
+      const a = 1 - this.boltT / 0.22
+      ctx.save()
+      ctx.globalCompositeOperation = 'lighter'
+      ctx.strokeStyle = `rgba(190,220,255,${(a * 0.75).toFixed(3)})`
+      ctx.lineWidth = 2.4
+      ctx.beginPath()
+      ctx.moveTo(this.bolt[0].x, this.bolt[0].y)
+      for (const p of this.bolt) ctx.lineTo(p.x, p.y)
+      ctx.stroke()
+      ctx.lineWidth = 6
+      ctx.strokeStyle = `rgba(140,180,255,${(a * 0.18).toFixed(3)})`
+      ctx.stroke()
+      ctx.restore()
+    }
+
+    for (const L of this.layers) {
+      const n = L.pts.length - 1
+      const span = w * 1.7
+      const off = -(((camX * L.parallax * 6) % span) + span) % span
+      const baseY = hy + 1
+      ctx.beginPath()
+      ctx.moveTo(off - span - 4, baseY + 8)
+      // two tiles, drawn with quadratics so ridges read as rock rather than teeth
+      for (let tile = -1; tile <= 1; tile++) {
+        for (let i = 0; i <= n; i++) {
+          const x = off + tile * span + (i / n) * span
+          const y = baseY - L.pts[i] * h * L.scale
+          if (tile === -1 && i === 0) ctx.lineTo(x, y)
+          else {
+            const px = off + tile * span + ((i - 0.5) / n) * span
+            const py = baseY - ((L.pts[i] + L.pts[Math.max(0, i - 1)]) / 2) * h * L.scale
+            ctx.quadraticCurveTo(px, py, x, y)
+          }
+        }
+      }
+      ctx.lineTo(off + span * 2 + 4, baseY + 8)
+      ctx.closePath()
+      ctx.fillStyle = L.fill
+      ctx.fill()
+    }
+
+    if (rainAmt > 0.02 && this.nDrops) {
+      ctx.save()
+      ctx.strokeStyle = C.rain
+      ctx.lineWidth = 1.1
+      ctx.beginPath()
+      const slant = windDir * 5 + 2.5
+      for (let i = 0; i < this.nDrops; i++) {
+        const sp = this.drops[i * 4 + 2]
+        const y = (this.drops[i * 4 + 1] + t * 900 * sp) % h
+        const x = (this.drops[i * 4] + y * slant * 0.14) % w
+        const len = 9 + sp * 16
+        ctx.moveTo(x, y)
+        ctx.lineTo(x - slant * 0.9, y - len)
+      }
+      ctx.globalAlpha = clamp01(rainAmt)
+      ctx.stroke()
+      ctx.restore()
+    }
+  }
+
+  update(dt: number): void {
+    this.boltT += dt
+  }
+}

--- a/dynawalla/games/trebuchet/src/render/hud.ts
+++ b/dynawalla/games/trebuchet/src/render/hud.ts
@@ -1,0 +1,344 @@
+/**
+ * The HUD is numerals and glyphs — no words at all. Two reasons: a word costs five
+ * translations and a child reading a label is a child not watching the arc. The
+ * whole interface is: the equation you were handed, the number you are dialling,
+ * and the wind trying to spoil it.
+ */
+
+import { clamp01, easeOutBack, easeOutCubic, easeOutExpo } from '../core/ease.ts'
+import { C, font, roundRect } from './theme.ts'
+
+export type Btn = { x: number; y: number; w: number; h: number; id: string }
+
+export type HudState = {
+  w: number
+  h: number
+  /** css pixels of the shortest sensible touch target */
+  unit: number
+  equation: string
+  rack: string[]
+  rackActive: number
+  wave: number
+  score: number
+  scorePop: number
+  combo: number
+  wind: number
+  showWind: boolean
+  loftUnlocked: boolean
+  loftIndex: number
+  loftCount: number
+  muted: boolean
+  /** 0..1 intro banner progress */
+  introT: number
+  /** 0..1 wave-clear card progress, -1 when not showing */
+  clearT: number
+  clearHits: number
+  clearOf: number
+  /** the pop animation on the dial numeral */
+  dialPop: number
+  canFire: boolean
+}
+
+export function hudButtons(w: number, h: number, unit: number, loftUnlocked: boolean): Btn[] {
+  const pad = Math.round(unit * 0.4)
+  const fire = Math.round(unit * 1.6)
+  const small = Math.round(unit * 0.72)
+  const gap = Math.round(fire - small * 2)
+  const by = h - pad - fire
+  const bx = w - pad - fire
+  const btns: Btn[] = [
+    { id: 'fire', x: bx, y: by, w: fire, h: fire },
+    { id: 'plus', x: bx - Math.round(pad * 0.6) - small, y: by, w: small, h: small },
+    { id: 'minus', x: bx - Math.round(pad * 0.6) - small, y: by + small + gap, w: small, h: small },
+    { id: 'mute', x: w - pad - small * 0.8, y: pad * 0.6, w: small * 0.8, h: small * 0.8 },
+  ]
+  if (loftUnlocked) {
+    const lw = Math.round(unit * 0.95)
+    const lh = Math.round(unit * 2.6)
+    btns.push({ id: 'loft', x: pad, y: h - pad - lh, w: lw, h: lh })
+  }
+  return btns
+}
+
+export function drawHud(ctx: CanvasRenderingContext2D, st: HudState, btns: Btn[], time: number): void {
+  const { w, h, unit } = st
+  ctx.save()
+  ctx.textBaseline = 'middle'
+
+  /* ---- the equation: the most legible thing on the screen ---- */
+  const eqSize = Math.round(Math.min(unit * 1.15, w * 0.09))
+  const intro = easeOutExpo(clamp01(st.introT))
+  const plaqueW = Math.max(ctx.measureText(st.equation).width, eqSize * 5.4)
+  ctx.font = font(eqSize, 900)
+  const mw = ctx.measureText(st.equation).width
+  const pw = Math.max(mw + eqSize * 1.6, plaqueW)
+  const ph = eqSize * 1.62
+  const px = (w - pw) / 2
+  const py = Math.round(unit * 0.32) + (1 - intro) * -60
+  ctx.globalAlpha = intro
+  roundRect(ctx, px, py, pw, ph, 6)
+  ctx.fillStyle = 'rgba(6,8,18,0.62)'
+  ctx.fill()
+  ctx.strokeStyle = 'rgba(242,233,213,0.16)'
+  ctx.lineWidth = 1
+  ctx.stroke()
+  ctx.fillStyle = C.bone
+  ctx.textAlign = 'center'
+  ctx.fillText(st.equation, w / 2, py + ph / 2 + 1)
+  ctx.globalAlpha = 1
+
+  /* ---- the rack: every boulder left, and what is written on it ---- */
+  const slots = rackLayout(st)
+  const rowH = slots.length ? slots[0].h : Math.round(unit * 0.5)
+  const ry = py + ph + rowH * 0.9
+  for (let i = 0; i < slots.length; i++) {
+    const s = slots[i]
+    const active = i === st.rackActive
+    ctx.globalAlpha = intro * (active ? 1 : 0.62)
+    roundRect(ctx, s.x, s.y, s.w, s.h, 5)
+    ctx.fillStyle = active ? 'rgba(255,138,50,0.16)' : 'rgba(8,11,24,0.5)'
+    ctx.fill()
+    ctx.strokeStyle = active ? C.fire1 : 'rgba(242,233,213,0.18)'
+    ctx.lineWidth = active ? 2 : 1
+    ctx.stroke()
+    // the stone itself, so the row reads as ammunition and not as a tab bar
+    ctx.beginPath()
+    ctx.arc(s.x + s.h * 0.5, s.y + s.h / 2, s.h * (active ? 0.26 : 0.2), 0, Math.PI * 2)
+    ctx.fillStyle = active ? C.fire1 : C.boneDim
+    ctx.fill()
+    ctx.font = font(Math.round(s.h * 0.46), 800)
+    ctx.textAlign = 'left'
+    ctx.fillStyle = active ? C.bone : C.boneDim
+    ctx.fillText(st.rack[i], s.x + s.h * 0.9, s.y + s.h / 2 + 1)
+  }
+  ctx.globalAlpha = 1
+  void time
+
+  /* ---- wind ---- */
+  if (st.showWind) {
+    const wy = ry + rowH * 1.15
+    const s = Math.round(unit * 0.5)
+    ctx.font = font(s, 900)
+    const txt = (st.wind > 0 ? '+' : '') + String(st.wind)
+    const tw = ctx.measureText(txt).width
+    const aw = s * 1.5
+    const cx = w / 2
+    ctx.globalAlpha = intro
+    // the arrow: direction is shape, not colour
+    const dir = Math.sign(st.wind) || 1
+    const ax = cx - (tw + aw) / 2
+    ctx.beginPath()
+    ctx.moveTo(ax, wy)
+    ctx.lineTo(ax + aw * dir, wy)
+    ctx.moveTo(ax + aw * dir, wy)
+    ctx.lineTo(ax + (aw - s * 0.4) * dir, wy - s * 0.25)
+    ctx.moveTo(ax + aw * dir, wy)
+    ctx.lineTo(ax + (aw - s * 0.4) * dir, wy + s * 0.25)
+    ctx.strokeStyle = C.windChip
+    ctx.lineWidth = Math.max(2, s * 0.12)
+    ctx.lineCap = 'round'
+    ctx.stroke()
+    ctx.fillStyle = C.windChip
+    ctx.textAlign = 'left'
+    ctx.fillText(txt, ax + aw + s * 0.35, wy)
+    ctx.globalAlpha = 1
+  }
+
+  /* ---- wave + score, small, out of the way ---- */
+  const cs = Math.round(unit * 0.44)
+  ctx.font = font(cs, 800)
+  ctx.textAlign = 'left'
+  ctx.fillStyle = C.boneDim
+  ctx.fillText(String(st.wave), Math.round(unit * 0.42), Math.round(unit * 0.55))
+  // wave pips
+  for (let i = 0; i < Math.min(st.wave, 12); i++) {
+    ctx.fillRect(Math.round(unit * 0.42) + i * 5, Math.round(unit * 0.55) + cs * 0.7, 3, 3)
+  }
+  ctx.textAlign = 'right'
+  const pop = 1 + easeOutBack(clamp01(st.scorePop)) * (1 - clamp01(st.scorePop)) * 0.5
+  ctx.save()
+  const sx = w - Math.round(unit * 1.5)
+  const sy = Math.round(unit * 0.55)
+  ctx.translate(sx, sy)
+  ctx.scale(pop, pop)
+  ctx.fillStyle = st.combo > 1 ? C.fire1 : C.boneDim
+  ctx.font = font(cs, 900)
+  ctx.fillText(String(st.score), 0, 0)
+  ctx.restore()
+  if (st.combo > 1) {
+    ctx.font = font(cs * 0.8, 900)
+    ctx.fillStyle = C.fire1
+    ctx.fillText('×' + st.combo, sx, sy + cs * 1.1)
+  }
+
+  /* ---- controls ---- */
+  for (const b of btns) {
+    if (b.id === 'fire') drawFire(ctx, b, st.canFire, time)
+    else if (b.id === 'minus') drawStep(ctx, b, '−')
+    else if (b.id === 'plus') drawStep(ctx, b, '+')
+    else if (b.id === 'mute') drawMute(ctx, b, st.muted)
+    else if (b.id === 'loft') drawLoft(ctx, b, st.loftIndex, st.loftCount)
+  }
+
+  /* ---- wave clear card ---- */
+  if (st.clearT >= 0) {
+    const k = easeOutCubic(clamp01(st.clearT))
+    const a = st.clearT > 0.75 ? 1 - (st.clearT - 0.75) / 0.25 : 1
+    ctx.globalAlpha = clamp01(a)
+    const cw = Math.min(w * 0.5, unit * 4.4)
+    const chh = unit * 1.9
+    const cx = (w - cw) / 2
+    const cy = h * 0.34 + (1 - k) * 40
+    roundRect(ctx, cx, cy, cw, chh, 8)
+    ctx.fillStyle = 'rgba(6,8,18,0.78)'
+    ctx.fill()
+    ctx.strokeStyle = st.clearHits === st.clearOf ? C.fire1 : 'rgba(242,233,213,0.2)'
+    ctx.lineWidth = 2
+    ctx.stroke()
+    ctx.textAlign = 'center'
+    ctx.fillStyle = st.clearHits === st.clearOf ? C.fire1 : C.bone
+    ctx.font = font(Math.round(unit * 1.15), 900)
+    ctx.fillText(`${st.clearHits}/${st.clearOf}`, w / 2, cy + chh * 0.5)
+    ctx.globalAlpha = 1
+  }
+
+  ctx.restore()
+}
+
+function drawFire(ctx: CanvasRenderingContext2D, b: Btn, active: boolean, time: number): void {
+  const cx = b.x + b.w / 2
+  const cy = b.y + b.h / 2
+  const pulse = active ? 1 + Math.sin(time * 3.4) * 0.02 : 1
+  ctx.save()
+  ctx.translate(cx, cy)
+  ctx.scale(pulse, pulse)
+  roundRect(ctx, -b.w / 2, -b.h / 2, b.w, b.h, b.w * 0.24)
+  ctx.fillStyle = active ? 'rgba(255,95,24,0.20)' : 'rgba(120,120,140,0.10)'
+  ctx.fill()
+  ctx.strokeStyle = active ? C.fire2 : 'rgba(242,233,213,0.22)'
+  ctx.lineWidth = 2.5
+  ctx.stroke()
+  // a launch arc with an arrowhead — no word needed
+  const r = b.w * 0.3
+  ctx.beginPath()
+  ctx.arc(0, r * 0.7, r, Math.PI * 1.06, Math.PI * 1.94)
+  ctx.strokeStyle = active ? C.fire1 : 'rgba(242,233,213,0.3)'
+  ctx.lineWidth = 3
+  ctx.lineCap = 'round'
+  ctx.stroke()
+  const ex = Math.cos(Math.PI * 1.94) * r
+  const ey = r * 0.7 + Math.sin(Math.PI * 1.94) * r
+  ctx.beginPath()
+  ctx.moveTo(ex, ey)
+  ctx.lineTo(ex - r * 0.36, ey - r * 0.1)
+  ctx.moveTo(ex, ey)
+  ctx.lineTo(ex - r * 0.1, ey + r * 0.36)
+  ctx.stroke()
+  ctx.restore()
+}
+
+function drawStep(ctx: CanvasRenderingContext2D, b: Btn, glyph: string): void {
+  roundRect(ctx, b.x, b.y, b.w, b.h, b.w * 0.26)
+  ctx.fillStyle = 'rgba(10,14,28,0.5)'
+  ctx.fill()
+  ctx.strokeStyle = 'rgba(143,227,255,0.3)'
+  ctx.lineWidth = 2
+  ctx.stroke()
+  ctx.fillStyle = C.steel
+  ctx.font = font(Math.round(b.h * 0.52), 900)
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(glyph, b.x + b.w / 2, b.y + b.h / 2 + 1)
+}
+
+function drawMute(ctx: CanvasRenderingContext2D, b: Btn, muted: boolean): void {
+  const cx = b.x + b.w / 2
+  const cy = b.y + b.h / 2
+  const r = b.w * 0.22
+  ctx.save()
+  ctx.globalAlpha = 0.5
+  ctx.strokeStyle = C.bone
+  ctx.lineWidth = 2
+  ctx.beginPath()
+  ctx.moveTo(cx - r, cy - r * 0.45)
+  ctx.lineTo(cx - r * 0.4, cy - r * 0.45)
+  ctx.lineTo(cx + r * 0.2, cy - r)
+  ctx.lineTo(cx + r * 0.2, cy + r)
+  ctx.lineTo(cx - r * 0.4, cy + r * 0.45)
+  ctx.lineTo(cx - r, cy + r * 0.45)
+  ctx.closePath()
+  ctx.stroke()
+  if (muted) {
+    ctx.beginPath()
+    ctx.moveTo(cx + r * 0.5, cy - r * 0.6)
+    ctx.lineTo(cx + r * 1.2, cy + r * 0.6)
+    ctx.moveTo(cx + r * 1.2, cy - r * 0.6)
+    ctx.lineTo(cx + r * 0.5, cy + r * 0.6)
+    ctx.stroke()
+  } else {
+    for (let i = 1; i <= 2; i++) {
+      ctx.beginPath()
+      ctx.arc(cx + r * 0.3, cy, r * (0.5 + i * 0.4), -0.9, 0.9)
+      ctx.stroke()
+    }
+  }
+  ctx.restore()
+}
+
+function drawLoft(ctx: CanvasRenderingContext2D, b: Btn, idx: number, count: number): void {
+  roundRect(ctx, b.x, b.y, b.w, b.h, b.w * 0.24)
+  ctx.fillStyle = 'rgba(10,14,28,0.42)'
+  ctx.fill()
+  ctx.strokeStyle = 'rgba(143,227,255,0.22)'
+  ctx.lineWidth = 2
+  ctx.stroke()
+  const n = count
+  const cell = b.h / n
+  for (let i = 0; i < n; i++) {
+    // bottom = flat, top = lofted; the notch shape says which is which
+    const y = b.y + b.h - (i + 0.5) * cell
+    const on = i === idx
+    const wdt = b.w * (0.22 + (i / (n - 1)) * 0.42)
+    ctx.beginPath()
+    ctx.moveTo(b.x + b.w / 2 - wdt / 2, y)
+    ctx.lineTo(b.x + b.w / 2 + wdt / 2, y)
+    ctx.strokeStyle = on ? C.steel : 'rgba(143,227,255,0.28)'
+    ctx.lineWidth = on ? 4 : 2
+    ctx.lineCap = 'round'
+    ctx.stroke()
+  }
+  const y = b.y + b.h - (idx + 0.5) * cell
+  ctx.beginPath()
+  ctx.arc(b.x + b.w / 2, y, b.w * 0.16, 0, Math.PI * 2)
+  ctx.fillStyle = C.steel
+  ctx.fill()
+}
+
+/**
+ * Where each boulder in the rack sits. One function, used by both the renderer and
+ * the hit test, so a tap can never land somewhere the eye disagrees with.
+ */
+export function rackLayout(st: HudState): Array<{ x: number; y: number; w: number; h: number }> {
+  const { w, unit } = st
+  const eqSize = Math.round(Math.min(unit * 1.15, w * 0.09))
+  const ph = eqSize * 1.62
+  const py = Math.round(unit * 0.32)
+  const h = Math.round(unit * 0.5)
+  const gap = Math.round(h * 0.28)
+  const widths = st.rack.map((t) => Math.round(h * 0.9 + t.length * h * 0.27 + h * 0.35))
+  const total = widths.reduce((a, b) => a + b, 0) + Math.max(0, st.rack.length - 1) * gap
+  let x = (w - total) / 2
+  const y = py + ph + h * 0.9 - h / 2
+  return widths.map((wd) => {
+    const slot = { x, y, w: wd, h }
+    x += wd + gap
+    return slot
+  })
+}
+
+export function hitBtn(btns: Btn[], x: number, y: number, slop = 6): Btn | null {
+  for (const b of btns) {
+    if (x >= b.x - slop && x <= b.x + b.w + slop && y >= b.y - slop && y <= b.y + b.h + slop) return b
+  }
+  return null
+}

--- a/dynawalla/games/trebuchet/src/render/pieces.ts
+++ b/dynawalla/games/trebuchet/src/render/pieces.ts
@@ -1,0 +1,554 @@
+/**
+ * Everything that stands on the ground, drawn as silhouette + one warm rim.
+ * All of this runs inside the world transform (y up, units = metres), so line
+ * widths are divided by `s` and text goes through `worldText`.
+ */
+
+import { clamp01, easeOutBack, easeOutCubic } from '../core/ease.ts'
+import { worldX, type Crater, type Ghost, type Ram, type Tower } from '../sim/world.ts'
+import { C, font, worldText } from './theme.ts'
+
+export const PIVOT_X = 0.5
+export const PIVOT_Y = 11
+export const ARM_L = 7.5
+export const CW_L = 2.6
+export const RELEASE_DEG = 42
+export const ARMED_DEG = 208
+
+export const armTip = (deg: number): { x: number; y: number } => ({
+  x: PIVOT_X + ARM_L * Math.cos((deg * Math.PI) / 180),
+  y: PIVOT_Y + ARM_L * Math.sin((deg * Math.PI) / 180),
+})
+
+/* ---------------------------------------------------------------- ground */
+
+export function drawGround(
+  ctx: CanvasRenderingContext2D,
+  s: number,
+  fieldMax: number,
+  craters: Crater[],
+  scrub: Float32Array,
+): void {
+  const x0 = -40
+  const x1 = worldX(fieldMax) + 40
+
+  // the plain
+  ctx.beginPath()
+  ctx.moveTo(x0, -60)
+  ctx.lineTo(x0, 0)
+  ctx.lineTo(x1, 0)
+  ctx.lineTo(x1, -60)
+  ctx.closePath()
+  ctx.fillStyle = C.ground
+  ctx.fill()
+
+  // strata: the earth is not a void, it is rock the siege stands on
+  ctx.beginPath()
+  for (let i = 1; i <= 5; i++) {
+    const y = -i * i * 1.4
+    ctx.moveTo(x0, y)
+    for (let x = x0; x < x1; x += 14) {
+      ctx.lineTo(x + 14, y + Math.sin(x * 0.06 + i) * 0.6)
+    }
+  }
+  ctx.strokeStyle = C.groundLine
+  ctx.globalAlpha = 0.055
+  ctx.lineWidth = 1.4 / s
+  ctx.stroke()
+  ctx.globalAlpha = 1
+
+  // craters cut into the lip
+  for (const cr of craters) {
+    const a = clamp01(1 - cr.age / 26)
+    ctx.beginPath()
+    ctx.ellipse(cr.x, 0, cr.r, cr.r * 0.42, 0, 0, Math.PI, false)
+    ctx.fillStyle = C.groundDeep
+    ctx.globalAlpha = 0.55 + a * 0.45
+    ctx.fill()
+    ctx.globalAlpha = 1
+  }
+
+  // the rim of light along the horizon edge
+  ctx.beginPath()
+  ctx.moveTo(x0, 0)
+  for (const cr of craters.slice().sort((p, q) => p.x - q.x)) {
+    ctx.lineTo(cr.x - cr.r, 0)
+    ctx.lineTo(cr.x, -cr.r * 0.34)
+    ctx.lineTo(cr.x + cr.r, 0)
+  }
+  ctx.lineTo(x1, 0)
+  ctx.strokeStyle = C.groundLine
+  ctx.lineWidth = 1.6 / s
+  ctx.globalAlpha = 0.75
+  ctx.stroke()
+  ctx.globalAlpha = 1
+
+  // scrub tufts: pre-seeded, one path
+  ctx.beginPath()
+  for (let i = 0; i < scrub.length; i += 2) {
+    const x = scrub[i]
+    const hgt = scrub[i + 1]
+    ctx.moveTo(x, 0)
+    ctx.lineTo(x + hgt * 0.3, hgt)
+    ctx.moveTo(x, 0)
+    ctx.lineTo(x - hgt * 0.24, hgt * 0.8)
+  }
+  ctx.strokeStyle = C.scrub
+  ctx.lineWidth = 1.4 / s
+  ctx.stroke()
+}
+
+export function drawMilestones(
+  ctx: CanvasRenderingContext2D,
+  s: number,
+  fieldMax: number,
+  emphasis: number,
+): void {
+  for (let m = 10; m <= fieldMax; m += 10) {
+    const x = worldX(m)
+    const major = m % 50 === 0
+    const h = major ? 2.6 : 1.6
+    ctx.beginPath()
+    ctx.moveTo(x, -h * 0.55)
+    ctx.lineTo(x, h)
+    ctx.strokeStyle = C.stoneRim
+    ctx.globalAlpha = (major ? 0.7 : 0.4) * (0.45 + emphasis * 0.55)
+    ctx.lineWidth = (major ? 2.6 : 1.8) / s
+    ctx.stroke()
+    ctx.globalAlpha = 1
+    worldText(ctx, s, x, -h * 0.75, (c) => {
+      c.font = font(major ? 15 : 13, 800)
+      c.textAlign = 'center'
+      c.textBaseline = 'top'
+      c.fillStyle = C.bone
+      c.globalAlpha = (major ? 0.7 : 0.46) * (0.4 + emphasis * 0.6)
+      c.fillText(String(m), 0, 0)
+      c.globalAlpha = 1
+    })
+  }
+}
+
+/* ------------------------------------------------------------ trebuchet */
+
+/** A timber the beam is actually made of, not a line. */
+function timber(
+  ctx: CanvasRenderingContext2D,
+  s: number,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  w1: number,
+  w2 = w1,
+): void {
+  const dx = x2 - x1
+  const dy = y2 - y1
+  const m = Math.hypot(dx, dy) || 1
+  const nx = -dy / m
+  const ny = dx / m
+  ctx.beginPath()
+  ctx.moveTo(x1 + nx * w1 * 0.5, y1 + ny * w1 * 0.5)
+  ctx.lineTo(x2 + nx * w2 * 0.5, y2 + ny * w2 * 0.5)
+  ctx.lineTo(x2 - nx * w2 * 0.5, y2 - ny * w2 * 0.5)
+  ctx.lineTo(x1 - nx * w1 * 0.5, y1 - ny * w1 * 0.5)
+  ctx.closePath()
+  ctx.fillStyle = C.stoneLit
+  ctx.fill()
+  ctx.strokeStyle = C.stoneRim
+  ctx.globalAlpha = 0.55
+  ctx.lineWidth = 1.7 / s
+  ctx.stroke()
+  ctx.globalAlpha = 1
+}
+
+export function drawTrebuchet(
+  ctx: CanvasRenderingContext2D,
+  s: number,
+  armDeg: number,
+  recoil: number,
+  damage: number,
+  loaded: boolean,
+  boulderR: number,
+): void {
+  // escarpment (does not recoil — only the machine does)
+  ctx.beginPath()
+  ctx.moveTo(-40, -40)
+  ctx.lineTo(-40, 5.2)
+  ctx.lineTo(-8, 5.4)
+  ctx.lineTo(2, 5.1)
+  ctx.lineTo(7.2, 4.6)
+  ctx.lineTo(8.6, 2.2)
+  ctx.lineTo(9.4, 0)
+  ctx.lineTo(9.4, -40)
+  ctx.closePath()
+  ctx.fillStyle = C.ground
+  ctx.fill()
+  ctx.beginPath()
+  ctx.moveTo(-40, 5.2)
+  ctx.lineTo(-8, 5.4)
+  ctx.lineTo(2, 5.1)
+  ctx.lineTo(7.2, 4.6)
+  ctx.lineTo(8.6, 2.2)
+  ctx.lineTo(9.4, 0)
+  ctx.strokeStyle = C.groundLine
+  ctx.lineWidth = 1.8 / s
+  ctx.globalAlpha = 0.85
+  ctx.stroke()
+  ctx.globalAlpha = 1
+
+  ctx.save()
+  ctx.translate(-recoil * 0.7, 0)
+
+  const th = (armDeg * Math.PI) / 180
+  const tip = { x: PIVOT_X + ARM_L * Math.cos(th), y: PIVOT_Y + ARM_L * Math.sin(th) }
+  const cw = { x: PIVOT_X - CW_L * Math.cos(th), y: PIVOT_Y - CW_L * Math.sin(th) }
+
+  // sledge
+  timber(ctx, s, -4.6, 5.3, 5.0, 5.0, 0.62)
+  // A-frame + braces + rear stay
+  timber(ctx, s, -3.4, 5.3, PIVOT_X, PIVOT_Y, 0.66, 0.42)
+  timber(ctx, s, 4.2, 5.05, PIVOT_X, PIVOT_Y, 0.66, 0.42)
+  timber(ctx, s, -2.1, 7.7, 2.9, 7.7, 0.34)
+  timber(ctx, s, -4.4, 5.4, -1.4, 9.2, 0.3)
+  // wheels
+  for (const wx of [-3.4, 3.6]) {
+    ctx.beginPath()
+    ctx.arc(wx, 5.0, 0.8, 0, Math.PI * 2)
+    ctx.fillStyle = C.stone
+    ctx.fill()
+    ctx.strokeStyle = C.stoneRim
+    ctx.globalAlpha = 0.5
+    ctx.lineWidth = 1.6 / s
+    ctx.stroke()
+    ctx.globalAlpha = 1
+  }
+
+  // the beam, tapering to the sling end
+  timber(ctx, s, cw.x, cw.y, tip.x, tip.y, 0.62, 0.34)
+
+  // counterweight: a slung crate, always hanging plumb
+  const linkX = cw.x
+  const linkY = cw.y
+  timber(ctx, s, linkX, linkY, linkX, linkY - 1.0, 0.16)
+  ctx.beginPath()
+  ctx.rect(linkX - 1.35, linkY - 3.5, 2.7, 2.5)
+  ctx.fillStyle = C.stoneLit
+  ctx.fill()
+  ctx.strokeStyle = C.stoneRim
+  ctx.globalAlpha = 0.6
+  ctx.lineWidth = 2 / s
+  ctx.stroke()
+  ctx.beginPath()
+  ctx.moveTo(linkX - 1.35, linkY - 2.3)
+  ctx.lineTo(linkX + 1.35, linkY - 2.3)
+  ctx.globalAlpha = 0.3
+  ctx.lineWidth = 1.4 / s
+  ctx.stroke()
+  ctx.globalAlpha = 1
+
+  // pivot pin
+  ctx.beginPath()
+  ctx.arc(PIVOT_X, PIVOT_Y, 0.42, 0, Math.PI * 2)
+  ctx.fillStyle = C.stoneRim
+  ctx.globalAlpha = 0.8
+  ctx.fill()
+  ctx.globalAlpha = 1
+
+  // sling + shot: the pouch hangs, and rests on the deck while armed
+  if (loaded) {
+    const sth = ((armDeg + 52) * Math.PI) / 180
+    let bx = tip.x + Math.cos(sth) * 2.6
+    let by = tip.y + Math.sin(sth) * 2.6
+    if (by < 5.9) {
+      by = 5.9
+      bx = Math.min(bx, tip.x + 1.6)
+    }
+    ctx.beginPath()
+    ctx.moveTo(tip.x, tip.y)
+    ctx.lineTo(bx - 0.5, by + 0.3)
+    ctx.moveTo(tip.x, tip.y)
+    ctx.lineTo(bx + 0.5, by + 0.3)
+    ctx.strokeStyle = C.stoneRim
+    ctx.globalAlpha = 0.55
+    ctx.lineWidth = 1.6 / s
+    ctx.stroke()
+    ctx.globalAlpha = 1
+    drawBoulder(ctx, bx, by, boulderR, 0.55)
+  }
+
+  // battle damage: chips out of the frame
+  if (damage > 0.01) {
+    ctx.globalAlpha = clamp01(damage)
+    ctx.beginPath()
+    for (let i = 0; i < 5; i++) {
+      const x = -3 + i * 1.7
+      ctx.moveTo(x, 5.2)
+      ctx.lineTo(x + 0.5, 5.2 + 0.9 * ((i % 3) + 1) * 0.3)
+    }
+    ctx.strokeStyle = C.danger
+    ctx.lineWidth = 2 / s
+    ctx.stroke()
+    ctx.globalAlpha = 1
+  }
+  ctx.restore()
+}
+
+export function drawBoulder(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  r: number,
+  heat: number,
+): void {
+  ctx.beginPath()
+  ctx.arc(x, y, r, 0, Math.PI * 2)
+  ctx.fillStyle = heat > 0.85 ? C.fire2 : C.stoneLit
+  ctx.fill()
+  ctx.beginPath()
+  ctx.arc(x - r * 0.18, y + r * 0.2, r * (heat > 0.85 ? 0.7 : 0.55), 0, Math.PI * 2)
+  ctx.fillStyle = heat > 0.85 ? C.fire0 : heat > 0.6 ? C.fire1 : C.stoneRim
+  ctx.globalAlpha = 0.25 + heat * 0.72
+  ctx.fill()
+  ctx.globalAlpha = 1
+}
+
+/* ---------------------------------------------------------------- keeps */
+
+export function drawTower(
+  ctx: CanvasRenderingContext2D,
+  s: number,
+  t: Tower,
+  showBanner: boolean,
+  reveal: boolean,
+  time: number,
+): void {
+  const bx = worldX(t.range)
+
+  // attached blocks, leaning as one body
+  ctx.save()
+  ctx.translate(bx, 0)
+  ctx.rotate(t.lean)
+  ctx.beginPath()
+  for (const b of t.blocks) {
+    if (b.loose) continue
+    ctx.rect(b.x - b.w / 2, b.y - b.h / 2, b.w, b.h)
+  }
+  ctx.fillStyle = C.stone
+  ctx.fill()
+  // warm rim on the lit (right) side and along every top edge
+  ctx.strokeStyle = C.stoneRim
+  ctx.lineWidth = 1.5 / s
+  ctx.globalAlpha = 0.34 + t.flash * 0.6
+  ctx.stroke()
+  ctx.globalAlpha = 1
+
+  if (t.damage > 0.02) {
+    ctx.beginPath()
+    const n = Math.ceil(t.damage * 6)
+    for (let i = 0; i < n; i++) {
+      const yy = ((i * 3.7) % t.heightM) * 0.9 + 0.6
+      const xx = -t.widthM / 2 + ((i * 1.9) % t.widthM)
+      ctx.moveTo(xx, yy)
+      ctx.lineTo(xx + 0.7, yy + 1.1)
+      ctx.lineTo(xx + 0.2, yy + 1.9)
+    }
+    ctx.strokeStyle = C.danger
+    ctx.globalAlpha = 0.35 + t.damage * 0.4
+    ctx.lineWidth = 1.6 / s
+    ctx.stroke()
+    ctx.globalAlpha = 1
+  }
+  ctx.restore()
+
+  // loose blocks in world space
+  if (t.blocks.some((b) => b.loose)) {
+    ctx.beginPath()
+    for (const b of t.blocks) {
+      if (!b.loose) continue
+      ctx.save()
+      ctx.translate(b.x, b.y)
+      ctx.rotate(b.rot)
+      ctx.rect(-b.w / 2, -b.h / 2, b.w, b.h)
+      ctx.restore()
+    }
+    ctx.fillStyle = C.stone
+    ctx.fill()
+    ctx.strokeStyle = C.stoneRim
+    ctx.globalAlpha = 0.18
+    ctx.lineWidth = 1 / s
+    ctx.stroke()
+    ctx.globalAlpha = 1
+  }
+
+  if (!t.alive) return
+
+  // banner
+  if (showBanner || reveal) {
+    const top = t.heightM + 3.4
+    const rv = showBanner ? 1 : easeOutCubic(clamp01(t.reveal))
+    const sway = Math.sin(time * 1.7 + t.range) * 0.16
+    ctx.save()
+    ctx.translate(bx, 0)
+    ctx.rotate(t.lean)
+    ctx.beginPath()
+    ctx.moveTo(0, t.heightM - 0.4)
+    ctx.lineTo(0, top)
+    ctx.strokeStyle = C.stoneRim
+    ctx.globalAlpha = 0.4 * rv
+    ctx.lineWidth = 1.4 / s
+    ctx.stroke()
+    ctx.globalAlpha = 1
+
+    const bw = 5.0
+    const bh = 3.3
+    ctx.beginPath()
+    ctx.moveTo(-bw / 2, top)
+    ctx.lineTo(bw / 2, top + sway * 0.5)
+    ctx.lineTo(bw / 2 + sway, top - bh)
+    ctx.lineTo(0, top - bh * 0.78)
+    ctx.lineTo(-bw / 2 + sway * 0.4, top - bh)
+    ctx.closePath()
+    ctx.fillStyle = reveal && !showBanner ? C.bannerWanted : C.banner
+    ctx.globalAlpha = 0.92 * rv
+    ctx.fill()
+    ctx.globalAlpha = 1
+    worldText(ctx, s, 0, top - 0.7, (c) => {
+      c.font = font(Math.max(13, Math.min(30, s * 2.3)), 900)
+      c.textAlign = 'center'
+      c.textBaseline = 'middle'
+      c.fillStyle = C.bannerInk
+      c.globalAlpha = rv
+      c.fillText(String(t.value), 0, 0)
+      c.globalAlpha = 1
+    })
+    ctx.restore()
+  }
+}
+
+/* ------------------------------------------------------------ obstacles */
+
+export function drawWall(ctx: CanvasRenderingContext2D, s: number, x: number, h: number): void {
+  const w = 2.4
+  ctx.beginPath()
+  ctx.moveTo(x - w / 2, 0)
+  ctx.lineTo(x - w / 2, h)
+  for (let i = 0; i < 4; i++) {
+    const xx = x - w / 2 + (i * w) / 4
+    ctx.lineTo(xx, h + (i % 2 === 0 ? 0.9 : 0))
+    ctx.lineTo(xx + w / 8, h + (i % 2 === 0 ? 0.9 : 0))
+  }
+  ctx.lineTo(x + w / 2, h)
+  ctx.lineTo(x + w / 2, 0)
+  ctx.closePath()
+  ctx.fillStyle = C.stone
+  ctx.fill()
+  ctx.strokeStyle = C.stoneCold
+  ctx.globalAlpha = 0.45
+  ctx.lineWidth = 1.5 / s
+  ctx.stroke()
+  ctx.globalAlpha = 1
+}
+
+export function drawRam(ctx: CanvasRenderingContext2D, s: number, ram: Ram, time: number): void {
+  const x = worldX(ram.range)
+  const bob = Math.sin(time * 7) * 0.12
+  ctx.save()
+  ctx.translate(x, bob)
+  // hoarding — a big armoured shed, readable at any zoom
+  ctx.beginPath()
+  ctx.moveTo(-4.6, 1.3)
+  ctx.lineTo(-3.4, 6.2)
+  ctx.lineTo(3.4, 6.2)
+  ctx.lineTo(4.6, 1.3)
+  ctx.closePath()
+  ctx.fillStyle = C.stone
+  ctx.fill()
+  ctx.strokeStyle = C.danger
+  ctx.globalAlpha = 0.75
+  ctx.lineWidth = 2.4 / s
+  ctx.stroke()
+  ctx.globalAlpha = 1
+  // brazier on the roof: the one hot thing on the field that is not yours
+  const flicker = 0.7 + Math.sin(time * 13) * 0.3
+  ctx.beginPath()
+  ctx.arc(0, 6.9, 0.8 * flicker, 0, Math.PI * 2)
+  ctx.fillStyle = C.fire1
+  ctx.globalAlpha = 0.85
+  ctx.fill()
+  ctx.globalAlpha = 1
+  // the ram head, swinging
+  const swing = Math.sin(time * 3.1) * 0.5
+  ctx.beginPath()
+  ctx.moveTo(-4.2, 3.0 + swing)
+  ctx.lineTo(-7.4, 3.0 + swing * 1.6)
+  ctx.strokeStyle = C.stoneLit
+  ctx.lineWidth = 0.9
+  ctx.lineCap = 'round'
+  ctx.stroke()
+  ctx.strokeStyle = C.stoneRim
+  ctx.globalAlpha = 0.6
+  ctx.lineWidth = 2 / s
+  ctx.stroke()
+  ctx.globalAlpha = 1
+  // wheels
+  for (const wx of [-2.6, 2.6]) {
+    ctx.beginPath()
+    ctx.arc(wx, 1.3, 1.3, 0, Math.PI * 2)
+    ctx.fillStyle = C.stoneLit
+    ctx.fill()
+    ctx.beginPath()
+    ctx.moveTo(wx, 1.3)
+    ctx.lineTo(wx + Math.cos(ram.wheel) * 1.3, 1.3 + Math.sin(ram.wheel) * 1.3)
+    ctx.moveTo(wx, 1.3)
+    ctx.lineTo(wx - Math.cos(ram.wheel) * 1.3, 1.3 - Math.sin(ram.wheel) * 1.3)
+    ctx.strokeStyle = C.danger
+    ctx.globalAlpha = 0.7
+    ctx.lineWidth = 2 / s
+    ctx.stroke()
+    ctx.globalAlpha = 1
+  }
+  ctx.restore()
+}
+
+/* --------------------------------------------------------------- traces */
+
+export function drawGhosts(ctx: CanvasRenderingContext2D, s: number, ghosts: Ghost[]): void {
+  ctx.save()
+  ctx.setLineDash([0.7 / 1, 1.5 / 1])
+  for (const g of ghosts) {
+    const a = clamp01(1 - g.age / 14) * 0.5
+    if (a <= 0.01) continue
+    ctx.beginPath()
+    for (let i = 0; i < g.pts.length; i++) {
+      const p = g.pts[i]
+      if (i === 0) ctx.moveTo(p.x, p.y)
+      else ctx.lineTo(p.x, p.y)
+    }
+    ctx.strokeStyle = g.hit ? C.stoneRim : C.steel
+    ctx.globalAlpha = a
+    ctx.lineWidth = 1.3 / s
+    ctx.stroke()
+  }
+  ctx.restore()
+  ctx.globalAlpha = 1
+}
+
+export function drawCraterLabels(ctx: CanvasRenderingContext2D, s: number, craters: Crater[]): void {
+  for (const cr of craters) {
+    const a = clamp01(1 - cr.age / 12)
+    if (a <= 0.02) continue
+    const pop = easeOutBack(clamp01(cr.age / 0.28))
+    worldText(ctx, s, cr.x, -0.5, (c) => {
+      c.font = font(Math.max(11, Math.min(20, s * 1.7)), 800)
+      c.textAlign = 'center'
+      c.textBaseline = 'top'
+      c.globalAlpha = a * 0.85
+      c.fillStyle = cr.correct ? C.stoneRim : C.steel
+      c.save()
+      c.scale(pop, pop)
+      c.fillText(String(cr.label), 0, 0)
+      c.restore()
+      c.globalAlpha = 1
+    })
+  }
+}

--- a/dynawalla/games/trebuchet/src/render/theme.ts
+++ b/dynawalla/games/trebuchet/src/render/theme.ts
@@ -1,0 +1,112 @@
+/**
+ * STORMFALL — the visual register.
+ *
+ * A siege fought at dusk under a breaking storm. Everything on the ground is a
+ * near-black silhouette with a single warm rim of light along its top edge; the sky
+ * behind it is a bruise going from indigo to ember. Two colours do all the work:
+ * cold light from above, warm light from the fire you throw. Nothing is grey, and
+ * nothing is decorated — shapes read at a glance from across a room, which is the
+ * whole requirement for a game whose subject is *where things land*.
+ */
+
+export const C = {
+  skyStops: [
+    [0.0, '#03050d'],
+    [0.28, '#0a0f2c'],
+    [0.52, '#221844'],
+    [0.72, '#57224a'],
+    [0.85, '#a63d2b'],
+    [0.93, '#e57f39'],
+    [1.0, '#ffcb8a'],
+  ] as Array<[number, string]>,
+
+  ridgeFar: '#111634',
+  ridgeMid: '#0a0e22',
+  ridgeNear: '#050710',
+
+  ground: '#04060e',
+  groundLine: '#ff9a4a',
+  groundDeep: '#02030a',
+  scrub: '#080c1a',
+
+  stone: '#070a16',
+  stoneLit: '#171d33',
+  stoneRim: '#ffab5e',
+  stoneCold: '#5f86c9',
+
+  banner: '#e4d7ba',
+  bannerInk: '#0c1020',
+  bannerWanted: '#ffd98a',
+
+  fire0: '#fff4d6',
+  fire1: '#ffb44e',
+  fire2: '#ff5f18',
+  smoke: '#2a2333',
+  dust: '#4a3b46',
+
+  bone: '#f2e9d5',
+  boneDim: 'rgba(242,233,213,0.42)',
+  steel: '#8fe3ff',
+  steelDim: 'rgba(143,227,255,0.35)',
+  windChip: '#ffd08a',
+  rain: 'rgba(168,198,255,0.20)',
+  danger: '#ff8a5c',
+} as const
+
+export const FONT_STACK =
+  'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif'
+
+export const font = (px: number, weight = 800, tracking = 0): string => {
+  void tracking
+  return `${weight} ${px}px ${FONT_STACK}`
+}
+
+export type Frame = {
+  ctx: CanvasRenderingContext2D
+  w: number
+  h: number
+  /** pixels per metre, including the camera punch */
+  s: number
+  /** seconds since mount, scaled */
+  t: number
+  dt: number
+  reduced: boolean
+}
+
+/** Draw pixel-sized text at a world position without inheriting the flipped world scale. */
+export function worldText(
+  ctx: CanvasRenderingContext2D,
+  s: number,
+  x: number,
+  y: number,
+  fn: (c: CanvasRenderingContext2D) => void,
+): void {
+  ctx.save()
+  ctx.translate(x, y)
+  ctx.scale(1 / s, -1 / s)
+  fn(ctx)
+  ctx.restore()
+}
+
+/** A rounded rectangle path, in whatever space is current. */
+export function roundRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+): void {
+  const rr = Math.min(r, Math.abs(w) / 2, Math.abs(h) / 2)
+  ctx.beginPath()
+  ctx.moveTo(x + rr, y)
+  ctx.lineTo(x + w - rr, y)
+  ctx.quadraticCurveTo(x + w, y, x + w, y + rr)
+  ctx.lineTo(x + w, y + h - rr)
+  ctx.quadraticCurveTo(x + w, y + h, x + w - rr, y + h)
+  ctx.lineTo(x + rr, y + h)
+  ctx.quadraticCurveTo(x, y + h, x, y + h - rr)
+  ctx.lineTo(x, y + rr)
+  ctx.quadraticCurveTo(x, y, x + rr, y)
+  ctx.closePath()
+}

--- a/dynawalla/games/trebuchet/src/sim/ballistics.test.ts
+++ b/dynawalla/games/trebuchet/src/sim/ballistics.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { G, GRAZE_M, heightAtX, posAt, resolve, samplePath, shotScore, solve } from './ballistics.ts'
+
+const LOFTS = [26, 34, 42, 52, 63]
+
+test('the dial IS the range: landing = power + wind, exactly, for every integer input', () => {
+  for (let R = 8; R <= 122; R++) {
+    for (const a of LOFTS) {
+      for (const wind of [-9, -4, 0, 3, 9]) {
+        const s = solve(R, a, wind)
+        assert.equal(s.landing, R + wind, `R=${R} a=${a} w=${wind}`)
+        assert.ok(Number.isInteger(s.landing))
+      }
+    }
+  }
+})
+
+test('the arc actually arrives where the integer says it does', () => {
+  for (let R = 10; R <= 120; R += 7) {
+    for (const a of LOFTS) {
+      for (const wind of [-6, 0, 5]) {
+        const s = solve(R, a, wind)
+        const end = posAt(s, s.T)
+        assert.ok(Math.abs(end.x - (R + wind)) < 1e-9, `x drift R=${R}`)
+        assert.ok(Math.abs(end.y) < 1e-9, `y drift R=${R}`)
+      }
+    }
+  }
+})
+
+test('loft changes the shape of the arc, never the landing', () => {
+  const flat = solve(70, LOFTS[0], 0)
+  const high = solve(70, LOFTS[4], 0)
+  assert.equal(flat.landing, high.landing)
+  assert.ok(high.apexY > flat.apexY * 1.8, 'a high loft must actually be high')
+  assert.ok(high.T > flat.T, 'a high loft must hang longer')
+})
+
+test('a high loft clears an obstacle a flat one hits', () => {
+  const wallX = 30
+  const flat = heightAtX(solve(80, LOFTS[0], 0), wallX)
+  const high = heightAtX(solve(80, LOFTS[4], 0), wallX)
+  assert.ok(high > flat + 8, `flat=${flat} high=${high}`)
+})
+
+test('gravity is the only thing pulling down: apex time = vy/g', () => {
+  const s = solve(64, 42, 0)
+  assert.ok(Math.abs(s.apexT - s.vy / G) < 1e-12)
+  const apex = posAt(s, s.apexT)
+  assert.ok(Math.abs(apex.y - s.apexY) < 1e-9)
+})
+
+test('wind bends the path but never the arithmetic', () => {
+  const still = solve(60, 42, 0)
+  const blown = solve(60, 42, 6)
+  assert.equal(blown.landing - still.landing, 6)
+  assert.ok(Math.abs(blown.T - still.T) < 1e-12, 'wind is horizontal only')
+  const mid = posAt(blown, blown.T / 2)
+  const midStill = posAt(still, still.T / 2)
+  assert.ok(mid.x > midStill.x, 'a tailwind must visibly push it along')
+})
+
+test('outcome tiers are integer compares — 0, 1, 3 metres and out', () => {
+  const towers = [
+    { id: 0, range: 30, value: 30, alive: true },
+    { id: 1, range: 56, value: 56, alive: true },
+    { id: 2, range: 90, value: 90, alive: true },
+  ]
+  assert.equal(resolve(56, towers).quality, 'direct')
+  assert.equal(resolve(57, towers).quality, 'solid')
+  assert.equal(resolve(55, towers).quality, 'solid')
+  assert.equal(resolve(59, towers).quality, 'graze')
+  assert.equal(resolve(53, towers).quality, 'graze')
+  assert.equal(resolve(60, towers).quality, 'miss')
+  assert.equal(resolve(60, towers).target, null)
+  assert.equal(resolve(59, towers).errorM, GRAZE_M)
+  assert.equal(resolve(56, towers).target?.value, 56)
+})
+
+test('a dead keep is not a target', () => {
+  const towers = [
+    { id: 0, range: 40, value: 40, alive: false },
+    { id: 1, range: 70, value: 70, alive: true },
+  ]
+  assert.equal(resolve(40, towers).quality, 'miss')
+  assert.equal(resolve(70, towers).quality, 'direct')
+})
+
+test('being wrong is never worth more than being right', () => {
+  for (let combo = 0; combo < 12; combo++) {
+    assert.ok(shotScore('direct', combo, 0.5) > shotScore('solid', combo, 0.5))
+    assert.equal(shotScore('graze', combo, 0.5), 0)
+    assert.equal(shotScore('miss', combo, 0.5), 0)
+  }
+})
+
+test('sampled path is finite and starts at the launch height', () => {
+  const s = solve(100, 42, -7)
+  const pts = samplePath(s, 40)
+  assert.equal(pts.length, 41)
+  assert.ok(Math.abs(pts[0].y - s.h) < 1e-9)
+  for (const p of pts) {
+    assert.ok(Number.isFinite(p.x) && Number.isFinite(p.y))
+  }
+})

--- a/dynawalla/games/trebuchet/src/sim/ballistics.ts
+++ b/dynawalla/games/trebuchet/src/sim/ballistics.ts
@@ -1,0 +1,147 @@
+/**
+ * Ballistics.
+ *
+ * The honesty rule: **the dial is the range**. A shot dialled to 56 with no wind
+ * lands at exactly 56 metres — not 55.98. The float maths below shapes the arc for
+ * the eye; it never decides anything. Every outcome is decided by integer compare
+ * in `resolve()`.
+ *
+ * Solution: launch from height `h`, land on y = 0, horizontal distance R, at the
+ * chosen launch angle. Two knobs that do genuinely different jobs:
+ *   power  -> WHERE it lands   (R, integer metres)
+ *   loft   -> the SHAPE of the arc getting there (same landing, different sky)
+ * Wind is a constant horizontal acceleration sized so the landing is displaced by
+ * exactly `wind` metres — the arc visibly bends and the arithmetic stays exact.
+ */
+
+/** Heavier-than-Earth gravity: a 100 m shot flies for ~2.5 s, which is the drama window. */
+export const G = 34
+export const LAUNCH_H = 11
+
+export type Solved = {
+  R: number
+  wind: number
+  angleDeg: number
+  h: number
+  /** flight time to ground, seconds */
+  T: number
+  vx: number
+  vy: number
+  /** constant horizontal acceleration from wind */
+  ax: number
+  /** exact landing metre = R + wind */
+  landing: number
+  apexY: number
+  apexT: number
+}
+
+export function solve(R: number, angleDeg: number, wind: number, h: number = LAUNCH_H): Solved {
+  const th = (angleDeg * Math.PI) / 180
+  const tan = Math.tan(th)
+  const T = Math.sqrt((2 * (h + R * tan)) / G)
+  const vx = R / T
+  const vy = vx * tan
+  const ax = T > 0 ? (2 * wind) / (T * T) : 0
+  return {
+    R,
+    wind,
+    angleDeg,
+    h,
+    T,
+    vx,
+    vy,
+    ax,
+    landing: R + wind,
+    apexT: vy / G,
+    apexY: h + (vy * vy) / (2 * G),
+  }
+}
+
+export function posAt(s: Solved, t: number): { x: number; y: number } {
+  return {
+    x: s.vx * t + 0.5 * s.ax * t * t,
+    y: s.h + s.vy * t - 0.5 * G * t * t,
+  }
+}
+
+export function velAt(s: Solved, t: number): { vx: number; vy: number } {
+  return { vx: s.vx + s.ax * t, vy: s.vy - G * t }
+}
+
+/** Time at which the shot crosses horizontal position x (NaN if it never does). */
+export function timeAtX(s: Solved, x: number): number {
+  if (Math.abs(s.ax) < 1e-9) return x / s.vx
+  const disc = s.vx * s.vx + 2 * s.ax * x
+  if (disc < 0) return NaN
+  const root = Math.sqrt(disc)
+  const t1 = (-s.vx + root) / s.ax
+  const t2 = (-s.vx - root) / s.ax
+  const cands = [t1, t2].filter((t) => t >= 0)
+  if (!cands.length) return NaN
+  return Math.min(...cands)
+}
+
+/** Height at horizontal position x — the wall-clearance question. */
+export function heightAtX(s: Solved, x: number): number {
+  const t = timeAtX(s, x)
+  if (!Number.isFinite(t)) return -1
+  return posAt(s, t).y
+}
+
+/** Sample the arc for drawing. Cheap: closed form, no integration. */
+export function samplePath(s: Solved, n: number, until = s.T): Array<{ x: number; y: number }> {
+  const pts: Array<{ x: number; y: number }> = []
+  for (let i = 0; i <= n; i++) {
+    pts.push(posAt(s, (i / n) * until))
+  }
+  return pts
+}
+
+/* ------------------------------------------------------------------ *
+ * Outcome — integers only, no float ever reaches a comparison.
+ * ------------------------------------------------------------------ */
+
+export type HitQuality = 'direct' | 'solid' | 'graze' | 'miss'
+
+export type TargetRef = { id: number; range: number; value: number; alive: boolean }
+
+export type Outcome<T extends TargetRef = TargetRef> = {
+  landing: number
+  target: T | null
+  quality: HitQuality
+  /** |landing − target.range| in whole metres; the "how wrong" the ground shows you */
+  errorM: number
+}
+
+/** Blast reach in metres — a landing this close still shakes a tower's footings. */
+export const GRAZE_M = 3
+
+/**
+ * Where did the shot land, and what did that mean? `landing` and every `range`
+ * are integers, so `errorM` is an integer and the tiering is exact.
+ */
+export function resolve<T extends TargetRef>(landing: number, targets: readonly T[]): Outcome<T> {
+  let best: T | null = null
+  let bestErr = Number.MAX_SAFE_INTEGER
+  for (const t of targets) {
+    if (!t.alive) continue
+    const e = Math.abs(landing - t.range)
+    if (e < bestErr) {
+      bestErr = e
+      best = t
+    }
+  }
+  if (!best) return { landing, target: null, quality: 'miss', errorM: 0 }
+  const quality: HitQuality =
+    bestErr === 0 ? 'direct' : bestErr <= 1 ? 'solid' : bestErr <= GRAZE_M ? 'graze' : 'miss'
+  return { landing, target: quality === 'miss' ? null : best, quality, errorM: bestErr }
+}
+
+/** Score for a shot. Integer in, integer out. */
+export function shotScore(quality: HitQuality, combo: number, difficulty01: number): number {
+  const base = quality === 'direct' ? 120 : quality === 'solid' ? 80 : 0
+  if (base === 0) return 0
+  const diff = 1 + Math.round(difficulty01 * 4) // 1..5
+  const chain = 1 + Math.min(combo, 12) * 0.25
+  return Math.round(base * diff * chain)
+}

--- a/dynawalla/games/trebuchet/src/sim/targeting.test.ts
+++ b/dynawalla/games/trebuchet/src/sim/targeting.test.ts
@@ -1,0 +1,89 @@
+/**
+ * The rule this file defends, learned the hard way in playtest:
+ *
+ *   A shot dialled to 22 flew over the keep standing at 14 — and the collision
+ *   check caught it there, scored it against the wrong keep, and reported the
+ *   WRONG answer as CORRECT. Correct arithmetic was punished and incorrect
+ *   arithmetic was rewarded, both by geometry.
+ *
+ * So: intervening keeps are scenery. The only thing that decides a shot is the
+ * metre it comes down on, computed from integers before the boulder has moved.
+ */
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { LAUNCH_H, posAt, resolve, solve } from './ballistics.ts'
+
+const LOFTS = [30, 38, 46, 55, 65]
+const WORLD_X = (r: number): number => 6 + r
+const KEEP_HALF_W = 4.6 / 2 + 0.55
+const KEEP_TALL = 5 * 1.95 + 1.2
+
+function towers(ranges: number[]): Array<{ id: number; range: number; value: number; alive: boolean }> {
+  return ranges.map((r, i) => ({ id: i, range: r, value: r, alive: true }))
+}
+
+/** Does the arc physically pass through the box of a keep it is NOT aimed at? */
+function clipsAnInnocent(R: number, loft: number, ranges: number[]): boolean {
+  const s = solve(R, loft, 0, LAUNCH_H)
+  const out = resolve(s.landing, towers(ranges))
+  const N = 900
+  for (let i = 0; i <= N; i++) {
+    const p = posAt(s, (i / N) * s.T)
+    const wx = p.x + 6
+    for (const r of ranges) {
+      if (out.target && r === out.target.range && out.errorM <= 2) continue
+      if (Math.abs(wx - WORLD_X(r)) < KEEP_HALF_W && p.y < KEEP_TALL && p.y > 0) return true
+    }
+  }
+  return false
+}
+
+test('a shot aimed past a nearer keep is never scored against that keep', () => {
+  // the exact playtest case: keeps at 14 / 22 / 41, boulder says 22
+  const t = towers([14, 22, 41])
+  const s = solve(22, LOFTS[2], 0, LAUNCH_H)
+  const out = resolve(s.landing, t)
+  assert.equal(out.target?.range, 22)
+  assert.equal(out.quality, 'direct')
+  assert.equal(out.errorM, 0)
+})
+
+test('the outcome depends on the dial alone, not on what is standing in the way', () => {
+  const crowded = [14, 22, 30, 38, 46, 54]
+  for (const aim of crowded) {
+    for (const loft of LOFTS) {
+      const s = solve(aim, loft, 0, LAUNCH_H)
+      const out = resolve(s.landing, towers(crowded))
+      assert.equal(out.target?.range, aim, `aim=${aim} loft=${loft}`)
+      assert.equal(out.quality, 'direct')
+    }
+  }
+})
+
+test('an intervening keep can be in the way, and it still changes nothing', () => {
+  // At the minimum eight-metre spacing the descending arc genuinely does pass
+  // through the far shoulder of the keep in front of its target — the geometry
+  // does not allow otherwise. That is handled in the RENDERER (the boulder is
+  // drawn behind the keeps, so it reads as depth). What must never happen is the
+  // SIMULATION noticing: the outcome is identical whether or not anything stands
+  // in the way.
+  const field = [14, 22, 30, 38, 46, 54, 62, 70]
+  const clipping = LOFTS.some((loft) => clipsAnInnocent(38, loft, field))
+  assert.ok(clipping, 'if this ever stops being true the renderer note can be dropped')
+  const crowded = resolve(solve(38, LOFTS[2], 0, LAUNCH_H).landing, towers(field))
+  const alone = resolve(solve(38, LOFTS[2], 0, LAUNCH_H).landing, towers([38]))
+  assert.equal(crowded.target?.range, alone.target?.range)
+  assert.equal(crowded.quality, alone.quality)
+  assert.equal(crowded.errorM, alone.errorM)
+})
+
+test('a wrong dial that lands on a rival keep is scored against THAT keep', () => {
+  const t = towers([14, 22, 41])
+  const out = resolve(22, t)
+  assert.equal(out.target?.value, 22)
+  // and a keep 3 m away is a graze, not a hit
+  assert.equal(resolve(19, t).quality, 'graze')
+  assert.equal(resolve(19, t).target?.value, 22)
+})

--- a/dynawalla/games/trebuchet/src/sim/world.test.ts
+++ b/dynawalla/games/trebuchet/src/sim/world.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { makeRng } from '../core/rng.ts'
+import { createStubHost } from '../stubHost.ts'
+import { buildTower, layoutTowerValues, pullQuestions, shatter, stepBlocks, waveConfig } from './world.ts'
+
+const MIN_GAP = 8
+
+test('no two keeps can ever occupy the same ground', () => {
+  const rng = makeRng(7)
+  for (let trial = 0; trial < 400; trial++) {
+    const answers = [rng.int(14, 118)]
+    while (answers.length < 3) {
+      const v = rng.int(14, 118)
+      if (answers.every((a) => Math.abs(a - v) >= MIN_GAP)) answers.push(v)
+    }
+    const pools = answers.map((a) => [a + 4, a - 9, a + 11, a - 20])
+    const vals = layoutTowerValues(answers, pools, 3, MIN_GAP, 14, 118, rng)
+    assert.equal(vals.length, answers.length + 3)
+    for (let i = 1; i < vals.length; i++) {
+      assert.ok(vals[i] - vals[i - 1] >= MIN_GAP, `${vals[i - 1]} and ${vals[i]} overlap`)
+    }
+    for (const a of answers) assert.ok(vals.includes(a), 'every answer must have a keep to stand on')
+    for (const v of vals) assert.ok(Number.isInteger(v) && v >= 14 && v <= 118)
+  }
+})
+
+test('a wave never hands you two boulders whose keeps would overlap', () => {
+  const host = createStubHost({ seed: 31337 })
+  for (let w = 1; w <= 40; w++) {
+    const cfg = waveConfig(w)
+    host.setDifficulty(cfg.difficulty)
+    host.setDistractorCount(Math.max(2, cfg.extraTowers + 1))
+    const { boulders } = pullQuestions(() => host.next(), cfg.ammo, MIN_GAP, 14, 118)
+    assert.equal(boulders.length, cfg.ammo, `wave ${w} could not fill the rack`)
+    for (let i = 0; i < boulders.length; i++) {
+      for (let j = i + 1; j < boulders.length; j++) {
+        assert.ok(Math.abs(boulders[i].answer - boulders[j].answer) >= MIN_GAP)
+      }
+    }
+  }
+})
+
+test('escalation is monotonic where it should be and bounded everywhere', () => {
+  let prevDiff = -1
+  for (let w = 1; w <= 60; w++) {
+    const c = waveConfig(w)
+    assert.ok(c.difficulty >= prevDiff, 'difficulty never goes backwards')
+    assert.ok(c.difficulty <= 0.95)
+    prevDiff = c.difficulty
+    assert.ok(c.ammo >= 2 && c.ammo <= 6)
+    assert.ok(c.extraTowers >= 1 && c.extraTowers <= 3)
+    assert.ok(c.wind >= 0 && c.wind <= 9)
+  }
+  // the first two waves are deliberately bare: one idea at a time
+  for (const w of [1, 2]) {
+    const c = waveConfig(w)
+    assert.equal(c.wind, 0)
+    assert.equal(c.loft, false)
+    assert.equal(c.wall, false)
+    assert.equal(c.ram, false)
+    assert.equal(c.banners, true)
+  }
+  assert.ok(waveConfig(3).wind > 0, 'wind arrives at wave 3')
+  assert.equal(waveConfig(4).loft, true, 'the loft lever arrives at wave 4')
+  assert.equal(waveConfig(5).volley, true, 'every fifth wave is a volley')
+  assert.ok(waveConfig(7).ram, 'the ram arrives at wave 7')
+})
+
+test('a struck keep comes apart and then settles — no perpetual motion', () => {
+  const rng = makeRng(3)
+  const t = buildTower(0, 60, rng)
+  const before = t.blocks.length
+  const freed = shatter(t, 66, 1, 1.5, rng)
+  assert.ok(freed > 0, 'a direct hit must free blocks')
+  assert.equal(t.blocks.length, before, 'blocks are never allocated during play')
+  let steps = 0
+  while (stepBlocks(t, 1 / 60) && steps < 60 * 30) steps++
+  assert.ok(steps < 60 * 30, 'the rubble must come to rest')
+  for (const b of t.blocks) {
+    if (!b.loose) continue
+    assert.ok(b.y >= 0, 'nothing falls through the world')
+    assert.ok(Number.isFinite(b.x) && Number.isFinite(b.y))
+  }
+})
+
+test('a graze frees fewer blocks than a direct hit', () => {
+  const rng = makeRng(11)
+  const a = buildTower(0, 60, makeRng(5))
+  const b = buildTower(0, 60, makeRng(5))
+  const hard = shatter(a, 66, 1, 1.5, rng)
+  const soft = shatter(b, 63, 0.2, 0.32, rng)
+  assert.ok(hard > soft, `direct=${hard} graze=${soft}`)
+})

--- a/dynawalla/games/trebuchet/src/sim/world.ts
+++ b/dynawalla/games/trebuchet/src/sim/world.ts
@@ -1,0 +1,309 @@
+/**
+ * The siege field: what a wave is, what stands on it, and how it comes apart.
+ *
+ * The ground is exactly flat at y = 0 across the whole firing field. That is a
+ * design decision, not laziness — the plain IS the number line, and a bumpy one
+ * would put a float between the dial and the outcome.
+ */
+
+import type { Question } from '../contract.ts'
+import { type Rng } from '../core/rng.ts'
+
+/** World x of the launch point; ranges are measured from here. */
+export const LAUNCH_X = 6
+export const FIELD_MAX = 122
+export const worldX = (rangeM: number): number => LAUNCH_X + rangeM
+
+export type WaveConfig = {
+  index: number
+  difficulty: number
+  /** boulders in the rack — one question each. When the rack empties, the wave ends. */
+  ammo: number
+  /** rival keeps beyond the ones your boulders are for */
+  extraTowers: number
+  /** magnitude cap of the crosswind, 0 for none */
+  wind: number
+  /** wind rerolls between shots */
+  gusty: boolean
+  /** the loft lever is available */
+  loft: boolean
+  wall: boolean
+  ram: boolean
+  /** keeps wear their number on a banner (the choice scaffold) */
+  banners: boolean
+  /** the boss wave: pick which boulder to load */
+  volley: boolean
+}
+
+export function waveConfig(i: number): WaveConfig {
+  const boss = i % 5 === 0
+  const d = Math.min(0.95, 0.04 + (i - 1) * 0.072)
+  return {
+    index: i,
+    difficulty: d,
+    ammo: Math.min(5, 2 + Math.floor((i - 1) / 2)) + (boss ? 1 : 0),
+    extraTowers: Math.min(3, 1 + Math.floor((i - 1) / 3)),
+    wind: i < 3 ? 0 : Math.min(9, 2 + Math.floor((i - 3) / 1.6)),
+    gusty: i >= 7,
+    loft: i >= 4,
+    wall: i >= 5 && i % 3 !== 1,
+    ram: i >= 7 && i % 2 === 1,
+    banners: i < 8 ? true : i % 3 !== 0,
+    volley: boss,
+  }
+}
+
+/* ------------------------------------------------------------------ */
+
+export type Block = {
+  /** offsets from the tower base while attached; world coords once loose */
+  x: number
+  y: number
+  w: number
+  h: number
+  rot: number
+  vx: number
+  vy: number
+  spin: number
+  loose: boolean
+  settled: boolean
+  tone: number
+}
+
+export type Tower = {
+  id: number
+  /** integer metres from the launch point — and its printed value; they are the same number */
+  range: number
+  value: number
+  alive: boolean
+  /** 0..1 structural damage from grazes */
+  damage: number
+  lean: number
+  leanV: number
+  blocks: Block[]
+  heightM: number
+  widthM: number
+  /** set when a boulder's answer names this keep */
+  wanted: boolean
+  /** banner reveal animation 0..1 */
+  reveal: number
+  /** hit flash 0..1 */
+  flash: number
+}
+
+export function buildTower(id: number, range: number, rng: Rng, tall = false): Tower {
+  const rows = tall ? rng.int(5, 6) : rng.int(3, 5)
+  const w = 4.6
+  const rowH = 1.95
+  const blocks: Block[] = []
+  for (let r = 0; r < rows; r++) {
+    const inset = r >= rows - 1 ? 0.5 : 0
+    const n = r >= rows - 1 ? 1 : 2
+    for (let c = 0; c < n; c++) {
+      const bw = (w - inset * 2) / n
+      blocks.push({
+        x: -w / 2 + inset + c * bw + bw / 2,
+        y: r * rowH + rowH / 2,
+        w: bw * 0.97,
+        h: rowH * 0.94,
+        rot: 0,
+        vx: 0,
+        vy: 0,
+        spin: 0,
+        loose: false,
+        settled: false,
+        tone: rng.int(0, 2),
+      })
+    }
+  }
+  // crenellations
+  for (let k = 0; k < 3; k++) {
+    blocks.push({
+      x: -w / 2 + 0.9 + k * 1.4,
+      y: rows * rowH + 0.55,
+      w: 1.0,
+      h: 1.1,
+      rot: 0,
+      vx: 0,
+      vy: 0,
+      spin: 0,
+      loose: false,
+      settled: false,
+      tone: rng.int(0, 2),
+    })
+  }
+  return {
+    id,
+    range,
+    value: range,
+    alive: true,
+    damage: 0,
+    lean: 0,
+    leanV: 0,
+    blocks,
+    heightM: rows * rowH + 1.2,
+    widthM: w,
+    wanted: false,
+    reveal: 0,
+    flash: 0,
+  }
+}
+
+/**
+ * Knock a tower apart from an impulse origin.
+ * `freeAll` is what a kill uses: a destroyed keep must not be left standing,
+ * because a keep that is standing reads as a keep you did not destroy.
+ */
+export function shatter(
+  t: Tower,
+  originX: number,
+  originY: number,
+  power: number,
+  rng: Rng,
+  freeAll = false,
+  maxFree = Infinity,
+): number {
+  const bx = worldX(t.range)
+  let freed = 0
+  // nearest masonry first, so a glancing blow chips the face rather than
+  // teleporting the far side of the keep into the sky
+  const order = t.blocks
+    .map((b, i) => ({ b, i, d: Math.hypot(bx + b.x - originX, b.y - originY) }))
+    .sort((p, q) => p.d - q.d)
+  for (const { b } of order) {
+    if (b.loose) continue
+    if (freed >= maxFree) break
+    const wx = bx + b.x
+    const wy = b.y
+    const dx = wx - originX
+    const dy = wy - originY
+    const dist = Math.max(1.2, Math.hypot(dx, dy))
+    const f = Math.max(freeAll ? 3.2 : 0, (power * 26) / (dist * dist))
+    if (!freeAll && f < 0.7 && rng.next() > 0.45) continue
+    b.loose = true
+    freed++
+    const m = Math.hypot(dx, dy) || 1
+    b.x = wx
+    b.y = wy
+    b.vx = (dx / m) * f * rng.range(0.7, 1.35) + rng.range(-1.5, 3.5)
+    b.vy = (dy / m) * f * rng.range(0.8, 1.5) + rng.range(2, 9)
+    b.spin = rng.range(-7, 7)
+  }
+  return freed
+}
+
+const BLOCK_G = 26
+
+export function stepBlocks(t: Tower, dt: number): boolean {
+  let moving = false
+  for (const b of t.blocks) {
+    if (!b.loose || b.settled) continue
+    b.vy -= BLOCK_G * dt
+    b.x += b.vx * dt
+    b.y += b.vy * dt
+    b.rot += b.spin * dt
+    if (b.y - b.h * 0.5 <= 0) {
+      b.y = b.h * 0.5
+      if (Math.abs(b.vy) < 2.2) {
+        b.vy = 0
+        b.vx *= 0.55
+        b.spin *= 0.5
+        if (Math.abs(b.vx) < 0.5 && Math.abs(b.spin) < 0.6) {
+          b.settled = true
+          b.vx = 0
+          b.spin = 0
+          // lie flat where it fell
+          b.rot = Math.round(b.rot / (Math.PI / 2)) * (Math.PI / 2)
+        }
+      } else {
+        b.vy = -b.vy * 0.28
+        b.vx *= 0.7
+        b.spin *= 0.7
+      }
+    }
+    moving = true
+  }
+  // the stump leans and rights itself
+  if (t.lean !== 0 || t.leanV !== 0) {
+    t.leanV += -t.lean * 24 * dt
+    t.leanV *= Math.exp(-4.5 * dt)
+    t.lean += t.leanV * dt
+    if (Math.abs(t.lean) < 0.002 && Math.abs(t.leanV) < 0.01) {
+      t.lean = 0
+      t.leanV = 0
+    } else moving = true
+  }
+  return moving
+}
+
+/* ------------------------------------------------------------------ */
+
+export type Crater = { x: number; r: number; depth: number; age: number; label: number; correct: boolean }
+
+export type Ghost = { pts: Array<{ x: number; y: number }>; landing: number; age: number; hit: boolean }
+
+/** A battering ram: pure pressure. No number on it — read the ground to lead it. */
+export type Ram = {
+  /** metres from the launch point, decreasing */
+  range: number
+  speed: number
+  alive: boolean
+  wheel: number
+  hp: number
+  bob: number
+}
+
+/**
+ * Lay out the keeps. Every value must be an integer, inside the field, and at
+ * least `minGap` from every other, or two keeps would occupy the same ground.
+ */
+export function layoutTowerValues(
+  answers: number[],
+  pools: number[][],
+  extra: number,
+  minGap: number,
+  lo: number,
+  hi: number,
+  rng: Rng,
+): number[] {
+  const chosen = answers.slice()
+  const ok = (v: number): boolean =>
+    Number.isInteger(v) && v >= lo && v <= hi && chosen.every((c) => Math.abs(v - c) >= minGap)
+  const flat: number[] = []
+  const maxLen = Math.max(0, ...pools.map((p) => p.length))
+  for (let i = 0; i < maxLen; i++) for (const p of pools) if (i < p.length) flat.push(p[i])
+  for (const v of flat) {
+    if (chosen.length >= answers.length + extra) break
+    if (ok(v)) chosen.push(v)
+  }
+  let guard = 0
+  while (chosen.length < answers.length + extra && guard++ < 500) {
+    const v = rng.int(lo, hi)
+    if (ok(v)) chosen.push(v)
+  }
+  return chosen.sort((a, b) => a - b)
+}
+
+export type Boulder = { q: Question; answer: number; spent: boolean; hit: boolean }
+
+/** Pull `n` questions whose answers can all stand apart on the same field. */
+export function pullQuestions(
+  next: () => Question,
+  n: number,
+  minGap: number,
+  lo: number,
+  hi: number,
+): { boulders: Boulder[]; pools: number[][] } {
+  const boulders: Boulder[] = []
+  const pools: number[][] = []
+  let guard = 0
+  while (boulders.length < n && guard++ < 200) {
+    const q = next()
+    const a = Number(q.answer)
+    if (!Number.isInteger(a) || a < lo || a > hi) continue
+    if (boulders.some((b) => Math.abs(b.answer - a) < minGap)) continue
+    boulders.push({ q, answer: a, spent: false, hit: false })
+    pools.push(q.distractors.map(Number).filter(Number.isInteger))
+  }
+  return { boulders, pools }
+}

--- a/dynawalla/games/trebuchet/src/stubHost.test.ts
+++ b/dynawalla/games/trebuchet/src/stubHost.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { ANSWER_MAX, ANSWER_MIN, MIN_GAP, createStubHost, spreadDistractors } from './stubHost.ts'
+import { makeRng } from './core/rng.ts'
+
+/** Evaluate the prompt independently of the generator that produced it. */
+function evaluatePrompt(p: string): number {
+  const m = /^(\d+)\s*([+−×÷])\s*(\d+)$/.exec(p)
+  assert.ok(m, `unparseable prompt: ${p}`)
+  const a = Number(m[1])
+  const b = Number(m[3])
+  switch (m[2]) {
+    case '+':
+      return a + b
+    case '−':
+      return a - b
+    case '×':
+      return a * b
+    case '÷':
+      assert.equal(a % b, 0, `${p} is not exact`)
+      return a / b
+  }
+  throw new Error('unreachable')
+}
+
+test('every question the host hands out is arithmetically true', () => {
+  const h = createStubHost({ seed: 12345 })
+  for (let d = 0; d <= 1.0001; d += 0.1) {
+    h.setDifficulty(d)
+    for (let i = 0; i < 300; i++) {
+      const q = h.next()
+      assert.equal(Number(q.answer), evaluatePrompt(q.prompt), q.prompt)
+      assert.ok(Number.isInteger(Number(q.answer)))
+    }
+  }
+})
+
+test('answers always fit the field', () => {
+  const h = createStubHost({ seed: 777 })
+  for (let d = 0; d <= 1.0001; d += 0.05) {
+    h.setDifficulty(d)
+    for (let i = 0; i < 200; i++) {
+      const a = Number(h.next().answer)
+      assert.ok(a >= ANSWER_MIN && a <= ANSWER_MAX, `answer ${a} off the field`)
+    }
+  }
+})
+
+test('distractors are integers, separated, in range, and never the answer', () => {
+  const h = createStubHost({ seed: 4242 })
+  for (const k of [1, 2, 3, 4, 5]) {
+    h.setDistractorCount(k)
+    for (let d = 0; d <= 1.0001; d += 0.2) {
+      h.setDifficulty(d)
+      for (let i = 0; i < 150; i++) {
+        const q = h.next()
+        const a = Number(q.answer)
+        assert.equal(q.distractors.length, k)
+        const vals = q.distractors.map(Number)
+        for (const v of vals) {
+          assert.ok(Number.isInteger(v), `${v} not an integer`)
+          assert.ok(v >= ANSWER_MIN && v <= ANSWER_MAX, `${v} off the field`)
+          assert.ok(Math.abs(v - a) >= MIN_GAP, `${v} too close to ${a}`)
+        }
+        for (let x = 0; x < vals.length; x++) {
+          for (let y = x + 1; y < vals.length; y++) {
+            assert.ok(Math.abs(vals[x] - vals[y]) >= MIN_GAP, `${vals[x]} and ${vals[y]} would overlap`)
+          }
+        }
+      }
+    }
+  }
+})
+
+test('the same seed plays the same siege, every time', () => {
+  const a = createStubHost({ seed: 999 })
+  const b = createStubHost({ seed: 999 })
+  for (let i = 0; i < 200; i++) {
+    const qa = a.next()
+    const qb = b.next()
+    assert.equal(qa.prompt, qb.prompt)
+    assert.equal(qa.answer, qb.answer)
+    assert.deepEqual(qa.distractors, qb.distractors)
+  }
+  const c = createStubHost({ seed: 1000 })
+  assert.notEqual(c.next().prompt + c.next().prompt, (() => {
+    const d = createStubHost({ seed: 999 })
+    return d.next().prompt + d.next().prompt
+  })())
+})
+
+test('mal-rule distractors are preferred when they are legal', () => {
+  // 7 x 8 = 56. Legal mal-rules: 49 (one group short), 63 (one group long),
+  // 15 (added instead), 65 (digits reversed). 54 is only 2 away, so its keep would
+  // stand inside the target's keep — it has to be dropped however good an error it is.
+  const rng = makeRng(1)
+  const legal = [49, 63, 15, 65]
+  for (let seed = 1; seed < 40; seed++) {
+    const picked = spreadDistractors(56, [49, 63, 54, 15, 65], 2, makeRng(seed))
+    assert.equal(picked.length, 2)
+    for (const p of picked) assert.ok(legal.includes(p), `unexpected ${p}`)
+    assert.ok(!picked.includes(54), '54 is 2 away and would overlap the target')
+  }
+  void rng
+})
+
+test('reports carry through to the caller', () => {
+  const seen: string[] = []
+  const h = createStubHost({ seed: 5, onReport: (r) => seen.push(`${r.questionId}:${r.correct}`) })
+  const q = h.next()
+  h.report({ questionId: q.id, correct: true, ms: 1200, answered: q.answer })
+  assert.deepEqual(seen, [`${q.id}:true`])
+  assert.equal(h.reports.length, 1)
+})

--- a/dynawalla/games/trebuchet/src/stubHost.ts
+++ b/dynawalla/games/trebuchet/src/stubHost.ts
@@ -1,0 +1,229 @@
+/**
+ * Local stub Host. Seeded, deterministic, exact integer arithmetic only.
+ *
+ * It exists so the game is playable standalone with `npm run dev`. The real
+ * curriculum will replace it wholesale; nothing outside this file knows it exists.
+ *
+ * Distractors are real mal-rule outputs — the errors a child actually makes —
+ * because in this game a distractor is a place on the ground, and landing there
+ * has to mean something.
+ */
+
+import type { Host, Question } from './contract.ts'
+import { makeRng, shuffled, type Rng } from './core/rng.ts'
+
+/** Towers stand at their own value in metres, so answers must fit the field. */
+export const ANSWER_MIN = 14
+export const ANSWER_MAX = 118
+/** Two towers closer than this would overlap on screen. */
+export const MIN_GAP = 8
+
+export type Report = { questionId: string; correct: boolean; ms: number; answered: string }
+
+type Cand = { prompt: string; answer: number; mal: number[]; domain: string }
+
+const uniqInt = (xs: number[]): number[] => Array.from(new Set(xs))
+
+function reverseDigits(n: number): number {
+  const s = String(n)
+  if (s.length < 2) return -1
+  const r = Number(s.split('').reverse().join(''))
+  return r === n ? -1 : r
+}
+
+/** a + b with the errors that actually happen: dropped carry, carry twice, off-by-ten. */
+function genAdd(rng: Rng, d: number): Cand {
+  const hi = d < 0.3 ? 12 : d < 0.6 ? 29 : 58
+  const lo = d < 0.3 ? 4 : d < 0.6 ? 8 : 14
+  let a = rng.int(lo, hi)
+  let b = rng.int(lo, hi)
+  if (a + b < ANSWER_MIN) b += ANSWER_MIN - (a + b)
+  if (a + b > ANSWER_MAX) a -= a + b - ANSWER_MAX
+  const answer = a + b
+  const droppedCarry = (a % 10) + (b % 10) >= 10 ? answer - 10 : answer + 10
+  const mal = uniqInt([
+    droppedCarry,
+    answer + 10,
+    answer - 10,
+    answer + 9,
+    answer + b, // counted the second addend twice
+    reverseDigits(answer),
+  ])
+  return { prompt: `${a} + ${b}`, answer, mal, domain: 'add-sub' }
+}
+
+/** a − b. The great mal-rule: subtract the smaller digit from the larger, per column. */
+function genSub(rng: Rng, d: number): Cand {
+  const hi = d < 0.3 ? 40 : d < 0.6 ? 78 : 130
+  let a = rng.int(ANSWER_MIN + 8, hi)
+  let b = rng.int(3, Math.max(4, Math.floor(a / 2)))
+  if (a - b < ANSWER_MIN) b = a - ANSWER_MIN
+  if (a - b > ANSWER_MAX) a = ANSWER_MAX + b
+  const answer = a - b
+  // smaller-from-larger, column by column
+  let sml = 0
+  let place = 1
+  for (let x = a, y = b; x > 0 || y > 0; x = Math.floor(x / 10), y = Math.floor(y / 10)) {
+    sml += Math.abs((x % 10) - (y % 10)) * place
+    place *= 10
+  }
+  const mal = uniqInt([
+    sml,
+    answer + 10, // forgot to decrement the borrowed column
+    answer - 10,
+    answer + 1,
+    answer - 1,
+    reverseDigits(answer),
+  ])
+  return { prompt: `${a} − ${b}`, answer, mal, domain: 'add-sub' }
+}
+
+/** a × b. Off-by-one-group is the error worth making visible on the ground. */
+function genMul(rng: Rng, d: number): Cand {
+  const table = d < 0.35 ? rng.int(2, 6) : d < 0.7 ? rng.int(3, 9) : rng.int(6, 12)
+  const other = d < 0.35 ? rng.int(3, 9) : d < 0.7 ? rng.int(4, 11) : rng.int(5, 12)
+  let a = table
+  let b = other
+  if (a * b < ANSWER_MIN) b = Math.ceil(ANSWER_MIN / a)
+  if (a * b > ANSWER_MAX) b = Math.floor(ANSWER_MAX / a)
+  const answer = a * b
+  const mal = uniqInt([
+    answer - a, // one group short
+    answer + a, // one group long
+    answer - b,
+    answer + b,
+    a + b, // added instead
+    reverseDigits(answer),
+  ])
+  return { prompt: `${a} × ${b}`, answer, mal, domain: 'mul-div' }
+}
+
+/** a ÷ b, always exact. */
+function genDiv(rng: Rng, d: number): Cand {
+  const b = d < 0.75 ? rng.int(2, 6) : rng.int(3, 9)
+  const answer = d < 0.75 ? rng.int(ANSWER_MIN, 28) : rng.int(ANSWER_MIN, 44)
+  const a = answer * b
+  const mal = uniqInt([answer + 1, answer - 1, answer + b, answer - b, a - b, reverseDigits(answer)])
+  return { prompt: `${a} ÷ ${b}`, answer, mal, domain: 'mul-div' }
+}
+
+/**
+ * Pick `count` distractors: prefer real mal-rules, keep them legal and separable,
+ * then fill with plausible near-magnitudes. Every value is an integer.
+ */
+export function spreadDistractors(answer: number, mal: number[], count: number, rng: Rng): number[] {
+  const ok = (v: number, chosen: number[]): boolean =>
+    Number.isInteger(v) &&
+    v >= ANSWER_MIN &&
+    v <= ANSWER_MAX &&
+    Math.abs(v - answer) >= MIN_GAP &&
+    chosen.every((c) => Math.abs(v - c) >= MIN_GAP)
+
+  const chosen: number[] = []
+  for (const m of shuffled(mal, rng)) {
+    if (chosen.length >= count) break
+    if (ok(m, chosen)) chosen.push(m)
+  }
+  // Fillers: still plausible magnitudes, just not mal-rule derived.
+  let guard = 0
+  while (chosen.length < count && guard++ < 400) {
+    const sign = rng.chance(0.5) ? 1 : -1
+    const step = MIN_GAP + rng.int(0, 14)
+    const v = answer + sign * step
+    if (ok(v, chosen)) chosen.push(v)
+  }
+  while (chosen.length < count) {
+    // Last resort — walk the field for any legal slot. Deterministic.
+    for (let v = ANSWER_MIN; v <= ANSWER_MAX && chosen.length < count; v++) {
+      if (ok(v, chosen)) chosen.push(v)
+    }
+  }
+  return chosen
+}
+
+export type StubOptions = {
+  seed?: number
+  /** how many distractors each question must carry (one per rival tower) */
+  distractorCount?: number
+  /** 0..1 — the wave sets this before pulling */
+  difficulty?: number
+  haptics?: (kind: 'light' | 'medium' | 'heavy' | 'success' | 'failure') => void
+  onReport?: (r: Report) => void
+}
+
+export type StubHost = Host & {
+  setDifficulty(d: number): void
+  setDistractorCount(n: number): void
+  readonly reports: Report[]
+}
+
+export function createStubHost(opts: StubOptions = {}): StubHost {
+  const rng = makeRng(opts.seed ?? 0x5eed1e)
+  let difficulty = opts.difficulty ?? 0
+  let distractorCount = opts.distractorCount ?? 2
+  let n = 0
+  const reports: Report[] = []
+
+  const reducedMotion = (): boolean =>
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+  return {
+    reports,
+    setDifficulty(d) {
+      difficulty = Math.max(0, Math.min(1, d))
+    },
+    setDistractorCount(k) {
+      distractorCount = Math.max(1, Math.min(5, Math.round(k)))
+    },
+    next(): Question {
+      const d = difficulty
+      const weights: Array<[() => Cand, number]> = [
+        [() => genAdd(rng, d), d < 0.25 ? 5 : 2],
+        [() => genSub(rng, d), d < 0.15 ? 2 : 3],
+        [() => genMul(rng, d), d < 0.3 ? 0 : 4],
+        [() => genDiv(rng, d), d < 0.55 ? 0 : 2],
+      ]
+      const total = weights.reduce((s, w) => s + w[1], 0)
+      let r = rng.next() * total
+      let cand: Cand = weights[0][0]()
+      for (const [make, w] of weights) {
+        r -= w
+        if (r <= 0) {
+          cand = make()
+          break
+        }
+      }
+      // Safety net: the field is the answer space, so an answer must fit in it.
+      if (cand.answer < ANSWER_MIN || cand.answer > ANSWER_MAX) cand = genAdd(rng, 0.2)
+      const distractors = spreadDistractors(cand.answer, cand.mal, distractorCount, rng)
+      n += 1
+      return {
+        id: `q${n}-${cand.answer}`,
+        prompt: cand.prompt,
+        answer: String(cand.answer),
+        distractors: distractors.map(String),
+        domain: cand.domain,
+        difficulty: d,
+      }
+    },
+    report(r) {
+      reports.push(r)
+      opts.onReport?.(r)
+    },
+    haptic(kind) {
+      opts.haptics?.(kind)
+      if (typeof navigator !== 'undefined' && typeof navigator.vibrate === 'function') {
+        const ms =
+          kind === 'light' ? 8 : kind === 'medium' ? 18 : kind === 'heavy' ? 42 : kind === 'success' ? 26 : 34
+        try {
+          navigator.vibrate(kind === 'success' ? [16, 40, 26] : kind === 'failure' ? [30, 60, 30] : ms)
+        } catch {
+          /* haptics are a garnish; never let them throw into the frame */
+        }
+      }
+    },
+    prefersReducedMotion: reducedMotion,
+  }
+}

--- a/dynawalla/games/trebuchet/tsconfig.json
+++ b/dynawalla/games/trebuchet/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "types": ["node"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": false,
+    "exactOptionalPropertyTypes": false,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": false,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/dynawalla/games/trebuchet/vite.config.ts
+++ b/dynawalla/games/trebuchet/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  server: { port: 4173, strictPort: false },
+  build: {
+    target: 'es2022',
+    lib: {
+      entry: 'src/index.ts',
+      name: 'DynawallaTrebuchet',
+      formats: ['es'],
+      fileName: 'trebuchet',
+    },
+    rollupOptions: { output: { inlineDynamicImports: true } },
+  },
+})


### PR DESCRIPTION
## What

Commit `dynawalla/games/trebuchet` — COUNTERPOISE, a brass trebuchet where the scale physically is the equals sign.

## Why

This prototype existed **only as untracked files in a worktree**. It appeared in
zero git refs: `git log --all -- dynawalla/games/trebuchet` returned no commits. It was
never committed, never branched, never pushed. Pruning that worktree — which the
repo's own session hook recommends doing after a merge — would have destroyed it
with no reflog and no dangling object to recover from.

Ten sibling prototypes were in the same state. This PR is one of that set.

## Blast radius

**Areas touched:** dynawalla (new directory only)

- [x] Additive only. Every path is new under `dynawalla/games/trebuchet/`; no existing
      file is modified or deleted. Nothing imports it yet.
- [ ] **Every touched path is covered by a `ci.yml` area filter** — **NO, and
      stated deliberately.** `dynawalla/games/` is absent from the `covered`
      regex (`ci.yml:226`), so the `uncovered` step will warn. This is
      pre-existing: the five games already on `main` have no CI either. No job
      builds, type-checks or tests any game. The gates below were therefore run
      locally, by hand. A games-area filter is the correct follow-up and is
      called out rather than silently bundled here.
- [x] **Pack back-compat.** No published pack zip, `voiceId` or catalog entry
      touched. App floor 0.20.6 unaffected.
- [x] **Native integrity.** No Rust, no `src-tauri`, no `links =`, no `[patch]`.
- [x] **Strings.** No `corpan-app` locale keys added; this pack does not use the
      Corpán i18n catalog.
- [x] **Curriculum.** No skill id renamed or reused, no grade metadata changed,
      no generator binding altered.
- [x] **Secrets.** No `.p8`, keystore, service-account JSON, issuer id, key id or
      token. Verified the diff is source, config and `index.html` only.

`package-lock.json` and `qa/shots` are gitignored, matching
`dynawalla/games/slice` and `.../siege`.

## Proof

Run in `dynawalla/games/trebuchet/` after `npm install`:

```
$ npm test
# tests 30 # pass 30 # fail 0 

$ npm run tsc          # tsc --noEmit
0 errors

$ npm run build
✓ built in 25ms
```

Scope check — the branch adds this game and nothing else:

```
$ git diff --name-only origin/main...HEAD | grep -cv '^dynawalla/games/trebuchet/'
0
$ git diff --diff-filter=D --name-only origin/main...HEAD | wc -l
0
```
