### PR TITLE
dynawalla/games/counterweight: THE COUNTERWEIGHT — an arm-wrestle you win by one

### DIFF
--- a/dynawalla/games/counterweight/.gitignore
+++ b/dynawalla/games/counterweight/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+
+# The pack build. `packs/build.mjs` regenerates it and stages it into the app.
+dist-pack/
+
+# Capture scratch — screenshots and the tmp files the capture driver writes.
+qa/shots
+qa/tmp
+
+package-lock.json

--- a/dynawalla/games/counterweight/README.md
+++ b/dynawalla/games/counterweight/README.md
@@ -1,0 +1,139 @@
+# THE COUNTERWEIGHT
+
+> His pan carries the sum and never its total. Yours carries a number you steer
+> with place-value counterweights. Hold exactly one notch ahead.
+
+An arm-wrestle across a steelyard beam. Rank 30, S tier, in
+[`docs/catalog/ARCADE_CANON.md`](../../docs/catalog/ARCADE_CANON.md), after
+*Arm Wrestling* (1985). The canon entry calls it **the most unmashable design in
+the catalogue**, which is a claim about behaviour, so
+[`src/test/mash.test.ts`](src/test/mash.test.ts) settles it by playing rather
+than by arguing.
+
+## The loop
+
+The Iron Turk sits across the beam.
+
+**His pan** carries a column operation — `473 + 168`, drawn as a column, ruled
+underneath. Its total is never anywhere on the screen.
+
+**Your pan** carries a load, a numeral, and it stays where you left it between
+rounds.
+
+**The rack** is four pillars — thousands, hundreds, tens, ones — each with a face
+that hangs weight on and a face that takes it off. That is the entire input
+vocabulary. There is no keypad.
+
+**The rule is `load − his = 1`.** Not "somewhere above": one. That is what
+winning an arm-wrestle looks like — never comfortable, a hair in front — and it
+is what makes the answer exact instead of a range you could bracket by watching
+the beam lean.
+
+Strike **SEAT** and the beam is judged. One notch ahead and he gives ground; five
+lengths of ground and the Turk goes over. Anything else and he takes a length
+back.
+
+## Where the mathematics is
+
+Two column operations per round, both native, neither of them a question anybody
+asks out loud.
+
+1. **Evaluate his column.** `473 + 168` is 641, and nothing on the screen is
+   going to tell you.
+2. **Decompose the difference.** You are on 500 and you need 642, so the round is
+   asking for 142 — one hundred, four tens, two ones.
+
+And the thing a child works out for themselves, because the rack has a take-off
+face: **eight is not eight ones, it is ten less two**. Going from 613 to 621 the
+naive path is eight blows on the ones pillar; the short path is one on the tens
+and two off the ones. That is balanced base-ten notation, and
+[`game/places.ts`](src/game/places.ts) is simultaneously the optimal player and
+the definition of what the game is asking for.
+
+What crosses to the host is `load − 1`: the value the child's beam *asserted* his
+column to be. Play it right and that is the canonical value. Drop a carry and it
+is the mal-rule output — exactly — so the misconception routes itself with no
+extra wiring. The game never compares anything to an answer; the host judges.
+
+## Why mashing loses
+
+A steelyard is a bar of steel. Hang a weight on it and it rings, and a bar struck
+again while it is still ringing rings harder, because the second blow arrives in
+phase with the first. Keep that up and the steel does not get loud — it shears.
+
+So [`game/strain.ts`](src/game/strain.ts) charges every blow by **when it lands**.
+A blow after the ring has died costs 2. A blow straight on top of the last one
+costs 13. Strain bleeds out at 6 a second and the beam shears at 34.
+
+| Player | What happens |
+|---|---|
+| Hits everything as fast as a thumb moves | Shears in about a fifth of a second, every round, forever |
+| Hits one plate fast | Same |
+| Hits one plate slowly, under the resonance window | Never shears — and never gets anywhere either: the window is thirteen seconds, a pan only travels so far in ones, and nothing about walking it lands on the one notch |
+| Hunts by watching which way the beam leans | Every probe needs the beam to stop ringing first, and the window runs out |
+| Does the arithmetic | Ten deliberate blows, a quarter-second apart, peaks at about a third of the shear limit |
+
+That last row is the one that makes the rest mean anything, so
+`mash.test.ts` asserts it too: over twelve seeds a solver puts six or more Turks
+over and shears the beam never, while every masher, every hammer on every one of
+the eight faces, and the beam-watcher put over **zero**.
+
+Two more pressures keep the round live without being mashable:
+
+* **The clock.** The window closes and the beam is seated where it stands. The
+  whistle does not wait, and the load you had on the bar is the claim you made.
+* **The sag.** A pan nobody is tending settles — one unit, then another. You
+  cannot find the notch early and sit on it. Any strike re-seats it, so this only
+  ever bites a player who has stopped playing.
+
+## The beam
+
+[`sim/beam.ts`](src/sim/beam.ts) is a real spring and damper, and its resting
+angle is a *saturating* function of the margin: fine gradation within a few units
+of level, hard against its stop past that. So it confirms an answer and refuses
+to hand one over — there is no magnitude information out where a three-digit
+number lives.
+
+A bowed-metal drone tracks the tilt, so the beam is audible as well as visible
+and a child can hold the notch with their eyes on the rack. The plates are
+pitched by place: the ones plate is a bright tick, the thousands a low clang.
+Place value is a thing you can hear here.
+
+**Reduced motion is a branch, not a degradation.** The beam still moves, because
+the beam moving *is* the information; it is critically damped instead, so it
+travels to its reading and stops rather than ringing its way there. Same reading,
+same reach, same clock — every duration in `TIMING_REDUCED` is identical.
+
+## The arithmetic it is served
+
+The host serves from the curriculum's `add` domain — the only active one, seven
+live rows, all whole-number column addition and subtraction — and reveals the
+canonical value, which becomes the weight on his pan. `items.reveal` is
+load-bearing: without it the adapter drops every item and the pack serves nothing
+at all, silently.
+
+[`stubHost.ts`](src/stubHost.ts) is that runtime, offline: the same ladder, exact
+integer arithmetic throughout, and distractors that are real mal-rule outputs
+ported from
+[`malrules/columnOp.ts`](../../packs/shared/curriculum/src/malrules/columnOp.ts)
+with their `applies()` guards intact.
+
+## Being pinned
+
+Nothing is taken. The arm goes back to level and the same Turk squares up again,
+no harder than before — ADR-0009, stakes without loss. `transition` is called at
+exactly one place in this game, when a Turk goes over, and never anywhere near a
+defeat.
+
+## Running it
+
+```
+npm install
+npm run dev        # the standalone harness on :4327, stub host, no runtime needed
+npm test           # 78 cases: the rules, the strain, the beam, the mashers
+npm run tsc
+npm run build:pack # the installable pack
+```
+
+In the dev harness: `Q/A` ±1000, `W/S` ±100, `E/D` ±10, `R/F` ±1, space seats the
+beam, and `p` raises and lowers a sheet — the same call the host makes.

