### PR TITLE
dynawalla/games/coil: THE COIL OF NINETY-SIX — the cut is the partition, and cracking a ten is the borrow

### DIFF
--- a/dynawalla/games/coil/.gitignore
+++ b/dynawalla/games/coil/.gitignore
@@ -1,0 +1,13 @@
+node_modules/
+dist/
+
+# The pack build. `packs/build.mjs` regenerates it and stages it into the app.
+dist-pack/
+
+# Capture scratch. Nothing here is an input to a build.
+qa/shots
+qa/tmp
+
+# The lockfile is not committed for a game: every game pins the same three dev
+# dependencies by range and the repository has no workspace resolution to share.
+package-lock.json

--- a/dynawalla/games/coil/README.md
+++ b/dynawalla/games/coil/README.md
@@ -1,0 +1,171 @@
+# THE COIL OF NINETY-SIX
+
+**An articulated brass coil is a number written in place value. Shear the lit
+number off it, and the machine does the arithmetic in front of you.**
+
+After *Centipede* (1980): a segmented thing descends a lane, one shot splits it
+in two, and the debris you leave behind is what makes the board hard.
+
+```bash
+npm install
+npm run dev        # http://127.0.0.1:4396 — playable standalone, stub Host included
+npm test           # 79 tests
+npm run tsc
+npm run build:pack # what installs on a tablet: pack.html only, no stub Host
+```
+
+`?seed=7` pins the question stream, `?rung=0..5` pins the stub's difficulty,
+`?reduced=1` forces the reduced-motion branch.
+
+---
+
+## The coil
+
+A link is a place. A **bead** is one, a ribbed **drum** is ten, a pierced
+**ring** is a hundred, a notched **tower** is a thousand, and each place above
+that adds a notch. A coil is the links a number is made of, biggest first — so
+the coil *is* the numeral, with the positions made physical instead of implied.
+
+```
+ 72  →  ▮▮▮▮▮▮▮ ● ●              seven tens and two ones
+403  →  ◎◎◎◎ ● ● ●               four hundreds and three ones — and no tens link at all
+```
+
+A zero digit is the **absence of a link**. That is why borrowing across a zero
+is something a child can see rather than a rule they are told.
+
+## The loop
+
+The wall carves the problem the curriculum served and lights one operand. The
+whole instruction is four words: **shear off the lit number.**
+
+| the wall says | the coil is | you shear off | what the machine does |
+|---|---|---|---|
+| `72 − 25` | **72**, the minuend | `25` | the piece is carried away, and **what crawls on is 47** |
+| `47 + 25` | stock — a coil of ninety-six | `25` | the piece is **welded onto an ingot of 47**, and the ingot reads 101 |
+
+You never subtract and you never add. You regroup and you take, and the answer
+comes out of the machine — which is the number reported to the host.
+
+**The shear makes one cut, at one joint, and takes the tail.** That is the whole
+of the difficulty, and it is exact:
+
+> Twenty-five is two tens and five ones. A coil of seventy-two ends in *two*
+> ones, so there is no joint anywhere on it worth twenty-five. Crack a ten open
+> — right where the jaws are — and ten ones drop into the chain between the tens
+> you keep and the tens you give away. Now walk the cut back through them.
+
+That is the borrow. It is not a rule about digits and there is no other way to
+do it.
+
+## Where the math lives
+
+**Native, and impossible to fake.** A cut at joint `k` is a partition
+`N = k + (N − k)`, and the number the host is judged against is the *length of a
+piece of brass*, computed by counting links. There is no keypad, no multiple
+choice, and nothing the game can round.
+
+Three things fall out of that, and each is a test:
+
+1. **A wrong cut produces the number that cut is worth.** Shearing two tens and
+   the two loose ones off seventy-two — the greedy take that skips the borrow —
+   leaves fifty, and fifty is reported. It is the smaller-from-larger family of
+   error, *performed* rather than typed.
+2. **Every claim is a whole number.** `place.ts` is integer arithmetic on exact
+   powers of ten from beginning to end; there is no float anywhere in an answer
+   or a comparison.
+3. **Breaking never changes what you are holding.** Cracking the link at the
+   jaws leaves `suffixValue(links, cut)` untouched. A break buys resolution,
+   never a different amount — so it is safe to explore.
+
+### The one place the coil is stricter than the column
+
+`64 − 31` regroups no column, and it still costs one break: three tens and one
+one cannot be the *end* of a chain that finishes with four ones. `breaksNeeded`
+measures how much change a demand needs, which is at least the column
+algorithm's regroupings and sometimes one more. That is deliberate — cracking a
+ten to make change is the physical act that regrouping is a rule *about*.
+
+## The punishment is your own floor
+
+There is no timer, no lamp, no buzzer and no life. Aiming is free, cracking is
+free, and hesitating is free — punishing a child for thinking is the failure
+mode this whole programme exists to avoid.
+
+What a careless cut costs is **space**:
+
+- A piece that is not the demand does not fit the wall. It falls in the lane as
+  **slag**, and each lump takes two cells out of a lane that holds ninety-six.
+- A coil longer than the cells it has left is **buried at the mouth**,
+  head-first — which takes away exactly the big links you borrow from.
+- Every break makes the coil nine links longer. **Crack everything open and you
+  bury your own coil.**
+- An **exact cut smashes two lumps** on its way to the wall. Play at half
+  accuracy and the lane never gets ahead of you.
+
+The escape is the **furnace**: melt every lump, at the cost of feeding the
+current coil to it. Nothing is reported, nothing is recorded, and a choked lane
+is a decision rather than a dead end.
+
+And the wall itself **never regresses**. A miss costs slag; it never takes a
+brick back out.
+
+## What the host serves, and what this does with it
+
+Only the `add` domain is active, so the stream is column addition and
+subtraction — which is exactly what this game is. `round.ts` reads
+`Item.prompt` (the `top ± bottom` shape `dynawalla-app/src/packs/items.ts`
+emits, U+2212 included) together with the canonical answer from
+`items.reveal`:
+
+- `a − b = c`, consistent → **take**: coil `a`, demand `b`, claim `a − severed`.
+- `a + b = c`, consistent → **fill**: coil `stockFor(b)`, cradle `a`,
+  claim `a + severed`.
+- anything else with a whole-number answer → **fill** with an empty cradle and
+  the answer itself as the demand. A pack must never quietly play a different
+  problem from the one the curriculum served, so an inconsistent prompt loses to
+  the canonical answer.
+- a fraction, a decimal, an empty pool → **refused**, never approximated. The
+  item is skipped, the host is asked again, and nothing is recorded against a
+  child for a question the pack declined to draw.
+
+`items.reveal` is declared and is not optional: without it the shared adapter's
+pool never fills and the pack serves nothing at all, silently.
+
+## The register
+
+**The forge alley of the bazaar, after dark.** Carved stone, brass that has been
+handled, lapis on the hundreds, a girih lattice that is the wall the bricks are
+laid into rather than wallpaper, and exactly one cold light — the recess.
+Nothing glows for encouragement.
+
+Every place is a **silhouette before it is a colour**, so the coil reads for a
+colour-blind child by construction. A numeral is never coloured information;
+what is lit on the wall is the *demand*, and it is lit by light, not by hue.
+
+**Reduced motion is a branch**: the whip, the particles and the idle pulses are
+pinned at rest and the flight collapses to 180 ms, while every readable state
+stays exactly where it was.
+
+**A slip is smaller than a seat**, on duration, gain, particle count and
+animated elements, and `reactions.test.ts` asserts it. A wrong cut is a dull
+lump of metal landing on stone and a quarter-second of oxide across the lane —
+never a flash, never a shake, never a sound of refusal.
+
+## Layout
+
+```
+src/game/place.ts      the coil as arithmetic: break, fuse, suffix, change
+src/game/round.ts      a served item, read as a cut
+src/game/board.ts      the lane: slag, burial, the jaws, the furnace
+src/game/session.ts    rounds, the wall, one report per item
+src/game/reactions.ts  the tier table and the two invariants
+src/render/            layout (pure), scene, particles, palette
+src/audio/audio.ts     procedural WebAudio, including the sonified partition
+src/stubHost.ts        seeded column arithmetic with executable mal-rules
+```
+
+The partition is **heard** as well as carved: when the jaws close, the piece
+that comes away plays as a rising note-run and the piece that stays plays as a
+falling one, one note per link, pitched by place. Nothing in the game depends on
+hearing it.

--- a/dynawalla/games/coil/index.html
+++ b/dynawalla/games/coil/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <title>THE COIL OF NINETY-SIX — dev harness</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #0b0906;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+      #readout {
+        position: fixed;
+        left: 8px;
+        bottom: 6px;
+        z-index: 5;
+        font: 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+        color: rgba(255, 232, 190, 0.42);
+        pointer-events: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <div id="readout">host.report → 0/0</div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/coil/pack.html
+++ b/dynawalla/games/coil/pack.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#0b0906" />
+    <title>THE COIL OF NINETY-SIX</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #0b0906;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         The dev harness's `#readout` is not here — it reported the stub host's
+         tally, and inside a real host the host draws the progress. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/coil/pack.json
+++ b/dynawalla/games/coil/pack.json
@@ -1,0 +1,24 @@
+{
+  "id": "dynawalla.coil",
+  "version": "0.1.0",
+  "name": "THE COIL OF NINETY-SIX",
+  "description": "An articulated brass coil is a number written in place value. Shear off the glowing number — crack a link open when the ones run short — and the machine performs the arithmetic in front of you.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-multidigit",
+      "dw.add.regroup.add-short-addend",
+      "dw.add.regroup.subtract-short-subtrahend",
+      "dw.add.regroup.subtract-across-zero"
+    ],
+    "grades": [1, 4]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/coil/package.json
+++ b/dynawalla/games/coil/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@dynawalla/game-coil",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "THE COIL OF NINETY-SIX — shear the glowing number off an articulated place-value coil; the cut performs the arithmetic.",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4396",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
+    "build:pack": "vite build --config vite.pack.config.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^6.0.0",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/games/coil/src/audio/audio.ts
+++ b/dynawalla/games/coil/src/audio/audio.ts
@@ -1,0 +1,244 @@
+// Procedural WebAudio. No assets, no samples, nothing fetched.
+//
+// Every cue is built as **transient → body → tail**, because that is what makes
+// a synthesised hit read as a physical event rather than a beep: a 3–12 ms
+// click that carries the impact, a pitched body that carries identity, and a
+// decay that carries size.
+//
+// The one thing here that is not decoration is `partition`. When the shear
+// closes, the two pieces are played as two note-runs — the piece that comes off
+// rising, the piece that stays falling — one note per link, pitched by place.
+// A child hears `72 = 25 + 47` as two phrases whose lengths and registers say
+// what the numbers are. It is the same information the wall carves, in the one
+// channel a child can take in while looking somewhere else. Nothing in the game
+// depends on hearing it.
+
+const PENTATONIC = [0, 3, 5, 7, 10] as const
+
+/** Nothing is ever scheduled above this; the partials of a bell add up fast. */
+function safeHz(f: number): number {
+  return Math.max(20, Math.min(14000, f))
+}
+
+function semitone(i: number): number {
+  const k = Math.max(0, Math.min(PENTATONIC.length * 4 - 1, i))
+  return (PENTATONIC[k % PENTATONIC.length] as number) + Math.floor(k / PENTATONIC.length) * 12
+}
+
+export class Audio {
+  private ctx: AudioContext | null = null
+  private bus: GainNode | null = null
+  private noise: AudioBuffer | null = null
+  private voices = 0
+  private readonly maxVoices = 28
+  enabled = true
+
+  /** Must be called from a user gesture. Safe to call repeatedly. */
+  async start(): Promise<void> {
+    if (this.ctx) {
+      if (this.ctx.state === "suspended") await this.ctx.resume().catch(() => {})
+      return
+    }
+    type WithWebkit = typeof globalThis & { webkitAudioContext?: typeof AudioContext }
+    const Ctor = globalThis.AudioContext ?? (globalThis as WithWebkit).webkitAudioContext
+    if (!Ctor) {
+      console.warn("[coil] no AudioContext; running silent")
+      return
+    }
+    try {
+      const ctx = new Ctor()
+      const comp = ctx.createDynamicsCompressor()
+      comp.threshold.value = -16
+      comp.knee.value = 24
+      comp.ratio.value = 6
+      comp.attack.value = 0.003
+      comp.release.value = 0.15
+      const bus = ctx.createGain()
+      bus.gain.value = 0.8
+      bus.connect(comp)
+      comp.connect(ctx.destination)
+
+      const len = Math.floor(ctx.sampleRate * 0.5)
+      const buf = ctx.createBuffer(1, len, ctx.sampleRate)
+      const d = buf.getChannelData(0)
+      let s = 0x9e3779b9
+      for (let i = 0; i < len; i++) {
+        s ^= s << 13
+        s ^= s >>> 17
+        s ^= s << 5
+        d[i] = ((s >>> 0) / 2147483648 - 1) * 0.6
+      }
+
+      this.ctx = ctx
+      this.bus = bus
+      this.noise = buf
+      await ctx.resume().catch(() => {})
+    } catch (error) {
+      console.warn("[coil] audio unavailable", error)
+    }
+  }
+
+  dispose(): void {
+    const ctx = this.ctx
+    this.ctx = null
+    this.bus = null
+    this.noise = null
+    void ctx?.close().catch(() => {})
+  }
+
+  private ready(): { ctx: AudioContext; bus: GainNode } | null {
+    if (!this.enabled || !this.ctx || !this.bus) return null
+    if (this.voices >= this.maxVoices) return null
+    return { ctx: this.ctx, bus: this.bus }
+  }
+
+  private spend(seconds: number): void {
+    this.voices++
+    globalThis.setTimeout(
+      () => {
+        this.voices = Math.max(0, this.voices - 1)
+      },
+      Math.ceil(seconds * 1000) + 40,
+    )
+  }
+
+  /** A short filtered noise burst: the transient of anything metal. */
+  private strike(at: number, gain: number, hz: number, decay: number): void {
+    const r = this.ready()
+    if (!r || !this.noise) return
+    const src = r.ctx.createBufferSource()
+    src.buffer = this.noise
+    const bp = r.ctx.createBiquadFilter()
+    bp.type = "bandpass"
+    bp.frequency.value = safeHz(hz)
+    bp.Q.value = 1.4
+    const g = r.ctx.createGain()
+    g.gain.setValueAtTime(gain, at)
+    g.gain.exponentialRampToValueAtTime(0.0001, at + decay)
+    src.connect(bp)
+    bp.connect(g)
+    g.connect(r.bus)
+    src.start(at)
+    src.stop(at + decay + 0.02)
+    this.spend(decay)
+  }
+
+  /** A struck body: sine fundamental plus a quiet triangle octave. */
+  private tone(
+    at: number,
+    hz: number,
+    gain: number,
+    decay: number,
+    type: OscillatorType = "sine",
+  ): void {
+    const r = this.ready()
+    if (!r) return
+    const osc = r.ctx.createOscillator()
+    osc.type = type
+    osc.frequency.value = safeHz(hz)
+    const g = r.ctx.createGain()
+    g.gain.setValueAtTime(0.0001, at)
+    g.gain.exponentialRampToValueAtTime(gain, at + 0.006)
+    g.gain.exponentialRampToValueAtTime(0.0001, at + decay)
+    osc.connect(g)
+    g.connect(r.bus)
+    osc.start(at)
+    osc.stop(at + decay + 0.02)
+    this.spend(decay)
+  }
+
+  private get when(): number {
+    return this.ctx ? this.ctx.currentTime : 0
+  }
+
+  /** The shear moving one joint. Tiny, dry, and never fatiguing. */
+  aim(place: number): void {
+    const t = this.when
+    this.strike(t, 0.055, 2400 + place * 320, 0.026)
+  }
+
+  /** The borrow: a link cracking into ten. A snap, then ten scattering pips. */
+  crack(place: number): void {
+    const t = this.when
+    this.strike(t, 0.4, 1500 - place * 90, 0.07)
+    this.tone(t, 260 - place * 18, 0.16, 0.16, "triangle")
+    for (let i = 0; i < 6; i++) {
+      this.strike(t + 0.03 + i * 0.022, 0.09, 3200 + i * 140, 0.03)
+    }
+  }
+
+  /** The jaws closing. Scrape, then the bite. */
+  shear(): void {
+    const t = this.when
+    this.strike(t, 0.16, 5200, 0.05)
+    this.strike(t + 0.05, 0.5, 900, 0.1)
+    this.tone(t + 0.05, 148, 0.2, 0.2, "triangle")
+  }
+
+  /**
+   * The partition, heard.
+   *
+   * `off` is the piece that came away and `stay` is what remained, each as a
+   * list of place exponents. The first run rises, the second falls, and the
+   * place sets the register, so a run of ones is a fast bright flurry and a run
+   * of hundreds is four low strokes.
+   */
+  partition(off: readonly number[], stay: readonly number[], at = 0): void {
+    const base = this.when + at
+    const cap = 14
+    const stepA = off.length > 8 ? 0.045 : 0.07
+    for (let i = 0; i < Math.min(cap, off.length); i++) {
+      const p = off[i] as number
+      const hz = 262 * 2 ** ((semitone(i) + (2 - Math.min(3, p)) * 5) / 12)
+      this.tone(base + i * stepA, hz, 0.15, 0.24)
+      this.tone(base + i * stepA, hz * 2, 0.035, 0.14, "triangle")
+    }
+    const gap = base + Math.min(cap, off.length) * stepA + 0.12
+    const stepB = stay.length > 8 ? 0.04 : 0.06
+    const n = Math.min(cap, stay.length)
+    for (let i = 0; i < n; i++) {
+      const p = stay[stay.length - 1 - i] as number
+      const hz = 262 * 2 ** ((semitone(n - 1 - i) + (2 - Math.min(3, p)) * 5 - 12) / 12)
+      this.tone(gap + i * stepB, hz, 0.11, 0.22)
+    }
+  }
+
+  /** An exact piece seating into the wall. One detent, one bell. */
+  seat(): void {
+    const t = this.when
+    this.strike(t, 0.22, 3000, 0.04)
+    this.tone(t + 0.01, 523.25, 0.2, 0.5)
+    this.tone(t + 0.01, 784, 0.09, 0.44, "triangle")
+    this.tone(t + 0.09, 1046.5, 0.07, 0.5)
+  }
+
+  /**
+   * A piece that did not fit, hitting the floor.
+   *
+   * Deliberately not a buzzer and deliberately quieter and shorter than
+   * `seat` — being wrong must not be the more interesting sound. It is a dull
+   * lump of metal landing on stone, which is exactly what happened.
+   */
+  slag(): void {
+    const t = this.when
+    this.strike(t, 0.2, 260, 0.09)
+    this.tone(t, 74, 0.12, 0.18, "triangle")
+  }
+
+  /** The furnace taking the lane back. Air, then a swell. */
+  furnace(): void {
+    const t = this.when
+    this.strike(t, 0.3, 700, 0.5)
+    this.tone(t + 0.05, 98, 0.16, 0.7, "sawtooth")
+    this.tone(t + 0.05, 147, 0.07, 0.6, "triangle")
+  }
+
+  /** A course of the wall closing. The one big sound in the game. */
+  course(): void {
+    const t = this.when
+    for (let i = 0; i < 4; i++) {
+      this.tone(t + i * 0.11, 262 * 2 ** (semitone(i * 2) / 12), 0.17, 0.7)
+    }
+    this.strike(t + 0.44, 0.24, 1800, 0.28)
+  }
+}

--- a/dynawalla/games/coil/src/contract.ts
+++ b/dynawalla/games/coil/src/contract.ts
@@ -1,0 +1,41 @@
+// The host↔game contract. This is the shape the runtime lands underneath us;
+// it must not drift. Nothing else in this package may redefine these types.
+//
+// `mount` delegates to `./mount.ts`. That module imports `Host` from here
+// type-only, and a type-only import is erased, so there is no runtime cycle.
+
+import { mountCoil } from "./mount.ts"
+
+export type Question = {
+  id: string
+  prompt: string
+  answer: string
+  distractors: string[]
+  domain: string
+  difficulty: number
+}
+
+export type Host = {
+  next(opts?: { domain?: string; difficulty?: number }): Question
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+  haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void
+  prefersReducedMotion(): boolean
+
+  /**
+   * A natural stopping point the child *reached*: a level cleared, a run
+   * completed, a boss down.
+   *
+   * OPTIONAL and feature-detected — a stub host does not implement it and the
+   * game must not care. Fire and forget: nothing is returned, nothing may be
+   * awaited, and the game must not branch on it.
+   *
+   * **Never after a failure.** Not a defeat, not a breach, not a wrong answer,
+   * not a timer. This is the call the host may put a sheet on top of, and a
+   * purchase surface next to a failure is the thing that is forbidden outright.
+   */
+  transition?(kind: "level" | "run" | "boss", label?: string): void
+}
+
+export function mount(el: HTMLElement, host: Host): { unmount(): void } {
+  return mountCoil(el, host)
+}

