### PR TITLE
dynawalla/games/beam: LATTICE RUNNER — the beam only kills what it divides, and it sings the remainder

### DIFF
--- a/dynawalla/games/beam/.gitignore
+++ b/dynawalla/games/beam/.gitignore
@@ -1,0 +1,12 @@
+node_modules/
+dist/
+
+# The pack build. `packs/build.mjs` regenerates it and stages it into the app.
+dist-pack/
+
+# QA captures. The committed screenshot set lives elsewhere; these are scratch.
+qa/shots
+qa/tmp
+
+# Each game resolves its own devDependencies; the lockfile is not shared.
+package-lock.json

--- a/dynawalla/games/beam/README.md
+++ b/dynawalla/games/beam/README.md
@@ -1,0 +1,156 @@
+# LATTICE RUNNER
+
+> after *Beam Rider* (1983). Rank 23, S tier, wave 2 of `docs/catalog/ARCADE_CANON.md`.
+>
+> **Loop:** ride a divisor beam; only a beam that divides the automaton kills it.
+> **Juice:** resonance lock as two waveforms phasing — division made audible.
+
+## The rule
+
+A lattice of five beams runs from a vanishing point down to the floor. Each beam is
+tuned to a whole number. Automata walk down the lattice carrying whole numbers.
+
+> A pulse fired up beam `b` destroys an automaton carrying `v`
+> **if and only if `b` divides `v`.**
+
+That sentence is `resonates()` in `src/sim/lattice.ts`, it is stated exactly once, and
+`src/test/pulse.test.ts` asserts the biconditional over every readable beam against every
+legible hull value. Nothing else in the package is allowed to have an opinion about
+whether a kill lands.
+
+The automata **step sideways** as they descend, so a number is reachable from several
+beams at different moments. That is what makes divisibility a decision rather than a
+lookup: 84 can be taken from 3, from 4, from 7, and the tight divisor pays double. The
+economy is the pedagogy — the obvious read is always the cheapest one on the board.
+
+A pulse that does not divide costs nothing but time: the automaton rings and is shoved
+further down the lattice. Nothing is deducted and nothing is scolded.
+
+## The resonance lock
+
+While you are riding a beam, two oscillators run: the beam's tone and the automaton's,
+detuned by the **phase offset** `(v mod b) / b`. Two tones a little apart beat against
+each other, and the beat rate is the mismatch. When the beam divides the value the
+mismatch is exactly zero, the beating stops, and the pair collapses into one pure tone.
+
+The same two waveforms are drawn along the beam. At zero offset they are the same curve
+and the eye sees one bright line; at any other offset the beam looks braided. The picture
+and the sound carry identical information, so the game is fully playable with the volume
+off.
+
+It is deliberately **not** a verdict light. A remainder of one out of twelve is a slow,
+almost-locked wobble — 83 and 85 both read as "one away from a multiple of 12", because a
+phase is circular and that happens to be true. The ear narrows the field and never
+finishes the job, so a child who can divide is always faster than a child waiting for the
+tone to settle. The scaffold fades on its own.
+
+## Where the curriculum enters
+
+A **CORE** descends the middle of the lattice two seconds after the last one cleared,
+carrying a problem the host served — `247 + 158` — and fractures into one automaton per
+candidate value. Killing one hands it in.
+
+The number that is tuned here is the **dead time**, not the thinking time: the gap plus
+the core's approach is about four seconds, and the answering window — the candidates'
+fall from the fracture line to the floor — is about ten seconds early in a run, closing
+to six at full pressure. Comprehension is measured, never rationed; what was cut is the
+time with nothing on the lattice to think about. A wave ends the moment it is answered,
+so reading quickly is what buys the next problem.
+
+So a submission costs four real steps, three of them mathematics:
+
+1. do the column arithmetic, `247 + 158 = 405`;
+2. find 405 among the candidates;
+3. find a beam that divides 405 — on this board, 5;
+4. ride there before the candidates land.
+
+The divisibility rule is the **lock on the trigger**: you cannot hand in a number you
+cannot factor. It is not decoration around a quiz, and it is not a quiz bolted onto a
+shooter.
+
+### What is declared, and what is not
+
+`pack.json` declares the seven **active** `dw.add.*` rows and nothing else. Those are the
+skills the host can actually serve today, and the CORE is the only thing in the game that
+is reported.
+
+No `dw.div.*` row is declared. Divisibility is native to this mechanic and it is what the
+child does continuously — but every row in the `div` domain is `status: "draft"`, so
+claiming one would advertise coverage the curriculum cannot serve. When `div` is promoted
+this game gets better with **no code change**: the CORE takes whatever expression the
+ladder hands it, and a quotient on the hull is the same object as a sum on the hull.
+
+The stream of ordinary automata is the game's own mathematics — divisibility over numbers
+the game itself made up. Nobody asked those questions, so nothing about them is reported.
+
+### Items that are passed over
+
+An answer with no divisor in the readable beam range — a prime like 83, or 169 — cannot
+be killed on a lattice a child can read, so the item is passed over and the next one
+drawn (up to eight attempts; measured pass rate is above 70%, so eight draws miss less
+than once in ten thousand). A passed-over item is never shown and never reported.
+Silence is honest; an unanswerable question is not.
+
+The same filter closes a leak: if a beam had to be tuned to the answer's own number, the
+label at the foot of the lattice would print the answer. `usableCoreValue()` requires a
+divisor **strictly smaller** than the value, and `src/test/core.test.ts` asserts that no
+beam label is ever equal to a candidate's number.
+
+## Stakes
+
+Three anchors. An ordinary automaton reaching the floor breaches one; at zero the lattice
+goes dark. A wrong submission costs **no anchor** — it collapses the resonance multiplier
+to one, which is the entire economy, and the true statement is shown once, plainly. Two
+cores read relights an anchor, cumulatively, and that progress is never taken away.
+
+Escalation is on the size of the run — elapsed time and total kills — and never on an
+unbroken streak. `src/test/director.test.ts` asserts that two runs reaching the same
+totals by different routes land on identical pressure.
+
+## Running it
+
+```sh
+npm install
+npm run dev          # http://127.0.0.1:4321 — playable against the seeded stub host
+npm test             # rules, not rendering
+npm run tsc
+npm run build:pack   # → dist-pack/, which packs/build.mjs stages into the app
+```
+
+`?seed=1234` fixes the stub host's question stream; `?reduced=1` forces the reduced-motion
+branch.
+
+Controls: tap a beam to ride to it and fire on arrival; tap the beam you are on to fire
+now; **drag** to ride without firing, which is the listening verb. Arrow keys and space
+on a desktop.
+
+## Reduced motion
+
+A branch, not a degradation. The resonance traces stop travelling and are drawn as a
+still figure of the same two waves — the phase relationship, which is the whole point, is
+entirely legible standing still. No shake, no punch zoom, no hitstop, no flash. The
+audio, which is not motion, is unchanged.
+
+## Layout
+
+| Path | What lives there |
+|---|---|
+| `src/sim/lattice.ts` | the kill rule, the phase, and lattice tuning |
+| `src/sim/pulse.ts` | what a pulse does to what it meets — pure, and the biconditional's home |
+| `src/sim/core.ts` | turning a served item into a wave |
+| `src/sim/field.ts` | the automata and their walk down the lattice |
+| `src/sim/director.ts` | pacing, the value stream, and the scoring gradient |
+| `src/render/geom.ts` | the hall's perspective, pure and tested |
+| `src/render/hall.ts` | drawing, including the phasing traces |
+| `src/mount.ts` | the game: input, the frame loop, and the reporting seam |
+
+## Two random streams
+
+`rng` is the run — the numbers on the hulls, how the lattice tunes, which column a
+candidate takes. `fx` is decoration — the angle a spark leaves at, and nothing else.
+
+They were one stream, which was a defect and not an untidiness: every emitter draws once
+per particle and the quality tier scales the particle count, so a cheap tablet spawning
+45% of the sparks consumed a different number of draws and, from that frame on, played a
+*different game* from the same seed than an expensive one. `the quality tier cannot
+change the game` in `src/test/loop.test.ts` asserts the separation directly.

--- a/dynawalla/games/beam/index.html
+++ b/dynawalla/games/beam/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <title>LATTICE RUNNER — dev harness</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #04060d;
+        overscroll-behavior: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+      #readout {
+        position: fixed;
+        left: 8px;
+        bottom: 6px;
+        z-index: 5;
+        font: 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+        color: rgba(255, 255, 255, 0.42);
+        pointer-events: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <div id="readout">host.report → 0/0</div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/beam/pack.html
+++ b/dynawalla/games/beam/pack.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#04060d" />
+    <title>LATTICE RUNNER</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #04060d;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         The dev harness's `#readout` is not here — it reported the stub host's
+         tally, and inside a real host the host draws the progress. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/beam/pack.json
+++ b/dynawalla/games/beam/pack.json
@@ -1,0 +1,24 @@
+{
+  "id": "dynawalla.beam",
+  "version": "0.1.0",
+  "name": "LATTICE RUNNER",
+  "description": "A lattice of numbered beams. Ride one and fire, and a pulse destroys an automaton only when the beam divides the number it carries — while the beam sings the remainder against it, and goes pure when it hits zero.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-multidigit",
+      "dw.add.regroup.add-short-addend",
+      "dw.add.regroup.subtract-short-subtrahend",
+      "dw.add.regroup.subtract-across-zero"
+    ],
+    "grades": [1, 4]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/beam/package.json
+++ b/dynawalla/games/beam/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@dynawalla/game-beam",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "LATTICE RUNNER — ride a divisor beam. A pulse fired up beam b destroys an automaton carrying v if and only if b divides v, and the beam sings the remainder while you decide.",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4321",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
+    "build:pack": "vite build --config vite.pack.config.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^6.0.0",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/games/beam/src/audio.ts
+++ b/dynawalla/games/beam/src/audio.ts
@@ -1,0 +1,403 @@
+// Procedural WebAudio. No assets, no samples, nothing fetched.
+//
+// The signature of this game lives in `setLock`. Two oscillators run
+// continuously whenever the runner is under an automaton: one is the beam's
+// tone, one is the automaton's, and they are detuned by the **phase offset**
+// `(value mod beam) / beam`. Two tones a little apart beat against each other,
+// and the beat rate is the mismatch. When the beam divides the value the
+// mismatch is exactly zero, the beating stops, and the two collapse into one
+// pure sustained tone.
+//
+// That is division made audible, and it is deliberately *not* a verdict light.
+// The ear gets the remainder as a physical quantity — a remainder of one out of
+// twelve is a slow, nearly-locked wobble — so listening narrows the field but
+// never finishes the job, and a child who can divide is faster than a child who
+// waits for the tone to settle. The scaffold fades on its own.
+//
+// Nothing here is the sole channel for any information; the phasing is drawn on
+// the beam as well, and the whole system is disableable.
+
+const PENTATONIC = [0, 3, 5, 7, 10] as const
+
+function semis(i: number): number {
+  const k = Math.min(Math.max(0, i), PENTATONIC.length * 3 - 1)
+  const oct = Math.floor(k / PENTATONIC.length)
+  return (PENTATONIC[k % PENTATONIC.length] as number) + oct * 12
+}
+
+function safeHz(f: number): number {
+  return Math.max(20, Math.min(15000, f))
+}
+
+export class Audio {
+  private ctx: AudioContext | null = null
+  private master: GainNode | null = null
+  private bus: GainNode | null = null
+  private noise: AudioBuffer | null = null
+  private voices = 0
+  private readonly maxVoices = 24
+  private started = false
+  private warnedSilent = false
+  enabled = true
+
+  // The lock voice — the two phasing oscillators, plus a body partial.
+  private lockA: OscillatorNode | null = null
+  private lockB: OscillatorNode | null = null
+  private lockBody: OscillatorNode | null = null
+  private lockGain: GainNode | null = null
+  private lockTone: BiquadFilterNode | null = null
+  private bedOscs: OscillatorNode[] = []
+
+  /** Must be called from a user gesture. Safe to call repeatedly. */
+  async start(): Promise<void> {
+    if (this.started) {
+      if (this.ctx?.state === "suspended") await this.ctx.resume().catch(() => {})
+      return
+    }
+    type WithWebkit = typeof globalThis & { webkitAudioContext?: typeof AudioContext }
+    const Ctor = globalThis.AudioContext ?? (globalThis as WithWebkit).webkitAudioContext
+    if (!Ctor) {
+      // Once, not once per tap. A device with no WebAudio is a fact about the
+      // device, and repeating it a thousand times buries everything else.
+      if (!this.warnedSilent) {
+        this.warnedSilent = true
+        console.warn("[beam] no AudioContext; running silent")
+      }
+      return
+    }
+    try {
+      const ctx = new Ctor()
+      this.ctx = ctx
+      const comp = ctx.createDynamicsCompressor()
+      comp.threshold.value = -18
+      comp.knee.value = 26
+      comp.ratio.value = 6
+      comp.attack.value = 0.003
+      comp.release.value = 0.16
+      const master = ctx.createGain()
+      master.gain.value = 0.85
+      const bus = ctx.createGain()
+      bus.gain.value = 1
+      bus.connect(comp)
+      comp.connect(master)
+      master.connect(ctx.destination)
+      this.master = master
+      this.bus = bus
+
+      // One second of white noise, generated once and reused by every transient.
+      const len = Math.floor(ctx.sampleRate)
+      const buf = ctx.createBuffer(1, len, ctx.sampleRate)
+      const d = buf.getChannelData(0)
+      let s = 0x9e3779b9
+      for (let i = 0; i < len; i++) {
+        s ^= s << 13
+        s ^= s >>> 17
+        s ^= s << 5
+        d[i] = ((s >>> 0) / 2147483648 - 1) * 0.6
+      }
+      this.noise = buf
+
+      await ctx.resume().catch(() => {})
+      this.started = true
+      this.buildLock()
+      this.buildBed()
+    } catch (e) {
+      console.warn("[beam] audio failed to start", e)
+    }
+  }
+
+  private buildLock(): void {
+    const ctx = this.ctx
+    const bus = this.bus
+    if (!ctx || !bus) return
+    const gain = ctx.createGain()
+    gain.gain.value = 0
+    const tone = ctx.createBiquadFilter()
+    tone.type = "lowpass"
+    tone.frequency.value = 900
+    tone.Q.value = 0.4
+    gain.connect(tone)
+    tone.connect(bus)
+
+    const a = ctx.createOscillator()
+    a.type = "sine"
+    a.frequency.value = 220
+    const b = ctx.createOscillator()
+    b.type = "sine"
+    b.frequency.value = 220
+    const body = ctx.createOscillator()
+    body.type = "triangle"
+    body.frequency.value = 110
+    const bodyGain = ctx.createGain()
+    bodyGain.gain.value = 0.32
+    a.connect(gain)
+    b.connect(gain)
+    body.connect(bodyGain)
+    bodyGain.connect(gain)
+    a.start()
+    b.start()
+    body.start()
+    this.lockA = a
+    this.lockB = b
+    this.lockBody = body
+    this.lockGain = gain
+    this.lockTone = tone
+  }
+
+  private buildBed(): void {
+    const ctx = this.ctx
+    const bus = this.bus
+    if (!ctx || !bus) return
+    const g = ctx.createGain()
+    g.gain.value = 0.035
+    g.connect(bus)
+    for (const [hz, type] of [
+      [55, "sine"],
+      [82.5, "sine"],
+    ] as const) {
+      const o = ctx.createOscillator()
+      o.type = type
+      o.frequency.value = hz
+      o.detune.value = (Math.random() - 0.5) * 8
+      o.connect(g)
+      o.start()
+      this.bedOscs.push(o)
+    }
+  }
+
+  /**
+   * Drive the resonance lock.
+   *
+   * @param beamHz  the ridden beam's own tone
+   * @param phase   signed phase offset in (−0.5, 0.5]; exactly 0 means the beam
+   *                divides the automaton's value
+   * @param present false when nothing is above the runner — the voice ducks out
+   *                rather than droning at an imaginary target
+   */
+  setLock(beamHz: number, phase: number, present: boolean): void {
+    const ctx = this.ctx
+    if (!ctx || !this.lockA || !this.lockB || !this.lockGain || !this.lockBody || !this.lockTone) {
+      return
+    }
+    const t = ctx.currentTime
+    const f = safeHz(beamHz)
+    this.lockA.frequency.setTargetAtTime(f, t, 0.05)
+    // ±48 cents at a half-turn of phase: wide enough to beat audibly at about
+    // six hertz, narrow enough that the pair still reads as one note.
+    this.lockB.detune.setTargetAtTime(phase * 96, t, 0.05)
+    this.lockB.frequency.setTargetAtTime(f, t, 0.05)
+    this.lockBody.frequency.setTargetAtTime(safeHz(f * 0.5), t, 0.08)
+    const locked = phase === 0
+    // Locked, the filter opens and the pair gets a touch louder: the sound goes
+    // from a muffled wobble to something glassy and whole.
+    this.lockTone.frequency.setTargetAtTime(locked ? 2600 : 780, t, 0.06)
+    this.lockGain.gain.setTargetAtTime(
+      !present || !this.enabled ? 0 : locked ? 0.075 : 0.05,
+      t,
+      0.07,
+    )
+  }
+
+  setEnabled(on: boolean): void {
+    this.enabled = on
+    if (this.master && this.ctx) {
+      this.master.gain.setTargetAtTime(on ? 0.85 : 0, this.ctx.currentTime, 0.02)
+    }
+  }
+
+  suspend(): void {
+    this.ctx?.suspend().catch(() => console.warn("[beam] audio suspend refused"))
+  }
+
+  dispose(): void {
+    for (const o of [this.lockA, this.lockB, this.lockBody, ...this.bedOscs]) {
+      if (!o) continue
+      try {
+        o.stop()
+      } catch {
+        console.warn("[beam] oscillator already stopped")
+      }
+    }
+    this.bedOscs.length = 0
+    this.lockA = null
+    this.lockB = null
+    this.lockBody = null
+    this.ctx?.close().catch(() => console.warn("[beam] audio close refused"))
+    this.ctx = null
+    this.started = false
+  }
+
+  private ok(): boolean {
+    return this.enabled && this.ctx !== null && this.bus !== null && this.voices < this.maxVoices
+  }
+
+  private voice(): void {
+    this.voices++
+    setTimeout(() => {
+      this.voices--
+    }, 900)
+  }
+
+  private transient(t: number, dur: number, freq: number, q: number, gain: number): void {
+    const ctx = this.ctx
+    const bus = this.bus
+    if (!ctx || !bus || !this.noise) return
+    const src = ctx.createBufferSource()
+    src.buffer = this.noise
+    src.playbackRate.value = 0.8 + Math.random() * 0.5
+    const bp = ctx.createBiquadFilter()
+    bp.type = "bandpass"
+    bp.frequency.value = freq
+    bp.Q.value = q
+    const g = ctx.createGain()
+    g.gain.setValueAtTime(0, t)
+    g.gain.linearRampToValueAtTime(gain, t + 0.0016)
+    g.gain.exponentialRampToValueAtTime(0.0001, t + dur)
+    src.connect(bp)
+    bp.connect(g)
+    g.connect(bus)
+    src.start(t, Math.random() * 0.4)
+    src.stop(t + dur + 0.02)
+  }
+
+  private tone(
+    t: number,
+    freq: number,
+    dur: number,
+    gain: number,
+    type: OscillatorType = "sine",
+    detune = 0,
+  ): void {
+    const ctx = this.ctx
+    const bus = this.bus
+    if (!ctx || !bus) return
+    const o = ctx.createOscillator()
+    o.type = type
+    o.frequency.setValueAtTime(safeHz(freq), t)
+    o.detune.value = detune
+    const g = ctx.createGain()
+    g.gain.setValueAtTime(0, t)
+    g.gain.linearRampToValueAtTime(gain, t + 0.006)
+    g.gain.exponentialRampToValueAtTime(0.0001, t + dur)
+    o.connect(g)
+    g.connect(bus)
+    o.start(t)
+    o.stop(t + dur + 0.03)
+  }
+
+  /** Sliding onto a beam. A detent, not a note — the ride must not sing. */
+  ride(): void {
+    if (!this.ok() || !this.ctx) return
+    this.voice()
+    this.transient(this.ctx.currentTime, 0.03, 1900 + Math.random() * 500, 3, 0.09)
+  }
+
+  /** The pulse leaving the runner. */
+  fire(): void {
+    if (!this.ok() || !this.ctx) return
+    this.voice()
+    const t = this.ctx.currentTime
+    this.transient(t, 0.05, 3100, 1.4, 0.11)
+    this.tone(t, 520, 0.1, 0.05, "triangle")
+    this.tone(t + 0.005, 1040, 0.07, 0.02, "sine")
+  }
+
+  /**
+   * An automaton coming apart. `step` walks a minor pentatonic ladder, so a
+   * pulse that opens four multiples in one sweep rises without sounding wrong.
+   */
+  shatter(step: number): void {
+    if (!this.ok() || !this.ctx) return
+    this.voice()
+    const t = this.ctx.currentTime
+    const base = 262 * Math.pow(2, semis(step) / 12)
+    this.transient(t, 0.08, 2400 + Math.random() * 800, 0.9, 0.16)
+    this.tone(t + 0.003, base, 0.22, 0.11, "triangle", (Math.random() - 0.5) * 14)
+    this.tone(t + 0.003, base * 2, 0.13, 0.045, "sine")
+    this.tone(t + 0.012, base * 0.5, 0.3, 0.05, "sine")
+  }
+
+  /** A pulse that did not divide. A dry, detuned knock. Never a buzzer. */
+  dissonance(): void {
+    if (!this.ok() || !this.ctx) return
+    this.voice()
+    const t = this.ctx.currentTime
+    this.transient(t, 0.05, 420, 2.2, 0.1)
+    this.tone(t, 146, 0.14, 0.06, "triangle", -34)
+    this.tone(t + 0.004, 151, 0.14, 0.05, "triangle", 34)
+  }
+
+  /** The CORE entering the hall. Lapis, low, a door opening. */
+  coreArrive(): void {
+    if (!this.ok() || !this.ctx) return
+    this.voice()
+    const t = this.ctx.currentTime
+    this.tone(t, 98, 0.6, 0.09, "sine")
+    this.tone(t + 0.02, 147, 0.5, 0.05, "sine")
+    this.tone(t + 0.04, 196, 0.42, 0.035, "triangle")
+  }
+
+  /** The CORE breaking into its candidates. */
+  fracture(): void {
+    if (!this.ok() || !this.ctx) return
+    this.voice()
+    const t = this.ctx.currentTime
+    this.transient(t, 0.16, 1700, 0.6, 0.2)
+    for (let i = 0; i < 4; i++) {
+      this.tone(t + i * 0.03, 392 * Math.pow(2, i / 12), 0.2, 0.045, "sine")
+    }
+  }
+
+  /** The answer, taken. The biggest sound in the game. */
+  ascend(): void {
+    if (!this.ok() || !this.ctx) return
+    this.voice()
+    const t = this.ctx.currentTime
+    for (let i = 0; i < 6; i++) {
+      this.tone(t + i * 0.045, 262 * Math.pow(2, semis(i + 3) / 12), 0.5, 0.075, "sine")
+      this.tone(t + i * 0.045, 262 * Math.pow(2, semis(i + 3) / 12) * 2, 0.3, 0.025, "triangle")
+    }
+    this.tone(t, 131, 0.9, 0.06, "sine")
+  }
+
+  /** A candidate taken that was not the answer. Falls, does not scold. */
+  settleWrong(): void {
+    if (!this.ok() || !this.ctx) return
+    this.voice()
+    const t = this.ctx.currentTime
+    this.tone(t, 196, 0.28, 0.07, "sine")
+    this.tone(t + 0.07, 165, 0.34, 0.06, "sine")
+    this.tone(t + 0.15, 131, 0.5, 0.05, "sine")
+  }
+
+  /** Something reached the floor. */
+  breach(): void {
+    if (!this.ok() || !this.ctx) return
+    this.voice()
+    const t = this.ctx.currentTime
+    this.transient(t, 0.22, 180, 0.7, 0.24)
+    this.tone(t, 62, 0.6, 0.13, "sine")
+    this.tone(t + 0.01, 93, 0.3, 0.05, "triangle", -18)
+  }
+
+  /** An anchor relit. Rising, warm, earned. */
+  riser(): void {
+    if (!this.ok() || !this.ctx) return
+    this.voice()
+    const t = this.ctx.currentTime
+    for (let i = 0; i < 5; i++) {
+      this.tone(t + i * 0.06, 175 * Math.pow(2, semis(i) / 12), 0.45, 0.06, "triangle")
+    }
+  }
+
+  /** The lattice going dark. */
+  collapse(): void {
+    if (!this.ok() || !this.ctx) return
+    this.voice()
+    const t = this.ctx.currentTime
+    this.tone(t, 220, 1.4, 0.09, "sine", 0)
+    this.tone(t + 0.1, 146, 1.5, 0.08, "sine")
+    this.tone(t + 0.2, 98, 1.8, 0.07, "sine")
+    this.transient(t, 0.5, 300, 0.5, 0.12)
+  }
+}

--- a/dynawalla/games/beam/src/contract.ts
+++ b/dynawalla/games/beam/src/contract.ts
@@ -1,0 +1,41 @@
+// The host↔game contract. This is the shape the runtime lands underneath us;
+// it must not drift. Nothing else in this package may redefine these types.
+//
+// `mount` delegates to `./mount.ts`. That module imports `Host` from here
+// type-only, and a type-only import is erased, so there is no runtime cycle.
+
+import { mountBeam } from "./mount.ts"
+
+export type Question = {
+  id: string
+  prompt: string
+  answer: string
+  distractors: string[]
+  domain: string
+  difficulty: number
+}
+
+export type Host = {
+  next(opts?: { domain?: string; difficulty?: number }): Question
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+  haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void
+  prefersReducedMotion(): boolean
+
+  /**
+   * A natural stopping point the child *reached*: a level cleared, a run
+   * completed, a boss down.
+   *
+   * OPTIONAL and feature-detected — a stub host does not implement it and the
+   * game must not care. Fire and forget: nothing is returned, nothing may be
+   * awaited, and the game must not branch on it.
+   *
+   * **Never after a failure.** Not a defeat, not a breach, not a wrong answer,
+   * not a timer. This is the call the host may put a sheet on top of, and a
+   * purchase surface next to a failure is the thing that is forbidden outright.
+   */
+  transition?(kind: "level" | "run" | "boss", label?: string): void
+}
+
+export function mount(el: HTMLElement, host: Host): { unmount(): void } {
+  return mountBeam(el, host)
+}