--- a/dynawalla/games/counterweight/index.html
+++ b/dynawalla/games/counterweight/index.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <title>THE COUNTERWEIGHT — dev harness</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #0a0b0e;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+      #readout {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 2;
+        padding: 4px 8px;
+        font: 500 11px/1.4 ui-monospace, monospace;
+        color: #6d7686;
+        background: rgba(10, 11, 14, 0.72);
+        pointer-events: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <!-- Dev only. The real pack entry is `pack.html`, which has no readout:
+         inside a host, the host draws the progress. -->
+    <div id="readout"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/counterweight/pack.html
+++ b/dynawalla/games/counterweight/pack.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#0a0b0e" />
+    <title>THE COUNTERWEIGHT</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #0a0b0e;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         The dev harness's readout is not here — it reported the stub host's
+         tally, and inside a real host the host draws the progress. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/counterweight/pack.json
+++ b/dynawalla/games/counterweight/pack.json
@@ -1,0 +1,24 @@
+{
+  "id": "dynawalla.counterweight",
+  "version": "0.1.0",
+  "name": "THE COUNTERWEIGHT",
+  "description": "An arm-wrestle across a steelyard beam. His pan carries a column sum and never its total; yours carries a number you steer with place-value counterweights. Hold exactly one notch ahead and seat the beam — but steel struck in a rhythm shears.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-multidigit",
+      "dw.add.regroup.add-short-addend",
+      "dw.add.regroup.subtract-short-subtrahend",
+      "dw.add.regroup.subtract-across-zero"
+    ],
+    "grades": [1, 4]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/counterweight/package.json
+++ b/dynawalla/games/counterweight/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@dynawalla/game-counterweight",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "THE COUNTERWEIGHT — a steelyard arm-wrestle against the Iron Turk. His pan carries a column sum you must evaluate; yours carries a number you steer with place-value counterweights. Hold one notch ahead.",
+  "engines": {
+    "node": ">=22.12"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4327 --strictPort",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
+    "build:pack": "vite build --config vite.pack.config.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^6.0.0",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/games/counterweight/src/audio.ts
+++ b/dynawalla/games/counterweight/src/audio.ts
@@ -1,0 +1,279 @@
+// Asset-free Web Audio. No files, no decode, nothing on the answer path.
+//
+// The one voice that matters is the **bowed drone**: a sawtooth through a
+// narrow band-pass, the note a heavy steel bar makes when it is under load.
+// Its pitch tracks the tilt of the beam — flat and low at dead level, rising as
+// your side goes down. So the beam is audible as well as visible, which is what
+// lets a child hold the notch with their eyes on the rack.
+//
+// It is deliberately quiet and deliberately narrow in range. A drone that swept
+// an octave would be a siren; this one moves about a major third across the
+// whole of the beam's travel, which is enough to hear and not enough to nag.
+//
+// The strikes are pitched **by place**: the ones plate is a small bright tick
+// and the thousands plate is a low, heavy clang. Place value is a thing you can
+// hear here, and a child working the rack learns the four voices before they
+// could tell you why.
+
+import type { Place } from "./game/places.ts"
+
+type Ctor = new () => AudioContext
+
+/** Where the drone sits at dead level, and how far the tilt moves it. */
+const DRONE_HZ = 116
+const DRONE_SPAN = 0.28
+
+const PLACE_HZ: Record<Place, number> = { 1: 1180, 10: 830, 100: 520, 1000: 288 }
+
+export class Audio {
+  private ctx: AudioContext | null = null
+  private master: GainNode | null = null
+  private droneOsc: OscillatorNode | null = null
+  private droneBand: BiquadFilterNode | null = null
+  private droneGain: GainNode | null = null
+  private failed = false
+
+  private context(): AudioContext | null {
+    if (this.ctx || this.failed) return this.ctx
+    const g = globalThis as unknown as { AudioContext?: Ctor; webkitAudioContext?: Ctor }
+    const Ctx = g.AudioContext ?? g.webkitAudioContext
+    if (!Ctx) {
+      this.failed = true
+      return null
+    }
+    try {
+      const ctx = new Ctx()
+      const master = ctx.createGain()
+      master.gain.value = 0.5
+      master.connect(ctx.destination)
+      this.ctx = ctx
+      this.master = master
+      return ctx
+    } catch (error) {
+      // Loud, never silent. A yard with no sound is playable; a yard that threw
+      // on the first tap and swallowed it is a bug nobody finds.
+      console.warn("[counterweight] no audio context", error)
+      this.failed = true
+      return null
+    }
+  }
+
+  /** Web Audio needs a gesture. The first strike is the first gesture there is. */
+  resume(): void {
+    const ctx = this.context()
+    if (!ctx) return
+    if (ctx.state !== "suspended") return
+    void ctx.resume().catch((error: unknown) => {
+      // Loud, never silent. This runs at most once a session — after the first
+      // gesture the context is running — so a warning here is a real signal that
+      // the yard is about to be played in silence, not noise.
+      console.warn("[counterweight] the audio context would not resume", error)
+    })
+  }
+
+  /** Bring the drone up. Called when a window opens. */
+  bow(): void {
+    const ctx = this.context()
+    if (!ctx || !this.master || this.droneOsc) return
+    const osc = ctx.createOscillator()
+    osc.type = "sawtooth"
+    osc.frequency.value = DRONE_HZ
+    const band = ctx.createBiquadFilter()
+    band.type = "bandpass"
+    band.frequency.value = DRONE_HZ * 3
+    band.Q.value = 5.5
+    const gain = ctx.createGain()
+    gain.gain.value = 0
+    gain.gain.linearRampToValueAtTime(0.075, ctx.currentTime + 0.5)
+    osc.connect(band)
+    band.connect(gain)
+    gain.connect(this.master)
+    osc.start()
+    this.droneOsc = osc
+    this.droneBand = band
+    this.droneGain = gain
+  }
+
+  /**
+   * The drone follows the beam.
+   *
+   * `tilt` is −1..1 and `ring` is 0..1: a beam still travelling opens the filter
+   * so the note goes bright and unsettled, and a beam that has come to rest
+   * closes it back down. That is the settle cue, and it arrives before the eye
+   * gets there.
+   */
+  track(tilt: number, ring: number): void {
+    const ctx = this.ctx
+    if (!ctx || !this.droneOsc || !this.droneBand || !this.droneGain) return
+    const t = ctx.currentTime
+    const clamped = Math.max(-1, Math.min(1, tilt))
+    const hz = DRONE_HZ * (1 + clamped * DRONE_SPAN)
+    this.droneOsc.frequency.setTargetAtTime(hz, t, 0.06)
+    this.droneBand.frequency.setTargetAtTime(hz * (2.4 + ring * 4.5), t, 0.05)
+    this.droneGain.gain.setTargetAtTime(0.06 + ring * 0.045, t, 0.08)
+  }
+
+  /** Stop bowing. */
+  release(): void {
+    const ctx = this.ctx
+    const osc = this.droneOsc
+    const gain = this.droneGain
+    if (!ctx || !osc || !gain) return
+    this.droneOsc = null
+    this.droneBand = null
+    this.droneGain = null
+    const t = ctx.currentTime
+    gain.gain.cancelScheduledValues(t)
+    gain.gain.setTargetAtTime(0, t, 0.09)
+    try {
+      osc.stop(t + 0.5)
+    } catch {
+      console.warn("[counterweight] the drone would not stop")
+    }
+  }
+
+  /** A plate lands. Pitched by place; harder blows bite harder. */
+  clang(place: Place, impulse: number): void {
+    const ctx = this.context()
+    if (!ctx || !this.master) return
+    const t = ctx.currentTime
+    const hz = PLACE_HZ[place]
+    const bite = Math.max(0, Math.min(1, (impulse - 2) / 9))
+
+    const osc = ctx.createOscillator()
+    osc.type = "triangle"
+    osc.frequency.setValueAtTime(hz * (1.3 + bite * 0.4), t)
+    osc.frequency.exponentialRampToValueAtTime(hz, t + 0.05)
+    const gain = ctx.createGain()
+    gain.gain.setValueAtTime(0.0001, t)
+    gain.gain.exponentialRampToValueAtTime(0.16 + bite * 0.12, t + 0.006)
+    gain.gain.exponentialRampToValueAtTime(0.0001, t + 0.22 + bite * 0.2)
+    osc.connect(gain)
+    gain.connect(this.master)
+    osc.start(t)
+    osc.stop(t + 0.5)
+
+    // The metallic edge: a short burst through a high band-pass. A resonant blow
+    // gets more of it, so mashing sounds like what it is.
+    const noise = ctx.createOscillator()
+    noise.type = "square"
+    noise.frequency.setValueAtTime(hz * 3.7, t)
+    const band = ctx.createBiquadFilter()
+    band.type = "bandpass"
+    band.frequency.value = hz * 3.4
+    band.Q.value = 2.2
+    const edge = ctx.createGain()
+    edge.gain.setValueAtTime(0.0001, t)
+    edge.gain.exponentialRampToValueAtTime(0.02 + bite * 0.07, t + 0.004)
+    edge.gain.exponentialRampToValueAtTime(0.0001, t + 0.09)
+    noise.connect(band)
+    band.connect(edge)
+    edge.connect(this.master)
+    noise.start(t)
+    noise.stop(t + 0.15)
+  }
+
+  /** A refused strike: the plate is still swinging. A dead, unmusical thud. */
+  refuse(): void {
+    const ctx = this.context()
+    if (!ctx || !this.master) return
+    const t = ctx.currentTime
+    const osc = ctx.createOscillator()
+    osc.type = "sine"
+    osc.frequency.setValueAtTime(88, t)
+    const gain = ctx.createGain()
+    gain.gain.setValueAtTime(0.0001, t)
+    gain.gain.exponentialRampToValueAtTime(0.05, t + 0.005)
+    gain.gain.exponentialRampToValueAtTime(0.0001, t + 0.07)
+    osc.connect(gain)
+    gain.connect(this.master)
+    osc.start(t)
+    osc.stop(t + 0.12)
+  }
+
+  /** The pan settles a unit on its own. A tiny descending tick. */
+  sag(): void {
+    const ctx = this.context()
+    if (!ctx || !this.master) return
+    const t = ctx.currentTime
+    const osc = ctx.createOscillator()
+    osc.type = "sine"
+    osc.frequency.setValueAtTime(420, t)
+    osc.frequency.exponentialRampToValueAtTime(300, t + 0.1)
+    const gain = ctx.createGain()
+    gain.gain.setValueAtTime(0.0001, t)
+    gain.gain.exponentialRampToValueAtTime(0.035, t + 0.01)
+    gain.gain.exponentialRampToValueAtTime(0.0001, t + 0.14)
+    osc.connect(gain)
+    gain.connect(this.master)
+    osc.start(t)
+    osc.stop(t + 0.2)
+  }
+
+  /** The beam seats true: a cold, clean fifth. The best sound in the game. */
+  held(): void {
+    this.chord([784, 1176], 0.1, 0.5)
+  }
+
+  /** He takes ground. Low, short, not cruel. */
+  lost(): void {
+    this.chord([196, 233], 0.085, 0.32)
+  }
+
+  /** The steel lets go. */
+  shear(): void {
+    const ctx = this.context()
+    if (!ctx || !this.master) return
+    const t = ctx.currentTime
+    const osc = ctx.createOscillator()
+    osc.type = "sawtooth"
+    osc.frequency.setValueAtTime(760, t)
+    osc.frequency.exponentialRampToValueAtTime(74, t + 0.42)
+    const gain = ctx.createGain()
+    gain.gain.setValueAtTime(0.0001, t)
+    gain.gain.exponentialRampToValueAtTime(0.19, t + 0.008)
+    gain.gain.exponentialRampToValueAtTime(0.0001, t + 0.6)
+    osc.connect(gain)
+    gain.connect(this.master)
+    osc.start(t)
+    osc.stop(t + 0.7)
+  }
+
+  /** A Turk goes over. */
+  fanfare(): void {
+    this.chord([523, 659, 784], 0.09, 0.85)
+    const ctx = this.ctx
+    if (!ctx) return
+    globalThis.setTimeout(() => this.chord([659, 784, 1046], 0.085, 0.9), 190)
+  }
+
+  private chord(hz: readonly number[], peak: number, seconds: number): void {
+    const ctx = this.context()
+    if (!ctx || !this.master) return
+    const t = ctx.currentTime
+    for (const f of hz) {
+      const osc = ctx.createOscillator()
+      osc.type = "sine"
+      osc.frequency.value = f
+      const gain = ctx.createGain()
+      gain.gain.setValueAtTime(0.0001, t)
+      gain.gain.exponentialRampToValueAtTime(peak / hz.length + 0.001, t + 0.012)
+      gain.gain.exponentialRampToValueAtTime(0.0001, t + seconds)
+      osc.connect(gain)
+      gain.connect(this.master)
+      osc.start(t)
+      osc.stop(t + seconds + 0.1)
+    }
+  }
+
+  dispose(): void {
+    this.release()
+    const ctx = this.ctx
+    this.ctx = null
+    this.master = null
+    if (!ctx) return
+    void ctx.close().catch(() => {
+      console.warn("[counterweight] the audio context would not close")
+    })
+  }
+}

--- a/dynawalla/games/counterweight/src/contract.ts
+++ b/dynawalla/games/counterweight/src/contract.ts
@@ -1,0 +1,56 @@
+// The host↔game contract. This is the shape the runtime lands underneath us;
+// it must not drift. Nothing else in this package may redefine these types.
+//
+// `mount` delegates to `./mount.ts`. That module imports `Host` from here
+// type-only, and a type-only import is erased, so there is no runtime cycle.
+
+import { mountCounterweight } from "./mount.ts"
+
+export type Question = {
+  id: string
+  prompt: string
+  answer: string
+  distractors: string[]
+  domain: string
+  difficulty: number
+}
+
+export type Host = {
+  next(opts?: { domain?: string; difficulty?: number }): Question
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+  haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void
+  prefersReducedMotion(): boolean
+
+  /**
+   * A natural stopping point the child *reached*: a level cleared, a run
+   * completed, a boss down.
+   *
+   * OPTIONAL and feature-detected — a stub host does not implement it and the
+   * game must not care. Fire and forget: nothing is returned, nothing may be
+   * awaited, and the game must not branch on it.
+   *
+   * **Never after a failure.** Here that means exactly one call site: the Turk
+   * going over. Being pinned yourself is not a stopping point, and a purchase
+   * surface next to a defeat is forbidden outright.
+   */
+  transition?(kind: "level" | "run" | "boss", label?: string): void
+}
+
+/**
+ * The handle `mount` returns.
+ *
+ * `pause` and `resume` are not optional decoration. The host can drop a sheet
+ * over a still-mounted, still-running pack — a transition surface, a parent
+ * gate — and this game's round is a clock with a verdict at the end of it. A
+ * window that opened and closed behind a sheet would seat the beam wherever it
+ * happened to stand and mark the child wrong for a sum they were never shown.
+ */
+export type Handle = {
+  unmount(): void
+  pause(): void
+  resume(): void
+}
+
+export function mount(el: HTMLElement, host: Host): Handle {
+  return mountCounterweight(el, host)
+}

--- a/dynawalla/games/counterweight/src/core/rng.ts
+++ b/dynawalla/games/counterweight/src/core/rng.ts
@@ -1,0 +1,57 @@
+// A seeded, deterministic PRNG. Every stochastic decision in the match and in
+// the stub host runs through one of these, so a bout can be replayed exactly —
+// which is what makes "no mashing strategy wins this" a testable claim rather
+// than an opinion.
+//
+// mulberry32: 32-bit state, no allocation, and trivially portable to a test.
+
+export class Rng {
+  private s: number
+
+  constructor(seed: number) {
+    // Force to uint32; a 0 seed is legal for mulberry32 but degenerate-looking,
+    // so nudge it off zero.
+    this.s = (seed >>> 0) || 0x9e3779b9
+  }
+
+  /** Uniform in [0, 1). */
+  next(): number {
+    this.s = (this.s + 0x6d2b79f5) >>> 0
+    let t = this.s
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+
+  /** Uniform in [lo, hi). */
+  range(lo: number, hi: number): number {
+    return lo + this.next() * (hi - lo)
+  }
+
+  /** Uniform integer in [lo, hi] inclusive. */
+  int(lo: number, hi: number): number {
+    if (hi <= lo) return lo
+    return lo + Math.floor(this.next() * (hi - lo + 1))
+  }
+
+  /** True with probability p. */
+  chance(p: number): boolean {
+    return this.next() < p
+  }
+
+  pick<T>(xs: readonly T[]): T {
+    if (xs.length === 0) throw new Error("rng.pick: empty")
+    return xs[Math.floor(this.next() * xs.length)] as T
+  }
+
+  /** In-place Fisher–Yates. Returns the same array for chaining. */
+  shuffle<T>(xs: T[]): T[] {
+    for (let i = xs.length - 1; i > 0; i--) {
+      const j = Math.floor(this.next() * (i + 1))
+      const a = xs[i] as T
+      xs[i] = xs[j] as T
+      xs[j] = a
+    }
+    return xs
+  }
+}

--- a/dynawalla/games/counterweight/src/game/best.ts
+++ b/dynawalla/games/counterweight/src/game/best.ts
@@ -1,0 +1,90 @@
+// The tally, across sessions.
+//
+// **`localStorage` is unreachable inside a pack frame.** The document sits on an
+// opaque origin, so every property access on it throws rather than returning
+// null — which is why the in-memory mirror below is not a cache but the actual
+// source of truth for the running session. A game that trusted the read would
+// show a fresh tally on every seat, forever, on the only surface that matters.
+//
+// Nothing here can go backwards: `record` keeps the maximum it has ever seen.
+// Being pinned costs the arm, never the tally.
+
+// The storage slot, versioned so a schema change orphans an old record rather
+// than mis-reading it. `gitleaks:allow` because the pinned scanner's
+// `generic-api-key` rule reads `<NAME> = "<long dotted string>"` as a
+// credential. It is a storage path, it is on the client, and this repository is
+// public on purpose.
+const TALLY_SLOT = "dynawalla.counterweight.tally.v1" // gitleaks:allow
+
+export type Tally = {
+  /** Turks put over, ever. */
+  readonly turks: number
+  /** The longest run of rounds seated true in one bout, ever. */
+  readonly hold: number
+}
+
+const memory = { turks: 0, hold: 0 }
+let loaded = false
+
+function storage(): Storage | null {
+  try {
+    const s = globalThis.localStorage
+    // Touching the object is not enough — an opaque origin throws on access to
+    // the property itself in some engines and on the first read in others, so
+    // the probe has to be a real read.
+    s.getItem(TALLY_SLOT)
+    return s
+  } catch {
+    // **The one deliberate silence in this package.** Inside a pack frame this
+    // throw is not an error, it is the normal state of the world, and it would
+    // fire on every launch on every device. Everything past the probe — a record
+    // that will not parse, a write that is refused — is logged loudly below.
+    return null
+  }
+}
+
+export function loadTally(): Tally {
+  if (loaded) return { ...memory }
+  loaded = true
+  const s = storage()
+  if (!s) return { ...memory }
+  try {
+    const raw = s.getItem(TALLY_SLOT)
+    if (!raw) return { ...memory }
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== "object" || parsed === null) return { ...memory }
+    const rec = parsed as Partial<Tally>
+    if (Number.isInteger(rec.turks) && (rec.turks as number) > memory.turks) {
+      memory.turks = rec.turks as number
+    }
+    if (Number.isInteger(rec.hold) && (rec.hold as number) > memory.hold) {
+      memory.hold = rec.hold as number
+    }
+  } catch (error) {
+    // Loud, never silent: a record that will not parse is a bug worth seeing.
+    console.warn("[counterweight] the tally could not be read", error)
+  }
+  return { ...memory }
+}
+
+/** Record a session's totals. Monotone — nothing here can take a Turk back. */
+export function recordTally(turks: number, hold: number): Tally {
+  if (Number.isInteger(turks) && turks > memory.turks) memory.turks = turks
+  if (Number.isInteger(hold) && hold > memory.hold) memory.hold = hold
+  const s = storage()
+  if (s) {
+    try {
+      s.setItem(TALLY_SLOT, JSON.stringify(memory))
+    } catch (error) {
+      console.warn("[counterweight] the tally could not be written", error)
+    }
+  }
+  return { ...memory }
+}
+
+/** Tests only: drop the in-memory mirror so each case starts clean. */
+export function resetTallyForTest(): void {
+  memory.turks = 0
+  memory.hold = 0
+  loaded = false
+}

--- a/dynawalla/games/counterweight/src/game/bout.ts
+++ b/dynawalla/games/counterweight/src/game/bout.ts
@@ -1,0 +1,430 @@
+// THE COUNTERWEIGHT — the rules.
+//
+// A steelyard beam between you and the Iron Turk.
+//
+//   * **His pan carries a column sum** — `473 + 168`, drawn as a column and
+//     never as a total. The number is there; nobody is going to write it down
+//     for you.
+//   * **Your pan carries a load**, a numeral, and it stays where you left it
+//     between rounds. You move it by striking place-value counterweights.
+//   * **You must hold exactly one notch ahead.** `load − his = 1`. Not
+//     "somewhere above": one. That is what winning an arm-wrestle looks like —
+//     never comfortable, a hair in front — and it is what makes the answer exact
+//     rather than a range you can bracket by watching the beam.
+//   * Strike **SEAT** and the beam is judged. One notch ahead and he gives
+//     ground. Anything else and he takes it.
+//
+// Three pressures keep it live, and none of them is a mash:
+//
+//   1. **The clock.** The round has a window; when it runs out the beam is
+//      seated where it stands. The whistle does not wait.
+//   2. **The sag.** Leave the beam alone and your pan settles — one unit, then
+//      another. You cannot find the notch early and sit on it. Any strike
+//      re-seats the pan and the sag starts over, so this only bites a player who
+//      has stopped playing.
+//   3. **The strain.** Every strike rings the steel and strain does not bleed
+//      out as fast as a mash puts it in. See `strain.ts` — that module is the
+//      answer to "what stops a child hitting plates fast".
+//
+// What crosses to the host is `load − 1`: the value the child's beam asserts his
+// column sum to be. Get the sum right and it is the canonical value. Drop a
+// carry and it is the mal-rule output, exactly, so the diagnosis routes with no
+// extra wiring — the game never compares anything to an answer.
+
+import type { Question } from "../contract.ts"
+import { applyStrike, PILLAR_COOLDOWN_MS, type Place, type Strike } from "./places.ts"
+import { Strain } from "./strain.ts"
+
+/** How far the arm travels before somebody is over. */
+export const GROUND = 5
+
+export type Phase =
+  /** The weight is coming down on his pan. The beam lurches; input is dead. */
+  | "hang"
+  /** The window. Strike plates, read the beam, seat when you believe it. */
+  | "press"
+  /** The verdict is showing. */
+  | "settle"
+
+export type Verdict = "true" | "short" | "over" | "shear"
+
+export type Timing = {
+  /** The weight coming down. */
+  readonly hangMs: number
+  /** The window to find the notch and seat it. */
+  readonly pressMs: number
+  /** The verdict beat. */
+  readonly settleMs: number
+  /** Quiet time before the pan starts to settle. */
+  readonly sagGraceMs: number
+  /** How long each further unit of sag takes. */
+  readonly sagPeriodMs: number
+  /** Strain at which the steel shears. */
+  readonly shearAt: number
+}
+
+export const TIMING: Timing = {
+  hangMs: 760,
+  pressMs: 13000,
+  settleMs: 1150,
+  sagGraceMs: 1500,
+  sagPeriodMs: 1300,
+  shearAt: 34,
+}
+
+/**
+ * Reduced motion is a branch, not a degradation, and a clock is not motion.
+ * Every duration here is identical to the one above; what changes is in
+ * `sim/beam.ts`, where the beam travels to its reading instead of ringing its
+ * way there. Nobody gets less time for asking for a calmer screen.
+ */
+export const TIMING_REDUCED: Timing = TIMING
+
+/**
+ * The Turk gets stronger. Never by making the arithmetic unfair — the host owns
+ * the ladder — but by shortening the window, tightening the steel and grinding
+ * harder.
+ */
+export function timingForBout(bout: number, base: Timing = TIMING): Timing {
+  const step = Math.max(0, bout - 1)
+  return {
+    hangMs: base.hangMs,
+    pressMs: Math.max(7600, base.pressMs - step * 1100),
+    settleMs: base.settleMs,
+    sagGraceMs: Math.max(900, base.sagGraceMs - step * 120),
+    sagPeriodMs: Math.max(750, base.sagPeriodMs - step * 110),
+    shearAt: Math.max(24, base.shearAt - step * 2),
+  }
+}
+
+export type Match = {
+  /** Which Turk, one-based. */
+  bout: number
+  /** −GROUND (you are over) … +GROUND (he is over). */
+  arm: number
+  /** Turks put over, this session. */
+  won: number
+  /** Rounds seated exactly true, this session. */
+  held: number
+}
+
+export type Seat = {
+  readonly question: Question
+  readonly verdict: Verdict
+  /** The load on your pan at the moment of judgement. */
+  readonly load: number
+  /** The value the beam asserted his column to be: `load − 1`. */
+  readonly asserted: number
+  /** Milliseconds from the window opening to the seat. */
+  readonly ms: number
+  /** True when the child struck SEAT rather than running out of window. */
+  readonly declared: boolean
+}
+
+export type BoutEvent =
+  | { kind: "hang"; question: Question; delta: number }
+  | { kind: "open" }
+  | { kind: "strike"; strike: Strike; load: number; impulse: number }
+  | { kind: "refused"; reason: "cooldown" | "phase" }
+  | { kind: "sag"; load: number }
+  | { kind: "seat"; seat: Seat; arm: number }
+  | { kind: "won"; bout: number }
+  | { kind: "pinned"; bout: number }
+
+/**
+ * Where the first pan of a session starts.
+ *
+ * Deliberately not the answer and deliberately not zero: a handful of strikes
+ * away, on a value with the same shape, rounded to a round number so the
+ * opening move is legible. The child's first act is to see that they are, say,
+ * 142 light.
+ */
+export function openingLoad(target: number): number {
+  const grain = target >= 1000 ? 1000 : target >= 100 ? 100 : 10
+  const base = Math.round(target / grain) * grain
+  return Math.max(grain, base - grain)
+}
+
+/**
+ * The state machine. Pure: it is handed a `deal()` and told how much time
+ * passed, and it hands back events. It touches no canvas, no audio and no host.
+ */
+export class Bout {
+  private readonly deal: () => Question
+  private readonly base: Timing
+  private phaseName: Phase = "hang"
+  private elapsed = 0
+  private duration: number
+  private state: Match = { bout: 1, arm: 0, won: 0, held: 0 }
+  private current: Question | null = null
+  private target = 0
+  private loadValue = 0
+  private lastSeat: Seat | null = null
+  private strainMeter: Strain
+  private timing: Timing
+  private readonly cooldowns = new Map<Place, number>()
+  private sagIdleMs = 0
+  private stopped = false
+  private started = false
+  private seeded = false
+
+  constructor(deal: () => Question, base: Timing = TIMING) {
+    this.deal = deal
+    this.base = base
+    this.timing = timingForBout(1, this.base)
+    this.strainMeter = new Strain({ shearAt: this.timing.shearAt })
+    this.duration = this.timing.hangMs
+  }
+
+  get phase(): Phase {
+    return this.phaseName
+  }
+
+  get match(): Match {
+    return this.state
+  }
+
+  get question(): Question | null {
+    return this.current
+  }
+
+  /** His column's value. Known to the game, never drawn. */
+  get his(): number {
+    return this.target
+  }
+
+  /** Your pan. */
+  get load(): number {
+    return this.loadValue
+  }
+
+  /** `load − his`. Zero is dead level; the game wants exactly 1. */
+  get margin(): number {
+    return this.loadValue - this.target
+  }
+
+  get strain(): Strain {
+    return this.strainMeter
+  }
+
+  /** The verdict currently on the beam, if one is showing. */
+  get seat(): Seat | null {
+    return this.phaseName === "settle" ? this.lastSeat : null
+  }
+
+  get paused(): boolean {
+    return this.stopped
+  }
+
+  get elapsedMs(): number {
+    return this.elapsed
+  }
+
+  /** 0..1 through the current phase. The renderer's only clock. */
+  get progress(): number {
+    return this.duration <= 0 ? 1 : Math.max(0, Math.min(1, this.elapsed / this.duration))
+  }
+
+  get timings(): Timing {
+    return this.timing
+  }
+
+  /** Whether this pillar is still swinging back. */
+  cooling(place: Place): boolean {
+    return (this.cooldowns.get(place) ?? 0) > 0
+  }
+
+  /**
+   * The host has put something over the frame. **The clock stops dead.**
+   *
+   * This game calls `transition` every time a Turk goes over, and the SDK
+   * documents that a transition may raise a sheet while leaving the pack
+   * mounted and its rAF running. Without this the press window would open and
+   * close behind that sheet, seat the beam wherever it stood, and mark the child
+   * wrong for a column they were never shown — while taking ground off them for
+   * it. A reward that costs the match is the worst bug this game could have.
+   */
+  pause(): void {
+    this.stopped = true
+  }
+
+  resume(): void {
+    this.stopped = false
+  }
+
+  /** Deal the first weight. Legal once. */
+  begin(): BoutEvent[] {
+    if (this.started) return []
+    this.started = true
+    return this.hang()
+  }
+
+  /**
+   * Time passes. Returns everything that happened in it.
+   *
+   * A paused bout consumes nothing — not the window, not the sag, not the
+   * strain bleed. Time behind a sheet is not the child's time.
+   */
+  advance(dtMs: number): BoutEvent[] {
+    if (this.stopped || dtMs <= 0 || !this.started) return []
+    const events: BoutEvent[] = []
+    let left = dtMs
+    // Chunked so a long frame cannot skip a phase boundary or a sag tick.
+    while (left > 0) {
+      const step = Math.min(left, 40)
+      left -= step
+      events.push(...this.step(step))
+    }
+    return events
+  }
+
+  /**
+   * Strike a face on the rack.
+   *
+   * Refused outside the window and refused while that pillar is still swinging
+   * back. Every accepted strike moves the pan by exactly the place's value and
+   * puts strain into the steel — and if that strain reaches the shear limit, the
+   * round ends on the blow that broke it.
+   */
+  strike(strike: Strike): BoutEvent[] {
+    if (this.stopped || this.phaseName !== "press") return [{ kind: "refused", reason: "phase" }]
+    if (this.cooling(strike.place)) return [{ kind: "refused", reason: "cooldown" }]
+
+    this.cooldowns.set(strike.place, PILLAR_COOLDOWN_MS)
+    const impulse = this.strainMeter.strike()
+    this.loadValue = applyStrike(this.loadValue, strike)
+    this.sagIdleMs = 0
+    const events: BoutEvent[] = [{ kind: "strike", strike, load: this.loadValue, impulse }]
+    if (this.strainMeter.isSheared) events.push(...this.judge(false, "shear"))
+    return events
+  }
+
+  /** Strike SEAT: judge the beam now. */
+  seatNow(): BoutEvent[] {
+    if (this.stopped || this.phaseName !== "press") return [{ kind: "refused", reason: "phase" }]
+    return this.judge(true)
+  }
+
+  private step(dt: number): BoutEvent[] {
+    const events: BoutEvent[] = []
+    for (const [place, left] of this.cooldowns) {
+      const next = left - dt
+      if (next <= 0) this.cooldowns.delete(place)
+      else this.cooldowns.set(place, next)
+    }
+
+    if (this.phaseName === "press") {
+      this.strainMeter.advance(dt)
+      // The pan settles under a load nobody is tending.
+      this.sagIdleMs += dt
+      while (this.sagIdleMs >= this.timing.sagGraceMs + this.timing.sagPeriodMs) {
+        this.sagIdleMs -= this.timing.sagPeriodMs
+        this.loadValue -= 1
+        events.push({ kind: "sag", load: this.loadValue })
+      }
+    }
+
+    this.elapsed += dt
+    if (this.elapsed < this.duration) return events
+
+    // Carried across the boundary, so a chunked frame does not quietly shave a
+    // few milliseconds off every phase it crosses.
+    const over = this.elapsed - this.duration
+    switch (this.phaseName) {
+      case "hang": {
+        this.enter("press", this.timing.pressMs)
+        this.sagIdleMs = 0
+        events.push({ kind: "open" })
+        break
+      }
+      case "press": {
+        // The whistle. The beam is judged where it stands — which is honest:
+        // that load is the claim the child had on the bar when time ran out.
+        events.push(...this.judge(false))
+        break
+      }
+      case "settle": {
+        if (this.state.arm >= GROUND) {
+          const bout = this.state.bout
+          this.state.won += 1
+          this.state.bout += 1
+          this.state.arm = 0
+          this.timing = timingForBout(this.state.bout, this.base)
+          events.push({ kind: "won", bout })
+        } else if (this.state.arm <= -GROUND) {
+          // Pinned. The Turk does not get stronger for it and nothing is taken
+          // away: the arm goes back to level and the same one squares up again.
+          // Stakes without loss — ADR-0009.
+          this.state.arm = 0
+          events.push({ kind: "pinned", bout: this.state.bout })
+        }
+        events.push(...this.hang())
+        break
+      }
+      default:
+        break
+    }
+    this.elapsed = Math.min(over, this.duration)
+    return events
+  }
+
+  private hang(): BoutEvent[] {
+    const question = this.deal()
+    this.current = question
+    const answer = Number(question.answer)
+    if (!Number.isInteger(answer)) {
+      // A host that served something this game cannot weigh. Loud, never
+      // silent: a pan with no number on it is a round nobody can win.
+      console.error("[counterweight] a question arrived with a non-integer answer", question.answer)
+    }
+    this.target = Number.isInteger(answer) ? answer : 0
+    // The very first weight of the session lands on an empty pan. Give it a
+    // start within striking distance so the first round is arithmetic rather
+    // than a hundred blows on the thousands pillar.
+    //
+    // Flagged rather than tested against a load of zero: a player who happens to
+    // drive their pan down to nothing would otherwise be handed a free reset
+    // onto the next weight, which is a rule nobody was told about and a way to
+    // dodge a round you had already lost.
+    if (!this.seeded) {
+      this.seeded = true
+      this.loadValue = openingLoad(this.target)
+    }
+    this.strainMeter = new Strain({ shearAt: this.timing.shearAt })
+    this.sagIdleMs = 0
+    this.enter("hang", this.timing.hangMs)
+    return [{ kind: "hang", question, delta: this.target + 1 - this.loadValue }]
+  }
+
+  private judge(declared: boolean, forced?: "shear"): BoutEvent[] {
+    const question = this.current
+    if (!question) return []
+    const margin = this.margin
+    const verdict: Verdict =
+      forced === "shear" ? "shear" : margin === 1 ? "true" : margin < 1 ? "short" : "over"
+    const seat: Seat = {
+      question,
+      verdict,
+      load: this.loadValue,
+      asserted: this.loadValue - 1,
+      ms: Math.max(0, Math.round(this.elapsed)),
+      declared,
+    }
+    this.lastSeat = seat
+    // Ground moves by one either way. An arm-wrestle is a tug, not a scoreline.
+    if (verdict === "true") {
+      this.state.arm = Math.min(GROUND, this.state.arm + 1)
+      this.state.held += 1
+    } else {
+      this.state.arm = Math.max(-GROUND, this.state.arm - 1)
+    }
+    this.enter("settle", this.timing.settleMs)
+    return [{ kind: "seat", seat, arm: this.state.arm }]
+  }
+
+  private enter(phase: Phase, duration: number): void {
+    this.phaseName = phase
+    this.elapsed = 0
+    this.duration = duration
+  }
+}

--- a/dynawalla/games/counterweight/src/game/column.ts
+++ b/dynawalla/games/counterweight/src/game/column.ts
@@ -1,0 +1,30 @@
+// The prompt, split back into the column the Turk's pan has to draw.
+//
+// The host hands over a display string — `"473 + 168"` — and the column is this
+// game's own presentation of it, because lining the places up is the thing the
+// `dw.add.column.*` rows are named for and a single line hides it.
+//
+// Anything that will not split is drawn on one line rather than dropped. A pan
+// with nothing on it is the one state that must never happen: it is a round the
+// child cannot win and cannot see why.
+
+export type Column = {
+  readonly top: string
+  readonly glyph: string
+  readonly bottom: string
+}
+
+const SHAPE = /^\s*([\d ,. ]*\d)\s*([+\-−–])\s*([\d ,. ]*\d)\s*$/
+
+export function splitPrompt(prompt: string): Column | null {
+  const match = SHAPE.exec(prompt)
+  if (!match) return null
+  const [, top, glyph, bottom] = match
+  if (!top || !glyph || !bottom) return null
+  return {
+    top: top.trim(),
+    // One minus sign, whatever the host sent.
+    glyph: glyph === "+" ? "+" : "−",
+    bottom: bottom.trim(),
+  }
+}

--- a/dynawalla/games/counterweight/src/game/places.ts
+++ b/dynawalla/games/counterweight/src/game/places.ts
@@ -1,0 +1,106 @@
+// The rack: four pillars of counterweights, one per decimal place, each with a
+// face that hangs weight on and a face that takes it off.
+//
+// This is the whole input vocabulary of the game. There is no keypad and no
+// numeral entry: your pan's load is moved by striking a place, which is why the
+// shortest way to any load is its **balanced place-value decomposition**. The
+// mathematics is not decoration on top of the controls — it *is* the control
+// scheme, and `planStrikes` below is simultaneously the optimal player and the
+// definition of what the child is being asked to do.
+//
+// Everything here is integer. A load, a delta and a strike count are counts of
+// whole units; nothing in this file produces or compares a float.
+
+/** Decimal places, heaviest first — the order the pillars stand in. */
+export const PLACES = [1000, 100, 10, 1] as const
+
+export type Place = (typeof PLACES)[number]
+
+/** Which way a face moves the pan. */
+export type Direction = 1 | -1
+
+export type Strike = {
+  readonly place: Place
+  readonly dir: Direction
+}
+
+/** How far one strike on this face moves the load. Always exact. */
+export function strikeValue(strike: Strike): number {
+  return strike.place * strike.dir
+}
+
+export function applyStrike(load: number, strike: Strike): number {
+  return load + strikeValue(strike)
+}
+
+export function applyAll(load: number, strikes: readonly Strike[]): number {
+  let out = load
+  for (const strike of strikes) out = applyStrike(out, strike)
+  return out
+}
+
+/**
+ * The shortest sequence of strikes that moves a pan by exactly `delta`.
+ *
+ * The trick a child works out for themselves, and the reason the rack has a
+ * take-off face at all: **eight is not eight ones, it is ten less two**. Going
+ * from 613 to 621 the naive path is eight strikes on the ones pillar; the short
+ * path is one on the tens and two off the ones. That is balanced base-ten
+ * notation — digits in −5..5 — and it is the game's core insight, discoverable
+ * from the rack without anyone explaining it.
+ *
+ * The thousands pillar is the top of the rack, so it absorbs whatever is left
+ * after the lower three places are balanced; its digit may exceed 5 and there is
+ * nothing above it to borrow from.
+ *
+ * Returned heaviest-first, which is also the order a player naturally strikes:
+ * get the magnitude right, then trim.
+ */
+export function planStrikes(delta: number): Strike[] {
+  if (!Number.isInteger(delta)) throw new Error("planStrikes: delta must be an integer")
+  const digits = new Map<Place, number>()
+
+  let rest = delta
+  // Units, tens, hundreds: take each place to its nearest multiple, carrying the
+  // remainder up. `rest` stays an exact integer at every step because every
+  // subtraction is of a multiple of the place.
+  for (const place of [1, 10, 100] as const) {
+    const within = rest % (place * 10)
+    // `%` in JS keeps the sign of the dividend, so this is already signed.
+    let digit = within / place
+    // `within` is a multiple of `place` by construction, so this is exact.
+    if (digit > 5) digit -= 10
+    else if (digit < -5) digit += 10
+    digits.set(place, digit)
+    rest -= digit * place
+  }
+  digits.set(1000, rest / 1000)
+
+  const out: Strike[] = []
+  for (const place of PLACES) {
+    const digit = digits.get(place) ?? 0
+    const dir: Direction = digit >= 0 ? 1 : -1
+    for (let i = 0; i < Math.abs(digit); i++) out.push({ place, dir })
+  }
+  return out
+}
+
+/** How many strikes the shortest path to `delta` costs. */
+export function strikesFor(delta: number): number {
+  return planStrikes(delta).length
+}
+
+/** Every face on the rack, in reading order: a whole rack of eight. */
+export const FACES: readonly Strike[] = PLACES.flatMap((place) => [
+  { place, dir: 1 as Direction },
+  { place, dir: -1 as Direction },
+])
+
+/**
+ * A struck plate has to swing back before it can be struck again.
+ *
+ * Short — this is not a balance mechanic, it is what stops one press being read
+ * as two on a touchscreen that fires a pointer and a click. The thing that makes
+ * mashing lose lives in `strain.ts`.
+ */
+export const PILLAR_COOLDOWN_MS = 110

--- a/dynawalla/games/counterweight/src/game/strain.ts
+++ b/dynawalla/games/counterweight/src/game/strain.ts
@@ -1,0 +1,118 @@
+// **The reason mashing loses.**
+//
+// A steelyard is a bar of steel. Hang a weight on it and it rings, and a bar
+// that is struck again while it is still ringing rings harder — the second blow
+// arrives in phase with the first. Keep that up and the steel does not simply
+// get loud; it shears.
+//
+// So every strike puts strain into the beam, and how much depends entirely on
+// **when it lands**. A blow that arrives after the ring has died costs almost
+// nothing. A blow that lands on top of the last one costs six times as much.
+// Strain bleeds away on its own; past the shear limit the beam snaps and the
+// round is over.
+//
+// The consequence, which is the design:
+//
+//   * A player who works the sum out and then strikes the eight or ten plates
+//     their answer needs, a quarter-second apart, never comes close to the
+//     limit.
+//   * A player who mashes shears the beam in **under half a second**, before
+//     they could have arrived anywhere by accident.
+//   * A player who ignores the sum and hunts for the answer by watching which
+//     way the beam leans has to wait for it to settle between probes, and the
+//     round clock — not this — is what runs out on them.
+//
+// Every quantity here is an integer in strain units. That is not fussiness: the
+// shear verdict is a comparison, a comparison on a float is a comparison that
+// depends on frame timing, and "the beam snapped and I do not know why" is not
+// something a child should ever be handed.
+
+/** Strain a blow costs when the beam is already still. */
+export const BASE_STRAIN = 2
+
+/**
+ * How long the ring lasts. A blow inside this window is in phase with the last
+ * one and is charged for it, on a straight ramp from `BASE_STRAIN` at the edge
+ * to `BASE_STRAIN + RESONANCE_MS / RESONANCE_DIVISOR` at zero gap.
+ */
+export const RESONANCE_MS = 220
+export const RESONANCE_DIVISOR = 20
+
+/**
+ * Strain that bleeds out of the steel per second.
+ *
+ * Set from the worst case a *correct* player can face: the longest balanced plan
+ * on this rack is around twenty-five blows, and twenty-five deliberate blows a
+ * quarter-second apart must never shear the beam. Punishing the child who did
+ * the arithmetic because their answer happened to need a lot of plates would be
+ * the game lying about what it rewards.
+ */
+export const BLEED_PER_SEC = 6
+
+export type StrainLimits = {
+  /** Strain at or above which the beam shears. */
+  readonly shearAt: number
+}
+
+/** What one blow costs, given the gap since the previous one. */
+export function impulseFor(gapMs: number): number {
+  const gap = Math.max(0, gapMs)
+  if (gap >= RESONANCE_MS) return BASE_STRAIN
+  return BASE_STRAIN + Math.floor((RESONANCE_MS - gap) / RESONANCE_DIVISOR)
+}
+
+/**
+ * The beam's strain, in whole units, with the bleed accumulated in milliseconds
+ * so that a 16 ms frame and a 4 ms frame reach the same number.
+ */
+export class Strain {
+  private readonly limits: StrainLimits
+  private value = 0
+  private bleedMs = 0
+  private sinceStrike = Number.POSITIVE_INFINITY
+  private sheared = false
+
+  constructor(limits: StrainLimits) {
+    this.limits = limits
+  }
+
+  get level(): number {
+    return this.value
+  }
+
+  /** 0..1 against the shear limit. The only float here, and it is for the dial. */
+  get load(): number {
+    return Math.max(0, Math.min(1, this.value / this.limits.shearAt))
+  }
+
+  get isSheared(): boolean {
+    return this.sheared
+  }
+
+  advance(dtMs: number): void {
+    if (dtMs <= 0) return
+    this.sinceStrike = this.sinceStrike === Number.POSITIVE_INFINITY ? this.sinceStrike : this.sinceStrike + dtMs
+    if (this.value <= 0) {
+      this.bleedMs = 0
+      return
+    }
+    this.bleedMs += dtMs
+    const shed = Math.floor((this.bleedMs * BLEED_PER_SEC) / 1000)
+    if (shed > 0) {
+      this.value = Math.max(0, this.value - shed)
+      this.bleedMs -= Math.floor((shed * 1000) / BLEED_PER_SEC)
+    }
+  }
+
+  /**
+   * Record a blow. Returns the strain it cost, so the renderer can flare the
+   * beam in proportion and the audio can bite harder on a resonant one.
+   */
+  strike(): number {
+    const impulse = impulseFor(this.sinceStrike)
+    this.value += impulse
+    this.sinceStrike = 0
+    if (this.value >= this.limits.shearAt) this.sheared = true
+    return impulse
+  }
+}

--- a/dynawalla/games/counterweight/src/index.ts
+++ b/dynawalla/games/counterweight/src/index.ts
@@ -1,0 +1,3 @@
+export { mount } from "./contract.ts"
+export type { Handle, Host, Question } from "./contract.ts"
+export { createStubHost } from "./stubHost.ts"

--- a/dynawalla/games/counterweight/src/main.ts
+++ b/dynawalla/games/counterweight/src/main.ts
@@ -1,0 +1,46 @@
+// The standalone dev harness. `npm run dev`, and the whole match is playable
+// with no runtime underneath it: the stub host in `stubHost.ts` deals the same
+// column arithmetic the real one does.
+//
+// The readout along the bottom is dev-only and is not in `pack.html`. Inside a
+// real host, the host draws the progress.
+
+import { mount } from "./contract.ts"
+import { createStubHost } from "./stubHost.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("counterweight: #app missing")
+const readout = document.getElementById("readout")
+
+let asked = 0
+let right = 0
+let transitions = 0
+
+const host = createStubHost({
+  seed: (Date.now() ^ 0x9a11c7) >>> 0,
+  onReport: (r) => {
+    asked += 1
+    if (r.correct) right += 1
+    if (readout) {
+      readout.textContent =
+        `${right}/${asked} held · last ${r.answered} in ${r.ms} ms · ` +
+        `${transitions} stopping point${transitions === 1 ? "" : "s"} · ` +
+        `Q/A ±1000 · W/S ±100 · E/D ±10 · R/F ±1 · space = seat`
+    }
+  },
+  onTransition: () => {
+    transitions += 1
+  },
+})
+
+const handle = mount(root, host)
+
+// The dev harness is the one place a pause can be exercised by hand: press `p`.
+// It is the same call the host makes when it raises a sheet.
+let sheeted = false
+globalThis.addEventListener("keydown", (event) => {
+  if (event.key.toLowerCase() !== "p") return
+  sheeted = !sheeted
+  if (sheeted) handle.pause()
+  else handle.resume()
+})

--- a/dynawalla/games/counterweight/src/mount.ts
+++ b/dynawalla/games/counterweight/src/mount.ts
@@ -1,0 +1,338 @@
+// THE COUNTERWEIGHT.
+//
+// The wiring, and nothing else: the rules are in `game/bout.ts`, the physics in
+// `sim/beam.ts`, the yard in `render/scene.ts`. This file owns the frame, the
+// input, the host calls and the clock — and the clock is the part with teeth,
+// because a clock that runs behind a sheet costs the child a round they never
+// saw.
+
+import type { Handle, Host } from "./contract.ts"
+import { Audio } from "./audio.ts"
+import { Bout, type BoutEvent, TIMING, TIMING_REDUCED } from "./game/bout.ts"
+import { loadTally, recordTally } from "./game/best.ts"
+import { splitPrompt, type Column } from "./game/column.ts"
+import type { Place } from "./game/places.ts"
+import { Beam, MAX_TILT, TUNING, TUNING_REDUCED } from "./sim/beam.ts"
+import { PALETTE } from "./render/palette.ts"
+import { Scene } from "./render/scene.ts"
+
+/**
+ * The largest step the clock is allowed to take in one frame.
+ *
+ * A backgrounded tab hands back a delta of minutes. Letting that through would
+ * spend a press window and seat the beam wherever it stood. Clamping means time
+ * nearly stops when frames stop, which is the only fair reading of "they were
+ * not here".
+ */
+const MAX_STEP_MS = 120
+
+/** Keys, for the dev harness and for anybody on a keyboard. */
+const KEY_FACE: Record<string, { place: Place; dir: 1 | -1 }> = {
+  q: { place: 1000, dir: 1 },
+  a: { place: 1000, dir: -1 },
+  w: { place: 100, dir: 1 },
+  s: { place: 100, dir: -1 },
+  e: { place: 10, dir: 1 },
+  d: { place: 10, dir: -1 },
+  r: { place: 1, dir: 1 },
+  f: { place: 1, dir: -1 },
+}
+
+export function mountCounterweight(el: HTMLElement, host: Host): Handle {
+  const canvas = document.createElement("canvas")
+  canvas.style.cssText =
+    "position:absolute;inset:0;width:100%;height:100%;display:block;touch-action:none"
+  el.appendChild(canvas)
+
+  const reduced = host.prefersReducedMotion()
+  const scene = new Scene(canvas)
+  const audio = new Audio()
+  const beam = new Beam(reduced ? TUNING_REDUCED : TUNING)
+  const bout = new Bout(() => host.next({ domain: "add" }), reduced ? TIMING_REDUCED : TIMING)
+
+  let tally = loadTally()
+  let running = true
+  let frame = 0
+  let last = 0
+  /** Set by the host's `pause`. Blocks the clock *and* the input, separately. */
+  let sheeted = false
+  let column: Column | null = null
+  let promptRaw = ""
+  /**
+   * When the current window opened, on the wall clock. Latency the child is
+   * billed for is measured from here, and a pause shifts it forward so a sheet
+   * is not charged as thinking time.
+   */
+  let openedAt = 0
+  let pausedAt = 0
+  let holdRun = 0
+  const pressed = new Set<string>()
+  let seatHeld = false
+  /** Item ids already reported. One report per item, ever. */
+  const reported = new Set<string>()
+
+  const now = (): number =>
+    typeof performance === "object" && typeof performance.now === "function"
+      ? performance.now()
+      : Date.now()
+
+  const handle = (events: readonly BoutEvent[]): void => {
+    for (const event of events) {
+      switch (event.kind) {
+        case "hang": {
+          promptRaw = event.question.prompt
+          column = splitPrompt(event.question.prompt)
+          beam.aim(bout.margin)
+          break
+        }
+        case "open": {
+          openedAt = now()
+          audio.bow()
+          break
+        }
+        case "strike": {
+          beam.aim(bout.margin)
+          beam.hit(event.impulse, event.strike.dir)
+          audio.clang(event.strike.place, event.impulse)
+          host.haptic(event.impulse >= 6 ? "medium" : "light")
+          if (!reduced) {
+            const at = scene.faceCentre(event.strike.place, event.strike.dir)
+            scene.sparks.strike(at.x, at.y, 1, event.impulse, PALETTE.brassBright)
+          }
+          break
+        }
+        case "refused": {
+          if (event.reason === "cooldown") audio.refuse()
+          break
+        }
+        case "sag": {
+          beam.aim(bout.margin)
+          audio.sag()
+          break
+        }
+        case "seat": {
+          report(event.seat.question.id, event.seat.verdict === "true", event.seat.asserted)
+          beam.aim(bout.margin)
+          if (event.seat.verdict === "true") {
+            holdRun += 1
+            audio.held()
+            host.haptic("success")
+            scene.flash(PALETTE.seat, 200)
+          } else {
+            holdRun = 0
+            if (event.seat.verdict === "shear") {
+              audio.shear()
+              host.haptic("failure")
+              beam.slam(-1)
+              scene.shake(reduced ? 0 : 7, 220)
+              if (!reduced) {
+                scene.sparks.shear(scene.layout.fulcrum.x, scene.layout.fulcrum.y, PALETTE.strain)
+              }
+            } else {
+              audio.lost()
+              host.haptic("heavy")
+            }
+          }
+          tally = recordTally(bout.match.won, Math.max(tally.hold, holdRun))
+          break
+        }
+        case "won": {
+          audio.fanfare()
+          host.haptic("success")
+          scene.flash(PALETTE.brassBright, 240)
+          tally = recordTally(bout.match.won, Math.max(tally.hold, holdRun))
+          // The one call site. A Turk going over is a thing the child *reached*;
+          // being pinned is not, and a purchase surface next to a defeat is
+          // forbidden outright.
+          host.transition?.("boss", `Turk ${event.bout}`)
+          break
+        }
+        case "pinned": {
+          audio.lost()
+          host.haptic("heavy")
+          holdRun = 0
+          break
+        }
+        default:
+          break
+      }
+    }
+  }
+
+  const report = (questionId: string, correct: boolean, asserted: number): void => {
+    if (questionId === "" || reported.has(questionId)) return
+    reported.add(questionId)
+    // The host judges. What crosses is the value the beam asserted his column to
+    // be — which, when the child ran a broken column procedure, is exactly the
+    // mal-rule output, so the diagnosis routes with nothing else to write.
+    host.report({
+      questionId,
+      correct,
+      ms: Math.max(0, Math.round(now() - openedAt)),
+      answered: String(asserted),
+    })
+  }
+
+  const tick = (t: number): void => {
+    if (!running) return
+    frame = requestAnimationFrame(tick)
+    const dt = last === 0 ? 16 : Math.min(MAX_STEP_MS, t - last)
+    last = t
+    // One place where the simulation is frozen, rather than a guard in each
+    // subsystem. `Bout` stops its own clock too — `pause.test.ts` is written
+    // against that — and this is what stops the beam and the drone with it.
+    if (!sheeted) {
+      handle(bout.advance(dt))
+      beam.advance(dt)
+      audio.track(beam.angle / MAX_TILT, beam.ring)
+    }
+    scene.advance(dt, reduced)
+    scene.draw({
+      bout,
+      beam,
+      reduced,
+      best: tally,
+      pressed,
+      seatHeld,
+      paused: sheeted,
+      column,
+      promptRaw,
+    })
+  }
+
+  const pointAt = (event: { clientX?: number; clientY?: number }): { x: number; y: number } => {
+    const rect = canvas.getBoundingClientRect()
+    return { x: (event.clientX ?? 0) - rect.left, y: (event.clientY ?? 0) - rect.top }
+  }
+
+  const act = (target: ReturnType<Scene["pick"]>): void => {
+    if (!target) return
+    audio.resume()
+    if (target.kind === "seat") {
+      seatHeld = true
+      handle(bout.seatNow())
+      return
+    }
+    pressed.add(`${target.place}:${target.dir}`)
+    handle(bout.strike({ place: target.place, dir: target.dir }))
+  }
+
+  const down = (event: Event): void => {
+    event.preventDefault()
+    // A press that lands while the host's sheet is up is a press on the sheet.
+    // `Bout` refuses it anyway — that is where the rules live — but the refusal
+    // comes back after this handler has already lit the plate up and woken the
+    // audio context. Stopping it here is what keeps the rack from answering a
+    // tap the child aimed somewhere else.
+    if (sheeted) return
+    const at = pointAt(event as PointerEvent)
+    act(scene.pick(at.x, at.y))
+  }
+
+  const up = (): void => {
+    pressed.clear()
+    seatHeld = false
+  }
+
+  const key = (event: KeyboardEvent): void => {
+    if (event.repeat || sheeted) return
+    const k = event.key.toLowerCase()
+    if (k === " " || k === "enter") {
+      event.preventDefault()
+      act({ kind: "seat" })
+      globalThis.setTimeout(up, 90)
+      return
+    }
+    const face = KEY_FACE[k]
+    if (!face) return
+    event.preventDefault()
+    act({ kind: "face", place: face.place, dir: face.dir })
+    globalThis.setTimeout(up, 90)
+  }
+
+  const resize = (): void => {
+    scene.resize()
+  }
+
+  canvas.addEventListener("pointerdown", down)
+  canvas.addEventListener("pointerup", up)
+  canvas.addEventListener("pointercancel", up)
+  globalThis.addEventListener("keydown", key)
+  globalThis.addEventListener("keyup", up)
+  globalThis.addEventListener("resize", resize)
+
+  const observer =
+    typeof ResizeObserver === "function"
+      ? new ResizeObserver(() => {
+          scene.resize()
+        })
+      : null
+  observer?.observe(el)
+
+  // A hidden tab is the same situation as a sheet, and it arrives far more
+  // often. `MAX_STEP_MS` alone would still spend 120 ms a frame on a throttled
+  // timer; this stops the world outright.
+  const visibility = (): void => {
+    const doc = globalThis.document as Document | undefined
+    if (!doc) return
+    if (doc.visibilityState === "hidden") pauseAll()
+    else resumeAll()
+  }
+
+  const pauseAll = (): void => {
+    if (sheeted) return
+    sheeted = true
+    pausedAt = now()
+    bout.pause()
+    audio.release()
+  }
+
+  const resumeAll = (): void => {
+    if (!sheeted) return
+    sheeted = false
+    // The sheet is not the child's thinking time. Shift the mark forward by
+    // exactly how long it was up, so the latency this round reports is the time
+    // they actually had the beam in front of them.
+    if (pausedAt > 0) openedAt += now() - pausedAt
+    pausedAt = 0
+    last = 0
+    if (bout.phase === "press") audio.bow()
+    bout.resume()
+  }
+
+  globalThis.document?.addEventListener("visibilitychange", visibility)
+
+  handle(bout.begin())
+  beam.settleTo(bout.margin)
+  frame = requestAnimationFrame(tick)
+
+  return {
+    /**
+     * The host has raised a sheet over a still-mounted, still-running pack.
+     *
+     * Both halves matter. The clock stops, so a press window cannot open and
+     * close behind the sheet and seat the beam on a column the child never saw.
+     * And input stops, so a tap meant for the sheet is not a blow on the rack.
+     */
+    pause(): void {
+      pauseAll()
+    },
+    resume(): void {
+      resumeAll()
+    },
+    unmount(): void {
+      running = false
+      cancelAnimationFrame(frame)
+      canvas.removeEventListener("pointerdown", down)
+      canvas.removeEventListener("pointerup", up)
+      canvas.removeEventListener("pointercancel", up)
+      globalThis.removeEventListener("keydown", key)
+      globalThis.removeEventListener("keyup", up)
+      globalThis.removeEventListener("resize", resize)
+      globalThis.document?.removeEventListener("visibilitychange", visibility)
+      observer?.disconnect()
+      audio.dispose()
+      canvas.remove()
+    },
+  }
+}

--- a/dynawalla/games/counterweight/src/pack.ts
+++ b/dynawalla/games/counterweight/src/pack.ts
@@ -1,0 +1,62 @@
+// THE COUNTERWEIGHT, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous surface `Host` in
+// `contract.ts` already describes — so the beam, the rack, the strain and the
+// yard are untouched.
+//
+// What crosses the boundary is the weight on his pan. The curriculum draws a
+// column operation, the host reveals its canonical value, and that value is what
+// the beam is weighed against. **`items.reveal` is declared and it is
+// load-bearing**: without it the adapter gets an empty canonical value, drops
+// every item, and the pack mounts and warms and serves no questions at all, with
+// nothing failing anywhere.
+//
+// The child's answer is never a choice off a list. It is the load they put on
+// their own pan, minus the one notch they are holding — reported verbatim, so a
+// dropped carry arrives at the host as the mal-rule output and routes itself.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import { mount } from "./contract.ts"
+import type { Host } from "./contract.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("counterweight: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "add" })
+  // Stocked before the first frame: the first weight is hung the instant the
+  // game mounts, and a pan with a blank face is the kind of thing that happens
+  // exactly once, on launch, in front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context come down before the frame does rather than a frame or two after.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+
+  // **The sheet.** A transition can put a surface over the frame, and the SDK
+  // documents that the pack then receives `pause` while it stays mounted and
+  // running. This game calls `transition` every time a Turk goes over, so it is
+  // not hypothetical: an unpaused press window would open and close behind that
+  // sheet, seat the beam wherever it happened to stand, mark the child wrong for
+  // a column they were never shown, and take ground off them for it. A reward
+  // that costs the match is the worst bug this game could have.
+  //
+  // These two lines are the whole subscription, and without them the handle's
+  // `pause`/`resume` are inert — the methods exist, and nothing ever calls them.
+  mounted.client.on("pause", () => {
+    handle.pause()
+  })
+  mounted.client.on("resume", () => {
+    handle.resume()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[counterweight] could not start", error)
+  renderNoHost(root, "THE COUNTERWEIGHT")
+})

