### PR TITLE
feat(dynawalla/games): make PULSE, SPLITBEAT and SERPENT installable packs

### DIFF
--- a/dynawalla/games/pulse/pack.html
+++ b/dynawalla/games/pulse/pack.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#04050a" />
+    <title>PULSE</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #04050a;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         The dev harness in `index.html` sets these same styles from
+         `main.ts`; here they are static, because the pack has no dev entry. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/pulse/pack.json
+++ b/dynawalla/games/pulse/pack.json
@@ -1,0 +1,21 @@
+{
+  "id": "dynawalla.pulse",
+  "version": "0.1.0",
+  "name": "PULSE",
+  "description": "A rhythm-action game where fractions are literally rhythm. The visible playfield is exactly one bar, a note's position is its fraction of the whole, and you answer by hitting a thing at the right time.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.frac.arith.add-like-denominators",
+      "dw.frac.arith.add-unlike-denominators",
+      "dw.frac.arith.subtract-fractions",
+      "dw.frac.arith.multiply-by-a-whole"
+    ],
+    "grades": [3, 5]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/pulse/package.json
+++ b/dynawalla/games/pulse/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:pack": "vite build --config vite.pack.config.ts",
     "preview": "vite preview --port 4173",
     "tsc": "tsc --noEmit",
     "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\""

--- a/dynawalla/games/pulse/src/pack.ts
+++ b/dynawalla/games/pulse/src/pack.ts
@@ -1,0 +1,46 @@
+// PULSE, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous surface the `Host`
+// type in `contract.ts` already describes — so the chart generator, the
+// judge, the stage governor and the audio scheduler are untouched.
+//
+// What crosses the boundary is a bar. A question's answer is a fraction, and
+// in PULSE a fraction IS a position inside one bar, so the gate places the
+// canonical value and the mal-rule distractors along the bar and the child
+// answers by striking at the right *time*. The game never decides whether a
+// strike was right in the curriculum's sense: it reports the value it was
+// aimed at, and `items.answer` is the judge.
+//
+// `gate.ts` already handles a host whose answer is not a fraction in (0, 1] —
+// it falls back to labelled targets rather than positions — so a host serving
+// whole-number arithmetic degrades to a playable game rather than a broken one.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import { mount } from "./mount.ts"
+import type { Host } from "./contract.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("pulse: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "fractions" })
+  // Stocked before the first frame: the first bar is charted the moment the
+  // run starts, and a bar with no numbers on it is the kind of thing that
+  // happens exactly once, on launch, in front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context are torn down before the frame is, rather than a frame or two
+  // after it.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[pulse] could not start", error)
+  renderNoHost(root, "PULSE")
+})

--- a/dynawalla/games/pulse/vite.pack.config.ts
+++ b/dynawalla/games/pulse/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produced a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})

--- a/dynawalla/games/rhythm/pack.html
+++ b/dynawalla/games/rhythm/pack.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#05060f" />
+    <title>SPLITBEAT</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #05060f;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         The dev harness's `#stage` is not here — `#app` is the id every pack
+         mounts into, and the harness in `index.html` keeps its own. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/rhythm/pack.json
+++ b/dynawalla/games/rhythm/pack.json
@@ -1,0 +1,23 @@
+{
+  "id": "dynawalla.rhythm",
+  "version": "0.1.0",
+  "name": "SPLITBEAT",
+  "description": "A three-lane rhythm game where the bar of music is the fraction bar. The answer is a subdivision you can hear, so a child who can feel the groove can find the fraction.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.frac.arith.add-like-denominators",
+      "dw.frac.arith.add-unlike-denominators",
+      "dw.frac.arith.multiply-by-a-whole",
+      "dw.frac.arith.multiply-fractions",
+      "dw.frac.equivalence.build-equivalent",
+      "dw.mul.multidigit.times-one-digit"
+    ],
+    "grades": [3, 5]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/rhythm/package.json
+++ b/dynawalla/games/rhythm/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
+    "build:pack": "vite build --config vite.pack.config.ts",
     "preview": "vite preview",
     "tsc": "tsc --noEmit",
     "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\""