--- a/dynawalla/games/beam/src/core/feel.ts
+++ b/dynawalla/games/beam/src/core/feel.ts
@@ -1,0 +1,172 @@
+// The response layer — Nijman's "Art of Screenshake", by name:
+//
+//   trauma shake · directional camera kick · punch zoom · hitstop (freeze
+//   frames) · slow-motion · screen flash · squash-and-stretch · sleep on impact
+//
+// Two rules carried over from the house game-feel foundation because they are
+// right, and because getting them wrong is the classic way an "educational"
+// game turns into a worksheet:
+//
+//   * **Hitstop is only ever spent on success.** A freeze frame is a reward.
+//     Spending one on a wrong answer slows the retry at the exact moment the
+//     loop must be fastest. Being wrong gets a directional kick instead.
+//   * **Nothing blocks input.** Every effect here draws *over* the next moment;
+//     none of them gate the pointer. A child who is faster than the celebration
+//     is never punished for it.
+
+export type FeelOptions = {
+  reducedMotion: boolean
+}
+
+/** Hard ceiling for a children's product: no more than this many flashes/sec. */
+const MAX_FLASHES_PER_SEC = 3
+const MIN_FLASH_GAP_MS = 1000 / MAX_FLASHES_PER_SEC
+/** And no single flash may ever exceed this alpha, at any tier, ever. */
+const MAX_FLASH_ALPHA = 0.42
+
+export class Feel {
+  trauma = 0 // 0..1, shake is trauma²
+  kickX = 0
+  kickY = 0
+  zoom = 0 // additive; 0.1 == 10% punch in
+  private flash = 0
+  private flashColor = "#ffffff"
+  private lastFlashAt = -1e9
+  private hitstopMs = 0
+  private slowUntil = 0
+  private slowFrom = 1
+  private slowMs = 1
+  private nowMs = 0
+
+  reducedMotion: boolean
+
+  // Resolved each frame; read by the renderer.
+  shakeX = 0
+  shakeY = 0
+  scale = 1
+  flashAlpha = 0
+
+  private seed = 0x2545f491
+
+  constructor(o: FeelOptions) {
+    this.reducedMotion = o.reducedMotion
+  }
+
+  private rand(): number {
+    // xorshift32, so shake never allocates and never calls Math.random.
+    let x = this.seed
+    x ^= x << 13
+    x ^= x >>> 17
+    x ^= x << 5
+    this.seed = x >>> 0
+    return (this.seed / 4294967296) * 2 - 1
+  }
+
+  addTrauma(v: number): void {
+    if (this.reducedMotion) return
+    this.trauma = Math.min(1, this.trauma + v)
+  }
+
+  /** A kick along a direction — the cut's normal, or away from the bomb. */
+  kick(dx: number, dy: number, mag: number): void {
+    if (this.reducedMotion) return
+    const l = Math.hypot(dx, dy) || 1
+    this.kickX += (dx / l) * mag
+    this.kickY += (dy / l) * mag
+  }
+
+  punch(v: number): void {
+    if (this.reducedMotion) return
+    this.zoom += v
+  }
+
+  /** Freeze frames. Success only — `assertSuccessOnly` in the tests enforces it. */
+  hitstop(ms: number): void {
+    if (this.reducedMotion) return
+    this.hitstopMs = Math.max(this.hitstopMs, ms)
+  }
+
+  /** Slow-motion: drop to `from`, recover to 1 over `ms`. */
+  slowmo(from: number, ms: number): void {
+    if (this.reducedMotion) return
+    if (from >= this.timeScale()) return
+    this.slowFrom = from
+    this.slowMs = ms
+    this.slowUntil = this.nowMs + ms
+  }
+
+  /**
+   * Screen flash, rate-limited. A request that arrives too soon after the last
+   * one is *not* queued — it is dropped, and the pending flash is topped up
+   * instead. Queuing would let a fast combo emit a strobe.
+   */
+  requestFlash(alpha: number, color: string): void {
+    if (this.reducedMotion) return
+    const a = Math.min(MAX_FLASH_ALPHA, alpha)
+    if (this.nowMs - this.lastFlashAt < MIN_FLASH_GAP_MS) {
+      this.flash = Math.max(this.flash, a * 0.5)
+      return
+    }
+    this.lastFlashAt = this.nowMs
+    this.flash = Math.max(this.flash, a)
+    this.flashColor = color
+  }
+
+  timeScale(): number {
+    if (this.nowMs >= this.slowUntil) return 1
+    const t = 1 - (this.slowUntil - this.nowMs) / this.slowMs // 0 → 1
+    // easeOutCubic back to real time: the recovery should feel like release.
+    const e = 1 - Math.pow(1 - t, 3)
+    return this.slowFrom + (1 - this.slowFrom) * e
+  }
+
+  /**
+   * @param dtMs real elapsed time
+   * @returns the number of ms the *simulation* should advance — zero while a
+   *          hitstop is being served.
+   */
+  advance(dtMs: number, nowMs: number): number {
+    this.nowMs = nowMs
+
+    if (this.hitstopMs > 0) {
+      this.hitstopMs -= dtMs
+      // Decay the visual response even during a freeze, so a long hitstop does
+      // not resume into a stale shake.
+      this.decay(dtMs)
+      return 0
+    }
+    this.decay(dtMs)
+    return dtMs * this.timeScale()
+  }
+
+  private decay(dtMs: number): void {
+    const dt = dtMs / 1000
+    this.trauma = Math.max(0, this.trauma - dt * 1.55)
+    const k = Math.exp(-dt * 11)
+    this.kickX *= k
+    this.kickY *= k
+    this.zoom *= Math.exp(-dt * 8.5)
+    this.flash = Math.max(0, this.flash - dt * 2.6)
+
+    const t2 = this.trauma * this.trauma
+    const amp = t2 * 26
+    this.shakeX = this.rand() * amp + this.kickX
+    this.shakeY = this.rand() * amp + this.kickY
+    this.scale = 1 + this.zoom + t2 * 0.012
+    this.flashAlpha = this.flash
+  }
+
+  get currentFlashColor(): string {
+    return this.flashColor
+  }
+
+  reset(): void {
+    this.trauma = 0
+    this.kickX = 0
+    this.kickY = 0
+    this.zoom = 0
+    this.flash = 0
+    this.hitstopMs = 0
+    this.slowUntil = 0
+  }
+}

