### PR TITLE
docs(dynawalla): ratify the product name as Dynawalla (ADR-0016)

### DIFF
--- a/dynawalla/docs/DECISIONS/ADR-0016-app-store-product-name.md
+++ b/dynawalla/docs/DECISIONS/ADR-0016-app-store-product-name.md
@@ -1,12 +1,27 @@
 # ADR-0016 — App Store product name
 
-**Status:** Proposed — awaiting founder
-**Needed before:** the ASC app record is created in M1
+**Status:** Accepted — founder, 2026-07-27
+**Decided:** the product name is **Dynawalla**. Bundle id `inc.corpora.dynawalla`.
+
+> "name is Dynawalla. inc.corpora.dynawalla" — founder, 2026-07-27
+
+The working name "Dynawalla: Apprentice of Numbers" is **dropped**. The name is the
+bare word, matching the bundle id and the domain the founder already owns.
+
+**This was ratified after the App Store Connect record already existed**, so it records
+reality rather than authorising it. The App Store SKU is immutable and is now set; the
+subtitle, not the name, is where any descriptive phrase belongs from here.
+
+The two counsel-grade collision vectors below (**Dynamo Maths**; **Physics Wallah**'s
+"family of 'wallah' marks") are **not** resolved by this decision and are not resolved by
+the record existing. They remain open items for counsel, and the paid clearance search is
+still advisable. So are the two hygiene items — the dangling DNS records on the owned
+domain, and the public repo tying the name to dietary-supplement health claims.
 
 ## Context
 
-The working name is **"Dynawalla: Apprentice of Numbers"**. Before an app record exists,
-two checks are cheap and afterwards they are very expensive:
+Before an app record existed, two checks were cheap and afterwards they are very
+expensive:
 
 1. A trademark search on the name.
 2. An availability check on both stores — App Store names are unique per territory, and
@@ -23,9 +38,10 @@ Some of the identifiers involved are literally immutable:
 The store *display name* can be changed later, but not cheaply: it carries the SEO and
 the word-of-mouth.
 
-## Decision required
+## The decision that was required, and how it resolved
 
 Confirm the product name, or supply a different one, before M1 creates the app records.
+**Resolved 2026-07-27: Dynawalla.**
 
 **Founder's expectation, 2026-07-25:**
 

--- a/dynawalla/docs/MISSION.md
+++ b/dynawalla/docs/MISSION.md
@@ -1,4 +1,4 @@
-# Dynawalla: Apprentice of Numbers — Mission
+# Dynawalla — Mission
 
 Status: a host shell exists and ships no content. See [STATUS.md](STATUS.md).
 Index: [README.md](README.md).

--- a/dynawalla/docs/STORE.md
+++ b/dynawalla/docs/STORE.md
@@ -12,7 +12,7 @@ service-account JSON. The repository is public (`G-11`).
 | | Value |
 |---|---|
 | Bundle id / applicationId | `inc.corpora.dynawalla` (founder decision #6 — note `inc.`, not `com.`) |
-| Working product name | Dynawalla: Apprentice of Numbers — [ADR-0016](DECISIONS/ADR-0016-app-store-product-name.md) |
+| Product name | **Dynawalla** — ratified 2026-07-27, [ADR-0016](DECISIONS/ADR-0016-app-store-product-name.md). The App Store SKU is immutable and is now set. |
 | iOS deployment target | 16.0, `ITSAppUsesNonExemptEncryption: false` |
 | Android | `minSdk 26`, `compileSdk 36`, `targetSdk 36` |
 

--- a/dynawalla/dynawalla-app/README.md
+++ b/dynawalla/dynawalla-app/README.md
@@ -1,6 +1,6 @@
 # dynawalla-app
 
-The Tauri 2 shell for **Dynawalla: Apprentice of Numbers** — bundle
+The Tauri 2 shell for **Dynawalla** — bundle
 `inc.corpora.dynawalla`.
 
 Program docs live in [`../docs/`](../docs/README.md); the architecture this tree


### PR DESCRIPTION
## What

ADR-0016 moves from `Proposed — awaiting founder` to `Accepted`. The product name is
**Dynawalla**. Drops the working name "Dynawalla: Apprentice of Numbers" from
`STORE.md`, `MISSION.md` and `dynawalla-app/README.md`.

## Why

The founder settled it on 2026-07-27: *"name is Dynawalla. inc.corpora.dynawalla"*.

The App Store Connect app record **already exists** — confirmed live by the new ASC
preflight step passing in release run
[30296868647](https://github.com/corpora-inc/encorpora/actions/runs/30296868647).
So the repo was contradicting the store, and the App Store SKU is immutable. This
records reality rather than authorising it.

## Blast radius

- [x] Documentation only. No code, no workflow, no build.
- [x] Bundle id `inc.corpora.dynawalla` unchanged — it never depended on the display name.
- [ ] **This does not clear the name.** The two counsel-grade collision vectors are
      untouched: **Dynamo Maths** (a live UK children's mathematics intervention, ages
      6-11, shared `Dyna-` prefix, same customers, same subject) and **Physics Wallah**'s
      injunction asserting rights over a *"family of trademarks using the suffix
      'wallah'"* (relevant only if India is a launch market). A paid clearance search
      before filing remains advisable.
- [ ] Two hygiene items stay open, both still recorded in the ADR: dangling DNS records
      on the domain we own, and a public repo tying the name to dietary-supplement health
      claims — one search away from a product aimed at seven-year-olds.

## Proof

```
$ grep -rn "Apprentice of Numbers" dynawalla/ | grep -v ADR-0016
(no output)
```

Every reference outside the ADR's own history is gone. The ADR retains the full
2026-07-25 research record verbatim; only its status and framing changed.
