### PR TITLE
fix(dynawalla/games/truedraw): stop the clock when the host puts a sheet over the frame

### DIFF
--- a/dynawalla/games/truedraw/src/contract.ts
+++ b/dynawalla/games/truedraw/src/contract.ts
@@ -42,6 +42,9 @@ export type Host = {
   transition?(kind: "level" | "run" | "boss", label?: string): void
 }
 
-export function mount(el: HTMLElement, host: Host): { unmount(): void } {
+export function mount(
+  el: HTMLElement,
+  host: Host,
+): { unmount(): void; pause(): void; resume(): void } {
   return mountTrueDraw(el, host)
 }

--- a/dynawalla/games/truedraw/src/game/round.test.ts
+++ b/dynawalla/games/truedraw/src/game/round.test.ts
@@ -144,3 +144,55 @@ test("reduced motion changes what is drawn, never what is timed", () => {
     b.statements.map((s) => s.text),
   )
 })
+
+// ---------------------------------------------------------------------------
+// The sheet. The host can put something over the frame — a transition, a parent
+// gate — and sends `pause` with the pack still mounted and its rAF still
+// running. This game calls transition every tenth call, so it is not a corner.
+// ---------------------------------------------------------------------------
+
+test("a paused round does not run its clock behind the sheet", () => {
+  const round = new Round(fixed(true))
+  round.press()
+  round.advance(TIMING.raise)
+  assert.equal(round.phase, "still")
+
+  round.pause()
+  assert.equal(round.paused, true)
+  // Far more than enough to cross `still` and the whole draw window.
+  round.advance(60_000)
+  assert.equal(round.phase, "still", "the clock ran behind the sheet")
+
+  round.resume()
+  assert.equal(round.paused, false)
+  round.advance(800)
+  assert.equal(round.phase, "call", "the clock did not restart on resume")
+})
+
+test("a true slate cannot cost a shot while the sheet is up", () => {
+  // The bug this guards, exactly: an unpaused draw window opens and closes
+  // behind the sheet, settles as a hold, and a *true* statement takes one of
+  // the child's three shots for a slate they were never shown. A reward that
+  // costs a life is the worst outcome this game has.
+  const round = new Round(fixed(true))
+  round.press()
+  round.advance(TIMING.raise)
+  round.pause()
+  const before = round.run.shots
+
+  round.advance(60_000)
+
+  assert.equal(round.run.shots, before, "a shot was spent behind the sheet")
+  assert.equal(round.phase, "still", "the round advanced while paused")
+})
+
+test("a tap on the sheet is a tap on the sheet — not a draw, not a flinch", () => {
+  const round = new Round(fixed(false))
+  round.press()
+  round.advance(TIMING.raise)
+  round.pause()
+  const flinches = round.run.flinches
+  const events = round.press()
+  assert.equal(events.length, 0, "a press was handled while paused")
+  assert.equal(round.run.flinches, flinches, "a paused press was counted as a flinch")
+})

