### PR TITLE
dynawalla/games/colossus: COLOSSUS — a wrong strike makes the tower taller

### DIFF
--- a/dynawalla/games/colossus/.gitignore
+++ b/dynawalla/games/colossus/.gitignore
@@ -1,0 +1,12 @@
+node_modules/
+dist/
+
+# The pack build. `packs/build.mjs` regenerates it and stages it into the app.
+dist-pack/
+
+# Local QA scratch: screenshots and temporary captures.
+qa/shots
+qa/tmp
+
+# The lockfile is not committed for a game package; the repo pins at the root.
+package-lock.json

--- a/dynawalla/games/colossus/index.html
+++ b/dynawalla/games/colossus/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <title>COLOSSUS — dev harness</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #120c14;
+        overscroll-behavior: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+      #readout {
+        position: fixed;
+        left: 8px;
+        bottom: 6px;
+        z-index: 5;
+        font: 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+        color: rgba(255, 255, 255, 0.42);
+        pointer-events: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <div id="readout">host.report → 0/0</div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/colossus/pack.html
+++ b/dynawalla/games/colossus/pack.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#120c14" />
+    <title>COLOSSUS</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #120c14;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme.
+         The dev harness's `#readout` is not here — it reported the stub host's
+         tally, and inside a real host the host draws the progress. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/colossus/pack.json
+++ b/dynawalla/games/colossus/pack.json
@@ -1,0 +1,24 @@
+{
+  "id": "dynawalla.colossus",
+  "version": "0.1.0",
+  "name": "COLOSSUS",
+  "description": "You are the giant. A keystone carries a sum; the tower carries numbers. Punch out the floors whose product matches the keystone and the tower comes down on top of you. Strike wrong and the tower gets taller.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-multidigit",
+      "dw.add.regroup.add-short-addend",
+      "dw.add.regroup.subtract-short-subtrahend",
+      "dw.add.regroup.subtract-across-zero"
+    ],
+    "grades": [1, 4]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/colossus/package.json
+++ b/dynawalla/games/colossus/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@dynawalla/game-colossus",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "COLOSSUS — a giant at the foot of a tower. Punch out the floors whose product matches the keystone; a wrong strike makes the tower taller.",
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4345",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
+    "build:pack": "vite build --config vite.pack.config.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^6.0.0",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/games/colossus/src/audio/audio.ts
+++ b/dynawalla/games/colossus/src/audio/audio.ts
@@ -1,0 +1,154 @@
+// The sound of the building. Synthesised here, in this pack's own
+// `AudioContext` — the host's `feedback.sound` capability is a different thing
+// and is not declared.
+//
+// Everything is stone: noise through a band-pass with a fast decay, plus a low
+// sine that carries the weight. Nothing in here is a buzzer, because nothing in
+// this game is a buzz — a wrong strike sounds like more masonry arriving, which
+// is exactly what it is.
+
+type Ctor = typeof AudioContext
+
+function contextCtor(): Ctor | null {
+  const g = globalThis as unknown as { AudioContext?: Ctor; webkitAudioContext?: Ctor }
+  return g.AudioContext ?? g.webkitAudioContext ?? null
+}
+
+export class Audio {
+  private ctx: AudioContext | null = null
+  private bus: GainNode | null = null
+  private noise: AudioBuffer | null = null
+
+  /** Web Audio needs a gesture. The first touch in the game is the first one. */
+  resume(): void {
+    if (!this.ctx) {
+      const Ctx = contextCtor()
+      if (!Ctx) return
+      try {
+        this.ctx = new Ctx()
+      } catch (error) {
+        console.warn("[colossus] no audio context", error)
+        return
+      }
+      this.bus = this.ctx.createGain()
+      this.bus.gain.value = 0.7
+      this.bus.connect(this.ctx.destination)
+      this.noise = this.makeNoise(this.ctx)
+    }
+    if (this.ctx.state === "suspended") {
+      void this.ctx.resume().catch((error: unknown) => {
+        console.warn("[colossus] audio could not resume", error)
+      })
+    }
+  }
+
+  private makeNoise(ctx: AudioContext): AudioBuffer {
+    const buf = ctx.createBuffer(1, Math.floor(ctx.sampleRate * 1.4), ctx.sampleRate)
+    const data = buf.getChannelData(0)
+    let last = 0
+    for (let i = 0; i < data.length; i++) {
+      // Brown-ish noise: grit rather than hiss. Stone, not steam.
+      last = (last + Math.random() * 2 - 1) * 0.5
+      data[i] = last
+    }
+    return buf
+  }
+
+  private rumble(when: number, dur: number, freq: number, gain: number, q: number): void {
+    const ctx = this.ctx
+    const bus = this.bus
+    if (!ctx || !bus || !this.noise) return
+    const src = ctx.createBufferSource()
+    src.buffer = this.noise
+    src.playbackRate.value = 0.7 + Math.random() * 0.5
+    const filter = ctx.createBiquadFilter()
+    filter.type = "bandpass"
+    filter.frequency.value = freq
+    filter.Q.value = q
+    const g = ctx.createGain()
+    g.gain.setValueAtTime(0, when)
+    g.gain.linearRampToValueAtTime(gain, when + 0.012)
+    g.gain.exponentialRampToValueAtTime(0.0001, when + dur)
+    src.connect(filter).connect(g).connect(bus)
+    src.start(when)
+    src.stop(when + dur + 0.05)
+  }
+
+  private tone(when: number, dur: number, from: number, to: number, gain: number): void {
+    const ctx = this.ctx
+    const bus = this.bus
+    if (!ctx || !bus) return
+    const osc = ctx.createOscillator()
+    osc.type = "sine"
+    osc.frequency.setValueAtTime(from, when)
+    osc.frequency.exponentialRampToValueAtTime(Math.max(20, to), when + dur)
+    const g = ctx.createGain()
+    g.gain.setValueAtTime(0, when)
+    g.gain.linearRampToValueAtTime(gain, when + 0.02)
+    g.gain.exponentialRampToValueAtTime(0.0001, when + dur)
+    osc.connect(g).connect(bus)
+    osc.start(when)
+    osc.stop(when + dur + 0.05)
+  }
+
+  private now(): number {
+    return this.ctx ? this.ctx.currentTime + 0.005 : 0
+  }
+
+  /** Taking hold of a slab. `depth` is how many are in the fist already. */
+  hold(depth: number): void {
+    if (!this.ctx) return
+    const t = this.now()
+    this.rumble(t, 0.09, 900, 0.1, 2.2)
+    this.tone(t, 0.16, 220 * Math.pow(1.26, Math.min(5, depth)), 180, 0.075)
+  }
+
+  release(): void {
+    if (!this.ctx) return
+    this.rumble(this.now(), 0.07, 620, 0.06, 1.8)
+  }
+
+  /** The building coming apart. */
+  collapse(floors: number): void {
+    if (!this.ctx) return
+    const t = this.now()
+    this.rumble(t, 0.5, 180, 0.5, 0.7)
+    this.rumble(t + 0.03, 0.9, 70, 0.42, 0.5)
+    this.tone(t, 0.7, 120, 34, 0.32)
+    for (let i = 0; i < Math.min(6, floors); i++) {
+      this.rumble(t + 0.08 + i * 0.055, 0.24, 320 + i * 90, 0.16, 1.4)
+    }
+  }
+
+  /** More stone arriving. Heavy, slow, and not a scold. */
+  growth(count: number): void {
+    if (!this.ctx) return
+    const t = this.now()
+    for (let i = 0; i < count; i++) {
+      this.rumble(t + i * 0.13, 0.3, 150 - i * 18, 0.38, 0.8)
+      this.tone(t + i * 0.13, 0.26, 88 - i * 8, 40, 0.2)
+    }
+  }
+
+  /** The last floor leaves the ground line. */
+  topple(): void {
+    if (!this.ctx) return
+    const t = this.now()
+    this.rumble(t, 1.5, 90, 0.55, 0.4)
+    this.tone(t, 1.4, 180, 28, 0.4)
+    // A short bright fifth over the top, so the ground shaking reads as a win.
+    this.tone(t + 0.1, 0.5, 392, 588, 0.12)
+    this.tone(t + 0.24, 0.6, 588, 784, 0.1)
+  }
+
+  dispose(): void {
+    const ctx = this.ctx
+    this.ctx = null
+    this.bus = null
+    this.noise = null
+    if (!ctx) return
+    void ctx.close().catch(() => {
+      // A context that was already closed is not news.
+    })
+  }
+}

--- a/dynawalla/games/colossus/src/contract.ts
+++ b/dynawalla/games/colossus/src/contract.ts
@@ -1,0 +1,59 @@
+// The host↔game contract. This is the shape the runtime lands underneath us;
+// it must not drift. Nothing else in this package may redefine these types.
+//
+// `mount` delegates to `./mount.ts`. That module imports `Host` from here
+// type-only, and a type-only import is erased, so there is no runtime cycle.
+
+import { mountColossus } from "./mount.ts"
+
+export type Question = {
+  id: string
+  /** "47 + 25" — the operator glyph is already in it. */
+  prompt: string
+  /** "72" — exact, canonical, and never computed by this game. */
+  answer: string
+  /**
+   * Wrong values a child actually produces: the host's mal-rule outputs first,
+   * near-misses after. COLOSSUS stands each of them up as a slab, so a child
+   * who drops a carry has a floor to punch that is *exactly* their mistake and
+   * the misconception routes back to the host with no extra wiring.
+   */
+  distractors: string[]
+  domain: string
+  /** 0..1. A monotone reading of the ladder, not a claim about hardness. */
+  difficulty: number
+}
+
+export type Host = {
+  next(opts?: { domain?: string; difficulty?: number }): Question
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+  haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void
+  prefersReducedMotion(): boolean
+
+  /**
+   * A natural stopping point the child *reached*: a level cleared, a run
+   * completed, a boss down.
+   *
+   * OPTIONAL and feature-detected — a stub host does not implement it and the
+   * game must not care. Fire and forget: nothing is returned, nothing may be
+   * awaited, and the game must not branch on it.
+   *
+   * **Never after a failure.** COLOSSUS calls it when a tower has been brought
+   * down, never when one is left standing — a purchase surface next to a
+   * shortfall is the thing that is forbidden outright.
+   */
+  transition?(kind: "level" | "run" | "boss", label?: string): void
+}
+
+/**
+ * Mount the game into `el`.
+ *
+ * `pause`/`resume` are part of the surface because the host can put a sheet
+ * over a still-mounted, still-running pack. See `mount.ts`.
+ */
+export function mount(
+  el: HTMLElement,
+  host: Host,
+): { unmount(): void; pause(): void; resume(): void } {
+  return mountColossus(el, host)
+}

--- a/dynawalla/games/colossus/src/core/feel.ts
+++ b/dynawalla/games/colossus/src/core/feel.ts
@@ -1,0 +1,45 @@
+// Feel: the curves everything in this game moves on, in one place so the whole
+// building has one physics rather than eight.
+
+/** Clamp to 0..1. */
+export function unit(x: number): number {
+  return x < 0 ? 0 : x > 1 ? 1 : x
+}
+
+export function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t
+}
+
+/** Frame-rate independent approach: `k` is the fraction closed per 16.7 ms. */
+export function approach(a: number, b: number, k: number, dt: number): number {
+  const t = 1 - Math.pow(1 - unit(k), dt / 16.6667)
+  return a + (b - a) * t
+}
+
+/** Heavy things start slow and arrive fast. Gravity, near enough. */
+export function easeInQuad(t: number): number {
+  const x = unit(t)
+  return x * x
+}
+
+export function easeOutCubic(t: number): number {
+  const x = 1 - unit(t)
+  return 1 - x * x * x
+}
+
+export function easeOutBack(t: number): number {
+  const x = unit(t) - 1
+  return 1 + 2.2 * x * x * x + 1.2 * x * x
+}
+
+/**
+ * A settle: overshoot once, then a short shudder that dies.
+ *
+ * A stone slab weighing several tonnes does not bounce like a ball, so the
+ * amplitude is small and the decay is fast. Anything springier reads as rubber.
+ */
+export function settle(t: number): number {
+  const x = unit(t)
+  if (x >= 1) return 1
+  return 1 - Math.cos(x * Math.PI * 3.1) * Math.exp(-6.2 * x) * (1 - x)
+}

--- a/dynawalla/games/colossus/src/core/rng.ts
+++ b/dynawalla/games/colossus/src/core/rng.ts
@@ -1,0 +1,61 @@
+// A seeded, deterministic PRNG. Every stochastic decision in the game and in
+// the stub host runs through one of these so a run can be replayed exactly.
+//
+// mulberry32: 32-bit state, no allocation, passes gjrand well enough for a game
+// and is trivially portable to a test.
+
+export class Rng {
+  private s: number
+
+  constructor(seed: number) {
+    // Force to uint32; a 0 seed is legal for mulberry32 but degenerate-looking,
+    // so nudge it off zero.
+    this.s = (seed >>> 0) || 0x9e3779b9
+  }
+
+  /** Uniform in [0, 1). */
+  next(): number {
+    this.s = (this.s + 0x6d2b79f5) >>> 0
+    let t = this.s
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+
+  /** Uniform in [lo, hi). */
+  range(lo: number, hi: number): number {
+    return lo + this.next() * (hi - lo)
+  }
+
+  /** Uniform integer in [lo, hi] inclusive. */
+  int(lo: number, hi: number): number {
+    if (hi <= lo) return lo
+    return lo + Math.floor(this.next() * (hi - lo + 1))
+  }
+
+  /** True with probability p. */
+  chance(p: number): boolean {
+    return this.next() < p
+  }
+
+  pick<T>(xs: readonly T[]): T {
+    if (xs.length === 0) throw new Error("rng.pick: empty")
+    return xs[Math.floor(this.next() * xs.length)] as T
+  }
+
+  /** In-place Fisher–Yates. Returns the same array for chaining. */
+  shuffle<T>(xs: T[]): T[] {
+    for (let i = xs.length - 1; i > 0; i--) {
+      const j = Math.floor(this.next() * (i + 1))
+      const a = xs[i] as T
+      xs[i] = xs[j] as T
+      xs[j] = a
+    }
+    return xs
+  }
+
+  /** Snapshot/restore so a subsystem can be forked without disturbing the run. */
+  fork(salt: number): Rng {
+    return new Rng((this.s ^ Math.imul(salt, 0x85ebca6b)) >>> 0)
+  }
+}

--- a/dynawalla/games/colossus/src/game/best.ts
+++ b/dynawalla/games/colossus/src/game/best.ts
@@ -1,0 +1,62 @@
+// The one number worth remembering: how many colossi the child has put on the
+// ground back to back. Not accuracy, not a percentage — a thing that happened.
+//
+// **`localStorage` throws inside a pack frame.** The document is on an opaque
+// origin, so every access is guarded and the value is held in memory as well.
+// A child who plays a whole sitting in a pack frame still sees their best rise;
+// it just does not survive the app being closed, which is a smaller loss than
+// a game that will not start.
+
+// gitleaks: a dotted string constant assigned to a `*_KEY` name reads as a
+// credential to every secret scanner there is. It is a storage slot name.
+const BEST_SLOT = "dw.colossus.best" // gitleaks:allow
+
+let memory = 0
+let loaded = false
+
+function store(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null
+  } catch (error) {
+    console.warn("[colossus] localStorage is not reachable from this frame", error)
+    return null
+  }
+}
+
+/** The longest run of towers brought all the way down. */
+export function bestStreak(): number {
+  if (loaded) return memory
+  loaded = true
+  const slot = store()
+  if (slot) {
+    try {
+      const raw = Number(slot.getItem(BEST_SLOT) ?? "0")
+      if (Number.isFinite(raw) && raw > 0) memory = Math.floor(raw)
+    } catch (error) {
+      console.warn("[colossus] a best could not be read back", error)
+    }
+  }
+  return memory
+}
+
+/** Record a run of toppled towers. Returns true when it is a new best. */
+export function recordStreak(towers: number): boolean {
+  const previous = bestStreak()
+  if (towers <= previous) return false
+  memory = towers
+  const slot = store()
+  if (slot) {
+    try {
+      slot.setItem(BEST_SLOT, String(towers))
+    } catch (error) {
+      console.warn("[colossus] a best could not be written", error)
+    }
+  }
+  return true
+}
+
+/** Tests own the module's state; nothing in the game calls this. */
+export function resetBestForTest(): void {
+  memory = 0
+  loaded = false
+}

