### PR TITLE
dynawalla/games/lattice: THE LATTICE — the multiplier is a live factor tree, and the resonance is where the thinking is

### DIFF
--- a/dynawalla/games/lattice/.gitignore
+++ b/dynawalla/games/lattice/.gitignore
@@ -1,0 +1,12 @@
+node_modules/
+dist/
+
+# The pack build. `packs/build.mjs` regenerates it and stages it into the app.
+dist-pack/
+
+# Local QA scratch: screenshots and temporary captures.
+qa/shots
+qa/tmp
+
+# The lockfile is not committed for a game package; the repo pins at the root.
+package-lock.json

--- a/dynawalla/games/lattice/README.md
+++ b/dynawalla/games/lattice/README.md
@@ -1,0 +1,173 @@
+# THE LATTICE
+
+A twin-stick arena strung on a mass-spring grid that tears and re-knits.
+
+Composite **husks** drift on the sheet. A shot cracks one along a factor pair —
+72 becomes 8 and 9, the 8 becomes 2 and 4, the 4 becomes 2 and 2 — and **a shot
+at a prime is refused**, because a prime does not go. So the field grinds itself
+down into primes, and primes are what the ship sweeps. What is swept shows in a
+**factor tile bar**: `2·2·3` with a running 12 beside it, changing the instant a
+mote is taken.
+
+Hanging in the middle of it is a **resonator** with a problem on its face, and
+it opens for exactly one thing.
+
+*After* Geometry Wars: Retro Evolved 2 (2005) — rank 2, S tier, in
+`docs/catalog/ARCADE_CANON.md`.
+
+---
+
+## The two layers, and which one is the learning
+
+The canon is explicit about this pack, and it is worth repeating in full:
+
+> Honest caveat: the passive layer is absorption, not reasoning; the
+> target-product resonance is where the thinking is and it must ship on.
+
+### The passive layer — absorption
+
+Shooting husks apart and sweeping the primes up. A child sees `2·2·3` become 12
+hundreds of times in a sitting, with a sound and a colour attached, and never
+answers a question to do it. That is worth having. It is not reasoning: nothing
+is chosen, and a child who does it perfectly has not decided anything.
+
+It ships as the *default*. You can fly the arena, shoot everything and sweep,
+and the game is a game.
+
+### The target-product resonance — the thinking, and it shipped
+
+The resonator carries a problem the curriculum drew — `47 + 25`. It opens for a
+hold whose **primes multiply to the answer**, and nothing else. To open it a
+child has to:
+
+1. work out that `47 + 25` is 72;
+2. decide *which* primes on the field multiply to 72 — 2·2·2·3·3;
+3. crack the husks that are holding those primes, and no others;
+4. sweep exactly them, and **nothing else**, because the hold is exact.
+
+Sweeping a stray 5 on the way past is a real cost. It does not scold and it does
+not end anything — but the hold now reads 360 and the resonator does not
+resonate. The way out is to **tap your own tile bar**, which throws the hold back
+onto the field as motes, and start the hold again. Nothing the child worked for
+is ever destroyed.
+
+Flying into the resonator asserts `product(hold)`. That value — an exact integer
+the child assembled on purpose — is what goes to the host, and the host judges
+it. The game never decides whether an answer was right.
+
+**Primeness is a wall.** When the answer is prime, no amount of sweeping smaller
+numbers reaches it: the only hold that opens a prime `p` is the single mote `p`,
+which has to be found drifting on the field. It is the same property `foundry
+street` relies on, and it is asserted exhaustively in `resonance.test.ts`.
+
+---
+
+## What is reported, and what is the game's own mathematics
+
+Following the `slice` precedent. Only the `add` curriculum domain is active
+(`alg`, `div`, `frac`, `mul`, `ns` are all `draft`), and `covers` is a request
+rather than an instruction — the host serves whole-number column arithmetic
+regardless. So:
+
+* **Reported:** the product the child asserted at the resonator, as a string,
+  against the question id the resonator was carrying. Exact, integer, and
+  judgeable by the host with no interpretation. Once per question — a refusal
+  spends the id, and the resonator then stays as a goal the child can still
+  open.
+* **Not reported:** everything about the factoring. Cracking 72 into 8 and 9 is
+  arithmetic the child performs with a trigger, not a question anybody asked.
+
+`pack.json` declares the seven **active** `dw.add.*` skills, each checked by hand
+against `packs/shared/curriculum/src/graph/domains/add.ts`. There is deliberately
+no `dw.mul.*` row: the multiplication domain is 100% `draft`, and declaring one
+would imply coverage the curriculum cannot serve.
+
+Distractors are load-bearing rather than decorative. When a resonator is armed,
+the field is seeded with the primes of the answer **plus** the extra primes one
+of the host's mal-rule answers needs — so a child who dropped a carry can
+assemble their own mistake, and the misconception routes back to the host with
+no extra wiring.
+
+---
+
+## Controls
+
+Twin-stick, on every input a child might have. Tablet and desktop are equal
+targets.
+
+| | Move | Aim / fire | Drop the hold |
+|---|---|---|---|
+| Touch | left thumb, anywhere on the left half | right thumb | tap the tile bar |
+| Keyboard | `WASD` | arrow keys, or `space` to fire straight ahead | `Escape` |
+| Mouse | `WASD` | the cursor aims, the button fires | tap the tile bar |
+
+---
+
+## Reduced motion is a branch, not a switch
+
+Turning the sheet off would delete the only cue that says *where a number came
+apart*. So the reduced branch keeps the whole simulation and changes its
+character: the springs are stiff, the damping is at critical, the amplitude
+ceiling is about a fifth, and there is no screen shake. The sheet dents and
+returns in about a quarter of a second with no travelling wave and no ringing. A
+strut still tears — it is drawn as a strut that has gone dark rather than as one
+that has been flung.
+
+`grid.test.ts` asserts all of it: the reduced branch must **move** (the test
+fails if someone "fixes" it by switching the simulation off), must travel less
+than half as far, and must turn around at most once, while the full branch rings.
+
+---
+
+## Layout
+
+```
+src/
+  contract.ts     the Host↔game contract; mount(el, host) → { unmount, pause, resume }
+  stubHost.ts     seeded, deterministic, exact-integer, mal-rule distractors
+  main.ts         the dev harness entry (npm run dev); P raises a fake host sheet
+  pack.ts         the pack entry; subscribes pause/resume, dispose
+  mount.ts        canvas, clock, twin-stick input, event wiring
+  core/rng.ts     mulberry32
+  game/factor.ts     primes, splitting, husking — exact integers only
+  game/resonance.ts  the rule the whole learning claim rests on
+  game/bank.ts       the hold, and the factor tile bar
+  game/arena.ts      the rules: husks, motes, the ship, the resonator
+  game/best.ts       the longest chain, guarded for a pack frame
+  sim/grid.ts     the mass-spring sheet that tears and re-knits
+  render/         palette, scene, sparks
+  audio/audio.ts  asset-free Web Audio, C5–C6 pentatonic
+  test/           71 tests: rules, not rendering
+```
+
+## Tests
+
+```
+npm test        71 tests
+npm run tsc     0 errors
+npm run build   the library build
+npm run build:pack   the pack build → dist-pack/
+```
+
+The ones that matter:
+
+* `resonance.test.ts` — a target is cleared **only** by a genuine prime
+  factorisation of it (exhaustive over every multiset of small primes to six
+  tiles against every target to 200); a prime target cannot be assembled from
+  smaller factors (exhaustive); an empty hold asserts nothing.
+* `bank.test.ts` — the tile bar is a true factorisation of the value beside it
+  after **every** operation on **every** path, over a four-thousand-step seeded
+  sitting.
+* `factor.test.ts` — splitting conserves the product exactly for every composite
+  under 2000; grinding a husk to exhaustion yields exactly its prime
+  factorisation.
+* `arena.test.ts` — the field can always supply the answer's factorisation; one
+  question, one report; a refusal never raises a stopping point; a released mote
+  is thrown clear rather than instantly re-swept.
+* `pause.test.ts` — **verified to fail with every pause guard removed**, not by
+  reading them.
+* `loop.test.ts` — a scripted child plays the real arena through the real
+  physics and opens resonators. The failure it catches is silent and total: a
+  game where nothing throws and nothing can be beaten.
+* `grid.test.ts` — no NaN, always returns to rest, always knits back, and the
+  reduced-motion branch is a branch.

