### PR TITLE
dynawalla/games/street: FOUNDRY STREET — the crowd is the array model, and prime is a wall you walk into

### DIFF
--- a/dynawalla/games/street/.gitignore
+++ b/dynawalla/games/street/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+
+# The pack build. `packs/build.mjs` regenerates it and stages it into the app.
+dist-pack/
+
+qa/shots
+qa/tmp
+package-lock.json

--- a/dynawalla/games/street/README.md
+++ b/dynawalla/games/street/README.md
@@ -1,0 +1,85 @@
+# FOUNDRY STREET
+
+*after Final Fight (1989) — `ARCADE_CANON.md` rank 13, S tier*
+
+The night shift comes up the street in a mob. You have two verbs, and both of
+them are claims about a number.
+
+**STRIKE a stud** — *"this number goes into them."* If it does, the crack runs
+the length of the block at 2400 px/s and the mob comes apart into that many to a
+rank: the same bodies, rearranged into a rectangle the child made. If it does
+not, the crack rings off. The mob stands split into groups with the remainder
+left over, and closes back up.
+
+**SWING** — *"they are solid."* Fists work on a rank whose size is prime and
+bounce off one that is not, because a composite rank has something to hold on to
+and a prime rank has nothing.
+
+## Why the mathematics is the mechanic
+
+Nobody is told what a prime is.
+
+A mob of thirteen refuses **every stud on the bar** — and the bar is complete,
+so "nothing on the bar works" means "nothing works". Then it goes down in one
+punch. The two rules are the same rule seen from both sides: *what will not
+break is the thing you can hit.* Primeness is a wall you walk into, not a fact
+you are given.
+
+The rectangle is the array model, and the child builds it. Striking 3 at twelve
+makes four ranks of three, in front of them, out of the same twelve people.
+Knocking those ranks down one at a time is `3 + 3 + 3 + 3`, drawn.
+
+The **hum** is the last piece: a mob drones at `humHz(n) = 264 · n^(−1/3)`,
+which is the design entry's *"block hum pitch is log of the number"* written as
+a power law. Every doubling of the crowd drops it exactly four semitones, so
+halving a mob sounds like the same move whether it was twenty-four going to
+twelve or four going to two. The child hears the number get smaller a frame
+before the crack finishes crossing the street.
+
+The fastest route through a wave is **strike the largest prime that goes into
+them** — `minimumTaps(n) = 1 + n / largestPrimeFactor(n)`, which `factor.test.ts`
+checks against a breadth-first search over real game states rather than against
+the argument in the comment.
+
+## The stake has no clock in it
+
+The mob leans on you when you are wrong (`push.ts`) and gives ground when you
+put a rank down. Six slips with no answer in between and it shoves you back a
+block — the wave restarts with the smallest prime factor lit on the bar, and
+**nothing built is taken**. Standing still and reading the mob costs exactly
+nothing, because a child who is thinking must never be losing.
+
+## What the host judges
+
+The **shutter** between waves, and only that. A problem chalked on steel, four
+rivets carrying the canonical answer and the host's mal-rule outputs, and the
+rivet the child strikes is reported as-is. The game never marks it.
+
+The factoring is the game's own arithmetic and is not reported — only `add` has
+active curriculum rows, so a mob coming apart into ranks is not a question
+anybody asked. `covers.skills` claims the shutter, and every id on it is an
+`active` row of `dw.add`.
+
+## Layout
+
+| | |
+|---|---|
+| `src/game/factor.ts` | primality, seams, the optimal route. Exact integers only. |
+| `src/game/crowd.ts` | `ranks × size`, and the two verbs. Pure. |
+| `src/game/street.ts` | the phase machine, the clock, and the pause guards. |
+| `src/game/shutter.ts` | the plate, and the one report per item. |
+| `src/game/push.ts` | the stake. No durations anywhere in it. |
+| `src/game/energy.ts` | reaction tiers; `energy(SLIP) < energy(SEAT)`. |
+| `src/render/scene.ts` | canvas 2D. Draws the rectangles input reads. |
+| `src/audio/tone.ts` | the hum law, as a pure function with a test. |
+
+```
+npm run dev            the game, wired to the stub host
+npm run dev -- --open  ?seed=1&reduced=1&pause=1
+npm test               97 tests, no canvas, no rAF, no clock
+npm run build:pack     the installable pack
+```
+
+`?pause=1` puts a sheet over the frame for two seconds every time the game
+reports a stopping point, which is what a real host does after a `transition`.
+It is there because that is the state the pause guards exist for.

--- a/dynawalla/games/street/index.html
+++ b/dynawalla/games/street/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <title>FOUNDRY STREET — dev harness</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #0a0806;
+        overscroll-behavior: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+      #readout {
+        position: fixed;
+        left: 8px;
+        bottom: 6px;
+        z-index: 5;
+        font: 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+        color: rgba(255, 255, 255, 0.42);
+        pointer-events: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <div id="readout">host.report → 0/0</div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/street/pack.html
+++ b/dynawalla/games/street/pack.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#0a0806" />
+    <title>FOUNDRY STREET</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: #0a0806;
+        overscroll-behavior: none;
+        -webkit-tap-highlight-color: transparent;
+        -webkit-user-select: none;
+        user-select: none;
+        touch-action: none;
+      }
+      #app {
+        position: fixed;
+        inset: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- The pack entry. No inline script: `script-src` carries no
+         'unsafe-inline' and the document is framed on an opaque origin, so
+         every URL here is relative and resolves against the pack scheme. -->
+    <div id="app"></div>
+    <script type="module" src="/src/pack.ts"></script>
+  </body>
+</html>

--- a/dynawalla/games/street/pack.json
+++ b/dynawalla/games/street/pack.json
@@ -1,0 +1,24 @@
+{
+  "id": "dynawalla.street",
+  "version": "0.1.0",
+  "name": "FOUNDRY STREET",
+  "description": "The night shift comes up the street in a mob. A mob that splits is not a mob — pick the number it splits into and the crack runs the length of the block. What refuses every split is solid, and solid is the only thing your fists can take down.",
+  "sdk": "1.0.0",
+  "host": { "min": "0.1.0", "max": "1.0.0" },
+  "entry": "pack.html",
+  "capabilities": ["items", "items.reveal", "haptics"],
+  "covers": {
+    "skills": [
+      "dw.add.column.add-no-regroup",
+      "dw.add.column.subtract-no-regroup",
+      "dw.add.regroup.add-multidigit",
+      "dw.add.regroup.subtract-multidigit",
+      "dw.add.regroup.add-short-addend",
+      "dw.add.regroup.subtract-short-subtrahend",
+      "dw.add.regroup.subtract-across-zero"
+    ],
+    "grades": [1, 4]
+  },
+  "locales": ["en"],
+  "build": { "config": "vite.pack.config.ts", "out": "dist-pack" }
+}

--- a/dynawalla/games/street/package.json
+++ b/dynawalla/games/street/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@dynawalla/game-street",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "FOUNDRY STREET — a night-shift beat-'em-up where the crowd is the array model. Break a mob along a factor seam; what will not break is prime, and prime is the only thing you can knock down.",
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4321",
+    "tsc": "tsc --noEmit",
+    "test": "node --experimental-strip-types --no-warnings=ExperimentalWarning --test \"src/**/*.test.ts\"",
+    "build:pack": "vite build --config vite.pack.config.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.0",
+    "typescript": "^6.0.0",
+    "vite": "^8.1.5"
+  }
+}

--- a/dynawalla/games/street/src/audio/audio.ts
+++ b/dynawalla/games/street/src/audio/audio.ts
@@ -1,0 +1,235 @@
+// Asset-free Web Audio. No files, no decode, nothing on the answer path.
+//
+// The pack synthesises its own sound with an `AudioContext`; it does **not**
+// declare the `audio` capability, which is the host's own feedback sounds and a
+// different thing entirely.
+//
+// The drone is the point. A mob hums at `humHz(size)` and glides to the new
+// pitch the instant a seam lands, so the child hears twelve become three before
+// the crack has finished crossing the street. Everything else in here is short,
+// dry and mechanical: struck steel, a shutter roll, bodies hitting cobbles. No
+// chimes, no sparkle, and nothing at all that is louder when the child is
+// wrong.
+
+import { BOUNCE_HZ, REWARD_HZ, RINGOFF_HZ, fellHz, humHz } from "./tone.ts"
+
+type Ctx = AudioContext
+
+/** The mix ceiling. Everything below is a fraction of this. */
+const MASTER = 0.5
+
+export class StreetAudio {
+  private ctx: Ctx | null = null
+  private master: GainNode | null = null
+  private drone: OscillatorNode | null = null
+  private droneGain: GainNode | null = null
+  private noise: AudioBuffer | null = null
+  private dead = false
+
+  private ensure(): Ctx | null {
+    if (this.dead) return null
+    if (this.ctx) return this.ctx
+    try {
+      const Ctor =
+        (globalThis as { AudioContext?: typeof AudioContext }).AudioContext ??
+        (globalThis as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+      if (!Ctor) return null
+      const ctx = new Ctor()
+      const master = ctx.createGain()
+      master.gain.value = MASTER
+      master.connect(ctx.destination)
+      this.ctx = ctx
+      this.master = master
+      return ctx
+    } catch (error) {
+      // Loud, never silent. A frame with no audio is playable; a frame that
+      // threw on the first tap is not, and the next person needs to see why.
+      console.warn("[street] no audio context", error)
+      this.dead = true
+      return null
+    }
+  }
+
+  /** Web Audio needs a gesture. The first tap in the game is the first gesture. */
+  resume(): void {
+    const ctx = this.ensure()
+    if (!ctx) return
+    if (ctx.state === "suspended") void ctx.resume().catch(() => {})
+  }
+
+  private noiseBuffer(ctx: Ctx): AudioBuffer {
+    if (this.noise) return this.noise
+    const frames = Math.floor(ctx.sampleRate * 0.4)
+    const buffer = ctx.createBuffer(1, frames, ctx.sampleRate)
+    const data = buffer.getChannelData(0)
+    // A deterministic fill: the same grit every session, and no `Math.random`
+    // anywhere in the shipped runtime.
+    let s = 0x9e3779b9
+    for (let i = 0; i < frames; i++) {
+      s = (Math.imul(s ^ (s >>> 15), s | 1) + 0x6d2b79f5) >>> 0
+      data[i] = (s >>> 0) / 2147483648 - 1
+    }
+    this.noise = buffer
+    return buffer
+  }
+
+  private tone(
+    freq: number,
+    opts: {
+      type?: OscillatorType
+      gain?: number
+      attack?: number
+      decay?: number
+      to?: number
+      delay?: number
+    } = {},
+  ): void {
+    const ctx = this.ensure()
+    if (!ctx || !this.master) return
+    const now = ctx.currentTime + (opts.delay ?? 0)
+    const osc = ctx.createOscillator()
+    const gain = ctx.createGain()
+    osc.type = opts.type ?? "triangle"
+    osc.frequency.setValueAtTime(Math.max(20, freq), now)
+    if (opts.to !== undefined) {
+      osc.frequency.exponentialRampToValueAtTime(Math.max(20, opts.to), now + (opts.decay ?? 0.2))
+    }
+    const peak = opts.gain ?? 0.2
+    gain.gain.setValueAtTime(0.0001, now)
+    gain.gain.exponentialRampToValueAtTime(peak, now + (opts.attack ?? 0.004))
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + (opts.decay ?? 0.2))
+    osc.connect(gain).connect(this.master)
+    osc.start(now)
+    osc.stop(now + (opts.decay ?? 0.2) + 0.05)
+  }
+
+  private grit(opts: { gain?: number; decay?: number; hz?: number; q?: number } = {}): void {
+    const ctx = this.ensure()
+    if (!ctx || !this.master) return
+    const now = ctx.currentTime
+    const src = ctx.createBufferSource()
+    src.buffer = this.noiseBuffer(ctx)
+    const filter = ctx.createBiquadFilter()
+    filter.type = "bandpass"
+    filter.frequency.value = opts.hz ?? 1400
+    filter.Q.value = opts.q ?? 0.8
+    const gain = ctx.createGain()
+    const decay = opts.decay ?? 0.16
+    gain.gain.setValueAtTime(opts.gain ?? 0.18, now)
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + decay)
+    src.connect(filter).connect(gain).connect(this.master)
+    src.start(now)
+    src.stop(now + decay + 0.02)
+  }
+
+  // ------------------------------------------------------------- the mob --
+
+  /** Start or re-pitch the drone. `0` puts it away. */
+  hum(size: number): void {
+    const ctx = this.ensure()
+    if (!ctx || !this.master) return
+    if (size <= 0) {
+      this.droneGain?.gain.setTargetAtTime(0.0001, ctx.currentTime, 0.08)
+      return
+    }
+    if (!this.drone || !this.droneGain) {
+      const osc = ctx.createOscillator()
+      const gain = ctx.createGain()
+      osc.type = "sawtooth"
+      const filter = ctx.createBiquadFilter()
+      filter.type = "lowpass"
+      filter.frequency.value = 620
+      gain.gain.value = 0.0001
+      osc.frequency.value = humHz(size)
+      osc.connect(filter).connect(gain).connect(this.master)
+      osc.start()
+      this.drone = osc
+      this.droneGain = gain
+    }
+    // A glide, not a jump: the mob re-forms over the crack, and the pitch
+    // arriving with the new rectangle is the whole trick.
+    this.drone.frequency.setTargetAtTime(humHz(size), ctx.currentTime, 0.06)
+    this.droneGain.gain.setTargetAtTime(0.055, ctx.currentTime, 0.09)
+  }
+
+  /** A seam landed. Steel parting, then the drone lifts. */
+  crack(size: number): void {
+    this.grit({ gain: 0.26, decay: 0.14, hz: 2600, q: 0.7 })
+    this.tone(humHz(size) * 4, { type: "square", gain: 0.16, decay: 0.12, to: humHz(size) * 6 })
+  }
+
+  /** A seam refused. One hard ring, and nothing else. */
+  ringoff(): void {
+    this.tone(RINGOFF_HZ, { type: "square", gain: 0.1, decay: 0.11, to: RINGOFF_HZ * 0.94 })
+    this.grit({ gain: 0.08, decay: 0.07, hz: 3200, q: 2 })
+  }
+
+  /** Fists off locked arms. Dull, low, over immediately. */
+  bounce(): void {
+    this.tone(BOUNCE_HZ, { type: "sine", gain: 0.15, decay: 0.1, to: BOUNCE_HZ * 0.7 })
+  }
+
+  /** A rank going down. */
+  down(size: number): void {
+    this.tone(fellHz(size), { type: "triangle", gain: 0.2, decay: 0.18 })
+    this.tone(70, { type: "sine", gain: 0.22, decay: 0.2, to: 44 })
+    this.grit({ gain: 0.1, decay: 0.1, hz: 700, q: 0.6 })
+  }
+
+  /** The street is empty. A short rising figure; the longest reward is a block. */
+  cleared(solid: boolean): void {
+    const notes = solid ? [0, 2, 4] : [0, 2]
+    notes.forEach((i, n) => {
+      this.tone(REWARD_HZ[i] as number, { gain: 0.15, decay: 0.34, delay: n * 0.075 })
+    })
+  }
+
+  /** A block finished. The only tier-3 sound in the game. */
+  block(): void {
+    REWARD_HZ.forEach((hz, n) => {
+      this.tone(hz, { gain: 0.14, decay: 0.5, delay: n * 0.06 })
+    })
+    this.tone(REWARD_HZ[0] as number, { gain: 0.12, decay: 0.9, delay: 0.34, type: "sine" })
+  }
+
+  // --------------------------------------------------------- the shutter --
+
+  shutter(up: boolean): void {
+    this.grit({ gain: 0.14, decay: 0.4, hz: up ? 900 : 500, q: 0.5 })
+    this.tone(up ? 180 : 130, { type: "sawtooth", gain: 0.08, decay: 0.34, to: up ? 300 : 90 })
+  }
+
+  rivet(right: boolean): void {
+    if (right) {
+      this.tone(880, { type: "square", gain: 0.13, decay: 0.14, to: 1320 })
+      return
+    }
+    this.tone(240, { type: "square", gain: 0.09, decay: 0.12, to: 180 })
+  }
+
+  /** The mob leans in. A pressure sound, not an alarm. */
+  lean(marks: number): void {
+    this.tone(58 + marks * 5, { type: "sine", gain: 0.12, decay: 0.26, to: 42 })
+  }
+
+  /** Shoved back a block. */
+  shove(): void {
+    this.grit({ gain: 0.2, decay: 0.44, hz: 340, q: 0.4 })
+    this.tone(120, { type: "sawtooth", gain: 0.14, decay: 0.5, to: 60 })
+  }
+
+  dispose(): void {
+    this.dead = true
+    try {
+      this.drone?.stop()
+    } catch {
+      console.warn("[street] the drone would not stop")
+    }
+    this.drone = null
+    this.droneGain = null
+    const ctx = this.ctx
+    this.ctx = null
+    this.master = null
+    void ctx?.close().catch(() => {})
+  }
+}

--- a/dynawalla/games/street/src/audio/tone.test.ts
+++ b/dynawalla/games/street/src/audio/tone.test.ts
@@ -1,0 +1,91 @@
+// The design entry names one sound out loud: **the block hum pitch is the log
+// of the number.** So it is checked as a law rather than as a table of
+// frequencies — the frequencies are taste, the law is the design.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { crowdPool } from "../game/factor.ts"
+import {
+  BOUNCE_HZ,
+  HUM_ROOT,
+  HUM_SEMITONES_PER_DOUBLING,
+  REWARD_HZ,
+  RINGOFF_HZ,
+  fellHz,
+  humHz,
+  humSemitones,
+} from "./tone.ts"
+
+test("a bigger mob hums lower, strictly, at every size", () => {
+  for (let n = 1; n < 64; n++) {
+    assert.ok(humHz(n + 1) < humHz(n), `${n + 1} did not hum below ${n}`)
+  }
+})
+
+test("the pitch is the log of the number: every doubling is the same interval", () => {
+  // This is the whole claim. Halving a mob sounds like the same move whether it
+  // was twenty-four going to twelve or four going to two, so the child hears
+  // "smaller by the same amount" and not merely "different".
+  const step = 12 * Math.log2(humHz(1) / humHz(2))
+  assert.ok(Math.abs(step - HUM_SEMITONES_PER_DOUBLING) < 1e-9)
+  for (let n = 1; n <= 40; n++) {
+    const interval = 12 * Math.log2(humHz(n) / humHz(n * 2))
+    assert.ok(
+      Math.abs(interval - HUM_SEMITONES_PER_DOUBLING) < 1e-9,
+      `${n} → ${n * 2} moved ${interval} semitones`,
+    )
+  }
+  // And a quadrupling is exactly twice a doubling, which is what "log" means.
+  for (let n = 1; n <= 20; n++) {
+    const four = 12 * Math.log2(humHz(n) / humHz(n * 4))
+    assert.ok(Math.abs(four - 2 * HUM_SEMITONES_PER_DOUBLING) < 1e-9)
+  }
+})
+
+test("humSemitones is humHz said the other way round", () => {
+  for (let n = 1; n <= 40; n++) {
+    const fromHz = 12 * Math.log2(humHz(n) / HUM_ROOT)
+    assert.ok(Math.abs(fromHz - humSemitones(n)) < 1e-9, `${n}`)
+  }
+  // `-0 === 0`, and a mob of one is the root by definition.
+  assert.ok(humSemitones(1) === 0)
+})
+
+test("every mob the street can send hums somewhere audible", () => {
+  for (const n of crowdPool()) {
+    const hz = humHz(n)
+    assert.ok(Number.isFinite(hz))
+    assert.ok(hz > 60, `a mob of ${n} hums at ${hz} Hz, below a tablet speaker`)
+    assert.ok(hz < 400, `a mob of ${n} hums at ${hz} Hz, up among the numerals`)
+    assert.ok(fellHz(n) > hz, "a rank fell below its own drone")
+  }
+})
+
+test("a degenerate size does not produce a degenerate pitch", () => {
+  for (const n of [0, -3, 0.5, Number.NaN]) {
+    const hz = humHz(n)
+    assert.ok(Number.isFinite(hz) || Number.isNaN(n), `humHz(${n}) = ${hz}`)
+  }
+  assert.equal(humHz(0), HUM_ROOT)
+  assert.equal(humHz(-9), HUM_ROOT)
+})
+
+test("a refusal does not sing the mob's number", () => {
+  // A ring-off is the sound of a stud hitting something that does not give, and
+  // it is the same sound whichever mob refused it. One that carried the number
+  // would hand the child information for being wrong.
+  assert.equal(typeof RINGOFF_HZ, "number")
+  assert.ok(RINGOFF_HZ > 1000)
+  for (const n of crowdPool()) {
+    assert.notEqual(humHz(n), RINGOFF_HZ)
+  }
+  assert.ok(BOUNCE_HZ < humHz(24), "locked arms rang above the biggest mob")
+})
+
+test("the reward notes are a pentatonic and nothing is doubled", () => {
+  assert.equal(new Set(REWARD_HZ).size, REWARD_HZ.length)
+  for (let i = 1; i < REWARD_HZ.length; i++) {
+    assert.ok((REWARD_HZ[i] as number) > (REWARD_HZ[i - 1] as number))
+  }
+})

--- a/dynawalla/games/street/src/audio/tone.ts
+++ b/dynawalla/games/street/src/audio/tone.ts
@@ -1,0 +1,65 @@
+// The hum law, and why it is a pure function in its own file.
+//
+// The design entry for this game names one sound out loud: **the block's hum
+// pitch is the log of the number.** That is not decoration. A mob standing in
+// the street hums, and the hum is the only thing in the game that tells you how
+// big it is *before* you read the lamp — so when a seam lands and twelve
+// becomes four ranks of three, the drone jumps up a fixed interval and the
+// child hears the number get smaller a frame before they see it.
+//
+// Written as a power law, which is the same statement:
+//
+//     pitch in semitones  =  const − 12/3 · log2(n)
+//     frequency in hertz  =  HUM_ROOT · n^(−1/3)
+//
+// Every doubling of the crowd drops the hum by exactly four semitones — a major
+// third, the same interval every time, so halving a mob twice is audibly the
+// same move twice. `tone.test.ts` asserts the interval is constant rather than
+// asserting particular frequencies, because the constancy is the design and the
+// frequencies are taste.
+
+/** The hum of a mob of one, extended down from. Below the numerals, above mud. */
+export const HUM_ROOT = 264
+
+/** Semitones the hum falls per doubling of the crowd. */
+export const HUM_SEMITONES_PER_DOUBLING = 4
+
+/** The drone of a rank of `n`. Bigger mob, lower hum. */
+export function humHz(n: number): number {
+  const size = Math.max(1, n)
+  return HUM_ROOT * Math.pow(size, -HUM_SEMITONES_PER_DOUBLING / 12)
+}
+
+/** The same law in semitones, for anything that wants to reason in intervals. */
+export function humSemitones(n: number): number {
+  return -HUM_SEMITONES_PER_DOUBLING * Math.log2(Math.max(1, n))
+}
+
+/**
+ * The pitch a falling rank rings at: the hum of its own size, an octave up, so
+ * a rank of three and a rank of eleven are told apart by ear as they go down.
+ */
+export function fellHz(n: number): number {
+  return humHz(n) * 2
+}
+
+/**
+ * The ring of a refused seam.
+ *
+ * Deliberately **not** derived from the mob: a ring-off is the sound of a stud
+ * hitting something that does not give, and it is the same sound whichever mob
+ * refused it. A ring-off that sang the mob's number would reward being wrong
+ * with information the child did not earn.
+ */
+export const RINGOFF_HZ = 1860
+
+/**
+ * The dull note of fists off locked arms.
+ *
+ * Below the drone of the biggest mob there is, on purpose: a bounce is the mob
+ * absorbing a punch, and it has to sit under them rather than ring out of them.
+ */
+export const BOUNCE_HZ = 72
+
+/** The pentatonic the rewards are built on, in hertz. C5 minor pentatonic. */
+export const REWARD_HZ: readonly number[] = [523.25, 622.25, 698.46, 783.99, 932.33] as const

--- a/dynawalla/games/street/src/contract.ts
+++ b/dynawalla/games/street/src/contract.ts
@@ -1,0 +1,51 @@
+// The host↔game contract. This is the shape the runtime lands underneath us;
+// it must not drift. Nothing else in this package may redefine these types.
+//
+// `mount` delegates to `./mount.ts`. That module imports `Host` from here
+// type-only, and a type-only import is erased, so there is no runtime cycle.
+
+import { mountStreet } from "./mount.ts"
+
+export type Question = {
+  id: string
+  /** "47 + 25" — the operator glyph is already in it. */
+  prompt: string
+  /** "72" — exact, canonical, and never computed by this game. */
+  answer: string
+  /**
+   * Wrong values a child actually produces: the host's mal-rule outputs first,
+   * near-misses after. They go on the rivets, which is why choosing between
+   * them is arithmetic rather than elimination.
+   */
+  distractors: string[]
+  domain: string
+  difficulty: number
+}
+
+export type Host = {
+  next(opts?: { domain?: string; difficulty?: number }): Question
+  report(r: { questionId: string; correct: boolean; ms: number; answered: string }): void
+  haptic(k: "light" | "medium" | "heavy" | "success" | "failure"): void
+  prefersReducedMotion(): boolean
+
+  /**
+   * A natural stopping point the child *reached*: a level cleared, a run
+   * completed, a boss down.
+   *
+   * OPTIONAL and feature-detected — a stub host does not implement it and the
+   * game must not care. Fire and forget: nothing is returned, nothing may be
+   * awaited, and the game must not branch on it.
+   *
+   * **Never after a failure.** This game fires it on a finished block and
+   * nowhere else — never on a shove-back, never on a caved rivet. A purchase
+   * surface must not sit next to a failure.
+   */
+  transition?(kind: "level" | "run" | "boss", label?: string): void
+}
+
+export function mount(
+  el: HTMLElement,
+  host: Host,
+): { unmount(): void; pause(): void; resume(): void } {
+  return mountStreet(el, host)
+}

