### PR TITLE
feat(dynawalla/games): make CLAIM, GUILTY and DEEPSWARM installable packs

### DIFF
--- a/dynawalla/games/claim/pack.html
+++ b/dynawalla/games/claim/pack.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#0d0d12" />
+    <title>CLAIM</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #0d0d12;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         The dev harness mounted into `#stage`; the id here is `#app` because
+         that is what every pack entry in this repository uses, and the game
+         takes whatever element it is handed. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/claim/pack.json
+++ b/dynawalla/games/claim/pack.json
@@ -1,0 +1,35 @@
+{
+  "id": "dynawalla.claim",
+  "version": "0.1.0",
+  "name": "CLAIM",
+  "description": "Cut the plane and take exactly the fraction you were asked for. Three quarters of the ground stops being something you read and becomes something you carved, with the hunt loose inside the region you have not closed yet.",
+  "sdk": "1.0.0",
+  "host": {
+    "min": "0.1.0",
+    "max": "1.0.0"
+  },
+  "entry": "pack.html",
+  "capabilities": [
+    "items",
+    "items.reveal",
+    "haptics"
+  ],
+  "covers": {
+    "skills": [
+      "dw.frac.arith.multiply-by-a-whole",
+      "dw.frac.equivalence.lowest-terms",
+      "dw.frac.compare.unlike-fractions"
+    ],
+    "grades": [
+      3,
+      5
+    ]
+  },
+  "locales": [
+    "en"
+  ],
+  "build": {
+    "config": "vite.pack.config.ts",
+    "out": "dist-pack"
+  }
+}

--- a/dynawalla/games/claim/package.json
+++ b/dynawalla/games/claim/package.json
@@ -13,7 +13,8 @@
     "build": "vite build",
     "preview": "vite preview --port 4197 --strictPort",
     "tsc": "tsc --noEmit",
-    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test 'test/*.test.ts'"
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test 'test/*.test.ts'",
+    "build:pack": "vite build --config vite.pack.config.ts"
   },
   "devDependencies": {
     "@types/node": "^22.20.1",

--- a/dynawalla/games/claim/src/pack.ts
+++ b/dynawalla/games/claim/src/pack.ts
@@ -1,0 +1,43 @@
+// CLAIM, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous `Host` surface that
+// `contract.ts` already describes — so the rail, the trail, the hunt and the
+// exact-integer arena are untouched.
+//
+// What crosses the boundary is the goal. `goalFromQuestion` takes the host's
+// question and uses its answer as a cell count when it can be one, and spends
+// it on the revive gate when it cannot: a curriculum that hands back "15 − 8"
+// is not describing an area, and the game must not depend on any particular
+// one being plugged in. The game never decides whether a claim was right — it
+// reports the count the child cut to and the host is the judge.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+
+import "./style.css"
+import type { Host } from "./contract.ts"
+import { mount } from "./game/index.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("claim: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "fraction-of-area" })
+  // Stocked before the first frame: the goal card is the first thing drawn and
+  // a blank one is the kind of thing that happens exactly once, on launch, in
+  // front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context are torn down before the frame is, rather than a frame or two after.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[claim] could not start", error)
+  renderNoHost(root, "CLAIM")
+})

--- a/dynawalla/games/claim/vite.pack.config.ts
+++ b/dynawalla/games/claim/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produced a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})

--- a/dynawalla/games/guilty/pack.html
+++ b/dynawalla/games/guilty/pack.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#03060c" />
+    <title>GUILTY</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #03060c;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         `src/style.css` is not linked either — it is dev-harness chrome, and
+         the rules that matter are the eight above. The game paints one canvas
+         and drags no styles along. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/guilty/pack.json
+++ b/dynawalla/games/guilty/pack.json
@@ -1,0 +1,38 @@
+{
+  "id": "dynawalla.guilty",
+  "version": "0.1.0",
+  "name": "GUILTY",
+  "description": "Shoot the Guilty Number. A fixed-position shooter in a bioluminescent trench: the sum descends on four husks, three of them carrying a mistake children actually make, and the bolt has to land on the one that is right.",
+  "sdk": "1.0.0",
+  "host": {
+    "min": "0.1.0",
+    "max": "1.0.0"
+  },
+  "entry": "pack.html",
+  "capabilities": [
+    "items",
+    "items.reveal",
+    "haptics"
+  ],
+  "covers": {
+    "skills": [
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-multidigit",
+      "dw.mul.multidigit.times-one-digit",
+      "dw.div.whole.divide-exact"
+    ],
+    "grades": [
+      1,
+      5
+    ]
+  },
+  "locales": [
+    "en"
+  ],
+  "build": {
+    "config": "vite.pack.config.ts",
+    "out": "dist-pack"
+  }
+}

--- a/dynawalla/games/guilty/package.json
+++ b/dynawalla/games/guilty/package.json
@@ -13,7 +13,8 @@
     "preview": "vite preview --port 4179",
     "tsc": "tsc --noEmit",
     "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
