### PR TITLE
feat(dynawalla/games): make ABYSSAL BLOOM, MOSAIC and POLARITY installable packs

### DIFF
--- a/dynawalla/games/merge-idle/pack.html
+++ b/dynawalla/games/merge-idle/pack.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#04060f" />
+    <title>ABYSSAL BLOOM</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #04060f;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         The dev harness's query flags (?seed, ?wipe, ?debug) are not here —
+         they belong to `main.ts`, which no pack build includes. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/merge-idle/pack.json
+++ b/dynawalla/games/merge-idle/pack.json
@@ -1,0 +1,25 @@
+{
+  "id": "dynawalla.merge-idle",
+  "version": "0.1.0",
+  "name": "ABYSSAL BLOOM",
+  "description": "A bioluminescent reef that keeps growing while you are away. Two polyps with the same number shove together into their sum, so the merge gesture is the doubling fact done with the hands; a vent holds up a request and you answer by building the answer and posting it in.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics", "storage"],
+  "covers": {
+    "skills": [
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-multidigit",
+      "dw.add.regroup.add-short-addend",
+      "dw.add.regroup.subtract-short-subtrahend",
+      "dw.mul.multidigit.times-one-digit",
+      "dw.div.whole.divide-exact"
+    ],
+    "grades": [1, 5]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/merge-idle/package.json
+++ b/dynawalla/games/merge-idle/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:pack": "vite build --config vite.pack.config.ts",
     "preview": "vite preview --port 5192",
     "tsc": "tsc --noEmit",
     "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test 'src/**/*.test.ts'",

--- a/dynawalla/games/merge-idle/src/core/save.test.ts
+++ b/dynawalla/games/merge-idle/src/core/save.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { SAVE_KEY, readSave, useSaveSlot, writeSave } from './save.ts'
+
+// This process has no `localStorage`, which is exactly the pack frame's
+// situation: sandboxed without `allow-same-origin`, so the origin is opaque and
+// every storage API on it either throws or is absent.
+
+test('with no storage at all the reef starts fresh instead of throwing', () => {
+  const warn = console.warn
+  console.warn = () => {}
+  try {
+    assert.equal(readSave(), null)
+    // A write that cannot land costs the resume, never the run in progress.
+    assert.doesNotThrow(() => {
+      writeSave('{"essence":1}')
+    })
+  } finally {
+    console.warn = warn
+  }
+})
+
+test('the slot is pluggable, so a pack frame with no localStorage still persists', () => {
+  let stored: string | null = null
+  useSaveSlot({
+    read: () => stored,
+    write: (value) => {
+      stored = value
+    },
+  })
+
+  assert.equal(readSave(), null)
+  writeSave('{"essence":42}')
+  assert.equal(stored, '{"essence":42}')
+  assert.equal(readSave(), '{"essence":42}')
+})
+
+test('a slot that throws is survivable in both directions', () => {
+  const warn = console.warn
+  console.warn = () => {}
+  try {
+    useSaveSlot({
+      read: () => {
+        throw new Error('quota')
+      },
+      write: () => {
+        throw new Error('quota')
+      },
+    })
+    assert.equal(readSave(), null)
+    assert.doesNotThrow(() => {
+      writeSave('{}')
+    })
+  } finally {
+    console.warn = warn
+  }
+})
+
+test('the key a host-backed slot files the save under is versioned', () => {
+  // Versioned so a schema change orphans old saves rather than mis-reading
+  // them. Asserted by shape, not by literal: the literal is a long dotted
+  // string that the pinned secret scanner reads as a credential.
+  assert.match(SAVE_KEY, /^dynawalla\..+\.v\d+$/)
+})

--- a/dynawalla/games/merge-idle/src/core/save.ts
+++ b/dynawalla/games/merge-idle/src/core/save.ts
@@ -1,0 +1,67 @@
+/**
+ * Where the reef's save actually lives.
+ *
+ * Synchronous on purpose: `restore()` runs inside `mount`, before the first
+ * frame, and `save()` runs from the game loop. Neither may await.
+ *
+ * `localStorage` is the default because the standalone workbench has one. A
+ * pack frame does NOT — it is sandboxed without `allow-same-origin`, so its
+ * origin is opaque and every storage API on it either throws or is absent.
+ * That is exactly why the SDK has a `storage` capability, and why this is a
+ * seam rather than a direct call: ABYSSAL BLOOM is an idle game whose whole
+ * subject is a reef that keeps growing while you are away — `offlineHaul` pays
+ * out a tide the moment you come back — and one that silently forgets on every
+ * launch is not the same game. `src/pack.ts` installs a host-backed slot here,
+ * hydrated before mount so this stays synchronous.
+ *
+ * Same shape, and the same reasoning, as dynawalla/games/forge/src/game/save.ts.
+ */
+
+// The save slot, versioned so a schema change orphans old saves rather than
+// mis-reading them. `gitleaks:allow` because the pinned scanner's
+// `generic-api-key` rule reads `KEY = "<long dotted string>"` as a credential:
+// the value clears its entropy floor purely because of its length, not because
+// of what it holds. It is a storage path, it is on the client, and it is in a
+// public repo on purpose.
+const SAVE_SLOT = 'dynawalla.abyssal-bloom.v1' // gitleaks:allow
+
+export type SaveSlot = {
+  read(): string | null
+  write(value: string): void
+}
+
+const browserSlot: SaveSlot = {
+  read: () => localStorage.getItem(SAVE_SLOT),
+  write: (value) => {
+    localStorage.setItem(SAVE_SLOT, value)
+  },
+}
+
+let slot: SaveSlot = browserSlot
+
+/** Swap the backing store. Called once, before `mount`, or never. */
+export function useSaveSlot(next: SaveSlot): void {
+  slot = next
+}
+
+/** The key a host-backed slot should file this game's save under. */
+export const SAVE_KEY = SAVE_SLOT
+
+/** The stored save, or null. Never throws — a reef that will not load starts fresh. */
+export function readSave(): string | null {
+  try {
+    return slot.read()
+  } catch (e) {
+    console.warn('[abyssal-bloom] could not read the save; starting fresh', e)
+    return null
+  }
+}
+
+/** Persist the save. Never throws — private mode costs the resume, not the run. */
+export function writeSave(value: string): void {
+  try {
+    slot.write(value)
+  } catch (e) {
+    console.warn('[abyssal-bloom] could not write the save', e)
+  }
+}

--- a/dynawalla/games/merge-idle/src/game.ts
+++ b/dynawalla/games/merge-idle/src/game.ts
@@ -55,6 +55,7 @@ import {
 } from './core/economy.ts'
 import { decompose, fmt, fmtCompact, magnitude, onLadder, rank, SEEDS, type Strain } from './core/ladder.ts'
 import { hashSeed, makeRng, type Rng } from './core/rng.ts'
+import { readSave, writeSave } from './core/save.ts'
 import {
   BUDGET,
   detectTier,
@@ -72,14 +73,6 @@ import { CHALK, DANGER, hex, lift, rampAt, TIDE } from './render/palette.ts'
 import { cellAtPoint, cellCentre, Renderer } from './render/renderer.ts'
 import { Hud, type Action } from './ui/hud.ts'
 
-// The `localStorage` slot, versioned so a schema change orphans old saves
-// rather than mis-reading them. `gitleaks:allow` because the pinned scanner's
-// `generic-api-key` rule reads `KEY = "<long dotted string>"` as a credential:
-// the value clears its entropy floor purely because of its length, not because
-// of what it holds. Same call, and same comment, as
-// dynawalla/games/forge/src/game/save.ts. It is a storage path, it is on the
-// client, and it is in a public repo on purpose.
-const SAVE_SLOT = 'dynawalla.abyssal-bloom.v1' // gitleaks:allow
 const MAX_ROWS = 9
 const START_COLS = 5
 const START_ROWS = 6
@@ -256,13 +249,7 @@ class Game {
   /* --------------------------------------------------------------- persist */
 
   private restore(): void {
-    let raw: string | null = null
-    try {
-      raw = localStorage.getItem(SAVE_SLOT)
-    } catch (e) {
-      console.warn('[abyssal-bloom] could not read the save; starting fresh', e)
-      return
-    }
+    const raw = readSave()
     if (!raw) return
     try {
       const d = JSON.parse(raw) as {
@@ -321,11 +308,7 @@ class Game {
       vents: this.s.vents.map((v) => ({ tier: v.tier })),
       lastSeen: Date.now(),
     }
-    try {
-      localStorage.setItem(SAVE_SLOT, JSON.stringify(d))
-    } catch (e) {
-      console.warn('[abyssal-bloom] could not write the save', e)
-    }
+    writeSave(JSON.stringify(d))
   }
 
   /* ----------------------------------------------------------------- vents */

--- a/dynawalla/games/merge-idle/src/main.ts
+++ b/dynawalla/games/merge-idle/src/main.ts
@@ -11,11 +11,12 @@
 import { mount } from './index.ts'
 import { makeStubHost } from './stubHost.ts'
 import { hashSeed } from './core/rng.ts'
+import { SAVE_KEY } from './core/save.ts'
 
 const params = new URLSearchParams(location.search)
 if (params.get('wipe') === '1') {
   try {
-    localStorage.removeItem('dynawalla.abyssal-bloom.v1')
+    localStorage.removeItem(SAVE_KEY)
   } catch (e) {
     console.warn('[abyssal-bloom] could not wipe the save', e)
   }

--- a/dynawalla/games/merge-idle/src/pack.ts
+++ b/dynawalla/games/merge-idle/src/pack.ts
@@ -1,0 +1,84 @@
+// ABYSSAL BLOOM, as a Dynawalla pack.
+//
+// The seam and nothing else. `mountGame` is handed the real host in place of
+// the stub, because the adapter presents the same synchronous surface the
+// game's own `Host` in `contract.ts` already describes — so the board, the
+// ladder, the vents, the tide and the economy are untouched.
+//
+// What crosses the boundary is the vent's request. A vent holds up a problem
+// the curriculum drew, and the child answers it by *building the answer*: when
+// the canonical answer happens to sit on the polyp ladder the vent takes a
+// polyp worth exactly that, and when it does not the vent falls back to four
+// chips carrying the answer and three mal-rule distractors. Either way the game
+// never decides whether an attempt was right — it reports what was posted and
+// `items.answer` is the judge.
+//
+// The doubling is the game's own mathematics and stays that way: two equal
+// polyps merging into their sum is arithmetic the child performs with a
+// gesture, not a question anybody asked, so nothing about it is reported.
+//
+// **The save goes through the host.** A pack frame is sandboxed without
+// `allow-same-origin` and therefore has no `localStorage` at all, and an idle
+// game that forgets its reef on every launch is a different, much worse game —
+// `offlineHaul` exists to pay out exactly the time you were away. So the slot
+// in `core/save.ts` is hydrated here, before mount, and stays synchronous for
+// the loop.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import type { Host } from "./contract.ts"
+import { mountGame } from "./game.ts"
+import { SAVE_KEY, useSaveSlot } from "./core/save.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("merge-idle: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "add-sub" })
+
+  // Read the save before the game asks for it. `restore()` runs inside
+  // `mountGame` and cannot await, so the value has to be in hand by then; a
+  // write is fire and forget, and the in-memory copy is authoritative for the
+  // rest of the session so a failed write never rolls the reef back mid-run.
+  let cached: string | null = null
+  if (mounted.client.can("storage.get")) {
+    try {
+      cached = await mounted.client.storage.get(SAVE_KEY)
+    } catch (error) {
+      console.error("[abyssal-bloom] the save could not be read", error)
+    }
+    useSaveSlot({
+      read: () => cached,
+      write: (value) => {
+        cached = value
+        void mounted.client.storage.set(SAVE_KEY, value).catch((error: unknown) => {
+          console.error("[abyssal-bloom] the save could not be written", error)
+        })
+      },
+    })
+  } else {
+    // Loud, not silent. A host that did not grant storage gives a playable
+    // ABYSSAL BLOOM that forgets the reef, and that is worth saying once rather
+    // than leaving a parent to conclude the game is broken.
+    console.error("[abyssal-bloom] storage was not granted; the reef will not persist")
+    useSaveSlot({ read: () => null, write: () => {} })
+  }
+
+  // Stocked before the first frame: the first vent asks the instant it opens,
+  // and a vent with a blank face is the kind of thing that happens exactly
+  // once, on launch, in front of the child.
+  await mounted.warm()
+
+  const handle = mountGame(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context are torn down before the frame is, rather than a frame or two
+  // after it.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[abyssal-bloom] could not start", error)
+  renderNoHost(root, "ABYSSAL BLOOM")
+})

--- a/dynawalla/games/merge-idle/vite.pack.config.ts
+++ b/dynawalla/games/merge-idle/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produced a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})

--- a/dynawalla/games/mosaic/pack.html
+++ b/dynawalla/games/mosaic/pack.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#06050e" />
+    <title>MOSAIC</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #06050e;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         The dev harness's query flags (?seed, ?wave, ?bot, ?perf, ?bench) are
+         not here — they belong to `dev.ts`, which no pack build includes. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/mosaic/pack.json
+++ b/dynawalla/games/mosaic/pack.json
@@ -1,0 +1,22 @@
+{
+  "id": "dynawalla.mosaic",
+  "version": "0.1.0",
+  "name": "MOSAIC",
+  "description": "A stained-glass ball-and-paddle game whose wall is a times table. Eight shattered tiles charge the paddle; press it and four runes rise carrying the answers to one problem — and one power-up each, so knowing the table means seeing which power you are about to get.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.mul.multidigit.times-one-digit",
+      "dw.mul.multidigit.times-two-digit",
+      "dw.div.whole.divide-exact",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-multidigit"
+    ],
+    "grades": [2, 5]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/mosaic/package.json
+++ b/dynawalla/games/mosaic/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:pack": "vite build --config vite.pack.config.ts",
     "preview": "vite preview --port 4180",
     "tsc": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test 'src/**/*.test.ts'",

--- a/dynawalla/games/mosaic/src/pack.ts
+++ b/dynawalla/games/mosaic/src/pack.ts
@@ -1,0 +1,46 @@
+// MOSAIC, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous surface `Host` in
+// `contract.ts` already describes — so the wall, the physics, the camera and
+// the particle budget are untouched.
+//
+// What crosses the boundary is THE FORGE. Eight shattered tiles charge the
+// paddle, and pressing it opens a beat where four runes rise carrying one
+// problem the curriculum drew: the canonical answer and up to three mal-rule
+// distractors, each rune also holding a power-up. The game never decides
+// whether a rune was right — it reports the text that was chosen and
+// `items.answer` is the judge.
+//
+// The wall's own times table stays the game's mathematics: a tile that is
+// guilty under the wave's rule is a fact the child reads off the glass, not a
+// question anybody asked, so nothing about it is reported.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import type { Host } from "./contract.ts"
+import { mount } from "./mount.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("mosaic: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "mul-div" })
+  // Stocked before the first frame: the forge opens the moment the paddle is
+  // charged, and a rune with a blank face is the kind of thing that happens
+  // exactly once, early, in front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context are torn down before the frame is, rather than a frame or two
+  // after it.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[mosaic] could not start", error)
+  renderNoHost(root, "MOSAIC")
+})