--- a/dynawalla/games/street/src/core/feel.ts
+++ b/dynawalla/games/street/src/core/feel.ts
@@ -1,0 +1,87 @@
+// Timings, and the one number the design document names out loud.
+//
+// Reduced motion is a **branch**, not a degradation (`EXPERIENCE_DESIGN.md`).
+// The reduced table below keeps every beat that carries information — the crack
+// still travels, the ring-off still holds the mob still long enough to read the
+// remainder — and removes travel and particles. Nothing gets shorter than the
+// time it takes to read what happened.
+
+/**
+ * The crack runs at **2400 px/s**. Straight out of the design entry, and the
+ * reason a landing seam feels like a decision that already happened rather than
+ * an animation you wait for: across a 900 px street that is 375 ms, and across
+ * a 320 px phone it is 133 ms.
+ *
+ * It is a *speed*, not a duration, which is the whole point — the crack takes
+ * as long as the street is wide, so a big mob's break is visibly a longer event
+ * than a small one's on the same screen.
+ */
+export const CRACK_PX_PER_S = 2400
+
+/** How long a crack across `px` of street takes, in milliseconds. */
+export function crackMs(px: number): number {
+  return (Math.max(0, px) / CRACK_PX_PER_S) * 1000
+}
+
+export type Timing = {
+  /** The mob walking on at the top of a wave. */
+  readonly approach: number
+  /** Held after the crack lands, so the new rectangle is read before input reopens. */
+  readonly settle: number
+  /** A refused seam. Long enough to count the remainder standing in the gap. */
+  readonly ringoff: number
+  /** Fists off locked arms. Short: being wrong is never the interesting frame. */
+  readonly bounce: number
+  /** One rank going down. */
+  readonly fall: number
+  /** The street empty, before the shutter comes down. */
+  readonly clear: number
+  /** The shutter rolling down, and rolling up again. */
+  readonly shutterDown: number
+  readonly shutterUp: number
+  /** A rivet caving in. */
+  readonly rivet: number
+  /** Being shoved back a block. */
+  readonly shove: number
+}
+
+export const TIMING: Timing = {
+  approach: 620,
+  settle: 260,
+  // The longest thing that is not a reward, because it is the most informative:
+  // the mob stands split into groups with the remainder over, and then closes.
+  ringoff: 720,
+  bounce: 240,
+  fall: 190,
+  clear: 700,
+  shutterDown: 420,
+  shutterUp: 520,
+  rivet: 260,
+  shove: 900,
+}
+
+export const TIMING_REDUCED: Timing = {
+  approach: 260,
+  settle: 200,
+  // Unchanged. There is no travel in standing still to reduce, and shortening
+  // it would take away the only chance to read the remainder.
+  ringoff: 720,
+  bounce: 200,
+  fall: 120,
+  clear: 360,
+  shutterDown: 200,
+  shutterUp: 240,
+  rivet: 200,
+  shove: 420,
+}
+
+/**
+ * The largest step the clock takes in one frame.
+ *
+ * A backgrounded tab hands back a delta of minutes. Letting that through would
+ * run a whole wave while the child was looking at something else. Clamping
+ * means time nearly stops when frames stop, which is the only fair reading of
+ * "they were not here" — and it is a different mechanism from `pause`, which is
+ * the host telling us so explicitly.
+ */
+export const MAX_STEP_MS = 120

--- a/dynawalla/games/street/src/core/rng.ts
+++ b/dynawalla/games/street/src/core/rng.ts
@@ -1,0 +1,61 @@
+// A seeded, deterministic PRNG. Every stochastic decision in the game and in
+// the stub host runs through one of these so a run can be replayed exactly, and
+// so a test never depends on `Math.random`.
+//
+// mulberry32: 32-bit state, no allocation, and trivially portable to a test.
+
+export class Rng {
+  private s: number
+
+  constructor(seed: number) {
+    // Force to uint32; a 0 seed is legal for mulberry32 but degenerate-looking,
+    // so nudge it off zero.
+    this.s = (seed >>> 0) || 0x9e3779b9
+  }
+
+  /** Uniform in [0, 1). */
+  next(): number {
+    this.s = (this.s + 0x6d2b79f5) >>> 0
+    let t = this.s
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+
+  /** Uniform in [lo, hi). */
+  range(lo: number, hi: number): number {
+    return lo + this.next() * (hi - lo)
+  }
+
+  /** Uniform integer in [lo, hi] inclusive. */
+  int(lo: number, hi: number): number {
+    if (hi <= lo) return lo
+    return lo + Math.floor(this.next() * (hi - lo + 1))
+  }
+
+  /** True with probability p. */
+  chance(p: number): boolean {
+    return this.next() < p
+  }
+
+  pick<T>(xs: readonly T[]): T {
+    if (xs.length === 0) throw new Error("rng.pick: empty")
+    return xs[Math.floor(this.next() * xs.length)] as T
+  }
+
+  /** In-place Fisher–Yates. Returns the same array for chaining. */
+  shuffle<T>(xs: T[]): T[] {
+    for (let i = xs.length - 1; i > 0; i--) {
+      const j = Math.floor(this.next() * (i + 1))
+      const a = xs[i] as T
+      xs[i] = xs[j] as T
+      xs[j] = a
+    }
+    return xs
+  }
+
+  /** Snapshot/restore so a subsystem can be forked without disturbing the run. */
+  fork(salt: number): Rng {
+    return new Rng((this.s ^ Math.imul(salt, 0x85ebca6b)) >>> 0)
+  }
+}

--- a/dynawalla/games/street/src/game/best.test.ts
+++ b/dynawalla/games/street/src/game/best.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { blocksCleared, recordBlocks, resetBlocks } from "./best.ts"
+
+type Store = { getItem(k: string): string | null; setItem(k: string, v: string): void }
+
+function withStorage(store: Store | null, body: () => void): void {
+  const g = globalThis as { localStorage?: unknown }
+  const had = Object.prototype.hasOwnProperty.call(g, "localStorage")
+  const before = g.localStorage
+  Object.defineProperty(g, "localStorage", { value: store, configurable: true, writable: true })
+  try {
+    body()
+  } finally {
+    if (had) Object.defineProperty(g, "localStorage", { value: before, configurable: true, writable: true })
+    else delete g.localStorage
+  }
+}
+
+function memoryStore(): Store & { map: Map<string, string> } {
+  const map = new Map<string, string>()
+  return {
+    map,
+    getItem: (k) => map.get(k) ?? null,
+    setItem: (k, v) => {
+      map.set(k, v)
+    },
+  }
+}
+
+/** A pack frame: an opaque origin, and a `localStorage` that *raises*. */
+function refusingStore(): Store {
+  return {
+    getItem() {
+      throw new DOMException("The operation is insecure.", "SecurityError")
+    },
+    setItem() {
+      throw new DOMException("The operation is insecure.", "SecurityError")
+    },
+  }
+}
+
+test("the count never goes down", () => {
+  resetBlocks()
+  withStorage(memoryStore(), () => {
+    assert.equal(recordBlocks(4), true)
+    assert.equal(blocksCleared(), 4)
+    assert.equal(recordBlocks(2), false, "a smaller number replaced the record")
+    assert.equal(blocksCleared(), 4)
+    assert.equal(recordBlocks(4), false)
+    assert.equal(recordBlocks(5), true)
+    assert.equal(blocksCleared(), 5)
+  })
+  resetBlocks()
+})
+
+test("a refusing store costs the session, not the pack", () => {
+  // `localStorage` throws inside a pack frame. The record has to survive that
+  // in memory, because a pack that crashed on the first block cleared would
+  // show the child nothing ever again.
+  resetBlocks()
+  withStorage(refusingStore(), () => {
+    assert.equal(blocksCleared(), 0)
+    assert.equal(recordBlocks(3), true)
+    assert.equal(blocksCleared(), 3, "the record was lost when the store refused")
+    assert.equal(recordBlocks(1), false)
+    assert.equal(blocksCleared(), 3)
+  })
+  resetBlocks()
+})
+
+test("no store at all is not an error either", () => {
+  resetBlocks()
+  withStorage(null, () => {
+    assert.equal(blocksCleared(), 0)
+    assert.equal(recordBlocks(2), true)
+    assert.equal(blocksCleared(), 2)
+  })
+  resetBlocks()
+})
+
+test("a stored value is read back, and rubbish in the slot is not", () => {
+  const store = memoryStore()
+  store.map.set("dynawalla.street.blocks.v1", "7")
+  resetBlocks()
+  withStorage(store, () => {
+    assert.equal(blocksCleared(), 7)
+  })
+  store.map.set("dynawalla.street.blocks.v1", "not a number")
+  resetBlocks()
+  withStorage(store, () => {
+    assert.equal(blocksCleared(), 0)
+  })
+  store.map.set("dynawalla.street.blocks.v1", "-4")
+  resetBlocks()
+  withStorage(store, () => {
+    assert.equal(blocksCleared(), 0)
+  })
+  resetBlocks()
+})
+
+test("only whole blocks are recorded", () => {
+  resetBlocks()
+  withStorage(memoryStore(), () => {
+    assert.equal(recordBlocks(2.7), true)
+    assert.equal(blocksCleared(), 2)
+    assert.equal(recordBlocks(Number.NaN), false)
+    assert.equal(blocksCleared(), 2)
+  })
+  resetBlocks()
+})

--- a/dynawalla/games/street/src/game/best.ts
+++ b/dynawalla/games/street/src/game/best.ts
@@ -1,0 +1,61 @@
+// Blocks cleared, remembered.
+//
+// **`localStorage` throws inside a pack frame.** The document is on an opaque
+// origin, and a WebKit that refuses the property does it by raising rather than
+// by returning `null`. So the record lives in memory first and the store is a
+// best-effort mirror: a pack that could not persist still shows the child the
+// right number for the length of the session, and a pack that *crashed* on the
+// first block cleared would show them nothing ever again.
+//
+// Nothing here ever goes down. `record()` keeps the larger of the two, which is
+// the whole of `P-04` in one line: construction does not regress.
+
+// A storage slot, versioned so a schema change orphans an old value rather than
+// mis-reading it. `gitleaks:allow` because the pinned scanner's
+// `generic-api-key` rule reads `KEY = "<long dotted string>"` as a credential.
+// It is a storage path, it is on the client, and it is in a public repo on
+// purpose.
+const BEST_SLOT = "dynawalla.street.blocks.v1" // gitleaks:allow
+
+let memory = 0
+let loaded = false
+
+function read(): number {
+  try {
+    const raw = globalThis.localStorage?.getItem(BEST_SLOT)
+    const n = raw === null || raw === undefined ? 0 : Number.parseInt(raw, 10)
+    return Number.isInteger(n) && n > 0 ? n : 0
+  } catch (error) {
+    // Noisy, never silent: a storage that refuses is a real fact about the
+    // frame and the next person debugging it should be able to see it.
+    console.warn("[street] blocks cleared could not be read", error)
+    return 0
+  }
+}
+
+export function blocksCleared(): number {
+  if (!loaded) {
+    loaded = true
+    memory = Math.max(memory, read())
+  }
+  return memory
+}
+
+/** Returns true when this beat the record. */
+export function recordBlocks(blocks: number): boolean {
+  const n = Math.trunc(blocks)
+  if (!Number.isInteger(n) || n <= blocksCleared()) return false
+  memory = n
+  try {
+    globalThis.localStorage?.setItem(BEST_SLOT, String(n))
+  } catch (error) {
+    console.warn("[street] blocks cleared could not be written", error)
+  }
+  return true
+}
+
+/** Tests only: forget everything, including whether the store was consulted. */
+export function resetBlocks(): void {
+  memory = 0
+  loaded = false
+}

--- a/dynawalla/games/street/src/game/crowd.test.ts
+++ b/dynawalla/games/street/src/game/crowd.test.ts
@@ -1,0 +1,148 @@
+// The crowd, played through without a canvas.
+//
+// The invariant that carries the art direction as much as the arithmetic:
+// **nobody leaves a crack.** A seam rearranges the same bodies into a different
+// rectangle, and if that ever stopped being exactly true the array model on
+// screen would be a picture of a lie.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import {
+  canPunch,
+  isCleanBreak,
+  isCleared,
+  newCrowd,
+  punch,
+  standing,
+  strike,
+  type Crowd,
+} from "./crowd.ts"
+import { bar, crowdPool, isPrime, minimumTaps, seamsFor } from "./factor.ts"
+
+test("a landing seam conserves every body", () => {
+  for (const n of crowdPool()) {
+    const start = newCrowd(n)
+    for (const k of bar(n)) {
+      const result = strike(start, k)
+      if (result.kind !== "crack") continue
+      assert.equal(standing(result.crowd), standing(start), `${k} on ${n} lost bodies`)
+      assert.equal(result.crowd.size, k, "the new rank is not the stud struck")
+      assert.equal(result.crowd.ranks * k, n)
+      assert.equal(result.crowd.total, n)
+      assert.equal(result.crowd.downed, 0)
+    }
+  }
+})
+
+test("a refused seam changes nothing at all", () => {
+  for (const n of crowdPool()) {
+    const start = newCrowd(n)
+    for (const k of bar(n)) {
+      const result = strike(start, k)
+      if (result.kind !== "ringoff") continue
+      assert.deepEqual(result.crowd, start, `${k} on ${n} moved the mob`)
+      assert.equal(result.remainder, n % k)
+      assert.ok(result.remainder > 0, "a refusal with no remainder is a landing")
+    }
+  }
+})
+
+test("a prime mob refuses every stud on its bar", () => {
+  for (const n of crowdPool()) {
+    if (!isPrime(n)) continue
+    const start = newCrowd(n)
+    assert.deepEqual(seamsFor(n), [])
+    for (const k of bar(n)) {
+      assert.equal(strike(start, k).kind, "ringoff", `${k} broke the prime ${n}`)
+    }
+    // And the thing that will not break is the thing you can hit.
+    assert.equal(canPunch(start), true, `the prime ${n} could not be punched`)
+  }
+})
+
+test("fists bounce off a composite rank and land on a prime one", () => {
+  for (const n of crowdPool()) {
+    const start = newCrowd(n)
+    const result = punch(start)
+    if (isPrime(n)) {
+      assert.equal(result.kind, "down", `the prime ${n} did not go down`)
+      if (result.kind !== "down") return
+      assert.equal(result.felled, n)
+      assert.equal(result.cleared, true)
+      assert.equal(result.crowd.downed, n)
+      assert.equal(standing(result.crowd), 0)
+    } else {
+      assert.equal(result.kind, "bounce", `the composite ${n} was punched down`)
+      if (result.kind !== "bounce") return
+      assert.deepEqual(result.crowd, start)
+    }
+  }
+})
+
+test("standing plus downed is the whole mob at every step of every wave", () => {
+  const rng = new Rng(0x51de)
+  for (const n of crowdPool()) {
+    let crowd = newCrowd(n)
+    let guard = 0
+    while (!isCleared(crowd) && guard++ < 400) {
+      assert.equal(standing(crowd) + crowd.downed, crowd.total, `bookkeeping broke on ${n}`)
+      if (canPunch(crowd)) {
+        const result = punch(crowd)
+        assert.equal(result.kind, "down")
+        crowd = result.crowd
+        continue
+      }
+      // A composite rank: take a seam at random from the ones on offer, so the
+      // walk is not the same walk every time.
+      const seams = seamsFor(crowd.size)
+      assert.ok(seams.length > 0, `stuck on a rank of ${crowd.size}`)
+      const result = strike(crowd, rng.pick(seams))
+      assert.equal(result.kind, "crack")
+      crowd = result.crowd
+    }
+    assert.equal(isCleared(crowd), true, `a crowd of ${n} never cleared`)
+    assert.equal(crowd.downed, n)
+    assert.equal(standing(crowd), 0)
+  }
+})
+
+test("every wave clears however badly it is played", () => {
+  // The worst legal play: always take the *smallest* seam, which is the longest
+  // route through the tree. It still terminates, and it still terminates fast
+  // enough that a child who never finds the good move is not stranded.
+  for (const n of crowdPool()) {
+    let crowd = newCrowd(n)
+    let taps = 0
+    let guard = 0
+    while (!isCleared(crowd) && guard++ < 500) {
+      if (canPunch(crowd)) {
+        crowd = (punch(crowd) as { crowd: Crowd }).crowd
+      } else {
+        const worst = seamsFor(crowd.size)[0] as number
+        crowd = (strike(crowd, worst) as { crowd: Crowd }).crowd
+      }
+      taps++
+    }
+    assert.equal(isCleared(crowd), true, `the worst play never cleared ${n}`)
+    assert.ok(taps >= minimumTaps(n), `the worst play beat the optimum on ${n}`)
+    assert.ok(taps <= 16, `the worst play on ${n} took ${taps} taps`)
+  }
+})
+
+test("a punched-out crowd stays punched out", () => {
+  let crowd = newCrowd(5)
+  crowd = (punch(crowd) as { crowd: Crowd }).crowd
+  assert.equal(isCleared(crowd), true)
+  assert.equal(canPunch(crowd), false)
+  assert.equal(punch(crowd).kind, "bounce")
+  assert.equal(strike(crowd, 2).kind, "ringoff")
+})
+
+test("a clean break is the minimum with nothing refused", () => {
+  assert.equal(isCleanBreak(5, 0, 5), true)
+  assert.equal(isCleanBreak(5, 1, 5), false, "an error still counted as clean")
+  assert.equal(isCleanBreak(6, 0, 5), false, "a longer route still counted as clean")
+  assert.equal(isCleanBreak(minimumTaps(12), 0, minimumTaps(12)), true)
+})

--- a/dynawalla/games/street/src/game/crowd.ts
+++ b/dynawalla/games/street/src/game/crowd.ts
@@ -1,0 +1,117 @@
+// The crowd, as two integers.
+//
+// `ranks` ranks of `size` bodies. That is the whole state, and it is why the
+// thing on screen is always a rectangle rather than a heap that happens to
+// arrange itself into one: there is no representation here for a ragged crowd.
+//
+// Everything is pure. `street.ts` owns the clock and the animations; this file
+// owns what is true, and `crowd.test.ts` plays whole waves through it with no
+// canvas, no rAF and no host.
+
+import { isPrime, isSeam, leftover } from "./factor.ts"
+
+export type Crowd = {
+  /** How many ranks are still standing. Never negative. */
+  readonly ranks: number
+  /** Bodies in each rank. Every rank is the same width — see the file header. */
+  readonly size: number
+  /** Bodies knocked down so far this wave. Counts up, never down. */
+  readonly downed: number
+  /** Bodies the wave started with. `standing + downed === total`, always. */
+  readonly total: number
+}
+
+export function newCrowd(total: number): Crowd {
+  const n = Math.max(2, Math.trunc(total))
+  return { ranks: 1, size: n, downed: 0, total: n }
+}
+
+/** Bodies still on their feet. */
+export function standing(crowd: Crowd): number {
+  return crowd.ranks * crowd.size
+}
+
+export function isCleared(crowd: Crowd): boolean {
+  return crowd.ranks === 0
+}
+
+/** A rank can be knocked down exactly when it is prime. This is the game. */
+export function canPunch(crowd: Crowd): boolean {
+  return crowd.ranks > 0 && isPrime(crowd.size)
+}
+
+export type StrikeResult =
+  | {
+      readonly kind: "crack"
+      readonly crowd: Crowd
+      /** The stud that landed. */
+      readonly seam: number
+      /** Ranks before and after, so the renderer can draw the split. */
+      readonly wasRanks: number
+      readonly wasSize: number
+    }
+  | {
+      readonly kind: "ringoff"
+      readonly crowd: Crowd
+      readonly seam: number
+      /** Bodies left standing outside the groups. The remainder, made visible. */
+      readonly remainder: number
+    }
+
+/**
+ * Strike stud `k` at the crowd.
+ *
+ * On a landing the body count is conserved by construction — `size / k` is an
+ * exact integer because `isSeam` already established that `k` divides `size` —
+ * and `crowd.test.ts` asserts conservation over every crowd and every stud.
+ */
+export function strike(crowd: Crowd, k: number): StrikeResult {
+  if (crowd.ranks === 0 || !isSeam(crowd.size, k)) {
+    return { kind: "ringoff", crowd, seam: k, remainder: leftover(crowd.size, k) }
+  }
+  const groups = crowd.size / k
+  return {
+    kind: "crack",
+    crowd: { ...crowd, ranks: crowd.ranks * groups, size: k },
+    seam: k,
+    wasRanks: crowd.ranks,
+    wasSize: crowd.size,
+  }
+}
+
+export type PunchResult =
+  | {
+      readonly kind: "down"
+      readonly crowd: Crowd
+      /** Bodies that just fell. One rank's worth. */
+      readonly felled: number
+      /** The wave ended with this punch. */
+      readonly cleared: boolean
+    }
+  | {
+      readonly kind: "bounce"
+      readonly crowd: Crowd
+      /** Why it bounced: they are locked, and this is what they are locked as. */
+      readonly size: number
+    }
+
+/** Swing at the front rank. */
+export function punch(crowd: Crowd): PunchResult {
+  if (!canPunch(crowd)) return { kind: "bounce", crowd, size: crowd.size }
+  const next: Crowd = {
+    ...crowd,
+    ranks: crowd.ranks - 1,
+    downed: crowd.downed + crowd.size,
+  }
+  return { kind: "down", crowd: next, felled: crowd.size, cleared: next.ranks === 0 }
+}
+
+/**
+ * A clean break is a wave cleared in the fewest taps there are, with nothing
+ * refused along the way. It is not a score and it is not shown as a percentage:
+ * it is a stamp on a wave that was played well, and the street forgets it
+ * immediately.
+ */
+export function isCleanBreak(taps: number, errors: number, minimum: number): boolean {
+  return errors === 0 && taps === minimum
+}

--- a/dynawalla/games/street/src/game/energy.test.ts
+++ b/dynawalla/games/street/src/game/energy.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  type Beat,
+  HAPTIC,
+  REWARDS,
+  SEATS,
+  SLIPS,
+  TIER_BUDGET,
+  energy,
+  reactionFor,
+} from "./energy.ts"
+
+const ctx = { size: 8, bestSeam: false }
+
+test("being wrong is never more interesting than being right", () => {
+  // `energy(SLIP) < energy(SEAT)`, the invariant from EXPERIENCE_DESIGN.md, and
+  // in this game the temptation it guards is specific: a refused seam wants
+  // sparks the whole width of the street.
+  const quietestSeat = Math.min(...SEATS.map((b) => energy(reactionFor(b, ctx))))
+  for (const slip of SLIPS) {
+    const e = energy(reactionFor(slip, ctx))
+    assert.ok(e < quietestSeat, `${slip} (${e}) is louder than the quietest seat (${quietestSeat})`)
+  }
+})
+
+test("a reward is louder than a seat, and a block is the loudest thing there is", () => {
+  const loudestSeat = Math.max(...SEATS.map((b) => energy(reactionFor(b, ctx))))
+  for (const reward of REWARDS) {
+    assert.ok(energy(reactionFor(reward, ctx)) > loudestSeat, `${reward} is quieter than a seat`)
+  }
+  const block = energy(reactionFor("block", ctx))
+  for (const beat of [...SLIPS, ...SEATS, ...REWARDS] as Beat[]) {
+    if (beat === "block") continue
+    assert.ok(block > energy(reactionFor(beat, ctx)), `${beat} outweighs a finished block`)
+  }
+})
+
+test("escalation takes no streak, no combo and no run length", () => {
+  // The signature is the assertion. `reactionFor` sees what happened and the
+  // number it happened to, and there is nowhere to put "you have been right
+  // nine times" — which is the loop this product bans.
+  assert.equal(reactionFor.length, 2)
+  const keys = Object.keys(ctx).sort()
+  assert.deepEqual(keys, ["bestSeam", "size"])
+  // And it is stable: the same beat on the same number is the same reaction
+  // however long the child has been playing.
+  const first = reactionFor("crack", { size: 8, bestSeam: false })
+  const later = reactionFor("crack", { size: 8, bestSeam: false })
+  assert.deepEqual(first, later)
+})
+
+test("a crack escalates on the size of the mob and on choosing well", () => {
+  const plain = reactionFor("crack", { size: 8, bestSeam: false })
+  const big = reactionFor("crack", { size: 18, bestSeam: false })
+  const good = reactionFor("crack", { size: 8, bestSeam: true })
+  assert.equal(plain.tier, 0)
+  assert.equal(big.tier, 1)
+  assert.equal(good.tier, 1)
+  assert.ok(energy(big) > energy(plain))
+  assert.ok(energy(good) > energy(plain))
+  assert.equal(big.budgetMs, TIER_BUDGET[1])
+})
+
+test("nothing but a crack escalates at all", () => {
+  for (const beat of [...SLIPS, ...REWARDS, "down", "rivetRight"] as Beat[]) {
+    assert.deepEqual(
+      reactionFor(beat, { size: 2, bestSeam: false }),
+      reactionFor(beat, { size: 24, bestSeam: true }),
+      `${beat} escalated`,
+    )
+  }
+})
+
+test("every reaction sits inside its tier's budget", () => {
+  for (const beat of [...SLIPS, ...SEATS, ...REWARDS] as Beat[]) {
+    const r = reactionFor(beat, ctx)
+    assert.ok(r.budgetMs <= TIER_BUDGET[r.tier], `${beat} overruns tier ${r.tier}`)
+    assert.ok(r.particles > 0 && r.peakGain > 0 && r.elements > 0)
+    assert.ok(r.peakGain <= 0.5, `${beat} peaks at ${r.peakGain}`)
+  }
+})
+
+test("the device only says failure for the one thing that takes something away", () => {
+  const failures = (Object.keys(HAPTIC) as Beat[]).filter((b) => HAPTIC[b] === "failure")
+  assert.deepEqual(failures, ["shove"])
+  // A refused seam is how the child finds out a number does not go. The motor
+  // must not editorialise about it.
+  assert.equal(HAPTIC.ringoff, "light")
+  assert.equal(HAPTIC.bounce, "light")
+  assert.equal(HAPTIC.rivetWrong, "light")
+})

