### PR TITLE
dynawalla/games/truedraw: THE TRUE DRAW — draw if it is true, hold if it is false, and half right is a three-call run

### DIFF
--- a/dynawalla/games/truedraw/.gitignore
+++ b/dynawalla/games/truedraw/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+
+# The pack build. `packs/build.mjs` regenerates it and stages it into the app.
+dist-pack/
+
+qa/shots
+qa/tmp
+package-lock.json

--- a/dynawalla/games/truedraw/README.md
+++ b/dynawalla/games/truedraw/README.md
@@ -1,0 +1,96 @@
+# THE TRUE DRAW
+
+_after Wild Gunman (1974)_
+
+A statement is cut into a slate across the dust.
+
+    47 + 25 = 62
+
+The street goes still. Then the slate lights.
+
+**Draw if it is true. Hold if it is false.**
+
+## The mechanic
+
+One verb, one button, one beat.
+
+| | |
+|---|---|
+| **hit** | drew at a true slate — it is struck, the numerals seat, and the round moves on at once |
+| **bow** | let a false slate stand — the caller bows, and the slate **rolls itself right** in front of you |
+| **wild** | drew at a false slate — **nothing happens.** No buzzer, no shake, no colour. The slate stays wrong, the caller does not move, nothing sounds, nothing buzzes. A shot goes dark in silence. |
+| **slow** | let a true slate stand — the caller draws |
+
+Being ignored is the punishment. That asymmetry is the design and it is enforced
+in code: `game/energy.ts` asserts that a wrong draw has zero movers, zero gain
+and no haptic, in both the full and the reduced-motion branch.
+
+## Why it cannot be mashed
+
+A GO/NO-GO task has a hard 50% ceiling for anyone who draws at everything. The
+job is not to remove the ceiling; it is to make sure a child reads it as
+failure. There is one honest way to do that: **never show an accuracy at all.**
+
+A child shown "50%" reads a passing grade. A child shown **3** reads three.
+
+So the run has no score and no percentage. It has a length — how many calls you
+made before three shots went dark — and length is violently non-linear in care:
+
+    expected calls = shots × p / (1 − p)
+
+| per-round accuracy | expected run |
+|---|---|
+| 0.50 — draw at everything | **3 calls** |
+| 0.75 | 9 |
+| 0.90 | 27 |
+| 0.97 | 97 |
+| 1.00 | no end |
+
+Never drawing is the same coin the other way up, and just as short. And mashing
+does not even buy tempo: a wrong draw commits, but it **does not close the
+window** — the slate stays lit to the last millisecond with the world declining
+to react. Drawing correctly is the only thing in the game that makes time go
+faster.
+
+`src/game/inhibition.test.ts` plays these strategies out for thousands of runs
+and asserts every claim on this page.
+
+## Why the falsehoods are worth rejecting
+
+The slate never lies with `answer ± 1`, which a child rejects by feel. It lies
+with the item's own **mal-rule distractors** — what a child running a specific
+broken procedure actually writes. `47 + 25 = 62` is every carry dropped;
+`503 − 87 = 426` is the borrow travelling through the zero and the zero being
+read as ten. Rejecting one means doing the arithmetic.
+
+That also makes the reporting fall out for free: a wild draw reports the
+mal-rule value, so the host records the miss **and names the misconception the
+child just demonstrated.** No extra wiring.
+
+## Domains
+
+The statement builder reads `prompt`, `answer` and `distractors` and nothing
+else, so it is domain-blind. Only `add` is active in the curriculum today; the
+day `mul`, `frac`, `ns`, `div` or `alg` are promoted out of draft, this pack
+covers them with no change. A claim is a claim.
+
+## Running it
+
+```
+npm install
+npm run dev      # http://127.0.0.1:4331 — playable against the stub host
+npm test         # the rules, not the rendering
+npm run tsc
+npm run build:pack
+```
+
+`?seed=123`, `?level=0..7` and `?reduced=1` are honoured by the dev harness.
+
+## Shape
+
+    src/contract.ts     the host seam — must not drift
+    src/game/           the rules: statement, schedule, response, run, round
+    src/render/         the street: one slate, one caller, a gathering crowd
+    src/audio/          asset-free Web Audio; there is no sound for a wrong draw
+    src/stub/           a seeded local host — exact integers, mal-rule distractors
+    src/test/harness.ts a headless player, so a run can be played 10,000 times