--- a/dynawalla/games/beam/src/core/rng.ts
+++ b/dynawalla/games/beam/src/core/rng.ts
@@ -1,0 +1,61 @@
+// A seeded, deterministic PRNG. Every stochastic decision in the game and in
+// the stub host runs through one of these so a run can be replayed exactly.
+//
+// mulberry32: 32-bit state, no allocation, passes gjrand well enough for a game
+// and is trivially portable to a test.
+
+export class Rng {
+  private s: number
+
+  constructor(seed: number) {
+    // Force to uint32; a 0 seed is legal for mulberry32 but degenerate-looking,
+    // so nudge it off zero.
+    this.s = (seed >>> 0) || 0x9e3779b9
+  }
+
+  /** Uniform in [0, 1). */
+  next(): number {
+    this.s = (this.s + 0x6d2b79f5) >>> 0
+    let t = this.s
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+
+  /** Uniform in [lo, hi). */
+  range(lo: number, hi: number): number {
+    return lo + this.next() * (hi - lo)
+  }
+
+  /** Uniform integer in [lo, hi] inclusive. */
+  int(lo: number, hi: number): number {
+    if (hi <= lo) return lo
+    return lo + Math.floor(this.next() * (hi - lo + 1))
+  }
+
+  /** True with probability p. */
+  chance(p: number): boolean {
+    return this.next() < p
+  }
+
+  pick<T>(xs: readonly T[]): T {
+    if (xs.length === 0) throw new Error("rng.pick: empty")
+    return xs[Math.floor(this.next() * xs.length)] as T
+  }
+
+  /** In-place Fisher–Yates. Returns the same array for chaining. */
+  shuffle<T>(xs: T[]): T[] {
+    for (let i = xs.length - 1; i > 0; i--) {
+      const j = Math.floor(this.next() * (i + 1))
+      const a = xs[i] as T
+      xs[i] = xs[j] as T
+      xs[j] = a
+    }
+    return xs
+  }
+
+  /** Snapshot/restore so a subsystem can be forked without disturbing the run. */
+  fork(salt: number): Rng {
+    return new Rng((this.s ^ Math.imul(salt, 0x85ebca6b)) >>> 0)
+  }
+}

--- a/dynawalla/games/beam/src/core/tiers.ts
+++ b/dynawalla/games/beam/src/core/tiers.ts
@@ -1,0 +1,98 @@
+// Quality tiers. The mid-range tablet sets the FLOOR — LOW is what has to hold
+// 60fps, and ULTRA is allowed to be extravagant.
+//
+// The tier is picked once from device signals and then *ratchets down only*,
+// driven by a rolling frame-time budget. It never ratchets back up mid-run: a
+// tier that oscillates produces a visibly pulsing particle count, which is
+// worse than being one tier low the whole way.
+
+export type TierName = "low" | "high" | "ultra"
+
+export type Quality = {
+  name: TierName
+  /** Ceiling on live particles. */
+  particles: number
+  /** Multiplies every emitter's burst count. */
+  burst: number
+  /** Render scale — devicePixelRatio is clamped to this. */
+  maxDpr: number
+  /** Soft glow under the automata and along the beams. */
+  glow: boolean
+  /** Samples per resonance trace. The phasing curve is drawn as a polyline. */
+  traceSamples: number
+  /** Motes drifting in the hall behind the lattice. */
+  dust: number
+}
+
+export const TIERS: Record<TierName, Quality> = {
+  low: { name: "low", particles: 420, burst: 0.45, maxDpr: 1.5, glow: false, traceSamples: 34, dust: 0 },
+  high: { name: "high", particles: 1400, burst: 1, maxDpr: 2, glow: true, traceSamples: 62, dust: 46 },
+  ultra: { name: "ultra", particles: 3200, burst: 1.8, maxDpr: 2.25, glow: true, traceSamples: 96, dust: 90 },
+}
+
+const ORDER: TierName[] = ["low", "high", "ultra"]
+
+export function detectTier(): TierName {
+  const nav = globalThis.navigator as (Navigator & { deviceMemory?: number }) | undefined
+  const cores = nav?.hardwareConcurrency ?? 4
+  const mem = nav?.deviceMemory ?? 4
+  const px = (globalThis.screen?.width ?? 1024) * (globalThis.screen?.height ?? 768)
+
+  // A phone with 8 fast cores still has a small thermal envelope, so cores
+  // alone overrates mobile. Memory is the better proxy for "this is a cheap
+  // tablet", and pixel count for "this is going to cost a lot to fill".
+  if (cores <= 4 || mem <= 3) return "low"
+  if (cores >= 8 && mem >= 8 && px >= 1_500_000) return "ultra"
+  return "high"
+}
+
+/**
+ * Watches frame time and ratchets the tier down when the device cannot hold the
+ * budget. Deliberately slow to fire: a single 40ms frame is a GC pause, not a
+ * verdict. It takes a sustained quarter-second of overrun.
+ */
+export class TierGovernor {
+  private samples = new Float32Array(60)
+  private i = 0
+  private filled = 0
+  private overrunMs = 0
+  private cooldown = 0
+  quality: Quality
+
+  constructor(start: TierName) {
+    this.quality = TIERS[start]
+  }
+
+  /** @returns true when the tier changed this frame. */
+  sample(dtMs: number): boolean {
+    this.samples[this.i] = dtMs
+    this.i = (this.i + 1) % this.samples.length
+    if (this.filled < this.samples.length) this.filled++
+
+    if (this.cooldown > 0) {
+      this.cooldown -= dtMs
+      return false
+    }
+    // 20ms ≈ the point where a 60Hz display has certainly dropped a frame.
+    this.overrunMs = dtMs > 20 ? this.overrunMs + (dtMs - 20) : Math.max(0, this.overrunMs - 4)
+    if (this.overrunMs < 250) return false
+
+    const idx = ORDER.indexOf(this.quality.name)
+    if (idx <= 0) {
+      this.overrunMs = 0
+      return false
+    }
+    this.quality = TIERS[ORDER[idx - 1] as TierName]
+    this.overrunMs = 0
+    this.cooldown = 3000
+    console.warn(`[beam] frame budget missed; quality → ${this.quality.name}`)
+    return true
+  }
+
+  /** Median frame time over the window, for the on-screen perf readout. */
+  medianMs(): number {
+    if (this.filled === 0) return 0
+    const a = Array.from(this.samples.slice(0, this.filled)).sort((x, y) => x - y)
+    return a[a.length >> 1] as number
+  }
+}

--- a/dynawalla/games/beam/src/index.ts
+++ b/dynawalla/games/beam/src/index.ts
@@ -1,0 +1,5 @@
+// The package entry. A game is a library that mounts into a host element; the
+// dev harness and the pack entry are the two callers.
+
+export { mount } from "./contract.ts"
+export type { Host, Question } from "./contract.ts"

--- a/dynawalla/games/beam/src/main.ts
+++ b/dynawalla/games/beam/src/main.ts
@@ -1,0 +1,36 @@
+// Standalone dev harness. `npm run dev` → a playable game wired to the local
+// stub Host, with no runtime underneath it.
+
+import { mount } from "./contract.ts"
+import { createStubHost } from "./stubHost.ts"
+
+const el = document.getElementById("app")
+if (!el) throw new Error("beam: #app missing")
+
+const params = new URLSearchParams(location.search)
+const seed = Number(params.get("seed") ?? "") || 0xbea3
+const reduced = params.has("reduced") ? params.get("reduced") !== "0" : undefined
+
+let answered = 0
+let correct = 0
+const readout = document.getElementById("readout")
+
+const host = createStubHost({
+  seed,
+  ...(reduced === undefined ? {} : { reducedMotion: reduced }),
+  onReport(r) {
+    answered++
+    if (r.correct) correct++
+    if (readout) {
+      readout.textContent = `host.report → ${correct}/${answered} · last ${r.ms}ms · "${r.answered || "—"}"`
+    }
+    console.info("[beam/host] report", r)
+  },
+})
+
+const handle = mount(el, host)
+
+// Vite HMR: tear the old instance down so audio contexts and rAF loops do not
+// accumulate across edits.
+type HotModule = { hot?: { dispose(cb: () => void): void } }
+;(import.meta as unknown as HotModule).hot?.dispose(() => handle.unmount())

--- a/dynawalla/games/beam/src/mount.ts
+++ b/dynawalla/games/beam/src/mount.ts
@@ -1,0 +1,929 @@
+// LATTICE RUNNER — the game.
+//
+// You ride the foot of a lattice of numbered beams. Automata walk down it
+// carrying numbers. A pulse fired up beam `b` destroys an automaton carrying
+// `v` **if and only if b divides v** — that is the entire rule, it is stated
+// once in `sim/lattice.ts`, and nothing here is allowed to have an opinion
+// about it.
+//
+// Because the automata step sideways as they descend, a number is reachable
+// from several beams at different moments, so "can I kill this" is never a
+// lookup: 84 can be taken from 3, from 4, from 7 — and the tight divisor pays
+// double, which is the pedagogy written into the economy rather than into a
+// lecture.
+//
+// Every eight seconds a CORE comes down the middle carrying a problem the
+// curriculum served — `247 + 158` — and fractures into candidate values. To
+// hand one in you must do the column arithmetic *and* find a beam that divides
+// the value you believe in. The divisibility rule is the lock on the trigger:
+// you cannot submit a number you cannot factor.
+//
+// And the whole time, the beam you are riding sings against the automaton above
+// you at the phase `(v mod b) / b`. At zero the two waveforms fuse. Division,
+// audible.
+
+import type { Host, Question } from "./contract.ts"
+import { Audio } from "./audio.ts"
+import { Feel } from "./core/feel.ts"
+import { Rng } from "./core/rng.ts"
+import { detectTier, TierGovernor } from "./core/tiers.ts"
+import { columnAt, columnX, makeGeom, project } from "./render/geom.ts"
+import {
+  drawAnchors,
+  drawAutomaton,
+  drawBeams,
+  drawHall,
+  drawPulse,
+  drawRunner,
+  drawScore,
+  drawTraces,
+  type BeamStyle,
+} from "./render/hall.ts"
+import {
+  BEAM_HOT,
+  BRASS_HOT,
+  DISSONANT,
+  font,
+  LAPIS_HOT,
+  PAPER,
+  RESONANT,
+  RESONANT_HOT,
+  UI_FONT,
+  withAlpha,
+} from "./render/palette.ts"
+import { KIND_MOTE, KIND_SHARD, Particles } from "./render/particles.ts"
+import { buildCore, type CoreWave } from "./sim/core.ts"
+import { Director, fieldValue, killScore } from "./sim/director.ts"
+import { A_CANDIDATE, A_CORE, A_ORDINARY, type Automaton, Field } from "./sim/field.ts"
+import { phaseOffset, resonates, tuneLattice, validBeamCount } from "./sim/lattice.ts"
+import { resolveStrike } from "./sim/pulse.ts"
+
+const N_BEAMS = 5
+const ANCHORS = 3
+/** Cores read that buy an anchor back. Cumulative — never taken away again. */
+const READ_PER_ANCHOR = 2
+const RESONANCE_MAX = 4
+const RESONANCE_SECONDS = 10
+const CHAIN_WINDOW = 1.4
+const PULSE_SECONDS = 0.42
+const FIRE_COOLDOWN = 0.14
+/** The in-memory best, so a pack frame with no storage still shows one. */
+let sessionBest = 0
+
+type Pulse = { alive: boolean; col: number; t: number; prevT: number; hits: number }
+type Pop = { alive: boolean; x: number; y: number; life: number; max: number; text: string; size: number; color: string }
+type Banner = { text: string; sub: string; life: number; max: number; color: string }
+
+export function mountBeam(el: HTMLElement, host: Host): { unmount(): void } {
+  // ── surface ──────────────────────────────────────────────────────────────
+  const root = document.createElement("div")
+  root.style.cssText =
+    "position:relative;width:100%;height:100%;overflow:hidden;touch-action:none;" +
+    "-webkit-user-select:none;user-select:none;background:#04060d;cursor:pointer;"
+  const canvas = document.createElement("canvas")
+  canvas.style.cssText = "position:absolute;inset:0;width:100%;height:100%;display:block;"
+  root.appendChild(canvas)
+  el.appendChild(root)
+
+  const ctx0 = canvas.getContext("2d", { alpha: false })
+  if (!ctx0) throw new Error("beam: could not acquire a 2D context")
+  const g: CanvasRenderingContext2D = ctx0
+
+  // ── systems ──────────────────────────────────────────────────────────────
+  const reduced = host.prefersReducedMotion()
+  const gov = new TierGovernor(detectTier())
+  const feel = new Feel({ reducedMotion: reduced })
+  const audio = new Audio()
+  const parts = new Particles()
+  const field = new Field()
+  const director = new Director()
+  // Two streams, deliberately separated.
+  //
+  // `rng` is the RUN: the numbers on the hulls, how the lattice tunes, which
+  // column a candidate takes, when an automaton turns. `fx` is decoration: the
+  // angle a spark leaves at, and nothing else.
+  //
+  // They were one stream, and that was a real defect rather than an untidiness.
+  // Every emitter draws once per particle, and the quality tier scales the
+  // particle count — so a cheap tablet, spawning 45% of the sparks, consumed a
+  // different number of draws and from that frame on played a *different game*
+  // from the same seed than an expensive one. It also made the headless loop
+  // test pass on a 12-core laptop and fail on a 4-core CI runner, which is how
+  // it was caught. Decoration must never be able to move the mathematics.
+  let rng = new Rng(0xbea3 ^ (Date.now() & 0xffffff))
+  let fx = new Rng(0x0fec7 ^ (Date.now() & 0xffffff))
+
+  // ── run state ────────────────────────────────────────────────────────────
+  let geom = makeGeom(320, 480, N_BEAMS)
+  let dpr = 1
+  let running = true
+  let over = false
+  let overAt = 0
+  let beams: number[] = tuneLattice([], N_BEAMS, () => rng.next())
+  let runnerCol = Math.floor(N_BEAMS / 2)
+  let runnerSlide = runnerCol
+  let fireOnArrive = false
+  let fireCooldown = 0
+  let score = 0
+  let best = readBest()
+  let anchors = ANCHORS
+  let credit = 0
+  let chain = 0
+  let chainTimer = 0
+  let resonance = 1
+  let resonanceLeft = 0
+  let traceScroll = 0
+  let asked = 0
+  let right = 0
+  let coresRead = 0
+  let lastTransitionAt = 0
+
+  // ── the live CORE ────────────────────────────────────────────────────────
+  let wave: CoreWave | null = null
+  let waveAskedAt = 0
+  let coreBody: Automaton | null = null
+
+  const pulses: Pulse[] = []
+  for (let i = 0; i < 4; i++) pulses.push({ alive: false, col: 0, t: 0, prevT: 0, hits: 0 })
+
+  const pops: Pop[] = []
+  for (let i = 0; i < 24; i++)
+    pops.push({ alive: false, x: 0, y: 0, life: 0, max: 1, text: "", size: 20, color: PAPER })
+  let banner: Banner | null = null
+
+  const swept: Automaton[] = []
+  const landed: Automaton[] = []
+  /** Reused every frame so the draw order costs no allocation. */
+  const order: Automaton[] = []
+
+  const colBrass = parts.colorId(BRASS_HOT)
+  const colGold = parts.colorId(RESONANT)
+  const colGoldHot = parts.colorId(RESONANT_HOT)
+  const colBeam = parts.colorId(BEAM_HOT)
+  const colWrong = parts.colorId(DISSONANT)
+  const colLapis = parts.colorId(LAPIS_HOT)
+
+  function readBest(): number {
+    try {
+      return Math.max(sessionBest, Number(localStorage.getItem("dw.beam.best") ?? "0") || 0)
+    } catch {
+      // A pack frame is an opaque origin and every `localStorage` access throws
+      // there. The in-memory best is not a fallback, it is the real one on a
+      // tablet; the browser copy is a convenience for the dev harness.
+      console.warn("[beam] localStorage unavailable; best score is session-only")
+      return sessionBest
+    }
+  }
+  function writeBest(v: number): void {
+    sessionBest = Math.max(sessionBest, v)
+    try {
+      localStorage.setItem("dw.beam.best", String(v))
+    } catch {
+      console.warn("[beam] could not persist best score")
+    }
+  }
+
+  // ── layout ───────────────────────────────────────────────────────────────
+  function resize(): void {
+    const q = gov.quality
+    const rect = root.getBoundingClientRect()
+    const w = Math.max(320, Math.round(rect.width))
+    const h = Math.max(320, Math.round(rect.height))
+    geom = makeGeom(w, h, N_BEAMS)
+    dpr = Math.min(q.maxDpr, globalThis.devicePixelRatio || 1)
+    canvas.width = Math.round(w * dpr)
+    canvas.height = Math.round(h * dpr)
+    parts.limit = q.particles
+  }
+  const ro = new ResizeObserver(() => resize())
+  ro.observe(root)
+  resize()
+
+  // ── helpers ──────────────────────────────────────────────────────────────
+  function pop(text: string, x: number, y: number, size: number, color: string): void {
+    const s = Math.max(12, Math.min(size, geom.w * 0.09))
+    for (const p of pops) {
+      if (p.alive) continue
+      p.alive = true
+      p.x = Math.max(s * 2, Math.min(geom.w - s * 2, x))
+      p.y = y
+      p.max = 0.85
+      p.life = p.max
+      p.text = text
+      p.size = s
+      p.color = color
+      return
+    }
+  }
+
+  function showBanner(text: string, sub: string, color: string, secs: number): void {
+    banner = { text, sub, life: secs, max: secs, color }
+  }
+
+  function burst(x: number, y: number, colorId: number, n: number, speed: number, shard = false): void {
+    const count = Math.round(n * gov.quality.burst)
+    for (let i = 0; i < count; i++) {
+      const a = fx.next() * Math.PI * 2
+      const s = speed * (0.2 + fx.next() * 1.1)
+      parts.spawn(
+        shard && fx.chance(0.45) ? KIND_SHARD : KIND_MOTE,
+        x,
+        y,
+        Math.cos(a) * s,
+        Math.sin(a) * s,
+        0.32 + fx.next() * 0.55,
+        3 + fx.next() * 6,
+        colorId,
+        1.9,
+      )
+    }
+  }
+
+  function scoreMul(): number {
+    return (1 + Math.min(4, Math.floor(chain / 3))) * resonance
+  }
+
+  /** Cheap, allocation-free scan for the values currently in the air. */
+  function liveOrdinaryValues(): number[] {
+    const out: number[] = []
+    for (const b of field.bodies) if (b.alive && b.kind === A_ORDINARY) out.push(b.value)
+    return out
+  }
+
+  /**
+   * Re-tune the lattice.
+   *
+   * The candidates come first so the answer is always killable; the values
+   * already in the air come second, so an automaton in flight keeps its beam
+   * whenever there is room. Anything that survives the retune out of tune is
+   * dispersed rather than left as a breach the child could do nothing about.
+   */
+  function retune(required: readonly number[]): void {
+    beams = tuneLattice([...required, ...liveOrdinaryValues()], N_BEAMS, () => rng.next())
+    for (const b of field.bodies) {
+      if (!b.alive || b.kind !== A_ORDINARY) continue
+      if (validBeamCount(beams, b.value) > 0) continue
+      const p = project(geom, b.slide, b.t)
+      burst(p.x, p.y, colBeam, 10, 130)
+      b.alive = false
+    }
+  }
+
+  function spawnOrdinary(): void {
+    const p = director.pressure()
+    const b = field.spawn()
+    if (!b) return
+    b.kind = A_ORDINARY
+    b.value = fieldValue(beams, p.tightness, () => rng.next())
+    b.text = String(b.value)
+    b.beam = rng.int(0, N_BEAMS - 1)
+    b.slide = b.beam
+    b.t = 0
+    b.speed = 1 / p.descentSeconds
+    b.stepIn = rng.range(0.3, 1) * p.stepSeconds
+    b.stepDir = rng.chance(0.5) ? 1 : -1
+    b.spawnedAt = performance.now()
+    director.noteSpawn()
+  }
+
+  /**
+   * Draw an item the lattice can actually be tuned to.
+   *
+   * An answer with no divisor in the beam range — a prime, or 169 — cannot be
+   * killed on a board a child can read, so the item is passed over and the next
+   * one drawn. A passed-over item is never shown and never reported: silence is
+   * honest, an unanswerable question is not.
+   */
+  function drawWave(): CoreWave | null {
+    const p = director.pressure()
+    for (let tries = 0; tries < 8; tries++) {
+      const q: Question = host.next({ difficulty: 2 + Math.round(p.level * 7) })
+      if (!q.id) return null
+      const built = buildCore(
+        { id: q.id, prompt: q.prompt, answer: q.answer, distractors: q.distractors },
+        N_BEAMS,
+        () => rng.next(),
+      )
+      if (built) return built
+    }
+    console.warn("[beam] no item in eight draws had an answer this lattice can be tuned to")
+    return null
+  }
+
+  function spawnCore(): void {
+    // The body is claimed *before* the item is drawn. The other way round, a
+    // full field threw away a question the host had already served — and,
+    // because nothing reset the cooldown, it did so again on the next frame and
+    // every frame after that, draining the pool at sixty items a second.
+    const b = field.spawn()
+    if (!b) {
+      director.deferCore()
+      return
+    }
+    const built = drawWave()
+    if (!built) {
+      b.alive = false
+      director.deferCore()
+      return
+    }
+    wave = built
+    retune(built.candidates.map((c) => c.value))
+    const p = director.pressure()
+    b.kind = A_CORE
+    b.value = built.answer
+    b.text = built.prompt
+    b.beam = Math.floor(N_BEAMS / 2)
+    b.slide = b.beam
+    b.t = 0
+    // A CORE crosses a little faster than the stream and never steps sideways:
+    // it is the thing being read, not the thing being chased, and the reading
+    // time it owes the child is spent on the candidates rather than on the
+    // approach.
+    b.speed = 1 / (p.descentSeconds * 0.85)
+    b.stepIn = 1e9
+    b.spawnedAt = performance.now()
+    coreBody = b
+    waveAskedAt = performance.now()
+    asked++
+    director.noteCore()
+    audio.coreArrive()
+  }
+
+  function fracture(core: Automaton): void {
+    const w = wave
+    if (!w) return
+    core.fractured = true
+    const p = director.pressure()
+    const cp = project(geom, core.slide, core.t)
+    burst(cp.x, cp.y, colLapis, 40, 320, true)
+    feel.addTrauma(0.25)
+    feel.punch(0.02)
+    audio.fracture()
+
+    const cols = rng.shuffle([...Array(N_BEAMS).keys()])
+    w.candidates.forEach((c, i) => {
+      const b = field.spawn()
+      if (!b) return
+      b.kind = A_CANDIDATE
+      b.value = c.value
+      b.text = String(c.value)
+      b.correct = c.correct
+      b.beam = cols[i % cols.length] as number
+      b.slide = core.slide
+      b.t = core.t
+      // Slower than the stream, and it steps: a candidate has to be reachable
+      // from more than the beam it happened to land on. The fall from the
+      // fracture line to the floor is the answering window — about ten seconds
+      // early in a run, closing to six at full pressure, which brackets the
+      // house p50 of six and p90 of fourteen for two-digit regrouping.
+      b.speed = 1 / (p.descentSeconds * 1.6)
+      b.stepIn = 0.55 + i * 0.12
+      b.stepDir = i % 2 === 0 ? 1 : -1
+      b.spawnedAt = performance.now()
+    })
+    core.alive = false
+    coreBody = null
+  }
+
+  function clearCandidates(flashCorrect: boolean): void {
+    for (const b of field.bodies) {
+      if (!b.alive || b.kind !== A_CANDIDATE) continue
+      const p = project(geom, b.slide, b.t)
+      if (flashCorrect && b.correct) burst(p.x, p.y, colGold, 26, 240, true)
+      else burst(p.x, p.y, colBeam, 8, 120)
+      b.alive = false
+    }
+  }
+
+  function expireWave(): void {
+    const w = wave
+    if (!w) return
+    // Reported, and honestly: the child did not answer. `answered` is empty
+    // because nothing was handed in, and this is the one report in the game
+    // that is not the result of an action.
+    host.report({
+      questionId: w.questionId,
+      correct: false,
+      ms: Math.round(performance.now() - waveAskedAt),
+      answered: "",
+    })
+    showBanner(`${w.prompt} = ${w.answer}`, "", LAPIS_HOT, 1.6)
+    clearCandidates(true)
+    wave = null
+    coreBody = null
+  }
+
+  // ── firing ───────────────────────────────────────────────────────────────
+  function fire(): void {
+    if (over || fireCooldown > 0) return
+    for (const p of pulses) {
+      if (p.alive) continue
+      p.alive = true
+      p.col = runnerCol
+      p.t = 1
+      p.prevT = 1
+      p.hits = 0
+      fireCooldown = FIRE_COOLDOWN
+      feel.kick(0, -1, 2.4)
+      audio.fire()
+      host.haptic("light")
+      return
+    }
+  }
+
+  function stepPulses(dt: number): void {
+    for (const p of pulses) {
+      if (!p.alive) continue
+      p.prevT = p.t
+      p.t -= dt / PULSE_SECONDS
+      const beam = beams[p.col]
+      if (beam === undefined) {
+        p.alive = false
+        continue
+      }
+      field.sweep(p.col, p.prevT, Math.max(0, p.t), swept)
+      for (const body of swept) {
+        const strike = resolveStrike(beam, body.kind, body.value, body === swept[0])
+        if (strike === "submit") {
+          p.hits++
+          submit(body, beam)
+          p.alive = false
+          break
+        }
+        if (strike === "shatter") {
+          p.hits++
+          shatter(body, beam, p.hits)
+        } else if (strike === "dissonance") {
+          dissonance(body)
+        }
+      }
+      if (p.t <= 0) p.alive = false
+    }
+  }
+
+  function shatter(body: Automaton, beam: number, step: number): void {
+    const p = project(geom, body.slide, body.t)
+    const valid = validBeamCount(beams, body.value)
+    const gain = Math.round(killScore(beam, body.value, valid) * scoreMul())
+    score += gain
+    chain++
+    chainTimer = CHAIN_WINDOW
+    director.recordKill()
+    body.alive = false
+    burst(p.x, p.y, colBrass, 22, 260, true)
+    burst(p.x, p.y, colGold, 10, 180)
+    audio.shatter(chain)
+    feel.addTrauma(0.16)
+    feel.punch(0.015)
+    host.haptic("light")
+    if (valid <= 1) {
+      // The tight intercept: the only beam on the board that divides it. This
+      // is the read worth learning and it is the one the economy pays for.
+      pop(`SOLE ×2  +${gain}`, p.x, p.y - 18, 22, RESONANT_HOT)
+      feel.requestFlash(0.1, RESONANT_HOT)
+      host.haptic("medium")
+    } else {
+      pop(`+${gain}`, p.x, p.y - 14, 20, RESONANT)
+    }
+    if (step === 3) {
+      feel.slowmo(0.42, 420)
+      showBanner("HARMONIC", "three on one pulse", RESONANT, 1.0)
+      host.haptic("success")
+    }
+  }
+
+  function dissonance(body: Automaton): void {
+    body.ring = 0.5
+    // The cost of a wrong read is time, not damage: the automaton is shoved
+    // down the lattice. Nothing is deducted, nothing is scolded.
+    body.urgency = Math.min(2.4, body.urgency + 0.35)
+    const p = project(geom, body.slide, body.t)
+    burst(p.x, p.y, colWrong, 8, 130)
+    audio.dissonance()
+    feel.kick(0, 1, 3)
+    host.haptic("medium")
+  }
+
+  function submit(body: Automaton, beam: number): void {
+    const w = wave
+    if (!w) return
+    const p = project(geom, body.slide, body.t)
+    const ms = Math.round(performance.now() - waveAskedAt)
+    host.report({ questionId: w.questionId, correct: body.correct, ms, answered: String(body.value) })
+    body.alive = false
+
+    if (body.correct) {
+      right++
+      coresRead++
+      if (anchors < ANCHORS) credit = Math.min(READ_PER_ANCHOR, credit + 1)
+      resonance = Math.min(RESONANCE_MAX, resonance + 1)
+      resonanceLeft = RESONANCE_SECONDS
+      const gain = Math.round((260 + beam * 40) * scoreMul())
+      score += gain
+      audio.ascend()
+      feel.hitstop(reduced ? 0 : 90)
+      feel.slowmo(0.32, 560)
+      feel.addTrauma(0.45)
+      feel.punch(0.07)
+      feel.requestFlash(0.22, RESONANT_HOT)
+      host.haptic("success")
+      burst(p.x, p.y, colGoldHot, 60, 520, true)
+      pop(`+${gain}`, p.x, p.y - 26, 34, RESONANT_HOT)
+      showBanner(
+        `${w.prompt} = ${body.value}`,
+        `${beam} DIVIDES IT · RESONANCE ×${resonance}`,
+        RESONANT,
+        1.6,
+      )
+      clearCandidates(false)
+      wave = null
+      if (credit >= READ_PER_ANCHOR && anchors < ANCHORS) {
+        anchors++
+        credit -= READ_PER_ANCHOR
+        audio.riser()
+        showBanner("AN ANCHOR RELIT", "two cores read", RESONANT, 1.5)
+        host.haptic("success")
+      }
+      // A natural stopping point the child reached, never a failure. Rationed
+      // here as well as by the host so a long run does not spam it.
+      const now = performance.now()
+      if (coresRead % 5 === 0 && now - lastTransitionAt > 60_000) {
+        lastTransitionAt = now
+        host.transition?.("level", `${coresRead} cores`)
+      }
+    } else {
+      audio.settleWrong()
+      feel.kick(0, 1, 9)
+      feel.addTrauma(0.28)
+      feel.requestFlash(0.12, DISSONANT)
+      host.haptic("failure")
+      // The whole economy, gone. That is the cost of a guess — never an anchor,
+      // never a lecture, and the true statement is shown once, plainly.
+      resonance = 1
+      resonanceLeft = 0
+      burst(p.x, p.y, colWrong, 26, 300)
+      showBanner(`${w.prompt} = ${w.answer}`, "", LAPIS_HOT, 1.7)
+      clearCandidates(true)
+      wave = null
+    }
+  }
+
+  function breach(body: Automaton): void {
+    const x = columnX(geom, body.slide)
+    burst(x, geom.floorY, colWrong, 34, 340, true)
+    audio.breach()
+    feel.addTrauma(reduced ? 0 : 0.7)
+    feel.kick(0, 1, 16)
+    feel.requestFlash(0.2, DISSONANT)
+    host.haptic("failure")
+    chain = 0
+    chainTimer = 0
+    anchors--
+    if (anchors <= 0) {
+      anchors = 0
+      endRun()
+    }
+  }
+
+  function endRun(): void {
+    over = true
+    overAt = performance.now()
+    if (score > best) {
+      best = score
+      writeBest(best)
+    }
+    audio.collapse()
+    feel.addTrauma(0.6)
+    feel.slowmo(0.25, 900)
+    showBanner("THE LATTICE GOES DARK", "tap to tune it again", RESONANT, 3)
+  }
+
+  function restart(): void {
+    over = false
+    score = 0
+    anchors = ANCHORS
+    credit = 0
+    chain = 0
+    chainTimer = 0
+    resonance = 1
+    resonanceLeft = 0
+    fireOnArrive = false
+    fireCooldown = 0
+    asked = 0
+    right = 0
+    coresRead = 0
+    wave = null
+    coreBody = null
+    banner = null
+    field.clear()
+    parts.clear()
+    feel.reset()
+    director.reset()
+    for (const p of pulses) p.alive = false
+    for (const p of pops) p.alive = false
+    rng = new Rng(0xbea3 ^ (Date.now() & 0xffffff))
+    fx = new Rng(0x0fec7 ^ (Date.now() & 0xffffff))
+    beams = tuneLattice([], N_BEAMS, () => rng.next())
+    runnerCol = Math.floor(N_BEAMS / 2)
+    runnerSlide = runnerCol
+  }
+
+  // ── input ────────────────────────────────────────────────────────────────
+  let pointerDown = false
+  let downX = 0
+  let downY = 0
+  let dragged = false
+
+  function localX(e: PointerEvent): number {
+    return e.clientX - canvas.getBoundingClientRect().left
+  }
+
+  function rideTo(col: number, alsoFire: boolean): void {
+    const c = Math.max(0, Math.min(N_BEAMS - 1, col))
+    if (c !== runnerCol) {
+      runnerCol = c
+      audio.ride()
+    }
+    if (alsoFire) fireOnArrive = true
+  }
+
+  function onDown(e: PointerEvent): void {
+    void audio.start()
+    if (over) {
+      if (performance.now() - overAt > 550) restart()
+      return
+    }
+    pointerDown = true
+    dragged = false
+    downX = e.clientX
+    downY = e.clientY
+    const col = columnAt(geom, localX(e))
+    if (col === runnerCol) fire()
+    else rideTo(col, true)
+    canvas.setPointerCapture(e.pointerId)
+  }
+
+  function onMove(e: PointerEvent): void {
+    if (!pointerDown) return
+    if (!dragged && Math.hypot(e.clientX - downX, e.clientY - downY) > 14) dragged = true
+    if (!dragged) return
+    // A drag is the *listening* verb: it rides the lattice without firing, so a
+    // child can sweep the beams and hear which one locks.
+    fireOnArrive = false
+    rideTo(columnAt(geom, localX(e)), false)
+  }
+
+  function onUp(e: PointerEvent): void {
+    pointerDown = false
+    if (canvas.hasPointerCapture(e.pointerId)) canvas.releasePointerCapture(e.pointerId)
+  }
+
+  function onKey(e: KeyboardEvent): void {
+    if (e.key === "ArrowLeft") rideTo(runnerCol - 1, false)
+    else if (e.key === "ArrowRight") rideTo(runnerCol + 1, false)
+    else if (e.key === " " || e.key === "Enter") {
+      void audio.start()
+      if (over) restart()
+      else fire()
+    } else return
+    e.preventDefault()
+  }
+
+  canvas.addEventListener("pointerdown", onDown)
+  canvas.addEventListener("pointermove", onMove)
+  canvas.addEventListener("pointerup", onUp)
+  canvas.addEventListener("pointercancel", onUp)
+  globalThis.addEventListener("keydown", onKey)
+
+  // ── frame ────────────────────────────────────────────────────────────────
+  let last = performance.now()
+  let raf = 0
+
+  function step(dt: number): void {
+    const p = director.pressure()
+    director.advance(dt)
+    fireCooldown = Math.max(0, fireCooldown - dt)
+    if (chainTimer > 0) {
+      chainTimer -= dt
+      if (chainTimer <= 0) chain = 0
+    }
+    if (resonanceLeft > 0) {
+      resonanceLeft -= dt
+      if (resonanceLeft <= 0) resonance = 1
+    }
+    if (!reduced) traceScroll += dt * 0.42
+
+    // The runner slides; a tap on another beam fires the moment it arrives, so
+    // the ride and the shot are one gesture rather than two.
+    runnerSlide += (runnerCol - runnerSlide) * Math.min(1, dt * 16)
+    if (Math.abs(runnerSlide - runnerCol) < 0.05) {
+      runnerSlide = runnerCol
+      if (fireOnArrive) {
+        fireOnArrive = false
+        fire()
+      }
+    }
+
+    if (!over) {
+      if (director.wantsCore(wave !== null)) spawnCore()
+      if (field.liveCount(A_ORDINARY) < 9 && director.wantsSpawn(field.liveCount(A_ORDINARY))) {
+        spawnOrdinary()
+      }
+    }
+
+    field.update(dt, N_BEAMS, p.stepSeconds, landed)
+    for (const body of landed) {
+      if (over) {
+        body.alive = false
+        continue
+      }
+      if (body.kind === A_CANDIDATE) {
+        body.alive = false
+        // One candidate on the floor ends the reading — the rest are its
+        // siblings and there is nothing left to choose between.
+        if (wave) expireWave()
+      } else if (body.kind === A_CORE) {
+        body.alive = false
+        coreBody = null
+        if (wave) expireWave()
+      } else {
+        body.alive = false
+        breach(body)
+      }
+    }
+
+    if (coreBody && coreBody.alive && !coreBody.fractured && coreBody.t >= 0.26) {
+      fracture(coreBody)
+    }
+
+    stepPulses(dt)
+    parts.update(dt)
+
+    for (const q of pops) {
+      if (!q.alive) continue
+      q.life -= dt
+      q.y -= dt * 46
+      if (q.life <= 0) q.alive = false
+    }
+    if (banner) {
+      banner.life -= dt
+      if (banner.life <= 0) banner = null
+    }
+  }
+
+  /** The resonance lock: what the beam under the runner is singing against. */
+  function lock(): { target: Automaton | null; phase: number } {
+    const col = Math.round(runnerSlide)
+    const beam = beams[col]
+    const target = field.target(col)
+    if (beam === undefined || !target || target.kind === A_CORE) {
+      return { target: null, phase: 0.5 }
+    }
+    return { target, phase: phaseOffset(beam, target.value) }
+  }
+
+  function draw(nowMs: number): void {
+    const q = gov.quality
+    g.setTransform(dpr, 0, 0, dpr, 0, 0)
+    drawHall(g, geom)
+
+    const { target, phase } = lock()
+    const locked = target !== null && phase === 0
+    const beamCol = Math.round(runnerSlide)
+
+    g.save()
+    // Screenshake, punch zoom and the slow-motion camera, all at once.
+    g.translate(geom.w / 2 + feel.shakeX, geom.h / 2 + feel.shakeY)
+    g.scale(feel.scale, feel.scale)
+    g.translate(-geom.w / 2, -geom.h / 2)
+
+    const styles: BeamStyle[] = []
+    for (let i = 0; i < N_BEAMS; i++) {
+      styles.push({ lit: i === beamCol ? (locked ? 1 : 0.72) : 0.12, label: beams[i] ?? 0 })
+    }
+    drawBeams(g, geom, styles)
+
+    if (target) {
+      drawTraces(g, geom, beamCol, phase, reduced ? 0 : traceScroll, q.traceSamples, locked)
+    }
+
+    // Far to near, so a nearer automaton overlaps a further one.
+    const ridden = beams[beamCol]
+    order.length = 0
+    for (const b of field.bodies) if (b.alive) order.push(b)
+    order.sort((a, b) => a.t - b.t)
+    for (const b of order) {
+      const pr = project(geom, b.slide, b.t)
+      // The lock ring: worn only by an automaton the beam under the runner
+      // actually divides, right now. Never by "the correct candidate" — a
+      // candidate carrying the answer is drawn exactly like one that is not.
+      const hot =
+        b.kind !== A_CORE &&
+        Math.round(b.slide) === beamCol &&
+        ridden !== undefined &&
+        resonates(ridden, b.value)
+          ? 1
+          : 0
+      drawAutomaton(g, {
+        x: pr.x,
+        y: pr.y,
+        r: Math.max(7, (b.kind === A_CORE ? 46 : 26) * pr.scale),
+        text: b.text,
+        kind: b.kind,
+        ring: b.ring,
+        hot,
+        glow: q.glow,
+      })
+    }
+
+    for (const p of pulses) if (p.alive) drawPulse(g, geom, p.col, Math.max(0, p.t))
+    parts.draw(g)
+    drawRunner(g, geom, runnerSlide, fireCooldown > 0 ? 1 : locked ? 0.7 : 0.2, q.glow)
+    g.restore()
+
+    // Chrome sits outside the shake so the numbers never blur.
+    drawScore(g, geom, score, resonance)
+    drawAnchors(g, geom, anchors, ANCHORS, credit, READ_PER_ANCHOR)
+
+    for (const p of pops) {
+      if (!p.alive) continue
+      const t = p.life / p.max
+      g.globalAlpha = Math.min(1, t * 2)
+      g.font = font(UI_FONT, p.size)
+      g.textAlign = "center"
+      g.textBaseline = "middle"
+      g.fillStyle = p.color
+      g.fillText(p.text, p.x, p.y)
+      g.globalAlpha = 1
+    }
+
+    if (banner) {
+      const t = banner.life / banner.max
+      g.globalAlpha = Math.min(1, t * 3)
+      const y = geom.h * 0.3
+      const size = Math.max(19, Math.min(geom.w * 0.075, 40))
+      g.font = font(UI_FONT, size)
+      g.textAlign = "center"
+      g.textBaseline = "middle"
+      g.fillStyle = withAlpha("#04060d", 0.72)
+      g.fillRect(0, y - size * 1.1, geom.w, size * 2.5)
+      g.fillStyle = banner.color
+      g.fillText(banner.text, geom.w / 2, y)
+      if (banner.sub) {
+        g.font = font(UI_FONT, Math.max(11, size * 0.42))
+        g.fillStyle = withAlpha(PAPER, 0.7)
+        g.fillText(banner.sub, geom.w / 2, y + size * 0.95)
+      }
+      g.globalAlpha = 1
+    }
+
+    if (over) {
+      g.fillStyle = withAlpha("#04060d", 0.62)
+      g.fillRect(0, 0, geom.w, geom.h)
+      g.font = font(UI_FONT, Math.max(15, Math.min(geom.w * 0.05, 24)))
+      g.textAlign = "center"
+      g.fillStyle = withAlpha(PAPER, 0.85)
+      g.fillText(`${score}`, geom.w / 2, geom.h * 0.52)
+      g.font = font(UI_FONT, 13)
+      g.fillStyle = withAlpha(PAPER, 0.5)
+      g.fillText(
+        `best ${best} · ${right}/${asked} cores read`,
+        geom.w / 2,
+        geom.h * 0.52 + 26,
+      )
+    }
+
+    audio.setLock(140 + (beams[beamCol] ?? 2) * 26, target ? phase : 0.5, target !== null)
+    void nowMs
+  }
+
+  function frame(nowMs: number): void {
+    if (!running) return
+    raf = requestAnimationFrame(frame)
+    const rawDt = Math.min(64, nowMs - last)
+    last = nowMs
+    // A tier change moves the render scale and the particle ceiling, and both
+    // of those live in `resize` — without this the governor drops the tier and
+    // nothing gets cheaper.
+    if (gov.sample(rawDt)) resize()
+    const simMs = feel.advance(rawDt, nowMs)
+    if (simMs > 0) step(Math.min(0.05, simMs / 1000))
+    draw(nowMs)
+  }
+  raf = requestAnimationFrame(frame)
+
+  return {
+    unmount(): void {
+      running = false
+      cancelAnimationFrame(raf)
+      ro.disconnect()
+      canvas.removeEventListener("pointerdown", onDown)
+      canvas.removeEventListener("pointermove", onMove)
+      canvas.removeEventListener("pointerup", onUp)
+      canvas.removeEventListener("pointercancel", onUp)
+      globalThis.removeEventListener("keydown", onKey)
+      audio.dispose()
+      root.remove()
+    },
+  }
+}

--- a/dynawalla/games/beam/src/pack.ts
+++ b/dynawalla/games/beam/src/pack.ts
@@ -1,0 +1,46 @@
+// LATTICE RUNNER, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous surface `Host` in
+// `contract.ts` already describes — so the lattice, the field, the pulse and
+// the resonance lock are untouched.
+//
+// What crosses the boundary is the CORE. A core carries a problem the
+// curriculum drew and fractures into the candidate values the host revealed;
+// the child hands one in by destroying it from a beam that divides it. The game
+// never decides whether a submission was right — it labels which candidate
+// carries the canonical value the host returned, reports the value that was
+// struck, and the host's record is the one that counts.
+//
+// The stream of ordinary automata is the game's own mathematics: divisibility
+// over numbers the game itself made up. Nobody asked those questions, so
+// nothing about them is reported.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import { mount } from "./contract.ts"
+import type { Host } from "./contract.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("beam: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "add-sub" })
+  // Stocked before the first frame: a core comes down inside the first ten
+  // seconds, and a core with a blank face is the kind of thing that happens
+  // exactly once, on launch, in front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context are torn down before the frame is, rather than a frame or two
+  // after it.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[beam] could not start", error)
+  renderNoHost(root, "LATTICE RUNNER")
+})