--- a/dynawalla/games/colossus/src/game/factor.ts
+++ b/dynawalla/games/colossus/src/game/factor.ts
@@ -1,0 +1,131 @@
+// Exact integer factorisation. Every number in this file is an integer and
+// every comparison is between integers; a float never reaches a slab, a
+// product, or a reported answer.
+//
+// This is the game's *own* mathematics, not the curriculum's. The host asked
+// "what is 47 + 25". Splitting the answer into 8 × 9 is a thing COLOSSUS does
+// to turn a number into a building, and nothing about it is reported.
+
+import type { Rng } from "../core/rng.ts"
+
+/**
+ * The largest number a slab may carry.
+ *
+ * Four digits, because three-digit column addition answers 1998 and a keystone
+ * the tower cannot carry is a keystone the child never gets asked.
+ */
+export const MAX_SLAB = 9999
+
+/**
+ * The largest factor the game will ever ask a child to multiply *by*.
+ *
+ * The factoring is the game's own mathematics and it must stay easier than the
+ * curriculum's, or the tiers invert: a keystone reading `198 + 246` split into
+ * `12 × 37` would make the addition the easy half. So a split only happens when
+ * one factor is times-table stone and the other is small; otherwise the answer
+ * stands on a single slab and the arithmetic is the whole task, which is the
+ * right shape at the tiers where the arithmetic is three digits wide.
+ */
+export const SMALL_SLAB = 12
+
+/** The other factor of a pair. `7 × 13` is fair; `12 × 37` is a different game. */
+export const PAIR_CAP = 25
+
+/** Prime factors of `n`, ascending, with multiplicity. `n >= 2`. */
+export function primeFactors(n: number): number[] {
+  const out: number[] = []
+  let m = n
+  for (let p = 2; p * p <= m; p += p === 2 ? 1 : 2) {
+    while (m % p === 0) {
+      out.push(p)
+      m = Math.floor(m / p)
+    }
+  }
+  if (m > 1) out.push(m)
+  return out
+}
+
+/** Every `d` with `2 <= d <= n / d` and `n % d === 0`. Ascending. */
+export function divisorPairs(n: number): Array<[number, number]> {
+  const out: Array<[number, number]> = []
+  for (let d = 2; d * d <= n; d++) {
+    if (n % d === 0) out.push([d, Math.floor(n / d)])
+  }
+  return out
+}
+
+/**
+ * Split `value` into exactly `want` slabs whose product is `value`.
+ *
+ * Returns fewer slabs than asked for when the number will not go — 73 is prime
+ * and there is no honest pair, so it comes back as a single slab reading 73.
+ * That is not a degradation: a one-slab keystone is "find the floor that equals
+ * 47 + 25", which is the same arithmetic with the multiplication layer off, and
+ * it is exactly what the youngest tier should be playing.
+ *
+ * Guarantees, all asserted in `factor.test.ts`:
+ *   * the product of the result is `value`, exactly;
+ *   * every slab is a positive integer no larger than `MAX_SLAB`;
+ *   * the result is never empty.
+ */
+export function slabsFor(value: number, want: number, rng: Rng): number[] {
+  if (!Number.isInteger(value) || value < 2 || value > MAX_SLAB) return [value]
+  const target = Math.max(1, Math.min(3, Math.round(want)))
+  if (target === 1) return [value]
+
+  if (target === 3) {
+    const triple = intoBuckets(value, 3, SMALL_SLAB, rng)
+    if (triple) return triple
+  }
+
+  // A pair a child can see: one times-table factor, one small one. When there
+  // is none — 444 is 12 × 37 and nothing kinder — the answer stands on a slab
+  // of its own rather than being bent into a harder sum than the keystone.
+  const pairs = divisorPairs(value).filter(([a, b]) => a <= SMALL_SLAB && b <= PAIR_CAP)
+  if (pairs.length === 0) return [value]
+
+  // The roundest splits first: 72 as 8 × 9 before 72 as 3 × 24.
+  const tidy = pairs.filter(([, b]) => b <= SMALL_SLAB)
+  const [a, b] = rng.pick(tidy.length > 0 ? tidy : pairs)
+  return rng.chance(0.5) ? [a, b] : [b, a]
+}
+
+/**
+ * Recombine the prime factors of `value` into exactly `count` buckets, each at
+ * most `cap`. `null` when the primes will not go — 2 × 3 × 251 cannot become
+ * three slabs of twelve or less.
+ *
+ * Exhaustive over assignments for the small factor counts this game produces
+ * (a value under 1000 has at most nine prime factors, so at most 3^9 = 19683
+ * assignments), and the first legal one wins after a seeded shuffle so the same
+ * value does not always break the same way.
+ */
+function intoBuckets(value: number, count: number, cap: number, rng: Rng): number[] | null {
+  const primes = primeFactors(value)
+  if (primes.length < count) return null
+  if (primes.some((p) => p > cap)) return null
+
+  const order = rng.shuffle(primes.slice())
+  const total = count ** order.length
+  const start = rng.int(0, total - 1)
+
+  for (let step = 0; step < total; step++) {
+    const code = (start + step) % total
+    const buckets = new Array<number>(count).fill(1)
+    let rest = code
+    for (const p of order) {
+      const slot = rest % count
+      rest = Math.floor(rest / count)
+      buckets[slot] = (buckets[slot] as number) * p
+    }
+    if (buckets.every((b) => b >= 2 && b <= cap)) return buckets
+  }
+  return null
+}
+
+/** The product of a list of slab values. Exact; overflow is impossible here. */
+export function productOf(values: readonly number[]): number {
+  let out = 1
+  for (const v of values) out *= v
+  return out
+}

--- a/dynawalla/games/colossus/src/game/game.ts
+++ b/dynawalla/games/colossus/src/game/game.ts
@@ -1,0 +1,367 @@
+// COLOSSUS — the rules, with no canvas anywhere near them.
+//
+// One verb: STRIKE.
+//
+//   * A keystone hangs over the tower carrying a sum: `47 + 25`.
+//   * Every floor of the tower carries a number.
+//   * Tap floors to take hold of them. The fist reads back what you are
+//     holding as an expression — `8 × 9` — and never as a total. The child
+//     multiplies; the game does not do it for them.
+//   * STRIKE. If what you are holding multiplies to the keystone, those floors
+//     blow out, everything above falls into the hole, and the keystone's own
+//     decoys crumble with it.
+//   * If it does not, **the tower gets taller.** Fresh slabs thud down on the
+//     top and the keystone rides up out of reach. No buzzer, no lost life, no
+//     red X. More building.
+//
+// Taking hold of a floor is free and reversible, so exploring a factorisation
+// costs nothing. STRIKE is the assertion, and it is the only thing reported.
+// Flail at it and the tower grows faster than you can bring it down, which is
+// a thing a child can see from across a room.
+//
+// **What crosses to the host.** The product of what was held, as a string. That
+// is a value the host can judge exactly against its canonical answer, and when
+// it is wrong it is usually wrong in a way the host recognises: the decoy slabs
+// are the mal-rule outputs, so punching one reports the misconception itself.
+
+import type { Host, Question } from "../contract.ts"
+import { Rng } from "../core/rng.ts"
+import { productOf, slabsFor } from "./factor.ts"
+import {
+  FLOOR_BUDGET,
+  GROWTH,
+  MAX_FLOORS,
+  MAX_KEYSTONES,
+  MIN_KEYSTONES,
+  answerOf,
+  floorsFor,
+  isUsable,
+  rubble,
+  slabCount,
+  standingSolution,
+  type Floor,
+} from "./tower.ts"
+
+export type GameEvent =
+  | { kind: "hold"; floor: Floor }
+  | { kind: "release"; floor: Floor }
+  | { kind: "clear"; removed: readonly Floor[]; product: number; keystone: Question }
+  | { kind: "grow"; added: readonly Floor[]; product: number; keystone: Question; capped: boolean }
+  | { kind: "keystone"; question: Question }
+  | { kind: "level"; level: number; toppled: boolean; cleared: number }
+  | { kind: "stalled" }
+
+export type Tally = {
+  /** Keystones brought down. */
+  cleared: number
+  /** Keystones that got away. */
+  missed: number
+  /** Towers put on the ground. */
+  toppled: number
+}
+
+/** How many draws we are willing to make to find one question we can build with. */
+const DRAW_ATTEMPTS = 8
+
+export class Game {
+  private readonly host: Host
+  private readonly rng: Rng
+  private id = 1
+
+  private queue: Question[] = []
+  private cursor = 0
+  private levelNo = 1
+  /** Keystones brought down in the tower currently standing. */
+  private clearedHere = 0
+
+  private tower: Floor[] = []
+  private held = new Set<number>()
+
+  /** Wall-clock mark for the current keystone, shifted forward across a pause. */
+  private askedAt = 0
+  private paused = false
+  private pausedAt = 0
+
+  /** Nothing the host serves can be built with. Loud, and drawn on the surface. */
+  private stalledFlag = false
+
+  readonly tally: Tally = { cleared: 0, missed: 0, toppled: 0 }
+
+  constructor(host: Host, rng: Rng, now: number) {
+    this.host = host
+    this.rng = rng
+    this.askedAt = now
+  }
+
+  /** Build the first tower. Separate from the constructor so events can be seen. */
+  begin(now: number): GameEvent[] {
+    return this.buildLevel(now)
+  }
+
+  get floors(): readonly Floor[] {
+    return this.tower
+  }
+
+  get height(): number {
+    return this.tower.length
+  }
+
+  get level(): number {
+    return this.levelNo
+  }
+
+  get stalled(): boolean {
+    return this.stalledFlag
+  }
+
+  /** Keystones answered so far in this tower, right or wrong. */
+  get progress(): { done: number; total: number } {
+    return { done: this.cursor, total: this.queue.length }
+  }
+
+  get keystone(): Question | null {
+    return this.queue[this.cursor] ?? null
+  }
+
+  get isPaused(): boolean {
+    return this.paused
+  }
+
+  get holding(): readonly number[] {
+    return [...this.held]
+  }
+
+  /** The values in the fist, in tower order, so the fist reads bottom-up. */
+  heldValues(): number[] {
+    return this.tower.filter((f) => this.held.has(f.id)).map((f) => f.value)
+  }
+
+  isHeld(id: number): boolean {
+    return this.held.has(id)
+  }
+
+  /**
+   * Take hold of a floor, or let it go.
+   *
+   * Inert while paused. The host can put a sheet over a still-mounted pack, and
+   * a touch that lands behind it is not a thing the child did.
+   */
+  toggle(id: number): GameEvent[] {
+    if (this.paused || this.stalledFlag) return []
+    const floor = this.tower.find((f) => f.id === id)
+    if (!floor) return []
+    if (this.held.delete(id)) return [{ kind: "release", floor }]
+    this.held.add(id)
+    return [{ kind: "hold", floor }]
+  }
+
+  /** Let go of everything. Free, and never reported. */
+  releaseAll(): void {
+    if (this.paused) return
+    this.held.clear()
+  }
+
+  /**
+   * STRIKE.
+   *
+   * An empty fist is not an assertion: it does nothing, reports nothing and
+   * costs nothing. Everything else is reported, and the tower answers.
+   */
+  strike(now: number): GameEvent[] {
+    if (this.paused || this.stalledFlag) return []
+    const keystone = this.keystone
+    if (!keystone) return []
+    const values = this.heldValues()
+    if (values.length === 0) return []
+
+    const product = productOf(values)
+    const target = answerOf(keystone)
+    const right = product === target
+    const ms = Math.max(0, now - this.askedAt)
+
+    // The host judges. What goes across is the value the child asserted — and
+    // when they punched a decoy that value is the mal-rule output itself.
+    this.host.report({
+      questionId: keystone.id,
+      correct: right,
+      ms,
+      answered: String(product),
+    })
+
+    const events: GameEvent[] = right
+      ? this.collapse(keystone, product)
+      : this.grow(keystone, product)
+
+    this.held.clear()
+    this.cursor += 1
+    events.push(...this.afterKeystone(now))
+    return events
+  }
+
+  /** The host put a sheet over us. Stop the clock; stop taking input. */
+  pause(now: number): void {
+    if (this.paused) return
+    this.paused = true
+    this.pausedAt = now
+  }
+
+  /**
+   * The sheet came off. Shift the keystone's wall-clock mark forward by the
+   * span the child was not here for, so the latency reported is time they
+   * actually spent looking at the tower.
+   */
+  resume(now: number): void {
+    if (!this.paused) return
+    this.paused = false
+    this.askedAt += Math.max(0, now - this.pausedAt)
+  }
+
+  // ── internals ─────────────────────────────────────────────────────────────
+
+  private collapse(keystone: Question, product: number): GameEvent[] {
+    const doomed = new Set<number>(this.held)
+    for (const floor of this.tower) {
+      // The keystone's own stones go with it: the floors that made its answer
+      // and the slabs that carried its lies. That is the big collapse, and it
+      // is what makes the tower a countdown rather than a scoreboard.
+      if (floor.owner === this.cursor) doomed.add(floor.id)
+    }
+    const removed = this.tower.filter((f) => doomed.has(f.id))
+    this.tower = this.tower.filter((f) => !doomed.has(f.id))
+    this.tally.cleared += 1
+    this.clearedHere += 1
+    return [{ kind: "clear", removed, product, keystone }]
+  }
+
+  private grow(keystone: Question, product: number): GameEvent[] {
+    // The keystone's stones stay standing and go cold. They belong to nobody
+    // now, so nothing will ever carry them out for free.
+    for (const floor of this.tower) {
+      if (floor.owner === this.cursor) {
+        floor.owner = -1
+        floor.kind = "rubble"
+      }
+    }
+    const room = Math.max(0, MAX_FLOORS - this.tower.length)
+    const added = rubble(Math.min(GROWTH, room), this.rng, () => this.id++)
+    this.tower.push(...added)
+    this.tally.missed += 1
+    return [{ kind: "grow", added, product, keystone, capped: added.length < GROWTH }]
+  }
+
+  /** Move to the next keystone, or wrap the level up and raise the next tower. */
+  private afterKeystone(now: number): GameEvent[] {
+    if (this.cursor < this.queue.length) {
+      this.askedAt = now
+      const events: GameEvent[] = []
+      this.replant()
+      const next = this.keystone
+      if (next) events.push({ kind: "keystone", question: next })
+      return events
+    }
+
+    const toppled = this.tower.length === 0
+    if (toppled) this.tally.toppled += 1
+    const cleared = this.clearedHere
+    const events: GameEvent[] = [{ kind: "level", level: this.levelNo, toppled, cleared }]
+
+    // A tower the child brought keystones down on is a stopping point they
+    // reached. A tower left standing is not a failure in this game — there is
+    // no failure state — but it is not an achievement either, so the sheet the
+    // host may raise here waits for a level with at least one clear in it.
+    if (cleared > 0) this.host.transition?.("level", toppled ? "toppled" : "level")
+
+    this.levelNo += 1
+    events.push(...this.buildLevel(now))
+    return events
+  }
+
+  /**
+   * Raise the next tower.
+   *
+   * Keystones are taken until the building is about `FLOOR_BUDGET` floors tall,
+   * not until a fixed count is reached: a keystone whose answer is cut into
+   * three slabs is more building than one cut into a single slab, and a tower
+   * a child cannot reach the top of is a worse tower whichever tier built it.
+   */
+  private buildLevel(now: number): GameEvent[] {
+    this.clearedHere = 0
+    const questions: Question[] = []
+    const floors: Floor[] = []
+
+    while (questions.length < MAX_KEYSTONES) {
+      if (questions.length >= MIN_KEYSTONES && floors.length >= FLOOR_BUDGET) break
+      const question = this.drawOne()
+      if (!question) break
+      const want = slabCount(question.difficulty, this.levelNo, questions.length)
+      floors.push(...floorsFor(question, questions.length, want, this.rng, () => this.id++))
+      questions.push(question)
+    }
+
+    if (questions.length === 0) {
+      this.stalledFlag = true
+      console.error("[colossus] the host served nothing this game can build a tower from")
+      return [{ kind: "stalled" }]
+    }
+
+    // Shuffled through the whole height, so the answer to the third keystone is
+    // not standing in a neat band above the answer to the second.
+    this.rng.shuffle(floors)
+    this.queue = questions
+    this.tower = floors
+    this.cursor = 0
+    this.held.clear()
+    this.askedAt = now
+    const first = this.keystone
+    return first ? [{ kind: "keystone", question: first }] : []
+  }
+
+  /**
+   * Re-plant the current keystone's answer if it is no longer standing.
+   *
+   * A child who makes 72 out of an 8 from this keystone and a 9 borrowed from a
+   * later one is entirely right, and the later keystone must not be left
+   * unanswerable for it. The stones come back; the tower is a little taller for
+   * it, which is honest — that answer was spent.
+   */
+  private replant(): void {
+    const question = this.keystone
+    if (!question) return
+    const standing = standingSolution(this.tower, this.cursor)
+    if (standing.product === answerOf(question)) return
+
+    const stale = new Set(standing.ids)
+    this.tower = this.tower.filter((f) => !stale.has(f.id))
+    const want = slabCount(question.difficulty, this.levelNo, this.cursor)
+    const values = slabsFor(answerOf(question), want, this.rng)
+    const fresh: Floor[] = values.map((value) => ({
+      id: this.id++,
+      value,
+      owner: this.cursor,
+      kind: "solution" as const,
+    }))
+    // Slotted through the height rather than dropped on the top: a keystone's
+    // answer must never be the three slabs that just appeared.
+    for (const floor of fresh) {
+      const at = this.rng.int(0, this.tower.length)
+      this.tower.splice(at, 0, floor)
+    }
+  }
+
+  /**
+   * One keystone this game can actually build with: an exact positive integer
+   * answer. A decimal cannot be a product of slabs, and rounding one would
+   * report a value the child never asserted, so it is dropped rather than bent.
+   */
+  private drawOne(): Question | null {
+    for (let i = 0; i < DRAW_ATTEMPTS; i++) {
+      const question = this.host.next()
+      if (isUsable(question)) return question
+    }
+    console.warn("[colossus] the host served nothing buildable in eight draws")
+    return null
+  }
+}
+
+/** Exposed for the tests and the HUD; the engine owns the numbers. */
+export { GROWTH, MAX_FLOORS, MAX_KEYSTONES, MIN_KEYSTONES }