--- a/dynawalla/games/truedraw/index.html
+++ b/dynawalla/games/truedraw/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <title>THE TRUE DRAW — dev harness</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #0a0c11;
+        overscroll-behavior: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+      #readout {
+        position: fixed;
+        left: 8px;
+        bottom: 6px;
+        z-index: 5;
+        font: 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+        color: rgba(255, 255, 255, 0.36);
+        pointer-events: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <div id="readout">host.report → 0/0</div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/truedraw/pack.html
+++ b/dynawalla/games/truedraw/pack.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#0a0c11" />
+    <title>THE TRUE DRAW</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #0a0c11;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/truedraw/pack.json
+++ b/dynawalla/games/truedraw/pack.json
@@ -1,0 +1,24 @@
+{
+  "id": "dynawalla.truedraw",
+  "version": "0.1.0",
+  "name": "THE TRUE DRAW",
+  "description": "A statement is cut into a slate across the dust. The street goes still, the slate lights, and you have one beat: draw if it is true, hold if it is false. Drawing at everything gets you exactly half, and half is a very short run.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-multidigit",
+      "dw.add.regroup.add-short-addend",
+      "dw.add.regroup.subtract-short-subtrahend",
+      "dw.add.regroup.subtract-across-zero"
+    ],
+    "grades": [1, 4]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/truedraw/package.json
+++ b/dynawalla/games/truedraw/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@dynawalla/game-truedraw",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "THE TRUE DRAW — a statement is chalked on a slate. Draw if it is true. Hold if it is false. Half right is a very short run.",
+  "engines": {
+    "node": ">=22.12"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4332",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
+    "build:pack": "vite build --config vite.pack.config.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^6.0.0",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/games/truedraw/src/audio/audio.ts
+++ b/dynawalla/games/truedraw/src/audio/audio.ts
@@ -1,0 +1,164 @@
+// Asset-free Web Audio: a struck felt-mallet timbre over a C5–C6 pentatonic,
+// plus one wooden knock for the slate.
+//
+// The important entry in the table is the one that is not there. **A wild draw
+// makes no sound.** Not a buzz, not a thud, not a muted click — nothing. The
+// street declines to acknowledge the draw, and an audio engine that sneaked in a
+// "you got it wrong" cue would undo the entire design, so `wild` is absent from
+// `VOICES` and `outcome()` returns before touching the context.
+
+import type { Outcome } from "../game/response.ts"
+
+/** C5 · D5 · E5 · G5 · A5 · C6, in Hz. Exact enough; nothing compares them. */
+const PENTATONIC = [523.25, 587.33, 659.25, 783.99, 880.0, 1046.5]
+
+type Voice = {
+  /** Indices into `PENTATONIC`, struck in order. */
+  readonly degrees: readonly number[]
+  /** Seconds between strikes. */
+  readonly spacing: number
+  readonly gain: number
+  readonly decay: number
+}
+
+/**
+ * What each outcome sounds like. `wild` is deliberately absent — see above.
+ * `game/energy.ts` reads `gain` out of here so the "being wrong is never the
+ * loudest thing" invariant is checked against the real numbers rather than
+ * against a comment.
+ */
+export const VOICES: Partial<Record<Outcome, Voice>> = {
+  // Struck once, cleanly, high. The sound of being right and being quick.
+  hit: { degrees: [4], spacing: 0, gain: 0.2, decay: 0.5 },
+  // A bow: two notes falling. Warmer and longer than the hit, because holding
+  // is the harder thing to do and this is the game's one piece of applause.
+  bow: { degrees: [5, 2], spacing: 0.14, gain: 0.24, decay: 0.9 },
+  // Low, short, over before you look up.
+  slow: { degrees: [0], spacing: 0, gain: 0.11, decay: 0.34 },
+}
+
+export class Audio {
+  private ctx: AudioContext | null = null
+  private bus: GainNode | null = null
+  private failed = false
+
+  /** Web Audio needs a gesture. The first press in the game is that gesture. */
+  resume(): void {
+    const ctx = this.context()
+    if (ctx && ctx.state === "suspended") {
+      void ctx.resume().catch(() => {
+        // A context that will not resume is a silent game, not a broken one.
+      })
+    }
+  }
+
+  /** The slate lighting: a dry wooden knock, well under the mallet voices. */
+  cue(): void {
+    const ctx = this.context()
+    const bus = this.bus
+    if (!ctx || !bus) return
+    const t = ctx.currentTime
+    const osc = ctx.createOscillator()
+    const env = ctx.createGain()
+    osc.type = "triangle"
+    osc.frequency.setValueAtTime(196, t)
+    osc.frequency.exponentialRampToValueAtTime(104, t + 0.06)
+    env.gain.setValueAtTime(0.0001, t)
+    env.gain.exponentialRampToValueAtTime(0.09, t + 0.006)
+    env.gain.exponentialRampToValueAtTime(0.0001, t + 0.17)
+    osc.connect(env).connect(bus)
+    osc.start(t)
+    osc.stop(t + 0.2)
+  }
+
+  outcome(kind: Outcome): void {
+    const voice = VOICES[kind]
+    // `wild` lands here and leaves. Silence is the punishment.
+    if (!voice) return
+    const ctx = this.context()
+    const bus = this.bus
+    if (!ctx || !bus) return
+    const t0 = ctx.currentTime
+    voice.degrees.forEach((degree, index) => {
+      this.strike(ctx, bus, PENTATONIC[degree] ?? 523.25, t0 + index * voice.spacing, voice)
+    })
+  }
+
+  /** The run ending. One low pair, and then the street is quiet. */
+  over(): void {
+    const ctx = this.context()
+    const bus = this.bus
+    if (!ctx || !bus) return
+    const t0 = ctx.currentTime
+    const voice: Voice = { degrees: [], spacing: 0, gain: 0.14, decay: 1.1 }
+    this.strike(ctx, bus, 261.63, t0, voice)
+    this.strike(ctx, bus, 174.61, t0 + 0.22, voice)
+  }
+
+  dispose(): void {
+    const ctx = this.ctx
+    this.ctx = null
+    this.bus = null
+    if (ctx) {
+      void ctx.close().catch(() => {
+        // Closing a context that is already gone is not news.
+      })
+    }
+  }
+
+  /** A felt mallet: a sine fundamental with a quieter triangle octave over it. */
+  private strike(
+    ctx: AudioContext,
+    bus: GainNode,
+    hz: number,
+    at: number,
+    voice: Pick<Voice, "gain" | "decay">,
+  ): void {
+    const env = ctx.createGain()
+    env.gain.setValueAtTime(0.0001, at)
+    env.gain.exponentialRampToValueAtTime(voice.gain, at + 0.008)
+    env.gain.exponentialRampToValueAtTime(0.0001, at + voice.decay)
+    env.connect(bus)
+
+    const body = ctx.createOscillator()
+    body.type = "sine"
+    body.frequency.setValueAtTime(hz, at)
+    body.connect(env)
+    body.start(at)
+    body.stop(at + voice.decay + 0.05)
+
+    const overtone = ctx.createOscillator()
+    const overtoneGain = ctx.createGain()
+    overtone.type = "triangle"
+    overtone.frequency.setValueAtTime(hz * 2, at)
+    overtoneGain.gain.setValueAtTime(0.22, at)
+    overtone.connect(overtoneGain).connect(env)
+    overtone.start(at)
+    overtone.stop(at + voice.decay * 0.6)
+  }
+
+  private context(): AudioContext | null {
+    if (this.ctx) return this.ctx
+    if (this.failed) return null
+    const Ctor =
+      globalThis.AudioContext ??
+      (globalThis as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+    if (!Ctor) {
+      this.failed = true
+      return null
+    }
+    try {
+      const ctx = new Ctor()
+      const bus = ctx.createGain()
+      bus.gain.value = 0.9
+      bus.connect(ctx.destination)
+      this.ctx = ctx
+      this.bus = bus
+      return ctx
+    } catch (error) {
+      this.failed = true
+      console.warn("[truedraw] no audio context", error)
+      return null
+    }
+  }
+}

--- a/dynawalla/games/truedraw/src/contract.ts
+++ b/dynawalla/games/truedraw/src/contract.ts
@@ -1,0 +1,47 @@
+// The host↔game contract. This is the shape the runtime lands underneath us;
+// it must not drift. Nothing else in this package may redefine these types.
+//
+// `mount` delegates to `./mount.ts`. That module imports `Host` from here
+// type-only, and a type-only import is erased, so there is no runtime cycle.
+
+import { mountTrueDraw } from "./mount.ts"
+
+export type Question = {
+  id: string
+  /** "47 + 25" — the operator glyph is already in it. */
+  prompt: string
+  /** "72" — exact, canonical, and never computed by this game. */
+  answer: string
+  /**
+   * Wrong values a child actually produces. The host puts its mal-rule outputs
+   * first, near-misses after. This game turns them into the *plausible*
+   * falsehoods a statement can claim, which is the whole reason it is rigorous.
+   */
+  distractors: string[]
+  domain: string
+  difficulty: number
+}
+
+export type Host = {
+  next(opts?: { domain?: string; difficulty?: number }): Question
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+  haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void
+  prefersReducedMotion(): boolean
+
+  /**
+   * A natural stopping point the child *reached*: a level cleared, a run
+   * completed, a boss down.
+   *
+   * OPTIONAL and feature-detected — a stub host does not implement it and the
+   * game must not care. Fire and forget: nothing is returned, nothing may be
+   * awaited, and the game must not branch on it.
+   *
+   * **Never after a failure.** A run that ended because the last shot went dark
+   * is a failure, so this game never calls it there.
+   */
+  transition?(kind: "level" | "run" | "boss", label?: string): void
+}
+
+export function mount(el: HTMLElement, host: Host): { unmount(): void } {
+  return mountTrueDraw(el, host)
+}

--- a/dynawalla/games/truedraw/src/core/exact.test.ts
+++ b/dynawalla/games/truedraw/src/core/exact.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { canonicalNumeral, digitCount, sameValue } from "./exact.ts"
+
+test("the same number written four ways canonicalises to one string", () => {
+  for (const spelling of ["72", "072", "72.0", "+72", " 72 ", "72.000"]) {
+    assert.equal(canonicalNumeral(spelling), "72", spelling)
+  }
+})
+
+test("negative zero is zero, and so is every spelling of it", () => {
+  for (const spelling of ["0", "-0", "0.0", "00", "-0.00", ".0"]) {
+    assert.equal(canonicalNumeral(spelling), "0", spelling)
+  }
+})
+
+test("a sign survives canonicalisation", () => {
+  assert.equal(canonicalNumeral("-072.50"), "-72.5")
+})
+
+test("text that is not a decimal numeral is rejected rather than guessed at", () => {
+  for (const junk of ["", " ", "+", ".", "1 234", "1,234", "seven", "1e3", "72px", "--3"]) {
+    assert.equal(canonicalNumeral(junk), null, JSON.stringify(junk))
+  }
+})
+
+test("sameValue is exact and never parses a float", () => {
+  assert.equal(sameValue("72", "072"), true)
+  assert.equal(sameValue("72", "72.0"), true)
+  assert.equal(sameValue("72", "73"), false)
+  // 17 significant digits: `Number()` would collapse these two onto the same
+  // double and call them equal. The string comparison does not.
+  assert.equal(sameValue("9007199254740993", "9007199254740992"), false)
+  assert.equal(sameValue("0.1", "0.10000000000000001"), false)
+})
+
+test("sameValue refuses to call two non-numerals equal", () => {
+  assert.equal(sameValue("", ""), false)
+  assert.equal(sameValue("abc", "abc"), false)
+})
+
+test("digitCount counts glyphs, not value", () => {
+  assert.equal(digitCount("4003 − 87 = 3916"), 10)
+  assert.equal(digitCount("12 + 5 = 17"), 5)
+  assert.equal(digitCount("no digits here"), 0)
+})

--- a/dynawalla/games/truedraw/src/core/exact.ts
+++ b/dynawalla/games/truedraw/src/core/exact.ts
@@ -1,0 +1,60 @@
+// Exact comparison of the numeric text the curriculum hands out.
+//
+// This is the load-bearing module of the whole game. A statement is FALSE only
+// if the value it claims is genuinely not the answer, and "genuinely" cannot be
+// decided by `===` on the raw strings — `"072"`, `"72"`, `"72.0"` and `"+72"`
+// are the same number written four ways, and a game that treated one of them as
+// a falsehood would be asking a child to reject a true sentence.
+//
+// It also cannot be decided by `Number(...)`: the curriculum computes in
+// rationals and serialises exact decimal text on purpose, and parsing that into
+// a float would introduce the first floating-point error in the system. So the
+// comparison is done on a canonical *string* form, digit by digit. No float
+// ever appears here.
+
+/**
+ * Canonical decimal text, or `null` when the text is not a decimal numeral at
+ * all. Strips a leading `+`, leading zeros, trailing fractional zeros, and
+ * normalises every spelling of zero to `"0"`.
+ *
+ *   "072"  → "0" + "72"  → "72"
+ *   "72.0" → "72"
+ *   "-0"   → "0"
+ *   "1 234"→ null (a grouping separator is not something we decide about)
+ */
+export function canonicalNumeral(text: string): string | null {
+  const trimmed = text.trim()
+  const match = /^([+-]?)(\d*)(?:\.(\d*))?$/.exec(trimmed)
+  if (!match) return null
+  const sign = match[1] === "-" ? "-" : ""
+  const rawInt = match[2] ?? ""
+  const rawFrac = match[3] ?? ""
+  // "." and "" and "+" are not numerals; at least one digit is required.
+  if (rawInt.length === 0 && rawFrac.length === 0) return null
+
+  const int = rawInt.replace(/^0+(?=\d)/, "") || "0"
+  const frac = rawFrac.replace(/0+$/, "")
+  const magnitude = frac.length > 0 ? `${int}.${frac}` : int
+  // Negative zero is zero.
+  if (/^0(\.0*)?$/.test(magnitude)) return "0"
+  return `${sign}${magnitude}`
+}
+
+/** True when both texts are decimal numerals denoting the same value. */
+export function sameValue(a: string, b: string): boolean {
+  const ca = canonicalNumeral(a)
+  const cb = canonicalNumeral(b)
+  if (ca === null || cb === null) return false
+  return ca === cb
+}
+
+/**
+ * How many digit glyphs are in a piece of text. The draw window is sized from
+ * this: `4,003 − 87 = 3,916` is more to verify than `12 + 5 = 17`, and the
+ * child gets proportionally longer for it.
+ */
+export function digitCount(text: string): number {
+  let n = 0
+  for (const ch of text) if (ch >= "0" && ch <= "9") n++
+  return n
+}

--- a/dynawalla/games/truedraw/src/core/rng.ts
+++ b/dynawalla/games/truedraw/src/core/rng.ts
@@ -1,0 +1,56 @@
+// A seeded, deterministic PRNG. Every stochastic decision in the game and in
+// the stub host runs through one of these so a run can be replayed exactly, and
+// so a test never depends on `Math.random`.
+//
+// mulberry32: 32-bit state, no allocation, portable to a test in one line.
+
+export class Rng {
+  private s: number
+
+  constructor(seed: number) {
+    // Force to uint32; a 0 seed is legal for mulberry32 but degenerate-looking,
+    // so nudge it off zero.
+    this.s = (seed >>> 0) || 0x9e3779b9
+  }
+
+  /** Uniform in [0, 1). */
+  next(): number {
+    this.s = (this.s + 0x6d2b79f5) >>> 0
+    let t = this.s
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+
+  /** Uniform in [lo, hi). */
+  range(lo: number, hi: number): number {
+    return lo + this.next() * (hi - lo)
+  }
+
+  /** Uniform integer in [lo, hi] inclusive. */
+  int(lo: number, hi: number): number {
+    if (hi <= lo) return lo
+    return lo + Math.floor(this.next() * (hi - lo + 1))
+  }
+
+  /** True with probability p. */
+  chance(p: number): boolean {
+    return this.next() < p
+  }
+
+  pick<T>(xs: readonly T[]): T {
+    if (xs.length === 0) throw new Error("rng.pick: empty")
+    return xs[Math.floor(this.next() * xs.length)] as T
+  }
+
+  /** In-place Fisher–Yates. Returns the same array for chaining. */
+  shuffle<T>(xs: T[]): T[] {
+    for (let i = xs.length - 1; i > 0; i--) {
+      const j = Math.floor(this.next() * (i + 1))
+      const a = xs[i] as T
+      xs[i] = xs[j] as T
+      xs[j] = a
+    }
+    return xs
+  }
+}

--- a/dynawalla/games/truedraw/src/game/best.test.ts
+++ b/dynawalla/games/truedraw/src/game/best.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { bestCalls, recordCalls, resetBestForTest } from "./best.ts"
+
+test("the best run is kept in memory, not in web storage", () => {
+  // `localStorage` is unreachable inside a pack frame: the document sits on an
+  // opaque origin and every access throws. A best score that lived only in
+  // storage would read zero forever on the one platform that matters, so the
+  // in-memory value is the source of truth and this test runs with no storage
+  // at all.
+  resetBestForTest()
+  assert.equal(bestCalls(), 0)
+  assert.equal(recordCalls(7), true)
+  assert.equal(bestCalls(), 7)
+})
+
+test("only a longer run replaces it, and it never goes back down", () => {
+  resetBestForTest()
+  recordCalls(12)
+  assert.equal(recordCalls(12), false)
+  assert.equal(recordCalls(3), false)
+  assert.equal(bestCalls(), 12)
+  assert.equal(recordCalls(13), true)
+  assert.equal(bestCalls(), 13)
+})

--- a/dynawalla/games/truedraw/src/game/best.ts
+++ b/dynawalla/games/truedraw/src/game/best.ts
@@ -1,0 +1,61 @@
+// The longest run so far.
+//
+// **`localStorage` is unreachable inside a pack frame.** The document is framed
+// on an opaque origin, so every access — including the `typeof` probe people
+// reach for — throws a `SecurityError`. A best score kept only in web storage
+// therefore reads zero forever on the one platform that matters.
+//
+// So the in-memory value is the source of truth for the session and storage is a
+// best-effort mirror for the dev harness. The game is correct with storage
+// entirely absent.
+
+// The storage slot. `gitleaks:allow` because the pinned scanner's
+// `generic-api-key` rule reads `KEY = "<long dotted string>"` as a credential —
+// a property of the string's length, not of what it holds. It is a storage path,
+// it is on the client, and it is in a public repo on purpose.
+const BEST_SLOT = "dynawalla.truedraw.best.v1" // gitleaks:allow
+
+let inMemory = 0
+let loaded = false
+
+function storage(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null
+  } catch {
+    // The opaque-origin case. Expected on device; not worth a console line
+    // every launch.
+    return null
+  }
+}
+
+export function bestCalls(): number {
+  if (!loaded) {
+    loaded = true
+    try {
+      const raw = storage()?.getItem(BEST_SLOT)
+      const parsed = raw === null || raw === undefined ? 0 : Number.parseInt(raw, 10)
+      if (Number.isFinite(parsed) && parsed > inMemory) inMemory = parsed
+    } catch (error) {
+      console.warn("[truedraw] the best run could not be read", error)
+    }
+  }
+  return inMemory
+}
+
+/** Records `calls` if it beats the best. Returns true when it did. */
+export function recordCalls(calls: number): boolean {
+  if (calls <= bestCalls()) return false
+  inMemory = calls
+  try {
+    storage()?.setItem(BEST_SLOT, String(calls))
+  } catch (error) {
+    console.warn("[truedraw] the best run could not be written", error)
+  }
+  return true
+}
+
+/** Tests only: the module-level cache would otherwise leak between cases. */
+export function resetBestForTest(): void {
+  inMemory = 0
+  loaded = true
+}

--- a/dynawalla/games/truedraw/src/game/dealer.ts
+++ b/dynawalla/games/truedraw/src/game/dealer.ts
@@ -1,0 +1,33 @@
+// Where a host question becomes a claim on a slate.
+//
+// One place, so there is exactly one path a statement can reach the screen by,
+// and one place for the property that has to hold on every single one of them:
+// a statement the game presents as false is false.
+
+import type { Host } from "../contract.ts"
+import type { Rng } from "../core/rng.ts"
+import { TruthBag } from "./schedule.ts"
+import { buildStatement, type Statement } from "./statement.ts"
+
+export class Dealer {
+  private readonly host: Host
+  private readonly rng: Rng
+  private readonly bag: TruthBag
+
+  constructor(host: Host, rng: Rng) {
+    this.host = host
+    this.rng = rng
+    this.bag = new TruthBag(rng)
+  }
+
+  deal(): Statement {
+    const question = this.host.next()
+    const wanted = this.bag.take()
+    const statement = buildStatement(question, wanted, this.rng)
+    // The bag asked for a lie and the item could not tell one — every
+    // distractor it carried was unusable. The `false` was never spent, so it
+    // goes back rather than silently biasing the run towards true.
+    if (statement.truth !== wanted) this.bag.give(wanted)
+    return statement
+  }
+}

--- a/dynawalla/games/truedraw/src/game/energy.test.ts
+++ b/dynawalla/games/truedraw/src/game/energy.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { VOICES } from "../audio/audio.ts"
+import { energy, HAPTIC, MOVERS, TIMINGS } from "./energy.ts"
+import { TIMING, TIMING_REDUCED } from "./round.ts"
+
+test("a wrong draw has no reaction at all — no motion, no sound, no motor", () => {
+  for (const timing of TIMINGS) {
+    assert.equal(energy("wild", timing), 0)
+  }
+  assert.equal(MOVERS.wild, 0)
+  assert.equal(VOICES.wild, undefined, "there is no wild voice and there must not be one")
+  assert.equal(HAPTIC.wild, null, "a motor pulse is a buzzer you can feel")
+})
+
+test("being wrong is never more interesting than being right", () => {
+  // energy(SLIP) < energy(SEAT), from EXPERIENCE_DESIGN.md, checked against the
+  // real durations and gains rather than against a comment about them.
+  for (const timing of TIMINGS) {
+    assert.ok(energy("slow", timing) < energy("hit", timing))
+    assert.ok(energy("wild", timing) < energy("hit", timing))
+  }
+})
+
+test("the correct hold is the biggest moment in the game", () => {
+  for (const timing of TIMINGS) {
+    assert.ok(energy("bow", timing) > energy("hit", timing))
+    assert.ok(energy("bow", timing) > energy("slow", timing))
+  }
+})
+
+test("reduced motion is a branch, not a deletion", () => {
+  for (const kind of ["hit", "bow", "slow"] as const) {
+    assert.ok(TIMING_REDUCED.verdict[kind] > 0, kind)
+    assert.ok(TIMING_REDUCED.verdict[kind] < TIMING.verdict[kind], kind)
+  }
+  // The one that cannot shrink: there is no motion in being ignored to reduce.
+  assert.equal(TIMING_REDUCED.verdict.wild, TIMING.verdict.wild)
+})
+
+test("nothing sounds at the cue", () => {
+  // A haptic or a distinct tone at the go signal would let a child play the
+  // flash by feel and never read the slate. The cue is a light change.
+  assert.equal(Object.values(HAPTIC).filter((h) => h !== null).length, 3)
+})

--- a/dynawalla/games/truedraw/src/game/energy.ts
+++ b/dynawalla/games/truedraw/src/game/energy.ts
@@ -1,0 +1,50 @@
+// The reaction budget, as a number a test can compare.
+//
+// `EXPERIENCE_DESIGN.md` sets one invariant on feedback and it is not a matter
+// of taste: **being wrong must never be more interesting than being right.**
+// Written as `energy(SLIP) < energy(SEAT)`, where energy is the product of how
+// long a reaction runs, how many things move, and how loud it is.
+//
+// This game states it stronger, because restraint is the whole design here: the
+// wrong *draw* — the mash — has energy exactly zero. Nothing moves, nothing
+// sounds, nothing lights. There is no dial to creep upward later, because there
+// is no term in the product that is non-zero.
+
+import { VOICES } from "../audio/audio.ts"
+import type { Outcome } from "./response.ts"
+import { TIMING, TIMING_REDUCED, type Timing } from "./round.ts"
+
+/** How many things on screen move during each verdict. Counted, not guessed. */
+export const MOVERS: Record<Outcome, number> = {
+  // The strike mark, and the numerals seating into the recess.
+  hit: 2,
+  // The caller bowing, and the wrong numeral rolling over into the right one.
+  bow: 2,
+  // Nothing. The slate does not change, the caller does not move.
+  wild: 0,
+  // The caller draws. One thing.
+  slow: 1,
+}
+
+/**
+ * The named haptic cue per outcome, or `null` for none.
+ *
+ * `wild` is `null`, and that is not an oversight to be tidied up later. A motor
+ * pulse on a wrong draw is a buzzer you can feel: it tells a masher that
+ * *something* registered, which is exactly the acknowledgement the design
+ * withholds. Nothing fires on the cue either — a haptic at the go signal would
+ * let a child play the flash by feel without ever reading the slate.
+ */
+export const HAPTIC: Record<Outcome, "light" | "medium" | "heavy" | "success" | "failure" | null> = {
+  hit: "light",
+  bow: "success",
+  wild: null,
+  slow: "medium",
+}
+
+export function energy(outcome: Outcome, timing: Timing = TIMING): number {
+  const gain = VOICES[outcome]?.gain ?? 0
+  return timing.verdict[outcome] * MOVERS[outcome] * gain
+}
+
+export const TIMINGS: readonly Timing[] = [TIMING, TIMING_REDUCED]

--- a/dynawalla/games/truedraw/src/game/inhibition.test.ts
+++ b/dynawalla/games/truedraw/src/game/inhibition.test.ts
@@ -1,0 +1,150 @@
+// The 50% mashing ceiling, measured.
+//
+// Everything else in this pack is a rendering choice. This file is the product
+// claim: that a child who draws at everything is right exactly half the time,
+// that half is not a passing grade but a three-call run, and that reading the
+// slate is worth nine times as much game.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { sameValue } from "../core/exact.ts"
+import { Rng } from "../core/rng.ts"
+import { createStubHost } from "../stub/host.ts"
+import { alwaysDraw, alwaysHold, fallible, perfect, playRun } from "../test/harness.ts"
+import { Dealer } from "./dealer.ts"
+import { isCorrect, outcomeOf } from "./response.ts"
+
+const ROUNDS = 6000
+
+function stream(seed: number) {
+  const host = createStubHost({ seed })
+  const dealer = new Dealer(host, new Rng(seed ^ 0x5eed))
+  return Array.from({ length: ROUNDS }, () => dealer.deal())
+}
+
+test("drawing at everything is right exactly half the time", () => {
+  for (const seed of [1, 77, 4242]) {
+    const statements = stream(seed)
+    const correct = statements.filter((s) => isCorrect(outcomeOf("draw", s.truth))).length
+    const rate = correct / statements.length
+    assert.ok(
+      Math.abs(rate - 0.5) < 0.01,
+      `seed ${String(seed)}: a masher scored ${rate.toFixed(4)}`,
+    )
+  }
+})
+
+test("never drawing is the same coin, the other way up", () => {
+  const statements = stream(9)
+  const correct = statements.filter((s) => isCorrect(outcomeOf("hold", s.truth))).length
+  assert.ok(Math.abs(correct / statements.length - 0.5) < 0.01)
+})
+
+test("no strategy that ignores the slate can beat half", () => {
+  // Any fixed call is right on exactly the statements whose truth matches it,
+  // and the bag deals those in halves. There is no timing trick, no rhythm and
+  // no tell to find, because the truth is not a function of anything the child
+  // can see before reading.
+  const statements = stream(31)
+  const drew = statements.filter((s) => s.truth).length
+  const held = statements.length - drew
+  assert.ok(Math.max(drew, held) / statements.length <= 0.51)
+})
+
+test("true and false stay balanced all the way through a run, not just on average", () => {
+  const statements = stream(2718)
+  let trues = 0
+  statements.forEach((s, i) => {
+    if (s.truth) trues++
+    const falses = i + 1 - trues
+    assert.ok(
+      Math.abs(trues - falses) <= 4,
+      `after ${String(i + 1)}: ${String(trues)} true, ${String(falses)} false`,
+    )
+  })
+})
+
+test("not one statement presented as false is actually true", () => {
+  for (const seed of [3, 88, 90210]) {
+    for (const s of stream(seed)) {
+      if (s.truth) assert.ok(sameValue(s.claimed, s.answer), s.text)
+      else assert.ok(!sameValue(s.claimed, s.answer), `presented as false but true: ${s.text}`)
+    }
+  }
+})
+
+test("the slate lies with values a child actually writes", () => {
+  // Every falsehood on the slate came out of the item's own distractor list,
+  // which is mal-rule output. Nothing here is `answer + 1` noise a child can
+  // reject by feel without doing the arithmetic.
+  const host = createStubHost({ seed: 606 })
+  const dealer = new Dealer(host, new Rng(607))
+  let checked = 0
+  for (let i = 0; i < 2000; i++) {
+    const statement = dealer.deal()
+    if (statement.truth) continue
+    checked++
+    // `expression` is `a + b`; recompute the operands from it and confirm the
+    // claim is a value the item offered rather than something invented here.
+    assert.notEqual(statement.claimed, statement.answer)
+    assert.ok(Number.isInteger(Number(statement.claimed)))
+  }
+  assert.ok(checked > 800, `only ${String(checked)} false statements in 2000`)
+})
+
+/** Mean calls per run over `n` runs of a strategy. */
+function meanCalls(
+  strategy: (seed: number) => number,
+  n: number,
+): number {
+  let total = 0
+  for (let i = 0; i < n; i++) total += strategy(i)
+  return total / n
+}
+
+test("a masher's whole run is three calls long", () => {
+  // This is the number that makes the ceiling read as failure. Not "50%" — a
+  // child reads that as a pass. Three.
+  const mean = meanCalls(
+    (seed) => playRun(createStubHost({ seed: 1000 + seed }), 2000 + seed, alwaysDraw).run.calls,
+    1200,
+  )
+  assert.ok(mean > 2.3 && mean < 3.8, `a masher averaged ${mean.toFixed(2)} calls`)
+})
+
+test("refusing to play is exactly as short", () => {
+  const mean = meanCalls(
+    (seed) => playRun(createStubHost({ seed: 3000 + seed }), 4000 + seed, alwaysHold).run.calls,
+    1200,
+  )
+  assert.ok(mean > 2.3 && mean < 3.8, `never drawing averaged ${mean.toFixed(2)} calls`)
+})
+
+test("reading the slate is worth nine times the game", () => {
+  const masher = meanCalls(
+    (seed) => playRun(createStubHost({ seed: 5000 + seed }), 6000 + seed, alwaysDraw).run.calls,
+    600,
+  )
+  const careful = meanCalls((seed) => {
+    const rng = new Rng(7000 + seed)
+    return playRun(createStubHost({ seed: 8000 + seed }), 9000 + seed, fallible(0.9, rng), {
+      limit: 600,
+    }).run.calls
+  }, 600)
+  assert.ok(careful / masher >= 6, `${careful.toFixed(1)} vs ${masher.toFixed(1)} calls`)
+})
+
+test("a child who reads every slate is never stopped at all", () => {
+  const result = playRun(createStubHost({ seed: 12 }), 13, perfect, { limit: 300 })
+  assert.equal(result.run.shots, 3)
+  assert.equal(result.run.over, false)
+})
+
+test("mashing does not even buy tempo", () => {
+  // A wrong draw does not close the window, so a masher sits through every
+  // window in full. Per statement presented, they get strictly less game.
+  const masher = playRun(createStubHost({ seed: 41 }), 42, alwaysDraw, { limit: 60 })
+  const reader = playRun(createStubHost({ seed: 41 }), 42, perfect, { limit: 60 })
+  assert.ok(masher.statements.length < reader.statements.length)
+})

--- a/dynawalla/games/truedraw/src/game/response.test.ts
+++ b/dynawalla/games/truedraw/src/game/response.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { isCorrect, outcomeOf, responseFor } from "./response.ts"
+import type { Statement } from "./statement.ts"
+
+function statement(over: Partial<Statement> = {}): Statement {
+  return {
+    questionId: "q1",
+    expression: "47 + 25",
+    claimed: "62",
+    answer: "72",
+    truth: false,
+    text: "47 + 25 = 62",
+    windowMs: 2100,
+    stillMs: 900,
+    ...over,
+  }
+}
+
+test("the four outcomes are the two calls against the two truths", () => {
+  assert.equal(outcomeOf("draw", true), "hit")
+  assert.equal(outcomeOf("draw", false), "wild")
+  assert.equal(outcomeOf("hold", false), "bow")
+  assert.equal(outcomeOf("hold", true), "slow")
+})
+
+test("drawing and holding are each right exactly half the time", () => {
+  const outcomes = [
+    outcomeOf("draw", true),
+    outcomeOf("draw", false),
+    outcomeOf("hold", true),
+    outcomeOf("hold", false),
+  ]
+  assert.equal(outcomes.filter(isCorrect).length, 2)
+})
+
+test("a wrong draw reports the mal-rule value, so the misconception routes", () => {
+  const s = statement()
+  // The child said "62". 62 is the carry-dropped output, the host records a
+  // miss and names the diagnosis. This is the format's best property.
+  assert.equal(responseFor("wild", s), "62")
+})
+
+test("a correct draw reports the value it claimed, which is the answer", () => {
+  const s = statement({ claimed: "72", truth: true })
+  assert.equal(responseFor("hit", s), "72")
+})
+
+test("a correct hold is credited rather than recorded as a miss", () => {
+  // A child who correctly rejects a mal-rule value has done the thing this
+  // game measures. Reporting the claimed value instead would demote them down
+  // the ladder for playing perfectly.
+  assert.equal(responseFor("bow", statement()), "72")
+})
+
+test("letting a true statement stand reports nothing the host can parse", () => {
+  const s = statement({ claimed: "72", truth: true })
+  // Unparseable, so it is recorded as a miss with no diagnosis. Refusing a
+  // true sentence is not a misconception with a name.
+  assert.equal(responseFor("slow", s), "")
+})

--- a/dynawalla/games/truedraw/src/game/response.ts
+++ b/dynawalla/games/truedraw/src/game/response.ts
@@ -1,0 +1,61 @@
+// What the child said, and what the host is told they said.
+//
+// Four outcomes, and the asymmetry between them is the design:
+//
+//   hit   drew on a true statement    — the slate is struck and the claim seats
+//   bow   held on a false statement   — the caller bows, the slate corrects itself
+//   wild  drew on a false statement   — nothing happens at all
+//   slow  held on a true statement    — the caller draws
+//
+// `wild` is the one that matters. A wrong draw is not buzzed, not shaken, not
+// flashed red. The world simply does not acknowledge it: the slate stays wrong,
+// the caller does not move, no sound plays. A shot goes dark and the round ends
+// in the same silence it began in. Being ignored is the punishment.
+
+import type { Statement } from "./statement.ts"
+
+export type Call = "draw" | "hold"
+export type Outcome = "hit" | "bow" | "wild" | "slow"
+
+export function outcomeOf(call: Call, truth: boolean): Outcome {
+  if (call === "draw") return truth ? "hit" : "wild"
+  return truth ? "slow" : "bow"
+}
+
+export function isCorrect(outcome: Outcome): boolean {
+  return outcome === "hit" || outcome === "bow"
+}
+
+/**
+ * The response reported to the host, which is the only judge.
+ *
+ * The host records value-answers, so a classification has to be expressed as
+ * one. Each mapping below is the honest reading of what the child asserted:
+ *
+ *   hit  — "the answer is 72", and it is. Recorded correct.
+ *   wild — "the answer is 62". Recorded wrong, **and diagnosed**: 62 is the
+ *          carry-dropped mal-rule, so drawing at a false slate routes the exact
+ *          misconception the child just demonstrated. This is the single best
+ *          property of the format and it comes for free.
+ *   bow  — "the answer is not 62". A correct rejection of a mal-rule value is
+ *          the thing this game is measuring, and it is credited: the answer is
+ *          reported. That is a slightly generous reading of the evidence, and it
+ *          is the deliberate one — the alternative records a child who played
+ *          perfectly as having missed, which would demote them down the ladder
+ *          for being right.
+ *   slow — "the answer is not 72", and it is. Nothing a child could have written
+ *          expresses that, so nothing is: the empty response is unparseable, the
+ *          host records a miss, and no mal-rule is named. Refusing a true
+ *          sentence is not a misconception with a name.
+ */
+export function responseFor(outcome: Outcome, statement: Statement): string {
+  switch (outcome) {
+    case "hit":
+    case "wild":
+      return statement.claimed
+    case "bow":
+      return statement.answer
+    case "slow":
+      return ""
+  }
+}

--- a/dynawalla/games/truedraw/src/game/round.test.ts
+++ b/dynawalla/games/truedraw/src/game/round.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { createStubHost } from "../stub/host.ts"
+import { alwaysDraw, alwaysHold, perfect, playRun } from "../test/harness.ts"
+import { isCorrect } from "./response.ts"
+import { Round, TIMING, TIMING_REDUCED } from "./round.ts"
+import type { Statement } from "./statement.ts"
+
+function fixed(truth: boolean, windowMs = 2000, stillMs = 800): () => Statement {
+  return () => ({
+    questionId: "q",
+    expression: "47 + 25",
+    claimed: truth ? "72" : "62",
+    answer: "72",
+    truth,
+    text: `47 + 25 = ${truth ? "72" : "62"}`,
+    windowMs,
+    stillMs,
+  })
+}
+
+test("a run is idle until the first tap, and the first tap is the start", () => {
+  const round = new Round(fixed(true))
+  assert.equal(round.phase, "idle")
+  round.advance(5000)
+  assert.equal(round.phase, "idle", "nothing happens on its own")
+  const events = round.press()
+  assert.equal(events[0]?.kind, "begin")
+  assert.equal(round.phase, "raise")
+})
+
+test("the phases run raise, still, call — and the cue is the only signal", () => {
+  const round = new Round(fixed(true))
+  round.press()
+  assert.equal(round.phase, "raise")
+  round.advance(TIMING.raise)
+  assert.equal(round.phase, "still")
+  const events = round.advance(800)
+  assert.equal(round.phase, "call")
+  assert.equal(events.filter((e) => e.kind === "cue").length, 1)
+})
+
+test("a press before the slate lights is a flinch: counted, and ignored", () => {
+  const round = new Round(fixed(false))
+  round.press()
+  const events = round.press()
+  assert.equal(events[0]?.kind, "flinch")
+  assert.equal(round.run.flinches, 1)
+  assert.equal(round.run.shots, 3)
+  assert.equal(round.phase, "raise", "the round is not advanced by a flinch")
+})
+
+test("drawing at a true slate settles at once — the only thing that hurries the game", () => {
+  const round = new Round(fixed(true))
+  round.press()
+  round.advance(TIMING.raise + 800)
+  assert.equal(round.phase, "call")
+  round.advance(200)
+  const events = round.press()
+  const settled = events.find((e) => e.kind === "settled")
+  assert.equal(settled?.kind === "settled" && settled.outcome, "hit")
+  assert.equal(round.phase, "verdict")
+  assert.ok(settled?.kind === "settled" && settled.reactionMs <= 220)
+})
+
+test("drawing at a false slate buys no time at all", () => {
+  // The press is spent, the world does not react, and the window still runs to
+  // the last millisecond. Mashing gets the slowest possible game.
+  const round = new Round(fixed(false, 2000))
+  round.press()
+  round.advance(TIMING.raise + 800)
+  assert.equal(round.phase, "call")
+  round.advance(100)
+  assert.deepEqual(round.press(), [], "nothing happens")
+  assert.equal(round.phase, "call", "and the clock does not move on")
+  round.advance(400)
+  assert.equal(round.phase, "call")
+  const events = round.advance(1600)
+  const settled = events.find((e) => e.kind === "settled")
+  assert.equal(settled?.kind === "settled" && settled.outcome, "wild")
+  assert.equal(round.run.shots, 2)
+})
+
+test("letting a false slate stand is the bow", () => {
+  const round = new Round(fixed(false, 2000))
+  round.press()
+  round.advance(TIMING.raise + 800)
+  const events = round.advance(2000)
+  const settled = events.find((e) => e.kind === "settled")
+  assert.equal(settled?.kind === "settled" && settled.outcome, "bow")
+  assert.equal(round.run.calls, 1)
+  assert.equal(round.run.shots, 3)
+})
+
+test("letting a true slate stand costs a shot", () => {
+  const round = new Round(fixed(true, 2000))
+  round.press()
+  round.advance(TIMING.raise + 800)
+  const events = round.advance(2000)
+  const settled = events.find((e) => e.kind === "settled")
+  assert.equal(settled?.kind === "settled" && settled.outcome, "slow")
+  assert.equal(round.run.shots, 2)
+})
+
+test("a long frame gap is spent phase by phase, never skipped", () => {
+  // A backgrounded tab hands back one enormous delta. The machine must not owe
+  // the child a round it never played.
+  const round = new Round(fixed(false, 2000))
+  round.press()
+  const events = round.advance(20_000)
+  assert.ok(events.some((e) => e.kind === "cue"))
+  assert.ok(events.some((e) => e.kind === "settled"))
+})
+
+test("three misses end the run and the street stays cleared", () => {
+  const host = createStubHost({ seed: 5 })
+  const result = playRun(host, 11, alwaysHold, { limit: 200 })
+  assert.equal(result.finished, true)
+  assert.equal(result.run.over, true)
+  assert.equal(result.run.shots, 0)
+  assert.equal(result.events.filter((e) => e.kind === "over").length, 1)
+  assert.equal(result.run.calls, result.outcomes.filter(isCorrect).length)
+})
+
+test("a perfect player is never stopped", () => {
+  const host = createStubHost({ seed: 6 })
+  const result = playRun(host, 12, perfect, { limit: 150 })
+  assert.equal(result.finished, false, "the cap ended it, not the game")
+  assert.equal(result.run.shots, 3)
+  assert.ok(result.run.calls >= 150)
+})
+
+test("reduced motion changes what is drawn, never what is timed", () => {
+  const host = createStubHost({ seed: 7 })
+  const a = playRun(host, 21, alwaysDraw, { timing: TIMING })
+  const b = playRun(createStubHost({ seed: 7 }), 21, alwaysDraw, { timing: TIMING_REDUCED })
+  // Same seed, same questions, same truth schedule, same calls: the motion
+  // preference is a rendering branch and touches no rule.
+  assert.deepEqual(a.outcomes, b.outcomes)
+  assert.equal(a.run.calls, b.run.calls)
+  assert.deepEqual(
+    a.statements.map((s) => s.text),
+    b.statements.map((s) => s.text),
+  )
+})

--- a/dynawalla/games/truedraw/src/game/round.ts
+++ b/dynawalla/games/truedraw/src/game/round.ts
@@ -1,0 +1,266 @@
+// The round, as a clock.
+//
+//   RAISE    the slate comes up out of the dust, blank
+//   STILL    the statement is cut into it, unlit. Nothing else moves.
+//   CALL     the slate lights. The window is open. One press is your call.
+//   VERDICT  what the street does about it
+//   CLEAR    the slate goes back down
+//
+// Two rules in here carry the whole feel.
+//
+// **A wrong draw does not stop the clock.** Drawing at a true slate commits
+// instantly and the round moves on — that is the reward for reading, and it is
+// the only thing in the game that makes time go faster. Drawing at a *false*
+// slate commits too, but the window still runs out to the last millisecond,
+// with nothing on screen changing. A masher therefore gets no tempo out of
+// mashing: they get the slowest possible game, sitting through a window they
+// already spent, watching a slate that does not care.
+//
+// **Nothing escalates.** The window is a function of the statement and of
+// nothing else — not of how long the run has lasted. `EXPERIENCE_DESIGN.md`
+// bans escalation on run length and a creeping timer is that ban's exact
+// target. A long run here is longer, never faster.
+//
+// The machine is driven by elapsed milliseconds rather than by frames, so
+// `round.test.ts` plays whole runs with no canvas, no rAF and no clock.
+
+import { applyFlinch, applyOutcome, newRun, type Run } from "./run.ts"
+import { isCorrect, outcomeOf, type Outcome } from "./response.ts"
+import type { Statement } from "./statement.ts"
+
+export type Phase = "idle" | "raise" | "still" | "call" | "verdict" | "clear" | "over"
+
+export type RoundEvent =
+  | { kind: "present"; statement: Statement }
+  /** The slate lit. This is the go signal and the only cue there is. */
+  | { kind: "cue"; statement: Statement }
+  /** A press before the slate lit. Counted, and otherwise ignored. */
+  | { kind: "flinch" }
+  | { kind: "settled"; outcome: Outcome; statement: Statement; reactionMs: number }
+  | { kind: "over"; run: Run }
+  | { kind: "begin" }
+
+export type Timing = {
+  raise: number
+  clear: number
+  verdict: Record<Outcome, number>
+  /** How long the ledger is untouchable, so a run does not end in a stray tap. */
+  overLock: number
+}
+
+export const TIMING: Timing = {
+  raise: 220,
+  clear: 200,
+  verdict: {
+    // Struck, seated, gone. The correct draw is the fast one.
+    hit: 520,
+    // The bow, and the slate rolling itself right. The longest thing in the
+    // game, because it is the best thing in the game.
+    bow: 940,
+    // Nothing happens. The beat exists so the silence is legible as silence
+    // rather than as a dropped frame.
+    wild: 620,
+    slow: 640,
+  },
+  overLock: 900,
+}
+
+export const TIMING_REDUCED: Timing = {
+  raise: 110,
+  clear: 100,
+  verdict: {
+    hit: 300,
+    // Still the longest, still the payoff: a cross-fade from the wrong numeral
+    // to the right one instead of a roll. A branch, not a degradation.
+    bow: 520,
+    // Unchanged, and it is the one that could not change: there is no motion in
+    // being ignored to reduce.
+    wild: 620,
+    slow: 360,
+  },
+  overLock: 900,
+}
+
+export class Round {
+  private readonly deal: () => Statement
+  private readonly timing: Timing
+
+  private phaseName: Phase = "idle"
+  private elapsed = 0
+  private duration = 0
+  private current: Statement | null = null
+  private lastOutcome: Outcome | null = null
+  private committed: Outcome | null = null
+  private reaction = 0
+  private state: Run = newRun()
+
+  constructor(deal: () => Statement, timing: Timing = TIMING) {
+    this.deal = deal
+    this.timing = timing
+  }
+
+  get phase(): Phase {
+    return this.phaseName
+  }
+
+  get run(): Run {
+    return this.state
+  }
+
+  get statement(): Statement | null {
+    return this.current
+  }
+
+  /** The outcome the verdict is currently showing, if any. */
+  get outcome(): Outcome | null {
+    return this.phaseName === "verdict" || this.phaseName === "clear" ? this.lastOutcome : null
+  }
+
+  /** 0..1 through the current phase. The renderer's only clock. */
+  get progress(): number {
+    return this.duration <= 0 ? 1 : Math.max(0, Math.min(1, this.elapsed / this.duration))
+  }
+
+  get elapsedMs(): number {
+    return this.elapsed
+  }
+
+  get durationMs(): number {
+    return this.duration
+  }
+
+  /** Start a run. Legal from `idle` and from `over`. */
+  begin(): RoundEvent[] {
+    if (this.phaseName !== "idle" && this.phaseName !== "over") return []
+    this.state = newRun()
+    this.lastOutcome = null
+    const events: RoundEvent[] = [{ kind: "begin" }]
+    events.push(...this.present())
+    return events
+  }
+
+  advance(dt: number): RoundEvent[] {
+    if (this.phaseName === "idle" || this.phaseName === "over") {
+      this.elapsed += Math.max(0, dt)
+      return []
+    }
+    const events: RoundEvent[] = []
+    this.elapsed += Math.max(0, dt)
+    // A `while`, not an `if`: a backgrounded tab hands back a delta longer than
+    // several phases, and a machine that advanced one phase per frame would owe
+    // the child a round it never played.
+    let guard = 0
+    // `phase` rather than `this.phaseName`: the guard clause above narrowed the
+    // field, and the compiler does not know that `finishPhase` widens it again.
+    while (this.elapsed >= this.duration && this.phase !== "over" && guard++ < 16) {
+      const carry = this.elapsed - this.duration
+      events.push(...this.finishPhase())
+      this.elapsed = carry
+    }
+    return events
+  }
+
+  /** One press. Returns whatever it caused, which is often nothing. */
+  press(): RoundEvent[] {
+    switch (this.phaseName) {
+      case "raise":
+      case "still": {
+        this.state = applyFlinch(this.state)
+        return [{ kind: "flinch" }]
+      }
+      case "call": {
+        if (this.committed !== null) return []
+        const statement = this.current
+        if (!statement) return []
+        this.reaction = this.elapsed
+        const outcome = outcomeOf("draw", statement.truth)
+        this.committed = outcome
+        // A true draw stops the clock. A wild one does not: the window runs its
+        // full length with the world declining to react.
+        if (outcome === "hit") return this.settle(outcome)
+        return []
+      }
+      case "idle": {
+        // Nothing on the street but the caller and three loaded shots. The
+        // first tap is the start button, which is why there is not one.
+        return this.begin()
+      }
+      case "over": {
+        if (this.elapsed < this.timing.overLock) return []
+        return this.begin()
+      }
+      default:
+        return []
+    }
+  }
+
+  private present(): RoundEvent[] {
+    this.current = this.deal()
+    this.committed = null
+    this.reaction = 0
+    this.enter("raise", this.timing.raise)
+    return [{ kind: "present", statement: this.current }]
+  }
+
+  private finishPhase(): RoundEvent[] {
+    const statement = this.current
+    switch (this.phaseName) {
+      case "raise": {
+        this.enter("still", statement ? statement.stillMs : 900)
+        return []
+      }
+      case "still": {
+        this.enter("call", statement ? statement.windowMs : 2000)
+        return statement ? [{ kind: "cue", statement }] : []
+      }
+      case "call": {
+        // Either a wild draw that has been sitting on the clock, or no press at
+        // all — which is a hold, and a hold is a call like any other.
+        const outcome = this.committed ?? outcomeOf("hold", statement ? statement.truth : true)
+        if (this.committed === null) this.reaction = this.duration
+        return this.settle(outcome)
+      }
+      case "verdict": {
+        this.enter("clear", this.timing.clear)
+        return []
+      }
+      case "clear": {
+        if (this.state.over) {
+          this.enter("over", Number.POSITIVE_INFINITY)
+          return [{ kind: "over", run: this.state }]
+        }
+        return this.present()
+      }
+      default:
+        return []
+    }
+  }
+
+  private settle(outcome: Outcome): RoundEvent[] {
+    const statement = this.current
+    this.lastOutcome = outcome
+    this.committed = outcome
+    this.state = applyOutcome(this.state, outcome)
+    this.enter("verdict", this.timing.verdict[outcome])
+    if (!statement) return []
+    return [
+      {
+        kind: "settled",
+        outcome,
+        statement,
+        reactionMs: Math.round(this.reaction),
+      },
+    ]
+  }
+
+  private enter(phase: Phase, duration: number): void {
+    this.phaseName = phase
+    this.duration = duration
+    this.elapsed = 0
+  }
+}
+
+/** Convenience for the tests and the ledger: was this a call or a miss. */
+export function settledCorrectly(event: RoundEvent): boolean {
+  return event.kind === "settled" && isCorrect(event.outcome)
+}

--- a/dynawalla/games/truedraw/src/game/run.test.ts
+++ b/dynawalla/games/truedraw/src/game/run.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { applyFlinch, applyOutcome, crowdOf, expectedCalls, newRun, SHOTS } from "./run.ts"
+
+test("a run starts loaded and empty", () => {
+  const run = newRun()
+  assert.equal(run.shots, SHOTS)
+  assert.equal(run.calls, 0)
+  assert.equal(run.over, false)
+})
+
+test("a correct call adds to the tally and costs nothing", () => {
+  let run = newRun()
+  run = applyOutcome(run, "hit")
+  run = applyOutcome(run, "bow")
+  assert.equal(run.calls, 2)
+  assert.equal(run.shots, SHOTS)
+})
+
+test("a miss spends a shot and never takes back a call", () => {
+  let run = applyOutcome(applyOutcome(newRun(), "hit"), "hit")
+  run = applyOutcome(run, "wild")
+  assert.equal(run.calls, 2, "the tally only ever rises")
+  assert.equal(run.shots, SHOTS - 1)
+  assert.equal(run.wild, 1)
+})
+
+test("three misses clear the street, in any mixture", () => {
+  for (const kinds of [
+    ["wild", "wild", "wild"],
+    ["slow", "slow", "slow"],
+    ["wild", "slow", "wild"],
+  ] as const) {
+    let run = newRun()
+    for (const kind of kinds) run = applyOutcome(run, kind)
+    assert.equal(run.over, true, kinds.join("/"))
+    assert.equal(run.shots, 0)
+  }
+})
+
+test("a finished run absorbs anything else that arrives", () => {
+  let run = newRun()
+  for (const kind of ["wild", "wild", "wild"] as const) run = applyOutcome(run, kind)
+  const frozen = applyOutcome(applyFlinch(run), "hit")
+  assert.deepEqual(frozen, run)
+})
+
+test("a flinch is counted and costs nothing", () => {
+  const run = applyFlinch(applyFlinch(newRun()))
+  assert.equal(run.flinches, 2)
+  assert.equal(run.shots, SHOTS)
+  assert.equal(run.calls, 0)
+})
+
+test("the crowd is the tally, capped, and never smaller than it was", () => {
+  let run = newRun()
+  let last = 0
+  for (let i = 0; i < 40; i++) {
+    run = applyOutcome(run, "hit")
+    const crowd = crowdOf(run)
+    assert.ok(crowd >= last)
+    last = crowd
+  }
+  assert.equal(crowdOf(run), 14)
+})
+
+test("half right is a three-call run — the whole design in one number", () => {
+  // Drawing at everything is right exactly half the time, and half is not a
+  // grade here: it is a length. There is no arrangement of three calls that
+  // looks like doing well.
+  assert.equal(expectedCalls(0.5), 3)
+  assert.equal(expectedCalls(0.75), 9)
+  assert.ok(Math.abs(expectedCalls(0.9) - 27) < 1e-9)
+  assert.equal(expectedCalls(1), Number.POSITIVE_INFINITY)
+  assert.equal(expectedCalls(0), 0)
+})
+
+test("run length climbs faster than accuracy does", () => {
+  // The gap between a masher and a careful player is not ten percent. It is
+  // nine times the run.
+  let previous = -1
+  for (const p of [0.5, 0.6, 0.7, 0.8, 0.9, 0.95]) {
+    const calls = expectedCalls(p)
+    assert.ok(calls > previous, `${String(p)}`)
+    previous = calls
+  }
+  assert.ok(expectedCalls(0.9) / expectedCalls(0.5) >= 9)
+})

--- a/dynawalla/games/truedraw/src/game/run.ts
+++ b/dynawalla/games/truedraw/src/game/run.ts
@@ -1,0 +1,100 @@
+// The run, and why half right is a failure.
+//
+// This is the module the whole design rests on. A GO/NO-GO task has a hard 50%
+// ceiling for anyone who ignores the statement and just draws — that is not a
+// flaw to be patched, it is the measurement. The job here is to make sure that
+// ceiling *reads* as failure to a seven-year-old, and there is exactly one
+// honest way to do it: **never show an accuracy at all.**
+//
+// A child shown "50%" reads a passing grade. A child shown a tally of three
+// reads what it is.
+//
+// So the run has no score and no percentage. It has a **length**: how many calls
+// you made before three shots went dark. And the length of a run is violently
+// non-linear in how carefully you play, because misses are a budget rather than
+// a subtraction:
+//
+//     expected calls = shots × p / (1 − p)
+//
+//        p = 0.50  (draw at everything)  →   3 calls
+//        p = 0.75                        →   9 calls
+//        p = 0.90                        →  27 calls
+//        p = 0.97                        →  97 calls
+//        p = 1.00                        →  no end
+//
+// A masher's whole run is three calls long. There is no arrangement of three
+// that looks like doing well, no number on the slate to misread, and nothing to
+// argue with: the street empties before a crowd ever gathers. The same is true
+// of the other degenerate strategy — never drawing is also exactly half, and
+// also three calls.
+//
+// Nothing here ever *subtracts*. A miss spends a shot; it does not take back a
+// call you made. Construction never regresses (`P-04`) — the pull is "my run was
+// getting long", never "my score is at risk".
+
+import type { Outcome } from "./response.ts"
+import { isCorrect } from "./response.ts"
+
+/** Misses a run survives. Three, as in the original. */
+export const SHOTS = 3
+
+/** Witnesses that can stand in the haze. Past this the crowd is a crowd. */
+export const CROWD_MAX = 14
+
+export type Run = {
+  /** Shots left. At zero the street clears. */
+  readonly shots: number
+  /** Correct calls made. This is the tally, and it is the only one. */
+  readonly calls: number
+  /** Drew at a false slate. */
+  readonly wild: number
+  /** Let a true slate stand. */
+  readonly slow: number
+  /** Pressed before the slate lit. Ignored, and counted anyway. */
+  readonly flinches: number
+  readonly over: boolean
+}
+
+export function newRun(): Run {
+  return { shots: SHOTS, calls: 0, wild: 0, slow: 0, flinches: 0, over: false }
+}
+
+export function applyOutcome(run: Run, outcome: Outcome): Run {
+  if (run.over) return run
+  if (isCorrect(outcome)) {
+    return { ...run, calls: run.calls + 1 }
+  }
+  const shots = run.shots - 1
+  return {
+    ...run,
+    shots,
+    wild: run.wild + (outcome === "wild" ? 1 : 0),
+    slow: run.slow + (outcome === "slow" ? 1 : 0),
+    over: shots <= 0,
+  }
+}
+
+/** A press before the slate lit. It costs nothing and is never hidden. */
+export function applyFlinch(run: Run): Run {
+  if (run.over) return run
+  return { ...run, flinches: run.flinches + 1 }
+}
+
+/** Witnesses currently standing. One per call, and it never goes back down. */
+export function crowdOf(run: Run): number {
+  return Math.min(CROWD_MAX, run.calls)
+}
+
+/**
+ * Expected calls in a run at per-round accuracy `p`. Negative binomial: the
+ * number of successes before the `shots`-th failure.
+ *
+ * Exported because it is the design claim, and a claim in a comment is not
+ * checked. `run.test.ts` asserts the 0.5 case is 3 and that a simulated masher
+ * lands on it.
+ */
+export function expectedCalls(p: number, shots: number = SHOTS): number {
+  if (p >= 1) return Number.POSITIVE_INFINITY
+  if (p <= 0) return 0
+  return (shots * p) / (1 - p)
+}

--- a/dynawalla/games/truedraw/src/game/schedule.test.ts
+++ b/dynawalla/games/truedraw/src/game/schedule.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import { BLOCK, TruthBag } from "./schedule.ts"
+
+test("every whole block is exactly half true", () => {
+  const bag = new TruthBag(new Rng(7))
+  for (let block = 0; block < 200; block++) {
+    let trues = 0
+    for (let i = 0; i < BLOCK; i++) if (bag.take()) trues++
+    assert.equal(trues, BLOCK / 2, `block ${String(block)}`)
+  }
+})
+
+test("the imbalance over any prefix stays inside one block", () => {
+  const bag = new TruthBag(new Rng(31337))
+  let trues = 0
+  let falses = 0
+  for (let i = 0; i < 4000; i++) {
+    if (bag.take()) trues++
+    else falses++
+    assert.ok(
+      Math.abs(trues - falses) <= BLOCK,
+      `after ${String(i + 1)}: ${String(trues)} true, ${String(falses)} false`,
+    )
+  }
+})
+
+test("a child never sees more than three of the same call in a row", () => {
+  for (const seed of [1, 2, 3, 99, 12345]) {
+    const bag = new TruthBag(new Rng(seed))
+    let value = bag.take()
+    let length = 1
+    for (let i = 1; i < 4000; i++) {
+      const next = bag.take()
+      if (next === value) length++
+      else {
+        value = next
+        length = 1
+      }
+      assert.ok(length <= 3, `seed ${String(seed)} produced a run of ${String(length)}`)
+    }
+  }
+})
+
+test("an unspendable lie goes back into the bag rather than biasing the run", () => {
+  const bag = new TruthBag(new Rng(5))
+  const first = bag.take()
+  bag.give(first)
+  assert.equal(bag.take(), first, "the returned value is dealt again")
+})
+
+test("a debt that can never be spent is written off rather than hoarded", () => {
+  const bag = new TruthBag(new Rng(11))
+  // A stream of items that could only be told truthfully. Without the cap this
+  // queue would grow without bound and then dump every stored `false` at once.
+  for (let i = 0; i < 500; i++) {
+    bag.take()
+    bag.give(false)
+  }
+  let trues = 0
+  for (let i = 0; i < 400; i++) if (bag.take()) trues++
+  assert.ok(trues >= 150 && trues <= 250, `${String(trues)} true out of 400 after the write-off`)
+})

--- a/dynawalla/games/truedraw/src/game/schedule.ts
+++ b/dynawalla/games/truedraw/src/game/schedule.ts
@@ -1,0 +1,88 @@
+// The truth balancer.
+//
+// A coin flip per round is wrong twice over. It drifts — a seeded run can hand a
+// child seven true statements in a row and teach them that drawing always works
+// — and it makes the 50% mashing ceiling a statement about expectation rather
+// than about what actually happened in the run they just played.
+//
+// So truth is dealt from a bag: blocks of four, two true and two false,
+// shuffled. Over any whole block the counts are exactly equal, and over any
+// prefix the imbalance is at most two. A masher therefore does not get 50% on
+// average — they get within one call of half, every single run.
+//
+// One more constraint: a shuffle is rejected if it would extend a same-truth
+// tail past three. Four falses in a row is inside the bag's guarantee and
+// outside what a child reads as fair.
+
+import type { Rng } from "../core/rng.ts"
+
+export const BLOCK = 4
+const MAX_SAME_RUN = 3
+
+export class TruthBag {
+  private readonly rng: Rng
+  private queue: boolean[] = []
+  private tailTruth = true
+  private tailLength = 0
+
+  constructor(rng: Rng) {
+    this.rng = rng
+  }
+
+  /** The next truth value to try to tell. */
+  take(): boolean {
+    if (this.queue.length === 0) this.refill()
+    const next = this.queue.shift()
+    // The refill above guarantees a non-empty queue; this keeps the types
+    // honest without a non-null assertion.
+    const truth = next ?? true
+    if (truth === this.tailTruth) this.tailLength += 1
+    else {
+      this.tailTruth = truth
+      this.tailLength = 1
+    }
+    return truth
+  }
+
+  /**
+   * Give a truth value back, unspent.
+   *
+   * An item whose distractors are all unusable can only be told truthfully, so
+   * the `false` the bag dealt was never spent. Returning it keeps the block
+   * balanced instead of quietly biasing the whole run towards true.
+   */
+  give(truth: boolean): void {
+    // A stream of items that can only be told truthfully would otherwise pile
+    // up an unspendable debt of `false`s and, the moment one usable item
+    // arrived, spend it all at once. Past a block's worth the debt is written
+    // off: the balance guarantee is about a run, not about an accounting
+    // identity.
+    if (this.queue.length >= BLOCK) return
+    this.queue.unshift(truth)
+    if (this.tailLength > 0) this.tailLength -= 1
+  }
+
+  private refill(): void {
+    const block = [true, true, false, false]
+    for (let attempt = 0; attempt < 8; attempt++) {
+      this.rng.shuffle(block)
+      if (!this.extendsRunTooFar(block)) break
+    }
+    this.queue = block.slice()
+  }
+
+  private extendsRunTooFar(block: readonly boolean[]): boolean {
+    let value = this.tailTruth
+    let length = this.tailLength
+    for (const truth of block) {
+      if (truth === value) {
+        length += 1
+        if (length > MAX_SAME_RUN) return true
+      } else {
+        value = truth
+        length = 1
+      }
+    }
+    return false
+  }
+}

--- a/dynawalla/games/truedraw/src/game/statement.test.ts
+++ b/dynawalla/games/truedraw/src/game/statement.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import type { Question } from "../contract.ts"
+import { sameValue } from "../core/exact.ts"
+import { Rng } from "../core/rng.ts"
+import { createStubHost } from "../stub/host.ts"
+import { buildStatement, falsehoodsFor, stillFor, windowFor } from "./statement.ts"
+
+function question(over: Partial<Question> = {}): Question {
+  return {
+    id: "q1",
+    prompt: "47 + 25",
+    answer: "72",
+    distractors: ["62", "82"],
+    domain: "add",
+    difficulty: 0.4,
+    ...over,
+  }
+}
+
+test("a true statement claims the canonical answer, verbatim", () => {
+  const s = buildStatement(question(), true, new Rng(1))
+  assert.equal(s.truth, true)
+  assert.equal(s.claimed, "72")
+  assert.equal(s.text, "47 + 25 = 72")
+})
+
+test("a false statement claims a mal-rule value", () => {
+  const s = buildStatement(question(), false, new Rng(1))
+  assert.equal(s.truth, false)
+  assert.ok(["62", "82"].includes(s.claimed))
+  assert.equal(s.text, `47 + 25 = ${s.claimed}`)
+})
+
+test("the answer wearing a different coat is not a falsehood", () => {
+  // Every one of these *is* 72. A statement built from one would present a
+  // true sentence and ask the child to reject it.
+  const q = question({ distractors: ["072", "72.0", "+72", " 72 "] })
+  assert.deepEqual(falsehoodsFor(q), [])
+  const s = buildStatement(q, false, new Rng(3))
+  assert.equal(s.truth, true, "with nothing to lie with, the slate tells the truth")
+})
+
+test("an answer that is not a numeral makes every claim untellable", () => {
+  // The worst failure this game has is presenting a true sentence as false. If
+  // the canonical value cannot be read, no claim can be *proved* wrong, so none
+  // is presented as wrong — the slate tells the truth and the round is worth
+  // nothing rather than worth a lie.
+  for (const answer of ["", "  ", "seven", "1,234"]) {
+    const q = question({ answer, distractors: ["62", "82"] })
+    assert.deepEqual(falsehoodsFor(q), [], JSON.stringify(answer))
+    assert.equal(buildStatement(q, false, new Rng(9)).truth, true, JSON.stringify(answer))
+  }
+})
+
+test("junk in the distractor list is dropped rather than drawn", () => {
+  const q = question({ distractors: ["", "seven", "1,234", "62"] })
+  assert.deepEqual(falsehoodsFor(q), ["62"])
+})
+
+test("a duplicate distractor is offered once", () => {
+  const q = question({ distractors: ["62", "062", "62.00", "82"] })
+  assert.deepEqual(falsehoodsFor(q), ["62", "82"])
+})
+
+test("across a long stream, a false statement is never accidentally true", () => {
+  const host = createStubHost({ seed: 0xf001 })
+  const rng = new Rng(0xf002)
+  let falses = 0
+  for (let i = 0; i < 6000; i++) {
+    const q = host.next()
+    const s = buildStatement(q, i % 2 === 0, rng)
+    if (s.truth) {
+      assert.ok(sameValue(s.claimed, s.answer), `claimed ${s.claimed} for answer ${s.answer}`)
+      continue
+    }
+    falses++
+    assert.ok(!sameValue(s.claimed, s.answer), `a "false" statement claimed the answer: ${s.text}`)
+  }
+  assert.ok(falses > 2800, `only ${String(falses)} false statements were buildable`)
+})
+
+test("the mal-rule value is preferred over the padding", () => {
+  // The host puts the diagnostic value first. A slate that only ever lied with
+  // a near-miss would be teaching the child to reject by feel.
+  const q = question({ distractors: ["62", "73", "71", "82"] })
+  let head = 0
+  const rng = new Rng(808)
+  for (let i = 0; i < 2000; i++) {
+    if (buildStatement(q, false, rng).claimed === "62") head++
+  }
+  assert.ok(head > 900 && head < 1300, `${String(head)} of 2000 used the mal-rule`)
+})
+
+test("the draw window is a function of the statement and of nothing else", () => {
+  // In particular not of how long the run has been going: a reaction game that
+  // tightens its window as a run lengthens is escalation on run length, which
+  // EXPERIENCE_DESIGN.md bans outright.
+  const short = windowFor("12 + 5 = 17")
+  const long = windowFor("753 + 577 = 1330")
+  assert.ok(long > short, "more numeral, more time")
+  assert.equal(windowFor("12 + 5 = 17"), short, "the same statement always gets the same window")
+  assert.ok(short >= 1750 && long <= 3600, "clamped at both ends")
+  assert.equal(windowFor("no digits at all"), 1750)
+})
+
+test("a four-digit sum gets time a child could actually use", () => {
+  // EXPERIENCE_DESIGN.md puts multi-digit regrouping at a 6 s p50. Verifying a
+  // claim is cheaper than computing one — the ones column alone rejects most
+  // mal-rules — but not so much cheaper that three seconds is honest.
+  const rng = new Rng(4)
+  const text = "753 + 577 = 1330"
+  const budget = windowFor(text) + stillFor(text, rng)
+  assert.ok(budget >= 4400, `only ${String(budget)}ms to verify a four-digit sum`)
+})
+
+test("a short statement comes at you faster than a long one", () => {
+  // The stillness flattens where the window climbs: a lead-in long enough for
+  // `753 + 577 = 1330` is dead air on `12 + 5 = 17`.
+  const rng = new Rng(5)
+  const quick = windowFor("12 + 5 = 17") + stillFor("12 + 5 = 17", rng)
+  const slow = windowFor("4003 − 87 = 3916") + stillFor("4003 − 87 = 3916", rng)
+  assert.ok(quick < slow - 800, `${String(quick)}ms vs ${String(slow)}ms`)
+})
+
+test("the stillness before the cue is jittered but bounded", () => {
+  const rng = new Rng(17)
+  for (let i = 0; i < 500; i++) {
+    const still = stillFor("4003 − 87 = 3916", rng)
+    assert.ok(still >= 450 && still <= 1400, String(still))
+  }
+})

--- a/dynawalla/games/truedraw/src/game/statement.ts
+++ b/dynawalla/games/truedraw/src/game/statement.ts
@@ -1,0 +1,149 @@
+// Turning a question into a claim.
+//
+// The host serves `{ prompt: "47 + 25", answer: "72", distractors: [...] }`.
+// This game never asks that question. It makes a *statement* out of it —
+// `47 + 25 = 72` or `47 + 25 = 62` — and asks the only question a GO/NO-GO task
+// can ask: is that so?
+//
+// Two things make this rigorous rather than a coin toss.
+//
+//  1. **The falsehood is a mal-rule output.** `answer ± 1` is noise: a child
+//     rejects it by feel, without doing the arithmetic. `62` is what a child who
+//     drops the carry in `47 + 25` actually writes, so rejecting it *is* the
+//     work. The host puts its mal-rule values at the front of `distractors` and
+//     its place-value near-misses behind them, and the weighting below prefers
+//     the front.
+//
+//  2. **A false statement is never accidentally true.** Every candidate is
+//     compared to the answer with exact decimal-string arithmetic before it is
+//     allowed onto the slate. Nothing here parses a numeral into a `number`.
+//
+// The mapping is domain-blind on purpose. It reads `prompt`, `answer` and
+// `distractors` and nothing else, so the day `mul`, `frac` or `alg` are promoted
+// out of draft this game covers them with no change: a claim is a claim.
+
+import { canonicalNumeral, digitCount, sameValue } from "../core/exact.ts"
+import type { Rng } from "../core/rng.ts"
+import type { Question } from "../contract.ts"
+
+export type Statement = {
+  /** The served item this claim was built from. `""` when the pool ran dry. */
+  questionId: string
+  /** "47 + 25" */
+  expression: string
+  /** The value the slate claims. */
+  claimed: string
+  /** The value the curriculum says is right. */
+  answer: string
+  /** Whether the claim on the slate is true. */
+  truth: boolean
+  /** "47 + 25 = 62" */
+  text: string
+  /** How long the draw window stays open once the slate lights, in ms. */
+  windowMs: number
+  /** How long the street stays still before the slate lights, in ms. */
+  stillMs: number
+}
+
+/**
+ * The draw window, and the stillness before it.
+ *
+ * Both are a function of how much numeral there is to verify and of nothing
+ * else. In particular **neither depends on how long the run has been going**:
+ * `EXPERIENCE_DESIGN.md` bans escalation on run length, and a reaction game that
+ * quietly tightens its window every round is exactly that ban's target. A long
+ * run in this game is not faster. It is only longer.
+ *
+ * The two slopes pull in opposite directions on purpose. The window climbs
+ * steeply — `753 + 577 = 1330` needs real time, and `EXPERIENCE_DESIGN.md`'s own
+ * cadence table puts multi-digit regrouping at a 6 s p50 — while the stillness
+ * *flattens*, because a lead-in long enough for a four-digit sum is dead air on
+ * `12 + 5 = 17`. Short statements come at you faster; long ones give more room.
+ * Verification is cheaper than computation (the ones column alone rejects most
+ * mal-rules), which is why the budget can be under the cadence target at all.
+ */
+export function windowFor(text: string): number {
+  const d = digitCount(text)
+  return Math.max(1750, Math.min(3600, 1300 + 215 * d))
+}
+
+export function stillFor(text: string, rng: Rng): number {
+  const d = digitCount(text)
+  const base = Math.max(620, Math.min(1150, 420 + 80 * d))
+  // A fixed lead would let a child pre-load the press and stop reading. The
+  // jitter is small enough to stay a beat and large enough to defeat that.
+  return Math.round(base + rng.range(-140, 180))
+}
+
+/**
+ * Every distractor that is a legal, genuinely-wrong claim, in the host's own
+ * order, deduplicated by value rather than by spelling.
+ */
+export function falsehoodsFor(question: Question): string[] {
+  const canonicalAnswer = canonicalNumeral(question.answer)
+  // If the answer itself is not a numeral we cannot prove any claim wrong, and
+  // an unprovable claim must never be presented as false. This is the one
+  // failure mode that matters more than any other: a child asked to reject a
+  // true sentence learns that the game lies, and the game has no way to tell
+  // them otherwise. Nothing here guesses.
+  if (canonicalAnswer === null) return []
+
+  const seen = new Set<string>([canonicalAnswer])
+  const out: string[] = []
+  for (const candidate of question.distractors) {
+    const canonical = canonicalNumeral(candidate)
+    // Not a numeral, or the answer wearing a different coat. Either way it
+    // cannot go on a slate under "this is false".
+    if (canonical === null || seen.has(canonical)) continue
+    if (sameValue(candidate, question.answer)) continue
+    seen.add(canonical)
+    out.push(candidate)
+  }
+  return out
+}
+
+/**
+ * Build the claim. `wantTruth` is what the balancer asked for; the returned
+ * statement's `truth` is what was actually possible, and the caller reconciles
+ * the two — an item with no usable distractor can only ever be told truthfully.
+ */
+export function buildStatement(question: Question, wantTruth: boolean, rng: Rng): Statement {
+  const expression = question.prompt
+  let claimed = question.answer
+  let truth = true
+
+  if (!wantTruth) {
+    const falsehoods = falsehoodsFor(question)
+    const picked = pickFalsehood(falsehoods, rng)
+    if (picked !== null) {
+      claimed = picked
+      truth = false
+    }
+  }
+
+  const text = `${expression} = ${claimed}`
+  return {
+    questionId: question.id,
+    expression,
+    claimed,
+    answer: question.answer,
+    truth,
+    text,
+    windowMs: windowFor(text),
+    stillMs: stillFor(text, rng),
+  }
+}
+
+/**
+ * Weighted towards the head of the list, which is where the host puts the
+ * values a real broken procedure produces. The tail is place-value padding and
+ * is worth showing sometimes — a child who learns that the slate only ever lies
+ * in one way has learned the pack, not the arithmetic.
+ */
+function pickFalsehood(falsehoods: readonly string[], rng: Rng): string | null {
+  const head = falsehoods[0]
+  if (head === undefined) return null
+  if (falsehoods.length === 1) return head
+  if (rng.chance(0.55)) return head
+  return rng.pick(falsehoods.slice(1))
+}

--- a/dynawalla/games/truedraw/src/index.ts
+++ b/dynawalla/games/truedraw/src/index.ts
@@ -1,0 +1,3 @@
+export { mount } from "./contract.ts"
+export type { Host, Question } from "./contract.ts"
+export { createStubHost } from "./stub/host.ts"

--- a/dynawalla/games/truedraw/src/main.ts
+++ b/dynawalla/games/truedraw/src/main.ts
@@ -1,0 +1,39 @@
+// Standalone dev harness. `npm run dev` → a playable game wired to the local
+// stub Host, with no runtime underneath it.
+
+import { mount } from "./contract.ts"
+import { createStubHost } from "./stub/host.ts"
+
+const el = document.getElementById("app")
+if (!el) throw new Error("truedraw: #app missing")
+
+const params = new URLSearchParams(location.search)
+const seed = Number(params.get("seed") ?? "") || 0x7a1e5
+const level = Number(params.get("level") ?? "")
+const reduced = params.has("reduced") ? params.get("reduced") !== "0" : undefined
+
+let answered = 0
+let correct = 0
+const readout = document.getElementById("readout")
+
+const host = createStubHost({
+  seed,
+  ...(Number.isFinite(level) && params.has("level") ? { level } : {}),
+  ...(reduced === undefined ? {} : { reducedMotion: reduced }),
+  onReport(r) {
+    answered++
+    if (r.correct) correct++
+    if (readout) {
+      readout.textContent = `host.report → ${String(correct)}/${String(answered)} · last ${String(r.ms)}ms · "${r.answered || "—"}"`
+    }
+  },
+})
+
+const handle = mount(el, host)
+
+// Vite HMR: tear the old instance down so audio contexts and rAF loops do not
+// accumulate across edits.
+type HotModule = { hot?: { dispose(cb: () => void): void } }
+;(import.meta as unknown as HotModule).hot?.dispose(() => {
+  handle.unmount()
+})

--- a/dynawalla/games/truedraw/src/mount.ts
+++ b/dynawalla/games/truedraw/src/mount.ts
@@ -1,0 +1,176 @@
+// THE TRUE DRAW.
+//
+// One verb: draw.
+//
+//   * A statement is cut into the slate — `47 + 25 = 72`, or `47 + 25 = 62`.
+//     The wrong ones are not `answer ± 1`; they are what a child who drops the
+//     carry actually writes, so rejecting one means doing the arithmetic.
+//   * The street goes still. Then the slate lights. That is the only cue there
+//     is, and it is a light change, not a motion.
+//   * **Draw if it is true.** Hold if it is false.
+//   * A correct hold is the best thing in the game: the caller bows, and the
+//     slate rolls itself right in front of you.
+//   * A wrong draw is ignored. The slate does not change, the caller does not
+//     move, nothing sounds, nothing buzzes. A shot goes dark and the round ends
+//     in the silence it started in.
+//
+// Draw at everything and you are right exactly half the time, which is three
+// calls before the street clears. There is no percentage anywhere in this game
+// to misread as a pass.
+
+import { Audio } from "./audio/audio.ts"
+import type { Host } from "./contract.ts"
+import { bestCalls, recordCalls } from "./game/best.ts"
+import { Dealer } from "./game/dealer.ts"
+import { HAPTIC } from "./game/energy.ts"
+import { isCorrect, responseFor } from "./game/response.ts"
+import { Round, TIMING, TIMING_REDUCED, type RoundEvent } from "./game/round.ts"
+import { Rng } from "./core/rng.ts"
+import { Scene } from "./render/scene.ts"
+
+/** A milestone the child *reached*. Never fired when a run ends. */
+const TRANSITION_EVERY = 10
+
+/**
+ * The largest step the clock is allowed to take in one frame.
+ *
+ * A backgrounded tab hands back a delta of minutes. Letting that through would
+ * spend a draw window, three shots and a whole run while the child was looking
+ * at something else. Clamping means time nearly stops when frames stop, which is
+ * the only fair reading of "they were not here".
+ */
+const MAX_STEP_MS = 120
+
+export function mountTrueDraw(el: HTMLElement, host: Host): { unmount(): void } {
+  const canvas = document.createElement("canvas")
+  canvas.style.cssText = "position:absolute;inset:0;width:100%;height:100%;display:block;touch-action:none"
+  el.appendChild(canvas)
+
+  const reduced = host.prefersReducedMotion()
+  const scene = new Scene(canvas)
+  const audio = new Audio()
+  const rng = new Rng((Date.now() ^ 0x51ed) >>> 0)
+  const dealer = new Dealer(host, rng)
+  const round = new Round(() => dealer.deal(), reduced ? TIMING_REDUCED : TIMING)
+
+  let best = bestCalls()
+  let running = true
+  let last = 0
+  let frame = 0
+  let milestones = 0
+
+  const handle = (events: readonly RoundEvent[]): void => {
+    for (const event of events) {
+      switch (event.kind) {
+        case "cue": {
+          audio.cue()
+          break
+        }
+        case "settled": {
+          // The host is the judge. What goes across is the value the child
+          // effectively asserted — and on a wrong draw that value is a mal-rule
+          // output, so the misconception routes itself.
+          host.report({
+            questionId: event.statement.questionId,
+            correct: isCorrect(event.outcome),
+            ms: event.reactionMs,
+            answered: responseFor(event.outcome, event.statement),
+          })
+          audio.outcome(event.outcome)
+          const cue = HAPTIC[event.outcome]
+          if (cue) host.haptic(cue)
+          // A run of ten calls is a thing the child finished. A run that ended
+          // is not, and `transition` is never called there: a purchase surface
+          // must not sit next to a failure.
+          if (isCorrect(event.outcome)) {
+            const calls = round.run.calls
+            if (calls > 0 && calls % TRANSITION_EVERY === 0 && calls > milestones) {
+              milestones = calls
+              host.transition?.("level")
+            }
+          }
+          break
+        }
+        case "over": {
+          audio.over()
+          host.haptic("heavy")
+          if (recordCalls(event.run.calls)) best = event.run.calls
+          break
+        }
+        case "begin": {
+          milestones = 0
+          break
+        }
+        default:
+          break
+      }
+    }
+  }
+
+  const tick = (now: number): void => {
+    if (!running) return
+    frame = requestAnimationFrame(tick)
+    const dt = last === 0 ? 16 : Math.min(MAX_STEP_MS, now - last)
+    last = now
+    handle(round.advance(dt))
+    scene.draw({
+      phase: round.phase,
+      progress: round.progress,
+      elapsedMs: round.elapsedMs,
+      statement: round.statement,
+      outcome: round.outcome,
+      run: round.run,
+      best,
+      reduced,
+    })
+  }
+
+  const press = (event: Event): void => {
+    event.preventDefault()
+    // Web Audio needs a gesture, and the first press in the game is the first
+    // gesture there is.
+    audio.resume()
+    handle(round.press())
+  }
+
+  const key = (event: KeyboardEvent): void => {
+    if (event.repeat) return
+    if (event.key !== " " && event.key !== "Enter") return
+    press(event)
+  }
+
+  const resize = (): void => {
+    scene.resize()
+  }
+
+  canvas.addEventListener("pointerdown", press)
+  globalThis.addEventListener("keydown", key)
+  globalThis.addEventListener("resize", resize)
+
+  const observer =
+    typeof ResizeObserver === "function"
+      ? new ResizeObserver(() => {
+          scene.resize()
+        })
+      : null
+  observer?.observe(el)
+
+  // No start screen and no start button. The street stands empty with three
+  // loaded shots breathing under a lowered slate, and the first tap anywhere is
+  // the start — which also happens to be the gesture Web Audio needs before the
+  // first cue can sound.
+  frame = requestAnimationFrame(tick)
+
+  return {
+    unmount(): void {
+      running = false
+      cancelAnimationFrame(frame)
+      canvas.removeEventListener("pointerdown", press)
+      globalThis.removeEventListener("keydown", key)
+      globalThis.removeEventListener("resize", resize)
+      observer?.disconnect()
+      audio.dispose()
+      canvas.remove()
+    },
+  }
+}

--- a/dynawalla/games/truedraw/src/pack.ts
+++ b/dynawalla/games/truedraw/src/pack.ts
@@ -1,0 +1,44 @@
+// THE TRUE DRAW, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous surface `Host` in
+// `contract.ts` already describes — so the round clock, the truth balancer, the
+// statement builder and the slate are untouched.
+//
+// What crosses the boundary is the claim. `items.reveal` is declared and is not
+// optional here: without the canonical value there is no such thing as a true
+// statement, and the pack would mount, warm, and serve a slate with nothing on
+// it. The distractors that come with the item are the mal-rule outputs a real
+// broken procedure produces, and they are what the slate lies with.
+//
+// The game never decides whether a call was right. It reports the value the
+// child effectively asserted and the host judges — and on a wrong draw that
+// value is the mal-rule itself, so the diagnosis routes with no extra wiring.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import { mount } from "./contract.ts"
+import type { Host } from "./contract.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("truedraw: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "add-sub" })
+  // Stocked before the first frame. The first slate goes up within a second of
+  // the first tap, and a blank one is the kind of thing that happens exactly
+  // once, on launch, in front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context come down before the frame does rather than a frame or two after.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[truedraw] could not start", error)
+  renderNoHost(root, "THE TRUE DRAW")
+})