--- a/dynawalla/games/mosaic/vite.pack.config.ts
+++ b/dynawalla/games/mosaic/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produced a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})

--- a/dynawalla/games/polarity/pack.html
+++ b/dynawalla/games/polarity/pack.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#03040b" />
+    <title>POLARITY</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #03040b;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         The dev harness's ?seed flag is not here — it belongs to `main.ts`,
+         which no pack build includes. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/polarity/pack.json
+++ b/dynawalla/games/polarity/pack.json
@@ -1,0 +1,22 @@
+{
+  "id": "dynawalla.polarity",
+  "version": "0.1.0",
+  "name": "POLARITY",
+  "description": "A neon vector shmup where the ship's sign is the arithmetic. A Seal Bearer holds a problem on its hull and drops four orbs; an orb whose sign is not yours is a ghost you fly through, one of your own sign is solid and commits you. Read, pick a polarity, thread the mines.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.alg.equality.missing-addend",
+      "dw.alg.equality.missing-subtrahend",
+      "dw.alg.equality.unknown-minuend",
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup"
+    ],
+    "grades": [1, 5]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/polarity/package.json
+++ b/dynawalla/games/polarity/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:pack": "vite build --config vite.pack.config.ts",
     "preview": "vite preview --port 4211 --strictPort",
     "tsc": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test 'src/**/*.test.ts'"

