### PR TITLE
dynawalla/games/polarity: POLARITY — signed-integer orbs where the sign is the mechanic

### DIFF
--- a/dynawalla/games/polarity/.gitignore
+++ b/dynawalla/games/polarity/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+dist-pack/
+
+# Playtest capture output: multi-MB PNGs, regenerated on demand.
+qa/shots
+qa/tmp
+
+# Not tracked, matching dynawalla/games/slice and .../merge. These prototypes
+# pin nothing beyond vite + typescript in devDependencies.
+package-lock.json

--- a/dynawalla/games/polarity/index.html
+++ b/dynawalla/games/polarity/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no"
+    />
+    <meta name="theme-color" content="#03040b" />
+    <title>POLARITY</title>
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' fill='%2303040b'/%3E%3Cpath d='M16 4 L26 16 L16 28 L6 16 Z' fill='none' stroke='%23ffcd52' stroke-width='3'/%3E%3Ccircle cx='16' cy='16' r='5' fill='none' stroke='%2338dcff' stroke-width='3'/%3E%3C/svg%3E"
+    />
+    <style>
+      html, body { margin: 0; padding: 0; height: 100%; background: #03040b; overscroll-behavior: none; -webkit-tap-highlight-color: transparent; }
+      #app { position: fixed; inset: 0; }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/polarity/package.json
+++ b/dynawalla/games/polarity/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@dynawalla/game-polarity",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "POLARITY — a neon vector shmup where your ship's sign IS the arithmetic: match a bullet's polarity to absorb it into a running signed sum, flip to phase through the wrong answers.",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4211 --strictPort",
+    "tsc": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test 'src/**/*.test.ts'"
+  },
+  "dependencies": {
+    "three": "^0.181.0"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.1",
+    "@types/three": "^0.181.0",
+    "typescript": "~6.0.3",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/games/polarity/src/audio/audio.ts
+++ b/dynawalla/games/polarity/src/audio/audio.ts
@@ -1,0 +1,397 @@
+/**
+ * Every sound in POLARITY is synthesised at runtime — no assets ship.
+ *
+ * Each hit has the three parts a sound needs to feel physical: a TRANSIENT
+ * (click/noise), a BODY (pitched) and a TAIL (filtered decay). Pitch varies per
+ * event, and absorbs climb a pentatonic ladder with the chain, so a long chain
+ * is audibly a melody going somewhere and forty absorbs in a row never fatigue.
+ *
+ * Sound never carries information alone: everything audible is also visible.
+ */
+
+type Voice = { stop: (t: number) => void };
+
+const PENT = [0, 2, 4, 7, 9, 12, 14, 16, 19, 21, 24, 26, 28, 31];
+
+export class Audio {
+  private ctx: AudioContext | null = null;
+  private master: GainNode | null = null;
+  private bus: DynamicsCompressorNode | null = null;
+  private musicGain: GainNode | null = null;
+  private voices = 0;
+  private lastAt: Record<string, number> = {};
+  enabled = true;
+  musicOn = true;
+  private step = 0;
+  private nextNote = 0;
+  private timer: number | null = null;
+  private intensity = 0;
+
+  /** Must be called from a user gesture on iOS. Safe to call repeatedly. */
+  resume(): void {
+    if (!this.ctx) {
+      const C = (window.AudioContext ??
+        (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext) as
+        | typeof AudioContext
+        | undefined;
+      if (!C) return;
+      try {
+        this.ctx = new C();
+      } catch (e) {
+        console.warn("[polarity] no audio context", e);
+        return;
+      }
+      this.bus = this.ctx.createDynamicsCompressor();
+      this.bus.threshold.value = -14;
+      this.bus.knee.value = 24;
+      this.bus.ratio.value = 8;
+      this.bus.attack.value = 0.003;
+      this.bus.release.value = 0.18;
+      this.master = this.ctx.createGain();
+      this.master.gain.value = 0.72;
+      this.musicGain = this.ctx.createGain();
+      this.musicGain.gain.value = 0.0;
+      this.bus.connect(this.master);
+      this.master.connect(this.ctx.destination);
+      this.musicGain.connect(this.bus);
+      this.startClock();
+    }
+    if (this.ctx.state === "suspended") void this.ctx.resume();
+  }
+
+  setEnabled(on: boolean): void {
+    this.enabled = on;
+    if (this.master) this.master.gain.value = on ? 0.72 : 0;
+  }
+
+  setMusic(on: boolean): void {
+    this.musicOn = on;
+    if (this.musicGain && this.ctx)
+      this.musicGain.gain.setTargetAtTime(on ? 1 : 0, this.ctx.currentTime, 0.15);
+  }
+
+  setIntensity(v: number): void {
+    this.intensity = Math.max(0, Math.min(1, v));
+  }
+
+  dispose(): void {
+    if (this.timer !== null) clearInterval(this.timer);
+    this.timer = null;
+    void this.ctx?.close();
+    this.ctx = null;
+  }
+
+  // -------------------------------------------------------------------------
+  // primitives
+  // -------------------------------------------------------------------------
+
+  private gate(key: string, ms: number): boolean {
+    const now = performance.now();
+    const last = this.lastAt[key] ?? -1e9;
+    if (now - last < ms) return false;
+    this.lastAt[key] = now;
+    return true;
+  }
+
+  private env(
+    dur: number,
+    peak: number,
+    attack = 0.004,
+    curve: "exp" | "lin" = "exp",
+  ): GainNode | null {
+    const ctx = this.ctx;
+    if (!ctx || !this.enabled || this.voices > 26) return null;
+    const g = ctx.createGain();
+    const t = ctx.currentTime;
+    g.gain.setValueAtTime(0.0001, t);
+    g.gain.linearRampToValueAtTime(peak, t + attack);
+    if (curve === "exp") g.gain.exponentialRampToValueAtTime(0.0001, t + dur);
+    else g.gain.linearRampToValueAtTime(0.0001, t + dur);
+    this.voices++;
+    const done = (): void => {
+      this.voices--;
+    };
+    setTimeout(done, (dur + 0.1) * 1000);
+    return g;
+  }
+
+  private tone(
+    freq: number,
+    dur: number,
+    type: OscillatorType,
+    peak: number,
+    opts?: { bend?: number; lp?: number; attack?: number; dest?: AudioNode },
+  ): Voice | null {
+    const ctx = this.ctx;
+    if (!ctx) return null;
+    const g = this.env(dur, peak, opts?.attack);
+    if (!g) return null;
+    const o = ctx.createOscillator();
+    o.type = type;
+    const t = ctx.currentTime;
+    o.frequency.setValueAtTime(freq, t);
+    if (opts?.bend) o.frequency.exponentialRampToValueAtTime(Math.max(20, opts.bend), t + dur);
+    let node: AudioNode = o;
+    if (opts?.lp) {
+      const f = ctx.createBiquadFilter();
+      f.type = "lowpass";
+      f.frequency.setValueAtTime(opts.lp, t);
+      f.Q.value = 0.9;
+      o.connect(f);
+      node = f;
+    }
+    node.connect(g);
+    g.connect(opts?.dest ?? (this.bus as AudioNode));
+    o.start(t);
+    o.stop(t + dur + 0.02);
+    return { stop: (s) => o.stop(s) };
+  }
+
+  private noise(
+    dur: number,
+    peak: number,
+    opts?: { hp?: number; lp?: number; bend?: number; q?: number },
+  ): void {
+    const ctx = this.ctx;
+    if (!ctx) return;
+    const g = this.env(dur, peak, 0.002);
+    if (!g) return;
+    const n = Math.max(1, Math.floor(ctx.sampleRate * dur));
+    const buf = ctx.createBuffer(1, n, ctx.sampleRate);
+    const d = buf.getChannelData(0);
+    let s = 0;
+    for (let i = 0; i < n; i++) {
+      s = s * 0.55 + (Math.random() * 2 - 1) * 0.45;
+      d[i] = s;
+    }
+    const src = ctx.createBufferSource();
+    src.buffer = buf;
+    const t = ctx.currentTime;
+    let node: AudioNode = src;
+    if (opts?.hp) {
+      const f = ctx.createBiquadFilter();
+      f.type = "highpass";
+      f.frequency.value = opts.hp;
+      node.connect(f);
+      node = f;
+    }
+    if (opts?.lp) {
+      const f = ctx.createBiquadFilter();
+      f.type = "lowpass";
+      f.frequency.setValueAtTime(opts.lp, t);
+      if (opts.bend) f.frequency.exponentialRampToValueAtTime(Math.max(60, opts.bend), t + dur);
+      f.Q.value = opts.q ?? 1;
+      node.connect(f);
+      node = f;
+    }
+    node.connect(g);
+    g.connect(this.bus as AudioNode);
+    src.start(t);
+  }
+
+  private hz(semi: number, base = 196): number {
+    return base * Math.pow(2, semi / 12);
+  }
+
+  // -------------------------------------------------------------------------
+  // the palette
+  // -------------------------------------------------------------------------
+
+  absorb(chain: number, pol: number, big: boolean): void {
+    if (!this.gate("absorb", 22)) return;
+    const semi = PENT[Math.min(PENT.length - 1, chain % PENT.length)] ?? 0;
+    const oct = Math.min(2, Math.floor(chain / PENT.length));
+    const f = this.hz(semi + oct * 12, pol > 0 ? 262 : 196);
+    this.tone(f, big ? 0.24 : 0.13, pol > 0 ? "triangle" : "sine", big ? 0.3 : 0.16, {
+      lp: pol > 0 ? 5200 : 2600,
+      bend: f * 1.32,
+      attack: 0.002,
+    });
+    if (big) {
+      this.tone(f * 0.5, 0.34, "sine", 0.2, { bend: f * 0.52 });
+      this.noise(0.07, 0.1, { hp: 1800, lp: 8000 });
+    }
+  }
+
+  flip(pol: number): void {
+    if (!this.gate("flip", 30)) return;
+    this.noise(0.09, 0.16, { hp: 400, lp: pol > 0 ? 6500 : 2200, bend: pol > 0 ? 1400 : 5200 });
+    this.tone(pol > 0 ? 420 : 300, 0.1, "square", 0.09, { bend: pol > 0 ? 640 : 190, lp: 3200 });
+  }
+
+  clutch(): void {
+    const base = 523.25;
+    for (const [i, m] of [1, 1.5, 2, 3].entries()) {
+      const g = this.tone(base * m, 0.9 - i * 0.1, "sine", 0.16 - i * 0.02, { attack: 0.006 });
+      void g;
+    }
+    this.noise(0.5, 0.1, { hp: 3000, lp: 12000, bend: 3000 });
+  }
+
+  shoot(pol: number): void {
+    if (!this.gate("shoot", 55)) return;
+    this.tone(pol > 0 ? 900 : 700, 0.045, "square", 0.035, { bend: pol > 0 ? 1500 : 400, lp: 5000 });
+  }
+
+  hitEnemy(weak: boolean): void {
+    if (!this.gate("hitE", 26)) return;
+    this.noise(weak ? 0.09 : 0.05, weak ? 0.16 : 0.09, { hp: 900, lp: weak ? 9000 : 5000, bend: 1200 });
+    if (weak) this.tone(180, 0.09, "triangle", 0.08, { bend: 90 });
+  }
+
+  kill(big: boolean): void {
+    this.noise(big ? 0.6 : 0.24, big ? 0.42 : 0.24, { lp: big ? 4200 : 3000, bend: 120, q: 2 });
+    this.tone(big ? 110 : 190, big ? 0.6 : 0.26, "sine", big ? 0.34 : 0.16, { bend: big ? 38 : 60 });
+    if (big) this.tone(58, 0.9, "sine", 0.3, { bend: 26 });
+  }
+
+  release(perfect: boolean): void {
+    this.tone(perfect ? 180 : 150, 0.5, "sawtooth", 0.24, { bend: perfect ? 1500 : 700, lp: 4200 });
+    this.noise(0.42, 0.26, { hp: 200, lp: 11000, bend: 500 });
+    this.tone(62, 0.5, "sine", 0.32, { bend: 34 });
+    if (perfect) {
+      for (const [i, m] of [1, 1.5, 2, 2.5, 3].entries())
+        this.tone(392 * m, 0.7 - i * 0.06, "triangle", 0.11, { attack: 0.005 });
+    }
+  }
+
+  overload(): void {
+    this.tone(220, 0.34, "sawtooth", 0.22, { bend: 1400, lp: 2600 });
+    this.noise(0.5, 0.34, { lp: 6000, bend: 200, q: 3 });
+    this.tone(70, 0.6, "square", 0.2, { bend: 30, lp: 700 });
+  }
+
+  hurt(): void {
+    this.noise(0.4, 0.4, { lp: 2400, bend: 120, q: 2.4 });
+    this.tone(150, 0.3, "sawtooth", 0.24, { bend: 48, lp: 1600 });
+    this.tone(93, 0.5, "sine", 0.24, { bend: 40 });
+  }
+
+  sealWon(): void {
+    const root = 261.63;
+    const chord = [1, 1.26, 1.5, 2, 2.52, 3];
+    for (const [i, m] of chord.entries()) {
+      const o = this.ctx;
+      if (!o) return;
+      setTimeout(() => {
+        this.tone(root * m, 0.85 - i * 0.06, "triangle", 0.15, { attack: 0.006 });
+      }, i * 42);
+    }
+    this.noise(0.7, 0.2, { hp: 2200, lp: 14000, bend: 2500 });
+    this.tone(65, 0.8, "sine", 0.3, { bend: 33 });
+  }
+
+  /** Never a game-show buzzer. A heavy, dull detonation and a falling minor 3rd. */
+  sealWrong(): void {
+    this.noise(0.55, 0.4, { lp: 1500, bend: 90, q: 3 });
+    this.tone(196, 0.36, "triangle", 0.2, { bend: 165, lp: 1400 });
+    this.tone(98, 0.7, "sine", 0.26, { bend: 62 });
+  }
+
+  bossIn(): void {
+    this.tone(48, 1.5, "sawtooth", 0.3, { bend: 96, lp: 900 });
+    this.noise(1.4, 0.2, { lp: 900, bend: 3000, q: 2 });
+  }
+
+  stratum(): void {
+    for (const [i, m] of [1, 1.5, 2].entries())
+      setTimeout(() => this.tone(330 * m, 0.5, "triangle", 0.12), i * 70);
+  }
+
+  ui(kind: "tap" | "big"): void {
+    if (kind === "tap") this.tone(660, 0.07, "triangle", 0.09, { bend: 880 });
+    else {
+      this.tone(330, 0.3, "triangle", 0.14, { bend: 660 });
+      this.noise(0.2, 0.1, { hp: 2000, lp: 9000 });
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // music bed — a two-bar pulse that tightens as the run escalates
+  // -------------------------------------------------------------------------
+
+  private startClock(): void {
+    this.timer = setInterval(() => this.schedule(), 60) as unknown as number;
+  }
+
+  private schedule(): void {
+    const ctx = this.ctx;
+    const dest = this.musicGain;
+    if (!ctx || !dest || !this.enabled || !this.musicOn) return;
+    const bpm = 104 + this.intensity * 48;
+    const spb = 60 / bpm / 2; // eighth notes
+    if (this.nextNote < ctx.currentTime) this.nextNote = ctx.currentTime + 0.06;
+    while (this.nextNote < ctx.currentTime + 0.25) {
+      this.note(this.nextNote, this.step, dest);
+      this.step = (this.step + 1) % 32;
+      this.nextNote += spb;
+    }
+  }
+
+  private note(t: number, step: number, dest: GainNode): void {
+    const ctx = this.ctx;
+    if (!ctx) return;
+    const g = (peak: number, dur: number, atk = 0.003): GainNode => {
+      const n = ctx.createGain();
+      n.gain.setValueAtTime(0.0001, t);
+      n.gain.linearRampToValueAtTime(peak, t + atk);
+      n.gain.exponentialRampToValueAtTime(0.0001, t + dur);
+      n.connect(dest);
+      return n;
+    };
+    const osc = (f: number, type: OscillatorType, dur: number, node: GainNode, lp?: number): void => {
+      const o = ctx.createOscillator();
+      o.type = type;
+      o.frequency.setValueAtTime(f, t);
+      if (lp) {
+        const fl = ctx.createBiquadFilter();
+        fl.type = "lowpass";
+        fl.frequency.setValueAtTime(lp, t);
+        o.connect(fl);
+        fl.connect(node);
+      } else o.connect(node);
+      o.start(t);
+      o.stop(t + dur + 0.02);
+    };
+
+    // kick on 0 and 12 of every 16
+    if (step % 16 === 0 || step % 16 === 10) {
+      const n = g(0.34, 0.24);
+      const o = ctx.createOscillator();
+      o.type = "sine";
+      o.frequency.setValueAtTime(150, t);
+      o.frequency.exponentialRampToValueAtTime(42, t + 0.16);
+      o.connect(n);
+      o.start(t);
+      o.stop(t + 0.26);
+    }
+    // driving bass
+    const BASS = [0, 0, 3, 0, 5, 0, 3, -2];
+    if (step % 2 === 0) {
+      const s = BASS[(step / 2) % 8] ?? 0;
+      osc(this.hz(s, 65.4), "sawtooth", 0.16, g(0.15, 0.18), 340 + this.intensity * 900);
+    }
+    // arp, only once the run has heat
+    if (this.intensity > 0.12 && step % 2 === 1) {
+      const ARP = [12, 19, 24, 19, 15, 22, 27, 22];
+      const s = ARP[((step - 1) / 2) % 8] ?? 12;
+      osc(this.hz(s, 65.4), "square", 0.07, g(0.05 + this.intensity * 0.04, 0.09), 3200);
+    }
+    // hat
+    if (step % 4 === 2 && this.intensity > 0.28) {
+      const n = g(0.05, 0.05);
+      const len = Math.floor(ctx.sampleRate * 0.05);
+      const buf = ctx.createBuffer(1, len, ctx.sampleRate);
+      const d = buf.getChannelData(0);
+      for (let i = 0; i < len; i++) d[i] = (Math.random() * 2 - 1) * (1 - i / len);
+      const src = ctx.createBufferSource();
+      src.buffer = buf;
+      const f = ctx.createBiquadFilter();
+      f.type = "highpass";
+      f.frequency.value = 7000;
+      src.connect(f);
+      f.connect(n);
+      src.start(t);
+    }
+  }
+}

--- a/dynawalla/games/polarity/src/contract.ts
+++ b/dynawalla/games/polarity/src/contract.ts
@@ -1,0 +1,28 @@
+/**
+ * The game <-> runtime contract.
+ *
+ * A shared package will replace this file. Keep the shape EXACTLY as written so
+ * the swap is a one-line import change. `mount` here is the *declaration* only —
+ * the real implementation is exported from `./index.ts`, and a test asserts the
+ * two stay assignable.
+ */
+
+export type Question = {
+  id: string;
+  prompt: string; // "−9 + 4"
+  answer: string; // "−5"  — exact, canonical
+  distractors: string[]; // plausible wrong answers, ideally real mal-rule outputs
+  domain: string; // "int-add" | "int-sub" | ...
+  difficulty: number; // 0..1
+};
+
+export type Host = {
+  next(opts?: { domain?: string; difficulty?: number }): Question;
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void;
+  haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void;
+  prefersReducedMotion(): boolean;
+};
+
+export function mount(_el: HTMLElement, _host: Host): { unmount(): void } {
+  throw new Error("contract declaration only — the implementation is ./index.ts");
+}

--- a/dynawalla/games/polarity/src/core/labels.ts
+++ b/dynawalla/games/polarity/src/core/labels.ts
@@ -1,0 +1,26 @@
+/**
+ * Numeral atlas addressing. Every printed number in the playfield is one quad
+ * sampling one tile, so a screen full of labelled bullets costs a single draw
+ * call and no text layout at all.
+ *
+ * Legibility rule learned the hard way elsewhere in this program: a numeral a
+ * child has 0.45s to read gets a heavy geometric face, a solid backing plate
+ * and a real U+2212 minus — never an engraved serif.
+ */
+
+export const LABEL_MIN = -40;
+export const LABEL_MAX = 40;
+export const LABEL_COLS = 9;
+export const LABEL_ROWS = 9;
+export const LABEL_COUNT = LABEL_COLS * LABEL_ROWS; // 81 == the whole range
+
+/** Atlas tile for an integer, or -1 if it is outside the printable range. */
+export function labelTile(v: number): number {
+  if (!Number.isInteger(v) || v < LABEL_MIN || v > LABEL_MAX) return -1;
+  return v - LABEL_MIN;
+}
+
+/** Inverse of `labelTile`, for tests and debugging. */
+export function tileValue(tile: number): number {
+  return tile + LABEL_MIN;
+}

--- a/dynawalla/games/polarity/src/core/rng.ts
+++ b/dynawalla/games/polarity/src/core/rng.ts
@@ -1,0 +1,50 @@
+/** Deterministic, seedable PRNG. No Math.random anywhere in the game. */
+
+export type Rng = {
+  /** float in [0,1) */
+  f(): number;
+  /** integer in [lo,hi] inclusive */
+  i(lo: number, hi: number): number;
+  /** float in [lo,hi) */
+  r(lo: number, hi: number): number;
+  /** +1 or -1 */
+  sign(): number;
+  /** true with probability p */
+  chance(p: number): boolean;
+  /** uniform pick */
+  pick<T>(xs: readonly T[]): T;
+  /** in-place Fisher-Yates */
+  shuffle<T>(xs: T[]): T[];
+  fork(tag: number): Rng;
+};
+
+/** mulberry32 — small, fast, good enough, and identical on every platform. */
+export function makeRng(seed: number): Rng {
+  let s = seed >>> 0;
+  const f = (): number => {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+  const rng: Rng = {
+    f,
+    i: (lo, hi) => lo + Math.floor(f() * (hi - lo + 1)),
+    r: (lo, hi) => lo + f() * (hi - lo),
+    sign: () => (f() < 0.5 ? -1 : 1),
+    chance: (p) => f() < p,
+    pick: <T,>(xs: readonly T[]): T => xs[Math.floor(f() * xs.length)] as T,
+    shuffle: <T,>(xs: T[]): T[] => {
+      for (let i = xs.length - 1; i > 0; i--) {
+        const j = Math.floor(f() * (i + 1));
+        const a = xs[i] as T;
+        xs[i] = xs[j] as T;
+        xs[j] = a;
+      }
+      return xs;
+    },
+    fork: (tag) => makeRng((s ^ Math.imul(tag + 1, 0x9e3779b1)) >>> 0),
+  };
+  return rng;
+}

--- a/dynawalla/games/polarity/src/core/tier.ts
+++ b/dynawalla/games/polarity/src/core/tier.ts
@@ -1,0 +1,139 @@
+/**
+ * Quality tiers. The mid-range tablet sets the FLOOR, never the ceiling: LOW is
+ * a budget that always holds 60fps, ULTRA is allowed to be extravagant. The
+ * runtime also demotes live if frames are being missed, so a device we guessed
+ * wrong about recovers within a couple of seconds instead of stuttering for a
+ * whole session.
+ */
+
+export type TierName = "low" | "mid" | "ultra";
+
+export type Tier = {
+  name: TierName;
+  /** hard caps on the instanced pools */
+  bullets: number;
+  particles: number;
+  /** particles emitted per unit of event weight */
+  partScale: number;
+  /** real bloom post-pass */
+  bloom: boolean;
+  /** chromatic aberration + grain + scanline in the composite */
+  grade: boolean;
+  /** animated backdrop (drifting field lines, nebula) */
+  liveBackdrop: boolean;
+  /** device pixel ratio ceiling */
+  maxDpr: number;
+  /** persistent scorch/wake layer */
+  wake: boolean;
+  trails: boolean;
+};
+
+const TIERS: Record<TierName, Tier> = {
+  low: {
+    name: "low",
+    bullets: 720,
+    particles: 900,
+    partScale: 0.45,
+    bloom: false,
+    grade: false,
+    liveBackdrop: true,
+    maxDpr: 1.5,
+    wake: false,
+    trails: false,
+  },
+  mid: {
+    name: "mid",
+    bullets: 1100,
+    particles: 2200,
+    partScale: 0.8,
+    bloom: false,
+    grade: true,
+    liveBackdrop: true,
+    maxDpr: 2,
+    wake: true,
+    trails: true,
+  },
+  ultra: {
+    name: "ultra",
+    bullets: 1600,
+    particles: 4600,
+    partScale: 1.35,
+    bloom: true,
+    grade: true,
+    liveBackdrop: true,
+    maxDpr: 2.25,
+    wake: true,
+    trails: true,
+  },
+};
+
+export const tierByName = (n: TierName): Tier => TIERS[n];
+
+/** A cheap, conservative first guess. The live monitor does the real work. */
+export function detectTier(): Tier {
+  try {
+    const url = new URL(location.href);
+    const forced = url.searchParams.get("tier") as TierName | null;
+    if (forced && TIERS[forced]) return TIERS[forced];
+  } catch {
+    /* not in a browser with a parsable URL — fall through */
+  }
+  const nav = navigator as Navigator & { deviceMemory?: number; hardwareConcurrency?: number };
+  const mem = nav.deviceMemory ?? 4;
+  const cpu = nav.hardwareConcurrency ?? 4;
+  const dpr = typeof devicePixelRatio === "number" ? devicePixelRatio : 1;
+  const px = (innerWidth || 1024) * (innerHeight || 768) * Math.min(dpr, 2) ** 2;
+  if (mem >= 8 && cpu >= 8 && px < 4.6e6) return TIERS.ultra;
+  if (mem <= 3 || cpu <= 4) return TIERS.low;
+  return TIERS.mid;
+}
+
+/**
+ * Watches frame cost and steps the tier down (never silently up past the
+ * detected ceiling) so a wrong guess costs ~1.5s of judder, not a session.
+ */
+export class TierMonitor {
+  private samples: number[] = [];
+  private cursor = 0;
+  private cooldown = 0;
+  constructor(
+    public tier: Tier,
+    private readonly onChange: (t: Tier) => void,
+    private readonly ceiling: TierName = tier.name,
+  ) {
+    for (let i = 0; i < 90; i++) this.samples.push(16.7);
+  }
+
+  /** @returns the (possibly new) tier */
+  sample(frameMs: number, dtWall: number): Tier {
+    this.samples[this.cursor] = frameMs;
+    this.cursor = (this.cursor + 1) % this.samples.length;
+    this.cooldown -= dtWall;
+    if (this.cooldown > 0) return this.tier;
+
+    let over = 0;
+    let sum = 0;
+    for (const s of this.samples) {
+      sum += s;
+      if (s > 20) over++;
+    }
+    const mean = sum / this.samples.length;
+    const order: TierName[] = ["low", "mid", "ultra"];
+    const at = order.indexOf(this.tier.name);
+    const cap = order.indexOf(this.ceiling);
+
+    if ((over > this.samples.length * 0.28 || mean > 19) && at > 0) {
+      this.set(order[at - 1] as TierName);
+    } else if (over === 0 && mean < 11.5 && at < cap) {
+      this.set(order[at + 1] as TierName);
+    }
+    return this.tier;
+  }
+
+  private set(n: TierName): void {
+    this.tier = TIERS[n];
+    this.cooldown = 4;
+    for (let i = 0; i < this.samples.length; i++) this.samples[i] = 16.7;
+    this.onChange(this.tier);
+  }
+}

--- a/dynawalla/games/polarity/src/core/util.ts
+++ b/dynawalla/games/polarity/src/core/util.ts
@@ -1,0 +1,52 @@
+export const TAU = Math.PI * 2;
+
+export const clamp = (v: number, lo: number, hi: number): number =>
+  v < lo ? lo : v > hi ? hi : v;
+export const clamp01 = (v: number): number => (v < 0 ? 0 : v > 1 ? 1 : v);
+export const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+export const inv = (a: number, b: number, v: number): number => (b === a ? 0 : (v - a) / (b - a));
+
+/** Frame-rate independent exponential approach. `h` is the half-life in seconds. */
+export const approach = (a: number, b: number, h: number, dt: number): number =>
+  h <= 0 ? b : b + (a - b) * Math.pow(2, -dt / h);
+
+export const easeOutCubic = (t: number): number => 1 - Math.pow(1 - t, 3);
+export const easeOutQuint = (t: number): number => 1 - Math.pow(1 - t, 5);
+export const easeInCubic = (t: number): number => t * t * t;
+export const easeOutBack = (t: number): number => {
+  const c = 1.9;
+  return 1 + (c + 1) * Math.pow(t - 1, 3) + c * Math.pow(t - 1, 2);
+};
+/** 0 → 1 → 0, peaking at t=0.5. Good for one-shot pops. */
+export const pulse = (t: number): number => {
+  const x = clamp01(t);
+  return Math.sin(x * Math.PI);
+};
+/** Fast decaying spring wobble in [-1,1], for punches. */
+export const wobble = (t: number, freq = 14, decay = 9): number =>
+  Math.sin(t * freq) * Math.exp(-t * decay);
+
+export const angleTo = (dx: number, dy: number): number => Math.atan2(dy, dx);
+export const dist2 = (ax: number, ay: number, bx: number, by: number): number => {
+  const dx = ax - bx;
+  const dy = ay - by;
+  return dx * dx + dy * dy;
+};
+
+/** Shortest signed difference between two angles. */
+export const angDiff = (a: number, b: number): number => {
+  let d = (b - a) % TAU;
+  if (d > Math.PI) d -= TAU;
+  if (d < -Math.PI) d += TAU;
+  return d;
+};
+
+export const fmtScore = (n: number): string => {
+  const s = Math.floor(n).toString();
+  let out = "";
+  for (let i = 0; i < s.length; i++) {
+    if (i > 0 && (s.length - i) % 3 === 0) out += " ";
+    out += s[i];
+  }
+  return out;
+};

--- a/dynawalla/games/polarity/src/env.d.ts
+++ b/dynawalla/games/polarity/src/env.d.ts
@@ -1,0 +1,4 @@
+declare module "*.css?inline" {
+  const css: string;
+  export default css;
+}

--- a/dynawalla/games/polarity/src/game/constants.ts
+++ b/dynawalla/games/polarity/src/game/constants.ts
@@ -1,0 +1,142 @@
+/**
+ * One place for every tuned number. Field units: the playfield is always 100
+ * wide; its height follows the container aspect, clamped so neither a phone nor
+ * an ultrawide desktop gets an unplayable shape.
+ */
+
+export const HALF_W = 50;
+export const MIN_HALF_H = 55;
+export const MAX_HALF_H = 95;
+
+// --- player -----------------------------------------------------------------
+export const PLAYER = {
+  /** the lethal dot — deliberately tiny and always drawn, danmaku-style */
+  hit: 1.15,
+  /** magnet reach for chaff and charge bullets (never for seal orbs) */
+  absorb: 5.0,
+  /** how hard the ship chases the pointer; half-life in seconds */
+  chaseHalfLife: 0.055,
+  /** keyboard accel / max speed in units per second */
+  accel: 620,
+  maxSpeed: 96,
+  friction: 0.0006,
+  fireEvery: 0.085,
+  shotSpeed: 132,
+  shotDamage: 1,
+  /** shooting an enemy of the opposite polarity does this much extra */
+  oppositeBonus: 2,
+  shields: 3,
+  invuln: 1.7,
+  flipCooldown: 0.06,
+  /** a flip inside this window that saves you from a bullet is a CLUTCH */
+  clutchWindow: 0.16,
+  clutchRadius: 4.2,
+} as const;
+
+// --- the core band ----------------------------------------------------------
+export const CORE = {
+  capBase: 20,
+  capStep: 4,
+  capMax: 60,
+  /** the gauge starts warning here */
+  warnAt: 0.74,
+  ventStun: 0.5,
+  dartSpeed: 118,
+  dartDamage: 2,
+  dartTurn: 7.5,
+  dartLife: 2.6,
+} as const;
+
+// --- bullets ----------------------------------------------------------------
+export const enum BK {
+  Chaff = 0,
+  Charge = 1,
+  Orb = 2,
+  Shot = 3,
+  Dart = 4,
+  Lance = 5,
+}
+
+export const BULLET = {
+  chaffR: 1.9,
+  chargeR: 3.1,
+  orbR: 5.4,
+  shotR: 1.0,
+  dartR: 1.35,
+  lanceR: 2.5,
+} as const;
+
+// --- enemies ----------------------------------------------------------------
+export const enum EK {
+  Mote = 0,
+  Weaver = 1,
+  Spinner = 2,
+  Battery = 3,
+  Lancer = 4,
+  Bearer = 5,
+  Warden = 6,
+}
+
+export type EnemySpec = {
+  hp: number;
+  r: number;
+  score: number;
+  /** contact damage to the player */
+  ram: boolean;
+};
+
+export const ENEMY: Record<number, EnemySpec> = {
+  [EK.Mote]: { hp: 2, r: 3.0, score: 40, ram: false },
+  [EK.Weaver]: { hp: 5, r: 3.6, score: 90, ram: false },
+  [EK.Spinner]: { hp: 8, r: 4.4, score: 150, ram: false },
+  [EK.Battery]: { hp: 16, r: 5.6, score: 280, ram: false },
+  [EK.Lancer]: { hp: 4, r: 3.2, score: 120, ram: true },
+  [EK.Bearer]: { hp: 64, r: 9.5, score: 900, ram: false },
+  [EK.Warden]: { hp: 210, r: 14, score: 3200, ram: false },
+};
+
+// --- pacing -----------------------------------------------------------------
+export const PACE = {
+  /** seconds per stratum; the HUD counts these */
+  stratum: 30,
+  firstBearer: 14,
+  bearerEvery: 34,
+  bearerEveryMin: 26,
+  /** every Nth bearer is a Warden instead */
+  wardenEvery: 3,
+  spawnBase: 0.62,
+  spawnPerLvl: 0.135,
+  spawnMax: 3.3,
+  speedPerLvl: 0.042,
+  speedMax: 0.62,
+} as const;
+
+// --- palette (linear-ish sRGB triples, additive) ----------------------------
+export const COL = {
+  posCore: [1.0, 0.83, 0.34] as const,
+  posEdge: [1.0, 0.45, 0.08] as const,
+  posHot: [1.0, 0.97, 0.86] as const,
+  negCore: [0.28, 0.88, 1.0] as const,
+  negEdge: [0.42, 0.3, 1.0] as const,
+  negHot: [0.83, 0.95, 1.0] as const,
+  neutral: [0.75, 0.78, 0.86] as const,
+  bad: [1.0, 0.24, 0.35] as const,
+  gold: [1.0, 0.88, 0.5] as const,
+} as const;
+
+export const polColor = (p: number): readonly [number, number, number] =>
+  p > 0 ? COL.posCore : p < 0 ? COL.negCore : COL.neutral;
+export const polEdge = (p: number): readonly [number, number, number] =>
+  p > 0 ? COL.posEdge : p < 0 ? COL.negEdge : COL.neutral;
+export const polHot = (p: number): readonly [number, number, number] =>
+  p > 0 ? COL.posHot : p < 0 ? COL.negHot : COL.neutral;
+
+// --- scoring ----------------------------------------------------------------
+export const SCORE = {
+  absorb: 12,
+  clutch: 400,
+  sealCorrect: 1500,
+  bearerKill: 2400,
+  wardenLockExact: 6000,
+  wardenLockNear: 1400,
+} as const;

--- a/dynawalla/games/polarity/src/game/enemies.ts
+++ b/dynawalla/games/polarity/src/game/enemies.ts
@@ -1,0 +1,275 @@
+import { TAU, approach, clamp } from "../core/util.ts";
+import { labelTile } from "../core/labels.ts";
+import { BK, BULLET, COL, EK, ENEMY, HALF_W, polColor } from "./constants.ts";
+import type { Bullet, Enemy } from "./types.ts";
+import { addBullet, addEnemy, burst, inField, ring, type World } from "./world.ts";
+
+// ---------------------------------------------------------------------------
+// firing helpers
+// ---------------------------------------------------------------------------
+
+export function fireChaff(
+  w: World,
+  x: number,
+  y: number,
+  ang: number,
+  speed: number,
+  pol: number,
+  mag = 1,
+): Bullet | null {
+  const b = addBullet(w);
+  if (!b) return null;
+  b.x = x;
+  b.y = y;
+  b.vx = Math.cos(ang) * speed;
+  b.vy = Math.sin(ang) * speed;
+  b.v = pol * mag;
+  b.r = BULLET.chaffR;
+  b.kind = BK.Chaff;
+  b.owner = 0;
+  b.life = 12;
+  b.dmg = 1;
+  b.rot = ang;
+  b.spin = pol > 0 ? 2.2 : -1.4;
+  b.label = mag > 1 ? labelTile(b.v) : -1;
+  return b;
+}
+
+export function fireCharge(
+  w: World,
+  x: number,
+  y: number,
+  ang: number,
+  speed: number,
+  value: number,
+): Bullet | null {
+  const b = addBullet(w);
+  if (!b) return null;
+  b.x = x;
+  b.y = y;
+  b.vx = Math.cos(ang) * speed;
+  b.vy = Math.sin(ang) * speed;
+  b.v = value;
+  b.r = BULLET.chargeR;
+  b.kind = BK.Charge;
+  b.owner = 0;
+  b.life = 14;
+  b.dmg = 1;
+  b.rot = 0;
+  b.spin = value > 0 ? 1.1 : -0.8;
+  b.label = labelTile(value);
+  b.grow = 1;
+  return b;
+}
+
+export function fireLance(w: World, x: number, y: number, ang: number, speed: number, pol: number): void {
+  const b = addBullet(w);
+  if (!b) return;
+  b.x = x;
+  b.y = y;
+  b.vx = Math.cos(ang) * speed;
+  b.vy = Math.sin(ang) * speed;
+  b.v = pol;
+  b.r = BULLET.lanceR;
+  b.kind = BK.Lance;
+  b.owner = 0;
+  b.life = 6;
+  b.dmg = 1;
+  b.rot = ang;
+}
+
+// ---------------------------------------------------------------------------
+// spawning
+// ---------------------------------------------------------------------------
+
+export function spawnEnemy(w: World, kind: EK, x?: number): Enemy | null {
+  const e = addEnemy(w);
+  if (!e) return null;
+  const spec = ENEMY[kind] ?? ENEMY[EK.Mote];
+  if (!spec) return null;
+  e.kind = kind;
+  e.hp = spec.hp;
+  e.maxHp = spec.hp;
+  e.r = spec.r;
+  e.pol = w.rng.sign();
+  e.x = x ?? w.rng.r(-HALF_W + 10, HALF_W - 10);
+  e.y = w.halfH + spec.r + 4;
+  e.ax = e.x;
+  e.ay = w.halfH * 0.42;
+  e.vx = 0;
+  e.vy = 0;
+  e.spin = 0;
+
+  switch (kind) {
+    case EK.Mote:
+      e.vy = -20;
+      e.spin = w.rng.r(-1.4, 1.4);
+      break;
+    case EK.Weaver:
+      e.vy = -15;
+      break;
+    case EK.Spinner:
+      e.vy = -22;
+      e.ay = w.rng.r(w.halfH * 0.16, w.halfH * 0.5);
+      e.spin = w.rng.sign() * 1.15;
+      break;
+    case EK.Battery:
+      e.vy = -12;
+      e.ay = w.rng.r(w.halfH * 0.42, w.halfH * 0.66);
+      break;
+    case EK.Lancer:
+      e.vy = -34;
+      e.pol = w.rng.sign();
+      break;
+    case EK.Bearer:
+      e.x = 0;
+      e.ax = 0;
+      e.ay = w.halfH * 0.44;
+      e.vy = -26;
+      e.hp = spec.hp;
+      e.maxHp = spec.hp;
+      break;
+    case EK.Warden:
+      e.x = 0;
+      e.ax = 0;
+      e.ay = w.halfH * 0.5;
+      e.vy = -20;
+      e.pol = 1;
+      break;
+  }
+  ring(w, e.x, e.y, e.r * 1.4, polColor(e.pol), 0.4, 1.1);
+  return e;
+}
+
+// ---------------------------------------------------------------------------
+// per-kind behaviour
+// ---------------------------------------------------------------------------
+
+const aim = (e: Enemy, w: World): number => Math.atan2(w.py - e.y, w.px - e.x);
+
+/** Speed scaling from the director, so every pattern ramps together. */
+export function stepEnemy(w: World, e: Enemy, dt: number, spd: number): void {
+  e.age += dt;
+  e.rot += e.spin * dt;
+  if (e.hitFlash > 0) e.hitFlash = Math.max(0, e.hitFlash - dt * 5);
+  e.fireT -= dt;
+
+  switch (e.kind) {
+    case EK.Mote: {
+      e.x += Math.sin(e.age * 1.7 + e.seed) * 13 * dt;
+      e.y += e.vy * dt * spd;
+      if (e.fireT <= 0 && e.y < w.halfH - 6) {
+        e.fireT = 1.5 / spd;
+        fireChaff(w, e.x, e.y - e.r, aim(e, w), 40 * spd, e.pol, w.stratum >= 6 ? 2 : 1);
+        e.hitFlash = Math.max(e.hitFlash, 0.35);
+      }
+      break;
+    }
+    case EK.Weaver: {
+      e.x = e.ax + Math.sin(e.age * 1.25 + e.seed) * (HALF_W - 12);
+      e.y += e.vy * dt * spd;
+      if (e.fireT <= 0 && e.y < w.halfH - 6) {
+        e.fireT = 1.45 / spd;
+        const a = aim(e, w);
+        for (let i = -1; i <= 1; i++) {
+          fireChaff(w, e.x, e.y - e.r, a + i * 0.24, 44 * spd, i === 0 ? e.pol : -e.pol);
+        }
+        e.hitFlash = 0.4;
+      }
+      break;
+    }
+    case EK.Spinner: {
+      e.y = approach(e.y, e.ay, 0.7, dt);
+      e.x += Math.sin(e.age * 0.8 + e.seed) * 9 * dt;
+      if (e.fireT <= 0 && e.y < w.halfH - 4) {
+        e.fireT = 0.15 / spd;
+        // two counter-signed arms — the classic weave-through-the-spiral
+        for (let arm = 0; arm < 2; arm++) {
+          const a = e.rot + arm * Math.PI;
+          fireChaff(w, e.x + Math.cos(a) * e.r, e.y + Math.sin(a) * e.r, a, 33 * spd, arm ? -1 : 1);
+        }
+      }
+      break;
+    }
+    case EK.Battery: {
+      e.y = approach(e.y, e.ay, 0.9, dt);
+      e.x = approach(e.x, e.ax + Math.sin(e.age * 0.55 + e.seed) * 20, 0.6, dt);
+      if (e.fireT <= 0 && e.y < w.halfH - 4) {
+        e.fireT = 2.15 / spd;
+        const n = w.stratum >= 4 ? 3 : 2;
+        for (let i = 0; i < n; i++) {
+          const sign = w.rng.sign();
+          const mag = w.rng.i(2, Math.min(9, 3 + w.stratum));
+          const a = -Math.PI / 2 + (i - (n - 1) / 2) * 0.42 + w.rng.r(-0.08, 0.08);
+          fireCharge(w, e.x, e.y - e.r * 0.6, a, 26 * spd, sign * mag);
+        }
+        e.hitFlash = 0.6;
+        burst(w, e.x, e.y - e.r, 6, 22, polColor(e.pol), { life: 0.3, size: 1.1 });
+      }
+      break;
+    }
+    case EK.Lancer: {
+      // lock onto the player's column, then dive
+      if (e.age < 0.55) {
+        e.x = approach(e.x, w.px, 0.18, dt);
+        e.y += -10 * dt;
+      } else {
+        e.y += e.vy * 2.4 * dt * spd;
+        if (e.fireT <= 0) {
+          e.fireT = 0.34;
+          fireLance(w, e.x, e.y - e.r, -Math.PI / 2, 78 * spd, e.pol);
+        }
+      }
+      break;
+    }
+    case EK.Bearer:
+    case EK.Warden:
+      // driven by seal.ts / warden.ts
+      break;
+  }
+}
+
+/** True when the enemy has left the bottom of the field for good. */
+export function enemyEscaped(w: World, e: Enemy): boolean {
+  return e.y < -w.halfH - e.r - 6 || !inField(w, e.x, e.y, e.r + 30);
+}
+
+export function enemyDeathFx(w: World, e: Enemy): void {
+  const col = polColor(e.pol);
+  const big = e.r > 6;
+  burst(w, e.x, e.y, big ? 46 : 16, big ? 78 : 46, col, {
+    life: big ? 0.8 : 0.5,
+    size: big ? 2.6 : 1.7,
+    kind: 1,
+  });
+  burst(w, e.x, e.y, big ? 26 : 9, big ? 44 : 26, COL.posHot, { life: 0.32, size: 1.2 });
+  ring(w, e.x, e.y, e.r * 1.1, col, big ? 0.6 : 0.36, big ? 2.4 : 1.3);
+}
+
+/** A single spinning debris shard field, used for the player's death. */
+export function shatter(w: World, x: number, y: number, col: readonly number[], n = 40): void {
+  for (let i = 0; i < n; i++) {
+    const a = (i / n) * TAU + w.rng.r(-0.2, 0.2);
+    const s = w.rng.r(24, 96);
+    const p = addBullet(w);
+    if (p) {
+      // reuse the bullet pool for inert debris so the shatter is dense
+      p.x = x;
+      p.y = y;
+      p.vx = Math.cos(a) * s;
+      p.vy = Math.sin(a) * s;
+      p.v = 0;
+      p.r = w.rng.r(0.7, 2.1);
+      p.kind = BK.Shot;
+      p.owner = 2; // inert
+      p.life = w.rng.r(0.6, 1.5);
+      p.rot = a;
+      p.spin = w.rng.r(-9, 9);
+    }
+  }
+  burst(w, x, y, 60, 90, col, { life: 1.1, size: 2.4, kind: 1 });
+}
+
+export const enemyIsBoss = (e: Enemy): boolean => e.kind === EK.Bearer || e.kind === EK.Warden;
+
+export const enemyHpFrac = (e: Enemy): number => clamp(e.hp / e.maxHp, 0, 1);

--- a/dynawalla/games/polarity/src/game/seal.ts
+++ b/dynawalla/games/polarity/src/game/seal.ts
@@ -1,0 +1,444 @@
+import { labelTile } from "../core/labels.ts";
+import { TAU, approach, clamp } from "../core/util.ts";
+import { parseInt_ } from "../math/signed.ts";
+import {
+  BK,
+  BULLET,
+  COL,
+  CORE,
+  EK,
+  ENEMY,
+  HALF_W,
+  PACE,
+  SCORE,
+  polColor,
+  polHot,
+} from "./constants.ts";
+import { fireChaff, fireCharge, spawnEnemy } from "./enemies.ts";
+import type { Bullet, Enemy } from "./types.ts";
+import {
+  addBullet,
+  burst,
+  cue,
+  flash,
+  hitstop,
+  punch,
+  ring,
+  shake,
+  shockwave,
+  slowmo,
+  type World,
+} from "./world.ts";
+
+/**
+ * The question layer, and the only place `host.next()` / `host.report()` are
+ * called.
+ *
+ * The whole integration is motion, not UI. A Seal Bearer holds the prompt on
+ * its hull and drops four ORBS carrying the answer and three mal-rule
+ * distractors. An orb's SIGN is its polarity, so:
+ *
+ *   - you can fly straight through any orb whose sign is not yours — wrong
+ *     answers of the opposite sign are ghosts;
+ *   - an orb of your own sign is solid, and touching it commits you.
+ *
+ * So answering is: read the prompt, pick a polarity, thread the mines. There is
+ * no button, no red X and no lecture — a wrong answer detonates in your face
+ * and costs a shield, which is a real price, and the correct orb is still
+ * sitting there waiting.
+ */
+
+const ORB_SPEED_IN = 26;
+const ORB_HOLD_BASE = 7.5;
+const ORB_HOLD_MIN = 4.6;
+
+export function bearerDue(w: World): boolean {
+  return !w.bossActive && w.t >= w.nextBearer;
+}
+
+export function scheduleNextBearer(w: World): void {
+  const gap = Math.max(PACE.bearerEveryMin, PACE.bearerEvery - w.bearerCount * 1.1);
+  w.nextBearer = w.t + gap;
+}
+
+export function launchBoss(w: World): void {
+  w.bearerCount++;
+  const warden = w.bearerCount % PACE.wardenEvery === 0;
+  const e = spawnEnemy(w, warden ? EK.Warden : EK.Bearer);
+  if (!e) return;
+  const spec = ENEMY[warden ? EK.Warden : EK.Bearer];
+  if (spec) {
+    // bosses toughen with depth so they stay a real fight at minute 20
+    const scale = 1 + Math.min(2.4, w.stratum * 0.16);
+    e.hp = Math.round(spec.hp * scale);
+    e.maxHp = e.hp;
+  }
+  w.bossActive = true;
+  w.hush = 1;
+  w.events.push(warden ? "warden" : "bearer");
+  shockwave(w, 0, w.halfH * 0.5, 1, 0, 0.9);
+}
+
+// ---------------------------------------------------------------------------
+// asking
+// ---------------------------------------------------------------------------
+
+function askQuestion(w: World, e: Enemy, orbCount: number): void {
+  const q = w.host.next({ difficulty: clamp(0.14 + w.stratum * 0.06, 0, 1) });
+  w.sealSerial++;
+  w.seal.serial = w.sealSerial;
+  w.seal.state = "asking";
+  w.seal.q = q;
+  w.seal.askedAt = w.t;
+  w.seal.answered = "";
+  e.seal = w.sealSerial;
+  w.prompt = q.prompt;
+  w.promptV++;
+  w.stats.asked++;
+
+  const values: number[] = [parseInt_(q.answer)];
+  for (const d of q.distractors) values.push(parseInt_(d));
+  const order = w.rng.shuffle(values.map((v, i) => ({ v, correct: i === 0 })));
+  const n = Math.min(orbCount, order.length);
+
+  for (let i = 0; i < n; i++) {
+    const o = order[i];
+    if (!o) continue;
+    const b = addBullet(w);
+    if (!b) continue;
+    const spread = (HALF_W - 12) * 2;
+    const tx = -spread / 2 + (spread * (i + 0.5)) / n;
+    b.x = e.x;
+    b.y = e.y - e.r * 0.4;
+    b.vx = (tx - e.x) * 0.55;
+    b.vy = -ORB_SPEED_IN;
+    b.v = o.v;
+    b.r = BULLET.orbR;
+    b.kind = BK.Orb;
+    b.owner = 0;
+    b.life = 40;
+    b.label = labelTile(o.v);
+    b.seal = w.sealSerial;
+    b.correct = o.correct ? 1 : 0;
+    b.wob = w.rng.f() * TAU;
+    b.grow = 1;
+    b.dmg = 1;
+  }
+  ring(w, e.x, e.y, e.r * 1.6, COL.gold, 0.55, 2.2);
+  burst(w, e.x, e.y, 26, 42, COL.gold, { life: 0.6, size: 1.8 });
+  punch(w, 0.35);
+  cue(w, "seal");
+}
+
+/** Orb flight: glide to the presentation band, hover and weave, then leave. */
+export function stepOrb(w: World, b: Bullet, dt: number, hurry: number): void {
+  const band = -w.halfH * 0.06;
+  b.wob += dt * 1.15;
+  if (b.y > band) {
+    b.y += b.vy * dt * hurry;
+    b.vx = approach(b.vx, 0, 0.4, dt);
+    b.x += b.vx * dt;
+  } else {
+    b.y = approach(b.y, band + Math.sin(b.wob * 1.3) * 5.5, 0.5, dt);
+    b.x += Math.cos(b.wob * 0.9 + b.v) * 11 * dt * hurry;
+    b.x = clamp(b.x, -HALF_W + b.r, HALF_W - b.r);
+  }
+  b.rot += (b.v > 0 ? 0.9 : -0.7) * dt;
+  if (b.grow > 0) b.grow = Math.max(0, b.grow - dt * 3.4);
+}
+
+// ---------------------------------------------------------------------------
+// resolution
+// ---------------------------------------------------------------------------
+
+function killSealOrbs(w: World, serial: number, correctToo: boolean): void {
+  for (let i = 0; i < w.bulletN; i++) {
+    const b = w.bullets[i] as Bullet;
+    if (b.seal !== serial) continue;
+    if (!correctToo && b.correct) continue;
+    burst(w, b.x, b.y, 12, 40, polColor(b.v), { life: 0.45, size: 1.6, kind: 1 });
+    b.live = false;
+  }
+}
+
+export function onOrbTouched(w: World, b: Bullet): void {
+  const q = w.seal.q;
+  const first = w.seal.state === "asking";
+  const correct = b.correct === 1;
+
+  if (first && q) {
+    w.seal.answered = String(b.v);
+    w.seal.state = correct ? "won" : "lost";
+    w.host.report({
+      questionId: q.id,
+      correct,
+      ms: Math.max(1, Math.round((w.t - w.seal.askedAt) * 1000)),
+      answered: w.seal.answered,
+    });
+    if (correct) w.stats.right++;
+  }
+
+  if (correct) sealBroken(w, b);
+  else sealWrong(w, b);
+}
+
+function sealBroken(w: World, b: Bullet): void {
+  const serial = b.seal;
+  const col = polColor(b.v);
+
+  // the answer is worth real charge — and it can never overload you
+  const before = w.core;
+  w.core = clamp(w.core + b.v, -w.cap, w.cap);
+  const spilled = Math.abs(before + b.v) - Math.abs(w.core);
+  w.chain += 6;
+  w.stats.absorbs++;
+  const mult = Math.min(9, 1 + Math.floor(w.chain / 6));
+  w.stats.score += SCORE.sealCorrect * mult + Math.max(0, spilled) * 60;
+
+  b.live = false;
+  killSealOrbs(w, serial, true);
+
+  hitstop(w, 0.1);
+  slowmo(w, 0.42, 0.72);
+  punch(w, 1);
+  shake(w, 0.5);
+  flash(w, 0.3, COL.gold);
+  shockwave(w, b.x, b.y, 1.4, b.v > 0 ? 1 : -1, 0.85);
+  ring(w, b.x, b.y, 4, COL.gold, 0.7, 3.4);
+  ring(w, b.x, b.y, 9, polHot(b.v), 0.55, 2.2);
+  burst(w, b.x, b.y, 70, 110, COL.gold, { life: 1, size: 2.6, kind: 1 });
+  burst(w, b.x, b.y, 34, 60, col, { life: 0.7, size: 2 });
+  w.host.haptic("success");
+  w.events.push("seal-won");
+
+  // crack the bearer open
+  for (let i = 0; i < w.enemyN; i++) {
+    const e = w.enemies[i] as Enemy;
+    if (e.seal !== serial) continue;
+    e.lockState = 2; // vulnerable
+    e.hitFlash = 1;
+    e.fireT = 1.6;
+    if (e.kind === EK.Bearer) e.hp = Math.min(e.hp, Math.ceil(e.maxHp * 0.34));
+    else e.hp = Math.min(e.hp, Math.ceil(e.maxHp * 0.62));
+  }
+}
+
+function sealWrong(w: World, b: Bullet): void {
+  const serial = b.seal;
+  b.live = false;
+  burst(w, b.x, b.y, 44, 96, COL.bad, { life: 0.75, size: 2.3, kind: 1 });
+  ring(w, b.x, b.y, 5, COL.bad, 0.5, 3);
+  shockwave(w, b.x, b.y, 1.1, 0, 0.6);
+  w.events.push("seal-wrong");
+  // the remaining orbs get harder to reach, and the bearer answers back
+  for (let i = 0; i < w.bulletN; i++) {
+    const o = w.bullets[i] as Bullet;
+    if (o.seal === serial) o.wob += 1.4;
+  }
+  for (let i = 0; i < w.enemyN; i++) {
+    const e = w.enemies[i] as Enemy;
+    if (e.seal !== serial) continue;
+    for (let k = 0; k < 14; k++) {
+      const a = (k / 14) * TAU;
+      fireChaff(w, e.x, e.y, a, 34, k % 2 ? 1 : -1);
+    }
+  }
+}
+
+export function sealTimedOut(w: World): void {
+  const q = w.seal.q;
+  if (w.seal.state !== "asking" || !q) return;
+  w.seal.state = "lost";
+  w.host.report({
+    questionId: q.id,
+    correct: false,
+    ms: Math.max(1, Math.round((w.t - w.seal.askedAt) * 1000)),
+    answered: "",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// bearer + warden choreography
+// ---------------------------------------------------------------------------
+
+export function stepBoss(w: World, e: Enemy, dt: number, spd: number): void {
+  e.age += dt;
+  if (e.hitFlash > 0) e.hitFlash = Math.max(0, e.hitFlash - dt * 4);
+  e.fireT -= dt;
+  e.rot += dt * (e.kind === EK.Warden ? 0.5 : 0.32);
+
+  e.y = approach(e.y, e.ay, 0.85, dt);
+  e.x = approach(e.x, e.ax + Math.sin(e.age * 0.6 + e.seed) * 13, 0.9, dt);
+
+  if (e.kind === EK.Bearer) stepBearer(w, e, dt, spd);
+  else stepWarden(w, e, dt, spd);
+}
+
+function stepBearer(w: World, e: Enemy, _dt: number, spd: number): void {
+  if (e.phase === 0 && e.age > 1.15) {
+    e.phase = 1;
+    askQuestion(w, e, 4);
+    e.lockState = 0;
+    e.fireT = 1.2;
+  }
+  if (e.phase === 1) {
+    const hold = Math.max(ORB_HOLD_MIN, ORB_HOLD_BASE - w.bearerCount * 0.35);
+    if (w.t - w.seal.askedAt > hold + 3 && w.seal.state === "asking") {
+      sealTimedOut(w);
+      killSealOrbs(w, e.seal, true);
+      e.phase = 2;
+      e.lockState = 2;
+    } else if (w.seal.state !== "asking") {
+      e.phase = 2;
+    }
+    // light suppressing fire so the puzzle is not a rest stop
+    if (e.fireT <= 0) {
+      e.fireT = 1.5 / spd;
+      const a = Math.atan2(w.py - e.y, w.px - e.x);
+      fireChaff(w, e.x - e.r * 0.7, e.y, a, 30 * spd, 1);
+      fireChaff(w, e.x + e.r * 0.7, e.y, a, 30 * spd, -1);
+    }
+  }
+  if (e.phase === 2 && e.fireT <= 0) {
+    e.fireT = 0.85 / spd;
+    for (let i = 0; i < 5; i++) {
+      const a = -Math.PI / 2 + (i - 2) * 0.3 + Math.sin(e.age) * 0.3;
+      fireChaff(w, e.x, e.y - e.r * 0.5, a, 42 * spd, i % 2 ? 1 : -1);
+    }
+  }
+}
+
+/**
+ * The Warden is the deep end: it locks itself to an exact core value taken from
+ * a host question, and only a RELEASE at that exact total breaks the lock.
+ * Getting within two still does real damage, so a younger player still makes
+ * progress; exactness is worth three times as much.
+ */
+function stepWarden(w: World, e: Enemy, _dt: number, spd: number): void {
+  const hpf = e.hp / e.maxHp;
+
+  if (e.phase === 0 && e.age > 1.1) {
+    e.phase = 1;
+    e.fireT = 0.4;
+  }
+
+  // phase 1 — alternating polarity walls you fly INTO
+  if (e.phase === 1) {
+    if (e.fireT <= 0) {
+      e.fireT = 0.62 / spd;
+      e.lockState = 0;
+      const pol = ((e.age * 1.6) | 0) % 2 ? 1 : -1;
+      const gap = Math.sin(e.age * 0.9) * (HALF_W * 0.45);
+      for (let i = -8; i <= 8; i++) {
+        const x = (i / 8) * (HALF_W - 4);
+        if (Math.abs(x - gap) < 9) continue;
+        fireChaff(w, x, e.y - e.r * 0.7, -Math.PI / 2, 40 * spd, pol);
+      }
+    }
+    if (e.age > 6.5) {
+      e.phase = 2;
+      askQuestion(w, e, 0); // no orbs — the lock IS the answer
+      e.lockWant = clamp(parseInt_(w.seal.q?.answer ?? "0"), -w.cap, w.cap);
+      e.lockState = 1;
+      e.fireT = 0.6;
+      cue(w, "lock");
+      ring(w, e.x, e.y, e.r * 1.8, COL.gold, 0.7, 3);
+      w.events.push("lock-open");
+    }
+  }
+
+  // phase 2 — the lock: it feeds you charge, you steer the total, you vent
+  if (e.phase === 2) {
+    if (e.fireT <= 0) {
+      e.fireT = 1.25 / spd;
+      for (let i = 0; i < 3; i++) {
+        const sign = i === 1 ? Math.sign(e.lockWant - w.core) || 1 : w.rng.sign();
+        const mag = w.rng.i(2, 8);
+        const a = -Math.PI / 2 + (i - 1) * 0.5;
+        fireCharge(w, e.x, e.y - e.r * 0.5, a, 24 * spd, sign * mag);
+      }
+      for (let i = 0; i < 4; i++) {
+        fireChaff(w, e.x, e.y, -Math.PI / 2 + (i - 1.5) * 0.7, 32 * spd, w.rng.sign());
+      }
+    }
+    if (w.t - w.seal.askedAt > 15) {
+      sealTimedOut(w);
+      e.phase = 3;
+      e.lockState = 0;
+      e.fireT = 0.2;
+    }
+  }
+
+  // phase 3 — enrage, then loop back
+  if (e.phase === 3) {
+    if (e.fireT <= 0) {
+      e.fireT = 0.1 / spd;
+      const a = e.rot * 3.4;
+      for (let arm = 0; arm < 3; arm++) {
+        const t = a + (arm / 3) * TAU;
+        fireChaff(w, e.x, e.y, t, 38 * spd, arm % 2 ? 1 : -1, hpf < 0.4 ? 2 : 1);
+      }
+    }
+    if (e.age > 0 && w.t - w.seal.askedAt > 22) {
+      e.phase = 1;
+      e.age = 0;
+      e.fireT = 0.5;
+    }
+  }
+}
+
+/** Called from the sim when the player releases while a lock is open. */
+export function tryLock(w: World, e: Enemy): "exact" | "near" | "miss" {
+  const d = Math.abs(w.core - e.lockWant);
+  const res = d === 0 ? "exact" : d <= 2 ? "near" : "miss";
+  if (res === "miss") {
+    ring(w, e.x, e.y, e.r * 1.4, COL.bad, 0.45, 2.4);
+    burst(w, e.x, e.y, 20, 50, COL.bad, { life: 0.5, size: 1.8 });
+    shake(w, 0.22);
+    return res;
+  }
+  const exact = res === "exact";
+  e.hp -= exact ? Math.ceil(e.maxHp * 0.42) : Math.ceil(e.maxHp * 0.14);
+  e.hitFlash = 1;
+  e.phase = 3;
+  e.lockState = 0;
+  w.stats.score += exact ? SCORE.wardenLockExact : SCORE.wardenLockNear;
+  if (exact && w.seal.state === "asking" && w.seal.q) {
+    w.seal.state = "won";
+    w.stats.right++;
+    w.host.report({
+      questionId: w.seal.q.id,
+      correct: true,
+      ms: Math.max(1, Math.round((w.t - w.seal.askedAt) * 1000)),
+      answered: String(w.core),
+    });
+  }
+  hitstop(w, exact ? 0.13 : 0.06);
+  slowmo(w, exact ? 0.5 : 0.2, 0.7);
+  punch(w, exact ? 1 : 0.5);
+  shake(w, exact ? 0.65 : 0.3);
+  flash(w, exact ? 0.34 : 0.16, COL.gold);
+  shockwave(w, e.x, e.y, exact ? 1.8 : 1, 0, 1);
+  burst(w, e.x, e.y, exact ? 90 : 40, exact ? 130 : 70, COL.gold, {
+    life: 1,
+    size: 2.8,
+    kind: 1,
+  });
+  w.host.haptic(exact ? "success" : "medium");
+  w.events.push(exact ? "lock-exact" : "lock-near");
+  return res;
+}
+
+export function bossDefeated(w: World, e: Enemy): void {
+  if (w.seal.state === "asking" && e.seal === w.seal.serial) {
+    sealTimedOut(w);
+    killSealOrbs(w, e.seal, true);
+  }
+  w.bossActive = false;
+  w.hush = 0;
+  w.stats.score += e.kind === EK.Warden ? SCORE.wardenLockExact : SCORE.bearerKill;
+  scheduleNextBearer(w);
+  // grow the band every boss — the arithmetic gets more room to breathe
+  w.cap = Math.min(CORE.capMax, w.cap + CORE.capStep);
+  w.events.push("boss-down");
+}

--- a/dynawalla/games/polarity/src/game/sim.ts
+++ b/dynawalla/games/polarity/src/game/sim.ts
@@ -1,0 +1,778 @@
+import { labelTile } from "../core/labels.ts";
+import { TAU, angDiff, approach, clamp, clamp01 } from "../core/util.ts";
+import { absorbable, chainMult, overloaded, releaseYield } from "../math/signed.ts";
+import {
+  BK,
+  BULLET,
+  COL,
+  CORE,
+  EK,
+  ENEMY,
+  HALF_W,
+  PACE,
+  PLAYER,
+  SCORE,
+  polColor,
+  polEdge,
+  polHot,
+} from "./constants.ts";
+import {
+  enemyDeathFx,
+  enemyEscaped,
+  enemyIsBoss,
+  shatter,
+  spawnEnemy,
+  stepEnemy,
+} from "./enemies.ts";
+import {
+  bearerDue,
+  bossDefeated,
+  launchBoss,
+  onOrbTouched,
+  stepBoss,
+  stepOrb,
+  tryLock,
+} from "./seal.ts";
+import type { Bullet, Enemy, FloatText, Particle } from "./types.ts";
+import {
+  addBullet,
+  addText,
+  burst,
+  clampToField,
+  cue,
+  flash,
+  hitstop,
+  inField,
+  punch,
+  ring,
+  shake,
+  shockwave,
+  slowmo,
+  stepWaves,
+  type World,
+} from "./world.ts";
+
+// ---------------------------------------------------------------------------
+// pacing
+// ---------------------------------------------------------------------------
+
+export const speedMul = (w: World): number =>
+  1 + Math.min(PACE.speedMax, w.stratum * PACE.speedPerLvl);
+
+const UNLOCK: readonly EK[][] = [
+  [EK.Mote],
+  [EK.Mote, EK.Weaver],
+  [EK.Mote, EK.Weaver, EK.Spinner],
+  [EK.Mote, EK.Weaver, EK.Spinner, EK.Battery],
+  [EK.Mote, EK.Weaver, EK.Spinner, EK.Battery, EK.Lancer],
+];
+
+function direct(w: World, dt: number): void {
+  const lvl = Math.floor(w.t / PACE.stratum);
+  if (lvl !== w.stratum) {
+    w.stratum = lvl;
+    if (lvl > 0) {
+      w.events.push("stratum");
+      shockwave(w, 0, 0, 0.8, 0, 1.1);
+    }
+  }
+  if (w.bossActive) return;
+
+  const rate = Math.min(PACE.spawnMax, PACE.spawnBase + lvl * PACE.spawnPerLvl);
+  w.spawnAcc += dt * rate;
+  const table = UNLOCK[Math.min(UNLOCK.length - 1, Math.floor(lvl / 1.5))] ?? UNLOCK[0];
+  while (w.spawnAcc >= 1) {
+    w.spawnAcc -= 1;
+    if (!table) break;
+    const k = w.rng.pick(table);
+    // batteries arrive in pairs so there is always charge to steer the core with
+    if (k === EK.Battery && w.rng.chance(0.5)) {
+      spawnEnemy(w, k, -18);
+      spawnEnemy(w, k, 18);
+    } else if (k === EK.Mote && w.rng.chance(0.45)) {
+      const x0 = w.rng.r(-HALF_W + 14, HALF_W - 14);
+      for (let i = 0; i < 3; i++) spawnEnemy(w, k, x0 + (i - 1) * 11);
+    } else spawnEnemy(w, k);
+  }
+  if (bearerDue(w)) launchBoss(w);
+}
+
+// ---------------------------------------------------------------------------
+// player actions (called by the input layer)
+// ---------------------------------------------------------------------------
+
+export function flip(w: World): void {
+  if (w.phase !== "play" || w.flipT > 0) return;
+  const from = w.pol;
+  w.pol = -from;
+  w.flipT = PLAYER.flipCooldown;
+  w.polMorph = 0;
+  w.events.push("flip");
+
+  // CLUTCH: did that flip turn a bullet that was about to kill you into food?
+  let saved = 0;
+  for (let i = 0; i < w.bulletN; i++) {
+    const b = w.bullets[i] as Bullet;
+    if (b.owner !== 0 || b.kind === BK.Orb) continue;
+    if (absorbable(b.v, from as 1 | -1)) continue;
+    if (!absorbable(b.v, w.pol as 1 | -1)) continue;
+    const dx = w.px - b.x;
+    const dy = w.py - b.y;
+    const d2 = dx * dx + dy * dy;
+    if (d2 > PLAYER.clutchRadius * PLAYER.clutchRadius) continue;
+    if (b.vx * dx + b.vy * dy <= 0) continue; // not closing
+    saved++;
+  }
+  if (saved > 0) {
+    w.chain += 2 + saved;
+    w.stats.clutches++;
+    w.stats.score += SCORE.clutch * saved * chainMult(w.chain);
+    slowmo(w, 0.3, 0.82);
+    hitstop(w, 0.045);
+    punch(w, 0.55);
+    shake(w, 0.16);
+    ring(w, w.px, w.py, 3, polHot(w.pol), 0.55, 2.6);
+    ring(w, w.px, w.py, 7, COL.gold, 0.42, 1.6);
+    burst(w, w.px, w.py, 26, 60, COL.gold, { life: 0.6, size: 1.7 });
+    w.host.haptic("success");
+    w.events.push("clutch");
+    cue(w, "clutch");
+  } else {
+    ring(w, w.px, w.py, 3.4, polColor(w.pol), 0.3, 1.5);
+    burst(w, w.px, w.py, 8, 28, polEdge(w.pol), { life: 0.28, size: 1.1 });
+    w.host.haptic("light");
+  }
+}
+
+export function release(w: World): void {
+  if (w.phase !== "play" || w.stun > 0) return;
+
+  // an open Warden lock is graded against the exact total first
+  for (let i = 0; i < w.enemyN; i++) {
+    const e = w.enemies[i] as Enemy;
+    if (e.kind === EK.Warden && e.lockState === 1) {
+      tryLock(w, e);
+      break;
+    }
+  }
+
+  const mult = chainMult(w.chain);
+  const { darts, score, perfect } = releaseYield(w.core, w.cap, mult);
+  if (darts === 0) {
+    burst(w, w.px, w.py + 2, 5, 18, polEdge(w.pol), { life: 0.2, size: 0.9 });
+    w.events.push("fizzle");
+    return;
+  }
+  const sign = w.core >= 0 ? 1 : -1;
+  const col = polColor(sign);
+  for (let i = 0; i < darts; i++) {
+    const b = addBullet(w);
+    if (!b) break;
+    const a = -Math.PI / 2 + Math.PI + (i / darts - 0.5) * 2.1 + w.rng.r(-0.08, 0.08);
+    b.x = w.px;
+    b.y = w.py;
+    b.vx = Math.cos(a) * CORE.dartSpeed * w.rng.r(0.7, 1.1);
+    b.vy = Math.sin(a) * CORE.dartSpeed * w.rng.r(0.7, 1.1);
+    b.v = sign;
+    b.r = BULLET.dartR;
+    b.kind = BK.Dart;
+    b.owner = 1;
+    b.life = CORE.dartLife;
+    b.homing = CORE.dartTurn;
+    b.dmg = CORE.dartDamage * (perfect ? 2 : 1);
+    b.rot = a;
+  }
+  w.stats.score += score;
+  w.stats.releases++;
+  if (perfect) w.stats.perfects++;
+  w.recoil = 1;
+  w.core = 0;
+  w.events.push(perfect ? "perfect" : "release");
+  hitstop(w, perfect ? 0.075 : 0.03);
+  punch(w, perfect ? 0.9 : 0.5);
+  shake(w, perfect ? 0.42 : 0.22);
+  shockwave(w, w.px, w.py, perfect ? 1.5 : 0.9, sign, perfect ? 0.8 : 0.55);
+  ring(w, w.px, w.py, 4, perfect ? COL.gold : col, 0.5, perfect ? 3.2 : 1.8);
+  burst(w, w.px, w.py, perfect ? 60 : 26, perfect ? 110 : 70, perfect ? COL.gold : col, {
+    life: 0.7,
+    size: 2.2,
+    kind: 1,
+  });
+  if (perfect) {
+    flash(w, 0.22, COL.gold);
+    slowmo(w, 0.22, 0.7);
+  }
+  w.host.haptic(perfect ? "success" : "medium");
+  cue(w, "release");
+}
+
+// ---------------------------------------------------------------------------
+// core changes
+// ---------------------------------------------------------------------------
+
+function absorb(w: World, b: Bullet): void {
+  w.core += b.v;
+  w.chain++;
+  w.chainT = 1.2;
+  w.stats.absorbs++;
+  if (w.chain > w.stats.bestChain) w.stats.bestChain = w.chain;
+  w.stats.score += SCORE.absorb * chainMult(w.chain);
+
+  const col = polColor(b.v);
+  const big = b.kind === BK.Charge;
+  burst(w, b.x, b.y, big ? 16 : 6, big ? 46 : 26, col, {
+    life: big ? 0.45 : 0.3,
+    size: big ? 1.7 : 1.1,
+  });
+  if (big) {
+    ring(w, w.px, w.py, 3.2, polHot(b.v), 0.3, 1.4);
+    const tile = labelTile(b.v);
+    if (tile >= 0) addText(w, tile, b.x, b.y, polHot(b.v));
+    punch(w, 0.18);
+    w.host.haptic("light");
+  }
+  b.live = false;
+  w.events.push(big ? "absorb-big" : "absorb");
+  cue(w, "absorb");
+
+  if (overloaded(w.core, w.cap)) overload(w);
+}
+
+function overload(w: World): void {
+  const sign = w.core >= 0 ? 1 : -1;
+  w.stats.overloads++;
+  w.chain = 0;
+  w.core = 0;
+  w.stun = CORE.ventStun;
+  w.events.push("overload");
+  hitstop(w, 0.06);
+  shake(w, 0.55);
+  punch(w, 0.7);
+  flash(w, 0.2, COL.bad);
+  shockwave(w, w.px, w.py, 1.3, sign, 0.7);
+  ring(w, w.px, w.py, 3, COL.bad, 0.6, 3.4);
+  burst(w, w.px, w.py, 46, 90, COL.bad, { life: 0.7, size: 2.1, kind: 1 });
+  // the vent still clears the bullets nearest to you — a loss, not a death trap
+  for (let i = 0; i < w.bulletN; i++) {
+    const b = w.bullets[i] as Bullet;
+    if (b.owner !== 0 || b.kind === BK.Orb) continue;
+    const dx = b.x - w.px;
+    const dy = b.y - w.py;
+    if (dx * dx + dy * dy < 22 * 22) {
+      burst(w, b.x, b.y, 3, 26, COL.bad, { life: 0.25, size: 0.9 });
+      b.live = false;
+    }
+  }
+  w.host.haptic("heavy");
+}
+
+function hurt(w: World, x: number, y: number): void {
+  if (w.invuln > 0 || w.phase !== "play") return;
+  w.shields--;
+  w.invuln = PLAYER.invuln;
+  w.chain = 0;
+  w.core = Math.trunc(w.core / 2);
+  w.events.push("hurt");
+  hitstop(w, 0.09);
+  shake(w, 0.75);
+  punch(w, 0.85);
+  flash(w, 0.26, COL.bad);
+  shockwave(w, x, y, 1.2, 0, 0.7);
+  ring(w, w.px, w.py, 4, COL.bad, 0.55, 3);
+  burst(w, w.px, w.py, 40, 82, COL.bad, { life: 0.8, size: 2.2, kind: 1 });
+  w.host.haptic("failure");
+  if (w.shields <= 0) beginDeath(w);
+}
+
+function beginDeath(w: World): void {
+  w.phase = "dying";
+  w.stun = 99;
+  w.events.push("death");
+  hitstop(w, 0.2);
+  slowmo(w, 1.4, 0.9);
+  shake(w, 1);
+  punch(w, 1);
+  flash(w, 0.3, COL.bad);
+  shockwave(w, w.px, w.py, 2, 0, 1.3);
+  shatter(w, w.px, w.py, polColor(w.pol), 44);
+}
+
+// ---------------------------------------------------------------------------
+// the step
+// ---------------------------------------------------------------------------
+
+export function step(w: World, dtWall: number): void {
+  const fx = w.fx;
+  w.wall += dtWall;
+
+  // hit-stop: the whole world freezes solid. Impact reads as weight.
+  if (fx.hitstop > 0) {
+    fx.hitstop -= dtWall;
+    decayFx(w, dtWall, true);
+    return;
+  }
+
+  // slow motion
+  let scale = 1;
+  if (fx.slowFor > 0) {
+    fx.slowT += dtWall;
+    const k = clamp01(fx.slowT / fx.slowFor);
+    const depth = fx.slow;
+    scale = 1 - depth * (1 - k) * (1 - k);
+    if (fx.slowT >= fx.slowFor) {
+      fx.slowFor = 0;
+      fx.slow = 0;
+      scale = 1;
+    }
+  }
+  const dt = Math.min(0.05, dtWall * scale);
+  if (w.phase === "play") w.t += dt;
+  w.stats.depth = w.t;
+
+  if (w.phase === "play") direct(w, dt);
+  const spd = speedMul(w);
+
+  stepPlayer(w, dt);
+  stepEnemies(w, dt, spd);
+  stepBullets(w, dt, spd);
+  stepParticles(w, dt);
+  stepTexts(w, dt);
+  decayFx(w, dtWall, false);
+
+  if (w.phase === "dying" && fx.slowFor === 0) {
+    w.phase = "revive";
+    w.events.push("revive-offer");
+  }
+}
+
+function decayFx(w: World, dt: number, frozen: boolean): void {
+  const fx = w.fx;
+  fx.trauma = Math.max(0, fx.trauma - dt * 1.9);
+  fx.flash = Math.max(0, fx.flash - dt * 4.2);
+  fx.ab = Math.max(0, fx.ab - dt * 3);
+  fx.glow = approach(fx.glow, 0, 0.25, dt);
+  if (fx.punch > 0) {
+    fx.punchT += dt;
+    if (fx.punchT > 0.5) fx.punch = 0;
+  }
+  if (!frozen) stepWaves(fx, dt);
+  w.cueT = Math.max(0, w.cueT - dt);
+  w.chainT = Math.max(0, w.chainT - dt);
+  w.coreShown = approach(w.coreShown, w.core, 0.045, dt);
+}
+
+function stepPlayer(w: World, dt: number): void {
+  if (w.phase === "dying" || w.phase === "revive" || w.phase === "over") {
+    w.polMorph = Math.min(1, w.polMorph + dt * 5);
+    return;
+  }
+  w.flipT = Math.max(0, w.flipT - dt);
+  w.polMorph = Math.min(1, w.polMorph + dt * 7.5);
+  w.invuln = Math.max(0, w.invuln - dt);
+  w.stun = Math.max(0, w.stun - dt);
+  w.recoil = Math.max(0, w.recoil - dt * 3.4);
+  w.overloadWarn = clamp01(Math.abs(w.core) / w.cap);
+
+  if (w.pointing) {
+    w.px = approach(w.px, w.tx, PLAYER.chaseHalfLife, dt);
+    w.py = approach(w.py, w.ty, PLAYER.chaseHalfLife, dt);
+    w.pvx = 0;
+    w.pvy = 0;
+  } else {
+    w.px += w.pvx * dt;
+    w.py += w.pvy * dt;
+    const f = Math.pow(PLAYER.friction, dt);
+    w.pvx *= f;
+    w.pvy *= f;
+  }
+  clampToField(w);
+
+  // engine wake
+  if (!w.reduced && w.rng.chance(0.75)) {
+    burst(w, w.px + w.rng.r(-1, 1), w.py - 3.4, 1, 16, polEdge(w.pol), {
+      life: 0.26,
+      size: 1.1,
+      dir: -Math.PI / 2,
+      spread: 0.8,
+    });
+  }
+
+  if (w.phase !== "play" || w.stun > 0) return;
+  w.fireT -= dt;
+  if (w.fireT <= 0) {
+    w.fireT += PLAYER.fireEvery;
+    const side = (w.stats.absorbs + Math.round(w.t * 12)) % 2 ? 1 : -1;
+    for (const s of [-1, 1]) {
+      const b = addBullet(w);
+      if (!b) break;
+      b.x = w.px + s * 2.4;
+      b.y = w.py + 2.6;
+      b.vx = s * 2 + w.rng.r(-1.5, 1.5);
+      b.vy = PLAYER.shotSpeed;
+      b.v = w.pol;
+      b.r = BULLET.shotR;
+      b.kind = BK.Shot;
+      b.owner = 1;
+      b.life = 1.6;
+      b.dmg = PLAYER.shotDamage;
+      b.rot = Math.PI / 2;
+    }
+    burst(w, w.px + side * 2.4, w.py + 3.2, 2, 26, polHot(w.pol), {
+      life: 0.12,
+      size: 1.2,
+      dir: Math.PI / 2,
+      spread: 0.7,
+    });
+    w.recoil = Math.max(w.recoil, 0.22);
+  }
+}
+
+function stepEnemies(w: World, dt: number, spd: number): void {
+  for (let i = 0; i < w.enemyN; ) {
+    const e = w.enemies[i] as Enemy;
+    if (!e.live) {
+      dropEnemy(w, i);
+      continue;
+    }
+    if (enemyIsBoss(e)) stepBoss(w, e, dt, spd);
+    else stepEnemy(w, e, dt, spd);
+
+    // ramming
+    if (w.phase === "play" && w.invuln <= 0) {
+      const spec = ENEMY[e.kind];
+      const rr = e.r * 0.72 + PLAYER.hit;
+      const dx = e.x - w.px;
+      const dy = e.y - w.py;
+      if ((spec?.ram || enemyIsBoss(e)) && dx * dx + dy * dy < rr * rr) {
+        hurt(w, e.x, e.y);
+        if (spec?.ram) e.hp = 0;
+      }
+    }
+
+    if (e.hp <= 0) {
+      enemyDeathFx(w, e);
+      const spec = ENEMY[e.kind];
+      w.stats.score += (spec?.score ?? 40) * chainMult(w.chain);
+      if (enemyIsBoss(e)) {
+        bossDefeated(w, e);
+        hitstop(w, 0.14);
+        slowmo(w, 0.6, 0.8);
+        shake(w, 0.8);
+        punch(w, 1);
+        flash(w, 0.28, COL.gold);
+      }
+      e.live = false;
+      dropEnemy(w, i);
+      continue;
+    }
+    if (!enemyIsBoss(e) && enemyEscaped(w, e)) {
+      e.live = false;
+      dropEnemy(w, i);
+      continue;
+    }
+    i++;
+  }
+}
+
+function dropEnemy(w: World, i: number): void {
+  w.enemyN--;
+  const last = w.enemies[w.enemyN] as Enemy;
+  w.enemies[w.enemyN] = w.enemies[i] as Enemy;
+  w.enemies[i] = last;
+}
+
+function stepBullets(w: World, dt: number, spd: number): void {
+  const alive = w.phase === "play";
+  const absorbR2 = PLAYER.absorb * PLAYER.absorb;
+  const grabR2 = (PLAYER.hit + 2.2) * (PLAYER.hit + 2.2);
+  const hurry = w.seal.state === "asking" ? 1 : 2.2;
+
+  for (let i = 0; i < w.bulletN; ) {
+    const b = w.bullets[i] as Bullet;
+    if (!b.live) {
+      dropBullet(w, i);
+      continue;
+    }
+    b.age += dt;
+    if (b.age >= b.life) {
+      if (b.seal > 0 && b.correct) {
+        // the answer left the field: nothing more to do, seal.ts already reported
+        b.live = false;
+      }
+      b.live = false;
+      dropBullet(w, i);
+      continue;
+    }
+
+    if (b.kind === BK.Orb) {
+      stepOrb(w, b, dt, hurry);
+      if (alive && absorbable(b.v, w.pol as 1 | -1)) {
+        const rr = b.r * 0.8 + PLAYER.hit;
+        const dx = b.x - w.px;
+        const dy = b.y - w.py;
+        if (dx * dx + dy * dy < rr * rr) {
+          onOrbTouched(w, b);
+          dropBullet(w, i);
+          continue;
+        }
+      }
+      i++;
+      continue;
+    }
+
+    if (b.owner === 2) {
+      // inert debris
+      b.x += b.vx * dt;
+      b.y += b.vy * dt;
+      b.vx *= Math.pow(0.2, dt);
+      b.vy *= Math.pow(0.2, dt);
+      b.rot += b.spin * dt;
+      i++;
+      continue;
+    }
+
+    if (b.homing > 0) {
+      let bx = 0;
+      let by = 0;
+      let best = Infinity;
+      for (let k = 0; k < w.enemyN; k++) {
+        const e = w.enemies[k] as Enemy;
+        const dx = e.x - b.x;
+        const dy = e.y - b.y;
+        const d = dx * dx + dy * dy;
+        if (d < best) {
+          best = d;
+          bx = e.x;
+          by = e.y;
+        }
+      }
+      if (best < Infinity) {
+        const want = Math.atan2(by - b.y, bx - b.x);
+        const cur = Math.atan2(b.vy, b.vx);
+        const na = cur + clamp(angDiff(cur, want), -b.homing * dt, b.homing * dt);
+        const sp = Math.hypot(b.vx, b.vy);
+        b.vx = Math.cos(na) * sp;
+        b.vy = Math.sin(na) * sp;
+        b.rot = na;
+      }
+      if (!w.reduced && w.rng.chance(0.5)) {
+        burst(w, b.x, b.y, 1, 6, polEdge(b.v), { life: 0.22, size: 0.85 });
+      }
+    }
+
+    const m = b.owner === 0 ? spd : 1;
+    b.x += b.vx * dt * m;
+    b.y += b.vy * dt * m;
+    b.rot += b.spin * dt;
+    if (b.grow > 0) b.grow = Math.max(0, b.grow - dt * 4);
+
+    if (b.owner === 1) {
+      // player ordnance vs enemies
+      let hitOne = false;
+      for (let k = 0; k < w.enemyN; k++) {
+        const e = w.enemies[k] as Enemy;
+        const rr = e.r + b.r;
+        const dx = e.x - b.x;
+        const dy = e.y - b.y;
+        if (dx * dx + dy * dy > rr * rr) continue;
+        let dmg = b.dmg;
+        if (e.pol !== 0 && e.pol !== b.v) dmg *= PLAYER.oppositeBonus; // Ikaruga's rule
+        if (e.lockState === 2) dmg *= 3; // a cracked seal is soft
+        e.hp -= dmg;
+        e.hitFlash = 1;
+        const col = polColor(b.v);
+        burst(w, b.x, b.y, dmg > b.dmg ? 7 : 3, dmg > b.dmg ? 40 : 22, col, {
+          life: 0.24,
+          size: dmg > b.dmg ? 1.4 : 1,
+        });
+        if (dmg > b.dmg) w.events.push("weak");
+        hitOne = true;
+        break;
+      }
+      if (hitOne || !inField(w, b.x, b.y, 12)) {
+        b.live = false;
+        dropBullet(w, i);
+        continue;
+      }
+      i++;
+      continue;
+    }
+
+    // hostile bullet vs player
+    if (alive) {
+      const dx = b.x - w.px;
+      const dy = b.y - w.py;
+      const d2 = dx * dx + dy * dy;
+      if (absorbable(b.v, w.pol as 1 | -1)) {
+        if (d2 < absorbR2 && w.stun <= 0) {
+          const d = Math.sqrt(d2) || 1;
+          const pull = 1 - d / PLAYER.absorb;
+          b.pull = Math.max(b.pull, pull);
+          const k = 340 * pull * pull * dt;
+          b.vx -= (dx / d) * k;
+          b.vy -= (dy / d) * k;
+          if (d2 < grabR2) {
+            absorb(w, b);
+            dropBullet(w, i);
+            continue;
+          }
+        } else b.pull = Math.max(0, b.pull - dt * 3);
+      } else {
+        b.pull = 0;
+        const rr = b.r * 0.62 + PLAYER.hit;
+        if (d2 < rr * rr) {
+          hurt(w, b.x, b.y);
+          b.live = false;
+          dropBullet(w, i);
+          continue;
+        }
+      }
+    }
+
+    if (!inField(w, b.x, b.y, 14)) {
+      b.live = false;
+      dropBullet(w, i);
+      continue;
+    }
+    i++;
+  }
+}
+
+function dropBullet(w: World, i: number): void {
+  w.bulletN--;
+  const last = w.bullets[w.bulletN] as Bullet;
+  w.bullets[w.bulletN] = w.bullets[i] as Bullet;
+  w.bullets[i] = last;
+}
+
+function stepParticles(w: World, dt: number): void {
+  for (let i = 0; i < w.partN; ) {
+    const p = w.parts[i] as Particle;
+    p.age += dt;
+    if (p.age >= p.life) {
+      p.live = false;
+      w.partN--;
+      const last = w.parts[w.partN] as Particle;
+      w.parts[w.partN] = p;
+      w.parts[i] = last;
+      continue;
+    }
+    if (p.kind !== 2) {
+      p.x += p.vx * dt;
+      p.y += p.vy * dt;
+      const f = Math.pow(p.drag, dt * 60);
+      p.vx *= f;
+      p.vy *= f;
+      p.rot += p.spin * dt;
+    }
+    i++;
+  }
+}
+
+function stepTexts(w: World, dt: number): void {
+  for (let i = 0; i < w.textN; ) {
+    const t = w.texts[i] as FloatText;
+    t.age += dt;
+    if (t.age >= t.life) {
+      t.live = false;
+      w.textN--;
+      const last = w.texts[w.textN] as FloatText;
+      w.texts[w.textN] = t;
+      w.texts[i] = last;
+      continue;
+    }
+    t.y += t.vy * dt;
+    t.vy *= Math.pow(0.06, dt);
+    i++;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// run lifecycle
+// ---------------------------------------------------------------------------
+
+export function startRun(w: World): void {
+  w.phase = "play";
+  w.t = 0;
+  w.px = 0;
+  w.py = -w.halfH * 0.62;
+  w.tx = w.px;
+  w.ty = w.py;
+  w.pvx = 0;
+  w.pvy = 0;
+  w.pol = 1;
+  w.polMorph = 1;
+  w.shields = PLAYER.shields;
+  w.invuln = 1.2;
+  w.stun = 0;
+  w.core = 0;
+  w.coreShown = 0;
+  w.cap = CORE.capBase;
+  w.chain = 0;
+  w.bulletN = 0;
+  w.enemyN = 0;
+  w.partN = 0;
+  w.textN = 0;
+  w.spawnAcc = 0;
+  w.stratum = 0;
+  w.bearerCount = 0;
+  w.bossActive = false;
+  w.bank = 1;
+  w.nextBearer = PACE.firstBearer;
+  w.seal.state = "idle";
+  w.seal.q = null;
+  w.fx.waveN = 0;
+  w.stats.score = 0;
+  w.stats.absorbs = 0;
+  w.stats.clutches = 0;
+  w.stats.bestChain = 0;
+  w.stats.asked = 0;
+  w.stats.right = 0;
+  w.stats.releases = 0;
+  w.stats.perfects = 0;
+  w.stats.overloads = 0;
+  w.events.push("start");
+  shockwave(w, w.px, w.py, 1.2, 1, 0.8);
+}
+
+export function revive(w: World): void {
+  w.phase = "play";
+  w.shields = PLAYER.shields;
+  w.invuln = 2.4;
+  w.stun = 0;
+  w.core = 0;
+  w.bank = 0;
+  w.events.push("revive");
+  // clear the field and pay for every bullet cleared
+  let cleared = 0;
+  for (let i = 0; i < w.bulletN; i++) {
+    const b = w.bullets[i] as Bullet;
+    if (b.owner !== 0) continue;
+    burst(w, b.x, b.y, 3, 40, COL.gold, { life: 0.5, size: 1.2 });
+    b.live = false;
+    cleared++;
+  }
+  w.stats.score += cleared * 40;
+  hitstop(w, 0.12);
+  slowmo(w, 0.5, 0.7);
+  shake(w, 0.7);
+  punch(w, 1);
+  flash(w, 0.3, COL.gold);
+  shockwave(w, w.px, w.py, 2.4, 0, 1.2);
+  for (let r = 0; r < 4; r++) ring(w, w.px, w.py, 4 + r * 9, COL.gold, 0.7 + r * 0.1, 2.6);
+  burst(w, w.px, w.py, 90, 130, COL.gold, { life: 1, size: 2.6, kind: 1 });
+  w.host.haptic("success");
+}
+
+export function endRun(w: World): void {
+  w.phase = "over";
+  if (w.stats.score > w.stats.best) w.stats.best = w.stats.score;
+  w.events.push("over");
+}
+
+/** Absorb-radius aura pulse used by the renderer; kept here so tests can see it. */
+export const auraPulse = (w: World): number =>
+  0.55 + 0.45 * Math.sin(w.wall * 3.1) * (1 - clamp01(w.overloadWarn));
+
+export const chainMultiplier = (w: World): number => chainMult(w.chain);
+export const TAU_ = TAU;

--- a/dynawalla/games/polarity/src/game/types.ts
+++ b/dynawalla/games/polarity/src/game/types.ts
@@ -1,0 +1,132 @@
+import type { Question } from "../contract.ts";
+import type { BK, EK } from "./constants.ts";
+
+/**
+ * Every entity is a pooled, monomorphic plain object. Pools never shrink and
+ * nothing is allocated during a frame — the free list hands back the same
+ * objects for the whole session, so V8 keeps one hidden class per pool and the
+ * GC has nothing to collect while the player is dodging.
+ */
+
+export type Bullet = {
+  live: boolean;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  /** signed value. Its SIGN is its polarity; 0 is neutral and always absorbable. */
+  v: number;
+  r: number;
+  kind: BK;
+  /** 0 = hostile, 1 = the player's */
+  owner: number;
+  rot: number;
+  spin: number;
+  age: number;
+  life: number;
+  /** atlas tile for the printed numeral, -1 for none */
+  label: number;
+  /** >0 = homing strength (darts) */
+  homing: number;
+  /** currently being sucked into the ship: 0..1 */
+  pull: number;
+  /** seal serial this orb belongs to, 0 = not a seal orb */
+  seal: number;
+  /** for seal orbs only */
+  correct: number;
+  dmg: number;
+  wob: number;
+  grow: number;
+};
+
+export type Enemy = {
+  live: boolean;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  kind: EK;
+  pol: number;
+  hp: number;
+  maxHp: number;
+  r: number;
+  age: number;
+  fireT: number;
+  phase: number;
+  rot: number;
+  spin: number;
+  hitFlash: number;
+  seed: number;
+  /** entry/hover choreography target */
+  ax: number;
+  ay: number;
+  /** boss only: the core value the lock demands */
+  lockWant: number;
+  lockState: number;
+  /** boss/bearer only: which seal serial it owns */
+  seal: number;
+  dying: number;
+};
+
+export type Particle = {
+  live: boolean;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  age: number;
+  life: number;
+  size: number;
+  size2: number;
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+  rot: number;
+  spin: number;
+  drag: number;
+  /** 0 dot · 1 shard · 2 ring · 3 spark-line */
+  kind: number;
+};
+
+export type FloatText = {
+  live: boolean;
+  x: number;
+  y: number;
+  vy: number;
+  age: number;
+  life: number;
+  /** atlas tile index */
+  label: number;
+  size: number;
+  r: number;
+  g: number;
+  b: number;
+};
+
+export type SealState = "idle" | "asking" | "won" | "lost";
+
+export type Seal = {
+  serial: number;
+  state: SealState;
+  q: Question | null;
+  askedAt: number;
+  /** what the player flew into, for the report */
+  answered: string;
+};
+
+export type RunStats = {
+  score: number;
+  best: number;
+  depth: number;
+  absorbs: number;
+  clutches: number;
+  bestChain: number;
+  asked: number;
+  right: number;
+  releases: number;
+  perfects: number;
+  overloads: number;
+};
+
+export type Phase = "title" | "play" | "dying" | "revive" | "over";

--- a/dynawalla/games/polarity/src/game/world.ts
+++ b/dynawalla/games/polarity/src/game/world.ts
@@ -1,0 +1,570 @@
+import type { Host } from "../contract.ts";
+import { makeRng, type Rng } from "../core/rng.ts";
+import type { Tier } from "../core/tier.ts";
+import { TAU, clamp, clamp01 } from "../core/util.ts";
+import { BK, CORE, EK, HALF_W, MAX_HALF_H, MIN_HALF_H, PLAYER } from "./constants.ts";
+import type { Bullet, Enemy, FloatText, Particle, Phase, RunStats, Seal } from "./types.ts";
+
+// ---------------------------------------------------------------------------
+// screen feel — written by the sim, read by the renderer
+// ---------------------------------------------------------------------------
+
+export type Fx = {
+  /** Art-of-Screenshake trauma: shake is trauma², so it decays perceptually. */
+  trauma: number;
+  /** one-shot scale punch */
+  punch: number;
+  punchT: number;
+  /** rotational kick */
+  tilt: number;
+  /** frames frozen solid on impact */
+  hitstop: number;
+  /** 0..1, how far into slow-motion we are */
+  slow: number;
+  slowT: number;
+  slowFor: number;
+  /** full-screen wash: alpha, rgb. Rate-limited — children's product. */
+  flash: number;
+  flashR: number;
+  flashG: number;
+  flashB: number;
+  flashAt: number;
+  flashCount: number;
+  flashWindow: number;
+  /** chromatic aberration amount 0..1 */
+  ab: number;
+  /** additive bloom drive */
+  glow: number;
+  /** shockwave rings: x,y,age,life,strength,pol */
+  waves: Float32Array;
+  waveN: number;
+};
+
+const WAVE_STRIDE = 6;
+const WAVE_MAX = 24;
+
+export function makeFx(): Fx {
+  return {
+    trauma: 0,
+    punch: 0,
+    punchT: 0,
+    tilt: 0,
+    hitstop: 0,
+    slow: 0,
+    slowT: 0,
+    slowFor: 0,
+    flash: 0,
+    flashR: 1,
+    flashG: 1,
+    flashB: 1,
+    flashAt: -99,
+    flashCount: 0,
+    flashWindow: 0,
+    ab: 0,
+    glow: 0,
+    waves: new Float32Array(WAVE_MAX * WAVE_STRIDE),
+    waveN: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// world
+// ---------------------------------------------------------------------------
+
+export type World = {
+  host: Host;
+  rng: Rng;
+  tier: Tier;
+  reduced: boolean;
+
+  phase: Phase;
+  /** seconds of simulated play (excludes pauses, includes slow-motion at real rate) */
+  t: number;
+  /** wall time, for cadence that should not be slowed */
+  wall: number;
+  halfH: number;
+
+  // player
+  px: number;
+  py: number;
+  pvx: number;
+  pvy: number;
+  /** pointer/keyboard target */
+  tx: number;
+  ty: number;
+  pointing: boolean;
+  pol: number;
+  polMorph: number;
+  flipT: number;
+  fireT: number;
+  shields: number;
+  invuln: number;
+  stun: number;
+  recoil: number;
+  bank: number;
+
+  // core
+  core: number;
+  coreShown: number;
+  cap: number;
+  chain: number;
+  chainT: number;
+  overloadWarn: number;
+
+  // pools
+  bullets: Bullet[];
+  bulletN: number;
+  enemies: Enemy[];
+  enemyN: number;
+  parts: Particle[];
+  partN: number;
+  texts: FloatText[];
+  textN: number;
+
+  // director
+  spawnAcc: number;
+  nextBearer: number;
+  bearerCount: number;
+  stratum: number;
+  bossActive: boolean;
+  hush: number;
+
+  seal: Seal;
+  sealSerial: number;
+  /** current question text; the renderer bakes a texture when `promptV` changes */
+  prompt: string;
+  promptV: number;
+
+  stats: RunStats;
+  fx: Fx;
+
+  /** one-shot UI cues, shown at most once ever */
+  cues: Set<string>;
+  cueNow: string;
+  cueT: number;
+
+  /** set by the sim, consumed by the shell */
+  events: string[];
+};
+
+const mkBullet = (): Bullet => ({
+  live: false,
+  x: 0,
+  y: 0,
+  vx: 0,
+  vy: 0,
+  v: 0,
+  r: 1,
+  kind: BK.Chaff,
+  owner: 0,
+  rot: 0,
+  spin: 0,
+  age: 0,
+  life: 8,
+  label: -1,
+  homing: 0,
+  pull: 0,
+  seal: 0,
+  correct: 0,
+  dmg: 1,
+  wob: 0,
+  grow: 0,
+});
+
+const mkEnemy = (): Enemy => ({
+  live: false,
+  x: 0,
+  y: 0,
+  vx: 0,
+  vy: 0,
+  kind: EK.Mote,
+  pol: 1,
+  hp: 1,
+  maxHp: 1,
+  r: 3,
+  age: 0,
+  fireT: 0,
+  phase: 0,
+  rot: 0,
+  spin: 0,
+  hitFlash: 0,
+  seed: 0,
+  ax: 0,
+  ay: 0,
+  lockWant: 0,
+  lockState: 0,
+  seal: 0,
+  dying: 0,
+});
+
+const mkPart = (): Particle => ({
+  live: false,
+  x: 0,
+  y: 0,
+  vx: 0,
+  vy: 0,
+  age: 0,
+  life: 1,
+  size: 1,
+  size2: 1,
+  r: 1,
+  g: 1,
+  b: 1,
+  a: 1,
+  rot: 0,
+  spin: 0,
+  drag: 1,
+  kind: 0,
+});
+
+const mkText = (): FloatText => ({
+  live: false,
+  x: 0,
+  y: 0,
+  vy: 0,
+  age: 0,
+  life: 1,
+  label: 0,
+  size: 1,
+  r: 1,
+  g: 1,
+  b: 1,
+});
+
+function fill<T>(n: number, f: () => T): T[] {
+  const a: T[] = new Array(n);
+  for (let i = 0; i < n; i++) a[i] = f();
+  return a;
+}
+
+export function makeWorld(host: Host, tier: Tier, seed: number): World {
+  const w: World = {
+    host,
+    rng: makeRng(seed),
+    tier,
+    reduced: host.prefersReducedMotion(),
+    phase: "title",
+    t: 0,
+    wall: 0,
+    halfH: 70,
+    px: 0,
+    py: -40,
+    pvx: 0,
+    pvy: 0,
+    tx: 0,
+    ty: -40,
+    pointing: false,
+    pol: 1,
+    polMorph: 1,
+    flipT: 0,
+    fireT: 0,
+    shields: PLAYER.shields,
+    invuln: 0,
+    stun: 0,
+    recoil: 0,
+    bank: 1,
+    core: 0,
+    coreShown: 0,
+    cap: CORE.capBase,
+    chain: 0,
+    chainT: 0,
+    overloadWarn: 0,
+    bullets: fill(tier.bullets, mkBullet),
+    bulletN: 0,
+    enemies: fill(48, mkEnemy),
+    enemyN: 0,
+    parts: fill(tier.particles, mkPart),
+    partN: 0,
+    texts: fill(64, mkText),
+    textN: 0,
+    spawnAcc: 0,
+    nextBearer: 0,
+    bearerCount: 0,
+    stratum: 0,
+    bossActive: false,
+    hush: 0,
+    seal: { serial: 0, state: "idle", q: null, askedAt: 0, answered: "" },
+    sealSerial: 0,
+    prompt: "",
+    promptV: 0,
+    stats: {
+      score: 0,
+      best: 0,
+      depth: 0,
+      absorbs: 0,
+      clutches: 0,
+      bestChain: 0,
+      asked: 0,
+      right: 0,
+      releases: 0,
+      perfects: 0,
+      overloads: 0,
+    },
+    fx: makeFx(),
+    cues: new Set(),
+    cueNow: "",
+    cueT: 0,
+    events: [],
+  };
+  return w;
+}
+
+/** Re-pool when the tier changes; keeps everything that is currently alive. */
+export function repool(w: World, tier: Tier): void {
+  w.tier = tier;
+  while (w.bullets.length < tier.bullets) w.bullets.push(mkBullet());
+  while (w.parts.length < tier.particles) w.parts.push(mkPart());
+  w.bulletN = Math.min(w.bulletN, tier.bullets);
+  w.partN = Math.min(w.partN, tier.particles);
+}
+
+export function setAspect(w: World, aspect: number): void {
+  w.halfH = clamp(HALF_W * aspect, MIN_HALF_H, MAX_HALF_H);
+}
+
+// ---------------------------------------------------------------------------
+// pool acquire — swap-remove compaction keeps every live entity contiguous
+// ---------------------------------------------------------------------------
+
+export function addBullet(w: World): Bullet | null {
+  const cap = w.tier.bullets;
+  if (w.bulletN >= cap) return null;
+  const b = w.bullets[w.bulletN] as Bullet;
+  w.bulletN++;
+  b.live = true;
+  b.age = 0;
+  b.life = 9;
+  b.label = -1;
+  b.homing = 0;
+  b.pull = 0;
+  b.seal = 0;
+  b.correct = 0;
+  b.dmg = 1;
+  b.wob = 0;
+  b.grow = 0;
+  b.spin = 0;
+  b.rot = 0;
+  b.owner = 0;
+  b.v = 0;
+  return b;
+}
+
+export function addEnemy(w: World): Enemy | null {
+  if (w.enemyN >= w.enemies.length) return null;
+  const e = w.enemies[w.enemyN] as Enemy;
+  w.enemyN++;
+  e.live = true;
+  e.age = 0;
+  e.fireT = 0;
+  e.phase = 0;
+  e.hitFlash = 0;
+  e.rot = 0;
+  e.spin = 0;
+  e.dying = 0;
+  e.lockWant = 0;
+  e.lockState = 0;
+  e.seal = 0;
+  e.seed = w.rng.f() * 1000;
+  return e;
+}
+
+export function addPart(w: World): Particle | null {
+  if (w.partN >= w.tier.particles) return null;
+  const p = w.parts[w.partN] as Particle;
+  w.partN++;
+  p.live = true;
+  p.age = 0;
+  p.drag = 1;
+  p.rot = 0;
+  p.spin = 0;
+  p.kind = 0;
+  p.size2 = 0;
+  return p;
+}
+
+export function addText(w: World, label: number, x: number, y: number, c: readonly number[]): void {
+  if (w.textN >= w.texts.length) return;
+  const t = w.texts[w.textN] as FloatText;
+  w.textN++;
+  t.live = true;
+  t.x = x;
+  t.y = y;
+  t.vy = 26;
+  t.age = 0;
+  t.life = 0.95;
+  t.label = label;
+  t.size = 6.4;
+  t.r = c[0] as number;
+  t.g = c[1] as number;
+  t.b = c[2] as number;
+}
+
+// ---------------------------------------------------------------------------
+// fx helpers
+// ---------------------------------------------------------------------------
+
+export function shake(w: World, amount: number): void {
+  if (w.reduced) return;
+  w.fx.trauma = Math.min(1, w.fx.trauma + amount);
+}
+
+export function punch(w: World, amount: number): void {
+  if (w.reduced) amount *= 0.3;
+  if (amount > w.fx.punch) {
+    w.fx.punch = Math.min(1, amount);
+    w.fx.punchT = 0;
+  }
+}
+
+export function hitstop(w: World, seconds: number): void {
+  w.fx.hitstop = Math.max(w.fx.hitstop, w.reduced ? seconds * 0.4 : seconds);
+}
+
+export function slowmo(w: World, seconds: number, depth = 1): void {
+  const s = w.reduced ? seconds * 0.5 : seconds;
+  if (s > w.fx.slowFor - w.fx.slowT) {
+    w.fx.slowFor = s;
+    w.fx.slowT = 0;
+    w.fx.slow = depth;
+  }
+}
+
+/**
+ * A full-screen wash. Hard-limited to 3 per second and to a modest alpha —
+ * this is a children's product and photosensitivity is not negotiable.
+ */
+export function flash(w: World, a: number, c: readonly number[]): void {
+  const fx = w.fx;
+  if (w.wall - fx.flashWindow > 1) {
+    fx.flashWindow = w.wall;
+    fx.flashCount = 0;
+  }
+  if (fx.flashCount >= 3) return;
+  fx.flashCount++;
+  fx.flashAt = w.wall;
+  const cap = w.reduced ? 0.14 : 0.4;
+  fx.flash = Math.max(fx.flash, Math.min(cap, a));
+  fx.flashR = c[0] as number;
+  fx.flashG = c[1] as number;
+  fx.flashB = c[2] as number;
+}
+
+export function shockwave(
+  w: World,
+  x: number,
+  y: number,
+  strength: number,
+  pol: number,
+  life = 0.6,
+): void {
+  const fx = w.fx;
+  if (fx.waveN >= WAVE_MAX) return;
+  const i = fx.waveN * WAVE_STRIDE;
+  fx.waves[i] = x;
+  fx.waves[i + 1] = y;
+  fx.waves[i + 2] = 0;
+  fx.waves[i + 3] = life;
+  fx.waves[i + 4] = strength;
+  fx.waves[i + 5] = pol;
+  fx.waveN++;
+}
+
+export function stepWaves(fx: Fx, dt: number): void {
+  for (let i = 0; i < fx.waveN; ) {
+    const o = i * WAVE_STRIDE;
+    fx.waves[o + 2] = (fx.waves[o + 2] as number) + dt;
+    if ((fx.waves[o + 2] as number) >= (fx.waves[o + 3] as number)) {
+      fx.waveN--;
+      const l = fx.waveN * WAVE_STRIDE;
+      for (let k = 0; k < WAVE_STRIDE; k++) fx.waves[o + k] = fx.waves[l + k] as number;
+    } else i++;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// particle bursts
+// ---------------------------------------------------------------------------
+
+export function burst(
+  w: World,
+  x: number,
+  y: number,
+  n: number,
+  speed: number,
+  col: readonly number[],
+  opts?: { life?: number; size?: number; kind?: number; spread?: number; dir?: number },
+): void {
+  const count = Math.max(1, Math.round(n * w.tier.partScale * (w.reduced ? 0.4 : 1)));
+  const life = opts?.life ?? 0.55;
+  const size = opts?.size ?? 1.5;
+  const kind = opts?.kind ?? 0;
+  const spread = opts?.spread ?? TAU;
+  const dir = opts?.dir ?? 0;
+  for (let i = 0; i < count; i++) {
+    const p = addPart(w);
+    if (!p) return;
+    const a = dir + (w.rng.f() - 0.5) * spread;
+    const s = speed * (0.35 + w.rng.f() * 0.9);
+    p.x = x;
+    p.y = y;
+    p.vx = Math.cos(a) * s;
+    p.vy = Math.sin(a) * s;
+    p.life = life * (0.6 + w.rng.f() * 0.8);
+    p.size = size * (0.55 + w.rng.f() * 0.9);
+    p.size2 = p.size;
+    p.r = col[0] as number;
+    p.g = col[1] as number;
+    p.b = col[2] as number;
+    p.a = 1;
+    p.kind = kind;
+    p.rot = w.rng.f() * TAU;
+    p.spin = (w.rng.f() - 0.5) * 14;
+    p.drag = 0.86;
+  }
+}
+
+export function ring(
+  w: World,
+  x: number,
+  y: number,
+  r0: number,
+  col: readonly number[],
+  life = 0.42,
+  width = 1.4,
+): void {
+  const p = addPart(w);
+  if (!p) return;
+  p.x = x;
+  p.y = y;
+  p.vx = 0;
+  p.vy = 0;
+  p.life = life;
+  p.size = r0;
+  p.size2 = width;
+  p.r = col[0] as number;
+  p.g = col[1] as number;
+  p.b = col[2] as number;
+  p.a = 1;
+  p.kind = 2;
+  p.rot = 0;
+  p.spin = 0;
+  p.drag = 1;
+}
+
+export function cue(w: World, key: string, seconds = 2.2): void {
+  if (w.cues.has(key)) return;
+  w.cues.add(key);
+  w.cueNow = key;
+  w.cueT = seconds;
+}
+
+export const inField = (w: World, x: number, y: number, pad = 8): boolean =>
+  x > -HALF_W - pad && x < HALF_W + pad && y > -w.halfH - pad && y < w.halfH + pad;
+
+export const clampToField = (w: World): void => {
+  const m = 3;
+  w.px = clamp(w.px, -HALF_W + m, HALF_W - m);
+  w.py = clamp(w.py, -w.halfH + m, w.halfH - m);
+};
+
+export const chainAlpha = (w: World): number => clamp01(w.chainT / 1.2);

--- a/dynawalla/games/polarity/src/index.ts
+++ b/dynawalla/games/polarity/src/index.ts
@@ -1,0 +1,3 @@
+/** The pack entry point. `mount` matches ./contract.ts exactly. */
+export { mount } from "./mount.ts";
+export type { Host, Question } from "./contract.ts";

--- a/dynawalla/games/polarity/src/input/input.ts
+++ b/dynawalla/games/polarity/src/input/input.ts
@@ -1,0 +1,177 @@
+import { PLAYER } from "../game/constants.ts";
+import { flip, release } from "../game/sim.ts";
+import type { World } from "../game/world.ts";
+import { fit, toWorldX, toWorldY } from "../render/view.ts";
+
+/**
+ * Touch is primary — this is a form that lives on a tablet — and desktop is a
+ * first-class second, not a fallback.
+ *
+ * TOUCH   drag anywhere to fly (relative, so your thumb never covers the ship);
+ *         a quick tap flips; a second finger flips without letting go; the two
+ *         big pads flip and vent for anyone who never discovers the gestures.
+ * MOUSE   the ship tracks the cursor 1:1; left click flips, right click vents.
+ * KEYS    arrows/WASD fly, Space/J flips, Shift/K vents, P or Esc pauses.
+ */
+
+export type InputHooks = {
+  onPause: () => void;
+  onAnyInput: () => void;
+  /** the shell handles taps on overlays itself; input is suspended then */
+  isBlocked: () => boolean;
+};
+
+const TAP_MS = 190;
+const TAP_PX = 14;
+
+export class Input {
+  private keys = new Set<string>();
+  private primary = -1;
+  private downAt = 0;
+  private downX = 0;
+  private downY = 0;
+  private shipX = 0;
+  private shipY = 0;
+  private moved = 0;
+  private readonly off: (() => void)[] = [];
+
+  constructor(
+    private readonly el: HTMLElement,
+    private readonly w: World,
+    private readonly hooks: InputHooks,
+  ) {
+    const on = <K extends keyof HTMLElementEventMap>(
+      t: HTMLElement | Window | Document,
+      k: K | string,
+      f: (e: never) => void,
+      opts?: AddEventListenerOptions,
+    ): void => {
+      t.addEventListener(k, f as EventListener, opts);
+      this.off.push(() => t.removeEventListener(k, f as EventListener, opts));
+    };
+
+    on(el, "pointerdown", (e: PointerEvent) => this.down(e), { passive: false });
+    on(el, "pointermove", (e: PointerEvent) => this.move(e), { passive: false });
+    on(el, "pointerup", (e: PointerEvent) => this.up(e));
+    on(el, "pointercancel", (e: PointerEvent) => this.up(e));
+    on(el, "contextmenu", (e: Event) => e.preventDefault());
+    on(window, "keydown", (e: KeyboardEvent) => this.key(e, true));
+    on(window, "keyup", (e: KeyboardEvent) => this.key(e, false));
+    on(window, "blur", () => this.keys.clear());
+  }
+
+  dispose(): void {
+    for (const f of this.off) f();
+    this.off.length = 0;
+  }
+
+  private frame(): { f: ReturnType<typeof fit>; w: number; h: number; rect: DOMRect } {
+    const rect = this.el.getBoundingClientRect();
+    return { f: fit(rect.width, rect.height, this.w.halfH), w: rect.width, h: rect.height, rect };
+  }
+
+  private down(e: PointerEvent): void {
+    this.hooks.onAnyInput();
+    if (this.hooks.isBlocked()) return;
+    e.preventDefault();
+    if (e.pointerType === "mouse") {
+      if (e.button === 2) release(this.w);
+      else flip(this.w);
+      return;
+    }
+    if (this.primary !== -1) {
+      // a second finger is the flip, so you never have to stop flying
+      flip(this.w);
+      return;
+    }
+    this.primary = e.pointerId;
+    this.el.setPointerCapture?.(e.pointerId);
+    const { f, w: cw, h: ch, rect } = this.frame();
+    this.downX = toWorldX(e.clientX - rect.left, cw, f);
+    this.downY = toWorldY(e.clientY - rect.top, ch, f);
+    this.shipX = this.w.px;
+    this.shipY = this.w.py;
+    this.downAt = performance.now();
+    this.moved = 0;
+    this.w.pointing = true;
+    this.w.tx = this.w.px;
+    this.w.ty = this.w.py;
+  }
+
+  private move(e: PointerEvent): void {
+    if (this.hooks.isBlocked()) return;
+    const { f, w: cw, h: ch, rect } = this.frame();
+    const wx = toWorldX(e.clientX - rect.left, cw, f);
+    const wy = toWorldY(e.clientY - rect.top, ch, f);
+    if (e.pointerType === "mouse") {
+      this.w.pointing = true;
+      this.w.tx = wx;
+      this.w.ty = wy;
+      return;
+    }
+    if (e.pointerId !== this.primary) return;
+    e.preventDefault();
+    const dx = wx - this.downX;
+    const dy = wy - this.downY;
+    this.moved = Math.max(this.moved, Math.hypot(dx, dy) * f.scale);
+    // slight gain so the far corners are reachable without a full-screen swipe
+    this.w.tx = this.shipX + dx * 1.18;
+    this.w.ty = this.shipY + dy * 1.18;
+  }
+
+  private up(e: PointerEvent): void {
+    if (e.pointerId !== this.primary) return;
+    this.primary = -1;
+    const quick = performance.now() - this.downAt < TAP_MS && this.moved < TAP_PX;
+    if (quick && !this.hooks.isBlocked()) flip(this.w);
+    // the ship holds its last position rather than snapping anywhere
+    this.w.tx = this.w.px;
+    this.w.ty = this.w.py;
+  }
+
+  private key(e: KeyboardEvent, down: boolean): void {
+    const c = e.code;
+    if (down) this.hooks.onAnyInput();
+    const nav =
+      c === "ArrowLeft" ||
+      c === "ArrowRight" ||
+      c === "ArrowUp" ||
+      c === "ArrowDown" ||
+      c === "KeyW" ||
+      c === "KeyA" ||
+      c === "KeyS" ||
+      c === "KeyD" ||
+      c === "Space";
+    if (nav) e.preventDefault();
+    if (down) {
+      if (this.keys.has(c)) return;
+      this.keys.add(c);
+      if (this.hooks.isBlocked()) return;
+      if (c === "Space" || c === "KeyJ" || c === "KeyZ") flip(this.w);
+      else if (c === "ShiftLeft" || c === "ShiftRight" || c === "KeyK" || c === "KeyX")
+        release(this.w);
+      else if (c === "KeyP" || c === "Escape") this.hooks.onPause();
+    } else this.keys.delete(c);
+  }
+
+  /** Keyboard flight, integrated once per frame. */
+  step(dt: number): void {
+    const k = this.keys;
+    const lx = (k.has("ArrowRight") || k.has("KeyD") ? 1 : 0) - (k.has("ArrowLeft") || k.has("KeyA") ? 1 : 0);
+    const ly = (k.has("ArrowUp") || k.has("KeyW") ? 1 : 0) - (k.has("ArrowDown") || k.has("KeyS") ? 1 : 0);
+    if (lx === 0 && ly === 0) return;
+    this.w.pointing = false;
+    const m = Math.hypot(lx, ly) || 1;
+    this.w.pvx += (lx / m) * PLAYER.accel * dt;
+    this.w.pvy += (ly / m) * PLAYER.accel * dt;
+    const sp = Math.hypot(this.w.pvx, this.w.pvy);
+    if (sp > PLAYER.maxSpeed) {
+      this.w.pvx = (this.w.pvx / sp) * PLAYER.maxSpeed;
+      this.w.pvy = (this.w.pvy / sp) * PLAYER.maxSpeed;
+    }
+  }
+
+  /** Called by the HUD pads. */
+  static flip = flip;
+  static release = release;
+}

--- a/dynawalla/games/polarity/src/main.ts
+++ b/dynawalla/games/polarity/src/main.ts
@@ -1,0 +1,17 @@
+/**
+ * Standalone dev entry: the local stub Host so `npm run dev` is the real game.
+ * The runtime lands underneath this later; nothing else changes.
+ */
+import { mount } from "./index.ts";
+import { makeStubHost } from "./stubHost.ts";
+
+const el = document.getElementById("app");
+if (!el) throw new Error("[polarity] #app missing");
+
+const seed = Number(new URL(location.href).searchParams.get("seed") ?? "") || 0x50147;
+const host = makeStubHost({ seed });
+const handle = mount(el, host);
+
+// keep hot-reload from stacking instances
+const h = import.meta as unknown as { hot?: { dispose(cb: () => void): void } };
+h.hot?.dispose(() => handle.unmount());

--- a/dynawalla/games/polarity/src/math/signed.test.ts
+++ b/dynawalla/games/polarity/src/math/signed.test.ts
@@ -1,0 +1,99 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  MINUS,
+  absorbable,
+  bandLoad,
+  chainMult,
+  coreAfter,
+  fmtInt,
+  fmtSigned,
+  lockResult,
+  overloaded,
+  parseInt_,
+  polarityOf,
+  releaseYield,
+} from "./signed.ts";
+
+test("fmtSigned uses a real minus sign and an explicit plus", () => {
+  assert.equal(fmtSigned(7), "+7");
+  assert.equal(fmtSigned(0), "0");
+  assert.equal(fmtSigned(-5), `${MINUS}5`);
+  assert.throws(() => fmtSigned(1.5));
+});
+
+test("fmtInt / parseInt_ round-trip every integer we ever display", () => {
+  for (let n = -99; n <= 99; n++) {
+    assert.equal(parseInt_(fmtInt(n)), n);
+    assert.equal(parseInt_(fmtSigned(n)), n);
+  }
+  assert.throws(() => parseInt_("seven"));
+  assert.throws(() => parseInt_("1.5"));
+});
+
+test("zero is the origin: absorbable in either polarity", () => {
+  assert.equal(polarityOf(0), 0);
+  assert.equal(absorbable(0, 1), true);
+  assert.equal(absorbable(0, -1), true);
+  assert.equal(absorbable(4, 1), true);
+  assert.equal(absorbable(4, -1), false);
+  assert.equal(absorbable(-4, -1), true);
+  assert.equal(absorbable(-4, 1), false);
+});
+
+test("absorbing is plain integer addition, including negatives", () => {
+  assert.equal(coreAfter(0, -7), -7);
+  assert.equal(coreAfter(-7, -7), -14);
+  assert.equal(coreAfter(-14, 20), 6);
+  // and it is exact for long chains
+  let c = 0;
+  const vs = [-9, 4, -3, 12, -1, -1, 8, -20, 7];
+  for (const v of vs) c = coreAfter(c, v);
+  assert.equal(
+    c,
+    vs.reduce((a, b) => a + b, 0),
+  );
+  assert.equal(c, -3);
+});
+
+test("the band is symmetric and exclusive at the edge", () => {
+  assert.equal(overloaded(20, 20), false);
+  assert.equal(overloaded(-20, 20), false);
+  assert.equal(overloaded(21, 20), true);
+  assert.equal(overloaded(-21, 20), true);
+  assert.equal(bandLoad(-10, 20), 0.5);
+  assert.equal(bandLoad(0, 20), 0);
+  assert.equal(bandLoad(20, 20), 1);
+});
+
+test("release pays the accumulated total, both signs equally", () => {
+  const pos = releaseYield(18, 20, 1);
+  const neg = releaseYield(-18, 20, 1);
+  assert.deepEqual(pos, neg, "sign must never change the payout");
+  assert.equal(pos.perfect, true);
+  assert.equal(releaseYield(2, 20, 1).darts, 0, "a fizzle below 3 stops spam");
+  assert.equal(releaseYield(10, 20, 1).perfect, false);
+  assert.equal(releaseYield(20, 20, 1).perfect, true);
+  assert.equal(releaseYield(17, 20, 1).perfect, false);
+  // perfect is worth exactly 3x the score of the same magnitude un-perfect
+  assert.equal(releaseYield(18, 20, 1).score, 18 * 25 * 3);
+  assert.equal(releaseYield(18, 40, 1).score, 18 * 25);
+  // darts never exceed the pool budget
+  assert.ok(releaseYield(120, 120, 9).darts <= 36);
+});
+
+test("chain multiplier is stepped and capped", () => {
+  assert.equal(chainMult(0), 1);
+  assert.equal(chainMult(5), 1);
+  assert.equal(chainMult(6), 2);
+  assert.equal(chainMult(48), 9);
+  assert.equal(chainMult(9999), 9);
+});
+
+test("lock tolerance rewards exactness but still pays a near miss", () => {
+  assert.equal(lockResult(-14, -14), "exact");
+  assert.equal(lockResult(-12, -14), "near");
+  assert.equal(lockResult(-16, -14), "near");
+  assert.equal(lockResult(-11, -14), "miss");
+  assert.equal(lockResult(14, -14), "miss");
+});

--- a/dynawalla/games/polarity/src/math/signed.ts
+++ b/dynawalla/games/polarity/src/math/signed.ts
@@ -1,0 +1,95 @@
+/**
+ * Exact signed-integer arithmetic. Every number here is an integer; no float
+ * ever reaches an answer or a comparison. This is the actual subject matter of
+ * the game — the ship's core is a running signed sum and the polarity is a sign
+ * — so it lives in one small, fully tested module.
+ */
+
+/** U+2212 MINUS SIGN. Reads as arithmetic; a hyphen reads as a dash. */
+export const MINUS = "−";
+
+export type Polarity = 1 | -1;
+
+/** Canonical display for a signed integer: "+7", "0", "−5". */
+export function fmtSigned(n: number): string {
+  if (!Number.isInteger(n)) throw new Error(`fmtSigned: not an integer: ${n}`);
+  if (n === 0) return "0";
+  return n > 0 ? `+${n}` : `${MINUS}${-n}`;
+}
+
+/** Bare magnitude-with-sign, no leading plus: "7", "0", "−5". */
+export function fmtInt(n: number): string {
+  if (!Number.isInteger(n)) throw new Error(`fmtInt: not an integer: ${n}`);
+  return n < 0 ? `${MINUS}${-n}` : `${n}`;
+}
+
+/** Parse either display form back to an integer. Throws on anything else. */
+export function parseInt_(s: string): number {
+  const t = s.trim().replace(/−/g, "-").replace(/^\+/, "");
+  if (!/^-?\d+$/.test(t)) throw new Error(`parseInt_: not an integer: ${JSON.stringify(s)}`);
+  return Number(t);
+}
+
+/**
+ * The polarity a value belongs to. Zero is the origin: it is absorbable in
+ * EITHER polarity, which is both a nice mechanic and arithmetically honest.
+ */
+export function polarityOf(v: number): Polarity | 0 {
+  return v === 0 ? 0 : v > 0 ? 1 : -1;
+}
+
+/** Can a ship in polarity `p` absorb a value `v`? Zero always yes. */
+export function absorbable(v: number, p: Polarity): boolean {
+  return v === 0 || (v > 0 ? p === 1 : p === -1);
+}
+
+/** The core after absorbing `v`. Plain integer addition — that is the point. */
+export function coreAfter(core: number, v: number): number {
+  return core + v;
+}
+
+/** Has the core left the band [-cap, +cap]? */
+export function overloaded(core: number, cap: number): boolean {
+  return core > cap || core < -cap;
+}
+
+/** 0..1 — how close to the edge of the band, either side. */
+export function bandLoad(core: number, cap: number): number {
+  return cap <= 0 ? 1 : Math.min(1, Math.abs(core) / cap);
+}
+
+/**
+ * Release payout. Integer in, integer out — the released charge is worth the
+ * accumulated total, scaled by the chain multiplier, with a bonus for venting
+ * within `edge` of the cap (riding the band edge is the skill ceiling).
+ */
+export function releaseYield(
+  core: number,
+  cap: number,
+  mult: number,
+  edge = 2,
+): { darts: number; score: number; perfect: boolean } {
+  const mag = Math.abs(core);
+  if (mag < 3) return { darts: 0, score: 0, perfect: false };
+  const perfect = mag >= cap - edge && mag <= cap;
+  const darts = Math.min(36, mag + (perfect ? 8 : 0));
+  const score = mag * 25 * mult * (perfect ? 3 : 1);
+  return { darts, score, perfect };
+}
+
+/** Chain multiplier: 1× at 0, +1 every 6 absorbs, hard-capped at 9×. */
+export function chainMult(chain: number): number {
+  return Math.min(9, 1 + Math.floor(chain / 6));
+}
+
+/**
+ * Lock tolerance for a Warden seal: the boss demands an exact core value.
+ * Exact is a full break; near misses do graduated damage so a younger player
+ * still makes progress, but exactness is worth three times as much.
+ */
+export function lockResult(core: number, want: number): "exact" | "near" | "miss" {
+  const d = Math.abs(core - want);
+  if (d === 0) return "exact";
+  if (d <= 2) return "near";
+  return "miss";
+}

--- a/dynawalla/games/polarity/src/mount.ts
+++ b/dynawalla/games/polarity/src/mount.ts
@@ -1,0 +1,356 @@
+import styles from "./ui/styles.css?inline";
+import type { Host, Question } from "./contract.ts";
+import { TierMonitor, detectTier } from "./core/tier.ts";
+import { clamp01 } from "./core/util.ts";
+import { Audio } from "./audio/audio.ts";
+import { EK } from "./game/constants.ts";
+import { endRun, flip, release, revive, startRun, step } from "./game/sim.ts";
+import type { Enemy } from "./game/types.ts";
+import { cue, makeWorld, repool, setAspect } from "./game/world.ts";
+import { Input } from "./input/input.ts";
+import { Renderer } from "./render/renderer.ts";
+import { Hud } from "./ui/hud.ts";
+
+const BEST_KEY = "polarity.best.v1";
+// `gitleaks:allow` — the pinned scanner's `generic-api-key` rule reads
+// `KEY = "<dotted string>"` as a credential once the value clears its entropy
+// floor, which this one does on length alone while `polarity.best.v1` next door
+// does not. It is a localStorage path on the client, in a deliberately public
+// repo. Same call, and same comment, as dynawalla/games/forge/src/game/save.ts.
+const SEEN_SLOT = "polarity.seen.v1"; // gitleaks:allow
+
+let styleTag: HTMLStyleElement | null = null;
+function ensureStyles(): void {
+  if (styleTag?.isConnected) return;
+  styleTag = document.createElement("style");
+  styleTag.dataset.polarity = "1";
+  styleTag.textContent = styles;
+  document.head.appendChild(styleTag);
+}
+
+function loadBest(): number {
+  try {
+    return Number(localStorage.getItem(BEST_KEY) ?? "0") || 0;
+  } catch (e) {
+    console.warn("[polarity] best score unreadable", e);
+    return 0;
+  }
+}
+function saveBest(n: number): void {
+  try {
+    localStorage.setItem(BEST_KEY, String(Math.floor(n)));
+  } catch (e) {
+    console.warn("[polarity] best score not saved", e);
+  }
+}
+function loadSeen(): string[] {
+  try {
+    return JSON.parse(localStorage.getItem(SEEN_SLOT) ?? "[]") as string[];
+  } catch {
+    return [];
+  }
+}
+function saveSeen(s: Set<string>): void {
+  try {
+    localStorage.setItem(SEEN_SLOT, JSON.stringify([...s]));
+  } catch (e) {
+    console.warn("[polarity] cue memory not saved", e);
+  }
+}
+
+export function mount(el: HTMLElement, host: Host): { unmount(): void } {
+  ensureStyles();
+  const root = document.createElement("div");
+  root.className = "pol-root";
+  root.dataset.pol = "1";
+  el.appendChild(root);
+
+  const tier0 = detectTier();
+  const world = makeWorld(host, tier0, (Date.now() ^ 0x9e37) >>> 0);
+  world.stats.best = loadBest();
+  for (const k of loadSeen()) world.cues.add(k);
+
+  const renderer = new Renderer(root, tier0);
+  const audio = new Audio();
+  let paused = false;
+  let reviveQ: Question | null = null;
+  let reviveAt = 0;
+
+  const monitor = new TierMonitor(
+    tier0,
+    (t) => {
+      repool(world, t);
+      renderer.setTier(t);
+    },
+    tier0.name,
+  );
+
+  const hud = new Hud(root, {
+    onFlip: () => {
+      audio.resume();
+      flip(world);
+    },
+    onVent: () => {
+      audio.resume();
+      release(world);
+    },
+    onStart: () => {
+      audio.resume();
+      hud.hideVeil();
+      startRun(world);
+    },
+    onAgain: () => {
+      audio.resume();
+      hud.hideVeil();
+      startRun(world);
+    },
+    onRevive: (answered) => {
+      if (reviveQ) {
+        host.report({
+          questionId: reviveQ.id,
+          correct: true,
+          ms: Math.max(1, Math.round((performance.now() - reviveAt))),
+          answered,
+        });
+        world.stats.asked++;
+        world.stats.right++;
+      }
+      reviveQ = null;
+      hud.hideVeil();
+      revive(world);
+      audio.sealWon();
+    },
+    onSkipRevive: () => {
+      if (reviveQ) {
+        host.report({
+          questionId: reviveQ.id,
+          correct: false,
+          ms: Math.max(1, Math.round(performance.now() - reviveAt)),
+          answered: "",
+        });
+        world.stats.asked++;
+      }
+      reviveQ = null;
+      audio.sealWrong();
+      host.haptic("failure");
+      finish();
+    },
+    onToggleSound: () => {
+      audio.resume();
+      const on = !audio.enabled;
+      audio.setEnabled(on);
+      audio.setMusic(on);
+      hud.setSound(on);
+      if (on) audio.ui("tap");
+    },
+    onTogglePause: () => {
+      if (world.phase !== "play" && !paused) return;
+      paused = !paused;
+      if (paused) hud.showPause();
+      else hud.hideVeil();
+      audio.ui("tap");
+    },
+  });
+  hud.setSound(true);
+
+  const input = new Input(root, world, {
+    onPause: () => {
+      if (world.phase === "play" || paused) {
+        paused = !paused;
+        if (paused) hud.showPause();
+        else hud.hideVeil();
+      }
+    },
+    onAnyInput: () => audio.resume(),
+    isBlocked: () => hud.blocked(),
+  });
+
+  function finish(): void {
+    endRun(world);
+    saveBest(world.stats.best);
+    hud.showOver(world);
+  }
+
+  // --- events -> sound + haptics --------------------------------------------
+  function drain(): void {
+    const ev = world.events;
+    for (let i = 0; i < ev.length; i++) {
+      switch (ev[i]) {
+        case "absorb":
+          audio.absorb(world.chain, world.pol, false);
+          break;
+        case "absorb-big":
+          audio.absorb(world.chain, world.pol, true);
+          break;
+        case "flip":
+          audio.flip(world.pol);
+          break;
+        case "clutch":
+          audio.clutch();
+          break;
+        case "release":
+          audio.release(false);
+          break;
+        case "perfect":
+          audio.release(true);
+          break;
+        case "fizzle":
+          audio.ui("tap");
+          break;
+        case "overload":
+          audio.overload();
+          break;
+        case "hurt":
+          audio.hurt();
+          break;
+        case "weak":
+          audio.hitEnemy(true);
+          break;
+        case "seal-won":
+        case "lock-exact":
+          audio.sealWon();
+          break;
+        case "seal-wrong":
+          audio.sealWrong();
+          break;
+        case "lock-near":
+          audio.ui("big");
+          break;
+        case "bearer":
+        case "warden":
+        case "lock-open":
+          audio.bossIn();
+          break;
+        case "boss-down":
+          audio.kill(true);
+          hud.banner_("SEAL BROKEN");
+          break;
+        case "stratum":
+          audio.stratum();
+          hud.banner_(`STRATUM ${world.stratum}`);
+          break;
+        case "death":
+          audio.kill(true);
+          audio.hurt();
+          break;
+        case "revive-offer":
+          offerRevive();
+          break;
+        default:
+          break;
+      }
+    }
+    ev.length = 0;
+  }
+
+  function offerRevive(): void {
+    if (world.bank <= 0) {
+      finish();
+      return;
+    }
+    try {
+      reviveQ = host.next({ difficulty: 0.2 });
+    } catch (e) {
+      console.error("[polarity] host.next failed on revive", e);
+      finish();
+      return;
+    }
+    reviveAt = performance.now();
+    const opts = [reviveQ.answer, ...reviveQ.distractors.slice(0, 2)];
+    for (let i = opts.length - 1; i > 0; i--) {
+      const j = world.rng.i(0, i);
+      const a = opts[i] as string;
+      opts[i] = opts[j] as string;
+      opts[j] = a;
+    }
+    hud.showRevive(reviveQ.prompt, opts, reviveQ.answer);
+  }
+
+  // --- sizing ---------------------------------------------------------------
+  let cssW = 1;
+  let cssH = 1;
+  function measure(): void {
+    const r = root.getBoundingClientRect();
+    cssW = Math.max(1, Math.round(r.width));
+    cssH = Math.max(1, Math.round(r.height));
+    setAspect(world, cssH / cssW);
+    renderer.resize(cssW, cssH);
+  }
+  const ro = new ResizeObserver(() => measure());
+  ro.observe(root);
+  measure();
+
+  // --- loop -----------------------------------------------------------------
+  let raf = 0;
+  let last = performance.now();
+  let ventCued = false;
+  let running = true;
+
+  const frame = (now: number): void => {
+    if (!running) return;
+    raf = requestAnimationFrame(frame);
+    const t0 = performance.now();
+    let dt = (now - last) / 1000;
+    last = now;
+    if (dt > 0.25) dt = 1 / 60; // a backgrounded tab must not teleport the world
+    dt = Math.min(dt, 0.05);
+
+    world.reduced = host.prefersReducedMotion();
+
+    if (!paused) {
+      input.step(dt);
+      step(world, dt);
+      drain();
+
+      if (world.phase === "play") {
+        if (!ventCued && Math.abs(world.core) >= 8) {
+          ventCued = true;
+          cue(world, "release");
+        }
+        audio.setIntensity(clamp01(world.stratum / 10) * 0.6 + clamp01(world.chain / 40) * 0.4);
+      }
+      if (world.phase === "title") hud.showTitle(world.stats.best);
+    }
+
+    hud.update(world, Math.abs(world.core) >= world.cap - 4);
+    renderer.draw(world, paused ? 0 : dt);
+
+    monitor.sample(performance.now() - t0, dt);
+  };
+  raf = requestAnimationFrame(frame);
+
+  const onVis = (): void => {
+    if (document.hidden && world.phase === "play" && !paused) {
+      paused = true;
+      hud.showPause();
+    }
+  };
+  document.addEventListener("visibilitychange", onVis);
+
+  hud.showTitle(world.stats.best);
+
+  return {
+    unmount(): void {
+      running = false;
+      cancelAnimationFrame(raf);
+      document.removeEventListener("visibilitychange", onVis);
+      ro.disconnect();
+      saveSeen(world.cues);
+      saveBest(world.stats.best);
+      input.dispose();
+      hud.dispose();
+      renderer.dispose();
+      audio.dispose();
+      root.remove();
+    },
+  };
+}
+
+/** Exposed for the shell: the boss currently holding a question, if any. */
+export const activeSealHost = (enemies: Enemy[], n: number, serial: number): Enemy | null => {
+  for (let i = 0; i < n; i++) {
+    const e = enemies[i] as Enemy;
+    if (e.seal === serial && (e.kind === EK.Bearer || e.kind === EK.Warden)) return e;
+  }
+  return null;
+};

--- a/dynawalla/games/polarity/src/render/atlas.ts
+++ b/dynawalla/games/polarity/src/render/atlas.ts
@@ -1,0 +1,98 @@
+import { CanvasTexture, LinearFilter, SRGBColorSpace, Texture } from "three";
+import { LABEL_COLS, LABEL_COUNT, LABEL_MIN, LABEL_ROWS } from "../core/labels.ts";
+
+const FACE =
+  '900 76px ui-rounded, "SF Pro Rounded", "Segoe UI Variable Display", ' +
+  '"Nimbus Sans", Inter, system-ui, sans-serif';
+
+/**
+ * Bakes -40..40 into one square-tiled texture. White on transparent so the
+ * shader can tint per instance; a soft dark rim is baked in so a numeral stays
+ * readable when it lands on top of its own additive glow.
+ */
+export function buildLabelAtlas(tilePx: number): Texture {
+  const c = document.createElement("canvas");
+  c.width = LABEL_COLS * tilePx;
+  c.height = LABEL_ROWS * tilePx;
+  const g = c.getContext("2d");
+  if (!g) throw new Error("[polarity] 2d context unavailable for the label atlas");
+
+  g.textAlign = "center";
+  g.textBaseline = "middle";
+
+  for (let i = 0; i < LABEL_COUNT; i++) {
+    const v = i + LABEL_MIN;
+    const col = i % LABEL_COLS;
+    const row = (i / LABEL_COLS) | 0;
+    const cx = col * tilePx + tilePx / 2;
+    const cy = row * tilePx + tilePx / 2;
+    const s = v < 0 ? "−" + -v : String(v);
+
+    g.save();
+    g.translate(cx, cy);
+    g.scale(tilePx / 128, tilePx / 128);
+    g.font = FACE;
+    // squeeze 3-glyph labels so "−40" occupies the same box as "7"
+    const w = g.measureText(s).width;
+    const maxW = 104;
+    if (w > maxW) g.scale(maxW / w, 1);
+
+    // dark contrast rim first, then the solid face
+    g.lineJoin = "round";
+    g.miterLimit = 2;
+    g.strokeStyle = "rgba(0,0,0,0.92)";
+    g.lineWidth = 13;
+    g.strokeText(s, 0, 2);
+    g.fillStyle = "#ffffff";
+    g.fillText(s, 0, 2);
+    g.restore();
+  }
+
+  const tex = new CanvasTexture(c);
+  tex.colorSpace = SRGBColorSpace;
+  tex.minFilter = LinearFilter;
+  tex.magFilter = LinearFilter;
+  tex.generateMipmaps = false;
+  tex.anisotropy = 1;
+  tex.needsUpdate = true;
+  return tex;
+}
+
+/**
+ * A one-off texture for a question prompt ("−9 + 4"). Rebuilt once per seal,
+ * never per frame. Wide aspect so it reads across a boss hull.
+ */
+export function buildPromptTexture(prompt: string, wpx = 1024, hpx = 256): Texture {
+  const c = document.createElement("canvas");
+  c.width = wpx;
+  c.height = hpx;
+  const g = c.getContext("2d");
+  if (!g) throw new Error("[polarity] 2d context unavailable for a prompt");
+  g.textAlign = "center";
+  g.textBaseline = "middle";
+  g.font =
+    '800 132px ui-rounded, "SF Pro Rounded", "Segoe UI Variable Display", ' +
+    '"Nimbus Sans", Inter, system-ui, sans-serif';
+  let w = g.measureText(prompt).width;
+  const maxW = wpx - 48;
+  g.save();
+  g.translate(wpx / 2, hpx / 2);
+  if (w > maxW) g.scale(maxW / w, 1);
+  g.lineJoin = "round";
+  g.miterLimit = 2;
+  g.strokeStyle = "rgba(0,0,0,0.94)";
+  g.lineWidth = 20;
+  g.strokeText(prompt, 0, 4);
+  g.fillStyle = "#ffffff";
+  g.fillText(prompt, 0, 4);
+  g.restore();
+  w = 0;
+
+  const tex = new CanvasTexture(c);
+  tex.colorSpace = SRGBColorSpace;
+  tex.minFilter = LinearFilter;
+  tex.magFilter = LinearFilter;
+  tex.generateMipmaps = false;
+  tex.needsUpdate = true;
+  return tex;
+}

--- a/dynawalla/games/polarity/src/render/renderer.ts
+++ b/dynawalla/games/polarity/src/render/renderer.ts
@@ -1,0 +1,595 @@
+import {
+  AdditiveBlending,
+  DoubleSide,
+  InstancedBufferAttribute,
+  InstancedBufferGeometry,
+  Mesh,
+  NormalBlending,
+  OrthographicCamera,
+  PlaneGeometry,
+  Scene,
+  ShaderMaterial,
+  Vector2,
+  WebGLRenderer,
+  type Blending,
+  type BufferAttribute,
+  type Texture,
+} from "three";
+import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer.js";
+import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
+import { ShaderPass } from "three/examples/jsm/postprocessing/ShaderPass.js";
+import { UnrealBloomPass } from "three/examples/jsm/postprocessing/UnrealBloomPass.js";
+import { LABEL_COLS, LABEL_ROWS, labelTile } from "../core/labels.ts";
+import type { Tier } from "../core/tier.ts";
+import { clamp, clamp01, wobble } from "../core/util.ts";
+import { BK, COL, EK, HALF_W, PLAYER, polColor, polHot } from "../game/constants.ts";
+import type { Bullet, Enemy, FloatText, Particle } from "../game/types.ts";
+import type { World } from "../game/world.ts";
+import { buildLabelAtlas, buildPromptTexture } from "./atlas.ts";
+import {
+  BACKDROP_FRAG,
+  BACKDROP_VERT,
+  BULLET_FRAG,
+  BULLET_VERT,
+  ENEMY_FRAG,
+  ENEMY_VERT,
+  FRONT_FRAG,
+  FRONT_VERT,
+  GRADE_SHADER,
+  LABEL_FRAG,
+  LABEL_VERT,
+  PART_FRAG,
+  PART_VERT,
+  PLAYER_FRAG,
+  PLAYER_VERT,
+  WAVE_FRAG,
+  WAVE_VERT,
+} from "./shaders.ts";
+
+type Layer = {
+  mesh: Mesh;
+  geo: InstancedBufferGeometry;
+  attrs: Record<string, InstancedBufferAttribute>;
+  cap: number;
+};
+
+const QUAD = new PlaneGeometry(1, 1);
+
+function makeLayer(
+  cap: number,
+  spec: Record<string, number>,
+  mat: ShaderMaterial,
+  order: number,
+): Layer {
+  const geo = new InstancedBufferGeometry();
+  geo.index = QUAD.index;
+  geo.setAttribute("position", QUAD.getAttribute("position") as BufferAttribute);
+  geo.setAttribute("uv", QUAD.getAttribute("uv") as BufferAttribute);
+  const attrs: Record<string, InstancedBufferAttribute> = {};
+  for (const [name, size] of Object.entries(spec)) {
+    const a = new InstancedBufferAttribute(new Float32Array(cap * size), size);
+    a.setUsage(35048 /* DynamicDrawUsage */);
+    geo.setAttribute(name, a);
+    attrs[name] = a;
+  }
+  geo.instanceCount = 0;
+  const mesh = new Mesh(geo, mat);
+  mesh.frustumCulled = false;
+  mesh.renderOrder = order;
+  return { mesh, geo, attrs, cap };
+}
+
+const shader = (
+  vert: string,
+  frag: string,
+  uniforms: Record<string, { value: unknown }>,
+  blending: Blending = AdditiveBlending,
+): ShaderMaterial =>
+  new ShaderMaterial({
+    vertexShader: vert,
+    fragmentShader: frag,
+    uniforms,
+    transparent: true,
+    depthTest: false,
+    depthWrite: false,
+    blending,
+    side: DoubleSide,
+  });
+
+export class Renderer {
+  readonly canvas: HTMLCanvasElement;
+  private readonly gl: WebGLRenderer;
+  private readonly scene = new Scene();
+  private readonly cam = new OrthographicCamera(-50, 50, 70, -70, 0, 10);
+  private composer: EffectComposer | null = null;
+  private bloom: UnrealBloomPass | null = null;
+  private grade: ShaderPass | null = null;
+
+  private bullets: Layer;
+  private enemies: Layer;
+  private parts: Layer;
+  private labels: Layer;
+  private waves: Layer;
+  private readonly player: Mesh;
+  private readonly backdrop: Mesh;
+  private readonly front: Mesh;
+  private readonly promptMesh: Mesh;
+  private promptTex: Texture | null = null;
+  private promptV = -1;
+
+  private readonly uBack: Record<string, { value: unknown }>;
+  private readonly uFront: Record<string, { value: unknown }>;
+  private readonly uPlayer: Record<string, { value: unknown }>;
+  private readonly uBullet: Record<string, { value: unknown }>;
+  private readonly uEnemy: Record<string, { value: unknown }>;
+  private readonly uPrompt: Record<string, { value: unknown }>;
+
+  private atlas: Texture;
+  private tier: Tier;
+  private w = 1;
+  private h = 1;
+  private polSmooth = 1;
+  private shakeT = 0;
+  /** world units per device pixel — drives every antialias width */
+  private px = 0.1;
+
+  constructor(host: HTMLElement, tier: Tier) {
+    this.tier = tier;
+    this.canvas = document.createElement("canvas");
+    this.canvas.className = "pol-canvas";
+    host.appendChild(this.canvas);
+
+    this.gl = new WebGLRenderer({
+      canvas: this.canvas,
+      antialias: false,
+      alpha: false,
+      powerPreference: "high-performance",
+      stencil: false,
+      depth: false,
+    });
+    this.gl.setClearColor(0x03040b, 1);
+    this.gl.autoClear = true;
+
+    this.atlas = buildLabelAtlas(tier.name === "low" ? 96 : 128);
+
+    this.uBack = {
+      uTime: { value: 0 },
+      uPol: { value: 1 },
+      uHeat: { value: 0 },
+      uAspect: { value: 1 },
+      uLoad: { value: 0 },
+      uAlive: { value: 1 },
+      uMotion: { value: 1 },
+      uField: { value: new Vector2(1, 1) },
+    };
+    this.uFront = {
+      uFlash: { value: 0 },
+      uFlashCol: { value: [1, 1, 1] },
+      uTime: { value: 0 },
+      uLoad: { value: 0 },
+      uScan: { value: 0 },
+      uAspect: { value: 1 },
+    };
+    this.uPlayer = {
+      uPos: { value: new Vector2(0, 0) },
+      uScale: { value: 30 },
+      uPol: { value: 1 },
+      uPx: { value: 0.01 },
+      uTime: { value: 0 },
+      uInvuln: { value: 0 },
+      uAura: { value: 0.4 },
+      uLoad: { value: 0 },
+      uRecoil: { value: 0 },
+      uStun: { value: 0 },
+      uAlive: { value: 1 },
+    };
+    this.uBullet = { uBoost: { value: 1 }, uPx: { value: 0.1 } };
+    this.uEnemy = { uTime: { value: 0 }, uPx: { value: 0.1 } };
+    this.uPrompt = { uMap: { value: null }, uAlpha: { value: 0 }, uCol: { value: [1, 1, 1] } };
+
+    this.backdrop = new Mesh(QUAD, shader(BACKDROP_VERT, BACKDROP_FRAG, this.uBack, NormalBlending));
+    this.backdrop.frustumCulled = false;
+    this.backdrop.renderOrder = -100;
+    this.scene.add(this.backdrop);
+
+    this.waves = makeLayer(
+      24,
+      { iPos: 2, iT: 1, iStrength: 1, iPol: 1 },
+      shader(WAVE_VERT, WAVE_FRAG, {}),
+      5,
+    );
+    this.parts = makeLayer(
+      tier.particles,
+      { iPos: 2, iSize: 1, iSize2: 1, iCol: 3, iAlpha: 1, iRot: 1, iKind: 1, iT: 1 },
+      shader(PART_VERT, PART_FRAG, {}),
+      10,
+    );
+    this.enemies = makeLayer(
+      64,
+      { iPos: 2, iSize: 1, iRot: 1, iKind: 1, iPol: 1, iFlash: 1, iHp: 1 },
+      shader(ENEMY_VERT, ENEMY_FRAG, this.uEnemy),
+      20,
+    );
+    this.bullets = makeLayer(
+      tier.bullets,
+      { iPos: 2, iSize: 1, iRot: 1, iKind: 1, iPol: 1, iPull: 1, iGrow: 1 },
+      shader(BULLET_VERT, BULLET_FRAG, this.uBullet),
+      30,
+    );
+    this.labels = makeLayer(
+      512,
+      { iPos: 2, iSize: 1, iTile: 1, iAlpha: 1, iCol: 3 },
+      shader(LABEL_VERT, LABEL_FRAG, {
+        uMap: { value: this.atlas },
+        uGrid: { value: new Vector2(LABEL_COLS, LABEL_ROWS) },
+      }),
+      40,
+    );
+
+    this.player = new Mesh(QUAD, shader(PLAYER_VERT, PLAYER_FRAG, this.uPlayer));
+    this.player.frustumCulled = false;
+    this.player.renderOrder = 35;
+
+    this.promptMesh = new Mesh(
+      QUAD,
+      shader(
+        /* glsl */ `
+        varying vec2 vUv; uniform vec2 uPos; uniform vec2 uSize;
+        void main(){ vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(uPos + position.xy * uSize, 0.0, 1.0); }`,
+        /* glsl */ `
+        varying vec2 vUv; uniform sampler2D uMap; uniform float uAlpha; uniform vec3 uCol;
+        void main(){
+          vec4 t = texture2D(uMap, vUv);
+          float a = t.a * uAlpha;
+          if (a < 0.005) discard;
+          gl_FragColor = vec4(mix(vec3(0.0), uCol, t.r), a);
+        }`,
+        { ...this.uPrompt, uPos: { value: new Vector2(0, 0) }, uSize: { value: new Vector2(1, 1) } },
+        NormalBlending,
+      ),
+    );
+    this.promptMesh.frustumCulled = false;
+    this.promptMesh.renderOrder = 45;
+
+    this.front = new Mesh(QUAD, shader(FRONT_VERT, FRONT_FRAG, this.uFront));
+    this.front.frustumCulled = false;
+    this.front.renderOrder = 100;
+
+    for (const l of [this.waves, this.parts, this.enemies, this.bullets, this.labels])
+      this.scene.add(l.mesh);
+    this.scene.add(this.player, this.promptMesh, this.front);
+
+    this.buildPost(tier);
+  }
+
+  private buildPost(tier: Tier): void {
+    this.composer?.dispose();
+    this.composer = null;
+    this.bloom = null;
+    this.grade = null;
+    if (!tier.bloom && !tier.grade) return;
+    const c = new EffectComposer(this.gl);
+    c.addPass(new RenderPass(this.scene, this.cam));
+    if (tier.bloom) {
+      this.bloom = new UnrealBloomPass(new Vector2(this.w, this.h), 0.62, 0.68, 0.12);
+      c.addPass(this.bloom);
+    }
+    if (tier.grade) {
+      this.grade = new ShaderPass(GRADE_SHADER as never);
+      this.grade.renderToScreen = true;
+      c.addPass(this.grade);
+    } else if (this.bloom) {
+      this.bloom.renderToScreen = true;
+    }
+    this.composer = c;
+    c.setSize(this.w, this.h);
+  }
+
+  setTier(tier: Tier): void {
+    if (tier.name === this.tier.name) return;
+    this.tier = tier;
+    this.gl.setPixelRatio(Math.min(devicePixelRatio || 1, tier.maxDpr));
+    this.buildPost(tier);
+    this.resize(this.w, this.h);
+  }
+
+  resize(cssW: number, cssH: number): void {
+    this.w = Math.max(1, cssW);
+    this.h = Math.max(1, cssH);
+    this.gl.setPixelRatio(Math.min(devicePixelRatio || 1, this.tier.maxDpr));
+    this.gl.setSize(this.w, this.h, false);
+    this.composer?.setSize(this.w, this.h);
+    this.bloom?.setSize(this.w, this.h);
+  }
+
+  /** Fit the playfield into the canvas, letterboxing into the cabinet gutters. */
+  private frame(w: World): void {
+    const scale = Math.min(this.w / (2 * HALF_W), this.h / (2 * w.halfH));
+    const halfWv = this.w / (2 * scale);
+    const halfHv = this.h / (2 * scale);
+    this.cam.left = -halfWv;
+    this.cam.right = halfWv;
+    this.cam.top = halfHv;
+    this.cam.bottom = -halfHv;
+    this.px = (2 * halfWv) / Math.max(1, this.w * Math.min(devicePixelRatio || 1, this.tier.maxDpr));
+    (this.uBack.uField as { value: Vector2 }).value.set(
+      clamp(HALF_W / halfWv, 0.05, 1),
+      clamp(w.halfH / halfHv, 0.05, 1),
+    );
+    (this.uBack.uAspect as { value: number }).value = this.w / this.h;
+    (this.uFront.uAspect as { value: number }).value = this.w / this.h;
+  }
+
+  dispose(): void {
+    this.composer?.dispose();
+    this.gl.dispose();
+    this.atlas.dispose();
+    this.promptTex?.dispose();
+    this.canvas.remove();
+  }
+
+  // -------------------------------------------------------------------------
+
+  draw(w: World, dt: number): void {
+    const fx = w.fx;
+    this.frame(w);
+
+    // --- camera: trauma shake (shake = trauma², Art of Screenshake), punch, tilt
+    this.shakeT += dt;
+    const tr = fx.trauma * fx.trauma;
+    const amp = tr * 5.2;
+    const sx = Math.sin(this.shakeT * 61.7) * amp + Math.sin(this.shakeT * 113.1) * amp * 0.4;
+    const sy = Math.cos(this.shakeT * 73.3) * amp + Math.cos(this.shakeT * 131.7) * amp * 0.35;
+    this.cam.position.set(sx, sy, 5);
+    this.cam.rotation.z = w.reduced ? 0 : tr * 0.035 * Math.sin(this.shakeT * 44.0);
+    const pz = fx.punch > 0 ? wobble(fx.punchT, 26, 11) * fx.punch : 0;
+    this.cam.zoom = 1 + pz * 0.055;
+    this.cam.updateProjectionMatrix();
+
+    // --- backdrop / composite uniforms
+    this.polSmooth += (w.pol - this.polSmooth) * Math.min(1, dt * 9);
+    const load = clamp01(Math.abs(w.core) / Math.max(1, w.cap));
+    const alive = w.phase === "play" ? 1 : 0;
+    (this.uBack.uTime as { value: number }).value = w.wall;
+    (this.uBack.uPol as { value: number }).value = this.polSmooth;
+    (this.uBack.uHeat as { value: number }).value = clamp01(w.stratum / 14);
+    (this.uBack.uLoad as { value: number }).value = load;
+    (this.uBack.uAlive as { value: number }).value = alive;
+    (this.uBack.uMotion as { value: number }).value = w.reduced ? 0 : 1;
+
+    (this.uFront.uFlash as { value: number }).value = fx.flash;
+    (this.uFront.uFlashCol as { value: number[] }).value = [fx.flashR, fx.flashG, fx.flashB];
+    (this.uFront.uTime as { value: number }).value = w.wall;
+    (this.uFront.uLoad as { value: number }).value = load;
+    (this.uFront.uScan as { value: number }).value = this.tier.grade && !w.reduced ? 1 : 0;
+
+    (this.uBullet.uPx as { value: number }).value = this.px;
+    // small screens get visually fatter bullets; the hitbox never changes
+    (this.uBullet.uBoost as { value: number }).value = this.w < 520 ? 1.22 : 1;
+    (this.uEnemy.uTime as { value: number }).value = w.wall;
+    (this.uEnemy.uPx as { value: number }).value = this.px;
+
+    this.fillWaves(w);
+    this.fillParticles(w);
+    this.fillEnemies(w);
+    this.fillBullets(w);
+    this.fillLabels(w);
+    this.fillPlayer(w, load, alive);
+    this.fillPrompt(w);
+
+    if (this.grade) {
+      const u = this.grade.uniforms as Record<string, { value: number }>;
+      if (u.uAmount) u.uAmount.value = w.reduced ? 0 : clamp(tr * 3.2 + fx.flash * 2.0, 0, 2.2);
+      if (u.uTime) u.uTime.value = w.wall;
+      if (u.uGrain) u.uGrain.value = w.reduced ? 0.02 : 0.05;
+    }
+    if (this.bloom) {
+      this.bloom.strength = 0.55 + fx.glow * 0.5 + (w.reduced ? 0 : tr * 0.5);
+    }
+
+    if (this.composer) this.composer.render();
+    else this.gl.render(this.scene, this.cam);
+  }
+
+  // -------------------------------------------------------------------------
+
+  private fillWaves(w: World): void {
+    const L = this.waves;
+    const pos = L.attrs.iPos as InstancedBufferAttribute;
+    const t = L.attrs.iT as InstancedBufferAttribute;
+    const s = L.attrs.iStrength as InstancedBufferAttribute;
+    const p = L.attrs.iPol as InstancedBufferAttribute;
+    const src = w.fx.waves;
+    const n = Math.min(L.cap, w.fx.waveN);
+    for (let i = 0; i < n; i++) {
+      const o = i * 6;
+      (pos.array as Float32Array)[i * 2] = src[o] as number;
+      (pos.array as Float32Array)[i * 2 + 1] = src[o + 1] as number;
+      (t.array as Float32Array)[i] = (src[o + 2] as number) / (src[o + 3] as number);
+      (s.array as Float32Array)[i] = src[o + 4] as number;
+      (p.array as Float32Array)[i] = src[o + 5] as number;
+    }
+    L.geo.instanceCount = n;
+    for (const a of [pos, t, s, p]) a.needsUpdate = true;
+  }
+
+  private fillParticles(w: World): void {
+    const L = this.parts;
+    const pos = (L.attrs.iPos as InstancedBufferAttribute).array as Float32Array;
+    const size = (L.attrs.iSize as InstancedBufferAttribute).array as Float32Array;
+    const size2 = (L.attrs.iSize2 as InstancedBufferAttribute).array as Float32Array;
+    const col = (L.attrs.iCol as InstancedBufferAttribute).array as Float32Array;
+    const alpha = (L.attrs.iAlpha as InstancedBufferAttribute).array as Float32Array;
+    const rot = (L.attrs.iRot as InstancedBufferAttribute).array as Float32Array;
+    const kind = (L.attrs.iKind as InstancedBufferAttribute).array as Float32Array;
+    const tt = (L.attrs.iT as InstancedBufferAttribute).array as Float32Array;
+    const n = Math.min(L.cap, w.partN);
+    for (let i = 0; i < n; i++) {
+      const p = w.parts[i] as Particle;
+      const t = clamp01(p.age / p.life);
+      pos[i * 2] = p.x;
+      pos[i * 2 + 1] = p.y;
+      size[i] = p.kind === 2 ? p.size : p.size * (1 - t * 0.55);
+      size2[i] = p.size2;
+      col[i * 3] = p.r;
+      col[i * 3 + 1] = p.g;
+      col[i * 3 + 2] = p.b;
+      alpha[i] = p.a * (1 - t) * (1 - t);
+      rot[i] = p.rot;
+      kind[i] = p.kind;
+      tt[i] = t;
+    }
+    L.geo.instanceCount = n;
+    for (const k of Object.keys(L.attrs)) (L.attrs[k] as InstancedBufferAttribute).needsUpdate = true;
+  }
+
+  private fillEnemies(w: World): void {
+    const L = this.enemies;
+    const pos = (L.attrs.iPos as InstancedBufferAttribute).array as Float32Array;
+    const size = (L.attrs.iSize as InstancedBufferAttribute).array as Float32Array;
+    const rot = (L.attrs.iRot as InstancedBufferAttribute).array as Float32Array;
+    const kind = (L.attrs.iKind as InstancedBufferAttribute).array as Float32Array;
+    const pol = (L.attrs.iPol as InstancedBufferAttribute).array as Float32Array;
+    const flash = (L.attrs.iFlash as InstancedBufferAttribute).array as Float32Array;
+    const hp = (L.attrs.iHp as InstancedBufferAttribute).array as Float32Array;
+    const n = Math.min(L.cap, w.enemyN);
+    for (let i = 0; i < n; i++) {
+      const e = w.enemies[i] as Enemy;
+      pos[i * 2] = e.x;
+      pos[i * 2 + 1] = e.y;
+      size[i] = e.r * (1 + e.hitFlash * 0.09);
+      rot[i] = e.rot;
+      kind[i] = e.kind;
+      pol[i] = e.pol;
+      flash[i] = e.hitFlash;
+      hp[i] = clamp01(e.hp / e.maxHp);
+    }
+    L.geo.instanceCount = n;
+    for (const k of Object.keys(L.attrs)) (L.attrs[k] as InstancedBufferAttribute).needsUpdate = true;
+  }
+
+  private fillBullets(w: World): void {
+    const L = this.bullets;
+    const pos = (L.attrs.iPos as InstancedBufferAttribute).array as Float32Array;
+    const size = (L.attrs.iSize as InstancedBufferAttribute).array as Float32Array;
+    const rot = (L.attrs.iRot as InstancedBufferAttribute).array as Float32Array;
+    const kind = (L.attrs.iKind as InstancedBufferAttribute).array as Float32Array;
+    const pol = (L.attrs.iPol as InstancedBufferAttribute).array as Float32Array;
+    const pull = (L.attrs.iPull as InstancedBufferAttribute).array as Float32Array;
+    const grow = (L.attrs.iGrow as InstancedBufferAttribute).array as Float32Array;
+    const n = Math.min(L.cap, w.bulletN);
+    for (let i = 0; i < n; i++) {
+      const b = w.bullets[i] as Bullet;
+      pos[i * 2] = b.x;
+      pos[i * 2 + 1] = b.y;
+      size[i] = b.r;
+      rot[i] = b.rot;
+      kind[i] = b.kind;
+      pol[i] = b.owner === 2 ? 0 : Math.sign(b.v);
+      pull[i] = b.pull;
+      grow[i] = b.grow;
+    }
+    L.geo.instanceCount = n;
+    for (const k of Object.keys(L.attrs)) (L.attrs[k] as InstancedBufferAttribute).needsUpdate = true;
+  }
+
+  private fillLabels(w: World): void {
+    const L = this.labels;
+    const pos = (L.attrs.iPos as InstancedBufferAttribute).array as Float32Array;
+    const size = (L.attrs.iSize as InstancedBufferAttribute).array as Float32Array;
+    const tile = (L.attrs.iTile as InstancedBufferAttribute).array as Float32Array;
+    const alpha = (L.attrs.iAlpha as InstancedBufferAttribute).array as Float32Array;
+    const col = (L.attrs.iCol as InstancedBufferAttribute).array as Float32Array;
+    let n = 0;
+    const put = (
+      x: number,
+      y: number,
+      s: number,
+      t: number,
+      a: number,
+      c: readonly number[],
+    ): void => {
+      if (n >= L.cap || t < 0) return;
+      pos[n * 2] = x;
+      pos[n * 2 + 1] = y;
+      size[n] = s;
+      tile[n] = t;
+      alpha[n] = a;
+      col[n * 3] = c[0] as number;
+      col[n * 3 + 1] = c[1] as number;
+      col[n * 3 + 2] = c[2] as number;
+      n++;
+    };
+
+    const boost = this.w < 520 ? 1.18 : 1;
+    for (let i = 0; i < w.bulletN; i++) {
+      const b = w.bullets[i] as Bullet;
+      if (b.label < 0) continue;
+      const s = (b.kind === BK.Orb ? b.r * 1.35 : b.r * 1.55) * boost;
+      put(b.x, b.y, s, b.label, 1, polHot(b.v));
+    }
+    for (let i = 0; i < w.textN; i++) {
+      const t = w.texts[i] as FloatText;
+      const k = clamp01(t.age / t.life);
+      put(t.x, t.y, t.size * (1 + k * 0.5), t.label, (1 - k) * (1 - k), [t.r, t.g, t.b]);
+    }
+    // the Warden prints the exact total it demands, right on its hull
+    for (let i = 0; i < w.enemyN; i++) {
+      const e = w.enemies[i] as Enemy;
+      if (e.kind !== EK.Warden || e.lockState !== 1) continue;
+      const tl = labelTile(e.lockWant);
+      const pulse = 0.7 + 0.3 * Math.sin(w.wall * 5);
+      put(e.x, e.y, e.r * 1.15, tl, pulse, COL.gold);
+    }
+    L.geo.instanceCount = n;
+    for (const k of Object.keys(L.attrs)) (L.attrs[k] as InstancedBufferAttribute).needsUpdate = true;
+  }
+
+  private fillPlayer(w: World, load: number, alive: number): void {
+    const scale = PLAYER.absorb * 2.9;
+    (this.uPlayer.uPos as { value: Vector2 }).value.set(w.px, w.py - w.recoil * 1.6);
+    (this.uPlayer.uScale as { value: number }).value = scale;
+    // morph runs through zero so the hull genuinely inverts rather than recolours
+    const m = w.polMorph >= 1 ? w.pol : w.pol * (w.polMorph * 2 - 1) * -1;
+    (this.uPlayer.uPol as { value: number }).value = w.polMorph >= 1 ? w.pol : m;
+    (this.uPlayer.uPx as { value: number }).value = this.px / scale;
+    (this.uPlayer.uTime as { value: number }).value = w.wall;
+    (this.uPlayer.uInvuln as { value: number }).value = w.invuln > 0 ? 1 : 0;
+    (this.uPlayer.uAura as { value: number }).value = (PLAYER.absorb / scale) * 3;
+    (this.uPlayer.uLoad as { value: number }).value = load;
+    (this.uPlayer.uRecoil as { value: number }).value = w.recoil;
+    (this.uPlayer.uStun as { value: number }).value = w.stun > 0 && w.phase === "play" ? 1 : 0;
+    (this.uPlayer.uAlive as { value: number }).value = alive;
+    this.player.visible = w.phase === "play";
+  }
+
+  private fillPrompt(w: World): void {
+    if (w.promptV !== this.promptV) {
+      this.promptV = w.promptV;
+      this.promptTex?.dispose();
+      this.promptTex = w.prompt ? buildPromptTexture(w.prompt) : null;
+      const u = (this.promptMesh.material as ShaderMaterial).uniforms;
+      (u.uMap as { value: Texture | null }).value = this.promptTex;
+    }
+    let host: Enemy | null = null;
+    for (let i = 0; i < w.enemyN; i++) {
+      const e = w.enemies[i] as Enemy;
+      if (e.seal === w.seal.serial && (e.kind === EK.Bearer || e.kind === EK.Warden)) host = e;
+    }
+    const show = host !== null && w.seal.state === "asking" && this.promptTex !== null;
+    this.promptMesh.visible = show;
+    if (!show || !host) return;
+    const u = (this.promptMesh.material as ShaderMaterial).uniforms;
+    const wide = Math.min(HALF_W * 1.6, 62);
+    (u.uPos as { value: Vector2 }).value.set(host.x, host.y + host.r * 1.28);
+    (u.uSize as { value: Vector2 }).value.set(wide, wide * 0.25);
+    (u.uAlpha as { value: number }).value = 1;
+    (u.uCol as { value: number[] }).value = [...COL.gold] as number[];
+  }
+
+  /** The polarity colour a HUD element should use. Kept here so CSS matches GLSL. */
+  static hudColor(pol: number): string {
+    const c = polColor(pol);
+    return `rgb(${Math.round((c[0] as number) * 255)},${Math.round((c[1] as number) * 255)},${Math.round((c[2] as number) * 255)})`;
+  }
+}

--- a/dynawalla/games/polarity/src/render/shaders.ts
+++ b/dynawalla/games/polarity/src/render/shaders.ts
@@ -1,0 +1,611 @@
+/**
+ * All GLSL for POLARITY.
+ *
+ * The register is a vector monitor: everything is drawn as a signed-distance
+ * shape with an additive halo, so nothing is a sprite and nothing is a texture
+ * except the numerals. Polarity is carried on four independent channels at
+ * once — SHAPE (diamond vs ring), GLYPH (a cut-out + or −), COLOUR (amber vs
+ * cyan) and, on anything big enough to print, the NUMERAL's own sign. Colour is
+ * therefore never load-bearing on its own.
+ */
+
+export const COMMON = /* glsl */ `
+  #define TAU 6.28318530718
+  vec3 POS_A = vec3(1.00, 0.80, 0.28);
+  vec3 POS_B = vec3(1.00, 0.38, 0.06);
+  vec3 NEG_A = vec3(0.22, 0.86, 1.00);
+  vec3 NEG_B = vec3(0.44, 0.28, 1.00);
+  vec3 NEU_A = vec3(0.80, 0.83, 0.92);
+
+  vec3 polA(float p){ return p > 0.5 ? POS_A : (p < -0.5 ? NEG_A : NEU_A); }
+  vec3 polB(float p){ return p > 0.5 ? POS_B : (p < -0.5 ? NEG_B : NEU_A); }
+
+  float sdDiamond(vec2 p){ return abs(p.x) + abs(p.y); }
+  float sdBox(vec2 p, vec2 b){ vec2 d = abs(p) - b; return min(max(d.x,d.y),0.0) + length(max(d,0.0)); }
+  // regular n-gon, returned as a radius-like scalar (compare against a radius)
+  float ngon(vec2 p, float n, float rot){
+    float a = atan(p.y, p.x) - rot;
+    float k = TAU / n;
+    float m = mod(a + k * 0.5, k) - k * 0.5;
+    return length(p) * cos(m) / cos(k * 0.5);
+  }
+  float plusMask(vec2 p, float len, float th){
+    float a = sdBox(p, vec2(len, th));
+    float b = sdBox(p, vec2(th, len));
+    return min(a, b);
+  }
+  float aa(float d, float w){ return 1.0 - smoothstep(-w, w, d); }
+  float hash21(vec2 p){
+    p = fract(p * vec2(123.34, 456.21));
+    p += dot(p, p + 45.32);
+    return fract(p.x * p.y);
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// backdrop — a slow, deep, breathing field. Never competes with the bullets.
+// ---------------------------------------------------------------------------
+
+export const BACKDROP_VERT = /* glsl */ `
+  varying vec2 vUv;
+  void main(){ vUv = uv; gl_Position = vec4(position.xy, 0.0, 1.0); }
+`;
+
+export const BACKDROP_FRAG =
+  COMMON +
+  /* glsl */ `
+  varying vec2 vUv;
+  uniform float uTime;
+  uniform float uPol;       // -1..1, smoothed
+  uniform float uHeat;      // 0..1 escalation
+  uniform float uAspect;
+  uniform float uLoad;      // 0..1 core band load
+  uniform float uAlive;     // 1 playing, 0 frozen/dead
+  uniform float uMotion;    // 0 when prefers-reduced-motion
+  uniform vec2 uField;      // playfield half-extent in NDC — the cabinet rails
+
+  void main(){
+    vec2 uv = vUv;
+    vec2 p = (uv - 0.5) * vec2(uAspect, 1.0) * 2.0;
+
+    // deep base, pushed very slightly toward the current polarity
+    vec3 col = mix(vec3(0.012,0.016,0.036), vec3(0.026,0.014,0.030), uHeat);
+    col += polA(uPol) * 0.030 * (0.55 + 0.45 * sin(uTime * 0.35));
+
+    // receding field lines: the floor of the shaft you are flying down
+    float t = uTime * (0.06 + 0.05 * uHeat) * uMotion;
+    float depth = 1.0 / max(0.06, 1.0 - uv.y * 0.92);
+    float rows = fract(depth * 1.1 - t * 3.0);
+    float rowLine = smoothstep(0.965, 1.0, rows) * smoothstep(1.0, 0.35, depth * 0.30);
+    float cols = abs(fract((uv.x - 0.5) * depth * 5.0 + 0.5) - 0.5);
+    float colLine = smoothstep(0.035, 0.0, cols) * smoothstep(1.0, 0.30, depth * 0.30);
+    vec3 grid = mix(vec3(0.10,0.34,0.62), polA(uPol), 0.35);
+    col += grid * (rowLine * 0.16 + colLine * 0.10);
+
+    // drifting nebula bands
+    float n = sin(p.x * 1.7 + uTime * 0.19 * uMotion) * sin(p.y * 1.1 - uTime * 0.13 * uMotion);
+    col += polB(uPol) * 0.022 * (0.5 + 0.5 * n);
+
+    // band-load bloom from the bottom: the closer to overload, the hotter the floor
+    float floorGlow = smoothstep(0.55, 0.0, uv.y) * uLoad * uLoad;
+    col += mix(polA(uPol), vec3(1.0,0.25,0.30), smoothstep(0.7,1.0,uLoad)) * floorGlow * 0.22;
+
+    // static grain keeps the black from banding on cheap panels
+    col += (hash21(uv * 900.0 + fract(uTime)) - 0.5) * 0.014;
+
+    // vignette + a dead-run desaturation
+    float vig = smoothstep(1.55, 0.30, length(p));
+    col *= 0.35 + 0.65 * vig;
+    col = mix(vec3(dot(col, vec3(0.33))), col, 0.30 + 0.70 * uAlive);
+
+    // the cabinet: everything outside the playfield falls away, and the rails
+    // that bound it glow. On a wide desktop this is what stops the shmup from
+    // looking like a stretched phone game.
+    vec2 n = abs((vUv - 0.5) * 2.0);
+    float outside = max(step(uField.x, n.x), step(uField.y, n.y));
+    col *= mix(1.0, 0.30, outside);
+    float railX = smoothstep(0.010, 0.0, abs(n.x - uField.x)) * step(n.y, uField.y + 0.02);
+    float railY = smoothstep(0.010, 0.0, abs(n.y - uField.y)) * step(n.x, uField.x + 0.02);
+    col += mix(vec3(0.35, 0.55, 0.95), polA(uPol), 0.5) * (railX + railY * 0.6) * 0.55;
+
+    gl_FragColor = vec4(col, 1.0);
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// bullets
+// ---------------------------------------------------------------------------
+
+export const BULLET_VERT = /* glsl */ `
+  attribute vec2 iPos;
+  attribute float iSize;
+  attribute float iRot;
+  attribute float iKind;
+  attribute float iPol;
+  attribute float iPull;
+  attribute float iGrow;
+  varying vec2 vP;
+  varying float vKind;
+  varying float vPol;
+  varying float vPull;
+  varying float vAA;
+  uniform float uBoost;
+  uniform float uPx;
+  void main(){
+    vP = position.xy * 2.0;
+    vKind = iKind;
+    vPol = iPol;
+    vPull = iPull;
+    float s = iSize * uBoost * (1.0 + iGrow * 0.55) * (1.0 + iPull * 0.22);
+    vAA = clamp(uPx / max(0.001, s), 0.004, 0.9);
+    float c = cos(iRot), sn = sin(iRot);
+    vec2 q = vec2(position.x * c - position.y * sn, position.x * sn + position.y * c);
+    // halo needs room outside the body
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(iPos + q * s * 3.0, 0.0, 1.0);
+  }
+`;
+
+export const BULLET_FRAG =
+  COMMON +
+  /* glsl */ `
+  varying vec2 vP;
+  varying float vKind;
+  varying float vPol;
+  varying float vPull;
+  varying float vAA;
+
+  void main(){
+    vec2 p = vP * 1.5;              // body occupies |p| < 1
+    float r = length(p);
+    if (r > 3.0) discard;
+    float w = max(0.012, vAA * 1.6);
+
+    vec3 A = polA(vPol);
+    vec3 B = polB(vPol);
+    float body = 0.0;
+    float glyph = 0.0;
+    float rim = 0.0;
+
+    if (vKind < 0.5) {
+      // CHAFF — polarity decides the silhouette outright
+      if (vPol > 0.0) {
+        float d = sdDiamond(p) - 0.95;
+        body = aa(d, w);
+        rim  = aa(abs(d) - 0.10, w);
+        glyph = aa(plusMask(p, 0.44, 0.13), w);
+      } else {
+        float d = abs(r - 0.72) - 0.26;
+        body = aa(d, w);
+        rim  = aa(abs(r - 0.98) - 0.06, w);
+        glyph = aa(sdBox(p, vec2(0.40, 0.11)), w);
+      }
+    } else if (vKind < 1.5) {
+      // CHARGE — a heavy plate that carries a printed numeral
+      float d = (vPol > 0.0) ? (ngon(p, 4.0, 0.785) - 0.92) : (r - 0.92);
+      body = aa(d, w) * 0.80;
+      rim  = aa(abs(d) - 0.10, w);
+    } else if (vKind < 2.5) {
+      // SEAL ORB — big, slow, unmistakable, with a counter-rotating collar
+      float d = (vPol > 0.0) ? (ngon(p, 6.0, 0.0) - 0.86) : (r - 0.86);
+      body = aa(d, w) * 0.68;
+      rim  = aa(abs(d) - 0.075, w) * 1.4;
+      float coll = abs(r - 1.16) - 0.045;
+      rim += aa(coll, w) * (0.5 + 0.5 * sin(atan(p.y, p.x) * 8.0));
+    } else if (vKind < 3.5) {
+      // PLAYER SHOT — a hot little bolt
+      float d = sdBox(p, vec2(0.16, 0.62)) - 0.12;
+      body = aa(d, w);
+      rim = body;
+    } else if (vKind < 4.5) {
+      // DART — released charge, seeking
+      float d = ngon(p, 3.0, -1.5708) - 0.86;
+      body = aa(d, w);
+      rim = aa(abs(d) - 0.09, w);
+    } else {
+      // LANCE — a fast needle
+      float d = sdBox(p, vec2(0.14, 0.95)) - 0.08;
+      body = aa(d, w);
+      rim = aa(abs(d) - 0.07, w);
+    }
+
+    float halo = exp(-max(0.0, r - 0.9) * 2.6) * 0.55;
+    vec3 col = B * body * 0.9 + A * rim * 1.5 + A * halo * (0.5 + vPull);
+    col += vec3(1.0) * glyph * 1.25;
+    col += A * vPull * 0.7 * body;
+
+    float a = clamp(max(max(body, rim * 1.1), halo) + glyph, 0.0, 1.0);
+    if (a < 0.004) discard;
+    gl_FragColor = vec4(col, a);
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// enemies
+// ---------------------------------------------------------------------------
+
+export const ENEMY_VERT = /* glsl */ `
+  attribute vec2 iPos;
+  attribute float iSize;
+  attribute float iRot;
+  attribute float iKind;
+  attribute float iPol;
+  attribute float iFlash;
+  attribute float iHp;
+  varying vec2 vP;
+  varying float vKind;
+  varying float vPol;
+  varying float vFlash;
+  varying float vHp;
+  varying float vAA;
+  uniform float uPx;
+  void main(){
+    vP = position.xy * 2.0;
+    vKind = iKind; vPol = iPol; vFlash = iFlash; vHp = iHp;
+    vAA = clamp(uPx / max(0.001, iSize), 0.003, 0.6);
+    float c = cos(iRot), sn = sin(iRot);
+    vec2 q = vec2(position.x * c - position.y * sn, position.x * sn + position.y * c);
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(iPos + q * iSize * 3.0, 0.0, 1.0);
+  }
+`;
+
+export const ENEMY_FRAG =
+  COMMON +
+  /* glsl */ `
+  varying vec2 vP;
+  varying float vKind;
+  varying float vPol;
+  varying float vFlash;
+  varying float vHp;
+  varying float vAA;
+  uniform float uTime;
+
+  void main(){
+    vec2 p = vP * 1.5;
+    float r = length(p);
+    if (r > 2.4) discard;
+    float w = max(0.010, vAA * 1.5);
+    vec3 A = polA(vPol);
+    vec3 B = polB(vPol);
+
+    float shell = 0.0, core = 0.0, mark = 0.0;
+    if (vKind < 0.5) {                       // MOTE
+      float d = ngon(p, 3.0, 1.5708) - 0.86;
+      shell = aa(abs(d) - 0.10, w); core = aa(d + 0.30, w) * 0.5;
+    } else if (vKind < 1.5) {                // WEAVER
+      float d = ngon(p, 3.0, -1.5708) - 0.92;
+      shell = aa(abs(d) - 0.09, w);
+      core = aa(ngon(p, 3.0, -1.5708) - 0.42, w) * 0.7;
+    } else if (vKind < 2.5) {                // SPINNER
+      float d = abs(ngon(p, 6.0, 0.0) - 0.80) - 0.10;
+      shell = aa(d, w);
+      mark = aa(abs(ngon(p, 3.0, uTime) - 0.34) - 0.07, w);
+    } else if (vKind < 3.5) {                // BATTERY
+      float o = ngon(p, 6.0, 0.5236) - 0.94;
+      shell = aa(abs(o) - 0.12, w);
+      core = aa(ngon(p, 6.0, 0.5236) - 0.50, w) * 0.85;
+      mark = aa(sdBox(p, vec2(0.44, 0.055)), w);
+    } else if (vKind < 4.5) {                // LANCER
+      float d = ngon(vec2(p.x * 1.7, p.y), 3.0, -1.5708) - 0.95;
+      shell = aa(abs(d) - 0.10, w); core = aa(d + 0.35, w) * 0.6;
+    } else if (vKind < 5.5) {                // BEARER
+      float o = ngon(p, 6.0, 0.0) - 0.94;
+      shell = aa(abs(o) - 0.085, w);
+      float ring2 = abs(r - 0.62) - 0.05;
+      shell += aa(ring2, w) * 0.8;
+      mark = aa(abs(ngon(p, 3.0, -uTime * 0.7) - 0.34) - 0.06, w);
+    } else {                                  // WARDEN
+      float o = ngon(p, 8.0, 0.0) - 1.0;
+      shell = aa(abs(o) - 0.075, w);
+      shell += aa(abs(ngon(p, 4.0, uTime * 0.4) - 0.70) - 0.045, w) * 0.9;
+      shell += aa(abs(r - 0.34) - 0.05, w);
+      mark = aa(plusMask(p, 0.22, 0.055), w) * step(0.0, vPol);
+    }
+
+    // damage: the hull darkens and the seams glow as hp drops
+    float hurt = 1.0 - vHp;
+    vec3 col = A * shell * (1.3 + hurt * 0.9) + B * core * 0.55 + vec3(1.0) * mark * 0.9;
+    col += mix(vec3(0.0), vec3(1.0, 0.35, 0.32), hurt * 0.5) * shell * 0.5;
+    col += vec3(1.0) * vFlash * (shell + core) * 1.8;
+    float halo = exp(-max(0.0, r - 0.95) * 3.0) * 0.30;
+    col += A * halo;
+
+    float a = clamp(max(max(shell, core * 0.9), mark) + halo + vFlash * 0.3, 0.0, 1.0);
+    if (a < 0.004) discard;
+    gl_FragColor = vec4(col, a);
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// particles
+// ---------------------------------------------------------------------------
+
+export const PART_VERT = /* glsl */ `
+  attribute vec2 iPos;
+  attribute float iSize;
+  attribute float iSize2;
+  attribute vec3 iCol;
+  attribute float iAlpha;
+  attribute float iRot;
+  attribute float iKind;
+  attribute float iT;
+  varying vec2 vP;
+  varying vec3 vCol;
+  varying float vAlpha;
+  varying float vKind;
+  varying float vT;
+  varying float vRatio;
+  void main(){
+    vP = position.xy * 2.0;
+    vCol = iCol; vAlpha = iAlpha; vKind = iKind; vT = iT;
+    float s = iSize;
+    vRatio = 1.0;
+    if (iKind > 1.5 && iKind < 2.5) { s = iSize + iSize2; vRatio = iSize2 / max(0.001, s); }
+    float c = cos(iRot), sn = sin(iRot);
+    vec2 q = vec2(position.x * c - position.y * sn, position.x * sn + position.y * c);
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(iPos + q * s * 3.2, 0.0, 1.0);
+  }
+`;
+
+export const PART_FRAG =
+  COMMON +
+  /* glsl */ `
+  varying vec2 vP;
+  varying vec3 vCol;
+  varying float vAlpha;
+  varying float vKind;
+  varying float vT;
+  varying float vRatio;
+  void main(){
+    vec2 p = vP * 1.6;
+    float r = length(p);
+    float a;
+    if (vKind < 0.5) {
+      a = exp(-r * r * 3.4);
+    } else if (vKind < 1.5) {
+      // shard: a stretched sliver that shortens as it dies
+      float d = abs(p.y) * (2.6 + vT * 6.0) + abs(p.x) * 0.55;
+      a = exp(-d * d * 1.6) * exp(-r * 0.8);
+    } else if (vKind < 2.5) {
+      // ring: expands and thins
+      float rr = mix(0.20, 1.0, vT);
+      float th = max(0.03, vRatio * (1.0 - vT) * 0.9);
+      a = exp(-pow(abs(r - rr) / th, 2.0));
+    } else {
+      float d = abs(p.x) * 6.0 + abs(p.y) * 0.5;
+      a = exp(-d * d);
+    }
+    a *= vAlpha;
+    if (a < 0.004) discard;
+    gl_FragColor = vec4(vCol * (0.75 + a * 0.9), a);
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// numerals
+// ---------------------------------------------------------------------------
+
+export const LABEL_VERT = /* glsl */ `
+  attribute vec2 iPos;
+  attribute float iSize;
+  attribute float iTile;
+  attribute float iAlpha;
+  attribute vec3 iCol;
+  varying vec2 vUv;
+  varying float vAlpha;
+  varying vec3 vCol;
+  uniform vec2 uGrid;
+  void main(){
+    float col = mod(iTile, uGrid.x);
+    float row = floor(iTile / uGrid.x);
+    vUv = (uv + vec2(col, uGrid.y - 1.0 - row)) / uGrid;
+    vAlpha = iAlpha; vCol = iCol;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(iPos + position.xy * iSize, 0.0, 1.0);
+  }
+`;
+
+export const LABEL_FRAG = /* glsl */ `
+  varying vec2 vUv;
+  varying float vAlpha;
+  varying vec3 vCol;
+  uniform sampler2D uMap;
+  void main(){
+    vec4 t = texture2D(uMap, vUv);
+    float a = t.a * vAlpha;
+    if (a < 0.005) discard;
+    // the baked dark rim stays dark; the face takes the instance tint
+    vec3 col = mix(vec3(0.0), vCol, t.r);
+    gl_FragColor = vec4(col, a);
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// player
+// ---------------------------------------------------------------------------
+
+export const PLAYER_VERT = /* glsl */ `
+  varying vec2 vP;
+  uniform vec2 uPos;
+  uniform float uScale;
+  void main(){
+    vP = position.xy * 2.0;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(uPos + position.xy * uScale, 0.0, 1.0);
+  }
+`;
+
+export const PLAYER_FRAG =
+  COMMON +
+  /* glsl */ `
+  varying vec2 vP;
+  uniform float uPol;      // -1..1 morph
+  uniform float uPx;
+  uniform float uTime;
+  uniform float uInvuln;
+  uniform float uAura;     // absorb radius in local units
+  uniform float uLoad;     // 0..1
+  uniform float uRecoil;
+  uniform float uStun;
+  uniform float uAlive;
+
+  void main(){
+    vec2 p = vP * 1.5;
+    float r = length(p);
+    float w = max(0.02, uPx * 1.4);
+    vec3 A = polA(uPol > 0.0 ? 1.0 : -1.0);
+    vec3 B = polB(uPol > 0.0 ? 1.0 : -1.0);
+    vec3 col = vec3(0.0);
+    float a = 0.0;
+
+    // --- absorb aura: the exact reach of the magnet, so it is never a mystery
+    float ring = abs(r - uAura) - (0.010 + 0.006 * sin(uTime * 4.0));
+    float aur = aa(ring, w * 1.6);
+    float pulse = 0.35 + 0.30 * sin(uTime * 3.2 - r * 12.0);
+    col += A * aur * pulse * 1.5 * uAlive;
+    a = max(a, aur * 0.55 * uAlive);
+    // dashes around the aura so it reads without relying on colour
+    float ang = atan(p.y, p.x);
+    float dash = step(0.45, fract(ang / TAU * 18.0 + uTime * 0.10));
+    col += A * aur * dash * 0.9 * uAlive;
+
+    // --- hull: a wedge that inverts with polarity
+    float sc = 1.0 / (0.16 + 0.02 * uRecoil);
+    vec2 q = p * sc;
+    float wedge = ngon(vec2(q.x * 0.86, q.y), 3.0, 1.5708) - 1.0;
+    float hull = aa(wedge, w * sc);
+    float edge = aa(abs(wedge) - 0.13, w * sc);
+    float fillAmt = uPol > 0.0 ? 1.0 : 0.16;   // positive is solid, negative is hollow
+    col += B * hull * fillAmt * 0.85;
+    col += A * edge * 2.1;
+
+    // sign cut into the hull
+    float g = uPol > 0.0 ? plusMask(q, 0.42, 0.13) : sdBox(q, vec2(0.40, 0.12));
+    float glyph = aa(g, w * sc) * step(wedge, 0.0);
+    col += vec3(1.0) * glyph * 1.5;
+    a = max(a, max(hull * max(fillAmt, 0.55), max(edge, glyph)));
+
+    // --- the lethal dot: always drawn, never a mystery
+    float dot_ = aa(r - 0.036, w * 0.9);
+    col += mix(vec3(1.0), vec3(1.0, 0.30, 0.34), uLoad) * dot_ * 2.6;
+    a = max(a, dot_);
+
+    // --- state overlays
+    float flick = uInvuln > 0.0 ? (0.35 + 0.65 * step(0.5, fract(uTime * 9.0))) : 1.0;
+    float stunRing = uStun > 0.0 ? aa(abs(r - 0.20 - 0.05 * sin(uTime * 22.0)) - 0.012, w) : 0.0;
+    col += vec3(1.0, 0.28, 0.30) * stunRing * 2.0;
+    a = max(a, stunRing);
+
+    col *= flick;
+    a *= flick;
+    if (a < 0.004) discard;
+    gl_FragColor = vec4(col, clamp(a, 0.0, 1.0));
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// shockwaves
+// ---------------------------------------------------------------------------
+
+export const WAVE_VERT = /* glsl */ `
+  attribute vec2 iPos;
+  attribute float iT;
+  attribute float iStrength;
+  attribute float iPol;
+  varying vec2 vP;
+  varying float vT;
+  varying float vS;
+  varying float vPol;
+  void main(){
+    vP = position.xy * 2.0;
+    vT = iT; vS = iStrength; vPol = iPol;
+    float s = (4.0 + iT * 90.0 * iStrength);
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(iPos + position.xy * s, 0.0, 1.0);
+  }
+`;
+
+export const WAVE_FRAG =
+  COMMON +
+  /* glsl */ `
+  varying vec2 vP;
+  varying float vT;
+  varying float vS;
+  varying float vPol;
+  void main(){
+    float r = length(vP);
+    float th = mix(0.16, 0.02, vT);
+    float a = exp(-pow(abs(r - 0.92) / th, 2.0)) * (1.0 - vT) * (1.0 - vT);
+    // a second, offset ring gives the wave a chromatic leading edge
+    float a2 = exp(-pow(abs(r - 0.86) / (th * 1.6), 2.0)) * (1.0 - vT) * 0.5;
+    vec3 col = polA(vPol) * a + polB(vPol) * a2;
+    float al = clamp(a + a2, 0.0, 1.0) * 0.9 * vS;
+    if (al < 0.004) discard;
+    gl_FragColor = vec4(col, al);
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// foreground composite (flash, scanline, edge burn) — one full-screen quad
+// ---------------------------------------------------------------------------
+
+export const FRONT_VERT = BACKDROP_VERT;
+
+export const FRONT_FRAG =
+  COMMON +
+  /* glsl */ `
+  varying vec2 vUv;
+  uniform float uFlash;
+  uniform vec3 uFlashCol;
+  uniform float uTime;
+  uniform float uLoad;
+  uniform float uScan;
+  uniform float uAspect;
+  void main(){
+    vec2 p = (vUv - 0.5) * vec2(uAspect, 1.0) * 2.0;
+    vec3 col = uFlashCol * uFlash;
+    // overload pressure burns in from the frame edge — readable without colour
+    float edge = smoothstep(0.55, 1.5, length(p));
+    col += mix(vec3(0.25,0.45,1.0), vec3(1.0,0.22,0.26), smoothstep(0.6,1.0,uLoad))
+         * edge * uLoad * uLoad * 0.34 * (0.75 + 0.25 * sin(uTime * (4.0 + uLoad * 12.0)));
+    float scan = (0.5 + 0.5 * sin(vUv.y * 900.0)) * uScan * 0.035;
+    col += vec3(scan) * 0.5;
+    float a = clamp(max(uFlash, max(edge * uLoad * uLoad * 0.34, scan)), 0.0, 1.0);
+    if (a < 0.003) discard;
+    gl_FragColor = vec4(col, a);
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// final grade (mid + ultra): chromatic aberration, grain, soft vignette
+// ---------------------------------------------------------------------------
+
+export const GRADE_SHADER = {
+  uniforms: {
+    tDiffuse: { value: null as unknown },
+    uAmount: { value: 0 },
+    uTime: { value: 0 },
+    uGrain: { value: 0.05 },
+  },
+  vertexShader: /* glsl */ `
+    varying vec2 vUv;
+    void main(){ vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }
+  `,
+  fragmentShader:
+    COMMON +
+    /* glsl */ `
+    varying vec2 vUv;
+    uniform sampler2D tDiffuse;
+    uniform float uAmount;
+    uniform float uTime;
+    uniform float uGrain;
+    void main(){
+      vec2 c = vUv - 0.5;
+      float k = uAmount * 0.006 * (0.3 + dot(c, c) * 3.0);
+      vec4 col;
+      col.r = texture2D(tDiffuse, vUv + c * k).r;
+      col.g = texture2D(tDiffuse, vUv).g;
+      col.b = texture2D(tDiffuse, vUv - c * k).b;
+      col.a = 1.0;
+      col.rgb += (hash21(vUv * 1024.0 + fract(uTime * 7.0)) - 0.5) * uGrain;
+      col.rgb *= 0.72 + 0.28 * smoothstep(1.25, 0.25, length(c) * 2.0);
+      gl_FragColor = col;
+    }
+  `,
+};

--- a/dynawalla/games/polarity/src/render/view.ts
+++ b/dynawalla/games/polarity/src/render/view.ts
@@ -1,0 +1,23 @@
+import { HALF_W } from "../game/constants.ts";
+
+export type Fit = {
+  /** css pixels per world unit */
+  scale: number;
+  /** half the visible frustum, in world units */
+  halfWv: number;
+  halfHv: number;
+};
+
+/** Fit the 100-unit-wide playfield into the canvas, letterboxing the remainder. */
+export function fit(cssW: number, cssH: number, halfH: number): Fit {
+  const scale = Math.min(cssW / (2 * HALF_W), cssH / (2 * halfH));
+  return { scale, halfWv: cssW / (2 * scale), halfHv: cssH / (2 * scale) };
+}
+
+export function toWorldX(cssX: number, cssW: number, f: Fit): number {
+  return (cssX - cssW / 2) / f.scale;
+}
+
+export function toWorldY(cssY: number, cssH: number, f: Fit): number {
+  return -(cssY - cssH / 2) / f.scale;
+}

--- a/dynawalla/games/polarity/src/stubHost.test.ts
+++ b/dynawalla/games/polarity/src/stubHost.test.ts
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { VALUE_MAX, VALUE_MIN, chooseDistractors, makeStubHost } from "./stubHost.ts";
+import { makeRng } from "./core/rng.ts";
+import { parseInt_ } from "./math/signed.ts";
+
+// The host runs in the browser; `navigator` and `matchMedia` are absent under
+// node. haptic()/prefersReducedMotion() are only touched by the game, not here.
+test("every generated question is a well-formed signed-integer question", () => {
+  const h = makeStubHost({ seed: 1234 });
+  const domains = new Set<string>();
+  for (let i = 0; i < 4000; i++) {
+    // Sweep the difficulty band. The generator table is chosen by difficulty
+    // (EASY < 0.3 <= MID < 0.68 <= HARD), and `hard` only climbs in response to
+    // report(). A loop that just calls next() never leaves EASY, so it can only
+    // ever observe 3 of the 6 families and never exercises the MID/HARD ones.
+    const q = h.next({ difficulty: (i % 100) / 99 });
+    domains.add(q.domain);
+
+    const a = parseInt_(q.answer); // throws if not an exact integer
+    assert.ok(a >= VALUE_MIN && a <= VALUE_MAX, `answer out of orb range: ${q.answer}`);
+
+    assert.equal(q.distractors.length, 3, `wanted 3 distractors, got ${q.distractors.length}`);
+    const vals = q.distractors.map(parseInt_);
+    for (const v of vals) {
+      assert.ok(v >= VALUE_MIN && v <= VALUE_MAX, `distractor out of orb range: ${v}`);
+      assert.notEqual(v, a, `distractor equals the answer in ${q.prompt}`);
+    }
+    assert.equal(new Set(vals).size, 3, `duplicate distractors in ${q.prompt}`);
+
+    assert.ok(q.prompt.length > 0 && q.prompt.length <= 22, `prompt too long: ${q.prompt}`);
+    assert.doesNotMatch(q.prompt, /-/, "use U+2212, never a hyphen");
+    assert.ok(q.id.length > 0);
+    assert.ok(q.difficulty >= 0 && q.difficulty <= 1);
+  }
+  // the whole family table is reachable across a long run
+  assert.ok(domains.size >= 5, `only saw domains ${[...domains].join(",")}`);
+});
+
+test("prompts are arithmetically true", () => {
+  const h = makeStubHost({ seed: 77 });
+  const norm = (s: string): string => s.replace(/−/g, "-").replace(/×/g, "*");
+  let checked = 0;
+  for (let i = 0; i < 1500; i++) {
+    // Sweep difficulty here too, so the int-chain / int-mul / int-dist branches
+    // below are actually reached rather than passing vacuously.
+    const q = h.next({ difficulty: (i % 100) / 99 });
+    const a = parseInt_(q.answer);
+    const p = norm(q.prompt);
+    if (q.domain === "int-dist") {
+      const m = /^(-?\d+) to (-?\d+)$/.exec(p);
+      assert.ok(m, p);
+      assert.equal(a, Math.abs(Number(m[2]) - Number(m[1])));
+    } else if (q.domain === "int-missing") {
+      const m = /^(-?\d+) \+ \? = (-?\d+)$/.exec(p);
+      assert.ok(m, p);
+      assert.equal(Number(m[1]) + a, Number(m[2]));
+    } else {
+      // add / sub / chain / mul are plain infix over integers
+      assert.match(p, /^[-()\d+*\s]+$/, p);
+      // eslint-disable-next-line no-new-func -- test-only evaluation of our own generated infix
+      const v = Function(`"use strict";return (${p})`)() as number;
+      assert.equal(v, a, `${q.prompt} should be ${a}, computed ${v}`);
+    }
+    checked++;
+  }
+  assert.ok(checked === 1500);
+});
+
+test("seeded runs are byte-identical", () => {
+  const a = makeStubHost({ seed: 99 });
+  const b = makeStubHost({ seed: 99 });
+  for (let i = 0; i < 500; i++) assert.deepEqual(a.next(), b.next());
+});
+
+test("difficulty adapts up on fast-correct and down on wrong", () => {
+  const h = makeStubHost({ seed: 5, difficulty: 0.5 });
+  for (let i = 0; i < 10; i++)
+    h.report({ questionId: "x", correct: true, ms: 1200, answered: "1" });
+  assert.ok(h.difficulty() > 0.5);
+  for (let i = 0; i < 20; i++)
+    h.report({ questionId: "x", correct: false, ms: 4000, answered: "1" });
+  assert.equal(h.difficulty(), 0);
+  assert.ok(h.next().difficulty === 0);
+});
+
+test("a pinned domain is honoured", () => {
+  const h = makeStubHost({ seed: 3 });
+  for (let i = 0; i < 60; i++) assert.equal(h.next({ domain: "int-mul" }).domain, "int-mul");
+});
+
+test("chooseDistractors prefers same-sign mal-rules — the dangerous ones", () => {
+  const rng = makeRng(11);
+  // answer −5, mal-rules offering −11 (sign-of-larger) and +11, +13
+  const d = chooseDistractors(-5, [-11, 11, 13, -3], rng).map(parseInt_);
+  assert.equal(d.length, 3);
+  assert.ok(d.includes(-11) && d.includes(-3), `same-sign first: got ${d.join(",")}`);
+});
+
+test("chooseDistractors always fills to three even when mal-rules collide", () => {
+  const rng = makeRng(12);
+  const d = chooseDistractors(4, [4, 4, 4], rng).map(parseInt_);
+  assert.equal(new Set(d).size, 3);
+  assert.ok(!d.includes(4));
+});

--- a/dynawalla/games/polarity/src/stubHost.ts
+++ b/dynawalla/games/polarity/src/stubHost.ts
@@ -1,0 +1,285 @@
+/**
+ * Local stub Host so POLARITY is playable standalone with `npm run dev`.
+ *
+ * Every value here is an exact integer — no float reaches an answer or a
+ * comparison. The subject is signed integers, because that is literally the
+ * ship's mechanic: polarity is a sign and the core is a running signed sum.
+ *
+ * Distractors are real mal-rule outputs — the wrong answer a child actually
+ * produces when a specific procedure breaks — not random noise. That matters
+ * here more than usual: a distractor becomes a physical mine on the playfield,
+ * so a distractor that no one would ever pick is a wasted obstacle.
+ *
+ * Difficulty is adaptive (up on fast + correct, down on wrong), which is what
+ * the real host does, so swapping it in changes nothing about how this feels.
+ */
+import type { Host, Question } from "./contract.ts";
+import { makeRng, type Rng } from "./core/rng.ts";
+import { MINUS, fmtInt } from "./math/signed.ts";
+
+// ---------------------------------------------------------------------------
+// mal-rules — documented signed-integer errors
+// ---------------------------------------------------------------------------
+
+/** Adds magnitudes and keeps the sign of the larger one: −7 + 4 → −11. */
+export function malSignOfLarger(a: number, b: number): number {
+  const mag = Math.abs(a) + Math.abs(b);
+  const dom = Math.abs(a) >= Math.abs(b) ? a : b;
+  return dom < 0 ? -mag : mag;
+}
+
+/** Drops every minus sign and does the operation on magnitudes. */
+export function malSignsDropped(a: number, b: number, op: "+" | "-" | "*"): number {
+  const x = Math.abs(a);
+  const y = Math.abs(b);
+  return op === "+" ? x + y : op === "-" ? x - y : x * y;
+}
+
+/** "Always take the smaller from the larger": a − b becomes b − a. */
+export function malSubtractReversed(a: number, b: number): number {
+  return b - a;
+}
+
+/** Sees a − (−b) and cancels one minus too many: a − (−b) → a − b. */
+export function malDoubleNegCollapsed(a: number, b: number): number {
+  return a - Math.abs(b);
+}
+
+/** Reads a − b with b negative as a plain sum of magnitudes with a's sign. */
+export function malSubtractAsAdd(a: number, b: number): number {
+  return a + b;
+}
+
+/** "Two minuses in a product must leave a minus somewhere": (−a)(−b) → −ab. */
+export function malProductAlwaysNegative(a: number, b: number): number {
+  return -Math.abs(a * b);
+}
+
+/** Counts the endpoints as well as the steps on the number line. */
+export function malOffByOne(v: number): number {
+  return v >= 0 ? v + 1 : v - 1;
+}
+
+// ---------------------------------------------------------------------------
+// question families
+// ---------------------------------------------------------------------------
+
+type Built = { prompt: string; answer: number; wrong: number[]; domain: string };
+
+const NEG = (n: number): string => (n < 0 ? `(${MINUS}${-n})` : `${n}`);
+
+/** a + b, mixed signs. The bread and butter. */
+function intAdd(rng: Rng, hard: number): Built {
+  const span = 6 + Math.round(hard * 14);
+  let a = rng.i(1, span) * rng.sign();
+  let b = rng.i(1, span) * rng.sign();
+  if (rng.chance(0.55) && Math.sign(a) === Math.sign(b)) b = -b; // favour mixed signs
+  if (a === -b) b += rng.sign(); // avoid a trivial 0 too often
+  return {
+    prompt: `${fmtInt(a)} + ${NEG(b)}`,
+    answer: a + b,
+    wrong: [malSignOfLarger(a, b), malSignsDropped(a, b, "+"), a - b, malOffByOne(a + b)],
+    domain: "int-add",
+  };
+}
+
+/** a − b including a − (−b), the single most productive error site. */
+function intSub(rng: Rng, hard: number): Built {
+  const span = 6 + Math.round(hard * 14);
+  const a = rng.i(1, span) * (rng.chance(0.55) ? -1 : 1);
+  const b = rng.i(1, span) * (rng.chance(0.5) ? -1 : 1);
+  return {
+    prompt: `${fmtInt(a)} ${MINUS} ${NEG(b)}`,
+    answer: a - b,
+    wrong: [
+      malSubtractAsAdd(a, b),
+      malSubtractReversed(a, b),
+      malDoubleNegCollapsed(a, b),
+      malSignsDropped(a, b, "-"),
+    ],
+    domain: "int-sub",
+  };
+}
+
+/** Three terms — the running-sum skill the core gauge trains directly. */
+function intChain(rng: Rng, hard: number): Built {
+  const span = 4 + Math.round(hard * 9);
+  const a = rng.i(1, span) * rng.sign();
+  const b = rng.i(1, span) * rng.sign();
+  const c = rng.i(1, span) * rng.sign();
+  return {
+    prompt: `${fmtInt(a)} + ${NEG(b)} + ${NEG(c)}`,
+    answer: a + b + c,
+    wrong: [
+      a + b - c,
+      malSignOfLarger(a + b, c),
+      Math.abs(a) + Math.abs(b) + Math.abs(c),
+      a - b + c,
+    ],
+    domain: "int-chain",
+  };
+}
+
+/** Sign rules for a product, kept small so the answer stays on an orb. */
+function intMul(rng: Rng, hard: number): Built {
+  const hi = 3 + Math.round(hard * 5);
+  const a = rng.i(2, hi) * rng.sign();
+  const b = rng.i(2, Math.min(hi, 7)) * rng.sign();
+  return {
+    prompt: `${NEG(a)} × ${NEG(b)}`,
+    answer: a * b,
+    wrong: [
+      malProductAlwaysNegative(a, b),
+      malSignsDropped(a, b, "*"),
+      -(a * b),
+      a + b, // the perennial "multiply looks like add" slip
+    ],
+    domain: "int-mul",
+  };
+}
+
+/** Missing addend — reads as "what do I have to absorb to get there". */
+function intMissing(rng: Rng, hard: number): Built {
+  const span = 5 + Math.round(hard * 12);
+  const a = rng.i(1, span) * rng.sign();
+  const ans = rng.i(1, span) * rng.sign();
+  const c = a + ans;
+  return {
+    prompt: `${fmtInt(a)} + ? = ${fmtInt(c)}`,
+    answer: ans,
+    wrong: [c - Math.abs(a), Math.abs(c) - Math.abs(a), a - c, -ans],
+    domain: "int-missing",
+  };
+}
+
+/** Distance between two integers on the line — always non-negative. */
+function intDist(rng: Rng, hard: number): Built {
+  const span = 6 + Math.round(hard * 14);
+  const a = rng.i(-span, span);
+  const b = rng.i(-span, span);
+  if (a === b) return intDist(rng, hard);
+  return {
+    prompt: `${fmtInt(a)} to ${fmtInt(b)}`,
+    answer: Math.abs(b - a),
+    wrong: [b - a, a - b, Math.abs(a) + Math.abs(b), Math.abs(Math.abs(b) - Math.abs(a))],
+    domain: "int-dist",
+  };
+}
+
+type Gen = (rng: Rng, hard: number) => Built;
+
+const EASY: readonly Gen[] = [intAdd, intSub, intMissing];
+const MID: readonly Gen[] = [intAdd, intSub, intChain, intMul, intMissing, intDist];
+const HARD: readonly Gen[] = [intSub, intChain, intMul, intMissing, intDist];
+
+const BY_DOMAIN: Record<string, Gen> = {
+  "int-add": intAdd,
+  "int-sub": intSub,
+  "int-chain": intChain,
+  "int-mul": intMul,
+  "int-missing": intMissing,
+  "int-dist": intDist,
+};
+
+// ---------------------------------------------------------------------------
+// assembly
+// ---------------------------------------------------------------------------
+
+/** Orb values have to fit a two-character label and stay readable at speed. */
+export const VALUE_MIN = -40;
+export const VALUE_MAX = 40;
+
+function inRange(n: number): boolean {
+  return Number.isInteger(n) && n >= VALUE_MIN && n <= VALUE_MAX;
+}
+
+/**
+ * Pick three distinct, in-range distractors, preferring genuine mal-rules and
+ * padding with near-misses only if the mal-rules collide. At least one keeps
+ * the answer's sign where possible: same-sign distractors are the ones that
+ * are actually dangerous in flight, since you can phase through the others.
+ */
+export function chooseDistractors(answer: number, wrong: number[], rng: Rng): string[] {
+  const seen = new Set<number>([answer]);
+  const out: number[] = [];
+  const push = (n: number): void => {
+    if (out.length >= 3) return;
+    if (!inRange(n) || seen.has(n)) return;
+    seen.add(n);
+    out.push(n);
+  };
+  const sameSign = wrong.filter((w) => w !== 0 && answer !== 0 && Math.sign(w) === Math.sign(answer));
+  for (const w of rng.shuffle(sameSign.slice())) push(w);
+  for (const w of rng.shuffle(wrong.slice())) push(w);
+  for (let d = 1; out.length < 3 && d < 24; d++) {
+    push(answer + d);
+    push(answer - d);
+  }
+  return rng.shuffle(out).map(fmtInt);
+}
+
+export type StubOpts = {
+  seed?: number;
+  /** starting difficulty 0..1 */
+  difficulty?: number;
+  onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void;
+};
+
+/** Build the standalone host. Seeded, so a dev run is reproducible. */
+export function makeStubHost(opts: StubOpts = {}): Host & { difficulty(): number } {
+  const rng = makeRng(opts.seed ?? 0x50147);
+  let hard = Math.min(1, Math.max(0, opts.difficulty ?? 0.18));
+  let n = 0;
+
+  const build = (want?: { domain?: string; difficulty?: number }): Question => {
+    const d = Math.min(1, Math.max(0, want?.difficulty ?? hard));
+    const table = d < 0.3 ? EASY : d < 0.68 ? MID : HARD;
+    const pinned = want?.domain ? BY_DOMAIN[want.domain] : undefined;
+    let b: Built | null = null;
+    for (let attempt = 0; attempt < 40; attempt++) {
+      const cand = (pinned ?? rng.pick(table))(rng, d);
+      if (inRange(cand.answer)) {
+        b = cand;
+        break;
+      }
+    }
+    if (!b) b = intAdd(rng, 0.2);
+    n++;
+    return {
+      id: `stub-${n}-${b.domain}`,
+      prompt: b.prompt,
+      answer: fmtInt(b.answer),
+      distractors: chooseDistractors(b.answer, b.wrong, rng),
+      domain: b.domain,
+      difficulty: d,
+    };
+  };
+
+  return {
+    next: (o) => build(o),
+    report: (r) => {
+      if (r.correct) hard = Math.min(1, hard + (r.ms < 5200 ? 0.055 : 0.022));
+      else hard = Math.max(0, hard - 0.085);
+      opts.onReport?.(r);
+    },
+    haptic: (k) => {
+      const nav = navigator as Navigator & { vibrate?: (p: number | number[]) => boolean };
+      if (typeof nav.vibrate !== "function") return;
+      const pat: Record<string, number | number[]> = {
+        light: 8,
+        medium: 16,
+        heavy: 34,
+        success: [12, 26, 18],
+        failure: [30, 42, 30],
+      };
+      try {
+        nav.vibrate(pat[k] ?? 10);
+      } catch (e) {
+        console.warn("[polarity] vibrate failed", e);
+      }
+    },
+    prefersReducedMotion: () =>
+      typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion: reduce)").matches,
+    difficulty: () => hard,
+  };
+}

--- a/dynawalla/games/polarity/src/ui/hud.ts
+++ b/dynawalla/games/polarity/src/ui/hud.ts
@@ -1,0 +1,392 @@
+import { clamp01, fmtScore } from "../core/util.ts";
+import { fmtInt, fmtSigned, parseInt_ } from "../math/signed.ts";
+import { PLAYER } from "../game/constants.ts";
+import type { World } from "../game/world.ts";
+
+/**
+ * The HUD is DOM, not canvas: crisp numerals at every density, real safe-area
+ * insets, and a `prefers-reduced-motion` path that costs nothing. Everything
+ * here is written only when the value it shows actually changes, so a whole
+ * minute of play does zero layout work.
+ *
+ * The core gauge is the only piece a player really has to read, so it is the
+ * biggest thing on the screen after the ship: a signed numeral over a bar that
+ * grows LEFT for negative and RIGHT for positive. Sign is position, not colour.
+ */
+
+const el = <K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  cls?: string,
+  text?: string,
+): HTMLElementTagNameMap[K] => {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text !== undefined) n.textContent = text;
+  return n;
+};
+
+const CUE_TEXT: Record<string, string> = {
+  absorb: "ABSORB",
+  seal: "MATCH THE SIGN",
+  clutch: "CLUTCH",
+  release: "VENT",
+  lock: "VENT EXACTLY",
+};
+
+export type HudHooks = {
+  onFlip: () => void;
+  onVent: () => void;
+  onStart: () => void;
+  onAgain: () => void;
+  onRevive: (answered: string) => void;
+  onSkipRevive: () => void;
+  onToggleSound: () => void;
+  onTogglePause: () => void;
+};
+
+export class Hud {
+  readonly root: HTMLElement;
+  private readonly score: HTMLElement;
+  private readonly best: HTMLElement;
+  private readonly chain: HTMLElement;
+  private readonly coreNum: HTMLElement;
+  private readonly bar: HTMLElement;
+  private readonly fill: HTMLElement;
+  private readonly capL: HTMLElement;
+  private readonly capR: HTMLElement;
+  private readonly pips: HTMLElement[] = [];
+  private readonly stratum: HTMLElement;
+  private readonly cue: HTMLElement;
+  private readonly banner: HTMLElement;
+  private readonly padFlip: HTMLElement;
+  private readonly padVent: HTMLElement;
+  private readonly keyhint: HTMLElement;
+  private readonly veil: HTMLElement;
+  private readonly veilBody: HTMLElement;
+  private readonly sndBtn: HTMLButtonElement;
+  private readonly pauseBtn: HTMLButtonElement;
+
+  private last = {
+    score: -1,
+    best: -1,
+    chain: -1,
+    core: NaN,
+    cap: -1,
+    shields: -1,
+    stratum: -1,
+    pol: 0,
+    warn: -1,
+    veil: "",
+    ventReady: -1,
+  };
+  private cueKey = "";
+  private touch = false;
+
+  constructor(host: HTMLElement, private readonly hooks: HudHooks) {
+    this.root = el("div", "pol-hud");
+
+    // --- top -------------------------------------------------------------
+    const top = el("div", "pol-top");
+    const left = el("div");
+    this.score = el("div", "pol-score");
+    this.score.innerHTML = "<b>0</b>";
+    this.best = el("span", "pol-best", "BEST 0");
+    this.score.appendChild(this.best);
+    this.chain = el("div", "pol-chain", "×1");
+    left.append(this.score, this.chain);
+
+    const core = el("div", "pol-core");
+    this.coreNum = el("div", "pol-corenum", "0");
+    this.bar = el("div", "pol-bar");
+    this.fill = el("div", "pol-fill");
+    this.bar.appendChild(this.fill);
+    const caps = el("div", "pol-caps");
+    this.capL = el("span", undefined, "−20");
+    this.capR = el("span", undefined, "+20");
+    caps.append(this.capL, this.capR);
+    core.append(this.coreNum, this.bar, caps);
+
+    const right = el("div", "pol-right");
+    const shields = el("div", "pol-shields");
+    for (let i = 0; i < PLAYER.shields; i++) {
+      const p = el("i", "pol-pip");
+      this.pips.push(p);
+      shields.appendChild(p);
+    }
+    this.stratum = el("div", "pol-stratum", "STRATUM 0");
+    right.append(shields, this.stratum);
+
+    top.append(left, core, right);
+
+    // --- middle ----------------------------------------------------------
+    const mid = el("div", "pol-mid");
+    this.cue = el("div", "pol-cue");
+    mid.appendChild(this.cue);
+    this.banner = el("div", "pol-banner");
+
+    // --- bottom ----------------------------------------------------------
+    const pads = el("div", "pol-pads");
+    this.padFlip = el("div", "pol-pad", "FLIP");
+    this.padVent = el("div", "pol-pad", "VENT");
+    this.padVent.dataset.vent = "1";
+    pads.append(this.padFlip, this.padVent);
+    this.keyhint = el(
+      "div",
+      "pol-keyhint",
+      "MOVE  ←↑↓→ / WASD      FLIP  SPACE      VENT  SHIFT",
+    );
+
+    this.root.append(top, mid, pads, this.banner, this.keyhint);
+
+    // --- corner controls --------------------------------------------------
+    const mini = el("div", "pol-mini");
+    this.sndBtn = el("button", undefined, "SND") as HTMLButtonElement;
+    this.pauseBtn = el("button", undefined, "II") as HTMLButtonElement;
+    mini.append(this.sndBtn, this.pauseBtn);
+    this.root.appendChild(mini);
+
+    // --- overlay ----------------------------------------------------------
+    this.veil = el("div", "pol-veil");
+    this.veilBody = el("div");
+    this.veil.appendChild(this.veilBody);
+    this.root.appendChild(this.veil);
+
+    host.appendChild(this.root);
+
+    const tap = (n: HTMLElement, f: () => void): void => {
+      n.addEventListener(
+        "pointerdown",
+        (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          this.touch = this.touch || e.pointerType !== "mouse";
+          f();
+        },
+        { passive: false },
+      );
+    };
+    tap(this.padFlip, hooks.onFlip);
+    tap(this.padVent, hooks.onVent);
+    tap(this.sndBtn, hooks.onToggleSound);
+    tap(this.pauseBtn, hooks.onTogglePause);
+    window.addEventListener(
+      "pointerdown",
+      (e) => {
+        if (e.pointerType !== "mouse") this.touch = true;
+      },
+      { capture: true },
+    );
+  }
+
+  dispose(): void {
+    this.root.remove();
+  }
+
+  setSound(on: boolean): void {
+    this.sndBtn.dataset.off = on ? "0" : "1";
+  }
+
+  blocked(): boolean {
+    return !this.veil.hidden;
+  }
+
+  banner_(text: string): void {
+    this.banner.textContent = text;
+    this.banner.dataset.on = "0";
+    void this.banner.offsetWidth;
+    this.banner.dataset.on = "1";
+  }
+
+  // -------------------------------------------------------------------------
+
+  update(w: World, ventReady: boolean): void {
+    const L = this.last;
+
+    if (w.pol !== L.pol) {
+      L.pol = w.pol;
+      this.root.parentElement?.setAttribute("data-pol", String(w.pol));
+    }
+
+    const s = Math.floor(w.stats.score);
+    if (s !== L.score) {
+      L.score = s;
+      const b = this.score.firstChild;
+      if (b) b.textContent = fmtScore(s);
+    }
+    if (w.stats.best !== L.best) {
+      L.best = w.stats.best;
+      this.best.textContent = `BEST ${fmtScore(w.stats.best)}`;
+    }
+
+    const mult = Math.min(9, 1 + Math.floor(w.chain / 6));
+    if (mult !== L.chain) {
+      if (mult > L.chain && L.chain > 0) {
+        this.chain.dataset.hot = "0";
+        void this.chain.offsetWidth;
+        this.chain.dataset.hot = "1";
+      }
+      L.chain = mult;
+      this.chain.textContent = `×${mult}`;
+    }
+    this.chain.dataset.on = w.chainT > 0 && mult > 1 ? "1" : "0";
+
+    // --- the gauge
+    const shown = Math.round(w.coreShown);
+    const warn = Math.abs(w.core) >= w.cap - 2 ? 1 : 0;
+    if (shown !== L.core) {
+      L.core = shown;
+      this.coreNum.textContent = fmtSigned(shown);
+      this.coreNum.dataset.zero = shown === 0 ? "1" : "0";
+      const frac = clamp01(Math.abs(w.coreShown) / Math.max(1, w.cap));
+      this.fill.style.width = `${(frac * 50).toFixed(2)}%`;
+      this.fill.dataset.neg = w.coreShown < 0 ? "1" : "0";
+    }
+    if (warn !== L.warn) {
+      L.warn = warn;
+      this.coreNum.dataset.warn = String(warn);
+      this.bar.dataset.warn = String(warn);
+    }
+    if (w.cap !== L.cap) {
+      L.cap = w.cap;
+      this.capL.textContent = fmtInt(-w.cap);
+      this.capR.textContent = `+${w.cap}`;
+    }
+
+    if (w.shields !== L.shields) {
+      L.shields = w.shields;
+      for (let i = 0; i < this.pips.length; i++) {
+        const p = this.pips[i];
+        if (p) p.dataset.off = i < w.shields ? "0" : "1";
+      }
+    }
+    if (w.stratum !== L.stratum) {
+      L.stratum = w.stratum;
+      this.stratum.textContent = `STRATUM ${w.stratum}`;
+    }
+
+    const vr = ventReady ? 1 : 0;
+    if (vr !== L.ventReady) {
+      L.ventReady = vr;
+      this.padVent.dataset.ready = String(vr);
+    }
+
+    if (w.cueNow && w.cueNow !== this.cueKey && w.cueT > 0) {
+      this.cueKey = w.cueNow;
+      this.cue.textContent = CUE_TEXT[w.cueNow] ?? "";
+      this.cue.dataset.on = "0";
+      void this.cue.offsetWidth;
+      this.cue.dataset.on = "1";
+    }
+    if (w.cueT <= 0) this.cueKey = "";
+
+    const showPads = this.touch && w.phase === "play";
+    this.padFlip.dataset.hide = showPads ? "0" : "1";
+    this.padVent.dataset.hide = showPads ? "0" : "1";
+    this.keyhint.style.opacity = this.touch || w.phase !== "play" ? "0" : "";
+  }
+
+  // -------------------------------------------------------------------------
+  // overlays
+  // -------------------------------------------------------------------------
+
+  hideVeil(): void {
+    this.veil.hidden = true;
+    this.last.veil = "";
+  }
+
+  showTitle(best: number): void {
+    if (this.last.veil === "title") return;
+    this.last.veil = "title";
+    this.veil.hidden = false;
+    this.veilBody.replaceChildren();
+    const t = el("div", "pol-title");
+    t.innerHTML = "POLA<i>R</i><u>I</u>TY";
+    const sub = el(
+      "div",
+      "pol-sub",
+      "MATCH A BULLET'S SIGN TO DRINK IT. YOUR TOTAL IS THE WEAPON. VENT IT AT THE EDGE.",
+    );
+    const b = el("button", "pol-btn", "PLAY") as HTMLButtonElement;
+    b.addEventListener("pointerdown", (e) => {
+      e.preventDefault();
+      this.hooks.onStart();
+    });
+    this.veilBody.append(t, sub, b);
+    if (best > 0) this.veilBody.append(el("div", "pol-best", `BEST ${fmtScore(best)}`));
+  }
+
+  showPause(): void {
+    if (this.last.veil === "pause") return;
+    this.last.veil = "pause";
+    this.veil.hidden = false;
+    this.veilBody.replaceChildren();
+    const t = el("div", "pol-title", "PAUSED");
+    const b = el("button", "pol-btn", "RESUME") as HTMLButtonElement;
+    b.addEventListener("pointerdown", (e) => {
+      e.preventDefault();
+      this.hooks.onTogglePause();
+    });
+    this.veilBody.append(t, b);
+  }
+
+  /**
+   * The continue screen. This is the slot a free-to-play game fills with an
+   * advert; here it is one signed-integer question, and the reward is a full
+   * shield and a screen-clearing shockwave.
+   */
+  showRevive(prompt: string, options: string[], correct: string): void {
+    if (this.last.veil === "revive") return;
+    this.last.veil = "revive";
+    this.veil.hidden = false;
+    this.veilBody.replaceChildren();
+    const ask = el("div", "pol-ask", "REPOLARIZE");
+    const p = el("div", "pol-prompt", prompt);
+    const row = el("div", "pol-orbs");
+    for (const o of options) {
+      const v = parseInt_(o);
+      const btn = el("button", "pol-orb") as HTMLButtonElement;
+      btn.dataset.neg = v < 0 ? "1" : "0";
+      btn.appendChild(el("span", undefined, fmtInt(v)));
+      btn.addEventListener("pointerdown", (e) => {
+        e.preventDefault();
+        if (btn.dataset.dead === "1") return;
+        if (o === correct) this.hooks.onRevive(o);
+        else {
+          btn.dataset.dead = "1";
+          this.hooks.onSkipRevive();
+        }
+      });
+      row.appendChild(btn);
+    }
+    this.veilBody.append(ask, p, row);
+  }
+
+  showOver(w: World): void {
+    if (this.last.veil === "over") return;
+    this.last.veil = "over";
+    this.veil.hidden = false;
+    this.veilBody.replaceChildren();
+    const st = w.stats;
+    const head = el("div", "pol-over", st.score >= st.best && st.score > 0 ? "NEW BEST" : "RUN ENDED");
+    const n = el("div", "pol-final", fmtScore(st.score));
+    const grid = el("div", "pol-stats");
+    const mins = Math.floor(st.depth / 60);
+    const secs = Math.floor(st.depth % 60);
+    const rows: [string, string][] = [
+      ["TIME", `${mins}:${String(secs).padStart(2, "0")}`],
+      ["STRATUM", String(w.stratum)],
+      ["ABSORBED", String(st.absorbs)],
+      ["BEST CHAIN", String(st.bestChain)],
+      ["CLUTCH FLIPS", String(st.clutches)],
+      ["PERFECT VENTS", String(st.perfects)],
+      ["SEALS", `${st.right}/${st.asked}`],
+    ];
+    for (const [k, v] of rows) grid.append(el("span", undefined, k), el("span", undefined, v));
+    const b = el("button", "pol-btn", "AGAIN") as HTMLButtonElement;
+    b.addEventListener("pointerdown", (e) => {
+      e.preventDefault();
+      this.hooks.onAgain();
+    });
+    this.veilBody.append(head, n, grid, b);
+  }
+}

--- a/dynawalla/games/polarity/src/ui/styles.css
+++ b/dynawalla/games/polarity/src/ui/styles.css
@@ -1,0 +1,333 @@
+/* POLARITY — vector-monitor register. Hard edges, hairline rules, additive
+   neon. No cards, no gradients-as-decoration, no rounded SaaS chrome. */
+
+.pol-root {
+  --pos: #ffcd52;
+  --pos-dim: #7a5a1c;
+  --neg: #38dcff;
+  --neg-dim: #1a5e73;
+  --bad: #ff3d52;
+  --gold: #ffe08a;
+  --ink: #eef3ff;
+  --void: #03040b;
+  --face: 900 1em/1 ui-rounded, "SF Pro Rounded", "Segoe UI Variable Display", "Nimbus Sans",
+    Inter, system-ui, sans-serif;
+
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  background: var(--void);
+  color: var(--ink);
+  font: var(--face);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: none;
+  contain: strict;
+}
+
+.pol-root[data-pol="1"] { --now: var(--pos); --now-dim: var(--pos-dim); }
+.pol-root[data-pol="-1"] { --now: var(--neg); --now-dim: var(--neg-dim); }
+
+.pol-canvas { position: absolute; inset: 0; width: 100%; height: 100%; display: block; }
+
+.pol-hud {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  padding: max(10px, env(safe-area-inset-top)) max(10px, env(safe-area-inset-right))
+    max(10px, env(safe-area-inset-bottom)) max(10px, env(safe-area-inset-left));
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+}
+
+/* ---------------------------------------------------------------- top row */
+.pol-top { display: grid; grid-template-columns: 1fr auto 1fr; align-items: start; gap: 8px; }
+
+.pol-score { font-size: clamp(15px, 3.6vw, 26px); text-shadow: 0 0 14px #6cf8; }
+.pol-score b { font-weight: 900; }
+.pol-best { display: block; font-size: 0.52em; opacity: 0.45; letter-spacing: 0.16em; margin-top: 3px; }
+
+.pol-chain {
+  display: block;
+  margin-top: 6px;
+  font-size: clamp(13px, 3vw, 20px);
+  color: var(--gold);
+  opacity: 0;
+  transform: translateX(-4px);
+  transition: opacity 0.18s;
+}
+.pol-chain[data-on="1"] { opacity: 1; }
+.pol-chain[data-hot="1"] { animation: polBeat 0.45s ease-out; }
+
+.pol-right { justify-self: end; text-align: right; }
+.pol-shields { display: flex; gap: 5px; justify-content: flex-end; }
+.pol-pip {
+  width: clamp(11px, 2.6vw, 17px);
+  height: clamp(11px, 2.6vw, 17px);
+  border: 2px solid var(--now);
+  transform: rotate(45deg);
+  box-shadow: 0 0 10px color-mix(in srgb, var(--now) 60%, transparent);
+  transition: opacity 0.2s, background 0.2s;
+  background: color-mix(in srgb, var(--now) 55%, transparent);
+}
+.pol-pip[data-off="1"] { opacity: 0.22; background: none; box-shadow: none; }
+.pol-stratum {
+  margin-top: 7px;
+  font-size: clamp(10px, 2.2vw, 13px);
+  letter-spacing: 0.22em;
+  opacity: 0.55;
+}
+
+/* ------------------------------------------------------------- core gauge */
+.pol-core { justify-self: center; text-align: center; width: min(62vw, 340px); }
+
+.pol-corenum {
+  font-size: clamp(30px, 8.4vw, 62px);
+  line-height: 0.94;
+  color: var(--now);
+  text-shadow: 0 0 26px color-mix(in srgb, var(--now) 70%, transparent);
+  transition: color 0.12s;
+}
+.pol-corenum[data-warn="1"] { color: var(--bad); text-shadow: 0 0 30px #ff3d5288; animation: polBeat 0.36s infinite; }
+.pol-corenum[data-zero="1"] { color: #8a93ad; text-shadow: none; }
+
+.pol-bar {
+  position: relative;
+  height: clamp(9px, 2.1vw, 14px);
+  margin-top: 5px;
+  border: 1px solid #ffffff26;
+  background: #ffffff0a;
+}
+.pol-bar::before { /* the zero axis */
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: -3px;
+  bottom: -3px;
+  width: 2px;
+  background: #ffffffb0;
+  transform: translateX(-1px);
+}
+.pol-fill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 0;
+  background: var(--now);
+  box-shadow: 0 0 16px color-mix(in srgb, var(--now) 75%, transparent);
+  transform-origin: left center;
+}
+.pol-fill[data-neg="1"] { left: auto; right: 50%; }
+.pol-bar[data-warn="1"] { border-color: var(--bad); }
+.pol-bar[data-warn="1"] .pol-fill { background: var(--bad); box-shadow: 0 0 20px #ff3d5299; }
+.pol-caps {
+  display: flex;
+  justify-content: space-between;
+  font-size: clamp(9px, 2vw, 12px);
+  opacity: 0.4;
+  margin-top: 3px;
+  letter-spacing: 0.1em;
+}
+
+/* ------------------------------------------------------------------- cues */
+.pol-mid { display: grid; place-items: center; pointer-events: none; }
+.pol-cue {
+  font-size: clamp(20px, 6.4vw, 46px);
+  letter-spacing: 0.14em;
+  color: var(--gold);
+  text-shadow: 0 0 30px #ffe08a66;
+  opacity: 0;
+  transform: translateY(10px) scale(0.94);
+}
+.pol-cue[data-on="1"] { animation: polCue 2.2s ease-out forwards; }
+
+.pol-banner {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 34%;
+  text-align: center;
+  font-size: clamp(17px, 5vw, 34px);
+  letter-spacing: 0.3em;
+  color: var(--ink);
+  opacity: 0;
+}
+.pol-banner[data-on="1"] { animation: polCue 1.5s ease-out forwards; }
+
+/* ------------------------------------------------------------------- pads */
+.pol-pads { display: flex; justify-content: space-between; align-items: flex-end; gap: 10px; }
+.pol-pad {
+  pointer-events: auto;
+  width: clamp(64px, 19vw, 108px);
+  height: clamp(64px, 19vw, 108px);
+  border: 2px solid currentColor;
+  background: color-mix(in srgb, currentColor 10%, transparent);
+  color: var(--now);
+  display: grid;
+  place-items: center;
+  font-size: clamp(11px, 2.6vw, 15px);
+  letter-spacing: 0.16em;
+  cursor: pointer;
+  clip-path: polygon(16% 0, 100% 0, 100% 84%, 84% 100%, 0 100%, 0 16%);
+  transition: transform 0.07s, background 0.12s, opacity 0.2s;
+  touch-action: none;
+}
+.pol-pad:active { transform: scale(0.93); background: color-mix(in srgb, currentColor 28%, transparent); }
+.pol-pad[data-vent="1"] { color: var(--gold); }
+.pol-pad[data-ready="1"] { animation: polReady 1.05s ease-in-out infinite; }
+.pol-pad[data-hide="1"] { opacity: 0; pointer-events: none; }
+
+.pol-keyhint {
+  position: absolute;
+  bottom: max(10px, env(safe-area-inset-bottom));
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: clamp(9px, 1.9vw, 12px);
+  letter-spacing: 0.2em;
+  opacity: 0.35;
+}
+
+/* --------------------------------------------------------------- overlays */
+.pol-veil {
+  position: absolute;
+  inset: 0;
+  pointer-events: auto;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(120% 90% at 50% 40%, #03040bd0, #03040bfa);
+  backdrop-filter: blur(3px);
+  padding: 20px;
+  text-align: center;
+}
+.pol-veil[hidden] { display: none; }
+
+.pol-title { font-size: clamp(40px, 13vw, 112px); letter-spacing: 0.06em; line-height: 0.9; }
+.pol-title i { font-style: normal; color: var(--pos); }
+.pol-title u { text-decoration: none; color: var(--neg); }
+.pol-sub {
+  margin-top: 14px;
+  font-size: clamp(11px, 2.7vw, 15px);
+  letter-spacing: 0.18em;
+  opacity: 0.6;
+  max-width: 30ch;
+  line-height: 1.7;
+}
+
+.pol-btn {
+  margin-top: 26px;
+  pointer-events: auto;
+  border: 2px solid var(--gold);
+  color: var(--gold);
+  background: #ffe08a14;
+  padding: 15px 40px;
+  font: var(--face);
+  font-size: clamp(16px, 4.2vw, 24px);
+  letter-spacing: 0.24em;
+  cursor: pointer;
+  clip-path: polygon(10px 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%, 0 10px);
+  transition: transform 0.08s, background 0.15s;
+}
+.pol-btn:active { transform: scale(0.96); }
+.pol-btn:hover { background: #ffe08a2a; }
+
+.pol-prompt {
+  font-size: clamp(30px, 9vw, 62px);
+  letter-spacing: 0.04em;
+  margin-bottom: 8px;
+}
+.pol-ask { font-size: clamp(10px, 2.4vw, 13px); letter-spacing: 0.3em; opacity: 0.5; }
+
+.pol-orbs { display: flex; gap: clamp(10px, 3.4vw, 26px); margin-top: 26px; justify-content: center; }
+.pol-orb {
+  pointer-events: auto;
+  width: clamp(74px, 22vw, 118px);
+  height: clamp(74px, 22vw, 118px);
+  display: grid;
+  place-items: center;
+  font: var(--face);
+  font-size: clamp(24px, 7vw, 40px);
+  color: var(--pos);
+  border: 3px solid currentColor;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 42%, color-mix(in srgb, currentColor 26%, transparent), transparent 68%);
+  box-shadow: 0 0 30px color-mix(in srgb, currentColor 45%, transparent), inset 0 0 22px color-mix(in srgb, currentColor 25%, transparent);
+  cursor: pointer;
+  transition: transform 0.09s;
+}
+.pol-orb[data-neg="1"] { color: var(--neg); border-radius: 50%; }
+.pol-orb[data-neg="0"] { border-radius: 12%; transform: rotate(45deg); }
+.pol-orb[data-neg="0"] span { transform: rotate(-45deg); }
+.pol-orb:active { transform: scale(0.93); }
+.pol-orb[data-neg="0"]:active { transform: rotate(45deg) scale(0.93); }
+.pol-orb[data-dead="1"] { opacity: 0.2; pointer-events: none; }
+
+.pol-stats {
+  margin-top: 20px;
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  gap: 6px 26px;
+  font-size: clamp(11px, 2.7vw, 15px);
+  letter-spacing: 0.1em;
+  opacity: 0.75;
+}
+.pol-stats span:nth-child(odd) { opacity: 0.5; text-align: right; }
+.pol-stats span:nth-child(even) { text-align: left; color: var(--gold); }
+
+.pol-final { font-size: clamp(34px, 11vw, 78px); color: var(--gold); line-height: 1; }
+.pol-over { font-size: clamp(12px, 3vw, 17px); letter-spacing: 0.34em; opacity: 0.55; }
+
+.pol-mini {
+  position: absolute;
+  top: max(10px, env(safe-area-inset-top));
+  right: max(10px, env(safe-area-inset-right));
+  display: flex;
+  gap: 8px;
+  pointer-events: auto;
+}
+.pol-mini button {
+  width: 34px;
+  height: 34px;
+  border: 1px solid #ffffff33;
+  background: #ffffff0d;
+  color: var(--ink);
+  font: var(--face);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  opacity: 0.6;
+}
+.pol-mini button[data-off="1"] { opacity: 0.24; }
+
+/* ----------------------------------------------------------------- motion */
+@keyframes polBeat {
+  0% { transform: scale(1); }
+  40% { transform: scale(1.16); }
+  100% { transform: scale(1); }
+}
+@keyframes polCue {
+  0% { opacity: 0; transform: translateY(14px) scale(0.9); }
+  14% { opacity: 1; transform: translateY(0) scale(1.04); }
+  24% { transform: translateY(0) scale(1); }
+  76% { opacity: 1; }
+  100% { opacity: 0; transform: translateY(-10px) scale(1); }
+}
+@keyframes polReady {
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, currentColor 55%, transparent); }
+  50% { box-shadow: 0 0 0 10px transparent; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pol-chain[data-hot="1"], .pol-corenum[data-warn="1"], .pol-pad[data-ready="1"] { animation: none; }
+  .pol-cue[data-on="1"], .pol-banner[data-on="1"] { animation: polFade 2.2s linear forwards; }
+  @keyframes polFade { 0%, 88% { opacity: 1; } 100% { opacity: 0; } }
+}
+
+@media (max-width: 360px) {
+  .pol-core { width: 74vw; }
+  .pol-stats { grid-template-columns: auto auto; gap: 4px 14px; }
+}

--- a/dynawalla/games/polarity/tsconfig.json
+++ b/dynawalla/games/polarity/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": [],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": false,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src", "vite.config.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/dynawalla/games/polarity/tsconfig.test.json
+++ b/dynawalla/games/polarity/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "types": ["node"] },
+  "include": ["src"],
+  "exclude": []
+}

--- a/dynawalla/games/polarity/vite.config.ts
+++ b/dynawalla/games/polarity/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  base: "./",
+  server: { port: 4211, strictPort: false },
+  build: { target: "es2022", assetsInlineLimit: 100000 },
+});


### PR DESCRIPTION
## What

Commit `dynawalla/games/polarity` — COUNTERPOISE, a brass polarity where the scale physically is the equals sign.

## Why

This prototype existed **only as untracked files in a worktree**. It appeared in
zero git refs: `git log --all -- dynawalla/games/polarity` returned no commits. It was
never committed, never branched, never pushed. Pruning that worktree — which the
repo's own session hook recommends doing after a merge — would have destroyed it
with no reflog and no dangling object to recover from.

Ten sibling prototypes were in the same state. This PR is one of that set.

### Fix carried in this PR

The stubHost test asserted that the whole family table is reachable and failed,
seeing only `int-add`, `int-sub`, `int-missing`.

**The host is right; the test was under-specified.** The generator table is
chosen by difficulty (`EASY < 0.3 <= MID < 0.68 <= HARD`) and difficulty only
climbs in response to `report()`. A loop that just calls `next()` sits at the
0.18 start forever, so `int-chain`, `int-mul` and `int-dist` were never
generated — and the arithmetic-truth test's branches for those three passed
vacuously. Both loops now sweep the difficulty band, so all six families are
genuinely exercised for the first time.

## Blast radius

**Areas touched:** dynawalla (new directory only)

- [x] Additive only. Every path is new under `dynawalla/games/polarity/`; no existing
      file is modified or deleted. Nothing imports it yet.
- [ ] **Every touched path is covered by a `ci.yml` area filter** — **NO, and
      stated deliberately.** `dynawalla/games/` is absent from the `covered`
      regex (`ci.yml:226`), so the `uncovered` step will warn. This is
      pre-existing: the five games already on `main` have no CI either. No job
      builds, type-checks or tests any game. The gates below were therefore run
      locally, by hand. A games-area filter is the correct follow-up and is
      called out rather than silently bundled here.
- [x] **Pack back-compat.** No published pack zip, `voiceId` or catalog entry
      touched. App floor 0.20.6 unaffected.
- [x] **Native integrity.** No Rust, no `src-tauri`, no `links =`, no `[patch]`.
- [x] **Strings.** No `corpan-app` locale keys added; this pack does not use the
      Corpán i18n catalog.
- [x] **Curriculum.** No skill id renamed or reused, no grade metadata changed,
      no generator binding altered.
- [x] **Secrets.** No `.p8`, keystore, service-account JSON, issuer id, key id or
      token. Verified the diff is source, config and `index.html` only.

`package-lock.json` and `qa/shots` are gitignored, matching
`dynawalla/games/slice` and `.../siege`.

## Proof

Run in `dynawalla/games/polarity/` after `npm install`:

```
$ npm test
# tests 15 # pass 15 # fail 0 

$ npm run tsc          # tsc --noEmit
0 errors

$ npm run build
✓ built in 140ms
```

Scope check — the branch adds this game and nothing else:

```
$ git diff --name-only origin/main...HEAD | grep -cv '^dynawalla/games/polarity/'
0
$ git diff --diff-filter=D --name-only origin/main...HEAD | wc -l
0
```