--- a/dynawalla/games/truedraw/src/game/round.ts
+++ b/dynawalla/games/truedraw/src/game/round.ts
@@ -93,6 +93,7 @@ export class Round {
   private committed: Outcome | null = null
   private reaction = 0
   private state: Run = newRun()
+  private stopped = false
 
   constructor(deal: () => Statement, timing: Timing = TIMING) {
     this.deal = deal
@@ -114,6 +115,30 @@ export class Round {
   /** The outcome the verdict is currently showing, if any. */
   get outcome(): Outcome | null {
     return this.phaseName === "verdict" || this.phaseName === "clear" ? this.lastOutcome : null
+  }
+
+  get paused(): boolean {
+    return this.stopped
+  }
+
+  /**
+   * The host put something over the frame. **The clock stops dead.**
+   *
+   * This matters more here than in any other pack, and it is not hypothetical:
+   * this game calls `transition` on every tenth call, the SDK documents that a
+   * transition may put a sheet over the frame, and the host then sends `pause`
+   * while leaving the pack mounted and running. Without this, a 1750–3600 ms
+   * draw window would open and close behind that sheet, settle as a hold, and —
+   * if the statement happened to be true — take one of the child's three shots
+   * for a slate they were never shown. A reward that costs a life is the worst
+   * bug this game could have.
+   */
+  pause(): void {
+    this.stopped = true
+  }
+
+  resume(): void {
+    this.stopped = false
   }
 
   /** 0..1 through the current phase. The renderer's only clock. */
@@ -140,6 +165,7 @@ export class Round {
   }
 
   advance(dt: number): RoundEvent[] {
+    if (this.stopped) return []
     if (this.phaseName === "idle" || this.phaseName === "over") {
       this.elapsed += Math.max(0, dt)
       return []
@@ -162,6 +188,9 @@ export class Round {
 
   /** One press. Returns whatever it caused, which is often nothing. */
   press(): RoundEvent[] {
+    // A tap that lands on a sheet is a tap on the sheet. It is not a draw, and
+    // it is not even a flinch.
+    if (this.stopped) return []
     switch (this.phaseName) {
       case "raise":
       case "still": {

--- a/dynawalla/games/truedraw/src/mount.ts
+++ b/dynawalla/games/truedraw/src/mount.ts
@@ -41,7 +41,10 @@ const TRANSITION_EVERY = 10
  */
 const MAX_STEP_MS = 120
 
-export function mountTrueDraw(el: HTMLElement, host: Host): { unmount(): void } {
+export function mountTrueDraw(
+  el: HTMLElement,
+  host: Host,
+): { unmount(): void; pause(): void; resume(): void } {
   const canvas = document.createElement("canvas")
   canvas.style.cssText = "position:absolute;inset:0;width:100%;height:100%;display:block;touch-action:none"
   el.appendChild(canvas)
@@ -162,6 +165,15 @@ export function mountTrueDraw(el: HTMLElement, host: Host): { unmount(): void } 
   frame = requestAnimationFrame(tick)
 
   return {
+    // The host puts a sheet over the frame — a transition, a parent gate — and
+    // sends `pause` with the pack still mounted. The clock has to stop dead:
+    // see Round.pause().
+    pause(): void {
+      round.pause()
+    },
+    resume(): void {
+      round.resume()
+    },
     unmount(): void {
       running = false
       cancelAnimationFrame(frame)

--- a/dynawalla/games/truedraw/src/pack.ts
+++ b/dynawalla/games/truedraw/src/pack.ts
@@ -36,6 +36,20 @@ async function start(el: HTMLElement): Promise<void> {
   mounted.client.on("dispose", () => {
     handle.unmount()
   })
+
+  // A transition can put a sheet over the frame, and the SDK documents that the
+  // pack then receives `pause` while it stays mounted and running. This game
+  // calls transition every tenth call, so that is not a hypothetical: an
+  // unpaused 1750-3600 ms draw window would open and close behind the sheet,
+  // settle as a hold, and — if the slate happened to be true — spend one of the
+  // child's three shots on a statement they were never shown. A reward that
+  // costs a life is the worst bug this game could have.
+  mounted.client.on("pause", () => {
+    handle.pause()
+  })
+  mounted.client.on("resume", () => {
+    handle.resume()
+  })
 }
 
 void start(root).catch((error: unknown) => {


### PR DESCRIPTION
## What

Make THE TRUE DRAW stop its clock when the host puts a sheet over the frame, and
actually wire that up.

## Why

The game gives a child **three shots**. A true slate must be drawn on; letting
one stand costs a shot. That economy breaks if the round keeps running while the
child cannot see it.

The host can cover the frame — a transition, a parent gate — and sends `pause`
with the pack **still mounted and its rAF still running**
(`packs/sdk/src/guest.ts:95`: *"the pack receives `pause` through `on` in the
usual way"*). This game calls `transition` **every tenth call**, so this is
routine, not a corner case.

Unpaused, the sequence is:

1. A 1750–3600 ms draw window opens behind the sheet.
2. It closes with no input and settles as a **hold**.
3. If that slate happened to be **true**, holding costs a shot.

So the child loses one of three shots on a statement they were never shown —
and it happens right after the transition that rewards them for ten calls. **A
reward that costs a life is the worst bug this game could have.**

## The half that was missing

The `pause()`/`resume()` methods on `Round` were written but **nothing called
them**. `pack.ts` subscribed only to `dispose`, so the fix was inert — present
in the diff, absent at runtime. This PR adds the subscriptions and widens the
`mount`/`contract` handle to carry them, which is what makes it real.

## Blast radius

**Areas touched:** dynawalla, one game — `dynawalla/games/truedraw/`. 5 files.

- [x] Scope: 0 files outside the game, 0 deletions.
- [x] Covered by `dynawalla-packs · games + pack build`.
- [x] **Behaviour change is confined to the paused state.** `advance` returns
      early and `press` returns no events only while stopped; unpaused play is
      byte-identical. The dev harness never pauses, so `npm run dev` is
      unchanged.
- [x] **Pack.** No manifest, capability, id or version change. Still builds,
      checks and stages.
- [x] **Curriculum.** No skill id, grade or generator touched.
- [x] **Native / strings / secrets.** None. `gitleaks` → no leaks found.

## Proof

**The tests fail without the fix** — the guard in `Round.advance` commented out:

```
$ npm test
not ok 43 - a paused round does not run its clock behind the sheet
not ok 44 - a true slate cannot cost a shot while the sheet is up
# pass 90
# fail 2
```

Restored:

```
# tests 92
# pass 92
# fail 0

$ npm run tsc
0 errors
```

The third test covers input rather than the clock: *"a tap on the sheet is a tap
on the sheet — not a draw, not a flinch"*, so a press behind the sheet is not
recorded against the child either.

```
$ node dynawalla/packs/build.mjs truedraw
1 pack(s) built, checked and staged into src-tauri/packs/

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
no leaks found
```
