### PR TITLE
docs: expunge the stale diff-size cap; state the real trunk rule

### DIFF
--- a/.claude/agents/adversarial-reviewer.md
+++ b/.claude/agents/adversarial-reviewer.md
@@ -26,33 +26,31 @@ Its behaviour, verbatim from the script:
   exits 1 rather than reporting "no findings". A green review means the review
   actually ran.
 
-## The diff-size trap — split, do not retry
+## Diff size — no cap, and nothing to measure
 
-`get_diff()` truncates:
+There is **no size at which this gate stops reviewing**. `get_diff()` never
+truncates; `chunk_diff()` packs per-file segments into chunks of at most
+`MAX_CHUNK_CHARS` (default 200 000 **characters per chunk**, not per PR), every
+lens runs over every chunk, findings are unioned, and
 
 ```python
-max_bytes = int(os.environ.get("MAX_DIFF_BYTES", "200000"))
-if len(diff) > max_bytes:
-    diff = diff[:max_bytes] + "\n\n[diff truncated for length]\n"
+"".join(c.text for c in chunks) == diff
 ```
 
-(`.github/scripts/adversarial_review.py:115`.)
+is asserted before a single model call is made. A file larger than one chunk is
+split, never truncated and never rejected.
 
-Everything past 200 000 bytes is **never seen by any lens**. The gate can go
-green on a PR whose second half was never reviewed, and there is no signal in
-the check status that this happened. Re-running the workflow changes nothing —
-the same prefix gets reviewed again.
+The sticky review comment states the arithmetic on every run, e.g. *"32 file(s),
+281638 chars, 2 chunk(s) of <= 200000; every lens read 100% of that diff, 0
+chars dropped"*. Read that line rather than guessing.
 
-So: measure before you push.
+**Do not tell an author to split a PR for size, and do not measure a byte
+count.** This file previously did both, describing a real bug — the gate once
+truncated at 200 000 bytes and still reported `success` — that has since been
+fixed by chunking. `MAX_DIFF_BYTES` no longer exists.
 
-```bash
-git -C <worktree> diff --unified=3 origin/main...HEAD | wc -c
-```
-
-Over ~200 000 → **split the PR into stacked, independently reviewable PRs**.
-Do not raise `MAX_DIFF_BYTES`; do not retry the run. A generated/vendored blob
-inflating the count (lockfiles, fixtures, bundled dist) is the usual cause —
-land that in its own mechanical PR first so the reviewable PR fits.
+Split a PR when it does more than one thing. That is a review-quality judgement,
+not a gate constraint.
 
 ## The three lenses
 
@@ -93,9 +91,8 @@ regressions.
    review `origin/main...HEAD`. Review the **whole** branch, not the last commit.
 2. Read the diff. Then read the surrounding file for anything you intend to
    call a bug — the diff hunk alone is not enough context to judge one.
-3. Check the byte size (above). If truncation would apply, say so first: that
-   finding outranks every code finding, because the CI gate is about to review
-   half a PR.
+3. Do **not** check the byte size — there is no cap and nothing truncates. If the
+   branch is large, review all of it; that is what the CI gate does too.
 4. Report findings sorted HIGH first, each with `file:line`, one sentence of
    what breaks, and a concrete failure scenario (inputs → wrong output). No
    scenario means no finding.

--- a/.claude/skills/trunk-pr/SKILL.md
+++ b/.claude/skills/trunk-pr/SKILL.md
@@ -31,11 +31,23 @@ tracked separately — until it lands, follow this file.
 
 ## 0. Ground rules
 
+- **Local `main` changes by pull/fast-forward and by nothing else.** That is the
+  rule the rest of this file exists to serve. Every change reaches it the same
+  way: worktree → remote branch → PR → squash-merge → pull the new `origin/main`
+  down as a fast-forward. The primary checkout should sit on a clean `main` at
+  all times — no edits, no commits, no `checkout -b`, nothing uncommitted.
+  If `git merge --ff-only origin/main` ever refuses, that is the alarm: the
+  checkout has diverged and must be investigated, never forced.
 - The primary checkout is **read-only**. Read from it, run read-only git in it,
   never edit or check out in it.
 - Every worktree goes **outside** the repo directory, at `$WT_ROOT/<branch>`.
   Worktrees nested inside the repo bloat every search and get left behind (27
   are nested there today).
