### PR TITLE
dynawalla/games/pulse: PULSE — a rhythm-action game where a note's position is its fraction of the bar

### DIFF
--- a/dynawalla/games/pulse/.gitignore
+++ b/dynawalla/games/pulse/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+dist-pack/
+
+# Playtest capture output: multi-MB PNGs, regenerated on demand.
+qa/shots
+qa/tmp
+
+# Not tracked, matching dynawalla/games/slice and .../merge. These prototypes
+# pin nothing beyond vite + typescript in devDependencies.
+package-lock.json

--- a/dynawalla/games/pulse/index.html
+++ b/dynawalla/games/pulse/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#04050a" />
+    <title>PULSE</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/pulse/package.json
+++ b/dynawalla/games/pulse/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@dynawalla/game-pulse",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "PULSE — a rhythm-action game where fractions are literally rhythm. The visible playfield is exactly one bar; a note's position is its fraction of the whole.",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4173",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\""
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.3",
+    "typescript": "~5.8.3",
+    "vite": "^6.3.5"
+  }
+}

--- a/dynawalla/games/pulse/src/audio/engine.ts
+++ b/dynawalla/games/pulse/src/audio/engine.ts
@@ -1,0 +1,200 @@
+/**
+ * The audio engine. Everything is synthesised — there is not one asset byte.
+ *
+ * Signal flow:
+ *
+ *   drumBus ┐
+ *   musicBus├─► preMix ─► colour(lowpass) ─► glue(comp) ─► drive(softclip) ─► master
+ *   fxBus   ┘      ▲                                                            │
+ *                  │                                                            ▼
+ *   reverbReturn ◄─ convolver ◄─ reverbSend                                  analyser ─► out
+ *
+ * The compressor sits BEFORE the soft clipper, not after. Reversed — which is the
+ * order you reach for first — a loud bar hits the clipper flat out and the master bus
+ * turns into a square wave, which is exactly what happened here the first time. The
+ * clipper is now a safety net that only the transients touch.
+ *
+ * `colour` is the punishment: a missed phrase sweeps it down to 380 Hz and the whole
+ * track goes underwater for a bar. Nothing flashes red; the music just gets worse,
+ * which is how a real band tells you that you dropped it.
+ */
+
+export type Engine = {
+  ctx: AudioContext;
+  drumBus: GainNode;
+  musicBus: GainNode;
+  fxBus: GainNode;
+  reverbSend: GainNode;
+  colour: BiquadFilterNode;
+  master: GainNode;
+  analyser: AnalyserNode;
+  noise: AudioBuffer;
+  /** Current audio-clock time, in seconds. */
+  now(): number;
+  /** Output latency in seconds — how far ahead of the speaker the clock runs. */
+  latency(): number;
+  wave: Float32Array;
+  spectrum: Uint8Array;
+  /** Refresh `wave` and `spectrum` from the analyser. Call once per rendered frame. */
+  sample(): void;
+  setMuted(m: boolean): void;
+  muted(): boolean;
+  resume(): Promise<void>;
+  dispose(): void;
+};
+
+function softClipCurve(amount: number): Float32Array {
+  const n = 2048;
+  const curve = new Float32Array(n);
+  for (let i = 0; i < n; i++) {
+    const x = (i / (n - 1)) * 2 - 1;
+    curve[i] = Math.tanh(x * amount) / Math.tanh(amount);
+  }
+  return curve;
+}
+
+/** A synthetic impulse response: decaying noise with a slight early-reflection tilt. */
+function makeIR(ctx: AudioContext, seconds: number, decay: number): AudioBuffer {
+  const len = Math.max(1, Math.floor(ctx.sampleRate * seconds));
+  const buf = ctx.createBuffer(2, len, ctx.sampleRate);
+  for (let c = 0; c < 2; c++) {
+    const ch = buf.getChannelData(c);
+    let last = 0;
+    for (let i = 0; i < len; i++) {
+      const t = i / len;
+      const env = Math.pow(1 - t, decay);
+      // Slightly low-passed noise reads as a room rather than as hiss.
+      const white = Math.random() * 2 - 1;
+      last = last * 0.42 + white * 0.58;
+      const early = i < len * 0.02 ? 1.6 : 1;
+      ch[i] = last * env * early * 0.6;
+    }
+  }
+  return buf;
+}
+
+function makeNoise(ctx: AudioContext, seconds: number): AudioBuffer {
+  const len = Math.floor(ctx.sampleRate * seconds);
+  const buf = ctx.createBuffer(1, len, ctx.sampleRate);
+  const ch = buf.getChannelData(0);
+  for (let i = 0; i < len; i++) ch[i] = Math.random() * 2 - 1;
+  return buf;
+}
+
+export function createEngine(): Engine {
+  const Ctor: typeof AudioContext =
+    window.AudioContext ?? (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+  const ctx = new Ctor({ latencyHint: "interactive" });
+
+  const master = ctx.createGain();
+  master.gain.value = 0.78;
+
+  const analyser = ctx.createAnalyser();
+  analyser.fftSize = 2048;
+  analyser.smoothingTimeConstant = 0.72;
+  analyser.minDecibels = -84;
+  analyser.maxDecibels = -6;
+
+  const glue = ctx.createDynamicsCompressor();
+  glue.threshold.value = -20;
+  glue.knee.value = 26;
+  glue.ratio.value = 6;
+  glue.attack.value = 0.004;
+  glue.release.value = 0.14;
+
+  const drive = ctx.createWaveShaper();
+  drive.curve = softClipCurve(1.25);
+  drive.oversample = "2x";
+
+  const colour = ctx.createBiquadFilter();
+  colour.type = "lowpass";
+  colour.frequency.value = 20000;
+  colour.Q.value = 0.9;
+
+  const preMix = ctx.createGain();
+  preMix.gain.value = 0.5;
+
+  const drumBus = ctx.createGain();
+  const musicBus = ctx.createGain();
+  const fxBus = ctx.createGain();
+  drumBus.gain.value = 0.9;
+  musicBus.gain.value = 0.7;
+  fxBus.gain.value = 0.7;
+
+  const convolver = ctx.createConvolver();
+  convolver.buffer = makeIR(ctx, 1.9, 2.6);
+  const reverbSend = ctx.createGain();
+  reverbSend.gain.value = 0.8;
+  const reverbReturn = ctx.createGain();
+  reverbReturn.gain.value = 0.3;
+
+  drumBus.connect(preMix);
+  musicBus.connect(preMix);
+  fxBus.connect(preMix);
+  reverbSend.connect(convolver);
+  convolver.connect(reverbReturn);
+  reverbReturn.connect(preMix);
+
+  preMix.connect(colour);
+  colour.connect(glue);
+  glue.connect(drive);
+  drive.connect(master);
+  master.connect(analyser);
+  analyser.connect(ctx.destination);
+
+  const noise = makeNoise(ctx, 2);
+  const wave = new Float32Array(analyser.fftSize);
+  const spectrum = new Uint8Array(analyser.frequencyBinCount);
+
+  let isMuted = false;
+  let prevGain = 0.9;
+
+  return {
+    ctx,
+    drumBus,
+    musicBus,
+    fxBus,
+    reverbSend,
+    colour,
+    master,
+    analyser,
+    noise,
+    wave,
+    spectrum,
+    now: () => ctx.currentTime,
+    latency: () => {
+      const c = ctx as AudioContext & { outputLatency?: number };
+      const out = typeof c.outputLatency === "number" && c.outputLatency > 0 ? c.outputLatency : 0;
+      return out || ctx.baseLatency || 0.012;
+    },
+    sample() {
+      analyser.getFloatTimeDomainData(wave);
+      analyser.getByteFrequencyData(spectrum);
+    },
+    setMuted(m) {
+      if (m === isMuted) return;
+      isMuted = m;
+      const t = ctx.currentTime;
+      if (m) {
+        prevGain = master.gain.value;
+        master.gain.cancelScheduledValues(t);
+        master.gain.setTargetAtTime(0.0001, t, 0.02);
+      } else {
+        master.gain.cancelScheduledValues(t);
+        master.gain.setTargetAtTime(prevGain, t, 0.02);
+      }
+    },
+    muted: () => isMuted,
+    async resume() {
+      if (ctx.state !== "running") await ctx.resume();
+    },
+    dispose() {
+      try {
+        master.disconnect();
+        void ctx.close();
+      } catch {
+        /* already gone */
+      }
+    },
+  };
+}

--- a/dynawalla/games/pulse/src/audio/music.ts
+++ b/dynawalla/games/pulse/src/audio/music.ts
@@ -1,0 +1,62 @@
+/**
+ * The harmony. A minor, four-bar loop, one chord per bar, so a whole bar is one
+ * colour and the fraction gate that lands on that bar has a home key.
+ *
+ * Layers unlock as the player earns them. That is the reward: not a badge, a bass
+ * player turning up.
+ */
+
+/** Semitone offset from A2 (110 Hz) → frequency. */
+export function hz(semis: number): number {
+  return 110 * Math.pow(2, semis / 12);
+}
+
+export type Chord = { root: number; quality: "min" | "maj" | "sus" };
+
+/** i — VI — III — VII in A minor: Am, F, C, G. */
+export const PROGRESSION: readonly Chord[] = [
+  { root: 0, quality: "min" },
+  { root: 8, quality: "maj" },
+  { root: 3, quality: "maj" },
+  { root: 10, quality: "maj" },
+];
+
+const TRIAD: Record<Chord["quality"], readonly number[]> = {
+  min: [0, 3, 7],
+  maj: [0, 4, 7],
+  sus: [0, 5, 7],
+};
+
+export function chordAt(bar: number): Chord {
+  return PROGRESSION[((bar % PROGRESSION.length) + PROGRESSION.length) % PROGRESSION.length]!;
+}
+
+/** Voiced up in the pad register. */
+export function chordFreqs(c: Chord, octave = 2): number[] {
+  return TRIAD[c.quality].map((s) => hz(c.root + s + 12 * octave));
+}
+
+/** A minor pentatonic — every note in it sounds right over every chord in the loop. */
+export const PENTATONIC = [0, 3, 5, 7, 10] as const;
+
+/**
+ * The combo melody. Hit 1 is low, hit 40 is two octaves up and glittering. This is
+ * the single strongest reason to keep a streak alive, and it costs nothing.
+ */
+export function comboNote(combo: number): number {
+  const idx = combo % PENTATONIC.length;
+  const oct = Math.min(3, Math.floor(combo / PENTATONIC.length));
+  return hz(PENTATONIC[idx]! + 12 * (2 + oct));
+}
+
+export type LayerId = "bass" | "arp" | "pad" | "shaker";
+export const LAYER_ORDER: readonly LayerId[] = ["bass", "pad", "arp", "shaker"];
+
+/** Bass rhythm per stage tier, as beat offsets inside a bar. */
+export const BASS_PATTERNS: readonly (readonly number[])[] = [
+  [0],
+  [0, 2],
+  [0, 1.5, 2],
+  [0, 0.75, 2, 2.5],
+  [0, 0.5, 1.5, 2, 3, 3.5],
+];

--- a/dynawalla/games/pulse/src/audio/scheduler.test.ts
+++ b/dynawalla/games/pulse/src/audio/scheduler.test.ts
@@ -1,0 +1,70 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Lookahead, Timeline } from "./scheduler.ts";
+
+test("the tempo map does not move anything already scheduled", () => {
+  const tl = new Timeline(10, 120, 4);
+  const beat8 = tl.timeAt(8);
+  assert.ok(Math.abs(beat8 - (10 + 8 * 0.5)) < 1e-9);
+  tl.setTempoAtBeat(8, 60);
+  assert.ok(Math.abs(tl.timeAt(8) - beat8) < 1e-9, "the join must be continuous");
+  assert.ok(Math.abs(tl.timeAt(4) - (10 + 2)) < 1e-9, "earlier beats must not move");
+  assert.ok(Math.abs(tl.timeAt(12) - (beat8 + 4)) < 1e-9, "later beats run at the new tempo");
+});
+
+test("beat and time are inverses across a tempo change", () => {
+  const tl = new Timeline(0, 100, 4);
+  tl.setTempoAtBeat(16, 150);
+  tl.setTempoAtBeat(32, 84);
+  for (const beat of [0, 3.5, 15.9, 16, 24, 32, 40.25]) {
+    assert.ok(Math.abs(tl.beatAt(tl.timeAt(beat)) - beat) < 1e-9, `round trip failed at ${beat}`);
+  }
+});
+
+test("negative beats extrapolate, so a count-in has somewhere to live", () => {
+  const tl = new Timeline(5, 120, 4);
+  assert.ok(Math.abs(tl.timeAt(-4) - (5 - 2)) < 1e-9);
+});
+
+test("bars and beats agree", () => {
+  const tl = new Timeline(0, 90, 4);
+  assert.equal(tl.beatOfBar(3), 12);
+  assert.equal(tl.barOfBeat(12), 3);
+  assert.equal(tl.barOfBeat(13.9), 3);
+  assert.equal(tl.spbAtBeat(0), 60 / 90);
+});
+
+test("the lookahead fills every bar exactly once, in order, ahead of time", () => {
+  const tl = new Timeline(0, 120, 4); // a bar is 2 s
+  let now = 0;
+  const filled: number[] = [];
+  const times: number[] = [];
+  const la = new Lookahead(
+    () => now,
+    tl,
+    (bar, t) => {
+      filled.push(bar);
+      times.push(t - now);
+    },
+    { lookaheadSec: () => 2.4 },
+  );
+  la.start(0);
+  for (let i = 0; i < 400; i++) {
+    now += 1 / 60;
+    la.pump();
+  }
+  la.stop();
+  assert.deepEqual(filled, [...filled].sort((a, b) => a - b), "bars must arrive in order");
+  assert.equal(new Set(filled).size, filled.length, "no bar may be filled twice");
+  assert.ok(filled.length >= 3, "bars should keep arriving");
+  // Every bar was handed over before it started, which is what makes it visible.
+  for (const lead of times) assert.ok(lead >= 0, `a bar was filled ${lead.toFixed(3)} s late`);
+});
+
+test("a lookahead shorter than a bar would hide notes; the run's is not", () => {
+  // The playfield shows exactly one bar, so the schedule depth must exceed one bar.
+  const bpm = 84;
+  const barSeconds = (60 / bpm) * 4;
+  const runLookahead = barSeconds * 1.2 + 0.25;
+  assert.ok(runLookahead > barSeconds, "notes would pop in already arriving");
+});