--- a/dynawalla/games/beam/src/render/geom.ts
+++ b/dynawalla/games/beam/src/render/geom.ts
@@ -1,0 +1,72 @@
+// The hall's perspective. Pure arithmetic, no canvas — which is what lets the
+// projection be tested rather than eyeballed.
+//
+// The lattice is a fan of beams running from a vanishing point on the horizon
+// down to evenly spaced feet along the floor. An automaton's position is
+// `(column, t)` with `t` at 0 on the horizon and 1 on the floor, and the map
+// from `t` to the screen is a real perspective divide rather than a lerp: a
+// thing far up the lattice barely moves, then rushes the last third. That
+// acceleration is the whole reason the descent has tension.
+
+export type Geom = {
+  w: number
+  h: number
+  columns: number
+  vpX: number
+  horizonY: number
+  floorY: number
+  margin: number
+}
+
+/** How deep the hall is. Bigger = more foreshortening near the horizon. */
+const DEPTH = 6
+
+export function makeGeom(w: number, h: number, columns: number): Geom {
+  return {
+    w,
+    h,
+    columns: Math.max(1, columns),
+    vpX: w * 0.5,
+    horizonY: h * 0.155,
+    floorY: h * 0.845,
+    // Wide enough that the outermost beam's label is never clipped.
+    margin: Math.max(26, Math.min(w * 0.11, 74)),
+  }
+}
+
+/** Where a beam meets the floor. `col` may be fractional — a mid-slide body. */
+export function columnX(g: Geom, col: number): number {
+  if (g.columns <= 1) return g.vpX
+  const span = g.w - g.margin * 2
+  return g.margin + (col / (g.columns - 1)) * span
+}
+
+/**
+ * Screen position and size factor for `(col, t)`.
+ *
+ * `scale` is 1 at the floor and about 1/7 at the horizon, and it is the same
+ * number the hull, its glyph and its shadow are all sized by — so an automaton
+ * never changes proportion as it comes down, only size.
+ */
+export function project(g: Geom, col: number, t: number): { x: number; y: number; scale: number } {
+  const clamped = Math.max(0, Math.min(1, t))
+  const s = 1 / (1 + (1 - clamped) * DEPTH)
+  const s0 = 1 / (1 + DEPTH)
+  const p = (s - s0) / (1 - s0)
+  return {
+    x: g.vpX + (columnX(g, col) - g.vpX) * p,
+    y: g.horizonY + (g.floorY - g.horizonY) * p,
+    scale: s,
+  }
+}
+
+/**
+ * The column nearest a screen x at floor level — how a tap on the lower band
+ * chooses a beam.
+ */
+export function columnAt(g: Geom, x: number): number {
+  if (g.columns <= 1) return 0
+  const span = g.w - g.margin * 2
+  const raw = ((x - g.margin) / span) * (g.columns - 1)
+  return Math.max(0, Math.min(g.columns - 1, Math.round(raw)))
+}

--- a/dynawalla/games/beam/src/render/hall.ts
+++ b/dynawalla/games/beam/src/render/hall.ts
@@ -1,0 +1,383 @@
+// Drawing the resonance hall.
+//
+// Everything in here is a function of state passed in; nothing owns any. The
+// two pieces that matter are `drawTraces`, which is the phasing made visible,
+// and `drawAutomaton`, which keeps the three classes apart by silhouette so the
+// board still parses with the colour taken out.
+
+import { columnX, project, type Geom } from "./geom.ts"
+import {
+  BEAM,
+  BEAM_HOT,
+  BEAM_LIT,
+  BRASS,
+  BRASS_DARK,
+  BRASS_HOT,
+  DISSONANT,
+  font,
+  HALL_LOW,
+  HALL_TOP,
+  INK,
+  LAPIS,
+  LAPIS_EDGE,
+  LAPIS_HOT,
+  NUM_FONT,
+  PAPER,
+  RESONANT,
+  RESONANT_HOT,
+  STONE,
+  STONE_EDGE,
+  UI_FONT,
+  withAlpha,
+} from "./palette.ts"
+
+/**
+ * A soft additive bloom.
+ *
+ * A radial gradient and not a flat ellipse: painted at a constant alpha, a
+ * translucent disc over near-black stone has a hard rim and reads as an
+ * *object* — the hall fills up with grey saucers. Light has no edge.
+ */
+function glow(
+  g: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  rx: number,
+  ry: number,
+  color: string,
+  alpha: number,
+): void {
+  const r = Math.max(1, Math.max(rx, ry))
+  const grad = g.createRadialGradient(x, y, 0, x, y, r)
+  grad.addColorStop(0, withAlpha(color, alpha))
+  grad.addColorStop(0.45, withAlpha(color, alpha * 0.4))
+  grad.addColorStop(1, withAlpha(color, 0))
+  g.save()
+  g.globalCompositeOperation = "lighter"
+  g.fillStyle = grad
+  g.beginPath()
+  g.ellipse(x, y, rx, ry, 0, 0, Math.PI * 2)
+  g.fill()
+  g.restore()
+}
+
+export function drawHall(g: CanvasRenderingContext2D, geom: Geom): void {
+  const grad = g.createLinearGradient(0, 0, 0, geom.h)
+  grad.addColorStop(0, HALL_TOP)
+  grad.addColorStop(0.6, HALL_TOP)
+  grad.addColorStop(1, HALL_LOW)
+  g.fillStyle = grad
+  g.fillRect(0, 0, geom.w, geom.h)
+
+  // The far wall: a carved band at the horizon, so the beams come *out of*
+  // something rather than fading into a void.
+  g.fillStyle = STONE
+  g.fillRect(0, 0, geom.w, geom.horizonY)
+  g.fillStyle = withAlpha(STONE_EDGE, 0.9)
+  g.fillRect(0, geom.horizonY - 3, geom.w, 3)
+
+  // Girih as structure, not wallpaper: the wall is scored by the same fan the
+  // lattice uses, so the room and the mechanism are visibly the same object.
+  g.strokeStyle = withAlpha(STONE_EDGE, 0.5)
+  g.lineWidth = 1
+  const rows = 4
+  for (let r = 1; r <= rows; r++) {
+    const y = (geom.horizonY * r) / (rows + 1)
+    g.beginPath()
+    g.moveTo(0, y)
+    g.lineTo(geom.w, y)
+    g.stroke()
+  }
+
+  // The floor plate the runner rides.
+  g.fillStyle = STONE
+  g.fillRect(0, geom.floorY + 2, geom.w, geom.h - geom.floorY)
+  g.fillStyle = withAlpha(STONE_EDGE, 0.75)
+  g.fillRect(0, geom.floorY + 2, geom.w, 2)
+}
+
+export type BeamStyle = {
+  /** 0..1 — how lit this beam is. The ridden beam sits near 1. */
+  lit: number
+  label: number
+}
+
+export function drawBeams(g: CanvasRenderingContext2D, geom: Geom, styles: BeamStyle[]): void {
+  for (let i = 0; i < styles.length; i++) {
+    const s = styles[i] as BeamStyle
+    const foot = columnX(geom, i)
+    const lit = Math.max(0, Math.min(1, s.lit))
+    // Two strokes: a wide dim halo and a hairline core. The halo is what makes
+    // the beam read as light rather than as a drawn line.
+    g.globalAlpha = 0.16 + lit * 0.34
+    g.strokeStyle = lit > 0.5 ? BEAM_LIT : BEAM
+    g.lineWidth = 5 + lit * 7
+    g.beginPath()
+    g.moveTo(geom.vpX, geom.horizonY)
+    g.lineTo(foot, geom.floorY)
+    g.stroke()
+
+    g.globalAlpha = 0.45 + lit * 0.55
+    g.strokeStyle = lit > 0.5 ? BEAM_HOT : BEAM_LIT
+    g.lineWidth = 1 + lit * 1.4
+    g.beginPath()
+    g.moveTo(geom.vpX, geom.horizonY)
+    g.lineTo(foot, geom.floorY)
+    g.stroke()
+    g.globalAlpha = 1
+
+    // The label, carved into the floor plate at the beam's foot. This is the
+    // divisor the child is choosing, so it is the largest chrome on screen.
+    const size = Math.max(15, Math.min(geom.w * 0.055, 30))
+    g.font = font(NUM_FONT, size)
+    g.textAlign = "center"
+    g.textBaseline = "middle"
+    const ly = geom.floorY + (geom.h - geom.floorY) * 0.5
+    g.fillStyle = withAlpha(INK, 0.85)
+    g.fillText(String(s.label), foot, ly + 1.5)
+    g.fillStyle = lit > 0.5 ? BEAM_HOT : withAlpha(PAPER, 0.62)
+    g.fillText(String(s.label), foot, ly)
+  }
+}
+
+/**
+ * THE PHASING. Two waveforms drawn along the ridden beam, separated by the
+ * phase offset of the automaton overhead.
+ *
+ * At offset zero the two curves are the same curve and the eye sees one bright
+ * line; at any other offset they cross each other repeatedly and the beam looks
+ * braided. This is the picture the sound is making, and it carries the same
+ * information — so the game is playable with the volume off.
+ *
+ * Under reduced motion the curves do not travel: `scroll` is passed as a
+ * constant and what is drawn is a still figure of the same two waves. That is a
+ * branch, not a degradation — the phase relationship, which is the whole point,
+ * is fully legible standing still.
+ */
+export function drawTraces(
+  g: CanvasRenderingContext2D,
+  geom: Geom,
+  col: number,
+  phase: number,
+  scroll: number,
+  samples: number,
+  locked: boolean,
+): void {
+  const foot = columnX(geom, col)
+  const dx = foot - geom.vpX
+  const dy = geom.floorY - geom.horizonY
+  const len = Math.hypot(dx, dy) || 1
+  // Perpendicular to the beam, so the wave rides on it rather than across it.
+  const nx = -dy / len
+  const ny = dx / len
+  const CYCLES = 5
+
+  for (const [offset, color, width, alpha] of [
+    [0, BEAM_HOT, 2.2, 0.95],
+    [phase, locked ? BEAM_HOT : RESONANT, 2.2, locked ? 0.95 : 0.8],
+  ] as const) {
+    g.strokeStyle = color
+    g.lineWidth = width
+    g.globalAlpha = alpha
+    g.beginPath()
+    for (let i = 0; i <= samples; i++) {
+      // All the way to 1: the wave has to arrive at the runner's feet. Stopping
+      // at 0.98 left an eighty-pixel dead gap above the shuttle, because the
+      // perspective divide crowds the last stretch of the beam.
+      const t = 0.02 + (i / samples) * 0.98
+      const p = project(geom, col, t)
+      const amp = 5 + 16 * p.scale
+      const wave = Math.sin((t * CYCLES + scroll + offset) * Math.PI * 2)
+      const x = p.x + nx * wave * amp
+      const y = p.y + ny * wave * amp
+      if (i === 0) g.moveTo(x, y)
+      else g.lineTo(x, y)
+    }
+    g.stroke()
+  }
+  g.globalAlpha = 1
+}
+
+export type HullSpec = {
+  x: number
+  y: number
+  /** Half-width of the hull in screen pixels. */
+  r: number
+  text: string
+  kind: number
+  ring: number
+  /** 0..1 — resonance with the beam the runner is on right now. */
+  hot: number
+  glow: boolean
+}
+
+const A_CORE = 1
+const A_CANDIDATE = 2
+
+// Note what is *not* in `HullSpec`: whether a candidate is the canonical one.
+// The renderer is never told, so it cannot leak it. A candidate carrying the
+// answer is drawn exactly like one that is not.
+
+export function drawAutomaton(g: CanvasRenderingContext2D, s: HullSpec): void {
+  const ringing = s.ring > 0
+  const edge = s.kind === A_CORE ? LAPIS_EDGE : ringing ? DISSONANT : s.hot > 0 ? RESONANT : BRASS
+  const fill = s.kind === A_CORE ? LAPIS : BRASS_DARK
+  const w = s.kind === A_CORE ? s.r * 2.35 : s.r
+  const h = s.kind === A_CORE ? s.r * 0.82 : s.r
+
+  if (s.glow) {
+    glow(g, s.x, s.y, w * 2.1, h * 2.1, s.hot > 0 ? RESONANT : edge, 0.16 + s.hot * 0.3)
+  }
+
+  g.beginPath()
+  if (s.kind === A_CORE) {
+    // A slab. Wide, flat, unmistakably not one of the numbers.
+    g.moveTo(s.x - w, s.y)
+    g.lineTo(s.x - w * 0.86, s.y - h)
+    g.lineTo(s.x + w * 0.86, s.y - h)
+    g.lineTo(s.x + w, s.y)
+    g.lineTo(s.x + w * 0.86, s.y + h)
+    g.lineTo(s.x - w * 0.86, s.y + h)
+  } else if (s.kind === A_CANDIDATE) {
+    // A hexagon — a thing that was struck off something larger.
+    for (let i = 0; i < 6; i++) {
+      const a = (i / 6) * Math.PI * 2 + Math.PI / 6
+      const px = s.x + Math.cos(a) * w
+      const py = s.y + Math.sin(a) * h
+      if (i === 0) g.moveTo(px, py)
+      else g.lineTo(px, py)
+    }
+  } else {
+    // A rhombus, point down: it reads as descending even in a still frame.
+    g.moveTo(s.x, s.y - h * 1.12)
+    g.lineTo(s.x + w, s.y)
+    g.lineTo(s.x, s.y + h * 1.12)
+    g.lineTo(s.x - w, s.y)
+  }
+  g.closePath()
+  g.fillStyle = fill
+  g.fill()
+  g.lineWidth = Math.max(1.2, s.r * 0.11)
+  g.strokeStyle = edge
+  g.stroke()
+
+  if (s.hot > 0 && s.kind !== A_CORE) {
+    // The lock ring: the automaton the runner's beam currently divides wears a
+    // hairline of the resonance colour. Confirmation, after the judgement.
+    g.globalAlpha = 0.55 + s.hot * 0.45
+    g.lineWidth = Math.max(1, s.r * 0.07)
+    g.strokeStyle = RESONANT_HOT
+    g.beginPath()
+    g.ellipse(s.x, s.y, w * 1.32, h * 1.32, 0, 0, Math.PI * 2)
+    g.stroke()
+    g.globalAlpha = 1
+  }
+
+  const size = Math.max(9, s.kind === A_CORE ? s.r * 0.78 : s.r * 1.05)
+  g.font = font(NUM_FONT, size)
+  g.textAlign = "center"
+  g.textBaseline = "middle"
+  g.fillStyle = withAlpha(INK, 0.8)
+  g.fillText(s.text, s.x, s.y + 1.2)
+  g.fillStyle = s.kind === A_CORE ? LAPIS_HOT : ringing ? PAPER : BRASS_HOT
+  g.fillText(s.text, s.x, s.y)
+}
+
+/** The runner: a brass shuttle seated on the floor plate. */
+export function drawRunner(
+  g: CanvasRenderingContext2D,
+  geom: Geom,
+  col: number,
+  charge: number,
+  lit: boolean,
+): void {
+  const x = columnX(geom, col)
+  const y = geom.floorY
+  const r = Math.max(15, Math.min(geom.w * 0.045, 30))
+  if (lit) glow(g, x, y, r * 2.4, r * 1.5, BEAM_LIT, 0.2 + charge * 0.34)
+  g.beginPath()
+  g.moveTo(x, y - r * 1.15)
+  g.lineTo(x + r * 0.92, y + r * 0.55)
+  g.lineTo(x, y + r * 0.18)
+  g.lineTo(x - r * 0.92, y + r * 0.55)
+  g.closePath()
+  g.fillStyle = BRASS
+  g.fill()
+  g.lineWidth = 2
+  g.strokeStyle = charge > 0.5 ? BEAM_HOT : BRASS_HOT
+  g.stroke()
+}
+
+/** The pulse: a rung of light climbing the beam. */
+export function drawPulse(
+  g: CanvasRenderingContext2D,
+  geom: Geom,
+  col: number,
+  t: number,
+): void {
+  const p = project(geom, col, t)
+  const w = (18 + 34 * p.scale) * 0.5
+  g.save()
+  g.globalCompositeOperation = "lighter"
+  for (const [ww, a, hh] of [
+    [w * 1.9, 0.22, 9],
+    [w, 0.8, 4],
+    [w * 0.5, 1, 2],
+  ] as const) {
+    g.globalAlpha = a
+    g.fillStyle = a === 1 ? BEAM_HOT : BEAM_LIT
+    g.fillRect(p.x - ww, p.y - hh * p.scale * 0.9, ww * 2, hh * p.scale * 1.8 + 1.5)
+  }
+  g.restore()
+  g.globalAlpha = 1
+}
+
+/** The anchors: three lamps set into the floor plate. */
+export function drawAnchors(
+  g: CanvasRenderingContext2D,
+  geom: Geom,
+  lit: number,
+  total: number,
+  credit: number,
+  perAnchor: number,
+): void {
+  const r = 6
+  const gap = 18
+  const x0 = geom.w - 14 - (total - 1) * gap
+  const y = 18
+  for (let i = 0; i < total; i++) {
+    const on = i < lit
+    g.beginPath()
+    g.arc(x0 + i * gap, y, r, 0, Math.PI * 2)
+    g.fillStyle = on ? RESONANT : withAlpha(PAPER, 0.13)
+    g.fill()
+    if (on) glow(g, x0 + i * gap, y, r * 2.4, r * 2.4, RESONANT, 0.4)
+  }
+  // Progress toward relighting one, drawn as an arc filling on the next lamp.
+  if (lit < total && credit > 0) {
+    const cx = x0 + lit * gap
+    g.beginPath()
+    g.arc(cx, y, r + 3, -Math.PI / 2, -Math.PI / 2 + (credit / perAnchor) * Math.PI * 2)
+    g.strokeStyle = RESONANT_HOT
+    g.lineWidth = 2
+    g.stroke()
+  }
+}
+
+export function drawScore(
+  g: CanvasRenderingContext2D,
+  geom: Geom,
+  score: number,
+  resonance: number,
+): void {
+  g.font = font(UI_FONT, Math.max(17, Math.min(geom.w * 0.055, 27)))
+  g.textAlign = "left"
+  g.textBaseline = "middle"
+  g.fillStyle = withAlpha(PAPER, 0.9)
+  g.fillText(String(score), 14, 20)
+  if (resonance > 1) {
+    g.font = font(UI_FONT, 14)
+    g.fillStyle = RESONANT
+    g.fillText(`RESONANCE ×${resonance}`, 14, 42)
+  }
+}

--- a/dynawalla/games/beam/src/render/palette.ts
+++ b/dynawalla/games/beam/src/render/palette.ts
@@ -1,0 +1,65 @@
+// LATTICE RUNNER — a resonance hall, cut into stone, lit only by the lattice.
+//
+// The register is the house one: brass, lapis, carved stone, cold celestial
+// light. Not neon, not gradient soup. The beams are the only light source in
+// the room, so everything else is either lit by them or is a silhouette.
+//
+// Two rules this palette exists to enforce:
+//   * **A numeral is never coloured information.** Every number on a hull is
+//     the same near-white, one weight, geometric sans. Colour says what class
+//     a thing is; the glyph says what it is worth.
+//   * **Every class differs in silhouette first, colour second** — a CORE is a
+//     wide slab, a candidate is a hexagon, an ordinary automaton is a rhombus.
+//     Read with the colour removed, the board still parses.
+
+/** The hall. Stone, unlit, cold. */
+export const HALL_TOP = "#04060d"
+export const HALL_LOW = "#0a1018"
+export const STONE = "#141b26"
+export const STONE_EDGE = "#222d3d"
+
+/** The lattice itself: cold celestial light, dim until ridden. */
+export const BEAM = "#2b6a86"
+export const BEAM_LIT = "#7fe8ff"
+export const BEAM_HOT = "#e8fdff"
+
+/** Brass — every automaton hull. */
+export const BRASS = "#c9902f"
+export const BRASS_DARK = "#5d431a"
+export const BRASS_HOT = "#ffdf9e"
+
+/** Lapis — the CORE, and only the CORE. */
+export const LAPIS = "#3b57d6"
+export const LAPIS_EDGE = "#8ea6ff"
+export const LAPIS_HOT = "#dfe7ff"
+
+/** The resonance payoff. One colour, used nowhere else, so it *means*. */
+export const RESONANT = "#ffd24a"
+export const RESONANT_HOT = "#fff6d6"
+
+/** Dissonance — copper oxide. Never used as decoration, only on a failed lock. */
+export const DISSONANT = "#c1533a"
+
+/** Damage. The anchors, and the floor when something lands on it. */
+export const ANCHOR = "#ffb03a"
+export const BREACH = "#ff3b47"
+
+export const INK = "#05070d"
+export const PAPER = "#f4f8ff"
+
+export function withAlpha(hex: string, a: number): string {
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+  return `rgba(${r},${g},${b},${a})`
+}
+
+/** The stack every numeral is drawn in. Geometric, heavy, unambiguous. */
+export const NUM_FONT =
+  '800 %spx "Avenir Next", "Segoe UI", "Roboto", "Helvetica Neue", Arial, sans-serif'
+export const UI_FONT =
+  '700 %spx "Avenir Next", "Segoe UI", "Roboto", "Helvetica Neue", Arial, sans-serif'
+
+export function font(spec: string, px: number): string {
+  return spec.replace("%s", String(Math.round(px)))
+}

--- a/dynawalla/games/beam/src/render/particles.ts
+++ b/dynawalla/games/beam/src/render/particles.ts
@@ -1,0 +1,144 @@
+// Struct-of-arrays particle field. Allocated once at the ULTRA ceiling and
+// never grown; the tier caps how many are allowed *alive*, so a tier change
+// costs nothing and allocates nothing.
+//
+// Zero per-frame allocation is not a slogan here — there is no object literal,
+// no closure and no array push anywhere in `update` or `draw`. Everything is
+// drawn with `fillRect` under a single transform per shard, which is what keeps
+// three thousand of them inside the frame budget on the tablet that sets the
+// floor.
+
+export const KIND_MOTE = 0
+/** A stretched streak, drawn along its velocity — shattered brass. */
+export const KIND_SHARD = 1
+
+const CAP = 3400
+
+export class Particles {
+  private x = new Float32Array(CAP)
+  private y = new Float32Array(CAP)
+  private vx = new Float32Array(CAP)
+  private vy = new Float32Array(CAP)
+  private life = new Float32Array(CAP)
+  private inv = new Float32Array(CAP)
+  private size = new Float32Array(CAP)
+  private drag = new Float32Array(CAP)
+  private kind = new Uint8Array(CAP)
+  private col = new Uint8Array(CAP)
+
+  private colors: string[] = []
+  private colorIndex = new Map<string, number>()
+  private count = 0
+  limit = 1400
+
+  colorId(hex: string): number {
+    const hit = this.colorIndex.get(hex)
+    if (hit !== undefined) return hit
+    const id = this.colors.length
+    this.colors.push(hex)
+    this.colorIndex.set(hex, id)
+    return id
+  }
+
+  get alive(): number {
+    return this.count
+  }
+
+  clear(): void {
+    this.count = 0
+  }
+
+  spawn(
+    kind: number,
+    x: number,
+    y: number,
+    vx: number,
+    vy: number,
+    lifeS: number,
+    size: number,
+    colorId: number,
+    drag: number,
+  ): void {
+    if (this.count >= this.limit || this.count >= CAP) return
+    const i = this.count++
+    this.x[i] = x
+    this.y[i] = y
+    this.vx[i] = vx
+    this.vy[i] = vy
+    this.life[i] = lifeS
+    this.inv[i] = 1 / Math.max(0.02, lifeS)
+    this.size[i] = size
+    this.drag[i] = drag
+    this.kind[i] = kind
+    this.col[i] = colorId
+  }
+
+  update(dt: number): void {
+    let n = this.count
+    for (let i = 0; i < n; i++) {
+      const l = (this.life[i] as number) - dt
+      if (l <= 0) {
+        n--
+        this.swap(i, n)
+        i--
+        continue
+      }
+      this.life[i] = l
+      const k = Math.exp(-(this.drag[i] as number) * dt)
+      this.vx[i] = (this.vx[i] as number) * k
+      this.vy[i] = (this.vy[i] as number) * k
+      this.x[i] = (this.x[i] as number) + (this.vx[i] as number) * dt
+      this.y[i] = (this.y[i] as number) + (this.vy[i] as number) * dt
+    }
+    this.count = n
+  }
+
+  private swap(a: number, b: number): void {
+    if (a === b) return
+    for (const arr of [this.x, this.y, this.vx, this.vy, this.life, this.inv, this.size, this.drag]) {
+      const t = arr[a] as number
+      arr[a] = arr[b] as number
+      arr[b] = t
+    }
+    for (const arr of [this.kind, this.col]) {
+      const t = arr[a] as number
+      arr[a] = arr[b] as number
+      arr[b] = t
+    }
+  }
+
+  draw(g: CanvasRenderingContext2D): void {
+    g.save()
+    g.globalCompositeOperation = "lighter"
+    let last = -1
+    for (let i = 0; i < this.count; i++) {
+      const c = this.col[i] as number
+      if (c !== last) {
+        g.fillStyle = this.colors[c] as string
+        last = c
+      }
+      const t = (this.life[i] as number) * (this.inv[i] as number)
+      g.globalAlpha = t * t
+      const s = (this.size[i] as number) * (0.35 + t * 0.65)
+      const px = this.x[i] as number
+      const py = this.y[i] as number
+      if (this.kind[i] === KIND_SHARD) {
+        const vx = this.vx[i] as number
+        const vy = this.vy[i] as number
+        const l = Math.hypot(vx, vy) || 1
+        const stretch = Math.min(5, 1 + l / 320)
+        // `transform` and not `setTransform`: the camera's shake and punch-zoom
+        // matrix is already on the context, and replacing it here would draw
+        // every shard outside the shake while everything else moved with it.
+        g.save()
+        g.transform(vx / l, vy / l, -vy / l, vx / l, px, py)
+        g.fillRect(-s * stretch * 0.5, -s * 0.22, s * stretch, s * 0.44)
+        g.restore()
+      } else {
+        g.fillRect(px - s * 0.5, py - s * 0.5, s, s)
+      }
+    }
+    g.restore()
+    g.globalAlpha = 1
+  }
+}

