### PR TITLE
dynawalla/games/foundry: THE GRAPPLE FOUNDRY — escape the pin on an exact sum

### DIFF
--- a/dynawalla/games/foundry/.gitignore
+++ b/dynawalla/games/foundry/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+
+# The pack build. `packs/build.mjs` regenerates it and stages it into the app.
+dist-pack/
+
+# Capture scratch — screenshots and the tmp files the capture driver writes.
+qa/shots
+qa/tmp
+
+package-lock.json

--- a/dynawalla/games/foundry/README.md
+++ b/dynawalla/games/foundry/README.md
@@ -1,0 +1,102 @@
+# THE GRAPPLE FOUNDRY
+
+> Four seconds, two pedals, one exact total, and a referee who is already
+> counting.
+
+A wrestling pin you escape with arithmetic. Rank 4, S tier, in
+[`docs/catalog/ARCADE_CANON.md`](../../docs/catalog/ARCADE_CANON.md), after
+*Pro Wrestling / WWF Superstars* (1986).
+
+## The loop
+
+You are on your back with a leverage bar across your chest. Above the ring, a
+slate board carries a sum. Two pedals hang off the frame — one light, one heavy,
+each stamped with a whole number — and every tap drops that plate's weight onto
+the bar.
+
+Work out what the board is asking, build that **exact** number out of the two
+plates, and the bar tips and you kick out.
+
+Three ways the fall ends badly, and each of them is a different piece of
+mathematics:
+
+| | what happened | why it is the right punishment |
+|---|---|---|
+| **TOO MUCH** | the bar went one over | mashing loses instantly, so the escape has to be planned before the first tap |
+| **NO WAY OUT** | the remainder cannot be made from these two plates | the coin problem's real structure — `7+7+7` on a target of 24 leaves three, and nothing makes three out of fours and sevens |
+| **THREE** | the count ran out | the child's time is measured, and here it is also spent |
+
+And one more, which is the point of the whole thing: **WAVED OFF**. Land the bar
+on the exact value a broken procedure produces and the hall comes up, half the
+building thinks you are out, and the referee waves it off.
+
+Below the target that costs count and nothing else — the bar passes through, the
+fall goes on, and escaping *after* one is the biggest reaction in the game.
+Above it the bar can only arrive by going over, so the fall is already lost when
+it lands; the child is still told which number was refused rather than just that
+something was. That second case is the only one subtraction has, because every
+mal-rule for a difference comes out *larger* than the difference: `52 − 27 = 25`,
+and 35 is what you write if you take the smaller digit from the larger in each
+column.
+
+The three procedures are ported from
+[`malrules/columnOp.ts`](../../packs/shared/curriculum/src/malrules/columnOp.ts)
+along with their `applies()` guards, so a rule that would coincide with the
+correct procedure emits nothing at all.
+
+## Where the arithmetic comes from
+
+The host serves an item from the curriculum's `add` domain — the only active one,
+seven live rows, all whole-number column addition and subtraction. Its canonical
+value becomes the target. **The answer is never shown.** The board carries
+`4,003 − 87` and the bar has to reach 3,916, so a fall asks two questions back to
+back: evaluate the column sum, then decompose it.
+
+The plates themselves are the game's own. `game/plates.ts` cuts a pair for
+whatever target it is handed, preferring a round heavy plate, a single-digit
+light one, coprime denominations, an escape around five taps, and — importantly —
+a pair with more than one way out, because 24 from 4s and 7s has exactly one
+escape and that is a cliff rather than a puzzle. Nothing about the decomposition
+is reported: it is arithmetic the child performs with their thumbs, not a
+question anybody asked.
+
+The count is a function of the **work**, never of the run. A longer sum and a
+longer decomposition both buy more time; winning six falls in a row buys none.
+A single-digit sum with a short escape lands at almost exactly the canon's four
+seconds; a four-digit borrow gets nearly eight.
+
+## Running it
+
+```sh
+npm install
+npm run dev          # http://127.0.0.1:4321 — playable against the stub host
+npm test             # the rules; 75 cases, no canvas, no Math.random
+npm run tsc
+npm run build:pack   # → dist-pack/, what a tablet installs
+```
+
+Dev-harness query parameters: `?seed=123` replays a card, `?level=7` pins the
+ladder at a rung, `?reduced=1` forces the reduced-motion branch.
+
+Controls are the whole screen: left half is the light plate, right half the
+heavy one. `A`/`D` and the arrow keys work too, and `M` mutes.
+
+## Layout
+
+```
+src/
+  contract.ts      the Host interface — byte-identical in shape across games
+  stubHost.ts      seeded column add/sub with real mal-rule distractors
+  mount.ts         surface, loop, input and juice. Decides nothing.
+  audio.ts         procedural Web Audio; silence is a cue, not an absence
+  core/            rng · feel (screenshake, hitstop, flash) · quality tiers
+  game/
+    plates.ts      the two-denomination exact-target problem
+    bout.ts        the rules: lockup → pin → kickout | pinfall
+    reaction.ts    tier picker, with no run-length input and a test that says so
+    save.ts        the belt, monotone, and safe on an opaque origin
+  render/          layout · crowd · ring · decals · particles · hud · palette
+```
+
+`game/` holds every rule and every integer. `render/` draws state and judges
+nothing. That split is why the tests are about the game and not about pixels.