--- a/dynawalla/games/coil/src/core/rng.ts
+++ b/dynawalla/games/coil/src/core/rng.ts
@@ -1,0 +1,56 @@
+// A seeded, deterministic PRNG. Every stochastic decision in the game and in
+// the stub host runs through one of these so a run can be replayed exactly, and
+// so no test in this package ever calls `Math.random`.
+//
+// mulberry32: 32-bit state, no allocation, and trivially portable to a test.
+
+export class Rng {
+  private s: number
+
+  constructor(seed: number) {
+    // Force to uint32; a 0 seed is legal for mulberry32 but degenerate-looking,
+    // so nudge it off zero.
+    this.s = (seed >>> 0) || 0x9e3779b9
+  }
+
+  /** Uniform in [0, 1). */
+  next(): number {
+    this.s = (this.s + 0x6d2b79f5) >>> 0
+    let t = this.s
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+
+  /** Uniform in [lo, hi). */
+  range(lo: number, hi: number): number {
+    return lo + this.next() * (hi - lo)
+  }
+
+  /** Uniform integer in [lo, hi] inclusive. */
+  int(lo: number, hi: number): number {
+    if (hi <= lo) return lo
+    return lo + Math.floor(this.next() * (hi - lo + 1))
+  }
+
+  /** True with probability p. */
+  chance(p: number): boolean {
+    return this.next() < p
+  }
+
+  pick<T>(xs: readonly T[]): T {
+    if (xs.length === 0) throw new Error("rng.pick: empty")
+    return xs[Math.floor(this.next() * xs.length)] as T
+  }
+
+  /** In-place Fisher–Yates. Returns the same array for chaining. */
+  shuffle<T>(xs: T[]): T[] {
+    for (let i = xs.length - 1; i > 0; i--) {
+      const j = Math.floor(this.next() * (i + 1))
+      const a = xs[i] as T
+      xs[i] = xs[j] as T
+      xs[j] = a
+    }
+    return xs
+  }
+}

--- a/dynawalla/games/coil/src/game/board.test.ts
+++ b/dynawalla/games/coil/src/game/board.test.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import {
+  MIN_CELLS,
+  SLAG_CELLS,
+  SLAG_CLEARED_PER_HIT,
+  SLAG_PER_MISS,
+  aim,
+  breakAtCut,
+  breakable,
+  buried,
+  clampCut,
+  createBoard,
+  cutRange,
+  openCells,
+  pendingValue,
+  reload,
+  settle,
+  shear,
+  stoke,
+} from "./board.ts"
+import { breaksNeeded, coilOf, suffixValues, valueOf } from "./place.ts"
+
+const SEED = 0x0c011960
+
+test("a fresh board parks the shear on the last link", () => {
+  const board = createBoard(coilOf(72), 96)
+  assert.equal(board.cut, 8)
+  assert.equal(pendingValue(board), 1)
+  assert.equal(board.slag, 0)
+})
+
+test("the shear can always take at least one link and never a buried one", () => {
+  const rng = new Rng(SEED ^ 0x77)
+  for (let i = 0; i < 200; i++) {
+    const board = createBoard(coilOf(rng.int(1, 99_999)), rng.int(8, 96))
+    board.slag = rng.int(0, 12)
+    const { min, max } = cutRange(board)
+    assert.equal(min, buried(board))
+    assert.ok(max >= min)
+    assert.equal(clampCut(board, -100), min)
+    assert.equal(clampCut(board, 10_000), max)
+    aim(board, -100)
+    assert.ok(board.cut >= buried(board))
+    assert.ok(pendingValue(board) > 0 || board.links.length === 0)
+  }
+})
+
+test("slag takes cells away and the coil is buried head-first", () => {
+  const board = createBoard(coilOf(99_999), 40)
+  assert.equal(board.links.length, 45)
+  assert.equal(openCells(board), 40)
+  assert.equal(buried(board), 5)
+  board.slag = 4
+  assert.equal(openCells(board), 40 - 4 * SLAG_CELLS)
+  assert.equal(buried(board), 45 - 32)
+})
+
+test("however choked the lane gets, some of it stays walkable", () => {
+  const board = createBoard(coilOf(72), 20)
+  board.slag = 500
+  assert.equal(openCells(board), MIN_CELLS)
+  assert.ok(cutRange(board).max >= cutRange(board).min)
+})
+
+test("a buried link cannot be cracked open", () => {
+  const board = createBoard(coilOf(99_999), 20)
+  const b = buried(board)
+  assert.ok(b > 0)
+  assert.equal(breakable(board, b - 1), false)
+  assert.equal(breakable(board, b), true)
+})
+
+test("cracking at the cut leaves the pending value untouched", () => {
+  const rng = new Rng(SEED ^ 0x88)
+  for (let i = 0; i < 200; i++) {
+    const board = createBoard(coilOf(rng.int(100, 99_999)), 96)
+    aim(board, rng.int(0, board.links.length - 1))
+    const before = pendingValue(board)
+    const grew = board.links.length
+    if (!breakAtCut(board)) continue
+    assert.equal(pendingValue(board), before)
+    assert.equal(board.links.length, grew + 9)
+  }
+})
+
+test("cracking a bead is refused and changes nothing", () => {
+  const board = createBoard(coilOf(72), 96)
+  aim(board, 8)
+  const before = board.links.slice()
+  assert.equal(breakAtCut(board), false)
+  assert.deepEqual(board.links, before)
+})
+
+test("a shear is a partition: the two pieces add back up to the coil", () => {
+  const rng = new Rng(SEED ^ 0x99)
+  for (let i = 0; i < 300; i++) {
+    const value = rng.int(1, 99_999)
+    const board = createBoard(coilOf(value), 96)
+    aim(board, rng.int(0, board.links.length - 1))
+    const result = shear(board)
+    assert.equal(result.severed + result.restValue, value)
+    assert.equal(result.piece.length + result.rest.length, board.links.length)
+    assert.ok(Number.isSafeInteger(result.severed))
+    assert.ok(result.severed > 0)
+  }
+})
+
+test("an exact cut clears slag; a miss adds it, and slag never goes negative", () => {
+  const board = createBoard(coilOf(72), 96)
+  settle(board, false)
+  assert.equal(board.slag, SLAG_PER_MISS)
+  settle(board, false)
+  assert.equal(board.slag, SLAG_PER_MISS * 2)
+  settle(board, true)
+  assert.equal(board.slag, 2 * SLAG_PER_MISS - SLAG_CLEARED_PER_HIT)
+  settle(board, true)
+  assert.equal(board.slag, 0)
+  settle(board, true)
+  assert.equal(board.slag, 0)
+})
+
+test("playing at half accuracy digs the lane out rather than choking it", () => {
+  const board = createBoard(coilOf(72), 96)
+  let worst = 0
+  for (let i = 0; i < 40; i++) {
+    settle(board, i % 2 === 0)
+    worst = Math.max(worst, board.slag)
+  }
+  assert.equal(worst, 1, "the lane never gets ahead of the player")
+  assert.ok(board.slag <= 1)
+})
+
+test("playing badly chokes the lane, which is the whole of the punishment", () => {
+  const board = createBoard(coilOf(99_999), 96)
+  assert.equal(buried(board), 0)
+  for (let i = 0; i < 30; i++) settle(board, false)
+  assert.equal(board.slag, 30 * SLAG_PER_MISS)
+  assert.ok(buried(board) > 0, "the coil no longer fits on the floor it was given")
+  // And it is undone by playing well, not by waiting.
+  for (let i = 0; i < 15; i++) settle(board, true)
+  assert.equal(board.slag, 0)
+  assert.equal(buried(board), 0)
+})
+
+test("the furnace melts the lane, and reload keeps the slag", () => {
+  const board = createBoard(coilOf(72), 96)
+  board.slag = 7
+  reload(board, coilOf(403))
+  assert.equal(board.slag, 7, "a new coil does not clean the floor")
+  assert.equal(valueOf(board.links), 403)
+  stoke(board)
+  assert.equal(board.slag, 0)
+})
+
+test("a choked board is a decision, never a dead end", () => {
+  // Bury the coil badly enough that the tens are unreachable, then prove the
+  // furnace is the way out: everything is reachable again afterwards.
+  const board = createBoard(coilOf(87_654), 96)
+  board.slag = 40
+  assert.ok(buried(board) > 0)
+  stoke(board)
+  assert.equal(buried(board), 0)
+  assert.equal(breakable(board, 0), true)
+})
+
+test("the demand is reachable by cracking only at the cut", () => {
+  // The interaction only ever breaks the link the jaws are parked on, so the
+  // greedy walk `breaksNeeded` counts has to be a strategy the child can
+  // actually perform. This replays it through the board's own API.
+  const rng = new Rng(SEED ^ 0xaa)
+  for (let i = 0; i < 200; i++) {
+    const whole = rng.int(10, 99_999)
+    const demand = rng.int(1, whole)
+    const board = createBoard(coilOf(whole), 4_096)
+    let guard = 0
+    for (;;) {
+      const table = suffixValues(board.links)
+      const exact = table.indexOf(demand)
+      if (exact >= 0) {
+        aim(board, exact)
+        break
+      }
+      // Park where the take overshoots by the least, then crack.
+      let at = board.links.length - 1
+      for (let j = board.links.length - 1; j >= 0; j--) {
+        if ((table[j] as number) > demand) {
+          at = j
+          break
+        }
+      }
+      aim(board, at)
+      assert.equal(breakAtCut(board), true, "the boundary link can always be cracked")
+      guard++
+      assert.ok(guard < 40, "the walk terminates")
+    }
+    assert.equal(pendingValue(board), demand)
+    assert.ok(breaksNeeded(coilOf(whole), demand) >= 0)
+    assert.equal(valueOf(board.links), whole)
+  }
+})
+
+test("SLAG_CELLS is what makes the lane a rule and not a decoration", () => {
+  const board = createBoard(coilOf(9), 30)
+  const clean = openCells(board)
+  board.slag = 3
+  assert.equal(clean - openCells(board), 3 * SLAG_CELLS)
+})

--- a/dynawalla/games/coil/src/game/board.ts
+++ b/dynawalla/games/coil/src/game/board.ts
@@ -1,0 +1,144 @@
+// The lane, and the only thing in this game that punishes you.
+//
+// There is no timer, no lamp and no buzzer. Hesitating costs nothing; aiming
+// costs nothing; cracking a link open and changing your mind costs nothing that
+// a correct cut will not undo. What a thoughtless cut costs is **space**, and
+// space is the thing the coil needs to exist:
+//
+//   * A cut that is not exact drops its piece on the floor as **slag**. Slag
+//     sits in the lane and each lump occupies cells the coil can no longer use.
+//   * A coil longer than the cells left over is **buried** at the mouth,
+//     head-first. A buried link cannot be broken, and the biggest places are at
+//     the head — so a choked lane takes away exactly the links you borrow from.
+//   * An exact cut clears two lumps: the severed piece smashes them on its way
+//     to the wall. Play well and the lane clears itself faster than it fouls.
+//
+// Breaking a link is what makes this bite. Every break makes the coil nine
+// links longer, so a child who cracks everything open buries their own coil.
+// The efficient strategy is to crack only at the boundary and only when the
+// take actually overshoots — which is why the jaws are the only place a link
+// can be cracked, and why the lane, not a message, is what teaches it.
+//
+// The escape is the **furnace**: melt every lump, at the cost of feeding the
+// current coil to it. Always available, costs no answer, reports nothing. A
+// choked board is never a dead end, it is a decision.
+
+import { breakAt, canBreak, suffixValue, valueOf } from "./place.ts"
+
+/** Cells one lump of slag takes out of the lane. */
+export const SLAG_CELLS = 2
+
+/** Lumps a wrong cut leaves behind, and lumps an exact cut smashes. */
+export const SLAG_PER_MISS = 1
+export const SLAG_CLEARED_PER_HIT = 2
+
+/** However choked the lane gets, this many cells stay walkable. */
+export const MIN_CELLS = 6
+
+export type Board = {
+  /** Place exponents, head first. */
+  links: number[]
+  /** The joint the shear is parked at: `links[cut..]` is what comes off. */
+  cut: number
+  slag: number
+  /** Cells the lane geometry offers when nothing is in the way. */
+  capacity: number
+}
+
+export function createBoard(links: number[], capacity: number): Board {
+  const board: Board = { links, cut: Math.max(0, links.length - 1), slag: 0, capacity }
+  board.cut = clampCut(board, board.cut)
+  return board
+}
+
+/** Cells the coil may occupy right now. */
+export function openCells(board: Board): number {
+  return Math.max(MIN_CELLS, board.capacity - board.slag * SLAG_CELLS)
+}
+
+/**
+ * How many links are stuck in the mouth. Head-first, because the head is where
+ * the coil enters and because burying the tail would make the game unplayable
+ * rather than harder — the tail is what you shear.
+ */
+export function buried(board: Board): number {
+  return Math.max(0, board.links.length - openCells(board))
+}
+
+/** The joints the shear can reach. At least one link always comes off. */
+export function cutRange(board: Board): { min: number; max: number } {
+  const min = buried(board)
+  const max = Math.max(min, board.links.length - 1)
+  return { min, max }
+}
+
+export function clampCut(board: Board, cut: number): number {
+  const { min, max } = cutRange(board)
+  return Math.max(min, Math.min(max, cut))
+}
+
+/** Park the shear at a joint. Free, unlimited, and never reported. */
+export function aim(board: Board, cut: number): void {
+  board.cut = clampCut(board, cut)
+}
+
+/** The value that would come off if the lever were pulled now. */
+export function pendingValue(board: Board): number {
+  return suffixValue(board.links, board.cut)
+}
+
+/** A link the child may crack open: reachable, and worth more than one. */
+export function breakable(board: Board, index: number): boolean {
+  return index >= buried(board) && canBreak(board.links, index)
+}
+
+/**
+ * Crack the link the shear is parked at.
+ *
+ * Parked at, and not anywhere: the borrow that matters is the one at the
+ * boundary between what you are taking and what you are keeping, and making
+ * that the only breakable link is what stops the game from becoming a bag of
+ * blocks. The cut index does not move, and `pendingValue` is unchanged by
+ * construction — a break gives you finer resolution, never a different amount.
+ */
+export function breakAtCut(board: Board): boolean {
+  if (!breakable(board, board.cut)) return false
+  board.links = breakAt(board.links, board.cut)
+  board.cut = clampCut(board, board.cut)
+  return true
+}
+
+export type Shear = {
+  /** The links that came off, and what they are worth. */
+  readonly piece: number[]
+  readonly severed: number
+  /** What stayed on the lane. */
+  readonly rest: number[]
+  readonly restValue: number
+}
+
+/** Close the shear. The board is not mutated; `settle` decides what happens. */
+export function shear(board: Board): Shear {
+  const cut = clampCut(board, board.cut)
+  const piece = board.links.slice(cut)
+  const rest = board.links.slice(0, cut)
+  return { piece, severed: valueOf(piece), rest, restValue: valueOf(rest) }
+}
+
+/** Apply the consequence of a cut to the lane. Slag never goes below zero. */
+export function settle(board: Board, exact: boolean): void {
+  board.slag = exact
+    ? Math.max(0, board.slag - SLAG_CLEARED_PER_HIT)
+    : board.slag + SLAG_PER_MISS
+}
+
+/** Melt everything in the lane. The caller feeds the coil to the furnace. */
+export function stoke(board: Board): void {
+  board.slag = 0
+}
+
+/** A fresh coil enters. The lane keeps its slag; that is the whole point. */
+export function reload(board: Board, links: number[]): void {
+  board.links = links
+  board.cut = clampCut(board, links.length - 1)
+}

--- a/dynawalla/games/coil/src/game/place.test.ts
+++ b/dynawalla/games/coil/src/game/place.test.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import {
+  MAX_PLACE,
+  breakAt,
+  breaksNeeded,
+  canBreak,
+  canonical,
+  coilOf,
+  fuseOnce,
+  isCanonical,
+  linkValue,
+  suffixValue,
+  suffixValues,
+  valueOf,
+} from "./place.ts"
+
+/** Seeded inside the file: no test in this package touches `Math.random`. */
+const SEED = 0x0c011960
+
+test("a link is an exact power of ten, at every place the game can reach", () => {
+  for (let p = 0; p <= MAX_PLACE; p++) {
+    const v = linkValue(p)
+    assert.ok(Number.isSafeInteger(v), `10^${String(p)} is exact`)
+    assert.equal(String(v), `1${"0".repeat(p)}`)
+  }
+  assert.throws(() => linkValue(-1), RangeError)
+  assert.throws(() => linkValue(MAX_PLACE + 1), RangeError)
+  assert.throws(() => linkValue(1.5), RangeError)
+})
+
+test("a coil is the numeral: 72 is seven tens and two ones", () => {
+  assert.deepEqual(coilOf(72), [1, 1, 1, 1, 1, 1, 1, 0, 0])
+  assert.deepEqual(coilOf(0), [])
+  assert.deepEqual(coilOf(5), [0, 0, 0, 0, 0])
+  // A zero digit is the *absence* of a link, which is what makes borrowing
+  // across a zero a physical fact rather than a rule about digits.
+  assert.deepEqual(coilOf(403), [2, 2, 2, 2, 0, 0, 0])
+  assert.equal(coilOf(403).filter((p) => p === 1).length, 0)
+})
+
+test("coilOf round-trips through valueOf for a wide sweep", () => {
+  const rng = new Rng(SEED)
+  for (let i = 0; i < 400; i++) {
+    const v = rng.int(0, 999_999)
+    assert.equal(valueOf(coilOf(v)), v)
+  }
+})
+
+test("coilOf refuses anything that is not a whole number", () => {
+  assert.throws(() => coilOf(-1), RangeError)
+  assert.throws(() => coilOf(1.5), RangeError)
+  assert.throws(() => coilOf(Number.NaN), RangeError)
+})
+
+test("breaking preserves the coil's value, exactly", () => {
+  const rng = new Rng(SEED ^ 0x11)
+  for (let i = 0; i < 200; i++) {
+    const value = rng.int(1, 99_999)
+    let links = coilOf(value)
+    for (let k = 0; k < 6; k++) {
+      const at = rng.int(0, links.length - 1)
+      if (!canBreak(links, at)) continue
+      links = breakAt(links, at)
+      assert.equal(valueOf(links), value)
+    }
+  }
+})
+
+test("breaking adds exactly nine links and leaves the ten in place", () => {
+  const links = coilOf(72)
+  const broken = breakAt(links, 4)
+  assert.equal(broken.length, links.length + 9)
+  assert.deepEqual(broken.slice(0, 4), [1, 1, 1, 1])
+  assert.deepEqual(broken.slice(4, 14), Array.from({ length: 10 }, () => 0))
+  assert.deepEqual(broken.slice(14), [1, 1, 0, 0])
+})
+
+test("breaking at the cut never changes what the cut is worth", () => {
+  // This is the property the whole interaction rests on: a child cracks a link
+  // open to get finer resolution, not to change the amount they are holding.
+  const rng = new Rng(SEED ^ 0x22)
+  for (let i = 0; i < 200; i++) {
+    let links = coilOf(rng.int(10, 99_999))
+    for (let k = 0; k < 5; k++) {
+      const cut = rng.int(0, links.length - 1)
+      if (!canBreak(links, cut)) continue
+      const before = suffixValue(links, cut)
+      links = breakAt(links, cut)
+      assert.equal(suffixValue(links, cut), before)
+    }
+  }
+})
+
+test("a bead cannot be cracked open", () => {
+  const links = coilOf(5)
+  assert.equal(canBreak(links, 0), false)
+  assert.deepEqual(breakAt(links, 0), links)
+  assert.equal(canBreak(links, 99), false)
+})
+
+test("fuse is the inverse of break, and it is the carry", () => {
+  const links = coilOf(72)
+  const broken = breakAt(links, 4)
+  const fused = fuseOnce(broken)
+  assert.notEqual(fused, null)
+  assert.deepEqual(fused, links)
+  assert.equal(fuseOnce(links), null)
+})
+
+test("fusing twelve ones onto sixty makes a numeral again", () => {
+  // 47 welded to 25: six tens and twelve ones, which is not how a number is
+  // written. Fusing until it no longer applies is the carry, and it lands on 72.
+  const welded = [...coilOf(40), ...coilOf(7), ...coilOf(20), ...coilOf(5)]
+  assert.equal(valueOf(welded), 72)
+  let chain = welded.slice()
+  for (let guard = 0; guard < 20; guard++) {
+    const next = fuseOnce(chain)
+    if (!next) break
+    chain = next
+  }
+  assert.equal(valueOf(chain), 72)
+  assert.deepEqual(canonical(chain), coilOf(72))
+})
+
+test("canonical form is the numeral, and a fresh coil is already in it", () => {
+  assert.equal(isCanonical(coilOf(4_003)), true)
+  assert.equal(isCanonical(breakAt(coilOf(4_003), 0)), false)
+  assert.deepEqual(canonical(breakAt(coilOf(4_003), 0)), coilOf(4_003))
+})
+
+test("suffixValues agrees with suffixValue at every joint", () => {
+  const rng = new Rng(SEED ^ 0x33)
+  const links = breakAt(breakAt(coilOf(rng.int(1_000, 9_999)), 0), 3)
+  const table = suffixValues(links)
+  assert.equal(table.length, links.length + 1)
+  assert.equal(table[links.length], 0)
+  for (let i = 0; i <= links.length; i++) assert.equal(table[i], suffixValue(links, i))
+})
+
+test("72 − 25: the demand costs exactly one break, and it is reachable", () => {
+  const links = coilOf(72)
+  // Twenty-five is not a suffix of seven tens and two ones. There is no cut.
+  assert.equal(suffixValues(links).includes(25), false)
+  assert.equal(breaksNeeded(links, 25), 1)
+
+  // Crack the ten at the boundary and walk the cut back through the ones.
+  const broken = breakAt(links, 4)
+  const table = suffixValues(broken)
+  const cut = table.indexOf(25)
+  assert.ok(cut > 0, "twenty-five is now a cut")
+  assert.equal(suffixValue(broken, cut), 25)
+  // What crawls on is the answer, and nobody subtracted anything.
+  assert.equal(valueOf(broken.slice(0, cut)), 47)
+})
+
+test("the change a demand costs is one break per place it has to reach down", () => {
+  const cases: [number, number, number][] = [
+    // Nothing to reach for: the demand is already the tail of the chain.
+    [72, 72, 0],
+    [403, 3, 0],
+    [9_999, 999, 0],
+    // One ten cracked open to make ones.
+    [72, 25, 1],
+    [93, 47, 1],
+    // No column of `64 − 31` regroups, and the cut still needs change: three
+    // tens and one one cannot be the end of a chain ending in four ones.
+    [64, 31, 1],
+    // Reaching from a hundred, or a thousand, down to a single one.
+    [500, 1, 2],
+    [1_000, 1, 3],
+    // Borrowing across a zero, physically: the tens link does not exist.
+    [403, 87, 2],
+    [4_003, 87, 3],
+    [400_300, 87, 2],
+  ]
+  for (const [whole, part, expected] of cases) {
+    assert.equal(breaksNeeded(coilOf(whole), part), expected, `${String(whole)} − ${String(part)}`)
+  }
+})
+
+test("a demand the coil cannot cover has no cut at all", () => {
+  assert.equal(breaksNeeded(coilOf(72), 73), -1)
+  assert.equal(breaksNeeded(coilOf(72), -1), -1)
+  assert.equal(breaksNeeded([], 1), -1)
+})
+
+test("every demand is reachable, and the search always terminates", () => {
+  const rng = new Rng(SEED ^ 0x44)
+  for (let i = 0; i < 500; i++) {
+    const whole = rng.int(1, 99_999)
+    const part = rng.int(0, whole)
+    const links = coilOf(whole)
+    const breaks = breaksNeeded(links, part)
+    assert.ok(breaks >= 0, `${String(part)} out of ${String(whole)} is reachable`)
+
+    // Replay the breaks the count promises and check the cut really exists.
+    let chain = links
+    for (let k = 0; k < breaks; k++) {
+      let taken = 0
+      let j = chain.length - 1
+      while (j >= 0 && taken + linkValue(chain[j] as number) <= part) {
+        taken += linkValue(chain[j] as number)
+        j--
+      }
+      chain = breakAt(chain, j)
+    }
+    assert.ok(suffixValues(chain).includes(part), "the cut exists after the breaks")
+    assert.equal(valueOf(chain), whole)
+  }
+})

--- a/dynawalla/games/coil/src/game/place.ts
+++ b/dynawalla/games/coil/src/game/place.ts
@@ -1,0 +1,216 @@
+// The coil, as arithmetic.
+//
+// A coil is an articulated chain of **links**, and a link is nothing but a
+// place: a link of place `p` is worth `10^p`. So a coil is an array of place
+// exponents, and its value is the sum of the powers — which makes a coil a
+// number written in base ten with the positions made physical instead of
+// implied.
+//
+//   72  →  [1,1,1,1,1,1,1, 0,0]      seven tens and two ones
+//   403 →  [2,2,2,2, 0,0,0]          four hundreds and three ones
+//
+// Everything in this file is exact integer arithmetic on `number`. Nothing is
+// rounded, nothing is compared with a tolerance, and no value ever leaves here
+// as a float: `10 ** p` is exact for every `p` this game can reach, and the
+// guard in `valueOf` is what keeps that true rather than assumed.
+//
+// Two operations, and they are the two things a child does in column
+// arithmetic:
+//
+//   * **break** — one link of place `p` becomes ten links of place `p−1`, in
+//     the position it occupied. That is the borrow, and it is the only way to
+//     get finer resolution out of a coil.
+//   * **fuse** — ten adjacent links of the same place become one link of the
+//     place above. That is the carry.
+//
+// Both preserve the coil's value exactly, and both are asserted to.
+
+/** The largest place a link may carry. `10 ** 15` is still an exact integer. */
+export const MAX_PLACE = 15
+
+/** The value of a single link of place `p`. Exact for every legal `p`. */
+export function linkValue(p: number): number {
+  if (!Number.isInteger(p) || p < 0 || p > MAX_PLACE) {
+    throw new RangeError(`coil: place ${String(p)} is out of range`)
+  }
+  return 10 ** p
+}
+
+/** The value of a whole coil, or of any run of links. */
+export function valueOf(links: readonly number[]): number {
+  let total = 0
+  for (const p of links) total += linkValue(p)
+  return total
+}
+
+/**
+ * The coil a whole number arrives as: its digits, biggest place at the head.
+ *
+ * This is the numeral and nothing more — `403` is four hundreds and three ones,
+ * with no tens link at all, exactly as the numeral is written. The zero in the
+ * middle is the *absence* of a link, which is what makes borrowing across a
+ * zero physically visible rather than a rule about digits.
+ */
+export function coilOf(value: number): number[] {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new RangeError(`coil: ${String(value)} is not a whole number`)
+  }
+  const links: number[] = []
+  const digits = String(value)
+  for (let i = 0; i < digits.length; i++) {
+    const d = digits.charCodeAt(i) - 48
+    const place = digits.length - 1 - i
+    for (let k = 0; k < d; k++) links.push(place)
+  }
+  return links
+}
+
+/**
+ * The value of the suffix `links[cut..]` — the piece the shear takes off.
+ *
+ * The severed piece is always a suffix because the shear makes **one** cut, at
+ * one joint, and the tail is the free end. That single constraint is what turns
+ * the coil into a place-value puzzle instead of a shopping list: you cannot
+ * simply pick out two tens and five ones, you have to arrange for them to be
+ * the last thing on the chain.
+ */
+export function suffixValue(links: readonly number[], cut: number): number {
+  let total = 0
+  for (let i = Math.max(0, cut); i < links.length; i++) total += linkValue(links[i] as number)
+  return total
+}
+
+/** Every value the shear can currently take, indexed by cut position. */
+export function suffixValues(links: readonly number[]): number[] {
+  const out = new Array<number>(links.length + 1)
+  let running = 0
+  out[links.length] = 0
+  for (let i = links.length - 1; i >= 0; i--) {
+    running += linkValue(links[i] as number)
+    out[i] = running
+  }
+  return out
+}
+
+/** A link may be cracked open when it is worth more than one. */
+export function canBreak(links: readonly number[], index: number): boolean {
+  const p = links[index]
+  return p !== undefined && p > 0
+}
+
+/**
+ * The borrow. `links[index]`, a link of place `p`, becomes ten links of place
+ * `p−1` **occupying the same position**.
+ *
+ * In place, and that is the whole design. If the ten new links were appended or
+ * the coil were re-sorted, the reachable suffix values would collapse to the
+ * running sums of a descending chain, and a demand like `25` against `72` would
+ * be unreachable no matter how much you broke: every ten would sit ahead of
+ * every one, so a suffix could never hold two tens and five ones. Breaking in
+ * place is what lets the borrowed ones sit between the tens you keep and the
+ * tens you give away.
+ *
+ * Returns a new array. The value is unchanged, and the value of the suffix at
+ * `index` is unchanged too — which is the property that makes breaking safe to
+ * do while aiming.
+ */
+export function breakAt(links: readonly number[], index: number): number[] {
+  if (!canBreak(links, index)) return links.slice()
+  const p = links[index] as number
+  const out = links.slice(0, index)
+  for (let k = 0; k < 10; k++) out.push(p - 1)
+  for (let i = index + 1; i < links.length; i++) out.push(links[i] as number)
+  return out
+}
+
+/**
+ * The carry, and the inverse of `breakAt`: the first run of ten adjacent links
+ * of the same place collapses into one link of the place above.
+ *
+ * Used when two coils are welded together — `47` welded to `25` is six tens and
+ * twelve ones, and twelve ones is not how a number is written. Applied until it
+ * no longer applies, a coil reaches canonical form: at most nine links of any
+ * one place, biggest first, which is the numeral again.
+ */
+export function fuseOnce(links: readonly number[]): number[] | null {
+  for (let i = 0; i + 9 < links.length; i++) {
+    const p = links[i] as number
+    if (p >= MAX_PLACE) continue
+    let run = true
+    for (let k = 1; k < 10; k++) {
+      if (links[i + k] !== p) {
+        run = false
+        break
+      }
+    }
+    if (!run) continue
+    const out = links.slice(0, i)
+    out.push(p + 1)
+    for (let j = i + 10; j < links.length; j++) out.push(links[j] as number)
+    return out
+  }
+  return null
+}
+
+/**
+ * The canonical form of a coil: the numeral for its value.
+ *
+ * Computed from the value rather than by fusing repeatedly, because they are
+ * the same answer and this one cannot loop. `fuseOnce` still exists as its own
+ * step so the carry can be *drawn* happening, ten links at a time.
+ */
+export function canonical(links: readonly number[]): number[] {
+  return coilOf(valueOf(links))
+}
+
+/** True when a coil is already the numeral for its value. */
+export function isCanonical(links: readonly number[]): boolean {
+  const want = canonical(links)
+  if (want.length !== links.length) return false
+  for (let i = 0; i < links.length; i++) if (want[i] !== links[i]) return false
+  return true
+}
+
+/**
+ * The fewest breaks that make `target` reachable as a suffix — how much change
+ * the demand costs.
+ *
+ * **Not the same number as the column algorithm's regroupings, and more often
+ * larger.** A single cut takes a *contiguous* tail, so `64 − 31` costs a break
+ * even though no column needs one: three tens and one one cannot be the end of
+ * a chain that finishes with four ones until a ten is cracked open. That is the
+ * shape of the constraint and it is deliberate — cracking a ten to make change
+ * is the physical act regrouping is a rule about, and this game charges for it
+ * every time it is genuinely needed and never when it is not.
+ *
+ * Not used to judge anything and never shown as a score. It drives the hint
+ * that surfaces after a long hesitation, and it is the measure the tests use to
+ * prove that every demand is reachable.
+ *
+ * The search is the strategy the interaction affords: walk in from the tail
+ * taking whole links while they fit, and when the next link overshoots, crack
+ * that link open and keep walking. It terminates because every break strictly
+ * reduces the place of the link at the boundary, and a link of place zero
+ * cannot overshoot a target the chain can cover.
+ */
+export function breaksNeeded(links: readonly number[], target: number): number {
+  if (target < 0 || target > valueOf(links)) return -1
+  let chain = links.slice()
+  let breaks = 0
+  for (;;) {
+    let taken = 0
+    let i = chain.length - 1
+    while (i >= 0) {
+      const v = linkValue(chain[i] as number)
+      if (taken + v > target) break
+      taken += v
+      i--
+    }
+    if (taken === target) return breaks
+    if (i < 0) return -1
+    if (!canBreak(chain, i)) return -1
+    chain = breakAt(chain, i)
+    breaks++
+    if (breaks > 64) return -1
+  }
+}

