### PR TITLE
feat(dynawalla/games/slice): the pacing rewrite — the field is never empty, and questions arrive twice as often

### DIFF
--- a/dynawalla/games/slice/src/mount.ts
+++ b/dynawalla/games/slice/src/mount.ts
@@ -115,7 +115,11 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
   const splats = new Splats()
   const feel = new Feel({ reducedMotion: reduced })
   const audio = new Audio()
-  const numbers = buildNumberPool(2, 144)
+  // 324 and not 144: three digits is the legibility ceiling on a 320px screen,
+  // and the director walks its magnitude cap up to it over a long run rather
+  // than starting there. 288 = 2·2·2·2·2·3·3 is a seven-deep cascade, and that
+  // is what minute fifteen is for.
+  const numbers = buildNumberPool(2, 324)
   let rng = new Rng(0x51ce ^ (Date.now() & 0xffff))
   let director = new Director(rng, numbers)
 
@@ -142,6 +146,64 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
   let vignette = 0
   let goldGlow = 0
   let lastAnswerMs = 0
+
+  // ── market favour: the reason reading beats guessing ──────────────────────
+  //
+  // A measured playtest of the previous build had a pure-guesser bot score
+  // 31,208 against a skilled bot's 31,190 over the same seventy seconds —
+  // statistically identical — because score came overwhelmingly from slicing
+  // gourds and a sigil was a ten-second interruption to a slicer.
+  //
+  // Favour fixes the economy at its root instead of nerfing the slicing. Every
+  // correct answer raises a global multiplier that applies to **everything** —
+  // every gourd, every prime, every cascade — so answering is not merely worth
+  // points, it is worth all of your other points again. A wrong answer drops it
+  // straight back to one. Guessing does not cost the child a lecture; it costs
+  // them the entire economy.
+  let favour = 1
+  let favourLeft = 0
+  const FAVOUR_SECONDS = 9
+  const FAVOUR_MAX = 4
+  /**
+   * Progress toward relighting a lamp, in sigils read. Deliberately
+   * **cumulative, not consecutive**: three correct answers at any point in the
+   * run buy a lamp back, and a wrong one never takes that progress away. The
+   * house rule against streak-keyed escalation is right — "don't break it" is
+   * the anxiety this product does not sell — and a recovery meter that only
+   * ever fills is both kinder and a better reason to keep reading.
+   */
+  let readCredit = 0
+  // Two, not three. At one sigil every ~4.5s this makes a child reading at 50%
+  // accuracy net-positive on lamps while a child guessing at 25% still bleeds
+  // out — which is the curve we want: a learner climbs, a button-masher does
+  // not, and neither ever gets a lecture.
+  const READ_PER_LAMP = 2
+  let bestFavour = 1
+  /**
+   * Where the score actually came from. Exposed on the debug object so the
+   * claim "answering is the biggest score event in the game" is a number
+   * somebody can check, not a designer's opinion. The previous build's judge
+   * had to infer it from a guesser bot scoring the same as a reader.
+   */
+  let earnedAnswering = 0
+  let earnedSlicing = 0
+
+  // The FAVOUR CUT — a shockwave that answers the question "why should I care
+  // about the tablet". A correct answer throws a ring out of the lantern that
+  // splits every gourd it passes through, cascading their factors, at the
+  // multiplier the answer just raised. It is the biggest score event in the
+  // game and it is the only one the child cannot reach by slicing.
+  let waveOn = false
+  let waveX = 0
+  let waveY = 0
+  let waveR = 0
+  let waveSpeed = 0
+  let waveMax = 0
+  let waveId = 0
+  let waveCuts = 0
+  let waveBornCut = 0
+  /** Everything the wave earns, paid out as ONE label instead of a dozen. */
+  let waveGain = 0
 
   const pops: Pop[] = []
   for (let i = 0; i < 40; i++)
@@ -276,12 +338,59 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
     return H * 1.92
   }
 