-    "check": "npm run tsc && npm test"
+    "check": "npm run tsc && npm test",
+    "build:pack": "vite build --config vite.pack.config.ts"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/dynawalla/games/guilty/src/pack.ts
+++ b/dynawalla/games/guilty/src/pack.ts
@@ -1,0 +1,41 @@
+// GUILTY, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// dev host, because the adapter presents the same synchronous `Host` surface
+// that `contract.ts` already describes — so the trench, the husks, the wave
+// ladder and the boss are untouched.
+//
+// What crosses the boundary is the accusation. The host draws a problem and
+// reveals its canonical answer; the game writes that answer on one descending
+// husk and the mal-rule distractors on the others, which is the sanctioned use
+// of `items.reveal` — placing the answer, never judging it. The game reports
+// which husk was shot and the host is the judge.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts";
+
+import type { Host } from "./contract.ts";
+import { mount } from "./game/game.ts";
+
+const root = document.getElementById("app");
+if (!root) throw new Error("guilty: #app missing");
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "arith" });
+  // Stocked before the first frame: wave one drops a husk immediately, and a
+  // husk with a blank face is the kind of thing that happens exactly once, on
+  // launch, in front of the child.
+  await mounted.warm();
+
+  const handle = mount(el, mounted.host as unknown as Host);
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context are torn down before the frame is, rather than a frame or two after.
+  mounted.client.on("dispose", () => {
+    handle.unmount();
+  });
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[guilty] could not start", error);
+  renderNoHost(root, "GUILTY");
+});

--- a/dynawalla/games/guilty/vite.pack.config.ts
+++ b/dynawalla/games/guilty/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produced a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})

--- a/dynawalla/games/horde/pack.html
+++ b/dynawalla/games/horde/pack.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#04060f" />
+    <title>DEEPSWARM</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #04060f;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         The game's own stylesheet is not linked: `src/index.ts` imports it
+         `?inline` and injects it on mount, so it travels inside the bundle. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/horde/pack.json
+++ b/dynawalla/games/horde/pack.json
@@ -1,0 +1,39 @@
+{
+  "id": "dynawalla.horde",
+  "version": "0.1.0",
+  "name": "DEEPSWARM",
+  "description": "A bioluminescent horde-survivor. Move; the swarm comes; the light wins. Every level-up is a card draw, and the sealed card and the rift both stay shut until the arithmetic written on them is answered.",
+  "sdk": "1.0.0",
+  "host": {
+    "min": "0.1.0",
+    "max": "1.0.0"
+  },
+  "entry": "pack.html",
+  "capabilities": [
+    "items",
+    "items.reveal",
+    "haptics"
+  ],
+  "covers": {
+    "skills": [
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-multidigit",
+      "dw.mul.multidigit.times-one-digit",
+      "dw.mul.multidigit.times-two-digit",
+      "dw.div.whole.divide-exact"
+    ],
+    "grades": [
+      1,
+      5
+    ]
+  },
+  "locales": [
+    "en"
+  ],
+  "build": {
+    "config": "vite.pack.config.ts",
+    "out": "dist-pack"
+  }
+}

--- a/dynawalla/games/horde/package.json
+++ b/dynawalla/games/horde/package.json
@@ -13,7 +13,8 @@
     "build": "vite build",
     "preview": "vite preview --port 4179 --strictPort",
     "tsc": "tsc --noEmit",
-    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test src/**/*.test.ts"
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test src/**/*.test.ts",
+    "build:pack": "vite build --config vite.pack.config.ts"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",

--- a/dynawalla/games/horde/src/pack.ts
+++ b/dynawalla/games/horde/src/pack.ts
@@ -1,0 +1,45 @@
+// DEEPSWARM, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous `Host` surface that
+// `contract.ts` already describes — so the swarm, the loadout cards, the tier
+// governor and the WebGL2 renderer are untouched.
+//
+// What crosses the boundary is the seal. A sealed card and a rift both carry a
+// problem the host drew, and the host also reveals its canonical answer so the
+// game can write it on one orb and the mal-rule distractors on the others —
+// placing the answer, never judging it. The game reports which orb was struck
+// and the host is the judge.
+//
+// `mount` lives in `./index.ts` and not in `./contract.ts`: the contract file
+// carries a throwing stub on purpose, so the shape stays byte-identical across
+// every game without anybody importing it by accident.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+
+import type { Host } from "./contract.ts"
+import { mount } from "./index.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("horde: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "arith" })
+  // Stocked before the first frame: the first level-up can arrive within
+  // seconds, and a sealed card with a blank face is the kind of thing that
+  // happens exactly once, on launch, in front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context are torn down before the frame is, rather than a frame or two after.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[horde] could not start", error)
+  renderNoHost(root, "DEEPSWARM")
+})

--- a/dynawalla/games/horde/vite.pack.config.ts
+++ b/dynawalla/games/horde/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produced a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})