--- a/dynawalla/games/pulse/src/audio/scheduler.ts
+++ b/dynawalla/games/pulse/src/audio/scheduler.ts
@@ -1,0 +1,135 @@
+/**
+ * Transport and lookahead scheduling — "A Tale of Two Clocks".
+ *
+ * `setInterval` jitters by tens of milliseconds, which is audible and fatal in a
+ * rhythm game. So the interval never *plays* anything: it walks the timeline a
+ * lookahead window ahead and hands every event an absolute `AudioContext` time.
+ * The audio thread places them with sample accuracy.
+ *
+ * Tempo is a piecewise map, not a scalar, so a stage can change BPM at a bar line
+ * without any previously scheduled event moving.
+ */
+
+export type TempoSegment = { beat0: number; time0: number; spb: number };
+
+export class Timeline {
+  private segs: TempoSegment[];
+  readonly beatsPerBar: number;
+
+  constructor(startTime: number, bpm: number, beatsPerBar = 4) {
+    this.segs = [{ beat0: 0, time0: startTime, spb: 60 / bpm }];
+    this.beatsPerBar = beatsPerBar;
+  }
+
+  get bpm(): number {
+    return 60 / this.segs[this.segs.length - 1]!.spb;
+  }
+
+  /** Change tempo starting at an absolute beat. Must be >= the last segment start. */
+  setTempoAtBeat(beat: number, bpm: number): void {
+    const spb = 60 / bpm;
+    const last = this.segs[this.segs.length - 1]!;
+    if (Math.abs(last.spb - spb) < 1e-9) return;
+    if (beat <= last.beat0) {
+      this.segs[this.segs.length - 1] = { beat0: last.beat0, time0: last.time0, spb };
+      return;
+    }
+    this.segs.push({ beat0: beat, time0: this.timeAt(beat), spb });
+  }
+
+  timeAt(beat: number): number {
+    let seg = this.segs[0]!;
+    for (const s of this.segs) if (s.beat0 <= beat) seg = s;
+    return seg.time0 + (beat - seg.beat0) * seg.spb;
+  }
+
+  beatAt(time: number): number {
+    let seg = this.segs[0]!;
+    for (const s of this.segs) if (s.time0 <= time) seg = s;
+    return seg.beat0 + (time - seg.time0) / seg.spb;
+  }
+
+  /** Seconds per beat at an absolute beat — used to size timing windows visually. */
+  spbAtBeat(beat: number): number {
+    let seg = this.segs[0]!;
+    for (const s of this.segs) if (s.beat0 <= beat) seg = s;
+    return seg.spb;
+  }
+
+  barOfBeat(beat: number): number {
+    return Math.floor(beat / this.beatsPerBar);
+  }
+  beatOfBar(bar: number): number {
+    return bar * this.beatsPerBar;
+  }
+}
+
+export type SchedulerOptions = {
+  /**
+   * How far ahead bars are committed, in seconds. This is a function because it must
+   * exceed one bar: the playfield shows exactly one bar of future, so a note has to
+   * exist a whole measure before it is heard or it pops into view already arriving.
+   * At 84 BPM that is ~3.3 s of scheduling depth, which Web Audio handles happily —
+   * the only cost is that a mix change lands on the next bar line instead of
+   * instantly, which is where a musician would put it anyway.
+   */
+  lookaheadSec?: () => number;
+  /** How often the walker runs. */
+  tickMs?: number;
+};
+
+/**
+ * Pulls musical bars into the future. `fill(bar)` is called exactly once per bar,
+ * in order, as soon as that bar's start time falls inside the lookahead window.
+ */
+export class Lookahead {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private nextBar = 0;
+  readonly lookaheadSec: () => number;
+  private readonly tickMs: number;
+  private readonly now: () => number;
+  private readonly timeline: Timeline;
+  private readonly fill: (bar: number, barStartTime: number) => void;
+
+  constructor(
+    now: () => number,
+    timeline: Timeline,
+    fill: (bar: number, barStartTime: number) => void,
+    opts: SchedulerOptions = {},
+  ) {
+    this.now = now;
+    this.timeline = timeline;
+    this.fill = fill;
+    this.lookaheadSec = opts.lookaheadSec ?? (() => 0.28);
+    this.tickMs = opts.tickMs ?? 22;
+  }
+
+  start(fromBar = 0): void {
+    this.nextBar = fromBar;
+    this.pump();
+    this.timer = setInterval(() => this.pump(), this.tickMs);
+  }
+
+  stop(): void {
+    if (this.timer !== null) clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  /** Bars already handed to `fill`. */
+  get filledThrough(): number {
+    return this.nextBar - 1;
+  }
+
+  pump(): void {
+    const horizon = this.now() + this.lookaheadSec();
+    // Guard against a runaway loop if a fill() call never advances the clock.
+    let guard = 0;
+    while (guard++ < 64) {
+      const t = this.timeline.timeAt(this.timeline.beatOfBar(this.nextBar));
+      if (t > horizon) break;
+      const bar = this.nextBar;
+      this.nextBar++;
+      this.fill(bar, t);
+    }
+  }
+}

--- a/dynawalla/games/pulse/src/audio/voices.ts
+++ b/dynawalla/games/pulse/src/audio/voices.ts
@@ -1,0 +1,361 @@
+/**
+ * Procedural voices. Every sound is transient + body + tail, and every one of them
+ * carries a small random detune so a thousand hits never fatigue the ear.
+ *
+ * Nothing here reads game state; callers pass an absolute audio-clock time so the
+ * lookahead scheduler can place events with sample accuracy.
+ */
+
+import type { Engine } from "./engine.ts";
+
+const EPS = 0.0001;
+
+function vary(r: number, cents: number): number {
+  return Math.pow(2, ((Math.random() * 2 - 1) * cents) / 1200) * r;
+}
+
+function env(
+  ctx: AudioContext,
+  g: GainNode,
+  at: number,
+  peak: number,
+  attack: number,
+  decay: number,
+  hold = 0,
+): void {
+  const p = g.gain;
+  p.setValueAtTime(EPS, at);
+  p.exponentialRampToValueAtTime(Math.max(EPS, peak), at + attack);
+  if (hold > 0) p.setValueAtTime(Math.max(EPS, peak), at + attack + hold);
+  p.exponentialRampToValueAtTime(EPS, at + attack + hold + decay);
+}
+
+function stopAt(nodes: AudioScheduledSourceNode[], t: number): void {
+  for (const n of nodes) n.stop(t);
+}
+
+function send(e: Engine, node: AudioNode, amount: number): void {
+  if (amount <= 0) return;
+  const g = e.ctx.createGain();
+  g.gain.value = amount;
+  node.connect(g);
+  g.connect(e.reverbSend);
+}
+
+export type Voices = ReturnType<typeof createVoices>;
+
+export function createVoices(e: Engine) {
+  const ctx = e.ctx;
+
+  const noiseSource = (at: number, dur: number, playbackRate = 1): AudioBufferSourceNode => {
+    const s = ctx.createBufferSource();
+    s.buffer = e.noise;
+    s.loop = true;
+    s.playbackRate.value = playbackRate;
+    s.start(at, Math.random() * 1.5, dur + 0.05);
+    return s;
+  };
+
+  return {
+    /** Sub-heavy kick: click transient, pitch-swept sine body, short tail. */
+    kick(at: number, gain = 1): void {
+      const g = ctx.createGain();
+      g.connect(e.drumBus);
+      const o = ctx.createOscillator();
+      o.type = "sine";
+      const f = o.frequency;
+      f.setValueAtTime(vary(150, 40), at);
+      f.exponentialRampToValueAtTime(vary(44, 25), at + 0.075);
+      o.connect(g);
+      env(ctx, g, at, 0.95 * gain, 0.003, 0.26);
+      o.start(at);
+      stopAt([o], at + 0.4);
+
+      const cg = ctx.createGain();
+      const hp = ctx.createBiquadFilter();
+      hp.type = "highpass";
+      hp.frequency.value = 1400;
+      const n = noiseSource(at, 0.03);
+      n.connect(hp);
+      hp.connect(cg);
+      cg.connect(e.drumBus);
+      env(ctx, cg, at, 0.2 * gain, 0.001, 0.022);
+      stopAt([n], at + 0.08);
+    },
+
+    /** Snare: bandpassed noise + a triangle body a fifth apart. */
+    snare(at: number, gain = 1): void {
+      const bp = ctx.createBiquadFilter();
+      bp.type = "bandpass";
+      bp.frequency.value = vary(1850, 90);
+      bp.Q.value = 0.7;
+      const ng = ctx.createGain();
+      const n = noiseSource(at, 0.2);
+      n.connect(bp);
+      bp.connect(ng);
+      ng.connect(e.drumBus);
+      env(ctx, ng, at, 0.5 * gain, 0.002, 0.15);
+      send(e, ng, 0.18);
+      stopAt([n], at + 0.3);
+
+      const bg = ctx.createGain();
+      bg.connect(e.drumBus);
+      const o = ctx.createOscillator();
+      o.type = "triangle";
+      o.frequency.setValueAtTime(vary(196, 50), at);
+      o.frequency.exponentialRampToValueAtTime(vary(150, 40), at + 0.1);
+      o.connect(bg);
+      env(ctx, bg, at, 0.3 * gain, 0.002, 0.1);
+      o.start(at);
+      stopAt([o], at + 0.25);
+    },
+
+    /** Hat. `open` stretches the tail; pitch wanders so a 16th roll stays alive. */
+    hat(at: number, gain = 1, open = false): void {
+      const hp = ctx.createBiquadFilter();
+      hp.type = "highpass";
+      hp.frequency.value = vary(7600, 140);
+      const g = ctx.createGain();
+      const dur = open ? 0.26 : 0.045;
+      const n = noiseSource(at, dur + 0.05, vary(1, 200));
+      n.connect(hp);
+      hp.connect(g);
+      g.connect(e.drumBus);
+      env(ctx, g, at, (open ? 0.2 : 0.17) * gain, 0.001, dur);
+      if (open) send(e, g, 0.14);
+      stopAt([n], at + dur + 0.12);
+    },
+
+    clap(at: number, gain = 1): void {
+      const bp = ctx.createBiquadFilter();
+      bp.type = "bandpass";
+      bp.frequency.value = vary(1500, 80);
+      bp.Q.value = 1.4;
+      const g = ctx.createGain();
+      g.connect(e.drumBus);
+      bp.connect(g);
+      for (let i = 0; i < 3; i++) {
+        const t = at + i * 0.011;
+        const n = noiseSource(t, 0.03);
+        n.connect(bp);
+        stopAt([n], t + 0.05);
+      }
+      env(ctx, g, at, 0.42 * gain, 0.002, 0.19);
+      send(e, g, 0.26);
+    },
+
+    tom(at: number, hz: number, gain = 1): void {
+      const g = ctx.createGain();
+      g.connect(e.drumBus);
+      const o = ctx.createOscillator();
+      o.type = "sine";
+      o.frequency.setValueAtTime(vary(hz * 1.5, 30), at);
+      o.frequency.exponentialRampToValueAtTime(vary(hz, 30), at + 0.14);
+      o.connect(g);
+      env(ctx, g, at, 0.5 * gain, 0.003, 0.24);
+      send(e, g, 0.2);
+      o.start(at);
+      stopAt([o], at + 0.4);
+    },
+
+    /** Bass: two detuned saws through an enveloped lowpass. */
+    bass(at: number, hz: number, dur: number, gain = 1): void {
+      const lp = ctx.createBiquadFilter();
+      lp.type = "lowpass";
+      lp.Q.value = 7;
+      lp.frequency.setValueAtTime(Math.min(6000, hz * 9), at);
+      lp.frequency.exponentialRampToValueAtTime(Math.max(90, hz * 2.2), at + Math.min(0.22, dur));
+      const g = ctx.createGain();
+      lp.connect(g);
+      g.connect(e.musicBus);
+      const osc: OscillatorNode[] = [];
+      for (const det of [-7, 7]) {
+        const o = ctx.createOscillator();
+        o.type = "sawtooth";
+        o.frequency.value = hz;
+        o.detune.value = det;
+        o.connect(lp);
+        o.start(at);
+        osc.push(o);
+      }
+      const sub = ctx.createOscillator();
+      sub.type = "sine";
+      sub.frequency.value = hz / 2;
+      const sg = ctx.createGain();
+      sg.gain.value = 0.55;
+      sub.connect(sg);
+      sg.connect(lp);
+      sub.start(at);
+      osc.push(sub);
+      env(ctx, g, at, 0.34 * gain, 0.006, Math.max(0.06, dur * 0.7), dur * 0.25);
+      stopAt(osc, at + dur + 0.3);
+    },
+
+    /** The player's own voice: a bright pluck. Its pitch climbs with the combo. */
+    pluck(at: number, hz: number, gain = 1, bright = 1): void {
+      const lp = ctx.createBiquadFilter();
+      lp.type = "lowpass";
+      lp.Q.value = 3;
+      lp.frequency.setValueAtTime(Math.min(15000, hz * 12 * bright), at);
+      lp.frequency.exponentialRampToValueAtTime(Math.max(200, hz * 2), at + 0.16);
+      const g = ctx.createGain();
+      lp.connect(g);
+      g.connect(e.musicBus);
+      const osc: OscillatorNode[] = [];
+      for (const [type, det, lvl] of [
+        ["triangle", 0, 1],
+        ["square", 9, 0.32],
+        ["sawtooth", -11, 0.22],
+      ] as const) {
+        const o = ctx.createOscillator();
+        o.type = type;
+        o.frequency.value = vary(hz, 5);
+        o.detune.value = det;
+        const og = ctx.createGain();
+        og.gain.value = lvl;
+        o.connect(og);
+        og.connect(lp);
+        o.start(at);
+        osc.push(o);
+      }
+      env(ctx, g, at, 0.24 * gain, 0.003, 0.3);
+      send(e, g, 0.28);
+      stopAt(osc, at + 0.5);
+    },
+
+    /** A wide chord swell for phrase ends and the drop. */
+    chord(at: number, hzs: readonly number[], dur: number, gain = 1): void {
+      const lp = ctx.createBiquadFilter();
+      lp.type = "lowpass";
+      lp.frequency.setValueAtTime(700, at);
+      lp.frequency.linearRampToValueAtTime(5200, at + dur * 0.5);
+      const g = ctx.createGain();
+      lp.connect(g);
+      g.connect(e.musicBus);
+      const osc: OscillatorNode[] = [];
+      for (const hz of hzs) {
+        for (const det of [-9, 9]) {
+          const o = ctx.createOscillator();
+          o.type = "sawtooth";
+          o.frequency.value = hz;
+          o.detune.value = det;
+          const og = ctx.createGain();
+          og.gain.value = 0.32;
+          o.connect(og);
+          og.connect(lp);
+          o.start(at);
+          osc.push(o);
+        }
+      }
+      env(ctx, g, at, 0.2 * gain, 0.05, dur * 0.7, dur * 0.3);
+      send(e, g, 0.5);
+      stopAt(osc, at + dur + 0.9);
+    },
+
+    /** Big downbeat impact for a drop: sub thump + noise sweep + shimmer. */
+    impact(at: number, gain = 1): void {
+      const g = ctx.createGain();
+      g.connect(e.fxBus);
+      const o = ctx.createOscillator();
+      o.type = "sine";
+      o.frequency.setValueAtTime(190, at);
+      o.frequency.exponentialRampToValueAtTime(32, at + 0.4);
+      o.connect(g);
+      env(ctx, g, at, 1.0 * gain, 0.004, 0.7);
+      send(e, g, 0.4);
+      o.start(at);
+      stopAt([o], at + 1.2);
+
+      const bp = ctx.createBiquadFilter();
+      bp.type = "bandpass";
+      bp.Q.value = 0.8;
+      bp.frequency.setValueAtTime(5200, at);
+      bp.frequency.exponentialRampToValueAtTime(280, at + 0.5);
+      const ng = ctx.createGain();
+      const n = noiseSource(at, 0.6);
+      n.connect(bp);
+      bp.connect(ng);
+      ng.connect(e.fxBus);
+      env(ctx, ng, at, 0.4 * gain, 0.003, 0.55);
+      send(e, ng, 0.6);
+      stopAt([n], at + 0.9);
+    },
+
+    /** Upward riser into a drop. */
+    riser(at: number, dur: number, gain = 1): void {
+      const bp = ctx.createBiquadFilter();
+      bp.type = "bandpass";
+      bp.Q.value = 3.5;
+      bp.frequency.setValueAtTime(260, at);
+      bp.frequency.exponentialRampToValueAtTime(8200, at + dur);
+      const g = ctx.createGain();
+      const n = noiseSource(at, dur + 0.1);
+      n.connect(bp);
+      bp.connect(g);
+      g.connect(e.fxBus);
+      g.gain.setValueAtTime(EPS, at);
+      g.gain.exponentialRampToValueAtTime(0.3 * gain, at + dur);
+      g.gain.exponentialRampToValueAtTime(EPS, at + dur + 0.12);
+      send(e, g, 0.4);
+      stopAt([n], at + dur + 0.25);
+    },
+
+    /** A missed note: a dull, detuned thud. Wrong, not punitive. */
+    thud(at: number, gain = 1): void {
+      const lp = ctx.createBiquadFilter();
+      lp.type = "lowpass";
+      lp.frequency.value = 420;
+      const g = ctx.createGain();
+      lp.connect(g);
+      g.connect(e.fxBus);
+      const o = ctx.createOscillator();
+      o.type = "square";
+      o.frequency.setValueAtTime(vary(120, 60), at);
+      o.frequency.exponentialRampToValueAtTime(vary(72, 60), at + 0.12);
+      o.connect(lp);
+      env(ctx, g, at, 0.24 * gain, 0.004, 0.16);
+      o.start(at);
+      stopAt([o], at + 0.35);
+    },
+
+    /** A wrong gate answer: the band stumbles. */
+    stumble(at: number, gain = 1): void {
+      const g = ctx.createGain();
+      g.connect(e.fxBus);
+      const osc: OscillatorNode[] = [];
+      for (const [hz, det] of [
+        [116, 0],
+        [123, 14],
+      ] as const) {
+        const o = ctx.createOscillator();
+        o.type = "sawtooth";
+        o.frequency.setValueAtTime(hz, at);
+        o.frequency.exponentialRampToValueAtTime(hz * 0.62, at + 0.34);
+        o.detune.value = det;
+        const lp = ctx.createBiquadFilter();
+        lp.type = "lowpass";
+        lp.frequency.setValueAtTime(1400, at);
+        lp.frequency.exponentialRampToValueAtTime(240, at + 0.3);
+        o.connect(lp);
+        lp.connect(g);
+        o.start(at);
+        osc.push(o);
+      }
+      env(ctx, g, at, 0.3 * gain, 0.005, 0.4);
+      stopAt(osc, at + 0.7);
+    },
+
+    /** Tiny interface blip — menus, toggles, calibration taps. */
+    blip(at: number, hz = 880, gain = 1): void {
+      const g = ctx.createGain();
+      g.connect(e.fxBus);
+      const o = ctx.createOscillator();
+      o.type = "square";
+      o.frequency.value = vary(hz, 8);
+      o.connect(g);
+      env(ctx, g, at, 0.12 * gain, 0.002, 0.06);
+      o.start(at);
+      stopAt([o], at + 0.12);
+    },
+  };
+}

--- a/dynawalla/games/pulse/src/contract.ts
+++ b/dynawalla/games/pulse/src/contract.ts
@@ -1,0 +1,22 @@
+/**
+ * The host contract. A shared package will replace this file later; keep the shape
+ * EXACTLY as written so the swap is a one-line import change.
+ */
+
+export type Question = {
+  id: string;
+  prompt: string; // "15 − 8"
+  answer: string; // "7"  — exact, canonical
+  distractors: string[]; // plausible wrong answers, ideally real mal-rule outputs
+  domain: string; // "add-sub" | "fractions" | ...
+  difficulty: number; // 0..1
+};
+
+export type Host = {
+  next(): Question; // pull the next question
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void;
+  haptic(kind: "light" | "medium" | "heavy" | "success" | "failure"): void;
+  prefersReducedMotion(): boolean;
+};
+
+export type Mounted = { unmount(): void };

--- a/dynawalla/games/pulse/src/dev/bot.ts
+++ b/dynawalla/games/pulse/src/dev/bot.ts
@@ -1,0 +1,143 @@
+/**
+ * QA harness — NOT part of the game.
+ *
+ * Loaded only by the standalone dev entry behind `?bot=`, never by `mount()`. It
+ * plays through the real input path (`run.input(lane, performance.now())`), so it
+ * exercises exactly the code a thumb does, including the clock conversion and the
+ * judgment windows. Nothing here bypasses a gate, forces a grade, or reaches into
+ * game state to award a point.
+ *
+ * `skill` in [0,1] shapes how hard it plays: timing jitter, how often it lets a note
+ * go, and how often it takes the wrong fraction. Turning it down is how you look at
+ * the failure states without having to fail on purpose.
+ */
+
+import type { Run } from "../game/run.ts";
+
+export type BotOptions = {
+  /** 0 = sloppy beginner, 1 = machine. */
+  skill?: number;
+  /** Extra constant offset in ms, to test the auto-calibrator. */
+  biasMs?: number;
+};
+
+export type Bot = {
+  stop(): void;
+  /** One decision pass. Public so a busy-loop burst can drive it without rAF. */
+  tick(): void;
+  readonly stats: { pressed: number; skipped: number; wrong: number };
+};
+
+export function attachBot(run: Run, opts: BotOptions = {}): Bot {
+  const skill = Math.max(0, Math.min(1, opts.skill ?? 0.9));
+  const bias = opts.biasMs ?? 0;
+  const jitterMs = 12 + (1 - skill) * 90;
+  const skipRate = (1 - skill) * 0.3;
+  const wrongGateRate = (1 - skill) * 0.55;
+  const stats = { pressed: 0, skipped: 0, wrong: 0 };
+  const decided = new Map<number, { at: number; lane: number } | null>();
+  let alive = true;
+
+  const tick = (): void => {
+    if (!run.running) return;
+    const heard = run.heard();
+
+    for (const n of run.notes.all()) {
+      if (n.judged !== null) continue;
+      if (n.time - heard > 0.35) continue;
+      let plan = decided.get(n.id);
+      if (plan === undefined) {
+        if (n.gate) {
+          // Only ever decide once per gate, and only among live candidates.
+          const wrong = Math.random() < wrongGateRate;
+          const want = wrong ? !n.gate.correct : n.gate.correct;
+          plan = want
+            ? { at: n.time + ((Math.random() * 2 - 1) * jitterMs + bias) / 1000, lane: n.lane }
+            : null;
+          if (want && wrong) stats.wrong++;
+        } else if (Math.random() < skipRate) {
+          plan = null;
+        } else {
+          plan = { at: n.time + ((Math.random() * 2 - 1) * jitterMs + bias) / 1000, lane: n.lane };
+        }
+        decided.set(n.id, plan);
+        if (decided.size > 400) decided.clear();
+      }
+      if (plan === null) {
+        stats.skipped++;
+        continue;
+      }
+      if (heard >= plan.at) {
+        // Convert the intended audio moment back into the input clock the game reads.
+        run.input(plan.lane, performance.now());
+        stats.pressed++;
+        decided.set(n.id, null);
+      }
+    }
+  };
+  const loop = (): void => {
+    if (!alive) return;
+    requestAnimationFrame(loop);
+    tick();
+  };
+  requestAnimationFrame(loop);
+
+  return {
+    stop() {
+      alive = false;
+    },
+    tick,
+    stats,
+  };
+}
+
+type Driver = { drive(on: boolean): void; step(ms: number): void };
+
+/**
+ * Run the real loop at a real frame rate for `ms`, without `requestAnimationFrame`.
+ *
+ * A throttled background tab hands out one rAF every couple of seconds, which is
+ * useless for both playing and measuring. A synchronous busy loop calling the game's
+ * own `step()` runs the identical code path against the identical (real) audio clock,
+ * so what you screenshot afterwards is a genuine frame of a genuine run.
+ *
+ * `syncEveryFrame` reads one pixel back after each frame, which forces the canvas to
+ * actually rasterise; without it the timing measures only the JS that records the
+ * draw calls, and reports a number two or three times better than the truth.
+ */
+export function burst(
+  driver: Driver,
+  bot: Bot | null,
+  ms: number,
+  opts: { targetHz?: number; syncEveryFrame?: boolean; canvas?: HTMLCanvasElement } = {},
+): { frames: number; meanMs: number; p95Ms: number; maxMs: number; wallMs: number } {
+  const hz = opts.targetHz ?? 60;
+  const budget = 1000 / hz;
+  const sctx = opts.syncEveryFrame && opts.canvas ? opts.canvas.getContext("2d") : null;
+  const samples: number[] = [];
+  driver.drive(true);
+  const t0 = performance.now();
+  let last = t0;
+  let frames = 0;
+  while (performance.now() - t0 < ms) {
+    const now = performance.now();
+    const dt = now - last;
+    if (dt < budget) continue; // busy-wait: setTimeout is clamped in a hidden tab
+    last = now;
+    const a = performance.now();
+    driver.step(dt);
+    bot?.tick();
+    if (sctx) sctx.getImageData(0, 0, 1, 1);
+    samples.push(performance.now() - a);
+    frames++;
+  }
+  const wallMs = performance.now() - t0;
+  samples.sort((x, y) => x - y);
+  return {
+    frames,
+    meanMs: samples.reduce((x, y) => x + y, 0) / Math.max(1, samples.length),
+    p95Ms: samples[Math.floor(samples.length * 0.95)] ?? 0,
+    maxMs: samples[samples.length - 1] ?? 0,
+    wallMs,
+  };
+}

--- a/dynawalla/games/pulse/src/game/chart.test.ts
+++ b/dynawalla/games/pulse/src/game/chart.test.ts
@@ -1,0 +1,122 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { barNotes, BEATS_PER_BAR, laneVoices, _clearChartCache } from "./chart.ts";
+import { STAGES, stageAt } from "./stages.ts";
+
+test("the same seed and bar is always the same bar", () => {
+  const a = barNotes(STAGES[3]!, "seed-a", 17);
+  _clearChartCache();
+  const b = barNotes(STAGES[3]!, "seed-a", 17);
+  assert.deepEqual(a, b);
+  _clearChartCache();
+  const c = barNotes(STAGES[3]!, "seed-b", 17);
+  assert.notDeepEqual(a, c);
+});
+
+test("every bar is playable: in range, in bounds, and not a wall", () => {
+  for (let s = 0; s < 12; s++) {
+    const stage = stageAt(s);
+    for (let bar = 0; bar < 24; bar++) {
+      const notes = barNotes(stage, "playable", bar);
+      assert.ok(notes.length > 0, `stage ${s} bar ${bar} is empty`);
+      assert.ok(notes.length <= 30, `stage ${s} bar ${bar} has ${notes.length} notes`);
+      for (const n of notes) {
+        assert.ok(n.beatInBar >= 0 && n.beatInBar < BEATS_PER_BAR, `beat ${n.beatInBar} out of bar`);
+        assert.ok(n.lane >= 0 && n.lane < stage.lanes, `lane ${n.lane} outside ${stage.lanes}`);
+        assert.ok(laneVoices(stage.lanes).includes(n.kind) || n.kind === "tom");
+      }
+    }
+  }
+});
+
+test("no lane is ever asked for two notes at the same instant", () => {
+  for (let s = 0; s < 12; s++) {
+    const stage = stageAt(s);
+    for (let bar = 0; bar < 16; bar++) {
+      const seen = new Set<string>();
+      for (const n of barNotes(stage, "collide", bar)) {
+        const key = `${n.lane}:${n.beatInBar.toFixed(4)}`;
+        assert.ok(!seen.has(key), `stage ${s} bar ${bar}: duplicate at ${key}`);
+        seen.add(key);
+      }
+    }
+  }
+});
+
+test("hands stay physically possible, including across the bar line", () => {
+  for (let s = 0; s < 12; s++) {
+    const stage = stageAt(s);
+    const spb = 60 / stage.bpm;
+    // Lay 16 consecutive bars end to end and look at every gap in every lane.
+    const byLane = new Map<number, number[]>();
+    for (let bar = 0; bar < 16; bar++) {
+      for (const n of barNotes(stage, "speed", bar)) {
+        const arr = byLane.get(n.lane) ?? [];
+        arr.push(bar * BEATS_PER_BAR + n.beatInBar);
+        byLane.set(n.lane, arr);
+      }
+    }
+    for (const [lane, beats] of byLane) {
+      beats.sort((a, b) => a - b);
+      for (let i = 1; i < beats.length; i++) {
+        const ms = (beats[i]! - beats[i - 1]!) * spb * 1000;
+        assert.ok(ms >= 85, `stage ${s} lane ${lane}: ${ms.toFixed(1)} ms apart`);
+      }
+    }
+  }
+});
+
+test("the downbeat is always there — the groove has an anchor", () => {
+  for (let s = 0; s < 8; s++) {
+    const stage = STAGES[s]!;
+    for (let bar = 0; bar < 8; bar++) {
+      const notes = barNotes(stage, "anchor", bar);
+      assert.ok(
+        notes.some((n) => n.beatInBar === 0),
+        `stage ${s} bar ${bar} has no downbeat`,
+      );
+    }
+  }
+});
+
+test("a polyrhythm stage really lays N notes evenly across the bar", () => {
+  const stage = STAGES[5]!; // three over four
+  assert.ok(stage.poly);
+  const notes = barNotes(stage, "poly", 4).filter((n) => n.div === -stage.poly!.perBar);
+  assert.equal(notes.length, stage.poly!.perBar);
+  const beats = notes.map((n) => n.beatInBar).sort((a, b) => a - b);
+  for (let i = 0; i < beats.length; i++) {
+    assert.ok(
+      Math.abs(beats[i]! - (i * BEATS_PER_BAR) / stage.poly!.perBar) < 1e-6,
+      `poly note ${i} at ${beats[i]}`,
+    );
+  }
+});
+
+test("a phrase restates itself rather than being fresh noise every bar", () => {
+  const stage = STAGES[1]!;
+  const sig = (bar: number) =>
+    barNotes(stage, "motif", bar)
+      .map((n) => `${n.lane}@${n.beatInBar}`)
+      .sort()
+      .join(",");
+  const a = sig(0);
+  const b = sig(2);
+  const shared = a.split(",").filter((x) => b.includes(x)).length;
+  assert.ok(shared >= a.split(",").length * 0.7, "bars 0 and 2 of a phrase should share a motif");
+});
+
+test("escalation is monotone where it should be and bounded where it must be", () => {
+  for (let i = 1; i < STAGES.length; i++) {
+    assert.ok(STAGES[i]!.bpm >= STAGES[i - 1]!.bpm, `stage ${i} slowed down`);
+    assert.ok(STAGES[i]!.gateFloor > STAGES[i - 1]!.gateFloor, `stage ${i} got easier`);
+  }
+  for (let i = STAGES.length; i < 80; i++) {
+    const s = stageAt(i);
+    assert.ok(s.bpm <= 168, `endless stage ${i} runs at ${s.bpm} bpm`);
+    assert.ok(s.gateFloor <= 1, `endless stage ${i} floor ${s.gateFloor}`);
+    assert.ok(s.density <= 0.65, `endless stage ${i} density ${s.density}`);
+    assert.ok(s.lanes <= 3 && s.bars > 0);
+  }
+  assert.ok(stageAt(40).bpm > STAGES[STAGES.length - 1]!.bpm, "endless mode must keep climbing");
+});

--- a/dynawalla/games/pulse/src/game/chart.ts
+++ b/dynawalla/games/pulse/src/game/chart.ts
@@ -1,0 +1,233 @@
+/**
+ * Chart generation — seeded, deterministic, and *composed* rather than sprinkled.
+ *
+ * Random notes feel like static. Real grooves are a motif repeated with variation, so
+ * a phrase of four bars is generated as a unit: bars 0-2 restate a motif with small
+ * mutations and bar 3 is a fill. That is the difference between a pattern a child
+ * wants to learn and a pattern they merely survive.
+ */
+
+import { makeRng, hashSeed, type Rng } from "../rng.ts";
+import type { StageSpec } from "./stages.ts";
+
+export type NoteKind = "kick" | "snare" | "hat" | "tom";
+
+export type ChartNote = {
+  /** Beat offset inside the bar. Exact grid rational rendered as a float position. */
+  beatInBar: number;
+  lane: number;
+  /** Subdivision family. Positive = per-beat division. Negative = |n| notes per bar. */
+  div: number;
+  kind: NoteKind;
+  accent: boolean;
+};
+
+export const BEATS_PER_BAR = 4;
+
+/** Top lane is the highest voice, bottom lane the lowest — pitch maps to height. */
+export function laneVoices(lanes: number): NoteKind[] {
+  if (lanes <= 1) return ["kick"];
+  if (lanes === 2) return ["snare", "kick"];
+  return ["hat", "snare", "kick"];
+}
+
+/** Smallest per-beat division that lands exactly on this offset. */
+function divOf(beat: number, divs: readonly number[]): number {
+  const sorted = [...divs].sort((a, b) => a - b);
+  for (const d of sorted) {
+    const x = beat * d;
+    if (Math.abs(x - Math.round(x)) < 1e-6) return d;
+  }
+  return sorted[sorted.length - 1] ?? 1;
+}
+
+function gridSlots(divs: readonly number[]): number[] {
+  const set = new Set<number>();
+  for (const d of divs) {
+    for (let k = 0; k < BEATS_PER_BAR * d; k++) set.add(Math.round((k / d) * 1e6) / 1e6);
+  }
+  return [...set].sort((a, b) => a - b);
+}
+
+function laneFor(div: number, lanes: number, rng: Rng): number {
+  if (lanes <= 1) return 0;
+  if (lanes === 2) return div >= 2 ? 0 : 1;
+  if (div >= 4) return 0;
+  if (div === 3) return rng.bool(0.65) ? 0 : 1;
+  if (div === 2) return rng.bool(0.55) ? 1 : 0;
+  return rng.bool(0.7) ? 2 : 1;
+}
+
+function maxNotes(lanes: number): number {
+  return lanes >= 3 ? 20 : lanes === 2 ? 15 : 10;
+}
+
+/**
+ * The smallest gap one hand may be asked for, in beats.
+ *
+ * 88 ms is about the floor for a repeated single-limb strike, and it is also the
+ * point below which two notes stop being two notes and start being one smear the
+ * judge cannot attribute. Capped at 0.24 beats so a sixteenth run (0.25) survives
+ * even at the endless-mode tempo ceiling, while the genuinely lethal case — a
+ * sixteenth and a triplet 1/12 of a beat apart — is always refused.
+ */
+export function minGapBeats(bpm: number): number {
+  return Math.min(0.24, (0.088 * bpm) / 60);
+}
+
+/** Enforces "one lane, one hand": unique slots and a humanly playable gap. */
+class Placer {
+  private readonly byLane = new Map<number, number[]>();
+  private readonly gap: number;
+  private readonly downbeatLane: number;
+
+  constructor(gap: number, downbeatLane: number) {
+    this.gap = gap;
+    this.downbeatLane = downbeatLane;
+  }
+
+  can(beat: number, lane: number): boolean {
+    // Leave room for the next bar's downbeat, which lands in its own lane at 0.
+    if (lane === this.downbeatLane && BEATS_PER_BAR - beat < this.gap) return false;
+    const xs = this.byLane.get(lane);
+    if (!xs) return true;
+    for (const x of xs) if (Math.abs(x - beat) < this.gap - 1e-9) return false;
+    return true;
+  }
+
+  take(beat: number, lane: number): boolean {
+    if (!this.can(beat, lane)) return false;
+    const xs = this.byLane.get(lane);
+    if (xs) xs.push(beat);
+    else this.byLane.set(lane, [beat]);
+    return true;
+  }
+}
+
+type PhraseKey = string;
+const phraseCache = new Map<PhraseKey, ChartNote[][]>();
+
+function buildPhrase(stage: StageSpec, runSeed: string, phrase: number): ChartNote[][] {
+  const rng = makeRng(hashSeed(`${runSeed}|s${stage.id}|p${phrase}`));
+  const voices = laneVoices(stage.lanes);
+  const slots = gridSlots(stage.divs);
+  const gap = minGapBeats(stage.bpm);
+  const downbeatLane = stage.lanes - 1;
+  const polyLane = stage.poly ? Math.min(stage.poly.lane, stage.lanes - 1) : -1;
+
+  // --- The motif: which grid slots this phrase likes.
+  const motif: { beat: number; div: number; lane: number; accent: boolean }[] = [];
+  const motifPlacer = new Placer(gap, downbeatLane);
+  const place = (beat: number, lane: number, accent: boolean): void => {
+    if (!motifPlacer.take(beat, lane)) return;
+    motif.push({ beat, div: divOf(beat, stage.divs), lane, accent });
+  };
+
+  // Anchors first: the downbeat, then the backbeat if there is a snare lane.
+  place(0, downbeatLane, true);
+  if (stage.lanes >= 2) {
+    place(1, Math.max(0, stage.lanes - 2), true);
+    place(3, Math.max(0, stage.lanes - 2), true);
+  } else if (rng.bool(0.8)) {
+    place(2, 0, true);
+  }
+
+  for (const beat of slots) {
+    if (motif.length >= maxNotes(stage.lanes)) break;
+    const d = divOf(beat, stage.divs);
+    const weight = d === 1 ? 1 : d === 2 ? 0.8 : d === 3 ? 0.62 : 0.5;
+    const onBeat = Math.abs(beat - Math.round(beat)) < 1e-6;
+    const p = stage.density * weight * (onBeat ? 1.25 : 1);
+    if (!rng.bool(p)) continue;
+    const lane = laneFor(d, stage.lanes, rng);
+    // The polyrhythm lane belongs to the polyrhythm; grid notes stay out of it.
+    if (lane === polyLane) continue;
+    place(beat, lane, onBeat && rng.bool(0.4));
+  }
+  motif.sort((a, b) => a.beat - b.beat || a.lane - b.lane);
+
+  // --- Four bars: restate, mutate, restate, fill.
+  const bars: ChartNote[][] = [];
+  for (let b = 0; b < 4; b++) {
+    const out: ChartNote[] = [];
+    const placer = new Placer(gap, downbeatLane);
+    const isFill = b === 3;
+    const mutate = b === 1 || b === 3;
+
+    // The polyrhythm is laid first: it owns its lane outright.
+    if (stage.poly) {
+      const perBar = stage.poly.perBar;
+      for (let k = 0; k < perBar; k++) {
+        const beat = (k * BEATS_PER_BAR) / perBar;
+        if (!placer.take(beat, polyLane)) continue;
+        out.push({
+          beatInBar: beat,
+          lane: polyLane,
+          div: -perBar,
+          kind: voices[polyLane] ?? "tom",
+          accent: k === 0,
+        });
+      }
+    }
+
+    for (const m of motif) {
+      const isAnchor = m.beat === 0;
+      if (mutate && !isAnchor && rng.bool(0.14)) continue; // drop a note
+      let lane = m.lane;
+      if (mutate && !isAnchor && stage.lanes > 1 && rng.bool(0.12)) {
+        const moved = Math.min(stage.lanes - 1, Math.max(0, lane + (rng.bool(0.5) ? 1 : -1)));
+        if (moved !== polyLane) lane = moved;
+      }
+      if (!placer.take(m.beat, lane)) continue;
+      out.push({
+        beatInBar: m.beat,
+        lane,
+        div: m.div,
+        kind: voices[lane] ?? "kick",
+        accent: m.accent,
+      });
+    }
+
+    if (isFill) {
+      // A fill is a run of the stage's fastest subdivision across the last beat.
+      const fastest = Math.max(...stage.divs);
+      const start = BEATS_PER_BAR - 1;
+      const steps = Math.min(6, fastest);
+      for (let k = 0; k < steps; k++) {
+        const beat = start + k / fastest;
+        if (beat >= BEATS_PER_BAR) break;
+        let lane = stage.lanes >= 3 ? (k % 2 === 0 ? 1 : 0) : Math.max(0, stage.lanes - 2);
+        if (lane === polyLane) lane = Math.max(0, Math.min(stage.lanes - 1, lane === 0 ? 1 : 0));
+        if (!placer.take(beat, lane)) continue;
+        out.push({
+          beatInBar: beat,
+          lane,
+          div: fastest,
+          kind: stage.lanes >= 3 ? "tom" : (voices[lane] ?? "snare"),
+          accent: k === 0,
+        });
+      }
+    }
+
+    out.sort((a, b2) => a.beatInBar - b2.beatInBar || a.lane - b2.lane);
+    bars.push(out);
+  }
+  return bars;
+}
+
+export function barNotes(stage: StageSpec, runSeed: string, bar: number): ChartNote[] {
+  const phrase = Math.floor(bar / 4);
+  const key = `${runSeed}|${stage.id}|${phrase}`;
+  let bars = phraseCache.get(key);
+  if (!bars) {
+    bars = buildPhrase(stage, runSeed, phrase);
+    if (phraseCache.size > 64) phraseCache.clear();
+    phraseCache.set(key, bars);
+  }
+  return bars[bar % 4] ?? [];
+}
+
+/** Test seam — drop memoised phrases so a determinism test starts clean. */
+export function _clearChartCache(): void {
+  phraseCache.clear();
+}

--- a/dynawalla/games/pulse/src/game/gate.test.ts
+++ b/dynawalla/games/pulse/src/game/gate.test.ts
@@ -1,0 +1,93 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildGate } from "./gate.ts";
+import { makeRng, hashSeed } from "../rng.ts";
+import { createStubHost } from "../stubHost.ts";
+import { parseRat, toFloat } from "../math/rational.ts";
+import type { Question } from "../contract.ts";
+
+const rng = () => makeRng(hashSeed("gate-test"));
+
+test("a candidate's position in the bar IS its value", () => {
+  const q: Question = {
+    id: "q1",
+    prompt: "1/2 + 1/4",
+    answer: "3/4",
+    distractors: ["2/6", "1/4", "1"],
+    domain: "fractions-add",
+    difficulty: 0.3,
+  };
+  const g = buildGate(q, rng());
+  assert.ok(g.positional);
+  for (const c of g.candidates) {
+    assert.ok(Math.abs(c.pos - toFloat(parseRat(c.label)!)) < 1e-12, `${c.label} placed at ${c.pos}`);
+  }
+  const correct = g.candidates.filter((c) => c.correct);
+  assert.equal(correct.length, 1);
+  assert.equal(correct[0]!.label, "3/4");
+  assert.ok(Math.abs(correct[0]!.pos - 0.75) < 1e-12);
+});
+
+test("candidates arrive in ascending order — the bar is a number line", () => {
+  const h = createStubHost({ seed: "order" });
+  const r = rng();
+  for (let i = 0; i < 200; i++) {
+    h.setFloor((i % 100) / 100);
+    const g = buildGate(h.next(), r);
+    for (let k = 1; k < g.candidates.length; k++) {
+      assert.ok(g.candidates[k]!.pos > g.candidates[k - 1]!.pos, "candidates out of order");
+    }
+    assert.equal(g.candidates.filter((c) => c.correct).length, 1);
+    assert.ok(g.candidates.length >= 2 && g.candidates.length <= 4);
+    for (const c of g.candidates) assert.ok(c.pos > 0 && c.pos <= 1);
+  }
+});
+
+test("a non-fractional host still plays; it just stops being a number line", () => {
+  const q: Question = {
+    id: "q2",
+    prompt: "15 − 8",
+    answer: "7",
+    distractors: ["5", "4", "9"],
+    domain: "add-sub",
+    difficulty: 0.2,
+  };
+  const g = buildGate(q, rng());
+  assert.equal(g.positional, false);
+  assert.equal(g.candidates.length, 4);
+  assert.equal(g.candidates.filter((c) => c.correct).length, 1);
+  for (const c of g.candidates) assert.ok(c.pos > 0 && c.pos <= 1);
+  assert.deepEqual(
+    [...g.candidates].map((c) => c.pos).sort((a, b) => a - b),
+    g.candidates.map((c) => c.pos).sort((a, b) => a - b),
+  );
+});
+
+test("a decimal answer falls back rather than being silently mis-placed", () => {
+  const q: Question = {
+    id: "q3",
+    prompt: "0.5 + 0.25",
+    answer: "0.75",
+    distractors: ["0.3", "0.7", "1.0"],
+    domain: "decimals",
+    difficulty: 0.5,
+  };
+  const g = buildGate(q, rng());
+  assert.equal(g.positional, false);
+  assert.ok(g.candidates.some((c) => c.correct && c.label === "0.75"));
+});
+
+test("the correct answer survives even when every distractor is unusable", () => {
+  const q: Question = {
+    id: "q4",
+    prompt: "1/2 + 1/4",
+    answer: "3/4",
+    // Out of range, duplicated, and crowding the answer.
+    distractors: ["9/4", "3/4", "19/24"],
+    domain: "fractions-add",
+    difficulty: 0.9,
+  };
+  const g = buildGate(q, rng());
+  assert.equal(g.candidates.length, 1);
+  assert.ok(g.candidates[0]!.correct);
+});

--- a/dynawalla/games/pulse/src/game/gate.ts
+++ b/dynawalla/games/pulse/src/game/gate.ts
@@ -1,0 +1,109 @@
+/**
+ * The fraction gate — the reason this game exists.
+ *
+ * The visible playfield to the right of the strike line is exactly one bar. One bar
+ * is one whole. So a value in `(0, 1]` has a position, and a position has a moment:
+ * the candidate labelled `3/4` sits three quarters of the way across the bar and
+ * crosses the strike line three quarters of the way through it.
+ *
+ * You answer `1/2 + 1/4` by hitting a thing at the right *time*. There is no answer
+ * button, no keypad and no multiple-choice list — the number line is the timeline.
+ *
+ * If a future host emits an answer that is not a fraction in `(0,1]` the gate falls
+ * back to even spacing and still plays; it just stops being a number line.
+ */
+
+import type { Question } from "../contract.ts";
+import { type Rat, parseRat, inBar, cmp, sub, toFloat, eq, rat } from "../math/rational.ts";
+import type { Rng } from "../rng.ts";
+
+export type GateCandidate = {
+  label: string;
+  /** Position in the bar, 0..1 — rendering only. */
+  pos: number;
+  correct: boolean;
+  /** Set when the label is a real fraction, for the pie glyph. */
+  frac: { n: number; d: number } | null;
+};
+
+export type BuiltGate = {
+  questionId: string;
+  prompt: string;
+  candidates: GateCandidate[];
+  /** False when the host answered in something other than a bar fraction. */
+  positional: boolean;
+};
+
+/**
+ * How much of the bar must separate two candidates.
+ *
+ * This is a *display* constraint, not a mathematical one, so it is passed in rather
+ * than fixed: a 1372 px landscape bar can hold four orbs a twelfth apart, and a 544 px
+ * phone bar cannot — they overlap and become unreadable, which is the one thing a
+ * "shoot the guilty one" game may never be. Crowded candidates are dropped, never
+ * moved: a candidate's position is its value, and nudging it would be a lie.
+ */
+export type GateFit = { maxCandidates: number; minGapDenom: number };
+
+export const DEFAULT_FIT: GateFit = { maxCandidates: 4, minGapDenom: 12 };
+
+function farEnough(v: Rat, kept: Rat[], minGap: Rat): boolean {
+  for (const k of kept) {
+    const d = cmp(v, k) >= 0 ? sub(v, k) : sub(k, v);
+    if (cmp(d, minGap) < 0) return false;
+  }
+  return true;
+}
+
+export function buildGate(q: Question, rng: Rng, fit: GateFit = DEFAULT_FIT): BuiltGate {
+  const maxCandidates = Math.max(2, fit.maxCandidates);
+  const minGap = rat(1n, BigInt(Math.max(2, Math.round(fit.minGapDenom))));
+  const ans = parseRat(q.answer);
+  const dis = q.distractors.map((s) => ({ s, r: parseRat(s) }));
+  // Only the *answer* decides whether the bar can still be a number line. A host
+  // that hands over one unusable distractor loses that distractor, not the mechanic.
+  const positional = ans !== null && inBar(ans);
+
+  if (!positional || ans === null) {
+    // Non-fractional host: keep the game playable, lose the number line.
+    const all = [{ s: q.answer, correct: true }, ...q.distractors.map((s) => ({ s, correct: false }))];
+    rng.shuffle(all);
+    const used = all.slice(0, maxCandidates);
+    if (!used.some((u) => u.correct)) {
+      used[used.length - 1] = { s: q.answer, correct: true };
+      rng.shuffle(used);
+    }
+    return {
+      questionId: q.id,
+      prompt: q.prompt,
+      positional: false,
+      candidates: used.map((u, i) => ({
+        label: u.s,
+        pos: (i + 1) / (used.length + 1),
+        correct: u.correct,
+        frac: null,
+      })),
+    };
+  }
+
+  const kept: Rat[] = [ans];
+  const out: GateCandidate[] = [
+    { label: q.answer, pos: toFloat(ans), correct: true, frac: { n: Number(ans.n), d: Number(ans.d) } },
+  ];
+  for (const d of dis) {
+    if (out.length >= maxCandidates) break;
+    const r = d.r;
+    if (r === null || !inBar(r)) continue;
+    if (kept.some((k) => eq(k, r))) continue;
+    if (!farEnough(r, kept, minGap)) continue;
+    kept.push(r);
+    out.push({
+      label: d.s,
+      pos: toFloat(r),
+      correct: false,
+      frac: { n: Number(r.n), d: Number(r.d) },
+    });
+  }
+  out.sort((a, b) => a.pos - b.pos);
+  return { questionId: q.id, prompt: q.prompt, candidates: out, positional: true };
+}