--- a/dynawalla/games/colossus/src/game/tower.ts
+++ b/dynawalla/games/colossus/src/game/tower.ts
@@ -1,0 +1,200 @@
+// The tower: what a floor is, and how a level's tower is built out of the
+// keystones it will be asked to answer.
+//
+// The tower is the level's whole worklist made physical. Every floor standing
+// in it belongs to a keystone — either as part of that keystone's solution, or
+// as a slab bearing one of the wrong values a child actually produces for it.
+// Clear a keystone and its floors leave the building. Clear them all and the
+// colossus is on the ground.
+//
+// That is why the growth penalty bites: a wrong strike does not take a life or
+// sound a buzzer, it drops fresh slabs on top of the tower. The child is not
+// told off. They are handed more work, and they can see exactly how much.
+
+import type { Question } from "../contract.ts"
+import type { Rng } from "../core/rng.ts"
+import { MAX_SLAB, productOf, slabsFor } from "./factor.ts"
+
+export type FloorKind =
+  /** Part of a keystone's answer. The product of a keystone's solution floors is its answer. */
+  | "solution"
+  /** A slab bearing one of a keystone's mal-rule values. Punching it is a diagnosis. */
+  | "decoy"
+  /** What a wrong strike leaves behind. Belongs to nobody and never leaves on its own. */
+  | "rubble"
+
+export type Floor = {
+  readonly id: number
+  readonly value: number
+  /** Index of the keystone this floor belongs to; `-1` once it belongs to nobody. */
+  owner: number
+  kind: FloorKind
+}
+
+/**
+ * How tall a fresh tower wants to be, in floors.
+ *
+ * Not a keystone count — a *height* budget, because a keystone answered with
+ * three slabs builds more building than one answered with a single slab. The
+ * level takes keystones until it has about this much tower, so a six-year-old
+ * on single slabs and a ten-year-old on triples both get a colossus of roughly
+ * the same size, and neither gets one they cannot reach the top of.
+ */
+export const FLOOR_BUDGET = 9
+
+/** Floors under and over the budget. A tower is never shorter or longer. */
+export const MIN_KEYSTONES = 3
+export const MAX_KEYSTONES = 5
+
+/** Floors a wrong strike stacks on top. Fixed, so a child can count it. */
+export const GROWTH = 2
+
+/**
+ * The tallest a tower is allowed to get.
+ *
+ * Not mercy — the cost of a wrong strike is real and stays real. It is that a
+ * slab in a sixteen-floor tower is already down to about a third of an inch on
+ * a phone, and a tower a child cannot reliably tap punishes them twice. Past
+ * the cap the strike still costs the keystone; the building just stops taking
+ * new stone.
+ */
+export const MAX_FLOORS = 16
+
+/** Values rubble is cut from: small, anonymous, and no use to anybody. */
+const RUBBLE_LO = 2
+const RUBBLE_HI = 12
+
+/** A question this game can build with: an exact positive integer answer. */
+export function isUsable(question: Question): boolean {
+  const n = Number(question.answer)
+  return Number.isInteger(n) && n >= 1 && n <= MAX_SLAB
+}
+
+export function answerOf(question: Question): number {
+  return Number(question.answer)
+}
+
+/**
+ * How many slabs a keystone's answer is broken into.
+ *
+ * One slab is "punch the floor that equals 47 + 25" — the same arithmetic with
+ * the multiplication layer switched off, and the right thing for a six-year-old
+ * on the first rung of the column ladder. The layer switches on as the host's
+ * own ladder rises, and never because the game got bored.
+ */
+export function slabCount(difficulty: number, level: number, ordinal: number): number {
+  // The very first keystone of a session is always one slab. The mechanic
+  // teaches itself in a single punch and nobody has to be told the rules.
+  if (level <= 1 && ordinal === 0) return 1
+  const d = Math.max(0, Math.min(1, difficulty))
+  if (d < 0.3) return 1
+  if (d < 0.65) return 2
+  return 3
+}
+
+/** Distinct integer mal-rule values worth standing up as slabs. */
+export function decoyValues(question: Question, limit: number): number[] {
+  const answer = answerOf(question)
+  const seen = new Set<number>([answer])
+  const out: number[] = []
+  for (const text of question.distractors) {
+    if (out.length >= limit) break
+    const n = Number(text)
+    if (!Number.isInteger(n) || n < 1 || n > MAX_SLAB || seen.has(n)) continue
+    seen.add(n)
+    out.push(n)
+  }
+  return out
+}
+
+/**
+ * The floors one keystone puts into the building: the slabs its answer is cut
+ * into, plus slabs carrying the wrong values a child actually produces for it.
+ *
+ * A keystone answered with one slab gets two decoys; one answered with two or
+ * three gets one. Every keystone is therefore three or four floors of building,
+ * which is what makes a height budget mean anything — and it keeps the tower
+ * from becoming a wall of near-misses at the tiers where the answer is already
+ * spread over three slabs.
+ */
+export function floorsFor(
+  question: Question,
+  index: number,
+  want: number,
+  rng: Rng,
+  nextId: () => number,
+): Floor[] {
+  const out: Floor[] = []
+  for (const value of slabsFor(answerOf(question), want, rng)) {
+    out.push({ id: nextId(), value, owner: index, kind: "solution" })
+  }
+  for (const value of decoyValues(question, out.length === 1 ? 2 : 1)) {
+    out.push({ id: nextId(), value, owner: index, kind: "decoy" })
+  }
+  return out
+}
+
+export type LevelPlan = {
+  readonly floors: Floor[]
+  /** `solutions[i]` is the ids that multiply to `questions[i]`'s answer. */
+  readonly solutions: number[][]
+}
+
+/**
+ * Build the tower for a level from the keystones it will pose.
+ *
+ * Floors are shuffled through the whole height, so the answer to the third
+ * keystone is not sitting in a neat band above the answer to the second.
+ */
+export function buildTower(
+  questions: readonly Question[],
+  level: number,
+  rng: Rng,
+  nextId: () => number,
+): LevelPlan {
+  const floors: Floor[] = []
+  const solutions: number[][] = []
+
+  questions.forEach((question, i) => {
+    const want = slabCount(question.difficulty, level, i)
+    const mine = floorsFor(question, i, want, rng, nextId)
+    solutions.push(mine.filter((f) => f.kind === "solution").map((f) => f.id))
+    floors.push(...mine)
+  })
+
+  rng.shuffle(floors)
+  return { floors, solutions }
+}
+
+/** Fresh rubble for the top of the tower. */
+export function rubble(count: number, rng: Rng, nextId: () => number): Floor[] {
+  const out: Floor[] = []
+  for (let i = 0; i < count; i++) {
+    out.push({ id: nextId(), value: rng.int(RUBBLE_LO, RUBBLE_HI), owner: -1, kind: "rubble" })
+  }
+  return out
+}
+
+/**
+ * The floors still standing for keystone `index`, and whether they still
+ * multiply to its answer.
+ *
+ * A child may punch out a floor that belonged to a *later* keystone — arming a
+ * 9 from the fourth keystone and a 8 from the first is a legitimate way to make
+ * 72 — which can leave a keystone that has not been asked yet without an
+ * answer. `Game` re-plants when that happens; this is the check.
+ */
+export function standingSolution(
+  floors: readonly Floor[],
+  index: number,
+): { ids: number[]; product: number } {
+  const ids: number[] = []
+  const values: number[] = []
+  for (const floor of floors) {
+    if (floor.owner === index && floor.kind === "solution") {
+      ids.push(floor.id)
+      values.push(floor.value)
+    }
+  }
+  return { ids, product: values.length === 0 ? 0 : productOf(values) }
+}

--- a/dynawalla/games/colossus/src/index.ts
+++ b/dynawalla/games/colossus/src/index.ts
@@ -1,0 +1,3 @@
+export type { Host, Question } from "./contract.ts"
+export { mount } from "./contract.ts"
+export { createStubHost } from "./stubHost.ts"

--- a/dynawalla/games/colossus/src/main.ts
+++ b/dynawalla/games/colossus/src/main.ts
@@ -1,0 +1,58 @@
+// Standalone dev harness. `npm run dev` → a playable game wired to the local
+// stub Host, with no runtime underneath it.
+//
+//   ?seed=123        pin the run
+//   ?reduced         force the reduced-motion branch (`?reduced=0` forces off)
+//   ?difficulty=0.8  pin the ladder instead of sweeping it
+//   ?pause           bind `p` to the host's pause/resume, so the sheet the real
+//                    host raises can be rehearsed here
+
+import { mount } from "./contract.ts"
+import { createStubHost } from "./stubHost.ts"
+
+const el = document.getElementById("app")
+if (!el) throw new Error("colossus: #app missing")
+
+const params = new URLSearchParams(location.search)
+const seed = Number(params.get("seed") ?? "") || 0x5eed1ce
+const reduced = params.has("reduced") ? params.get("reduced") !== "0" : undefined
+const pinned = params.has("difficulty") ? Number(params.get("difficulty")) : undefined
+
+let answered = 0
+let correct = 0
+const readout = document.getElementById("readout")
+
+const host = createStubHost({
+  seed,
+  ...(reduced === undefined ? {} : { reducedMotion: reduced }),
+  ...(pinned === undefined || Number.isNaN(pinned) ? {} : { difficulty: pinned }),
+  onReport(r) {
+    answered++
+    if (r.correct) correct++
+    if (readout) {
+      readout.textContent = `host.report → ${correct}/${answered} · last ${Math.round(r.ms)}ms · "${r.answered || "—"}"`
+    }
+    console.info("[colossus/host] report", r)
+  },
+  onTransition(kind, label) {
+    console.info("[colossus/host] transition", kind, label)
+  },
+})
+
+const handle = mount(el, host)
+
+// The real host raises a sheet and sends `pause` with the pack still mounted.
+// Rehearse it here rather than discovering it on a tablet.
+let held = false
+globalThis.addEventListener("keydown", (event) => {
+  if (event.key !== "p" && event.key !== "P") return
+  held = !held
+  if (held) handle.pause()
+  else handle.resume()
+  if (readout) readout.textContent = held ? "host → pause" : "host → resume"
+})
+
+// Vite HMR: tear the old instance down so audio contexts and rAF loops do not
+// accumulate across edits.
+type HotModule = { hot?: { dispose(cb: () => void): void } }
+;(import.meta as unknown as HotModule).hot?.dispose(() => handle.unmount())

--- a/dynawalla/games/colossus/src/mount.ts
+++ b/dynawalla/games/colossus/src/mount.ts
@@ -1,0 +1,224 @@
+// COLOSSUS — the shell. Canvas, clock, input, and the wiring from the rules in
+// `game/game.ts` to the building in `render/scene.ts`.
+//
+// **The pause.** The host can put a sheet — a stopping-point card, a parent
+// gate — over a pack that is still mounted and still running, and this game
+// calls `transition` at the end of every tower, so that is not hypothetical.
+// Three things have to stop dead, and each of them is a real bug if it does
+// not:
+//
+//   1. **Input.** A touch that lands while the sheet is up is not something the
+//      child did. Left unguarded it strikes the fist, reports an answer to a
+//      keystone nobody was looking at, and grows the tower for it.
+//   2. **The keystone's clock.** The reported latency is the time the child
+//      spent thinking. Time spent behind a sheet is not that.
+//   3. **The frame.** The collapse would otherwise play out to nobody and the
+//      tower would be a different shape when the sheet came off.
+//
+// `Game.pause`/`Game.resume` own 1 and 2; the rAF loop here owns 3.
+
+import { Audio } from "./audio/audio.ts"
+import type { Host } from "./contract.ts"
+import { Rng } from "./core/rng.ts"
+import { bestStreak, recordStreak } from "./game/best.ts"
+import { Game, type GameEvent } from "./game/game.ts"
+import { Scene, type Banner } from "./render/scene.ts"
+import { STRIKE_ON } from "./render/palette.ts"
+
+/**
+ * The largest step the clock may take in one frame.
+ *
+ * A backgrounded tab hands back a delta of minutes. Nothing in COLOSSUS is on a
+ * timer, so this is about the physics: a two-minute step would teleport every
+ * falling slab through the building and land it with a shake like an
+ * earthquake. Clamping means time nearly stops when frames stop.
+ */
+const MAX_STEP_MS = 120
+
+const BANNER_MS = 1500
+
+export function mountColossus(
+  el: HTMLElement,
+  host: Host,
+): { unmount(): void; pause(): void; resume(): void } {
+  const canvas = document.createElement("canvas")
+  canvas.style.cssText =
+    "position:absolute;inset:0;width:100%;height:100%;display:block;touch-action:none"
+  el.appendChild(canvas)
+
+  const reduced = host.prefersReducedMotion()
+  const seed = (Date.now() ^ 0xc0105) >>> 0
+  const scene = new Scene(canvas, reduced, seed)
+  const audio = new Audio()
+  const game = new Game(host, new Rng(seed), now())
+
+  let best = bestStreak()
+  let streak = 0
+  let running = true
+  let paused = false
+  let last = 0
+  let frame = 0
+  let banner: Banner | null = null
+
+  function now(): number {
+    return typeof performance === "object" ? performance.now() : Date.now()
+  }
+
+  const apply = (events: readonly GameEvent[]): void => {
+    for (const event of events) {
+      switch (event.kind) {
+        case "hold": {
+          audio.hold(game.holding.length)
+          host.haptic("light")
+          break
+        }
+        case "release": {
+          audio.release()
+          break
+        }
+        case "clear": {
+          scene.blowOut(event.removed, game.floors)
+          audio.collapse(event.removed.length)
+          host.haptic("success")
+          break
+        }
+        case "grow": {
+          // Not a buzz and not a scold. The cost is the stone, and the stone is
+          // what the child hears and sees arriving.
+          scene.dropIn(event.added, game.height - event.added.length)
+          audio.growth(event.added.length)
+          host.haptic("medium")
+          break
+        }
+        case "level": {
+          if (event.toppled) {
+            streak += 1
+            audio.topple()
+            host.haptic("heavy")
+            if (recordStreak(streak)) best = streak
+            banner = { title: "THE COLOSSUS KNEELS", tint: STRIKE_ON, age: 0 }
+          } else {
+            // Not a failure and not drawn as one. The tower that is still
+            // standing is the only comment the game makes, and the next one is
+            // already going up.
+            streak = 0
+          }
+          scene.reset()
+          break
+        }
+        case "stalled": {
+          console.error("[colossus] stalled: no buildable keystones")
+          break
+        }
+        default:
+          break
+      }
+    }
+  }
+
+  const tick = (t: number): void => {
+    if (!running) return
+    frame = requestAnimationFrame(tick)
+    const dt = last === 0 ? 16 : Math.min(MAX_STEP_MS, t - last)
+    last = t
+
+    // Behind a sheet the world holds its shape. The frame is still drawn — a
+    // frozen pack under a translucent host sheet is what a paused game looks
+    // like — but nothing in it moves and nothing in it is decided.
+    if (!paused) {
+      scene.advance(dt, state())
+      if (banner) {
+        banner.age += dt
+        if (banner.age > BANNER_MS) banner = null
+      }
+    }
+    scene.draw(state())
+  }
+
+  const state = () => ({
+    floors: game.floors,
+    isHeld: (id: number) => game.isHeld(id),
+    prompt: game.keystone?.prompt ?? "",
+    heldValues: game.heldValues(),
+    level: game.level,
+    progress: game.progress,
+    best,
+    paused,
+    stalled: game.stalled,
+    banner,
+  })
+
+  const press = (event: PointerEvent): void => {
+    event.preventDefault()
+    // A press that lands while the host's sheet is up is the sheet's, not ours.
+    if (paused) return
+    audio.resume()
+    const rect = canvas.getBoundingClientRect()
+    const x = event.clientX - rect.left
+    const y = event.clientY - rect.top
+
+    if (scene.hitsStrike(x, y)) {
+      apply(game.strike(now()))
+      return
+    }
+    const id = scene.floorAt(x, y, game.floors)
+    if (id !== null) apply(game.toggle(id))
+  }
+
+  const key = (event: KeyboardEvent): void => {
+    if (event.repeat || paused) return
+    if (event.key === " " || event.key === "Enter") {
+      event.preventDefault()
+      audio.resume()
+      apply(game.strike(now()))
+      return
+    }
+    if (event.key === "Escape") game.releaseAll()
+  }
+
+  const resize = (): void => {
+    scene.resize()
+  }
+
+  canvas.addEventListener("pointerdown", press)
+  globalThis.addEventListener("keydown", key)
+  globalThis.addEventListener("resize", resize)
+
+  const observer =
+    typeof ResizeObserver === "function"
+      ? new ResizeObserver(() => {
+          scene.resize()
+        })
+      : null
+  observer?.observe(el)
+
+  apply(game.begin(now()))
+  frame = requestAnimationFrame(tick)
+
+  return {
+    pause(): void {
+      if (paused) return
+      paused = true
+      game.pause(now())
+    },
+    resume(): void {
+      if (!paused) return
+      paused = false
+      game.resume(now())
+      // The next frame computes its delta from `last`, which was set before the
+      // sheet went up. Forget it, or the first frame back is a whole sheet's
+      // worth of gravity in one step.
+      last = 0
+    },
+    unmount(): void {
+      running = false
+      cancelAnimationFrame(frame)
+      canvas.removeEventListener("pointerdown", press)
+      globalThis.removeEventListener("keydown", key)
+      globalThis.removeEventListener("resize", resize)
+      observer?.disconnect()
+      audio.dispose()
+      canvas.remove()
+    },
+  }
+}