--- a/dynawalla/games/counterweight/src/render/layout.ts
+++ b/dynawalla/games/counterweight/src/render/layout.ts
@@ -1,0 +1,113 @@
+// Where everything stands, computed once per resize.
+//
+// Phone portrait, tablet portrait and a desktop window are all first-class: the
+// stack is the same everywhere and only the proportions move. Nothing is
+// measured from text — numerals live on a tabular grid, so a four-digit load
+// does not push the beam down after a two-digit one.
+
+import { PLACES, type Place } from "../game/places.ts"
+
+export type Rect = { x: number; y: number; w: number; h: number }
+
+export type PillarRects = {
+  readonly place: Place
+  /** Hang weight on. */
+  readonly up: Rect
+  /** Take weight off. */
+  readonly down: Rect
+  readonly cx: number
+}
+
+export type Layout = {
+  readonly w: number
+  readonly h: number
+  /** Narrow enough that the rack labels shorten and the pans stack tighter. */
+  readonly compact: boolean
+  readonly unit: number
+  readonly hud: Rect
+  readonly stage: Rect
+  readonly fulcrum: { x: number; y: number }
+  /** Half the beam, centre to pan hook. */
+  readonly arm: number
+  readonly panDrop: number
+  readonly panW: number
+  readonly panH: number
+  readonly gauge: Rect
+  readonly rack: Rect
+  readonly pillars: readonly PillarRects[]
+  readonly seat: Rect
+}
+
+export function layoutFor(w: number, h: number): Layout {
+  const compact = Math.min(w, h) < 420
+  const unit = Math.max(11, Math.min(w, h) * (compact ? 0.038 : 0.03))
+
+  const pad = Math.round(unit * 0.9)
+  const hudH = Math.round(unit * 3.1)
+  // The rack is the thing a thumb has to reach, so it is sized from the shorter
+  // edge and given the floor rather than the leftovers.
+  const rackH = Math.round(Math.min(h * 0.34, unit * 12.4))
+  const seatH = Math.round(Math.min(h * 0.1, unit * 3.4))
+  const gaugeH = Math.round(unit * 1.5)
+
+  const hud: Rect = { x: pad, y: pad, w: w - pad * 2, h: hudH }
+  const seat: Rect = { x: pad, y: h - pad - seatH, w: w - pad * 2, h: seatH }
+  const rack: Rect = { x: pad, y: seat.y - pad * 0.6 - rackH, w: w - pad * 2, h: rackH }
+  const gauge: Rect = {
+    x: pad,
+    y: rack.y - pad * 0.5 - gaugeH,
+    w: w - pad * 2,
+    h: gaugeH,
+  }
+  const stageTop = hud.y + hud.h + pad * 0.4
+  const stage: Rect = { x: pad, y: stageTop, w: w - pad * 2, h: Math.max(unit * 6, gauge.y - pad * 0.5 - stageTop) }
+
+  const arm = Math.min(stage.w * 0.4, stage.h * 0.78)
+  const panW = Math.min(arm * 0.92, stage.w * 0.42)
+  const panH = Math.min(stage.h * 0.46, unit * 6.2)
+  const panDrop = Math.min(stage.h * 0.3, unit * 3.2)
+  const fulcrum = {
+    x: stage.x + stage.w / 2,
+    y: stage.y + Math.min(stage.h * 0.34, unit * 4.4),
+  }
+
+  const gap = Math.round(unit * 0.5)
+  const pillarW = (rack.w - gap * (PLACES.length - 1)) / PLACES.length
+  const faceH = (rack.h - gap) / 2
+  const pillars: PillarRects[] = PLACES.map((place, i) => {
+    const x = rack.x + i * (pillarW + gap)
+    return {
+      place,
+      up: { x, y: rack.y, w: pillarW, h: faceH },
+      down: { x, y: rack.y + faceH + gap, w: pillarW, h: faceH },
+      cx: x + pillarW / 2,
+    }
+  })
+
+  return {
+    w,
+    h,
+    compact,
+    unit,
+    hud,
+    stage,
+    fulcrum,
+    arm,
+    panDrop,
+    panW,
+    panH,
+    gauge,
+    rack,
+    pillars,
+    seat,
+  }
+}
+
+export function hit(rect: Rect, x: number, y: number, slack = 0): boolean {
+  return (
+    x >= rect.x - slack &&
+    x <= rect.x + rect.w + slack &&
+    y >= rect.y - slack &&
+    y <= rect.y + rect.h + slack
+  )
+}

--- a/dynawalla/games/counterweight/src/render/palette.ts
+++ b/dynawalla/games/counterweight/src/render/palette.ts
@@ -1,0 +1,65 @@
+// The yard behind the bazaar's weighing house: night, a cold sky, and one
+// brazier. Brass for the beam, cold steel for your side, ember for his.
+//
+// The vocabulary is mechanical, not confetti — EXPERIENCE_DESIGN's juice
+// ceiling. Nothing in here is a primary colour and nothing celebrates in
+// rainbow: a held notch is a *cold* highlight seating into brass, which reads as
+// precision rather than as a prize.
+
+export const PALETTE = {
+  night: "#0a0b0e",
+  nightDeep: "#06070a",
+  yard: "#12141a",
+  stone: "#1c202a",
+  stoneEdge: "#262c39",
+
+  brass: "#c8a45c",
+  brassDim: "#7d6636",
+  brassBright: "#f0d79a",
+
+  steel: "#9fb4c8",
+  steelDim: "#54657a",
+  steelBright: "#dcebf7",
+
+  ember: "#d1633a",
+  emberDim: "#7a3a22",
+  emberBright: "#ff9a63",
+
+  ink: "#e8ecf3",
+  inkDim: "#7d879a",
+  inkFaint: "#4a5364",
+
+  /** The cold seat highlight. The best colour in the game, used sparingly. */
+  seat: "#8fe6ff",
+  /** Strain past the safe reach. */
+  strain: "#e0573f",
+} as const
+
+/** `rgba` from a hex triple. Kept tiny; there is no colour library here. */
+export function alpha(hex: string, a: number): string {
+  const n = Number.parseInt(hex.slice(1), 16)
+  const r = (n >> 16) & 255
+  const g = (n >> 8) & 255
+  const b = n & 255
+  return `rgba(${r},${g},${b},${Math.max(0, Math.min(1, a)).toFixed(3)})`
+}
+
+/** Linear blend between two hex colours. */
+export function mix(from: string, to: string, t: number): string {
+  const k = Math.max(0, Math.min(1, t))
+  const a = Number.parseInt(from.slice(1), 16)
+  const b = Number.parseInt(to.slice(1), 16)
+  const r = Math.round(((a >> 16) & 255) * (1 - k) + ((b >> 16) & 255) * k)
+  const g = Math.round(((a >> 8) & 255) * (1 - k) + ((b >> 8) & 255) * k)
+  const c = Math.round((a & 255) * (1 - k) + (b & 255) * k)
+  return `#${((r << 16) | (g << 8) | c).toString(16).padStart(6, "0")}`
+}
+
+/** Numerals sit on a tabular grid so a four-digit load does not reflow a two. */
+export const FACE_NUM = "700 {size}px ui-monospace, 'SF Mono', 'Roboto Mono', monospace"
+export const FACE_TEXT =
+  "600 {size}px 'Avenir Next', 'Segoe UI', system-ui, -apple-system, sans-serif"
+
+export function font(face: string, size: number): string {
+  return face.replace("{size}", String(Math.round(size)))
+}

