### PR TITLE
test(dynawalla/games/horde): close the hyphen assertion's blind spot

### DIFF
--- a/dynawalla/games/horde/src/stubHost.test.ts
+++ b/dynawalla/games/horde/src/stubHost.test.ts
@@ -34,7 +34,16 @@ test("every generated question is well formed", () => {
     assert.equal(new Set(vals).size, 3, `duplicate distractors in ${q.prompt}`)
 
     assert.ok(q.prompt.length > 0, "empty prompt")
-    assert.doesNotMatch(q.prompt, /(?<![0-9(])-/, "use U+2212, never a hyphen")
+    // Strict: no ASCII hyphen anywhere in a prompt. Every generator emits
+    // U+2212 for both subtraction and negation, so nothing legitimate puts a
+    // hyphen here.
+    //
+    // The `(?<![0-9(])-` lookbehind this replaces had a hole exactly where it
+    // mattered: it accepted `(-4) + 2`, because the hyphen follows `(`. That is
+    // the precise shape genSigned produces — `(−a) + (−b)` — so a generator
+    // regressing from U+2212 to ASCII in its negation branch was the one
+    // regression the assertion could not see.
+    assert.doesNotMatch(q.prompt, /-/, "use U+2212, never a hyphen")
     assert.ok(q.id.length > 0, "empty id")
   }
 })


### PR DESCRIPTION
## What

Replace horde's hyphen assertion `doesNotMatch(prompt, /(?<![0-9(])-/)` with the
strict `doesNotMatch(prompt, /-/)`.

## Why

I wrote the lookbehind version in #568 and it has a hole exactly where it
matters. The lookbehind exempts a hyphen that follows `(`, so `(-4) + 2` passes:

```
$ node -e 'const loose=/(?<![0-9(])-/, strict=/-/;
  for (const s of ["5 - 3","(-4) + 2","7 − 2"])
    console.log(JSON.stringify(s), "loose-catches:", loose.test(s), "strict-catches:", strict.test(s))'
"5 - 3" loose-catches: true strict-catches: true
"(-4) + 2" loose-catches: false strict-catches: true
"7 − 2" loose-catches: false strict-catches: false
```

`(-4) + 2` is precisely the shape `genSigned` emits — `(−a) + (−b)`. So the one
regression this assertion exists to catch, a generator dropping U+2212 for ASCII
in its negation branch, was the one regression it could not see. The last line
confirms the strict form still accepts legitimate U+2212 prompts, so this
tightens without becoming a false alarm.

## Blast radius

**Areas touched:** dynawalla (one test file)

- [x] Test-only. One assertion in `dynawalla/games/horde/src/stubHost.test.ts`.
      No game code, no generator, no other game.
- [x] Covered by the `dynawalla-packs · games + pack build` job added in #560.
- [x] **Pack back-compat.** Nothing published, no catalog entry, no `voiceId`.
- [x] **Native integrity.** No Rust, no `src-tauri`, no `links =`, no `[patch]`.
- [x] **Strings.** No user-visible strings; not a locale change.
- [x] **Curriculum.** No skill id, grade, binding or answer schema touched. This
      strengthens a check on generator output; it does not change that output.
- [x] **Secrets.** None.

## Proof

```
$ npm test          # in dynawalla/games/horde/
# tests 7
# pass 7
# fail 0

$ npm run tsc       # tsc --noEmit
0 errors
```

Empirically justified, not just argued — across 4,000 prompts spanning the whole
difficulty ramp (all five families), zero contain an ASCII hyphen, so the strict
assertion has no false positive to hit:

```
$ node --experimental-strip-types -e '…4000 prompts, difficulty (i%10)+1…'
prompts with an ASCII hyphen: 0 of 4000
```

```
$ git diff --name-only origin/main...HEAD
dynawalla/games/horde/src/stubHost.test.ts
```