--- a/dynawalla/games/colossus/src/pack.ts
+++ b/dynawalla/games/colossus/src/pack.ts
@@ -1,0 +1,65 @@
+// COLOSSUS, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous surface `Host` in
+// `contract.ts` already describes — so the tower, the fist, the collapse and
+// the growth penalty are untouched.
+//
+// What crosses the boundary is the keystone. A keystone carries a problem the
+// curriculum drew; the slabs standing in the tower carry numbers, and the value
+// the child asserts is the product of the slabs they were holding when they
+// struck. That is a value the host can judge exactly — and because two of the
+// slabs planted for every keystone carry its mal-rule outputs, a wrong strike
+// usually reports the misconception itself rather than noise.
+//
+// `items.reveal` is declared and is not optional. Without the canonical value
+// there is no tower to build: the answer is what the slabs are cut from. A pack
+// without the grant would mount, warm, and stand up an empty building.
+//
+// Splitting 72 into 8 × 9 is the game's own mathematics — a thing the child
+// performs with a gesture rather than a question anybody asked — so nothing
+// about the factoring is reported.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import { mount } from "./contract.ts"
+import type { Host } from "./contract.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("colossus: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "add-sub" })
+  // Stocked before the first frame. A tower is built from six keystones at
+  // once, so an empty pool on launch is not a dull moment — it is a building
+  // with nothing in it, in front of the child, exactly once.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context come down before the frame does rather than a frame or two after.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+
+  // A transition can put a sheet over the frame, and the SDK documents that the
+  // pack keeps running underneath it. COLOSSUS calls `transition` at the end of
+  // every tower, so this is routine rather than hypothetical — and unguarded it
+  // is the worst bug this game could have: a touch landing behind the sheet
+  // strikes the fist, reports an answer to a keystone the child never saw, and
+  // grows the tower they have to bring down.
+  //
+  // These handlers are the whole subscription. `handle.pause()` is inert until
+  // something calls it.
+  mounted.client.on("pause", () => {
+    handle.pause()
+  })
+  mounted.client.on("resume", () => {
+    handle.resume()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[colossus] could not start", error)
+  renderNoHost(root, "COLOSSUS")
+})

--- a/dynawalla/games/colossus/src/render/dust.ts
+++ b/dynawalla/games/colossus/src/render/dust.ts
@@ -1,0 +1,124 @@
+// Dust. A slab landing on a slab throws a low sheet of it sideways; a slab
+// blowing out throws it everywhere.
+//
+// Reduced motion does not get "less dust". It gets a different thing: one soft
+// ring that expands once and fades, which reads as an impact without anything
+// travelling across the field of view.
+
+import { unit } from "../core/feel.ts"
+import type { Rng } from "../core/rng.ts"
+import { DUST } from "./palette.ts"
+
+type Mote = {
+  x: number
+  y: number
+  vx: number
+  vy: number
+  r: number
+  life: number
+  age: number
+}
+
+type Ring = { x: number; y: number; r: number; life: number; age: number }
+
+const MAX_MOTES = 260
+
+export class Dust {
+  private motes: Mote[] = []
+  private rings: Ring[] = []
+  private readonly rng: Rng
+  private readonly reduced: boolean
+
+  constructor(rng: Rng, reduced: boolean) {
+    this.rng = rng
+    this.reduced = reduced
+  }
+
+  /** A slab set down hard: a low sheet that runs out sideways along the stone. */
+  impact(x: number, y: number, width: number, force: number): void {
+    if (this.reduced) {
+      this.rings.push({ x, y, r: width * 0.3, life: 420, age: 0 })
+      return
+    }
+    const n = Math.round(6 + force * 16)
+    for (let i = 0; i < n; i++) {
+      const side = this.rng.chance(0.5) ? -1 : 1
+      this.push({
+        x: x + this.rng.range(-width * 0.5, width * 0.5),
+        y: y + this.rng.range(-3, 3),
+        vx: side * this.rng.range(0.04, 0.34) * (0.5 + force),
+        vy: -this.rng.range(0.02, 0.16) * (0.4 + force),
+        r: this.rng.range(2, 7.5),
+        life: this.rng.range(520, 1250),
+        age: 0,
+      })
+    }
+  }
+
+  /** A slab blown out of the building. */
+  burst(x: number, y: number, width: number): void {
+    if (this.reduced) {
+      this.rings.push({ x, y, r: width * 0.45, life: 520, age: 0 })
+      return
+    }
+    for (let i = 0; i < 26; i++) {
+      const a = this.rng.range(0, Math.PI * 2)
+      const s = this.rng.range(0.06, 0.52)
+      this.push({
+        x: x + this.rng.range(-width * 0.4, width * 0.4),
+        y: y + this.rng.range(-10, 10),
+        vx: Math.cos(a) * s,
+        vy: Math.sin(a) * s - 0.08,
+        r: this.rng.range(2.5, 10),
+        life: this.rng.range(680, 1600),
+        age: 0,
+      })
+    }
+  }
+
+  private push(m: Mote): void {
+    if (this.motes.length >= MAX_MOTES) this.motes.shift()
+    this.motes.push(m)
+  }
+
+  advance(dt: number): void {
+    for (const m of this.motes) {
+      m.age += dt
+      m.x += m.vx * dt
+      m.y += m.vy * dt
+      m.vy += 0.00022 * dt // dust is light; it hangs, then sinks
+      m.vx *= 0.995
+      m.r += 0.006 * dt
+    }
+    this.motes = this.motes.filter((m) => m.age < m.life)
+    for (const r of this.rings) r.age += dt
+    this.rings = this.rings.filter((r) => r.age < r.life)
+  }
+
+  draw(ctx: CanvasRenderingContext2D): void {
+    ctx.save()
+    for (const m of this.motes) {
+      const t = unit(m.age / m.life)
+      ctx.globalAlpha = (1 - t) * (1 - t) * 0.5
+      ctx.fillStyle = DUST
+      ctx.beginPath()
+      ctx.arc(m.x, m.y, m.r, 0, Math.PI * 2)
+      ctx.fill()
+    }
+    for (const r of this.rings) {
+      const t = unit(r.age / r.life)
+      ctx.globalAlpha = (1 - t) * 0.34
+      ctx.strokeStyle = DUST
+      ctx.lineWidth = 10 * (1 - t) + 1
+      ctx.beginPath()
+      ctx.arc(r.x, r.y, r.r * (0.5 + t * 1.5), 0, Math.PI * 2)
+      ctx.stroke()
+    }
+    ctx.restore()
+  }
+
+  clear(): void {
+    this.motes = []
+    this.rings = []
+  }
+}

--- a/dynawalla/games/colossus/src/render/palette.ts
+++ b/dynawalla/games/colossus/src/render/palette.ts
@@ -1,0 +1,48 @@
+// The bazaar at dusk, from the foot of something enormous.
+//
+// **One rule the palette must never break: a slab's colour may not say what it
+// is for.** A solution slab, a decoy carrying a mal-rule value and a lump of
+// rubble left by a wrong strike are cut from the same stone and lit the same
+// way. The moment rubble looks like rubble, the growth penalty stops costing
+// anything, and the growth penalty is the whole game.
+//
+// The only colour that means something is the one on a slab the child is
+// holding, which is information they put there themselves.
+
+export const SKY_HIGH = "#150c1e"
+export const SKY_MID = "#3d1433"
+export const SKY_LOW = "#8f3a2c"
+export const EMBER = "#e0703a"
+
+export const HAZE = "rgba(224, 112, 58, 0.16)"
+export const GROUND = "#0d0812"
+export const GROUND_EDGE = "#2a1526"
+
+/** Limestone. Every slab, whatever it is for. */
+export const SLAB_FACE = "#d9c49c"
+export const SLAB_TOP = "#f1e4c6"
+export const SLAB_SIDE = "#9c8058"
+export const SLAB_TEXT = "#2c1e16"
+export const SLAB_CRACK = "rgba(60, 40, 26, 0.22)"
+
+/** A slab in the fist. The child put this colour there. */
+export const HELD_FACE = "#ffd166"
+export const HELD_TOP = "#fff0bd"
+export const HELD_SIDE = "#c98a1f"
+export const HELD_GLOW = "rgba(255, 178, 60, 0.55)"
+
+export const KEYSTONE_FACE = "#241426"
+export const KEYSTONE_EDGE = "#6c3f5c"
+export const KEYSTONE_INK = "#ffe9c4"
+
+export const GIANT = "#150d1c"
+export const GIANT_RIM = "rgba(255, 150, 84, 0.75)"
+
+export const DUST = "rgba(226, 205, 168, 0.85)"
+
+export const HUD_INK = "#f4e7cf"
+export const HUD_DIM = "rgba(244, 231, 207, 0.5)"
+export const HUD_PLATE = "rgba(18, 10, 20, 0.82)"
+export const HUD_EDGE = "rgba(255, 200, 130, 0.28)"
+export const STRIKE_ON = "#ff8a4c"
+export const STRIKE_OFF = "rgba(120, 92, 76, 0.55)"