--- a/dynawalla/games/beam/src/sim/core.ts
+++ b/dynawalla/games/beam/src/sim/core.ts
@@ -1,0 +1,146 @@
+// The CORE wave: where the curriculum enters the lattice.
+//
+// An ordinary automaton carries a number and the child judges divisibility. A
+// CORE carries a **problem** — `47 + 38`, drawn from the host — and when it
+// fractures at the midline it throws out one automaton per candidate value.
+// Killing one submits it.
+//
+// That is the whole integration, and the reason it is not a quiz bolted onto a
+// shooter: to submit a value the child must do the column arithmetic *and* find
+// a beam that divides the result. The divisibility rule is not decoration
+// around the answer, it is the lock on the trigger — you cannot hand in a
+// number you cannot factor.
+//
+// Nothing in this module compares a response to an answer. It labels which
+// candidate is canonical from the value the host revealed, and the game reports
+// what was struck.
+
+import { beamDivisors, resonates, tuneLattice, usableCoreValue } from "./lattice.ts"
+
+export type Candidate = { value: number; correct: boolean }
+
+export type CoreWave = {
+  questionId: string
+  prompt: string
+  /** The canonical value, as revealed by the host. Never computed here. */
+  answer: number
+  /** Beam labels, ascending. Tuned so every candidate below is killable. */
+  beams: number[]
+  candidates: Candidate[]
+}
+
+/**
+ * Mal-rule outputs for column arithmetic, used only to top a thin candidate set
+ * back up to something worth choosing between.
+ *
+ * Every one is a procedure a child actually runs: the carry written and never
+ * added in, the carry added twice, the same slip a column to the left, and the
+ * transcription reversal. None of them is `answer + 1`.
+ */
+export function columnMalRules(answer: number): number[] {
+  return [answer - 10, answer + 10, answer - 100, answer + 100, reverseDigits(answer)]
+}
+
+/** 63 → 36. A real transcription slip, not noise. */
+export function reverseDigits(n: number): number {
+  let out = 0
+  let m = n
+  while (m > 0) {
+    out = out * 10 + (m % 10)
+    m = Math.floor(m / 10)
+  }
+  return out
+}
+
+function parseValue(s: string): number | null {
+  if (!/^\d{1,4}$/.test(s.trim())) return null
+  const n = Number(s.trim())
+  return Number.isInteger(n) && n >= 2 ? n : null
+}
+
+/** Fewer than this and the choice is not a choice. */
+const MIN_CANDIDATES = 2
+const MAX_CANDIDATES = 4
+
+export type CoreSource = {
+  id: string
+  prompt: string
+  answer: string
+  distractors: string[]
+}
+
+/**
+ * Turn a served item into a wave, or return `null` if it cannot be one.
+ *
+ * `null` is not a failure to paper over: an answer with no divisor in the beam
+ * range (a prime, or 169) genuinely cannot be killed on a lattice a child can
+ * read, and presenting it would be presenting an unanswerable question. The
+ * caller draws the next item instead. A dropped item is never reported.
+ */
+export function buildCore(
+  source: CoreSource,
+  beamCount: number,
+  rand: () => number,
+): CoreWave | null {
+  const answer = parseValue(source.answer)
+  if (answer === null || !usableCoreValue(answer)) return null
+
+  const seen = new Set<number>([answer])
+  const values: number[] = [answer]
+  for (const raw of source.distractors) {
+    if (values.length >= MAX_CANDIDATES) break
+    const v = parseValue(raw)
+    // A distractor is held to the same standard as the answer. A small prime —
+    // 5, 7, 11 — can only be killed from its own beam, and a beam labelled 5
+    // sitting under a hull carrying 5 is glyph matching, not division. Such a
+    // distractor is dropped rather than allowed to corrupt the lattice.
+    if (v === null || seen.has(v) || !usableCoreValue(v)) continue
+    seen.add(v)
+    values.push(v)
+  }
+
+  // The lattice is tuned to the values that exist so far. The answer is first
+  // in the list, so it gets the first forced beam and is always killable.
+  let beams = tuneLattice(values, beamCount, rand)
+  let kept = values.filter((v) => beamDivisors(v).some((d) => beams.includes(d)))
+
+  if (kept.length < MIN_CANDIDATES) {
+    // The host's distractors were all unkillable on this lattice (a prime
+    // distractor, most often). Top up with mal-rules rather than shipping a
+    // wave where the only thing on screen is the answer.
+    const extra: number[] = []
+    for (const v of columnMalRules(answer)) {
+      if (extra.length + kept.length >= MIN_CANDIDATES + 1) break
+      if (seen.has(v) || !usableCoreValue(v)) continue
+      if (!beamDivisors(v).some((d) => beams.includes(d))) continue
+      seen.add(v)
+      extra.push(v)
+    }
+    kept = [...kept, ...extra]
+  }
+  if (kept.length < MIN_CANDIDATES) return null
+
+  // Re-tune against exactly what will be on screen, so no beam label prints a
+  // candidate's number back at the child.
+  beams = tuneLattice(kept, beamCount, rand)
+  if (!beams.some((b) => resonates(b, answer))) return null
+  kept = kept.filter((v) => v === answer || beams.some((b) => resonates(b, v)))
+  if (kept.length < MIN_CANDIDATES) return null
+
+  // Shuffle by rejection so the answer is not always the leftmost candidate.
+  const order = [...kept]
+  for (let i = order.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1))
+    const t = order[i] as number
+    order[i] = order[j] as number
+    order[j] = t
+  }
+
+  return {
+    questionId: source.id,
+    prompt: source.prompt,
+    answer,
+    beams,
+    candidates: order.map((value) => ({ value, correct: value === answer })),
+  }
+}

--- a/dynawalla/games/beam/src/sim/director.ts
+++ b/dynawalla/games/beam/src/sim/director.ts
@@ -1,0 +1,188 @@
+// Pacing. What descends, how fast, how often it steps sideways, and when the
+// next CORE comes.
+//
+// Two rules from the house experience design shape every number in here:
+//
+//   * **Escalation is on difficulty, never on run length as a streak.** The
+//     pressure curve below is a function of elapsed time and total kills — the
+//     size of the run — and of nothing that a single mistake can reset. There is
+//     no "don't break it" in this game.
+//   * **The field is never empty.** A lattice with nothing on it is a lattice
+//     with no mathematics on it, so the floor on live automata rises with the
+//     run rather than the ceiling alone.
+
+import { isFieldValue, MAX_BEAM, resonates, validBeamCount } from "./lattice.ts"
+
+export type Pressure = {
+  /** 0..1 — the single scalar every other number below is derived from. */
+  level: number
+  /** Seconds an automaton takes to cross the lattice, top to floor. */
+  descentSeconds: number
+  /** Seconds between an automaton's sideways steps along the lattice. */
+  stepSeconds: number
+  /** Seconds between spawns. */
+  spawnGap: number
+  /** How many automata the director wants alive at once. */
+  floorCount: number
+  /** Preference, 0..1, for values that only one beam divides. */
+  tightness: number
+}
+
+const lerp = (a: number, b: number, t: number): number => a + (b - a) * t
+
+export class Director {
+  private elapsed = 0
+  private kills = 0
+  private sinceSpawn = 0
+  private sinceCore = 0
+  private coresRun = 0
+
+  /** Seconds of play, for the pressure curve. Advanced by the frame loop. */
+  advance(dt: number): void {
+    this.elapsed += dt
+    this.sinceSpawn += dt
+    this.sinceCore += dt
+  }
+
+  recordKill(): void {
+    this.kills++
+  }
+
+  get killCount(): number {
+    return this.kills
+  }
+
+  get coreCount(): number {
+    return this.coresRun
+  }
+
+  pressure(): Pressure {
+    // Ninety seconds to the top of the curve, with kills pulling it forward so
+    // a child who is good at this gets there sooner than one who is grinding.
+    const byTime = Math.min(1, this.elapsed / 90)
+    const byKills = Math.min(1, this.kills / 60)
+    const level = Math.min(1, byTime * 0.65 + byKills * 0.45)
+    return {
+      level,
+      // The floor was 13 and that was wrong. A run opens at pressure zero, and
+      // at 13 seconds a crossing the first minute of play contained about two
+      // curriculum problems — a child's first thirty seconds with this game is
+      // exactly when it has to prove it is about arithmetic.
+      descentSeconds: lerp(10, 5.8, level),
+      stepSeconds: lerp(1.15, 0.62, level),
+      spawnGap: lerp(2.0, 0.95, level),
+      floorCount: Math.round(lerp(2, 5, level)),
+      tightness: lerp(0.15, 0.8, level),
+    }
+  }
+
+  /** True when it is time to put another ordinary automaton on the lattice. */
+  wantsSpawn(live: number): boolean {
+    const p = this.pressure()
+    if (live < p.floorCount) return true
+    return this.sinceSpawn >= p.spawnGap
+  }
+
+  noteSpawn(): void {
+    this.sinceSpawn = 0
+  }
+
+  /**
+   * A CORE two seconds after the last one cleared, and never while one is
+   * already down.
+   *
+   * The number that matters here is the DEAD TIME — how long the lattice holds
+   * no question at all. It is this gap plus the core's approach to the fracture
+   * line, and at the first cadence tried it was eleven seconds, which put one
+   * curriculum item in front of a child every twenty-four seconds of play. That
+   * is a shooter with some arithmetic in it rather than the other way round.
+   *
+   * The answering window is deliberately NOT part of the tightening: a child's
+   * comprehension time is measured, never rationed. What was cut is the time
+   * with nothing to think about. A wave ends the moment it is answered, so
+   * reading quickly is what buys the next problem — the pacing rewards fluency
+   * instead of running on a fixed clock.
+   */
+  wantsCore(coreLive: boolean): boolean {
+    if (coreLive) return false
+    return this.sinceCore >= 2
+  }
+
+  noteCore(): void {
+    this.sinceCore = 0
+    this.coresRun++
+  }
+
+  /**
+   * A core was wanted and could not be built — the field was full, or eight
+   * items in a row had answers no readable lattice can be tuned to. Back off
+   * the same four seconds rather than retrying on the very next frame, which
+   * would drain the host's item pool at sixty draws a second.
+   */
+  deferCore(): void {
+    this.sinceCore = 0
+  }
+
+  reset(): void {
+    this.elapsed = 0
+    this.kills = 0
+    this.sinceSpawn = 0
+    this.sinceCore = 0
+    this.coresRun = 0
+  }
+}
+
+/**
+ * A value for an ordinary automaton on this lattice.
+ *
+ * Built as `beam × multiplier`, so it is killable by construction — there is no
+ * dodge verb in this game and an unkillable automaton would be a breach the
+ * child could do nothing about. `tightness` biases toward values that exactly
+ * one beam divides, which is the precision intercept the run escalates into.
+ */
+export function fieldValue(
+  beams: readonly number[],
+  tightness: number,
+  rand: () => number,
+): number {
+  if (beams.length === 0) return MAX_BEAM
+  const wantTight = rand() < tightness
+  let best = 0
+  let bestScore = -1
+  // A handful of draws, keeping the one that best matches what was asked for.
+  // Cheap, allocation-free, and it degrades to "any legal value" rather than
+  // looping forever when a lattice has no tight values left in range.
+  for (let attempt = 0; attempt < 12; attempt++) {
+    const beam = beams[Math.min(beams.length - 1, Math.floor(rand() * beams.length))] as number
+    const mult = 2 + Math.floor(rand() * 14)
+    const value = beam * mult
+    if (!isFieldValue(beams, value)) continue
+    const n = validBeamCount(beams, value)
+    const score = wantTight ? (n === 1 ? 3 : n === 2 ? 1 : 0) : n >= 2 ? 2 : 1
+    if (score > bestScore) {
+      bestScore = score
+      best = value
+    }
+    if (bestScore >= 3) break
+  }
+  if (best === 0) {
+    const beam = beams[0] as number
+    best = beam * 2
+  }
+  return best
+}
+
+/**
+ * The score a kill pays: the tighter the divisor, the more it is worth.
+ *
+ * This is the pedagogy written into the economy. Killing 84 from beam 2 is the
+ * thing anyone can see; killing it from beam 7 is the thing worth learning. So
+ * a lone valid beam pays double, and a bigger divisor pays more than a smaller
+ * one — the trivial read is always the cheapest one on the board.
+ */
+export function killScore(beam: number, value: number, validBeams: number): number {
+  if (!resonates(beam, value)) return 0
+  const base = 8 + beam * 5 + Math.min(40, Math.floor(value / 8))
+  const sole = validBeams <= 1 ? 2 : 1
+  return base * sole
+}

--- a/dynawalla/games/beam/src/sim/field.ts
+++ b/dynawalla/games/beam/src/sim/field.ts
@@ -1,0 +1,166 @@
+// The automata, and their walk down the lattice.
+//
+// Position is expressed as `(beam, t)` and nothing else: `beam` is an index
+// into the lattice's labels and `t` runs 0 at the horizon to 1 at the floor.
+// Screen space is the renderer's problem, which is what lets the descent, the
+// sideways stepping and the intercept be tested with no canvas at all.
+//
+// The sideways step is the reason divisibility is a *decision* rather than a
+// lookup. An automaton carrying 84 walks the lattice; on a board of 3·4·5·7·9
+// it can be taken from four different beams, and the child chooses which — the
+// obvious one now, or the tight one worth double if they can get there in time.
+
+export const A_ORDINARY = 0
+export const A_CORE = 1
+export const A_CANDIDATE = 2
+
+export type Automaton = {
+  alive: boolean
+  kind: number
+  /** The number on the hull. For a CORE this is the answer, and it is hidden. */
+  value: number
+  /** What is printed on the hull: a numeral, or a CORE's problem. */
+  text: string
+  /** Lattice column, an index into the beam labels. */
+  beam: number
+  /** Animated column, eased toward `beam` — the visible slide. */
+  slide: number
+  /** 0 at the horizon, 1 at the floor. */
+  t: number
+  /** Turns per second down the lattice. */
+  speed: number
+  /** Multiplies `speed`. A dissonant strike raises it: a wrong read costs time. */
+  urgency: number
+  stepIn: number
+  stepDir: number
+  /** Seconds left of the dissonance ring — visual and audible, never a penalty. */
+  ring: number
+  /** Candidate bookkeeping. */
+  correct: boolean
+  /** Serial, so a kill can be matched to the body that produced it. */
+  serial: number
+  /** Set on a CORE the frame it fractures, so it fractures exactly once. */
+  fractured: boolean
+  spawnedAt: number
+}
+
+const CAP = 40
+
+function blank(): Automaton {
+  return {
+    alive: false,
+    kind: A_ORDINARY,
+    value: 0,
+    text: "",
+    beam: 0,
+    slide: 0,
+    t: 0,
+    speed: 0.1,
+    urgency: 1,
+    stepIn: 1,
+    stepDir: 1,
+    ring: 0,
+    correct: false,
+    serial: 0,
+    fractured: false,
+    spawnedAt: 0,
+  }
+}
+
+export class Field {
+  readonly bodies: Automaton[] = []
+  private serial = 0
+
+  constructor() {
+    for (let i = 0; i < CAP; i++) this.bodies.push(blank())
+  }
+
+  spawn(): Automaton | null {
+    for (const b of this.bodies) {
+      if (b.alive) continue
+      const s = ++this.serial
+      Object.assign(b, blank())
+      b.alive = true
+      b.serial = s
+      return b
+    }
+    return null
+  }
+
+  clear(): void {
+    for (const b of this.bodies) b.alive = false
+  }
+
+  liveCount(kind?: number): number {
+    let n = 0
+    for (const b of this.bodies) {
+      if (!b.alive) continue
+      if (kind !== undefined && b.kind !== kind) continue
+      n++
+    }
+    return n
+  }
+
+  /**
+   * Advance every automaton. Returns the bodies that reached the floor this
+   * step — the caller decides what a breach costs, because a CORE candidate
+   * landing is a missed question and an ordinary automaton landing is damage.
+   */
+  update(dt: number, columns: number, stepSeconds: number, out: Automaton[]): void {
+    out.length = 0
+    for (const b of this.bodies) {
+      if (!b.alive) continue
+      if (b.ring > 0) b.ring = Math.max(0, b.ring - dt)
+      b.t += b.speed * b.urgency * dt
+      // Ease the drawn column toward the logical one. Exponential, so the slide
+      // is quick at the start and settles — a step reads as a decision, not a
+      // drift.
+      b.slide += (b.beam - b.slide) * Math.min(1, dt * 11)
+      b.stepIn -= dt
+      if (b.stepIn <= 0 && columns > 1) {
+        b.stepIn += stepSeconds
+        let next = b.beam + b.stepDir
+        if (next < 0 || next > columns - 1) {
+          b.stepDir = -b.stepDir
+          next = b.beam + b.stepDir
+        }
+        b.beam = Math.max(0, Math.min(columns - 1, next))
+      }
+      if (b.t >= 1) {
+        b.t = 1
+        out.push(b)
+      }
+    }
+  }
+
+  /**
+   * Bodies a pulse fired up `column` sweeps through as it travels from `fromT`
+   * down to `toT` (remember `t` counts *down* the screen, so a rising pulse has
+   * `toT < fromT`). Sorted nearest-first, which is the order the pulse meets
+   * them and therefore the order they must resolve in.
+   */
+  sweep(column: number, fromT: number, toT: number, out: Automaton[]): void {
+    out.length = 0
+    for (const b of this.bodies) {
+      if (!b.alive) continue
+      // The drawn column is what the child aimed at, so the hit test uses it —
+      // an automaton visibly mid-slide is half on each beam and forgiving on
+      // both, which is the right way round for a moving target.
+      if (Math.abs(b.slide - column) > 0.45) continue
+      if (b.t > fromT || b.t < toT) continue
+      out.push(b)
+    }
+    out.sort((x, y) => y.t - x.t)
+  }
+
+  /** The automaton a runner on `column` is currently resonating against. */
+  target(column: number): Automaton | null {
+    let best: Automaton | null = null
+    for (const b of this.bodies) {
+      if (!b.alive) continue
+      if (Math.abs(b.slide - column) > 0.5) continue
+      if (best === null || b.t > best.t) best = b
+    }
+    return best
+  }
+}

--- a/dynawalla/games/beam/src/sim/lattice.ts
+++ b/dynawalla/games/beam/src/sim/lattice.ts
@@ -1,0 +1,155 @@
+// The lattice — and with it, the whole of this game's mathematics.
+//
+// A beam is a whole number. An automaton carries a whole number. The single
+// rule the entire game is built on lives in `resonates`:
+//
+//     a pulse fired up beam `b` destroys an automaton carrying `v`
+//     **if and only if** b divides v.
+//
+// Nothing else in this package is allowed to decide whether a kill lands. The
+// renderer asks, the audio asks, the scorer asks, and the tests assert the
+// biconditional directly.
+//
+// The second idea here is `phaseOffset`, which is what makes division audible.
+// `v / b` has a fractional part; that fraction is a **phase**. Two waveforms
+// separated by that phase beat against each other, and they beat at zero — they
+// fuse into one pure tone — exactly when the fraction is zero, which is exactly
+// when b divides v. The ear is not being told the answer; it is being handed
+// the remainder as a physical quantity. And because a phase is circular, 83 and
+// 85 both read as "one away from a multiple of 12" — which is true, and is the
+// near-miss a child most needs to feel.
+
+/** The smallest number a beam may be tuned to. A beam of 1 divides everything. */
+export const MIN_BEAM = 2
+/**
+ * The largest number a beam may be tuned to. Twelve is not arbitrary: it is the
+ * top of the divisibility facts this product's grade band actually learns, and
+ * a two-digit label still reads at the foot of a beam on a 320px screen.
+ */
+export const MAX_BEAM = 12
+
+/** Every b in [MIN_BEAM, MAX_BEAM] that divides `n`, ascending. */
+export function beamDivisors(n: number): number[] {
+  const out: number[] = []
+  if (!Number.isInteger(n) || n <= 0) return out
+  for (let b = MIN_BEAM; b <= MAX_BEAM; b++) if (n % b === 0) out.push(b)
+  return out
+}
+
+/**
+ * THE KILL RULE. One expression, one place, quoted by every other module.
+ *
+ * Guarded rather than trusting: a NaN value from a malformed item must read as
+ * "no resonance" and cost the child nothing, not throw inside the frame loop.
+ */
+export function resonates(beam: number, value: number): boolean {
+  if (!Number.isInteger(beam) || !Number.isInteger(value)) return false
+  if (beam < MIN_BEAM || value <= 0) return false
+  return value % beam === 0
+}
+
+/**
+ * The phase gap between a beam's waveform and an automaton's, in turns, signed,
+ * in (−0.5, 0.5].
+ *
+ * Zero **exactly** when the beam divides the value — that identity is the
+ * contract between the sound, the picture and the kill rule, and it is asserted
+ * as a biconditional in the tests.
+ */
+export function phaseOffset(beam: number, value: number): number {
+  if (!Number.isInteger(beam) || !Number.isInteger(value) || beam < MIN_BEAM) return 0.5
+  const p = (((value % beam) + beam) % beam) / beam
+  return p > 0.5 ? p - 1 : p
+}
+
+/**
+ * How hard this value is on this lattice: the number of beams that divide it.
+ * A value with one valid beam is a precision intercept; a value with four is a
+ * gift. The scorer pays for the former, the director escalates toward it.
+ */
+export function validBeamCount(beams: readonly number[], value: number): number {
+  let n = 0
+  for (const b of beams) if (resonates(b, value)) n++
+  return n
+}
+
+/**
+ * Tune a lattice of `count` beams so that every value in `required` is killable
+ * on it.
+ *
+ * The forced picks come first — the smallest beam-range divisor of each
+ * required value — and the rest of the lattice is filled with distinct labels
+ * that are *not equal to any required value*. That last clause closes a real
+ * leak: a beam labelled 8 sitting under an automaton carrying 8 lets a child
+ * match two glyphs instead of dividing.
+ */
+export function tuneLattice(
+  required: readonly number[],
+  count: number,
+  rand: () => number,
+): number[] {
+  const chosen = new Set<number>()
+  const banned = new Set<number>(required)
+
+  for (const v of required) {
+    if (chosen.size >= count) break
+    const divisors = beamDivisors(v)
+    if (divisors.some((b) => chosen.has(b))) continue
+    // The ban is a preference; killability is the requirement. A value whose
+    // only divisor in range is itself — a small prime — gets that beam anyway,
+    // because an odd-looking label is a far smaller problem than an automaton
+    // nothing on the board can touch. `usableCoreValue` keeps that case away
+    // from the curriculum path, where the leak would matter.
+    const d = divisors.find((b) => !banned.has(b)) ?? divisors[0]
+    if (d !== undefined) chosen.add(d)
+  }
+
+  // Fill. Shuffled by rejection over a shrinking candidate list so the lattice
+  // is different every wave and the child cannot memorise a fixed board.
+  const pool: number[] = []
+  for (let b = MIN_BEAM; b <= MAX_BEAM; b++) if (!chosen.has(b) && !banned.has(b)) pool.push(b)
+  while (chosen.size < count && pool.length > 0) {
+    const i = Math.min(pool.length - 1, Math.floor(rand() * pool.length))
+    chosen.add(pool[i] as number)
+    pool.splice(i, 1)
+  }
+  // Only reachable if `banned` swallowed most of the range — a lattice must
+  // still have `count` beams, so the ban is relaxed before the size is.
+  for (let b = MIN_BEAM; b <= MAX_BEAM && chosen.size < count; b++) chosen.add(b)
+
+  return [...chosen].sort((a, b) => a - b)
+}
+
+/**
+ * A value the game may draw on an ordinary automaton: a positive integer of at
+ * most three digits, killable somewhere on this lattice.
+ *
+ * Every automaton in the stream is killable. There is no "let it through"
+ * verb in this game, so an unkillable automaton would be a guaranteed breach
+ * the child could do nothing about.
+ */
+export function isFieldValue(beams: readonly number[], value: number): boolean {
+  if (!Number.isInteger(value) || value < 2 || value > 999) return false
+  return validBeamCount(beams, value) > 0
+}
+
+/**
+ * Whether a curriculum answer can be the seed of a CORE wave.
+ *
+ * Two conditions, both load-bearing:
+ *
+ *   * It must have a divisor in the beam range, or no lattice can be tuned to
+ *     kill it and the child would be asked for something impossible.
+ *   * That divisor must be smaller than the value itself — i.e. the value is
+ *     composite. If the only tuning were the value's own number, the beam label
+ *     would print the answer at the foot of the lattice.
+ *
+ * An item whose answer fails this is not asked. It is dropped before the child
+ * ever sees it, and it is never reported: silence is honest, a question with no
+ * reachable answer is not.
+ */
+export function usableCoreValue(value: number): boolean {
+  if (!Number.isInteger(value) || value < 4 || value > 9999) return false
+  const d = beamDivisors(value)
+  return d.length > 0 && (d[0] as number) < value
+}

--- a/dynawalla/games/beam/src/sim/pulse.ts
+++ b/dynawalla/games/beam/src/sim/pulse.ts
@@ -1,0 +1,43 @@
+// What a pulse does to the thing it meets.
+//
+// Extracted out of the frame loop on purpose: this is the decision the whole
+// game turns on, and it should be provable without a canvas. `resolveStrike` is
+// a pure function of the beam, the class of automaton and the number on its
+// hull, and the tests assert the biconditional it exists to enforce — a kill is
+// possible **if and only if** the beam divides the value.
+
+import { A_CANDIDATE, A_CORE } from "./field.ts"
+import { resonates } from "./lattice.ts"
+
+export type Strike =
+  /** The automaton comes apart. The beam divides it. */
+  | "shatter"
+  /** A CORE candidate comes apart, and its value is handed in as the answer. */
+  | "submit"
+  /** The beam does not divide it: it rings and is shoved down the lattice. */
+  | "dissonance"
+  /** Nothing happens — the pulse rings off armour, or off a body behind one. */
+  | "pass"
+
+/**
+ * @param isFirst whether this is the first body the pulse met on its way up.
+ *   Only the first one rings: a stray shot must not shove a whole column of
+ *   automata down the lattice for a single wrong read.
+ */
+export function resolveStrike(
+  beam: number,
+  kind: number,
+  value: number,
+  isFirst: boolean,
+): Strike {
+  // A CORE is armoured until it fractures. The problem written on it is not the
+  // target; the values it throws out are.
+  if (kind === A_CORE) return "pass"
+  if (resonates(beam, value)) return kind === A_CANDIDATE ? "submit" : "shatter"
+  return isFirst ? "dissonance" : "pass"
+}
+
+/** Whether a pulse fired up `beam` can kill `value` at all. The rule, restated. */
+export function canKill(beam: number, value: number): boolean {
+  return resonates(beam, value)
+}