### PR DESCRIPTION
## What

Make three games installable packs: **CLAIM**, **GUILTY** and **DEEPSWARM**
(`claim`, `guilty`, `horde`).

## Why

`dynawalla/packs/build.mjs` discovers a pack by globbing for a directory under
`games/` with a `pack.json` in it — "discovery is a glob, not a list". These
three had none, so they were in `main` and invisible to the pack build, the
catalog and the app's game browser. They shipped to nobody.

They are three of the eleven games rescued in #561–#571, which were saved from
deletion but never packaged. With this, every rescued game is packaged.

## Blast radius

**Areas touched:** dynawalla, three game directories. Additive only.

- [x] Scope verified: 0 files outside `dynawalla/games/{claim,guilty,horde}/`,
      0 deletions.
- [x] Covered by the `dynawalla-packs · games + pack build` job.
- [x] **Capabilities: `items`, `items.reveal`, `haptics`** for all three.
      `items.reveal` is **mandatory**, not a nicety: the shared host resolves an
      item's canonical value through it
      (`packs/shared/game-host/index.ts:149-167`), and without the grant
      `canonical` is `""`, every item is dropped and the pool never fills — the
      pack mounts, warms and serves nothing, with no crash and no failing gate.
      `audio` is deliberately **not** declared: that capability is
      `feedback.sound` ("Play the app's sounds") and all three synthesise their
      own through `AudioContext`, as every shipped pack does. `items.answer` is
      not a capability at all and `dw-pack check` rejects it by name.
- [x] **Curriculum.** No skill id renamed, reused or added. Every id was
      verified by hand against
      `packs/shared/curriculum/src/graph/domains/*.ts`, because **`dw-pack
      check` does not validate skill ids** and a fictional one passes silently:
      - `claim` → 3 `dw.frac.*` (multiply-by-a-whole, lowest-terms,
        compare-unlike), grades 3–5 — it is a game about taking exactly the
        fraction you were asked for.
      - `guilty` → 4 `dw.add.*` + `times-one-digit` + `divide-exact`, grades 1–5.
      - `horde` → the same plus `times-two-digit`, grades 1–5, matching the five
        families its generator actually produces (add, sub, mul, div, signed).
      **Stated limitation:** the `frac`, `mul` and `div` rows are all
      `status: "draft"`. Only `add` has active rows (7 of 8). `ladder()` defaults
      to `activeNodes()` and `covers` is documented as "a request, not an
      instruction", so CLAIM in particular will be served the add ladder until
      `frac` is promoted. Relabelling a fraction game to `dw.add.*` ids would
      make the manifest lie to match a curriculum gap; promoting those domains
      is curriculum work outside this blast radius.
- [x] **Pack back-compat.** Three new ids at `0.1.0`; nothing published changed
      in place, no catalog entry dropped.
- [x] **Native integrity.** No Rust, no `src-tauri` source, no `links =`.
- [x] **Strings.** Names/descriptions live in `pack.json`; `locales: ["en"]`
      declared honestly.
- [x] **No build artifacts.** `dist-pack/` and `src-tauri/packs/` are gitignored;
      confirmed absent from the diff.
- [x] **Secrets.** `gitleaks detect --log-opts="origin/main..HEAD"` → no leaks.

## Proof

The real builder for each — it builds, validates via `dw-pack check`, and stages:

```
$ node dynawalla/packs/build.mjs claim
  capabilities items, items.reveal, haptics   covers 3 skills, grades 3–5
  1 pack(s) built, checked and staged into src-tauri/packs/

$ node dynawalla/packs/build.mjs guilty
  capabilities items, items.reveal, haptics   covers 6 skills, grades 1–5
  1 pack(s) built, checked and staged into src-tauri/packs/

$ node dynawalla/packs/build.mjs horde
  capabilities items, items.reveal, haptics   covers 7 skills, grades 1–5
  1 pack(s) built, checked and staged into src-tauri/packs/
```

The built entry really carries its script — the failure mode the vite config
warns about is a `pack.html` that loads, paints the body colour and runs nothing:

```
claim   <script type="module" crossorigin src="./assets/pack-DgoOYLWh.js"
guilty  <script type="module" crossorigin src="./assets/pack-KTH09KBq.js"
horde   <script type="module" crossorigin src="./assets/pack-BJe4f_Sf.js"
```

Tests run **five times each**, because one green run is not proof — a sibling
game passed once and then failed 3 of the next 5 from unseeded `Math.random`:

```
claim   failed_runs=0/5   tscErr=0
guilty  failed_runs=0/5   tscErr=0
horde   failed_runs=0/5   tscErr=0
```

```
$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
no leaks found

$ git diff --name-only origin/main...HEAD | grep -vcE '^dynawalla/games/(claim|guilty|horde)/'
0
$ git diff --diff-filter=D --name-only origin/main...HEAD | wc -l
0
```
