### PR TITLE
dynawalla/games/horde: DEEPSWARM — a horde survivor whose weapon table is bought with arithmetic

### DIFF
--- a/dynawalla/games/horde/.gitignore
+++ b/dynawalla/games/horde/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+dist-pack/
+
+# Playtest capture output: multi-MB PNGs, regenerated on demand.
+qa/shots
+qa/tmp
+
+# Not tracked, matching dynawalla/games/slice and .../merge. These prototypes
+# pin nothing beyond vite + typescript in devDependencies.
+package-lock.json

--- a/dynawalla/games/horde/index.html
+++ b/dynawalla/games/horde/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1, user-scalable=no"
+    />
+    <meta name="theme-color" content="#04060f" />
+    <title>DEEPSWARM</title>
+    <style>
+      html, body { margin: 0; height: 100%; background: #04060f; overflow: hidden; }
+      #app { position: fixed; inset: 0; }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/horde/package.json
+++ b/dynawalla/games/horde/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@dynawalla/game-horde",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "DEEPSWARM — a bioluminescent horde-survivor. Move; the swarm comes; the light wins.",
+  "main": "src/index.ts",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4179 --strictPort",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test src/**/*.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "typescript": "~6.0.3",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/games/horde/src/contract.ts
+++ b/dynawalla/games/horde/src/contract.ts
@@ -1,0 +1,14 @@
+export type Question = { id: string; prompt: string; answer: string; distractors: string[]; domain: string; difficulty: number }
+export type Host = {
+  next(opts?: { domain?: string; difficulty?: number }): Question
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+  haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void
+  prefersReducedMotion(): boolean
+}
+export function mount(el: HTMLElement, host: Host): { unmount(): void } {
+  // Real implementation lives in ./index.ts — this file exists so the contract
+  // shape is checked in isolation and stays byte-identical across every game.
+  void el
+  void host
+  throw new Error("horde: import mount from './index.ts'")
+}

--- a/dynawalla/games/horde/src/core/audio.ts
+++ b/dynawalla/games/horde/src/core/audio.ts
@@ -1,0 +1,370 @@
+/**
+ * Every sound is synthesized at runtime. There are no audio files.
+ *
+ * Three constraints shape the whole kit:
+ *  1. **Transient / body / tail.** A sound with only a body is a beep, and a
+ *     child hears four hundred of these a minute.
+ *  2. **Pitch variation on every voice.** The single fastest way to make a
+ *     game unbearable is a hit sound that is byte-identical 8000 times.
+ *  3. **Voice limiting.** A horde survivor kills 40 things in a second. An
+ *     unlimited kit produces a wall of mud and blows the audio thread.
+ *
+ * Sound never carries information alone — every cue here has a visual twin.
+ */
+
+type Voice =
+  | "hit" | "kill" | "killBig" | "pickup" | "levelup" | "card"
+  | "coreOpen" | "answerRight" | "answerWrong" | "overcharge" | "nova"
+  | "hurt" | "death" | "riftOpen" | "revive" | "tick" | "warn" | "evolve"
+
+const PENT = [0, 2, 4, 7, 9]
+
+export class Audio {
+  private ctx: AudioContext | null = null
+  private master!: GainNode
+  private bus!: DynamicsCompressorNode
+  private noise!: AudioBuffer
+  private padGain!: GainNode
+  private padFilter!: BiquadFilterNode
+  private padOscs: OscillatorNode[] = []
+  private frameVoices = 0
+  private lastAt: Partial<Record<Voice, number>> = {}
+  enabled = true
+  private started = false
+  private pickupStep = 0
+
+  /** Must be called from a user gesture on iOS; safe to call repeatedly. */
+  async init(): Promise<void> {
+    if (this.ctx) {
+      if (this.ctx.state === "suspended") await this.ctx.resume().catch(() => {})
+      return
+    }
+    const Ctor: typeof AudioContext =
+      window.AudioContext ?? (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
+    if (!Ctor) return
+    const ctx = new Ctor({ latencyHint: "interactive" })
+    this.ctx = ctx
+
+    this.bus = ctx.createDynamicsCompressor()
+    this.bus.threshold.value = -18
+    this.bus.knee.value = 24
+    this.bus.ratio.value = 8
+    this.bus.attack.value = 0.003
+    this.bus.release.value = 0.16
+
+    this.master = ctx.createGain()
+    this.master.gain.value = 0.62
+    this.bus.connect(this.master)
+    this.master.connect(ctx.destination)
+
+    // One reusable noise table — allocating a buffer per shot is a stutter.
+    const n = ctx.createBuffer(1, ctx.sampleRate * 0.5, ctx.sampleRate)
+    const d = n.getChannelData(0)
+    let s = 0
+    for (let i = 0; i < d.length; i++) {
+      s = s * 0.86 + (Math.random() * 2 - 1) * 0.42
+      d[i] = s
+    }
+    this.noise = n
+
+    this.buildPad()
+    if (ctx.state === "suspended") await ctx.resume().catch(() => {})
+  }
+
+  private buildPad(): void {
+    const ctx = this.ctx!
+    this.padFilter = ctx.createBiquadFilter()
+    this.padFilter.type = "lowpass"
+    this.padFilter.frequency.value = 260
+    this.padFilter.Q.value = 1.4
+    this.padGain = ctx.createGain()
+    this.padGain.gain.value = 0
+    this.padFilter.connect(this.padGain)
+    this.padGain.connect(this.bus)
+
+    // A slowly beating drone: the abyss has a pulse.
+    for (const [f, det, type] of [
+      [55, 0, "sawtooth"], [55.4, 0, "sawtooth"], [82.5, 0, "triangle"], [110, 6, "sine"],
+    ] as [number, number, OscillatorType][]) {
+      const o = ctx.createOscillator()
+      o.type = type
+      o.frequency.value = f
+      o.detune.value = det
+      const g = ctx.createGain()
+      g.gain.value = 0.24
+      o.connect(g)
+      g.connect(this.padFilter)
+      // Slow independent drift keeps it from ever locking into a beat.
+      const lfo = ctx.createOscillator()
+      lfo.type = "sine"
+      lfo.frequency.value = 0.031 + Math.random() * 0.06
+      const la = ctx.createGain()
+      la.gain.value = 3.2
+      lfo.connect(la)
+      la.connect(o.detune)
+      lfo.start()
+      o.start()
+      this.padOscs.push(o, lfo)
+    }
+  }
+
+  /** 0..1 — how deep the run has gone. Opens the filter and lifts the bed. */
+  setIntensity(v: number): void {
+    if (!this.ctx || !this.enabled) return
+    const t = this.ctx.currentTime
+    this.padGain.gain.setTargetAtTime(0.05 + v * 0.11, t, 1.2)
+    this.padFilter.frequency.setTargetAtTime(220 + v * 900, t, 1.6)
+  }
+
+  /** Ducks the bed hard — used for the level-up freeze and the Rift. */
+  duck(amount: number, seconds = 0.25): void {
+    if (!this.ctx) return
+    const t = this.ctx.currentTime
+    this.master.gain.cancelScheduledValues(t)
+    this.master.gain.setTargetAtTime(0.62 * amount, t, 0.05)
+    this.master.gain.setTargetAtTime(0.62, t + seconds, 0.22)
+  }
+
+  frame(): void {
+    this.frameVoices = 0
+  }
+
+  setEnabled(on: boolean): void {
+    this.enabled = on
+    if (this.ctx) this.master.gain.setTargetAtTime(on ? 0.62 : 0, this.ctx.currentTime, 0.05)
+  }
+
+  private gate(v: Voice, budget: number, minGapMs: number): boolean {
+    if (!this.ctx || !this.enabled) return false
+    if (!this.started) return false
+    if (this.frameVoices >= budget) return false
+    const now = performance.now()
+    const last = this.lastAt[v] ?? -1e9
+    if (now - last < minGapMs) return false
+    this.lastAt[v] = now
+    this.frameVoices++
+    return true
+  }
+
+  markStarted(): void {
+    this.started = true
+  }
+
+  /* ------------------------------------------------------------ builders */
+
+  private env(g: GainNode, t: number, a: number, d: number, peak: number, sustain = 0, hold = 0): void {
+    g.gain.setValueAtTime(0.0001, t)
+    g.gain.exponentialRampToValueAtTime(Math.max(0.0002, peak), t + a)
+    if (hold > 0 && sustain > 0) {
+      g.gain.exponentialRampToValueAtTime(Math.max(0.0002, sustain), t + a + d * 0.35)
+      g.gain.setValueAtTime(Math.max(0.0002, sustain), t + a + d * 0.35 + hold)
+      g.gain.exponentialRampToValueAtTime(0.0001, t + a + d + hold)
+    } else {
+      g.gain.exponentialRampToValueAtTime(0.0001, t + a + d)
+    }
+  }
+
+  private tone(
+    t: number, type: OscillatorType, f0: number, f1: number,
+    a: number, d: number, peak: number, dest?: AudioNode,
+  ): void {
+    const ctx = this.ctx!
+    const o = ctx.createOscillator()
+    o.type = type
+    o.frequency.setValueAtTime(f0, t)
+    if (f1 !== f0) o.frequency.exponentialRampToValueAtTime(Math.max(1, f1), t + a + d)
+    const g = ctx.createGain()
+    this.env(g, t, a, d, peak)
+    o.connect(g)
+    g.connect(dest ?? this.bus)
+    o.start(t)
+    o.stop(t + a + d + 0.03)
+  }
+
+  private burst(
+    t: number, type: BiquadFilterType, f0: number, f1: number,
+    a: number, d: number, peak: number, q = 1,
+  ): void {
+    const ctx = this.ctx!
+    const src = ctx.createBufferSource()
+    src.buffer = this.noise
+    src.playbackRate.value = 0.7 + Math.random() * 0.7
+    const bq = ctx.createBiquadFilter()
+    bq.type = type
+    bq.Q.value = q
+    bq.frequency.setValueAtTime(f0, t)
+    if (f1 !== f0) bq.frequency.exponentialRampToValueAtTime(Math.max(40, f1), t + a + d)
+    const g = ctx.createGain()
+    this.env(g, t, a, d, peak)
+    src.connect(bq)
+    bq.connect(g)
+    g.connect(this.bus)
+    src.start(t, Math.random() * 0.2)
+    src.stop(t + a + d + 0.03)
+  }
+
+  /* -------------------------------------------------------------- voices */
+
+  hit(): void {
+    if (!this.gate("hit", 5, 14)) return
+    const t = this.ctx!.currentTime
+    const p = 1 + (Math.random() - 0.5) * 0.5
+    this.burst(t, "highpass", 2200 * p, 900 * p, 0.001, 0.035, 0.055)
+    this.tone(t, "triangle", 720 * p, 380 * p, 0.001, 0.045, 0.045)
+  }
+
+  kill(): void {
+    if (!this.gate("kill", 6, 11)) return
+    const t = this.ctx!.currentTime
+    const p = 0.82 + Math.random() * 0.5
+    this.burst(t, "bandpass", 1500 * p, 380 * p, 0.001, 0.07, 0.075, 1.4)
+    this.tone(t, "sine", 300 * p, 96 * p, 0.001, 0.085, 0.06)
+  }
+
+  killBig(): void {
+    if (!this.gate("killBig", 8, 60)) return
+    const t = this.ctx!.currentTime
+    const p = 0.9 + Math.random() * 0.25
+    this.burst(t, "lowpass", 2400, 180, 0.002, 0.34, 0.2, 0.8)
+    this.tone(t, "sine", 150 * p, 42, 0.003, 0.5, 0.3)
+    this.tone(t, "triangle", 420 * p, 210 * p, 0.004, 0.34, 0.09)
+    this.tone(t, "sine", 1260 * p, 1180 * p, 0.004, 0.7, 0.05)
+  }
+
+  pickup(): void {
+    if (!this.gate("pickup", 4, 26)) return
+    const t = this.ctx!.currentTime
+    // Wanders up and down a pentatonic ladder: musical, never a streak signal.
+    this.pickupStep = (this.pickupStep + 1) % 12
+    const oct = Math.floor(this.pickupStep / PENT.length)
+    const semis = PENT[this.pickupStep % PENT.length] + oct * 12
+    const f = 660 * Math.pow(2, semis / 12)
+    this.tone(t, "triangle", f, f, 0.001, 0.075, 0.05)
+    this.tone(t, "sine", f * 2, f * 2, 0.001, 0.05, 0.022)
+  }
+
+  levelup(): void {
+    if (!this.gate("levelup", 12, 200)) return
+    const t = this.ctx!.currentTime
+    ;[0, 4, 7, 12, 16].forEach((s, i) => {
+      const f = 330 * Math.pow(2, s / 12)
+      this.tone(t + i * 0.045, "triangle", f, f, 0.006, 0.55, 0.075)
+    })
+    this.burst(t, "highpass", 600, 6000, 0.02, 0.5, 0.05)
+    this.tone(t, "sine", 90, 55, 0.004, 0.45, 0.2)
+  }
+
+  card(): void {
+    if (!this.gate("card", 8, 40)) return
+    const t = this.ctx!.currentTime
+    this.burst(t, "bandpass", 1800, 700, 0.001, 0.06, 0.1, 2.4)
+    this.tone(t, "square", 180, 130, 0.001, 0.07, 0.035)
+  }
+
+  tick(): void {
+    if (!this.gate("tick", 4, 30)) return
+    const t = this.ctx!.currentTime
+    this.burst(t, "highpass", 4200, 3000, 0.0008, 0.02, 0.03)
+  }
+
+  warn(): void {
+    if (!this.gate("warn", 10, 220)) return
+    const t = this.ctx!.currentTime
+    this.tone(t, "sawtooth", 132, 118, 0.02, 0.42, 0.055)
+    this.tone(t, "sine", 66, 58, 0.02, 0.5, 0.1)
+  }
+
+  coreOpen(): void {
+    if (!this.gate("coreOpen", 12, 400)) return
+    const t = this.ctx!.currentTime
+    this.tone(t, "sine", 55, 110, 0.35, 0.9, 0.16)
+    this.tone(t, "triangle", 440, 660, 0.3, 1.0, 0.05)
+    this.burst(t, "bandpass", 400, 3200, 0.4, 0.9, 0.045, 3)
+  }
+
+  answerRight(): void {
+    if (!this.gate("answerRight", 16, 120)) return
+    const t = this.ctx!.currentTime
+    ;[0, 7, 12, 19, 24].forEach((s, i) => {
+      const f = 392 * Math.pow(2, s / 12)
+      this.tone(t + i * 0.03, "triangle", f, f, 0.004, 0.6, 0.085)
+    })
+    this.tone(t, "sine", 110, 220, 0.01, 0.5, 0.22)
+    this.burst(t, "highpass", 900, 9000, 0.006, 0.42, 0.07)
+  }
+
+  answerWrong(): void {
+    if (!this.gate("answerWrong", 12, 120)) return
+    const t = this.ctx!.currentTime
+    // Dull and physical, never a buzzer. Being wrong is not the loud moment.
+    this.tone(t, "sine", 150, 84, 0.004, 0.3, 0.17)
+    this.tone(t, "triangle", 149, 82, 0.004, 0.26, 0.07)
+    this.burst(t, "lowpass", 900, 220, 0.003, 0.2, 0.09)
+  }
+
+  overcharge(): void {
+    if (!this.gate("overcharge", 20, 300)) return
+    const t = this.ctx!.currentTime
+    this.tone(t, "sawtooth", 110, 880, 0.18, 0.5, 0.08)
+    this.tone(t, "sine", 55, 40, 0.02, 1.1, 0.32)
+    this.burst(t, "highpass", 300, 11000, 0.16, 0.7, 0.1)
+    ;[0, 5, 12].forEach((s, i) => this.tone(t + 0.18 + i * 0.05, "triangle", 523 * Math.pow(2, s / 12), 0, 0.005, 0.9, 0.07))
+  }
+
+  nova(): void {
+    if (!this.gate("nova", 20, 200)) return
+    const t = this.ctx!.currentTime
+    this.tone(t, "sine", 120, 28, 0.004, 1.3, 0.42)
+    this.burst(t, "lowpass", 9000, 120, 0.004, 0.85, 0.26, 0.6)
+    this.burst(t, "highpass", 2000, 14000, 0.02, 0.6, 0.08)
+  }
+
+  hurt(): void {
+    if (!this.gate("hurt", 10, 180)) return
+    const t = this.ctx!.currentTime
+    this.tone(t, "sine", 190, 60, 0.002, 0.24, 0.24)
+    this.burst(t, "lowpass", 1400, 200, 0.002, 0.2, 0.14)
+  }
+
+  evolve(): void {
+    if (!this.gate("evolve", 20, 400)) return
+    const t = this.ctx!.currentTime
+    this.tone(t, "sawtooth", 220, 1760, 0.3, 0.35, 0.07)
+    ;[0, 4, 7, 11, 14].forEach((s, i) => this.tone(t + 0.25 + i * 0.04, "triangle", 523 * Math.pow(2, s / 12), 0, 0.005, 1.0, 0.075))
+    this.tone(t + 0.25, "sine", 65, 44, 0.01, 1.2, 0.3)
+  }
+
+  death(): void {
+    if (!this.gate("death", 24, 400)) return
+    const t = this.ctx!.currentTime
+    this.tone(t, "sawtooth", 220, 30, 0.01, 1.5, 0.14)
+    this.tone(t, "sine", 110, 24, 0.01, 1.8, 0.24)
+    this.burst(t, "lowpass", 5000, 90, 0.02, 1.4, 0.13, 0.7)
+  }
+
+  riftOpen(): void {
+    if (!this.gate("riftOpen", 24, 500)) return
+    const t = this.ctx!.currentTime
+    this.tone(t, "sine", 44, 66, 0.6, 2.2, 0.2)
+    this.tone(t, "triangle", 330, 494, 0.8, 2.0, 0.045)
+    this.burst(t, "bandpass", 200, 1800, 0.9, 1.8, 0.05, 4)
+  }
+
+  revive(): void {
+    if (!this.gate("revive", 30, 300)) return
+    const t = this.ctx!.currentTime
+    ;[0, 7, 12, 16, 19, 24, 28, 31].forEach((s, i) => {
+      const f = 262 * Math.pow(2, s / 12)
+      this.tone(t + i * 0.045, "triangle", f, f, 0.004, 0.85, 0.085)
+    })
+    this.tone(t, "sine", 55, 110, 0.02, 1.6, 0.34)
+    this.burst(t, "highpass", 400, 13000, 0.1, 1.1, 0.1)
+  }
+
+  destroy(): void {
+    for (const o of this.padOscs) { try { o.stop() } catch { /* already stopped */ } }
+    this.padOscs.length = 0
+    this.ctx?.close().catch(() => {})
+    this.ctx = null
+  }
+}

--- a/dynawalla/games/horde/src/core/input.ts
+++ b/dynawalla/games/horde/src/core/input.ts
@@ -1,0 +1,180 @@
+/**
+ * One verb: MOVE. Weapons fire themselves.
+ *
+ * Touch is primary — a floating stick that materialises wherever the thumb
+ * lands, because a fixed stick in a corner is a thumb-stretch on a tablet and
+ * a child re-grips constantly. Desktop is deliberate, not an afterthought:
+ * WASD/arrows are analogue-smoothed so a keyboard player still gets the
+ * drifting, momentum-y feel a stick gives, and holding the pointer steers too.
+ */
+
+export type Stick = {
+  /** −1..1 */
+  x: number
+  y: number
+  /** 0..1 */
+  mag: number
+  /** Screen-space anchor for drawing the stick, in CSS pixels. */
+  originX: number
+  originY: number
+  knobX: number
+  knobY: number
+  active: boolean
+  /** True while the current gesture came from a finger. */
+  touch: boolean
+}
+
+const DEAD = 0.06
+const RADIUS = 62
+
+export class Input {
+  readonly stick: Stick = {
+    x: 0, y: 0, mag: 0,
+    originX: 0, originY: 0, knobX: 0, knobY: 0,
+    active: false, touch: false,
+  }
+
+  private keys = new Set<string>()
+  private pointerId: number | null = null
+  private kx = 0
+  private ky = 0
+  private detachers: (() => void)[] = []
+  /** Consumed by the game each frame; set by any key or tap. */
+  anyPress = false
+
+  private el: HTMLElement
+
+  constructor(el: HTMLElement) {
+    this.el = el
+    const stop = (e: Event) => e.preventDefault()
+
+    const down = (e: PointerEvent) => {
+      // Anything with its own pointer-events (cards, buttons) already ate this.
+      if (this.pointerId !== null) return
+      this.pointerId = e.pointerId
+      this.stick.touch = e.pointerType !== "mouse"
+      const r = this.el.getBoundingClientRect()
+      this.stick.originX = e.clientX - r.left
+      this.stick.originY = e.clientY - r.top
+      this.stick.knobX = this.stick.originX
+      this.stick.knobY = this.stick.originY
+      this.stick.active = true
+      this.anyPress = true
+      try { this.el.setPointerCapture(e.pointerId) } catch { /* not capturable */ }
+    }
+
+    const move = (e: PointerEvent) => {
+      if (e.pointerId !== this.pointerId) return
+      const r = this.el.getBoundingClientRect()
+      const px = e.clientX - r.left
+      const py = e.clientY - r.top
+      let dx = px - this.stick.originX
+      let dy = py - this.stick.originY
+      const d = Math.hypot(dx, dy)
+      if (d > RADIUS) {
+        // Re-anchor so the stick never feels "stuck" during a long drag.
+        this.stick.originX = px - (dx / d) * RADIUS
+        this.stick.originY = py - (dy / d) * RADIUS
+        dx = (dx / d) * RADIUS
+        dy = (dy / d) * RADIUS
+      }
+      this.stick.knobX = this.stick.originX + dx
+      this.stick.knobY = this.stick.originY + dy
+    }
+
+    const up = (e: PointerEvent) => {
+      if (e.pointerId !== this.pointerId) return
+      this.pointerId = null
+      this.stick.active = false
+    }
+
+    const kd = (e: KeyboardEvent) => {
+      this.keys.add(e.key.toLowerCase())
+      this.anyPress = true
+      if (["arrowup", "arrowdown", "arrowleft", "arrowright", " "].includes(e.key.toLowerCase())) e.preventDefault()
+    }
+    const ku = (e: KeyboardEvent) => this.keys.delete(e.key.toLowerCase())
+    const blur = () => this.keys.clear()
+
+    this.el.addEventListener("pointerdown", down)
+    this.el.addEventListener("pointermove", move)
+    this.el.addEventListener("pointerup", up)
+    this.el.addEventListener("pointercancel", up)
+    this.el.addEventListener("touchstart", stop, { passive: false })
+    this.el.addEventListener("contextmenu", stop)
+    window.addEventListener("keydown", kd)
+    window.addEventListener("keyup", ku)
+    window.addEventListener("blur", blur)
+
+    this.detachers.push(() => {
+      this.el.removeEventListener("pointerdown", down)
+      this.el.removeEventListener("pointermove", move)
+      this.el.removeEventListener("pointerup", up)
+      this.el.removeEventListener("pointercancel", up)
+      this.el.removeEventListener("touchstart", stop)
+      this.el.removeEventListener("contextmenu", stop)
+      window.removeEventListener("keydown", kd)
+      window.removeEventListener("keyup", ku)
+      window.removeEventListener("blur", blur)
+    })
+  }
+
+  held(k: string): boolean {
+    return this.keys.has(k)
+  }
+
+  /** Latches: returns true once per press. */
+  pressed(k: string): boolean {
+    if (!this.keys.has(k)) return false
+    this.keys.delete(k)
+    return true
+  }
+
+  update(dt: number): void {
+    // Keyboard, smoothed toward the raw axis so it behaves like a stick.
+    const kxTarget =
+      (this.held("d") || this.held("arrowright") ? 1 : 0) - (this.held("a") || this.held("arrowleft") ? 1 : 0)
+    const kyTarget =
+      (this.held("s") || this.held("arrowdown") ? 1 : 0) - (this.held("w") || this.held("arrowup") ? 1 : 0)
+    const k = 1 - Math.pow(0.0007, dt)
+    this.kx += (kxTarget - this.kx) * k
+    this.ky += (kyTarget - this.ky) * k
+    if (Math.abs(this.kx) < 0.004) this.kx = 0
+    if (Math.abs(this.ky) < 0.004) this.ky = 0
+
+    let x = this.kx
+    let y = this.ky
+
+    if (this.stick.active) {
+      const dx = (this.stick.knobX - this.stick.originX) / RADIUS
+      const dy = (this.stick.knobY - this.stick.originY) / RADIUS
+      const m = Math.hypot(dx, dy)
+      if (m > DEAD) {
+        // Rescale past the dead zone so the first millimetre of travel counts.
+        const s = (m - DEAD) / (1 - DEAD) / m
+        x = dx * s
+        y = dy * s
+      }
+    }
+
+    const mag = Math.hypot(x, y)
+    if (mag > 1) {
+      x /= mag
+      y /= mag
+    }
+    this.stick.x = x
+    this.stick.y = y
+    this.stick.mag = Math.min(1, mag)
+  }
+
+  takeAnyPress(): boolean {
+    const v = this.anyPress
+    this.anyPress = false
+    return v
+  }
+
+  destroy(): void {
+    for (const d of this.detachers) d()
+    this.detachers.length = 0
+  }
+}

--- a/dynawalla/games/horde/src/core/tiers.ts
+++ b/dynawalla/games/horde/src/core/tiers.ts
@@ -1,0 +1,150 @@
+/**
+ * Quality tiers. The mid-range tablet is the FLOOR, never the ceiling.
+ *
+ * ULTRA is allowed to be genuinely absurd — two bloom octaves, chromatic
+ * aberration, a persistent bioluminescent stain layer, 1800 simultaneous
+ * enemies. LOW keeps every mechanic and every readable signal and drops only
+ * ornament, so a child on a cheap tablet plays the same game.
+ */
+
+export type TierName = "low" | "mid" | "ultra"
+
+export type Tier = {
+  name: TierName
+  maxEnemies: number
+  maxBullets: number
+  maxParticles: number
+  maxNumbers: number
+  maxGems: number
+  /** Instances the sprite buffer can hold in one frame. */
+  maxInstances: number
+  /** 0 = none, 1 = one octave, 2 = two octaves. */
+  bloomOctaves: number
+  /** Persistent light-stain layer where the horde died. */
+  stain: boolean
+  /** Chromatic aberration driven by trauma. */
+  aberration: boolean
+  /** Render scale multiplier applied on top of devicePixelRatio. */
+  renderScale: number
+  /** Cap on devicePixelRatio. */
+  maxDpr: number
+  /** Particle count multiplier. */
+  particleScale: number
+  /** Enemy separation neighbour budget per enemy per frame. */
+  separationBudget: number
+}
+
+const TIERS: Record<TierName, Tier> = {
+  low: {
+    name: "low",
+    maxEnemies: 420,
+    maxBullets: 420,
+    maxParticles: 900,
+    maxNumbers: 90,
+    maxGems: 420,
+    maxInstances: 4200,
+    bloomOctaves: 0,
+    stain: false,
+    aberration: false,
+    renderScale: 1,
+    maxDpr: 1.25,
+    particleScale: 0.42,
+    separationBudget: 5,
+  },
+  mid: {
+    name: "mid",
+    maxEnemies: 900,
+    maxBullets: 900,
+    maxParticles: 2600,
+    maxNumbers: 190,
+    maxGems: 900,
+    maxInstances: 11000,
+    bloomOctaves: 1,
+    stain: true,
+    aberration: true,
+    renderScale: 1,
+    maxDpr: 1.75,
+    particleScale: 1,
+    separationBudget: 8,
+  },
+  ultra: {
+    name: "ultra",
+    maxEnemies: 1800,
+    maxBullets: 1600,
+    maxParticles: 6000,
+    maxNumbers: 300,
+    maxGems: 1600,
+    maxInstances: 24000,
+    bloomOctaves: 2,
+    stain: true,
+    aberration: true,
+    renderScale: 1,
+    maxDpr: 2,
+    particleScale: 1.9,
+    separationBudget: 10,
+  },
+}
+
+export function tier(name: TierName): Tier {
+  return TIERS[name]
+}
+
+/** A first guess from the device, before a single frame has been measured. */
+export function detectTier(): TierName {
+  if (typeof navigator === "undefined") return "mid"
+  const mem = (navigator as Navigator & { deviceMemory?: number }).deviceMemory ?? 4
+  const cores = navigator.hardwareConcurrency ?? 4
+  const coarse = typeof matchMedia === "function" && matchMedia("(pointer: coarse)").matches
+  const px = typeof window !== "undefined" ? window.innerWidth * window.innerHeight : 1e6
+
+  if (mem >= 8 && cores >= 8 && !(coarse && px < 500000)) return "ultra"
+  if (mem <= 2 || cores <= 3) return "low"
+  return "mid"
+}
+
+/**
+ * A running frame-time judge. It only ever steps *down*, and only on sustained
+ * evidence, so a single hitch during a level-up never costs a child their
+ * bloom for the rest of the run.
+ */
+export class TierGovernor {
+  private samples = new Float32Array(120)
+  private i = 0
+  private filled = 0
+  private cooldown = 4
+  current: TierName
+
+  constructor(current: TierName) {
+    this.current = current
+  }
+
+  /** @returns the new tier if it changed, else null. */
+  sample(dtMs: number): TierName | null {
+    this.samples[this.i] = dtMs
+    this.i = (this.i + 1) % this.samples.length
+    if (this.filled < this.samples.length) this.filled++
+    if (this.filled < this.samples.length) return null
+    if (this.cooldown > 0) {
+      this.cooldown--
+      this.filled = 0
+      return null
+    }
+
+    // 90th-percentile-ish: how bad are the bad frames, not the average.
+    const sorted = Array.prototype.slice.call(this.samples, 0, this.filled).sort((a: number, b: number) => a - b)
+    const p90 = sorted[Math.floor(sorted.length * 0.9)] as number
+    this.filled = 0
+
+    if (p90 > 26 && this.current === "ultra") {
+      this.current = "mid"
+      this.cooldown = 6
+      return "mid"
+    }
+    if (p90 > 30 && this.current === "mid") {
+      this.current = "low"
+      this.cooldown = 999999
+      return "low"
+    }
+    return null
+  }
+}

--- a/dynawalla/games/horde/src/env.d.ts
+++ b/dynawalla/games/horde/src/env.d.ts
@@ -1,0 +1,4 @@
+declare module "*.css?inline" {
+  const css: string
+  export default css
+}

--- a/dynawalla/games/horde/src/game/enemies.ts
+++ b/dynawalla/games/horde/src/game/enemies.ts
@@ -1,0 +1,117 @@
+/**
+ * The swarm. Nine archetypes, each separated on THREE axes at once — shape,
+ * colour and motion — so a child reads the threat at a glance and a
+ * colour-blind child reads it just as fast.
+ */
+
+export const BEHAVIOUR = {
+  CHASE: 0,
+  DART: 1,
+  KEEP: 2,
+  CHARGE: 3,
+  ORBIT: 4,
+  SPLIT: 5,
+  WARDEN: 6,
+} as const
+
+export type EnemyDef = {
+  key: string
+  name: string
+  hp: number
+  speed: number
+  radius: number
+  /** Contact damage per second while overlapping the player. */
+  dps: number
+  xp: number
+  shape: number
+  col: [number, number, number]
+  behaviour: number
+  /** Minutes into the run before this can spawn. */
+  from: number
+  /** Relative spawn weight once unlocked. */
+  weight: number
+  /** Multiplier on the knockback it takes. */
+  massInv: number
+  spin: number
+  elite?: boolean
+}
+
+import { SHAPE } from "../gfx/renderer.ts"
+
+export const ENEMIES: EnemyDef[] = [
+  {
+    key: "drifter", name: "DRIFTER",
+    hp: 10, speed: 46, radius: 15, dps: 9, xp: 1,
+    shape: SHAPE.CHITIN, col: [0.16, 0.86, 0.98], behaviour: BEHAVIOUR.CHASE,
+    from: 0, weight: 100, massInv: 1, spin: 0.4,
+  },
+  {
+    key: "darter", name: "DARTER",
+    hp: 7, speed: 104, radius: 11, dps: 7, xp: 1,
+    shape: SHAPE.DART, col: [1.0, 0.24, 0.70], behaviour: BEHAVIOUR.DART,
+    from: 0.7, weight: 72, massInv: 1.4, spin: 0,
+  },
+  {
+    key: "husk", name: "HUSK",
+    hp: 58, speed: 30, radius: 26, dps: 16, xp: 4,
+    shape: SHAPE.CHITIN, col: [0.60, 0.34, 1.0], behaviour: BEHAVIOUR.CHASE,
+    from: 2.0, weight: 34, massInv: 0.35, spin: 0.18,
+  },
+  {
+    key: "spitter", name: "SPITTER",
+    hp: 20, speed: 40, radius: 15, dps: 6, xp: 3,
+    shape: SHAPE.RING, col: [0.55, 1.0, 0.34], behaviour: BEHAVIOUR.KEEP,
+    from: 3.2, weight: 30, massInv: 1.1, spin: 1.1,
+  },
+  {
+    key: "splitter", name: "SPLITTER",
+    hp: 30, speed: 52, radius: 20, dps: 11, xp: 3,
+    shape: SHAPE.SHARD, col: [0.86, 1.0, 0.28], behaviour: BEHAVIOUR.SPLIT,
+    from: 4.6, weight: 30, massInv: 0.8, spin: 1.9,
+  },
+  {
+    key: "sporeling", name: "SPORE",
+    hp: 5, speed: 118, radius: 8, dps: 5, xp: 1,
+    shape: SHAPE.DISC, col: [0.74, 1.0, 0.58], behaviour: BEHAVIOUR.CHASE,
+    from: 99, weight: 0, massInv: 1.8, spin: 0,
+  },
+  {
+    key: "lancer", name: "LANCER",
+    hp: 42, speed: 66, radius: 17, dps: 22, xp: 5,
+    shape: SHAPE.SHARD, col: [1.0, 0.42, 0.14], behaviour: BEHAVIOUR.CHARGE,
+    from: 6.0, weight: 26, massInv: 0.6, spin: 0,
+  },
+  {
+    key: "leech", name: "LEECH",
+    hp: 26, speed: 88, radius: 13, dps: 9, xp: 2,
+    shape: SHAPE.GEM, col: [0.30, 1.0, 0.86], behaviour: BEHAVIOUR.ORBIT,
+    from: 7.5, weight: 26, massInv: 1.2, spin: 2.4,
+  },
+  {
+    key: "warden", name: "WARDEN",
+    hp: 620, speed: 38, radius: 46, dps: 30, xp: 60,
+    shape: SHAPE.CHITIN, col: [1.0, 0.80, 0.30], behaviour: BEHAVIOUR.WARDEN,
+    from: 99, weight: 0, massInv: 0.08, spin: 0.5, elite: true,
+  },
+]
+
+export const E_INDEX: Record<string, number> = Object.fromEntries(ENEMIES.map((e, i) => [e.key, i]))
+
+/**
+ * The escalation curve. Health and speed climb, but health climbs much faster
+ * than speed — a horde that outruns the player at minute 15 is unplayable,
+ * a horde that takes four hits instead of one is *the power fantasy working*.
+ */
+export function hpScale(minutes: number): number {
+  return 1 + minutes * 0.42 + minutes * minutes * 0.030
+}
+
+export function speedScale(minutes: number): number {
+  return Math.min(1.55, 1 + minutes * 0.021)
+}
+
+/** Enemies alive the director aims for, at a given minute. */
+export function targetPopulation(minutes: number, cap: number): number {
+  const t = 26 + minutes * 30 + minutes * minutes * 2.4
+  return Math.min(cap, Math.floor(t))
+}

--- a/dynawalla/games/horde/src/game/feel.ts
+++ b/dynawalla/games/horde/src/game/feel.ts
@@ -1,0 +1,127 @@
+/**
+ * Screenshake, hitstop, kick, punch-zoom, flash — Nijman's list, with the two
+ * rules a children's product adds on top:
+ *
+ *  - **The flash limiter is hard.** Additive full-screen flashes are capped in
+ *    amplitude and rate. A game cannot ask for a brighter or more frequent
+ *    flash than the limiter allows, so no future edit can introduce one.
+ *  - **Reduced motion removes movement, never information.** Shake becomes a
+ *    still frame; hitstop stays (it is timing, not motion); the flash becomes
+ *    a dim tint. Everything a player must *know* is still on screen.
+ */
+
+export class Feel {
+  trauma = 0
+  kickX = 0
+  kickY = 0
+  zoom = 1
+  private zoomVel = 0
+  hitstopMs = 0
+  private t = 0
+
+  flashR = 0
+  flashG = 0
+  flashB = 0
+  flashA = 0
+  private flashDecay = 6
+  private lastBigFlash = -1e9
+  private flashCount = 0
+  private flashWindowStart = 0
+
+  reduced = false
+
+  /** Absolute ceilings. Nothing may exceed these, ever. */
+  static readonly MAX_FLASH = 0.34
+  static readonly MAX_FLASH_REDUCED = 0.09
+  /** Full-screen flashes above `BIG` are limited to this many per second. */
+  static readonly BIG = 0.12
+  static readonly BIG_PER_SEC = 3
+
+  shake(amount: number): void {
+    this.trauma = Math.min(1, this.trauma + amount)
+  }
+
+  kick(dx: number, dy: number, amount: number): void {
+    const d = Math.hypot(dx, dy) || 1
+    this.kickX += (dx / d) * amount
+    this.kickY += (dy / d) * amount
+  }
+
+  punch(amount: number): void {
+    this.zoomVel += amount
+  }
+
+  stop(ms: number): void {
+    // Hitstop is only ever spent on success. Never on being hurt: the retry
+    // must be the fastest thing in the game.
+    this.hitstopMs = Math.max(this.hitstopMs, this.reduced ? Math.min(ms, 40) : ms)
+  }
+
+  flash(r: number, g: number, b: number, a: number, decay = 6): void {
+    const cap = this.reduced ? Feel.MAX_FLASH_REDUCED : Feel.MAX_FLASH
+    let amt = Math.min(a, cap)
+    const now = this.t
+    if (amt > Feel.BIG) {
+      if (now - this.flashWindowStart > 1) {
+        this.flashWindowStart = now
+        this.flashCount = 0
+      }
+      if (this.flashCount >= Feel.BIG_PER_SEC || now - this.lastBigFlash < 0.16) {
+        amt = Feel.BIG // demote, never drop: the signal survives, the strobe does not
+      } else {
+        this.flashCount++
+        this.lastBigFlash = now
+      }
+    }
+    if (amt <= this.flashA) return
+    this.flashR = r
+    this.flashG = g
+    this.flashB = b
+    this.flashA = amt
+    this.flashDecay = decay
+  }
+
+  update(dt: number): void {
+    this.t += dt
+    const k = 1 - Math.pow(0.0001, dt)
+    this.trauma = Math.max(0, this.trauma - dt * 1.75)
+    this.kickX -= this.kickX * k
+    this.kickY -= this.kickY * k
+    if (Math.abs(this.kickX) < 0.02) this.kickX = 0
+    if (Math.abs(this.kickY) < 0.02) this.kickY = 0
+
+    // Punch-zoom as a spring so it overshoots once and settles.
+    const stiff = 150
+    const damp = 17
+    this.zoomVel += (1 - this.zoom) * stiff * dt - this.zoomVel * damp * dt
+    this.zoom += this.zoomVel * dt
+    this.zoom = Math.max(0.88, Math.min(1.14, this.zoom))
+
+    this.flashA = Math.max(0, this.flashA - dt * this.flashDecay * Math.max(0.4, this.flashA + 0.3))
+  }
+
+  /** Screen-space offset in world units, given the current view width. */
+  shakeOffset(out: Float32Array, worldPerPixel: number, seed: number): void {
+    if (this.reduced) {
+      out[0] = 0
+      out[1] = 0
+      return
+    }
+    const s = this.trauma * this.trauma
+    const a = seed * 12.9898
+    // Two decorrelated sines rather than random(): shake that jitters per
+    // frame reads as noise, shake that oscillates reads as impact.
+    out[0] = Math.sin(a * 3.1 + this.t * 61) * s * 26 * worldPerPixel
+    out[1] = Math.cos(a * 2.3 + this.t * 53) * s * 26 * worldPerPixel
+  }
+
+  reset(): void {
+    this.trauma = 0
+    this.kickX = 0
+    this.kickY = 0
+    this.zoom = 1
+    this.zoomVel = 0
+    this.hitstopMs = 0
+    this.flashA = 0
+  }
+}

--- a/dynawalla/games/horde/src/game/game.ts
+++ b/dynawalla/games/horde/src/game/game.ts
@@ -1,0 +1,1913 @@
+/**
+ * DEEPSWARM. One verb — move. The weapons fire themselves, the swarm never
+ * stops, and every thirty seconds you get stronger than the maths says you
+ * should be.
+ *
+ * The arithmetic lives in three places, none of which is a quiz:
+ *   CORE   — swim into it, time crawls, three numbered orbs circle you, and
+ *            the one you touch decides whether the next nine seconds are an
+ *            apocalypse or an ambush. You answer with the same verb you play
+ *            with.
+ *   CACHE  — a sealed fourth card at level-up. Open it or ignore it.
+ *   RIFT   — you died. Charge it with answers and come back.
+ * And underneath all of it, every upgrade card states its own arithmetic, so
+ * choosing well is comparing products under pressure.
+ */
+import type { Host, Question } from "../contract.ts"
+import { Audio } from "../core/audio.ts"
+import { Input } from "../core/input.ts"
+import { detectTier, tier, TierGovernor, type Tier, type TierName } from "../core/tiers.ts"
+import { Renderer, SHAPE } from "../gfx/renderer.ts"
+import { BEHAVIOUR, ENEMIES, E_INDEX, hpScale, speedScale, targetPopulation } from "./enemies.ts"
+import { Feel } from "./feel.ts"
+import {
+  cooldown, makeBuild, realDamage, reach, rollCards, xpForLevel,
+  type Build, type Card,
+} from "./loadout.ts"
+import { Bullets, Enemies, Gems, Grid, Numbers, Particles, Shocks } from "./world.ts"
+import { Overlay } from "../ui/overlay.ts"
+
+const STEP = 1 / 60
+const AREA = 402 // sqrt(halfW*halfH): a constant amount of world on any screen
+
+type Mode = "title" | "play" | "levelup" | "core" | "rift" | "over" | "paused"
+
+type Orb = { x: number; y: number; ang: number; text: string; correct: boolean; state: number; t: number }
+
+export class Game {
+  private root: HTMLElement
+  private host: Host
+  private canvas: HTMLCanvasElement
+  private r: Renderer
+  private input: Input
+  private audio = new Audio()
+  private feel = new Feel()
+  private ui: Overlay
+  private gov: TierGovernor
+  private T: Tier
+
+  private E!: Enemies
+  private B!: Bullets
+  private EB!: Bullets
+  private P!: Particles
+  private G!: Gems
+  private N!: Numbers
+  private S!: Shocks
+  private grid!: Grid
+  private range = new Int32Array(4)
+  private shakeOut = new Float32Array(2)
+
+  private raf = 0
+  private lastT = 0
+  private acc = 0
+  private alive = true
+  private ro: ResizeObserver | null = null
+
+  /* ------------------------------------------------------------ run state */
+  mode: Mode = "title"
+  private runT = 0
+  private wallT = 0
+  private kills = 0
+  private level = 1
+  private xp = 0
+  private xpNeed = xpForLevel(1)
+  private build: Build = makeBuild()
+  private px = 0
+  private py = 0
+  private pvx = 0
+  private pvy = 0
+  private pAng = 0
+  private invuln = 0
+  private overcharge = 0
+  private revives = 0
+  private hurtCd = 0
+  private levelUps = 0
+  private correct = 0
+  private asked = 0
+  private bestMs = 0
+
+  private camX = 0
+  private camY = 0
+  private halfW = AREA
+  private halfH = AREA
+  private timeScale = 1
+  private timeScaleTarget = 1
+  private desat = 0
+
+  private spawnAcc = 0
+  private wardenAt = 42
+  private tideAt = 74
+  private coreAt = 20
+  private coreX = 0
+  private coreY = 0
+  private coreLive = false
+  private corePhase = 0
+
+  private q: Question | null = null
+  private orbs: Orb[] = []
+  private qT = 0
+  private qStart = 0
+  private qAnswered = false
+
+  private riftNeeded = 1
+  private riftCharges = 0
+  private riftT = 0
+  private riftQ: Question | null = null
+
+  private cards: Card[] = []
+  private sealedQ: Question | null = null
+
+  private rng: () => number
+  private fpsAcc = 0
+  private fpsN = 0
+  private fpsShown = 0
+  private debug = false
+  private reduced = false
+
+  constructor(root: HTMLElement, host: Host) {
+    this.root = root
+    this.host = host
+    this.reduced = host.prefersReducedMotion()
+    this.feel.reduced = this.reduced
+
+    this.canvas = document.createElement("canvas")
+    this.canvas.className = "hz-canvas"
+    root.appendChild(this.canvas)
+
+    const name: TierName = detectTier()
+    this.T = tier(name)
+    this.gov = new TierGovernor(name)
+    this.r = new Renderer(this.canvas, this.T.maxInstances)
+    this.applyTier(this.T)
+    this.allocate(this.T)
+
+    this.input = new Input(this.canvas)
+    this.ui = new Overlay(root)
+    this.wireUi()
+
+    let seed = (Date.now() ^ 0x9e3779b9) >>> 0
+    this.rng = () => {
+      seed = (seed + 0x6d2b79f5) >>> 0
+      let t = seed
+      t = Math.imul(t ^ (t >>> 15), t | 1)
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+    }
+
+    try {
+      this.debug = new URLSearchParams(location.search).has("debug")
+    } catch { /* no location in an embedded host */ }
+
+    this.resize()
+    this.ro = new ResizeObserver(() => this.resize())
+    this.ro.observe(root)
+    window.addEventListener("resize", this.onWinResize)
+
+    this.reset()
+    this.lastT = performance.now()
+    this.raf = requestAnimationFrame(this.tick)
+  }
+
+  private onWinResize = () => this.resize()
+
+  private applyTier(T: Tier): void {
+    this.r.bloomOctaves = this.reduced ? Math.min(1, T.bloomOctaves) : T.bloomOctaves
+    this.r.stainEnabled = T.stain
+  }
+
+  private allocate(T: Tier): void {
+    this.E = new Enemies(T.maxEnemies)
+    this.B = new Bullets(T.maxBullets)
+    this.EB = new Bullets(Math.max(140, T.maxBullets >> 2))
+    this.P = new Particles(T.maxParticles)
+    this.G = new Gems(T.maxGems)
+    this.N = new Numbers(T.maxNumbers)
+    this.S = new Shocks(96)
+    this.grid = new Grid(T.maxEnemies)
+  }
+
+  private wireUi(): void {
+    this.ui.onStart = () => {
+      void this.audio.init().then(() => this.audio.markStarted())
+      this.ui.hideTitle()
+      this.reset()
+      this.mode = "play"
+    }
+    this.ui.onRestart = () => {
+      this.ui.hideOver()
+      this.reset()
+      this.mode = "play"
+    }
+    this.ui.onToggleSound = () => {
+      const on = !this.audio.enabled
+      this.audio.setEnabled(on)
+      this.ui.setSound(on)
+      if (on) void this.audio.init().then(() => this.audio.markStarted())
+    }
+    this.ui.onTogglePause = () => {
+      if (this.mode === "play") {
+        this.mode = "paused"
+        this.ui.setPaused(true)
+        this.ui.say("PAUSED", "", "#9fd8ff")
+      } else if (this.mode === "paused") {
+        this.mode = "play"
+        this.ui.setPaused(false)
+      }
+    }
+    this.ui.onPickCard = (i) => this.pickCard(i)
+    this.ui.onSealed = (res) => this.sealedAnswer(res)
+    this.ui.onRiftAnswer = (res) => this.riftAnswer(res)
+  }
+
+  /* -------------------------------------------------------------- lifecycle */
+
+  private resize(): void {
+    const rect = this.root.getBoundingClientRect()
+    const w = Math.max(200, rect.width || window.innerWidth)
+    const h = Math.max(200, rect.height || window.innerHeight)
+    const dpr = Math.min(window.devicePixelRatio || 1, this.T.maxDpr)
+    this.r.resize(w, h, dpr * this.T.renderScale)
+    const aspect = w / h
+    this.halfW = AREA * Math.sqrt(aspect)
+    this.halfH = AREA / Math.sqrt(aspect)
+  }
+
+  reset(): void {
+    this.E.pool.reset()
+    this.B.pool.reset()
+    this.EB.pool.reset()
+    this.P.pool.reset()
+    this.G.pool.reset()
+    this.N.pool.reset()
+    this.S.pool.reset()
+    this.r.clearStain()
+    this.build = makeBuild()
+    this.runT = 0
+    this.kills = 0
+    this.level = 1
+    this.xp = 0
+    this.xpNeed = xpForLevel(1)
+    this.px = 0
+    this.py = 0
+    this.pvx = 0
+    this.pvy = 0
+    this.camX = 0
+    this.camY = 0
+    this.invuln = 2
+    this.overcharge = 0
+    this.revives = 0
+    this.levelUps = 0
+    this.correct = 0
+    this.asked = 0
+    this.bestMs = 0
+    this.spawnAcc = 0
+    this.wardenAt = 42
+    this.tideAt = 74
+    this.coreAt = 20
+    this.coreLive = false
+    this.q = null
+    this.orbs.length = 0
+    this.timeScale = 1
+    this.timeScaleTarget = 1
+    this.desat = 0
+    this.feel.reset()
+    this.ui.hideCards()
+    this.ui.hideRift()
+    this.ui.setPaused(false)
+    this.syncHud()
+  }
+
+  destroy(): void {
+    this.alive = false
+    cancelAnimationFrame(this.raf)
+    this.ro?.disconnect()
+    window.removeEventListener("resize", this.onWinResize)
+    this.input.destroy()
+    this.audio.destroy()
+    this.r.destroy()
+    this.ui.destroy()
+    this.canvas.remove()
+  }
+
+  /* -------------------------------------------------------------- the loop */
+
+  private tick = (now: number) => {
+    if (!this.alive) return
+    this.raf = requestAnimationFrame(this.tick)
+
+    let frame = (now - this.lastT) / 1000
+    this.lastT = now
+    if (frame > 0.25) frame = 0.25
+    const frameMs = frame * 1000
+
+    this.fpsAcc += frame
+    this.fpsN++
+    if (this.fpsAcc >= 0.5) {
+      this.fpsShown = this.fpsN / this.fpsAcc
+      this.fpsAcc = 0
+      this.fpsN = 0
+      if (this.debug) {
+        this.ui.setFps(
+          `${this.fpsShown.toFixed(0)} fps  ${this.T.name}\n` +
+          `${this.E.pool.n} foes  ${this.B.pool.n} shots\n` +
+          `${this.P.pool.n} bits  ${this.r.spriteCount} quads`,
+        )
+      }
+    }
+    if (this.mode === "play") {
+      const t = this.gov.sample(frameMs)
+      if (t) this.downgrade(t)
+    }
+
+    this.wallT += frame
+    this.audio.frame()
+    this.input.update(frame)
+    this.feel.update(frame)
+    this.keyboard()
+
+    // Hitstop freezes the simulation, never the renderer.
+    if (this.feel.hitstopMs > 0) {
+      this.feel.hitstopMs -= frameMs
+    } else {
+      const simming = this.mode === "play" || this.mode === "core"
+      if (simming) {
+        this.timeScale += (this.timeScaleTarget - this.timeScale) * Math.min(1, frame * 9)
+        this.acc += frame
+        let steps = 0
+        while (this.acc >= STEP && steps < 4) {
+          this.step(STEP)
+          this.acc -= STEP
+          steps++
+        }
+        if (steps === 4) this.acc = 0
+      } else {
+        this.acc = 0
+      }
+    }
+
+    if (this.mode === "rift") this.riftTick(frame)
+    this.desat += ((this.mode === "rift" ? 0.85 : 0) - this.desat) * Math.min(1, frame * 6)
+
+    this.draw(frame)
+  }
+
+  /** Desktop is deliberate: a keyboard plays the whole game, menus included. */
+  private keyboard(): void {
+    if (this.input.pressed("escape") || this.input.pressed("p")) {
+      if (this.mode === "play" || this.mode === "paused") this.ui.onTogglePause()
+    }
+    if (this.mode === "title" || this.mode === "over") {
+      if (this.input.pressed("enter") || this.input.pressed(" ")) {
+        if (this.mode === "title") this.ui.onStart()
+        else this.ui.onRestart()
+      }
+      return
+    }
+    if (this.mode === "levelup") {
+      for (let i = 0; i < 3; i++) {
+        if (this.input.pressed(String(i + 1))) this.pickCard(i)
+      }
+    }
+    this.input.takeAnyPress()
+  }
+
+  private downgrade(name: TierName): void {
+    console.warn(`[horde] frame budget missed — dropping to the ${name} tier`)
+    this.T = tier(name)
+    this.applyTier(this.T)
+    this.r.setCapacity(this.T.maxInstances)
+    // Entity pools keep their size: shrinking them mid-run would delete the
+    // swarm the player is fighting. Only the ornament goes.
+    this.resize()
+  }
+
+  /* ------------------------------------------------------------------ step */
+
+  private step(rawDt: number): void {
+    const dt = rawDt * this.timeScale
+    // Bullet time slows the world, not the diver. That asymmetry *is* the
+    // reward for reaching the core.
+    const pdt = rawDt * (0.62 + 0.38 * this.timeScale)
+
+    if (this.mode === "play") this.runT += dt
+    const minutes = this.runT / 60
+
+    this.movePlayer(pdt)
+    this.buildGrid()
+    this.updateEnemies(dt, minutes)
+    this.fireWeapons(dt)
+    this.updateBullets(dt)
+    this.updateShocks(dt)
+    this.updateGems(dt)
+    this.updateParticles(rawDt)
+    this.updateNumbers(rawDt)
+    this.contact(dt)
+
+    if (this.mode === "play") {
+      this.director(dt, minutes)
+      this.regen(dt)
+      this.checkCore()
+    }
+    if (this.mode === "core") this.questTick(rawDt)
+
+    if (this.overcharge > 0) {
+      this.overcharge -= dt
+      if (this.overcharge <= 0) this.ui.say("SPENT", "", "#8fb6d8")
+    }
+    if (this.invuln > 0) this.invuln -= dt
+    if (this.hurtCd > 0) this.hurtCd -= dt
+
+    this.audio.setIntensity(Math.min(1, minutes / 9 + (this.overcharge > 0 ? 0.3 : 0)))
+  }
+
+  private movePlayer(dt: number): void {
+    const s = this.build.stats
+    const st = this.input.stick
+    const ax = st.x * s.speed
+    const ay = st.y * s.speed
+    // Heavy acceleration but a hard cap, so the diver feels weighty yet exact.
+    const k = 1 - Math.pow(0.00004, dt)
+    this.pvx += (ax - this.pvx) * k
+    this.pvy += (ay - this.pvy) * k
+    this.px += this.pvx * dt
+    this.py += this.pvy * dt
+    if (st.mag > 0.02) this.pAng = Math.atan2(this.pvy, this.pvx)
+
+    // Wake bubbles.
+    if (st.mag > 0.3 && this.rng() < 0.5) {
+      this.particle(
+        this.px - this.pvx * 0.04, this.py - this.pvy * 0.04,
+        -this.pvx * 0.12 + (this.rng() - 0.5) * 26, -this.pvy * 0.12 + (this.rng() - 0.5) * 26,
+        0.5, 5 + this.rng() * 4, 0.4, 0.85, 1.0, SHAPE.DISC, 0.3,
+      )
+    }
+  }
+
+  private buildGrid(): void {
+    const pad = 260
+    this.grid.configure(
+      this.px - this.halfW - pad, this.py - this.halfH - pad,
+      (this.halfW + pad) * 2, (this.halfH + pad) * 2, 46,
+    )
+    this.grid.build(this.E.pool.cap, this.E.pool.alive, this.E.x, this.E.y)
+  }
+
+  /* --------------------------------------------------------------- enemies */
+
+  private updateEnemies(dt: number, minutes: number): void {
+    const E = this.E
+    const cap = E.pool.cap
+    const sScale = speedScale(minutes)
+    const far = (this.halfW + this.halfH) * 1.9
+
+    for (let i = 0; i < cap; i++) {
+      if (E.pool.alive[i] === 0) continue
+      const def = ENEMIES[E.type[i]]
+      let dx = this.px - E.x[i]
+      let dy = this.py - E.y[i]
+      const d2 = dx * dx + dy * dy
+      const d = Math.sqrt(d2) || 1
+
+      // Anything that wanders far outside the live region is recycled rather
+      // than simulated forever.
+      if (d > far) { E.pool.kill(i); continue }
+
+      const spd = def.speed * sScale
+      let wx = dx / d
+      let wy = dy / d
+
+      switch (def.behaviour) {
+        case BEHAVIOUR.DART: {
+          E.st[i] -= dt
+          if (E.st[i] <= 0) { E.st[i] = 0.9 + this.rng() * 0.8; E.st2[i] = 0.42 }
+          if (E.st2[i] > 0) { E.st2[i] -= dt; wx *= 2.1; wy *= 2.1 }
+          break
+        }
+        case BEHAVIOUR.KEEP: {
+          const want = 250
+          if (d < want) { wx = -wx * 0.9; wy = -wy * 0.9 }
+          else if (d < want + 90) { wx = -wy * 0.8; wy = wx * 0.8 }
+          E.st[i] -= dt
+          if (E.st[i] <= 0 && d < 520) {
+            E.st[i] = 2.4 + this.rng() * 1.4
+            this.enemyShot(E.x[i], E.y[i], dx / d, dy / d, 8 + minutes * 1.4)
+          }
+          break
+        }
+        case BEHAVIOUR.CHARGE: {
+          E.st[i] -= dt
+          if (E.st2[i] > 0) {
+            // Committed dash: no steering, which is what makes it dodgeable.
+            E.st2[i] -= dt
+            E.vx[i] *= 1 - dt * 0.6
+            E.vy[i] *= 1 - dt * 0.6
+            E.x[i] += E.vx[i] * dt
+            E.y[i] += E.vy[i] * dt
+            E.rot[i] = Math.atan2(E.vy[i], E.vx[i])
+            E.flash[i] = Math.max(E.flash[i], 0.25)
+            if (E.hitCd[i] > 0) E.hitCd[i] -= dt
+            continue
+          }
+          if (E.st[i] <= 0 && d < 460) {
+            E.st[i] = 2.6 + this.rng() * 1.2
+            E.st2[i] = 0.72
+            E.vx[i] = (dx / d) * 780
+            E.vy[i] = (dy / d) * 780
+            this.audio.tick()
+            for (let k = 0; k < 8; k++) {
+              const a = this.rng() * Math.PI * 2
+              this.particle(E.x[i], E.y[i], Math.cos(a) * 130, Math.sin(a) * 130, 0.3, 6, 1, 0.4, 0.15, SHAPE.SPARK, 0.5)
+            }
+          }
+          break
+        }
+        case BEHAVIOUR.ORBIT: {
+          const want = 150
+          const tang = d < want + 60 ? 1 : 0.25
+          const nx = -wy
+          const ny = wx
+          const pull = (d - want) / want
+          wx = nx * tang + wx * pull
+          wy = ny * tang + wy * pull
+          break
+        }
+        case BEHAVIOUR.WARDEN: {
+          E.st[i] -= dt
+          if (E.st[i] <= 0) {
+            E.st[i] = 3.6
+            const n = 5
+            for (let k = 0; k < n; k++) {
+              const a = (k / n) * Math.PI * 2 + this.rng()
+              this.spawnAt(
+                E.x[i] + Math.cos(a) * 60, E.y[i] + Math.sin(a) * 60,
+                this.rng() < 0.5 ? E_INDEX.darter : E_INDEX.drifter, minutes,
+              )
+            }
+            this.shock(E.x[i], E.y[i], 130, 0, 0.4, 1, 1.0, 0.78, 0.3, 0)
+          }
+          break
+        }
+        default:
+          break
+      }
+
+      const tvx = wx * spd
+      const tvy = wy * spd
+      const acc = 1 - Math.pow(0.02, dt)
+      E.vx[i] += (tvx - E.vx[i]) * acc
+      E.vy[i] += (tvy - E.vy[i]) * acc
+      E.x[i] += E.vx[i] * dt
+      E.y[i] += E.vy[i] * dt
+      E.rot[i] += def.spin * dt + (def.behaviour === BEHAVIOUR.DART ? 0 : 0)
+      if (def.behaviour === BEHAVIOUR.DART) E.rot[i] = Math.atan2(E.vy[i], E.vx[i]) - Math.PI / 2
+      if (E.flash[i] > 0) E.flash[i] = Math.max(0, E.flash[i] - dt * 5.5)
+      if (E.hitCd[i] > 0) E.hitCd[i] -= dt
+    }
+
+    this.separate(dt)
+  }
+
+  /** The horde has to look like a horde: bodies push each other apart. */
+  private separate(dt: number): void {
+    const E = this.E
+    const g = this.grid
+    const items = g.items
+    const cols = g.cols
+    const rows = g.rows
+    const budget = this.T.separationBudget
+    const push = 260 * dt
+
+    for (let cy = 0; cy < rows; cy++) {
+      for (let cx = 0; cx < cols; cx++) {
+        const c = cy * cols + cx
+        const s0 = g.start(c)
+        const e0 = g.end(c)
+        if (e0 - s0 === 0) continue
+        for (let a = s0; a < e0; a++) {
+          const i = items[a]
+          let used = 0
+          // Same cell, later entries only — every pair is visited once.
+          for (let b = a + 1; b < e0 && used < budget; b++) {
+            if (this.pair(i, items[b], push)) used++
+          }
+          // Right, down-left, down, down-right — the standard half-neighbourhood.
+          for (let n = 0; n < 4 && used < budget; n++) {
+            const nx = cx + (n === 0 ? 1 : n === 1 ? -1 : n === 2 ? 0 : 1)
+            const ny = cy + (n === 0 ? 0 : 1)
+            if (nx < 0 || nx >= cols || ny >= rows) continue
+            const c2 = ny * cols + nx
+            const s1 = g.start(c2)
+            const e1 = g.end(c2)
+            for (let b = s1; b < e1 && used < budget; b++) {
+              if (this.pair(i, items[b], push)) used++
+            }
+          }
+        }
+      }
+    }
+    void E
+  }
+
+  private pair(i: number, j: number, push: number): boolean {
+    const E = this.E
+    const dx = E.x[j] - E.x[i]
+    const dy = E.y[j] - E.y[i]
+    const want = E.radius[i] + E.radius[j]
+    const d2 = dx * dx + dy * dy
+    if (d2 >= want * want || d2 < 0.0001) return false
+    const d = Math.sqrt(d2)
+    const overlap = (want - d) / want
+    const nx = dx / d
+    const ny = dy / d
+    const mi = ENEMIES[E.type[i]].massInv
+    const mj = ENEMIES[E.type[j]].massInv
+    const f = push * overlap
+    E.x[i] -= nx * f * mi
+    E.y[i] -= ny * f * mi
+    E.x[j] += nx * f * mj
+    E.y[j] += ny * f * mj
+    return true
+  }
+
+  /* --------------------------------------------------------------- weapons */
+
+  private fireWeapons(dt: number): void {
+    const s = this.build.stats
+    const rate = s.ratePct * (this.overcharge > 0 ? 2 : 1)
+    const dmgPct = s.dmgPct * (this.overcharge > 0 ? 1.5 : 1)
+
+    for (const w of this.build.weapons) {
+      const cd = cooldown(w, rate) / 1000
+      w.phase += dt
+      switch (w.key) {
+        case "splinter": {
+          w.t -= dt
+          if (w.t > 0) break
+          w.t = cd
+          const tgt = this.nearest(this.px, this.py, 900)
+          const base = tgt >= 0 ? Math.atan2(this.E.y[tgt] - this.py, this.E.x[tgt] - this.px) : this.pAng
+          const spread = Math.min(0.62, 0.09 * (w.count - 1))
+          for (let k = 0; k < w.count; k++) {
+            const a = base + (w.count === 1 ? 0 : (k / (w.count - 1) - 0.5) * 2 * spread)
+            this.shot(a, 640, realDamage(w, dmgPct), w.pierce, 1.5, 0.62, 0.94, 1.0, 9, 0)
+          }
+          this.feel.kick(-Math.cos(base), -Math.sin(base), 0.7)
+          break
+        }
+        case "swarm": {
+          w.t -= dt
+          if (w.t > 0) break
+          w.t = cd
+          for (let k = 0; k < w.count; k++) {
+            const a = this.rng() * Math.PI * 2
+            this.shot(a, 200 + this.rng() * 90, realDamage(w, dmgPct), w.pierce, 4.5, 1.0, 0.45, 0.82, 7, 1)
+          }
+          break
+        }
+        case "arc": {
+          w.t -= dt
+          if (w.t > 0) break
+          w.t = cd
+          this.arc(w.count, realDamage(w, dmgPct), reach(w, s.areaPct))
+          break
+        }
+        case "pulse": {
+          w.t -= dt
+          if (w.t > 0) break
+          w.t = cd
+          this.shock(this.px, this.py, reach(w, s.areaPct), realDamage(w, dmgPct), 0.42, 1, 0.34, 1.0, 0.86, 340)
+          this.audio.tick()
+          this.feel.shake(0.1)
+          break
+        }
+        case "spore": {
+          w.t -= dt
+          if (w.t > 0) break
+          w.t = cd
+          for (let k = 0; k < w.count; k++) {
+            const a = this.rng() * Math.PI * 2
+            const dst = 40 + this.rng() * 150
+            const i = this.B.pool.spawn()
+            if (i < 0) break
+            this.B.x[i] = this.px + Math.cos(a) * dst
+            this.B.y[i] = this.py + Math.sin(a) * dst
+            this.B.vx[i] = 0
+            this.B.vy[i] = 0
+            this.B.life[i] = 1.5
+            this.B.dmg[i] = realDamage(w, dmgPct)
+            this.B.pierce[i] = 1
+            this.B.kind[i] = 2
+            this.B.crit[i] = 0
+            this.B.rot[i] = 0
+            this.B.tgt[i] = reach(w, s.areaPct)
+            this.B.r[i] = 0.72; this.B.g[i] = 1.0; this.B.b[i] = 0.36
+            this.B.size[i] = 11
+          }
+          break
+        }
+        case "halo": {
+          const rad = reach(w, s.areaPct)
+          const spin = w.phase * 2.1
+          for (let k = 0; k < w.count; k++) {
+            const a = spin + (k / w.count) * Math.PI * 2
+            this.meleeHit(
+              this.px + Math.cos(a) * rad, this.py + Math.sin(a) * rad,
+              21, realDamage(w, dmgPct), 190,
+            )
+          }
+          break
+        }
+        case "lance": {
+          w.t -= dt
+          if (w.t > 0) break
+          w.t = cd
+          const len = reach(w, s.areaPct)
+          const spin = w.phase * 0.85
+          for (let k = 0; k < w.count; k++) {
+            const a = spin + (k / w.count) * Math.PI * 2
+            const steps = Math.max(6, Math.floor(len / 40))
+            for (let t = 1; t <= steps; t++) {
+              const d = (t / steps) * len
+              this.meleeHit(this.px + Math.cos(a) * d, this.py + Math.sin(a) * d, 26, realDamage(w, dmgPct), 90)
+            }
+          }
+          break
+        }
+      }
+    }
+  }
+
+  private shot(
+    ang: number, speed: number, dmg: number, pierce: number, life: number,
+    r: number, g: number, b: number, size: number, kind: number,
+  ): number {
+    const i = this.B.pool.spawn()
+    if (i < 0) return -1
+    const s = this.build.stats
+    const crit = this.rng() * 100 < s.critPct
+    this.B.x[i] = this.px
+    this.B.y[i] = this.py
+    this.B.vx[i] = Math.cos(ang) * speed
+    this.B.vy[i] = Math.sin(ang) * speed
+    this.B.life[i] = life
+    this.B.dmg[i] = crit ? dmg * s.critMul : dmg
+    this.B.pierce[i] = pierce
+    this.B.kind[i] = kind
+    this.B.crit[i] = crit ? 1 : 0
+    this.B.rot[i] = ang
+    this.B.tgt[i] = -1
+    if (this.overcharge > 0) { this.B.r[i] = 1; this.B.g[i] = 0.82; this.B.b[i] = 0.34 }
+    else { this.B.r[i] = r; this.B.g[i] = g; this.B.b[i] = b }
+    this.B.size[i] = crit ? size * 1.5 : size
+    return i
+  }
+
+  private enemyShot(x: number, y: number, dx: number, dy: number, dmg: number): void {
+    const i = this.EB.pool.spawn()
+    if (i < 0) return
+    this.EB.x[i] = x
+    this.EB.y[i] = y
+    this.EB.vx[i] = dx * 210
+    this.EB.vy[i] = dy * 210
+    this.EB.life[i] = 5
+    this.EB.dmg[i] = dmg
+    this.EB.size[i] = 9
+    this.EB.rot[i] = Math.atan2(dy, dx)
+    this.audio.tick()
+  }
+
+  private arc(chains: number, dmg: number, range: number): void {
+    let fx = this.px
+    let fy = this.py
+    let last = -1
+    for (let c = 0; c < chains; c++) {
+      const i = this.nearest(fx, fy, c === 0 ? range : 210, last)
+      if (i < 0) break
+      const ex = this.E.x[i]
+      const ey = this.E.y[i]
+      // Draw the bolt as a chain of short-lived sparks along the segment.
+      const steps = Math.max(3, Math.floor(Math.hypot(ex - fx, ey - fy) / 26))
+      for (let t = 0; t <= steps; t++) {
+        const u = t / steps
+        const jx = (this.rng() - 0.5) * 24
+        const jy = (this.rng() - 0.5) * 24
+        this.particle(
+          fx + (ex - fx) * u + jx, fy + (ey - fy) * u + jy,
+          0, 0, 0.16, 8, 0.76, 0.66, 1.0, SHAPE.SPARK, 0.9,
+        )
+      }
+      this.damage(i, dmg, this.rng() * 100 < this.build.stats.critPct, fx, fy, 60)
+      fx = ex
+      fy = ey
+      last = i
+    }
+    if (last >= 0) this.audio.hit()
+  }
+
+  /** Damage everything inside a radius, respecting the shared contact cooldown. */
+  private meleeHit(x: number, y: number, rad: number, dmg: number, knock: number): void {
+    const g = this.grid
+    const E = this.E
+    g.range(x, y, rad + 48, this.range)
+    for (let cy = this.range[1]; cy <= this.range[3]; cy++) {
+      for (let cx = this.range[0]; cx <= this.range[2]; cx++) {
+        const c = cy * g.cols + cx
+        for (let k = g.start(c); k < g.end(c); k++) {
+          const i = g.items[k]
+          if (E.hitCd[i] > 0) continue
+          const dx = E.x[i] - x
+          const dy = E.y[i] - y
+          const rr = rad + E.radius[i]
+          if (dx * dx + dy * dy > rr * rr) continue
+          E.hitCd[i] = 0.16
+          this.damage(i, dmg, this.rng() * 100 < this.build.stats.critPct, x, y, knock)
+        }
+      }
+    }
+  }
+
+  private nearest(x: number, y: number, maxR: number, exclude = -1): number {
+    const g = this.grid
+    const E = this.E
+    g.range(x, y, maxR, this.range)
+    let best = -1
+    let bestD = maxR * maxR
+    for (let cy = this.range[1]; cy <= this.range[3]; cy++) {
+      for (let cx = this.range[0]; cx <= this.range[2]; cx++) {
+        const c = cy * g.cols + cx
+        for (let k = g.start(c); k < g.end(c); k++) {
+          const i = g.items[k]
+          if (i === exclude) continue
+          const dx = E.x[i] - x
+          const dy = E.y[i] - y
+          const d2 = dx * dx + dy * dy
+          if (d2 < bestD) { bestD = d2; best = i }
+        }
+      }
+    }
+    return best
+  }
+
+  /* --------------------------------------------------------------- bullets */
+
+  private updateBullets(dt: number): void {
+    const B = this.B
+    const E = this.E
+    const g = this.grid
+    for (let i = 0; i < B.pool.cap; i++) {
+      if (B.pool.alive[i] === 0) continue
+      B.life[i] -= dt
+      if (B.life[i] <= 0) {
+        if (B.kind[i] === 2) {
+          // A spore pod blooms when its fuse runs out.
+          this.shock(B.x[i], B.y[i], B.tgt[i], B.dmg[i], 0.36, 2, 0.72, 1.0, 0.36, 180)
+          this.audio.hit()
+        }
+        B.pool.kill(i)
+        continue
+      }
+
+      if (B.kind[i] === 1) {
+        // Homing mote: re-acquire when its mark dies.
+        if (B.tgt[i] < 0 || E.pool.alive[B.tgt[i]] === 0) B.tgt[i] = this.nearest(B.x[i], B.y[i], 520)
+        if (B.tgt[i] >= 0) {
+          const dx = E.x[B.tgt[i]] - B.x[i]
+          const dy = E.y[B.tgt[i]] - B.y[i]
+          const d = Math.hypot(dx, dy) || 1
+          const want = 380
+          B.vx[i] += ((dx / d) * want - B.vx[i]) * Math.min(1, dt * 5.5)
+          B.vy[i] += ((dy / d) * want - B.vy[i]) * Math.min(1, dt * 5.5)
+        }
+        B.rot[i] = Math.atan2(B.vy[i], B.vx[i])
+      }
+
+      if (B.kind[i] !== 2) {
+        B.x[i] += B.vx[i] * dt
+        B.y[i] += B.vy[i] * dt
+      }
+
+      if (B.kind[i] === 2) continue // pods only detonate
+
+      const rad = B.size[i] * 0.9
+      g.range(B.x[i], B.y[i], rad + 50, this.range)
+      let done = false
+      for (let cy = this.range[1]; cy <= this.range[3] && !done; cy++) {
+        for (let cx = this.range[0]; cx <= this.range[2] && !done; cx++) {
+          const c = cy * g.cols + cx
+          for (let k = g.start(c); k < g.end(c); k++) {
+            const j = g.items[k]
+            const dx = E.x[j] - B.x[i]
+            const dy = E.y[j] - B.y[i]
+            const rr = rad + E.radius[j]
+            if (dx * dx + dy * dy > rr * rr) continue
+            this.damage(j, B.dmg[i], B.crit[i] === 1, B.x[i], B.y[i], 150)
+            if (--B.pierce[i] <= 0) { B.pool.kill(i); done = true; break }
+          }
+        }
+      }
+    }
+
+    // Enemy fire.
+    const EB = this.EB
+    for (let i = 0; i < EB.pool.cap; i++) {
+      if (EB.pool.alive[i] === 0) continue
+      EB.life[i] -= dt
+      EB.x[i] += EB.vx[i] * dt
+      EB.y[i] += EB.vy[i] * dt
+      if (EB.life[i] <= 0) { EB.pool.kill(i); continue }
+      const dx = EB.x[i] - this.px
+      const dy = EB.y[i] - this.py
+      if (dx * dx + dy * dy < 22 * 22) {
+        this.hurt(EB.dmg[i])
+        EB.pool.kill(i)
+      }
+    }
+  }
+
+  private shock(
+    x: number, y: number, rMax: number, dmg: number, life: number, kind: number,
+    r: number, g: number, b: number, knock: number,
+  ): void {
+    const i = this.S.pool.spawn()
+    if (i < 0) return
+    this.S.x[i] = x
+    this.S.y[i] = y
+    this.S.r[i] = 6
+    this.S.rMax[i] = rMax
+    this.S.dmg[i] = dmg
+    this.S.life[i] = life
+    this.S.max[i] = life
+    this.S.kind[i] = kind
+    this.S.cr[i] = r
+    this.S.cg[i] = g
+    this.S.cb[i] = b
+    this.S.knock[i] = knock
+  }
+
+  private updateShocks(dt: number): void {
+    const S = this.S
+    const E = this.E
+    const g = this.grid
+    for (let i = 0; i < S.pool.cap; i++) {
+      if (S.pool.alive[i] === 0) continue
+      const prev = S.r[i]
+      S.life[i] -= dt
+      const u = 1 - Math.max(0, S.life[i]) / S.max[i]
+      S.r[i] = S.rMax[i] * (1 - Math.pow(1 - u, 2.6))
+      if (S.life[i] <= 0) { S.pool.kill(i); continue }
+      if (S.dmg[i] <= 0) continue
+
+      g.range(S.x[i], S.y[i], S.r[i] + 48, this.range)
+      for (let cy = this.range[1]; cy <= this.range[3]; cy++) {
+        for (let cx = this.range[0]; cx <= this.range[2]; cx++) {
+          const c = cy * g.cols + cx
+          for (let k = g.start(c); k < g.end(c); k++) {
+            const j = g.items[k]
+            const dx = E.x[j] - S.x[i]
+            const dy = E.y[j] - S.y[i]
+            const d = Math.hypot(dx, dy)
+            // Only the leading edge of the ring bites, so it reads as a wave.
+            if (d > S.r[i] + E.radius[j] || d < prev - E.radius[j] - 10) continue
+            if (E.hitCd[j] > 0) continue
+            E.hitCd[j] = 0.22
+            this.damage(j, S.dmg[i], false, S.x[i], S.y[i], S.knock[i])
+          }
+        }
+      }
+    }
+  }
+
+  /* ---------------------------------------------------------------- damage */
+
+  private damage(i: number, amount: number, crit: boolean, sx: number, sy: number, knock: number): void {
+    const E = this.E
+    if (E.pool.alive[i] === 0) return
+    const dmg = crit ? amount * this.build.stats.critMul : amount
+    E.hp[i] -= dmg
+    E.flash[i] = 1
+
+    const dx = E.x[i] - sx
+    const dy = E.y[i] - sy
+    const d = Math.hypot(dx, dy) || 1
+    const mi = ENEMIES[E.type[i]].massInv
+    E.vx[i] += (dx / d) * knock * mi
+    E.vy[i] += (dy / d) * knock * mi
+
+    this.number(E.x[i], E.y[i] - E.radius[i], Math.round(dmg), crit)
+
+    const hard = this.P.pool.n > this.T.maxParticles * 0.8
+    const n = hard ? 1 : Math.round((crit ? 7 : 3) * this.T.particleScale)
+    for (let k = 0; k < n; k++) {
+      const a = Math.atan2(dy, dx) + (this.rng() - 0.5) * 1.5
+      const sp = 90 + this.rng() * 190
+      this.particle(
+        E.x[i], E.y[i], Math.cos(a) * sp, Math.sin(a) * sp, 0.3 + this.rng() * 0.2,
+        4 + this.rng() * 4, 1, 1, 1, SHAPE.SPARK, 0.85,
+      )
+    }
+    this.audio.hit()
+
+    if (E.hp[i] <= 0) this.slay(i)
+  }
+
+  private slay(i: number): void {
+    const E = this.E
+    const def = ENEMIES[E.type[i]]
+    const x = E.x[i]
+    const y = E.y[i]
+    const [cr, cg, cb] = def.col
+    this.kills++
+
+    const burst = Math.round((def.elite ? 60 : 8) * this.T.particleScale)
+    for (let k = 0; k < burst; k++) {
+      const a = this.rng() * Math.PI * 2
+      const sp = (def.elite ? 240 : 110) * (0.35 + this.rng())
+      this.particle(
+        x, y, Math.cos(a) * sp, Math.sin(a) * sp,
+        0.35 + this.rng() * (def.elite ? 0.9 : 0.35),
+        (def.elite ? 9 : 4) + this.rng() * 6,
+        cr, cg, cb, this.rng() < 0.4 ? SHAPE.SPARK : SHAPE.DISC, 0.4,
+      )
+    }
+    this.r.stain(x, y, def.radius * (def.elite ? 3.4 : 1.9), cr * 0.16, cg * 0.16, cb * 0.16, def.elite ? 0.5 : 0.16)
+
+    if (def.elite) {
+      this.audio.killBig()
+      this.feel.shake(0.5)
+      this.feel.stop(70)
+      this.feel.punch(0.4)
+      this.feel.flash(1, 0.85, 0.5, 0.2)
+      this.host.haptic("heavy")
+      this.shock(x, y, 320, 0, 0.55, 1, 1, 0.82, 0.32, 0)
+      this.ui.say("WARDEN FELLED", "THE LIGHT IS YOURS", "#ffd166")
+      // The vacuum moment: every gem on the field comes to you at once.
+      for (let k = 0; k < this.G.pool.cap; k++) if (this.G.pool.alive[k] === 1) this.G.pulled[k] = 1
+      this.dropCore(x, y)
+    } else {
+      this.audio.kill()
+      this.feel.shake(0.035)
+    }
+
+    // Splitters seed the next wave from their own corpse.
+    if (def.behaviour === BEHAVIOUR.SPLIT) {
+      for (let k = 0; k < 3; k++) {
+        const a = (k / 3) * Math.PI * 2 + this.rng()
+        const j = this.spawnAt(x + Math.cos(a) * 26, y + Math.sin(a) * 26, E_INDEX.sporeling, this.runT / 60)
+        if (j >= 0) {
+          this.E.vx[j] = Math.cos(a) * 220
+          this.E.vy[j] = Math.sin(a) * 220
+        }
+      }
+    }
+
+    this.dropGem(x, y, def.xp)
+    E.pool.kill(i)
+  }
+
+  private hurt(amount: number): void {
+    if (this.invuln > 0 || this.mode !== "play") return
+    const s = this.build.stats
+    const dmg = Math.max(1, amount - s.armor)
+    s.hp -= dmg
+    if (this.hurtCd <= 0) {
+      this.hurtCd = 0.24
+      this.audio.hurt()
+      this.host.haptic("medium")
+      this.feel.shake(0.24)
+      // A directional kick rather than hitstop: being hurt must never be the
+      // slow, emphatic moment.
+      this.feel.kick(this.pvx, this.pvy, 2.4)
+      this.feel.flash(1, 0.28, 0.4, 0.1, 9)
+    }
+    this.ui.setLife(s.hp, s.maxHp)
+    if (s.hp <= 0) this.die()
+  }
+
+  private regen(dt: number): void {
+    const s = this.build.stats
+    if (s.regenPer10s > 0 && s.hp < s.maxHp) {
+      s.hp = Math.min(s.maxHp, s.hp + (s.regenPer10s / 10) * dt)
+      this.ui.setLife(s.hp, s.maxHp)
+    }
+  }
+
+  private contact(dt: number): void {
+    const g = this.grid
+    const E = this.E
+    g.range(this.px, this.py, 70, this.range)
+    let touch = 0
+    for (let cy = this.range[1]; cy <= this.range[3]; cy++) {
+      for (let cx = this.range[0]; cx <= this.range[2]; cx++) {
+        const c = cy * g.cols + cx
+        for (let k = g.start(c); k < g.end(c); k++) {
+          const i = g.items[k]
+          const dx = E.x[i] - this.px
+          const dy = E.y[i] - this.py
+          const rr = 15 + E.radius[i]
+          if (dx * dx + dy * dy > rr * rr) continue
+          touch += ENEMIES[E.type[i]].dps
+        }
+      }
+    }
+    if (touch > 0) this.hurt(touch * dt)
+  }
+
+  /* ------------------------------------------------------------------ gems */
+
+  private dropGem(x: number, y: number, value: number): void {
+    const i = this.G.pool.spawn()
+    if (i < 0) return
+    const a = this.rng() * Math.PI * 2
+    this.G.x[i] = x
+    this.G.y[i] = y
+    this.G.vx[i] = Math.cos(a) * 70
+    this.G.vy[i] = Math.sin(a) * 70
+    this.G.value[i] = value
+    this.G.t[i] = 0
+    this.G.pulled[i] = 0
+  }
+
+  private updateGems(dt: number): void {
+    const G = this.G
+    const s = this.build.stats
+    const mag = s.magnet
+    for (let i = 0; i < G.pool.cap; i++) {
+      if (G.pool.alive[i] === 0) continue
+      G.t[i] += dt
+      const dx = this.px - G.x[i]
+      const dy = this.py - G.y[i]
+      const d = Math.hypot(dx, dy) || 1
+      if (G.pulled[i] === 1 || d < mag) {
+        G.pulled[i] = 1
+        const pull = 240 + (1 - Math.min(1, d / 420)) * 900
+        G.vx[i] += (dx / d) * pull * dt
+        G.vy[i] += (dy / d) * pull * dt
+      } else {
+        G.vx[i] *= 1 - Math.min(1, dt * 3.2)
+        G.vy[i] *= 1 - Math.min(1, dt * 3.2)
+      }
+      G.x[i] += G.vx[i] * dt
+      G.y[i] += G.vy[i] * dt
+      if (d < 22) {
+        this.gain(G.value[i])
+        this.audio.pickup()
+        for (let k = 0; k < 2; k++) {
+          this.particle(G.x[i], G.y[i], (this.rng() - 0.5) * 90, (this.rng() - 0.5) * 90, 0.25, 4, 0.4, 1, 0.86, SHAPE.SPARK, 0.8)
+        }
+        G.pool.kill(i)
+      }
+    }
+  }
+
+  private gain(v: number): void {
+    this.xp += Math.max(1, Math.round((v * this.build.stats.xpPct) / 100))
+    while (this.xp >= this.xpNeed) {
+      this.xp -= this.xpNeed
+      this.level++
+      this.xpNeed = xpForLevel(this.level)
+      this.levelUp()
+    }
+    this.ui.setXp(this.xp / this.xpNeed)
+    this.ui.setKills(this.kills)
+  }
+
+  /* -------------------------------------------------------------- particles */
+
+  private particle(
+    x: number, y: number, vx: number, vy: number, life: number, size: number,
+    r: number, g: number, b: number, shape: number, drag: number,
+  ): void {
+    const i = this.P.pool.spawn()
+    if (i < 0) return
+    const P = this.P
+    P.x[i] = x; P.y[i] = y; P.vx[i] = vx; P.vy[i] = vy
+    P.life[i] = life; P.max[i] = life; P.size[i] = size
+    P.r[i] = r; P.g[i] = g; P.b[i] = b
+    P.rot[i] = this.rng() * 6.28
+    P.spin[i] = (this.rng() - 0.5) * 9
+    P.drag[i] = drag
+    P.shape[i] = shape
+    P.glow[i] = 0.4
+  }
+
+  private updateParticles(dt: number): void {
+    const P = this.P
+    for (let i = 0; i < P.pool.cap; i++) {
+      if (P.pool.alive[i] === 0) continue
+      P.life[i] -= dt
+      if (P.life[i] <= 0) { P.pool.kill(i); continue }
+      const k = 1 - Math.pow(P.drag[i] * 0.02 + 0.0002, dt)
+      P.vx[i] -= P.vx[i] * k
+      P.vy[i] -= P.vy[i] * k
+      P.x[i] += P.vx[i] * dt
+      P.y[i] += P.vy[i] * dt
+      P.rot[i] += P.spin[i] * dt
+    }
+  }
+
+  private number(x: number, y: number, value: number, crit: boolean): void {
+    if (!crit && this.N.pool.n > this.T.maxNumbers * 0.82) return
+    const i = this.N.pool.spawn()
+    if (i < 0) return
+    const N = this.N
+    N.x[i] = x + (this.rng() - 0.5) * 14
+    N.y[i] = y
+    N.vy[i] = crit ? -150 : -96
+    N.vx[i] = (this.rng() - 0.5) * 46
+    N.life[i] = crit ? 0.95 : 0.62
+    N.max[i] = N.life[i]
+    N.value[i] = Math.max(1, value)
+    N.crit[i] = crit ? 1 : 0
+    if (crit) { N.r[i] = 1; N.g[i] = 0.82; N.b[i] = 0.24 }
+    else { N.r[i] = 0.86; N.g[i] = 0.96; N.b[i] = 1 }
+  }
+
+  private updateNumbers(dt: number): void {
+    const N = this.N
+    for (let i = 0; i < N.pool.cap; i++) {
+      if (N.pool.alive[i] === 0) continue
+      N.life[i] -= dt
+      if (N.life[i] <= 0) { N.pool.kill(i); continue }
+      N.y[i] += N.vy[i] * dt
+      N.x[i] += N.vx[i] * dt
+      N.vy[i] += 190 * dt
+    }
+  }
+
+  /* -------------------------------------------------------------- director */
+
+  private spawnAt(x: number, y: number, type: number, minutes: number): number {
+    const i = this.E.pool.spawn()
+    if (i < 0) return -1
+    const def = ENEMIES[type]
+    const E = this.E
+    E.x[i] = x
+    E.y[i] = y
+    E.vx[i] = 0
+    E.vy[i] = 0
+    E.type[i] = type
+    E.hp[i] = Math.round(def.hp * hpScale(minutes))
+    E.maxHp[i] = E.hp[i]
+    E.radius[i] = def.radius
+    E.flash[i] = 0.6
+    E.hitCd[i] = 0
+    E.rot[i] = this.rng() * 6.28
+    E.st[i] = this.rng() * 2
+    E.st2[i] = 0
+    E.born[i] = this.runT
+    return i
+  }
+
+  private spawnRing(count: number, type: number, minutes: number, angle: number, spread: number): void {
+    const rad = Math.max(this.halfW, this.halfH) * 1.16
+    for (let k = 0; k < count; k++) {
+      const a = angle + (count === 1 ? 0 : (k / count - 0.5) * spread)
+      const jitter = 1 + (this.rng() - 0.5) * 0.14
+      this.spawnAt(this.px + Math.cos(a) * rad * jitter, this.py + Math.sin(a) * rad * jitter, type, minutes)
+    }
+  }
+
+  private pickType(minutes: number): number {
+    let total = 0
+    for (const e of ENEMIES) if (minutes >= e.from) total += e.weight
+    let r = this.rng() * total
+    for (let i = 0; i < ENEMIES.length; i++) {
+      if (minutes < ENEMIES[i].from) continue
+      r -= ENEMIES[i].weight
+      if (r <= 0) return i
+    }
+    return 0
+  }
+
+  private director(dt: number, minutes: number): void {
+    const want = targetPopulation(minutes, this.T.maxEnemies - 40)
+    const deficit = want - this.E.pool.n
+    if (deficit > 0) {
+      this.spawnAcc += dt * (7 + minutes * 5)
+      const n = Math.min(Math.floor(this.spawnAcc), deficit, 14)
+      if (n > 0) {
+        this.spawnAcc -= n
+        const a = this.rng() * Math.PI * 2
+        const type = this.pickType(minutes)
+        this.spawnRing(n, type, minutes, a, 1.1)
+      }
+    }
+
+    if (this.runT >= this.wardenAt) {
+      this.wardenAt += Math.max(34, 62 - minutes * 2)
+      const a = this.rng() * Math.PI * 2
+      this.spawnRing(1, E_INDEX.warden, minutes, a, 0)
+      this.ui.say("WARDEN", "SOMETHING BIG IS AWAKE", "#ffd166")
+      this.audio.warn()
+      this.feel.shake(0.32)
+      this.host.haptic("heavy")
+    }
+
+    if (this.runT >= this.tideAt) {
+      this.tideAt += Math.max(38, 78 - minutes * 2.5)
+      const a = this.rng() * Math.PI * 2
+      const type = minutes > 5 ? this.pickType(minutes) : E_INDEX.drifter
+      this.spawnRing(Math.min(90, 22 + Math.floor(minutes * 7)), type, minutes, a, 0.85)
+      this.ui.say("A TIDE", "IT IS COMING FROM ONE SIDE", "#7fe6ff")
+      this.audio.warn()
+    }
+
+    if (!this.coreLive && this.runT >= this.coreAt) {
+      const a = this.rng() * Math.PI * 2
+      const d = 300 + this.rng() * 190
+      this.dropCore(this.px + Math.cos(a) * d, this.py + Math.sin(a) * d)
+    }
+  }
+
+  private dropCore(x: number, y: number): void {
+    if (this.coreLive) return
+    this.coreLive = true
+    this.coreX = x
+    this.coreY = y
+    this.corePhase = 0
+    this.coreAt = this.runT + 40
+    this.audio.coreOpen()
+    this.ui.say("A CORE", "SWIM INTO IT", "#ffd166")
+    this.shock(x, y, 260, 0, 0.7, 1, 1, 0.82, 0.34, 0)
+  }
+
+  /* ------------------------------------------------------------ the core Q */
+
+  private openQuestion(): void {
+    const difficulty = Math.max(1, Math.min(10, 1 + Math.floor(this.runT / 88)))
+    const q = this.host.next({ difficulty })
+    this.q = q
+    this.asked++
+    this.qAnswered = false
+    this.qT = 8.5
+    this.qStart = performance.now()
+    this.mode = "core"
+    this.timeScaleTarget = 0.15
+    this.coreLive = false
+    this.audio.duck(0.55, 0.5)
+    this.audio.coreOpen()
+    this.host.haptic("light")
+    this.feel.flash(1, 0.85, 0.45, 0.16)
+    this.feel.punch(-0.2)
+
+    const opts = [q.answer, ...q.distractors.slice(0, 2)]
+    for (let i = opts.length - 1; i > 0; i--) {
+      const j = Math.floor(this.rng() * (i + 1))
+      const t = opts[i]; opts[i] = opts[j]; opts[j] = t
+    }
+    this.orbs.length = 0
+    const base = this.rng() * Math.PI * 2
+    for (let i = 0; i < opts.length; i++) {
+      this.orbs.push({
+        x: 0, y: 0,
+        ang: base + (i / opts.length) * Math.PI * 2,
+        text: opts[i],
+        correct: opts[i] === q.answer,
+        state: 0,
+        t: 0,
+      })
+    }
+  }
+
+  private questTick(dt: number): void {
+    this.qT -= dt
+    const rad = 172
+    for (const o of this.orbs) {
+      o.ang += dt * 0.42
+      o.x = this.px + Math.cos(o.ang) * rad
+      o.y = this.py + Math.sin(o.ang) * rad
+      if (o.state !== 0) { o.t += dt; continue }
+      if (this.qAnswered) continue
+      const dx = o.x - this.px
+      const dy = o.y - this.py
+      // The orbit is a fixed distance away; you reach one by *swimming out*
+      // to it, which is the same verb as everything else in the game.
+      const px = this.px + this.pvx * 0.06
+      const py = this.py + this.pvy * 0.06
+      if ((o.x - px) * (o.x - px) + (o.y - py) * (o.y - py) < 40 * 40) {
+        void dx; void dy
+        this.answer(o)
+      }
+    }
+    if (!this.qAnswered && this.qT <= 0) this.closeQuestion(null)
+  }
+
+  private answer(o: Orb): void {
+    if (this.qAnswered || !this.q) return
+    this.qAnswered = true
+    const ms = performance.now() - this.qStart
+    if (!this.bestMs || ms < this.bestMs) this.bestMs = ms
+    o.state = o.correct ? 1 : 2
+    this.host.report({ questionId: this.q.id, correct: o.correct, ms, answered: o.text })
+    if (o.correct) this.correct++
+    else for (const other of this.orbs) if (other.correct) other.state = 1
+
+    if (o.correct) {
+      this.audio.answerRight()
+      this.audio.overcharge()
+      this.host.haptic("success")
+      this.overcharge = 9
+      this.feel.stop(110)
+      this.feel.shake(0.72)
+      this.feel.punch(0.55)
+      this.feel.flash(1, 0.9, 0.55, 0.32, 3.4)
+      this.ui.say("OVERCHARGE", "NINE SECONDS OF RUIN", "#ffe08a")
+      const big = Math.max(this.halfW, this.halfH) * 1.55
+      this.shock(this.px, this.py, big, 9999, 0.85, 1, 1, 0.86, 0.4, 620)
+      for (let k = 0; k < Math.round(120 * this.T.particleScale); k++) {
+        const a = this.rng() * Math.PI * 2
+        const sp = 220 + this.rng() * 780
+        this.particle(this.px, this.py, Math.cos(a) * sp, Math.sin(a) * sp, 0.5 + this.rng() * 0.7, 6 + this.rng() * 9, 1, 0.86, 0.42, this.rng() < 0.5 ? SHAPE.SPARK : SHAPE.DISC, 0.5)
+      }
+    } else {
+      this.audio.answerWrong()
+      this.host.haptic("failure")
+      this.feel.shake(0.4)
+      this.feel.kick(o.x - this.px, o.y - this.py, 3)
+      this.feel.flash(0.9, 0.3, 0.5, 0.1, 8)
+      this.ui.say("THE SWARM ANSWERS", "THE GOLD ONE WAS THE ONE", "#ff9ab6")
+      // The cost is real and it is legible: a pack lands on top of you.
+      const minutes = this.runT / 60
+      for (let k = 0; k < 9; k++) {
+        const a = (k / 9) * Math.PI * 2
+        this.spawnAt(this.px + Math.cos(a) * 190, this.py + Math.sin(a) * 190, this.pickType(minutes), minutes)
+      }
+      for (let k = 0; k < Math.round(40 * this.T.particleScale); k++) {
+        const a = this.rng() * Math.PI * 2
+        this.particle(o.x, o.y, Math.cos(a) * 260, Math.sin(a) * 260, 0.5, 6, 1, 0.32, 0.5, SHAPE.SPARK, 0.6)
+      }
+    }
+    // A short beat to read the result, then back to the fight.
+    window.setTimeout(() => this.closeQuestion(o), 620)
+  }
+
+  private closeQuestion(o: Orb | null): void {
+    if (this.mode !== "core") return
+    if (!o) {
+      this.ui.say("IT CLOSED", "", "#8fb6d8")
+      this.audio.tick()
+      if (this.q) this.host.report({ questionId: this.q.id, correct: false, ms: 8500, answered: "" })
+    }
+    this.q = null
+    this.orbs.length = 0
+    this.mode = "play"
+    this.timeScaleTarget = 1
+  }
+
+  /* -------------------------------------------------------------- level up */
+
+  private levelUp(): void {
+    this.levelUps++
+    this.ui.setLevel(this.level)
+    this.audio.levelup()
+    this.audio.duck(0.4, 0.4)
+    this.host.haptic("success")
+    this.feel.flash(0.6, 0.95, 1, 0.22, 4)
+    this.feel.punch(0.3)
+    this.feel.stop(70)
+    this.mode = "levelup"
+    this.timeScale = 1
+    this.timeScaleTarget = 1
+
+    this.cards = rollCards(this.build, this.rng, 3, this.runT / 60)
+    this.sealedQ = null
+    if (this.levelUps % 3 === 0) {
+      const difficulty = Math.max(1, Math.min(10, 1 + Math.floor(this.runT / 88)))
+      this.sealedQ = this.host.next({ difficulty })
+      this.asked++
+    }
+    this.ui.showCards(this.cards, this.sealedQ, this.level)
+  }
+
+  private pickCard(i: number): void {
+    const c = this.cards[i]
+    if (!c) return
+    c.apply()
+    this.audio.card()
+    this.host.haptic("light")
+    this.ui.hideCards()
+    this.ui.say(c.title, c.tag, "#9fe8ff")
+    this.feel.punch(0.22)
+    this.syncHud()
+    this.mode = "play"
+    this.lastT = performance.now()
+    this.acc = 0
+  }
+
+  private sealedAnswer(res: { correct: boolean; ms: number; answered: string }): void {
+    if (!this.sealedQ) return
+    this.host.report({ questionId: this.sealedQ.id, correct: res.correct, ms: res.ms, answered: res.answered })
+    if (res.correct) {
+      this.correct++
+      this.audio.evolve()
+      this.host.haptic("success")
+      const reward = rollCards(this.build, this.rng, 1, this.runT / 60, true)[0]
+      reward.apply()
+      this.feel.flash(1, 0.88, 0.5, 0.28, 3.6)
+      this.feel.punch(0.5)
+      this.feel.shake(0.4)
+      window.setTimeout(() => {
+        this.ui.hideCards()
+        this.ui.say(reward.title, `${reward.tag} — SEALED CACHE`, "#ffd166")
+        this.syncHud()
+        this.mode = "play"
+        this.lastT = performance.now()
+        this.acc = 0
+      }, 520)
+    } else {
+      this.audio.answerWrong()
+      this.host.haptic("failure")
+    }
+    this.sealedQ = null
+  }
+
+  /* ------------------------------------------------------------------ rift */
+
+  private die(): void {
+    if (this.mode === "rift" || this.mode === "over") return
+    this.build.stats.hp = 0
+    this.audio.death()
+    this.host.haptic("failure")
+    this.feel.shake(0.6)
+    this.feel.flash(0.9, 0.35, 0.55, 0.16, 3)
+    for (let k = 0; k < Math.round(90 * this.T.particleScale); k++) {
+      const a = this.rng() * Math.PI * 2
+      const sp = 120 + this.rng() * 420
+      this.particle(this.px, this.py, Math.cos(a) * sp, Math.sin(a) * sp, 0.8 + this.rng(), 7, 1, 0.94, 0.7, SHAPE.SPARK, 0.4)
+    }
+    this.mode = "rift"
+    this.riftNeeded = this.revives + 1
+    this.riftCharges = 0
+    this.riftT = 20 + this.riftNeeded * 6
+    this.audio.riftOpen()
+    this.audio.duck(0.35, 0.8)
+    this.nextRiftQuestion()
+  }
+
+  private nextRiftQuestion(): void {
+    const difficulty = Math.max(1, Math.min(10, 1 + Math.floor(this.runT / 88)))
+    this.riftQ = this.host.next({ difficulty })
+    this.asked++
+    this.ui.showRift(this.riftQ, this.riftCharges, this.riftNeeded)
+  }
+
+  private riftAnswer(res: { correct: boolean; ms: number; answered: string }): void {
+    if (!this.riftQ) return
+    this.host.report({ questionId: this.riftQ.id, correct: res.correct, ms: res.ms, answered: res.answered })
+    if (res.correct) {
+      this.correct++
+      this.riftCharges++
+      this.audio.answerRight()
+      this.host.haptic("success")
+      this.feel.flash(1, 0.9, 0.6, 0.2)
+    } else {
+      // Progress is never taken away. Time is: the cost is real, and it is
+      // the one cost a child can see draining.
+      this.riftT = Math.max(1.5, this.riftT - 4)
+      this.audio.answerWrong()
+      this.host.haptic("failure")
+    }
+    window.setTimeout(() => {
+      if (this.mode !== "rift") return
+      if (this.riftCharges >= this.riftNeeded) this.revive()
+      else this.nextRiftQuestion()
+    }, res.correct ? 480 : 900)
+  }
+
+  private riftTick(dt: number): void {
+    this.riftT -= dt
+    this.ui.setRiftClock(this.riftT / (20 + this.riftNeeded * 6))
+    if (this.riftT <= 0) this.over()
+  }
+
+  private revive(): void {
+    this.revives++
+    this.ui.hideRift()
+    this.mode = "play"
+    this.lastT = performance.now()
+    this.acc = 0
+    const s = this.build.stats
+    s.hp = s.maxHp
+    this.invuln = 3.5
+    this.audio.revive()
+    this.audio.nova()
+    this.host.haptic("success")
+    this.feel.stop(140)
+    this.feel.shake(0.85)
+    this.feel.punch(0.7)
+    this.feel.flash(1, 0.95, 0.8, 0.34, 2.6)
+    this.ui.say("RISEN", "THE RIFT HELD", "#ffe6a8")
+    this.shock(this.px, this.py, Math.max(this.halfW, this.halfH) * 1.7, 9999, 0.9, 1, 1, 0.95, 0.7, 900)
+    for (let k = 0; k < Math.round(160 * this.T.particleScale); k++) {
+      const a = this.rng() * Math.PI * 2
+      const sp = 260 + this.rng() * 900
+      this.particle(this.px, this.py, Math.cos(a) * sp, Math.sin(a) * sp, 0.6 + this.rng() * 0.8, 7 + this.rng() * 10, 1, 0.95, 0.75, SHAPE.SPARK, 0.45)
+    }
+    this.ui.setLife(s.hp, s.maxHp)
+  }
+
+  private over(): void {
+    this.mode = "over"
+    this.ui.hideRift()
+    let best = 0
+    try {
+      best = Number(localStorage.getItem("hz.best") || 0)
+      if (this.runT > best) { best = this.runT; localStorage.setItem("hz.best", String(Math.round(best))) }
+    } catch { /* storage can be denied; the run still counts */ }
+    const mm = Math.floor(this.runT / 60)
+    const ss = Math.floor(this.runT % 60)
+    this.ui.showOver(
+      [
+        { label: "SURVIVED", value: `${mm}:${ss < 10 ? "0" : ""}${ss}` },
+        { label: "SLAIN", value: String(this.kills) },
+        { label: "LEVEL", value: String(this.level) },
+        { label: "ANSWERED", value: `${this.correct}/${this.asked}` },
+        { label: "BEST", value: `${Math.floor(best / 60)}:${String(Math.floor(best % 60)).padStart(2, "0")}` },
+      ],
+      "THE DARK TOOK YOU",
+    )
+  }
+
+  private syncHud(): void {
+    const s = this.build.stats
+    this.ui.setLife(s.hp, s.maxHp)
+    this.ui.setLevel(this.level)
+    this.ui.setXp(this.xp / this.xpNeed)
+    this.ui.setKills(this.kills)
+    this.ui.setWeapons(
+      this.build.weapons.map((w) => `${w.name} <b>${w.count}×${realDamage(w, s.dmgPct)}</b>`),
+    )
+  }
+
+  /* ------------------------------------------------------------------ draw */
+
+  private draw(frame: number): void {
+    const zoom = this.feel.zoom
+    const hw = this.halfW / zoom
+    const hh = this.halfH / zoom
+
+    // Camera leads the diver so you can see where you are going.
+    const leadX = this.px + this.pvx * 0.14
+    const leadY = this.py + this.pvy * 0.14
+    const k = Math.min(1, frame * 7.5)
+    this.camX += (leadX - this.camX) * k
+    this.camY += (leadY - this.camY) * k
+    this.feel.shakeOffset(this.shakeOut, (hw * 2) / Math.max(1, this.r.w), this.wallT)
+
+    const r = this.r
+    r.beginFrame(this.camX + this.shakeOut[0] + this.feel.kickX, this.camY + this.shakeOut[1] + this.feel.kickY, hw, hh)
+
+    const minX = this.camX - hw - 90
+    const maxX = this.camX + hw + 90
+    const minY = this.camY - hh - 90
+    const maxY = this.camY + hh + 90
+    const t = this.wallT
+
+    /* stains and ground-level shocks first (order is cosmetic under additive) */
+    const S = this.S
+    for (let i = 0; i < S.pool.cap; i++) {
+      if (S.pool.alive[i] === 0) continue
+      const u = 1 - S.life[i] / S.max[i]
+      const a = (1 - u) * (1 - u) * 0.95
+      const rr = S.r[i]
+      r.sprite(S.x[i], S.y[i], rr, rr, 0, S.cr[i], S.cg[i], S.cb[i], a, SHAPE.RING, 0.1 + u * 0.16, 0.3)
+      r.sprite(S.x[i], S.y[i], rr * 0.96, rr * 0.96, 0, S.cr[i], S.cg[i], S.cb[i], a * 0.18, SHAPE.DISC, 2.4, 0)
+    }
+
+    /* gems */
+    const G = this.G
+    for (let i = 0; i < G.pool.cap; i++) {
+      if (G.pool.alive[i] === 0) continue
+      const x = G.x[i]
+      const y = G.y[i]
+      if (x < minX || x > maxX || y < minY || y > maxY) continue
+      const big = G.value[i] >= 40
+      const sz = big ? 15 : G.value[i] >= 3 ? 9 : 7
+      const pulse = 1 + Math.sin(t * 7 + i) * 0.14
+      const cr = big ? 1 : 0.34
+      const cg = big ? 0.86 : 1
+      const cb = big ? 0.36 : 0.86
+      r.sprite(x, y, sz * 2.6, sz * 2.6, 0, cr, cg, cb, 0.22, SHAPE.DISC, 1.7, 0)
+      r.sprite(x, y, sz * pulse, sz * pulse, t * 2 + i, cr, cg, cb, 1, SHAPE.GEM, 1, 0.3)
+    }
+
+    /* enemies */
+    const E = this.E
+    for (let i = 0; i < E.pool.cap; i++) {
+      if (E.pool.alive[i] === 0) continue
+      const x = E.x[i]
+      const y = E.y[i]
+      if (x < minX || x > maxX || y < minY || y > maxY) continue
+      const def = ENEMIES[E.type[i]]
+      const rad = E.radius[i]
+      const f = E.flash[i]
+      const [cr, cg, cb] = def.col
+      r.sprite(x, y, rad * 2.3, rad * 2.3, 0, cr, cg, cb, 0.20 + f * 0.3, SHAPE.DISC, 1.9, 0)
+      r.sprite(x, y, rad, rad, E.rot[i], cr, cg, cb, 0.95, def.shape, 0.15, f * 0.9)
+      if (def.elite) {
+        const hpf = Math.max(0, E.hp[i] / E.maxHp[i])
+        r.sprite(x, y, rad * 1.5, rad * 1.5, t * 1.3, 1, 0.86, 0.4, 0.55, SHAPE.RING, 0.05, 0.2)
+        r.sprite(x, y, rad * 1.9, rad * 1.9, -t * 0.9, 1, 0.7, 0.3, 0.34, SHAPE.RING, 0.03, 0)
+        // Health as a shrinking arc of light: readable without a bar.
+        r.sprite(x, y - rad * 2.2, rad * 1.5 * hpf, 4, 0, 1, 0.5, 0.4, 0.9, SHAPE.CAPSULE, 0.5, 0.4)
+      }
+      if (def.behaviour === BEHAVIOUR.CHARGE && E.st2[i] > 0) {
+        r.sprite(x, y, rad * 3.4, rad * 1.1, E.rot[i], 1, 0.5, 0.2, 0.5, SHAPE.CAPSULE, 0.35, 0.4)
+      }
+    }
+
+    /* player bullets */
+    const B = this.B
+    for (let i = 0; i < B.pool.cap; i++) {
+      if (B.pool.alive[i] === 0) continue
+      const x = B.x[i]
+      const y = B.y[i]
+      if (x < minX || x > maxX || y < minY || y > maxY) continue
+      const sz = B.size[i]
+      if (B.kind[i] === 2) {
+        const fuse = 1 - B.life[i] / 1.5
+        r.sprite(x, y, sz * (1 + fuse * 1.6), sz * (1 + fuse * 1.6), t * 5, B.r[i], B.g[i], B.b[i], 0.8, SHAPE.RING, 0.2, fuse * 0.6)
+        r.sprite(x, y, sz * 2.4, sz * 2.4, 0, B.r[i], B.g[i], B.b[i], 0.2, SHAPE.DISC, 1.8, 0)
+      } else {
+        r.sprite(x, y, sz * 2.6, sz * 1.7, B.rot[i], B.r[i], B.g[i], B.b[i], 0.9, SHAPE.CAPSULE, 0.34, 0.55)
+        r.sprite(x, y, sz * 3.2, sz * 3.2, 0, B.r[i], B.g[i], B.b[i], 0.24, SHAPE.DISC, 1.9, 0)
+      }
+    }
+
+    /* enemy bullets — a different shape as well as a different colour */
+    const EB = this.EB
+    for (let i = 0; i < EB.pool.cap; i++) {
+      if (EB.pool.alive[i] === 0) continue
+      r.sprite(EB.x[i], EB.y[i], 11, 11, t * 4, 1, 0.34, 0.24, 0.95, SHAPE.SHARD, 0.3, 0.2)
+      r.sprite(EB.x[i], EB.y[i], 26, 26, 0, 1, 0.3, 0.2, 0.28, SHAPE.DISC, 1.9, 0)
+    }
+
+    /* halo + lance, drawn from the build rather than stored */
+    this.drawMelee(t)
+
+    /* particles */
+    const P = this.P
+    for (let i = 0; i < P.pool.cap; i++) {
+      if (P.pool.alive[i] === 0) continue
+      const u = P.life[i] / P.max[i]
+      const sz = P.size[i] * (0.35 + u * 0.65)
+      r.sprite(P.x[i], P.y[i], sz, sz, P.rot[i], P.r[i], P.g[i], P.b[i], u * 0.95, P.shape[i], 1.4, P.glow[i] * u)
+    }
+
+    /* the core */
+    if (this.coreLive) {
+      this.corePhase += frame
+      const p = this.corePhase
+      const pulse = 1 + Math.sin(p * 3.4) * 0.12
+      r.sprite(this.coreX, this.coreY, 96 * pulse, 96 * pulse, 0, 1, 0.8, 0.32, 0.28, SHAPE.DISC, 1.6, 0)
+      r.sprite(this.coreX, this.coreY, 46 * pulse, 46 * pulse, p * 1.1, 1, 0.84, 0.36, 0.95, SHAPE.RING, 0.09, 0.3)
+      r.sprite(this.coreX, this.coreY, 30, 30, -p * 1.7, 1, 0.9, 0.5, 1, SHAPE.SPARK, 0.4, 0.5)
+      r.sprite(this.coreX, this.coreY, 70 + Math.sin(p * 2) * 12, 70 + Math.sin(p * 2) * 12, -p * 0.6, 1, 0.78, 0.3, 0.4, SHAPE.RING, 0.03, 0)
+      this.drawOffscreenMarker(this.coreX, this.coreY, hw, hh, 1, 0.82, 0.34)
+    }
+
+    /* the question */
+    if (this.q) {
+      const fade = Math.min(1, this.qT * 2)
+      r.text(this.q.prompt, this.px, this.py - 116, 56, 1, 1, 1, fade)
+      const ring = 172
+      r.sprite(this.px, this.py, ring, ring, t * 0.4, 1, 0.86, 0.44, 0.30 * fade, SHAPE.RING, 0.012, 0.2)
+      // Time as a closing iris, not a number.
+      const frac = Math.max(0, this.qT / 8.5)
+      r.sprite(this.px, this.py, ring * (0.35 + frac * 0.62), ring * (0.35 + frac * 0.62), -t * 0.9, 1, 0.7, 0.3, 0.34 * fade, SHAPE.RING, 0.02, 0)
+      for (const o of this.orbs) {
+        const hot = o.state === 1 ? 1 : 0
+        const bad = o.state === 2 ? 1 : 0
+        const cr = bad ? 1 : 1
+        const cg = bad ? 0.3 : 0.88
+        const cb = bad ? 0.45 : 0.45
+        const s = 40 + (o.state ? Math.sin(o.t * 22) * 5 : Math.sin(t * 5 + o.ang) * 3)
+        r.sprite(o.x, o.y, s * 2.4, s * 2.4, 0, cr, cg, cb, 0.3 + hot * 0.5, SHAPE.DISC, 1.7, hot * 0.5)
+        r.sprite(o.x, o.y, s, s, t * 0.8, cr, cg, cb, 0.95, SHAPE.RING, 0.14, hot * 0.7 + bad * 0.3)
+        r.text(o.text, o.x, o.y, 38, 1, 1, 1, 1)
+      }
+    }
+
+    /* damage numbers */
+    const N = this.N
+    for (let i = 0; i < N.pool.cap; i++) {
+      if (N.pool.alive[i] === 0) continue
+      const u = N.life[i] / N.max[i]
+      const crit = N.crit[i] === 1
+      const size = (crit ? 34 : 22) * (1 + (1 - u) * 0.12)
+      r.text(String(N.value[i]), N.x[i], N.y[i], size, N.r[i], N.g[i], N.b[i], Math.min(1, u * 1.9))
+    }
+
+    /* the diver */
+    this.drawPlayer(t)
+
+    /* the stick */
+    if (this.input.stick.active && this.input.stick.touch) this.drawStick(hw, hh)
+
+    const intensity = Math.min(1, this.runT / 540)
+    r.endFrame({
+      time: t,
+      intensity,
+      flashR: this.feel.flashR,
+      flashG: this.feel.flashG,
+      flashB: this.feel.flashB,
+      flashA: this.feel.flashA,
+      aberration: this.T.aberration && !this.reduced
+        ? Math.min(0.010, this.feel.trauma * this.feel.trauma * 0.014 + (this.overcharge > 0 ? 0.0018 : 0))
+        : 0,
+      vignette: 0.85,
+      desat: this.desat,
+      bloom: 1 + (this.overcharge > 0 ? 0.42 : 0),
+    })
+
+    if (this.mode === "play" || this.mode === "core") this.ui.setClock(this.runT)
+  }
+
+  private drawMelee(t: number): void {
+    const r = this.r
+    const s = this.build.stats
+    for (const w of this.build.weapons) {
+      if (w.key === "halo") {
+        const rad = reach(w, s.areaPct)
+        const spin = w.phase * 2.1
+        r.sprite(this.px, this.py, rad, rad, 0, 1, 0.72, 0.34, 0.16, SHAPE.RING, 0.015, 0)
+        for (let k = 0; k < w.count; k++) {
+          const a = spin + (k / w.count) * Math.PI * 2
+          const x = this.px + Math.cos(a) * rad
+          const y = this.py + Math.sin(a) * rad
+          r.sprite(x, y, 30, 12, a + Math.PI / 2, 1, 0.75, 0.36, 0.95, SHAPE.SHARD, 0.5, 0.35)
+          r.sprite(x, y, 46, 46, 0, 1, 0.7, 0.3, 0.22, SHAPE.DISC, 1.8, 0)
+        }
+      } else if (w.key === "lance") {
+        const len = reach(w, s.areaPct)
+        const spin = w.phase * 0.85
+        for (let k = 0; k < w.count; k++) {
+          const a = spin + (k / w.count) * Math.PI * 2
+          const mx = this.px + (Math.cos(a) * len) / 2
+          const my = this.py + (Math.sin(a) * len) / 2
+          r.sprite(mx, my, len / 2, 16, a, 1, 0.4, 0.34, 0.75, SHAPE.CAPSULE, 0.28, 0.5)
+          r.sprite(mx, my, len / 2, 34, a, 1, 0.3, 0.3, 0.2, SHAPE.CAPSULE, 0.5, 0)
+        }
+        void t
+      }
+    }
+  }
+
+  private drawPlayer(t: number): void {
+    const r = this.r
+    const oc = this.overcharge > 0
+    const inv = this.invuln > 0
+    const blink = inv ? 0.55 + Math.sin(t * 30) * 0.4 : 1
+    const cr = oc ? 1 : 1
+    const cg = oc ? 0.85 : 0.96
+    const cb = oc ? 0.4 : 0.78
+
+    if (oc) {
+      const p = 1 + Math.sin(t * 9) * 0.1
+      r.sprite(this.px, this.py, 150 * p, 150 * p, 0, 1, 0.8, 0.3, 0.22, SHAPE.DISC, 1.5, 0)
+      r.sprite(this.px, this.py, 64 * p, 64 * p, -t * 3, 1, 0.86, 0.4, 0.55, SHAPE.RING, 0.05, 0.3)
+      r.sprite(this.px, this.py, 92, 92, t * 2, 1, 0.78, 0.32, 0.3, SHAPE.RING, 0.02, 0)
+    }
+    if (inv) r.sprite(this.px, this.py, 44, 44, -t * 4, 0.6, 0.95, 1, 0.5, SHAPE.RING, 0.06, 0.3)
+
+    r.sprite(this.px, this.py, 60, 60, 0, cr, cg, cb, 0.30 * blink, SHAPE.DISC, 1.5, 0)
+    r.sprite(this.px, this.py, 30, 30, t * 1.4, cr, cg, cb, 0.75 * blink, SHAPE.RING, 0.16, 0.4)
+    r.sprite(this.px, this.py, 26, 26, -t * 2.2, 1, 1, 1, blink, SHAPE.SPARK, 0.28, 0.55)
+  }
+
+  private drawStick(hw: number, hh: number): void {
+    const st = this.input.stick
+    const r = this.r
+    const wpp = (hw * 2) / Math.max(1, this.canvas.clientWidth)
+    const hpp = (hh * 2) / Math.max(1, this.canvas.clientHeight)
+    const ox = this.camX - hw + st.originX * wpp
+    const oy = this.camY - hh + st.originY * hpp
+    const kx = this.camX - hw + st.knobX * wpp
+    const ky = this.camY - hh + st.knobY * hpp
+    const rad = 62 * wpp
+    r.sprite(ox, oy, rad, rad, 0, 0.5, 0.85, 1, 0.22, SHAPE.RING, 0.03, 0)
+    r.sprite(kx, ky, rad * 0.4, rad * 0.4, 0, 0.7, 0.95, 1, 0.5, SHAPE.DISC, 1.2, 0.2)
+  }
+
+  private drawOffscreenMarker(x: number, y: number, hw: number, hh: number, r0: number, g0: number, b0: number): void {
+    const dx = x - this.camX
+    const dy = y - this.camY
+    if (Math.abs(dx) < hw * 0.92 && Math.abs(dy) < hh * 0.92) return
+    const a = Math.atan2(dy, dx)
+    const ex = this.camX + Math.max(-hw * 0.9, Math.min(hw * 0.9, dx))
+    const ey = this.camY + Math.max(-hh * 0.9, Math.min(hh * 0.9, dy))
+    const pulse = 1 + Math.sin(this.wallT * 6) * 0.2
+    this.r.sprite(ex, ey, 26 * pulse, 26 * pulse, a - Math.PI / 2, r0, g0, b0, 0.9, SHAPE.DART, 0.4, 0.4)
+    this.r.sprite(ex, ey, 60, 60, 0, r0, g0, b0, 0.2, SHAPE.DISC, 1.7, 0)
+  }
+
+  /* ------------------------------------------------------- external events */
+
+  /** Called from the frame loop in `play` mode — kept separate for clarity. */
+  checkCore(): void {
+    if (!this.coreLive || this.mode !== "play") return
+    const dx = this.coreX - this.px
+    const dy = this.coreY - this.py
+    if (dx * dx + dy * dy < 46 * 46) this.openQuestion()
+  }
+}

--- a/dynawalla/games/horde/src/game/loadout.ts
+++ b/dynawalla/games/horde/src/game/loadout.ts
@@ -1,0 +1,463 @@
+/**
+ * The build. Every number a card shows is an integer the simulation actually
+ * uses — there is no display value and no hidden value, so a child who reads
+ * `5 × 14 = 70` and picks it gets exactly seventy.
+ *
+ * This is the ambient arithmetic layer. It is not a quiz: it is the ordinary
+ * business of choosing an upgrade, made honest. Choosing well *is* comparing
+ * products, and choosing badly costs you the next thirty seconds.
+ */
+
+export type WeaponKey = "splinter" | "halo" | "arc" | "pulse" | "swarm" | "lance" | "spore"
+
+export type Weapon = {
+  key: WeaponKey
+  name: string
+  /** shards / blades / chain links / motes / pods / beams */
+  count: number
+  dmg: number
+  cdMs: number
+  radius: number
+  pierce: number
+  /** runtime */
+  t: number
+  phase: number
+  level: number
+}
+
+export type Stats = {
+  maxHp: number
+  hp: number
+  speed: number
+  magnet: number
+  dmgPct: number
+  ratePct: number
+  areaPct: number
+  critPct: number
+  critMul: number
+  regenPer10s: number
+  xpPct: number
+  armor: number
+}
+
+const BASE: Record<WeaponKey, Omit<Weapon, "t" | "phase" | "level">> = {
+  splinter: { key: "splinter", name: "SPLINTER", count: 1, dmg: 6, cdMs: 620, radius: 0, pierce: 1 },
+  halo: { key: "halo", name: "HALO", count: 2, dmg: 5, cdMs: 340, radius: 82, pierce: 99 },
+  arc: { key: "arc", name: "ARC", count: 2, dmg: 9, cdMs: 1050, radius: 300, pierce: 1 },
+  pulse: { key: "pulse", name: "PULSE", count: 1, dmg: 14, cdMs: 2200, radius: 130, pierce: 99 },
+  swarm: { key: "swarm", name: "SWARM", count: 2, dmg: 5, cdMs: 850, radius: 0, pierce: 1 },
+  lance: { key: "lance", name: "LANCE", count: 1, dmg: 4, cdMs: 90, radius: 430, pierce: 99 },
+  spore: { key: "spore", name: "SPORE", count: 1, dmg: 22, cdMs: 1900, radius: 74, pierce: 99 },
+}
+
+export const WEAPON_BLURB: Record<WeaponKey, string> = {
+  splinter: "shards at the nearest thing",
+  halo: "blades that orbit you",
+  arc: "lightning that jumps",
+  pulse: "a ring that shoves the swarm off you",
+  swarm: "motes that hunt",
+  lance: "a beam that sweeps the dark",
+  spore: "pods that bloom",
+}
+
+export const MAX_WEAPONS = 5
+
+export function makeWeapon(key: WeaponKey): Weapon {
+  return { ...BASE[key], t: 0, phase: Math.random() * Math.PI * 2, level: 1 }
+}
+
+export function newStats(): Stats {
+  return {
+    maxHp: 100, hp: 100,
+    speed: 205,
+    magnet: 78,
+    dmgPct: 100,
+    ratePct: 100,
+    areaPct: 100,
+    critPct: 5,
+    critMul: 2,
+    regenPer10s: 0,
+    xpPct: 100,
+    armor: 0,
+  }
+}
+
+/** The headline number on a weapon card: what one full volley is worth. */
+export function power(w: Weapon, dmgPct: number): number {
+  return w.count * Math.max(1, Math.round((w.dmg * dmgPct) / 100))
+}
+
+export function realDamage(w: Weapon, dmgPct: number): number {
+  return Math.max(1, Math.round((w.dmg * dmgPct) / 100))
+}
+
+export function cooldown(w: Weapon, ratePct: number): number {
+  return Math.max(48, Math.round((w.cdMs * 100) / Math.max(20, ratePct)))
+}
+
+export function reach(w: Weapon, areaPct: number): number {
+  return Math.round((w.radius * areaPct) / 100)
+}
+
+/* ------------------------------------------------------------------ cards */
+
+export type Rarity = 0 | 1 | 2
+
+export type Card = {
+  id: string
+  kind: "weapon-new" | "weapon-up" | "passive" | "heal"
+  title: string
+  /** The offer, in the player's language of integers. */
+  tag: string
+  /** Left and right of the arrow, both exact. */
+  before: string
+  after: string
+  /** Big legible resulting number; "" when the card has no single figure. */
+  head: string
+  sub: string
+  rarity: Rarity
+  hue: [number, number, number]
+  apply: () => void
+}
+
+export type Build = {
+  weapons: Weapon[]
+  stats: Stats
+  has(key: WeaponKey): Weapon | undefined
+}
+
+export function makeBuild(): Build {
+  const weapons: Weapon[] = [makeWeapon("splinter")]
+  const stats = newStats()
+  return {
+    weapons,
+    stats,
+    has(key) {
+      return weapons.find((w) => w.key === key)
+    },
+  }
+}
+
+const WEAPON_HUE: Record<WeaponKey, [number, number, number]> = {
+  splinter: [0.55, 0.92, 1.0],
+  halo: [1.0, 0.72, 0.32],
+  arc: [0.72, 0.62, 1.0],
+  pulse: [0.34, 1.0, 0.82],
+  swarm: [1.0, 0.45, 0.78],
+  lance: [1.0, 0.36, 0.30],
+  spore: [0.72, 1.0, 0.36],
+}
+
+const PASSIVE_HUE: [number, number, number] = [0.85, 0.90, 1.0]
+
+type Offer = { weight: number; make: () => Card }
+
+/**
+ * @param rng deterministic per-run
+ * @param sealed when true, only rare and epic offers are eligible — this is
+ *        what the arithmetic lock on the fourth card buys you.
+ */
+export function rollCards(
+  build: Build, rng: () => number, n: number, minutes: number, sealed = false,
+): Card[] {
+  const s = build.stats
+  const offers: Offer[] = []
+
+  /* ---- weapon damage / count, one card each so the trade is a real one -- */
+  for (const w of build.weapons) {
+    const p0 = power(w, s.dmgPct)
+    const d0 = realDamage(w, s.dmgPct)
+
+    const addCount = w.key === "pulse" ? 0 : (w.key === "halo" || w.key === "swarm" ? 2 : (w.key === "lance" ? 1 : 2))
+    if (addCount > 0 && w.count < 26) {
+      offers.push({
+        weight: 26,
+        make: () => ({
+          id: `${w.key}-count`,
+          kind: "weapon-up",
+          title: w.name,
+          tag: `+${addCount} ${countNoun(w.key, addCount)}`,
+          before: `${w.count} × ${d0} = ${p0}`,
+          after: `${w.count + addCount} × ${d0} = ${(w.count + addCount) * d0}`,
+          head: String((w.count + addCount) * d0),
+          sub: "VOLLEY",
+          rarity: 1,
+          hue: WEAPON_HUE[w.key],
+          apply: () => {
+            w.count += addCount
+            w.level++
+          },
+        }),
+      })
+    }
+
+    const addDmg = Math.max(2, Math.round(w.dmg * 0.45))
+    offers.push({
+      weight: 30,
+      make: () => {
+        const d1 = Math.max(1, Math.round(((w.dmg + addDmg) * s.dmgPct) / 100))
+        return {
+          id: `${w.key}-dmg`,
+          kind: "weapon-up",
+          title: w.name,
+          tag: `+${addDmg} DAMAGE`,
+          before: `${w.count} × ${d0} = ${p0}`,
+          after: `${w.count} × ${d1} = ${w.count * d1}`,
+          head: String(w.count * d1),
+          sub: "VOLLEY",
+          rarity: 0,
+          hue: WEAPON_HUE[w.key],
+          apply: () => {
+            w.dmg += addDmg
+            w.level++
+          },
+        }
+      },
+    })
+
+    if (w.cdMs > 70) {
+      offers.push({
+        weight: 16,
+        make: () => {
+          const c0 = cooldown(w, s.ratePct)
+          const nd = Math.max(48, Math.round(w.cdMs * 0.78))
+          const c1 = Math.max(48, Math.round((nd * 100) / Math.max(20, s.ratePct)))
+          return {
+            id: `${w.key}-rate`,
+            kind: "weapon-up",
+            title: w.name,
+            tag: "FASTER",
+            before: `every ${c0} ms`,
+            after: `every ${c1} ms`,
+            head: `${Math.round(60000 / c1)}`,
+            sub: "PER MINUTE",
+            rarity: 1,
+            hue: WEAPON_HUE[w.key],
+            apply: () => {
+              w.cdMs = nd
+              w.level++
+            },
+          }
+        },
+      })
+    }
+
+    if (w.radius > 0) {
+      offers.push({
+        weight: 14,
+        make: () => ({
+          id: `${w.key}-radius`,
+          kind: "weapon-up",
+          title: w.name,
+          tag: "+30 REACH",
+          before: `reach ${reach(w, s.areaPct)}`,
+          after: `reach ${Math.round(((w.radius + 30) * s.areaPct) / 100)}`,
+          head: String(Math.round(((w.radius + 30) * s.areaPct) / 100)),
+          sub: "REACH",
+          rarity: 0,
+          hue: WEAPON_HUE[w.key],
+          apply: () => {
+            w.radius += 30
+            w.level++
+          },
+        }),
+      })
+    }
+  }
+
+  /* ---- a new weapon ------------------------------------------------------ */
+  if (build.weapons.length < MAX_WEAPONS) {
+    const owned = new Set(build.weapons.map((w) => w.key))
+    const unlockAt: Record<WeaponKey, number> = {
+      splinter: 0, halo: 0, arc: 0.4, pulse: 0.8, swarm: 1.4, spore: 2.4, lance: 3.4,
+    }
+    for (const key of Object.keys(BASE) as WeaponKey[]) {
+      if (owned.has(key)) continue
+      if (minutes < unlockAt[key]) continue
+      offers.push({
+        weight: 42,
+        make: () => {
+          const w = makeWeapon(key)
+          return {
+            id: `new-${key}`,
+            kind: "weapon-new",
+            title: w.name,
+            tag: "NEW WEAPON",
+            before: WEAPON_BLURB[key],
+            after: `${w.count} × ${realDamage(w, s.dmgPct)} = ${power(w, s.dmgPct)}`,
+            head: String(power(w, s.dmgPct)),
+            sub: "VOLLEY",
+            rarity: 2,
+            hue: WEAPON_HUE[key],
+            apply: () => {
+              build.weapons.push(w)
+            },
+          }
+        },
+      })
+    }
+  }
+
+  /* ---- passives ---------------------------------------------------------- */
+  const passives: Offer[] = [
+    {
+      weight: 24,
+      make: () => ({
+        id: "p-dmg", kind: "passive", title: "FEROCITY", tag: "+25% ALL DAMAGE",
+        before: `${s.dmgPct}%`, after: `${s.dmgPct + 25}%`,
+        head: `${s.dmgPct + 25}%`, sub: "DAMAGE", rarity: 1, hue: PASSIVE_HUE,
+        apply: () => { s.dmgPct += 25 },
+      }),
+    },
+    {
+      weight: 20,
+      make: () => ({
+        id: "p-rate", kind: "passive", title: "QUICKENING", tag: "+20% FIRE RATE",
+        before: `${s.ratePct}%`, after: `${s.ratePct + 20}%`,
+        head: `${s.ratePct + 20}%`, sub: "RATE", rarity: 1, hue: PASSIVE_HUE,
+        apply: () => { s.ratePct += 20 },
+      }),
+    },
+    {
+      weight: 18,
+      make: () => ({
+        id: "p-area", kind: "passive", title: "WIDENING", tag: "+20% AREA",
+        before: `${s.areaPct}%`, after: `${s.areaPct + 20}%`,
+        head: `${s.areaPct + 20}%`, sub: "AREA", rarity: 0, hue: PASSIVE_HUE,
+        apply: () => { s.areaPct += 20 },
+      }),
+    },
+    {
+      weight: 20,
+      make: () => ({
+        id: "p-hp", kind: "passive", title: "CARAPACE", tag: "+30 MAX LIFE",
+        before: `${s.maxHp}`, after: `${s.maxHp + 30}`,
+        head: `${s.maxHp + 30}`, sub: "LIFE", rarity: 0, hue: PASSIVE_HUE,
+        apply: () => { s.maxHp += 30; s.hp = Math.min(s.maxHp, s.hp + 30) },
+      }),
+    },
+    {
+      weight: 16,
+      make: () => ({
+        id: "p-speed", kind: "passive", title: "CURRENT", tag: "+18 SPEED",
+        before: `${s.speed}`, after: `${s.speed + 18}`,
+        head: `${s.speed + 18}`, sub: "SPEED", rarity: 0, hue: PASSIVE_HUE,
+        apply: () => { s.speed += 18 },
+      }),
+    },
+    {
+      weight: 15,
+      make: () => ({
+        id: "p-magnet", kind: "passive", title: "PULL", tag: "+55 MAGNET",
+        before: `${s.magnet}`, after: `${s.magnet + 55}`,
+        head: `${s.magnet + 55}`, sub: "MAGNET", rarity: 0, hue: PASSIVE_HUE,
+        apply: () => { s.magnet += 55 },
+      }),
+    },
+    {
+      weight: 13,
+      make: () => ({
+        id: "p-crit", kind: "passive", title: "FRACTURE", tag: "+10% CRIT",
+        before: `${s.critPct}% × ${s.critMul}`, after: `${s.critPct + 10}% × ${s.critMul}`,
+        head: `${s.critPct + 10}%`, sub: "CRIT", rarity: 1, hue: PASSIVE_HUE,
+        apply: () => { s.critPct += 10 },
+      }),
+    },
+    {
+      weight: 7,
+      make: () => ({
+        id: "p-critmul", kind: "passive", title: "SHATTER", tag: "CRIT ×1 MORE",
+        before: `${s.critPct}% × ${s.critMul}`, after: `${s.critPct}% × ${s.critMul + 1}`,
+        head: `×${s.critMul + 1}`, sub: "ON CRIT", rarity: 2, hue: PASSIVE_HUE,
+        apply: () => { s.critMul += 1 },
+      }),
+    },
+    {
+      weight: 12,
+      make: () => ({
+        id: "p-regen", kind: "passive", title: "MEND", tag: "+4 LIFE / 10 s",
+        before: `${s.regenPer10s} / 10 s`, after: `${s.regenPer10s + 4} / 10 s`,
+        head: `${s.regenPer10s + 4}`, sub: "REGEN", rarity: 1, hue: PASSIVE_HUE,
+        apply: () => { s.regenPer10s += 4 },
+      }),
+    },
+    {
+      weight: 11,
+      make: () => ({
+        id: "p-armor", kind: "passive", title: "PLATING", tag: "−2 DAMAGE TAKEN",
+        before: `${s.armor}`, after: `${s.armor + 2}`,
+        head: `${s.armor + 2}`, sub: "ARMOUR", rarity: 1, hue: PASSIVE_HUE,
+        apply: () => { s.armor += 2 },
+      }),
+    },
+    {
+      weight: 10,
+      make: () => ({
+        id: "p-xp", kind: "passive", title: "AVARICE", tag: "+25% LIGHT",
+        before: `${s.xpPct}%`, after: `${s.xpPct + 25}%`,
+        head: `${s.xpPct + 25}%`, sub: "LIGHT", rarity: 1, hue: PASSIVE_HUE,
+        apply: () => { s.xpPct += 25 },
+      }),
+    },
+  ]
+  offers.push(...passives)
+
+  if (s.hp < s.maxHp * 0.7) {
+    offers.push({
+      weight: 22,
+      make: () => ({
+        id: "heal", kind: "heal", title: "SURGE", tag: "RESTORE LIFE",
+        before: `${Math.ceil(s.hp)}`, after: `${s.maxHp}`,
+        head: `${s.maxHp - Math.ceil(s.hp)}`, sub: "HEALED", rarity: 0, hue: [0.4, 1, 0.7],
+        apply: () => { s.hp = s.maxHp },
+      }),
+    })
+  }
+
+  /* ---- draw -------------------------------------------------------------- */
+  const out: Card[] = []
+  const used = new Set<string>()
+  const pool = offers.slice()
+  let guard = 0
+  while (out.length < n && pool.length > 0 && guard++ < 400) {
+    let total = 0
+    for (const o of pool) total += o.weight
+    let r = rng() * total
+    let idx = 0
+    for (let i = 0; i < pool.length; i++) {
+      r -= pool[i].weight
+      if (r <= 0) { idx = i; break }
+      idx = i
+    }
+    const card = pool[idx].make()
+    pool.splice(idx, 1)
+    if (used.has(card.id)) continue
+    if (sealed && card.rarity === 0) continue
+    used.add(card.id)
+    out.push(card)
+  }
+  // A pool that ran dry (every offer used) still has to hand back something.
+  while (out.length < n) {
+    const s2 = build.stats
+    out.push({
+      id: `fill-${out.length}`, kind: "passive", title: "FEROCITY", tag: "+25% ALL DAMAGE",
+      before: `${s2.dmgPct}%`, after: `${s2.dmgPct + 25}%`,
+      head: `${s2.dmgPct + 25}%`, sub: "DAMAGE", rarity: 1, hue: PASSIVE_HUE,
+      apply: () => { s2.dmgPct += 25 },
+    })
+  }
+  return out
+}
+
+function countNoun(k: WeaponKey, n: number): string {
+  const one: Record<WeaponKey, string> = {
+    splinter: "SHARD", halo: "BLADE", arc: "JUMP", pulse: "RING",
+    swarm: "MOTE", lance: "BEAM", spore: "POD",
+  }
+  return n === 1 ? one[k] : `${one[k]}S`
+}
+
+/** XP needed to reach level n+1 from level n. Integers only. */
+export function xpForLevel(level: number): number {
+  return 5 + level * 4 + Math.floor((level * level) / 5)
+}

--- a/dynawalla/games/horde/src/game/world.ts
+++ b/dynawalla/games/horde/src/game/world.ts
@@ -1,0 +1,334 @@
+/**
+ * Every entity lives in a preallocated typed array. Nothing in here allocates
+ * after construction — a horde survivor that garbage-collects at minute twelve
+ * is a horde survivor that stutters exactly when the screen is fullest.
+ */
+
+export class Pool {
+  cap: number
+  n = 0
+  private free: Int32Array
+  private freeN: number
+  alive: Uint8Array
+
+  constructor(cap: number) {
+    this.cap = cap
+    this.free = new Int32Array(cap)
+    for (let i = 0; i < cap; i++) this.free[i] = cap - 1 - i
+    this.freeN = cap
+    this.alive = new Uint8Array(cap)
+  }
+
+  /** @returns index, or −1 when the pool is exhausted. */
+  spawn(): number {
+    if (this.freeN === 0) return -1
+    const i = this.free[--this.freeN]
+    this.alive[i] = 1
+    this.n++
+    return i
+  }
+
+  kill(i: number): void {
+    if (this.alive[i] === 0) return
+    this.alive[i] = 0
+    this.free[this.freeN++] = i
+    this.n--
+  }
+
+  reset(): void {
+    this.alive.fill(0)
+    for (let i = 0; i < this.cap; i++) this.free[i] = this.cap - 1 - i
+    this.freeN = this.cap
+    this.n = 0
+  }
+}
+
+/**
+ * A uniform grid over the live region. Rebuilt from scratch every tick with a
+ * counting sort: two linear passes, no per-frame allocation, no hash map.
+ */
+export class Grid {
+  cell = 44
+  cols = 1
+  rows = 1
+  originX = 0
+  originY = 0
+  private counts: Int32Array
+  private cursor: Int32Array
+  items: Int32Array
+  private maxCells: number
+
+  constructor(maxItems: number, maxCells = 26000) {
+    this.maxCells = maxCells
+    this.counts = new Int32Array(maxCells + 1)
+    this.cursor = new Int32Array(maxCells + 1)
+    this.items = new Int32Array(maxItems)
+  }
+
+  configure(minX: number, minY: number, w: number, h: number, cell: number): void {
+    this.cell = cell
+    this.originX = minX
+    this.originY = minY
+    let cols = Math.max(1, Math.ceil(w / cell))
+    let rows = Math.max(1, Math.ceil(h / cell))
+    while (cols * rows > this.maxCells) {
+      // Coarsen rather than overflow; correctness never depends on cell size.
+      this.cell *= 1.35
+      cols = Math.max(1, Math.ceil(w / this.cell))
+      rows = Math.max(1, Math.ceil(h / this.cell))
+    }
+    this.cols = cols
+    this.rows = rows
+  }
+
+  cellOf(x: number, y: number): number {
+    let cx = Math.floor((x - this.originX) / this.cell)
+    let cy = Math.floor((y - this.originY) / this.cell)
+    if (cx < 0) cx = 0
+    else if (cx >= this.cols) cx = this.cols - 1
+    if (cy < 0) cy = 0
+    else if (cy >= this.rows) cy = this.rows - 1
+    return cy * this.cols + cx
+  }
+
+  build(count: number, alive: Uint8Array, xs: Float32Array, ys: Float32Array): void {
+    const cells = this.cols * this.rows
+    const counts = this.counts
+    counts.fill(0, 0, cells + 1)
+    for (let i = 0; i < count; i++) {
+      if (alive[i] === 0) continue
+      counts[this.cellOf(xs[i], ys[i]) + 1]++
+    }
+    for (let c = 0; c < cells; c++) counts[c + 1] += counts[c]
+    this.cursor.set(counts.subarray(0, cells + 1))
+    for (let i = 0; i < count; i++) {
+      if (alive[i] === 0) continue
+      const c = this.cellOf(xs[i], ys[i])
+      this.items[this.cursor[c]++] = i
+    }
+  }
+
+  start(cell: number): number {
+    return this.counts[cell]
+  }
+
+  end(cell: number): number {
+    return this.counts[cell + 1]
+  }
+
+  /** Clamped cell coordinates for an AABB query. */
+  range(x: number, y: number, r: number, out: Int32Array): void {
+    let x0 = Math.floor((x - r - this.originX) / this.cell)
+    let x1 = Math.floor((x + r - this.originX) / this.cell)
+    let y0 = Math.floor((y - r - this.originY) / this.cell)
+    let y1 = Math.floor((y + r - this.originY) / this.cell)
+    if (x0 < 0) x0 = 0
+    if (y0 < 0) y0 = 0
+    if (x1 >= this.cols) x1 = this.cols - 1
+    if (y1 >= this.rows) y1 = this.rows - 1
+    out[0] = x0
+    out[1] = y0
+    out[2] = x1
+    out[3] = y1
+  }
+}
+
+export class Enemies {
+  pool: Pool
+  x: Float32Array
+  y: Float32Array
+  vx: Float32Array
+  vy: Float32Array
+  hp: Float32Array
+  maxHp: Float32Array
+  type: Uint8Array
+  flash: Float32Array
+  hitCd: Float32Array
+  rot: Float32Array
+  radius: Float32Array
+  /** Behaviour scratch: charge wind-up, warden spawn timer, orbit phase. */
+  st: Float32Array
+  st2: Float32Array
+  /** Damage the run has taken from this one, for the elite health bar. */
+  born: Float32Array
+
+  constructor(cap: number) {
+    this.pool = new Pool(cap)
+    this.x = new Float32Array(cap)
+    this.y = new Float32Array(cap)
+    this.vx = new Float32Array(cap)
+    this.vy = new Float32Array(cap)
+    this.hp = new Float32Array(cap)
+    this.maxHp = new Float32Array(cap)
+    this.type = new Uint8Array(cap)
+    this.flash = new Float32Array(cap)
+    this.hitCd = new Float32Array(cap)
+    this.rot = new Float32Array(cap)
+    this.radius = new Float32Array(cap)
+    this.st = new Float32Array(cap)
+    this.st2 = new Float32Array(cap)
+    this.born = new Float32Array(cap)
+  }
+}
+
+export class Bullets {
+  pool: Pool
+  x: Float32Array
+  y: Float32Array
+  vx: Float32Array
+  vy: Float32Array
+  life: Float32Array
+  dmg: Float32Array
+  pierce: Int16Array
+  kind: Uint8Array
+  crit: Uint8Array
+  rot: Float32Array
+  /** Homing target index, or −1. */
+  tgt: Int32Array
+  r: Float32Array
+  g: Float32Array
+  b: Float32Array
+  size: Float32Array
+
+  constructor(cap: number) {
+    this.pool = new Pool(cap)
+    this.x = new Float32Array(cap)
+    this.y = new Float32Array(cap)
+    this.vx = new Float32Array(cap)
+    this.vy = new Float32Array(cap)
+    this.life = new Float32Array(cap)
+    this.dmg = new Float32Array(cap)
+    this.pierce = new Int16Array(cap)
+    this.kind = new Uint8Array(cap)
+    this.crit = new Uint8Array(cap)
+    this.rot = new Float32Array(cap)
+    this.tgt = new Int32Array(cap)
+    this.r = new Float32Array(cap)
+    this.g = new Float32Array(cap)
+    this.b = new Float32Array(cap)
+    this.size = new Float32Array(cap)
+  }
+}
+
+export class Particles {
+  pool: Pool
+  x: Float32Array
+  y: Float32Array
+  vx: Float32Array
+  vy: Float32Array
+  life: Float32Array
+  max: Float32Array
+  size: Float32Array
+  r: Float32Array
+  g: Float32Array
+  b: Float32Array
+  rot: Float32Array
+  spin: Float32Array
+  drag: Float32Array
+  shape: Uint8Array
+  glow: Float32Array
+
+  constructor(cap: number) {
+    this.pool = new Pool(cap)
+    this.x = new Float32Array(cap)
+    this.y = new Float32Array(cap)
+    this.vx = new Float32Array(cap)
+    this.vy = new Float32Array(cap)
+    this.life = new Float32Array(cap)
+    this.max = new Float32Array(cap)
+    this.size = new Float32Array(cap)
+    this.r = new Float32Array(cap)
+    this.g = new Float32Array(cap)
+    this.b = new Float32Array(cap)
+    this.rot = new Float32Array(cap)
+    this.spin = new Float32Array(cap)
+    this.drag = new Float32Array(cap)
+    this.shape = new Uint8Array(cap)
+    this.glow = new Float32Array(cap)
+  }
+}
+
+export class Gems {
+  pool: Pool
+  x: Float32Array
+  y: Float32Array
+  vx: Float32Array
+  vy: Float32Array
+  value: Float32Array
+  t: Float32Array
+  pulled: Uint8Array
+
+  constructor(cap: number) {
+    this.pool = new Pool(cap)
+    this.x = new Float32Array(cap)
+    this.y = new Float32Array(cap)
+    this.vx = new Float32Array(cap)
+    this.vy = new Float32Array(cap)
+    this.value = new Float32Array(cap)
+    this.t = new Float32Array(cap)
+    this.pulled = new Uint8Array(cap)
+  }
+}
+
+export class Numbers {
+  pool: Pool
+  x: Float32Array
+  y: Float32Array
+  vy: Float32Array
+  vx: Float32Array
+  life: Float32Array
+  max: Float32Array
+  value: Int32Array
+  crit: Uint8Array
+  r: Float32Array
+  g: Float32Array
+  b: Float32Array
+
+  constructor(cap: number) {
+    this.pool = new Pool(cap)
+    this.x = new Float32Array(cap)
+    this.y = new Float32Array(cap)
+    this.vy = new Float32Array(cap)
+    this.vx = new Float32Array(cap)
+    this.life = new Float32Array(cap)
+    this.max = new Float32Array(cap)
+    this.value = new Int32Array(cap)
+    this.crit = new Uint8Array(cap)
+    this.r = new Float32Array(cap)
+    this.g = new Float32Array(cap)
+    this.b = new Float32Array(cap)
+  }
+}
+
+/** Expanding damage rings: PULSE, spore blooms, the nova, the Rift. */
+export class Shocks {
+  pool: Pool
+  x: Float32Array
+  y: Float32Array
+  r: Float32Array
+  rMax: Float32Array
+  dmg: Float32Array
+  life: Float32Array
+  max: Float32Array
+  kind: Uint8Array
+  cr: Float32Array
+  cg: Float32Array
+  cb: Float32Array
+  knock: Float32Array
+
+  constructor(cap: number) {
+    this.pool = new Pool(cap)
+    this.x = new Float32Array(cap)
+    this.y = new Float32Array(cap)
+    this.r = new Float32Array(cap)
+    this.rMax = new Float32Array(cap)
+    this.dmg = new Float32Array(cap)
+    this.life = new Float32Array(cap)
+    this.max = new Float32Array(cap)
+    this.kind = new Uint8Array(cap)
+    this.cr = new Float32Array(cap)
+    this.cg = new Float32Array(cap)
+    this.cb = new Float32Array(cap)
+    this.knock = new Float32Array(cap)
+  }
+}

--- a/dynawalla/games/horde/src/gfx/glyphs.ts
+++ b/dynawalla/games/horde/src/gfx/glyphs.ts
@@ -1,0 +1,63 @@
+/**
+ * A glyph atlas baked into a canvas at boot, so in-world text (damage numbers,
+ * the answer orbs, PERFECT) draws in the same instanced pass as everything
+ * else and costs nothing.
+ *
+ * The typeface is a heavy geometric sans, deliberately. The catalogue that
+ * came before this one shipped engraved serif numerals on fast-moving targets
+ * a child has under half a second to read. Ornament never eats legibility.
+ */
+
+export const GLYPH_CHARS = "0123456789+-−×÷=?!%.,×ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+export type GlyphMetric = { u0: number; v0: number; u1: number; v1: number; aw: number; ah: number }
+
+export type Atlas = {
+  canvas: HTMLCanvasElement
+  size: number
+  metrics: Map<string, GlyphMetric>
+  /** Height of a cell in atlas pixels, used to normalise draw scale. */
+  cell: number
+}
+
+export function buildAtlas(): Atlas {
+  const cell = 72
+  const cols = 8
+  const rows = Math.ceil(GLYPH_CHARS.length / cols)
+  const size = 1 << Math.ceil(Math.log2(Math.max(cell * cols, cell * rows)))
+  const canvas = document.createElement("canvas")
+  canvas.width = size
+  canvas.height = size
+  const g = canvas.getContext("2d")!
+  g.clearRect(0, 0, size, size)
+  g.textAlign = "center"
+  g.textBaseline = "middle"
+  g.fillStyle = "#fff"
+
+  const px = Math.round(cell * 0.72)
+  g.font = `900 ${px}px ui-rounded, "SF Pro Rounded", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif`
+
+  const metrics = new Map<string, GlyphMetric>()
+  const seen = new Set<string>()
+  let idx = 0
+  for (const ch of GLYPH_CHARS) {
+    if (seen.has(ch)) continue
+    seen.add(ch)
+    const cx = (idx % cols) * cell
+    const cy = Math.floor(idx / cols) * cell
+    g.fillText(ch, cx + cell / 2, cy + cell / 2)
+    const w = g.measureText(ch).width
+    metrics.set(ch, {
+      u0: cx / size,
+      v0: cy / size,
+      u1: (cx + cell) / size,
+      v1: (cy + cell) / size,
+      // Advance as a fraction of the drawn cell height, so callers scale by
+      // one number (the text height in world units) and spacing follows.
+      aw: Math.min(1.05, w / cell + 0.1),
+      ah: 1,
+    })
+    idx++
+  }
+  return { canvas, size, metrics, cell }
+}

--- a/dynawalla/games/horde/src/gfx/renderer.ts
+++ b/dynawalla/games/horde/src/gfx/renderer.ts
@@ -1,0 +1,517 @@
+/**
+ * The renderer. One instanced-quad pipeline draws every enemy, projectile,
+ * particle, gem and glyph in two draw calls; a persistent stain buffer keeps
+ * the bioluminescent spill where the horde died; bloom does the rest.
+ *
+ * Nothing here allocates after `resize`. `sprite()` and `glyph()` write
+ * straight into a preallocated Float32Array.
+ */
+import { buildAtlas, type Atlas } from "./glyphs.ts"
+import {
+  ABYSS_FS, BLUR_FS, BRIGHT_FS, COMPOSITE_FS, FS_TRI_VS,
+  GLYPH_FS, GLYPH_VS, SPRITE_FS, SPRITE_VS, STAIN_FADE_FS,
+} from "./shaders.ts"
+
+export const SHAPE = {
+  DISC: 0, RING: 1, SHARD: 2, DART: 3, CHITIN: 4, SPARK: 5, CAPSULE: 6, GEM: 7,
+} as const
+
+const SPRITE_STRIDE = 12 // x y hw hh rot r g b a shape p0 p1
+const GLYPH_STRIDE = 12 // x y hw hh u0 v0 u1 v1 r g b a
+
+function compile(gl: WebGL2RenderingContext, type: number, src: string): WebGLShader {
+  const s = gl.createShader(type)!
+  gl.shaderSource(s, src)
+  gl.compileShader(s)
+  if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) {
+    const log = gl.getShaderInfoLog(s)
+    console.error("[horde] shader compile failed:", log, "\n", src.slice(0, 400))
+    throw new Error(`horde: shader compile failed: ${log}`)
+  }
+  return s
+}
+
+function link(gl: WebGL2RenderingContext, vs: string, fs: string): WebGLProgram {
+  const p = gl.createProgram()!
+  gl.attachShader(p, compile(gl, gl.VERTEX_SHADER, vs))
+  gl.attachShader(p, compile(gl, gl.FRAGMENT_SHADER, fs))
+  gl.linkProgram(p)
+  if (!gl.getProgramParameter(p, gl.LINK_STATUS)) {
+    const log = gl.getProgramInfoLog(p)
+    console.error("[horde] program link failed:", log)
+    throw new Error(`horde: program link failed: ${log}`)
+  }
+  return p
+}
+
+type Target = { fb: WebGLFramebuffer; tex: WebGLTexture; w: number; h: number }
+
+export class Renderer {
+  readonly gl: WebGL2RenderingContext
+  readonly canvas: HTMLCanvasElement
+  private atlas: Atlas
+  private atlasTex!: WebGLTexture
+
+  private pSprite!: WebGLProgram
+  private pGlyph!: WebGLProgram
+  private pAbyss!: WebGLProgram
+  private pBright!: WebGLProgram
+  private pBlur!: WebGLProgram
+  private pComposite!: WebGLProgram
+  private pStainFade!: WebGLProgram
+  private pBlit!: WebGLProgram
+
+  private uni = new Map<WebGLProgram, Map<string, WebGLUniformLocation | null>>()
+
+  private vaoSprite!: WebGLVertexArrayObject
+  private vboSprite!: WebGLBuffer
+  private vaoGlyph!: WebGLVertexArrayObject
+  private vboGlyph!: WebGLBuffer
+  private vaoEmpty!: WebGLVertexArrayObject
+
+  private spriteData!: Float32Array
+  private glyphData!: Float32Array
+  private spriteN = 0
+  private glyphN = 0
+  private spriteCap = 0
+  private glyphCap = 0
+
+  /** Stain deposits are written into their own slice of the sprite array. */
+  private stainData!: Float32Array
+  private stainN = 0
+
+  private scene!: Target
+  private b0!: Target
+  private b1!: Target
+  private b2!: Target
+  private b3!: Target
+  private stainA!: Target
+  private stainB!: Target
+
+  private floatOk = false
+  bloomOctaves = 2
+  stainEnabled = true
+
+  // camera
+  camX = 0
+  camY = 0
+  halfW = 640
+  halfH = 360
+  private prevCamX = 0
+  private prevCamY = 0
+
+  w = 1
+  h = 1
+  dpr = 1
+
+  constructor(canvas: HTMLCanvasElement, maxInstances: number) {
+    this.canvas = canvas
+    const gl = canvas.getContext("webgl2", {
+      alpha: false,
+      antialias: false,
+      depth: false,
+      stencil: false,
+      powerPreference: "high-performance",
+      preserveDrawingBuffer: false,
+      desynchronized: true,
+    })
+    if (!gl) throw new Error("horde: WebGL2 is required")
+    this.gl = gl
+    this.floatOk = !!gl.getExtension("EXT_color_buffer_float")
+    gl.getExtension("OES_texture_float_linear")
+
+    this.pSprite = link(gl, SPRITE_VS, SPRITE_FS)
+    this.pGlyph = link(gl, GLYPH_VS, GLYPH_FS)
+    this.pAbyss = link(gl, FS_TRI_VS, ABYSS_FS)
+    this.pBright = link(gl, FS_TRI_VS, BRIGHT_FS)
+    this.pBlur = link(gl, FS_TRI_VS, BLUR_FS)
+    this.pComposite = link(gl, FS_TRI_VS, COMPOSITE_FS)
+    this.pStainFade = link(gl, FS_TRI_VS, STAIN_FADE_FS)
+    this.pBlit = link(gl, FS_TRI_VS, `#version 300 es
+precision highp float; in vec2 v_uv; out vec4 o_col; uniform sampler2D u_tex;
+void main(){ vec3 c = texture(u_tex, v_uv).rgb; o_col = vec4(c, 1.0); }`)
+
+    this.atlas = buildAtlas()
+    this.atlasTex = gl.createTexture()!
+    gl.bindTexture(gl.TEXTURE_2D, this.atlasTex)
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, this.atlas.canvas)
+    gl.generateMipmap(gl.TEXTURE_2D)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+
+    this.vaoEmpty = gl.createVertexArray()!
+    this.setCapacity(maxInstances)
+
+    gl.disable(gl.DEPTH_TEST)
+    gl.disable(gl.CULL_FACE)
+    gl.enable(gl.BLEND)
+  }
+
+  /** Re-sizes the instance arrays. Called on boot and on a tier change only. */
+  setCapacity(maxInstances: number): void {
+    const gl = this.gl
+    this.spriteCap = maxInstances
+    this.glyphCap = Math.max(512, Math.floor(maxInstances * 0.22))
+    this.spriteData = new Float32Array(this.spriteCap * SPRITE_STRIDE)
+    this.stainData = new Float32Array(Math.max(256, Math.floor(this.spriteCap * 0.18)) * SPRITE_STRIDE)
+    this.glyphData = new Float32Array(this.glyphCap * GLYPH_STRIDE)
+
+    if (!this.vboSprite) {
+      this.vboSprite = gl.createBuffer()!
+      this.vaoSprite = gl.createVertexArray()!
+      this.vboGlyph = gl.createBuffer()!
+      this.vaoGlyph = gl.createVertexArray()!
+    }
+
+    gl.bindVertexArray(this.vaoSprite)
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.vboSprite)
+    gl.bufferData(gl.ARRAY_BUFFER, this.spriteData.byteLength, gl.DYNAMIC_DRAW)
+    const S = SPRITE_STRIDE * 4
+    const attr = (loc: number, n: number, off: number) => {
+      gl.enableVertexAttribArray(loc)
+      gl.vertexAttribPointer(loc, n, gl.FLOAT, false, S, off * 4)
+      gl.vertexAttribDivisor(loc, 1)
+    }
+    attr(0, 2, 0); attr(1, 2, 2); attr(2, 1, 4); attr(3, 4, 5); attr(4, 3, 9)
+
+    gl.bindVertexArray(this.vaoGlyph)
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.vboGlyph)
+    gl.bufferData(gl.ARRAY_BUFFER, this.glyphData.byteLength, gl.DYNAMIC_DRAW)
+    const G = GLYPH_STRIDE * 4
+    const gattr = (loc: number, n: number, off: number) => {
+      gl.enableVertexAttribArray(loc)
+      gl.vertexAttribPointer(loc, n, gl.FLOAT, false, G, off * 4)
+      gl.vertexAttribDivisor(loc, 1)
+    }
+    gattr(0, 2, 0); gattr(1, 2, 2); gattr(2, 4, 4); gattr(3, 4, 8)
+    gl.bindVertexArray(null)
+  }
+
+  private makeTarget(w: number, h: number, hdr: boolean): Target {
+    const gl = this.gl
+    const tex = gl.createTexture()!
+    gl.bindTexture(gl.TEXTURE_2D, tex)
+    const useF = hdr && this.floatOk
+    gl.texImage2D(
+      gl.TEXTURE_2D, 0, useF ? gl.RGBA16F : gl.RGBA, Math.max(1, w), Math.max(1, h), 0,
+      gl.RGBA, useF ? gl.HALF_FLOAT : gl.UNSIGNED_BYTE, null,
+    )
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+    const fb = gl.createFramebuffer()!
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb)
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0)
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null)
+    return { fb, tex, w: Math.max(1, w), h: Math.max(1, h) }
+  }
+
+  private free(t: Target | undefined): void {
+    if (!t) return
+    this.gl.deleteFramebuffer(t.fb)
+    this.gl.deleteTexture(t.tex)
+  }
+
+  resize(cssW: number, cssH: number, dpr: number): void {
+    const w = Math.max(2, Math.round(cssW * dpr))
+    const h = Math.max(2, Math.round(cssH * dpr))
+    if (w === this.w && h === this.h && dpr === this.dpr) return
+    this.w = w
+    this.h = h
+    this.dpr = dpr
+    this.canvas.width = w
+    this.canvas.height = h
+    this.canvas.style.width = `${cssW}px`
+    this.canvas.style.height = `${cssH}px`
+
+    for (const t of [this.scene, this.b0, this.b1, this.b2, this.b3, this.stainA, this.stainB]) this.free(t)
+    this.scene = this.makeTarget(w, h, true)
+    const hw = Math.max(2, w >> 1)
+    const hh = Math.max(2, h >> 1)
+    this.b0 = this.makeTarget(hw, hh, true)
+    this.b1 = this.makeTarget(hw, hh, true)
+    this.b2 = this.makeTarget(Math.max(2, w >> 2), Math.max(2, h >> 2), true)
+    this.b3 = this.makeTarget(Math.max(2, w >> 2), Math.max(2, h >> 2), true)
+    this.stainA = this.makeTarget(Math.max(2, w >> 1), Math.max(2, h >> 1), true)
+    this.stainB = this.makeTarget(Math.max(2, w >> 1), Math.max(2, h >> 1), true)
+    // Clear the fresh stain buffers so garbage never blooms on the first frame.
+    const gl = this.gl
+    for (const t of [this.stainA, this.stainB]) {
+      gl.bindFramebuffer(gl.FRAMEBUFFER, t.fb)
+      gl.clearColor(0, 0, 0, 1)
+      gl.clear(gl.COLOR_BUFFER_BIT)
+    }
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null)
+  }
+
+  /* ------------------------------------------------------------- writing */
+
+  beginFrame(camX: number, camY: number, halfW: number, halfH: number): void {
+    this.prevCamX = this.camX
+    this.prevCamY = this.camY
+    this.camX = camX
+    this.camY = camY
+    this.halfW = halfW
+    this.halfH = halfH
+    this.spriteN = 0
+    this.glyphN = 0
+    this.stainN = 0
+  }
+
+  get spriteCount(): number {
+    return this.spriteN
+  }
+
+  sprite(
+    x: number, y: number, hw: number, hh: number, rot: number,
+    r: number, g: number, b: number, a: number,
+    shape: number, p0 = 1, p1 = 0,
+  ): void {
+    if (this.spriteN >= this.spriteCap) return
+    const d = this.spriteData
+    let i = this.spriteN * SPRITE_STRIDE
+    d[i++] = x; d[i++] = y; d[i++] = hw; d[i++] = hh; d[i++] = rot
+    d[i++] = r; d[i++] = g; d[i++] = b; d[i++] = a
+    d[i++] = shape; d[i++] = p0; d[i] = p1
+    this.spriteN++
+  }
+
+  /** A permanent-ish deposit of light in the world where something died. */
+  stain(x: number, y: number, rad: number, r: number, g: number, b: number, a: number): void {
+    if (!this.stainEnabled) return
+    const cap = this.stainData.length / SPRITE_STRIDE
+    if (this.stainN >= cap) return
+    const d = this.stainData
+    let i = this.stainN * SPRITE_STRIDE
+    d[i++] = x; d[i++] = y; d[i++] = rad; d[i++] = rad; d[i++] = 0
+    d[i++] = r; d[i++] = g; d[i++] = b; d[i++] = a
+    d[i++] = SHAPE.DISC; d[i++] = 1.6; d[i] = 0
+    this.stainN++
+  }
+
+  /** @returns the width drawn, in world units. */
+  text(
+    s: string, x: number, y: number, size: number,
+    r: number, g: number, b: number, a: number, centred = true,
+  ): number {
+    const m = this.atlas.metrics
+    let total = 0
+    for (let i = 0; i < s.length; i++) {
+      const gm = m.get(s[i])
+      total += gm ? gm.aw * size : size * 0.5
+    }
+    let cx = centred ? x - total / 2 : x
+    for (let i = 0; i < s.length; i++) {
+      const gm = m.get(s[i])
+      if (!gm) { cx += size * 0.5; continue }
+      const adv = gm.aw * size
+      if (this.glyphN < this.glyphCap && s[i] !== " ") {
+        const d = this.glyphData
+        let k = this.glyphN * GLYPH_STRIDE
+        // The cell is square; centre the glyph on its advance box.
+        d[k++] = cx + adv / 2; d[k++] = y; d[k++] = size * 0.72; d[k++] = size * 0.72
+        d[k++] = gm.u0; d[k++] = gm.v0; d[k++] = gm.u1; d[k++] = gm.v1
+        d[k++] = r; d[k++] = g; d[k++] = b; d[k] = a
+        this.glyphN++
+      }
+      cx += adv
+    }
+    return total
+  }
+
+  measure(s: string, size: number): number {
+    const m = this.atlas.metrics
+    let total = 0
+    for (let i = 0; i < s.length; i++) {
+      const gm = m.get(s[i])
+      total += gm ? gm.aw * size : size * 0.5
+    }
+    return total
+  }
+
+  /* ------------------------------------------------------------- drawing */
+
+  private u(p: WebGLProgram, name: string): WebGLUniformLocation | null {
+    let m = this.uni.get(p)
+    if (!m) { m = new Map(); this.uni.set(p, m) }
+    if (!m.has(name)) m.set(name, this.gl.getUniformLocation(p, name))
+    return m.get(name)!
+  }
+
+  private fsPass(prog: WebGLProgram, target: Target | null): void {
+    const gl = this.gl
+    gl.bindFramebuffer(gl.FRAMEBUFFER, target ? target.fb : null)
+    gl.viewport(0, 0, target ? target.w : this.w, target ? target.h : this.h)
+    gl.useProgram(prog)
+    gl.bindVertexArray(this.vaoEmpty)
+    gl.drawArrays(gl.TRIANGLES, 0, 3)
+  }
+
+  private bindTex(prog: WebGLProgram, name: string, tex: WebGLTexture, unit: number): void {
+    const gl = this.gl
+    gl.activeTexture(gl.TEXTURE0 + unit)
+    gl.bindTexture(gl.TEXTURE_2D, tex)
+    gl.uniform1i(this.u(prog, name), unit)
+  }
+
+  endFrame(opts: {
+    time: number
+    intensity: number
+    flashR: number; flashG: number; flashB: number; flashA: number
+    aberration: number
+    vignette: number
+    desat: number
+    bloom: number
+  }): void {
+    const gl = this.gl
+    const camVec = [this.camX, this.camY, 1 / this.halfW, 1 / this.halfH] as const
+
+    /* --- 1. stain: fade + world-lock shift, ping-pong ------------------- */
+    if (this.stainEnabled) {
+      const dxUv = ((this.camX - this.prevCamX) / (this.halfW * 2))
+      const dyUv = -((this.camY - this.prevCamY) / (this.halfH * 2))
+      gl.disable(gl.BLEND)
+      gl.useProgram(this.pStainFade)
+      this.bindTex(this.pStainFade, "u_tex", this.stainA.tex, 0)
+      gl.uniform1f(this.u(this.pStainFade, "u_fade"), 0.968)
+      gl.uniform2f(this.u(this.pStainFade, "u_shift"), dxUv, dyUv)
+      this.fsPass(this.pStainFade, this.stainB)
+      const t = this.stainA; this.stainA = this.stainB; this.stainB = t
+
+      if (this.stainN > 0) {
+        gl.enable(gl.BLEND)
+        gl.blendFunc(gl.ONE, gl.ONE)
+        gl.bindFramebuffer(gl.FRAMEBUFFER, this.stainA.fb)
+        gl.viewport(0, 0, this.stainA.w, this.stainA.h)
+        gl.useProgram(this.pSprite)
+        gl.uniform4f(this.u(this.pSprite, "u_cam"), camVec[0], camVec[1], camVec[2], camVec[3])
+        gl.bindVertexArray(this.vaoSprite)
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.vboSprite)
+        gl.bufferSubData(gl.ARRAY_BUFFER, 0, this.stainData, 0, this.stainN * SPRITE_STRIDE)
+        gl.drawArraysInstanced(gl.TRIANGLE_STRIP, 0, 4, this.stainN)
+      }
+    }
+
+    /* --- 2. background -------------------------------------------------- */
+    gl.disable(gl.BLEND)
+    gl.useProgram(this.pAbyss)
+    gl.uniform2f(this.u(this.pAbyss, "u_res"), this.w, this.h)
+    gl.uniform2f(this.u(this.pAbyss, "u_cam"), this.camX, this.camY)
+    gl.uniform1f(this.u(this.pAbyss, "u_time"), opts.time)
+    gl.uniform1f(this.u(this.pAbyss, "u_intensity"), opts.intensity)
+    gl.uniform1f(this.u(this.pAbyss, "u_scale"), (this.halfW * 2) / this.w)
+    this.fsPass(this.pAbyss, this.scene)
+
+    /* --- 3. stain into the scene ---------------------------------------- */
+    if (this.stainEnabled) {
+      gl.enable(gl.BLEND)
+      gl.blendFunc(gl.ONE, gl.ONE)
+      gl.useProgram(this.pBlit)
+      this.bindTex(this.pBlit, "u_tex", this.stainA.tex, 0)
+      this.fsPass(this.pBlit, this.scene)
+    }
+
+    /* --- 4. sprites ------------------------------------------------------ */
+    gl.enable(gl.BLEND)
+    gl.blendFunc(gl.ONE, gl.ONE)
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.scene.fb)
+    gl.viewport(0, 0, this.scene.w, this.scene.h)
+    if (this.spriteN > 0) {
+      gl.useProgram(this.pSprite)
+      gl.uniform4f(this.u(this.pSprite, "u_cam"), camVec[0], camVec[1], camVec[2], camVec[3])
+      gl.bindVertexArray(this.vaoSprite)
+      gl.bindBuffer(gl.ARRAY_BUFFER, this.vboSprite)
+      gl.bufferSubData(gl.ARRAY_BUFFER, 0, this.spriteData, 0, this.spriteN * SPRITE_STRIDE)
+      gl.drawArraysInstanced(gl.TRIANGLE_STRIP, 0, 4, this.spriteN)
+    }
+
+    /* --- 5. glyphs ------------------------------------------------------- */
+    if (this.glyphN > 0) {
+      gl.useProgram(this.pGlyph)
+      gl.uniform4f(this.u(this.pGlyph, "u_cam"), camVec[0], camVec[1], camVec[2], camVec[3])
+      this.bindTex(this.pGlyph, "u_tex", this.atlasTex, 0)
+      gl.bindVertexArray(this.vaoGlyph)
+      gl.bindBuffer(gl.ARRAY_BUFFER, this.vboGlyph)
+      gl.bufferSubData(gl.ARRAY_BUFFER, 0, this.glyphData, 0, this.glyphN * GLYPH_STRIDE)
+      gl.drawArraysInstanced(gl.TRIANGLE_STRIP, 0, 4, this.glyphN)
+    }
+
+    /* --- 6. bloom -------------------------------------------------------- */
+    gl.disable(gl.BLEND)
+    let amt0 = 0
+    let amt1 = 0
+    if (this.bloomOctaves >= 1) {
+      gl.useProgram(this.pBright)
+      this.bindTex(this.pBright, "u_tex", this.scene.tex, 0)
+      gl.uniform1f(this.u(this.pBright, "u_threshold"), 0.42)
+      this.fsPass(this.pBright, this.b0)
+
+      gl.useProgram(this.pBlur)
+      this.bindTex(this.pBlur, "u_tex", this.b0.tex, 0)
+      gl.uniform2f(this.u(this.pBlur, "u_dir"), 1 / this.b0.w, 0)
+      this.fsPass(this.pBlur, this.b1)
+      this.bindTex(this.pBlur, "u_tex", this.b1.tex, 0)
+      gl.uniform2f(this.u(this.pBlur, "u_dir"), 0, 1 / this.b0.h)
+      this.fsPass(this.pBlur, this.b0)
+      amt0 = 0.95 * opts.bloom
+
+      if (this.bloomOctaves >= 2) {
+        gl.useProgram(this.pBlit)
+        this.bindTex(this.pBlit, "u_tex", this.b0.tex, 0)
+        this.fsPass(this.pBlit, this.b2)
+        gl.useProgram(this.pBlur)
+        this.bindTex(this.pBlur, "u_tex", this.b2.tex, 0)
+        gl.uniform2f(this.u(this.pBlur, "u_dir"), 2.4 / this.b2.w, 0)
+        this.fsPass(this.pBlur, this.b3)
+        this.bindTex(this.pBlur, "u_tex", this.b3.tex, 0)
+        gl.uniform2f(this.u(this.pBlur, "u_dir"), 0, 2.4 / this.b2.h)
+        this.fsPass(this.pBlur, this.b2)
+        amt1 = 0.75 * opts.bloom
+      }
+    }
+
+    /* --- 7. composite ---------------------------------------------------- */
+    const P = this.pComposite
+    gl.useProgram(P)
+    this.bindTex(P, "u_scene", this.scene.tex, 0)
+    this.bindTex(P, "u_bloom0", (this.bloomOctaves >= 1 ? this.b0 : this.scene).tex, 1)
+    this.bindTex(P, "u_bloom1", (this.bloomOctaves >= 2 ? this.b2 : this.scene).tex, 2)
+    gl.uniform1f(this.u(P, "u_bloomAmt0"), amt0)
+    gl.uniform1f(this.u(P, "u_bloomAmt1"), amt1)
+    gl.uniform1f(this.u(P, "u_aberration"), opts.aberration)
+    gl.uniform1f(this.u(P, "u_vignette"), opts.vignette)
+    gl.uniform4f(this.u(P, "u_flash"), opts.flashR, opts.flashG, opts.flashB, opts.flashA)
+    gl.uniform1f(this.u(P, "u_time"), opts.time)
+    gl.uniform1f(this.u(P, "u_desat"), opts.desat)
+    this.fsPass(P, null)
+    gl.bindVertexArray(null)
+  }
+
+  clearStain(): void {
+    const gl = this.gl
+    for (const t of [this.stainA, this.stainB]) {
+      gl.bindFramebuffer(gl.FRAMEBUFFER, t.fb)
+      gl.clearColor(0, 0, 0, 1)
+      gl.clear(gl.COLOR_BUFFER_BIT)
+    }
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null)
+  }
+
+  destroy(): void {
+    const gl = this.gl
+    for (const t of [this.scene, this.b0, this.b1, this.b2, this.b3, this.stainA, this.stainB]) this.free(t)
+    gl.deleteBuffer(this.vboSprite)
+    gl.deleteBuffer(this.vboGlyph)
+    gl.deleteVertexArray(this.vaoSprite)
+    gl.deleteVertexArray(this.vaoGlyph)
+    gl.deleteVertexArray(this.vaoEmpty)
+    gl.deleteTexture(this.atlasTex)
+    for (const p of [this.pSprite, this.pGlyph, this.pAbyss, this.pBright, this.pBlur, this.pComposite, this.pStainFade, this.pBlit]) {
+      gl.deleteProgram(p)
+    }
+    gl.getExtension("WEBGL_lose_context")?.loseContext()
+  }
+}