--- a/dynawalla/games/foundry/index.html
+++ b/dynawalla/games/foundry/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <title>THE GRAPPLE FOUNDRY — dev harness</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #0b0a10;
+        overscroll-behavior: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+      #readout {
+        position: fixed;
+        left: 8px;
+        bottom: 6px;
+        z-index: 5;
+        font: 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+        color: rgba(255, 255, 255, 0.42);
+        pointer-events: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <div id="readout">host.report → 0/0</div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/foundry/pack.html
+++ b/dynawalla/games/foundry/pack.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#0b0a10" />
+    <title>THE GRAPPLE FOUNDRY</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #0b0a10;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         The dev harness's `#readout` is not here — it reported the stub host's
+         tally, and inside a real host the host draws the progress. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/foundry/pack.json
+++ b/dynawalla/games/foundry/pack.json
@@ -1,0 +1,24 @@
+{
+  "id": "dynawalla.foundry",
+  "version": "0.1.0",
+  "name": "THE GRAPPLE FOUNDRY",
+  "description": "Pinned on the foundry canvas with the referee counting. Two leverage plates, one exact total, three slaps. Work out what the board is asking, build that number out of the plates, and kick out — but overshoot by one and the fall is already lost.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-multidigit",
+      "dw.add.regroup.add-short-addend",
+      "dw.add.regroup.subtract-short-subtrahend",
+      "dw.add.regroup.subtract-across-zero"
+    ],
+    "grades": [1, 4]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/foundry/package.json
+++ b/dynawalla/games/foundry/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@dynawalla/game-foundry",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "THE GRAPPLE FOUNDRY — a wrestling pin you escape by loading two leverage plates to an exact sum. Overshoot and the fall is lost.",
+  "engines": {
+    "node": ">=22.12"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4321 --strictPort",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
+    "build:pack": "vite build --config vite.pack.config.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^6.0.0",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/games/foundry/src/audio.ts
+++ b/dynawalla/games/foundry/src/audio.ts
@@ -1,0 +1,314 @@
+// Procedural Web Audio. No assets, no samples, nothing fetched.
+//
+// Every cue is built as **transient → body → tail**, because that is what makes
+// a synthesised hit read as a physical event rather than a beep: a 3–12ms noise
+// click that carries the impact, a pitched body that carries identity, and a
+// decay that carries size.
+//
+// The one thing that is *not* a sound is the most important sound in the game.
+// The canon asked for "silence on failure", and this module takes that
+// literally: `pinfall()` ducks the crowd bed to nothing in 90ms and plays one
+// dry, unpitched thud. There is no sad trombone and no descending arpeggio,
+// because being wrong must never be the more interesting thing to listen to —
+// the same rule `energy(SLIP) < energy(SEAT)` states on the visual side.
+//
+// Nothing here is the sole channel for any information; every cue has a visual
+// twin, and the whole system is disableable.
+
+/** Nothing is ever scheduled above this; the partials of a bell add up fast. */
+function safeHz(f: number): number {
+  return Math.max(20, Math.min(15000, f))
+}
+
+/** A minor pentatonic, so any two notes the escape picks are consonant. */
+const PENTATONIC = [0, 3, 5, 7, 10] as const
+
+function semis(i: number): number {
+  const k = Math.min(Math.max(0, i), PENTATONIC.length * 3 - 1)
+  const oct = Math.floor(k / PENTATONIC.length)
+  return (PENTATONIC[k % PENTATONIC.length] as number) + oct * 12
+}
+
+export class Audio {
+  private ctx: AudioContext | null = null
+  private bus: GainNode | null = null
+  private bedGain: GainNode | null = null
+  private bedNodes: AudioNode[] = []
+  private noise: AudioBuffer | null = null
+  private voices = 0
+  private readonly maxVoices = 22
+  private started = false
+  enabled = true
+
+  /** Must be called from a user gesture. Safe to call repeatedly. */
+  async start(): Promise<void> {
+    if (this.started) {
+      if (this.ctx?.state === "suspended") await this.ctx.resume().catch(() => {})
+      return
+    }
+    type WithWebkit = typeof globalThis & { webkitAudioContext?: typeof AudioContext }
+    const Ctor = globalThis.AudioContext ?? (globalThis as WithWebkit).webkitAudioContext
+    if (!Ctor) {
+      console.warn("[foundry] no AudioContext; running silent")
+      return
+    }
+    try {
+      const ctx = new Ctor()
+      this.ctx = ctx
+      const comp = ctx.createDynamicsCompressor()
+      comp.threshold.value = -17
+      comp.knee.value = 26
+      comp.ratio.value = 6
+      comp.attack.value = 0.003
+      comp.release.value = 0.16
+      const bus = ctx.createGain()
+      bus.gain.value = 0.9
+      bus.connect(comp)
+      comp.connect(ctx.destination)
+      this.bus = bus
+
+      // One second of white noise, generated once and reused by every transient.
+      const len = Math.floor(ctx.sampleRate)
+      const buf = ctx.createBuffer(1, len, ctx.sampleRate)
+      const d = buf.getChannelData(0)
+      let s = 0x9e3779b9
+      for (let i = 0; i < len; i++) {
+        s ^= s << 13
+        s ^= s >>> 17
+        s ^= s << 5
+        d[i] = ((s >>> 0) / 4294967296) * 2 - 1
+      }
+      this.noise = buf
+
+      this.buildBed()
+      this.started = true
+    } catch (error) {
+      console.warn("[foundry] audio could not start", error)
+    }
+  }
+
+  /** The hall: a low filtered-noise crowd that never stops and never resolves. */
+  private buildBed(): void {
+    const ctx = this.ctx
+    const bus = this.bus
+    const noise = this.noise
+    if (!ctx || !bus || !noise) return
+    const src = ctx.createBufferSource()
+    src.buffer = noise
+    src.loop = true
+    const band = ctx.createBiquadFilter()
+    band.type = "bandpass"
+    band.frequency.value = 420
+    band.Q.value = 0.6
+    const gain = ctx.createGain()
+    gain.gain.value = 0
+    src.connect(band)
+    band.connect(gain)
+    gain.connect(bus)
+    src.start()
+    this.bedGain = gain
+    this.bedNodes = [src, band, gain]
+  }
+
+  /** Crowd volume follows heat. Ramped, never stepped. */
+  setHeat(heat: number, seconds = 0.4): void {
+    const ctx = this.ctx
+    const g = this.bedGain
+    if (!ctx || !g || !this.enabled) return
+    const target = 0.012 + Math.max(0, Math.min(1, heat)) * 0.075
+    g.gain.cancelScheduledValues(ctx.currentTime)
+    g.gain.setTargetAtTime(target, ctx.currentTime, Math.max(0.05, seconds / 3))
+  }
+
+  private voice(): boolean {
+    if (!this.enabled || !this.ctx || !this.bus) return false
+    if (this.voices >= this.maxVoices) return false
+    this.voices++
+    return true
+  }
+
+  private release(seconds: number): void {
+    globalThis.setTimeout(
+      () => {
+        this.voices = Math.max(0, this.voices - 1)
+      },
+      Math.max(40, seconds * 1000),
+    )
+  }
+
+  private click(gain: number, hz: number, decay: number, q = 1.4): void {
+    const ctx = this.ctx
+    const bus = this.bus
+    const noise = this.noise
+    if (!ctx || !bus || !noise) return
+    const src = ctx.createBufferSource()
+    src.buffer = noise
+    const filt = ctx.createBiquadFilter()
+    filt.type = "bandpass"
+    filt.frequency.value = safeHz(hz)
+    filt.Q.value = q
+    const amp = ctx.createGain()
+    const t = ctx.currentTime
+    amp.gain.setValueAtTime(0, t)
+    amp.gain.linearRampToValueAtTime(gain, t + 0.003)
+    amp.gain.exponentialRampToValueAtTime(0.0001, t + decay)
+    src.connect(filt)
+    filt.connect(amp)
+    amp.connect(bus)
+    src.start(t)
+    src.stop(t + decay + 0.02)
+  }
+
+  private tone(hz: number, gain: number, decay: number, type: OscillatorType = "triangle"): void {
+    const ctx = this.ctx
+    const bus = this.bus
+    if (!ctx || !bus) return
+    const osc = ctx.createOscillator()
+    osc.type = type
+    osc.frequency.value = safeHz(hz)
+    const amp = ctx.createGain()
+    const t = ctx.currentTime
+    amp.gain.setValueAtTime(0, t)
+    amp.gain.linearRampToValueAtTime(gain, t + 0.008)
+    amp.gain.exponentialRampToValueAtTime(0.0001, t + decay)
+    osc.connect(amp)
+    amp.connect(bus)
+    osc.start(t)
+    osc.stop(t + decay + 0.02)
+  }
+
+  /**
+   * A plate going down.
+   *
+   * The pitch rides the load: the closer the bar is to the target, the higher
+   * the clank. It is a second channel for "how close am I" that costs nothing
+   * to read, and it has a visual twin in the bar's tilt — a child who cannot
+   * hear it loses no information.
+   */
+  plate(heavy: boolean, fraction: number): void {
+    if (!this.voice()) return
+    const f = Math.max(0, Math.min(1, fraction))
+    const base = heavy ? 168 : 268
+    const hz = base * Math.pow(2, semis(Math.round(f * 7)) / 12)
+    this.click(heavy ? 0.5 : 0.36, hz * 3.1, heavy ? 0.075 : 0.05, 2.2)
+    this.tone(hz, heavy ? 0.3 : 0.22, heavy ? 0.4 : 0.26, "triangle")
+    this.tone(hz * 2.02, 0.07, 0.2, "sine")
+    this.release(0.45)
+  }
+
+  /** Palm on canvas. Flat, unpitched, and louder each time. */
+  slap(index: number): void {
+    if (!this.voice()) return
+    const i = Math.max(1, Math.min(3, index))
+    this.click(0.34 + i * 0.14, 190 + i * 40, 0.12 + i * 0.02, 0.7)
+    this.tone(58 - i * 4, 0.2 + i * 0.05, 0.16, "sine")
+    this.release(0.25)
+  }
+
+  /** The escape. The biggest thing in the game, sized by the reaction tier. */
+  kickout(tier: number): void {
+    const ctx = this.ctx
+    if (!ctx || !this.voice()) return
+    const t = Math.max(0, Math.min(3, tier))
+    this.click(0.62, 900, 0.3, 0.5)
+    this.click(0.42, 2400, 0.16, 0.9)
+    // A brass chord that opens upward. The higher the tier, the more of it.
+    const root = 146.8
+    const chord = [0, 7, 12, 16, 19].slice(0, 3 + t)
+    chord.forEach((s, i) => {
+      const osc = ctx.createOscillator()
+      osc.type = i === 0 ? "sawtooth" : "triangle"
+      osc.frequency.value = safeHz(root * Math.pow(2, s / 12))
+      const amp = ctx.createGain()
+      const at = ctx.currentTime + i * 0.018
+      const peak = (0.2 - i * 0.025) * (0.65 + t * 0.14)
+      amp.gain.setValueAtTime(0, at)
+      amp.gain.linearRampToValueAtTime(Math.max(0.02, peak), at + 0.02)
+      amp.gain.exponentialRampToValueAtTime(0.0001, at + 0.7 + t * 0.2)
+      osc.connect(amp)
+      if (this.bus) amp.connect(this.bus)
+      osc.start(at)
+      osc.stop(at + 0.95 + t * 0.2)
+    })
+    // The hall comes up and comes back down.
+    const g = this.bedGain
+    if (g) {
+      const now = ctx.currentTime
+      g.gain.cancelScheduledValues(now)
+      g.gain.setValueAtTime(g.gain.value, now)
+      g.gain.linearRampToValueAtTime(0.11 + t * 0.03, now + 0.09)
+      g.gain.setTargetAtTime(0.04, now + 0.35, 0.5)
+    }
+    this.release(1.2)
+  }
+
+  /**
+   * A false finish: the hall surges and is cut off flat. Everybody thought that
+   * was it. The wave-off is a dry wood knock, not a buzzer.
+   */
+  falseFinish(): void {
+    const ctx = this.ctx
+    if (!ctx || !this.voice()) return
+    const g = this.bedGain
+    if (g) {
+      const now = ctx.currentTime
+      g.gain.cancelScheduledValues(now)
+      g.gain.setValueAtTime(g.gain.value, now)
+      g.gain.linearRampToValueAtTime(0.1, now + 0.13)
+      g.gain.setValueAtTime(0.1, now + 0.2)
+      g.gain.linearRampToValueAtTime(0.02, now + 0.23)
+    }
+    this.click(0.3, 1500, 0.05, 3)
+    this.tone(392, 0.12, 0.09, "square")
+    this.release(0.4)
+  }
+
+  /** The pinfall. The bed is cut and one dry thud lands in the hole it leaves. */
+  pinfall(): void {
+    const ctx = this.ctx
+    if (!ctx) return
+    const g = this.bedGain
+    if (g) {
+      const now = ctx.currentTime
+      g.gain.cancelScheduledValues(now)
+      g.gain.setValueAtTime(g.gain.value, now)
+      g.gain.linearRampToValueAtTime(0.0, now + 0.09)
+    }
+    if (!this.voice()) return
+    this.click(0.4, 120, 0.2, 0.5)
+    this.release(0.3)
+  }
+
+  /** A challenger put away. One bell, and the hall stays up for a while. */
+  title(): void {
+    if (!this.voice()) return
+    this.click(0.3, 3200, 0.1, 2)
+    this.tone(523.25, 0.2, 1.5, "sine")
+    this.tone(783.99, 0.11, 1.3, "sine")
+    this.tone(1046.5, 0.07, 1.0, "sine")
+    this.release(1.6)
+  }
+
+  setEnabled(on: boolean): void {
+    this.enabled = on
+    if (!on) this.setHeat(0, 0.15)
+  }
+
+  dispose(): void {
+    for (const n of this.bedNodes) {
+      try {
+        ;(n as AudioScheduledSourceNode).stop?.()
+      } catch {
+        // A node that was never started throws on stop. Nothing to do about it
+        // and nothing worth telling anyone.
+      }
+      n.disconnect()
+    }
+    this.bedNodes = []
+    this.bedGain = null
+    void this.ctx?.close().catch(() => {})
+    this.ctx = null
+    this.bus = null
+    this.started = false
+  }
+}

--- a/dynawalla/games/foundry/src/contract.ts
+++ b/dynawalla/games/foundry/src/contract.ts
@@ -1,0 +1,42 @@
+// The host↔game contract. This is the shape the runtime lands underneath us;
+// it must not drift. Nothing else in this package may redefine these types.
+//
+// `mount` delegates to `./mount.ts`. That module imports `Host` from here
+// type-only, and a type-only import is erased, so there is no runtime cycle.
+
+import { mountFoundry } from "./mount.ts"
+
+export type Question = {
+  id: string
+  prompt: string
+  answer: string
+  distractors: string[]
+  domain: string
+  difficulty: number
+}
+
+export type Host = {
+  next(opts?: { domain?: string; difficulty?: number }): Question
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+  haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void
+  prefersReducedMotion(): boolean
+
+  /**
+   * A natural stopping point the child *reached*: a level cleared, a run
+   * completed, a boss down.
+   *
+   * OPTIONAL and feature-detected — a stub host does not implement it and the
+   * game must not care. Fire and forget: nothing is returned, nothing may be
+   * awaited, and the game must not branch on it.
+   *
+   * **Never after a failure.** Not a lost fall, not a pinfall, not a wrong
+   * total, not the count running out. This is the call the host may put a
+   * sheet on top of, and a purchase surface next to a failure is the thing
+   * that is forbidden outright.
+   */
+  transition?(kind: "level" | "run" | "boss", label?: string): void
+}
+
+export function mount(el: HTMLElement, host: Host): { unmount(): void } {
+  return mountFoundry(el, host)
+}

--- a/dynawalla/games/foundry/src/core/feel.ts
+++ b/dynawalla/games/foundry/src/core/feel.ts
@@ -1,0 +1,169 @@
+// The response layer — trauma shake, directional kick, punch zoom, hitstop,
+// slow-motion and a rate-limited screen flash.
+//
+// Two house rules, and in a wrestling game both of them bite:
+//
+//   * **Hitstop is only ever spent on success.** A freeze frame is a reward.
+//     The kick-out gets one. The pinfall gets none — it gets *stillness*, which
+//     is a different thing: the world keeps running, quietly, while nothing
+//     happens. `feel.test.ts` asserts a pinfall never requests one.
+//   * **Nothing blocks input.** Every effect here draws over the next moment
+//     and none of them gate the pointer. A child who is already reaching for
+//     the plates while the crowd is still going is never made to wait.
+
+export type FeelOptions = {
+  reducedMotion: boolean
+}
+
+/** Hard ceiling for a children's product: no more than this many flashes/sec. */
+const MAX_FLASHES_PER_SEC = 3
+const MIN_FLASH_GAP_MS = 1000 / MAX_FLASHES_PER_SEC
+/** And no single flash may ever exceed this alpha, at any tier, ever. */
+const MAX_FLASH_ALPHA = 0.42
+
+export class Feel {
+  trauma = 0 // 0..1; shake is trauma²
+  kickX = 0
+  kickY = 0
+  zoom = 0 // additive; 0.1 == 10% punch in
+  private flash = 0
+  private flashColor = "#ffffff"
+  private lastFlashAt = -1e9
+  private hitstopMs = 0
+  private slowUntil = 0
+  private slowFrom = 1
+  private slowMs = 1
+  private nowMs = 0
+
+  reducedMotion: boolean
+
+  // Resolved each frame; read by the renderer.
+  shakeX = 0
+  shakeY = 0
+  scale = 1
+  flashAlpha = 0
+
+  private seed = 0x2545f491
+
+  constructor(o: FeelOptions) {
+    this.reducedMotion = o.reducedMotion
+  }
+
+  private rand(): number {
+    // xorshift32, so shake never allocates and never calls Math.random.
+    let x = this.seed
+    x ^= x << 13
+    x ^= x >>> 17
+    x ^= x << 5
+    this.seed = x >>> 0
+    return (this.seed / 4294967296) * 2 - 1
+  }
+
+  addTrauma(v: number): void {
+    if (this.reducedMotion) return
+    this.trauma = Math.min(1, this.trauma + v)
+  }
+
+  /** A kick along a direction — up out of the canvas, or down under the pin. */
+  kick(dx: number, dy: number, mag: number): void {
+    if (this.reducedMotion) return
+    const l = Math.hypot(dx, dy) || 1
+    this.kickX += (dx / l) * mag
+    this.kickY += (dy / l) * mag
+  }
+
+  punch(v: number): void {
+    if (this.reducedMotion) return
+    this.zoom += v
+  }
+
+  /** Freeze frames. Success only. */
+  hitstop(ms: number): void {
+    if (this.reducedMotion) return
+    this.hitstopMs = Math.max(this.hitstopMs, ms)
+  }
+
+  /** Slow-motion: drop to `from`, recover to 1 over `ms`. */
+  slowmo(from: number, ms: number): void {
+    if (this.reducedMotion) return
+    if (from >= this.timeScale()) return
+    this.slowFrom = from
+    this.slowMs = ms
+    this.slowUntil = this.nowMs + ms
+  }
+
+  /**
+   * Screen flash, rate-limited. A request that arrives too soon after the last
+   * one is *not* queued — it is dropped and the pending flash is topped up
+   * instead. Queuing would let three fast slaps emit a strobe.
+   */
+  requestFlash(alpha: number, color: string): void {
+    if (this.reducedMotion) return
+    const a = Math.min(MAX_FLASH_ALPHA, alpha)
+    if (this.nowMs - this.lastFlashAt < MIN_FLASH_GAP_MS) {
+      this.flash = Math.max(this.flash, a * 0.5)
+      return
+    }
+    this.lastFlashAt = this.nowMs
+    this.flash = Math.max(this.flash, a)
+    this.flashColor = color
+  }
+
+  timeScale(): number {
+    if (this.nowMs >= this.slowUntil) return 1
+    const t = 1 - (this.slowUntil - this.nowMs) / this.slowMs // 0 → 1
+    // easeOutCubic back to real time: the recovery should feel like release.
+    const e = 1 - Math.pow(1 - t, 3)
+    return this.slowFrom + (1 - this.slowFrom) * e
+  }
+
+  /**
+   * @param dtMs real elapsed time
+   * @param nowMs the frame clock
+   * @returns the number of ms the *simulation* should advance — zero while a
+   *          hitstop is being served.
+   */
+  advance(dtMs: number, nowMs: number): number {
+    this.nowMs = nowMs
+    if (this.hitstopMs > 0) {
+      this.hitstopMs -= dtMs
+      // Decay the visual response even during a freeze, so a long hitstop does
+      // not resume into a stale shake.
+      this.decay(dtMs)
+      return 0
+    }
+    this.decay(dtMs)
+    return dtMs * this.timeScale()
+  }
+
+  private decay(dtMs: number): void {
+    const dt = dtMs / 1000
+    this.trauma = Math.max(0, this.trauma - dt * 1.55)
+    const k = Math.exp(-dt * 11)
+    this.kickX *= k
+    this.kickY *= k
+    this.zoom *= Math.exp(-dt * 8.5)
+    this.flash = Math.max(0, this.flash - dt * 2.6)
+
+    const t2 = this.trauma * this.trauma
+    const amp = t2 * 24
+    this.shakeX = this.rand() * amp + this.kickX
+    this.shakeY = this.rand() * amp + this.kickY
+    this.scale = 1 + this.zoom + t2 * 0.012
+    this.flashAlpha = this.flash
+  }
+
+  get currentFlashColor(): string {
+    return this.flashColor
+  }
+
+  reset(): void {
+    this.trauma = 0
+    this.kickX = 0
+    this.kickY = 0
+    this.zoom = 0
+    this.flash = 0
+    this.hitstopMs = 0
+    this.slowUntil = 0
+  }
+}

--- a/dynawalla/games/foundry/src/core/rng.ts
+++ b/dynawalla/games/foundry/src/core/rng.ts
@@ -1,0 +1,62 @@
+// A seeded, deterministic PRNG. Every stochastic decision in the bout and in
+// the stub host runs through one of these so a match can be replayed exactly —
+// which is what makes "the plates you were dealt were fair" a testable claim
+// rather than an opinion.
+//
+// mulberry32: 32-bit state, no allocation, and trivially portable to a test.
+
+export class Rng {
+  private s: number
+
+  constructor(seed: number) {
+    // Force to uint32; a 0 seed is legal for mulberry32 but degenerate-looking,
+    // so nudge it off zero.
+    this.s = (seed >>> 0) || 0x9e3779b9
+  }
+
+  /** Uniform in [0, 1). */
+  next(): number {
+    this.s = (this.s + 0x6d2b79f5) >>> 0
+    let t = this.s
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+
+  /** Uniform in [lo, hi). */
+  range(lo: number, hi: number): number {
+    return lo + this.next() * (hi - lo)
+  }
+
+  /** Uniform integer in [lo, hi] inclusive. */
+  int(lo: number, hi: number): number {
+    if (hi <= lo) return lo
+    return lo + Math.floor(this.next() * (hi - lo + 1))
+  }
+
+  /** True with probability p. */
+  chance(p: number): boolean {
+    return this.next() < p
+  }
+
+  pick<T>(xs: readonly T[]): T {
+    if (xs.length === 0) throw new Error("rng.pick: empty")
+    return xs[Math.floor(this.next() * xs.length)] as T
+  }
+
+  /** In-place Fisher–Yates. Returns the same array for chaining. */
+  shuffle<T>(xs: T[]): T[] {
+    for (let i = xs.length - 1; i > 0; i--) {
+      const j = Math.floor(this.next() * (i + 1))
+      const a = xs[i] as T
+      xs[i] = xs[j] as T
+      xs[j] = a
+    }
+    return xs
+  }
+
+  /** Fork a sub-stream so a subsystem can be seeded without disturbing the run. */
+  fork(salt: number): Rng {
+    return new Rng((this.s ^ Math.imul(salt, 0x85ebca6b)) >>> 0)
+  }
+}

--- a/dynawalla/games/foundry/src/core/tiers.ts
+++ b/dynawalla/games/foundry/src/core/tiers.ts
@@ -1,0 +1,127 @@
+// Quality tiers. The mid-range tablet sets the FLOOR — LOW is what has to hold
+// 60fps, and ULTRA is allowed to be extravagant.
+//
+// The tier is picked once from device signals and then *ratchets down only*,
+// driven by a rolling frame-time budget. It never ratchets back up mid-bout: a
+// tier that oscillates produces a visibly pulsing crowd, which is worse than
+// being one tier low the whole way.
+
+export type TierName = "low" | "high" | "ultra"
+
+export type Quality = {
+  name: TierName
+  /** Ceiling on live particles. */
+  particles: number
+  /** Multiplies every emitter's burst count. */
+  burst: number
+  /** Cooling glow decals kept on the canvas. */
+  decals: number
+  /** Lanterns drawn in the crowd. */
+  crowd: number
+  /** Render scale — devicePixelRatio is clamped to this. */
+  maxDpr: number
+  /** Soft glow behind hot metal. */
+  glow: boolean
+  /** Rope sag is resolved per segment rather than as one curve. */
+  ropeDetail: number
+}
+
+export const TIERS: Record<TierName, Quality> = {
+  low: {
+    name: "low",
+    particles: 320,
+    burst: 0.45,
+    decals: 4,
+    crowd: 90,
+    maxDpr: 1.5,
+    glow: false,
+    ropeDetail: 6,
+  },
+  high: {
+    name: "high",
+    particles: 1100,
+    burst: 1,
+    decals: 8,
+    crowd: 220,
+    maxDpr: 2,
+    glow: true,
+    ropeDetail: 14,
+  },
+  ultra: {
+    name: "ultra",
+    particles: 2400,
+    burst: 1.8,
+    decals: 12,
+    crowd: 380,
+    maxDpr: 2.25,
+    glow: true,
+    ropeDetail: 22,
+  },
+}
+
+const ORDER: TierName[] = ["low", "high", "ultra"]
+
+export function detectTier(): TierName {
+  const nav = globalThis.navigator as (Navigator & { deviceMemory?: number }) | undefined
+  const cores = nav?.hardwareConcurrency ?? 4
+  const mem = nav?.deviceMemory ?? 4
+  const px = (globalThis.screen?.width ?? 1024) * (globalThis.screen?.height ?? 768)
+
+  // A phone with 8 fast cores still has a small thermal envelope, so cores
+  // alone overrates mobile. Memory is the better proxy for "this is a cheap
+  // tablet", and pixel count for "this is going to cost a lot to fill".
+  if (cores <= 4 || mem <= 3) return "low"
+  if (cores >= 8 && mem >= 8 && px >= 1_500_000) return "ultra"
+  return "high"
+}
+
+/**
+ * Watches frame time and ratchets the tier down when the device cannot hold the
+ * budget. Deliberately slow to fire: a single 40ms frame is a GC pause, not a
+ * verdict. It takes a sustained quarter-second of overrun.
+ */
+export class TierGovernor {
+  private samples = new Float32Array(60)
+  private i = 0
+  private filled = 0
+  private overrunMs = 0
+  private cooldown = 0
+  quality: Quality
+
+  constructor(start: TierName) {
+    this.quality = TIERS[start]
+  }
+
+  /** @returns true when the tier changed this frame. */
+  sample(dtMs: number): boolean {
+    this.samples[this.i] = dtMs
+    this.i = (this.i + 1) % this.samples.length
+    if (this.filled < this.samples.length) this.filled++
+
+    if (this.cooldown > 0) {
+      this.cooldown -= dtMs
+      return false
+    }
+    // 20ms ≈ the point where a 60Hz display has certainly dropped a frame.
+    this.overrunMs = dtMs > 20 ? this.overrunMs + (dtMs - 20) : Math.max(0, this.overrunMs - 4)
+    if (this.overrunMs < 250) return false
+
+    const idx = ORDER.indexOf(this.quality.name)
+    if (idx <= 0) {
+      this.overrunMs = 0
+      return false
+    }
+    this.quality = TIERS[ORDER[idx - 1] as TierName]
+    this.overrunMs = 0
+    this.cooldown = 3000
+    console.warn(`[foundry] frame budget missed; quality → ${this.quality.name}`)
+    return true
+  }
+
+  /** Median frame time over the window. */
+  medianMs(): number {
+    if (this.filled === 0) return 0
+    const a = Array.from(this.samples.slice(0, this.filled)).sort((x, y) => x - y)
+    return a[a.length >> 1] as number
+  }
+}

--- a/dynawalla/games/foundry/src/game/bout.ts
+++ b/dynawalla/games/foundry/src/game/bout.ts
@@ -1,0 +1,442 @@
+// The bout — the rules of the match, with nothing drawn.
+//
+// Every judgement in the game lives here and is synchronous, pure integer
+// arithmetic over the current fall. The renderer reads this state; it never
+// decides anything. That split is what lets the whole loop be tested without a
+// canvas, and it is why the tests in `bout.test.ts` are about the rules and not
+// about pixels.
+//
+// A fall, end to end:
+//
+//   LOCKUP   the challenger takes you down. ~0.8s. Taps skip it.
+//   PIN      the referee's board shows the sum; the count begins. Two plates.
+//            Land the exact total and you kick out. Anything else loses the
+//            fall — over the total, out of moves, or out of count.
+//   KICKOUT  the escape. Budget comes from the reaction tier the fall earned.
+//   PINFALL  silence. The crowd bed cuts, nothing bursts, the referee's hand
+//            comes down. Shorter and quieter than the escape, always, because
+//            `energy(SLIP) < energy(SEAT)` is a rule and not a preference.
+
+import type { Host, Question } from "../contract.ts"
+import { Rng } from "../core/rng.ts"
+import { choosePlates, minTapsFor, reachable, type Plates } from "./plates.ts"
+import { reactionTier, REACTIONS, type ReactionTier } from "./reaction.ts"
+
+export type Phase = "lockup" | "pin" | "kickout" | "pinfall"
+
+/** How a fall ended. Exactly one of these is reported per served item. */
+export type FallOutcome = "escaped" | "overshot" | "stuck" | "counted-out"
+
+export type PlateSide = "a" | "b"
+
+export type BoutEvent =
+  | { kind: "lockup"; challenger: string }
+  | { kind: "pin-begin" }
+  | { kind: "slap"; index: 1 | 2 | 3 }
+  | { kind: "load"; side: PlateSide; value: number; load: number; fraction: number }
+  | { kind: "false-finish"; value: number }
+  | { kind: "escape"; tier: ReactionTier; taps: number; minTaps: number; repaired: boolean }
+  | {
+      kind: "pinfall"
+      reason: Exclude<FallOutcome, "escaped">
+      /** The bar came to rest on the exact output of a known broken procedure. */
+      diagnosed: boolean
+    }
+  | { kind: "cast"; beltPlates: number }
+  | { kind: "title"; challenger: string; beaten: number }
+
+/** The three slaps, and then you are out. */
+export const SLAP_COUNT = 3
+
+const LOCKUP_S = 0.82
+const PINFALL_S = 1.3
+/** A false finish costs count, but it may never *be* the third slap. */
+const FALSE_FINISH_COST_S = 0.36
+const FALSE_FINISH_SAFETY_S = 0.55
+
+/**
+ * Escapes needed to put a challenger away.
+ *
+ * Driven by how many challengers have been **beaten**, never by how many have
+ * walked out. Losing a bout brings a fresh opponent out at the same demand: a
+ * game that asked for one more escape after a defeat would be escalating on
+ * failure, which is the shape of thing this product does not do.
+ */
+export function fallsToBeat(challengersBeaten: number): number {
+  return 4 + Math.min(4, challengersBeaten)
+}
+
+/**
+ * Challengers cast in the foundry. Names only — the art is procedural and the
+ * names exist so a child can tell one bout from the next and so the title beat
+ * has something true to say.
+ */
+export const CHALLENGERS = [
+  "THE BELLOWS",
+  "SLAG BROTHER",
+  "COLD CHISEL",
+  "THE ANVIL WIDOW",
+  "TONGS",
+  "QUENCH",
+  "THE CRUCIBLE",
+  "HAMMERHEAD",
+] as const
+
+/**
+ * Whatever the host reports, squashed to 0..1.
+ *
+ * The pack host sends `item.level / 8`, already normalised. A host that sent a
+ * raw 1..10 ladder index instead would otherwise pin every fall at maximum
+ * pressure, so the out-of-range branch exists and is tested rather than assumed
+ * unreachable.
+ */
+export function normalizeDifficulty(d: number): number {
+  if (!Number.isFinite(d)) return 0
+  if (d <= 1) return Math.max(0, d)
+  return Math.max(0, Math.min(1, (d - 1) / 9))
+}
+
+/** Digits in the prompt — a cheap, honest proxy for how long it takes to read. */
+export function promptDigits(prompt: string): number {
+  let n = 0
+  for (const ch of prompt) if (ch >= "0" && ch <= "9") n++
+  return n
+}
+
+/**
+ * Seconds between referee slaps.
+ *
+ * **Time is a function of the work, never of the run.** A longer decomposition
+ * and a longer sum both buy count; winning six falls in a row buys nothing,
+ * because a clock that tightens on a streak is the loop this product bans. The
+ * only concession to the ladder is a ~15% tempo lift across its whole length,
+ * which is pace, not pressure.
+ *
+ * The canon asked for four seconds. A single-digit sum with a three-tap escape
+ * lands at almost exactly that; `4,003 − 87` gets nearer eight, because a child
+ * who can do that sum still has to *do* it.
+ */
+export function slapPeriodFor(minTaps: number, digits: number, difficulty: number): number {
+  const base = 0.55 + 0.17 * Math.max(0, minTaps) + 0.19 * Math.max(0, digits)
+  const tempo = 1.06 - 0.16 * Math.max(0, Math.min(1, difficulty))
+  return Math.max(1.05, Math.min(3.2, base * tempo))
+}
+
+export type Fall = {
+  questionId: string
+  prompt: string
+  target: number
+  plates: Plates
+  /** What is on the bar right now. Starts at 0, only ever rises. */
+  load: number
+  taps: number
+  /** Taps spent on each plate, so the escape can be read back as a sentence. */
+  tapsA: number
+  tapsB: number
+  /** The fewest taps this escape could cost from an empty bar. */
+  minTaps: number
+  /** Mal-rule totals: values a real broken procedure produces, either side of the target. */
+  traps: number[]
+  /** Traps already sprung — each one only ever fires once. */
+  sprung: number[]
+  slapPeriod: number
+  /** Seconds since the pin began. */
+  elapsed: number
+  /** Seconds of count eaten by false finishes. */
+  advance: number
+  /** Slaps that have landed, 0..3. */
+  slaps: number
+  difficulty: number
+}
+
+export type BoutOptions = {
+  host: Host
+  seed?: number
+  /** Called for every rule-level event, in order, during `tick`. */
+  onEvent?: (e: BoutEvent) => void
+}
+
+export class Bout {
+  private readonly host: Host
+  private readonly rng: Rng
+  private readonly emit: (e: BoutEvent) => void
+
+  phase: Phase = "lockup"
+  /** Seconds remaining in a non-`pin` phase. */
+  phaseLeft = LOCKUP_S
+  fall: Fall
+  /** 0..1. Crowd noise and lantern light only — it touches no rule and no clock. */
+  heat = 0.1
+  /** Cast onto the belt on every escape, and never taken off again. */
+  beltPlates = 0
+  challengerIndex = 0
+  /** Escapes taken off the current challenger. */
+  falls = 0
+  /** Falls the current challenger has taken off you. */
+  lost = 0
+  challengersBeaten = 0
+  /** The reaction the last escape earned, for the renderer to size the beat by. */
+  lastTier: ReactionTier = 0
+  lastOutcome: FallOutcome | null = null
+
+  constructor(options: BoutOptions) {
+    this.host = options.host
+    this.rng = new Rng(options.seed ?? 0x9a11ed)
+    this.emit = options.onEvent ?? (() => {})
+    this.fall = this.cutFall()
+  }
+
+  get challenger(): string {
+    return CHALLENGERS[this.challengerIndex % CHALLENGERS.length] as string
+  }
+
+  /** Escapes still owed before this challenger is beaten. */
+  get toBeat(): number {
+    return Math.max(0, fallsToBeat(this.challengersBeaten) - this.falls)
+  }
+
+  /** 0..1 through the count. 1 is the third slap. */
+  get countFraction(): number {
+    if (this.phase !== "pin") return 0
+    const window = this.fall.slapPeriod * SLAP_COUNT
+    return Math.max(0, Math.min(1, (this.fall.elapsed + this.fall.advance) / window))
+  }
+
+  /** Cut the next fall: pull an item, turn its value into a target, hang plates. */
+  private cutFall(): Fall {
+    const q: Question = this.host.next()
+    const parsed = Number.parseInt(q.answer, 10)
+    // A pool that ran dry hands back a drawable question with no id. The fall is
+    // still playable — a child must never see a frozen ring — but nothing about
+    // it is reported, because there is no item to report it against.
+    const usable = Number.isInteger(parsed) && parsed >= 1
+    const target = usable ? parsed : 12
+    const difficulty = normalizeDifficulty(q.difficulty)
+    const plates = choosePlates(target, this.rng, { pressure: difficulty })
+    const minTaps = minTapsFor(target, plates.a, plates.b) ?? plates.taps
+
+    // Mal-rule totals, above and below the target alike, because the two are
+    // different beats rather than one beat and one dead case:
+    //
+    //   * **Below** the target the bar passes through the value and the fall
+    //     goes on. The hall comes up, the referee waves it off, it costs count.
+    //   * **Above** it, the bar can only arrive there by going over — so the
+    //     fall is already lost when it lands. It is still worth naming: the
+    //     value is not noise, it is a specific broken procedure, and the child
+    //     gets told what was refused rather than just that something was.
+    //
+    // The second case is the only one subtraction has. Every mal-rule this
+    // domain produces for a difference comes out *larger* than the difference —
+    // smaller-from-larger skips the borrow, borrow-across-zero keeps a thousand
+    // it should have given up, and reading `−` as `+` is larger still. A rule
+    // that only kept the ones below the target would have left every
+    // subtraction fall with no diagnosis at all.
+    const traps: number[] = []
+    for (const d of q.distractors) {
+      const v = Number.parseInt(d, 10)
+      if (!Number.isInteger(v) || v < 1 || v === target) continue
+      if (!traps.includes(v)) traps.push(v)
+    }
+
+    return {
+      questionId: usable ? q.id : "",
+      prompt: q.prompt,
+      target,
+      plates,
+      load: 0,
+      taps: 0,
+      tapsA: 0,
+      tapsB: 0,
+      minTaps,
+      traps,
+      sprung: [],
+      slapPeriod: slapPeriodFor(minTaps, promptDigits(q.prompt), difficulty),
+      elapsed: 0,
+      advance: 0,
+      slaps: 0,
+      difficulty,
+    }
+  }
+
+  /**
+   * Advance the rules. `dt` is seconds of *simulation* time, already scaled.
+   *
+   * Clamped to a quarter-second because a tab that was backgrounded for a
+   * minute must not deliver a minute of count in one frame — a child coming
+   * back to three slaps they never saw has been cheated by the app, not beaten
+   * by the game. The visibility handler pauses the loop as well; this is the
+   * belt to that pair of braces.
+   */
+  tick(dt: number): void {
+    const step = Math.max(0, Math.min(0.25, dt))
+    this.decayHeat(step)
+
+    if (this.phase === "pin") {
+      this.fall.elapsed += step
+      const t = this.fall.elapsed + this.fall.advance
+      while (this.fall.slaps < SLAP_COUNT && t >= (this.fall.slaps + 1) * this.fall.slapPeriod) {
+        this.fall.slaps++
+        this.emit({ kind: "slap", index: this.fall.slaps as 1 | 2 | 3 })
+        this.host.haptic(this.fall.slaps === SLAP_COUNT ? "heavy" : "medium")
+      }
+      if (this.fall.slaps >= SLAP_COUNT) this.loseFall("counted-out")
+      return
+    }
+
+    this.phaseLeft -= step
+    if (this.phaseLeft > 0) return
+    if (this.phase === "lockup") {
+      this.phase = "pin"
+      this.emit({ kind: "pin-begin" })
+      return
+    }
+    // A kickout or a pinfall has played out. Next challenger takedown.
+    this.nextFall()
+  }
+
+  /**
+   * A plate went down.
+   *
+   * During a lockup this skips the takedown instead of loading — a child who is
+   * already reaching for the pedals should not have their first tap eaten by an
+   * animation, and should not have it spent either.
+   */
+  tap(side: PlateSide): void {
+    if (this.phase === "lockup") {
+      this.phaseLeft = 0
+      return
+    }
+    // A tap during the escape or the pinfall cuts the beat short. It never
+    // loads, so nothing is ever spent on a screen that was not asking for it.
+    if (this.phase !== "pin") {
+      if (this.phaseLeft > 0.16) this.phaseLeft = 0.16
+      return
+    }
+
+    const f = this.fall
+    const value = side === "a" ? f.plates.a : f.plates.b
+    f.load += value
+    f.taps++
+    if (side === "a") f.tapsA++
+    else f.tapsB++
+    const fraction = f.target > 0 ? Math.min(1, f.load / f.target) : 1
+    this.emit({ kind: "load", side, value, load: f.load, fraction })
+
+    if (f.load === f.target) {
+      this.escape()
+      return
+    }
+    if (f.load > f.target) {
+      this.host.haptic("failure")
+      this.loseFall("overshot")
+      return
+    }
+    // Below the target from here down.
+    // A known wrong answer, reached exactly. The crowd comes up, the referee
+    // waves it off, and it costs count — but never the fall. A false finish
+    // that could itself end the match would be a trap, and the child would have
+    // learned that a mal-rule is fatal rather than that it is wrong.
+    let falseFinish = false
+    if (f.traps.includes(f.load) && !f.sprung.includes(f.load)) {
+      falseFinish = true
+      f.sprung.push(f.load)
+      const window = f.slapPeriod * SLAP_COUNT
+      const room = Math.max(0, window - FALSE_FINISH_SAFETY_S - (f.elapsed + f.advance))
+      f.advance += Math.min(FALSE_FINISH_COST_S, room)
+      this.emit({ kind: "false-finish", value: f.load })
+    }
+    // The bar is under the target and there is no combination of these two
+    // plates that closes the gap. Not out of time and not over — out of moves,
+    // which is the shape the coin problem actually has, and saying so at once
+    // is more honest than running a count down on a dead position.
+    if (!reachable(f.target - f.load, f.plates.a, f.plates.b)) {
+      this.host.haptic("failure")
+      this.loseFall("stuck")
+      return
+    }
+    this.host.haptic(falseFinish ? "medium" : "light")
+  }
+
+  private escape(): void {
+    const f = this.fall
+    const repaired = f.sprung.length > 0
+    const tier = reactionTier({
+      difficulty: f.difficulty,
+      minTaps: f.minTaps,
+      taps: f.taps,
+      repaired,
+    })
+    this.lastTier = tier
+    this.lastOutcome = "escaped"
+    this.report(true, String(f.target))
+    this.host.haptic("success")
+
+    this.beltPlates++
+    this.falls++
+    this.heat = Math.min(1, this.heat + 0.15)
+    this.emit({ kind: "escape", tier, taps: f.taps, minTaps: f.minTaps, repaired })
+    this.emit({ kind: "cast", beltPlates: this.beltPlates })
+
+    if (this.falls >= fallsToBeat(this.challengersBeaten)) {
+      const beaten = this.challenger
+      this.challengersBeaten++
+      this.emit({ kind: "title", challenger: beaten, beaten: this.challengersBeaten })
+      // A stopping point the child *reached*. Only ever here: never after a
+      // pinfall, never after the count, never after an overshoot.
+      this.host.transition?.("level", beaten)
+      this.challengerIndex++
+      this.falls = 0
+      this.lost = 0
+    }
+
+    this.phase = "kickout"
+    this.phaseLeft = Math.max(0.75, REACTIONS[tier].budgetMs / 1000)
+  }
+
+  private loseFall(reason: Exclude<FallOutcome, "escaped">): void {
+    const f = this.fall
+    this.lastOutcome = reason
+    this.lastTier = -1
+    // Where the bar came to rest, and whether that is a value with a name.
+    const diagnosed = f.traps.includes(f.load)
+    this.report(false, f.load > 0 ? String(f.load) : "")
+    this.lost++
+    // The crowd goes quiet. Nothing the child built comes off the belt.
+    this.heat = Math.max(0, this.heat - 0.24)
+    this.emit({ kind: "pinfall", reason, diagnosed })
+    if (this.lost >= SLAP_COUNT) {
+      // The challenger takes the bout. A fresh one walks out; the belt keeps
+      // every plate it was ever handed.
+      this.challengerIndex++
+      this.falls = 0
+      this.lost = 0
+    }
+    this.phase = "pinfall"
+    this.phaseLeft = PINFALL_S
+  }
+
+  /** Exactly once per fall, and only for an item the host actually served. */
+  private report(correct: boolean, answered: string): void {
+    const f = this.fall
+    if (f.questionId === "") return
+    this.host.report({
+      questionId: f.questionId,
+      correct,
+      ms: Math.round(f.elapsed * 1000),
+      answered,
+    })
+    f.questionId = ""
+  }
+
+  private nextFall(): void {
+    this.fall = this.cutFall()
+    this.phase = "lockup"
+    this.phaseLeft = LOCKUP_S
+    this.emit({ kind: "lockup", challenger: this.challenger })
+  }
+
+  private decayHeat(dt: number): void {
+    const floor = 0.08
+    if (this.heat > floor) this.heat = Math.max(floor, this.heat - dt * 0.035)
+  }
+}

--- a/dynawalla/games/foundry/src/game/plates.ts
+++ b/dynawalla/games/foundry/src/game/plates.ts
@@ -1,0 +1,259 @@
+// The leverage plates — the mathematics of the escape, and the whole game.
+//
+// You are pinned. Two plates hang off the ring frame, one light and one heavy,
+// each stamped with a whole number. Every tap drops that plate's weight onto
+// the bar across your chest. Reach the target **exactly** and the bar tips and
+// you kick out. Go one over and the bar crushes you and the fall is lost.
+//
+// That is the two-denomination exact-target problem — the coin problem, the
+// smallest interesting object in number theory that a six-year-old can hold in
+// their head — and it is the mechanic rather than a quiz laid over one. The
+// target is the value of the sum on the referee's board, so a fall asks two
+// questions back to back:
+//
+//     "what is 62 − 38?"          the served item
+//     "how do I make 24 from 7s and 5s?"   the escape
+//
+// Everything in this file is exact integer arithmetic. There is no float in a
+// plate value, a target, a remainder or a comparison, and `plates.test.ts`
+// asserts that over the whole reachable target range rather than on a sample.
+
+/** The pair of plates hanging on the frame, and the escape they were cut for. */
+export type Plates = {
+  /** The light plate. Always the smaller of the two. */
+  a: number
+  /** The heavy plate. Always strictly greater than `a`. */
+  b: number
+  /** Taps on the light plate in the shortest escape that uses both plates. */
+  x: number
+  /** Taps on the heavy plate in that same escape. */
+  y: number
+  /** `x + y` — how many taps the escape costs at best. */
+  taps: number
+}
+
+/**
+ * The tap budget an escape may cost.
+ *
+ * The floor is 2 because a one-tap escape is not a decomposition, it is a
+ * button. The ceiling is 9 because past that the count runs out on manual
+ * dexterity rather than on arithmetic, and a child who knew the answer would
+ * still lose — which is the one failure this game must never produce.
+ */
+export const MIN_TAPS = 2
+export const MAX_TAPS = 9
+
+/**
+ * Plate sizes, and why they are bounds rather than constants.
+ *
+ * A pedal is a physical object with a number stamped on it, read at speed with
+ * a referee counting, so the default ceilings are small. But the host serves
+ * whatever the ladder has reached, and at the top of `dw.add` that is a
+ * four-digit column sum — a target of 3,916 cannot be made from plates capped
+ * at 400 in nine taps, and a game that quietly failed to cut a pair for it
+ * would be a game that stops working exactly when a child gets good.
+ *
+ * So the ceilings scale with the target and the defaults are the floor.
+ */
+const BASE_MAX_PLATE = 400
+const BASE_MAX_LIGHT = 14
+
+function maxHeavyFor(target: number): number {
+  return Math.max(BASE_MAX_PLATE, Math.ceil(target / 2))
+}
+
+function maxLightFor(target: number): number {
+  return Math.max(BASE_MAX_LIGHT, Math.min(99, Math.floor(target / 12)))
+}
+
+export function gcd(m: number, n: number): number {
+  let p = Math.abs(m)
+  let q = Math.abs(n)
+  while (q > 0) {
+    const r = p % q
+    p = q
+    q = r
+  }
+  return p
+}
+
+/**
+ * Can `remaining` be made from these two plates at all, with any number of taps?
+ *
+ * This is the dead-end test, and it is the reason the game has a third outcome
+ * beside "escaped" and "overshot". With plates 4 and 7 and a target of 24, a
+ * child who taps 7, 7, 7 is on 21 with three to go: no combination of 4 and 7
+ * makes 3, and every further tap overshoots. They are not out of time and they
+ * have not gone over — they are simply stuck, and the honest thing is to say
+ * so at once instead of running the count down on a position with no move in
+ * it.
+ *
+ * Exhaustive by construction: `y` cannot exceed `remaining / b`, so the loop is
+ * bounded and every branch is integer division and remainder.
+ */
+export function reachable(remaining: number, a: number, b: number): boolean {
+  if (!Number.isInteger(remaining) || remaining < 0) return false
+  if (remaining === 0) return true
+  if (a <= 0 || b <= 0) return false
+  for (let y = 0; y * b <= remaining; y++) {
+    if ((remaining - y * b) % a === 0) return true
+  }
+  return false
+}
+
+/** The fewest taps that make `remaining` exactly, or `null` when nothing does. */
+export function minTapsFor(remaining: number, a: number, b: number): number | null {
+  if (!Number.isInteger(remaining) || remaining < 0) return null
+  if (remaining === 0) return 0
+  if (a <= 0 || b <= 0) return null
+  let best: number | null = null
+  for (let y = 0; y * b <= remaining; y++) {
+    const rest = remaining - y * b
+    if (rest % a !== 0) continue
+    const taps = y + rest / a
+    if (best === null || taps < best) best = taps
+  }
+  return best
+}
+
+/**
+ * Every escape from `target` on these plates that costs at most `maxTaps`.
+ *
+ * The game does not show this to the child — it is what the tests use to prove
+ * that a chosen pair is escapable, and what the bout uses to decide how much
+ * count to give.
+ */
+export function representations(
+  target: number,
+  a: number,
+  b: number,
+  maxTaps: number = MAX_TAPS,
+): Array<{ x: number; y: number }> {
+  const out: Array<{ x: number; y: number }> = []
+  if (!Number.isInteger(target) || target < 1 || a <= 0 || b <= 0) return out
+  for (let y = 0; y * b <= target; y++) {
+    const rest = target - y * b
+    if (rest % a !== 0) continue
+    const x = rest / a
+    if (x + y > maxTaps) continue
+    out.push({ x, y })
+  }
+  return out
+}
+
+/**
+ * How good a pair of plates is for a given target. Lower is better.
+ *
+ * These weights are the whole design of the difficulty curve, so they are
+ * written out rather than tuned by hand into a magic constant:
+ *
+ *   * **Five taps is the sweet spot.** Two is a shrug, nine is a drum solo.
+ *   * **The heavy plate should be round-ish.** A 25 or a 40 is a landmark a
+ *     child counts in; a 37 is arithmetic on top of arithmetic.
+ *   * **A single-digit light plate.** It is the one being tapped repeatedly and
+ *     the running total has to stay mentally cheap.
+ *   * **Coprime plates are the good problem.** When gcd(a, b) is 1 the pair
+ *     reaches every large target and the search has real structure. When the
+ *     heavy plate is a multiple of the light one the light plate is decoration.
+ *   * **A pure heavy-plate escape is a trap for the designer, not the child.**
+ *     If the target is a small multiple of `b`, the fastest escape ignores half
+ *     the equipment, and the fall stops being a decomposition.
+ *   * **A pair with exactly one way out is a cliff.** 24 from 4s and 7s has a
+ *     single escape — six fours — because 7y ≡ 24 (mod 4) forces y to zero, so
+ *     the very first tap of the heavy plate is fatal. That is a true and
+ *     interesting fact about the coin problem and a miserable thing to hand a
+ *     seven-year-old with a referee counting, so it is heavily penalised. It is
+ *     not forbidden: dead ends are the shape of this problem and removing them
+ *     entirely would remove the reason to think before tapping.
+ */
+export function scorePair(target: number, a: number, b: number, x: number, y: number): number {
+  let score = Math.abs(x + y - 5) * 3
+  if (b % 10 === 0) score -= 2
+  else if (b % 5 === 0) score -= 1
+  else score += 2
+  if (a > 9) score += 3
+  if (a === 1) score += 6
+  if (b > 99) score += 3
+  if (gcd(a, b) > 1) score += 2
+  if (b % a === 0) score += 2
+  // Integer throughout: `0` means "the heavy plate does not divide the target",
+  // which is a fact about divisibility and not a very large number.
+  const soloTaps = target % b === 0 ? target / b : 0
+  if (soloTaps >= 1 && soloTaps <= 3) score += 4
+  if (representations(target, a, b, MAX_TAPS).length < 2) score += 5
+  return score
+}
+
+export type ChoosePlatesOptions = {
+  /**
+   * 0..1. Pushes the escape longer and the plates less round as a child climbs
+   * the ladder. It never changes what is *true* — every pair returned is exact
+   * and escapable at any pressure.
+   */
+  pressure?: number
+}
+
+/**
+ * Cut a pair of plates for this target.
+ *
+ * The returned pair is **always** exact: `a·x + b·y === target`, on every input.
+ *
+ * For every target of 5 or more it also uses both plates and costs between
+ * `MIN_TAPS` and `MAX_TAPS` taps.
+ *
+ * Below that the guarantee narrows, and it has to: 1 and 2 cannot be split
+ * across two distinct plates that are both used, and 3 and 4 only with a light
+ * plate of 1. Targets that small are reachable — `22 − 21` is a legal item on
+ * the no-regroup rung — so the fallbacks at the bottom return a short, honest,
+ * one-plate fall rather than throwing in front of a child.
+ */
+export function choosePlates(
+  target: number,
+  rng: { int(lo: number, hi: number): number; next(): number },
+  options: ChoosePlatesOptions = {},
+): Plates {
+  const pressure = Math.max(0, Math.min(1, options.pressure ?? 0))
+  // The tap window opens upward under pressure: a beginner is offered escapes
+  // around four taps, a fluent child around six.
+  const wantMax = Math.min(MAX_TAPS, 5 + Math.round(pressure * 4))
+
+  type Candidate = Plates & { score: number }
+  const found: Candidate[] = []
+
+  if (Number.isInteger(target) && target >= 3) {
+    const maxLight = maxLightFor(target)
+    const maxHeavy = maxHeavyFor(target)
+    for (let a = 2; a <= maxLight; a++) {
+      for (let x = 1; x <= wantMax - 1; x++) {
+        const rest = target - a * x
+        if (rest < 1) break
+        for (let y = 1; y <= wantMax - x; y++) {
+          if (rest % y !== 0) continue
+          const b = rest / y
+          if (b <= a || b > maxHeavy) continue
+          const taps = x + y
+          if (taps < MIN_TAPS || taps > wantMax) continue
+          found.push({ a, b, x, y, taps, score: scorePair(target, a, b, x, y) })
+        }
+      }
+    }
+  }
+
+  if (found.length > 0) {
+    let best = found[0]!.score
+    for (const c of found) if (c.score < best) best = c.score
+    // Everything within a couple of points of the best is an equally good
+    // fall; picking among them is what stops the same two plates hanging on
+    // the frame every time a target repeats.
+    const shortlist = found.filter((c) => c.score <= best + 2)
+    const pick = shortlist[rng.int(0, shortlist.length - 1)] ?? shortlist[0]!
+    return { a: pick.a, b: pick.b, x: pick.x, y: pick.y, taps: pick.taps }
+  }
+
+  // Degenerate targets. 1 and 2 cannot be split across two distinct plates that
+  // are both used, so the light plate becomes 1 and the escape is short and
+  // honest rather than impossible.
+  if (target >= 3) return { a: 1, b: target - 1, x: 1, y: 1, taps: 2 }
+  if (target === 2) return { a: 1, b: 2, x: 2, y: 0, taps: 2 }
+  return { a: 1, b: 2, x: 1, y: 0, taps: 1 }
+}

--- a/dynawalla/games/foundry/src/game/reaction.ts
+++ b/dynawalla/games/foundry/src/game/reaction.ts
@@ -1,0 +1,92 @@
+// The reaction vocabulary, and the one rule that keeps it honest.
+//
+// `docs/EXPERIENCE_DESIGN.md` fixes the tiers and their budgets, and fixes two
+// invariants that this module exists to make testable:
+//
+//   1. **Escalation is on difficulty and repair, never on run length.** A
+//      combo-momentum function is exactly the loop this product bans, so the
+//      input to `reactionTier` carries no streak, no chain and no combo, and
+//      `reaction.test.ts` asserts that by name over `REACTION_INPUT_KEYS`.
+//   2. **`energy(SLIP) < energy(SEAT)`.** Being wrong must not be the more
+//      interesting thing to watch. In a wrestling game that invariant has teeth,
+//      because a body going limp under a three-count is inherently more animated
+//      than one standing up — which is why the pinfall here is *silence*: the
+//      crowd bed cuts, nothing bursts, and the only motion is the referee's hand
+//      coming down. The canon called for that beat and the invariant demands it.
+
+export type ReactionTier = -1 | 0 | 1 | 2 | 3
+
+export const SLIP: ReactionTier = -1
+export const SEAT: ReactionTier = 0
+export const ENGAGE: ReactionTier = 1
+export const ILLUMINATE: ReactionTier = 2
+export const MECHANISM: ReactionTier = 3
+
+/**
+ * The complete set of things the tier may be computed from. Frozen and exported
+ * so a test can assert that nothing resembling a run length was ever added.
+ */
+export const REACTION_INPUT_KEYS = ["difficulty", "minTaps", "taps", "repaired"] as const
+
+export type ReactionInput = {
+  /** 0..1, normalised from whatever the host reports. */
+  difficulty: number
+  /** The fewest taps the escape could have cost. */
+  minTaps: number
+  /** What it actually cost. */
+  taps: number
+  /** The child hit a known mal-rule total on the way and got out anyway. */
+  repaired: boolean
+}
+
+export type Reaction = {
+  tier: ReactionTier
+  /** How long the effect owns the screen. Nothing ever waits for it. */
+  budgetMs: number
+  /** Particle budget at the reference quality tier. */
+  particles: number
+  /** Peak audio gain, 0..1. */
+  peakGain: number
+  /** How many things move at once. */
+  elements: number
+}
+
+export const REACTIONS: Record<ReactionTier, Reaction> = {
+  [-1]: { tier: SLIP, budgetMs: 260, particles: 0, peakGain: 0.16, elements: 2 },
+  0: { tier: SEAT, budgetMs: 200, particles: 10, peakGain: 0.4, elements: 4 },
+  1: { tier: ENGAGE, budgetMs: 450, particles: 34, peakGain: 0.55, elements: 6 },
+  2: { tier: ILLUMINATE, budgetMs: 900, particles: 90, peakGain: 0.7, elements: 9 },
+  3: { tier: MECHANISM, budgetMs: 1800, particles: 190, peakGain: 0.85, elements: 13 },
+}
+
+/** budgetMs × particles × peakGain × animatedElements, with a floor of 1 particle. */
+export function energy(r: Reaction): number {
+  return r.budgetMs * Math.max(1, r.particles) * r.peakGain * r.elements
+}
+
+/**
+ * Which reaction an escape earns.
+ *
+ * Takes exactly one argument, and that argument is a pure description of *this*
+ * fall. There is deliberately nowhere to put "and they have won six in a row".
+ */
+export function reactionTier(input: ReactionInput): ReactionTier {
+  const difficulty = Math.max(0, Math.min(1, input.difficulty))
+  // Weight in "how much work was that": the length of the decomposition plus
+  // how far the curriculum has climbed, plus a fixed step for repairing a
+  // mal-rule you used to fire — which the design doc reserves tier 2 for.
+  let weight = 0
+  if (input.minTaps >= 4) weight += 1
+  if (input.minTaps >= 6) weight += 1
+  if (difficulty >= 0.34) weight += 1
+  if (difficulty >= 0.7) weight += 1
+  // An escape taken in more taps than it needed is still an escape, and it is
+  // still exact. It just does not climb.
+  if (input.taps > input.minTaps + 2) weight -= 1
+  if (input.repaired) weight += 2
+
+  if (weight <= 0) return SEAT
+  if (weight === 1) return ENGAGE
+  if (weight <= 3) return ILLUMINATE
+  return MECHANISM
+}

--- a/dynawalla/games/foundry/src/game/save.ts
+++ b/dynawalla/games/foundry/src/game/save.ts
@@ -1,0 +1,89 @@
+// The belt, across sessions.
+//
+// **`localStorage` is unreachable inside a pack frame.** The document sits on
+// an opaque origin, so every property access on it throws rather than returning
+// null — which is why the in-memory mirror below is not a cache but the actual
+// source of truth for the running session. A game that trusted the read would
+// show a belt of zero plates on every kick-out, forever, on the only surface
+// that matters.
+//
+// Nothing here can regress the belt: `record` keeps the maximum it has ever
+// seen. That is `P-04` — construction never goes backwards — and it is the
+// child-safe version of loss aversion. Losing a fall costs the fall, never the
+// belt.
+
+// The storage slot, versioned so a schema change orphans an old record rather
+// than mis-reading it. `gitleaks:allow` because the pinned scanner's
+// `generic-api-key` rule reads `<NAME> = "<long dotted string>"` as a
+// credential. It is a storage path, it is on the client, and this repository is
+// public on purpose.
+const BELT_SLOT = "dynawalla.foundry.belt.v1" // gitleaks:allow
+
+export type Belt = {
+  /** The most plates ever cast onto the belt in one session. */
+  best: number
+  /** Challengers put away, ever. */
+  beaten: number
+}
+
+const memory: Belt = { best: 0, beaten: 0 }
+let loaded = false
+
+function storage(): Storage | null {
+  try {
+    const s = globalThis.localStorage
+    // Touching the object is not enough — an opaque origin throws on access to
+    // the property itself in some engines and on the first read in others, so
+    // the probe has to be a real read.
+    s.getItem(BELT_SLOT)
+    return s
+  } catch {
+    return null
+  }
+}
+
+export function loadBelt(): Belt {
+  if (loaded) return { ...memory }
+  loaded = true
+  const s = storage()
+  if (!s) return { ...memory }
+  try {
+    const raw = s.getItem(BELT_SLOT)
+    if (!raw) return { ...memory }
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== "object" || parsed === null) return { ...memory }
+    const rec = parsed as Partial<Belt>
+    if (Number.isInteger(rec.best) && (rec.best as number) > memory.best) {
+      memory.best = rec.best as number
+    }
+    if (Number.isInteger(rec.beaten) && (rec.beaten as number) > memory.beaten) {
+      memory.beaten = rec.beaten as number
+    }
+  } catch (error) {
+    // Loud, never silent: a record that will not parse is a bug worth seeing.
+    console.warn("[foundry] the belt record could not be read", error)
+  }
+  return { ...memory }
+}
+
+/** Record a session's totals. Monotone — nothing here can take a plate off. */
+export function recordBelt(plates: number, beaten: number): Belt {
+  if (Number.isInteger(plates) && plates > memory.best) memory.best = plates
+  if (Number.isInteger(beaten) && beaten > memory.beaten) memory.beaten = beaten
+  const s = storage()
+  if (s) {
+    try {
+      s.setItem(BELT_SLOT, JSON.stringify(memory))
+    } catch (error) {
+      console.warn("[foundry] the belt record could not be written", error)
+    }
+  }
+  return { ...memory }
+}
+
+/** Tests only: drop the in-memory mirror so each case starts clean. */
+export function resetBeltForTest(): void {
+  memory.best = 0
+  memory.beaten = 0
+  loaded = false
+}

--- a/dynawalla/games/foundry/src/index.ts
+++ b/dynawalla/games/foundry/src/index.ts
@@ -1,0 +1,3 @@
+export type { Host, Question } from "./contract.ts"
+export { mount } from "./contract.ts"
+export { createStubHost } from "./stubHost.ts"

--- a/dynawalla/games/foundry/src/main.ts
+++ b/dynawalla/games/foundry/src/main.ts
@@ -1,0 +1,42 @@
+// Standalone dev harness. `npm run dev` → a playable bout wired to the local
+// stub Host, with no runtime underneath it.
+//
+//   ?seed=123     replay the same card
+//   ?level=7      pin the ladder at a rung instead of walking it
+//   ?reduced=1    force the reduced-motion branch
+
+import { mount } from "./contract.ts"
+import { createStubHost } from "./stubHost.ts"
+
+const el = document.getElementById("app")
+if (!el) throw new Error("foundry: #app missing")
+
+const params = new URLSearchParams(location.search)
+const seed = Number(params.get("seed") ?? "") || 0x6f057d
+const level = params.has("level") ? Number(params.get("level")) : undefined
+const reduced = params.has("reduced") ? params.get("reduced") !== "0" : undefined
+
+let answered = 0
+let correct = 0
+const readout = document.getElementById("readout")
+
+const host = createStubHost({
+  seed,
+  ...(level === undefined || Number.isNaN(level) ? {} : { level }),
+  ...(reduced === undefined ? {} : { reducedMotion: reduced }),
+  onReport(r) {
+    answered++
+    if (r.correct) correct++
+    if (readout) {
+      readout.textContent = `host.report → ${correct}/${answered} · last ${r.ms}ms · "${r.answered || "—"}"`
+    }
+    console.info("[foundry/host] report", r)
+  },
+})
+
+const handle = mount(el, host)
+
+// Vite HMR: tear the old instance down so audio contexts and rAF loops do not
+// accumulate across edits.
+type HotModule = { hot?: { dispose(cb: () => void): void } }
+;(import.meta as unknown as HotModule).hot?.dispose(() => handle.unmount())

--- a/dynawalla/games/foundry/src/mount.ts
+++ b/dynawalla/games/foundry/src/mount.ts
@@ -1,0 +1,533 @@
+// THE GRAPPLE FOUNDRY — the wiring.
+//
+// One verb: **stamp a plate**.
+//
+// You are on your back with a bar across your chest and a referee counting to
+// three. Two pedals hang off the ring frame, one light and one heavy, each with
+// a whole number stamped on it. The board above the ring carries a sum. Work
+// out what that sum is, then build that exact number out of the two plates
+// before the third slap lands, and the bar tips and you kick out.
+//
+//   * **Exact, or nothing.** One over the total and the bar comes down. That is
+//     what stops the wrestling-game reflex — mashing loses instantly, so the
+//     only way through is to know the number before you start tapping.
+//   * **Out of moves is a real way to lose.** Seven, seven, seven on a target of
+//     twenty-four leaves three, and nothing makes three out of fours and sevens.
+//     The game says so at once instead of running the count out on a dead board.
+//   * **A false finish is a mal-rule.** Land the bar on the exact value a broken
+//     procedure produces and the hall comes up and the referee waves it off. It
+//     costs count. It never costs the fall.
+//
+// This module owns the surface, the loop and the juice, and it decides nothing:
+// every rule lives in `game/bout.ts` and every piece of arithmetic in
+// `game/plates.ts`.
+
+import type { Host } from "./contract.ts"
+import { Audio } from "./audio.ts"
+import { Feel } from "./core/feel.ts"
+import { detectTier, TierGovernor } from "./core/tiers.ts"
+import { Bout, type BoutEvent } from "./game/bout.ts"
+import { loadBelt, recordBelt } from "./game/save.ts"
+import { REACTIONS } from "./game/reaction.ts"
+import { Crowd } from "./render/crowd.ts"
+import { Decals } from "./render/decals.ts"
+import {
+  drawBanner,
+  drawBelt,
+  drawBoard,
+  drawCount,
+  drawLoad,
+  drawPedals,
+  type Banner,
+  type PedalState,
+} from "./render/hud.ts"
+import { computeLayout, type Layout } from "./render/layout.ts"
+import { KIND_DUST, KIND_SHARD, KIND_SPARK, Particles } from "./render/particles.ts"
+import { drawFrame, drawGrapple, drawMat, drawReferee } from "./render/ring.ts"
+import {
+  CHALK,
+  HEAT_WHITE,
+  KICKOUT,
+  NIGHT,
+  OXIDE,
+  BRASS_HI,
+  withAlpha,
+} from "./render/palette.ts"
+
+export function mountFoundry(el: HTMLElement, host: Host): { unmount(): void } {
+  // ── surface ──────────────────────────────────────────────────────────────
+  const root = document.createElement("div")
+  root.style.cssText =
+    "position:relative;width:100%;height:100%;overflow:hidden;touch-action:none;" +
+    "-webkit-user-select:none;user-select:none;background:#0b0a10;cursor:pointer;"
+  const canvas = document.createElement("canvas")
+  canvas.style.cssText = "position:absolute;inset:0;width:100%;height:100%;display:block;"
+  root.appendChild(canvas)
+  el.appendChild(root)
+
+  const ctx0 = canvas.getContext("2d", { alpha: false })
+  if (!ctx0) throw new Error("foundry: could not acquire a 2D context")
+  const g: CanvasRenderingContext2D = ctx0
+
+  // ── systems ──────────────────────────────────────────────────────────────
+  const reduced = host.prefersReducedMotion()
+  const gov = new TierGovernor(detectTier())
+  const feel = new Feel({ reducedMotion: reduced })
+  const parts = new Particles()
+  const decals = new Decals()
+  const crowd = new Crowd()
+  const audio = new Audio()
+  // Read once so a returning session's record is carried forward, and written on
+  // every cast. The value is not drawn: see the note in `draw()`.
+  loadBelt()
+
+  let layout: Layout = computeLayout(320, 568)
+  const crowdSeed = 0x1b0c
+
+  const bout = new Bout({ host, seed: 0x9a11ed, onEvent: handle })
+
+  // ── presentation state ───────────────────────────────────────────────────
+  const pedalA: PedalState = { value: bout.fall.plates.a, since: 99 }
+  const pedalB: PedalState = { value: bout.fall.plates.b, since: 99 }
+  let banner: Banner | null = null
+  /** Seconds since the last slap landed; drives the referee's arm. */
+  let slapAge = 99
+  let boardShake = 0
+  let loadPulse = 0
+  let crowdFlare = 0
+  let seam = 0
+  let freshPlateMs = 1e6
+  let rise = 0
+  let riseTarget = 0
+  let audioArmed = false
+  let lastHeat = -1
+  let paused = false
+  let raf = 0
+  let last = 0
+
+  function setBanner(text: string, sub: string, color: string, seconds: number): void {
+    // Never queued. A banner that arrived while another was up replaces it, so a
+    // fast child is never reading a stale line about a fall they already left.
+    banner = { text, sub, life: seconds, maxLife: seconds, color }
+  }
+
+  // ── the events the rules emit ────────────────────────────────────────────
+  function handle(e: BoutEvent): void {
+    switch (e.kind) {
+      case "lockup": {
+        pedalA.value = bout.fall.plates.a
+        pedalB.value = bout.fall.plates.b
+        riseTarget = 0
+        rise = 0
+        loadPulse = 0
+        boardShake = 0
+        slapAge = 99
+        break
+      }
+
+      case "pin-begin": {
+        feel.kick(0, 1, 5)
+        parts.burst(
+          KIND_DUST,
+          layout.cx,
+          layout.cy + layout.unit,
+          Math.round(14 * gov.quality.burst),
+          130,
+          -Math.PI / 2,
+          Math.PI * 1.5,
+          layout.unit * 0.3,
+        )
+        break
+      }
+
+      case "slap": {
+        slapAge = 0
+        audio.slap(e.index)
+        feel.addTrauma(0.1 + e.index * 0.05)
+        feel.kick(0, 1, 3 + e.index * 2)
+        decals.slap(
+          layout.cx - layout.unit * (2.6 - e.index * 0.8),
+          layout.cy + layout.unit * 1.1,
+          layout.unit * 0.75,
+          (e.index - 2) * 0.4,
+          gov.quality.decals,
+        )
+        parts.burst(
+          KIND_DUST,
+          layout.cx - layout.unit * (2.6 - e.index * 0.8),
+          layout.cy + layout.unit * 1.1,
+          Math.round(10 * gov.quality.burst),
+          90,
+          -Math.PI / 2,
+          Math.PI,
+          layout.unit * 0.26,
+        )
+        break
+      }
+
+      case "load": {
+        const p = e.side === "a" ? pedalA : pedalB
+        p.since = 0
+        loadPulse = 1
+        seam = 1
+        riseTarget = e.fraction * 0.22
+        audio.plate(e.side === "b", e.fraction)
+        feel.kick(0, -1, 2 + e.fraction * 3)
+        const px = e.side === "a" ? layout.w * 0.25 : layout.w * 0.75
+        parts.burst(
+          KIND_SPARK,
+          px,
+          layout.padTop + 4,
+          Math.round((6 + e.fraction * 10) * gov.quality.burst),
+          260 + e.fraction * 220,
+          -Math.PI / 2,
+          1.1,
+          layout.unit * 0.16,
+        )
+        break
+      }
+
+      case "false-finish": {
+        audio.falseFinish()
+        boardShake = 1
+        crowdFlare = 0.55
+        feel.addTrauma(0.16)
+        decals.refusal(
+          layout.cx + layout.unit * 1.6,
+          layout.cy + layout.unit * 0.7,
+          layout.unit * 0.9,
+          gov.quality.decals,
+        )
+        setBanner("WAVED OFF", `${e.value} is not it`, OXIDE, 1.0)
+        break
+      }
+
+      case "escape": {
+        const r = REACTIONS[e.tier]
+        const f = bout.fall
+        audio.kickout(e.tier)
+        crowdFlare = 1
+        seam = 1
+        riseTarget = 1
+        feel.hitstop(e.tier >= 2 ? 90 : 55)
+        feel.addTrauma(0.5 + e.tier * 0.12)
+        feel.punch(0.03 + e.tier * 0.012)
+        feel.kick(0, -1, 16)
+        feel.requestFlash(0.16 + e.tier * 0.05, HEAT_WHITE)
+        if (e.tier >= 2) feel.slowmo(0.45, 240)
+        decals.scorch(layout.cx, layout.cy + layout.unit * 0.9, layout.unit * 1.5, gov.quality.decals)
+        parts.burst(
+          KIND_SPARK,
+          layout.cx,
+          layout.cy,
+          Math.round(r.particles * 0.7 * gov.quality.burst),
+          520 + e.tier * 130,
+          -Math.PI / 2,
+          Math.PI * 1.35,
+          layout.unit * 0.2,
+        )
+        parts.burst(
+          KIND_SHARD,
+          layout.cx,
+          layout.cy,
+          Math.round(r.particles * 0.16 * gov.quality.burst),
+          340,
+          -Math.PI / 2,
+          Math.PI * 1.1,
+          layout.unit * 0.3,
+        )
+        // The sentence the fall just proved, in the child's own taps. True,
+        // specific, and never a compliment.
+        const parts_ = [
+          f.tapsB > 0 ? `${f.tapsB}×${f.plates.b}` : "",
+          f.tapsA > 0 ? `${f.tapsA}×${f.plates.a}` : "",
+        ].filter(Boolean)
+        setBanner(
+          e.repaired ? "KICK OUT — REPAIRED" : "KICK OUT",
+          `${parts_.join(" + ")} = ${f.target}`,
+          KICKOUT,
+          Math.max(1.1, r.budgetMs / 1000),
+        )
+        break
+      }
+
+      case "pinfall": {
+        // Silence. No burst, no flash, no freeze frame — the world keeps
+        // running and nothing happens in it. `energy(SLIP) < energy(SEAT)`.
+        audio.pinfall()
+        crowdFlare = 0
+        riseTarget = 0
+        feel.kick(0, 1, 7)
+        const f = bout.fall
+        // A bar that came to rest on a value with a name gets told which one.
+        // "WAVED OFF" is the same word the non-fatal beat uses on purpose: the
+        // referee refused the same number, it just arrived too late to survive.
+        const text = e.diagnosed
+          ? "WAVED OFF"
+          : e.reason === "overshot"
+            ? "TOO MUCH"
+            : e.reason === "stuck"
+              ? "NO WAY OUT"
+              : "THREE"
+        const sub =
+          e.reason === "stuck"
+            ? `${f.target - f.load} left, and ${f.plates.a} and ${f.plates.b} cannot make it`
+            : f.load > 0
+              ? `${f.load} — it needed ${f.target}`
+              : `it needed ${f.target}`
+        setBanner(text, sub, OXIDE, 1.25)
+        if (e.diagnosed) {
+          decals.refusal(
+            layout.cx + layout.unit * 1.6,
+            layout.cy + layout.unit * 0.7,
+            layout.unit * 0.9,
+            gov.quality.decals,
+          )
+        }
+        break
+      }
+
+      case "cast": {
+        freshPlateMs = 0
+        recordBelt(e.beltPlates, bout.challengersBeaten)
+        break
+      }
+
+      case "title": {
+        audio.title()
+        crowdFlare = 1
+        feel.requestFlash(0.2, BRASS_HI)
+        setBanner(`${e.challenger} IS DOWN`, `${bout.beltPlates} plates on the belt`, BRASS_HI, 1.8)
+        parts.burst(
+          KIND_SPARK,
+          layout.cx,
+          layout.beltY + layout.beltH,
+          Math.round(60 * gov.quality.burst),
+          420,
+          Math.PI / 2,
+          Math.PI * 1.2,
+          layout.unit * 0.18,
+        )
+        break
+      }
+    }
+  }
+
+  // ── sizing ───────────────────────────────────────────────────────────────
+  function resize(): void {
+    const rect = root.getBoundingClientRect()
+    const w = Math.max(240, Math.round(rect.width || 320))
+    const h = Math.max(360, Math.round(rect.height || 568))
+    const dpr = Math.min(globalThis.devicePixelRatio || 1, gov.quality.maxDpr)
+    canvas.width = Math.round(w * dpr)
+    canvas.height = Math.round(h * dpr)
+    g.setTransform(dpr, 0, 0, dpr, 0, 0)
+    layout = computeLayout(w, h)
+    crowd.layout(w, layout.horizon, gov.quality.crowd, crowdSeed)
+    parts.setLimit(gov.quality.particles)
+  }
+
+  const ro =
+    typeof ResizeObserver === "function"
+      ? new ResizeObserver(() => {
+          resize()
+        })
+      : null
+  ro?.observe(root)
+  resize()
+
+  // ── input ────────────────────────────────────────────────────────────────
+  // The whole screen is two pedals. A four-second escape must never be lost to
+  // a thumb that landed 20px outside a button, so there is no outside.
+  function armAudio(): void {
+    if (audioArmed) return
+    audioArmed = true
+    void audio.start().then(() => {
+      lastHeat = bout.heat
+      audio.setHeat(bout.heat, 0.8)
+    })
+  }
+
+  function onPointerDown(ev: PointerEvent): void {
+    ev.preventDefault()
+    armAudio()
+    const rect = canvas.getBoundingClientRect()
+    bout.tap(ev.clientX - rect.left < rect.width / 2 ? "a" : "b")
+  }
+
+  function onKeyDown(ev: KeyboardEvent): void {
+    if (ev.repeat) return
+    const k = ev.key.toLowerCase()
+    if (k === "arrowleft" || k === "a") {
+      armAudio()
+      bout.tap("a")
+    } else if (k === "arrowright" || k === "d") {
+      armAudio()
+      bout.tap("b")
+    } else if (k === "m") {
+      audio.setEnabled(!audio.enabled)
+    } else {
+      return
+    }
+    ev.preventDefault()
+  }
+
+  function onVisibility(): void {
+    // The count must not run while the tablet is in a pocket. A child who comes
+    // back to a lost fall they never saw has been cheated by the app.
+    paused = document.visibilityState === "hidden"
+    if (paused) {
+      audio.setHeat(0, 0.2)
+      lastHeat = -1
+    } else {
+      last = 0
+    }
+  }
+
+  canvas.addEventListener("pointerdown", onPointerDown, { passive: false })
+  globalThis.addEventListener("keydown", onKeyDown)
+  document.addEventListener("visibilitychange", onVisibility)
+
+  // ── loop ─────────────────────────────────────────────────────────────────
+  function frame(now: number): void {
+    raf = requestAnimationFrame(frame)
+    if (last === 0) last = now
+    const rawMs = Math.min(64, now - last)
+    last = now
+    if (paused) return
+
+    // A downgrade has to move the levers that actually cost fill rate. `maxDpr`
+    // and the lantern count are only read in `resize()`, and a pack frame at a
+    // fixed size never resizes again — so without this a device that dropped to
+    // `low` would keep rendering at DPR 2 with a full crowd for the rest of the
+    // session, which is exactly the work that was too slow.
+    if (gov.sample(rawMs)) resize()
+    const simMs = feel.advance(rawMs, now)
+    const dt = simMs / 1000
+    const realDt = rawMs / 1000
+
+    bout.tick(dt)
+
+    // Presentation decays run on real time so a hitstop does not freeze the
+    // referee's arm halfway through a slap.
+    slapAge += realDt
+    pedalA.since += realDt
+    pedalB.since += realDt
+    boardShake = Math.max(0, boardShake - realDt * 3.2)
+    loadPulse = Math.max(0, loadPulse - realDt * 3.6)
+    crowdFlare = Math.max(0, crowdFlare - realDt * 1.15)
+    seam = Math.max(0, seam - realDt * 1.5)
+    freshPlateMs += rawMs
+    rise += (riseTarget - rise) * Math.min(1, realDt * 9)
+
+    parts.step(dt, layout.matBottom - layout.unit * 0.2)
+    decals.step(dt)
+    crowd.step(realDt)
+
+    // The crowd bed is ramped, not stepped, so it is only re-scheduled when the
+    // hall has actually changed. Cancelling and re-targeting a gain sixty times
+    // a second is audible as a flutter and is pure work.
+    const wantedHeat = Math.min(1, bout.heat + crowdFlare * 0.5)
+    if (Math.abs(wantedHeat - lastHeat) > 0.02) {
+      lastHeat = wantedHeat
+      audio.setHeat(wantedHeat, 0.5)
+    }
+
+    if (banner) {
+      banner.life -= realDt
+      if (banner.life <= 0) banner = null
+    }
+
+    draw()
+  }
+
+  function draw(): void {
+    const l = layout
+    const q = gov.quality
+    const f = bout.fall
+    const live = bout.phase === "pin"
+
+    g.save()
+    if (!reduced && (feel.shakeX !== 0 || feel.shakeY !== 0 || feel.scale !== 1)) {
+      g.translate(l.cx, l.cy)
+      g.scale(feel.scale, feel.scale)
+      g.translate(-l.cx + feel.shakeX, -l.cy + feel.shakeY)
+    }
+
+    g.fillStyle = NIGHT
+    g.fillRect(0, 0, l.w, l.h)
+
+    crowd.draw(g, bout.heat, reduced ? crowdFlare * 0.4 : crowdFlare, q.glow)
+
+    drawFrame(g, l, q.ropeDetail, decals.warmth(), false)
+    drawMat(g, l, decals, q.glow)
+
+    const countFraction = bout.countFraction
+    drawGrapple(
+      g,
+      l,
+      {
+        rise,
+        press: live ? 0.4 + countFraction * 0.5 : 0.2,
+        wobble: reduced ? 0 : performance.now() / 1000,
+        count: countFraction,
+      },
+      f.target > 0 ? Math.min(1, f.load / f.target) : 0,
+      seam,
+    )
+
+    if (bout.phase !== "kickout") {
+      drawReferee(g, l, Math.min(1, slapAge / Math.max(0.35, f.slapPeriod * 0.55)), f.slaps)
+    }
+
+    drawFrame(g, l, q.ropeDetail, decals.warmth(), true)
+
+    if (!reduced) parts.draw(g, q.glow)
+
+    drawCount(g, l, countFraction, f.slaps, live)
+    drawLoad(g, l, f.load, f.target > 0 ? f.load / f.target : 0, reduced ? 0 : loadPulse)
+    drawBoard(g, l, f.prompt, reduced ? 0 : boardShake, countFraction)
+    drawBelt(g, l, bout.beltPlates, bout.challengersBeaten, freshPlateMs)
+    drawPedals(g, l, pedalA, pedalB, live)
+
+    if (banner) drawBanner(g, l, banner)
+
+    g.restore()
+
+    if (feel.flashAlpha > 0.001) {
+      g.fillStyle = withAlpha(feel.currentFlashColor, feel.flashAlpha)
+      g.fillRect(0, 0, l.w, l.h)
+    }
+
+    // The one persistent line of chrome: who is across the ring and how many
+    // falls they still owe. Bottom-left, out of the pedals' way.
+    //
+    // The session best is deliberately *not* here. Inside a pack frame the belt
+    // record cannot be read back, and both numbers are monotone within a
+    // session, so it would always print the number already sitting next to it —
+    // a fifth numeral on a surface that has room for four.
+    g.save()
+    g.font = "700 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace"
+    g.textAlign = "left"
+    g.textBaseline = "alphabetic"
+    g.fillStyle = withAlpha(CHALK, 0.34)
+    g.fillText(`${bout.challenger} · ${bout.toBeat} TO GO`, 10, l.padTop - 8)
+    g.restore()
+  }
+
+  raf = requestAnimationFrame(frame)
+
+  return {
+    unmount(): void {
+      cancelAnimationFrame(raf)
+      canvas.removeEventListener("pointerdown", onPointerDown)
+      globalThis.removeEventListener("keydown", onKeyDown)
+      document.removeEventListener("visibilitychange", onVisibility)
+      ro?.disconnect()
+      audio.dispose()
+      parts.clear()
+      decals.clear()
+      root.remove()
+    },
+  }
+}

--- a/dynawalla/games/foundry/src/pack.ts
+++ b/dynawalla/games/foundry/src/pack.ts
@@ -1,0 +1,47 @@
+// THE GRAPPLE FOUNDRY, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous surface `Host` in
+// `contract.ts` already describes — so the bout, the plates, the referee and
+// the cooling canvas are untouched.
+//
+// What crosses the boundary is the target. The curriculum draws a column sum,
+// the host reveals its canonical value, and that value becomes the number the
+// bar has to reach. The plates are the game's own: `game/plates.ts` cuts a pair
+// for the target it was handed, so a two-digit sum hangs a 7 and a 20 on the
+// frame and a four-digit one hangs something heavier. Nothing about the
+// decomposition is reported — it is arithmetic the child performs with their
+// thumbs, not a question anybody asked.
+//
+// `items.reveal` is declared and it is load-bearing: without it the adapter
+// gets an empty canonical value, drops every item, and the pack mounts and
+// warms and serves no questions at all, with nothing failing anywhere.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import { mount } from "./contract.ts"
+import type { Host } from "./contract.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("foundry: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "add" })
+  // Stocked before the first frame: the first fall is cut the instant the game
+  // mounts, and a board with a blank face is the kind of thing that happens
+  // exactly once, on launch, in front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context are torn down before the frame is, rather than a frame or two
+  // after it.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[foundry] could not start", error)
+  renderNoHost(root, "THE GRAPPLE FOUNDRY")
+})