--- a/dynawalla/games/street/src/game/energy.ts
+++ b/dynawalla/games/street/src/game/energy.ts
@@ -1,0 +1,136 @@
+// The reaction vocabulary, and the two invariants that keep it honest.
+//
+// `EXPERIENCE_DESIGN.md` fixes both:
+//
+//   1. **`energy(SLIP) < energy(SEAT)`**, where energy is
+//      `budgetMs × particles × peakGain × animatedElements`. Being wrong must
+//      not be more interesting than being right. A street full of sparks off a
+//      refused seam is exactly the failure this bans, and a ring-off is the
+//      single most tempting thing in this game to over-animate.
+//   2. **Escalation is on difficulty and on the strategic choice, never on run
+//      length.** `reactionFor` takes what happened and the number it happened
+//      to. It takes no streak, no combo, no wave index, and `energy.test.ts`
+//      asserts the signature by calling it with everything the game knows and
+//      showing the result does not move.
+
+export type Beat =
+  /** A seam refused. The mob stands split with the remainder over, and closes. */
+  | "ringoff"
+  /** Fists off locked arms. */
+  | "bounce"
+  /** A rivet caved in. */
+  | "rivetWrong"
+  /** Shoved back a block. */
+  | "shove"
+  /** A seam landed and the rectangle changed shape. */
+  | "crack"
+  /** A rank went down. */
+  | "down"
+  /** The shutter went up. */
+  | "rivetRight"
+  /** The street is empty. */
+  | "cleared"
+  /** A mob that refused every seam, taken with a fist. The best thing here. */
+  | "solid"
+  /** A block finished. Once per block, and the only tier-3 in the game. */
+  | "block"
+
+export type Tier = -1 | 0 | 1 | 2 | 3
+
+export type Reaction = {
+  readonly tier: Tier
+  readonly budgetMs: number
+  readonly particles: number
+  readonly peakGain: number
+  readonly elements: number
+}
+
+/** Tier budgets, straight from the reaction table in `EXPERIENCE_DESIGN.md`. */
+export const TIER_BUDGET: Record<Tier, number> = {
+  [-1]: 260,
+  0: 200,
+  1: 450,
+  2: 900,
+  3: 1800,
+}
+
+const BASE: Record<Beat, Reaction> = {
+  // Slips. Two sparks, a quiet knock, one thing moving. Deliberately the
+  // cheapest reactions in the file.
+  ringoff: { tier: -1, budgetMs: 260, particles: 2, peakGain: 0.16, elements: 1 },
+  bounce: { tier: -1, budgetMs: 240, particles: 2, peakGain: 0.14, elements: 1 },
+  rivetWrong: { tier: -1, budgetMs: 260, particles: 2, peakGain: 0.15, elements: 1 },
+  // A setback, and still not a spectacle. The mob leans in and the lamp swings;
+  // nothing bursts.
+  shove: { tier: -1, budgetMs: 260, particles: 3, peakGain: 0.18, elements: 2 },
+
+  // Seats.
+  crack: { tier: 0, budgetMs: 200, particles: 10, peakGain: 0.34, elements: 4 },
+  down: { tier: 0, budgetMs: 200, particles: 8, peakGain: 0.3, elements: 3 },
+  rivetRight: { tier: 0, budgetMs: 200, particles: 6, peakGain: 0.32, elements: 3 },
+
+  // Rewards.
+  cleared: { tier: 2, budgetMs: 900, particles: 22, peakGain: 0.42, elements: 6 },
+  solid: { tier: 2, budgetMs: 900, particles: 26, peakGain: 0.46, elements: 7 },
+  block: { tier: 3, budgetMs: 1800, particles: 34, peakGain: 0.5, elements: 9 },
+}
+
+/** `budgetMs × particles × peakGain × animatedElements`. The doc's formula. */
+export function energy(r: Reaction): number {
+  return r.budgetMs * r.particles * r.peakGain * r.elements
+}
+
+export type BeatContext = {
+  /** The rank size the beat happened to. Difficulty, and the only escalator. */
+  readonly size: number
+  /** The seam struck was the one that clears the wave fastest. A choice, not a streak. */
+  readonly bestSeam: boolean
+}
+
+/**
+ * The reaction for a beat.
+ *
+ * A crack steps up one tier when the mob was large or when the seam struck was
+ * the fastest one available — harder problems and better choices earn more,
+ * which is the sanctioned escalation. Nothing else in the game escalates at
+ * all.
+ */
+export function reactionFor(beat: Beat, ctx: BeatContext): Reaction {
+  const base = BASE[beat]
+  if (beat !== "crack") return base
+  if (!ctx.bestSeam && ctx.size < 12) return base
+  return {
+    tier: 1,
+    budgetMs: TIER_BUDGET[1],
+    particles: 16,
+    peakGain: 0.38,
+    elements: 5,
+  }
+}
+
+export type HapticCue = "light" | "medium" | "heavy" | "success" | "failure"
+
+/**
+ * What the street asks the device for. The host owns the waveform.
+ *
+ * A ring-off gets `light` and not `failure`: refusing a seam is how the child
+ * finds out a number does not go, and the device must not editorialise about
+ * it. The only `failure` in the game is being shoved back a block, which is the
+ * only thing that actually takes something away.
+ */
+export const HAPTIC: Record<Beat, HapticCue> = {
+  ringoff: "light",
+  bounce: "light",
+  rivetWrong: "light",
+  shove: "failure",
+  crack: "medium",
+  down: "medium",
+  rivetRight: "medium",
+  cleared: "success",
+  solid: "success",
+  block: "success",
+}
+
+export const SLIPS: readonly Beat[] = ["ringoff", "bounce", "rivetWrong", "shove"] as const
+export const SEATS: readonly Beat[] = ["crack", "down", "rivetRight"] as const
+export const REWARDS: readonly Beat[] = ["cleared", "solid", "block"] as const

--- a/dynawalla/games/street/src/game/factor.test.ts
+++ b/dynawalla/games/street/src/game/factor.test.ts
@@ -1,0 +1,208 @@
+// The three claims this game exists to make, and they are checked over the
+// whole space rather than over examples. Nothing here is sampled and nothing
+// here uses `Math.random`.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  CROWD_MAX,
+  CROWD_MIN,
+  STUDS,
+  bar,
+  bestSeam,
+  crowdPool,
+  isComposite,
+  isPrime,
+  isSeam,
+  largestPrimeFactor,
+  leftover,
+  minimumTaps,
+  primeFactors,
+  seamsFor,
+  smallestPrimeFactor,
+} from "./factor.ts"
+
+// ------------------------------------------------------- the three claims --
+
+test("a prime crowd has no valid seam", () => {
+  // The pedagogy in one assertion. A child is never told thirteen is prime;
+  // they strike every stud on the bar at thirteen and thirteen does not move.
+  for (let n = 2; n <= 400; n++) {
+    if (!isPrime(n)) continue
+    assert.deepEqual(seamsFor(n), [], `${n} is prime and offered a seam`)
+    for (const k of STUDS) {
+      assert.equal(isSeam(n, k), false, `stud ${k} landed on the prime ${n}`)
+    }
+    // And the bar the child is actually shown is exhausted too — "nothing on
+    // the bar works" has to mean "nothing works" or the lesson is a lie.
+    for (const k of bar(n)) {
+      assert.equal(isSeam(n, k), false, `a shown stud ${k} landed on the prime ${n}`)
+    }
+  }
+})
+
+test("every seam the game accepts is a true factor pair", () => {
+  for (let n = 2; n <= 400; n++) {
+    for (let k = -3; k <= n + 3; k++) {
+      if (!isSeam(n, k)) continue
+      const other = n / k
+      assert.ok(Number.isInteger(other), `${n} / ${k} was not an integer`)
+      assert.equal(k * other, n, `${k} × ${other} did not make ${n}`)
+      assert.ok(k >= 2, `a seam of ${k} is not a break`)
+      assert.ok(other >= 2, `a seam of ${k} on ${n} left a single rank`)
+      assert.equal(n % k, 0)
+      assert.equal(leftover(n, k), 0, "an accepted seam left a remainder")
+    }
+  }
+})
+
+test("every composite crowd has at least one seam, and it is on the bar", () => {
+  // A wave you cannot clear is worse than one that is too easy. `bar(size)`
+  // narrows the studs to those below the rank, so this checks the seam is one
+  // the child is actually shown, not merely one that exists.
+  for (const n of crowdPool()) {
+    if (isPrime(n)) continue
+    const seams = seamsFor(n)
+    assert.ok(seams.length > 0, `the composite ${n} had no seam`)
+    const shown = bar(n).filter((k) => isSeam(n, k))
+    assert.ok(shown.length > 0, `the composite ${n} had no seam on the bar`)
+  }
+})
+
+test("the bar can express every seam that exists, for every crowd", () => {
+  // Stronger than "at least one": there is no number that divides a mob and no
+  // stud to say it with. That is what makes a bar full of ring-offs honest.
+  for (const n of crowdPool()) {
+    const seams = seamsFor(n)
+    const shown = bar(n).filter((k) => isSeam(n, k))
+    assert.deepEqual(shown, seams, `the bar for ${n} did not offer every seam`)
+  }
+})
+
+// ------------------------------------------------------------- primality --
+
+test("isPrime agrees with a trial-division sieve up to 2000", () => {
+  const sieve = new Array<boolean>(2001).fill(true)
+  sieve[0] = false
+  sieve[1] = false
+  for (let i = 2; i * i <= 2000; i++) {
+    if (!sieve[i]) continue
+    for (let j = i * i; j <= 2000; j += i) sieve[j] = false
+  }
+  for (let n = 0; n <= 2000; n++) {
+    assert.equal(isPrime(n), sieve[n], `isPrime(${n})`)
+  }
+  assert.equal(isPrime(1.5), false)
+  assert.equal(isPrime(-7), false)
+  assert.equal(isPrime(Number.NaN), false)
+})
+
+test("isComposite is the exact complement inside the pool", () => {
+  for (const n of crowdPool()) {
+    assert.equal(isComposite(n), !isPrime(n))
+  }
+})
+
+test("prime factors multiply back to the number, exactly", () => {
+  for (let n = 2; n <= 500; n++) {
+    const fs = primeFactors(n)
+    assert.ok(fs.length > 0)
+    assert.equal(
+      fs.reduce((a, b) => a * b, 1),
+      n,
+    )
+    for (const f of fs) assert.equal(isPrime(f), true, `${f} is not prime`)
+    assert.equal(smallestPrimeFactor(n), fs[0])
+    assert.equal(largestPrimeFactor(n), fs[fs.length - 1])
+  }
+})
+
+// ------------------------------------------------------ the optimal route --
+
+/**
+ * The fewest taps to clear a crowd of `n`, found by breadth-first search over
+ * the actual game states rather than by the closed form `minimumTaps` uses.
+ *
+ * A state is `ranks` ranks of `size`. A strike costs one tap and turns it into
+ * `ranks * size / k` ranks of `k`; a punch costs one tap, is legal only on a
+ * prime rank, and takes one rank away. Cleared is `ranks === 0`.
+ */
+function searchMinimumTaps(n: number): number {
+  const start = `1:${n}`
+  const seen = new Map<string, number>([[start, 0]])
+  let queue: string[] = [start]
+  while (queue.length > 0) {
+    const next: string[] = []
+    for (const key of queue) {
+      const cost = seen.get(key) as number
+      const [ranksText, sizeText] = key.split(":")
+      const ranks = Number(ranksText)
+      const size = Number(sizeText)
+      if (ranks === 0) return cost
+      const moves: string[] = []
+      if (isPrime(size)) moves.push(`${ranks - 1}:${size}`)
+      for (let k = 2; k < size; k++) {
+        if (size % k === 0) moves.push(`${(ranks * size) / k}:${k}`)
+      }
+      for (const move of moves) {
+        if (seen.has(move)) continue
+        seen.set(move, cost + 1)
+        next.push(move)
+      }
+    }
+    queue = next
+  }
+  return Number.POSITIVE_INFINITY
+}
+
+test("minimumTaps matches a breadth-first search over real game states", () => {
+  for (const n of crowdPool()) {
+    assert.equal(minimumTaps(n), searchMinimumTaps(n), `minimumTaps(${n})`)
+  }
+})
+
+test("the optimal opening strike is the largest prime factor", () => {
+  for (const n of crowdPool()) {
+    if (isPrime(n)) {
+      // Nothing to strike. The answer to a solid mob is a fist.
+      assert.equal(bestSeam(n), 0)
+      assert.equal(minimumTaps(n), 1)
+      continue
+    }
+    const k = bestSeam(n)
+    assert.equal(isSeam(n, k), true, `the best seam ${k} does not land on ${n}`)
+    assert.equal(isPrime(k), true, `the best seam ${k} is not prime`)
+    // Striking it leaves `n / k` prime ranks, so the wave is one strike plus
+    // that many punches — and that is the minimum.
+    assert.equal(1 + n / k, minimumTaps(n))
+  }
+})
+
+test("no wave in the pool is longer than eleven taps", () => {
+  // A feel bound, and the reason `CROWD_MAX` is 24. A wave that runs longer
+  // than this stops being a wave and starts being a sentence.
+  for (const n of crowdPool()) {
+    assert.ok(minimumTaps(n) <= 11, `a crowd of ${n} needs ${minimumTaps(n)} taps`)
+  }
+})
+
+test("the pool sits inside its stated bounds", () => {
+  const pool = crowdPool()
+  assert.equal(pool[0], CROWD_MIN)
+  assert.equal(pool[pool.length - 1], CROWD_MAX)
+  assert.equal(new Set(pool).size, pool.length)
+  assert.ok(pool.some((n) => isPrime(n)), "no prime mob can ever arrive")
+  assert.ok(pool.some((n) => !isPrime(n)), "no composite mob can ever arrive")
+})
+
+test("a refused seam leaves the remainder standing", () => {
+  for (const n of crowdPool()) {
+    for (const k of bar(n)) {
+      if (isSeam(n, k)) continue
+      const rest = leftover(n, k)
+      assert.ok(rest > 0 || k >= n, `${k} refused ${n} with nothing left over`)
+      assert.equal(Math.floor(n / k) * k + rest, n, "the groups and the remainder do not add up")
+    }
+  }
+})

--- a/dynawalla/games/street/src/game/factor.ts
+++ b/dynawalla/games/street/src/game/factor.ts
@@ -1,0 +1,172 @@
+// The mathematics of the street. Exact integers only: no float ever enters a
+// crowd size, a seam, a rank count or a comparison in this file.
+//
+// One idea carries the whole game.
+//
+//   A **crowd** is `ranks` ranks of `size` bodies each — a rectangle, and
+//   therefore an array model the child built rather than one they were shown.
+//
+//   A **seam** is a number `k` you strike. It is valid on a crowd whose rank
+//   size is `size` exactly when `2 <= k < size` and `k` divides `size`. The
+//   crack lands and every rank of `size` becomes `size / k` ranks of `k`. The
+//   body count is untouched: `ranks * size === (ranks * size / k) * k`.
+//
+//   A rank can be **knocked down** exactly when its size is prime.
+//
+// Those two rules are the same rule seen from both sides, and between them they
+// are the pedagogy:
+//
+//   * A **prime** rank has no divisor strictly between 1 and itself, so *every*
+//     stud on the bar rings off it. The child is never told a number is prime.
+//     They strike 2, 3, 4, 5, 6 at a mob of thirteen and thirteen does not
+//     move. That is what prime is.
+//   * And the thing that will not break is the thing you can hit. A composite
+//     rank locks arms and your fists bounce off it; a prime rank goes down in
+//     one. So every tap in this game is a claim about a number, and the street
+//     answers it in under a frame.
+
+/** Primes small enough to sieve by, covering everything the street can spawn. */
+const SMALL_PRIMES = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47] as const
+
+export function isPrime(n: number): boolean {
+  if (!Number.isInteger(n) || n < 2) return false
+  for (const p of SMALL_PRIMES) {
+    if (n === p) return true
+    if (n % p === 0) return false
+  }
+  for (let d = 49; d * d <= n; d += 2) {
+    if (n % d === 0) return false
+  }
+  return true
+}
+
+export function isComposite(n: number): boolean {
+  return Number.isInteger(n) && n >= 4 && !isPrime(n)
+}
+
+/**
+ * The studs on the breaker bar, in order.
+ *
+ * It runs to 12 rather than to 9 for a reason that is a design guarantee and
+ * not a convenience: the largest proper divisor of any crowd this game spawns
+ * is `size / 2 <= 12`, so **every seam that exists is a stud the child can
+ * strike**. There is no number that divides the mob and no way to say it. That
+ * makes "nothing on the bar works" mean "nothing works", which is the only way
+ * a ring-off can honestly teach primeness.
+ *
+ * `bar()` narrows this to the studs that could conceivably apply, so a rank of
+ * five never shows the child a nine.
+ */
+export const STUDS: readonly number[] = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const
+
+/** The studs offered against a rank of `size`: every stud below it. */
+export function bar(size: number): number[] {
+  return STUDS.filter((k) => k < size)
+}
+
+/** Every valid seam on a rank of `size`, ascending. Empty exactly when prime. */
+export function seamsFor(size: number): number[] {
+  if (!Number.isInteger(size) || size < 2) return []
+  const out: number[] = []
+  for (let k = 2; k < size; k++) {
+    if (size % k === 0) out.push(k)
+  }
+  return out
+}
+
+/** Whether striking `k` at a rank of `size` lands. The one gate on a strike. */
+export function isSeam(size: number, k: number): boolean {
+  if (!Number.isInteger(size) || !Number.isInteger(k)) return false
+  if (k < 2 || k >= size) return false
+  return size % k === 0
+}
+
+/**
+ * The remainder a refused seam leaves standing.
+ *
+ * A crack that rings off is not silent about *why*. Striking 5 at a mob of
+ * twelve makes two groups of five and leaves two bodies over, and those two are
+ * drawn standing apart in the gap before the mob closes back up. Division with
+ * a remainder, shown rather than named.
+ */
+export function leftover(size: number, k: number): number {
+  if (!Number.isInteger(size) || !Number.isInteger(k) || k < 1) return 0
+  return size % k
+}
+
+export function primeFactors(n: number): number[] {
+  const out: number[] = []
+  if (!Number.isInteger(n) || n < 2) return out
+  let m = n
+  for (let d = 2; d * d <= m; d++) {
+    while (m % d === 0) {
+      out.push(d)
+      m /= d
+    }
+  }
+  if (m > 1) out.push(m)
+  return out
+}
+
+/** The largest prime dividing `n`. `0` for anything below 2. */
+export function largestPrimeFactor(n: number): number {
+  const fs = primeFactors(n)
+  return fs.length === 0 ? 0 : (fs[fs.length - 1] as number)
+}
+
+/** The smallest prime dividing `n`. Used as the hint after a shove-back. */
+export function smallestPrimeFactor(n: number): number {
+  const fs = primeFactors(n)
+  return fs.length === 0 ? 0 : (fs[0] as number)
+}
+
+/**
+ * The fewest taps that clear a crowd of `n`, and the proof is short enough to
+ * put here because the number is shown to the child as a target.
+ *
+ * From one rank of `n`, a strike of `k` produces `n / k` ranks of `k`, and the
+ * ranks can only be knocked down once their size is prime. A chain of strikes
+ * `n = s0 > s1 > … > sm = p` costs `m` strikes plus `n / p` punches, and the
+ * punch count depends only on the prime it ends at — never on the route. So
+ * more than one strike is always strictly worse, and one strike is always
+ * available on a composite (strike a prime factor). Therefore:
+ *
+ *     prime n     →  1                      (a fist, and nothing else)
+ *     composite n →  1 + n / largestPrimeFactor(n)
+ *
+ * Which is also the lesson: **strike the biggest prime that goes into it.**
+ * `factor.test.ts` checks this against a breadth-first search over crowd states
+ * rather than trusting the argument.
+ */
+export function minimumTaps(n: number): number {
+  if (!Number.isInteger(n) || n < 2) return 0
+  if (isPrime(n)) return 1
+  return 1 + n / largestPrimeFactor(n)
+}
+
+/** The strike that achieves `minimumTaps`. `0` when the crowd is already prime. */
+export function bestSeam(n: number): number {
+  if (!isComposite(n)) return 0
+  return largestPrimeFactor(n)
+}
+
+/**
+ * Crowd sizes the street may send.
+ *
+ * The ceiling is 24 and it is a feel number, not a rendering one: `1 + 24 / 3`
+ * is nine taps, which is a long enough wave to have a shape and a short enough
+ * one that a child who chose badly is not serving a sentence. Primes are in the
+ * pool on purpose and are not a trap — a prime mob is the fastest wave in the
+ * game and the loudest, because the answer to it is a fist.
+ *
+ * 2 and 3 are excluded as *opening* sizes: a mob that is over in one tap before
+ * the child has read it is a beat, not a wave.
+ */
+export const CROWD_MIN = 4
+export const CROWD_MAX = 24
+
+export function crowdPool(): number[] {
+  const out: number[] = []
+  for (let n = CROWD_MIN; n <= CROWD_MAX; n++) out.push(n)
+  return out
+}

--- a/dynawalla/games/street/src/game/push.test.ts
+++ b/dynawalla/games/street/src/game/push.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { PUSH_MAX, isShoved, newPush, pressed, pressure, relieved } from "./push.ts"
+
+test("the meter starts at the far end of the street", () => {
+  const push = newPush()
+  assert.equal(push.marks, 0)
+  assert.equal(isShoved(push), false)
+  assert.equal(pressure(push), 0)
+})
+
+test("six slips with nothing in between is a shove", () => {
+  let push = newPush()
+  for (let i = 0; i < PUSH_MAX - 1; i++) {
+    push = pressed(push)
+    assert.equal(isShoved(push), false, `shoved after ${i + 1} slips`)
+  }
+  push = pressed(push)
+  assert.equal(isShoved(push), true)
+  assert.equal(pressure(push), 1)
+})
+
+test("a rank going down buys ground back", () => {
+  let push = newPush()
+  push = pressed(pressed(pressed(push)))
+  assert.equal(push.marks, 3)
+  push = relieved(push)
+  assert.equal(push.marks, 2)
+  // A run of good taps at the far end does not bank credit for later slips.
+  push = relieved(relieved(relieved(relieved(push))))
+  assert.equal(push.marks, 0)
+})
+
+test("the meter has no clock in it", () => {
+  // Nothing in this module takes a duration, a timestamp or a frame delta:
+  // standing still and reading the mob costs exactly nothing, which is the
+  // whole reason a timer is not the stake in this game.
+  assert.equal(pressed.length, 1)
+  assert.equal(relieved.length, 1)
+  assert.equal(newPush.length, 0)
+})
+
+test("the meter never leaves its rails", () => {
+  let push = newPush()
+  for (let i = 0; i < 40; i++) push = pressed(push)
+  assert.equal(push.marks, PUSH_MAX)
+  for (let i = 0; i < 40; i++) push = relieved(push)
+  assert.equal(push.marks, 0)
+})

--- a/dynawalla/games/street/src/game/push.ts
+++ b/dynawalla/games/street/src/game/push.ts
@@ -1,0 +1,42 @@
+// THE PUSH — the only stake in the game, and it has no clock in it.
+//
+// The mob leans on you when you are wrong and gives ground when you put a rank
+// down. Nothing here counts seconds, because a child who is *thinking* must
+// never be losing: `EXPERIENCE_DESIGN.md` puts escalation on difficulty and
+// repair and bans it on run length, and a creeping timer is that ban's exact
+// target. Standing still and reading the mob costs nothing at all.
+//
+// At the top of the meter the mob shoves you back a block. That restarts the
+// wave — it never touches the blocks you have already cleared. Construction
+// does not regress (`P-04`); what you lose is ground, and ground is retakeable.
+
+/** Marks between the mob and you. Six errors with no answer in between. */
+export const PUSH_MAX = 6
+
+export type Push = {
+  /** 0 = the far end of the street. `PUSH_MAX` = they are on top of you. */
+  readonly marks: number
+}
+
+export function newPush(): Push {
+  return { marks: 0 }
+}
+
+/** A refused seam, a bounced fist, a caved rivet. They gain a mark. */
+export function pressed(push: Push): Push {
+  return { marks: Math.min(PUSH_MAX, push.marks + 1) }
+}
+
+/** A rank went down. They give one back. */
+export function relieved(push: Push): Push {
+  return { marks: Math.max(0, push.marks - 1) }
+}
+
+export function isShoved(push: Push): boolean {
+  return push.marks >= PUSH_MAX
+}
+
+/** 0..1, for the renderer. The only float in the rules layer, and it draws. */
+export function pressure(push: Push): number {
+  return push.marks / PUSH_MAX
+}

