### PR TITLE
dynawalla/games/rhythm: SPLITBEAT — a three-lane rhythm game where the bar of music is the fraction bar

### DIFF
--- a/dynawalla/games/rhythm/.gitignore
+++ b/dynawalla/games/rhythm/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+dist-pack/
+
+# Playtest capture output: multi-MB PNGs, regenerated on demand.
+qa/shots
+qa/tmp
+
+# Not tracked, matching dynawalla/games/slice and .../merge. These prototypes
+# pin nothing beyond vite + typescript in devDependencies.
+package-lock.json

--- a/dynawalla/games/rhythm/index.html
+++ b/dynawalla/games/rhythm/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no, maximum-scale=1"
+    />
+    <meta name="color-scheme" content="dark" />
+    <title>Splitbeat</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        background: #05060f;
+        overflow: hidden;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+      }
+      #stage {
+        position: fixed;
+        inset: 0;
+        touch-action: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="stage"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/rhythm/package.json
+++ b/dynawalla/games/rhythm/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@dynawalla/game-rhythm",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Splitbeat — a three-lane rhythm-action game where the bar of music is the fraction bar.",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\""
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^5.9.3",
+    "vite": "^7.1.5"
+  }
+}

--- a/dynawalla/games/rhythm/src/audio/engine.ts
+++ b/dynawalla/games/rhythm/src/audio/engine.ts
@@ -1,0 +1,669 @@
+/**
+ * Splitbeat audio. Everything is synthesised at runtime — there is not one
+ * sample file in this package.
+ *
+ * Structure, and why:
+ *  - `AudioContext.currentTime` is the ONLY musical clock. requestAnimationFrame
+ *    is for pixels. Notes are scheduled ahead with `start(when)`; the renderer
+ *    reads the same clock and derives pixel positions from it, so picture and
+ *    sound cannot drift apart even when a frame is dropped.
+ *  - Every voice is transient + body + tail. A drum with no transient reads as
+ *    mush on a tablet speaker; a drum with no tail reads as a click.
+ *  - Every voice takes a `tune` and a `gain` jitter so the hundredth kick is not
+ *    bit-identical to the first. Sample-identical repetition is what makes a
+ *    rhythm game's audio fatiguing after four minutes.
+ */
+
+export type Bus = "drums" | "music" | "sfx";
+
+const A4 = 440;
+export const midiToHz = (m: number): number => A4 * Math.pow(2, (m - 69) / 12);
+
+/** exponentialRamp cannot reach zero; this is the floor everything decays to. */
+const EPS = 0.0001;
+
+function tanhCurve(amount: number, n = 1024): Float32Array<ArrayBuffer> {
+  const c = new Float32Array(n);
+  for (let i = 0; i < n; i++) {
+    const x = (i / (n - 1)) * 2 - 1;
+    c[i] = Math.tanh(x * amount) / Math.tanh(amount);
+  }
+  return c;
+}
+
+export class AudioEngine {
+  readonly ctx: AudioContext;
+
+  private master: GainNode;
+  private masterFilter: BiquadFilterNode;
+  private limiter: DynamicsCompressorNode;
+  readonly analyser: AnalyserNode;
+
+  private drums: GainNode;
+  private drumDrive: WaveShaperNode;
+  private music: GainNode;
+  private sfx: GainNode;
+
+  private verb: ConvolverNode;
+  private verbGain: GainNode;
+  private delay: DelayNode;
+  private delayFb: GainNode;
+  private delayGain: GainNode;
+
+  private noise: AudioBuffer;
+  private rngState = 0x9e3779b9;
+
+  /** live spectrum + waveform, read once per frame by the renderer */
+  readonly freq: Uint8Array<ArrayBuffer>;
+  readonly wave: Uint8Array<ArrayBuffer>;
+
+  private _muted = false;
+  private disposed = false;
+
+  constructor() {
+    const Ctor: typeof AudioContext =
+      (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext ??
+      window.AudioContext;
+    // `interactive` keeps output latency low, which matters more here than
+    // buffer safety — this is a timing game.
+    this.ctx = new Ctor({ latencyHint: "interactive" });
+    const ctx = this.ctx;
+
+    this.limiter = ctx.createDynamicsCompressor();
+    this.limiter.threshold.value = -8;
+    this.limiter.knee.value = 6;
+    this.limiter.ratio.value = 12;
+    this.limiter.attack.value = 0.003;
+    this.limiter.release.value = 0.16;
+
+    this.analyser = ctx.createAnalyser();
+    this.analyser.fftSize = 1024;
+    this.analyser.smoothingTimeConstant = 0.72;
+    this.analyser.minDecibels = -84;
+    this.analyser.maxDecibels = -12;
+    this.freq = new Uint8Array(this.analyser.frequencyBinCount);
+    this.wave = new Uint8Array(this.analyser.fftSize);
+
+    this.master = ctx.createGain();
+    this.master.gain.value = 0.9;
+
+    this.masterFilter = ctx.createBiquadFilter();
+    this.masterFilter.type = "lowpass";
+    this.masterFilter.frequency.value = 20000;
+    this.masterFilter.Q.value = 0.6;
+
+    this.masterFilter.connect(this.master);
+    this.master.connect(this.limiter);
+    this.limiter.connect(this.analyser);
+    this.analyser.connect(ctx.destination);
+
+    this.drums = ctx.createGain();
+    this.drums.gain.value = 1.0;
+    this.drumDrive = ctx.createWaveShaper();
+    this.drumDrive.curve = tanhCurve(1.9);
+    this.drumDrive.oversample = "2x";
+    this.drums.connect(this.drumDrive);
+    this.drumDrive.connect(this.masterFilter);
+
+    this.music = ctx.createGain();
+    this.music.gain.value = 0.62;
+    this.music.connect(this.masterFilter);
+
+    this.sfx = ctx.createGain();
+    this.sfx.gain.value = 0.85;
+    this.sfx.connect(this.masterFilter);
+
+    // --- procedural plate: noise burst with an exponential tail ------------
+    this.verb = ctx.createConvolver();
+    this.verb.buffer = this.makeImpulse(1.9, 2.6);
+    this.verbGain = ctx.createGain();
+    this.verbGain.gain.value = 0.34;
+    this.verb.connect(this.verbGain);
+    this.verbGain.connect(this.masterFilter);
+
+    // --- dotted-eighth feedback delay -------------------------------------
+    this.delay = ctx.createDelay(1.5);
+    this.delay.delayTime.value = 0.34;
+    this.delayFb = ctx.createGain();
+    this.delayFb.gain.value = 0.36;
+    const dlpf = ctx.createBiquadFilter();
+    dlpf.type = "lowpass";
+    dlpf.frequency.value = 2600;
+    this.delayGain = ctx.createGain();
+    this.delayGain.gain.value = 0.5;
+    this.delay.connect(dlpf);
+    dlpf.connect(this.delayFb);
+    this.delayFb.connect(this.delay);
+    dlpf.connect(this.delayGain);
+    this.delayGain.connect(this.masterFilter);
+
+    this.noise = this.makeNoise(2.5);
+  }
+
+  /* ---------------------------------------------------------------- */
+  /* infrastructure                                                    */
+  /* ---------------------------------------------------------------- */
+
+  get now(): number {
+    return this.ctx.currentTime;
+  }
+
+  /** Round-trip output latency, used to align visuals with what is heard. */
+  get outputLatency(): number {
+    const c = this.ctx as AudioContext & { outputLatency?: number; baseLatency?: number };
+    const out = typeof c.outputLatency === "number" && isFinite(c.outputLatency) ? c.outputLatency : 0;
+    const base = typeof c.baseLatency === "number" && isFinite(c.baseLatency) ? c.baseLatency : 0;
+    return out || base || 0;
+  }
+
+  async resume(): Promise<void> {
+    if (this.disposed) return;
+    if (this.ctx.state !== "running") {
+      try {
+        await this.ctx.resume();
+      } catch (err) {
+        console.warn("[splitbeat] AudioContext.resume failed", err);
+      }
+    }
+  }
+
+  setMuted(m: boolean): void {
+    this._muted = m;
+    this.master.gain.cancelScheduledValues(this.now);
+    this.master.gain.setTargetAtTime(m ? 0 : 0.9, this.now, 0.02);
+  }
+  get muted(): boolean {
+    return this._muted;
+  }
+
+  /** Musical duck: the whole mix goes underwater for `dur` seconds. */
+  muffle(dur: number, toHz = 420): void {
+    const t = this.now;
+    const f = this.masterFilter.frequency;
+    f.cancelScheduledValues(t);
+    f.setValueAtTime(Math.max(f.value, 800), t);
+    f.exponentialRampToValueAtTime(toHz, t + 0.05);
+    f.exponentialRampToValueAtTime(20000, t + dur);
+  }
+
+  /** Tape stop: pitch and brightness collapse together. */
+  tapeStop(dur = 0.85): void {
+    const t = this.now;
+    const f = this.masterFilter.frequency;
+    f.cancelScheduledValues(t);
+    f.setValueAtTime(20000, t);
+    f.exponentialRampToValueAtTime(180, t + dur);
+    const o = this.ctx.createOscillator();
+    const g = this.ctx.createGain();
+    o.type = "sawtooth";
+    o.frequency.setValueAtTime(320, t);
+    o.frequency.exponentialRampToValueAtTime(28, t + dur);
+    g.gain.setValueAtTime(0.0, t);
+    g.gain.linearRampToValueAtTime(0.16, t + 0.03);
+    g.gain.exponentialRampToValueAtTime(EPS, t + dur);
+    o.connect(g);
+    g.connect(this.sfx);
+    o.start(t);
+    o.stop(t + dur + 0.05);
+  }
+
+  /** Bring the mix back up instantly (used on revive). */
+  clearFilter(ramp = 0.25): void {
+    const t = this.now;
+    const f = this.masterFilter.frequency;
+    f.cancelScheduledValues(t);
+    f.setValueAtTime(Math.max(120, f.value), t);
+    f.exponentialRampToValueAtTime(20000, t + ramp);
+  }
+
+  setDelayTime(seconds: number): void {
+    this.delay.delayTime.setTargetAtTime(Math.max(0.02, Math.min(1.4, seconds)), this.now, 0.08);
+  }
+
+  /** Music-layer level, so combo can literally open the arrangement up. */
+  setMusicGain(v: number, ramp = 0.4): void {
+    this.music.gain.setTargetAtTime(v, this.now, ramp);
+  }
+
+  pollSpectrum(): void {
+    this.analyser.getByteFrequencyData(this.freq);
+    this.analyser.getByteTimeDomainData(this.wave);
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    try {
+      this.master.disconnect();
+      this.analyser.disconnect();
+      void this.ctx.close();
+    } catch (err) {
+      console.warn("[splitbeat] audio dispose failed", err);
+    }
+  }
+
+  /* ---------------------------------------------------------------- */
+  /* buffers                                                           */
+  /* ---------------------------------------------------------------- */
+
+  /** Deterministic noise — same texture every session, no Math.random drift. */
+  private rand(): number {
+    let x = this.rngState;
+    x ^= x << 13;
+    x ^= x >>> 17;
+    x ^= x << 5;
+    this.rngState = x >>> 0;
+    return (this.rngState / 4294967296) * 2 - 1;
+  }
+
+  private makeNoise(seconds: number): AudioBuffer {
+    const n = Math.floor(this.ctx.sampleRate * seconds);
+    const buf = this.ctx.createBuffer(1, n, this.ctx.sampleRate);
+    const d = buf.getChannelData(0);
+    for (let i = 0; i < n; i++) d[i] = this.rand();
+    return buf;
+  }
+
+  private makeImpulse(seconds: number, decay: number): AudioBuffer {
+    const rate = this.ctx.sampleRate;
+    const n = Math.floor(rate * seconds);
+    const buf = this.ctx.createBuffer(2, n, rate);
+    for (let ch = 0; ch < 2; ch++) {
+      const d = buf.getChannelData(ch);
+      for (let i = 0; i < n; i++) {
+        const t = i / n;
+        // a touch of early-reflection sparsity keeps it from sounding like a
+        // plain noise swell
+        const sparse = i < rate * 0.012 ? 0.25 : 1;
+        d[i] = this.rand() * Math.pow(1 - t, decay) * sparse;
+      }
+    }
+    return buf;
+  }
+
+  private bus(b: Bus): GainNode {
+    return b === "drums" ? this.drums : b === "music" ? this.music : this.sfx;
+  }
+
+  private src(t: number, dur: number, offset = -1): AudioBufferSourceNode {
+    const s = this.ctx.createBufferSource();
+    s.buffer = this.noise;
+    const off = offset >= 0 ? offset : Math.abs(this.rand()) * (this.noise.duration - dur - 0.01);
+    s.start(t, off, dur + 0.02);
+    s.stop(t + dur + 0.02);
+    return s;
+  }
+
+  private send(node: AudioNode, verb: number, delay: number): void {
+    if (verb > 0) {
+      const g = this.ctx.createGain();
+      g.gain.value = verb;
+      node.connect(g);
+      g.connect(this.verb);
+    }
+    if (delay > 0) {
+      const g = this.ctx.createGain();
+      g.gain.value = delay;
+      node.connect(g);
+      g.connect(this.delay);
+    }
+  }
+
+  /* ---------------------------------------------------------------- */
+  /* voices                                                            */
+  /* ---------------------------------------------------------------- */
+
+  kick(t: number, gain = 1, tune = 1): void {
+    const ctx = this.ctx;
+    const g = ctx.createGain();
+    const o = ctx.createOscillator();
+    o.type = "sine";
+    const f0 = 168 * tune * (1 + this.rand() * 0.02);
+    o.frequency.setValueAtTime(f0, t);
+    o.frequency.exponentialRampToValueAtTime(44 * tune, t + 0.075);
+    const peak = 0.95 * gain;
+    g.gain.setValueAtTime(EPS, t);
+    g.gain.exponentialRampToValueAtTime(peak, t + 0.004);
+    g.gain.exponentialRampToValueAtTime(EPS, t + 0.34);
+    o.connect(g);
+    g.connect(this.bus("drums"));
+    o.start(t);
+    o.stop(t + 0.4);
+
+    // transient: a short highpassed tick so it cuts through a tablet speaker
+    const cg = ctx.createGain();
+    const hp = ctx.createBiquadFilter();
+    hp.type = "highpass";
+    hp.frequency.value = 1100;
+    cg.gain.setValueAtTime(0.5 * gain, t);
+    cg.gain.exponentialRampToValueAtTime(EPS, t + 0.022);
+    const s = this.src(t, 0.03);
+    s.connect(hp);
+    hp.connect(cg);
+    cg.connect(this.bus("drums"));
+    this.send(g, 0.05, 0);
+  }
+
+  snare(t: number, gain = 1, tune = 1): void {
+    const ctx = this.ctx;
+    // body
+    const bo = ctx.createOscillator();
+    const bg = ctx.createGain();
+    bo.type = "triangle";
+    bo.frequency.setValueAtTime(196 * tune * (1 + this.rand() * 0.03), t);
+    bo.frequency.exponentialRampToValueAtTime(148 * tune, t + 0.09);
+    bg.gain.setValueAtTime(EPS, t);
+    bg.gain.exponentialRampToValueAtTime(0.42 * gain, t + 0.003);
+    bg.gain.exponentialRampToValueAtTime(EPS, t + 0.13);
+    bo.connect(bg);
+    bg.connect(this.bus("drums"));
+    bo.start(t);
+    bo.stop(t + 0.18);
+
+    // rattle
+    const bp = ctx.createBiquadFilter();
+    bp.type = "bandpass";
+    bp.frequency.value = 1750 * tune * (1 + this.rand() * 0.06);
+    bp.Q.value = 0.7;
+    const ng = ctx.createGain();
+    ng.gain.setValueAtTime(EPS, t);
+    ng.gain.exponentialRampToValueAtTime(0.62 * gain, t + 0.002);
+    ng.gain.exponentialRampToValueAtTime(EPS, t + 0.19);
+    const s = this.src(t, 0.22);
+    s.connect(bp);
+    bp.connect(ng);
+    ng.connect(this.bus("drums"));
+    this.send(ng, 0.3, 0);
+  }
+
+  hat(t: number, gain = 1, open = false): void {
+    const ctx = this.ctx;
+    const hp = ctx.createBiquadFilter();
+    hp.type = "highpass";
+    hp.frequency.value = 7400 * (1 + this.rand() * 0.05);
+    const bp = ctx.createBiquadFilter();
+    bp.type = "bandpass";
+    bp.frequency.value = 10800;
+    bp.Q.value = 0.5;
+    const dur = open ? 0.26 : 0.052;
+    const g = ctx.createGain();
+    g.gain.setValueAtTime(EPS, t);
+    g.gain.exponentialRampToValueAtTime((open ? 0.3 : 0.42) * gain, t + 0.001);
+    g.gain.exponentialRampToValueAtTime(EPS, t + dur);
+    const s = this.src(t, dur + 0.02);
+    s.connect(hp);
+    hp.connect(bp);
+    bp.connect(g);
+    g.connect(this.bus("drums"));
+    this.send(g, open ? 0.24 : 0.1, 0.12);
+  }
+
+  /** Two-operator FM bell — the "reward" timbre. */
+  bell(t: number, midi: number, gain = 1, decay = 0.55, verb = 0.5): void {
+    const ctx = this.ctx;
+    const f = midiToHz(midi);
+    const car = ctx.createOscillator();
+    car.type = "sine";
+    car.frequency.value = f;
+    const mod = ctx.createOscillator();
+    mod.type = "sine";
+    mod.frequency.value = f * 2.01;
+    const modG = ctx.createGain();
+    modG.gain.setValueAtTime(f * 3.4, t);
+    modG.gain.exponentialRampToValueAtTime(f * 0.05, t + decay * 0.6);
+    mod.connect(modG);
+    modG.connect(car.frequency);
+    const g = ctx.createGain();
+    g.gain.setValueAtTime(EPS, t);
+    g.gain.exponentialRampToValueAtTime(0.3 * gain, t + 0.004);
+    g.gain.exponentialRampToValueAtTime(EPS, t + decay);
+    car.connect(g);
+    g.connect(this.bus("music"));
+    this.send(g, verb, 0.3);
+    mod.start(t);
+    car.start(t);
+    mod.stop(t + decay + 0.05);
+    car.stop(t + decay + 0.05);
+  }
+
+  bass(t: number, dur: number, midi: number, gain = 1): void {
+    const ctx = this.ctx;
+    const f = midiToHz(midi);
+    const lp = ctx.createBiquadFilter();
+    lp.type = "lowpass";
+    lp.Q.value = 7;
+    lp.frequency.setValueAtTime(Math.min(180 + f * 2, 900), t);
+    lp.frequency.exponentialRampToValueAtTime(Math.max(90, f * 1.4), t + Math.min(0.3, dur));
+    const g = ctx.createGain();
+    g.gain.setValueAtTime(EPS, t);
+    g.gain.exponentialRampToValueAtTime(0.5 * gain, t + 0.012);
+    g.gain.setTargetAtTime(0.34 * gain, t + 0.05, 0.2);
+    g.gain.setValueAtTime(0.34 * gain, t + dur * 0.86);
+    g.gain.exponentialRampToValueAtTime(EPS, t + dur);
+    const saw = ctx.createOscillator();
+    saw.type = "sawtooth";
+    saw.frequency.value = f;
+    saw.detune.value = this.rand() * 5;
+    const sub = ctx.createOscillator();
+    sub.type = "sine";
+    sub.frequency.value = f / 2;
+    const subG = ctx.createGain();
+    subG.gain.value = 0.7;
+    saw.connect(lp);
+    sub.connect(subG);
+    subG.connect(lp);
+    lp.connect(g);
+    g.connect(this.bus("music"));
+    saw.start(t);
+    sub.start(t);
+    saw.stop(t + dur + 0.06);
+    sub.stop(t + dur + 0.06);
+  }
+
+  pad(t: number, dur: number, midis: readonly number[], gain = 1): void {
+    const ctx = this.ctx;
+    const lp = ctx.createBiquadFilter();
+    lp.type = "lowpass";
+    lp.frequency.setValueAtTime(500, t);
+    lp.frequency.linearRampToValueAtTime(2100, t + dur * 0.45);
+    lp.frequency.linearRampToValueAtTime(700, t + dur);
+    lp.Q.value = 1.2;
+    const g = ctx.createGain();
+    g.gain.setValueAtTime(EPS, t);
+    g.gain.linearRampToValueAtTime(0.085 * gain, t + dur * 0.3);
+    g.gain.setValueAtTime(0.085 * gain, t + dur * 0.7);
+    g.gain.exponentialRampToValueAtTime(EPS, t + dur);
+    lp.connect(g);
+    g.connect(this.bus("music"));
+    this.send(g, 0.55, 0);
+    for (const m of midis) {
+      const f = midiToHz(m);
+      for (let k = 0; k < 2; k++) {
+        const o = ctx.createOscillator();
+        o.type = "sawtooth";
+        o.frequency.value = f;
+        o.detune.value = (k === 0 ? -7 : 7) + this.rand() * 4;
+        o.connect(lp);
+        o.start(t);
+        o.stop(t + dur + 0.1);
+      }
+    }
+  }
+
+  arp(t: number, midi: number, gain = 1): void {
+    const ctx = this.ctx;
+    const o = ctx.createOscillator();
+    o.type = "square";
+    o.frequency.value = midiToHz(midi);
+    o.detune.value = this.rand() * 6;
+    const lp = ctx.createBiquadFilter();
+    lp.type = "lowpass";
+    lp.frequency.value = 2800;
+    lp.Q.value = 3;
+    const g = ctx.createGain();
+    g.gain.setValueAtTime(EPS, t);
+    g.gain.exponentialRampToValueAtTime(0.1 * gain, t + 0.006);
+    g.gain.exponentialRampToValueAtTime(EPS, t + 0.2);
+    o.connect(lp);
+    lp.connect(g);
+    g.connect(this.bus("music"));
+    this.send(g, 0.2, 0.5);
+    o.start(t);
+    o.stop(t + 0.26);
+  }
+
+  lead(t: number, dur: number, midi: number, gain = 1): void {
+    const ctx = this.ctx;
+    const g = ctx.createGain();
+    g.gain.setValueAtTime(EPS, t);
+    g.gain.exponentialRampToValueAtTime(0.13 * gain, t + 0.02);
+    g.gain.setValueAtTime(0.13 * gain, t + dur * 0.8);
+    g.gain.exponentialRampToValueAtTime(EPS, t + dur);
+    const lp = ctx.createBiquadFilter();
+    lp.type = "lowpass";
+    lp.frequency.value = 4200;
+    const vib = ctx.createOscillator();
+    vib.type = "sine";
+    vib.frequency.value = 5.2;
+    const vibG = ctx.createGain();
+    vibG.gain.setValueAtTime(0, t);
+    vibG.gain.linearRampToValueAtTime(5, t + dur * 0.5);
+    vib.connect(vibG);
+    for (const [type, det, lvl] of [
+      ["triangle", 0, 1],
+      ["sawtooth", 6, 0.34],
+    ] as const) {
+      const o = ctx.createOscillator();
+      o.type = type;
+      o.frequency.value = midiToHz(midi);
+      o.detune.value = det;
+      vibG.connect(o.detune);
+      const og = ctx.createGain();
+      og.gain.value = lvl;
+      o.connect(og);
+      og.connect(lp);
+      o.start(t);
+      o.stop(t + dur + 0.08);
+    }
+    lp.connect(g);
+    g.connect(this.bus("music"));
+    this.send(g, 0.4, 0.35);
+    vib.start(t);
+    vib.stop(t + dur + 0.08);
+  }
+
+  /* --- non-musical feedback ---------------------------------------- */
+
+  /** Rising tension for a gate approach. */
+  riser(t: number, dur: number, gain = 1): void {
+    const ctx = this.ctx;
+    const bp = ctx.createBiquadFilter();
+    bp.type = "bandpass";
+    bp.Q.value = 3.5;
+    bp.frequency.setValueAtTime(300, t);
+    bp.frequency.exponentialRampToValueAtTime(7200, t + dur);
+    const g = ctx.createGain();
+    g.gain.setValueAtTime(EPS, t);
+    g.gain.linearRampToValueAtTime(0.3 * gain, t + dur * 0.92);
+    g.gain.exponentialRampToValueAtTime(EPS, t + dur);
+    const s = this.src(t, dur + 0.05);
+    s.connect(bp);
+    bp.connect(g);
+    g.connect(this.bus("sfx"));
+    this.send(g, 0.4, 0);
+  }
+
+  /** Big low impact — damage, breakdown, sector change. */
+  impact(t: number, gain = 1): void {
+    const ctx = this.ctx;
+    const o = ctx.createOscillator();
+    o.type = "sine";
+    o.frequency.setValueAtTime(120, t);
+    o.frequency.exponentialRampToValueAtTime(26, t + 0.5);
+    const g = ctx.createGain();
+    g.gain.setValueAtTime(EPS, t);
+    g.gain.exponentialRampToValueAtTime(0.85 * gain, t + 0.005);
+    g.gain.exponentialRampToValueAtTime(EPS, t + 0.6);
+    o.connect(g);
+    g.connect(this.bus("sfx"));
+    o.start(t);
+    o.stop(t + 0.65);
+    const lp = ctx.createBiquadFilter();
+    lp.type = "lowpass";
+    lp.frequency.setValueAtTime(2400, t);
+    lp.frequency.exponentialRampToValueAtTime(180, t + 0.35);
+    const ng = ctx.createGain();
+    ng.gain.setValueAtTime(0.5 * gain, t);
+    ng.gain.exponentialRampToValueAtTime(EPS, t + 0.4);
+    const s = this.src(t, 0.42);
+    s.connect(lp);
+    lp.connect(ng);
+    ng.connect(this.bus("sfx"));
+    this.send(ng, 0.5, 0);
+  }
+
+  /** Glass: a scatter of short bandpassed bursts at unrelated pitches. */
+  shatter(t: number, gain = 1, count = 9): void {
+    for (let i = 0; i < count; i++) {
+      const dt = t + i * (0.008 + Math.abs(this.rand()) * 0.02);
+      const bp = this.ctx.createBiquadFilter();
+      bp.type = "bandpass";
+      bp.frequency.value = 1800 + Math.abs(this.rand()) * 7000;
+      bp.Q.value = 9 + Math.abs(this.rand()) * 14;
+      const g = this.ctx.createGain();
+      const lvl = (0.16 + Math.abs(this.rand()) * 0.14) * gain;
+      g.gain.setValueAtTime(lvl, dt);
+      g.gain.exponentialRampToValueAtTime(EPS, dt + 0.12 + Math.abs(this.rand()) * 0.2);
+      const s = this.src(dt, 0.34);
+      s.connect(bp);
+      bp.connect(g);
+      g.connect(this.bus("sfx"));
+      this.send(g, 0.55, 0.2);
+    }
+  }
+
+  /** A missed note: the hole where a drum should have been. */
+  thud(t: number, gain = 1): void {
+    const lp = this.ctx.createBiquadFilter();
+    lp.type = "lowpass";
+    lp.frequency.value = 260;
+    const g = this.ctx.createGain();
+    g.gain.setValueAtTime(0.4 * gain, t);
+    g.gain.exponentialRampToValueAtTime(EPS, t + 0.14);
+    const s = this.src(t, 0.16);
+    s.connect(lp);
+    lp.connect(g);
+    g.connect(this.bus("sfx"));
+  }
+
+  /** A tap that hit nothing. Quiet, dry, and clearly "not a note". */
+  tick(t: number, gain = 1): void {
+    const hp = this.ctx.createBiquadFilter();
+    hp.type = "highpass";
+    hp.frequency.value = 2600;
+    const g = this.ctx.createGain();
+    g.gain.setValueAtTime(0.07 * gain, t);
+    g.gain.exponentialRampToValueAtTime(EPS, t + 0.035);
+    const s = this.src(t, 0.05);
+    s.connect(hp);
+    hp.connect(g);
+    g.connect(this.bus("sfx"));
+  }
+
+  /** Upward chirp for a correct gate; downward for a wrong one. */
+  chirp(t: number, from: number, to: number, dur = 0.22, gain = 1): void {
+    const o = this.ctx.createOscillator();
+    o.type = "triangle";
+    o.frequency.setValueAtTime(from, t);
+    o.frequency.exponentialRampToValueAtTime(to, t + dur);
+    const g = this.ctx.createGain();
+    g.gain.setValueAtTime(EPS, t);
+    g.gain.exponentialRampToValueAtTime(0.22 * gain, t + 0.01);
+    g.gain.exponentialRampToValueAtTime(EPS, t + dur);
+    o.connect(g);
+    g.connect(this.bus("sfx"));
+    this.send(g, 0.3, 0.2);
+    o.start(t);
+    o.stop(t + dur + 0.03);
+  }
+}

--- a/dynawalla/games/rhythm/src/audio/music.ts
+++ b/dynawalla/games/rhythm/src/audio/music.ts
@@ -1,0 +1,238 @@
+/**
+ * Procedural arrangement.
+ *
+ * The player is the drummer. The kick, snare and bell you hear on a hit are
+ * *your* hits — miss and there is a hole in the groove. Everything in this file
+ * is the band behind you: bass, pad, arpeggio, counter-melody, and a quiet
+ * pulse so there is always a clock to lock onto even in a bar with no notes.
+ *
+ * Layers unlock with combo, so escalation is something you HEAR before you read
+ * it off a number.
+ */
+
+import type { AudioEngine } from "./engine.ts";
+
+export type Quality = "min" | "maj";
+export type Chord = { off: number; q: Quality };
+
+export type Sector = {
+  id: string;
+  /** shown once, briefly, when the sector turns over */
+  name: string;
+  /** midi note of the tonic, bass register */
+  root: number;
+  prog: readonly Chord[];
+  /** 0 = straight, 0.2 ≈ light swing on offbeat eighths */
+  swing: number;
+  bpmBias: number;
+};
+
+/** Natural-minor harmony, so every progression is consonant with the same
+ *  pentatonic lead pool and sectors can cross-fade without a key clash. */
+export const SECTORS: readonly Sector[] = [
+  {
+    id: "indigo",
+    name: "INDIGO",
+    root: 45, // A2
+    prog: [
+      { off: 0, q: "min" },
+      { off: 8, q: "maj" },
+      { off: 3, q: "maj" },
+      { off: 10, q: "maj" },
+    ],
+    swing: 0,
+    bpmBias: 0,
+  },
+  {
+    id: "ember",
+    name: "EMBER",
+    root: 43, // G2
+    prog: [
+      { off: 0, q: "min" },
+      { off: 10, q: "maj" },
+      { off: 8, q: "maj" },
+      { off: 10, q: "maj" },
+    ],
+    swing: 0.16,
+    bpmBias: 4,
+  },
+  {
+    id: "violet",
+    name: "VIOLET",
+    root: 47, // B2
+    prog: [
+      { off: 0, q: "min" },
+      { off: 5, q: "min" },
+      { off: 10, q: "maj" },
+      { off: 0, q: "min" },
+    ],
+    swing: 0,
+    bpmBias: 8,
+  },
+  {
+    id: "glacier",
+    name: "GLACIER",
+    root: 41, // F2
+    prog: [
+      { off: 8, q: "maj" },
+      { off: 10, q: "maj" },
+      { off: 0, q: "min" },
+      { off: 3, q: "maj" },
+    ],
+    swing: 0,
+    bpmBias: 6,
+  },
+  {
+    id: "solar",
+    name: "SOLAR",
+    root: 44, // G#2
+    prog: [
+      { off: 0, q: "min" },
+      { off: 1, q: "maj" },
+      { off: 10, q: "maj" },
+      { off: 8, q: "maj" },
+    ],
+    swing: 0.12,
+    bpmBias: 12,
+  },
+  {
+    id: "abyss",
+    name: "ABYSS",
+    root: 39, // D#2
+    prog: [
+      { off: 0, q: "min" },
+      { off: 0, q: "min" },
+      { off: 10, q: "maj" },
+      { off: 5, q: "min" },
+    ],
+    swing: 0.2,
+    bpmBias: 14,
+  },
+];
+
+/** Minor pentatonic — every note in it works over every chord above. */
+const PENT = [0, 3, 5, 7, 10] as const;
+
+const triad = (c: Chord): number[] => (c.q === "min" ? [0, 3, 7] : [0, 4, 7]).map((i) => i + c.off);
+
+/** Deterministic per-bar noise, so a replay of bar 91 sounds like bar 91. */
+function barRng(bar: number, salt: number) {
+  let a = (bar * 0x9e3779b1 + salt * 0x85ebca77) >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export type ArrangeCtx = {
+  /** 0..4 — how much of the band is playing */
+  layer: number;
+  /** dips to ~0.35 while a gate is being read, so the question can breathe */
+  intensity: number;
+};
+
+/**
+ * Schedule one bar of backing. `t0` is the absolute AudioContext time of beat 1
+ * and `spb` is seconds-per-beat; both are supplied by the conductor so a tempo
+ * change lands exactly on a bar line.
+ */
+export function scheduleBar(
+  eng: AudioEngine,
+  t0: number,
+  spb: number,
+  bar: number,
+  sector: Sector,
+  ctx: ArrangeCtx,
+): void {
+  const chord = sector.prog[bar % sector.prog.length]!;
+  const rng = barRng(bar, sector.root);
+  const barDur = spb * 4;
+  const { layer, intensity } = ctx;
+  const lvl = 0.55 + intensity * 0.45;
+
+  const chordRoot = sector.root + chord.off;
+  const tones = triad(chord);
+
+  /* ---- pad ---------------------------------------------------------- */
+  const padNotes = tones.map((i) => sector.root + 24 + i);
+  if (layer >= 2) padNotes.push(sector.root + 36 + tones[1]!); // open it up
+  if (layer >= 4) padNotes.push(sector.root + 26 + chord.off); // add the 9th
+  eng.pad(t0, barDur * 0.99, padNotes, (0.9 + layer * 0.06) * lvl);
+
+  /* ---- bass --------------------------------------------------------- */
+  // beat, duration-in-beats, semitones above the chord root
+  const flat: readonly [number, number, number][] = [
+    [0, 1.9, 0],
+    [2, 1.9, 0],
+  ];
+  const drive: readonly [number, number, number][] = [
+    [0, 0.9, 0],
+    [1.5, 0.4, 0],
+    [2, 0.9, 7],
+    [3, 0.4, 0],
+    [3.5, 0.4, 12],
+  ];
+  const runner: readonly [number, number, number][] = [
+    [0, 0.45, 0],
+    [0.75, 0.2, 0],
+    [1.5, 0.45, 12],
+    [2, 0.45, 0],
+    [2.75, 0.2, 7],
+    [3.5, 0.45, 10],
+  ];
+  const bassPat = layer >= 3 ? runner : layer >= 1 ? drive : flat;
+  for (const [b, d, semi] of bassPat) {
+    eng.bass(t0 + b * spb, d * spb, chordRoot + semi, (0.95 + layer * 0.04) * lvl);
+  }
+
+  /* ---- pulse: the clock, always present ----------------------------- */
+  // Quiet enough to sit under the player's own drums, loud enough that a bar
+  // with no notes still has a beat you can feel.
+  const pulseDiv = layer >= 2 ? 8 : 4;
+  for (let i = 0; i < pulseDiv; i++) {
+    const swung = i % 2 === 1 ? sector.swing * 0.5 : 0;
+    const t = t0 + ((i + swung) / pulseDiv) * 4 * spb;
+    const accent = i % (pulseDiv / 2) === 0;
+    eng.hat(t, (accent ? 0.2 : 0.11) * lvl, false);
+  }
+
+  /* ---- arpeggio ----------------------------------------------------- */
+  if (layer >= 1) {
+    const pool = [tones[0]!, tones[1]!, tones[2]!, tones[0]! + 12, tones[2]!, tones[1]!];
+    const steps = layer >= 3 ? 8 : 4;
+    for (let i = 0; i < steps; i++) {
+      if (layer < 3 && rng() < 0.25) continue;
+      const swung = i % 2 === 1 ? sector.swing * 0.5 : 0;
+      const t = t0 + ((i + swung) / steps) * 4 * spb;
+      eng.arp(t, sector.root + 24 + pool[i % pool.length]!, (0.8 + layer * 0.05) * lvl);
+    }
+  }
+
+  /* ---- counter-melody ------------------------------------------------ */
+  if (layer >= 3) {
+    const slots = [0, 1.5, 2.5, 3.5];
+    for (const b of slots) {
+      if (rng() < 0.42) continue;
+      const deg = PENT[Math.floor(rng() * PENT.length)]!;
+      const oct = layer >= 4 && rng() < 0.4 ? 12 : 0;
+      eng.lead(t0 + b * spb, spb * 0.9, sector.root + 36 + deg + oct, (0.9 + layer * 0.05) * lvl);
+    }
+  }
+
+  /* ---- shimmer ------------------------------------------------------- */
+  if (layer >= 4 && bar % 2 === 0) {
+    const deg = PENT[Math.floor(rng() * PENT.length)]!;
+    eng.bell(t0 + 3.5 * spb, sector.root + 48 + deg, 0.5 * lvl, 0.9, 0.75);
+  }
+}
+
+/** A short cadence played when a gate answer is correct — a musical "yes". */
+export function cadence(eng: AudioEngine, t: number, spb: number, sector: Sector, up: boolean): void {
+  const seq = up ? [0, 3, 7, 12] : [12, 10, 7, 3];
+  for (let i = 0; i < seq.length; i++) {
+    eng.bell(t + i * spb * 0.16, sector.root + 48 + seq[i]!, 0.85 - i * 0.08, 0.7, 0.7);
+  }
+}

--- a/dynawalla/games/rhythm/src/contract.ts
+++ b/dynawalla/games/rhythm/src/contract.ts
@@ -1,0 +1,26 @@
+/**
+ * The Dynawalla game contract. Verbatim from the pack spec:
+ *
+ *   export type Question = { id: string; prompt: string; answer: string; distractors: string[]; domain: string; difficulty: number }
+ *   export type Host = {
+ *     next(opts?: { domain?: string; difficulty?: number }): Question
+ *     report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+ *     haptic(k: "light"|"medium"|"heavy"|"success"|"failure"): void
+ *     prefersReducedMotion(): boolean
+ *   }
+ *   export function mount(el: HTMLElement, host: Host): { unmount(): void }
+ *
+ * `Question` and `Host` below are byte-identical to the spec. `mount` is a
+ * signature, not a value, so it lives here as the `Mount` type and is
+ * implemented in `src/index.ts` — `export const mount: Mount` there pins the
+ * implementation to exactly this shape at compile time.
+ */
+
+export type Question = { id: string; prompt: string; answer: string; distractors: string[]; domain: string; difficulty: number }
+export type Host = {
+  next(opts?: { domain?: string; difficulty?: number }): Question
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+  haptic(k: "light"|"medium"|"heavy"|"success"|"failure"): void
+  prefersReducedMotion(): boolean
+}
+export type Mount = (el: HTMLElement, host: Host) => { unmount(): void }

--- a/dynawalla/games/rhythm/src/game/chart.test.ts
+++ b/dynawalla/games/rhythm/src/game/chart.test.ts
@@ -1,0 +1,171 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { grooveBar, polyBar, subdivisionFor, MUSICAL_CELLS, type ChartNote } from "./chart.ts";
+import { windowsFor, verdictFor, BASE_WINDOWS } from "./judge.ts";
+import { createStubHost, parseRat, fmt, rat } from "../stubHost.ts";
+
+const out: ChartNote[] = [];
+
+/* ---------------- subdivision mapping ---------------- */
+
+test("an answer that is a musical denominator becomes that subdivision", () => {
+  assert.deepEqual(subdivisionFor("1/8"), { cells: 8, accentEvery: 4 });
+  assert.deepEqual(subdivisionFor("1/4"), { cells: 4, accentEvery: 2 });
+  assert.deepEqual(subdivisionFor("1/3"), { cells: 3, accentEvery: 2 });
+  assert.equal(subdivisionFor("8")!.cells, 8);
+  assert.equal(subdivisionFor("16")!.cells, 16);
+});
+
+test("3/8 accents every third of eight — the tresillo, not a plain eighth line", () => {
+  assert.deepEqual(subdivisionFor("3/8"), { cells: 8, accentEvery: 3 });
+});
+
+test("an answer that is not a rhythm returns null rather than being forced", () => {
+  // The brief's rule: never cripple the game to force the elegant case.
+  for (const a of ["37", "5", "1", "1/1", "1/5", "1/7", "banana", "", "2/9"]) {
+    assert.equal(subdivisionFor(a), null, `expected null for ${JSON.stringify(a)}`);
+  }
+});
+
+/* ---------------- groove shape ---------------- */
+
+test("every generated note lands exactly on a cell boundary", () => {
+  for (const cells of MUSICAL_CELLS) {
+    for (let bar = 0; bar < 40; bar++) {
+      grooveBar({ bar, cells, accentEvery: 2, density: 0.7, difficulty: 4, showcase: false }, out);
+      for (const n of out) {
+        const expected = (n.cell * 4) / n.cells;
+        assert.ok(
+          Math.abs(n.beat - expected) < 1e-9,
+          `bar ${bar} cells ${cells}: beat ${n.beat} is off the grid`,
+        );
+        assert.ok(n.beat >= 0 && n.beat < 4, `beat ${n.beat} escaped the bar`);
+      }
+    }
+  }
+});
+
+test("a bar always announces itself on beat one", () => {
+  for (const cells of MUSICAL_CELLS) {
+    for (let bar = 0; bar < 30; bar++) {
+      grooveBar({ bar, cells, accentEvery: 2, density: 0.2, difficulty: 1, showcase: false }, out);
+      assert.ok(out.some((n) => n.beat === 0), `bar ${bar} cells ${cells} lost its downbeat`);
+    }
+  }
+});
+
+test("notes never collide within a lane", () => {
+  for (const cells of MUSICAL_CELLS) {
+    for (let bar = 0; bar < 60; bar++) {
+      grooveBar({ bar, cells, accentEvery: 3, density: 1, difficulty: 8, showcase: false }, out);
+      const seen = new Set<string>();
+      for (const n of out) {
+        const k = `${n.lane}@${n.beat.toFixed(6)}`;
+        assert.ok(!seen.has(k), `duplicate ${k} in bar ${bar} cells ${cells}`);
+        seen.add(k);
+      }
+    }
+  }
+});
+
+test("the showcase plays the answer in full — every slice is struck", () => {
+  for (const cells of MUSICAL_CELLS) {
+    grooveBar({ bar: 3, cells, accentEvery: 2, density: 1, difficulty: 3, showcase: true }, out);
+    assert.equal(out.length, cells, `showcase at ${cells} cells produced ${out.length} notes`);
+  }
+});
+
+test("three-against-four really is three against four", () => {
+  polyBar(1, out);
+  const three = out.filter((n) => n.lane === 2);
+  const four = out.filter((n) => n.lane !== 2);
+  assert.equal(four.length, 4);
+  assert.ok(three.length >= 2 && three.length <= 3);
+  // They agree only on beat one — that is lcm(3,4) made audible.
+  const shared = three.filter((a) => four.some((b) => Math.abs(a.beat - b.beat) < 1e-9));
+  assert.deepEqual(shared.map((s) => s.beat), [0]);
+});
+
+/* ---------------- judgement ---------------- */
+
+test("windows never let one tap claim two adjacent notes", () => {
+  // 16ths at 152bpm are ~99ms apart. The base Good window is 155ms, which would
+  // overlap; the clamp is what stops a fast run turning into mush.
+  for (const spacing of [0.06, 0.1, 0.15, 0.25, 0.5, 1]) {
+    const w = windowsFor(spacing);
+    assert.ok(w.miss * 2 <= spacing * 1.001, `miss window ${w.miss} overlaps at spacing ${spacing}`);
+    assert.ok(w.perfect <= w.great && w.great <= w.good && w.good <= w.miss, "windows out of order");
+  }
+});
+
+test("wide spacing keeps the generous base windows", () => {
+  const w = windowsFor(2);
+  assert.equal(w.perfect, BASE_WINDOWS.perfect);
+  assert.equal(w.good, BASE_WINDOWS.good);
+});
+
+test("verdicts are symmetric about the beat and give up outside the window", () => {
+  const w = windowsFor(1);
+  assert.equal(verdictFor(0, w), "perfect");
+  assert.equal(verdictFor(-0.05, w), "perfect");
+  assert.equal(verdictFor(0.09, w), "great");
+  assert.equal(verdictFor(-0.14, w), "good");
+  assert.equal(verdictFor(0.19, w), "miss");
+  assert.equal(verdictFor(0.4, w), null);
+  assert.equal(verdictFor(-0.4, w), null);
+});
+
+/* ---------------- the stub host ---------------- */
+
+test("exact rationals: no float ever reaches an answer string", () => {
+  assert.equal(fmt(rat(2, 8)), "1/4");
+  assert.equal(fmt(rat(4, 2)), "2");
+  assert.equal(fmt(rat(-2, -4)), "1/2");
+  assert.equal(fmt(rat(3, -9)), "-1/3");
+  for (const s of ["1/4", "3", "3/8", "-1/3"]) {
+    assert.equal(fmt(parseRat(s)!), s, `round trip failed for ${s}`);
+  }
+});
+
+test("the host is deterministic under a seed", () => {
+  const a = createStubHost({ seed: 99 });
+  const b = createStubHost({ seed: 99 });
+  for (let i = 0; i < 200; i++) {
+    const qa = a.next({ difficulty: (i % 10) + 1 });
+    const qb = b.next({ difficulty: (i % 10) + 1 });
+    assert.deepEqual(qa, qb);
+  }
+});
+
+test("no question is unwinnable: two distinct distractors, none equal to the answer", () => {
+  const h = createStubHost({ seed: 7 });
+  for (let i = 0; i < 4000; i++) {
+    const q = h.next({ difficulty: (i % 10) + 1 });
+    const tiles = [q.answer, ...q.distractors.slice(0, 2)];
+    assert.equal(new Set(tiles).size, 3, `duplicate tile in ${q.prompt} -> ${tiles.join("|")}`);
+    assert.ok(q.distractors.length >= 2, `too few distractors for ${q.prompt}`);
+  }
+});
+
+test("every answer is an exact integer or reduced fraction — never a decimal", () => {
+  const h = createStubHost({ seed: 11 });
+  for (let i = 0; i < 4000; i++) {
+    const q = h.next({ difficulty: (i % 10) + 1 });
+    for (const s of [q.answer, ...q.distractors]) {
+      assert.ok(!s.includes("."), `decimal leaked into ${JSON.stringify(s)} from ${q.prompt}`);
+      assert.notEqual(parseRat(s), null, `unparseable answer ${JSON.stringify(s)} from ${q.prompt}`);
+    }
+  }
+});
+
+test("plain-arithmetic mode still yields playable questions (graceful degradation)", () => {
+  const h = createStubHost({ seed: 3, musical: false });
+  let musical = 0;
+  for (let i = 0; i < 500; i++) {
+    const q = h.next({ difficulty: 6 });
+    if (subdivisionFor(q.answer)) musical++;
+    assert.ok(q.prompt.length > 0);
+  }
+  // Most plain-arithmetic answers are not rhythms. The game must survive that.
+  assert.ok(musical < 400, "expected mostly unplayable answers in arithmetic mode");
+});

--- a/dynawalla/games/rhythm/src/game/chart.ts
+++ b/dynawalla/games/rhythm/src/game/chart.ts
@@ -1,0 +1,183 @@
+/**
+ * Pattern generation.
+ *
+ * A bar is a grid of `cells` equal slices — which is exactly what a denominator
+ * is. `cells: 8` means the bar is cut into eighths, the floor is ruled into 8
+ * segments, and the notes land on the cuts. When the player answers a gate with
+ * `1/8`, the world re-rules itself into 8 and they PLAY the answer they gave.
+ *
+ * Lane assignment follows metric weight rather than chance, because a random
+ * sprinkle of notes does not feel like a groove and a child can tell.
+ */
+
+export type Lane = 0 | 1 | 2;
+
+export type ChartNote = {
+  /** position within the bar, in beats (0..4) */
+  beat: number;
+  lane: Lane;
+  accent: boolean;
+  /** which slice of the bar this note sits on, and how many slices there are */
+  cell: number;
+  cells: number;
+};
+
+/** Denominators that are also playable subdivisions of a 4/4 bar. */
+export const MUSICAL_CELLS = [2, 3, 4, 6, 8, 12, 16] as const;
+
+export type Subdivision = { cells: number; accentEvery: number };
+
+/**
+ * Map a host answer onto a playable subdivision, or null when the answer is not
+ * a rhythm (e.g. `37`). Null is normal and the conductor has a generic payoff
+ * for it — the game must never be crippled to force the elegant case.
+ */
+export function subdivisionFor(answer: string): Subdivision | null {
+  const t = answer.trim();
+  const whole = /^(\d+)$/.exec(t);
+  if (whole) {
+    const n = Number(whole[1]);
+    if ((MUSICAL_CELLS as readonly number[]).includes(n)) {
+      return { cells: n, accentEvery: n >= 8 ? 4 : n >= 6 ? 3 : 2 };
+    }
+    return null;
+  }
+  const frac = /^(\d+)\s*\/\s*(\d+)$/.exec(t);
+  if (frac) {
+    const n = Number(frac[1]);
+    const d = Number(frac[2]);
+    if (d === 1) return null;
+    if (!(MUSICAL_CELLS as readonly number[]).includes(d)) return null;
+    // 3/8 accents every 3rd of 8 — the tresillo. 1/8 just accents the beats.
+    const accentEvery = n > 1 && n < d ? n : d >= 8 ? 4 : d >= 6 ? 3 : 2;
+    return { cells: d, accentEvery };
+  }
+  return null;
+}
+
+function rngFor(seed: number) {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Lane by metric weight: downbeats are low, backbeats are mid, the rest ride. */
+function laneFor(cell: number, cells: number): Lane {
+  const beat = (cell * 4) / cells;
+  const onBeat = Math.abs(beat - Math.round(beat)) < 1e-9;
+  if (cells === 2 || cells % 4 === 0) {
+    if (onBeat) {
+      const b = Math.round(beat) % 4;
+      return b === 0 || b === 2 ? 0 : 1;
+    }
+    return 2;
+  }
+  // 3, 6, 12: a cyclic three-feel. Every third cell is the anchor.
+  const m = cell % 3;
+  return m === 0 ? 0 : m === 1 ? 2 : 1;
+}
+
+export type BarSpec = {
+  bar: number;
+  cells: number;
+  accentEvery: number;
+  /** 0..1, how much of the grid is filled beyond the structural notes */
+  density: number;
+  difficulty: number;
+  /** true for the payoff bars right after a correct gate */
+  showcase: boolean;
+};
+
+/**
+ * One bar of groove. Structural notes (bar start, backbeats) are always
+ * present; everything else is filled by density so the pattern breathes.
+ */
+export function grooveBar(spec: BarSpec, out: ChartNote[]): ChartNote[] {
+  out.length = 0;
+  const { bar, cells, accentEvery, density, difficulty, showcase } = spec;
+  const rnd = rngFor(bar * 2654435761 + cells * 40503);
+
+  for (let i = 0; i < cells; i++) {
+    const beat = (i * 4) / cells;
+    const lane = laneFor(i, cells);
+    const accent = i % accentEvery === 0;
+
+    let keep: boolean;
+    if (i === 0) {
+      keep = true; // the bar always announces itself
+    } else if (showcase) {
+      keep = true; // the payoff plays the answer in full, every slice
+    } else if (lane === 1) {
+      keep = true; // never drop a backbeat; it is the spine of the groove
+    } else if (lane === 0) {
+      keep = rnd() < 0.72 + density * 0.28;
+    } else {
+      keep = rnd() < density;
+    }
+    if (keep) out.push({ beat, lane, accent, cell: i, cells });
+  }
+
+  // Syncopation: from difficulty 5, occasionally pull a note off the grid into
+  // the slot just before a backbeat. This is what stops long runs feeling like
+  // a metronome.
+  if (!showcase && difficulty >= 5 && cells >= 8 && rnd() < 0.35) {
+    const target = Math.round((cells * 3) / 4); // beat 3
+    const idx = out.findIndex((n) => n.cell === target);
+    if (idx >= 0 && target - 1 > 0 && !out.some((n) => n.cell === target - 1)) {
+      const n = out[idx]!;
+      n.cell = target - 1;
+      n.beat = ((target - 1) * 4) / cells;
+      n.accent = true;
+    }
+  }
+
+  out.sort((a, b) => a.beat - b.beat);
+  return out;
+}
+
+/**
+ * The showpiece: three against four, performed with two hands.
+ *
+ * Lanes 0 and 1 hold a four-grid while lane 2 rides a three-grid. The two
+ * agree only on beat 1 — which is the common denominator, made audible. This
+ * is the same fact as `lcm(3,4) = 12`, except the child solves it with their
+ * hands and hears it resolve.
+ */
+export function polyBar(bar: number, out: ChartNote[]): ChartNote[] {
+  out.length = 0;
+  const rnd = rngFor(bar * 1013904223 + 77);
+  for (let i = 0; i < 4; i++) {
+    out.push({
+      beat: i,
+      lane: i % 2 === 0 ? 0 : 1,
+      accent: i === 0,
+      cell: i * 3,
+      cells: 12,
+    });
+  }
+  for (let i = 0; i < 3; i++) {
+    if (i > 0 && rnd() < 0.08) continue;
+    out.push({
+      beat: (i * 4) / 3,
+      lane: 2,
+      accent: i === 0,
+      cell: i * 4,
+      cells: 12,
+    });
+  }
+  out.sort((a, b) => a.beat - b.beat);
+  return out;
+}
+
+/** A near-empty bar: the inhale before a gate, so the question can be read. */
+export function inhaleBar(out: ChartNote[]): ChartNote[] {
+  out.length = 0;
+  out.push({ beat: 0, lane: 0, accent: true, cell: 0, cells: 4 });
+  out.push({ beat: 2, lane: 0, accent: false, cell: 2, cells: 4 });
+  return out;
+}

--- a/dynawalla/games/rhythm/src/game/core.ts
+++ b/dynawalla/games/rhythm/src/game/core.ts
@@ -1,0 +1,925 @@
+/**
+ * Splitbeat game core: transport, planner, judgement, gates.
+ *
+ * TRANSPORT. `AudioContext.currentTime` is the only clock. Bars are planned
+ * ahead into a ring buffer that records each bar's absolute start time and
+ * seconds-per-beat, so a tempo change lands exactly on a bar line and the
+ * renderer can position any note by `(note.time - now) * pxPerSecond` without
+ * ever consulting a tempo map.
+ *
+ * TWO CURSORS. Notes are materialised ~3.4s ahead (cheap, no audio) so they can
+ * scroll in. Backing audio is scheduled only ~0.25s ahead, so when combo
+ * unlocks a new layer you hear it on the next bar rather than four bars later.
+ *
+ * NO HITSTOP ON NOTES. Freezing the picture is the standard way to make an
+ * impact land, but in a rhythm game the picture is tempo-locked to the music,
+ * so a freeze desynchronises the scroll from what you are hearing. The punch is
+ * delivered instead by zoom, shake, lane flash and particles — and true hitstop
+ * is allowed only when no note is within 0.35s, which is exactly the aftermath
+ * bar where the gate shatters.
+ */
+
+import { AudioEngine } from "../audio/engine.ts";
+import { SECTORS, scheduleBar, cadence, type Sector } from "../audio/music.ts";
+import type { Host, Question } from "../contract.ts";
+import {
+  grooveBar,
+  polyBar,
+  inhaleBar,
+  subdivisionFor,
+  type ChartNote,
+  type Lane,
+} from "./chart.ts";
+import { layerFor, multiplierFor, verdictFor, windowsFor, VERDICT_SCORE, type Verdict } from "./judge.ts";
+
+export type { Lane };
+
+export const LANES = 3;
+const NOTE_POOL = 320;
+const BAR_RING = 64;
+const NOTE_HORIZON = 3.4;
+const AUDIO_HORIZON = 0.3;
+const LEAD_IN = 0.45;
+const MAX_CHARGE = 5;
+
+export type Note = {
+  active: boolean;
+  time: number;
+  lane: Lane;
+  accent: boolean;
+  cell: number;
+  cells: number;
+  /** per-lane average spacing in this bar; drives the timing windows */
+  spacing: number;
+  isChoice: boolean;
+  gateId: number;
+  label: string;
+  correct: boolean;
+  /** 0 pending, 1 struck, 2 missed */
+  state: 0 | 1 | 2;
+  verdict: Verdict | null;
+  delta: number;
+  bornAt: number;
+  hitAt: number;
+};
+
+export type Gate = {
+  id: number;
+  active: boolean;
+  q: Question | null;
+  time: number;
+  revealAt: number;
+  resolved: boolean;
+  correct: boolean;
+  answered: string;
+  labels: [string, string, string];
+  correctLane: Lane;
+  cells: number | null;
+  accentEvery: number;
+  /** 0..1 animation drivers, advanced by the renderer's clock */
+  shatter: number;
+  crack: number;
+};
+
+export type EventKind =
+  | "hit"
+  | "miss"
+  | "ghost"
+  | "gate-correct"
+  | "gate-wrong"
+  | "sector"
+  | "breakdown"
+  | "revive"
+  | "charge-up";
+
+export type GameEvent = {
+  kind: EventKind;
+  lane: Lane;
+  verdict: Verdict | null;
+  accent: boolean;
+  strength: number;
+};
+
+export type Phase = "title" | "playing" | "breakdown" | "paused";
+
+export type Fx = {
+  shake: number;
+  shakeAngle: number;
+  zoom: number;
+  flash: number;
+  chroma: number;
+  laneFlash: [number, number, number];
+  vignette: number;
+  hitstopUntil: number;
+  timeDilate: number;
+};
+
+const KEY_LANE: Record<string, Lane> = {
+  ArrowDown: 0, a: 0, j: 0, "1": 0, z: 0,
+  ArrowRight: 1, s: 1, k: 1, "2": 1, x: 1, " ": 1,
+  ArrowUp: 2, d: 2, l: 2, "3": 2, c: 2,
+};
+
+const clamp = (v: number, lo: number, hi: number) => (v < lo ? lo : v > hi ? hi : v);
+
+export class Game {
+  readonly eng: AudioEngine;
+  readonly host: Host;
+
+  readonly notes: Note[] = [];
+  readonly gates: Gate[] = [];
+  readonly events: GameEvent[] = [];
+  private eventCount = 0;
+
+  /**
+   * Ring of planned bars, so the renderer can rule the floor into the current
+   * subdivision. This is the whole visual thesis: the bar of music IS the
+   * fraction bar, cut into `cells` equal slices, and the notes land on the cuts.
+   */
+  readonly barGrid: { t: number; dur: number; cells: number; playEvery: number }[] = [];
+  private gridCur = 0;
+
+  phase: Phase = "title";
+  score = 0;
+  combo = 0;
+  bestCombo = 0;
+  charge = MAX_CHARGE;
+  difficulty = 1;
+  gatesTotal = 0;
+  gatesCorrect = 0;
+  notesHit = 0;
+  notesMissed = 0;
+  perfectRun = 0;
+  sectorIdx = 0;
+  sectorFlash = 0;
+  /** last judgement, for the timing meter */
+  lastDelta = 0;
+  lastVerdict: Verdict | null = null;
+  lastJudgeAt = 0;
+
+  /** the gate the player is currently being asked, or null */
+  activeGate: Gate | null = null;
+  /** the revive question during a breakdown */
+  reviveGate: Gate | null = null;
+
+  cells = 4;
+  accentEvery = 2;
+  bpm = 92;
+
+  readonly fx: Fx = {
+    shake: 0,
+    shakeAngle: 0,
+    zoom: 1,
+    flash: 0,
+    chroma: 0,
+    laneFlash: [0, 0, 0],
+    vignette: 0,
+    hitstopUntil: 0,
+    timeDilate: 1,
+  };
+
+  /** user timing calibration, seconds; positive = player is hitting late */
+  calibration = 0;
+  soundOn = true;
+  reduced = false;
+
+  private barTime = new Float64Array(BAR_RING);
+  private barSpb = new Float64Array(BAR_RING);
+  private noteCursor = 0;
+  private audioCursor = 0;
+  private cycleStartBar = 0;
+  private grooveBars = 6;
+  private gateSeq = 0;
+  private schedTimer = 0;
+  private laneLock = [0, 0, 0];
+  private scratch: ChartNote[] = [];
+  private started = false;
+
+  constructor(host: Host) {
+    this.host = host;
+    this.eng = new AudioEngine();
+    this.reduced = host.prefersReducedMotion();
+    for (let i = 0; i < NOTE_POOL; i++) {
+      this.notes.push({
+        active: false, time: 0, lane: 0, accent: false, cell: 0, cells: 4, spacing: 0.5,
+        isChoice: false, gateId: -1, label: "", correct: false, state: 0, verdict: null,
+        delta: 0, bornAt: 0, hitAt: 0,
+      });
+    }
+    for (let i = 0; i < 6; i++) {
+      this.gates.push({
+        id: -1, active: false, q: null, time: 0, revealAt: 0, resolved: false, correct: false,
+        answered: "", labels: ["", "", ""], correctLane: 0, cells: null, accentEvery: 2,
+        shatter: 0, crack: 0,
+      });
+    }
+    for (let i = 0; i < 64; i++) {
+      this.events.push({ kind: "hit", lane: 0, verdict: null, accent: false, strength: 1 });
+    }
+    for (let i = 0; i < 24; i++) this.barGrid.push({ t: -99, dur: 2, cells: 4, playEvery: 1 });
+  }
+
+  get sector(): Sector {
+    return SECTORS[this.sectorIdx % SECTORS.length]!;
+  }
+
+  get audioNow(): number {
+    return this.eng.now;
+  }
+
+  /** Musical time a tap at wall-clock `audioTime` corresponds to. */
+  private judgeTime(t: number): number {
+    return t - this.eng.outputLatency - this.calibration;
+  }
+
+  /* ---------------------------------------------------------------- */
+  /* events (pooled — the renderer drains this every frame)            */
+  /* ---------------------------------------------------------------- */
+
+  private emit(kind: EventKind, lane: Lane, verdict: Verdict | null, accent: boolean, strength: number): void {
+    if (this.eventCount >= this.events.length) return;
+    const e = this.events[this.eventCount++]!;
+    e.kind = kind;
+    e.lane = lane;
+    e.verdict = verdict;
+    e.accent = accent;
+    e.strength = strength;
+  }
+  get pendingEvents(): number {
+    return this.eventCount;
+  }
+  clearEvents(): void {
+    this.eventCount = 0;
+  }
+
+  /* ---------------------------------------------------------------- */
+  /* lifecycle                                                         */
+  /* ---------------------------------------------------------------- */
+
+  async start(): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+    await this.eng.resume();
+    this.phase = "playing";
+    this.reanchor();
+    this.schedTimer = self.setInterval(() => this.pump(), 22);
+  }
+
+  private reanchor(): void {
+    const t = this.eng.now + LEAD_IN;
+    this.noteCursor = 0;
+    this.audioCursor = 0;
+    this.cycleStartBar = 0;
+    this.barTime[0] = t;
+    this.barSpb[0] = 60 / this.bpm;
+    this.applyDifficulty();
+    this.barSpb[0] = 60 / this.bpm;
+  }
+
+  pause(): void {
+    if (this.phase !== "playing") return;
+    this.phase = "paused";
+    this.eng.setMusicGain(0.0, 0.12);
+  }
+
+  resumeFromPause(): void {
+    if (this.phase !== "paused") return;
+    this.phase = "playing";
+    this.eng.setMusicGain(0.62, 0.2);
+    this.flushNotes();
+    this.reanchorSoft();
+  }
+
+  /** Re-seat the transport at "now" without resetting the run. */
+  private reanchorSoft(): void {
+    const t = this.eng.now + LEAD_IN;
+    const bar = this.noteCursor;
+    this.barTime[bar % BAR_RING] = t;
+    this.barSpb[bar % BAR_RING] = 60 / this.bpm;
+    this.audioCursor = bar;
+    this.cycleStartBar = bar;
+  }
+
+  private flushNotes(): void {
+    for (const n of this.notes) n.active = false;
+    for (const g of this.gates) g.active = false;
+    this.activeGate = null;
+  }
+
+  destroy(): void {
+    if (this.schedTimer) self.clearInterval(this.schedTimer);
+    this.schedTimer = 0;
+    this.eng.dispose();
+  }
+
+  /* ---------------------------------------------------------------- */
+  /* difficulty                                                        */
+  /* ---------------------------------------------------------------- */
+
+  private applyDifficulty(): void {
+    const d = this.difficulty;
+    this.bpm = 92 + d * 6 + this.sector.bpmBias;
+    this.grooveBars = d < 3 ? 6 : d < 6 ? 5 : 4;
+    this.eng.setDelayTime((60 / this.bpm) * 0.75);
+  }
+
+  private get maxCells(): number {
+    const d = this.difficulty;
+    return d < 3 ? 8 : d < 6 ? 12 : 16;
+  }
+
+  private get density(): number {
+    return clamp(0.2 + this.difficulty * 0.075, 0.2, 0.95);
+  }
+
+  private adjustDifficulty(delta: number): void {
+    this.difficulty = clamp(this.difficulty + delta, 1, 10);
+  }
+
+  /* ---------------------------------------------------------------- */
+  /* planner                                                           */
+  /* ---------------------------------------------------------------- */
+
+  private pump(): void {
+    if (this.phase !== "playing") return;
+    const now = this.eng.now;
+
+    let guard = 0;
+    while (guard++ < 8) {
+      const bar = this.noteCursor;
+      const t = this.barTime[bar % BAR_RING]!;
+      if (t >= now + NOTE_HORIZON) break;
+      if (!this.planBar(bar)) break;
+      this.noteCursor = bar + 1;
+    }
+
+    guard = 0;
+    while (guard++ < 8 && this.audioCursor < this.noteCursor) {
+      const bar = this.audioCursor;
+      const t = this.barTime[bar % BAR_RING]!;
+      if (t >= now + AUDIO_HORIZON) break;
+      const spb = this.barSpb[bar % BAR_RING]!;
+      const g = this.activeGate;
+      // Dip the arrangement while a question is on screen so it can be read.
+      const reading = g && !g.resolved && now >= g.revealAt ? 0.42 : 1;
+      scheduleBar(this.eng, t, spb, bar, this.sector, {
+        layer: layerFor(this.combo),
+        intensity: reading,
+      });
+      this.audioCursor = bar + 1;
+    }
+  }
+
+  private roleOf(bar: number): "groove" | "reveal" | "inhale" | "gate" | "aftermath" | "payoff" {
+    const i = bar - this.cycleStartBar;
+    const G = this.grooveBars;
+    if (i < G - 1) return "groove";
+    if (i === G - 1) return "reveal";
+    if (i === G) return "inhale";
+    if (i === G + 1) return "gate";
+    if (i === G + 2) return "aftermath";
+    return "payoff";
+  }
+
+  /** Plan one bar. Returns false when the bar cannot be planned yet. */
+  private planBar(bar: number): boolean {
+    const idx = bar % BAR_RING;
+    // Roll the cycle over first, so roleOf() is asked about the right cycle.
+    if (bar - this.cycleStartBar >= this.grooveBars + 5) {
+      this.cycleStartBar = bar;
+      this.applyDifficulty();
+    }
+    const role = this.roleOf(bar);
+    const t0 = this.barTime[idx]!;
+    const spb = 60 / this.bpm;
+    this.barSpb[idx] = spb;
+
+    if (role === "payoff") {
+      const g = this.activeGate;
+      // Do not commit the payoff until the answer is in — the payoff *is* the
+      // answer, played.
+      if (g && !g.resolved) return false;
+    }
+
+    let list: ChartNote[];
+    let cells = clamp(this.cells, 2, this.maxCells);
+    let playEvery = 1;
+    let showcase = false;
+
+    if (role === "inhale" || role === "gate" || role === "aftermath") {
+      list = inhaleBar(this.scratch);
+      cells = 4;
+      if (role === "gate") list.length = 0;
+      if (role === "aftermath") list.length = 0;
+    } else if (role === "payoff") {
+      const g = this.activeGate;
+      showcase = true;
+      if (g && g.correct && g.cells) {
+        cells = g.cells;
+        this.accentEvery = g.accentEvery;
+        if (cells > this.maxCells) playEvery = Math.ceil(cells / this.maxCells);
+      } else {
+        cells = clamp(this.cells, 2, this.maxCells);
+      }
+      list = grooveBar(
+        { bar, cells, accentEvery: this.accentEvery, density: 1, difficulty: this.difficulty, showcase: true },
+        this.scratch,
+      );
+      if (playEvery > 1) list = list.filter((n) => n.cell % playEvery === 0);
+    } else if (this.difficulty >= 6 && (bar * 7919) % 4 === 0) {
+      list = polyBar(bar, this.scratch);
+      cells = 12;
+    } else {
+      list = grooveBar(
+        {
+          bar,
+          cells,
+          accentEvery: this.accentEvery,
+          density: this.density,
+          difficulty: this.difficulty,
+          showcase: false,
+        },
+        this.scratch,
+      );
+    }
+
+    // Per-lane spacing drives the timing windows for every note in this bar.
+    const barDur = spb * 4;
+    const perLane = [0, 0, 0];
+    for (const n of list) perLane[n.lane]!++;
+    const spacing: number[] = [
+      barDur / Math.max(1, perLane[0]!),
+      barDur / Math.max(1, perLane[1]!),
+      barDur / Math.max(1, perLane[2]!),
+    ];
+
+    for (const cn of list) {
+      const n = this.takeNote();
+      if (!n) break;
+      n.time = t0 + cn.beat * spb;
+      n.lane = cn.lane;
+      n.accent = cn.accent;
+      n.cell = cn.cell;
+      n.cells = cells;
+      n.spacing = spacing[cn.lane]!;
+      n.isChoice = false;
+      n.gateId = -1;
+      n.label = "";
+      n.correct = false;
+      n.state = 0;
+      n.verdict = null;
+      n.bornAt = this.eng.now;
+      n.hitAt = 0;
+    }
+
+    if (role === "reveal") this.spawnGate(t0, spb);
+    if (role === "gate") this.placeChoiceNotes(t0, spb);
+    if (showcase && this.activeGate?.correct && this.activeGate.cells) {
+      this.cells = clamp(this.activeGate.cells, 2, this.maxCells);
+    }
+
+    const g = this.barGrid[this.gridCur % this.barGrid.length]!;
+    this.gridCur++;
+    g.t = t0;
+    g.dur = barDur;
+    g.cells = cells;
+    g.playEvery = playEvery;
+
+    this.barTime[(bar + 1) % BAR_RING] = t0 + barDur;
+    return true;
+  }
+
+  private takeNote(): Note | null {
+    for (const n of this.notes) if (!n.active) { n.active = true; return n; }
+    return null;
+  }
+
+  private takeGate(): Gate {
+    for (const g of this.gates) if (!g.active) return g;
+    return this.gates[0]!;
+  }
+
+  /* ---------------------------------------------------------------- */
+  /* gates                                                             */
+  /* ---------------------------------------------------------------- */
+
+  private spawnGate(revealT0: number, spb: number): void {
+    const q = this.host.next({ difficulty: Math.round(this.difficulty) });
+    const g = this.takeGate();
+    g.id = ++this.gateSeq;
+    g.active = true;
+    g.q = q;
+    g.revealAt = revealT0;
+    // Two bars after the reveal bar starts: [reveal][inhale][gate]
+    g.time = revealT0 + spb * 8;
+    g.resolved = false;
+    g.correct = false;
+    g.answered = "";
+    g.shatter = 0;
+    g.crack = 0;
+
+    const sub = subdivisionFor(q.answer);
+    g.cells = sub ? sub.cells : null;
+    g.accentEvery = sub ? sub.accentEvery : this.accentEvery;
+
+    const wrong = q.distractors.filter((d) => d !== q.answer).slice(0, 2);
+    while (wrong.length < 2) wrong.push(String(wrong.length + 1));
+    const lane = (this.gateSeq * 7 + Math.floor(revealT0 * 13)) % 3 as Lane;
+    const labels: [string, string, string] = ["", "", ""];
+    labels[lane] = q.answer;
+    let w = 0;
+    for (let i = 0; i < 3; i++) if (i !== lane) labels[i] = wrong[w++]!;
+    g.labels = labels;
+    g.correctLane = lane;
+    this.activeGate = g;
+
+    // Tension: a riser through the inhale bar into the gate.
+    if (this.soundOn) this.eng.riser(revealT0 + spb * 4, spb * 4, 0.85);
+  }
+
+  private placeChoiceNotes(t0: number, spb: number): void {
+    const g = this.activeGate;
+    if (!g) return;
+    // The bar we are actually planning is authoritative for the strike time.
+    g.time = t0;
+    for (let lane = 0 as Lane; lane < 3; lane = (lane + 1) as Lane) {
+      const n = this.takeNote();
+      if (!n) break;
+      n.time = t0;
+      n.lane = lane;
+      n.accent = true;
+      n.cell = 0;
+      n.cells = 1;
+      n.spacing = spb * 4;
+      n.isChoice = true;
+      n.gateId = g.id;
+      n.label = g.labels[lane]!;
+      n.correct = lane === g.correctLane;
+      n.state = 0;
+      n.verdict = null;
+      n.bornAt = this.eng.now;
+      n.hitAt = 0;
+    }
+  }
+
+  private resolveGate(g: Gate, answered: string, correct: boolean, ms: number): void {
+    if (g.resolved) return;
+    g.resolved = true;
+    g.correct = correct;
+    g.answered = answered;
+    this.gatesTotal++;
+    const t = this.eng.now;
+    const spb = 60 / this.bpm;
+
+    if (g.q) {
+      this.host.report({ questionId: g.q.id, correct, ms: Math.max(0, Math.round(ms)), answered });
+    }
+
+    if (correct) {
+      this.gatesCorrect++;
+      const bonus = g.cells ? 400 + g.cells * 60 : 400;
+      this.score += bonus * multiplierFor(this.combo);
+      this.charge = Math.min(MAX_CHARGE, this.charge + 1);
+      this.adjustDifficulty(0.34);
+      this.emit("gate-correct", g.correctLane, null, true, 1);
+      this.host.haptic("success");
+      if (this.soundOn) {
+        this.eng.shatter(t, 1, 12);
+        this.eng.chirp(t, 420, 1400, 0.26, 1);
+        cadence(this.eng, t + 0.05, spb, this.sector, true);
+        this.eng.clearFilter(0.2);
+      }
+      this.kick(1.0, 1.045, 0.55);
+      this.requestHitstop(0.07);
+      if (this.gatesCorrect % 4 === 0) this.advanceSector();
+    } else {
+      this.charge -= 2;
+      this.combo = 0;
+      this.perfectRun = 0;
+      this.adjustDifficulty(-0.22);
+      this.emit("gate-wrong", g.correctLane, null, true, 1);
+      this.host.haptic("failure");
+      if (this.soundOn) {
+        this.eng.impact(t, 1);
+        this.eng.chirp(t, 300, 120, 0.34, 0.9);
+        this.eng.muffle(spb * 4, 380);
+        // Demonstrate the answer rather than lecture about it: the correct
+        // subdivision is played as a ghost rhythm on the bell.
+        const dcells = g.cells ?? 4;
+        const n = Math.min(dcells, 8);
+        for (let i = 0; i < n; i++) {
+          this.eng.bell(t + 0.35 + (i * spb * 4) / n, this.sector.root + 48, 0.4, 0.35, 0.6);
+        }
+      }
+      this.kick(1.0, 0.965, 0.85);
+      if (this.charge <= 0) this.enterBreakdown();
+    }
+  }
+
+  private advanceSector(): void {
+    this.sectorIdx = (this.sectorIdx + 1) % SECTORS.length;
+    this.sectorFlash = 1;
+    this.applyDifficulty();
+    this.emit("sector", 1, null, true, 1);
+    if (this.soundOn) {
+      this.eng.impact(this.eng.now, 0.7);
+      this.eng.riser(this.eng.now, 0.5, 0.6);
+    }
+  }
+
+  /* ---------------------------------------------------------------- */
+  /* breakdown / revive — the run never ends                           */
+  /* ---------------------------------------------------------------- */
+
+  private enterBreakdown(): void {
+    this.phase = "breakdown";
+    this.charge = 0;
+    this.combo = 0;
+    this.flushNotes();
+    if (this.soundOn) this.eng.tapeStop(0.9);
+    this.host.haptic("heavy");
+    this.emit("breakdown", 1, null, true, 1);
+    this.kick(1.0, 1.06, 1);
+
+    const q = this.host.next({ difficulty: Math.max(1, Math.round(this.difficulty - 2)) });
+    const g = this.takeGate();
+    g.id = ++this.gateSeq;
+    g.active = true;
+    g.q = q;
+    g.time = 0;
+    g.revealAt = this.eng.now;
+    g.resolved = false;
+    g.correct = false;
+    g.answered = "";
+    g.shatter = 0;
+    g.crack = 0;
+    const sub = subdivisionFor(q.answer);
+    g.cells = sub ? sub.cells : null;
+    g.accentEvery = sub ? sub.accentEvery : 2;
+    const wrong = q.distractors.filter((d) => d !== q.answer).slice(0, 2);
+    while (wrong.length < 2) wrong.push(String(wrong.length + 1));
+    const lane = (this.gateSeq * 5) % 3 as Lane;
+    const labels: [string, string, string] = ["", "", ""];
+    labels[lane] = q.answer;
+    let w = 0;
+    for (let i = 0; i < 3; i++) if (i !== lane) labels[i] = wrong[w++]!;
+    g.labels = labels;
+    g.correctLane = lane;
+    this.reviveGate = g;
+  }
+
+  private answerRevive(lane: Lane): void {
+    const g = this.reviveGate;
+    if (!g || g.resolved) return;
+    const correct = lane === g.correctLane;
+    const ms = (this.eng.now - g.revealAt) * 1000;
+    g.resolved = true;
+    g.correct = correct;
+    g.answered = g.labels[lane]!;
+    this.gatesTotal++;
+    if (g.q) this.host.report({ questionId: g.q.id, correct, ms: Math.round(ms), answered: g.answered });
+
+    const t = this.eng.now;
+    if (correct) {
+      this.gatesCorrect++;
+      this.charge = MAX_CHARGE;
+      this.score += 800;
+      this.emit("revive", lane, null, true, 1);
+      this.host.haptic("success");
+      if (this.soundOn) {
+        this.eng.clearFilter(0.35);
+        this.eng.shatter(t, 1, 16);
+        this.eng.riser(t, 0.45, 1);
+        cadence(this.eng, t + 0.1, 60 / this.bpm, this.sector, true);
+      }
+      this.kick(1, 1.08, 0.9);
+    } else {
+      this.charge = 3;
+      this.adjustDifficulty(-1.6);
+      this.emit("gate-wrong", g.correctLane, null, true, 1);
+      this.host.haptic("failure");
+      if (this.soundOn) {
+        this.eng.clearFilter(0.6);
+        this.eng.impact(t, 0.8);
+        const dcells = g.cells ?? 4;
+        const spb = 60 / this.bpm;
+        for (let i = 0; i < Math.min(dcells, 8); i++) {
+          this.eng.bell(t + 0.3 + (i * spb * 4) / Math.min(dcells, 8), this.sector.root + 48, 0.45, 0.4, 0.6);
+        }
+      }
+      this.kick(1, 0.95, 0.7);
+    }
+    this.reviveGate = null;
+    this.activeGate = null;
+    this.phase = "playing";
+    this.applyDifficulty();
+    this.cells = clamp(this.cells, 2, this.maxCells);
+    this.reanchorSoft();
+  }
+
+  /* ---------------------------------------------------------------- */
+  /* input                                                             */
+  /* ---------------------------------------------------------------- */
+
+  laneFromKey(key: string): Lane | undefined {
+    return KEY_LANE[key] ?? KEY_LANE[key.toLowerCase()];
+  }
+
+  /** `at` is an AudioContext-domain timestamp. */
+  hit(lane: Lane, at: number): void {
+    if (this.phase === "breakdown") {
+      this.answerRevive(lane);
+      return;
+    }
+    if (this.phase !== "playing") return;
+
+    const t = this.judgeTime(at);
+    if (t < this.laneLock[lane]!) return;
+
+    let best: Note | null = null;
+    let bestAbs = Infinity;
+    for (const n of this.notes) {
+      if (!n.active || n.state !== 0 || n.lane !== lane) continue;
+      const d = t - n.time;
+      const a = d < 0 ? -d : d;
+      if (a < bestAbs) {
+        bestAbs = a;
+        best = n;
+      }
+    }
+
+    if (best) {
+      const w = windowsFor(best.spacing);
+      const delta = t - best.time;
+      const v = verdictFor(delta, w);
+      if (v && v !== "miss") {
+        this.strike(best, v, delta);
+        return;
+      }
+      if (v === "miss") {
+        // Inside the outer window but outside "good": a real, cheap mistake.
+        this.strike(best, "miss", delta);
+        return;
+      }
+    }
+
+    // Nothing there. Cheap, but it locks the lane briefly so mashing is not a
+    // free win — that lock is what makes a wrong answer at a gate cost you.
+    this.laneLock[lane] = t + 0.11;
+    this.emit("ghost", lane, null, false, 0.4);
+    if (this.soundOn) this.eng.tick(this.eng.now, 1);
+  }
+
+  private strike(n: Note, v: Verdict, delta: number): void {
+    n.state = v === "miss" ? 2 : 1;
+    n.verdict = v;
+    n.delta = delta;
+    n.hitAt = this.eng.now;
+    this.lastDelta = delta;
+    this.lastVerdict = v;
+    this.lastJudgeAt = this.eng.now;
+
+    if (n.isChoice) {
+      const g = this.gates.find((x) => x.active && x.id === n.gateId);
+      // Every choice tile in the row is spent the moment one is struck.
+      for (const o of this.notes) if (o.active && o.isChoice && o.gateId === n.gateId && o !== n) o.state = 2;
+      if (g) this.resolveGate(g, n.label, n.correct, (this.eng.now - g.revealAt) * 1000);
+      return;
+    }
+
+    if (v === "miss") {
+      this.registerMiss(n, true);
+      return;
+    }
+
+    this.notesHit++;
+    this.combo++;
+    if (this.combo > this.bestCombo) this.bestCombo = this.combo;
+    this.perfectRun = v === "perfect" ? this.perfectRun + 1 : 0;
+    if (this.perfectRun > 0 && this.perfectRun % 12 === 0 && this.charge < MAX_CHARGE) {
+      this.charge++;
+      this.emit("charge-up", n.lane, v, true, 1);
+      if (this.soundOn) this.eng.chirp(this.eng.now, 700, 1500, 0.2, 0.7);
+    }
+    this.score += VERDICT_SCORE[v] * multiplierFor(this.combo) * (n.accent ? 2 : 1);
+
+    const t = this.eng.now;
+    if (this.soundOn) {
+      const power = v === "perfect" ? 1 : v === "great" ? 0.82 : 0.6;
+      const g = power * (n.accent ? 1.15 : 1);
+      // Pitch drifts a touch with the note's place in the bar so a 16-note run
+      // reads as a phrase rather than a machine gun.
+      const tune = 1 + ((n.cell / Math.max(1, n.cells)) - 0.5) * 0.06;
+      if (n.lane === 0) this.eng.kick(t, g, tune);
+      else if (n.lane === 1) this.eng.snare(t, g, tune);
+      else this.eng.hat(t, g * 1.1, n.accent);
+      if (v === "perfect" && n.accent) {
+        this.eng.bell(t, this.sector.root + 48 + (n.cell % 5) * 2, 0.35, 0.35, 0.5);
+      }
+    }
+    this.host.haptic(v === "perfect" ? "medium" : "light");
+    this.emit("hit", n.lane, v, n.accent, v === "perfect" ? 1 : v === "great" ? 0.75 : 0.5);
+
+    const mag = (v === "perfect" ? 1 : v === "great" ? 0.7 : 0.4) * (n.accent ? 1.5 : 1);
+    this.kick(mag, 1 + 0.012 * mag, 0.16 * mag);
+    this.fx.laneFlash[n.lane] = Math.min(1, this.fx.laneFlash[n.lane]! + 0.5 + mag * 0.5);
+  }
+
+  private registerMiss(n: Note, struck: boolean): void {
+    n.state = 2;
+    this.notesMissed++;
+    this.combo = 0;
+    this.perfectRun = 0;
+    this.charge -= 1;
+    this.lastVerdict = "miss";
+    this.lastJudgeAt = this.eng.now;
+    this.emit("miss", n.lane, "miss", n.accent, struck ? 0.7 : 1);
+    this.host.haptic("failure");
+    if (this.soundOn) this.eng.thud(this.eng.now, struck ? 0.7 : 1);
+    this.kick(0.7, 0.985, 0.5);
+    this.fx.vignette = Math.min(1, this.fx.vignette + 0.55);
+    if (this.charge <= 0) this.enterBreakdown();
+  }
+
+  /* ---------------------------------------------------------------- */
+  /* frame                                                             */
+  /* ---------------------------------------------------------------- */
+
+  private kick(shake: number, zoom: number, chroma: number): void {
+    if (this.reduced) {
+      this.fx.flash = Math.min(0.35, this.fx.flash + shake * 0.12);
+      return;
+    }
+    this.fx.shake = Math.min(2.2, this.fx.shake + shake);
+    this.fx.shakeAngle = Math.random() * Math.PI * 2;
+    this.fx.zoom = Math.max(this.fx.zoom, zoom);
+    this.fx.chroma = Math.min(1.4, this.fx.chroma + chroma);
+  }
+
+  /** True hitstop, but only when it cannot desynchronise a note. */
+  private requestHitstop(seconds: number): void {
+    if (this.reduced) return;
+    const now = this.eng.now;
+    for (const n of this.notes) {
+      if (n.active && n.state === 0 && n.time - now < 0.35) return;
+    }
+    this.fx.hitstopUntil = now + seconds;
+  }
+
+  /** Called once per rendered frame. `dt` is real seconds. */
+  update(dt: number): void {
+    const now = this.eng.now;
+    const f = this.fx;
+    const k = Math.min(1, dt * 60);
+
+    f.shake *= Math.pow(0.0016, dt);
+    f.chroma *= Math.pow(0.0006, dt);
+    f.flash *= Math.pow(0.00005, dt);
+    f.vignette *= Math.pow(0.06, dt);
+    f.zoom += (1 - f.zoom) * Math.min(1, k * 0.22);
+    for (let i = 0; i < 3; i++) f.laneFlash[i] = f.laneFlash[i]! * Math.pow(0.004, dt);
+    if (this.sectorFlash > 0) this.sectorFlash = Math.max(0, this.sectorFlash - dt * 0.35);
+
+    if (this.phase !== "playing") return;
+
+    // Retire notes and register misses.
+    for (const n of this.notes) {
+      if (!n.active) continue;
+      const w = windowsFor(n.spacing);
+      if (n.state === 0 && now - n.time > w.miss) {
+        if (n.isChoice) {
+          const g = this.gates.find((x) => x.active && x.id === n.gateId);
+          n.state = 2;
+          if (g && !g.resolved) {
+            for (const o of this.notes) if (o.active && o.isChoice && o.gateId === n.gateId) o.state = 2;
+            this.resolveGate(g, "", false, (now - g.revealAt) * 1000);
+          }
+        } else {
+          this.registerMiss(n, false);
+        }
+      }
+      if (now - n.time > 0.9) n.active = false;
+    }
+
+    for (const g of this.gates) {
+      if (!g.active) continue;
+      if (g.resolved) {
+        if (g.correct) g.shatter = Math.min(1, g.shatter + dt * 2.2);
+        else g.crack = Math.min(1, g.crack + dt * 2.2);
+        if (now - g.time > 2.4) {
+          g.active = false;
+          if (this.activeGate === g) this.activeGate = null;
+        }
+      } else {
+        g.crack = clamp(1 - (g.time - now) / 2.2, 0, 0.92);
+      }
+    }
+
+    this.eng.setMusicGain(0.5 + layerFor(this.combo) * 0.05, 0.5);
+  }
+
+  get accuracy(): number {
+    const total = this.notesHit + this.notesMissed;
+    return total === 0 ? 1 : this.notesHit / total;
+  }
+}

--- a/dynawalla/games/rhythm/src/game/judge.ts
+++ b/dynawalla/games/rhythm/src/game/judge.ts
@@ -1,0 +1,76 @@
+/**
+ * Timing judgement.
+ *
+ * The windows are deliberately generous — this is a children's product, and the
+ * difficulty should come from what is being asked, never from demanding
+ * millisecond precision. For reference, DDR's "Great" is about ±92ms and osu!'s
+ * mid-difficulty 100-window is about ±100ms; Splitbeat's *Good* reaches ±155ms.
+ *
+ * The one place they tighten is when notes get close together: a ±155ms window
+ * on a 16th-note run at 150bpm (100ms apart) would let one tap claim three
+ * different notes. So every window is clamped to a fraction of the current
+ * spacing. That clamp is the difference between a run feeling crisp and feeling
+ * like mush.
+ */
+
+export type Verdict = "perfect" | "great" | "good" | "miss";
+
+export type Windows = { perfect: number; great: number; good: number; miss: number };
+
+export const BASE_WINDOWS: Windows = {
+  perfect: 0.058,
+  great: 0.105,
+  good: 0.155,
+  miss: 0.205,
+};
+
+/** `spacing` is seconds between adjacent notes in the densest active lane. */
+export function windowsFor(spacing: number): Windows {
+  // The 45ms floor stops the windows collapsing to nothing on a dense bar, but
+  // it must never grow past half the gap between two notes — if it did, one tap
+  // would sit inside two notes' windows at once and the nearest-note search
+  // would silently eat the wrong one.
+  const cap = Math.min(spacing * 0.5, Math.max(0.045, spacing * 0.46));
+  return {
+    perfect: Math.min(BASE_WINDOWS.perfect, cap * 0.34),
+    great: Math.min(BASE_WINDOWS.great, cap * 0.62),
+    good: Math.min(BASE_WINDOWS.good, cap * 0.86),
+    miss: Math.min(BASE_WINDOWS.miss, cap),
+  };
+}
+
+/** `delta` is (hitTime - noteTime); sign is kept by the caller for the meter. */
+export function verdictFor(delta: number, w: Windows): Verdict | null {
+  const a = Math.abs(delta);
+  if (a <= w.perfect) return "perfect";
+  if (a <= w.great) return "great";
+  if (a <= w.good) return "good";
+  if (a <= w.miss) return "miss";
+  return null; // not this note's business at all
+}
+
+export const VERDICT_SCORE: Record<Verdict, number> = {
+  perfect: 100,
+  great: 62,
+  good: 28,
+  miss: 0,
+};
+
+/** Combo multiplier: climbs fast early so it is felt, then caps. */
+export function multiplierFor(combo: number): number {
+  if (combo < 8) return 1;
+  if (combo < 20) return 2;
+  if (combo < 40) return 3;
+  if (combo < 70) return 4;
+  if (combo < 110) return 6;
+  return 8;
+}
+
+/** How much of the band is playing, from the same combo ladder. */
+export function layerFor(combo: number): number {
+  if (combo < 8) return 0;
+  if (combo < 20) return 1;
+  if (combo < 40) return 2;
+  if (combo < 80) return 3;
+  return 4;
+}

--- a/dynawalla/games/rhythm/src/index.ts
+++ b/dynawalla/games/rhythm/src/index.ts
@@ -1,0 +1,342 @@
+/**
+ * Splitbeat — mount point.
+ *
+ * Input timing is the subtle part. A pointer or key event carries a timestamp in
+ * the `performance.now()` epoch, but every note lives in the `AudioContext`
+ * epoch, and the two are unrelated. Each frame records both clocks; an event is
+ * converted with `audio = audioAtFrame + (event.timeStamp - perfAtFrame)/1000`.
+ * Judging against `performance.now()` directly would add a whole frame of
+ * jitter — 16ms, which is a third of the Perfect window.
+ */
+
+import type { Host, Mount } from "./contract.ts";
+import { Game, type Lane } from "./game/core.ts";
+import { Renderer } from "./render/renderer.ts";
+import { autoTier, type Tier } from "./theme.ts";
+
+const CSS = `
+.sb-root{position:absolute;inset:0;overflow:hidden;background:#05060f;
+  font-family:"Inter","SF Pro Display","Segoe UI",system-ui,-apple-system,sans-serif;
+  color:#eaf2ff;-webkit-user-select:none;user-select:none;touch-action:none}
+.sb-canvas{position:absolute;inset:0;width:100%;height:100%;display:block}
+.sb-overlay{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;
+  flex-direction:column;gap:2.2vh;text-align:center;padding:4vmin;
+  background:radial-gradient(120% 90% at 50% 40%,rgba(10,16,48,.72),rgba(3,4,12,.94));
+  backdrop-filter:blur(3px)}
+.sb-title{font-size:clamp(38px,11vmin,120px);font-weight:900;letter-spacing:-.03em;margin:0;
+  background:linear-gradient(96deg,#7ee8ff 0%,#ff6fae 55%,#ffb45c 100%);
+  -webkit-background-clip:text;background-clip:text;color:transparent;line-height:.95}
+.sb-sub{font-size:clamp(12px,2.5vmin,19px);font-weight:600;letter-spacing:.16em;
+  color:rgba(190,215,255,.72);margin:0;text-transform:uppercase}
+.sb-btn{appearance:none;border:2px solid rgba(150,220,255,.85);background:rgba(10,18,44,.9);
+  color:#fff;font:800 clamp(15px,3.4vmin,24px)/1 inherit;letter-spacing:.14em;
+  padding:1.05em 2.4em;border-radius:999px;cursor:pointer;transition:transform .12s,box-shadow .12s;
+  box-shadow:0 0 0 0 rgba(120,220,255,.5)}
+.sb-btn:hover,.sb-btn:focus-visible{transform:translateY(-2px);box-shadow:0 0 34px 2px rgba(120,220,255,.4);outline:none}
+.sb-btn:active{transform:translateY(1px)}
+.sb-legend{display:flex;gap:1.4vmin;flex-wrap:wrap;justify-content:center;margin-top:1vh}
+.sb-chip{display:flex;align-items:center;gap:.6em;font-size:clamp(10px,1.9vmin,14px);font-weight:700;
+  letter-spacing:.1em;padding:.55em 1em;border-radius:10px;background:rgba(255,255,255,.05);
+  border:1px solid rgba(255,255,255,.1)}
+.sb-dot{width:1.05em;height:1.05em;flex:none}
+.sb-gear{position:absolute;top:max(8px,env(safe-area-inset-top));right:max(8px,env(safe-area-inset-right));
+  width:40px;height:40px;border-radius:12px;border:1px solid rgba(255,255,255,.16);
+  background:rgba(6,10,26,.72);color:#cfe4ff;font:800 17px/1 inherit;cursor:pointer;z-index:6}
+.sb-panel{position:absolute;top:56px;right:max(8px,env(safe-area-inset-right));width:min(290px,86vw);
+  background:rgba(6,10,26,.96);border:1px solid rgba(255,255,255,.14);border-radius:16px;
+  padding:16px;display:grid;gap:14px;z-index:6;box-shadow:0 18px 60px rgba(0,0,0,.6)}
+.sb-row{display:grid;gap:7px}
+.sb-lab{font-size:11px;font-weight:800;letter-spacing:.14em;color:rgba(180,205,240,.72);text-transform:uppercase}
+.sb-seg{display:flex;gap:6px}
+.sb-seg button{flex:1;appearance:none;border:1px solid rgba(255,255,255,.16);background:rgba(255,255,255,.04);
+  color:#dceaff;font:700 12px/1 inherit;padding:9px 0;border-radius:9px;cursor:pointer;letter-spacing:.06em}
+.sb-seg button[aria-pressed=true]{background:rgba(120,220,255,.22);border-color:rgba(120,220,255,.75);color:#fff}
+.sb-panel input[type=range]{width:100%;accent-color:#7ee8ff}
+.sb-val{font:700 12px/1 inherit;color:rgba(190,215,255,.8)}
+.sb-perf{position:absolute;left:6px;bottom:6px;font:700 11px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace;
+  color:rgba(150,200,255,.75);z-index:5;pointer-events:none;white-space:pre}
+.sb-hide{display:none!important}
+@media (prefers-reduced-motion:reduce){.sb-btn{transition:none}}
+`;
+
+export const mount: Mount = (el: HTMLElement, host: Host) => {
+  const root = document.createElement("div");
+  root.className = "sb-root";
+  const style = document.createElement("style");
+  style.textContent = CSS;
+  root.appendChild(style);
+
+  const canvas = document.createElement("canvas");
+  canvas.className = "sb-canvas";
+  root.appendChild(canvas);
+  el.appendChild(root);
+
+  let game: Game;
+  try {
+    game = new Game(host);
+  } catch (err) {
+    console.error("[splitbeat] could not create the audio engine", err);
+    const msg = document.createElement("div");
+    msg.className = "sb-overlay";
+    msg.innerHTML = `<p class="sb-sub">Audio is unavailable on this device.</p>`;
+    root.appendChild(msg);
+    return { unmount: () => el.removeChild(root) };
+  }
+
+  let tier: Tier = autoTier();
+  const renderer = new Renderer(canvas, game, tier);
+
+  /* ---------------- start screen ---------------- */
+  const overlay = document.createElement("div");
+  overlay.className = "sb-overlay";
+  const laneChips = [
+    ["LOW", "#ff9c38", "A / J / ↓"],
+    ["MID", "#ff4d8d", "S / K / →"],
+    ["HIGH", "#4ee2ff", "D / L / ↑"],
+  ]
+    .map(
+      ([n, c, k]) =>
+        `<span class="sb-chip"><svg class="sb-dot" viewBox="0 0 10 10" aria-hidden="true"><circle cx="5" cy="5" r="4.4" fill="${c}"/></svg>${n}<span style="opacity:.5">${k}</span></span>`,
+    )
+    .join("");
+  overlay.innerHTML =
+    `<h1 class="sb-title">SPLITBEAT</h1>` +
+    `<p class="sb-sub">Play the bar. Split the beat.</p>` +
+    `<button class="sb-btn" type="button">PLAY</button>` +
+    `<p class="sb-sub" style="letter-spacing:.1em;opacity:.62">Tap the lane on the beat</p>` +
+    `<div class="sb-legend">${laneChips}</div>`;
+  root.appendChild(overlay);
+  const playBtn = overlay.querySelector("button")!;
+
+  /* ---------------- settings ---------------- */
+  const gear = document.createElement("button");
+  gear.className = "sb-gear";
+  gear.type = "button";
+  gear.setAttribute("aria-label", "Settings");
+  gear.textContent = "⚙";
+  root.appendChild(gear);
+
+  const panel = document.createElement("div");
+  panel.className = "sb-panel sb-hide";
+  panel.innerHTML = `
+    <div class="sb-row"><span class="sb-lab">Sound</span>
+      <div class="sb-seg" data-k="sound">
+        <button type="button" data-v="on" aria-pressed="true">ON</button>
+        <button type="button" data-v="off" aria-pressed="false">OFF</button>
+      </div></div>
+    <div class="sb-row"><span class="sb-lab">Quality</span>
+      <div class="sb-seg" data-k="tier">
+        <button type="button" data-v="low" aria-pressed="false">LOW</button>
+        <button type="button" data-v="mid" aria-pressed="false">MID</button>
+        <button type="button" data-v="ultra" aria-pressed="false">ULTRA</button>
+      </div></div>
+    <div class="sb-row"><span class="sb-lab">Motion</span>
+      <div class="sb-seg" data-k="motion">
+        <button type="button" data-v="full" aria-pressed="true">FULL</button>
+        <button type="button" data-v="reduced" aria-pressed="false">REDUCED</button>
+      </div></div>
+    <div class="sb-row"><span class="sb-lab">Timing offset <span class="sb-val" data-cal>0 ms</span></span>
+      <input type="range" min="-150" max="150" step="5" value="0" aria-label="Timing offset in milliseconds" />
+    </div>`;
+  root.appendChild(panel);
+
+  const perfBox = document.createElement("div");
+  perfBox.className = "sb-perf sb-hide";
+  root.appendChild(perfBox);
+  const showPerf = new URLSearchParams(location.search).has("perf");
+  if (showPerf) perfBox.classList.remove("sb-hide");
+
+  const syncSeg = (k: string, v: string) => {
+    panel.querySelectorAll<HTMLButtonElement>(`[data-k="${k}"] button`).forEach((b) => {
+      b.setAttribute("aria-pressed", String(b.dataset.v === v));
+    });
+  };
+  syncSeg("tier", tier);
+  syncSeg("motion", game.reduced ? "reduced" : "full");
+
+  panel.addEventListener("click", (e) => {
+    const b = (e.target as HTMLElement).closest("button");
+    if (!b) return;
+    const k = b.parentElement?.getAttribute("data-k");
+    const v = b.dataset.v!;
+    if (k === "sound") {
+      game.soundOn = v === "on";
+      game.eng.setMuted(v !== "on");
+    } else if (k === "tier") {
+      tier = v as Tier;
+      renderer.setTier(tier);
+    } else if (k === "motion") {
+      game.reduced = v === "reduced";
+    }
+    if (k) syncSeg(k, v);
+  });
+
+  const cal = panel.querySelector<HTMLInputElement>("input[type=range]")!;
+  const calOut = panel.querySelector<HTMLElement>("[data-cal]")!;
+  cal.addEventListener("input", () => {
+    const ms = Number(cal.value);
+    game.calibration = ms / 1000;
+    calOut.textContent = `${ms > 0 ? "+" : ""}${ms} ms`;
+  });
+
+  gear.addEventListener("click", () => {
+    const open = panel.classList.toggle("sb-hide");
+    if (!open) game.pause();
+    else game.resumeFromPause();
+  });
+
+  /* ---------------- input ---------------- */
+  let perfAtFrame = performance.now();
+  let audioAtFrame = 0;
+
+  const toAudioTime = (stamp: number): number => {
+    // Some engines hand out timestamps in a different epoch; fall back rather
+    // than judge against nonsense.
+    const d = stamp - perfAtFrame;
+    if (!isFinite(d) || Math.abs(d) > 5000) return game.audioNow;
+    return audioAtFrame + d / 1000;
+  };
+
+  const onPointer = (e: PointerEvent) => {
+    if (panel.contains(e.target as Node) || gear.contains(e.target as Node)) return;
+    e.preventDefault();
+    if (game.phase === "title") {
+      void begin();
+      return;
+    }
+    if (!panel.classList.contains("sb-hide")) return;
+    const rect = canvas.getBoundingClientRect();
+    const lane = renderer.laneFromY(e.clientY - rect.top);
+    game.hit(lane, toAudioTime(e.timeStamp));
+  };
+
+  const onKey = (e: KeyboardEvent) => {
+    if (e.repeat) return;
+    if (e.key === "Escape") {
+      panel.classList.toggle("sb-hide");
+      if (panel.classList.contains("sb-hide")) game.resumeFromPause();
+      else game.pause();
+      return;
+    }
+    const lane = game.laneFromKey(e.key);
+    if (lane === undefined) return;
+    e.preventDefault();
+    if (game.phase === "title") {
+      void begin();
+      return;
+    }
+    game.hit(lane as Lane, toAudioTime(e.timeStamp));
+  };
+
+  root.addEventListener("pointerdown", onPointer, { passive: false });
+  window.addEventListener("keydown", onKey, { passive: false });
+
+  const onVisibility = () => {
+    if (document.hidden) game.pause();
+  };
+  document.addEventListener("visibilitychange", onVisibility);
+
+  const ro = new ResizeObserver(() => renderer.resize());
+  ro.observe(root);
+  window.addEventListener("orientationchange", () => renderer.resize());
+
+  /* ---------------- loop ---------------- */
+  let raf = 0;
+  let last = performance.now();
+  let frames = 0;
+  let acc = 0;
+  let fps = 60;
+  let worst = 0;
+  let slowWindows = 0;
+  let alive = true;
+
+  const loop = () => {
+    if (!alive) return;
+    raf = requestAnimationFrame(loop);
+    const t = performance.now();
+    let dt = (t - last) / 1000;
+    last = t;
+    if (dt > 0.1) dt = 0.1; // a tab that was backgrounded must not teleport
+    perfAtFrame = t;
+    audioAtFrame = game.audioNow;
+
+    game.eng.pollSpectrum();
+    game.update(dt);
+    renderer.frame(dt, audioAtFrame);
+
+    frames++;
+    acc += dt;
+    if (dt > worst) worst = dt;
+    if (acc >= 1) {
+      fps = frames / acc;
+      if (showPerf) {
+        perfBox.textContent =
+          `${fps.toFixed(1)} fps  worst ${(worst * 1000).toFixed(1)}ms\n` +
+          `tier ${tier}  dpr ${(window.devicePixelRatio || 1).toFixed(1)}  ${renderer.W}x${renderer.H}\n` +
+          `sparks ${renderer.particles.liveSparks}  notes ${game.notes.filter((n) => n.active).length}\n` +
+          `lv ${game.difficulty.toFixed(2)}  bpm ${game.bpm.toFixed(0)}  cells ${game.cells}  combo ${game.combo}`;
+      }
+      // Automatic, one-way relief valve: never upgrade behind the player's back.
+      if (fps < 50 && tier !== "low") {
+        slowWindows++;
+        if (slowWindows >= 2) {
+          tier = tier === "ultra" ? "mid" : "low";
+          renderer.setTier(tier);
+          syncSeg("tier", tier);
+          slowWindows = 0;
+          console.warn(`[splitbeat] sustained ${fps.toFixed(1)}fps — dropping to ${tier}`);
+        }
+      } else {
+        slowWindows = 0;
+      }
+      frames = 0;
+      acc = 0;
+      worst = 0;
+    }
+  };
+
+  async function begin(): Promise<void> {
+    overlay.classList.add("sb-hide");
+    try {
+      await game.start();
+    } catch (err) {
+      console.error("[splitbeat] failed to start", err);
+    }
+  }
+  playBtn.addEventListener("click", () => void begin());
+
+  renderer.resize();
+  raf = requestAnimationFrame(loop);
+
+  // A small debug handle: measuring fps from the outside is otherwise guesswork.
+  (window as unknown as Record<string, unknown>).__splitbeat = {
+    get fps() { return fps; },
+    get tier() { return tier; },
+    get state() {
+      return {
+        phase: game.phase, score: game.score, combo: game.combo, charge: game.charge,
+        difficulty: game.difficulty, bpm: game.bpm, cells: game.cells,
+        gates: game.gatesTotal, correct: game.gatesCorrect,
+        accuracy: game.accuracy, notesHit: game.notesHit, notesMissed: game.notesMissed,
+      };
+    },
+    setTier: (t: Tier) => { tier = t; renderer.setTier(t); syncSeg("tier", t); },
+    game, renderer,
+  };
+
+  return {
+    unmount() {
+      alive = false;
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+      root.removeEventListener("pointerdown", onPointer);
+      window.removeEventListener("keydown", onKey);
+      document.removeEventListener("visibilitychange", onVisibility);
+      game.destroy();
+      delete (window as unknown as Record<string, unknown>).__splitbeat;
+      if (root.parentNode === el) el.removeChild(root);
+    },
+  };
+};
+
+export type { Host, Question, Mount } from "./contract.ts";

--- a/dynawalla/games/rhythm/src/main.ts
+++ b/dynawalla/games/rhythm/src/main.ts
@@ -1,0 +1,18 @@
+/** Standalone dev entry: the game plus the local stub host. `npm run dev`. */
+
+import { mount } from "./index.ts";
+import { createStubHost } from "./stubHost.ts";
+
+const el = document.getElementById("stage");
+if (!el) throw new Error("[splitbeat] #stage missing");
+
+const params = new URLSearchParams(location.search);
+const host = createStubHost({
+  seed: Number(params.get("seed") ?? 20260726) >>> 0,
+  // ?musical=0 feeds plain arithmetic only, to prove the game degrades
+  // gracefully when an answer is not a playable subdivision.
+  musical: params.get("musical") !== "0",
+});
+
+const handle = mount(el, host);
+(window as unknown as Record<string, unknown>).__unmount = () => handle.unmount();

--- a/dynawalla/games/rhythm/src/render/particles.ts
+++ b/dynawalla/games/rhythm/src/render/particles.ts
@@ -1,0 +1,321 @@
+/**
+ * Pooled particle system. Nothing in here allocates after construction — the
+ * pools are typed arrays, the colours are palette indices rather than strings,
+ * and dead particles are overwritten in a ring rather than spliced.
+ *
+ * Glow is drawn by blitting a pre-baked radial sprite per colour instead of
+ * calling `arc()` a thousand times a frame. On the low tier that is the
+ * difference between 60fps and 40.
+ */
+
+import { rgba, type Rgb } from "../theme.ts";
+
+export const PAL_LANE0 = 0;
+export const PAL_LANE1 = 1;
+export const PAL_LANE2 = 2;
+export const PAL_WHITE = 3;
+export const PAL_HORIZON = 4;
+export const PAL_BLOOM = 5;
+export const PAL_GOLD = 6;
+export const PAL_DIM = 7;
+const PAL_COUNT = 8;
+
+const SPRITE = 64;
+
+export class Particles {
+  private palette: Rgb[] = [
+    [255, 156, 56],
+    [255, 77, 141],
+    [78, 226, 255],
+    [255, 255, 255],
+    [120, 205, 255],
+    [70, 110, 255],
+    [255, 226, 138],
+    [110, 120, 150],
+  ];
+  private sprites: HTMLCanvasElement[] = [];
+
+  // --- sparks (structure of arrays) ---
+  private sx: Float32Array;
+  private sy: Float32Array;
+  private svx: Float32Array;
+  private svy: Float32Array;
+  private slife: Float32Array;
+  private smax: Float32Array;
+  private ssize: Float32Array;
+  private sdrag: Float32Array;
+  private sgrav: Float32Array;
+  private spal: Uint8Array;
+  private skind: Uint8Array; // 0 glow dot, 1 streak
+  private scur = 0;
+  readonly sparkCap: number;
+
+  // --- shards ---
+  private hx: Float32Array;
+  private hy: Float32Array;
+  private hvx: Float32Array;
+  private hvy: Float32Array;
+  private hrot: Float32Array;
+  private hvrot: Float32Array;
+  private hlife: Float32Array;
+  private hmax: Float32Array;
+  private hsize: Float32Array;
+  private hpal: Uint8Array;
+  private hcur = 0;
+  readonly shardCap: number;
+
+  // --- rings ---
+  private rx: Float32Array;
+  private ry: Float32Array;
+  private rr0: Float32Array;
+  private rr1: Float32Array;
+  private rlife: Float32Array;
+  private rmax: Float32Array;
+  private rw: Float32Array;
+  private rpal: Uint8Array;
+  private rsquare: Uint8Array;
+  private rcur = 0;
+  readonly ringCap: number;
+
+  // --- floating labels ---
+  private fx: Float32Array;
+  private fy: Float32Array;
+  private fvy: Float32Array;
+  private flife: Float32Array;
+  private fmax: Float32Array;
+  private fsize: Float32Array;
+  private fpal: Uint8Array;
+  private ftext: string[] = [];
+  private fcur = 0;
+  readonly floatCap = 20;
+
+  constructor(sparks: number, shards: number, rings: number) {
+    this.sparkCap = sparks;
+    this.shardCap = shards;
+    this.ringCap = rings;
+    const f = (n: number) => new Float32Array(n);
+    this.sx = f(sparks); this.sy = f(sparks); this.svx = f(sparks); this.svy = f(sparks);
+    this.slife = f(sparks); this.smax = f(sparks); this.ssize = f(sparks);
+    this.sdrag = f(sparks); this.sgrav = f(sparks);
+    this.spal = new Uint8Array(sparks); this.skind = new Uint8Array(sparks);
+
+    this.hx = f(shards); this.hy = f(shards); this.hvx = f(shards); this.hvy = f(shards);
+    this.hrot = f(shards); this.hvrot = f(shards); this.hlife = f(shards);
+    this.hmax = f(shards); this.hsize = f(shards); this.hpal = new Uint8Array(shards);
+
+    this.rx = f(rings); this.ry = f(rings); this.rr0 = f(rings); this.rr1 = f(rings);
+    this.rlife = f(rings); this.rmax = f(rings); this.rw = f(rings);
+    this.rpal = new Uint8Array(rings); this.rsquare = new Uint8Array(rings);
+
+    this.fx = f(this.floatCap); this.fy = f(this.floatCap); this.fvy = f(this.floatCap);
+    this.flife = f(this.floatCap); this.fmax = f(this.floatCap); this.fsize = f(this.floatCap);
+    this.fpal = new Uint8Array(this.floatCap);
+    for (let i = 0; i < this.floatCap; i++) this.ftext.push("");
+
+    for (let i = 0; i < PAL_COUNT; i++) this.sprites.push(this.bake(this.palette[i]!));
+  }
+
+  /** Sector colours change; re-bake only the two that depend on the sector. */
+  setSectorColors(horizon: Rgb, bloom: Rgb): void {
+    this.palette[PAL_HORIZON] = horizon;
+    this.palette[PAL_BLOOM] = bloom;
+    this.sprites[PAL_HORIZON] = this.bake(horizon);
+    this.sprites[PAL_BLOOM] = this.bake(bloom);
+  }
+
+  private bake(c: Rgb): HTMLCanvasElement {
+    const cv = document.createElement("canvas");
+    cv.width = cv.height = SPRITE;
+    const g = cv.getContext("2d")!;
+    const grd = g.createRadialGradient(SPRITE / 2, SPRITE / 2, 0, SPRITE / 2, SPRITE / 2, SPRITE / 2);
+    grd.addColorStop(0, rgba(c, 1));
+    grd.addColorStop(0.35, rgba(c, 0.55));
+    grd.addColorStop(1, rgba(c, 0));
+    g.fillStyle = grd;
+    g.fillRect(0, 0, SPRITE, SPRITE);
+    return cv;
+  }
+
+  /* ------------------------------------------------------------ */
+
+  spark(x: number, y: number, vx: number, vy: number, life: number, size: number, pal: number, kind = 0, drag = 2.2, grav = 0): void {
+    const i = this.scur;
+    this.scur = (i + 1) % this.sparkCap;
+    this.sx[i] = x; this.sy[i] = y; this.svx[i] = vx; this.svy[i] = vy;
+    this.slife[i] = life; this.smax[i] = life; this.ssize[i] = size;
+    this.spal[i] = pal; this.skind[i] = kind; this.sdrag[i] = drag; this.sgrav[i] = grav;
+  }
+
+  burst(x: number, y: number, n: number, pal: number, power: number, rnd: () => number, streaks = false): void {
+    for (let i = 0; i < n; i++) {
+      const a = rnd() * Math.PI * 2;
+      const sp = (0.35 + rnd() * 1.0) * power;
+      this.spark(
+        x, y,
+        Math.cos(a) * sp, Math.sin(a) * sp,
+        0.28 + rnd() * 0.5,
+        3 + rnd() * 7 * (power / 300),
+        pal,
+        streaks && rnd() < 0.4 ? 1 : 0,
+        2.0 + rnd() * 2,
+        rnd() * 260,
+      );
+    }
+  }
+
+  shard(x: number, y: number, vx: number, vy: number, life: number, size: number, pal: number, vrot: number): void {
+    const i = this.hcur;
+    this.hcur = (i + 1) % this.shardCap;
+    this.hx[i] = x; this.hy[i] = y; this.hvx[i] = vx; this.hvy[i] = vy;
+    this.hrot[i] = 0; this.hvrot[i] = vrot;
+    this.hlife[i] = life; this.hmax[i] = life; this.hsize[i] = size; this.hpal[i] = pal;
+  }
+
+  ring(x: number, y: number, r0: number, r1: number, life: number, w: number, pal: number, square = false): void {
+    const i = this.rcur;
+    this.rcur = (i + 1) % this.ringCap;
+    this.rx[i] = x; this.ry[i] = y; this.rr0[i] = r0; this.rr1[i] = r1;
+    this.rlife[i] = life; this.rmax[i] = life; this.rw[i] = w;
+    this.rpal[i] = pal; this.rsquare[i] = square ? 1 : 0;
+  }
+
+  floater(x: number, y: number, text: string, size: number, pal: number): void {
+    const i = this.fcur;
+    this.fcur = (i + 1) % this.floatCap;
+    this.fx[i] = x; this.fy[i] = y; this.fvy[i] = -70;
+    this.flife[i] = 0.72; this.fmax[i] = 0.72; this.fsize[i] = size; this.fpal[i] = pal;
+    this.ftext[i] = text;
+  }
+
+  /* ------------------------------------------------------------ */
+
+  update(dt: number): void {
+    for (let i = 0; i < this.sparkCap; i++) {
+      const l = this.slife[i]!;
+      if (l <= 0) continue;
+      this.slife[i] = l - dt;
+      const d = Math.exp(-this.sdrag[i]! * dt);
+      this.svx[i] = this.svx[i]! * d;
+      this.svy[i] = this.svy[i]! * d + this.sgrav[i]! * dt;
+      this.sx[i] = this.sx[i]! + this.svx[i]! * dt;
+      this.sy[i] = this.sy[i]! + this.svy[i]! * dt;
+    }
+    for (let i = 0; i < this.shardCap; i++) {
+      const l = this.hlife[i]!;
+      if (l <= 0) continue;
+      this.hlife[i] = l - dt;
+      this.hvy[i] = this.hvy[i]! + 900 * dt;
+      this.hvx[i] = this.hvx[i]! * Math.exp(-0.6 * dt);
+      this.hx[i] = this.hx[i]! + this.hvx[i]! * dt;
+      this.hy[i] = this.hy[i]! + this.hvy[i]! * dt;
+      this.hrot[i] = this.hrot[i]! + this.hvrot[i]! * dt;
+    }
+    for (let i = 0; i < this.ringCap; i++) {
+      if (this.rlife[i]! <= 0) continue;
+      this.rlife[i] = this.rlife[i]! - dt;
+    }
+    for (let i = 0; i < this.floatCap; i++) {
+      if (this.flife[i]! <= 0) continue;
+      this.flife[i] = this.flife[i]! - dt;
+      this.fy[i] = this.fy[i]! + this.fvy[i]! * dt;
+      this.fvy[i] = this.fvy[i]! * Math.exp(-2.4 * dt);
+    }
+  }
+
+  draw(ctx: CanvasRenderingContext2D, font: (px: number, w?: number) => string): void {
+    ctx.save();
+    ctx.globalCompositeOperation = "lighter";
+
+    // sparks — glow blits
+    for (let i = 0; i < this.sparkCap; i++) {
+      const l = this.slife[i]!;
+      if (l <= 0) continue;
+      const t = l / this.smax[i]!;
+      const s = this.ssize[i]! * (0.4 + t * 1.4);
+      ctx.globalAlpha = t * t;
+      if (this.skind[i] === 1) {
+        const x = this.sx[i]!, y = this.sy[i]!;
+        const px = x - this.svx[i]! * 0.035, py = y - this.svy[i]! * 0.035;
+        ctx.strokeStyle = rgba(this.palette[this.spal[i]!]!, 1);
+        ctx.lineWidth = Math.max(1, s * 0.5);
+        ctx.lineCap = "round";
+        ctx.beginPath();
+        ctx.moveTo(px, py);
+        ctx.lineTo(x, y);
+        ctx.stroke();
+      } else {
+        const sp = this.sprites[this.spal[i]!]!;
+        ctx.drawImage(sp, this.sx[i]! - s, this.sy[i]! - s, s * 2, s * 2);
+      }
+    }
+
+    // rings
+    ctx.globalCompositeOperation = "lighter";
+    for (let i = 0; i < this.ringCap; i++) {
+      const l = this.rlife[i]!;
+      if (l <= 0) continue;
+      const t = 1 - l / this.rmax[i]!;
+      const e = 1 - Math.pow(1 - t, 3);
+      const r = this.rr0[i]! + (this.rr1[i]! - this.rr0[i]!) * e;
+      ctx.globalAlpha = (1 - t) * (1 - t) * 0.9;
+      ctx.strokeStyle = rgba(this.palette[this.rpal[i]!]!, 1);
+      ctx.lineWidth = this.rw[i]! * (1 - t * 0.7);
+      ctx.beginPath();
+      if (this.rsquare[i] === 1) ctx.rect(this.rx[i]! - r, this.ry[i]! - r, r * 2, r * 2);
+      else ctx.arc(this.rx[i]!, this.ry[i]!, Math.max(0.5, r), 0, Math.PI * 2);
+      ctx.stroke();
+    }
+
+    // shards — solid geometry reads better than glow for broken glass
+    ctx.globalCompositeOperation = "source-over";
+    for (let i = 0; i < this.shardCap; i++) {
+      const l = this.hlife[i]!;
+      if (l <= 0) continue;
+      const t = l / this.hmax[i]!;
+      const s = this.hsize[i]!;
+      ctx.save();
+      ctx.translate(this.hx[i]!, this.hy[i]!);
+      ctx.rotate(this.hrot[i]!);
+      ctx.globalAlpha = Math.min(1, t * 1.6);
+      ctx.fillStyle = rgba(this.palette[this.hpal[i]!]!, 0.85);
+      ctx.beginPath();
+      ctx.moveTo(-s, -s * 0.6);
+      ctx.lineTo(s * 0.8, -s);
+      ctx.lineTo(s, s * 0.7);
+      ctx.lineTo(-s * 0.5, s);
+      ctx.closePath();
+      ctx.fill();
+      ctx.restore();
+    }
+
+    // floaters
+    ctx.globalCompositeOperation = "lighter";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    for (let i = 0; i < this.floatCap; i++) {
+      const l = this.flife[i]!;
+      if (l <= 0) continue;
+      const t = l / this.fmax[i]!;
+      ctx.globalAlpha = Math.min(1, t * 1.8);
+      ctx.font = font(this.fsize[i]! * (1 + (1 - t) * 0.15), 900);
+      ctx.fillStyle = rgba(this.palette[this.fpal[i]!]!, 1);
+      ctx.fillText(this.ftext[i]!, this.fx[i]!, this.fy[i]!);
+    }
+
+    ctx.restore();
+  }
+
+  clear(): void {
+    this.slife.fill(0);
+    this.hlife.fill(0);
+    this.rlife.fill(0);
+    this.flife.fill(0);
+  }
+
+  /** live count, for the perf HUD */
+  get liveSparks(): number {
+    let n = 0;
+    for (let i = 0; i < this.sparkCap; i++) if (this.slife[i]! > 0) n++;
+    return n;
+  }
+}

--- a/dynawalla/games/rhythm/src/render/renderer.ts
+++ b/dynawalla/games/rhythm/src/render/renderer.ts
@@ -1,0 +1,1014 @@
+/**
+ * Canvas renderer.
+ *
+ * Why 2D canvas and not Three.js: the whole visual thesis of this game is that
+ * a bar of music is a fraction bar — a straight line cut into equal slices, read
+ * left to right like a number line. That is a 2D idea, and forcing it into a 3D
+ * scene would cost frame budget and legibility to gain nothing. The dazzle comes
+ * from where it belongs in this genre: a skyline cut live from the FFT of the
+ * master bus, a waveform for a horizon, real bloom, and a lot of pooled
+ * particles.
+ *
+ * Legibility rules that are enforced here and are not negotiable:
+ *  - Note glyphs differ by SHAPE as well as colour.
+ *  - Every numeral is heavy grotesque, drawn with a dark contrast pass behind
+ *    it, at a size derived from the short screen axis.
+ *  - Full-screen luminance jumps are rate-limited and amplitude-capped. A
+ *    children's product does not get to strobe.
+ */
+
+import type { Game, Lane } from "../game/core.ts";
+import {
+  LANE_COLOR, LANE_NAME, LANE_SHAPE, font, mix, rgba, themeFor,
+  TIER_SPEC, type Rgb, type Tier,
+} from "../theme.ts";
+import { drawRich, measureRich } from "./typeset.ts";
+import {
+  Particles, PAL_BLOOM, PAL_DIM, PAL_GOLD, PAL_HORIZON, PAL_WHITE,
+} from "./particles.ts";
+
+const LEAD = 1.85; // seconds a note is visible before its strike
+const HISTORY = 110;
+const FLASH_MIN_GAP = 0.34;
+const FLASH_MAX = 0.42;
+
+type Hist = { t: number; lane: Lane; power: number; live: boolean };
+
+export class Renderer {
+  private ctx: CanvasRenderingContext2D;
+  private bloomA: HTMLCanvasElement;
+  private bloomB: HTMLCanvasElement;
+  private noteGlow: HTMLCanvasElement[] = [];
+
+  private dpr = 1;
+  W = 0;
+  H = 0;
+  private playTop = 0;
+  private playH = 0;
+  private laneH = 0;
+  private strikeX = 0;
+  private pps = 200;
+  private u = 10; // type unit, from the short axis
+
+  private spec = TIER_SPEC.mid;
+  tier: Tier = "mid";
+
+  private smoothFar: Float32Array;
+  private smoothNear: Float32Array;
+  private dustX: Float32Array;
+  private dustY: Float32Array;
+  private dustZ: Float32Array;
+
+  private hist: Hist[] = [];
+  private histCur = 0;
+
+  private lastBeat = -1;
+  private beatPulse = 0;
+  private barPulse = 0;
+  private comboPop = 0;
+  private lastFlashAt = -10;
+  private crackSeed: Float32Array;
+
+  constructor(
+    private canvas: HTMLCanvasElement,
+    private game: Game,
+    tier: Tier,
+  ) {
+    const c = canvas.getContext("2d", { alpha: false });
+    if (!c) throw new Error("[splitbeat] 2D canvas context unavailable");
+    this.ctx = c;
+    this.bloomA = document.createElement("canvas");
+    this.bloomB = document.createElement("canvas");
+    this.smoothFar = new Float32Array(TIER_SPEC.ultra.bars);
+    this.smoothNear = new Float32Array(TIER_SPEC.ultra.bars);
+    this.dustX = new Float32Array(TIER_SPEC.ultra.dust);
+    this.dustY = new Float32Array(TIER_SPEC.ultra.dust);
+    this.dustZ = new Float32Array(TIER_SPEC.ultra.dust);
+    this.crackSeed = new Float32Array(64);
+    for (let i = 0; i < this.crackSeed.length; i++) this.crackSeed[i] = Math.random();
+    for (let i = 0; i < HISTORY; i++) this.hist.push({ t: -99, lane: 0, power: 0, live: false });
+    this.particles = new Particles(4, 4, 4); // replaced by setTier
+    this.setTier(tier);
+  }
+
+  particles: Particles;
+
+  setTier(t: Tier): void {
+    this.tier = t;
+    this.spec = TIER_SPEC[t];
+    this.particles = new Particles(this.spec.sparks, this.spec.shards, this.spec.rings);
+    const th = themeFor(this.game.sector.id);
+    this.particles.setSectorColors(th.horizon, th.bloom);
+    this.resize();
+  }
+
+  resize(): void {
+    const w = Math.max(320, this.canvas.clientWidth || window.innerWidth);
+    const h = Math.max(240, this.canvas.clientHeight || window.innerHeight);
+    this.dpr = Math.min(this.spec.maxDpr, window.devicePixelRatio || 1);
+    this.W = w;
+    this.H = h;
+    this.canvas.width = Math.round(w * this.dpr);
+    this.canvas.height = Math.round(h * this.dpr);
+
+    const short = Math.min(w, h);
+    this.u = short / 46;
+    const topPad = Math.max(58, h * 0.155);
+    const botPad = Math.max(40, h * 0.11);
+    this.playTop = topPad;
+    this.playH = Math.max(120, h - topPad - botPad);
+    this.laneH = this.playH / 3;
+    this.strikeX = Math.min(Math.max(w * 0.235, 62), 240);
+    this.pps = (w - this.strikeX) / LEAD;
+
+    const bw = Math.max(64, Math.round(this.canvas.width / 4));
+    const bh = Math.max(48, Math.round(this.canvas.height / 4));
+    this.bloomA.width = bw;
+    this.bloomA.height = bh;
+    this.bloomB.width = Math.max(32, bw >> 1);
+    this.bloomB.height = Math.max(24, bh >> 1);
+
+    for (let i = 0; i < this.dustX.length; i++) {
+      this.dustX[i] = Math.random() * w;
+      this.dustY[i] = Math.random() * h;
+      this.dustZ[i] = 0.2 + Math.random() * 1.4;
+    }
+    this.bakeNoteGlow();
+  }
+
+  private bakeNoteGlow(): void {
+    this.noteGlow = [];
+    const r = Math.max(24, Math.round(this.laneH * 0.9));
+    for (let l = 0; l < 3; l++) {
+      const cv = document.createElement("canvas");
+      cv.width = cv.height = r * 2;
+      const g = cv.getContext("2d")!;
+      const grd = g.createRadialGradient(r, r, 0, r, r, r);
+      const c = LANE_COLOR[l]!;
+      grd.addColorStop(0, rgba(c, 0.95));
+      grd.addColorStop(0.28, rgba(c, 0.42));
+      grd.addColorStop(1, rgba(c, 0));
+      g.fillStyle = grd;
+      g.fillRect(0, 0, r * 2, r * 2);
+      this.noteGlow.push(cv);
+    }
+  }
+
+  /** screen y of a lane's centre — lane 0 (low) sits at the bottom */
+  laneY(l: number): number {
+    return this.playTop + (2 - l) * this.laneH + this.laneH / 2;
+  }
+
+  laneFromY(y: number): Lane {
+    const rel = (y - this.playTop) / this.laneH;
+    const idx = 2 - Math.floor(rel);
+    return Math.max(0, Math.min(2, idx)) as Lane;
+  }
+
+  private xAt(t: number, now: number): number {
+    return this.strikeX + (t - now) * this.pps;
+  }
+
+  /* ================================================================ */
+
+  frame(dt: number, now: number): void {
+    const g = this.game;
+    const ctx = this.ctx;
+    const th = themeFor(g.sector.id);
+
+    this.drainEvents(now);
+    this.particles.update(dt);
+    if (this.comboPop > 0) this.comboPop = Math.max(0, this.comboPop - dt * 3.4);
+    if (this.beatPulse > 0) this.beatPulse = Math.max(0, this.beatPulse - dt * 3.2);
+    if (this.barPulse > 0) this.barPulse = Math.max(0, this.barPulse - dt * 2.1);
+    this.trackBeat(now);
+
+    ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
+    ctx.globalCompositeOperation = "source-over";
+    ctx.globalAlpha = 1;
+
+    // sky
+    const grd = ctx.createLinearGradient(0, 0, 0, this.H);
+    const lift = Math.min(0.35, this.beatPulse * 0.22 + g.fx.flash * 0.4);
+    grd.addColorStop(0, `rgb(${th.skyTop[0]},${th.skyTop[1]},${th.skyTop[2]})`);
+    grd.addColorStop(0.55, `rgb(${mix(th.skyTop, th.skyBottom, 0.75 + lift)[0]},${mix(th.skyTop, th.skyBottom, 0.75 + lift)[1]},${mix(th.skyTop, th.skyBottom, 0.75 + lift)[2]})`);
+    grd.addColorStop(1, `rgb(${th.skyBottom[0]},${th.skyBottom[1]},${th.skyBottom[2]})`);
+    ctx.fillStyle = grd;
+    ctx.fillRect(0, 0, this.W, this.H);
+
+    // camera
+    ctx.save();
+    if (!g.reduced) {
+      const amp = g.fx.shake * this.u * 0.62;
+      const sx = Math.cos(g.fx.shakeAngle) * amp + (Math.random() - 0.5) * amp * 0.9;
+      const sy = Math.sin(g.fx.shakeAngle) * amp + (Math.random() - 0.5) * amp * 0.9;
+      ctx.translate(this.W / 2 + sx, this.H / 2 + sy);
+      ctx.scale(g.fx.zoom, g.fx.zoom);
+      ctx.translate(-this.W / 2, -this.H / 2);
+    }
+
+    this.drawDust(dt, th);
+    this.drawSkyline(th);
+    this.drawGrid(now, th);
+    if (this.spec.scope) this.drawScope(th);
+    this.drawLaneBands(th);
+    if (this.spec.ribbon) this.drawRibbon(now);
+    this.drawNotes(now, g);
+    this.drawGates(now, g);
+    this.drawStrike(th);
+    this.particles.draw(ctx, font);
+
+    ctx.restore();
+
+    if (this.spec.bloom) this.applyBloom();
+    this.drawPost(g);
+    this.drawHud(now, g, th);
+  }
+
+  /* ---------------------------------------------------------------- */
+
+  private trackBeat(now: number): void {
+    const g = this.game;
+    for (const b of g.barGrid) {
+      if (now < b.t || now >= b.t + b.dur) continue;
+      const spb = b.dur / 4;
+      const beat = Math.floor((now - b.t) / spb);
+      const id = Math.round(b.t * 100) * 4 + beat;
+      if (id !== this.lastBeat) {
+        this.lastBeat = id;
+        this.beatPulse = 1;
+        if (beat === 0) this.barPulse = 1;
+        if (!this.game.reduced) {
+          this.particles.ring(this.strikeX, this.playTop + this.playH / 2, this.laneH * 0.4, this.laneH * (beat === 0 ? 2.4 : 1.5), beat === 0 ? 0.5 : 0.34, beat === 0 ? 3 : 2, PAL_HORIZON);
+        }
+      }
+      return;
+    }
+  }
+
+  private drainEvents(now: number): void {
+    const g = this.game;
+    const n = g.pendingEvents;
+    if (n === 0) return;
+    const rnd = Math.random;
+    for (let i = 0; i < n; i++) {
+      const e = g.events[i]!;
+      const y = this.laneY(e.lane);
+      const pal = e.lane;
+      switch (e.kind) {
+        case "hit": {
+          const power = e.strength * (e.accent ? 1.5 : 1);
+          const count = Math.round((this.spec.sparks / 44) * power);
+          this.particles.burst(this.strikeX, y, count, pal, 300 * power, rnd, this.spec.streaks);
+          this.particles.ring(this.strikeX, y, this.laneH * 0.16, this.laneH * (0.6 + power * 0.7), 0.34, 3 + power * 3, pal, LANE_SHAPE[e.lane] === "square");
+          if (e.verdict === "perfect") {
+            this.particles.ring(this.strikeX, y, this.laneH * 0.1, this.laneH * 1.5, 0.46, 2, PAL_GOLD);
+            this.particles.burst(this.strikeX, y, Math.round(count * 0.4), PAL_GOLD, 420, rnd, this.spec.streaks);
+          }
+          this.pushHist(now, e.lane, power);
+          this.comboPop = 1;
+          break;
+        }
+        case "miss":
+          this.particles.burst(this.strikeX, y, Math.round(this.spec.sparks / 60), PAL_DIM, 160, rnd, false);
+          this.particles.floater(this.strikeX + this.u * 3, y - this.laneH * 0.3, "MISS", this.u * 1.5, PAL_DIM);
+          break;
+        case "ghost":
+          this.particles.ring(this.strikeX, y, this.laneH * 0.1, this.laneH * 0.3, 0.2, 2, PAL_DIM);
+          break;
+        case "gate-correct": {
+          const cx = this.strikeX;
+          const cy = this.playTop + this.playH / 2;
+          for (let k = 0; k < this.spec.shards; k++) {
+            const a = rnd() * Math.PI * 2;
+            const sp = 200 + rnd() * 900;
+            this.particles.shard(
+              cx + (rnd() - 0.5) * this.u * 4,
+              this.playTop + rnd() * this.playH,
+              Math.cos(a) * sp + 240,
+              Math.sin(a) * sp - 260,
+              0.8 + rnd() * 0.8,
+              this.u * (0.4 + rnd() * 1.1),
+              rnd() < 0.5 ? PAL_WHITE : PAL_HORIZON,
+              (rnd() - 0.5) * 14,
+            );
+          }
+          this.particles.burst(cx, cy, this.spec.sparks >> 2, PAL_WHITE, 900, rnd, this.spec.streaks);
+          this.particles.ring(cx, cy, this.u, this.W * 0.9, 0.8, 8, PAL_WHITE);
+          this.particles.ring(cx, cy, this.u, this.W * 0.6, 0.6, 5, PAL_GOLD);
+          this.particles.floater(cx + this.u * 6, cy - this.laneH, "SPLIT!", this.u * 3, PAL_GOLD);
+          this.bigFlash(now, 0.4);
+          break;
+        }
+        case "gate-wrong": {
+          const cy = this.playTop + this.playH / 2;
+          this.particles.burst(this.strikeX, cy, this.spec.sparks >> 3, PAL_DIM, 500, rnd, false);
+          this.particles.ring(this.strikeX, cy, this.u, this.W * 0.5, 0.7, 6, PAL_DIM, true);
+          break;
+        }
+        case "charge-up":
+          this.particles.floater(this.strikeX + this.u * 3, this.laneY(e.lane) - this.laneH * 0.4, "+1", this.u * 1.8, PAL_GOLD);
+          break;
+        case "sector": {
+          this.particles.burst(this.W / 2, this.playTop + this.playH / 2, this.spec.sparks >> 2, PAL_BLOOM, 1100, rnd, this.spec.streaks);
+          this.particles.ring(this.W / 2, this.playTop + this.playH / 2, this.u, this.W, 1.0, 10, PAL_BLOOM);
+          const th = themeFor(this.game.sector.id);
+          this.particles.setSectorColors(th.horizon, th.bloom);
+          this.bigFlash(now, 0.36);
+          break;
+        }
+        case "breakdown":
+          this.particles.burst(this.strikeX, this.playTop + this.playH / 2, this.spec.sparks >> 2, PAL_DIM, 700, rnd, false);
+          break;
+        case "revive":
+          this.particles.burst(this.W / 2, this.playTop + this.playH / 2, this.spec.sparks >> 1, PAL_GOLD, 1200, rnd, this.spec.streaks);
+          this.particles.ring(this.W / 2, this.playTop + this.playH / 2, this.u, this.W * 1.2, 0.9, 12, PAL_GOLD);
+          this.bigFlash(now, 0.42);
+          break;
+      }
+    }
+    g.clearEvents();
+  }
+
+  /** Rate-limited and amplitude-capped. Children's product. */
+  private bigFlash(now: number, amount: number): void {
+    if (this.game.reduced) return;
+    if (now - this.lastFlashAt < FLASH_MIN_GAP) return;
+    this.lastFlashAt = now;
+    this.game.fx.flash = Math.min(FLASH_MAX, Math.max(this.game.fx.flash, amount));
+  }
+
+  private pushHist(t: number, lane: Lane, power: number): void {
+    const h = this.hist[this.histCur % HISTORY]!;
+    this.histCur++;
+    h.t = t;
+    h.lane = lane;
+    h.power = power;
+    h.live = true;
+  }
+
+  /* ---------------------------------------------------------------- */
+  /* background                                                        */
+  /* ---------------------------------------------------------------- */
+
+  private drawDust(dt: number, th: ReturnType<typeof themeFor>): void {
+    const n = this.spec.dust;
+    if (n === 0) return;
+    const ctx = this.ctx;
+    ctx.save();
+    ctx.globalCompositeOperation = "lighter";
+    for (let i = 0; i < n; i++) {
+      let x = this.dustX[i]! - this.dustZ[i]! * 26 * dt;
+      if (x < -4) {
+        x = this.W + 4;
+        this.dustY[i] = Math.random() * this.H;
+      }
+      this.dustX[i] = x;
+      const a = 0.05 + this.dustZ[i]! * 0.09 + this.beatPulse * 0.06;
+      ctx.fillStyle = rgba(th.horizon, a);
+      const s = this.dustZ[i]! * 1.5;
+      ctx.fillRect(x, this.dustY[i]!, s, s);
+    }
+    ctx.restore();
+  }
+
+  /**
+   * The canyon: two skylines cut from the live FFT, one hanging from the top
+   * and one rising from the bottom, with the playfield in the gap between them.
+   */
+  private drawSkyline(th: ReturnType<typeof themeFor>): void {
+    const ctx = this.ctx;
+    const eng = this.game.eng;
+    const bars = this.spec.bars;
+    const bw = this.W / bars;
+    const topEdge = this.playTop;
+    const botEdge = this.playTop + this.playH;
+    const maxUp = topEdge * 0.98;
+    const maxDown = (this.H - botEdge) * 0.98;
+
+    for (let pass = 0; pass < 2; pass++) {
+      const far = pass === 0;
+      const smooth = far ? this.smoothFar : this.smoothNear;
+      const col = far ? th.farBar : th.nearBar;
+      const k = far ? 0.10 : 0.26;
+      const skew = far ? 0.55 : 1;
+      ctx.fillStyle = rgba(col, far ? 0.55 : 0.9);
+      for (let i = 0; i < bars; i++) {
+        const bin = Math.min(
+          eng.freq.length - 1,
+          Math.floor(Math.pow((i + 0.5) / bars, 1.75) * 190) + (far ? 2 : 0),
+        );
+        const target = (eng.freq[bin] ?? 0) / 255;
+        smooth[i] = smooth[i]! + (target - smooth[i]!) * k;
+        const v = Math.pow(smooth[i]!, 1.35) * skew;
+        const x = i * bw + (far ? bw * 0.1 : bw * 0.22);
+        const w = bw * (far ? 0.8 : 0.56);
+        const hUp = 8 + v * maxUp;
+        const hDn = 8 + v * maxDown;
+        ctx.fillRect(x, topEdge - hUp, w, hUp);
+        ctx.fillRect(x, botEdge, w, hDn);
+      }
+    }
+
+    // horizon glow along both playfield edges
+    ctx.save();
+    ctx.globalCompositeOperation = "lighter";
+    for (const y of [topEdge, botEdge]) {
+      const g = ctx.createLinearGradient(0, y - this.u * 1.5, 0, y + this.u * 1.5);
+      g.addColorStop(0, rgba(th.horizon, 0));
+      g.addColorStop(0.5, rgba(th.horizon, 0.32 + this.beatPulse * 0.2));
+      g.addColorStop(1, rgba(th.horizon, 0));
+      ctx.fillStyle = g;
+      ctx.fillRect(0, y - this.u * 1.5, this.W, this.u * 3);
+    }
+    ctx.restore();
+  }
+
+  private drawScope(th: ReturnType<typeof themeFor>): void {
+    const ctx = this.ctx;
+    const w = this.game.eng.wave;
+    const cy = this.playTop + this.playH / 2;
+    const amp = this.laneH * 0.62;
+    const step = Math.max(1, Math.floor(w.length / Math.min(this.W, 480)));
+    ctx.save();
+    ctx.globalCompositeOperation = "lighter";
+    ctx.strokeStyle = rgba(th.horizon, 0.22);
+    ctx.lineWidth = Math.max(1, this.u * 0.16);
+    ctx.beginPath();
+    for (let i = 0, k = 0; i < w.length; i += step, k++) {
+      const x = (i / w.length) * this.W;
+      const y = cy + ((w[i]! - 128) / 128) * amp;
+      if (k === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  /**
+   * The floor, ruled into the current subdivision. This is the thesis: the bar
+   * is a fraction bar, cut into `cells` equal slices, and every note lands on a
+   * cut. Answer `1/8` at a gate and the world re-rules itself into eight.
+   */
+  private drawGrid(now: number, th: ReturnType<typeof themeFor>): void {
+    const ctx = this.ctx;
+    const top = this.playTop;
+    const bot = this.playTop + this.playH;
+    for (const b of this.game.barGrid) {
+      const x0 = this.xAt(b.t, now);
+      const x1 = this.xAt(b.t + b.dur, now);
+      if (x1 < -40 || x0 > this.W + 40) continue;
+      const cw = (x1 - x0) / b.cells;
+
+      // alternating cell tint so "cut into N" is read as segments, not ticks
+      for (let i = 0; i < b.cells; i += 2) {
+        const cx = x0 + i * cw;
+        if (cx > this.W || cx + cw < 0) continue;
+        ctx.fillStyle = rgba(th.grid, 0.045);
+        ctx.fillRect(cx, top, cw, this.playH);
+      }
+      // cell dividers
+      ctx.fillStyle = rgba(th.grid, 0.2);
+      for (let i = 1; i < b.cells; i++) {
+        const cx = x0 + i * cw;
+        if (cx < -2 || cx > this.W + 2) continue;
+        ctx.fillRect(cx, top, Math.max(1, this.u * 0.06), this.playH);
+      }
+      // bar line, and the fraction it represents
+      if (x0 > -2 && x0 < this.W + 2) {
+        ctx.fillStyle = rgba(th.horizon, 0.5 + this.barPulse * 0.35);
+        ctx.fillRect(x0 - this.u * 0.06, top, Math.max(1.5, this.u * 0.14), this.playH);
+        const label = `1/${b.cells}`;
+        drawRich(ctx, label, x0 + this.u * 0.5, bot - this.u * 1.35, this.u * 0.82, {
+          fill: rgba(th.horizon, 0.4),
+        });
+      }
+    }
+  }
+
+  private drawLaneBands(th: ReturnType<typeof themeFor>): void {
+    const ctx = this.ctx;
+    for (let l = 0; l < 3; l++) {
+      const y = this.playTop + (2 - l) * this.laneH;
+      const c = LANE_COLOR[l]!;
+      const flash = Math.min(0.3, this.game.fx.laneFlash[l]! * 0.3);
+      ctx.fillStyle = rgba(c, 0.035 + flash);
+      ctx.fillRect(0, y, this.W, this.laneH);
+      ctx.fillStyle = rgba(th.grid, 0.14);
+      ctx.fillRect(0, y, this.W, Math.max(1, this.u * 0.05));
+    }
+    ctx.fillStyle = rgba(th.grid, 0.14);
+    ctx.fillRect(0, this.playTop + this.playH, this.W, Math.max(1, this.u * 0.05));
+  }
+
+  /** Everything you have already played, streaming away behind the strike. */
+  private drawRibbon(now: number): void {
+    const ctx = this.ctx;
+    ctx.save();
+    ctx.globalCompositeOperation = "lighter";
+    for (const h of this.hist) {
+      if (!h.live) continue;
+      const age = now - h.t;
+      if (age > 4 || age < 0) {
+        if (age > 4) h.live = false;
+        continue;
+      }
+      const x = this.strikeX - age * this.pps * 0.42;
+      if (x < -20) {
+        h.live = false;
+        continue;
+      }
+      const a = (1 - age / 4) * 0.5;
+      const y = this.laneY(h.lane);
+      const r = this.laneH * 0.1 * (0.6 + h.power * 0.6);
+      ctx.fillStyle = rgba(LANE_COLOR[h.lane]!, a);
+      ctx.beginPath();
+      ctx.ellipse(x, y, r * 2.2, r, 0, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.restore();
+  }
+
+  /* ---------------------------------------------------------------- */
+  /* notes                                                             */
+  /* ---------------------------------------------------------------- */
+
+  private drawNotes(now: number, g: Game): void {
+    const ctx = this.ctx;
+    const chroma = g.reduced ? 0 : Math.min(1, g.fx.chroma) * this.u * 0.32;
+
+    for (const n of g.notes) {
+      if (!n.active || n.isChoice) continue;
+      const x = this.xAt(n.time, now);
+      if (x < -this.laneH || x > this.W + this.laneH) continue;
+      const y = this.laneY(n.lane);
+      const born = Math.min(1, (now - n.bornAt) / 0.25);
+      let scale = 1;
+      let alpha = born;
+
+      if (n.state === 1) {
+        const age = now - n.hitAt;
+        if (age > 0.26) continue;
+        const k = age / 0.26;
+        scale = 1 + k * 1.7;
+        alpha = (1 - k) * 0.9;
+      } else if (n.state === 2) {
+        const age = now - n.time;
+        if (age > 0.5) continue;
+        scale = 1 - Math.min(0.5, age);
+        alpha = Math.max(0, 0.45 - age);
+      } else {
+        // gentle approach growth, so the strike is the peak of the motion
+        const lead = Math.max(0, (n.time - now) / LEAD);
+        scale = 0.82 + (1 - lead) * 0.18;
+      }
+      if (alpha <= 0.01) continue;
+
+      const r = Math.min(this.laneH * 0.3, this.u * 1.5) * (n.accent ? 1.28 : 1) * scale;
+      this.drawGlyph(ctx, x, y, r, n.lane, alpha, n.accent, n.state === 2, chroma);
+    }
+  }
+
+  private drawGlyph(
+    ctx: CanvasRenderingContext2D,
+    x: number, y: number, r: number, lane: number,
+    alpha: number, accent: boolean, dead: boolean, chroma: number,
+  ): void {
+    const c = dead ? ([120, 128, 150] as Rgb) : LANE_COLOR[lane]!;
+    const shape = LANE_SHAPE[lane]!;
+
+    if (!dead) {
+      ctx.save();
+      ctx.globalCompositeOperation = "lighter";
+      ctx.globalAlpha = alpha * (accent ? 0.85 : 0.6);
+      const gl = this.noteGlow[lane]!;
+      const gr = r * 2.6;
+      ctx.drawImage(gl, x - gr, y - gr, gr * 2, gr * 2);
+      ctx.restore();
+    }
+
+    const path = (ox: number, oy: number, rr: number) => {
+      ctx.beginPath();
+      if (shape === "disc") {
+        ctx.arc(x + ox, y + oy, rr, 0, Math.PI * 2);
+      } else if (shape === "square") {
+        const s = rr * 0.92;
+        ctx.rect(x + ox - s, y + oy - s, s * 2, s * 2);
+      } else {
+        const s = rr * 1.12;
+        ctx.moveTo(x + ox, y + oy - s);
+        ctx.lineTo(x + ox + s * 0.92, y + oy + s * 0.72);
+        ctx.lineTo(x + ox - s * 0.92, y + oy + s * 0.72);
+        ctx.closePath();
+      }
+    };
+
+    if (chroma > 0.2 && !dead) {
+      ctx.save();
+      ctx.globalCompositeOperation = "lighter";
+      ctx.globalAlpha = alpha * 0.35;
+      ctx.fillStyle = "rgb(255,40,40)";
+      path(-chroma, 0, r);
+      ctx.fill();
+      ctx.fillStyle = "rgb(40,220,255)";
+      path(chroma, 0, r);
+      ctx.fill();
+      ctx.restore();
+    }
+
+    ctx.globalAlpha = alpha;
+    // dark contrast pass so a bright note never dissolves into a bright sky
+    ctx.fillStyle = "rgba(4,6,16,0.85)";
+    path(0, 0, r * 1.16);
+    ctx.fill();
+
+    ctx.fillStyle = rgba(c, 1);
+    path(0, 0, r);
+    ctx.fill();
+
+    ctx.globalAlpha = alpha * 0.85;
+    ctx.fillStyle = rgba(mix(c, [255, 255, 255], 0.65), 1);
+    path(0, -r * 0.22, r * 0.42);
+    ctx.fill();
+
+    if (accent && !dead) {
+      ctx.globalAlpha = alpha * 0.9;
+      ctx.strokeStyle = "rgba(255,255,255,0.95)";
+      ctx.lineWidth = Math.max(1.5, r * 0.16);
+      path(0, 0, r * 1.42);
+      ctx.stroke();
+    }
+    ctx.globalAlpha = 1;
+  }
+
+  /* ---------------------------------------------------------------- */
+  /* gates                                                             */
+  /* ---------------------------------------------------------------- */
+
+  private drawGates(now: number, g: Game): void {
+    const ctx = this.ctx;
+    const top = this.playTop;
+    const H = this.playH;
+
+    for (const gate of g.gates) {
+      if (!gate.active || gate === g.reviveGate) continue;
+      // the slab rides just behind the tiles
+      const sx = this.xAt(gate.time + 0.14, now);
+      if (sx < -this.W || sx > this.W * 2) continue;
+      const w = Math.max(this.u * 1.6, this.u * 2.2);
+
+      let alpha = 1;
+      let ox = 0;
+      if (gate.resolved && gate.correct) {
+        alpha = 1 - gate.shatter;
+      } else if (gate.resolved && !gate.correct) {
+        ox = -Math.sin(gate.crack * Math.PI) * this.u * 0.8;
+      }
+      if (alpha <= 0.02) continue;
+
+      ctx.save();
+      ctx.globalAlpha = alpha;
+      const grd = ctx.createLinearGradient(sx + ox, top, sx + ox + w, top + H);
+      grd.addColorStop(0, "rgba(10,14,32,0.94)");
+      grd.addColorStop(0.5, "rgba(26,34,68,0.88)");
+      grd.addColorStop(1, "rgba(8,10,24,0.94)");
+      ctx.fillStyle = grd;
+      ctx.fillRect(sx + ox, top, w, H);
+      ctx.strokeStyle = gate.resolved && !gate.correct ? "rgba(255,120,140,0.95)" : "rgba(190,225,255,0.85)";
+      ctx.lineWidth = Math.max(2, this.u * 0.16);
+      ctx.strokeRect(sx + ox, top, w, H);
+
+      // cracks grow as it approaches; they are the readable "this is coming"
+      const cracks = Math.floor(gate.crack * 9);
+      ctx.strokeStyle = `rgba(210,235,255,${0.15 + gate.crack * 0.5})`;
+      ctx.lineWidth = Math.max(1, this.u * 0.06);
+      ctx.beginPath();
+      for (let i = 0; i < cracks; i++) {
+        const s = this.crackSeed[i]!;
+        const y0 = top + s * H;
+        ctx.moveTo(sx + ox, y0);
+        ctx.lineTo(sx + ox + w * (0.4 + s * 0.6), y0 + (s - 0.5) * this.u * 3);
+      }
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    // choice tiles
+    const chroma = g.reduced ? 0 : Math.min(1, g.fx.chroma) * this.u * 0.25;
+    for (const n of g.notes) {
+      if (!n.active || !n.isChoice) continue;
+      const x = this.xAt(n.time, now);
+      if (x < -this.W * 0.5 || x > this.W + this.laneH * 3) continue;
+      const y = this.laneY(n.lane);
+      const born = Math.min(1, (now - n.bornAt) / 0.25);
+
+      let alpha = born;
+      let scale = 1;
+      if (n.state === 1) {
+        const age = now - n.hitAt;
+        if (age > 0.4) continue;
+        scale = 1 + (age / 0.4) * 0.5;
+        alpha = 1 - age / 0.4;
+      } else if (n.state === 2) {
+        const age = now - n.time;
+        if (age > 0.5) continue;
+        alpha = Math.max(0, (1 - age / 0.5) * 0.35);
+      }
+      if (alpha <= 0.02) continue;
+
+      const tw = Math.min(this.laneH * 1.5, this.u * 6.4) * scale;
+      const thh = this.laneH * 0.76 * scale;
+      const c = LANE_COLOR[n.lane]!;
+
+      ctx.save();
+      ctx.globalAlpha = alpha;
+      if (chroma > 0.2) {
+        ctx.globalCompositeOperation = "lighter";
+        ctx.globalAlpha = alpha * 0.3;
+        ctx.fillStyle = "rgb(255,40,40)";
+        this.roundRect(ctx, x - tw / 2 - chroma, y - thh / 2, tw, thh, this.u * 0.5);
+        ctx.fill();
+        ctx.fillStyle = "rgb(40,220,255)";
+        this.roundRect(ctx, x - tw / 2 + chroma, y - thh / 2, tw, thh, this.u * 0.5);
+        ctx.fill();
+        ctx.globalCompositeOperation = "source-over";
+        ctx.globalAlpha = alpha;
+      }
+
+      ctx.save();
+      ctx.globalCompositeOperation = "lighter";
+      ctx.globalAlpha = alpha * 0.45;
+      const gl = this.noteGlow[n.lane]!;
+      ctx.drawImage(gl, x - tw * 0.8, y - thh * 0.9, tw * 1.6, thh * 1.8);
+      ctx.restore();
+
+      ctx.fillStyle = "rgba(6,9,22,0.93)";
+      this.roundRect(ctx, x - tw / 2, y - thh / 2, tw, thh, this.u * 0.5);
+      ctx.fill();
+      ctx.strokeStyle = rgba(c, 0.95);
+      ctx.lineWidth = Math.max(2.5, this.u * 0.2);
+      this.roundRect(ctx, x - tw / 2, y - thh / 2, tw, thh, this.u * 0.5);
+      ctx.stroke();
+
+      const size = Math.min(thh * 0.42, tw * 0.4);
+      drawRich(ctx, n.label, x, y, size, { fill: "#ffffff", glow: rgba(c, 0.9), glowWidth: size * 0.5 }, true);
+      ctx.restore();
+    }
+  }
+
+  private roundRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number): void {
+    const rr = Math.min(r, w / 2, h / 2);
+    ctx.beginPath();
+    ctx.moveTo(x + rr, y);
+    ctx.arcTo(x + w, y, x + w, y + h, rr);
+    ctx.arcTo(x + w, y + h, x, y + h, rr);
+    ctx.arcTo(x, y + h, x, y, rr);
+    ctx.arcTo(x, y, x + w, y, rr);
+    ctx.closePath();
+  }
+
+  /* ---------------------------------------------------------------- */
+  /* strike column                                                     */
+  /* ---------------------------------------------------------------- */
+
+  private drawStrike(th: ReturnType<typeof themeFor>): void {
+    const ctx = this.ctx;
+    const g = this.game;
+    const top = this.playTop;
+
+    ctx.save();
+    ctx.globalCompositeOperation = "lighter";
+    const glow = ctx.createLinearGradient(this.strikeX - this.u * 3, 0, this.strikeX + this.u * 3, 0);
+    glow.addColorStop(0, rgba(th.bloom, 0));
+    glow.addColorStop(0.5, rgba(th.bloom, 0.22 + this.beatPulse * 0.25));
+    glow.addColorStop(1, rgba(th.bloom, 0));
+    ctx.fillStyle = glow;
+    ctx.fillRect(this.strikeX - this.u * 3, top, this.u * 6, this.playH);
+    ctx.restore();
+
+    for (let l = 0; l < 3; l++) {
+      const y = this.laneY(l);
+      const c = LANE_COLOR[l]!;
+      const f = Math.min(1, g.fx.laneFlash[l]!);
+      const w = this.u * 1.15;
+      const h = this.laneH * 0.72;
+
+      ctx.globalAlpha = 1;
+      ctx.fillStyle = `rgba(6,9,20,0.8)`;
+      this.roundRect(ctx, this.strikeX - w / 2, y - h / 2, w, h, this.u * 0.34);
+      ctx.fill();
+      ctx.strokeStyle = rgba(c, 0.5 + f * 0.5);
+      ctx.lineWidth = Math.max(2, this.u * (0.13 + f * 0.16));
+      this.roundRect(ctx, this.strikeX - w / 2, y - h / 2, w, h, this.u * 0.34);
+      ctx.stroke();
+
+      if (f > 0.02) {
+        ctx.save();
+        ctx.globalCompositeOperation = "lighter";
+        ctx.globalAlpha = Math.min(0.5, f * 0.5);
+        ctx.fillStyle = rgba(c, 1);
+        this.roundRect(ctx, this.strikeX - w / 2, y - h / 2, w, h, this.u * 0.34);
+        ctx.fill();
+        ctx.restore();
+      }
+    }
+    ctx.globalAlpha = 1;
+  }
+
+  /* ---------------------------------------------------------------- */
+  /* post + hud                                                        */
+  /* ---------------------------------------------------------------- */
+
+  private applyBloom(): void {
+    const ctx = this.ctx;
+    const a = this.bloomA.getContext("2d")!;
+    const b = this.bloomB.getContext("2d")!;
+    a.globalCompositeOperation = "source-over";
+    a.clearRect(0, 0, this.bloomA.width, this.bloomA.height);
+    a.drawImage(this.canvas, 0, 0, this.bloomA.width, this.bloomA.height);
+    b.clearRect(0, 0, this.bloomB.width, this.bloomB.height);
+    b.drawImage(this.bloomA, 0, 0, this.bloomB.width, this.bloomB.height);
+
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.globalCompositeOperation = "lighter";
+    ctx.globalAlpha = 0.34;
+    ctx.drawImage(this.bloomA, 0, 0, this.canvas.width, this.canvas.height);
+    ctx.globalAlpha = 0.42;
+    ctx.drawImage(this.bloomB, 0, 0, this.canvas.width, this.canvas.height);
+    ctx.restore();
+  }
+
+  private drawPost(g: Game): void {
+    const ctx = this.ctx;
+    ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
+    if (g.fx.flash > 0.005) {
+      ctx.save();
+      ctx.globalCompositeOperation = "lighter";
+      ctx.fillStyle = `rgba(255,255,255,${Math.min(FLASH_MAX, g.fx.flash) * 0.5})`;
+      ctx.fillRect(0, 0, this.W, this.H);
+      ctx.restore();
+    }
+    if (g.fx.vignette > 0.01) {
+      const r = Math.max(this.W, this.H);
+      const grd = ctx.createRadialGradient(this.W / 2, this.H / 2, r * 0.25, this.W / 2, this.H / 2, r * 0.75);
+      grd.addColorStop(0, "rgba(120,0,30,0)");
+      grd.addColorStop(1, `rgba(150,10,40,${Math.min(0.55, g.fx.vignette * 0.55)})`);
+      ctx.fillStyle = grd;
+      ctx.fillRect(0, 0, this.W, this.H);
+    }
+  }
+
+  private drawHud(now: number, g: Game, th: ReturnType<typeof themeFor>): void {
+    const ctx = this.ctx;
+    const u = this.u;
+    ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
+    ctx.textBaseline = "middle";
+
+    // --- score -------------------------------------------------------
+    ctx.textAlign = "left";
+    ctx.font = font(u * 2.05, 900);
+    ctx.fillStyle = "rgba(255,255,255,0.97)";
+    ctx.fillText(String(Math.round(g.score)).padStart(6, "0"), u * 0.9, u * 1.55);
+    ctx.font = font(u * 0.78, 700);
+    ctx.fillStyle = rgba(th.horizon, 0.75);
+    ctx.fillText(`${g.sector.name}  ·  ${Math.round(g.bpm)} BPM  ·  LV ${g.difficulty.toFixed(1)}`, u * 0.95, u * 2.95);
+
+    // --- charge ------------------------------------------------------
+    const cellW = u * 1.15;
+    const cx0 = this.W - u * 0.9 - cellW * 5 - u * 0.4;
+    for (let i = 0; i < 5; i++) {
+      const on = i < g.charge;
+      const x = cx0 + i * (cellW + u * 0.1);
+      ctx.fillStyle = on ? rgba(th.horizon, 0.95) : "rgba(255,255,255,0.13)";
+      this.roundRect(ctx, x, u * 0.85, cellW, u * 0.72, u * 0.16);
+      ctx.fill();
+      if (!on) {
+        ctx.strokeStyle = "rgba(255,255,255,0.22)";
+        ctx.lineWidth = 1;
+        ctx.stroke();
+      }
+    }
+
+    // --- combo -------------------------------------------------------
+    if (g.combo > 2) {
+      const pop = 1 + this.comboPop * 0.18;
+      const size = u * (1.9 + Math.min(1.6, g.combo / 44)) * pop;
+      ctx.textAlign = "left";
+      ctx.font = font(size, 900);
+      const glow = g.combo >= 40 ? [255, 226, 138] : [255, 255, 255];
+      ctx.save();
+      ctx.shadowColor = `rgba(${glow[0]},${glow[1]},${glow[2]},0.85)`;
+      ctx.shadowBlur = size * 0.42;
+      ctx.fillStyle = "#ffffff";
+      const cy = this.playTop - u * 0.9;
+      ctx.fillText(String(g.combo), this.strikeX - u * 0.2, cy);
+      const w = ctx.measureText(String(g.combo)).width;
+      ctx.font = font(size * 0.46, 800);
+      ctx.fillStyle = rgba(th.horizon, 0.95);
+      const mult = g.combo < 8 ? 1 : g.combo < 20 ? 2 : g.combo < 40 ? 3 : g.combo < 70 ? 4 : g.combo < 110 ? 6 : 8;
+      ctx.fillText(`x${mult}`, this.strikeX + w + u * 0.2, cy + size * 0.12);
+      ctx.restore();
+    }
+
+    // --- the question ------------------------------------------------
+    const gate = g.phase === "breakdown" ? g.reviveGate : g.activeGate;
+    if (gate && gate.q && !gate.resolved && now >= gate.revealAt - 0.05) {
+      const size = Math.min(u * 2.5, this.W / (measureRich(ctx, gate.q.prompt, 100) / 100) * 0.86);
+      const bw = measureRich(ctx, gate.q.prompt, size) + u * 2.4;
+      const bh = size * 2.3;
+      const bx = this.W / 2 - bw / 2;
+      const by = u * 0.55;
+      ctx.fillStyle = "rgba(4,6,18,0.82)";
+      this.roundRect(ctx, bx, by, bw, bh, u * 0.55);
+      ctx.fill();
+      ctx.strokeStyle = rgba(th.horizon, 0.55);
+      ctx.lineWidth = Math.max(1.5, u * 0.1);
+      this.roundRect(ctx, bx, by, bw, bh, u * 0.55);
+      ctx.stroke();
+      drawRich(ctx, gate.q.prompt, this.W / 2, by + bh / 2, size, {
+        fill: "#ffffff",
+        glow: rgba(th.horizon, 0.8),
+        glowWidth: size * 0.4,
+      }, true);
+
+      if (g.phase !== "breakdown") {
+        const remain = Math.max(0, Math.min(1, (gate.time - now) / 2.4));
+        ctx.fillStyle = rgba(th.horizon, 0.85);
+        ctx.fillRect(bx + u * 0.4, by + bh - u * 0.3, (bw - u * 0.8) * remain, u * 0.18);
+      }
+    }
+
+    // --- timing meter ------------------------------------------------
+    if (now - g.lastJudgeAt < 1.1 && g.lastVerdict) {
+      const mw = Math.min(this.W * 0.5, u * 13);
+      const mx = this.W / 2 - mw / 2;
+      const my = this.playTop + this.playH + u * 1.5;
+      const a = 1 - (now - g.lastJudgeAt) / 1.1;
+      ctx.globalAlpha = a;
+      ctx.fillStyle = "rgba(255,255,255,0.14)";
+      ctx.fillRect(mx, my - u * 0.1, mw, u * 0.2);
+      ctx.fillStyle = "rgba(255,255,255,0.4)";
+      ctx.fillRect(this.W / 2 - u * 0.05, my - u * 0.4, u * 0.1, u * 0.8);
+      if (g.lastVerdict !== "miss") {
+        const p = Math.max(-1, Math.min(1, g.lastDelta / 0.2));
+        ctx.fillStyle = rgba(th.horizon, 1);
+        ctx.fillRect(this.W / 2 + (p * mw) / 2 - u * 0.12, my - u * 0.5, u * 0.24, u);
+      }
+      ctx.textAlign = "center";
+      ctx.font = font(u * 0.72, 800);
+      ctx.fillStyle = "rgba(255,255,255,0.85)";
+      const word = g.lastVerdict.toUpperCase();
+      const side = g.lastVerdict === "miss" ? "" : g.lastDelta < -0.012 ? "  EARLY" : g.lastDelta > 0.012 ? "  LATE" : "";
+      ctx.fillText(word + side, this.W / 2, my + u * 1.1);
+      ctx.globalAlpha = 1;
+    }
+
+    // --- lane legend at the strike ------------------------------------
+    ctx.textAlign = "center";
+    ctx.font = font(u * 0.55, 800);
+    for (let l = 0; l < 3; l++) {
+      ctx.fillStyle = rgba(LANE_COLOR[l]!, 0.5);
+      ctx.fillText(LANE_NAME[l]!, this.strikeX, this.laneY(l) + this.laneH * 0.42);
+    }
+
+    // --- sector announce ---------------------------------------------
+    if (g.sectorFlash > 0) {
+      const a = Math.sin(Math.min(1, g.sectorFlash) * Math.PI);
+      ctx.globalAlpha = a;
+      ctx.textAlign = "center";
+      ctx.font = font(u * 4.2, 900);
+      ctx.fillStyle = rgba(th.horizon, 0.9);
+      ctx.fillText(g.sector.name, this.W / 2, this.playTop + this.playH / 2);
+      ctx.globalAlpha = 1;
+    }
+
+    // --- breakdown overlay -------------------------------------------
+    if (g.phase === "breakdown" && g.reviveGate) {
+      ctx.fillStyle = "rgba(3,4,12,0.72)";
+      ctx.fillRect(0, 0, this.W, this.H);
+      const pulse = 0.5 + 0.5 * Math.sin(now * 5);
+      ctx.textAlign = "center";
+      ctx.font = font(u * 1.15, 900);
+      ctx.fillStyle = rgba(th.horizon, 0.7 + pulse * 0.3);
+      ctx.fillText("RESTART THE HEART", this.W / 2, this.playTop - u * 1.2);
+
+      for (let l = 0; l < 3; l++) {
+        const y = this.laneY(l);
+        const c = LANE_COLOR[l]!;
+        const w = Math.min(this.W * 0.82, u * 20);
+        const h = this.laneH * 0.78;
+        ctx.fillStyle = "rgba(7,10,24,0.95)";
+        this.roundRect(ctx, this.W / 2 - w / 2, y - h / 2, w, h, u * 0.6);
+        ctx.fill();
+        ctx.strokeStyle = rgba(c, 0.75 + pulse * 0.25);
+        ctx.lineWidth = Math.max(3, u * 0.24);
+        this.roundRect(ctx, this.W / 2 - w / 2, y - h / 2, w, h, u * 0.6);
+        ctx.stroke();
+        drawRich(ctx, g.reviveGate.labels[l]!, this.W / 2, y, Math.min(h * 0.44, u * 2.6), {
+          fill: "#ffffff", glow: rgba(c, 0.9), glowWidth: u,
+        }, true);
+      }
+    }
+  }
+}

--- a/dynawalla/games/rhythm/src/render/typeset.ts
+++ b/dynawalla/games/rhythm/src/render/typeset.ts
@@ -1,0 +1,132 @@
+/**
+ * Fraction-aware typesetting.
+ *
+ * A prompt arrives from the host as a plain string — `1/4 + 1/4 = ?`. Drawing
+ * that literally gives a child a slash, which is not what a fraction looks like
+ * in any book they have ever read. Every `n/d` token is set properly stacked:
+ * numerator, rule, denominator.
+ *
+ * Layout is measured once per string at a reference size and scaled, so nothing
+ * is measured during a frame.
+ */
+
+import { font } from "../theme.ts";
+
+type Seg =
+  | { frac: false; t: string; w: number }
+  | { frac: true; n: string; d: string; suffix: string; w: number; barW: number; sufW: number };
+
+type Layout = { segs: Seg[]; w: number };
+
+const REF = 100;
+const GAP = 0.26 * REF;
+const NUM_SCALE = 0.74;
+
+const cache = new Map<string, Layout>();
+const FRACTION = /^([\d?]+)\s*\/\s*([\d?]+)(.*)$/;
+
+function layoutOf(ctx: CanvasRenderingContext2D, text: string): Layout {
+  const hit = cache.get(text);
+  if (hit) return hit;
+
+  const segs: Seg[] = [];
+  const prevFont = ctx.font;
+  for (const raw of text.split(/\s+/)) {
+    if (!raw) continue;
+    const m = FRACTION.exec(raw);
+    if (m) {
+      const n = m[1]!;
+      const d = m[2]!;
+      const suffix = m[3] ?? "";
+      ctx.font = font(REF * NUM_SCALE, 900);
+      const barW = Math.max(ctx.measureText(n).width, ctx.measureText(d).width) * 1.24;
+      ctx.font = font(REF, 800);
+      const sufW = suffix ? ctx.measureText(suffix).width : 0;
+      segs.push({ frac: true, n, d, suffix, w: barW + sufW, barW, sufW });
+    } else {
+      ctx.font = font(REF, 800);
+      segs.push({ frac: false, t: raw, w: ctx.measureText(raw).width });
+    }
+  }
+  ctx.font = prevFont;
+
+  let w = 0;
+  for (let i = 0; i < segs.length; i++) w += segs[i]!.w + (i > 0 ? GAP : 0);
+  const l: Layout = { segs, w };
+  if (cache.size > 400) cache.clear();
+  cache.set(text, l);
+  return l;
+}
+
+/** Width the string will occupy when drawn at `size`. */
+export function measureRich(ctx: CanvasRenderingContext2D, text: string, size: number): number {
+  return (layoutOf(ctx, text).w * size) / REF;
+}
+
+/** Total height including numerator and denominator, at `size`. */
+export function heightRich(text: string, size: number): number {
+  return /[\d?]+\s*\/\s*[\d?]+/.test(text) ? size * 1.86 : size * 1.06;
+}
+
+export type RichStyle = {
+  fill: string;
+  /** optional outer glow; skipped when empty */
+  glow?: string;
+  glowWidth?: number;
+};
+
+/**
+ * Draw `text` with stacked fractions. `x` is the LEFT edge unless `center` is
+ * true, in which case it is the centre. `y` is the vertical centre.
+ */
+export function drawRich(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  x: number,
+  y: number,
+  size: number,
+  style: RichStyle,
+  center = false,
+): number {
+  const l = layoutOf(ctx, text);
+  const k = size / REF;
+  const total = l.w * k;
+  let cx = center ? x - total / 2 : x;
+
+  ctx.save();
+  ctx.textBaseline = "middle";
+  ctx.textAlign = "left";
+  if (style.glow) {
+    ctx.shadowColor = style.glow;
+    ctx.shadowBlur = style.glowWidth ?? size * 0.5;
+  }
+  ctx.fillStyle = style.fill;
+
+  for (let i = 0; i < l.segs.length; i++) {
+    const s = l.segs[i]!;
+    if (i > 0) cx += GAP * k;
+    if (!s.frac) {
+      ctx.font = font(size, 800);
+      ctx.fillText(s.t, cx, y);
+      cx += s.w * k;
+      continue;
+    }
+    const barW = s.barW * k;
+    const numSize = size * NUM_SCALE;
+    ctx.font = font(numSize, 900);
+    ctx.textAlign = "center";
+    ctx.fillText(s.n, cx + barW / 2, y - size * 0.46);
+    ctx.fillText(s.d, cx + barW / 2, y + size * 0.5);
+    ctx.textAlign = "left";
+    const th = Math.max(2, size * 0.085);
+    ctx.fillRect(cx + barW * 0.06, y - th / 2, barW * 0.88, th);
+    cx += barW;
+    if (s.suffix) {
+      ctx.font = font(size, 800);
+      ctx.fillText(s.suffix, cx, y);
+      cx += s.sufW * k;
+    }
+  }
+  ctx.restore();
+  return total;
+}

--- a/dynawalla/games/rhythm/src/stubHost.ts
+++ b/dynawalla/games/rhythm/src/stubHost.ts
@@ -1,0 +1,362 @@
+/**
+ * Local stub Host so Splitbeat is playable standalone with `npm run dev`.
+ *
+ * Rules it obeys, because the real host obeys them:
+ *  - Exact arithmetic only. Every quantity is a pair of integers (n, d). No
+ *    float ever reaches an `answer` string or a comparison. `0.1 + 0.2 !== 0.3`
+ *    would mark correct work wrong deterministically, so floats are banned here
+ *    the same way they are banned in `curriculum/` and `engine/`.
+ *  - Seeded and deterministic. Same seed, same stream of questions, forever.
+ *  - Distractors are real mal-rule outputs — the answer a child actually
+ *    produces when they apply a plausible-but-wrong procedure — never noise.
+ */
+
+import type { Host, Question } from "./contract.ts";
+
+
+/* ------------------------------------------------------------------ */
+/* exact rationals                                                     */
+/* ------------------------------------------------------------------ */
+
+export type Rat = { n: number; d: number };
+
+function gcd(a: number, b: number): number {
+  a = a < 0 ? -a : a;
+  b = b < 0 ? -b : b;
+  while (b !== 0) {
+    const t = a % b;
+    a = b;
+    b = t;
+  }
+  return a === 0 ? 1 : a;
+}
+
+/** Normalised rational. `d` is always positive; the pair is always reduced. */
+export function rat(n: number, d: number): Rat {
+  if (d === 0) throw new Error("rat: zero denominator");
+  if (d < 0) {
+    n = -n;
+    d = -d;
+  }
+  const g = gcd(n, d);
+  return { n: n / g, d: d / g };
+}
+
+const add = (a: Rat, b: Rat): Rat => rat(a.n * b.d + b.n * a.d, a.d * b.d);
+const mul = (a: Rat, b: Rat): Rat => rat(a.n * b.n, a.d * b.d);
+const div = (a: Rat, b: Rat): Rat => rat(a.n * b.d, a.d * b.n);
+
+/** "3", "1/4", "3/8" — the only shapes the game has to render or compare. */
+export function fmt(r: Rat): string {
+  return r.d === 1 ? String(r.n) : `${r.n}/${r.d}`;
+}
+
+/** Parse "3", "1/4", "-2/3". Returns null for anything else. */
+export function parseRat(s: string): Rat | null {
+  const t = s.trim();
+  let m = /^(-?\d+)$/.exec(t);
+  if (m) return { n: Number(m[1]), d: 1 };
+  m = /^(-?\d+)\s*\/\s*(\d+)$/.exec(t);
+  if (m) {
+    const d = Number(m[2]);
+    if (d === 0) return null;
+    return rat(Number(m[1]), d);
+  }
+  return null;
+}
+
+/* ------------------------------------------------------------------ */
+/* seeded rng — mulberry32, deterministic and dependency-free           */
+/* ------------------------------------------------------------------ */
+
+export function makeRng(seed: number) {
+  let a = seed >>> 0;
+  return {
+    /** uniform in [0,1) — used only for *selection*, never for an answer */
+    f(): number {
+      a = (a + 0x6d2b79f5) >>> 0;
+      let t = a;
+      t = Math.imul(t ^ (t >>> 15), t | 1);
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    },
+    /** integer in [lo, hi] inclusive */
+    int(lo: number, hi: number): number {
+      return lo + Math.floor(this.f() * (hi - lo + 1));
+    },
+    pick<T>(xs: readonly T[]): T {
+      return xs[Math.floor(this.f() * xs.length)]!;
+    },
+  };
+}
+export type Rng = ReturnType<typeof makeRng>;
+
+/* ------------------------------------------------------------------ */
+/* question templates                                                  */
+/* ------------------------------------------------------------------ */
+
+type Built = { prompt: string; answer: string; wrong: string[]; domain: string };
+
+/** Denominators that are also playable beat subdivisions of a 4/4 bar. */
+const MUSICAL_D = [2, 3, 4, 6, 8] as const;
+
+/**
+ * `1/4 + 1/4 = ?`
+ * Mal-rules: add across (n+n)/(d+d); keep numerator, add denominators;
+ * add numerators, multiply denominators.
+ */
+function tAddLike(rng: Rng, hard: boolean): Built {
+  const d = hard ? rng.pick([3, 4, 6, 8] as const) : rng.pick([2, 4, 8] as const);
+  const a = rat(1, d);
+  const k = hard ? rng.int(1, Math.max(1, d - 1)) : 1;
+  const b = rat(k, d);
+  const ans = add(a, b);
+  const wrong = [
+    fmt(rat(a.n + b.n, a.d + b.d)), // added across
+    fmt(rat(a.n + b.n, a.d * b.d)), // added tops, multiplied bottoms
+    fmt(rat(a.n, a.d + b.d)), // added only the bottoms
+  ];
+  return { prompt: `${fmt(a)} + ${fmt(b)} = ?`, answer: fmt(ans), wrong, domain: "fractions.add" };
+}
+
+/**
+ * `1/2 + 1/4 = ?` — unlike denominators, the classic common-denominator trap.
+ */
+function tAddUnlike(rng: Rng): Built {
+  const pairs = [
+    [rat(1, 2), rat(1, 4)],
+    [rat(1, 2), rat(1, 8)],
+    [rat(1, 4), rat(1, 8)],
+    [rat(1, 2), rat(1, 6)],
+    [rat(1, 3), rat(1, 6)],
+    [rat(3, 8), rat(1, 8)],
+  ] as const;
+  const [a, b] = rng.pick(pairs);
+  const ans = add(a, b);
+  const wrong = [
+    fmt(rat(a.n + b.n, a.d + b.d)), // added across
+    fmt(rat(a.n + b.n, Math.max(a.d, b.d))), // kept the bigger bottom
+    fmt(mul(a, b)), // multiplied instead
+  ];
+  return { prompt: `${fmt(a)} + ${fmt(b)} = ?`, answer: fmt(ans), wrong, domain: "fractions.add" };
+}
+
+/**
+ * `How many 1/8 fit in 1/2?` — the question a drummer answers with their hands.
+ */
+function tHowMany(rng: Rng, hard: boolean): Built {
+  const whole = hard ? rng.pick([rat(1, 2), rat(1, 4), rat(3, 4), rat(1, 1)]) : rng.pick([rat(1, 1), rat(1, 2)]);
+  // `whole / (1/small)` is a whole number of pieces only when the bar's own
+  // denominator divides `small`; require at least 2 pieces so the question is
+  // never the degenerate "how many 1/4 fit in 1/4".
+  const usable = MUSICAL_D.filter((d) => d % whole.d === 0 && d * whole.n >= 2 * whole.d);
+  const small = usable.length > 0 ? rng.pick(usable) : 8;
+  const piece = rat(1, small);
+  const ans = div(whole, piece);
+  const wrong = [
+    String(small), // read the bottom number off and stopped
+    String(Math.max(1, small - whole.d)), // subtracted the bottoms
+    fmt(mul(whole, piece)), // multiplied instead of divided
+  ];
+  return {
+    prompt: `How many ${fmt(piece)} fit in ${fmt(whole)}?`,
+    answer: fmt(ans),
+    wrong,
+    domain: "fractions.divide",
+  };
+}
+
+/** `1/2 of 1/2 = ?` and `3 x 1/8 = ?` */
+function tScale(rng: Rng, hard: boolean): Built {
+  if (rng.f() < 0.5) {
+    const d1 = rng.pick([2, 3, 4] as const);
+    const d2 = rng.pick(hard ? ([2, 3, 4] as const) : ([2, 4] as const));
+    const a = rat(1, d1);
+    const b = rat(1, d2);
+    const ans = mul(a, b);
+    const wrong = [
+      fmt(add(a, b)), // added instead
+      fmt(rat(1, d1 + d2)), // added the bottoms
+      fmt(rat(2, d1 * d2)), // doubled the top for no reason
+    ];
+    return { prompt: `${fmt(a)} of ${fmt(b)} = ?`, answer: fmt(ans), wrong, domain: "fractions.multiply" };
+  }
+  const k = rng.int(2, hard ? 5 : 3);
+  const d = rng.pick([2, 3, 4, 8] as const);
+  const a = rat(1, d);
+  const ans = mul(rat(k, 1), a);
+  const wrong = [
+    fmt(rat(k, d * k)), // multiplied the bottom too
+    fmt(rat(1, d * k)), // multiplied only the bottom
+    fmt(rat(k + 1, d)), // off by one
+  ];
+  return { prompt: `${k} x ${fmt(a)} = ?`, answer: fmt(ans), wrong, domain: "fractions.multiply" };
+}
+
+/** `2/8 = ?/4` — equivalence, stated so the answer is a single number. */
+function tEquivalent(rng: Rng): Built {
+  const base = rng.pick([rat(1, 2), rat(1, 4), rat(3, 4), rat(1, 3), rat(2, 3)]);
+  const k = rng.int(2, 4);
+  const shownN = base.n * k;
+  const shownD = base.d * k;
+  const ans = base.n;
+  const wrong = [
+    String(shownN), // copied the top across
+    String(base.d), // answered with the bottom
+    String(shownN - k), // subtracted the scale factor
+  ];
+  return {
+    prompt: `${shownN}/${shownD} = ?/${base.d}`,
+    answer: String(ans),
+    wrong,
+    domain: "fractions.equivalence",
+  };
+}
+
+/** Skip-counting, which is a groove: `4, 8, 12, ?` */
+function tSkipCount(rng: Rng, hard: boolean): Built {
+  const step = hard ? rng.int(3, 9) : rng.pick([2, 3, 4, 5, 10] as const);
+  const start = step * rng.int(1, 3);
+  const shown = [start, start + step, start + step * 2];
+  const ans = start + step * 3;
+  const wrong = [
+    String(ans + step), // one term too far
+    String(ans - 1), // counted by one at the end
+    String(shown[2]! + shown[0]!), // added the first term instead of the step
+  ];
+  return { prompt: `${shown.join(", ")}, ?`, answer: String(ans), wrong, domain: "counting.skip" };
+}
+
+/** Tempo as ratio: `90 x 2 = ?` beats per minute. */
+function tTempo(rng: Rng, hard: boolean): Built {
+  const base = rng.int(3, 12) * 10;
+  if (hard && rng.f() < 0.5) {
+    // `base` is a multiple of 10; halving is exact only when it is a multiple
+    // of 20, so force that rather than emit a fraction of a beat-per-minute.
+    const even = base % 20 === 0 ? base : base + 10;
+    return {
+      prompt: `half of ${even} = ?`,
+      answer: String(even / 2),
+      wrong: [String(even - 2), String(even / 2 + 10), String(even * 2)],
+      domain: "number.scale",
+    };
+  }
+  return {
+    prompt: `${base} x 2 = ?`,
+    answer: String(base * 2),
+    wrong: [String(base + 2), String(base * 2 - 10), String(base + base / 2)],
+    domain: "number.scale",
+  };
+}
+
+/** Plain arithmetic, so the game is exercised on questions it cannot "play". */
+function tArith(rng: Rng, hard: boolean): Built {
+  const a = rng.int(hard ? 12 : 3, hard ? 40 : 12);
+  const b = rng.int(hard ? 12 : 2, hard ? 30 : 9);
+  if (rng.f() < 0.5) {
+    return {
+      prompt: `${a} + ${b} = ?`,
+      answer: String(a + b),
+      wrong: [String(a + b + 10), String(a + b - 1), String(a - b)],
+      domain: "number.add",
+    };
+  }
+  const hi = Math.max(a, b);
+  const lo = Math.min(a, b);
+  return {
+    prompt: `${hi} - ${lo} = ?`,
+    answer: String(hi - lo),
+    wrong: [String(hi - lo - 1), String(hi + lo), String(lo - hi)],
+    domain: "number.subtract",
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* the host                                                            */
+/* ------------------------------------------------------------------ */
+
+export type StubHostOptions = {
+  seed?: number;
+  /** set false to prove the game degrades correctly on unplayable answers */
+  musical?: boolean;
+  onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void;
+};
+
+export function createStubHost(opts: StubHostOptions = {}): Host & { log: readonly unknown[] } {
+  const rng = makeRng(opts.seed ?? 0x5b17bea7);
+  const musical = opts.musical !== false;
+  let counter = 0;
+  const log: unknown[] = [];
+
+  const reduced =
+    typeof matchMedia === "function" ? matchMedia("(prefers-reduced-motion: reduce)") : null;
+
+  function build(difficulty: number): Built {
+    const hard = difficulty >= 5;
+    const roll = rng.f();
+    if (!musical) return tArith(rng, hard);
+    // Weighted toward the fraction/subdivision core, because that is what this
+    // game can turn into a rhythm. The tail keeps other domains in the mix.
+    if (roll < 0.24) return tAddLike(rng, hard);
+    if (roll < 0.42) return tHowMany(rng, hard);
+    if (roll < 0.56) return tScale(rng, hard);
+    if (roll < 0.68) return difficulty >= 3 ? tAddUnlike(rng) : tAddLike(rng, false);
+    if (roll < 0.78) return tEquivalent(rng);
+    if (roll < 0.9) return tSkipCount(rng, hard);
+    if (roll < 0.96) return tTempo(rng, hard);
+    return tArith(rng, hard);
+  }
+
+  return {
+    log,
+    next(o): Question {
+      const difficulty = Math.max(1, Math.min(10, Math.round(o?.difficulty ?? 1)));
+      let b = build(difficulty);
+      // Never offer a distractor equal to the answer, and never two identical
+      // tiles — a duplicate tile is an unwinnable question.
+      let guard = 0;
+      while (guard++ < 24) {
+        const uniq = Array.from(new Set(b.wrong.filter((w) => w !== b.answer)));
+        if (uniq.length >= 2) {
+          b = { ...b, wrong: uniq };
+          break;
+        }
+        b = build(difficulty);
+      }
+      counter += 1;
+      return {
+        id: `stub-${counter}`,
+        prompt: b.prompt,
+        answer: b.answer,
+        distractors: b.wrong.slice(0, 3),
+        domain: b.domain,
+        difficulty,
+      };
+    },
+    report(r) {
+      log.push(r);
+      opts.onReport?.(r);
+    },
+    haptic(k) {
+      // Standalone browsers get the Vibration API where it exists; the packaged
+      // runtime replaces this with the native haptics plugin. Silent elsewhere.
+      const nav = navigator as Navigator & { vibrate?: (p: number | number[]) => boolean };
+      if (typeof nav.vibrate !== "function") return;
+      const pattern: Record<string, number | number[]> = {
+        light: 8,
+        medium: 18,
+        heavy: 34,
+        success: [12, 40, 22],
+        failure: [30, 60, 30],
+      };
+      try {
+        nav.vibrate(pattern[k] ?? 10);
+      } catch {
+        /* a vibrate() rejection is never worth breaking a frame over */
+      }
+    },
+    prefersReducedMotion() {
+      return !!reduced?.matches;
+    },
+  };
+}

--- a/dynawalla/games/rhythm/src/theme.ts
+++ b/dynawalla/games/rhythm/src/theme.ts
@@ -1,0 +1,130 @@
+/**
+ * Visual register: a neon oscilloscope canyon. Deep indigo night, a skyline cut
+ * from the live FFT of the master bus, a waveform for a horizon, and a floor
+ * ruled into the current subdivision.
+ *
+ * Two rules this file exists to enforce:
+ *
+ *  1. LANE IDENTITY IS FIXED FOREVER. Amber is always the low drum, rose always
+ *     the mid, cyan always the high — in every sector, at every difficulty. The
+ *     world changes colour around the player; the thing their hands have
+ *     learned does not. Each lane also has its own SHAPE, so none of this
+ *     information is carried by colour alone.
+ *  2. ORNAMENT NEVER EATS LEGIBILITY. Numerals are heavy grotesque, never
+ *     engraved or serif, and are drawn at a size derived from the smaller
+ *     screen axis so they hold at 320px.
+ */
+
+export type Rgb = readonly [number, number, number];
+
+export const rgba = (c: Rgb, a: number): string => `rgba(${c[0]},${c[1]},${c[2]},${a})`;
+export const rgb = (c: Rgb): string => `rgb(${c[0]},${c[1]},${c[2]})`;
+
+export const mix = (a: Rgb, b: Rgb, t: number): Rgb => [
+  Math.round(a[0] + (b[0] - a[0]) * t),
+  Math.round(a[1] + (b[1] - a[1]) * t),
+  Math.round(a[2] + (b[2] - a[2]) * t),
+];
+
+/** Lane colour AND lane shape. Never one without the other. */
+export const LANE_COLOR: readonly Rgb[] = [
+  [255, 156, 56], // 0 low  — amber
+  [255, 77, 141], // 1 mid  — rose
+  [78, 226, 255], // 2 high — cyan
+];
+export type LaneShape = "disc" | "square" | "wedge";
+export const LANE_SHAPE: readonly LaneShape[] = ["disc", "square", "wedge"];
+/** Screen-reader / legend text; also drawn under the strike pads. */
+export const LANE_NAME: readonly string[] = ["LOW", "MID", "HIGH"];
+
+export type SectorTheme = {
+  /** background gradient, top → bottom */
+  skyTop: Rgb;
+  skyBottom: Rgb;
+  /** far and near skyline silhouettes */
+  farBar: Rgb;
+  nearBar: Rgb;
+  /** horizon glow + oscilloscope trace */
+  horizon: Rgb;
+  /** floor rules and cell dividers */
+  grid: Rgb;
+  /** haze behind the strike column */
+  bloom: Rgb;
+};
+
+export const SECTOR_THEME: Record<string, SectorTheme> = {
+  indigo: {
+    skyTop: [6, 8, 26], skyBottom: [16, 22, 62], farBar: [30, 40, 104], nearBar: [58, 78, 186],
+    horizon: [120, 205, 255], grid: [86, 120, 220], bloom: [70, 110, 255],
+  },
+  ember: {
+    skyTop: [22, 6, 8], skyBottom: [58, 18, 12], farBar: [96, 34, 22], nearBar: [176, 66, 30],
+    horizon: [255, 170, 96], grid: [200, 96, 52], bloom: [255, 110, 40],
+  },
+  violet: {
+    skyTop: [15, 5, 28], skyBottom: [42, 12, 70], farBar: [74, 26, 122], nearBar: [136, 52, 210],
+    horizon: [214, 150, 255], grid: [150, 90, 230], bloom: [170, 70, 255],
+  },
+  glacier: {
+    skyTop: [3, 14, 20], skyBottom: [8, 40, 54], farBar: [16, 68, 90], nearBar: [34, 128, 160],
+    horizon: [150, 240, 255], grid: [70, 170, 205], bloom: [50, 190, 230],
+  },
+  solar: {
+    skyTop: [24, 16, 3], skyBottom: [62, 44, 8], farBar: [110, 76, 18], nearBar: [196, 142, 34],
+    horizon: [255, 224, 130], grid: [216, 168, 60], bloom: [255, 190, 50],
+  },
+  abyss: {
+    skyTop: [2, 4, 8], skyBottom: [6, 16, 26], farBar: [12, 34, 52], nearBar: [26, 74, 104],
+    horizon: [110, 235, 210], grid: [50, 140, 140], bloom: [40, 220, 180],
+  },
+};
+
+export const themeFor = (id: string): SectorTheme => SECTOR_THEME[id] ?? SECTOR_THEME.indigo!;
+
+/* -------------------------------------------------------------------- */
+/* quality tiers                                                         */
+/* -------------------------------------------------------------------- */
+
+export type Tier = "low" | "mid" | "ultra";
+
+export type TierSpec = {
+  sparks: number;
+  shards: number;
+  rings: number;
+  /** skyline resolution */
+  bars: number;
+  /** draw the oscilloscope horizon */
+  scope: boolean;
+  /** additive bloom pass on an offscreen half-res buffer */
+  bloom: boolean;
+  /** trailing ribbon of everything you have played */
+  ribbon: boolean;
+  /** per-note motion streaks */
+  streaks: boolean;
+  /** starfield dust */
+  dust: number;
+  maxDpr: number;
+};
+
+export const TIER_SPEC: Record<Tier, TierSpec> = {
+  low: { sparks: 260, shards: 56, rings: 20, bars: 26, scope: false, bloom: false, ribbon: false, streaks: false, dust: 0, maxDpr: 1.5 },
+  mid: { sparks: 760, shards: 170, rings: 40, bars: 52, scope: true, bloom: true, ribbon: true, streaks: false, dust: 60, maxDpr: 2 },
+  ultra: { sparks: 1900, shards: 420, rings: 76, bars: 96, scope: true, bloom: true, ribbon: true, streaks: true, dust: 150, maxDpr: 2 },
+};
+
+export function autoTier(): Tier {
+  const nav = navigator as Navigator & { deviceMemory?: number };
+  const mem = nav.deviceMemory ?? 4;
+  const cores = navigator.hardwareConcurrency ?? 4;
+  const px = window.innerWidth * window.innerHeight * Math.min(2, window.devicePixelRatio || 1);
+  if (mem >= 8 && cores >= 8) return "ultra";
+  if (mem <= 3 || cores <= 4 || px > 4_500_000) return "low";
+  return "mid";
+}
+
+/** Heavy grotesque only. Numerals must survive a 0.45s glance at speed. */
+export const FONT_STACK =
+  '"Inter", "SF Pro Display", "Segoe UI", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif';
+
+export const font = (px: number, weight = 800): string =>
+  `${weight} ${px.toFixed(1)}px ${FONT_STACK}`;

--- a/dynawalla/games/rhythm/tsconfig.json
+++ b/dynawalla/games/rhythm/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": false,
+    "exactOptionalPropertyTypes": false,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/dynawalla/games/rhythm/vite.config.ts
+++ b/dynawalla/games/rhythm/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    // The game is one self-contained chunk; a pack loader fetches it whole.
+    rollupOptions: { output: { manualChunks: undefined } },
+  },
+  server: { host: "127.0.0.1", port: 5183, strictPort: false },
+});


### PR DESCRIPTION
## What

Commit `dynawalla/games/rhythm` — COUNTERPOISE, a brass rhythm where the scale physically is the equals sign.

## Why

This prototype existed **only as untracked files in a worktree**. It appeared in
zero git refs: `git log --all -- dynawalla/games/rhythm` returned no commits. It was
never committed, never branched, never pushed. Pruning that worktree — which the
repo's own session hook recommends doing after a merge — would have destroyed it
with no reflog and no dangling object to recover from.

Ten sibling prototypes were in the same state. This PR is one of that set.

### Fix carried in this PR

Its `tsconfig.json` set `"types": []` while `chart.test.ts` imports `node:test`
and `node:assert/strict`. `tsc --noEmit` failed, and because `build` is
`tsc --noEmit && vite build`, the game did not build at all. Added `@types/node`
and set `"types": ["node"]`, matching `dynawalla/games/slice`.

## Blast radius

**Areas touched:** dynawalla (new directory only)

- [x] Additive only. Every path is new under `dynawalla/games/rhythm/`; no existing
      file is modified or deleted. Nothing imports it yet.
- [ ] **Every touched path is covered by a `ci.yml` area filter** — **NO, and
      stated deliberately.** `dynawalla/games/` is absent from the `covered`
      regex (`ci.yml:226`), so the `uncovered` step will warn. This is
      pre-existing: the five games already on `main` have no CI either. No job
      builds, type-checks or tests any game. The gates below were therefore run
      locally, by hand. A games-area filter is the correct follow-up and is
      called out rather than silently bundled here.
- [x] **Pack back-compat.** No published pack zip, `voiceId` or catalog entry
      touched. App floor 0.20.6 unaffected.
- [x] **Native integrity.** No Rust, no `src-tauri`, no `links =`, no `[patch]`.
- [x] **Strings.** No `corpan-app` locale keys added; this pack does not use the
      Corpán i18n catalog.
- [x] **Curriculum.** No skill id renamed or reused, no grade metadata changed,
      no generator binding altered.
- [x] **Secrets.** No `.p8`, keystore, service-account JSON, issuer id, key id or
      token. Verified the diff is source, config and `index.html` only.

`package-lock.json` and `qa/shots` are gitignored, matching
`dynawalla/games/slice` and `.../siege`.

## Proof

Run in `dynawalla/games/rhythm/` after `npm install`:

```
$ npm test
# tests 16 # pass 16 # fail 0 

$ npm run tsc          # tsc --noEmit
0 errors

$ npm run build
✓ built in 156ms
```

Scope check — the branch adds this game and nothing else:

```
$ git diff --name-only origin/main...HEAD | grep -cv '^dynawalla/games/rhythm/'
0
$ git diff --diff-filter=D --name-only origin/main...HEAD | wc -l
0
```