--- a/dynawalla/games/beam/src/stubHost.ts
+++ b/dynawalla/games/beam/src/stubHost.ts
@@ -1,0 +1,188 @@
+// A local stub Host so the game is playable standalone with `npm run dev`.
+//
+// It serves what the live curriculum serves. Only the `add` domain has active
+// rows — whole-number column addition and subtraction, with and without
+// regrouping — so this stub serves exactly that and nothing else. A stub that
+// handed out division while the ladder cannot is a stub that lies about the
+// game, and the first thing anyone would notice on a real device is that the
+// mathematics changed.
+//
+// Three properties the real runtime also honours, all asserted in
+// `src/test/stubHost.test.ts`:
+//
+//   1. **Exact arithmetic.** Every operand, answer and distractor is an
+//      integer. No float ever reaches an answer string or a comparison.
+//   2. **Seeded and deterministic.** Same seed → same question stream, forever.
+//   3. **Distractors are real mal-rule outputs** — what a child running a
+//      specific broken procedure actually writes down. Not `answer + 1` noise.
+
+import type { Host, Question } from "./contract.ts"
+import { Rng } from "./core/rng.ts"
+
+type Domain = "add" | "sub"
+
+/** Digit-reversal: 63 → 36. A real transcription slip. */
+function reverseDigits(n: number): number {
+  let out = 0
+  let m = n
+  while (m > 0) {
+    out = out * 10 + (m % 10)
+    m = Math.floor(m / 10)
+  }
+  return out
+}
+
+/** Column addition with every carry dropped: 27 + 15 → 32. */
+function addNoCarry(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    out += ((x % 10) + (y % 10)) % 10 * place
+    place *= 10
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return out
+}
+
+/** The smaller-from-larger bug: 52 − 27 → 35, taking |2−7| in the ones column. */
+function subSmallerFromLarger(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    out += Math.abs((x % 10) - (y % 10)) * place
+    place *= 10
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return out
+}
+
+function malRulesFor(domain: Domain, a: number, b: number, answer: number): number[] {
+  if (domain === "add") {
+    return [
+      addNoCarry(a, b), // wrote the carry down and never added it in
+      answer - 10, // carried, then dropped the carry in the tens
+      answer + 10, // carried twice
+      answer - 100, // the same slip a column further left
+      Math.abs(a - b), // reached for the wrong operation
+      reverseDigits(answer),
+    ]
+  }
+  return [
+    subSmallerFromLarger(a, b), // took the small digit from the large one
+    answer + 10, // borrowed without decrementing the next column
+    answer - 10, // decremented twice
+    answer + 100, // the same slip a column further left
+    a + b, // wrong operation
+    reverseDigits(answer),
+  ]
+}
+
+function operandsFor(domain: Domain, difficulty: number, rng: Rng): [number, number] {
+  // Difficulty is clamped to 1..10 and stretches the operand range, walking the
+  // active ladder: two digits without regrouping at the bottom, three digits
+  // with it at the top. Answers stay at three digits, because a numeral on an
+  // automaton is read at speed and four digits is not legible at 320px.
+  const d = Math.max(1, Math.min(10, Math.round(difficulty)))
+  if (domain === "add") {
+    const hi = 12 + d * 45 // 57..462
+    return [rng.int(6, hi), rng.int(6, hi)]
+  }
+  const hi = 24 + d * 60 // 84..624
+  const a = rng.int(14, hi)
+  const b = rng.int(4, Math.max(5, a - 2))
+  return [a, b]
+}
+
+const GLYPH: Record<Domain, string> = { add: "+", sub: "−" }
+
+export type StubHostOptions = {
+  seed?: number
+  reducedMotion?: boolean
+  /** Observe reports — the dev harness draws a running accuracy readout. */
+  onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void
+  /** Observe haptics so the harness can show they fired on a device with none. */
+  onHaptic?: (k: string) => void
+}
+
+export function createStubHost(opts: StubHostOptions = {}): Host {
+  const rng = new Rng(opts.seed ?? 0xbea3)
+  let n = 0
+  const domains: Domain[] = ["add", "add", "sub"]
+
+  return {
+    next(o) {
+      const difficulty = Math.max(1, Math.min(10, Math.round(o?.difficulty ?? 3)))
+      const domain = (o?.domain as Domain | undefined) ?? rng.pick(domains)
+      const [a, b] = operandsFor(domain, difficulty, rng)
+      const answer = domain === "add" ? a + b : a - b
+
+      // Mal-rule outputs, deduped, filtered to values that are legal on a hull:
+      // a positive integer of at most three digits that is not the answer.
+      const seen = new Set<number>([answer])
+      const pool: number[] = []
+      for (const v of malRulesFor(domain, a, b, answer)) {
+        if (!Number.isInteger(v) || v < 2 || v > 999 || seen.has(v)) continue
+        seen.add(v)
+        pool.push(v)
+      }
+      rng.shuffle(pool)
+
+      // Top up from place-value slips if a particular (a, b) collapsed several
+      // mal-rules onto the same value — 30 + 30 makes "no carry" and the answer
+      // and the reversal all collide.
+      for (const k of [20, 30, 90, 200, 11, 9]) {
+        if (pool.length >= 3) break
+        for (const v of [answer + k, answer - k]) {
+          if (pool.length >= 3) break
+          if (!Number.isInteger(v) || v < 2 || v > 999 || seen.has(v)) continue
+          seen.add(v)
+          pool.push(v)
+        }
+      }
+
+      n++
+      return {
+        id: `stub-${n}`,
+        prompt: `${a} ${GLYPH[domain]} ${b}`,
+        answer: String(answer),
+        distractors: pool.slice(0, 3).map(String),
+        domain,
+        difficulty,
+      } satisfies Question
+    },
+
+    report(r) {
+      opts.onReport?.(r)
+    },
+
+    haptic(k) {
+      opts.onHaptic?.(k)
+      const nav = globalThis.navigator as Navigator | undefined
+      if (!nav || typeof nav.vibrate !== "function") return
+      const ms =
+        k === "light" ? 8 : k === "medium" ? 18 : k === "heavy" ? 34 : k === "success" ? 12 : 40
+      try {
+        if (k === "success") nav.vibrate([ms, 26, ms])
+        else if (k === "failure") nav.vibrate([ms, 40, ms])
+        else nav.vibrate(ms)
+      } catch {
+        // A browser that exposes vibrate but refuses it (no user gesture yet,
+        // or a policy block) must never take the frame down with it.
+        console.warn("[beam] navigator.vibrate refused")
+      }
+    },
+
+    prefersReducedMotion() {
+      if (opts.reducedMotion !== undefined) return opts.reducedMotion
+      return (
+        typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion: reduce)").matches
+      )
+    },
+  }
+}

--- a/dynawalla/games/beam/src/test/core.test.ts
+++ b/dynawalla/games/beam/src/test/core.test.ts
@@ -1,0 +1,188 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { Rng } from "../core/rng.ts"
+import { createStubHost } from "../stubHost.ts"
+import { buildCore, columnMalRules, reverseDigits, type CoreSource } from "../sim/core.ts"
+import { beamDivisors, resonates, usableCoreValue } from "../sim/lattice.ts"
+
+const BEAMS = 5
+
+function harvest(seed: number, n: number) {
+  const rng = new Rng(seed)
+  const host = createStubHost({ seed: seed ^ 0x5151, reducedMotion: false })
+  const waves = []
+  let attempts = 0
+  while (waves.length < n && attempts < n * 20) {
+    attempts++
+    const q = host.next({ difficulty: 1 + (attempts % 10) })
+    const built = buildCore(
+      { id: q.id, prompt: q.prompt, answer: q.answer, distractors: q.distractors },
+      BEAMS,
+      () => rng.next(),
+    )
+    if (built) waves.push({ q, built })
+  }
+  return waves
+}
+
+test("every wave the game builds can be answered on the lattice it was built with", () => {
+  const waves = harvest(0xc0de, 1500)
+  assert.ok(waves.length >= 1500, `only built ${waves.length} waves`)
+  for (const { q, built } of waves) {
+    assert.equal(built.beams.length, BEAMS)
+    assert.equal(new Set(built.beams).size, BEAMS)
+    assert.equal(String(built.answer), q.answer, "the canonical value came from the host, unchanged")
+    // THE POINT: the answer is always killable. A question you cannot hand in
+    // is not a question, and this is the invariant that makes the divisibility
+    // gate a lock on the trigger rather than a wall.
+    assert.ok(
+      built.beams.some((b) => resonates(b, built.answer)),
+      `no beam in ${built.beams.join(",")} divides the answer ${built.answer}`,
+    )
+  }
+})
+
+test("every candidate on screen is killable, and only from a beam that divides it", () => {
+  for (const { built } of harvest(0xfeed, 1200)) {
+    for (const c of built.candidates) {
+      const valid = built.beams.filter((b) => resonates(b, c.value))
+      assert.ok(valid.length > 0, `candidate ${c.value} cannot be taken from any beam`)
+      for (const b of built.beams) {
+        assert.equal(
+          valid.includes(b),
+          c.value % b === 0,
+          `beam ${b} vs candidate ${c.value}: the kill rule was not the whole story`,
+        )
+      }
+    }
+  }
+})
+
+test("exactly one candidate is canonical, and it is the host's value", () => {
+  for (const { built } of harvest(0xbeef, 1200)) {
+    const correct = built.candidates.filter((c) => c.correct)
+    assert.equal(correct.length, 1, `${built.prompt} produced ${correct.length} correct candidates`)
+    assert.equal((correct[0] as { value: number }).value, built.answer)
+    const values = built.candidates.map((c) => c.value)
+    assert.equal(new Set(values).size, values.length, "duplicate candidates")
+    assert.ok(values.length >= 2, "a single candidate is not a choice")
+    assert.ok(values.length <= 4, "more than four candidates does not fit the lattice")
+  }
+})
+
+test("no beam label prints a candidate's number back at the child", () => {
+  for (const { built } of harvest(0x1234, 1500)) {
+    for (const c of built.candidates) {
+      assert.ok(
+        !built.beams.includes(c.value),
+        `beam ${c.value} is also a candidate — that is glyph matching, not division`,
+      )
+    }
+  }
+})
+
+test("the answer is not always in the same place", () => {
+  const waves = harvest(0x777, 900)
+  const at = [0, 0, 0, 0]
+  for (const { built } of waves) {
+    const i = built.candidates.findIndex((c) => c.correct)
+    at[i] = (at[i] as number) + 1
+  }
+  assert.ok((at[0] as number) / waves.length < 0.45, "the answer sits first too often")
+  assert.ok((at[1] as number) > 0 && (at[2] as number) > 0, "the answer never reaches the later slots")
+})
+
+test("an item whose answer no readable beam divides is passed over, not faked", () => {
+  const rng = new Rng(3)
+  for (const prime of ["83", "97", "101", "211", "169", "221"]) {
+    const src: CoreSource = {
+      id: "q",
+      prompt: `x + y`,
+      answer: prime,
+      distractors: ["84", "96", "100"],
+    }
+    assert.equal(buildCore(src, BEAMS, () => rng.next()), null, `${prime} should be passed over`)
+    assert.equal(usableCoreValue(Number(prime)), false)
+  }
+})
+
+test("a malformed item never becomes a wave", () => {
+  const rng = new Rng(11)
+  for (const answer of ["", "abc", "0", "1", "-12", "4.5", "12345"]) {
+    const src: CoreSource = { id: "q", prompt: "p", answer, distractors: ["84", "96"] }
+    assert.equal(buildCore(src, BEAMS, () => rng.next()), null, `answer "${answer}"`)
+  }
+})
+
+test("thin distractor sets are topped up with mal-rules, never with noise", () => {
+  // Every host distractor here is prime, so none of them survives the lattice
+  // and the top-up path is the only thing that can produce a second candidate.
+  const rng = new Rng(0x5150)
+  const built = buildCore(
+    { id: "q", prompt: "40 + 44", answer: "84", distractors: ["83", "97", "101"] },
+    BEAMS,
+    () => rng.next(),
+  )
+  assert.ok(built, "a wave should still have been built")
+  assert.ok(built.candidates.length >= 2)
+  const wrong = built.candidates.filter((c) => !c.correct).map((c) => c.value)
+  const legal = new Set(columnMalRules(84))
+  for (const v of wrong) {
+    assert.ok(legal.has(v), `${v} is not a column-arithmetic mal-rule output`)
+    // And in particular: never the off-by-one that teaches nothing.
+    assert.notEqual(Math.abs(v - 84), 1)
+  }
+})
+
+test("the mal-rules are the procedures children actually run", () => {
+  assert.deepEqual(columnMalRules(342), [332, 352, 242, 442, 243])
+  assert.equal(reverseDigits(63), 36)
+  assert.equal(reverseDigits(100), 1)
+  assert.equal(reverseDigits(7), 7)
+})
+
+test("a wave is deterministic for a seed", () => {
+  const src: CoreSource = {
+    id: "q1",
+    prompt: "247 + 158",
+    answer: "405",
+    distractors: ["395", "415", "504"],
+  }
+  const ra = new Rng(99)
+  const rb = new Rng(99)
+  assert.deepEqual(
+    buildCore(src, BEAMS, () => ra.next()),
+    buildCore(src, BEAMS, () => rb.next()),
+  )
+})
+
+test("the drop rate is small enough that the child is never left waiting", () => {
+  // The game draws up to eight items looking for one the lattice can be tuned
+  // to. If the pass-over rate were high that budget would run out on screen.
+  const rng = new Rng(0xaaa)
+  const host = createStubHost({ seed: 0xbbb })
+  let ok = 0
+  const N = 4000
+  for (let i = 0; i < N; i++) {
+    const q = host.next({ difficulty: 1 + (i % 10) })
+    const built = buildCore(
+      { id: q.id, prompt: q.prompt, answer: q.answer, distractors: q.distractors },
+      BEAMS,
+      () => rng.next(),
+    )
+    if (built) ok++
+  }
+  const rate = ok / N
+  assert.ok(rate > 0.7, `only ${(rate * 100).toFixed(1)}% of items could be put on a lattice`)
+  // Eight independent draws at this rate miss less than once in a million.
+  assert.ok(Math.pow(1 - rate, 8) < 1e-4)
+})
+
+test("every value a wave puts on screen has a divisor in the readable range", () => {
+  for (const { built } of harvest(0x2468, 800)) {
+    for (const c of built.candidates) {
+      assert.ok(beamDivisors(c.value).length > 0, `${c.value} is unreachable on any lattice`)
+    }
+  }
+})

--- a/dynawalla/games/beam/src/test/director.test.ts
+++ b/dynawalla/games/beam/src/test/director.test.ts
@@ -1,0 +1,143 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { Rng } from "../core/rng.ts"
+import { Director, fieldValue, killScore } from "../sim/director.ts"
+import { resonates, validBeamCount } from "../sim/lattice.ts"
+
+const BOARDS = [
+  [2, 3, 5, 7, 11],
+  [3, 4, 5, 7, 9],
+  [2, 4, 6, 8, 12],
+  [5, 6, 7, 9, 10],
+]
+
+test("every automaton the director puts on the lattice can be killed on it", () => {
+  // There is no dodge verb in this game, so an unkillable automaton would be a
+  // guaranteed breach the child could do nothing about.
+  const rng = new Rng(0xd1)
+  for (const beams of BOARDS) {
+    for (let tightness = 0; tightness <= 1.0001; tightness += 0.1) {
+      for (let i = 0; i < 900; i++) {
+        const v = fieldValue(beams, tightness, () => rng.next())
+        assert.ok(Number.isInteger(v), `${v} is not an integer`)
+        assert.ok(v >= 2 && v <= 999, `${v} is not legible on a moving hull`)
+        assert.ok(
+          beams.some((b) => resonates(b, v)),
+          `nothing on ${beams.join(",")} divides ${v}`,
+        )
+      }
+    }
+  }
+})
+
+test("tightness really does push the stream toward the precision intercept", () => {
+  const beams = [3, 4, 5, 7, 9]
+  const meanValid = (tightness: number, seed: number): number => {
+    const rng = new Rng(seed)
+    let sum = 0
+    const n = 4000
+    for (let i = 0; i < n; i++) sum += validBeamCount(beams, fieldValue(beams, tightness, () => rng.next()))
+    return sum / n
+  }
+  const loose = meanValid(0, 0x1111)
+  const tight = meanValid(1, 0x1111)
+  assert.ok(tight < loose, `tight ${tight.toFixed(2)} should be below loose ${loose.toFixed(2)}`)
+  assert.ok(loose - tight > 0.25, "the difficulty knob barely moved anything")
+})
+
+test("the stream is deterministic for a seed", () => {
+  const draw = (seed: number): number[] => {
+    const rng = new Rng(seed)
+    return Array.from({ length: 200 }, () => fieldValue([3, 4, 5, 7, 9], 0.5, () => rng.next()))
+  }
+  assert.deepEqual(draw(4), draw(4))
+  assert.notDeepEqual(draw(4), draw(5))
+})
+
+test("the tight divisor is always worth more than the obvious one", () => {
+  // 84 is divisible by 2, 3, 4, 6, 7 and 12. Taking it from the biggest beam is
+  // the read worth learning, and it must never pay less than taking it from 2.
+  const beams = [2, 3, 4, 7, 12]
+  const paid = beams.map((b) => killScore(b, 84, validBeamCount(beams, 84)))
+  for (let i = 1; i < paid.length; i++) {
+    assert.ok((paid[i] as number) > (paid[i - 1] as number), "a bigger divisor must pay more")
+  }
+  // And the sole valid beam doubles.
+  assert.equal(killScore(7, 35, 1), killScore(7, 35, 2) * 2)
+})
+
+test("a beam that does not divide pays nothing at all", () => {
+  for (let beam = 2; beam <= 12; beam++) {
+    for (let v = 2; v <= 400; v++) {
+      if (v % beam === 0) assert.ok(killScore(beam, v, 3) > 0)
+      else assert.equal(killScore(beam, v, 3), 0)
+    }
+  }
+})
+
+test("pressure rises with the size of a run and is bounded", () => {
+  const d = new Director()
+  const start = d.pressure()
+  assert.equal(start.level, 0)
+  for (let i = 0; i < 400; i++) {
+    d.advance(1)
+    d.recordKill()
+  }
+  const end = d.pressure()
+  assert.equal(end.level, 1)
+  assert.ok(end.descentSeconds < start.descentSeconds)
+  assert.ok(end.spawnGap < start.spawnGap)
+  assert.ok(end.stepSeconds < start.stepSeconds)
+  assert.ok(end.floorCount > start.floorCount)
+  assert.ok(end.tightness > start.tightness)
+  // Never so fast that a three-digit number cannot be read on the way down.
+  assert.ok(end.descentSeconds >= 5.5)
+  // And never so slow at the start that the first minute holds two problems.
+  assert.ok(start.descentSeconds <= 10)
+})
+
+test("escalation is on the size of the run, never on an unbroken streak", () => {
+  // Two directors that reach the same totals by different routes must land on
+  // the same pressure — a mistake in the middle changes nothing. This is the
+  // house rule against streak-keyed escalation, as an assertion.
+  const steady = new Director()
+  const lumpy = new Director()
+  for (let i = 0; i < 40; i++) {
+    steady.advance(0.5)
+    steady.recordKill()
+  }
+  for (let i = 0; i < 40; i++) lumpy.recordKill()
+  for (let i = 0; i < 40; i++) lumpy.advance(0.5)
+  assert.deepEqual(steady.pressure(), lumpy.pressure())
+})
+
+test("the lattice is never left empty, and a core never overlaps a core", () => {
+  const d = new Director()
+  assert.ok(d.wantsSpawn(0), "an empty lattice must always want an automaton")
+  d.noteSpawn()
+  assert.ok(d.wantsSpawn(0), "the floor count beats the cooldown")
+  assert.equal(d.wantsSpawn(9), false, "a full lattice waits for the gap")
+  assert.equal(d.wantsCore(true), false, "a second core while one is live is forbidden")
+  assert.equal(d.wantsCore(false), false, "and one does not arrive instantly")
+  d.advance(1)
+  assert.equal(d.wantsCore(false), false, "the dead gap is real, if short")
+  d.advance(2)
+  assert.ok(d.wantsCore(false))
+  d.noteCore()
+  assert.equal(d.wantsCore(false), false)
+  assert.equal(d.coreCount, 1)
+})
+
+test("reset returns the director to the first second of a run", () => {
+  const d = new Director()
+  for (let i = 0; i < 100; i++) {
+    d.advance(1)
+    d.recordKill()
+  }
+  d.noteCore()
+  d.reset()
+  assert.deepEqual(d.pressure(), new Director().pressure())
+  assert.equal(d.killCount, 0)
+  assert.equal(d.coreCount, 0)
+})

--- a/dynawalla/games/beam/src/test/feel.test.ts
+++ b/dynawalla/games/beam/src/test/feel.test.ts
@@ -1,0 +1,74 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { Feel } from "../core/feel.ts"
+
+test("reduced motion is a branch, not a degradation: nothing travels at all", () => {
+  const f = new Feel({ reducedMotion: true })
+  f.addTrauma(1)
+  f.kick(1, 1, 40)
+  f.punch(0.4)
+  f.hitstop(200)
+  f.slowmo(0.2, 800)
+  f.requestFlash(0.4, "#fff")
+  const simMs = f.advance(16, 1000)
+  assert.equal(simMs, 16, "a reduced-motion frame must never be frozen")
+  assert.equal(f.shakeX, 0)
+  assert.equal(f.shakeY, 0)
+  assert.equal(f.scale, 1)
+  assert.equal(f.flashAlpha, 0)
+  assert.equal(f.timeScale(), 1)
+})
+
+test("a hitstop freezes the simulation and then hands the time back", () => {
+  const f = new Feel({ reducedMotion: false })
+  f.hitstop(90)
+  assert.equal(f.advance(16, 0), 0)
+  assert.equal(f.advance(16, 16), 0)
+  let now = 32
+  for (let i = 0; i < 8; i++) {
+    now += 16
+    if (f.advance(16, now) > 0) break
+  }
+  assert.ok(f.advance(16, now + 16) > 0, "the freeze never released")
+})
+
+test("flashes are rate-limited and capped, so a fast run cannot strobe", () => {
+  const f = new Feel({ reducedMotion: false })
+  let peak = 0
+  let now = 0
+  for (let i = 0; i < 240; i++) {
+    now += 16
+    f.requestFlash(1, "#fff")
+    f.advance(16, now)
+    peak = Math.max(peak, f.flashAlpha)
+  }
+  // Four seconds of a flash requested on every single frame.
+  assert.ok(peak <= 0.42 + 1e-9, `flash reached ${peak}`)
+})
+
+test("slow motion recovers to real time and never speeds it up", () => {
+  const f = new Feel({ reducedMotion: false })
+  f.advance(16, 1000)
+  f.slowmo(0.3, 400)
+  f.advance(16, 1000)
+  assert.ok(f.timeScale() < 1)
+  f.advance(16, 1500)
+  assert.equal(f.timeScale(), 1)
+  for (let t = 1000; t <= 1500; t += 20) {
+    f.advance(16, t)
+    assert.ok(f.timeScale() <= 1 + 1e-9, "time must never run fast")
+  }
+})
+
+test("reset puts the camera back where it started", () => {
+  const f = new Feel({ reducedMotion: false })
+  f.addTrauma(1)
+  f.kick(1, 0, 30)
+  f.punch(0.3)
+  f.reset()
+  f.advance(16, 2000)
+  assert.ok(Math.abs(f.shakeX) < 1e-6)
+  assert.ok(Math.abs(f.scale - 1) < 1e-6)
+  assert.equal(f.flashAlpha, 0)
+})

--- a/dynawalla/games/beam/src/test/geom.test.ts
+++ b/dynawalla/games/beam/src/test/geom.test.ts
@@ -1,0 +1,75 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { columnAt, columnX, makeGeom, project } from "../render/geom.ts"
+
+const SIZES: [number, number][] = [
+  [320, 568], // the smallest phone this ships to
+  [390, 844],
+  [768, 1024], // iPad portrait
+  [1280, 800], // desktop and tablet landscape are first-class targets
+]
+
+test("the lattice fits inside every viewport, with room for its labels", () => {
+  for (const [w, h] of SIZES) {
+    const g = makeGeom(w, h, 5)
+    for (let c = 0; c < 5; c++) {
+      const x = columnX(g, c)
+      assert.ok(x >= 0 && x <= w, `beam ${c} foot at ${x} is off a ${w}px screen`)
+      assert.ok(x >= g.margin - 0.001 && x <= w - g.margin + 0.001, `beam ${c} has no label room`)
+    }
+    // Beams never collide: the gap has to stay wide enough to tap.
+    const gap = columnX(g, 1) - columnX(g, 0)
+    assert.ok(gap > 40, `a ${gap.toFixed(0)}px beam gap cannot be hit with a finger`)
+  }
+})
+
+test("the projection pins the horizon and the floor exactly", () => {
+  const g = makeGeom(768, 1024, 5)
+  const far = project(g, 0, 0)
+  const near = project(g, 0, 1)
+  assert.equal(far.y, g.horizonY)
+  assert.equal(far.x, g.vpX, "every beam starts at the vanishing point")
+  assert.equal(near.y, g.floorY)
+  assert.equal(near.x, columnX(g, 0))
+  assert.equal(near.scale, 1)
+})
+
+test("descent accelerates toward the child rather than sliding at a constant rate", () => {
+  const g = makeGeom(390, 844, 5)
+  const step = (t: number): number => project(g, 4, t + 0.05).y - project(g, 4, t).y
+  assert.ok(step(0.8) > step(0.4), "the last stretch must be the fastest")
+  assert.ok(step(0.4) > step(0.05))
+  let prev = -1
+  for (let t = 0; t <= 1.0001; t += 0.05) {
+    const p = project(g, 3, t)
+    assert.ok(p.y > prev, "y must be monotone down the lattice")
+    prev = p.y
+    assert.ok(p.scale > 0 && p.scale <= 1)
+  }
+})
+
+test("out-of-range t is clamped rather than projected off the world", () => {
+  const g = makeGeom(390, 844, 5)
+  assert.deepEqual(project(g, 2, -3), project(g, 2, 0))
+  assert.deepEqual(project(g, 2, 9), project(g, 2, 1))
+})
+
+test("a tap anywhere on the floor lands on a real beam", () => {
+  for (const [w, h] of SIZES) {
+    const g = makeGeom(w, h, 5)
+    for (let x = -40; x <= w + 40; x += 3) {
+      const c = columnAt(g, x)
+      assert.ok(Number.isInteger(c) && c >= 0 && c <= 4, `tap at ${x} chose ${c}`)
+    }
+    // And a tap on a beam's own foot chooses that beam.
+    for (let c = 0; c < 5; c++) assert.equal(columnAt(g, columnX(g, c)), c)
+  }
+})
+
+test("a single-beam lattice degenerates without dividing by zero", () => {
+  const g = makeGeom(390, 844, 1)
+  assert.equal(columnX(g, 0), g.vpX)
+  assert.equal(columnAt(g, 300), 0)
+  assert.ok(Number.isFinite(project(g, 0, 0.5).x))
+})