--- a/dynawalla/games/street/src/game/shutter.test.ts
+++ b/dynawalla/games/street/src/game/shutter.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import { RIVETS, newShutter, rightRivet, strikeRivet } from "./shutter.ts"
+
+const source = {
+  id: "q-1",
+  prompt: "47 + 25",
+  answer: "72",
+  // A dropped carry, a doubled carry, the wrong operation.
+  distractors: ["62", "82", "22"],
+}
+
+test("a plate carries the answer and the host's wrong values, and no more", () => {
+  const plate = newShutter(source, new Rng(1))
+  assert.equal(plate.rivets.length, RIVETS)
+  const texts = plate.rivets.map((r) => r.text).sort()
+  assert.deepEqual(texts, ["22", "62", "72", "82"])
+  assert.ok(plate.rivets.every((r) => !r.dead))
+  assert.equal(plate.open, false)
+  assert.equal(plate.reported, false)
+})
+
+test("a plate with fewer wrong values is short, not padded with invention", () => {
+  // The game never makes up a wrong answer. A host that offered one distractor
+  // gets a two-rivet plate, because a fabricated third would be a numeral no
+  // child's procedure produces and elimination practice rather than arithmetic.
+  const plate = newShutter({ ...source, distractors: ["62"] }, new Rng(2))
+  assert.equal(plate.rivets.length, 2)
+})
+
+test("duplicates never take two rivets", () => {
+  const plate = newShutter({ ...source, distractors: ["62", "62", "72", "82"] }, new Rng(3))
+  const texts = plate.rivets.map((r) => r.text)
+  assert.equal(new Set(texts).size, texts.length)
+  assert.ok(texts.includes("72"))
+})
+
+test("the plate is shuffled, so the answer is not always in one place", () => {
+  const places = new Set<number>()
+  for (let seed = 1; seed <= 40; seed++) {
+    places.add(rightRivet(newShutter(source, new Rng(seed))))
+  }
+  assert.ok(places.size >= 3, "the canonical rivet sat in the same place every time")
+})
+
+test("the right rivet opens the plate and reports what was struck", () => {
+  const plate = newShutter(source, new Rng(4))
+  const result = strikeRivet(plate, rightRivet(plate))
+  assert.equal(result.opened, true)
+  assert.equal(result.shutter.open, true)
+  assert.deepEqual(result.report, { questionId: "q-1", answered: "72" })
+})
+
+test("a wrong rivet caves in, reports the mal-rule, and leaves the plate down", () => {
+  const plate = newShutter(source, new Rng(5))
+  const wrong = plate.rivets.findIndex((r) => r.text !== plate.answer)
+  const wrongText = plate.rivets[wrong]?.text as string
+  const result = strikeRivet(plate, wrong)
+  assert.equal(result.opened, false)
+  assert.equal(result.shutter.open, false)
+  assert.equal(result.shutter.rivets[wrong]?.dead, true)
+  // The value that crosses is the mal-rule output itself, so the misconception
+  // routes to the scheduler with no extra wiring.
+  assert.deepEqual(result.report, { questionId: "q-1", answered: wrongText })
+})
+
+test("a plate is reported exactly once, however many rivets are struck", () => {
+  let plate = newShutter(source, new Rng(6))
+  const right = rightRivet(plate)
+  let reports = 0
+  for (let i = 0; i < plate.rivets.length; i++) {
+    if (i === right) continue
+    const result = strikeRivet(plate, i)
+    if (result.report) reports++
+    plate = result.shutter
+  }
+  const opened = strikeRivet(plate, right)
+  if (opened.report) reports++
+  assert.equal(reports, 1, "one plate produced more than one report")
+  assert.equal(opened.opened, true)
+})
+
+test("a hole is not an answer", () => {
+  const plate = newShutter(source, new Rng(7))
+  const wrong = plate.rivets.findIndex((r) => r.text !== plate.answer)
+  const once = strikeRivet(plate, wrong)
+  const twice = strikeRivet(once.shutter, wrong)
+  assert.equal(twice.shutter, once.shutter, "a dead rivet changed the plate")
+  assert.equal(twice.report, null)
+})
+
+test("an open plate takes no more strikes", () => {
+  const plate = newShutter(source, new Rng(8))
+  const open = strikeRivet(plate, rightRivet(plate)).shutter
+  const after = strikeRivet(open, 0)
+  assert.equal(after.shutter, open)
+  assert.equal(after.report, null)
+})
+
+test("an index nobody could have struck is inert", () => {
+  const plate = newShutter(source, new Rng(9))
+  for (const index of [-1, 4, 99, Number.NaN]) {
+    const result = strikeRivet(plate, index)
+    assert.equal(result.shutter, plate)
+    assert.equal(result.report, null)
+  }
+})

--- a/dynawalla/games/street/src/game/shutter.ts
+++ b/dynawalla/games/street/src/game/shutter.ts
@@ -1,0 +1,103 @@
+// THE SHUTTER — the only surface in this game the host judges.
+//
+// A steel roller comes down across the street with the problem chalked on it
+// and four rivets punched through the plate. The mob is behind it, leaning. You
+// hit a rivet; the right one throws the shutter up and lets them out.
+//
+// **The game never marks it.** The first rivet struck is reported, with the
+// text on it, and the host decides — that is the whole contract. A wrong rivet
+// caves in and goes dark so the child can still open the shutter and get on
+// with the street, and nothing after the first strike is reported: a record only
+// ever rises, and the same item answered twice would raise it twice.
+//
+// The numerals on the rivets are the host's, never this game's: the canonical
+// answer plus mal-rule outputs, which are wrong values a child with a specific
+// broken procedure actually writes down. Dropping the carry gives you 62 where
+// 72 belongs, and 62 is on the plate.
+
+import type { Rng } from "../core/rng.ts"
+
+export type Rivet = {
+  readonly text: string
+  /** Struck, wrong, and out. Purely a state of the plate — not a verdict. */
+  readonly dead: boolean
+}
+
+export type Shutter = {
+  readonly questionId: string
+  /** "47 + 25", operator glyph included. Chalked across the plate. */
+  readonly prompt: string
+  /** The host's canonical value. Used to decide whether the plate opens. */
+  readonly answer: string
+  readonly rivets: readonly Rivet[]
+  /** True once a rivet has been struck. Gates the single report. */
+  readonly reported: boolean
+  readonly open: boolean
+}
+
+export type ShutterSource = {
+  readonly id: string
+  readonly prompt: string
+  readonly answer: string
+  readonly distractors: readonly string[]
+}
+
+/** Rivets on a plate. Four when the host has three wrong values, fewer if not. */
+export const RIVETS = 4
+
+export function newShutter(source: ShutterSource, rng: Rng): Shutter {
+  const seen = new Set<string>([source.answer])
+  const texts: string[] = [source.answer]
+  for (const d of source.distractors) {
+    if (texts.length >= RIVETS) break
+    if (d === "" || seen.has(d)) continue
+    seen.add(d)
+    texts.push(d)
+  }
+  rng.shuffle(texts)
+  return {
+    questionId: source.id,
+    prompt: source.prompt,
+    answer: source.answer,
+    rivets: texts.map((text) => ({ text, dead: false })),
+    reported: false,
+    open: false,
+  }
+}
+
+export type RivetStrike = {
+  readonly shutter: Shutter
+  /** Whether the plate went up. */
+  readonly opened: boolean
+  /**
+   * What to send the host, or `null` when this strike is not the first one on
+   * this plate. `null` is not "nothing happened" — it is "already reported".
+   */
+  readonly report: { readonly questionId: string; readonly answered: string } | null
+}
+
+/**
+ * Hit rivet `index`.
+ *
+ * A dead rivet is inert: it has already caved in, and hitting a hole is not an
+ * answer. That is the one case that produces neither a report nor a change.
+ */
+export function strikeRivet(shutter: Shutter, index: number): RivetStrike {
+  const rivet = shutter.rivets[index]
+  if (shutter.open || !rivet || rivet.dead) {
+    return { shutter, opened: false, report: null }
+  }
+  const right = rivet.text === shutter.answer
+  const rivets = shutter.rivets.map((r, i) => (i === index && !right ? { ...r, dead: true } : r))
+  const next: Shutter = { ...shutter, rivets, reported: true, open: right }
+  return {
+    shutter: next,
+    opened: right,
+    report: shutter.reported ? null : { questionId: shutter.questionId, answered: rivet.text },
+  }
+}
+
+/** The index of the canonical rivet. For tests and for the dev harness only. */
+export function rightRivet(shutter: Shutter): number {
+  return shutter.rivets.findIndex((r) => r.text === shutter.answer)
+}

--- a/dynawalla/games/street/src/game/street.test.ts
+++ b/dynawalla/games/street/src/game/street.test.ts
@@ -1,0 +1,439 @@
+// The whole street, played with no canvas, no rAF and no host.
+//
+// The machine is driven by elapsed milliseconds, so a block that takes half a
+// minute on a tablet takes half a millisecond here — and the pause guards,
+// which are the thing this file exists for, can be checked against a clock that
+// is not a real one.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { TIMING } from "../core/feel.ts"
+import { Rng } from "../core/rng.ts"
+import { bestSeam, crowdPool, isPrime, minimumTaps, seamsFor } from "./factor.ts"
+import { PUSH_MAX } from "./push.ts"
+import { rightRivet } from "./shutter.ts"
+import { Street, type Phase, type StreetEvent } from "./street.ts"
+import { WAVES_PER_BLOCK } from "./wave.ts"
+
+/** A deterministic plate source. The numerals are exact integers, as ever. */
+function dealer(): () => {
+  id: string
+  prompt: string
+  answer: string
+  distractors: string[]
+} {
+  let n = 0
+  return () => {
+    n++
+    const a = 40 + n
+    const b = 20 + n
+    return {
+      id: `q-${n}`,
+      prompt: `${a} + ${b}`,
+      answer: String(a + b),
+      // A dropped carry, a doubled carry, the wrong operation. Mal-rules, not
+      // `answer ± 1`.
+      distractors: [String(a + b - 10), String(a + b + 10), String(Math.abs(a - b))],
+    }
+  }
+}
+
+function newStreet(seed = 0x57ee7): Street {
+  const street = new Street({ deal: dealer(), rng: new Rng(seed) })
+  street.setStreetWidth(720)
+  return street
+}
+
+/** Advance in real-sized frames and collect everything that came out. */
+function run(street: Street, ms: number): StreetEvent[] {
+  const out: StreetEvent[] = []
+  for (let t = 0; t < ms; t += 16) out.push(...street.advance(16))
+  return out
+}
+
+/** Advance until the street reaches `phase`, or give up. */
+function until(street: Street, phase: Phase, cap = 400): StreetEvent[] {
+  const out: StreetEvent[] = []
+  for (let i = 0; i < cap && street.phase !== phase; i++) out.push(...street.advance(16))
+  assert.equal(street.phase, phase, `the street never reached ${phase}`)
+  return out
+}
+
+/** Open the plate correctly and walk out to the mob. */
+function throughPlate(street: Street): StreetEvent[] {
+  const out = until(street, "shutter")
+  const plate = street.shutter
+  assert.ok(plate)
+  out.push(...street.hitRivet(rightRivet(plate)))
+  out.push(...until(street, "melee"))
+  return out
+}
+
+/** Clear the mob in front of you the fast way. Returns the events. */
+function clearWave(street: Street): StreetEvent[] {
+  const out: StreetEvent[] = []
+  let guard = 0
+  while (street.phase !== "clear" && guard++ < 200) {
+    if (street.phase !== "melee") {
+      out.push(...street.advance(16))
+      continue
+    }
+    const size = street.crowd.size
+    out.push(...(isPrime(size) ? street.swing() : street.strikeStud(bestSeam(size))))
+  }
+  assert.equal(street.phase, "clear", "the wave never cleared")
+  return out
+}
+
+// ------------------------------------------------------------ the shape --
+
+test("the street opens with a plate, and the plate is readable before input counts", () => {
+  const street = newStreet()
+  street.begin()
+  assert.equal(street.phase, "shutter-down")
+  assert.equal(street.open, false, "input was live while the plate was still coming down")
+  // A rivet struck at a plate that has not landed is not an answer.
+  assert.deepEqual(street.hitRivet(0), [])
+
+  const events = until(street, "shutter")
+  assert.equal(events.filter((e) => e.kind === "shutter").length, 1)
+  assert.equal(street.open, true)
+})
+
+test("a plate is reported once, and what is reported is the numeral struck", () => {
+  const street = newStreet()
+  street.begin()
+  until(street, "shutter")
+  const plate = street.shutter
+  assert.ok(plate)
+  const right = rightRivet(plate)
+  const wrong = plate.rivets.findIndex((_, i) => i !== right)
+  const wrongText = plate.rivets[wrong]?.text as string
+
+  const first = street.hitRivet(wrong).filter((e) => e.kind === "report")
+  assert.equal(first.length, 1)
+  const report = first[0]
+  assert.ok(report && report.kind === "report")
+  assert.equal(report.answered, wrongText, "the game reported something other than what was struck")
+  assert.equal(report.correct, false)
+  assert.equal(report.questionId, plate.questionId)
+
+  // The plate is still down and the rivet is out. Nothing more is reported: a
+  // record only ever rises, and the same item answered twice would raise it
+  // twice for one piece of work.
+  until(street, "shutter")
+  const second = street.hitRivet(rightRivet(street.shutter as NonNullable<typeof plate>))
+  assert.equal(second.filter((e) => e.kind === "report").length, 0)
+  assert.equal(street.phase, "shutter-up")
+})
+
+test("the mob that comes through is always one the bar can break", () => {
+  const street = newStreet()
+  street.begin()
+  const pool = new Set(crowdPool())
+  const sizes: number[] = []
+  for (let wave = 0; wave < 24; wave++) {
+    throughPlate(street)
+    const size = street.crowd.size
+    sizes.push(size)
+    assert.ok(pool.has(size), `a mob of ${size} is outside the pool`)
+    if (!isPrime(size)) assert.ok(seamsFor(size).length > 0)
+    clearWave(street)
+    until(street, "shutter")
+  }
+  // Never twice running, and not all one number either.
+  for (let i = 1; i < sizes.length; i++) assert.notEqual(sizes[i], sizes[i - 1])
+  assert.ok(new Set(sizes).size >= 5, "the street sends the same handful of mobs")
+})
+
+test("a wave cleared the fast way takes exactly the minimum, and is stamped clean", () => {
+  const street = newStreet()
+  street.begin()
+  for (let wave = 0; wave < 8; wave++) {
+    throughPlate(street)
+    const size = street.crowd.size
+    const events = clearWave(street)
+    const cleared = events.find((e) => e.kind === "cleared")
+    assert.ok(cleared && cleared.kind === "cleared")
+    assert.equal(cleared.size, size)
+    assert.equal(cleared.taps, minimumTaps(size), `a clean route on ${size} was not minimal`)
+    assert.equal(cleared.clean, true)
+    assert.equal(cleared.solid, isPrime(size))
+    until(street, "shutter")
+  }
+})
+
+test("a block is three waves, and a finished block is the only thing marked", () => {
+  const street = newStreet()
+  street.begin()
+  const marks: number[] = []
+  for (let wave = 0; wave < WAVES_PER_BLOCK * 2; wave++) {
+    throughPlate(street)
+    clearWave(street)
+    for (const event of until(street, "shutter")) {
+      if (event.kind === "block") marks.push(event.blocks)
+    }
+  }
+  assert.deepEqual(marks, [1, 2], "a block did not tick over every three waves")
+  assert.equal(street.blocks, 2)
+})
+
+// ----------------------------------------------------------- being wrong --
+
+test("a refused seam holds the mob still and shows the remainder", () => {
+  const street = newStreet()
+  street.begin()
+  throughPlate(street)
+  // Walk to a mob that has a stud it refuses. Every crowd in the pool does.
+  let refused = 0
+  for (let wave = 0; wave < 12 && refused === 0; wave++) {
+    const size = street.crowd.size
+    const bad = [2, 3, 5, 7, 11].find((k) => k < size && size % k !== 0)
+    if (bad === undefined) {
+      clearWave(street)
+      until(street, "shutter")
+      throughPlate(street)
+      continue
+    }
+    const events = street.strikeStud(bad)
+    const ring = events.find((e) => e.kind === "ringoff")
+    assert.ok(ring && ring.kind === "ringoff")
+    assert.equal(ring.seam, bad)
+    assert.equal(ring.remainder, size % bad)
+    assert.equal(street.crowd.size, size, "a refused seam moved the mob")
+    assert.equal(street.phase, "ringoff")
+    refused++
+  }
+  assert.equal(refused, 1)
+})
+
+test("fists off a locked rank cost a mark and nothing else", () => {
+  const street = newStreet()
+  street.begin()
+  throughPlate(street)
+  while (isPrime(street.crowd.size)) {
+    clearWave(street)
+    until(street, "shutter")
+    throughPlate(street)
+  }
+  const before = street.crowd
+  const events = street.swing()
+  assert.ok(events.some((e) => e.kind === "bounce"))
+  assert.deepEqual(street.crowd, before)
+  assert.equal(street.push.marks, 1)
+})
+
+test("six slips shove you back, and nothing built is taken", () => {
+  const street = newStreet()
+  street.begin()
+  throughPlate(street)
+  while (isPrime(street.crowd.size)) {
+    clearWave(street)
+    until(street, "shutter")
+    throughPlate(street)
+  }
+  const size = street.crowd.size
+  const blocks = street.blocks
+
+  for (let i = 0; i < PUSH_MAX - 1; i++) {
+    assert.equal(street.phase, "melee")
+    street.swing() // locked arms: a slip, every time
+    run(street, TIMING.bounce + 32)
+  }
+  assert.equal(street.push.marks, PUSH_MAX - 1)
+  const shoved = street.swing()
+  assert.ok(shoved.some((e) => e.kind === "shove"))
+  assert.equal(street.phase, "shove")
+
+  // The same mob comes back with the smallest prime that goes into it lit on
+  // the bar, and the ledger is untouched.
+  until(street, "melee")
+  assert.equal(street.crowd.size, size)
+  assert.equal(street.crowd.ranks, 1)
+  assert.equal(street.blocks, blocks, "a shove-back took a finished block away")
+  assert.equal(street.push.marks, 0)
+  assert.ok(street.hintSeam >= 2)
+  assert.equal(size % street.hintSeam, 0, "the hint is not a seam")
+})
+
+test("a wrong rivet does not also lean on the mob", () => {
+  // The answer has already gone to the host, which is where a wrong answer
+  // belongs. Charging for it twice would make a child working out `503 − 178`
+  // worse off than one who guesses fast.
+  const street = newStreet()
+  street.begin()
+  until(street, "shutter")
+  const plate = street.shutter
+  assert.ok(plate)
+  const right = rightRivet(plate)
+  street.hitRivet(plate.rivets.findIndex((_, i) => i !== right))
+  assert.equal(street.push.marks, 0)
+})
+
+test("knockdowns chain, and a tap into an empty street costs nothing", () => {
+  // Eight ranks going down has to feel like a combo, not a queue: a swing lands
+  // during the fall of the rank before it. A strike deliberately does not
+  // chain — re-cutting a mob mid-crack would mean never seeing the rectangle
+  // you just made.
+  const street = newStreet()
+  street.begin()
+  throughPlate(street)
+  while (isPrime(street.crowd.size) || street.crowd.size < 6) {
+    clearWave(street)
+    until(street, "shutter")
+    throughPlate(street)
+  }
+  const size = street.crowd.size
+  street.strikeStud(bestSeam(size))
+  until(street, "melee")
+  const ranks = street.crowd.ranks
+  assert.ok(ranks >= 2, `only ${ranks} ranks to chain through`)
+
+  // Every punch after the first lands inside the previous rank's fall.
+  street.swing()
+  assert.equal(street.phase, "fall")
+  for (let i = 1; i < ranks; i++) {
+    const events = street.swing()
+    assert.ok(
+      events.some((e) => e.kind === "down"),
+      `the ${i + 1}th punch of the chain did not land`,
+    )
+  }
+  assert.equal(street.crowd.ranks, 0)
+
+  // And the street is empty. More taps are not claims about anything, so they
+  // are neither bounces nor marks.
+  assert.deepEqual(street.swing(), [])
+  assert.equal(street.push.marks, 0)
+  assert.deepEqual(street.strikeStud(2), [], "a stud landed on nobody")
+})
+
+// ---------------------------------------------------------- the pause trap --
+
+test("the clock stops dead behind a sheet", () => {
+  // Guard one: `advance` returns immediately while paused. Remove that line and
+  // this test fails — the plate lands, the wave starts, and a block the child
+  // never watched ticks over behind the host's sheet.
+  const street = newStreet()
+  street.begin()
+  until(street, "shutter")
+  throughPlate(street)
+  assert.equal(street.phase, "melee")
+  street.strikeStud(street.crowd.size % 2 === 0 ? 2 : 3)
+  const phase = street.phase
+
+  street.pause()
+  assert.equal(street.paused, true)
+  const events = run(street, 30_000)
+  assert.deepEqual(events, [], "the machine produced events behind the sheet")
+  assert.equal(street.phase, phase, "the street advanced while paused")
+  assert.equal(street.elapsedMs, 0, "the phase clock ran while paused")
+  assert.equal(street.open, false, "the street said it was taking input while paused")
+
+  street.resume()
+  assert.equal(street.paused, false)
+  until(street, "melee")
+})
+
+test("a tap behind a sheet is not a tap", () => {
+  // Guard two, and it is a separate guard on purpose: a machine that stood
+  // still but still took input would spend the child's seam — and, at the
+  // plate, their one report — on a screen they could not see. This test fails
+  // if the `this.stopped` check is removed from `strikeStud`, from `swing`, or
+  // from `hitRivet`, independently of guard one.
+  const street = newStreet()
+  street.begin()
+  until(street, "shutter")
+
+  street.pause()
+  const plate = street.shutter
+  assert.ok(plate)
+  assert.deepEqual(street.hitRivet(rightRivet(plate)), [], "a rivet was struck behind the sheet")
+  assert.equal(street.shutter?.reported, false, "the plate was answered behind the sheet")
+  assert.equal(street.phase, "shutter", "the plate opened behind the sheet")
+  street.resume()
+
+  throughPlate(street)
+  const crowd = street.crowd
+  const taps = street.taps
+  street.pause()
+  assert.deepEqual(street.strikeStud(bestSeam(crowd.size) || 2), [], "a stud landed behind the sheet")
+  assert.deepEqual(street.swing(), [], "a swing landed behind the sheet")
+  assert.deepEqual(street.crowd, crowd, "the mob changed behind the sheet")
+  assert.equal(street.taps, taps)
+  assert.equal(street.push.marks, 0, "a slip was recorded behind the sheet")
+})
+
+test("a sheet is not thinking time", () => {
+  // Guard three, and the one with a number attached. The latency reported for a
+  // plate is measured on the street's own clock, and that clock does not
+  // accumulate while paused — so a thirty-second sheet is worth zero
+  // milliseconds of the child's time. Without guard one this reports 30 seconds
+  // of deliberation over a plate that was behind a sheet, and the host records
+  // it against them.
+  const street = newStreet()
+  street.begin()
+  until(street, "shutter")
+
+  run(street, 1_200)
+  street.pause()
+  run(street, 30_000)
+  street.resume()
+  run(street, 800)
+
+  const plate = street.shutter
+  assert.ok(plate)
+  const events = street.hitRivet(rightRivet(plate))
+  const report = events.find((e) => e.kind === "report")
+  assert.ok(report && report.kind === "report")
+  assert.ok(report.ms >= 1_900, `reported ${report.ms} ms, which is less than the time spent`)
+  assert.ok(report.ms <= 2_200, `reported ${report.ms} ms, so the sheet was charged to the child`)
+})
+
+test("a paused street still resumes into the same wave", () => {
+  const street = newStreet()
+  street.begin()
+  throughPlate(street)
+  const crowd = street.crowd
+  street.pause()
+  run(street, 5_000)
+  street.resume()
+  assert.deepEqual(street.crowd, crowd)
+  clearWave(street)
+})
+
+// -------------------------------------------------------------- the clock --
+
+test("a frame delta longer than a phase does not owe the child a beat", () => {
+  const street = newStreet()
+  street.begin()
+  // One enormous step: the phases run through in order rather than one per
+  // frame, and the machine lands somewhere that waits for the child.
+  street.advance(20_000)
+  assert.ok(street.phase === "shutter" || street.phase === "melee", `landed on ${street.phase}`)
+  assert.equal(street.open, true)
+})
+
+test("the crack takes longer across a wider street, because it is a speed", () => {
+  const wide = newStreet()
+  wide.setStreetWidth(1200)
+  const narrow = newStreet()
+  narrow.setStreetWidth(320)
+  for (const street of [wide, narrow]) {
+    street.begin()
+    throughPlate(street)
+    while (isPrime(street.crowd.size)) {
+      clearWave(street)
+      until(street, "shutter")
+      throughPlate(street)
+    }
+    street.strikeStud(bestSeam(street.crowd.size))
+    assert.equal(street.phase, "crack")
+  }
+  assert.ok(
+    wide.durationMs > narrow.durationMs,
+    `a 1200 px crack (${wide.durationMs} ms) was not longer than a 320 px one (${narrow.durationMs} ms)`,
+  )
+  assert.equal(Math.round(wide.durationMs - narrow.durationMs), Math.round(((1200 - 320) / 2400) * 1000))
+})