--- a/dynawalla/games/lattice/index.html
+++ b/dynawalla/games/lattice/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <title>THE LATTICE — dev harness</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #050810;
+        overscroll-behavior: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+      #readout {
+        position: fixed;
+        left: 8px;
+        bottom: 6px;
+        z-index: 5;
+        font: 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+        color: rgba(255, 255, 255, 0.42);
+        pointer-events: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <div id="readout">host.report → 0/0</div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/lattice/pack.html
+++ b/dynawalla/games/lattice/pack.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#050810" />
+    <title>THE LATTICE</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #050810;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/lattice/pack.json
+++ b/dynawalla/games/lattice/pack.json
@@ -1,0 +1,24 @@
+{
+  "id": "dynawalla.lattice",
+  "version": "0.1.0",
+  "name": "THE LATTICE",
+  "description": "A twin-stick arena strung on a mass-spring grid. Shoot a composite husk and it splits along a factor pair; primes cannot be split, so primes are what is left to sweep. Fly into the resonator holding the primes that multiply to what it is asking.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-multidigit",
+      "dw.add.regroup.add-short-addend",
+      "dw.add.regroup.subtract-short-subtrahend",
+      "dw.add.regroup.subtract-across-zero"
+    ],
+    "grades": [1, 4]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/lattice/package.json
+++ b/dynawalla/games/lattice/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@dynawalla/game-lattice",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "THE LATTICE — a twin-stick arena on a mass-spring grid. Shoot a composite and it splits into two factors; primes cannot be split, so they are what is left to sweep.",
+  "engines": {
+    "node": ">=22.6.0"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4351",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
+    "build:pack": "vite build --config vite.pack.config.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^6.0.0",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/games/lattice/src/audio/audio.ts
+++ b/dynawalla/games/lattice/src/audio/audio.ts
@@ -1,0 +1,150 @@
+// Asset-free Web Audio. No files, no decode, nothing on the answer path.
+//
+// The timbre is the one the experience design specifies: a struck felt mallet —
+// a sine with a 0.22-gain triangle an octave up — over a C5–C6 pentatonic. The
+// arena's own sounds are made of the same material: a split is a stone chip, a
+// prime is a struck bell that will not break, a resonance is the pentatonic
+// running up.
+//
+// **Nothing here is queued.** A note that arrives while the context is busy is
+// dropped, never stacked, because a hundred husks coming apart in a second is a
+// real thing a child can do and a queue would turn it into a smear.
+
+/** C5–C6 pentatonic, in Hz. The whole melodic vocabulary. */
+const PENTATONIC = [523.25, 587.33, 659.25, 783.99, 880.0, 1046.5]
+
+/** The most voices that may sound at once. Over this, the note is dropped. */
+const MAX_VOICES = 10
+
+export class Audio {
+  private ctx: AudioContext | null = null
+  private master: GainNode | null = null
+  private voices = 0
+  private failed = false
+
+  /** Called from a user gesture; a context created before one stays suspended. */
+  resume(): void {
+    const ctx = this.context()
+    if (ctx && ctx.state === "suspended") {
+      void ctx.resume().catch((error: unknown) => {
+        console.warn("[lattice] the audio context refused to resume", error)
+      })
+    }
+  }
+
+  private context(): AudioContext | null {
+    if (this.ctx || this.failed) return this.ctx
+    try {
+      const Ctor =
+        globalThis.AudioContext ??
+        (globalThis as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+      if (!Ctor) {
+        this.failed = true
+        console.warn("[lattice] this runtime has no AudioContext; the arena is silent")
+        return null
+      }
+      this.ctx = new Ctor()
+      this.master = this.ctx.createGain()
+      this.master.gain.value = 0.5
+      this.master.connect(this.ctx.destination)
+    } catch (error) {
+      this.failed = true
+      console.warn("[lattice] the audio context could not be created", error)
+    }
+    return this.ctx
+  }
+
+  /** One struck note. `when` is an offset in seconds from now. */
+  private strike(freq: number, gain: number, ms: number, when = 0, kind: OscillatorType = "sine"): void {
+    const ctx = this.context()
+    const master = this.master
+    if (!ctx || !master) return
+    if (this.voices >= MAX_VOICES) return
+    this.voices += 1
+
+    const t = ctx.currentTime + when
+    const env = ctx.createGain()
+    env.connect(master)
+    env.gain.setValueAtTime(0.0001, t)
+    env.gain.exponentialRampToValueAtTime(Math.max(0.0002, gain), t + 0.008)
+    env.gain.exponentialRampToValueAtTime(0.0001, t + ms / 1000)
+
+    const osc = ctx.createOscillator()
+    osc.type = kind
+    osc.frequency.setValueAtTime(freq, t)
+    osc.connect(env)
+    osc.start(t)
+    osc.stop(t + ms / 1000 + 0.02)
+
+    // The felt: a triangle an octave up at a fifth of the gain gives the mallet
+    // its thud without adding a second pitch a child would hear as a chord.
+    const felt = ctx.createOscillator()
+    felt.type = "triangle"
+    felt.frequency.setValueAtTime(freq * 2, t)
+    const feltGain = ctx.createGain()
+    feltGain.gain.setValueAtTime(0.22, t)
+    felt.connect(feltGain)
+    feltGain.connect(env)
+    felt.start(t)
+    felt.stop(t + ms / 1000 + 0.02)
+
+    osc.onended = () => {
+      this.voices = Math.max(0, this.voices - 1)
+      try {
+        env.disconnect()
+      } catch {
+        // A node disconnected twice is not worth a line in a child's console.
+      }
+    }
+  }
+
+  /** A stone chip. Pitched by how far down the tree the split went. */
+  split(depth: number): void {
+    const i = Math.min(PENTATONIC.length - 1, Math.max(0, depth))
+    this.strike((PENTATONIC[i] as number) * 0.5, 0.16, 130, 0, "square")
+  }
+
+  /** A prime refusing a shot: a bell that will not break. */
+  wall(): void {
+    this.strike(1318.5, 0.09, 220, 0, "sine")
+  }
+
+  /** A mote swept: one step up the pentatonic per tile held. */
+  sweep(tiles: number): void {
+    const i = Math.min(PENTATONIC.length - 1, Math.max(0, tiles - 1))
+    this.strike(PENTATONIC[i] as number, 0.13, 180)
+  }
+
+  /** The trigger. Quiet by design — it fires many times a second. */
+  shot(): void {
+    this.strike(196, 0.03, 45, 0, "square")
+  }
+
+  /** A resonator opening: the pentatonic run, one note per prime it took. */
+  open(tiles: number): void {
+    const n = Math.max(2, Math.min(PENTATONIC.length, tiles))
+    for (let i = 0; i < n; i++) {
+      this.strike(PENTATONIC[i] as number, 0.17, 420, i * 0.055)
+    }
+  }
+
+  /** A refusal. Lower, shorter, and quieter than a resonance — never a buzzer. */
+  refuse(): void {
+    this.strike(233.08, 0.1, 190, 0, "triangle")
+  }
+
+  /** A jostle: a mote knocked loose. */
+  jostle(): void {
+    this.strike(155.56, 0.11, 160, 0, "triangle")
+  }
+
+  dispose(): void {
+    const ctx = this.ctx
+    this.ctx = null
+    this.master = null
+    if (!ctx) return
+    void ctx.close().catch((error: unknown) => {
+      console.warn("[lattice] the audio context did not close", error)
+    })
+  }
+}

--- a/dynawalla/games/lattice/src/contract.ts
+++ b/dynawalla/games/lattice/src/contract.ts
@@ -1,0 +1,61 @@
+// The host↔game contract. This is the shape the runtime lands underneath us;
+// it must not drift. Nothing else in this package may redefine these types.
+//
+// `mount` delegates to `./mount.ts`. That module imports `Host` from here
+// type-only, and a type-only import is erased, so there is no runtime cycle.
+
+import { mountLattice } from "./mount.ts"
+
+export type Question = {
+  id: string
+  /** "47 + 25" — the operator glyph is already in it. */
+  prompt: string
+  /** "72" — exact, canonical, and never computed by this game. */
+  answer: string
+  /**
+   * Wrong values a child actually produces: the host's mal-rule outputs first.
+   * THE LATTICE seeds the field so that at least one of them is *reachable* —
+   * its primes are drifting out there too — so a child who drops a carry can
+   * assemble their own mistake and the misconception routes back to the host
+   * with no extra wiring.
+   */
+  distractors: string[]
+  domain: string
+  /** 0..1. A monotone reading of the ladder, not a claim about hardness. */
+  difficulty: number
+}
+
+export type Host = {
+  next(opts?: { domain?: string; difficulty?: number }): Question
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+  haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void
+  prefersReducedMotion(): boolean
+
+  /**
+   * A natural stopping point the child *reached*: a level cleared, a run
+   * completed, a boss down.
+   *
+   * OPTIONAL and feature-detected — a stub host does not implement it and the
+   * game must not care. Fire and forget: nothing is returned, nothing may be
+   * awaited, and the game must not branch on it.
+   *
+   * **Never after a failure.** THE LATTICE calls it when a resonator has been
+   * opened, never when one has refused — a purchase surface next to a mistake
+   * is the thing that is forbidden outright.
+   */
+  transition?(kind: "level" | "run" | "boss", label?: string): void
+}
+
+/**
+ * Mount the game into `el`.
+ *
+ * `pause`/`resume` are part of the surface because the host can put a sheet
+ * over a still-mounted, still-running pack — and this game calls `transition`
+ * every time a resonator opens, so it raises that sheet itself. See `mount.ts`.
+ */
+export function mount(
+  el: HTMLElement,
+  host: Host,
+): { unmount(): void; pause(): void; resume(): void } {
+  return mountLattice(el, host)
+}

--- a/dynawalla/games/lattice/src/core/rng.ts
+++ b/dynawalla/games/lattice/src/core/rng.ts
@@ -1,0 +1,60 @@
+// A seeded, deterministic PRNG. Every stochastic decision in the game and in
+// the stub host runs through one of these so a run can be replayed exactly.
+//
+// mulberry32: 32-bit state, no allocation, and trivially portable into a test.
+
+export class Rng {
+  private s: number
+
+  constructor(seed: number) {
+    // Force to uint32; a 0 seed is legal for mulberry32 but degenerate-looking,
+    // so nudge it off zero.
+    this.s = (seed >>> 0) || 0x9e3779b9
+  }
+
+  /** Uniform in [0, 1). */
+  next(): number {
+    this.s = (this.s + 0x6d2b79f5) >>> 0
+    let t = this.s
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+
+  /** Uniform in [lo, hi). */
+  range(lo: number, hi: number): number {
+    return lo + this.next() * (hi - lo)
+  }
+
+  /** Uniform integer in [lo, hi] inclusive. */
+  int(lo: number, hi: number): number {
+    if (hi <= lo) return lo
+    return lo + Math.floor(this.next() * (hi - lo + 1))
+  }
+
+  /** True with probability p. */
+  chance(p: number): boolean {
+    return this.next() < p
+  }
+
+  pick<T>(xs: readonly T[]): T {
+    if (xs.length === 0) throw new Error("rng.pick: empty")
+    return xs[Math.floor(this.next() * xs.length)] as T
+  }
+
+  /** In-place Fisher–Yates. Returns the same array for chaining. */
+  shuffle<T>(xs: T[]): T[] {
+    for (let i = xs.length - 1; i > 0; i--) {
+      const j = Math.floor(this.next() * (i + 1))
+      const a = xs[i] as T
+      xs[i] = xs[j] as T
+      xs[j] = a
+    }
+    return xs
+  }
+
+  /** Snapshot/restore so a subsystem can be forked without disturbing the run. */
+  fork(salt: number): Rng {
+    return new Rng((this.s ^ Math.imul(salt, 0x85ebca6b)) >>> 0)
+  }
+}

--- a/dynawalla/games/lattice/src/game/arena.ts
+++ b/dynawalla/games/lattice/src/game/arena.ts
@@ -1,0 +1,661 @@
+// THE LATTICE — the rules.
+//
+// Everything a child can do to this game happens through a method on `Arena`,
+// and every method returns the list of things that happened. Nothing in this
+// file draws, measures a canvas, or reads a clock it was not handed; the shell
+// in `mount.ts` owns all three. That split is why the rules are testable
+// without a browser and why the tests in `src/test` are about the mathematics
+// rather than about pixels.
+//
+// The loop, in one paragraph. Composite husks drift on the grid. A shot cracks
+// one along a factor pair — 72 becomes 8 and 9, the 8 becomes 2 and 4, the 4
+// becomes 2 and 2 — and a shot that hits a prime is refused, because a prime
+// does not go. So the field grinds itself down into primes, and primes are what
+// the ship sweeps. What is swept shows in the tile bar as a live factor tree:
+// `2·2·3` under a running 12. In the middle of it all hangs a resonator with a
+// problem on its face, and it opens for one thing only — a hold whose primes
+// multiply to the answer.
+
+import { Bank } from "./bank.ts"
+import type { Host, Question } from "../contract.ts"
+import type { Rng } from "../core/rng.ts"
+import {
+  MOTE_PRIMES,
+  huskify,
+  isPrime,
+  multisetDifference,
+  primeFactors,
+  splitPair,
+} from "./factor.ts"
+import { isAskable, resonate } from "./resonance.ts"
+
+/** The largest value a resonator will ask for. See `resonance.isAskable`. */
+export const MAX_TARGET = 999
+
+/** How many questions to draw looking for one a resonator can honestly ask. */
+const DRAW_ATTEMPTS = 8
+
+/** Radii in arena units. The arena is nominally about 1000 units wide. */
+export const SHIP_R = 15
+export const MOTE_R = 17
+export const HUSK_R = 24
+export const RESONATOR_R = 46
+export const SHOT_R = 5
+
+/** Speeds, in arena units per second. */
+const SHIP_ACCEL = 2600
+const SHIP_DRAG = 4.2
+const SHIP_MAX = 620
+const SHOT_SPEED = 1150
+const SHOT_LIFE_MS = 1400
+const FIRE_COOLDOWN_MS = 110
+const DRIFT_MIN = 30
+const DRIFT_MAX = 110
+
+/** How long a refused resonator stays dim before it will listen again. */
+const REFUSE_COOLDOWN_MS = 900
+
+/** How long the ship is intangible after a jostle, so one bump is one cost. */
+const JOSTLE_GRACE_MS = 700
+
+/**
+ * Where a released mote lands, and how long the ship cannot pick one up.
+ *
+ * Both exist for the same reason, and it is not cosmetic: a mote handed back at
+ * the ship's own position is a mote the ship is already touching, so it is
+ * swept again on the very next frame. Venting would then do nothing at all, a
+ * refusal would hand the same wrong hold straight back, and a jostle would cost
+ * nothing — three separate rules quietly cancelled by one geometry mistake.
+ * So released motes are thrown clear on a ring, moving outward, and the ship's
+ * sweep is deaf for long enough for them to get there.
+ */
+const RELEASE_RADIUS = 96
+const RELEASE_GRACE_MS = 520
+
+export type Vec = { x: number; y: number }
+
+export type Body = {
+  readonly id: number
+  /** The integer on its face. Composite → a husk. Prime → a mote to sweep. */
+  readonly value: number
+  readonly prime: boolean
+  x: number
+  y: number
+  vx: number
+  vy: number
+  /** Set the frame it was born, so the shell can pop it in. */
+  age: number
+}
+
+export type Shot = { id: number; x: number; y: number; vx: number; vy: number; life: number }
+
+export type Resonator = {
+  readonly questionId: string
+  readonly prompt: string
+  readonly target: number
+  x: number
+  y: number
+  vx: number
+  vy: number
+  /** Milliseconds of dim after a refusal. Counts down. */
+  cooldown: number
+  /** Once a resonator has been answered once, the id is spent. */
+  reported: boolean
+  age: number
+}
+
+export type ArenaEvent =
+  | { kind: "split"; at: Vec; from: number; into: readonly [number, number] }
+  | { kind: "wall"; at: Vec; value: number }
+  | { kind: "sweep"; at: Vec; value: number; tiles: readonly number[]; total: number }
+  | { kind: "full"; at: Vec }
+  | { kind: "jostle"; at: Vec; lost: number | null }
+  | { kind: "vent"; at: Vec; count: number }
+  | { kind: "fire"; at: Vec }
+  | { kind: "open"; at: Vec; target: number; tiles: readonly number[] }
+  | { kind: "refuse"; at: Vec; asserted: number; target: number }
+  | { kind: "arrive"; at: Vec; target: number; prompt: string }
+  | { kind: "stalled" }
+
+export type ArenaOptions = { width: number; height: number }
+
+export class Arena {
+  readonly bank = new Bank()
+  ship: Vec & { vx: number; vy: number } = { x: 0, y: 0, vx: 0, vy: 0 }
+  bodies: Body[] = []
+  shots: Shot[] = []
+  resonator: Resonator | null = null
+
+  /** How many resonators the child has opened. The only number worth showing. */
+  opened = 0
+  /** Consecutive resonators opened without a refusal in between. */
+  chain = 0
+  stalled = false
+
+  private width: number
+  private height: number
+  private nextId = 1
+  private aim: Vec = { x: 1, y: 0 }
+  private move: Vec = { x: 0, y: 0 }
+  private cooldownMs = 0
+  private graceMs = 0
+  private sweepGraceMs = 0
+  private paused = false
+  private pausedAt = 0
+  /** Wall-clock mark the current resonator was armed at, shifted over a pause. */
+  private askedAt = 0
+
+  private readonly host: Host
+  private readonly rng: Rng
+
+  constructor(host: Host, rng: Rng, options: ArenaOptions) {
+    this.host = host
+    this.rng = rng
+    this.width = Math.max(320, options.width)
+    this.height = Math.max(320, options.height)
+    this.ship.x = this.width / 2
+    this.ship.y = this.height * 0.72
+  }
+
+  // ── the frame ────────────────────────────────────────────────────────────
+
+  begin(now: number): ArenaEvent[] {
+    return this.arm(now)
+  }
+
+  resize(width: number, height: number): void {
+    this.width = Math.max(320, width)
+    this.height = Math.max(320, height)
+    const clamp = (p: { x: number; y: number }, r: number): void => {
+      p.x = Math.min(Math.max(r, p.x), this.width - r)
+      p.y = Math.min(Math.max(r, p.y), this.height - r)
+    }
+    clamp(this.ship, SHIP_R)
+    for (const b of this.bodies) clamp(b, b.prime ? MOTE_R : HUSK_R)
+    if (this.resonator) clamp(this.resonator, RESONATOR_R)
+  }
+
+  get bounds(): { width: number; height: number } {
+    return { width: this.width, height: this.height }
+  }
+
+  get isPaused(): boolean {
+    return this.paused
+  }
+
+  /**
+   * The host put a sheet over a frame that is still mounted and still running.
+   * Three things stop dead, and each is real damage if it does not: input (a
+   * touch behind the sheet is not something the child did), the resonator's
+   * clock (time behind a sheet is not time spent thinking), and the world.
+   */
+  pause(now: number): void {
+    if (this.paused) return
+    this.paused = true
+    this.pausedAt = now
+  }
+
+  resume(now: number): void {
+    if (!this.paused) return
+    this.paused = false
+    // Shift the mark forward by exactly the sheet, so the latency reported is
+    // still the time the child spent with the problem.
+    this.askedAt += Math.max(0, now - this.pausedAt)
+  }
+
+  // ── input ────────────────────────────────────────────────────────────────
+
+  setMove(x: number, y: number): void {
+    if (this.paused) return
+    const m = Math.hypot(x, y)
+    this.move = m > 1 ? { x: x / m, y: y / m } : { x, y }
+  }
+
+  setAim(x: number, y: number): void {
+    if (this.paused) return
+    const m = Math.hypot(x, y)
+    if (m > 1e-6) this.aim = { x: x / m, y: y / m }
+  }
+
+  get aiming(): Vec {
+    return this.aim
+  }
+
+  fire(): ArenaEvent[] {
+    if (this.paused || this.cooldownMs > 0) return []
+    this.cooldownMs = FIRE_COOLDOWN_MS
+    this.shots.push({
+      id: this.nextId++,
+      x: this.ship.x + this.aim.x * (SHIP_R + 4),
+      y: this.ship.y + this.aim.y * (SHIP_R + 4),
+      vx: this.aim.x * SHOT_SPEED + this.ship.vx * 0.3,
+      vy: this.aim.y * SHOT_SPEED + this.ship.vy * 0.3,
+      life: SHOT_LIFE_MS,
+    })
+    return [{ kind: "fire", at: { x: this.ship.x, y: this.ship.y } }]
+  }
+
+  /**
+   * Everything in the hold goes back on the field as motes.
+   *
+   * The bank is exact, so a child who swept a stray 5 needs a way out that is
+   * not "start again" and is not a penalty. Nothing is destroyed: the primes
+   * come back and can be re-swept, which is also why this is honest — the
+   * factorisation on the bar never becomes a lie about what is on the field.
+   */
+  vent(): ArenaEvent[] {
+    if (this.paused) return []
+    const let_go = this.bank.release()
+    if (let_go.length === 0) return []
+    this.scatter(let_go, this.ship.x, this.ship.y)
+    return [{ kind: "vent", at: { x: this.ship.x, y: this.ship.y }, count: let_go.length }]
+  }
+
+  // ── the three mathematical acts ───────────────────────────────────────────
+
+  /**
+   * A shot lands on a body.
+   *
+   * A composite comes apart along a factor pair — exactly, with the product
+   * conserved. A prime does not: that is the wall, and it has its own event and
+   * its own sound rather than being a silent no-op.
+   */
+  strike(bodyId: number): ArenaEvent[] {
+    if (this.paused) return []
+    const index = this.bodies.findIndex((b) => b.id === bodyId)
+    if (index < 0) return []
+    const body = this.bodies[index] as Body
+    const at = { x: body.x, y: body.y }
+
+    if (body.prime) {
+      // Not a miss and not a failure. The shot shoves the mote — a child who
+      // works this out can herd a 13 across the arena with their gun, which is
+      // the reward for noticing that primes do not go.
+      const m = Math.hypot(body.vx, body.vy) || 1
+      body.vx += (body.vx / m) * 90
+      body.vy += (body.vy / m) * 90
+      return [{ kind: "wall", at, value: body.value }]
+    }
+
+    const pair = splitPair(body.value, this.rng)
+    if (!pair) {
+      // Unreachable: `prime` is exactly `isPrime(value)` and everything else
+      // above 3 has a divisor pair. Loud rather than silent if it ever is not.
+      console.error("[lattice] a composite would not split", body.value)
+      return []
+    }
+    this.bodies.splice(index, 1)
+    const angle = this.rng.range(0, Math.PI * 2)
+    const kick = this.rng.range(70, 150)
+    this.spawnAt(pair[0], body.x, body.y, body.vx + Math.cos(angle) * kick, body.vy + Math.sin(angle) * kick)
+    this.spawnAt(pair[1], body.x, body.y, body.vx - Math.cos(angle) * kick, body.vy - Math.sin(angle) * kick)
+    return [{ kind: "split", at, from: body.value, into: pair }]
+  }
+
+  /**
+   * The ship reaches a body.
+   *
+   * A prime is swept into the hold. A composite is not — it jostles the ship
+   * and shakes one mote loose, which is a cost the child can see and recover
+   * from rather than a loss. Nothing here ends a run.
+   */
+  touch(bodyId: number): ArenaEvent[] {
+    if (this.paused) return []
+    const index = this.bodies.findIndex((b) => b.id === bodyId)
+    if (index < 0) return []
+    const body = this.bodies[index] as Body
+    const at = { x: body.x, y: body.y }
+
+    if (!body.prime) {
+      if (this.graceMs > 0) return []
+      this.graceMs = JOSTLE_GRACE_MS
+      const lost = this.bank.spill()
+      if (lost !== null) this.scatter([lost], body.x, body.y)
+      // Shove both apart so the ship is not held inside the husk.
+      const dx = this.ship.x - body.x
+      const dy = this.ship.y - body.y
+      const m = Math.hypot(dx, dy) || 1
+      this.ship.vx += (dx / m) * 260
+      this.ship.vy += (dy / m) * 260
+      body.vx -= (dx / m) * 120
+      body.vy -= (dy / m) * 120
+      return [{ kind: "jostle", at, lost }]
+    }
+
+    // A mote thrown clear a moment ago is still leaving; the ship is deaf to
+    // it until it has, or a vent and a refusal would both undo themselves.
+    if (this.sweepGraceMs > 0) return []
+
+    if (!this.bank.take(body.value)) {
+      // A full hold is not a failure and must not become a stuck note: the
+      // ship sits inside the mote for as long as it likes, so the refusal is
+      // announced once and then goes quiet.
+      if (this.graceMs > 0) return []
+      this.graceMs = JOSTLE_GRACE_MS
+      return [{ kind: "full", at }]
+    }
+    this.bodies.splice(index, 1)
+    return [
+      {
+        kind: "sweep",
+        at,
+        value: body.value,
+        tiles: this.bank.tiles.slice(),
+        total: this.bank.value,
+      },
+    ]
+  }
+
+  /**
+   * The ship flies into the resonator, asserting the product of its hold.
+   *
+   * This is the only value that crosses to the host, and it is exact: the
+   * product of a set of integers the child chose. The game does not decide
+   * whether it was right — it says what was asserted and the host judges. An
+   * empty hold asserts nothing at all and is not a mistake.
+   */
+  enter(now: number): ArenaEvent[] {
+    if (this.paused) return []
+    const res = this.resonator
+    if (!res || res.cooldown > 0) return []
+    const at = { x: res.x, y: res.y }
+
+    const verdict = resonate(res.target, this.bank.tiles)
+    if (verdict.kind === "silent") return []
+
+    // Once per question. A refusal spends the id — the resonator stays as a
+    // goal the child can still open, but the host hears one answer, which is
+    // the only honest reading of "what did they say when they were asked".
+    if (!res.reported) {
+      res.reported = true
+      this.host.report({
+        questionId: res.questionId,
+        correct: verdict.kind === "open",
+        ms: Math.max(0, Math.round(now - this.askedAt)),
+        answered: String(verdict.asserted),
+      })
+    }
+
+    if (verdict.kind === "refuse") {
+      res.cooldown = REFUSE_COOLDOWN_MS
+      this.chain = 0
+      // The hold comes back onto the field rather than evaporating. The child
+      // keeps every mote they worked for; what they spend is the trip.
+      const back = this.bank.release()
+      this.scatter(back, res.x, res.y)
+      this.host.haptic("light")
+      return [{ kind: "refuse", at, asserted: verdict.asserted, target: res.target }]
+    }
+
+    const tiles = this.bank.release()
+    this.opened += 1
+    this.chain += 1
+    this.host.haptic("success")
+    const events: ArenaEvent[] = [{ kind: "open", at, target: res.target, tiles }]
+    // Only ever after something the child finished. Never after a refusal.
+    this.host.transition?.("level", "resonance")
+    events.push(...this.arm(now))
+    return events
+  }
+
+  // ── the world ────────────────────────────────────────────────────────────
+
+  /**
+   * Advance the world by `dtMs`, resolving collisions into rule calls.
+   *
+   * Behind a sheet nothing moves and nothing is decided — the shell still
+   * draws, because a frozen pack under a translucent host sheet is what a
+   * paused game looks like, but this returns immediately.
+   */
+  step(dtMs: number): ArenaEvent[] {
+    if (this.paused) return []
+    const dt = Math.min(120, Math.max(0, dtMs)) / 1000
+    if (dt === 0) return []
+    const events: ArenaEvent[] = []
+
+    this.cooldownMs = Math.max(0, this.cooldownMs - dtMs)
+    this.graceMs = Math.max(0, this.graceMs - dtMs)
+    this.sweepGraceMs = Math.max(0, this.sweepGraceMs - dtMs)
+    if (this.resonator) {
+      this.resonator.cooldown = Math.max(0, this.resonator.cooldown - dtMs)
+      this.resonator.age += dtMs
+    }
+
+    // The ship.
+    this.ship.vx += this.move.x * SHIP_ACCEL * dt
+    this.ship.vy += this.move.y * SHIP_ACCEL * dt
+    const drag = Math.exp(-SHIP_DRAG * dt)
+    this.ship.vx *= drag
+    this.ship.vy *= drag
+    const speed = Math.hypot(this.ship.vx, this.ship.vy)
+    if (speed > SHIP_MAX) {
+      this.ship.vx = (this.ship.vx / speed) * SHIP_MAX
+      this.ship.vy = (this.ship.vy / speed) * SHIP_MAX
+    }
+    this.ship.x += this.ship.vx * dt
+    this.ship.y += this.ship.vy * dt
+    this.bounce(this.ship, SHIP_R, 0.4)
+
+    // Bodies.
+    for (const body of this.bodies) {
+      body.age += dtMs
+      body.x += body.vx * dt
+      body.y += body.vy * dt
+      this.bounce(body, body.prime ? MOTE_R : HUSK_R, 1)
+      // Drifting husks slow to a readable pace rather than pinballing forever.
+      const s = Math.hypot(body.vx, body.vy)
+      if (s > DRIFT_MAX) {
+        const k = Math.exp(-2.2 * dt)
+        body.vx *= k
+        body.vy *= k
+      } else if (s < DRIFT_MIN && s > 1e-6) {
+        body.vx *= 1 + 1.5 * dt
+        body.vy *= 1 + 1.5 * dt
+      }
+    }
+
+    if (this.resonator) {
+      this.resonator.x += this.resonator.vx * dt
+      this.resonator.y += this.resonator.vy * dt
+      this.bounce(this.resonator, RESONATOR_R, 1)
+    }
+
+    // Shots, and what they hit.
+    for (let i = this.shots.length - 1; i >= 0; i--) {
+      const shot = this.shots[i] as Shot
+      shot.life -= dtMs
+      shot.x += shot.vx * dt
+      shot.y += shot.vy * dt
+      if (
+        shot.life <= 0 ||
+        shot.x < -40 ||
+        shot.y < -40 ||
+        shot.x > this.width + 40 ||
+        shot.y > this.height + 40
+      ) {
+        this.shots.splice(i, 1)
+        continue
+      }
+      const hit = this.bodies.find(
+        (b) => dist2(shot, b) < (SHOT_R + (b.prime ? MOTE_R : HUSK_R)) ** 2,
+      )
+      if (!hit) continue
+      this.shots.splice(i, 1)
+      events.push(...this.strike(hit.id))
+    }
+
+    // The ship, and what it reaches. A copy of the id list, because `touch`
+    // mutates `bodies` and a live iteration would skip its neighbour.
+    for (const id of this.bodies.map((b) => b.id)) {
+      const body = this.bodies.find((b) => b.id === id)
+      if (!body) continue
+      const reach = (SHIP_R + (body.prime ? MOTE_R : HUSK_R)) ** 2
+      if (dist2(this.ship, body) < reach) events.push(...this.touch(id))
+    }
+
+    return events
+  }
+
+  /** Milliseconds the child has had with the current resonator. */
+  elapsed(now: number): number {
+    return Math.max(0, now - this.askedAt)
+  }
+
+  // ── seeding ──────────────────────────────────────────────────────────────
+
+  /**
+   * Draw a question, hang a resonator on it, and stock the field with husks
+   * that come apart into exactly the primes its answer needs — plus the primes
+   * behind one of the host's mal-rule answers, so a child who drops a carry can
+   * assemble their own mistake and the misconception routes back to the host.
+   */
+  private arm(now: number): ArenaEvent[] {
+    this.askedAt = now
+    let question: Question | null = null
+    for (let i = 0; i < DRAW_ATTEMPTS; i++) {
+      const drawn = this.host.next({ domain: "add" })
+      const target = Number(drawn.answer)
+      if (isAskable(target, MAX_TARGET)) {
+        question = drawn
+        break
+      }
+    }
+    if (!question) {
+      // Nothing the resonator could honestly ask for. The arena stays playable
+      // — husks still crack, primes still sweep — and this is loud.
+      this.stalled = true
+      console.error("[lattice] no askable target in", DRAW_ATTEMPTS, "draws")
+      return [{ kind: "stalled" }]
+    }
+    this.stalled = false
+
+    const target = Number(question.answer)
+    const wanted = primeFactors(target)
+    const values = huskify(wanted, this.rng)
+
+    // One reachable mal-rule: the primes it needs that the answer does not
+    // already supply. Kept small, or the field becomes a haystack.
+    const decoy = this.pickDecoy(question, wanted)
+    if (decoy.length > 0) values.push(...huskify(decoy, this.rng))
+
+    // A little chaff, so "sweep only what you need" is a decision rather than
+    // a formality. Never more than three, and always small enough to read.
+    const chaff = this.rng.int(1, 3)
+    for (let i = 0; i < chaff; i++) values.push(this.rng.pick(MOTE_PRIMES.slice(0, 6)))
+
+    this.bodies = []
+    this.shots = []
+    this.rng.shuffle(values)
+    for (const value of values) {
+      const edge = 70
+      const x = this.rng.range(edge, this.width - edge)
+      const y = this.rng.range(edge, this.height * 0.62)
+      this.spawnAt(
+        value,
+        x,
+        y,
+        this.rng.range(-DRIFT_MAX, DRIFT_MAX),
+        this.rng.range(-DRIFT_MAX, DRIFT_MAX),
+      )
+    }
+
+    this.resonator = {
+      questionId: question.id,
+      prompt: question.prompt,
+      target,
+      x: this.width / 2,
+      y: this.height * 0.26,
+      vx: this.rng.range(-26, 26),
+      vy: this.rng.range(-14, 14),
+      cooldown: 0,
+      reported: false,
+      age: 0,
+    }
+
+    return [
+      {
+        kind: "arrive",
+        at: { x: this.resonator.x, y: this.resonator.y },
+        target,
+        prompt: question.prompt,
+      },
+    ]
+  }
+
+  /**
+   * The extra primes one of the host's mal-rule answers needs.
+   *
+   * `[]` when none of them is reachable without turning the field into a
+   * haystack — which is a fine outcome: the child then simply cannot assemble
+   * anything but the answer and whatever the chaff allows.
+   */
+  private pickDecoy(question: Question, wanted: readonly number[]): number[] {
+    for (const raw of question.distractors) {
+      const value = Number(raw)
+      if (!isAskable(value, MAX_TARGET)) continue
+      const extra = multisetDifference(primeFactors(value), wanted)
+      if (extra.length === 0 || extra.length > 3) continue
+      if (extra.some((p) => p > 47)) continue
+      return extra
+    }
+    return []
+  }
+
+  /**
+   * Throw a handful of motes clear of a point, and go deaf to sweeping while
+   * they get there. Every path that hands primes back to the field uses this.
+   */
+  private scatter(values: readonly number[], x: number, y: number): void {
+    this.sweepGraceMs = RELEASE_GRACE_MS
+    const turn = this.rng.range(0, Math.PI * 2)
+    for (let i = 0; i < values.length; i++) {
+      const angle = turn + (i / Math.max(1, values.length)) * Math.PI * 2
+      const px = Math.min(
+        Math.max(MOTE_R, x + Math.cos(angle) * RELEASE_RADIUS),
+        this.width - MOTE_R,
+      )
+      const py = Math.min(
+        Math.max(MOTE_R, y + Math.sin(angle) * RELEASE_RADIUS),
+        this.height - MOTE_R,
+      )
+      const speed = this.rng.range(DRIFT_MIN, DRIFT_MAX)
+      this.spawnAt(values[i] as number, px, py, Math.cos(angle) * speed, Math.sin(angle) * speed)
+    }
+  }
+
+  private spawnAt(value: number, x: number, y: number, vx: number, vy: number): void {
+    this.bodies.push({
+      id: this.nextId++,
+      value,
+      prime: isPrime(value),
+      x,
+      y,
+      vx,
+      vy,
+      age: 0,
+    })
+  }
+
+  private bounce(p: { x: number; y: number; vx: number; vy: number }, r: number, k: number): void {
+    if (p.x < r) {
+      p.x = r
+      p.vx = Math.abs(p.vx) * k
+    } else if (p.x > this.width - r) {
+      p.x = this.width - r
+      p.vx = -Math.abs(p.vx) * k
+    }
+    if (p.y < r) {
+      p.y = r
+      p.vy = Math.abs(p.vy) * k
+    } else if (p.y > this.height - r) {
+      p.y = this.height - r
+      p.vy = -Math.abs(p.vy) * k
+    }
+  }
+}
+
+function dist2(a: { x: number; y: number }, b: { x: number; y: number }): number {
+  const dx = a.x - b.x
+  const dy = a.y - b.y
+  return dx * dx + dy * dy
+}

--- a/dynawalla/games/lattice/src/game/bank.ts
+++ b/dynawalla/games/lattice/src/game/bank.ts
@@ -1,0 +1,81 @@
+// The bank, and the factor tile bar that draws it.
+//
+// The bar is the passive layer made visible: every prime the child has swept,
+// laid out in ascending order with a running product on the end. `2·2·3 = 12`
+// is on screen the whole time the child is holding those three motes, and it
+// changes the instant a fourth arrives.
+//
+// One invariant, and `bank.test.ts` asserts it after every operation on every
+// path: **the tile bar is always a true factorisation of the value it shows.**
+// Every tile is prime, and the product of the tiles is exactly the value. There
+// is no code path — not a spill, not a clear, not a refusal — that can leave
+// the bar reading something that is not true of the number beside it.
+
+import { ascending, isPrime, productOf } from "./factor.ts"
+
+/**
+ * The most motes a child may hold at once.
+ *
+ * Twelve, because the largest target a resonator will ask for is 999 and the
+ * worst case under that is 512 = 2⁹ — nine tiles, with room over for a couple
+ * of stray sweeps before the hold refuses.
+ */
+export const BANK_CAPACITY = 12
+
+export class Bank {
+  private held: number[] = []
+
+  /**
+   * Sweep a prime into the bank. Returns false when it was refused — not a
+   * prime, or the hold is full — and the caller draws that as the mote bouncing
+   * off rather than as anything the child did wrong.
+   */
+  take(prime: number): boolean {
+    if (!isPrime(prime)) return false
+    if (this.held.length >= BANK_CAPACITY) return false
+    this.held.push(prime)
+    this.held.sort((a, b) => a - b)
+    return true
+  }
+
+  /**
+   * Shake one mote loose — what a collision with a drifting husk costs. The
+   * largest one goes, because losing the 13 out of `2·2·13` is a loss the child
+   * can see, and because it keeps the bar from silently becoming a wrong shape.
+   *
+   * Returns the prime that fell out, or `null` when there was nothing to lose.
+   */
+  spill(): number | null {
+    if (this.held.length === 0) return null
+    return this.held.pop() ?? null
+  }
+
+  /** Everything back on the field. Returns what was let go. */
+  release(): number[] {
+    const out = this.held
+    this.held = []
+    return out
+  }
+
+  get tiles(): readonly number[] {
+    return this.held
+  }
+
+  /** The running product. 1 for an empty hold — the multiplicative identity. */
+  get value(): number {
+    return productOf(this.held)
+  }
+
+  get size(): number {
+    return this.held.length
+  }
+
+  get isFull(): boolean {
+    return this.held.length >= BANK_CAPACITY
+  }
+
+  /** The tile bar, as drawn: `2·2·3`. Empty string for an empty hold. */
+  get label(): string {
+    return ascending(this.held).join("·")
+  }
+}

--- a/dynawalla/games/lattice/src/game/best.ts
+++ b/dynawalla/games/lattice/src/game/best.ts
@@ -1,0 +1,63 @@
+// The one number worth remembering: the longest run of resonators opened back
+// to back without a refusal. Not accuracy, not a percentage — a thing that
+// happened.
+//
+// **`localStorage` throws inside a pack frame.** The document is on an opaque
+// origin, so every access is guarded and the value is held in memory as well.
+// A child who plays a whole sitting in a pack frame still sees their best rise;
+// it just does not survive the app being closed, which is a far smaller loss
+// than a game that will not start.
+
+// gitleaks: a dotted string constant assigned to a `*_KEY` name reads as a
+// credential to every secret scanner there is. It is a storage slot name.
+const BEST_SLOT = "dw.lattice.best" // gitleaks:allow
+
+let memory = 0
+let loaded = false
+
+function store(): Storage | null {
+  try {
+    return globalThis.localStorage ?? null
+  } catch (error) {
+    console.warn("[lattice] localStorage is not reachable from this frame", error)
+    return null
+  }
+}
+
+/** The longest chain of resonators opened without a refusal. */
+export function bestChain(): number {
+  if (loaded) return memory
+  loaded = true
+  const slot = store()
+  if (slot) {
+    try {
+      const raw = Number(slot.getItem(BEST_SLOT) ?? "0")
+      if (Number.isFinite(raw) && raw > 0) memory = Math.floor(raw)
+    } catch (error) {
+      console.warn("[lattice] a best could not be read back", error)
+    }
+  }
+  return memory
+}
+
+/** Record a chain. Returns true when it is a new best. */
+export function recordChain(chain: number): boolean {
+  const previous = bestChain()
+  if (chain <= previous) return false
+  memory = chain
+  const slot = store()
+  if (slot) {
+    try {
+      slot.setItem(BEST_SLOT, String(chain))
+    } catch (error) {
+      console.warn("[lattice] a best could not be written", error)
+    }
+  }
+  return true
+}
+
+/** Tests own the module's state; nothing in the game calls this. */
+export function resetBestForTest(): void {
+  memory = 0
+  loaded = false
+}

--- a/dynawalla/games/lattice/src/game/factor.ts
+++ b/dynawalla/games/lattice/src/game/factor.ts
@@ -1,0 +1,159 @@
+// Exact integer factorisation. Every number in this file is an integer and
+// every comparison is between integers; a float never reaches a husk, a bank,
+// a product, or a reported answer.
+//
+// This is the game's *own* mathematics. The host asked "what is 47 + 25". That
+// a 72 can be cracked into 8 and 9, and the 8 into 2 and 4, and the 4 into 2
+// and 2, until only primes are left drifting on the grid, is a thing THE
+// LATTICE does with a trigger finger rather than a question anybody asked.
+// Nothing about the cracking is reported.
+//
+// The one property the whole game stands on: **a prime cannot be split.** A
+// shot that hits a prime is refused, and no amount of sweeping smaller numbers
+// will ever multiply up to it. Primeness is a wall the child hits hundreds of
+// times a session, at speed, with a sound attached.
+
+import type { Rng } from "../core/rng.ts"
+
+/** The largest value a husk may carry, and so the largest resonator target. */
+export const MAX_HUSK = 9999
+
+/** Primes small enough to be drawn as a drifting mote and read at speed. */
+export const MOTE_PRIMES = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47] as const
+
+export function isPrime(n: number): boolean {
+  if (!Number.isInteger(n) || n < 2) return false
+  if (n % 2 === 0) return n === 2
+  for (let d = 3; d * d <= n; d += 2) {
+    if (n % d === 0) return false
+  }
+  return true
+}
+
+/** Prime factors of `n`, ascending, with multiplicity. `[]` for `n < 2`. */
+export function primeFactors(n: number): number[] {
+  if (!Number.isInteger(n) || n < 2) return []
+  const out: number[] = []
+  let m = n
+  while (m % 2 === 0) {
+    out.push(2)
+    m /= 2
+  }
+  for (let p = 3; p * p <= m; p += 2) {
+    while (m % p === 0) {
+      out.push(p)
+      m /= p
+    }
+  }
+  if (m > 1) out.push(m)
+  return out
+}
+
+/** Every `d` with `2 <= d <= n / d` and `n % d === 0`. Ascending. */
+export function divisorPairs(n: number): Array<[number, number]> {
+  const out: Array<[number, number]> = []
+  if (!Number.isInteger(n) || n < 4) return out
+  for (let d = 2; d * d <= n; d++) {
+    if (n % d === 0) out.push([d, n / d])
+  }
+  return out
+}
+
+/**
+ * Crack `n` into two factors, both at least 2, whose product is exactly `n`.
+ *
+ * `null` when `n` is prime or below 4 — that is the wall, and it is the whole
+ * reason this function returns a nullable rather than throwing: the arena asks
+ * every shot the same question and the answer "this one does not go" is an
+ * ordinary answer with its own sound.
+ *
+ * The pair is chosen to be *seeable*: the split nearest the square root first,
+ * so 72 comes apart as 8 × 9 rather than as 2 × 36, and the tree the child
+ * watches is balanced rather than a stalk.
+ */
+export function splitPair(n: number, rng: Rng): [number, number] | null {
+  const pairs = divisorPairs(n)
+  if (pairs.length === 0) return null
+
+  // Rank by how balanced the split is; keep the tidiest third, then pick.
+  const ranked = pairs.slice().sort((x, y) => x[1] / x[0] - y[1] / y[0])
+  const keep = Math.max(1, Math.ceil(ranked.length / 3))
+  const [a, b] = rng.pick(ranked.slice(0, keep)) as [number, number]
+  return rng.chance(0.5) ? [a, b] : [b, a]
+}
+
+/** The product of a list. Exact; every input here is a bounded integer. */
+export function productOf(values: readonly number[]): number {
+  let out = 1
+  for (const v of values) out *= v
+  return out
+}
+
+/** Ascending copy. The bank and the tile bar are always read in this order. */
+export function ascending(values: readonly number[]): number[] {
+  return values.slice().sort((a, b) => a - b)
+}
+
+/** Multiset equality over integers. Order-insensitive, count-sensitive. */
+export function sameMultiset(a: readonly number[], b: readonly number[]): boolean {
+  if (a.length !== b.length) return false
+  const x = ascending(a)
+  const y = ascending(b)
+  for (let i = 0; i < x.length; i++) {
+    if (x[i] !== y[i]) return false
+  }
+  return true
+}
+
+/**
+ * `a` with one copy of each element of `b` removed, where present.
+ * Used to work out which primes a distractor needs that the answer does not.
+ */
+export function multisetDifference(a: readonly number[], b: readonly number[]): number[] {
+  const out = a.slice()
+  for (const v of b) {
+    const at = out.indexOf(v)
+    if (at >= 0) out.splice(at, 1)
+  }
+  return out
+}
+
+/**
+ * Gather a list of primes into husks: composite numbers that, cracked all the
+ * way down, give back exactly those primes and nothing else.
+ *
+ * Guaranteed by `factor.test.ts`: the product of the husks equals the product
+ * of the primes handed in, every husk is an integer in `2..MAX_HUSK`, and
+ * cracking every husk to exhaustion returns the same multiset.
+ *
+ * A husk carries two or three primes when they fit under the cap and one when
+ * they do not — a lone 47 drifting as a prime from the start is not a
+ * degradation, it is the wall standing in plain sight.
+ */
+export function huskify(primes: readonly number[], rng: Rng): number[] {
+  const pool = rng.shuffle(primes.slice())
+  const husks: number[] = []
+  while (pool.length > 0) {
+    const want = pool.length >= 3 && rng.chance(0.35) ? 3 : pool.length >= 2 ? 2 : 1
+    let value = 1
+    let taken = 0
+    while (taken < want && pool.length > 0) {
+      const p = pool[0] as number
+      if (value * p > MAX_HUSK && taken > 0) break
+      if (value * p > MAX_HUSK) {
+        // A single prime larger than the cap cannot happen (targets are capped)
+        // but the guard keeps the loop total rather than infinite.
+        husks.push(p)
+        pool.shift()
+        value = 1
+        taken = 0
+        continue
+      }
+      value *= p
+      pool.shift()
+      taken += 1
+    }
+    if (value > 1) husks.push(value)
+  }
+  return husks
+}

--- a/dynawalla/games/lattice/src/game/resonance.ts
+++ b/dynawalla/games/lattice/src/game/resonance.ts
@@ -1,0 +1,71 @@
+// THE RESONANCE — where the thinking is.
+//
+// The passive layer of this game is absorption: shooting a husk apart, watching
+// 12 become 4 and 3 and then 2 and 2 and 3, sweeping the primes up, seeing the
+// tile bar read `2·2·3` under a running 12. A child gets that hundreds of times
+// a session with sound and colour attached, and it is worth having, but it is
+// not reasoning. Nothing is chosen.
+//
+// The resonator is the choice. It hangs in the lattice carrying a problem the
+// curriculum drew — `47 + 25` — and it opens for exactly one thing: a bank
+// holding a set of primes whose product is the answer. To open it a child has
+// to work out the answer, decide which primes on the field multiply to it,
+// crack the husks that hold those primes and no others, and sweep them and
+// **nothing else**, because the bank is exact. Sweeping a stray 5 on the way
+// past is a real cost — it does not scold, but it does not resonate either.
+//
+// Three properties, each asserted in `resonance.test.ts`:
+//
+//   1. **A target opens only to a genuine prime factorisation of it.** Every
+//      tile prime, product exactly the target. By unique factorisation the bank
+//      is then *the* prime factorisation of the target, not merely one product
+//      that happens to land.
+//   2. **A prime target is a wall.** Nothing assembled out of smaller factors
+//      reaches it; the only bank that opens a prime `p` is the single mote `p`,
+//      which has to be found drifting on the field rather than built.
+//   3. **The empty bank asserts nothing.** Flying through a resonator with an
+//      empty hold is not a wrong answer and is not reported — it is a child
+//      moving through the arena.
+
+import { isPrime, productOf } from "./factor.ts"
+
+export type Resonance =
+  /** The bank was empty. Not an assertion, not a report, not a mistake. */
+  | { readonly kind: "silent" }
+  /** The bank's product is the target and every tile is prime. */
+  | { readonly kind: "open"; readonly asserted: number }
+  /** A genuine assertion that is not the target. Reported; the host judges. */
+  | { readonly kind: "refuse"; readonly asserted: number }
+
+/**
+ * What a bank does when it is carried into a resonator asking for `target`.
+ *
+ * `bank` is the swept primes. The caller owns the invariant that they are
+ * primes — `Bank` refuses anything else — but this checks it anyway, because
+ * "every tile is prime" is half of what "a prime factorisation" means and a
+ * rule that trusts its input is a rule that is not being enforced.
+ */
+export function resonate(target: number, bank: readonly number[]): Resonance {
+  if (bank.length === 0) return { kind: "silent" }
+  const asserted = productOf(bank)
+  if (!bank.every(isPrime)) return { kind: "refuse", asserted }
+  if (!Number.isInteger(target) || target < 2) return { kind: "refuse", asserted }
+  return asserted === target ? { kind: "open", asserted } : { kind: "refuse", asserted }
+}
+
+/** Convenience for the tests and for the arena's scoring: did it open? */
+export function opens(target: number, bank: readonly number[]): boolean {
+  return resonate(target, bank).kind === "open"
+}
+
+/**
+ * A value the resonator can honestly ask for.
+ *
+ * The curriculum serves column arithmetic and its answers include 0 and 1 and
+ * the occasional four-digit sum. A resonator asking for 1 would open to an
+ * empty hold, which is not a question; one asking for 10007 would need a mote
+ * nobody can read. The arena draws again rather than bending the number.
+ */
+export function isAskable(target: number, max: number): boolean {
+  return Number.isInteger(target) && target >= 2 && target <= max
+}

--- a/dynawalla/games/lattice/src/index.ts
+++ b/dynawalla/games/lattice/src/index.ts
@@ -1,0 +1,7 @@
+// The package's public surface: the contract and the mount, and nothing else.
+// A host imports `mount` and hands it an element and a `Host`.
+
+export { mount } from "./contract.ts"
+export type { Host, Question } from "./contract.ts"
+export { createStubHost } from "./stubHost.ts"
+export type { StubHostOptions } from "./stubHost.ts"

--- a/dynawalla/games/lattice/src/main.ts
+++ b/dynawalla/games/lattice/src/main.ts
@@ -1,0 +1,39 @@
+// The dev harness. `npm run dev` serves `index.html`, which loads this: the
+// game mounted against the local stub host, with a running readout of what has
+// been reported so the seam is visible without a runtime underneath it.
+//
+// Nothing in here ships. The pack entry is `pack.ts`.
+
+import { mount } from "./contract.ts"
+import { createStubHost } from "./stubHost.ts"
+
+const root = document.getElementById("app")
+const readout = document.getElementById("readout")
+if (!root) throw new Error("lattice: #app missing")
+
+let asked = 0
+let right = 0
+
+const host = createStubHost({
+  seed: 0x1a771ce,
+  onReport: (r) => {
+    asked += 1
+    if (r.correct) right += 1
+    if (readout) readout.textContent = `host.report → ${right}/${asked}  last "${r.answered}" ${r.ms}ms`
+  },
+  onTransition: (kind, label) => {
+    console.info("[lattice] transition", kind, label ?? "")
+  },
+})
+
+const handle = mount(root, host)
+
+// The harness stands in for the host's sheet, so the pause path is exercised
+// during development rather than first seen on a tablet: `P` raises it.
+let paused = false
+globalThis.addEventListener("keydown", (event) => {
+  if (event.key !== "p" && event.key !== "P") return
+  paused = !paused
+  if (paused) handle.pause()
+  else handle.resume()
+})

--- a/dynawalla/games/lattice/src/mount.ts
+++ b/dynawalla/games/lattice/src/mount.ts
@@ -1,0 +1,368 @@
+// THE LATTICE — the shell. Canvas, clock, twin-stick input, and the wiring
+// from the rules in `game/arena.ts` to the sheet in `sim/grid.ts` and the
+// drawing in `render/scene.ts`.
+//
+// **The pause.** The host can put a sheet — a stopping-point card, a parent
+// gate, a day-pass offer — over a pack that is still mounted and still running,
+// and this game calls `transition` every time a resonator opens, so it raises
+// that sheet itself. Three things have to stop dead, and each is a real bug if
+// it does not:
+//
+//   1. **Input.** A thumb resting on a virtual stick while a sheet is up is not
+//      the child flying. Unguarded, the ship keeps moving, sweeps motes nobody
+//      chose, and can fly through the resonator and assert a product the child
+//      never assembled — reporting an answer to a question they never saw.
+//   2. **The resonator's clock.** The latency reported is meant to be time the
+//      child spent thinking. Time behind a sheet is not that.
+//   3. **The world.** The husks would drift, the sheet would ring out, and the
+//      arena would be a different arena when the sheet came off.
+//
+// `Arena.pause`/`Arena.resume` own 1 and 2 — every rule method returns early
+// while paused, and `resume` shifts the question mark forward by exactly the
+// sheet. The rAF loop here owns 3.
+//
+// **Twin-stick, on every input a child might have.** Left thumb moves, right
+// thumb aims and fires; on a keyboard WASD moves and the arrow keys aim, with
+// the mouse as an alternative aim and its button as the trigger. Tablet and
+// desktop are first-class targets here, not a phone game stretched.
+
+import { Audio } from "./audio/audio.ts"
+import type { Host } from "./contract.ts"
+import { Rng } from "./core/rng.ts"
+import { Arena, type ArenaEvent } from "./game/arena.ts"
+import { bestChain, recordChain } from "./game/best.ts"
+import { Scene } from "./render/scene.ts"
+import { BRASS_LIGHT, CELESTIAL, OXIDE } from "./render/palette.ts"
+import { Grid } from "./sim/grid.ts"
+
+/**
+ * The largest step the clock may take in one frame.
+ *
+ * A backgrounded tab hands back a delta of minutes. Nothing here is on a timer,
+ * so this is about the physics: a two-minute step would teleport every husk
+ * through the sheet and tear the whole lattice at once.
+ */
+const MAX_STEP_MS = 120
+
+/** Grid density. Chosen so a tablet draws about 1,100 struts, not 10,000. */
+const GRID_CELL = 46
+
+/** How far a virtual stick has to travel to be at full deflection. */
+const STICK_RANGE = 64
+
+type Stick = { id: number; ox: number; oy: number; x: number; y: number } | null
+
+export function mountLattice(
+  el: HTMLElement,
+  host: Host,
+): { unmount(): void; pause(): void; resume(): void } {
+  const canvas = document.createElement("canvas")
+  canvas.style.cssText =
+    "position:absolute;inset:0;width:100%;height:100%;display:block;touch-action:none"
+  el.appendChild(canvas)
+
+  const reduced = host.prefersReducedMotion()
+  const seed = (Date.now() ^ 0x1a771ce) >>> 0
+  const scene = new Scene(canvas, reduced)
+  const audio = new Audio()
+  const arena = new Arena(host, new Rng(seed), {
+    width: scene.cssWidth,
+    height: scene.cssHeight,
+  })
+  const grid = new Grid({
+    cols: Math.max(6, Math.round(scene.cssWidth / GRID_CELL)),
+    rows: Math.max(6, Math.round(scene.cssHeight / GRID_CELL)),
+    width: scene.cssWidth,
+    height: scene.cssHeight,
+    reduced,
+  })
+
+  let best = bestChain()
+  let running = true
+  let paused = false
+  let last = 0
+  let frame = 0
+  let firing = false
+  let mouseDown = false
+
+  let moveStick: Stick = null
+  let aimStick: Stick = null
+  const keys = new Set<string>()
+
+  function now(): number {
+    return typeof performance === "object" ? performance.now() : Date.now()
+  }
+
+  const apply = (events: readonly ArenaEvent[]): void => {
+    for (const event of events) {
+      switch (event.kind) {
+        case "split": {
+          grid.impulse(event.at.x, event.at.y, 620, 2.4)
+          scene.split(event.at.x, event.at.y)
+          audio.split(String(event.from).length)
+          host.haptic("light")
+          break
+        }
+        case "wall": {
+          grid.impulse(event.at.x, event.at.y, 180, 1.4)
+          scene.wall(event.at.x, event.at.y)
+          audio.wall()
+          break
+        }
+        case "sweep": {
+          scene.sweep(event.at.x, event.at.y)
+          audio.sweep(event.tiles.length)
+          host.haptic("light")
+          break
+        }
+        case "full": {
+          scene.say("HOLD IS FULL", OXIDE)
+          audio.refuse()
+          break
+        }
+        case "jostle": {
+          grid.impulse(event.at.x, event.at.y, 420, 2)
+          scene.jostle(event.at.x, event.at.y)
+          audio.jostle()
+          host.haptic("medium")
+          break
+        }
+        case "vent": {
+          scene.sweep(arena.ship.x, arena.ship.y)
+          audio.refuse()
+          host.haptic("light")
+          break
+        }
+        case "fire": {
+          audio.shot()
+          break
+        }
+        case "open": {
+          grid.implode(event.at.x, event.at.y, 1400, 7)
+          scene.celebrate(event.at.x, event.at.y, event.tiles)
+          audio.open(event.tiles.length)
+          if (recordChain(arena.chain)) best = arena.chain
+          break
+        }
+        case "refuse": {
+          // Not a scold and not drawn as one. The primes come back on the
+          // field; what it cost was the trip, and that is the whole comment.
+          grid.impulse(event.at.x, event.at.y, 300, 3)
+          scene.refusal(event.at.x, event.at.y)
+          scene.say("NOT YET", OXIDE)
+          audio.refuse()
+          break
+        }
+        case "arrive": {
+          grid.impulse(event.at.x, event.at.y, 260, 5)
+          break
+        }
+        case "stalled": {
+          console.error("[lattice] no askable target; the arena is running without a resonator")
+          break
+        }
+        default:
+          break
+      }
+    }
+  }
+
+  /** Keyboard sticks, folded into the same two vectors the thumbs produce. */
+  const readKeys = (): void => {
+    let mx = 0
+    let my = 0
+    if (keys.has("a") || keys.has("A")) mx -= 1
+    if (keys.has("d") || keys.has("D")) mx += 1
+    if (keys.has("w") || keys.has("W")) my -= 1
+    if (keys.has("s") || keys.has("S")) my += 1
+    let ax = 0
+    let ay = 0
+    if (keys.has("ArrowLeft")) ax -= 1
+    if (keys.has("ArrowRight")) ax += 1
+    if (keys.has("ArrowUp")) ay -= 1
+    if (keys.has("ArrowDown")) ay += 1
+
+    if (moveStick === null) arena.setMove(mx, my)
+    if (aimStick === null && (ax !== 0 || ay !== 0)) arena.setAim(ax, ay)
+
+    // Derived every frame rather than latched, so no input path can leave the
+    // trigger stuck down — a held trigger through a pause is exactly the class
+    // of bug the pause guards exist to prevent.
+    firing = aimStick !== null || mouseDown || keys.has(" ") || ax !== 0 || ay !== 0
+  }
+
+  const tick = (t: number): void => {
+    if (!running) return
+    frame = requestAnimationFrame(tick)
+    const dt = last === 0 ? 16 : Math.min(MAX_STEP_MS, t - last)
+    last = t
+
+    // Behind a sheet the arena holds its shape. The frame is still drawn — a
+    // frozen pack under a translucent host sheet is what a paused game looks
+    // like — but nothing moves and nothing is decided.
+    if (!paused) {
+      readKeys()
+      if (firing) apply(arena.fire())
+      apply(arena.step(dt))
+      grid.step(dt)
+      scene.advance(dt)
+    }
+    scene.draw(arena, grid, { best, paused, stalled: arena.stalled })
+  }
+
+  // ── pointers ─────────────────────────────────────────────────────────────
+
+  const at = (event: PointerEvent): { x: number; y: number } => {
+    const rect = canvas.getBoundingClientRect()
+    return { x: event.clientX - rect.left, y: event.clientY - rect.top }
+  }
+
+  const down = (event: PointerEvent): void => {
+    event.preventDefault()
+    if (paused) return
+    audio.resume()
+    const p = at(event)
+
+    // Tapping your own hold lets it go. The bank is exact, so a child who swept
+    // a stray 5 needs a way out that is not "start again" — and nothing is
+    // destroyed: the motes go back on the field.
+    if (scene.hitsTileBar(p.x, p.y)) {
+      apply(arena.vent())
+      return
+    }
+
+    // A mouse is not a thumb. On a desktop the cursor is the right stick and
+    // the button is the trigger; WASD is the left stick. Making a mouse drag a
+    // virtual stick would fight the pointer the child is already aiming with.
+    if (event.pointerType === "mouse") {
+      mouseDown = true
+      arena.setAim(p.x - arena.ship.x, p.y - arena.ship.y)
+      return
+    }
+
+    if (p.x < scene.cssWidth / 2 && moveStick === null) {
+      moveStick = { id: event.pointerId, ox: p.x, oy: p.y, x: p.x, y: p.y }
+      canvas.setPointerCapture(event.pointerId)
+      return
+    }
+    if (aimStick === null) {
+      aimStick = { id: event.pointerId, ox: p.x, oy: p.y, x: p.x, y: p.y }
+      canvas.setPointerCapture(event.pointerId)
+    }
+  }
+
+  const move = (event: PointerEvent): void => {
+    if (paused) return
+    const p = at(event)
+    if (moveStick && moveStick.id === event.pointerId) {
+      moveStick.x = p.x
+      moveStick.y = p.y
+      arena.setMove((p.x - moveStick.ox) / STICK_RANGE, (p.y - moveStick.oy) / STICK_RANGE)
+      return
+    }
+    if (aimStick && aimStick.id === event.pointerId) {
+      aimStick.x = p.x
+      aimStick.y = p.y
+      const dx = p.x - aimStick.ox
+      const dy = p.y - aimStick.oy
+      if (Math.hypot(dx, dy) > 6) arena.setAim(dx, dy)
+      return
+    }
+    // A mouse with no button down still aims.
+    if (event.pointerType === "mouse") {
+      arena.setAim(p.x - arena.ship.x, p.y - arena.ship.y)
+    }
+  }
+
+  const up = (event: PointerEvent): void => {
+    if (event.pointerType === "mouse") mouseDown = false
+    if (moveStick && moveStick.id === event.pointerId) {
+      moveStick = null
+      arena.setMove(0, 0)
+    }
+    if (aimStick && aimStick.id === event.pointerId) aimStick = null
+    try {
+      canvas.releasePointerCapture(event.pointerId)
+    } catch {
+      // A capture the browser already dropped is not an error.
+    }
+  }
+
+  const keyDown = (event: KeyboardEvent): void => {
+    if (paused || event.repeat) return
+    keys.add(event.key)
+    if (event.key === " ") {
+      event.preventDefault()
+      audio.resume()
+    }
+    if (event.key === "Escape") apply(arena.vent())
+    if (event.key.startsWith("Arrow")) event.preventDefault()
+  }
+
+  const keyUp = (event: KeyboardEvent): void => {
+    keys.delete(event.key)
+  }
+
+  const resize = (): void => {
+    const box = scene.resize()
+    arena.resize(box.width, box.height)
+    grid.resize(box.width, box.height)
+  }
+
+  canvas.addEventListener("pointerdown", down)
+  canvas.addEventListener("pointermove", move)
+  canvas.addEventListener("pointerup", up)
+  canvas.addEventListener("pointercancel", up)
+  globalThis.addEventListener("keydown", keyDown)
+  globalThis.addEventListener("keyup", keyUp)
+  globalThis.addEventListener("resize", resize)
+
+  const observer =
+    typeof ResizeObserver === "function" ? new ResizeObserver(() => resize()) : null
+  observer?.observe(el)
+
+  resize()
+  scene.say("SHOOT WHAT SPLITS", CELESTIAL)
+  apply(arena.begin(now()))
+  frame = requestAnimationFrame(tick)
+
+  return {
+    pause(): void {
+      if (paused) return
+      paused = true
+      arena.pause(now())
+      // Whatever the thumbs were doing, they are not doing it any more. Left
+      // set, a resting thumb would fly the ship through the resonator behind
+      // the sheet and assert a product nobody assembled.
+      moveStick = null
+      aimStick = null
+      firing = false
+      mouseDown = false
+      keys.clear()
+      scene.say("PAUSED", BRASS_LIGHT)
+    },
+    resume(): void {
+      if (!paused) return
+      paused = false
+      arena.resume(now())
+      // The next frame computes its delta from `last`, set before the sheet
+      // went up. Forget it, or the first frame back is a whole sheet's worth of
+      // drift and springs in one step.
+      last = 0
+    },
+    unmount(): void {
+      running = false
+      cancelAnimationFrame(frame)
+      canvas.removeEventListener("pointerdown", down)
+      canvas.removeEventListener("pointermove", move)
+      canvas.removeEventListener("pointerup", up)
+      canvas.removeEventListener("pointercancel", up)
+      globalThis.removeEventListener("keydown", keyDown)
+      globalThis.removeEventListener("keyup", keyUp)
+      globalThis.removeEventListener("resize", resize)
+      observer?.disconnect()
+      audio.dispose()
+      scene.dispose()
+    },
+  }
+}

--- a/dynawalla/games/lattice/src/pack.ts
+++ b/dynawalla/games/lattice/src/pack.ts
@@ -1,0 +1,66 @@
+// THE LATTICE, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous surface `Host` in
+// `contract.ts` already describes — so the arena, the sheet, the bank and the
+// resonance rule are untouched.
+//
+// What crosses the boundary is the resonator. It carries a problem the
+// curriculum drew, the host reveals its canonical value, and that value becomes
+// the product the child has to assemble out of primes. The value reported back
+// is the product of the primes they were holding when they flew into it — an
+// exact integer the host can judge, and usually the child's own mal-rule rather
+// than noise, because the field is seeded so one of the host's mal-rule answers
+// is assemblable too.
+//
+// Cracking 72 into 8 and 9 and then into 2·2·2·3·3 is the game's own
+// mathematics — a thing the child performs with a trigger rather than a
+// question anybody asked — so nothing about the cracking is reported.
+//
+// `items.reveal` is declared and it is load-bearing: without the canonical
+// value the adapter drops every item, and the pack mounts and warms and serves
+// no questions at all, with nothing failing anywhere.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import { mount } from "./contract.ts"
+import type { Host } from "./contract.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("lattice: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "add" })
+  // Stocked before the first frame: the arena arms a resonator the instant it
+  // mounts, and a resonator with a blank face is the kind of thing that happens
+  // exactly once, on launch, in front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context come down before the frame does rather than a frame or two after.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+
+  // A transition can put a sheet over the frame, and the SDK documents that the
+  // pack keeps running underneath it. THE LATTICE calls `transition` every time
+  // a resonator opens, so this is routine rather than hypothetical — and
+  // unguarded it is the worst bug this game could have: a thumb resting on a
+  // virtual stick behind the sheet flies the ship on, sweeps motes nobody
+  // chose, and can assert a product at a resonator the child never saw.
+  //
+  // These two handlers are the whole subscription. `handle.pause()` is inert
+  // until something calls it.
+  mounted.client.on("pause", () => {
+    handle.pause()
+  })
+  mounted.client.on("resume", () => {
+    handle.resume()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[lattice] could not start", error)
+  renderNoHost(root, "THE LATTICE")
+})