+- Re-base a branch with `git rebase origin/main`. **Never `git reset --soft
+  origin/main`** — when `main` has moved it re-parents your commit onto the new
+  tip while keeping the old tree, silently reverting everything that landed in
+  between, with no conflict and no warning. Catch it before pushing:
+  `git -C "$WT" diff --name-only origin/main...HEAD` must list only your files.
 - Path-gate anything you add to CI. That is what makes constant merging safe in
   a monorepo.
 
@@ -117,20 +129,26 @@ their output — the PR body needs them.
   `corpan/corpan-app/public/locales/`. `npm run check:i18n` runs inside `npm run
   build` and fails the build on any missing key.
 
-## 6. Diff size — split before you push
+## 6. Diff size — there is no cap; do not split for one
 
-The adversarial-review gate truncates the diff at `MAX_DIFF_BYTES`, default
-**200 000** (`.github/scripts/adversarial_review.py:115`). Past that byte
-offset, **no lens sees the code**, and the check can go green having reviewed
-half your PR. Re-running does not help; it re-reviews the same prefix.
+**A PR is never too large for the gate.** `adversarial-review` splits the diff
+on `diff --git` boundaries into budget-sized chunks, runs every lens over every
+chunk, unions the findings, and asserts `"".join(chunks) == diff` **before it
+makes a single model call**. A file bigger than one chunk is split, not
+truncated and not rejected. `MAX_CHUNK_CHARS` (default 200 000) is a per-chunk
+budget, not a limit on your PR.
 
-```bash
-git -C "$WT" diff --unified=3 origin/main...HEAD | wc -c
-```
+Observed: a 281 638-char diff reviewed as "2 chunk(s) of <= 200000; every lens
+read 100% of that diff, 0 chars dropped".
 
-Over ~200 000 → split into stacked PRs. Land generated or vendored bulk
-(lockfiles, fixtures, bundled dist) in its own mechanical PR first so the
-reviewable change fits.
+This section used to say the opposite, and the old advice is what the sticky
+review comment now disproves on every large PR. The behaviour it warned about
+was real — the gate once truncated at 200 000 bytes and still reported
+`success`; PR #521 was 850 261 bytes across 186 files and the model saw 67 of
+them — but that hole was closed by chunking, not by asking authors to split.
+`MAX_DIFF_BYTES` no longer exists in the script.
+
+Split a PR when it does more than one thing, never to hit a byte count.
 
 `hygiene` also fails any added non-LFS file over 5 MiB.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,12 @@
 <!--
-Trunk-based: one change, one PR, squash-merged. Keep it small — the
-adversarial-review gate truncates the diff at 200000 bytes
-(.github/scripts/adversarial_review.py:115) and never sees the rest. Check with:
-  git diff --unified=3 origin/main...HEAD | wc -c
+Trunk-based: one change, one PR, squash-merged.
+
+Keep it small because a small PR is easier to review, NOT because of a size
+limit — there isn't one. `adversarial-review` chunks the diff on `diff --git`
+boundaries, runs every lens over every chunk, and asserts the concatenated
+chunks equal the diff before it makes a single model call. A large PR is
+reviewed in full or the check fails; it can no longer pass having read part of
+it. Do not split a PR to satisfy a byte count.
 -->
 
 ## What

--- a/dynawalla/AGENTS.md
+++ b/dynawalla/AGENTS.md
@@ -56,11 +56,18 @@ and passing every test on the way. Plugin identifiers and `links =` values never
 
 ## PR size
 
-`adversarial-review` currently **truncates** above `MAX_DIFF_BYTES` (200,000) and still
-reports green — so an oversized PR is reviewed on a fraction of its diff and looks
-reviewed. PR-0a.2 makes it fail. Split now either way: check
-`git diff origin/main | wc -c` before pushing. One generator family per PR; one domain
-per node-promotion PR.
+There is **no size limit**. `adversarial-review` chunks the diff, reviews every chunk
+with every lens, and asserts the chunks reconstitute the diff exactly before calling a
+model — so a large PR is reviewed in full or the check fails. It can no longer pass
+having read a prefix.
+
+Size is still a review-quality question, not a gate question: one generator family per
+PR, one domain per node-promotion PR, because a reviewer holds one idea at a time. Split
+a PR when it does two things, never to hit a byte count.
+
+(This section previously said the gate truncated above `MAX_DIFF_BYTES` and told you to
+split pre-emptively. That was true and is not any more — the hole was closed by chunking
+rather than by the planned fail-and-split, and `MAX_DIFF_BYTES` no longer exists.)
 
 ## Never
 