--- a/dynawalla/games/street/src/game/street.ts
+++ b/dynawalla/games/street/src/game/street.ts
@@ -1,0 +1,531 @@
+// The street, as a machine.
+//
+// Driven by elapsed milliseconds rather than by frames, so `street.test.ts`
+// plays whole blocks with no canvas, no rAF and no clock — and so the one thing
+// that must be true about time here can be tested at all.
+//
+// ## The clock, and the sheet
+//
+// The host may put a sheet over a pack that is **still mounted and still
+// running** and send `pause`. This game calls `transition` when a block is
+// finished, which is precisely the call that raises the sheet, so it is not a
+// hypothetical. Two things would go wrong without a guard, and both of them
+// take something from the child:
+//
+//   * A phase behind the sheet would run to its end. A wave would clear, a
+//     shutter would roll, a block would tick over, all unwatched.
+//   * The latency reported for a shutter is measured on this machine's own
+//     clock, and a clock that keeps running behind a sheet reports forty
+//     seconds of thinking for a plate the child never saw. The host records
+//     that against them.
+//
+// So `advance` stops dead while paused and the clock does not accumulate, which
+// means every wall-clock mark this file holds is automatically shifted forward
+// by exactly the length of the pause. Input is refused separately, because
+// "the machine did not move" and "the tap did not count" are two different
+// guards and removing either one is a bug on its own.
+
+import { CRACK_PX_PER_S, TIMING, type Timing, crackMs } from "../core/feel.ts"
+import type { Rng } from "../core/rng.ts"
+import {
+  type Crowd,
+  type PunchResult,
+  type StrikeResult,
+  isCleanBreak,
+  isCleared,
+  newCrowd,
+  punch,
+  strike,
+} from "./crowd.ts"
+import { type Beat } from "./energy.ts"
+import { bestSeam, isPrime, minimumTaps, smallestPrimeFactor } from "./factor.ts"
+import { type Push, isShoved, newPush, pressed, relieved } from "./push.ts"
+import {
+  type Shutter,
+  type ShutterSource,
+  newShutter,
+  strikeRivet,
+} from "./shutter.ts"
+import { WAVES_PER_BLOCK, nextWaveSize } from "./wave.ts"
+
+export type Phase =
+  /** The plate coming down. */
+  | "shutter-down"
+  /** The plate is up on the wall and readable. **Input open.** */
+  | "shutter"
+  /** A rivet caving in. */
+  | "rivet"
+  /** The plate going up. */
+  | "shutter-up"
+  /** The mob walking on. */
+  | "approach"
+  /** The mob is in front of you. **Input open.** */
+  | "melee"
+  /** A seam landed and the crack is running. */
+  | "crack"
+  /** A seam refused. */
+  | "ringoff"
+  /** Fists off locked arms. */
+  | "bounce"
+  /** A rank going down. */
+  | "fall"
+  /** The street empty. */
+  | "clear"
+  /** Shoved back. */
+  | "shove"
+
+export type StreetEvent =
+  | { readonly kind: "shutter"; readonly shutter: Shutter }
+  | {
+      readonly kind: "report"
+      readonly questionId: string
+      readonly answered: string
+      readonly correct: boolean
+      readonly ms: number
+    }
+  | { readonly kind: "wave"; readonly size: number; readonly solid: boolean }
+  | { readonly kind: "crack"; readonly seam: number; readonly crowd: Crowd }
+  | { readonly kind: "ringoff"; readonly seam: number; readonly remainder: number }
+  | { readonly kind: "bounce"; readonly size: number }
+  | { readonly kind: "down"; readonly felled: number; readonly crowd: Crowd }
+  | {
+      readonly kind: "cleared"
+      readonly size: number
+      readonly taps: number
+      readonly clean: boolean
+      readonly solid: boolean
+    }
+  | { readonly kind: "shove" }
+  | { readonly kind: "block"; readonly blocks: number }
+  /** Everything that wants a sound, a shake and a motor. Ordered with the rest. */
+  | { readonly kind: "beat"; readonly beat: Beat; readonly size: number; readonly best: boolean }
+
+export type StreetOptions = {
+  /** Where the plates come from. Called once per shutter. */
+  readonly deal: () => ShutterSource
+  readonly rng: Rng
+  readonly timing?: Timing
+}
+
+/** How wide the crack has to run, before the scene has ever been measured. */
+const DEFAULT_STREET_PX = 720
+
+export class Street {
+  private readonly deal: () => ShutterSource
+  private readonly rng: Rng
+  private readonly timing: Timing
+
+  private phaseName: Phase = "shutter-down"
+  private elapsed = 0
+  private duration: number
+  private stopped = false
+
+  /** Monotonic while running, frozen while paused. Every mark below is on it. */
+  private clock = 0
+  private litAt = 0
+
+  private streetPx = DEFAULT_STREET_PX
+
+  private plate: Shutter | null = null
+  private mob: Crowd = newCrowd(4)
+  private pushState: Push = newPush()
+
+  private waveSize = 0
+  private previousSize = 0
+  private tapCount = 0
+  private errorCount = 0
+  private hint = 0
+
+  private blockIndex = 0
+  private waveInBlock = 0
+  private blocksDone = 0
+
+  constructor(options: StreetOptions) {
+    this.deal = options.deal
+    this.rng = options.rng
+    this.timing = options.timing ?? TIMING
+    this.duration = this.timing.shutterDown
+  }
+
+  get phase(): Phase {
+    return this.phaseName
+  }
+
+  get crowd(): Crowd {
+    return this.mob
+  }
+
+  get shutter(): Shutter | null {
+    return this.plate
+  }
+
+  get push(): Push {
+    return this.pushState
+  }
+
+  get blocks(): number {
+    return this.blocksDone
+  }
+
+  get block(): number {
+    return this.blockIndex
+  }
+
+  get waveOfBlock(): number {
+    return this.waveInBlock
+  }
+
+  get taps(): number {
+    return this.tapCount
+  }
+
+  /** The lit stud after a shove-back. `0` when there is no hint standing. */
+  get hintSeam(): number {
+    return this.hint
+  }
+
+  get paused(): boolean {
+    return this.stopped
+  }
+
+  /** 0..1 through the current phase. The renderer's only clock. */
+  get progress(): number {
+    if (this.duration <= 0) return 1
+    return Math.max(0, Math.min(1, this.elapsed / this.duration))
+  }
+
+  get elapsedMs(): number {
+    return this.elapsed
+  }
+
+  get durationMs(): number {
+    return this.duration
+  }
+
+  /** Whether a tap would be read right now. Drives the renderer's affordances. */
+  get open(): boolean {
+    if (this.stopped) return false
+    return this.phaseName === "melee" || this.phaseName === "shutter"
+  }
+
+  /**
+   * How wide the crack runs. Set on every resize.
+   *
+   * The crack is a **speed** (`CRACK_PX_PER_S`), so this changes how long a
+   * break takes rather than how fast it looks — which is the point: a break
+   * across an iPad is a longer event than the same break on a phone, and it
+   * should be.
+   */
+  setStreetWidth(px: number): void {
+    this.streetPx = Math.max(80, px)
+  }
+
+  /**
+   * The host put something over the frame. **The clock stops dead.**
+   * See the file header for what a running clock costs the child here.
+   */
+  pause(): void {
+    this.stopped = true
+  }
+
+  resume(): void {
+    this.stopped = false
+  }
+
+  /** The first plate. Idempotent — a second call is a no-op. */
+  begin(): StreetEvent[] {
+    if (this.plate !== null) return []
+    return this.raisePlate()
+  }
+
+  private raisePlate(): StreetEvent[] {
+    this.plate = newShutter(this.deal(), this.rng)
+    this.enter("shutter-down")
+    return []
+  }
+
+  private enter(phase: Phase): void {
+    this.phaseName = phase
+    this.elapsed = 0
+    this.duration = this.durationOf(phase)
+    if (phase === "shutter") this.litAt = this.clock
+  }
+
+  private durationOf(phase: Phase): number {
+    switch (phase) {
+      case "shutter-down":
+        return this.timing.shutterDown
+      case "shutter":
+        return 0
+      case "rivet":
+        return this.timing.rivet
+      case "shutter-up":
+        return this.timing.shutterUp
+      case "approach":
+        return this.timing.approach
+      case "melee":
+        return 0
+      case "crack":
+        return crackMs(this.streetPx) + this.timing.settle
+      case "ringoff":
+        return this.timing.ringoff
+      case "bounce":
+        return this.timing.bounce
+      case "fall":
+        return this.timing.fall
+      case "clear":
+        return this.timing.clear
+      case "shove":
+        return this.timing.shove
+    }
+  }
+
+  /** The two phases that wait on the child rather than on the clock. */
+  private waits(phase: Phase): boolean {
+    return phase === "melee" || phase === "shutter"
+  }
+
+  advance(dt: number): StreetEvent[] {
+    // Guard one: the machine does not move behind a sheet, and the clock does
+    // not accumulate, which is what shifts every mark forward by the length of
+    // the pause. Removing this line breaks three tests in `street.test.ts`.
+    if (this.stopped) return []
+    const step = Math.max(0, dt)
+    this.clock += step
+    if (this.waits(this.phaseName)) return []
+
+    const out: StreetEvent[] = []
+    this.elapsed += step
+    // A `while`, not an `if`: a frame delta longer than a phase would otherwise
+    // owe the child a beat that never played.
+    let guard = 0
+    while (this.elapsed >= this.duration && !this.waits(this.phaseName) && guard++ < 24) {
+      const over = this.elapsed - this.duration
+      out.push(...this.finish())
+      this.elapsed += over
+      if (this.waits(this.phaseName)) break
+    }
+    return out
+  }
+
+  /** The current phase ran out. Decide what the street does next. */
+  private finish(): StreetEvent[] {
+    switch (this.phaseName) {
+      case "shutter-down":
+        this.enter("shutter")
+        return this.plate === null ? [] : [{ kind: "shutter", shutter: this.plate }]
+
+      case "rivet":
+        this.enter("shutter")
+        return []
+
+      case "shutter-up":
+        return this.startWave()
+
+      case "approach":
+        this.enter("melee")
+        return []
+
+      case "crack":
+      case "ringoff":
+      case "bounce":
+        this.enter("melee")
+        return []
+
+      case "fall": {
+        if (isCleared(this.mob)) return this.finishWave()
+        this.enter("melee")
+        return []
+      }
+
+      case "clear":
+        return this.afterWave()
+
+      case "shove":
+        return this.restartWave()
+
+      // Waiting phases never expire; `advance` returns before it reaches here.
+      case "melee":
+      case "shutter":
+        return []
+    }
+  }
+
+  private startWave(): StreetEvent[] {
+    const size = nextWaveSize(this.rng, this.blockIndex, this.previousSize)
+    this.waveSize = size
+    this.hint = 0
+    this.previousSize = size
+    this.mob = newCrowd(size)
+    this.pushState = newPush()
+    this.tapCount = 0
+    this.errorCount = 0
+    this.enter("approach")
+    return [{ kind: "wave", size, solid: isPrime(size) }]
+  }
+
+  private finishWave(): StreetEvent[] {
+    const size = this.waveSize
+    const clean = isCleanBreak(this.tapCount, this.errorCount, minimumTaps(size))
+    const solid = isPrime(size)
+    this.hint = 0
+    this.enter("clear")
+    return [
+      { kind: "cleared", size, taps: this.tapCount, clean, solid },
+      { kind: "beat", beat: solid ? "solid" : "cleared", size, best: clean },
+    ]
+  }
+
+  private afterWave(): StreetEvent[] {
+    this.waveInBlock += 1
+    const out: StreetEvent[] = []
+    if (this.waveInBlock >= WAVES_PER_BLOCK) {
+      this.waveInBlock = 0
+      this.blockIndex += 1
+      this.blocksDone += 1
+      out.push({ kind: "block", blocks: this.blocksDone })
+      out.push({ kind: "beat", beat: "block", size: this.waveSize, best: false })
+    }
+    // A fresh plate, and therefore a fresh wave: the hint is spent.
+    this.waveSize = 0
+    out.push(...this.raisePlate())
+    return out
+  }
+
+  private restartWave(): StreetEvent[] {
+    // The same mob comes back, and the smallest prime that goes into it is lit
+    // on the bar. Scaffolding, not a punishment: nothing built was taken, and
+    // the child gets the one fact that unsticks them.
+    this.hint = smallestPrimeFactor(this.waveSize)
+    this.mob = newCrowd(this.waveSize)
+    this.pushState = newPush()
+    this.tapCount = 0
+    this.errorCount = 0
+    this.enter("approach")
+    return [{ kind: "wave", size: this.waveSize, solid: isPrime(this.waveSize) }]
+  }
+
+  /** A slip: the mob leans in, and may lean all the way in. */
+  private lean(): StreetEvent[] {
+    this.errorCount += 1
+    this.pushState = pressed(this.pushState)
+    if (!isShoved(this.pushState)) return []
+    this.enter("shove")
+    return [
+      { kind: "shove" },
+      { kind: "beat", beat: "shove", size: this.mob.size, best: false },
+    ]
+  }
+
+  // ---------------------------------------------------------------- input --
+
+  /**
+   * Strike stud `k` at the mob.
+   *
+   * Guard two: a tap behind a sheet is not a tap. This is separate from the
+   * clock guard on purpose — a machine that stood still but still took input
+   * would spend the child's seam on a screen they could not see.
+   */
+  strikeStud(k: number): StreetEvent[] {
+    if (this.stopped || this.phaseName !== "melee") return []
+    const result: StrikeResult = strike(this.mob, k)
+    if (result.kind === "ringoff") {
+      this.mob = result.crowd
+      const out: StreetEvent[] = [
+        { kind: "ringoff", seam: result.seam, remainder: result.remainder },
+        { kind: "beat", beat: "ringoff", size: this.mob.size, best: false },
+      ]
+      const shoved = this.lean()
+      if (shoved.length === 0) this.enter("ringoff")
+      return [...out, ...shoved]
+    }
+    const best = bestSeam(result.wasSize) === result.seam
+    this.mob = result.crowd
+    this.tapCount += 1
+    this.hint = 0
+    this.enter("crack")
+    return [
+      { kind: "crack", seam: result.seam, crowd: this.mob },
+      { kind: "beat", beat: "crack", size: result.wasSize, best },
+    ]
+  }
+
+  /** Swing at the front rank. A claim that the rank in front of you is prime. */
+  swing(): StreetEvent[] {
+    if (this.stopped) return []
+    // Punches **chain**: a swing lands during the fall of the rank before it.
+    // Eight ranks going down has to feel like a combo rather than like a queue,
+    // and a beat-'em-up that made you wait 300 ms between fists would be the
+    // wrong genre. A strike does not chain — re-cutting a mob mid-crack would
+    // mean the child never sees the rectangle they just made.
+    if (this.phaseName !== "melee" && this.phaseName !== "fall") return []
+    // The last rank is already on its way down. A tap into an empty street is
+    // not a claim about anything, so it is neither a bounce nor a mark.
+    if (this.mob.ranks === 0) return []
+    const result: PunchResult = punch(this.mob)
+    if (result.kind === "bounce") {
+      const out: StreetEvent[] = [
+        { kind: "bounce", size: result.size },
+        { kind: "beat", beat: "bounce", size: result.size, best: false },
+      ]
+      const shoved = this.lean()
+      if (shoved.length === 0) this.enter("bounce")
+      return [...out, ...shoved]
+    }
+    const felled = result.felled
+    this.mob = result.crowd
+    this.tapCount += 1
+    this.pushState = relieved(this.pushState)
+    this.enter("fall")
+    return [
+      { kind: "down", felled, crowd: this.mob },
+      { kind: "beat", beat: "down", size: felled, best: false },
+    ]
+  }
+
+  /**
+   * Hit rivet `index` on the plate.
+   *
+   * Guard three, and the one with a number attached: the latency reported here
+   * is `this.clock - this.litAt`, both of which are frozen while paused. A
+   * strike accepted behind a sheet would carry the length of the sheet as the
+   * child's thinking time.
+   */
+  hitRivet(index: number): StreetEvent[] {
+    if (this.stopped || this.phaseName !== "shutter" || this.plate === null) return []
+    const before = this.plate
+    const result = strikeRivet(before, index)
+    if (result.shutter === before) return []
+    this.plate = result.shutter
+
+    const out: StreetEvent[] = []
+    if (result.report !== null) {
+      out.push({
+        kind: "report",
+        questionId: result.report.questionId,
+        answered: result.report.answered,
+        correct: result.opened,
+        ms: Math.max(0, Math.round(this.clock - this.litAt)),
+      })
+    }
+    if (result.opened) {
+      out.push({ kind: "beat", beat: "rivetRight", size: 0, best: false })
+      this.enter("shutter-up")
+      return out
+    }
+    out.push({ kind: "beat", beat: "rivetWrong", size: 0, best: false })
+    // The rivet is out and the plate is still down: that is the whole cost, and
+    // it is deliberately not also a push on the mob. The answer has already
+    // gone to the host, which is where a wrong answer belongs. Charging for it
+    // twice — once on the record and once on the street — would make a child
+    // who is genuinely working out `503 − 178` worse off than one who guesses
+    // fast, and it would make the arithmetic the thing to be afraid of.
+    this.enter("rivet")
+    return out
+  }
+
+  /** Tests and the renderer: the crack's speed is a stated design number. */
+  static get crackSpeed(): number {
+    return CRACK_PX_PER_S
+  }
+}

--- a/dynawalla/games/street/src/game/wave.test.ts
+++ b/dynawalla/games/street/src/game/wave.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { Rng } from "../core/rng.ts"
+import { CROWD_MAX, CROWD_MIN, bar, isPrime, isSeam, seamsFor } from "./factor.ts"
+import { WAVES_PER_BLOCK, bandFor, isSolid, nextWaveSize, wavesPerBlock } from "./wave.ts"
+
+test("every mob the street can send is breakable or punchable, and never neither", () => {
+  const rng = new Rng(0xb10c)
+  let previous = 0
+  for (let i = 0; i < 4000; i++) {
+    const size = nextWaveSize(rng, i % 6, previous)
+    assert.ok(size >= CROWD_MIN && size <= CROWD_MAX, `a mob of ${size}`)
+    if (isPrime(size)) {
+      assert.deepEqual(seamsFor(size), [], `the prime ${size} offered a seam`)
+    } else {
+      assert.ok(bar(size).some((k) => isSeam(size, k)), `the composite ${size} had no seam on the bar`)
+    }
+    previous = size
+  }
+})
+
+test("the same mob never arrives twice running", () => {
+  const rng = new Rng(0x5a3e)
+  let previous = 0
+  for (let i = 0; i < 4000; i++) {
+    const size = nextWaveSize(rng, 3, previous)
+    assert.notEqual(size, previous, "the same rectangle came round the corner twice")
+    previous = size
+  }
+})
+
+test("the band widens with blocks finished, and then stops", () => {
+  assert.deepEqual(bandFor(0), { lo: 4, hi: 9 })
+  assert.ok(bandFor(3).hi > bandFor(0).hi)
+  // It stops widening: difficulty escalates on what the child finished, and
+  // then the street is just the street. Nothing here escalates forever.
+  assert.deepEqual(bandFor(3), bandFor(9))
+  assert.deepEqual(bandFor(3), bandFor(1000))
+  assert.deepEqual(bandFor(-5), bandFor(0))
+})
+
+test("the opening block stays small", () => {
+  const rng = new Rng(0x0e11)
+  for (let i = 0; i < 500; i++) {
+    const size = nextWaveSize(rng, 0, 0)
+    assert.ok(size <= 9, `a mob of ${size} in the first block`)
+  }
+})
+
+test("both kinds of mob turn up", () => {
+  const rng = new Rng(0xb0d1)
+  let primes = 0
+  let composites = 0
+  let previous = 0
+  for (let i = 0; i < 600; i++) {
+    const size = nextWaveSize(rng, 3, previous)
+    if (isPrime(size)) primes++
+    else composites++
+    previous = size
+  }
+  assert.ok(primes > 40, `only ${primes} solid mobs in 600`)
+  assert.ok(composites > 200, `only ${composites} breakable mobs in 600`)
+})
+
+test("the same seed is the same street, forever", () => {
+  const draw = () => {
+    const rng = new Rng(0xfeed)
+    const out: number[] = []
+    let previous = 0
+    for (let i = 0; i < 60; i++) {
+      previous = nextWaveSize(rng, Math.floor(i / WAVES_PER_BLOCK), previous)
+      out.push(previous)
+    }
+    return out
+  }
+  assert.deepEqual(draw(), draw())
+})
+
+test("a block is three waves and a solid mob is a prime one", () => {
+  assert.equal(wavesPerBlock(), WAVES_PER_BLOCK)
+  assert.equal(WAVES_PER_BLOCK, 3)
+  assert.equal(isSolid(13), true)
+  assert.equal(isSolid(12), false)
+})

--- a/dynawalla/games/street/src/game/wave.ts
+++ b/dynawalla/games/street/src/game/wave.ts
@@ -1,0 +1,65 @@
+// Which mob comes round the corner.
+//
+// A band per block, widening. Not a difficulty curve on *run length* — the band
+// is a function of how many blocks have been finished, which is a thing the
+// child did, and it stops widening at the fourth block. After that the street
+// is the street.
+//
+// Two properties `wave.test.ts` holds:
+//
+//   * every size the street can send is inside the pool `factor.ts` guarantees
+//     the breaker bar can express, so there is never a mob whose seam the child
+//     cannot say; and
+//   * a size never repeats back to back, because the second identical mob in a
+//     row is a mob nobody looks at.
+
+import { CROWD_MAX, CROWD_MIN, isPrime } from "./factor.ts"
+import type { Rng } from "../core/rng.ts"
+
+export const WAVES_PER_BLOCK = 3
+
+type Band = { readonly lo: number; readonly hi: number }
+
+const BANDS: readonly Band[] = [
+  { lo: 4, hi: 9 },
+  { lo: 4, hi: 12 },
+  { lo: 6, hi: 16 },
+  { lo: 6, hi: CROWD_MAX },
+] as const
+
+export function bandFor(blockIndex: number): Band {
+  const i = Math.max(0, Math.min(BANDS.length - 1, Math.trunc(blockIndex)))
+  return BANDS[i] as Band
+}
+
+/**
+ * The next mob.
+ *
+ * `previous` is rejected so the same rectangle never arrives twice running. The
+ * rejection loop is bounded: every band holds at least six sizes, so a second
+ * draw almost always differs and the bound is there for the pathological case
+ * rather than for the common one.
+ */
+export function nextWaveSize(rng: Rng, blockIndex: number, previous: number): number {
+  const { lo, hi } = bandFor(blockIndex)
+  let size = rng.int(lo, hi)
+  for (let guard = 0; guard < 12 && size === previous; guard++) {
+    size = rng.int(lo, hi)
+  }
+  if (size === previous) size = size === hi ? lo : size + 1
+  return Math.max(CROWD_MIN, Math.min(CROWD_MAX, size))
+}
+
+/**
+ * How many mobs a block holds. Fixed, and short: a block is the unit the street
+ * celebrates and the unit the host may put a sheet after, so it has to be
+ * reachable inside a couple of minutes from a standing start.
+ */
+export function wavesPerBlock(): number {
+  return WAVES_PER_BLOCK
+}
+
+/** For the renderer's marquee: a solid mob is worth naming. */
+export function isSolid(size: number): boolean {
+  return isPrime(size)
+}

--- a/dynawalla/games/street/src/index.ts
+++ b/dynawalla/games/street/src/index.ts
@@ -1,0 +1,3 @@
+export type { Host, Question } from "./contract.ts"
+export { mount } from "./contract.ts"
+export { createStubHost } from "./stubHost.ts"

--- a/dynawalla/games/street/src/main.ts
+++ b/dynawalla/games/street/src/main.ts
@@ -1,0 +1,50 @@
+// Standalone dev harness. `npm run dev` → a playable game wired to the local
+// stub Host, with no runtime underneath it.
+//
+// `?pause=1` puts a sheet over the frame for two seconds every time the game
+// reports a stopping point, which is exactly what a real host does after a
+// `transition`. It is here because that is the state the pause guards exist
+// for, and a guard nobody can see working is a guard nobody trusts.
+
+import { mount } from "./contract.ts"
+import { createStubHost } from "./stubHost.ts"
+
+const el = document.getElementById("app")
+if (!el) throw new Error("street: #app missing")
+
+const params = new URLSearchParams(location.search)
+const seed = Number(params.get("seed") ?? "") || 0x57ee7
+const reduced = params.has("reduced") ? params.get("reduced") !== "0" : undefined
+const sheet = params.get("pause") === "1"
+
+let answered = 0
+let correct = 0
+const readout = document.getElementById("readout")
+
+let handle: { unmount(): void; pause(): void; resume(): void } | null = null
+
+const host = createStubHost({
+  seed,
+  ...(reduced === undefined ? {} : { reducedMotion: reduced }),
+  onReport(r) {
+    answered++
+    if (r.correct) correct++
+    if (readout) {
+      readout.textContent = `host.report → ${correct}/${answered} · last ${r.ms}ms · "${r.answered || "—"}"`
+    }
+    console.info("[street/host] report", r)
+  },
+  onTransition(kind, l) {
+    console.info("[street/host] transition", kind, l ?? "")
+    if (!sheet || !handle) return
+    handle.pause()
+    globalThis.setTimeout(() => handle?.resume(), 2000)
+  },
+})
+
+handle = mount(el, host)
+
+// Vite HMR: tear the old instance down so audio contexts and rAF loops do not
+// accumulate across edits.
+type HotModule = { hot?: { dispose(cb: () => void): void } }
+;(import.meta as unknown as HotModule).hot?.dispose(() => handle?.unmount())