--- a/dynawalla/games/lattice/src/render/palette.ts
+++ b/dynawalla/games/lattice/src/render/palette.ts
@@ -1,0 +1,57 @@
+// The material palette. Brass, lapis, carved stone, cold celestial light —
+// al-Jazari's workshop rather than a neon arcade. The colours here are pigments
+// and metals, never lighting effects: no purple-to-teal gradient, no glow that
+// is not something incandescing.
+//
+// Two families do all the work:
+//
+//   * **Stone and brass** for composites. A husk is a carved block with its
+//     numeral cut into it; it is inert until it is shot.
+//   * **Cold celestial** for primes. A prime is the thing that will not go, and
+//     it is the only light in the arena that is its own. That is not decoration
+//     — the child learns to read "this one is lit" as "this one is prime" long
+//     before they could define the word.
+
+export const VOID = "#050810"
+export const VOID_HI = "#0a1020"
+
+/** The sheet. Struts at rest, and a strut that has let go. */
+export const STRUT = "rgba(84,116,168,0.30)"
+export const STRUT_HOT = "rgba(126,170,232,0.72)"
+export const STRUT_TORN = "rgba(214,138,74,0.85)"
+
+/** Carved stone: a composite husk. */
+export const STONE = "#2b3242"
+export const STONE_EDGE = "#4a5568"
+export const STONE_INK = "#cfd8e6"
+
+/** Brass: the ship, the resonator's ring, the tile bar's frame. */
+export const BRASS = "#c9a227"
+export const BRASS_DIM = "#8c7320"
+export const BRASS_LIGHT = "#f0d878"
+
+/** Cold celestial: a prime mote, and everything primeness touches. */
+export const CELESTIAL = "#8fd8ff"
+export const CELESTIAL_DIM = "#3f7ea0"
+export const CELESTIAL_INK = "#04121c"
+
+/** Lapis: the resonator's core, and the sheet where it is listening. */
+export const LAPIS = "#1e3a8a"
+export const LAPIS_LIGHT = "#4c6ef5"
+
+/** Copper oxide: a refusal. Never red, never a buzzer colour. */
+export const OXIDE = "#9c6b3f"
+
+export const INK = "#e8e2d6"
+export const INK_DIM = "rgba(232,226,214,0.52)"
+
+/** The numeral face. Tabular so a 2 and a 13 do not shift the layout. */
+export const NUMERAL = "600 __PX__px/1 ui-monospace, SFMono-Regular, Menlo, monospace"
+
+export function numeralFont(px: number): string {
+  return NUMERAL.replace("__PX__", String(Math.round(px)))
+}
+
+export function chromeFont(px: number, weight = 500): string {
+  return `${weight} ${Math.round(px)}px/1.2 system-ui, -apple-system, "Segoe UI", sans-serif`
+}