--- a/dynawalla/games/foundry/src/render/crowd.ts
+++ b/dynawalla/games/foundry/src/render/crowd.ts
@@ -1,0 +1,95 @@
+// The crowd — a bazaar at night with a ring dropped into the middle of it.
+//
+// Not people: lanterns. A field of hanging lamps at four depths, each one a
+// household that came out to watch, and the only thing that changes about them
+// is how hard they are burning. Heat rises on an escape and the whole hall
+// brightens; a pinfall drops it and the lamps go back to embers.
+//
+// Deterministic from a seed, so the same match looks the same twice, and laid
+// out once at resize rather than per frame.
+
+import { Rng } from "../core/rng.ts"
+import { CROWD_DIM, CROWD_LANTERN, LAPIS_DEEP, NIGHT, withAlpha } from "./palette.ts"
+
+type Lantern = {
+  x: number
+  y: number
+  r: number
+  /** 0 = far, 1 = near the ring. Drives size and how much it reacts. */
+  depth: number
+  phase: number
+  rate: number
+}
+
+export class Crowd {
+  private lanterns: Lantern[] = []
+  private w = 0
+  private horizon = 0
+  private t = 0
+
+  /** Rebuild for a new viewport. Cheap enough to call on every resize. */
+  layout(w: number, horizon: number, count: number, seed: number): void {
+    this.w = w
+    this.horizon = horizon
+    const rng = new Rng(seed)
+    const list: Lantern[] = []
+    for (let i = 0; i < count; i++) {
+      const depth = rng.next() ** 1.4
+      // Lanterns crowd the horizon and thin out as they come forward, which is
+      // what a hall full of people actually looks like from the ring.
+      const y = horizon * (0.12 + depth * 0.86)
+      const x = rng.range(-0.04, 1.04) * w
+      list.push({
+        x,
+        y,
+        r: 1.1 + depth * 3.4,
+        depth,
+        phase: rng.range(0, Math.PI * 2),
+        rate: rng.range(0.4, 1.5),
+      })
+    }
+    // Far first, so near lanterns overdraw.
+    list.sort((a, b) => a.depth - b.depth)
+    this.lanterns = list
+  }
+
+  step(dt: number): void {
+    this.t += dt
+  }
+
+  /**
+   * @param heat 0..1 — how loud the hall is
+   * @param flare 0..1 — a momentary surge, spent by the caller over ~1s
+   */
+  draw(g: CanvasRenderingContext2D, heat: number, flare: number, glow: boolean): void {
+    const h = Math.max(0, Math.min(1, heat))
+    const f = Math.max(0, Math.min(1, flare))
+
+    // The hall itself: night, with a warm wash rising off the crowd.
+    const sky = g.createLinearGradient(0, 0, 0, this.horizon)
+    sky.addColorStop(0, NIGHT)
+    sky.addColorStop(0.55, LAPIS_DEEP)
+    sky.addColorStop(1, withAlpha(CROWD_DIM, 0.5 + h * 0.35 + f * 0.25))
+    g.fillStyle = sky
+    g.fillRect(0, 0, this.w, this.horizon + 1)
+
+    for (const l of this.lanterns) {
+      const flicker = 0.72 + 0.28 * Math.sin(this.t * l.rate * 2.4 + l.phase)
+      const lit = (0.16 + h * 0.66 + f * 0.5) * flicker * (0.45 + l.depth * 0.55)
+      const a = Math.max(0, Math.min(1, lit))
+      if (a < 0.02) continue
+      g.fillStyle = withAlpha(CROWD_LANTERN, a)
+      g.beginPath()
+      g.arc(l.x, l.y, l.r, 0, Math.PI * 2)
+      g.fill()
+      if (!glow || a < 0.45 || l.depth < 0.5) continue
+      const grad = g.createRadialGradient(l.x, l.y, 0, l.x, l.y, l.r * 6)
+      grad.addColorStop(0, withAlpha(CROWD_LANTERN, a * 0.28))
+      grad.addColorStop(1, withAlpha(CROWD_LANTERN, 0))
+      g.fillStyle = grad
+      g.beginPath()
+      g.arc(l.x, l.y, l.r * 6, 0, Math.PI * 2)
+      g.fill()
+    }
+  }
+}