--- a/dynawalla/games/coil/src/game/reactions.test.ts
+++ b/dynawalla/games/coil/src/game/reactions.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { REACTIONS, type Moment, type Tier, energy, tierFor } from "./reactions.ts"
+
+test("being wrong is never the more interesting thing that happens", () => {
+  assert.ok(energy("slip") < energy("seat"), "energy(SLIP) < energy(SEAT)")
+  assert.ok(energy("seat") < energy("engage"))
+  assert.ok(energy("engage") < energy("illuminate"))
+})
+
+test("every tier fits inside the budget it declares", () => {
+  const ceilings: Record<Tier, number> = {
+    slip: 260,
+    seat: 200,
+    engage: 450,
+    illuminate: 1_800,
+  }
+  for (const [tier, ceiling] of Object.entries(ceilings) as [Tier, number][]) {
+    assert.ok(REACTIONS[tier].budgetMs <= ceiling, tier)
+    assert.ok(REACTIONS[tier].budgetMs > 0, tier)
+  }
+})
+
+test("escalation is on difficulty and repair, never on run length", () => {
+  // The whole input, spelled out. If a streak, a combo or a run counter is ever
+  // added to `Moment`, this fails — which is the point.
+  const moment: Moment = { exact: true, courseClosed: false, breaks: 0 }
+  assert.deepEqual(Object.keys(moment).sort(), ["breaks", "courseClosed", "exact"])
+  assert.equal(tierFor.length, 1)
+})
+
+test("the tier follows what the cut cost", () => {
+  assert.equal(tierFor({ exact: false, courseClosed: false, breaks: 0 }), "slip")
+  assert.equal(tierFor({ exact: false, courseClosed: false, breaks: 4 }), "slip")
+  assert.equal(tierFor({ exact: true, courseClosed: false, breaks: 0 }), "seat")
+  assert.equal(tierFor({ exact: true, courseClosed: false, breaks: 1 }), "engage")
+  assert.equal(tierFor({ exact: true, courseClosed: true, breaks: 0 }), "illuminate")
+})
+
+test("a slip is quieter and shorter than a seat on every axis that matters", () => {
+  assert.ok(REACTIONS.slip.peakGain < REACTIONS.seat.peakGain)
+  assert.ok(REACTIONS.slip.animatedElements < REACTIONS.seat.animatedElements)
+  assert.ok(REACTIONS.slip.particles < REACTIONS.seat.particles)
+})

--- a/dynawalla/games/coil/src/game/reactions.ts
+++ b/dynawalla/games/coil/src/game/reactions.ts
@@ -1,0 +1,60 @@
+// What the game does back, and how much of it.
+//
+// Two invariants from `docs/EXPERIENCE_DESIGN.md`, both asserted in
+// `reactions.test.ts` because neither survives being a comment:
+//
+//   1. **`energy(SLIP) < energy(SEAT)`.** Being wrong must not be the more
+//      interesting thing that happens. In this game that is easy to get wrong,
+//      because a piece of brass bouncing off the floor is inherently more
+//      animated than one seating into a recess — so the slip is deliberately
+//      short, dull, low-gain and nearly still, and the seat carries the light.
+//   2. **Escalation is on difficulty and repair, never on run length.**
+//      `tierFor` takes no streak, no combo and no run counter; its whole input
+//      is what the cut cost and whether it closed a course. A test asserts the
+//      shape of that input, so adding a streak means changing a test on purpose
+//      rather than by accident.
+
+export type Tier = "slip" | "seat" | "engage" | "illuminate"
+
+export type Reaction = {
+  readonly budgetMs: number
+  readonly particles: number
+  readonly peakGain: number
+  readonly animatedElements: number
+}
+
+export const REACTIONS: Record<Tier, Reaction> = {
+  // A lump of metal that did not fit, landing on stone. 260 ms, and over.
+  slip: { budgetMs: 260, particles: 9, peakGain: 0.2, animatedElements: 2 },
+  // The detent: the piece seats, one brick is laid, one bell.
+  seat: { budgetMs: 200, particles: 12, peakGain: 0.42, animatedElements: 3 },
+  // A cut that cost a regrouping. The whip runs the length of the coil.
+  engage: { budgetMs: 450, particles: 20, peakGain: 0.5, animatedElements: 5 },
+  // A course closed. The wall lights, once, for as long as it takes to see.
+  illuminate: { budgetMs: 900, particles: 34, peakGain: 0.6, animatedElements: 7 },
+}
+
+/** budgetMs × particles × peakGain × animatedElements. The proxy, spelled out. */
+export function energy(tier: Tier): number {
+  const r = REACTIONS[tier]
+  return r.budgetMs * r.particles * r.peakGain * r.animatedElements
+}
+
+/**
+ * What just happened, and nothing about how long it has been happening.
+ *
+ * `breaks` is how many links the child cracked open for this cut — the number
+ * of regroupings they performed, which is the honest difficulty of the item
+ * they just did rather than a count of how many they have done in a row.
+ */
+export type Moment = {
+  readonly exact: boolean
+  readonly courseClosed: boolean
+  readonly breaks: number
+}
+
+export function tierFor(moment: Moment): Tier {
+  if (!moment.exact) return "slip"
+  if (moment.courseClosed) return "illuminate"
+  return moment.breaks > 0 ? "engage" : "seat"
+}

--- a/dynawalla/games/coil/src/game/round.test.ts
+++ b/dynawalla/games/coil/src/game/round.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import type { Question } from "../contract.ts"
+import { Rng } from "../core/rng.ts"
+import { breaksNeeded, coilOf, valueOf } from "./place.ts"
+import { claimOf, isExact, roundFrom, stockFor } from "./round.ts"
+
+const SEED = 0x0c011960
+const MINUS = "−"
+
+function q(prompt: string, answer: string): Question {
+  return { id: "q1", prompt, answer, distractors: [], domain: "add", difficulty: 0 }
+}
+
+test("a subtraction makes the coil the minuend and the demand the subtrahend", () => {
+  const good = roundFrom(q(`72 ${MINUS} 25`, "47"))
+  assert.notEqual(good, null)
+  assert.equal(good?.mode, "take")
+  assert.equal(good?.coil, 72)
+  assert.equal(good?.demand, 25)
+  assert.equal(good?.ingot, 0)
+  assert.equal(good?.answer, 47)
+})
+
+test("an ASCII hyphen and an en dash read as subtraction too", () => {
+  for (const glyph of ["-", "–", MINUS]) {
+    const round = roundFrom(q(`93 ${glyph} 47`, "46"))
+    assert.equal(round?.mode, "take", glyph)
+    assert.equal(round?.coil, 93)
+    assert.equal(round?.demand, 47)
+  }
+})
+
+test("an addition puts the first addend in the cradle and shears the second", () => {
+  const round = roundFrom(q("47 + 25", "72"))
+  assert.equal(round?.mode, "fill")
+  assert.equal(round?.demand, 25)
+  assert.equal(round?.ingot, 47)
+  assert.equal(round?.answer, 72)
+  assert.ok((round?.coil ?? 0) >= 25, "the stock covers the demand")
+})
+
+test("the stock coil is ninety-six of the right order, and it always covers", () => {
+  assert.equal(stockFor(1), 96)
+  assert.equal(stockFor(96), 96)
+  assert.equal(stockFor(97), 960)
+  assert.equal(stockFor(960), 960)
+  assert.equal(stockFor(961), 9_600)
+  const rng = new Rng(SEED ^ 0x55)
+  for (let i = 0; i < 300; i++) {
+    const demand = rng.int(1, 500_000)
+    const stock = stockFor(demand)
+    assert.ok(stock >= demand)
+    assert.equal(String(stock).replace(/0+$/, ""), "96")
+    assert.ok(breaksNeeded(coilOf(stock), demand) >= 0, "the demand is cuttable from stock")
+  }
+})
+
+test("an item this game cannot cut is refused rather than approximated", () => {
+  assert.equal(roundFrom(q("1/2 + 1/4", "3/4")), null)
+  assert.equal(roundFrom(q("2.5 + 1.5", "4.0")), null)
+  assert.equal(roundFrom(q("", "0")), null)
+  assert.equal(roundFrom(q("nine", "0")), null)
+})
+
+test("a demand equal to the whole coil is a legal cut, not a refusal", () => {
+  // `allowZeroResult` is false on every active row, so the host does not serve
+  // this — but the shear can sever the whole chain at joint zero, so there is
+  // nothing to refuse.
+  const round = roundFrom(q(`5 ${MINUS} 5`, "0"))
+  assert.equal(round?.mode, "take")
+  assert.equal(round?.coil, 5)
+  assert.equal(round?.demand, 5)
+  assert.equal(claimOf(round as NonNullable<typeof round>, 5), 0)
+})
+
+test("an unparseable prompt with a whole answer still plays, as a fill", () => {
+  const round = roundFrom(q("what is nine and nine", "18"))
+  assert.equal(round?.mode, "fill")
+  assert.equal(round?.demand, 18)
+  assert.equal(round?.ingot, 0)
+  assert.equal(round?.coil, 96)
+})
+
+test("an inconsistent prompt falls back rather than trusting the operands", () => {
+  // The prompt says one thing and the canonical answer says another. The answer
+  // is the host's, so it wins, and the round becomes a plain fill: shear the
+  // answer itself off the stock coil. A pack must never quietly play a
+  // different problem from the one the curriculum served.
+  for (const [prompt, answer, demand] of [
+    ["40 + 40", "99", 99],
+    [`72 ${MINUS} 25`, "72", 72],
+  ] as [string, string, number][]) {
+    const round = roundFrom(q(prompt, answer))
+    assert.equal(round?.mode, "fill", prompt)
+    assert.equal(round?.demand, demand, prompt)
+    assert.equal(round?.ingot, 0, prompt)
+    assert.equal(round?.answer, Number(answer), prompt)
+  }
+})
+
+test("the claim is the canonical answer exactly when the cut is exact", () => {
+  const rng = new Rng(SEED ^ 0x66)
+  for (let i = 0; i < 500; i++) {
+    const add = rng.chance(0.5)
+    const a = rng.int(10, 9_999)
+    const b = rng.int(1, add ? 999 : Math.max(1, a - 1))
+    const answer = add ? a + b : a - b
+    const round = roundFrom(q(`${String(a)} ${add ? "+" : MINUS} ${String(b)}`, String(answer)))
+    assert.notEqual(round, null)
+    if (!round) continue
+
+    assert.equal(claimOf(round, round.demand), round.answer)
+    assert.equal(isExact(round, round.demand), true)
+
+    // Every other cut claims something else. That is what makes the cut the
+    // answer: there is no way to be wrong and land on the right number.
+    const off = rng.int(1, 40)
+    const wrong = Math.max(0, round.demand - off)
+    if (wrong !== round.demand) {
+      assert.notEqual(claimOf(round, wrong), round.answer)
+      assert.equal(isExact(round, wrong), false)
+    }
+  }
+})
+
+test("a claim is always a whole number, on any cut the shear can make", () => {
+  const round = roundFrom(q(`403 ${MINUS} 87`, "316"))
+  assert.notEqual(round, null)
+  if (!round) return
+  const links = coilOf(round.coil)
+  for (let cut = 0; cut <= links.length; cut++) {
+    const claimed = claimOf(round, valueOf(links.slice(cut)))
+    assert.ok(Number.isSafeInteger(claimed), `cut ${String(cut)} claims an integer`)
+    assert.ok(claimed >= 0)
+  }
+})
+
+test("a wrong cut produces the number that cut is worth, not noise", () => {
+  const round = roundFrom(q(`72 ${MINUS} 25`, "47"))
+  assert.notEqual(round, null)
+  if (!round) return
+  // Shearing two tens and the two loose ones — the greedy take that skips the
+  // borrow — leaves fifty. That is the smaller-from-larger family of error,
+  // performed rather than typed.
+  assert.equal(claimOf(round, 22), 50)
+  assert.equal(isExact(round, 22), false)
+})

--- a/dynawalla/games/coil/src/game/round.ts
+++ b/dynawalla/games/coil/src/game/round.ts
@@ -1,0 +1,150 @@
+// Reading a served question as a cut.
+//
+// The host serves column arithmetic — `72 − 25`, `47 + 25` — and this file is
+// the whole of how that becomes a physical act. There is one rule, and a child
+// is told it once:
+//
+//   > **Shear off the glowing number. The machine does the rest.**
+//
+// The glowing number is always the second operand, `b`. What the machine does
+// with the severed piece is what the operator says:
+//
+//   * `a − b`  the coil **is** `a`. The piece you shear off is carried away,
+//              and what crawls on is the answer. You never subtracted; you
+//              regrouped and took, and `a − b` came out.
+//   * `a + b`  the coil is stock. The piece you shear off is **welded** onto an
+//              ingot of `a` sitting in the wall, and the ingot's new value is
+//              the answer. Welding twelve ones onto seven is a carry, and the
+//              carry is drawn happening.
+//
+// In both, the cut is correct exactly when the severed value equals `b`, and in
+// both, the number reported to the host is a physical fact about the coil the
+// child left behind. There is no keypad and nothing to guess: a wrong cut
+// produces a wrong number that is *the number that cut is worth*.
+//
+// **Everything here is integer.** An item whose answer is not a non-negative
+// whole number is refused rather than approximated, and `mount.ts` asks the
+// host for another.
+
+import type { Question } from "../contract.ts"
+
+export type Mode = "take" | "fill"
+
+export type Round = {
+  readonly questionId: string
+  /** As carved on the wall. */
+  readonly prompt: string
+  readonly mode: Mode
+  /** The coil that arrives, as a whole number. */
+  readonly coil: number
+  /** The value that must be severed — the glowing operand. */
+  readonly demand: number
+  /** What is already in the wall's cradle. `0` in `take` mode. */
+  readonly ingot: number
+  /** The canonical answer, exactly as the host spelled it. */
+  readonly answerText: string
+  /** The canonical answer as an integer. */
+  readonly answer: number
+}
+
+/** U+2212 MINUS, U+2013 EN DASH and the ASCII hyphen all read as subtraction. */
+const OPERATORS = /^\s*(\d+)\s*([+−–-])\s*(\d+)\s*$/
+
+/**
+ * The stock coil, when the item does not hand us one.
+ *
+ * Ninety-six of something: the smallest `96 × 10^k` that can cover the demand.
+ * Ninety-six because the coil is named for it, and because `96` is nine tens
+ * and six ones — a coil whose head is deep in tens and whose tail is only six
+ * ones long, so almost every demand costs at least one break. A stock of `100`
+ * would be a single link, and a single link is not a coil.
+ */
+export function stockFor(demand: number): number {
+  let stock = 96
+  while (stock < demand && stock <= 96_000_000_000) stock *= 10
+  return stock
+}
+
+/** A decimal integer string, or `null`. Never `parseFloat`, never rounded. */
+function integerOf(text: string): number | null {
+  const trimmed = text.trim()
+  if (!/^\d+$/.test(trimmed)) return null
+  const value = Number(trimmed)
+  return Number.isSafeInteger(value) ? value : null
+}
+
+/**
+ * Build the round a question describes, or `null` when the item cannot be cut.
+ *
+ * The fallback is deliberate and total: an item whose prompt this cannot parse
+ * — a different family, a different renderer, a template that has not been
+ * written yet — still plays, as a `fill` with an empty cradle, where the
+ * demand simply *is* the answer. The game therefore has no way to be handed a
+ * question it cannot present, which is the only safe posture for a pack whose
+ * `covers` is a request rather than an instruction.
+ */
+export function roundFrom(q: Question): Round | null {
+  const answer = integerOf(q.answer)
+  if (answer === null) return null
+
+  const parsed = OPERATORS.exec(q.prompt)
+  if (parsed) {
+    const [, left, operator, right] = parsed
+    const a = integerOf(left ?? "")
+    const b = integerOf(right ?? "")
+    const subtract = operator !== "+"
+    if (a !== null && b !== null && b >= 1) {
+      if (subtract && a - b === answer && b <= a) {
+        return {
+          questionId: q.id,
+          prompt: q.prompt,
+          mode: "take",
+          coil: a,
+          demand: b,
+          ingot: 0,
+          answerText: q.answer.trim(),
+          answer,
+        }
+      }
+      if (!subtract && a + b === answer) {
+        return {
+          questionId: q.id,
+          prompt: q.prompt,
+          mode: "fill",
+          coil: stockFor(b),
+          demand: b,
+          ingot: a,
+          answerText: q.answer.trim(),
+          answer,
+        }
+      }
+    }
+  }
+
+  if (answer < 1) return null
+  return {
+    questionId: q.id,
+    prompt: q.prompt.trim() === "" ? q.answer.trim() : q.prompt,
+    mode: "fill",
+    coil: stockFor(answer),
+    demand: answer,
+    ingot: 0,
+    answerText: q.answer.trim(),
+    answer,
+  }
+}
+
+/**
+ * What the child is claiming, given the piece they sheared off.
+ *
+ * The number the host is told. It is never the game's opinion of whether the
+ * cut was right — it is what the machine is left holding.
+ */
+export function claimOf(round: Round, severed: number): number {
+  return round.mode === "take" ? round.coil - severed : round.ingot + severed
+}
+
+/** The game's own belief, for its own feedback. The host is the judge. */
+export function isExact(round: Round, severed: number): boolean {
+  return severed === round.demand
+}