--- a/dynawalla/games/lattice/src/render/particles.ts
+++ b/dynawalla/games/lattice/src/render/particles.ts
@@ -1,0 +1,89 @@
+// Sparks. A fixed pool, because a game that allocates in its draw loop is a
+// game that stutters on a mid-range tablet halfway through a session.
+//
+// The vocabulary is deliberately mechanical: chips off carved stone, a filing
+// struck off brass. Not confetti and not a starburst — the hostile reference
+// board in the experience design names both, and this is where they would get
+// in.
+
+export type Spark = {
+  x: number
+  y: number
+  vx: number
+  vy: number
+  life: number
+  max: number
+  size: number
+  hue: string
+}
+
+const POOL = 320
+
+export class Sparks {
+  private readonly pool: Spark[] = []
+  private cursor = 0
+
+  private reduced: boolean
+
+  constructor(reduced: boolean) {
+    this.reduced = reduced
+    for (let i = 0; i < POOL; i++) {
+      this.pool.push({ x: 0, y: 0, vx: 0, vy: 0, life: 0, max: 1, size: 1, hue: "#fff" })
+    }
+  }
+
+  setReduced(reduced: boolean): void {
+    this.reduced = reduced
+    if (reduced) for (const s of this.pool) s.life = 0
+  }
+
+  /**
+   * Throw `count` chips. Under reduced motion this is a third as many, a third
+   * as fast and half as long-lived — present, so the moment still has an
+   * edge, but with nothing travelling far enough to be a distraction.
+   */
+  burst(x: number, y: number, count: number, speed: number, hue: string, size = 2.4): void {
+    const n = this.reduced ? Math.max(2, Math.round(count / 3)) : count
+    const v = this.reduced ? speed * 0.28 : speed
+    const life = this.reduced ? 220 : 520
+    for (let i = 0; i < n; i++) {
+      const s = this.pool[this.cursor] as Spark
+      this.cursor = (this.cursor + 1) % POOL
+      const a = Math.random() * Math.PI * 2
+      const m = v * (0.4 + Math.random() * 0.6)
+      s.x = x
+      s.y = y
+      s.vx = Math.cos(a) * m
+      s.vy = Math.sin(a) * m
+      s.max = life * (0.6 + Math.random() * 0.6)
+      s.life = s.max
+      s.size = size
+      s.hue = hue
+    }
+  }
+
+  step(dtMs: number): void {
+    const dt = Math.min(120, dtMs) / 1000
+    const drag = Math.exp(-3.4 * dt)
+    for (const s of this.pool) {
+      if (s.life <= 0) continue
+      s.life -= dtMs
+      s.x += s.vx * dt
+      s.y += s.vy * dt
+      s.vx *= drag
+      s.vy *= drag
+    }
+  }
+
+  draw(ctx: CanvasRenderingContext2D): void {
+    for (const s of this.pool) {
+      if (s.life <= 0) continue
+      const t = s.life / s.max
+      ctx.globalAlpha = Math.max(0, Math.min(1, t))
+      ctx.fillStyle = s.hue
+      const r = s.size * (0.4 + t * 0.6)
+      ctx.fillRect(s.x - r, s.y - r, r * 2, r * 2)
+    }
+    ctx.globalAlpha = 1
+  }
+}

--- a/dynawalla/games/lattice/src/render/scene.ts
+++ b/dynawalla/games/lattice/src/render/scene.ts
@@ -1,0 +1,508 @@
+// The shell's drawing. Canvas 2D, one pass, no allocation in the hot loop
+// beyond what the browser does for a path.
+//
+// The arena's coordinate space *is* CSS pixel space — `mount.ts` resizes the
+// arena to the element — so there is no camera and no transform to get wrong.
+// The device pixel ratio is applied once, to the context, at resize.
+//
+// What is drawn, back to front: the sheet, the resonator, the bodies, the
+// shots, the ship, the sparks, and then the chrome — the factor tile bar, which
+// is the whole passive layer made legible and is never allowed to be covered by
+// anything.
+
+import type { Arena, Body, Resonator } from "../game/arena.ts"
+import { HUSK_R, MOTE_R, RESONATOR_R, SHIP_R, SHOT_R } from "../game/arena.ts"
+import type { Grid } from "../sim/grid.ts"
+import { Sparks } from "./particles.ts"
+import {
+  BRASS,
+  BRASS_LIGHT,
+  CELESTIAL,
+  CELESTIAL_DIM,
+  CELESTIAL_INK,
+  INK,
+  INK_DIM,
+  LAPIS,
+  LAPIS_LIGHT,
+  OXIDE,
+  STONE,
+  STONE_EDGE,
+  STONE_INK,
+  STRUT,
+  STRUT_HOT,
+  STRUT_TORN,
+  VOID,
+  VOID_HI,
+  chromeFont,
+  numeralFont,
+} from "./palette.ts"
+
+export type Banner = { text: string; tint: string; age: number }
+
+const BANNER_MS = 1400
+
+export class Scene {
+  private ctx: CanvasRenderingContext2D
+  private dpr = 1
+  cssWidth = 0
+  cssHeight = 0
+  readonly sparks: Sparks
+  banner: Banner | null = null
+  /** Screen shake, in pixels. Zero forever under reduced motion. */
+  private shake = 0
+  /**
+   * Where the tile bar was last drawn. Tapping your own hold is how you let it
+   * go, so the shell needs the rectangle and the bar is the only thing that
+   * knows where it ended up.
+   */
+  private barRect = { x: 0, y: 0, w: 0, h: 0 }
+
+  private readonly canvas: HTMLCanvasElement
+  private reduced: boolean
+
+  constructor(canvas: HTMLCanvasElement, reduced: boolean) {
+    this.canvas = canvas
+    this.reduced = reduced
+    const ctx = canvas.getContext("2d", { alpha: false })
+    if (!ctx) throw new Error("lattice: no 2d context")
+    this.ctx = ctx
+    this.sparks = new Sparks(reduced)
+    this.resize()
+  }
+
+  setReduced(reduced: boolean): void {
+    this.reduced = reduced
+    this.sparks.setReduced(reduced)
+    if (reduced) this.shake = 0
+  }
+
+  resize(): { width: number; height: number } {
+    const rect = this.canvas.getBoundingClientRect()
+    this.cssWidth = Math.max(320, Math.round(rect.width || 800))
+    this.cssHeight = Math.max(320, Math.round(rect.height || 600))
+    this.dpr = Math.min(2.5, globalThis.devicePixelRatio || 1)
+    this.canvas.width = Math.round(this.cssWidth * this.dpr)
+    this.canvas.height = Math.round(this.cssHeight * this.dpr)
+    this.ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0)
+    return { width: this.cssWidth, height: this.cssHeight }
+  }
+
+  /** A knock felt through the frame. Under reduced motion it is not felt. */
+  knock(amount: number): void {
+    if (this.reduced) return
+    this.shake = Math.min(14, this.shake + amount)
+  }
+
+  say(text: string, tint: string): void {
+    this.banner = { text, tint, age: 0 }
+  }
+
+  advance(dtMs: number): void {
+    this.sparks.step(dtMs)
+    this.shake *= Math.exp(-0.009 * dtMs)
+    if (this.shake < 0.15) this.shake = 0
+    if (this.banner) {
+      this.banner.age += dtMs
+      if (this.banner.age > BANNER_MS) this.banner = null
+    }
+  }
+
+  draw(arena: Arena, grid: Grid, state: { best: number; paused: boolean; stalled: boolean }): void {
+    const ctx = this.ctx
+    const w = this.cssWidth
+    const h = this.cssHeight
+
+    ctx.save()
+    if (this.shake > 0) {
+      ctx.translate((Math.random() - 0.5) * this.shake, (Math.random() - 0.5) * this.shake)
+    }
+
+    // The void, with a cold wash where the resonator is listening.
+    ctx.fillStyle = VOID
+    ctx.fillRect(-20, -20, w + 40, h + 40)
+    if (arena.resonator) {
+      const g = ctx.createRadialGradient(
+        arena.resonator.x,
+        arena.resonator.y,
+        0,
+        arena.resonator.x,
+        arena.resonator.y,
+        Math.max(w, h) * 0.55,
+      )
+      g.addColorStop(0, VOID_HI)
+      g.addColorStop(1, VOID)
+      ctx.fillStyle = g
+      ctx.fillRect(-20, -20, w + 40, h + 40)
+    }
+
+    this.drawGrid(grid)
+    if (arena.resonator) this.drawResonator(arena.resonator, arena.ship)
+    for (const body of arena.bodies) this.drawBody(body)
+
+    ctx.fillStyle = BRASS_LIGHT
+    for (const shot of arena.shots) {
+      ctx.beginPath()
+      ctx.arc(shot.x, shot.y, SHOT_R, 0, Math.PI * 2)
+      ctx.fill()
+    }
+
+    this.drawShip(arena)
+    this.sparks.draw(ctx)
+    ctx.restore()
+
+    this.drawTileBar(arena)
+    this.drawStatus(arena, state)
+    if (state.paused) this.drawSheet()
+  }
+
+  // ── the sheet ────────────────────────────────────────────────────────────
+
+  private drawGrid(grid: Grid): void {
+    const ctx = this.ctx
+    ctx.lineWidth = 1
+    // Two passes so the torn struts sit on top of the intact ones and read as
+    // a seam rather than as noise mixed through the weave.
+    ctx.strokeStyle = STRUT
+    ctx.beginPath()
+    for (let s = 0; s < grid.struts; s++) {
+      if ((grid.strutTorn[s] as number) > 0) continue
+      const a = grid.strutA[s] as number
+      const b = grid.strutB[s] as number
+      const ax = grid.x[a] as number
+      const ay = grid.y[a] as number
+      const bx = grid.x[b] as number
+      const by = grid.y[b] as number
+      const stretch = Math.abs(
+        (Math.hypot(bx - ax, by - ay) - (grid.strutRest[s] as number)) /
+          (grid.strutRest[s] as number),
+      )
+      if (stretch > 0.12) continue
+      ctx.moveTo(ax, ay)
+      ctx.lineTo(bx, by)
+    }
+    ctx.stroke()
+
+    // Struts under load light up: this is where the sheet is carrying the news.
+    ctx.strokeStyle = STRUT_HOT
+    ctx.beginPath()
+    for (let s = 0; s < grid.struts; s++) {
+      if ((grid.strutTorn[s] as number) > 0) continue
+      const a = grid.strutA[s] as number
+      const b = grid.strutB[s] as number
+      const ax = grid.x[a] as number
+      const ay = grid.y[a] as number
+      const bx = grid.x[b] as number
+      const by = grid.y[b] as number
+      const stretch = Math.abs(
+        (Math.hypot(bx - ax, by - ay) - (grid.strutRest[s] as number)) /
+          (grid.strutRest[s] as number),
+      )
+      if (stretch <= 0.12) continue
+      ctx.moveTo(ax, ay)
+      ctx.lineTo(bx, by)
+    }
+    ctx.stroke()
+
+    // The tear. Two stubs with nothing between them — the sheet is open here.
+    ctx.strokeStyle = STRUT_TORN
+    ctx.lineWidth = 1.6
+    ctx.beginPath()
+    for (let s = 0; s < grid.struts; s++) {
+      const torn = grid.strutTorn[s] as number
+      if (torn <= 0) continue
+      const a = grid.strutA[s] as number
+      const b = grid.strutB[s] as number
+      const ax = grid.x[a] as number
+      const ay = grid.y[a] as number
+      const bx = grid.x[b] as number
+      const by = grid.y[b] as number
+      ctx.moveTo(ax, ay)
+      ctx.lineTo(ax + (bx - ax) * 0.3, ay + (by - ay) * 0.3)
+      ctx.moveTo(bx, by)
+      ctx.lineTo(bx + (ax - bx) * 0.3, by + (ay - by) * 0.3)
+    }
+    ctx.stroke()
+    ctx.lineWidth = 1
+  }
+
+  // ── the bodies ───────────────────────────────────────────────────────────
+
+  private drawBody(body: Body): void {
+    const ctx = this.ctx
+    const pop = Math.min(1, body.age / 160)
+    const r = (body.prime ? MOTE_R : HUSK_R) * (0.6 + 0.4 * pop)
+
+    if (body.prime) {
+      // A prime is the only thing in the arena that is its own light source.
+      ctx.beginPath()
+      for (let i = 0; i < 6; i++) {
+        const a = (i / 6) * Math.PI * 2 - Math.PI / 2
+        const x = body.x + Math.cos(a) * r
+        const y = body.y + Math.sin(a) * r
+        if (i === 0) ctx.moveTo(x, y)
+        else ctx.lineTo(x, y)
+      }
+      ctx.closePath()
+      ctx.fillStyle = CELESTIAL
+      ctx.fill()
+      ctx.strokeStyle = CELESTIAL_DIM
+      ctx.lineWidth = 2
+      ctx.stroke()
+      ctx.fillStyle = CELESTIAL_INK
+      ctx.font = numeralFont(r * 1.05)
+      ctx.textAlign = "center"
+      ctx.textBaseline = "middle"
+      ctx.fillText(String(body.value), body.x, body.y + 1)
+      return
+    }
+
+    // A composite is carved stone: inert, and waiting to be opened.
+    ctx.save()
+    ctx.translate(body.x, body.y)
+    ctx.beginPath()
+    const k = r * 0.82
+    ctx.rect(-k, -k, k * 2, k * 2)
+    ctx.fillStyle = STONE
+    ctx.fill()
+    ctx.strokeStyle = STONE_EDGE
+    ctx.lineWidth = 2
+    ctx.stroke()
+    ctx.fillStyle = STONE_INK
+    const digits = String(body.value).length
+    ctx.font = numeralFont((k * 1.5) / Math.max(1, digits * 0.62))
+    ctx.textAlign = "center"
+    ctx.textBaseline = "middle"
+    ctx.fillText(String(body.value), 0, 1)
+    ctx.restore()
+  }
+
+  private drawShip(arena: Arena): void {
+    const ctx = this.ctx
+    const aim = arena.aiming
+    const a = Math.atan2(aim.y, aim.x)
+    ctx.save()
+    ctx.translate(arena.ship.x, arena.ship.y)
+    ctx.rotate(a)
+    ctx.beginPath()
+    ctx.moveTo(SHIP_R * 1.35, 0)
+    ctx.lineTo(-SHIP_R * 0.85, SHIP_R * 0.85)
+    ctx.lineTo(-SHIP_R * 0.35, 0)
+    ctx.lineTo(-SHIP_R * 0.85, -SHIP_R * 0.85)
+    ctx.closePath()
+    ctx.fillStyle = BRASS
+    ctx.fill()
+    ctx.strokeStyle = BRASS_LIGHT
+    ctx.lineWidth = 1.5
+    ctx.stroke()
+    ctx.restore()
+  }
+
+  private drawResonator(res: Resonator, ship: { x: number; y: number }): void {
+    const ctx = this.ctx
+    const listening = res.cooldown <= 0
+    const pulse = this.reduced ? 0 : Math.sin(res.age / 420) * 2.6
+    const r = RESONATOR_R + pulse
+
+    ctx.save()
+    ctx.translate(res.x, res.y)
+
+    ctx.beginPath()
+    ctx.arc(0, 0, r, 0, Math.PI * 2)
+    ctx.fillStyle = listening ? LAPIS : "#241f1a"
+    ctx.fill()
+    ctx.lineWidth = 5
+    ctx.strokeStyle = listening ? BRASS : OXIDE
+    ctx.stroke()
+
+    // A second ring that closes as the *ship* nears, not as the hold nears.
+    //
+    // This started out as a proximity ring on the value — it filled as the
+    // hold's product approached the target and went gold when it matched. That
+    // is the comparison the child is here to make. A ring that makes it for
+    // them turns "work out 47 + 25, then work out which primes reach 72" into
+    // "sweep until the light goes gold", and the whole reasoning layer is gone
+    // with nothing failing anywhere. So the only instrument for comparing is
+    // the child's own tile bar against the answer they worked out, and this
+    // ring says nothing about arithmetic at all.
+    if (listening) {
+      const near = Math.max(0, Math.min(1, 1 - Math.hypot(ship.x - res.x, ship.y - res.y) / 380))
+      if (near > 0.01) {
+        ctx.beginPath()
+        ctx.arc(0, 0, r + 9, -Math.PI / 2, -Math.PI / 2 + near * Math.PI * 2)
+        ctx.strokeStyle = LAPIS_LIGHT
+        ctx.lineWidth = 3
+        ctx.stroke()
+      }
+    }
+
+    ctx.fillStyle = listening ? INK : INK_DIM
+    ctx.font = numeralFont(Math.min(26, (r * 1.7) / Math.max(3, res.prompt.length * 0.5)))
+    ctx.textAlign = "center"
+    ctx.textBaseline = "middle"
+    ctx.fillText(res.prompt, 0, 0)
+    ctx.restore()
+  }
+
+  // ── the chrome ───────────────────────────────────────────────────────────
+
+  /**
+   * The factor tile bar. This is the passive layer and it is the reason the
+   * game teaches anything at all when nobody is trying: `2·2·3` sitting under a
+   * running 12, changing the instant a mote is swept.
+   */
+  private drawTileBar(arena: Arena): void {
+    const ctx = this.ctx
+    const tiles = arena.bank.tiles
+    const h = this.cssHeight
+    const w = this.cssWidth
+    const size = Math.max(26, Math.min(40, w / 16))
+    const gap = size * 0.22
+    const dotW = size * 0.5
+    const y = h - size * 1.5
+
+    const total = tiles.length * size + Math.max(0, tiles.length - 1) * dotW
+    const valueText = tiles.length === 0 ? "" : `= ${arena.bank.value}`
+    ctx.font = chromeFont(size * 0.8, 600)
+    const valueW = valueText === "" ? 0 : ctx.measureText(valueText).width + gap * 2
+    const left = (w - (total + valueW)) / 2
+    let x = left
+    // A 44px minimum hit zone around the bar, per the touch-target rule — the
+    // bar is small type and the tap that drops a hold must not be fiddly.
+    this.barRect =
+      tiles.length === 0
+        ? { x: 0, y: 0, w: 0, h: 0 }
+        : {
+            x: left - 12,
+            y: y - Math.max(22, size),
+            w: total + valueW + 24,
+            h: Math.max(44, size * 2),
+          }
+
+    ctx.textAlign = "center"
+    ctx.textBaseline = "middle"
+    for (let i = 0; i < tiles.length; i++) {
+      const value = tiles[i] as number
+      ctx.beginPath()
+      ctx.rect(x, y - size / 2, size, size)
+      ctx.fillStyle = CELESTIAL
+      ctx.fill()
+      ctx.strokeStyle = CELESTIAL_DIM
+      ctx.lineWidth = 2
+      ctx.stroke()
+      ctx.fillStyle = CELESTIAL_INK
+      ctx.font = numeralFont(size * 0.62)
+      ctx.fillText(String(value), x + size / 2, y + 1)
+      x += size
+      if (i < tiles.length - 1) {
+        ctx.fillStyle = INK_DIM
+        ctx.font = chromeFont(size * 0.7, 700)
+        ctx.fillText("·", x + dotW / 2, y)
+        x += dotW
+      }
+    }
+    if (valueText !== "") {
+      ctx.fillStyle = BRASS_LIGHT
+      ctx.font = chromeFont(size * 0.8, 600)
+      ctx.textAlign = "left"
+      ctx.fillText(valueText, x + gap, y)
+    } else {
+      // Shown only until the first resonator has been opened. After that the
+      // child knows, and a line of standing instructions on every empty hold
+      // for the rest of the session is copy nobody reads and everybody pays to
+      // translate.
+      if (arena.opened === 0) {
+        ctx.fillStyle = INK_DIM
+        ctx.font = chromeFont(size * 0.52, 500)
+        ctx.textAlign = "center"
+        ctx.fillText("SWEEP THE LIT ONES", w / 2, y)
+      }
+    }
+  }
+
+  private drawStatus(
+    arena: Arena,
+    state: { best: number; paused: boolean; stalled: boolean },
+  ): void {
+    const ctx = this.ctx
+    const size = Math.max(12, Math.min(17, this.cssWidth / 46))
+    ctx.font = chromeFont(size, 600)
+    ctx.textAlign = "left"
+    ctx.textBaseline = "top"
+    ctx.fillStyle = INK_DIM
+    ctx.fillText(`OPENED ${arena.opened}`, 14, 12)
+    ctx.fillStyle = arena.chain > 0 ? BRASS_LIGHT : INK_DIM
+    ctx.fillText(`CHAIN ${arena.chain}`, 14, 12 + size * 1.5)
+    ctx.textAlign = "right"
+    ctx.fillStyle = INK_DIM
+    ctx.fillText(`BEST ${state.best}`, this.cssWidth - 14, 12)
+
+    if (state.stalled) {
+      ctx.textAlign = "center"
+      ctx.fillStyle = OXIDE
+      ctx.fillText("NO RESONATOR — SWEEP ON", this.cssWidth / 2, 12)
+    }
+
+    if (this.banner) {
+      const t = Math.min(1, this.banner.age / 180)
+      ctx.globalAlpha = Math.min(1, (BANNER_MS - this.banner.age) / 360) * t
+      ctx.textAlign = "center"
+      ctx.textBaseline = "middle"
+      ctx.fillStyle = this.banner.tint
+      ctx.font = chromeFont(Math.max(20, Math.min(38, this.cssWidth / 20)), 700)
+      ctx.fillText(this.banner.text, this.cssWidth / 2, this.cssHeight * 0.46)
+      ctx.globalAlpha = 1
+    }
+  }
+
+  /** What the pack looks like under the host's sheet: still, and honest. */
+  private drawSheet(): void {
+    const ctx = this.ctx
+    ctx.fillStyle = "rgba(5,8,16,0.55)"
+    ctx.fillRect(0, 0, this.cssWidth, this.cssHeight)
+    ctx.fillStyle = INK_DIM
+    ctx.font = chromeFont(Math.max(14, Math.min(20, this.cssWidth / 40)), 600)
+    ctx.textAlign = "center"
+    ctx.textBaseline = "middle"
+    ctx.fillText("PAUSED", this.cssWidth / 2, this.cssHeight / 2)
+  }
+
+  /** Did a press land on the tile bar? That gesture drops the hold. */
+  hitsTileBar(x: number, y: number): boolean {
+    const r = this.barRect
+    return r.w > 0 && x >= r.x && x <= r.x + r.w && y >= r.y && y <= r.y + r.h
+  }
+
+  /** Ceremony for a resonator opening. Colour and light, never confetti. */
+  celebrate(x: number, y: number, tiles: readonly number[]): void {
+    this.sparks.burst(x, y, 14 + tiles.length * 5, 420, BRASS_LIGHT, 3)
+    this.sparks.burst(x, y, 10 + tiles.length * 3, 260, CELESTIAL, 2)
+    this.knock(6)
+    this.say("RESONANCE", BRASS_LIGHT)
+  }
+
+  refusal(x: number, y: number): void {
+    this.sparks.burst(x, y, 8, 160, OXIDE, 2)
+  }
+
+  split(x: number, y: number): void {
+    this.sparks.burst(x, y, 12, 300, STONE_INK, 2.2)
+    this.knock(1.6)
+  }
+
+  wall(x: number, y: number): void {
+    this.sparks.burst(x, y, 5, 130, CELESTIAL, 1.8)
+  }
+
+  sweep(x: number, y: number): void {
+    this.sparks.burst(x, y, 6, 180, CELESTIAL, 1.6)
+  }
+
+  jostle(x: number, y: number): void {
+    this.sparks.burst(x, y, 9, 220, OXIDE, 2)
+    this.knock(3)
+  }
+
+  dispose(): void {
+    this.canvas.remove()
+  }
+}

