### PR TITLE
ci(testflight): add an internal tester by API, and refuse to guess when the email is not on the team

### DIFF
--- a/.github/scripts/manage_testflight_testers.py
+++ b/.github/scripts/manage_testflight_testers.py
@@ -1,0 +1,658 @@
+#!/usr/bin/env python3
+"""Add a TestFlight beta tester to Dynawalla's INTERNAL group, by API.
+
+The standing rule is that App Store Connect and Play are driven by API, not by
+clicking. The App Store Connect credentials exist only as GitHub Actions
+secrets, so this script's home is `.github/workflows/testflight-testers.yml`
+and its first real execution is a `workflow_dispatch` — it cannot be rehearsed
+against the live API from a developer machine. Everything that does not need
+the network is unit-tested in `test_manage_testflight_testers.py`; everything
+that does is written to fail LOUDLY and specifically rather than to guess.
+
+THE THING THAT BITES. An *internal* TestFlight tester must already be a user on
+the App Store Connect team — Apple documents `isInternalGroup` as "Only
+existing users of App Store Connect may be added for internal beta testing."
+External testers are email-only but need Beta App Review of each build. So an
+email that is not on the team cannot simply be added, and Apple's refusal is a
+generic 409/422 that reads like a bug. This script therefore checks
+`GET /v1/users` FIRST and says exactly which situation it is in:
+
+  * already in the internal group  -> success, nothing sent (idempotent)
+  * an App Store Connect user      -> added to the internal group
+  * not a user, no --invite        -> FAILS, naming precisely what is required
+  * not a user, with --invite      -> sends a team invitation, then stops:
+                                      the invitation must be ACCEPTED before
+                                      the account exists and can be a tester
+
+--invite is opt-in on purpose. Inviting someone to the App Store Connect team
+is a real permission grant on the Corpora Inc. developer account and must never
+be a side effect of "add a tester". The invitation is scoped to this one app
+(`allAppsVisible: false` + `visibleApps: [dynawalla]`) and to the least
+privileged role that Apple's TestFlight documentation accepts as an internal
+tester.
+
+Usage:
+  manage_testflight_testers.py --email a@b.com [--invite] [--dry-run]
+                               [--role DEVELOPER] [--group-name NAME]
+                               [--first-name F --last-name L]
+
+Environment:
+  ASC_KEY_ID     App Store Connect API key id
+  ASC_ISSUER_ID  App Store Connect issuer id
+  ASC_API_KEY_P8 the .p8 private key (the PEM text itself)
+  ASC_BUNDLE_ID  optional, defaults to inc.corpora.dynawalla
+
+None of those values is ever printed. Only their presence/absence is. This
+repository is public.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+# The ES256/JWT auth for App Store Connect already exists in this directory and
+# is already covered by tests, including the re-mint-before-Apple's-ceiling
+# behaviour. Import it rather than writing a second way to authenticate.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from verify_testflight_upload import API, Bearer, fail, require  # noqa: E402
+
+DEFAULT_BUNDLE_ID = "inc.corpora.dynawalla"
+DEFAULT_GROUP_NAME = "Internal Testers"
+
+# Apple's ceiling for `limit` on every endpoint used here.
+PAGE_LIMIT = "200"
+# A paginated read that never terminates would be answered as "not found", and
+# "not found" is the branch that sends an invitation. Refuse instead.
+MAX_PAGES = 25
+
+# https://developer.apple.com/testflight/ — "Designate up to 100 members of
+# your development team who hold the Account Holder, Admin, App Manager,
+# Developer, or Marketing role as beta testers." ACCOUNT_HOLDER is deliberately
+# absent: it is the account owner and is not something to invite anyone into.
+INTERNAL_TESTER_ROLES = ("DEVELOPER", "APP_MANAGER", "MARKETING", "ADMIN")
+
+
+class ApiError(Exception):
+    """A non-2xx from App Store Connect, kept structured so callers can branch.
+
+    Apple does not document the error it returns when a non-team email is
+    pushed at an internal group, so no caller may branch on `detail` text — the
+    status code and the `errors[].code` prefix are all that is load-bearing.
+    """
+
+    def __init__(self, method: str, url: str, code: int, body: str) -> None:
+        super().__init__(f"{method} {url} -> HTTP {code}")
+        self.method = method
+        self.url = url
+        self.code = code
+        self.body = body
+
+    @property
+    def codes(self) -> list[str]:
+        try:
+            parsed = json.loads(self.body)
+        except (ValueError, TypeError):
+            return []
+        return [str(e.get("code", "")) for e in (parsed.get("errors") or [])]
+
+
+# ---- pure helpers (unit-tested) --------------------------------------------
+
+
+def same_email(left: str | None, right: str | None) -> bool:
+    """Email comparison for identity, not for delivery.
+
+    Case-insensitive because App Store Connect echoes back whatever case was
+    typed, and a case difference here would re-invite a user who already
+    exists. Nothing else is normalised: `a+b@x.com` and `a@x.com` are DIFFERENT
+    App Store Connect accounts even though Gmail delivers both to one inbox,
+    and folding the `+tag` would make this script report success about the
+    wrong account.
+    """
+    if not left or not right:
+        return False
+    return left.strip().lower() == right.strip().lower()
+
+
+def derive_names(email: str, first: str | None, last: str | None) -> tuple[str, str]:
+    """First/last name for the tester or invitation record.
+
+    `POST /v1/userInvitations` REQUIRES both, so they cannot be left empty.
+    Explicit flags always win; otherwise guess from the local part
+    (`skylar.saveland+apple@gmail.com` -> `Skylar Saveland`), which is a label
+    on a TestFlight row and not an identity claim. Anything unguessable falls
+    back to the local part and `TestFlight`, never to an empty string — Apple
+    rejects those with a 400 that reads like a malformed request.
+    """
+    local = email.split("@", 1)[0].split("+", 1)[0]
+    parts = [p for p in local.replace("_", ".").replace("-", ".").split(".") if p]
+    guess_first = parts[0].capitalize() if parts else "TestFlight"
+    guess_last = parts[-1].capitalize() if len(parts) > 1 else "TestFlight"
+    return (first or guess_first).strip(), (last or guess_last).strip()
+
+
+def internal_groups(groups: list[dict], name: str | None) -> list[dict]:
+    """The internal beta groups, optionally narrowed to one by name.
+
+    `isInternalGroup` is compared with `is True`, not truthily: a payload where
+    the field is absent (a `fields[betaGroups]` change, a future API version)
+    must not be read as internal. Adding an email to a group that is really
+    EXTERNAL is the one silent wrong outcome available here — it would appear
+    to succeed and then sit behind Beta App Review forever.
+    """
+    found = [g for g in groups if ((g.get("attributes") or {}).get("isInternalGroup")) is True]
+    if name:
+        found = [g for g in found if ((g.get("attributes") or {}).get("name")) == name]
+    return found
+
+
+def group_label(group: dict) -> str:
+    attributes = group.get("attributes") or {}
+    return f"{attributes.get('name')!r} (id {group.get('id')})"
+
+
+def explain(exc: ApiError) -> str:
+    """The standard, actionable rendering of an App Store Connect failure."""
+    detail = exc.body[:600]
+    if exc.code == 401:
+        return "App Store Connect returned 401 — the API key is not valid for this team."
+    if exc.code == 403:
+        return (
+            f"{exc.method} {exc.url} -> 403. The App Store Connect key lacks the role this "
+            f"call needs. Managing testers needs App Manager or Admin; sending a user "
+            f"invitation needs Admin. Response: {detail}"
+        )
+    if exc.code == 404:
+        return f"{exc.method} {exc.url} -> 404. That resource does not exist. Response: {detail}"
+    return f"{exc.method} {exc.url} -> HTTP {exc.code}: {detail}"
+
+
+# ---- network ---------------------------------------------------------------
+
+
+def request_json(method: str, url: str, bearer: Bearer, body: dict | None = None) -> dict:
+    """One App Store Connect call. Raises ApiError on any non-2xx.
+
+    The bearer token is only ever placed in the Authorization header and is
+    never logged, never echoed into a message, and never written to an output.
+    """
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    request = urllib.request.Request(url, data=data, method=method)
+    request.add_header("Authorization", f"Bearer {bearer.value()}")
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            raw = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        raise ApiError(method, url, exc.code, exc.read().decode("utf-8", "replace")) from None
+    except urllib.error.URLError as exc:
+        fail(f"{method} {url} failed: {exc}")
+    # A linkage POST answers 204 with an empty body; json.loads("") would raise.
+    return json.loads(raw) if raw.strip() else {}
+
+
+def _pages(path: str, params: dict[str, str], bearer: Bearer) -> list[dict]:
+    """Every page of a collection, following `links.next` verbatim.
+
+    Client-side matching is applied by every caller on top of whatever
+    `filter[...]` is passed. That is deliberate: a filter Apple silently
+    ignored would otherwise turn "is this email on the team?" into "is ANY
+    email on the team?" and answer yes. With client-side matching, an ignored
+    filter costs a few extra pages and still gives the right answer.
+    """
+    url = f"{API}/{path}?{urllib.parse.urlencode(params)}"
+    items: list[dict] = []
+    seen = 0
+    while url:
+        payload = request_json("GET", url, bearer)
+        items.extend(payload.get("data") or [])
+        seen += 1
+        if seen >= MAX_PAGES:
+            # Never degrade to a partial answer: "absent from a truncated list"
+            # is exactly how this script would decide to send an invitation
+            # that is not needed.
+            fail(
+                f"GET {path} still had more pages after {MAX_PAGES} × {PAGE_LIMIT} results. "
+                "Refusing to answer from a truncated list."
+            )
+        url = ((payload.get("links") or {}).get("next")) or ""
+    return items
+
+
+def get_all(path: str, params: dict[str, str], bearer: Bearer) -> list[dict]:
+    """`_pages`, aborting on any API error."""
+    try:
+        return _pages(path, params, bearer)
+    except ApiError as exc:
+        fail(explain(exc))
+
+
+def try_get_all(
+    path: str, params: dict[str, str], bearer: Bearer, tolerate: tuple[int, ...]
+) -> list[dict] | None:
+    """`_pages`, but None — "could not read" — for the listed status codes.
+
+    None is NOT an empty list and callers must not collapse the two.
+    """
+    try:
+        return _pages(path, params, bearer)
+    except ApiError as exc:
+        if exc.code in tolerate:
+            return None
+        fail(explain(exc))
+
+
+# ---- reads -----------------------------------------------------------------
+
+
+def resolve_app(bundle_id: str, bearer: Bearer) -> str:
+    apps = get_all("apps", {"filter[bundleId]": bundle_id, "limit": PAGE_LIMIT}, bearer)
+    matches = [a for a in apps if (a.get("attributes") or {}).get("bundleId") == bundle_id]
+    if not matches:
+        fail(
+            f"No App Store Connect app record for bundle id {bundle_id}. There is no "
+            "app-create operation in the API — the record is created on the App Store "
+            "Connect website (dynawalla/docs/STORE.md). This is a founder action."
+        )
+    app_id = str(matches[0]["id"])
+    print(f"App Store Connect app {app_id} for {bundle_id}.")
+    return app_id
+
+
+def find_internal_group(app_id: str, bearer: Bearer, name: str | None) -> dict | None:
+    groups = get_all(f"apps/{app_id}/betaGroups", {"limit": PAGE_LIMIT}, bearer)
+    for group in groups:
+        attributes = group.get("attributes") or {}
+        kind = "internal" if attributes.get("isInternalGroup") is True else "external"
+        print(f"  beta group {group.get('id')}: {attributes.get('name')!r} [{kind}]")
+    candidates = internal_groups(groups, name)
+    if len(candidates) > 1:
+        fail(
+            "This app has more than one internal beta group "
+            f"({', '.join(group_label(g) for g in candidates)}). Re-run with "
+            "--group-name to say which one, rather than picking for you."
+        )
+    return candidates[0] if candidates else None
+
+
+def group_has_tester(group_id: str, email: str, bearer: Bearer) -> bool:
+    """Membership read via the group's own sub-resource.
+
+    `GET /v1/betaGroups/{id}/betaTesters` accepts NO filters at all, so nothing
+    can be silently ignored — unlike `GET /v1/betaTesters?filter[betaGroups]=`,
+    where an ignored filter would report a tester of some other group as a
+    member of this one and skip the add. An internal group holds at most 100
+    testers, so this is one page.
+    """
+    testers = get_all(f"betaGroups/{group_id}/betaTesters", {"limit": PAGE_LIMIT}, bearer)
+    return any(same_email((t.get("attributes") or {}).get("email"), email) for t in testers)
+
+
+def find_beta_tester(email: str, bearer: Bearer) -> dict | None:
+    testers = get_all(
+        "betaTesters", {"filter[email]": email, "limit": PAGE_LIMIT}, bearer
+    )
+    for tester in testers:
+        if same_email((tester.get("attributes") or {}).get("email"), email):
+            return tester
+    return None
+
+
+def find_asc_user(email: str, bearer: Bearer) -> dict | None:
+    """The App Store Connect team member for this email, if there is one.
+
+    `User` has no `email` attribute; `username` IS the Apple Account address.
+
+    A 403 here is its own diagnosis, not a generic permissions error: reading
+    the team roster needs the ADMIN role, while everything else this script
+    does needs only App Manager. It is a plausible shape for the CI key to
+    have, and "the key cannot see the roster" must not be answered as "the
+    address is not on the team" — that is the branch that offers to invite.
+    """
+    users = try_get_all("users", {"filter[username]": email, "limit": PAGE_LIMIT}, bearer, (403,))
+    if users is None:
+        fail(
+            "This App Store Connect API key cannot list team users (403). That read "
+            "needs the ADMIN role — an App Manager key can manage testers but cannot "
+            "see who is on the team, and an internal tester that cannot be confirmed "
+            "to be a team member will not be added on a guess. Re-issue the key with "
+            "the Admin role (App Store Connect > Users and Access > Integrations) and "
+            "re-run. Nothing was changed."
+        )
+    for user in users:
+        if same_email((user.get("attributes") or {}).get("username"), email):
+            return user
+    return None
+
+
+def find_pending_invitation(email: str, bearer: Bearer) -> dict | None:
+    """A team invitation already sent and not yet accepted.
+
+    Listed WITHOUT a filter parameter on purpose: the pending-invitation list
+    is tiny, and a filter Apple rejected with a 400 would abort the one read
+    that keeps --invite from sending a duplicate.
+
+    A 403 is tolerated. Reading user invitations needs the Admin role, but
+    everything up to here needs only App Manager — so an App-Manager key must
+    still be able to reach the "this address is not on the team, here is what
+    to do" report instead of dying on a permission it does not need for that
+    answer. An actual invitation would 403 too, loudly, one call later.
+    """
+    invitations = try_get_all("userInvitations", {"limit": PAGE_LIMIT}, bearer, (403,))
+    if invitations is None:
+        print(
+            "::warning::this API key cannot list pending user invitations (403 — that "
+            "read needs the Admin role). Continuing without knowing whether one is "
+            "already pending."
+        )
+        return None
+    for invitation in invitations:
+        if same_email((invitation.get("attributes") or {}).get("email"), email):
+            return invitation
+    return None
+
+
+# ---- writes ----------------------------------------------------------------
+
+
+def create_internal_group(app_id: str, name: str, bearer: Bearer) -> dict:
+    """`isInternalGroup` is settable at creation, so this needs no clicking."""
+    print(f"::notice::creating internal beta group {name!r} for app {app_id}")
+    body = {
+        "data": {
+            "type": "betaGroups",
+            "attributes": {
+                "name": name,
+                "isInternalGroup": True,
+                # Internal testers should receive every build automatically;
+                # without this each build has to be assigned to the group by
+                # hand, which is the clicking this script exists to avoid.
+                "hasAccessToAllBuilds": True,
+            },
+            "relationships": {"app": {"data": {"type": "apps", "id": app_id}}},
+        }
+    }
+    try:
+        created = request_json("POST", f"{API}/betaGroups", bearer, body)
+    except ApiError as exc:
+        fail(
+            f"Could not create an internal beta group: {explain(exc)} "
+            "Apple's BetaGroupCreateRequest accepts name + isInternalGroup + an app "
+            "relationship; if it refused them, create the group in App Store Connect "
+            "under TestFlight > Internal Testing and re-run with --group-name."
+        )
+    group = created.get("data") or {}
+    if not group.get("id"):
+        fail(f"App Store Connect returned no id for the new beta group: {created}")
+    print(f"Created internal beta group {group_label(group)}.")
+    return group
+
+
+def add_tester(group: dict, email: str, first: str, last: str, bearer: Bearer) -> None:
+    """Put an existing App Store Connect user into the internal group.
+
+    Two routes, and which one applies depends on whether a BetaTester record
+    for this email already exists anywhere on the account:
+
+      * none exists -> POST /v1/betaTesters creates it AND links the group (201)
+      * one exists  -> POST /v1/betaGroups/{id}/relationships/betaTesters (204)
+
+    Creating a tester whose email already has a record is a 409, so the lookup
+    is not an optimisation.
+    """
+    group_id = str(group["id"])
+    existing = find_beta_tester(email, bearer)
+    if existing:
+        tester_id = str(existing["id"])
+        print(f"Beta tester record {tester_id} already exists; linking it to the group.")
+        url = f"{API}/betaGroups/{group_id}/relationships/betaTesters"
+        body: dict[str, Any] = {"data": [{"type": "betaTesters", "id": tester_id}]}
+    else:
+        url = f"{API}/betaTesters"
+        body = {
+            "data": {
+                "type": "betaTesters",
+                "attributes": {"email": email, "firstName": first, "lastName": last},
+                "relationships": {
+                    "betaGroups": {"data": [{"type": "betaGroups", "id": group_id}]}
+                },
+            }
+        }
+    try:
+        request_json("POST", url, bearer, body)
+    except ApiError as exc:
+        if exc.code in (400, 409, 422):
+            fail(
+                f"App Store Connect refused to add {email} to internal group "
+                f"{group_label(group)} (HTTP {exc.code}, codes {exc.codes or ['?']}). "
+                "The usual cause is that the account is not eligible as an INTERNAL "
+                "tester: only App Store Connect users holding Account Holder, Admin, "
+                "App Manager, Developer or Marketing may be. Full response: "
+                f"{exc.body[:600]}"
+            )
+        fail(explain(exc))
+    print(f"Added {email} to internal beta group {group_label(group)}.")
+
+
+def send_invitation(
+    app_id: str, email: str, first: str, last: str, role: str, bearer: Bearer
+) -> None:
+    """Invite the address onto the App Store Connect team. A real grant.
+
+    Scoped as tightly as the API allows: one role, and `allAppsVisible: false`
+    with `visibleApps` pinned to this app. Apple documents neither the
+    per-role constraints on `allAppsVisible` nor whether every role tolerates a
+    `visibleApps` list, so a refusal of the scoped form retries ONCE with the
+    account-wide form — and says so, loudly, because that is a wider grant than
+    the one that was attempted first.
+    """
+    scoped = {
+        "data": {
+            "type": "userInvitations",
+            "attributes": {
+                "email": email,
+                "firstName": first,
+                "lastName": last,
+                "roles": [role],
+                "allAppsVisible": False,
+                "provisioningAllowed": False,
+            },
+            "relationships": {"visibleApps": {"data": [{"type": "apps", "id": app_id}]}},
+        }
+    }
+    print(f"::notice::sending an App Store Connect team invitation to {email} as {role}")
+    try:
+        request_json("POST", f"{API}/userInvitations", bearer, scoped)
+    except ApiError as exc:
+        if exc.code not in (400, 409, 422):
+            fail(explain(exc))
+        print(
+            f"::warning::App Store Connect refused the app-scoped invitation "
+            f"(HTTP {exc.code}, codes {exc.codes or ['?']}). Retrying ONCE with "
+            "allAppsVisible=true, which is a WIDER grant: the invitee will see every "
+            "app on the Corpora Inc. account, not just Dynawalla."
+        )
+        wide = json.loads(json.dumps(scoped))
+        wide["data"]["attributes"]["allAppsVisible"] = True
+        wide["data"].pop("relationships")
+        try:
+            request_json("POST", f"{API}/userInvitations", bearer, wide)
+        except ApiError as retry:
+            fail(
+                f"Could not invite {email} to the App Store Connect team: {explain(retry)}"
+            )
+
+
+# ---- reporting -------------------------------------------------------------
+
+
+def summarise(lines: list[str]) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines) + "\n")
+
+
+# ---- entry point -----------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Manage TestFlight internal testers.")
+    parser.add_argument("--email", required=True, help="the tester's Apple Account email")
+    parser.add_argument(
+        "--invite",
+        action="store_true",
+        help=(
+            "if the email is not already on the App Store Connect team, send it a team "
+            "invitation. This GRANTS ACCESS to the Corpora Inc. developer account and is "
+            "never done implicitly."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="read everything, change nothing, and print what would be done",
+    )
+    parser.add_argument(
+        "--role",
+        default="DEVELOPER",
+        choices=INTERNAL_TESTER_ROLES,
+        help="role for --invite (default DEVELOPER; MARKETING is the least privileged "
+        "role Apple accepts as an internal tester)",
+    )
+    parser.add_argument("--group-name", default=None, help="disambiguate the internal group")
+    parser.add_argument("--first-name", default=None)
+    parser.add_argument("--last-name", default=None)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    email = args.email.strip()
+    if "@" not in email or email.startswith("@") or email.endswith("@"):
+        fail(f"--email does not look like an email address: {email!r}")
+    first, last = derive_names(email, args.first_name, args.last_name)
+    bundle_id = os.environ.get("ASC_BUNDLE_ID", "").strip() or DEFAULT_BUNDLE_ID
+    if args.dry_run:
+        print("::notice::--dry-run: every write below is described, not sent.")
+
+    bearer = Bearer(require("ASC_KEY_ID"), require("ASC_ISSUER_ID"), require("ASC_API_KEY_P8"))
+    app_id = resolve_app(bundle_id, bearer)
+
+    group = find_internal_group(app_id, bearer, args.group_name)
+    if group is None:
+        name = args.group_name or DEFAULT_GROUP_NAME
+        if args.dry_run:
+            print(f"WOULD create internal beta group {name!r} for app {app_id}.")
+            summarise([f"- would create internal beta group `{name}`"])
+            return
+        group = create_internal_group(app_id, name, bearer)
+    print(f"Internal beta group: {group_label(group)}.")
+
+    # Idempotence first, and before the team-membership read: an address that
+    # is already testing is a success no matter what the users endpoint says.
+    if group_has_tester(str(group["id"]), email, bearer):
+        print(f"{email} is already a tester in {group_label(group)}. Nothing to do.")
+        summarise([f"- `{email}` was already an internal tester of `{bundle_id}`"])
+        return
+
+    user = find_asc_user(email, bearer)
+    if user is not None:
+        roles = (user.get("attributes") or {}).get("roles") or []
+        print(f"{email} is App Store Connect user {user.get('id')} with roles {roles}.")
+        if args.dry_run:
+            print(f"WOULD add {email} to {group_label(group)}.")
+            summarise([f"- would add `{email}` to internal group `{group_label(group)}`"])
+            return
+        add_tester(group, email, first, last, bearer)
+        summarise([f"- added `{email}` to internal group `{group_label(group)}`"])
+        return
+
+    # Not on the team. This is THE case that fails obscurely if it is left to
+    # Apple to reject, so it is decided here instead.
+    print(f"{email} is NOT an App Store Connect user on this team.")
+    pending = find_pending_invitation(email, bearer)
+    if pending is not None:
+        expires = (pending.get("attributes") or {}).get("expirationDate")
+        print(
+            f"A team invitation for {email} is already pending (expires {expires}). "
+            "It must be ACCEPTED from that mailbox before the account exists and can "
+            "be an internal tester. Re-run this workflow after accepting."
+        )
+        summarise(
+            [
+                f"- `{email}` has a **pending** App Store Connect invitation (expires {expires})",
+                "- accept it from that mailbox, then re-run this workflow to add the tester",
+            ]
+        )
+        return
+
+    if not args.invite:
+        # Printed, then failed with ONE line: `::error::` is an annotation and
+        # only its first line renders as one. The detail belongs in the log.
+        print(
+            f"\n{email} is not a user on the App Store Connect team, so it cannot be an "
+            "INTERNAL TestFlight tester — Apple allows only existing App Store Connect "
+            "users in an internal group. Nothing was changed.\n"
+            "\nTo proceed, ONE of:\n"
+            "  (a) re-run this workflow with invite=true. That sends an App Store "
+            f"Connect team invitation to {email}, scoped to {bundle_id}, with the "
+            f"{args.role} role. It is a real permission grant on the Corpora Inc. "
+            "developer account, which is why it is opt-in and not automatic.\n"
+            "      The invitation must then be ACCEPTED from that mailbox; only once "
+            "the account exists can this workflow add it as a tester.\n"
+            "  (b) use an EXTERNAL beta group instead — email-only, no team membership, "
+            "but every build then needs Beta App Review before testers can install it. "
+            "This script does not do that.\n"
+        )
+        summarise(
+            [
+                f"- `{email}` is **not** an App Store Connect user — nothing was changed",
+                "- re-run with `invite: true` to send a team invitation (a permission grant)",
+            ]
+        )
+        fail(
+            f"{email} is not on the App Store Connect team; re-run with invite=true to "
+            "invite them. Nothing was changed."
+        )
+
+    if args.dry_run:
+        print(f"WOULD invite {email} to the App Store Connect team as {args.role}.")
+        summarise([f"- would invite `{email}` to the team as `{args.role}`"])
+        return
+
+    send_invitation(app_id, email, first, last, args.role, bearer)
+    print(
+        "\n"
+        "================ ACTION REQUIRED ================\n"
+        f"An App Store Connect team invitation was sent to {email} as {args.role}, "
+        f"scoped to {bundle_id}.\n"
+        "The tester was NOT added to TestFlight: a PENDING invitation is not an "
+        "account, and only existing App Store Connect users may join an internal "
+        "beta group.\n"
+        f"1. Accept the invitation from {email}.\n"
+        "2. Re-run this workflow (invite is not needed the second time).\n"
+        "================================================="
+    )
+    summarise(
+        [
+            f"- **invited** `{email}` to the App Store Connect team as `{args.role}`",
+            f"- scoped to `{bundle_id}` (`allAppsVisible: false`)",
+            "- **NOT yet a TestFlight tester** — accept the invitation, then re-run this "
+            "workflow",
+        ]
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_manage_testflight_testers.py
+++ b/.github/scripts/test_manage_testflight_testers.py
@@ -1,0 +1,523 @@
+"""Tests for the TestFlight internal-tester manager.
+
+Same reason `test_verify_testflight_upload.py` exists, one notch worse: this
+script's credentials live only in GitHub Actions, so it CANNOT be rehearsed
+against the live API before its first real dispatch, and its failure mode is to
+mutate the Corpora Inc. App Store Connect account in a way nobody asked for.
+These tests are the only thing standing in for that rehearsal.
+
+What each one is guarding:
+
+  * an internal group is chosen by `isInternalGroup is True` and never by
+    position — adding an email to an EXTERNAL group looks like success and then
+    sits behind Beta App Review forever
+  * a tester already in the group is a SUCCESS, and sends nothing
+  * an email that is not an App Store Connect user is REFUSED, with nothing
+    sent, unless --invite was passed — inviting is a permission grant
+  * --invite stops after the invitation: a pending invitation is not an account
+  * --dry-run sends no POST at all
+  * a truncated paginated read is never answered as "absent"
+  * the private key never reaches stdout
+
+Run: python -m pytest .github/scripts -q
+"""
+
+import io
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import manage_testflight_testers as mt  # noqa: E402
+
+EMAIL = "skylar.saveland+apple@gmail.com"
+APP = {"id": "app1", "attributes": {"bundleId": "inc.corpora.dynawalla"}}
+INTERNAL = {"id": "grp-int", "attributes": {"name": "Internal Testers", "isInternalGroup": True}}
+EXTERNAL = {"id": "grp-ext", "attributes": {"name": "Public", "isInternalGroup": False}}
+# A stand-in for the .p8, shaped by `hygiene.yml`'s gitleaks scan of this very
+# diff — which flagged two earlier spellings of this line. No PEM armour, because
+# the `private-key` rule matches `-----BEGIN ... PRIVATE KEY-----` in a fixture
+# as happily as in a real key; no `SECRET`/`KEY` in the name and spaces in the
+# value, because `generic-api-key` matches on the assignment target and on a
+# `[\w.=-]{10,150}` value.
+P8_STAND_IN = "p8 stand-in, must never be logged"
+
+
+class FakeApi:
+    """The HTTP layer. Routes on (method, path); records every mutation.
+
+    Deliberately NOT a mock of `request_json`'s callers: pagination, the
+    client-side email matching that defends against an ignored `filter[...]`,
+    and the 201-vs-204 body handling all live in the layer above it.
+    """
+
+    def __init__(self, *, groups=None, members=(), testers=(), users=(), invitations=()):
+        self.groups = [INTERNAL] if groups is None else groups
+        self.members = list(members)
+        self.testers = list(testers)
+        self.users = list(users)
+        self.invitations = list(invitations)
+        self.writes = []
+        self.responses = {}  # (method, path) -> exception to raise
+
+    def __call__(self, method, url, bearer, body=None):
+        path = urllib.parse.urlparse(url).path
+        key = (method, path)
+        if key in self.responses:
+            raise self.responses.pop(key)
+        if method == "POST":
+            self.writes.append((path, body))
+            return self._post(path, body)
+        return {"data": self._get(path)}
+
+    def _get(self, path):
+        if path == "/v1/apps":
+            return [APP]
+        if path == "/v1/apps/app1/betaGroups":
+            return self.groups
+        if path.endswith("/betaTesters") and path.startswith("/v1/betaGroups/"):
+            return self.members
+        if path == "/v1/betaTesters":
+            return self.testers
+        if path == "/v1/users":
+            return self.users
+        if path == "/v1/userInvitations":
+            return self.invitations
+        raise AssertionError(f"unrouted GET {path}")
+
+    def _post(self, path, body):
+        if path == "/v1/betaGroups":
+            created = {
+                "id": "grp-new",
+                "attributes": dict(body["data"]["attributes"]),
+            }
+            self.groups.append(created)
+            return {"data": created}
+        if path == "/v1/betaTesters":
+            return {"data": {"id": "tester-new"}}
+        if path.endswith("/relationships/betaTesters"):
+            return {}  # a real 204: empty body
+        if path == "/v1/userInvitations":
+            return {"data": {"id": "inv-new"}}
+        raise AssertionError(f"unrouted POST {path}")
+
+    def posted(self, path):
+        return [b for p, b in self.writes if p == path]
+
+
+@pytest.fixture
+def env(monkeypatch):
+    monkeypatch.setenv("ASC_KEY_ID", "K")
+    monkeypatch.setenv("ASC_ISSUER_ID", "I")
+    monkeypatch.setenv("ASC_API_KEY_P8", P8_STAND_IN)
+    monkeypatch.setenv("ASC_BUNDLE_ID", "inc.corpora.dynawalla")
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    monkeypatch.setattr(mt.Bearer, "value", lambda self: "tok")
+
+
+def run(monkeypatch, api, *argv):
+    monkeypatch.setattr(mt, "request_json", api)
+    mt.main(["--email", EMAIL, *argv])
+    return api
+
+
+def as_tester(email):
+    return {"id": "tester-1", "attributes": {"email": email}}
+
+
+# ------------------------------------------------- already a tester: SUCCESS
+
+
+def test_already_a_tester_is_success_and_sends_nothing(env, monkeypatch, capsys):
+    api = run(monkeypatch, FakeApi(members=[as_tester(EMAIL)]))
+    assert api.writes == []
+    assert "already a tester" in capsys.readouterr().out
+
+
+def test_membership_match_is_case_insensitive(env, monkeypatch, capsys):
+    """App Store Connect echoes back whatever case was typed. A case-sensitive
+    comparison would re-add — or worse, re-invite — an existing tester."""
+    api = run(monkeypatch, FakeApi(members=[as_tester("Skylar.Saveland+Apple@Gmail.com")]))
+    assert api.writes == []
+    assert "already a tester" in capsys.readouterr().out
+
+
+def test_a_plus_tag_is_a_different_account(env, monkeypatch):
+    """Gmail delivers both to one inbox; App Store Connect treats them as two
+    accounts. Folding the tag would report success about the wrong one."""
+    assert not mt.same_email("skylar.saveland@gmail.com", EMAIL)
+    api = run(monkeypatch, FakeApi(members=[as_tester("skylar.saveland@gmail.com")],
+                                   users=[{"id": "u1", "attributes": {"username": EMAIL}}]))
+    assert api.posted("/v1/betaTesters")  # not treated as already present
+
+
+# --------------------------------------------------- is an ASC user: ADD them
+
+
+def test_an_asc_user_is_added_to_the_internal_group(env, monkeypatch, capsys):
+    api = run(monkeypatch, FakeApi(users=[{"id": "u1", "attributes": {"username": EMAIL,
+                                                                     "roles": ["DEVELOPER"]}}]))
+    (body,) = api.posted("/v1/betaTesters")
+    assert body["data"]["attributes"]["email"] == EMAIL
+    assert body["data"]["relationships"]["betaGroups"]["data"] == [
+        {"type": "betaGroups", "id": "grp-int"}
+    ]
+    assert api.posted("/v1/userInvitations") == []
+    assert "Added" in capsys.readouterr().out
+
+
+def test_an_existing_tester_record_is_linked_not_recreated(env, monkeypatch):
+    """POST /v1/betaTesters on an email that already has a record is a 409. If
+    the address tests another app, the linkage route is the only one that
+    works."""
+    api = run(
+        monkeypatch,
+        FakeApi(users=[{"id": "u1", "attributes": {"username": EMAIL}}],
+                testers=[as_tester(EMAIL)]),
+    )
+    assert api.posted("/v1/betaTesters") == []
+    (body,) = api.posted("/v1/betaGroups/grp-int/relationships/betaTesters")
+    assert body == {"data": [{"type": "betaTesters", "id": "tester-1"}]}
+
+
+def test_apples_refusal_to_add_explains_internal_eligibility(env, monkeypatch, capsys):
+    """Apple documents no error for 'not a team member into an internal group'.
+    Whatever 4xx arrives must not surface as a raw API error."""
+    api = FakeApi(users=[{"id": "u1", "attributes": {"username": EMAIL}}])
+    api.responses[("POST", "/v1/betaTesters")] = mt.ApiError(
+        "POST", "u", 409, json.dumps({"errors": [{"code": "STATE_ERROR", "detail": "nope"}]})
+    )
+    monkeypatch.setattr(mt, "request_json", api)
+    with pytest.raises(SystemExit):
+        mt.main(["--email", EMAIL])
+    out = capsys.readouterr().out
+    assert "INTERNAL" in out and "STATE_ERROR" in out
+
+
+# ------------------------------------------- NOT an ASC user: refuse, or invite
+
+
+def test_not_an_asc_user_without_invite_refuses_and_changes_nothing(env, monkeypatch, capsys):
+    api = FakeApi()
+    monkeypatch.setattr(mt, "request_json", api)
+    with pytest.raises(SystemExit) as exc:
+        mt.main(["--email", EMAIL])
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert api.writes == [], "nothing may be sent on the refusal path"
+    assert "not a user on the App Store Connect team" in out
+    assert "invite=true" in out  # names the opt-in
+    assert "Nothing was changed" in out
+
+
+def test_invite_sends_a_scoped_team_invitation_and_stops(env, monkeypatch, capsys):
+    api = run(monkeypatch, FakeApi(), "--invite")
+    (body,) = api.posted("/v1/userInvitations")
+    attributes = body["data"]["attributes"]
+    assert attributes["email"] == EMAIL
+    assert attributes["roles"] == ["DEVELOPER"]
+    assert attributes["allAppsVisible"] is False
+    assert attributes["provisioningAllowed"] is False
+    assert body["data"]["relationships"]["visibleApps"]["data"] == [
+        {"type": "apps", "id": "app1"}
+    ]
+    # A pending invitation is not an account: the tester must NOT be added.
+    assert api.posted("/v1/betaTesters") == []
+    out = capsys.readouterr().out
+    assert "ACTION REQUIRED" in out and "Re-run this workflow" in out
+
+
+def test_invite_role_is_constrained_to_apples_internal_tester_roles():
+    """Apple accepts only Account Holder / Admin / App Manager / Developer /
+    Marketing as internal testers. Inviting as SALES would produce a team member
+    who still cannot test."""
+    with pytest.raises(SystemExit):
+        mt.parse_args(["--email", EMAIL, "--role", "SALES"])
+    assert "ACCOUNT_HOLDER" not in mt.INTERNAL_TESTER_ROLES
+
+
+def test_a_pending_invitation_is_not_sent_twice(env, monkeypatch, capsys):
+    api = run(
+        monkeypatch,
+        FakeApi(invitations=[{"id": "i1", "attributes": {"email": EMAIL,
+                                                         "expirationDate": "2026-08-03"}}]),
+        "--invite",
+    )
+    assert api.writes == []
+    assert "already pending" in capsys.readouterr().out
+
+
+def test_a_pending_invitation_is_reported_even_without_invite(env, monkeypatch, capsys):
+    api = run(
+        monkeypatch,
+        FakeApi(invitations=[{"id": "i1", "attributes": {"email": EMAIL}}]),
+    )
+    assert api.writes == []
+    assert "pending" in capsys.readouterr().out
+
+
+def test_an_app_manager_key_still_gets_the_not_a_team_member_report(env, monkeypatch, capsys):
+    """Listing user invitations needs Admin; everything before it needs only App
+    Manager. A 403 on that ONE read must not replace the actionable report with
+    a permissions error about a call the answer did not depend on."""
+    api = FakeApi()
+    api.responses[("GET", "/v1/userInvitations")] = mt.ApiError("GET", "u", 403, "{}")
+    monkeypatch.setattr(mt, "request_json", api)
+    with pytest.raises(SystemExit):
+        mt.main(["--email", EMAIL])
+    out = capsys.readouterr().out
+    assert "cannot list pending user invitations" in out
+    assert "not on the App Store Connect team" in out
+    assert api.writes == []
+
+
+def test_an_unreadable_roster_is_not_read_as_not_a_member(env, monkeypatch, capsys):
+    """`GET /v1/users` needs Admin. If the key cannot see the roster, "absent
+    from the roster" is not a fact — and it is the branch that offers to
+    invite. Refuse instead, with the role named."""
+    api = FakeApi()
+    api.responses[("GET", "/v1/users")] = mt.ApiError("GET", "u", 403, "{}")
+    monkeypatch.setattr(mt, "request_json", api)
+    with pytest.raises(SystemExit):
+        mt.main(["--email", EMAIL, "--invite"])
+    out = capsys.readouterr().out
+    assert "ADMIN role" in out and "Nothing was changed" in out
+    assert api.writes == [], "an unreadable roster must not trigger an invitation"
+
+
+def test_only_tolerated_codes_are_tolerated(env, monkeypatch, capsys):
+    def boom(method, url, bearer, body=None):
+        raise mt.ApiError(method, url, 403, "{}")
+
+    monkeypatch.setattr(mt, "request_json", boom)
+    assert mt.try_get_all("userInvitations", {}, None, (403,)) is None
+    with pytest.raises(SystemExit):  # the same 403 through the strict reader
+        mt.get_all("users", {}, None)
+    with pytest.raises(SystemExit):  # a code that is not on the list
+        mt.try_get_all("userInvitations", {}, None, (404,))
+
+
+def test_a_refused_app_scoped_invitation_retries_wide_and_says_so(env, monkeypatch, capsys):
+    """Apple does not document whether every role tolerates
+    allAppsVisible=false + visibleApps. The fallback is a WIDER grant, so it
+    must be announced, not silent."""
+    api = FakeApi()
+    api.responses[("POST", "/v1/userInvitations")] = mt.ApiError("POST", "u", 409, "{}")
+    monkeypatch.setattr(mt, "request_json", api)
+    mt.main(["--email", EMAIL, "--invite"])
+    (body,) = api.posted("/v1/userInvitations")
+    assert body["data"]["attributes"]["allAppsVisible"] is True
+    assert "relationships" not in body["data"]
+    assert "::warning::" in capsys.readouterr().out
+
+
+# -------------------------------------------------------------- group choice
+
+
+def test_no_internal_group_is_created_as_internal(env, monkeypatch):
+    api = run(
+        monkeypatch,
+        FakeApi(groups=[EXTERNAL], users=[{"id": "u1", "attributes": {"username": EMAIL}}]),
+    )
+    (body,) = api.posted("/v1/betaGroups")
+    assert body["data"]["attributes"]["isInternalGroup"] is True
+    assert body["data"]["relationships"]["app"]["data"]["id"] == "app1"
+    # ...and the tester lands in the NEW group, not the external one.
+    (tester_body,) = api.posted("/v1/betaTesters")
+    assert tester_body["data"]["relationships"]["betaGroups"]["data"][0]["id"] == "grp-new"
+
+
+def test_an_external_group_is_never_mistaken_for_internal():
+    assert mt.internal_groups([EXTERNAL], None) == []
+    # A payload that simply omits the flag is not internal either.
+    assert mt.internal_groups([{"id": "x", "attributes": {"name": "n"}}], None) == []
+    assert mt.internal_groups([INTERNAL, EXTERNAL], None) == [INTERNAL]
+    assert mt.internal_groups([INTERNAL], "Other") == []
+
+
+def test_two_internal_groups_refuse_to_guess(env, monkeypatch, capsys):
+    other = {"id": "g2", "attributes": {"name": "Second", "isInternalGroup": True}}
+    api = FakeApi(groups=[INTERNAL, other])
+    monkeypatch.setattr(mt, "request_json", api)
+    with pytest.raises(SystemExit):
+        mt.main(["--email", EMAIL])
+    assert "--group-name" in capsys.readouterr().out
+    assert api.writes == []
+
+
+def test_group_name_selects_among_several(env, monkeypatch):
+    other = {"id": "g2", "attributes": {"name": "Second", "isInternalGroup": True}}
+    api = run(
+        monkeypatch,
+        FakeApi(groups=[INTERNAL, other], users=[{"id": "u1", "attributes": {"username": EMAIL}}]),
+        "--group-name",
+        "Second",
+    )
+    (body,) = api.posted("/v1/betaTesters")
+    assert body["data"]["relationships"]["betaGroups"]["data"][0]["id"] == "g2"
+
+
+# ------------------------------------------------------------------ dry run
+
+
+@pytest.mark.parametrize(
+    "state,extra",
+    [
+        ({"users": [{"id": "u1", "attributes": {"username": EMAIL}}]}, []),
+        ({}, ["--invite"]),
+        ({"groups": []}, ["--invite"]),
+    ],
+)
+def test_dry_run_sends_no_post(env, monkeypatch, capsys, state, extra):
+    api = run(monkeypatch, FakeApi(**state), "--dry-run", *extra)
+    assert api.writes == []
+    assert "WOULD" in capsys.readouterr().out
+
+
+# -------------------------------------------------------------- app + pages
+
+
+def test_no_app_record_is_a_founder_action(env, monkeypatch, capsys):
+    api = FakeApi()
+    api._get = lambda path: []  # type: ignore[method-assign]
+    monkeypatch.setattr(mt, "request_json", api)
+    with pytest.raises(SystemExit):
+        mt.main(["--email", EMAIL])
+    assert "founder action" in capsys.readouterr().out
+
+
+def test_pagination_follows_links_next(env, monkeypatch):
+    pages = [
+        {"data": [{"id": "u0", "attributes": {"username": "someone@else.com"}}],
+         "links": {"next": f"{mt.API}/users?cursor=2"}},
+        {"data": [{"id": "u1", "attributes": {"username": EMAIL}}]},
+    ]
+    calls = []
+
+    def api(method, url, bearer, body=None):
+        if method == "GET" and url.startswith(f"{mt.API}/users"):
+            calls.append(url)
+            return pages[len(calls) - 1]
+        return FakeApi()(method, url, bearer, body)
+
+    monkeypatch.setattr(mt, "request_json", api)
+    assert mt.find_asc_user(EMAIL, None)["id"] == "u1"
+    assert len(calls) == 2 and "cursor=2" in calls[1]
+
+
+def test_an_endless_page_chain_is_a_failure_not_an_absence(env, monkeypatch, capsys):
+    """"Absent from a truncated list" is the branch that sends an invitation.
+    It must never be reached by giving up on pagination."""
+    monkeypatch.setattr(
+        mt,
+        "request_json",
+        lambda *a, **k: {"data": [], "links": {"next": f"{mt.API}/users?cursor=x"}},
+    )
+    with pytest.raises(SystemExit):
+        mt.find_asc_user(EMAIL, None)
+    assert "truncated list" in capsys.readouterr().out
+
+
+def test_client_side_matching_survives_an_ignored_filter(env, monkeypatch):
+    """If Apple ever ignored filter[username], a trusting implementation would
+    report the first user on the team as the match."""
+    monkeypatch.setattr(
+        mt,
+        "request_json",
+        lambda *a, **k: {"data": [{"id": "u9", "attributes": {"username": "someone@else.com"}}]},
+    )
+    assert mt.find_asc_user(EMAIL, None) is None
+
+
+# --------------------------------------------------------- secrets + plumbing
+
+
+def test_the_private_key_never_reaches_stdout(env, monkeypatch, capsys):
+    """This repository is public and these logs are public."""
+    api = FakeApi(users=[{"id": "u1", "attributes": {"username": EMAIL}}])
+    monkeypatch.setattr(mt, "request_json", api)
+    mt.main(["--email", EMAIL])
+    captured = capsys.readouterr()
+    for stream in (captured.out, captured.err):
+        assert P8_STAND_IN not in stream
+        assert "stand-in" not in stream
+        assert "tok" not in stream.replace("workflow", "")  # the bearer token
+
+
+def test_a_missing_secret_is_named(monkeypatch, capsys):
+    monkeypatch.delenv("ASC_KEY_ID", raising=False)
+    monkeypatch.setenv("ASC_ISSUER_ID", "I")
+    monkeypatch.setenv("ASC_API_KEY_P8", "P")
+    with pytest.raises(SystemExit):
+        mt.main(["--email", EMAIL])
+    assert "ASC_KEY_ID is not set" in capsys.readouterr().out
+
+
+def test_a_malformed_email_is_rejected_before_any_call(env, monkeypatch, capsys):
+    api = FakeApi()
+    monkeypatch.setattr(mt, "request_json", api)
+    with pytest.raises(SystemExit):
+        mt.main(["--email", "not-an-email"])
+    assert api.writes == []
+    assert "does not look like an email" in capsys.readouterr().out
+
+
+def test_derive_names():
+    assert mt.derive_names(EMAIL, None, None) == ("Skylar", "Saveland")
+    assert mt.derive_names("qa@corpora.inc", None, None) == ("Qa", "TestFlight")
+    assert mt.derive_names(EMAIL, "Given", "Chosen") == ("Given", "Chosen")
+
+
+def test_step_summary_is_appended_when_actions_provides_one(env, monkeypatch, tmp_path):
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    run(monkeypatch, FakeApi(members=[as_tester(EMAIL)]))
+    assert "already an internal tester" in summary.read_text()
+
+
+# ------------------------------------------------------------- HTTP branches
+
+
+def _http_error(code, body=b"{}"):
+    return urllib.error.HTTPError("https://example.invalid", code, "boom", {}, io.BytesIO(body))
+
+
+def test_request_json_raises_a_structured_api_error(env, monkeypatch):
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda *a, **k: (_ for _ in ()).throw(
+            _http_error(409, b'{"errors":[{"code":"ENTITY_ERROR"}]}')
+        ),
+    )
+    with pytest.raises(mt.ApiError) as exc:
+        mt.request_json("POST", f"{mt.API}/betaTesters", mt.Bearer("K", "I", "P"), {"a": 1})
+    assert exc.value.code == 409
+    assert exc.value.codes == ["ENTITY_ERROR"]
+
+
+def test_a_204_with_an_empty_body_is_not_a_json_error(env, monkeypatch):
+    class Empty:
+        def read(self):
+            return b""
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: Empty())
+    assert mt.request_json("POST", f"{mt.API}/x", mt.Bearer("K", "I", "P"), {}) == {}
+
+
+def test_explain_names_the_missing_role_on_403():
+    assert "App Manager or Admin" in mt.explain(mt.ApiError("GET", "u", 403, "{}"))
+    assert "not valid for this team" in mt.explain(mt.ApiError("GET", "u", 401, "{}"))
+    assert "404" in mt.explain(mt.ApiError("GET", "u", 404, "{}"))

--- a/.github/workflows/testflight-testers.yml
+++ b/.github/workflows/testflight-testers.yml
@@ -1,0 +1,120 @@
+name: TestFlight · manage internal testers
+
+# Adds an email to Dynawalla's INTERNAL TestFlight group, by API.
+#
+# It lives here, and not in a developer's shell, because the App Store Connect
+# credentials exist ONLY as repository secrets — there are none on any machine.
+# That is also why the script it runs cannot be rehearsed against the live API
+# before this workflow's first dispatch: everything in it that does not need
+# the network is covered by `.github/scripts/test_manage_testflight_testers.py`,
+# which the `ci-scripts` job runs on every change under `.github/scripts/`.
+#
+# workflow_dispatch ONLY. Nothing about adding a tester should happen because a
+# commit landed.
+#
+# WHAT THIS CAN DO TO THE ACCOUNT:
+#   * create an internal beta group for the app, if none exists
+#   * add an existing App Store Connect user to that group
+#   * with `invite: true` ONLY — send an App Store Connect TEAM INVITATION,
+#     which is a real permission grant on the Corpora Inc. developer account.
+#     Apple allows only existing App Store Connect users in an internal group,
+#     so an outside email cannot be added without one. It is opt-in for that
+#     reason and is never a side effect of "add a tester".
+#
+# Run it with `invite: false, dry_run: true` first if you want to see the
+# account's current state without changing anything.
+
+on:
+  workflow_dispatch:
+    inputs:
+      email:
+        description: "Apple Account email of the tester"
+        required: true
+        type: string
+      invite:
+        description: "If not already on the App Store Connect team, INVITE them (grants team access)"
+        required: false
+        type: boolean
+        default: false
+      dry_run:
+        description: "Read everything, change nothing"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  # Two dispatches racing on the same beta group would interleave a membership
+  # read with another run's write. Never cancel: a cancelled run may already
+  # have sent an invitation.
+  group: testflight-testers
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  manage:
+    name: Add internal tester
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # Fail HARD and name the secret. `release-mobile.yml` emits a warning and
+      # skips, which reports SUCCESS — a green run that did nothing is exactly
+      # the failure this repository has already been bitten by. Only presence
+      # is tested; no value is printed, ever.
+      - name: Require App Store Connect credentials
+        env:
+          HAVE_KEY_ID: ${{ secrets.ASC_KEY_ID != '' }}
+          HAVE_ISSUER: ${{ secrets.ASC_ISSUER_ID != '' }}
+          HAVE_KEY: ${{ secrets.ASC_API_KEY_P8 != '' }}
+        run: |
+          set -euo pipefail
+          missing=0
+          check() {
+            if [ "$2" != "true" ]; then
+              echo "::error::secret $1 is not set"
+              missing=1
+            fi
+          }
+          check ASC_KEY_ID "$HAVE_KEY_ID"
+          check ASC_ISSUER_ID "$HAVE_ISSUER"
+          check ASC_API_KEY_P8 "$HAVE_KEY"
+          if [ "$missing" -ne 0 ]; then
+            echo "See dynawalla/docs/STORE.md for how each one is produced."
+            exit 1
+          fi
+
+      - name: Manage the internal tester
+        # Every secret AND every dispatch input arrives through `env:`, never
+        # interpolated into the script TEXT. `${{ ... }}` inside `run:` is
+        # substituted before bash sees it: for a secret that puts the value on
+        # the command line, and for `inputs.email` — a string a human types —
+        # it is a shell-injection hole.
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
+          ASC_BUNDLE_ID: inc.corpora.dynawalla
+          TESTER_EMAIL: ${{ inputs.email }}
+          INVITE: ${{ inputs.invite }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          python3 -m pip install --quiet --disable-pip-version-check 'pyjwt[crypto]'
+          # Built as an array, not a string: `[ x = y ] && ARGS+=(...)` as a
+          # bare statement returns 1 when the condition is false and aborts the
+          # step under `set -e`.
+          ARGS=(--email "$TESTER_EMAIL")
+          if [ "$INVITE" = "true" ]; then
+            ARGS+=(--invite)
+          fi
+          if [ "$DRY_RUN" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+          python3 .github/scripts/manage_testflight_testers.py "${ARGS[@]}"


### PR DESCRIPTION
## What

Add `.github/scripts/manage_testflight_testers.py` and a `workflow_dispatch`-only
`.github/workflows/testflight-testers.yml` that add an email to Dynawalla's
**internal** TestFlight group over the App Store Connect API.

The immediate use is `skylar.saveland+apple@gmail.com`.

## Why

The standing rule is that App Store Connect and Play are driven by API, not by
clicking. The ASC credentials (`ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_API_KEY_P8`)
exist **only** as repository secrets — there are none on any developer machine —
so a dispatchable workflow is the only place this can run at all.

That also means the script's first real execution is its first dispatch: it
cannot be rehearsed against the live API. It is written accordingly. Auth is not
reinvented — it imports `Bearer`/`mint_token` from `verify_testflight_upload.py`,
which already re-mints before Apple's 20-minute ceiling and is already tested.

**The thing that bites.** An *internal* tester must already be a user on the App
Store Connect team — Apple documents `isInternalGroup` as *"Only existing users
of App Store Connect may be added for internal beta testing."* An outside email
is refused with a generic 4xx that reads like a bug. (External testers are
email-only but put every build behind Beta App Review.) So the script reads
`GET /v1/users` **first** and names the situation it is in:

| situation | what happens |
|---|---|
| already in the internal group | success, nothing sent (idempotent) |
| is an App Store Connect user | added to the internal group |
| **not** a user, no `--invite` | **fails**, nothing sent, prints exactly what is required |
| not a user, with `--invite` | sends a scoped team invitation, then **stops** — a pending invitation is not an account |
| invitation already pending | reports it, sends nothing |
| no internal group exists | creates one (`isInternalGroup: true` is settable at creation) |

## Blast radius

**Areas touched:** CI only. Three new files, nothing existing edited. No app,
pack, native, curriculum or string surface is touched.

- [x] Every touched path is covered by a `ci.yml` area filter. `.github/scripts/**`
      matches the `ci_scripts` filter, so `ci-scripts · tests` runs these tests;
      `^\.github/` is on the `exempt` list of the `uncovered` warning.
- [x] **Secrets.** No `.p8`, key id, issuer id or token appears in the diff or can
      appear in a log. Secrets reach the job only through `env:`, never
      interpolated into `run:` text — and neither does `inputs.email`, which is a
      human-typed string and therefore a shell-injection vector. A test asserts
      the private-key value never reaches stdout/stderr. The test's `.p8` stand-in
      deliberately carries no PEM armour, because `hygiene.yml`'s gitleaks
      `private-key` rule matches the armour in a fixture just as happily as in a
      real key.

**This script can mutate the live Corpora Inc. App Store Connect account.** What
it can do, and the gates:

1. **Grant App Store Connect team access** — `POST /v1/userInvitations`. Only
   when `--invite` / `invite: true` is passed, only when the address is not
   already a team user and has no invitation pending. It is opt-in precisely
   because it is a real permission grant on the developer account, and it is
   never a side effect of "add a tester". The default run refuses and explains
   instead. The invitation is scoped as tightly as the API allows —
   `allAppsVisible: false` + `visibleApps: [dynawalla]`, `provisioningAllowed:
   false`, one role from the five Apple accepts as internal testers (default
   `DEVELOPER`). Apple does not document whether every role tolerates that
   scoping, so a 4xx retries **once** account-wide and prints a `::warning::`
   saying the grant just got wider. `skylar.saveland+apple@gmail.com` is the
   founder's own alternate address and he asked for this explicitly.
2. **Create a beta group** — `POST /v1/betaGroups`, only when the app has no
   internal group. Reversible; not a permission grant.
3. **Add a beta tester** — `POST /v1/betaTesters` (or the linkage route when a
   tester record for that email already exists, which is a 409 otherwise).

Nothing runs on push. `workflow_dispatch` only, `permissions: contents: read`,
`concurrency` serialised and never cancelled (a cancelled run may already have
sent an invitation). `dry_run: true` performs every read and no write.

Deliberate refusals, because a wrong guess here is worse than a red X: more than
one internal group without `--group-name`; a `links.next` chain that outlives
the page cap ("absent from a truncated list" is the branch that would send an
invitation); a `GET /v1/users` 403 (that read needs Admin — "the key cannot see
the roster" must never be answered as "not on the team"). Group internality is
tested with `is True`, never truthily: adding an address to an *external* group
looks like success and then sits behind Beta App Review forever.

## Proof

```
$ python3 -m py_compile .github/scripts/manage_testflight_testers.py
(exit 0)

$ python -c "import yaml;yaml.safe_load(open('.github/workflows/testflight-testers.yml'))"
name: TestFlight · manage internal testers
triggers: ['workflow_dispatch']
inputs: email(string, required) / invite(boolean, false) / dry_run(boolean, false)
steps: ['actions/checkout@v4', 'actions/setup-python@v5',
        'Require App Store Connect credentials', 'Manage the internal tester']

$ python -m pytest .github/scripts -q        # the whole ci-scripts suite
...............................................................................
295 passed in 12.05s
```

40 of those 295 are new. The branches they cover: already-a-tester (and
case-insensitively, and *not* across a `+tag`, which is a different Apple
account); is-an-ASC-user (create route, and the link route when a tester record
already exists); Apple refusing the add (the message explains internal-tester
eligibility rather than surfacing a raw error); is-not-an-ASC-user with and
without `--invite` (nothing is sent on the refusal path); a pending invitation
not sent twice; the wider-grant retry announcing itself; no-internal-group
(created as internal, and the tester lands in the new group, not the external
one); two internal groups refusing to guess; `--dry-run` sending zero POSTs;
pagination following `links.next` and refusing a truncated answer; client-side
email matching surviving a `filter[...]` Apple might ignore; 401/403/404
rendering; and the private key never reaching stdout.

The API shapes (`isInternalGroup` settable at creation, `filter[email]` on
`/v1/betaTesters` but *no* filters on `/v1/betaGroups/{id}/betaTesters`,
`username` rather than `email` on `User`, 201-vs-204 bodies, `limit` max 200)
were each read off Apple's own schema JSON. The three things Apple does **not**
document — the exact error for a non-team email into an internal group, whether
a pending invitation can be added, and the per-role `allAppsVisible` constraint
— are the three places the script is defensive rather than assertive, and each
carries a comment saying so.

**Not executed:** the live API. It cannot be, from here. The first dispatch is
the first execution — run it with `dry_run: true` first to read the account's
state without changing anything.