--- a/dynawalla/games/counterweight/src/render/particles.ts
+++ b/dynawalla/games/counterweight/src/render/particles.ts
@@ -1,0 +1,89 @@
+// Sparks off struck steel, and the shards of a sheared beam.
+//
+// A fixed pool, no allocation in the loop, and a hard ceiling on how much can be
+// on screen at once — the juice dose in EXPERIENCE_DESIGN is a ceiling, not a
+// target. Under reduced motion the emitters are simply never called; the field
+// still exists and still draws nothing, which is cheaper than branching in the
+// draw path.
+
+import { alpha } from "./palette.ts"
+
+type Spark = {
+  x: number
+  y: number
+  vx: number
+  vy: number
+  life: number
+  max: number
+  size: number
+  hue: string
+}
+
+const CAP = 120
+
+export class Sparks {
+  private readonly pool: Spark[] = []
+  private cursor = 0
+
+  constructor() {
+    for (let i = 0; i < CAP; i++) {
+      this.pool.push({ x: 0, y: 0, vx: 0, vy: 0, life: 0, max: 1, size: 1, hue: "#fff" })
+    }
+  }
+
+  /** A blow landed on a plate: a short cone of sparks off the face. */
+  strike(x: number, y: number, dir: number, strength: number, hue: string): void {
+    const n = Math.min(14, 4 + Math.round(strength))
+    for (let i = 0; i < n; i++) {
+      const s = this.pool[this.cursor++ % CAP] as Spark
+      const spread = (i / n - 0.5) * 2.2
+      const speed = 90 + strength * 26 + i * 7
+      s.x = x
+      s.y = y
+      s.vx = spread * speed * 0.5
+      s.vy = -dir * speed
+      s.max = 260 + (i % 5) * 40
+      s.life = s.max
+      s.size = 1.4 + (i % 3) * 0.7
+      s.hue = hue
+    }
+  }
+
+  /** The steel let go. A wide, slow shower — the only big effect in the game. */
+  shear(x: number, y: number, hue: string): void {
+    for (let i = 0; i < 40; i++) {
+      const s = this.pool[this.cursor++ % CAP] as Spark
+      const a = (i / 40) * Math.PI * 2
+      const speed = 130 + (i % 7) * 34
+      s.x = x
+      s.y = y
+      s.vx = Math.cos(a) * speed
+      s.vy = Math.sin(a) * speed - 60
+      s.max = 520 + (i % 6) * 70
+      s.life = s.max
+      s.size = 1.6 + (i % 4) * 0.9
+      s.hue = hue
+    }
+  }
+
+  advance(dtMs: number): void {
+    const dt = dtMs / 1000
+    for (const s of this.pool) {
+      if (s.life <= 0) continue
+      s.life -= dtMs
+      s.vy += 900 * dt
+      s.vx *= 0.985
+      s.x += s.vx * dt
+      s.y += s.vy * dt
+    }
+  }
+
+  draw(ctx: CanvasRenderingContext2D): void {
+    for (const s of this.pool) {
+      if (s.life <= 0) continue
+      const t = s.life / s.max
+      ctx.fillStyle = alpha(s.hue, t * t)
+      ctx.fillRect(s.x - s.size / 2, s.y - s.size / 2, s.size, s.size * (1 + (1 - t) * 1.6))
+    }
+  }
+}

--- a/dynawalla/games/counterweight/src/render/scene.ts
+++ b/dynawalla/games/counterweight/src/render/scene.ts
@@ -1,0 +1,523 @@
+// The yard, drawn.
+//
+// One canvas, no DOM, no images and no fonts to load — nothing on the answer
+// path waits for the world. Every frame is: the yard, the arm, the beam with its
+// two pans, the strain gauge, the rack, the seat lever.
+//
+// **What the beam is allowed to say.** His pan carries the column and never its
+// total. Your pan carries your load. The beam carries the difference, and only
+// near level does it carry it finely — see `sim/beam.ts`. Nothing on this canvas
+// ever draws his number, and nothing draws the answer after a seat either: the
+// child is told *what they claimed*, which is the thing that is theirs.
+
+import { GROUND, type Bout, type Seat, type Verdict } from "../game/bout.ts"
+import type { Column } from "../game/column.ts"
+import type { Place } from "../game/places.ts"
+import type { Beam } from "../sim/beam.ts"
+import { hit, layoutFor, type Layout, type Rect } from "./layout.ts"
+import { alpha, FACE_NUM, FACE_TEXT, font, mix, PALETTE } from "./palette.ts"
+import { Sparks } from "./particles.ts"
+
+export type SceneState = {
+  readonly bout: Bout
+  readonly beam: Beam
+  readonly reduced: boolean
+  readonly best: { turks: number; hold: number }
+  /** Pillars pressed this frame, for the depressed look. */
+  readonly pressed: ReadonlySet<string>
+  readonly seatHeld: boolean
+  /** Set while the host has a sheet over the frame. */
+  readonly paused: boolean
+  /** The split column on the Turk's pan, or null when the prompt would not split. */
+  readonly column: Column | null
+  readonly promptRaw: string
+}
+
+const VERDICT_WORD: Record<Verdict, string> = {
+  true: "HELD",
+  short: "UNDER",
+  over: "OVER",
+  shear: "SHEARED",
+}
+
+const VERDICT_HUE: Record<Verdict, string> = {
+  true: PALETTE.seat,
+  short: PALETTE.ember,
+  over: PALETTE.ember,
+  shear: PALETTE.strain,
+}
+
+/** Thousands separators, so a four-digit load reads at a glance. */
+function grouped(n: number): string {
+  const sign = n < 0 ? "−" : ""
+  return sign + Math.abs(n).toString().replace(/\B(?=(\d{3})+(?!\d))/g, " ")
+}
+
+function placeLabel(place: Place, dir: 1 | -1): string {
+  return `${dir > 0 ? "+" : "−"}${grouped(place)}`
+}
+
+function roundRect(ctx: CanvasRenderingContext2D, r: Rect, radius: number): void {
+  const k = Math.min(radius, r.w / 2, r.h / 2)
+  ctx.beginPath()
+  ctx.moveTo(r.x + k, r.y)
+  ctx.lineTo(r.x + r.w - k, r.y)
+  ctx.quadraticCurveTo(r.x + r.w, r.y, r.x + r.w, r.y + k)
+  ctx.lineTo(r.x + r.w, r.y + r.h - k)
+  ctx.quadraticCurveTo(r.x + r.w, r.y + r.h, r.x + r.w - k, r.y + r.h)
+  ctx.lineTo(r.x + k, r.y + r.h)
+  ctx.quadraticCurveTo(r.x, r.y + r.h, r.x, r.y + r.h - k)
+  ctx.lineTo(r.x, r.y + k)
+  ctx.quadraticCurveTo(r.x, r.y, r.x + k, r.y)
+  ctx.closePath()
+}
+
+export class Scene {
+  private readonly canvas: HTMLCanvasElement
+  private readonly ctx: CanvasRenderingContext2D
+  private box: Layout
+  private dpr = 1
+  readonly sparks = new Sparks()
+  private shakeMs = 0
+  private shakeAmp = 0
+  private flashMs = 0
+  private flashHue: string = PALETTE.seat
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.canvas = canvas
+    const ctx = canvas.getContext("2d")
+    if (!ctx) throw new Error("counterweight: no 2d context")
+    this.ctx = ctx
+    this.box = layoutFor(1, 1)
+    this.resize()
+  }
+
+  get layout(): Layout {
+    return this.box
+  }
+
+  resize(): void {
+    const rect = this.canvas.getBoundingClientRect()
+    const w = Math.max(1, Math.round(rect.width || 360))
+    const h = Math.max(1, Math.round(rect.height || 640))
+    this.dpr = Math.min(3, Math.max(1, globalThis.devicePixelRatio || 1))
+    this.canvas.width = Math.round(w * this.dpr)
+    this.canvas.height = Math.round(h * this.dpr)
+    this.box = layoutFor(w, h)
+  }
+
+  /** Which face, if any, is under this point. */
+  pick(x: number, y: number): { kind: "face"; place: Place; dir: 1 | -1 } | { kind: "seat" } | null {
+    if (hit(this.box.seat, x, y, this.box.unit * 0.5)) return { kind: "seat" }
+    for (const pillar of this.box.pillars) {
+      if (hit(pillar.up, x, y, this.box.unit * 0.25)) {
+        return { kind: "face", place: pillar.place, dir: 1 }
+      }
+      if (hit(pillar.down, x, y, this.box.unit * 0.25)) {
+        return { kind: "face", place: pillar.place, dir: -1 }
+      }
+    }
+    return null
+  }
+
+  /** Where a face sits, so sparks come off the plate that was struck. */
+  faceCentre(place: Place, dir: 1 | -1): { x: number; y: number } {
+    const pillar = this.box.pillars.find((p) => p.place === place)
+    if (!pillar) return { x: this.box.w / 2, y: this.box.h / 2 }
+    const r = dir > 0 ? pillar.up : pillar.down
+    return { x: r.x + r.w / 2, y: r.y + r.h / 2 }
+  }
+
+  shake(amplitude: number, ms: number): void {
+    this.shakeAmp = Math.max(this.shakeAmp, amplitude)
+    this.shakeMs = Math.max(this.shakeMs, ms)
+  }
+
+  flash(hue: string, ms: number): void {
+    this.flashHue = hue
+    this.flashMs = Math.max(this.flashMs, ms)
+  }
+
+  advance(dtMs: number, reduced: boolean): void {
+    if (!reduced) this.sparks.advance(dtMs)
+    this.shakeMs = Math.max(0, this.shakeMs - dtMs)
+    if (this.shakeMs === 0) this.shakeAmp = 0
+    this.flashMs = Math.max(0, this.flashMs - dtMs)
+  }
+
+  draw(state: SceneState): void {
+    const ctx = this.ctx
+    ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0)
+    if (this.shakeMs > 0 && !state.reduced) {
+      const k = this.shakeMs / 90
+      ctx.translate(Math.sin(this.shakeMs * 0.9) * this.shakeAmp * k, Math.cos(this.shakeMs * 1.3) * this.shakeAmp * k * 0.6)
+    }
+
+    this.drawYard(state)
+    this.drawHud(state)
+    this.drawBeam(state)
+    this.drawGauge(state)
+    this.drawRack(state)
+    this.drawSeat(state)
+    if (!state.reduced) this.sparks.draw(ctx)
+    this.drawFlash()
+    if (state.paused) this.drawSheet()
+  }
+
+  // ---------------------------------------------------------------------------
+
+  private drawYard(state: SceneState): void {
+    const ctx = this.ctx
+    const { w, h } = this.box
+    const sky = ctx.createLinearGradient(0, 0, 0, h)
+    sky.addColorStop(0, PALETTE.nightDeep)
+    sky.addColorStop(0.55, PALETTE.night)
+    sky.addColorStop(1, PALETTE.yard)
+    ctx.fillStyle = sky
+    ctx.fillRect(0, 0, w, h)
+
+    // The brazier behind his pan. Reduced motion holds it still rather than
+    // removing it — the light is the set, not an effect.
+    const glow = ctx.createRadialGradient(
+      w * 0.78,
+      this.box.stage.y + this.box.stage.h * 0.3,
+      0,
+      w * 0.78,
+      this.box.stage.y + this.box.stage.h * 0.3,
+      Math.max(w, h) * 0.55,
+    )
+    const heat = state.reduced ? 0.06 : 0.06 + Math.abs(state.beam.angle) * 0.05
+    glow.addColorStop(0, alpha(PALETTE.ember, heat))
+    glow.addColorStop(1, alpha(PALETTE.ember, 0))
+    ctx.fillStyle = glow
+    ctx.fillRect(0, 0, w, h)
+  }
+
+  private drawHud(state: SceneState): void {
+    const ctx = this.ctx
+    const { hud, unit } = this.box
+    const match = state.bout.match
+
+    ctx.textBaseline = "alphabetic"
+    ctx.textAlign = "left"
+    ctx.font = font(FACE_TEXT, unit * 0.86)
+    ctx.fillStyle = PALETTE.inkDim
+    ctx.fillText(`TURK ${match.bout}`, hud.x, hud.y + unit * 0.95)
+
+    ctx.textAlign = "right"
+    ctx.fillStyle = PALETTE.inkFaint
+    const tally = state.best.turks > 0 ? `BEST ${state.best.turks}` : "FIRST BOUT"
+    ctx.fillText(tally, hud.x + hud.w, hud.y + unit * 0.95)
+
+    // The arm: a tug bar. Centre is level; his end is on the right.
+    const barY = hud.y + unit * 1.6
+    const barH = Math.max(4, unit * 0.5)
+    const bar: Rect = { x: hud.x, y: barY, w: hud.w, h: barH }
+    ctx.fillStyle = PALETTE.stone
+    roundRect(ctx, bar, barH / 2)
+    ctx.fill()
+
+    const mid = hud.x + hud.w / 2
+    const reach = (hud.w / 2) * (match.arm / GROUND)
+    const ahead = match.arm >= 0
+    ctx.fillStyle = ahead ? PALETTE.seat : PALETTE.ember
+    if (Math.abs(reach) > 0.5) {
+      roundRect(
+        ctx,
+        { x: Math.min(mid, mid + reach), y: barY, w: Math.abs(reach), h: barH },
+        barH / 2,
+      )
+      ctx.fill()
+    }
+    // The two stops and the centre notch.
+    ctx.fillStyle = PALETTE.stoneEdge
+    ctx.fillRect(mid - 1, barY - unit * 0.24, 2, barH + unit * 0.48)
+  }
+
+  private drawBeam(state: SceneState): void {
+    const ctx = this.ctx
+    const { fulcrum, arm, unit } = this.box
+    const angle = state.beam.angle
+    // Positive margin is your side *down*: an arm-wrestle pushes the loser's
+    // hand toward the table, and your side is the left one.
+    const tilt = -angle
+
+    // The post.
+    ctx.strokeStyle = PALETTE.stoneEdge
+    ctx.lineWidth = Math.max(3, unit * 0.42)
+    ctx.beginPath()
+    ctx.moveTo(fulcrum.x, fulcrum.y)
+    ctx.lineTo(fulcrum.x, this.box.stage.y + this.box.stage.h)
+    ctx.stroke()
+
+    const lx = fulcrum.x - Math.cos(tilt) * arm
+    const ly = fulcrum.y - Math.sin(tilt) * arm
+    const rx = fulcrum.x + Math.cos(tilt) * arm
+    const ry = fulcrum.y + Math.sin(tilt) * arm
+
+    // The beam. Ring shows as a hot rim along the steel.
+    const ring = state.beam.ring
+    ctx.lineCap = "round"
+    ctx.strokeStyle = PALETTE.brassDim
+    ctx.lineWidth = Math.max(5, unit * 0.62)
+    ctx.beginPath()
+    ctx.moveTo(lx, ly)
+    ctx.lineTo(rx, ry)
+    ctx.stroke()
+    ctx.strokeStyle = mix(PALETTE.brass, PALETTE.brassBright, ring)
+    ctx.lineWidth = Math.max(2, unit * 0.26)
+    ctx.beginPath()
+    ctx.moveTo(lx, ly)
+    ctx.lineTo(rx, ry)
+    ctx.stroke()
+
+    // The fulcrum knuckle, and the index mark on it.
+    ctx.fillStyle = PALETTE.brass
+    ctx.beginPath()
+    ctx.arc(fulcrum.x, fulcrum.y, unit * 0.52, 0, Math.PI * 2)
+    ctx.fill()
+
+    // **The reading is only true when the steel has stopped.** A struck beam is
+    // travelling through every value between where it was and where it is going,
+    // so the index lights only once it has come to rest — which is exactly what
+    // makes "strike and squint" cost a settle each time instead of being free.
+    if (state.beam.settled) {
+      ctx.fillStyle = Math.abs(state.bout.margin) <= 1 ? PALETTE.seat : PALETTE.steelBright
+      ctx.beginPath()
+      ctx.arc(fulcrum.x, fulcrum.y, unit * 0.2, 0, Math.PI * 2)
+      ctx.fill()
+    }
+
+    this.drawChain(lx, ly, this.box.panDrop)
+    this.drawChain(rx, ry, this.box.panDrop)
+    this.drawYourPan(state, lx, ly + this.box.panDrop)
+    this.drawHisPan(state, rx, ry + this.box.panDrop)
+  }
+
+  private drawChain(x: number, y: number, drop: number): void {
+    const ctx = this.ctx
+    ctx.strokeStyle = PALETTE.steelDim
+    ctx.lineWidth = Math.max(1, this.box.unit * 0.12)
+    ctx.beginPath()
+    ctx.moveTo(x, y)
+    ctx.lineTo(x, y + drop)
+    ctx.stroke()
+  }
+
+  private drawYourPan(state: SceneState, cx: number, cy: number): void {
+    const ctx = this.ctx
+    const { panW, panH, unit } = this.box
+    const r: Rect = { x: cx - panW / 2, y: cy, w: panW, h: panH }
+    ctx.fillStyle = alpha(PALETTE.stone, 0.94)
+    roundRect(ctx, r, unit * 0.5)
+    ctx.fill()
+    ctx.strokeStyle = PALETTE.steelDim
+    ctx.lineWidth = 1.5
+    ctx.stroke()
+
+    ctx.textAlign = "center"
+    ctx.textBaseline = "middle"
+    ctx.fillStyle = PALETTE.inkFaint
+    ctx.font = font(FACE_TEXT, unit * 0.72)
+    ctx.fillText("YOUR LOAD", cx, r.y + unit * 0.86)
+
+    ctx.fillStyle = PALETTE.steelBright
+    ctx.font = font(FACE_NUM, Math.min(unit * 2.5, panW / 3.1))
+    ctx.fillText(grouped(state.bout.load), cx, r.y + panH * 0.62)
+  }
+
+  private drawHisPan(state: SceneState, cx: number, cy: number): void {
+    const ctx = this.ctx
+    const { panW, panH, unit } = this.box
+    const r: Rect = { x: cx - panW / 2, y: cy, w: panW, h: panH }
+    ctx.fillStyle = alpha(PALETTE.stone, 0.94)
+    roundRect(ctx, r, unit * 0.5)
+    ctx.fill()
+    ctx.strokeStyle = PALETTE.emberDim
+    ctx.lineWidth = 1.5
+    ctx.stroke()
+
+    ctx.textAlign = "center"
+    ctx.textBaseline = "middle"
+    ctx.fillStyle = PALETTE.inkFaint
+    ctx.font = font(FACE_TEXT, unit * 0.72)
+    ctx.fillText("HIS", cx, r.y + unit * 0.86)
+
+    // The column. Two lines and a rule — and no total, ever. Right-aligned on a
+    // tabular grid so the places line up, because lining the places up is the
+    // whole skill this row of the graph is about.
+    const size = Math.min(unit * 1.55, panW / 4.4)
+    ctx.font = font(FACE_NUM, size)
+    ctx.fillStyle = PALETTE.ink
+    const right = r.x + panW - unit * 0.9
+    ctx.textAlign = "right"
+    const column = state.column
+    if (column) {
+      const top = r.y + panH * 0.46
+      ctx.fillText(column.top, right, top)
+      ctx.fillText(column.bottom, right, top + size * 1.12)
+      ctx.textAlign = "left"
+      ctx.fillStyle = PALETTE.emberBright
+      ctx.fillText(column.glyph, r.x + unit * 0.9, top + size * 1.12)
+      ctx.strokeStyle = PALETTE.inkFaint
+      ctx.lineWidth = 1.5
+      ctx.beginPath()
+      ctx.moveTo(r.x + unit * 0.8, top + size * 1.72)
+      ctx.lineTo(right + size * 0.1, top + size * 1.72)
+      ctx.stroke()
+    } else {
+      ctx.textAlign = "center"
+      ctx.fillText(state.promptRaw, cx, r.y + panH * 0.62)
+    }
+  }
+
+  private drawGauge(state: SceneState): void {
+    const ctx = this.ctx
+    const { gauge, unit } = this.box
+    const bout = state.bout
+
+    // Left two-thirds: the window. Right third: the strain in the steel.
+    const split = Math.round(gauge.w * 0.62)
+    const clock: Rect = { x: gauge.x, y: gauge.y, w: split, h: gauge.h }
+    const strainBar: Rect = {
+      x: gauge.x + split + unit * 0.7,
+      y: gauge.y,
+      w: gauge.w - split - unit * 0.7,
+      h: gauge.h,
+    }
+
+    ctx.fillStyle = PALETTE.stone
+    roundRect(ctx, clock, gauge.h / 2)
+    ctx.fill()
+    if (bout.phase === "press") {
+      const left = 1 - bout.progress
+      const urgent = left < 0.28
+      ctx.fillStyle = urgent ? PALETTE.ember : PALETTE.brassDim
+      roundRect(ctx, { ...clock, w: Math.max(2, clock.w * left) }, gauge.h / 2)
+      ctx.fill()
+    }
+
+    ctx.fillStyle = PALETTE.stone
+    roundRect(ctx, strainBar, gauge.h / 2)
+    ctx.fill()
+    const load = bout.strain.load
+    if (load > 0) {
+      ctx.fillStyle = mix(PALETTE.brass, PALETTE.strain, load)
+      roundRect(ctx, { ...strainBar, w: Math.max(2, strainBar.w * load) }, gauge.h / 2)
+      ctx.fill()
+    }
+    ctx.textAlign = "right"
+    ctx.textBaseline = "middle"
+    ctx.font = font(FACE_TEXT, unit * 0.62)
+    ctx.fillStyle = load > 0.72 ? PALETTE.strain : PALETTE.inkFaint
+    ctx.fillText("STRAIN", strainBar.x + strainBar.w, strainBar.y - unit * 0.62)
+  }
+
+  private drawRack(state: SceneState): void {
+    const ctx = this.ctx
+    const { unit } = this.box
+    const live = state.bout.phase === "press" && !state.paused
+
+    for (const pillar of this.box.pillars) {
+      for (const dir of [1, -1] as const) {
+        const r = dir > 0 ? pillar.up : pillar.down
+        const key = `${pillar.place}:${dir}`
+        const down = state.pressed.has(key)
+        const cooling = state.bout.cooling(pillar.place)
+        const base = dir > 0 ? PALETTE.stone : PALETTE.yard
+        ctx.fillStyle = down ? mix(base, PALETTE.brass, 0.42) : base
+        roundRect(ctx, r, unit * 0.42)
+        ctx.fill()
+        ctx.strokeStyle = live
+          ? cooling
+            ? PALETTE.stoneEdge
+            : dir > 0
+              ? PALETTE.brassDim
+              : PALETTE.steelDim
+          : PALETTE.stoneEdge
+        ctx.lineWidth = down ? 2.4 : 1.4
+        ctx.stroke()
+
+        ctx.textAlign = "center"
+        ctx.textBaseline = "middle"
+        ctx.font = font(FACE_NUM, Math.min(unit * 1.05, r.w / 3.4))
+        ctx.fillStyle = live ? (dir > 0 ? PALETTE.brassBright : PALETTE.steel) : PALETTE.inkFaint
+        ctx.fillText(placeLabel(pillar.place, dir), r.x + r.w / 2, r.y + r.h / 2)
+      }
+    }
+  }
+
+  private drawSeat(state: SceneState): void {
+    const ctx = this.ctx
+    const { seat, unit } = this.box
+    const bout = state.bout
+    const showing = bout.seat
+
+    ctx.fillStyle = state.seatHeld ? mix(PALETTE.stone, PALETTE.seat, 0.3) : PALETTE.stone
+    roundRect(ctx, seat, unit * 0.5)
+    ctx.fill()
+    ctx.strokeStyle = showing ? VERDICT_HUE[showing.verdict] : PALETTE.brassDim
+    ctx.lineWidth = 1.8
+    ctx.stroke()
+
+    ctx.textAlign = "center"
+    ctx.textBaseline = "middle"
+    const cx = seat.x + seat.w / 2
+    const cy = seat.y + seat.h / 2
+
+    if (showing) {
+      this.drawVerdict(showing, cx, cy)
+      return
+    }
+    if (bout.phase === "hang") {
+      ctx.font = font(FACE_TEXT, unit * 1.0)
+      ctx.fillStyle = PALETTE.inkFaint
+      ctx.fillText(this.box.compact ? "HE HANGS" : "HE HANGS A WEIGHT", cx, cy)
+      return
+    }
+    ctx.font = font(FACE_TEXT, unit * 1.22)
+    ctx.fillStyle = PALETTE.brassBright
+    ctx.fillText(this.box.compact ? "SEAT" : "SEAT THE BEAM", cx, cy)
+  }
+
+  private drawVerdict(showing: Seat, cx: number, cy: number): void {
+    const ctx = this.ctx
+    const unit = this.box.unit
+    ctx.font = font(FACE_TEXT, unit * 1.22)
+    ctx.fillStyle = VERDICT_HUE[showing.verdict]
+    const compact = this.box.compact
+    if (showing.verdict === "true") {
+      ctx.fillText(compact ? "HELD" : "HELD — ONE AHEAD", cx, cy)
+      return
+    }
+    if (showing.verdict === "shear") {
+      ctx.fillText(compact ? "SHEARED" : "SHEARED — TOO MANY BLOWS", cx, cy)
+      return
+    }
+    // What the child claimed, never what the answer was. The number they put on
+    // the beam is theirs; the Turk's total stays the Turk's.
+    const called = grouped(showing.asserted)
+    ctx.fillText(
+      compact
+        ? `${VERDICT_WORD[showing.verdict]} · ${called}`
+        : `${VERDICT_WORD[showing.verdict]} — YOU CALLED ${called}`,
+      cx,
+      cy,
+    )
+  }
+
+  private drawFlash(): void {
+    if (this.flashMs <= 0) return
+    const ctx = this.ctx
+    ctx.fillStyle = alpha(this.flashHue, (this.flashMs / 240) * 0.12)
+    ctx.fillRect(0, 0, this.box.w, this.box.h)
+  }
+
+  private drawSheet(): void {
+    // The host has something over the frame. The yard is still there, dimmed,
+    // and nothing under it is running.
+    const ctx = this.ctx
+    ctx.fillStyle = alpha(PALETTE.nightDeep, 0.55)
+    ctx.fillRect(0, 0, this.box.w, this.box.h)
+  }
+}