--- a/dynawalla/games/coil/src/game/session.test.ts
+++ b/dynawalla/games/coil/src/game/session.test.ts
@@ -1,0 +1,270 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import type { Question } from "../contract.ts"
+import { Rng } from "../core/rng.ts"
+import { aim } from "./board.ts"
+import { breaksNeeded, coilOf, suffixValues } from "./place.ts"
+import { COURSE, type Report, createSession } from "./session.ts"
+
+const SEED = 0x0c011960
+const MINUS = "−"
+
+type Harness = {
+  session: ReturnType<typeof createSession>
+  reports: Report[]
+  transitions: { kind: string; label?: string }[]
+  served: number
+}
+
+function harness(questions: Question[], capacity = 96): Harness {
+  const reports: Report[] = []
+  const transitions: { kind: string; label?: string }[] = []
+  const state = { served: 0, t: 0 }
+  const session = createSession({
+    nextQuestion: () => {
+      const q = questions[state.served]
+      state.served += 1
+      return q ?? null
+    },
+    report: (r) => reports.push(r),
+    now: () => {
+      state.t += 1_000
+      return state.t
+    },
+    capacity,
+    transition: (kind, label) => transitions.push(label === undefined ? { kind } : { kind, label }),
+  })
+  return {
+    session,
+    reports,
+    transitions,
+    get served() {
+      return state.served
+    },
+  }
+}
+
+function ask(prompt: string, answer: string, id = "q"): Question {
+  return { id, prompt, answer, distractors: [], domain: "add", difficulty: 0 }
+}
+
+/** Park the shear where the pending piece is worth `want`, cracking as needed. */
+function dial(session: ReturnType<typeof createSession>, want: number): number {
+  let breaks = 0
+  for (let guard = 0; guard < 64; guard++) {
+    const table = suffixValues(session.board.links)
+    const exact = table.indexOf(want)
+    if (exact >= 0) {
+      session.aim(exact)
+      return breaks
+    }
+    let at = session.board.links.length - 1
+    for (let j = session.board.links.length - 1; j >= 0; j--) {
+      if ((table[j] as number) > want) {
+        at = j
+        break
+      }
+    }
+    session.aim(at)
+    if (!session.crack()) break
+    breaks++
+  }
+  return breaks
+}
+
+test("a run opens on the first item it can cut", () => {
+  const h = harness([ask(`72 ${MINUS} 25`, "47", "a")])
+  assert.equal(h.session.round?.coil, 72)
+  assert.equal(h.session.round?.demand, 25)
+  assert.deepEqual(h.session.board.links, coilOf(72))
+})
+
+test("an exact cut reports the answer the machine is left holding", () => {
+  const h = harness([ask(`72 ${MINUS} 25`, "47", "a")])
+  const breaks = dial(h.session, 25)
+  assert.equal(breaks, breaksNeeded(coilOf(72), 25))
+  const outcome = h.session.commit()
+  assert.equal(outcome?.severed, 25)
+  assert.equal(outcome?.claimed, 47)
+  assert.equal(outcome?.exact, true)
+  assert.deepEqual(h.reports, [{ questionId: "a", correct: true, ms: 1_000, answered: "47" }])
+})
+
+test("a careless cut reports the number that cut is worth", () => {
+  const h = harness([ask(`72 ${MINUS} 25`, "47", "a")])
+  // Two tens and the two loose ones: the take that skips the borrow.
+  dial(h.session, 22)
+  const outcome = h.session.commit()
+  assert.equal(outcome?.severed, 22)
+  assert.equal(outcome?.claimed, 50)
+  assert.equal(outcome?.exact, false)
+  assert.equal(h.reports[0]?.answered, "50")
+  assert.equal(h.reports[0]?.correct, false)
+})
+
+test("an addition welds the piece to the cradle and claims the total", () => {
+  const h = harness([ask("47 + 25", "72", "a")])
+  assert.equal(h.session.round?.mode, "fill")
+  assert.equal(h.session.round?.ingot, 47)
+  dial(h.session, 25)
+  const outcome = h.session.commit()
+  assert.equal(outcome?.claimed, 72)
+  assert.equal(h.reports[0]?.answered, "72")
+})
+
+test("a brick records what the child made, not the piece they cut", () => {
+  const take = harness([ask(`72 ${MINUS} 25`, "47", "a")])
+  dial(take.session, 25)
+  take.session.commit()
+  assert.deepEqual([...take.session.wall], [{ value: 47, mode: "take", course: 0 }])
+
+  const fill = harness([ask("47 + 25", "72", "b")])
+  dial(fill.session, 25)
+  fill.session.commit()
+  assert.deepEqual([...fill.session.wall], [{ value: 72, mode: "fill", course: 0 }])
+})
+
+test("one report per item, however many times the lever is pulled", () => {
+  const h = harness([ask(`72 ${MINUS} 25`, "47", "a")])
+  dial(h.session, 25)
+  h.session.commit()
+  h.session.commit()
+  h.session.commit()
+  assert.equal(h.reports.length, 1)
+})
+
+test("the coil the child is holding is the coil the shear left", () => {
+  const h = harness([ask(`72 ${MINUS} 25`, "47", "a")])
+  dial(h.session, 25)
+  const outcome = h.session.commit()
+  assert.equal(h.session.debugCoilValue(), 47)
+  assert.deepEqual([...(outcome?.rest ?? [])], h.session.board.links)
+})
+
+test("the wall never regresses, whatever the run does", () => {
+  const rng = new Rng(SEED ^ 0xbb)
+  const questions: Question[] = []
+  for (let i = 0; i < 60; i++) {
+    const a = rng.int(30, 9_999)
+    const b = rng.int(1, a - 1)
+    questions.push(ask(`${String(a)} ${MINUS} ${String(b)}`, String(a - b), `q${String(i)}`))
+  }
+  const h = harness(questions)
+  let height = 0
+  for (let i = 0; i < 50; i++) {
+    const round = h.session.round
+    if (!round) break
+    dial(h.session, rng.chance(0.55) ? round.demand : Math.max(1, round.demand - rng.int(1, 9)))
+    h.session.commit()
+    assert.ok(h.session.wall.length >= height, "no brick is ever taken back out")
+    height = h.session.wall.length
+    h.session.advance()
+  }
+  assert.ok(height > 0)
+  assert.equal(h.session.wall.length, h.session.exactCuts)
+})
+
+test("a course closing is a stopping point, and a miss never is", () => {
+  const questions: Question[] = []
+  for (let i = 0; i < COURSE + 2; i++) {
+    questions.push(ask(`90 ${MINUS} 40`, "50", `q${String(i)}`))
+  }
+  const h = harness(questions)
+  for (let i = 0; i < COURSE; i++) {
+    dial(h.session, 40)
+    h.session.commit()
+    h.session.advance()
+  }
+  assert.equal(h.transitions.length, 1)
+  assert.equal(h.transitions[0]?.kind, "level")
+  assert.equal(h.transitions[0]?.label, "course 1")
+
+  // Now miss, repeatedly. Nothing fires.
+  const before = h.transitions.length
+  for (let i = 0; i < 2; i++) {
+    dial(h.session, 30)
+    h.session.commit()
+    h.session.advance()
+  }
+  assert.equal(h.transitions.length, before)
+})
+
+test("an item the game cannot cut is skipped and never reported", () => {
+  const h = harness([
+    ask("1/2 + 1/4", "3/4", "frac"),
+    ask("2.5 + 1.5", "4.0", "dec"),
+    ask(`72 ${MINUS} 25`, "47", "good"),
+  ])
+  assert.equal(h.session.round?.questionId, "good")
+  dial(h.session, 25)
+  h.session.commit()
+  assert.equal(h.reports.length, 1)
+  assert.equal(h.reports[0]?.questionId, "good")
+})
+
+test("a host with nothing to serve leaves a quiet alley, not a crash", () => {
+  const h = harness([])
+  assert.equal(h.session.round, null)
+  assert.equal(h.session.commit(), null)
+  assert.equal(h.session.advance(), false)
+  assert.deepEqual(h.reports, [])
+})
+
+test("the furnace costs a coil and no record", () => {
+  const h = harness([ask(`72 ${MINUS} 25`, "47", "a"), ask(`93 ${MINUS} 47`, "46", "b")])
+  h.session.board.slag = 6
+  assert.equal(h.session.stoke(), true)
+  assert.equal(h.session.board.slag, 0)
+  assert.equal(h.session.round?.questionId, "b")
+  assert.deepEqual(h.reports, [], "nothing is recorded for a coil that was melted")
+})
+
+test("resizing the lane keeps the shear where the child left it", () => {
+  const h = harness([ask(`9999 ${MINUS} 1234`, "8765", "a")], 96)
+  h.session.aim(20)
+  const value = suffixValues(h.session.board.links)[20]
+  h.session.resize(40)
+  h.session.resize(96)
+  assert.equal(suffixValues(h.session.board.links)[h.session.board.cut], value)
+})
+
+test("a full run stays exact: every claim is an integer string", () => {
+  const rng = new Rng(SEED ^ 0xcc)
+  const questions: Question[] = []
+  for (let i = 0; i < 40; i++) {
+    const add = rng.chance(0.5)
+    const a = rng.int(20, 4_999)
+    const b = rng.int(1, add ? 999 : a - 1)
+    questions.push(
+      ask(
+        `${String(a)} ${add ? "+" : MINUS} ${String(b)}`,
+        String(add ? a + b : a - b),
+        `q${String(i)}`,
+      ),
+    )
+  }
+  const h = harness(questions)
+  for (let i = 0; i < 40; i++) {
+    const round = h.session.round
+    if (!round) break
+    dial(h.session, round.demand)
+    h.session.commit()
+    h.session.advance()
+  }
+  assert.equal(h.reports.length, 40)
+  for (const r of h.reports) {
+    assert.match(r.answered, /^\d+$/)
+    assert.equal(r.correct, true)
+  }
+  assert.equal(h.session.exactCuts, 40)
+})
+
+test("aim is free and never reaches the host", () => {
+  const h = harness([ask(`403 ${MINUS} 87`, "316", "a")])
+  for (let i = 0; i < 50; i++) aim(h.session.board, i % 7)
+  h.session.crack()
+  h.session.crack()
+  assert.deepEqual(h.reports, [])
+  assert.equal(h.session.answered, 0)
+})

--- a/dynawalla/games/coil/src/game/session.ts
+++ b/dynawalla/games/coil/src/game/session.ts
@@ -1,0 +1,229 @@
+// The run: rounds, the wall that gets built, and the one report per item.
+//
+// Deliberately DOM-free and clock-free — every dependency is injected — so the
+// whole rule set is tested in Node with no canvas, no host and no frame.
+//
+// **The wall never regresses.** A wrong cut costs slag, which the lane clears
+// again; it never takes a brick back out. That is the child-safe form of loss
+// aversion the programme is built on: the pull to come back is "my wall is
+// unfinished", not "my streak is at risk".
+
+import type { Question } from "../contract.ts"
+import { coilOf, valueOf } from "./place.ts"
+import {
+  type Board,
+  type Shear,
+  aim,
+  breakAtCut,
+  createBoard,
+  reload,
+  settle,
+  shear,
+  stoke,
+} from "./board.ts"
+import { type Mode, type Round, claimOf, isExact, roundFrom } from "./round.ts"
+
+/** Exact cuts that finish a course of the wall. */
+export const COURSE = 8
+
+/** Questions refused in a row before the run gives up asking. */
+const REFUSAL_LIMIT = 24
+
+export type Brick = {
+  /**
+   * The number the child made, not the piece they cut.
+   *
+   * The wall is a record of answers produced — in a take that is the coil that
+   * crawled on, in a fill it is the ingot's new total — because "what I made"
+   * is the thing worth looking back at, and the piece was only ever the means.
+   */
+  readonly value: number
+  readonly mode: Mode
+  /** The course this brick sits in, from zero. */
+  readonly course: number
+}
+
+export type Outcome = {
+  readonly round: Round
+  readonly severed: number
+  readonly claimed: number
+  readonly exact: boolean
+  readonly piece: readonly number[]
+  readonly rest: readonly number[]
+  readonly ms: number
+}
+
+export type Report = {
+  questionId: string
+  correct: boolean
+  ms: number
+  answered: string
+}
+
+export type SessionDeps = {
+  /** The next question, or `null` when the host has nothing. */
+  readonly nextQuestion: () => Question | null
+  readonly report: (r: Report) => void
+  /** Milliseconds. Injected so a test does not race a real clock. */
+  readonly now: () => number
+  /** Cells the lane offers. Re-set when the viewport changes. */
+  capacity: number
+  /** A natural stopping point was reached. Never called after a miss. */
+  readonly transition?: (kind: "level" | "run" | "boss", label?: string) => void
+}
+
+export type Session = ReturnType<typeof createSession>
+
+export function createSession(deps: SessionDeps) {
+  let round: Round | null = null
+  let board: Board = createBoard(coilOf(96), deps.capacity)
+  let startedAt = deps.now()
+  let answered = 0
+  let exactCuts = 0
+  const wall: Brick[] = []
+  /** Ids already reported, so a double lever-pull cannot inflate a record. */
+  const spent = new Set<string>()
+
+  const load = (): boolean => {
+    for (let attempt = 0; attempt < REFUSAL_LIMIT; attempt++) {
+      const question = deps.nextQuestion()
+      if (question === null) break
+      const next = roundFrom(question)
+      // An item this game cannot cut — a fraction, an empty pool, a family with
+      // no prompt renderer — is skipped rather than approximated, and the host
+      // is asked again. It is never reported, so nothing is recorded against a
+      // child for a question the pack declined to draw.
+      if (next === null) continue
+      round = next
+      board.capacity = deps.capacity
+      reload(board, coilOf(next.coil))
+      startedAt = deps.now()
+      return true
+    }
+    round = null
+    return false
+  }
+
+  load()
+
+  return {
+    get round(): Round | null {
+      return round
+    },
+    get board(): Board {
+      return board
+    },
+    get wall(): readonly Brick[] {
+      return wall
+    },
+    get answered(): number {
+      return answered
+    },
+    get exactCuts(): number {
+      return exactCuts
+    },
+    /** 0..1 across the current course. Drawn as a course being laid. */
+    get courseProgress(): number {
+      return (exactCuts % COURSE) / COURSE
+    },
+
+    /** The lane geometry changed. Keeps the shear where the child left it. */
+    resize(capacity: number): void {
+      deps.capacity = capacity
+      board.capacity = capacity
+      aim(board, board.cut)
+    },
+
+    aim(cut: number): void {
+      aim(board, cut)
+    },
+
+    /** The borrow. Returns false when the shear is on a link worth one. */
+    crack(): boolean {
+      return breakAtCut(board)
+    },
+
+    /** What the lever would take right now, without taking it. */
+    preview(): Shear {
+      return shear(board)
+    },
+
+    /**
+     * Pull the lever.
+     *
+     * One report per item, and the report carries the number the machine is
+     * left holding — not the game's opinion of it. `correct` is what the game
+     * believes so the host can see the disagreement; the host is the judge.
+     */
+    commit(): Outcome | null {
+      if (!round) return null
+      const result = shear(board)
+      const exact = isExact(round, result.severed)
+      const claimed = claimOf(round, result.severed)
+      const ms = Math.max(0, Math.round(deps.now() - startedAt))
+
+      if (!spent.has(round.questionId) && round.questionId !== "") {
+        spent.add(round.questionId)
+        deps.report({
+          questionId: round.questionId,
+          correct: exact,
+          ms,
+          answered: String(claimed),
+        })
+      }
+
+      answered += 1
+      settle(board, exact)
+      // The piece is gone from the lane the instant the jaws close, so the coil
+      // the child is looking at is always the coil they are holding. What flies
+      // to the wall is drawn by the renderer, not by the board.
+      reload(board, result.rest)
+      if (exact) {
+        exactCuts += 1
+        wall.push({
+          value: claimed,
+          mode: round.mode,
+          course: Math.floor((exactCuts - 1) / COURSE),
+        })
+        // A course laid is a stopping point the child *reached*. Never fired on
+        // a miss: a purchase surface must not sit next to a failure.
+        if (exactCuts % COURSE === 0) {
+          deps.transition?.("level", `course ${String(exactCuts / COURSE)}`)
+        }
+      }
+
+      return {
+        round,
+        severed: result.severed,
+        claimed,
+        exact,
+        piece: result.piece,
+        rest: result.rest,
+        ms,
+      }
+    },
+
+    /** The next coil enters. Slag stays; that is the point of slag. */
+    advance(): boolean {
+      return load()
+    },
+
+    /**
+     * Feed the coil to the furnace and melt every lump.
+     *
+     * Nothing is reported: the child did not answer, and an unanswered item is
+     * one the host simply never hears about. It is the only way out of a lane
+     * choked badly enough that the links worth borrowing from are buried, and
+     * it costs a coil rather than a record.
+     */
+    stoke(): boolean {
+      stoke(board)
+      return load()
+    },
+
+    /** Diagnostic only. Never drawn: this is the answer. */
+    debugCoilValue(): number {
+      return valueOf(board.links)
+    },
+  }
+}

--- a/dynawalla/games/coil/src/index.ts
+++ b/dynawalla/games/coil/src/index.ts
@@ -1,0 +1,5 @@
+// The package surface. A host imports `mount` and hands it an element and a
+// `Host`; nothing else here is public API.
+
+export { mount } from "./contract.ts"
+export type { Host, Question } from "./contract.ts"

--- a/dynawalla/games/coil/src/main.ts
+++ b/dynawalla/games/coil/src/main.ts
@@ -1,0 +1,45 @@
+// Standalone dev harness. `npm run dev` → a playable game wired to the local
+// stub Host, with no runtime underneath it.
+//
+//   ?seed=123     pin the question stream
+//   ?rung=5       pin the stub's rung 0..5 instead of letting it walk up
+//   ?reduced=1    force the reduced-motion branch
+
+import { mount } from "./contract.ts"
+import { createStubHost } from "./stubHost.ts"
+
+const el = document.getElementById("app")
+if (!el) throw new Error("coil: #app missing")
+
+const params = new URLSearchParams(location.search)
+const seed = Number(params.get("seed") ?? "") || 0x0c011960
+const rungParam = params.get("rung")
+const rung = rungParam === null ? undefined : Number(rungParam)
+const reduced = params.has("reduced") ? params.get("reduced") !== "0" : undefined
+
+let answered = 0
+let correct = 0
+const readout = document.getElementById("readout")
+
+const host = createStubHost({
+  seed,
+  ...(rung === undefined || Number.isNaN(rung) ? {} : { rung }),
+  ...(reduced === undefined ? {} : { reducedMotion: reduced }),
+  onReport(r) {
+    answered++
+    if (r.correct) correct++
+    if (readout) {
+      readout.textContent = `host.report → ${String(correct)}/${String(answered)} · last ${String(r.ms)}ms · "${r.answered}"`
+    }
+    console.info("[coil/host] report", r)
+  },
+})
+
+const handle = mount(el, host)
+
+// Vite HMR: tear the old instance down so audio contexts and rAF loops do not
+// accumulate across edits.
+type HotModule = { hot?: { dispose(cb: () => void): void } }
+;(import.meta as unknown as HotModule).hot?.dispose(() => {
+  handle.unmount()
+})

