### PR TITLE
fix(dynawalla/games/beam): stop the clock when the host puts a sheet over the frame

### DIFF
--- a/dynawalla/games/beam/src/contract.ts
+++ b/dynawalla/games/beam/src/contract.ts
@@ -36,6 +36,24 @@ export type Host = {
   transition?(kind: "level" | "run" | "boss", label?: string): void
 }
 
-export function mount(el: HTMLElement, host: Host): { unmount(): void } {
+export type Handle = {
+  unmount(): void
+  /**
+   * The host has put something over the frame, or the app went to the
+   * background. **Stop the clock dead.**
+   *
+   * This is not cosmetic for this game: the answering window *is* the
+   * candidates' fall to the floor, so a wave that keeps descending behind a
+   * sheet expires against a child who was never shown it — and it is this
+   * game's own `transition()` call that most often raises that sheet. While
+   * paused nothing advances, nothing is reported, no input is read, and on
+   * resume every wall-clock mark is shifted forward by exactly the time the
+   * sheet was up, so the latency the host records is the child's and not the
+   * sheet's.
+   */
+  setPaused(paused: boolean): void
+}
+
+export function mount(el: HTMLElement, host: Host): Handle {
   return mountBeam(el, host)
 }

--- a/dynawalla/games/beam/src/mount.ts
+++ b/dynawalla/games/beam/src/mount.ts
@@ -74,7 +74,10 @@ type Pulse = { alive: boolean; col: number; t: number; prevT: number; hits: numb
 type Pop = { alive: boolean; x: number; y: number; life: number; max: number; text: string; size: number; color: string }
 type Banner = { text: string; sub: string; life: number; max: number; color: string }
 
-export function mountBeam(el: HTMLElement, host: Host): { unmount(): void } {
+export function mountBeam(el: HTMLElement, host: Host): {
+  unmount(): void
+  setPaused(paused: boolean): void
+} {
   // ── surface ──────────────────────────────────────────────────────────────
   const root = document.createElement("div")
   root.style.cssText =
@@ -117,6 +120,8 @@ export function mountBeam(el: HTMLElement, host: Host): { unmount(): void } {
   let geom = makeGeom(320, 480, N_BEAMS)
   let dpr = 1
   let running = true
+  let paused = false
+  let pausedAt = 0
   let over = false
   let overAt = 0
   let beams: number[] = tuneLattice([], N_BEAMS, () => rng.next())
@@ -282,7 +287,6 @@ export function mountBeam(el: HTMLElement, host: Host): { unmount(): void } {
     b.speed = 1 / p.descentSeconds
     b.stepIn = rng.range(0.3, 1) * p.stepSeconds
     b.stepDir = rng.chance(0.5) ? 1 : -1
-    b.spawnedAt = performance.now()
     director.noteSpawn()
   }
 
@@ -341,7 +345,6 @@ export function mountBeam(el: HTMLElement, host: Host): { unmount(): void } {
     // approach.
     b.speed = 1 / (p.descentSeconds * 0.85)
     b.stepIn = 1e9
-    b.spawnedAt = performance.now()
     coreBody = b
     waveAskedAt = performance.now()
     asked++
@@ -379,7 +382,6 @@ export function mountBeam(el: HTMLElement, host: Host): { unmount(): void } {
       b.speed = 1 / (p.descentSeconds * 1.6)
       b.stepIn = 0.55 + i * 0.12
       b.stepDir = i % 2 === 0 ? 1 : -1
-      b.spawnedAt = performance.now()
     })
     core.alive = false
     coreBody = null
@@ -415,7 +417,7 @@ export function mountBeam(el: HTMLElement, host: Host): { unmount(): void } {
 
   // ── firing ───────────────────────────────────────────────────────────────
   function fire(): void {
-    if (over || fireCooldown > 0) return
+    if (paused || over || fireCooldown > 0) return
     for (const p of pulses) {
       if (p.alive) continue
       p.alive = true
@@ -648,6 +650,7 @@ export function mountBeam(el: HTMLElement, host: Host): { unmount(): void } {
   }
 
   function onDown(e: PointerEvent): void {
+    if (paused) return
     void audio.start()
     if (over) {
       if (performance.now() - overAt > 550) restart()
@@ -664,7 +667,7 @@ export function mountBeam(el: HTMLElement, host: Host): { unmount(): void } {
   }
 
   function onMove(e: PointerEvent): void {
-    if (!pointerDown) return
+    if (paused || !pointerDown) return
     if (!dragged && Math.hypot(e.clientX - downX, e.clientY - downY) > 14) dragged = true
     if (!dragged) return
     // A drag is the *listening* verb: it rides the lattice without firing, so a
@@ -674,11 +677,13 @@ export function mountBeam(el: HTMLElement, host: Host): { unmount(): void } {
   }
 
   function onUp(e: PointerEvent): void {
+    if (paused) return
     pointerDown = false
     if (canvas.hasPointerCapture(e.pointerId)) canvas.releasePointerCapture(e.pointerId)
   }
 
   function onKey(e: KeyboardEvent): void {
+    if (paused) return
     if (e.key === "ArrowLeft") rideTo(runnerCol - 1, false)
     else if (e.key === "ArrowRight") rideTo(runnerCol + 1, false)
     else if (e.key === " " || e.key === "Enter") {
@@ -900,6 +905,13 @@ export function mountBeam(el: HTMLElement, host: Host): { unmount(): void } {
   function frame(nowMs: number): void {
     if (!running) return
     raf = requestAnimationFrame(frame)
+    if (paused) {
+      // Nothing steps and nothing is drawn: the canvas holds its last frame,
+      // which is the right thing to have underneath whatever the host put on
+      // top. `last` still tracks so a resume cannot land one enormous frame.
+      last = nowMs
+      return
+    }
     const rawDt = Math.min(64, nowMs - last)
     last = nowMs
     // A tier change moves the render scale and the particle ceiling, and both
@@ -912,7 +924,32 @@ export function mountBeam(el: HTMLElement, host: Host): { unmount(): void } {
   }
   raf = requestAnimationFrame(frame)
 
+  function setPaused(on: boolean): void {
+    if (on === paused) return
+    paused = on
+    if (on) {
+      pausedAt = performance.now()
+      pointerDown = false
+      fireOnArrive = false
+      audio.setLock(220, 0.5, false)
+      audio.suspend()
+      return
+    }
+    // Every wall-clock mark moves forward by exactly the time the sheet was up.
+    // Without this the next `report` would carry the sheet's seconds as the
+    // child's thinking time, and the learner model would read a child who was
+    // shown nothing as a child who could not answer.
+    const held = performance.now() - pausedAt
+    waveAskedAt += held
+    overAt += held
+    lastTransitionAt += held
+    last = performance.now()
+    void audio.start()
+  }
+
   return {
+    setPaused,
+
     unmount(): void {
       running = false
       cancelAnimationFrame(raf)

--- a/dynawalla/games/beam/src/pack.ts
+++ b/dynawalla/games/beam/src/pack.ts
@@ -32,6 +32,18 @@ async function start(el: HTMLElement): Promise<void> {
 
   const handle = mount(el, mounted.host as unknown as Host)
 
+  // The host can put a sheet over a still-mounted pack — a purchase surface, a
+  // parent gate — and the call most likely to raise one is this game's own
+  // `transition()`. The answering window here IS the candidates' fall to the
+  // floor, so a wave left running behind a sheet expires against a child who
+  // was never shown it. The clock stops dead instead.
+  mounted.client.on("pause", () => {
+    handle.setPaused(true)
+  })
+  mounted.client.on("resume", () => {
+    handle.setPaused(false)
+  })
+
   // The host tells a pack before its port dies, so the rAF loop and the audio
   // context are torn down before the frame is, rather than a frame or two
   // after it.

--- a/dynawalla/games/beam/src/sim/field.ts
+++ b/dynawalla/games/beam/src/sim/field.ts
@@ -41,7 +41,6 @@ export type Automaton = {
   serial: number
   /** Set on a CORE the frame it fractures, so it fractures exactly once. */
   fractured: boolean
-  spawnedAt: number
 }
 
 const CAP = 40
@@ -63,7 +62,6 @@ function blank(): Automaton {
     correct: false,
     serial: 0,
     fractured: false,
-    spawnedAt: 0,
   }
 }
 

--- a/dynawalla/games/beam/src/test/loop.test.ts
+++ b/dynawalla/games/beam/src/test/loop.test.ts
@@ -268,6 +268,83 @@ test("a very small viewport is still a playable lattice", () => {
   }
 })
 
+test("PAUSE STOPS THE CLOCK: a wave cannot expire behind the host's sheet", () => {
+  // The failure this exists to make impossible: the host puts a sheet over a
+  // still-mounted pack — and the call most likely to raise one is this game's
+  // own `transition()` — while the candidates keep falling underneath it. The
+  // window closes, the item is reported wrong, and the child was never shown
+  // the question.
+  const surface = stubSurface(768, 1024, 0xba5e0, 12)
+  const restore = surface.install()
+  const reports: Report[] = []
+  const host = createStubHost({ seed: 0x9e11, reducedMotion: false, onReport: (r) => reports.push(r) })
+  const handle = mount(surface.el, host)
+  const step = surface.pump()
+  const press = (key: string): void => {
+    surface.keys.get("keydown")?.({ key, preventDefault: () => undefined })
+  }
+  try {
+    // Play until a wave is certainly in the air and at least one item has run.
+    for (let i = 0; i < 900; i++) {
+      step(16)
+      if (i % 5 === 0) press(" ")
+    }
+    assert.ok(reports.length > 0, "nothing was reported before the pause")
+    const before = reports.length
+
+    handle.setPaused(true)
+    // Three minutes behind the sheet, with the child mashing at it throughout.
+    for (let i = 0; i < 11_250; i++) {
+      step(16)
+      if (i % 5 === 0) press(" ")
+      if (i % 11 === 0) press("ArrowLeft")
+    }
+    assert.equal(reports.length, before, "an item was resolved while the game was paused")
+
+    handle.setPaused(false)
+    for (let i = 0; i < 3000; i++) {
+      step(16)
+      if (i % 5 === 0) press(" ")
+      if (i % 13 === 0) press("ArrowRight")
+    }
+    assert.ok(reports.length > before, "the game did not come back after the sheet lifted")
+  } finally {
+    handle.unmount()
+    restore()
+  }
+
+  // And the sheet's three minutes are not billed to the child. Every latency is
+  // bounded by the answering window, which is nowhere near a minute.
+  for (const r of reports) {
+    assert.ok(r.ms < 60_000, `a report carried ${r.ms}ms — the pause leaked into the latency`)
+  }
+})
+
+test("pausing twice is not two pauses, and resuming an unpaused game is nothing", () => {
+  const surface = stubSurface(768, 1024, 0x1d3, 12)
+  const restore = surface.install()
+  const reports: Report[] = []
+  const host = createStubHost({ seed: 0x1d3, reducedMotion: false, onReport: (r) => reports.push(r) })
+  const handle = mount(surface.el, host)
+  const step = surface.pump()
+  try {
+    handle.setPaused(false)
+    for (let i = 0; i < 600; i++) step(16)
+    handle.setPaused(true)
+    handle.setPaused(true)
+    const before = reports.length
+    for (let i = 0; i < 3000; i++) step(16)
+    assert.equal(reports.length, before)
+    handle.setPaused(false)
+    handle.setPaused(false)
+    for (let i = 0; i < 1200; i++) step(16)
+  } finally {
+    handle.unmount()
+    restore()
+  }
+  for (const r of reports) assert.ok(r.ms < 60_000)
+})
+
 test("a stalled tab that resumes does not teleport the lattice into the floor", () => {
   // A backgrounded tab hands the loop one enormous frame when it comes back.
   // The clamp has to swallow it, or every automaton on screen lands at once.


### PR DESCRIPTION
## What

Make LATTICE RUNNER stop its clock when the host puts a sheet over the frame.

## Why

This game is **entirely timed windows**. Candidates descend and a wave expires
whether or not anyone is looking.

The host can cover a still-mounted pack and send `pause` — and the call most
likely to raise that sheet is this game's own `transition()`. Unpaused, the
candidates keep falling underneath it: the window closes, the item is reported
**wrong**, and the child was never shown the question.

Same class as the truedraw fix in #592, and worse here, because in truedraw only
a *true* slate cost a shot — here **every single item is timed**, so every item
that passes behind the sheet is a miss recorded against the child.

Written after #591 merged and left uncommitted in a worktree when the agent
stalled. Recovered and verified rather than dropped.

## What it does

`setPaused` stops the frame loop, the fire path, and every input handler, and on
resume shifts each wall-clock mark forward by exactly the paused duration — so
the sheet's minutes are **not billed to the child's answer latency**. Pausing
twice is one pause; resuming an unpaused game is nothing.

Wired end to end: `pack.ts` subscribes to `pause`/`resume`. That is the half
that makes it real — the truedraw fix shipped its methods inert for exactly one
commit because nothing called them.

## Blast radius

**Areas touched:** dynawalla, one game — `dynawalla/games/beam/`. 5 files.

- [x] Scope: 0 files outside the game, 0 deletions.
- [x] Covered by `dynawalla-packs · games + pack build`.
- [x] **Unpaused play is unchanged.** Every guard is `if (paused)`; with no
      sheet the code paths are identical. The dev harness never pauses.
- [x] **Pack.** No manifest, capability, id or version change. Still builds,
      checks and stages.
- [x] **Curriculum.** No skill id, grade or generator touched. The latency
      correction makes `report.ms` *more* honest, which the adaptive engine
      consumes.
- [x] **Native / strings / secrets.** None. `gitleaks` → no leaks found.

## Proof

```
$ npm test        # in dynawalla/games/beam/, x3
# pass 76 # fail 0   <- 1
# pass 76 # fail 0   <- 2
# pass 76 # fail 0   <- 3

$ npm run tsc
0 errors

$ node dynawalla/packs/build.mjs beam
1 pack(s) built, checked and staged into src-tauri/packs/
```

**The test earns its keep — with a caveat worth reading.** With every pause
guard removed, the headless full-game test fails as it should:

```
not ok 54 - PAUSE STOPS THE CLOCK: a wave cannot expire behind the host's sheet
# pass 75
# fail 1
```

But disabling **only** the frame-loop guard was *not* enough to fail it: the
input guards still swallowed the presses, so no item resolved and the assertion
held. That first result would have read as a passing test over broken code. It
is the reason the verification here is "remove every guard" rather than "remove
the obvious one", and it is worth remembering the next time a pause test looks
green.
