### PR TITLE
docs(trunk-pr): catalogue the failure modes, and verify what the harness can enforce

### DIFF
--- a/.claude/skills/trunk-pr/FAILURE-MODES.md
+++ b/.claude/skills/trunk-pr/FAILURE-MODES.md
@@ -1,0 +1,345 @@
+# Failure modes of the worktree → PR → trunk loop
+
+Companion to [`SKILL.md`](SKILL.md). Every entry here **actually happened in
+this repo**, most of them in a single day. They share one property, which is why
+they are worth a document:
+
+> **They all look like success.** No crash, no red check, no conflict. The work
+> looks done, the gate looks green, `main` looks fine.
+
+Each entry gives the symptom, why it is invisible, and a **guard** — a command
+you can run, or a rule you can follow, that turns it back into a visible
+failure.
+
+The invariant the whole loop exists to protect:
+
+> **Local `main` changes by fast-forward from `origin/main` and by nothing else.**
+> The primary checkout sits on a clean `main` at all times. Every change reaches
+> it as worktree → remote branch → PR → squash-merge → pull.
+
+---
+
+## A. Work that never reaches git
+
+### A1. Untracked work is invisible to every ref-based search
+
+**What happened.** Eleven finished games — ~60k lines — existed only as
+untracked files inside worktrees. `git log --all -- dynawalla/games/<name>`
+returned **zero commits** for every one. They were never committed, never
+branched, never stashed.
+
+**How much danger, exactly** — verified rather than assumed, because the honest
+version is narrower than the scary one:
+
+| Action | Result |
+| --- | --- |
+| `git worktree remove <path>` | **Refuses.** `fatal: '<path>' contains modified or untracked files, use --force to delete it` |
+| `git worktree remove --force <path>` | **Destroys it.** No reflog, no dangling object |
+| Claude Code's periodic worktree sweep | **Skips it.** The sweep "skips a worktree that still holds work: changed or untracked files, or unpushed commits", and never touches worktrees you made with `--worktree` |
+
+So git and the sweep both defend you, and the loss vector is narrower than
+"pruning deletes your work". What remains is still real: `--force` is precisely
+what someone reaches for *when the plain remove fails*, and the work has no
+backup anywhere — not in a ref, not in a stash, not in the object store. Any
+`git clean -fdx`, disk loss, or impatient `--force` ends it, and nothing warns
+you first because as far as git is concerned there is nothing there.
+
+**Why invisible.** `git log --all`, `git branch -a`, `git stash list` and
+`git fsck --lost-found` all search *objects*. Untracked files are not objects.
+Every one of those commands answers "nothing here" and is correct.
+
+**Guard.** When taking inventory, sweep the filesystem, not the object store:
+
+```bash
+git worktree list --porcelain | grep '^worktree' | cut -d' ' -f2 | while read -r d; do
+  n=$(git -C "$d" status --porcelain | wc -l)
+  [ "$n" -gt 0 ] && printf '%-60s %s dirty/untracked\n' "$d" "$n"
+done
+```
+
+**Never** `git worktree remove` a worktree whose `git status --porcelain` is
+non-empty without reading what is in it first.
+
+### A2. A stalled agent leaves finished work uncommitted, or committed and unpushed
+
+**What happened.** Three of six background subagents hit the no-progress
+watchdog. Two had committed but not pushed. One had *amended* its commit after
+the orchestrator had already taken the branch, so its final work — which
+included the most consequential bug fix of the session — sat diverged and
+invisible while its PR merged without it.
+
+**Why invisible.** The agent's last words were "All green. Amending the commit."
+That reads as success. The PR was green and merged. Nothing anywhere said a
+newer commit existed.
+
+**Guard.** When an agent dies, **inspect its worktree before believing its PR**:
+
+```bash
+git -C "$WT" status --porcelain                       # uncommitted?
+git -C "$WT" rev-list --count @{u}..HEAD               # committed, unpushed?
+git -C "$WT" rev-list --count HEAD..@{u}               # diverged from what you pushed?
+git -C "$WT" diff origin/main HEAD -- <its paths>      # what does it have that main lacks?
+```
+
+If local and upstream have diverged, diff the **trees**, not the commits — the
+commit ids differ after any rebase or amend, which proves nothing either way.
+
+### A3. Uncommitted work looks identical whether it is newer or stale
+
+**What happened.** Arena and runner each carried ~1,000 and ~400 lines of
+uncommitted changes on a branch whose upstream had moved. Impossible to tell by
+inspection whether it was newer work worth keeping or a superseded leftover.
+
+**Guard.** Two cheap questions settle it:
+
+```bash
+git -C "$WT" log -1 --format=%ci HEAD; git -C "$WT" log -1 --format=%ci @{u}
+git -C "$WT" diff --name-only -- <paths> | while read -r f; do
+  stat -f '%Sm %N' -t '%Y-%m-%d %H:%M' "$WT/$f"; done | sort -r | head
+```
+
+File mtimes later than both commit dates ⇒ the working tree is the newest state.
+Then confirm nothing upstream is lost:
+
+```bash
+git -C "$WT" diff HEAD @{u} -- <paths>   # empty ⇒ same tree ⇒ WIP is a strict superset
+```
+
+---
+
+## B. Git operations that silently do the wrong thing
+
+### B1. `git reset --soft origin/main` reverts everything that landed in between
+
+**What happened.** `origin/main` advanced mid-session. A `reset --soft
+origin/main` re-parented the commit onto the **new** tip while keeping the
+**old** tree. The result reverted a whole merged PR across 35 files. No
+conflict. No warning. It force-pushed cleanly.
+
+**Guard.** Re-base with `git rebase origin/main`. **Never `reset --soft`.**
+Then always:
+
+```bash
+git -C "$WT" diff --name-only origin/main...HEAD | grep -v '^<your path>/'   # must be empty
+git -C "$WT" diff --diff-filter=D --name-only origin/main...HEAD             # must be empty
+```
+
+A deletion you did not intend is the signature of this bug.
+
+### B2. `cd <repo> && git …` operates on the primary checkout
+
+**Why.** The shell's working directory **resets between tool calls**. A `cd` in
+an earlier call does not persist, so a later bare `git` runs wherever the tool
+starts — the primary checkout. This has put commits on the primary checkout, off
+any branch anyone was tracking.
+
+**Guard.** `git -C "$WT" …` on **every single** invocation. No exceptions.
+Same for `gh`: pass `--repo`.
+
+### B3. Renaming a branch does not move its worktree directory
+
+`git branch -m old new` leaves the directory at `$WT_ROOT/old`. Subsequent
+`git -C "$WT_ROOT/new"` fails with "No such file or directory" — or worse,
+silently targets a path you did not mean. Track the **path** and the **branch**
+as separate variables.
+
+### B4. Unrelated deletions in a worktree abort a rebase
+
+Worktrees accumulate stray deletions of tracked build output
+(`corpan/packs/*/dist/*`). `git rebase` then aborts with "cannot rebase: You have
+unstaged changes" — nothing to do with your work.
+
+**Guard.** `git -C "$WT" checkout -- .` first. Stage only your own path:
+`git -C "$WT" add <your dir>`. **Never `git add -A`** — it sweeps those
+deletions into your commit.
+
+### B5. Discovery by position breaks when the base moves
+
+`g=$(ls dir | head -1)` picked `forge` instead of the target game, because
+rebasing onto a newer `main` had restored other games into the directory. Five
+commits silently became no-ops.
+
+**Guard.** Name things explicitly. After any `git add`, assert something was
+staged:
+
+```bash
+n=$(git -C "$WT" diff --cached --numstat -- "$path" | wc -l)
+[ "$n" -eq 0 ] && { echo "NOTHING STAGED — abort"; exit 1; }
+```
+
+### B6. `gitleaks` scans every commit in the range
+
+A fix in a *later* commit does not clear a secret introduced in an earlier one —
+the range still contains it. Also: the `generic-api-key` rule fires on
+`const SOMETHING_KEY = "dotted.string.v1"`, i.e. ordinary `localStorage` names,
+because it matches on entropy and length, not meaning.
+
+**Guard.** Amend or squash so the string never appears in the range. For the
+false positive, rename to `*_SLOT` and add `// gitleaks:allow` with a comment
+saying why — the pattern is in `dynawalla/games/forge/src/game/save.ts`.
+
+### B7. zsh does not word-split unquoted variables
+
+`set -- $pair` inside a loop silently produced one argument instead of two, and
+every `git -C` in that loop targeted a nonexistent path. The tool's shell is
+zsh; do not carry bash word-splitting habits into it.
+
+---
+
+## C. Gates that pass while being wrong
+
+This is the most dangerous class: **a green check over unreviewed or untested
+code.**
+
+### C1. One green test run is not proof
+
+`serpent` passed once, then failed **3 of the next 5 runs**, in three different
+tests. Its world uses raw `Math.random` for ambience by design, and the test bot
+drew from the same stream.
+
+**Guard.** Run a new or newly-touched suite **5 times** before calling it green.
+If it flakes, seed the randomness **inside the test file** — do not change the
+game's randomness to suit a test.
+
+### C2. A test can encode the bug as the intended behaviour
+
+PULSE had a passing test asserting `candidates.length === 1` for the exact shape
+where the child is handed a single unmissable target. It described what the code
+did, not what a child should get.
+
+**Guard.** When a test blocks a fix, read its **title** for the intent, not its
+assertion for the contract. Preserve the intent, correct the assertion, and say
+so in the commit.
+
+### C3. A test can pass vacuously
+
+Three instances in one day:
+
+- `polarity` swept 4,000 questions but never escalated difficulty, so 3 of 6
+  generator families were **never generated** and their assertions never ran.
+- A `horde` regex used a lookbehind that exempted `(-4)` — precisely the shape
+  the generator emits — so the one regression it existed to catch was the one it
+  could not see.
+- A sweep over the *wrong host*: PULSE's own stub serves fractions, so sweeping
+  it could not produce the degenerate case the test was written for.
+
+**Guard.** Make the test **prove it visited the case**:
+
+```ts
+assert.ok(degenerateShapes > 0, "swept nothing that could degenerate");
+```
+
+And prove the test earns its keep by **breaking the fix and watching it fail**.
+A regression test never observed failing is a decoration.
+
+### C4. A gate can validate the schema and not the meaning
+
+`dw-pack check` validates a pack manifest and **does not** check that
+`covers.skills` names real curriculum skills. A fictional id passes silently.
+Related: a pack that omits the `items.reveal` capability serves **zero
+questions** — it mounts, warms, and is simply empty. No crash, no failing gate.
+
+**Guard.** Know what each gate actually asserts. When a gate cannot check
+something, check it by hand and **write in the PR that you did**.
+
+### C5. A NUL byte makes a file binary, and binary is excluded from review
+
+`glyphs.test.ts` contained a literal NUL. Git classified it as binary, so its
+content was excluded from every diff **and from the adversarial-review gate**.
+
+**Guard.** `git diff --numstat` shows `-` `-` for binary files. A source file
+with `-` in those columns is a bug.
+
+### C6. `cancelled` counts as failure, and looks like a real one
+
+`ci-gate` fails on `cancelled` as well as `failure`. A superseded run — from
+your own force-push — leaves a red `ci-gate` whose cause is a `dynawalla-app`
+job marked `cancelled`, not anything about your code.
+
+**Guard.** Read *which* job failed before debugging. `gh run rerun <id>` for a
+cancellation.
+
+---
+
+## D. Orchestration
+
+### D1. Parallel agents collide in a shared scratchpad
+
+Agents wrote commit-message files to the same session scratchpad path. One
+`git commit --amend` picked up **a different PR's subject line**.
+
+**Guard.** Namespace every temp file with your branch:
+`/tmp/.../<branch>-commit-msg.txt`. After any commit or amend, verify what
+landed before pushing:
+
+```bash
+git -C "$WT" log -1 --format='%s'
+git -C "$WT" show --stat --oneline HEAD | head -20
+```
+
+### D2. Propagating an unvalidated recipe multiplies the mistake
+
+A packaging recipe was nearly handed to five agents at once. Validating it end
+to end on **one** unit first caught two traps that would otherwise have shipped
+five times over — including a capability that makes the artifact silently empty.
+
+**Guard.** Prove the procedure on one unit yourself. Hand out the **verified**
+recipe, including the traps you hit.
+
+### D3. A correction must reach agents already in flight
+
+When you discover the recipe was wrong, agents mid-task are still applying the
+old one. Message every one of them immediately, with the evidence, and say
+explicitly whether to amend or open a follow-up.
+
+### D4. Delegation does not transfer responsibility
+
+Every returned result here was verified independently — skill ids resolved
+against the graph, scope re-checked, tests re-run. Agents got things right that
+the orchestrator got wrong, **and** left work behind that looked finished. Trust
+the reasoning; verify the artifact.
+
+---
+
+## E. Stale guidance is a failure mode
+
+A rule survived in **seven files** after the thing it described was fixed:
+`adversarial-review` truncated diffs at 200,000 bytes and still reported green
+(PR #521: 850,261 bytes, 186 files, 67 reviewed, conclusion `success`). Real bug.
+The planned fix was "fail above the cap, make authors split". What actually
+shipped was **chunking with asserted full coverage** — so the hole closed and no
+one needs to split anything. The docs never caught up, and cost real work in
+PRs split for nothing.
+
+**Guard.** When a doc states a mechanism, check the mechanism — not the doc's
+age. Every doc here is a claim about code, and code is checkable. When you find
+a stale claim, delete it **and say what replaced it**, so the next reader knows
+it was reconsidered rather than forgotten.
+
+---
+
+## Preflight
+
+Before `git push`, from the worktree:
+
+```bash
+git -C "$WT" diff --name-only origin/main...HEAD | grep -v '^<your path>/'   # empty
+git -C "$WT" diff --diff-filter=D --name-only origin/main...HEAD            # empty
+git -C "$WT" log --oneline origin/main..HEAD                                # only yours
+cd "$WT" && gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
+# gates for what you touched, tests ×5 if they are new or newly touched
+```
+
+## Postflight
+
+After the merge:
+
+```bash
+git -C "$REPO" fetch origin
+git -C "$REPO" merge --ff-only origin/main     # refuses ⇒ investigate, never force
+git -C "$REPO" status --porcelain              # must be empty
+git -C "$REPO" worktree remove "$WT"           # only after checking it is clean (A1)
+```
+
+`--ff-only` is the invariant, expressed as a command. If it refuses, something
+wrote to the primary checkout, and that is the incident — not the refusal.

--- a/.claude/skills/trunk-pr/HARNESS.md
+++ b/.claude/skills/trunk-pr/HARNESS.md
@@ -1,0 +1,349 @@
+# Making the loop resilient — what the harness can enforce
+
+Companion to [`SKILL.md`](SKILL.md) and [`FAILURE-MODES.md`](FAILURE-MODES.md).
+This file is about **mechanism**: which of those failure modes Claude Code can
+catch for us, with syntax verified against the current docs rather than
+remembered.
+
+Everything below was checked against `code.claude.com/docs` on 2026-07-27.
+Where a thing does **not** exist, it says so — a plausible-looking config that
+silently does nothing is worse than no config.
+
+---
+
+## The invariant
+
+> **Local `main` changes by fast-forward from `origin/main` and by nothing
+> else.** The primary checkout stays clean. Every change reaches it as
+> worktree → remote branch → PR → squash-merge → pull.
+
+The rest of this file is about making that structurally true instead of
+merely agreed.
+
+---
+
+## Why permission rules alone cannot express it
+
+This was the obstacle, and it is worth stating precisely because it is what
+`.claude/README.md` ran into when it considered and rejected hard denies:
+
+- Bash rules are **glob patterns over the command string**. They support `*` at
+  any position and nothing else. No shell logic, no conditionals.
+  `Bash(git commit * && ! grep worktree)` is not a rule; it is a wish.
+- Rules are evaluated **deny → ask → allow, first match wins, and specificity
+  does not reorder them**. The docs are explicit: *"a deny rule can't carry
+  allowlist exceptions."*
+- A permission rule never sees **where** the command would run. "Deny `git
+  commit` in the primary checkout but allow it in a worktree" is not expressible,
+  because `cwd` is not part of the match.
+
+So `deny` is the wrong tool: `Bash(git commit *)` would block every commit in
+every worktree too, which is the whole job.
+
+## Why a PreToolUse hook is the right tool
+
+A hook **does** see `cwd`, and the docs give it precedence:
+
+> "A blocking hook also takes precedence over allow rules. A hook that exits
+> with code 2 stops the tool call before permission rules are evaluated […]
+> To run all Bash commands without prompts except for a few you want blocked,
+> add `"Bash"` to your allow list and register a PreToolUse hook that rejects
+> those specific commands."
+
+That is exactly our shape: allow the work, block the one location.
+
+### Verified hook facts
+
+| Fact | Detail |
+| --- | --- |
+| `matcher` matches the **tool name** | `"Bash"`, `"Edit\|Write"`, or a regex. **Not** the command string |
+| `if` is a real **hook-entry** field | Uses permission-rule syntax to narrow on arguments, e.g. `"Bash(git commit *)"`. It sits on the hook, not on the matcher group |
+| Blocking | `exit 2` with the reason on **stderr**; or `exit 0` printing `hookSpecificOutput` with `permissionDecision: "deny"` and `permissionDecisionReason` |
+| stdin | JSON with `session_id`, `cwd`, `tool_name`, `tool_input`, `tool_use_id`, `permission_mode`, `transcript_path` |
+| Subagent events | `SubagentStart` / `SubagentStop` are real, matched on **agent type**, and receive `agent_id` and `agent_type` |
+| Hook decisions don't bypass rules | A matching `deny` still blocks even if a hook returned `allow` |
+
+---
+
+## Recommendation 1 — make the primary checkout structurally read-only
+
+The single highest-value change, and the direct expression of the invariant.
+
+`.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/primary-checkout-guard.sh\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`.claude/hooks/primary-checkout-guard.sh` — blocks **git writes whose working
+directory is the primary checkout**, and nothing else:
+
+```bash
+#!/usr/bin/env bash
+# Blocks git WRITES in the primary checkout. Worktrees are untouched.
+# Exit 2 = block, with the reason on stderr. Exit 0 = allow.
+set -u
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+cwd=$(printf '%s' "$input" | jq -r '.cwd // ""')
+
+# Only git matters here.
+case "$cmd" in *git*) ;; *) exit 0 ;; esac
+
+# An explicit `git -C <path>` names its own target; judge that, not cwd.
+target="$cwd"
+if printf '%s' "$cmd" | grep -qE '(^|[[:space:]])git[[:space:]]+-C[[:space:]]'; then
+  t=$(printf '%s' "$cmd" | awk '{for(i=1;i<NF;i++) if($i=="-C"){print $(i+1); exit}}' | tr -d '"'"'"'')
+  [ -n "$t" ] && target="$t"
+fi
+[ -d "$target" ] || exit 0
+
+# Resolve EVERYTHING from inside the target. `rev-parse --git-common-dir` returns
+# a path relative to the repo it was asked about, so resolving it against the
+# hook's own cwd silently yields nothing and the guard fails OPEN. That bug was
+# in the first version of this script and only a `git -C <primary>` test caught
+# it — see FAILURE-MODES C3.
+here=$(cd "$target" 2>/dev/null && pwd -P) || exit 0
+common=$(cd "$target" 2>/dev/null && cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd -P) || exit 0
+[ -n "$here" ] && [ -n "$common" ] || exit 0
+primary=$(dirname "$common")
+case "$here" in "$primary"|"$primary"/*) ;; *) exit 0 ;; esac   # in a worktree: allow
+
+# In the primary checkout. Match the SUBCOMMAND, not a substring: `git -C <path>
+# commit` contains no literal "git commit", so substring patterns miss exactly
+# the cross-directory call that is most likely to be the mistake. Skip git's
+# global options to find the verb.
+verb=$(printf '%s' "$cmd" | awk '{
+  i=1; while (i<=NF && $i!="git") i++; i++
+  while (i<=NF) {
+    if ($i=="-C" || $i=="-c") { i+=2; continue }
+    if ($i ~ /^-/)            { i++;  continue }
+    print $i; exit
+  }
+}')
+
+case "$verb" in
+  # The fast-forward ritual, and anything read-only.
+  fetch|status|log|show|diff|rev-parse|ls-tree|ls-files|ls-remote|merge-base|\
+  cat-file|for-each-ref|check-ignore|blame|worktree|remote|describe|shortlog|\
+  rev-list|grep|config|help|version|"") exit 0 ;;
+  # Allowed only in its fast-forward form.
+  merge|pull)
+    case "$cmd" in *--ff-only*) exit 0 ;; esac ;;
+esac
+
+echo "BLOCKED: 'git $verb' would write in the PRIMARY CHECKOUT ($primary)." >&2
+echo "Local main changes ONLY by:  git -C '$primary' merge --ff-only origin/main" >&2
+echo "Work belongs in a worktree:  git -C '$primary' worktree add -b <branch> \$WT_ROOT/<branch> origin/main" >&2
+exit 2
+```
+
+**Verified, because a guard that fails open is worse than no guard.** The 16
+cases below all pass. Feed the hook a JSON line on stdin and check its exit code
+(`2` = blocked, `0` = allowed):
+
+| Command | cwd | Exit |
+| --- | --- | --- |
+| `git commit -m x` | primary | **2** |
+| `git commit -m x` | worktree | 0 |
+| `git merge --ff-only origin/main` | primary | 0 |
+| `git merge origin/feature` | primary | **2** |
+| `git -C <primary> commit -m x` | worktree | **2** |
+| `git -C <worktree> commit -m x` | primary | 0 |
+| `git -C <primary> push origin main` | `/tmp` | **2** |
+| `npm test` | primary | 0 |
+| `git worktree add …` | primary | 0 |
+| `git status` / `git fetch origin` | primary | 0 |
+| `git checkout -b foo` | primary | **2** |
+| `git clean -fdx` | primary | **2** |
+| `git reset --soft origin/main` | primary | **2** |
+| `git rebase origin/main` | worktree | 0 |
+| `git stash` | primary | **2** |
+
+Writing those tests found **two real bugs in this very script**, both of which
+failed *open* — silently allowing what they were written to block:
+
+1. `git -C <path> rev-parse --git-common-dir` returns a path **relative to the
+   target repo**. Resolving it against the hook's own cwd produced nothing, and
+   the guard exited 0. It only looked correct because the first tests happened
+   to run from the primary checkout.
+2. Matching `*"git commit"*` as a substring misses `git -C /path commit` — there
+   is no literal `git commit` in it. That is *exactly* the cross-directory call
+   most likely to be the mistake. Fixed by parsing the **subcommand**, skipping
+   git's global options.
+
+Both are instances of FAILURE-MODES C3 (a check that passes for the wrong
+reason), found the only way such things are found: by asserting the guard fails
+when it should.
+
+**Tradeoffs, stated honestly.**
+
+- This **is** a blocking hook, and `.claude/README.md` currently says nothing in
+  `.claude/` blocks. That policy was written against a *blanket* `deny` on
+  `gh pr merge`, which would have blocked the CTO's own merges. This is
+  different: it blocks one **location**, never a workflow, and the escape hatch
+  is a one-word change of directory. If we adopt it, `README.md`'s "Nothing here
+  blocks anything" must be amended in the same PR — a doc that lies about the
+  control plane is exactly failure mode E.
+- Runs on **every** Bash call. It is `jq` plus a couple of `git rev-parse`s;
+  keep it that cheap and keep the 10s timeout.
+- It cannot see through `bash -c '…'` wrappers or shell aliases. It raises the
+  cost of the mistake; it does not make it impossible.
+
+---
+
+## Recommendation 2 — never let a dead agent take work with it
+
+Our worst failure of the day: an agent hit the watchdog having committed but not
+pushed, and in one case having amended *after* the orchestrator took the branch.
+The most consequential bug fix of the session was left behind in a worktree,
+looking finished.
+
+**`SubagentStop` fires when a subagent finishes** and receives `agent_id` and
+`agent_type`. Use it to make abandoned work loud:
+
+```json
+{
+  "hooks": {
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/subagent-work-audit.sh\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+```bash
+#!/usr/bin/env bash
+# Reports any worktree holding work that is not on the remote.
+set -u
+input=$(cat); cwd=$(printf '%s' "$input" | jq -r '.cwd // ""')
+common=$(git -C "$cwd" rev-parse --git-common-dir 2>/dev/null) || exit 0
+findings=""
+while read -r d; do
+  [ -d "$d" ] || continue
+  dirty=$(git -C "$d" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+  unpushed=$(git -C "$d" rev-list --count @{u}..HEAD 2>/dev/null || echo 0)
+  [ "$dirty" = "0" ] && [ "${unpushed:-0}" = "0" ] && continue
+  findings="${findings}  ${d}: ${dirty} uncommitted, ${unpushed} unpushed\n"
+done < <(git -C "$cwd" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')
+[ -n "$findings" ] && printf 'WORK NOT ON THE REMOTE:\n%b' "$findings" >&2
+exit 0
+```
+
+Exit 0 so it only reports. It turns "the agent said it was done" into a
+checkable claim.
+
+**This is not hypothetical. Run against this repo today, it found:**
+
+```
+worktrees holding unpushed work: 51
+total uncommitted files across them: 864
+total unpushed commits: 45
+```
+
+One worktree alone holds **501 uncommitted files**. None of that is in a PR;
+none of it is on a remote; none of it is visible to `git log --all`. That
+backlog accumulated silently, one finished-looking agent at a time, which is
+precisely the argument for the hook: it costs nothing and it makes the invisible
+loud. (Triage is a separate job — most of it is probably stale, but "probably"
+is doing a lot of work in that sentence, and nobody can currently tell.)
+
+**Discipline that matters more than the hook**, and belongs in every brief:
+
+> Push after every commit. A commit that only exists in a worktree is not
+> delivered. If you amend, push again — even if you already pushed, and
+> especially if someone else may have taken the branch.
+
+---
+
+## Recommendation 3 — stop agents colliding in the scratchpad
+
+**There is no per-subagent scratch isolation.** Subagents in a session share the
+scratchpad path, which is how one `--amend` picked up another PR's subject line.
+`isolation: worktree` isolates the *checkout*, not `/tmp`.
+
+Convention, since there is no mechanism: **namespace every temp file by branch
+or `agent_id`**, and verify after any commit or amend:
+
+```bash
+git -C "$WT" log -1 --format='%s'
+git -C "$WT" show --stat --oneline HEAD | head -20
+```
+
+`SubagentStart` receives `agent_id`, so a hook could pre-create
+`$SCRATCH/$agent_id` — but the convention is what actually prevents the bug, and
+it costs nothing.
+
+---
+
+## Recommendation 4 — the settings we should set
+
+```json
+{
+  "worktree": { "baseRef": "fresh" }
+}
+```
+
+`"fresh"` (the default) branches every worktree from `origin/HEAD`, which is our
+rule already. Worth writing down so nobody sets `"head"` and starts branching
+subagent worktrees off in-progress local state.
+
+Also real and useful:
+
+- **`.worktreeinclude`** — `.gitignore`-syntax list of gitignored files copied
+  into each new worktree (`.env` and friends). Only matters once a game needs
+  local config.
+- **`isolation: worktree`** in a subagent's frontmatter makes isolation
+  permanent for that agent type. Our workers already get explicit worktrees; this
+  is the declarative version.
+- **`cleanupPeriodDays`** governs the sweep — which, verified, **skips worktrees
+  holding work** and never touches `--worktree` ones. Claude's cleanup is not the
+  thing that loses work.
+
+---
+
+## What does not exist — do not build on it
+
+| Belief | Reality |
+| --- | --- |
+| Subagents get a watchdog that resumes them | **No.** Background *sessions* have supervision; in-session subagents do not. A stalled subagent stays stalled — the orchestrator must notice and take over |
+| `SendMessage` recovers a crashed agent | It resumes an agent from its transcript; it is not crash recovery, and it will not retrieve work the agent never pushed |
+| Subagents get isolated temp dirs | **No.** Namespace them yourself |
+| A `deny` rule can say "except in a worktree" | **No.** Deny rules cannot carry exceptions and cannot see `cwd` |
+| Auto-checkpointing of agent work | **No** hook fires on a timer. `PostToolUse` on `Bash(git commit *)` could auto-push, but an auto-push that fires mid-rebase is its own hazard — prefer the discipline and the audit hook |
+
+---
+
+## Adoption order
+
+1. **Recommendation 2** (`SubagentStop` audit) — pure gain, blocks nothing,
+   directly addresses the failure that cost the most today.
+2. **The briefing discipline** — push after every commit; namespace scratch
+   files; verify the commit after amending. Free.
+3. **Recommendation 1** (primary-checkout guard) — the real enforcement of the
+   invariant, but it changes `.claude/`'s advisory-only posture and needs
+   `README.md` amended in the same PR. Founder's call.
+4. **Recommendation 4** — write `worktree.baseRef: "fresh"` down.

--- a/.claude/skills/trunk-pr/SKILL.md
+++ b/.claude/skills/trunk-pr/SKILL.md
@@ -13,6 +13,14 @@ The old "long-lived integration branch, big-bang squash" methodology is
 **dead**. Do not restore it, do not cite it, do not open a branch that
 accumulates weeks of work.
 
+### Read this too
+
+[`FAILURE-MODES.md`](FAILURE-MODES.md) — the ways this loop goes wrong **while
+looking like it went right**. Every entry happened here. If you are about to
+`reset --soft`, prune a worktree, trust a single green test run, take over from
+a dead agent, or hand a recipe to several agents at once, the answer is in
+there. It ends with a copy-pasteable preflight and postflight.
+
 ### Relationship to `AGENTS.md`
 
 `AGENTS.md` owns the process: the board, the gates, the pack checklist, the


### PR DESCRIPTION
## What

Two companions to the `trunk-pr` skill:

- **`FAILURE-MODES.md`** — the ways the worktree → PR → trunk loop goes wrong
  *while looking like it went right*. Every entry happened in this repo.
- **`HARNESS.md`** — what Claude Code can actually enforce, verified against the
  current docs, with a working primary-checkout guard and a subagent work audit.

## Why

One day of running this loop at scale produced a set of failures that share one
property, which is the reason they are worth a document:

> **They all look like success.** No crash, no red check, no conflict. The work
> looks done, the gate looks green, `main` looks fine.

A catalogue of *those* is worth more than a restatement of the procedure, which
already exists in `SKILL.md`.

## What is in FAILURE-MODES.md

Each entry gives the symptom, why it is invisible, and a command that turns it
back into a visible failure.

- **Work that never reaches git** — untracked-only work is in zero refs and
  `git log --all` correctly answers "nothing here"; a stalled agent leaves
  finished work uncommitted, or committed and unpushed, or amended after someone
  already took the branch.
- **Git operations that silently do the wrong thing** — `reset --soft` onto a
  moved `main` re-parents your commit while keeping the old tree and reverts
  everything that landed in between, with no conflict and no warning (it cost 35
  files here). Plus `cd repo && git` hitting the primary checkout because cwd
  resets between tool calls, branch renames not moving worktree directories, and
  `gitleaks` scanning every commit in the range so a later fix does not clear it.
- **Gates that pass while being wrong** — the most dangerous class. One green
  run is not proof (a suite failed 3 of 5 once actually repeated); a test can
  encode the bug as the intended behaviour; a test can pass vacuously (three
  distinct instances in one day); a gate can validate schema and not meaning;
  and a NUL byte makes a file **binary**, excluding it from every diff and from
  the review gate.
- **Orchestration** — parallel agents colliding in the shared scratchpad (one
  `--amend` took a different PR's subject line), and propagating an unvalidated
  recipe to N agents multiplying the mistake N times.
- **Stale guidance**, which is a failure mode in its own right: a rule outlived
  the bug it described by seven files and caused PRs to be split for nothing.

It ends with a copy-pasteable preflight and postflight.

### It corrects something I had wrong

I had written that pruning a worktree would have destroyed the eleven rescued
games. Checked rather than assumed:

| Action | Result |
| --- | --- |
| `git worktree remove <path>` | **Refuses** — "contains modified or untracked files, use --force" |
| `git worktree remove --force` | Destroys it |
| Claude Code's periodic sweep | **Skips** worktrees holding work; never touches `--worktree` ones |

The doc now states the verified behaviour. The real lesson stands on its own and
does not need the scarier version: work in zero refs has no backup anywhere.

## What is in HARNESS.md

**Permission rules cannot express our invariant, and it is worth knowing why.**
Bash rules are globs over the command string — no shell logic. Deny beats allow
with no exceptions ("a deny rule can't carry allowlist exceptions"). And no rule
sees `cwd`, so "deny `git commit` in the primary checkout but allow it in a
worktree" is not expressible. This is the wall `.claude/README.md` hit when it
considered and rejected hard denies.

**A PreToolUse hook can**, and the docs give it precedence: *"A blocking hook
also takes precedence over allow rules […] add `"Bash"` to your allow list and
register a PreToolUse hook that rejects those specific commands."*

Two hooks, both included and both tested:

1. **Primary-checkout guard** — blocks git *writes* whose target is the primary
   checkout, allows the fast-forward ritual and every read, and never touches a
   worktree.
2. **`SubagentStop` audit** — reports any worktree holding work that is not on
   the remote. Blocks nothing.

### Writing the tests found two bugs in my own guard, both failing OPEN

1. `git -C <path> rev-parse --git-common-dir` returns a path **relative to the
   target repo**. Resolved against the hook's cwd it produced nothing and the
   guard exited 0 — it only looked right because early tests ran from the
   primary checkout.
2. Substring-matching `*"git commit"*` misses `git -C /path commit`, which
   contains no such literal. That is **exactly** the cross-directory call most
   likely to be the mistake. Fixed by parsing the subcommand past git's global
   options.

Both are FAILURE-MODES C3 — a check passing for the wrong reason — found the
only way such things are found: by asserting the guard fails when it should.
16 cases now pass, and the matrix is in the file.

### The audit hook found a real backlog immediately

```
worktrees holding unpushed work: 51
total uncommitted files across them: 864
total unpushed commits: 45
```

One worktree holds **501 uncommitted files**. None of it is in a PR, on a
remote, or visible to `git log --all`. Most is probably stale — but "probably"
is doing a lot of work there, and nobody can currently tell. Triage is a
separate job; this PR only makes it visible.

## Blast radius

**Areas touched:** `.claude/skills/trunk-pr/` only. Docs.

- [x] Scope: 0 files outside `.claude/skills/trunk-pr/`, 0 deletions.
- [x] **Nothing is activated by this PR.** Both hooks are *proposed in a
      markdown file*; `settings.json` is untouched, no script is added under
      `.claude/hooks/`. Merging changes no behaviour.
- [x] **The guard, if adopted, changes `.claude/`'s advisory-only posture.**
      `README.md` currently says "Nothing here blocks anything". That policy was
      written against a blanket `deny` on `gh pr merge` which would have blocked
      the CTO's own merges; this blocks one *location*, never a workflow. Either
      way, adopting it means amending `README.md` in the same PR — a control
      plane that lies about itself is failure mode E. Called out in the file,
      and deliberately left as the founder's call.
- [x] Docs with no gate by design; no `ci.yml` area filter needed.
- [x] **Pack back-compat / native / strings / curriculum.** Untouched.
- [x] **Secrets.** `gitleaks` → no leaks found.

## Proof

```
$ git diff --name-only origin/main...HEAD
.claude/skills/trunk-pr/FAILURE-MODES.md
.claude/skills/trunk-pr/HARNESS.md
.claude/skills/trunk-pr/SKILL.md

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
no leaks found
```

Guard hook, extracted from the doc and driven with real JSON on stdin —
16 passed, 0 failed. Sample:

```
  commit in primary                        exit=2 want=2 OK
  commit in worktree                       exit=0 want=0 OK
  git -C <primary> commit  FROM worktree   exit=2 want=2 OK
  git -C <worktree> commit FROM primary    exit=0 want=0 OK
  git merge --ff-only origin/main          exit=0 want=0 OK
  git merge origin/feature                 exit=2 want=2 OK
  git reset --soft origin/main             exit=2 want=2 OK
  npm test in primary                      exit=0 want=0 OK
```

Every claim about Claude Code behaviour in `HARNESS.md` was checked against
`code.claude.com/docs` (hooks, worktrees, permissions) on 2026-07-27, and the
file states plainly where a mechanism does **not** exist — subagent watchdogs,
crash recovery via `SendMessage`, per-subagent scratch isolation, and
auto-checkpointing are all called out as things not to build on.