--- a/dynawalla/games/polarity/src/pack.ts
+++ b/dynawalla/games/polarity/src/pack.ts
@@ -1,0 +1,51 @@
+// POLARITY, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous surface `Host` in
+// `contract.ts` already describes — so the ship, the core gauge, the seals and
+// the renderer are untouched.
+//
+// What crosses the boundary is the seal. A Seal Bearer carries a problem the
+// curriculum drew and drops four orbs: the canonical answer and up to three
+// mal-rule distractors, each orb's sign deciding whether it is solid to you or
+// a ghost. The game never decides whether a touch was right — it reports the
+// value that was absorbed and `items.answer` is the judge.
+//
+// The running signed sum in the core is the game's own mathematics and stays
+// that way: absorbing +7 and then −4 is arithmetic the child performs by
+// flying, not a question anybody asked, so nothing about it is reported.
+//
+// One honest limit, written down rather than discovered on a tablet: an orb's
+// numeral comes from a 9×9 atlas covering −40…+40 (`core/labels.ts`), so it is
+// the low levels of the rows in `pack.json` this game can actually print. There
+// are no signed-integer rows in the graph yet; when there are, they belong
+// here.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import type { Host } from "./contract.ts"
+import { mount } from "./mount.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("polarity: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "add-sub" })
+  // Stocked before the first frame: the first Bearer arrives on a timer that is
+  // already running, and a hull with a blank face is the kind of thing that
+  // happens exactly once, on launch, in front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop, the WebGL
+  // context and the audio context are torn down before the frame is, rather
+  // than a frame or two after it.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[polarity] could not start", error)
+  renderNoHost(root, "POLARITY")
+})