--- a/dynawalla/games/pulse/src/game/judge.test.ts
+++ b/dynawalla/games/pulse/src/game/judge.test.ts
@@ -1,0 +1,81 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classify, multiplierFor, NoteQueue, WINDOWS } from "./judge.ts";
+
+const note = (time: number, lane = 0) => ({
+  time,
+  beat: time * 2,
+  lane,
+  div: 1,
+  kind: "kick" as const,
+  accent: false,
+});
+
+test("windows are symmetric and ordered", () => {
+  assert.equal(classify(0), "perfect");
+  assert.equal(classify(WINDOWS.perfect - 0.001), "perfect");
+  assert.equal(classify(-(WINDOWS.perfect - 0.001)), "perfect");
+  assert.equal(classify(WINDOWS.perfect + 0.001), "great");
+  assert.equal(classify(-(WINDOWS.great + 0.001)), "good");
+  assert.equal(classify(WINDOWS.good + 0.001), "miss");
+  assert.ok(WINDOWS.perfect < WINDOWS.great && WINDOWS.great < WINDOWS.good);
+});
+
+test("a hit takes the nearest unjudged note in its lane, not the first", () => {
+  const q = new NoteQueue();
+  q.add(note(10.0));
+  q.add(note(10.09));
+  const r = q.hit(0, 10.08);
+  assert.ok(r);
+  assert.equal(r.note.time, 10.09);
+  assert.equal(r.judgment, "perfect");
+  // The near-simultaneous note behind it is still available.
+  const r2 = q.hit(0, 10.005);
+  assert.ok(r2);
+  assert.equal(r2.note.time, 10.0);
+});
+
+test("lanes are independent unless the caller asks for any lane", () => {
+  const q = new NoteQueue();
+  q.add(note(5, 2));
+  assert.equal(q.hit(0, 5), null, "lane 0 must not steal lane 2's note");
+  const any = q.hit(0, 5, true);
+  assert.ok(any);
+  assert.equal(any.note.lane, 2);
+});
+
+test("a note is never judged twice", () => {
+  const q = new NoteQueue();
+  q.add(note(3));
+  assert.ok(q.hit(0, 3.01));
+  assert.equal(q.hit(0, 3.02), null);
+});
+
+test("reap misses only what has genuinely passed", () => {
+  const q = new NoteQueue();
+  q.add(note(1));
+  q.add(note(2));
+  assert.equal(q.reap(1 + WINDOWS.good - 0.001).length, 0, "still inside the window");
+  const missed = q.reap(1 + WINDOWS.good + 0.001);
+  assert.equal(missed.length, 1);
+  assert.equal(missed[0]!.time, 1);
+  assert.equal(q.reap(1.2).length, 0, "a note is only reaped once");
+});
+
+test("multiplier steps every ten and caps at eight", () => {
+  assert.equal(multiplierFor(0), 1);
+  assert.equal(multiplierFor(9), 1);
+  assert.equal(multiplierFor(10), 2);
+  assert.equal(multiplierFor(69), 7);
+  assert.equal(multiplierFor(70), 8);
+  assert.equal(multiplierFor(100000), 8);
+});
+
+test("prune keeps the queue bounded without dropping live notes", () => {
+  const q = new NoteQueue();
+  for (let i = 0; i < 400; i++) q.add(note(i * 0.1));
+  q.prune(30);
+  const live = q.all().filter((n) => n.time > 30 - 1.6);
+  assert.equal(q.all().length, live.length);
+  assert.ok(q.all().length < 400);
+});

--- a/dynawalla/games/pulse/src/game/judge.ts
+++ b/dynawalla/games/pulse/src/game/judge.ts
@@ -1,0 +1,134 @@
+/**
+ * Timing judgment. Pure and DOM-free so it can be tested in node.
+ *
+ * Windows are absolute seconds, not fractions of a beat — a human's timing accuracy
+ * does not get better because the tempo went up. They are generous by rhythm-game
+ * standards (PERFECT is ±55 ms where a hard game uses ±25) because the point is to
+ * make a nine-year-old feel like a drummer, and PERFECT is still worth chasing since
+ * it is the only grade that raises the combo melody an extra step.
+ */
+
+import type { NoteKind } from "./chart.ts";
+
+export type Judgment = "perfect" | "great" | "good" | "miss";
+
+export const WINDOWS = {
+  perfect: 0.055,
+  great: 0.105,
+  good: 0.17,
+} as const;
+
+export const JUDGE_SCORE: Record<Judgment, number> = {
+  perfect: 100,
+  great: 60,
+  good: 30,
+  miss: 0,
+};
+
+export function classify(deltaSec: number): Judgment {
+  const d = Math.abs(deltaSec);
+  if (d <= WINDOWS.perfect) return "perfect";
+  if (d <= WINDOWS.great) return "great";
+  if (d <= WINDOWS.good) return "good";
+  return "miss";
+}
+
+/** ×1 at combo 0, +1 every 10, capped at ×8. Never resets to below ×1. */
+export function multiplierFor(combo: number): number {
+  return Math.min(8, 1 + Math.floor(combo / 10));
+}
+
+export type GateInfo = {
+  questionId: string;
+  label: string;
+  correct: boolean;
+  /** Rational value as a float in (0,1] — only ever used to place a pixel. */
+  pos: number;
+};
+
+export type LiveNote = {
+  id: number;
+  time: number;
+  beat: number;
+  lane: number;
+  div: number;
+  kind: NoteKind;
+  accent: boolean;
+  judged: Judgment | null;
+  /** Set on fraction-gate candidates. */
+  gate?: GateInfo;
+  /** Render-only bookkeeping. */
+  pop: number;
+};
+
+export type HitResult = { note: LiveNote; delta: number; judgment: Judgment };
+
+export class NoteQueue {
+  private notes: LiveNote[] = [];
+  private nextId = 1;
+
+  add(n: Omit<LiveNote, "id" | "judged" | "pop">): LiveNote {
+    const note: LiveNote = { ...n, id: this.nextId++, judged: null, pop: 0 };
+    this.notes.push(note);
+    return note;
+  }
+
+  all(): readonly LiveNote[] {
+    return this.notes;
+  }
+
+  /** Unjudged gate candidates currently on screen. */
+  gateNotes(): LiveNote[] {
+    return this.notes.filter((n) => n.gate !== undefined && n.judged === null);
+  }
+
+  /**
+   * Nearest unjudged note in `lane` inside the GOOD window. Nearest-wins is what
+   * keeps dense sixteenth runs from mis-assigning a hit to the note behind.
+   */
+  hit(lane: number, t: number, anyLane = false): HitResult | null {
+    let best: LiveNote | null = null;
+    let bestAbs = Infinity;
+    for (const n of this.notes) {
+      if (n.judged !== null) continue;
+      if (!anyLane && n.lane !== lane) continue;
+      const d = Math.abs(n.time - t);
+      if (d < bestAbs) {
+        bestAbs = d;
+        best = n;
+      }
+    }
+    if (!best || bestAbs > WINDOWS.good) return null;
+    const delta = t - best.time;
+    const judgment = classify(delta);
+    best.judged = judgment;
+    return { note: best, delta, judgment };
+  }
+
+  /** Notes that have run past the window unhit. Marks them missed and returns them. */
+  reap(t: number): LiveNote[] {
+    const out: LiveNote[] = [];
+    for (const n of this.notes) {
+      if (n.judged === null && n.time < t - WINDOWS.good) {
+        n.judged = "miss";
+        out.push(n);
+      }
+    }
+    return out;
+  }
+
+  /** Forget everything older than `t`. Keeps the array small and the loop O(visible). */
+  prune(t: number): void {
+    if (this.notes.length < 96) return;
+    this.notes = this.notes.filter((n) => n.time > t - 1.6);
+  }
+
+  clear(): void {
+    this.notes = [];
+  }
+
+  /** Cancel unjudged notes in a beat range without scoring them (stage change). */
+  cancelAfter(t: number): void {
+    this.notes = this.notes.filter((n) => n.time <= t);
+  }
+}

--- a/dynawalla/games/pulse/src/game/run.ts
+++ b/dynawalla/games/pulse/src/game/run.ts
@@ -1,0 +1,582 @@
+/**
+ * The run: the thing that is actually happening.
+ *
+ * Owns the transport, the chart, the judge, the gates and the mix. Draws nothing —
+ * every visible consequence is announced through `Fx` so the renderer and the juice
+ * layer stay replaceable and this file stays testable.
+ *
+ * Two clocks, and the distinction matters:
+ *   - `engine.now()` is when a sound will be *scheduled*.
+ *   - `heard()` is `now() - outputLatency`: what the player is hearing this instant.
+ * Notes are drawn against `heard()` and input is timestamped against `heard()`, so
+ * the picture, the sound and the judgment agree even on a laptop with 40 ms of
+ * Bluetooth latency.
+ */
+
+import type { Host } from "../contract.ts";
+import { createEngine, type Engine } from "../audio/engine.ts";
+import { createVoices, type Voices } from "../audio/voices.ts";
+import { Lookahead, Timeline } from "../audio/scheduler.ts";
+import {
+  BASS_PATTERNS,
+  chordAt,
+  chordFreqs,
+  comboNote,
+  hz,
+  LAYER_ORDER,
+  PENTATONIC,
+  type LayerId,
+} from "../audio/music.ts";
+import { barNotes, BEATS_PER_BAR, laneVoices, type ChartNote } from "./chart.ts";
+import { buildGate, DEFAULT_FIT, type BuiltGate } from "./gate.ts";
+import { classify, multiplierFor, NoteQueue, WINDOWS, type Judgment, type LiveNote } from "./judge.ts";
+import { stageAt, type StageSpec } from "./stages.ts";
+import { makeRng, hashSeed, type Rng } from "../rng.ts";
+
+export type GateOutcome = "correct" | "wrong" | "expired";
+
+export type Fx = {
+  hit(note: LiveNote, judgment: Judgment, delta: number, combo: number): void;
+  miss(note: LiveNote): void;
+  stray(lane: number): void;
+  gateOpen(gate: BuiltGate): void;
+  gateResolved(outcome: GateOutcome, note: LiveNote | null, gate: BuiltGate): void;
+  bar(bar: number, downbeatTime: number): void;
+  stageChanged(stage: StageSpec, index: number): void;
+  drop(): void;
+  stumble(): void;
+  overdrive(on: boolean): void;
+  layerEarned(layer: LayerId): void;
+};
+
+export type RunOptions = {
+  host: Host;
+  fx: Fx;
+  seed?: string;
+  /** Extra input offset in ms. Positive = the player's taps are treated as earlier. */
+  calibrationMs?: number;
+  onCalibrationChange?: (ms: number) => void;
+  /** Start partway up the escalation. For QA and for showing someone the top end. */
+  startStage?: number;
+};
+
+const HEALTH = {
+  miss: -0.05,
+  strayBurst: -0.02,
+  perfect: 0.014,
+  great: 0.007,
+  gateCorrect: 0.16,
+  gateWrong: -0.19,
+  gateExpired: -0.05,
+};
+
+export type ActiveGate = {
+  built: BuiltGate;
+  bar: number;
+  openedAtPerf: number;
+  resolved: boolean;
+};
+
+export class Run {
+  readonly engine: Engine;
+  readonly voices: Voices;
+  readonly timeline: Timeline;
+  readonly notes = new NoteQueue();
+  private readonly look: Lookahead;
+  private readonly host: Host;
+  private readonly fx: Fx;
+  private readonly rng: Rng;
+  readonly seed: string;
+
+  stageIndex = 0;
+  stage: StageSpec = stageAt(0);
+  private stageStartBar = 0;
+
+  score = 0;
+  combo = 0;
+  bestCombo = 0;
+  health = 1;
+  hits = 0;
+  perfects = 0;
+  misses = 0;
+  gatesCorrect = 0;
+  gatesSeen = 0;
+
+  layers = new Set<LayerId>(["bass"]);
+  gate: ActiveGate | null = null;
+  gateStreak = 0;
+  overdriveUntilBar = -1;
+  bar = 0;
+  running = false;
+
+  /** Rolling timing error, used for silent auto-calibration. */
+  private deltas: number[] = [];
+  calibrationMs: number;
+  private readonly onCalibrationChange: ((ms: number) => void) | undefined;
+  private strayTimes: number[] = [];
+  private lastReapTime = 0;
+
+  constructor(o: RunOptions) {
+    this.host = o.host;
+    this.fx = o.fx;
+    this.seed = o.seed ?? `pulse-${Date.now().toString(36)}`;
+    this.rng = makeRng(hashSeed(this.seed));
+    this.calibrationMs = o.calibrationMs ?? 0;
+    this.onCalibrationChange = o.onCalibrationChange;
+    if (o.startStage) {
+      this.stageIndex = Math.max(0, Math.floor(o.startStage));
+      this.stage = stageAt(this.stageIndex);
+      (this.host as Host & { setFloor?: (d: number) => void }).setFloor?.(this.stage.gateFloor);
+    }
+    this.engine = createEngine();
+    this.voices = createVoices(this.engine);
+    this.timeline = new Timeline(this.engine.now() + 0.4, this.stage.bpm, BEATS_PER_BAR);
+    this.look = new Lookahead(
+      () => this.engine.now(),
+      this.timeline,
+      (bar, t) => this.fillBar(bar, t),
+      { lookaheadSec: () => this.barSeconds() * 1.2 + 0.25 },
+    );
+  }
+
+  barSeconds(): number {
+    return this.timeline.spbAtBeat(this.timeline.beatOfBar(this.bar)) * BEATS_PER_BAR;
+  }
+
+  /** Audio time of the sound reaching the player's ears right now. */
+  heard(): number {
+    return this.engine.now() - this.engine.latency();
+  }
+
+  nowBeat(): number {
+    return this.timeline.beatAt(this.heard());
+  }
+
+  /**
+   * Synchronous by design. An earlier version awaited `engine.resume()` first, and on
+   * a page where autoplay never unlocked, that promise simply never settled — the HUD
+   * drew, the stage name sat there, and not one note was ever scheduled. Nothing that
+   * makes the game exist may sit behind a promise the platform is allowed to ignore.
+   * Resume is fired and forgotten; a suspended context freezes `currentTime`, so the
+   * transport is still correctly anchored whenever the audio does come up.
+   */
+  start(): void {
+    void this.engine.resume();
+    const t0 = this.engine.now() + 0.35;
+    this.timeline.setTempoAtBeat(0, this.stage.bpm);
+    (this.timeline as unknown as { segs: { beat0: number; time0: number; spb: number }[] }).segs = [
+      { beat0: 0, time0: t0 + (60 / this.stage.bpm) * BEATS_PER_BAR, spb: 60 / this.stage.bpm },
+    ];
+    // A one-bar count-in: four clicks, so the tempo is in the body before bar 0.
+    for (let b = -BEATS_PER_BAR; b < 0; b++) {
+      const t = this.timeline.timeAt(b);
+      this.voices.hat(t, b === -BEATS_PER_BAR ? 1 : 0.55);
+      if (b === -BEATS_PER_BAR) this.voices.blip(t, 660, 0.7);
+    }
+    this.running = true;
+    this.look.start(0);
+    this.fx.stageChanged(this.stage, 0);
+  }
+
+  stop(): void {
+    this.running = false;
+    this.look.stop();
+  }
+
+  dispose(): void {
+    this.stop();
+    this.engine.dispose();
+  }
+
+  // ---------------------------------------------------------------- scheduling
+
+  isGateBar(bar: number): boolean {
+    const into = bar - this.stageStartBar;
+    if (into <= 2) return false;
+    return (into + 1) % this.stage.gateEvery === 0;
+  }
+
+  private fillBar(bar: number, t: number): void {
+    this.bar = bar;
+    const beat0 = this.timeline.beatOfBar(bar);
+
+    // --- Stage advance lands on the bar line, tempo and all.
+    if (bar > 0 && bar - this.stageStartBar >= this.stage.bars) {
+      this.setStage(this.stageIndex + 1, beat0);
+    }
+
+    const spb = this.timeline.spbAtBeat(beat0);
+    const chord = chordAt(bar);
+    const overdrive = bar <= this.overdriveUntilBar;
+
+    this.fx.bar(bar, t);
+
+    // --- Backing: the band that keeps playing whatever the player does.
+    this.scheduleBacking(bar, t, spb, overdrive);
+
+    if (this.isGateBar(bar)) {
+      this.scheduleGateBar(bar, t, spb);
+      return;
+    }
+
+    // --- A riser into the next bar when it is a gate: the drop is announced.
+    if (this.isGateBar(bar + 1)) {
+      this.voices.riser(t + spb * (BEATS_PER_BAR - 2), spb * 2, 0.85);
+    }
+
+    // --- Phrase punctuation.
+    if (bar % 4 === 0) {
+      if (this.layers.has("pad")) {
+        this.voices.chord(t, chordFreqs(chord, 2), spb * BEATS_PER_BAR * 0.95, overdrive ? 1.1 : 0.8);
+      }
+      if (bar % 16 === 0 && bar > 0) {
+        this.voices.impact(t, 0.85);
+        this.fx.drop();
+      }
+    }
+
+    // --- Player notes.
+    for (const n of barNotes(this.stage, this.seed, bar)) {
+      const beat = beat0 + n.beatInBar;
+      this.notes.add({
+        time: this.timeline.timeAt(beat),
+        beat,
+        lane: n.lane,
+        div: n.div,
+        kind: n.kind,
+        accent: n.accent,
+      });
+    }
+  }
+
+  private scheduleBacking(bar: number, t: number, spb: number, overdrive: boolean): void {
+    const chord = chordAt(bar);
+    const root = hz(chord.root + 24);
+    const tier = Math.min(BASS_PATTERNS.length - 1, Math.floor(this.stageIndex / 2));
+    if (this.layers.has("bass")) {
+      for (const b of BASS_PATTERNS[tier]!) {
+        this.voices.bass(t + b * spb, root / 2, spb * 0.62, overdrive ? 1.15 : 1);
+      }
+    }
+    if (this.layers.has("shaker")) {
+      for (let k = 0; k < BEATS_PER_BAR * 2; k++) {
+        if (k % 2 === 0) continue;
+        this.voices.hat(t + (k / 2) * spb, 0.34, false);
+      }
+    }
+    if (this.layers.has("arp")) {
+      const seq = PENTATONIC;
+      for (let k = 0; k < BEATS_PER_BAR * 2; k++) {
+        if ((k + bar) % 3 !== 0) continue;
+        const semi = chord.root + seq[(k + bar) % seq.length]! + 36;
+        this.voices.pluck(t + (k / 2) * spb, hz(semi), 0.3, 1.4);
+      }
+    }
+  }
+
+  private scheduleGateBar(bar: number, t: number, spb: number): void {
+    // The band takes over so the groove never thins while the player thinks.
+    for (let b = 0; b < BEATS_PER_BAR; b++) {
+      const bt = t + b * spb;
+      if (b % 2 === 0) this.voices.kick(bt, 0.8);
+      else this.voices.clap(bt, 0.7);
+      this.voices.hat(bt + spb * 0.5, 0.3, false);
+    }
+
+    const q = this.host.next();
+    const built = buildGate(q, this.rng, { ...DEFAULT_FIT, maxCandidates: 4 });
+    this.gatesSeen++;
+    const beat0 = this.timeline.beatOfBar(bar);
+    for (const c of built.candidates) {
+      const beat = beat0 + c.pos * BEATS_PER_BAR;
+      this.notes.add({
+        time: this.timeline.timeAt(beat),
+        beat,
+        lane: Math.floor((this.stage.lanes - 1) / 2),
+        div: 0,
+        kind: "tom",
+        accent: c.correct,
+        gate: { questionId: q.id, label: c.label, correct: c.correct, pos: c.pos },
+      });
+    }
+    this.gate = { built, bar, openedAtPerf: performance.now(), resolved: false };
+    this.fx.gateOpen(built);
+  }
+
+  private setStage(index: number, atBeat: number): void {
+    this.stageIndex = Math.max(0, index);
+    this.stage = stageAt(this.stageIndex);
+    this.stageStartBar = this.timeline.barOfBeat(atBeat);
+    this.timeline.setTempoAtBeat(atBeat, this.stage.bpm);
+    const anyHost = this.host as Host & { setFloor?: (d: number) => void };
+    anyHost.setFloor?.(this.stage.gateFloor);
+    this.fx.stageChanged(this.stage, this.stageIndex);
+  }
+
+  // -------------------------------------------------------------------- input
+
+  /**
+   * @param lane   lane index the player struck
+   * @param perfMs `performance.now()` of the input event
+   */
+  input(lane: number, perfMs: number): void {
+    if (!this.running) return;
+    // Any input is a gesture; if the platform is still holding audio hostage, this is
+    // the moment it stops.
+    if (this.engine.ctx.state !== "running") void this.engine.resume();
+    const tHit = this.perfToHeard(perfMs);
+    const gateActive = this.gate !== null && !this.gate.resolved;
+    const res = this.notes.hit(lane, tHit, gateActive);
+    if (!res) {
+      this.onStray(lane, tHit);
+      return;
+    }
+    const { note, delta, judgment } = res;
+    if (note.gate) this.resolveGate(note, judgment, delta);
+    else this.onHit(note, judgment, delta);
+  }
+
+  private perfToHeard(perfMs: number): number {
+    const offset = this.engine.now() - performance.now() / 1000;
+    return perfMs / 1000 + offset - this.engine.latency() - this.calibrationMs / 1000;
+  }
+
+  private onHit(note: LiveNote, judgment: Judgment, delta: number): void {
+    this.hits++;
+    this.combo++;
+    this.bestCombo = Math.max(this.bestCombo, this.combo);
+    const mult = this.multiplier();
+    const base = judgment === "perfect" ? 100 : judgment === "great" ? 60 : 30;
+    this.score += base * mult;
+    if (judgment === "perfect") {
+      this.perfects++;
+      this.health = Math.min(1, this.health + HEALTH.perfect);
+    } else if (judgment === "great") {
+      this.health = Math.min(1, this.health + HEALTH.great);
+    }
+    this.recordDelta(delta, judgment);
+
+    const t = this.engine.now() + 0.002;
+    const gain = note.accent ? 1.15 : 0.95;
+    if (note.kind === "kick") this.voices.kick(t, gain);
+    else if (note.kind === "snare") this.voices.snare(t, gain);
+    else if (note.kind === "hat") this.voices.hat(t, gain, note.accent);
+    else this.voices.tom(t, 180 - note.lane * 34, gain);
+    this.voices.pluck(
+      t,
+      comboNote(this.combo),
+      judgment === "perfect" ? 1 : 0.7,
+      judgment === "perfect" ? 1.5 : 1,
+    );
+    this.fx.hit(note, judgment, delta, this.combo);
+  }
+
+  private onStray(lane: number, t: number): void {
+    this.voices.hat(this.engine.now() + 0.002, 0.12, false);
+    this.strayTimes.push(t);
+    this.strayTimes = this.strayTimes.filter((s) => t - s < 1.2);
+    if (this.strayTimes.length > 4) {
+      this.health = Math.max(0, this.health + HEALTH.strayBurst);
+      this.checkStumble();
+    }
+    this.fx.stray(lane);
+  }
+
+  private resolveGate(note: LiveNote, judgment: Judgment, _delta: number): void {
+    const g = this.gate;
+    if (!g || g.resolved) return;
+    const info = note.gate!;
+    g.resolved = true;
+    const ms = Math.max(1, Math.round(performance.now() - g.openedAtPerf));
+    this.host.report({
+      questionId: info.questionId,
+      correct: info.correct,
+      ms,
+      answered: info.label,
+    });
+
+    if (info.correct) {
+      this.gatesCorrect++;
+      this.gateStreak++;
+      this.combo++;
+      this.bestCombo = Math.max(this.bestCombo, this.combo);
+      const bonus = judgment === "perfect" ? 1200 : judgment === "great" ? 900 : 700;
+      this.score += bonus * this.multiplier();
+      this.health = Math.min(1, this.health + HEALTH.gateCorrect);
+      this.earnLayer();
+      const t = this.engine.now() + 0.002;
+      this.voices.impact(t, 0.75);
+      this.voices.chord(t, chordFreqs(chordAt(this.bar), 3), this.barSeconds() * 0.6, 1);
+      this.voices.pluck(t, comboNote(this.combo + 4), 1.1, 1.7);
+      this.host.haptic(judgment === "perfect" ? "success" : "medium");
+      if (this.gateStreak > 0 && this.gateStreak % 4 === 0) {
+        this.overdriveUntilBar = this.bar + 8;
+        this.fx.overdrive(true);
+        this.voices.riser(t, 0.5, 1);
+      }
+      this.fx.gateResolved("correct", note, g.built);
+    } else {
+      this.gateStreak = 0;
+      this.combo = 0;
+      this.health = Math.max(0, this.health + HEALTH.gateWrong);
+      this.duck(this.barSeconds() * 0.9);
+      this.voices.stumble(this.engine.now() + 0.002);
+      this.host.haptic("failure");
+      this.fx.gateResolved("wrong", note, g.built);
+      this.checkStumble();
+    }
+    // The unchosen candidates stop being targets the moment one is struck.
+    for (const n of this.notes.gateNotes()) if (n !== note) n.judged = "miss";
+  }
+
+  private earnLayer(): void {
+    for (const l of LAYER_ORDER) {
+      if (!this.layers.has(l)) {
+        this.layers.add(l);
+        this.fx.layerEarned(l);
+        return;
+      }
+    }
+  }
+
+  private loseLayer(): void {
+    for (let i = LAYER_ORDER.length - 1; i >= 0; i--) {
+      const l = LAYER_ORDER[i]!;
+      if (l !== "bass" && this.layers.has(l)) {
+        this.layers.delete(l);
+        return;
+      }
+    }
+  }
+
+  /** The failure sound: the whole mix goes underwater for a moment. */
+  private duck(seconds: number): void {
+    const t = this.engine.now();
+    const f = this.engine.colour.frequency;
+    f.cancelScheduledValues(t);
+    f.setValueAtTime(Math.max(400, f.value), t);
+    f.exponentialRampToValueAtTime(380, t + 0.06);
+    f.exponentialRampToValueAtTime(20000, t + Math.max(0.35, seconds));
+  }
+
+  private checkStumble(): void {
+    if (this.health > 0.0001) return;
+    // No game over, ever. The music falls apart and the stage steps back.
+    this.health = 0.62;
+    this.combo = 0;
+    this.gateStreak = 0;
+    this.overdriveUntilBar = -1;
+    this.loseLayer();
+    this.duck(1.6);
+    this.voices.stumble(this.engine.now() + 0.002, 1.2);
+    this.host.haptic("heavy");
+    if (this.stageIndex > 0) {
+      const nextBarBeat = this.timeline.beatOfBar(this.bar + 1);
+      this.setStage(this.stageIndex - 1, nextBarBeat);
+      this.notes.cancelAfter(this.timeline.timeAt(nextBarBeat));
+    }
+    this.fx.stumble();
+  }
+
+  multiplier(): number {
+    const m = multiplierFor(this.combo);
+    return this.bar <= this.overdriveUntilBar ? m * 2 : m;
+  }
+
+  overdriveActive(): boolean {
+    return this.bar <= this.overdriveUntilBar && this.overdriveUntilBar >= 0;
+  }
+
+  // ------------------------------------------------------------------- update
+
+  /** Call once per rendered frame. */
+  update(): void {
+    if (!this.running) return;
+    const t = this.heard();
+    if (t <= this.lastReapTime) return;
+    /**
+     * A frame gap the player could not have played through (a tab switch, a long
+     * hitch) is not a performance. Sweep those notes off the board without scoring
+     * them: being punished for a stall the game caused is the fastest way to make a
+     * child stop trusting it.
+     */
+    const stalled = t - this.lastReapTime > 0.6;
+    this.lastReapTime = t;
+    if (stalled) {
+      this.notes.reap(t);
+      this.combo = 0;
+      this.look.pump();
+      return;
+    }
+
+    for (const n of this.notes.reap(t)) {
+      if (n.gate) continue; // gate expiry is handled as a unit below
+      this.misses++;
+      this.combo = 0;
+      this.health = Math.max(0, this.health + HEALTH.miss);
+      this.voices.thud(this.engine.now() + 0.002, 0.55);
+      this.fx.miss(n);
+      this.checkStumble();
+    }
+
+    const g = this.gate;
+    if (g && !g.resolved) {
+      const lastBeat = this.timeline.beatOfBar(g.bar) + BEATS_PER_BAR;
+      if (t > this.timeline.timeAt(lastBeat) + WINDOWS.good) {
+        g.resolved = true;
+        this.gateStreak = 0;
+        this.health = Math.max(0, this.health + HEALTH.gateExpired);
+        this.host.report({
+          questionId: g.built.questionId,
+          correct: false,
+          ms: Math.max(1, Math.round(performance.now() - g.openedAtPerf)),
+          answered: "",
+        });
+        this.duck(0.5);
+        this.fx.gateResolved("expired", null, g.built);
+        this.checkStumble();
+      }
+    }
+    if (this.gate && this.gate.resolved && t > this.timeline.timeAt(this.timeline.beatOfBar(this.gate.bar) + BEATS_PER_BAR) + 0.4) {
+      this.gate = null;
+    }
+    if (this.overdriveUntilBar >= 0 && this.bar > this.overdriveUntilBar) {
+      this.overdriveUntilBar = -1;
+      this.fx.overdrive(false);
+    }
+    this.notes.prune(t);
+    this.look.pump();
+  }
+
+  // -------------------------------------------------------------- calibration
+
+  /**
+   * Silent auto-calibration. A tablet over Bluetooth can sit 120 ms behind and no
+   * child will ever find a settings screen to fix it, so once there is real evidence
+   * of a consistent bias we absorb most of it. Bounded, gradual, and it only ever
+   * looks at hits the player already landed.
+   */
+  private recordDelta(delta: number, judgment: Judgment): void {
+    if (judgment === "good" || judgment === "great" || judgment === "perfect") {
+      this.deltas.push(delta * 1000);
+      if (this.deltas.length > 32) this.deltas.shift();
+    }
+    if (this.deltas.length < 16) return;
+    const sorted = [...this.deltas].sort((a, b) => a - b);
+    const median = sorted[Math.floor(sorted.length / 2)]!;
+    if (Math.abs(median) < 25) return;
+    const next = Math.max(-140, Math.min(140, this.calibrationMs + median * 0.5));
+    if (Math.abs(next - this.calibrationMs) < 1) return;
+    this.calibrationMs = next;
+    this.deltas = [];
+    this.onCalibrationChange?.(next);
+  }
+
+  accuracy(): number {
+    const total = this.hits + this.misses;
+    return total === 0 ? 1 : this.hits / total;
+  }
+}
+
+export type { ChartNote, LiveNote, StageSpec };
+export { laneVoices, classify };