--- a/dynawalla/games/rhythm/src/pack.ts
+++ b/dynawalla/games/rhythm/src/pack.ts
@@ -1,0 +1,45 @@
+// SPLITBEAT, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous surface the `Host`
+// type in `contract.ts` already describes — so the chart, the three lanes, the
+// judge and the audio engine are untouched.
+//
+// What crosses the boundary is a bar of music. A question's answer is a
+// fraction, and SPLITBEAT plays that fraction: `1/4` is a quarter note you can
+// hear, so the lane carrying the right answer is the lane that sounds like the
+// answer. The game never decides whether a hit was right — it reports the tile
+// it was aimed at and `items.answer` is the judge.
+//
+// A host answer that is not a playable subdivision is already handled: the
+// game falls back to reading the tile rather than playing it, which is exactly
+// what `?musical=0` in the dev harness exists to prove.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import { mount } from "./index.ts"
+import type { Host } from "./contract.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("splitbeat: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "fractions" })
+  // Stocked before the first frame: the first tiles are charted the moment the
+  // game mounts, and a blank tile is the kind of thing that happens exactly
+  // once, on launch, in front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context are torn down before the frame is, rather than a frame or two
+  // after it.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[splitbeat] could not start", error)
+  renderNoHost(root, "SPLITBEAT")
+})

--- a/dynawalla/games/rhythm/vite.pack.config.ts
+++ b/dynawalla/games/rhythm/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produced a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})

--- a/dynawalla/games/serpent/pack.html
+++ b/dynawalla/games/serpent/pack.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#01060c" />
+    <title>SERPENT</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #01060c;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         The dev harness's `#stage` and its `__serpent` playtest seam are not
+         here — `#app` is the id every pack mounts into. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/serpent/pack.json
+++ b/dynawalla/games/serpent/pack.json
@@ -1,0 +1,25 @@
+{
+  "id": "dynawalla.serpent",
+  "version": "0.1.0",
+  "name": "SERPENT",
+  "description": "A bioluminescent deep-sea snake that may eat only the values satisfying the condition written across the arena floor. Every orb is a claim, and swallowing the wrong one costs a length of tail.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.alg.equality.balance-meaning",
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup",
+      "dw.mul.multidigit.times-one-digit",
+      "dw.div.whole.divide-exact",
+      "dw.frac.compare.same-numerator",
+      "dw.frac.compare.unlike-fractions",
+      "dw.frac.equivalence.lowest-terms"
+    ],
+    "grades": [1, 5]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/serpent/package.json
+++ b/dynawalla/games/serpent/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:pack": "vite build --config vite.pack.config.ts",
     "preview": "vite preview --port 5291",
     "tsc": "tsc --noEmit",
     "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\""

--- a/dynawalla/games/serpent/src/pack.ts
+++ b/dynawalla/games/serpent/src/pack.ts
@@ -1,0 +1,42 @@
+// SERPENT, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous surface the `Host`
+// type in `contract.ts` already describes — so the world, the orbs, the tail,
+// the camera and the ambience are untouched.
+//
+// What crosses the boundary is the condition and the field under it. A
+// question's canonical answer stocks the pool of orbs that may be eaten and
+// its mal-rule distractors stock the maze of orbs that may not, which is why
+// the wrong orbs are near misses a child actually produces rather than noise.
+// The game never decides whether a bite was right in the curriculum's sense:
+// it reports the label it swallowed and `items.answer` is the judge.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import { mount } from "./index.ts"
+import type { Host } from "./contract.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("serpent: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "mixed" })
+  // Stocked before the first frame: the world adopts a condition the instant
+  // it is created, and an arena floor with a blank condition on it is the kind
+  // of thing that happens exactly once, on launch, in front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context are torn down before the frame is, rather than a frame or two
+  // after it.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[serpent] could not start", error)
+  renderNoHost(root, "SERPENT")
+})

--- a/dynawalla/games/serpent/tsconfig.json
+++ b/dynawalla/games/serpent/tsconfig.json
@@ -22,5 +22,5 @@
     "noEmit": true,
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts", "vite.config.ts"]
+  "include": ["src/**/*.ts", "vite.config.ts", "vite.pack.config.ts"]
 }