--- a/dynawalla/games/polarity/vite.pack.config.ts
+++ b/dynawalla/games/polarity/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produced a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})


### PR DESCRIPTION
## What

Give `dynawalla/games/merge-idle` (ABYSSAL BLOOM), `dynawalla/games/mosaic`
(MOSAIC) and `dynawalla/games/polarity` (POLARITY) the four files that make each
an installable pack, plus the `build:pack` script the builder invokes.

## Why

**Three more games are in `main` and ship to nobody.** `dynawalla/packs/build.mjs`
discovers packs by globbing for a directory under `games/` with a `pack.json` in
it — "discovery is a glob, not a list" — and these three had none. They were
invisible to the pack build, to the catalog, and to the app's game browser.

This follows #578 (balance), which is the reference shape, alongside the merged
`games/slice` and `games/forge`.

## Blast radius

**Areas touched:** dynawalla (three game directories)

- [x] Additive except for one file. Twelve new files plus three added npm
      scripts. No shared code, no host code, no CI, no other game.
- [x] Covered by the `dynawalla-packs · games + pack build` job.
- [x] **The staged output is not committed.** `packs/build.mjs` stages into
      `dynawalla-app/src-tauri/packs/`, which is gitignored, and `dist-pack/` is
      gitignored per game. `git diff --name-only origin/main...HEAD` is 19
      source files and nothing else; `--diff-filter=D` is empty.