--- a/dynawalla/docs/ACCEPTANCE_CRITERIA.md
+++ b/dynawalla/docs/ACCEPTANCE_CRITERIA.md
@@ -321,10 +321,15 @@ See [PACK_SYSTEM.md](PACK_SYSTEM.md) and
       Verify: `gh api` on the protection object; a docs-only PR shows exactly three
       required checks.
       Evidence: UNMET
-- [ ] **C-02** A PR exceeding `MAX_DIFF_BYTES` **fails** `adversarial-review` with
-      `::error::diff too large to review — split this PR`.
-      Verify: deliberate oversized test PR.
-      Evidence: UNMET
+- [x] **C-02** `adversarial-review` reviews a diff of **any** size in full: it chunks on
+      `diff --git` boundaries, runs every lens over every chunk, and asserts
+      `"".join(chunks) == diff` before the first model call. A file larger than one
+      chunk is split, never truncated or rejected.
+      Verify: a large PR's sticky comment states the chunk count and the chars dropped.
+      Evidence: MET — PR #557 reported "32 file(s), 281638 chars, 2 chunk(s) of
+      <= 200000; every lens read 100% of that diff, 0 chars dropped".
+      Supersedes the original C-02, which required the gate to **fail** above
+      `MAX_DIFF_BYTES` and make the author split. Chunking removed the need.
 - [ ] **C-03** A run where exactly one of three lenses errors fails the required check.
       Verify: deliberate single-lens failure injection.
       Evidence: UNMET

--- a/dynawalla/docs/MASTER_PLAN.md
+++ b/dynawalla/docs/MASTER_PLAN.md
@@ -32,29 +32,41 @@ What each milestone is now aimed at:
 | **M9 — profiles, parents, accessibility** | Substantially **pulled forward and delivered**: profiles are real (add, name, switch, remove, erase), the parent area exists, settings act on the document and on packs. What is left of M9 is i18n fill and the parental gate. |
 | M10 — store readiness | Unaffected in shape. What ships is the host plus its first packs. |
 
-**The sizing law below still holds and now bites somewhere new.** A pack is a
-diff too, and "one pack per PR" will be over the cap for anything ambitious. Pack
-work is planned at the same honest granularity as curriculum work: a slice per
-PR, not a world per PR.
+**The sizing law below still holds and now bites somewhere new**, though not for
+the reason first written. There is no cap to be "over": a pack is a diff too,
+and an ambitious one is simply a large diff, which the gate reviews in full. The
+reason to keep it small is that a reviewer holds one idea at a time. Pack work
+is planned at the same honest granularity as curriculum work: a slice per PR,
+not a world per PR.
 
 ---
 
 ## The sizing law, and why it changes the plan
 
-Trunk-based development plus a hard diff cap is not a style preference here — it is
-the enforcement mechanism. `adversarial-review` truncates a diff at
-`MAX_DIFF_BYTES` and, once M0a lands, **fails** above it rather than reviewing half a
-PR and reporting green.
+Trunk-based development is not a style preference here — it is the enforcement
+mechanism. Its rule is about *where changes come from*, not how big they are:
+**local `main` only ever moves by fast-forward from `origin/main`**, and every
+change reaches it as worktree → remote branch → PR → squash-merge → pull.
+
+There is **no diff cap**. `adversarial-review` chunks a diff and asserts it
+reviewed 100% of it before making a model call, so a large PR is reviewed in
+full or the check fails. (This paragraph used to promise a hard cap that
+**fails** above `MAX_DIFF_BYTES`; that was the M0a plan, chunking replaced it,
+and `MAX_DIFF_BYTES` no longer exists. Do not split a PR for size.)
 
 That has a consequence the first draft of this plan missed, and it is the single
 largest correction carried into this document:
 
 > **Curriculum breadth planned as manifest rows is a defect.** A `SkillNode` literal
 > with its ~20 fields is 30–40 lines. "Ship 42 generator families in six PRs" and
-> "promote 390 nodes in four PRs" are each 5–20× the diff cap. Either the cap gets
-> raised until it means nothing — destroying the one mechanism that makes constant
-> merging safe — or the milestone silently becomes 120 PRs against a list that names
+> "promote 390 nodes in four PRs" are each 5–20× the size any one reviewer can hold
+> in their head. The milestone silently becomes 120 PRs against a list that names
 > 22, discovered mid-flight.