--- a/dynawalla/games/colossus/src/render/scene.ts
+++ b/dynawalla/games/colossus/src/render/scene.ts
@@ -1,0 +1,732 @@
+// The building, drawn.
+//
+// Nothing in here decides anything. The rules live in `game/game.ts` and this
+// module is told what is standing; its whole job is to make a tower that is one
+// floor taller *feel* one floor taller.
+//
+// Three things carry that:
+//
+//   1. **The camera pulls back with volume.** One scale factor fits tower plus
+//      keystone into the frame, and everything — slabs, keystone, the colossus
+//      itself — is drawn through it. A tower that grew makes the giant smaller.
+//      Nobody has to be told the tower got bigger; they are further away.
+//   2. **Floors fall.** A slab's height above the ground is simulated, not
+//      tweened: blow a hole in the middle and everything above accelerates into
+//      it and lands, with dust and a shake proportional to how far it fell.
+//   3. **Rubble is indistinguishable from stone.** See `palette.ts`.
+//
+// Reduced motion takes a different branch, not a smaller one: the camera is
+// still fitted, slabs still change height, and the impact still reports itself
+// — but positions are set rather than travelled to, and the dust is a ring in
+// place of a cloud. See `dust.ts`.
+
+import { approach, easeOutCubic, unit } from "../core/feel.ts"
+import { Rng } from "../core/rng.ts"
+import type { Floor } from "../game/tower.ts"
+import { Dust } from "./dust.ts"
+import * as C from "./palette.ts"
+
+/** World units. One floor of the colossus. */
+const FLOOR_H = 56
+const FLOOR_W = 300
+const KEY_H = 92
+const KEY_GAP = 22
+const GIANT_H = 306
+
+/** Gravity, world units per millisecond squared. Stone, not feathers. */
+const G = 0.0042
+const MAX_FALL = 2.4
+
+export type Banner = { title: string; tint: string; age: number }
+
+export type SceneState = {
+  readonly floors: readonly Floor[]
+  readonly isHeld: (id: number) => boolean
+  readonly prompt: string
+  readonly heldValues: readonly number[]
+  readonly level: number
+  readonly progress: { done: number; total: number }
+  readonly best: number
+  readonly paused: boolean
+  readonly stalled: boolean
+  readonly banner: Banner | null
+}
+
+type Slab = {
+  /** Height of the slab's underside above the ground, in world units. */
+  h: number
+  v: number
+  landed: boolean
+}
+
+type Debris = {
+  value: number
+  x: number
+  y: number
+  vx: number
+  vy: number
+  spin: number
+  angle: number
+  age: number
+  life: number
+}
+
+export type Metrics = {
+  /** Screen-space y of the ground line. */
+  groundY: number
+  cx: number
+  scale: number
+  /** The strike pill, in screen space. */
+  strike: { x: number; y: number; w: number; h: number }
+}
+
+export class Scene {
+  private readonly canvas: HTMLCanvasElement
+  private readonly ctx: CanvasRenderingContext2D
+  private readonly dust: Dust
+  private readonly rng: Rng
+  private readonly reduced: boolean
+
+  private w = 0
+  private h = 0
+  private dpr = 1
+
+  private slabs = new Map<number, Slab>()
+  private debris: Debris[] = []
+
+  private scale = 1
+  private shake = 0
+  private time = 0
+  /** 1 the instant the fist lands, decaying to 0. Drives the arm, nothing else. */
+  private punch = 0
+
+  private metrics: Metrics = {
+    groundY: 0,
+    cx: 0,
+    scale: 1,
+    strike: { x: 0, y: 0, w: 0, h: 0 },
+  }
+
+  constructor(canvas: HTMLCanvasElement, reduced: boolean, seed: number) {
+    this.canvas = canvas
+    const ctx = canvas.getContext("2d", { alpha: false })
+    if (!ctx) throw new Error("colossus: no 2d context")
+    this.ctx = ctx
+    this.reduced = reduced
+    this.rng = new Rng(seed ^ 0xc0105505)
+    this.dust = new Dust(this.rng.fork(7), reduced)
+    this.resize()
+  }
+
+  resize(): void {
+    const rect = this.canvas.getBoundingClientRect()
+    this.dpr = Math.min(3, globalThis.devicePixelRatio || 1)
+    this.w = Math.max(1, Math.round(rect.width))
+    this.h = Math.max(1, Math.round(rect.height))
+    this.canvas.width = Math.round(this.w * this.dpr)
+    this.canvas.height = Math.round(this.h * this.dpr)
+  }
+
+  get view(): Metrics {
+    return this.metrics
+  }
+
+  /** Slabs blown out of the building fly; the hole they leave is real. */
+  blowOut(removed: readonly Floor[], order: readonly Floor[]): void {
+    const { groundY, cx, scale } = this.metrics
+    for (const floor of removed) {
+      const slab = this.slabs.get(floor.id)
+      const h = slab ? slab.h : indexOfIn(order, floor.id) * FLOOR_H
+      const y = groundY - (h + FLOOR_H * 0.5) * scale
+      this.dust.burst(cx, y, FLOOR_W * scale)
+      if (!this.reduced) {
+        this.debris.push({
+          value: floor.value,
+          x: cx + this.rng.range(-30, 30),
+          y,
+          vx: this.rng.range(-0.62, 0.62),
+          vy: -this.rng.range(0.18, 0.72),
+          spin: this.rng.range(-0.004, 0.004),
+          angle: 0,
+          age: 0,
+          life: 1500,
+        })
+      }
+      this.slabs.delete(floor.id)
+    }
+    this.shake = Math.min(1, this.shake + 0.5 + removed.length * 0.1)
+    this.punch = 1
+  }
+
+  /** New stone comes in from above the frame and lands on the top. */
+  dropIn(added: readonly Floor[], baseIndex: number): void {
+    added.forEach((floor, i) => {
+      const target = (baseIndex + i) * FLOOR_H
+      this.slabs.set(floor.id, {
+        h: this.reduced ? target : target + 320 + i * 120,
+        v: 0,
+        landed: this.reduced,
+      })
+    })
+    this.shake = Math.min(1, this.shake + 0.28)
+    this.punch = 1
+  }
+
+  advance(dt: number, state: SceneState): void {
+    this.time += dt
+    const n = state.floors.length
+
+    // The camera. Fit tower plus keystone plus a little sky.
+    const hudTop = 74
+    const hudBottom = this.strikeBarHeight() + 26
+    const usableH = Math.max(120, this.h - hudTop - hudBottom)
+    const worldH = n * FLOOR_H + KEY_GAP + KEY_H + FLOOR_H * 0.6
+    const byHeight = usableH / Math.max(worldH, FLOOR_H * 6)
+    // A narrow frame gives the building less of the width, not more: the
+    // colossus has to have somewhere to stand, and a phone in portrait is the
+    // only case where the two are fighting over the same pixels.
+    const byWidth = (this.w * (this.w < 640 ? 0.68 : 0.82)) / (FLOOR_W * 1.18)
+    const want = Math.min(1.05, byHeight, byWidth)
+    this.scale = this.reduced ? want : approach(this.scale, want, 0.06, dt)
+
+    const groundY = this.h - hudBottom
+    this.metrics = {
+      groundY,
+      cx: this.w * 0.5,
+      scale: this.scale,
+      strike: this.strikeRect(),
+    }
+
+    // Slab physics. Anything above its resting height is falling.
+    state.floors.forEach((floor, i) => {
+      const target = i * FLOOR_H
+      let slab = this.slabs.get(floor.id)
+      if (!slab) {
+        slab = { h: this.reduced ? target : target + 26, v: 0, landed: this.reduced }
+        this.slabs.set(floor.id, slab)
+      }
+      if (this.reduced) {
+        slab.h = target
+        slab.landed = true
+        return
+      }
+      if (slab.h > target) {
+        slab.v = Math.min(MAX_FALL, slab.v + G * dt)
+        slab.h -= slab.v * dt
+        if (slab.h <= target) {
+          const force = Math.min(1, slab.v / 1.4)
+          slab.h = target
+          slab.v = 0
+          if (!slab.landed || force > 0.18) {
+            this.dust.impact(
+              this.metrics.cx,
+              groundY - target * this.scale,
+              FLOOR_W * this.scale,
+              force,
+            )
+            this.shake = Math.min(1, this.shake + force * 0.42)
+          }
+          slab.landed = true
+        }
+      } else if (slab.h < target) {
+        // Stone slotted in underneath: it rises to meet the building.
+        slab.h = Math.min(target, slab.h + 0.9 * dt)
+      }
+    })
+
+    // Forget slabs that are no longer standing.
+    const live = new Set(state.floors.map((f) => f.id))
+    for (const id of [...this.slabs.keys()]) if (!live.has(id)) this.slabs.delete(id)
+
+    for (const d of this.debris) {
+      d.age += dt
+      d.x += d.vx * dt
+      d.y += d.vy * dt
+      d.vy += 0.0022 * dt
+      d.angle += d.spin * dt
+    }
+    this.debris = this.debris.filter((d) => d.age < d.life && d.y < this.h + 200)
+
+    this.dust.advance(dt)
+    this.shake = Math.max(0, this.shake - dt / 420)
+    this.punch = Math.max(0, this.punch - dt / 320)
+  }
+
+  draw(state: SceneState): void {
+    const ctx = this.ctx
+    ctx.save()
+    ctx.scale(this.dpr, this.dpr)
+
+    this.sky()
+    this.skyline()
+
+    const shake = this.reduced ? 0 : this.shake * this.shake
+    ctx.save()
+    if (shake > 0) {
+      ctx.translate(
+        Math.sin(this.time * 0.09) * shake * 9,
+        Math.cos(this.time * 0.13) * shake * 7,
+      )
+    }
+
+    this.giant()
+    this.ground()
+    this.tower(state)
+    this.keystone(state)
+    for (const d of this.debris) this.debrisSlab(d)
+    this.dust.draw(ctx)
+    ctx.restore()
+
+    this.hud(state)
+    if (state.banner) this.banner(state.banner)
+    if (state.stalled) this.stalled()
+    ctx.restore()
+  }
+
+  // ── the world ─────────────────────────────────────────────────────────────
+
+  private sky(): void {
+    const ctx = this.ctx
+    const g = ctx.createLinearGradient(0, 0, 0, this.h)
+    g.addColorStop(0, C.SKY_HIGH)
+    g.addColorStop(0.52, C.SKY_MID)
+    g.addColorStop(1, C.SKY_LOW)
+    ctx.fillStyle = g
+    ctx.fillRect(0, 0, this.w, this.h)
+
+    // The sun going down behind the bazaar, low and enormous.
+    const gy = this.metrics.groundY
+    const sun = ctx.createRadialGradient(this.w * 0.5, gy, 0, this.w * 0.5, gy, this.w * 0.72)
+    sun.addColorStop(0, "rgba(255, 176, 96, 0.42)")
+    sun.addColorStop(0.45, "rgba(224, 112, 58, 0.16)")
+    sun.addColorStop(1, "rgba(224, 112, 58, 0)")
+    ctx.fillStyle = sun
+    ctx.fillRect(0, 0, this.w, this.h)
+  }
+
+  /** Minarets, far off, so the tower has something to be taller than. */
+  private skyline(): void {
+    const ctx = this.ctx
+    const gy = this.metrics.groundY
+    ctx.save()
+    ctx.fillStyle = "rgba(20, 12, 26, 0.66)"
+    const rng = new Rng(0x51571e)
+    let x = -20
+    while (x < this.w + 40) {
+      const w = rng.range(26, 62)
+      const h = rng.range(24, 96)
+      ctx.fillRect(x, gy - h, w, h + 4)
+      if (rng.chance(0.34)) {
+        // A minaret: a needle with a bulb.
+        const mx = x + w * 0.5
+        ctx.fillRect(mx - 4, gy - h - 46, 8, 46)
+        ctx.beginPath()
+        ctx.arc(mx, gy - h - 50, 9, 0, Math.PI * 2)
+        ctx.fill()
+      }
+      x += w + rng.range(6, 26)
+    }
+    ctx.restore()
+  }
+
+  private ground(): void {
+    const ctx = this.ctx
+    const gy = this.metrics.groundY
+    ctx.fillStyle = C.GROUND
+    ctx.fillRect(0, gy, this.w, this.h - gy)
+    ctx.fillStyle = C.GROUND_EDGE
+    ctx.fillRect(0, gy - 2, this.w, 3)
+    ctx.fillStyle = C.HAZE
+    ctx.fillRect(0, gy - 26, this.w, 26)
+  }
+
+  /**
+   * The colossus. Drawn through the same camera as the tower, which is the
+   * point: when the building grows, the giant is further away and smaller, and
+   * a child reads "this got bigger than me" without a word of copy.
+   *
+   * A silhouette with one rim light off the sunset, and the rim is the same
+   * silhouette drawn once more a few pixels toward the sun — so it can never
+   * drift off the shape it belongs to, whatever the arm is doing.
+   *
+   * No face. A face would make it a character with an opinion about how the
+   * child is doing, and the only thing here entitled to an opinion is the
+   * building.
+   */
+  private giant(): void {
+    const ctx = this.ctx
+    const { groundY, cx, scale } = this.metrics
+    const u = GIANT_H * scale
+    // Beside the building where there is room, and behind it where there is
+    // not. On a phone the tower takes the width and the fist goes behind the
+    // stone — which is fine: the fist is a flourish, and a colossus whose helm
+    // and shoulder rise past the edge of the frame reads as *more* enormous,
+    // not less.
+    const x = Math.max(u * 0.24, cx - FLOOR_W * 0.5 * scale - u * 0.8)
+    const breathe = this.reduced ? 0 : Math.sin(this.time * 0.0016) * u * 0.008
+    // The arm winds back and comes through on a strike. `punch` is spent in
+    // `advance`, so a still frame is a giant standing still.
+    const reach = u * (0.04 + easeOutCubic(this.punch) * 0.28)
+    const rim = Math.max(1.2, u * 0.011)
+
+    ctx.save()
+    ctx.translate(x, groundY + breathe)
+    ctx.lineJoin = "round"
+    ctx.lineCap = "round"
+
+    ctx.save()
+    ctx.translate(rim, -rim * 0.5)
+    this.giantBody(u, reach, C.GIANT_RIM)
+    ctx.restore()
+    this.giantBody(u, reach, C.GIANT)
+
+    ctx.restore()
+  }
+
+  /** Every piece of the colossus, in one colour. Called twice; see `giant`. */
+  private giantBody(u: number, reach: number, ink: string): void {
+    const ctx = this.ctx
+    ctx.fillStyle = ink
+    ctx.strokeStyle = ink
+
+    // Legs: heavy, planted, slightly apart.
+    ctx.lineWidth = u * 0.16
+    ctx.beginPath()
+    ctx.moveTo(-u * 0.14, -u * 0.08)
+    ctx.lineTo(-u * 0.09, -u * 0.34)
+    ctx.moveTo(u * 0.12, -u * 0.08)
+    ctx.lineTo(u * 0.07, -u * 0.34)
+    ctx.stroke()
+
+    // Torso: narrow at the hips, enormous across the shoulders.
+    ctx.beginPath()
+    ctx.moveTo(-u * 0.16, -u * 0.28)
+    ctx.lineTo(u * 0.16, -u * 0.28)
+    ctx.lineTo(u * 0.27, -u * 0.62)
+    ctx.lineTo(u * 0.24, -u * 0.71)
+    ctx.lineTo(-u * 0.24, -u * 0.71)
+    ctx.lineTo(-u * 0.27, -u * 0.62)
+    ctx.closePath()
+    ctx.fill()
+
+    // A squared helm with a short spire, so the silhouette belongs to the same
+    // city as the minarets behind it. The spire sinks into the helm so the two
+    // are one shape rather than two.
+    ctx.beginPath()
+    ctx.moveTo(-u * 0.035, -u * 0.86)
+    ctx.lineTo(0, -u * 1.04)
+    ctx.lineTo(u * 0.035, -u * 0.86)
+    ctx.closePath()
+    ctx.fill()
+    roundRect(ctx, -u * 0.1, -u * 0.9, u * 0.2, u * 0.2, u * 0.05)
+    ctx.fill()
+
+    // The far arm hangs. The near arm is cocked, and the fist is the thing that
+    // meets the building.
+    ctx.lineWidth = u * 0.1
+    ctx.beginPath()
+    ctx.moveTo(-u * 0.22, -u * 0.66)
+    ctx.lineTo(-u * 0.3, -u * 0.34)
+    ctx.stroke()
+
+    const fistX = u * 0.5 + reach
+    const fistY = -u * 0.58
+    ctx.lineWidth = u * 0.12
+    ctx.beginPath()
+    ctx.moveTo(u * 0.2, -u * 0.66)
+    ctx.lineTo(u * 0.4 + reach * 0.5, -u * 0.7)
+    ctx.lineTo(fistX, fistY)
+    ctx.stroke()
+    roundRect(ctx, fistX - u * 0.1, fistY - u * 0.1, u * 0.2, u * 0.2, u * 0.06)
+    ctx.fill()
+  }
+
+  private tower(state: SceneState): void {
+    const { groundY, cx, scale } = this.metrics
+    const w = FLOOR_W * scale
+    const fh = FLOOR_H * scale
+
+    state.floors.forEach((floor, i) => {
+      const slab = this.slabs.get(floor.id)
+      const h = slab ? slab.h : i * FLOOR_H
+      const y = groundY - (h + FLOOR_H) * scale
+      this.slab(cx - w / 2, y, w, fh, floor.value, state.isHeld(floor.id))
+    })
+  }
+
+  private slab(x: number, y: number, w: number, h: number, value: number, held: boolean): void {
+    const ctx = this.ctx
+    const inset = Math.max(1, h * 0.06)
+    const face = held ? C.HELD_FACE : C.SLAB_FACE
+    const top = held ? C.HELD_TOP : C.SLAB_TOP
+    const side = held ? C.HELD_SIDE : C.SLAB_SIDE
+
+    if (held) {
+      ctx.save()
+      ctx.shadowColor = C.HELD_GLOW
+      ctx.shadowBlur = Math.max(10, h * 0.55)
+    }
+
+    ctx.fillStyle = side
+    ctx.fillRect(x, y, w, h - inset)
+    ctx.fillStyle = face
+    ctx.fillRect(x + inset, y + inset, w - inset * 2, h - inset * 3)
+    ctx.fillStyle = top
+    ctx.fillRect(x + inset, y + inset, w - inset * 2, Math.max(1, inset * 0.9))
+
+    if (held) ctx.restore()
+
+    // Cut lines, so a slab reads as quarried stone rather than a rectangle.
+    ctx.strokeStyle = C.SLAB_CRACK
+    ctx.lineWidth = 1
+    ctx.beginPath()
+    ctx.moveTo(x + w * 0.22, y + h * 0.18)
+    ctx.lineTo(x + w * 0.22, y + h * 0.82)
+    ctx.moveTo(x + w * 0.78, y + h * 0.18)
+    ctx.lineTo(x + w * 0.78, y + h * 0.82)
+    ctx.stroke()
+
+    const label = String(value)
+    const size = fit(label, w * 0.46, h * 0.62)
+    ctx.font = `800 ${size}px ui-rounded, "SF Pro Rounded", system-ui, sans-serif`
+    ctx.textAlign = "center"
+    ctx.textBaseline = "middle"
+    ctx.fillStyle = C.SLAB_TEXT
+    ctx.fillText(label, x + w / 2, y + h * 0.47)
+  }
+
+  private debrisSlab(d: Debris): void {
+    const ctx = this.ctx
+    const t = unit(d.age / d.life)
+    const s = this.metrics.scale
+    ctx.save()
+    ctx.globalAlpha = 1 - t * t
+    ctx.translate(d.x, d.y)
+    ctx.rotate(d.angle)
+    const w = FLOOR_W * 0.34 * s
+    const h = FLOOR_H * 0.7 * s
+    ctx.fillStyle = C.SLAB_SIDE
+    ctx.fillRect(-w / 2, -h / 2, w, h)
+    ctx.fillStyle = C.SLAB_FACE
+    ctx.fillRect(-w / 2 + 2, -h / 2 + 2, w - 4, h - 5)
+    ctx.fillStyle = C.SLAB_TEXT
+    const size = fit(String(d.value), w * 0.7, h * 0.6)
+    ctx.font = `800 ${size}px ui-rounded, "SF Pro Rounded", system-ui, sans-serif`
+    ctx.textAlign = "center"
+    ctx.textBaseline = "middle"
+    ctx.fillText(String(d.value), 0, 0)
+    ctx.restore()
+  }
+
+  /** The keystone: the sum the whole building answers to, hung over the top. */
+  private keystone(state: SceneState): void {
+    const ctx = this.ctx
+    const { groundY, cx, scale } = this.metrics
+    const n = state.floors.length
+    const w = FLOOR_W * 1.16 * scale
+    const h = KEY_H * scale
+    const y = groundY - (n * FLOOR_H + KEY_GAP + KEY_H) * scale
+    const x = cx - w / 2
+    const float = this.reduced ? 0 : Math.sin(this.time * 0.0018) * h * 0.05
+
+    ctx.save()
+    ctx.translate(0, float)
+
+    // The chain of light that holds it over the building.
+    const grad = ctx.createLinearGradient(cx, y + h, cx, groundY - n * FLOOR_H * scale)
+    grad.addColorStop(0, "rgba(255, 200, 130, 0.5)")
+    grad.addColorStop(1, "rgba(255, 200, 130, 0)")
+    ctx.strokeStyle = grad
+    ctx.lineWidth = Math.max(1.5, 4 * scale)
+    ctx.beginPath()
+    ctx.moveTo(cx, y + h)
+    ctx.lineTo(cx, groundY - n * FLOOR_H * scale)
+    ctx.stroke()
+
+    ctx.fillStyle = C.KEYSTONE_FACE
+    roundRect(ctx, x, y, w, h, Math.min(14, h * 0.18))
+    ctx.fill()
+    ctx.strokeStyle = C.KEYSTONE_EDGE
+    ctx.lineWidth = Math.max(1.5, 2.5 * scale)
+    ctx.stroke()
+
+    const label = state.prompt || "—"
+    const size = fit(label, w * 0.86, h * 0.5)
+    ctx.font = `700 ${size}px ui-rounded, "SF Pro Rounded", system-ui, sans-serif`
+    ctx.textAlign = "center"
+    ctx.textBaseline = "middle"
+    ctx.fillStyle = C.KEYSTONE_INK
+    ctx.fillText(label, cx, y + h * 0.5)
+    ctx.restore()
+  }
+
+  // ── the chrome ────────────────────────────────────────────────────────────
+
+  private strikeBarHeight(): number {
+    return Math.max(96, Math.min(132, this.h * 0.14))
+  }
+
+  private strikeRect(): { x: number; y: number; w: number; h: number } {
+    const barH = this.strikeBarHeight()
+    const h = Math.max(58, Math.min(78, barH * 0.62))
+    const w = Math.min(this.w - 40, 520)
+    return { x: (this.w - w) / 2, y: this.h - barH + (barH - h) / 2, w, h }
+  }
+
+  private hud(state: SceneState): void {
+    const ctx = this.ctx
+
+    // Top left: which tower this is. Top right: how many keystones are left in
+    // it, as stones. No sentences: the pips are the progress.
+    ctx.font = `700 13px ui-rounded, "SF Pro Rounded", system-ui, sans-serif`
+    ctx.textAlign = "left"
+    ctx.textBaseline = "middle"
+    ctx.fillStyle = C.HUD_DIM
+    ctx.fillText(`TOWER ${state.level}`, 18, 30)
+
+    const total = Math.max(1, state.progress.total)
+    const pipW = 10
+    const gap = 6
+    const right = this.w - 18
+    for (let i = 0; i < total; i++) {
+      const x = right - (total - i) * (pipW + gap) + gap
+      ctx.fillStyle = i < state.progress.done ? C.HUD_DIM : C.HUD_INK
+      ctx.fillRect(x, 25, pipW, 10)
+    }
+
+    if (state.best > 0) {
+      ctx.textAlign = "left"
+      ctx.fillStyle = C.HUD_DIM
+      ctx.fillText(`BEST ${state.best}`, 18, 50)
+    }
+
+    // The fist. It reads back the expression the child is holding — and never
+    // its total. Multiplying it out is their half of the bargain.
+    const r = this.metrics.strike
+    const armed = state.heldValues.length > 0
+    ctx.save()
+    ctx.fillStyle = C.HUD_PLATE
+    roundRect(ctx, r.x, r.y, r.w, r.h, r.h * 0.32)
+    ctx.fill()
+    ctx.strokeStyle = armed ? C.STRIKE_ON : C.HUD_EDGE
+    ctx.lineWidth = armed ? 2.5 : 1.2
+    ctx.stroke()
+
+    if (armed) {
+      const expr = state.heldValues.join(" × ")
+      const size = fit(expr, r.w * 0.52, r.h * 0.52)
+      ctx.font = `800 ${size}px ui-rounded, "SF Pro Rounded", system-ui, sans-serif`
+      ctx.textAlign = "left"
+      ctx.textBaseline = "middle"
+      ctx.fillStyle = C.HUD_INK
+      ctx.fillText(expr, r.x + r.h * 0.36, r.y + r.h * 0.5)
+
+      ctx.font = `800 ${Math.round(r.h * 0.3)}px ui-rounded, "SF Pro Rounded", system-ui, sans-serif`
+      ctx.textAlign = "right"
+      ctx.fillStyle = C.STRIKE_ON
+      ctx.fillText("STRIKE", r.x + r.w - r.h * 0.36, r.y + r.h * 0.5)
+    } else {
+      ctx.font = `700 ${Math.round(r.h * 0.26)}px ui-rounded, "SF Pro Rounded", system-ui, sans-serif`
+      ctx.textAlign = "center"
+      ctx.textBaseline = "middle"
+      ctx.fillStyle = C.STRIKE_OFF
+      ctx.fillText("STRIKE", r.x + r.w / 2, r.y + r.h * 0.5)
+    }
+    ctx.restore()
+
+    if (state.paused) {
+      ctx.fillStyle = "rgba(10, 6, 12, 0.55)"
+      ctx.fillRect(0, 0, this.w, this.h)
+    }
+  }
+
+  private banner(b: Banner): void {
+    const ctx = this.ctx
+    const t = unit(b.age / 1500)
+    const rise = easeOutCubic(unit(b.age / 420))
+    ctx.save()
+    ctx.globalAlpha = t > 0.75 ? (1 - t) * 4 : 1
+    ctx.textAlign = "center"
+    ctx.textBaseline = "middle"
+    const size = fit(b.title, this.w * 0.82, 56)
+    ctx.font = `900 ${size}px ui-rounded, "SF Pro Rounded", system-ui, sans-serif`
+    ctx.fillStyle = b.tint
+    ctx.shadowColor = "rgba(0,0,0,0.6)"
+    ctx.shadowBlur = 18
+    const y = this.h * 0.34 + (1 - rise) * (this.reduced ? 0 : 28)
+    ctx.fillText(b.title, this.w / 2, y)
+    ctx.restore()
+  }
+
+  private stalled(): void {
+    const ctx = this.ctx
+    ctx.fillStyle = "rgba(10, 6, 12, 0.86)"
+    ctx.fillRect(0, 0, this.w, this.h)
+    ctx.textAlign = "center"
+    ctx.textBaseline = "middle"
+    ctx.fillStyle = C.HUD_INK
+    ctx.font = `600 17px ui-rounded, "SF Pro Rounded", system-ui, sans-serif`
+    ctx.fillText("Nothing to build with.", this.w / 2, this.h / 2)
+  }
+
+  // ── hit testing ───────────────────────────────────────────────────────────
+
+  /** The floor under a screen point, tested against where it is *drawn*. */
+  floorAt(px: number, py: number, floors: readonly Floor[]): number | null {
+    const { groundY, cx, scale } = this.metrics
+    const w = FLOOR_W * scale
+    if (Math.abs(px - cx) > w / 2 + 8) return null
+    for (let i = floors.length - 1; i >= 0; i--) {
+      const floor = floors[i]
+      if (!floor) continue
+      const slab = this.slabs.get(floor.id)
+      const h = slab ? slab.h : i * FLOOR_H
+      const top = groundY - (h + FLOOR_H) * scale
+      const bottom = groundY - h * scale
+      if (py >= top && py <= bottom) return floor.id
+    }
+    return null
+  }
+
+  hitsStrike(px: number, py: number): boolean {
+    const r = this.metrics.strike
+    return px >= r.x && px <= r.x + r.w && py >= r.y && py <= r.y + r.h
+  }
+
+  reset(): void {
+    this.slabs.clear()
+    this.debris = []
+    this.dust.clear()
+    this.shake = 0
+    this.punch = 0
+  }
+}
+
+function indexOfIn(order: readonly Floor[], id: number): number {
+  const i = order.findIndex((f) => f.id === id)
+  return i < 0 ? 0 : i
+}
+
+/** A font size that keeps `text` inside a box, without measuring in a loop. */
+function fit(text: string, maxW: number, maxH: number): number {
+  const perChar = maxW / Math.max(1, text.length * 0.62)
+  return Math.max(9, Math.min(maxH, perChar))
+}
+
+function roundRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+): void {
+  const rad = Math.min(r, w / 2, h / 2)
+  ctx.beginPath()
+  ctx.moveTo(x + rad, y)
+  ctx.arcTo(x + w, y, x + w, y + h, rad)
+  ctx.arcTo(x + w, y + h, x, y + h, rad)
+  ctx.arcTo(x, y + h, x, y, rad)
+  ctx.arcTo(x, y, x + w, y, rad)
+  ctx.closePath()
+}