--- a/dynawalla/games/pulse/src/game/stages.ts
+++ b/dynawalla/games/pulse/src/game/stages.ts
@@ -1,0 +1,159 @@
+/**
+ * Escalation.
+ *
+ * A stage is a subdivision. The glyph is the honest fraction of a *bar* that one
+ * note occupies: a quarter note is 1/4 of the bar, an eighth is 1/8, a triplet
+ * eighth is 1/12, and three-against-four means one lane in thirds over another in
+ * quarters. Nobody has to be told this. You feel 1/12 in your hands and then you see
+ * it written down, which is the entire pedagogical trick of the game.
+ */
+
+export type Poly = { lane: number; perBar: number };
+
+export type StageSpec = {
+  id: number;
+  title: string;
+  /** The fraction of one bar that this stage's fastest note occupies. */
+  glyph: string;
+  bpm: number;
+  bars: number;
+  lanes: 1 | 2 | 3;
+  /** Subdivisions of a beat in play. 1 = quarters, 2 = eighths, 3 = triplets, 4 = 16ths. */
+  divs: number[];
+  density: number;
+  poly?: Poly;
+  gateEvery: number;
+  gateFloor: number;
+  /** Which subdivision the bar ruler is ticked at. */
+  tickDiv: number;
+};
+
+export const STAGES: readonly StageSpec[] = [
+  {
+    id: 0,
+    title: "QUARTERS",
+    glyph: "1/4",
+    bpm: 84,
+    bars: 16,
+    lanes: 1,
+    divs: [1],
+    density: 0.9,
+    gateEvery: 8,
+    gateFloor: 0.05,
+    tickDiv: 1,
+  },
+  {
+    id: 1,
+    title: "EIGHTHS",
+    glyph: "1/8",
+    bpm: 92,
+    bars: 16,
+    lanes: 2,
+    divs: [1, 2],
+    density: 0.6,
+    gateEvery: 8,
+    gateFloor: 0.14,
+    tickDiv: 2,
+  },
+  {
+    id: 2,
+    title: "TRIPLETS",
+    glyph: "1/12",
+    bpm: 96,
+    bars: 16,
+    lanes: 2,
+    divs: [1, 3],
+    density: 0.55,
+    gateEvery: 6,
+    gateFloor: 0.24,
+    tickDiv: 3,
+  },
+  {
+    id: 3,
+    title: "MIXED",
+    glyph: "1/8 · 1/12",
+    bpm: 100,
+    bars: 20,
+    lanes: 3,
+    divs: [1, 2, 3],
+    density: 0.5,
+    gateEvery: 6,
+    gateFloor: 0.34,
+    tickDiv: 2,
+  },
+  {
+    id: 4,
+    title: "SIXTEENTHS",
+    glyph: "1/16",
+    bpm: 104,
+    bars: 20,
+    lanes: 3,
+    divs: [1, 2, 4],
+    density: 0.42,
+    gateEvery: 6,
+    gateFloor: 0.44,
+    tickDiv: 4,
+  },
+  {
+    id: 5,
+    title: "THREE OVER FOUR",
+    glyph: "1/3 : 1/4",
+    bpm: 108,
+    bars: 20,
+    lanes: 3,
+    divs: [1, 2],
+    density: 0.4,
+    poly: { lane: 0, perBar: 3 },
+    gateEvery: 6,
+    gateFloor: 0.54,
+    tickDiv: 4,
+  },
+  {
+    id: 6,
+    title: "FIVE OVER FOUR",
+    glyph: "1/5 : 1/4",
+    bpm: 112,
+    bars: 20,
+    lanes: 3,
+    divs: [1, 2, 4],
+    density: 0.38,
+    poly: { lane: 0, perBar: 5 },
+    gateEvery: 5,
+    gateFloor: 0.64,
+    tickDiv: 4,
+  },
+  {
+    id: 7,
+    title: "EVERYTHING",
+    glyph: "1/16 · 1/12 · 1/5",
+    bpm: 118,
+    bars: 24,
+    lanes: 3,
+    divs: [1, 2, 3, 4],
+    density: 0.42,
+    poly: { lane: 2, perBar: 5 },
+    gateEvery: 5,
+    gateFloor: 0.72,
+    tickDiv: 4,
+  },
+];
+
+/**
+ * After the last written stage the game keeps going forever: the hardest shapes
+ * come back a little faster each loop, capped so it stays humanly playable.
+ */
+export function stageAt(index: number): StageSpec {
+  if (index < STAGES.length) return STAGES[index]!;
+  const loop = Math.floor((index - STAGES.length) / 3) + 1;
+  const base = STAGES[5 + ((index - STAGES.length) % 3)]!;
+  return {
+    ...base,
+    id: index,
+    title: base.title,
+    bpm: Math.min(168, base.bpm + loop * 5),
+    bars: 20,
+    density: Math.min(0.62, base.density + loop * 0.035),
+    gateEvery: 5,
+    gateFloor: Math.min(0.95, base.gateFloor + loop * 0.06),
+  };
+}

--- a/dynawalla/games/pulse/src/input.ts
+++ b/dynawalla/games/pulse/src/input.ts
@@ -1,0 +1,124 @@
+/**
+ * Input. Touch and desktop are designed, not ported.
+ *
+ * TOUCH — the lane you tap is the lane you hit, anywhere in the playfield's band, so
+ * the target is a third of the screen rather than a button. Every `pointerdown` is
+ * independent, so two thumbs on two lanes on the same beat both land.
+ *
+ * DESKTOP — three rows of keys, home-row for either hand, plus the arrows, plus
+ * space for the middle. A one-lane stage accepts all of them.
+ *
+ * Timestamps come from `event.timeStamp`, which is sampled by the browser when the
+ * event was generated rather than when JavaScript got around to it. On a busy frame
+ * that is worth 8-16 ms of accuracy, which is a whole judgment grade.
+ */
+
+import { laneAtPoint, type Layout } from "./render/layout.ts";
+
+export type Slot = "top" | "mid" | "bottom";
+
+const KEY_SLOT: Record<string, Slot> = {
+  f: "top",
+  j: "top",
+  w: "top",
+  i: "top",
+  arrowup: "top",
+  g: "mid",
+  k: "mid",
+  s: "mid",
+  arrowright: "mid",
+  " ": "mid",
+  h: "bottom",
+  l: "bottom",
+  x: "bottom",
+  arrowdown: "bottom",
+};
+
+export function slotToLane(slot: Slot, laneCount: number): number {
+  if (laneCount <= 1) return 0;
+  if (laneCount === 2) return slot === "top" ? 0 : 1;
+  return slot === "top" ? 0 : slot === "mid" ? 1 : 2;
+}
+
+export type InputHandlers = {
+  hit(lane: number, perfMs: number): void;
+  /** Return true to swallow the event (a UI button was pressed). */
+  tap(x: number, y: number): boolean;
+  pause(): void;
+  togglePerf(): void;
+};
+
+export type InputBinding = { dispose(): void };
+
+export function bindInput(
+  el: HTMLElement,
+  getLayout: () => Layout,
+  getLaneCount: () => number,
+  h: InputHandlers,
+): InputBinding {
+  const held = new Set<string>();
+
+  const onKeyDown = (e: KeyboardEvent): void => {
+    const k = e.key.toLowerCase();
+    if (k === "escape" || k === "p") {
+      h.pause();
+      e.preventDefault();
+      return;
+    }
+    if (k === "`" || e.code === "F3") {
+      h.togglePerf();
+      e.preventDefault();
+      return;
+    }
+    const slot = KEY_SLOT[k];
+    if (!slot) return;
+    e.preventDefault();
+    if (e.repeat || held.has(k)) return;
+    held.add(k);
+    h.hit(slotToLane(slot, getLaneCount()), stamp(e));
+  };
+
+  const onKeyUp = (e: KeyboardEvent): void => {
+    held.delete(e.key.toLowerCase());
+  };
+
+  const onPointerDown = (e: PointerEvent): void => {
+    const rect = el.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    if (h.tap(x, y)) {
+      e.preventDefault();
+      return;
+    }
+    e.preventDefault();
+    h.hit(laneAtPoint(getLayout(), x, y), stamp(e));
+  };
+
+  const onBlur = (): void => held.clear();
+
+  window.addEventListener("keydown", onKeyDown, { passive: false });
+  window.addEventListener("keyup", onKeyUp);
+  window.addEventListener("blur", onBlur);
+  el.addEventListener("pointerdown", onPointerDown, { passive: false });
+  el.addEventListener("contextmenu", preventDefault);
+
+  return {
+    dispose() {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+      window.removeEventListener("blur", onBlur);
+      el.removeEventListener("pointerdown", onPointerDown);
+      el.removeEventListener("contextmenu", preventDefault);
+    },
+  };
+}
+
+function preventDefault(e: Event): void {
+  e.preventDefault();
+}
+
+/** `event.timeStamp` is in the `performance.now()` epoch for trusted events. */
+function stamp(e: Event): number {
+  const t = e.timeStamp;
+  return Number.isFinite(t) && t > 0 ? t : performance.now();
+}

--- a/dynawalla/games/pulse/src/juice/ease.ts
+++ b/dynawalla/games/pulse/src/juice/ease.ts
@@ -1,0 +1,39 @@
+/** Named easings. Called by name at every call site so the feel is reviewable. */
+
+export const linear = (t: number): number => t;
+
+export const outQuad = (t: number): number => 1 - (1 - t) * (1 - t);
+export const outCubic = (t: number): number => 1 - Math.pow(1 - t, 3);
+export const outQuint = (t: number): number => 1 - Math.pow(1 - t, 5);
+export const outExpo = (t: number): number => (t >= 1 ? 1 : 1 - Math.pow(2, -10 * t));
+
+export const inQuad = (t: number): number => t * t;
+export const inCubic = (t: number): number => t * t * t;
+
+export const inOutCubic = (t: number): number =>
+  t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+
+export const outBack = (t: number, overshoot = 1.9): number => {
+  const c3 = overshoot + 1;
+  return 1 + c3 * Math.pow(t - 1, 3) + overshoot * Math.pow(t - 1, 2);
+};
+
+export const outElastic = (t: number, period = 0.32): number => {
+  if (t <= 0) return 0;
+  if (t >= 1) return 1;
+  const c4 = (2 * Math.PI) / period;
+  return Math.pow(2, -10 * t) * Math.sin((t * 10 - 0.75) * c4) + 1;
+};
+
+/** A single sharp bump: 0 → 1 → 0, peaking at `peak`. */
+export const impulse = (t: number, peak = 0.18): number => {
+  if (t <= 0 || t >= 1) return 0;
+  return t < peak ? outQuad(t / peak) : outCubic(1 - (t - peak) / (1 - peak));
+};
+
+export const clamp01 = (t: number): number => (t < 0 ? 0 : t > 1 ? 1 : t);
+export const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+
+/** Frame-rate independent exponential approach. `rate` = e-folds per second. */
+export const approach = (cur: number, target: number, rate: number, dt: number): number =>
+  target + (cur - target) * Math.exp(-rate * dt);

--- a/dynawalla/games/pulse/src/juice/flash.ts
+++ b/dynawalla/games/pulse/src/juice/flash.ts
@@ -1,0 +1,59 @@
+/**
+ * Photosensitivity governor. This is a children's product; this file is a safety
+ * device, not an effect.
+ *
+ * WCAG 2.3.1 forbids more than three general flashes in any one second. We enforce a
+ * hard floor of 340 ms between accepted *global* flashes (≤ 2.94 Hz) regardless of
+ * tempo, cap the luminance a single flash can add, and refuse outright under
+ * `prefers-reduced-motion`. Anything smaller than a quarter of the viewport is a
+ * local highlight, not a general flash, and is not governed here.
+ *
+ * `accepted` and `rejected` are counted so a test can prove the limiter holds under
+ * a 60-per-second request storm.
+ */
+
+export const MIN_FLASH_INTERVAL_SEC = 0.34;
+export const MAX_FLASH_LUMINANCE = 0.16;
+
+export class FlashGovernor {
+  private last = -Infinity;
+  private value = 0;
+  private readonly reduced: () => boolean;
+  accepted = 0;
+  rejected = 0;
+
+  constructor(reduced: () => boolean) {
+    this.reduced = reduced;
+  }
+
+  /** Returns true when the flash was allowed. Never throws, never queues. */
+  request(now: number, intensity: number): boolean {
+    if (this.reduced()) {
+      this.rejected++;
+      return false;
+    }
+    if (now - this.last < MIN_FLASH_INTERVAL_SEC) {
+      this.rejected++;
+      return false;
+    }
+    this.last = now;
+    this.accepted++;
+    this.value = Math.min(MAX_FLASH_LUMINANCE, Math.max(this.value, intensity * MAX_FLASH_LUMINANCE));
+    return true;
+  }
+
+  /** Decays fast — a flash is a transient, not a wash. */
+  update(dt: number): void {
+    this.value = Math.max(0, this.value - dt * 1.9);
+  }
+
+  /** Current additive luminance, already clamped to the legal maximum. */
+  get level(): number {
+    return Math.min(MAX_FLASH_LUMINANCE, this.value);
+  }
+
+  reset(): void {
+    this.value = 0;
+    this.last = -Infinity;
+  }
+}

--- a/dynawalla/games/pulse/src/juice/hitstop.ts
+++ b/dynawalla/games/pulse/src/juice/hitstop.ts
@@ -1,0 +1,53 @@
+/**
+ * Hitstop — Vlambeer's "Art of Screenshake", with the one adjustment a rhythm game
+ * demands.
+ *
+ * A normal action game freezes the whole simulation for a few frames on impact. Here
+ * the simulation is *music*: freeze it and the groove desynchronises, which is worse
+ * than no juice at all. So hitstop dilates only the **effects clock** — particles,
+ * ripples, the camera punch, the trail decay — while notes and audio stay welded to
+ * the audio clock. You get the slam without ever dropping a beat.
+ */
+
+export class Hitstop {
+  private remaining = 0;
+  private scale = 1;
+
+  /**
+   * @param ms      how long the effects clock is dilated
+   * @param factor  0 = frozen, 0.25 = quarter speed
+   */
+  hit(ms: number, factor = 0): void {
+    const secs = ms / 1000;
+    if (secs <= this.remaining && factor >= this.scale) return;
+    this.remaining = Math.max(this.remaining, secs);
+    this.scale = Math.min(this.scale, factor);
+  }
+
+  /** Consume real dt, return the dt the effects layer should use. */
+  step(dt: number): number {
+    if (this.remaining <= 0) {
+      this.scale = 1;
+      return dt;
+    }
+    const used = Math.min(dt, this.remaining);
+    this.remaining -= dt;
+    if (this.remaining <= 0) {
+      const rest = -this.remaining;
+      this.remaining = 0;
+      const out = used * this.scale + rest;
+      this.scale = 1;
+      return out;
+    }
+    return dt * this.scale;
+  }
+
+  get active(): boolean {
+    return this.remaining > 0;
+  }
+
+  reset(): void {
+    this.remaining = 0;
+    this.scale = 1;
+  }
+}

--- a/dynawalla/games/pulse/src/juice/juice.test.ts
+++ b/dynawalla/games/pulse/src/juice/juice.test.ts
@@ -1,0 +1,108 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { FlashGovernor, MAX_FLASH_LUMINANCE, MIN_FLASH_INTERVAL_SEC } from "./flash.ts";
+import { Hitstop } from "./hitstop.ts";
+import { Shake } from "./shake.ts";
+import { approach, clamp01, outBack, outElastic, outQuint } from "./ease.ts";
+
+test("the flash governor holds WCAG 2.3.1 under a request storm", () => {
+  // 60 requests a second for ten seconds, i.e. what a sixteenth-note strobe would ask
+  // for at a tempo no rhythm game would refuse.
+  const g = new FlashGovernor(() => false);
+  let t = 0;
+  for (let i = 0; i < 600; i++) {
+    g.request(t, 1);
+    t += 1 / 60;
+  }
+  assert.ok(g.accepted <= 3 * 10 + 1, `accepted ${g.accepted} flashes in 10 s`);
+  assert.ok(g.accepted > 0, "the limiter must not refuse everything");
+  assert.ok(MIN_FLASH_INTERVAL_SEC >= 1 / 3, "interval must be at or below 3 Hz");
+});
+
+test("a flash never exceeds the luminance cap, however hard it is pushed", () => {
+  const g = new FlashGovernor(() => false);
+  g.request(0, 1000);
+  assert.ok(g.level <= MAX_FLASH_LUMINANCE + 1e-9);
+  g.request(10, 4);
+  assert.ok(g.level <= MAX_FLASH_LUMINANCE + 1e-9);
+});
+
+test("reduced motion refuses every flash outright", () => {
+  const g = new FlashGovernor(() => true);
+  for (let i = 0; i < 50; i++) g.request(i, 1);
+  assert.equal(g.accepted, 0);
+  assert.equal(g.level, 0);
+});
+
+test("flashes decay to nothing", () => {
+  const g = new FlashGovernor(() => false);
+  g.request(0, 1);
+  for (let i = 0; i < 60; i++) g.update(1 / 60);
+  assert.equal(g.level, 0);
+});
+
+test("hitstop dilates the effects clock and always hands the time back", () => {
+  const hs = new Hitstop();
+  hs.hit(100, 0);
+  let dilated = 0;
+  let real = 0;
+  for (let i = 0; i < 30; i++) {
+    dilated += hs.step(1 / 60);
+    real += 1 / 60;
+  }
+  assert.ok(dilated < real, "frozen effects must fall behind real time");
+  assert.ok(dilated > 0.3, "and must resume once the stop expires");
+  assert.equal(hs.active, false);
+  // Once clear, it is exactly transparent.
+  assert.equal(hs.step(0.016), 0.016);
+});
+
+test("hitstop takes the strongest request, not the latest", () => {
+  const hs = new Hitstop();
+  hs.hit(120, 0);
+  hs.hit(20, 0.9);
+  const d = hs.step(1 / 60);
+  assert.ok(d < 1 / 60 / 2, "the weaker later request must not cancel the freeze");
+});
+
+test("trauma-squared shake decays cleanly to exactly zero", () => {
+  const s = new Shake(2, 3);
+  s.add(1);
+  s.update(1 / 60, 20, 0.02);
+  const first = Math.abs(s.x) + Math.abs(s.y);
+  assert.ok(first > 0);
+  for (let i = 0; i < 120; i++) s.update(1 / 60, 20, 0.02);
+  assert.equal(s.x, 0);
+  assert.equal(s.y, 0);
+  assert.equal(s.rot, 0);
+  assert.equal(s.level, 0);
+});
+
+test("shake is quadratic: a small event is nearly invisible, a big one is not", () => {
+  const small = new Shake(2, 3);
+  const big = new Shake(2, 3);
+  small.add(0.25);
+  big.add(1);
+  small.update(1 / 60, 20, 0.02);
+  big.update(1 / 60, 20, 0.02);
+  const ratio = (Math.abs(big.x) + 1e-9) / (Math.abs(small.x) + 1e-9);
+  assert.ok(ratio > 8, `expected a quadratic gap, got ${ratio.toFixed(1)}×`);
+});
+
+test("easings are well behaved at the endpoints", () => {
+  for (const fn of [outQuint, outBack, outElastic]) {
+    assert.ok(Math.abs(fn(0)) < 1e-6, `${fn.name}(0)`);
+    assert.ok(Math.abs(fn(1) - 1) < 1e-6, `${fn.name}(1)`);
+  }
+  assert.equal(clamp01(-2), 0);
+  assert.equal(clamp01(4), 1);
+});
+
+test("approach is frame-rate independent", () => {
+  const at = (steps: number): number => {
+    let v = 0;
+    for (let i = 0; i < steps; i++) v = approach(v, 1, 6, 1 / steps);
+    return v;
+  };
+  assert.ok(Math.abs(at(60) - at(240)) < 1e-6, "60 Hz and 240 Hz must land in the same place");
+});

--- a/dynawalla/games/pulse/src/juice/shake.ts
+++ b/dynawalla/games/pulse/src/juice/shake.ts
@@ -1,0 +1,72 @@
+/**
+ * Screen shake, the trauma model (Squirrel Eiserloh / "Juicing Your Cameras").
+ *
+ * Events add *trauma*, not offset. Displacement is `trauma^2`, so small events
+ * barely register and a drop is violent, and trauma decays linearly so shake always
+ * ends cleanly instead of asymptoting into a permanent wobble. Offsets come from a
+ * smooth value-noise walk rather than `Math.random()` per frame, which is the
+ * difference between a camera kick and a buzzing artefact.
+ */
+
+export class Shake {
+  private trauma = 0;
+  private readonly decay: number;
+  private t = 0;
+  private readonly seeds: number[];
+
+  x = 0;
+  y = 0;
+  rot = 0;
+
+  constructor(decay = 1.9, seed = 1) {
+    this.decay = decay;
+    this.seeds = [seed * 0.913, seed * 1.771 + 3.1, seed * 2.393 + 7.7];
+  }
+
+  add(amount: number): void {
+    this.trauma = Math.min(1, this.trauma + amount);
+  }
+
+  get level(): number {
+    return this.trauma;
+  }
+
+  /** `maxPx` and `maxRot` are the amplitudes at full trauma. */
+  update(dt: number, maxPx: number, maxRot: number): void {
+    this.t += dt;
+    this.trauma = Math.max(0, this.trauma - this.decay * dt);
+    const s = this.trauma * this.trauma;
+    if (s <= 0.00002) {
+      this.x = 0;
+      this.y = 0;
+      this.rot = 0;
+      return;
+    }
+    this.x = s * maxPx * noise(this.t * 22 + this.seeds[0]!);
+    this.y = s * maxPx * noise(this.t * 24.7 + this.seeds[1]!);
+    this.rot = s * maxRot * noise(this.t * 18.3 + this.seeds[2]!);
+  }
+
+  reset(): void {
+    this.trauma = 0;
+    this.x = 0;
+    this.y = 0;
+    this.rot = 0;
+  }
+}
+
+/** Smooth 1-D value noise in [-1, 1]. */
+function noise(x: number): number {
+  const i = Math.floor(x);
+  const f = x - i;
+  const u = f * f * (3 - 2 * f);
+  return hash(i) * (1 - u) + hash(i + 1) * u;
+}
+
+function hash(i: number): number {
+  let h = Math.imul(i | 0, 0x27d4eb2d);
+  h ^= h >>> 15;
+  h = Math.imul(h, 0x85ebca6b);
+  h ^= h >>> 13;
+  return ((h >>> 0) / 4294967296) * 2 - 1;
+}

--- a/dynawalla/games/pulse/src/main.ts
+++ b/dynawalla/games/pulse/src/main.ts
@@ -1,0 +1,70 @@
+/**
+ * Standalone dev entry. `npm run dev` and the game is playable with the local stub
+ * host — no curriculum package, no engine package, no app shell.
+ *
+ * Haptics degrade silently: in the shipped app the host routes `haptic()` to
+ * `tauri-plugin-haptics`; here it is `navigator.vibrate` where that exists and
+ * nothing at all where it does not.
+ */
+
+import { mount } from "./mount.ts";
+import { createStubHost } from "./stubHost.ts";
+
+const VIBE: Record<string, number | number[]> = {
+  light: 8,
+  medium: 16,
+  heavy: [24, 18, 30],
+  success: [12, 24, 12],
+  failure: [34, 40, 34],
+};
+
+const root = document.getElementById("root");
+if (!root) throw new Error("pulse: #root missing");
+
+const params = new URLSearchParams(location.search);
+const host = createStubHost({
+  seed: params.get("seed") ?? "pulse-dev",
+  startDifficulty: Number(params.get("difficulty") ?? "0.12"),
+  haptic(kind) {
+    if (typeof navigator.vibrate === "function") navigator.vibrate(VIBE[kind] ?? 8);
+  },
+  onReport(r) {
+    if (params.has("log")) console.info("[pulse] report", r);
+  },
+});
+
+document.documentElement.style.height = "100%";
+document.body.style.height = "100%";
+document.body.style.margin = "0";
+document.body.style.background = "#04050a";
+root.style.position = "fixed";
+root.style.inset = "0";
+
+mount(root, host, {
+  ignoreVisibility: params.has("nopause"),
+  startStage: params.has("stage") ? Number(params.get("stage")) : 0,
+});
+
+// QA harness. Never reachable from `mount()`, only from this dev entry.
+if (params.has("bot") || params.has("qa")) {
+  void import("./dev/bot.ts").then(({ attachBot, burst }) => {
+    const g = window as unknown as {
+      __PULSE__?: Record<string, unknown> & { run: never; start?: () => void };
+    };
+    const api = g.__PULSE__;
+    if (!api) return;
+    api.start?.();
+    const bot = params.has("bot")
+      ? attachBot(api.run, {
+          skill: Number(params.get("bot") ?? "0.9"),
+          biasMs: Number(params.get("bias") ?? "0"),
+        })
+      : null;
+    api.bot = bot;
+    api.burst = (ms: number, o: Parameters<typeof burst>[3] = {}) =>
+      burst(api as unknown as Parameters<typeof burst>[0], bot, ms, {
+        canvas: root.querySelector("canvas") as HTMLCanvasElement,
+        ...o,
+      });
+  });
+}

--- a/dynawalla/games/pulse/src/math/malrules.ts
+++ b/dynawalla/games/pulse/src/math/malrules.ts
@@ -1,0 +1,96 @@
+/**
+ * Mal-rules: the wrong answers children actually produce.
+ *
+ * A distractor that nobody would ever write teaches nothing and is trivially
+ * eliminated. Every rule here is a documented systematic error, so a learner who
+ * holds the misconception finds their own answer sitting right there on the bar.
+ */
+
+import { type Rat, rat, add as radd, sub as rsub } from "./rational.ts";
+
+export type MalRule = {
+  id: string;
+  /** The misconception, in one line, for anyone reading a report. */
+  why: string;
+};
+
+export type MalOut = { value: Rat; rule: MalRule };
+
+const R = {
+  addAcross: { id: "add-across", why: "adds numerators and denominators: a/b + c/d = (a+c)/(b+d)" },
+  keepDenom: { id: "keep-denominator", why: "adds numerators, keeps one denominator" },
+  subAcross: { id: "sub-across", why: "subtracts numerators and denominators" },
+  mulDenomToo: { id: "multiply-denominator-too", why: "n × a/b = (n·a)/(n·b)" },
+  complementFlip: {
+    id: "complement-flip",
+    why: "1 − a/b computed as (b−a)/a — subtracts inside the fraction the wrong way",
+  },
+  complementNumer: { id: "complement-numerator-only", why: "1 − a/b = (1−a)/b, treating 1 as 1/b" },
+  offByOneNum: { id: "off-by-one-numerator", why: "counts the ticks, not the gaps" },
+  denomOfLarger: { id: "denominator-of-larger", why: "keeps the bigger denominator, adds numerators" },
+} as const satisfies Record<string, MalRule>;
+
+const safe = (fn: () => Rat): Rat | null => {
+  try {
+    return fn();
+  } catch {
+    return null;
+  }
+};
+
+export function malForAdd(a: Rat, b: Rat): MalOut[] {
+  const out: MalOut[] = [];
+  const across = safe(() => rat(a.n + b.n, a.d + b.d));
+  if (across) out.push({ value: across, rule: R.addAcross });
+  const keep = safe(() => rat(a.n + b.n, a.d));
+  if (keep) out.push({ value: keep, rule: R.keepDenom });
+  const bigger = safe(() => rat(a.n + b.n, a.d > b.d ? a.d : b.d));
+  if (bigger) out.push({ value: bigger, rule: R.denomOfLarger });
+  const off = safe(() => {
+    const s = radd(a, b);
+    return rat(s.n + 1n, s.d);
+  });
+  if (off) out.push({ value: off, rule: R.offByOneNum });
+  return out;
+}
+
+export function malForSub(a: Rat, b: Rat): MalOut[] {
+  const out: MalOut[] = [];
+  const across = safe(() => (a.d === b.d ? rat(a.n - b.n, 1n) : rat(a.n - b.n, a.d - b.d)));
+  if (across) out.push({ value: across, rule: R.subAcross });
+  const keep = safe(() => rat(a.n - b.n, a.d));
+  if (keep) out.push({ value: keep, rule: R.keepDenom });
+  const off = safe(() => {
+    const s = rsub(a, b);
+    return rat(s.n + 1n, s.d);
+  });
+  if (off) out.push({ value: off, rule: R.offByOneNum });
+  return out;
+}
+
+export function malForMul(n: bigint, f: Rat): MalOut[] {
+  const out: MalOut[] = [];
+  const both = safe(() => rat(n * f.n, n * f.d));
+  if (both) out.push({ value: both, rule: R.mulDenomToo });
+  const off = safe(() => rat(n * f.n + 1n, f.d));
+  if (off) out.push({ value: off, rule: R.offByOneNum });
+  const plus = safe(() => rat(n + f.n, f.d));
+  if (plus) out.push({ value: plus, rule: R.keepDenom });
+  return out;
+}
+
+export function malForComplement(f: Rat): MalOut[] {
+  const out: MalOut[] = [];
+  const flip = safe(() => rat(f.d - f.n, f.n));
+  if (flip) out.push({ value: flip, rule: R.complementFlip });
+  const numOnly = safe(() => rat(1n - f.n, f.d));
+  if (numOnly) out.push({ value: numOnly, rule: R.complementNumer });
+  const off = safe(() => {
+    const s = rsub({ n: 1n, d: 1n }, f);
+    return rat(s.n + 1n, s.d);
+  });
+  if (off) out.push({ value: off, rule: R.offByOneNum });
+  return out;
+}
+
+export const MAL_RULES = R;

--- a/dynawalla/games/pulse/src/math/rational.test.ts
+++ b/dynawalla/games/pulse/src/math/rational.test.ts
@@ -1,0 +1,78 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { add, cmp, eq, fmt, inBar, mul, ONE, parseRat, rat, sub, toFloat, ZERO } from "./rational.ts";
+
+test("normalises to a single representation", () => {
+  assert.deepEqual(rat(2, 4), rat(1, 2));
+  assert.deepEqual(rat(-2, -4), rat(1, 2));
+  assert.deepEqual(rat(2, -4), rat(-1, 2));
+  assert.deepEqual(rat(0, 7), ZERO);
+  assert.deepEqual(rat(5, 5), ONE);
+});
+
+test("addition is exact where floats are not", () => {
+  assert.ok(eq(add(rat(1, 3), rat(1, 6)), rat(1, 2)));
+
+  // 1/10 + 2/10 is 3/10. In IEEE doubles it is 0.30000000000000004, so a child who
+  // answers correctly is marked wrong — deterministically, on every device.
+  assert.ok(eq(add(rat(1, 10), rat(2, 10)), rat(3, 10)));
+  assert.notEqual(0.1 + 0.2, 0.3);
+
+  // 7/10 − 4/10 is 3/10; the float is 0.29999999999999993.
+  assert.ok(eq(sub(rat(7, 10), rat(4, 10)), rat(3, 10)));
+  assert.notEqual(0.7 - 0.4, 0.3);
+
+  // Ten tenths is one. Accumulating 0.1 ten times is 0.9999999999999999.
+  let acc = ZERO;
+  let f = 0;
+  for (let i = 0; i < 10; i++) {
+    acc = add(acc, rat(1, 10));
+    f += 0.1;
+  }
+  assert.ok(eq(acc, ONE));
+  assert.notEqual(f, 1);
+});
+
+test("subtraction, multiplication, comparison", () => {
+  assert.ok(eq(sub(rat(3, 4), rat(1, 4)), rat(1, 2)));
+  assert.ok(eq(sub(ONE, rat(3, 8)), rat(5, 8)));
+  assert.ok(eq(mul(rat(3), rat(1, 8)), rat(3, 8)));
+  assert.equal(cmp(rat(1, 3), rat(1, 2)), -1);
+  assert.equal(cmp(rat(2, 4), rat(1, 2)), 0);
+  assert.equal(cmp(rat(5, 6), rat(4, 5)), 1);
+});
+
+test("comparison never consults a float", () => {
+  // 1/3 and 33333333333333331/100000000000000000 collapse to the same double.
+  const a = rat(1n, 3n);
+  const b = rat(33333333333333331n, 100000000000000000n);
+  assert.equal(toFloat(a), toFloat(b));
+  assert.notEqual(cmp(a, b), 0);
+});
+
+test("canonical formatting and round-tripping", () => {
+  assert.equal(fmt(rat(3, 4)), "3/4");
+  assert.equal(fmt(rat(4, 4)), "1");
+  assert.equal(fmt(rat(0, 9)), "0");
+  assert.equal(fmt(rat(-1, 2)), "-1/2");
+  for (const s of ["3/4", "1", "0", "-1/2", "12/16"]) {
+    const r = parseRat(s);
+    assert.ok(r);
+    assert.ok(eq(parseRat(fmt(r))!, r));
+  }
+});
+
+test("parse refuses anything that is not an integer fraction", () => {
+  for (const s of ["0.75", "3 / four", "", "1/0", "7x", "1.5/2"]) {
+    assert.equal(parseRat(s), null, `expected null for ${JSON.stringify(s)}`);
+  }
+  assert.deepEqual(parseRat(" 3 / 4 "), rat(3, 4));
+});
+
+test("inBar is the (0,1] window a bar position can hold", () => {
+  assert.ok(inBar(rat(1, 8)));
+  assert.ok(inBar(ONE));
+  assert.ok(!inBar(ZERO));
+  assert.ok(!inBar(rat(9, 8)));
+  assert.ok(!inBar(rat(-1, 2)));
+});

