### PR TITLE
fix(dynawalla/games/pulse): never hand a child a single unmissable target

### DIFF
--- a/dynawalla/games/pulse/src/game/gate.test.ts
+++ b/dynawalla/games/pulse/src/game/gate.test.ts
@@ -88,6 +88,80 @@ test("the correct answer survives even when every distractor is unusable", () =>
     difficulty: 0.9,
   };
   const g = buildGate(q, rng());
-  assert.equal(g.candidates.length, 1);
-  assert.ok(g.candidates[0]!.correct);
+  assert.ok(
+    g.candidates.some((c) => c.correct && c.label === "3/4"),
+    "the answer must survive — that is what this test is named for",
+  );
+  // It used to assert `candidates.length === 1`, which described what the code
+  // did rather than what a child should be handed: a lone target drawn as a
+  // full pie, unmissable. None of these three can sit on the bar, so the gate
+  // now gives up the number line rather than the question.
+  assert.ok(g.candidates.length >= 2, `only ${g.candidates.length} candidate(s)`);
+  assert.equal(g.positional, false);
+  // `3/4` was a distractor AND the answer. It must not appear twice, once
+  // scoring right and once wrong.
+  assert.equal(g.candidates.filter((c) => c.label === "3/4").length, 1, "answer duplicated");
+  assert.equal(g.candidates.filter((c) => c.correct).length, 1, "exactly one correct");
+});
+
+test("a gate is never a single unmissable target", () => {
+  // The bug this guards: the positional path admits a distractor only if it
+  // lands in (0,1]. When the host serves column arithmetic — which it does
+  // today, the ladder being `add`-only — the answer can be in the bar while
+  // every distractor is outside it, and the child was handed one candidate
+  // drawn as a full pie. Not a question; a formality.
+  const q: Question = {
+    id: "q-degenerate",
+    prompt: "43 − 42",
+    answer: "1",
+    distractors: ["2", "11", "0"],
+    domain: "add-sub",
+    difficulty: 0.2,
+  };
+  const g = buildGate(q, rng());
+  assert.ok(g.candidates.length >= 2, `only ${g.candidates.length} candidate(s)`);
+  assert.equal(g.positional, false, "should fall back to the flat presentation");
+  assert.equal(g.candidates.filter((c) => c.correct).length, 1, "exactly one correct");
+});
+
+test("column arithmetic never yields fewer than two candidates", () => {
+  // The real host, not this game's stub. PULSE's own stub serves fractions, so
+  // sweeping it would pass this vacuously — it can barely produce the
+  // degenerate shape. The live curriculum ladder is `add`-only, so what PULSE
+  // is actually handed is whole-number column arithmetic, where the answer
+  // often lands in (0,1] only when it is exactly 1 and the distractors never
+  // do. That is the case worth sweeping.
+  const r = rng();
+  let degenerateShapes = 0;
+  for (let a = 0; a <= 60; a++) {
+    for (let b = 0; b <= 60; b++) {
+      const ansV = a - b;
+      const q: Question = {
+        id: `col-${a}-${b}`,
+        prompt: `${a} − ${b}`,
+        answer: String(ansV),
+        distractors: [String(ansV + 1), String(ansV - 1), String(a + b)],
+        domain: "add-sub",
+        difficulty: 0.2,
+      };
+      const g = buildGate(q, r);
+      assert.ok(g.candidates.length >= 2, `${q.prompt} gave ${g.candidates.length} candidate(s)`);
+      assert.equal(g.candidates.filter((c) => c.correct).length, 1, `${q.prompt} correct-count`);
+      const labels = g.candidates.map((c) => c.label);
+      assert.equal(new Set(labels).size, labels.length, `${q.prompt} duplicated a label`);
+      if (ansV === 1) degenerateShapes++;
+    }
+  }
+  // Proves the sweep actually visited the shape it exists to catch.
+  assert.ok(degenerateShapes > 0, "swept nothing that could degenerate");
+});
+
+test("the fraction stub host also always gives a real choice", () => {
+  const h = createStubHost({ seed: "gate-degenerate-sweep" });
+  const r = rng();
+  for (let i = 0; i < 3000; i++) {
+    const g = buildGate(h.next(), r);
+    assert.ok(g.candidates.length >= 2, `${g.prompt} gave ${g.candidates.length} candidate(s)`);
+    assert.equal(g.candidates.filter((c) => c.correct).length, 1, `${g.prompt} correct-count`);
+  }
 });

--- a/dynawalla/games/pulse/src/game/gate.ts
+++ b/dynawalla/games/pulse/src/game/gate.ts
@@ -64,9 +64,26 @@ export function buildGate(q: Question, rng: Rng, fit: GateFit = DEFAULT_FIT): Bu
   // that hands over one unusable distractor loses that distractor, not the mechanic.
   const positional = ans !== null && inBar(ans);
 
-  if (!positional || ans === null) {
-    // Non-fractional host: keep the game playable, lose the number line.
-    const all = [{ s: q.answer, correct: true }, ...q.distractors.map((s) => ({ s, correct: false }))];
+  /**
+   * Keep the game playable, lose the number line.
+   *
+   * Distractors equal to the answer are dropped first. A host that sends one
+   * (and they do — `3/4` against an answer of `3/4`, or `6/8` against it) would
+   * otherwise put the same label on the bar twice, once scoring as right and
+   * once as wrong. Equality is by VALUE where both parse, so `6/8` is caught
+   * against `3/4`, and by label otherwise.
+   */
+  const flat = (): BuiltGate => {
+    const seen: Rat[] = ans === null ? [] : [ans];
+    const usable = q.distractors.filter((s) => {
+      if (s === q.answer) return false;
+      const r = parseRat(s);
+      if (r === null) return true;
+      if (seen.some((k) => eq(k, r))) return false;
+      seen.push(r);
+      return true;
+    });
+    const all = [{ s: q.answer, correct: true }, ...usable.map((s) => ({ s, correct: false }))];
     rng.shuffle(all);
     const used = all.slice(0, maxCandidates);
     if (!used.some((u) => u.correct)) {
@@ -84,7 +101,9 @@ export function buildGate(q: Question, rng: Rng, fit: GateFit = DEFAULT_FIT): Bu
         frac: null,
       })),
     };