--- a/dynawalla/games/street/src/mount.ts
+++ b/dynawalla/games/street/src/mount.ts
@@ -1,0 +1,237 @@
+// FOUNDRY STREET.
+//
+// The night shift comes up the street in a mob. You have two verbs and both of
+// them are claims about a number.
+//
+//   **STRIKE a stud.** "This number goes into them." If it does, the crack runs
+//   the length of the block at 2400 px/s and the mob comes apart into that many
+//   to a rank — the same bodies, rearranged into a rectangle the child made. If
+//   it does not, the crack rings off, the mob stands in groups with the
+//   remainder left over, and closes back up.
+//
+//   **SWING.** "They are solid." Fists work on a rank whose size is prime and
+//   bounce off one that is not, because a composite rank has something to hold
+//   on to and a prime rank has nothing.
+//
+// Nobody is told what a prime is. Thirteen refuses every stud on the bar, and
+// then goes down in one punch.
+//
+// The shutter between waves is the other half: a problem chalked on steel, four
+// rivets, and the host is the judge of which one opens it.
+
+import { StreetAudio } from "./audio/audio.ts"
+import { MAX_STEP_MS, TIMING, TIMING_REDUCED } from "./core/feel.ts"
+import { Rng } from "./core/rng.ts"
+import type { Host } from "./contract.ts"
+import { blocksCleared, recordBlocks } from "./game/best.ts"
+import { HAPTIC } from "./game/energy.ts"
+import { pressure } from "./game/push.ts"
+import { Street, type StreetEvent } from "./game/street.ts"
+import { WAVES_PER_BLOCK } from "./game/wave.ts"
+import { Scene, hit, type Frame } from "./render/scene.ts"
+
+export function mountStreet(
+  el: HTMLElement,
+  host: Host,
+): { unmount(): void; pause(): void; resume(): void } {
+  const canvas = document.createElement("canvas")
+  canvas.style.cssText =
+    "position:absolute;inset:0;width:100%;height:100%;display:block;touch-action:none"
+  el.appendChild(canvas)
+
+  const reduced = host.prefersReducedMotion()
+  const scene = new Scene(canvas)
+  const audio = new StreetAudio()
+  const rng = new Rng((Date.now() ^ 0x57ee7) >>> 0)
+
+  const street = new Street({
+    rng,
+    timing: reduced ? TIMING_REDUCED : TIMING,
+    deal: () => {
+      const q = host.next({ domain: "add" })
+      return { id: q.id, prompt: q.prompt, answer: q.answer, distractors: q.distractors }
+    },
+  })
+  street.setStreetWidth(scene.width)
+
+  let best = blocksCleared()
+  let running = true
+  let frameId = 0
+  let last = 0
+  let lastSeam = 0
+  let lastRemainder = 0
+  let clean = false
+
+  const handle = (events: readonly StreetEvent[]): void => {
+    for (const event of events) {
+      switch (event.kind) {
+        case "report": {
+          // The host is the judge. What crosses is the numeral on the rivet the
+          // child struck — and a wrong one is a mal-rule output, so the
+          // misconception routes itself with no extra wiring.
+          host.report({
+            questionId: event.questionId,
+            correct: event.correct,
+            ms: event.ms,
+            answered: event.answered,
+          })
+          audio.rivet(event.correct)
+          if (event.correct) audio.shutter(true)
+          break
+        }
+        case "wave": {
+          audio.hum(event.size)
+          break
+        }
+        case "crack": {
+          lastSeam = event.seam
+          audio.crack(event.crowd.size)
+          audio.hum(event.crowd.size)
+          break
+        }
+        case "ringoff": {
+          lastSeam = event.seam
+          lastRemainder = event.remainder
+          audio.ringoff()
+          break
+        }
+        case "bounce": {
+          audio.bounce()
+          break
+        }
+        case "down": {
+          audio.down(event.felled)
+          break
+        }
+        case "cleared": {
+          clean = event.clean
+          audio.cleared(event.solid)
+          audio.hum(0)
+          break
+        }
+        case "shove": {
+          audio.shove()
+          break
+        }
+        case "shutter": {
+          audio.hum(0)
+          audio.shutter(false)
+          break
+        }
+        case "block": {
+          audio.block()
+          if (recordBlocks(event.blocks)) best = event.blocks
+          // A block finished is a thing the child *reached*, which is the only
+          // kind of moment this call is allowed to mark. It is never fired on a
+          // shove-back, and the host may answer it by putting a sheet over a
+          // still-running pack — which is what `pause()` below exists for.
+          host.transition?.("level")
+          break
+        }
+        case "beat": {
+          const cue = HAPTIC[event.beat]
+          host.haptic(cue)
+          if (event.beat === "ringoff" || event.beat === "bounce") {
+            audio.lean(street.push.marks)
+          }
+          break
+        }
+      }
+    }
+  }
+
+  const frameOf = (): Frame => ({
+    phase: street.phase,
+    progress: street.progress,
+    crowd: street.crowd,
+    shutter: street.shutter,
+    pressure: pressure(street.push),
+    pushMarks: street.push.marks,
+    blocks: street.blocks,
+    best,
+    waveOfBlock: street.waveOfBlock,
+    wavesPerBlock: WAVES_PER_BLOCK,
+    hintSeam: street.hintSeam,
+    lastSeam,
+    lastRemainder,
+    clean,
+    reduced,
+  })
+
+  const tick = (now: number): void => {
+    if (!running) return
+    frameId = requestAnimationFrame(tick)
+    const dt = last === 0 ? 16 : Math.min(MAX_STEP_MS, now - last)
+    last = now
+    handle(street.advance(dt))
+    scene.draw(frameOf())
+  }
+
+  const press = (event: PointerEvent): void => {
+    event.preventDefault()
+    // Web Audio needs a gesture, and the first tap in the game is the first one.
+    audio.resume()
+    const layout = scene.lastLayout
+    if (!layout) return
+    const rect = canvas.getBoundingClientRect()
+    const x = event.clientX - rect.left
+    const y = event.clientY - rect.top
+
+    if (street.phase === "shutter") {
+      for (const rivet of layout.rivets) {
+        if (hit(rivet.rect, x, y)) {
+          handle(street.hitRivet(rivet.index))
+          return
+        }
+      }
+      return
+    }
+    for (const stud of layout.studs) {
+      if (hit(stud.rect, x, y)) {
+        handle(street.strikeStud(stud.k))
+        return
+      }
+    }
+    if (hit(layout.mob, x, y)) handle(street.swing())
+  }
+
+  const resize = (): void => {
+    scene.resize()
+    street.setStreetWidth(scene.width)
+  }
+
+  canvas.addEventListener("pointerdown", press)
+  globalThis.addEventListener("resize", resize)
+
+  const observer =
+    typeof ResizeObserver === "function"
+      ? new ResizeObserver(() => {
+          resize()
+        })
+      : null
+  observer?.observe(el)
+
+  handle(street.begin())
+  frameId = requestAnimationFrame(tick)
+
+  return {
+    // The host puts a sheet over the frame — a transition, a parent gate — and
+    // sends `pause` with the pack still mounted and its rAF still firing. The
+    // clock has to stop dead and input has to stop counting: see `Street`.
+    pause(): void {
+      street.pause()
+    },
+    resume(): void {
+      street.resume()
+    },
+    unmount(): void {
+      running = false
+      cancelAnimationFrame(frameId)
+      canvas.removeEventListener("pointerdown", press)
+      globalThis.removeEventListener("resize", resize)
+      observer?.disconnect()
+      audio.dispose()
+      canvas.remove()
+    },
+  }
+}

--- a/dynawalla/games/street/src/pack.ts
+++ b/dynawalla/games/street/src/pack.ts
@@ -1,0 +1,68 @@
+// FOUNDRY STREET, as a Dynawalla pack.
+//
+// The seam and nothing else. `mount` is handed the real host in place of the
+// stub, because the adapter presents the same synchronous `Host` surface
+// `contract.ts` already describes — so the crowd, the breaker bar, the push and
+// the crack are untouched.
+//
+// ## What crosses the boundary, and what does not
+//
+// **The shutter does.** It carries a problem the curriculum drew, four rivets
+// carry the canonical answer and the host's mal-rule outputs, and the rivet the
+// child strikes is reported as-is. The game never marks it: `items.reveal` is
+// declared and is not optional, because without the canonical value there is no
+// such thing as a plate that opens — but the *verdict* is the host's, and the
+// value reported on a wrong strike is the mal-rule itself, so the misconception
+// routes with no extra wiring.
+//
+// **The factoring does not.** Only the `add` domain has active rows, so the
+// host serves whole-number column arithmetic no matter what a pack declares —
+// and a mob of twelve coming apart into four ranks of three is not a question
+// anybody asked. It is arithmetic the child performs with a gesture, the way
+// slicing a composite is in THE SPLIT, and nothing about it is reported. What
+// `covers.skills` claims is the shutter, and every id on it is an `active` row
+// of `dw.add`.
+//
+// ## The sheet
+//
+// The host may put a sheet over a pack that is still mounted and still running,
+// and the call most likely to raise one is this game's own `transition` on a
+// finished block. `pause` and `resume` are wired here because the methods on
+// the handle are inert unless this file subscribes — a clock left running
+// behind a sheet would clear a wave nobody watched and would report the length
+// of the sheet as the child's thinking time on a plate they never saw.
+
+import { createGameHost, renderNoHost } from "../../../packs/shared/game-host/index.ts"
+import { mount } from "./contract.ts"
+import type { Host } from "./contract.ts"
+
+const root = document.getElementById("app")
+if (!root) throw new Error("street: #app missing")
+
+async function start(el: HTMLElement): Promise<void> {
+  const mounted = await createGameHost({ domain: "add-sub" })
+  // Stocked before the first frame: the plate comes down inside half a second
+  // of launch, and a plate with a blank face is the kind of thing that happens
+  // exactly once, in front of the child.
+  await mounted.warm()
+
+  const handle = mount(el, mounted.host as unknown as Host)
+
+  // The host tells a pack before its port dies, so the rAF loop and the audio
+  // context come down before the frame does rather than a frame or two after.
+  mounted.client.on("dispose", () => {
+    handle.unmount()
+  })
+
+  mounted.client.on("pause", () => {
+    handle.pause()
+  })
+  mounted.client.on("resume", () => {
+    handle.resume()
+  })
+}
+
+void start(root).catch((error: unknown) => {
+  console.error("[street] could not start", error)
+  renderNoHost(root, "FOUNDRY STREET")
+})

--- a/dynawalla/games/street/src/render/fakeCanvas.ts
+++ b/dynawalla/games/street/src/render/fakeCanvas.ts
@@ -1,0 +1,133 @@
+// A recording 2D context.
+//
+// The rendered-output gate in `EXPERIENCE_DESIGN.md` is a human looking at
+// PNGs, and it should be. This is the part a machine can hold: that the scene
+// draws without throwing at any size, in either motion branch, at every phase —
+// and, the one that is a design claim rather than a robustness claim, that a
+// wrong draw puts **no additional ink on the screen at all**.
+//
+// It records the ops rather than rasterising, so it needs no canvas backend and
+// runs in the same plain `node --test` as everything else.
+
+export type Op = {
+  readonly name: string
+  readonly args: readonly unknown[]
+  /** `globalAlpha` at the moment of the call. Ink drawn at 0 is ink not drawn. */
+  readonly alpha: number
+  /** The `fillStyle` or `strokeStyle` in force — so a colour change is visible. */
+  readonly style: string
+}
+
+export type Recorder = {
+  readonly ops: Op[]
+  /** Ops that put something on the screen, as opposed to setting up state. */
+  ink(): Op[]
+  reset(): void
+}
+
+const INK = new Set(["fill", "stroke", "fillRect", "strokeRect", "fillText"])
+
+/**
+ * A canvas-shaped object with a recording context. Returned as `unknown` so the
+ * cast happens at the one call site rather than being spread through the file.
+ */
+export function fakeCanvas(width: number, height: number): { canvas: unknown; rec: Recorder } {
+  const ops: Op[] = []
+  let ctxRef: Record<string, unknown> | null = null
+  const STROKES = new Set(["stroke", "strokeRect"])
+  const record = (name: string) => (...args: unknown[]) => {
+    const alpha = ctxRef?.["globalAlpha"]
+    // Only the ops that actually consume a style carry one. `clearRect` and
+    // friends would otherwise report whatever colour the previous frame left
+    // behind, which is a fact about the recorder rather than about the frame.
+    const style = INK.has(name) ? ctxRef?.[STROKES.has(name) ? "strokeStyle" : "fillStyle"] : ""
+    ops.push({
+      name,
+      args,
+      alpha: typeof alpha === "number" ? alpha : 1,
+      // A gradient is an object; the constant colour cases are strings and are
+      // the ones a "nothing changed" comparison needs to see.
+      style: typeof style === "string" ? style : "<gradient>",
+    })
+  }
+
+  const gradient = {
+    addColorStop: record("addColorStop"),
+  }
+
+  const ctx: Record<string, unknown> = {
+    canvas: null,
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 1,
+    lineCap: "butt",
+    globalAlpha: 1,
+    font: "",
+    textAlign: "left",
+    textBaseline: "alphabetic",
+    setTransform: record("setTransform"),
+    clearRect: record("clearRect"),
+    save: record("save"),
+    restore: record("restore"),
+    translate: record("translate"),
+    rotate: record("rotate"),
+    beginPath: record("beginPath"),
+    closePath: record("closePath"),
+    moveTo: record("moveTo"),
+    lineTo: record("lineTo"),
+    arc: record("arc"),
+    ellipse: record("ellipse"),
+    quadraticCurveTo: record("quadraticCurveTo"),
+    bezierCurveTo: record("bezierCurveTo"),
+    roundRect: record("roundRect"),
+    setLineDash: record("setLineDash"),
+    rect: record("rect"),
+    clip: record("clip"),
+    fill: record("fill"),
+    stroke: record("stroke"),
+    fillRect: record("fillRect"),
+    strokeRect: record("strokeRect"),
+    fillText: record("fillText"),
+    createLinearGradient: (...args: unknown[]) => {
+      ops.push({ name: "createLinearGradient", args, alpha: 1, style: "" })
+      return gradient
+    },
+    createRadialGradient: (...args: unknown[]) => {
+      ops.push({ name: "createRadialGradient", args, alpha: 1, style: "" })
+      return gradient
+    },
+    // A crude but monotone metric: enough for the layout code, which only ever
+    // asks for relative widths.
+    measureText: (text: string) => ({ width: [...text].length * 9 }),
+  }
+
+  const canvas = {
+    width: 0,
+    height: 0,
+    style: {} as Record<string, string>,
+    getContext: () => ctx,
+    getBoundingClientRect: () => ({ width, height, top: 0, left: 0, right: width, bottom: height }),
+  }
+  ctx["canvas"] = canvas
+  ctxRef = ctx
+
+  return {
+    canvas,
+    rec: {
+      ops,
+      ink: () => ops.filter((op) => INK.has(op.name)),
+      reset: () => {
+        ops.length = 0
+      },
+    },
+  }
+}
+
+/** Every numeric argument the scene passed to the context, flattened. */
+export function numbersIn(ops: readonly Op[]): number[] {
+  const out: number[] = []
+  for (const op of ops) {
+    for (const arg of op.args) if (typeof arg === "number") out.push(arg)
+  }
+  return out
+}

--- a/dynawalla/games/street/src/render/palette.ts
+++ b/dynawalla/games/street/src/render/palette.ts
@@ -1,0 +1,72 @@
+// The street's materials.
+//
+// Cast iron, soot, cold sodium light and the orange of an open furnace door.
+// **Material, not lighting effects** — no purple-to-teal, no glassmorphism, no
+// neon. The only saturated colour in the game is the ember of the foundry
+// itself, and it is used for exactly one thing: heat. A crack is hot. Locked
+// arms are cold iron. That is the whole colour logic and it is legible without
+// reading anything.
+
+export const PALETTE = {
+  /** Night above the roofline. */
+  sky: "#0a0806",
+  skyLow: "#171310",
+  /** Wet cobbles. */
+  ground: "#100d0b",
+  groundLine: "#221b16",
+  /** The wall the shutter hangs on. */
+  wall: "#15110e",
+  wallLine: "#2a2119",
+
+  /** Cast iron: what a locked, composite rank is made of. */
+  iron: "#3a3630",
+  ironLit: "#5b544a",
+  ironDark: "#221f1b",
+
+  /** Steel: a rank that is prime, and can be taken. Cooler, brighter, alive. */
+  steel: "#8fa0a8",
+  steelLit: "#c6d4d9",
+  steelDark: "#5a666c",
+
+  /** Heat. The crack, the brazier, the furnace door. */
+  ember: "#ff7a1c",
+  emberHot: "#ffd08a",
+  emberDeep: "#a63c05",
+
+  /** Brass: the breaker bar and the rivets. Things you strike. */
+  brass: "#c08f3c",
+  brassLit: "#f0cf85",
+  brassDark: "#6d4e1c",
+
+  /** Chalk on steel. Numerals live here and nowhere else. */
+  chalk: "#efe7d8",
+  chalkDim: "#9d9484",
+
+  /** Sodium lamp. */
+  lamp: "#ffb867",
+} as const
+
+/** A hairline that reads on both iron and cobble. */
+export const HAIRLINE = "rgba(239, 231, 216, 0.10)"
+
+/** Numerals. Tabular so a two-digit lamp does not shove a one-digit one. */
+export const FACE = `600 %dpx ui-monospace, "SF Mono", Menlo, Consolas, monospace`
+export const LABEL = `500 %dpx ui-sans-serif, -apple-system, "Segoe UI", Roboto, sans-serif`
+
+export function face(px: number): string {
+  return FACE.replace("%d", String(Math.round(px)))
+}
+
+export function label(px: number): string {
+  return LABEL.replace("%d", String(Math.round(px)))
+}
+
+/** `rgba` from a hex and an alpha, so the palette stays a list of materials. */
+export function alpha(hex: string, a: number): string {
+  const h = hex.replace("#", "")
+  const n = Number.parseInt(h.length === 3 ? h.replace(/(.)/g, "$1$1") : h, 16)
+  const r = (n >> 16) & 255
+  const g = (n >> 8) & 255
+  const b = n & 255
+  return `rgba(${r}, ${g}, ${b}, ${a})`
+}