--- a/dynawalla/games/serpent/vite.pack.config.ts
+++ b/dynawalla/games/serpent/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produced a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})


### PR DESCRIPTION
## What

Give `pulse` (PULSE), `rhythm` (SPLITBEAT) and `serpent` (SERPENT) the four
files that make a game an installable pack — `pack.json`, `pack.html`,
`src/pack.ts`, `vite.pack.config.ts` — plus the `build:pack` script the builder
invokes.

## Why

**Three finished games are in `main` and ship to nobody.**
`dynawalla/packs/build.mjs` discovers a pack by globbing for a directory under
`games/` with a `pack.json` in it; these three had none, so they are invisible
to the pack build, to the catalog, and to the app's game browser.

They are three of the eleven games rescued in #561–#571 and never packaged.
#578 is the reference this follows, and with both landed the packaged set goes
from five of sixteen to nine:

```
forge YES · merge YES · siege YES · slice YES · stack YES
pulse YES · rhythm YES · serpent YES   ← this PR
balance (#578) · claim NO · guilty NO · horde NO · merge-idle NO
mosaic NO · polarity NO · trebuchet NO
```

## Blast radius

**Areas touched:** dynawalla (three game directories)

- [x] **Additive.** Twelve new files, three added npm scripts, one `include`
      entry in `serpent/tsconfig.json` so its pack config is typechecked
      alongside the vite config that was already there. **No game code
      changed** — `pack.ts` is a seam and nothing else, because the shared
      adapter in `packs/shared/game-host/index.ts` already presents the same
      synchronous `Host` surface each game's `contract.ts` describes. No shared
      code, no host code, no CI.
- [x] Covered by the `dynawalla-packs · games + pack build` job.
- [x] **`mount` comes from a different file in each game** and was grepped, not
      assumed: `pulse/src/mount.ts`, `rhythm/src/index.ts`,
      `serpent/src/index.ts`. `serpent/src/index.ts` re-exports
      `game/mount.ts:mountSerpent`; the pack goes through the public entry.
- [x] **The staged output is not committed.** `build.mjs` stages into
      `dynawalla-app/src-tauri/packs/`, gitignored at `src-tauri/.gitignore:58`;
      `dist-pack/` is gitignored per game (each `.gitignore:3`). Verified: the
      diff is sixteen paths, all under `games/{pulse,rhythm,serpent}/`, zero
      deletions, zero artifacts.
- [x] **Capabilities are what the pack actually calls**, not a wishlist. All
      three declare exactly `items`, `items.reveal`, `haptics`.
      - `items.reveal` is **required**, not optional: the adapter places the
        canonical answer before the child reaches it (a note's position on the
        bar, a lane, an edible orb) and `createGameHost` logs
        *"items.reveal was not granted; questions cannot be placed"* and stops
        filling the pool without it. A pack that omits it stocks nothing.
      - **No `audio`.** That capability is `feedback.sound` — *the app's*
        sounds. All three synthesise their own with `AudioContext`, which needs
        no grant, exactly as `slice` and `siege` do.
      - **No `storage`.** That capability is the SDK's `storage.*`; none of the
        three calls it. Every direct `localStorage` touch —
        `pulse/src/settings.ts:16,33`, `serpent/src/game/audio.ts:55,284`,
        `serpent/src/game/world.ts:129,138` — is already inside a `try`/`catch`
        that falls back to a default, so a sandboxed frame with no
        `localStorage` degrades (no remembered best score, no remembered mute)
        rather than throwing. Declaring `storage` without calling it would be a
        parent-facing permission the pack never exercises. Routing those saves
        through the SDK the way `forge` does is a follow-up, not this PR.