--- a/dynawalla/games/truedraw/src/render/fakeCanvas.ts
+++ b/dynawalla/games/truedraw/src/render/fakeCanvas.ts
@@ -1,0 +1,124 @@
+// A recording 2D context.
+//
+// The rendered-output gate in `EXPERIENCE_DESIGN.md` is a human looking at
+// PNGs, and it should be. This is the part a machine can hold: that the scene
+// draws without throwing at any size, in either motion branch, at every phase —
+// and, the one that is a design claim rather than a robustness claim, that a
+// wrong draw puts **no additional ink on the screen at all**.
+//
+// It records the ops rather than rasterising, so it needs no canvas backend and
+// runs in the same plain `node --test` as everything else.
+
+export type Op = {
+  readonly name: string
+  readonly args: readonly unknown[]
+  /** `globalAlpha` at the moment of the call. Ink drawn at 0 is ink not drawn. */
+  readonly alpha: number
+  /** The `fillStyle` or `strokeStyle` in force — so a colour change is visible. */
+  readonly style: string
+}
+
+export type Recorder = {
+  readonly ops: Op[]
+  /** Ops that put something on the screen, as opposed to setting up state. */
+  ink(): Op[]
+  reset(): void
+}
+
+const INK = new Set(["fill", "stroke", "fillRect", "strokeRect", "fillText"])
+
+/**
+ * A canvas-shaped object with a recording context. Returned as `unknown` so the
+ * cast happens at the one call site rather than being spread through the file.
+ */
+export function fakeCanvas(width: number, height: number): { canvas: unknown; rec: Recorder } {
+  const ops: Op[] = []
+  let ctxRef: Record<string, unknown> | null = null
+  const STROKES = new Set(["stroke", "strokeRect"])
+  const record = (name: string) => (...args: unknown[]) => {
+    const alpha = ctxRef?.["globalAlpha"]
+    // Only the ops that actually consume a style carry one. `clearRect` and
+    // friends would otherwise report whatever colour the previous frame left
+    // behind, which is a fact about the recorder rather than about the frame.
+    const style = INK.has(name) ? ctxRef?.[STROKES.has(name) ? "strokeStyle" : "fillStyle"] : ""
+    ops.push({
+      name,
+      args,
+      alpha: typeof alpha === "number" ? alpha : 1,
+      // A gradient is an object; the constant colour cases are strings and are
+      // the ones a "nothing changed" comparison needs to see.
+      style: typeof style === "string" ? style : "<gradient>",
+    })
+  }
+
+  const gradient = {
+    addColorStop: record("addColorStop"),
+  }
+
+  const ctx: Record<string, unknown> = {
+    canvas: null,
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 1,
+    lineCap: "butt",
+    globalAlpha: 1,
+    font: "",
+    textAlign: "left",
+    textBaseline: "alphabetic",
+    setTransform: record("setTransform"),
+    clearRect: record("clearRect"),
+    save: record("save"),
+    restore: record("restore"),
+    translate: record("translate"),
+    rotate: record("rotate"),
+    beginPath: record("beginPath"),
+    closePath: record("closePath"),
+    moveTo: record("moveTo"),
+    lineTo: record("lineTo"),
+    arc: record("arc"),
+    rect: record("rect"),
+    clip: record("clip"),
+    fill: record("fill"),
+    stroke: record("stroke"),
+    fillRect: record("fillRect"),
+    strokeRect: record("strokeRect"),
+    fillText: record("fillText"),
+    createLinearGradient: (...args: unknown[]) => {
+      ops.push({ name: "createLinearGradient", args, alpha: 1, style: "" })
+      return gradient
+    },
+    // A crude but monotone metric: enough for the layout code, which only ever
+    // asks for relative widths.
+    measureText: (text: string) => ({ width: [...text].length * 9 }),
+  }
+
+  const canvas = {
+    width: 0,
+    height: 0,
+    style: {} as Record<string, string>,
+    getContext: () => ctx,
+    getBoundingClientRect: () => ({ width, height, top: 0, left: 0, right: width, bottom: height }),
+  }
+  ctx["canvas"] = canvas
+  ctxRef = ctx
+
+  return {
+    canvas,
+    rec: {
+      ops,
+      ink: () => ops.filter((op) => INK.has(op.name)),
+      reset: () => {
+        ops.length = 0
+      },
+    },
+  }
+}
+
+/** Every numeric argument the scene passed to the context, flattened. */
+export function numbersIn(ops: readonly Op[]): number[] {
+  const out: number[] = []
+  for (const op of ops) {
+    for (const arg of op.args) if (typeof arg === "number") out.push(arg)
+  }
+  return out
+}