--- a/dynawalla/games/street/src/render/scene.test.ts
+++ b/dynawalla/games/street/src/render/scene.test.ts
@@ -1,0 +1,279 @@
+// The rendered-output gate in `EXPERIENCE_DESIGN.md` is a human looking at
+// PNGs, and it should be. This is the part a machine can hold: that the scene
+// draws without throwing at every size, in both motion branches and at every
+// phase; that the rectangles it draws are the rectangles input reads; that a
+// touch target is a touch target; and — the one that is a design claim rather
+// than a robustness claim — that **being wrong puts no more ink on the screen
+// than being right**.
+
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { newCrowd, strike } from "../game/crowd.ts"
+import { bar } from "../game/factor.ts"
+import { newShutter } from "../game/shutter.ts"
+import type { Phase } from "../game/street.ts"
+import { Rng } from "../core/rng.ts"
+import { fakeCanvas } from "./fakeCanvas.ts"
+import { Scene, hit, type Frame } from "./scene.ts"
+
+const PHASES: readonly Phase[] = [
+  "shutter-down",
+  "shutter",
+  "rivet",
+  "shutter-up",
+  "approach",
+  "melee",
+  "crack",
+  "ringoff",
+  "bounce",
+  "fall",
+  "clear",
+  "shove",
+] as const
+
+const SIZES: ReadonlyArray<readonly [number, number]> = [
+  [320, 568],
+  [390, 844],
+  [768, 1024],
+  [1024, 768],
+  [1366, 1024],
+] as const
+
+function plate() {
+  return newShutter(
+    { id: "q", prompt: "5,001 − 2,798", answer: "2203", distractors: ["2213", "3203", "2797"] },
+    new Rng(7),
+  )
+}
+
+function frame(over: Partial<Frame> = {}): Frame {
+  return {
+    phase: "melee",
+    progress: 0.5,
+    crowd: newCrowd(12),
+    shutter: plate(),
+    pressure: 0.25,
+    pushMarks: 2,
+    blocks: 3,
+    best: 5,
+    waveOfBlock: 1,
+    wavesPerBlock: 3,
+    hintSeam: 0,
+    lastSeam: 3,
+    lastRemainder: 0,
+    clean: false,
+    reduced: false,
+    ...over,
+  }
+}
+
+function sceneAt(w: number, h: number) {
+  const { canvas, rec } = fakeCanvas(w, h)
+  const scene = new Scene(canvas as HTMLCanvasElement)
+  return { scene, rec }
+}
+
+test("the scene draws at every size, in every phase, in both motion branches", () => {
+  for (const [w, h] of SIZES) {
+    const { scene, rec } = sceneAt(w, h)
+    for (const phase of PHASES) {
+      for (const reduced of [false, true]) {
+        for (const crowd of [newCrowd(4), newCrowd(13), newCrowd(24), { ...newCrowd(24), ranks: 8, size: 3 }]) {
+          for (const progress of [0, 0.5, 1]) {
+            rec.reset()
+            scene.draw(frame({ phase, reduced, crowd, progress }))
+            assert.ok(rec.ink().length > 0, `${phase} at ${w}×${h} drew nothing`)
+          }
+        }
+      }
+    }
+  }
+})
+
+test("an empty street and a spent mob still draw", () => {
+  const { scene, rec } = sceneAt(390, 844)
+  for (const phase of PHASES) {
+    rec.reset()
+    scene.draw(frame({ phase, crowd: { ranks: 0, size: 2, downed: 24, total: 24 } }))
+    assert.ok(rec.ink().length > 0, phase)
+  }
+  rec.reset()
+  scene.draw(frame({ shutter: null, phase: "melee" }))
+  assert.ok(rec.ink().length > 0)
+})
+
+test("every body standing is drawn, and drawn inside the street", () => {
+  // The rectangle is the arithmetic, so a rank clipped off the bottom is a
+  // picture of a lie: `12 = 4 × 3` has to have twelve people in it. One `arc`
+  // per head, and the heads are the only arcs the scene draws.
+  for (const [w, h] of SIZES) {
+    const { scene, rec } = sceneAt(w, h)
+    for (const crowd of [
+      newCrowd(24),
+      { ...newCrowd(24), ranks: 12, size: 2 },
+      { ...newCrowd(24), ranks: 8, size: 3 },
+      { ...newCrowd(16), ranks: 8, size: 2 },
+      { ...newCrowd(9), ranks: 3, size: 3 },
+    ]) {
+      rec.reset()
+      const layout = scene.draw(frame({ crowd, phase: "melee", pressure: 1 }))
+      const heads = rec.ops.filter((op) => op.name === "arc")
+      assert.equal(
+        heads.length,
+        crowd.ranks * crowd.size,
+        `${crowd.ranks} × ${crowd.size} drew ${heads.length} bodies at ${w}×${h}`,
+      )
+      for (const head of heads) {
+        const y = head.args[1] as number
+        assert.ok(y >= 0 && y <= layout.mob.y + layout.mob.h, `a body sat at y=${y} at ${w}×${h}`)
+      }
+    }
+  }
+})
+
+test("a stud is always a real touch target", () => {
+  // A stud smaller than a finger reads as "that number did not work", which is
+  // the one misreading this game cannot afford.
+  for (const [w, h] of SIZES) {
+    const { scene } = sceneAt(w, h)
+    for (const size of [4, 12, 24]) {
+      const layout = scene.draw(frame({ crowd: newCrowd(size) }))
+      assert.equal(layout.studs.length, bar(size).length, `the bar for ${size}`)
+      for (const stud of layout.studs) {
+        assert.ok(stud.rect.w >= 40, `a ${stud.rect.w}px stud at ${w}×${h}`)
+        assert.ok(stud.rect.h >= 44, `a ${stud.rect.h}px stud at ${w}×${h}`)
+        assert.ok(stud.rect.x >= 0 && stud.rect.x + stud.rect.w <= w + 0.5, "a stud ran off the side")
+        assert.ok(stud.rect.y + stud.rect.h <= h + 0.5, "a stud ran off the bottom")
+      }
+    }
+  }
+})
+
+test("a rivet is always a real touch target, and is on the plate", () => {
+  for (const [w, h] of SIZES) {
+    const { scene } = sceneAt(w, h)
+    const f = frame({ phase: "shutter", progress: 1 })
+    const layout = scene.draw(f)
+    assert.equal(layout.rivets.length, 4)
+    for (const rivet of layout.rivets) {
+      assert.ok(rivet.rect.h >= 44, `a ${rivet.rect.h}px rivet at ${w}×${h}`)
+      assert.ok(rivet.rect.w >= 44, `a ${rivet.rect.w}px rivet at ${w}×${h}`)
+      assert.ok(rivet.rect.x >= 0 && rivet.rect.x + rivet.rect.w <= w + 0.5)
+      assert.ok(rivet.rect.y + rivet.rect.h <= h + 0.5)
+    }
+  }
+})
+
+test("nothing a finger can touch overlaps anything else it can touch", () => {
+  const overlaps = (a: { x: number; y: number; w: number; h: number }, b: typeof a): boolean =>
+    a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h
+  for (const [w, h] of SIZES) {
+    const { scene } = sceneAt(w, h)
+    for (const size of [4, 9, 16, 24]) {
+      const layout = scene.draw(frame({ crowd: newCrowd(size) }))
+      for (let i = 0; i < layout.studs.length; i++) {
+        for (let j = i + 1; j < layout.studs.length; j++) {
+          const a = layout.studs[i]?.rect
+          const b = layout.studs[j]?.rect
+          assert.ok(a && b && !overlaps(a, b), `studs ${i} and ${j} overlap at ${w}×${h}`)
+        }
+        const stud = layout.studs[i]?.rect
+        assert.ok(stud && !overlaps(stud, layout.mob), "a stud sits on top of the mob")
+      }
+    }
+  }
+})
+
+test("the rectangle drawn is the rectangle struck", () => {
+  const { scene } = sceneAt(390, 844)
+  const layout = scene.draw(frame({ crowd: newCrowd(12) }))
+  for (const stud of layout.studs) {
+    const cx = stud.rect.x + stud.rect.w / 2
+    const cy = stud.rect.y + stud.rect.h / 2
+    assert.equal(hit(stud.rect, cx, cy), true, `the centre of stud ${stud.k} is not on stud ${stud.k}`)
+    for (const other of layout.studs) {
+      if (other.k === stud.k) continue
+      assert.equal(hit(other.rect, cx, cy), false, `stud ${stud.k} also reads as ${other.k}`)
+    }
+  }
+  assert.equal(hit(layout.mob, layout.mob.x + 1, layout.mob.y + 1), true)
+  assert.equal(hit(layout.mob, layout.mob.x - 1, layout.mob.y), false)
+})
+
+test("the bar narrows with the rank, so a five never shows a nine", () => {
+  const { scene } = sceneAt(390, 844)
+  const twelve = scene.draw(frame({ crowd: newCrowd(12) }))
+  const cracked = strike(newCrowd(12), 3)
+  assert.equal(cracked.kind, "crack")
+  const three = scene.draw(frame({ crowd: cracked.kind === "crack" ? cracked.crowd : newCrowd(3) }))
+  assert.deepEqual(twelve.studs.map((s) => s.k), [2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+  assert.deepEqual(three.studs.map((s) => s.k), [2])
+})
+
+test("being wrong puts no more ink on the screen than being right", () => {
+  // The temptation this guards is specific: a refused seam wants sparks the
+  // whole width of the street. `energy(SLIP) < energy(SEAT)` is the numeric
+  // form of the rule; this is the drawn form.
+  //
+  // Measured as the ink a reaction *adds* over the same street at rest, because
+  // the bar narrows with the rank size and a raw frame count would be comparing
+  // two different sets of studs rather than two reactions.
+  const { scene, rec } = sceneAt(390, 844)
+  const ink = (f: Frame): number => {
+    rec.reset()
+    scene.draw(f)
+    return rec.ink().length
+  }
+  const added = (crowd: Frame["crowd"], over: Partial<Frame>): number =>
+    ink(frame({ crowd, ...over })) - ink(frame({ crowd, phase: "melee", lastSeam: 0, lastRemainder: 0 }))
+
+  const twelve = newCrowd(12)
+  const cracked = { ...twelve, ranks: 4, size: 3 }
+
+  const right = added(cracked, { phase: "crack", lastSeam: 3 })
+  const wrong = added(twelve, { phase: "ringoff", lastSeam: 5, lastRemainder: 2 })
+  const bounced = added(twelve, { phase: "bounce" })
+
+  assert.ok(right > 0, "a landing seam added no ink at all")
+  assert.ok(wrong <= right, `a refused seam added ${wrong} marks against a landing seam's ${right}`)
+  assert.ok(bounced <= right, `a bounce added ${bounced} marks against a landing seam's ${right}`)
+})
+
+test("the reduced branch keeps the crack and drops the travel", () => {
+  // Reduced motion is a branch, not a degradation: the crack still crosses the
+  // street, because the crack is how the child knows the seam landed.
+  const { scene, rec } = sceneAt(390, 844)
+  const crowd = { ...newCrowd(12), ranks: 4, size: 3 }
+  rec.reset()
+  scene.draw(frame({ phase: "crack", crowd, reduced: true, progress: 0.4 }))
+  const strokes = rec.ops.filter((op) => op.name === "stroke")
+  assert.ok(strokes.length > 0, "the reduced branch drew no crack")
+  assert.ok(rec.ink().length > 0)
+})
+
+test("a resize does not strand the layout input reads", () => {
+  const { canvas, rec } = fakeCanvas(390, 844)
+  const scene = new Scene(canvas as HTMLCanvasElement)
+  assert.equal(scene.lastLayout, null)
+  scene.draw(frame())
+  assert.ok(scene.lastLayout)
+  scene.resize()
+  assert.equal(scene.lastLayout, null, "a stale layout survived a resize")
+  rec.reset()
+  const layout = scene.draw(frame())
+  assert.equal(scene.lastLayout, layout)
+})
+
+test("the hint is drawn as a lit stud rather than as a sentence", () => {
+  // No transient status text anywhere: state lives in the design. The only
+  // thing a shove-back changes on screen is which stud is brass-bright.
+  const { scene, rec } = sceneAt(390, 844)
+  rec.reset()
+  scene.draw(frame({ crowd: newCrowd(12), hintSeam: 0 }))
+  const plain = rec.ops.filter((op) => op.name === "fillText").map((op) => String(op.args[0]))
+  rec.reset()
+  scene.draw(frame({ crowd: newCrowd(12), hintSeam: 2 }))
+  const hinted = rec.ops.filter((op) => op.name === "fillText").map((op) => String(op.args[0]))
+  assert.deepEqual(hinted, plain, "the hint added words to the screen")
+})

--- a/dynawalla/games/street/src/render/scene.ts
+++ b/dynawalla/games/street/src/render/scene.ts
@@ -1,0 +1,519 @@
+// The street, drawn.
+//
+// Canvas 2D, one pass, no allocation in the hot path beyond the layout object.
+// The layout is computed from the frame and **returned**, because the hit
+// regions and the drawn shapes have to be the same rectangles: a stud that is
+// drawn in one place and struck in another is the bug that makes a child think
+// the game is lying to them.
+//
+// Two things here are load-bearing rather than decorative.
+//
+//   * **The mob is a rectangle and the rectangle is the arithmetic.** `ranks`
+//     rows of `size` bodies. When a seam lands the same bodies rearrange into
+//     `ranks × size / k` rows of `k`, and nobody leaves. The child is looking
+//     at `12 = 4 × 3` because they made it.
+//   * **Iron versus steel.** A rank whose size is composite is drawn as cast
+//     iron, dark and locked. A rank whose size is prime is steel: cooler,
+//     brighter, and lit from the side. The child can see which mobs their fists
+//     work on before they swing, and that reading *is* a primality judgement.
+
+import type { Crowd } from "../game/crowd.ts"
+import type { Phase } from "../game/street.ts"
+import type { Shutter } from "../game/shutter.ts"
+import { PALETTE, alpha, face, label } from "./palette.ts"
+import { bar, isPrime } from "../game/factor.ts"
+import { PUSH_MAX } from "../game/push.ts"
+
+export type Rect = { x: number; y: number; w: number; h: number }
+
+export type Layout = {
+  readonly width: number
+  readonly height: number
+  /** Tapping anywhere in here swings. */
+  readonly mob: Rect
+  /** One per stud on the bar, in the order `bar(size)` returns them. */
+  readonly studs: ReadonlyArray<{ readonly k: number; readonly rect: Rect }>
+  /** One per rivet while the plate is down. */
+  readonly rivets: ReadonlyArray<{ readonly index: number; readonly rect: Rect }>
+}
+
+export type Frame = {
+  readonly phase: Phase
+  readonly progress: number
+  readonly crowd: Crowd
+  readonly shutter: Shutter | null
+  /** 0..1 — how far the mob has leaned in. */
+  readonly pressure: number
+  readonly pushMarks: number
+  readonly blocks: number
+  readonly best: number
+  readonly waveOfBlock: number
+  readonly wavesPerBlock: number
+  /** The stud lit as a hint after a shove-back. `0` when none is standing. */
+  readonly hintSeam: number
+  /** The stud last struck, and what it left over. Drives the ring-off drawing. */
+  readonly lastSeam: number
+  readonly lastRemainder: number
+  readonly clean: boolean
+  readonly reduced: boolean
+}
+
+const MIN_TOUCH = 44
+
+/** Rank-to-rank spacing, as a multiple of the body cell. A body is 1.5 cells tall. */
+const ROW_PITCH = 1.55
+
+export class Scene {
+  private readonly canvas: HTMLCanvasElement
+  private readonly ctx: CanvasRenderingContext2D
+  private dpr = 1
+  private w = 0
+  private h = 0
+  private layoutCache: Layout | null = null
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.canvas = canvas
+    const ctx = canvas.getContext("2d")
+    if (!ctx) throw new Error("street: no 2d context")
+    this.ctx = ctx
+    this.resize()
+  }
+
+  resize(): void {
+    const rect = this.canvas.getBoundingClientRect()
+    const dpr = Math.min(3, (globalThis.devicePixelRatio as number | undefined) ?? 1)
+    this.w = Math.max(1, Math.round(rect.width || 360))
+    this.h = Math.max(1, Math.round(rect.height || 640))
+    this.dpr = dpr
+    this.canvas.width = Math.round(this.w * dpr)
+    this.canvas.height = Math.round(this.h * dpr)
+    this.layoutCache = null
+  }
+
+  get width(): number {
+    return this.w
+  }
+
+  /**
+   * The rectangles the frame will be drawn into, and the ones input reads.
+   *
+   * Recomputed whenever the rank size or the plate changes, because the bar
+   * narrows to `bar(size)`: a rank of five never shows a nine, so the studs
+   * move.
+   */
+  layout(frame: Frame): Layout {
+    const w = this.w
+    const h = this.h
+    const pad = Math.round(Math.min(20, w * 0.045))
+
+    // The bar sits on the bottom. It grows rows until every stud clears a 44 px
+    // target — a smaller stud on a phone is a stud a child misses, and a missed
+    // stud reads as "that number did not work".
+    const studs = bar(frame.crowd.size)
+    const cols = Math.max(1, Math.min(6, Math.floor((w - pad * 2 + 8) / (MIN_TOUCH + 8))))
+    const rows = Math.max(1, Math.ceil(studs.length / cols))
+    const cellW = (w - pad * 2 - (cols - 1) * 8) / cols
+    const cellH = Math.max(MIN_TOUCH, Math.min(64, (h * 0.24 - (rows - 1) * 8) / rows))
+    const barH = rows * cellH + (rows - 1) * 8
+    const barTop = h - pad - barH
+
+    const placed: Array<{ k: number; rect: Rect }> = []
+    for (let i = 0; i < studs.length; i++) {
+      const r = Math.floor(i / cols)
+      const c = i % cols
+      // The last row is centred, so a bar of eight does not read as a bar of
+      // six with two stragglers.
+      const inRow = Math.min(cols, studs.length - r * cols)
+      const rowW = inRow * cellW + (inRow - 1) * 8
+      const x0 = (w - rowW) / 2
+      placed.push({
+        k: studs[i] as number,
+        rect: { x: x0 + c * (cellW + 8), y: barTop + r * (cellH + 8), w: cellW, h: cellH },
+      })
+    }
+
+    const hudH = Math.round(Math.min(96, h * 0.14))
+    const streetTop = hudH
+    const streetH = Math.max(80, barTop - pad - streetTop)
+    const mob: Rect = { x: pad, y: streetTop, w: w - pad * 2, h: streetH }
+
+    const rivets: Array<{ index: number; rect: Rect }> = []
+    const plate = frame.shutter
+    if (plate) {
+      const n = plate.rivets.length
+      const rcols = n <= 2 ? n : 2
+      const rrows = Math.ceil(n / rcols)
+      const gap = 12
+      const rw = Math.min(180, (mob.w - (rcols - 1) * gap) / rcols)
+      const rh = Math.max(MIN_TOUCH, Math.min(78, (mob.h * 0.46 - (rrows - 1) * gap) / rrows))
+      const gridW = rcols * rw + (rcols - 1) * gap
+      const x0 = mob.x + (mob.w - gridW) / 2
+      const y0 = mob.y + mob.h * 0.44
+      for (let i = 0; i < n; i++) {
+        const r = Math.floor(i / rcols)
+        const c = i % rcols
+        rivets.push({
+          index: i,
+          rect: { x: x0 + c * (rw + gap), y: Math.min(y0 + r * (rh + gap), h - rh - 4), w: rw, h: rh },
+        })
+      }
+    }
+
+    const out: Layout = { width: w, height: h, mob, studs: placed, rivets }
+    this.layoutCache = out
+    return out
+  }
+
+  /** The last layout drawn. Input reads this; it is never null after a frame. */
+  get lastLayout(): Layout | null {
+    return this.layoutCache
+  }
+
+  draw(frame: Frame): Layout {
+    const ctx = this.ctx
+    const layout = this.layout(frame)
+    ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0)
+    ctx.clearRect(0, 0, this.w, this.h)
+
+    this.drawStreet(frame)
+    this.drawHud(frame, layout)
+
+    const plateDown =
+      frame.phase === "shutter-down" || frame.phase === "shutter" || frame.phase === "rivet" || frame.phase === "shutter-up"
+    if (plateDown && frame.shutter) this.drawShutter(frame, layout)
+    else this.drawMob(frame, layout)
+
+    this.drawBar(frame, layout)
+    return layout
+  }
+
+  // -------------------------------------------------------------- ground --
+
+  private drawStreet(frame: Frame): void {
+    const ctx = this.ctx
+    const g = ctx.createLinearGradient(0, 0, 0, this.h)
+    g.addColorStop(0, PALETTE.sky)
+    g.addColorStop(0.55, PALETTE.skyLow)
+    g.addColorStop(1, PALETTE.ground)
+    ctx.fillStyle = g
+    ctx.fillRect(0, 0, this.w, this.h)
+
+    // The furnace door down the far end. It is the light source, it is the only
+    // saturated thing on screen, and it breathes with the push: the closer the
+    // mob is, the more of the street it blocks.
+    const cx = this.w * 0.5
+    const cy = this.h * 0.2
+    const r = Math.max(40, this.w * 0.42) * (1 - frame.pressure * 0.35)
+    const glow = ctx.createRadialGradient(cx, cy, 0, cx, cy, r)
+    glow.addColorStop(0, alpha(PALETTE.emberHot, 0.2))
+    glow.addColorStop(0.4, alpha(PALETTE.ember, 0.09))
+    glow.addColorStop(1, alpha(PALETTE.emberDeep, 0))
+    ctx.fillStyle = glow
+    ctx.fillRect(0, 0, this.w, this.h)
+
+    // Cobble courses, thinning with distance. Structure, not texture noise.
+    ctx.strokeStyle = PALETTE.groundLine
+    ctx.lineWidth = 1
+    for (let i = 1; i <= 7; i++) {
+      const t = i / 8
+      const y = this.h * (0.42 + t * t * 0.58)
+      ctx.globalAlpha = 0.25 + t * 0.35
+      ctx.beginPath()
+      ctx.moveTo(0, y)
+      ctx.lineTo(this.w, y)
+      ctx.stroke()
+    }
+    ctx.globalAlpha = 1
+  }
+
+  // ----------------------------------------------------------------- hud --
+
+  private drawHud(frame: Frame, layout: Layout): void {
+    const ctx = this.ctx
+    const pad = layout.mob.x
+    const top = Math.round(Math.min(96, this.h * 0.14))
+
+    // The tally lamp: how many are still standing, and how wide a rank is. The
+    // two numbers the whole game is about, and the only numerals up here.
+    const standing = frame.crowd.ranks * frame.crowd.size
+    ctx.textBaseline = "middle"
+    ctx.textAlign = "left"
+    ctx.fillStyle = PALETTE.chalk
+    ctx.font = face(Math.round(top * 0.42))
+    ctx.fillText(String(standing), pad, top * 0.44)
+
+    ctx.font = label(Math.round(top * 0.17))
+    ctx.fillStyle = PALETTE.chalkDim
+    ctx.globalAlpha = 0.8
+    const w = ctx.measureText(String(standing)).width
+    void w
+    ctx.fillText(
+      frame.crowd.ranks > 1 ? `${frame.crowd.ranks} × ${frame.crowd.size}` : "IN THE STREET",
+      pad,
+      top * 0.72,
+    )
+    ctx.globalAlpha = 1
+
+    // Blocks cleared. A count of finished things, and it never goes down.
+    ctx.textAlign = "right"
+    ctx.fillStyle = PALETTE.brass
+    ctx.font = face(Math.round(top * 0.3))
+    ctx.fillText(String(frame.blocks), this.w - pad, top * 0.42)
+    ctx.font = label(Math.round(top * 0.15))
+    ctx.fillStyle = PALETTE.chalkDim
+    ctx.globalAlpha = 0.7
+    ctx.fillText(frame.best > frame.blocks ? `BLOCKS · BEST ${frame.best}` : "BLOCKS", this.w - pad, top * 0.68)
+    ctx.globalAlpha = 1
+
+    // The push, as notches between the far end and you.
+    const nx = pad
+    const ny = top * 0.92
+    const nw = (this.w - pad * 2) / PUSH_MAX
+    for (let i = 0; i < PUSH_MAX; i++) {
+      const lit = i < frame.pushMarks
+      ctx.fillStyle = lit ? PALETTE.ember : PALETTE.ironDark
+      ctx.globalAlpha = lit ? 0.75 : 0.5
+      ctx.fillRect(nx + i * nw + 1, ny, nw - 3, 2)
+    }
+    ctx.globalAlpha = 1
+  }
+
+  // ----------------------------------------------------------------- mob --
+
+  private drawMob(frame: Frame, layout: Layout): void {
+    const ctx = this.ctx
+    const { crowd } = frame
+    if (crowd.ranks === 0 && frame.phase !== "fall" && frame.phase !== "clear") return
+
+    const area = layout.mob
+    // Leaning in: the mob occupies more of the street as the push builds.
+    const lean = frame.pressure * area.h * 0.16
+    const top = area.y + area.h * 0.16 + lean
+
+    const prime = isPrime(crowd.size)
+    const ringoff = frame.phase === "ringoff" && frame.lastSeam > 1
+    const groups = ringoff ? Math.floor(crowd.size / frame.lastSeam) : 0
+    const remainder = ringoff ? frame.lastRemainder : 0
+
+    // A rank is a row, and **every rank is on screen**. The body size is taken
+    // from whichever of the two constraints bites — the width of the widest
+    // rank or the height of the whole stack — because a mob with a rank clipped
+    // off the bottom is a rectangle that does not say what it says. Twelve
+    // ranks of two has to read as twelve ranks of two.
+    const perRow = crowd.size
+    const gapCount = ringoff ? groups : 0
+    const rows = Math.max(1, crowd.ranks)
+    const usable = area.w * 0.92 - gapCount * 10
+    const fromWidth = usable / Math.max(1, perRow)
+    const fromHeight = (area.h * 0.72) / rows / ROW_PITCH
+    const cell = Math.max(4, Math.min(34, Math.min(fromWidth, fromHeight)))
+    const rowH = cell * ROW_PITCH
+
+    for (let r = 0; r < crowd.ranks; r++) {
+      const rowWidth = perRow * cell + gapCount * 10
+      let x = area.x + (area.w - rowWidth) / 2
+      const y = top + r * rowH
+      for (let i = 0; i < perRow; i++) {
+        if (ringoff && frame.lastSeam > 0 && i > 0 && i % frame.lastSeam === 0 && i / frame.lastSeam <= groups) {
+          x += 10
+        }
+        // The remainder: the bodies standing outside the groups the refused
+        // seam tried to make. `groups * seam + remainder === size`, so this is
+        // the tail of the rank and it is drawn hot.
+        const over = ringoff && i >= crowd.size - remainder
+        this.drawBody(x, y, cell, prime, over, frame)
+        x += cell
+      }
+    }
+
+    // The crack: a hot line along every new seam, travelling at 2400 px/s. The
+    // machine already turned that speed into this phase's duration, so the
+    // progress here *is* the crack's position.
+    if (frame.phase === "crack") {
+      const reach = area.x + area.w * Math.min(1, frame.progress * 1.35)
+      ctx.strokeStyle = PALETTE.emberHot
+      ctx.lineWidth = frame.reduced ? 1.5 : 2.5
+      ctx.globalAlpha = frame.reduced ? 0.7 : 1 - Math.max(0, frame.progress - 0.7) / 0.3
+      for (let r = 1; r < crowd.ranks; r++) {
+        const y = top + r * rowH - rowH * 0.14
+        ctx.beginPath()
+        ctx.moveTo(area.x, y)
+        ctx.lineTo(reach, y)
+        ctx.stroke()
+      }
+      ctx.globalAlpha = 1
+    }
+  }
+
+  /**
+   * One body.
+   *
+   * Iron when the rank is composite — locked, dark, arms in. Steel when it is
+   * prime — upright, lit, and takeable. `over` is a body standing outside the
+   * groups a refused seam tried to make: the remainder, drawn as the thing it
+   * is rather than named.
+   */
+  private drawBody(x: number, y: number, cell: number, prime: boolean, over: boolean, frame: Frame): void {
+    const ctx = this.ctx
+    const w = cell * 0.78
+    const h = cell * 1.5
+    const body = over ? PALETTE.ember : prime ? PALETTE.steel : PALETTE.iron
+    const lit = over ? PALETTE.emberHot : prime ? PALETTE.steelLit : PALETTE.ironLit
+
+    ctx.globalAlpha = frame.phase === "clear" ? 0.35 : 1
+    // Torso: a shouldered slab, not a rounded cartoon.
+    ctx.fillStyle = body
+    ctx.beginPath()
+    ctx.moveTo(x + cell * 0.11, y + h * 0.34)
+    ctx.lineTo(x + cell * 0.11 + w, y + h * 0.34)
+    ctx.lineTo(x + cell * 0.11 + w * 0.86, y + h)
+    ctx.lineTo(x + cell * 0.11 + w * 0.14, y + h)
+    ctx.closePath()
+    ctx.fill()
+    // Head.
+    ctx.beginPath()
+    ctx.arc(x + cell * 0.11 + w * 0.5, y + h * 0.19, w * 0.29, 0, Math.PI * 2)
+    ctx.fill()
+    // The lit edge. One stroke, from the furnace end of the street.
+    ctx.strokeStyle = lit
+    ctx.globalAlpha *= 0.55
+    ctx.lineWidth = 1
+    ctx.beginPath()
+    ctx.moveTo(x + cell * 0.11 + w * 0.06, y + h * 0.36)
+    ctx.lineTo(x + cell * 0.11 + w * 0.18, y + h * 0.96)
+    ctx.stroke()
+    ctx.globalAlpha = 1
+  }
+
+  // ------------------------------------------------------------- shutter --
+
+  private drawShutter(frame: Frame, layout: Layout): void {
+    const ctx = this.ctx
+    const plate = frame.shutter
+    if (!plate) return
+    const area = layout.mob
+
+    // How far down the plate hangs. Down phase rolls in, up phase rolls out.
+    const t =
+      frame.phase === "shutter-down"
+        ? frame.progress
+        : frame.phase === "shutter-up"
+          ? 1 - frame.progress
+          : 1
+    const h = area.h * t
+    if (h <= 1) return
+
+    ctx.save()
+    ctx.beginPath()
+    ctx.rect(area.x, area.y, area.w, h)
+    ctx.clip()
+
+    ctx.fillStyle = PALETTE.wall
+    ctx.fillRect(area.x, area.y, area.w, area.h)
+    // Corrugations. A roller shutter is a stack of slats and that is the only
+    // texture it needs.
+    ctx.strokeStyle = PALETTE.wallLine
+    ctx.lineWidth = 1
+    const slat = Math.max(8, area.h / 22)
+    for (let y = area.y; y < area.y + area.h; y += slat) {
+      ctx.beginPath()
+      ctx.moveTo(area.x, y)
+      ctx.lineTo(area.x + area.w, y)
+      ctx.stroke()
+    }
+
+    // The problem, chalked.
+    ctx.textAlign = "center"
+    ctx.textBaseline = "middle"
+    ctx.fillStyle = PALETTE.chalk
+    const size = Math.min(area.w * 0.13, area.h * 0.14)
+    ctx.font = face(size)
+    ctx.fillText(plate.prompt, area.x + area.w / 2, area.y + area.h * 0.24)
+
+    for (const { index, rect } of layout.rivets) {
+      const rivet = plate.rivets[index]
+      if (!rivet) continue
+      const caving = frame.phase === "rivet" && rivet.dead
+      this.drawRivet(rect, rivet.text, rivet.dead, caving ? frame.progress : 1, plate.open)
+    }
+
+    ctx.restore()
+  }
+
+  private drawRivet(rect: Rect, text: string, dead: boolean, t: number, open: boolean): void {
+    const ctx = this.ctx
+    const r = Math.min(rect.h, rect.w) * 0.22
+    ctx.globalAlpha = dead ? 0.28 + 0.2 * (1 - t) : 1
+    ctx.fillStyle = dead ? PALETTE.ironDark : PALETTE.brassDark
+    this.roundRect(rect.x, rect.y, rect.w, rect.h, r)
+    ctx.fill()
+    ctx.fillStyle = dead ? PALETTE.iron : PALETTE.brass
+    this.roundRect(rect.x, rect.y, rect.w, rect.h - 3, r)
+    ctx.fill()
+
+    ctx.textAlign = "center"
+    ctx.textBaseline = "middle"
+    ctx.fillStyle = dead ? PALETTE.ironLit : open ? PALETTE.emberHot : "#241a08"
+    ctx.font = face(Math.min(rect.h * 0.46, rect.w * 0.34))
+    ctx.fillText(text, rect.x + rect.w / 2, rect.y + rect.h / 2 - 1)
+    ctx.globalAlpha = 1
+  }
+
+  // ----------------------------------------------------------------- bar --
+
+  private drawBar(frame: Frame, layout: Layout): void {
+    const ctx = this.ctx
+    const plateDown =
+      frame.phase === "shutter-down" || frame.phase === "shutter" || frame.phase === "rivet"
+    if (plateDown) return
+
+    for (const { k, rect } of layout.studs) {
+      const hinted = frame.hintSeam === k
+      const ringing = frame.phase === "ringoff" && frame.lastSeam === k
+      const struck = frame.phase === "crack" && frame.lastSeam === k
+
+      ctx.globalAlpha = frame.phase === "melee" ? 1 : 0.72
+      ctx.fillStyle = PALETTE.brassDark
+      this.roundRect(rect.x, rect.y, rect.w, rect.h, 5)
+      ctx.fill()
+      ctx.fillStyle = struck ? PALETTE.emberHot : ringing ? PALETTE.iron : hinted ? PALETTE.brassLit : PALETTE.brass
+      this.roundRect(rect.x, rect.y, rect.w, rect.h - 3, 5)
+      ctx.fill()
+
+      ctx.textAlign = "center"
+      ctx.textBaseline = "middle"
+      ctx.fillStyle = ringing ? PALETTE.ironLit : "#241a08"
+      ctx.font = face(Math.min(rect.h * 0.5, rect.w * 0.5))
+      ctx.fillText(String(k), rect.x + rect.w / 2, rect.y + rect.h / 2 - 1)
+      ctx.globalAlpha = 1
+    }
+  }
+
+  /** `roundRect` with a manual fallback: an old WebView has the arcs but not it. */
+  private roundRect(x: number, y: number, w: number, h: number, r: number): void {
+    const ctx = this.ctx as CanvasRenderingContext2D & {
+      roundRect?: (x: number, y: number, w: number, h: number, r: number) => void
+    }
+    ctx.beginPath()
+    if (typeof ctx.roundRect === "function") {
+      ctx.roundRect(x, y, w, h, r)
+      return
+    }
+    const rad = Math.max(0, Math.min(r, Math.min(w, h) / 2))
+    ctx.moveTo(x + rad, y)
+    ctx.lineTo(x + w - rad, y)
+    ctx.arc(x + w - rad, y + rad, rad, -Math.PI / 2, 0)
+    ctx.lineTo(x + w, y + h - rad)
+    ctx.arc(x + w - rad, y + h - rad, rad, 0, Math.PI / 2)
+    ctx.lineTo(x + rad, y + h)
+    ctx.arc(x + rad, y + h - rad, rad, Math.PI / 2, Math.PI)
+    ctx.lineTo(x, y + rad)
+    ctx.arc(x + rad, y + rad, rad, Math.PI, -Math.PI / 2)
+    ctx.closePath()
+  }
+}
+
+/** Whether a point is inside a rectangle. Input's only geometry. */
+export function hit(rect: Rect, x: number, y: number): boolean {
+  return x >= rect.x && x <= rect.x + rect.w && y >= rect.y && y <= rect.y + rect.h
+}