--- a/dynawalla/games/horde/src/gfx/shaders.ts
+++ b/dynawalla/games/horde/src/gfx/shaders.ts
@@ -1,0 +1,297 @@
+/* All GLSL for DEEPSWARM. No textures ship with the game: every shape is an
+ * SDF evaluated in the fragment shader, and the one texture that exists (the
+ * glyph atlas) is drawn into a canvas at boot. */
+
+export const SPRITE_VS = /* glsl */ `#version 300 es
+precision highp float;
+
+// per-instance
+layout(location=0) in vec2  i_pos;
+layout(location=1) in vec2  i_half;
+layout(location=2) in float i_rot;
+layout(location=3) in vec4  i_col;
+layout(location=4) in vec3  i_shape;   // shape id, p0, p1
+
+uniform vec4 u_cam;        // camX, camY, 1/halfW, 1/halfH
+
+out vec2  v_uv;
+out vec4  v_col;
+out vec3  v_shape;
+
+void main() {
+  // Unit quad from the vertex id — no vertex buffer at all.
+  vec2 corner = vec2((gl_VertexID & 1) == 0 ? -1.0 : 1.0,
+                     (gl_VertexID & 2) == 0 ? -1.0 : 1.0);
+  v_uv = corner;
+  v_col = i_col;
+  v_shape = i_shape;
+
+  float s = sin(i_rot), c = cos(i_rot);
+  vec2 local = corner * i_half;
+  vec2 world = i_pos + vec2(local.x * c - local.y * s, local.x * s + local.y * c);
+  gl_Position = vec4((world.x - u_cam.x) * u_cam.z, (world.y - u_cam.y) * u_cam.w, 0.0, 1.0);
+}`
+
+export const SPRITE_FS = /* glsl */ `#version 300 es
+precision highp float;
+
+in vec2  v_uv;
+in vec4  v_col;
+in vec3  v_shape;
+out vec4 o_col;
+
+float hexDist(vec2 p) {
+  p = abs(p);
+  // flat-top hexagon
+  return max(p.x * 0.8660254 + p.y * 0.5, p.y);
+}
+
+void main() {
+  int   id = int(v_shape.x + 0.5);
+  float p0 = v_shape.y;
+  float p1 = v_shape.z;
+  vec2  uv = v_uv;
+  float a  = 0.0;
+
+  if (id == 0) {                                   // DISC — soft radial glow
+    float r = length(uv);
+    a = pow(max(0.0, 1.0 - r), max(0.35, p0));
+  } else if (id == 1) {                            // RING
+    float r = length(uv);
+    float w = max(0.02, p0);
+    a = smoothstep(w, 0.0, abs(r - (1.0 - w))) ;
+    a *= smoothstep(1.02, 0.98, r);
+  } else if (id == 2) {                            // SHARD — elongated diamond
+    float d = abs(uv.x) + abs(uv.y);
+    a = smoothstep(1.0, 1.0 - max(0.08, p0), d);
+    a += 0.65 * smoothstep(0.55, 0.0, d);          // hot core
+  } else if (id == 3) {                            // DART — triangle, +y nose
+    float d = max(abs(uv.x) * 1.15 + (uv.y * 0.5 + 0.5) * 0.6 - 0.55, -uv.y - 0.95);
+    a = smoothstep(0.06, -0.14, d);
+    a += 0.5 * smoothstep(0.0, -0.5, d);
+  } else if (id == 4) {                            // CHITIN — hex body + rim
+    float h = hexDist(uv);
+    float body = smoothstep(0.98, 0.90, h);
+    float rim  = smoothstep(0.10, 0.0, abs(h - 0.90));
+    float core = pow(max(0.0, 1.0 - length(uv) * 1.55), 2.2);
+    a = body * 0.30 + rim * 1.0 + core * (0.55 + p0);
+  } else if (id == 5) {                            // SPARK — 4-point flare
+    float r = length(uv);
+    float cross_ = pow(max(0.0, 1.0 - abs(uv.x) * (7.0 + p0 * 26.0)), 2.0)
+                 + pow(max(0.0, 1.0 - abs(uv.y) * (7.0 + p0 * 26.0)), 2.0);
+    a = pow(max(0.0, 1.0 - r), 3.0) * 1.35 + cross_ * max(0.0, 1.0 - r) * 0.9;
+  } else if (id == 6) {                            // CAPSULE — tracer
+    float d = length(vec2(max(abs(uv.x) - (1.0 - p0), 0.0), uv.y * (1.0 / max(0.05, p0))));
+    a = smoothstep(1.0, 0.25, d);
+    a += 0.8 * smoothstep(0.5, 0.0, d);
+  } else if (id == 7) {                            // GEM — rhombus + rim
+    float d = abs(uv.x) * 1.0 + abs(uv.y) * 0.78;
+    a = smoothstep(0.14, 0.0, abs(d - 0.82)) * 1.2 + smoothstep(0.82, 0.1, d) * 0.55;
+  } else {                                         // fallback: square-ish glow
+    a = max(0.0, 1.0 - max(abs(uv.x), abs(uv.y)));
+  }
+
+  a *= v_col.a;
+  if (a <= 0.002) discard;
+  // Additive, premultiplied. p1 lifts the whole thing toward white so a
+  // "hot" instance blooms without changing hue.
+  vec3 rgb = mix(v_col.rgb, vec3(1.0), clamp(p1, 0.0, 1.0));
+  o_col = vec4(rgb * a, a);
+}`
+
+export const GLYPH_VS = /* glsl */ `#version 300 es
+precision highp float;
+layout(location=0) in vec2 i_pos;
+layout(location=1) in vec2 i_half;
+layout(location=2) in vec4 i_uv;     // u0,v0,u1,v1
+layout(location=3) in vec4 i_col;
+uniform vec4 u_cam;
+out vec2 v_uv;
+out vec4 v_col;
+void main() {
+  vec2 corner = vec2((gl_VertexID & 1) == 0 ? -1.0 : 1.0,
+                     (gl_VertexID & 2) == 0 ? -1.0 : 1.0);
+  v_uv = vec2(mix(i_uv.x, i_uv.z, corner.x * 0.5 + 0.5),
+              mix(i_uv.w, i_uv.y, corner.y * 0.5 + 0.5));
+  v_col = i_col;
+  vec2 world = i_pos + corner * i_half;
+  gl_Position = vec4((world.x - u_cam.x) * u_cam.z, (world.y - u_cam.y) * u_cam.w, 0.0, 1.0);
+}`
+
+export const GLYPH_FS = /* glsl */ `#version 300 es
+precision highp float;
+in vec2 v_uv;
+in vec4 v_col;
+uniform sampler2D u_tex;
+out vec4 o_col;
+void main() {
+  float m = texture(u_tex, v_uv).a;
+  if (m <= 0.004) discard;
+  float a = m * v_col.a;
+  o_col = vec4(v_col.rgb * a, a);
+}`
+
+/** Fullscreen triangle — no attributes. */
+export const FS_TRI_VS = /* glsl */ `#version 300 es
+precision highp float;
+out vec2 v_uv;
+void main() {
+  vec2 p = vec2((gl_VertexID << 1) & 2, gl_VertexID & 2);
+  v_uv = p;
+  gl_Position = vec4(p * 2.0 - 1.0, 0.0, 1.0);
+}`
+
+export const ABYSS_FS = /* glsl */ `#version 300 es
+precision highp float;
+in vec2 v_uv;
+out vec4 o_col;
+uniform vec2  u_res;
+uniform vec2  u_cam;
+uniform float u_time;
+uniform float u_intensity;   // 0..1 how deep the run has gone
+uniform float u_scale;       // world units per pixel
+
+float hash(vec2 p) { return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453); }
+
+float noise(vec2 p) {
+  vec2 i = floor(p), f = fract(p);
+  f = f * f * (3.0 - 2.0 * f);
+  return mix(mix(hash(i), hash(i + vec2(1, 0)), f.x),
+             mix(hash(i + vec2(0, 1)), hash(i + vec2(1, 1)), f.x), f.y);
+}
+
+void main() {
+  vec2 frag = v_uv * u_res;
+  vec2 world = (frag - u_res * 0.5) * u_scale + u_cam;
+
+  // Deep water: indigo that warms very slightly as the run escalates.
+  vec3 col = mix(vec3(0.016, 0.021, 0.055), vec3(0.045, 0.017, 0.062), u_intensity);
+
+  // Slow caustic sheets, two octaves, drifting in opposite directions.
+  float c1 = noise(world * 0.0032 + vec2(u_time * 0.019, -u_time * 0.011));
+  float c2 = noise(world * 0.0071 - vec2(u_time * 0.013, u_time * 0.023));
+  float caustic = pow(max(0.0, c1 * 0.65 + c2 * 0.5 - 0.44), 2.4);
+  col += vec3(0.10, 0.26, 0.42) * caustic * (0.5 + u_intensity * 0.9);
+
+  // The lattice. Two scales, the finer one fading out as you zoom.
+  vec2 g = world * 0.0125;
+  vec2 gf = abs(fract(g) - 0.5);
+  float line = smoothstep(0.5, 0.47, max(gf.x, gf.y));
+  col += vec3(0.05, 0.11, 0.20) * line * 0.55;
+
+  vec2 g2 = world * 0.0025;
+  vec2 gf2 = abs(fract(g2) - 0.5);
+  float line2 = smoothstep(0.5, 0.485, max(gf2.x, gf2.y));
+  col += vec3(0.08, 0.16, 0.30) * line2 * 0.7;
+
+  // Marine snow: slow motes drifting through the beam.
+  vec2 sp = world * 0.02 + vec2(0.0, u_time * 0.35);
+  vec2 si = floor(sp);
+  float m = hash(si);
+  if (m > 0.986) {
+    vec2 sf = fract(sp) - 0.5;
+    float d = length(sf);
+    col += vec3(0.35, 0.62, 0.85) * pow(max(0.0, 1.0 - d * 3.4), 5.0) * 0.55;
+  }
+
+  o_col = vec4(col, 1.0);
+}`
+
+export const BRIGHT_FS = /* glsl */ `#version 300 es
+precision highp float;
+in vec2 v_uv;
+out vec4 o_col;
+uniform sampler2D u_tex;
+uniform float u_threshold;
+void main() {
+  vec3 c = texture(u_tex, v_uv).rgb;
+  float l = dot(c, vec3(0.2126, 0.7152, 0.0722));
+  float k = max(0.0, l - u_threshold) / max(0.0001, l);
+  o_col = vec4(c * k, 1.0);
+}`
+
+export const BLUR_FS = /* glsl */ `#version 300 es
+precision highp float;
+in vec2 v_uv;
+out vec4 o_col;
+uniform sampler2D u_tex;
+uniform vec2 u_dir;      // texel step
+void main() {
+  // 9-tap gaussian folded into 5 bilinear fetches.
+  vec3 c = texture(u_tex, v_uv).rgb * 0.2270270270;
+  c += texture(u_tex, v_uv + u_dir * 1.3846153846).rgb * 0.3162162162;
+  c += texture(u_tex, v_uv - u_dir * 1.3846153846).rgb * 0.3162162162;
+  c += texture(u_tex, v_uv + u_dir * 3.2307692308).rgb * 0.0702702703;
+  c += texture(u_tex, v_uv - u_dir * 3.2307692308).rgb * 0.0702702703;
+  o_col = vec4(c, 1.0);
+}`
+
+export const COMPOSITE_FS = /* glsl */ `#version 300 es
+precision highp float;
+in vec2 v_uv;
+out vec4 o_col;
+uniform sampler2D u_scene;
+uniform sampler2D u_bloom0;
+uniform sampler2D u_bloom1;
+uniform float u_bloomAmt0;
+uniform float u_bloomAmt1;
+uniform float u_aberration;
+uniform float u_vignette;
+uniform vec4  u_flash;      // rgb + strength
+uniform float u_time;
+uniform float u_desat;      // 1 while the Rift is open
+
+vec3 tonemap(vec3 x) {
+  // Filmic-ish. Keeps hue as things blow out instead of going magenta.
+  x = max(vec3(0.0), x);
+  return (x * (2.51 * x + 0.03)) / (x * (2.43 * x + 0.59) + 0.14);
+}
+
+void main() {
+  vec2 uv = v_uv;
+  vec2 off = (uv - 0.5) * u_aberration;
+
+  vec3 scene;
+  if (u_aberration > 0.0001) {
+    scene.r = texture(u_scene, uv + off).r;
+    scene.g = texture(u_scene, uv).g;
+    scene.b = texture(u_scene, uv - off).b;
+  } else {
+    scene = texture(u_scene, uv).rgb;
+  }
+
+  vec3 bloom = texture(u_bloom0, uv).rgb * u_bloomAmt0
+             + texture(u_bloom1, uv).rgb * u_bloomAmt1;
+
+  vec3 col = scene + bloom;
+  col = tonemap(col * 1.06);
+
+  // Flash is additive and clamped; the caller rate-limits it.
+  col += u_flash.rgb * u_flash.a;
+
+  float r = length((uv - 0.5) * vec2(1.0, 0.92));
+  col *= mix(1.0, smoothstep(0.95, 0.28, r), u_vignette);
+
+  if (u_desat > 0.001) {
+    float l = dot(col, vec3(0.2126, 0.7152, 0.0722));
+    col = mix(col, vec3(l) * vec3(0.72, 0.78, 1.05), u_desat);
+  }
+
+  // A whisper of grain so flat areas do not band on cheap panels.
+  float g = fract(sin(dot(uv * u_time, vec2(12.9898, 78.233))) * 43758.5453);
+  col += (g - 0.5) * 0.012;
+
+  o_col = vec4(col, 1.0);
+}`
+
+export const STAIN_FADE_FS = /* glsl */ `#version 300 es
+precision highp float;
+in vec2 v_uv;
+out vec4 o_col;
+uniform sampler2D u_tex;
+uniform float u_fade;
+uniform vec2  u_shift;   // camera motion in uv space
+void main() {
+  vec3 c = texture(u_tex, v_uv + u_shift).rgb;
+  o_col = vec4(max(vec3(0.0), c * u_fade - 0.0016), 1.0);
+}`