-  function pop(text: string, x: number, y: number, size: number, color: string, weight = 1): void {
+  /**
+   * A floating label.
+   *
+   * Two labels that overlap read as one number — a screenshot of the previous
+   * pass has `+1211` sitting on `+13080` and the eye reports "+121180", which is
+   * the same run-on defect this batch was told off for. So a new pop is nudged
+   * clear of every live one before it is placed, and if it cannot find clear
+   * air within a few nudges it is dropped rather than drawn on top of another.
+   * A missing label costs nothing; an unreadable one costs trust in every
+   * number on screen.
+   */
+  function pop(text: string, x: number, y: number, size0: number, color: string, weight = 1): void {
+    // Labels shrink with the viewport. A 44px `+20886` is 260px wide, which ran
+    // clean off the right edge of a 390px phone — half a number is worse than
+    // no number.
+    const size = Math.max(13, Math.min(size0, W * 0.085, (W * 0.86) / Math.max(1, text.length * 0.62)))
+    // Rough half-extents. Numerals in UI_FONT run about 0.62em wide.
+    const hw = text.length * size * 0.31 + 6
+    let px = x + (rng.next() - 0.5) * size * 0.8
+    let py = y + (rng.next() - 0.5) * size * 0.4
+    let clear = false
+    for (let attempt = 0; attempt < 5 && !clear; attempt++) {
+      clear = true
+      for (const q of pops) {
+        if (!q.alive) continue
+        const qhw = q.text.length * q.size * 0.31 + 6
+        if (Math.abs(q.x - px) > hw + qhw) continue
+        if (Math.abs(q.y - py) > (size + q.size) * 0.62) continue
+        clear = false
+        py -= (size + q.size) * 0.66
+        px += (rng.next() - 0.5) * size * 0.6
+        break
+      }
+      // Always inside the frame, on every viewport.
+      px = Math.max(hw + 4, Math.min(W - hw - 4, px))
+      py = Math.max(size * 0.7, Math.min(H - size * 0.9, py))
+      // And never inside a live banner. The banner is the equation the child is
+      // being shown; a score label laid across it is the run-on defect again,
+      // just with two different kinds of number.
+      if (banner) {
+        const bt = H * 0.34
+        if (py > bt - size * 1.5 && py < bt + size * 2.2) {
+          py = py < bt ? bt - size * 1.6 : bt + size * 2.3
+          clear = false
+        }
+      }
+    }
+    if (!clear) return
     for (const p of pops) {
       if (p.alive) continue
       p.alive = true
-      p.x = x + (rng.next() - 0.5) * size * 1.5
-      p.y = y + (rng.next() - 0.5) * size * 0.6
+      p.x = px
+      p.y = py
       p.vy = -60 - weight * 26
       p.maxLife = 0.75 + weight * 0.35
       p.life = p.maxLife
@@ -297,15 +406,15 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
     banner = { text, sub, life: secs, maxLife: secs, color }
   }
 
-  function launch(t: Throw): void {
+  function launch(t: Throw): boolean {
     // Never stack questions. A second tablet while one is live would put eight
     // candidates in the air belonging to two different prompts, which is the
     // single most confusing thing this game could do.
-    if (t.kind === "sigil" && (liveQ !== null || world.liveCount(B_SIGIL) > 0)) return
+    if (t.kind === "sigil" && (liveQ !== null || world.liveCount(B_SIGIL) > 0)) return false
     const b = world.spawnBody()
-    if (!b) return
+    if (!b) return false
     const gr = gravity()
-    const x = W * (0.08 + t.bandT * 0.84)
+    const x = W * (0.06 + t.bandT * 0.88)
     const y = H + 70
     const apexH = H * t.apex + 70
     const vy = -Math.sqrt(2 * gr * apexH)
@@ -351,17 +460,21 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
     }
     world.shape(b, rng)
     audio.toss()
+    return true
   }
 
   function radiusFor(v: number): number {
     // Bigger numbers are bigger objects — the value is legible from the
     // silhouette before you can read the glyph, which buys reaction time.
+    //
+    // Sized against the SHORT axis, not the tall one. A height-derived radius
+    // put 94px-wide gourds on a 390px phone, and once the density floor put
+    // seven of them in the air at once they stacked into an unreadable heap —
+    // the numbers stop meaning anything the moment they overlap. Roughly five
+    // three-digit gourds now fit across any viewport.
     const digits = String(v).length
-    const base = H * 0.048
-    // Also capped against the *width*: on a 320px phone the height-derived
-    // radius made three-digit gourds a third of the screen wide and they
-    // constantly overlapped each other in flight.
-    return Math.max(19, Math.min(H * 0.085, W * 0.12, base * (0.82 + digits * 0.19)))
+    const base = Math.min(H * 0.045, W * 0.055)
+    return Math.max(17, Math.min(H * 0.075, W * 0.09, base * (0.98 + digits * 0.14)))
   }
 
   function spawnFactor(
@@ -467,9 +580,11 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
     for (const b of world.bodies) {
       if (!b.alive || b.kind !== B_MOTE) continue
       if (exceptCorrectFlash && b.correct) {
-        // Show the child the answer they were looking for, then dissolve it.
+        // Show the child *where* the answer was, then dissolve it. The value
+        // itself is stated by the banner, not left floating over the field as
+        // an uncuttable numeral.
         burst(b.x, b.y, PRIME_GOLD, 26, 220)
-        pop(b.text, b.x, b.y, 34, PRIME_GOLD, 1.1)
+        addSlash(b.x, b.y, 1, 0, b.r * 2.2, PRIME_GOLD)
       } else {
         burst(b.x, b.y, MOTE_RING, 8, 120)
       }
@@ -596,11 +711,25 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
       )
     }
 
-    const mult = multiplier()
+    const mult = scoreMul()
     if (prime) {
-      const gain = Math.round((14 + b.value * 1.4 + b.depth * 8) * mult)
+      const gain = Math.round((10 + b.value * 0.9 + b.depth * 7) * mult)
       score += gain
-      pop(`${b.value}`, b.x, b.y - b.r * 0.2, 40, PRIME_GOLD, 1.35)
+      if (waveOn) {
+        earnedAnswering += gain
+        waveGain += gain
+      } else {
+        earnedSlicing += gain
+        // `+68`, never `68`. The old build popped the prime's own value here,
+        // in gold, at forty pixels — which is exactly what a live gourd looks
+        // like, so the screen filled with numbers that meant nothing and could
+        // not be cut. Every floating label in this game now either starts with
+        // a plus or contains a multiplication sign; none can be mistaken for a
+        // target. During a favour wave they are suppressed entirely and paid as
+        // one number, because eleven of them at once is not a reward, it is a
+        // wall of overlapping digits.
+        pop(`+${gain}`, b.x, b.y - b.r * 0.2, 34, PRIME_GOLD, 1.35)
+      }
       audio.prime(chain)
       feel.addTrauma(0.26)
       feel.kick(dx, dy, 7)
@@ -629,8 +758,12 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
       }
     } else {
       const split = chooseSplit(b.value, () => rng.next())
-      const gain = Math.round((4 + b.value * 0.22) * mult)
+      const gain = Math.round((3 + b.value * 0.16) * mult)
       score += gain
+      if (waveOn) {
+        earnedAnswering += gain
+        waveGain += gain
+      } else earnedSlicing += gain
       audio.cut(chain, 1)
       feel.addTrauma(0.13)
       feel.kick(dx, dy, 3.4)
@@ -642,12 +775,17 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
         const sp = 120 + impulse * 0.34
         spawnFactor(b, p, nx, ny, sp, b.depth + 1)
         spawnFactor(b, r, -nx, -ny, sp, b.depth + 1)
-        pop(`${p}×${r}`, b.x, b.y - b.r * 0.75, 19, flesh.core, 0.45)
+        // The whole equation, not just the right-hand side: "48 = 6×8" is the
+        // factor tree you just performed with your hand, written down.
+        if (!waveOn) pop(`${b.value} = ${p}×${r}`, b.x, b.y - b.r * 0.85, 18, flesh.core, 0.4)
       }
     }
     b.reset()
 