- [x] **Curriculum.** No skill id renamed, reused or added. As #578 warned,
      **`dw-pack check` does not validate skill ids against the curriculum** — a
      fictional id passes silently — so every id below was checked by hand
      against `packs/shared/curriculum/src/graph/domains/*.ts` and chosen by
      reading each game's own generators rather than copied from a neighbour:
      - **PULSE** — 4 frac skills, grades 3–5. `stubHost.ts` builds only
        fraction values in `(0, 1]`, because in PULSE a value *is* a position
        inside one bar: `buildAdd` (like and unlike denominators), `buildSub`
        and `buildComplement` (`1 − 3/8`), `buildMul` (`3 × 1/8`). Maps to
        `add-like-denominators`, `add-unlike-denominators`,
        `subtract-fractions`, `multiply-by-a-whole`.
      - **SPLITBEAT** — 5 frac skills + `mul.multidigit.times-one-digit`,
        grades 3–5. `tAddLike`, `tAddUnlike`, `tScale` (both `1/2 of 1/2` and
        `3 × 1/8`, hence both multiply rows) and `tEquivalent` (`6/8 = ?/4` →
        `equivalence.build-equivalent`). `tSkipCount` and `tTempo` are
        skip-counting and doubling, which is the times-one-digit row.
        `tHowMany` (*how many 1/8 fit in 1/2*) is deliberately **not** claimed
        as `div.whole.divide-exact` — that row is long division with a two-to
        four-digit quotient, and a single-digit answer to a measurement-division
        question is not it.
      - **SERPENT** — 8 skills across three domains, grades 1–5, because
        `src/stub/generators.ts` has exactly three condition families.
        `eqCondition` writes `= 12` on the floor and fills the water with
        expressions worth 12 — `a + b`, `v+b − b`, `p × q`, `v·b ÷ b` — which
        is `alg.equality.balance-meaning` first (the equals sign as a claim of
        sameness, which is the whole mechanic) plus `add.column.add-no-regroup`,
        `add.column.subtract-no-regroup` at the low levels and
        `mul.multidigit.times-one-digit`, `div.whole.divide-exact` at levels
        3–4, where `expressionsFor` emits two-digit-quotient, one-digit-divisor
        exact division that matches `divideExact`'s level-0 params exactly.
        `multipleCondition` is the times tables. `fracCondition` compares
        candidates to a reference and ships an unreduced equal-value trap on
        purpose (`2/4` is not `> 1/2`), which is `frac.compare.unlike-fractions`,
        `frac.compare.same-numerator` and `frac.equivalence.lowest-terms`.
      - `covers.grades` is each pack's own min/max over the `gradeBand` of the
        skills it names — 3–5, 3–5, 1–5 — not a guess.
- [x] **Pack back-compat.** Three new ids, `dynawalla.pulse`,
      `dynawalla.rhythm`, `dynawalla.serpent`, all at `0.1.0`. Nothing published
      changes in place, no catalog entry dropped, no `minAppVersion` moved.
- [x] **Native integrity.** No Rust, no `src-tauri` source, no `links =`.
- [x] **Strings.** Pack name and description live in `pack.json`;
      `locales: ["en"]` is declared honestly rather than claiming coverage that
      does not exist. `pack.html` carries no copy beyond the `<title>`.
- [x] **Secrets.** None — `gitleaks` clean over the range, below.

### Known limitation, deliberately not fixed here

None of the three calls `session.transition`, so they contribute no natural
stopping point to the day pass. `slice` does (`mount.ts:945`, via an optional
`transition?` on its own `Host` type). Adding it means touching game code in
three places and belongs in its own PR, per game, where the *right* moment can
be argued — never after a defeat.

## Proof

The real builder, not just a local vite run — it builds, runs `dw-pack check`
and stages:

```
$ node dynawalla/packs/build.mjs pulse

── dynawalla.pulse@0.1.0  (games/pulse)
vite v6.4.3 building for production...
✓ 37 modules transformed.
dist-pack/pack.html                 1.26 kB │ gzip:  0.65 kB
dist-pack/assets/pack-Bu9LRNHc.js  71.43 kB │ gzip: 25.68 kB
✓ built in 176ms
dynawalla.pulse@0.1.0 — PULSE
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       4 skills, grades 3–5
  on disk      3 files, 73636 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

```
$ node dynawalla/packs/build.mjs rhythm