--- a/dynawalla/games/counterweight/src/sim/beam.ts
+++ b/dynawalla/games/counterweight/src/sim/beam.ts
@@ -1,0 +1,127 @@
+// The beam itself: a real spring-and-damper, because the beam is the only
+// instrument in the game that tells you anything.
+//
+// **What it reads, and what it deliberately will not read.** The beam's resting
+// angle is a *saturating* function of the margin. Within a few units of level it
+// has genuine gradation — you can feel one notch ahead differently from dead
+// level — and past that it is hard against its stop and says nothing but "miles
+// out". So it is a trim instrument, not an oracle: a player who has done the
+// arithmetic gets confirmation, and a player who has not cannot bisect their way
+// to a three-digit number through it.
+//
+// **The ring is the cost of a probe.** A blow sets the beam swinging, and a
+// swinging beam has no reading — the angle is travelling through everything. So
+// "strike and look" costs a settle, roughly a third of a second, every time. The
+// window runs out on anyone doing that thirty times.
+//
+// **Reduced motion is a branch here, and only here.** The beam still moves,
+// because the beam moving *is* the information; it is critically damped instead,
+// so it travels to its reading and stops rather than ringing its way there. Same
+// reading, same timing, no oscillation.
+
+/** Radians at the stop. A beam against its stop is unmistakable. */
+export const MAX_TILT = 0.42
+
+/**
+ * Units of margin per unit of tilt-shape. Small: the interesting region is the
+ * handful of units either side of level, and everything past it is the stop.
+ */
+export const SENSITIVITY = 3
+
+export type BeamTuning = {
+  /** Spring constant, rad/s² per rad. */
+  readonly stiffness: number
+  /** Damping, per second. */
+  readonly damping: number
+  /** Angular velocity a blow imparts, rad/s per unit of strain. */
+  readonly kick: number
+}
+
+export const TUNING: BeamTuning = { stiffness: 78, damping: 6.4, kick: 0.055 }
+
+/**
+ * Critically damped, no kick. `damping = 2√stiffness` is the boundary at which a
+ * spring stops overshooting, so this is the same beam with the ring taken out
+ * rather than a different beam.
+ */
+export const TUNING_REDUCED: BeamTuning = {
+  stiffness: 78,
+  damping: 2 * Math.sqrt(78),
+  kick: 0,
+}
+
+/** Below this angular speed the beam is readable. */
+export const SETTLE_OMEGA = 0.06
+
+/** Where the beam wants to sit for a given margin. */
+export function restAngle(margin: number): number {
+  return MAX_TILT * Math.tanh(margin / SENSITIVITY)
+}
+
+export class Beam {
+  private readonly tuning: BeamTuning
+  private theta = 0
+  private omega = 0
+  private target = 0
+
+  constructor(tuning: BeamTuning = TUNING) {
+    this.tuning = tuning
+  }
+
+  /** Positive is your side down — you are ahead. */
+  get angle(): number {
+    return this.theta
+  }
+
+  get velocity(): number {
+    return this.omega
+  }
+
+  /** True when the beam has stopped travelling and its reading can be trusted. */
+  get settled(): boolean {
+    return Math.abs(this.omega) < SETTLE_OMEGA
+  }
+
+  /** 0..1 — how much ring is left in the steel. Drives the shimmer and the drone. */
+  get ring(): number {
+    return Math.max(0, Math.min(1, Math.abs(this.omega) / 2.4))
+  }
+
+  /** The margin changed. */
+  aim(margin: number): void {
+    this.target = restAngle(margin)
+  }
+
+  /** A blow landed. `strength` is the strain it cost, so a hard blow rings hard. */
+  hit(strength: number, direction: number): void {
+    this.omega += this.tuning.kick * strength * Math.sign(direction || 1)
+  }
+
+  /** Slam to the stop and hold — the shear, and the pin. */
+  slam(direction: number): void {
+    this.theta = MAX_TILT * 1.5 * Math.sign(direction || 1)
+    this.omega = 0
+  }
+
+  advance(dtMs: number): void {
+    // Fixed sub-steps: an explicit integrator on a stiff spring goes unstable if
+    // it is handed a 120 ms frame, and an unstable beam is a beam that flies off
+    // the screen in front of a child.
+    let left = Math.max(0, dtMs)
+    while (left > 0) {
+      const step = Math.min(left, 4)
+      left -= step
+      const dt = step / 1000
+      const accel = -this.tuning.stiffness * (this.theta - this.target) - this.tuning.damping * this.omega
+      this.omega += accel * dt
+      this.theta += this.omega * dt
+    }
+  }
+
+  /** Put the beam where it belongs with no travel. Used when a round opens. */
+  settleTo(margin: number): void {
+    this.target = restAngle(margin)
+    this.theta = this.target
+    this.omega = 0
+  }
+}

--- a/dynawalla/games/counterweight/src/stubHost.ts
+++ b/dynawalla/games/counterweight/src/stubHost.ts
@@ -1,0 +1,302 @@
+// A local stub Host so the match is playable standalone with `npm run dev`.
+//
+// It serves what the real runtime serves and nothing else. Only the `add`
+// domain is active in the curriculum graph, every one of its seven live rows is
+// a whole-number column operation, and `covers` is a request rather than an
+// instruction — so a stub that dealt fractions or long division would be a
+// rehearsal for a match that never happens. Column add and column subtract, at
+// two to four digits, is the truth.
+//
+// Three properties the real runtime also honours, asserted by
+// `src/test/stubHost.test.ts`:
+//
+//   1. **Exact arithmetic.** Every operand, answer and distractor is an integer.
+//      No float ever reaches an answer string or a comparison.
+//   2. **Seeded and deterministic.** Same seed → same question stream, forever.
+//      That is what makes "no mashing strategy beats a Turk" a claim a test can
+//      settle rather than an opinion.
+//   3. **Distractors are real mal-rule outputs.** Each one is the value a child
+//      running a specific broken procedure actually writes down. The procedures
+//      are ported from `packs/shared/curriculum/src/malrules/columnOp.ts` —
+//      `mis.add.carry-dropped`, `mis.add.smaller-from-larger` and
+//      `mis.add.borrow-across-zero` — including their `applies()` guards, so a
+//      rule that would coincide with the correct procedure emits nothing at all.
+//      Never `answer ± 1`, and never a fixed offset off the answer.
+//
+// The third one earns its keep here. THE COUNTERWEIGHT never *places* a
+// distractor — there is nothing to choose between, only a beam to hold — but the
+// value the child's beam asserts is reported verbatim, so a child who drops a
+// carry seats their pan on the carry-dropped value and the Turk recognises it.
+// He has seen that one before. That beat is the diagnosis, and a stub that made
+// wrong answers up would fire it at random.
+
+import type { Host, Question } from "./contract.ts"
+import { Rng } from "./core/rng.ts"
+
+type Op = "add" | "sub"
+
+/** Digits of `n`, least significant first. `0` is one digit. */
+function digitsOf(n: number): number[] {
+  if (n === 0) return [0]
+  const out: number[] = []
+  let m = n
+  while (m > 0) {
+    out.push(m % 10)
+    m = Math.floor(m / 10)
+  }
+  return out
+}
+
+function fromDigits(ds: readonly number[]): number {
+  let out = 0
+  for (let i = ds.length - 1; i >= 0; i--) out = out * 10 + (ds[i] as number)
+  return out
+}
+
+/** Columns the pair occupies. */
+function colsOf(a: number, b: number): number {
+  return Math.max(digitsOf(a).length, digitsOf(b).length)
+}
+
+/**
+ * `mis.add.carry-dropped` — every column added, no carry ever recorded or added
+ * into the next one. 27 + 15 → 32.
+ *
+ * Undefined when nothing carries: then it is the correct procedure.
+ */
+export function carryDropped(a: number, b: number): number | null {
+  const da = digitsOf(a)
+  const db = digitsOf(b)
+  const n = colsOf(a, b)
+  const out: number[] = []
+  let carried = false
+  for (let i = 0; i < n; i++) {
+    const sum = (da[i] ?? 0) + (db[i] ?? 0)
+    if (sum > 9) carried = true
+    out.push(sum % 10)
+  }
+  return carried ? fromDigits(out) : null
+}
+
+/**
+ * `mis.add.smaller-from-larger` — in every column the smaller digit is taken
+ * from the larger, whichever is on top, and nothing is regrouped. 52 − 27 → 35.
+ *
+ * Undefined when no column would have needed regrouping.
+ */
+export function smallerFromLarger(a: number, b: number): number | null {
+  const da = digitsOf(a)
+  const db = digitsOf(b)
+  const n = colsOf(a, b)
+  let needed = false
+  const out: number[] = []
+  for (let i = 0; i < n; i++) {
+    const top = da[i] ?? 0
+    const bot = db[i] ?? 0
+    if (bot > top) needed = true
+    out.push(Math.abs(top - bot))
+  }
+  return needed ? fromDigits(out) : null
+}
+
+/**
+ * `mis.add.borrow-across-zero` — regrouped all the way down through a run of
+ * zeros, writing them as 9s, and never decrementing the digit above the run.
+ * 403 − 87 → 416, not 316.
+ *
+ * Undefined unless the borrow chain actually crossed a zero: with a non-zero
+ * digit to borrow from, this procedure decrements it correctly and is correct.
+ */
+export function borrowAcrossZero(a: number, b: number): number | null {
+  const da = digitsOf(a)
+  const db = digitsOf(b)
+  const n = colsOf(a, b)
+  const work = da.slice()
+  while (work.length < n) work.push(0)
+  const out: number[] = []
+  let crossedZero = false
+  for (let i = 0; i < n; i++) {
+    let top = work[i] as number
+    const bot = db[i] ?? 0
+    if (top < bot) {
+      let j = i + 1
+      while (j < n && (work[j] as number) === 0) {
+        work[j] = 9
+        j++
+      }
+      if (j >= n) return null
+      // The bug, and only here: a run of zeros became 9s and the digit above it
+      // was left alone. With no run, the decrement happens and this is correct.
+      if (j > i + 1) crossedZero = true
+      else work[j] = (work[j] as number) - 1
+      top += 10
+    }
+    out.push(top - bot)
+  }
+  return crossedZero ? fromDigits(out) : null
+}
+
+/**
+ * The wrong operation entirely — the one error below that is *not* one of the
+ * graph's three, and is named as such rather than dressed up as one. A child who
+ * reads `+` as `−` is not running a broken column procedure; they are answering
+ * a different question, and the value is worth having on the beam all the same.
+ */
+export function wrongOperation(op: Op, a: number, b: number): number {
+  return op === "add" ? Math.abs(a - b) : a + b
+}
+
+function malRulesFor(op: Op, a: number, b: number): number[] {
+  const rules =
+    op === "add"
+      ? [carryDropped(a, b), wrongOperation(op, a, b)]
+      : [smallerFromLarger(a, b), borrowAcrossZero(a, b), wrongOperation(op, a, b)]
+  return rules.filter((v): v is number => v !== null)
+}
+
+/**
+ * Operands, drawn to the shape of the seven active `dw.add` rows.
+ *
+ * `level` is 0..7 and matches what the host's ladder walks: two digits without
+ * regrouping at the bottom, four digits with regrouping across a zero at the
+ * top. The stub is the ladder, not a random-number generator with a difficulty
+ * knob taped to it.
+ */
+function operandsFor(op: Op, level: number, rng: Rng): [number, number] {
+  const lv = Math.max(0, Math.min(7, Math.round(level)))
+  const digits = lv <= 1 ? 2 : lv <= 4 ? 3 : 4
+  const lo = 10 ** (digits - 1)
+  const hi = 10 ** digits - 1
+
+  if (op === "add") {
+    if (lv <= 1) {
+      // No regrouping: built column by column so no column can carry.
+      const da: number[] = []
+      const db: number[] = []
+      for (let i = 0; i < digits; i++) {
+        const x = rng.int(i === digits - 1 ? 1 : 0, 8)
+        const y = rng.int(i === digits - 1 ? 1 : 0, 9 - x)
+        da.push(x)
+        db.push(y)
+      }
+      return [fromDigits(da), fromDigits(db)]
+    }
+    // Short addend at the top of the ladder — `4,003 + 87` is its own row.
+    if (lv >= 6) return [rng.int(lo, hi), rng.int(10, 99)]
+    return [rng.int(lo, hi), rng.int(lo, hi)]
+  }
+
+  if (lv <= 1) {
+    // No regrouping: every top digit is at least the bottom one, and the ones
+    // column is strictly greater so the difference is never zero — the graph
+    // sets `allowZeroResult: false`, and a pan with nothing on it is not a round.
+    const da: number[] = []
+    const db: number[] = []
+    for (let i = 0; i < digits; i++) {
+      const top = rng.int(i === digits - 1 ? 2 : 1, 9)
+      const lowest = i === digits - 1 ? 1 : 0
+      da.push(top)
+      db.push(rng.int(lowest, i === 0 ? top - 1 : top))
+    }
+    return [fromDigits(da), fromDigits(db)]
+  }
+  if (lv >= 6) {
+    // Across a zero: plant one so `borrowAcrossZero` has something to be wrong
+    // about, which is what makes that diagnosis reachable at all.
+    const ds = [rng.int(0, 9), 0, rng.int(1, 9), rng.int(1, 9)].slice(0, digits)
+    const a = Math.max(fromDigits(ds), 100)
+    return [a, rng.int(10, Math.max(11, Math.min(99, a - 1)))]
+  }
+  const a = rng.int(lo + 10, hi)
+  return [a, rng.int(lo, a - 1)]
+}
+
+const GLYPH: Record<Op, string> = { add: "+", sub: "−" }
+
+/** The ladder's height, matching the host's `item.level / 8` normalisation. */
+const LEVELS = 8
+
+export type StubHostOptions = {
+  seed?: number
+  reducedMotion?: boolean
+  /** Pin the ladder level instead of walking it. For tests and for capture runs. */
+  level?: number
+  /** Observe reports — the dev harness draws a running tally from this. */
+  onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void
+  /** Observe haptics so the harness can show they fired on a device that has none. */
+  onHaptic?: (k: string) => void
+  /** Observe stopping points, so the harness can prove they only follow a win. */
+  onTransition?: (kind: string, label?: string) => void
+}
+
+export function createStubHost(options: StubHostOptions = {}): Host {
+  const rng = new Rng(options.seed ?? 0x9a11c7)
+  let served = 0
+
+  return {
+    next(o) {
+      served++
+      // A slow walk up the ladder, so a dev session sees two-digit sums first
+      // and four-digit borrows twenty rounds later — the shape of a real
+      // scheduler, without pretending to be one.
+      const level =
+        options.level !== undefined
+          ? Math.max(0, Math.min(LEVELS - 1, Math.round(options.level)))
+          : Math.min(LEVELS - 1, Math.floor((served - 1) / 6))
+      const op: Op = rng.chance(0.5) ? "add" : "sub"
+      const [a, b] = operandsFor(op, level, rng)
+      const answer = op === "add" ? a + b : a - b
+
+      const seen = new Set<number>([answer])
+      const pool: number[] = []
+      for (const v of malRulesFor(op, a, b)) {
+        if (!Number.isInteger(v) || v < 1 || seen.has(v)) continue
+        seen.add(v)
+        pool.push(v)
+      }
+      rng.shuffle(pool)
+
+      return {
+        id: `stub-${served}`,
+        prompt: `${a} ${GLYPH[op]} ${b}`,
+        answer: String(answer),
+        distractors: pool.slice(0, 3).map(String),
+        domain: o?.domain ?? "add",
+        // Normalised the way the pack host normalises it: `item.level / 8`.
+        difficulty: level / LEVELS,
+      } satisfies Question
+    },
+
+    report(r) {
+      options.onReport?.(r)
+    },
+
+    haptic(k) {
+      options.onHaptic?.(k)
+      const nav = globalThis.navigator as Navigator | undefined
+      if (!nav || typeof nav.vibrate !== "function") return
+      const ms =
+        k === "light" ? 8 : k === "medium" ? 18 : k === "heavy" ? 34 : k === "success" ? 12 : 40
+      try {
+        if (k === "success") nav.vibrate([ms, 26, ms])
+        else if (k === "failure") nav.vibrate([ms, 40, ms])
+        else nav.vibrate(ms)
+      } catch {
+        // A browser that exposes vibrate but refuses it (no user gesture yet, or
+        // a policy block) must never take the frame down with it.
+        console.warn("[counterweight] navigator.vibrate refused")
+      }
+    },
+
+    prefersReducedMotion() {
+      if (options.reducedMotion !== undefined) return options.reducedMotion
+      return (
+        typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion: reduce)").matches
+      )
+    },
+
+    transition(kind, label) {
+      options.onTransition?.(kind, label)
+    },
+  }
+}

--- a/dynawalla/games/counterweight/src/test/beam.test.ts
+++ b/dynawalla/games/counterweight/src/test/beam.test.ts
@@ -1,0 +1,84 @@
+// The beam is the game's only instrument. These are the two things it must be:
+// **stable**, so it never flies off the screen, and **saturating**, so it cannot
+// be used as a substitute for the arithmetic.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Beam, MAX_TILT, restAngle, SETTLE_OMEGA, TUNING, TUNING_REDUCED } from "../sim/beam.ts"
+
+test("the beam reads finely near level and says nothing at all far from it", () => {
+  // One notch ahead has to be visibly different from dead level: that difference
+  // is the whole reward for landing it exactly.
+  assert.ok(restAngle(1) - restAngle(0) > 0.1)
+  assert.ok(restAngle(0) - restAngle(-1) > 0.1)
+
+  // And by the time you are a hundred out, so is a thousand. There is no
+  // magnitude information past the stop, so no amount of watching gets you to a
+  // three-digit number.
+  assert.ok(Math.abs(restAngle(120) - restAngle(9000)) < 0.001)
+  assert.ok(Math.abs(restAngle(120)) > MAX_TILT * 0.99)
+})
+
+test("the reading is monotone in the margin", () => {
+  let previous = -Infinity
+  for (let m = -60; m <= 60; m++) {
+    const a = restAngle(m)
+    assert.ok(a >= previous, `the beam went the wrong way at margin ${m}`)
+    previous = a
+  }
+})
+
+test("the beam settles, and a blow makes it stop being readable", () => {
+  const beam = new Beam(TUNING)
+  beam.settleTo(1)
+  assert.equal(beam.settled, true)
+  beam.hit(9, 1)
+  assert.equal(beam.settled, false, "a blow left the beam readable")
+
+  let ms = 0
+  while (!beam.settled && ms < 4000) {
+    beam.advance(16)
+    ms += 16
+  }
+  assert.ok(beam.settled, "the beam never came to rest")
+  // The cost of a probe. Long enough that hunting is slower than thinking, short
+  // enough that a player who has done the arithmetic is not kept waiting.
+  assert.ok(ms > 120 && ms < 900, `a blow took ${ms} ms to settle`)
+})
+
+test("a stiff spring stays stable even when the frame takes an age", () => {
+  const beam = new Beam(TUNING)
+  beam.settleTo(0)
+  beam.aim(40)
+  for (let i = 0; i < 200; i++) {
+    beam.advance(120)
+    assert.ok(Number.isFinite(beam.angle), "the beam went to infinity")
+    assert.ok(Math.abs(beam.angle) < MAX_TILT * 3, `the beam flew off at ${beam.angle}`)
+  }
+  assert.ok(Math.abs(beam.angle - restAngle(40)) < 0.01)
+})
+
+test("the reduced-motion beam travels to the same reading without ringing", () => {
+  const calm = new Beam(TUNING_REDUCED)
+  calm.settleTo(-6)
+  calm.aim(6)
+  let overshoot = 0
+  for (let i = 0; i < 400; i++) {
+    calm.advance(8)
+    overshoot = Math.max(overshoot, calm.angle - restAngle(6))
+  }
+  assert.ok(overshoot < 1e-6, `the calm beam overshot by ${overshoot}`)
+  assert.ok(Math.abs(calm.angle - restAngle(6)) < 0.001, "the calm beam never arrived")
+  // Same reading, same destination — a branch, not a degradation.
+  const loud = new Beam(TUNING)
+  loud.settleTo(6)
+  assert.ok(Math.abs(loud.angle - calm.angle) < 0.001)
+})
+
+test("a blow under reduced motion does not set the beam ringing", () => {
+  const calm = new Beam(TUNING_REDUCED)
+  calm.settleTo(0)
+  calm.hit(12, 1)
+  assert.ok(Math.abs(calm.velocity) < SETTLE_OMEGA)
+})

--- a/dynawalla/games/counterweight/src/test/best.test.ts
+++ b/dynawalla/games/counterweight/src/test/best.test.ts
@@ -1,0 +1,107 @@
+// The tally has to survive a storage that is not there — which, inside a pack
+// frame, is the normal case rather than the edge one.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { loadTally, recordTally, resetTallyForTest } from "../game/best.ts"
+
+type Slot = { value: string | null; throwOnRead?: boolean; throwOnWrite?: boolean }
+
+function withStorage(slot: Slot | null, body: () => void): void {
+  const had = Object.getOwnPropertyDescriptor(globalThis, "localStorage")
+  const fake =
+    slot === null
+      ? undefined
+      : {
+          getItem() {
+            if (slot.throwOnRead) throw new Error("opaque origin")
+            return slot.value
+          },
+          setItem(_key: string, value: string) {
+            if (slot.throwOnWrite) throw new Error("quota")
+            slot.value = value
+          },
+        }
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    writable: true,
+    value: fake,
+  })
+  try {
+    body()
+  } finally {
+    if (had) Object.defineProperty(globalThis, "localStorage", had)
+    else Reflect.deleteProperty(globalThis, "localStorage")
+  }
+}
+
+test("a storage that throws on the first read costs the session nothing", () => {
+  // This is the pack frame: an opaque origin, and every touch of `localStorage`
+  // throws. The in-memory mirror is the source of truth, not a cache.
+  resetTallyForTest()
+  withStorage({ value: null, throwOnRead: true }, () => {
+    assert.deepEqual(loadTally(), { turks: 0, hold: 0 })
+    assert.deepEqual(recordTally(3, 7), { turks: 3, hold: 7 })
+    assert.deepEqual(recordTally(1, 2), { turks: 3, hold: 7 }, "the tally went backwards")
+  })
+})
+
+test("no storage at all is the same story", () => {
+  resetTallyForTest()
+  withStorage(null, () => {
+    assert.deepEqual(recordTally(2, 4), { turks: 2, hold: 4 })
+    assert.deepEqual(loadTally(), { turks: 2, hold: 4 })
+  })
+})
+
+test("a real storage round-trips, and never regresses", () => {
+  const slot: Slot = { value: null }
+  resetTallyForTest()
+  withStorage(slot, () => {
+    recordTally(5, 9)
+    assert.ok(slot.value)
+  })
+  resetTallyForTest()
+  withStorage(slot, () => {
+    assert.deepEqual(loadTally(), { turks: 5, hold: 9 })
+    assert.deepEqual(recordTally(4, 3), { turks: 5, hold: 9 })
+  })
+})
+
+test("a record that will not parse is loud, and is not fatal", () => {
+  resetTallyForTest()
+  const warnings: unknown[] = []
+  const original = console.warn
+  console.warn = (...args: unknown[]) => warnings.push(args)
+  try {
+    withStorage({ value: "{not json" }, () => {
+      assert.deepEqual(loadTally(), { turks: 0, hold: 0 })
+    })
+  } finally {
+    console.warn = original
+  }
+  assert.equal(warnings.length, 1, "a broken record went by in silence")
+})
+
+test("a write that is refused is loud, and the session keeps its tally", () => {
+  resetTallyForTest()
+  const warnings: unknown[] = []
+  const original = console.warn
+  console.warn = (...args: unknown[]) => warnings.push(args)
+  try {
+    withStorage({ value: null, throwOnWrite: true }, () => {
+      assert.deepEqual(recordTally(6, 2), { turks: 6, hold: 2 })
+    })
+  } finally {
+    console.warn = original
+  }
+  assert.equal(warnings.length, 1)
+})
+
+test("nonsense in the record is ignored rather than trusted", () => {
+  resetTallyForTest()
+  withStorage({ value: JSON.stringify({ turks: "many", hold: 4.5 }) }, () => {
+    assert.deepEqual(loadTally(), { turks: 0, hold: 0 })
+  })
+})