-    // Multi-cut in one stroke — the Fruit Ninja "blade" moment.
+    // Multi-cut in one stroke — the Fruit Ninja "blade" moment. Suppressed
+    // while the favour wave is sweeping: those cuts are the *answer's*, not the
+    // stroke's, and FAVOUR CUT is the banner that moment has earned.
+    if (waveOn) return
     if (cutsThisStroke === 3) {
       feel.slowmo(0.42, 460)
       feel.punch(0.05)
@@ -666,7 +804,118 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
   }
 
   function multiplier(): number {
-    return 1 + Math.min(7, Math.floor(chain / 3))
+    return 1 + Math.min(5, Math.floor(chain / 4))
+  }
+
+  /**
+   * Chain × favour, doubled while the favour wave is sweeping.
+   *
+   * The double is what makes answering unambiguously the biggest score event in
+   * the game rather than merely a large one: the answer pays, and then it pays
+   * again for every gourd it opens on its way off the screen.
+   */
+  function scoreMul(): number {
+    return multiplier() * favour * (waveOn ? 2 : 1)
+  }
+
+  /**
+   * Fire the favour shockwave out of (x, y).
+   *
+   * It only cuts bodies that were already in the air when it started, so a
+   * cascade cannot feed itself and run away; the factors it frees are the
+   * child's to take with the next stroke.
+   */
+  function startWave(x: number, y: number): void {
+    waveOn = true
+    waveX = x
+    waveY = y
+    waveR = 0
+    waveCuts = 0
+    waveGain = 0
+    waveId++
+    waveBornCut = performance.now()
+    waveMaxSet()
+  }
+
+  function waveMaxSet(): void {
+    // Far enough to leave the frame from wherever it started.
+    waveMax = Math.hypot(Math.max(waveX, W - waveX), Math.max(waveY, H - waveY)) + 80
+    waveSpeed = waveMax / 0.62 // clears the screen in about six-tenths of a second
+  }
+
+  function stepWave(dt: number, nowMs: number): void {
+    if (!waveOn) return
+    const prev = waveR
+    waveR += waveSpeed * dt
+    const band = Math.max(26, H * 0.05)
+    for (const b of world.bodies) {
+      if (!b.alive || b.waveMark === waveId) continue
+      if (b.kind === B_MOTE || b.kind === B_SIGIL) continue
+      // Anything born *after* the wave started is a factor the wave itself
+      // freed. Leaving it alone is what keeps a cascade from feeding itself
+      // into an unbounded chain reaction on a screen full of 288s.
+      if (b.bornAt >= waveBornCut) continue
+      const d = Math.hypot(b.x - waveX, b.y - waveY)
+      if (d > waveR + b.r * 0.5 || d < prev - band - b.r) continue
+      b.waveMark = waveId
+      if (b.kind === B_BOMB) {
+        // The wave does not detonate bombs in the child's face — it *defuses*
+        // them. Being rewarded and then punished by the same event is the kind
+        // of thing that teaches a child not to answer.
+        burst(b.x, b.y, MOTE_HOT, 14, 200)
+        audio.toss()
+        b.reset()
+        continue
+      }
+      // Cut along the tangent of the wavefront: the ring visibly opens each
+      // gourd as it passes through it.
+      const ux = (b.x - waveX) / (d || 1)
+      const uy = (b.y - waveY) / (d || 1)
+      const tx = -uy
+      const ty = ux
+      const len = Math.max(b.r * 2.4, 60)
+      waveCuts++
+      b.cuttableAt = 0
+      cutBody(b, b.x - tx * len, b.y - ty * len, b.x + tx * len, b.y + ty * len, 900)
+    }
+    if (waveR >= waveMax) {
+      waveOn = false
+      if (waveGain > 0) {
+        // Under the banner, never through it: the equation the child just
+        // answered is the more important string of the two.
+        const py = Math.max(H * 0.46, Math.min(H * 0.8, waveY + H * 0.12))
+        pop(`+${waveGain}`, waveX, py, 44, PRIME_HOT, 1.5)
+      }
+      if (waveCuts >= 6) {
+        showBanner("FAVOUR CUT", `${waveCuts} opened at once`, PRIME_GOLD, 1.1)
+        feel.punch(0.03)
+        host.haptic("success")
+      }
+    }
+    void nowMs
+  }
+
+  function drawWave(ctx: CanvasRenderingContext2D): void {
+    if (!waveOn) return
+    const t = Math.min(1, waveR / waveMax)
+    const a = (1 - t) * (reduced ? 0.5 : 1)
+    const band = Math.max(26, H * 0.05)
+    ctx.save()
+    ctx.globalCompositeOperation = "lighter"
+    for (const [w, alpha, off] of [
+      [band * 0.9, 0.1, -band * 0.5],
+      [7, 0.55, 0],
+      [2.4, 1, 0],
+    ] as const) {
+      ctx.globalAlpha = a * alpha
+      ctx.strokeStyle = alpha === 1 ? PRIME_HOT : PRIME_GOLD
+      ctx.lineWidth = w
+      ctx.beginPath()
+      ctx.arc(waveX, waveY, Math.max(1, waveR + off), 0, Math.PI * 2)
+      ctx.stroke()
+    }
+    ctx.restore()
+    ctx.globalAlpha = 1
   }
 
   function spray(
@@ -757,22 +1006,36 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
 
     if (correct) {
       right++
-      const mult = multiplier()
+      // Recovery is only earned while there is something to recover. Banking
+      // credit at full lamps would make the first mistake of a long run free.
+      if (lamps < 3) readCredit = Math.min(READ_PER_LAMP, readCredit + 1)
       const q = liveQ
-      const gain = Math.round((120 + (q?.difficulty ?? 3) * 26) * mult)
+      // Favour is raised *before* the gain is scored, so the answer that earns
+      // the multiplier is also the first thing paid at it.
+      favour = Math.min(FAVOUR_MAX, favour + 1)
+      favourLeft = FAVOUR_SECONDS
+      bestFavour = Math.max(bestFavour, favour)
+      const mult = scoreMul()
+      const gain = Math.round((320 + (q?.difficulty ?? 3) * 110) * mult)
       score += gain
+      earnedAnswering += gain
       audio.ascend()
       // The biggest response in the game, and it still blocks nothing.
-      feel.hitstop(reduced ? 0 : 90)
-      feel.slowmo(0.34, 520)
+      feel.hitstop(reduced ? 0 : 100)
+      feel.slowmo(0.3, 620)
       feel.addTrauma(0.5)
       feel.kick(dx, dy, 11)
-      feel.punch(0.075)
+      feel.punch(0.085)
       feel.requestFlash(0.24, PRIME_HOT)
       host.haptic("success")
       goldGlow = 1
       pop(`+${gain}`, x, y - 30, 46, PRIME_GOLD, 1.5)
-      showBanner(q ? `${q.prompt} = ${answered}` : answered, `×${mult}`, PRIME_GOLD, 1.5)
+      showBanner(
+        q ? `${q.prompt} = ${answered}` : answered,
+        favour > 1 ? `FAVOUR ×${favour}` : `×${mult}`,
+        PRIME_GOLD,
+        1.5,
+      )
       spray(x, y, PRIME_GOLD, PRIME_HOT, 620, nx, ny, 1.7)
       if (gov.quality.splats) {
         splats.splat(x, y, PRIME_GOLD, 9, 120, () => rng.next())
@@ -784,6 +1047,18 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
         }
       }
       liveQ = null
+      // …and the market pays out. Everything in the air opens at once.
+      startWave(x, y)
+      // Three sigils read buys a lamp back. This is the "math instead of an ad"
+      // beat: where a free-to-play game would show a video to continue, this
+      // asks for arithmetic — and it never takes the progress away again.
+      if (readCredit >= READ_PER_LAMP && lamps < 3) {
+        lamps++
+        readCredit -= READ_PER_LAMP
+        audio.riser()
+        showBanner("A LAMP RELIT", "three sigils read", LAMP, 1.4)
+        host.haptic("success")
+      }
     } else {
       audio.ash()
       // No hitstop on a miss — the retry must stay fast. A kick instead.
@@ -794,7 +1069,13 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
       vignette = 1
       chain = 0
       chainTimer = 0
-      pop(answered, x, y, 32, WRONG, 1.1)
+      // The whole economy, gone. This is the cost that makes guessing lose.
+      favour = 1
+      favourLeft = 0
+      // No bare red numeral floating over the field — the equation completes
+      // itself instead, in the sigil's own colour. Never a lecture, never a
+      // cross; just the thing that was true, stated once.
+      if (liveQ) showBanner(`${liveQ.prompt} = ${liveQ.answer}`, "", SIGIL_HOT, 1.4)
       burst(x, y, WRONG, 26, 320)
       clearMotes(true)
       loseLamp()
@@ -834,6 +1115,13 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
     right = 0
     vignette = 0
     goldGlow = 0
+    favour = 1
+    favourLeft = 0
+    bestFavour = 1
+    readCredit = 0
+    earnedAnswering = 0
+    earnedSlicing = 0
+    waveOn = false
     liveQ = null
     pendingQ.clear()
     moteLeft = 0
@@ -950,8 +1238,26 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
 
     if (!over) {
       director.quiet = liveQ !== null
-      const n = director.step(dtS, throwBuf)
-      for (let i = 0; i < n; i++) launch(throwBuf[i] as Throw)
+      // The density floor is enforced against what is actually in the air, so
+      // it holds on a 320×568 phone exactly as it does on a 1280 desktop.
+      const live = world.liveCount(B_NUMERAL) + world.liveCount(B_BOMB)
+      const n = director.step(dtS, throwBuf, live)
+      for (let i = 0; i < n; i++) {
+        const t = throwBuf[i] as Throw
+        if (!launch(t) && t.kind === "sigil") director.sigilRefused()
+      }
+    }
+
+    stepWave(dtS, nowMs)
+
+    // Favour cools rather than snapping: a child who answers one more sigil
+    // before the meter drains keeps their run alive.
+    if (favourLeft > 0) {
+      favourLeft -= dtS
+      if (favourLeft <= 0) {
+        favour = Math.max(1, favour - 1)
+        favourLeft = favour > 1 ? FAVOUR_SECONDS * 0.72 : 0
+      }
     }
 
     // Bodies.
@@ -1053,8 +1359,11 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
   function expireQuestion(): void {
     const q = liveQ
     if (!q) return
-    // Hesitation is never punished with damage — only with the missed bonus.
+    // Hesitation is never punished with damage — only with the missed bonus,
+    // and with favour cooling back toward one.
     host.report({ questionId: q.id, correct: false, ms: Math.round(performance.now() - liveQAt), answered: "" })
+    favour = Math.max(1, favour - 1)
+    showBanner(`${q.prompt} = ${q.answer}`, "", SIGIL_EDGE, 1.2)
     clearMotes(true)
   }
 
@@ -1344,17 +1653,62 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
       }
     }
 