--- a/dynawalla/games/truedraw/src/render/glyphs.test.ts
+++ b/dynawalla/games/truedraw/src/render/glyphs.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { correctionFor, digitCellWidth, layout } from "./glyphs.ts"
+
+/** A stand-in for the canvas: a proportional face where `1` is narrow. */
+const face = {
+  measureText(text: string): { width: number } {
+    let w = 0
+    for (const ch of text) {
+      if (ch === "1") w += 5
+      else if (ch >= "0" && ch <= "9") w += 11
+      else if (ch === " ") w += 6
+      else w += 13
+    }
+    return { width: w }
+  },
+}
+
+test("the digit cell is the widest numeral in the face", () => {
+  assert.equal(digitCellWidth(face), 11)
+})
+
+test("two statements with the same shape occupy the same grid", () => {
+  const cell = digitCellWidth(face)
+  const a = layout(face, "4003 − 87 = 3916", cell)
+  const b = layout(face, "1111 − 11 = 1100", cell)
+  assert.equal(a.width, b.width, "a 1 must not reflow the line")
+  assert.deepEqual(
+    a.cells.map((c) => c.x),
+    b.cells.map((c) => c.x),
+  )
+})
+
+test("a digit takes the cell and everything else takes its own width", () => {
+  const l = layout(face, "1 + 1", digitCellWidth(face))
+  assert.equal(l.cells[0]?.w, 11)
+  assert.equal(l.cells[0]?.digit, true)
+  assert.equal(l.cells[1]?.w, 6)
+  assert.equal(l.cells[1]?.digit, false)
+})
+
+test("a same-width correction rolls only the columns that changed", () => {
+  const l = layout(face, "47 + 25 = 62", digitCellWidth(face))
+  const correction = correctionFor(l, "62", "72")
+  assert.equal(correction.canRoll, true)
+  assert.equal(correction.rolls.length, 1)
+  assert.equal(correction.rolls[0]?.from, "6")
+  assert.equal(correction.rolls[0]?.to, "7")
+  assert.equal(correction.rolls[0]?.index, l.cells.length - 2)
+})
+
+test("two columns can roll at once", () => {
+  const l = layout(face, "503 − 87 = 426", digitCellWidth(face))
+  const correction = correctionFor(l, "426", "416")
+  assert.deepEqual(
+    correction.rolls.map((r) => [r.from, r.to]),
+    [["2", "1"]],
+  )
+})
+
+test("a correction that changes the digit count cannot roll", () => {
+  const l = layout(face, "95 + 5 = 90", digitCellWidth(face))
+  const correction = correctionFor(l, "90", "100")
+  assert.equal(correction.canRoll, false)
+  assert.equal(correction.rolls.length, 0)
+  assert.equal(correction.start, l.cells.length - 2)
+})