+>
+> (As first written this argued from a hard diff cap that the gate would enforce.
+> The cap is gone — diffs are chunked and reviewed in full — but the conclusion is
+> unchanged and now rests where it always should have: on what a human can review,
+> not on what a script will truncate.)
 
 So the plan is stated at its honest granularity: **one generator family per PR** (~600–1,200
 lines each), **one domain per node-promotion PR**, **mal-rules in batches of ~10–14**.
@@ -105,7 +117,7 @@ touches the CDN or Corpán's release ritual.
 | PR | What |
 |---|---|
 | 0a.1 | Bootstrap: docs (this set), `.claude/` agents/skills/hooks/commands + `.gitignore` negations, PR and issue templates, `LICENSE` placeholder, the deprecated-methodology expunge, five inert `ci.yml` area filters, `uncovered` in **warn** mode, **delete `.github/workflows/pr-agent.yml`**, and `dynawalla/tools/check-docs-refs.mjs` — every `R-NN`, `CG-NN` and `EG-NN` reference resolves to a real heading or gate row, and every acceptance id is claimed by a milestone exit list. This class of drift already happened once in the draft. |
-| 0a.2 | `adversarial_review.py`, four fixes in one PR: truncation exits non-zero with `::error::diff too large to review — split this PR`; **any** lens error fails (today only all-lenses-fail closes, so two of three timeouts pass green); the resolved provider+model printed to `$GITHUB_STEP_SUMMARY`; a 1-token model ping before spending three full-diff calls. `MAX_DIFF_BYTES` becomes a repo variable at 400,000. Adds the fork-PR path and an `admin-override` break-glass label. |
+| 0a.2 | `adversarial_review.py`, four fixes in one PR: truncation exits non-zero with `::error::diff too large to review — split this PR`; **any** lens error fails (today only all-lenses-fail closes, so two of three timeouts pass green); the resolved provider+model printed to `$GITHUB_STEP_SUMMARY`; a 1-token model ping before spending three full-diff calls. `MAX_DIFF_BYTES` becomes a repo variable at 400,000. Adds the fork-PR path and an `admin-override` break-glass label. **SHIPPED, but the truncation item was superseded:** the diff is CHUNKED with asserted 100% coverage instead of failing above a cap, so there is no size limit and no split-the-PR error. `MAX_DIFF_BYTES` no longer exists. |
 | 0a.3 | Flip `uncovered` to failing, gated `if: github.event_name == 'pull_request'`; explicit no-CI allowlist; PR-size advisory step. |
 | 0a.4 | `.cargo/config.toml` generated from `config.toml.in` resolving `$ANDROID_NDK_HOME`, replacing the hardcoded local NDK path. Keeps the `linker = "/usr/bin/cc"` Apple pins. **Must land before 0a.5.** |
 | 0a.5 | Native CI gate **inside `ci.yml`** so it can be a `ci-gate` need: `rust-linux` (ubuntu, `if: native`) = fmt + `clippy -D warnings` + test over `native/` **and** explicitly over `corpan/corpan-app/src-tauri/Cargo.toml`, plus `cargo check --target aarch64-linux-android`, plus the two `cargo metadata | jq -e` vendored-fork assertions; `rust-apple` (macos-14, `if: native`) = the per-plugin `aarch64-apple-ios` loop lifted from `ios-native.yml`. **Delete `ios-native.yml`.** |

--- a/dynawalla/docs/RELEASE_ENGINEERING.md
+++ b/dynawalla/docs/RELEASE_ENGINEERING.md
@@ -19,28 +19,32 @@ Keep it. **Required contexts stay exactly three: `ci-gate`, `adversarial-review`
 
 ## Fix 1 — the adversarial reviewer
 
-This is the highest-value change in the program, because the diff-size discipline that
-makes constant merging safe is currently unenforced.
+**Status: DONE.** All three defects below are fixed in
+`.github/scripts/adversarial_review.py`. The section is kept because the defects are
+worth remembering — each one produced a *green* required check over unreviewed code.
 
