### PR TITLE
feat(dynawalla/games/trebuchet): make TREBUCHET an installable pack

### DIFF
--- a/dynawalla/games/trebuchet/pack.html
+++ b/dynawalla/games/trebuchet/pack.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#03050d" />
+    <title>TREBUCHET</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #03050d;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         `index.html`'s dev entry stays where it is — it mounts the stub host
+         and hangs it off `window`, which is a debugging surface and not
+         something to ship inside a child's tablet. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/trebuchet/pack.json
+++ b/dynawalla/games/trebuchet/pack.json
@@ -1,0 +1,21 @@
+{
+  "id": "dynawalla.trebuchet",
+  "version": "0.1.0",
+  "name": "TREBUCHET",
+  "description": "A siege where the range dial is the answer. Work the sum, wind the arm to that many metres and the keep standing at your number comes down — miss and the boulder lands on the keep your mistake named, out on the field where you can see how far off it was.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-multidigit"
+    ],
+    "grades": [1, 3]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/trebuchet/package.json
+++ b/dynawalla/games/trebuchet/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:pack": "vite build --config vite.pack.config.ts",
     "preview": "vite preview --port 4183",
     "tsc": "tsc --noEmit",
     "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test 'src/**/*.test.ts'"

--- a/dynawalla/games/trebuchet/src/pack.ts
+++ b/dynawalla/games/trebuchet/src/pack.ts
@@ -1,0 +1,46 @@
+// TREBUCHET, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous surface the `Host` in
+// `contract.ts` already describes — so the ballistics, the wind, the wave
+// governor and the dial are untouched.
+//
+// What crosses the boundary is a question and the value it is worth. A keep
+// stands at its own answer in metres, which means the answer has to be known
+// before the child fires rather than after — that is what `items.reveal` is
+// for, and it is why the game can put an error somewhere on the ground instead
+// of behind a buzzer. The game never judges: it reports the range it actually
+// struck, and the host decides what that was worth.
+//
+// The stub host in `stubHost.ts` stays exactly where it is. It is what
+// `npm run dev` mounts, it is what the ballistics tests drive, and it is not
+// what a tablet loads.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import { mount } from "./index.ts"
+import type { Host } from "./contract.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("trebuchet: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "add-sub" })
+  // Stocked before the first frame: a wave lays out its keeps from the answers
+  // it pulled, and a wave that opens with no ammunition is the kind of thing
+  // that happens exactly once, on launch, in front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context are torn down before the frame is, rather than a frame or two
+  // after it.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[trebuchet] could not start", error)
+  renderNoHost(root, "TREBUCHET")
+})

--- a/dynawalla/games/trebuchet/vite.pack.config.ts
+++ b/dynawalla/games/trebuchet/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produced a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})


### PR DESCRIPTION
## What

Make **TREBUCHET** an installable pack (`dynawalla/games/trebuchet`).

## Why

`dynawalla/packs/build.mjs` discovers a pack by globbing for a directory under
`games/` with a `pack.json` in it — "discovery is a glob, not a list".
TREBUCHET had none, so it was in `main` and invisible to the pack build, the
catalog and the app's game browser. It shipped to nobody.

It is the last of the eleven games rescued in #561–#571 to be packaged.

## Blast radius

**Areas touched:** dynawalla, one game directory. Additive only — 5 files.

- [x] Scope verified: 0 files outside `dynawalla/games/trebuchet/`, 0 deletions.
- [x] Covered by the `dynawalla-packs · games + pack build` job.
- [x] **Capabilities: `items`, `items.reveal`, `haptics`.**
      `items.reveal` is **mandatory**: the shared host resolves an item's
      canonical value through it (`packs/shared/game-host/index.ts:149-167`),
      and without the grant `canonical` is `""`, every item is dropped and the
      pool never fills — the pack mounts, warms and serves nothing, with no
      crash and no failing gate. TREBUCHET needs it on its own terms too: a keep
      stands on the field at its own answer in metres, so the value has to be
      known before the child fires, which is what lets a wrong shot land
      somewhere visible instead of behind a buzzer.
      `audio` is deliberately **not** declared — that capability is
      `feedback.sound` ("Play the app's sounds") and the game synthesises its
      own through `AudioContext`, as every shipped pack does.
- [x] **Curriculum.** No skill id renamed, reused or added. Four `dw.add.*` ids
      (column add/subtract no-regroup, multidigit add/subtract), grades 1–3,
      each verified by hand against
      `packs/shared/curriculum/src/graph/domains/add.ts` — **`dw-pack check`
      does not validate skill ids**, so a fictional one would pass silently.
      These are the one domain that is actually `status: "active"` today, so
      unlike its siblings this pack's declared coverage is servable now.
- [x] **Pack back-compat.** New id `dynawalla.trebuchet` at `0.1.0`; nothing
      published changed in place, no catalog entry dropped.
- [x] **Native integrity.** No Rust, no `src-tauri` source, no `links =`.
- [x] **Strings.** Name/description in `pack.json`; `locales: ["en"]` honest.
- [x] **No build artifacts.** `dist-pack/`, `qa/shots` (~24 MB of playtest PNGs)
      and `src-tauri/packs/` are all gitignored; confirmed absent from the diff.
- [x] **Secrets.** `gitleaks detect --log-opts="origin/main..HEAD"` → no leaks.

## Proof

The real builder — builds, validates via `dw-pack check`, stages:

```
$ node dynawalla/packs/build.mjs trebuchet
  capabilities items, items.reveal, haptics   covers       4 skills, grades 1–3 1 pack(s) built, checked and staged into src-tauri/packs/ 
```

The built entry carries its script, which is the failure the vite config warns
about (a `pack.html` that loads, paints the body colour and runs no code):

```
<script type="module" crossorigin src="./assets/pack-Be4edODx.js"
```

Tests run **five times**, because one green run is not proof — a sibling game
passed once then failed 3 of the next 5 from unseeded `Math.random`:

```
trebuchet  failed_runs=0/5   tscErr=0
```

```
$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
no leaks found

$ git diff --name-only origin/main...HEAD | grep -cv '^dynawalla/games/trebuchet/'
0
$ git diff --diff-filter=D --name-only origin/main...HEAD | wc -l
0
```