--- a/dynawalla/games/foundry/src/render/decals.ts
+++ b/dynawalla/games/foundry/src/render/decals.ts
@@ -1,0 +1,129 @@
+// The canvas remembers.
+//
+// This is the design canon's "canvas glow-decal cooling", and it is the one
+// piece of persistent state on the mat. Every kick-out scorches the spot the
+// bar was on, at white heat; every refused total leaves a cold oxide smear. A
+// scorch does not vanish — it *cools*, through the heat ramp in `palette.ts`,
+// over about twelve seconds, and then stays as a dark bruise until the tier's
+// decal budget pushes it off the bottom.
+//
+// It costs almost nothing and it does more than any particle: a child glancing
+// at the mat can see the shape of the last minute of their own match.
+
+import { heatColor, withAlpha } from "./palette.ts"
+
+export type DecalKind = "scorch" | "refusal" | "slap"
+
+type Decal = {
+  kind: DecalKind
+  x: number
+  y: number
+  r: number
+  /** 1 → just poured, 0 → cold. Falls at a fixed rate; never resets. */
+  heat: number
+  /** Cold decals keep a bruise this dark. */
+  stain: number
+  rot: number
+}
+
+/** Seconds from white heat to cold. */
+const COOL_S = 12
+
+export class Decals {
+  private list: Decal[] = []
+
+  /** A kick-out. The hottest mark on the mat and the only white one. */
+  scorch(x: number, y: number, r: number, cap: number): void {
+    this.push({ kind: "scorch", x, y, r, heat: 1, stain: 0.34, rot: 0 }, cap)
+  }
+
+  /** A refused total. Never hot: failure does not glow. */
+  refusal(x: number, y: number, r: number, cap: number): void {
+    this.push({ kind: "refusal", x, y, r, heat: 0, stain: 0.3, rot: 0 }, cap)
+  }
+
+  /** The referee's palm. Three of these stack up under a body. */
+  slap(x: number, y: number, r: number, rot: number, cap: number): void {
+    this.push({ kind: "slap", x, y, r, heat: 0.22, stain: 0.24, rot }, cap)
+  }
+
+  private push(d: Decal, cap: number): void {
+    this.list.push(d)
+    const limit = Math.max(2, cap)
+    while (this.list.length > limit) this.list.shift()
+  }
+
+  step(dt: number): void {
+    for (const d of this.list) d.heat = Math.max(0, d.heat - dt / COOL_S)
+  }
+
+  /** Drawn under everything on the mat, so bodies and rope shadows sit on top. */
+  draw(g: CanvasRenderingContext2D, glow: boolean): void {
+    g.save()
+    for (const d of this.list) {
+      if (d.kind === "slap") {
+        g.save()
+        g.translate(d.x, d.y)
+        g.rotate(d.rot)
+        g.fillStyle = withAlpha("#4a4234", d.stain * (0.5 + d.heat))
+        // A palm: four fingers and a heel, not an ellipse. It has to read as a
+        // hand at a glance or the three-count is just three smudges.
+        for (let i = 0; i < 4; i++) {
+          const fx = (i - 1.5) * d.r * 0.42
+          g.beginPath()
+          g.ellipse(fx, -d.r * 0.55, d.r * 0.15, d.r * 0.42, 0, 0, Math.PI * 2)
+          g.fill()
+        }
+        g.beginPath()
+        g.ellipse(0, d.r * 0.2, d.r * 0.62, d.r * 0.44, 0, 0, Math.PI * 2)
+        g.fill()
+        g.restore()
+        continue
+      }
+
+      if (d.kind === "refusal") {
+        g.strokeStyle = withAlpha("#8c3a24", d.stain)
+        g.lineWidth = Math.max(2, d.r * 0.16)
+        g.lineCap = "round"
+        // A struck-through mark. The referee's wave-off, printed on the mat.
+        g.beginPath()
+        g.moveTo(d.x - d.r * 0.8, d.y - d.r * 0.5)
+        g.lineTo(d.x + d.r * 0.8, d.y + d.r * 0.5)
+        g.stroke()
+        continue
+      }
+
+      // A scorch. Dark ring, hot core while there is any heat left in it.
+      g.fillStyle = withAlpha("#241d16", d.stain)
+      g.beginPath()
+      g.ellipse(d.x, d.y, d.r, d.r * 0.62, 0, 0, Math.PI * 2)
+      g.fill()
+      if (d.heat <= 0.001) continue
+      const c = heatColor(d.heat)
+      g.fillStyle = withAlpha(c, 0.28 + d.heat * 0.55)
+      g.beginPath()
+      g.ellipse(d.x, d.y, d.r * (0.34 + d.heat * 0.4), d.r * (0.2 + d.heat * 0.26), 0, 0, Math.PI * 2)
+      g.fill()
+      if (!glow) continue
+      const grad = g.createRadialGradient(d.x, d.y, 0, d.x, d.y, d.r * 1.7)
+      grad.addColorStop(0, withAlpha(c, 0.3 * d.heat))
+      grad.addColorStop(1, withAlpha(c, 0))
+      g.fillStyle = grad
+      g.beginPath()
+      g.ellipse(d.x, d.y, d.r * 1.7, d.r * 1.1, 0, 0, Math.PI * 2)
+      g.fill()
+    }
+    g.restore()
+  }
+
+  /** How warm the mat is overall, 0..1. The crowd bed rides on this. */
+  warmth(): number {
+    let sum = 0
+    for (const d of this.list) sum += d.heat
+    return Math.min(1, sum / 4)
+  }
+
+  clear(): void {
+    this.list.length = 0
+  }
+}

--- a/dynawalla/games/foundry/src/render/hud.ts
+++ b/dynawalla/games/foundry/src/render/hud.ts
@@ -1,0 +1,301 @@
+// Everything with a number on it.
+//
+// There are exactly four: the board, the bar's running total, the two pedals,
+// and the belt. That is the whole readable surface, and the constraint is
+// deliberate — a child has three referee slaps to read all of it, so anything
+// fifth would be something they had to learn to ignore.
+//
+// The one thing never shown is the answer. The board carries the sum and the
+// bar carries what is on it; the number in between is the child's.
+
+import type { Layout } from "./layout.ts"
+import {
+  BRASS,
+  BRASS_DARK,
+  BRASS_HI,
+  CHALK,
+  INK,
+  IRON,
+  IRON_DARK,
+  IRON_EDGE,
+  KICKOUT,
+  OXIDE,
+  heatColor,
+  mix,
+  stamp,
+  withAlpha,
+} from "./palette.ts"
+
+/** Rounded rectangle path. Corners are small: this is cast metal, not a card. */
+function plate(g: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number): void {
+  const k = Math.min(r, w / 2, h / 2)
+  g.beginPath()
+  g.moveTo(x + k, y)
+  g.lineTo(x + w - k, y)
+  g.arcTo(x + w, y, x + w, y + k, k)
+  g.lineTo(x + w, y + h - k)
+  g.arcTo(x + w, y + h, x + w - k, y + h, k)
+  g.lineTo(x + k, y + h)
+  g.arcTo(x, y + h, x, y + h - k, k)
+  g.lineTo(x, y + k)
+  g.arcTo(x, y, x + k, y, k)
+  g.closePath()
+}
+
+/**
+ * The hanging board. Slate in a brass frame, on two chains, carrying the sum
+ * the referee is waiting on.
+ *
+ * `shake` is spent by the caller on a false finish — the board is what was
+ * misread, so it is the board that takes the hit.
+ */
+export function drawBoard(
+  g: CanvasRenderingContext2D,
+  l: Layout,
+  prompt: string,
+  shake: number,
+  urgency: number,
+): void {
+  const swingX = Math.sin(shake * 34) * shake * 9
+  g.save()
+  g.translate(swingX, 0)
+
+  // Chains up into the dark.
+  g.strokeStyle = withAlpha(BRASS_DARK, 0.8)
+  g.lineWidth = Math.max(1.5, l.unit * 0.08)
+  for (const cx of [l.boardX + l.boardW * 0.22, l.boardX + l.boardW * 0.78]) {
+    g.beginPath()
+    g.moveTo(cx - swingX * 0.6, 0)
+    g.lineTo(cx, l.boardY)
+    g.stroke()
+  }
+
+  g.fillStyle = IRON_DARK
+  plate(g, l.boardX, l.boardY, l.boardW, l.boardH, 5)
+  g.fill()
+  g.strokeStyle = urgency > 0.66 ? mix(BRASS, heatColor(0.6), (urgency - 0.66) / 0.34) : BRASS_DARK
+  g.lineWidth = Math.max(2, l.unit * 0.12)
+  plate(g, l.boardX, l.boardY, l.boardW, l.boardH, 5)
+  g.stroke()
+
+  // The sum. Sized to the board rather than measured against it — the numerals
+  // sit on a fixed grid so a four-digit prompt does not reflow after a
+  // two-digit one, which is the budget rule in EXPERIENCE_DESIGN.md.
+  const chars = Math.max(7, prompt.length)
+  const px = Math.min(l.boardH * 0.62, (l.boardW * 1.55) / chars)
+  g.font = stamp(px)
+  g.textAlign = "center"
+  g.textBaseline = "middle"
+  g.fillStyle = withAlpha(INK, 0.75)
+  g.fillText(prompt, l.boardX + l.boardW / 2 + 2, l.boardY + l.boardH / 2 + 2)
+  g.fillStyle = CHALK
+  g.fillText(prompt, l.boardX + l.boardW / 2, l.boardY + l.boardH / 2)
+  g.restore()
+}
+
+/**
+ * The running total on the bar.
+ *
+ * Deliberately present. Without it the fall is a memory test rather than a
+ * decomposition, and the arithmetic being tested is not "can you keep a tally
+ * while a stranger counts at you".
+ */
+export function drawLoad(
+  g: CanvasRenderingContext2D,
+  l: Layout,
+  load: number,
+  fraction: number,
+  pulse: number,
+): void {
+  const u = l.unit
+  const y = l.matTop + u * 1.05
+  const px = u * (1.7 + pulse * 0.45)
+  g.save()
+  g.font = stamp(px)
+  g.textAlign = "center"
+  g.textBaseline = "middle"
+  g.fillStyle = withAlpha(INK, 0.55)
+  g.fillText(String(load), l.cx + 2, y + 3)
+  g.fillStyle = fraction >= 1 ? KICKOUT : mix(CHALK, heatColor(Math.min(1, fraction)), fraction * 0.8)
+  g.fillText(String(load), l.cx, y)
+  g.font = stamp(u * 0.44, 700)
+  g.fillStyle = withAlpha(CHALK, 0.42)
+  g.fillText("ON THE BAR", l.cx, y + px * 0.72)
+  g.restore()
+}
+
+export type PedalState = {
+  value: number
+  /** Seconds since it was last struck; drives the depression and the shine. */
+  since: number
+}
+
+/**
+ * The two pedals.
+ *
+ * Half the screen each, full width of their half, with a floor of 150px of
+ * height in `layout.ts`. They are the only interactive object in the game and
+ * the escape is timed, so they are enormous on purpose.
+ */
+export function drawPedals(
+  g: CanvasRenderingContext2D,
+  l: Layout,
+  light: PedalState,
+  heavy: PedalState,
+  live: boolean,
+): void {
+  const gap = Math.max(4, l.w * 0.008)
+  const halves: Array<[PedalState, number, number, string]> = [
+    [light, 0, l.w / 2 - gap / 2, "LIGHT"],
+    [heavy, l.w / 2 + gap / 2, l.w / 2 - gap / 2, "HEAVY"],
+  ]
+  for (const [p, x, w, label] of halves) {
+    const press = Math.max(0, 1 - p.since / 0.14)
+    const drop = press * Math.min(9, l.padH * 0.05)
+    const y = l.padTop + drop
+    const h = l.padH - drop
+
+    // The socket the pedal sits in.
+    g.fillStyle = IRON_DARK
+    g.fillRect(x, l.padTop, w, l.padH)
+
+    const grad = g.createLinearGradient(0, y, 0, y + h)
+    grad.addColorStop(0, live ? IRON_EDGE : "#26262e")
+    grad.addColorStop(0.5, IRON)
+    grad.addColorStop(1, IRON_DARK)
+    g.fillStyle = grad
+    plate(g, x + 3, y, w - 6, h - 6, 6)
+    g.fill()
+
+    // A brass wear-strip along the top edge, brighter the more recently struck.
+    g.fillStyle = press > 0.05 ? mix(BRASS, BRASS_HI, press) : withAlpha(BRASS_DARK, live ? 0.85 : 0.4)
+    g.fillRect(x + 3, y, w - 6, Math.max(3, l.unit * 0.16))
+
+    const px = Math.min(h * 0.5, (w * 1.25) / Math.max(2, String(p.value).length))
+    g.save()
+    g.font = stamp(px)
+    g.textAlign = "center"
+    g.textBaseline = "middle"
+    const cx = x + w / 2
+    const cy = y + h * 0.46
+    g.fillStyle = withAlpha(INK, 0.7)
+    g.fillText(String(p.value), cx + 2, cy + 3)
+    g.fillStyle = live ? mix(BRASS_HI, "#ffffff", press * 0.6) : withAlpha(BRASS_DARK, 0.7)
+    g.fillText(String(p.value), cx, cy)
+    g.font = stamp(Math.max(9, l.unit * 0.34), 700)
+    g.fillStyle = withAlpha(CHALK, live ? 0.3 : 0.14)
+    g.fillText(label, cx, y + h * 0.86)
+    g.restore()
+  }
+}
+
+/**
+ * The belt.
+ *
+ * One plate cast onto it per escape, and nothing ever takes one off — the
+ * child-safe version of loss aversion from `EXPERIENCE_DESIGN.md`. It is the
+ * construction: the reason to come back is "my belt is nine plates long", never
+ * "my streak is at risk".
+ */
+export function drawBelt(
+  g: CanvasRenderingContext2D,
+  l: Layout,
+  plates: number,
+  beaten: number,
+  freshMs: number,
+): void {
+  const h = l.beltH
+  const y = l.beltY
+  const shown = Math.min(plates, Math.max(6, Math.floor(l.w / (h * 0.72))))
+  const pw = h * 0.5
+  const total = shown * (pw + 3)
+  const x0 = l.cx - total / 2
+
+  g.save()
+  // The strap.
+  g.fillStyle = withAlpha(IRON_DARK, 0.85)
+  plate(g, x0 - 8, y + h * 0.22, total + 16, h * 0.56, 3)
+  g.fill()
+
+  for (let i = 0; i < shown; i++) {
+    const x = x0 + i * (pw + 3)
+    // The newest plate is still cooling.
+    const fresh = i === shown - 1 ? Math.max(0, 1 - freshMs / 900) : 0
+    g.fillStyle = fresh > 0 ? heatColor(fresh) : BRASS
+    g.fillRect(x, y + h * 0.24, pw, h * 0.52)
+    g.fillStyle = withAlpha(BRASS_HI, 0.5)
+    g.fillRect(x, y + h * 0.24, pw, h * 0.12)
+  }
+
+  g.font = stamp(Math.max(10, h * 0.4), 700)
+  g.textBaseline = "middle"
+  g.textAlign = "left"
+  g.fillStyle = withAlpha(CHALK, 0.5)
+  g.fillText(`${plates}`, x0 + total + 14, y + h * 0.5)
+  if (beaten > 0) {
+    g.textAlign = "right"
+    g.fillStyle = withAlpha(BRASS_HI, 0.72)
+    g.fillText(`${beaten}★`, x0 - 16, y + h * 0.5)
+  }
+  g.restore()
+}
+
+/** A short, loud line over the ring. One at a time, never queued. */
+export type Banner = {
+  text: string
+  sub: string
+  life: number
+  maxLife: number
+  color: string
+}
+
+export function drawBanner(g: CanvasRenderingContext2D, l: Layout, b: Banner): void {
+  const t = b.life / b.maxLife
+  const rise = (1 - t) * l.unit * 0.9
+  const a = Math.min(1, t * 2.6)
+  g.save()
+  g.textAlign = "center"
+  g.textBaseline = "middle"
+  g.font = stamp(l.unit * 1.4)
+  g.fillStyle = withAlpha(INK, a * 0.5)
+  g.fillText(b.text, l.cx + 2, l.cy - l.unit * 2.4 - rise + 3)
+  g.fillStyle = withAlpha(b.color, a)
+  g.fillText(b.text, l.cx, l.cy - l.unit * 2.4 - rise)
+  if (b.sub) {
+    g.font = stamp(l.unit * 0.52, 700)
+    g.fillStyle = withAlpha(CHALK, a * 0.6)
+    g.fillText(b.sub, l.cx, l.cy - l.unit * 1.5 - rise)
+  }
+  g.restore()
+}
+
+/**
+ * The count, as a bar of three segments across the top of the mat.
+ *
+ * Not a ring and not a shrinking wedge: three discrete slaps, because that is
+ * what the referee is actually doing and a continuous drain would be a timer
+ * pretending to be drama.
+ */
+export function drawCount(
+  g: CanvasRenderingContext2D,
+  l: Layout,
+  fraction: number,
+  slaps: number,
+  live: boolean,
+): void {
+  const w = Math.min(l.w * 0.62, l.unit * 12)
+  const x0 = l.cx - w / 2
+  const y = l.matTop - Math.max(7, l.unit * 0.5)
+  const h = Math.max(4, l.unit * 0.2)
+  const seg = (w - 8) / 3
+  for (let i = 0; i < 3; i++) {
+    const x = x0 + i * (seg + 4)
+    g.fillStyle = withAlpha(IRON_DARK, 0.8)
+    g.fillRect(x, y, seg, h)
+    if (!live) continue
+    const local = Math.max(0, Math.min(1, fraction * 3 - i))
+    if (local <= 0) continue
+    g.fillStyle = i < slaps ? OXIDE : mix(BRASS, OXIDE, local)
+    g.fillRect(x, y, seg * local, h)
+  }
+}