--- a/dynawalla/games/coil/src/mount.ts
+++ b/dynawalla/games/coil/src/mount.ts
@@ -1,0 +1,423 @@
+// THE COIL OF NINETY-SIX — the game.
+//
+// A brass coil descends the alley. It is a number, written in place value with
+// the positions made physical: a bead is one, a ribbed drum is ten, a pierced
+// ring is a hundred, a notched tower is a thousand. The wall carves the problem
+// and lights one operand.
+//
+//   > **Shear off the glowing number. The machine does the rest.**
+//
+// `72 − 25`: the coil *is* seventy-two. Shear twenty-five off it and what
+// crawls on is forty-seven — you never subtracted, you regrouped and took, and
+// the answer came out of the machine. `47 + 25`: the coil is stock, and the
+// piece you shear off is welded to an ingot of forty-seven sitting in the wall.
+//
+// The whole of the mathematics is in the cut, because the shear makes **one**
+// cut, at one joint, and takes the tail. Twenty-five is two tens and five ones,
+// and a coil of seven tens and two ones has only two ones on its tail — so you
+// crack a ten open into ten ones, right where the jaws are, and walk the cut
+// back through them. That is the borrow, and there is no other way to do it.
+//
+// Nothing here has a timer. Aiming is free, cracking is free, and hesitating is
+// free. What a careless cut costs is **space**: the piece falls in the lane as
+// slag, slag takes cells away, and a coil with nowhere to lie is buried
+// head-first — which takes away exactly the big links you borrow from. An exact
+// cut smashes two lumps on its way to the wall. The board you have to play on
+// is the board you made.
+
+import type { Host } from "./contract.ts"
+import { Audio } from "./audio/audio.ts"
+import { SLAG_CELLS, buried as buriedCount } from "./game/board.ts"
+import { breaksNeeded, coilOf } from "./game/place.ts"
+import { REACTIONS, type Tier, tierFor } from "./game/reactions.ts"
+import { COURSE, createSession } from "./game/session.ts"
+import { cellAt, cellNear, inside } from "./render/layout.ts"
+import { type SceneState, Scene } from "./render/scene.ts"
+
+/** Hesitation before the hint offers itself. Long, and it never hurries. */
+const HINT_AFTER_MS = 9_000
+
+export function mountCoil(el: HTMLElement, host: Host): { unmount(): void } {
+  const container = document.createElement("div")
+  container.style.cssText = "position:absolute;inset:0;overflow:hidden;background:#0b0906"
+  el.appendChild(container)
+
+  const scene = new Scene(container)
+  const audio = new Audio()
+  let reduced = host.prefersReducedMotion()
+
+  const session = createSession({
+    nextQuestion: () => {
+      try {
+        return host.next()
+      } catch (error) {
+        console.error("[coil] the host could not serve a question", error)
+        return null
+      }
+    },
+    report: (r) => {
+      host.report(r)
+    },
+    now: () => performance.now(),
+    capacity: scene.layout.lane.capacity,
+    transition: (kind, label) => {
+      host.transition?.(kind, label)
+    },
+  })
+
+  // Animated quantities. Every one of them is decayed in `frame`, and every one
+  // of them is pinned at rest under reduced motion — which is why that setting
+  // is a branch in one place rather than a second renderer.
+  const fx = {
+    aimPulse: 0,
+    crackPulse: 0,
+    seatPulse: 0,
+    missPulse: 0,
+    furnaceGlow: 0,
+    shearPress: 0,
+    whip: 0,
+    hint: 0,
+  }
+
+  let flight: SceneState["flight"] = null
+  let breaksThisRound = 0
+  let lastInputAt = performance.now()
+  let running = true
+  let raf = 0
+  let last = performance.now()
+  let clock = 0
+
+  // ------------------------------------------------------------------ input
+
+  const linkAt = (px: number, py: number): number => {
+    const lane = scene.layout.lane
+    const board = session.board
+    const cell = cellNear(lane, px, py, lane.capacity)
+    if (cell < 0) return -1
+    const index = buriedCount(board) + (cell - board.slag * SLAG_CELLS)
+    if (index < buriedCount(board) || index > board.links.length - 1) return -1
+    return index
+  }
+
+  const linkCentre = (index: number): { x: number; y: number } => {
+    const lane = scene.layout.lane
+    const cell = Math.max(
+      0,
+      Math.min(lane.capacity - 1, session.board.slag * SLAG_CELLS + (index - buriedCount(session.board))),
+    )
+    return cellAt(lane, cell)
+  }
+
+  // How fast `seatPulse` fades. Set from the tier's own budget, so a 260 ms
+  // slip cannot linger on screen for as long as a 900 ms course.
+  const decayFor = { current: 0.3 }
+
+  const react = (tier: Tier): void => {
+    const r = REACTIONS[tier]
+    const scale = reduced ? 0 : 1
+    switch (tier) {
+      case "slip":
+        fx.missPulse = 1
+        fx.whip = 0.35 * scale
+        break
+      case "seat":
+        fx.seatPulse = 1
+        fx.whip = 0.5 * scale
+        break
+      case "engage":
+        fx.seatPulse = 1
+        fx.whip = 0.85 * scale
+        break
+      case "illuminate":
+        fx.seatPulse = 1
+        fx.whip = 1 * scale
+        break
+    }
+    // The budget is honoured by the decay rate: a tier that owns 260 ms decays
+    // four times faster than one that owns 900.
+    decayFor.current = r.budgetMs / 1000
+  }
+
+  const commit = (): void => {
+    const round = session.round
+    if (!round || flight) return
+    const preview = session.preview()
+    const centre = linkCentre(session.board.cut)
+    const outcome = session.commit()
+    if (!outcome) return
+
+    const closed = outcome.exact && session.exactCuts % COURSE === 0
+    const tier = tierFor({ exact: outcome.exact, courseClosed: closed, breaks: breaksThisRound })
+    react(tier)
+
+    audio.shear()
+    if (!reduced) audio.partition(preview.piece, preview.rest, 0.12)
+    if (outcome.exact) {
+      audio.seat()
+      if (closed) audio.course()
+      host.haptic(closed ? "heavy" : "success")
+    } else {
+      audio.slag()
+      host.haptic("light")
+    }
+
+    flight = {
+      links: preview.piece,
+      exact: outcome.exact,
+      fromX: centre.x,
+      fromY: centre.y,
+      t: 0,
+    }
+    if (!reduced) {
+      if (outcome.exact) scene.burstSeat(centre.x, centre.y)
+      else scene.burstSlag(centre.x, centre.y)
+    }
+    breaksThisRound = 0
+  }
+
+  const crack = (): void => {
+    const centre = linkCentre(session.board.cut)
+    if (!session.crack()) {
+      // A bead cannot be cracked open. Nothing happens, quietly: a refusal that
+      // makes a noise teaches a child to fear the control.
+      return
+    }
+    breaksThisRound += 1
+    fx.crackPulse = 1
+    audio.crack(session.board.links[session.board.cut] as number)
+    host.haptic("medium")
+    if (!reduced) scene.burstCrack(centre.x, centre.y)
+  }
+
+  const stoke = (): void => {
+    if (flight) return
+    fx.furnaceGlow = 1
+    audio.furnace()
+    host.haptic("heavy")
+    const f = scene.layout.furnace
+    if (!reduced) scene.burstFurnace(f.x + f.w / 2, f.y)
+    session.stoke()
+    breaksThisRound = 0
+    lastInputAt = performance.now()
+    fx.hint = 0
+  }
+
+  let pointer = -1
+  let downIndex = -1
+  let movedIndex = -1
+  let cutOnDown = -1
+  let onShear = false
+
+  const local = (e: PointerEvent): { x: number; y: number } => {
+    const rect = scene.canvas.getBoundingClientRect()
+    return { x: e.clientX - rect.left, y: e.clientY - rect.top }
+  }
+
+  const onDown = (e: PointerEvent): void => {
+    if (pointer !== -1) return
+    pointer = e.pointerId
+    void audio.start()
+    lastInputAt = performance.now()
+    fx.hint = 0
+    const { x, y } = local(e)
+
+    if (inside(scene.layout.shear, x, y)) {
+      onShear = true
+      fx.shearPress = 1
+      return
+    }
+    if (inside(scene.layout.furnace, x, y)) {
+      stoke()
+      return
+    }
+    const index = linkAt(x, y)
+    if (index < 0) return
+    cutOnDown = session.board.cut
+    downIndex = index
+    movedIndex = index
+    session.aim(index)
+    fx.aimPulse = 1
+    if (index !== cutOnDown) audio.aim(session.board.links[index] as number)
+  }
+
+  const onMove = (e: PointerEvent): void => {
+    if (e.pointerId !== pointer || onShear || downIndex < 0) return
+    const { x, y } = local(e)
+    const index = linkAt(x, y)
+    if (index < 0 || index === movedIndex) return
+    movedIndex = index
+    session.aim(index)
+    fx.aimPulse = 1
+    audio.aim(session.board.links[session.board.cut] as number)
+  }
+
+  const onUp = (e: PointerEvent): void => {
+    if (e.pointerId !== pointer) return
+    pointer = -1
+    if (onShear) {
+      onShear = false
+      const { x, y } = local(e)
+      if (inside(scene.layout.shear, x, y)) commit()
+      return
+    }
+    // A second tap on the link the jaws are already parked on cracks it open.
+    // Aiming first is what makes that safe: there is no gesture that breaks a
+    // link you were not already looking at.
+    if (downIndex >= 0 && movedIndex === downIndex && cutOnDown === downIndex) crack()
+    downIndex = -1
+    movedIndex = -1
+    cutOnDown = -1
+  }
+
+  const onCancel = (): void => {
+    pointer = -1
+    onShear = false
+    downIndex = -1
+    movedIndex = -1
+    cutOnDown = -1
+  }
+
+  /** Keyboard, for a desk. Same three verbs, nothing extra. */
+  const onKey = (e: KeyboardEvent): void => {
+    const board = session.board
+    lastInputAt = performance.now()
+    fx.hint = 0
+    switch (e.key) {
+      case "ArrowLeft":
+        session.aim(board.cut - 1)
+        fx.aimPulse = 1
+        break
+      case "ArrowRight":
+        session.aim(board.cut + 1)
+        fx.aimPulse = 1
+        break
+      case "b":
+      case "B":
+        void audio.start()
+        crack()
+        break
+      case "Enter":
+      case " ":
+        void audio.start()
+        fx.shearPress = 1
+        commit()
+        break
+      default:
+        return
+    }
+    e.preventDefault()
+  }
+
+  scene.canvas.addEventListener("pointerdown", onDown)
+  scene.canvas.addEventListener("pointermove", onMove)
+  globalThis.addEventListener("pointerup", onUp)
+  globalThis.addEventListener("pointercancel", onCancel)
+  globalThis.addEventListener("keydown", onKey)
+
+  const media =
+    typeof matchMedia === "function" ? matchMedia("(prefers-reduced-motion: reduce)") : null
+  const onMedia = (): void => {
+    reduced = host.prefersReducedMotion()
+  }
+  media?.addEventListener("change", onMedia)
+
+  const resize = (): void => {
+    const l = scene.resize(container.clientWidth, container.clientHeight)
+    session.resize(l.lane.capacity)
+  }
+  const observer =
+    typeof ResizeObserver === "function"
+      ? new ResizeObserver(() => {
+          resize()
+        })
+      : null
+  observer?.observe(container)
+  globalThis.addEventListener("resize", resize)
+  resize()
+
+  // ------------------------------------------------------------------ frame
+
+  const decay = (v: number, dt: number, seconds: number): number =>
+    Math.max(0, v - dt / Math.max(0.05, seconds))
+
+  const frame = (now: number): void => {
+    if (!running) return
+    const dt = Math.min(0.05, Math.max(0, (now - last) / 1000))
+    last = now
+    clock += dt
+
+    fx.aimPulse = decay(fx.aimPulse, dt, 0.22)
+    fx.crackPulse = decay(fx.crackPulse, dt, 0.36)
+    fx.seatPulse = decay(fx.seatPulse, dt, decayFor.current)
+    fx.missPulse = decay(fx.missPulse, dt, 0.26)
+    fx.furnaceGlow = decay(fx.furnaceGlow, dt, 0.9)
+    fx.shearPress = decay(fx.shearPress, dt, 0.12)
+    fx.whip = decay(fx.whip, dt, reduced ? 0.001 : 0.5)
+    if (!reduced) scene.particles.step(dt)
+
+    if (flight) {
+      flight.t += dt / (reduced ? 0.18 : 0.52)
+      if (flight.t >= 1) {
+        flight = null
+        session.advance()
+        breaksThisRound = 0
+        lastInputAt = now
+      }
+    }
+
+    // The hint arrives on its own after a long stillness, and only when the
+    // demand actually costs a regrouping — telling a child the shape of a cut
+    // they could already reach is noise, not help.
+    const idle = now - lastInputAt
+    const round = session.round
+    const costly = round ? breaksNeeded(session.board.links, round.demand) > 0 : false
+    fx.hint =
+      idle > HINT_AFTER_MS && costly && !flight
+        ? Math.min(1, fx.hint + dt * 1.4)
+        : decay(fx.hint, dt, 0.4)
+
+    const board = session.board
+    const state: SceneState = {
+      round,
+      links: board.links,
+      cut: board.cut,
+      buried: buriedCount(board),
+      slag: board.slag,
+      ingot: round && round.mode === "fill" && round.ingot > 0 ? coilOf(round.ingot) : [],
+      wall: session.wall,
+      exactCuts: session.exactCuts,
+      reduced,
+      t: clock,
+      aimPulse: reduced ? 0 : fx.aimPulse,
+      crackPulse: reduced ? 0 : fx.crackPulse,
+      seatPulse: fx.seatPulse,
+      missPulse: fx.missPulse,
+      furnaceGlow: fx.furnaceGlow,
+      shearPress: fx.shearPress,
+      whip: reduced ? 0 : fx.whip,
+      hint: fx.hint,
+      flight,
+    }
+    scene.draw(state)
+    raf = requestAnimationFrame(frame)
+  }
+  raf = requestAnimationFrame(frame)
+
+  return {
+    unmount(): void {
+      running = false
+      cancelAnimationFrame(raf)
+      scene.canvas.removeEventListener("pointerdown", onDown)
+      scene.canvas.removeEventListener("pointermove", onMove)
+      globalThis.removeEventListener("pointerup", onUp)
+      globalThis.removeEventListener("pointercancel", onCancel)
+      globalThis.removeEventListener("keydown", onKey)
+      globalThis.removeEventListener("resize", resize)
+      observer?.disconnect()
+      media?.removeEventListener("change", onMedia)
+      audio.dispose()
+      scene.destroy()
+      container.remove()
+    },
+  }
+}

--- a/dynawalla/games/coil/src/pack.ts
+++ b/dynawalla/games/coil/src/pack.ts
@@ -1,0 +1,45 @@
+// THE COIL OF NINETY-SIX, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous surface `Host` in
+// `contract.ts` already describes — so the coil, the shear, the lane and the
+// wall are untouched by the swap.
+//
+// What crosses the boundary is the item, and the game reads exactly two things
+// off it: the prompt, which it carves on the wall and parses into a whole and a
+// demand, and the canonical answer, which is what `items.reveal` is for. The
+// game never decides whether a cut was right — it reports the number the
+// machine is left holding, and the host judges it.
+//
+// `items.reveal` is declared in `pack.json` for that reason and is not
+// optional: without it the adapter's pool never fills, and a pack that mounts,
+// warms and serves nothing is the failure mode with no symptom.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import { mount } from "./contract.ts"
+import type { Host } from "./contract.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("coil: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "add-sub" })
+  // Stocked before the first frame: the first coil is built from the first
+  // item, and a coil with no number behind it is the kind of thing that happens
+  // exactly once, on launch, in front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context are torn down before the frame is, rather than a frame or two
+  // after it.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[coil] could not start", error)
+  renderNoHost(root, "THE COIL OF NINETY-SIX")
+})

--- a/dynawalla/games/coil/src/render/layout.test.ts
+++ b/dynawalla/games/coil/src/render/layout.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import { LANE_CELLS, cellAt, cellNear, inside, layout } from "./layout.ts"
+
+const SEED = 0x0c011960
+
+/** Phone portrait, phone landscape, tablet portrait, tablet landscape, desktop. */
+const VIEWPORTS: [number, number][] = [
+  [320, 568],
+  [390, 844],
+  [844, 390],
+  [768, 1024],
+  [1024, 768],
+  [1366, 1024],
+  [1920, 1080],
+]
+
+test("the lane never claims more than ninety-six cells", () => {
+  for (const [w, h] of VIEWPORTS) {
+    const l = layout(w, h)
+    assert.ok(l.lane.capacity <= LANE_CELLS, `${String(w)}×${String(h)}`)
+    assert.ok(l.lane.capacity >= 12, `${String(w)}×${String(h)} is playable`)
+  }
+})
+
+test("nothing overlaps and nothing leaves the viewport", () => {
+  for (const [w, h] of VIEWPORTS) {
+    const l = layout(w, h)
+    assert.ok(l.wall.y >= 0)
+    assert.ok(l.wall.x >= 0)
+    assert.ok(l.wall.x + l.wall.w <= w + 0.5)
+    assert.ok(l.lane.y >= l.wall.y + l.wall.h, `${String(w)}×${String(h)} lane clears the wall`)
+    assert.ok(l.levers.y >= l.lane.y + l.lane.h - 0.5)
+    assert.ok(l.levers.y + l.levers.h <= h + 0.5)
+    assert.ok(l.shear.x + l.shear.w <= l.levers.x + l.levers.w + 0.5)
+    assert.ok(l.furnace.x + l.furnace.w < l.shear.x, "the two levers cannot be confused")
+  }
+})
+
+test("every lever is at least a finger across", () => {
+  for (const [w, h] of VIEWPORTS) {
+    const l = layout(w, h)
+    assert.ok(l.shear.w >= 44 && l.shear.h >= 44, `shear at ${String(w)}×${String(h)}`)
+    assert.ok(l.furnace.w >= 44 && l.furnace.h >= 44, `furnace at ${String(w)}×${String(h)}`)
+  }
+})
+
+test("consecutive lane cells are adjacent — the chain never jumps", () => {
+  for (const [w, h] of VIEWPORTS) {
+    const l = layout(w, h)
+    for (let i = 1; i < l.lane.capacity; i++) {
+      const a = cellAt(l.lane, i - 1)
+      const b = cellAt(l.lane, i)
+      const d = Math.hypot(a.x - b.x, a.y - b.y)
+      assert.ok(d <= Math.max(l.lane.pitch, l.lane.rowPitch) + 1, `${String(i)} at ${String(w)}`)
+    }
+  }
+})
+
+test("the serpentine turns at the end of every row and never crosses itself", () => {
+  const l = layout(1024, 768)
+  const seen = new Set<string>()
+  for (let i = 0; i < l.lane.capacity; i++) {
+    const c = cellAt(l.lane, i)
+    const key = `${String(Math.round(c.x))}:${String(Math.round(c.y))}`
+    assert.equal(seen.has(key), false, `cell ${String(i)} is its own`)
+    seen.add(key)
+  }
+  assert.equal(cellAt(l.lane, 0).dir, 1)
+  assert.equal(cellAt(l.lane, l.lane.cols).dir, -1)
+})
+
+test("cellNear finds the cell under a point and refuses one that is not", () => {
+  const l = layout(768, 1024)
+  const rng = new Rng(SEED ^ 0xdd)
+  for (let k = 0; k < 200; k++) {
+    const i = rng.int(0, l.lane.capacity - 1)
+    const c = cellAt(l.lane, i)
+    const jitter = l.lane.pitch * 0.2
+    const hit = cellNear(l.lane, c.x + rng.range(-jitter, jitter), c.y + rng.range(-jitter, jitter), l.lane.capacity)
+    assert.equal(hit, i)
+  }
+  assert.equal(cellNear(l.lane, -500, -500, l.lane.capacity), -1)
+})
+
+test("a point inside a rect is inside it", () => {
+  const l = layout(1024, 768)
+  assert.equal(inside(l.shear, l.shear.x + 1, l.shear.y + 1), true)
+  assert.equal(inside(l.shear, l.shear.x - 1, l.shear.y + 1), false)
+  assert.equal(inside(l.furnace, l.shear.x + 1, l.shear.y + 1), false)
+})
+
+test("the layout is a pure function of the viewport", () => {
+  for (const [w, h] of VIEWPORTS) {
+    assert.deepEqual(layout(w, h), layout(w, h))
+  }
+})

--- a/dynawalla/games/coil/src/render/layout.ts
+++ b/dynawalla/games/coil/src/render/layout.ts
@@ -1,0 +1,141 @@
+// Where everything is. Pure geometry, no canvas, no state — so the lane's
+// capacity, which is a *rule* (it is what slag takes away), is computed by a
+// function a test can call.
+//
+// The lane is a serpentine: rows walked alternately left-to-right and
+// right-to-left, which is the shape a centipede descends a screen in and the
+// shape that fits the most links into a rectangle without ever crossing itself.
+//
+// **The lane holds ninety-six cells.** That is the coil the game is named for:
+// a full lane is nine tens and six ones of brass, and every lump of slag takes
+// two of them away for good until an exact cut smashes it.
+
+/** The lane's ceiling, whatever the viewport offers. The title, literally. */
+export const LANE_CELLS = 96
+
+/** Sixteen to a row, so six rows are the whole ninety-six. */
+export const LANE_COLS = 16
+
+export type Rect = { x: number; y: number; w: number; h: number }
+
+export type Lane = Rect & {
+  rows: number
+  cols: number
+  /** Distance between two link centres along a row. */
+  pitch: number
+  rowPitch: number
+  /** Radius the largest link is drawn at. */
+  unit: number
+  capacity: number
+}
+
+export type Layout = {
+  w: number
+  h: number
+  /** Small screens get a tighter wall and one fewer lane row. */
+  compact: boolean
+  wall: Rect
+  lane: Lane
+  levers: Rect
+  shear: Rect
+  furnace: Rect
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v))
+}
+
+export function layout(w: number, h: number): Layout {
+  const compact = Math.min(w, h) < 560
+  const pad = clamp(Math.min(w, h) * 0.035, 10, 26)
+
+  const wallH = clamp(h * (compact ? 0.26 : 0.28), 118, 240)
+  const leverH = clamp(h * 0.13, 70, 118)
+
+  const wall: Rect = { x: pad, y: pad, w: w - pad * 2, h: wallH }
+  const levers: Rect = { x: pad, y: h - leverH - pad, w: w - pad * 2, h: leverH }
+
+  const laneY = wall.y + wall.h + pad * 0.9
+  const laneH = Math.max(80, levers.y - pad * 0.9 - laneY)
+  const laneW = w - pad * 2
+
+  // Sixteen cells to a row, six rows: ninety-six, which is the coil the game is
+  // named for and exactly the lane it gets. Capping the columns rather than
+  // filling the width is what makes the serpentine serpentine — a desktop lane
+  // thirty cells wide would draw one long straight line and never turn.
+  const pitch = clamp(Math.min(laneW / LANE_COLS, laneH / 6.2), 15, 44)
+  const cols = Math.max(6, Math.min(LANE_COLS, Math.floor(laneW / pitch)))
+  const rowPitch = clamp(laneH / 6, pitch * 1.15, pitch * 1.9)
+  const rows = Math.max(2, Math.min(7, Math.floor(laneH / rowPitch)))
+
+  const lane: Lane = {
+    x: pad,
+    y: laneY,
+    w: laneW,
+    h: laneH,
+    rows,
+    cols,
+    pitch,
+    rowPitch,
+    unit: pitch * 0.44,
+    capacity: Math.min(LANE_CELLS, rows * cols),
+  }
+
+  const leverW = clamp(levers.w * 0.34, 108, 220)
+  const shear: Rect = {
+    x: levers.x + levers.w - leverW,
+    y: levers.y,
+    w: leverW,
+    h: levers.h,
+  }
+  const furnace: Rect = {
+    x: levers.x,
+    y: levers.y,
+    w: clamp(levers.w * 0.26, 84, 168),
+    h: levers.h,
+  }
+
+  return { w, h, compact, wall, lane, levers, shear, furnace }
+}
+
+/**
+ * The centre of lane cell `i`, and which way the coil is travelling through it.
+ *
+ * Odd rows run right-to-left, so consecutive cells are always adjacent and the
+ * chain never jumps. `dir` is what the renderer rotates a link by, and what
+ * makes the turn at the end of a row read as a turn rather than a teleport.
+ */
+export function cellAt(lane: Lane, i: number): { x: number; y: number; dir: 1 | -1 } {
+  const index = Math.max(0, i)
+  const row = Math.min(lane.rows - 1, Math.floor(index / lane.cols))
+  const raw = index - row * lane.cols
+  const col = row % 2 === 0 ? raw : lane.cols - 1 - raw
+  const spanW = lane.pitch * lane.cols
+  const left = lane.x + (lane.w - spanW) / 2 + lane.pitch / 2
+  const spanH = lane.rowPitch * lane.rows
+  const top = lane.y + (lane.h - spanH) / 2 + lane.rowPitch / 2
+  return {
+    x: left + col * lane.pitch,
+    y: top + row * lane.rowPitch,
+    dir: row % 2 === 0 ? 1 : -1,
+  }
+}
+
+/** The cell nearest a point, or `-1` when the point is not on the lane. */
+export function cellNear(lane: Lane, px: number, py: number, count: number): number {
+  let best = -1
+  let bestD = (lane.pitch * 0.95) ** 2
+  for (let i = 0; i < count; i++) {
+    const c = cellAt(lane, i)
+    const d = (c.x - px) ** 2 + (c.y - py) ** 2
+    if (d < bestD) {
+      bestD = d
+      best = i
+    }
+  }
+  return best
+}
+
+export function inside(r: Rect, px: number, py: number): boolean {
+  return px >= r.x && px <= r.x + r.w && py >= r.y && py <= r.y + r.h
+}