--- a/dynawalla/games/horde/src/index.ts
+++ b/dynawalla/games/horde/src/index.ts
@@ -1,0 +1,55 @@
+import css from "./style.css?inline"
+import type { Host } from "./contract.ts"
+import { Game } from "./game/game.ts"
+
+export type { Host, Question } from "./contract.ts"
+export { createStubHost } from "./stubHost.ts"
+
+let styleTag: HTMLStyleElement | null = null
+let mounts = 0
+
+function ensureStyles(): void {
+  if (styleTag) return
+  styleTag = document.createElement("style")
+  styleTag.setAttribute("data-horde", "")
+  styleTag.textContent = css
+  document.head.appendChild(styleTag)
+}
+
+/**
+ * Mount DEEPSWARM into `el`. The element is sized by the host; the game fills
+ * it and never touches anything outside it.
+ */
+export function mount(el: HTMLElement, host: Host): { unmount(): void } {
+  ensureStyles()
+  mounts++
+  const root = document.createElement("div")
+  root.className = "hz-root"
+  el.appendChild(root)
+
+  let game: Game | null = null
+  try {
+    game = new Game(root, host)
+  } catch (err) {
+    // Never fail silently: a black rectangle with no explanation is the worst
+    // possible outcome for a child and for whoever has to debug it.
+    console.error("[horde] failed to start", err)
+    root.innerHTML =
+      '<div class="hz-modal hz-open"><div class="hz-big">NO LIGHT</div>' +
+      '<div class="hz-tagline">THIS DEVICE CANNOT OPEN THE DEEP</div>' +
+      '<div class="hz-hint">DEEPSWARM needs WebGL2. Try another browser, or turn hardware acceleration back on.</div></div>'
+  }
+
+  return {
+    unmount() {
+      game?.destroy()
+      game = null
+      root.remove()
+      mounts--
+      if (mounts <= 0 && styleTag) {
+        styleTag.remove()
+        styleTag = null
+      }
+    },
+  }
+}