--- a/dynawalla/games/truedraw/src/render/glyphs.ts
+++ b/dynawalla/games/truedraw/src/render/glyphs.ts
@@ -1,0 +1,84 @@
+// Tabular layout for the slate.
+//
+// Canvas has no `font-variant-numeric: tabular-nums`, so a proportional serif
+// reflows the whole statement when a `1` follows an `8` — and the statement is
+// read at speed, under a clock, by a child. So digits are laid out on a fixed
+// cell measured from the widest numeral in the face, and everything else takes
+// its natural width. `4003 − 87 = 3916` and `1111 − 11 = 1100` occupy the same
+// grid.
+//
+// This is also what makes the correction roll possible at all: a digit that
+// rolls over into another digit has to roll inside a box that does not move.
+
+export type Cell = {
+  readonly ch: string
+  /** Left edge, relative to the start of the run. */
+  readonly x: number
+  readonly w: number
+  readonly digit: boolean
+}
+
+export type Layout = {
+  readonly cells: readonly Cell[]
+  readonly width: number
+  /** The fixed digit cell this layout was built on. */
+  readonly cellW: number
+}
+
+type Measurer = { measureText(text: string): { width: number } }
+
+/** The widest digit in the current face and size. */
+export function digitCellWidth(ctx: Measurer): number {
+  let w = 0
+  for (let d = 0; d <= 9; d++) w = Math.max(w, ctx.measureText(String(d)).width)
+  return w
+}
+
+export function layout(ctx: Measurer, text: string, cellW: number): Layout {
+  const cells: Cell[] = []
+  let x = 0
+  for (const ch of text) {
+    const digit = ch >= "0" && ch <= "9"
+    const w = digit ? cellW : ctx.measureText(ch).width
+    cells.push({ ch, x, w, digit })
+    x += w
+  }
+  return { cells, width: x, cellW }
+}
+
+/**
+ * Which trailing cells hold the claimed value, and whether it can roll into the
+ * answer in place.
+ *
+ * A roll needs the two numerals to have the same number of glyphs — `62 → 72`
+ * rolls one column, `90 → 100` cannot roll at all and cross-fades instead. The
+ * caller picks the branch; this only reports which it is.
+ */
+export type Correction = {
+  /** Index of the first cell of the claimed value. */
+  readonly start: number
+  /** Per-column pairs, present only when a roll is possible. */
+  readonly rolls: readonly { readonly index: number; readonly from: string; readonly to: string }[]
+  readonly canRoll: boolean
+}
+
+export function correctionFor(
+  layoutOf: Layout,
+  claimed: string,
+  answer: string,
+): Correction {
+  const start = Math.max(0, layoutOf.cells.length - [...claimed].length)
+  if ([...claimed].length !== [...answer].length) {
+    return { start, rolls: [], canRoll: false }
+  }
+  const from = [...claimed]
+  const to = [...answer]
+  const rolls: { index: number; from: string; to: string }[] = []
+  for (let i = 0; i < from.length; i++) {
+    const a = from[i] ?? ""
+    const b = to[i] ?? ""
+    if (a === b) continue
+    rolls.push({ index: start + i, from: a, to: b })
+  }
+  return { start, rolls, canRoll: rolls.length > 0 }
+}

--- a/dynawalla/games/truedraw/src/render/palette.ts
+++ b/dynawalla/games/truedraw/src/render/palette.ts
@@ -1,0 +1,54 @@
+// Material, not lighting. Brass, lapis, carved stone, cold celestial light,
+// and a lot of unlit dust — the palette of `EXPERIENCE_DESIGN.md`'s art
+// direction, with nothing in it that glows for its own sake.
+//
+// There is no accent colour and no "primary action" colour, on purpose: those
+// are the two tells the hostile reference board calls a dashboard.
+
+export const NIGHT = "#0a0c11"
+export const NIGHT_DEEP = "#06070b"
+export const DUST = "#171410"
+export const DUST_LIT = "#241d15"
+export const HAZE = "#1d222b"
+
+export const STONE = "#2b2f38"
+export const STONE_EDGE = "#3b414d"
+export const STONE_RECESS = "#191c22"
+
+export const BRASS = "#b08d4e"
+export const BRASS_DIM = "#6b5730"
+export const BRASS_LIT = "#e6c281"
+
+export const LAPIS = "#22406b"
+
+/** The statement before the slate lights: legible, and plainly unlit. */
+export const CHALK_UNLIT = "#5c6577"
+/** The statement once it lights. Cold, celestial, the only bright thing. */
+export const CHALK_LIT = "#d6e6ff"
+/** A value the slate is about to admit was wrong. */
+export const CHALK_WRONG = "#7d7466"
+
+export const FIGURE = "#0e1017"
+export const FIGURE_RIM = "#3c4353"
+
+export function withAlpha(hex: string, alpha: number): string {
+  const n = Number.parseInt(hex.slice(1), 16)
+  const r = (n >> 16) & 255
+  const g = (n >> 8) & 255
+  const b = n & 255
+  return `rgba(${String(r)}, ${String(g)}, ${String(b)}, ${String(Math.max(0, Math.min(1, alpha)))})`
+}
+
+/** Linear blend between two hex colours. */
+export function mix(a: string, b: string, t: number): string {
+  const k = Math.max(0, Math.min(1, t))
+  const na = Number.parseInt(a.slice(1), 16)
+  const nb = Number.parseInt(b.slice(1), 16)
+  const r = Math.round(((na >> 16) & 255) * (1 - k) + ((nb >> 16) & 255) * k)
+  const g = Math.round(((na >> 8) & 255) * (1 - k) + ((nb >> 8) & 255) * k)
+  const bl = Math.round((na & 255) * (1 - k) + (nb & 255) * k)
+  return `rgb(${String(r)}, ${String(g)}, ${String(bl)})`
+}
+
+/** The engraved face. A serif, because a slate is cut, not printed. */
+export const SLATE_FONT = `"Iowan Old Style", "Palatino Linotype", Palatino, "Times New Roman", Georgia, serif`