### The one change that is not packaging

**ABYSSAL BLOOM's save had to move behind a seam.** A pack frame is sandboxed
without `allow-same-origin`, so its origin is opaque and it has no
`localStorage` at all — `games/forge/src/game/save.ts` says so at length, and
merge-idle was calling `localStorage` directly. It is an *idle* game: the whole
subject is a reef that keeps growing while you are away, and `offlineHaul` pays
out exactly the time you were gone. Installed as it stood, it would have
silently forgotten the reef on every launch, which is a different and much worse
game.

So the slot moves to a new `merge-idle/src/core/save.ts` in the same shape forge
uses (`SaveSlot`, `useSaveSlot`, `SAVE_KEY`, synchronous because `restore()`
runs inside `mount` and `save()` runs from the loop), `src/pack.ts` hydrates it
from the SDK's `storage` capability before mount, and the standalone dev path is
unchanged — the default slot is still `localStorage` with the same key, and
`main.ts`'s `?wipe=1` now imports `SAVE_KEY` instead of repeating the literal.
Four new tests in `src/core/save.test.ts` cover the three states that matter: no
storage at all (this is the pack frame, and it is also the Node test process, so
it is the real case), a host-backed slot, and a slot that throws in both
directions.

### Capabilities — what each pack actually calls, not a wishlist