--- a/dynawalla/games/horde/src/main.ts
+++ b/dynawalla/games/horde/src/main.ts
@@ -1,0 +1,25 @@
+/** Standalone shell: `npm run dev` and play. The real host replaces this. */
+import { mount } from "./index.ts"
+import { createStubHost } from "./stubHost.ts"
+
+const el = document.getElementById("app")
+if (!el) throw new Error("horde: #app is missing")
+
+let correct = 0
+let asked = 0
+const host = createStubHost({
+  seed: 20260726,
+  onReport(r) {
+    asked++
+    if (r.correct) correct++
+    console.log(
+      `[stub-host] ${r.questionId} ${r.correct ? "✓" : "✗"} answered=${r.answered} ` +
+      `${Math.round(r.ms)} ms  —  ${correct}/${asked}`,
+    )
+  },
+})
+
+const handle = mount(el, host)
+
+// Handy while iterating: window.__horde.unmount()
+;(window as unknown as { __horde: unknown }).__horde = handle

--- a/dynawalla/games/horde/src/stubHost.test.ts
+++ b/dynawalla/games/horde/src/stubHost.test.ts
@@ -1,0 +1,107 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { createStubHost, mulberry32 } from "./stubHost.ts"
+
+/**
+ * The stub host is the only part of the game that produces mathematics, so it
+ * is the part that has to be provably right. The renderer can be wrong and a
+ * child sees an ugly frame; this file can be wrong and a child is told correct
+ * work is incorrect.
+ *
+ * `next()` takes the difficulty explicitly here. The live ramp is driven by the
+ * run, and a loop that just calls `next()` would sit at the default forever and
+ * never reach the `div` or `signed` families.
+ */
+
+/** Prompt glyphs are typographic (U+2212, ×, ÷); make them evaluable. */
+const norm = (s: string): string =>
+  s.replace(/−/g, "-").replace(/×/g, "*").replace(/÷/g, "/")
+
+test("every generated question is well formed", () => {
+  const h = createStubHost({ seed: 4242 })
+  for (let i = 0; i < 4000; i++) {
+    const q = h.next({ difficulty: (i % 10) + 1 })
+
+    const a = Number(q.answer)
+    assert.ok(Number.isInteger(a), `answer is not an exact integer: ${q.answer}`)
+
+    assert.equal(q.distractors.length, 3, `wanted 3 distractors in ${q.prompt}`)
+    const vals = q.distractors.map(Number)
+    for (const v of vals) {
+      assert.ok(Number.isInteger(v), `distractor is not an exact integer: ${v}`)
+      assert.notEqual(v, a, `distractor equals the answer in ${q.prompt}`)
+    }
+    assert.equal(new Set(vals).size, 3, `duplicate distractors in ${q.prompt}`)
+
+    assert.ok(q.prompt.length > 0, "empty prompt")
+    assert.doesNotMatch(q.prompt, /(?<![0-9(])-/, "use U+2212, never a hyphen")
+    assert.ok(q.id.length > 0, "empty id")
+  }
+})
+
+test("prompts are arithmetically true", () => {
+  const h = createStubHost({ seed: 77 })
+  let checked = 0
+  for (let i = 0; i < 3000; i++) {
+    const q = h.next({ difficulty: (i % 10) + 1 })
+    const a = Number(q.answer)
+    const p = norm(q.prompt)
+
+    assert.match(p, /^[-()\d+*/\s]+$/, `unexpected glyph in prompt: ${q.prompt}`)
+    // eslint-disable-next-line no-new-func -- test-only evaluation of our own generated infix
+    const v = Function(`"use strict";return (${p})`)() as number
+    assert.equal(v, a, `${q.prompt} should be ${a}, computed ${v}`)
+
+    if (q.domain === "div") {
+      // Division must come out exact — a remainder would be unanswerable.
+      assert.ok(Number.isInteger(v), `${q.prompt} is not an exact division`)
+    }
+    checked++
+  }
+  assert.equal(checked, 3000)
+})
+
+test("the whole family table is reachable across the difficulty ramp", () => {
+  const h = createStubHost({ seed: 9 })
+  const seen = new Set<string>()
+  for (let i = 0; i < 4000; i++) seen.add(h.next({ difficulty: (i % 10) + 1 }).domain)
+  assert.deepEqual(
+    [...seen].sort(),
+    ["add", "div", "mul", "signed", "sub"],
+    `only saw ${[...seen].sort().join(",")}`,
+  )
+})
+
+test("a pinned domain is honoured", () => {
+  const h = createStubHost({ seed: 3 })
+  for (const d of ["add", "sub", "mul", "div", "signed"]) {
+    for (let i = 0; i < 50; i++) {
+      assert.equal(h.next({ domain: d, difficulty: 8 }).domain, d)
+    }
+  }
+})
+
+test("seeded runs are byte-identical", () => {
+  const a = createStubHost({ seed: 99 })
+  const b = createStubHost({ seed: 99 })
+  for (let i = 0; i < 500; i++) {
+    assert.deepEqual(a.next({ difficulty: (i % 10) + 1 }), b.next({ difficulty: (i % 10) + 1 }))
+  }
+})
+
+test("mulberry32 is deterministic and stays in [0,1)", () => {
+  const a = mulberry32(1234)
+  const b = mulberry32(1234)
+  for (let i = 0; i < 1000; i++) {
+    const v = a()
+    assert.equal(v, b())
+    assert.ok(v >= 0 && v < 1, `rng out of range: ${v}`)
+  }
+})
+
+test("report reaches the onReport hook", () => {
+  const got: string[] = []
+  const h = createStubHost({ seed: 1, onReport: (r) => got.push(r.questionId) })
+  h.report({ questionId: "q-1", correct: true, ms: 900, answered: "7" })
+  assert.deepEqual(got, ["q-1"])
+})

--- a/dynawalla/games/horde/src/stubHost.ts
+++ b/dynawalla/games/horde/src/stubHost.ts
@@ -1,0 +1,256 @@
+/**
+ * A local, standalone Host so `npm run dev` is playable with no runtime
+ * underneath. The real Dynawalla host replaces this wholesale.
+ *
+ * Rules this file obeys, and that the real host also obeys:
+ *  - **Exact integer arithmetic only.** No float appears in an answer or in a
+ *    comparison. `0.1 + 0.2 !== 0.3` would mark correct work wrong, forever,
+ *    deterministically.
+ *  - **Seeded and deterministic.** Same seed, same stream of questions.
+ *  - **Distractors are mal-rule outputs** — what a child who applied a real,
+ *    nameable wrong procedure would actually write down. A distractor that is
+ *    `answer + 1` teaches nothing and is trivially eliminated.
+ */
+import type { Host, Question } from "./contract.ts"
+
+/* ------------------------------------------------------------------ rng -- */
+
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/* ------------------------------------------------------- mal-rule helpers */
+
+/** Column-wise add with every carry dropped: 47 + 38 → 715 becomes 75. */
+function noCarryAdd(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  while (a > 0 || b > 0) {
+    const d = ((a % 10) + (b % 10)) % 10
+    out += d * place
+    a = Math.floor(a / 10)
+    b = Math.floor(b / 10)
+    place *= 10
+  }
+  return out
+}
+
+/** "Take the smaller from the larger" in every column: 52 − 27 → 35. */
+function smallerFromLarger(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  while (a > 0 || b > 0) {
+    const x = a % 10
+    const y = b % 10
+    out += Math.abs(x - y) * place
+    a = Math.floor(a / 10)
+    b = Math.floor(b / 10)
+    place *= 10
+  }
+  return out
+}
+
+/** Borrowed once and then forgot to decrement the next column. */
+function forgotBorrow(a: number, b: number): number {
+  const ones = a % 10
+  const bOnes = b % 10
+  if (ones >= bOnes) return a - b + 10
+  return a - b + 10
+}
+
+/* --------------------------------------------------------------- shaping */
+
+type Gen = (rng: () => number, d: number) => { prompt: string; answer: number; wrong: number[] }
+
+const clampD = (d: number) => Math.max(1, Math.min(10, Math.round(d)))
+const pick = (rng: () => number, n: number) => Math.floor(rng() * n)
+const between = (rng: () => number, lo: number, hi: number) => lo + Math.floor(rng() * (hi - lo + 1))
+
+const genAdd: Gen = (rng, d) => {
+  const hi = [9, 12, 20, 40, 70, 99, 160, 300, 600, 999][clampD(d) - 1]
+  const lo = d <= 2 ? 1 : Math.max(2, Math.floor(hi / 8))
+  const a = between(rng, lo, hi)
+  const b = between(rng, lo, hi)
+  const ans = a + b
+  return {
+    prompt: `${a} + ${b}`,
+    answer: ans,
+    wrong: [noCarryAdd(a, b), ans - 10, ans + 10, ans - 1, a + b + (b % 10 === 0 ? 100 : 9)],
+  }
+}
+
+const genSub: Gen = (rng, d) => {
+  const hi = [9, 14, 25, 45, 80, 99, 180, 350, 650, 999][clampD(d) - 1]
+  let a = between(rng, Math.max(2, Math.floor(hi / 3)), hi)
+  let b = between(rng, 1, a)
+  if (a < b) [a, b] = [b, a]
+  const ans = a - b
+  return {
+    prompt: `${a} − ${b}`,
+    answer: ans,
+    wrong: [smallerFromLarger(a, b), forgotBorrow(a, b), a + b, ans + 10, ans - 10],
+  }
+}
+
+const genMul: Gen = (rng, d) => {
+  const table = [5, 6, 8, 9, 10, 12, 12, 12, 15, 20][clampD(d) - 1]
+  const big = d >= 6 ? between(rng, 11, 20 + d * 6) : between(rng, 2, table)
+  const a = d >= 6 ? big : between(rng, 2, table)
+  const b = between(rng, 2, Math.min(12, table))
+  const ans = a * b
+  return {
+    prompt: `${a} × ${b}`,
+    answer: ans,
+    // off-by-one-multiple is the classic skip-counting slip; a+b is the
+    // operator confusion; a*(b) with a dropped partial-product carry is the
+    // long-multiplication error.
+    wrong: [a * (b - 1), a * (b + 1), a + b, ans - 10, noCarryAdd(a * (b - 1), a)],
+  }
+}
+
+const genDiv: Gen = (rng, d) => {
+  const bMax = [4, 5, 6, 8, 9, 10, 11, 12, 12, 12][clampD(d) - 1]
+  const qMax = [5, 6, 8, 9, 10, 12, 14, 16, 20, 25][clampD(d) - 1]
+  const b = between(rng, 2, bMax)
+  const q = between(rng, 2, qMax)
+  const a = b * q
+  return {
+    prompt: `${a} ÷ ${b}`,
+    answer: q,
+    wrong: [q + 1, q - 1, a - b, b, Math.floor(a / (b + 1))],
+  }
+}
+
+/** Signed work — the polarity that a horde survivor's shield/damage maths needs. */
+const genSigned: Gen = (rng, d) => {
+  const hi = [6, 9, 12, 18, 25, 40, 60, 90, 140, 200][clampD(d) - 1]
+  const a = between(rng, 1, hi)
+  const b = between(rng, 1, hi)
+  const neg = pick(rng, 2) === 0
+  if (neg) {
+    const ans = a - b
+    return {
+      prompt: `${a} + (−${b})`,
+      answer: ans,
+      // The sign-drop is *the* signed-arithmetic mal-rule.
+      wrong: [a + b, b - a, -(a + b), ans + 10, ans - 1],
+    }
+  }
+  const ans = -a - b
+  return {
+    prompt: `(−${a}) + (−${b})`,
+    answer: ans,
+    wrong: [a + b, b - a, a - b, ans + 10, ans + 1],
+  }
+}
+
+const DOMAINS: Record<string, Gen> = {
+  add: genAdd,
+  sub: genSub,
+  mul: genMul,
+  div: genDiv,
+  signed: genSigned,
+}
+
+/** Which domains are live at a given difficulty — the run's own ramp. */
+function domainsFor(d: number): string[] {
+  if (d <= 2) return ["add", "sub"]
+  if (d <= 4) return ["add", "sub", "mul"]
+  if (d <= 6) return ["add", "sub", "mul", "div"]
+  return ["add", "sub", "mul", "div", "signed"]
+}
+
+/* ------------------------------------------------------------------ host */
+
+export type StubHostOptions = {
+  seed?: number
+  /** Called on every `report`, so the standalone shell can show accuracy. */
+  onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void
+  haptic?: (k: "light" | "medium" | "heavy" | "success" | "failure") => void
+}
+
+export function createStubHost(opts: StubHostOptions = {}): Host {
+  const rng = mulberry32(opts.seed ?? 0x5eed1e)
+  let n = 0
+
+  return {
+    next(o): Question {
+      const difficulty = clampD(o?.difficulty ?? 3)
+      const pool = domainsFor(difficulty)
+      const domain = o?.domain && DOMAINS[o.domain] ? o.domain : pool[pick(rng, pool.length)]
+      const gen = DOMAINS[domain]
+
+      let g = gen(rng, difficulty)
+      // Reject degenerate items: an answer a child can read off the prompt.
+      for (let guard = 0; guard < 8; guard++) {
+        if (Math.abs(g.answer) > 1 && !g.prompt.startsWith(`${g.answer} `)) break
+        g = gen(rng, difficulty)
+      }
+
+      // Three distinct, plausible, non-answer distractors.
+      const seen = new Set<number>([g.answer])
+      const distractors: string[] = []
+      for (const w of g.wrong) {
+        if (distractors.length === 3) break
+        if (!Number.isInteger(w)) continue
+        if (seen.has(w)) continue
+        if (domain !== "signed" && w < 0) continue
+        seen.add(w)
+        distractors.push(String(w))
+      }
+      // Deterministic backfill, still never a float.
+      let pad = 1
+      while (distractors.length < 3) {
+        const w = g.answer + pad * (pad % 2 === 0 ? 1 : -1) * 2
+        pad++
+        if (seen.has(w) || (domain !== "signed" && w < 0)) continue
+        seen.add(w)
+        distractors.push(String(w))
+      }
+
+      n++
+      return {
+        id: `stub-${n}`,
+        prompt: g.prompt,
+        answer: String(g.answer),
+        distractors,
+        domain,
+        difficulty,
+      }
+    },
+
+    report(r) {
+      opts.onReport?.(r)
+    },
+
+    haptic(k) {
+      opts.haptic?.(k)
+      // Best-effort on Android Chrome; a silent no-op everywhere else.
+      const nav = navigator as Navigator & { vibrate?: (p: number | number[]) => boolean }
+      if (typeof nav.vibrate !== "function") return
+      const pattern: Record<string, number | number[]> = {
+        light: 8,
+        medium: 18,
+        heavy: 32,
+        success: [12, 28, 22],
+        failure: [26, 40, 26],
+      }
+      try {
+        nav.vibrate(pattern[k] ?? 10)
+      } catch {
+        /* a device that refuses to buzz is not an error */
+      }
+    },
+
+    prefersReducedMotion() {
+      return typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion: reduce)").matches
+    },
+  }
+}