--- a/dynawalla/games/beam/src/test/lattice.test.ts
+++ b/dynawalla/games/beam/src/test/lattice.test.ts
@@ -1,0 +1,198 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { Rng } from "../core/rng.ts"
+import {
+  beamDivisors,
+  isFieldValue,
+  MAX_BEAM,
+  MIN_BEAM,
+  phaseOffset,
+  resonates,
+  tuneLattice,
+  usableCoreValue,
+  validBeamCount,
+} from "../sim/lattice.ts"
+
+test("THE KILL RULE: a beam resonates with a value if and only if it divides it", () => {
+  for (let beam = MIN_BEAM; beam <= MAX_BEAM; beam++) {
+    for (let value = 1; value <= 1200; value++) {
+      assert.equal(
+        resonates(beam, value),
+        value % beam === 0,
+        `resonates(${beam}, ${value}) disagreed with divisibility`,
+      )
+    }
+  }
+})
+
+test("resonance is closed against the values a malformed item could produce", () => {
+  for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, -6, 0, 4.5]) {
+    assert.equal(resonates(3, bad), false, `resonates(3, ${bad}) must be false`)
+    assert.equal(resonates(bad, 12), false, `resonates(${bad}, 12) must be false`)
+  }
+  // …and a beam below the floor is never a beam, however divisible it looks.
+  assert.equal(resonates(1, 7), false)
+})
+
+test("phase is zero exactly when the beam divides — the sound and the rule agree", () => {
+  for (let beam = MIN_BEAM; beam <= MAX_BEAM; beam++) {
+    for (let value = 1; value <= 900; value++) {
+      const zero = phaseOffset(beam, value) === 0
+      assert.equal(
+        zero,
+        resonates(beam, value),
+        `phase and kill rule disagreed at beam ${beam}, value ${value}`,
+      )
+    }
+  }
+})
+
+test("phase stays inside a half turn either way, so the beat rate is bounded", () => {
+  for (let beam = MIN_BEAM; beam <= MAX_BEAM; beam++) {
+    for (let value = 1; value <= 900; value++) {
+      const p = phaseOffset(beam, value)
+      assert.ok(p > -0.5 && p <= 0.5, `phase ${p} out of range at ${beam}/${value}`)
+    }
+  }
+})
+
+test("a value one either side of a multiple reads as nearly locked, from both sides", () => {
+  // 83 and 85 are each one away from 84, and the phase is circular, so both
+  // must be within a twelfth of a turn of zero. This is the near-miss a child
+  // has to feel, and it is why the ear narrows the field without settling it.
+  assert.ok(Math.abs(phaseOffset(12, 85)) <= 1 / 12 + 1e-12)
+  assert.ok(Math.abs(phaseOffset(12, 83)) <= 1 / 12 + 1e-12)
+  assert.equal(phaseOffset(12, 84), 0)
+})
+
+test("beamDivisors lists exactly the beams that divide", () => {
+  assert.deepEqual(beamDivisors(84), [2, 3, 4, 6, 7, 12])
+  assert.deepEqual(beamDivisors(85), [5])
+  assert.deepEqual(beamDivisors(83), [])
+  assert.deepEqual(beamDivisors(169), [])
+  assert.deepEqual(beamDivisors(0), [])
+  assert.deepEqual(beamDivisors(-12), [])
+  for (let n = 1; n <= 600; n++) {
+    for (const d of beamDivisors(n)) assert.equal(n % d, 0)
+  }
+})
+
+test("validBeamCount counts what resonates and nothing else", () => {
+  const beams = [3, 4, 5, 7, 9]
+  assert.equal(validBeamCount(beams, 84), 3) // 3, 4, 7
+  assert.equal(validBeamCount(beams, 35), 2) // 5, 7
+  assert.equal(validBeamCount(beams, 11), 0)
+})
+
+test("a tuned lattice can always kill everything it was tuned for", () => {
+  const rng = new Rng(0x1a771ce)
+  for (let trial = 0; trial < 4000; trial++) {
+    const n = 1 + Math.floor(rng.next() * 4)
+    const required: number[] = []
+    for (let i = 0; i < n; i++) {
+      // Anything with a divisor in range, including the small primes that can
+      // only be killed from their own beam — the tuner must place all of them.
+      let v = rng.int(2, 999)
+      while (beamDivisors(v).length === 0) v = rng.int(2, 999)
+      required.push(v)
+    }
+    const beams = tuneLattice(required, 5, () => rng.next())
+    assert.equal(beams.length, 5)
+    assert.equal(new Set(beams).size, 5, "beams must be distinct")
+    for (let i = 1; i < beams.length; i++) {
+      assert.ok((beams[i] as number) > (beams[i - 1] as number), "beams must be ascending")
+    }
+    for (const b of beams) {
+      assert.ok(b >= MIN_BEAM && b <= MAX_BEAM, `beam ${b} is outside the readable range`)
+    }
+    for (const v of required) {
+      assert.ok(
+        beams.some((b) => resonates(b, v)),
+        `lattice ${beams.join(",")} cannot kill ${v}`,
+      )
+    }
+  }
+})
+
+test("a beam is never labelled with a number that is on a hull", () => {
+  // Otherwise a child matches two glyphs instead of dividing.
+  const rng = new Rng(0x9a771ce)
+  for (let trial = 0; trial < 3000; trial++) {
+    const required = [rng.int(2, 12), rng.int(2, 12) * 2, rng.int(4, 240)].filter(
+      (v) => beamDivisors(v).length > 0,
+    )
+    if (required.length === 0) continue
+    const beams = tuneLattice(required, 5, () => rng.next())
+    for (const v of required) {
+      if (!usableCoreValue(v)) continue
+      assert.ok(!beams.includes(v), `beam ${v} printed a hull value back at the child`)
+    }
+  }
+})
+
+test("a re-tune keeps the candidates killable and still hides their numbers", () => {
+  // This is the shape `mount.retune()` calls with: the wave's candidates first,
+  // then whatever ordinary automata happen to be in the air. The candidates must
+  // survive the competition for beams — the answer above all — and none of them
+  // may end up printed on a beam label.
+  const rng = new Rng(0x5e7)
+  for (let trial = 0; trial < 3000; trial++) {
+    const candidates: number[] = []
+    while (candidates.length < 1 + Math.floor(rng.next() * 4)) {
+      const v = rng.int(4, 999)
+      if (usableCoreValue(v) && !candidates.includes(v)) candidates.push(v)
+    }
+    // Ordinary automata are always `beam × multiplier`, so always composite.
+    const live: number[] = []
+    for (let i = 0; i < 8; i++) live.push(rng.int(2, 12) * rng.int(2, 15))
+
+    const beams = tuneLattice([...candidates, ...live], 5, () => rng.next())
+    assert.equal(beams.length, 5)
+    for (const c of candidates) {
+      assert.ok(
+        beams.some((b) => resonates(b, c)),
+        `re-tuned lattice ${beams.join(",")} cannot kill candidate ${c}`,
+      )
+      assert.ok(!beams.includes(c), `beam ${c} printed a candidate back at the child`)
+    }
+  }
+})
+
+test("the tuner is deterministic for a seed", () => {
+  const a = tuneLattice([84, 35], 5, () => new Rng(7).next())
+  const b = tuneLattice([84, 35], 5, () => new Rng(7).next())
+  assert.deepEqual(a, b)
+})
+
+test("usableCoreValue rejects exactly what cannot be put on a readable lattice", () => {
+  for (const prime of [83, 97, 101, 211, 997]) {
+    assert.equal(usableCoreValue(prime), false, `${prime} is prime and has no beam`)
+  }
+  for (const stubborn of [169, 221, 289]) {
+    assert.equal(usableCoreValue(stubborn), false, `${stubborn} has no divisor under 13`)
+  }
+  for (const fine of [84, 85, 100, 462, 918]) {
+    assert.equal(usableCoreValue(fine), true, `${fine} should be usable`)
+  }
+  for (const tiny of [0, 1, 2, 3, -8, 4.5]) {
+    assert.equal(usableCoreValue(tiny), false, `${tiny} is not a usable core`)
+  }
+  // The property the definition exists for: usable ⟹ killable, and by a beam
+  // strictly smaller than the value, so the label never prints the answer.
+  for (let n = 0; n <= 3000; n++) {
+    if (!usableCoreValue(n)) continue
+    const d = beamDivisors(n)
+    assert.ok(d.length > 0)
+    assert.ok((d[0] as number) < n)
+  }
+})
+
+test("isFieldValue admits only legible, killable numbers", () => {
+  const beams = [3, 4, 5, 7, 9]
+  assert.equal(isFieldValue(beams, 84), true)
+  assert.equal(isFieldValue(beams, 11), false, "nothing on this lattice divides 11")
+  assert.equal(isFieldValue(beams, 1), false)
+  assert.equal(isFieldValue(beams, 1008), false, "four digits cannot be read on a moving hull")
+  assert.equal(isFieldValue(beams, 4.5), false)
+})

--- a/dynawalla/games/beam/src/test/loop.test.ts
+++ b/dynawalla/games/beam/src/test/loop.test.ts
@@ -1,0 +1,290 @@
+// The whole game, played headlessly.
+//
+// Every other test in this package proves a rule in isolation. This one proves
+// the rules are wired to each other: it mounts the real `mountBeam` against a
+// stub surface, drives the real frame loop on a virtual clock, hammers the real
+// input handlers, and watches what comes out of `host.report`.
+//
+// It is not a rendering test — the 2D context is a no-op recorder and nothing
+// about pixels is asserted. What is asserted is that a CORE can be drawn,
+// descend, fracture, be intercepted from a beam that divides one of its
+// candidates, and be reported; and that three minutes of adversarial input
+// never throws.
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { mount } from "../contract.ts"
+import { Rng } from "../core/rng.ts"
+import { createStubHost } from "../stubHost.ts"
+
+type Handler = (e: unknown) => void
+
+/**
+ * A surface with no pixels. Every context method returns the context itself, so
+ * `createLinearGradient(...).addColorStop(...)` chains without a real canvas
+ * and every drawing call is a no-op that still has to *typecheck at runtime*.
+ */
+function stubSurface(
+  width: number,
+  height: number,
+  wallClock: number,
+  cores: number,
+): {
+  el: HTMLElement
+  install(): () => void
+  pump(): (ms: number) => void
+  keys: Map<string, Handler>
+} {
+  const rect = { left: 0, top: 0, width, height, right: width, bottom: height, x: 0, y: 0 }
+  const keys = new Map<string, Handler>()
+  const noop = new Proxy(function () {} as unknown as Record<string, unknown>, {
+    get: (_t, prop) => (prop === "then" ? undefined : noop),
+    set: () => true,
+    apply: () => noop,
+  }) as unknown as CanvasRenderingContext2D
+
+  const makeEl = (): HTMLElement => {
+    const el = {
+      style: { cssText: "" },
+      width: 0,
+      height: 0,
+      appendChild: () => undefined,
+      remove: () => undefined,
+      getBoundingClientRect: () => rect,
+      getContext: () => noop,
+      setPointerCapture: () => undefined,
+      releasePointerCapture: () => undefined,
+      hasPointerCapture: () => false,
+      addEventListener: (k: string, h: Handler) => keys.set(k, h),
+      removeEventListener: (k: string) => keys.delete(k),
+    }
+    return el as unknown as HTMLElement
+  }
+
+  let pending: ((t: number) => void) | null = null
+  let clock = 0
+
+  const saved = {
+    raf: globalThis.requestAnimationFrame,
+    caf: globalThis.cancelAnimationFrame,
+    ro: (globalThis as { ResizeObserver?: unknown }).ResizeObserver,
+    now: performance.now,
+    key: globalThis.addEventListener,
+    unkey: globalThis.removeEventListener,
+    dpr: (globalThis as { devicePixelRatio?: number }).devicePixelRatio,
+    doc: (globalThis as { document?: unknown }).document,
+    dateNow: Date.now,
+    nav: Object.getOwnPropertyDescriptor(globalThis, "navigator"),
+  }
+
+  const install = (): (() => void) => {
+    globalThis.requestAnimationFrame = ((cb: (t: number) => void): number => {
+      pending = cb
+      return 1
+    }) as typeof globalThis.requestAnimationFrame
+    globalThis.cancelAnimationFrame = ((): void => {
+      pending = null
+    }) as typeof globalThis.cancelAnimationFrame
+    ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe(): void {}
+      disconnect(): void {}
+    }
+    performance.now = () => clock
+    // The game seeds its own run RNG from the wall clock, which is right on a
+    // tablet and fatal in a test: a suite that is green four runs out of five
+    // has proved nothing. Pinning `Date.now` makes a whole play-through
+    // reproducible, and the seed is what varies between them.
+    Date.now = () => wallClock
+    // The quality tier is read once from `navigator.hardwareConcurrency`, so
+    // this is the knob that decides whether the game runs LOW or HIGH.
+    Object.defineProperty(globalThis, "navigator", {
+      value: { hardwareConcurrency: cores },
+      configurable: true,
+      writable: true,
+    })
+    ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = 2
+    globalThis.addEventListener = ((k: string, h: Handler): void => {
+      keys.set(k, h)
+    }) as unknown as typeof globalThis.addEventListener
+    globalThis.removeEventListener = ((k: string): void => {
+      keys.delete(k)
+    }) as unknown as typeof globalThis.removeEventListener
+    ;(globalThis as { document?: unknown }).document = { createElement: () => makeEl() }
+    return () => {
+      globalThis.requestAnimationFrame = saved.raf
+      globalThis.cancelAnimationFrame = saved.caf
+      ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = saved.ro
+      performance.now = saved.now
+      ;(globalThis as { devicePixelRatio?: number }).devicePixelRatio = saved.dpr
+      globalThis.addEventListener = saved.key
+      globalThis.removeEventListener = saved.unkey
+      ;(globalThis as { document?: unknown }).document = saved.doc
+      Date.now = saved.dateNow
+      if (saved.nav) Object.defineProperty(globalThis, "navigator", saved.nav)
+    }
+  }
+
+  return {
+    el: makeEl(),
+    install,
+    pump: () => (ms: number) => {
+      clock += ms
+      const cb = pending
+      pending = null
+      cb?.(clock)
+    },
+    keys,
+  }
+}
+
+type Report = { questionId: string; correct: boolean; ms: number; answered: string }
+
+function play(seed: number, frames: number, reducedMotion: boolean, cores = 12): Report[] {
+  const surface = stubSurface(768, 1024, seed * 7919, cores)
+  const restore = surface.install()
+  const reports: Report[] = []
+  const host = createStubHost({
+    seed,
+    reducedMotion,
+    onReport: (r) => reports.push(r),
+  })
+  const handle = mount(surface.el, host)
+  const step = surface.pump()
+  const rng = new Rng(seed ^ 0x51de)
+  const press = (key: string): void => {
+    surface.keys.get("keydown")?.({ key, preventDefault: () => undefined })
+  }
+  try {
+    for (let i = 0; i < frames; i++) {
+      step(16)
+      // A child's hands: mostly moving, firing often, and occasionally leaning
+      // on the trigger the way a five-year-old does.
+      if (rng.chance(0.09)) press(rng.chance(0.5) ? "ArrowLeft" : "ArrowRight")
+      if (rng.chance(0.22)) press(" ")
+    }
+  } finally {
+    handle.unmount()
+    restore()
+  }
+  return reports
+}
+
+test("the whole loop runs: a core descends, fractures, is intercepted and reported", () => {
+  // Pooled over six seeds rather than asserted on one. A single run of random
+  // flailing hitting the canonical candidate is a coin toss, and a suite that
+  // depends on a coin toss is a suite that goes red for no reason.
+  const runs = [0x10be, 0x20be, 0x30be, 0x40be, 0x50be, 0x60be].map((s) => play(s, 3000, false))
+  const reports = runs.flat()
+  // 3000 frames at 16ms is 48 seconds each, so 288 seconds of play in total.
+  // Random input — a bot that never once decides to answer — measures 30 items
+  // out of that, one every nine and a half seconds, and a child who reads sees
+  // them faster because a wave ends the moment it is answered. The floor is set
+  // well under the measurement; what it guards against is a regression to the
+  // first cadence tried, which managed twelve.
+  assert.ok(reports.length >= 22, `only ${reports.length} items in 288s of play`)
+  assert.ok(
+    runs.every((r) => r.length > 0),
+    "one of the six runs never served a single item",
+  )
+  assert.ok(
+    reports.some((r) => r.correct),
+    "random play never once hit the canonical candidate",
+  )
+  assert.ok(
+    reports.some((r) => !r.correct),
+    "random play never once missed",
+  )
+})
+
+test("the quality tier cannot change the game — decoration never moves the maths", () => {
+  // This is the invariant that a shared RNG broke: the particle emitters draw
+  // once per spark, and the tier scales the spark count, so a four-core tablet
+  // consumed a different number of draws and played a different game from the
+  // same seed than a twelve-core one. Same seed, opposite ends of the tier
+  // table, identical stream of answers.
+  for (const seed of [0x9a1, 0x9a2, 0x9a3]) {
+    assert.deepEqual(
+      play(seed, 2400, false, 2),
+      play(seed, 2400, false, 32),
+      `seed ${seed} played differently on a cheap device than on an expensive one`,
+    )
+  }
+})
+
+test("a run is reproducible from its seed", () => {
+  assert.deepEqual(play(0x7e57, 2400, false), play(0x7e57, 2400, false))
+  assert.notDeepEqual(play(0x7e57, 2400, false), play(0x7e58, 2400, false))
+})
+
+test("nothing is ever reported that the host did not serve", () => {
+  for (const r of play(0x2222, 5000, false)) {
+    assert.ok(r.questionId.length > 0, "a report carried no item id")
+    assert.ok(Number.isInteger(r.ms) && r.ms >= 0, `bad latency ${r.ms}`)
+    // Either a value was struck, or the candidates landed and nothing was
+    // handed in. Never a float, never a sign, never a fragment.
+    assert.ok(r.answered === "" || /^\d+$/.test(r.answered), `bad answer "${r.answered}"`)
+    if (r.answered === "") assert.equal(r.correct, false)
+  }
+})
+
+test("an item is reported at most once", () => {
+  const seen = new Set<string>()
+  for (const r of play(0x3333, 5000, false)) {
+    assert.ok(!seen.has(r.questionId), `${r.questionId} was reported twice`)
+    seen.add(r.questionId)
+  }
+})
+
+test("the reduced-motion branch plays the same game, not a lesser one", () => {
+  // Not asserted equal to the motion branch: hitstop and slow-motion really do
+  // change how much simulation a frame carries, and reduced motion switches
+  // both off. What must hold is that it is the same game — items arrive, and
+  // they can be answered.
+  const reports = [0x4444, 0x5555, 0x6666].flatMap((s) => play(s, 4000, true))
+  assert.ok(reports.length >= 10, `reduced motion only produced ${reports.length} items`)
+  assert.ok(reports.some((r) => r.correct))
+  assert.ok(reports.some((r) => !r.correct))
+})
+
+test("mounting and unmounting repeatedly leaves nothing running", () => {
+  for (let i = 0; i < 12; i++) play(0x5000 + i, 220, i % 2 === 0, i % 3 === 0 ? 2 : 12)
+})
+
+test("a very small viewport is still a playable lattice", () => {
+  const surface = stubSurface(320, 480, 0x2b1d, 4)
+  const restore = surface.install()
+  const host = createStubHost({ seed: 7, reducedMotion: false })
+  const handle = mount(surface.el, host)
+  const step = surface.pump()
+  try {
+    for (let i = 0; i < 900; i++) {
+      step(16)
+      if (i % 7 === 0) surface.keys.get("keydown")?.({ key: " ", preventDefault: () => undefined })
+    }
+  } finally {
+    handle.unmount()
+    restore()
+  }
+})
+
+test("a stalled tab that resumes does not teleport the lattice into the floor", () => {
+  // A backgrounded tab hands the loop one enormous frame when it comes back.
+  // The clamp has to swallow it, or every automaton on screen lands at once.
+  const surface = stubSurface(768, 1024, 0x77a1, 12)
+  const restore = surface.install()
+  const reports: Report[] = []
+  const host = createStubHost({ seed: 9, reducedMotion: false, onReport: (r) => reports.push(r) })
+  const handle = mount(surface.el, host)
+  const step = surface.pump()
+  try {
+    for (let i = 0; i < 400; i++) step(16)
+    step(45_000) // forty-five seconds hidden
+    for (let i = 0; i < 400; i++) step(16)
+  } finally {
+    handle.unmount()
+    restore()
+  }
+  // Nothing threw, and the run did not silently end during the stall.
+  assert.ok(reports.every((r) => r.ms >= 0))
+})

--- a/dynawalla/games/beam/src/test/pulse.test.ts
+++ b/dynawalla/games/beam/src/test/pulse.test.ts
@@ -1,0 +1,172 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { Rng } from "../core/rng.ts"
+import { A_CANDIDATE, A_CORE, A_ORDINARY, type Automaton, Field } from "../sim/field.ts"
+import { MAX_BEAM, MIN_BEAM } from "../sim/lattice.ts"
+import { canKill, resolveStrike } from "../sim/pulse.ts"
+
+test("A KILL IS POSSIBLE IF AND ONLY IF THE BEAM DIVIDES THE VALUE", () => {
+  // The headline invariant of the whole game, asserted as a biconditional over
+  // every readable beam and every legible hull value, for both killable
+  // classes, and in both pulse positions.
+  for (let beam = MIN_BEAM; beam <= MAX_BEAM; beam++) {
+    for (let value = 2; value <= 999; value++) {
+      const divides = value % beam === 0
+      assert.equal(canKill(beam, value), divides)
+      for (const isFirst of [true, false]) {
+        const ordinary = resolveStrike(beam, A_ORDINARY, value, isFirst)
+        const candidate = resolveStrike(beam, A_CANDIDATE, value, isFirst)
+        assert.equal(
+          ordinary === "shatter",
+          divides,
+          `beam ${beam} vs ${value}: ordinary kill did not track divisibility`,
+        )
+        assert.equal(
+          candidate === "submit",
+          divides,
+          `beam ${beam} vs ${value}: candidate submission did not track divisibility`,
+        )
+      }
+    }
+  }
+})
+
+test("a beam that does not divide rings the first body it meets, and only that one", () => {
+  assert.equal(resolveStrike(5, A_ORDINARY, 84, true), "dissonance")
+  assert.equal(resolveStrike(5, A_ORDINARY, 84, false), "pass")
+  assert.equal(resolveStrike(5, A_CANDIDATE, 84, true), "dissonance")
+  assert.equal(resolveStrike(5, A_CANDIDATE, 84, false), "pass")
+})
+
+test("a CORE is armoured: the problem is never the target", () => {
+  for (let beam = MIN_BEAM; beam <= MAX_BEAM; beam++) {
+    for (const v of [84, 85, 90, 405]) {
+      assert.equal(resolveStrike(beam, A_CORE, v, true), "pass")
+      assert.equal(resolveStrike(beam, A_CORE, v, false), "pass")
+    }
+  }
+})
+
+test("nothing can be killed by a value that is not a whole number of beams", () => {
+  for (const bad of [Number.NaN, 4.5, -12, 0]) {
+    assert.equal(resolveStrike(6, A_ORDINARY, bad, true), "dissonance")
+    assert.equal(canKill(6, bad), false)
+  }
+})
+
+test("a pulse meets the bodies on its beam nearest first", () => {
+  const field = new Field()
+  const at = (t: number, col: number) => {
+    const b = field.spawn()
+    assert.ok(b)
+    b.kind = A_ORDINARY
+    b.t = t
+    b.beam = col
+    b.slide = col
+    b.value = Math.round(t * 100)
+    return b
+  }
+  at(0.2, 1)
+  at(0.8, 1)
+  at(0.5, 1)
+  at(0.5, 3) // a different beam: never swept
+  const out: Automaton[] = []
+  field.sweep(1, 1, 0, out)
+  assert.deepEqual(
+    out.map((b) => b.t),
+    [0.8, 0.5, 0.2],
+  )
+})
+
+test("a pulse only sweeps the slice of the beam it has travelled through", () => {
+  const field = new Field()
+  for (const t of [0.1, 0.4, 0.7, 0.95]) {
+    const b = field.spawn()
+    assert.ok(b)
+    b.kind = A_ORDINARY
+    b.t = t
+    b.beam = 2
+    b.slide = 2
+    b.value = 12
+  }
+  const out: Automaton[] = []
+  field.sweep(2, 0.75, 0.35, out)
+  assert.deepEqual(
+    out.map((b) => b.t),
+    [0.7, 0.4],
+  )
+})
+
+test("automata walk the lattice and turn back at the edges", () => {
+  const field = new Field()
+  const b = field.spawn()
+  assert.ok(b)
+  b.kind = A_ORDINARY
+  b.beam = 4
+  b.slide = 4
+  b.stepDir = 1
+  b.stepIn = 0
+  b.speed = 0
+  const landed: Automaton[] = []
+  const seen: number[] = []
+  for (let i = 0; i < 12; i++) {
+    field.update(0.5, 5, 0.5, landed)
+    seen.push(b.beam)
+  }
+  // Reflected off column 4 immediately and walked back down the lattice.
+  assert.deepEqual(seen, [3, 2, 1, 0, 1, 2, 3, 4, 3, 2, 1, 0])
+  assert.ok(seen.every((c) => c >= 0 && c <= 4))
+})
+
+test("an automaton that reaches the floor is reported exactly once per step", () => {
+  const field = new Field()
+  const b = field.spawn()
+  assert.ok(b)
+  b.kind = A_ORDINARY
+  b.t = 0.9
+  b.speed = 1
+  b.stepIn = 1e9
+  const landed: Automaton[] = []
+  field.update(0.05, 5, 1, landed)
+  assert.equal(landed.length, 0)
+  field.update(0.2, 5, 1, landed)
+  assert.equal(landed.length, 1)
+  assert.equal(b.t, 1)
+})
+
+test("dissonance costs time and nothing else", () => {
+  // The urgency multiplier is the only thing a wrong read touches: no score is
+  // deducted anywhere in this file, and no anchor is spent.
+  const field = new Field()
+  const b = field.spawn()
+  assert.ok(b)
+  b.speed = 0.1
+  b.urgency = 1
+  b.urgency = Math.min(2.4, b.urgency + 0.35)
+  assert.ok(b.urgency > 1 && b.urgency <= 2.4)
+})
+
+test("the field never hands out the same slot twice", () => {
+  const field = new Field()
+  const rng = new Rng(5)
+  const live = new Set<number>()
+  for (let i = 0; i < 500; i++) {
+    if (rng.chance(0.6)) {
+      const b = field.spawn()
+      if (b) {
+        assert.ok(!live.has(b.serial))
+        live.add(b.serial)
+      }
+    } else {
+      for (const b of field.bodies) {
+        if (b.alive) {
+          b.alive = false
+          live.delete(b.serial)
+          break
+        }
+      }
+    }
+    assert.equal(field.liveCount(), field.bodies.filter((b) => b.alive).length)
+  }
+})