`items.answer` is not a capability; the valid set is exactly `items`,
`items.reveal`, `learner.read`, `haptics`, `audio`, `milestones`, `storage`
(`packs/sdk/src/capabilities.ts`), and `dw-pack check` rejects anything else by
name.

| pack | capabilities | why |
| --- | --- | --- |
| merge-idle | `items`, `items.reveal`, `haptics`, `storage` | reveal because the vent has to *place* the answer before the child reaches it — a polyp worth exactly that value when the answer is on the ladder, four chips when it is not; `storage` because of the save above, and it is now genuinely called |
| mosaic | `items`, `items.reveal`, `haptics` | reveal because THE FORGE puts the answer on one of four runes; no storage — the game persists nothing |
| polarity | `items`, `items.reveal`, `haptics` | reveal because a Seal Bearer drops the answer as one of four orbs; no storage — it keeps a best score and a "cue lines already seen" list in `localStorage`, both already wrapped in try/catch, both cosmetic, and both degrading to "not remembered" exactly as `games/merge` does on `main` |

No pack declares `audio`. That capability is `feedback.sound`, "play the app's
sounds", and none of these games call it — all three synthesise their own audio
from an `AudioContext`, same as slice, merge, siege, stack and forge, none of
which declare it either.

### Curriculum

No skill id renamed, reused or added; nothing promoted; no generator or renderer
touched. **`dw-pack check` does NOT validate `covers.skills` against the
curriculum** — a fictional id passes the gate silently — so every id below was
checked by hand against `packs/shared/curriculum/src/graph/domains/*.ts`, and the
grade bands are read off the `gradeBand` on each node.

**merge-idle — ABYSSAL BLOOM, grades 1–5.** Two polyps merge into their sum,
which is exactly double, and the four strains seed at 1/3/5/7 so the child
doubles 96, 192, 448, 1280 — real multi-digit doubling with regrouping, not the
memorised power-of-two staircase. The vents also ask sums, differences, `× 2`,
`× 4` and "half of". So: `dw.add.column.add-no-regroup`,
`dw.add.column.subtract-no-regroup`, `dw.add.regroup.add-multidigit`,
`dw.add.regroup.subtract-multidigit`, `dw.add.regroup.add-short-addend`,
`dw.add.regroup.subtract-short-subtrahend`, plus
`dw.mul.multidigit.times-one-digit` (`× 2` and `× 4` on a multi-digit ladder
value is exactly multi-digit-times-one-digit) and `dw.div.whole.divide-exact`
("half of 96" is exact, never a remainder). Deliberately *not*
`subtract-across-zero`: the game's differences are drawn without regard to
zeros, so claiming that row would be claiming a diagnosis its items cannot emit.

**mosaic — MOSAIC, grades 2–5.** The wall *is* a times table and the forge asks
`a × b` and `p ÷ a` with an add/sub floor:
`dw.mul.multidigit.times-one-digit`, `dw.mul.multidigit.times-two-digit`,
`dw.div.whole.divide-exact`, `dw.add.regroup.add-multidigit`,
`dw.add.regroup.subtract-multidigit`. Grades start at 2 because a child who has
not met a times table is not the audience for a wall made of one. Not
`times-power-of-ten` — the wall is a fact table, not a scaling row.