--- a/dynawalla/games/lattice/src/sim/grid.ts
+++ b/dynawalla/games/lattice/src/sim/grid.ts
@@ -1,0 +1,274 @@
+// THE GRID — a mass-spring lattice that tears and re-knits.
+//
+// This is the thing the arena is strung on, and it is the reason the pack is
+// called what it is. Every point is a small mass held to its rest position by a
+// weak anchor spring and to its four neighbours by struts. A husk coming apart
+// puts an impulse into the sheet, the impulse travels, and a strut stretched
+// past its limit **lets go** — it stops pulling, the sheet opens, and a moment
+// later the strut finds its neighbour again and knits back. Nothing about that
+// is decorative: the tear is where the number came apart.
+//
+// **Reduced motion is a branch, not a switch.** Turning this off would remove
+// the only cue that says where a split happened. So the reduced branch keeps
+// the whole simulation and changes its character: the springs are stiff, the
+// damping is at critical, and the amplitude ceiling is low — the sheet dents
+// and recovers in about a fifth of a second with no travelling wave and no
+// ringing. A strut still tears; it is drawn as a strut that has gone dark
+// rather than as one that has been flung. A child who needs stillness still
+// sees where the 12 became a 4 and a 3.
+//
+// Everything here is pure arithmetic over `Float32Array`s and is tested without
+// a canvas: the sheet must never produce a NaN, must always come back to rest,
+// and must always re-knit every strut it tore.
+
+export type GridOptions = {
+  /** Points across and down. Struts are the edges between them. */
+  cols: number
+  rows: number
+  width: number
+  height: number
+  reduced: boolean
+}
+
+/** Rest length is derived from the cell size; strain is relative to it. */
+const TEAR_STRAIN = 0.62
+const TEAR_MS = 620
+const REDUCED_TEAR_MS = 260
+
+/** Points beyond which an impulse is not felt at all. Keeps a tap local. */
+const IMPULSE_FALLOFF = 2.4
+
+export class Grid {
+  cols: number
+  rows: number
+  private width: number
+  private height: number
+  private reduced: boolean
+
+  /** Live positions, rest positions, velocities. Flat, one entry per point. */
+  x: Float32Array
+  y: Float32Array
+  vx: Float32Array
+  vy: Float32Array
+  restX: Float32Array
+  restY: Float32Array
+
+  /** Struts as index pairs, with the milliseconds each has left to re-knit. */
+  strutA: Int32Array
+  strutB: Int32Array
+  strutTorn: Float32Array
+  strutRest: Float32Array
+
+  constructor(options: GridOptions) {
+    this.cols = Math.max(4, Math.round(options.cols))
+    this.rows = Math.max(4, Math.round(options.rows))
+    this.width = Math.max(64, options.width)
+    this.height = Math.max(64, options.height)
+    this.reduced = options.reduced
+
+    const n = this.cols * this.rows
+    this.x = new Float32Array(n)
+    this.y = new Float32Array(n)
+    this.vx = new Float32Array(n)
+    this.vy = new Float32Array(n)
+    this.restX = new Float32Array(n)
+    this.restY = new Float32Array(n)
+
+    const pairs: Array<[number, number]> = []
+    for (let r = 0; r < this.rows; r++) {
+      for (let c = 0; c < this.cols; c++) {
+        const i = r * this.cols + c
+        if (c + 1 < this.cols) pairs.push([i, i + 1])
+        if (r + 1 < this.rows) pairs.push([i, i + this.cols])
+      }
+    }
+    this.strutA = new Int32Array(pairs.map((p) => p[0]))
+    this.strutB = new Int32Array(pairs.map((p) => p[1]))
+    this.strutTorn = new Float32Array(pairs.length)
+    this.strutRest = new Float32Array(pairs.length)
+
+    this.layout()
+  }
+
+  get points(): number {
+    return this.cols * this.rows
+  }
+
+  get struts(): number {
+    return this.strutA.length
+  }
+
+  /** Struts currently letting go. The shell draws these differently. */
+  get tornCount(): number {
+    let n = 0
+    for (let s = 0; s < this.strutTorn.length; s++) {
+      if ((this.strutTorn[s] as number) > 0) n += 1
+    }
+    return n
+  }
+
+  /** The largest distance any point has been pushed from its rest position. */
+  get peakDisplacement(): number {
+    let best = 0
+    for (let i = 0; i < this.x.length; i++) {
+      const dx = (this.x[i] as number) - (this.restX[i] as number)
+      const dy = (this.y[i] as number) - (this.restY[i] as number)
+      const d = Math.hypot(dx, dy)
+      if (d > best) best = d
+    }
+    return best
+  }
+
+  setReduced(reduced: boolean): void {
+    this.reduced = reduced
+  }
+
+  resize(width: number, height: number): void {
+    this.width = Math.max(64, width)
+    this.height = Math.max(64, height)
+    this.layout()
+  }
+
+  /** Rest positions, live positions and rest lengths, all from the box. */
+  private layout(): void {
+    const dx = this.width / (this.cols - 1)
+    const dy = this.height / (this.rows - 1)
+    for (let r = 0; r < this.rows; r++) {
+      for (let c = 0; c < this.cols; c++) {
+        const i = r * this.cols + c
+        this.restX[i] = c * dx
+        this.restY[i] = r * dy
+        this.x[i] = c * dx
+        this.y[i] = r * dy
+        this.vx[i] = 0
+        this.vy[i] = 0
+      }
+    }
+    for (let s = 0; s < this.strutA.length; s++) {
+      const a = this.strutA[s] as number
+      const b = this.strutB[s] as number
+      this.strutRest[s] = Math.hypot(
+        (this.restX[a] as number) - (this.restX[b] as number),
+        (this.restY[a] as number) - (this.restY[b] as number),
+      )
+      this.strutTorn[s] = 0
+    }
+  }
+
+  /** The cell size, so the shell can size what it draws on the sheet. */
+  get cell(): { w: number; h: number } {
+    return { w: this.width / (this.cols - 1), h: this.height / (this.rows - 1) }
+  }
+
+  /**
+   * Push the sheet outward from a point.
+   *
+   * `strength` is in arena units per second. It falls off with distance in
+   * cells, so a 12 coming apart dents the sheet where it happened rather than
+   * shaking the whole screen — the loudness ceiling in the experience design is
+   * a real constraint and this is where it lives.
+   */
+  impulse(px: number, py: number, strength: number, radiusCells = 3): void {
+    const { w } = this.cell
+    const radius = Math.max(1, radiusCells) * w
+    const gain = this.reduced ? 0.22 : 1
+    for (let i = 0; i < this.x.length; i++) {
+      const dx = (this.x[i] as number) - px
+      const dy = (this.y[i] as number) - py
+      const d = Math.hypot(dx, dy)
+      if (d > radius * IMPULSE_FALLOFF) continue
+      const k = strength * gain * Math.exp(-(d * d) / (2 * radius * radius))
+      if (d < 1e-4) continue
+      this.vx[i] = (this.vx[i] as number) + (dx / d) * k
+      this.vy[i] = (this.vy[i] as number) + (dy / d) * k
+    }
+  }
+
+  /** Pull the sheet inward — what a resonator opening does to the lattice. */
+  implode(px: number, py: number, strength: number, radiusCells = 6): void {
+    this.impulse(px, py, -strength, radiusCells)
+  }
+
+  /**
+   * Advance the sheet.
+   *
+   * Semi-implicit Euler at a fixed substep. The substep is fixed rather than
+   * derived from the frame so a slow frame cannot blow the springs up; a frame
+   * that arrives late is simulated in more small steps, not one large one, and
+   * a frame that arrives after a minute (a backgrounded tab) is clamped.
+   */
+  step(dtMs: number): void {
+    const clamped = Math.min(120, Math.max(0, dtMs))
+    if (clamped === 0) return
+    const substep = 1000 / 240
+    const steps = Math.min(16, Math.max(1, Math.round(clamped / substep)))
+    const h = clamped / steps / 1000
+
+    // Reduced motion: stiff and at critical damping, so the sheet dents and
+    // returns without a single overshoot. Full motion: slack and springy.
+    const anchorK = this.reduced ? 260 : 34
+    const strutK = this.reduced ? 300 : 120
+    const damp = this.reduced ? 32 : 3.1
+    const tearMs = this.reduced ? REDUCED_TEAR_MS : TEAR_MS
+    const cap = this.reduced ? this.cell.w * 0.35 : this.cell.w * 2.4
+
+    for (let s = 0; s < this.strutTorn.length; s++) {
+      const left = this.strutTorn[s] as number
+      if (left > 0) this.strutTorn[s] = Math.max(0, left - clamped)
+    }
+
+    for (let n = 0; n < steps; n++) {
+      // Anchor springs.
+      for (let i = 0; i < this.x.length; i++) {
+        const dx = (this.restX[i] as number) - (this.x[i] as number)
+        const dy = (this.restY[i] as number) - (this.y[i] as number)
+        this.vx[i] = (this.vx[i] as number) + dx * anchorK * h
+        this.vy[i] = (this.vy[i] as number) + dy * anchorK * h
+      }
+
+      // Struts, and the strain that makes one let go.
+      for (let s = 0; s < this.strutA.length; s++) {
+        if ((this.strutTorn[s] as number) > 0) continue
+        const a = this.strutA[s] as number
+        const b = this.strutB[s] as number
+        const dx = (this.x[b] as number) - (this.x[a] as number)
+        const dy = (this.y[b] as number) - (this.y[a] as number)
+        const len = Math.hypot(dx, dy)
+        if (len < 1e-5) continue
+        const rest = this.strutRest[s] as number
+        const strain = (len - rest) / rest
+        if (strain > TEAR_STRAIN) {
+          this.strutTorn[s] = tearMs
+          continue
+        }
+        const f = strain * strutK * h
+        const ux = dx / len
+        const uy = dy / len
+        this.vx[a] = (this.vx[a] as number) + ux * f
+        this.vy[a] = (this.vy[a] as number) + uy * f
+        this.vx[b] = (this.vx[b] as number) - ux * f
+        this.vy[b] = (this.vy[b] as number) - uy * f
+      }
+
+      // Integrate, damp, and hold the sheet inside its ceiling.
+      const decay = Math.exp(-damp * h)
+      for (let i = 0; i < this.x.length; i++) {
+        this.vx[i] = (this.vx[i] as number) * decay
+        this.vy[i] = (this.vy[i] as number) * decay
+        let nx = (this.x[i] as number) + (this.vx[i] as number) * h
+        let ny = (this.y[i] as number) + (this.vy[i] as number) * h
+        const ox = nx - (this.restX[i] as number)
+        const oy = ny - (this.restY[i] as number)
+        const off = Math.hypot(ox, oy)
+        if (off > cap) {
+          nx = (this.restX[i] as number) + (ox / off) * cap
+          ny = (this.restY[i] as number) + (oy / off) * cap
+          this.vx[i] = (this.vx[i] as number) * 0.4
+          this.vy[i] = (this.vy[i] as number) * 0.4
+        }
+        this.x[i] = nx
+        this.y[i] = ny
+      }
+    }
+  }
+}

--- a/dynawalla/games/lattice/src/stubHost.ts
+++ b/dynawalla/games/lattice/src/stubHost.ts
@@ -1,0 +1,199 @@
+// A local stub Host so the game is playable standalone with `npm run dev`.
+//
+// Three properties the real runtime also honours, each asserted by
+// `src/test/stubHost.test.ts`:
+//
+//   1. **Exact arithmetic.** Every operand, answer and distractor is an
+//      integer. No float ever reaches an answer string or a comparison.
+//   2. **Seeded and deterministic.** Same seed → same question stream, forever.
+//   3. **Distractors are real mal-rule outputs** — what a child with a specific
+//      broken procedure actually writes down. Never `answer ± 1` noise. THE
+//      LATTICE seeds the field so one of them is assemblable, so these values
+//      are the wrong answers the game is actually able to hear.
+
+import type { Host, Question } from "./contract.ts"
+import { Rng } from "./core/rng.ts"
+
+type Domain = "add" | "sub"
+
+/** Digit-reversal: 63 → 36. A real transcription slip, not noise. */
+function reverseDigits(n: number): number {
+  let out = 0
+  let m = n
+  while (m > 0) {
+    out = out * 10 + (m % 10)
+    m = Math.floor(m / 10)
+  }
+  return out
+}
+
+/** Column addition with every carry dropped: 27 + 15 → 32. */
+function addNoCarry(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    const d = ((x % 10) + (y % 10)) % 10
+    out += d * place
+    place *= 10
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return out
+}
+
+/** The smaller-from-larger bug: 52 − 27 → 35, taking |2−7| in the ones column. */
+function subSmallerFromLarger(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    const dx = x % 10
+    const dy = y % 10
+    out += Math.abs(dx - dy) * place
+    place *= 10
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return out
+}
+
+function malRulesFor(domain: Domain, a: number, b: number, answer: number): number[] {
+  switch (domain) {
+    case "add":
+      return [
+        addNoCarry(a, b),
+        a + b - 10, // carried but never added the carry in
+        a + b + 10, // carried twice
+        Math.abs(a - b), // reached for the wrong operation
+        reverseDigits(answer),
+      ]
+    case "sub":
+      return [
+        subSmallerFromLarger(a, b),
+        a - b + 10, // borrowed without decrementing the next column
+        a - b - 10, // decremented twice
+        a + b, // wrong operation
+        reverseDigits(answer),
+      ]
+  }
+}
+
+function operandsFor(domain: Domain, difficulty: number, rng: Rng): [number, number] {
+  // `difficulty` is clamped to 1..10 and stretches the operand range. Answers
+  // stay under four digits at every difficulty: a resonator numeral is read at
+  // speed while the arena is moving, and the primes behind a four-digit answer
+  // are too many motes to hold.
+  const d = Math.max(1, Math.min(10, Math.round(difficulty)))
+  switch (domain) {
+    case "add": {
+      const hi = 8 + d * 9 // 17..98
+      return [rng.int(3, hi), rng.int(3, hi)]
+    }
+    case "sub": {
+      const hi = 12 + d * 9 // 21..102
+      const a = rng.int(8, hi)
+      const b = rng.int(2, Math.max(2, a - 2))
+      return [a, b]
+    }
+  }
+}
+
+function evaluate(domain: Domain, a: number, b: number): number {
+  return domain === "add" ? a + b : a - b
+}
+
+const GLYPH: Record<Domain, string> = { add: "+", sub: "−" }
+
+export type StubHostOptions = {
+  seed?: number
+  reducedMotion?: boolean
+  difficulty?: number
+  /** Observe reports — the dev harness draws a running accuracy readout. */
+  onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void
+  /** Observe haptics so the harness shows they fired on a device that has none. */
+  onHaptic?: (k: string) => void
+  /** Observe stopping points. The real host may sheet the frame on one. */
+  onTransition?: (kind: string, label?: string) => void
+}
+
+export function createStubHost(opts: StubHostOptions = {}): Host {
+  const rng = new Rng(opts.seed ?? 0x1a771ce)
+  let n = 0
+  const domains: Domain[] = ["add", "add", "sub"]
+
+  const host: Host = {
+    next(o) {
+      const difficulty = Math.max(
+        1,
+        Math.min(10, Math.round(o?.difficulty ?? opts.difficulty ?? 3)),
+      )
+      const domain = (o?.domain as Domain | undefined) ?? rng.pick(domains)
+      const [a, b] = operandsFor(domain, difficulty, rng)
+      const answer = evaluate(domain, a, b)
+
+      // Mal-rule outputs, deduped, filtered to values a resonator could legally
+      // ask for: a positive integer of at most four digits that is not the
+      // answer and is not 1 (a resonator asking for 1 opens to an empty hold).
+      const seen = new Set<number>([answer])
+      const pool: number[] = []
+      for (const v of malRulesFor(domain, a, b, answer)) {
+        if (!Number.isInteger(v) || v < 2 || v > 9999 || seen.has(v)) continue
+        seen.add(v)
+        pool.push(v)
+      }
+      rng.shuffle(pool)
+
+      n++
+      return {
+        id: `stub-${n}`,
+        prompt: `${a} ${GLYPH[domain]} ${b}`,
+        answer: String(answer),
+        distractors: pool.slice(0, 3).map(String),
+        domain,
+        difficulty: Math.max(0, Math.min(1, difficulty / 10)),
+      } satisfies Question
+    },
+
+    report(r) {
+      opts.onReport?.(r)
+    },
+
+    haptic(k) {
+      opts.onHaptic?.(k)
+      const nav = globalThis.navigator as Navigator | undefined
+      if (!nav || typeof nav.vibrate !== "function") return
+      const ms =
+        k === "light" ? 8 : k === "medium" ? 18 : k === "heavy" ? 34 : k === "success" ? 12 : 40
+      try {
+        if (k === "success") nav.vibrate([ms, 26, ms])
+        else if (k === "failure") nav.vibrate([ms, 40, ms])
+        else nav.vibrate(ms)
+      } catch (error) {
+        // A browser that exposes vibrate but refuses it (no user gesture yet,
+        // or a policy block) must never take the frame down with it.
+        console.warn("[lattice] navigator.vibrate refused", error)
+      }
+    },
+
+    prefersReducedMotion() {
+      if (opts.reducedMotion !== undefined) return opts.reducedMotion
+      return (
+        typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion: reduce)").matches
+      )
+    },
+  }
+
+  // Optional on the contract and feature-detected by the game, so it is only
+  // present when the harness asked to watch it — which is what makes the
+  // game's `host.transition?.()` call path real rather than assumed.
+  if (opts.onTransition) {
+    host.transition = (kind, label) => {
+      opts.onTransition?.(kind, label)
+    }
+  }
+
+  return host
+}