--- a/dynawalla/games/coil/src/render/palette.ts
+++ b/dynawalla/games/coil/src/render/palette.ts
@@ -1,0 +1,103 @@
+// THE COIL OF NINETY-SIX — the forge alley of the bazaar, after dark.
+//
+// The register: carved stone the colour of dry earth, brass that has been
+// handled, lapis inlay on the hundreds, and one cold light — the wall's carved
+// recess, lit from inside as if the mountain behind it were open. Warmth is
+// material (brass, ember, oxide); the cold is structural (the wall, the
+// celestial line the shear rides).
+//
+// Two rules this palette exists to enforce:
+//
+//   * **A place is a silhouette before it is a colour.** A one is a bead, a ten
+//     is a ribbed drum, a hundred is a pierced ring, a thousand is a notched
+//     tower. Colour follows, so the coil reads for a colour-blind child by
+//     construction rather than by luck.
+//   * **A numeral is never coloured information.** Every numeral is the same
+//     bone-white, one weight, on a dark carved ground. What glows on the wall is
+//     the *demand*, and it glows by light, not by hue.
+
+export const STONE_DEEP = "#0b0906"
+export const STONE = "#161210"
+export const STONE_LIT = "#221b16"
+export const STONE_EDGE = "#332821"
+export const GROOVE = "#0d0a08"
+
+export const BRASS = "#c08a2c"
+export const BRASS_HOT = "#ffd98a"
+export const BRASS_DARK = "#5e4113"
+export const BRASS_RIM = "#e8b96a"
+
+export const LAPIS = "#22408c"
+export const LAPIS_HOT = "#79b0ff"
+
+/** The cold light in the wall. Used for the recess, the shear, and nothing else. */
+export const CELESTIAL = "#a6e9ff"
+export const CELESTIAL_DIM = "#4b7d90"
+
+/** Oxide. Slag, and the buried head of a choked coil. */
+export const SLAG = "#3a4038"
+export const SLAG_EDGE = "#5c665a"
+
+export const EMBER = "#ff7a2c"
+export const EMBER_HOT = "#ffd0a0"
+
+export const BONE = "#f3e7cf"
+export const BONE_DIM = "#8b8272"
+export const INK = "#070504"
+
+export const UI_FONT =
+  '600 16px/1 "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif'
+
+export function font(size: number, weight = 700): string {
+  return `${String(weight)} ${String(Math.round(size))}px "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif`
+}
+
+export function numerals(size: number, weight = 700): string {
+  return `${String(weight)} ${String(Math.round(size))}px ui-monospace, "SF Mono", Menlo, monospace`
+}
+
+export function withAlpha(hex: string, a: number): string {
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+  return `rgba(${String(r)}, ${String(g)}, ${String(b)}, ${String(a)})`
+}
+
+/**
+ * The body colour of a link of place `p`.
+ *
+ * Brass through the ones and tens, lapis from the hundreds up, going colder and
+ * paler with each place so a six-figure coil reads as a gradient of *material*
+ * from the head down to the tail. The silhouette carries the actual reading.
+ */
+export function linkBody(p: number): string {
+  switch (p) {
+    case 0:
+      return "#d29a3a"
+    case 1:
+      return BRASS
+    case 2:
+      return "#3a5aa8"
+    case 3:
+      return "#7c86a8"
+    case 4:
+      return "#9aa4b8"
+    default:
+      return "#b9c1cc"
+  }
+}
+
+export function linkRim(p: number): string {
+  switch (p) {
+    case 0:
+      return BRASS_HOT
+    case 1:
+      return "#efc470"
+    case 2:
+      return LAPIS_HOT
+    case 3:
+      return "#cdd6ea"
+    default:
+      return "#e6ecf5"
+  }
+}

--- a/dynawalla/games/coil/src/render/particles.ts
+++ b/dynawalla/games/coil/src/render/particles.ts
@@ -1,0 +1,138 @@
+// A fixed-capacity particle pool. Allocated once, never grown, never garbage —
+// a mid-range Android WebView cannot afford a collection inside the frame that
+// carries the reaction.
+//
+// Three kinds, and they are the three materials in the game: brass filings off
+// a break, cold sparks off a seat, and oxide dust off a lump of slag hitting
+// the floor. Nothing here is confetti and nothing bursts radially from a point
+// for its own sake — every emitter is called by something that physically
+// happened.
+
+export const KIND_FILING = 0
+export const KIND_SPARK = 1
+export const KIND_DUST = 2
+
+const CAPACITY = 320
+
+type P = {
+  alive: boolean
+  kind: number
+  x: number
+  y: number
+  vx: number
+  vy: number
+  life: number
+  maxLife: number
+  size: number
+  spin: number
+  angle: number
+  colour: string
+}
+
+export class Particles {
+  private readonly pool: P[] = []
+  private cursor = 0
+
+  constructor() {
+    for (let i = 0; i < CAPACITY; i++) {
+      this.pool.push({
+        alive: false,
+        kind: 0,
+        x: 0,
+        y: 0,
+        vx: 0,
+        vy: 0,
+        life: 0,
+        maxLife: 1,
+        size: 1,
+        spin: 0,
+        angle: 0,
+        colour: "#fff",
+      })
+    }
+  }
+
+  private take(): P {
+    for (let n = 0; n < CAPACITY; n++) {
+      const p = this.pool[this.cursor] as P
+      this.cursor = (this.cursor + 1) % CAPACITY
+      if (!p.alive) return p
+    }
+    // Every slot is live. Steal the oldest rather than dropping the event: a
+    // missing burst reads as a bug, an overwritten one reads as a busy frame.
+    return this.pool[this.cursor] as P
+  }
+
+  clear(): void {
+    for (const p of this.pool) p.alive = false
+  }
+
+  emit(
+    kind: number,
+    x: number,
+    y: number,
+    count: number,
+    speed: number,
+    colour: string,
+    spread = Math.PI * 2,
+    aim = 0,
+  ): void {
+    for (let i = 0; i < count; i++) {
+      const p = this.take()
+      const a = aim + (i / Math.max(1, count) - 0.5) * spread + Math.random() * 0.24 - 0.12
+      const s = speed * (0.5 + Math.random() * 0.8)
+      p.alive = true
+      p.kind = kind
+      p.x = x
+      p.y = y
+      p.vx = Math.cos(a) * s
+      p.vy = Math.sin(a) * s
+      p.maxLife = kind === KIND_SPARK ? 0.42 : 0.7 + Math.random() * 0.4
+      p.life = p.maxLife
+      p.size = kind === KIND_DUST ? 2.4 + Math.random() * 2.6 : 1.4 + Math.random() * 2.2
+      p.angle = Math.random() * Math.PI
+      p.spin = (Math.random() - 0.5) * 12
+      p.colour = colour
+    }
+  }
+
+  step(dt: number): void {
+    for (const p of this.pool) {
+      if (!p.alive) continue
+      p.life -= dt
+      if (p.life <= 0) {
+        p.alive = false
+        continue
+      }
+      p.x += p.vx * dt
+      p.y += p.vy * dt
+      p.angle += p.spin * dt
+      // Filings and dust fall; sparks are light and drift.
+      p.vy += (p.kind === KIND_SPARK ? 190 : 980) * dt
+      const drag = p.kind === KIND_SPARK ? 2.4 : 1.1
+      p.vx -= p.vx * drag * dt
+    }
+  }
+
+  draw(ctx: CanvasRenderingContext2D): void {
+    for (const p of this.pool) {
+      if (!p.alive) continue
+      const t = p.life / p.maxLife
+      ctx.globalAlpha = p.kind === KIND_SPARK ? t : Math.min(1, t * 1.6)
+      ctx.fillStyle = p.colour
+      if (p.kind === KIND_DUST) {
+        ctx.beginPath()
+        ctx.arc(p.x, p.y, p.size * (0.5 + t * 0.7), 0, Math.PI * 2)
+        ctx.fill()
+      } else {
+        ctx.save()
+        ctx.translate(p.x, p.y)
+        ctx.rotate(p.angle)
+        const w = p.size * (p.kind === KIND_SPARK ? 2.6 : 1.5)
+        ctx.fillRect(-w / 2, -p.size / 2, w, p.size)
+        ctx.restore()
+      }
+    }
+    ctx.globalAlpha = 1
+  }
+}

