### PR TITLE
feat(dynawalla/games/balance): make COUNTERPOISE an installable pack

### DIFF
--- a/dynawalla/games/balance/pack.html
+++ b/dynawalla/games/balance/pack.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#07090e" />
+    <title>Counterpoise</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #07090e;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         The dev harness's readout is not here — it reported the stub host's
+         tally, and inside a real host the host draws the progress. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/balance/pack.json
+++ b/dynawalla/games/balance/pack.json
@@ -1,0 +1,37 @@
+{
+  "id": "dynawalla.balance",
+  "version": "0.1.0",
+  "name": "COUNTERPOISE",
+  "description": "A brass balance where the scale physically is the equals sign. Hang mass until the arm sits level, and the equality stops being a symbol you read and becomes a thing you did with your hands.",
+  "sdk": "1.0.0",
+  "host": {
+    "min": "0.1.0",
+    "max": "1.0.0"
+  },
+  "entry": "pack.html",
+  "capabilities": [
+    "items",
+    "items.reveal",
+    "haptics"
+  ],
+  "covers": {
+    "skills": [
+      "dw.alg.equality.balance-meaning",
+      "dw.alg.equality.missing-addend",
+      "dw.alg.equality.missing-subtrahend",
+      "dw.alg.equality.unknown-minuend",
+      "dw.alg.equality.missing-factor"
+    ],
+    "grades": [
+      1,
+      5
+    ]
+  },
+  "locales": [
+    "en"
+  ],
+  "build": {
+    "config": "vite.pack.config.ts",
+    "out": "dist-pack"
+  }
+}

--- a/dynawalla/games/balance/package.json
+++ b/dynawalla/games/balance/package.json
@@ -12,7 +12,8 @@
     "build": "vite build",
     "preview": "vite preview --port 4173 --strictPort",
     "tsc": "tsc --noEmit",