--- a/dynawalla/games/colossus/src/stubHost.ts
+++ b/dynawalla/games/colossus/src/stubHost.ts
@@ -1,0 +1,189 @@
+// A local stub Host so the game is playable standalone with `npm run dev`.
+//
+// It serves what the real host actually serves. Only the `add` domain has
+// active rows in the curriculum graph, so this stub serves column addition and
+// column subtraction and nothing else — a dev harness that fed multiplication
+// would flatter the game with questions no child will ever be asked.
+//
+// Three properties the real runtime also honours, asserted by
+// `src/test/stubHost.test.ts`:
+//
+//   1. **Exact arithmetic.** Every operand, answer and distractor is an
+//      integer. No float ever reaches an answer string or a comparison.
+//   2. **Seeded and deterministic.** Same seed → same question stream, forever.
+//   3. **Distractors are real mal-rule outputs** — what a child with a specific
+//      broken procedure writes down. Not `answer ± 1` noise. COLOSSUS stands
+//      each one up as a slab a child can punch, so the wrong values have to be
+//      the ones worth learning to reject.
+
+import type { Host, Question } from "./contract.ts"
+import { Rng } from "./core/rng.ts"
+
+type Domain = "add" | "sub"
+
+/** Digit-reversal: 63 → 36. A real transcription slip, not noise. */
+function reverseDigits(n: number): number {
+  let out = 0
+  let m = n
+  while (m > 0) {
+    out = out * 10 + (m % 10)
+    m = Math.floor(m / 10)
+  }
+  return out
+}
+
+/** Column addition with every carry dropped: 27 + 15 → 32. */
+function addNoCarry(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    out += ((x % 10) + (y % 10)) % 10 * place
+    place *= 10
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return out
+}
+
+/** The smaller-from-larger bug: 52 − 27 → 35, taking |2−7| in the ones column. */
+function subSmallerFromLarger(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    out += Math.abs((x % 10) - (y % 10)) * place
+    place *= 10
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return out
+}
+
+function malRulesFor(domain: Domain, a: number, b: number, answer: number): number[] {
+  if (domain === "add") {
+    return [
+      addNoCarry(a, b), // the carry never left the column it was made in
+      answer - 10, // carried but never added the carry in
+      answer + 10, // carried twice
+      Math.abs(a - b), // reached for the wrong operation
+      reverseDigits(answer),
+    ]
+  }
+  return [
+    subSmallerFromLarger(a, b),
+    answer + 10, // borrowed without decrementing the next column
+    answer - 10, // decremented twice
+    a + b, // wrong operation
+    reverseDigits(answer),
+  ]
+}
+
+/** `difficulty` is 0..1, the same monotone reading of the ladder the host sends. */
+function operandsFor(domain: Domain, difficulty: number, rng: Rng): [number, number] {
+  const d = Math.max(0, Math.min(1, difficulty))
+  const hi = Math.round(18 + d * 460) // 18..478
+  if (domain === "add") return [rng.int(4, hi), rng.int(4, hi)]
+  const a = rng.int(12, hi + 20)
+  const b = rng.int(3, Math.max(3, a - 1))
+  return [a, b]
+}
+
+const GLYPH: Record<Domain, string> = { add: "+", sub: "−" }
+
+export type StubHostOptions = {
+  seed?: number
+  reducedMotion?: boolean
+  /** Observe reports — the dev harness draws a running accuracy readout from this. */
+  onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void
+  /** Observe haptics so the harness can show they fired on a device that has none. */
+  onHaptic?: (k: string) => void
+  /** Observe stopping points, which a real host may put a sheet on top of. */
+  onTransition?: (kind: string, label?: string) => void
+  /** Pin the ladder instead of sweeping it. Useful for a screenshot. */
+  difficulty?: number
+}
+
+export function createStubHost(opts: StubHostOptions = {}): Host {
+  const rng = new Rng(opts.seed ?? 0x5eed1ce)
+  let n = 0
+
+  return {
+    next(o) {
+      n++
+      // Sweep the ladder across a session so the dev harness meets all three
+      // slab tiers — one slab, then a pair, then a triple — the way a child
+      // climbing the real ladder over weeks eventually does.
+      const swept = opts.difficulty ?? Math.min(1, ((n - 1) % 24) / 20)
+      const difficulty = Math.max(0, Math.min(1, o?.difficulty ?? swept))
+      const domain: Domain = o?.domain === "sub" ? "sub" : rng.chance(0.45) ? "sub" : "add"
+      const [a, b] = operandsFor(domain, difficulty, rng)
+      const answer = domain === "add" ? a + b : a - b
+
+      // Mal-rule outputs, deduped, filtered to values a slab can carry: a
+      // positive integer that is not the answer.
+      const seen = new Set<number>([answer])
+      const pool: number[] = []
+      for (const v of malRulesFor(domain, a, b, answer)) {
+        if (!Number.isInteger(v) || v < 1 || v > 9999 || seen.has(v)) continue
+        seen.add(v)
+        pool.push(v)
+      }
+      rng.shuffle(pool)
+
+      // Top up from near-misses when a particular (a, b) collapsed several
+      // mal-rules onto one value.
+      for (let k = 1; pool.length < 3 && k < 40; k++) {
+        for (const v of [answer + k, answer - k]) {
+          if (pool.length >= 3) break
+          if (!Number.isInteger(v) || v < 1 || v > 9999 || seen.has(v)) continue
+          seen.add(v)
+          pool.push(v)
+        }
+      }
+
+      return {
+        id: `stub-${n}`,
+        prompt: `${a} ${GLYPH[domain]} ${b}`,
+        answer: String(answer),
+        distractors: pool.slice(0, 3).map(String),
+        domain,
+        difficulty,
+      } satisfies Question
+    },
+
+    report(r) {
+      opts.onReport?.(r)
+    },
+
+    haptic(k) {
+      opts.onHaptic?.(k)
+      const nav = globalThis.navigator as Navigator | undefined
+      if (!nav || typeof nav.vibrate !== "function") return
+      const ms =
+        k === "light" ? 8 : k === "medium" ? 18 : k === "heavy" ? 34 : k === "success" ? 12 : 40
+      try {
+        if (k === "success") nav.vibrate([ms, 26, ms])
+        else if (k === "failure") nav.vibrate([ms, 40, ms])
+        else nav.vibrate(ms)
+      } catch {
+        // A browser that exposes vibrate but refuses it (no user gesture yet,
+        // or a policy block) must never take the frame down with it.
+        console.warn("[colossus] navigator.vibrate refused")
+      }
+    },
+
+    prefersReducedMotion() {
+      if (opts.reducedMotion !== undefined) return opts.reducedMotion
+      return (
+        typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion: reduce)").matches
+      )
+    },
+
+    transition(kind, label) {
+      opts.onTransition?.(kind, label)
+    },
+  }
+}

--- a/dynawalla/games/colossus/src/test/antimash.test.ts
+++ b/dynawalla/games/colossus/src/test/antimash.test.ts
@@ -1,0 +1,122 @@
+// The claim the whole design rests on: **flailing is strictly worse than
+// thinking, and the game shows you why rather than telling you off.**
+//
+// COLOSSUS has no lives, no buzzer, no timer and no red mark. The only thing a
+// wrong strike costs is more building. If that ever stops being true — a growth
+// path quietly clamped, a penalty accidentally made free — nothing else in the
+// game would fail, and it would become a slot machine that rewards speed.
+//
+// So this file plays it twice from identical seeds: same host, same stream of
+// keystones, same first tower, one child who works each keystone out and one
+// who grabs whatever is under their thumb and hits STRIKE.
+//
+// **Why a sitting and not a strike.** A single random grab can be right — on
+// the easiest tier the answer is one slab, and a tower is only nine or ten
+// floors, so a lucky poke lands sometimes. That is not a flaw; a game where
+// flailing is impossible is a game where nobody explores. The claim is about
+// the shape of a sitting, and that is what is measured here: over thirty
+// strikes the masher clears less, topples nothing, and spends the whole time
+// under a taller building.
+//
+// Everything is seeded from a literal. Nothing here reads `Math.random`, and
+// nothing here reads a wall clock.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import { GROWTH } from "../game/game.ts"
+import { mean, playByMashing, playCarefully, rig, stepClock } from "./harness.ts"
+
+const SEEDS = [0x1, 0xc0105, 0x5eed1ce, 0xbeef, 0x2718, 0x1414, 0xfeed, 0xd00d]
+const STRIKES = 30
+
+test("a mashing sitting is spent under a strictly taller building", () => {
+  for (const seed of SEEDS) {
+    const careful = rig(seed)
+    const masher = rig(seed)
+    const tag = `seed ${seed.toString(16)}`
+
+    // Identical towers: the level is built before anybody touches anything, so
+    // any difference from here is a difference in how it was played.
+    assert.deepEqual(
+      careful.game.floors.map((f) => f.value),
+      masher.game.floors.map((f) => f.value),
+      `${tag} did not build the same tower twice`,
+    )
+
+    const carefulHeights = playCarefully(careful.game, STRIKES, stepClock())
+    const masherHeights = playByMashing(masher.game, STRIKES, new Rng(seed ^ 0x77), stepClock())
+
+    assert.equal(carefulHeights.length, STRIKES)
+    assert.equal(masherHeights.length, STRIKES)
+    assert.ok(
+      mean(masherHeights) > mean(carefulHeights),
+      `${tag}: mashing averaged ${mean(masherHeights).toFixed(1)} floors, careful ${mean(carefulHeights).toFixed(1)}`,
+    )
+    assert.ok(
+      Math.max(...masherHeights) > Math.max(...carefulHeights),
+      `${tag}: mashing never got further behind than careful play did`,
+    )
+    // Careful play sees the ground. Mashing never does — the heights sampled
+    // here are read after the level has already rolled over, so a toppled
+    // tower shows up in the tally rather than as a zero in the series.
+    assert.ok(careful.game.tally.toppled > 0, `${tag}: careful play never cleared a tower`)
+    assert.equal(masher.game.tally.toppled, 0, `${tag}: mashing put a colossus on the ground`)
+  }
+})
+
+test("over a sitting, mashing clears less, topples nothing, and builds more", () => {
+  for (const seed of SEEDS) {
+    const careful = rig(seed)
+    const masher = rig(seed)
+    const tag = `seed ${seed.toString(16)}`
+
+    playCarefully(careful.game, STRIKES, stepClock())
+    playByMashing(masher.game, STRIKES, new Rng(seed ^ 0x77), stepClock())
+
+    assert.equal(careful.game.tally.cleared, STRIKES, `${tag}: careful play missed one`)
+    assert.equal(careful.game.tally.missed, 0, tag)
+    assert.ok(careful.game.tally.toppled >= 6, `${tag}: only ${careful.game.tally.toppled} toppled`)
+
+    assert.ok(
+      masher.game.tally.cleared < careful.game.tally.cleared,
+      `${tag}: mashing cleared ${masher.game.tally.cleared}`,
+    )
+    assert.equal(masher.game.tally.toppled, 0, `${tag}: mashing toppled a colossus`)
+    assert.ok(
+      masher.game.tally.missed > masher.game.tally.cleared * 2,
+      `${tag}: ${masher.game.tally.missed} missed against ${masher.game.tally.cleared} cleared`,
+    )
+    // Every miss is stone the child now has to punch back out.
+    assert.ok(masher.game.tally.missed * GROWTH >= 2 * STRIKES - 20, tag)
+
+    // The reports agree: a mashing sitting is a run of wrong answers, not a run
+    // of unanswered questions. Every strike in both sittings is judged.
+    assert.equal(careful.reports.length, STRIKES)
+    assert.equal(masher.reports.length, STRIKES)
+    assert.ok(careful.reports.every((r) => r.correct))
+    assert.ok(
+      masher.reports.filter((r) => r.correct).length < careful.reports.length / 2,
+      tag,
+    )
+  }
+})
+
+test("striking faster never helps: the penalty is stone, and stone does not decay", () => {
+  // Two mashers on the same seed, one taking eight seconds a strike and one
+  // taking a fifth of a second. They end up under the same tower, because
+  // nothing in COLOSSUS is on a clock.
+  const slow = rig(0x51004)
+  const fast = rig(0x51004)
+  playByMashing(slow.game, 12, new Rng(4), stepClock(8000))
+  playByMashing(fast.game, 12, new Rng(4), stepClock(200))
+  assert.equal(slow.game.height, fast.game.height)
+  assert.deepEqual(slow.game.tally, fast.game.tally)
+  assert.deepEqual(
+    slow.reports.map((r) => r.answered),
+    fast.reports.map((r) => r.answered),
+  )
+  // Only the latency differs, which is the one thing that should.
+  assert.ok(slow.reports.every((r, i) => r.ms > (fast.reports[i]?.ms ?? 0)))
+})