── dynawalla.rhythm@0.1.0  (games/rhythm)
vite v7.3.6 building client environment for production...
✓ 21 modules transformed.
dist-pack/pack.html                 1.27 kB │ gzip:  0.66 kB
dist-pack/assets/pack-T3KNh_kd.js  76.12 kB │ gzip: 25.76 kB
✓ built in 162ms
dynawalla.rhythm@0.1.0 — SPLITBEAT
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       6 skills, grades 3–5
  on disk      3 files, 78390 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

```
$ node dynawalla/packs/build.mjs serpent

── dynawalla.serpent@0.1.0  (games/serpent)
vite v8.1.5 building client environment for production...
✓ 31 modules transformed.
dist-pack/pack.html                 1.25 kB │ gzip:  0.65 kB
dist-pack/assets/pack-CU3UpA6y.js  61.00 kB │ gzip: 21.78 kB
✓ built in 27ms
dynawalla.serpent@0.1.0 — SERPENT
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       8 skills, grades 1–5
  on disk      3 files, 63339 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

The built entry really does carry its script — the failure mode the vite config
warns about is a `pack.html` that loads, paints the body colour and runs
nothing:

```
$ grep -o '<script[^>]*>' dynawalla/games/{pulse,rhythm,serpent}/dist-pack/pack.html
pulse:   <script type="module" crossorigin src="./assets/pack-Bu9LRNHc.js">
rhythm:  <script type="module" crossorigin src="./assets/pack-T3KNh_kd.js">
serpent: <script type="module" crossorigin src="./assets/pack-CU3UpA6y.js">
```

Each game's own gates, unchanged. Tests run five times per game because the
suites are the thing that would catch a regression in the games themselves, and
one green run is not evidence of a stable suite:

```
$ (cd dynawalla/games/pulse && npm run tsc && npm run build && for i in 1 2 3 4 5; do npm test; done)
tsc --noEmit                       (exit 0)
✓ built in 217ms
run 1: # pass 54 # fail 0
run 2: # pass 54 # fail 0
run 3: # pass 54 # fail 0
run 4: # pass 54 # fail 0
run 5: # pass 54 # fail 0

$ (cd dynawalla/games/rhythm && ...)
tsc --noEmit                       (exit 0)
✓ built in 142ms
run 1: # pass 16 # fail 0
run 2: # pass 16 # fail 0
run 3: # pass 16 # fail 0
run 4: # pass 16 # fail 0
run 5: # pass 16 # fail 0

$ (cd dynawalla/games/serpent && ...)
tsc --noEmit                       (exit 0)
✓ built in 21ms
run 1: # pass 31 # fail 0
run 2: # pass 31 # fail 0
run 3: # pass 31 # fail 0
run 4: # pass 31 # fail 0
run 5: # pass 31 # fail 0
```

`serpent/src/game/world.test.ts` pins `Math.random` to a seeded stream at
module scope because the world uses real `Math.random` for ambience; that pin
is untouched and is why 5/5 is 5/5.

Scope and secrets:

```
$ git diff --name-only origin/main...HEAD
dynawalla/games/pulse/pack.html
dynawalla/games/pulse/pack.json
dynawalla/games/pulse/package.json
dynawalla/games/pulse/src/pack.ts
dynawalla/games/pulse/vite.pack.config.ts
dynawalla/games/rhythm/pack.html
dynawalla/games/rhythm/pack.json
dynawalla/games/rhythm/package.json
dynawalla/games/rhythm/src/pack.ts
dynawalla/games/rhythm/vite.pack.config.ts
dynawalla/games/serpent/pack.html
dynawalla/games/serpent/pack.json
dynawalla/games/serpent/package.json
dynawalla/games/serpent/src/pack.ts
dynawalla/games/serpent/tsconfig.json
dynawalla/games/serpent/vite.pack.config.ts

$ git diff --name-only --diff-filter=D origin/main...HEAD
(empty)

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~15304 bytes (15.30 KB) in 35ms
INF no leaks found
```

The 131 real skill ids were extracted from the graph and every id in all three
`pack.json` files was confirmed present in that set:

```
$ grep -ohE '"dw\.[a-z0-9.-]+"' dynawalla/packs/shared/curriculum/src/graph/domains/*.ts \
    | tr -d '"' | sort -u | wc -l
131
```