--- a/dynawalla/games/truedraw/src/render/scene.test.ts
+++ b/dynawalla/games/truedraw/src/render/scene.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import type { Outcome } from "../game/response.ts"
+import type { Phase } from "../game/round.ts"
+import { newRun, applyOutcome, type Run } from "../game/run.ts"
+import type { Statement } from "../game/statement.ts"
+import { fakeCanvas, numbersIn, type Recorder } from "./fakeCanvas.ts"
+import { Scene, type SceneState } from "./scene.ts"
+
+const SIZES: readonly [number, number][] = [
+  [320, 568],
+  [390, 844],
+  [768, 1024],
+  [1280, 800],
+]
+
+const PHASES: readonly Phase[] = ["idle", "raise", "still", "call", "verdict", "clear", "over"]
+const OUTCOMES: readonly Outcome[] = ["hit", "bow", "wild", "slow"]
+
+function statement(over: Partial<Statement> = {}): Statement {
+  return {
+    questionId: "q",
+    expression: "4003 − 87",
+    claimed: "3926",
+    answer: "3916",
+    truth: false,
+    text: "4003 − 87 = 3926",
+    windowMs: 2800,
+    stillMs: 1400,
+    ...over,
+  }
+}
+
+function state(over: Partial<SceneState> = {}): SceneState {
+  return {
+    phase: "call",
+    progress: 0.5,
+    elapsedMs: 400,
+    statement: statement(),
+    outcome: null,
+    run: newRun(),
+    best: 0,
+    reduced: false,
+    ...over,
+  }
+}
+
+function scene(w: number, h: number): { scene: Scene; rec: Recorder } {
+  const { canvas, rec } = fakeCanvas(w, h)
+  return { scene: new Scene(canvas as HTMLCanvasElement), rec }
+}
+
+test("the street draws without throwing at every phase, size and motion branch", () => {
+  for (const [w, h] of SIZES) {
+    for (const reduced of [false, true]) {
+      const { scene: s, rec } = scene(w, h)
+      for (const phase of PHASES) {
+        for (const outcome of [null, ...OUTCOMES]) {
+          for (const progress of [0, 0.24, 0.5, 0.76, 1]) {
+            rec.reset()
+            s.draw(state({ phase, outcome, progress, elapsedMs: progress * 900, reduced }))
+            const bad = numbersIn(rec.ops).filter((n) => !Number.isFinite(n))
+            assert.equal(bad.length, 0, `${String(w)}×${String(h)} ${phase}/${String(outcome)}`)
+          }
+        }
+      }
+    }
+  }
+})
+
+test("a wrong draw changes nothing on the street — not one op, alpha or colour", () => {
+  // The design claim, at the level of the renderer, asserted as strictly as it
+  // can be: take the very last frame of the open window, then every frame of
+  // the wild verdict that follows, and require the street — everything up to
+  // and including the slate — to be *identical*. Same draw calls, same order,
+  // same alphas, same colours. No mark cut, no light regained, no bow.
+  //
+  // The hud is excluded and only the hud: one shot pip becomes a ring. That is
+  // the entire visible consequence of a wrong draw.
+  const fingerprint = (rec: ReturnType<typeof scene>["rec"]): string => {
+    const end = rec.ops.findLastIndex((op) => op.name === "restore")
+    return rec.ops
+      .slice(0, end + 1)
+      .map((op) => `${op.name}|${op.alpha.toFixed(4)}|${op.style}|${op.args.join(",")}`)
+      .join("\n")
+  }
+
+  const { scene: s, rec } = scene(768, 1024)
+  const run = newRun()
+  const st = statement({ windowMs: 2800 })
+
+  rec.reset()
+  s.draw(state({ phase: "call", progress: 1, elapsedMs: st.windowMs, statement: st, run }))
+  const window = fingerprint(rec)
+  assert.ok(window.length > 500, "the fingerprint is not vacuously short")
+
+  const spent = applyOutcome(run, "wild")
+  for (const progress of [0, 0.1, 0.5, 0.99, 1]) {
+    rec.reset()
+    s.draw(
+      state({
+        phase: "verdict",
+        outcome: "wild",
+        progress,
+        elapsedMs: progress * 620,
+        statement: st,
+        run: spent,
+      }),
+    )
+    assert.equal(fingerprint(rec), window, `the street changed at ${String(progress)}`)
+  }
+})
+
+test("the light goes out of the window, and that is the only clock", () => {
+  // No bar, no ring, no countdown, nothing that moves — the statement simply
+  // cools as the beat runs out. It must still be plainly legible at the end.
+  const { scene: s, rec } = scene(768, 1024)
+  const st = statement({ windowMs: 2800 })
+  const brightness: number[] = []
+  for (const elapsedMs of [90, 700, 1400, 2100, 2800]) {
+    rec.reset()
+    s.draw(state({ phase: "call", elapsedMs, progress: elapsedMs / st.windowMs, statement: st }))
+    const glyph = rec.ops.find((op) => op.name === "fillText")
+    // "rgb(r, g, b)" — the green channel is a fine proxy for how lit it is.
+    const green = Number(/rgb\(\d+, (\d+)/.exec(glyph?.style ?? "")?.[1] ?? "0")
+    brightness.push(green)
+  }
+  for (let i = 1; i < brightness.length; i++) {
+    assert.ok(
+      (brightness[i] ?? 0) < (brightness[i - 1] ?? 0),
+      `the street must keep cooling: ${brightness.join(" → ")}`,
+    )
+  }
+  // Unlit chalk is #5c6577 — green 101. The end of the window must still be
+  // meaningfully brighter than that.
+  assert.ok((brightness.at(-1) ?? 0) > 130, `too dark to read at the end: ${brightness.join(" → ")}`)
+})
+
+test("a correct hold is the loudest thing on the screen", () => {
+  const { scene: s, rec } = scene(768, 1024)
+  const run = newRun()
+  const counts: Record<string, number> = {}
+  for (const outcome of OUTCOMES) {
+    rec.reset()
+    s.draw(state({ phase: "verdict", outcome, progress: 0.6, elapsedMs: 500, run }))
+    counts[outcome] = rec.ink().length
+  }
+  assert.ok((counts["wild"] ?? 0) < (counts["hit"] ?? 0), "being ignored is the quietest")
+  assert.ok((counts["wild"] ?? 0) < (counts["bow"] ?? 0))
+})
+
+test("the correction is drawn whether or not the digit counts match", () => {
+  const { scene: s, rec } = scene(768, 1024)
+  for (const claim of [
+    // Same width: the columns roll.
+    statement({ claimed: "3926", answer: "3916", text: "4003 − 87 = 3926" }),
+    // Different width: there is no column to roll in, so it cross-fades.
+    statement({ claimed: "90", answer: "100", expression: "95 + 5", text: "95 + 5 = 90" }),
+  ]) {
+    for (const reduced of [false, true]) {
+      rec.reset()
+      s.draw(
+        state({ phase: "verdict", outcome: "bow", progress: 0.6, statement: claim, reduced }),
+      )
+      const texts = rec.ops.filter((op) => op.name === "fillText").map((op) => String(op.args[0]))
+      assert.ok(texts.includes("1"), `the corrected digit is on the slate: ${texts.join("")}`)
+      assert.equal(numbersIn(rec.ops).filter((n) => !Number.isFinite(n)).length, 0)
+    }
+  }
+})
+
+test("the corrected value is visible at the end of the cross-fade, not transparent", () => {
+  // The bug this test exists for: a running `globalAlpha *= (1 - t)` paired
+  // with a `/=` to undo it is exactly zero at `t = 1`, the division cannot
+  // recover it, and every glyph drawn afterwards — including the corrected
+  // numeral the whole fade exists to reveal — lands at alpha zero. The slate
+  // would appear to erase itself instead of correcting itself.
+  const { scene: s, rec } = scene(768, 1024)
+  const claim = statement({ claimed: "90", answer: "100", expression: "95 + 5", text: "95 + 5 = 90" })
+  for (const progress of [0.5, 0.74, 0.9, 1]) {
+    rec.reset()
+    s.draw(state({ phase: "verdict", outcome: "bow", progress, statement: claim }))
+    const corrected = rec.ops.filter((op) => op.name === "fillText" && op.args[0] === "1")
+    assert.ok(corrected.length > 0, `no corrected digit at ${String(progress)}`)
+    assert.ok(
+      corrected.some((op) => op.alpha > 0.2),
+      `the corrected digit was drawn at alpha ${String(corrected[0]?.alpha)} at ${String(progress)}`,
+    )
+  }
+})
+
+test("the slate leaves the context's alpha exactly as it found it", () => {
+  const { scene: s, rec } = scene(768, 1024)
+  for (const outcome of [null, ...OUTCOMES]) {
+    for (const progress of [0, 0.5, 1]) {
+      rec.reset()
+      s.draw(state({ phase: "verdict", outcome, progress }))
+      // Whatever the slate did inside its save/restore, the shot pips drawn
+      // after it must not inherit a faded or zeroed alpha. The pips are the
+      // first thing past the last `restore`, and they set no alpha of their own
+      // until after they are drawn — so they are the honest witness.
+      const tail = rec.ops.slice(rec.ops.findLastIndex((op) => op.name === "restore") + 1)
+      const pips = tail.filter((op) => op.name === "fill" || op.name === "stroke")
+      assert.ok(pips.length > 0, "the shots are drawn")
+      for (const pip of pips) {
+        assert.ok(pip.alpha > 0.2, `${String(outcome)} at ${String(progress)}: alpha ${String(pip.alpha)}`)
+      }
+    }
+  }
+})
+
+test("the crowd is the tally and never draws more people than calls", () => {
+  const { scene: s, rec } = scene(768, 1024)
+  let previous = -1
+  let run: Run = newRun()
+  for (let i = 0; i <= 20; i++) {
+    rec.reset()
+    s.draw(state({ phase: "still", run }))
+    const figures = rec.ops.filter((op) => op.name === "rotate").length
+    assert.ok(figures >= previous, "the crowd never steps back into the haze")
+    previous = figures
+    run = applyOutcome(run, "hit")
+  }
+  // The caller plus fourteen witnesses, and no more.
+  assert.equal(previous, 15)
+})
+
+test("the ledger shows a length and never a percentage", () => {
+  const { scene: s, rec } = scene(768, 1024)
+  let run = newRun()
+  for (let i = 0; i < 3; i++) run = applyOutcome(run, "hit")
+  for (let i = 0; i < 3; i++) run = applyOutcome(run, "wild")
+  rec.reset()
+  s.draw(state({ phase: "over", progress: 1, elapsedMs: 1200, run, best: 9 }))
+  const texts = rec.ops.filter((op) => op.name === "fillText").map((op) => String(op.args[0]))
+  assert.ok(texts.includes("3"), "the run's length, and it is three")
+  assert.ok(!texts.some((t) => t.includes("%")), "there is no percentage anywhere")
+})

--- a/dynawalla/games/truedraw/src/render/scene.ts
+++ b/dynawalla/games/truedraw/src/render/scene.ts
@@ -1,0 +1,529 @@
+// The street.
+//
+// Everything about this renderer is subtraction. There are no particles, no
+// glow layers, no confetti, no colour that means "correct". There is a dust
+// plane, a slate, a caller, and the people who have gathered to watch — and for
+// most of every round none of them move at all.
+//
+// The one bright event in the game is the slate lighting, and it is a light
+// change rather than a motion: the engraved statement goes from unlit stone to
+// cold celestial, the brass frame catches it, and that is the go signal. Total
+// stillness, then a slate-flash. Restraint as the whole design.
+
+import type { Outcome } from "../game/response.ts"
+import type { Phase } from "../game/round.ts"
+import type { Run } from "../game/run.ts"
+import { SHOTS } from "../game/run.ts"
+import type { Statement } from "../game/statement.ts"
+import { correctionFor, digitCellWidth, layout, type Layout } from "./glyphs.ts"
+import {
+  BRASS,
+  BRASS_DIM,
+  BRASS_LIT,
+  CHALK_LIT,
+  CHALK_UNLIT,
+  CHALK_WRONG,
+  DUST,
+  DUST_LIT,
+  FIGURE,
+  FIGURE_RIM,
+  HAZE,
+  LAPIS,
+  NIGHT,
+  NIGHT_DEEP,
+  SLATE_FONT,
+  STONE,
+  STONE_EDGE,
+  STONE_RECESS,
+  mix,
+  withAlpha,
+} from "./palette.ts"
+
+export type SceneState = {
+  readonly phase: Phase
+  /** 0..1 through the current phase. */
+  readonly progress: number
+  readonly elapsedMs: number
+  readonly statement: Statement | null
+  readonly outcome: Outcome | null
+  readonly run: Run
+  readonly best: number
+  readonly reduced: boolean
+}
+
+/**
+ * How much light is left on the street when the draw window closes. Not zero:
+ * the statement stays plainly legible to the last millisecond, because a child
+ * who is still reading must never be reading in the dark.
+ */
+const WINDOW_FLOOR = 0.45
+
+const easeOut = (t: number): number => 1 - (1 - t) * (1 - t) * (1 - t)
+const easeInOut = (t: number): number => (t < 0.5 ? 2 * t * t : 1 - (-2 * t + 2) ** 2 / 2)
+const clamp01 = (t: number): number => Math.max(0, Math.min(1, t))
+
+export class Scene {
+  private readonly canvas: HTMLCanvasElement
+  private readonly ctx: CanvasRenderingContext2D
+  private w = 0
+  private h = 0
+  private dpr = 1
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.canvas = canvas
+    const ctx = canvas.getContext("2d", { alpha: false })
+    if (!ctx) throw new Error("truedraw: no 2d context")
+    this.ctx = ctx
+    this.resize()
+  }
+
+  resize(): void {
+    const rect = this.canvas.getBoundingClientRect()
+    // A zero-sized parent happens for one frame during mount; refusing to
+    // divide by it is cheaper than guarding every call site.
+    this.w = Math.max(1, Math.round(rect.width))
+    this.h = Math.max(1, Math.round(rect.height))
+    this.dpr = Math.min(3, globalThis.devicePixelRatio || 1)
+    this.canvas.width = Math.round(this.w * this.dpr)
+    this.canvas.height = Math.round(this.h * this.dpr)
+  }
+
+  draw(state: SceneState): void {
+    const { ctx } = this
+    ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0)
+    ctx.clearRect(0, 0, this.w, this.h)
+
+    const horizon = this.h * 0.6
+    this.drawSky(horizon)
+    this.drawGround(horizon, state)
+    this.drawWitnesses(horizon, state)
+    this.drawCaller(horizon, state)
+    this.drawSlate(state)
+    this.drawShots(state)
+    this.drawTally(state)
+  }
+
+  // ── ground and sky ──────────────────────────────────────────────────────
+
+  private drawSky(horizon: number): void {
+    const { ctx } = this
+    const sky = ctx.createLinearGradient(0, 0, 0, horizon)
+    sky.addColorStop(0, NIGHT_DEEP)
+    sky.addColorStop(0.72, NIGHT)
+    sky.addColorStop(1, HAZE)
+    ctx.fillStyle = sky
+    ctx.fillRect(0, 0, this.w, horizon)
+  }
+
+  private drawGround(horizon: number, state: SceneState): void {
+    const { ctx } = this
+    const lit = this.litness(state)
+    const ground = ctx.createLinearGradient(0, horizon, 0, this.h)
+    ground.addColorStop(0, mix(DUST, DUST_LIT, lit * 0.7))
+    ground.addColorStop(1, NIGHT_DEEP)
+    ctx.fillStyle = ground
+    ctx.fillRect(0, horizon, this.w, this.h - horizon)
+
+    // The horizon itself: one hairline of lapis where the dust meets the sky.
+    ctx.fillStyle = withAlpha(LAPIS, 0.5 + lit * 0.3)
+    ctx.fillRect(0, horizon - 1, this.w, 1)
+  }
+
+  // ── the people ──────────────────────────────────────────────────────────
+
+  /**
+   * The crowd. One witness steps out of the haze per call made, and none of
+   * them ever steps back: this is the run's tally drawn as people, and a tally
+   * that could shrink would be the loss-aversion loop the product bans.
+   *
+   * A masher's street therefore stays empty, which is the entire point.
+   */
+  private drawWitnesses(horizon: number, state: SceneState): void {
+    const { ctx } = this
+    const count = Math.min(14, state.run.calls)
+    for (let i = 0; i < count; i++) {
+      const side = i % 2 === 0 ? -1 : 1
+      const rank = Math.floor(i / 2)
+      // Deterministic scatter: the same call count always draws the same
+      // street, so nothing shimmers between frames.
+      const jitter = ((i * 2654435761) % 1000) / 1000
+      const spread = 0.16 + rank * 0.075 + jitter * 0.05
+      const x = this.w * (0.5 + side * spread)
+      const depth = 1 - Math.min(0.55, rank * 0.09 + jitter * 0.06)
+      const height = this.h * 0.1 * depth
+      const y = horizon + this.h * 0.012 * (1 - depth) * 3
+      ctx.globalAlpha = 0.34 + depth * 0.4
+      this.figure(x, y, height, 0, 0)
+      ctx.globalAlpha = 1
+    }
+  }
+
+  /** The caller: still by default, bowing when you correctly let a lie stand. */
+  private drawCaller(horizon: number, state: SceneState): void {
+    const height = this.h * 0.155
+    const x = this.w * 0.5
+    const y = horizon + this.h * 0.008
+
+    let lean = 0
+    let arm = 0
+    if (state.outcome === "bow" && !state.reduced) {
+      // Down, held, and back up — the whole of it inside the verdict.
+      const t = state.phase === "verdict" ? state.progress : 1
+      lean = 0.42 * Math.sin(Math.PI * clamp01(t) ** 0.85)
+    }
+    if (state.outcome === "slow") {
+      // The caller draws. One motion, and it is over before you look up.
+      const t = state.phase === "verdict" ? easeOut(clamp01(state.progress * 3.2)) : 1
+      arm = t
+    }
+    this.figure(x, y, height, lean, arm, state.outcome === "bow" ? this.litness(state) : 0)
+  }
+
+  /**
+   * A silhouette. Deliberately faceless and deliberately made of the same three
+   * strokes as everything else on the street — the character in this product is
+   * an automaton drawn in the material language of the instruments, never a
+   * mascot.
+   */
+  private figure(x: number, y: number, height: number, lean: number, arm: number, rim = 0): void {
+    const { ctx } = this
+    const w = height * 0.3
+    ctx.save()
+    ctx.translate(x, y)
+    ctx.rotate(lean)
+
+    ctx.fillStyle = FIGURE
+    ctx.beginPath()
+    // A tapered coat: wide at the hem, narrow at the shoulder.
+    ctx.moveTo(-w * 0.62, 0)
+    ctx.lineTo(-w * 0.34, -height * 0.72)
+    ctx.lineTo(w * 0.34, -height * 0.72)
+    ctx.lineTo(w * 0.62, 0)
+    ctx.closePath()
+    ctx.fill()
+
+    ctx.beginPath()
+    ctx.arc(0, -height * 0.82, height * 0.11, 0, Math.PI * 2)
+    ctx.fill()
+
+    if (arm > 0) {
+      ctx.strokeStyle = FIGURE
+      ctx.lineWidth = Math.max(2, height * 0.075)
+      ctx.lineCap = "round"
+      ctx.beginPath()
+      ctx.moveTo(w * 0.28, -height * 0.62)
+      const reach = -Math.PI * 0.5 * arm
+      ctx.lineTo(w * 0.28 + Math.cos(reach) * height * 0.34, -height * 0.62 + Math.sin(reach) * height * 0.34)
+      ctx.stroke()
+    }
+
+    // One brass hairline down the lit side. The only thing that distinguishes
+    // the caller from the crowd, and it is a rim light, not a costume.
+    ctx.strokeStyle = withAlpha(rim > 0 ? BRASS_LIT : FIGURE_RIM, 0.55 + rim * 0.35)
+    ctx.lineWidth = 1.25
+    ctx.beginPath()
+    ctx.moveTo(-w * 0.62, 0)
+    ctx.lineTo(-w * 0.34, -height * 0.72)
+    ctx.stroke()
+    ctx.restore()
+  }
+
+  // ── the slate ───────────────────────────────────────────────────────────
+
+  /**
+   * How lit the street is: 0 while it is still, 1 the instant the slate catches.
+   *
+   * The rise is 90 ms and it does not travel, pulse or repeat — the cue is a
+   * light change, which is the whole of the juice budget spent in one place.
+   *
+   * Then it **cools**, back to `WINDOW_FLOOR` by the moment the window closes.
+   * That is the clock, and it is the only one: no bar, no ring, no countdown,
+   * nothing that moves. The beat is legible because the light is going out of
+   * it, which is what a child feels rather than reads.
+   */
+  private litness(state: SceneState): number {
+    if (state.phase === "call") {
+      const rise = clamp01(state.elapsedMs / 90)
+      const window = state.statement?.windowMs ?? 2000
+      const cool = clamp01((state.elapsedMs - 90) / Math.max(1, window - 90))
+      return rise * (1 - (1 - WINDOW_FLOOR) * cool)
+    }
+    if (state.phase === "verdict" || state.phase === "clear") {
+      // A wrong draw changes nothing, and that includes the light. The street
+      // stays exactly as dim as the window left it while the round runs out.
+      return state.outcome === "wild" ? WINDOW_FLOOR : 1
+    }
+    if (state.phase === "over") return 1
+    return 0
+  }
+
+  private slateBox(state: SceneState): { x: number; y: number; w: number; h: number; a: number } {
+    const w = Math.min(this.w * 0.88, 640)
+    const h = w * 0.3
+    const cx = this.w * 0.5
+    const cy = this.h * 0.4
+
+    let drop = 0
+    let a = 1
+    if (state.phase === "raise") {
+      const t = state.reduced ? 1 : easeOut(state.progress)
+      drop = (1 - t) * h * 1.5
+      a = state.reduced ? state.progress : t
+    } else if (state.phase === "clear") {
+      const t = state.reduced ? 0 : easeOut(state.progress)
+      drop = t * h * 1.5
+      a = 1 - (state.reduced ? state.progress : t)
+    } else if (state.phase === "idle") {
+      a = 0
+    }
+    return { x: cx - w / 2, y: cy - h / 2 + drop, w, h, a }
+  }
+
+  private drawSlate(state: SceneState): void {
+    const { ctx } = this
+    const box = this.slateBox(state)
+    if (box.a <= 0.001) return
+    const lit = this.litness(state)
+
+    ctx.save()
+    ctx.globalAlpha = box.a
+
+    // The stone.
+    const face = ctx.createLinearGradient(0, box.y, 0, box.y + box.h)
+    face.addColorStop(0, mix(STONE, STONE_EDGE, 0.35 + lit * 0.25))
+    face.addColorStop(1, STONE_RECESS)
+    ctx.fillStyle = face
+    ctx.fillRect(box.x, box.y, box.w, box.h)
+
+    // The brass frame. Two rules, one bright and one in shadow, so the frame
+    // reads as a machined edge rather than as a border.
+    ctx.strokeStyle = mix(BRASS_DIM, BRASS_LIT, lit)
+    ctx.lineWidth = 2
+    ctx.strokeRect(box.x + 1, box.y + 1, box.w - 2, box.h - 2)
+    ctx.strokeStyle = withAlpha(BRASS, 0.22 + lit * 0.3)
+    ctx.lineWidth = 1
+    ctx.strokeRect(box.x + 5.5, box.y + 5.5, box.w - 11, box.h - 11)
+
+    if (state.phase === "over") this.drawLedger(box, state)
+    else this.drawStatement(box, state, lit)
+
+    ctx.restore()
+  }
+
+  private faceFor(box: { w: number; h: number }, text: string): { px: number; layout: Layout } {
+    const { ctx } = this
+    const inner = box.w - box.h * 0.5
+    let px = box.h * 0.42
+    for (let pass = 0; pass < 3; pass++) {
+      ctx.font = `${String(Math.round(px))}px ${SLATE_FONT}`
+      const l = layout(ctx, text, digitCellWidth(ctx))
+      if (l.width <= inner) return { px, layout: l }
+      px *= (inner / l.width) * 0.98
+    }
+    ctx.font = `${String(Math.round(px))}px ${SLATE_FONT}`
+    return { px, layout: layout(ctx, text, digitCellWidth(ctx)) }
+  }
+
+  private drawStatement(
+    box: { x: number; y: number; w: number; h: number },
+    state: SceneState,
+    lit: number,
+  ): void {
+    const statement = state.statement
+    if (!statement) return
+    const { ctx } = this
+    const { px, layout: l } = this.faceFor(box, statement.text)
+    const originX = box.x + (box.w - l.width) / 2
+    const baseY = box.y + box.h / 2 + px * 0.35
+
+    ctx.textAlign = "left"
+    ctx.textBaseline = "alphabetic"
+
+    const correcting = state.outcome === "bow" && (state.phase === "verdict" || state.phase === "clear")
+    const correction = correcting ? correctionFor(l, statement.claimed, statement.answer) : null
+    // The roll starts a beat into the bow: the caller acknowledges you first,
+    // and only then does the slate admit it was wrong.
+    const rollT = correcting
+      ? clamp01(((state.phase === "verdict" ? state.progress : 1) - 0.24) / 0.5)
+      : 0
+
+    const chalk = mix(CHALK_UNLIT, CHALK_LIT, lit)
+    // Every alpha below is set *from* this rather than multiplied into the
+    // context. A running `*=` / `/=` pair looks equivalent and is not: at the
+    // end of the cross-fade the multiplier is zero, the division cannot undo
+    // it, and everything drawn afterwards — including the corrected numeral the
+    // fade exists to reveal — is drawn fully transparent.
+    const base = ctx.globalAlpha
+
+    for (let i = 0; i < l.cells.length; i++) {
+      const cell = l.cells[i]
+      if (!cell) continue
+      const rolling = correction?.rolls.find((r) => r.index === i)
+      const inClaim = correction !== null && i >= correction.start
+      const fading = inClaim && rollT > 0 && !correction.canRoll
+
+      if (rolling && rollT > 0) {
+        this.rollDigit(cell.x + originX, baseY, cell.w, px, rolling.from, rolling.to, rollT, state.reduced, chalk)
+        continue
+      }
+      if (fading) {
+        // Lengths differ, so there is no column to roll in. The wrong value
+        // fades out where it stands and the right one fades in over it.
+        ctx.globalAlpha = base * (1 - rollT)
+        this.glyph(cell.ch, cell.x + originX, baseY, cell.w, CHALK_WRONG)
+        ctx.globalAlpha = base
+        continue
+      }
+      this.glyph(cell.ch, cell.x + originX, baseY, cell.w, chalk)
+    }
+
+    if (correction !== null && !correction.canRoll && rollT > 0) {
+      const corrected = `${statement.expression} = ${statement.answer}`
+      const fixed = this.faceFor(box, corrected)
+      const fx = box.x + (box.w - fixed.layout.width) / 2
+      ctx.globalAlpha = base * rollT
+      for (const cell of fixed.layout.cells) {
+        this.glyph(cell.ch, cell.x + fx, baseY, cell.w, chalk)
+      }
+      ctx.globalAlpha = base
+    }
+
+    if (state.outcome === "hit" && (state.phase === "verdict" || state.phase === "clear")) {
+      this.drawStrike(box, state)
+    }
+  }
+
+  /** One glyph, centred in its cell so digits sit on the tabular grid. */
+  private glyph(ch: string, x: number, baseY: number, cellW: number, colour: string): void {
+    const { ctx } = this
+    const w = ctx.measureText(ch).width
+    ctx.fillStyle = colour
+    ctx.fillText(ch, x + (cellW - w) / 2, baseY)
+  }
+
+  /**
+   * The correction: a wrong digit rolls up out of its cell and the right one
+   * rolls in behind it, like a counter wheel. It is clipped to the cell, so the
+   * statement never reflows and nothing moves outside the recess.
+   *
+   * Reduced motion takes the same event as a cross-fade in place — a branch,
+   * not a degradation. The child still watches the slate correct itself.
+   */
+  private rollDigit(
+    x: number,
+    baseY: number,
+    cellW: number,
+    px: number,
+    from: string,
+    to: string,
+    t: number,
+    reduced: boolean,
+    colour: string,
+  ): void {
+    const { ctx } = this
+    if (reduced) {
+      const alpha = ctx.globalAlpha
+      ctx.globalAlpha = alpha * (1 - t)
+      this.glyph(from, x, baseY, cellW, CHALK_WRONG)
+      ctx.globalAlpha = alpha * t
+      this.glyph(to, x, baseY, cellW, colour)
+      ctx.globalAlpha = alpha
+      return
+    }
+    const e = easeInOut(t)
+    ctx.save()
+    ctx.beginPath()
+    ctx.rect(x, baseY - px * 1.02, cellW, px * 1.3)
+    ctx.clip()
+    this.glyph(from, x, baseY - e * px * 1.25, cellW, CHALK_WRONG)
+    this.glyph(to, x, baseY + (1 - e) * px * 1.25, cellW, colour)
+    ctx.restore()
+  }
+
+  /** A single incision across the face. Cut once, then still. */
+  private drawStrike(box: { x: number; y: number; w: number; h: number }, state: SceneState): void {
+    const { ctx } = this
+    const t = state.phase === "verdict" ? clamp01(state.progress / 0.3) : 1
+    const e = state.reduced ? 1 : easeOut(t)
+    const inset = box.h * 0.22
+    const x0 = box.x + inset
+    const y0 = box.y + box.h - inset
+    const x1 = box.x + box.w - inset
+    const y1 = box.y + inset
+    ctx.strokeStyle = withAlpha(BRASS_LIT, 0.5 * (state.reduced ? t : 1))
+    ctx.lineWidth = 1.5
+    ctx.beginPath()
+    ctx.moveTo(x0, y0)
+    ctx.lineTo(x0 + (x1 - x0) * e, y0 + (y1 - y0) * e)
+    ctx.stroke()
+  }
+
+  // ── the ledger ──────────────────────────────────────────────────────────
+
+  /**
+   * The run, over. One numeral: how many calls you made.
+   *
+   * There is no percentage here and there never will be. A child shown "50%"
+   * reads a passing grade; a child shown "3" reads three.
+   */
+  private drawLedger(box: { x: number; y: number; w: number; h: number }, state: SceneState): void {
+    const { ctx } = this
+    const px = box.h * 0.52
+    ctx.font = `${String(Math.round(px))}px ${SLATE_FONT}`
+    ctx.textAlign = "center"
+    ctx.textBaseline = "alphabetic"
+    ctx.fillStyle = CHALK_LIT
+    const t = clamp01(state.elapsedMs / 420)
+    ctx.globalAlpha *= state.reduced ? t : easeOut(t)
+    ctx.fillText(String(state.run.calls), box.x + box.w / 2, box.y + box.h * 0.6)
+
+    if (state.best > 0) {
+      const small = Math.round(box.h * 0.15)
+      ctx.font = `${String(small)}px ${SLATE_FONT}`
+      ctx.fillStyle = withAlpha(BRASS, 0.75)
+      ctx.fillText(`BEST ${String(state.best)}`, box.x + box.w / 2, box.y + box.h * 0.86)
+    }
+  }
+
+  // ── the hud, such as it is ──────────────────────────────────────────────
+
+  /** Three brass pips. A spent one is an empty ring, and it goes out in silence. */
+  private drawShots(state: SceneState): void {
+    const { ctx } = this
+    // Before a run starts there is nothing on the street but the caller and
+    // three loaded shots, breathing. That is the whole instruction: one tap.
+    if (state.phase === "idle") {
+      ctx.globalAlpha = state.reduced ? 0.7 : 0.45 + 0.35 * (0.5 + 0.5 * Math.sin(state.elapsedMs / 620))
+    }
+    const r = Math.max(3.5, this.h * 0.0075)
+    const gap = r * 3.4
+    const cx = this.w * 0.5
+    const y = this.h * 0.4 + Math.min(this.w * 0.88, 640) * 0.3 * 0.5 + r * 5
+    for (let i = 0; i < SHOTS; i++) {
+      const x = cx + (i - (SHOTS - 1) / 2) * gap
+      ctx.beginPath()
+      ctx.arc(x, y, r, 0, Math.PI * 2)
+      if (i < state.run.shots) {
+        ctx.fillStyle = BRASS
+        ctx.fill()
+      } else {
+        ctx.strokeStyle = withAlpha(BRASS_DIM, 0.7)
+        ctx.lineWidth = 1
+        ctx.stroke()
+      }
+    }
+    ctx.globalAlpha = 1
+  }
+
+  /** The tally: how many calls, in brass, small, above everything. */
+  private drawTally(state: SceneState): void {
+    if (state.phase === "idle" || state.phase === "over") return
+    const { ctx } = this
+    const px = Math.round(Math.max(15, this.h * 0.026))
+    ctx.font = `${String(px)}px ${SLATE_FONT}`
+    ctx.textAlign = "center"
+    ctx.textBaseline = "top"
+    ctx.fillStyle = withAlpha(BRASS, state.run.calls > 0 ? 0.8 : 0.3)
+    ctx.fillText(String(state.run.calls), this.w * 0.5, this.h * 0.055)
+  }
+}