-    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test src/*.test.ts"
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test src/*.test.ts",
+    "build:pack": "vite build --config vite.pack.config.ts"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/dynawalla/games/balance/src/pack.ts
+++ b/dynawalla/games/balance/src/pack.ts
@@ -1,0 +1,45 @@
+// COUNTERPOISE, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous `Host` surface that
+// `contract.ts` already describes — so the beam, the weights and the puzzle
+// ladder are untouched.
+//
+// What crosses the boundary is the puzzle. The host draws a problem; the beam
+// is where it gets answered, because hanging mass until the arm sits level IS
+// the equality. The game never decides whether a hang was right — it reports
+// the value the child settled on and the host is the judge.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import { mount } from "./game.ts"
+import type { Host } from "./contract.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("balance: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  // `items.reveal` is not optional. The shared host resolves an item's
+  // canonical value through it (`game-host/index.ts:160`); without the grant
+  // `canonical` is "", the item is dropped, and the pool never fills — a pack
+  // that mounts, warms, and then serves nothing, with no crash and no failing
+  // gate. COUNTERPOISE also needs the value up front for its own reason: a
+  // counterweight has to be worth the answer before the child hangs it.
+  const mounted = await createGameHost({ domain: "equality" })
+  // Stocked before the first frame: the beam presents a puzzle immediately, and
+  // a beam with a blank face is the kind of thing that happens exactly once, on
+  // launch, in front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context are torn down before the frame is, rather than a frame or two after.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[balance] could not start", error)
+  renderNoHost(root, "COUNTERPOISE")
+})

--- a/dynawalla/games/balance/vite.pack.config.ts
+++ b/dynawalla/games/balance/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produces a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})


### PR DESCRIPTION
## What

Give `dynawalla/games/balance` (COUNTERPOISE) the four files that make it an
installable pack, plus the `build:pack` script the builder invokes.

## Why

**The game is in `main` and ships to nobody.** `dynawalla/packs/build.mjs`
discovers packs by globbing for a directory under `games/` with a `pack.json` in
it — "discovery is a glob, not a list" — and balance has none. It is therefore
invisible to the pack build, to the catalog, and to the app's game browser.

This is not specific to balance. Only 5 of the 16 games on `main` are packaged:

```
forge YES · merge YES · siege YES · slice YES · stack YES
balance NO · claim NO · guilty NO · horde NO · merge-idle NO · mosaic NO
polarity NO · pulse NO · rhythm NO · serpent NO · trebuchet NO
```

The eleven `NO`s are the games rescued in #561–#571, which were saved from
deletion but never packaged. This PR is the first of that set and the reference
the rest follow.

## Blast radius

**Areas touched:** dynawalla (one game directory)

- [x] Additive. Four new files plus one added npm script. No existing game, no
      shared code, no host code, no CI. Nothing else can regress.
- [x] Covered by the `dynawalla-packs · games + pack build` job.
- [x] **The staged output is not committed.** `packs/build.mjs` stages into
      `dynawalla-app/src-tauri/packs/`, which is gitignored
      (`src-tauri/.gitignore:58`). `dist-pack/` is gitignored per game. Verified
      no build artifact is in the diff.
- [x] **Capabilities: `items`, `items.reveal`, `haptics`.** Two corrections I
      made to this PR after review, both worth knowing:
      **(a) `items.reveal` is mandatory, not optional.** The shared host
      resolves an item's canonical value through it
      (`packs/shared/game-host/index.ts:149-167`): without the grant
      `canonical` is `""`, the item is dropped, and the pool never fills. The
      pack mounts, warms and serves **zero questions** — no crash, no failing
      gate, and `dw-pack check` cannot see it. My first draft omitted it.
      **(b) `audio` removed as an over-claim.** That capability is exactly
      `feedback.sound`, shown to a parent as "Play the app's sounds". Balance
      never calls it — it owns its own `AudioContext`. None of the five shipped
      packs declares `audio` either.
      Also: **`items.answer` is not a capability.** The valid set is `items`,
      `items.reveal`, `learner.read`, `haptics`, `audio`, `milestones`,
      `storage`; `dw-pack check` rejects anything else by name.
- [x] **Curriculum.** No skill id renamed, reused or added. `covers.skills`
      names five existing equality skills from
      `packs/shared/curriculum/src/graph/domains/alg.ts`.
      **`dw-pack check` does NOT validate skill ids against the curriculum** — a
      fictional id passes the gate silently. These five were checked by hand
      against the graph, and that is worth a follow-up gate.
      **Known limitation, stated rather than hidden:** all five are
      `status: "draft"`. Only `add` has active rows (7); `alg`, `div`, `frac`,
      `mul` and `ns` are 100% draft. `ladder()` defaults to `activeNodes()`, and
      `covers` is documented as "a request, not an instruction", so COUNTERPOISE
      will be served the add ladder until `alg` is promoted. It is genuinely an
      equality game, so relabelling it to add/sub ids would make the manifest
      lie to match a curriculum gap. Promoting `alg` is curriculum work outside
      this blast radius.
- [x] **Pack back-compat.** New pack id `dynawalla.balance` at `0.1.0`; nothing
      published is changed in place, no catalog entry dropped.
- [x] **Native integrity.** No Rust, no `src-tauri` source, no `links =`.
- [x] **Strings.** Pack name/description live in `pack.json`; `locales: ["en"]`
      is declared honestly rather than claiming coverage that does not exist.
- [x] **Secrets.** None.

## Proof

The real builder, not just a local vite run — it builds, validates and stages:

```
$ node dynawalla/packs/build.mjs balance
dist-pack/pack.html                 1.27 kB │ gzip:  0.65 kB
dist-pack/assets/pack-CbVjWl_h.js  66.57 kB │ gzip: 22.20 kB
✓ built in 35ms
dynawalla.balance@0.1.0 — COUNTERPOISE
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       5 skills, grades 1–5
  on disk      3 files, 68810 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

The built entry really does carry its script — the failure mode the vite config
warns about is a `pack.html` that loads, paints the body colour and runs nothing:

```
$ grep -o '<script[^>]*>' dynawalla/games/balance/dist-pack/pack.html
<script type="module" crossorigin src="./assets/pack-CbVjWl_h.js">
```

The game itself is unchanged and still green:

```
$ npm test        # in dynawalla/games/balance/
# pass 18
# fail 0
$ npm run tsc
0 errors
$ npm run build
✓ built
```

```
$ git diff --name-only origin/main...HEAD
dynawalla/games/balance/pack.html
dynawalla/games/balance/pack.json
dynawalla/games/balance/package.json
dynawalla/games/balance/src/pack.ts
dynawalla/games/balance/vite.pack.config.ts
```