--- a/dynawalla/games/lattice/src/test/arena.test.ts
+++ b/dynawalla/games/lattice/src/test/arena.test.ts
@@ -1,0 +1,336 @@
+// THE ARENA — what the child can actually do, and what the host hears.
+//
+// The rules only. Nothing here draws, and nothing here reads a clock it was not
+// handed; the arena is a pure state machine over integers and the shell is what
+// turns collisions into these calls.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import { Arena, MAX_TARGET } from "../game/arena.ts"
+import { isPrime, primeFactors, productOf, sameMultiset } from "../game/factor.ts"
+import { createStubHost } from "../stubHost.ts"
+import { grindToPrimes, rig, sweepFactorisation } from "./harness.ts"
+
+test("a resonator always arrives with a target the arena can honestly ask for", () => {
+  for (let seed = 1; seed <= 60; seed++) {
+    const { arena } = rig(seed * 7919)
+    const res = arena.resonator
+    assert.ok(res, `seed ${seed} armed no resonator`)
+    assert.ok(Number.isInteger(res.target), `seed ${seed}: a non-integer target`)
+    assert.ok(res.target >= 2 && res.target <= MAX_TARGET, `seed ${seed}: target ${res.target}`)
+    assert.equal(arena.stalled, false)
+  }
+})
+
+test("shooting conserves the product: grinding the field never changes what is on it", () => {
+  for (let seed = 1; seed <= 40; seed++) {
+    const { arena } = rig(seed * 104729)
+    const before = productOf(arena.bodies.map((b) => b.value))
+    const primes = grindToPrimes(arena)
+    assert.ok(primes.every(isPrime), `seed ${seed}: something un-ground survived`)
+    assert.equal(
+      productOf(primes),
+      before,
+      `seed ${seed}: grinding the field changed its product`,
+    )
+  }
+})
+
+test("a shot at a prime is refused — it shoves the mote and never splits it", () => {
+  const { arena } = rig(0x9a11)
+  grindToPrimes(arena)
+  const mote = arena.bodies[0]
+  assert.ok(mote)
+  const count = arena.bodies.length
+  const value = mote.value
+  const events = arena.strike(mote.id)
+  assert.equal(events.length, 1)
+  assert.equal(events[0]?.kind, "wall")
+  assert.equal(arena.bodies.length, count, "a prime came apart under fire")
+  assert.equal(arena.bodies.find((b) => b.id === mote.id)?.value, value)
+})
+
+test("the field can always supply the answer's factorisation", () => {
+  // A resonator the field cannot answer is a resonator the child cannot open,
+  // which would make the whole thinking layer unreachable without anything
+  // failing anywhere. This is the test that would catch it.
+  for (let seed = 1; seed <= 50; seed++) {
+    const { arena } = rig(seed * 15485863)
+    const res = arena.resonator
+    assert.ok(res)
+    grindToPrimes(arena)
+    assert.ok(
+      sweepFactorisation(arena, res.target),
+      `seed ${seed}: the field could not supply the primes of ${res.target}`,
+    )
+    assert.equal(arena.bank.value, res.target)
+    assert.ok(sameMultiset(arena.bank.tiles, primeFactors(res.target)))
+  }
+})
+
+test("flying into the resonator with the right primes opens it and reports it", () => {
+  const { arena, reports, transitions } = rig(0x09e05)
+  const res = arena.resonator
+  assert.ok(res)
+  grindToPrimes(arena)
+  assert.ok(sweepFactorisation(arena, res.target))
+
+  const events = arena.enter(3200)
+  assert.ok(
+    events.some((e) => e.kind === "open"),
+    "the resonator did not open for its own factorisation",
+  )
+  assert.equal(arena.opened, 1)
+  assert.equal(arena.chain, 1)
+  assert.equal(arena.bank.size, 0, "the hold was not spent")
+
+  assert.equal(reports.length, 1)
+  assert.equal(reports[0]?.questionId, res.questionId)
+  assert.equal(reports[0]?.correct, true)
+  assert.equal(reports[0]?.answered, String(res.target))
+  assert.equal(reports[0]?.ms, 3200)
+
+  // A stopping point the child reached, never a failure.
+  assert.deepEqual(transitions, [{ kind: "level", label: "resonance" }])
+  // And the next question is already armed.
+  assert.ok(arena.resonator)
+  assert.notEqual(arena.resonator?.questionId, res.questionId)
+})
+
+test("a wrong product is reported as itself and does not open anything", () => {
+  const { arena, reports, transitions } = rig(0xbad1)
+  const res = arena.resonator
+  assert.ok(res)
+  grindToPrimes(arena)
+
+  // Sweep one prime and no more: unless the target is that prime, this is an
+  // honest wrong assertion — the kind a child makes by rushing.
+  const mote = arena.bodies.find((b) => b.prime && b.value !== res.target)
+  assert.ok(mote)
+  arena.touch(mote.id)
+  const asserted = arena.bank.value
+  assert.notEqual(asserted, res.target)
+
+  const events = arena.enter(2000)
+  assert.equal(events.length, 1)
+  assert.equal(events[0]?.kind, "refuse")
+  assert.equal(arena.opened, 0)
+  assert.equal(arena.chain, 0)
+  assert.equal(reports.length, 1)
+  assert.equal(reports[0]?.correct, false)
+  assert.equal(reports[0]?.answered, String(asserted))
+  // A purchase surface must never sit next to a mistake.
+  assert.deepEqual(transitions, [], "a refusal raised a stopping point")
+})
+
+test("a refusal hands the primes back — nothing the child worked for is destroyed", () => {
+  const { arena } = rig(0x9e17)
+  const res = arena.resonator
+  assert.ok(res)
+  grindToPrimes(arena)
+  const mote = arena.bodies.find((b) => b.prime && b.value !== res.target)
+  assert.ok(mote)
+  arena.touch(mote.id)
+  const held = arena.bank.tiles.slice()
+  const onField = arena.bodies.map((b) => b.value)
+
+  arena.enter(1000)
+  assert.equal(arena.bank.size, 0)
+  assert.ok(
+    sameMultiset(arena.bodies.map((b) => b.value), [...onField, ...held]),
+    "a refusal ate the primes the child was holding",
+  )
+})
+
+test("one question, one report: a second assertion is not heard again", () => {
+  const { arena, reports } = rig(0x2ce)
+  const res = arena.resonator
+  assert.ok(res)
+  grindToPrimes(arena)
+  const mote = arena.bodies.find((b) => b.prime && b.value !== res.target)
+  assert.ok(mote)
+
+  arena.touch(mote.id)
+  arena.enter(1000)
+  assert.equal(reports.length, 1)
+
+  // The resonator is dim for a moment after a refusal; step past it, then open
+  // it properly. The child gets their resonance; the host hears one answer.
+  arena.step(1000)
+  assert.ok(sweepFactorisation(arena, res.target))
+  const events = arena.enter(9000)
+  assert.ok(events.some((e) => e.kind === "open"))
+  assert.equal(reports.length, 1, "the same question was answered to the host twice")
+})
+
+test("an empty hold flies straight through: no event, no report", () => {
+  const { arena, reports } = rig(0x0e17)
+  assert.equal(arena.bank.size, 0)
+  assert.deepEqual(arena.enter(500), [])
+  assert.equal(reports.length, 0)
+  assert.equal(arena.opened, 0)
+})
+
+test("a resonator asking for a prime opens only for the mote carrying it", () => {
+  // The wall, in the arena rather than in the rule: a stub host wound forward
+  // to a prime answer, ground down, and every smaller prime on the field swept.
+  const host = createStubHost({ seed: 0x7a11, reducedMotion: true })
+  const arena = new Arena(host, new Rng(0x7a11), { width: 900, height: 700 })
+  arena.begin(0)
+  let guard = 0
+  while (arena.resonator && !isPrime(arena.resonator.target) && guard++ < 200) {
+    // Open it the honest way so the next question is drawn.
+    grindToPrimes(arena)
+    assert.ok(sweepFactorisation(arena, arena.resonator.target))
+    arena.enter(guard * 100)
+  }
+  const res = arena.resonator
+  assert.ok(res && isPrime(res.target), "no prime target came up in 200 questions")
+
+  grindToPrimes(arena)
+  // Sweep every prime on the field that is smaller than the target, and try.
+  for (const body of arena.bodies.filter((b) => b.value < res.target).slice(0, 6)) {
+    arena.touch(body.id)
+    if (arena.bank.value === res.target) break
+  }
+  if (arena.bank.value !== res.target) {
+    const events = arena.enter(1000)
+    assert.ok(
+      !events.some((e) => e.kind === "open"),
+      `the prime ${res.target} was assembled from smaller factors`,
+    )
+  }
+  // And the mote itself is on the field, because that is the only way in.
+  assert.ok(
+    arena.bodies.some((b) => b.value === res.target) || arena.bank.tiles.includes(res.target),
+    `the prime ${res.target} was asked for and no mote carried it`,
+  )
+})
+
+test("a composite jostles the ship and shakes a mote loose; it is never swept", () => {
+  const { arena } = rig(0x105)
+  const husk = arena.bodies.find((b) => !b.prime)
+  assert.ok(husk)
+  // Put something in the hold first, so there is something to lose.
+  arena.strike(husk.id)
+  const mote = arena.bodies.find((b) => b.prime)
+  assert.ok(mote)
+  arena.touch(mote.id)
+  assert.equal(arena.bank.size, 1)
+
+  const other = arena.bodies.find((b) => !b.prime)
+  if (other) {
+    const events = arena.touch(other.id)
+    assert.equal(events[0]?.kind, "jostle")
+    assert.equal(arena.bank.size, 0, "a jostle did not cost a mote")
+    assert.ok(
+      arena.bodies.some((b) => !b.prime && b.id === other.id),
+      "a jostle consumed the husk",
+    )
+  }
+})
+
+test("venting puts the whole hold back on the field", () => {
+  const { arena } = rig(0x0e27)
+  grindToPrimes(arena)
+  const mote = arena.bodies[0]
+  assert.ok(mote)
+  arena.touch(mote.id)
+  const onField = arena.bodies.map((b) => b.value)
+  const held = arena.bank.tiles.slice()
+  assert.equal(held.length, 1)
+
+  const events = arena.vent()
+  assert.equal(events[0]?.kind, "vent")
+  assert.equal(arena.bank.size, 0)
+  assert.ok(sameMultiset(arena.bodies.map((b) => b.value), [...onField, ...held]))
+  assert.deepEqual(arena.vent(), [], "venting an empty hold produced an event")
+})
+
+test("the hold refuses past its ceiling rather than dropping what is in it", () => {
+  const { arena } = rig(0xf0117)
+  grindToPrimes(arena)
+  // Sweep everything on the field; the hold either takes it or says it is full,
+  // and either way the bar stays a true factorisation of the value it shows.
+  for (const id of arena.bodies.map((b) => b.id)) {
+    arena.touch(id)
+    assert.equal(productOf(arena.bank.tiles), arena.bank.value)
+    assert.ok(arena.bank.tiles.every(isPrime))
+  }
+})
+
+test("stepping the world never changes any number on it", () => {
+  const { arena } = rig(0x57e9)
+  const before = arena.bodies.map((b) => b.value).sort((a, b) => a - b)
+  for (let i = 0; i < 240; i++) arena.step(16)
+  const after = arena.bodies
+    .filter((b) => !b.prime || true)
+    .map((b) => b.value)
+    .sort((a, b) => a - b)
+  // Drifting bodies may collide with the ship and be swept, so compare the
+  // product of everything that exists — field plus hold — instead.
+  assert.equal(
+    productOf(after) * arena.bank.value,
+    productOf(before),
+    "drifting changed the arithmetic",
+  )
+})
+
+test("a released mote is thrown clear, and the ship is deaf to it while it goes", () => {
+  // The bug this catches was invisible and total: a mote handed back at the
+  // ship's own position is a mote the ship is already touching, so it was swept
+  // again on the next frame. Venting did nothing, a refusal handed the same
+  // wrong hold straight back, and a jostle cost nothing.
+  const { arena } = rig(0x5ca7)
+  grindToPrimes(arena)
+  const mote = arena.bodies[0]
+  assert.ok(mote)
+  arena.touch(mote.id)
+  assert.equal(arena.bank.size, 1)
+
+  arena.vent()
+  assert.equal(arena.bank.size, 0)
+  // Half a second of frames with the ship sitting exactly where it vented.
+  for (let i = 0; i < 20; i++) arena.step(16)
+  assert.equal(arena.bank.size, 0, "a vented mote was swept straight back up")
+
+  // Every released mote landed clear of the ship rather than inside it.
+  for (const body of arena.bodies) {
+    const d = Math.hypot(body.x - arena.ship.x, body.y - arena.ship.y)
+    assert.ok(d > 20, `a released mote landed ${Math.round(d)} units from the ship`)
+  }
+})
+
+test("a refusal costs the trip: the hold is not handed straight back", () => {
+  const { arena } = rig(0x5ca8)
+  const res = arena.resonator
+  assert.ok(res)
+  grindToPrimes(arena)
+  const mote = arena.bodies.find((b) => b.prime && b.value !== res.target)
+  assert.ok(mote)
+  arena.touch(mote.id)
+  arena.enter(1000)
+  assert.equal(arena.bank.size, 0)
+  for (let i = 0; i < 20; i++) arena.step(16)
+  assert.equal(arena.bank.size, 0, "the refused hold was re-swept on the spot")
+})
+
+test("a jostle costs a mote, and the mote does not come straight back", () => {
+  const { arena } = rig(0x5ca9)
+  const husk = arena.bodies.find((b) => !b.prime)
+  assert.ok(husk)
+  arena.strike(husk.id)
+  const mote = arena.bodies.find((b) => b.prime)
+  assert.ok(mote)
+  arena.touch(mote.id)
+  assert.equal(arena.bank.size, 1)
+
+  const other = arena.bodies.find((b) => !b.prime)
+  if (!other) return
+  arena.touch(other.id)
+  assert.equal(arena.bank.size, 0)
+  for (let i = 0; i < 20; i++) arena.step(16)
+  assert.equal(arena.bank.size, 0, "the spilled mote was picked straight back up")
+})

--- a/dynawalla/games/lattice/src/test/bank.test.ts
+++ b/dynawalla/games/lattice/src/test/bank.test.ts
@@ -1,0 +1,124 @@
+// THE FACTOR TILE BAR — the passive layer, and the one thing it may never do.
+//
+// The bar is on screen the whole time a child is holding motes: `2·2·3` with a
+// running 12 beside it. It is the reason this game teaches anything when nobody
+// is trying, and it is worth exactly nothing if it can ever be false.
+//
+// So: **after every operation, on every path, the bar is a true factorisation
+// of the value it shows.** Every tile prime, the product exactly the value.
+// There is no sweep, spill, release or refusal that can leave it otherwise.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import { BANK_CAPACITY, Bank } from "../game/bank.ts"
+import { MOTE_PRIMES, ascending, isPrime, primeFactors, productOf } from "../game/factor.ts"
+
+/** The invariant, stated once and called after everything. */
+function assertTrueBar(bank: Bank, where: string): void {
+  const tiles = bank.tiles
+  assert.ok(
+    tiles.every(isPrime),
+    `${where}: the bar showed a tile that is not prime — ${JSON.stringify(tiles)}`,
+  )
+  assert.equal(
+    productOf(tiles),
+    bank.value,
+    `${where}: the bar read ${bank.label} but the value beside it was ${bank.value}`,
+  )
+  assert.deepEqual(
+    tiles.slice(),
+    ascending(tiles),
+    `${where}: the bar was not in ascending order`,
+  )
+  assert.equal(
+    bank.label,
+    tiles.join("·"),
+    `${where}: the drawn label disagreed with the tiles`,
+  )
+}
+
+test("an empty bar reads nothing and its value is the multiplicative identity", () => {
+  const bank = new Bank()
+  assert.equal(bank.size, 0)
+  assert.equal(bank.value, 1)
+  assert.equal(bank.label, "")
+  assertTrueBar(bank, "empty")
+})
+
+test("the bar is a true factorisation after every sweep, spill and release", () => {
+  // A long seeded sitting: sweep, spill, release, sweep again, thousands of
+  // times, checking the invariant after every single operation.
+  const rng = new Rng(0xba17ba2)
+  const bank = new Bank()
+  for (let step = 0; step < 4000; step++) {
+    const roll = rng.next()
+    if (roll < 0.66) {
+      bank.take(rng.pick(MOTE_PRIMES))
+      assertTrueBar(bank, `after a sweep at step ${step}`)
+    } else if (roll < 0.9) {
+      bank.spill()
+      assertTrueBar(bank, `after a spill at step ${step}`)
+    } else {
+      const let_go = bank.release()
+      assert.ok(let_go.every(isPrime), `a release at step ${step} let go of a non-prime`)
+      assertTrueBar(bank, `after a release at step ${step}`)
+    }
+  }
+})
+
+test("the bar shows exactly what was swept, in the order it is read", () => {
+  const bank = new Bank()
+  for (const p of [5, 2, 13, 2, 3]) assert.ok(bank.take(p))
+  assert.deepEqual(bank.tiles.slice(), [2, 2, 3, 5, 13])
+  assert.equal(bank.label, "2·2·3·5·13")
+  assert.equal(bank.value, 780)
+  assert.equal(productOf(primeFactors(780)), 780)
+  assertTrueBar(bank, "a mixed sweep")
+})
+
+test("a non-prime is refused outright — the bar cannot be made to lie", () => {
+  const bank = new Bank()
+  for (const bad of [1, 0, -3, 4, 6, 9, 12, 100, 2.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.equal(bank.take(bad), false, `the bank swallowed ${bad}`)
+    assertTrueBar(bank, `after refusing ${bad}`)
+  }
+  assert.equal(bank.size, 0)
+})
+
+test("a spill takes the largest tile, and the value follows it exactly", () => {
+  const bank = new Bank()
+  for (const p of [2, 3, 13]) bank.take(p)
+  assert.equal(bank.value, 78)
+  assert.equal(bank.spill(), 13)
+  assert.equal(bank.value, 6)
+  assertTrueBar(bank, "after a spill")
+  assert.equal(bank.spill(), 3)
+  assert.equal(bank.spill(), 2)
+  assert.equal(bank.spill(), null, "an empty hold spilled something")
+  assert.equal(bank.value, 1)
+  assertTrueBar(bank, "after emptying")
+})
+
+test("the hold has a ceiling, and refusing at it does not disturb the bar", () => {
+  const bank = new Bank()
+  for (let i = 0; i < BANK_CAPACITY; i++) assert.ok(bank.take(2))
+  assert.equal(bank.isFull, true)
+  assert.equal(bank.take(2), false, "the hold took a mote past its ceiling")
+  assert.equal(bank.size, BANK_CAPACITY)
+  assertTrueBar(bank, "at the ceiling")
+  // Nine twos is 512, the worst case under the largest target the resonator
+  // will ask for; the ceiling has to leave room over that.
+  assert.ok(BANK_CAPACITY >= 9, "the hold cannot carry the factorisation of 512")
+})
+
+test("a release hands back every tile and leaves the bar empty and true", () => {
+  const bank = new Bank()
+  for (const p of [2, 2, 3, 7]) bank.take(p)
+  const back = bank.release()
+  assert.deepEqual(ascending(back), [2, 2, 3, 7])
+  assert.equal(bank.size, 0)
+  assert.equal(bank.value, 1)
+  assertTrueBar(bank, "after a release")
+})

--- a/dynawalla/games/lattice/src/test/factor.test.ts
+++ b/dynawalla/games/lattice/src/test/factor.test.ts
@@ -1,0 +1,128 @@
+// The game's own mathematics: cracking a number open, exactly.
+//
+// Every assertion here is between integers. If a float ever reaches a husk, a
+// product or a bank, one of these fails.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import {
+  MAX_HUSK,
+  ascending,
+  divisorPairs,
+  huskify,
+  isPrime,
+  multisetDifference,
+  primeFactors,
+  productOf,
+  sameMultiset,
+  splitPair,
+} from "../game/factor.ts"
+
+test("isPrime agrees with trial division over the whole playable range", () => {
+  const sieve = new Uint8Array(1000).fill(1)
+  sieve[0] = 0
+  sieve[1] = 0
+  for (let p = 2; p < 1000; p++) {
+    if (!sieve[p]) continue
+    for (let m = p * p; m < 1000; m += p) sieve[m] = 0
+  }
+  for (let n = 0; n < 1000; n++) {
+    assert.equal(isPrime(n), sieve[n] === 1, `isPrime(${n})`)
+  }
+  assert.equal(isPrime(-7), false)
+  assert.equal(isPrime(2.5), false)
+})
+
+test("primeFactors multiplies back to the number, ascending, all prime", () => {
+  for (let n = 2; n <= 2000; n++) {
+    const factors = primeFactors(n)
+    assert.equal(productOf(factors), n, `product of the factors of ${n}`)
+    assert.ok(
+      factors.every(isPrime),
+      `a factor of ${n} was not prime: ${JSON.stringify(factors)}`,
+    )
+    assert.deepEqual(factors, ascending(factors), `the factors of ${n} were not ascending`)
+  }
+  assert.deepEqual(primeFactors(1), [])
+  assert.deepEqual(primeFactors(0), [])
+})
+
+test("a prime has no divisor pair — that is the wall, in one line", () => {
+  for (let n = 2; n <= 500; n++) {
+    if (!isPrime(n)) continue
+    assert.deepEqual(divisorPairs(n), [], `${n} is prime and offered a divisor pair`)
+    assert.equal(splitPair(n, new Rng(n)), null, `${n} is prime and split`)
+  }
+})
+
+test("splitPair conserves the product, exactly, for every composite under 2000", () => {
+  for (let n = 4; n <= 2000; n++) {
+    if (isPrime(n)) continue
+    for (let s = 0; s < 6; s++) {
+      const pair = splitPair(n, new Rng(n * 31 + s))
+      assert.ok(pair, `${n} is composite and would not split`)
+      const [a, b] = pair
+      assert.ok(Number.isInteger(a) && Number.isInteger(b), `${n} split into non-integers`)
+      assert.ok(a >= 2 && b >= 2, `${n} split into ${a} × ${b}, which has a 1 in it`)
+      assert.equal(a * b, n, `${n} split into ${a} × ${b}`)
+    }
+  }
+})
+
+test("grinding a husk to exhaustion yields exactly its prime factorisation", () => {
+  // The whole passive layer, in a loop: shoot until nothing splits, and what is
+  // left drifting must be the prime factorisation of what you started with.
+  for (const n of [12, 36, 72, 100, 128, 210, 360, 512, 720, 999]) {
+    const rng = new Rng(n * 7 + 1)
+    let field = [n]
+    for (let guard = 0; guard < 200 && field.some((v) => !isPrime(v)); guard++) {
+      const next: number[] = []
+      for (const v of field) {
+        const pair = isPrime(v) ? null : splitPair(v, rng)
+        if (pair) next.push(pair[0], pair[1])
+        else next.push(v)
+      }
+      field = next
+    }
+    assert.ok(field.every(isPrime), `${n} did not grind down: ${JSON.stringify(field)}`)
+    assert.ok(
+      sameMultiset(field, primeFactors(n)),
+      `${n} ground down to ${JSON.stringify(ascending(field))}`,
+    )
+  }
+})
+
+test("huskify hides a prime list inside composites that give it back", () => {
+  for (let n = 2; n <= 999; n++) {
+    const wanted = primeFactors(n)
+    const rng = new Rng(n * 977 + 3)
+    const husks = huskify(wanted, rng)
+    assert.ok(husks.length > 0, `${n} produced no husks`)
+    assert.equal(productOf(husks), n, `the husks for ${n} do not multiply to it`)
+    for (const h of husks) {
+      assert.ok(Number.isInteger(h) && h >= 2 && h <= MAX_HUSK, `${n} produced the husk ${h}`)
+    }
+    // And grinding every husk gives the primes back, with multiplicity.
+    const ground = husks.flatMap((h) => primeFactors(h))
+    assert.ok(sameMultiset(ground, wanted), `the husks for ${n} ground to something else`)
+  }
+})
+
+test("multiset helpers are count-sensitive, not set-sensitive", () => {
+  assert.equal(sameMultiset([2, 2, 3], [3, 2, 2]), true)
+  assert.equal(sameMultiset([2, 2, 3], [2, 3]), false)
+  assert.equal(sameMultiset([2, 3], [2, 2, 3]), false)
+  assert.deepEqual(multisetDifference([2, 2, 3, 5], [2, 3]), [2, 5])
+  assert.deepEqual(multisetDifference([2, 3], [2, 2, 3]), [])
+  assert.deepEqual(multisetDifference([7], []), [7])
+})
+
+test("productOf is exact over the values this game actually holds", () => {
+  assert.equal(productOf([]), 1)
+  assert.equal(productOf([2, 2, 3]), 12)
+  assert.equal(productOf([2, 2, 2, 3, 3]), 72)
+  assert.equal(productOf(primeFactors(999)), 999)
+  assert.ok(Number.isInteger(productOf(primeFactors(997))))
+})

--- a/dynawalla/games/lattice/src/test/grid.test.ts
+++ b/dynawalla/games/lattice/src/test/grid.test.ts
@@ -1,0 +1,150 @@
+// THE GRID — the sheet the arena is strung on, and the reduced-motion branch.
+//
+// This is the fleet's juice benchmark, which means it is also the thing most
+// likely to be quietly broken: a spring simulation that blows up produces NaN
+// and draws nothing, and a canvas that draws nothing looks exactly like a
+// canvas that is fine on a screenshot.
+//
+// Three properties, all of them about the simulation rather than the pixels:
+// it never produces a NaN, it always comes back to rest, and every strut it
+// tears is a strut it knits back.
+//
+// And one about the branch: **reduced motion is a different simulation, not an
+// absent one.** The sheet still dents where a number came apart — that is the
+// only cue saying where the split happened — but it is critically damped, so it
+// arrives and returns without a single overshoot, and its amplitude ceiling is
+// a fraction of the full one.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Grid } from "../sim/grid.ts"
+
+function make(reduced: boolean): Grid {
+  return new Grid({ cols: 20, rows: 15, width: 900, height: 675, reduced })
+}
+
+function finite(grid: Grid, where: string): void {
+  for (let i = 0; i < grid.x.length; i++) {
+    assert.ok(Number.isFinite(grid.x[i] as number), `${where}: x[${i}] is not finite`)
+    assert.ok(Number.isFinite(grid.y[i] as number), `${where}: y[${i}] is not finite`)
+    assert.ok(Number.isFinite(grid.vx[i] as number), `${where}: vx[${i}] is not finite`)
+    assert.ok(Number.isFinite(grid.vy[i] as number), `${where}: vy[${i}] is not finite`)
+  }
+}
+
+test("the sheet starts flat, with every strut whole", () => {
+  for (const reduced of [false, true]) {
+    const grid = make(reduced)
+    assert.equal(grid.peakDisplacement, 0)
+    assert.equal(grid.tornCount, 0)
+    assert.ok(grid.struts > 500, "the sheet has too few struts to be a lattice")
+    finite(grid, "at rest")
+  }
+})
+
+test("it never produces a NaN, however hard it is hit", () => {
+  for (const reduced of [false, true]) {
+    const grid = make(reduced)
+    for (let i = 0; i < 400; i++) {
+      grid.impulse((i * 37) % 900, (i * 53) % 675, 4000, 4)
+      grid.implode((i * 71) % 900, (i * 29) % 675, 3000, 6)
+      // Including the frames a backgrounded tab hands back.
+      grid.step(i % 17 === 0 ? 100000 : 16)
+      finite(grid, `after hit ${i} (reduced=${reduced})`)
+    }
+  }
+})
+
+test("the sheet always comes back to rest", () => {
+  for (const reduced of [false, true]) {
+    const grid = make(reduced)
+    grid.impulse(450, 340, 2600, 3)
+    let peak = 0
+    for (let i = 0; i < 20; i++) {
+      grid.step(16)
+      peak = Math.max(peak, grid.peakDisplacement)
+    }
+    assert.ok(peak > 1, `the sheet did not move at all (reduced=${reduced})`)
+    for (let i = 0; i < 400; i++) grid.step(16)
+    assert.ok(
+      grid.peakDisplacement < 0.5,
+      `the sheet was still ringing after six seconds (reduced=${reduced}): ${grid.peakDisplacement}`,
+    )
+    assert.equal(grid.tornCount, 0, "a strut never knitted back")
+  }
+})
+
+test("a hard enough hit tears the sheet, and the sheet knits back", () => {
+  const grid = make(false)
+  grid.impulse(450, 340, 9000, 2)
+  let tore = 0
+  for (let i = 0; i < 30; i++) {
+    grid.step(16)
+    tore = Math.max(tore, grid.tornCount)
+  }
+  assert.ok(tore > 0, "nothing tore under a hit that should have opened the sheet")
+  for (let i = 0; i < 300; i++) grid.step(16)
+  assert.equal(grid.tornCount, 0, "the sheet did not knit back")
+  assert.ok(grid.peakDisplacement < 0.5, "the sheet did not settle after a tear")
+})
+
+test("reduced motion is a branch: the sheet still dents, and it stops dead", () => {
+  const full = make(false)
+  const calm = make(true)
+  full.impulse(450, 340, 3000, 3)
+  calm.impulse(450, 340, 3000, 3)
+
+  // Sample the displacement at the centre of the hit over a second, and count
+  // how many times it turns around. A spring that rings crosses its own peak
+  // several times; a critically damped one rises once and comes back.
+  const trace = (grid: Grid): number[] => {
+    const out: number[] = []
+    for (let i = 0; i < 60; i++) {
+      grid.step(16)
+      out.push(grid.peakDisplacement)
+    }
+    return out
+  }
+  const turns = (xs: readonly number[]): number => {
+    let n = 0
+    for (let i = 2; i < xs.length; i++) {
+      const a = (xs[i - 1] as number) - (xs[i - 2] as number)
+      const b = (xs[i] as number) - (xs[i - 1] as number)
+      if (a > 0.02 && b < -0.02) n += 1
+      if (a < -0.02 && b > 0.02) n += 1
+    }
+    return n
+  }
+
+  const fullTrace = trace(full)
+  const calmTrace = trace(calm)
+  const fullPeak = Math.max(...fullTrace)
+  const calmPeak = Math.max(...calmTrace)
+
+  // It is present. This is the assertion that fails if someone "fixes" reduced
+  // motion by switching the simulation off — which would delete the only cue
+  // saying where a number came apart.
+  assert.ok(calmPeak > 0.5, `the reduced branch did not move at all: ${calmPeak}`)
+  // And it is calm: a fraction of the travel, and no ringing.
+  assert.ok(
+    calmPeak < fullPeak * 0.5,
+    `the reduced branch travelled ${calmPeak} against ${fullPeak}`,
+  )
+  assert.ok(
+    turns(calmTrace) <= 1,
+    `the reduced branch rang ${turns(calmTrace)} times; it must rise once and return`,
+  )
+  assert.ok(turns(fullTrace) >= 1, "the full branch did not ring at all")
+})
+
+test("resizing re-lays the sheet without leaving a strut torn or a point adrift", () => {
+  const grid = make(false)
+  grid.impulse(450, 340, 9000, 2)
+  for (let i = 0; i < 12; i++) grid.step(16)
+  grid.resize(1400, 500)
+  assert.equal(grid.tornCount, 0)
+  assert.equal(grid.peakDisplacement, 0)
+  finite(grid, "after a resize")
+  assert.ok(Math.abs((grid.x[grid.cols - 1] as number) - 1400) < 1e-3, "the sheet is not the box")
+})