--- a/dynawalla/games/counterweight/src/test/bout.test.ts
+++ b/dynawalla/games/counterweight/src/test/bout.test.ts
@@ -1,0 +1,252 @@
+// The rules, on a fixed deal.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import type { Question } from "../contract.ts"
+import {
+  Bout,
+  GROUND,
+  openingLoad,
+  TIMING,
+  type BoutEvent,
+  timingForBout,
+} from "../game/bout.ts"
+import { planStrikes } from "../game/places.ts"
+
+function question(answer: number, id = "q1"): Question {
+  return {
+    id,
+    prompt: `${answer - 100} + 100`,
+    answer: String(answer),
+    distractors: [],
+    domain: "add",
+    difficulty: 0.4,
+  }
+}
+
+/** A deal that hands out the same value forever, with fresh ids. */
+function fixed(answer: number): () => Question {
+  let n = 0
+  return () => question(answer, `q${++n}`)
+}
+
+/** Advance to the open window and hand back the events on the way. */
+function open(bout: Bout): BoutEvent[] {
+  const events = bout.begin()
+  events.push(...bout.advance(TIMING.hangMs + 1))
+  assert.equal(bout.phase, "press")
+  return events
+}
+
+/** Put the pan on `value` the way a player would: strike the plan. */
+function loadTo(bout: Bout, value: number): void {
+  for (const strike of planStrikes(value - bout.load)) {
+    bout.strike(strike)
+    bout.advance(300)
+  }
+  assert.equal(bout.load, value)
+}
+
+test("a round opens with a weight on his pan and a window on yours", () => {
+  const bout = new Bout(fixed(641))
+  const events = open(bout)
+  const hang = events.find((e) => e.kind === "hang")
+  assert.ok(hang && hang.kind === "hang")
+  assert.equal(hang.question.answer, "641")
+  assert.equal(bout.his, 641)
+  // The delta the round is asking for: his value, one notch, less what is there.
+  assert.equal(hang.delta, 641 + 1 - bout.load)
+  assert.ok(events.some((e) => e.kind === "open"))
+})
+
+test("one notch ahead holds; nothing else does", () => {
+  for (const [load, verdict] of [
+    [642, "true"],
+    [641, "short"],
+    [640, "short"],
+    [643, "over"],
+    [741, "over"],
+  ] as const) {
+    const bout = new Bout(fixed(641))
+    open(bout)
+    loadTo(bout, load)
+    const [event] = bout.seatNow()
+    assert.ok(event && event.kind === "seat")
+    assert.equal(event.seat.verdict, verdict, `a load of ${load} judged ${event.seat.verdict}`)
+  }
+})
+
+test("what crosses to the host is the value the beam claimed his column was", () => {
+  const bout = new Bout(fixed(641))
+  open(bout)
+  loadTo(bout, 632)
+  const [event] = bout.seatNow()
+  assert.ok(event && event.kind === "seat")
+  // A child who dropped a ten claims 631, not "wrong". That is the diagnosis.
+  assert.equal(event.seat.asserted, 631)
+  assert.equal(event.seat.load, 632)
+  assert.equal(event.seat.declared, true)
+})
+
+test("a held round takes ground and a missed one gives it back", () => {
+  const bout = new Bout(fixed(500))
+  open(bout)
+  loadTo(bout, 501)
+  bout.seatNow()
+  assert.equal(bout.match.arm, 1)
+  assert.equal(bout.match.held, 1)
+  bout.advance(TIMING.settleMs + TIMING.hangMs + 4)
+  assert.equal(bout.phase, "press")
+  loadTo(bout, 400)
+  bout.seatNow()
+  assert.equal(bout.match.arm, 0)
+})
+
+test("five held rounds put the Turk over, and only then", () => {
+  const bout = new Bout(fixed(500))
+  const events: BoutEvent[] = []
+  open(bout)
+  for (let i = 0; i < GROUND; i++) {
+    loadTo(bout, 501)
+    events.push(...bout.seatNow())
+    events.push(...bout.advance(TIMING.settleMs + TIMING.hangMs + 4))
+  }
+  const won = events.filter((e) => e.kind === "won")
+  assert.equal(won.length, 1, "the Turk went over the wrong number of times")
+  assert.equal(bout.match.won, 1)
+  assert.equal(bout.match.bout, 2)
+  assert.equal(bout.match.arm, 0, "the arm did not go back to level for the next Turk")
+})
+
+test("being pinned costs the arm and nothing else — no Turk, no tally, no punishment", () => {
+  const bout = new Bout(fixed(500))
+  const events: BoutEvent[] = []
+  open(bout)
+  for (let i = 0; i < GROUND; i++) {
+    events.push(...bout.seatNow())
+    events.push(...bout.advance(TIMING.settleMs + TIMING.hangMs + 4))
+  }
+  const pinned = events.filter((e) => e.kind === "pinned")
+  assert.equal(pinned.length, 1)
+  assert.equal(bout.match.won, 0)
+  // Stakes without loss: the same Turk squares back up, no harder than before.
+  assert.equal(bout.match.bout, 1)
+  assert.equal(bout.match.arm, 0)
+  assert.equal(bout.timings.pressMs, timingForBout(1).pressMs)
+  // And a pin is never a stopping point: nothing here is a `won` event.
+  assert.equal(events.filter((e) => e.kind === "won").length, 0)
+})
+
+test("the window running out seats the beam where it stands", () => {
+  // Sag is switched off for this one so the only thing under test is the
+  // whistle. The case just below covers what the pan does when it is left alone.
+  const bout = new Bout(fixed(500), { ...TIMING, sagGraceMs: 10 ** 9 })
+  open(bout)
+  loadTo(bout, 501)
+  const events = bout.advance(TIMING.pressMs + 100)
+  const seat = events.find((e) => e.kind === "seat")
+  assert.ok(seat && seat.kind === "seat")
+  // Honest either way: they had it, so it counts.
+  assert.equal(seat.seat.verdict, "true")
+  assert.equal(seat.seat.declared, false, "the whistle was recorded as a declaration")
+})
+
+test("a pan nobody is tending settles, and a strike re-seats it", () => {
+  const bout = new Bout(fixed(500))
+  open(bout)
+  const before = bout.load
+  bout.advance(TIMING.sagGraceMs + TIMING.sagPeriodMs * 3 + 20)
+  assert.equal(bout.load, before - 3, "the pan did not settle under a load left alone")
+
+  const now = bout.load
+  bout.strike({ place: 1, dir: 1 })
+  bout.advance(TIMING.sagGraceMs - 10)
+  assert.equal(bout.load, now + 1, "the sag did not start over after a strike")
+})
+
+test("a pillar still swinging back refuses the next blow", () => {
+  const bout = new Bout(fixed(500))
+  open(bout)
+  const first = bout.strike({ place: 10, dir: 1 })
+  assert.equal(first[0]?.kind, "strike")
+  const second = bout.strike({ place: 10, dir: 1 })
+  assert.deepEqual(second, [{ kind: "refused", reason: "cooldown" }])
+  // A different pillar is a different plate, and is free.
+  assert.equal(bout.strike({ place: 100, dir: 1 })[0]?.kind, "strike")
+})
+
+test("nothing can be struck outside the window", () => {
+  const bout = new Bout(fixed(500))
+  bout.begin()
+  assert.equal(bout.phase, "hang")
+  assert.deepEqual(bout.strike({ place: 1, dir: 1 }), [{ kind: "refused", reason: "phase" }])
+  assert.deepEqual(bout.seatNow(), [{ kind: "refused", reason: "phase" }])
+})
+
+test("shearing the steel ends the round on the blow that broke it", () => {
+  const bout = new Bout(fixed(500))
+  open(bout)
+  let events: BoutEvent[] = []
+  for (let i = 0; i < 200 && bout.phase === "press"; i++) {
+    events = bout.strike({ place: (i % 2 === 0 ? 1 : 10) as 1 | 10, dir: 1 })
+    bout.advance(56)
+  }
+  const seat = events.find((e) => e.kind === "seat")
+  assert.ok(seat && seat.kind === "seat", "mashing never sheared the beam")
+  assert.equal(seat.seat.verdict, "shear")
+  assert.equal(bout.match.arm, -1)
+})
+
+test("the Turk tightens the window and the steel, and never the arithmetic", () => {
+  const one = timingForBout(1)
+  const five = timingForBout(5)
+  assert.ok(five.pressMs < one.pressMs)
+  assert.ok(five.shearAt < one.shearAt)
+  assert.ok(five.sagPeriodMs < one.sagPeriodMs)
+  // Floors, so it stops at hard rather than running off to impossible.
+  const far = timingForBout(40)
+  assert.ok(far.pressMs >= 7000)
+  assert.ok(far.shearAt >= 20)
+  assert.equal(far.pressMs, timingForBout(41).pressMs)
+})
+
+test("the first pan of a session starts a few strikes off, never on the answer", () => {
+  for (const target of [45, 641, 1287, 9004]) {
+    const load = openingLoad(target)
+    assert.ok(Number.isInteger(load))
+    assert.ok(load > 0, `an opening load of ${load} is an empty pan`)
+    assert.notEqual(load, target + 1, "the opening load was the answer")
+    const strikes = planStrikes(target + 1 - load).length
+    assert.ok(strikes >= 2 && strikes <= 20, `${target} opened ${strikes} strikes away`)
+  }
+})
+
+test("a host that serves something unweighable is loud, and the round still runs", () => {
+  const errors: unknown[] = []
+  const original = console.error
+  console.error = (...args: unknown[]) => errors.push(args)
+  try {
+    const bout = new Bout(() => ({ ...question(0), answer: "seven" }))
+    open(bout)
+    assert.ok(errors.length > 0, "a non-integer answer went by in silence")
+    assert.equal(bout.phase, "press")
+  } finally {
+    console.error = original
+  }
+})
+
+test("driving your own pan to nothing is not a way out of the round", () => {
+  // The opening load is seeded once a session. Testing against a load of zero
+  // instead would hand a free reset to anybody who struck the pan down to
+  // nothing — a rule nobody was told about, and a way to dodge a round already
+  // lost.
+  const bout = new Bout(fixed(1500))
+  open(bout)
+  loadTo(bout, 0)
+  assert.equal(bout.load, 0)
+  bout.seatNow()
+  bout.advance(TIMING.settleMs + TIMING.hangMs + 4)
+  assert.equal(bout.phase, "press")
+  assert.equal(bout.load, 0, "the pan was quietly re-seeded")
+})

--- a/dynawalla/games/counterweight/src/test/column.test.ts
+++ b/dynawalla/games/counterweight/src/test/column.test.ts
@@ -1,0 +1,34 @@
+// The Turk's pan draws a column, and the host hands over a string. This is the
+// join, and its only hard rule is that the pan is never empty.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { splitPrompt } from "../game/column.ts"
+
+test("a sum splits into two operands and a glyph", () => {
+  assert.deepEqual(splitPrompt("473 + 168"), { top: "473", glyph: "+", bottom: "168" })
+})
+
+test("every minus a host might send comes out as one minus", () => {
+  for (const glyph of ["-", "−", "–"]) {
+    const column = splitPrompt(`5001 ${glyph} 2798`)
+    assert.deepEqual(column, { top: "5001", glyph: "−", bottom: "2798" })
+  }
+})
+
+test("grouped operands keep their grouping — the places must stay lined up", () => {
+  assert.deepEqual(splitPrompt("4 003 − 87"), { top: "4 003", glyph: "−", bottom: "87" })
+  assert.deepEqual(splitPrompt("4,003 − 87"), { top: "4,003", glyph: "−", bottom: "87" })
+})
+
+test("anything that is not a two-operand column comes back as nothing", () => {
+  // And `scene.ts` then draws the prompt on one line rather than an empty pan.
+  for (const prompt of ["", "473", "3 × 4 + 1", "what is 4 + 4?", "+ 168"]) {
+    assert.equal(splitPrompt(prompt), null, `"${prompt}" was read as a column`)
+  }
+})
+
+test("surrounding space is not part of an operand", () => {
+  assert.deepEqual(splitPrompt("  27   +   15  "), { top: "27", glyph: "+", bottom: "15" })
+})

--- a/dynawalla/games/counterweight/src/test/harness.ts
+++ b/dynawalla/games/counterweight/src/test/harness.ts
@@ -1,0 +1,196 @@
+// A headless player.
+//
+// `play()` drives a real `Bout` — the same class `mount.ts` drives — at a fixed
+// 16 ms step, feeding it strikes from a strategy. That is what lets the mashing
+// tests be an experiment rather than an argument: the masher is not a
+// description of mashing, it is a player, and it plays the shipping rules.
+
+import { Bout, type BoutEvent, type Timing, type Verdict } from "../game/bout.ts"
+import { FACES, planStrikes, type Strike } from "../game/places.ts"
+import type { Question } from "../contract.ts"
+import { Rng } from "../core/rng.ts"
+import { Beam, TUNING } from "../sim/beam.ts"
+import { createStubHost } from "../stubHost.ts"
+
+export type Table = {
+  /** The bout under way, so a strategy can read the beam and the clock. */
+  readonly bout: Bout
+  /** The beam, integrated alongside — a strategy that watches it pays for it. */
+  readonly beam: Beam
+  readonly rng: Rng
+  /** Milliseconds since this window opened. */
+  readonly windowMs: number
+}
+
+/** Return the actions to take on this tick. `"seat"` judges the beam. */
+export type Strategy = (table: Table) => ReadonlyArray<Strike | "seat">
+
+export type Play = {
+  readonly won: number
+  readonly held: number
+  readonly rounds: number
+  readonly verdicts: Record<Verdict, number>
+  readonly bestArm: number
+  readonly reports: ReadonlyArray<{ correct: boolean; answered: string }>
+}
+
+export type PlayOptions = {
+  readonly seed?: number
+  readonly seconds?: number
+  readonly level?: number
+  readonly timing?: Timing
+}
+
+const STEP = 16
+
+export function play(strategy: Strategy, options: PlayOptions = {}): Play {
+  const host = createStubHost({
+    seed: options.seed ?? 0x51ee,
+    reducedMotion: true,
+    ...(options.level === undefined ? {} : { level: options.level }),
+  })
+  const rng = new Rng((options.seed ?? 0x51ee) ^ 0x2f19)
+  const beam = new Beam(TUNING)
+  const deal = (): Question => host.next({ domain: "add" })
+  const bout = options.timing ? new Bout(deal, options.timing) : new Bout(deal)
+
+  const verdicts: Record<Verdict, number> = { true: 0, short: 0, over: 0, shear: 0 }
+  const reports: Array<{ correct: boolean; answered: string }> = []
+  let rounds = 0
+  let bestArm = 0
+  let windowMs = 0
+
+  const absorb = (events: readonly BoutEvent[]): void => {
+    for (const event of events) {
+      if (event.kind === "open") windowMs = 0
+      if (event.kind === "strike") beam.hit(event.impulse, event.strike.dir)
+      if (event.kind === "hang" || event.kind === "strike" || event.kind === "sag") {
+        beam.aim(bout.margin)
+      }
+      if (event.kind === "seat") {
+        rounds += 1
+        verdicts[event.seat.verdict] += 1
+        reports.push({
+          correct: event.seat.verdict === "true",
+          answered: String(event.seat.asserted),
+        })
+        beam.aim(bout.margin)
+        bestArm = Math.max(bestArm, event.arm)
+      }
+    }
+  }
+
+  absorb(bout.begin())
+  beam.settleTo(bout.margin)
+
+  const ticks = Math.round(((options.seconds ?? 120) * 1000) / STEP)
+  for (let i = 0; i < ticks; i++) {
+    absorb(bout.advance(STEP))
+    beam.advance(STEP)
+    if (bout.phase === "press") windowMs += STEP
+    for (const action of strategy({ bout, beam, rng, windowMs })) {
+      absorb(action === "seat" ? bout.seatNow() : bout.strike(action))
+      if (bout.phase !== "press") break
+    }
+  }
+
+  return { won: bout.match.won, held: bout.match.held, rounds, verdicts, bestArm, reports }
+}
+
+// ---------------------------------------------------------------------------
+// The strategies.
+// ---------------------------------------------------------------------------
+
+/** Hit anything, as fast as a thumb can. The thing the design has to beat. */
+export function masher(gapMs = 56): Strategy {
+  let since = 0
+  return ({ rng, bout }) => {
+    since += STEP
+    if (bout.phase !== "press" || since < gapMs) return []
+    since = 0
+    return [rng.pick(FACES)]
+  }
+}
+
+/** One plate, over and over — the other shape mashing takes. */
+export function hammer(strike: Strike, gapMs = 56): Strategy {
+  let since = 0
+  return ({ bout }) => {
+    since += STEP
+    if (bout.phase !== "press" || since < gapMs) return []
+    since = 0
+    return [strike]
+  }
+}
+
+/**
+ * A child who does the arithmetic: read his column, work out the difference,
+ * strike the places it decomposes into, seat.
+ *
+ * `thinkMs` is the pause before the first blow — the comprehension time
+ * EXPERIENCE_DESIGN measures and never limits.
+ */
+export function solver(thinkMs = 2400, gapMs = 280): Strategy {
+  let plan: Strike[] = []
+  let planned = false
+  let since = 0
+  let phase: string | null = null
+  return ({ bout, windowMs }) => {
+    if (bout.phase !== phase) {
+      phase = bout.phase
+      planned = false
+      plan = []
+      since = 0
+    }
+    if (bout.phase !== "press") return []
+    if (windowMs < thinkMs) return []
+    if (!planned) {
+      planned = true
+      // The arithmetic, done: his column's value, plus the one notch, less what
+      // is already on the pan.
+      plan = planStrikes(Number(bout.question?.answer ?? 0) + 1 - bout.load)
+      since = gapMs
+    }
+    since += STEP
+    if (since < gapMs) return []
+    since = 0
+    const next = plan.shift()
+    if (next) return [next]
+    return ["seat"]
+  }
+}
+
+/**
+ * A player who refuses to do the arithmetic and hunts for the notch by watching
+ * which way the beam leans: strike, wait for it to stop swinging, read the sign,
+ * strike again. The descent is by place, heaviest first — the fastest hunt there
+ * is on this rack.
+ */
+export function prober(): Strategy {
+  const order = [1000, 100, 10, 1] as const
+  let index = 0
+  let phase: string | null = null
+  let last: number | null = null
+  return ({ bout, beam }) => {
+    if (bout.phase !== phase) {
+      phase = bout.phase
+      index = 0
+      last = null
+    }
+    if (bout.phase !== "press") return []
+    // No reading off a beam that is still travelling.
+    if (!beam.settled) return []
+    const sign = Math.sign(beam.angle)
+    if (last !== null && sign !== 0 && sign !== last) {
+      // It crossed. Drop to the next place down.
+      index += 1
+      last = null
+      if (index >= order.length) return ["seat"]
+    }
+    const place = order[Math.min(index, order.length - 1)] ?? 1
+    // Positive angle is your side ahead; take weight off. Otherwise add.
+    const dir: 1 | -1 = sign > 0 ? -1 : 1
+    last = sign === 0 ? last : sign
+    return [{ place, dir }]
+  }
+}

--- a/dynawalla/games/counterweight/src/test/mash.test.ts
+++ b/dynawalla/games/counterweight/src/test/mash.test.ts
@@ -1,0 +1,112 @@
+// **The bar this game was designed against: no mashing strategy wins.**
+//
+// The canon entry calls THE COUNTERWEIGHT the most unmashable design in the
+// catalogue, and that is a claim about behaviour, so it is settled by playing
+// rather than by reading the source. Every case below drives the shipping `Bout`
+// with a bot and counts what it got. The bots are in `harness.ts`.
+//
+// Four ways to not do the arithmetic, and what each of them runs into:
+//
+//   * **Hit everything fast.** The steel shears — `strain.ts`. It is not that
+//     mashing is inefficient; it is that mashing ends the round.
+//   * **Hit one plate fast.** Same shear.
+//   * **Hit one plate slowly**, under the resonance window, so the steel never
+//     shears. Then the clock and the arithmetic get you: a pan can only travel
+//     so far in ones, and nothing about walking it lands on the one notch.
+//   * **Hunt by watching the beam** instead of computing. Every probe needs the
+//     beam to stop ringing first, and the window runs out — `beam.ts`.
+//
+// And the control, without which none of the above means anything: a bot that
+// *does* the arithmetic wins comfortably, every seed.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { FACES } from "../game/places.ts"
+import { hammer, masher, play, prober, solver } from "./harness.ts"
+
+/** Fixed, so this file has no unseeded randomness in it anywhere. */
+const SEEDS = Array.from({ length: 12 }, (_, i) => i * 7919 + 3)
+
+test("hitting everything as fast as a thumb can move never wins a Turk", () => {
+  for (const seed of SEEDS) {
+    const run = play(masher(56), { seed, seconds: 600 })
+    assert.equal(run.won, 0, `a masher put a Turk over on seed ${seed}`)
+    assert.equal(run.held, 0, `a masher held ${run.held} rounds on seed ${seed}`)
+    // And it is not that they ran out of time: they played eighty-odd rounds and
+    // sheared the beam in every single one.
+    assert.ok(run.rounds > 40, `only ${run.rounds} rounds on seed ${seed}`)
+    assert.equal(run.verdicts.shear, run.rounds)
+  }
+})
+
+test("a slower mash still never wins — at any speed a thumb can hold", () => {
+  for (const gap of [80, 120, 160, 200, 250, 300, 450, 700]) {
+    for (const seed of SEEDS.slice(0, 5)) {
+      const run = play(masher(gap), { seed, seconds: 480 })
+      assert.equal(run.won, 0, `a ${gap} ms mash won on seed ${seed}`)
+      assert.equal(run.held, 0, `a ${gap} ms mash held a round on seed ${seed}`)
+    }
+  }
+})
+
+test("hammering a single plate never wins, whichever plate it is", () => {
+  for (const face of FACES) {
+    for (const gap of [56, 200, 400]) {
+      for (const seed of SEEDS.slice(0, 4)) {
+        const run = play(hammer(face, gap), { seed, seconds: 400 })
+        const name = `${face.dir > 0 ? "+" : "−"}${face.place} at ${gap} ms`
+        assert.equal(run.won, 0, `hammering ${name} won on seed ${seed}`)
+        assert.equal(run.held, 0, `hammering ${name} held a round on seed ${seed}`)
+      }
+    }
+  }
+})
+
+test("hunting for the notch by watching the beam never wins either", () => {
+  // This one is allowed to land the odd round — a beam that told you nothing at
+  // all would be a beam not worth drawing. What it must not do is carry anybody
+  // through a Turk, because putting one over needs five net holds.
+  for (const seed of SEEDS) {
+    const run = play(prober(), { seed, seconds: 600 })
+    assert.equal(run.won, 0, `a beam-watcher put a Turk over on seed ${seed}`)
+    assert.ok(
+      run.held * 8 < run.rounds,
+      `a beam-watcher held ${run.held} of ${run.rounds} on seed ${seed}`,
+    )
+  }
+})
+
+test("and a player who does the arithmetic wins, comfortably, every seed", () => {
+  // The control. Without it every assertion above would also pass on a game that
+  // is simply impossible.
+  for (const seed of SEEDS) {
+    const run = play(solver(), { seed, seconds: 400 })
+    assert.ok(run.won >= 6, `a solver only put ${run.won} Turks over on seed ${seed}`)
+    assert.ok(
+      run.held / run.rounds > 0.85,
+      `a solver held only ${run.held} of ${run.rounds} on seed ${seed}`,
+    )
+    assert.equal(run.verdicts.shear, 0, `a solver sheared the beam on seed ${seed}`)
+  }
+})
+
+test("a player who thinks slowly still wins, just fewer of them", () => {
+  // Comprehension time is the child's and is never the thing being scored. A bot
+  // that takes four seconds to read the column before its first blow must still
+  // be able to put Turks over.
+  for (const seed of SEEDS.slice(0, 6)) {
+    const run = play(solver(4200, 300), { seed, seconds: 600 })
+    assert.ok(run.won >= 3, `a slow thinker only put ${run.won} Turks over on seed ${seed}`)
+  }
+})
+
+test("what a wrong seat reports is a number the child put there, not noise", () => {
+  // The diagnosis rides on this: the value reported is the load minus the one
+  // notch, so a child running a broken column procedure reports its output.
+  const run = play(solver(2400, 280), { seed: 0x51ee, seconds: 240 })
+  for (const report of run.reports) {
+    assert.match(report.answered, /^-?\d+$/, `"${report.answered}" is not a whole number`)
+  }
+  assert.ok(run.reports.length > 10)
+})