--- a/dynawalla/games/truedraw/src/stub/host.ts
+++ b/dynawalla/games/truedraw/src/stub/host.ts
@@ -1,0 +1,70 @@
+// A local stub Host so the game is playable standalone with `npm run dev`.
+//
+// It stands in for the runtime, not for the curriculum: it serves the same shape
+// the real adapter serves — an exact canonical answer plus mal-rule distractors,
+// most diagnostic first — so the statement builder behaves identically here and
+// on a device.
+
+import type { Host, Question } from "../contract.ts"
+import { Rng } from "../core/rng.ts"
+import { drawProblem, GLYPH } from "./questions.ts"
+
+export type StubHostOptions = {
+  seed?: number
+  reducedMotion?: boolean
+  /** 0..7, the rung of the ladder the stub sits on. */
+  level?: number
+  onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void
+  onHaptic?: (k: string) => void
+}
+
+export function createStubHost(opts: StubHostOptions = {}): Host {
+  const rng = new Rng(opts.seed ?? 0x7a1e5)
+  let served = 0
+
+  return {
+    next(o) {
+      const level = Math.max(
+        0,
+        Math.min(7, Math.round(o?.difficulty === undefined ? (opts.level ?? 3) : o.difficulty * 8)),
+      )
+      const drawn = drawProblem(level, rng)
+      served++
+      return {
+        id: `stub-${String(served)}`,
+        prompt: `${String(drawn.a)} ${GLYPH[drawn.op]} ${String(drawn.b)}`,
+        answer: String(drawn.answer),
+        distractors: drawn.distractors.map(String),
+        domain: o?.domain ?? "add",
+        difficulty: level / 8,
+      } satisfies Question
+    },
+
+    report(r) {
+      opts.onReport?.(r)
+    },
+
+    haptic(k) {
+      opts.onHaptic?.(k)
+      const nav = globalThis.navigator as Navigator | undefined
+      if (!nav || typeof nav.vibrate !== "function") return
+      const ms =
+        k === "light" ? 8 : k === "medium" ? 18 : k === "heavy" ? 34 : k === "success" ? 12 : 40
+      try {
+        if (k === "success") nav.vibrate([ms, 26, ms])
+        else nav.vibrate(ms)
+      } catch {
+        // A browser that exposes `vibrate` but refuses it — no user gesture yet,
+        // or a policy block — must never take the frame down with it.
+        console.warn("[truedraw] navigator.vibrate refused")
+      }
+    },
+
+    prefersReducedMotion() {
+      if (opts.reducedMotion !== undefined) return opts.reducedMotion
+      return (
+        typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion: reduce)").matches
+      )
+    },
+  }
+}

--- a/dynawalla/games/truedraw/src/stub/questions.test.ts
+++ b/dynawalla/games/truedraw/src/stub/questions.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import {
+  addNoCarry,
+  borrowAcrossZero,
+  drawProblem,
+  reverseDigits,
+  subSmallerFromLarger,
+} from "./questions.ts"
+
+test("each mal-rule reproduces the procedure it is named for", () => {
+  // Every carry dropped.
+  assert.equal(addNoCarry(47, 25), 62)
+  assert.equal(addNoCarry(9, 9), 8)
+  // The smaller digit taken from the larger, column by column.
+  assert.equal(subSmallerFromLarger(52, 27), 35)
+  // The borrow travels through the zero and the zero is read as ten.
+  assert.equal(borrowAcrossZero(503, 87), 426)
+  assert.equal(503 - 87, 416)
+  // A transcription slip, not a procedure.
+  assert.equal(reverseDigits(63), 36)
+})
+
+test("borrowAcrossZero refuses rather than inventing a non-digit", () => {
+  // No column to borrow from at all.
+  assert.equal(borrowAcrossZero(12, 99), -1)
+})
+
+test("the stream is exact integers only, at every level", () => {
+  for (let level = 0; level <= 7; level++) {
+    const rng = new Rng(1000 + level)
+    for (let i = 0; i < 400; i++) {
+      const drawn = drawProblem(level, rng)
+      for (const value of [drawn.a, drawn.b, drawn.answer, ...drawn.distractors]) {
+        assert.ok(Number.isInteger(value), `${String(value)} is not an integer`)
+      }
+      assert.ok(drawn.answer > 0, "an answer is a positive whole number")
+      const expected = drawn.op === "add" ? drawn.a + drawn.b : drawn.a - drawn.b
+      assert.equal(drawn.answer, expected)
+    }
+  }
+})
+
+test("a distractor is never the answer, and never a duplicate", () => {
+  const rng = new Rng(4242)
+  for (let i = 0; i < 3000; i++) {
+    const drawn = drawProblem(i % 8, rng)
+    const seen = new Set<number>()
+    for (const value of drawn.distractors) {
+      assert.notEqual(value, drawn.answer)
+      assert.ok(!seen.has(value), "duplicate distractor")
+      seen.add(value)
+    }
+  }
+})
+
+test("every problem carries at least one wrong value to lie with", () => {
+  const rng = new Rng(99)
+  for (let i = 0; i < 2000; i++) {
+    const drawn = drawProblem(i % 8, rng)
+    assert.ok(drawn.distractors.length >= 1, `${String(drawn.a)} ${drawn.op} ${String(drawn.b)}`)
+  }
+})
+
+test("the same seed is the same stream, forever", () => {
+  const a = new Rng(0xbeef)
+  const b = new Rng(0xbeef)
+  for (let i = 0; i < 200; i++) {
+    assert.deepEqual(drawProblem(3, a), drawProblem(3, b))
+  }
+})