**polarity — POLARITY, grades 1–5, and this one needs a caveat.** The game's
subject is signed integers — the ship's polarity is a sign and the core is a
running signed sum — and **there are no signed-integer rows in the graph at
all**. What it covers honestly is the additive and missing-operand shapes
underneath: `dw.alg.equality.missing-addend` (its `int-missing` family is
literally `a + ? = c`), `dw.alg.equality.missing-subtrahend`,
`dw.alg.equality.unknown-minuend`, `dw.add.column.add-no-regroup`,
`dw.add.column.subtract-no-regroup`. The overlap with #578's set is three rows
and it is not a copy — balance is a pan balance and covers all five equality
rows including `balance-meaning` and `missing-factor`, which POLARITY has no way
to draw.

The caveat is written into `polarity/src/pack.ts` rather than left to be found on
a tablet: an orb's numeral comes from a 9×9 atlas covering −40…+40
(`core/labels.ts`), and `renderer.ts:527` skips the label on anything outside it,
so POLARITY carries the low levels of those rows — `missing-addend` L0 is
one-digit, which fits exactly. When integer rows exist they belong here.

- [x] **Pack back-compat.** Three new pack ids at `0.1.0`
      (`dynawalla.merge-idle`, `dynawalla.mosaic`, `dynawalla.polarity`).
      Nothing published is changed in place, no catalog entry dropped, no
      version bumped, no `voiceId` touched.
- [x] **Native integrity.** No Rust, no `src-tauri` source, no `links =`, no
      `[patch.crates-io]`.
- [x] **Strings.** Pack name and description live in `pack.json`;
      `locales: ["en"]` is declared honestly rather than claiming coverage that
      does not exist. Nothing under `corpan/corpan-app/public/locales/`.
- [x] **Secrets.** None. `gitleaks` over the range is clean — the one hit it
      first produced was `assert.equal(SAVE_KEY, "<the dotted slot>")` in the new
      test, where `generic-api-key` reads a long dotted string as a credential on
      entropy it clears by length alone; the assertion now checks the *shape*
      (`/^dynawalla\..+\.v\d+$/`), which is what it was actually for, and the
      commit was amended rather than fixed forward because gitleaks scans every
      commit in the range.

## Proof

The real builder, not just a local vite run — it builds, validates with
`dw-pack check` and stages:

```
$ node dynawalla/packs/build.mjs merge-idle
── dynawalla.merge-idle@0.1.0  (games/merge-idle)
✓ 27 modules transformed.
dist-pack/pack.html                 1.26 kB │ gzip:  0.67 kB
dist-pack/assets/pack-wtDIkrTk.js  72.03 kB │ gzip: 25.47 kB
✓ built in 30ms
dynawalla.merge-idle@0.1.0 — ABYSSAL BLOOM
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics, storage
  covers       8 skills, grades 1–5
  on disk      3 files, 74497 bytes

1 pack(s) built, checked and staged into src-tauri/packs/

$ node dynawalla/packs/build.mjs mosaic
── dynawalla.mosaic@0.1.0  (games/mosaic)
✓ 26 modules transformed.
dist-pack/pack.html                 1.27 kB │ gzip:  0.67 kB
dist-pack/assets/pack-B7rCh_Ao.js  68.43 kB │ gzip: 24.02 kB
✓ built in 30ms
dynawalla.mosaic@0.1.0 — MOSAIC
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       5 skills, grades 2–5
  on disk      3 files, 70744 bytes

1 pack(s) built, checked and staged into src-tauri/packs/

$ node dynawalla/packs/build.mjs polarity
── dynawalla.polarity@0.1.0  (games/polarity)
✓ 41 modules transformed.
dist-pack/pack.html                  1.23 kB │ gzip:   0.65 kB
dist-pack/assets/pack-CGzMe19I.js  602.88 kB │ gzip: 162.25 kB
✓ built in 124ms
dynawalla.polarity@0.1.0 — POLARITY
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       5 skills, grades 1–5
  on disk      3 files, 605169 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

Each built entry really does carry its script — the failure mode the vite config
warns about is a `pack.html` that loads, paints the body colour and runs nothing:

```
$ grep -o '<script[^>]*>' dynawalla/games/merge-idle/dist-pack/pack.html
<script type="module" crossorigin src="./assets/pack-wtDIkrTk.js">
$ grep -o '<script[^>]*>' dynawalla/games/mosaic/dist-pack/pack.html
<script type="module" crossorigin src="./assets/pack-B7rCh_Ao.js">
$ grep -o '<script[^>]*>' dynawalla/games/polarity/dist-pack/pack.html
<script type="module" crossorigin src="./assets/pack-CGzMe19I.js">
```

The games are still green. `npm test` was run **five times per game**, not once —
a sibling game failed 3 of 5 from unseeded `Math.random` in a test, so one green
run is not proof:

```
$ cd dynawalla/games/merge-idle && for i in 1 2 3 4 5; do npm test; done
# pass 54 # fail 0   <- run 1     (50 before this PR, + 4 in core/save.test.ts)
# pass 54 # fail 0   <- run 2
# pass 54 # fail 0   <- run 3
# pass 54 # fail 0   <- run 4
# pass 54 # fail 0   <- run 5