--- a/dynawalla/games/coil/src/render/scene.ts
+++ b/dynawalla/games/coil/src/render/scene.ts
@@ -1,0 +1,806 @@
+// Everything that is drawn, and nothing that is decided.
+//
+// The scene takes a snapshot and paints it. It holds no game state, judges
+// nothing, and every animated quantity arrives as a number between zero and one
+// that `mount.ts` decays — so `prefersReducedMotion` is a set of numbers pinned
+// to their resting values rather than a second renderer.
+//
+// The register is the forge alley: carved stone, a girih lattice that is
+// *structure* and not wallpaper (it is the wall the bricks are laid into), and
+// exactly one cold light — the recess. Nothing glows for encouragement.
+
+import type { Brick } from "../game/session.ts"
+import type { Round } from "../game/round.ts"
+import { coilOf, linkValue } from "../game/place.ts"
+import { COURSE } from "../game/session.ts"
+import { SLAG_CELLS } from "../game/board.ts"
+import { type Layout, type Lane, cellAt, layout as computeLayout } from "./layout.ts"
+import { KIND_DUST, KIND_FILING, KIND_SPARK, Particles } from "./particles.ts"
+import {
+  BONE,
+  BONE_DIM,
+  BRASS,
+  BRASS_DARK,
+  BRASS_HOT,
+  CELESTIAL,
+  CELESTIAL_DIM,
+  EMBER,
+  EMBER_HOT,
+  GROOVE,
+  INK,
+  SLAG as SLAG_COLOUR,
+  SLAG_EDGE,
+  STONE,
+  STONE_DEEP,
+  STONE_EDGE,
+  STONE_LIT,
+  font,
+  linkBody,
+  linkRim,
+  numerals,
+  withAlpha,
+} from "./palette.ts"
+
+export type Flight = {
+  readonly links: readonly number[]
+  readonly exact: boolean
+  /** Where the piece was when the jaws closed. */
+  readonly fromX: number
+  readonly fromY: number
+  /** 0 at the lane, 1 at the wall recess or the floor. */
+  t: number
+}
+
+export type SceneState = {
+  round: Round | null
+  links: readonly number[]
+  cut: number
+  buried: number
+  slag: number
+  /** The cradle coil in `fill` mode: what the severed piece welds onto. */
+  ingot: readonly number[]
+  wall: readonly Brick[]
+  exactCuts: number
+  reduced: boolean
+  /** Seconds since mount, for the few things that idle. */
+  t: number
+  /** 0..1, decayed by the caller. */
+  aimPulse: number
+  crackPulse: number
+  seatPulse: number
+  missPulse: number
+  furnaceGlow: number
+  shearPress: number
+  whip: number
+  /** 0..1 — the ghost of the demand, offered after a long hesitation. */
+  hint: number
+  flight: Flight | null
+}
+
+const TAU = Math.PI * 2
+
+function roundRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+): void {
+  const rad = Math.min(r, w / 2, h / 2)
+  ctx.beginPath()
+  ctx.moveTo(x + rad, y)
+  ctx.arcTo(x + w, y, x + w, y + h, rad)
+  ctx.arcTo(x + w, y + h, x, y + h, rad)
+  ctx.arcTo(x, y + h, x, y, rad)
+  ctx.arcTo(x, y, x + w, y, rad)
+  ctx.closePath()
+}
+
+/** Places present in a run of links, biggest first, with their counts. */
+export function tally(links: readonly number[]): { place: number; n: number }[] {
+  const counts = new Map<number, number>()
+  for (const p of links) counts.set(p, (counts.get(p) ?? 0) + 1)
+  return [...counts.entries()]
+    .map(([place, n]) => ({ place, n }))
+    .sort((a, b) => b.place - a.place)
+}
+
+/**
+ * One link, drawn as its place.
+ *
+ * Silhouette first: a one is a bead, a ten is a ribbed drum, a hundred is a
+ * pierced ring, and everything above is a notched tower with one notch per
+ * place. A child can count the tens in a coil without reading a single colour.
+ */
+export function drawLink(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  unit: number,
+  place: number,
+  alpha = 1,
+  hot = 0,
+): void {
+  const body = linkBody(place)
+  const rim = linkRim(place)
+  ctx.save()
+  ctx.globalAlpha = alpha
+  ctx.lineWidth = Math.max(1, unit * 0.14)
+
+  if (place === 0) {
+    const r = unit * 0.44
+    ctx.fillStyle = body
+    ctx.beginPath()
+    ctx.arc(x, y, r, 0, TAU)
+    ctx.fill()
+    ctx.strokeStyle = rim
+    ctx.stroke()
+    ctx.fillStyle = withAlpha(rim, 0.7)
+    ctx.beginPath()
+    ctx.arc(x - r * 0.3, y - r * 0.34, r * 0.28, 0, TAU)
+    ctx.fill()
+  } else if (place === 1) {
+    const w = unit * 1.5
+    const h = unit * 0.94
+    ctx.fillStyle = body
+    roundRect(ctx, x - w / 2, y - h / 2, w, h, h * 0.32)
+    ctx.fill()
+    ctx.strokeStyle = rim
+    ctx.stroke()
+    ctx.strokeStyle = withAlpha(INK, 0.45)
+    ctx.lineWidth = Math.max(1, unit * 0.1)
+    for (let i = -1; i <= 1; i++) {
+      ctx.beginPath()
+      ctx.moveTo(x + i * w * 0.22, y - h * 0.3)
+      ctx.lineTo(x + i * w * 0.22, y + h * 0.3)
+      ctx.stroke()
+    }
+  } else if (place === 2) {
+    const outer = unit * 0.66
+    ctx.fillStyle = body
+    ctx.beginPath()
+    ctx.arc(x, y, outer, 0, TAU)
+    ctx.arc(x, y, outer * 0.46, 0, TAU, true)
+    ctx.fill("evenodd")
+    ctx.strokeStyle = rim
+    ctx.beginPath()
+    ctx.arc(x, y, outer, 0, TAU)
+    ctx.stroke()
+  } else {
+    const notches = Math.min(6, place)
+    const w = unit * 0.98
+    const h = unit * 1.46
+    ctx.fillStyle = body
+    roundRect(ctx, x - w / 2, y - h / 2, w, h, unit * 0.16)
+    ctx.fill()
+    ctx.strokeStyle = rim
+    ctx.stroke()
+    ctx.fillStyle = withAlpha(INK, 0.5)
+    for (let i = 0; i < notches; i++) {
+      const ny = y - h / 2 + (h * (i + 0.8)) / (notches + 0.7)
+      ctx.fillRect(x - w * 0.34, ny, w * 0.68, Math.max(1, unit * 0.1))
+    }
+  }
+
+  if (hot > 0) {
+    ctx.globalAlpha = alpha * hot
+    ctx.strokeStyle = CELESTIAL
+    ctx.lineWidth = Math.max(1.2, unit * 0.2)
+    ctx.beginPath()
+    ctx.arc(x, y, unit * 0.86, 0, TAU)
+    ctx.stroke()
+  }
+  ctx.restore()
+}
+
+export class Scene {
+  readonly canvas: HTMLCanvasElement
+  private readonly ctx: CanvasRenderingContext2D
+  readonly particles = new Particles()
+  private lattice: HTMLCanvasElement | null = null
+  layout: Layout
+  private dpr = 1
+
+  constructor(host: HTMLElement) {
+    const canvas = document.createElement("canvas")
+    canvas.style.cssText = "position:absolute;inset:0;width:100%;height:100%;display:block"
+    host.appendChild(canvas)
+    const ctx = canvas.getContext("2d", { alpha: false })
+    if (!ctx) throw new Error("coil: no 2d context")
+    this.canvas = canvas
+    this.ctx = ctx
+    this.layout = computeLayout(Math.max(1, host.clientWidth), Math.max(1, host.clientHeight))
+    this.resize(host.clientWidth, host.clientHeight)
+  }
+
+  resize(w: number, h: number): Layout {
+    const width = Math.max(320, Math.round(w))
+    const height = Math.max(360, Math.round(h))
+    this.dpr = Math.min(3, globalThis.devicePixelRatio || 1)
+    this.canvas.width = Math.round(width * this.dpr)
+    this.canvas.height = Math.round(height * this.dpr)
+    this.layout = computeLayout(width, height)
+    this.lattice = this.buildLattice(width, height)
+    return this.layout
+  }
+
+  destroy(): void {
+    this.canvas.remove()
+    this.lattice = null
+  }
+
+  /**
+   * The girih lattice, rendered once per resize.
+   *
+   * Eight-point strapwork on a square grid — the wall the bricks go into, drawn
+   * at the alpha of carved shadow rather than of decoration. Rasterised because
+   * redrawing a hundred stars per frame is the kind of thing that costs a
+   * mid-range tablet its frame budget for no visible gain.
+   */
+  private buildLattice(w: number, h: number): HTMLCanvasElement | null {
+    const off = document.createElement("canvas")
+    off.width = Math.round(w * this.dpr)
+    off.height = Math.round(h * this.dpr)
+    const c = off.getContext("2d")
+    if (!c) return null
+    c.scale(this.dpr, this.dpr)
+    const g = Math.max(52, Math.min(w, h) / 7)
+    c.strokeStyle = withAlpha(STONE_EDGE, 0.7)
+    c.lineWidth = 1.2
+    for (let y = -g; y < h + g; y += g) {
+      for (let x = -g; x < w + g; x += g) {
+        const cx = x + g / 2
+        const cy = y + g / 2
+        const r = g * 0.42
+        c.beginPath()
+        for (let i = 0; i < 8; i++) {
+          const a = (i / 8) * TAU + Math.PI / 8
+          const px = cx + Math.cos(a) * r
+          const py = cy + Math.sin(a) * r
+          if (i === 0) c.moveTo(px, py)
+          else c.lineTo(px, py)
+        }
+        c.closePath()
+        c.stroke()
+        c.beginPath()
+        for (let i = 0; i < 4; i++) {
+          const a = (i / 4) * TAU
+          const px = cx + Math.cos(a) * r * 1.36
+          const py = cy + Math.sin(a) * r * 1.36
+          if (i === 0) c.moveTo(px, py)
+          else c.lineTo(px, py)
+        }
+        c.closePath()
+        c.stroke()
+      }
+    }
+    return off
+  }
+
+  draw(s: SceneState): void {
+    const { ctx } = this
+    const L = this.layout
+    ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0)
+
+    const sky = ctx.createLinearGradient(0, 0, 0, L.h)
+    sky.addColorStop(0, STONE)
+    sky.addColorStop(0.55, STONE_DEEP)
+    sky.addColorStop(1, "#0f0a07")
+    ctx.fillStyle = sky
+    ctx.fillRect(0, 0, L.w, L.h)
+    if (this.lattice) {
+      ctx.save()
+      ctx.globalAlpha = 0.55
+      ctx.drawImage(this.lattice, 0, 0, L.w, L.h)
+      ctx.restore()
+    }
+
+    this.drawWall(s)
+    this.drawLane(s)
+    this.drawFlight(s)
+    this.particles.draw(ctx)
+    this.drawLevers(s)
+  }
+
+  // ---------------------------------------------------------------- the wall
+
+  private drawWall(s: SceneState): void {
+    const { ctx } = this
+    const r = this.layout.wall
+    ctx.save()
+    ctx.fillStyle = STONE_LIT
+    roundRect(ctx, r.x, r.y, r.w, r.h, 10)
+    ctx.fill()
+    ctx.strokeStyle = withAlpha(STONE_EDGE, 1)
+    ctx.lineWidth = 2
+    ctx.stroke()
+
+    // The recess: the one cold light. It brightens as the pending cut
+    // approaches the demand, which is the only continuous feedback in the game.
+    const cradle = s.round?.mode === "fill" && s.round.ingot > 0
+    const recessH = r.h * 0.52
+    const recessW = r.w * (cradle ? 0.6 : 0.91)
+    const rx = r.x + r.w * 0.045
+    const ry = r.y + r.h * 0.12
+    const glow = 0.24 + s.seatPulse * 0.5
+    ctx.fillStyle = withAlpha(CELESTIAL_DIM, 0.12 + glow * 0.2)
+    roundRect(ctx, rx, ry, recessW, recessH, 8)
+    ctx.fill()
+    ctx.strokeStyle = withAlpha(CELESTIAL, 0.32 + s.seatPulse * 0.5)
+    ctx.lineWidth = 1.5
+    ctx.stroke()
+
+    this.drawPrompt(s, rx, ry, recessW, recessH)
+    if (cradle) this.drawIngot(s, r.x + r.w * 0.815, ry + recessH * 0.5, r.w * 0.3)
+    this.drawCourses(s, r.x + r.w * 0.045, r.y + r.h * 0.72, r.w * 0.91, r.h * 0.2)
+    ctx.restore()
+  }
+
+  /**
+   * The problem, carved, with the demand lit.
+   *
+   * Two type sizes and one light. The glowing operand is the whole instruction
+   * the game has: shear that much off. The operator is what tells you what the
+   * machine will do with it, and it is drawn at the same size as the numbers
+   * because it is not punctuation, it is the verb.
+   */
+  private drawPrompt(s: SceneState, x: number, y: number, w: number, h: number): void {
+    const { ctx } = this
+    const round = s.round
+    ctx.save()
+    ctx.textBaseline = "middle"
+    if (!round) {
+      ctx.fillStyle = BONE_DIM
+      ctx.font = font(Math.min(20, h * 0.3))
+      ctx.textAlign = "center"
+      ctx.fillText("the alley is quiet", x + w / 2, y + h / 2)
+      ctx.restore()
+      return
+    }
+
+    const size = Math.min(w / Math.max(6, round.prompt.length) * 1.9, h * 0.5)
+    ctx.font = numerals(size)
+    const demandText = String(round.demand)
+    const head = round.prompt.endsWith(demandText)
+      ? round.prompt.slice(0, round.prompt.length - demandText.length)
+      : `${round.prompt} → `
+    const headW = ctx.measureText(head).width
+    const demandW = ctx.measureText(demandText).width
+    const startX = x + Math.max(12, (w - headW - demandW) / 2)
+    const midY = y + h * 0.44
+
+    ctx.textAlign = "left"
+    ctx.fillStyle = withAlpha(BONE, 0.86)
+    ctx.fillText(head, startX, midY)
+
+    // The demand, lit from behind the wall.
+    const pulse = s.reduced ? 0.72 : 0.72 + Math.sin(s.t * 2.1) * 0.12 + s.aimPulse * 0.2
+    ctx.save()
+    ctx.shadowColor = CELESTIAL
+    ctx.shadowBlur = size * 0.5 * pulse
+    ctx.fillStyle = CELESTIAL
+    ctx.fillText(demandText, startX + headW, midY)
+    ctx.restore()
+
+    // One line, and it is the whole rule of the game. What happens to the piece
+    // afterwards is not written down anywhere: in a take it leaves and the coil
+    // that stays is the answer, in a fill it flies to the cradle and joins the
+    // ingot, and a child learns which is which by watching it happen once.
+    ctx.font = font(Math.max(10, size * 0.24), 600)
+    ctx.fillStyle = withAlpha(BONE_DIM, 0.85)
+    ctx.textAlign = "left"
+    ctx.fillText("SHEAR OFF THE LIT NUMBER", startX, y + h * 0.86)
+    ctx.restore()
+  }
+
+  /** The cradle: what the severed piece is about to be welded to. */
+  private drawIngot(s: SceneState, cx: number, cy: number, w: number): void {
+    const round = s.round
+    if (!round || s.ingot.length === 0) return
+    const { ctx } = this
+    const groups = tally(s.ingot)
+    ctx.save()
+    ctx.fillStyle = withAlpha(STONE_DEEP, 0.6)
+    roundRect(ctx, cx - w / 2, cy - w * 0.24, w, w * 0.48, 6)
+    ctx.fill()
+    ctx.strokeStyle = withAlpha(BRASS_DARK, 0.9)
+    ctx.lineWidth = 1.5
+    ctx.stroke()
+
+    const unit = Math.min(11, w / 14)
+    let px = cx - w / 2 + unit * 1.4
+    for (const g of groups) {
+      const shown = Math.min(g.n, 4)
+      for (let i = 0; i < shown; i++) {
+        drawLink(ctx, px, cy - unit * 0.2, unit, g.place, 0.95)
+        px += unit * 1.25
+      }
+      if (g.n > shown) {
+        ctx.fillStyle = BONE_DIM
+        ctx.font = numerals(unit * 1.1, 600)
+        ctx.textAlign = "left"
+        ctx.textBaseline = "middle"
+        ctx.fillText(`×${String(g.n)}`, px, cy - unit * 0.2)
+        px += unit * 2.2
+      }
+      px += unit * 0.5
+    }
+
+    ctx.fillStyle = withAlpha(BONE, 0.9)
+    ctx.font = numerals(w * 0.13, 700)
+    ctx.textAlign = "center"
+    ctx.textBaseline = "top"
+    ctx.fillText(String(round.ingot), cx, cy + w * 0.1)
+    ctx.restore()
+  }
+
+  /**
+   * The wall the run builds. Never regresses: a miss costs slag, not a brick.
+   */
+  private drawCourses(s: SceneState, x: number, y: number, w: number, h: number): void {
+    const { ctx } = this
+    const perRow = COURSE
+    const rows = 2
+    const bw = w / perRow
+    const bh = Math.min(h / rows, bw * 0.42)
+    ctx.save()
+    for (let row = 0; row < rows; row++) {
+      for (let i = 0; i < perRow; i++) {
+        const index = s.exactCuts - (rows - row) * perRow + i
+        const bx = x + i * bw + (row % 2 === 1 ? bw * 0.16 : 0)
+        const by = y + row * (bh + 3)
+        const laid = index >= 0 && index < s.exactCuts
+        ctx.fillStyle = laid ? withAlpha(BRASS, 0.82) : withAlpha(STONE_DEEP, 0.55)
+        roundRect(ctx, bx, by, bw - 3, bh, 2)
+        ctx.fill()
+        if (laid) {
+          ctx.strokeStyle = withAlpha(BRASS_HOT, index === s.exactCuts - 1 ? s.seatPulse : 0.22)
+          ctx.lineWidth = 1.2
+          ctx.stroke()
+        }
+      }
+    }
+    const brick: Brick | undefined = s.wall[s.wall.length - 1]
+    if (brick) {
+      ctx.fillStyle = withAlpha(BONE_DIM, 0.7)
+      ctx.font = numerals(Math.max(9, bh * 0.8), 600)
+      ctx.textAlign = "right"
+      ctx.textBaseline = "middle"
+      ctx.fillText(String(brick.value), x + w, y + rows * (bh + 3) + bh * 0.4)
+    }
+    ctx.restore()
+  }
+
+  // ---------------------------------------------------------------- the lane
+
+  /** Lane cell holding link `i`. Slag sits at the mouth and pushes the coil on. */
+  cellForLink(s: SceneState, i: number): number {
+    return s.slag * SLAG_CELLS + (i - s.buried)
+  }
+
+  private drawLane(s: SceneState): void {
+    const { ctx } = this
+    const lane = this.layout.lane
+
+    // The groove the coil rides in.
+    ctx.save()
+    ctx.strokeStyle = GROOVE
+    ctx.lineWidth = lane.unit * 1.9
+    ctx.lineCap = "round"
+    ctx.lineJoin = "round"
+    ctx.beginPath()
+    for (let i = 0; i < lane.capacity; i++) {
+      const c = cellAt(lane, i)
+      if (i === 0) ctx.moveTo(c.x, c.y)
+      else ctx.lineTo(c.x, c.y)
+    }
+    ctx.stroke()
+    ctx.strokeStyle = withAlpha(STONE_EDGE, 0.5)
+    ctx.lineWidth = 1
+    ctx.stroke()
+    ctx.restore()
+
+    this.drawSlag(s, lane)
+    this.drawBuried(s, lane)
+    this.drawCoil(s, lane)
+    this.drawShear(s, lane)
+
+    // A miss stains the lane with oxide for a quarter of a second. It is the
+    // whole of the negative feedback: no flash, no shake, no sound of refusal —
+    // just the colour of the thing that is now lying on your floor.
+    if (s.missPulse > 0) {
+      ctx.save()
+      ctx.globalAlpha = s.missPulse * 0.22
+      ctx.fillStyle = SLAG_COLOUR
+      ctx.fillRect(lane.x, lane.y, lane.w, lane.h)
+      ctx.restore()
+    }
+  }
+
+  private drawSlag(s: SceneState, lane: Lane): void {
+    if (s.slag <= 0) return
+    const { ctx } = this
+    ctx.save()
+    for (let i = 0; i < s.slag * SLAG_CELLS; i++) {
+      const c = cellAt(lane, i)
+      const wob = Math.sin(i * 2.7) * lane.unit * 0.18
+      ctx.fillStyle = SLAG_COLOUR
+      ctx.beginPath()
+      ctx.ellipse(c.x, c.y + wob, lane.unit * 0.82, lane.unit * 0.6, i * 0.7, 0, TAU)
+      ctx.fill()
+      ctx.strokeStyle = withAlpha(SLAG_EDGE, 0.75)
+      ctx.lineWidth = 1.2
+      ctx.stroke()
+    }
+    ctx.restore()
+  }
+
+  /** Links that no longer fit, crushed into the mouth. Dim, and unbreakable. */
+  private drawBuried(s: SceneState, lane: Lane): void {
+    if (s.buried <= 0) return
+    const { ctx } = this
+    const c = cellAt(lane, 0)
+    ctx.save()
+    ctx.globalAlpha = 0.5
+    for (let i = 0; i < Math.min(s.buried, 8); i++) {
+      const p = s.links[i] as number
+      drawLink(ctx, c.x - lane.pitch * 0.7 + i * 2.6, c.y - lane.rowPitch * 0.62, lane.unit * 0.7, p, 0.7)
+    }
+    ctx.globalAlpha = 1
+    ctx.fillStyle = withAlpha(SLAG_EDGE, 0.95)
+    ctx.font = numerals(Math.max(10, lane.unit * 0.9), 700)
+    ctx.textAlign = "left"
+    ctx.textBaseline = "middle"
+    ctx.fillText(`${String(s.buried)} buried`, c.x + lane.pitch * 0.4, c.y - lane.rowPitch * 0.62)
+    ctx.restore()
+  }
+
+  private drawCoil(s: SceneState, lane: Lane): void {
+    const { ctx } = this
+    for (let i = s.buried; i < s.links.length; i++) {
+      const cell = this.cellForLink(s, i)
+      if (cell >= lane.capacity) break
+      const c = cellAt(lane, cell)
+      const pending = i >= s.cut
+      // The whip: the coil recoils away from the cut for a moment after a
+      // shear, strongest at the free end and dying out towards the head.
+      const wave =
+        s.whip > 0
+          ? Math.sin((i - s.cut) * 0.9 - s.whip * 9) *
+            lane.unit *
+            0.9 *
+            s.whip *
+            Math.min(1, Math.abs(i - s.cut) / 4)
+          : 0
+      const y = c.y + wave
+      drawLink(
+        ctx,
+        c.x,
+        y,
+        lane.unit,
+        s.links[i] as number,
+        1,
+        pending ? 0.35 + s.aimPulse * 0.5 : 0,
+      )
+      if (i === s.cut) {
+        // The link the shear is parked on is the one that can be cracked open.
+        const p = s.links[i] as number
+        if (p > 0) {
+          ctx.save()
+          ctx.globalAlpha = s.reduced ? 0.55 : 0.5 + Math.sin(s.t * 3) * 0.18 + s.crackPulse * 0.4
+          ctx.strokeStyle = CELESTIAL
+          ctx.lineWidth = 1.4
+          ctx.setLineDash([2, 3])
+          ctx.beginPath()
+          ctx.moveTo(c.x - lane.unit * 0.5, y - lane.unit * 0.7)
+          ctx.lineTo(c.x + lane.unit * 0.2, y)
+          ctx.lineTo(c.x - lane.unit * 0.35, y + lane.unit * 0.7)
+          ctx.stroke()
+          ctx.restore()
+        }
+      }
+    }
+  }
+
+  /** The jaws, parked in the joint ahead of the cut. */
+  private drawShear(s: SceneState, lane: Lane): void {
+    if (s.links.length === 0) return
+    const { ctx } = this
+    const cell = this.cellForLink(s, s.cut)
+    if (cell >= lane.capacity) return
+    const here = cellAt(lane, cell)
+    const prev = cellAt(lane, Math.max(0, cell - 1))
+    const jx = cell === 0 ? here.x - lane.pitch * 0.5 : (here.x + prev.x) / 2
+    const jy = cell === 0 ? here.y : (here.y + prev.y) / 2
+    const open = lane.unit * (0.95 - s.shearPress * 0.7)
+
+    ctx.save()
+    ctx.strokeStyle = withAlpha(CELESTIAL, 0.5 + s.aimPulse * 0.4)
+    ctx.lineWidth = 1.4
+    ctx.beginPath()
+    ctx.moveTo(jx, jy - lane.rowPitch * 0.42)
+    ctx.lineTo(jx, jy + lane.rowPitch * 0.42)
+    ctx.stroke()
+
+    ctx.fillStyle = CELESTIAL
+    for (const sign of [-1, 1]) {
+      ctx.beginPath()
+      ctx.moveTo(jx - lane.unit * 0.5, jy + sign * (open + lane.unit * 0.5))
+      ctx.lineTo(jx + lane.unit * 0.5, jy + sign * (open + lane.unit * 0.5))
+      ctx.lineTo(jx, jy + sign * open)
+      ctx.closePath()
+      ctx.fill()
+    }
+    ctx.restore()
+  }
+
+  // ------------------------------------------------------------- the flight
+
+  private drawFlight(s: SceneState): void {
+    const f = s.flight
+    if (!f) return
+    const { ctx } = this
+    const lane = this.layout.lane
+    const from = { x: f.fromX, y: f.fromY }
+    const wall = this.layout.wall
+    const to = f.exact
+      ? { x: wall.x + wall.w * 0.5, y: wall.y + wall.h * 0.82 }
+      : { x: lane.x + lane.w * 0.2, y: lane.y + lane.h + lane.unit }
+    const t = Math.min(1, Math.max(0, f.t))
+    const ease = f.exact ? 1 - (1 - t) ** 3 : t * t
+    const x = from.x + (to.x - from.x) * ease
+    const y = from.y + (to.y - from.y) * ease - (f.exact ? Math.sin(t * Math.PI) * lane.h * 0.3 : 0)
+
+    ctx.save()
+    ctx.globalAlpha = 1 - t * 0.35
+    const unit = lane.unit * (1 - t * 0.45)
+    const shown = Math.min(f.links.length, 12)
+    for (let i = 0; i < shown; i++) {
+      drawLink(ctx, x + (i - shown / 2) * unit * 1.1, y, unit, f.links[i] as number, 1, f.exact ? 0.4 : 0)
+    }
+    ctx.restore()
+  }
+
+  // ------------------------------------------------------------- the levers
+
+  private drawLevers(s: SceneState): void {
+    const { ctx } = this
+    const L = this.layout
+    this.drawGauge(s)
+
+    // FURNACE — melts the lane, costs the coil, reports nothing.
+    const f = L.furnace
+    ctx.save()
+    const heat = 0.25 + s.furnaceGlow * 0.75
+    const grad = ctx.createLinearGradient(f.x, f.y + f.h, f.x, f.y)
+    grad.addColorStop(0, withAlpha(EMBER, 0.15 + heat * 0.5))
+    grad.addColorStop(1, withAlpha(STONE_DEEP, 0.9))
+    ctx.fillStyle = grad
+    roundRect(ctx, f.x, f.y, f.w, f.h, 8)
+    ctx.fill()
+    ctx.strokeStyle = withAlpha(EMBER, 0.45 + s.furnaceGlow * 0.5)
+    ctx.lineWidth = 1.6
+    ctx.stroke()
+    ctx.fillStyle = s.slag > 0 ? EMBER_HOT : withAlpha(EMBER_HOT, 0.4)
+    ctx.font = font(Math.min(15, f.h * 0.26), 700)
+    ctx.textAlign = "center"
+    ctx.textBaseline = "middle"
+    ctx.fillText("FURNACE", f.x + f.w / 2, f.y + f.h * 0.36)
+    ctx.font = numerals(Math.min(19, f.h * 0.3), 700)
+    ctx.fillStyle = s.slag > 0 ? EMBER : withAlpha(BONE_DIM, 0.6)
+    ctx.fillText(`${String(s.slag)} slag`, f.x + f.w / 2, f.y + f.h * 0.7)
+    ctx.restore()
+
+    // SHEAR — the commit, and the only thing in the game that spends an item.
+    const r = L.shear
+    ctx.save()
+    const press = s.shearPress
+    const y = r.y + press * 6
+    ctx.fillStyle = withAlpha(BRASS_DARK, 0.55)
+    roundRect(ctx, r.x, r.y + 8, r.w, r.h - 8, 10)
+    ctx.fill()
+    const face = ctx.createLinearGradient(r.x, y, r.x, y + r.h)
+    face.addColorStop(0, withAlpha(BRASS_HOT, 0.9 - press * 0.25))
+    face.addColorStop(1, BRASS)
+    ctx.fillStyle = face
+    roundRect(ctx, r.x, y, r.w, r.h - 10, 10)
+    ctx.fill()
+    ctx.strokeStyle = withAlpha(INK, 0.5)
+    ctx.lineWidth = 1.5
+    ctx.stroke()
+    ctx.fillStyle = INK
+    ctx.font = font(Math.min(20, r.h * 0.3), 700)
+    ctx.textAlign = "center"
+    ctx.textBaseline = "middle"
+    ctx.fillText("SHEAR", r.x + r.w / 2, y + (r.h - 10) / 2)
+    ctx.restore()
+  }
+
+  /**
+   * The gauge: what the shear is holding, as places rather than as a numeral.
+   *
+   * Never a number. If it printed "25" the child would nudge until the digits
+   * matched and the place value would be the machine's job instead of theirs —
+   * so the gauge draws two drums and five beads and lets the reading be the
+   * work. That reading is the skill `dw.add.column.*` is named for.
+   */
+  private drawGauge(s: SceneState): void {
+    const { ctx } = this
+    const L = this.layout
+    const x = L.furnace.x + L.furnace.w + 12
+    const w = L.shear.x - x - 12
+    if (w < 60) return
+    const y = L.levers.y
+    const h = L.levers.h
+
+    ctx.save()
+    ctx.fillStyle = withAlpha(STONE_DEEP, 0.72)
+    roundRect(ctx, x, y, w, h, 8)
+    ctx.fill()
+    ctx.strokeStyle = withAlpha(CELESTIAL_DIM, 0.45)
+    ctx.lineWidth = 1.2
+    ctx.stroke()
+
+    const piece = s.links.slice(s.cut)
+    const groups = tally(piece)
+    const unit = Math.min(h * 0.26, 15)
+    let px = x + unit * 1.6
+    const cy = y + h * 0.46
+    for (const g of groups) {
+      // Countable while there is anything to count, and a multiplier once there
+      // is not: nine drums are read by counting them, sixteen ones are not.
+      if (g.n <= 10) {
+        for (let i = 0; i < g.n; i++) {
+          if (px > x + w - unit * 3) break
+          drawLink(ctx, px, cy, unit, g.place, 1, 0.25)
+          px += unit * 1.32
+        }
+      } else {
+        drawLink(ctx, px, cy, unit, g.place, 1, 0.25)
+        px += unit * 1.4
+        ctx.fillStyle = BONE
+        ctx.font = numerals(unit * 1.25, 700)
+        ctx.textAlign = "left"
+        ctx.textBaseline = "middle"
+        ctx.fillText(`×${String(g.n)}`, px, cy)
+        px += ctx.measureText(`×${String(g.n)}`).width + unit * 0.4
+      }
+      px += unit * 0.9
+    }
+
+    // The hint: the demand's own shape, ghosted, offered only after the child
+    // has been still for a while. It never costs anything and never hurries.
+    if (s.hint > 0 && s.round) {
+      ctx.globalAlpha = s.hint * 0.5
+      ctx.fillStyle = CELESTIAL
+      ctx.font = font(Math.max(10, h * 0.17), 600)
+      ctx.textAlign = "left"
+      ctx.textBaseline = "middle"
+      const want = tally(coilOf(s.round.demand))
+        .map((g) => `${String(g.n)}×${String(linkValue(g.place))}`)
+        .join("  ")
+      ctx.fillText(want, x + unit * 1.4, y + h * 0.82)
+      ctx.globalAlpha = 1
+    }
+    ctx.restore()
+  }
+
+  // ------------------------------------------------------------- emitters
+
+  burstCrack(x: number, y: number): void {
+    this.particles.emit(KIND_FILING, x, y, 14, 190, BRASS_HOT)
+  }
+
+  burstSeat(x: number, y: number): void {
+    this.particles.emit(KIND_SPARK, x, y, 12, 150, CELESTIAL)
+  }
+
+  burstSlag(x: number, y: number): void {
+    this.particles.emit(KIND_DUST, x, y, 9, 70, SLAG_EDGE)
+  }
+
+  burstFurnace(x: number, y: number): void {
+    this.particles.emit(KIND_SPARK, x, y, 20, 200, EMBER, Math.PI * 0.8, -Math.PI / 2)
+  }
+}

--- a/dynawalla/games/coil/src/stubHost.test.ts
+++ b/dynawalla/games/coil/src/stubHost.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { roundFrom } from "./game/round.ts"
+import {
+  addNoCarry,
+  borrowSkippingZero,
+  createStubHost,
+  subSmallerFromLarger,
+} from "./stubHost.ts"
+
+const SEED = 0x0c011960
+
+test("the stream is seeded: the same seed is the same run, forever", () => {
+  const a = createStubHost({ seed: SEED })
+  const b = createStubHost({ seed: SEED })
+  const c = createStubHost({ seed: SEED + 1 })
+  const first: string[] = []
+  const second: string[] = []
+  const third: string[] = []
+  for (let i = 0; i < 60; i++) {
+    first.push(a.next().prompt)
+    second.push(b.next().prompt)
+    third.push(c.next().prompt)
+  }
+  assert.deepEqual(first, second)
+  assert.notDeepEqual(first, third)
+})
+
+test("every operand, answer and distractor is an exact whole number", () => {
+  const host = createStubHost({ seed: SEED })
+  for (let i = 0; i < 600; i++) {
+    const q = host.next()
+    assert.match(q.answer, /^\d+$/, q.prompt)
+    assert.ok(Number.isSafeInteger(Number(q.answer)))
+    for (const d of q.distractors) {
+      assert.match(d, /^\d+$/, `${q.prompt} → ${d}`)
+      assert.notEqual(d, q.answer, "a distractor is never the answer")
+    }
+    assert.equal(new Set(q.distractors).size, q.distractors.length, "no duplicates")
+  }
+})
+
+test("the prompt is what the host actually emits, and the answer agrees with it", () => {
+  const host = createStubHost({ seed: SEED ^ 0x1 })
+  for (let i = 0; i < 600; i++) {
+    const q = host.next()
+    const m = /^(\d+) ([+−]) (\d+)$/.exec(q.prompt)
+    assert.notEqual(m, null, q.prompt)
+    if (!m) continue
+    const a = Number(m[1])
+    const b = Number(m[3])
+    assert.equal(Number(q.answer), m[2] === "+" ? a + b : a - b)
+    assert.ok(a > 0 && b > 0)
+    if (m[2] === "−") assert.ok(b < a, "the stub never serves a negative answer")
+  }
+})
+
+test("every question the stub serves is one this game can cut", () => {
+  const host = createStubHost({ seed: SEED ^ 0x2 })
+  for (let i = 0; i < 600; i++) {
+    const q = host.next()
+    const round = roundFrom(q)
+    assert.notEqual(round, null, q.prompt)
+    if (!round) continue
+    assert.ok(round.coil >= round.demand, q.prompt)
+    assert.ok(round.demand >= 1)
+    assert.equal(
+      round.mode === "take" ? round.coil - round.demand : round.ingot + round.demand,
+      round.answer,
+      q.prompt,
+    )
+  }
+})
+
+test("the stub walks its own ladder and a pinned rung stays put", () => {
+  const walking = createStubHost({ seed: SEED })
+  const early: number[] = []
+  const late: number[] = []
+  for (let i = 0; i < 30; i++) {
+    const q = walking.next()
+    ;(i < 5 ? early : late).push(Number(q.answer))
+  }
+  assert.ok(Math.max(...late) > Math.max(...early), "the coils get bigger")
+
+  const pinned = createStubHost({ seed: SEED, rung: 0 })
+  for (let i = 0; i < 40; i++) {
+    assert.ok(Number(pinned.next().answer) <= 99, "rung 0 stays small")
+  }
+})
+
+test("mal-rules are procedures a child runs, not noise around the answer", () => {
+  // 27 + 15 with every carry dropped.
+  assert.equal(addNoCarry(27, 15), 32)
+  assert.equal(addNoCarry(4, 5), 9)
+  // 52 − 27, taking the smaller digit from the larger in every column.
+  assert.equal(subSmallerFromLarger(52, 27), 35)
+  assert.equal(subSmallerFromLarger(97, 43), 54)
+  // 403 − 87, writing a ten into the column the borrow passed through where a
+  // nine belongs. Every one of these is exactly ten more than the answer, which
+  // is what makes it a diagnosis rather than a near-miss.
+  assert.equal(borrowSkippingZero(403, 87), 326)
+  assert.equal(borrowSkippingZero(4_003, 87), 3_926)
+  assert.equal(borrowSkippingZero(400_300, 87), 400_223)
+  // Nothing to borrow across is nothing for the bug to do.
+  assert.equal(borrowSkippingZero(97, 43), -1)
+  assert.equal(borrowSkippingZero(52, 27), -1)
+})
+
+test("a distractor is a wrong answer, never the right one dressed up", () => {
+  const host = createStubHost({ seed: SEED ^ 0x3 })
+  let malRules = 0
+  for (let i = 0; i < 400; i++) {
+    const q = host.next()
+    const m = /^(\d+) ([+−]) (\d+)$/.exec(q.prompt)
+    if (!m) continue
+    const a = Number(m[1])
+    const b = Number(m[3])
+    const known =
+      m[2] === "+"
+        ? [addNoCarry(a, b), a - b]
+        : [subSmallerFromLarger(a, b), borrowSkippingZero(a, b), a + b]
+    for (const d of q.distractors) {
+      if (known.includes(Number(d))) malRules++
+    }
+  }
+  assert.ok(malRules > 200, `mal-rule outputs dominate the distractors (${String(malRules)})`)
+})
+
+test("reduced motion is answered honestly and can be forced", () => {
+  assert.equal(createStubHost({ seed: SEED, reducedMotion: true }).prefersReducedMotion(), true)
+  assert.equal(createStubHost({ seed: SEED, reducedMotion: false }).prefersReducedMotion(), false)
+  // With no DOM and no override, the honest answer is "no".
+  assert.equal(createStubHost({ seed: SEED }).prefersReducedMotion(), false)
+})
+
+test("reports and haptics are observable, and a missing motor is not an error", () => {
+  const reports: string[] = []
+  const haptics: string[] = []
+  const host = createStubHost({
+    seed: SEED,
+    onReport: (r) => reports.push(r.answered),
+    onHaptic: (k) => haptics.push(k),
+  })
+  host.report({ questionId: "a", correct: true, ms: 10, answered: "47" })
+  host.haptic("success")
+  assert.deepEqual(reports, ["47"])
+  assert.deepEqual(haptics, ["success"])
+})