--- a/dynawalla/games/colossus/src/test/factor.test.ts
+++ b/dynawalla/games/colossus/src/test/factor.test.ts
@@ -1,0 +1,77 @@
+// Exact integer arithmetic, asserted. A float in here would become a float in
+// a reported answer, and the host judges by string equality.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import { MAX_SLAB, divisorPairs, primeFactors, productOf, slabsFor } from "../game/factor.ts"
+
+test("primeFactors multiplies back to the input, for everything a slab can carry", () => {
+  for (let n = 2; n <= 1200; n++) {
+    const primes = primeFactors(n)
+    assert.equal(productOf(primes), n, `primes of ${n}`)
+    for (const p of primes) {
+      assert.ok(Number.isInteger(p) && p >= 2, `${p} is not a prime factor`)
+      assert.equal(primeFactors(p).length, 1, `${p} is not prime`)
+    }
+  }
+})
+
+test("divisorPairs are exact and ordered", () => {
+  for (const n of [12, 72, 100, 210, 997, 1998]) {
+    for (const [a, b] of divisorPairs(n)) {
+      assert.equal(a * b, n)
+      assert.ok(a <= b)
+      assert.ok(Number.isInteger(a) && Number.isInteger(b))
+    }
+  }
+})
+
+test("slabsFor: the product is the value, exactly, at every requested width", () => {
+  const rng = new Rng(0xc0105)
+  for (let n = 1; n <= 2200; n++) {
+    for (const want of [1, 2, 3]) {
+      const slabs = slabsFor(n, want, rng)
+      assert.ok(slabs.length >= 1, `${n}/${want} produced no slab`)
+      assert.equal(productOf(slabs), n, `${n} split into ${slabs.join("×")}`)
+      for (const v of slabs) {
+        assert.ok(Number.isInteger(v), `${v} is not an integer`)
+        assert.ok(v >= 1 && v <= MAX_SLAB, `${v} is off the slab range`)
+      }
+      assert.ok(slabs.length <= want, `${n}/${want} produced ${slabs.length} slabs`)
+    }
+  }
+})
+
+test("a prime keystone comes back as one slab rather than a lie", () => {
+  const rng = new Rng(11)
+  assert.deepEqual(slabsFor(73, 2, rng), [73])
+  assert.deepEqual(slabsFor(73, 3, rng), [73])
+  assert.deepEqual(slabsFor(997, 3, rng), [997])
+})
+
+test("a composite keystone splits into times-table stone when it can", () => {
+  const rng = new Rng(5)
+  for (let i = 0; i < 200; i++) {
+    const pair = slabsFor(72, 2, rng)
+    assert.equal(pair.length, 2)
+    assert.equal(productOf(pair), 72)
+    assert.ok(
+      pair.every((v) => v <= 12),
+      `72 split into ${pair.join("×")}, which is not times-table stone`,
+    )
+  }
+  const triple = slabsFor(72, 3, rng)
+  assert.equal(triple.length, 3)
+  assert.equal(productOf(triple), 72)
+  assert.ok(triple.every((v) => v >= 2 && v <= 12))
+})
+
+test("slabsFor is seeded: the same seed builds the same tower forever", () => {
+  const a = new Rng(0xbeef)
+  const b = new Rng(0xbeef)
+  for (let n = 2; n < 400; n++) {
+    assert.deepEqual(slabsFor(n, 3, a), slabsFor(n, 3, b))
+  }
+})

--- a/dynawalla/games/colossus/src/test/harness.ts
+++ b/dynawalla/games/colossus/src/test/harness.ts
@@ -1,0 +1,108 @@
+// Shared scaffolding for the rules tests: a recording host, and two players.
+//
+// Every test in this package is seeded from a literal. Nothing here reads
+// `Math.random`, `Date.now` or `performance.now`, so a run that passes passes
+// every time and a run that fails fails every time.
+
+import type { Host } from "../contract.ts"
+import { Rng } from "../core/rng.ts"
+import { Game } from "../game/game.ts"
+import { createStubHost } from "../stubHost.ts"
+import { answerOf, standingSolution } from "../game/tower.ts"
+
+export type Report = { questionId: string; correct: boolean; ms: number; answered: string }
+
+export type Rig = {
+  host: Host
+  game: Game
+  reports: Report[]
+  transitions: Array<{ kind: string; label?: string }>
+  haptics: string[]
+}
+
+export function rig(seed = 0xc0105505, opts: { difficulty?: number } = {}): Rig {
+  const reports: Report[] = []
+  const transitions: Array<{ kind: string; label?: string }> = []
+  const haptics: string[] = []
+  const host = createStubHost({
+    seed,
+    reducedMotion: true,
+    ...(opts.difficulty === undefined ? {} : { difficulty: opts.difficulty }),
+    onReport: (r) => reports.push(r),
+    onHaptic: (k) => haptics.push(k),
+    onTransition: (kind, label) => transitions.push(label === undefined ? { kind } : { kind, label }),
+  })
+  const game = new Game(host, new Rng(seed ^ 0x1234), 0)
+  game.begin(0)
+  return { host, game, reports, transitions, haptics }
+}
+
+/** The ids of the floors that are standing as the current keystone's answer. */
+export function solutionIds(game: Game): number[] {
+  return standingSolution(game.floors, game.progress.done).ids
+}
+
+/** A child who works it out: hold the answer, strike once, every time. */
+export function playCarefully(game: Game, strikes: number, clock = stepClock()): number[] {
+  const heights: number[] = []
+  for (let i = 0; i < strikes; i++) {
+    if (game.stalled) break
+    for (const id of solutionIds(game)) game.toggle(id)
+    game.strike(clock())
+    heights.push(game.height)
+  }
+  return heights
+}
+
+/**
+ * A child who flails: grab whatever is under the thumb and hit STRIKE.
+ *
+ * Deliberately *not* an empty fist — an empty fist is not an assertion and
+ * costs nothing, which is by design. This is the honest model of mashing: a
+ * handful of distinct slabs, chosen without thinking, committed immediately.
+ *
+ * Returns the tower height after each strike, so a whole sitting can be
+ * compared rather than one lucky grab.
+ */
+export function playByMashing(
+  game: Game,
+  strikes: number,
+  rng: Rng,
+  clock = stepClock(),
+): number[] {
+  const heights: number[] = []
+  for (let i = 0; i < strikes; i++) {
+    if (game.stalled) break
+    const floors = game.floors
+    if (floors.length === 0) break
+    const want = rng.int(1, Math.min(3, floors.length))
+    const grabbed = new Set<number>()
+    let guard = 0
+    while (grabbed.size < want && guard++ < 40) {
+      const floor = floors[rng.int(0, floors.length - 1)]
+      if (floor) grabbed.add(floor.id)
+    }
+    for (const id of grabbed) game.toggle(id)
+    game.strike(clock())
+    heights.push(game.height)
+  }
+  return heights
+}
+
+export function mean(xs: readonly number[]): number {
+  return xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length
+}
+
+/** A wall clock that ticks a fixed amount per call. No real time anywhere. */
+export function stepClock(step = 1800): () => number {
+  let t = 0
+  return () => {
+    t += step
+    return t
+  }
+}
+
+export function currentAnswer(game: Game): number {
+  const keystone = game.keystone
+  return keystone ? answerOf(keystone) : 0
+}

--- a/dynawalla/games/colossus/src/test/pause.test.ts
+++ b/dynawalla/games/colossus/src/test/pause.test.ts
@@ -1,0 +1,135 @@
+// THE PAUSE.
+//
+// The host can put a sheet over a pack that is **still mounted and still
+// running** — a stopping-point card, a parent gate, a day-pass offer — and it
+// sends `pause` when it does. COLOSSUS calls `transition` at the end of every
+// tower it brings down, so it is one of the packs most likely to raise that
+// sheet itself.
+//
+// Two things have to stop dead, and both of them are real damage if they do not:
+//
+//   1. **Input.** A touch that lands while the sheet is up is not a thing the
+//      child did. Unguarded, it strikes the fist, reports an answer to a
+//      keystone nobody was looking at, and puts two more floors on the tower
+//      they now have to bring down. A penalty for a question they never saw is
+//      the worst bug this game could ship.
+//   2. **The keystone's clock.** The latency reported is meant to be time the
+//      child spent thinking. Time spent behind a sheet is not that, and a
+//      thirty-second sheet would tell the host a child laboured over a question
+//      they answered in two seconds.
+//
+// Each assertion here fails if the corresponding guard in `Game` is removed —
+// verified by removing them, not by reading them.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { rig, solutionIds } from "./harness.ts"
+
+test("a strike behind the sheet is not taken, not reported, and does not build", () => {
+  const { game, reports } = rig(0x9a05e)
+  // A full, correct fist — so nothing about this press is ambiguous except
+  // that it happened while the host had a sheet over the frame.
+  for (const id of solutionIds(game)) game.toggle(id)
+  const holding = game.holding.length
+  assert.ok(holding > 0)
+
+  const height = game.height
+  const cursor = game.progress.done
+
+  game.pause(1000)
+  const events = game.strike(1400)
+
+  assert.deepEqual(events, [], "a strike behind the sheet produced events")
+  assert.equal(reports.length, 0, "a strike behind the sheet was reported to the host")
+  assert.equal(game.height, height, "a strike behind the sheet changed the building")
+  assert.equal(game.progress.done, cursor, "a strike behind the sheet spent a keystone")
+  assert.equal(game.holding.length, holding, "a strike behind the sheet emptied the fist")
+})
+
+test("taking hold behind the sheet does nothing either", () => {
+  const { game } = rig(0x40b)
+  const floor = game.floors[0]
+  const other = game.floors[1]
+  assert.ok(floor && other)
+
+  game.toggle(floor.id)
+  game.pause(500)
+
+  assert.deepEqual(game.toggle(other.id), [], "a slab was picked up behind the sheet")
+  assert.deepEqual(game.toggle(floor.id), [], "a slab was put down behind the sheet")
+  game.releaseAll()
+  assert.deepEqual(game.holding, [floor.id], "the fist changed behind the sheet")
+
+  // And everything the child was holding is still in their hand when it lifts.
+  game.resume(900)
+  assert.deepEqual(game.holding, [floor.id])
+  assert.deepEqual(
+    game.toggle(other.id).map((e) => e.kind),
+    ["hold"],
+  )
+})
+
+test("the sheet is not thinking time: the latency reported skips it", () => {
+  const { game, reports } = rig(0x11ce)
+  for (const id of solutionIds(game)) game.toggle(id)
+
+  // Two seconds of looking at the tower, thirty seconds behind a sheet, then
+  // half a second more and a strike.
+  game.pause(2000)
+  game.resume(32000)
+  game.strike(32500)
+
+  const report = reports[0]
+  assert.ok(report)
+  assert.equal(report.ms, 2500, "the sheet was counted as time the child spent thinking")
+})
+
+test("a sheet raised between keystones does not charge the next one for it", () => {
+  const { game, reports } = rig(0x2ee)
+  // Answer the first keystone at four seconds.
+  for (const id of solutionIds(game)) game.toggle(id)
+  game.strike(4000)
+
+  // The host raises its sheet on the transition and holds it for a minute. The
+  // child had a tenth of a second with the next keystone before it went up.
+  game.pause(4100)
+  game.resume(64100)
+
+  for (const id of solutionIds(game)) game.toggle(id)
+  game.strike(65100)
+
+  assert.equal(reports.length, 2)
+  assert.equal(reports[0]?.ms, 4000)
+  assert.equal(reports[1]?.ms, 1100, "the next keystone was charged for the sheet")
+})
+
+test("pause and resume are idempotent, and resume alone changes nothing", () => {
+  const { game, reports } = rig(0x1de)
+  for (const id of solutionIds(game)) game.toggle(id)
+
+  game.resume(100) // never paused
+  game.pause(1000)
+  game.pause(5000) // a second pause must not move the mark
+  game.resume(9000)
+  game.resume(50000) // a second resume must not move it either
+  game.strike(10000)
+
+  const report = reports[0]
+  assert.ok(report)
+  assert.equal(report.ms, 2000)
+  assert.equal(game.isPaused, false)
+})
+
+test("the clock is a mark, not a stopwatch: a strike after resume is judged normally", () => {
+  const { game, reports } = rig(0x7e5)
+  for (const id of solutionIds(game)) game.toggle(id)
+  // 300 ms with the tower, nine seconds behind a sheet, 700 ms more.
+  game.pause(300)
+  game.resume(9300)
+  const events = game.strike(10000)
+  assert.ok(events.length > 0, "the game did not come back after the sheet lifted")
+  assert.equal(reports.length, 1)
+  assert.equal(reports[0]?.correct, true)
+  assert.equal(reports[0]?.ms, 1000)
+})