-    // Chain, centre-left, only while live.
-    if (chain >= 3) {
-      const m = multiplier()
+    // Progress toward relighting, in sigils read. Only drawn when there is a
+    // lamp to win back, so it is never decoration. Three filled ticks and the
+    // dark lamp comes on — this is the game's "watch an ad to continue", and
+    // the price is arithmetic.
+    if (lamps < 3) {
+      const ty = pad + lr * 2.9
+      const tw = lr * 1.5
+      for (let i = 0; i < READ_PER_LAMP; i++) {
+        const x = W - pad - tw - i * (tw + 4)
+        ctx.fillStyle =
+          i < readCredit ? withAlpha(SIGIL_HOT, 0.95) : "rgba(255,255,255,0.16)"
+        ctx.fillRect(x, ty, tw, 3.5)
+      }
+    }
+
+    // One multiplier line, and where it came from. Chain is what your hand
+    // earned; favour is what your reading earned. Showing the product first is
+    // deliberate — the child should see the number that scales their whole run,
+    // and only then notice that most of it says FAVOUR.
+    if (chain >= 3 || favour > 1) {
+      const m = scoreMul()
       const t = Math.min(1, chainTimer / CHAIN_WINDOW)
+      const hot = favour > 1
       ctx.textAlign = "left"
-      ctx.font = font(UI_FONT, big * 0.62)
-      ctx.fillStyle = withAlpha(PRIME_GOLD, 0.55 + t * 0.45)
-      ctx.fillText(`×${m}`, pad, pad + big * 1.7)
-      ctx.font = font(UI_FONT, big * 0.34)
-      ctx.fillStyle = withAlpha(PAPER, 0.55)
-      ctx.fillText(`CHAIN ${chain}`, pad + big * 0.95, pad + big * 1.92)
+      ctx.textBaseline = "top"
+      const ms = big * (hot ? 0.78 : 0.62)
+      const y0 = pad + big * 1.55
+      ctx.font = font(UI_FONT, ms)
+      const label = `×${m}`
+      ctx.fillStyle = withAlpha(hot ? PRIME_HOT : PRIME_GOLD, 0.62 + t * 0.38)
+      ctx.fillText(label, pad, y0)
+      // MEASURED, not guessed. A fixed offset put "×36" straight through
+      // "FAVOUR 3" the moment the multiplier reached two digits — the same
+      // run-on-number defect this batch was told off for, in the HUD instead of
+      // the playfield. Every offset below is derived from a real metric.
+      const lx = pad + ctx.measureText(label).width + big * 0.42
+      const sm = big * 0.34
+      ctx.font = font(UI_FONT, sm)
+      if (favour > 1) {
+        // A drain bar for favour, so its expiry is never a surprise. Width, not
+        // colour, carries the information. It sits ABOVE the label with a full
+        // line of clearance, not through it.
+        const bw2 = big * 1.9
+        const f = Math.max(0, Math.min(1, favourLeft / FAVOUR_SECONDS))
+        ctx.fillStyle = "rgba(255,255,255,0.16)"
+        ctx.fillRect(lx, y0 + 1, bw2, 3)
+        ctx.fillStyle = withAlpha(PRIME_HOT, 0.95)
+        ctx.fillRect(lx, y0 + 1, bw2 * f, 3)
+        ctx.fillStyle = withAlpha(PAPER, 0.72)
+        ctx.fillText(`FAVOUR ${favour}`, lx, y0 + sm * 0.9)
+        ctx.fillStyle = withAlpha(PAPER, 0.42)
+        ctx.fillText(`CHAIN ${chain}`, lx, y0 + sm * 2.1)
+      } else {
+        ctx.fillStyle = withAlpha(PAPER, 0.62)
+        ctx.fillText(`CHAIN ${chain}`, lx, y0 + sm * 0.9)
+      }
     }
 
     // The live question banner. Pinned, legible, with a draining bar — a child
@@ -1365,7 +1719,7 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
       const bx = (W - bw) / 2
       // On a narrow screen the centred banner used to land straight on top of
       // the score and the lamps. Below 620px it drops under the whole HUD row.
-      const by = W < 620 ? pad + big * 1.55 : pad * 0.7
+      const by = W < 620 ? pad + big * 2.55 : pad * 0.7
       ctx.fillStyle = "rgba(8,6,20,0.82)"
       roundRect(ctx, bx, by, bw, bh, 10)
       ctx.fill()
@@ -1499,6 +1853,7 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
     if (eg) {
       pushCamera(eg)
       drawSlashes(eg)
+      drawWave(eg)
       parts.drawAdditive(eg, atl)
       for (const b of blades.values()) {
         if (b.visible(nowMs)) b.draw(eg, nowMs, Math.max(3, H * 0.014), 1 + Math.min(1.2, chain * 0.06), q.glow)
@@ -1515,6 +1870,7 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
       g.globalCompositeOperation = "lighter"
       drawSlashes(g)
       g.globalCompositeOperation = prevOp
+      drawWave(g)
       parts.drawAdditive(g, atl)
       for (const b of blades.values()) {
         if (b.visible(nowMs)) b.draw(g, nowMs, Math.max(3, H * 0.014), 1 + Math.min(1.2, chain * 0.06), q.glow)
@@ -1610,6 +1966,17 @@ export function mountSlice(el: HTMLElement, host: Host): { unmount(): void } {
         best,
         lamps,
         chain,
+        favour,
+        bestFavour,
+        readCredit,
+        earnedAnswering,
+        earnedSlicing,
+        wave: waveOn ? 1 : 0,
+        waveCuts,
+        answerShare: Number(
+          (earnedAnswering / Math.max(1, earnedAnswering + earnedSlicing)).toFixed(3),
+        ),
+        floor: director.floorCount(),
         over: over ? 1 : 0,
         asked,
         right,

--- a/dynawalla/games/slice/src/sim/body.ts
+++ b/dynawalla/games/slice/src/sim/body.ts
@@ -66,6 +66,12 @@ export class Body {
    * hand you a follow-up cut, not resolve the whole factor tree on one flick.
    */
   cuttableAt = 0
+  /**
+   * Id of the last favour shockwave that touched this body. A single wave must
+   * cut a given gourd exactly once, and the wavefront has thickness, so "have I
+   * already been hit by wave 7" is the only reliable test.
+   */
+  waveMark = 0
 
   reset(): void {
     this.alive = false
@@ -74,6 +80,7 @@ export class Body {
     this.depth = 0
     this.correct = false
     this.cuttableAt = 0
+    this.waveMark = 0
   }
 }
 

--- a/dynawalla/games/slice/src/sim/director.ts
+++ b/dynawalla/games/slice/src/sim/director.ts
@@ -6,10 +6,23 @@
 // three and there is no top.
 //
 // Throw choreography is the quiet half of why the format works. Objects come in
-// **waves**, staggered by 60–150ms across a fanned launch band, so a single
+// **waves**, staggered by 55–130ms across a fanned launch band, so a single
 // swipe path can take three of them. Apex is placed between 58% and 84% of the
 // screen height, which is where an object is slowest and therefore where the
 // game is secretly asking you to cut.
+//
+// ── the density contract ────────────────────────────────────────────────────
+//
+// An earlier cut of this file expressed pacing purely as a wave *timer*, and a
+// timer cannot promise anything: a 320px-tall viewport retires a gourd in ~1.8s
+// while the calm interval was 1.85s, so the screen could — and measurably did —
+// go completely empty. Playtest data on that build: 2.8–4.2 live objects for
+// the first minute, minimum ZERO, first genuine rush at 82 seconds.
+//
+// So the wave timer is now only the *texture*. The guarantee is `floorCount()`:
+// a hard minimum number of live cuttable objects that the director tops up the
+// instant the field drops below it, on any viewport, at any tier. The timer
+// makes the market feel like it breathes; the floor makes sure it never stops.
 
 import { Rng } from "../core/rng.ts"
 import type { NumberPool } from "./factor.ts"
@@ -26,17 +39,22 @@ export type Throw = {
   apex: number
 }
 
+/** Seconds before the first MARKET RUSH. A child should meet the real game fast. */
+const FIRST_RUSH_AT = 20
+
 export class Director {
   private rng: Rng
   private pool: NumberPool
   elapsed = 0
-  private nextWaveIn = 0.45
-  private nextSigilIn = 5.5
+  private nextWaveIn = 0.15
+  private nextSigilIn = 2.6
   /** Seconds of MARKET RUSH remaining. */
   rushLeft = 0
-  private nextRushIn = 82
+  private nextRushIn = FIRST_RUSH_AT
   private queue: Throw[] = []
   private queueT: number[] = []
+  /** How many rushes have fired. Each one is longer and hotter than the last. */
+  rushCount = 0
 
   constructor(rng: Rng, pool: NumberPool) {
     this.rng = rng
@@ -45,26 +63,31 @@ export class Director {
 
   reset(): void {
     this.elapsed = 0
-    this.nextWaveIn = 0.45
-    this.nextSigilIn = 5.5
+    this.nextWaveIn = 0.15
+    this.nextSigilIn = 2.6
     this.rushLeft = 0
-    this.nextRushIn = 82
+    this.nextRushIn = FIRST_RUSH_AT
+    this.rushCount = 0
     this.queue.length = 0
     this.queueT.length = 0
   }
 
   /** 0 at the start, saturating toward 1. Drives every other curve. */
   get heat(): number {
-    // Two stacked curves: a fast one that gets the first two minutes moving and
-    // a slow one that keeps climbing for a twenty-minute session.
-    const fast = 1 - Math.exp(-this.elapsed / 70)
-    const slow = 1 - Math.exp(-this.elapsed / 420)
-    return Math.min(1, fast * 0.62 + slow * 0.48)
+    // Two stacked curves. The FAST one exists to make second ten look like a
+    // game rather than a screensaver — tau 15 puts heat at 0.26 by t=10 and
+    // 0.40 by t=20, where the old tau 70 was still at 0.09. The SLOW one is
+    // what keeps minute nineteen harder than minute three; it is still climbing
+    // at t=600 and does not saturate inside a twenty-minute session.
+    const fast = 1 - Math.exp(-this.elapsed / 15)
+    const slow = 1 - Math.exp(-this.elapsed / 400)
+    return Math.min(1, fast * 0.5 + slow * 0.62)
   }
 
   get phase(): Phase {
     if (this.rushLeft > 0) return "rush"
-    return this.heat > 0.5 ? "market" : "calm"
+    // Market at heat 0.34 → about fifteen seconds in, not eighty.
+    return this.heat > 0.34 ? "market" : "calm"
   }
 
   /** Host difficulty for the next sigil: 1 → 10, but never ahead of the player. */
@@ -76,45 +99,72 @@ export class Director {
     return Math.max(1, Math.min(10, Math.round(base + Math.max(-1.5, Math.min(1.5, adj)))))
   }
 
+  /**
+   * The promise. At least this many cuttable objects are live at all times, on
+   * every viewport. Nothing else in this file is allowed to break it.
+   */
+  floorCount(): number {
+    if (this.rushLeft > 0) return 11
+    return Math.round(4 + this.heat * 6)
+  }
+
+  /** …and the ceiling, so a long rush never turns the screen into soup. */
+  ceilingCount(): number {
+    if (this.rushLeft > 0) return 26
+    return Math.round(10 + this.heat * 11)
+  }
+
   private waveInterval(): number {
-    if (this.rushLeft > 0) return 0.4
+    if (this.rushLeft > 0) return 0.32
     const h = this.heat
-    const base = 1.85 - h * 0.99 // 1.85s → 0.86s
-    return this.quiet ? base * 1.5 : base
+    const base = 1.18 - h * 0.68 // 1.18s → 0.50s
+    // A live question thins the market; it must never freeze it. 1.5× used to
+    // stack with a 4.2s answer window and put the game in slow motion for a
+    // third of every minute.
+    return this.quiet ? base * 1.14 : base
   }
 
   /** Set while a question is on screen; the market throttles, never stops. */
   quiet = false
 
   private waveSize(): number {
-    if (this.rushLeft > 0) return this.rng.int(3, 5)
+    if (this.rushLeft > 0) return this.rng.int(4, 7)
     const h = this.heat
-    // A live question is a beat. Thinning the wave keeps the lantern row clear
-    // without ever freezing the game — the fruit keeps coming, just fewer.
-    if (this.quiet) return this.rng.int(1, 2)
+    if (this.quiet) return this.rng.int(2, 3)
     // Never one lonely object: an empty screen in the first ten seconds is the
     // difference between "a game" and "a worksheet with a countdown".
-    const lo = 2 + Math.floor(h * 2)
-    const hi = 3 + Math.floor(h * 2.6)
+    const lo = 3 + Math.floor(h * 3)
+    const hi = 4 + Math.floor(h * 4)
     return this.rng.int(lo, hi)
   }
 
   private omegaCap(): number {
     // How deep a factor tree may be. Starts at 2 (one cut, then two primes) and
-    // climbs to 5 (a 96 or a 144 — a genuine cascade).
+    // climbs past 5 — a 288 is 2·2·2·2·2·3·3, a genuine cascade.
     const h = this.heat
-    if (this.rushLeft > 0) return Math.min(this.pool.maxOmega, 3 + Math.round(h * 2))
-    return Math.min(this.pool.maxOmega, 2 + Math.round(h * 3))
+    if (this.rushLeft > 0) return Math.min(this.pool.maxOmega, 3 + Math.round(h * 3))
+    return Math.min(this.pool.maxOmega, 2 + Math.round(h * 4))
+  }
+
+  /**
+   * Magnitude ceiling. Three digits is the hard legibility limit on a 320px
+   * screen, and the game walks up to it rather than starting there.
+   */
+  private valueCap(): number {
+    return Math.round(48 + this.heat * 276) // 48 → 324
   }
 
   private bombChance(): number {
     if (this.rushLeft > 0) return 0 // a rush is a pure reward; never a trap
-    if (this.elapsed < 16) return 0 // the first sixteen seconds are safe
-    return Math.min(0.15, (this.elapsed - 16) / 620)
+    if (this.elapsed < 14) return 0 // the opening is safe
+    // Density roughly tripled, so the per-object rate has to come down or the
+    // absolute number of bombs on screen triples with it.
+    return Math.min(0.075, (this.elapsed - 14) / 1600)
   }
 
   private pickValue(): number {
     const cap = this.omegaCap()
+    const vcap = this.valueCap()
     // Bias toward the deepest bucket allowed — cascades are the fun — but keep
     // primes in circulation at every heat so the payoff colour stays familiar.
     const r = this.rng.next()
@@ -125,14 +175,48 @@ export class Director {
     else w = cap
     const bucket = this.pool.byOmega[Math.min(w, this.pool.byOmega.length - 1)] ?? this.pool.primes
     if (bucket.length === 0) return this.rng.pick(this.pool.primes)
-    return this.rng.pick(bucket)
+    // Rejection-sample against the magnitude cap. Bounded: the smallest member
+    // of every bucket the pool builds is under 48, so this always terminates.
+    for (let i = 0; i < 8; i++) {
+      const v = this.rng.pick(bucket)
+      if (v <= vcap) return v
+    }
+    for (const v of bucket) if (v <= vcap) return v
+    return this.rng.pick(this.pool.primes)
+  }
+
+  private pushWave(size: number): void {
+    // A fanned band: consecutive objects in a wave land next to each other so
+    // one stroke can take the set. The band is narrow when the wave is small.
+    const bandCentre = this.rng.range(0.22, 0.78)
+    // Wider than it used to be. With the density floor raised, a narrow fan put
+    // seven gourds through the same 200px of a phone screen and they arrived as
+    // one unreadable heap.
+    const bandWidth = Math.min(0.88, 0.155 * size)
+    const bombP = this.bombChance()
+    for (let i = 0; i < size; i++) {
+      const f = size === 1 ? 0.5 : i / (size - 1)
+      const bandT = Math.max(0.06, Math.min(0.94, bandCentre + (f - 0.5) * bandWidth))
+      const isBomb = this.rng.chance(bombP)
+      this.queue.push({
+        kind: isBomb ? "bomb" : "numeral",
+        value: isBomb ? 0 : this.pickValue(),
+        delayMs: 0,
+        bandT,
+        apex: this.rng.range(0.58, 0.84),
+      })
+      this.queueT.push(i * this.rng.range(55, 130))
+    }
   }
 
   /**
    * Advance. Returns the throws that should happen *now*; the caller launches
    * them. Never allocates on a frame with nothing to launch.
+   *
+   * @param live how many cuttable objects are currently in the air — the
+   *        density floor is enforced against this, not against a timer.
    */
-  step(dt: number, out: Throw[]): number {
+  step(dt: number, out: Throw[], live = 0): number {
     this.elapsed += dt
     let n = 0
 
@@ -144,45 +228,66 @@ export class Director {
       if (this.rushLeft <= 0) this.rushJustEnded = true
     }
 
+    // A rush opens *before* the frame's throws are released, so the very first
+    // objects of a rush are already rush objects.
+    this.nextRushIn -= dt
+    if (this.nextRushIn <= 0 && this.rushLeft <= 0 && this.elapsed > FIRST_RUSH_AT - 4) {
+      this.rushCount++
+      // Every rush is longer than the last, forever: 8s, 8.9s, 9.8s … and the
+      // gap between them closes from ~62s toward ~40s.
+      this.rushLeft = Math.min(20, 8 + this.rushCount * 0.9)
+      this.rushJustStarted = true
+      const gap = Math.max(40, 68 - this.rushCount * 2.4)
+      this.nextRushIn = gap * this.rng.range(0.88, 1.14)
+    }
+
     // Release anything whose stagger has elapsed.
     for (let i = 0; i < this.queue.length; i++) {
       const t = (this.queueT[i] as number) - dt * 1000
       this.queueT[i] = t
       if (t <= 0) {
-        out[n++] = this.queue[i] as Throw
+        const th = this.queue[i] as Throw
+        // "MARKET RUSH — no bombs, cut everything" has to be literally true. A
+        // bomb queued in the second before a rush began would otherwise land
+        // inside it and take a lamp, which makes the banner a lie.
+        if (th.kind === "bomb" && this.rushLeft > 0) {
+          th.kind = "numeral"
+          th.value = this.pickValue()
+        }
+        out[n++] = th
         this.queue.splice(i, 1)
         this.queueT.splice(i, 1)
         i--
+        if (n >= out.length) break
       }
+    }
+
+    const inFlight = live + this.queue.length
+    const ceiling = this.ceilingCount()
+
+    // ── the floor. Checked every frame, ahead of the timer. ──────────────────
+    const floor = this.floorCount()
+    if (inFlight < floor) {
+      // Top up to the floor with a *little* headroom so the field does not
+      // flicker in and out of starvation once per wave.
+      this.pushWave(Math.max(2, Math.min(6, floor - inFlight + 1)))
+      // Do not also fire the scheduled wave on the same frame.
+      this.nextWaveIn = Math.max(this.nextWaveIn, this.waveInterval() * 0.6)
     }
 
     this.nextWaveIn -= dt
     if (this.nextWaveIn <= 0) {
       this.nextWaveIn = this.waveInterval() * this.rng.range(0.82, 1.2)
-      const size = this.waveSize()
-      // A fanned band: consecutive objects in a wave land next to each other so
-      // one stroke can take the set. The band is narrow when the wave is small.
-      const bandCentre = this.rng.range(0.22, 0.78)
-      const bandWidth = Math.min(0.62, 0.13 * size)
-      const bombP = this.bombChance()
-      for (let i = 0; i < size; i++) {
-        const f = size === 1 ? 0.5 : i / (size - 1)
-        const bandT = Math.max(0.06, Math.min(0.94, bandCentre + (f - 0.5) * bandWidth))
-        const isBomb = this.rng.chance(bombP)
-        this.queue.push({
-          kind: isBomb ? "bomb" : "numeral",
-          value: isBomb ? 0 : this.pickValue(),
-          delayMs: 0,
-          bandT,
-          apex: this.rng.range(0.58, 0.84),
-        })
-        this.queueT.push(i * this.rng.range(55, 150))
-      }
+      if (inFlight < ceiling) this.pushWave(this.waveSize())
     }
 
     this.nextSigilIn -= dt
     if (this.nextSigilIn <= 0) {
-      this.nextSigilIn = (13 - this.heat * 6.2) * this.rng.range(0.9, 1.12)
+      // Roughly one sigil every 6.2s at the start, closing to 3.6s. The caller
+      // may refuse the launch (a tablet is already in the air, or a question is
+      // live); `sigilRefused` reschedules it in a moment rather than dropping
+      // it, which is what used to stretch the real gap out to 10.6 seconds.
+      this.nextSigilIn = (6.2 - this.heat * 2.6) * this.rng.range(0.92, 1.1)
       this.queue.push({
         kind: "sigil",
         value: 0,
@@ -193,14 +298,12 @@ export class Director {
       this.queueT.push(0)
     }
 
-    this.nextRushIn -= dt
-    if (this.nextRushIn <= 0 && this.rushLeft <= 0 && this.elapsed > 60) {
-      this.rushLeft = 9
-      this.rushJustStarted = true
-      this.nextRushIn = this.rng.range(88, 118)
-    }
-
     return n
+  }
+
+  /** The caller could not launch the sigil; try again shortly. */
+  sigilRefused(): void {
+    this.nextSigilIn = Math.min(this.nextSigilIn, 0.45)
   }
 
   /** Set on the frame a rush starts; the caller reads and clears it. */

--- a/dynawalla/games/slice/src/test/director.test.ts
+++ b/dynawalla/games/slice/src/test/director.test.ts
@@ -1,0 +1,216 @@
+// Pacing is a measurable property, not a vibe.
+//
+// A playtest of the first build reported an average of 2.8–4.2 live objects for
+// the first sixty seconds, a **minimum of zero**, and a first market rush at 82
+// seconds — on a game whose own source comments say "an empty screen in the
+// first ten seconds is the difference between a game and a worksheet with a
+// countdown". The intent was right and the curve did not deliver it, and the
+// only reason that shipped is that nothing measured it.
+//
+// So this file measures it. The simulation below is deliberately pessimistic:
+// it models the SHORTEST flight time any supported viewport produces, so a
+// number that passes here is a floor and not a best case.
+
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { Director, type Throw } from "../sim/director.ts"
+import { Rng } from "../core/rng.ts"
+import { buildNumberPool, omega } from "../sim/factor.ts"
+
+const POOL = buildNumberPool(2, 324)
+
+function blank(): Throw {
+  return { kind: "numeral", value: 0, delayMs: 0, bandT: 0, apex: 0 }
+}
+
+/**
+ * Run the director against a model of the world and report live-object density
+ * per second. `flight` is how long a thrown object stays cuttable — 1.8s is
+ * what a 320×568 phone actually produces, the harshest case.
+ */
+function density(
+  seconds: number,
+  flight = 1.8,
+  seed = 7,
+): { perSecond: number[]; min: number; firstRushAt: number } {
+  const d = new Director(new Rng(seed), POOL)
+  const out = Array.from({ length: 24 }, blank)
+  const alive: number[] = [] // remaining life of each live body
+  const perSecond: number[] = []
+  let min = Infinity
+  let firstRushAt = Infinity
+  let acc = 0
+  let samples = 0
+  let sum = 0
+
+  const dt = 1 / 60
+  for (let i = 0; i < seconds * 60; i++) {
+    for (let k = alive.length - 1; k >= 0; k--) {
+      const v = (alive[k] as number) - dt
+      if (v <= 0) alive.splice(k, 1)
+      else alive[k] = v
+    }
+    const n = d.step(dt, out, alive.length)
+    for (let k = 0; k < n; k++) {
+      const t = out[k] as Throw
+      // A sigil is answerable, not sliceable-and-gone; it is not part of the
+      // density the floor promises, so it is not counted.
+      if (t.kind !== "sigil") alive.push(flight)
+    }
+    if (d.rushLeft > 0 && firstRushAt === Infinity) firstRushAt = d.elapsed
+    // Ignore the first half second: the very first wave is still in the air.
+    if (i > 30) min = Math.min(min, alive.length)
+    sum += alive.length
+    samples++
+    acc += dt
+    if (acc >= 1) {
+      acc -= 1
+      perSecond.push(sum / samples)
+      sum = 0
+      samples = 0
+    }
+  }
+  return { perSecond, min, firstRushAt }
+}
+
+test("the field is never empty, on the harshest viewport, for five minutes", () => {
+  for (const seed of [1, 7, 99, 12345]) {
+    const { min } = density(300, 1.8, seed)
+    assert.ok(min >= 3, `seed ${seed}: field dropped to ${min} live objects`)
+  }
+})
+
+test("a child is juggling five objects by second ten, not second eighty", () => {
+  const { perSecond } = density(60)
+  const atTen = perSecond[9] as number
+  assert.ok(atTen >= 5, `only ${atTen.toFixed(1)} objects at t=10s`)
+  const firstMinute = perSecond.reduce((a, b) => a + b, 0) / perSecond.length
+  assert.ok(firstMinute >= 6, `first-minute average was ${firstMinute.toFixed(1)} objects`)
+})
+
+test("the first market rush lands inside the first half minute", () => {
+  for (const seed of [1, 7, 99]) {
+    const { firstRushAt } = density(90, 1.8, seed)
+    assert.ok(firstRushAt <= 26, `seed ${seed}: first rush at ${firstRushAt.toFixed(1)}s`)
+  }
+})
+
+test("density climbs across a twenty-minute session and never collapses", () => {
+  const { perSecond } = density(1200)
+  const mean = (a: number[]): number => a.reduce((x, y) => x + y, 0) / a.length
+  const early = mean(perSecond.slice(10, 60))
+  const late = mean(perSecond.slice(1000, 1190))
+  assert.ok(late > early, `late ${late.toFixed(1)} must beat early ${early.toFixed(1)}`)
+  for (let i = 0; i < perSecond.length; i++) {
+    assert.ok((perSecond[i] as number) >= 3, `second ${i} averaged ${perSecond[i]}`)
+  }
+})
+
+test("questions arrive at least twice as often as the old build's 10.6s", () => {
+  const d = new Director(new Rng(3), POOL)
+  const out = Array.from({ length: 24 }, blank)
+  let sigils = 0
+  for (let i = 0; i < 60 * 300; i++) {
+    const n = d.step(1 / 60, out, 8)
+    for (let k = 0; k < n; k++) if ((out[k] as Throw).kind === "sigil") sigils++
+  }
+  const gap = 300 / sigils
+  assert.ok(gap <= 5.2, `a sigil every ${gap.toFixed(1)}s`)
+})
+
+test("a refused sigil is retried, never dropped", () => {
+  const d = new Director(new Rng(3), POOL)
+  const out = Array.from({ length: 24 }, blank)
+  let sigils = 0
+  let refusals = 0
+  for (let i = 0; i < 60 * 120; i++) {
+    const n = d.step(1 / 60, out, 8)
+    for (let k = 0; k < n; k++) {
+      if ((out[k] as Throw).kind !== "sigil") continue
+      sigils++
+      // Refuse every other one, as a live question would.
+      if (sigils % 2 === 0) {
+        refusals++
+        d.sigilRefused()
+      }
+    }
+  }
+  assert.ok(refusals > 5, "the test did not exercise refusal")
+  // With half of them refused and retried within half a second, the offered
+  // rate must stay far above the scheduled rate — that is the whole point.
+  assert.ok(sigils >= 30, `only ${sigils} sigils offered in two minutes`)
+})
+
+test("every value the director can throw is legible: three digits, integer", () => {
+  const d = new Director(new Rng(11), POOL)
+  const out = Array.from({ length: 24 }, blank)
+  const seen = new Set<number>()
+  for (let i = 0; i < 60 * 1200; i++) {
+    const n = d.step(1 / 60, out, 6)
+    for (let k = 0; k < n; k++) {
+      const t = out[k] as Throw
+      if (t.kind !== "numeral") continue
+      seen.add(t.value)
+    }
+  }
+  assert.ok(seen.size > 60, `only ${seen.size} distinct values in twenty minutes`)
+  for (const v of seen) {
+    assert.ok(Number.isInteger(v), `${v} is not an integer`)
+    assert.ok(v >= 2 && v <= 999, `${v} is out of the legible band`)
+    assert.ok(String(v).length <= 3, `${v} is four digits`)
+  }
+})
+
+test("the cascade gets deeper over a long run", () => {
+  const d = new Director(new Rng(11), POOL)
+  const out = Array.from({ length: 24 }, blank)
+  let earlyMax = 0
+  let lateMax = 0
+  for (let i = 0; i < 60 * 900; i++) {
+    const n = d.step(1 / 60, out, 6)
+    for (let k = 0; k < n; k++) {
+      const t = out[k] as Throw
+      if (t.kind !== "numeral") continue
+      const w = omega(t.value)
+      if (d.elapsed < 30) earlyMax = Math.max(earlyMax, w)
+      else if (d.elapsed > 600) lateMax = Math.max(lateMax, w)
+    }
+  }
+  assert.ok(lateMax > earlyMax, `late omega ${lateMax} must beat early ${earlyMax}`)
+})
+
+test("a rush is always a reward: no bombs, ever", () => {
+  const d = new Director(new Rng(4), POOL)
+  const out = Array.from({ length: 24 }, blank)
+  let rushFrames = 0
+  for (let i = 0; i < 60 * 600; i++) {
+    const n = d.step(1 / 60, out, 6)
+    const inRush = d.rushLeft > 0
+    if (inRush) rushFrames++
+    for (let k = 0; k < n; k++) {
+      if (inRush) assert.notEqual((out[k] as Throw).kind, "bomb", "a bomb during a rush")
+    }
+  }
+  assert.ok(rushFrames > 60 * 40, "the test did not see enough rush")
+})
+
+test("rushes get longer and closer together, forever", () => {
+  const d = new Director(new Rng(4), POOL)
+  const out = Array.from({ length: 24 }, blank)
+  const lengths: number[] = []
+  let cur = 0
+  for (let i = 0; i < 60 * 1200; i++) {
+    d.step(1 / 60, out, 6)
+    if (d.rushLeft > 0) cur += 1 / 60
+    else if (cur > 0) {
+      lengths.push(cur)
+      cur = 0
+    }
+  }
+  assert.ok(lengths.length >= 8, `only ${lengths.length} rushes in twenty minutes`)
+  assert.ok(
+    (lengths.at(-1) as number) > (lengths[0] as number) + 1,
+    `last rush ${lengths.at(-1)}s vs first ${lengths[0]}s`,
+  )
+})


### PR DESCRIPTION
## What

Land THE SPLIT's pacing rewrite, salvaged from a worktree where it existed on no
remote and in no PR.

## Why

Auditing the repo's worktrees turned up **51 holding work that is not on any
remote** — 864 uncommitted files and 45 unpushed commits. Triaging those, almost
all of it is stale: branches whose content already reached `main` through a
squash-merge, so the local commits differ only by SHA.

**This commit is the exception.** It is real, finished, unmerged work, and
`main` has never seen it.

THE SPLIT shipped in #556 with pacing a judge pass found wanting: the field
could sit empty, the ramp was slow enough that a child was juggling five objects
around second **eighty** rather than second ten, and questions arrived every
10.6 seconds. This rewrites the director around the game's economy instead of a
timer, tightens label hygiene, and adds a 10-test suite that pins the result:

```
the field is never empty, on the harshest viewport, for five minutes
a child is juggling five objects by second ten, not second eighty
the first market rush lands inside the first half minute
density climbs across a twenty-minute session and never collapses
questions arrive at least twice as often as the old build's 10.6s
a refused sigil is retried, never dropped
every value the director can throw is legible: three digits, integer
the cascade gets deeper over a long run
a rush is always a reward: no bombs, ever
rushes get longer and closer together, forever
```

Those are **playability** assertions, which is the right shape for a product
whose claim is that the fun *is* the pedagogy. A slow, empty field is a
correctness bug there, not a polish item.

## How it was recovered

The commit sat on a slice branch based at #558. `mount.ts` and `director.ts` had
both moved on `main` since, so this is a real 3-way `git cherry-pick`, not a file
copy — git auto-merged both files with no conflict, and the gates below are run
against the merged result on today's `main`.

Worth recording, because it nearly went the other way: my first triage compared
each candidate commit against `main` with `git diff origin/main <sha> -- $files`
and reported **all five candidates identical**. That was wrong — the shell
expansion of a multi-line file list was broken, so the diff was empty for the
wrong reason and every candidate looked already-merged. Comparing **blob hashes
per file** showed `director.test.ts` is absent from `main` entirely. The other
four candidates (forge, stack, found-physics, dwqa) really are superseded; those
worktrees can be pruned.

## Blast radius

**Areas touched:** dynawalla, one game — `dynawalla/games/slice/`.

- [x] Scope: 0 files outside `dynawalla/games/slice/`, 0 deletions. 4 files.
- [x] Covered by the `dynawalla-packs · games + pack build` job.
- [x] **The pack is unaffected.** No manifest, capability, entry or version
      change; `slice` still builds, checks and stages. The commit predates
      packaging, but the cherry-pick carries only its own 4-file diff, so
      `pack.json`, `pack.html`, `src/pack.ts` and `vite.pack.config.ts` are
      untouched. Verified against the real builder below.
- [x] **Curriculum.** No skill id, grade, binding or generator changed. The
      director chooses *when* to ask, never *what* — the host still owns the
      mathematics.
- [x] **Native integrity.** No Rust, no `src-tauri`, no `links =`.
- [x] **Strings.** None added.
- [x] **Secrets.** `gitleaks` → no leaks found.

## Proof

Tests **×5**, because one green run is not proof — a sibling game passed once
then failed 3 of the next 5 from unseeded `Math.random`. 40 passing, up from 25:

```
# pass 40 # fail 0   <- 1
# pass 40 # fail 0   <- 2
# pass 40 # fail 0   <- 3
# pass 40 # fail 0   <- 4
# pass 40 # fail 0   <- 5

$ npm run tsc
0 errors
$ npm run build
✓ built
```

The pack still builds, validates and stages on today's `main`:

```
$ node dynawalla/packs/build.mjs slice
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
1 pack(s) built, checked and staged into src-tauri/packs/
```

```
$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
no leaks found

$ git diff --name-only origin/main...HEAD
dynawalla/games/slice/src/mount.ts
dynawalla/games/slice/src/sim/body.ts
dynawalla/games/slice/src/sim/director.ts
dynawalla/games/slice/src/test/director.test.ts
```