--- a/dynawalla/games/counterweight/src/test/mount.test.ts
+++ b/dynawalla/games/counterweight/src/test/mount.test.ts
@@ -1,0 +1,479 @@
+// A smoke test for the surface.
+//
+// `tsc` proves the draw calls type-check and the vite build proves the modules
+// resolve. Neither proves that a frame *runs* — a stale property, a function
+// renamed in `render/` and not in `mount.ts`, a value read before it is
+// assigned: all compile, and all crash on the first frame in front of a child.
+//
+// So this mounts the real game against a canvas that records instead of paints,
+// drives several hundred frames through weights hung, plates struck, beams
+// seated and Turks put over, and asserts that nothing threw and that the world
+// actually moved. It is not a rendering test — there are no pixels — it is a
+// test that the whole thing is wired to itself.
+//
+// It also drives the two pause paths the host can take: the sheet (`pause()`)
+// and a backgrounded tab (`visibilitychange`).
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { mount } from "../contract.ts"
+import type { Host, Question } from "../contract.ts"
+import { openingLoad } from "../game/bout.ts"
+import { PLACES, planStrikes } from "../game/places.ts"
+import { layoutFor } from "../render/layout.ts"
+import { createStubHost } from "../stubHost.ts"
+
+type Listener = (event: unknown) => void
+
+/** A 2D context that answers every call and records how much work it was asked for. */
+function fakeContext(counter: { calls: number; text: string[] }): CanvasRenderingContext2D {
+  const store = new Map<string, unknown>()
+  const noop = (name: string) =>
+    function (...args: unknown[]) {
+      counter.calls++
+      if (name === "fillText" && typeof args[0] === "string") counter.text.push(args[0])
+      // Gradients are the one call whose result is used, so everything returns
+      // something that can take a colour stop.
+      return { addColorStop() {} }
+    }
+  return new Proxy(
+    {},
+    {
+      get(_t, prop: string) {
+        if (store.has(prop)) return store.get(prop)
+        return noop(prop)
+      },
+      set(_t, prop: string, value) {
+        store.set(prop, value)
+        return true
+      },
+    },
+  ) as unknown as CanvasRenderingContext2D
+}
+
+type FakeElement = {
+  style: { cssText: string }
+  width: number
+  height: number
+  listeners: Map<string, Listener[]>
+  appendChild(child: unknown): void
+  remove(): void
+  addEventListener(type: string, fn: Listener): void
+  removeEventListener(type: string, fn: Listener): void
+  getBoundingClientRect(): { width: number; height: number; left: number; top: number }
+  getContext(): CanvasRenderingContext2D
+}
+
+function harness(size: { w: number; h: number }, counter: { calls: number; text: string[] }) {
+  const ctx = fakeContext(counter)
+  const make = (): FakeElement => {
+    const listeners = new Map<string, Listener[]>()
+    return {
+      style: { cssText: "" },
+      width: 0,
+      height: 0,
+      listeners,
+      appendChild() {},
+      remove() {},
+      addEventListener(type, fn) {
+        const list = listeners.get(type) ?? []
+        list.push(fn)
+        listeners.set(type, list)
+      },
+      removeEventListener(type, fn) {
+        listeners.set(type, (listeners.get(type) ?? []).filter((f) => f !== fn))
+      },
+      getBoundingClientRect: () => ({ width: size.w, height: size.h, left: 0, top: 0 }),
+      getContext: () => ctx,
+    }
+  }
+  const created: FakeElement[] = []
+  const doc = {
+    visibilityState: "visible",
+    listeners: new Map<string, Listener[]>(),
+    createElement() {
+      const el = make()
+      created.push(el)
+      return el
+    },
+    addEventListener(type: string, fn: Listener) {
+      const list = doc.listeners.get(type) ?? []
+      list.push(fn)
+      doc.listeners.set(type, list)
+    },
+    removeEventListener(type: string, fn: Listener) {
+      doc.listeners.set(type, (doc.listeners.get(type) ?? []).filter((f) => f !== fn))
+    },
+  }
+  return { host: make(), doc, created, ctx }
+}
+
+type Clock = { now: number }
+type Rig = ReturnType<typeof harness> & {
+  frames: Array<(t: number) => void>
+  /** The wall clock `mount.ts` bills latency against, under the test's control. */
+  clock: Clock
+}
+
+/**
+ * Install the browser globals `mount.ts` needs, run `body`, and take them back
+ * off again — including when `body` throws, which is the case this file exists
+ * to catch.
+ */
+function withBrowser(
+  size: { w: number; h: number },
+  counter: { calls: number; text: string[] },
+  body: (rig: Rig) => void,
+): void {
+  const rig = harness(size, counter)
+  const g = globalThis as Record<string, unknown>
+  const saved = new Map<string, PropertyDescriptor | undefined>()
+  const set = (key: string, value: unknown) => {
+    saved.set(key, Object.getOwnPropertyDescriptor(globalThis, key))
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value })
+  }
+  const frames: Array<(t: number) => void> = []
+  const clock: Clock = { now: 0 }
+  set("performance", { now: () => clock.now })
+  set("document", rig.doc)
+  set("devicePixelRatio", 2)
+  set("requestAnimationFrame", (fn: (t: number) => void) => {
+    frames.push(fn)
+    return frames.length
+  })
+  set("cancelAnimationFrame", () => {})
+  if (typeof g.addEventListener !== "function") set("addEventListener", () => {})
+  if (typeof g.removeEventListener !== "function") set("removeEventListener", () => {})
+
+  try {
+    body({ ...rig, frames, clock })
+  } finally {
+    for (const [key, descriptor] of saved) {
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor)
+      else Reflect.deleteProperty(globalThis, key)
+    }
+  }
+}
+
+/** The canvas is the second element `mount` creates: the root stand-in, then it. */
+function canvasOf(created: FakeElement[]): FakeElement {
+  const el = created[0]
+  if (!el) throw new Error("mount did not create a canvas")
+  return el
+}
+
+/**
+ * Run `n` frames at 60 Hz, draining the rAF queue each time.
+ *
+ * The wall clock moves with the frames, because it does on a device — which is
+ * the whole point of the latency case below: a sheet held up for half a minute
+ * moves `performance.now()` by half a minute whether or not the game is running.
+ */
+function pump(
+  frames: Array<(t: number) => void>,
+  n: number,
+  from = 0,
+  clock?: Clock,
+): number {
+  let t = from
+  for (let i = 0; i < n; i++) {
+    const next = frames.pop()
+    frames.length = 0
+    if (!next) break
+    t += 16.7
+    if (clock) clock.now = t
+    next(t)
+  }
+  return t
+}
+
+/**
+ * Every face on the rack, taken from the real layout rather than guessed. A
+ * guessed coordinate that lands on nothing turns this file into a test that the
+ * game renders while nobody is playing it.
+ */
+function facePoints(w: number, h: number): Array<{ x: number; y: number }> {
+  const box = layoutFor(w, h)
+  return box.pillars.flatMap((pillar) =>
+    [pillar.up, pillar.down].map((r) => ({ x: r.x + r.w / 2, y: r.y + r.h / 2 })),
+  )
+}
+
+/** The seat lever, likewise. */
+function seatPoint(w: number, h: number): { x: number; y: number } {
+  const { seat } = layoutFor(w, h)
+  return { x: seat.x + seat.w / 2, y: seat.y + seat.h / 2 }
+}
+
+for (const [w, h] of [
+  [320, 568],
+  [768, 1024],
+  [1366, 1024],
+] as const) {
+  test(`a whole match renders without throwing at ${w}×${h}`, () => {
+    const counter = { calls: 0, text: [] as string[] }
+    const reports: Array<{ correct: boolean; answered: string; ms: number }> = []
+    withBrowser({ w, h }, counter, ({ host, frames, created }) => {
+      const stub = createStubHost({
+        seed: 0x51ab,
+        reducedMotion: false,
+        onReport: (r) => reports.push(r),
+      })
+      const handle = mount(host as unknown as HTMLElement, stub)
+      const canvas = canvasOf(created)
+
+      let t = pump(frames, 900)
+      assert.ok(counter.calls > 5000, `only ${counter.calls} draw calls in 900 frames`)
+      assert.ok(counter.text.length > 0, "nothing was ever written in the yard")
+
+      // And a press goes all the way through the input handler into the rules.
+      const down = canvas.listeners.get("pointerdown")?.[0]
+      const up = canvas.listeners.get("pointerup")?.[0]
+      assert.ok(down && up, "the rack was never wired to anything")
+      const before = counter.calls
+      const points = facePoints(w, h)
+      for (let i = 0; i < 120; i++) {
+        const p = points[i % points.length] as { x: number; y: number }
+        down({ preventDefault() {}, clientX: p.x, clientY: p.y })
+        up({})
+        t = pump(frames, 20, t)
+      }
+      assert.ok(counter.calls > before)
+
+      // The seat lever, at the very bottom.
+      const lever = seatPoint(w, h)
+      for (let i = 0; i < 30; i++) {
+        down({ preventDefault() {}, clientX: lever.x, clientY: lever.y })
+        up({})
+        t = pump(frames, 40, t)
+      }
+
+      handle.unmount()
+      assert.equal(canvas.listeners.get("pointerdown")?.length ?? 0, 0)
+    })
+
+    // The frames were not just drawn, they were *played*: rounds were seated and
+    // the value that crossed was a whole number the child put on the beam.
+    assert.ok(reports.length > 4, `only ${reports.length} rounds were ever reported`)
+    for (const r of reports) {
+      assert.match(r.answered, /^-?\d+$/)
+      assert.ok(r.ms >= 0)
+    }
+  })
+}
+
+test("the reduced-motion branch plays the same match with no sparks", () => {
+  const counter = { calls: 0, text: [] as string[] }
+  const reports: unknown[] = []
+  withBrowser({ w: 768, h: 1024 }, counter, ({ host, frames, created }) => {
+    const stub = createStubHost({ seed: 0x51ab, reducedMotion: true, onReport: (r) => reports.push(r) })
+    const handle = mount(host as unknown as HTMLElement, stub)
+    let t = pump(frames, 400)
+    const canvas = canvasOf(created)
+    const down = canvas.listeners.get("pointerdown")?.[0] as Listener
+    const up = canvas.listeners.get("pointerup")?.[0] as Listener
+    for (let i = 0; i < 90; i++) {
+      const p = facePoints(768, 1024)[i % 8] as { x: number; y: number }
+      down({ preventDefault() {}, clientX: p.x, clientY: p.y })
+      up({})
+      t = pump(frames, 20, t)
+    }
+    const lever = seatPoint(768, 1024)
+    for (let i = 0; i < 8; i++) {
+      down({ preventDefault() {}, clientX: lever.x, clientY: lever.y })
+      up({})
+      t = pump(frames, 60, t)
+    }
+    // The information is all still there — the pans, the rack, the gauges are
+    // written every frame — it just arrives without travel.
+    assert.ok(counter.text.length > 0)
+    assert.ok(counter.calls > 3000)
+    handle.unmount()
+  })
+  assert.ok(reports.length > 0)
+})
+
+test("a Turk going over is the only thing that ever reaches `transition`", () => {
+  const counter = { calls: 0, text: [] as string[] }
+  const stops: string[] = []
+  let rounds = 0
+  let held = 0
+  withBrowser({ w: 768, h: 1024 }, counter, ({ host, frames }) => {
+    const stub = createStubHost({
+      seed: 0x51ab,
+      reducedMotion: true,
+      onTransition: (kind) => stops.push(kind),
+      onReport: (r) => {
+        rounds += 1
+        if (r.correct) held += 1
+      },
+    })
+    const handle = mount(host as unknown as HTMLElement, stub)
+    // No input at all: every round runs out of window and is lost. Dozens of
+    // failures, and not one of them may raise a purchase surface.
+    pump(frames, 20000)
+    handle.unmount()
+  })
+  assert.ok(rounds > 8, `only ${rounds} rounds went by`)
+  assert.equal(held, 0, "a match with no input somehow held a round")
+  assert.deepEqual(stops, [], "a stopping point was offered next to a failure")
+})
+
+test("the sheet stops the world, and lifting it gives the window back", () => {
+  // The host's `pause`, exactly as the pack seam calls it. Both halves are under
+  // test: the clock must stop, and a tap on the sheet must not reach the rack.
+  const counter = { calls: 0, text: [] as string[] }
+  const reports: unknown[] = []
+  withBrowser({ w: 768, h: 1024 }, counter, ({ host, frames, created }) => {
+    const stub = createStubHost({ seed: 0x51ab, reducedMotion: true, onReport: (r) => reports.push(r) })
+    const handle = mount(host as unknown as HTMLElement, stub)
+    let t = pump(frames, 120)
+    const canvas = canvasOf(created)
+    const down = canvas.listeners.get("pointerdown")?.[0] as Listener
+    const up = canvas.listeners.get("pointerup")?.[0] as Listener
+
+    handle.pause()
+    const seated = reports.length
+    // Thirty seconds behind the sheet — more than two whole windows.
+    t = pump(frames, 1800, t)
+    assert.equal(reports.length, seated, "rounds were seated behind the sheet")
+
+    // And presses on the sheet are presses on the sheet.
+    for (const p of facePoints(768, 1024)) {
+      down({ preventDefault() {}, clientX: p.x, clientY: p.y })
+      up({})
+    }
+    const lever = seatPoint(768, 1024)
+    down({ preventDefault() {}, clientX: lever.x, clientY: lever.y })
+    up({})
+    t = pump(frames, 60, t)
+    assert.equal(reports.length, seated, "the beam was seated through the sheet")
+
+    handle.resume()
+    t = pump(frames, 1800, t)
+    assert.ok(reports.length > seated, "the world never came back")
+    handle.unmount()
+  })
+})
+
+test("a backgrounded tab is the same as a sheet", () => {
+  const counter = { calls: 0, text: [] as string[] }
+  const reports: unknown[] = []
+  withBrowser({ w: 768, h: 1024 }, counter, ({ host, frames, doc }) => {
+    const stub = createStubHost({ seed: 0x51ab, reducedMotion: true, onReport: (r) => reports.push(r) })
+    const handle = mount(host as unknown as HTMLElement, stub)
+    let t = pump(frames, 120)
+
+    doc.visibilityState = "hidden"
+    for (const fn of doc.listeners.get("visibilitychange") ?? []) fn({})
+    const seated = reports.length
+    t = pump(frames, 1800, t)
+    assert.equal(reports.length, seated, "the window closed while the tab was hidden")
+
+    doc.visibilityState = "visible"
+    for (const fn of doc.listeners.get("visibilitychange") ?? []) fn({})
+    t = pump(frames, 1800, t)
+    assert.ok(reports.length > seated, "the world never came back")
+    handle.unmount()
+  })
+})
+
+test("a round can be held all the way through the canvas", () => {
+  // The end-to-end claim, and the one the rest of this file leans on: a player
+  // who reads the column, works out what the pan is missing, presses those faces
+  // and pulls the lever is told they held it. Everything above proves the game
+  // *runs*; this proves it can be *won* by the only route a child has.
+  const counter = { calls: 0, text: [] as string[] }
+  const reports: Array<{ correct: boolean; answered: string }> = []
+  const w = 768
+  const h = 1024
+
+  withBrowser({ w, h }, counter, ({ host, frames, created }) => {
+    let served: Question | null = null
+    const base = createStubHost({
+      seed: 0x51ab,
+      reducedMotion: true,
+      level: 3,
+      onReport: (r) => reports.push(r),
+    })
+    const stub: Host = {
+      ...base,
+      next: (o) => {
+        served = base.next(o)
+        return served
+      },
+    }
+
+    const handle = mount(host as unknown as HTMLElement, stub)
+    const canvas = canvasOf(created)
+    const down = canvas.listeners.get("pointerdown")?.[0] as Listener
+    const up = canvas.listeners.get("pointerup")?.[0] as Listener
+
+    // Past the weight coming down, into the open window.
+    let t = pump(frames, 60)
+    const question = served as Question | null
+    assert.ok(question, "no weight was ever hung")
+
+    // What the pan started on, and what the round is therefore asking for. The
+    // child does this in their head; the test does it in `places.ts`.
+    const target = Number(question.answer)
+    const plan = planStrikes(target + 1 - openingLoad(target))
+    assert.ok(plan.length > 0)
+
+    const faces = facePoints(w, h)
+    for (const strike of plan) {
+      const index = PLACES.indexOf(strike.place) * 2 + (strike.dir > 0 ? 0 : 1)
+      const p = faces[index] as { x: number; y: number }
+      down({ preventDefault() {}, clientX: p.x, clientY: p.y })
+      up({})
+      // Well clear of the pillar's swing-back and of the resonance window, and
+      // well inside the grace before the pan starts to settle.
+      t = pump(frames, 20, t)
+    }
+
+    const lever = seatPoint(w, h)
+    down({ preventDefault() {}, clientX: lever.x, clientY: lever.y })
+    up({})
+    pump(frames, 10, t)
+
+    handle.unmount()
+  })
+
+  assert.equal(reports.length, 1, `${reports.length} rounds were reported, not one`)
+  assert.equal(reports[0]?.correct, true, "the arithmetic was right and the beam did not hold")
+})
+
+test("time behind the sheet is not billed to the child as thinking time", () => {
+  // `Bout` can stop its own clock; it cannot do this one. Latency is measured
+  // against the wall clock, and the wall clock keeps running behind a sheet —
+  // so `mount.ts` has to shift the mark forward by exactly how long the sheet
+  // was up. Without that, a parent gate held open for half a minute is recorded
+  // as half a minute of a child staring at a column, and the fluency model in
+  // `EXPERIENCE_DESIGN.md` reads it as difficulty.
+  const counter = { calls: 0, text: [] as string[] }
+  const reports: Array<{ ms: number }> = []
+  const SHEET_FRAMES = 1800
+
+  withBrowser({ w: 768, h: 1024 }, counter, ({ host, frames, clock }) => {
+    const stub = createStubHost({ seed: 0x51ab, reducedMotion: true, onReport: (r) => reports.push(r) })
+    const handle = mount(host as unknown as HTMLElement, stub)
+
+    // Into the window, then the sheet goes up for thirty seconds.
+    let t = pump(frames, 90, 0, clock)
+    handle.pause()
+    t = pump(frames, SHEET_FRAMES, t, clock)
+    handle.resume()
+    // And then the window runs its course.
+    t = pump(frames, 1400, t, clock)
+    handle.unmount()
+  })
+
+  assert.ok(reports.length > 0, "no round was ever seated")
+  const sheetMs = SHEET_FRAMES * 16.7
+  const first = reports[0] as { ms: number }
+  assert.ok(
+    first.ms < sheetMs,
+    `${Math.round(first.ms)} ms was billed for a round that had a ${Math.round(sheetMs)} ms sheet over it`,
+  )
+})

--- a/dynawalla/games/counterweight/src/test/pause.test.ts
+++ b/dynawalla/games/counterweight/src/test/pause.test.ts
@@ -1,0 +1,123 @@
+// **The pause trap.**
+//
+// The host can raise a sheet — a transition surface, a parent gate — over a pack
+// that is still mounted and whose rAF is still running, and it sends `pause`
+// rather than unmounting. This game calls `transition` every time a Turk goes
+// over, so the sheet is not hypothetical: it is raised by the game's own success.
+//
+// Without the guards, the press window opens and closes behind that sheet, the
+// whistle seats the beam wherever it stood, and the child is marked wrong — and
+// loses ground — for a column they were never shown. A reward that costs the
+// match is the worst bug this game could have.
+//
+// Every assertion below fails if `Bout.pause` stops stopping the clock.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import type { Question } from "../contract.ts"
+import { Bout, TIMING } from "../game/bout.ts"
+
+function deal(answer: number): () => Question {
+  let n = 0
+  return () => ({
+    id: `q${++n}`,
+    prompt: `${answer - 40} + 40`,
+    answer: String(answer),
+    distractors: [],
+    domain: "add",
+    difficulty: 0.3,
+  })
+}
+
+function opened(): Bout {
+  const bout = new Bout(deal(500))
+  bout.begin()
+  bout.advance(TIMING.hangMs + 4)
+  assert.equal(bout.phase, "press")
+  return bout
+}
+
+test("the clock does not run behind the sheet", () => {
+  const bout = opened()
+  bout.pause()
+  assert.equal(bout.paused, true)
+
+  const before = bout.elapsedMs
+  // Far more than the whole window, and then some.
+  const events = bout.advance(120_000)
+
+  assert.deepEqual(events, [], "something happened behind the sheet")
+  assert.equal(bout.elapsedMs, before, "the clock ran behind the sheet")
+  assert.equal(bout.phase, "press", "the window closed behind the sheet")
+
+  bout.resume()
+  assert.equal(bout.paused, false)
+  bout.advance(TIMING.pressMs + 10)
+  assert.equal(bout.phase, "settle", "the clock did not restart on resume")
+})
+
+test("a round cannot be lost behind the sheet", () => {
+  // The bug, exactly: an unpaused window closes, the whistle seats a beam the
+  // child never saw, and the arm goes the wrong way for it.
+  const bout = opened()
+  bout.pause()
+  const arm = bout.match.arm
+  const held = bout.match.held
+
+  bout.advance(120_000)
+
+  assert.equal(bout.match.arm, arm, "ground was taken behind the sheet")
+  assert.equal(bout.match.held, held)
+  assert.equal(bout.seat, null, "the beam was judged behind the sheet")
+})
+
+test("the pan does not settle behind the sheet either", () => {
+  // The sag is a clock too, and a slow one. Left running behind a sheet it turns
+  // a correct load into a wrong one without a single frame the child saw.
+  const bout = opened()
+  const load = bout.load
+  bout.pause()
+  bout.advance(120_000)
+  assert.equal(bout.load, load, "the pan sagged behind the sheet")
+})
+
+test("the steel does not bleed behind the sheet", () => {
+  // The other direction of the same unfairness: time behind a sheet must not
+  // *help* either, or a pause becomes a way to reset a beam you nearly sheared.
+  const bout = opened()
+  for (let i = 0; i < 3; i++) {
+    bout.strike({ place: 1, dir: 1 })
+    bout.advance(120)
+  }
+  const strain = bout.strain.level
+  assert.ok(strain > 0)
+  bout.pause()
+  bout.advance(120_000)
+  assert.equal(bout.strain.level, strain, "the steel healed behind the sheet")
+})
+
+test("a tap on the sheet is a tap on the sheet — not a blow, not a seat", () => {
+  const bout = opened()
+  const load = bout.load
+  bout.pause()
+
+  assert.deepEqual(bout.strike({ place: 100, dir: 1 }), [{ kind: "refused", reason: "phase" }])
+  assert.equal(bout.load, load, "a blow landed through the sheet")
+  assert.deepEqual(bout.seatNow(), [{ kind: "refused", reason: "phase" }])
+  assert.equal(bout.seat, null, "the beam was seated through the sheet")
+})
+
+test("resuming does not hand back a window that has already gone", () => {
+  // A sheet raised with two seconds left leaves two seconds, not thirteen.
+  const bout = opened()
+  bout.advance(TIMING.pressMs - 2000)
+  bout.pause()
+  bout.advance(60_000)
+  bout.resume()
+
+  bout.advance(1900)
+  assert.equal(bout.phase, "press", "the window grew while the sheet was up")
+  bout.advance(200)
+  assert.equal(bout.phase, "settle", "the window did not close when it should have")
+})