--- a/dynawalla/games/pulse/src/math/rational.ts
+++ b/dynawalla/games/pulse/src/math/rational.ts
@@ -1,0 +1,100 @@
+/**
+ * Exact rational arithmetic over BigInt.
+ *
+ * A fraction that reaches an answer, a distractor or a comparison is NEVER a float.
+ * `1/3 + 1/6` must be exactly `1/2`, and `0.333… + 0.1666…` is not. Floats appear in
+ * this game only downstream of `toFloat`, and only ever to position a pixel.
+ *
+ * Invariants held by construction:
+ *   - `d > 0n`
+ *   - `gcd(|n|, d) === 1n`
+ *   - zero is exactly `{ n: 0n, d: 1n }`
+ * so structural equality and `cmp` agree and every value has one representation.
+ */
+
+export type Rat = { readonly n: bigint; readonly d: bigint };
+
+function gcd(a: bigint, b: bigint): bigint {
+  let x = a < 0n ? -a : a;
+  let y = b < 0n ? -b : b;
+  while (y !== 0n) {
+    const t = x % y;
+    x = y;
+    y = t;
+  }
+  return x;
+}
+
+export const ZERO: Rat = { n: 0n, d: 1n };
+export const ONE: Rat = { n: 1n, d: 1n };
+
+export function rat(n: bigint | number, d: bigint | number = 1n): Rat {
+  const num0 = typeof n === "number" ? BigInt(assertInt(n)) : n;
+  const den0 = typeof d === "number" ? BigInt(assertInt(d)) : d;
+  if (den0 === 0n) throw new RangeError("rat: zero denominator");
+  let num = num0;
+  let den = den0;
+  if (den < 0n) {
+    num = -num;
+    den = -den;
+  }
+  if (num === 0n) return ZERO;
+  const g = gcd(num, den);
+  return { n: num / g, d: den / g };
+}
+
+function assertInt(v: number): number {
+  if (!Number.isSafeInteger(v)) throw new RangeError(`rat: not a safe integer: ${String(v)}`);
+  return v;
+}
+
+export function add(a: Rat, b: Rat): Rat {
+  return rat(a.n * b.d + b.n * a.d, a.d * b.d);
+}
+export function sub(a: Rat, b: Rat): Rat {
+  return rat(a.n * b.d - b.n * a.d, a.d * b.d);
+}
+export function mul(a: Rat, b: Rat): Rat {
+  return rat(a.n * b.n, a.d * b.d);
+}
+
+/** -1 if a<b, 0 if equal, 1 if a>b. Exact: cross-multiplied integers. */
+export function cmp(a: Rat, b: Rat): -1 | 0 | 1 {
+  const l = a.n * b.d;
+  const r = b.n * a.d;
+  return l < r ? -1 : l > r ? 1 : 0;
+}
+
+export function eq(a: Rat, b: Rat): boolean {
+  return a.n === b.n && a.d === b.d;
+}
+
+/** Canonical display form: "3/4", "1", "0", "2" — never "4/4" or "0/3". */
+export function fmt(r: Rat): string {
+  return r.d === 1n ? String(r.n) : `${r.n}/${r.d}`;
+}
+
+/**
+ * Parse "3/4" | "3 / 4" | "2" | "-1/2". Returns null for anything else, including a
+ * decimal — a decimal answer means the host is not speaking fractions and the caller
+ * must fall back rather than guess.
+ */
+export function parseRat(s: string): Rat | null {
+  const t = s.trim();
+  const m = /^(-?\d{1,15})\s*(?:\/\s*(\d{1,15}))?$/.exec(t);
+  if (!m) return null;
+  const n = BigInt(m[1]!);
+  const d = m[2] === undefined ? 1n : BigInt(m[2]);
+  if (d === 0n) return null;
+  return rat(n, d);
+}
+
+/** ONLY for rendering. Never for a comparison and never for an answer. */
+export function toFloat(r: Rat): number {
+  return Number(r.n) / Number(r.d);
+}
+
+/** True when 0 < r <= 1 — the range a position inside one bar can represent. */
+export function inBar(r: Rat): boolean {
+  return cmp(r, ZERO) > 0 && cmp(r, ONE) <= 0;
+}

--- a/dynawalla/games/pulse/src/mount.ts
+++ b/dynawalla/games/pulse/src/mount.ts
@@ -1,0 +1,298 @@
+/**
+ * `mount(el, host)` — the whole game, in one DOM element.
+ *
+ * Owns the frame loop, the title/pause states, the two corner buttons and the wiring
+ * from `Run`'s events to the juice layer. Everything above this file is pure game or
+ * pure drawing; everything below is the browser.
+ */
+
+import type { Host, Mounted } from "./contract.ts";
+import { Run, type Fx } from "./game/run.ts";
+import { bindInput } from "./input.ts";
+import { createSurfaces } from "./render/canvas.ts";
+import { drawButtons, drawPause, drawPerf, drawTitle, hitButton } from "./render/chrome.ts";
+import { Scene } from "./render/scene.ts";
+import { loadSettings, prefersReducedMotion, saveSettings } from "./settings.ts";
+
+const CSS = `
+.pulse-root{position:relative;width:100%;height:100%;min-height:320px;background:#04050a;
+overflow:hidden;touch-action:none;user-select:none;-webkit-user-select:none;
+-webkit-tap-highlight-color:transparent;color-scheme:dark;contain:layout paint size;}
+.pulse-canvas{position:absolute;inset:0;display:block;width:100%;height:100%;}
+`;
+
+function injectCss(): void {
+  if (document.getElementById("pulse-style")) return;
+  const s = document.createElement("style");
+  s.id = "pulse-style";
+  s.textContent = CSS;
+  document.head.appendChild(s);
+}
+
+type Phase = "title" | "playing" | "paused";
+
+export type MountOptions = {
+  /**
+   * Automation only. A headless harness runs in a tab Chrome reports as hidden even
+   * while it renders at 60 Hz, and the auto-pause would stop the run under it.
+   */
+  ignoreVisibility?: boolean;
+  /** Start partway up the escalation instead of at quarter notes. */
+  startStage?: number;
+};
+
+export function mount(el: HTMLElement, host: Host, options: MountOptions = {}): Mounted {
+  injectCss();
+  el.classList.add("pulse-root");
+
+  const settings = loadSettings();
+  const surfaces = createSurfaces(el);
+  const lowPower =
+    Math.min(window.innerWidth, window.innerHeight) < 520 ||
+    (navigator.hardwareConcurrency ?? 8) <= 4;
+
+  const scene = new Scene(surfaces, {
+    reducedMotion: () => host.prefersReducedMotion() || prefersReducedMotion(),
+    lowPower,
+  });
+
+  const fx: Fx = {
+    hit(note, judgment, delta, combo) {
+      scene.hitBurst(note, judgment, combo, run.stage.lanes, run.nowBeat());
+      host.haptic(judgment === "perfect" ? "medium" : "light");
+      void delta;
+    },
+    miss(note) {
+      scene.missPulse(note, run.stage.lanes, run.nowBeat());
+    },
+    stray(lane) {
+      scene.strayPulse(lane);
+    },
+    gateOpen(g) {
+      scene.gateOpen(g);
+    },
+    gateResolved(outcome, note, g) {
+      scene.gateResolved(outcome, note, g, run.stage.lanes, run.nowBeat());
+    },
+    bar(bar) {
+      scene.onBar(bar);
+    },
+    stageChanged(stage, index) {
+      scene.stageCardShow(stage, index);
+      scene.resize(stage.lanes);
+    },
+    drop() {
+      scene.dropFlash();
+      host.haptic("heavy");
+    },
+    stumble() {
+      scene.stumbleShow();
+    },
+    overdrive(on) {
+      scene.overdriveSet(on);
+    },
+    layerEarned(layer) {
+      scene.layerBanner(layer);
+    },
+  };
+
+  const run = new Run({
+    host,
+    fx,
+    startStage: options.startStage,
+    calibrationMs: settings.calibrationMs,
+    onCalibrationChange(ms) {
+      settings.calibrationMs = ms;
+      saveSettings(settings);
+    },
+  });
+  run.engine.setMuted(settings.muted);
+
+  let phase: Phase = "title";
+  let titleT = 0;
+  let pauseK = 0;
+  let showPerf = new URLSearchParams(location.search).has("perf");
+  let raf = 0;
+  let last = performance.now();
+  const frameTimes: number[] = [];
+  let fps = 60;
+  let fpsAccum = 0;
+  let fpsFrames = 0;
+
+  const startPlaying = (): void => {
+    if (phase !== "title") return;
+    phase = "playing";
+    run.start();
+  };
+
+  const setPaused = (p: boolean): void => {
+    if (phase === "title") return;
+    if (p && phase === "playing") {
+      phase = "paused";
+      void run.engine.ctx.suspend();
+    } else if (!p && phase === "paused") {
+      phase = "playing";
+      void run.engine.ctx.resume();
+    }
+  };
+
+  const input = bindInput(
+    el,
+    () => scene.layout,
+    () => run.stage.lanes,
+    {
+      hit(lane, perfMs) {
+        if (phase === "title") {
+          startPlaying();
+          return;
+        }
+        if (phase === "paused") {
+          setPaused(false);
+          return;
+        }
+        run.input(lane, perfMs);
+      },
+      tap(x, y) {
+        const b = hitButton(x, y, surfaces.w, surfaces.h, scene.layout.compact);
+        if (!b) return false;
+        if (b === "mute") {
+          settings.muted = !settings.muted;
+          run.engine.setMuted(settings.muted);
+          saveSettings(settings);
+        } else {
+          if (phase === "title") startPlaying();
+          else setPaused(phase === "playing");
+        }
+        return true;
+      },
+      pause() {
+        if (phase === "title") startPlaying();
+        else setPaused(phase === "playing");
+      },
+      togglePerf() {
+        showPerf = !showPerf;
+      },
+    },
+  );
+
+  const onVisibility = (): void => {
+    if (document.hidden && !options.ignoreVisibility) setPaused(true);
+  };
+  document.addEventListener("visibilitychange", onVisibility);
+
+  const ro = new ResizeObserver(() => {
+    if (surfaces.resize()) scene.resize(run.stage.lanes);
+  });
+  ro.observe(el);
+  window.addEventListener("resize", onWindowResize);
+  function onWindowResize(): void {
+    if (surfaces.resize()) scene.resize(run.stage.lanes);
+  }
+
+  scene.resize(run.stage.lanes);
+
+  /**
+   * When a harness drives the loop itself, `requestAnimationFrame` stops touching the
+   * game. A browser that throttles rAF (a background tab) would otherwise interleave
+   * one enormous frame into the middle of a measured burst.
+   */
+  let externalDriver = false;
+
+  const step = (raw: number): void => {
+    const dt = Math.min(0.05, Math.max(0, raw / 1000));
+
+    frameTimes.push(raw);
+    if (frameTimes.length > 180) frameTimes.shift();
+    fpsAccum += raw;
+    fpsFrames++;
+    if (fpsAccum >= 500) {
+      fps = (fpsFrames * 1000) / fpsAccum;
+      fpsAccum = 0;
+      fpsFrames = 0;
+    }
+
+    // `visibilitychange` only fires on a *change*; a tab that was already in the
+    // background when the game mounted never gets one, and then plays on unwatched.
+    if (document.hidden && phase === "playing" && !options.ignoreVisibility) setPaused(true);
+
+    if (surfaces.resize()) scene.resize(run.stage.lanes);
+    if (scene.layout.laneCount !== run.stage.lanes) scene.resize(run.stage.lanes);
+
+    run.engine.sample();
+    const { ctx, w, h } = surfaces;
+
+    if (phase === "title") {
+      titleT += dt;
+      ctx.setTransform(surfaces.dpr, 0, 0, surfaces.dpr, 0, 0);
+      ctx.globalCompositeOperation = "source-over";
+      ctx.fillStyle = "#04050a";
+      ctx.fillRect(0, 0, w, h);
+      drawTitle(ctx, w, h, titleT, Math.max(settings.best, run.score), scene.layout.compact);
+    } else {
+      if (phase === "playing") run.update();
+      const drawMs = scene.draw(run, phase === "paused" ? 0 : dt);
+      pauseK = phase === "paused" ? Math.min(1, pauseK + dt * 5) : Math.max(0, pauseK - dt * 6);
+      if (pauseK > 0.002) drawPause(ctx, w, h, pauseK);
+      if (run.score > settings.best) {
+        settings.best = run.score;
+        settings.bestCombo = Math.max(settings.bestCombo, run.bestCombo);
+        if (run.bar % 4 === 0) saveSettings(settings);
+      }
+      if (showPerf) {
+        const sorted = [...frameTimes].sort((a, b) => a - b);
+        drawPerf(ctx, w, {
+          fps,
+          frameMs: frameTimes.reduce((a, b) => a + b, 0) / Math.max(1, frameTimes.length),
+          p95Ms: sorted[Math.floor(sorted.length * 0.95)] ?? 0,
+          drawMs,
+          particles: scene.particles.count,
+          notes: run.notes.all().length,
+          latencyMs: run.engine.latency(),
+          calibrationMs: run.calibrationMs,
+        });
+      }
+    }
+
+    ctx.globalCompositeOperation = "lighter";
+    drawButtons(ctx, w, h, scene.layout.compact, settings.muted, phase === "paused");
+  };
+
+  const frame = (t: number): void => {
+    raf = requestAnimationFrame(frame);
+    const raw = t - last;
+    last = t;
+    if (externalDriver) return;
+    step(raw);
+  };
+  raf = requestAnimationFrame(frame);
+
+  // Debug seam for automated verification and for the perf overlay's numbers.
+  (window as unknown as Record<string, unknown>).__PULSE__ = {
+    run,
+    scene,
+    stats: () => ({ fps, particles: scene.particles.count, notes: run.notes.all().length }),
+    start: startPlaying,
+    press: (lane: number) => run.input(lane, performance.now()),
+    /** Hand the loop to a harness. `step(ms)` then advances exactly one frame. */
+    drive(on: boolean) {
+      externalDriver = on;
+      last = performance.now();
+    },
+    step,
+  };
+
+  return {
+    unmount() {
+      cancelAnimationFrame(raf);
+      input.dispose();
+      ro.disconnect();
+      window.removeEventListener("resize", onWindowResize);
+      document.removeEventListener("visibilitychange", onVisibility);
+      saveSettings(settings);
+      run.dispose();
+      surfaces.dispose();
+      el.classList.remove("pulse-root");
+      delete (window as unknown as Record<string, unknown>).__PULSE__;
+    },
+  };
+}