--- a/dynawalla/games/coil/src/stubHost.ts
+++ b/dynawalla/games/coil/src/stubHost.ts
@@ -1,0 +1,220 @@
+// A local stub Host so the game is playable standalone with `npm run dev`.
+//
+// It imitates the one thing the real host actually serves this pack: column
+// addition and subtraction, in the shape `dynawalla-app/src/packs/items.ts`
+// emits it — `top − bottom` with a U+2212 MINUS, an integer answer, and a
+// closed list of wrong answers. The six rungs below are the shapes the seven
+// active `dw.add.*` rows declare, from a two-digit sum with nothing to regroup
+// up to a six-digit minuend with zeros to borrow across.
+//
+// Three properties the runtime also honours, asserted by `stubHost.test.ts`:
+//
+//   1. **Exact arithmetic.** Every operand, answer and distractor is an
+//      integer. No float ever reaches an answer string or a comparison.
+//   2. **Seeded and deterministic.** Same seed → same question stream, forever.
+//   3. **Distractors are real mal-rule outputs** — what a child running a
+//      specific broken procedure actually writes down, not `answer + 1` noise.
+//      This game can *produce* several of them physically: shearing two tens
+//      and two ones when the demand was twenty-five is the smaller-from-larger
+//      bug, performed rather than typed.
+
+import type { Host, Question } from "./contract.ts"
+import { Rng } from "./core/rng.ts"
+
+/** U+2212. A hyphen is not a minus sign, and at 40px a child can tell. */
+const MINUS = "−"
+
+/** Column addition with every carry dropped: 27 + 15 → 32. */
+export function addNoCarry(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    out += (((x % 10) + (y % 10)) % 10) * place
+    place *= 10
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return out
+}
+
+/** The smaller-from-larger bug: 52 − 27 → 35, taking |2−7| in the ones column. */
+export function subSmallerFromLarger(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    out += Math.abs((x % 10) - (y % 10)) * place
+    place *= 10
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return out
+}
+
+/**
+ * Borrowing across a zero and leaving a ten where a nine belongs.
+ *
+ * `403 − 87 → 326`, where the answer is `316`. The child borrows correctly all
+ * the way to the hundreds, but the zero the ten passed through is written as a
+ * ten rather than a nine — because "I took ten from the hundreds and put it
+ * here" is exactly what they did, and giving one of it away again to the ones
+ * column is the step that gets dropped.
+ *
+ * Returns `-1` when the item gives the bug nothing to fire on — there is no
+ * zero to borrow across — or when the buggy procedure does not land on a
+ * numeral, which is what the curriculum means by a mal-rule that does not
+ * apply.
+ */
+export function borrowSkippingZero(a: number, b: number): number {
+  const digits = String(a)
+    .split("")
+    .map((d) => Number(d))
+  const sub = String(b)
+    .padStart(digits.length, "0")
+    .split("")
+    .map((d) => Number(d))
+  if (sub.length !== digits.length) return -1
+  let fired = false
+  for (let i = digits.length - 1; i >= 0; i--) {
+    const top = digits[i] as number
+    const bottom = sub[i] as number
+    if (top >= bottom) {
+      digits[i] = top - bottom
+      continue
+    }
+    let j = i - 1
+    let adjacent = true
+    while (j >= 0 && digits[j] === 0) {
+      // The bug is here, and only on the first zero: it becomes a ten.
+      digits[j] = adjacent ? 10 : 9
+      if (adjacent) fired = true
+      adjacent = false
+      j--
+    }
+    if (j < 0) return -1
+    digits[j] = (digits[j] as number) - 1
+    digits[i] = top + 10 - bottom
+  }
+  if (!fired) return -1
+  for (const d of digits) if (d < 0 || d > 9) return -1
+  return Number(digits.join(""))
+}
+
+function malRules(op: "add" | "sub", a: number, b: number, answer: number): number[] {
+  if (op === "add") {
+    return [
+      addNoCarry(a, b),
+      answer - 10, // carried and never added the carry in
+      answer + 10, // carried twice
+      a - b, // reached for the wrong operation
+      answer - 100,
+    ]
+  }
+  return [
+    subSmallerFromLarger(a, b),
+    borrowSkippingZero(a, b),
+    answer + 10, // borrowed without decrementing the next column
+    answer - 10, // decremented twice
+    a + b, // wrong operation
+  ]
+}
+
+/** Minuend / sum ceilings and second-operand ceilings, rung by rung. */
+const ADD_A = [49, 89, 499, 899, 4999, 8999] as const
+const ADD_B = [30, 89, 99, 899, 99, 999] as const
+const SUB_A = [59, 99, 599, 999, 9999, 400_999] as const
+const SUB_B = [29, 89, 99, 899, 99, 999] as const
+
+function operands(op: "add" | "sub", rung: number, rng: Rng): [number, number] {
+  const d = Math.max(0, Math.min(5, Math.round(rung)))
+  if (op === "add") {
+    const a = rng.int(10, ADD_A[d] as number)
+    const b = rng.int(2, ADD_B[d] as number)
+    return [a, b]
+  }
+  const a = rng.int(20, SUB_A[d] as number)
+  const b = rng.int(2, Math.min(SUB_B[d] as number, Math.max(2, a - 1)))
+  return [a, b]
+}
+
+export type StubHostOptions = {
+  seed?: number
+  reducedMotion?: boolean
+  /** Pin the rung 0..5 instead of letting the stub walk up its own ladder. */
+  rung?: number
+  /** Observe reports — the dev harness draws a running accuracy readout. */
+  onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void
+  /** Observe haptics so the harness shows them on a device with no motor. */
+  onHaptic?: (k: string) => void
+}
+
+/** Questions served on one rung before the stub's own ladder steps up. */
+const RUNG_LENGTH = 5
+
+export function createStubHost(opts: StubHostOptions = {}): Host {
+  const rng = new Rng(opts.seed ?? 0x0c011960)
+  let n = 0
+
+  return {
+    next() {
+      // The real host's `difficulty` is a level *within* a skill, not a rung, so
+      // the stub walks its own ladder: five questions per rung, six rungs, then
+      // it stays at the top. Deterministic, and it shows the whole range of
+      // coil shapes inside a minute of `npm run dev`.
+      const rung = opts.rung ?? Math.min(5, Math.floor(n / RUNG_LENGTH))
+      const op: "add" | "sub" = rng.chance(0.5) ? "add" : "sub"
+      const [a, b] = operands(op, rung, rng)
+      const answer = op === "add" ? a + b : a - b
+
+      const seen = new Set<number>([answer])
+      const pool: number[] = []
+      for (const v of malRules(op, a, b, answer)) {
+        if (!Number.isSafeInteger(v) || v < 0 || seen.has(v)) continue
+        seen.add(v)
+        pool.push(v)
+      }
+      rng.shuffle(pool)
+
+      n++
+      return {
+        id: `stub-${String(n)}`,
+        prompt: `${String(a)} ${op === "add" ? "+" : MINUS} ${String(b)}`,
+        answer: String(answer),
+        distractors: pool.slice(0, 3).map(String),
+        domain: op,
+        difficulty: rung / 5,
+      } satisfies Question
+    },
+
+    report(r) {
+      opts.onReport?.(r)
+    },
+
+    haptic(k) {
+      opts.onHaptic?.(k)
+      const nav = globalThis.navigator as Navigator | undefined
+      if (!nav || typeof nav.vibrate !== "function") return
+      const ms =
+        k === "light" ? 8 : k === "medium" ? 18 : k === "heavy" ? 34 : k === "success" ? 12 : 40
+      try {
+        if (k === "success") nav.vibrate([ms, 26, ms])
+        else if (k === "failure") nav.vibrate([ms, 40, ms])
+        else nav.vibrate(ms)
+      } catch {
+        // A browser that exposes vibrate but refuses it (no user gesture yet,
+        // or a policy block) must never take the frame down with it.
+        console.warn("[coil] navigator.vibrate refused")
+      }
+    },
+
+    prefersReducedMotion() {
+      if (opts.reducedMotion !== undefined) return opts.reducedMotion
+      return (
+        typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion: reduce)").matches
+      )
+    },
+  }
+}

--- a/dynawalla/games/coil/tsconfig.json
+++ b/dynawalla/games/coil/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": false,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/dynawalla/games/coil/vite.config.ts
+++ b/dynawalla/games/coil/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite"
+
+// The game is a library that mounts into a host element. `npm run dev` serves
+// the standalone harness in `index.html`, which wires it to the local stub Host
+// so the whole thing is playable with no runtime underneath it.
+export default defineConfig({
+  server: { port: 4396, host: "127.0.0.1" },
+  build: {
+    target: "es2022",
+    lib: {
+      entry: "src/index.ts",
+      name: "DynawallaGameCoil",
+      formats: ["es"],
+      fileName: () => "coil.js",
+    },
+  },
+})

--- a/dynawalla/games/coil/vite.pack.config.ts
+++ b/dynawalla/games/coil/vite.pack.config.ts
@@ -1,0 +1,28 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ *
+ * The input is an absolute path resolved from this file. Vite injects the built
+ * module script into an HTML entry only when it recognises the entry as its
+ * own; a bare relative string produces a `pack.html` whose source script is
+ * stripped and never replaced — a document that loads, paints its body colour,
+ * and runs no code at all.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})


### PR DESCRIPTION
## What

Add **THE COIL OF NINETY-SIX** at `dynawalla/games/coil` — arcade canon rank 6, S tier, after *Centipede* (1980) — as a standalone vite/TypeScript game and a shipping Dynawalla pack (`dynawalla.coil`).

An articulated brass coil is a number written in place value: a bead is one, a ribbed drum is ten, a pierced ring is a hundred, a notched tower is a thousand. The wall carves the served problem and lights one operand, and the whole instruction is four words — **shear off the lit number**.

## Why

The canon's own justification is that the cut is structurally exact and impossible to fake: *"Cutting at segment k produces a partition of N, and the game sonifies both halves as note-runs so the arithmetic is heard as well as carved into the wall… the terrain punishes thoughtless play by choking your own board rather than buzzing at you."* Both halves of that are built here rather than gestured at.

**The shear makes ONE cut, at one joint, and takes the tail.** A cut at joint `k` is therefore the partition `N = k + (N − k)`, and the number reported to the host is the length of a piece of brass, counted link by link. There is no keypad, no multiple choice, and nothing the game can round.

That single constraint is what turns place value into a mechanic:

> Twenty-five is two tens and five ones. A coil of seventy-two ends in *two* ones, so no joint anywhere on it is worth twenty-five — until you crack a ten open right where the jaws are, and ten ones drop into the chain between the tens you keep and the tens you give away. Now walk the cut back through them.

That is the borrow, performed rather than described. It is the only way to do it, and `place.test.ts` asserts that the demand is unreachable before the break and reachable after it.

### How the served arithmetic drives the coil and the cut

Only the `add` domain is active, so the stream is column addition and subtraction — which is exactly this game. `round.ts` reads `Item.prompt` in the `top ± bottom` shape `dynawalla-app/src/packs/items.ts` emits (U+2212 included) together with the canonical answer from `items.reveal`:

| served | coil | lit demand | claim reported |
|---|---|---|---|
| `72 − 25 = 47` | **72**, the minuend | `25` | `coil − severed` → what crawls on is **47** |
| `47 + 25 = 72` | stock, `stockFor(25)` = 96 | `25` | `ingot + severed` → the cradle of 47 reads **72** |
| unparseable / inconsistent, whole answer | `stockFor(answer)` | the answer | `severed` |
| fraction, decimal, empty pool | — | — | **refused**, re-requested, never reported |

In every branch the cut is exact when `severed === demand`, and the claim is the canonical answer exactly then. Nobody adds and nobody subtracts: they regroup and take, and the answer comes out of the machine.

A wrong cut produces **the number that cut is worth**. Shearing two tens and the two loose ones off seventy-two — the greedy take that skips the borrow — leaves fifty, and `"50"` is what the host is told. That is the smaller-from-larger family of error, performed rather than typed.

### Choking your own board, not buzzing

No timer, no lamp, no buzzer. Aiming, cracking and hesitating are all free. What a careless cut costs is **space**:

- a piece that is not the demand falls in the lane as **slag**, and each lump takes two of the lane's ninety-six cells;
- a coil longer than the cells left is **buried head-first**, which removes exactly the big links you borrow from;
- every break makes the coil **nine links longer**, so cracking everything open buries your own coil;
- an exact cut **smashes two lumps** on its way to the wall — at half accuracy the lane never gets ahead of you.

The **furnace** melts the lane at the cost of the current coil, reports nothing and records nothing, so a choked lane is a decision and never a dead end. The wall never regresses: a miss costs slag, never a brick.

### One honest divergence, documented

`64 − 31` regroups no column and still costs one break: three tens and one one cannot be the *end* of a chain that finishes with four ones. `breaksNeeded` measures how much change a demand needs, which is at least the column algorithm's regroupings and sometimes one more. That is deliberate — cracking a ten to make change is the physical act regrouping is a rule *about* — and it is stated in `place.ts`, in the README, and pinned by a test case.

## Blast radius

**Areas touched:** dynawalla (one new directory, `dynawalla/games/coil/`). No existing file is modified and none is deleted.

- [x] Every touched path is covered by a `ci.yml` area filter — `dynawalla/games/**` is the same path the eighteen shipping games sit under.
- [x] **Pack back-compat.** New pack id `dynawalla.coil` at `0.1.0`; no published zip changed in place, no `voiceId` renamed, no catalog entry dropped or narrowed.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifest touched.
- [x] **Strings.** N/A — nothing under `corpan/corpan-app/public/locales/`. The game draws to canvas and carries five English strings (`SHEAR`, `FURNACE`, `N slag`, `SHEAR OFF THE LIT NUMBER`, and the no-host line from the shared helper); `locales: ["en"]` in `pack.json` states that honestly.
- [x] **Curriculum.** Nothing under `packs/shared/curriculum/` is touched: no id renamed, reused or promoted. The seven ids in `covers.skills` were verified **by hand** against `packs/shared/curriculum/src/graph/domains/add.ts` — all seven are `status: "active"`, and the eighth row (`dw.add.regroup.subtract-tenths`, `draft`) is deliberately not declared. Every operand, answer, distractor and claim in this pack is an exact integer; `place.ts` is integer arithmetic on exact powers of ten and there is no float in any answer or comparison.
- [x] **Secrets.** None. `gitleaks` clean over the commit range.

Two traps deliberately avoided: `items.reveal` **is** declared (without it the shared adapter's pool never fills and the pack serves zero questions, silently), and `audio` is **not** declared (that capability is `feedback.sound`; this game synthesises its own `AudioContext`). No `localStorage` anywhere — a pack frame is an opaque origin and every access throws.

## Proof

**`npm test` × 5** (in `dynawalla/games/coil/`), to catch a flake one green run would hide. Every stochastic test seeds its own `Rng` inside the test file; there is no `Math.random` in this package outside the particle jitter, which no test observes.

```
--- npm test, run 1 ---
# tests 79
# pass 79
# fail 0
--- npm test, run 2 ---
# tests 79
# pass 79
# fail 0
--- npm test, run 3 ---
# tests 79
# pass 79
# fail 0
--- npm test, run 4 ---
# tests 79
# pass 79
# fail 0
--- npm test, run 5 ---
# tests 79
# pass 79
# fail 0
```

**`npm run tsc`, `npm run build`, `npm run build:pack`**

```
> @dynawalla/game-coil@0.1.0 tsc
> tsc --noEmit

TSC OK
rendering chunks...
computing gzip size...
dist/coil.js  34.57 kB │ gzip: 11.32 kB

✓ built in 15ms
computing gzip size...
dist-pack/pack.html                 1.28 kB │ gzip:  0.67 kB
dist-pack/assets/pack-KDcSMmPP.js  33.63 kB │ gzip: 13.00 kB

✓ built in 25ms
=== script tag ===
<script type="module" crossorigin src="./assets/pack-KDcSMmPP.js">
```

The script tag resolves to `./assets/…`, not `/src/pack.ts` — the built page runs code.

**`node build.mjs coil`** from `dynawalla/packs/`

```
── dynawalla.coil@0.1.0  (games/coil)

> @dynawalla/game-coil@0.1.0 build:pack
> vite build --config vite.pack.config.ts

vite v8.1.5 building client environment for production...
transforming...✓ 24 modules transformed.
rendering chunks...
computing gzip size...
dist-pack/pack.html                 1.28 kB │ gzip:  0.67 kB
dist-pack/assets/pack-KDcSMmPP.js  33.63 kB │ gzip: 13.00 kB

✓ built in 24ms
dynawalla.coil@0.1.0 — THE COIL OF NINETY-SIX
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 35994 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

**Skill ids verified by hand against `domains/add.ts`** — `dw-pack check` does not validate `covers.skills`, so a fictional id passes it silently:

```
OK   dw.add.column.add-no-regroup -> active
OK   dw.add.column.subtract-no-regroup -> active
OK   dw.add.regroup.add-multidigit -> active
OK   dw.add.regroup.subtract-multidigit -> active
OK   dw.add.regroup.add-short-addend -> active
OK   dw.add.regroup.subtract-short-subtrahend -> active
OK   dw.add.regroup.subtract-across-zero -> active
capabilities: ['items', 'items.reveal', 'haptics']
```

**`gitleaks`** over the commit range

```
12:35AM INF 1 commits scanned.
12:35AM INF scanned ~156969 bytes (156.97 KB) in 61.9ms
12:35AM INF no leaks found
```

**Scope**

```
$ git diff --name-only origin/main...HEAD
dynawalla/games/coil/.gitignore
dynawalla/games/coil/README.md
dynawalla/games/coil/index.html
dynawalla/games/coil/pack.html
dynawalla/games/coil/pack.json
dynawalla/games/coil/package.json
dynawalla/games/coil/src/audio/audio.ts
dynawalla/games/coil/src/contract.ts
dynawalla/games/coil/src/core/rng.ts
dynawalla/games/coil/src/game/board.test.ts
dynawalla/games/coil/src/game/board.ts
dynawalla/games/coil/src/game/place.test.ts
dynawalla/games/coil/src/game/place.ts
dynawalla/games/coil/src/game/reactions.test.ts
dynawalla/games/coil/src/game/reactions.ts
dynawalla/games/coil/src/game/round.test.ts
dynawalla/games/coil/src/game/round.ts
dynawalla/games/coil/src/game/session.test.ts
dynawalla/games/coil/src/game/session.ts
dynawalla/games/coil/src/index.ts
dynawalla/games/coil/src/main.ts
dynawalla/games/coil/src/mount.ts
dynawalla/games/coil/src/pack.ts
dynawalla/games/coil/src/render/layout.test.ts
dynawalla/games/coil/src/render/layout.ts
dynawalla/games/coil/src/render/palette.ts
dynawalla/games/coil/src/render/particles.ts
dynawalla/games/coil/src/render/scene.ts
dynawalla/games/coil/src/stubHost.test.ts
dynawalla/games/coil/src/stubHost.ts
dynawalla/games/coil/tsconfig.json
dynawalla/games/coil/vite.config.ts
dynawalla/games/coil/vite.pack.config.ts

$ git diff --name-only --diff-filter=D origin/main...HEAD
(empty)
```

**Played, not just compiled.** Driven in Chrome against the stub host at 1316×907, and every claim above was watched happening:

- `14 + 87` (fill): the coil enters as ninety-six — nine drums and six beads — with a cradle of `14` in the wall. Cracking the head drum turns it into ten beads *in place*, the coil wraps onto the second lane row, and the gauge still reads the same amount. Parking the jaws nine beads in makes the gauge read eight drums and seven beads, the lever whips the piece to the wall, a brick is laid, and the harness prints `host.report → 1/1 · "101"`.
- `42 − 20` (take): no cradle, the recess runs the full width. Shearing greedily without cracking takes two drums and two beads, and the harness prints `host.report → 0/1 · "20"` — wrong, because the answer is 22. The piece falls, the furnace reads **1 slag**, an oxide stain crosses the lane for a quarter of a second, and there is no buzzer anywhere.

Two layout defects were found this way and fixed: the fill-mode cradle overlapped the carved recess, and the lane drew one long straight row instead of a serpentine (the columns are now capped at sixteen, so six rows are exactly the ninety-six the game is named for).

### What the 79 tests actually cover

Rules, never rendering. `layout.ts` is pure geometry so its invariants are testable without a canvas.

- **`place.test.ts`** — exact powers of ten at every reachable place; `coilOf` is the numeral and a zero digit is the *absence* of a link; break and fuse both preserve value exactly over a seeded sweep; **breaking at the cut never changes what the cut is worth** (the property the whole interaction rests on); fuse is the inverse of break and is the carry; and every demand is reachable, replayed break-for-break with the cut asserted to exist afterwards.
- **`round.test.ts`** — the take/fill/fallback table above, ASCII hyphen and en dash both read as subtraction, the stock coil is always ninety-six of the right order, the claim is the canonical answer exactly when the cut is exact and never otherwise, and an inconsistent prompt loses to the canonical answer rather than quietly playing a different problem.
- **`board.test.ts`** — the shear always takes at least one link and never a buried one; slag takes cells and burial is head-first; a buried link cannot be cracked; a shear is a partition whose two pieces add back to the coil; half accuracy never lets the lane get ahead of the player; thirty misses bury the coil and fifteen exact cuts dig it back out; and the demand is reachable **cracking only at the jaws**, replayed through the board's own API, since that is the only break the interaction affords.
- **`session.test.ts`** — one report per item however many times the lever is pulled; a course closing fires `transition("level")` and a miss never fires anything; an uncuttable item is skipped and never reported; a host with nothing to serve leaves a quiet alley rather than a crash; the furnace costs a coil and no record; and a forty-item run in which every claim is an integer string.
- **`reactions.test.ts`** — `energy(SLIP) < energy(SEAT)`, every tier inside its `EXPERIENCE_DESIGN.md` budget, and `tierFor` taking no streak, combo or run-length argument (asserted on the shape of its input, so adding one fails a test on purpose).
- **`layout.test.ts`** — seven viewports from 320×568 to 1920×1080: nothing overlaps or leaves the viewport, every lever is at least 44 px, consecutive lane cells are adjacent so the chain never jumps, the serpentine never crosses itself, and the layout is a pure function of the viewport.
- **`stubHost.test.ts`** — the stream is seeded and reproducible; every operand, answer and distractor is an exact integer; every question the stub serves is one `roundFrom` can cut; and the distractors are executable mal-rules (`addNoCarry(27,15) = 32`, `subSmallerFromLarger(52,27) = 35`, `borrowSkippingZero(403,87) = 326` — a ten written where a nine belongs, which lands exactly ten above the answer — returning `-1` where the bug has nothing to fire on).