--- a/dynawalla/games/foundry/src/render/layout.ts
+++ b/dynawalla/games/foundry/src/render/layout.ts
@@ -1,0 +1,102 @@
+// Where everything sits.
+//
+// Computed once per resize and read everywhere else, so no draw call measures
+// text or does trigonometry to find out where the mat is. The proportions hold
+// from a 320px phone to a landscape iPad because they are all fractions of the
+// short edge, with the two things a child touches — the pedals — pinned to a
+// generous absolute minimum instead.
+//
+// Tablet and desktop are first-class targets, not a phone layout stretched: the
+// ring is allowed to become wide and shallow, and the pedal band stops growing
+// once it is comfortably bigger than a hand.
+
+export type Layout = {
+  w: number
+  h: number
+  /** Bottom of the crowd, top of the ring structure. */
+  horizon: number
+  /** The mat, in screen space. Corners are the four ring posts. */
+  matTop: number
+  matBottom: number
+  matLeftTop: number
+  matRightTop: number
+  matLeftBottom: number
+  matRightBottom: number
+  /** Middle of the mat, where the pin happens. */
+  cx: number
+  cy: number
+  /** The hanging board that carries the sum. */
+  boardX: number
+  boardY: number
+  boardW: number
+  boardH: number
+  /** The pedal band. Split down the middle: light plate left, heavy right. */
+  padTop: number
+  padH: number
+  /** The belt strip along the top. */
+  beltY: number
+  beltH: number
+  /** Base size for stamped numerals. */
+  unit: number
+}
+
+export function computeLayout(w: number, h: number): Layout {
+  const short = Math.min(w, h)
+  const wide = w / h > 1.35
+
+  const beltH = Math.max(24, Math.min(44, short * 0.075))
+  const beltY = beltH * 0.28
+
+  const boardH = Math.max(56, Math.min(140, h * (wide ? 0.19 : 0.145)))
+  const boardW = Math.min(w * 0.86, Math.max(220, short * 1.15))
+  const boardY = beltY + beltH + Math.max(6, h * 0.018)
+  const boardX = (w - boardW) / 2
+
+  // The pedals get the bottom of the screen and a floor of 150px, because a
+  // four-second escape is lost on a thumb that missed, not on the arithmetic.
+  const padH = Math.max(150, Math.min(300, h * (wide ? 0.34 : 0.29)))
+  const padTop = h - padH
+
+  const horizon = boardY + boardH + Math.max(8, h * 0.02)
+  const matTop = horizon + Math.max(18, h * 0.045)
+  const matBottom = padTop - Math.max(12, h * 0.03)
+
+  // The ring is drawn in a shallow one-point perspective: the far edge is
+  // narrower than the near one. Just enough to sit the figures *in* something.
+  const inset = Math.min(w * 0.09, 74)
+  const matLeftTop = inset + (w - inset * 2) * 0.11
+  const matRightTop = w - matLeftTop
+  const matLeftBottom = inset * 0.42
+  const matRightBottom = w - matLeftBottom
+
+  return {
+    w,
+    h,
+    horizon,
+    matTop,
+    matBottom,
+    matLeftTop,
+    matRightTop,
+    matLeftBottom,
+    matRightBottom,
+    cx: w / 2,
+    cy: (matTop + matBottom) / 2,
+    boardX,
+    boardY,
+    boardW,
+    boardH,
+    padTop,
+    padH,
+    beltY,
+    beltH,
+    unit: Math.max(12, short * 0.052),
+  }
+}
+
+/** Half-width of the mat at a given screen y. Outside the mat, clamped. */
+export function matHalfWidth(l: Layout, y: number): number {
+  const t = Math.max(0, Math.min(1, (y - l.matTop) / Math.max(1, l.matBottom - l.matTop)))
+  const left = l.matLeftTop + (l.matLeftBottom - l.matLeftTop) * t
+  const right = l.matRightTop + (l.matRightBottom - l.matRightTop) * t
+  return (right - left) / 2
+}

--- a/dynawalla/games/foundry/src/render/palette.ts
+++ b/dynawalla/games/foundry/src/render/palette.ts
@@ -1,0 +1,98 @@
+// The material palette.
+//
+// Ancient-futurist, and specifically *not* the failure modes on the hostile
+// reference board in `docs/EXPERIENCE_DESIGN.md`: no purple-to-teal gradient, no
+// glassmorphism, no neon. Colour here is what a material is, not what a light
+// is doing to it — cast iron, brass, canvas, lapis night, and metal at four
+// temperatures on its way down from white heat.
+//
+// The foundry is a night market with a ring in the middle of it. The crowd is
+// lantern light at distance; the ring is the only thing lit properly.
+
+export const NIGHT = "#0b0a10"
+export const NIGHT_HIGH = "#141223"
+export const LAPIS = "#1b2a55"
+export const LAPIS_DEEP = "#101a38"
+
+export const IRON = "#2b2b33"
+export const IRON_EDGE = "#4a4a56"
+export const IRON_DARK = "#17171d"
+
+export const BRASS = "#c9973f"
+export const BRASS_HI = "#f0cf85"
+export const BRASS_DARK = "#7a5a22"
+
+export const CANVAS = "#c8bda6"
+export const CANVAS_DARK = "#8d846f"
+export const CANVAS_SHADOW = "#5d5748"
+
+/** Metal cooling: white → yellow → orange → dull red → gone. */
+export const HEAT_WHITE = "#fff6e2"
+export const HEAT_YELLOW = "#ffcb54"
+export const HEAT_ORANGE = "#ff7a1f"
+export const HEAT_RED = "#a32410"
+
+export const CROWD_LANTERN = "#ffb457"
+export const CROWD_DIM = "#3a2a1c"
+
+export const REF_CLOTH = "#e8e2d6"
+export const REF_STRIPE = "#1a1a1f"
+
+/** The one cold colour in the building: the escape. */
+export const KICKOUT = "#7fe3ff"
+export const KICKOUT_DEEP = "#1d6f8f"
+
+/** A refused total. Oxide, not a red alert light. */
+export const OXIDE = "#8c3a24"
+
+export const INK = "#0a0910"
+export const CHALK = "#efe7d6"
+
+export const UI_FONT =
+  '600 16px/1 ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace'
+
+/** A stamped numeral: condensed, heavy, unambiguous at 320px on a moving pedal. */
+export function stamp(px: number, weight = 800): string {
+  return `${weight} ${px}px/1 "Avenir Next Condensed", "Helvetica Neue", Impact, system-ui, sans-serif`
+}
+
+export function withAlpha(hex: string, a: number): string {
+  const h = hex.replace("#", "")
+  const r = Number.parseInt(h.slice(0, 2), 16)
+  const g = Number.parseInt(h.slice(2, 4), 16)
+  const b = Number.parseInt(h.slice(4, 6), 16)
+  return `rgba(${r},${g},${b},${Math.max(0, Math.min(1, a))})`
+}
+
+/** Mix two hex colours. `t` 0 → `from`, 1 → `to`. */
+export function mix(from: string, to: string, t: number): string {
+  const k = Math.max(0, Math.min(1, t))
+  const pa = from.replace("#", "")
+  const pb = to.replace("#", "")
+  const r = Math.round(
+    Number.parseInt(pa.slice(0, 2), 16) * (1 - k) + Number.parseInt(pb.slice(0, 2), 16) * k,
+  )
+  const g = Math.round(
+    Number.parseInt(pa.slice(2, 4), 16) * (1 - k) + Number.parseInt(pb.slice(2, 4), 16) * k,
+  )
+  const b = Math.round(
+    Number.parseInt(pa.slice(4, 6), 16) * (1 - k) + Number.parseInt(pb.slice(4, 6), 16) * k,
+  )
+  return `rgb(${r},${g},${b})`
+}
+
+/**
+ * The colour of metal at temperature `t`, 1 being just-poured and 0 being cold.
+ *
+ * Used by the canvas decals, which is where the design canon's "glow-decal
+ * cooling" lives: every escape scorches the canvas, and that scorch cools
+ * through this ramp over the next several seconds instead of being erased. A
+ * child can read how many falls they have taken off a challenger by how much of
+ * the mat is still warm.
+ */
+export function heatColor(t: number): string {
+  const k = Math.max(0, Math.min(1, t))
+  if (k > 0.72) return mix(HEAT_YELLOW, HEAT_WHITE, (k - 0.72) / 0.28)
+  if (k > 0.4) return mix(HEAT_ORANGE, HEAT_YELLOW, (k - 0.4) / 0.32)
+  return mix(HEAT_RED, HEAT_ORANGE, k / 0.4)
+}

--- a/dynawalla/games/foundry/src/render/particles.ts
+++ b/dynawalla/games/foundry/src/render/particles.ts
@@ -1,0 +1,222 @@
+// A flat, pooled particle system. No allocation after construction, no garbage
+// per frame, and a hard ceiling that the quality tier sets.
+//
+// Three kinds, and the vocabulary is deliberately mechanical rather than
+// festive — the hostile reference board bans confetti and starbursts by name:
+//
+//   SPARK   struck metal. A hot streak that cools as it falls.
+//   SHARD   a chip off a plate. Tumbles, has weight, lands.
+//   DUST    canvas dust punched up by a body. Slow, no glow.
+
+import { heatColor, withAlpha } from "./palette.ts"
+
+export const KIND_SPARK = 0
+export const KIND_SHARD = 1
+export const KIND_DUST = 2
+
+/**
+ * The array size. It is the ULTRA tier's ceiling; every tier below it runs the
+ * same arrays with a smaller `limit`, so a downgrade costs no allocation and a
+ * `low` device never iterates — or draws — the eighteen hundred slots it is not
+ * allowed to use.
+ */
+const CAP = 2400
+
+export class Particles {
+  private x = new Float32Array(CAP)
+  private y = new Float32Array(CAP)
+  private vx = new Float32Array(CAP)
+  private vy = new Float32Array(CAP)
+  private life = new Float32Array(CAP)
+  private maxLife = new Float32Array(CAP)
+  private size = new Float32Array(CAP)
+  private spin = new Float32Array(CAP)
+  private rot = new Float32Array(CAP)
+  private kind = new Uint8Array(CAP)
+  private hot = new Float32Array(CAP)
+  private alive = new Uint8Array(CAP)
+  private cursor = 0
+  private seed = 0x1f123bb5
+  /** Live ceiling, set from the quality tier. Never above `CAP`. */
+  private limit = CAP
+
+  count = 0
+
+  /**
+   * Set the live ceiling. Shrinking it kills whatever is already above the new
+   * line rather than leaving it stranded — a downgrade has to take effect on the
+   * next frame, not once the current burst happens to expire.
+   */
+  setLimit(n: number): void {
+    const next = Math.max(1, Math.min(CAP, Math.round(n)))
+    if (next < this.limit) {
+      for (let i = next; i < this.limit; i++) {
+        if (this.alive[i]) {
+          this.alive[i] = 0
+          this.count--
+        }
+      }
+    }
+    this.limit = next
+    if (this.cursor >= next) this.cursor = 0
+  }
+
+  private rand(): number {
+    let s = this.seed
+    s ^= s << 13
+    s ^= s >>> 17
+    s ^= s << 5
+    this.seed = s >>> 0
+    return this.seed / 4294967296
+  }
+
+  private slot(): number {
+    for (let n = 0; n < this.limit; n++) {
+      const i = (this.cursor + n) % this.limit
+      if (!this.alive[i]) {
+        this.cursor = (i + 1) % this.limit
+        return i
+      }
+    }
+    // Full: recycle the oldest thing under the cursor rather than dropping the
+    // emit. A burst that silently vanishes reads as a dropped frame.
+    const i = this.cursor
+    this.cursor = (i + 1) % this.limit
+    return i
+  }
+
+  emit(
+    kind: number,
+    x: number,
+    y: number,
+    vx: number,
+    vy: number,
+    life: number,
+    size: number,
+    hot = 1,
+  ): void {
+    const i = this.slot()
+    if (!this.alive[i]) this.count++
+    this.alive[i] = 1
+    this.kind[i] = kind
+    this.x[i] = x
+    this.y[i] = y
+    this.vx[i] = vx
+    this.vy[i] = vy
+    this.life[i] = life
+    this.maxLife[i] = life
+    this.size[i] = size
+    this.hot[i] = hot
+    this.rot[i] = this.rand() * Math.PI * 2
+    this.spin[i] = (this.rand() - 0.5) * 14
+  }
+
+  /**
+   * A burst of struck sparks along a direction, with spread.
+   * `n` is already multiplied by the tier's burst factor by the caller.
+   */
+  burst(
+    kind: number,
+    x: number,
+    y: number,
+    n: number,
+    speed: number,
+    dir: number,
+    spread: number,
+    size: number,
+  ): void {
+    const total = Math.max(0, Math.round(n))
+    for (let i = 0; i < total; i++) {
+      const a = dir + (this.rand() - 0.5) * spread
+      const s = speed * (0.35 + this.rand() * 0.9)
+      this.emit(
+        kind,
+        x + (this.rand() - 0.5) * 6,
+        y + (this.rand() - 0.5) * 6,
+        Math.cos(a) * s,
+        Math.sin(a) * s,
+        0.35 + this.rand() * 0.7,
+        size * (0.6 + this.rand() * 0.8),
+        0.7 + this.rand() * 0.3,
+      )
+    }
+  }
+
+  step(dt: number, floorY: number): void {
+    for (let i = 0; i < this.limit; i++) {
+      if (!this.alive[i]) continue
+      const k = this.kind[i]
+      const drag = k === KIND_DUST ? 1.6 : 0.9
+      const grav = k === KIND_DUST ? 120 : k === KIND_SHARD ? 1500 : 900
+      this.vx[i] = (this.vx[i] as number) * Math.exp(-dt * drag)
+      this.vy[i] = (this.vy[i] as number) * Math.exp(-dt * drag) + grav * dt
+      this.x[i] = (this.x[i] as number) + (this.vx[i] as number) * dt
+      this.y[i] = (this.y[i] as number) + (this.vy[i] as number) * dt
+      this.rot[i] = (this.rot[i] as number) + (this.spin[i] as number) * dt
+      if (k !== KIND_DUST && (this.y[i] as number) > floorY) {
+        // Bounce off the canvas, losing most of it. Sparks skitter.
+        this.y[i] = floorY
+        this.vy[i] = -(this.vy[i] as number) * 0.28
+        this.vx[i] = (this.vx[i] as number) * 0.7
+      }
+      const l = (this.life[i] as number) - dt
+      this.life[i] = l
+      if (l <= 0) {
+        this.alive[i] = 0
+        this.count--
+      }
+    }
+  }
+
+  draw(g: CanvasRenderingContext2D, glow: boolean): void {
+    g.save()
+    g.lineCap = "round"
+    for (let i = 0; i < this.limit; i++) {
+      if (!this.alive[i]) continue
+      const t = (this.life[i] as number) / (this.maxLife[i] as number)
+      const k = this.kind[i]
+      const s = this.size[i] as number
+      const x = this.x[i] as number
+      const y = this.y[i] as number
+
+      if (k === KIND_SPARK) {
+        const heat = (this.hot[i] as number) * t
+        g.strokeStyle = withAlpha(heatColor(heat), Math.min(1, t * 1.4))
+        g.lineWidth = Math.max(0.7, s * t)
+        const tail = 0.022
+        g.beginPath()
+        g.moveTo(x, y)
+        g.lineTo(x - (this.vx[i] as number) * tail, y - (this.vy[i] as number) * tail)
+        g.stroke()
+        if (glow && t > 0.55) {
+          g.fillStyle = withAlpha("#fff3d6", (t - 0.55) * 0.7)
+          g.beginPath()
+          g.arc(x, y, s * 0.9, 0, Math.PI * 2)
+          g.fill()
+        }
+        continue
+      }
+
+      if (k === KIND_SHARD) {
+        g.save()
+        g.translate(x, y)
+        g.rotate(this.rot[i] as number)
+        g.fillStyle = withAlpha(heatColor((this.hot[i] as number) * t * 0.8), Math.min(1, t * 1.6))
+        g.fillRect(-s * 0.5, -s * 0.28, s, s * 0.56)
+        g.restore()
+        continue
+      }
+
+      g.fillStyle = withAlpha("#a89c86", t * 0.32)
+      g.beginPath()
+      g.arc(x, y, s * (1.6 - t * 0.6), 0, Math.PI * 2)
+      g.fill()
+    }
+    g.restore()
+  }
+
+  clear(): void {
+    this.alive.fill(0)
+    this.count = 0
+  }
+}

--- a/dynawalla/games/foundry/src/render/ring.ts
+++ b/dynawalla/games/foundry/src/render/ring.ts
@@ -1,0 +1,304 @@
+// The ring, the two wrestlers and the referee.
+//
+// Everything here is drawn from primitives — cast-iron posts, brass
+// turnbuckles, a canvas mat, three sagging ropes, and figures built out of
+// tapered limbs. No sprites, no atlas, no image decode on the answer path.
+//
+// The figures are *cast*, not cartooned: heavy silhouettes with a hot seam
+// down them, as though they came out of a mould an hour ago and have not
+// finished cooling. That is the one idea holding the art direction together and
+// it is why nothing here has a face — a face makes it a mascot, and the hostile
+// reference board bans mascots by name.
+
+import type { Decals } from "./decals.ts"
+import type { Layout } from "./layout.ts"
+import {
+  BRASS,
+  BRASS_DARK,
+  BRASS_HI,
+  CANVAS,
+  CANVAS_DARK,
+  CANVAS_SHADOW,
+  IRON,
+  IRON_DARK,
+  IRON_EDGE,
+  REF_CLOTH,
+  REF_STRIPE,
+  heatColor,
+  withAlpha,
+} from "./palette.ts"
+
+/** The mat, its decals, and the four posts behind it. Everything else sits on top. */
+export function drawMat(g: CanvasRenderingContext2D, l: Layout, decals: Decals, glow: boolean): void {
+  // Apron: the skirt below the ropes, in shadow.
+  g.fillStyle = IRON_DARK
+  g.beginPath()
+  g.moveTo(l.matLeftBottom - 10, l.matBottom)
+  g.lineTo(l.matRightBottom + 10, l.matBottom)
+  g.lineTo(l.matRightBottom + 26, l.matBottom + 26)
+  g.lineTo(l.matLeftBottom - 26, l.matBottom + 26)
+  g.closePath()
+  g.fill()
+
+  const grad = g.createLinearGradient(0, l.matTop, 0, l.matBottom)
+  grad.addColorStop(0, CANVAS_DARK)
+  grad.addColorStop(0.45, CANVAS)
+  grad.addColorStop(1, CANVAS_DARK)
+  g.save()
+  g.beginPath()
+  g.moveTo(l.matLeftTop, l.matTop)
+  g.lineTo(l.matRightTop, l.matTop)
+  g.lineTo(l.matRightBottom, l.matBottom)
+  g.lineTo(l.matLeftBottom, l.matBottom)
+  g.closePath()
+  g.fillStyle = grad
+  g.fill()
+  g.clip()
+
+  decals.draw(g, glow)
+
+  // Woven canvas: a coarse cross-hatch that gives the mat a scale. Cheap, and
+  // it stops the biggest flat area on screen reading as a gradient panel.
+  g.strokeStyle = withAlpha(CANVAS_SHADOW, 0.16)
+  g.lineWidth = 1
+  const rows = 14
+  for (let i = 1; i < rows; i++) {
+    const y = l.matTop + ((l.matBottom - l.matTop) * i) / rows
+    g.beginPath()
+    g.moveTo(0, y)
+    g.lineTo(l.w, y)
+    g.stroke()
+  }
+  const cols = 12
+  for (let i = 1; i < cols; i++) {
+    const t = i / cols
+    g.beginPath()
+    g.moveTo(l.matLeftTop + (l.matRightTop - l.matLeftTop) * t, l.matTop)
+    g.lineTo(l.matLeftBottom + (l.matRightBottom - l.matLeftBottom) * t, l.matBottom)
+    g.stroke()
+  }
+  g.restore()
+}
+
+/** Posts, ropes and turnbuckles. Drawn after the figures so the near rope crosses them. */
+export function drawFrame(
+  g: CanvasRenderingContext2D,
+  l: Layout,
+  detail: number,
+  heat: number,
+  nearOnly: boolean,
+): void {
+  const posts: Array<[number, number, number]> = nearOnly
+    ? [
+        [l.matLeftBottom, l.matBottom, 1],
+        [l.matRightBottom, l.matBottom, 1],
+      ]
+    : [
+        [l.matLeftTop, l.matTop, 0.72],
+        [l.matRightTop, l.matTop, 0.72],
+      ]
+
+  const postH = (l.matBottom - l.matTop) * 0.52
+  for (const [px, py, scale] of posts) {
+    const ph = postH * scale
+    const pw = Math.max(7, l.unit * 0.42 * scale)
+    g.fillStyle = IRON
+    g.fillRect(px - pw / 2, py - ph, pw, ph)
+    g.fillStyle = IRON_EDGE
+    g.fillRect(px - pw / 2, py - ph, pw * 0.3, ph)
+    // The turnbuckle cap: brass, and the one thing that catches the mat light.
+    g.fillStyle = BRASS_DARK
+    g.fillRect(px - pw * 0.85, py - ph - pw * 0.55, pw * 1.7, pw * 0.85)
+    g.fillStyle = heat > 0.5 ? BRASS_HI : BRASS
+    g.fillRect(px - pw * 0.85, py - ph - pw * 0.55, pw * 1.7, pw * 0.3)
+  }
+
+  // Three ropes with real sag, resolved at the tier's detail.
+  const y0 = nearOnly ? l.matBottom : l.matTop
+  const x0 = nearOnly ? l.matLeftBottom : l.matLeftTop
+  const x1 = nearOnly ? l.matRightBottom : l.matRightTop
+  const scale = nearOnly ? 1 : 0.72
+  for (let r = 0; r < 3; r++) {
+    const top = y0 - postH * scale * (0.34 + r * 0.24)
+    const sag = (nearOnly ? 12 : 7) * (1 - r * 0.18)
+    g.strokeStyle = r === 1 ? BRASS : withAlpha(BRASS, 0.86)
+    g.lineWidth = Math.max(2, l.unit * 0.11 * scale)
+    g.beginPath()
+    for (let i = 0; i <= detail; i++) {
+      const t = i / detail
+      const x = x0 + (x1 - x0) * t
+      const y = top + Math.sin(t * Math.PI) * sag
+      if (i === 0) g.moveTo(x, y)
+      else g.lineTo(x, y)
+    }
+    g.stroke()
+  }
+}
+
+export type PinPose = {
+  /** 0 → flat on the mat, 1 → fully up and out. */
+  rise: number
+  /** 0..1 how much the challenger is bearing down. */
+  press: number
+  /** Struggle wobble, in radians. */
+  wobble: number
+  /** 0..1 of the way through the count — drives the challenger's lean. */
+  count: number
+}
+
+/** A tapered limb: a quad, not a stroked line, so it has mass. */
+function limb(
+  g: CanvasRenderingContext2D,
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+  w0: number,
+  w1: number,
+): void {
+  const dx = x1 - x0
+  const dy = y1 - y0
+  const len = Math.hypot(dx, dy) || 1
+  const nx = -dy / len
+  const ny = dx / len
+  g.beginPath()
+  g.moveTo(x0 + nx * w0, y0 + ny * w0)
+  g.lineTo(x1 + nx * w1, y1 + ny * w1)
+  g.lineTo(x1 - nx * w1, y1 - ny * w1)
+  g.lineTo(x0 - nx * w0, y0 - ny * w0)
+  g.closePath()
+  g.fill()
+}
+
+/**
+ * The two bodies.
+ *
+ * The player is underneath, on their back, with the leverage bar across their
+ * chest — the bar *is* the load meter, so the thing the child is filling is a
+ * physical object being pushed off them rather than a progress bar in a corner.
+ * The challenger is on top, leaning further in as the count runs.
+ */
+export function drawGrapple(
+  g: CanvasRenderingContext2D,
+  l: Layout,
+  pose: PinPose,
+  loadFraction: number,
+  seam: number,
+): void {
+  const u = l.unit
+  const cx = l.cx
+  const cy = l.cy + u * 0.5
+  const rise = Math.max(0, Math.min(1, pose.rise))
+
+  // ── the player, on their back ──────────────────────────────────────────
+  g.save()
+  g.translate(cx, cy)
+  g.rotate(pose.wobble * 0.05)
+  g.fillStyle = IRON
+  // Torso lying along the mat, head to the left.
+  limb(g, -u * 1.5, -rise * u * 0.9, u * 0.5, -rise * u * 0.35, u * 0.52, u * 0.62)
+  // Legs, kicking harder the closer the bar is to lifting.
+  const kick = Math.sin(pose.wobble * 6) * 0.3 * (0.4 + loadFraction)
+  limb(g, u * 0.4, -rise * u * 0.3, u * 1.7, -rise * u * 0.2 + kick * u, u * 0.4, u * 0.24)
+  limb(g, u * 0.4, -rise * u * 0.3, u * 1.8, -rise * u * 0.2 - kick * u, u * 0.4, u * 0.24)
+  // Head.
+  g.beginPath()
+  g.arc(-u * 1.85, -rise * u * 1.05, u * 0.42, 0, Math.PI * 2)
+  g.fill()
+  // The hot seam: this body came out of a mould and has not cooled.
+  g.strokeStyle = withAlpha(heatColor(0.35 + seam * 0.5), 0.5 + seam * 0.5)
+  g.lineWidth = Math.max(1.4, u * 0.07)
+  g.beginPath()
+  g.moveTo(-u * 1.45, -rise * u * 0.9)
+  g.lineTo(u * 0.45, -rise * u * 0.35)
+  g.stroke()
+  g.restore()
+
+  // ── the leverage bar ───────────────────────────────────────────────────
+  // It tips up as the load approaches the target: the child sees how close they
+  // are as an angle, not as a number they have to read while being counted.
+  const barLift = u * (0.35 + loadFraction * 1.5 + rise * 1.4)
+  const barTilt = -loadFraction * 0.34 - rise * 0.5
+  g.save()
+  g.translate(cx - u * 0.4, cy - barLift)
+  g.rotate(barTilt)
+  const halfBar = u * 2.5
+  g.fillStyle = IRON_EDGE
+  g.fillRect(-halfBar, -u * 0.14, halfBar * 2, u * 0.28)
+  g.fillStyle = withAlpha(heatColor(Math.min(1, loadFraction)), 0.35 + loadFraction * 0.6)
+  g.fillRect(-halfBar, -u * 0.14, halfBar * 2 * Math.min(1, loadFraction), u * 0.28)
+  // Collars at each end so it reads as a loaded bar and not as a meter.
+  g.fillStyle = IRON
+  g.fillRect(-halfBar - u * 0.16, -u * 0.3, u * 0.24, u * 0.6)
+  g.fillRect(halfBar - u * 0.08, -u * 0.3, u * 0.24, u * 0.6)
+  g.restore()
+
+  // ── the challenger, bearing down ───────────────────────────────────────
+  const lean = 0.2 + pose.press * 0.5 + pose.count * 0.28
+  g.save()
+  g.translate(cx + u * 0.6, cy - u * 0.2 - rise * u * 1.2)
+  g.rotate(-lean * 0.22)
+  g.fillStyle = IRON_DARK
+  limb(g, -u * 1.4, -u * 1.6, u * 0.9, -u * 0.6, u * 0.62, u * 0.5)
+  limb(g, -u * 1.2, -u * 1.3, -u * 1.6, u * 0.1, u * 0.3, u * 0.22)
+  limb(g, -u * 0.7, -u * 1.2, -u * 0.5, u * 0.15, u * 0.3, u * 0.22)
+  g.beginPath()
+  g.arc(-u * 1.75, -u * 2.0, u * 0.46, 0, Math.PI * 2)
+  g.fill()
+  g.strokeStyle = withAlpha("#5a3a20", 0.7)
+  g.lineWidth = Math.max(1.2, u * 0.06)
+  g.beginPath()
+  g.moveTo(-u * 1.3, -u * 1.55)
+  g.lineTo(u * 0.8, -u * 0.65)
+  g.stroke()
+  g.restore()
+}
+
+/**
+ * The referee's arm, mid-count.
+ *
+ * `swing` runs 0 → 1 across a single slap: the hand is up at 0, has hit the mat
+ * at about 0.35, and is on its way back after that. It is drawn over the bodies
+ * because it is the thing the child's eye must not lose.
+ */
+export function drawReferee(
+  g: CanvasRenderingContext2D,
+  l: Layout,
+  swing: number,
+  slaps: number,
+): void {
+  const u = l.unit
+  const baseX = l.cx - u * 4.2
+  const baseY = l.cy + u * 1.6
+  const s = Math.max(0, Math.min(1, swing))
+  // Fast down, slow up: the hand is only ever hurrying in one direction.
+  const drop = s < 0.35 ? (s / 0.35) ** 0.6 : 1 - ((s - 0.35) / 0.65) ** 1.7
+  const handX = baseX + u * (1.1 + drop * 1.5)
+  const handY = baseY - u * (2.4 - drop * 2.35)
+
+  g.save()
+  g.fillStyle = REF_CLOTH
+  // Body: a crouched official in stripes.
+  limb(g, baseX - u * 0.5, baseY, baseX - u * 0.1, baseY - u * 2.1, u * 0.42, u * 0.4)
+  g.beginPath()
+  g.arc(baseX - u * 0.05, baseY - u * 2.6, u * 0.38, 0, Math.PI * 2)
+  g.fill()
+  g.fillStyle = REF_STRIPE
+  for (let i = 0; i < 3; i++) {
+    g.fillRect(baseX - u * 0.5, baseY - u * (1.85 - i * 0.5), u * 0.85, u * 0.16)
+  }
+  g.fillStyle = REF_CLOTH
+  limb(g, baseX - u * 0.1, baseY - u * 1.9, handX, handY, u * 0.24, u * 0.3)
+  g.beginPath()
+  g.arc(handX, handY, u * 0.3, 0, Math.PI * 2)
+  g.fill()
+  g.restore()
+
+  // The count, held up in brass beside the referee. Three marks, filled.
+  for (let i = 0; i < 3; i++) {
+    const x = baseX - u * 1.5
+    const y = baseY - u * 2.6 + i * u * 0.7
+    g.fillStyle = i < slaps ? BRASS_HI : withAlpha(BRASS_DARK, 0.55)
+    g.fillRect(x, y, u * 0.62, u * 0.16)
+  }
+}