-Three defects, all verified:
+1. ~~**It truncates and still reports green.**~~ It truncated at `MAX_DIFF_BYTES`
+   (default 200,000). Measured: PR #521 was 850,261 diff bytes across 186 files; the
+   model saw 67 of them, stopping mid-alphabet, and the conclusion was `success`.
+   **Fixed differently, and better, than planned:** rather than failing above a cap and
+   making authors split, the diff is now **chunked** on `diff --git` boundaries, every
+   lens runs over every chunk, and `"".join(chunks) == diff` is asserted before the first
+   model call. A file larger than one chunk is split, never dropped. `MAX_DIFF_BYTES` is
+   gone; `MAX_CHUNK_CHARS` (default 200,000) is a per-chunk budget. **There is no PR size
+   limit, and no reason to split a PR for size.**
+2. ~~**It fails closed only when *all* lenses error.**~~ The guard was
+   `if errored == len(LENSES)`, so two of three lenses timing out yielded a green
+   required check on one lens' output. **Fixed:** any single lens error now fails closed.
+3. ~~**The provider is not what anyone assumes.**~~ `provider_and_key()` fell through to
+   the OpenAI key and a hardcoded default model. **Fixed:** the resolved provider and
+   model are written to `$GITHUB_STEP_SUMMARY`, and `ADVERSARIAL_MODEL` is constrained to
+   an `ALLOWED_MODELS` allow-list — an unlisted id is a hard error, not a silent
+   downgrade.
 
-1. **It truncates and still reports green.** `adversarial_review.py:115` truncates at
-   `MAX_DIFF_BYTES` (default 200,000). Measured: PR #521 was 850,261 diff bytes across
-   186 files; the model saw 67 of them, stopping mid-alphabet, and the conclusion was
-   `success`.
-2. **It fails closed only when *all* lenses error.** The guard is
-   `if errored == len(LENSES)`, so two of three lenses timing out yields a green required
-   check on one lens' output.
-3. **The provider is not what anyone assumes.** There is no `ANTHROPIC_API_KEY` among the
-   repository secrets and no repository variables at all, so `provider_and_key()` falls
-   through to the OpenAI key and a hardcoded default model.
-
-**One PR fixes all of it** (PR-0a.2): truncation exits non-zero with
-`::error::diff too large to review — split this PR`; **any** lens error fails; the
-resolved provider and model are printed into `$GITHUB_STEP_SUMMARY`; and a 1-token ping
-asserts the model responds before spending three full-diff calls. `MAX_DIFF_BYTES`
-becomes a repo *variable* starting at 400,000. The hardcoded app version in the prompt is
-replaced by a read of `tauri.conf.json`.
+The one planned item deliberately **not** carried out is the fail-and-split behaviour in
+the original PR-0a.2 (`::error::diff too large to review — split this PR`). Chunking made
+it unnecessary. Any doc still telling authors to split for size is stale; say so and
+delete it.
 
 **Break-glass:** an `admin-override` label that a named bypass actor can apply, so a
 provider outage does not freeze the trunk. Every use of it goes in the `STATUS.md`


### PR DESCRIPTION
## What

Delete the "diff size cap / split your PR" rule from the seven places that still
teach it, and put the rule that actually governs this repo in its place.

## Why

Seven files told authors and agents that `adversarial-review` truncates above
`MAX_DIFF_BYTES` (200,000) and still reports green, so you must measure
`git diff | wc -c` and split before pushing. **None of that is true any more,**
and the stale rule has a cost: it makes people split coherent changes into
stacked PRs for no reason, and it made me nearly split four game PRs today.

The bug it describes was real. PR #521 was 850,261 diff bytes across 186 files;
the model saw 67 of them, stopping mid-alphabet, and the check concluded
`success`. A green required check over unreviewed code is exactly the kind of
thing this repo is careful about.

But the planned fix — PR-0a.2, "truncation exits non-zero with
`::error::diff too large to review — split this PR`" — is **not what shipped.**
What shipped is better: the diff is **chunked** on `diff --git` boundaries,
every lens runs over every chunk, findings are unioned, and

```python
"".join(c.text for c in chunks) == diff
```

is asserted *before the first model call*. A file larger than one chunk is
split, never truncated and never rejected. `MAX_DIFF_BYTES` does not exist in
the script; `MAX_CHUNK_CHARS` (default 200,000) is a **per-chunk** budget.

So a large PR is now reviewed in full or the check fails. It can no longer pass
having read a prefix. The gate says so itself on every large run — from PR #557:

> 32 file(s), 281638 chars, 2 chunk(s) of <= 200000; every lens read 100% of
> that diff, 0 chars dropped