--- a/dynawalla/games/lattice/src/test/harness.ts
+++ b/dynawalla/games/lattice/src/test/harness.ts
@@ -1,0 +1,85 @@
+// Shared scaffolding for the rules tests: a recording host and an arena.
+//
+// Every test in this package is seeded from a literal. Nothing here reads
+// `Math.random`, `Date.now` or `performance.now`, so a run that passes passes
+// every time and a run that fails fails every time.
+
+import type { Host } from "../contract.ts"
+import { Rng } from "../core/rng.ts"
+import { Arena } from "../game/arena.ts"
+import { primeFactors } from "../game/factor.ts"
+import { createStubHost } from "../stubHost.ts"
+
+export type Report = { questionId: string; correct: boolean; ms: number; answered: string }
+
+export type Rig = {
+  host: Host
+  arena: Arena
+  reports: Report[]
+  transitions: Array<{ kind: string; label?: string }>
+  haptics: string[]
+}
+
+export function rig(seed = 0x1a771ce, opts: { difficulty?: number } = {}): Rig {
+  const reports: Report[] = []
+  const transitions: Array<{ kind: string; label?: string }> = []
+  const haptics: string[] = []
+  const host = createStubHost({
+    seed,
+    reducedMotion: true,
+    ...(opts.difficulty === undefined ? {} : { difficulty: opts.difficulty }),
+    onReport: (r) => reports.push(r),
+    onHaptic: (k) => haptics.push(k),
+    onTransition: (kind, label) =>
+      transitions.push(label === undefined ? { kind } : { kind, label }),
+  })
+  const arena = new Arena(host, new Rng(seed ^ 0x51de), { width: 900, height: 700 })
+  arena.begin(0)
+  return { host, arena, reports, transitions, haptics }
+}
+
+/**
+ * Grind every composite on the field down to primes, the way a child with a
+ * trigger finger does — by striking, over and over, until nothing splits.
+ *
+ * Returns the primes now drifting. Bounded, so a bug that makes a husk
+ * un-splittable fails the test rather than hanging the suite.
+ */
+export function grindToPrimes(arena: Arena, limit = 400): number[] {
+  for (let i = 0; i < limit; i++) {
+    const composite = arena.bodies.find((b) => !b.prime)
+    if (!composite) break
+    arena.strike(composite.id)
+  }
+  if (arena.bodies.some((b) => !b.prime)) throw new Error("a composite would not grind down")
+  return arena.bodies.map((b) => b.value)
+}
+
+/**
+ * Sweep exactly the primes that multiply to `target`, and nothing else.
+ *
+ * Returns false when the field cannot supply them — which is itself an
+ * assertion the seeding tests make, because a resonator the field cannot answer
+ * is a resonator the child cannot open.
+ */
+export function sweepFactorisation(arena: Arena, target: number): boolean {
+  const wanted = primeFactors(target)
+  for (const prime of wanted) {
+    const mote = arena.bodies.find((b) => b.prime && b.value === prime)
+    if (!mote) return false
+    // `touch` is the rule; the shell only ever calls it after a collision.
+    const before = arena.bank.size
+    arena.touch(mote.id)
+    if (arena.bank.size !== before + 1) return false
+  }
+  return true
+}
+
+/** A wall clock that ticks a fixed amount per call. No real time anywhere. */
+export function stepClock(step = 1800): () => number {
+  let t = 0
+  return () => {
+    t += step
+    return t
+  }
+}

--- a/dynawalla/games/lattice/src/test/loop.test.ts
+++ b/dynawalla/games/lattice/src/test/loop.test.ts
@@ -1,0 +1,153 @@
+// DOES THE LOOP CLOSE?
+//
+// Every other test in this package checks a rule in isolation: this one plays
+// the game. A scripted child flies the real arena through the real physics —
+// shooting husks apart, chasing the motes they need, avoiding the ones they do
+// not, and running at the resonator when the hold is right — and the assertion
+// is that resonators actually open.
+//
+// It is here because the failure it catches is silent and total. A field that
+// drifts its last 7 into a corner, a resonator that never listens again after a
+// refusal, a hold that fills with chaff and cannot be emptied: each of those
+// passes every unit test in this directory and leaves a child flying around an
+// arena that can never be beaten. Nothing throws. Nothing goes red. The game is
+// simply not a game.
+//
+// The clock is a counter, the arena's randomness is seeded, and the policy is
+// deterministic, so this is reproducible: it passes every time or it fails
+// every time.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import { Arena } from "../game/arena.ts"
+import { multisetDifference, primeFactors } from "../game/factor.ts"
+import { createStubHost } from "../stubHost.ts"
+
+type Report = { correct: boolean; answered: string }
+
+/** Fly toward a point, and aim there too. */
+function steer(arena: Arena, x: number, y: number): void {
+  const dx = x - arena.ship.x
+  const dy = y - arena.ship.y
+  arena.setMove(dx, dy)
+  arena.setAim(dx, dy)
+}
+
+function nearest<T extends { x: number; y: number }>(arena: Arena, xs: readonly T[]): T | null {
+  let best: T | null = null
+  let bestD = Number.POSITIVE_INFINITY
+  for (const item of xs) {
+    const d = Math.hypot(item.x - arena.ship.x, item.y - arena.ship.y)
+    if (d < bestD) {
+      bestD = d
+      best = item
+    }
+  }
+  return best
+}
+
+/**
+ * A child who is playing properly: work out what the resonator needs, break
+ * open whatever is holding those primes, collect exactly them, and go.
+ */
+function playCarefully(arena: Arena, frames: number): void {
+  let t = 0
+  for (let f = 0; f < frames; f++) {
+    t += 16
+    const res = arena.resonator
+    if (!res) break
+
+    const wanted = primeFactors(res.target)
+    const held = arena.bank.tiles.slice()
+    const surplus = multisetDifference(held, wanted)
+
+    if (surplus.length > 0) {
+      // Something got swept that the resonator does not want. Drop the lot and
+      // start the hold again — the primes go back on the field.
+      arena.vent()
+    } else if (held.length === wanted.length) {
+      // The hold is right. Run at it.
+      steer(arena, res.x, res.y)
+      if (Math.hypot(res.x - arena.ship.x, res.y - arena.ship.y) < 60) arena.enter(t)
+    } else {
+      const needed = multisetDifference(wanted, held)
+      const motes = arena.bodies.filter((b) => b.prime && needed.includes(b.value))
+      const mote = nearest(arena, motes)
+      if (mote) {
+        steer(arena, mote.x, mote.y)
+      } else {
+        // Nothing loose carries what is needed, so open something that does.
+        const husks = arena.bodies.filter(
+          (b) => !b.prime && needed.some((p) => b.value % p === 0),
+        )
+        const husk = nearest(arena, husks) ?? nearest(arena, arena.bodies.filter((b) => !b.prime))
+        if (husk) {
+          // Stand off and shoot rather than flying into it — a husk jostles.
+          const dx = husk.x - arena.ship.x
+          const dy = husk.y - arena.ship.y
+          arena.setAim(dx, dy)
+          const range = Math.hypot(dx, dy)
+          arena.setMove(range > 220 ? dx : -dx, range > 220 ? dy : -dy)
+          arena.fire()
+        } else {
+          // The field has nothing left that helps. Sit still rather than
+          // thrashing; the assertion below is what reports it.
+          arena.setMove(0, 0)
+        }
+      }
+    }
+    arena.step(16)
+  }
+}
+
+test("a child who plays it properly opens resonators, over and over", () => {
+  for (const seed of [0x1a771ce, 0x0c105, 0x5eed, 0xbea7, 0x9a11]) {
+    const reports: Report[] = []
+    const host = createStubHost({
+      seed,
+      reducedMotion: true,
+      onReport: (r) => reports.push({ correct: r.correct, answered: r.answered }),
+    })
+    const arena = new Arena(host, new Rng(seed ^ 0x51de), { width: 900, height: 700 })
+    arena.begin(0)
+
+    playCarefully(arena, 9000)
+
+    assert.ok(
+      arena.opened >= 4,
+      `seed ${seed.toString(16)}: a careful player opened only ${arena.opened} resonators in 9000 frames`,
+    )
+    assert.ok(reports.length >= arena.opened, "resonators opened without being reported")
+    // A careful player is right: they assembled the factorisation on purpose.
+    const wrong = reports.filter((r) => !r.correct).length
+    assert.ok(
+      wrong <= reports.length / 4,
+      `seed ${seed.toString(16)}: ${wrong} of ${reports.length} careful answers were wrong`,
+    )
+  }
+})
+
+test("a chain builds when nothing goes wrong, and the count is honest", () => {
+  const host = createStubHost({ seed: 0xc4a1, reducedMotion: true })
+  const arena = new Arena(host, new Rng(0xc4a1), { width: 1100, height: 800 })
+  arena.begin(0)
+  playCarefully(arena, 9000)
+  assert.equal(arena.chain, arena.opened, "a clean run did not build a chain")
+  assert.ok(arena.chain >= 4)
+})
+
+test("the arena never runs out of things to shoot", () => {
+  // Every resonator restocks the field, so a sitting cannot arrive at an empty
+  // arena with a question still on the board.
+  const host = createStubHost({ seed: 0x5106, reducedMotion: true })
+  const arena = new Arena(host, new Rng(0x5106), { width: 900, height: 700 })
+  arena.begin(0)
+  let emptyFrames = 0
+  for (let f = 0; f < 6000; f++) {
+    playCarefully(arena, 1)
+    if (arena.bodies.length === 0 && arena.bank.size === 0) emptyFrames += 1
+  }
+  assert.equal(emptyFrames, 0, `the arena was empty on ${emptyFrames} frames`)
+})

--- a/dynawalla/games/lattice/src/test/mount.test.ts
+++ b/dynawalla/games/lattice/src/test/mount.test.ts
@@ -1,0 +1,274 @@
+// A smoke test for the surface.
+//
+// `tsc` proves the draw calls type-check and the vite build proves the modules
+// resolve. Neither proves that a frame *runs* — a stale property, a function
+// renamed in `render/` and not in `mount.ts`, a value read before it is
+// assigned, all compile and all crash on the first frame in front of a child.
+//
+// So this mounts the real game against a canvas that records instead of paints,
+// drives hundreds of frames with the sticks moving and the trigger down, and
+// asserts that nothing threw, that the world moved, and that the host's sheet
+// stops it at the shell as well as in the rules.
+//
+// It is not a rendering test — there are no pixels to look at — it is a test
+// that the whole thing is wired to itself.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { mount } from "../contract.ts"
+import { createStubHost } from "../stubHost.ts"
+
+type Listener = (event: unknown) => void
+
+/** A 2D context that answers every call and records how much it was asked for. */
+function fakeContext(counter: { calls: number; text: string[] }): CanvasRenderingContext2D {
+  const store = new Map<string, unknown>()
+  const noop = (name: string) =>
+    function (...args: unknown[]) {
+      counter.calls++
+      if (name === "fillText" && typeof args[0] === "string") counter.text.push(args[0])
+      if (name === "measureText") return { width: 40 }
+      // Gradients are the one call whose result is used, so everything returns
+      // something that can take a colour stop.
+      return { addColorStop() {} }
+    }
+  return new Proxy(
+    {},
+    {
+      get(_t, prop: string) {
+        if (store.has(prop)) return store.get(prop)
+        return noop(prop)
+      },
+      set(_t, prop: string, value) {
+        store.set(prop, value)
+        return true
+      },
+    },
+  ) as unknown as CanvasRenderingContext2D
+}
+
+type FakeElement = {
+  style: { cssText: string }
+  width: number
+  height: number
+  listeners: Map<string, Listener[]>
+  appendChild(child: unknown): void
+  remove(): void
+  addEventListener(type: string, fn: Listener): void
+  removeEventListener(type: string, fn: Listener): void
+  setPointerCapture(): void
+  releasePointerCapture(): void
+  getBoundingClientRect(): { width: number; height: number; left: number; top: number }
+  getContext(): CanvasRenderingContext2D
+}
+
+function harness(size: { w: number; h: number }, counter: { calls: number; text: string[] }) {
+  const ctx = fakeContext(counter)
+  const make = (): FakeElement => {
+    const listeners = new Map<string, Listener[]>()
+    return {
+      style: { cssText: "" },
+      width: 0,
+      height: 0,
+      listeners,
+      appendChild() {},
+      remove() {},
+      addEventListener(type, fn) {
+        const list = listeners.get(type) ?? []
+        list.push(fn)
+        listeners.set(type, list)
+      },
+      removeEventListener(type, fn) {
+        listeners.set(
+          type,
+          (listeners.get(type) ?? []).filter((f) => f !== fn),
+        )
+      },
+      setPointerCapture() {},
+      releasePointerCapture() {},
+      getBoundingClientRect: () => ({ width: size.w, height: size.h, left: 0, top: 0 }),
+      getContext: () => ctx,
+    }
+  }
+  const created: FakeElement[] = []
+  const doc = {
+    createElement() {
+      const el = make()
+      created.push(el)
+      return el
+    },
+  }
+  return { host: make(), doc, created, ctx }
+}
+
+type Rig = ReturnType<typeof harness> & { frames: Array<(t: number) => void> }
+
+/**
+ * Install the browser globals `mount.ts` needs, run `body`, and take them back
+ * off again — including when `body` throws, which is the case this file exists
+ * to catch.
+ */
+function withBrowser(
+  size: { w: number; h: number },
+  counter: { calls: number; text: string[] },
+  body: (rig: Rig) => void,
+): void {
+  const rig = harness(size, counter)
+  const g = globalThis as Record<string, unknown>
+  const saved = new Map<string, PropertyDescriptor | undefined>()
+  const set = (key: string, value: unknown) => {
+    saved.set(key, Object.getOwnPropertyDescriptor(globalThis, key))
+    Object.defineProperty(globalThis, key, { configurable: true, writable: true, value })
+  }
+  const frames: Array<(t: number) => void> = []
+  set("document", rig.doc)
+  set("devicePixelRatio", 2)
+  set("requestAnimationFrame", (fn: (t: number) => void) => {
+    frames.push(fn)
+    return frames.length
+  })
+  set("cancelAnimationFrame", () => {})
+  if (typeof g.addEventListener !== "function") set("addEventListener", () => {})
+  if (typeof g.removeEventListener !== "function") set("removeEventListener", () => {})
+
+  try {
+    body({ ...rig, frames })
+  } finally {
+    for (const [key, descriptor] of saved) {
+      if (descriptor) Object.defineProperty(globalThis, key, descriptor)
+      else Reflect.deleteProperty(globalThis, key)
+    }
+  }
+}
+
+/** The canvas is the only element `mount` creates. */
+function canvasOf(created: FakeElement[]): FakeElement {
+  const el = created[0]
+  if (!el) throw new Error("mount did not create a canvas")
+  return el
+}
+
+/** Run `n` frames at 60Hz, draining the rAF queue each time. */
+function pump(frames: Array<(t: number) => void>, n: number, from = 0): number {
+  let t = from
+  for (let i = 0; i < n; i++) {
+    const next = frames.pop()
+    frames.length = 0
+    if (!next) break
+    t += 16.7
+    next(t)
+  }
+  return t
+}
+
+for (const [w, h] of [
+  [320, 568],
+  [768, 1024],
+  [1366, 1024],
+] as const) {
+  for (const reduced of [false, true]) {
+    test(`a sitting runs without throwing at ${w}×${h}, reducedMotion=${reduced}`, () => {
+      const counter = { calls: 0, text: [] as string[] }
+      withBrowser({ w, h }, counter, ({ host, frames, created }) => {
+        const stub = createStubHost({ seed: 0x1a771ce, reducedMotion: reduced })
+        const handle = mount(host as unknown as HTMLElement, stub)
+        const canvas = canvasOf(created)
+
+        let t = pump(frames, 240)
+        assert.ok(counter.calls > 3000, `only ${counter.calls} draw calls in 240 frames`)
+        assert.ok(counter.text.length > 0, "nothing was ever drawn with a numeral on it")
+
+        // Both thumbs down: fly with the left, aim and fire with the right.
+        const down = canvas.listeners.get("pointerdown")?.[0]
+        const move = canvas.listeners.get("pointermove")?.[0]
+        const up = canvas.listeners.get("pointerup")?.[0]
+        assert.ok(down && move && up, "the twin-stick listeners were not installed")
+
+        down({ preventDefault() {}, pointerId: 1, pointerType: "touch", clientX: w * 0.2, clientY: h * 0.7 })
+        down({ preventDefault() {}, pointerId: 2, pointerType: "touch", clientX: w * 0.8, clientY: h * 0.7 })
+        const before = counter.calls
+        for (let i = 0; i < 120; i++) {
+          move({
+            pointerId: 1,
+            pointerType: "touch",
+            clientX: w * 0.2 + Math.sin(i / 9) * 60,
+            clientY: h * 0.7 + Math.cos(i / 7) * 60,
+          })
+          move({
+            pointerId: 2,
+            pointerType: "touch",
+            clientX: w * 0.8 + Math.cos(i / 5) * 50,
+            clientY: h * 0.7 + Math.sin(i / 6) * 50,
+          })
+          t = pump(frames, 4, t)
+        }
+        assert.ok(counter.calls > before, "the arena stopped drawing while it was being flown")
+
+        up({ pointerId: 1, pointerType: "touch" })
+        up({ pointerId: 2, pointerType: "touch" })
+        t = pump(frames, 120, t)
+
+        // The host's sheet: the loop keeps running, the world does not.
+        handle.pause()
+        const painted = counter.calls
+        t = pump(frames, 60, t)
+        assert.ok(counter.calls > painted, "the frame stopped being drawn under the sheet")
+        assert.ok(
+          counter.text.includes("PAUSED"),
+          "the pack did not say it was paused under the sheet",
+        )
+
+        handle.resume()
+        t = pump(frames, 120, t)
+        handle.unmount()
+
+        // Nothing is left listening, and a frame after unmount is a no-op.
+        assert.equal(canvas.listeners.get("pointerdown")?.length ?? 0, 0)
+        const after = counter.calls
+        pump(frames, 5, t)
+        assert.equal(counter.calls, after, "the loop kept drawing after unmount")
+      })
+    })
+  }
+}
+
+test("a pause that arrives while a thumb is down does not fly the ship on", () => {
+  // The shell half of the pause. `Arena` refuses the input; this is the guard
+  // that also lets go of the sticks, so a thumb that was resting on one when
+  // the sheet came up is not still steering when it lifts.
+  const counter = { calls: 0, text: [] as string[] }
+  withBrowser({ w: 900, h: 700 }, counter, ({ host, frames, created }) => {
+    const reports: string[] = []
+    const stub = createStubHost({
+      seed: 0x5ee7,
+      reducedMotion: true,
+      onReport: (r) => reports.push(r.answered),
+    })
+    const handle = mount(host as unknown as HTMLElement, stub)
+    const canvas = canvasOf(created)
+    const down = canvas.listeners.get("pointerdown")?.[0]
+    const move = canvas.listeners.get("pointermove")?.[0]
+    assert.ok(down && move)
+
+    // A thumb pinned hard against the left stick, another on the trigger.
+    down({ preventDefault() {}, pointerId: 1, pointerType: "touch", clientX: 100, clientY: 400 })
+    move({ pointerId: 1, pointerType: "touch", clientX: 400, clientY: 100 })
+    down({ preventDefault() {}, pointerId: 2, pointerType: "touch", clientX: 700, clientY: 400 })
+    let t = pump(frames, 30)
+
+    handle.pause()
+    // Three seconds behind the sheet with both thumbs still on the glass.
+    for (let i = 0; i < 180; i++) {
+      move({ pointerId: 1, pointerType: "touch", clientX: 400, clientY: 100 })
+      t = pump(frames, 1, t)
+    }
+    const said = reports.length
+    handle.resume()
+    // One frame back, with nothing touched: the sticks were let go, so the
+    // ship must not still be flying the direction it was pinned in.
+    t = pump(frames, 1, t)
+    assert.equal(reports.length, said, "an answer was reported across the sheet")
+    handle.unmount()
+  })
+})