--- a/dynawalla/games/foundry/src/stubHost.ts
+++ b/dynawalla/games/foundry/src/stubHost.ts
@@ -1,0 +1,321 @@
+// A local stub Host so the bout is playable standalone with `npm run dev`.
+//
+// It serves what the real runtime serves and nothing else. Only the `add`
+// domain is active in the curriculum graph, every one of its seven live rows is
+// a whole-number column operation, and `covers` is a request rather than an
+// instruction — so a stub that dealt fractions or long division would be a
+// rehearsal for a match that never happens. Column add and column subtract, at
+// two to four digits, is the truth.
+//
+// Three properties the real runtime also honours, asserted by
+// `src/test/stubHost.test.ts`:
+//
+//   1. **Exact arithmetic.** Every operand, answer and distractor is an
+//      integer. No float ever reaches an answer string or a comparison.
+//   2. **Seeded and deterministic.** Same seed → same question stream, forever.
+//   3. **Distractors are real mal-rule outputs.** Each one is the value a child
+//      running a specific broken procedure actually writes down. The three
+//      procedures are ported from `packs/shared/curriculum/src/malrules/
+//      columnOp.ts` — `mis.add.carry-dropped`, `mis.add.smaller-from-larger`
+//      and `mis.add.borrow-across-zero` — including their `applies()` guards, so
+//      a rule that would coincide with the correct procedure emits nothing at
+//      all. Never `answer + 1`, and never a fixed offset off the answer.
+//
+// That matters more here than in a quiz game: in THE GRAPPLE FOUNDRY a
+// distractor is a *false finish*. Land the bar on one and the crowd comes up
+// and the referee waves it off. A value nobody would ever produce would make
+// that beat fire at random, and the beat is the diagnosis.
+
+import type { Host, Question } from "./contract.ts"
+import { Rng } from "./core/rng.ts"
+
+type Op = "add" | "sub"
+
+/** Digits of `n`, least significant first. `0` is one digit. */
+function digitsOf(n: number): number[] {
+  if (n === 0) return [0]
+  const out: number[] = []
+  let m = n
+  while (m > 0) {
+    out.push(m % 10)
+    m = Math.floor(m / 10)
+  }
+  return out
+}
+
+function fromDigits(ds: readonly number[]): number {
+  let out = 0
+  for (let i = ds.length - 1; i >= 0; i--) out = out * 10 + (ds[i] as number)
+  return out
+}
+
+/**
+ * The three mal-rules the `add` domain actually declares, ported from
+ * `packs/shared/curriculum/src/malrules/columnOp.ts` and matching it column for
+ * column.
+ *
+ * Two rules are carried over from that file along with the procedures:
+ *
+ *   1. **Run the buggy procedure, never a shortcut off the answer.**
+ *      `mis.add.borrow-across-zero` happens to come out as the correct answer
+ *      plus the thousand that was borrowed and never given up — but that is a
+ *      consequence of the procedure, not its definition, and a stub that
+ *      encoded the shortcut would stop matching the moment a borrow chain had a
+ *      different shape.
+ *   2. **A rule that does not *apply* emits nothing.** With no column to
+ *      regroup, taking the smaller digit from the larger *is* the correct
+ *      procedure, so the rule is undefined there rather than wrong. Each
+ *      function below returns `null` in exactly the cases the curriculum's
+ *      `applies()` returns false.
+ *
+ * The reference case, from that file's own docblock:
+ *
+ *     5001 − 2798.  Correct 2203.
+ *     3797 is smaller-from-larger — |5−2| |0−7| |0−9| |1−8|.
+ *     3203 is borrow-across-zero — the zeros written as 9s and the thousand
+ *          never taken off the leading digit.
+ */
+
+/** Columns the pair occupies. */
+function colsOf(a: number, b: number): number {
+  return Math.max(digitsOf(a).length, digitsOf(b).length)
+}
+
+/**
+ * `mis.add.carry-dropped` — every column added, no carry ever recorded or added
+ * into the next one. 27 + 15 → 32.
+ *
+ * Undefined when nothing carries: then it is the correct procedure.
+ */
+export function carryDropped(a: number, b: number): number | null {
+  const da = digitsOf(a)
+  const db = digitsOf(b)
+  const n = colsOf(a, b)
+  const out: number[] = []
+  let carried = false
+  for (let i = 0; i < n; i++) {
+    const sum = (da[i] ?? 0) + (db[i] ?? 0)
+    if (sum > 9) carried = true
+    out.push(sum % 10)
+  }
+  return carried ? fromDigits(out) : null
+}
+
+/**
+ * `mis.add.smaller-from-larger` — in every column the smaller digit is taken
+ * from the larger, whichever is on top, and nothing is regrouped.
+ * 52 − 27 → 35.
+ *
+ * Undefined when no column would have needed regrouping.
+ */
+export function smallerFromLarger(a: number, b: number): number | null {
+  const da = digitsOf(a)
+  const db = digitsOf(b)
+  const n = colsOf(a, b)
+  let needed = false
+  const out: number[] = []
+  for (let i = 0; i < n; i++) {
+    const top = da[i] ?? 0
+    const bot = db[i] ?? 0
+    if (bot > top) needed = true
+    out.push(Math.abs(top - bot))
+  }
+  return needed ? fromDigits(out) : null
+}
+
+/**
+ * `mis.add.borrow-across-zero` — regrouped all the way down through a run of
+ * zeros, writing them as 9s, and never decrementing the digit above the run.
+ * 403 − 87 → 416, not 316.
+ *
+ * Undefined unless the borrow chain actually crossed a zero: with a non-zero
+ * digit to borrow from, this procedure decrements it correctly and is the
+ * correct procedure.
+ */
+export function borrowAcrossZero(a: number, b: number): number | null {
+  const da = digitsOf(a)
+  const db = digitsOf(b)
+  const n = colsOf(a, b)
+  const work = da.slice()
+  while (work.length < n) work.push(0)
+  const out: number[] = []
+  let crossedZero = false
+  for (let i = 0; i < n; i++) {
+    let top = work[i] as number
+    const bot = db[i] ?? 0
+    if (top < bot) {
+      let j = i + 1
+      while (j < n && (work[j] as number) === 0) {
+        work[j] = 9
+        j++
+      }
+      if (j >= n) return null
+      // The bug, and only here: a run of zeros became 9s and the digit above it
+      // was left alone. With no run, the decrement happens and this is correct.
+      if (j > i + 1) crossedZero = true
+      else work[j] = (work[j] as number) - 1
+      top += 10
+    }
+    out.push(top - bot)
+  }
+  return crossedZero ? fromDigits(out) : null
+}
+
+/**
+ * The wrong operation entirely — the one error below that is *not* one of the
+ * graph's three, and is named as such rather than dressed up as one. A child who
+ * reads `+` as `−` is not running a broken column procedure; they are answering a
+ * different question, and the value is worth putting on the mat all the same.
+ */
+export function wrongOperation(op: Op, a: number, b: number): number {
+  return op === "add" ? Math.abs(a - b) : a + b
+}
+
+function malRulesFor(op: Op, a: number, b: number): number[] {
+  const rules =
+    op === "add"
+      ? [carryDropped(a, b), wrongOperation(op, a, b)]
+      : [smallerFromLarger(a, b), borrowAcrossZero(a, b), wrongOperation(op, a, b)]
+  return rules.filter((v): v is number => v !== null)
+}
+
+/**
+ * Operands, drawn to the shape of the seven active `dw.add` rows.
+ *
+ * `level` is 0..7 and matches what the host's ladder walks: two digits without
+ * regrouping at the bottom, four digits with regrouping across a zero at the
+ * top. The stub is the ladder, not a random-number generator with a difficulty
+ * knob taped to it.
+ */
+function operandsFor(op: Op, level: number, rng: Rng): [number, number] {
+  const lv = Math.max(0, Math.min(7, Math.round(level)))
+  const digits = lv <= 1 ? 2 : lv <= 4 ? 3 : 4
+  const lo = 10 ** (digits - 1)
+  const hi = 10 ** digits - 1
+
+  if (op === "add") {
+    if (lv <= 1) {
+      // No regrouping: build it column by column so no column can carry.
+      const da: number[] = []
+      const db: number[] = []
+      for (let i = 0; i < digits; i++) {
+        const x = rng.int(i === digits - 1 ? 1 : 0, 8)
+        const y = rng.int(i === digits - 1 ? 1 : 0, 9 - x)
+        da.push(x)
+        db.push(y)
+      }
+      return [fromDigits(da), fromDigits(db)]
+    }
+    // Short addend at the top of the ladder — `4,003 + 87` is its own row.
+    if (lv >= 6) return [rng.int(lo, hi), rng.int(10, 99)]
+    return [rng.int(lo, hi), rng.int(lo, hi)]
+  }
+
+  if (lv <= 1) {
+    // No regrouping: every top digit is at least the bottom one, and the ones
+    // column is strictly greater so the difference is never zero — the graph
+    // sets `allowZeroResult: false` and a target of nothing is not a fall.
+    const da: number[] = []
+    const db: number[] = []
+    for (let i = 0; i < digits; i++) {
+      const top = rng.int(i === digits - 1 ? 2 : 1, 9)
+      const lowest = i === digits - 1 ? 1 : 0
+      da.push(top)
+      db.push(rng.int(lowest, i === 0 ? top - 1 : top))
+    }
+    return [fromDigits(da), fromDigits(db)]
+  }
+  if (lv >= 6) {
+    // Across a zero: plant one so `borrowAcrossZero` has something to be wrong
+    // about, which is what makes that distractor worth showing.
+    const ds = [rng.int(0, 9), 0, rng.int(1, 9), rng.int(1, 9)].slice(0, digits)
+    const a = Math.max(fromDigits(ds), 100)
+    return [a, rng.int(10, Math.max(11, Math.min(99, a - 1)))]
+  }
+  const a = rng.int(lo + 10, hi)
+  return [a, rng.int(lo, a - 1)]
+}
+
+const GLYPH: Record<Op, string> = { add: "+", sub: "−" }
+
+/** The ladder's height, matching the host's `item.level / 8` normalisation. */
+const LEVELS = 8
+
+export type StubHostOptions = {
+  seed?: number
+  reducedMotion?: boolean
+  /** Pin the ladder level instead of walking it. For tests and for capture runs. */
+  level?: number
+  /** Observe reports — the dev harness draws a running accuracy readout from this. */
+  onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void
+  /** Observe haptics so the harness can show they fired on a device that has none. */
+  onHaptic?: (k: string) => void
+}
+
+export function createStubHost(options: StubHostOptions = {}): Host {
+  const rng = new Rng(options.seed ?? 0x6f057d)
+  let served = 0
+
+  return {
+    next(o) {
+      served++
+      // A slow walk up the ladder, so a dev session sees two-digit sums first
+      // and four-digit borrows twenty falls later — the shape of a real
+      // scheduler, without pretending to be one.
+      const level =
+        options.level !== undefined
+          ? Math.max(0, Math.min(LEVELS - 1, Math.round(options.level)))
+          : Math.min(LEVELS - 1, Math.floor((served - 1) / 6))
+      const op: Op = rng.chance(0.5) ? "add" : "sub"
+      const [a, b] = operandsFor(op, level, rng)
+      const answer = op === "add" ? a + b : a - b
+
+      const seen = new Set<number>([answer])
+      const pool: number[] = []
+      for (const v of malRulesFor(op, a, b)) {
+        if (!Number.isInteger(v) || v < 1 || seen.has(v)) continue
+        seen.add(v)
+        pool.push(v)
+      }
+      rng.shuffle(pool)
+
+      return {
+        id: `stub-${served}`,
+        prompt: `${a} ${GLYPH[op]} ${b}`,
+        answer: String(answer),
+        distractors: pool.slice(0, 3).map(String),
+        domain: o?.domain ?? "add",
+        // Normalised the way the pack host normalises it: `item.level / 8`.
+        difficulty: level / LEVELS,
+      } satisfies Question
+    },
+
+    report(r) {
+      options.onReport?.(r)
+    },
+
+    haptic(k) {
+      options.onHaptic?.(k)
+      const nav = globalThis.navigator as Navigator | undefined
+      if (!nav || typeof nav.vibrate !== "function") return
+      const ms =
+        k === "light" ? 8 : k === "medium" ? 18 : k === "heavy" ? 34 : k === "success" ? 12 : 40
+      try {
+        if (k === "success") nav.vibrate([ms, 26, ms])
+        else if (k === "failure") nav.vibrate([ms, 40, ms])
+        else nav.vibrate(ms)
+      } catch {
+        // A browser that exposes vibrate but refuses it (no user gesture yet, or
+        // a policy block) must never take the frame down with it.
+        console.warn("[foundry] navigator.vibrate refused")
+      }
+    },
+
+    prefersReducedMotion() {
+      if (options.reducedMotion !== undefined) return options.reducedMotion
+      return (
+        typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion: reduce)").matches
+      )
+    },
+  }
+}

--- a/dynawalla/games/foundry/src/test/bout.test.ts
+++ b/dynawalla/games/foundry/src/test/bout.test.ts
@@ -1,0 +1,414 @@
+// The rules of the match, with nothing drawn.
+//
+// Every case here drives the real `Bout` against a scripted host, so what is
+// being asserted is the thing that actually runs on a tablet rather than a
+// model of it. No `Math.random` anywhere: the host is a fixed list and the
+// bout's own `Rng` is seeded with a literal.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import type { Host, Question } from "../contract.ts"
+import {
+  Bout,
+  fallsToBeat,
+  normalizeDifficulty,
+  promptDigits,
+  slapPeriodFor,
+  SLAP_COUNT,
+  type BoutEvent,
+} from "../game/bout.ts"
+
+type Report = { questionId: string; correct: boolean; ms: number; answered: string }
+
+type Rig = {
+  bout: Bout
+  events: BoutEvent[]
+  reports: Report[]
+  haptics: string[]
+  transitions: string[]
+}
+
+/** A host that serves a fixed script, so a case is about the rules and nothing else. */
+function rig(questions: Question[], options: { transition?: boolean } = {}): Rig {
+  const events: BoutEvent[] = []
+  const reports: Report[] = []
+  const haptics: string[] = []
+  const transitions: string[] = []
+  let i = 0
+  const host: Host = {
+    next() {
+      const q = questions[Math.min(i, questions.length - 1)] as Question
+      i++
+      return { ...q, id: `${q.id}#${i}` }
+    },
+    report(r) {
+      reports.push(r)
+    },
+    haptic(k) {
+      haptics.push(k)
+    },
+    prefersReducedMotion() {
+      return false
+    },
+    ...(options.transition
+      ? {
+          transition(kind: string, label?: string) {
+            transitions.push(`${kind}:${label ?? ""}`)
+          },
+        }
+      : {}),
+  }
+  const bout = new Bout({ host, seed: 0x51ee7, onEvent: (e) => events.push(e) })
+  return { bout, events, reports, haptics, transitions }
+}
+
+function q(answer: number, prompt = "10 + 10", distractors: string[] = []): Question {
+  return { id: "q", prompt, answer: String(answer), distractors, domain: "add", difficulty: 0 }
+}
+
+/**
+ * Advance the bout by `seconds` at 60Hz.
+ *
+ * Never in one big tick: `Bout.tick` clamps a step to a quarter-second on
+ * purpose, so a test that handed it a whole four-second window would be testing
+ * the clamp rather than the count.
+ */
+function run(bout: Bout, seconds: number): void {
+  const steps = Math.ceil(seconds * 60)
+  for (let i = 0; i < steps; i++) bout.tick(seconds / steps)
+}
+
+/** Run the lockup out so the fall is live. */
+function toPin(bout: Bout): void {
+  for (let i = 0; i < 60 && bout.phase !== "pin"; i++) bout.tick(0.05)
+  assert.equal(bout.phase, "pin")
+}
+
+/** Play the current beat out until the next fall is ready to be taken. */
+function toLockup(bout: Bout): void {
+  for (let i = 0; i < 200 && bout.phase !== "lockup"; i++) bout.tick(0.05)
+}
+
+test("normalizeDifficulty accepts the host's 0..1 and defends against a raw ladder index", () => {
+  assert.equal(normalizeDifficulty(0), 0)
+  assert.equal(normalizeDifficulty(0.5), 0.5)
+  assert.equal(normalizeDifficulty(1), 1)
+  assert.equal(normalizeDifficulty(10), 1)
+  assert.equal(normalizeDifficulty(5.5), 0.5)
+  assert.equal(normalizeDifficulty(-3), 0)
+  assert.equal(normalizeDifficulty(Number.NaN), 0)
+})
+
+test("promptDigits counts digits and ignores everything else", () => {
+  assert.equal(promptDigits("47 + 26"), 4)
+  assert.equal(promptDigits("4003 − 87"), 6)
+  assert.equal(promptDigits(""), 0)
+})
+
+test("the count is a function of the work and of nothing else", () => {
+  const short = slapPeriodFor(3, 2, 0)
+  const long = slapPeriodFor(6, 6, 0)
+  assert.ok(long > short, "a longer sum and a longer escape must buy more count")
+  // The canon asked for four seconds. A single-digit sum with a short escape
+  // lands there; a four-digit borrow gets nearly twice as much.
+  assert.ok(short * SLAP_COUNT > 3.5 && short * SLAP_COUNT < 5.2, `${short * SLAP_COUNT}s`)
+  assert.ok(long * SLAP_COUNT > 6.5)
+  // The ladder lifts the tempo, but only slightly, and never below the floor.
+  assert.ok(slapPeriodFor(5, 4, 1) < slapPeriodFor(5, 4, 0))
+  assert.ok(slapPeriodFor(5, 4, 1) > slapPeriodFor(5, 4, 0) * 0.8)
+  assert.ok(slapPeriodFor(0, 0, 1) >= 1.05)
+})
+
+test("an exact total is an escape, reported correct with the target", () => {
+  const r = rig([q(24, "40 − 16")])
+  toPin(r.bout)
+  const { a, b } = r.bout.fall.plates
+  const rep = { x: 0, y: 0 }
+  for (let y = 0; y * b <= 24; y++) {
+    if ((24 - y * b) % a === 0) {
+      rep.y = y
+      rep.x = (24 - y * b) / a
+      break
+    }
+  }
+  for (let i = 0; i < rep.y; i++) r.bout.tap("b")
+  for (let i = 0; i < rep.x; i++) r.bout.tap("a")
+  assert.equal(r.bout.phase, "kickout")
+  assert.equal(r.reports.length, 1)
+  assert.equal(r.reports[0]?.correct, true)
+  assert.equal(r.reports[0]?.answered, "24")
+  assert.equal(r.bout.beltPlates, 1)
+  assert.ok(r.events.some((e) => e.kind === "escape"))
+})
+
+test("one over the target loses the fall at once, and reports the overshoot", () => {
+  const r = rig([q(20, "12 + 8")])
+  toPin(r.bout)
+  // Mashing the heavy plate: 7, 14, and then 21 — one over, and the bar comes
+  // down. This is the property that makes the game a decomposition rather than
+  // a button: the wrestling reflex loses instantly.
+  r.bout.fall.plates = { a: 3, b: 7, x: 2, y: 2, taps: 4 }
+  r.bout.fall.minTaps = 4
+  r.bout.tap("b")
+  r.bout.tap("b")
+  assert.equal(r.bout.phase, "pin")
+  r.bout.tap("b")
+  assert.equal(r.bout.phase, "pinfall")
+  const pinfall = r.events.find((e) => e.kind === "pinfall")
+  assert.ok(pinfall && pinfall.kind === "pinfall" && pinfall.reason === "overshot")
+  assert.equal(r.reports.length, 1)
+  assert.equal(r.reports[0]?.correct, false)
+  assert.equal(r.reports[0]?.answered, "21")
+  assert.equal(r.bout.beltPlates, 0, "a lost fall must never take a plate off the belt")
+})
+
+test("a dead position ends the fall immediately rather than running the count out", () => {
+  // Target 24 with plates 4 and 7 is the canonical dead end: 7+7+7 = 21, and
+  // three cannot be made. The bout must say so on the third tap.
+  const r = rig([q(24)])
+  toPin(r.bout)
+  // Force the pair rather than hoping the chooser picked it: this case is about
+  // what the rule does, not about what the chooser prefers.
+  r.bout.fall.plates = { a: 4, b: 7, x: 6, y: 0, taps: 6 }
+  r.bout.fall.minTaps = 6
+  // 24 = 4·6 is the *only* escape here, because 7y ≡ 24 (mod 4) forces y to
+  // zero. Four fours is fine; one seven is already fatal.
+  r.bout.tap("a")
+  r.bout.tap("a")
+  assert.equal(r.bout.phase, "pin")
+  r.bout.tap("b")
+  assert.equal(r.bout.phase, "pinfall")
+  const pinfall = r.events.find((e) => e.kind === "pinfall")
+  assert.ok(pinfall && pinfall.kind === "pinfall" && pinfall.reason === "stuck")
+  assert.equal(r.reports[0]?.answered, "15")
+})
+
+test("the third slap ends the fall, and only the third", () => {
+  const r = rig([q(240, "180 + 60")])
+  toPin(r.bout)
+  const p = r.bout.fall.slapPeriod
+  run(r.bout, p + 0.01)
+  assert.equal(r.bout.fall.slaps, 1)
+  assert.equal(r.bout.phase, "pin")
+  run(r.bout, p)
+  assert.equal(r.bout.fall.slaps, 2)
+  assert.equal(r.bout.phase, "pin")
+  run(r.bout, p)
+  assert.equal(r.bout.phase, "pinfall")
+  const pinfall = r.events.find((e) => e.kind === "pinfall")
+  assert.ok(pinfall && pinfall.kind === "pinfall" && pinfall.reason === "counted-out")
+  assert.equal(r.reports[0]?.answered, "", "an untouched bar is not an answer of zero")
+})
+
+test("a mal-rule total is waved off — it costs count, never the fall", () => {
+  const r = rig([q(24, "40 − 16", ["12", "36"])])
+  toPin(r.bout)
+  r.bout.fall.plates = { a: 6, b: 12, x: 2, y: 1, taps: 3 }
+  r.bout.fall.minTaps = 2
+  r.bout.tap("b") // 12 — the smaller-from-larger answer
+  assert.equal(r.bout.phase, "pin", "a false finish must never end a fall")
+  const wave = r.events.find((e) => e.kind === "false-finish")
+  assert.ok(wave && wave.kind === "false-finish" && wave.value === 12)
+  assert.ok(r.bout.fall.advance > 0, "the wave-off has to cost count")
+  assert.equal(r.reports.length, 0)
+  // And it only fires once for the same value.
+  const before = r.events.filter((e) => e.kind === "false-finish").length
+  r.bout.fall.load = 0
+  r.bout.tap("b")
+  assert.equal(r.events.filter((e) => e.kind === "false-finish").length, before)
+})
+
+test("a wave-off can never itself land the third slap", () => {
+  const r = rig([q(24, "40 − 16", ["12"])])
+  toPin(r.bout)
+  r.bout.fall.plates = { a: 6, b: 12, x: 2, y: 1, taps: 3 }
+  const window = r.bout.fall.slapPeriod * SLAP_COUNT
+  // Wind the count to a hair before the end, then spring the trap.
+  r.bout.fall.elapsed = window - 0.05
+  r.bout.tap("b")
+  assert.equal(r.bout.phase, "pin")
+  assert.ok(r.bout.fall.elapsed + r.bout.fall.advance < window)
+})
+
+test("recovering from a wave-off is what earns the biggest reaction", () => {
+  const r = rig([q(24, "40 − 16", ["12"])])
+  toPin(r.bout)
+  r.bout.fall.plates = { a: 6, b: 12, x: 2, y: 1, taps: 3 }
+  r.bout.tap("b") // 12, waved off
+  r.bout.tap("a") // 18
+  r.bout.tap("a") // 24 — out
+  const escape = r.events.find((e) => e.kind === "escape")
+  assert.ok(escape && escape.kind === "escape")
+  assert.equal(escape.repaired, true)
+  assert.ok(escape.tier >= 2, "a repair is a tier-2 event by design")
+})
+
+test("exactly one report per served item, ever", () => {
+  const r = rig([q(20, "12 + 8")])
+  toPin(r.bout)
+  r.bout.fall.plates = { a: 5, b: 10, x: 2, y: 1, taps: 3 }
+  r.bout.tap("b")
+  r.bout.tap("b")
+  assert.equal(r.bout.phase, "kickout")
+  assert.equal(r.reports.length, 1)
+  // Taps during the celebration must not load, spend or report anything.
+  r.bout.tap("a")
+  r.bout.tap("b")
+  assert.equal(r.reports.length, 1)
+  assert.equal(r.bout.fall.load, 20)
+})
+
+test("a question the pool could not serve is playable and is never reported", () => {
+  const r = rig([{ ...q(0, ""), id: "" }])
+  toPin(r.bout)
+  assert.equal(r.bout.fall.questionId, "")
+  assert.ok(r.bout.fall.target >= 1, "an unservable item must still cut a playable fall")
+  run(r.bout, r.bout.fall.slapPeriod * SLAP_COUNT + 0.05)
+  assert.equal(r.bout.phase, "pinfall")
+  assert.equal(r.reports.length, 0)
+})
+
+test("the belt only ever grows, across escapes and pinfalls alike", () => {
+  const r = rig([q(20, "12 + 8")])
+  let seen = 0
+  for (let round = 0; round < 12; round++) {
+    toPin(r.bout)
+    r.bout.fall.plates = { a: 5, b: 10, x: 2, y: 1, taps: 3 }
+    if (round % 3 === 0) {
+      // Lose it on the count.
+      run(r.bout, r.bout.fall.slapPeriod * SLAP_COUNT + 0.05)
+    } else {
+      r.bout.tap("b")
+      r.bout.tap("b")
+    }
+    assert.ok(r.bout.beltPlates >= seen, "the belt regressed")
+    seen = r.bout.beltPlates
+    toLockup(r.bout)
+  }
+  assert.ok(seen >= 8)
+})
+
+test("a stopping point is offered only after a challenger is beaten", () => {
+  const r = rig([q(20, "12 + 8")], { transition: true })
+  const needed = fallsToBeat(0)
+  for (let i = 0; i < needed; i++) {
+    toPin(r.bout)
+    r.bout.fall.plates = { a: 5, b: 10, x: 2, y: 1, taps: 3 }
+    r.bout.tap("b")
+    r.bout.tap("b")
+    toLockup(r.bout)
+  }
+  assert.equal(r.transitions.length, 1)
+  assert.ok(r.transitions[0]?.startsWith("level:"))
+  assert.equal(r.bout.challengersBeaten, 1)
+})
+
+test("no stopping point is ever offered after a lost fall", () => {
+  const r = rig([q(20, "12 + 8")], { transition: true })
+  for (let round = 0; round < 10; round++) {
+    toPin(r.bout)
+    run(r.bout, r.bout.fall.slapPeriod * SLAP_COUNT + 0.05)
+    toLockup(r.bout)
+  }
+  assert.equal(r.transitions.length, 0)
+})
+
+test("losing three falls hands the bout over without touching the belt", () => {
+  const r = rig([q(20, "12 + 8")])
+  toPin(r.bout)
+  r.bout.fall.plates = { a: 5, b: 10, x: 2, y: 1, taps: 3 }
+  r.bout.tap("b")
+  r.bout.tap("b")
+  const platesAfterEscape = r.bout.beltPlates
+  const firstChallenger = r.bout.challenger
+  for (let round = 0; round < SLAP_COUNT; round++) {
+    toLockup(r.bout)
+    toPin(r.bout)
+    run(r.bout, r.bout.fall.slapPeriod * SLAP_COUNT + 0.05)
+  }
+  assert.notEqual(r.bout.challenger, firstChallenger)
+  assert.equal(r.bout.beltPlates, platesAfterEscape)
+  assert.equal(r.bout.lost, 0)
+})
+
+test("the crowd never touches a rule: heat moves, the count does not", () => {
+  const r = rig([q(20, "12 + 8")])
+  toPin(r.bout)
+  const period = r.bout.fall.slapPeriod
+  r.bout.fall.plates = { a: 5, b: 10, x: 2, y: 1, taps: 3 }
+  const before = r.bout.heat
+  r.bout.tap("b")
+  r.bout.tap("b")
+  assert.ok(r.bout.heat > before)
+  toLockup(r.bout)
+  toPin(r.bout)
+  assert.equal(r.bout.fall.slapPeriod, period, "heat must not change the clock")
+})
+
+test("a tap during the lockup skips the takedown and is never spent", () => {
+  const r = rig([q(20, "12 + 8")])
+  assert.equal(r.bout.phase, "lockup")
+  r.bout.tap("a")
+  assert.equal(r.bout.fall.load, 0)
+  r.bout.tick(0.001)
+  assert.equal(r.bout.phase, "pin")
+})
+
+test("haptics fire on every slap and on the escape", () => {
+  const r = rig([q(20, "12 + 8")])
+  toPin(r.bout)
+  r.bout.fall.plates = { a: 5, b: 10, x: 2, y: 1, taps: 3 }
+  run(r.bout, r.bout.fall.slapPeriod + 0.02)
+  assert.ok(r.haptics.includes("medium"))
+  r.bout.tap("b")
+  r.bout.tap("b")
+  assert.ok(r.haptics.includes("success"))
+})
+
+test("fallsToBeat grows with wins and then levels off", () => {
+  assert.equal(fallsToBeat(0), 4)
+  assert.ok(fallsToBeat(3) > fallsToBeat(0))
+  assert.equal(fallsToBeat(9), fallsToBeat(4))
+})
+
+test("losing a bout never raises the price of the next one", () => {
+  const r = rig([q(20, "12 + 8")])
+  const before = r.bout.toBeat
+  // Drop three straight falls: a new challenger walks out.
+  for (let round = 0; round < SLAP_COUNT; round++) {
+    toPin(r.bout)
+    run(r.bout, r.bout.fall.slapPeriod * SLAP_COUNT + 0.05)
+    toLockup(r.bout)
+  }
+  assert.equal(r.bout.challengersBeaten, 0)
+  assert.equal(r.bout.toBeat, before, "the demand escalated on a defeat")
+})
+
+test("an over-the-target mal-rule total is named rather than merely refused", () => {
+  // Every mal-rule this domain has for a *difference* comes out larger than the
+  // difference, so the over-the-target case is the only diagnosis a subtraction
+  // fall can ever produce. 52 − 27 is 25; 35 is smaller-from-larger.
+  const named = rig([q(25, "52 − 27", ["35", "79"])])
+  toPin(named.bout)
+  named.bout.fall.plates = { a: 5, b: 30, x: 5, y: 0, taps: 5 }
+  named.bout.tap("a") // 5
+  assert.equal(named.bout.phase, "pin")
+  named.bout.tap("b") // 35 — over, and it is a value with a name
+  assert.equal(named.bout.phase, "pinfall")
+  const hit = named.events.filter((e) => e.kind === "pinfall")
+  assert.equal(hit.length, 1)
+  assert.ok(hit[0]?.kind === "pinfall" && hit[0].reason === "overshot" && hit[0].diagnosed)
+  assert.equal(named.reports[0]?.answered, "35", "the diagnosis is what gets reported")
+
+  // And an overshoot onto a value nobody produces is not dressed up as one.
+  const plain = rig([q(25, "52 − 27", ["35", "79"])])
+  toPin(plain.bout)
+  plain.bout.fall.plates = { a: 5, b: 10, x: 1, y: 2, taps: 3 }
+  plain.bout.tap("b") // 10
+  plain.bout.tap("b") // 20
+  plain.bout.tap("b") // 30 — over, unnamed
+  const miss = plain.events.find((e) => e.kind === "pinfall")
+  assert.ok(miss && miss.kind === "pinfall" && miss.diagnosed === false)
+  assert.equal(plain.reports[0]?.answered, "30")
+})