--- a/dynawalla/games/counterweight/src/test/places.test.ts
+++ b/dynawalla/games/counterweight/src/test/places.test.ts
@@ -1,0 +1,89 @@
+// The rack is a number system. These are the properties that make it one.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  applyAll,
+  applyStrike,
+  FACES,
+  PILLAR_COOLDOWN_MS,
+  PLACES,
+  planStrikes,
+  strikesFor,
+  strikeValue,
+} from "../game/places.ts"
+import { Rng } from "../core/rng.ts"
+
+test("the rack is four places and eight faces", () => {
+  assert.deepEqual([...PLACES], [1000, 100, 10, 1])
+  assert.equal(FACES.length, 8)
+  for (const place of PLACES) {
+    assert.equal(FACES.filter((f) => f.place === place && f.dir === 1).length, 1)
+    assert.equal(FACES.filter((f) => f.place === place && f.dir === -1).length, 1)
+  }
+  assert.ok(PILLAR_COOLDOWN_MS > 0 && PILLAR_COOLDOWN_MS < 200)
+})
+
+test("a plan lands on its delta exactly, over the whole reachable range", () => {
+  const rng = new Rng(0x9c07)
+  for (let i = 0; i < 4000; i++) {
+    const delta = rng.int(-9999, 9999)
+    const plan = planStrikes(delta)
+    assert.equal(applyAll(0, plan), delta, `plan for ${delta} did not land on it`)
+    for (const strike of plan) {
+      assert.ok(Number.isInteger(strikeValue(strike)))
+    }
+  }
+})
+
+test("the plan is balanced: no low place is ever struck more than five times", () => {
+  // This is the discovery the game is built around — eight is ten less two, not
+  // eight ones. If a plan ever asked for six blows on one of the low pillars, the
+  // shorter path through the pillar above it was there and was not taken.
+  const rng = new Rng(0x22b1)
+  for (let i = 0; i < 4000; i++) {
+    const plan = planStrikes(rng.int(-9999, 9999))
+    for (const place of [1, 10, 100] as const) {
+      assert.ok(
+        plan.filter((s) => s.place === place).length <= 5,
+        `${place}s pillar was struck more than five times`,
+      )
+    }
+  }
+})
+
+test("the plan is never longer than counting up in ones and tens would be", () => {
+  const rng = new Rng(0x4d33)
+  for (let i = 0; i < 2000; i++) {
+    const delta = rng.int(-9999, 9999)
+    const naive =
+      Math.abs(Math.trunc(delta / 1000)) +
+      Math.abs(Math.trunc((delta % 1000) / 100)) +
+      Math.abs(Math.trunc((delta % 100) / 10)) +
+      Math.abs(delta % 10)
+    assert.ok(strikesFor(delta) <= naive, `${delta}: ${strikesFor(delta)} > ${naive}`)
+  }
+})
+
+test("nothing at all is nothing to strike", () => {
+  assert.deepEqual(planStrikes(0), [])
+})
+
+test("a plan is ordered heaviest first", () => {
+  const plan = planStrikes(1234)
+  const order = plan.map((s) => PLACES.indexOf(s.place))
+  assert.deepEqual(order, [...order].sort((a, b) => a - b))
+})
+
+test("a strike moves the pan by exactly its place, and back again", () => {
+  for (const face of FACES) {
+    const up = applyStrike(500, face)
+    assert.equal(up, 500 + face.place * face.dir)
+    assert.equal(applyStrike(up, { place: face.place, dir: face.dir === 1 ? -1 : 1 }), 500)
+  }
+})
+
+test("a plan refuses a delta that is not a whole number of units", () => {
+  assert.throws(() => planStrikes(3.5), /integer/)
+})

--- a/dynawalla/games/counterweight/src/test/strain.test.ts
+++ b/dynawalla/games/counterweight/src/test/strain.test.ts
@@ -1,0 +1,86 @@
+// The strain model, on its own. `mash.test.ts` proves what it does to a player;
+// this proves the mechanism underneath is exact, frame-rate independent and
+// shaped the way the design says it is.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { BASE_STRAIN, impulseFor, RESONANCE_MS, Strain } from "../game/strain.ts"
+
+test("a blow on a still beam is the cheapest blow there is", () => {
+  assert.equal(impulseFor(RESONANCE_MS), BASE_STRAIN)
+  assert.equal(impulseFor(RESONANCE_MS + 5000), BASE_STRAIN)
+  assert.equal(impulseFor(Number.POSITIVE_INFINITY), BASE_STRAIN)
+})
+
+test("the cost rises the sooner a blow lands on the last one", () => {
+  let previous = Number.POSITIVE_INFINITY
+  for (let gap = 0; gap <= RESONANCE_MS; gap += 10) {
+    const cost = impulseFor(gap)
+    assert.ok(Number.isInteger(cost), `impulse at ${gap} ms was not a whole number`)
+    assert.ok(cost <= previous, `cost went up as the gap grew, at ${gap} ms`)
+    previous = cost
+  }
+  // A blow straight on top of the last one costs several times a patient one.
+  assert.ok(impulseFor(0) >= BASE_STRAIN * 5)
+})
+
+test("strain is whole units and never negative", () => {
+  const strain = new Strain({ shearAt: 34 })
+  strain.strike()
+  for (let i = 0; i < 400; i++) {
+    strain.advance(7)
+    assert.ok(Number.isInteger(strain.level))
+    assert.ok(strain.level >= 0)
+  }
+  assert.equal(strain.level, 0)
+})
+
+test("the bleed does not depend on how fast the frames come", () => {
+  const coarse = new Strain({ shearAt: 34 })
+  const fine = new Strain({ shearAt: 34 })
+  coarse.strike()
+  fine.strike()
+  for (let i = 0; i < 30; i++) coarse.advance(100)
+  for (let i = 0; i < 750; i++) fine.advance(4)
+  assert.equal(coarse.level, fine.level)
+})
+
+test("a mash shears the steel in well under a second", () => {
+  const strain = new Strain({ shearAt: 34 })
+  let ms = 0
+  while (!strain.isSheared && ms < 5000) {
+    strain.strike()
+    strain.advance(56)
+    ms += 56
+  }
+  assert.ok(strain.isSheared, "a mash never sheared the beam")
+  assert.ok(ms < 600, `a mash took ${ms} ms to shear; it has to be quicker than luck`)
+})
+
+test("a player who strikes deliberately never gets near the limit", () => {
+  // Twenty-five blows — a worst-case four-digit plan — a little over a quarter of
+  // a second apart. This has to be comfortable, or the game punishes the child
+  // who did the arithmetic.
+  const strain = new Strain({ shearAt: 24 })
+  let peak = 0
+  for (let i = 0; i < 25; i++) {
+    strain.strike()
+    peak = Math.max(peak, strain.level)
+    strain.advance(280)
+  }
+  assert.equal(strain.isSheared, false, "a deliberate plan sheared the beam")
+  assert.ok(peak < 24 * 0.8, `deliberate play peaked at ${peak} of 24`)
+})
+
+test("a fresh round is fresh steel", () => {
+  // Every round gets its own beam — `Bout.hang` cuts one, because the shear
+  // limit tightens from Turk to Turk. Nothing carries over from the last round's
+  // mistake.
+  const spent = new Strain({ shearAt: 10 })
+  while (!spent.isSheared) spent.strike()
+  const fresh = new Strain({ shearAt: 10 })
+  assert.equal(fresh.isSheared, false)
+  assert.equal(fresh.level, 0)
+  assert.equal(fresh.strike(), BASE_STRAIN)
+})

--- a/dynawalla/games/counterweight/src/test/stubHost.test.ts
+++ b/dynawalla/games/counterweight/src/test/stubHost.test.ts
@@ -1,0 +1,120 @@
+// The stub host has to be the runtime, not a rehearsal for one.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  borrowAcrossZero,
+  carryDropped,
+  createStubHost,
+  smallerFromLarger,
+  wrongOperation,
+} from "../stubHost.ts"
+import { splitPrompt } from "../game/column.ts"
+
+test("the reference case from the curriculum's own mal-rule file", () => {
+  // 5001 − 2798. Correct 2203.
+  assert.equal(smallerFromLarger(5001, 2798), 3797)
+  assert.equal(borrowAcrossZero(5001, 2798), 3203)
+})
+
+test("a mal-rule that would be the correct procedure emits nothing", () => {
+  // Nothing carries, so dropping the carry is just adding.
+  assert.equal(carryDropped(23, 14), null)
+  // No column needs regrouping, so taking the smaller from the larger is right.
+  assert.equal(smallerFromLarger(58, 23), null)
+  // The borrow chain never crossed a zero, so the decrement happened correctly.
+  assert.equal(borrowAcrossZero(52, 27), null)
+})
+
+test("the buggy procedures produce what a child actually writes", () => {
+  assert.equal(carryDropped(27, 15), 32)
+  assert.equal(smallerFromLarger(52, 27), 35)
+  assert.equal(borrowAcrossZero(403, 87), 416)
+  assert.equal(wrongOperation("add", 40, 15), 25)
+  assert.equal(wrongOperation("sub", 40, 15), 55)
+})
+
+test("the same seed is the same match, forever", () => {
+  const a = createStubHost({ seed: 0x1234 })
+  const b = createStubHost({ seed: 0x1234 })
+  for (let i = 0; i < 200; i++) {
+    assert.deepEqual(a.next(), b.next())
+  }
+})
+
+test("every operand, answer and distractor is a whole number", () => {
+  // The game weighs these on a beam and compares them for exact equality. A
+  // float anywhere in here would be a round nobody could ever win.
+  const host = createStubHost({ seed: 0x77aa })
+  for (let i = 0; i < 3000; i++) {
+    const q = host.next()
+    const answer = Number(q.answer)
+    assert.ok(Number.isInteger(answer), `answer "${q.answer}" is not a whole number`)
+    assert.ok(answer > 0, `answer ${answer} is not a weight`)
+    assert.equal(String(answer), q.answer, "the answer string is not canonical")
+    for (const d of q.distractors) {
+      const value = Number(d)
+      assert.ok(Number.isInteger(value), `distractor "${d}" is not a whole number`)
+      assert.notEqual(value, answer, "a distractor was the answer")
+    }
+  }
+})
+
+test("the prompt is the arithmetic, and the answer is its value", () => {
+  const host = createStubHost({ seed: 0x2b1c })
+  for (let i = 0; i < 2000; i++) {
+    const q = host.next()
+    const column = splitPrompt(q.prompt)
+    assert.ok(column, `"${q.prompt}" would not draw as a column`)
+    const top = Number(column.top)
+    const bottom = Number(column.bottom)
+    const value = column.glyph === "+" ? top + bottom : top - bottom
+    assert.equal(value, Number(q.answer), `${q.prompt} is not ${q.answer}`)
+  }
+})
+
+test("distractors are mal-rule outputs, never the answer off by a fixed step", () => {
+  const host = createStubHost({ seed: 0x5c0e })
+  let offByOne = 0
+  let total = 0
+  for (let i = 0; i < 3000; i++) {
+    const q = host.next()
+    const answer = Number(q.answer)
+    for (const d of q.distractors) {
+      total += 1
+      if (Math.abs(Number(d) - answer) === 1) offByOne += 1
+    }
+  }
+  assert.ok(total > 1000, "hardly any distractors were produced at all")
+  // A broken column procedure lands a whole place away, not next door. The odd
+  // coincidence is fine; a pattern is a stub that made its wrong answers up.
+  assert.ok(offByOne / total < 0.02, `${offByOne} of ${total} distractors were the answer ± 1`)
+})
+
+test("the ladder walks from two digits to four", () => {
+  const host = createStubHost({ seed: 0x3311 })
+  const first: number[] = []
+  const last: number[] = []
+  for (let i = 0; i < 60; i++) {
+    const q = host.next()
+    ;(i < 8 ? first : i >= 48 ? last : []).push(Number(q.answer))
+  }
+  assert.ok(Math.max(...first) < 1000, "the ladder started above two digits")
+  assert.ok(Math.max(...last) > 999, "the ladder never reached four digits")
+})
+
+test("a pinned level stays pinned", () => {
+  const host = createStubHost({ seed: 0x4001, level: 0 })
+  for (let i = 0; i < 100; i++) {
+    assert.equal(host.next().difficulty, 0)
+  }
+})
+
+test("a haptic on a device with no motor is not an error anybody hears about", () => {
+  const seen: string[] = []
+  const host = createStubHost({ seed: 1, onHaptic: (k) => seen.push(k) })
+  host.haptic("light")
+  host.haptic("failure")
+  assert.deepEqual(seen, ["light", "failure"])
+})

--- a/dynawalla/games/counterweight/tsconfig.json
+++ b/dynawalla/games/counterweight/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": false,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/dynawalla/games/counterweight/vite.config.ts
+++ b/dynawalla/games/counterweight/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite"
+
+// The game is a library that mounts into a host element. `npm run dev` serves
+// the standalone harness in `index.html`, which wires it to the local stub Host
+// so the whole match is playable with no runtime underneath it.
+export default defineConfig({
+  server: { port: 4327, host: "127.0.0.1" },
+  build: {
+    target: "es2022",
+    lib: {
+      entry: "src/index.ts",
+      name: "DynawallaGameCounterweight",
+      formats: ["es"],
+      fileName: () => "counterweight.js",
+    },
+  },
+})

--- a/dynawalla/games/counterweight/vite.pack.config.ts
+++ b/dynawalla/games/counterweight/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produces a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})


### PR DESCRIPTION
## What

Add **THE COUNTERWEIGHT** at `dynawalla/games/counterweight` — rank 30 of the arcade
canon, S tier, after *Arm Wrestling* (1985) — as a playable game and an installable
pack. An arm-wrestle across a steelyard beam: the Iron Turk's pan carries a column
operation and never its total, your pan carries a load you steer with place-value
counterweights, and you must hold **exactly one notch ahead** and seat the beam.

## Why

The canon entry calls this **the most unmashable design in the catalogue** and asks for
*live inequality maintenance* rather than "is A > B, answered once". That is a claim
about behaviour, so the design is built to make it true and
[`src/test/mash.test.ts`](https://github.com/corpora-inc/encorpora/blob/agent/dynawalla/game-counterweight/dynawalla/games/counterweight/src/test/mash.test.ts)
settles it by playing rather than by arguing.

**The mechanic is the mathematics.** The rack is four pillars — thousands, hundreds,
tens, ones — each with a face that hangs weight on and a face that takes it off. That
is the entire input vocabulary; there is no keypad. So a round is two column operations
back to back: evaluate his column, then decompose the difference between where your pan
is and where it has to be. And the thing a child discovers for themselves, because the
rack has a take-off face: **eight is not eight ones, it is ten less two**.
`game/places.ts` is at once the optimal player and the definition of what is being
asked.

**Why mashing loses.** A struck beam rings, and a beam struck again while it is still
ringing rings harder. `game/strain.ts` charges every blow by *when it lands* — 2 after
the ring has died, 13 straight on top of the last one — bleeding 6 a second against a
shear limit of 34. A masher shears the steel in about a fifth of a second: the round is
**over**, not merely wasted. Ten deliberate blows a quarter-second apart peak at about a
third of the limit, so the child who did the arithmetic is never punished for it.

Two further pressures keep the round live without being mashable: the window closes and
seats the beam where it stands, and a pan nobody is tending **sags** — you cannot find
the notch early and sit on it — while any strike re-seats it, so it only bites a player
who has stopped playing.

**Live inequality, not a quiz.** `load − his = 1` is judged continuously against a
target the child can never read off the screen, on a beam whose resting angle saturates
— fine gradation within a few units of level, hard against its stop past that — and
whose index lights only once the steel has stopped ringing. It confirms an answer and
refuses to hand one over.

What crosses to the host is `load − 1`: the value the beam *asserted* his column to be.
Play it right and that is the canonical value; drop a carry and it is the mal-rule
output exactly, so the misconception routes itself. The game never compares anything to
an answer.

## Blast radius

**Areas touched:** dynawalla (one new directory, `dynawalla/games/counterweight/`;
nothing else in the repo is modified, and no file is deleted).

- [x] Every touched path is covered by a `ci.yml` area filter — everything is under
      `dynawalla/games/`, the same path the twenty-two shipping games sit on.
- [x] **Pack back-compat.** A brand-new pack id, `dynawalla.counterweight` at `0.1.0`.
      No published zip changed in place, no `voiceId` renamed, no catalog entry dropped
      or narrowed.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri` manifest, no `links =`, no
      `[patch.crates-io]` in the diff.
- [x] **Strings.** N/A — `locales: ["en"]`, and nothing under
      `corpan/corpan-app/public/locales/` is touched.
- [x] **Curriculum.** N/A — no curriculum file changes. The pack *declares* seven
      `covers.skills`, each verified by hand against
      `packs/shared/curriculum/src/graph/domains/add.ts`: they are exactly the seven
      rows of the `add` domain whose `status` is `active`
      (`add-no-regroup`, `subtract-no-regroup`, `add-multidigit`, `subtract-multidigit`,
      `add-short-addend`, `subtract-short-subtrahend`, `subtract-across-zero`), with the
      `draft` `subtract-tenths` excluded. No id is renamed or reused. Every operand,
      answer, distractor and comparison in the game and its stub host is an exact
      integer — `stubHost.test.ts` asserts it over 3,000 items — and distractors are
      real mal-rule outputs ported from `malrules/columnOp.ts` with their `applies()`
      guards intact, never `answer ± 1`.
- [x] **Secrets.** None. `gitleaks` output below. The one dotted-string constant is
      `TALLY_SLOT` in `game/best.ts`, named and annotated per the house convention.

### Three things a reviewer cannot reconstruct from the diff

**1. `items.reveal` is load-bearing, not decorative.** `packs/shared/game-host/index.ts`
drops every item whose canonical value comes back empty. Without the grant this pack
would mount, warm, and serve **zero questions**, with nothing failing anywhere. It is
declared, and `src/pack.ts` says why at the call site.

**2. `audio` is deliberately not declared.** That capability is `feedback.sound` — the
host's own sounds. This pack synthesises its own `AudioContext` and needs no grant for
it. Declared set is `items`, `items.reveal`, `haptics`.

**3. The pause trap is handled at three levels, and each one is tested.**
`Bout.pause()` stops the window, the sag *and* the strain bleed dead — time behind a
sheet must not help either, or a pause becomes a way to reset a beam you nearly sheared.
`src/pack.ts` subscribes to the host's `pause`/`resume`; **without those two lines the
handle's methods are inert**. And `mount.ts` shifts the wall-clock mark forward on
resume, which `Bout` cannot do, so a sheet held open is not billed to the child as
thinking time. Removing the guards was verified to turn the suite red — output below.

## Proof

Every command run from `dynawalla/games/counterweight/` unless stated.

**1. `npm test`, five times — one green run is not proof.**

```
$ for i in 1 2 3 4 5; do npm test --silent | grep -E "^# (tests|pass|fail)" | tr '\n' ' '; echo; done
# tests 79 # pass 79 # fail 0
# tests 79 # pass 79 # fail 0
# tests 79 # pass 79 # fail 0
# tests 79 # pass 79 # fail 0
# tests 79 # pass 79 # fail 0
```

Also run under Node 24, which is what `dynawalla-packs` uses (this package pins
`engines.node >= 22.12` and commits no lockfile, so CI takes `build.mjs`'s
`npm install` branch):

```
$ ~/.nvm/versions/node/v24.18.0/bin/node --experimental-strip-types --test "src/**/*.test.ts"
ℹ tests 79
ℹ pass 79
ℹ fail 0
```

Nothing in the suite draws from an unseeded `Math.random`: every stochastic decision
runs through the seeded `Rng`, and `mash.test.ts` pins its twelve seeds in the file.

**2. The pause guards are load-bearing — the suite goes red without them.**

```
$ # Bout.pause() gutted + mount.ts frame/input/latency guards removed
$ npm test --silent | grep -E "^not ok|^# (pass|fail)"
not ok 44 - the sheet stops the world, and lifting it gives the window back
not ok 45 - a backgrounded tab is the same as a sheet
not ok 47 - the clock does not run behind the sheet
not ok 48 - a round cannot be lost behind the sheet
not ok 49 - the pan does not settle behind the sheet either
not ok 50 - the steel does not bleed behind the sheet
not ok 51 - a tap on the sheet is a tap on the sheet — not a blow, not a seat
not ok 52 - resuming does not hand back a window that has already gone
# pass 69
# fail 8

$ # and the one guard only mount.ts can hold, removed on its own
$ npm test --silent | grep -E "^not ok|^# (pass|fail)"
not ok 47 - time behind the sheet is not billed to the child as thinking time
# pass 77
# fail 1
```

(Guards restored; the 79/79 runs above are the shipping tree.)

**3. No mash strategy wins. Twelve seeds, ten minutes of play each.**

`mash.test.ts` drives the shipping `Bout` with bots — a masher at eight speeds from
56 ms to 700 ms, a hammer on each of the eight rack faces at three speeds, and a bot
that refuses the arithmetic and hunts for the notch by watching which way the beam
leans. Representative raw numbers from the same harness:

```
masher   won=0 held=0 rounds=105 verdicts={"true":0,"short":0,"over":0,"shear":105}
hammer   won=0 held=0 rounds=89  verdicts={"true":0,"short":0,"over":0,"shear":89}
hammer(slow, never shears)  won=0 held=0 rounds=16 verdicts={"true":0,"short":2,"over":14}
prober   won=0 held=0 rounds=32  verdicts={"true":0,"short":19,"over":0,"shear":13}
solver   won=7 held=37 rounds=37 verdicts={"true":37,"short":0,"over":0,"shear":0}

masher wins over 20 seeds × 600 s: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
prober wins over 20 seeds × 600 s: 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
solver wins over 20 seeds × 400 s: 11,11,10,10,10,10,11,11,11,10,11,11,11,11,11,12,11,10,11,10
```

The solver is the control, and it is not optional: without it every assertion above
would also pass on a game that is simply impossible. It is asserted too — six or more
Turks put over, better than 85% of rounds held, and the beam sheared **zero** times.

**4. `npm run tsc` → 0 errors.**

```
$ npm run tsc
> tsc --noEmit
$ echo $?
0
```

**5. `npm run build`.**

```
✓ 17 modules transformed.
dist/counterweight.js  37.39 kB │ gzip: 11.71 kB
✓ built in 14ms
```

**6. `npm run build:pack`, and the injected script is relative.**

```
$ npm run build:pack
✓ 25 modules transformed.
dist-pack/pack.html                 1.27 kB │ gzip:  0.66 kB
dist-pack/assets/pack-DexwrMj3.js  32.94 kB │ gzip: 11.98 kB
✓ built in 23ms

$ grep -o '<script[^>]*>' dist-pack/pack.html
<script type="module" crossorigin src="./assets/pack-DexwrMj3.js">
```

**7. The pipeline, from `dynawalla/packs/`.**

```
$ node build.mjs counterweight
dynawalla.counterweight@0.1.0 — THE COUNTERWEIGHT
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 35348 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

**8. Secrets.**

```
$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~171374 bytes (171.37 KB) in 45.2ms
INF no leaks found
```

**9. Scope.**

```
$ git diff --name-only origin/main...HEAD | grep -cv '^dynawalla/games/counterweight/'
0
$ git diff --name-only --diff-filter=D origin/main...HEAD
(empty)
```

**10. The declared skills are the active rows, checked against the graph rather
than by eye.**

```
$ node -e 'import("./packs/shared/curriculum/src/graph/domains/add.ts").then(...)'
active in graph : dw.add.column.add-no-regroup
                  dw.add.column.subtract-no-regroup
                  dw.add.regroup.add-multidigit
                  dw.add.regroup.add-short-addend
                  dw.add.regroup.subtract-across-zero
                  dw.add.regroup.subtract-multidigit
                  dw.add.regroup.subtract-short-subtrahend
declared        : (identical)
EXACT MATCH: true
```

**11. Calibration — the round is winnable at every rung of the ladder.**

The shortest legal path to a round's answer, measured over forty rounds at four
pinned ladder levels with the pan carrying over the way it does in play:

```
level 0: median 5 strikes, p90 8,  max 10
level 2: median 7 strikes, p90 11, max 12
level 5: median 13 strikes, p90 19, max 21
level 7: median 10 strikes, p90 15, max 15
```

Twenty-one blows a quarter-second apart is 5.9 s — inside even the 7.6 s window
floor — and `strain.test.ts` asserts that twenty-five such blows against the
tightest shear limit peak below 80% of it. The child who does the arithmetic is
never punished for an answer that happened to need a lot of plates.

**12. Hygiene.**

```
$ grep -rn "console\.log" src/   → no console.log
$ grep -rn "TODO\|FIXME\|XXX" src/ → no todos
```

Every `catch` in the diff logs visibly (`console.warn`/`console.error`); nothing is
swallowed. `localStorage` is treated as unreachable — the pack frame is an opaque origin
where the property access itself throws — so `game/best.ts` keeps an in-memory mirror as
the session's source of truth, with six cases in `best.test.ts` covering a throwing
read, a throwing write, no storage at all, and a record that will not parse.

Reduced motion is a branch: the beam still moves, because the beam moving *is* the
information, but it is critically damped so it travels to its reading instead of ringing
its way there. Same reading, same reach, and every duration in `TIMING_REDUCED` is
identical to `TIMING` — nobody gets less time for asking for a calmer screen.
`beam.test.ts` asserts the calm beam overshoots by zero and arrives at the same angle.

Being pinned takes nothing: the arm goes back to level and the same Turk squares up, no
harder than before (ADR-0009). `transition` is called at exactly one place in this game,
when a Turk goes over — `mount.test.ts` plays a match with no input at all, loses every
round, and asserts that not one stopping point was offered.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