--- a/dynawalla/games/pulse/src/render/canvas.ts
+++ b/dynawalla/games/pulse/src/render/canvas.ts
@@ -1,0 +1,100 @@
+/**
+ * Canvas plumbing.
+ *
+ * Two surfaces:
+ *  - `main`  — full device-pixel resolution, everything crisp.
+ *  - `trail` — HALF resolution, never cleared, only faded. Every glowing thing is
+ *    also drawn here additively, so it smears into a phosphor trail for free, and
+ *    upscaling a half-res buffer *is* the blur that makes the bloom. Full-res
+ *    feedback is the single easiest way to lose a tablet's fill rate; half-res costs
+ *    a quarter of it and looks better.
+ *
+ * Device pixel ratio is capped at 2. A 3× phone gains nothing visible here and pays
+ * 2.25× the fill.
+ */
+
+export type Surfaces = {
+  main: HTMLCanvasElement;
+  ctx: CanvasRenderingContext2D;
+  trail: HTMLCanvasElement;
+  tctx: CanvasRenderingContext2D;
+  scratchA: HTMLCanvasElement;
+  sctxA: CanvasRenderingContext2D;
+  scratchB: HTMLCanvasElement;
+  sctxB: CanvasRenderingContext2D;
+  /** CSS pixels. */
+  w: number;
+  h: number;
+  dpr: number;
+  /** Trail-buffer scale relative to CSS pixels. */
+  tscale: number;
+  resize(): boolean;
+  dispose(): void;
+};
+
+const MAX_DPR = 2;
+
+function make(): [HTMLCanvasElement, CanvasRenderingContext2D] {
+  const c = document.createElement("canvas");
+  const x = c.getContext("2d", { alpha: true, desynchronized: true });
+  if (!x) throw new Error("pulse: 2d context unavailable");
+  return [c, x];
+}
+
+export function createSurfaces(host: HTMLElement): Surfaces {
+  const [main, ctx] = make();
+  main.className = "pulse-canvas";
+  host.appendChild(main);
+  const [trail, tctx] = make();
+  const [scratchA, sctxA] = make();
+  const [scratchB, sctxB] = make();
+
+  const s: Surfaces = {
+    main,
+    ctx,
+    trail,
+    tctx,
+    scratchA,
+    sctxA,
+    scratchB,
+    sctxB,
+    w: 0,
+    h: 0,
+    dpr: 1,
+    tscale: 0.5,
+    resize() {
+      const rect = host.getBoundingClientRect();
+      const w = Math.max(320, Math.round(rect.width || window.innerWidth));
+      const h = Math.max(320, Math.round(rect.height || window.innerHeight));
+      const dpr = Math.min(MAX_DPR, window.devicePixelRatio || 1);
+      if (w === s.w && h === s.h && dpr === s.dpr) return false;
+      s.w = w;
+      s.h = h;
+      s.dpr = dpr;
+      main.width = Math.round(w * dpr);
+      main.height = Math.round(h * dpr);
+      main.style.width = `${w}px`;
+      main.style.height = `${h}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+      const tw = Math.max(2, Math.round(w * s.tscale));
+      const th = Math.max(2, Math.round(h * s.tscale));
+      for (const [c, x] of [
+        [trail, tctx],
+        [scratchA, sctxA],
+        [scratchB, sctxB],
+      ] as const) {
+        c.width = tw;
+        c.height = th;
+        x.setTransform(s.tscale, 0, 0, s.tscale, 0, 0);
+      }
+      tctx.clearRect(0, 0, w, h);
+      return true;
+    },
+    dispose() {
+      main.remove();
+    },
+  };
+  s.resize();
+  return s;
+}

--- a/dynawalla/games/pulse/src/render/chrome.ts
+++ b/dynawalla/games/pulse/src/render/chrome.ts
@@ -1,0 +1,241 @@
+/**
+ * Title, pause, the two corner buttons and the perf readout.
+ *
+ * All canvas, no DOM: one renderer means the chrome cannot drift away from the
+ * game's register, and there is no second styling system to keep in sync.
+ *
+ * Copy budget: the word PULSE, and nothing else. A ring contracting on the beat is
+ * how the title says "press", in every language.
+ */
+
+import { clamp01, outCubic, outQuint } from "../juice/ease.ts";
+import { glow } from "./glow.ts";
+import { INK, type Ink } from "./palette.ts";
+import { neon } from "./text.ts";
+
+export type ChromeButton = "mute" | "pause";
+
+const BTN = { size: 34, gap: 10, margin: 16 };
+const BTN_COMPACT = { size: 30, gap: 8, margin: 12 };
+
+function metrics(compact: boolean): typeof BTN {
+  return compact ? BTN_COMPACT : BTN;
+}
+
+export function buttonRect(
+  i: number,
+  w: number,
+  h: number,
+  compact: boolean,
+): { x: number; y: number; s: number } {
+  const m = metrics(compact);
+  const s = m.size;
+  const x = w - m.margin - s - i * (s + m.gap);
+  const y = h - m.margin - s;
+  return { x, y, s };
+}
+
+export function hitButton(x: number, y: number, w: number, h: number, compact: boolean): ChromeButton | null {
+  for (let i = 0; i < 2; i++) {
+    const r = buttonRect(i, w, h, compact);
+    const pad = 6;
+    if (x >= r.x - pad && x <= r.x + r.s + pad && y >= r.y - pad && y <= r.y + r.s + pad) {
+      return i === 0 ? "pause" : "mute";
+    }
+  }
+  return null;
+}
+
+export function drawButtons(
+  ctx: CanvasRenderingContext2D,
+  w: number,
+  h: number,
+  compact: boolean,
+  muted: boolean,
+  paused: boolean,
+): void {
+  const draw = (i: number, fn: (x: number, y: number, s: number) => void, ink: Ink, on: boolean): void => {
+    const r = buttonRect(i, w, h, compact);
+    const c = INK[ink];
+    ctx.strokeStyle = `rgba(${c[0]},${c[1]},${c[2]},${on ? 0.5 : 0.24})`;
+    ctx.lineWidth = 1;
+    ctx.strokeRect(r.x + 0.5, r.y + 0.5, r.s, r.s);
+    ctx.strokeStyle = `rgba(${c[0]},${c[1]},${c[2]},${on ? 0.9 : 0.45})`;
+    ctx.lineWidth = 1.8;
+    fn(r.x, r.y, r.s);
+  };
+
+  draw(
+    0,
+    (x, y, s) => {
+      const cx = x + s / 2;
+      const cy = y + s / 2;
+      ctx.beginPath();
+      if (paused) {
+        ctx.moveTo(cx - s * 0.14, cy - s * 0.2);
+        ctx.lineTo(cx + s * 0.22, cy);
+        ctx.lineTo(cx - s * 0.14, cy + s * 0.2);
+        ctx.closePath();
+      } else {
+        ctx.moveTo(cx - s * 0.14, cy - s * 0.2);
+        ctx.lineTo(cx - s * 0.14, cy + s * 0.2);
+        ctx.moveTo(cx + s * 0.14, cy - s * 0.2);
+        ctx.lineTo(cx + s * 0.14, cy + s * 0.2);
+      }
+      ctx.stroke();
+    },
+    "cyan",
+    true,
+  );
+
+  draw(
+    1,
+    (x, y, s) => {
+      const cx = x + s / 2;
+      const cy = y + s / 2;
+      ctx.beginPath();
+      ctx.moveTo(cx - s * 0.24, cy - s * 0.1);
+      ctx.lineTo(cx - s * 0.12, cy - s * 0.1);
+      ctx.lineTo(cx + s * 0.02, cy - s * 0.24);
+      ctx.lineTo(cx + s * 0.02, cy + s * 0.24);
+      ctx.lineTo(cx - s * 0.12, cy + s * 0.1);
+      ctx.lineTo(cx - s * 0.24, cy + s * 0.1);
+      ctx.closePath();
+      ctx.stroke();
+      ctx.beginPath();
+      if (muted) {
+        ctx.moveTo(cx + s * 0.12, cy - s * 0.12);
+        ctx.lineTo(cx + s * 0.28, cy + s * 0.12);
+        ctx.moveTo(cx + s * 0.28, cy - s * 0.12);
+        ctx.lineTo(cx + s * 0.12, cy + s * 0.12);
+      } else {
+        ctx.arc(cx + s * 0.04, cy, s * 0.18, -0.9, 0.9);
+        ctx.moveTo(cx + s * 0.04 + s * 0.29 * Math.cos(0.9), cy + s * 0.29 * Math.sin(-0.9));
+        ctx.arc(cx + s * 0.04, cy, s * 0.29, -0.9, 0.9);
+      }
+      ctx.stroke();
+    },
+    muted ? "rose" : "cyan",
+    !muted,
+  );
+}
+
+/** The title: the word, a live scope, and rings contracting on an 84 BPM pulse. */
+export function drawTitle(
+  ctx: CanvasRenderingContext2D,
+  w: number,
+  h: number,
+  t: number,
+  best: number,
+  compact: boolean,
+): void {
+  const cx = w / 2;
+  const cy = h * 0.44;
+  const bpm = 84;
+  const beat = (t * bpm) / 60;
+  const frac = beat - Math.floor(beat);
+  const pulse = Math.pow(1 - frac, 2.6);
+
+  ctx.globalCompositeOperation = "lighter";
+
+  // Idle scope: a procedural waveform so the display looks alive before audio can
+  // legally start.
+  ctx.beginPath();
+  for (let i = 0; i <= 240; i++) {
+    const x = (i / 240) * w;
+    const p = i / 240;
+    const y =
+      h * 0.78 +
+      Math.sin(p * 26 + t * 2.1) * h * 0.02 * (0.4 + pulse) +
+      Math.sin(p * 61 - t * 3.4) * h * 0.012 +
+      Math.sin(p * 7 + t * 0.9) * h * 0.02;
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.strokeStyle = `rgba(90,240,255,${(0.22 + pulse * 0.2).toFixed(3)})`;
+  ctx.lineWidth = 1.6;
+  ctx.stroke();
+
+  // Contracting rings — the universal "press".
+  for (let k = 0; k < 3; k++) {
+    const ph = (beat + k * 0.33) % 1;
+    const r = (compact ? 120 : 190) * (1 - outCubic(ph)) + 26;
+    const a = (1 - ph) * 0.62;
+    ctx.beginPath();
+    ctx.arc(cx, cy, r, 0, Math.PI * 2);
+    ctx.strokeStyle = `rgba(168,140,255,${a.toFixed(3)})`;
+    ctx.lineWidth = 2.4;
+    ctx.stroke();
+  }
+  glow(ctx, "violet", cx, cy, (compact ? 90 : 140) * (0.7 + pulse * 0.4), 0.3 + pulse * 0.28);
+
+  const size = compact ? 52 : Math.min(120, w * 0.13);
+  ctx.save();
+  ctx.translate(cx, cy);
+  const s = 1 + pulse * 0.035;
+  ctx.scale(s, s);
+  neon(ctx, "PULSE", 0, 0, size, "white", { alpha: 0.98, bloom: 1.6 });
+  ctx.restore();
+
+  if (best > 0) {
+    neon(ctx, best.toLocaleString("en-US"), cx, cy + size * 0.92, compact ? 15 : 20, "cyan", {
+      alpha: 0.5,
+      mono: true,
+    });
+  }
+}
+
+export function drawPause(ctx: CanvasRenderingContext2D, w: number, h: number, k: number): void {
+  ctx.globalCompositeOperation = "source-over";
+  ctx.fillStyle = `rgba(4,5,10,${(0.72 * k).toFixed(3)})`;
+  ctx.fillRect(0, 0, w, h);
+  ctx.globalCompositeOperation = "lighter";
+  const s = Math.min(64, w * 0.08);
+  const cx = w / 2;
+  const cy = h / 2;
+  const g = outQuint(clamp01(k));
+  ctx.strokeStyle = `rgba(235,245,255,${(0.85 * k).toFixed(3)})`;
+  ctx.lineWidth = s * 0.2;
+  ctx.lineCap = "round";
+  ctx.beginPath();
+  ctx.moveTo(cx - s * 0.28, cy - s * 0.4 * g);
+  ctx.lineTo(cx - s * 0.28, cy + s * 0.4 * g);
+  ctx.moveTo(cx + s * 0.28, cy - s * 0.4 * g);
+  ctx.lineTo(cx + s * 0.28, cy + s * 0.4 * g);
+  ctx.stroke();
+}
+
+export type PerfStats = {
+  fps: number;
+  frameMs: number;
+  p95Ms: number;
+  drawMs: number;
+  particles: number;
+  notes: number;
+  latencyMs: number;
+  calibrationMs: number;
+};
+
+export function drawPerf(ctx: CanvasRenderingContext2D, w: number, s: PerfStats): void {
+  const lines = [
+    `${s.fps.toFixed(1)} fps`,
+    `frame ${s.frameMs.toFixed(2)} ms  p95 ${s.p95Ms.toFixed(2)}`,
+    `draw ${s.drawMs.toFixed(2)} ms`,
+    `parts ${s.particles}  notes ${s.notes}`,
+    `latency ${(s.latencyMs * 1000).toFixed(1)} ms  cal ${s.calibrationMs.toFixed(0)} ms`,
+  ];
+  ctx.globalCompositeOperation = "source-over";
+  ctx.fillStyle = "rgba(0,0,0,0.55)";
+  ctx.fillRect(w - 214, 8, 206, 12 + lines.length * 15);
+  ctx.globalCompositeOperation = "lighter";
+  let y = 24;
+  for (const l of lines) {
+    neon(ctx, l, w - 202, y, 12, s.fps < 55 ? "rose" : "lime", {
+      align: "left",
+      mono: true,
+      alpha: 0.9,
+      bloom: 0,
+    });
+    y += 15;
+  }
+}

--- a/dynawalla/games/pulse/src/render/glow.ts
+++ b/dynawalla/games/pulse/src/render/glow.ts
@@ -1,0 +1,90 @@
+/**
+ * Pre-baked glow sprites.
+ *
+ * `ctx.shadowBlur` is the obvious way to make things glow and it is catastrophically
+ * slow — it re-blurs on every draw call. A radial-gradient disc rendered once per ink
+ * and then blitted with `globalCompositeOperation = "lighter"` costs one textured
+ * quad, so several hundred glows a frame stay inside budget on a mid-range tablet.
+ */
+
+import { INK, INK_KEYS, type Ink } from "./palette.ts";
+
+const SIZE = 128;
+const sprites = new Map<Ink, HTMLCanvasElement>();
+let ring: HTMLCanvasElement | null = null;
+
+function build(ink: Ink): HTMLCanvasElement {
+  const c = document.createElement("canvas");
+  c.width = SIZE;
+  c.height = SIZE;
+  const x = c.getContext("2d")!;
+  const [r, g, b] = INK[ink];
+  const grad = x.createRadialGradient(SIZE / 2, SIZE / 2, 0, SIZE / 2, SIZE / 2, SIZE / 2);
+  grad.addColorStop(0, `rgba(${r},${g},${b},1)`);
+  grad.addColorStop(0.12, `rgba(${r},${g},${b},0.85)`);
+  grad.addColorStop(0.32, `rgba(${r},${g},${b},0.32)`);
+  grad.addColorStop(0.62, `rgba(${r},${g},${b},0.07)`);
+  grad.addColorStop(1, `rgba(${r},${g},${b},0)`);
+  x.fillStyle = grad;
+  x.fillRect(0, 0, SIZE, SIZE);
+  return c;
+}
+
+export function warmGlow(): void {
+  for (const k of INK_KEYS) if (!sprites.has(k)) sprites.set(k, build(k));
+  ringSprite();
+}
+
+function ringSprite(): HTMLCanvasElement {
+  if (ring) return ring;
+  const c = document.createElement("canvas");
+  c.width = SIZE;
+  c.height = SIZE;
+  const x = c.getContext("2d")!;
+  const grad = x.createRadialGradient(SIZE / 2, SIZE / 2, SIZE * 0.3, SIZE / 2, SIZE / 2, SIZE / 2);
+  grad.addColorStop(0, "rgba(255,255,255,0)");
+  grad.addColorStop(0.62, "rgba(255,255,255,0.9)");
+  grad.addColorStop(0.78, "rgba(255,255,255,0.35)");
+  grad.addColorStop(1, "rgba(255,255,255,0)");
+  x.fillStyle = grad;
+  x.fillRect(0, 0, SIZE, SIZE);
+  ring = c;
+  return c;
+}
+
+/** Additive glow disc of radius `r` (CSS px) centred on x,y. */
+export function glow(
+  ctx: CanvasRenderingContext2D,
+  ink: Ink,
+  x: number,
+  y: number,
+  r: number,
+  alpha = 1,
+): void {
+  if (alpha <= 0.004 || r <= 0.4) return;
+  let s = sprites.get(ink);
+  if (!s) {
+    s = build(ink);
+    sprites.set(ink, s);
+  }
+  const prev = ctx.globalAlpha;
+  ctx.globalAlpha = Math.min(1, alpha);
+  ctx.drawImage(s, x - r, y - r, r * 2, r * 2);
+  ctx.globalAlpha = prev;
+}
+
+/** A soft white annulus — shockwaves, ripples, the strike halo. */
+export function halo(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  r: number,
+  alpha: number,
+): void {
+  if (alpha <= 0.004 || r <= 0.4) return;
+  const s = ringSprite();
+  const prev = ctx.globalAlpha;
+  ctx.globalAlpha = Math.min(1, alpha);
+  ctx.drawImage(s, x - r, y - r, r * 2, r * 2);
+  ctx.globalAlpha = prev;
+}

--- a/dynawalla/games/pulse/src/render/layout.test.ts
+++ b/dynawalla/games/pulse/src/render/layout.test.ts
@@ -1,0 +1,79 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { computeLayout, laneAtPoint } from "./layout.ts";
+
+const SIZES: [number, number, string][] = [
+  [1440, 900, "desktop"],
+  [1180, 820, "ipad landscape"],
+  [820, 1180, "ipad portrait"],
+  [390, 844, "phone portrait"],
+  [844, 390, "phone landscape"],
+];
+
+test("the visible field is exactly one bar, in every orientation", () => {
+  for (const [w, h, name] of SIZES) {
+    for (const lanes of [1, 2, 3]) {
+      const l = computeLayout(w, h, lanes);
+      const a = l.pt(0, 0.5);
+      const b = l.pt(1, 0.5);
+      const d = Math.hypot(b.x - a.x, b.y - a.y);
+      assert.ok(
+        Math.abs(d - l.runLen) < 1e-6,
+        `${name}/${lanes}: u=0..1 spans ${d.toFixed(1)} px, runLen is ${l.runLen.toFixed(1)}`,
+      );
+      assert.ok(l.runLen > 120, `${name}: only ${l.runLen.toFixed(0)} px of bar`);
+    }
+  }
+});
+
+test("nothing is laid out off screen", () => {
+  for (const [w, h, name] of SIZES) {
+    const l = computeLayout(w, h, 3);
+    for (const u of [0, 0.25, 0.5, 0.75, 1]) {
+      for (const v of [0, 0.5, 1]) {
+        const p = l.pt(u, v);
+        assert.ok(p.x >= -2 && p.x <= w + 2, `${name}: x=${p.x.toFixed(1)} at u=${u} v=${v}`);
+        assert.ok(p.y >= -2 && p.y <= h + 2, `${name}: y=${p.y.toFixed(1)} at u=${u} v=${v}`);
+      }
+    }
+  }
+});
+
+test("portrait falls, landscape scrolls", () => {
+  assert.equal(computeLayout(390, 844, 3).orient, "v");
+  assert.equal(computeLayout(844, 390, 3).orient, "h");
+  assert.equal(computeLayout(1440, 900, 3).orient, "h");
+  const v = computeLayout(390, 844, 3);
+  assert.ok(v.along.y < 0, "notes must approach from the top");
+  const hz = computeLayout(1440, 900, 3);
+  assert.ok(hz.along.x > 0, "future is to the right");
+});
+
+test("a tap lands in the lane it looks like it landed in", () => {
+  for (const [w, h] of SIZES) {
+    for (const lanes of [1, 2, 3]) {
+      const l = computeLayout(w, h, lanes);
+      for (let i = 0; i < lanes; i++) {
+        const p = l.pt(0, l.laneV(i));
+        assert.equal(laneAtPoint(l, p.x, p.y), i, `${w}x${h}/${lanes}: lane ${i} centre`);
+      }
+      // Anywhere on the screen still resolves to a real lane.
+      for (const [x, y] of [
+        [0, 0],
+        [w, h],
+        [w / 2, 0],
+        [0, h / 2],
+      ]) {
+        const lane = laneAtPoint(l, x!, y!);
+        assert.ok(lane >= 0 && lane < lanes);
+      }
+    }
+  }
+});
+
+test("touch targets stay fat enough for a thumb", () => {
+  for (const [w, h, name] of SIZES) {
+    const l = computeLayout(w, h, 3);
+    assert.ok(l.lanePitch >= 44, `${name}: lane pitch is only ${l.lanePitch.toFixed(0)} px`);
+  }
+});

--- a/dynawalla/games/pulse/src/render/layout.ts
+++ b/dynawalla/games/pulse/src/render/layout.ts
@@ -1,0 +1,116 @@
+/**
+ * Playfield geometry — the conceit of the whole game.
+ *
+ * The distance from the strike line to the far edge is **exactly one bar**. Not "a
+ * comfortable scroll speed": one bar. So the field is a fraction bar you can see:
+ * a thing halfway across is at 1/2, and it arrives halfway through the measure.
+ * Position, value and moment are the same fact, which is why answering `1/2 + 1/4`
+ * here is a rhythmic act rather than a quiz.
+ *
+ * Coordinates: `u` runs along time (0 = strike line, 1 = one bar ahead, negative =
+ * already played); `v` runs across lanes, 0..1. Landscape scrolls right-to-left like
+ * a drum score; portrait falls top-to-bottom like every phone rhythm game since
+ * Cytus, and it is the same code with the axes swapped.
+ */
+
+export type Orientation = "h" | "v";
+
+export type Layout = {
+  orient: Orientation;
+  w: number;
+  h: number;
+  laneCount: number;
+  /** Screen pixels for one bar. */
+  runLen: number;
+  /** Lane pitch in pixels across the field. */
+  lanePitch: number;
+  fieldThickness: number;
+  compact: boolean;
+  pt(u: number, v: number, out?: { x: number; y: number }): { x: number; y: number };
+  laneV(lane: number): number;
+  /** Unit vector along +u, in screen space. */
+  along: { x: number; y: number };
+  /** Unit vector along +v, in screen space. */
+  across: { x: number; y: number };
+  /** Where the strike line meets v=0 and v=1. */
+  strikeA: { x: number; y: number };
+  strikeB: { x: number; y: number };
+  /** u beyond which a note is off-screen and can be dropped. */
+  uMax: number;
+  uMin: number;
+};
+
+export function computeLayout(w: number, h: number, laneCount: number): Layout {
+  const orient: Orientation = w >= h * 1.02 ? "h" : "v";
+  const compact = Math.min(w, h) < 460;
+
+  if (orient === "h") {
+    const fieldThickness = Math.min(h * 0.56, Math.max(196, 128 * Math.max(1, laneCount) + 40));
+    const top = h * 0.5 - fieldThickness / 2 + h * 0.02;
+    const strikeX = Math.max(72, Math.min(160, w * 0.19));
+    const runLen = w - strikeX - Math.max(12, w * 0.02);
+    const lanePitch = fieldThickness / laneCount;
+    return {
+      orient,
+      w,
+      h,
+      laneCount,
+      runLen,
+      lanePitch,
+      fieldThickness,
+      compact,
+      pt(u, v, out) {
+        const o = out ?? { x: 0, y: 0 };
+        o.x = strikeX + u * runLen;
+        o.y = top + v * fieldThickness;
+        return o;
+      },
+      laneV: (lane) => (lane + 0.5) / laneCount,
+      along: { x: 1, y: 0 },
+      across: { x: 0, y: 1 },
+      strikeA: { x: strikeX, y: top },
+      strikeB: { x: strikeX, y: top + fieldThickness },
+      uMax: 1.06,
+      uMin: -strikeX / runLen - 0.06,
+    };
+  }
+
+  const fieldThickness = Math.min(w * 0.94, Math.max(190, 132 * Math.max(1, laneCount) + 30));
+  const left = w / 2 - fieldThickness / 2;
+  const strikeY = h * 0.775;
+  const runLen = strikeY - Math.max(64, h * 0.13);
+  const lanePitch = fieldThickness / laneCount;
+  return {
+    orient,
+    w,
+    h,
+    laneCount,
+    runLen,
+    lanePitch,
+    fieldThickness,
+    compact,
+    pt(u, v, out) {
+      const o = out ?? { x: 0, y: 0 };
+      o.x = left + v * fieldThickness;
+      o.y = strikeY - u * runLen;
+      return o;
+    },
+    laneV: (lane) => (lane + 0.5) / laneCount,
+    along: { x: 0, y: -1 },
+    across: { x: 1, y: 0 },
+    strikeA: { x: left, y: strikeY },
+    strikeB: { x: left + fieldThickness, y: strikeY },
+    uMax: 1.06,
+    uMin: -(h - strikeY) / runLen - 0.06,
+  };
+}
+
+/** Which lane a pointer at screen (x,y) belongs to. */
+export function laneAtPoint(l: Layout, x: number, y: number): number {
+  if (l.orient === "h") {
+    const v = (y - l.strikeA.y) / l.fieldThickness;
+    return Math.max(0, Math.min(l.laneCount - 1, Math.floor(v * l.laneCount)));
+  }
+  const v = (x - l.strikeA.x) / l.fieldThickness;
+  return Math.max(0, Math.min(l.laneCount - 1, Math.floor(v * l.laneCount)));
+}

--- a/dynawalla/games/pulse/src/render/palette.ts
+++ b/dynawalla/games/pulse/src/render/palette.ts
@@ -1,0 +1,45 @@
+/**
+ * The register: a CRT vector display in a dark room. Additive neon on near-black,
+ * phosphor persistence, no fills — everything is light.
+ *
+ * Hue is never the only carrier of meaning. Lane identity is also vertical position
+ * and voice; subdivision is also *shape*; judgment is also size, text and haptics.
+ */
+
+export type Ink = keyof typeof INK;
+
+export const INK = {
+  cyan: [90, 240, 255],
+  magenta: [255, 84, 214],
+  lime: [168, 255, 120],
+  amber: [255, 196, 84],
+  white: [235, 245, 255],
+  rose: [255, 96, 96],
+  violet: [168, 140, 255],
+} as const satisfies Record<string, readonly [number, number, number]>;
+
+export const INK_KEYS = Object.keys(INK) as Ink[];
+
+export function rgb(k: Ink, a = 1): string {
+  const c = INK[k];
+  return a >= 1 ? `rgb(${c[0]},${c[1]},${c[2]})` : `rgba(${c[0]},${c[1]},${c[2]},${a})`;
+}
+
+export const BG = "#04050a";
+export const BG_RGB = [4, 5, 10] as const;
+
+/** Lane inks, top (highest voice) to bottom. */
+export const LANE_INK: readonly Ink[] = ["cyan", "magenta", "amber"];
+
+export function laneInk(lane: number, laneCount: number): Ink {
+  if (laneCount <= 1) return "cyan";
+  if (laneCount === 2) return lane === 0 ? "magenta" : "amber";
+  return LANE_INK[lane] ?? "cyan";
+}
+
+export const JUDGE_INK = {
+  perfect: "lime",
+  great: "cyan",
+  good: "amber",
+  miss: "rose",
+} as const satisfies Record<string, Ink>;

--- a/dynawalla/games/pulse/src/render/particles.ts
+++ b/dynawalla/games/pulse/src/render/particles.ts
@@ -1,0 +1,282 @@
+/**
+ * Pooled particles, structure-of-arrays, zero allocation in the hot loop.
+ *
+ * The budget is a hard cap, not a hope: when the pool is full the oldest particle is
+ * recycled rather than the array growing, so a wall of sixteenths cannot walk the
+ * frame time off a cliff. Sparks are drawn as *lines from last position to current* —
+ * a free motion blur that costs one path segment and is the reason a burst reads as
+ * speed rather than as dots.
+ */
+
+import { INK_KEYS, type Ink, INK } from "./palette.ts";
+import { glow } from "./glow.ts";
+
+export const KIND_SPARK = 0;
+export const KIND_MOTE = 1;
+export const KIND_SHARD = 2;
+
+export type EmitOpts = {
+  ink: Ink;
+  count: number;
+  speed: number;
+  spread?: number;
+  angle?: number;
+  life?: number;
+  size?: number;
+  drag?: number;
+  grav?: number;
+  kind?: number;
+};
+
+export class Particles {
+  private x: Float32Array;
+  private y: Float32Array;
+  private px: Float32Array;
+  private py: Float32Array;
+  private vx: Float32Array;
+  private vy: Float32Array;
+  private life: Float32Array;
+  private maxLife: Float32Array;
+  private size: Float32Array;
+  private drag: Float32Array;
+  private grav: Float32Array;
+  private rot: Float32Array;
+  private rotv: Float32Array;
+  private ink: Uint8Array;
+  private kind: Uint8Array;
+  private n = 0;
+  readonly cap: number;
+  private cursor = 0;
+
+  constructor(cap: number) {
+    this.cap = cap;
+    const f = () => new Float32Array(cap);
+    this.x = f();
+    this.y = f();
+    this.px = f();
+    this.py = f();
+    this.vx = f();
+    this.vy = f();
+    this.life = f();
+    this.maxLife = f();
+    this.size = f();
+    this.drag = f();
+    this.grav = f();
+    this.rot = f();
+    this.rotv = f();
+    this.ink = new Uint8Array(cap);
+    this.kind = new Uint8Array(cap);
+  }
+
+  get count(): number {
+    return this.n;
+  }
+
+  clear(): void {
+    this.n = 0;
+  }
+
+  emit(cx: number, cy: number, o: EmitOpts): void {
+    const inkIdx = Math.max(0, INK_KEYS.indexOf(o.ink));
+    const spread = o.spread ?? Math.PI * 2;
+    const base = o.angle ?? 0;
+    const life = o.life ?? 0.5;
+    const size = o.size ?? 2.2;
+    const drag = o.drag ?? 2.6;
+    const grav = o.grav ?? 0;
+    const kind = o.kind ?? KIND_SPARK;
+    for (let k = 0; k < o.count; k++) {
+      let i: number;
+      if (this.n < this.cap) {
+        i = this.n++;
+      } else {
+        i = this.cursor++ % this.cap; // recycle oldest slot; budget is absolute
+      }
+      const a = base + (Math.random() - 0.5) * spread;
+      const sp = o.speed * (0.42 + Math.random() * 0.92);
+      this.x[i] = cx;
+      this.y[i] = cy;
+      this.px[i] = cx;
+      this.py[i] = cy;
+      this.vx[i] = Math.cos(a) * sp;
+      this.vy[i] = Math.sin(a) * sp;
+      const l = life * (0.65 + Math.random() * 0.7);
+      this.life[i] = l;
+      this.maxLife[i] = l;
+      this.size[i] = size * (0.6 + Math.random() * 0.9);
+      this.drag[i] = drag;
+      this.grav[i] = grav;
+      this.rot[i] = Math.random() * Math.PI * 2;
+      this.rotv[i] = (Math.random() - 0.5) * 14;
+      this.ink[i] = inkIdx;
+      this.kind[i] = kind;
+    }
+  }
+
+  update(dt: number): void {
+    if (dt <= 0) return;
+    for (let i = 0; i < this.n; i++) {
+      const l = this.life[i]! - dt;
+      if (l <= 0) {
+        const last = --this.n;
+        if (i !== last) this.swap(i, last);
+        i--;
+        continue;
+      }
+      this.life[i] = l;
+      this.px[i] = this.x[i]!;
+      this.py[i] = this.y[i]!;
+      const d = Math.exp(-this.drag[i]! * dt);
+      this.vx[i] = this.vx[i]! * d;
+      this.vy[i] = this.vy[i]! * d + this.grav[i]! * dt;
+      this.x[i] = this.x[i]! + this.vx[i]! * dt;
+      this.y[i] = this.y[i]! + this.vy[i]! * dt;
+      this.rot[i] = this.rot[i]! + this.rotv[i]! * dt;
+    }
+  }
+
+  private swap(a: number, b: number): void {
+    for (const arr of [
+      this.x,
+      this.y,
+      this.px,
+      this.py,
+      this.vx,
+      this.vy,
+      this.life,
+      this.maxLife,
+      this.size,
+      this.drag,
+      this.grav,
+      this.rot,
+      this.rotv,
+    ]) {
+      const t = arr[a]!;
+      arr[a] = arr[b]!;
+      arr[b] = t;
+    }
+    for (const arr of [this.ink, this.kind]) {
+      const t = arr[a]!;
+      arr[a] = arr[b]!;
+      arr[b] = t;
+    }
+  }
+
+  /** Additive. Caller sets `globalCompositeOperation = "lighter"`. */
+  draw(ctx: CanvasRenderingContext2D, motionScale = 1): void {
+    // Sparks, grouped by ink so the whole burst is one stroked path per colour.
+    for (let ci = 0; ci < INK_KEYS.length; ci++) {
+      let opened = false;
+      for (let i = 0; i < this.n; i++) {
+        if (this.ink[i] !== ci || this.kind[i] !== KIND_SPARK) continue;
+        if (!opened) {
+          ctx.beginPath();
+          opened = true;
+        }
+        const t = this.life[i]! / this.maxLife[i]!;
+        const sx = this.px[i]!;
+        const sy = this.py[i]!;
+        ctx.moveTo(sx, sy);
+        ctx.lineTo(
+          sx + (this.x[i]! - sx) * (1 + 1.4 * motionScale),
+          sy + (this.y[i]! - sy) * (1 + 1.4 * motionScale),
+        );
+        void t;
+      }
+      if (opened) {
+        const c = INK[INK_KEYS[ci]!];
+        ctx.strokeStyle = `rgba(${c[0]},${c[1]},${c[2]},0.85)`;
+        ctx.lineWidth = 2;
+        ctx.lineCap = "round";
+        ctx.stroke();
+      }
+    }
+
+    for (let i = 0; i < this.n; i++) {
+      const k = this.kind[i]!;
+      if (k === KIND_SPARK) continue;
+      const t = this.life[i]! / this.maxLife[i]!;
+      const ink = INK_KEYS[this.ink[i]!]!;
+      if (k === KIND_MOTE) {
+        glow(ctx, ink, this.x[i]!, this.y[i]!, this.size[i]! * (0.5 + t * 2.4), t * 0.75);
+      } else {
+        const c = INK[ink];
+        const s = this.size[i]! * (0.5 + t);
+        ctx.save();
+        ctx.translate(this.x[i]!, this.y[i]!);
+        ctx.rotate(this.rot[i]!);
+        ctx.strokeStyle = `rgba(${c[0]},${c[1]},${c[2]},${(t * 0.9).toFixed(3)})`;
+        ctx.lineWidth = 1.6;
+        ctx.beginPath();
+        ctx.moveTo(-s, -s * 0.7);
+        ctx.lineTo(s, 0);
+        ctx.lineTo(-s, s * 0.7);
+        ctx.closePath();
+        ctx.stroke();
+        ctx.restore();
+      }
+    }
+  }
+}
+
+/** Expanding shockwave rings — cheap, few, and the loudest single hit cue. */
+export class Ripples {
+  private rx: number[] = [];
+  private ry: number[] = [];
+  private t: number[] = [];
+  private dur: number[] = [];
+  private r0: number[] = [];
+  private r1: number[] = [];
+  private ink: Ink[] = [];
+  private wide: number[] = [];
+
+  add(x: number, y: number, r0: number, r1: number, dur: number, ink: Ink, wide = 1): void {
+    if (this.rx.length > 48) this.pop(0);
+    this.rx.push(x);
+    this.ry.push(y);
+    this.t.push(0);
+    this.dur.push(dur);
+    this.r0.push(r0);
+    this.r1.push(r1);
+    this.ink.push(ink);
+    this.wide.push(wide);
+  }
+
+  private pop(i: number): void {
+    for (const a of [this.rx, this.ry, this.t, this.dur, this.r0, this.r1, this.wide]) a.splice(i, 1);
+    this.ink.splice(i, 1);
+  }
+
+  update(dt: number): void {
+    for (let i = this.t.length - 1; i >= 0; i--) {
+      this.t[i] = this.t[i]! + dt;
+      if (this.t[i]! >= this.dur[i]!) this.pop(i);
+    }
+  }
+
+  clear(): void {
+    this.rx.length = 0;
+    this.ry.length = 0;
+    this.t.length = 0;
+    this.dur.length = 0;
+    this.r0.length = 0;
+    this.r1.length = 0;
+    this.wide.length = 0;
+    this.ink.length = 0;
+  }
+
+  draw(ctx: CanvasRenderingContext2D): void {
+    for (let i = 0; i < this.t.length; i++) {
+      const p = this.t[i]! / this.dur[i]!;
+      const eased = 1 - Math.pow(1 - p, 3); // outCubic
+      const r = this.r0[i]! + (this.r1[i]! - this.r0[i]!) * eased;
+      const a = (1 - p) * (1 - p) * 0.9;
+      const c = INK[this.ink[i]!];
+      ctx.strokeStyle = `rgba(${c[0]},${c[1]},${c[2]},${a.toFixed(3)})`;
+      ctx.lineWidth = Math.max(0.6, this.wide[i]! * 3 * (1 - p) + 0.6);
+      ctx.beginPath();
+      ctx.arc(this.rx[i]!, this.ry[i]!, r, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+}

--- a/dynawalla/games/pulse/src/render/scene.ts
+++ b/dynawalla/games/pulse/src/render/scene.ts
@@ -1,0 +1,1077 @@
+/**
+ * The scene: a CRT vector display in a dark room.
+ *
+ * Everything is additive light on near-black — no fills, no cards, no gradients that
+ * a design system would recognise. The frame is built in three passes:
+ *
+ *   1. background   — receding frame tunnel, dust, radial spectrum, oscilloscope
+ *   2. trail buffer — half resolution, faded not cleared, so every glow smears into
+ *                     phosphor persistence and the upscale *is* the bloom
+ *   3. foreground   — the crisp grid, the notes, the numbers
+ *
+ * Camera transform (shake, punch, roll) wraps 1-3. The HUD sits outside it so the
+ * score never becomes unreadable at the exact moment the score changes.
+ */
+
+import { BEATS_PER_BAR } from "../game/chart.ts";
+import { WINDOWS, type Judgment, type LiveNote } from "../game/judge.ts";
+import type { Run } from "../game/run.ts";
+import type { StageSpec } from "../game/stages.ts";
+import type { BuiltGate } from "../game/gate.ts";
+import type { GateOutcome } from "../game/run.ts";
+import { clamp01, impulse, lerp, outBack, outCubic, outExpo, outQuint, approach } from "../juice/ease.ts";
+import { FlashGovernor } from "../juice/flash.ts";
+import { Hitstop } from "../juice/hitstop.ts";
+import { Shake } from "../juice/shake.ts";
+import type { Surfaces } from "./canvas.ts";
+import { glow, halo, warmGlow } from "./glow.ts";
+import { computeLayout, type Layout } from "./layout.ts";
+import { BG_RGB, INK, JUDGE_INK, laneInk, rgb, type Ink } from "./palette.ts";
+import { KIND_MOTE, KIND_SHARD, Particles, Ripples } from "./particles.ts";
+import { fraction, fractionBar, measure, neon, setFont } from "./text.ts";
+
+type Popup = {
+  x: number;
+  y: number;
+  vy: number;
+  t: number;
+  dur: number;
+  text: string;
+  ink: Ink;
+  size: number;
+};
+
+type Dust = { x: number; y: number; z: number; s: number };
+
+export type SceneOptions = {
+  reducedMotion: () => boolean;
+  /** Lower budgets on phones. */
+  lowPower?: boolean;
+};
+
+const FRACTION_TOKEN = /^(-?\d+)\/(\d+)$/;
+const WINDOW_GOOD_SEC = WINDOWS.good;
+const WINDOW_PERFECT_SEC = WINDOWS.perfect;
+
+export class Scene {
+  layout: Layout;
+  readonly particles: Particles;
+  readonly ripples = new Ripples();
+  readonly shake: Shake;
+  readonly flash: FlashGovernor;
+  readonly hitstop = new Hitstop();
+
+  private popups: Popup[] = [];
+  private dust: Dust[] = [];
+  private displayScore = 0;
+  private comboPunch = 0;
+  private multPunch = 0;
+  private zoom = 1;
+  private roll = 0;
+  private chroma = 0;
+  private stageCard: { stage: StageSpec; index: number; t: number } | null = null;
+  private gateGlow = 0;
+  private gateBanner: { text: string; ink: Ink; t: number } | null = null;
+  private overdriveGlow = 0;
+  private stumbleGlow = 0;
+  private beatFlashT = 1;
+  private lastBeatSeen = -1;
+  private laneHit: number[] = [0, 0, 0];
+  private strikePulse = 0;
+  private lowHealthPhase = 0;
+  private time = 0;
+  private frameCost = 0;
+
+  private readonly s: Surfaces;
+  private readonly opts: SceneOptions;
+
+  constructor(s: Surfaces, opts: SceneOptions) {
+    this.s = s;
+    this.opts = opts;
+    warmGlow();
+    this.particles = new Particles(opts.lowPower ? 520 : 900);
+    this.shake = new Shake(2.05, 7);
+    this.flash = new FlashGovernor(opts.reducedMotion);
+    this.layout = computeLayout(s.w, s.h, 3);
+    this.seedDust();
+  }
+
+  private seedDust(): void {
+    const n = this.opts.lowPower ? 54 : 110;
+    this.dust = [];
+    for (let i = 0; i < n; i++) {
+      this.dust.push({
+        x: Math.random(),
+        y: Math.random(),
+        z: 0.25 + Math.random() * 0.75,
+        s: 0.6 + Math.random() * 1.8,
+      });
+    }
+  }
+
+  resize(laneCount: number): void {
+    this.layout = computeLayout(this.s.w, this.s.h, Math.max(1, laneCount));
+  }
+
+  // ------------------------------------------------------------------ fx in
+
+  hitBurst(note: LiveNote, judgment: Judgment, combo: number, laneCount: number, nowBeat: number): void {
+    const reduced = this.opts.reducedMotion();
+    const u = (note.beat - nowBeat) / BEATS_PER_BAR;
+    const p = this.layout.pt(Math.max(0, Math.min(0.06, u)), this.layout.laneV(Math.min(note.lane, laneCount - 1)));
+    const ink = judgment === "perfect" ? "lime" : laneInk(note.lane, laneCount);
+    const heavy = judgment === "perfect";
+    note.pop = 1;
+
+    const n = reduced ? (heavy ? 6 : 3) : heavy ? 26 : judgment === "great" ? 15 : 9;
+    const along = this.layout.along;
+    this.particles.emit(p.x, p.y, {
+      ink,
+      count: n,
+      speed: heavy ? 520 : 330,
+      life: heavy ? 0.5 : 0.34,
+      size: heavy ? 2.6 : 2,
+      drag: 3.4,
+      spread: Math.PI * 2,
+    });
+    if (!reduced) {
+      this.particles.emit(p.x, p.y, {
+        ink: "white",
+        count: heavy ? 8 : 4,
+        speed: 700,
+        life: 0.22,
+        drag: 6,
+        angle: Math.atan2(-along.y, -along.x),
+        spread: 1.0,
+      });
+      if (heavy) {
+        this.particles.emit(p.x, p.y, {
+          ink,
+          count: 6,
+          speed: 210,
+          life: 0.7,
+          size: 5,
+          drag: 1.6,
+          kind: KIND_MOTE,
+        });
+      }
+    }
+    this.ripples.add(p.x, p.y, this.noteRadius() * 0.7, this.noteRadius() * (heavy ? 5.2 : 3.2), heavy ? 0.44 : 0.3, ink, heavy ? 1.4 : 1);
+    this.shake.add(reduced ? 0 : heavy ? 0.19 : judgment === "great" ? 0.11 : 0.06);
+    this.hitstop.hit(heavy ? 34 : 14, heavy ? 0.08 : 0.35);
+    this.laneHit[note.lane] = 1;
+    this.strikePulse = Math.min(1.6, this.strikePulse + (heavy ? 0.9 : 0.55));
+    this.comboPunch = 1;
+    this.popup(p.x, p.y, judgment.toUpperCase(), JUDGE_INK[judgment], heavy ? 22 : 17);
+    if (combo > 0 && combo % 25 === 0) {
+      this.flash.request(this.time, 0.6);
+      this.shake.add(reduced ? 0 : 0.3);
+    }
+  }
+
+  missPulse(note: LiveNote, laneCount: number, nowBeat: number): void {
+    const u = (note.beat - nowBeat) / BEATS_PER_BAR;
+    const p = this.layout.pt(Math.max(-0.2, Math.min(0.06, u)), this.layout.laneV(Math.min(note.lane, laneCount - 1)));
+    note.pop = 1;
+    this.ripples.add(p.x, p.y, this.noteRadius() * 1.4, this.noteRadius() * 0.4, 0.3, "rose", 0.8);
+    if (!this.opts.reducedMotion()) {
+      this.particles.emit(p.x, p.y, {
+        ink: "rose",
+        count: 5,
+        speed: 120,
+        life: 0.4,
+        drag: 4,
+        grav: 620,
+        kind: KIND_SHARD,
+        size: 3,
+      });
+    }
+    this.popup(p.x, p.y, "MISS", "rose", 15);
+    this.comboPunch = 0;
+  }
+
+  strayPulse(lane: number): void {
+    this.laneHit[lane] = Math.max(this.laneHit[lane] ?? 0, 0.35);
+  }
+
+  gateOpen(_g: BuiltGate): void {
+    this.gateGlow = 1;
+  }
+
+  gateResolved(outcome: GateOutcome, note: LiveNote | null, _g: BuiltGate, laneCount: number, nowBeat: number): void {
+    const reduced = this.opts.reducedMotion();
+    if (outcome === "correct" && note) {
+      const u = (note.beat - nowBeat) / BEATS_PER_BAR;
+      const p = this.layout.pt(Math.max(0, Math.min(0.06, u)), this.layout.laneV(Math.min(note.lane, laneCount - 1)));
+      this.flash.request(this.time, 1);
+      this.shake.add(reduced ? 0 : 0.62);
+      this.hitstop.hit(reduced ? 20 : 90, 0.05);
+      this.zoom = 1.085;
+      this.roll = (Math.random() - 0.5) * 0.016;
+      this.chroma = 1;
+      for (const ink of ["lime", "cyan", "white"] as const) {
+        this.particles.emit(p.x, p.y, {
+          ink,
+          count: reduced ? 8 : 42,
+          speed: 900,
+          life: 0.75,
+          size: 3,
+          drag: 2.6,
+        });
+      }
+      this.particles.emit(p.x, p.y, {
+        ink: "lime",
+        count: reduced ? 3 : 14,
+        speed: 300,
+        life: 1.1,
+        size: 8,
+        drag: 1.3,
+        kind: KIND_MOTE,
+      });
+      this.ripples.add(p.x, p.y, 8, Math.max(this.s.w, this.s.h) * 0.95, 0.72, "lime", 2.2);
+      this.ripples.add(p.x, p.y, 8, Math.max(this.s.w, this.s.h) * 0.6, 0.5, "white", 1.4);
+      this.gateBanner = { text: "SOLVED", ink: "lime", t: 0 };
+    } else {
+      this.shake.add(reduced ? 0 : 0.42);
+      this.hitstop.hit(reduced ? 16 : 120, 0.12);
+      this.chroma = 0.85;
+      this.stumbleGlow = 1;
+      this.gateBanner = { text: outcome === "wrong" ? "OFF" : "GONE", ink: "rose", t: 0 };
+      if (note) {
+        const u = (note.beat - nowBeat) / BEATS_PER_BAR;
+        const p = this.layout.pt(Math.max(0, Math.min(0.06, u)), this.layout.laneV(Math.min(note.lane, laneCount - 1)));
+        this.particles.emit(p.x, p.y, {
+          ink: "rose",
+          count: reduced ? 6 : 26,
+          speed: 320,
+          life: 0.8,
+          size: 3,
+          drag: 2.2,
+          grav: 900,
+          kind: KIND_SHARD,
+        });
+      }
+    }
+    this.gateGlow = 0;
+  }
+
+  onBar(_bar: number): void {
+    this.zoom = Math.max(this.zoom, 1.012);
+  }
+
+  stageCardShow(stage: StageSpec, index: number): void {
+    this.stageCard = { stage, index, t: 0 };
+    this.zoom = Math.max(this.zoom, 1.05);
+    this.shake.add(this.opts.reducedMotion() ? 0 : 0.28);
+  }
+
+  dropFlash(): void {
+    this.flash.request(this.time, 0.85);
+    this.shake.add(this.opts.reducedMotion() ? 0 : 0.5);
+    this.zoom = Math.max(this.zoom, 1.07);
+    this.chroma = Math.max(this.chroma, 0.9);
+    const c = this.layout.pt(0.5, 0.5);
+    this.ripples.add(c.x, c.y, 10, Math.max(this.s.w, this.s.h), 0.85, "violet", 2);
+    if (!this.opts.reducedMotion()) {
+      this.particles.emit(c.x, c.y, { ink: "violet", count: 40, speed: 800, life: 0.9, drag: 2, size: 3 });
+    }
+  }
+
+  stumbleShow(): void {
+    this.stumbleGlow = 1.4;
+    this.shake.add(this.opts.reducedMotion() ? 0 : 0.8);
+    this.chroma = 1;
+    this.gateBanner = { text: "REGROUP", ink: "rose", t: 0 };
+  }
+
+  overdriveSet(on: boolean): void {
+    this.overdriveGlow = on ? 1 : 0;
+    if (on) {
+      this.gateBanner = { text: "OVERDRIVE", ink: "violet", t: 0 };
+      this.flash.request(this.time, 1);
+    }
+  }
+
+  layerBanner(name: string): void {
+    this.gateBanner = { text: name.toUpperCase(), ink: "cyan", t: 0 };
+  }
+
+  private popup(x: number, y: number, text: string, ink: Ink, size: number): void {
+    if (this.popups.length > 22) this.popups.shift();
+    this.popups.push({ x, y, vy: -68, t: 0, dur: 0.62, text, ink, size });
+  }
+
+  private noteRadius(): number {
+    return Math.min(this.layout.lanePitch * 0.3, this.layout.compact ? 17 : 24);
+  }
+
+  // ------------------------------------------------------------------- frame
+
+  /** @returns milliseconds spent inside draw, for the perf overlay. */
+  draw(run: Run, dtRaw: number): number {
+    const t0 = performance.now();
+    const reduced = this.opts.reducedMotion();
+    /**
+     * A stalled frame (a tab switch, a garbage-collection hitch, a throttled
+     * background tab) must not be replayed as a fifth of a second of simulation:
+     * particles would survive forever, the pool would fill, and the trail buffer
+     * would saturate. Above 120 ms we advance the effects clock by one nominal frame
+     * and wipe the trail instead.
+     */
+    const stalled = dtRaw > 0.12;
+    const dtReal = stalled ? 1 / 60 : dtRaw;
+    if (stalled) {
+      this.s.tctx.setTransform(this.s.tscale, 0, 0, this.s.tscale, 0, 0);
+      this.s.tctx.globalCompositeOperation = "copy";
+      this.s.tctx.clearRect(0, 0, this.s.w, this.s.h);
+      this.particles.clear();
+      this.ripples.clear();
+    }
+    this.time += dtReal;
+    const dt = this.hitstop.step(dtReal);
+
+    const nowBeat = run.nowBeat();
+    const beatFrac = nowBeat - Math.floor(nowBeat);
+    const beatIdx = Math.floor(nowBeat);
+    if (beatIdx !== this.lastBeatSeen) {
+      this.lastBeatSeen = beatIdx;
+      this.beatFlashT = 0;
+    }
+    this.beatFlashT = Math.min(1, this.beatFlashT + dtReal * 3.4);
+    const beatPulse = Math.pow(1 - clamp01(this.beatFlashT), 2.2);
+
+    // --- simulation of effects
+    this.particles.update(dt);
+    this.ripples.update(dt);
+    this.shake.update(dtReal, reduced ? 0 : this.layout.compact ? 9 : 15, reduced ? 0 : 0.012);
+    this.flash.update(dtReal);
+    this.zoom = approach(this.zoom, 1, 7.5, dtReal);
+    this.roll = approach(this.roll, 0, 6, dtReal);
+    this.chroma = approach(this.chroma, 0, 5.2, dtReal);
+    this.gateGlow = approach(this.gateGlow, run.gate && !run.gate.resolved ? 1 : 0, 6, dtReal);
+    this.stumbleGlow = Math.max(0, this.stumbleGlow - dtReal * 1.4);
+    this.strikePulse = approach(this.strikePulse, 0, 7, dtReal);
+    this.comboPunch = Math.max(0, this.comboPunch - dtReal * 3.6);
+    this.multPunch = Math.max(0, this.multPunch - dtReal * 2.6);
+    this.lowHealthPhase += dtReal * (run.health < 0.3 ? 2.4 : 0);
+    for (let i = 0; i < this.laneHit.length; i++) {
+      this.laneHit[i] = Math.max(0, (this.laneHit[i] ?? 0) - dtReal * 4.2);
+    }
+    for (let i = this.popups.length - 1; i >= 0; i--) {
+      const p = this.popups[i]!;
+      p.t += dt;
+      p.y += p.vy * dt;
+      p.vy *= Math.exp(-4 * dt);
+      if (p.t >= p.dur) this.popups.splice(i, 1);
+    }
+    if (this.stageCard) {
+      this.stageCard.t += dtReal;
+      if (this.stageCard.t > 2.6) this.stageCard = null;
+    }
+    if (this.gateBanner) {
+      this.gateBanner.t += dtReal;
+      if (this.gateBanner.t > 1.5) this.gateBanner = null;
+    }
+    this.displayScore = approach(this.displayScore, run.score, 9, dtReal);
+    for (const n of run.notes.all()) if (n.pop > 0) n.pop = Math.max(0, n.pop - dtReal / 0.3);
+
+    const { ctx, w, h } = this.s;
+    const laneCount = this.layout.laneCount;
+
+    // --- 1. background, in screen space (no camera): the vignette must not move.
+    ctx.setTransform(this.s.dpr, 0, 0, this.s.dpr, 0, 0);
+    ctx.globalCompositeOperation = "source-over";
+    ctx.fillStyle = `rgb(${BG_RGB[0]},${BG_RGB[1]},${BG_RGB[2]})`;
+    ctx.fillRect(0, 0, w, h);
+    this.drawVignette(run, beatPulse);
+
+    // --- camera
+    ctx.save();
+    const cx = w / 2;
+    const cy = h / 2;
+    ctx.translate(cx + this.shake.x, cy + this.shake.y);
+    ctx.rotate(this.shake.rot + this.roll);
+    const z = this.zoom * (1 + beatPulse * (reduced ? 0.002 : 0.006));
+    ctx.scale(z, z);
+    ctx.translate(-cx, -cy);
+
+    ctx.globalCompositeOperation = "lighter";
+    this.drawDust(dt, beatPulse);
+    this.drawTunnel(beatPulse, run);
+    this.drawSpectrum(run, beatPulse);
+    this.drawScope(run);
+
+    // --- 2. trail buffer
+    this.paintTrail(run, nowBeat, dt);
+    this.compositeTrail(ctx, reduced);
+
+    // --- 3. crisp foreground
+    ctx.globalCompositeOperation = "lighter";
+    this.drawGrid(run, nowBeat, beatFrac);
+    this.drawStrike(run, beatPulse);
+    this.drawNotes(run, nowBeat, false);
+    this.drawGatePrompt(run);
+    this.drawPopups();
+    ctx.restore();
+
+    // --- HUD outside the camera
+    ctx.globalCompositeOperation = "lighter";
+    this.drawHud(run);
+    this.drawStageCard();
+    this.drawBanner();
+
+    ctx.globalCompositeOperation = "source-over";
+    const flashLevel = this.flash.level;
+    if (flashLevel > 0.001) {
+      ctx.fillStyle = `rgba(210,235,255,${flashLevel.toFixed(3)})`;
+      ctx.fillRect(0, 0, w, h);
+    }
+
+    this.frameCost = performance.now() - t0;
+    return this.frameCost;
+  }
+
+  // -------------------------------------------------------------- background
+
+  private drawVignette(run: Run, beatPulse: number): void {
+    const { ctx, w, h } = this.s;
+    const g = ctx.createRadialGradient(w * 0.5, h * 0.5, 0, w * 0.5, h * 0.5, Math.max(w, h) * 0.72);
+    const danger = run.health < 0.34 ? (0.34 - run.health) / 0.34 : 0;
+    const pulse = danger * (0.5 + 0.5 * Math.sin(this.lowHealthPhase));
+    const od = this.overdriveGlow;
+    const r = Math.round(10 + pulse * 40 + od * 24);
+    const gg = Math.round(12 + od * 6 + beatPulse * 3);
+    const b = Math.round(26 + od * 40 + beatPulse * 5);
+    g.addColorStop(0, `rgba(${r},${gg},${b},${(0.55 + beatPulse * 0.12).toFixed(3)})`);
+    g.addColorStop(1, "rgba(0,0,0,0)");
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, w, h);
+  }
+
+  private drawDust(dt: number, beatPulse: number): void {
+    const { ctx, w, h } = this.s;
+    ctx.beginPath();
+    for (const d of this.dust) {
+      d.x -= dt * 0.012 * d.z;
+      if (d.x < -0.02) {
+        d.x = 1.02;
+        d.y = Math.random();
+      }
+      const x = d.x * w;
+      const y = d.y * h;
+      const r = d.s * (0.6 + beatPulse * 0.7) * d.z;
+      ctx.moveTo(x + r, y);
+      ctx.arc(x, y, r, 0, Math.PI * 2);
+    }
+    ctx.fillStyle = `rgba(120,180,255,${(0.1 + beatPulse * 0.08).toFixed(3)})`;
+    ctx.fill();
+  }
+
+  /** Concentric echoes of the playfield frame receding into the dark. */
+  private drawTunnel(beatPulse: number, run: Run): void {
+    const { ctx, w, h } = this.s;
+    const l = this.layout;
+    const a = l.pt(l.uMin, 0);
+    const b = l.pt(l.uMax, 1);
+    const x0 = Math.min(a.x, b.x);
+    const y0 = Math.min(a.y, b.y);
+    const fw = Math.abs(b.x - a.x);
+    const fh = Math.abs(b.y - a.y);
+    const cx = x0 + fw / 2;
+    const cy = y0 + fh / 2;
+    const layers = this.opts.lowPower ? 4 : 7;
+    const od = this.overdriveGlow;
+    for (let i = layers; i >= 1; i--) {
+      const s = 1 + i * 0.15 + beatPulse * 0.024 * i;
+      const alpha = (0.3 / i) * (1 + beatPulse * 0.9) * (1 + od * 1.4);
+      const ink = od > 0.5 ? INK.violet : run.health < 0.3 ? INK.rose : INK.cyan;
+      ctx.strokeStyle = `rgba(${ink[0]},${ink[1]},${ink[2]},${alpha.toFixed(3)})`;
+      ctx.lineWidth = 1;
+      ctx.strokeRect(cx - (fw * s) / 2, cy - (fh * s) / 2, fw * s, fh * s);
+    }
+    void w;
+    void h;
+  }
+
+  /**
+   * The spectrum, growing outward from both edges of the playfield.
+   *
+   * This was a ring centred on the strike point, which sits at 19% of the width — so
+   * three quarters of the ring fell off screen and the visible quarter read as a
+   * stray arc. Framing the field instead fills the space above and below it, keeps
+   * the eye where the notes are, and makes the whole layout breathe with the music.
+   */
+  private drawSpectrum(run: Run, beatPulse: number): void {
+    const { ctx } = this.s;
+    const sp = run.engine.spectrum;
+    if (sp.length === 0) return;
+    const l = this.layout;
+    const bins = this.opts.lowPower ? 40 : 72;
+    const od = this.overdriveGlow;
+    const reach = l.orient === "h" ? (this.s.h - l.fieldThickness) * 0.42 : (this.s.w - l.fieldThickness) * 0.42;
+    const span = l.orient === "h" ? this.s.w : this.s.h;
+    const ax = l.across;
+    ctx.lineWidth = Math.max(2, (span / bins) * 0.42);
+    ctx.lineCap = "butt";
+    ctx.beginPath();
+    for (let i = 0; i < bins; i++) {
+      const v = (sp[Math.floor(Math.pow(i / bins, 1.35) * sp.length * 0.72)] ?? 0) / 255;
+      const len = Math.pow(v, 1.7) * reach * (1 + od * 0.5) + 1;
+      const t = (i + 0.5) / bins;
+      for (const [edge, dir] of [
+        [0, -1],
+        [1, 1],
+      ] as const) {
+        const base = l.orient === "h" ? { x: t * span, y: l.pt(0, edge).y } : { x: l.pt(0, edge).x, y: t * span };
+        ctx.moveTo(base.x, base.y);
+        ctx.lineTo(base.x + ax.x * dir * len, base.y + ax.y * dir * len);
+      }
+    }
+    const ink = od > 0.5 ? INK.violet : INK.cyan;
+    ctx.strokeStyle = `rgba(${ink[0]},${ink[1]},${ink[2]},${(0.16 + beatPulse * 0.1).toFixed(3)})`;
+    ctx.stroke();
+  }
+
+  /** The literal waveform of the master bus. */
+  private drawScope(run: Run): void {
+    const { ctx, w, h } = this.s;
+    const wave = run.engine.wave;
+    if (wave.length === 0) return;
+    const l = this.layout;
+    const step = this.opts.lowPower ? 6 : 3;
+    const drawOne = (yc: number, amp: number, alpha: number, ink: Ink): void => {
+      ctx.beginPath();
+      for (let i = 0; i < wave.length; i += step) {
+        const x = (i / (wave.length - 1)) * w;
+        const y = yc + (wave[i] ?? 0) * amp;
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      const c = INK[ink];
+      ctx.strokeStyle = `rgba(${c[0]},${c[1]},${c[2]},${alpha.toFixed(3)})`;
+      ctx.lineWidth = 1.6;
+      ctx.stroke();
+    };
+    if (l.orient === "h") {
+      drawOne(h * 0.915, h * 0.062, 0.5, "cyan");
+      drawOne(h * 0.085, h * 0.042, 0.2, "magenta");
+    } else {
+      drawOne(h * 0.945, h * 0.032, 0.45, "cyan");
+      drawOne(h * 0.055, h * 0.024, 0.18, "magenta");
+    }
+  }
+
+  // ------------------------------------------------------------------ trails
+
+  private paintTrail(run: Run, nowBeat: number, dt: number): void {
+    const { tctx, w, h } = this.s;
+    tctx.setTransform(this.s.tscale, 0, 0, this.s.tscale, 0, 0);
+    /**
+     * Phosphor decay by REMOVING alpha, not by painting the background over it.
+     * Painting `rgba(bg, a)` in source-over drives the buffer's alpha toward 1 and
+     * its colour toward the background, and compositing that with `lighter` then
+     * lifts the whole screen — which is how the first build washed out to lavender.
+     * `destination-out` only ever takes light away.
+     *
+     * The rate is time-based, so a stalled frame fades proportionally instead of
+     * letting a decade of glow pile up behind one 0.3 wipe.
+     */
+    const decay = 1 - Math.exp(-21 * dt);
+    tctx.globalCompositeOperation = "destination-out";
+    tctx.fillStyle = `rgba(0,0,0,${Math.min(1, Math.max(0.02, decay)).toFixed(3)})`;
+    tctx.fillRect(0, 0, w, h);
+    tctx.globalCompositeOperation = "lighter";
+    this.particles.draw(tctx, this.opts.reducedMotion() ? 0.2 : 1);
+    this.ripples.draw(tctx);
+    this.drawNotes(run, nowBeat, true);
+  }
+
+  private compositeTrail(ctx: CanvasRenderingContext2D, reduced: boolean): void {
+    const { trail, w, h } = this.s;
+    ctx.globalCompositeOperation = "lighter";
+    const ch = reduced ? 0 : this.chroma;
+    if (ch > 0.06) {
+      // Real RGB split: tint two silhouettes of the trail buffer and offset them.
+      const d = ch * (this.layout.compact ? 5 : 9);
+      const tint = (dst: CanvasRenderingContext2D, colour: string): void => {
+        dst.setTransform(1, 0, 0, 1, 0, 0);
+        dst.globalCompositeOperation = "copy";
+        dst.drawImage(trail, 0, 0);
+        dst.globalCompositeOperation = "source-in";
+        dst.fillStyle = colour;
+        dst.fillRect(0, 0, trail.width, trail.height);
+      };
+      tint(this.s.sctxA, "#ff3050");
+      tint(this.s.sctxB, "#30d8ff");
+      ctx.globalAlpha = 0.62;
+      ctx.drawImage(this.s.scratchA, -d, 0, w, h);
+      ctx.drawImage(this.s.scratchB, d, 0, w, h);
+      ctx.globalAlpha = 0.8;
+      ctx.drawImage(trail, 0, 0, w, h);
+      ctx.globalAlpha = 1;
+    } else {
+      ctx.drawImage(trail, 0, 0, w, h);
+    }
+  }
+
+  // -------------------------------------------------------------------- grid
+
+  private drawGrid(run: Run, nowBeat: number, _beatFrac: number): void {
+    const { ctx } = this.s;
+    const l = this.layout;
+    const tickDiv = run.stage.tickDiv;
+    const first = Math.floor(nowBeat + l.uMin * BEATS_PER_BAR);
+    const last = Math.ceil(nowBeat + l.uMax * BEATS_PER_BAR);
+    const gate = run.gate && !run.gate.resolved ? 1 : 0;
+    const dim = 1 - gate * 0.45;
+
+    // Lane rails: each lane is a track, not a row of floating things.
+    ctx.beginPath();
+    for (let i = 0; i < l.laneCount; i++) {
+      const v = l.laneV(i);
+      const a = l.pt(l.uMin, v);
+      const b = l.pt(l.uMax, v);
+      ctx.moveTo(a.x, a.y);
+      ctx.lineTo(b.x, b.y);
+    }
+    ctx.strokeStyle = `rgba(90,150,200,${(0.14 * dim).toFixed(3)})`;
+    ctx.lineWidth = 1;
+    ctx.stroke();
+
+    // Field edges.
+    ctx.beginPath();
+    for (const v of [0, 1]) {
+      const a = l.pt(l.uMin, v);
+      const b = l.pt(l.uMax, v);
+      ctx.moveTo(a.x, a.y);
+      ctx.lineTo(b.x, b.y);
+    }
+    ctx.strokeStyle = `rgba(120,190,235,${(0.26 * dim).toFixed(3)})`;
+    ctx.lineWidth = 1.4;
+    ctx.stroke();
+
+    // Subdivision lines.
+    if (tickDiv > 1) {
+      ctx.beginPath();
+      for (let b = first; b <= last; b++) {
+        for (let k = 1; k < tickDiv; k++) {
+          const beat = b + k / tickDiv;
+          const u = (beat - nowBeat) / BEATS_PER_BAR;
+          if (u < l.uMin || u > l.uMax) continue;
+          const a = l.pt(u, 0);
+          const bpt = l.pt(u, 1);
+          ctx.moveTo(a.x, a.y);
+          ctx.lineTo(bpt.x, bpt.y);
+        }
+      }
+      ctx.strokeStyle = `rgba(80,140,190,${(0.13 * dim).toFixed(3)})`;
+      ctx.lineWidth = 1;
+      ctx.stroke();
+    }
+
+    // Beat lines + the fraction they sit at inside the bar.
+    const labelSize = l.compact ? 9 : 11;
+    for (let b = first; b <= last; b++) {
+      const u = (b - nowBeat) / BEATS_PER_BAR;
+      if (u < l.uMin || u > l.uMax) continue;
+      const isBar = ((b % BEATS_PER_BAR) + BEATS_PER_BAR) % BEATS_PER_BAR === 0;
+      const a = l.pt(u, 0);
+      const c = l.pt(u, 1);
+      ctx.beginPath();
+      ctx.moveTo(a.x, a.y);
+      ctx.lineTo(c.x, c.y);
+      ctx.strokeStyle = isBar
+        ? `rgba(150,215,255,${(0.5 * dim).toFixed(3)})`
+        : `rgba(90,160,210,${(0.24 * dim).toFixed(3)})`;
+      ctx.lineWidth = isBar ? 2 : 1;
+      ctx.stroke();
+
+      const lp = l.pt(u, 1);
+      const lx = lp.x + l.across.x * (l.compact ? 15 : 20);
+      const ly = lp.y + l.across.y * (l.compact ? 15 : 20);
+      const k = ((b % BEATS_PER_BAR) + BEATS_PER_BAR) % BEATS_PER_BAR;
+      if (isBar) {
+        neon(ctx, "1", lx, ly, labelSize * 1.5, "white", { alpha: 0.55 * dim, bloom: 0.4 });
+      } else {
+        fraction(ctx, k, BEATS_PER_BAR, lx, ly, labelSize, "cyan", 0.4 * dim);
+      }
+    }
+  }
+
+  private drawStrike(run: Run, beatPulse: number): void {
+    const { ctx } = this.s;
+    const l = this.layout;
+    const a = l.strikeA;
+    const b = l.strikeB;
+    const pulse = this.strikePulse;
+    const gate = this.gateGlow;
+
+    // The timing window, drawn to scale. A player can literally see how much room
+    // they have, and it visibly narrows as the tempo climbs.
+    const spb = run.timeline.spbAtBeat(run.nowBeat());
+    const uWin = WINDOW_GOOD_SEC / spb / BEATS_PER_BAR;
+    const uPerf = WINDOW_PERFECT_SEC / spb / BEATS_PER_BAR;
+    for (const [u, alpha] of [
+      [uWin, 0.05],
+      [uPerf, 0.09],
+    ] as const) {
+      const p0 = l.pt(-u, 0);
+      const p1 = l.pt(u, 1);
+      ctx.fillStyle = `rgba(120,220,255,${(alpha * (1 + pulse)).toFixed(3)})`;
+      ctx.fillRect(Math.min(p0.x, p1.x), Math.min(p0.y, p1.y), Math.abs(p1.x - p0.x), Math.abs(p1.y - p0.y));
+    }
+
+    ctx.beginPath();
+    ctx.moveTo(a.x, a.y);
+    ctx.lineTo(b.x, b.y);
+    ctx.strokeStyle = `rgba(235,250,255,${(0.5 + pulse * 0.45 + beatPulse * 0.16).toFixed(3)})`;
+    ctx.lineWidth = 2 + pulse * 3;
+    ctx.stroke();
+
+    const mid = l.pt(0, 0.5);
+    glow(ctx, gate > 0.3 ? "lime" : "white", mid.x, mid.y, l.fieldThickness * (0.5 + pulse * 0.35), 0.16 + pulse * 0.3 + gate * 0.2);
+
+    // Per-lane strike markers: a diamond that squashes when its lane is struck.
+    const r = this.noteRadius();
+    for (let i = 0; i < l.laneCount; i++) {
+      const p = l.pt(0, l.laneV(i));
+      const hit = this.laneHit[i] ?? 0;
+      const ink = laneInk(i, l.laneCount);
+      const sx = 1 + hit * 0.85;
+      const sy = 1 - hit * 0.4;
+      ctx.save();
+      ctx.translate(p.x, p.y);
+      if (l.orient === "h") ctx.scale(sy, sx);
+      else ctx.scale(sx, sy);
+      ctx.rotate(Math.PI / 4);
+      const c = INK[ink];
+      ctx.strokeStyle = `rgba(${c[0]},${c[1]},${c[2]},${(0.55 + hit * 0.45).toFixed(3)})`;
+      ctx.lineWidth = 2;
+      const s = r * 0.72;
+      ctx.strokeRect(-s / 2, -s / 2, s, s);
+      ctx.restore();
+      if (hit > 0.02) glow(ctx, ink, p.x, p.y, r * (1.4 + hit * 2.2), hit * 0.55);
+    }
+    void run;
+  }
+
+  // ------------------------------------------------------------------- notes
+
+  private drawNotes(run: Run, nowBeat: number, toTrail: boolean): void {
+    const ctx = toTrail ? this.s.tctx : this.s.ctx;
+    const l = this.layout;
+    const laneCount = l.laneCount;
+    const r = this.noteRadius();
+    const gateDim = run.gate && !run.gate.resolved ? 0.35 : 1;
+
+    for (const n of run.notes.all()) {
+      const u = (n.beat - nowBeat) / BEATS_PER_BAR;
+      if (u > l.uMax || u < l.uMin) continue;
+      const judged = n.judged !== null;
+      if (judged && n.pop <= 0) continue;
+      const lane = Math.min(n.lane, laneCount - 1);
+      const p = l.pt(u, l.laneV(lane));
+      const isGate = n.gate !== undefined;
+      const ink: Ink = isGate ? "violet" : laneInk(lane, laneCount);
+
+      // Fade in at the far edge so nothing pops into existence.
+      const enter = clamp01((1.04 - u) / 0.12);
+      let alpha = enter * (isGate ? 1 : gateDim);
+      let scale = 1 + (n.accent ? 0.16 : 0);
+      if (judged) {
+        const k = n.pop;
+        if (n.judged === "miss") {
+          alpha *= k * 0.5;
+          scale *= 0.6 + k * 0.4;
+        } else {
+          alpha *= k;
+          scale *= 1 + (1 - k) * 1.7; // outward pop
+        }
+      }
+      if (alpha <= 0.01) continue;
+
+      const rr = (isGate ? r * (l.compact ? 1.7 : 2.0) : r) * scale;
+      if (toTrail) {
+        glow(ctx, ink, p.x, p.y, rr * 2.1, alpha * (isGate ? 0.5 : 0.34));
+        continue;
+      }
+
+      glow(ctx, ink, p.x, p.y, rr * 1.6, alpha * 0.42);
+      const c = INK[ink];
+      ctx.strokeStyle = `rgba(${c[0]},${c[1]},${c[2]},${alpha.toFixed(3)})`;
+      ctx.lineWidth = isGate ? 2.5 : n.accent ? 2.4 : 1.8;
+      shape(ctx, n.div, p.x, p.y, rr, isGate);
+
+      if (isGate) {
+        const g = n.gate!;
+        const m = FRACTION_TOKEN.exec(g.label);
+        const inner = rr * 0.62;
+        if (m) {
+          fraction(ctx, Number(m[1]), Number(m[2]), p.x, p.y - inner * 0.06, inner * 0.84, "white", alpha);
+          fractionBar(
+            ctx,
+            Number(m[1]),
+            Number(m[2]),
+            p.x - rr * 0.72,
+            p.y + rr * (l.compact ? 0.72 : 0.78),
+            rr * 1.44,
+            l.compact ? 5 : 7,
+            "violet",
+            alpha * 0.9,
+          );
+        } else {
+          neon(ctx, g.label, p.x, p.y, inner, "white", { alpha });
+        }
+      }
+    }
+  }
+
+  private drawGatePrompt(run: Run): void {
+    const g = run.gate;
+    if (!g) return;
+    const k = this.gateGlow;
+    if (k <= 0.02) return;
+    const { ctx, w, h } = this.s;
+    const l = this.layout;
+    const size = l.compact ? 26 : Math.min(46, w * 0.05);
+    const y = l.orient === "h" ? Math.min(l.strikeA.y - size * 1.9, h * 0.2) : h * 0.075;
+    const cx = w / 2;
+    const grow = outBack(clamp01(k * 1.4)) * k;
+    ctx.save();
+    ctx.translate(cx, y);
+    ctx.scale(0.86 + grow * 0.14, 0.86 + grow * 0.14);
+    drawPromptTokens(ctx, g.built.prompt, 0, 0, size, k);
+    ctx.restore();
+  }
+
+  private drawPopups(): void {
+    const { ctx } = this.s;
+    for (const p of this.popups) {
+      const k = 1 - p.t / p.dur;
+      const a = k * k;
+      const s = p.size * (1 + (1 - k) * 0.35);
+      neon(ctx, p.text, p.x, p.y, s, p.ink, { alpha: a, bloom: 0.8 });
+    }
+  }
+
+  // --------------------------------------------------------------------- hud
+
+  private drawHud(run: Run): void {
+    const { ctx, w, h } = this.s;
+    const l = this.layout;
+    const pad = l.compact ? 14 : 26;
+    const big = l.compact ? 26 : 38;
+
+    // Score, monospaced so the digits never dance.
+    const score = Math.round(this.displayScore).toLocaleString("en-US");
+    neon(ctx, score, pad, pad + big * 0.5, big, "white", { align: "left", mono: true, alpha: 0.95 });
+
+    // Multiplier.
+    const mult = run.multiplier();
+    const mtxt = `×${mult}`;
+    const msize = big * (0.8 + this.multPunch * 0.5);
+    const mink: Ink = run.overdriveActive() ? "violet" : mult >= 4 ? "lime" : "cyan";
+    neon(ctx, mtxt, w - pad, pad + big * 0.5, msize, mink, { align: "right", mono: true, alpha: 0.95 });
+
+    // Combo, near the strike line where the eye already is.
+    if (run.combo >= 3) {
+      const p = l.pt(l.orient === "h" ? 0.02 : 0.02, l.orient === "h" ? -0.22 : 1.24);
+      const cs = (l.compact ? 30 : 46) * (1 + this.comboPunch * 0.28);
+      neon(ctx, String(run.combo), p.x, p.y, cs, run.combo >= 25 ? "lime" : "white", {
+        align: "center",
+        mono: true,
+        alpha: 0.5 + Math.min(0.5, run.combo / 60),
+      });
+    }
+
+    // Health: segmented, plus a label so it is not colour alone.
+    const segs = 10;
+    const bw = l.compact ? 110 : 168;
+    const bh = l.compact ? 5 : 7;
+    const bx = pad;
+    const by = pad + big + (l.compact ? 8 : 12);
+    const filled = Math.ceil(run.health * segs - 0.0001);
+    for (let i = 0; i < segs; i++) {
+      const cw = bw / segs;
+      const on = i < filled;
+      const ink: Ink = run.health < 0.3 ? "rose" : run.health < 0.6 ? "amber" : "cyan";
+      const c = INK[ink];
+      ctx.fillStyle = `rgba(${c[0]},${c[1]},${c[2]},${on ? 0.75 : 0.09})`;
+      ctx.fillRect(bx + i * cw, by, cw - 2, bh);
+    }
+
+    // Stage strip: the subdivision you are currently living in.
+    const sy = by + bh + (l.compact ? 12 : 16);
+    neon(ctx, run.stage.title, bx, sy, l.compact ? 10 : 12, "cyan", {
+      align: "left",
+      alpha: 0.55,
+    });
+
+    // The stage's note value, drawn as the fraction it is.
+    const glyph = run.stage.glyph;
+    const gx = bx + measure(ctx, run.stage.title, l.compact ? 10 : 12) + (l.compact ? 12 : 16);
+    drawGlyphChain(ctx, glyph, gx, sy, l.compact ? 9 : 11, 0.6);
+
+    void h;
+  }
+
+  private drawStageCard(): void {
+    const card = this.stageCard;
+    if (!card) return;
+    const { ctx, w, h } = this.s;
+    const t = card.t;
+    const inK = clamp01(t / 0.35);
+    const outK = 1 - clamp01((t - 1.9) / 0.7);
+    const a = Math.min(outExpo(inK), outCubic(outK));
+    if (a <= 0.01) return;
+    const cx = w / 2;
+    const cy = h * (this.layout.orient === "h" ? 0.5 : 0.42);
+    const s = (this.layout.compact ? 40 : 64) * (0.86 + outBack(inK) * 0.14);
+    ctx.save();
+    ctx.globalAlpha = 1;
+    neon(ctx, card.stage.title, cx, cy - s * 0.85, s, "white", { alpha: a * 0.95 });
+    drawGlyphChain(ctx, card.stage.glyph, cx, cy + s * 0.55, s * 0.44, a * 0.9, true);
+    ctx.restore();
+  }
+
+  private drawBanner(): void {
+    const b = this.gateBanner;
+    if (!b) return;
+    const { ctx, w, h } = this.s;
+    const k = clamp01(b.t / 1.5);
+    const a = (1 - k) * (1 - k);
+    const s = (this.layout.compact ? 30 : 48) * (1 + outQuint(clamp01(b.t * 4)) * 0.3);
+    neon(ctx, b.text, w / 2, h * (this.layout.orient === "h" ? 0.34 : 0.3), s, b.ink, { alpha: a });
+  }
+
+  get lastFrameCost(): number {
+    return this.frameCost;
+  }
+
+  reset(): void {
+    this.particles.clear();
+    this.ripples.clear();
+    this.popups.length = 0;
+    this.shake.reset();
+    this.flash.reset();
+    this.hitstop.reset();
+    this.displayScore = 0;
+    this.stageCard = null;
+    this.gateBanner = null;
+  }
+}
+
+// ------------------------------------------------------------------ helpers
+
+/** Subdivision shape. Positive div = per-beat; negative = |n| across the bar. */
+function shape(ctx: CanvasRenderingContext2D, div: number, x: number, y: number, r: number, gate: boolean): void {
+  if (gate) {
+    ctx.beginPath();
+    ctx.arc(x, y, r, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(x, y, r * 0.84, 0, Math.PI * 2);
+    ctx.stroke();
+    return;
+  }
+  if (div < 0) {
+    // Polyrhythm: a ring with |div| spokes — you can count the beam.
+    const n = -div;
+    ctx.beginPath();
+    ctx.arc(x, y, r * 0.72, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.beginPath();
+    for (let i = 0; i < n; i++) {
+      const a = (i / n) * Math.PI * 2 - Math.PI / 2;
+      ctx.moveTo(x + Math.cos(a) * r * 0.72, y + Math.sin(a) * r * 0.72);
+      ctx.lineTo(x + Math.cos(a) * r * 1.22, y + Math.sin(a) * r * 1.22);
+    }
+    ctx.stroke();
+    return;
+  }
+  if (div <= 1) {
+    ctx.beginPath();
+    ctx.arc(x, y, r * 0.86, 0, Math.PI * 2);
+    ctx.stroke();
+    return;
+  }
+  const sides = div === 2 ? 4 : div === 3 ? 3 : 6;
+  const rot = div === 2 ? Math.PI / 4 : -Math.PI / 2;
+  ctx.beginPath();
+  for (let i = 0; i < sides; i++) {
+    const a = rot + (i / sides) * Math.PI * 2;
+    const px = x + Math.cos(a) * r;
+    const py = y + Math.sin(a) * r;
+    if (i === 0) ctx.moveTo(px, py);
+    else ctx.lineTo(px, py);
+  }
+  ctx.closePath();
+  ctx.stroke();
+}
+
+/** Render "1/2 + 1/4" with real stacked fractions and the operator between them. */
+export function drawPromptTokens(
+  ctx: CanvasRenderingContext2D,
+  prompt: string,
+  cx: number,
+  cy: number,
+  size: number,
+  alpha: number,
+): void {
+  const tokens = prompt.split(/\s+/).filter(Boolean);
+  const widths: number[] = [];
+  const gap = size * 0.42;
+  for (const tk of tokens) {
+    const m = FRACTION_TOKEN.exec(tk);
+    if (m) {
+      setFont(ctx, size);
+      widths.push(Math.max(ctx.measureText(m[1]!).width, ctx.measureText(m[2]!).width) + size * 0.2);
+    } else {
+      widths.push(measure(ctx, tk, size * 1.05));
+    }
+  }
+  const total = widths.reduce((a, b) => a + b, 0) + gap * (tokens.length - 1);
+  let x = cx - total / 2;
+  for (let i = 0; i < tokens.length; i++) {
+    const tk = tokens[i]!;
+    const wI = widths[i]!;
+    const m = FRACTION_TOKEN.exec(tk);
+    if (m) fraction(ctx, Number(m[1]), Number(m[2]), x + wI / 2, cy, size, "white", alpha);
+    else neon(ctx, tk, x + wI / 2, cy, size * 1.05, "amber", { alpha });
+    x += wI + gap;
+  }
+}
+
+/** "1/8 · 1/12" or "1/3 : 1/4" drawn as stacked fractions with the joiner kept. */
+function drawGlyphChain(
+  ctx: CanvasRenderingContext2D,
+  glyph: string,
+  x: number,
+  y: number,
+  size: number,
+  alpha: number,
+  centred = false,
+): void {
+  const parts = glyph.split(/\s+/).filter(Boolean);
+  const widths = parts.map((p) => {
+    const m = FRACTION_TOKEN.exec(p);
+    if (m) {
+      setFont(ctx, size);
+      return Math.max(ctx.measureText(m[1]!).width, ctx.measureText(m[2]!).width) + size * 0.24;
+    }
+    return measure(ctx, p, size);
+  });
+  const gap = size * 0.4;
+  const total = widths.reduce((a, b) => a + b, 0) + gap * (parts.length - 1);
+  let cx = centred ? x - total / 2 : x;
+  for (let i = 0; i < parts.length; i++) {
+    const p = parts[i]!;
+    const wI = widths[i]!;
+    const m = FRACTION_TOKEN.exec(p);
+    if (m) fraction(ctx, Number(m[1]), Number(m[2]), cx + wI / 2, y, size, "lime", alpha);
+    else neon(ctx, p, cx + wI / 2, y, size, "cyan", { alpha: alpha * 0.7 });
+    cx += wI + gap;
+  }
+}
+
+export { lerp, impulse, rgb, halo };

--- a/dynawalla/games/pulse/src/render/text.ts
+++ b/dynawalla/games/pulse/src/render/text.ts
@@ -1,0 +1,131 @@
+/**
+ * Vector-display typography.
+ *
+ * Fractions are drawn *stacked* — numerator, rule, denominator — not as "3/4". A
+ * stacked fraction is how the notation is actually taught, it survives being small,
+ * and next to it we draw a miniature of the playfield itself: a bar cut into `d`
+ * segments with `n` lit. Two representations, neither of them colour-dependent.
+ */
+
+import { INK, type Ink } from "./palette.ts";
+
+export const DISPLAY_FONT =
+  '800 var(--s) "Avenir Next", "Segoe UI", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif';
+export const NUM_FONT =
+  '700 var(--s) ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace';
+
+function font(spec: string, size: number): string {
+  return spec.replace("var(--s)", `${size.toFixed(1)}px`);
+}
+
+export type TextOpts = {
+  align?: CanvasTextAlign;
+  baseline?: CanvasTextBaseline;
+  alpha?: number;
+  /** Extra soft halo passes. 0 disables. */
+  bloom?: number;
+  mono?: boolean;
+  track?: number;
+};
+
+/** Additive neon text. Caller should already be in "lighter" composite. */
+export function neon(
+  ctx: CanvasRenderingContext2D,
+  s: string,
+  x: number,
+  y: number,
+  size: number,
+  ink: Ink,
+  o: TextOpts = {},
+): void {
+  const c = INK[ink];
+  const a = o.alpha ?? 1;
+  ctx.font = font(o.mono ? NUM_FONT : DISPLAY_FONT, size);
+  ctx.textAlign = o.align ?? "center";
+  ctx.textBaseline = o.baseline ?? "middle";
+  const bloom = o.bloom ?? 1;
+  if (bloom > 0) {
+    ctx.lineJoin = "round";
+    ctx.strokeStyle = `rgba(${c[0]},${c[1]},${c[2]},${(0.1 * a * bloom).toFixed(3)})`;
+    ctx.lineWidth = size * 0.34;
+    ctx.strokeText(s, x, y);
+    ctx.strokeStyle = `rgba(${c[0]},${c[1]},${c[2]},${(0.18 * a * bloom).toFixed(3)})`;
+    ctx.lineWidth = size * 0.16;
+    ctx.strokeText(s, x, y);
+  }
+  ctx.fillStyle = `rgba(${c[0]},${c[1]},${c[2]},${a.toFixed(3)})`;
+  ctx.fillText(s, x, y);
+}
+
+/** Stacked fraction. Returns the drawn half-width so callers can lay out around it. */
+export function fraction(
+  ctx: CanvasRenderingContext2D,
+  n: number,
+  d: number,
+  cx: number,
+  cy: number,
+  size: number,
+  ink: Ink,
+  alpha = 1,
+): number {
+  const c = INK[ink];
+  if (d === 1) {
+    neon(ctx, String(n), cx, cy, size * 1.5, ink, { alpha });
+    ctx.font = font(DISPLAY_FONT, size * 1.5);
+    return ctx.measureText(String(n)).width / 2;
+  }
+  const ns = String(n);
+  const ds = String(d);
+  ctx.font = font(DISPLAY_FONT, size);
+  const wn = ctx.measureText(ns).width;
+  const wd = ctx.measureText(ds).width;
+  const half = Math.max(wn, wd) / 2 + size * 0.1;
+  const gap = size * 0.56;
+  neon(ctx, ns, cx, cy - gap, size, ink, { alpha, bloom: 0.7 });
+  neon(ctx, ds, cx, cy + gap, size, ink, { alpha, bloom: 0.7 });
+  ctx.strokeStyle = `rgba(${c[0]},${c[1]},${c[2]},${(alpha * 0.95).toFixed(3)})`;
+  ctx.lineWidth = Math.max(1.4, size * 0.09);
+  ctx.lineCap = "round";
+  ctx.beginPath();
+  ctx.moveTo(cx - half, cy);
+  ctx.lineTo(cx + half, cy);
+  ctx.stroke();
+  return half;
+}
+
+/**
+ * A miniature of the playfield: one bar cut into `d` equal cells with `n` lit. The
+ * same picture as the thing they are standing in, which is the point.
+ */
+export function fractionBar(
+  ctx: CanvasRenderingContext2D,
+  n: number,
+  d: number,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  ink: Ink,
+  alpha = 1,
+): void {
+  if (d < 1 || d > 24) return;
+  const c = INK[ink];
+  const cell = w / d;
+  ctx.lineWidth = 1;
+  for (let i = 0; i < d; i++) {
+    const lit = i < n;
+    ctx.fillStyle = `rgba(${c[0]},${c[1]},${c[2]},${((lit ? 0.55 : 0.08) * alpha).toFixed(3)})`;
+    ctx.fillRect(x + i * cell + 0.8, y, Math.max(1, cell - 1.6), h);
+  }
+  ctx.strokeStyle = `rgba(${c[0]},${c[1]},${c[2]},${(0.5 * alpha).toFixed(3)})`;
+  ctx.strokeRect(x + 0.5, y + 0.5, w - 1, h - 1);
+}
+
+export function measure(ctx: CanvasRenderingContext2D, s: string, size: number, mono = false): number {
+  ctx.font = font(mono ? NUM_FONT : DISPLAY_FONT, size);
+  return ctx.measureText(s).width;
+}
+
+export function setFont(ctx: CanvasRenderingContext2D, size: number, mono = false): void {
+  ctx.font = font(mono ? NUM_FONT : DISPLAY_FONT, size);
+}

--- a/dynawalla/games/pulse/src/rng.ts
+++ b/dynawalla/games/pulse/src/rng.ts
@@ -1,0 +1,56 @@
+/** Seeded, deterministic PRNG. Same seed → same run, forever. */
+
+export function hashSeed(s: string): number {
+  // FNV-1a 32-bit.
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+export type Rng = {
+  /** [0,1) */
+  f(): number;
+  /** integer in [0,n) */
+  i(n: number): number;
+  /** float in [a,b) */
+  range(a: number, b: number): number;
+  pick<T>(xs: readonly T[]): T;
+  /** Fisher-Yates, in place, returns the same array. */
+  shuffle<T>(xs: T[]): T[];
+  bool(p: number): boolean;
+};
+
+/** mulberry32 — small, fast, good enough for chart and particle variation. */
+export function makeRng(seed: number): Rng {
+  let a = seed >>> 0;
+  const f = (): number => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+  const i = (n: number): number => Math.floor(f() * n);
+  return {
+    f,
+    i,
+    range: (lo, hi) => lo + f() * (hi - lo),
+    pick: <T,>(xs: readonly T[]): T => {
+      if (xs.length === 0) throw new RangeError("pick: empty");
+      return xs[i(xs.length)]!;
+    },
+    shuffle: <T,>(xs: T[]): T[] => {
+      for (let k = xs.length - 1; k > 0; k--) {
+        const j = i(k + 1);
+        const tmp = xs[k]!;
+        xs[k] = xs[j]!;
+        xs[j] = tmp;
+      }
+      return xs;
+    },
+    bool: (p) => f() < p,
+  };
+}

--- a/dynawalla/games/pulse/src/settings.ts
+++ b/dynawalla/games/pulse/src/settings.ts
@@ -1,0 +1,45 @@
+/** Persisted preferences. Tiny, local, and never required for the game to run. */
+
+const KEY = "pulse.settings.v1";
+
+export type Settings = {
+  muted: boolean;
+  calibrationMs: number;
+  best: number;
+  bestCombo: number;
+};
+
+const DEFAULTS: Settings = { muted: false, calibrationMs: 0, best: 0, bestCombo: 0 };
+
+export function loadSettings(): Settings {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return { ...DEFAULTS };
+    const p = JSON.parse(raw) as Partial<Settings>;
+    return {
+      muted: typeof p.muted === "boolean" ? p.muted : DEFAULTS.muted,
+      calibrationMs:
+        typeof p.calibrationMs === "number" && Math.abs(p.calibrationMs) <= 250 ? p.calibrationMs : 0,
+      best: typeof p.best === "number" && p.best >= 0 ? p.best : 0,
+      bestCombo: typeof p.bestCombo === "number" && p.bestCombo >= 0 ? p.bestCombo : 0,
+    };
+  } catch {
+    return { ...DEFAULTS };
+  }
+}
+
+export function saveSettings(s: Settings): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(s));
+  } catch {
+    /* private mode, quota, whatever — the game does not care */
+  }
+}
+
+export function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}

--- a/dynawalla/games/pulse/src/stubHost.test.ts
+++ b/dynawalla/games/pulse/src/stubHost.test.ts
@@ -1,0 +1,110 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createStubHost } from "./stubHost.ts";
+import { add, cmp, eq, inBar, parseRat, rat, sub } from "./math/rational.ts";
+
+const MIN_GAP = rat(1n, 12n);
+
+function gap(a: ReturnType<typeof parseRat> | undefined, b: ReturnType<typeof parseRat> | undefined) {
+  return cmp(a!, b!) >= 0 ? sub(a!, b!) : sub(b!, a!);
+}
+
+test("every question is answerable as a position inside one bar", () => {
+  const h = createStubHost({ seed: "gates" });
+  for (let i = 0; i < 400; i++) {
+    if (i % 40 === 0) h.setFloor(i / 400);
+    const q = h.next();
+    const a = parseRat(q.answer);
+    assert.ok(a, `answer not a fraction: ${q.answer}`);
+    assert.ok(inBar(a), `answer outside (0,1]: ${q.answer} for ${q.prompt}`);
+    assert.equal(q.distractors.length, 3, `wrong distractor count for ${q.prompt}`);
+    for (const d of q.distractors) {
+      const r = parseRat(d);
+      assert.ok(r, `distractor not a fraction: ${d}`);
+      assert.ok(inBar(r), `distractor outside (0,1]: ${d}`);
+    }
+  }
+});
+
+test("candidates stay far enough apart to be four legible targets", () => {
+  const h = createStubHost({ seed: "spacing" });
+  for (let i = 0; i < 400; i++) {
+    h.setFloor((i % 100) / 100);
+    const q = h.next();
+    const all = [q.answer, ...q.distractors].map(parseRat);
+    for (let a = 0; a < all.length; a++) {
+      for (let b = a + 1; b < all.length; b++) {
+        assert.ok(!eq(all[a]!, all[b]!), `duplicate candidate in ${q.prompt}: ${q.answer}`);
+        assert.ok(
+          cmp(gap(all[a], all[b]), MIN_GAP) >= 0,
+          `candidates too close in ${q.prompt}: ${all[a]!.n}/${all[a]!.d} vs ${all[b]!.n}/${all[b]!.d}`,
+        );
+      }
+    }
+  }
+});
+
+test("the prompt actually evaluates to the stated answer", () => {
+  const h = createStubHost({ seed: "arith" });
+  for (let i = 0; i < 500; i++) {
+    h.setFloor((i % 100) / 100);
+    const q = h.next();
+    const m = /^(\S+)\s*([+−×])\s*(\S+)$/u.exec(q.prompt);
+    assert.ok(m, `unparseable prompt: ${q.prompt}`);
+    const [, ls, op, rs] = m;
+    const l = parseRat(ls!);
+    const r = parseRat(rs!);
+    assert.ok(l && r, `prompt operands not fractions: ${q.prompt}`);
+    const expect =
+      op === "+" ? add(l, r) : op === "−" ? sub(l, r) : rat(l.n * r.n, l.d * r.d);
+    assert.ok(
+      eq(expect, parseRat(q.answer)!),
+      `${q.prompt} should be ${expect.n}/${expect.d} but says ${q.answer}`,
+    );
+  }
+});
+
+test("the same seed is the same run, a different seed is not", () => {
+  const a = createStubHost({ seed: "same" });
+  const b = createStubHost({ seed: "same" });
+  const c = createStubHost({ seed: "other" });
+  const pull = (h: ReturnType<typeof createStubHost>) =>
+    Array.from({ length: 24 }, () => {
+      const q = h.next();
+      return `${q.prompt}=${q.answer}|${q.distractors.join(",")}`;
+    });
+  const ax = pull(a);
+  assert.deepEqual(ax, pull(b));
+  assert.notDeepEqual(ax, pull(c));
+});
+
+test("difficulty adapts up on right answers and down on wrong", () => {
+  const h = createStubHost({ seed: "adapt", startDifficulty: 0.4 });
+  const before = h.difficulty();
+  for (let i = 0; i < 6; i++) {
+    h.report({ questionId: `q${i}`, correct: true, ms: 900, answered: "1/2" });
+  }
+  assert.ok(h.difficulty() > before);
+  const peak = h.difficulty();
+  for (let i = 0; i < 6; i++) {
+    h.report({ questionId: `w${i}`, correct: false, ms: 3000, answered: "2/6" });
+  }
+  assert.ok(h.difficulty() < peak);
+  assert.equal(h.history().length, 12);
+});
+
+test("harder settings reach denominators the easy ones never do", () => {
+  const denoms = (floor: number): Set<bigint> => {
+    const h = createStubHost({ seed: "denoms" });
+    h.setFloor(floor);
+    const out = new Set<bigint>();
+    for (let i = 0; i < 120; i++) {
+      const q = h.next();
+      for (const s of [q.answer, ...q.distractors]) out.add(parseRat(s)!.d);
+    }
+    return out;
+  };
+  const easy = denoms(0.05);
+  const hard = denoms(0.95);
+  assert.ok(Math.max(...[...hard].map(Number)) > Math.max(...[...easy].map(Number)));
+});

--- a/dynawalla/games/pulse/src/stubHost.ts
+++ b/dynawalla/games/pulse/src/stubHost.ts
@@ -1,0 +1,225 @@
+/**
+ * Local stub host — exact, seeded, deterministic.
+ *
+ * Replaced by the real curriculum host later; the game never imports anything from
+ * here except through `Host`.
+ *
+ * Every answer is a fraction strictly inside `(0, 1]` because in PULSE a value IS a
+ * position inside one bar. Candidates are kept at least 1/12 of a bar apart so four
+ * of them are legible side by side at 390px wide.
+ */
+
+import type { Host, Question } from "./contract.ts";
+import { makeRng, hashSeed, type Rng } from "./rng.ts";
+import {
+  type Rat,
+  rat,
+  add,
+  sub,
+  mul,
+  cmp,
+  eq,
+  fmt,
+  inBar,
+  ONE,
+  toFloat,
+} from "./math/rational.ts";
+import { malForAdd, malForComplement, malForMul, malForSub, type MalOut } from "./math/malrules.ts";
+
+const MIN_GAP = rat(1n, 12n);
+
+type Built = { prompt: string; answer: Rat; mal: MalOut[]; domain: string };
+
+function denomPool(diff: number): number[] {
+  if (diff < 0.2) return [2, 4];
+  if (diff < 0.4) return [2, 3, 4];
+  if (diff < 0.6) return [2, 3, 4, 6, 8];
+  if (diff < 0.8) return [2, 3, 4, 5, 6, 8];
+  return [2, 3, 4, 5, 6, 8, 10, 12];
+}
+
+function buildAdd(rng: Rng, diff: number): Built | null {
+  const pool = denomPool(diff);
+  const unlike = diff >= 0.35 && rng.bool(Math.min(0.85, (diff - 0.35) * 2 + 0.3));
+  const d1 = rng.pick(pool);
+  const d2 = unlike ? rng.pick(pool.filter((x) => x !== d1)) ?? d1 : d1;
+  const n1 = 1 + rng.i(d1 - 1);
+  const n2 = 1 + rng.i(d2 - 1);
+  const a = rat(n1, d1);
+  const b = rat(n2, d2);
+  const s = add(a, b);
+  if (!inBar(s)) return null;
+  return { prompt: `${fmt(a)} + ${fmt(b)}`, answer: s, mal: malForAdd(a, b), domain: "fractions-add" };
+}
+
+function buildSub(rng: Rng, diff: number): Built | null {
+  const pool = denomPool(diff);
+  const unlike = diff >= 0.45 && rng.bool(Math.min(0.8, (diff - 0.45) * 2 + 0.25));
+  const d1 = rng.pick(pool);
+  const d2 = unlike ? rng.pick(pool.filter((x) => x !== d1)) ?? d1 : d1;
+  const n1 = 1 + rng.i(d1);
+  const n2 = 1 + rng.i(d2);
+  const a = rat(n1, d1);
+  const b = rat(n2, d2);
+  if (cmp(a, ONE) > 0) return null;
+  const s = sub(a, b);
+  if (!inBar(s)) return null;
+  return { prompt: `${fmt(a)} − ${fmt(b)}`, answer: s, mal: malForSub(a, b), domain: "fractions-sub" };
+}
+
+function buildMul(rng: Rng, diff: number): Built | null {
+  const pool = denomPool(diff);
+  const d = rng.pick(pool.filter((x) => x >= 3)) ?? 4;
+  const k = 2 + rng.i(Math.min(5, d - 1));
+  const unitOnly = diff < 0.5;
+  const f = rat(unitOnly ? 1 : 1 + rng.i(2), d);
+  const s = mul(rat(k), f);
+  if (!inBar(s)) return null;
+  return {
+    prompt: `${k} × ${fmt(f)}`,
+    answer: s,
+    mal: malForMul(BigInt(k), f),
+    domain: "fractions-mul",
+  };
+}
+
+function buildComplement(rng: Rng, diff: number): Built | null {
+  const pool = denomPool(diff);
+  const d = rng.pick(pool);
+  const n = 1 + rng.i(d - 1);
+  const f = rat(n, d);
+  const s = sub(ONE, f);
+  if (!inBar(s)) return null;
+  return { prompt: `1 − ${fmt(f)}`, answer: s, mal: malForComplement(f), domain: "fractions-sub" };
+}
+
+type Builder = (rng: Rng, diff: number) => Built | null;
+
+function buildersFor(diff: number): Builder[] {
+  if (diff < 0.28) return [buildAdd, buildAdd, buildMul];
+  if (diff < 0.5) return [buildAdd, buildComplement, buildMul, buildSub];
+  return [buildAdd, buildSub, buildMul, buildComplement, buildAdd, buildSub];
+}
+
+function farEnough(v: Rat, chosen: Rat[]): boolean {
+  for (const c of chosen) {
+    const diff = cmp(v, c) >= 0 ? sub(v, c) : sub(c, v);
+    if (cmp(diff, MIN_GAP) < 0) return false;
+  }
+  return true;
+}
+
+/** Near-miss fillers when the mal-rules do not yield three legible distractors. */
+function fillers(answer: Rat, rng: Rng, diff: number): Rat[] {
+  const out: Rat[] = [];
+  const pool = denomPool(diff);
+  const steps = [rat(1n, 4n), rat(1n, 3n), rat(1n, 2n), rat(1n, 6n), rat(2n, 3n), rat(3n, 4n)];
+  for (const s of rng.shuffle([...steps])) {
+    out.push(add(answer, s), sub(answer, s));
+  }
+  for (const d of pool) for (let n = 1; n <= d; n++) out.push(rat(n, d));
+  return out.filter(inBar);
+}
+
+function toQuestion(b: Built, rng: Rng, diff: number, id: string): Question {
+  const chosen: Rat[] = [b.answer];
+  const distractors: Rat[] = [];
+  const push = (v: Rat): boolean => {
+    if (!inBar(v)) return false;
+    if (chosen.some((c) => eq(c, v))) return false;
+    if (!farEnough(v, chosen)) return false;
+    chosen.push(v);
+    distractors.push(v);
+    return true;
+  };
+  for (const m of rng.shuffle([...b.mal])) {
+    if (distractors.length >= 3) break;
+    push(m.value);
+  }
+  for (const f of fillers(b.answer, rng, diff)) {
+    if (distractors.length >= 3) break;
+    push(f);
+  }
+  return {
+    id,
+    prompt: b.prompt,
+    answer: fmt(b.answer),
+    distractors: distractors.map(fmt),
+    domain: b.domain,
+    difficulty: Math.max(0, Math.min(1, diff)),
+  };
+}
+
+export type StubHostOptions = {
+  seed?: string;
+  /** Where the ramp starts. The game also raises it as stages escalate. */
+  startDifficulty?: number;
+  onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void;
+  haptic?: (kind: "light" | "medium" | "heavy" | "success" | "failure") => void;
+};
+
+export type StubHost = Host & {
+  /** The game nudges this as stages escalate; the host still adapts on top. */
+  setFloor(d: number): void;
+  difficulty(): number;
+  history(): ReadonlyArray<{ id: string; correct: boolean; ms: number }>;
+};
+
+export function createStubHost(opts: StubHostOptions = {}): StubHost {
+  const seedStr = opts.seed ?? "pulse";
+  const rng = makeRng(hashSeed(seedStr));
+  let diff = opts.startDifficulty ?? 0.12;
+  let floor = 0;
+  let counter = 0;
+  const log: { id: string; correct: boolean; ms: number }[] = [];
+
+  const reduced = (): boolean =>
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  return {
+    next(): Question {
+      counter++;
+      const d = Math.max(floor, diff);
+      for (let attempt = 0; attempt < 40; attempt++) {
+        const b = rng.pick(buildersFor(d))(rng, d);
+        if (!b) continue;
+        const q = toQuestion(b, rng, d, `pulse-${seedStr}-${counter}`);
+        if (q.distractors.length === 3) return q;
+      }
+      // Deterministic backstop: 1/4 + 1/4.
+      const a = rat(1n, 4n);
+      const s = add(a, a);
+      return {
+        id: `pulse-${seedStr}-${counter}`,
+        prompt: `${fmt(a)} + ${fmt(a)}`,
+        answer: fmt(s),
+        distractors: [fmt(rat(2n, 8n)), fmt(rat(3n, 4n)), fmt(rat(1n, 4n))].filter(
+          (x, i, arr) => arr.indexOf(x) === i && x !== fmt(s),
+        ),
+        domain: "fractions-add",
+        difficulty: d,
+      };
+    },
+    report(r) {
+      log.push({ id: r.questionId, correct: r.correct, ms: r.ms });
+      // Adapt: right and quick pushes up, wrong pulls down. Bounded, gentle, no cliff.
+      if (r.correct) diff = Math.min(1, diff + (r.ms < 2200 ? 0.05 : 0.025));
+      else diff = Math.max(0.05, diff - 0.07);
+      opts.onReport?.(r);
+    },
+    haptic(kind) {
+      opts.haptic?.(kind);
+    },
+    prefersReducedMotion: reduced,
+    setFloor(d) {
+      floor = Math.max(0, Math.min(1, d));
+    },
+    difficulty: () => Math.max(floor, diff),
+    history: () => log,
+  };
+}
+
+/** Exposed for the test suite. */
+export const _internal = { toFloat, MIN_GAP };

--- a/dynawalla/games/pulse/tsconfig.json
+++ b/dynawalla/games/pulse/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": false,
+    "verbatimModuleSyntax": false,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/dynawalla/games/pulse/vite.config.ts
+++ b/dynawalla/games/pulse/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  base: "./",
+  server: { port: 5183, strictPort: false },
+  build: {
+    target: "es2022",
+    outDir: "dist",
+    assetsInlineLimit: 0,
+  },
+});


### PR DESCRIPTION
## What

Commit `dynawalla/games/pulse` — COUNTERPOISE, a brass pulse where the scale physically is the equals sign.

## Why

This prototype existed **only as untracked files in a worktree**. It appeared in
zero git refs: `git log --all -- dynawalla/games/pulse` returned no commits. It was
never committed, never branched, never pushed. Pruning that worktree — which the
repo's own session hook recommends doing after a merge — would have destroyed it
with no reflog and no dangling object to recover from.

Ten sibling prototypes were in the same state. This PR is one of that set.

### Fix carried in this PR

`run.ts` passed a bare `4` to `buildGate`'s `fit` parameter, which takes a
`GateFit` object, so `tsc --noEmit` failed. It now passes
`{ ...DEFAULT_FIT, maxCandidates: 4 }` — what the literal was reaching for.
`DEFAULT_FIT.maxCandidates` is already `4`, so runtime behaviour is unchanged.

## Blast radius

**Areas touched:** dynawalla (new directory only)

- [x] Additive only. Every path is new under `dynawalla/games/pulse/`; no existing
      file is modified or deleted. Nothing imports it yet.
- [ ] **Every touched path is covered by a `ci.yml` area filter** — **NO, and
      stated deliberately.** `dynawalla/games/` is absent from the `covered`
      regex (`ci.yml:226`), so the `uncovered` step will warn. This is
      pre-existing: the five games already on `main` have no CI either. No job
      builds, type-checks or tests any game. The gates below were therefore run
      locally, by hand. A games-area filter is the correct follow-up and is
      called out rather than silently bundled here.
- [x] **Pack back-compat.** No published pack zip, `voiceId` or catalog entry
      touched. App floor 0.20.6 unaffected.
- [x] **Native integrity.** No Rust, no `src-tauri`, no `links =`, no `[patch]`.
- [x] **Strings.** No `corpan-app` locale keys added; this pack does not use the
      Corpán i18n catalog.
- [x] **Curriculum.** No skill id renamed or reused, no grade metadata changed,
      no generator binding altered.
- [x] **Secrets.** No `.p8`, keystore, service-account JSON, issuer id, key id or
      token. Verified the diff is source, config and `index.html` only.

`package-lock.json` and `qa/shots` are gitignored, matching
`dynawalla/games/slice` and `.../siege`.

## Proof

Run in `dynawalla/games/pulse/` after `npm install`:

```
$ npm test
# tests 54 # pass 54 # fail 0 

$ npm run tsc          # tsc --noEmit
0 errors

$ npm run build
✓ built in 197ms
```

Scope check — the branch adds this game and nothing else:

```
$ git diff --name-only origin/main...HEAD | grep -cv '^dynawalla/games/pulse/'
0
$ git diff --diff-filter=D --name-only origin/main...HEAD | wc -l
0
```