--- a/dynawalla/games/foundry/src/test/feel.test.ts
+++ b/dynawalla/games/foundry/src/test/feel.test.ts
@@ -1,0 +1,147 @@
+// The response layer, and the reduced-motion branch.
+//
+// Reduced motion is a branch and not a degradation: the game still says
+// everything it said, it just says it without travel. So the assertion is not
+// "the numbers are smaller" — it is that every motion channel is exactly zero
+// while the information channels are untouched.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Feel } from "../core/feel.ts"
+import { Rng } from "../core/rng.ts"
+import { computeLayout, matHalfWidth } from "../render/layout.ts"
+
+test("reduced motion zeroes every motion channel", () => {
+  const feel = new Feel({ reducedMotion: true })
+  feel.addTrauma(1)
+  feel.kick(1, 1, 40)
+  feel.punch(0.5)
+  feel.hitstop(400)
+  feel.slowmo(0.2, 400)
+  feel.requestFlash(1, "#ffffff")
+  const advanced = feel.advance(16, 16)
+  assert.equal(advanced, 16, "a hitstop must never be served under reduced motion")
+  assert.equal(feel.shakeX, 0)
+  assert.equal(feel.shakeY, 0)
+  assert.equal(feel.scale, 1)
+  assert.equal(feel.flashAlpha, 0)
+  assert.equal(feel.timeScale(), 1)
+})
+
+test("a hitstop stops the simulation and then gives the time back", () => {
+  const feel = new Feel({ reducedMotion: false })
+  feel.hitstop(50)
+  assert.equal(feel.advance(16, 16), 0)
+  assert.equal(feel.advance(16, 32), 0)
+  assert.equal(feel.advance(16, 48), 0)
+  assert.equal(feel.advance(16, 64), 0)
+  assert.ok(feel.advance(16, 80) > 0, "the freeze has to end")
+})
+
+test("flashes are rate-limited rather than queued, and capped", () => {
+  const feel = new Feel({ reducedMotion: false })
+  feel.advance(16, 1000)
+  feel.requestFlash(1, "#ffffff")
+  feel.advance(1, 1001)
+  const first = feel.flashAlpha
+  assert.ok(first <= 0.42, `a flash reached ${first}`)
+  // A second request 1ms later must not stack into a strobe.
+  feel.requestFlash(1, "#ffffff")
+  feel.advance(1, 1002)
+  assert.ok(feel.flashAlpha <= 0.42)
+})
+
+test("trauma and kick decay to nothing on their own", () => {
+  const feel = new Feel({ reducedMotion: false })
+  feel.addTrauma(1)
+  feel.kick(0, -1, 30)
+  for (let i = 0; i < 200; i++) feel.advance(16, 1000 + i * 16)
+  assert.ok(Math.abs(feel.shakeX) < 0.01)
+  assert.ok(Math.abs(feel.shakeY) < 0.01)
+  assert.equal(feel.trauma, 0)
+})
+
+test("shake never calls Math.random, so a replay is a replay", () => {
+  const a = new Feel({ reducedMotion: false })
+  const b = new Feel({ reducedMotion: false })
+  a.addTrauma(1)
+  b.addTrauma(1)
+  const trail = (f: Feel) =>
+    Array.from({ length: 30 }, (_, i) => {
+      f.advance(16, i * 16)
+      return f.shakeX.toFixed(6)
+    })
+  assert.deepEqual(trail(a), trail(b))
+})
+
+test("the layout keeps the pedals enormous at every size the app runs at", () => {
+  for (const [w, h] of [
+    [320, 568],
+    [390, 844],
+    [768, 1024],
+    [1024, 768],
+    [1366, 1024],
+  ] as const) {
+    const l = computeLayout(w, h)
+    assert.ok(l.padH >= 150, `${w}×${h} gave a ${l.padH}px pedal band`)
+    assert.ok(l.padTop > l.matTop, `${w}×${h} put the pedals above the mat`)
+    assert.ok(l.matBottom > l.matTop, `${w}×${h} inverted the mat`)
+    assert.ok(l.matBottom <= l.padTop, `${w}×${h} overlapped the mat and the pedals`)
+    assert.ok(l.boardY + l.boardH < l.horizon, `${w}×${h} put the board under the crowd`)
+    assert.ok(l.boardW <= w, `${w}×${h} ran the board off the screen`)
+  }
+})
+
+test("the mat narrows towards the far ropes and never inverts", () => {
+  const l = computeLayout(768, 1024)
+  const far = matHalfWidth(l, l.matTop)
+  const near = matHalfWidth(l, l.matBottom)
+  assert.ok(near > far, "the near edge of a ring is the wider one")
+  assert.ok(far > 0)
+  // Outside the mat the value is clamped rather than extrapolated to nonsense.
+  assert.equal(matHalfWidth(l, l.matTop - 500), far)
+  assert.equal(matHalfWidth(l, l.matBottom + 500), near)
+})
+
+test("the seeded rng is deterministic and stays in range", () => {
+  const a = new Rng(99)
+  const b = new Rng(99)
+  for (let i = 0; i < 500; i++) {
+    const v = a.next()
+    assert.equal(v, b.next())
+    assert.ok(v >= 0 && v < 1)
+  }
+  const r = new Rng(1)
+  for (let i = 0; i < 500; i++) {
+    const n = r.int(3, 7)
+    assert.ok(Number.isInteger(n) && n >= 3 && n <= 7)
+  }
+  assert.equal(new Rng(0).next(), new Rng(0).next())
+})
+
+test("the particle pool honours the quality tier's ceiling", async () => {
+  const { Particles, KIND_SPARK } = await import("../render/particles.ts")
+  const { TIERS } = await import("../core/tiers.ts")
+  const parts = new Particles()
+
+  parts.setLimit(TIERS.ultra.particles)
+  parts.burst(KIND_SPARK, 0, 0, 3000, 100, 0, 1, 2)
+  assert.ok(parts.count <= TIERS.ultra.particles)
+  const atUltra = parts.count
+  assert.ok(atUltra > TIERS.low.particles, "the ultra tier should be holding more than low allows")
+
+  // A downgrade has to take effect on the next frame, not once the burst that
+  // was already in flight happens to expire.
+  parts.setLimit(TIERS.low.particles)
+  assert.ok(
+    parts.count <= TIERS.low.particles,
+    `${parts.count} particles survived a downgrade to ${TIERS.low.particles}`,
+  )
+
+  // And the pool keeps working at the smaller ceiling.
+  parts.burst(KIND_SPARK, 0, 0, 3000, 100, 0, 1, 2)
+  assert.ok(parts.count <= TIERS.low.particles)
+  parts.clear()
+  assert.equal(parts.count, 0)
+})

--- a/dynawalla/games/foundry/src/test/mount.test.ts
+++ b/dynawalla/games/foundry/src/test/mount.test.ts
@@ -1,0 +1,244 @@
+// A smoke test for the surface.
+//
+// `tsc` proves the draw calls type-check and the vite build proves the modules
+// resolve. Neither proves that a frame *runs* — a stale property, a function
+// renamed in `render/` and not in `mount.ts`, a value read before it is
+// assigned, all compile and all crash on the first frame in front of a child.
+//
+// So this mounts the real game against a canvas that records instead of paints,
+// drives several hundred frames through a lockup, a full three-count, a pinfall
+// and an escape, and asserts that nothing threw and that the world actually
+// moved. It is not a rendering test — there are no pixels to look at — it is a
+// test that the whole thing is wired to itself.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { mount } from "../contract.ts"
+import { createStubHost } from "../stubHost.ts"
+
+type Listener = (event: unknown) => void
+
+/** A 2D context that answers every call and records how much work it was asked for. */
+function fakeContext(counter: { calls: number; text: string[] }): CanvasRenderingContext2D {
+  const store = new Map<string, unknown>()
+  const noop = (name: string) =>
+    function (...args: unknown[]) {
+      counter.calls++
+      if (name === "fillText" && typeof args[0] === "string") counter.text.push(args[0])
+      // Gradients are the one call whose result is used, so everything returns
+      // something that can take a colour stop.
+      return { addColorStop() {} }
+    }
+  return new Proxy(
+    {},
+    {
+      get(_t, prop: string) {
+        if (store.has(prop)) return store.get(prop)
+        return noop(prop)
+      },
+      set(_t, prop: string, value) {
+        store.set(prop, value)
+        return true
+      },
+    },
+  ) as unknown as CanvasRenderingContext2D
+}
+
+type FakeElement = {
+  style: { cssText: string }
+  width: number
+  height: number
+  listeners: Map<string, Listener[]>
+  appendChild(child: unknown): void
+  remove(): void
+  addEventListener(type: string, fn: Listener): void
+  removeEventListener(type: string, fn: Listener): void
+  getBoundingClientRect(): { width: number; height: number; left: number; top: number }
+  getContext(): CanvasRenderingContext2D
+}
+
+function harness(size: { w: number; h: number }, counter: { calls: number; text: string[] }) {
+  const ctx = fakeContext(counter)
+  const make = (): FakeElement => {
+    const listeners = new Map<string, Listener[]>()
+    return {
+      style: { cssText: "" },
+      width: 0,
+      height: 0,
+      listeners,
+      appendChild() {},
+      remove() {},
+      addEventListener(type, fn) {
+        const list = listeners.get(type) ?? []
+        list.push(fn)
+        listeners.set(type, list)
+      },
+      removeEventListener(type, fn) {
+        listeners.set(type, (listeners.get(type) ?? []).filter((f) => f !== fn))
+      },
+      getBoundingClientRect: () => ({ width: size.w, height: size.h, left: 0, top: 0 }),
+      getContext: () => ctx,
+    }
+  }
+  const created: FakeElement[] = []
+  const doc = {
+    visibilityState: "visible",
+    listeners: new Map<string, Listener[]>(),
+    createElement() {
+      const el = make()
+      created.push(el)
+      return el
+    },
+    addEventListener(type: string, fn: Listener) {
+      const list = doc.listeners.get(type) ?? []
+      list.push(fn)
+      doc.listeners.set(type, list)
+    },
+    removeEventListener(type: string, fn: Listener) {
+      doc.listeners.set(type, (doc.listeners.get(type) ?? []).filter((f) => f !== fn))
+    },
+  }
+  return { host: make(), doc, created, ctx }
+}
+
+type Rig = ReturnType<typeof harness> & { frames: Array<(t: number) => void> }
+
+/**
+ * Install the browser globals `mount.ts` needs, run `body`, and take them back
+ * off again — including when `body` throws, which is the case this file exists
+ * to catch.
+ */
+function withBrowser(
+  size: { w: number; h: number },
+  counter: { calls: number; text: string[] },
+  body: (rig: Rig) => void,
+): void {
+  const rig = harness(size, counter)
+  const g = globalThis as Record<string, unknown>
+  const saved = new Map<string, PropertyDescriptor | undefined>()
+  const set = (key: string, value: unknown) => {
+    saved.set(key, Object.getOwnPropertyDescriptor(globalThis, key))
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value })
+  }
+  const frames: Array<(t: number) => void> = []
+  set("document", rig.doc)
+  set("devicePixelRatio", 2)
+  set("requestAnimationFrame", (fn: (t: number) => void) => {
+    frames.push(fn)
+    return frames.length
+  })
+  set("cancelAnimationFrame", () => {})
+  if (typeof g.addEventListener !== "function") set("addEventListener", () => {})
+  if (typeof g.removeEventListener !== "function") set("removeEventListener", () => {})
+
+  try {
+    body({ ...rig, frames })
+  } finally {
+    for (const [key, descriptor] of saved) {
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor)
+      else Reflect.deleteProperty(globalThis, key)
+    }
+  }
+}
+
+/** The canvas is the second element `mount` creates: the root div, then it. */
+function canvasOf(created: FakeElement[]): FakeElement {
+  const el = created[1]
+  if (!el) throw new Error("mount did not create a canvas")
+  return el
+}
+
+/** Run `n` frames at 60Hz, draining the rAF queue each time. */
+function pump(frames: Array<(t: number) => void>, n: number, from = 0): number {
+  let t = from
+  for (let i = 0; i < n; i++) {
+    const next = frames.pop()
+    frames.length = 0
+    if (!next) break
+    t += 16.7
+    next(t)
+  }
+  return t
+}
+
+for (const [w, h] of [
+  [320, 568],
+  [768, 1024],
+  [1366, 1024],
+] as const) {
+  test(`a whole bout renders without throwing at ${w}×${h}`, () => {
+    const counter = { calls: 0, text: [] as string[] }
+    const reports: Array<{ correct: boolean }> = []
+    withBrowser({ w, h }, counter, ({ host, frames, created, doc }) => {
+      const stub = createStubHost({
+        seed: 0x51ab,
+        reducedMotion: false,
+        onReport: (r) => reports.push(r),
+      })
+      const handle = mount(host as unknown as HTMLElement, stub)
+      const canvas = canvasOf(created)
+
+      // Long enough for the lockup, a full three-count, the pinfall beat and the
+      // next takedown — several times over.
+      let t = pump(frames, 900)
+      assert.ok(counter.calls > 5000, `only ${counter.calls} draw calls in 900 frames`)
+      assert.ok(counter.text.length > 0, "nothing was ever written on the board")
+
+      // And a tap goes all the way through the input handler into the rules.
+      const down = canvas.listeners.get("pointerdown")?.[0]
+      assert.ok(down, "no pointerdown listener was installed")
+      const before = counter.calls
+      for (let i = 0; i < 30; i++) {
+        down({ preventDefault() {}, clientX: i % 2 === 0 ? w * 0.25 : w * 0.75, clientY: h * 0.9 })
+        t = pump(frames, 12, t)
+      }
+      assert.ok(counter.calls > before)
+
+      // Backgrounding the tab must stop the world without stopping the loop.
+      doc.visibilityState = "hidden"
+      for (const fn of doc.listeners.get("visibilitychange") ?? []) fn({})
+      const paused = counter.calls
+      t = pump(frames, 60, t)
+      assert.equal(counter.calls, paused, "the count kept running while hidden")
+      doc.visibilityState = "visible"
+      for (const fn of doc.listeners.get("visibilitychange") ?? []) fn({})
+      t = pump(frames, 30, t)
+      assert.ok(counter.calls > paused, "the world never came back")
+
+      handle.unmount()
+      assert.equal(canvas.listeners.get("pointerdown")?.length ?? 0, 0)
+    })
+
+    // The frames were not just drawn, they were *played*: falls were lost to the
+    // count and, once the taps started, falls were escaped.
+    assert.ok(reports.length > 0, "no item was ever reported")
+    assert.ok(
+      reports.some((r) => !r.correct),
+      "the count never ran out",
+    )
+    assert.ok(
+      reports.some((r) => r.correct),
+      "thirty taps never produced a single exact total",
+    )
+  })
+}
+
+test("the reduced-motion branch renders the same bout with no particles", () => {
+  const counter = { calls: 0, text: [] as string[] }
+  withBrowser({ w: 768, h: 1024 }, counter, ({ host, frames, created }) => {
+    const stub = createStubHost({ seed: 0x51ab, reducedMotion: true })
+    const handle = mount(host as unknown as HTMLElement, stub)
+    let t = pump(frames, 300)
+    const down = canvasOf(created).listeners.get("pointerdown")?.[0] as Listener
+    for (let i = 0; i < 20; i++) {
+      down({ preventDefault() {}, clientX: 200, clientY: 900 })
+      t = pump(frames, 10, t)
+    }
+    // The information is all still there — the board, the bar and the plates are
+    // written every frame — it just arrives without travel.
+    assert.ok(counter.text.length > 0)
+    assert.ok(counter.calls > 3000)
+    handle.unmount()
+  })
+})

--- a/dynawalla/games/foundry/src/test/plates.test.ts
+++ b/dynawalla/games/foundry/src/test/plates.test.ts
@@ -1,0 +1,183 @@
+// The escape is the mathematics, so this is the file that has to hold.
+//
+// Every case here is exhaustive over a range rather than sampled, and every
+// assertion is on integers. Nothing in this file calls `Math.random`: the two
+// places that need randomness take a seeded `Rng`, constructed inside the test
+// with a literal seed, so a green run is a fact and not a coincidence.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import {
+  choosePlates,
+  gcd,
+  MAX_TAPS,
+  minTapsFor,
+  reachable,
+  representations,
+  scorePair,
+} from "../game/plates.ts"
+
+/** Brute-force truth for `reachable`, written the slow obvious way on purpose. */
+function bruteReachable(remaining: number, a: number, b: number): boolean {
+  for (let x = 0; x * a <= remaining; x++) {
+    for (let y = 0; x * a + y * b <= remaining; y++) {
+      if (x * a + y * b === remaining) return true
+    }
+  }
+  return remaining === 0
+}
+
+test("gcd is the greatest common divisor, including the zero cases", () => {
+  assert.equal(gcd(12, 18), 6)
+  assert.equal(gcd(7, 5), 1)
+  assert.equal(gcd(0, 9), 9)
+  assert.equal(gcd(9, 0), 9)
+  assert.equal(gcd(-12, 18), 6)
+})
+
+test("reachable agrees with brute force over every small pair and remainder", () => {
+  for (let a = 1; a <= 9; a++) {
+    for (let b = a + 1; b <= 13; b++) {
+      for (let rem = 0; rem <= 90; rem++) {
+        assert.equal(
+          reachable(rem, a, b),
+          bruteReachable(rem, a, b),
+          `reachable(${rem}, ${a}, ${b}) disagreed with brute force`,
+        )
+      }
+    }
+  }
+})
+
+test("reachable refuses non-integers and negatives rather than guessing", () => {
+  assert.equal(reachable(-1, 3, 5), false)
+  assert.equal(reachable(2.5, 3, 5), false)
+  assert.equal(reachable(0, 3, 5), true)
+  assert.equal(reachable(10, 0, 5), false)
+})
+
+test("the canonical dead end: 24 from 4s and 7s, three sevens deep", () => {
+  assert.equal(reachable(24, 4, 7), true)
+  // 7 + 7 + 7 = 21 leaves three, and nothing makes three out of fours and sevens.
+  assert.equal(reachable(3, 4, 7), false)
+  // 7 + 7 = 14 leaves ten, which is also dead: 4 and 8 straddle it.
+  assert.equal(reachable(10, 4, 7), false)
+  // 4 + 4 + 4 = 12 leaves twelve, which is three more fours.
+  assert.equal(reachable(12, 4, 7), true)
+})
+
+test("minTapsFor returns the shortest escape and nothing shorter exists", () => {
+  assert.equal(minTapsFor(0, 3, 5), 0)
+  assert.equal(minTapsFor(26, 3, 5), 6) // 5+5+5+5+3+3
+  assert.equal(minTapsFor(15, 3, 5), 3) // 5+5+5 beats five threes
+  assert.equal(minTapsFor(3, 4, 7), null)
+  for (let target = 1; target <= 120; target++) {
+    const best = minTapsFor(target, 3, 7)
+    if (best === null) {
+      assert.equal(bruteReachable(target, 3, 7), false)
+      continue
+    }
+    let found = Infinity
+    for (const { x, y } of representations(target, 3, 7, 60)) found = Math.min(found, x + y)
+    assert.equal(best, found, `minTapsFor(${target}, 3, 7)`)
+  }
+})
+
+test("representations are exact, integral, and inside the tap budget", () => {
+  for (const [target, a, b] of [
+    [26, 3, 5],
+    [48, 7, 12],
+    [100, 6, 25],
+  ] as const) {
+    const reps = representations(target, a, b)
+    assert.ok(reps.length > 0, `no representation of ${target} from ${a}/${b}`)
+    for (const { x, y } of reps) {
+      assert.ok(Number.isInteger(x) && Number.isInteger(y))
+      assert.ok(x >= 0 && y >= 0)
+      assert.equal(a * x + b * y, target)
+      assert.ok(x + y <= MAX_TAPS)
+    }
+  }
+})
+
+test("scorePair encodes the design of the curve, not a hand-tuned constant", () => {
+  // A round heavy plate beats an awkward one at the same tap count.
+  assert.ok(scorePair(54, 7, 20, 2, 2) < scorePair(48, 7, 17, 2, 2))
+  // Five taps is the sweet spot; nine is a drum solo.
+  assert.ok(scorePair(74, 7, 20, 2, 3) < scorePair(129, 7, 20, 4, 5))
+  // A target the heavy plate reaches on its own in three taps is a trap: the
+  // fastest escape would ignore half the equipment.
+  assert.ok(scorePair(74, 7, 20, 2, 3) < scorePair(60, 7, 20, 2, 3))
+})
+
+test("the chooser avoids the single-escape cliff", () => {
+  // 24 from 4s and 7s has exactly one way out — six fours — because
+  // 7y ≡ 24 (mod 4) forces y to zero. The first tap of the heavy plate is
+  // fatal, which is a true fact about the coin problem and a cruel thing to
+  // hand a child under a three-count. Over a hundred seeds it must never come
+  // up, and every pair that does come up must offer a second route.
+  for (let seed = 1; seed <= 120; seed++) {
+    const p = choosePlates(24, new Rng(seed), {})
+    assert.ok(!(p.a === 4 && p.b === 7), `seed ${seed} cut the cliff pair`)
+    assert.ok(
+      representations(24, p.a, p.b).length >= 2,
+      `seed ${seed} cut a one-escape pair: ${p.a}/${p.b}`,
+    )
+  }
+})
+
+test("choosePlates always cuts an exact, escapable pair over the whole target range", () => {
+  for (let target = 1; target <= 400; target++) {
+    for (const pressure of [0, 0.5, 1]) {
+      const rng = new Rng(0x1234 + target)
+      const p = choosePlates(target, rng, { pressure })
+      assert.ok(Number.isInteger(p.a) && Number.isInteger(p.b), `non-integer plate for ${target}`)
+      assert.ok(Number.isInteger(p.x) && Number.isInteger(p.y), `non-integer taps for ${target}`)
+      assert.ok(p.a >= 1 && p.b > p.a, `plates not ordered for ${target}: ${p.a}/${p.b}`)
+      assert.equal(p.a * p.x + p.b * p.y, target, `pair does not reach ${target}`)
+      assert.equal(p.taps, p.x + p.y)
+      assert.ok(p.taps <= MAX_TAPS, `escape from ${target} costs ${p.taps} taps`)
+      assert.ok(reachable(target, p.a, p.b), `${target} unreachable from its own plates`)
+    }
+  }
+})
+
+test("above a trivial target both plates are always part of the escape", () => {
+  for (let target = 5; target <= 400; target++) {
+    const rng = new Rng(0x99 + target)
+    const p = choosePlates(target, rng, {})
+    assert.ok(p.x >= 1 && p.y >= 1, `${target} produced a one-plate escape: ${p.x}/${p.y}`)
+  }
+})
+
+test("the ladder's largest column sums still get a playable pair", () => {
+  // `dw.add.regroup.add-multidigit` tops out around four digits, and
+  // `4,003 − 87` is a real item. A pair must exist for every one of them.
+  for (const target of [1273, 1998, 3916, 9997, 19998]) {
+    const rng = new Rng(target)
+    const p = choosePlates(target, rng, { pressure: 1 })
+    assert.equal(p.a * p.x + p.b * p.y, target)
+    assert.ok(p.taps <= MAX_TAPS)
+    assert.ok(p.x >= 1 && p.y >= 1)
+  }
+})
+
+test("choosePlates is deterministic for a given seed and target", () => {
+  for (const target of [24, 73, 156]) {
+    const first = choosePlates(target, new Rng(0xabcdef), {})
+    const second = choosePlates(target, new Rng(0xabcdef), {})
+    assert.deepEqual(first, second)
+  }
+})
+
+test("pressure lengthens the escape rather than changing what is true", () => {
+  let easy = 0
+  let hard = 0
+  for (let target = 20; target <= 200; target++) {
+    easy += choosePlates(target, new Rng(target), { pressure: 0 }).taps
+    hard += choosePlates(target, new Rng(target), { pressure: 1 }).taps
+  }
+  assert.ok(hard > easy, `pressure did not lengthen escapes: ${easy} vs ${hard}`)
+})