--- a/dynawalla/games/lattice/src/test/pause.test.ts
+++ b/dynawalla/games/lattice/src/test/pause.test.ts
@@ -1,0 +1,201 @@
+// THE PAUSE.
+//
+// The host can put a sheet over a pack that is **still mounted and still
+// running** — a stopping-point card, a parent gate, a day-pass offer — and it
+// sends `pause` when it does. THE LATTICE calls `transition` every time a
+// resonator opens, so it is one of the packs most likely to raise that sheet
+// itself.
+//
+// Three things have to stop dead, and all three are real damage if they do not:
+//
+//   1. **Input.** A thumb resting on a virtual stick behind the sheet is not
+//      the child flying. Unguarded, the ship keeps moving, sweeps motes nobody
+//      chose, and can fly through the resonator and assert a product the child
+//      never assembled — an answer reported for a question they never saw.
+//   2. **The resonator's clock.** The latency reported is meant to be time the
+//      child spent thinking. Time behind a sheet is not that, and a
+//      thirty-second sheet would tell the host a child laboured over a question
+//      they answered in two seconds.
+//   3. **The world.** Husks drift, the ship coasts, and a sheet held for a
+//      minute would come off onto a completely different arena.
+//
+// **Every assertion here has been verified to fail with the guards removed.**
+// Not by reading them — by deleting every `if (this.paused) return` in
+// `Arena`, running this file, and watching it go red.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { grindToPrimes, rig, sweepFactorisation } from "./harness.ts"
+
+test("a shot behind the sheet does not crack anything", () => {
+  const { arena } = rig(0x5ee7)
+  const husk = arena.bodies.find((b) => !b.prime)
+  assert.ok(husk)
+  const before = arena.bodies.map((b) => b.id).sort((a, b) => a - b)
+
+  arena.pause(1000)
+  assert.deepEqual(arena.strike(husk.id), [], "a husk came apart behind the sheet")
+  assert.deepEqual(
+    arena.bodies.map((b) => b.id).sort((a, b) => a - b),
+    before,
+    "the field changed behind the sheet",
+  )
+  assert.equal(arena.isPaused, true)
+})
+
+test("a mote reached behind the sheet is not swept", () => {
+  const { arena } = rig(0x5ee8)
+  grindToPrimes(arena)
+  const mote = arena.bodies[0]
+  assert.ok(mote)
+
+  arena.pause(500)
+  assert.deepEqual(arena.touch(mote.id), [], "a mote was swept behind the sheet")
+  assert.equal(arena.bank.size, 0, "the hold changed behind the sheet")
+
+  // And it is still there to sweep when the sheet lifts.
+  arena.resume(900)
+  const events = arena.touch(mote.id)
+  assert.equal(events[0]?.kind, "sweep")
+  assert.equal(arena.bank.size, 1)
+})
+
+test("flying through the resonator behind the sheet reports nothing", () => {
+  // The worst bug this game could ship: a report against a question the child
+  // never saw, with a product they did not assemble.
+  const { arena, reports, transitions } = rig(0x5ee9)
+  const res = arena.resonator
+  assert.ok(res)
+  grindToPrimes(arena)
+  assert.ok(sweepFactorisation(arena, res.target))
+  const held = arena.bank.tiles.slice()
+
+  arena.pause(1000)
+  assert.deepEqual(arena.enter(1400), [], "the resonator answered behind the sheet")
+  assert.equal(reports.length, 0, "an answer was reported behind the sheet")
+  assert.deepEqual(transitions, [], "a stopping point was raised behind the sheet")
+  assert.equal(arena.opened, 0)
+  assert.deepEqual(arena.bank.tiles.slice(), held, "the hold was spent behind the sheet")
+})
+
+test("the world does not drift behind the sheet", () => {
+  const { arena } = rig(0x5eea)
+  arena.setMove(1, 1)
+  arena.step(16)
+  const shipX = arena.ship.x
+  const shipY = arena.ship.y
+  const positions = arena.bodies.map((b) => ({ id: b.id, x: b.x, y: b.y }))
+
+  arena.pause(2000)
+  for (let i = 0; i < 60; i++) assert.deepEqual(arena.step(16), [])
+
+  assert.equal(arena.ship.x, shipX, "the ship coasted behind the sheet")
+  assert.equal(arena.ship.y, shipY, "the ship coasted behind the sheet")
+  for (const before of positions) {
+    const now = arena.bodies.find((b) => b.id === before.id)
+    assert.ok(now)
+    assert.equal(now.x, before.x, `body ${before.id} drifted behind the sheet`)
+    assert.equal(now.y, before.y, `body ${before.id} drifted behind the sheet`)
+  }
+})
+
+test("the sticks are inert behind the sheet, and a resting thumb flies nothing", () => {
+  const { arena } = rig(0x5eeb)
+  arena.setMove(0, 0)
+  arena.setAim(1, 0)
+  const aim = { ...arena.aiming }
+
+  arena.pause(1000)
+  // A thumb that was already down when the sheet came up.
+  arena.setMove(1, 1)
+  arena.setAim(0, 1)
+  assert.deepEqual(arena.fire(), [], "the trigger fired behind the sheet")
+  assert.equal(arena.shots.length, 0, "a shot was created behind the sheet")
+  assert.deepEqual(arena.vent(), [], "the hold was vented behind the sheet")
+  assert.deepEqual(arena.aiming, aim, "the ship was turned behind the sheet")
+
+  // The move vector must not have been latched either: one step after resume,
+  // with the stick released, and the ship is still where it was.
+  const x = arena.ship.x
+  arena.resume(1400)
+  arena.setMove(0, 0)
+  arena.step(16)
+  assert.equal(arena.ship.x, x, "a stick set behind the sheet flew the ship on resume")
+})
+
+test("the sheet is not thinking time: the latency reported skips it", () => {
+  const { arena, reports } = rig(0x5eec)
+  const res = arena.resonator
+  assert.ok(res)
+  grindToPrimes(arena)
+  assert.ok(sweepFactorisation(arena, res.target))
+
+  // Two seconds with the problem, thirty seconds behind a sheet, then half a
+  // second more and a run at the resonator.
+  arena.pause(2000)
+  arena.resume(32000)
+  arena.enter(32500)
+
+  assert.equal(reports.length, 1)
+  assert.equal(reports[0]?.ms, 2500, "the sheet was counted as time the child spent thinking")
+})
+
+test("a sheet raised between resonators does not charge the next one for it", () => {
+  const { arena, reports } = rig(0x5eed)
+  const first = arena.resonator
+  assert.ok(first)
+  grindToPrimes(arena)
+  assert.ok(sweepFactorisation(arena, first.target))
+  arena.enter(4000)
+
+  // The host raises its sheet on the transition and holds it for a minute. The
+  // child had a tenth of a second with the next resonator before it went up.
+  arena.pause(4100)
+  arena.resume(64100)
+
+  const second = arena.resonator
+  assert.ok(second)
+  grindToPrimes(arena)
+  assert.ok(sweepFactorisation(arena, second.target))
+  arena.enter(65100)
+
+  assert.equal(reports.length, 2)
+  assert.equal(reports[0]?.ms, 4000)
+  assert.equal(reports[1]?.ms, 1100, "the next resonator was charged for the sheet")
+})
+
+test("pause and resume are idempotent, and resume alone changes nothing", () => {
+  const { arena, reports } = rig(0x5eee)
+  const res = arena.resonator
+  assert.ok(res)
+  grindToPrimes(arena)
+  assert.ok(sweepFactorisation(arena, res.target))
+
+  arena.resume(100) // never paused
+  arena.pause(1000)
+  arena.pause(5000) // a second pause must not move the mark
+  arena.resume(9000)
+  arena.resume(50000) // a second resume must not move it either
+  arena.enter(10000)
+
+  assert.equal(reports.length, 1)
+  assert.equal(reports[0]?.ms, 2000)
+  assert.equal(arena.isPaused, false)
+})
+
+test("the arena comes back: after the sheet lifts everything works again", () => {
+  const { arena, reports } = rig(0x5eef)
+  const res = arena.resonator
+  assert.ok(res)
+  arena.pause(300)
+  arena.resume(9300)
+
+  grindToPrimes(arena)
+  assert.ok(sweepFactorisation(arena, res.target), "the field was unusable after a sheet")
+  const events = arena.enter(10000)
+  assert.ok(events.some((e) => e.kind === "open"), "the arena did not come back")
+  assert.equal(reports.length, 1)
+  assert.equal(reports[0]?.correct, true)
+  assert.equal(reports[0]?.ms, 1000)
+})

--- a/dynawalla/games/lattice/src/test/resonance.test.ts
+++ b/dynawalla/games/lattice/src/test/resonance.test.ts
@@ -1,0 +1,124 @@
+// THE RESONANCE — the three properties the learning claim rests on.
+//
+// The passive layer of this game is absorption. This file is the part that is
+// reasoning, and each test here is one of the things a child would have to be
+// able to do for the claim "they factorised it" to be true.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Bank } from "../game/bank.ts"
+import { isPrime, primeFactors, productOf } from "../game/factor.ts"
+import { isAskable, opens, resonate } from "../game/resonance.ts"
+
+/** Every multiset of primes drawn from `alphabet` with at most `depth` tiles. */
+function banksFrom(alphabet: readonly number[], depth: number): number[][] {
+  const out: number[][] = []
+  const walk = (start: number, held: number[]): void => {
+    if (held.length > 0) out.push(held.slice())
+    if (held.length === depth) return
+    for (let i = start; i < alphabet.length; i++) {
+      held.push(alphabet[i] as number)
+      walk(i, held)
+      held.pop()
+    }
+  }
+  walk(0, [])
+  return out
+}
+
+test("a target is cleared only by a genuine prime factorisation of it", () => {
+  // Exhaustive: every multiset of small primes up to six tiles, against every
+  // target from 2 to 200. A bank opens the resonator if and only if every tile
+  // is prime and the product is exactly the target — which, by unique
+  // factorisation, means the bank *is* the prime factorisation of the target.
+  const alphabet = [2, 3, 5, 7, 11, 13]
+  const banks = banksFrom(alphabet, 6)
+  for (let target = 2; target <= 200; target++) {
+    const wanted = primeFactors(target)
+    for (const bank of banks) {
+      const opened = opens(target, bank)
+      const genuine =
+        bank.every(isPrime) && productOf(bank) === target && bank.length === wanted.length
+      assert.equal(
+        opened,
+        genuine,
+        `target ${target} vs bank ${JSON.stringify(bank)}: opened=${opened}`,
+      )
+    }
+  }
+})
+
+test("a composite tile never opens anything, even when the product is right", () => {
+  // 4 is not a prime, so `[4, 3]` is a decomposition of 12 but not *the* prime
+  // factorisation, and the resonator does not take it. This is the rule that
+  // keeps "factorisation" from quietly meaning "any two numbers that multiply".
+  assert.equal(opens(12, [4, 3]), false)
+  assert.equal(opens(12, [12]), false)
+  assert.equal(opens(12, [6, 2]), false)
+  assert.equal(opens(12, [2, 2, 3]), true)
+  assert.equal(opens(72, [8, 9]), false)
+  assert.equal(opens(72, [2, 2, 2, 3, 3]), true)
+})
+
+test("a prime target is a wall: nothing smaller assembles it", () => {
+  // The same property `foundry street` relies on, asserted the hard way. For
+  // every prime target under 200, every multiset of *strictly smaller* primes —
+  // exhaustively, to eight tiles — fails to reach it. The only bank that opens
+  // a prime is the single mote carrying it, which has to be found on the field
+  // rather than built.
+  for (let target = 2; target <= 200; target++) {
+    if (!isPrime(target)) continue
+    const smaller: number[] = []
+    for (let p = 2; p < target; p++) if (isPrime(p)) smaller.push(p)
+
+    for (const bank of banksFrom(smaller.slice(0, 8), 4)) {
+      assert.equal(
+        opens(target, bank),
+        false,
+        `the prime ${target} was assembled from ${JSON.stringify(bank)}`,
+      )
+    }
+    assert.equal(opens(target, [target]), true, `the mote ${target} did not open ${target}`)
+    assert.deepEqual(primeFactors(target), [target])
+  }
+})
+
+test("an empty hold asserts nothing — it is not a wrong answer", () => {
+  const verdict = resonate(60, [])
+  assert.equal(verdict.kind, "silent")
+  // A child flying through a resonator with nothing in the hold is a child
+  // moving through the arena, and the host must not hear an answer for it.
+})
+
+test("a genuine assertion that is not the target refuses, and says what was said", () => {
+  const verdict = resonate(72, [2, 2, 3, 5])
+  assert.equal(verdict.kind, "refuse")
+  assert.equal(verdict.kind === "refuse" && verdict.asserted, 60)
+})
+
+test("overshoot and undershoot both refuse — the hold is exact, not 'close'", () => {
+  assert.equal(opens(12, [2, 2, 3, 2]), false, "24 opened a resonator asking for 12")
+  assert.equal(opens(12, [2, 3]), false, "6 opened a resonator asking for 12")
+  assert.equal(opens(12, [2, 2, 3]), true)
+})
+
+test("a target the arena will not ask for is refused rather than fudged", () => {
+  assert.equal(isAskable(1, 999), false, "1 opens to an empty hold and is not a question")
+  assert.equal(isAskable(0, 999), false)
+  assert.equal(isAskable(-4, 999), false)
+  assert.equal(isAskable(1000, 999), false)
+  assert.equal(isAskable(2, 999), true)
+  assert.equal(isAskable(999, 999), true)
+  // And if one ever got through, the rule refuses rather than opening.
+  assert.equal(opens(1, [2]), false)
+  assert.equal(opens(0, [2]), false)
+})
+
+test("the bank's own invariant holds through the resonance rule", () => {
+  const bank = new Bank()
+  for (const p of [3, 2, 5, 2]) assert.ok(bank.take(p))
+  assert.equal(bank.value, 60)
+  assert.equal(opens(60, bank.tiles), true)
+  assert.equal(opens(30, bank.tiles), false)
+})

--- a/dynawalla/games/lattice/src/test/stubHost.test.ts
+++ b/dynawalla/games/lattice/src/test/stubHost.test.ts
@@ -1,0 +1,97 @@
+// The stub host's three promises, which the real runtime also has to keep.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { createStubHost } from "../stubHost.ts"
+
+test("the stream is seeded and deterministic, forever", () => {
+  const a = createStubHost({ seed: 0x1a771ce })
+  const b = createStubHost({ seed: 0x1a771ce })
+  for (let i = 0; i < 500; i++) {
+    const x = a.next()
+    const y = b.next()
+    assert.deepEqual(x, y, `question ${i} diverged`)
+  }
+  const c = createStubHost({ seed: 0x1a771cf })
+  assert.notDeepEqual(c.next().prompt, createStubHost({ seed: 0x1a771ce }).next().prompt)
+})
+
+test("every operand, answer and distractor is an exact integer", () => {
+  for (let seed = 1; seed <= 12; seed++) {
+    const host = createStubHost({ seed: seed * 7919 })
+    for (let i = 0; i < 400; i++) {
+      const q = host.next({ difficulty: 1 + (i % 10) })
+      const answer = Number(q.answer)
+      assert.ok(Number.isInteger(answer), `${q.prompt} = ${q.answer} is not an integer`)
+      assert.equal(String(answer), q.answer, `${q.answer} round-trips badly`)
+      for (const d of q.distractors) {
+        const value = Number(d)
+        assert.ok(Number.isInteger(value), `distractor ${d} for ${q.prompt} is not an integer`)
+        assert.notEqual(value, answer, `a distractor for ${q.prompt} equals the answer`)
+        assert.ok(value >= 2 && value <= 9999, `distractor ${d} is out of range`)
+      }
+      // And the prompt says what it means: the operands and the glyph.
+      const match = /^(\d+) ([+−]) (\d+)$/.exec(q.prompt)
+      assert.ok(match, `unreadable prompt ${q.prompt}`)
+      const a = Number(match[1])
+      const b = Number(match[3])
+      assert.equal(match[2] === "+" ? a + b : a - b, answer, `${q.prompt} ≠ ${q.answer}`)
+    }
+  }
+})
+
+test("distractors are mal-rule outputs, not answer ± 1 noise", () => {
+  // The point of a distractor is that a child with a specific broken procedure
+  // actually writes it down, so a wrong resonance tells the host *which*
+  // mistake. A stream where most distractors sit next to the answer would be
+  // noise dressed as diagnosis.
+  const host = createStubHost({ seed: 0xd15 })
+  let adjacent = 0
+  let total = 0
+  for (let i = 0; i < 600; i++) {
+    const q = host.next()
+    const answer = Number(q.answer)
+    for (const d of q.distractors) {
+      total += 1
+      if (Math.abs(Number(d) - answer) === 1) adjacent += 1
+    }
+  }
+  assert.ok(total > 800, `only ${total} distractors in 600 questions`)
+  assert.ok(adjacent / total < 0.06, `${adjacent}/${total} distractors were answer ± 1`)
+})
+
+test("a dropped carry is actually in there", () => {
+  // 27 + 15 with every carry dropped is 32. Whatever else the stub produces,
+  // this specific misconception has to be reachable or the diagnosis is empty.
+  const host = createStubHost({ seed: 0xca771 })
+  let found = false
+  for (let i = 0; i < 3000 && !found; i++) {
+    const q = host.next()
+    const match = /^(\d+) \+ (\d+)$/.exec(q.prompt)
+    if (!match) continue
+    const a = Number(match[1])
+    const b = Number(match[2])
+    if (a % 10 + (b % 10) < 10) continue // no carry to drop
+    const dropped = ((a % 10) + (b % 10)) % 10 + (Math.floor(a / 10) + Math.floor(b / 10)) % 10 * 10
+    if (q.distractors.includes(String(dropped))) found = true
+  }
+  assert.ok(found, "no dropped-carry distractor appeared in 3000 questions")
+})
+
+test("transition is present only when someone is watching for it", () => {
+  // The contract has it optional and the game feature-detects it, so a host
+  // without one must be a host the game does not fall over on.
+  const bare = createStubHost({ seed: 1 })
+  assert.equal(bare.transition, undefined)
+  const kinds: string[] = []
+  const watched = createStubHost({ seed: 1, onTransition: (k) => kinds.push(k) })
+  assert.equal(typeof watched.transition, "function")
+  watched.transition?.("level", "resonance")
+  assert.deepEqual(kinds, ["level"])
+})
+
+test("reduced motion is whatever the host says it is", () => {
+  assert.equal(createStubHost({ reducedMotion: true }).prefersReducedMotion(), true)
+  assert.equal(createStubHost({ reducedMotion: false }).prefersReducedMotion(), false)
+})

--- a/dynawalla/games/lattice/tsconfig.json
+++ b/dynawalla/games/lattice/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": false,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/dynawalla/games/lattice/vite.config.ts
+++ b/dynawalla/games/lattice/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite"
+
+// The game is a library that mounts into a host element. `npm run dev` serves
+// the standalone harness in `index.html`, which wires it to the local stub Host
+// so the whole thing is playable with no runtime underneath it.
+export default defineConfig({
+  server: { port: 4351, host: "127.0.0.1" },
+  build: {
+    target: "es2022",
+    lib: {
+      entry: "src/index.ts",
+      name: "DynawallaGameLattice",
+      formats: ["es"],
+      fileName: () => "lattice.js",
+    },
+  },
+})

--- a/dynawalla/games/lattice/vite.pack.config.ts
+++ b/dynawalla/games/lattice/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produces a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})


### PR DESCRIPTION
## What

Adds **THE LATTICE** at `dynawalla/games/lattice` — a twin-stick arena strung on
a mass-spring grid that tears and re-knits, and the Dynawalla pack that ships it.
Rank 2 / S tier / buildCost L in `docs/catalog/ARCADE_CANON.md`, after Geometry
Wars: Retro Evolved 2.

**The mechanic.** Composite **husks** drift on the sheet. A shot cracks one along
a factor pair — 72 → 8 and 9, 8 → 2 and 4, 4 → 2 and 2 — and **a shot at a prime
is refused**, because a prime does not go. So the field grinds itself down into
primes, and primes are what the ship sweeps, into a **factor tile bar** reading
`2·2·3` under a running 12.

**The target-product resonance ships in this PR, and it is where the thinking
is.** A **resonator** hangs in the lattice carrying a problem the curriculum drew
(`47 + 25`) and opens for exactly one thing: a hold whose primes multiply to the
answer. To open it a child has to work out that the answer is 72, decide *which*
primes reach it (2·2·2·3·3), crack the husks holding those primes, and sweep
those and **nothing else** — the hold is exact. Sweeping a stray 5 on the way
past is a real cost with no scolding: the hold now reads 360 and the resonator
does not resonate. Tapping your own tile bar throws the hold back onto the field
as motes so you can build it again; nothing the child worked for is destroyed.

Flying into the resonator asserts `product(hold)` — an exact integer the child
assembled on purpose. That is the only value reported, and the host judges it.

**Primeness is a wall.** When the answer is prime, no multiset of smaller primes
reaches it; the only hold that opens `p` is the single mote `p`, found drifting
on the field. Same property `foundry street` relies on, asserted exhaustively.

## Why

The canon's own caveat on this pack is the brief:

> Honest caveat: the passive layer is absorption, not reasoning; the
> target-product resonance is where the thinking is and it must ship on.

So the passive layer (sweep, watch the tile bar grow) is the default and the
resonance is the reason to fly anywhere in particular. Both are in this PR.

## Blast radius

**Areas touched:** dynawalla — one new directory, `dynawalla/games/lattice/`.
No existing file is touched, renamed or deleted (`--diff-filter=D` is empty).

- [x] Every touched path is covered by a `ci.yml` area filter — same paths as the
      24 shipping `dynawalla/games/*` packs.
- [x] **Pack back-compat.** New pack id `dynawalla.lattice@0.1.0`. Nothing
      published changed in place, no `voiceId` renamed, no catalog entry dropped
      or narrowed. `packs/build.mjs` discovers it by glob; no register edited.
- [x] **Native integrity.** N/A — no Rust, no `src-tauri`, no `links =`, no
      `[patch.crates-io]`.
- [x] **Strings.** N/A for `corpan-app` locales. The pack is `"locales": ["en"]`
      like every shipping game pack; all its strings are drawn on its own canvas.
- [x] **Curriculum.** No skill id renamed or reused; no skill promoted; no
      generator or renderer touched. `covers.skills` declares the **seven active**
      `dw.add.*` rows, each checked by hand against
      `packs/shared/curriculum/src/graph/domains/add.ts`
      (`dw.add.regroup.subtract-tenths` is `status: "draft"` and is deliberately
      **not** declared).
      **There is deliberately no `dw.mul.*` row.** The factorisation is the
      game's own mathematics, not the curriculum's — the `mul` domain is 100%
      `draft`, and declaring a row there would imply coverage the curriculum
      cannot serve. Note that `dw-pack check` does not validate `covers.skills`,
      so this was verified by hand rather than by the gate.
      Every number in the game is an exact integer; there is no float in any
      answer, product or comparison.
- [x] **Secrets.** None. `gitleaks` clean over the branch. The one storage-slot
      constant is named `BEST_SLOT` with a `// gitleaks:allow`, per
      `games/forge/src/game/save.ts`.

### Things this PR was careful about

- **`items.reveal` is declared.** Without it the shared adapter gets an empty
  canonical value and drops every item — the pack would mount, warm, and serve
  zero questions with nothing failing anywhere. The resonator's target *is* the
  canonical value, so this is load-bearing.
- **`audio` is not declared.** That capability is `feedback.sound`, the host's
  sounds. The pack synthesises its own asset-free Web Audio.
- **`localStorage` throws in a pack frame.** `game/best.ts` guards every access
  and holds the best chain in memory too.
- **The pause trap.** `pack.ts` subscribes `mounted.client.on("pause"|"resume")`
  — the methods are inert without it. `pause.test.ts` was verified to fail with
  **every** pause guard removed (see Proof), not by reading the code.
- **Reduced motion is a branch, not a degradation.** Switching the sheet off
  would delete the only cue saying where a number came apart. The reduced branch
  keeps the whole simulation and changes its character: stiff springs, critical
  damping, ~⅕ amplitude, no shake, no ringing — the sheet dents and returns in a
  quarter of a second, and a torn strut is drawn dark rather than flung.
  `grid.test.ts` fails if anyone "fixes" it by turning it off.
- **A real bug the loop test caught.** A released mote used to respawn at the
  ship's own position and be re-swept on the next frame, which silently
  cancelled three rules at once: venting did nothing, a refusal handed the same
  wrong hold straight back, and a jostle cost nothing. Released motes are now
  thrown clear on a ring with a short sweep-deaf window; three regression tests
  cover it.

## Proof

```
$ npm test        # five consecutive runs — one green run is not proof
# tests 71 # pass 71 # fail 0
# tests 71 # pass 71 # fail 0
# tests 71 # pass 71 # fail 0
# tests 71 # pass 71 # fail 0
# tests 71 # pass 71 # fail 0

$ npm run tsc
> tsc --noEmit
(0 errors)

$ npm run build
dist/lattice.js  38.49 kB │ gzip: 11.90 kB
✓ built in 14ms

$ npm run build:pack
dist-pack/pack.html                 1.12 kB │ gzip:  0.58 kB
dist-pack/assets/pack-wSP5g0hJ.js  35.02 kB │ gzip: 12.68 kB
✓ built in 24ms

$ grep -o '<script[^>]*>' dist-pack/pack.html
<script type="module" crossorigin src="./assets/pack-wSP5g0hJ.js">

$ cd ../../packs && node build.mjs lattice
dynawalla.lattice@0.1.0 — THE LATTICE
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 37258 bytes
1 pack(s) built, checked and staged into src-tauri/packs/

$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~178992 bytes (178.99 KB) in 45.5ms
INF no leaks found

$ git diff --name-only --diff-filter=D origin/main...HEAD
(empty)

$ git diff --name-only origin/main...HEAD | grep -cv '^dynawalla/games/lattice/'
0
```

### The pause guards, verified by removing them

Every `if (this.paused) return` was deleted from `Arena`, and `pause`/`resume`
were neutered so the flag was never set and the question mark was never shifted:

```
$ node --test src/test/pause.test.ts     # with EVERY guard removed
not ok 1 - a shot behind the sheet does not crack anything
not ok 2 - a mote reached behind the sheet is not swept
not ok 3 - flying through the resonator behind the sheet reports nothing
not ok 4 - the world does not drift behind the sheet
not ok 5 - the sticks are inert behind the sheet, and a resting thumb flies nothing
not ok 6 - the sheet is not thinking time: the latency reported skips it
not ok 7 - a sheet raised between resonators does not charge the next one for it
not ok 8 - pause and resume are idempotent, and resume alone changes nothing
not ok 9 - the arena comes back: after the sheet lifts everything works again
# tests 9 # pass 0 # fail 9

$ git checkout src/game/arena.ts && npm test
# tests 71 # pass 71 # fail 0
```

### The tests that carry the learning claim

- `resonance.test.ts` — **a target is cleared only by a genuine prime
  factorisation of it**, exhaustive over every multiset of `{2,3,5,7,11,13}` up
  to six tiles against every target from 2 to 200; `[4,3]` does not open 12 and
  `[8,9]` does not open 72. **A prime target cannot be assembled from smaller
  factors**, exhaustive over every multiset of strictly smaller primes for every
  prime under 200. An empty hold asserts nothing and is not reported.
- `bank.test.ts` — **the factor tile bar is always a true factorisation of the
  value beside it**: every tile prime, product exactly the value, ascending —
  asserted after every operation over a 4,000-step seeded sitting of sweeps,
  spills and releases.
- `factor.test.ts` — splitting conserves the product exactly for every composite
  under 2000; grinding a husk to exhaustion yields exactly its prime
  factorisation; `isPrime` checked against a sieve to 1000.
- `arena.test.ts` — the field can always supply the answer's factorisation (50
  seeds); one question, one report; a refusal never raises a `transition`; a
  refusal hands the primes back rather than eating them.
- `loop.test.ts` — a scripted child plays the **real arena through the real
  physics** and opens resonators. The failure it catches is silent and total: a
  game where nothing throws and nothing can ever be beaten.
- `mount.test.ts` — the real shell mounted against a recording canvas at three
  sizes × both motion branches, flown with both thumbs, paused and unmounted.

https://claude.ai/code/session_01Kv5YomKucjKXsH3dusgkeb