--- a/dynawalla/games/horde/src/style.css
+++ b/dynawalla/games/horde/src/style.css
@@ -1,0 +1,564 @@
+/* DEEPSWARM — bioluminescent abyss.
+   Near-black indigo, luminous edges, heavy geometric numerals. No serif on
+   anything a child has to read in under half a second. */
+
+.hz-root {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #04060f;
+  color: #e8f2ff;
+  font-family: ui-rounded, "SF Pro Rounded", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+  font-variant-numeric: tabular-nums;
+  -webkit-tap-highlight-color: transparent;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: none;
+  contain: layout paint style;
+}
+
+.hz-root * { box-sizing: border-box; }
+
+.hz-canvas {
+  position: absolute;
+  inset: 0;
+  display: block;
+  touch-action: none;
+}
+
+.hz-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ------------------------------------------------------------------- HUD */
+
+.hz-hud {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  padding: max(10px, env(safe-area-inset-top)) max(10px, env(safe-area-inset-right)) max(10px, env(safe-area-inset-bottom)) max(10px, env(safe-area-inset-left));
+}
+
+.hz-xpbar {
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 7px;
+  background: rgba(120, 190, 255, 0.10);
+}
+.hz-xpfill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, #35ffd6, #6ff0ff 55%, #d8fbff);
+  box-shadow: 0 0 14px #35ffd6, 0 0 34px rgba(53, 255, 214, 0.55);
+  transition: width 90ms linear;
+}
+
+.hz-top {
+  position: absolute;
+  top: calc(14px + env(safe-area-inset-top));
+  left: 0; right: 0;
+  display: flex;
+  justify-content: center;
+  gap: clamp(10px, 3vw, 26px);
+  align-items: baseline;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+}
+
+.hz-clock {
+  font-size: clamp(22px, 5.2vw, 38px);
+  font-weight: 900;
+  text-shadow: 0 0 18px rgba(120, 220, 255, 0.55);
+  letter-spacing: 0.02em;
+}
+
+.hz-chip {
+  font-size: clamp(11px, 2.6vw, 15px);
+  color: #8fb6d8;
+  letter-spacing: 0.13em;
+}
+.hz-chip b {
+  color: #dff3ff;
+  font-weight: 900;
+  font-size: clamp(13px, 3vw, 19px);
+}
+
+.hz-lvl {
+  color: #ffe08a;
+  text-shadow: 0 0 16px rgba(255, 200, 80, 0.6);
+}
+
+/* life */
+.hz-life {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: calc(16px + env(safe-area-inset-bottom));
+  width: min(380px, 62vw);
+  height: 12px;
+  background: rgba(255, 90, 120, 0.14);
+  border: 1px solid rgba(255, 130, 150, 0.25);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.hz-lifefill {
+  height: 100%;
+  width: 100%;
+  background: linear-gradient(90deg, #ff5f7a, #ff9c6a 70%, #ffd2a0);
+  box-shadow: 0 0 16px rgba(255, 100, 120, 0.8);
+  transition: width 110ms ease-out;
+}
+.hz-lifetext {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  color: #23070f;
+  mix-blend-mode: normal;
+  text-shadow: none;
+}
+
+.hz-weps {
+  position: absolute;
+  left: calc(12px + env(safe-area-inset-left));
+  bottom: calc(40px + env(safe-area-inset-bottom));
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: clamp(9px, 2.2vw, 12px);
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  color: #9dc4e4;
+}
+.hz-wep b { color: #eaf7ff; }
+
+.hz-banner {
+  position: absolute;
+  left: 0; right: 0;
+  top: 26%;
+  text-align: center;
+  font-size: clamp(28px, 9vw, 74px);
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  opacity: 0;
+  color: #fff;
+  text-shadow: 0 0 30px currentColor, 0 0 70px currentColor;
+}
+.hz-banner.hz-on { animation: hz-banner 1500ms cubic-bezier(0.16, 1, 0.3, 1) forwards; }
+@keyframes hz-banner {
+  0% { opacity: 0; transform: scale(0.62) translateY(14px); letter-spacing: -0.05em; }
+  12% { opacity: 1; transform: scale(1.09); letter-spacing: 0.1em; }
+  26% { transform: scale(1); }
+  74% { opacity: 1; }
+  100% { opacity: 0; transform: scale(1.03) translateY(-16px); }
+}
+
+.hz-sub {
+  position: absolute;
+  left: 0; right: 0;
+  top: calc(26% + clamp(34px, 10vw, 84px));
+  text-align: center;
+  font-size: clamp(11px, 2.8vw, 16px);
+  letter-spacing: 0.22em;
+  font-weight: 800;
+  opacity: 0;
+  color: #bcd8ee;
+}
+.hz-sub.hz-on { animation: hz-sub 1500ms ease-out forwards; }
+@keyframes hz-sub {
+  0% { opacity: 0; } 16% { opacity: 0.95; } 70% { opacity: 0.9; } 100% { opacity: 0; }
+}
+
+/* --------------------------------------------------------------- modals */
+
+.hz-modal {
+  position: absolute;
+  inset: 0;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+  padding: max(12px, env(safe-area-inset-top)) 12px max(12px, env(safe-area-inset-bottom));
+  background:
+    radial-gradient(120% 90% at 50% 40%, rgba(8, 14, 34, 0.62), rgba(2, 4, 12, 0.93));
+  backdrop-filter: blur(9px) saturate(0.85);
+  -webkit-backdrop-filter: blur(9px) saturate(0.85);
+}
+.hz-modal.hz-open { display: flex; animation: hz-fade 170ms ease-out; }
+@keyframes hz-fade { from { opacity: 0; } to { opacity: 1; } }
+
+.hz-title {
+  font-size: clamp(13px, 3.4vw, 19px);
+  font-weight: 900;
+  letter-spacing: 0.4em;
+  color: #7fe6ff;
+  text-shadow: 0 0 22px rgba(80, 220, 255, 0.7);
+  margin-bottom: clamp(8px, 2vw, 18px);
+  text-align: center;
+}
+
+/* cards */
+.hz-cards {
+  display: flex;
+  gap: clamp(7px, 1.6vw, 16px);
+  width: min(1080px, 96vw);
+  justify-content: center;
+  align-items: stretch;
+  flex-wrap: nowrap;
+}
+@media (max-aspect-ratio: 4/5) {
+  .hz-cards { flex-direction: column; width: min(520px, 96vw); }
+}
+
+.hz-card {
+  flex: 1 1 0;
+  min-width: 0;
+  position: relative;
+  border: 1px solid rgba(140, 200, 255, 0.22);
+  background: linear-gradient(170deg, rgba(16, 26, 52, 0.94), rgba(6, 10, 24, 0.96));
+  border-radius: 5px;
+  padding: clamp(9px, 1.8vw, 20px) clamp(8px, 1.6vw, 18px);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(3px, 0.8vw, 8px);
+  overflow: hidden;
+  transition: transform 110ms cubic-bezier(0.16, 1, 0.3, 1), border-color 110ms, box-shadow 140ms;
+  animation: hz-card-in 260ms cubic-bezier(0.16, 1, 0.3, 1) backwards;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+}
+.hz-card:nth-child(1) { animation-delay: 0ms; }
+.hz-card:nth-child(2) { animation-delay: 55ms; }
+.hz-card:nth-child(3) { animation-delay: 110ms; }
+.hz-card:nth-child(4) { animation-delay: 165ms; }
+@keyframes hz-card-in {
+  from { opacity: 0; transform: translateY(26px) scale(0.94); }
+  to { opacity: 1; transform: none; }
+}
+.hz-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--hue, #7fe6ff);
+  box-shadow: 0 0 18px var(--hue, #7fe6ff);
+}
+.hz-card:hover, .hz-card:focus-visible {
+  transform: translateY(-6px) scale(1.025);
+  border-color: var(--hue, #7fe6ff);
+  box-shadow: 0 0 0 1px var(--hue), 0 18px 60px -18px var(--hue);
+  outline: none;
+}
+.hz-card:active { transform: translateY(-2px) scale(0.99); }
+
+.hz-card-rarity {
+  position: absolute;
+  top: 0; right: 0;
+  padding: 3px 7px;
+  font-size: 9px;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  color: #04060f;
+  background: var(--hue, #7fe6ff);
+}
+.hz-card-r0 .hz-card-rarity { display: none; }
+
+.hz-card-title {
+  font-size: clamp(13px, 2.6vw, 20px);
+  font-weight: 900;
+  letter-spacing: 0.11em;
+  color: var(--hue, #cfe9ff);
+  padding-left: 8px;
+}
+.hz-card-tag {
+  font-size: clamp(10px, 2vw, 13px);
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  color: #e9f5ff;
+  padding-left: 8px;
+}
+.hz-card-math {
+  padding-left: 8px;
+  margin-top: auto;
+  font-size: clamp(10px, 1.9vw, 13px);
+  color: #7fa0c0;
+  letter-spacing: 0.02em;
+  line-height: 1.5;
+}
+.hz-card-math .hz-was { text-decoration: line-through; opacity: 0.65; }
+.hz-card-math .hz-now { color: #eaf7ff; font-weight: 800; }
+.hz-card-head {
+  padding-left: 8px;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+.hz-card-head b {
+  font-size: clamp(26px, 6vw, 46px);
+  font-weight: 900;
+  line-height: 0.95;
+  color: #fff;
+  text-shadow: 0 0 22px var(--hue, #7fe6ff);
+}
+.hz-card-head span {
+  font-size: clamp(8px, 1.7vw, 11px);
+  letter-spacing: 0.2em;
+  color: #85a8c8;
+  font-weight: 800;
+}
+
+/* sealed card */
+.hz-sealed {
+  --hue: #ffd166;
+  border-color: rgba(255, 209, 102, 0.5);
+  background: linear-gradient(170deg, rgba(46, 34, 10, 0.92), rgba(12, 8, 4, 0.96));
+  cursor: default;
+}
+.hz-sealed:hover { transform: none; box-shadow: none; border-color: rgba(255, 209, 102, 0.5); }
+.hz-seal-prompt {
+  font-size: clamp(20px, 5vw, 38px);
+  font-weight: 900;
+  color: #fff;
+  text-align: center;
+  letter-spacing: 0.02em;
+  text-shadow: 0 0 26px rgba(255, 209, 102, 0.8);
+  padding: clamp(2px, 1vw, 8px) 0;
+}
+.hz-seal-orbs { display: flex; gap: 6px; justify-content: center; flex-wrap: wrap; }
+.hz-orb {
+  flex: 1 1 0;
+  min-width: 52px;
+  padding: clamp(7px, 1.6vw, 13px) 4px;
+  font-size: clamp(15px, 3.4vw, 24px);
+  font-weight: 900;
+  color: #ffe9b8;
+  background: rgba(255, 209, 102, 0.09);
+  border: 1px solid rgba(255, 209, 102, 0.42);
+  border-radius: 3px;
+  cursor: pointer;
+  transition: transform 90ms, background 90ms;
+  font-family: inherit;
+  font-variant-numeric: tabular-nums;
+}
+.hz-orb:hover { background: rgba(255, 209, 102, 0.22); transform: translateY(-2px); }
+.hz-orb:active { transform: scale(0.96); }
+.hz-orb.hz-ok { background: #ffd166; color: #241800; animation: hz-pop 380ms ease-out; }
+.hz-orb.hz-no { background: rgba(120, 40, 60, 0.55); border-color: #ff7d9c; color: #ffd9e2; }
+@keyframes hz-pop { 0% { transform: scale(1); } 40% { transform: scale(1.18); } 100% { transform: scale(1); } }
+.hz-seal-note {
+  text-align: center;
+  font-size: clamp(8px, 1.7vw, 11px);
+  letter-spacing: 0.18em;
+  color: #c8a95e;
+  font-weight: 800;
+}
+
+/* ----------------------------------------------------------------- rift */
+
+.hz-rift .hz-title { color: #ff9ab6; text-shadow: 0 0 26px rgba(255, 120, 160, 0.7); }
+.hz-riftbox {
+  width: min(620px, 94vw);
+  border: 1px solid rgba(255, 140, 175, 0.34);
+  background: linear-gradient(170deg, rgba(34, 10, 24, 0.95), rgba(8, 3, 12, 0.97));
+  border-radius: 6px;
+  padding: clamp(14px, 3vw, 28px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(8px, 2vw, 16px);
+  box-shadow: 0 0 90px -20px rgba(255, 90, 140, 0.55);
+}
+.hz-charges { display: flex; gap: 8px; justify-content: center; }
+.hz-charge {
+  width: clamp(26px, 7vw, 42px);
+  height: clamp(26px, 7vw, 42px);
+  border: 2px solid rgba(255, 160, 190, 0.4);
+  border-radius: 50%;
+  transition: background 200ms, box-shadow 200ms, transform 200ms;
+}
+.hz-charge.hz-lit {
+  background: #ffd166;
+  border-color: #fff2c8;
+  box-shadow: 0 0 26px #ffb03a, 0 0 60px rgba(255, 176, 58, 0.6);
+  transform: scale(1.12);
+}
+.hz-prompt {
+  font-size: clamp(30px, 9vw, 66px);
+  font-weight: 900;
+  text-align: center;
+  color: #fff;
+  letter-spacing: 0.02em;
+  text-shadow: 0 0 34px rgba(150, 220, 255, 0.7);
+  line-height: 1.05;
+}
+.hz-answers { display: flex; gap: clamp(6px, 1.6vw, 12px); }
+@media (max-width: 420px) { .hz-answers { flex-wrap: wrap; } .hz-answers .hz-answer { flex: 1 1 44%; } }
+.hz-answer {
+  flex: 1 1 0;
+  min-width: 0;
+  padding: clamp(12px, 3vw, 22px) 4px;
+  font-size: clamp(20px, 5.4vw, 34px);
+  font-weight: 900;
+  color: #eaf7ff;
+  background: rgba(120, 190, 255, 0.08);
+  border: 1px solid rgba(140, 200, 255, 0.32);
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-variant-numeric: tabular-nums;
+  transition: transform 90ms, background 110ms, border-color 110ms;
+}
+.hz-answer:hover { background: rgba(120, 190, 255, 0.2); transform: translateY(-3px); }
+.hz-answer:active { transform: scale(0.97); }
+.hz-answer.hz-ok { background: #7dffd0; border-color: #d8fff2; color: #00281c; animation: hz-pop 380ms ease-out; }
+.hz-answer.hz-no { background: rgba(120, 40, 60, 0.5); border-color: #ff7d9c; color: #ffd9e2; }
+.hz-riftclock {
+  height: 5px;
+  background: rgba(255, 140, 175, 0.16);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.hz-riftclock i { display: block; height: 100%; background: #ff7da0; box-shadow: 0 0 14px #ff5f8a; }
+.hz-riftnote {
+  text-align: center;
+  font-size: clamp(9px, 2vw, 12px);
+  letter-spacing: 0.2em;
+  font-weight: 800;
+  color: #d69fb4;
+}
+
+/* ------------------------------------------------------ title / gameover */
+
+.hz-big {
+  font-size: clamp(38px, 13vw, 118px);
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  color: #eaf9ff;
+  text-shadow: 0 0 40px rgba(90, 220, 255, 0.75), 0 0 120px rgba(60, 140, 255, 0.45);
+  text-align: center;
+  line-height: 0.94;
+}
+.hz-tagline {
+  font-size: clamp(10px, 2.6vw, 15px);
+  letter-spacing: 0.34em;
+  color: #86b6d6;
+  font-weight: 800;
+  margin-top: 10px;
+  text-align: center;
+}
+.hz-btn {
+  margin-top: clamp(16px, 4vw, 34px);
+  padding: clamp(13px, 3vw, 20px) clamp(28px, 7vw, 60px);
+  font-size: clamp(14px, 3.4vw, 21px);
+  font-weight: 900;
+  letter-spacing: 0.26em;
+  color: #04141c;
+  background: linear-gradient(180deg, #9dffe4, #37e0c0);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  box-shadow: 0 0 40px -6px rgba(60, 240, 200, 0.85);
+  transition: transform 100ms, box-shadow 140ms;
+}
+.hz-btn:hover { transform: translateY(-3px) scale(1.02); box-shadow: 0 0 60px -4px rgba(60, 240, 200, 1); }
+.hz-btn:active { transform: scale(0.97); }
+.hz-btn.hz-ghost {
+  background: none;
+  color: #9dc4e4;
+  border: 1px solid rgba(140, 200, 255, 0.3);
+  box-shadow: none;
+  letter-spacing: 0.2em;
+  padding: 10px 22px;
+  font-size: clamp(10px, 2.4vw, 13px);
+  margin-top: 14px;
+}
+
+.hz-stats {
+  display: flex;
+  gap: clamp(14px, 5vw, 46px);
+  margin-top: clamp(14px, 3vw, 28px);
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.hz-stat { text-align: center; }
+.hz-stat b {
+  display: block;
+  font-size: clamp(24px, 7vw, 46px);
+  font-weight: 900;
+  color: #fff;
+  text-shadow: 0 0 24px rgba(120, 220, 255, 0.6);
+  line-height: 1;
+}
+.hz-stat span {
+  font-size: clamp(8px, 2vw, 11px);
+  letter-spacing: 0.2em;
+  color: #7fa4c4;
+  font-weight: 800;
+}
+
+.hz-hint {
+  margin-top: 18px;
+  font-size: clamp(9px, 2.2vw, 13px);
+  color: #6d90ae;
+  letter-spacing: 0.14em;
+  text-align: center;
+  line-height: 1.8;
+  font-weight: 700;
+  max-width: 46ch;
+}
+.hz-hint b { color: #a9d8f4; }
+
+/* corner buttons */
+.hz-corner {
+  position: absolute;
+  top: calc(10px + env(safe-area-inset-top));
+  right: calc(10px + env(safe-area-inset-right));
+  display: flex;
+  gap: 6px;
+  pointer-events: auto;
+}
+.hz-icon {
+  width: 40px; height: 40px;
+  display: grid; place-items: center;
+  background: rgba(10, 20, 40, 0.55);
+  border: 1px solid rgba(140, 200, 255, 0.22);
+  border-radius: 4px;
+  color: #b6d8f2;
+  cursor: pointer;
+  font-size: 15px;
+  font-weight: 900;
+  font-family: inherit;
+  letter-spacing: 0;
+}
+.hz-icon:hover { background: rgba(30, 60, 110, 0.7); color: #fff; }
+.hz-icon[aria-pressed="false"] { opacity: 0.42; }
+
+.hz-fps {
+  position: absolute;
+  left: calc(10px + env(safe-area-inset-left));
+  top: calc(12px + env(safe-area-inset-top));
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  color: #4f7ea0;
+  font-weight: 800;
+  pointer-events: none;
+  white-space: pre;
+  line-height: 1.5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hz-card, .hz-banner, .hz-sub, .hz-modal { animation: none !important; }
+  .hz-card:hover { transform: none; }
+  .hz-btn:hover { transform: none; }
+}

--- a/dynawalla/games/horde/src/ui/overlay.ts
+++ b/dynawalla/games/horde/src/ui/overlay.ts
@@ -1,0 +1,358 @@
+/**
+ * Everything that is text lives in the DOM: crisp at any density, selectable
+ * by a screen reader, and free. The canvas keeps the swarm.
+ */
+import type { Card } from "../game/loadout.ts"
+import type { Question } from "../contract.ts"
+
+const h = <K extends keyof HTMLElementTagNameMap>(
+  tag: K, cls?: string, text?: string,
+): HTMLElementTagNameMap[K] => {
+  const e = document.createElement(tag)
+  if (cls) e.className = cls
+  if (text !== undefined) e.textContent = text
+  return e
+}
+
+const rgb = (c: [number, number, number]) =>
+  `rgb(${Math.round(Math.min(1, c[0]) * 255)},${Math.round(Math.min(1, c[1]) * 255)},${Math.round(Math.min(1, c[2]) * 255)})`
+
+export type SealedResult = { correct: boolean; ms: number; answered: string }
+
+export class Overlay {
+  readonly root: HTMLElement
+  private xpFill: HTMLElement
+  private clock: HTMLElement
+  private lvl: HTMLElement
+  private kills: HTMLElement
+  private lifeFill: HTMLElement
+  private lifeText: HTMLElement
+  private weps: HTMLElement
+  private banner: HTMLElement
+  private subBanner: HTMLElement
+  private fps: HTMLElement
+
+  private cardModal: HTMLElement
+  private cardRow: HTMLElement
+  private cardTitle: HTMLElement
+
+  private riftModal: HTMLElement
+  private riftCharges: HTMLElement
+  private riftPrompt: HTMLElement
+  private riftAnswers: HTMLElement
+  private riftClock: HTMLElement
+  private riftNote: HTMLElement
+
+  private overModal: HTMLElement
+  private overStats: HTMLElement
+  private overTitle: HTMLElement
+
+  private titleModal: HTMLElement
+
+  private soundBtn: HTMLButtonElement
+  private pauseBtn: HTMLButtonElement
+
+  onPickCard: (i: number) => void = () => {}
+  onSealed: (r: SealedResult) => void = () => {}
+  onRiftAnswer: (r: SealedResult) => void = () => {}
+  onStart: () => void = () => {}
+  onRestart: () => void = () => {}
+  onToggleSound: () => void = () => {}
+  onTogglePause: () => void = () => {}
+
+  constructor(root: HTMLElement) {
+    this.root = root
+
+    const hud = h("div", "hz-hud")
+    const xp = h("div", "hz-xpbar")
+    this.xpFill = h("i", "hz-xpfill")
+    xp.appendChild(this.xpFill)
+
+    const top = h("div", "hz-top")
+    this.lvl = h("div", "hz-chip hz-lvl")
+    this.lvl.innerHTML = "LV <b>1</b>"
+    this.clock = h("div", "hz-clock", "0:00")
+    this.kills = h("div", "hz-chip")
+    this.kills.innerHTML = "<b>0</b> SLAIN"
+    top.append(this.lvl, this.clock, this.kills)
+
+    const life = h("div", "hz-life")
+    this.lifeFill = h("i", "hz-lifefill")
+    this.lifeText = h("div", "hz-lifetext", "100 / 100")
+    life.append(this.lifeFill, this.lifeText)
+
+    this.weps = h("div", "hz-weps")
+    this.banner = h("div", "hz-banner")
+    this.subBanner = h("div", "hz-sub")
+    this.fps = h("div", "hz-fps")
+
+    const corner = h("div", "hz-corner")
+    this.soundBtn = h("button", "hz-icon")
+    this.soundBtn.type = "button"
+    this.soundBtn.textContent = "♪"
+    this.soundBtn.setAttribute("aria-label", "Sound")
+    this.soundBtn.setAttribute("aria-pressed", "true")
+    this.soundBtn.onclick = (e) => { e.stopPropagation(); this.onToggleSound() }
+    this.pauseBtn = h("button", "hz-icon")
+    this.pauseBtn.type = "button"
+    this.pauseBtn.textContent = "II"
+    this.pauseBtn.setAttribute("aria-label", "Pause")
+    this.pauseBtn.onclick = (e) => { e.stopPropagation(); this.onTogglePause() }
+    corner.append(this.soundBtn, this.pauseBtn)
+
+    hud.append(xp, top, life, this.weps, this.banner, this.subBanner, this.fps, corner)
+
+    /* ---- level-up ---- */
+    this.cardModal = h("div", "hz-modal")
+    this.cardTitle = h("div", "hz-title", "CHOOSE")
+    this.cardRow = h("div", "hz-cards")
+    this.cardModal.append(this.cardTitle, this.cardRow)
+
+    /* ---- rift ---- */
+    this.riftModal = h("div", "hz-modal hz-rift")
+    const riftBox = h("div", "hz-riftbox")
+    const riftTitle = h("div", "hz-title", "THE RIFT")
+    this.riftCharges = h("div", "hz-charges")
+    this.riftPrompt = h("div", "hz-prompt", "")
+    this.riftAnswers = h("div", "hz-answers")
+    this.riftClock = h("div", "hz-riftclock")
+    this.riftClock.appendChild(h("i"))
+    this.riftNote = h("div", "hz-riftnote", "CHARGE THE RIFT TO COME BACK")
+    riftBox.append(riftTitle, this.riftCharges, this.riftPrompt, this.riftAnswers, this.riftClock, this.riftNote)
+    this.riftModal.appendChild(riftBox)
+
+    /* ---- over ---- */
+    this.overModal = h("div", "hz-modal")
+    this.overTitle = h("div", "hz-big", "THE DARK TOOK YOU")
+    this.overStats = h("div", "hz-stats")
+    const again = h("button", "hz-btn", "DIVE AGAIN")
+    again.type = "button"
+    again.onclick = () => this.onRestart()
+    this.overModal.append(this.overTitle, this.overStats, again)
+
+    /* ---- title ---- */
+    this.titleModal = h("div", "hz-modal hz-open")
+    const big = h("div", "hz-big", "DEEPSWARM")
+    const tag = h("div", "hz-tagline", "THE LIGHT IS YOURS. THE DARK IS EVERYTHING ELSE.")
+    const go = h("button", "hz-btn", "DIVE")
+    go.type = "button"
+    go.onclick = () => this.onStart()
+    const hint = h("div", "hz-hint")
+    hint.innerHTML =
+      "<b>DRAG</b> anywhere to swim &nbsp;·&nbsp; <b>WASD</b> or <b>ARROWS</b> on a keyboard<br>" +
+      "Your weapons fire themselves. All you do is move.<br>" +
+      "Swim into a golden <b>CORE</b> — time slows, and the number you touch decides what happens next."
+    this.titleModal.append(big, tag, go, hint)
+
+    root.append(hud, this.cardModal, this.riftModal, this.overModal, this.titleModal)
+  }
+
+  /* ------------------------------------------------------------------ hud */
+
+  setClock(seconds: number): void {
+    const m = Math.floor(seconds / 60)
+    const s = Math.floor(seconds % 60)
+    this.clock.textContent = `${m}:${s < 10 ? "0" : ""}${s}`
+  }
+
+  setXp(frac: number): void {
+    this.xpFill.style.width = `${Math.max(0, Math.min(1, frac)) * 100}%`
+  }
+
+  setLevel(n: number): void {
+    this.lvl.innerHTML = `LV <b>${n}</b>`
+  }
+
+  setKills(n: number): void {
+    this.kills.innerHTML = `<b>${n}</b> SLAIN`
+  }
+
+  setLife(hp: number, max: number): void {
+    const f = Math.max(0, Math.min(1, hp / max))
+    this.lifeFill.style.width = `${f * 100}%`
+    this.lifeText.textContent = `${Math.max(0, Math.ceil(hp))} / ${max}`
+  }
+
+  setWeapons(rows: string[]): void {
+    // Rebuilt only when the build changes, not per frame.
+    this.weps.textContent = ""
+    for (const r of rows) {
+      const d = h("div", "hz-wep")
+      d.innerHTML = r
+      this.weps.appendChild(d)
+    }
+  }
+
+  setFps(text: string): void {
+    this.fps.textContent = text
+  }
+
+  say(text: string, sub: string, colour: string): void {
+    this.banner.textContent = text
+    this.banner.style.color = colour
+    this.banner.classList.remove("hz-on")
+    void this.banner.offsetWidth
+    this.banner.classList.add("hz-on")
+    this.subBanner.textContent = sub
+    this.subBanner.classList.remove("hz-on")
+    void this.subBanner.offsetWidth
+    if (sub) this.subBanner.classList.add("hz-on")
+  }
+
+  setSound(on: boolean): void {
+    this.soundBtn.setAttribute("aria-pressed", String(on))
+    this.soundBtn.textContent = on ? "♪" : "✕"
+  }
+
+  setPaused(on: boolean): void {
+    this.pauseBtn.textContent = on ? "▶" : "II"
+  }
+
+  /* --------------------------------------------------------------- cards */
+
+  showCards(cards: Card[], sealed: Question | null, level: number): void {
+    this.cardTitle.textContent = `LEVEL ${level}`
+    this.cardRow.textContent = ""
+
+    cards.forEach((c, i) => {
+      const el = h("button", `hz-card hz-card-r${c.rarity}`)
+      el.type = "button"
+      el.style.setProperty("--hue", rgb(c.hue))
+      el.appendChild(h("div", "hz-card-rarity", c.rarity === 2 ? "RARE" : "GOOD"))
+      el.appendChild(h("div", "hz-card-title", c.title))
+      el.appendChild(h("div", "hz-card-tag", c.tag))
+      const head = h("div", "hz-card-head")
+      head.innerHTML = `<b>${c.head}</b><span>${c.sub}</span>`
+      el.appendChild(head)
+      const math = h("div", "hz-card-math")
+      math.innerHTML = `<span class="hz-was">${c.before}</span> → <span class="hz-now">${c.after}</span>`
+      el.appendChild(math)
+      el.onclick = () => this.onPickCard(i)
+      this.cardRow.appendChild(el)
+    })
+
+    if (sealed) this.cardRow.appendChild(this.buildSealed(sealed))
+    this.cardModal.classList.add("hz-open")
+    const first = this.cardRow.querySelector("button")
+    if (first) (first as HTMLElement).focus({ preventScroll: true })
+  }
+
+  private buildSealed(q: Question): HTMLElement {
+    const el = h("div", "hz-card hz-sealed hz-card-r2")
+    el.appendChild(h("div", "hz-card-rarity", "SEALED"))
+    el.appendChild(h("div", "hz-card-title", "SEALED CACHE"))
+    el.appendChild(h("div", "hz-seal-prompt", q.prompt))
+    const orbs = h("div", "hz-seal-orbs")
+    const options = shuffleWithAnswer(q)
+    const t0 = performance.now()
+    let done = false
+    for (const opt of options) {
+      const b = h("button", "hz-orb", opt)
+      b.type = "button"
+      b.onclick = () => {
+        if (done) return
+        done = true
+        const correct = opt === q.answer
+        b.classList.add(correct ? "hz-ok" : "hz-no")
+        if (!correct) {
+          // Show where the light actually was. No red X, no lecture.
+          for (const o of Array.from(orbs.children) as HTMLElement[]) {
+            if (o.textContent === q.answer) o.classList.add("hz-ok")
+          }
+        }
+        this.onSealed({ correct, ms: performance.now() - t0, answered: opt })
+      }
+      orbs.appendChild(b)
+    }
+    el.appendChild(orbs)
+    el.appendChild(h("div", "hz-seal-note", "OPEN IT, OR IGNORE IT"))
+    return el
+  }
+
+  hideCards(): void {
+    this.cardModal.classList.remove("hz-open")
+  }
+
+  /* ---------------------------------------------------------------- rift */
+
+  showRift(q: Question, charges: number, needed: number): void {
+    this.riftCharges.textContent = ""
+    for (let i = 0; i < needed; i++) {
+      const c = h("div", `hz-charge${i < charges ? " hz-lit" : ""}`)
+      this.riftCharges.appendChild(c)
+    }
+    this.riftPrompt.textContent = q.prompt
+    this.riftAnswers.textContent = ""
+    const options = shuffleWithAnswer(q)
+    const t0 = performance.now()
+    let done = false
+    for (const opt of options) {
+      const b = h("button", "hz-answer", opt)
+      b.type = "button"
+      b.onclick = () => {
+        if (done) return
+        done = true
+        const correct = opt === q.answer
+        b.classList.add(correct ? "hz-ok" : "hz-no")
+        if (!correct) {
+          for (const o of Array.from(this.riftAnswers.children) as HTMLElement[]) {
+            if (o.textContent === q.answer) o.classList.add("hz-ok")
+          }
+        }
+        this.onRiftAnswer({ correct, ms: performance.now() - t0, answered: opt })
+      }
+      this.riftAnswers.appendChild(b)
+    }
+    this.riftNote.textContent =
+      needed === 1 ? "ONE ANSWER AND YOU ARE BACK" : `${needed} ANSWERS AND YOU ARE BACK`
+    this.riftModal.classList.add("hz-open")
+    const first = this.riftAnswers.querySelector("button")
+    if (first) (first as HTMLElement).focus({ preventScroll: true })
+  }
+
+  setRiftClock(frac: number): void {
+    const i = this.riftClock.firstElementChild as HTMLElement
+    i.style.width = `${Math.max(0, Math.min(1, frac)) * 100}%`
+  }
+
+  hideRift(): void {
+    this.riftModal.classList.remove("hz-open")
+  }
+
+  /* ---------------------------------------------------------------- over */
+
+  showOver(stats: { label: string; value: string }[], title: string): void {
+    this.overTitle.textContent = title
+    this.overStats.textContent = ""
+    for (const s of stats) {
+      const d = h("div", "hz-stat")
+      d.innerHTML = `<b>${s.value}</b><span>${s.label}</span>`
+      this.overStats.appendChild(d)
+    }
+    this.overModal.classList.add("hz-open")
+  }
+
+  hideOver(): void {
+    this.overModal.classList.remove("hz-open")
+  }
+
+  hideTitle(): void {
+    this.titleModal.classList.remove("hz-open")
+  }
+
+  destroy(): void {
+    this.root.textContent = ""
+  }
+}
+
+/** Deterministic-enough shuffle of answer + distractors. */
+function shuffleWithAnswer(q: Question): string[] {
+  const opts = [q.answer, ...q.distractors.slice(0, 3)]
+  for (let i = opts.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    const t = opts[i]
+    opts[i] = opts[j]
+    opts[j] = t
+  }
+  return opts
+}

--- a/dynawalla/games/horde/tsconfig.json
+++ b/dynawalla/games/horde/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": false,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/dynawalla/games/horde/vite.config.ts
+++ b/dynawalla/games/horde/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite"
+
+export default defineConfig({
+  server: { port: 5179, strictPort: true },
+  build: {
+    target: "es2022",
+    // The game is one self-contained bundle; the pack host loads it as a module.
+    lib: { entry: "src/index.ts", formats: ["es"], fileName: "horde" },
+    rollupOptions: { output: { inlineDynamicImports: true } },
+  },
+})


### PR DESCRIPTION
## What

Commit `dynawalla/games/horde` — COUNTERPOISE, a brass horde where the scale physically is the equals sign.

## Why

This prototype existed **only as untracked files in a worktree**. It appeared in
zero git refs: `git log --all -- dynawalla/games/horde` returned no commits. It was
never committed, never branched, never pushed. Pruning that worktree — which the
repo's own session hook recommends doing after a merge — would have destroyed it
with no reflog and no dangling object to recover from.

Ten sibling prototypes were in the same state. This PR is one of that set.

### Fixes carried in this PR

- **Both `this.shot(...)` call sites passed 9 arguments to a 10-parameter
  method**, so `tsc --noEmit` failed. The omitted parameter is `life`: the swarm
  case assigned `B.life[i] = 4.5` on the very next line, and the `spore` case
  spawns manually with `life = 1.5`. Life is now passed explicitly (splinter
  `1.5`, swarm `4.5`) and the redundant override is gone.
- **`stubHost.ts` imported `Question` and never used it**, tripping
  `noUnusedLocals`. Now annotates `next(): Question`, which is what the import
  was for.
- **The game had no tests at all**, alone among the games here. Added
  `stubHost.test.ts`: well-formedness, arithmetic truth of every prompt,
  reachability of all five families across the ramp, domain pinning,
  determinism, and the report hook.

## Blast radius

**Areas touched:** dynawalla (new directory only)

- [x] Additive only. Every path is new under `dynawalla/games/horde/`; no existing
      file is modified or deleted. Nothing imports it yet.
- [ ] **Every touched path is covered by a `ci.yml` area filter** — **NO, and
      stated deliberately.** `dynawalla/games/` is absent from the `covered`
      regex (`ci.yml:226`), so the `uncovered` step will warn. This is
      pre-existing: the five games already on `main` have no CI either. No job
      builds, type-checks or tests any game. The gates below were therefore run
      locally, by hand. A games-area filter is the correct follow-up and is
      called out rather than silently bundled here.
- [x] **Pack back-compat.** No published pack zip, `voiceId` or catalog entry
      touched. App floor 0.20.6 unaffected.
- [x] **Native integrity.** No Rust, no `src-tauri`, no `links =`, no `[patch]`.
- [x] **Strings.** No `corpan-app` locale keys added; this pack does not use the
      Corpán i18n catalog.
- [x] **Curriculum.** No skill id renamed or reused, no grade metadata changed,
      no generator binding altered.
- [x] **Secrets.** No `.p8`, keystore, service-account JSON, issuer id, key id or
      token. Verified the diff is source, config and `index.html` only.

`package-lock.json` and `qa/shots` are gitignored, matching
`dynawalla/games/slice` and `.../siege`.

## Proof

Run in `dynawalla/games/horde/` after `npm install`:

```
$ npm test
# tests 7 # pass 7 # fail 0 

$ npm run tsc          # tsc --noEmit
0 errors

$ npm run build
✓ built in 45ms
```

Scope check — the branch adds this game and nothing else:

```
$ git diff --name-only origin/main...HEAD | grep -cv '^dynawalla/games/horde/'
0
$ git diff --diff-filter=D --name-only origin/main...HEAD | wc -l
0
```