--- a/dynawalla/games/street/src/stubHost.test.ts
+++ b/dynawalla/games/street/src/stubHost.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { createStubHost } from "./stubHost.ts"
+
+const DIGITS = /^\d+$/
+
+test("every numeral that reaches a rivet is an exact integer", () => {
+  // No float ever enters an answer or a comparison. A rivet reading `72.0000001`
+  // is not a wrong answer, it is a broken product.
+  for (let seed = 1; seed <= 40; seed++) {
+    const host = createStubHost({ seed })
+    for (let i = 0; i < 60; i++) {
+      const q = host.next({ difficulty: 1 + (i % 10) })
+      assert.match(q.answer, DIGITS, q.prompt)
+      assert.equal(Number.isInteger(Number(q.answer)), true)
+      assert.ok(Number(q.answer) > 0, `${q.prompt} = ${q.answer}`)
+      for (const d of q.distractors) {
+        assert.match(d, DIGITS, `${q.prompt} → ${d}`)
+        assert.equal(Number.isInteger(Number(d)), true)
+      }
+    }
+  }
+})
+
+test("the prompt and the answer agree, computed independently", () => {
+  const host = createStubHost({ seed: 0xa11 })
+  for (let i = 0; i < 400; i++) {
+    const q = host.next({ difficulty: 1 + (i % 10) })
+    const [left, glyph, right] = q.prompt.split(" ")
+    const a = Number(left)
+    const b = Number(right)
+    assert.ok(Number.isInteger(a) && Number.isInteger(b), q.prompt)
+    const expected = glyph === "+" ? a + b : a - b
+    assert.equal(Number(q.answer), expected, q.prompt)
+  }
+})
+
+test("no distractor is the answer, and none repeats", () => {
+  const host = createStubHost({ seed: 0xd15 })
+  for (let i = 0; i < 400; i++) {
+    const q = host.next({ difficulty: 1 + (i % 10) })
+    assert.ok(!q.distractors.includes(q.answer), `${q.prompt} offered its own answer twice`)
+    assert.equal(new Set(q.distractors).size, q.distractors.length, q.prompt)
+    assert.equal(q.distractors.length, 3, q.prompt)
+  }
+})
+
+test("the wrong values are mal-rule outputs, not answer ± 1 noise", () => {
+  // A rivet has to be worth rejecting. `answer ± 1` is rejected by counting; a
+  // dropped carry is rejected by doing the arithmetic, which is the point.
+  const host = createStubHost({ seed: 0x3a1 })
+  let nearMisses = 0
+  let total = 0
+  for (let i = 0; i < 400; i++) {
+    const q = host.next({ difficulty: 3 })
+    const answer = Number(q.answer)
+    for (const d of q.distractors) {
+      total++
+      if (Math.abs(Number(d) - answer) <= 2) nearMisses++
+    }
+  }
+  assert.ok(nearMisses / total < 0.12, `${nearMisses}/${total} of the rivets were near-misses`)
+})
+
+test("the same seed is the same stream, forever", () => {
+  const draw = () => {
+    const host = createStubHost({ seed: 0x5eed })
+    return Array.from({ length: 80 }, (_, i) => {
+      const q = host.next({ difficulty: 1 + (i % 10) })
+      return `${q.prompt}=${q.answer}|${q.distractors.join(",")}`
+    })
+  }
+  assert.deepEqual(draw(), draw())
+  const other = createStubHost({ seed: 0x5eee })
+  assert.notEqual(other.next().prompt, createStubHost({ seed: 0x5eed }).next().prompt)
+})
+
+test("difficulty widens the operands rather than changing the arithmetic", () => {
+  const widthAt = (difficulty: number): number => {
+    const host = createStubHost({ seed: 0xd1ff })
+    let max = 0
+    for (let i = 0; i < 200; i++) {
+      max = Math.max(max, Number(host.next({ difficulty }).answer))
+    }
+    return max
+  }
+  assert.ok(widthAt(9) > widthAt(1) * 4, "the top of the ladder is not wider than the bottom")
+})
+
+test("subtraction never goes below zero", () => {
+  const host = createStubHost({ seed: 0x5bb })
+  for (let i = 0; i < 600; i++) {
+    const q = host.next({ difficulty: 1 + (i % 10) })
+    if (!q.prompt.includes("−")) continue
+    assert.ok(Number(q.answer) > 0, q.prompt)
+  }
+})
+
+test("reports and haptics are observable, and a stopping point is offered", () => {
+  const reports: string[] = []
+  const haptics: string[] = []
+  const transitions: string[] = []
+  const host = createStubHost({
+    seed: 1,
+    reducedMotion: true,
+    onReport: (r) => reports.push(r.answered),
+    onHaptic: (k) => haptics.push(k),
+    onTransition: (k) => transitions.push(k),
+  })
+  host.report({ questionId: "q", correct: true, ms: 10, answered: "72" })
+  host.haptic("medium")
+  host.transition?.("level")
+  assert.deepEqual(reports, ["72"])
+  assert.deepEqual(haptics, ["medium"])
+  assert.deepEqual(transitions, ["level"])
+  assert.equal(host.prefersReducedMotion(), true)
+})

--- a/dynawalla/games/street/src/stubHost.ts
+++ b/dynawalla/games/street/src/stubHost.ts
@@ -1,0 +1,213 @@
+// A local stub Host so the game is playable standalone with `npm run dev`.
+//
+// It serves what the shipped curriculum actually serves: whole-number column
+// addition and subtraction, the `add` domain, because that is the only domain
+// with `active` rows in it. Nothing here is a claim about coverage — the real
+// host owns the ladder — it is a claim about *shape*, so that the plate the
+// harness draws is the plate a tablet draws.
+//
+// Three properties the real runtime also honours, asserted by
+// `src/stubHost.test.ts`:
+//
+//   1. **Exact arithmetic.** Every operand, answer and distractor is an
+//      integer. No float ever reaches an answer string or a comparison.
+//   2. **Seeded and deterministic.** Same seed → same question stream, forever.
+//   3. **Distractors are real mal-rule outputs** — what a child running a
+//      specific broken procedure writes down. Not `answer ± 1` noise. Dropping
+//      a carry, taking the smaller digit from the larger, borrowing without
+//      decrementing the column you borrowed from, and reaching for the wrong
+//      operation are the four that account for most of what goes on a page.
+
+import type { Host, Question } from "./contract.ts"
+import { Rng } from "./core/rng.ts"
+
+type Domain = "add" | "sub"
+
+/** Digit-reversal: 63 → 36. A transcription slip, not noise. */
+function reverseDigits(n: number): number {
+  let out = 0
+  let m = Math.abs(n)
+  while (m > 0) {
+    out = out * 10 + (m % 10)
+    m = Math.floor(m / 10)
+  }
+  return out
+}
+
+/** Column addition with every carry dropped: 27 + 15 → 32. */
+function addNoCarry(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    out += ((x % 10) + (y % 10)) % 10 * place
+    place *= 10
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return out
+}
+
+/** The smaller-from-larger bug: 52 − 27 → 35, taking |2 − 7| in the ones. */
+function subSmallerFromLarger(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    out += Math.abs((x % 10) - (y % 10)) * place
+    place *= 10
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return out
+}
+
+/**
+ * Borrowing without decrementing the column borrowed from: every column that
+ * needed a regroup gets its ten and the next column is left untouched.
+ */
+function subBorrowNoDecrement(a: number, b: number): number {
+  let out = 0
+  let place = 1
+  let x = a
+  let y = b
+  while (x > 0 || y > 0) {
+    const dx = x % 10
+    const dy = y % 10
+    out += (dx < dy ? dx + 10 - dy : dx - dy) * place
+    place *= 10
+    x = Math.floor(x / 10)
+    y = Math.floor(y / 10)
+  }
+  return out
+}
+
+function malRulesFor(domain: Domain, a: number, b: number, answer: number): number[] {
+  if (domain === "add") {
+    return [
+      addNoCarry(a, b),
+      answer - 10, // carried, never added the carry in
+      answer + 10, // carried twice
+      Math.abs(a - b), // reached for the wrong operation
+      reverseDigits(answer),
+    ]
+  }
+  return [
+    subSmallerFromLarger(a, b),
+    subBorrowNoDecrement(a, b),
+    answer + 10, // decremented nothing after the borrow
+    a + b, // reached for the wrong operation
+    reverseDigits(answer),
+  ]
+}
+
+/**
+ * Operands by difficulty, in the shape of the `add` domain's level tables:
+ * two digits without regrouping at the bottom, three and four digits with
+ * regrouping at the top. Every result is a positive integer.
+ */
+function operandsFor(domain: Domain, difficulty: number, rng: Rng): [number, number] {
+  const d = Math.max(1, Math.min(10, Math.round(difficulty)))
+  const hi = d <= 2 ? 49 : d <= 4 ? 99 : d <= 7 ? 499 : 4999
+  if (domain === "add") {
+    const a = rng.int(d <= 2 ? 11 : 12, hi)
+    const b = rng.int(d <= 2 ? 11 : 12, hi)
+    return [a, b]
+  }
+  const a = rng.int(Math.max(21, Math.floor(hi / 3)), hi)
+  const b = rng.int(11, Math.max(12, a - 1))
+  return [a, b]
+}
+
+const GLYPH: Record<Domain, string> = { add: "+", sub: "−" }
+
+export type StubHostOptions = {
+  seed?: number
+  reducedMotion?: boolean
+  /** Observe reports — the dev harness draws a running accuracy readout from this. */
+  onReport?: (r: { questionId: string; correct: boolean; ms: number; answered: string }) => void
+  /** Observe haptics so the harness can show they fired on a device that has none. */
+  onHaptic?: (k: string) => void
+  /** Observe stopping points, which a real host may answer with a sheet. */
+  onTransition?: (kind: string, label?: string) => void
+}
+
+export function createStubHost(opts: StubHostOptions = {}): Host {
+  const rng = new Rng(opts.seed ?? 0x57ee7)
+  let n = 0
+
+  return {
+    next(o) {
+      const difficulty = Math.max(1, Math.min(10, Math.round(o?.difficulty ?? 3)))
+      const domain: Domain = rng.chance(0.5) ? "add" : "sub"
+      const [a, b] = operandsFor(domain, difficulty, rng)
+      const answer = domain === "add" ? a + b : a - b
+
+      // Mal-rule outputs, deduped, filtered to values that are legal on a
+      // rivet: a positive integer that is not the answer.
+      const seen = new Set<number>([answer])
+      const pool: number[] = []
+      for (const v of malRulesFor(domain, a, b, answer)) {
+        if (!Number.isInteger(v) || v < 1 || seen.has(v)) continue
+        seen.add(v)
+        pool.push(v)
+      }
+      rng.shuffle(pool)
+
+      // Top up from near-misses when a particular (a, b) collapsed several
+      // mal-rules onto the same value.
+      for (let k = 1; pool.length < 3 && k < 40; k++) {
+        for (const v of [answer + k, answer - k]) {
+          if (pool.length >= 3) break
+          if (!Number.isInteger(v) || v < 1 || seen.has(v)) continue
+          seen.add(v)
+          pool.push(v)
+        }
+      }
+
+      n++
+      return {
+        id: `stub-${n}`,
+        prompt: `${a} ${GLYPH[domain]} ${b}`,
+        answer: String(answer),
+        distractors: pool.slice(0, 3).map(String),
+        domain,
+        difficulty,
+      } satisfies Question
+    },
+
+    report(r) {
+      opts.onReport?.(r)
+    },
+
+    haptic(k) {
+      opts.onHaptic?.(k)
+      const nav = globalThis.navigator as Navigator | undefined
+      if (!nav || typeof nav.vibrate !== "function") return
+      const ms =
+        k === "light" ? 8 : k === "medium" ? 18 : k === "heavy" ? 34 : k === "success" ? 12 : 40
+      try {
+        if (k === "success") nav.vibrate([ms, 26, ms])
+        else if (k === "failure") nav.vibrate([ms, 40, ms])
+        else nav.vibrate(ms)
+      } catch {
+        // A browser that exposes vibrate but refuses it (no user gesture yet,
+        // or a policy block) must never take the frame down with it.
+        console.warn("[street] navigator.vibrate refused")
+      }
+    },
+
+    prefersReducedMotion() {
+      if (opts.reducedMotion !== undefined) return opts.reducedMotion
+      return (
+        typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion: reduce)").matches
+      )
+    },
+
+    transition(kind, label) {
+      opts.onTransition?.(kind, label)
+    },
+  }
+}

--- a/dynawalla/games/street/tsconfig.json
+++ b/dynawalla/games/street/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": false,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/dynawalla/games/street/vite.config.ts
+++ b/dynawalla/games/street/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite"
+
+// The game is a library that mounts into a host element. `npm run dev` serves
+// the standalone harness in `index.html`, which wires it to the local stub Host
+// so the whole thing is playable with no runtime underneath it.
+export default defineConfig({
+  server: { port: 4321, host: "127.0.0.1" },
+  build: {
+    target: "es2022",
+    lib: {
+      entry: "src/index.ts",
+      name: "DynawallaGameStreet",
+      formats: ["es"],
+      fileName: () => "street.js",
+    },
+  },
+})

--- a/dynawalla/games/street/vite.pack.config.ts
+++ b/dynawalla/games/street/vite.pack.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vite"
+
+/**
+ * The pack build: only `pack.html`, so the dev harness and the stub host stay
+ * out of what is installed on a tablet.
+ *
+ * `base: "./"` matters — a pack is served from
+ * `dynawalla-pack://localhost/<id>/`, and an absolute asset path would resolve
+ * to the scheme root rather than to this pack.
+ */
+export default defineConfig({
+  base: "./",
+  build: {
+    target: "es2022",
+    assetsInlineLimit: 0,
+    outDir: "dist-pack",
+    emptyOutDir: true,
+    // An absolute path, resolved from this file. Vite injects the built module
+    // script into an HTML entry only when it recognises the entry as its own;
+    // a bare relative string produces a `pack.html` with the source script
+    // stripped and nothing put back — a document that loads, paints its body
+    // colour, and runs no code at all.
+    rollupOptions: { input: { pack: fileURLToPath(new URL("./pack.html", import.meta.url)) } },
+  },
+})


### PR DESCRIPTION
## What

Add **FOUNDRY STREET** at `dynawalla/games/street` — a new arcade pack after
Final Fight (1989), `ARCADE_CANON.md` rank 13, S tier, buildCost L.

A mob of *N* stands in `ranks × size`. Two verbs, and both of them are claims
about a number:

- **STRIKE a stud** — *"this number goes into them."* If it does, the crack runs
  the length of the block at **2400 px/s** and the same bodies rearrange into
  that many to a rank. If it does not, the crack rings off: the mob stands split
  into groups with the remainder over, and closes back up.
- **SWING** — *"they are solid."* Fists land on a rank whose size is prime and
  bounce off one that is not.

## Why

**The mathematics is the mechanic, and primeness is felt rather than announced.**

Nobody in this game is ever told what a prime is. A mob of thirteen refuses
*every stud on the bar* — and the bar is complete for every crowd the street can
send (`bar()` offers exactly `seamsFor()`, asserted over the whole pool), so
"nothing on the bar works" honestly means "nothing works". Then thirteen goes
down in one punch. The two rules are the same rule from both sides: **what will
not break is the thing you can hit.** Primeness is a wall the child walks into.

The rectangle is the array model and the child builds it: striking 3 at twelve
makes four ranks of three, out of the same twelve people, in front of them.
Knocking those ranks down one at a time is `3 + 3 + 3 + 3`, drawn.

The hum is `264 · n^(−1/3)` — the design entry's *"block hum pitch is log of the
number"* written as a power law. Every doubling of the crowd drops it exactly
four semitones, so halving a mob sounds like the same move whether it was 24 → 12
or 4 → 2. `tone.test.ts` asserts the *interval is constant*, not the frequencies.

The fastest route is **strike the largest prime that goes into them**:
`minimumTaps(n) = 1 + n / largestPrimeFactor(n)`, checked against a breadth-first
search over real game states rather than against the argument in the comment.

**Knockdowns chain.** A swing lands during the fall of the rank before it, so
eight ranks going down reads as a combo rather than a queue — the genre demands
it. A *strike* deliberately does not chain: re-cutting a mob mid-crack would
mean the child never sees the rectangle they just made.

**The stake has no clock in it.** The mob leans in when you are wrong and gives
ground when you put a rank down; six slips with no answer between shoves you back
a block, the wave restarts with the smallest prime factor lit as a hint, and
nothing built is taken (`P-04`). Standing still and reading the mob costs exactly
nothing — a child who is thinking must never be losing.

## Blast radius

**Areas touched:** dynawalla (one new directory, nothing else)

- [x] Every touched path is covered by a `ci.yml` area filter — every file is
      under `dynawalla/games/street/`.
- [x] **Pack back-compat.** New pack at `0.1.0`. No published zip changed, no
      `voiceId` renamed, no catalog entry dropped or moved.
- [x] **Native integrity.** N/A — no Rust, no manifest, no `links =` touched.
- [x] **Strings.** N/A — no `corpan-app` locale keys. The pack's own copy is the
      three words on its own surfaces (`locales: ["en"]`, as every sibling pack).
- [x] **Curriculum.** No skill id renamed, reused or promoted. `covers.skills`
      names the **seven `active` rows of `dw.add`** and nothing else — verified
      by hand against `packs/shared/curriculum/src/graph/domains/add.ts` (output
      below); the one `draft` row there, `dw.add.regroup.subtract-tenths`, is not
      claimed. **No `dw.mul.*` row is declared**, deliberately: `mul` is 100%
      `draft` and claiming it would imply coverage the curriculum cannot serve.
      No floats anywhere in an answer or a comparison.
- [x] **Secrets.** None. `gitleaks` output below. The one storage key is
      `BEST_SLOT` with a `// gitleaks:allow`, per `games/forge/src/game/save.ts`.

### The curriculum constraint, stated plainly

Only `add` is active, so the host serves whole-number column arithmetic whatever
a pack declares. This game does what THE SPLIT does: **two strands.**

- **The shutter** carries the host's problem — a plate of steel with four rivets
  holding the canonical answer and the host's mal-rule outputs. The rivet struck
  is reported as-is, **once per plate**, and the host is the judge. The game
  never marks it. That is what `covers.skills` claims.
- **The factoring** is the game's own arithmetic and **is not reported**. A mob
  of twelve coming apart into four ranks of three is not a question anybody
  asked; it is arithmetic the child performs with a gesture.

### The pause trap

`src/pack.ts` subscribes to `mounted.client.on("pause")` and `("resume")` — the
handle's methods are inert without it. `Street` carries **four independent
guards**: one on `advance` (the clock does not accumulate, which is what shifts
every wall-clock mark forward by the length of the sheet) and one each on
`strikeStud`, `swing` and `hitRivet`. Each was verified by deleting it and
watching a test go red — output below. The one with a number attached is
latency: this game calls `transition` on a finished block, and a clock that ran
behind the resulting sheet would report thirty seconds of "thinking" on a plate
the child never saw.

## Proof

```
$ npm test          # five times — one green run is not proof
--- run 1 ---   # tests 97 / # pass 97 / # fail 0
--- run 2 ---   # tests 97 / # pass 97 / # fail 0
--- run 3 ---   # tests 97 / # pass 97 / # fail 0
--- run 4 ---   # tests 97 / # pass 97 / # fail 0
--- run 5 ---   # tests 97 / # pass 97 / # fail 0
```

The three that carry the design (`src/game/factor.test.ts`), each checked over
the whole space rather than over examples:

```
ok 1 - a prime crowd has no valid seam
ok 2 - every seam the game accepts is a true factor pair
ok 3 - every composite crowd has at least one seam, and it is on the bar
ok 4 - the bar can express every seam that exists, for every crowd
ok 5 - isPrime agrees with a trial-division sieve up to 2000
ok 8 - minimumTaps matches a breadth-first search over real game states
ok 9 - the optimal opening strike is the largest prime factor
```

Every pause guard is load-bearing — each removed on its own, tests re-run:

```
--- guard removed from advance() ---
not ok 65 - the clock stops dead behind a sheet
not ok 67 - a sheet is not thinking time
# tests 97 / # pass 95 / # fail 2

--- guard removed from strikeStud() ---
not ok 66 - a tap behind a sheet is not a tap      # tests 97 / # fail 1

--- guard removed from swing() ---
not ok 66 - a tap behind a sheet is not a tap      # tests 97 / # fail 1

--- guard removed from hitRivet() ---
not ok 66 - a tap behind a sheet is not a tap      # tests 97 / # fail 1
```

```
$ npm run tsc
> tsc --noEmit
(no output — 0 errors)

$ npm run build
dist/street.js  33.25 kB │ gzip: 10.40 kB
✓ built in 14ms

$ npm run build:pack
dist-pack/pack.html                 1.12 kB │ gzip:  0.58 kB
dist-pack/assets/pack-BfJAiJrM.js  30.55 kB │ gzip: 11.28 kB
✓ built in 24ms

$ grep -o '<script[^>]*>' dist-pack/pack.html
<script type="module" crossorigin src="./assets/pack-BfJAiJrM.js">
```

```
$ cd dynawalla/packs && node build.mjs street
dynawalla.street@0.1.0 — FOUNDRY STREET
  entry        pack.html
  host         0.1.0 … <1.0.0
  sdk          1.0.0 (this SDK is 1.0.0)
  capabilities items, items.reveal, haptics
  covers       7 skills, grades 1–4
  on disk      3 files, 32792 bytes

1 pack(s) built, checked and staged into src-tauri/packs/
```

`dw-pack check` does not validate `covers.skills`, so every id was resolved
against `add.ts` by hand:

```
OK   dw.add.column.add-no-regroup            -> active
OK   dw.add.column.subtract-no-regroup       -> active
OK   dw.add.regroup.add-multidigit           -> active
OK   dw.add.regroup.subtract-multidigit      -> active
OK   dw.add.regroup.add-short-addend         -> active
OK   dw.add.regroup.subtract-short-subtrahend-> active
OK   dw.add.regroup.subtract-across-zero     -> active
ALL 7 CLAIMED ROWS ARE active
active rows in add.ts: 7, claimed: 7
```

```
$ gitleaks detect --no-banner --redact --log-opts="origin/main..HEAD"
INF 1 commits scanned.
INF scanned ~174303 bytes (174.30 KB) in 40.6ms
INF no leaks found

$ git diff --name-only origin/main...HEAD | grep -v '^dynawalla/games/street/'
(none)

$ git diff --name-only --diff-filter=D origin/main...HEAD
(empty)
```

42 files, all new, all under `dynawalla/games/street/`.