**In its place**, `trunk-pr` §0 now states the rule that does govern this repo:
local `main` moves **only** by fast-forward from `origin/main`, and every change
reaches it as worktree → remote branch → PR → squash-merge → pull. The primary
checkout sits on a clean `main`, always. If `git merge --ff-only origin/main`
ever refuses, that is an alarm to investigate, never to force.

§0 also now bans `git reset --soft origin/main` for re-basing. When `main` has
moved it re-parents your commit onto the new tip while keeping the **old tree**,
silently reverting everything that landed in between — no conflict, no warning.
It cost 35 files earlier today and was caught only by a scope check.

## Blast radius

**Areas touched:** docs + agent/skill definitions only. No code, no CI logic.

- [x] Seven files, all prose. `.github/pull_request_template.md`,
      `.claude/skills/trunk-pr/SKILL.md`, `.claude/agents/adversarial-reviewer.md`,
      `dynawalla/AGENTS.md`, and three `dynawalla/docs/` files. **No workflow YAML
      and no script behaviour changes** — `adversarial_review.py` is untouched;
      this PR makes the docs describe what it already does.
- [x] Docs/config with no gate by design, so no `ci.yml` area filter needed.
- [x] **Historical records preserved, not deleted.** `RELEASE_ENGINEERING.md`'s
      three verified defects and `MASTER_PLAN.md`'s PR-0a.2 row are marked
      resolved with what superseded them. I verified defects 2 and 3 are fixed
      too, rather than assuming: any single lens error now fails closed
      (previously `if errored == len(LENSES)`), and the resolved provider/model
      are written to `$GITHUB_STEP_SUMMARY`, with `ADVERSARIAL_MODEL` constrained
      to an `ALLOWED_MODELS` allow-list.
- [x] **Conclusions that rested on the cap are kept and re-grounded.**
      MASTER_PLAN's one-generator-family-per-PR granularity and AGENTS.md's PR
      size guidance still stand — now justified by what a reviewer can hold in
      their head rather than by what a script would truncate. I did not re-plan
      any milestone.
- [x] **Acceptance criteria.** `C-02` kept its id and flipped from UNMET to MET,
      restated as full-coverage chunking with the PR #557 evidence, and says
      explicitly that it supersedes the fail-above-cap version.
- [x] **Pack back-compat / native / strings / curriculum.** Untouched — no pack,
      no Rust, no locale key, no skill id.
- [x] **Secrets.** None.

## Proof

Every stale claim is gone or explicitly marked historical:

```
$ grep -rn "MAX_DIFF_BYTES" . --exclude-dir=node_modules --exclude-dir=.git \
    | grep -v adversarial_review.py
dynawalla/docs/RELEASE_ENGINEERING.md:26:  ~~It truncates and still reports green.~~ …
dynawalla/docs/RELEASE_ENGINEERING.md:32:  … `MAX_DIFF_BYTES` is gone …
dynawalla/docs/MASTER_PLAN.md:54:          … that was the M0a plan, chunking replaced it …
dynawalla/docs/MASTER_PLAN.md:55:          … no longer exists. Do not split a PR for size.)
dynawalla/AGENTS.md:68:                    (This section previously said …)
dynawalla/AGENTS.md:70:                    … `MAX_DIFF_BYTES` no longer exists.)
dynawalla/docs/ACCEPTANCE_CRITERIA.md:332: … Chunking removed the need.
```

All seven are past-tense annotations. No live instruction to measure or split
remains — including `adversarial-reviewer.md` step 3, which previously told the
reviewer to check byte size and rank truncation above every code finding.

Verified against the script rather than from memory:

```
$ grep -n "DEFAULT_CHUNK_CHARS\|MAX_CHUNK_CHARS" .github/scripts/adversarial_review.py
87:  MAX_CHUNK_CHARS     per-chunk character budget (default 200000)
157:DEFAULT_CHUNK_CHARS = 200000

$ grep -n 'Guarantee' .github/scripts/adversarial_review.py
812:    Guarantee: "".join(c.text for c in chunks) == diff, for budget >= MIN_CHUNK_CHARS.
```

```
$ git diff --name-only origin/main...HEAD
.claude/agents/adversarial-reviewer.md
.claude/skills/trunk-pr/SKILL.md
.github/pull_request_template.md
dynawalla/AGENTS.md
dynawalla/docs/ACCEPTANCE_CRITERIA.md
dynawalla/docs/MASTER_PLAN.md
dynawalla/docs/RELEASE_ENGINEERING.md
```
