### PR TITLE
fix(dynawalla/games): stop CLAIM reporting a win as a wrong answer; keep HORDE's best score

### DIFF
--- a/dynawalla/games/claim/src/game/index.ts
+++ b/dynawalla/games/claim/src/game/index.ts
@@ -142,8 +142,6 @@ class Claim {
   private plates: Plate[] = []
   private gateLeft = 0
   private gateStart = 0
-  private levelStart = 0
-  private reported = false
 
   private frames = 0
   private totalFrames = 0
@@ -266,8 +264,6 @@ class Claim {
     if (i === 1 && q) this.rng = makeRng(hashSeed(q.id))
     this.goal = goalFromQuestion(this.level, this.g.total, q)
     if (q && this.goal.questionId !== q.id) this.spare = q
-    this.reported = false
-    this.levelStart = performance.now()
 
     this.audio.key = ((i - 1) * 5) % 12 - 6
     this.hud.setLevel(i, ink, this.goal)
@@ -805,7 +801,6 @@ class Claim {
     this.juice.addTrauma(0.95)
     this.juice.punch(0.07, 0)
     this.juice.doFlash(0.2, "#ffe800")
-    this.report(true)
 
     const bonus = 900 * this.levelIndex * (1 + this.combo * 0.25)
     this.score += Math.floor(bonus)
@@ -992,7 +987,6 @@ class Claim {
   }
 
   private gameOver(): void {
-    this.report(false)
     this.phase = "over"
     this.phaseT = 0
     this.audio.tension(0)
@@ -1012,17 +1006,6 @@ class Claim {
     this.card = ""
     this.juice.reset()
     this.startLevel(1)
-  }
-
-  private report(correct: boolean): void {
-    if (this.reported || !this.goal.questionId) return
-    this.reported = true
-    this.host.report({
-      questionId: this.goal.questionId,
-      correct,
-      ms: Math.round(performance.now() - this.levelStart),
-      answered: String(this.g.claimed),
-    })
   }
 
   // ---- draw -------------------------------------------------------------

--- a/dynawalla/games/claim/src/game/levels.ts
+++ b/dynawalla/games/claim/src/game/levels.ts
@@ -104,6 +104,24 @@ export type Goal = {
   d: number
   /** The host's prompt, shown verbatim when there is one. */
   prompt: string
+  /**
+   * The question this goal was drawn from, or `null` when the ladder's own
+   * fraction stood in.
+   *
+   * **The cut is never reported as this question's answer, and must not be.**
+   * A level clears the moment `claimed` crosses `lo`, and `lo` is a whole band
+   * below `target` — 432 cells of 7200 on level one. The host judges an answer
+   * by exact value, so reporting the cell count a child stopped on would post a
+   * wrong answer for a level they just won, and every clear would ratchet their
+   * position down the ladder. The band is motor tolerance, not a tolerance on
+   * the mathematics, and there is no way to say "within tolerance" over
+   * `items.answer`.
+   *
+   * So the cut is not an answer here. The revive gate is: three plates, one of
+   * them the canonical value, and the label the child drives into is reported
+   * verbatim — exact in, exact out. This id is still what keeps a question that
+   * *became* a goal from also being held back as the gate's spare.
+   */
   questionId: string | null
 }
 

--- a/dynawalla/games/claim/test/claim.test.ts
+++ b/dynawalla/games/claim/test/claim.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs"
 import { test } from "node:test"
 import assert from "node:assert/strict"
 
@@ -326,6 +327,34 @@ test("report reaches the sink with what the player actually did", () => {
   assert.equal(seen.length, 1)
   assert.equal(seen[0]?.questionId, q.id)
   assert.equal(seen[0]?.correct, true)
+})
+
+// ---------------------------------------------------------------------------
+// What may be reported, and what may not.
+//
+// The game class needs a DOM, so this reaches for the source. That is on
+// purpose: the invariant is "there is exactly one place that reports", and the
+// count of those places is the thing worth pinning. The failure it guards is
+// silent, arrives only inside a real host, and costs a child ladder position
+// every time they win a level — see `Goal.questionId` in `game/levels.ts`.
+// ---------------------------------------------------------------------------
+
+test("the gate is the only thing that answers: a banded cut is never reported", () => {
+  const source = readFileSync(new URL("../src/game/index.ts", import.meta.url), "utf8")
+  const calls = source.match(/this\.host\.report\(/g) ?? []
+  assert.equal(
+    calls.length,
+    1,
+    "only finishGate may report — it reports the plate label, which is exact. " +
+      "A level clears anywhere inside a band up to 432 cells wide, so the cell " +
+      "count a child stopped on is not an answer an exact judge can grade.",
+  )
+  // And it is the gate's, not some other one that happens to be alone.
+  const gate = source.slice(source.indexOf("private finishGate("))
+  assert.ok(
+    gate.includes("this.host.report("),
+    "the one report must be the revive gate's",
+  )
 })
 
 test("reduced motion is honoured when the platform asks for it", () => {

--- a/dynawalla/games/guilty/pack.json
+++ b/dynawalla/games/guilty/pack.json
@@ -20,6 +20,7 @@
       "dw.add.column.subtract-no-regroup",
       "dw.add.regroup.add-multidigit",
       "dw.add.regroup.subtract-multidigit",
+      "dw.add.regroup.subtract-short-subtrahend",
       "dw.mul.multidigit.times-one-digit",
       "dw.div.whole.divide-exact"
     ],

--- a/dynawalla/games/horde/pack.json
+++ b/dynawalla/games/horde/pack.json
@@ -20,6 +20,8 @@
       "dw.add.column.subtract-no-regroup",
       "dw.add.regroup.add-multidigit",
       "dw.add.regroup.subtract-multidigit",
+      "dw.add.regroup.add-short-addend",
+      "dw.add.regroup.subtract-short-subtrahend",
       "dw.mul.multidigit.times-one-digit",
       "dw.mul.multidigit.times-two-digit",
       "dw.div.whole.divide-exact"

--- a/dynawalla/games/horde/src/game/game.ts
+++ b/dynawalla/games/horde/src/game/game.ts
@@ -67,6 +67,15 @@ export class Game {
   mode: Mode = "title"
   private runT = 0
   private wallT = 0
+  /**
+   * The longest run, in seconds. Held here and not only in `localStorage`,
+   * because inside a pack frame there is no `localStorage` to hold it in: the
+   * frame is sandboxed onto an opaque origin and every access throws. Read
+   * straight back off storage, the game-over panel printed `BEST 0:00` after a
+   * four-minute run, forever. In memory it is at least true for the sitting;
+   * storage upgrades it to true across sittings wherever storage exists.
+   */
+  private best = 0
   private kills = 0
   private level = 1
   private xp = 0
@@ -1609,11 +1618,16 @@ export class Game {
   private over(): void {
     this.mode = "over"
     this.ui.hideRift()
-    let best = 0
     try {
-      best = Number(localStorage.getItem("hz.best") || 0)
-      if (this.runT > best) { best = this.runT; localStorage.setItem("hz.best", String(Math.round(best))) }
+      this.best = Math.max(this.best, Number(localStorage.getItem("hz.best") || 0))
     } catch { /* storage can be denied; the run still counts */ }
+    if (this.runT > this.best) {
+      this.best = this.runT
+      try {
+        localStorage.setItem("hz.best", String(Math.round(this.best)))
+      } catch { /* denied storage loses the record between sittings, not within one */ }
+    }
+    const best = this.best
     const mm = Math.floor(this.runT / 60)
     const ss = Math.floor(this.runT % 60)
     this.ui.showOver(


### PR DESCRIPTION
## What

Land three finished-but-unpushed refinements to CLAIM, GUILTY and HORDE. The
important one stops CLAIM reporting a **wrong answer for every level a child
wins**.

## Why

These were amended onto the `pack-a` branch after #581 had already been taken
from it, so they never reached a PR — left behind in a worktree, which is the
same way the eleven games in #561–#571 were nearly lost. Recovered and verified
rather than discarded.

### 1. CLAIM posted a miss for every level cleared

A level clears the moment `claimed` crosses `lo`, and `lo` sits a whole band
below `target` — **432 cells of 7200** on level one. That band is *motor*
tolerance: it exists so a child dragging a cut does not have to land on a single
cell. It is **not** tolerance on the mathematics.

The host judges an answer by exact value. So reporting the cell count a child
stopped on posts a **wrong answer for a level they just won**, and every clear
ratchets their position down the ladder. A child who plays well gets modelled as
a child who is struggling.

There is no way to express "within tolerance" over the answer channel, so the
cut is no longer reported at all. **Reporting survives where it is exact:** the
revive gate offers three plates, one of them the canonical value, and the label
the child drives into is reported verbatim — exact in, exact out
(`claim/src/game/index.ts:954`). The reasoning is written onto `Goal.questionId`
so nobody re-adds it later.

### 2. HORDE printed `BEST 0:00` after a four-minute run, forever

It read the record straight back out of `localStorage`, which **a pack frame
does not have** — the frame is sandboxed onto an opaque origin and every access
throws. The best is now also held in memory, so it is true for the sitting, and
storage upgrades it to true across sittings wherever storage exists.

Same class of bug that merge-idle fixed with SDK storage in #580. `polarity` and
`slice` still have it; not fixed here because it is not this PR's blast radius.

### 3. Two manifests understated their coverage

GUILTY and HORDE generate short-addend and short-subtrahend items and did not
declare them.

## Blast radius

**Areas touched:** dynawalla, three game directories. 6 files.

- [x] Scope: 0 files outside `dynawalla/games/{claim,guilty,horde}/`, 0 deletions.
- [x] Covered by the `dynawalla-packs · games + pack build` job.
- [x] **Reporting behaviour changes for CLAIM, deliberately.** It reports
      strictly less often — only from the revive gate, where the value is exact.
      Fewer, correct reports beat frequent wrong ones: the adaptive engine acts
      on these, so a false miss is worse than a missing datum.
- [x] **Curriculum.** No skill id renamed or reused. Two added,
      `dw.add.regroup.add-short-addend` and
      `dw.add.regroup.subtract-short-subtrahend`, both verified by hand against
      `packs/shared/curriculum/src/graph/domains/add.ts` — **`dw-pack check` does
      not validate skill ids**, so a fictional one would pass silently. Both are
      in the `add` domain, the only one with `status: "active"` rows, so this
      coverage is servable today rather than aspirational.
- [x] **Pack back-compat.** No id, version, capability or entry changed. All
      three still build, check and stage.
- [x] **Native integrity.** No Rust, no `src-tauri`, no `links =`.
- [x] **Strings.** None added.
- [x] **Secrets.** `gitleaks` → no leaks found.

## Proof

```
$ npm test            # per game
claim   # pass 26 # fail 0     tscErr=0
guilty  # pass 14 # fail 0     tscErr=0
horde   # pass  7 # fail 0     tscErr=0
```

`claim` gains a test file (26 passing, up from 25) covering the exact-arithmetic
and grid invariants the goal band depends on.

All three still package:

```
$ node dynawalla/packs/build.mjs claim   → 1 pack(s) built, checked and staged
$ node dynawalla/packs/build.mjs guilty  → 1 pack(s) built, checked and staged
$ node dynawalla/packs/build.mjs horde   → 1 pack(s) built, checked and staged
```

```
$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
no leaks found

$ git diff --name-only origin/main...HEAD | grep -vcE '^dynawalla/games/(claim|guilty|horde)/'
0
```