-  }
+  };
+
+  if (!positional || ans === null) return flat();
 
   const kept: Rat[] = [ans];
   const out: GateCandidate[] = [
@@ -104,6 +123,18 @@ export function buildGate(q: Question, rng: Rng, fit: GateFit = DEFAULT_FIT): Bu
       frac: { n: Number(r.n), d: Number(r.d) },
     });
   }
+  // Losing ONE unusable distractor costs a distractor; losing them ALL costs the
+  // game. If nothing but the answer survived the bar, the child is handed a
+  // single target they cannot miss — not a question, a formality. Fall back to
+  // the flat presentation, which uses every choice the host sent regardless of
+  // whether it lands in (0,1].
+  //
+  // This is reachable in ordinary play, not a theoretical edge: the curriculum
+  // ladder is `add`-only today, so PULSE is served column arithmetic, and on
+  // `43 − 42` the answer is 1 (in the bar) while every distractor — 2, 11, 0 —
+  // is outside it.
+  if (out.length < 2) return flat();
+
   out.sort((a, b) => a.pos - b.pos);
   return { questionId: q.id, prompt: q.prompt, candidates: out, positional: true };
 }


### PR DESCRIPTION
## What

Stop PULSE building a gate with a single candidate, and fix a latent duplicate
-label bug in the fallback it now depends on.

## Why

PULSE's whole idea is that a note's position **is** its fraction of the bar, so
the positional path admits a candidate only if its value lands in `(0,1]`. When
every distractor falls outside, `out` kept only the answer — and the child was
shown **one target, drawn as a full pie**. It cannot be missed. It is not a
question; it is a formality, scored as though it were work.

**This is reachable in ordinary play.** The curriculum ladder is `add`-only
today — 7 active rows, with `frac`, `alg`, `div`, `mul` and `ns` all
`status: "draft"` — and `covers` is documented as "a request, not an
instruction". So PULSE, a fraction game, is served whole-number column
arithmetic. On `43 − 42` the answer is `1`, which is in the bar, while the
distractors `2`, `11` and `0` are not. One candidate.

Losing one unusable distractor costs a distractor; losing them all costs the
game. The fix falls back to the flat presentation that already exists for
non-fractional hosts: the number line is what gets given up, not the question.

### The second bug, found while making the first fix safe

That fallback never removed a distractor equal to the answer. A host sending
`3/4` as a distractor against an answer of `3/4` — which the existing test
fixture does — would put the same label on the bar twice, **once scoring right
and once wrong**. Now deduped by *value* where both parse (so `6/8` is caught
against `3/4`) and by label otherwise. This was latent before and would have
become reachable the moment the fallback started being used.

### A test that encoded the bug

`the correct answer survives even when every distractor is unusable` asserted
`candidates.length === 1`. That described what the code did, not what a child
should be handed. Its **title** states its intent, and that intent is preserved
and strengthened: the answer still survives, is no longer duplicated, and now
has something to be chosen against.

## Blast radius

**Areas touched:** dynawalla, one game — `dynawalla/games/pulse/`.

- [x] Scope: 0 files outside `dynawalla/games/pulse/`, 0 deletions.
- [x] Covered by the `dynawalla-packs · games + pack build` job.
- [x] **Behaviour change is narrow and in one direction.** The positional path is
      untouched whenever ≥2 candidates survive, which is every fraction question
      the game was designed for. The change only fires where the old result was
      a one-candidate gate.
- [x] **Curriculum.** No skill id, grade, binding or generator touched. Exact
      rational arithmetic throughout — dedupe compares `Rat` values, never
      floats.
- [x] **Pack back-compat.** No manifest, capability or version change.
- [x] **Native integrity.** No Rust, no `src-tauri`, no `links =`.
- [x] **Strings.** None added.
- [x] **Secrets.** `gitleaks` → no leaks found.

## Proof

**The tests fail without the fix.** With the one-line guard commented out:

```
$ npm test
not ok 19 - the correct answer survives even when every distractor is unusable
not ok 20 - a gate is never a single unmissable target
not ok 21 - column arithmetic never yields fewer than two candidates
```

Restored, three consecutive runs (one green run is not proof — a sibling game
passed once then failed 3 of the next 5 from unseeded `Math.random`):

```
# pass 57 # fail 0   <- 1
# pass 57 # fail 0   <- 2
# pass 57 # fail 0   <- 3

$ npm run tsc
0 errors
```

The sweep proves it is **not vacuous**. PULSE's own stub host serves fractions
and can barely produce the degenerate shape, so sweeping it would pass for the
wrong reason. The new sweep drives 61×61 column-arithmetic questions — what the
real host actually sends — asserts ≥2 candidates, exactly one correct and no
duplicated label on each, and then asserts it *visited* the shape it exists to
catch:

```ts
assert.ok(degenerateShapes > 0, "swept nothing that could degenerate");
```

The pack still builds, checks and stages:

```
$ node dynawalla/packs/build.mjs pulse
1 pack(s) built, checked and staged into src-tauri/packs/
```