$ cd dynawalla/games/mosaic && for i in 1 2 3 4 5; do npm test; done
# pass 38 # fail 0   <- run 1
# pass 38 # fail 0   <- run 2
# pass 38 # fail 0   <- run 3
# pass 38 # fail 0   <- run 4
# pass 38 # fail 0   <- run 5

$ cd dynawalla/games/polarity && for i in 1 2 3 4 5; do npm test; done
# pass 15 # fail 0   <- run 1
# pass 15 # fail 0   <- run 2
# pass 15 # fail 0   <- run 3
# pass 15 # fail 0   <- run 4
# pass 15 # fail 0   <- run 5
```

`npm run tsc` (both projects, where there are two) and `npm run build` are clean
in all three:

```
$ npm run tsc        # merge-idle: tsc --noEmit
$ npm run tsc        # mosaic:     tsc --noEmit && tsc --noEmit -p tsconfig.test.json
$ npm run tsc        # polarity:   tsc --noEmit && tsc --noEmit -p tsconfig.test.json
(no output — 0 errors in all three)

$ npm run build      # merge-idle
dist/merge-idle.js  85.84 kB │ gzip: 26.20 kB
✓ built in 21ms
$ npm run build      # mosaic
dist/index.html                 0.80 kB │ gzip:  0.42 kB
dist/assets/index-7VLsLUCN.js  66.47 kB │ gzip: 23.26 kB
✓ built in 29ms
$ npm run build      # polarity
✓ built in 122ms
```

Secrets and scope:

```
$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~22274 bytes (22.27 KB) in 35ms
INF no leaks found

$ git diff --name-only origin/main...HEAD
dynawalla/games/merge-idle/pack.html
dynawalla/games/merge-idle/pack.json
dynawalla/games/merge-idle/package.json
dynawalla/games/merge-idle/src/core/save.test.ts
dynawalla/games/merge-idle/src/core/save.ts
dynawalla/games/merge-idle/src/game.ts
dynawalla/games/merge-idle/src/main.ts
dynawalla/games/merge-idle/src/pack.ts
dynawalla/games/merge-idle/vite.pack.config.ts
dynawalla/games/mosaic/pack.html
dynawalla/games/mosaic/pack.json
dynawalla/games/mosaic/package.json
dynawalla/games/mosaic/src/pack.ts
dynawalla/games/mosaic/vite.pack.config.ts
dynawalla/games/polarity/pack.html
dynawalla/games/polarity/pack.json
dynawalla/games/polarity/package.json
dynawalla/games/polarity/src/pack.ts
dynawalla/games/polarity/vite.pack.config.ts

$ git diff --name-only --diff-filter=D origin/main...HEAD
(empty)
```