--- a/dynawalla/games/colossus/src/test/stubHost.test.ts
+++ b/dynawalla/games/colossus/src/test/stubHost.test.ts
@@ -1,0 +1,87 @@
+// The stub host's three promises, which the real runtime also has to keep.
+//
+// It matters that these are asserted rather than assumed: every other test in
+// this package plays the game through this host, so a stub that quietly served
+// a float or an unseeded stream would make the rest of the suite meaningless.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { createStubHost } from "../stubHost.ts"
+
+test("exact arithmetic: every answer and every distractor is a positive integer", () => {
+  const host = createStubHost({ seed: 0x1234 })
+  for (let i = 0; i < 3000; i++) {
+    const q = host.next()
+    assert.ok(/^\d+$/.test(q.answer), `answer "${q.answer}" is not an integer string`)
+    assert.ok(Number(q.answer) >= 1)
+    for (const d of q.distractors) {
+      assert.ok(/^\d+$/.test(d), `distractor "${d}" is not an integer string`)
+      assert.notEqual(d, q.answer, "a distractor was the answer")
+    }
+    assert.equal(new Set(q.distractors).size, q.distractors.length, "duplicate distractors")
+  }
+})
+
+test("the prompt and the answer agree, digit for digit", () => {
+  const host = createStubHost({ seed: 0x9 })
+  for (let i = 0; i < 2000; i++) {
+    const q = host.next()
+    const match = /^(\d+) ([+−]) (\d+)$/.exec(q.prompt)
+    assert.ok(match, `prompt "${q.prompt}" is not a column sum`)
+    const a = Number(match[1])
+    const b = Number(match[3])
+    const expected = match[2] === "+" ? a + b : a - b
+    assert.equal(Number(q.answer), expected, `"${q.prompt}" does not make ${q.answer}`)
+  }
+})
+
+test("seeded and deterministic: the same seed is the same stream, forever", () => {
+  const a = createStubHost({ seed: 0xc0105 })
+  const b = createStubHost({ seed: 0xc0105 })
+  for (let i = 0; i < 500; i++) {
+    assert.deepEqual(a.next(), b.next())
+  }
+  const c = createStubHost({ seed: 0xc0106 })
+  const d = createStubHost({ seed: 0xc0105 })
+  let same = 0
+  for (let i = 0; i < 200; i++) if (c.next().prompt === d.next().prompt) same++
+  assert.ok(same < 20, "two different seeds produced nearly the same stream")
+})
+
+test("distractors are mal-rule outputs, not `answer ± 1` noise", () => {
+  // The dropped-carry rule: 27 + 15 written down as 32, because the 1 the ones
+  // column made never reached the tens. It is the single most common column
+  // addition error there is, and COLOSSUS stands it up as a slab to punch.
+  const host = createStubHost({ seed: 0x1234, difficulty: 0.4 })
+  let malRules = 0
+  let nearMisses = 0
+  for (let i = 0; i < 600; i++) {
+    const q = host.next()
+    const answer = Number(q.answer)
+    for (const text of q.distractors) {
+      const v = Number(text)
+      if (Math.abs(v - answer) <= 2) nearMisses++
+      else malRules++
+    }
+  }
+  assert.ok(
+    malRules > nearMisses * 6,
+    `only ${malRules} mal-rule values against ${nearMisses} near-misses`,
+  )
+})
+
+test("reduced motion is whatever it is told, not whatever the machine has", () => {
+  assert.equal(createStubHost({ reducedMotion: true }).prefersReducedMotion(), true)
+  assert.equal(createStubHost({ reducedMotion: false }).prefersReducedMotion(), false)
+})
+
+test("difficulty is the 0..1 the real host sends, and it is clamped", () => {
+  const host = createStubHost({ seed: 3 })
+  for (let i = 0; i < 200; i++) {
+    const q = host.next()
+    assert.ok(q.difficulty >= 0 && q.difficulty <= 1, `difficulty ${q.difficulty}`)
+  }
+  assert.equal(host.next({ difficulty: 5 }).difficulty, 1)
+  assert.equal(host.next({ difficulty: -3 }).difficulty, 0)
+})

--- a/dynawalla/games/colossus/src/test/tower.test.ts
+++ b/dynawalla/games/colossus/src/test/tower.test.ts
@@ -1,0 +1,263 @@
+// The rules of the building.
+//
+// The one that matters most is here: **a wrong strike makes the tower taller.**
+// It is the only penalty in COLOSSUS — no lives, no buzzer, no red mark — and
+// if it ever silently stops working, flailing becomes free and the game is a
+// slot machine.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import { productOf } from "../game/factor.ts"
+import { Game, GROWTH, MAX_FLOORS, MAX_KEYSTONES, MIN_KEYSTONES } from "../game/game.ts"
+import { answerOf, standingSolution } from "../game/tower.ts"
+import { createStubHost } from "../stubHost.ts"
+import { currentAnswer, rig, solutionIds, stepClock } from "./harness.ts"
+
+test("the tower always stands the current keystone's answer up in it", () => {
+  const { game } = rig(0xa11ce)
+  for (let i = 0; i < 40 && !game.stalled; i++) {
+    const target = currentAnswer(game)
+    const standing = standingSolution(game.floors, game.progress.done)
+    assert.ok(standing.ids.length > 0, "the keystone has no floors standing for it")
+    assert.equal(standing.product, target, `standing floors do not multiply to ${target}`)
+    for (const id of standing.ids) game.toggle(id)
+    game.strike((i + 1) * 1000)
+  }
+})
+
+test("a wrong strike makes the tower taller — strictly, every time", () => {
+  const { game, reports } = rig(0xbadbad)
+  const clock = stepClock()
+
+  // Inside one tower. The last keystone of a level rolls the building over, and
+  // comparing heights across that would be comparing two different towers.
+  const keystones = game.progress.total
+  assert.ok(keystones >= MIN_KEYSTONES && keystones <= MAX_KEYSTONES)
+  const started = game.height
+
+  for (let i = 0; i < keystones - 1; i++) {
+    const target = currentAnswer(game)
+    // Hold one floor that is not on its own the answer. Deliberately wrong.
+    const wrong = game.floors.find((f) => f.value !== target)
+    assert.ok(wrong, "every tower has a floor that is not the answer")
+    game.toggle(wrong.id)
+
+    const before = game.height
+    const reportsBefore = reports.length
+    game.strike(clock())
+
+    assert.equal(reports.length, reportsBefore + 1, "a strike must be reported exactly once")
+    const last = reports[reports.length - 1]
+    assert.ok(last)
+    assert.equal(last.correct, false)
+    assert.equal(last.answered, String(wrong.value), "the reported value is what was held")
+
+    assert.ok(before + GROWTH <= MAX_FLOORS, "this tower was already at the cap")
+    assert.equal(game.height, before + GROWTH, "a wrong strike did not grow the tower")
+  }
+
+  // And the building the child is looking at is taller than the one they were
+  // handed, by exactly the work they made for themselves.
+  assert.equal(game.height, started + GROWTH * (keystones - 1))
+  assert.equal(game.tally.missed, keystones - 1)
+  assert.equal(game.tally.cleared, 0)
+})
+
+test("nothing else in the game makes the tower taller", () => {
+  // Holding, letting go, striking an empty fist, pausing: none of it builds.
+  const { game } = rig(0x9111)
+  const started = game.height
+  for (const floor of game.floors) game.toggle(floor.id)
+  assert.equal(game.height, started)
+  game.releaseAll()
+  game.strike(1000)
+  game.pause(1200)
+  game.resume(1400)
+  assert.equal(game.height, started)
+})
+
+test("a correct strike takes the keystone's stone out of the building", () => {
+  const { game, reports } = rig(0x0dd)
+  const clock = stepClock()
+  const target = currentAnswer(game)
+  const ids = solutionIds(game)
+  const owned = game.floors.filter((f) => f.owner === game.progress.done).length
+
+  const before = game.height
+  for (const id of ids) game.toggle(id)
+  game.strike(clock())
+
+  const last = reports[reports.length - 1]
+  assert.ok(last)
+  assert.equal(last.correct, true)
+  assert.equal(last.answered, String(target))
+  assert.ok(game.height < before, "a correct strike did not bring anything down")
+  // Its answer floors and its decoy floors both leave: the keystone's lies go
+  // down with its truth, which is what makes the tower a countdown.
+  assert.equal(game.height, before - owned)
+})
+
+test("the reported value is the exact product of the fist, as an integer string", () => {
+  const { game, reports } = rig(0x5eed)
+  const clock = stepClock()
+  for (let i = 0; i < 24 && !game.stalled; i++) {
+    const floors = game.floors
+    const rng = new Rng(0x900d ^ i)
+    const grab = Math.min(2, floors.length)
+    const held: number[] = []
+    for (let k = 0; k < grab; k++) {
+      const floor = floors[rng.int(0, floors.length - 1)]
+      if (floor && !held.includes(floor.value)) {
+        game.toggle(floor.id)
+        held.push(floor.value)
+      }
+    }
+    if (game.holding.length === 0) continue
+    const expected = productOf(game.heldValues())
+    game.strike(clock())
+    const last = reports[reports.length - 1]
+    assert.ok(last)
+    assert.equal(last.answered, String(expected))
+    assert.ok(/^\d+$/.test(last.answered), `"${last.answered}" is not an integer string`)
+  }
+})
+
+test("an empty fist is not an assertion: nothing reported, nothing built", () => {
+  const { game, reports } = rig(0xe0f)
+  const before = game.height
+  const events = game.strike(500)
+  assert.deepEqual(events, [])
+  assert.equal(reports.length, 0)
+  assert.equal(game.height, before)
+  assert.equal(game.progress.done, 0)
+})
+
+test("taking hold of stone and letting it go costs nothing", () => {
+  const { game, reports } = rig(0xf157)
+  const before = game.height
+  const floor = game.floors[0]
+  assert.ok(floor)
+  for (let i = 0; i < 20; i++) game.toggle(floor.id)
+  game.releaseAll()
+  assert.equal(reports.length, 0)
+  assert.equal(game.height, before)
+  assert.equal(game.holding.length, 0)
+})
+
+test("the building stops taking stone at the cap", () => {
+  const { game } = rig(0xcafe)
+  const clock = stepClock()
+  for (let i = 0; i < 60 && !game.stalled; i++) {
+    const target = currentAnswer(game)
+    const wrong = game.floors.find((f) => f.value !== target)
+    if (wrong) game.toggle(wrong.id)
+    game.strike(clock())
+    assert.ok(game.height <= MAX_FLOORS, `the tower reached ${game.height} floors`)
+  }
+})
+
+test("a tower cleared to the ground is toppled, and only then", () => {
+  const { game, transitions } = rig(0x7a11)
+  const clock = stepClock()
+  const keystones = game.progress.total
+  for (let i = 0; i < keystones; i++) {
+    for (const id of solutionIds(game)) game.toggle(id)
+    game.strike(clock())
+  }
+  assert.equal(game.tally.toppled, 1, "a perfect tower did not come down")
+  assert.equal(game.tally.cleared, keystones)
+  assert.equal(game.tally.missed, 0)
+  assert.deepEqual(transitions, [{ kind: "level", label: "toppled" }])
+})
+
+test("a level with nothing cleared raises no stopping point", () => {
+  const { game, transitions } = rig(0x1055)
+  const clock = stepClock()
+  const keystones = game.progress.total
+  for (let i = 0; i < keystones; i++) {
+    const target = currentAnswer(game)
+    const wrong = game.floors.find((f) => f.value !== target)
+    if (wrong) game.toggle(wrong.id)
+    game.strike(clock())
+  }
+  assert.equal(game.tally.cleared, 0)
+  assert.equal(game.tally.missed, keystones)
+  assert.deepEqual(transitions, [], "a purchase sheet must never sit next to a shortfall")
+})
+
+test("a keystone whose stone was spent on an earlier answer is re-planted", () => {
+  // Drive the engine with a host that serves one answer over and over, so every
+  // keystone's solution is the same slab and clearing one strips the next.
+  let n = 0
+  const host = {
+    next: () => {
+      n += 1
+      return {
+        id: `q-${n}`,
+        prompt: "8 + 4",
+        answer: "12",
+        distractors: ["3", "112"],
+        domain: "add",
+        difficulty: 0,
+      }
+    },
+    report: () => {},
+    haptic: () => {},
+    prefersReducedMotion: () => true,
+  }
+  const game = new Game(host, new Rng(9), 0)
+  game.begin(0)
+  const clock = stepClock()
+  const keystones = game.progress.total
+  for (let i = 0; i < keystones; i++) {
+    const standing = standingSolution(game.floors, game.progress.done)
+    assert.equal(standing.product, 12, `keystone ${i} has no answer standing`)
+    for (const id of standing.ids) game.toggle(id)
+    game.strike(clock())
+  }
+  assert.equal(game.tally.cleared, keystones)
+})
+
+test("a host that serves nothing buildable stalls loudly rather than lying", () => {
+  const host = {
+    next: () => ({
+      id: "bad",
+      prompt: "1 ÷ 3",
+      answer: "0.3333",
+      distractors: [],
+      domain: "frac",
+      difficulty: 0,
+    }),
+    report: () => {
+      throw new Error("an unbuildable question must never be reported")
+    },
+    haptic: () => {},
+    prefersReducedMotion: () => true,
+  }
+  const errors: unknown[] = []
+  const real = console.error
+  console.error = (...args: unknown[]) => errors.push(args)
+  try {
+    const game = new Game(host, new Rng(3), 0)
+    const events = game.begin(0)
+    assert.deepEqual(events, [{ kind: "stalled" }])
+    assert.ok(game.stalled)
+    assert.deepEqual(game.strike(10), [])
+    assert.equal(errors.length, 1, "a stall must be loud")
+  } finally {
+    console.error = real
+  }
+})
+
+test("the stub host only serves what the curriculum actually has active", () => {
+  const host = createStubHost({ seed: 0x515 })
+  for (let i = 0; i < 400; i++) {
+    const q = host.next()
+    assert.ok(q.domain === "add" || q.domain === "sub", `served ${q.domain}`)
+    const answer = Number(q.answer)
+    assert.ok(Number.isInteger(answer) && answer > 0)
+    assert.equal(answerOf(q), answer)
+  }
+})

--- a/dynawalla/games/colossus/tsconfig.json
+++ b/dynawalla/games/colossus/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": false,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/dynawalla/games/colossus/vite.config.ts
+++ b/dynawalla/games/colossus/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite"
+
+// The game is a library that mounts into a host element. `npm run dev` serves
+// the standalone harness in `index.html`, which wires it to the local stub Host
+// so the whole thing is playable with no runtime underneath it.
+export default defineConfig({
+  server: { port: 4344, host: "127.0.0.1", strictPort: true },
+  build: {
+    target: "es2022",
+    lib: {
+      entry: "src/index.ts",
+      name: "DynawallaGameColossus",
+      formats: ["es"],
+      fileName: () => "colossus.js",
+    },
+  },
+})

--- a/dynawalla/games/colossus/vite.pack.config.ts
+++ b/dynawalla/games/colossus/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produced a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})


### PR DESCRIPTION
## What

**COLOSSUS** — a new game at `dynawalla/games/colossus`, built from the arcade
canon (rank 12, S tier), after Rampage (1986). Punch out the floors whose
product matches the keystone.

## Why

The canon's line on it is *"wrong strikes GROW the tower. Best anti-mash penalty
here."* That penalty is the entire reason to build this design, so it is the
thing the tests defend:

- A wrong strike does not buzz, does not take a life, and does not end the run.
  **It adds a floor.** The child is given more work and can *see* it.
- That makes flailing self-defeating in a way a buzzer never manages — the cost
  is stone, and stone does not decay.

Five tests hold the line, including the pair that matter most:

```
a wrong strike makes the tower taller — strictly, every time
nothing else in the game makes the tower taller
a mashing sitting is spent under a strictly taller building
over a sitting, mashing clears less, topples nothing, and builds more
striking faster never helps: the penalty is stone, and stone does not decay
```

The second is the one worth calling out: a penalty that *other* things can also
cause is not a penalty a child can learn from. Pinning it down is what makes the
first assertion mean something.

## How it fits the curriculum we actually have

Only `add` is active (7 rows; `alg`, `div`, `frac`, `mul`, `ns` are all
`draft`), and `covers` is documented as "a request, not an instruction" — so the
host serves whole-number column arithmetic regardless.

This follows the `games/slice` precedent rather than pretending otherwise: the
**keystone comes from the value the host serves**, and the factoring is the
game's own mathematics — something the child performs with a gesture, not a
question anybody asked. Only what the host can judge exactly is reported. All
seven declared skills are `dw.add.*`, verified by hand against
`packs/shared/curriculum/src/graph/domains/add.ts`, because `dw-pack check` does
**not** validate skill ids and a fictional one passes silently.

## Blast radius

**Areas touched:** dynawalla, one new game directory. Additive.

- [x] Scope: 0 files outside `dynawalla/games/colossus/`, 0 deletions.
- [x] Covered by `dynawalla-packs · games + pack build`.
- [x] **Capabilities: `items`, `items.reveal`, `haptics`.** `items.reveal` is
      mandatory — without it `canonical` is `""`, every item is dropped and the
      pack serves zero questions with no crash and no failing gate. `audio` is
      deliberately **not** declared: that capability is `feedback.sound` (the
      host's sounds) and this game synthesises its own `AudioContext`.
- [x] **The host sheet is handled.** `pack.ts` subscribes to `pause`/`resume`,
      so a still-mounted pack does not run its clock behind a `transition()` and
      mark a child wrong for a question they were never shown. Three of four
      games in the previous wave shipped with that bug.
- [x] **Curriculum.** No skill id renamed, reused or added.
- [x] **Native / strings / secrets.** None. `gitleaks` → no leaks found.

## Proof

```
$ npm test        # in dynawalla/games/colossus/, x5
# pass 34 # fail 0   <- 1
# pass 34 # fail 0   <- 2
# pass 34 # fail 0   <- 3
# pass 34 # fail 0   <- 4
# pass 34 # fail 0   <- 5

$ npm run tsc
0 errors
```

The built entry carries its script — the failure the vite config warns about is
a `pack.html` that loads, paints the body colour and runs no code:

```
<script type="module" crossorigin src="./assets/pack-C8GlDiCR.js"
```

```
$ node dynawalla/packs/build.mjs colossus
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
1 pack(s) built, checked and staged into src-tauri/packs/

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
no leaks found

$ git diff --name-only origin/main...HEAD | grep -cv '^dynawalla/games/colossus/'
0
```

**Provenance, stated plainly.** The building agent dropped twice — once on a
network `ECONNRESET`, once on a watchdog — both times *after* pushing, so
nothing was lost. I finished the gates and verified its work independently
rather than taking the agent's word: the five test runs, the skill ids, the
scope and the pack build above are mine, not a report.