--- a/dynawalla/games/truedraw/src/stub/questions.ts
+++ b/dynawalla/games/truedraw/src/stub/questions.ts
@@ -1,0 +1,187 @@
+// The stub question source: whole-number column arithmetic, drawn exactly.
+//
+// Three properties, all asserted by `questions.test.ts`:
+//
+//   1. **Exact integer arithmetic.** Every operand, answer and distractor is an
+//      integer. There is not a float anywhere in this file — not in an operand,
+//      not in an answer, not in a comparison.
+//   2. **Seeded and deterministic.** Same seed, same stream, forever.
+//   3. **Distractors are mal-rule outputs.** Each one is what a child running a
+//      specific broken procedure actually writes down. `answer + 1` is noise a
+//      child rejects by feel; `47 + 25 = 62` is a claim they have to do the work
+//      to reject, and doing the work is the entire point of this game.
+//
+// This mirrors what the real curriculum serves — `columnOp` emits exactly these
+// diagnoses — so the dev harness and the device are playing the same game.
+
+import { Rng } from "../core/rng.ts"
+
+export type Op = "add" | "sub"
+
+export type Drawn = {
+  op: Op
+  a: number
+  b: number
+  answer: number
+  /** Mal-rule outputs, most diagnostic first. */
+  distractors: number[]
+}
+
+/** Column addition with every carry dropped: 47 + 25 → 62. */
+export function addNoCarry(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    out += (((x % 10) + (y % 10)) % 10) * place
+    place *= 10
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return out
+}
+
+/** Take the smaller digit from the larger in every column: 52 − 27 → 35. */
+export function subSmallerFromLarger(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    out += Math.abs((x % 10) - (y % 10)) * place
+    place *= 10
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return out
+}
+
+/**
+ * Borrowing *through* a zero and leaving it at ten.
+ *
+ * `503 − 87`: the ones need a borrow, the tens are zero, so the child reaches
+ * past to the hundreds — correctly — and then reads the tens column as ten
+ * rather than as the nine it became when it passed the borrow along. Ones
+ * `13 − 7 = 6`, tens `10 − 8 = 2`, hundreds `4`. Written down: `426`, against a
+ * true `416`.
+ *
+ * Returns `-1` when this procedure cannot run on these operands or produces a
+ * column that is not a digit; the caller drops it.
+ */
+export function borrowAcrossZero(a: number, b: number): number {
+  const top = digits(a)
+  const bottom = digits(b)
+  const out: number[] = []
+  for (let i = 0; i < top.length; i++) {
+    let t = top[i] ?? 0
+    const bo = bottom[i] ?? 0
+    if (t < bo) {
+      let j = i + 1
+      while (j < top.length && (top[j] ?? 0) === 0) j++
+      if (j >= top.length) return -1
+      top[j] = (top[j] ?? 0) - 1
+      // The bug, and the only line that differs from the correct algorithm: a
+      // zero the borrow travelled through should become nine.
+      for (let k = i + 1; k < j; k++) top[k] = 10
+      t += 10
+    }
+    const digit = t - bo
+    if (digit < 0 || digit > 9) return -1
+    out.push(digit)
+  }
+  return fromDigits(out)
+}
+
+/** Digit-reversal — a transcription slip, not a procedure: 63 → 36. */
+export function reverseDigits(n: number): number {
+  let out = 0
+  let m = n
+  while (m > 0) {
+    out = out * 10 + (m % 10)
+    m = Math.floor(m / 10)
+  }
+  return out
+}
+
+function digits(n: number): number[] {
+  const out: number[] = []
+  let m = n
+  if (m === 0) return [0]
+  while (m > 0) {
+    out.push(m % 10)
+    m = Math.floor(m / 10)
+  }
+  return out
+}
+
+function fromDigits(ds: readonly number[]): number {
+  let out = 0
+  for (let i = ds.length - 1; i >= 0; i--) out = out * 10 + (ds[i] ?? 0)
+  return out
+}
+
+/**
+ * Draw a problem at `level` 0..7, which stretches the operand width the way the
+ * real ladder does: two digits at the bottom, four at the top, regrouping from
+ * level two on.
+ */
+export function drawProblem(level: number, rng: Rng): Drawn {
+  const clamped = Math.max(0, Math.min(7, Math.round(level)))
+  const width = clamped < 2 ? 2 : clamped < 5 ? 3 : 4
+  const lo = width === 2 ? 12 : width === 3 ? 102 : 1002
+  const hi = width === 2 ? 98 : width === 3 ? 989 : 9899
+  const op: Op = rng.chance(0.5) ? "add" : "sub"
+
+  if (op === "add") {
+    const a = rng.int(lo, hi)
+    const b = rng.int(lo, hi)
+    const answer = a + b
+    return {
+      op,
+      a,
+      b,
+      answer,
+      distractors: dedupe(answer, [
+        addNoCarry(a, b),
+        answer - 10,
+        answer + 10,
+        Math.abs(a - b),
+        reverseDigits(answer),
+      ]),
+    }
+  }
+
+  // Keep the difference positive: this is whole-number subtraction and a
+  // negative answer is a different skill entirely.
+  const a = rng.int(lo + 10, hi)
+  const b = rng.int(lo, a - 1)
+  const answer = a - b
+  return {
+    op,
+    a,
+    b,
+    answer,
+    distractors: dedupe(answer, [
+      subSmallerFromLarger(a, b),
+      borrowAcrossZero(a, b),
+      answer + 10,
+      answer - 10,
+      reverseDigits(answer),
+    ]),
+  }
+}
+
+/** Positive integers, distinct, and never the answer. */
+function dedupe(answer: number, candidates: readonly number[]): number[] {
+  const seen = new Set<number>([answer])
+  const out: number[] = []
+  for (const value of candidates) {
+    if (!Number.isInteger(value) || value < 0 || seen.has(value)) continue
+    seen.add(value)
+    out.push(value)
+  }
+  return out
+}
+
+export const GLYPH: Record<Op, string> = { add: "+", sub: "−" }

--- a/dynawalla/games/truedraw/src/test/harness.ts
+++ b/dynawalla/games/truedraw/src/test/harness.ts
@@ -1,0 +1,97 @@
+// A headless player.
+//
+// The round is driven by elapsed milliseconds rather than by frames precisely so
+// that the design's central claim — that drawing at everything is a three-call
+// run — can be played out ten thousand times with no canvas, no clock and no
+// browser. This is that driver.
+
+import type { Host } from "../contract.ts"
+import { Rng } from "../core/rng.ts"
+import { Dealer } from "../game/dealer.ts"
+import type { Outcome } from "../game/response.ts"
+import { Round, TIMING, type RoundEvent, type Timing } from "../game/round.ts"
+import type { Run } from "../game/run.ts"
+import type { Statement } from "../game/statement.ts"
+
+export type Decision = "draw" | "hold"
+
+export type PlayResult = {
+  readonly outcomes: readonly Outcome[]
+  readonly statements: readonly Statement[]
+  readonly events: readonly RoundEvent[]
+  readonly run: Run
+  /** True when the run ended on its own rather than by hitting the cap. */
+  readonly finished: boolean
+}
+
+export type PlayOptions = {
+  readonly timing?: Timing
+  /** Milliseconds per simulated frame. */
+  readonly stepMs?: number
+  /** Rounds after which the driver gives up, for a strategy that never misses. */
+  readonly limit?: number
+  /** Fraction into the draw window at which a draw is committed. */
+  readonly drawAt?: number
+}
+
+export function playRun(
+  host: Host,
+  seed: number,
+  decide: (statement: Statement) => Decision,
+  options: PlayOptions = {},
+): PlayResult {
+  const timing = options.timing ?? TIMING
+  const step = options.stepMs ?? 20
+  const limit = options.limit ?? 400
+  const drawAt = options.drawAt ?? 0
+
+  const rng = new Rng(seed)
+  const dealer = new Dealer(host, rng)
+  const round = new Round(() => dealer.deal(), timing)
+
+  const outcomes: Outcome[] = []
+  const statements: Statement[] = []
+  const events: RoundEvent[] = []
+  /** Which statement index has already been called. One call per round. */
+  let actedOn = -1
+
+  const consume = (batch: readonly RoundEvent[]): void => {
+    for (const event of batch) {
+      events.push(event)
+      if (event.kind === "present") statements.push(event.statement)
+      else if (event.kind === "settled") outcomes.push(event.outcome)
+    }
+  }
+
+  consume(round.begin())
+  for (let i = 0; i < 2_000_000 && round.phase !== "over"; i++) {
+    consume(round.advance(step))
+    if (statements.length > limit) break
+    const index = statements.length - 1
+    const current = statements[index]
+    if (round.phase !== "call" || current === undefined || actedOn === index) continue
+    if (round.elapsedMs < current.windowMs * drawAt) continue
+    if (decide(current) === "draw") consume(round.press())
+    actedOn = index
+  }
+
+  return { outcomes, statements, events, run: round.run, finished: round.phase === "over" }
+}
+
+/** Draw at everything. The strategy the format has to defeat. */
+export const alwaysDraw = (): Decision => "draw"
+
+/** Never draw. The other half of the same coin, and just as short. */
+export const alwaysHold = (): Decision => "hold"
+
+/** Read the slate and call it. */
+export const perfect = (statement: Statement): Decision => (statement.truth ? "draw" : "hold")
+
+/** Read the slate, and be wrong `1 − p` of the time. */
+export function fallible(p: number, rng: Rng): (statement: Statement) => Decision {
+  return (statement) => {
+    const right = perfect(statement)
+    if (rng.chance(p)) return right
+    return right === "draw" ? "hold" : "draw"
+  }
+}

--- a/dynawalla/games/truedraw/tsconfig.json
+++ b/dynawalla/games/truedraw/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": false,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/dynawalla/games/truedraw/vite.config.ts
+++ b/dynawalla/games/truedraw/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite"
+
+// The game is a library that mounts into a host element. `npm run dev` serves
+// the standalone harness in `index.html`, which wires it to the local stub Host
+// so the whole thing is playable with no runtime underneath it.
+export default defineConfig({
+  server: { port: 4331, host: "127.0.0.1" },
+  build: {
+    target: "es2022",
+    lib: {
+      entry: "src/index.ts",
+      name: "DynawallaGameTrueDraw",
+      formats: ["es"],
+      fileName: () => "truedraw.js",
+    },
+  },
+})

--- a/dynawalla/games/truedraw/vite.pack.config.ts
+++ b/dynawalla/games/truedraw/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own; a
+    // bare relative string produces a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})


### PR DESCRIPTION
## What

Add **THE TRUE DRAW** at `dynawalla/games/truedraw/` — arcade-canon rank 10, S tier,
after *Wild Gunman (1974)*. A statement is cut into a slate across the dust
(`47 + 25 = 62`). The street goes still, the slate lights, and the child has one
beat: **draw if it is true, hold if it is false.**

Standalone vite + TypeScript game, and a pack (`pack.json` / `pack.html` /
`src/pack.ts` / `vite.pack.config.ts`) so `packs/build.mjs` discovers it.

## Why

The canon calls this "the cheapest pack on the list and one of the two most
rigorous". Three things in that summary were load-bearing and each is enforced by
a test rather than by a comment:

**1. The 50% mashing ceiling reads as failure.** A GO/NO-GO task has a hard half
for anyone who draws at everything. That is the measurement, not a bug to patch —
the job is making a seven-year-old read it as losing. There is one honest way:
**never show an accuracy at all.** A child shown "50%" reads a passing grade; a
child shown **3** reads three.

So the run has no score and no percentage. It has a *length* — calls made before
three shots go dark — and length is negative-binomial in care:

| accuracy | expected run |
|---|---|
| 0.50 draw at everything | **3 calls** |
| 0.75 | 9 |
| 0.90 | 27 |
| 1.00 | no end |

Never drawing is the same coin the other way up, and just as short. And mashing
does not even buy tempo: a wrong draw commits, but **does not close the window**
— the slate stays lit to the last millisecond with the world declining to react.
Drawing correctly is the only thing in the game that makes time go faster, so a
masher gets the slowest possible game *and* the shortest one.

**2. Wrong draws are punished by being ignored.** `wild` has zero movers, no
audio voice, and a `null` haptic — asserted in both the full and reduced-motion
branches (`game/energy.test.ts`), and asserted again at the renderer: a wild
verdict is byte-identical to the open window (`render/scene.test.ts`). Correct holds get the bow and a slate that rolls itself
right, digit by digit, inside a clipped tabular cell.

**3. Restraint is the aesthetic.** One dust plane, one slate, one caller, and a
crowd that gathers one witness per call. No particles anywhere. The single bright
event is the slate lighting, and it is a *light change* rather than a motion.

**The mathematics is the mechanic.** The slate never lies with `answer ± 1`,
which a child rejects by feel. It lies with the item's own **mal-rule
distractors** — `47 + 25 = 62` is every carry dropped, `503 − 87 = 426` is the
borrow travelling through the zero and the zero read as ten. Rejecting one means
doing the arithmetic. That also makes reporting fall out for free: a wild draw
reports the mal-rule value, so the host records the miss **and names the
misconception the child just demonstrated**, with no extra wiring.

**Only `add` is active, and this design does not care.** The statement builder
reads `prompt`, `answer` and `distractors` and nothing else, so it is
domain-blind: the day `mul` / `frac` / `ns` / `div` / `alg` leave draft, the pack
covers them unchanged. A claim is a claim.

## Blast radius

**Areas touched:** dynawalla — one new directory, `dynawalla/games/truedraw/`.
No file outside it is added, changed or deleted.

- [x] Every touched path is covered by a `ci.yml` area filter — `dynawalla/games/**`,
      same as the eighteen shipping games beside it.
- [x] **Pack back-compat.** New pack id `dynawalla.truedraw` at `0.1.0`; nothing
      published changed in place, no `voiceId` renamed, no catalog entry dropped.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifest touched.
- [x] **Strings.** N/A — no `corpan-app` locale strings. The game's only on-screen
      text is numerals and the single word `BEST`; `locales: ["en"]`, as with
      every other game pack.
- [x] **Curriculum.** No skill id renamed or reused, nothing promoted, no
      generator or renderer changed. `covers.skills` names the seven **active**
      `dw.add.*` rows — verified by hand against
      `packs/shared/curriculum/src/graph/domains/add.ts` (output below), because
      `dw-pack check` does not validate `covers.skills` and a fictional id passes
      silently. The draft `dw.add.regroup.subtract-tenths` is excluded.
      Exact-arithmetic rule honoured hard: `core/exact.ts` decides truth on
      canonical decimal *strings* and there is no float anywhere in an answer,
      an operand or a comparison.
- [x] **Secrets.** None. `gitleaks` clean over the range. The one storage-path
      constant is `BEST_SLOT` with `// gitleaks:allow`, per `games/forge/src/game/save.ts`.

Three pack traps deliberately avoided: `items.reveal` **is** declared (without it
`canonical` is `""`, every item is dropped and the pool never fills — and this
game literally cannot build a true statement without it); `audio` is **not**
declared (that is `feedback.sound`; the game synthesises its own `AudioContext`);
and `localStorage` is treated as unreachable — `game/best.ts` holds the best run
in memory and treats storage as a best-effort mirror, with a test that runs with
no storage at all.

## Proof

Every command run from `dynawalla/games/truedraw/` unless noted.

### 1. `npm test` — five consecutive runs

```
run 1: # tests 89 # pass 89 # fail 0
run 2: # tests 89 # pass 89 # fail 0
run 3: # tests 89 # pass 89 # fail 0
run 4: # tests 89 # pass 89 # fail 0
run 5: # tests 89 # pass 89 # fail 0
```

Every test is seeded inside its own file; nothing reads `Math.random`. The
inhibition suite is the product claim, played out headlessly:

```
✔ drawing at everything is right exactly half the time
✔ never drawing is the same coin, the other way up
✔ no strategy that ignores the slate can beat half
✔ true and false stay balanced all the way through a run, not just on average
✔ not one statement presented as false is actually true
✔ the slate lies with values a child actually writes
✔ a masher's whole run is three calls long
✔ refusing to play is exactly as short
✔ reading the slate is worth nine times the game
✔ a child who reads every slate is never stopped at all
✔ mashing does not even buy tempo
```

### 2. `npm run tsc`

```
> @dynawalla/game-truedraw@0.1.0 tsc
> tsc --noEmit
```

0 errors. `"types": ["node"]` set and `@types/node` in devDependencies.

### 3. `npm run build`

```
vite v8.1.5 building client environment for production...
✓ 20 modules transformed.
dist/truedraw.js  26.09 kB │ gzip: 8.76 kB
✓ built in 13ms
```

### 4. `npm run build:pack`

```
vite v8.1.5 building client environment for production...
✓ 28 modules transformed.
dist-pack/pack.html                 1.12 kB │ gzip: 0.58 kB
dist-pack/assets/pack-C4UHGT-k.js  24.68 kB │ gzip: 9.68 kB
✓ built in 22ms

$ grep -o '<script[^>]*>' dist-pack/pack.html
<script type="module" crossorigin src="./assets/pack-C4UHGT-k.js">
```

Hashed asset, not `/src/pack.ts` — the built page runs the built code.

### 5. `node build.mjs truedraw`, from `dynawalla/packs/`

```
── dynawalla.truedraw@0.1.0  (games/truedraw)
dynawalla.truedraw@0.1.0 — THE TRUE DRAW
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 26909 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

### 6. Every `covers.skills` id, checked by hand against the domain source

```
dw.add.column.add-no-regroup                         active
dw.add.column.subtract-no-regroup                    active
dw.add.regroup.add-multidigit                        active
dw.add.regroup.subtract-multidigit                   active
dw.add.regroup.add-short-addend                      active
dw.add.regroup.subtract-short-subtrahend             active
dw.add.regroup.subtract-across-zero                  active
```

### 7. `gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"`

```
INF 1 commits scanned.
INF scanned ~142761 bytes (142.76 KB) in 49.1ms
INF no leaks found
```

### 8. Scope

```
$ git diff --name-only origin/main...HEAD | sed 's#/[^/]*$##' | sort -u
dynawalla/games/truedraw
dynawalla/games/truedraw/src
dynawalla/games/truedraw/src/audio
dynawalla/games/truedraw/src/core
dynawalla/games/truedraw/src/game
dynawalla/games/truedraw/src/render
dynawalla/games/truedraw/src/stub
dynawalla/games/truedraw/src/test

$ git diff --name-only --diff-filter=D origin/main...HEAD
(empty)
```

One commit. Nothing deleted. Nothing outside the new directory.

### 9. Renderer, verified headlessly

Chrome was unavailable in this environment, so the rendered output is checked by
a recording 2D context (`render/fakeCanvas.ts`) rather than by a screenshot —
which is the more durable check in any case, because it runs in CI. The scene is
driven through every phase × outcome × progress at 320×568, 390×844, 768×1024
and 1280×800, in both motion branches, asserting no non-finite coordinate ever
reaches the context. Measured ink ops for one frame at 768×1024:

```
still     ink: 44   text: 17
call      ink: 44   text: 17
verdict hit   ink: 45   text: 17   ← the strike is cut
verdict bow   ink: 45   text: 18   ← the digit rolls: two glyphs in one cell
verdict wild  ink: 44   text: 17   ← nothing was added
verdict slow  ink: 45   text: 17   ← the caller draws
over      ink: 29   text: 2
```

The `wild` assertion is stronger than a count. The test takes the very last
frame of the open window and every frame of the wild verdict that follows, and
requires the whole street — every call up to and including the slate — to be
**identical**: same ops, same order, same `globalAlpha`, same colours. The only
permitted difference in the entire frame is one shot pip in the hud becoming a
ring. Being ignored is the punishment, and it is now a regression test that
cannot be softened by accident.

### 10. Two defects found and fixed in self-review, both now covered

- `render/scene.ts` — the length-changing correction (`95 + 5 = 90` → `100`)
  faded with a running `globalAlpha *= (1 - t)` / `/=` pair. At `t = 1` the
  multiplier is exactly zero and the division cannot recover it, so the
  corrected numeral the fade exists to reveal was drawn at alpha zero: the slate
  appeared to *erase* itself rather than correct itself. Every alpha is now set
  from a captured base. Test: *"the corrected value is visible at the end of the
  cross-fade, not transparent"*, plus a guard that the slate returns the
  context's alpha exactly as it found it.
- `game/statement.ts` — `falsehoodsFor` only skipped candidates equal to the
  answer. If the *answer itself* were not a readable numeral, nothing could be
  proved wrong and yet a claim would still have been presented as false. It now
  returns empty, so the slate tells the truth instead. This is the one failure
  mode that matters more than any other — a child asked to reject a true
  sentence learns the game lies, and the game has no way to tell them otherwise.

### 11. One feel change made during review

The draw window had no legible clock. It now has the only kind this game is
allowed: the street **cools** across the window, from fully lit at the cue back
to 45% by the moment it closes. No bar, no ring, no countdown, nothing that
moves — the beat is felt because the light is going out of it. The floor is 45%
and not zero because a child still reading must never be reading in the dark,
and a test asserts both the monotone cooling and the legibility floor. A wild
verdict holds the light exactly where the window left it, which is what makes
the "nothing changed" fingerprint above hold.


### 12. Pacing, measured across the ladder

The draw window and the stillness before it are both pure functions of the
statement — never of run length, which `EXPERIENCE_DESIGN.md` bans. The two
slopes pull opposite ways: the window climbs steeply while the stillness
flattens, so short statements come at you faster and long ones give more room.

```
level 0  e.g. "63 − 31 = 32"        hold-round 4897ms  draw-round 2782ms
level 3  e.g. "580 − 281 = 299"     hold-round 5751ms  draw-round 3230ms
level 7  e.g. "5753 − 2782 = 2971"  hold-round 6139ms  draw-round 3382ms
```

The asymmetry is the point: a correct draw ends the round on the spot, a hold is
waited out. Drawing is fast, holding is patient, and holding is the one that gets
the bow. A four-digit sum gets ≥4.4 s of decision budget against the doc's 6 s
p50 for multi-digit regrouping — verification is cheaper than computation, since
the ones column alone rejects most mal-rules, and a test pins that floor.

A sample of real generated statements, every truth value hand-checked:

```
580 − 281 = 299    true
191 − 185 = 14     false   smaller-from-larger (true 6)
450 − 253 = 203    false   smaller-from-larger (true 197)
267 + 135 = 402    true
752 + 934 = 686    false   every carry dropped (true 1686)
822 − 203 = 619    true
657 + 792 = 1449   true
593 + 119 = 602    false   every carry dropped (true 712)
175 − 152 = 32     false   digit reversal (true 23)
613 − 484 = 271    false   smaller-from-larger (true 129)
662 − 252 = 410    true
```

Seven true, seven false in fourteen — the bag deals in balanced blocks, so the
50% ceiling is what a masher actually got in that run, not what they got in
expectation.