--- a/dynawalla/games/beam/src/test/stubHost.test.ts
+++ b/dynawalla/games/beam/src/test/stubHost.test.ts
@@ -1,0 +1,154 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+import { createStubHost } from "../stubHost.ts"
+
+function drain(seed: number, n: number, difficulty?: number) {
+  const host = createStubHost({ seed, reducedMotion: false })
+  const out = []
+  for (let i = 0; i < n; i++) {
+    out.push(host.next(difficulty === undefined ? undefined : { difficulty }))
+  }
+  return out
+}
+
+test("the stream is deterministic for a seed", () => {
+  assert.deepEqual(drain(42, 80), drain(42, 80))
+  assert.notDeepEqual(drain(42, 80), drain(43, 80))
+})
+
+test("it serves only what the curriculum can actually serve", () => {
+  // The `add` domain is the only one with active rows: whole-number column
+  // addition and subtraction. A stub that handed out division while the ladder
+  // cannot would misrepresent the game on a real device.
+  for (const q of drain(1234, 900)) {
+    assert.ok(q.domain === "add" || q.domain === "sub", `unexpected domain ${q.domain}`)
+    assert.ok(/^\d+ [+−] \d+$/.test(q.prompt), `unexpected prompt ${q.prompt}`)
+  }
+})
+
+test("every answer is an exact integer and the prompt evaluates to it", () => {
+  for (let d = 1; d <= 10; d++) {
+    for (const q of drain(9001 + d, 300, d)) {
+      const m = /^(\d+) ([+−]) (\d+)$/.exec(q.prompt)
+      assert.ok(m, `unparseable prompt ${q.prompt}`)
+      const a = Number(m[1])
+      const b = Number(m[3])
+      const expected = m[2] === "+" ? a + b : a - b
+      assert.ok(Number.isInteger(expected), `${q.prompt} is not exact`)
+      assert.equal(q.answer, String(expected))
+      assert.equal(String(Number(q.answer)), q.answer, "answer must be a bare integer string")
+      assert.ok(Number(q.answer) > 0, `${q.prompt} = ${q.answer} must be positive`)
+    }
+  }
+})
+
+test("no floating point ever reaches an answer or a distractor", () => {
+  for (const q of drain(5150, 900)) {
+    for (const s of [q.answer, ...q.distractors]) {
+      assert.ok(/^\d+$/.test(s), `"${s}" is not a bare non-negative integer`)
+    }
+  }
+})
+
+test("there are always exactly three distinct distractors, none equal to the answer", () => {
+  for (let d = 1; d <= 10; d++) {
+    for (const q of drain(31337 + d, 400, d)) {
+      assert.equal(q.distractors.length, 3, `${q.prompt} produced ${q.distractors.length}`)
+      const set = new Set(q.distractors)
+      assert.equal(set.size, 3, `${q.prompt} has duplicate distractors`)
+      assert.ok(!set.has(q.answer), `${q.prompt} lists its own answer as a distractor`)
+    }
+  }
+})
+
+test("every value fits the three-digit legibility ceiling", () => {
+  for (let d = 1; d <= 10; d++) {
+    for (const q of drain(777 + d, 400, d)) {
+      for (const s of [q.answer, ...q.distractors]) {
+        assert.ok(s.length <= 3, `"${s}" from ${q.prompt} cannot be read on a moving hull`)
+      }
+    }
+  }
+})
+
+test("distractors are mal-rule outputs, not noise", () => {
+  // What a child running a specific broken column procedure actually writes:
+  // the carry dropped, the carry added twice, the same slip a column left, the
+  // small digit taken from the large one, the reversal, the wrong operation.
+  const reverse = (n: number): number => {
+    let out = 0
+    let m = n
+    while (m > 0) {
+      out = out * 10 + (m % 10)
+      m = Math.floor(m / 10)
+    }
+    return out
+  }
+  const digitwise = (a: number, b: number, f: (x: number, y: number) => number): number => {
+    let out = 0
+    let place = 1
+    let x = a
+    let y = b
+    while (x > 0 || y > 0) {
+      out += f(x % 10, y % 10) * place
+      place *= 10
+      x = Math.floor(x / 10)
+      y = Math.floor(y / 10)
+    }
+    return out
+  }
+  let malRule = 0
+  let total = 0
+  for (const q of drain(24680, 4000)) {
+    const m = /^(\d+) ([+−]) (\d+)$/.exec(q.prompt)
+    if (!m) continue
+    total++
+    const a = Number(m[1])
+    const b = Number(m[3])
+    const ans = Number(q.answer)
+    const expected = new Set(
+      m[2] === "+"
+        ? [digitwise(a, b, (x, y) => (x + y) % 10), ans - 10, ans + 10, ans - 100, Math.abs(a - b), reverse(ans)]
+        : [digitwise(a, b, (x, y) => Math.abs(x - y)), ans + 10, ans - 10, ans + 100, a + b, reverse(ans)],
+    )
+    if (q.distractors.some((s) => expected.has(Number(s)))) malRule++
+  }
+  assert.ok(total > 3000, "not enough items sampled")
+  assert.ok(malRule / total > 0.98, `only ${((malRule / total) * 100).toFixed(1)}% carried a mal-rule`)
+})
+
+test("no distractor is ever the off-by-one that teaches nothing", () => {
+  let offByOne = 0
+  let total = 0
+  for (const q of drain(1357, 3000)) {
+    const ans = Number(q.answer)
+    for (const s of q.distractors) {
+      total++
+      if (Math.abs(Number(s) - ans) === 1) offByOne++
+    }
+  }
+  assert.ok(total > 8000)
+  assert.equal(offByOne, 0, `${offByOne} distractors were answer ± 1`)
+})
+
+test("difficulty is clamped and monotone in operand size", () => {
+  const mean = (qs: { answer: string }[]): number =>
+    qs.reduce((s, q) => s + Number(q.answer), 0) / qs.length
+  assert.ok(mean(drain(11, 500, 10)) > mean(drain(11, 500, 1)) * 2)
+  for (const q of drain(11, 60, 99)) assert.ok(q.difficulty <= 10)
+  for (const q of drain(11, 60, -5)) assert.ok(q.difficulty >= 1)
+})
+
+test("report and haptic are safe to call with no DOM", () => {
+  const seen: string[] = []
+  const host = createStubHost({
+    seed: 1,
+    onReport: (r) => seen.push(r.questionId),
+    onHaptic: (k) => seen.push(k),
+  })
+  host.report({ questionId: "q1", correct: true, ms: 120, answered: "56" })
+  host.haptic("success")
+  assert.deepEqual(seen, ["q1", "success"])
+  assert.equal(typeof host.prefersReducedMotion(), "boolean")
+})

--- a/dynawalla/games/beam/tsconfig.json
+++ b/dynawalla/games/beam/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": false,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/dynawalla/games/beam/vite.config.ts
+++ b/dynawalla/games/beam/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite"
+
+// The game is a library that mounts into a host element. `npm run dev` serves
+// the standalone harness in `index.html`, which wires it to the local stub Host
+// so the whole thing is playable with no runtime underneath it.
+export default defineConfig({
+  server: { port: 4321, host: "127.0.0.1" },
+  build: {
+    target: "es2022",
+    lib: {
+      entry: "src/index.ts",
+      name: "DynawallaGameBeam",
+      formats: ["es"],
+      fileName: () => "beam.js",
+    },
+  },
+})

--- a/dynawalla/games/beam/vite.pack.config.ts
+++ b/dynawalla/games/beam/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produces a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})


### PR DESCRIPTION
## What

Add **LATTICE RUNNER** at `dynawalla/games/beam` — rank 23, S tier, wave 2 of
`docs/catalog/ARCADE_CANON.md`, after *Beam Rider* (1983). A standalone vite +
TypeScript game and a Dynawalla pack (`dynawalla.beam`).

The rule, stated once in `src/sim/lattice.ts` and quoted by everything else:

> A pulse fired up beam `b` destroys an automaton carrying `v`
> **if and only if `b` divides `v`.**

## Why

The catalogue calls this entry "NATIVE — cleanest divisibility integration in the
document", and it is: the beams are divisors, the hulls are dividends, and the
trigger will not fire on a number the beam does not divide. There is no dodge verb
and no "let it through", so every automaton in the stream is killable by
construction and every second of play is a divisibility judgement under movement
pressure.

Three design decisions carry the whole thing:

**Divisibility is a decision, not a lookup.** The automata step sideways as they
descend, so 84 on a board of 3·4·5·7·9 is reachable from three different beams at
three different moments. `killScore` pays more for a bigger divisor and doubles
when the beam was the *only* one on the board that divides — the trivial read is
always the cheapest one there. That is the pedagogy written into the economy
instead of into a lecture.

**The curriculum is the lock on the trigger, not a quiz bolted on.** Every four
seconds a CORE descends carrying a problem the host served — `247 + 158` — and
fractures at the midline into one automaton per candidate value. Handing one in
costs four steps, three of them mathematics: do the column arithmetic, find 405
among the candidates, find a beam that divides 405, get there before they land.
**You cannot submit a number you cannot factor.**

**The resonance lock is the signature and it is deliberately not an oracle.** Two
oscillators run against each other detuned by the phase `(v mod b) / b`. They beat
at the remainder and fuse into one pure tone at exactly zero — division made
audible. The same two waves are drawn along the ridden beam, so the picture and
the sound carry identical information and the game is fully playable muted. A
remainder of 1 out of 12 is a slow, almost-locked wobble, and 83 and 85 both read
as "one away from a multiple of 12" because a phase is circular and that is true.
The ear narrows the field and never finishes the job, so a child who can divide is
always faster than one waiting for the tone to settle. The scaffold fades on its own.

### Curriculum honesty — no draft skill is claimed

`pack.json` declares the **seven active `dw.add.*` rows** and nothing else. Each id
was checked by hand against `packs/shared/curriculum/src/graph/domains/add.ts`;
`dw.add.regroup.subtract-tenths` is `status: "draft"` and is deliberately omitted.
`dw-pack check` does not validate `covers.skills`, so a fictional id would have
passed silently.

**No `dw.div.*` row is declared, on purpose.** Divisibility is native to this
mechanic and it is what the child does continuously — but every row in the `div`
domain is `status: "draft"`, so declaring one would advertise coverage the
curriculum cannot serve. The stream of ordinary automata is the game's own
mathematics over numbers the game itself made up; nobody asked those questions, so
nothing about them is reported. **When `div` is promoted this game improves with no
code change** — the CORE takes whatever expression the ladder hands it, and a
quotient on a hull is the same object as a sum on a hull.

### Items that are passed over

An answer with no divisor in the readable beam range (2–12) — a prime like 83, or
169 — cannot be killed on a lattice a child can read. `usableCoreValue()` rejects
it, the item is passed over and the next is drawn. **A passed-over item is never
shown and never reported.** The same filter closes a leak: it requires a divisor
*strictly smaller* than the value, so a beam label can never print the answer at
the foot of the lattice. Measured pass rate is 74%, so the eight-draw budget misses
less than once in ten thousand — asserted in `core.test.ts`.

## Blast radius

**Areas touched:** dynawalla (one new game directory)

`git diff --name-only origin/main...HEAD` contains only `dynawalla/games/beam/`;
`--diff-filter=D` is empty. Nothing existing is touched — no shared module, no
host, no curriculum, no other pack. Worst case for an existing surface is a new
pack appearing in the catalogue.

- [x] Every touched path is covered by a `ci.yml` area filter — `dynawalla/games/**`,
      same as `games/slice` and `games/forge`.
- [x] **Pack back-compat.** New pack at `0.1.0`; no published zip changed in place,
      no `voiceId` renamed, no catalog entry dropped or narrowed.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no manifest touched.
- [x] **Strings.** N/A — a pack owns its own surface; nothing added under
      `corpan/corpan-app/public/locales/`. `locales: ["en"]`, as slice and forge.
- [x] **Curriculum.** Nothing renamed, reused, promoted or edited. `covers.skills`
      lists seven existing **active** ids, verified by hand against
      `graph/domains/add.ts`. No draft id is claimed. Every answer, operand and
      distractor in the stub host is an exact integer — never a float, asserted.
- [x] **Secrets.** None. `gitleaks` clean over the full commit range.

### Capability declaration, and the three traps

`"capabilities": ["items", "items.reveal", "haptics"]`.

- `items.reveal` **is** declared. Without it `packs/shared/game-host/index.ts:149-167`
  leaves `canonical` empty, every item is dropped and the pack serves zero questions
  with no crash and no failing gate — it would mount, warm, and sit there.
- `audio` is **not** declared: that capability is `feedback.sound`, and this game
  synthesises its own `AudioContext`. `items.answer` does not exist and is not used.
- `storage` is **not** declared, so `localStorage` is unreachable in a pack frame
  (opaque origin — every access throws). The best score is held in a module-level
  `sessionBest` and the browser copy is a dev-harness convenience inside a `try`.

## Proof

Real output. Node here is v22.17.1 (`engines` asks for 24; CI runs 24), which is why
the `EBADENGINE` warning appears on install and nowhere else.

### `npm test` — five consecutive runs (72 tests)

```
run 1: # tests 71 # pass 71 # fail 0 
run 2: # tests 71 # pass 71 # fail 0 
run 3: # tests 71 # pass 71 # fail 0 
run 4: # tests 71 # pass 71 # fail 0 
run 5: # tests 71 # pass 71 # fail 0 
```

The headline test, in full — `src/test/pulse.test.ts`:

```
ok 1 - A KILL IS POSSIBLE IF AND ONLY IF THE BEAM DIVIDES THE VALUE
ok 2 - a beam that does not divide rings the first body it meets, and only that one
ok 3 - a CORE is armoured: the problem is never the target
ok 4 - nothing can be killed by a value that is not a whole number of beams
ok 5 - a pulse meets the bodies on its beam nearest first
ok 6 - a pulse only sweeps the slice of the beam it has travelled through
ok 7 - automata walk the lattice and turn back at the edges
ok 8 - an automaton that reaches the floor is reported exactly once per step
ok 9 - dissonance costs time and nothing else
ok 10 - the field never hands out the same slot twice
# tests 10
# pass 10
# fail 0
```

And the end-to-end loop — `src/test/loop.test.ts` mounts the real `mountBeam`
against a stub surface and drives the real frame loop on a virtual clock:

```
ok 1 - the whole loop runs: a core descends, fractures, is intercepted and reported
ok 2 - nothing is ever reported that the host did not serve
ok 3 - an item is reported at most once
ok 4 - the reduced-motion branch plays the same game, not a lesser one
ok 5 - mounting and unmounting repeatedly leaves nothing running
ok 6 - a very small viewport is still a playable lattice
ok 7 - a stalled tab that resumes does not teleport the lattice into the floor
# tests 7
# pass 7
# fail 0
```

### `npm run tsc`

```

> @dynawalla/game-beam@0.1.0 tsc
> tsc --noEmit

(0 errors)
```

### `npm run build`

```

vite v8.1.5 building client environment for production...
[2K
transforming...✓ 17 modules transformed.
rendering chunks...
computing gzip size...
dist/beam.js  41.45 kB │ gzip: 13.42 kB

✓ built in 15ms
```

### `npm run build:pack`, and the script tag that proves the entry was rewritten

```
vite v8.1.5 building client environment for production...
[2K
transforming...✓ 27 modules transformed.
rendering chunks...
computing gzip size...
dist-pack/pack.html                 1.27 kB │ gzip:  0.66 kB
dist-pack/assets/pack-CGaNiziW.js  39.33 kB │ gzip: 14.88 kB

✓ built in 24ms

$ grep -o '<script[^>]*>' dist-pack/pack.html
<script type="module" crossorigin src="./assets/pack-CGaNiziW.js">
```

### `node build.mjs beam`

```
computing gzip size...
dist-pack/pack.html                 1.27 kB │ gzip:  0.66 kB
dist-pack/assets/pack-CGaNiziW.js  39.33 kB │ gzip: 14.88 kB

✓ built in 25ms
dynawalla.beam@0.1.0 — LATTICE RUNNER
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 41698 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

### `gitleaks` over the full commit range

```
12:42AM INF 1 commits scanned.
12:42AM INF scanned ~166999 bytes (167 KB) in 51.7ms
12:42AM INF no leaks found
```

### Scope

```
$ git diff --name-only origin/main...HEAD | sed "s|/[^/]*$||" | sort -u
dynawalla/games/beam
dynawalla/games/beam/src
dynawalla/games/beam/src/core
dynawalla/games/beam/src/render
dynawalla/games/beam/src/sim
dynawalla/games/beam/src/test

$ git diff --name-only --diff-filter=D origin/main...HEAD
(empty — nothing is deleted)
```

### Fixed in self-review, before merge

Four defects found by re-reading the diff, all now in the commit:

- **`spawnCore()` drained the host's item pool.** It drew a question and *then*
  asked the field for a body; on a full field it discarded a served item, and
  because nothing reset the cooldown it did so again on the very next frame — sixty
  items a second. The body is now claimed first, and both failure paths call the new
  `director.deferCore()`, which backs off the same four seconds without counting a
  core that never arrived.
- **The tier governor did nothing.** `gov.sample()` dropped the tier and `resize()`
  was never re-run, so neither the render scale nor the particle ceiling actually
  moved — the one mechanism that keeps a cheap tablet at 60fps was inert.
- **A per-frame allocation in the draw order.** `filter().sort()` built a fresh array
  every frame; it is now a reused buffer, matching the no-allocation rule the
  particle field is written to.
- **`restart()` left `fireOnArrive`/`fireCooldown` set**, so the first pulse of a new
  run could be swallowed or fire itself.

A new test, `a re-tune keeps the candidates killable and still hides their numbers`,
covers the property `mount.retune()` depends on and that `buildCore`'s own test did
not reach: when the wave's candidates compete with the values already in the air for
five beams, every candidate still has a beam that divides it and none of them ends up
printed on a label.

### The bug CI found, and the invariant that now guards it

The first push was green. The second failed `dynawalla-packs` — the headless loop test
served 8 items on the runner where it served 22 on this laptop, from identical, fully
seeded code. That is not flake; it is a real defect, and it is in the game rather than in
the test.

`burst()` drew from **the run's RNG**. Every emitter draws once per particle, and
`Quality.burst` scales the particle count by tier — so a four-core device (tier LOW, 45%
of the sparks) consumed a different number of draws than a twelve-core one and, from that
frame on, **played a different game from the same seed**: different numbers on the hulls,
a differently tuned lattice, candidates in different columns. CI runners have 4 vCPU and
this laptop has 12, which is exactly why it only showed up there.

Decoration is now a separate stream. `rng` is the run; `fx` is the sparks. The new test
`the quality tier cannot change the game — decoration never moves the maths` mounts the
same seed at 2 cores and at 32 and asserts the two report streams are `deepEqual`, and
`a run is reproducible from its seed` pins the rest. The harness pins
`navigator.hardwareConcurrency` alongside `Date.now` and `performance.now`, so the suite
no longer depends on the machine it runs on. Verified green five times on Node 22 **and**
five times on Node 24, which is what CI uses.

### Pacing, corrected by the same measurement

Pooling the loop test across six shorter runs instead of one long one exposed something
the single long run had hidden: the *early* game was slow. Escalation is on run size, so a
144-second sample was dominated by the high-pressure tail; six 48-second runs measure what
a child's first minute actually feels like, and it was **one problem every twenty-four
seconds**.

Two changes, both to the dead time and neither to the thinking time:

- `descentSeconds` floor 13 → 10. A run opens at pressure zero, and that is precisely when
  the game has to prove it is about arithmetic.
- The core gap is 4s → 2s and the fracture line moved from t=0.34 to t=0.26, cutting the
  approach. Dead time — the stretch with no question on the lattice at all — is now about
  four seconds.

The **answering window is deliberately untouched**: about ten seconds early in a run,
closing to six at full pressure, which brackets the house p50 of 6s and p90 of 14s for
two-digit regrouping. Comprehension time is measured, never rationed
(`docs/EXPERIENCE_DESIGN.md`). What was cut is the time with nothing to think about.

Measured result: a bot that never once decides to answer now gets **30 items in 288
seconds**, one every nine and a half, against twelve before. A child who reads sees them
sooner still, because a wave ends the moment it is answered — the pacing pays for fluency
instead of running on a fixed clock.

### Flake hunt

The first five-run pass was 4/5 green. The cause was real and is fixed: `mount`
seeds its run RNG from `Date.now()`, which is right on a tablet and fatal in a
test, so `loop.test.ts` now pins `Date.now` alongside `performance.now` and every
play-through is reproducible. Ten consecutive runs green afterwards.

### Seen running

The dev harness was loaded in Chrome at 1316x907 and screenshotted: the lattice
fans from the horizon, the beams carry their labels at the floor, the runner rides
and the beam lights under it, and the two resonance traces braid along the ridden
beam at the phase offset of the automaton overhead. Console is clean — no errors,
no warnings. Two rendering defects were found and fixed by looking at it: the
traces stopped 80px short of the runner because the perspective divide crowds the
last stretch of the beam, and every glow was a flat translucent ellipse, which over
near-black stone has a hard rim and reads as a grey saucer rather than as light —
both now radial-gradient blooms drawn additively.

### Re-run after the self-review fixes

```

run 1: # tests 72 # pass 72 # fail 0 
run 2: # tests 72 # pass 72 # fail 0 
run 3: # tests 72 # pass 72 # fail 0 
run 4: # tests 72 # pass 72 # fail 0 
run 5: # tests 72 # pass 72 # fail 0 

dist-pack/assets/pack-BJ_Xsh7N.js  39.45 kB │ gzip: 14.91 kB

✓ built in 24ms

<script type="module" crossorigin src="./assets/pack-BJ_Xsh7N.js">

dynawalla.beam@0.1.0 — LATTICE RUNNER
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 41809 bytes

1 pack(s) built, checked and staged into src-tauri/packs/

12:45AM INF no leaks found
```

### Final gate run — Node 22 and Node 24 (CI uses 24), five runs each

```

v22.17.1 —
  run 1: # tests 74 # pass 74 # fail 0 
  run 2: # tests 74 # pass 74 # fail 0 
  run 3: # tests 74 # pass 74 # fail 0 
  run 4: # tests 74 # pass 74 # fail 0 
  run 5: # tests 74 # pass 74 # fail 0 
v24.18.0 —
  run 1: ℹ tests 74 ℹ pass 74 ℹ fail 0 
  run 2: ℹ tests 74 ℹ pass 74 ℹ fail 0 
  run 3: ℹ tests 74 ℹ pass 74 ℹ fail 0 
  run 4: ℹ tests 74 ℹ pass 74 ℹ fail 0 
  run 5: ℹ tests 74 ℹ pass 74 ℹ fail 0 

dist-pack/assets/pack-zO2GdlcY.js  39.52 kB │ gzip: 14.93 kB

✓ built in 33ms

<script type="module" crossorigin src="./assets/pack-zO2GdlcY.js">

dynawalla.beam@0.1.0 — LATTICE RUNNER
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 41884 bytes

1 pack(s) built, checked and staged into src-tauri/packs/

12:54AM INF no leaks found
```