--- a/dynawalla/games/foundry/src/test/reaction.test.ts
+++ b/dynawalla/games/foundry/src/test/reaction.test.ts
@@ -1,0 +1,83 @@
+// The two invariants `docs/EXPERIENCE_DESIGN.md` states as unit tests, plus the
+// one this game adds because a wrestling pinfall is the exact thing that tempts
+// a designer to break them.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  energy,
+  REACTION_INPUT_KEYS,
+  REACTIONS,
+  reactionTier,
+  type ReactionInput,
+} from "../game/reaction.ts"
+
+test("energy(SLIP) < energy(SEAT): being wrong is never the better show", () => {
+  assert.ok(energy(REACTIONS[-1]) < energy(REACTIONS[0]))
+  // And the ladder above SEAT is monotone, so a bigger tier is a bigger event.
+  assert.ok(energy(REACTIONS[0]) < energy(REACTIONS[1]))
+  assert.ok(energy(REACTIONS[1]) < energy(REACTIONS[2]))
+  assert.ok(energy(REACTIONS[2]) < energy(REACTIONS[3]))
+})
+
+test("the pinfall is quieter and emptier than every escape", () => {
+  // Not *shorter*: EXPERIENCE_DESIGN.md gives SLIP 260ms against SEAT's 200ms,
+  // because a body settling takes longer to read than a gear tooth clicking.
+  // What it must never be is louder or busier.
+  assert.equal(REACTIONS[-1].particles, 0, "failure emits nothing")
+  for (const tier of [0, 1, 2, 3] as const) {
+    assert.ok(REACTIONS[-1].peakGain < REACTIONS[tier].peakGain)
+    assert.ok(REACTIONS[-1].elements < REACTIONS[tier].elements)
+  }
+})
+
+test("nothing resembling a run length is an input to the tier", () => {
+  assert.deepEqual([...REACTION_INPUT_KEYS], ["difficulty", "minTaps", "taps", "repaired"])
+  for (const key of REACTION_INPUT_KEYS) {
+    assert.ok(
+      !/streak|combo|chain|run|consecutive|multiplier/i.test(key),
+      `"${key}" is a run-length input and this product bans them`,
+    )
+  }
+  // The signature takes exactly one argument, so there is nowhere to smuggle a
+  // streak in as a second parameter either.
+  assert.equal(reactionTier.length, 1)
+})
+
+test("the tier is a pure function of the fall in front of it", () => {
+  const input: ReactionInput = { difficulty: 0.5, minTaps: 5, taps: 5, repaired: false }
+  const first = reactionTier(input)
+  for (let i = 0; i < 50; i++) assert.equal(reactionTier(input), first)
+})
+
+test("escalation is on difficulty and on length of decomposition", () => {
+  const easy = reactionTier({ difficulty: 0, minTaps: 2, taps: 2, repaired: false })
+  const mid = reactionTier({ difficulty: 0.5, minTaps: 5, taps: 5, repaired: false })
+  const hard = reactionTier({ difficulty: 0.9, minTaps: 7, taps: 7, repaired: false })
+  assert.equal(easy, 0)
+  assert.ok(mid > easy)
+  assert.ok(hard > mid)
+})
+
+test("repairing a mal-rule is worth a tier-2 by itself", () => {
+  const plain = reactionTier({ difficulty: 0, minTaps: 3, taps: 3, repaired: false })
+  const repaired = reactionTier({ difficulty: 0, minTaps: 3, taps: 3, repaired: true })
+  assert.ok(repaired >= 2)
+  assert.ok(repaired > plain)
+})
+
+test("a wasteful escape is still an escape, it just does not climb", () => {
+  const tight = reactionTier({ difficulty: 0.5, minTaps: 4, taps: 4, repaired: false })
+  const loose = reactionTier({ difficulty: 0.5, minTaps: 4, taps: 8, repaired: false })
+  assert.ok(loose <= tight)
+  assert.ok(loose >= 0, "an exact total is never punished with a slip")
+})
+
+test("difficulty outside 0..1 is clamped rather than believed", () => {
+  const wild = reactionTier({ difficulty: 40, minTaps: 9, taps: 9, repaired: true })
+  const top = reactionTier({ difficulty: 1, minTaps: 9, taps: 9, repaired: true })
+  assert.equal(wild, top)
+  assert.ok(top <= 3)
+  assert.ok(reactionTier({ difficulty: -5, minTaps: 2, taps: 2, repaired: false }) >= 0)
+})

--- a/dynawalla/games/foundry/src/test/save.test.ts
+++ b/dynawalla/games/foundry/src/test/save.test.ts
@@ -1,0 +1,105 @@
+// The belt has to survive the one environment it actually runs in: a pack
+// frame, on an opaque origin, where every `localStorage` access throws.
+
+import assert from "node:assert/strict"
+import { afterEach, test } from "node:test"
+
+import { loadBelt, recordBelt, resetBeltForTest } from "../game/save.ts"
+
+const original = Object.getOwnPropertyDescriptor(globalThis, "localStorage")
+
+/** Take `localStorage` off the global entirely — a real environment for a pack. */
+function removeStorage(): void {
+  Reflect.deleteProperty(globalThis, "localStorage")
+}
+
+function installStorage(impl: unknown): void {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    get() {
+      return impl
+    },
+  })
+}
+
+function restore(): void {
+  if (original) Object.defineProperty(globalThis, "localStorage", original)
+  else removeStorage()
+}
+
+afterEach(() => {
+  restore()
+  resetBeltForTest()
+})
+
+/** A storage that throws on every access, the way a pack frame's does. */
+function hostile(): unknown {
+  return new Proxy(
+    {},
+    {
+      get() {
+        throw new DOMException("The operation is insecure.", "SecurityError")
+      },
+    },
+  )
+}
+
+function working(): Storage {
+  const map = new Map<string, string>()
+  return {
+    get length() {
+      return map.size
+    },
+    clear: () => map.clear(),
+    getItem: (k: string) => map.get(k) ?? null,
+    key: (i: number) => Array.from(map.keys())[i] ?? null,
+    removeItem: (k: string) => {
+      map.delete(k)
+    },
+    setItem: (k: string, v: string) => {
+      map.set(k, v)
+    },
+  } as Storage
+}
+
+test("a storage that throws on every access never breaks the belt", () => {
+  installStorage(hostile())
+  assert.deepEqual(loadBelt(), { best: 0, beaten: 0 })
+  assert.deepEqual(recordBelt(9, 2), { best: 9, beaten: 2 })
+  // And the in-memory mirror is the source of truth for the rest of the
+  // session, which is the whole point: inside a pack the disk is never there.
+  assert.deepEqual(loadBelt(), { best: 9, beaten: 2 })
+})
+
+test("the belt is monotone — nothing can take a plate off it", () => {
+  installStorage(working())
+  recordBelt(12, 3)
+  assert.deepEqual(recordBelt(4, 1), { best: 12, beaten: 3 })
+  assert.deepEqual(recordBelt(0, 0), { best: 12, beaten: 3 })
+  assert.deepEqual(recordBelt(13, 3), { best: 13, beaten: 3 })
+})
+
+test("a record written in one session is read back in the next", () => {
+  const store = working()
+  installStorage(store)
+  recordBelt(7, 1)
+  resetBeltForTest()
+  assert.deepEqual(loadBelt(), { best: 7, beaten: 1 })
+})
+
+test("a corrupt record is ignored rather than trusted", () => {
+  const store = working()
+  store.setItem("dynawalla.foundry.belt.v1", "{not json")
+  installStorage(store)
+  assert.deepEqual(loadBelt(), { best: 0, beaten: 0 })
+
+  resetBeltForTest()
+  store.setItem("dynawalla.foundry.belt.v1", JSON.stringify({ best: "lots", beaten: 1.5 }))
+  assert.deepEqual(loadBelt(), { best: 0, beaten: 0 })
+})
+
+test("no storage object at all is a supported environment", () => {
+  removeStorage()
+  assert.deepEqual(loadBelt(), { best: 0, beaten: 0 })
+  assert.deepEqual(recordBelt(3, 0), { best: 3, beaten: 0 })
+})

--- a/dynawalla/games/foundry/src/test/stubHost.test.ts
+++ b/dynawalla/games/foundry/src/test/stubHost.test.ts
@@ -1,0 +1,200 @@
+// The stub host has to be as honest as the runtime it stands in for, because
+// every hour of development happens against it. If it deals a float, or a
+// distractor no child would ever produce, the game is being tuned against a
+// fiction.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  borrowAcrossZero,
+  carryDropped,
+  createStubHost,
+  smallerFromLarger,
+  wrongOperation,
+} from "../stubHost.ts"
+
+// The reference case is the one `packs/shared/curriculum/src/malrules/columnOp.ts`
+// puts in its own docblock, because the program has confused these two rules
+// once already.
+test("5001 − 2798 separates the two subtraction rules exactly as the curriculum does", () => {
+  assert.equal(5001 - 2798, 2203)
+  assert.equal(smallerFromLarger(5001, 2798), 3797) // |5−2| |0−7| |0−9| |1−8|
+  assert.equal(borrowAcrossZero(5001, 2798), 3203) // the thousand never given up
+})
+
+test("carryDropped adds every column and writes no carry", () => {
+  assert.equal(carryDropped(27, 15), 32) // 7+5→2, 2+1→3
+  assert.equal(carryDropped(456, 789), 135)
+  // Nothing carries, so the rule is the correct procedure and does not apply.
+  assert.equal(carryDropped(11, 11), null)
+})
+
+test("smallerFromLarger takes the smaller digit from the larger, every column", () => {
+  assert.equal(smallerFromLarger(52, 27), 35)
+  assert.equal(smallerFromLarger(403, 87), 484) // |3−7|, |0−8|, |4−0|
+  // No column needs regrouping, so the bug and the correct procedure coincide.
+  assert.equal(smallerFromLarger(58, 27), null)
+})
+
+test("borrowAcrossZero turns the zeros into nines and never pays for them", () => {
+  // 403 − 87 is 316. The bug writes 416: the four is never decremented.
+  assert.equal(borrowAcrossZero(403, 87), 416)
+  // 1002 − 5 is 997; the bug writes 1997.
+  assert.equal(borrowAcrossZero(1002, 5), 1997)
+  // With a non-zero digit to borrow from, this procedure decrements correctly —
+  // it *is* the correct procedure, so it does not apply. 61 − 28 = 33 is not a
+  // distractor anybody should be shown.
+  assert.equal(borrowAcrossZero(61, 28), null)
+  assert.equal(borrowAcrossZero(58, 27), null)
+})
+
+test("wrongOperation is named for what it is and is not dressed as a mal-rule", () => {
+  assert.equal(wrongOperation("add", 27, 15), 12)
+  assert.equal(wrongOperation("sub", 52, 27), 79)
+})
+
+test("every served question is exact integer arithmetic, end to end", () => {
+  const host = createStubHost({ seed: 0xc0ffee })
+  for (let i = 0; i < 400; i++) {
+    const q = host.next()
+    const answer = Number(q.answer)
+    assert.ok(Number.isInteger(answer), `non-integer answer "${q.answer}"`)
+    assert.ok(answer >= 1, `non-positive answer "${q.answer}" from "${q.prompt}"`)
+    assert.equal(String(answer), q.answer, "an answer must be its own canonical string")
+
+    const match = /^(\d+) ([+−]) (\d+)$/.exec(q.prompt)
+    assert.ok(match, `unparseable prompt "${q.prompt}"`)
+    const a = Number(match[1])
+    const b = Number(match[3])
+    assert.equal(match[2] === "+" ? a + b : a - b, answer, `prompt "${q.prompt}" ≠ ${q.answer}`)
+
+    for (const d of q.distractors) {
+      const v = Number(d)
+      assert.ok(Number.isInteger(v), `non-integer distractor "${d}"`)
+      assert.notEqual(v, answer, "a distractor must not be the answer")
+      assert.equal(String(v), d)
+    }
+    assert.equal(new Set(q.distractors).size, q.distractors.length, "duplicate distractor")
+    assert.ok(q.difficulty >= 0 && q.difficulty <= 1, "difficulty must be normalised")
+  }
+})
+
+test("distractors are mal-rule outputs, not near-misses", () => {
+  const host = createStubHost({ seed: 0x1234 })
+  let offByOne = 0
+  let explained = 0
+  let total = 0
+  for (let i = 0; i < 300; i++) {
+    const q = host.next()
+    const match = /^(\d+) ([+−]) (\d+)$/.exec(q.prompt)
+    assert.ok(match)
+    const a = Number(match[1])
+    const b = Number(match[3])
+    const answer = Number(q.answer)
+    const rules = (
+      match[2] === "+"
+        ? [carryDropped(a, b), wrongOperation("add", a, b)]
+        : [smallerFromLarger(a, b), borrowAcrossZero(a, b), wrongOperation("sub", a, b)]
+    ).filter((v) => v !== null)
+    for (const d of q.distractors) {
+      total++
+      const v = Number(d)
+      if (Math.abs(v - answer) === 1) offByOne++
+      if (rules.includes(v)) explained++
+    }
+  }
+  assert.ok(total > 0)
+  assert.equal(explained, total, "every distractor must be the output of a named mal-rule")
+  // An off-by-one can *happen* — some mal-rules land next door — but it must be
+  // a consequence, never the recipe.
+  assert.ok(offByOne / total < 0.1, `${offByOne}/${total} distractors were off-by-one`)
+})
+
+test("no distractor is a fixed offset from the answer", () => {
+  // The failure this guards against is a stub that computes a shortcut off the
+  // correct answer instead of running a buggy procedure. A rule that did would
+  // show the *same* gap on every item it fired on.
+  const host = createStubHost({ seed: 0x5150 })
+  const gaps = new Map<number, number>()
+  let total = 0
+  for (let i = 0; i < 400; i++) {
+    const q = host.next()
+    const answer = Number(q.answer)
+    for (const d of q.distractors) {
+      total++
+      const gap = Number(d) - answer
+      gaps.set(gap, (gaps.get(gap) ?? 0) + 1)
+    }
+  }
+  let worst = 0
+  for (const n of gaps.values()) worst = Math.max(worst, n)
+  assert.ok(
+    worst / total < 0.25,
+    `one gap accounted for ${worst}/${total} distractors — that is a shortcut, not a procedure`,
+  )
+})
+
+test("the same seed is the same card, forever", () => {
+  const a = createStubHost({ seed: 42 })
+  const b = createStubHost({ seed: 42 })
+  const c = createStubHost({ seed: 43 })
+  const from = (h: ReturnType<typeof createStubHost>) =>
+    Array.from({ length: 60 }, () => {
+      const q = h.next()
+      return `${q.prompt}=${q.answer}|${q.distractors.join(",")}`
+    })
+  assert.deepEqual(from(a), from(b))
+  assert.notDeepEqual(from(createStubHost({ seed: 42 })), from(c))
+})
+
+test("the ladder walks from two-digit sums to four-digit borrows", () => {
+  const host = createStubHost({ seed: 7 })
+  const first = host.next()
+  assert.equal(first.difficulty, 0)
+  let last = first
+  for (let i = 0; i < 200; i++) last = host.next()
+  assert.ok(last.difficulty > 0.5, "the ladder never climbed")
+  assert.ok(last.difficulty <= 1)
+})
+
+test("a pinned level serves that rung and only that rung", () => {
+  for (const level of [0, 3, 7]) {
+    const host = createStubHost({ seed: 5, level })
+    for (let i = 0; i < 40; i++) assert.equal(host.next().difficulty, level / 8)
+  }
+})
+
+test("the no-regroup rungs really do not regroup", () => {
+  const host = createStubHost({ seed: 0xbeef, level: 0 })
+  for (let i = 0; i < 200; i++) {
+    const q = host.next()
+    const match = /^(\d+) ([+−]) (\d+)$/.exec(q.prompt) as RegExpExecArray
+    const a = Number(match[1])
+    const b = Number(match[3])
+    if (match[2] === "+") {
+      // No column may sum past nine.
+      for (let p = 1; p <= 1000; p *= 10) {
+        assert.ok((Math.floor(a / p) % 10) + (Math.floor(b / p) % 10) <= 9, q.prompt)
+      }
+    } else {
+      // No column may need to borrow.
+      for (let p = 1; p <= 1000; p *= 10) {
+        assert.ok(Math.floor(a / p) % 10 >= Math.floor(b / p) % 10, q.prompt)
+      }
+    }
+  }
+})
+
+test("prefersReducedMotion is honoured when it is stated", () => {
+  assert.equal(createStubHost({ reducedMotion: true }).prefersReducedMotion(), true)
+  assert.equal(createStubHost({ reducedMotion: false }).prefersReducedMotion(), false)
+})
+
+test("report and haptic observers are called and never throw without a device", () => {
+  const seen: string[] = []
+  const host = createStubHost({ onReport: (r) => seen.push(r.answered), onHaptic: (k) => seen.push(k) })
+  host.report({ questionId: "x", correct: true, ms: 10, answered: "24" })
+  host.haptic("success")
+  assert.deepEqual(seen, ["24", "success"])
+})

--- a/dynawalla/games/foundry/tsconfig.json
+++ b/dynawalla/games/foundry/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": false,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/dynawalla/games/foundry/vite.config.ts
+++ b/dynawalla/games/foundry/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite"
+
+// The game is a library that mounts into a host element. `npm run dev` serves
+// the standalone harness in `index.html`, which wires it to the local stub Host
+// so the whole bout is playable with no runtime underneath it.
+export default defineConfig({
+  server: { port: 4321, host: "127.0.0.1" },
+  build: {
+    target: "es2022",
+    lib: {
+      entry: "src/index.ts",
+      name: "DynawallaGameFoundry",
+      formats: ["es"],
+      fileName: () => "foundry.js",
+    },
+  },
+})

--- a/dynawalla/games/foundry/vite.pack.config.ts
+++ b/dynawalla/games/foundry/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produces a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})


### PR DESCRIPTION
## What

Add **THE GRAPPLE FOUNDRY** at `dynawalla/games/foundry/` — rank 4, S tier in the
arcade canon, after *Pro Wrestling / WWF Superstars* (1986). A wrestling pin you
get out of with arithmetic, shipped as a pack.

You are on your back with a leverage bar across your chest and a referee counting
to three. A slate board above the ring carries a column sum. Two pedals hang off
the frame, one light and one heavy, each stamped with a whole number, and every
tap drops that plate's weight onto the bar. Work out what the board is asking,
build that **exact** number out of the two plates, and the bar tips and you kick
out.

## Why

The canon's own case for this one: *"Four seconds, two pedals worth 3 and 5, a
target of 26, three referee slaps and a crowd. It is a coin problem with a heart
rate. Overshoot is fatal so mashing loses instantly, and the escape explosion is
the biggest reward in the family. This is the pack to show a sceptic: it is
unambiguously a great wrestling game and unambiguously mental arithmetic, at the
same instant."*

It is also the best fit in the catalogue for the one constraint that actually
binds. Only the `add` domain is active — seven live rows, every one of them
whole-number column addition or subtraction — and `covers` is a request rather
than an instruction, so whatever a pack declares, the host serves column
arithmetic. A two-denomination exact-target problem **is** small-integer
arithmetic, so this design needs no fractions to make sense and degrades nowhere.

**How the served arithmetic drives the mechanic.** The host's canonical value for
an item becomes the target on the bar. The answer is never shown: the board says
`4,003 − 87` and the bar has to reach 3,916, so a fall asks two questions back to
back — evaluate the column sum, then decompose it. The plates are the game's own;
`game/plates.ts` cuts a pair for whatever target it is handed. Nothing about the
decomposition is reported, because it is arithmetic the child performs with their
thumbs rather than a question anybody asked.

Three ways a fall ends badly, and each is a different piece of mathematics:

| | what happened | why it is the right punishment |
|---|---|---|
| **TOO MUCH** | the bar went one over | mashing loses instantly, so the escape has to be planned before the first tap |
| **NO WAY OUT** | the remainder cannot be made from these two plates at all | the coin problem's real structure — `7+7+7` on 24 leaves three, and nothing makes three out of fours and sevens. The game says so at once rather than running a count down on a dead board |
| **THREE** | the count ran out | the child's time is measured, and here it is also spent |

And **WAVED OFF**, which is not a punishment. Land the bar on the exact output of
a broken procedure and the hall comes up, half the building thinks you are out,
and the referee waves it off. Below the target that costs count and nothing else,
and escaping afterwards is the biggest reaction in the game (`repaired` is the
tier-2 the design doc reserves for fixing an error you used to make). Above it the
bar can only arrive by going over, so the fall is already lost — but the child is
told *which* number was refused. That second case is the only one subtraction has,
because every mal-rule for a difference comes out larger than the difference.

The count is a function of the **work**, never of the run: a longer sum and a
longer decomposition both buy time, winning six falls in a row buys none. Belt
plates are cast on every escape and nothing takes one off, including losing a
bout — and losing a bout does not raise the price of the next one. The pinfall is
silence: the bed cuts, nothing bursts, no freeze frame, which is what
`energy(SLIP) < energy(SEAT)` demands in a game where a body going limp is
inherently the more animated moment.

Moves **AC-P-03** (a shipped arcade pack against the live `add` ladder) and adds
the fourth-ranked canon entry. `docs/MASTER_PLAN.md` names the canon build-out;
this is one entry of it, taken out of rank order because it is the best fit for
the only active domain.

## Blast radius

**Areas touched:** dynawalla (one new directory; nothing existing is modified)

- [x] Every touched path is covered by a `ci.yml` area filter — `dynawalla/games/**`
      is the filter the sibling packs already run under.
- [x] **Pack back-compat.** New pack id `dynawalla.foundry` at `0.1.0`. No published
      zip changed in place, no `voiceId` renamed, no catalog entry dropped or
      narrowed. Discovery is a glob for `pack.json`, so nothing was registered and
      nothing could go stale. Capabilities are exactly `items`, `items.reveal`,
      `haptics` — matching `slice` and `stack` verbatim. No `audio` (that is
      `feedback.sound`; the game synthesises its own `AudioContext`), no
      `items.answer` (which does not exist).
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifest touched.
- [x] **Strings.** N/A for `corpan-app/public/locales/` — this is a Dynawalla pack
      declaring `"locales": ["en"]`, as every shipped game pack does.
- [x] **Curriculum.** Nothing under `packs/shared/curriculum/` is touched. No skill
      id renamed or reused; all seven ids in `covers.skills` were verified by hand
      against `packs/shared/curriculum/src/graph/domains/add.ts` and are exactly the
      seven `active` rows (the `draft` decimal rung `subtract-tenths` is excluded).
      `dw-pack check` does *not* validate these, so this was checked programmatically
      rather than trusted. Every value in the game is an exact integer — no float
      reaches an answer, a target, a remainder or a comparison, asserted
      exhaustively over targets 1…400 at three pressures.
- [x] **Secrets.** None. `gitleaks` clean over the whole range. `BELT_SLOT` is a
      `localStorage` path with a `*_SLOT` name and a `gitleaks:allow`, per the
      pattern in `games/forge/src/game/save.ts`.

**Things a reviewer cannot reconstruct from the diff:**

- **`localStorage` is unreachable in a pack frame** (opaque origin — every access
  throws), so `game/save.ts` keeps an in-memory mirror that is the real source of
  truth for the session, and the belt count drawn on screen comes from the live
  `Bout`, never from storage. Tested against a `Proxy` that throws on every access.
- The stub host's mal-rules are **ported from
  `packs/shared/curriculum/src/malrules/columnOp.ts`**, including their `applies()`
  guards, so a rule that would coincide with the correct procedure emits nothing.
  A test pins `5001 − 2798`: correct 2203, smaller-from-larger 3797,
  borrow-across-zero 3203 — the exact case that file's docblock says the program
  has confused once already.
- The rendering is smoke-tested. `src/test/mount.test.ts` mounts the real game
  against a recording canvas and plays several hundred frames at 320×568, 768×1024
  and 1366×1024 plus the reduced-motion branch, then asserts falls were actually
  lost to the count and escaped by tapping. `tsc` and the vite build prove the
  draw calls compile and the modules resolve; neither proves a frame *runs*.
- **Self-reviewed adversarially before pushing**, and the findings are fixed in the
  commit: mal-rules above the target are now traps rather than discarded (without
  which no subtraction fall had any diagnosis at all); `carriedTwice` — a fixed
  offset off the answer, exactly what the curriculum's mal-rule file forbids — was
  deleted; a quality-tier downgrade now re-runs `resize()` so `maxDpr` and the
  lantern count move with it, and `Particles` honours the tier's ceiling instead of
  always holding the ULTRA number; losing a bout no longer increments the
  escapes-to-beat; a duplicated `BEST n` readout was removed.

## Proof

Real output, from `dynawalla/games/foundry/` unless noted.

```
--- npm test, five consecutive runs ---
run 1: # tests 75 # pass 75 # fail 0 
run 2: # tests 75 # pass 75 # fail 0 
run 3: # tests 75 # pass 75 # fail 0 
run 4: # tests 75 # pass 75 # fail 0 
run 5: # tests 75 # pass 75 # fail 0 

--- npm run tsc ---
> @dynawalla/game-foundry@0.1.0 tsc
> tsc --noEmit


--- npm run build ---
computing gzip size...
dist/foundry.js  50.50 kB │ gzip: 16.10 kB

✓ built in 17ms

--- npm run build:pack + the script tag that proves the entry is bundled ---
dist-pack/pack.html                 1.28 kB │ gzip:  0.67 kB
dist-pack/assets/pack-BRCcEQPh.js  43.47 kB │ gzip: 16.13 kB

✓ built in 24ms
<script type="module" crossorigin src="./assets/pack-BRCcEQPh.js">

--- node build.mjs foundry (from dynawalla/packs/) ---
✓ built in 24ms
dynawalla.foundry@0.1.0 — THE GRAPPLE FOUNDRY
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 45877 bytes

1 pack(s) built, checked and staged into src-tauri/packs/

--- gitleaks ---
12:30AM INF 1 commits scanned.
12:30AM INF scanned ~193882 bytes (193.88 KB) in 43.1ms
12:30AM INF no leaks found

--- scope ---
files outside dynawalla/games/foundry/:
  (none)
deletions:
  (none)
```

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
